### PR TITLE
The Big Reformat

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,90 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: true
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories: 
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IndentCaseLabels: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
               source /home/tgrogers-raid/a/common/gpgpu-sim-setup/common/export_gcc_version.sh 5.3.0
               git remote add upstream https://github.com/purdue-aalp/gpgpu-sim_distribution
               git fetch upstream
-              git diff --name-only upstream/dev | grep -E "*.cc|*.h|*.cpp|*.hpp" | xargs ./run-clang-format.py --clang-format-executable /home/tgrogers-raid/a/green349/clang-format
+              git diff --name-only upstream/dev | grep -E "*.cc|*.h|*.cpp|*.hpp" | xargs ./run-clang-format.py --clang-format-executable /tmp/clang-format
             ''' 
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,8 +13,7 @@ pipeline {
               source /home/tgrogers-raid/a/common/gpgpu-sim-setup/common/export_gcc_version.sh 5.3.0
               git remote add upstream https://github.com/purdue-aalp/gpgpu-sim_distribution
               git fetch upstream
-              cpp_diff= $(git diff --name-only upstream/dev | grep -E "*.cc|*.h|*.cpp|*.hpp")
-              if [[ $cpp_diff ]]; then
+              if git diff --name-only upstream/dev | grep -E "*.cc|*.h|*.cpp|*.hpp" ; then
                 git diff --name-only upstream/dev | grep -E "*.cc|*.h|*.cpp|*.hpp" | xargs ./run-clang-format.py --clang-format-executable /tgrogers-raid/a/common/clang-format/6.0.1/clang-format
               fi
             ''' 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@ pipeline {
               git remote add upstream https://github.com/purdue-aalp/gpgpu-sim_distribution
               git fetch upstream
               cpp_diff= $(git diff --name-only upstream/dev | grep -E "*.cc|*.h|*.cpp|*.hpp")
+              echo $cpp_diff
               if [[ $cpp_diff ]]; then
                 git diff --name-only upstream/dev | grep -E "*.cc|*.h|*.cpp|*.hpp" | xargs ./run-clang-format.py --clang-format-executable /tmp/clang-format
               fi

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,7 @@ pipeline {
         stage('formatting-check') {
           steps {
             sh '''
+              source /home/tgrogers-raid/a/common/gpgpu-sim-setup/common/export_gcc_version.sh 5.3.0
               git remote add upstream https://github.com/purdue-aalp/gpgpu-sim_distribution
               git fetch upstream
               git diff --name-only upstream/dev | grep -E "*.cc|*.h|*.cpp|*.hpp" | xargs ./run-clang-format.py --clang-format-executable /home/tgrogers-raid/a/green349/clang-format

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,6 @@ pipeline {
         stage('formatting-check') {
           steps {
             sh '''
-              git remote rm upstream
               git remote add upstream https://github.com/purdue-aalp/gpgpu-sim_distribution
               git fetch upstream
               git diff --name-only upstream/dev | grep -E "*.cc|*.h|*.cpp|*.hpp" | xargs ./run-clang-format.py --clang-format-executable /home/tgrogers-raid/a/green349/clang-format
@@ -103,6 +102,7 @@ pipeline {
     }
     post {
         success {
+            sh 'git remote rm upstream'
             emailext body:'''${SCRIPT, template="groovy-html.success.template"}''',
                 recipientProviders: [[$class: 'CulpritsRecipientProvider'],
                     [$class: 'RequesterRecipientProvider']],
@@ -111,6 +111,7 @@ pipeline {
                 to: 'tgrogers@purdue.edu'
         }
         failure {
+            sh 'git remote rm upstream'
             emailext body: "See ${BUILD_URL}",
                 recipientProviders: [[$class: 'CulpritsRecipientProvider'],
                     [$class: 'RequesterRecipientProvider']],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
               git remote add upstream https://github.com/purdue-aalp/gpgpu-sim_distribution
               git fetch upstream
               if git diff --name-only upstream/dev | grep -E "*.cc|*.h|*.cpp|*.hpp" ; then
-                git diff --name-only upstream/dev | grep -E "*.cc|*.h|*.cpp|*.hpp" | xargs ./run-clang-format.py --clang-format-executable /tgrogers-raid/a/common/clang-format/6.0.1/clang-format
+                git diff --name-only upstream/dev | grep -E "*.cc|*.h|*.cpp|*.hpp" | xargs ./run-clang-format.py --clang-format-executable /home/tgrogers-raid/a/common/clang-format/6.0.1/clang-format
               fi
             ''' 
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,10 @@ pipeline {
               source /home/tgrogers-raid/a/common/gpgpu-sim-setup/common/export_gcc_version.sh 5.3.0
               git remote add upstream https://github.com/purdue-aalp/gpgpu-sim_distribution
               git fetch upstream
-              git diff --name-only upstream/dev | grep -E "*.cc|*.h|*.cpp|*.hpp" | xargs ./run-clang-format.py --clang-format-executable /tmp/clang-format
+              cpp_diff= $(git diff --name-only upstream/dev | grep -E "*.cc|*.h|*.cpp|*.hpp")
+              if [[ $cpp_diff ]]; then
+                git diff --name-only upstream/dev | grep -E "*.cc|*.h|*.cpp|*.hpp" | xargs ./run-clang-format.py --clang-format-executable /tmp/clang-format
+              fi
             ''' 
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,17 +7,16 @@ pipeline {
         disableConcurrentBuilds()
     }
     stages {
-      stage('formatting-check') {
-        steps {
-          sh '''
-            git remote rm upstream
-            git remote add upstream https://github.com/purdue-aalp/gpgpu-sim_distribution
-            git fetch upstream
-            git diff --name-only upstream/dev | grep -E "*.cc|*.h|*.cpp|*.hpp" | xargs ./run-clang-format.py --clang-format-executable /home/tgrogers-raid/a/green349/clang-format
-          ''' 
+        stage('formatting-check') {
+          steps {
+            sh '''
+              git remote rm upstream
+              git remote add upstream https://github.com/purdue-aalp/gpgpu-sim_distribution
+              git fetch upstream
+              git diff --name-only upstream/dev | grep -E "*.cc|*.h|*.cpp|*.hpp" | xargs ./run-clang-format.py --clang-format-executable /home/tgrogers-raid/a/green349/clang-format
+            ''' 
+          }
         }
-    }
-    stages {
         stage('simulator-build') {
             steps {
                 parallel "4.2": {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,9 +14,8 @@ pipeline {
               git remote add upstream https://github.com/purdue-aalp/gpgpu-sim_distribution
               git fetch upstream
               cpp_diff= $(git diff --name-only upstream/dev | grep -E "*.cc|*.h|*.cpp|*.hpp")
-              echo $cpp_diff
               if [[ $cpp_diff ]]; then
-                git diff --name-only upstream/dev | grep -E "*.cc|*.h|*.cpp|*.hpp" | xargs ./run-clang-format.py --clang-format-executable /tmp/clang-format
+                git diff --name-only upstream/dev | grep -E "*.cc|*.h|*.cpp|*.hpp" | xargs ./run-clang-format.py --clang-format-executable /tgrogers-raid/a/common/clang-format/6.0.1/clang-format
               fi
             ''' 
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,17 @@ pipeline {
     options {
         disableConcurrentBuilds()
     }
-
+    stages {
+      stage('formatting-check') {
+        steps {
+          sh '''
+            git remote rm upstream
+            git remote add upstream https://github.com/purdue-aalp/gpgpu-sim_distribution
+            git fetch upstream
+            git diff --name-only upstream/dev | grep -E "*.cc|*.h|*.cpp|*.hpp" | xargs ./run-clang-format.py --clang-format-executable /home/tgrogers-raid/a/green349/clang-format
+          ''' 
+        }
+    }
     stages {
         stage('simulator-build') {
             steps {

--- a/libcuda/cuda_api.h
+++ b/libcuda/cuda_api.h
@@ -63,7 +63,8 @@ typedef uint64_t cuuint64_t;
 /**
  * CUDA API versioning support
  */
-#if defined(__CUDA_API_VERSION_INTERNAL) || defined(__DOXYGEN_ONLY__) || defined(CUDA_ENABLE_DEPRECATED)
+#if defined(__CUDA_API_VERSION_INTERNAL) || defined(__DOXYGEN_ONLY__) || \
+    defined(CUDA_ENABLE_DEPRECATED)
 #define __CUDA_DEPRECATED
 #elif defined(_MSC_VER)
 #define __CUDA_DEPRECATED __declspec(deprecated)
@@ -74,143 +75,148 @@ typedef uint64_t cuuint64_t;
 #endif
 
 #if defined(CUDA_FORCE_API_VERSION)
-    #if (CUDA_FORCE_API_VERSION == 3010)
-        #define __CUDA_API_VERSION 3010
-    #else
-        #error "Unsupported value of CUDA_FORCE_API_VERSION"
-    #endif
+#if (CUDA_FORCE_API_VERSION == 3010)
+#define __CUDA_API_VERSION 3010
 #else
-    #define __CUDA_API_VERSION 10010
+#error "Unsupported value of CUDA_FORCE_API_VERSION"
+#endif
+#else
+#define __CUDA_API_VERSION 10010
 #endif /* CUDA_FORCE_API_VERSION */
 
-#if defined(__CUDA_API_VERSION_INTERNAL) || defined(CUDA_API_PER_THREAD_DEFAULT_STREAM)
-    #define __CUDA_API_PER_THREAD_DEFAULT_STREAM
-    #define __CUDA_API_PTDS(api) api ## _ptds
-    #define __CUDA_API_PTSZ(api) api ## _ptsz
+#if defined(__CUDA_API_VERSION_INTERNAL) || \
+    defined(CUDA_API_PER_THREAD_DEFAULT_STREAM)
+#define __CUDA_API_PER_THREAD_DEFAULT_STREAM
+#define __CUDA_API_PTDS(api) api##_ptds
+#define __CUDA_API_PTSZ(api) api##_ptsz
 #else
-    #define __CUDA_API_PTDS(api) api
-    #define __CUDA_API_PTSZ(api) api
+#define __CUDA_API_PTDS(api) api
+#define __CUDA_API_PTSZ(api) api
 #endif
 
 #if defined(__CUDA_API_VERSION_INTERNAL) || __CUDA_API_VERSION >= 3020
-    #define cuDeviceTotalMem                    cuDeviceTotalMem_v2
-    #define cuCtxCreate                         cuCtxCreate_v2
-    #define cuModuleGetGlobal                   cuModuleGetGlobal_v2
-    #define cuMemGetInfo                        cuMemGetInfo_v2
-    #define cuMemAlloc                          cuMemAlloc_v2
-    #define cuMemAllocPitch                     cuMemAllocPitch_v2
-    #define cuMemFree                           cuMemFree_v2
-    #define cuMemGetAddressRange                cuMemGetAddressRange_v2
-    #define cuMemAllocHost                      cuMemAllocHost_v2
-    #define cuMemHostGetDevicePointer           cuMemHostGetDevicePointer_v2
-    #define cuMemcpyHtoD                        __CUDA_API_PTDS(cuMemcpyHtoD_v2)
-    #define cuMemcpyDtoH                        __CUDA_API_PTDS(cuMemcpyDtoH_v2)
-    #define cuMemcpyDtoD                        __CUDA_API_PTDS(cuMemcpyDtoD_v2)
-    #define cuMemcpyDtoA                        __CUDA_API_PTDS(cuMemcpyDtoA_v2)
-    #define cuMemcpyAtoD                        __CUDA_API_PTDS(cuMemcpyAtoD_v2)
-    #define cuMemcpyHtoA                        __CUDA_API_PTDS(cuMemcpyHtoA_v2)
-    #define cuMemcpyAtoH                        __CUDA_API_PTDS(cuMemcpyAtoH_v2)
-    #define cuMemcpyAtoA                        __CUDA_API_PTDS(cuMemcpyAtoA_v2)
-    #define cuMemcpyHtoAAsync                   __CUDA_API_PTSZ(cuMemcpyHtoAAsync_v2)
-    #define cuMemcpyAtoHAsync                   __CUDA_API_PTSZ(cuMemcpyAtoHAsync_v2)
-    #define cuMemcpy2D                          __CUDA_API_PTDS(cuMemcpy2D_v2)
-    #define cuMemcpy2DUnaligned                 __CUDA_API_PTDS(cuMemcpy2DUnaligned_v2)
-    #define cuMemcpy3D                          __CUDA_API_PTDS(cuMemcpy3D_v2)
-    #define cuMemcpyHtoDAsync                   __CUDA_API_PTSZ(cuMemcpyHtoDAsync_v2)
-    #define cuMemcpyDtoHAsync                   __CUDA_API_PTSZ(cuMemcpyDtoHAsync_v2)
-    #define cuMemcpyDtoDAsync                   __CUDA_API_PTSZ(cuMemcpyDtoDAsync_v2)
-    #define cuMemcpy2DAsync                     __CUDA_API_PTSZ(cuMemcpy2DAsync_v2)
-    #define cuMemcpy3DAsync                     __CUDA_API_PTSZ(cuMemcpy3DAsync_v2)
-    #define cuMemsetD8                          __CUDA_API_PTDS(cuMemsetD8_v2)
-    #define cuMemsetD16                         __CUDA_API_PTDS(cuMemsetD16_v2)
-    #define cuMemsetD32                         __CUDA_API_PTDS(cuMemsetD32_v2)
-    #define cuMemsetD2D8                        __CUDA_API_PTDS(cuMemsetD2D8_v2)
-    #define cuMemsetD2D16                       __CUDA_API_PTDS(cuMemsetD2D16_v2)
-    #define cuMemsetD2D32                       __CUDA_API_PTDS(cuMemsetD2D32_v2)
-    #define cuArrayCreate                       cuArrayCreate_v2
-    #define cuArrayGetDescriptor                cuArrayGetDescriptor_v2
-    #define cuArray3DCreate                     cuArray3DCreate_v2
-    #define cuArray3DGetDescriptor              cuArray3DGetDescriptor_v2
-    #define cuTexRefSetAddress                  cuTexRefSetAddress_v2
-    #define cuTexRefGetAddress                  cuTexRefGetAddress_v2
-    #define cuGraphicsResourceGetMappedPointer  cuGraphicsResourceGetMappedPointer_v2
+#define cuDeviceTotalMem cuDeviceTotalMem_v2
+#define cuCtxCreate cuCtxCreate_v2
+#define cuModuleGetGlobal cuModuleGetGlobal_v2
+#define cuMemGetInfo cuMemGetInfo_v2
+#define cuMemAlloc cuMemAlloc_v2
+#define cuMemAllocPitch cuMemAllocPitch_v2
+#define cuMemFree cuMemFree_v2
+#define cuMemGetAddressRange cuMemGetAddressRange_v2
+#define cuMemAllocHost cuMemAllocHost_v2
+#define cuMemHostGetDevicePointer cuMemHostGetDevicePointer_v2
+#define cuMemcpyHtoD __CUDA_API_PTDS(cuMemcpyHtoD_v2)
+#define cuMemcpyDtoH __CUDA_API_PTDS(cuMemcpyDtoH_v2)
+#define cuMemcpyDtoD __CUDA_API_PTDS(cuMemcpyDtoD_v2)
+#define cuMemcpyDtoA __CUDA_API_PTDS(cuMemcpyDtoA_v2)
+#define cuMemcpyAtoD __CUDA_API_PTDS(cuMemcpyAtoD_v2)
+#define cuMemcpyHtoA __CUDA_API_PTDS(cuMemcpyHtoA_v2)
+#define cuMemcpyAtoH __CUDA_API_PTDS(cuMemcpyAtoH_v2)
+#define cuMemcpyAtoA __CUDA_API_PTDS(cuMemcpyAtoA_v2)
+#define cuMemcpyHtoAAsync __CUDA_API_PTSZ(cuMemcpyHtoAAsync_v2)
+#define cuMemcpyAtoHAsync __CUDA_API_PTSZ(cuMemcpyAtoHAsync_v2)
+#define cuMemcpy2D __CUDA_API_PTDS(cuMemcpy2D_v2)
+#define cuMemcpy2DUnaligned __CUDA_API_PTDS(cuMemcpy2DUnaligned_v2)
+#define cuMemcpy3D __CUDA_API_PTDS(cuMemcpy3D_v2)
+#define cuMemcpyHtoDAsync __CUDA_API_PTSZ(cuMemcpyHtoDAsync_v2)
+#define cuMemcpyDtoHAsync __CUDA_API_PTSZ(cuMemcpyDtoHAsync_v2)
+#define cuMemcpyDtoDAsync __CUDA_API_PTSZ(cuMemcpyDtoDAsync_v2)
+#define cuMemcpy2DAsync __CUDA_API_PTSZ(cuMemcpy2DAsync_v2)
+#define cuMemcpy3DAsync __CUDA_API_PTSZ(cuMemcpy3DAsync_v2)
+#define cuMemsetD8 __CUDA_API_PTDS(cuMemsetD8_v2)
+#define cuMemsetD16 __CUDA_API_PTDS(cuMemsetD16_v2)
+#define cuMemsetD32 __CUDA_API_PTDS(cuMemsetD32_v2)
+#define cuMemsetD2D8 __CUDA_API_PTDS(cuMemsetD2D8_v2)
+#define cuMemsetD2D16 __CUDA_API_PTDS(cuMemsetD2D16_v2)
+#define cuMemsetD2D32 __CUDA_API_PTDS(cuMemsetD2D32_v2)
+#define cuArrayCreate cuArrayCreate_v2
+#define cuArrayGetDescriptor cuArrayGetDescriptor_v2
+#define cuArray3DCreate cuArray3DCreate_v2
+#define cuArray3DGetDescriptor cuArray3DGetDescriptor_v2
+#define cuTexRefSetAddress cuTexRefSetAddress_v2
+#define cuTexRefGetAddress cuTexRefGetAddress_v2
+#define cuGraphicsResourceGetMappedPointer cuGraphicsResourceGetMappedPointer_v2
 #endif /* __CUDA_API_VERSION_INTERNAL || __CUDA_API_VERSION >= 3020 */
 #if defined(__CUDA_API_VERSION_INTERNAL) || __CUDA_API_VERSION >= 4000
-    #define cuCtxDestroy                        cuCtxDestroy_v2
-    #define cuCtxPopCurrent                     cuCtxPopCurrent_v2
-    #define cuCtxPushCurrent                    cuCtxPushCurrent_v2
-    #define cuStreamDestroy                     cuStreamDestroy_v2
-    #define cuEventDestroy                      cuEventDestroy_v2
+#define cuCtxDestroy cuCtxDestroy_v2
+#define cuCtxPopCurrent cuCtxPopCurrent_v2
+#define cuCtxPushCurrent cuCtxPushCurrent_v2
+#define cuStreamDestroy cuStreamDestroy_v2
+#define cuEventDestroy cuEventDestroy_v2
 #endif /* __CUDA_API_VERSION_INTERNAL || __CUDA_API_VERSION >= 4000 */
 #if defined(__CUDA_API_VERSION_INTERNAL) || __CUDA_API_VERSION >= 4010
-    #define cuTexRefSetAddress2D                cuTexRefSetAddress2D_v3
+#define cuTexRefSetAddress2D cuTexRefSetAddress2D_v3
 #endif /* __CUDA_API_VERSION_INTERNAL || __CUDA_API_VERSION >= 4010 */
 #if defined(__CUDA_API_VERSION_INTERNAL) || __CUDA_API_VERSION >= 6050
-    #define cuLinkCreate                        cuLinkCreate_v2
-    #define cuLinkAddData                       cuLinkAddData_v2
-    #define cuLinkAddFile                       cuLinkAddFile_v2
+#define cuLinkCreate cuLinkCreate_v2
+#define cuLinkAddData cuLinkAddData_v2
+#define cuLinkAddFile cuLinkAddFile_v2
 #endif /* __CUDA_API_VERSION_INTERNAL || __CUDA_API_VERSION >= 6050 */
 #if defined(__CUDA_API_VERSION_INTERNAL) || __CUDA_API_VERSION >= 6050
-    #define cuMemHostRegister                   cuMemHostRegister_v2
-    #define cuGraphicsResourceSetMapFlags       cuGraphicsResourceSetMapFlags_v2
+#define cuMemHostRegister cuMemHostRegister_v2
+#define cuGraphicsResourceSetMapFlags cuGraphicsResourceSetMapFlags_v2
 #endif /* __CUDA_API_VERSION_INTERNAL || __CUDA_API_VERSION >= 6050 */
 #if defined(__CUDA_API_VERSION_INTERNAL) || __CUDA_API_VERSION >= 10010
-    #define cuStreamBeginCapture                __CUDA_API_PTSZ(cuStreamBeginCapture_v2)
+#define cuStreamBeginCapture __CUDA_API_PTSZ(cuStreamBeginCapture_v2)
 #elif defined(__CUDA_API_PER_THREAD_DEFAULT_STREAM)
-    #define cuStreamBeginCapture                __CUDA_API_PTSZ(cuStreamBeginCapture)
+#define cuStreamBeginCapture __CUDA_API_PTSZ(cuStreamBeginCapture)
 #endif /* __CUDA_API_VERSION_INTERNAL || __CUDA_API_VERSION >= 10010 */
 
 #if !defined(__CUDA_API_VERSION_INTERNAL)
-#if defined(__CUDA_API_VERSION) && __CUDA_API_VERSION >= 3020 && __CUDA_API_VERSION < 4010
-    #define cuTexRefSetAddress2D                cuTexRefSetAddress2D_v2
-#endif /* __CUDA_API_VERSION && __CUDA_API_VERSION >= 3020 && __CUDA_API_VERSION < 4010 */
+#if defined(__CUDA_API_VERSION) && __CUDA_API_VERSION >= 3020 && \
+    __CUDA_API_VERSION < 4010
+#define cuTexRefSetAddress2D cuTexRefSetAddress2D_v2
+#endif /* __CUDA_API_VERSION && __CUDA_API_VERSION >= 3020 && \
+          __CUDA_API_VERSION < 4010 */
 #endif /* __CUDA_API_VERSION_INTERNAL */
 
 #if defined(__CUDA_API_PER_THREAD_DEFAULT_STREAM)
-    #define cuMemcpy                            __CUDA_API_PTDS(cuMemcpy)
-    #define cuMemcpyAsync                       __CUDA_API_PTSZ(cuMemcpyAsync)
-    #define cuMemcpyPeer                        __CUDA_API_PTDS(cuMemcpyPeer)
-    #define cuMemcpyPeerAsync                   __CUDA_API_PTSZ(cuMemcpyPeerAsync)
-    #define cuMemcpy3DPeer                      __CUDA_API_PTDS(cuMemcpy3DPeer)
-    #define cuMemcpy3DPeerAsync                 __CUDA_API_PTSZ(cuMemcpy3DPeerAsync)
-    #define cuMemPrefetchAsync                  __CUDA_API_PTSZ(cuMemPrefetchAsync)
+#define cuMemcpy __CUDA_API_PTDS(cuMemcpy)
+#define cuMemcpyAsync __CUDA_API_PTSZ(cuMemcpyAsync)
+#define cuMemcpyPeer __CUDA_API_PTDS(cuMemcpyPeer)
+#define cuMemcpyPeerAsync __CUDA_API_PTSZ(cuMemcpyPeerAsync)
+#define cuMemcpy3DPeer __CUDA_API_PTDS(cuMemcpy3DPeer)
+#define cuMemcpy3DPeerAsync __CUDA_API_PTSZ(cuMemcpy3DPeerAsync)
+#define cuMemPrefetchAsync __CUDA_API_PTSZ(cuMemPrefetchAsync)
 
-    #define cuMemsetD8Async                     __CUDA_API_PTSZ(cuMemsetD8Async)
-    #define cuMemsetD16Async                    __CUDA_API_PTSZ(cuMemsetD16Async)
-    #define cuMemsetD32Async                    __CUDA_API_PTSZ(cuMemsetD32Async)
-    #define cuMemsetD2D8Async                   __CUDA_API_PTSZ(cuMemsetD2D8Async)
-    #define cuMemsetD2D16Async                  __CUDA_API_PTSZ(cuMemsetD2D16Async)
-    #define cuMemsetD2D32Async                  __CUDA_API_PTSZ(cuMemsetD2D32Async)
+#define cuMemsetD8Async __CUDA_API_PTSZ(cuMemsetD8Async)
+#define cuMemsetD16Async __CUDA_API_PTSZ(cuMemsetD16Async)
+#define cuMemsetD32Async __CUDA_API_PTSZ(cuMemsetD32Async)
+#define cuMemsetD2D8Async __CUDA_API_PTSZ(cuMemsetD2D8Async)
+#define cuMemsetD2D16Async __CUDA_API_PTSZ(cuMemsetD2D16Async)
+#define cuMemsetD2D32Async __CUDA_API_PTSZ(cuMemsetD2D32Async)
 
-    #define cuStreamGetPriority                 __CUDA_API_PTSZ(cuStreamGetPriority)
-    #define cuStreamGetFlags                    __CUDA_API_PTSZ(cuStreamGetFlags)
-    #define cuStreamGetCtx                      __CUDA_API_PTSZ(cuStreamGetCtx)
-    #define cuStreamWaitEvent                   __CUDA_API_PTSZ(cuStreamWaitEvent)
-    #define cuStreamEndCapture                  __CUDA_API_PTSZ(cuStreamEndCapture)
-    #define cuStreamIsCapturing                 __CUDA_API_PTSZ(cuStreamIsCapturing)
-    #define cuStreamGetCaptureInfo              __CUDA_API_PTSZ(cuStreamGetCaptureInfo)
-    #define cuStreamAddCallback                 __CUDA_API_PTSZ(cuStreamAddCallback)
-    #define cuStreamAttachMemAsync              __CUDA_API_PTSZ(cuStreamAttachMemAsync)
-    #define cuStreamQuery                       __CUDA_API_PTSZ(cuStreamQuery)
-    #define cuStreamSynchronize                 __CUDA_API_PTSZ(cuStreamSynchronize)
-    #define cuEventRecord                       __CUDA_API_PTSZ(cuEventRecord)
-    #define cuLaunchKernel                      __CUDA_API_PTSZ(cuLaunchKernel)
-    #define cuLaunchHostFunc                    __CUDA_API_PTSZ(cuLaunchHostFunc)
-    #define cuGraphicsMapResources              __CUDA_API_PTSZ(cuGraphicsMapResources)
-    #define cuGraphicsUnmapResources            __CUDA_API_PTSZ(cuGraphicsUnmapResources)
+#define cuStreamGetPriority __CUDA_API_PTSZ(cuStreamGetPriority)
+#define cuStreamGetFlags __CUDA_API_PTSZ(cuStreamGetFlags)
+#define cuStreamGetCtx __CUDA_API_PTSZ(cuStreamGetCtx)
+#define cuStreamWaitEvent __CUDA_API_PTSZ(cuStreamWaitEvent)
+#define cuStreamEndCapture __CUDA_API_PTSZ(cuStreamEndCapture)
+#define cuStreamIsCapturing __CUDA_API_PTSZ(cuStreamIsCapturing)
+#define cuStreamGetCaptureInfo __CUDA_API_PTSZ(cuStreamGetCaptureInfo)
+#define cuStreamAddCallback __CUDA_API_PTSZ(cuStreamAddCallback)
+#define cuStreamAttachMemAsync __CUDA_API_PTSZ(cuStreamAttachMemAsync)
+#define cuStreamQuery __CUDA_API_PTSZ(cuStreamQuery)
+#define cuStreamSynchronize __CUDA_API_PTSZ(cuStreamSynchronize)
+#define cuEventRecord __CUDA_API_PTSZ(cuEventRecord)
+#define cuLaunchKernel __CUDA_API_PTSZ(cuLaunchKernel)
+#define cuLaunchHostFunc __CUDA_API_PTSZ(cuLaunchHostFunc)
+#define cuGraphicsMapResources __CUDA_API_PTSZ(cuGraphicsMapResources)
+#define cuGraphicsUnmapResources __CUDA_API_PTSZ(cuGraphicsUnmapResources)
 
-    #define cuStreamWriteValue32                __CUDA_API_PTSZ(cuStreamWriteValue32)
-    #define cuStreamWaitValue32                 __CUDA_API_PTSZ(cuStreamWaitValue32)
-    #define cuStreamWriteValue64                __CUDA_API_PTSZ(cuStreamWriteValue64)
-    #define cuStreamWaitValue64                 __CUDA_API_PTSZ(cuStreamWaitValue64)
-    #define cuStreamBatchMemOp                  __CUDA_API_PTSZ(cuStreamBatchMemOp)
+#define cuStreamWriteValue32 __CUDA_API_PTSZ(cuStreamWriteValue32)
+#define cuStreamWaitValue32 __CUDA_API_PTSZ(cuStreamWaitValue32)
+#define cuStreamWriteValue64 __CUDA_API_PTSZ(cuStreamWriteValue64)
+#define cuStreamWaitValue64 __CUDA_API_PTSZ(cuStreamWaitValue64)
+#define cuStreamBatchMemOp __CUDA_API_PTSZ(cuStreamBatchMemOp)
 
-    #define cuLaunchCooperativeKernel           __CUDA_API_PTSZ(cuLaunchCooperativeKernel)
+#define cuLaunchCooperativeKernel __CUDA_API_PTSZ(cuLaunchCooperativeKernel)
 
-    #define cuSignalExternalSemaphoresAsync     __CUDA_API_PTSZ(cuSignalExternalSemaphoresAsync)
-    #define cuWaitExternalSemaphoresAsync       __CUDA_API_PTSZ(cuWaitExternalSemaphoresAsync)
+#define cuSignalExternalSemaphoresAsync \
+  __CUDA_API_PTSZ(cuSignalExternalSemaphoresAsync)
+#define cuWaitExternalSemaphoresAsync \
+  __CUDA_API_PTSZ(cuWaitExternalSemaphoresAsync)
 
-    #define cuGraphLaunch                       __CUDA_API_PTSZ(cuGraphLaunch)
+#define cuGraphLaunch __CUDA_API_PTSZ(cuGraphLaunch)
 #endif
 
 /**
@@ -242,7 +248,8 @@ extern "C" {
 
 /**
  * CUDA device pointer
- * CUdeviceptr is defined as an unsigned integer type whose size matches the size of a pointer on the target platform.
+ * CUdeviceptr is defined as an unsigned integer type whose size matches the
+ * size of a pointer on the target platform.
  */
 #if __CUDA_API_VERSION >= 3020
 
@@ -254,29 +261,34 @@ typedef unsigned int CUdeviceptr;
 
 #endif /* __CUDA_API_VERSION >= 3020 */
 
-typedef int CUdevice;                                     /**< CUDA device */
-typedef struct CUctx_st *CUcontext;                       /**< CUDA context */
-typedef struct CUmod_st *CUmodule;                        /**< CUDA module */
-typedef struct CUfunc_st *CUfunction;                     /**< CUDA function */
-typedef struct CUarray_st *CUarray;                       /**< CUDA array */
-typedef struct CUmipmappedArray_st *CUmipmappedArray;     /**< CUDA mipmapped array */
-typedef struct CUtexref_st *CUtexref;                     /**< CUDA texture reference */
-typedef struct CUsurfref_st *CUsurfref;                   /**< CUDA surface reference */
-typedef struct CUevent_st *CUevent;                       /**< CUDA event */
-typedef struct CUstream_st *CUstream;                     /**< CUDA stream */
-typedef struct CUgraphicsResource_st *CUgraphicsResource; /**< CUDA graphics interop resource */
-typedef unsigned long long CUtexObject;                   /**< An opaque value that represents a CUDA texture object */
-typedef unsigned long long CUsurfObject;                  /**< An opaque value that represents a CUDA surface object */
-typedef struct CUextMemory_st *CUexternalMemory;          /**< CUDA external memory */
-typedef struct CUextSemaphore_st *CUexternalSemaphore;    /**< CUDA external semaphore */
-typedef struct CUgraph_st *CUgraph;                       /**< CUDA graph */
-typedef struct CUgraphNode_st *CUgraphNode;               /**< CUDA graph node */
-typedef struct CUgraphExec_st *CUgraphExec;               /**< CUDA executable graph */
+typedef int CUdevice;                 /**< CUDA device */
+typedef struct CUctx_st *CUcontext;   /**< CUDA context */
+typedef struct CUmod_st *CUmodule;    /**< CUDA module */
+typedef struct CUfunc_st *CUfunction; /**< CUDA function */
+typedef struct CUarray_st *CUarray;   /**< CUDA array */
+typedef struct CUmipmappedArray_st
+    *CUmipmappedArray;                  /**< CUDA mipmapped array */
+typedef struct CUtexref_st *CUtexref;   /**< CUDA texture reference */
+typedef struct CUsurfref_st *CUsurfref; /**< CUDA surface reference */
+typedef struct CUevent_st *CUevent;     /**< CUDA event */
+typedef struct CUstream_st *CUstream;   /**< CUDA stream */
+typedef struct CUgraphicsResource_st
+    *CUgraphicsResource; /**< CUDA graphics interop resource */
+typedef unsigned long long
+    CUtexObject; /**< An opaque value that represents a CUDA texture object */
+typedef unsigned long long
+    CUsurfObject; /**< An opaque value that represents a CUDA surface object */
+typedef struct CUextMemory_st *CUexternalMemory; /**< CUDA external memory */
+typedef struct CUextSemaphore_st
+    *CUexternalSemaphore;                   /**< CUDA external semaphore */
+typedef struct CUgraph_st *CUgraph;         /**< CUDA graph */
+typedef struct CUgraphNode_st *CUgraphNode; /**< CUDA graph node */
+typedef struct CUgraphExec_st *CUgraphExec; /**< CUDA executable graph */
 
 #ifndef CU_UUID_HAS_BEEN_DEFINED
 #define CU_UUID_HAS_BEEN_DEFINED
-typedef struct CUuuid_st {                                /**< CUDA definition of UUID */
-    char bytes[16];
+typedef struct CUuuid_st { /**< CUDA definition of UUID */
+  char bytes[16];
 } CUuuid;
 #endif
 
@@ -291,21 +303,23 @@ typedef struct CUuuid_st {                                /**< CUDA definition o
  * CUDA IPC event handle
  */
 typedef struct CUipcEventHandle_st {
-    char reserved[CU_IPC_HANDLE_SIZE];
+  char reserved[CU_IPC_HANDLE_SIZE];
 } CUipcEventHandle;
 
 /**
  * CUDA IPC mem handle
  */
 typedef struct CUipcMemHandle_st {
-    char reserved[CU_IPC_HANDLE_SIZE];
+  char reserved[CU_IPC_HANDLE_SIZE];
 } CUipcMemHandle;
 
 /**
  * CUDA Ipc Mem Flags
  */
 typedef enum CUipcMem_flags_enum {
-    CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS = 0x1 /**< Automatically enable peer access between remote devices as needed */
+  CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS =
+      0x1 /**< Automatically enable peer access between remote devices as needed
+           */
 } CUipcMem_flags;
 
 #endif
@@ -314,34 +328,41 @@ typedef enum CUipcMem_flags_enum {
  * CUDA Mem Attach Flags
  */
 typedef enum CUmemAttach_flags_enum {
-    CU_MEM_ATTACH_GLOBAL = 0x1, /**< Memory can be accessed by any stream on any device */
-    CU_MEM_ATTACH_HOST   = 0x2, /**< Memory cannot be accessed by any stream on any device */
-    CU_MEM_ATTACH_SINGLE = 0x4  /**< Memory can only be accessed by a single stream on the associated device */
+  CU_MEM_ATTACH_GLOBAL =
+      0x1, /**< Memory can be accessed by any stream on any device */
+  CU_MEM_ATTACH_HOST =
+      0x2, /**< Memory cannot be accessed by any stream on any device */
+  CU_MEM_ATTACH_SINGLE = 0x4 /**< Memory can only be accessed by a single stream
+                                on the associated device */
 } CUmemAttach_flags;
 
 /**
  * Context creation flags
  */
 typedef enum CUctx_flags_enum {
-    CU_CTX_SCHED_AUTO          = 0x00, /**< Automatic scheduling */
-    CU_CTX_SCHED_SPIN          = 0x01, /**< Set spin as default scheduling */
-    CU_CTX_SCHED_YIELD         = 0x02, /**< Set yield as default scheduling */
-    CU_CTX_SCHED_BLOCKING_SYNC = 0x04, /**< Set blocking synchronization as default scheduling */
-    CU_CTX_BLOCKING_SYNC       = 0x04, /**< Set blocking synchronization as default scheduling
-                                         *  \deprecated This flag was deprecated as of CUDA 4.0
-                                         *  and was replaced with ::CU_CTX_SCHED_BLOCKING_SYNC. */
-    CU_CTX_SCHED_MASK          = 0x07,
-    CU_CTX_MAP_HOST            = 0x08, /**< Support mapped pinned allocations */
-    CU_CTX_LMEM_RESIZE_TO_MAX  = 0x10, /**< Keep local memory allocation after launch */
-    CU_CTX_FLAGS_MASK          = 0x1f
+  CU_CTX_SCHED_AUTO = 0x00,  /**< Automatic scheduling */
+  CU_CTX_SCHED_SPIN = 0x01,  /**< Set spin as default scheduling */
+  CU_CTX_SCHED_YIELD = 0x02, /**< Set yield as default scheduling */
+  CU_CTX_SCHED_BLOCKING_SYNC =
+      0x04, /**< Set blocking synchronization as default scheduling */
+  CU_CTX_BLOCKING_SYNC =
+      0x04, /**< Set blocking synchronization as default scheduling
+             *  \deprecated This flag was deprecated as of CUDA 4.0
+             *  and was replaced with ::CU_CTX_SCHED_BLOCKING_SYNC. */
+  CU_CTX_SCHED_MASK = 0x07,
+  CU_CTX_MAP_HOST = 0x08, /**< Support mapped pinned allocations */
+  CU_CTX_LMEM_RESIZE_TO_MAX =
+      0x10, /**< Keep local memory allocation after launch */
+  CU_CTX_FLAGS_MASK = 0x1f
 } CUctx_flags;
 
 /**
  * Stream creation flags
  */
 typedef enum CUstream_flags_enum {
-    CU_STREAM_DEFAULT      = 0x0, /**< Default stream flag */
-    CU_STREAM_NON_BLOCKING = 0x1  /**< Stream does not synchronize with stream 0 (the NULL stream) */
+  CU_STREAM_DEFAULT = 0x0, /**< Default stream flag */
+  CU_STREAM_NON_BLOCKING =
+      0x1 /**< Stream does not synchronize with stream 0 (the NULL stream) */
 } CUstream_flags;
 
 /**
@@ -352,7 +373,7 @@ typedef enum CUstream_flags_enum {
  *
  * See details of the \link_sync_behavior
  */
-#define CU_STREAM_LEGACY     ((CUstream)0x1)
+#define CU_STREAM_LEGACY ((CUstream)0x1)
 
 /**
  * Per-thread stream handle
@@ -368,10 +389,11 @@ typedef enum CUstream_flags_enum {
  * Event creation flags
  */
 typedef enum CUevent_flags_enum {
-    CU_EVENT_DEFAULT        = 0x0, /**< Default event flag */
-    CU_EVENT_BLOCKING_SYNC  = 0x1, /**< Event uses blocking synchronization */
-    CU_EVENT_DISABLE_TIMING = 0x2, /**< Event will not record timing data */
-    CU_EVENT_INTERPROCESS   = 0x4  /**< Event is suitable for interprocess use. CU_EVENT_DISABLE_TIMING must be set */
+  CU_EVENT_DEFAULT = 0x0,        /**< Default event flag */
+  CU_EVENT_BLOCKING_SYNC = 0x1,  /**< Event uses blocking synchronization */
+  CU_EVENT_DISABLE_TIMING = 0x2, /**< Event will not record timing data */
+  CU_EVENT_INTERPROCESS = 0x4    /**< Event is suitable for interprocess use.
+                                    CU_EVENT_DISABLE_TIMING must be set */
 } CUevent_flags;
 
 #if __CUDA_API_VERSION >= 8000
@@ -379,80 +401,93 @@ typedef enum CUevent_flags_enum {
  * Flags for ::cuStreamWaitValue32 and ::cuStreamWaitValue64
  */
 typedef enum CUstreamWaitValue_flags_enum {
-    CU_STREAM_WAIT_VALUE_GEQ   = 0x0,   /**< Wait until (int32_t)(*addr - value) >= 0 (or int64_t for 64 bit
-                                             values). Note this is a cyclic comparison which ignores wraparound.
-                                             (Default behavior.) */
-    CU_STREAM_WAIT_VALUE_EQ    = 0x1,   /**< Wait until *addr == value. */
-    CU_STREAM_WAIT_VALUE_AND   = 0x2,   /**< Wait until (*addr & value) != 0. */
-    CU_STREAM_WAIT_VALUE_NOR   = 0x3,   /**< Wait until ~(*addr | value) != 0. Support for this operation can be
-                                             queried with ::cuDeviceGetAttribute() and
-                                             ::CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_WAIT_VALUE_NOR.*/
-    CU_STREAM_WAIT_VALUE_FLUSH = 1<<30  /**< Follow the wait operation with a flush of outstanding remote writes. This
-                                             means that, if a remote write operation is guaranteed to have reached the
-                                             device before the wait can be satisfied, that write is guaranteed to be
-                                             visible to downstream device work. The device is permitted to reorder
-                                             remote writes internally. For example, this flag would be required if
-                                             two remote writes arrive in a defined order, the wait is satisfied by the
-                                             second write, and downstream work needs to observe the first write.
-                                             Support for this operation is restricted to selected platforms and can be
-                                             queried with ::CU_DEVICE_ATTRIBUTE_CAN_USE_WAIT_VALUE_FLUSH.*/
+  CU_STREAM_WAIT_VALUE_GEQ =
+      0x0, /**< Wait until (int32_t)(*addr - value) >= 0 (or int64_t for 64 bit
+                values). Note this is a cyclic comparison which ignores
+              wraparound. (Default behavior.) */
+  CU_STREAM_WAIT_VALUE_EQ = 0x1,  /**< Wait until *addr == value. */
+  CU_STREAM_WAIT_VALUE_AND = 0x2, /**< Wait until (*addr & value) != 0. */
+  CU_STREAM_WAIT_VALUE_NOR =
+      0x3, /**< Wait until ~(*addr | value) != 0. Support for this operation can
+              be queried with ::cuDeviceGetAttribute() and
+                ::CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_WAIT_VALUE_NOR.*/
+  CU_STREAM_WAIT_VALUE_FLUSH =
+      1 << 30 /**< Follow the wait operation with a flush of outstanding remote
+                 writes. This means that, if a remote write operation is
+                 guaranteed to have reached the device before the wait can be
+                 satisfied, that write is guaranteed to be visible to downstream
+                 device work. The device is permitted to reorder remote writes
+                 internally. For example, this flag would be required if two
+                 remote writes arrive in a defined order, the wait is satisfied
+                 by the second write, and downstream work needs to observe the
+                 first write. Support for this operation is restricted to
+                 selected platforms and can be queried with
+                 ::CU_DEVICE_ATTRIBUTE_CAN_USE_WAIT_VALUE_FLUSH.*/
 } CUstreamWaitValue_flags;
 
 /**
  * Flags for ::cuStreamWriteValue32
  */
 typedef enum CUstreamWriteValue_flags_enum {
-    CU_STREAM_WRITE_VALUE_DEFAULT           = 0x0, /**< Default behavior */
-    CU_STREAM_WRITE_VALUE_NO_MEMORY_BARRIER = 0x1  /**< Permits the write to be reordered with writes which were issued
-                                                        before it, as a performance optimization. Normally,
-                                                        ::cuStreamWriteValue32 will provide a memory fence before the
-                                                        write, which has similar semantics to
-                                                        __threadfence_system() but is scoped to the stream
-                                                        rather than a CUDA thread. */
+  CU_STREAM_WRITE_VALUE_DEFAULT = 0x0, /**< Default behavior */
+  CU_STREAM_WRITE_VALUE_NO_MEMORY_BARRIER =
+      0x1 /**< Permits the write to be reordered with writes which were issued
+               before it, as a performance optimization. Normally,
+               ::cuStreamWriteValue32 will provide a memory fence before the
+               write, which has similar semantics to
+               __threadfence_system() but is scoped to the stream
+               rather than a CUDA thread. */
 } CUstreamWriteValue_flags;
 
 /**
  * Operations for ::cuStreamBatchMemOp
  */
 typedef enum CUstreamBatchMemOpType_enum {
-    CU_STREAM_MEM_OP_WAIT_VALUE_32  = 1,     /**< Represents a ::cuStreamWaitValue32 operation */
-    CU_STREAM_MEM_OP_WRITE_VALUE_32 = 2,     /**< Represents a ::cuStreamWriteValue32 operation */
-    CU_STREAM_MEM_OP_WAIT_VALUE_64  = 4,     /**< Represents a ::cuStreamWaitValue64 operation */
-    CU_STREAM_MEM_OP_WRITE_VALUE_64 = 5,     /**< Represents a ::cuStreamWriteValue64 operation */
-    CU_STREAM_MEM_OP_FLUSH_REMOTE_WRITES = 3 /**< This has the same effect as ::CU_STREAM_WAIT_VALUE_FLUSH, but as a
-                                                  standalone operation. */
+  CU_STREAM_MEM_OP_WAIT_VALUE_32 =
+      1, /**< Represents a ::cuStreamWaitValue32 operation */
+  CU_STREAM_MEM_OP_WRITE_VALUE_32 =
+      2, /**< Represents a ::cuStreamWriteValue32 operation */
+  CU_STREAM_MEM_OP_WAIT_VALUE_64 =
+      4, /**< Represents a ::cuStreamWaitValue64 operation */
+  CU_STREAM_MEM_OP_WRITE_VALUE_64 =
+      5, /**< Represents a ::cuStreamWriteValue64 operation */
+  CU_STREAM_MEM_OP_FLUSH_REMOTE_WRITES =
+      3 /**< This has the same effect as ::CU_STREAM_WAIT_VALUE_FLUSH, but as a
+             standalone operation. */
 } CUstreamBatchMemOpType;
 
 /**
  * Per-operation parameters for ::cuStreamBatchMemOp
  */
 typedef union CUstreamBatchMemOpParams_union {
+  CUstreamBatchMemOpType operation;
+  struct CUstreamMemOpWaitValueParams_st {
     CUstreamBatchMemOpType operation;
-    struct CUstreamMemOpWaitValueParams_st {
-        CUstreamBatchMemOpType operation;
-        CUdeviceptr address;
-        union {
-            cuuint32_t value;
-            cuuint64_t value64;
-        };
-        unsigned int flags;
-        CUdeviceptr alias; /**< For driver internal use. Initial value is unimportant. */
-    } waitValue;
-    struct CUstreamMemOpWriteValueParams_st {
-        CUstreamBatchMemOpType operation;
-        CUdeviceptr address;
-        union {
-            cuuint32_t value;
-            cuuint64_t value64;
-        };
-        unsigned int flags;
-        CUdeviceptr alias; /**< For driver internal use. Initial value is unimportant. */
-    } writeValue;
-    struct CUstreamMemOpFlushRemoteWritesParams_st {
-        CUstreamBatchMemOpType operation;
-        unsigned int flags;
-    } flushRemoteWrites;
-    cuuint64_t pad[6];
+    CUdeviceptr address;
+    union {
+      cuuint32_t value;
+      cuuint64_t value64;
+    };
+    unsigned int flags;
+    CUdeviceptr
+        alias; /**< For driver internal use. Initial value is unimportant. */
+  } waitValue;
+  struct CUstreamMemOpWriteValueParams_st {
+    CUstreamBatchMemOpType operation;
+    CUdeviceptr address;
+    union {
+      cuuint32_t value;
+      cuuint64_t value64;
+    };
+    unsigned int flags;
+    CUdeviceptr
+        alias; /**< For driver internal use. Initial value is unimportant. */
+  } writeValue;
+  struct CUstreamMemOpFlushRemoteWritesParams_st {
+    CUstreamBatchMemOpType operation;
+    unsigned int flags;
+  } flushRemoteWrites;
+  cuuint64_t pad[6];
 } CUstreamBatchMemOpParams;
 #endif /* __CUDA_API_VERSION >= 8000 */
 
@@ -460,584 +495,739 @@ typedef union CUstreamBatchMemOpParams_union {
  * Occupancy calculator flag
  */
 typedef enum CUoccupancy_flags_enum {
-    CU_OCCUPANCY_DEFAULT                  = 0x0, /**< Default behavior */
-    CU_OCCUPANCY_DISABLE_CACHING_OVERRIDE = 0x1  /**< Assume global caching is enabled and cannot be automatically turned off */
+  CU_OCCUPANCY_DEFAULT = 0x0, /**< Default behavior */
+  CU_OCCUPANCY_DISABLE_CACHING_OVERRIDE =
+      0x1 /**< Assume global caching is enabled and cannot be automatically
+             turned off */
 } CUoccupancy_flags;
 
 /**
  * Array formats
  */
 typedef enum CUarray_format_enum {
-    CU_AD_FORMAT_UNSIGNED_INT8  = 0x01, /**< Unsigned 8-bit integers */
-    CU_AD_FORMAT_UNSIGNED_INT16 = 0x02, /**< Unsigned 16-bit integers */
-    CU_AD_FORMAT_UNSIGNED_INT32 = 0x03, /**< Unsigned 32-bit integers */
-    CU_AD_FORMAT_SIGNED_INT8    = 0x08, /**< Signed 8-bit integers */
-    CU_AD_FORMAT_SIGNED_INT16   = 0x09, /**< Signed 16-bit integers */
-    CU_AD_FORMAT_SIGNED_INT32   = 0x0a, /**< Signed 32-bit integers */
-    CU_AD_FORMAT_HALF           = 0x10, /**< 16-bit floating point */
-    CU_AD_FORMAT_FLOAT          = 0x20  /**< 32-bit floating point */
+  CU_AD_FORMAT_UNSIGNED_INT8 = 0x01,  /**< Unsigned 8-bit integers */
+  CU_AD_FORMAT_UNSIGNED_INT16 = 0x02, /**< Unsigned 16-bit integers */
+  CU_AD_FORMAT_UNSIGNED_INT32 = 0x03, /**< Unsigned 32-bit integers */
+  CU_AD_FORMAT_SIGNED_INT8 = 0x08,    /**< Signed 8-bit integers */
+  CU_AD_FORMAT_SIGNED_INT16 = 0x09,   /**< Signed 16-bit integers */
+  CU_AD_FORMAT_SIGNED_INT32 = 0x0a,   /**< Signed 32-bit integers */
+  CU_AD_FORMAT_HALF = 0x10,           /**< 16-bit floating point */
+  CU_AD_FORMAT_FLOAT = 0x20           /**< 32-bit floating point */
 } CUarray_format;
 
 /**
  * Texture reference addressing modes
  */
 typedef enum CUaddress_mode_enum {
-    CU_TR_ADDRESS_MODE_WRAP   = 0, /**< Wrapping address mode */
-    CU_TR_ADDRESS_MODE_CLAMP  = 1, /**< Clamp to edge address mode */
-    CU_TR_ADDRESS_MODE_MIRROR = 2, /**< Mirror address mode */
-    CU_TR_ADDRESS_MODE_BORDER = 3  /**< Border address mode */
+  CU_TR_ADDRESS_MODE_WRAP = 0,   /**< Wrapping address mode */
+  CU_TR_ADDRESS_MODE_CLAMP = 1,  /**< Clamp to edge address mode */
+  CU_TR_ADDRESS_MODE_MIRROR = 2, /**< Mirror address mode */
+  CU_TR_ADDRESS_MODE_BORDER = 3  /**< Border address mode */
 } CUaddress_mode;
 
 /**
  * Texture reference filtering modes
  */
 typedef enum CUfilter_mode_enum {
-    CU_TR_FILTER_MODE_POINT  = 0, /**< Point filter mode */
-    CU_TR_FILTER_MODE_LINEAR = 1  /**< Linear filter mode */
+  CU_TR_FILTER_MODE_POINT = 0, /**< Point filter mode */
+  CU_TR_FILTER_MODE_LINEAR = 1 /**< Linear filter mode */
 } CUfilter_mode;
 
 /**
  * Device properties
  */
 typedef enum CUdevice_attribute_enum {
-    CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK = 1,              /**< Maximum number of threads per block */
-    CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X = 2,                    /**< Maximum block dimension X */
-    CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y = 3,                    /**< Maximum block dimension Y */
-    CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z = 4,                    /**< Maximum block dimension Z */
-    CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X = 5,                     /**< Maximum grid dimension X */
-    CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y = 6,                     /**< Maximum grid dimension Y */
-    CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Z = 7,                     /**< Maximum grid dimension Z */
-    CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK = 8,        /**< Maximum shared memory available per block in bytes */
-    CU_DEVICE_ATTRIBUTE_SHARED_MEMORY_PER_BLOCK = 8,            /**< Deprecated, use CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK */
-    CU_DEVICE_ATTRIBUTE_TOTAL_CONSTANT_MEMORY = 9,              /**< Memory available on device for __constant__ variables in a CUDA C kernel in bytes */
-    CU_DEVICE_ATTRIBUTE_WARP_SIZE = 10,                         /**< Warp size in threads */
-    CU_DEVICE_ATTRIBUTE_MAX_PITCH = 11,                         /**< Maximum pitch in bytes allowed by memory copies */
-    CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK = 12,           /**< Maximum number of 32-bit registers available per block */
-    CU_DEVICE_ATTRIBUTE_REGISTERS_PER_BLOCK = 12,               /**< Deprecated, use CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK */
-    CU_DEVICE_ATTRIBUTE_CLOCK_RATE = 13,                        /**< Typical clock frequency in kilohertz */
-    CU_DEVICE_ATTRIBUTE_TEXTURE_ALIGNMENT = 14,                 /**< Alignment requirement for textures */
-    CU_DEVICE_ATTRIBUTE_GPU_OVERLAP = 15,                       /**< Device can possibly copy memory and execute a kernel concurrently. Deprecated. Use instead CU_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT. */
-    CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT = 16,              /**< Number of multiprocessors on device */
-    CU_DEVICE_ATTRIBUTE_KERNEL_EXEC_TIMEOUT = 17,               /**< Specifies whether there is a run time limit on kernels */
-    CU_DEVICE_ATTRIBUTE_INTEGRATED = 18,                        /**< Device is integrated with host memory */
-    CU_DEVICE_ATTRIBUTE_CAN_MAP_HOST_MEMORY = 19,               /**< Device can map host memory into CUDA address space */
-    CU_DEVICE_ATTRIBUTE_COMPUTE_MODE = 20,                      /**< Compute mode (See ::CUcomputemode for details) */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_WIDTH = 21,           /**< Maximum 1D texture width */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_WIDTH = 22,           /**< Maximum 2D texture width */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_HEIGHT = 23,          /**< Maximum 2D texture height */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_WIDTH = 24,           /**< Maximum 3D texture width */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_HEIGHT = 25,          /**< Maximum 3D texture height */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_DEPTH = 26,           /**< Maximum 3D texture depth */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_WIDTH = 27,   /**< Maximum 2D layered texture width */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_HEIGHT = 28,  /**< Maximum 2D layered texture height */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_LAYERS = 29,  /**< Maximum layers in a 2D layered texture */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_ARRAY_WIDTH = 27,     /**< Deprecated, use CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_WIDTH */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_ARRAY_HEIGHT = 28,    /**< Deprecated, use CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_HEIGHT */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_ARRAY_NUMSLICES = 29, /**< Deprecated, use CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_LAYERS */
-    CU_DEVICE_ATTRIBUTE_SURFACE_ALIGNMENT = 30,                 /**< Alignment requirement for surfaces */
-    CU_DEVICE_ATTRIBUTE_CONCURRENT_KERNELS = 31,                /**< Device can possibly execute multiple kernels concurrently */
-    CU_DEVICE_ATTRIBUTE_ECC_ENABLED = 32,                       /**< Device has ECC support enabled */
-    CU_DEVICE_ATTRIBUTE_PCI_BUS_ID = 33,                        /**< PCI bus ID of the device */
-    CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID = 34,                     /**< PCI device ID of the device */
-    CU_DEVICE_ATTRIBUTE_TCC_DRIVER = 35,                        /**< Device is using TCC driver model */
-    CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE = 36,                 /**< Peak memory clock frequency in kilohertz */
-    CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH = 37,           /**< Global memory bus width in bits */
-    CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE = 38,                     /**< Size of L2 cache in bytes */
-    CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR = 39,    /**< Maximum resident threads per multiprocessor */
-    CU_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT = 40,                /**< Number of asynchronous engines */
-    CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING = 41,                /**< Device shares a unified address space with the host */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LAYERED_WIDTH = 42,   /**< Maximum 1D layered texture width */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LAYERED_LAYERS = 43,  /**< Maximum layers in a 1D layered texture */
-    CU_DEVICE_ATTRIBUTE_CAN_TEX2D_GATHER = 44,                  /**< Deprecated, do not use. */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_GATHER_WIDTH = 45,    /**< Maximum 2D texture width if CUDA_ARRAY3D_TEXTURE_GATHER is set */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_GATHER_HEIGHT = 46,   /**< Maximum 2D texture height if CUDA_ARRAY3D_TEXTURE_GATHER is set */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_WIDTH_ALTERNATE = 47, /**< Alternate maximum 3D texture width */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_HEIGHT_ALTERNATE = 48,/**< Alternate maximum 3D texture height */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_DEPTH_ALTERNATE = 49, /**< Alternate maximum 3D texture depth */
-    CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID = 50,                     /**< PCI domain ID of the device */
-    CU_DEVICE_ATTRIBUTE_TEXTURE_PITCH_ALIGNMENT = 51,           /**< Pitch alignment requirement for textures */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_WIDTH = 52,      /**< Maximum cubemap texture width/height */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_LAYERED_WIDTH = 53,  /**< Maximum cubemap layered texture width/height */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_LAYERED_LAYERS = 54, /**< Maximum layers in a cubemap layered texture */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_WIDTH = 55,           /**< Maximum 1D surface width */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_WIDTH = 56,           /**< Maximum 2D surface width */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_HEIGHT = 57,          /**< Maximum 2D surface height */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_WIDTH = 58,           /**< Maximum 3D surface width */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_HEIGHT = 59,          /**< Maximum 3D surface height */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_DEPTH = 60,           /**< Maximum 3D surface depth */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_LAYERED_WIDTH = 61,   /**< Maximum 1D layered surface width */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_LAYERED_LAYERS = 62,  /**< Maximum layers in a 1D layered surface */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_WIDTH = 63,   /**< Maximum 2D layered surface width */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_HEIGHT = 64,  /**< Maximum 2D layered surface height */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_LAYERS = 65,  /**< Maximum layers in a 2D layered surface */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_WIDTH = 66,      /**< Maximum cubemap surface width */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_LAYERED_WIDTH = 67,  /**< Maximum cubemap layered surface width */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_LAYERED_LAYERS = 68, /**< Maximum layers in a cubemap layered surface */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LINEAR_WIDTH = 69,    /**< Maximum 1D linear texture width */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_WIDTH = 70,    /**< Maximum 2D linear texture width */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_HEIGHT = 71,   /**< Maximum 2D linear texture height */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_PITCH = 72,    /**< Maximum 2D linear texture pitch in bytes */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_MIPMAPPED_WIDTH = 73, /**< Maximum mipmapped 2D texture width */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_MIPMAPPED_HEIGHT = 74,/**< Maximum mipmapped 2D texture height */
-    CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR = 75,          /**< Major compute capability version number */
-    CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR = 76,          /**< Minor compute capability version number */
-    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_MIPMAPPED_WIDTH = 77, /**< Maximum mipmapped 1D texture width */
-    CU_DEVICE_ATTRIBUTE_STREAM_PRIORITIES_SUPPORTED = 78,       /**< Device supports stream priorities */
-    CU_DEVICE_ATTRIBUTE_GLOBAL_L1_CACHE_SUPPORTED = 79,         /**< Device supports caching globals in L1 */
-    CU_DEVICE_ATTRIBUTE_LOCAL_L1_CACHE_SUPPORTED = 80,          /**< Device supports caching locals in L1 */
-    CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR = 81,  /**< Maximum shared memory available per multiprocessor in bytes */
-    CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_MULTIPROCESSOR = 82,  /**< Maximum number of 32-bit registers available per multiprocessor */
-    CU_DEVICE_ATTRIBUTE_MANAGED_MEMORY = 83,                    /**< Device can allocate managed memory on this system */
-    CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD = 84,                    /**< Device is on a multi-GPU board */
-    CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD_GROUP_ID = 85,           /**< Unique id for a group of devices on the same multi-GPU board */
-    CU_DEVICE_ATTRIBUTE_HOST_NATIVE_ATOMIC_SUPPORTED = 86,       /**< Link between the device and the host supports native atomic operations (this is a placeholder attribute, and is not supported on any current hardware)*/
-    CU_DEVICE_ATTRIBUTE_SINGLE_TO_DOUBLE_PRECISION_PERF_RATIO = 87,  /**< Ratio of single precision performance (in floating-point operations per second) to double precision performance */
-    CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS = 88,            /**< Device supports coherently accessing pageable memory without calling cudaHostRegister on it */
-    CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS = 89,         /**< Device can coherently access managed memory concurrently with the CPU */
-    CU_DEVICE_ATTRIBUTE_COMPUTE_PREEMPTION_SUPPORTED = 90,      /**< Device supports compute preemption. */
-    CU_DEVICE_ATTRIBUTE_CAN_USE_HOST_POINTER_FOR_REGISTERED_MEM = 91, /**< Device can access host registered memory at the same virtual address as the CPU */
-    CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS = 92,            /**< ::cuStreamBatchMemOp and related APIs are supported. */
-    CU_DEVICE_ATTRIBUTE_CAN_USE_64_BIT_STREAM_MEM_OPS = 93,     /**< 64-bit operations are supported in ::cuStreamBatchMemOp and related APIs. */
-    CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_WAIT_VALUE_NOR = 94,     /**< ::CU_STREAM_WAIT_VALUE_NOR is supported. */
-    CU_DEVICE_ATTRIBUTE_COOPERATIVE_LAUNCH = 95,                /**< Device supports launching cooperative kernels via ::cuLaunchCooperativeKernel */
-    CU_DEVICE_ATTRIBUTE_COOPERATIVE_MULTI_DEVICE_LAUNCH = 96,   /**< Device can participate in cooperative kernels launched via ::cuLaunchCooperativeKernelMultiDevice */
-    CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN = 97, /**< Maximum optin shared memory per block */
-    CU_DEVICE_ATTRIBUTE_CAN_FLUSH_REMOTE_WRITES = 98,           /**< Both the ::CU_STREAM_WAIT_VALUE_FLUSH flag and the ::CU_STREAM_MEM_OP_FLUSH_REMOTE_WRITES MemOp are supported on the device. See \ref CUDA_MEMOP for additional details. */
-    CU_DEVICE_ATTRIBUTE_HOST_REGISTER_SUPPORTED = 99,           /**< Device supports host memory registration via ::cudaHostRegister. */
-    CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES = 100, /**< Device accesses pageable memory via the host's page tables. */
-    CU_DEVICE_ATTRIBUTE_DIRECT_MANAGED_MEM_ACCESS_FROM_HOST = 101, /**< The host can directly access managed memory on the device without migration. */
-    CU_DEVICE_ATTRIBUTE_MAX
+  CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK =
+      1, /**< Maximum number of threads per block */
+  CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X = 2, /**< Maximum block dimension X */
+  CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y = 3, /**< Maximum block dimension Y */
+  CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z = 4, /**< Maximum block dimension Z */
+  CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X = 5,  /**< Maximum grid dimension X */
+  CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y = 6,  /**< Maximum grid dimension Y */
+  CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Z = 7,  /**< Maximum grid dimension Z */
+  CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK =
+      8, /**< Maximum shared memory available per block in bytes */
+  CU_DEVICE_ATTRIBUTE_SHARED_MEMORY_PER_BLOCK =
+      8, /**< Deprecated, use CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK */
+  CU_DEVICE_ATTRIBUTE_TOTAL_CONSTANT_MEMORY =
+      9, /**< Memory available on device for __constant__ variables in a CUDA C
+            kernel in bytes */
+  CU_DEVICE_ATTRIBUTE_WARP_SIZE = 10, /**< Warp size in threads */
+  CU_DEVICE_ATTRIBUTE_MAX_PITCH =
+      11, /**< Maximum pitch in bytes allowed by memory copies */
+  CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK =
+      12, /**< Maximum number of 32-bit registers available per block */
+  CU_DEVICE_ATTRIBUTE_REGISTERS_PER_BLOCK =
+      12, /**< Deprecated, use CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK */
+  CU_DEVICE_ATTRIBUTE_CLOCK_RATE =
+      13, /**< Typical clock frequency in kilohertz */
+  CU_DEVICE_ATTRIBUTE_TEXTURE_ALIGNMENT =
+      14, /**< Alignment requirement for textures */
+  CU_DEVICE_ATTRIBUTE_GPU_OVERLAP =
+      15, /**< Device can possibly copy memory and execute a kernel
+             concurrently. Deprecated. Use instead
+             CU_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT. */
+  CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT =
+      16, /**< Number of multiprocessors on device */
+  CU_DEVICE_ATTRIBUTE_KERNEL_EXEC_TIMEOUT =
+      17, /**< Specifies whether there is a run time limit on kernels */
+  CU_DEVICE_ATTRIBUTE_INTEGRATED =
+      18, /**< Device is integrated with host memory */
+  CU_DEVICE_ATTRIBUTE_CAN_MAP_HOST_MEMORY =
+      19, /**< Device can map host memory into CUDA address space */
+  CU_DEVICE_ATTRIBUTE_COMPUTE_MODE =
+      20, /**< Compute mode (See ::CUcomputemode for details) */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_WIDTH =
+      21, /**< Maximum 1D texture width */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_WIDTH =
+      22, /**< Maximum 2D texture width */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_HEIGHT =
+      23, /**< Maximum 2D texture height */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_WIDTH =
+      24, /**< Maximum 3D texture width */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_HEIGHT =
+      25, /**< Maximum 3D texture height */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_DEPTH =
+      26, /**< Maximum 3D texture depth */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_WIDTH =
+      27, /**< Maximum 2D layered texture width */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_HEIGHT =
+      28, /**< Maximum 2D layered texture height */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_LAYERS =
+      29, /**< Maximum layers in a 2D layered texture */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_ARRAY_WIDTH =
+      27, /**< Deprecated, use
+             CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_WIDTH */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_ARRAY_HEIGHT =
+      28, /**< Deprecated, use
+             CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_HEIGHT */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_ARRAY_NUMSLICES =
+      29, /**< Deprecated, use
+             CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_LAYERS */
+  CU_DEVICE_ATTRIBUTE_SURFACE_ALIGNMENT =
+      30, /**< Alignment requirement for surfaces */
+  CU_DEVICE_ATTRIBUTE_CONCURRENT_KERNELS =
+      31, /**< Device can possibly execute multiple kernels concurrently */
+  CU_DEVICE_ATTRIBUTE_ECC_ENABLED = 32,   /**< Device has ECC support enabled */
+  CU_DEVICE_ATTRIBUTE_PCI_BUS_ID = 33,    /**< PCI bus ID of the device */
+  CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID = 34, /**< PCI device ID of the device */
+  CU_DEVICE_ATTRIBUTE_TCC_DRIVER = 35, /**< Device is using TCC driver model */
+  CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE =
+      36, /**< Peak memory clock frequency in kilohertz */
+  CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH =
+      37, /**< Global memory bus width in bits */
+  CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE = 38, /**< Size of L2 cache in bytes */
+  CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR =
+      39, /**< Maximum resident threads per multiprocessor */
+  CU_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT =
+      40, /**< Number of asynchronous engines */
+  CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING =
+      41, /**< Device shares a unified address space with the host */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LAYERED_WIDTH =
+      42, /**< Maximum 1D layered texture width */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LAYERED_LAYERS =
+      43, /**< Maximum layers in a 1D layered texture */
+  CU_DEVICE_ATTRIBUTE_CAN_TEX2D_GATHER = 44, /**< Deprecated, do not use. */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_GATHER_WIDTH =
+      45, /**< Maximum 2D texture width if CUDA_ARRAY3D_TEXTURE_GATHER is set */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_GATHER_HEIGHT =
+      46, /**< Maximum 2D texture height if CUDA_ARRAY3D_TEXTURE_GATHER is set
+           */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_WIDTH_ALTERNATE =
+      47, /**< Alternate maximum 3D texture width */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_HEIGHT_ALTERNATE =
+      48, /**< Alternate maximum 3D texture height */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_DEPTH_ALTERNATE =
+      49, /**< Alternate maximum 3D texture depth */
+  CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID = 50, /**< PCI domain ID of the device */
+  CU_DEVICE_ATTRIBUTE_TEXTURE_PITCH_ALIGNMENT =
+      51, /**< Pitch alignment requirement for textures */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_WIDTH =
+      52, /**< Maximum cubemap texture width/height */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_LAYERED_WIDTH =
+      53, /**< Maximum cubemap layered texture width/height */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_LAYERED_LAYERS =
+      54, /**< Maximum layers in a cubemap layered texture */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_WIDTH =
+      55, /**< Maximum 1D surface width */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_WIDTH =
+      56, /**< Maximum 2D surface width */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_HEIGHT =
+      57, /**< Maximum 2D surface height */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_WIDTH =
+      58, /**< Maximum 3D surface width */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_HEIGHT =
+      59, /**< Maximum 3D surface height */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_DEPTH =
+      60, /**< Maximum 3D surface depth */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_LAYERED_WIDTH =
+      61, /**< Maximum 1D layered surface width */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_LAYERED_LAYERS =
+      62, /**< Maximum layers in a 1D layered surface */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_WIDTH =
+      63, /**< Maximum 2D layered surface width */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_HEIGHT =
+      64, /**< Maximum 2D layered surface height */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_LAYERS =
+      65, /**< Maximum layers in a 2D layered surface */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_WIDTH =
+      66, /**< Maximum cubemap surface width */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_LAYERED_WIDTH =
+      67, /**< Maximum cubemap layered surface width */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_LAYERED_LAYERS =
+      68, /**< Maximum layers in a cubemap layered surface */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LINEAR_WIDTH =
+      69, /**< Maximum 1D linear texture width */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_WIDTH =
+      70, /**< Maximum 2D linear texture width */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_HEIGHT =
+      71, /**< Maximum 2D linear texture height */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_PITCH =
+      72, /**< Maximum 2D linear texture pitch in bytes */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_MIPMAPPED_WIDTH =
+      73, /**< Maximum mipmapped 2D texture width */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_MIPMAPPED_HEIGHT =
+      74, /**< Maximum mipmapped 2D texture height */
+  CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR =
+      75, /**< Major compute capability version number */
+  CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR =
+      76, /**< Minor compute capability version number */
+  CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_MIPMAPPED_WIDTH =
+      77, /**< Maximum mipmapped 1D texture width */
+  CU_DEVICE_ATTRIBUTE_STREAM_PRIORITIES_SUPPORTED =
+      78, /**< Device supports stream priorities */
+  CU_DEVICE_ATTRIBUTE_GLOBAL_L1_CACHE_SUPPORTED =
+      79, /**< Device supports caching globals in L1 */
+  CU_DEVICE_ATTRIBUTE_LOCAL_L1_CACHE_SUPPORTED =
+      80, /**< Device supports caching locals in L1 */
+  CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR =
+      81, /**< Maximum shared memory available per multiprocessor in bytes */
+  CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_MULTIPROCESSOR =
+      82, /**< Maximum number of 32-bit registers available per multiprocessor
+           */
+  CU_DEVICE_ATTRIBUTE_MANAGED_MEMORY =
+      83, /**< Device can allocate managed memory on this system */
+  CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD =
+      84, /**< Device is on a multi-GPU board */
+  CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD_GROUP_ID =
+      85, /**< Unique id for a group of devices on the same multi-GPU board */
+  CU_DEVICE_ATTRIBUTE_HOST_NATIVE_ATOMIC_SUPPORTED =
+      86, /**< Link between the device and the host supports native atomic
+             operations (this is a placeholder attribute, and is not supported
+             on any current hardware)*/
+  CU_DEVICE_ATTRIBUTE_SINGLE_TO_DOUBLE_PRECISION_PERF_RATIO =
+      87, /**< Ratio of single precision performance (in floating-point
+             operations per second) to double precision performance */
+  CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS =
+      88, /**< Device supports coherently accessing pageable memory without
+             calling cudaHostRegister on it */
+  CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS =
+      89, /**< Device can coherently access managed memory concurrently with the
+             CPU */
+  CU_DEVICE_ATTRIBUTE_COMPUTE_PREEMPTION_SUPPORTED =
+      90, /**< Device supports compute preemption. */
+  CU_DEVICE_ATTRIBUTE_CAN_USE_HOST_POINTER_FOR_REGISTERED_MEM =
+      91, /**< Device can access host registered memory at the same virtual
+             address as the CPU */
+  CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS =
+      92, /**< ::cuStreamBatchMemOp and related APIs are supported. */
+  CU_DEVICE_ATTRIBUTE_CAN_USE_64_BIT_STREAM_MEM_OPS =
+      93, /**< 64-bit operations are supported in ::cuStreamBatchMemOp and
+             related APIs. */
+  CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_WAIT_VALUE_NOR =
+      94, /**< ::CU_STREAM_WAIT_VALUE_NOR is supported. */
+  CU_DEVICE_ATTRIBUTE_COOPERATIVE_LAUNCH =
+      95, /**< Device supports launching cooperative kernels via
+             ::cuLaunchCooperativeKernel */
+  CU_DEVICE_ATTRIBUTE_COOPERATIVE_MULTI_DEVICE_LAUNCH =
+      96, /**< Device can participate in cooperative kernels launched via
+             ::cuLaunchCooperativeKernelMultiDevice */
+  CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN =
+      97, /**< Maximum optin shared memory per block */
+  CU_DEVICE_ATTRIBUTE_CAN_FLUSH_REMOTE_WRITES =
+      98, /**< Both the ::CU_STREAM_WAIT_VALUE_FLUSH flag and the
+             ::CU_STREAM_MEM_OP_FLUSH_REMOTE_WRITES MemOp are supported on the
+             device. See \ref CUDA_MEMOP for additional details. */
+  CU_DEVICE_ATTRIBUTE_HOST_REGISTER_SUPPORTED =
+      99, /**< Device supports host memory registration via ::cudaHostRegister.
+           */
+  CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES =
+      100, /**< Device accesses pageable memory via the host's page tables. */
+  CU_DEVICE_ATTRIBUTE_DIRECT_MANAGED_MEM_ACCESS_FROM_HOST =
+      101, /**< The host can directly access managed memory on the device
+              without migration. */
+  CU_DEVICE_ATTRIBUTE_MAX
 } CUdevice_attribute;
 
 /**
  * Legacy device properties
  */
 typedef struct CUdevprop_st {
-    int maxThreadsPerBlock;     /**< Maximum number of threads per block */
-    int maxThreadsDim[3];       /**< Maximum size of each dimension of a block */
-    int maxGridSize[3];         /**< Maximum size of each dimension of a grid */
-    int sharedMemPerBlock;      /**< Shared memory available per block in bytes */
-    int totalConstantMemory;    /**< Constant memory available on device in bytes */
-    int SIMDWidth;              /**< Warp size in threads */
-    int memPitch;               /**< Maximum pitch in bytes allowed by memory copies */
-    int regsPerBlock;           /**< 32-bit registers available per block */
-    int clockRate;              /**< Clock frequency in kilohertz */
-    int textureAlign;           /**< Alignment requirement for textures */
+  int maxThreadsPerBlock;  /**< Maximum number of threads per block */
+  int maxThreadsDim[3];    /**< Maximum size of each dimension of a block */
+  int maxGridSize[3];      /**< Maximum size of each dimension of a grid */
+  int sharedMemPerBlock;   /**< Shared memory available per block in bytes */
+  int totalConstantMemory; /**< Constant memory available on device in bytes */
+  int SIMDWidth;           /**< Warp size in threads */
+  int memPitch;     /**< Maximum pitch in bytes allowed by memory copies */
+  int regsPerBlock; /**< 32-bit registers available per block */
+  int clockRate;    /**< Clock frequency in kilohertz */
+  int textureAlign; /**< Alignment requirement for textures */
 } CUdevprop;
 
 /**
  * Pointer information
  */
 typedef enum CUpointer_attribute_enum {
-    CU_POINTER_ATTRIBUTE_CONTEXT = 1,        /**< The ::CUcontext on which a pointer was allocated or registered */
-    CU_POINTER_ATTRIBUTE_MEMORY_TYPE = 2,    /**< The ::CUmemorytype describing the physical location of a pointer */
-    CU_POINTER_ATTRIBUTE_DEVICE_POINTER = 3, /**< The address at which a pointer's memory may be accessed on the device */
-    CU_POINTER_ATTRIBUTE_HOST_POINTER = 4,   /**< The address at which a pointer's memory may be accessed on the host */
-    CU_POINTER_ATTRIBUTE_P2P_TOKENS = 5,     /**< A pair of tokens for use with the nv-p2p.h Linux kernel interface */
-    CU_POINTER_ATTRIBUTE_SYNC_MEMOPS = 6,    /**< Synchronize every synchronous memory operation initiated on this region */
-    CU_POINTER_ATTRIBUTE_BUFFER_ID = 7,      /**< A process-wide unique ID for an allocated memory region*/
-    CU_POINTER_ATTRIBUTE_IS_MANAGED = 8,     /**< Indicates if the pointer points to managed memory */
-    CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL = 9  /**< A device ordinal of a device on which a pointer was allocated or registered */
+  CU_POINTER_ATTRIBUTE_CONTEXT =
+      1, /**< The ::CUcontext on which a pointer was allocated or registered */
+  CU_POINTER_ATTRIBUTE_MEMORY_TYPE = 2, /**< The ::CUmemorytype describing the
+                                           physical location of a pointer */
+  CU_POINTER_ATTRIBUTE_DEVICE_POINTER =
+      3, /**< The address at which a pointer's memory may be accessed on the
+            device */
+  CU_POINTER_ATTRIBUTE_HOST_POINTER =
+      4, /**< The address at which a pointer's memory may be accessed on the
+            host */
+  CU_POINTER_ATTRIBUTE_P2P_TOKENS = 5, /**< A pair of tokens for use with the
+                                          nv-p2p.h Linux kernel interface */
+  CU_POINTER_ATTRIBUTE_SYNC_MEMOPS =
+      6, /**< Synchronize every synchronous memory operation initiated on this
+            region */
+  CU_POINTER_ATTRIBUTE_BUFFER_ID =
+      7, /**< A process-wide unique ID for an allocated memory region*/
+  CU_POINTER_ATTRIBUTE_IS_MANAGED =
+      8, /**< Indicates if the pointer points to managed memory */
+  CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL =
+      9 /**< A device ordinal of a device on which a pointer was allocated or
+           registered */
 } CUpointer_attribute;
 
 /**
  * Function properties
  */
 typedef enum CUfunction_attribute_enum {
-    /**
-     * The maximum number of threads per block, beyond which a launch of the
-     * function would fail. This number depends on both the function and the
-     * device on which the function is currently loaded.
-     */
-    CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK = 0,
+  /**
+   * The maximum number of threads per block, beyond which a launch of the
+   * function would fail. This number depends on both the function and the
+   * device on which the function is currently loaded.
+   */
+  CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK = 0,
 
-    /**
-     * The size in bytes of statically-allocated shared memory required by
-     * this function. This does not include dynamically-allocated shared
-     * memory requested by the user at runtime.
-     */
-    CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES = 1,
+  /**
+   * The size in bytes of statically-allocated shared memory required by
+   * this function. This does not include dynamically-allocated shared
+   * memory requested by the user at runtime.
+   */
+  CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES = 1,
 
-    /**
-     * The size in bytes of user-allocated constant memory required by this
-     * function.
-     */
-    CU_FUNC_ATTRIBUTE_CONST_SIZE_BYTES = 2,
+  /**
+   * The size in bytes of user-allocated constant memory required by this
+   * function.
+   */
+  CU_FUNC_ATTRIBUTE_CONST_SIZE_BYTES = 2,
 
-    /**
-     * The size in bytes of local memory used by each thread of this function.
-     */
-    CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES = 3,
+  /**
+   * The size in bytes of local memory used by each thread of this function.
+   */
+  CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES = 3,
 
-    /**
-     * The number of registers used by each thread of this function.
-     */
-    CU_FUNC_ATTRIBUTE_NUM_REGS = 4,
+  /**
+   * The number of registers used by each thread of this function.
+   */
+  CU_FUNC_ATTRIBUTE_NUM_REGS = 4,
 
-    /**
-     * The PTX virtual architecture version for which the function was
-     * compiled. This value is the major PTX version * 10 + the minor PTX
-     * version, so a PTX version 1.3 function would return the value 13.
-     * Note that this may return the undefined value of 0 for cubins
-     * compiled prior to CUDA 3.0.
-     */
-    CU_FUNC_ATTRIBUTE_PTX_VERSION = 5,
+  /**
+   * The PTX virtual architecture version for which the function was
+   * compiled. This value is the major PTX version * 10 + the minor PTX
+   * version, so a PTX version 1.3 function would return the value 13.
+   * Note that this may return the undefined value of 0 for cubins
+   * compiled prior to CUDA 3.0.
+   */
+  CU_FUNC_ATTRIBUTE_PTX_VERSION = 5,
 
-    /**
-     * The binary architecture version for which the function was compiled.
-     * This value is the major binary version * 10 + the minor binary version,
-     * so a binary version 1.3 function would return the value 13. Note that
-     * this will return a value of 10 for legacy cubins that do not have a
-     * properly-encoded binary architecture version.
-     */
-    CU_FUNC_ATTRIBUTE_BINARY_VERSION = 6,
+  /**
+   * The binary architecture version for which the function was compiled.
+   * This value is the major binary version * 10 + the minor binary version,
+   * so a binary version 1.3 function would return the value 13. Note that
+   * this will return a value of 10 for legacy cubins that do not have a
+   * properly-encoded binary architecture version.
+   */
+  CU_FUNC_ATTRIBUTE_BINARY_VERSION = 6,
 
-    /**
-     * The attribute to indicate whether the function has been compiled with
-     * user specified option "-Xptxas --dlcm=ca" set .
-     */
-    CU_FUNC_ATTRIBUTE_CACHE_MODE_CA = 7,
+  /**
+   * The attribute to indicate whether the function has been compiled with
+   * user specified option "-Xptxas --dlcm=ca" set .
+   */
+  CU_FUNC_ATTRIBUTE_CACHE_MODE_CA = 7,
 
-    /**
-     * The maximum size in bytes of dynamically-allocated shared memory that can be used by
-     * this function. If the user-specified dynamic shared memory size is larger than this
-     * value, the launch will fail.
-     * See ::cuFuncSetAttribute
-     */
-    CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES = 8,
+  /**
+   * The maximum size in bytes of dynamically-allocated shared memory that can
+   * be used by this function. If the user-specified dynamic shared memory size
+   * is larger than this value, the launch will fail. See ::cuFuncSetAttribute
+   */
+  CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES = 8,
 
-    /**
-     * On devices where the L1 cache and shared memory use the same hardware resources,
-     * this sets the shared memory carveout preference, in percent of the total shared memory.
-     * Refer to ::CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR.
-     * This is only a hint, and the driver can choose a different ratio if required to execute the function.
-     * See ::cuFuncSetAttribute
-     */
-    CU_FUNC_ATTRIBUTE_PREFERRED_SHARED_MEMORY_CARVEOUT = 9,
+  /**
+   * On devices where the L1 cache and shared memory use the same hardware
+   * resources, this sets the shared memory carveout preference, in percent of
+   * the total shared memory. Refer to
+   * ::CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR. This is only a
+   * hint, and the driver can choose a different ratio if required to execute
+   * the function. See ::cuFuncSetAttribute
+   */
+  CU_FUNC_ATTRIBUTE_PREFERRED_SHARED_MEMORY_CARVEOUT = 9,
 
-    CU_FUNC_ATTRIBUTE_MAX
+  CU_FUNC_ATTRIBUTE_MAX
 } CUfunction_attribute;
 
 /**
  * Function cache configurations
  */
 typedef enum CUfunc_cache_enum {
-    CU_FUNC_CACHE_PREFER_NONE    = 0x00, /**< no preference for shared memory or L1 (default) */
-    CU_FUNC_CACHE_PREFER_SHARED  = 0x01, /**< prefer larger shared memory and smaller L1 cache */
-    CU_FUNC_CACHE_PREFER_L1      = 0x02, /**< prefer larger L1 cache and smaller shared memory */
-    CU_FUNC_CACHE_PREFER_EQUAL   = 0x03  /**< prefer equal sized L1 cache and shared memory */
+  CU_FUNC_CACHE_PREFER_NONE =
+      0x00, /**< no preference for shared memory or L1 (default) */
+  CU_FUNC_CACHE_PREFER_SHARED =
+      0x01, /**< prefer larger shared memory and smaller L1 cache */
+  CU_FUNC_CACHE_PREFER_L1 =
+      0x02, /**< prefer larger L1 cache and smaller shared memory */
+  CU_FUNC_CACHE_PREFER_EQUAL =
+      0x03 /**< prefer equal sized L1 cache and shared memory */
 } CUfunc_cache;
 
 /**
  * Shared memory configurations
  */
 typedef enum CUsharedconfig_enum {
-    CU_SHARED_MEM_CONFIG_DEFAULT_BANK_SIZE    = 0x00, /**< set default shared memory bank size */
-    CU_SHARED_MEM_CONFIG_FOUR_BYTE_BANK_SIZE  = 0x01, /**< set shared memory bank width to four bytes */
-    CU_SHARED_MEM_CONFIG_EIGHT_BYTE_BANK_SIZE = 0x02  /**< set shared memory bank width to eight bytes */
+  CU_SHARED_MEM_CONFIG_DEFAULT_BANK_SIZE =
+      0x00, /**< set default shared memory bank size */
+  CU_SHARED_MEM_CONFIG_FOUR_BYTE_BANK_SIZE =
+      0x01, /**< set shared memory bank width to four bytes */
+  CU_SHARED_MEM_CONFIG_EIGHT_BYTE_BANK_SIZE =
+      0x02 /**< set shared memory bank width to eight bytes */
 } CUsharedconfig;
 
 /**
- * Shared memory carveout configurations. These may be passed to ::cuFuncSetAttribute
+ * Shared memory carveout configurations. These may be passed to
+ * ::cuFuncSetAttribute
  */
 typedef enum CUshared_carveout_enum {
-    CU_SHAREDMEM_CARVEOUT_DEFAULT       = -1,  /**< No preference for shared memory or L1 (default) */
-    CU_SHAREDMEM_CARVEOUT_MAX_SHARED    = 100, /**< Prefer maximum available shared memory, minimum L1 cache */
-    CU_SHAREDMEM_CARVEOUT_MAX_L1        = 0    /**< Prefer maximum available L1 cache, minimum shared memory */
+  CU_SHAREDMEM_CARVEOUT_DEFAULT =
+      -1, /**< No preference for shared memory or L1 (default) */
+  CU_SHAREDMEM_CARVEOUT_MAX_SHARED =
+      100, /**< Prefer maximum available shared memory, minimum L1 cache */
+  CU_SHAREDMEM_CARVEOUT_MAX_L1 =
+      0 /**< Prefer maximum available L1 cache, minimum shared memory */
 } CUshared_carveout;
 
 /**
  * Memory types
  */
 typedef enum CUmemorytype_enum {
-    CU_MEMORYTYPE_HOST    = 0x01,    /**< Host memory */
-    CU_MEMORYTYPE_DEVICE  = 0x02,    /**< Device memory */
-    CU_MEMORYTYPE_ARRAY   = 0x03,    /**< Array memory */
-    CU_MEMORYTYPE_UNIFIED = 0x04     /**< Unified device or host memory */
+  CU_MEMORYTYPE_HOST = 0x01,   /**< Host memory */
+  CU_MEMORYTYPE_DEVICE = 0x02, /**< Device memory */
+  CU_MEMORYTYPE_ARRAY = 0x03,  /**< Array memory */
+  CU_MEMORYTYPE_UNIFIED = 0x04 /**< Unified device or host memory */
 } CUmemorytype;
 
 /**
  * Compute Modes
  */
 typedef enum CUcomputemode_enum {
-    CU_COMPUTEMODE_DEFAULT           = 0, /**< Default compute mode (Multiple contexts allowed per device) */
-    CU_COMPUTEMODE_PROHIBITED        = 2, /**< Compute-prohibited mode (No contexts can be created on this device at this time) */
-    CU_COMPUTEMODE_EXCLUSIVE_PROCESS = 3  /**< Compute-exclusive-process mode (Only one context used by a single process can be present on this device at a time) */
+  CU_COMPUTEMODE_DEFAULT =
+      0, /**< Default compute mode (Multiple contexts allowed per device) */
+  CU_COMPUTEMODE_PROHIBITED = 2, /**< Compute-prohibited mode (No contexts can
+                                    be created on this device at this time) */
+  CU_COMPUTEMODE_EXCLUSIVE_PROCESS =
+      3 /**< Compute-exclusive-process mode (Only one context used by a single
+           process can be present on this device at a time) */
 } CUcomputemode;
 
 /**
  * Memory advise values
  */
 typedef enum CUmem_advise_enum {
-    CU_MEM_ADVISE_SET_READ_MOSTLY          = 1, /**< Data will mostly be read and only occassionally be written to */
-    CU_MEM_ADVISE_UNSET_READ_MOSTLY        = 2, /**< Undo the effect of ::CU_MEM_ADVISE_SET_READ_MOSTLY */
-    CU_MEM_ADVISE_SET_PREFERRED_LOCATION   = 3, /**< Set the preferred location for the data as the specified device */
-    CU_MEM_ADVISE_UNSET_PREFERRED_LOCATION = 4, /**< Clear the preferred location for the data */
-    CU_MEM_ADVISE_SET_ACCESSED_BY          = 5, /**< Data will be accessed by the specified device, so prevent page faults as much as possible */
-    CU_MEM_ADVISE_UNSET_ACCESSED_BY        = 6  /**< Let the Unified Memory subsystem decide on the page faulting policy for the specified device */
+  CU_MEM_ADVISE_SET_READ_MOSTLY =
+      1, /**< Data will mostly be read and only occassionally be written to */
+  CU_MEM_ADVISE_UNSET_READ_MOSTLY =
+      2, /**< Undo the effect of ::CU_MEM_ADVISE_SET_READ_MOSTLY */
+  CU_MEM_ADVISE_SET_PREFERRED_LOCATION =
+      3, /**< Set the preferred location for the data as the specified device */
+  CU_MEM_ADVISE_UNSET_PREFERRED_LOCATION =
+      4, /**< Clear the preferred location for the data */
+  CU_MEM_ADVISE_SET_ACCESSED_BY =
+      5, /**< Data will be accessed by the specified device, so prevent page
+            faults as much as possible */
+  CU_MEM_ADVISE_UNSET_ACCESSED_BY =
+      6 /**< Let the Unified Memory subsystem decide on the page faulting policy
+           for the specified device */
 } CUmem_advise;
 
 typedef enum CUmem_range_attribute_enum {
-    CU_MEM_RANGE_ATTRIBUTE_READ_MOSTLY            = 1, /**< Whether the range will mostly be read and only occassionally be written to */
-    CU_MEM_RANGE_ATTRIBUTE_PREFERRED_LOCATION     = 2, /**< The preferred location of the range */
-    CU_MEM_RANGE_ATTRIBUTE_ACCESSED_BY            = 3, /**< Memory range has ::CU_MEM_ADVISE_SET_ACCESSED_BY set for specified device */
-    CU_MEM_RANGE_ATTRIBUTE_LAST_PREFETCH_LOCATION = 4  /**< The last location to which the range was prefetched */
+  CU_MEM_RANGE_ATTRIBUTE_READ_MOSTLY =
+      1, /**< Whether the range will mostly be read and only occassionally be
+            written to */
+  CU_MEM_RANGE_ATTRIBUTE_PREFERRED_LOCATION =
+      2, /**< The preferred location of the range */
+  CU_MEM_RANGE_ATTRIBUTE_ACCESSED_BY =
+      3, /**< Memory range has ::CU_MEM_ADVISE_SET_ACCESSED_BY set for specified
+            device */
+  CU_MEM_RANGE_ATTRIBUTE_LAST_PREFETCH_LOCATION =
+      4 /**< The last location to which the range was prefetched */
 } CUmem_range_attribute;
 
 /**
  * Online compiler and linker options
  */
-typedef enum CUjit_option_enum
-{
-    /**
-     * Max number of registers that a thread may use.\n
-     * Option type: unsigned int\n
-     * Applies to: compiler only
-     */
-    CU_JIT_MAX_REGISTERS = 0,
+typedef enum CUjit_option_enum {
+  /**
+   * Max number of registers that a thread may use.\n
+   * Option type: unsigned int\n
+   * Applies to: compiler only
+   */
+  CU_JIT_MAX_REGISTERS = 0,
 
-    /**
-     * IN: Specifies minimum number of threads per block to target compilation
-     * for\n
-     * OUT: Returns the number of threads the compiler actually targeted.
-     * This restricts the resource utilization fo the compiler (e.g. max
-     * registers) such that a block with the given number of threads should be
-     * able to launch based on register limitations. Note, this option does not
-     * currently take into account any other resource limitations, such as
-     * shared memory utilization.\n
-     * Cannot be combined with ::CU_JIT_TARGET.\n
-     * Option type: unsigned int\n
-     * Applies to: compiler only
-     */
-    CU_JIT_THREADS_PER_BLOCK,
+  /**
+   * IN: Specifies minimum number of threads per block to target compilation
+   * for\n
+   * OUT: Returns the number of threads the compiler actually targeted.
+   * This restricts the resource utilization fo the compiler (e.g. max
+   * registers) such that a block with the given number of threads should be
+   * able to launch based on register limitations. Note, this option does not
+   * currently take into account any other resource limitations, such as
+   * shared memory utilization.\n
+   * Cannot be combined with ::CU_JIT_TARGET.\n
+   * Option type: unsigned int\n
+   * Applies to: compiler only
+   */
+  CU_JIT_THREADS_PER_BLOCK,
 
-    /**
-     * Overwrites the option value with the total wall clock time, in
-     * milliseconds, spent in the compiler and linker\n
-     * Option type: float\n
-     * Applies to: compiler and linker
-     */
-    CU_JIT_WALL_TIME,
+  /**
+   * Overwrites the option value with the total wall clock time, in
+   * milliseconds, spent in the compiler and linker\n
+   * Option type: float\n
+   * Applies to: compiler and linker
+   */
+  CU_JIT_WALL_TIME,
 
-    /**
-     * Pointer to a buffer in which to print any log messages
-     * that are informational in nature (the buffer size is specified via
-     * option ::CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES)\n
-     * Option type: char *\n
-     * Applies to: compiler and linker
-     */
-    CU_JIT_INFO_LOG_BUFFER,
+  /**
+   * Pointer to a buffer in which to print any log messages
+   * that are informational in nature (the buffer size is specified via
+   * option ::CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES)\n
+   * Option type: char *\n
+   * Applies to: compiler and linker
+   */
+  CU_JIT_INFO_LOG_BUFFER,
 
-    /**
-     * IN: Log buffer size in bytes.  Log messages will be capped at this size
-     * (including null terminator)\n
-     * OUT: Amount of log buffer filled with messages\n
-     * Option type: unsigned int\n
-     * Applies to: compiler and linker
-     */
-    CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES,
+  /**
+   * IN: Log buffer size in bytes.  Log messages will be capped at this size
+   * (including null terminator)\n
+   * OUT: Amount of log buffer filled with messages\n
+   * Option type: unsigned int\n
+   * Applies to: compiler and linker
+   */
+  CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES,
 
-    /**
-     * Pointer to a buffer in which to print any log messages that
-     * reflect errors (the buffer size is specified via option
-     * ::CU_JIT_ERROR_LOG_BUFFER_SIZE_BYTES)\n
-     * Option type: char *\n
-     * Applies to: compiler and linker
-     */
-    CU_JIT_ERROR_LOG_BUFFER,
+  /**
+   * Pointer to a buffer in which to print any log messages that
+   * reflect errors (the buffer size is specified via option
+   * ::CU_JIT_ERROR_LOG_BUFFER_SIZE_BYTES)\n
+   * Option type: char *\n
+   * Applies to: compiler and linker
+   */
+  CU_JIT_ERROR_LOG_BUFFER,
 
-    /**
-     * IN: Log buffer size in bytes.  Log messages will be capped at this size
-     * (including null terminator)\n
-     * OUT: Amount of log buffer filled with messages\n
-     * Option type: unsigned int\n
-     * Applies to: compiler and linker
-     */
-    CU_JIT_ERROR_LOG_BUFFER_SIZE_BYTES,
+  /**
+   * IN: Log buffer size in bytes.  Log messages will be capped at this size
+   * (including null terminator)\n
+   * OUT: Amount of log buffer filled with messages\n
+   * Option type: unsigned int\n
+   * Applies to: compiler and linker
+   */
+  CU_JIT_ERROR_LOG_BUFFER_SIZE_BYTES,
 
-    /**
-     * Level of optimizations to apply to generated code (0 - 4), with 4
-     * being the default and highest level of optimizations.\n
-     * Option type: unsigned int\n
-     * Applies to: compiler only
-     */
-    CU_JIT_OPTIMIZATION_LEVEL,
+  /**
+   * Level of optimizations to apply to generated code (0 - 4), with 4
+   * being the default and highest level of optimizations.\n
+   * Option type: unsigned int\n
+   * Applies to: compiler only
+   */
+  CU_JIT_OPTIMIZATION_LEVEL,
 
-    /**
-     * No option value required. Determines the target based on the current
-     * attached context (default)\n
-     * Option type: No option value needed\n
-     * Applies to: compiler and linker
-     */
-    CU_JIT_TARGET_FROM_CUCONTEXT,
+  /**
+   * No option value required. Determines the target based on the current
+   * attached context (default)\n
+   * Option type: No option value needed\n
+   * Applies to: compiler and linker
+   */
+  CU_JIT_TARGET_FROM_CUCONTEXT,
 
-    /**
-     * Target is chosen based on supplied ::CUjit_target.  Cannot be
-     * combined with ::CU_JIT_THREADS_PER_BLOCK.\n
-     * Option type: unsigned int for enumerated type ::CUjit_target\n
-     * Applies to: compiler and linker
-     */
-    CU_JIT_TARGET,
+  /**
+   * Target is chosen based on supplied ::CUjit_target.  Cannot be
+   * combined with ::CU_JIT_THREADS_PER_BLOCK.\n
+   * Option type: unsigned int for enumerated type ::CUjit_target\n
+   * Applies to: compiler and linker
+   */
+  CU_JIT_TARGET,
 
-    /**
-     * Specifies choice of fallback strategy if matching cubin is not found.
-     * Choice is based on supplied ::CUjit_fallback.  This option cannot be
-     * used with cuLink* APIs as the linker requires exact matches.\n
-     * Option type: unsigned int for enumerated type ::CUjit_fallback\n
-     * Applies to: compiler only
-     */
-    CU_JIT_FALLBACK_STRATEGY,
+  /**
+   * Specifies choice of fallback strategy if matching cubin is not found.
+   * Choice is based on supplied ::CUjit_fallback.  This option cannot be
+   * used with cuLink* APIs as the linker requires exact matches.\n
+   * Option type: unsigned int for enumerated type ::CUjit_fallback\n
+   * Applies to: compiler only
+   */
+  CU_JIT_FALLBACK_STRATEGY,
 
-    /**
-     * Specifies whether to create debug information in output (-g)
-     * (0: false, default)\n
-     * Option type: int\n
-     * Applies to: compiler and linker
-     */
-    CU_JIT_GENERATE_DEBUG_INFO,
+  /**
+   * Specifies whether to create debug information in output (-g)
+   * (0: false, default)\n
+   * Option type: int\n
+   * Applies to: compiler and linker
+   */
+  CU_JIT_GENERATE_DEBUG_INFO,
 
-    /**
-     * Generate verbose log messages (0: false, default)\n
-     * Option type: int\n
-     * Applies to: compiler and linker
-     */
-    CU_JIT_LOG_VERBOSE,
+  /**
+   * Generate verbose log messages (0: false, default)\n
+   * Option type: int\n
+   * Applies to: compiler and linker
+   */
+  CU_JIT_LOG_VERBOSE,
 
-    /**
-     * Generate line number information (-lineinfo) (0: false, default)\n
-     * Option type: int\n
-     * Applies to: compiler only
-     */
-    CU_JIT_GENERATE_LINE_INFO,
+  /**
+   * Generate line number information (-lineinfo) (0: false, default)\n
+   * Option type: int\n
+   * Applies to: compiler only
+   */
+  CU_JIT_GENERATE_LINE_INFO,
 
-    /**
-     * Specifies whether to enable caching explicitly (-dlcm) \n
-     * Choice is based on supplied ::CUjit_cacheMode_enum.\n
-     * Option type: unsigned int for enumerated type ::CUjit_cacheMode_enum\n
-     * Applies to: compiler only
-     */
-    CU_JIT_CACHE_MODE,
+  /**
+   * Specifies whether to enable caching explicitly (-dlcm) \n
+   * Choice is based on supplied ::CUjit_cacheMode_enum.\n
+   * Option type: unsigned int for enumerated type ::CUjit_cacheMode_enum\n
+   * Applies to: compiler only
+   */
+  CU_JIT_CACHE_MODE,
 
-    /**
-     * The below jit options are used for internal purposes only, in this version of CUDA
-     */
-    CU_JIT_NEW_SM3X_OPT,
-    CU_JIT_FAST_COMPILE,
+  /**
+   * The below jit options are used for internal purposes only, in this version
+   * of CUDA
+   */
+  CU_JIT_NEW_SM3X_OPT,
+  CU_JIT_FAST_COMPILE,
 
-    /**
-     * Array of device symbol names that will be relocated to the corresponing
-     * host addresses stored in ::CU_JIT_GLOBAL_SYMBOL_ADDRESSES.\n
-     * Must contain ::CU_JIT_GLOBAL_SYMBOL_COUNT entries.\n
-     * When loding a device module, driver will relocate all encountered
-     * unresolved symbols to the host addresses.\n
-     * It is only allowed to register symbols that correspond to unresolved
-     * global variables.\n
-     * It is illegal to register the same device symbol at multiple addresses.\n
-     * Option type: const char **\n
-     * Applies to: dynamic linker only
-     */
-    CU_JIT_GLOBAL_SYMBOL_NAMES,
+  /**
+   * Array of device symbol names that will be relocated to the corresponing
+   * host addresses stored in ::CU_JIT_GLOBAL_SYMBOL_ADDRESSES.\n
+   * Must contain ::CU_JIT_GLOBAL_SYMBOL_COUNT entries.\n
+   * When loding a device module, driver will relocate all encountered
+   * unresolved symbols to the host addresses.\n
+   * It is only allowed to register symbols that correspond to unresolved
+   * global variables.\n
+   * It is illegal to register the same device symbol at multiple addresses.\n
+   * Option type: const char **\n
+   * Applies to: dynamic linker only
+   */
+  CU_JIT_GLOBAL_SYMBOL_NAMES,
 
-    /**
-     * Array of host addresses that will be used to relocate corresponding
-     * device symbols stored in ::CU_JIT_GLOBAL_SYMBOL_NAMES.\n
-     * Must contain ::CU_JIT_GLOBAL_SYMBOL_COUNT entries.\n
-     * Option type: void **\n
-     * Applies to: dynamic linker only
-     */
-    CU_JIT_GLOBAL_SYMBOL_ADDRESSES,
+  /**
+   * Array of host addresses that will be used to relocate corresponding
+   * device symbols stored in ::CU_JIT_GLOBAL_SYMBOL_NAMES.\n
+   * Must contain ::CU_JIT_GLOBAL_SYMBOL_COUNT entries.\n
+   * Option type: void **\n
+   * Applies to: dynamic linker only
+   */
+  CU_JIT_GLOBAL_SYMBOL_ADDRESSES,
 
-    /**
-     * Number of entries in ::CU_JIT_GLOBAL_SYMBOL_NAMES and
-     * ::CU_JIT_GLOBAL_SYMBOL_ADDRESSES arrays.\n
-     * Option type: unsigned int\n
-     * Applies to: dynamic linker only
-     */
-    CU_JIT_GLOBAL_SYMBOL_COUNT,
+  /**
+   * Number of entries in ::CU_JIT_GLOBAL_SYMBOL_NAMES and
+   * ::CU_JIT_GLOBAL_SYMBOL_ADDRESSES arrays.\n
+   * Option type: unsigned int\n
+   * Applies to: dynamic linker only
+   */
+  CU_JIT_GLOBAL_SYMBOL_COUNT,
 
-    CU_JIT_NUM_OPTIONS
+  CU_JIT_NUM_OPTIONS
 
 } CUjit_option;
 
 /**
  * Online compilation targets
  */
-typedef enum CUjit_target_enum
-{
-    CU_TARGET_COMPUTE_20 = 20,       /**< Compute device class 2.0 */
-    CU_TARGET_COMPUTE_21 = 21,       /**< Compute device class 2.1 */
-    CU_TARGET_COMPUTE_30 = 30,       /**< Compute device class 3.0 */
-    CU_TARGET_COMPUTE_32 = 32,       /**< Compute device class 3.2 */
-    CU_TARGET_COMPUTE_35 = 35,       /**< Compute device class 3.5 */
-    CU_TARGET_COMPUTE_37 = 37,       /**< Compute device class 3.7 */
-    CU_TARGET_COMPUTE_50 = 50,       /**< Compute device class 5.0 */
-    CU_TARGET_COMPUTE_52 = 52,       /**< Compute device class 5.2 */
-    CU_TARGET_COMPUTE_53 = 53,       /**< Compute device class 5.3 */
-    CU_TARGET_COMPUTE_60 = 60,       /**< Compute device class 6.0.*/
-    CU_TARGET_COMPUTE_61 = 61,       /**< Compute device class 6.1.*/
-    CU_TARGET_COMPUTE_62 = 62,       /**< Compute device class 6.2.*/
-    CU_TARGET_COMPUTE_70 = 70,       /**< Compute device class 7.0.*/
-    CU_TARGET_COMPUTE_72 = 72,       /**< Compute device class 7.2.*/
-    CU_TARGET_COMPUTE_75 = 75        /**< Compute device class 7.5.*/
+typedef enum CUjit_target_enum {
+  CU_TARGET_COMPUTE_20 = 20, /**< Compute device class 2.0 */
+  CU_TARGET_COMPUTE_21 = 21, /**< Compute device class 2.1 */
+  CU_TARGET_COMPUTE_30 = 30, /**< Compute device class 3.0 */
+  CU_TARGET_COMPUTE_32 = 32, /**< Compute device class 3.2 */
+  CU_TARGET_COMPUTE_35 = 35, /**< Compute device class 3.5 */
+  CU_TARGET_COMPUTE_37 = 37, /**< Compute device class 3.7 */
+  CU_TARGET_COMPUTE_50 = 50, /**< Compute device class 5.0 */
+  CU_TARGET_COMPUTE_52 = 52, /**< Compute device class 5.2 */
+  CU_TARGET_COMPUTE_53 = 53, /**< Compute device class 5.3 */
+  CU_TARGET_COMPUTE_60 = 60, /**< Compute device class 6.0.*/
+  CU_TARGET_COMPUTE_61 = 61, /**< Compute device class 6.1.*/
+  CU_TARGET_COMPUTE_62 = 62, /**< Compute device class 6.2.*/
+  CU_TARGET_COMPUTE_70 = 70, /**< Compute device class 7.0.*/
+  CU_TARGET_COMPUTE_72 = 72, /**< Compute device class 7.2.*/
+  CU_TARGET_COMPUTE_75 = 75  /**< Compute device class 7.5.*/
 } CUjit_target;
 
 /**
  * Cubin matching fallback strategies
  */
-typedef enum CUjit_fallback_enum
-{
-    CU_PREFER_PTX = 0,  /**< Prefer to compile ptx if exact binary match not found */
+typedef enum CUjit_fallback_enum {
+  CU_PREFER_PTX =
+      0, /**< Prefer to compile ptx if exact binary match not found */
 
-    CU_PREFER_BINARY    /**< Prefer to fall back to compatible binary code if exact match not found */
+  CU_PREFER_BINARY /**< Prefer to fall back to compatible binary code if exact
+                      match not found */
 
 } CUjit_fallback;
 
 /**
  * Caching modes for dlcm
  */
-typedef enum CUjit_cacheMode_enum
-{
-    CU_JIT_CACHE_OPTION_NONE = 0, /**< Compile with no -dlcm flag specified */
-    CU_JIT_CACHE_OPTION_CG,       /**< Compile with L1 cache disabled */
-    CU_JIT_CACHE_OPTION_CA        /**< Compile with L1 cache enabled */
+typedef enum CUjit_cacheMode_enum {
+  CU_JIT_CACHE_OPTION_NONE = 0, /**< Compile with no -dlcm flag specified */
+  CU_JIT_CACHE_OPTION_CG,       /**< Compile with L1 cache disabled */
+  CU_JIT_CACHE_OPTION_CA        /**< Compile with L1 cache enabled */
 } CUjit_cacheMode;
 
 /**
  * Device code formats
  */
-typedef enum CUjitInputType_enum
-{
-    /**
-     * Compiled device-class-specific device code\n
-     * Applicable options: none
-     */
-    CU_JIT_INPUT_CUBIN = 0,
+typedef enum CUjitInputType_enum {
+  /**
+   * Compiled device-class-specific device code\n
+   * Applicable options: none
+   */
+  CU_JIT_INPUT_CUBIN = 0,
 
-    /**
-     * PTX source code\n
-     * Applicable options: PTX compiler options
-     */
-    CU_JIT_INPUT_PTX,
+  /**
+   * PTX source code\n
+   * Applicable options: PTX compiler options
+   */
+  CU_JIT_INPUT_PTX,
 
-    /**
-     * Bundle of multiple cubins and/or PTX of some device code\n
-     * Applicable options: PTX compiler options, ::CU_JIT_FALLBACK_STRATEGY
-     */
-    CU_JIT_INPUT_FATBINARY,
+  /**
+   * Bundle of multiple cubins and/or PTX of some device code\n
+   * Applicable options: PTX compiler options, ::CU_JIT_FALLBACK_STRATEGY
+   */
+  CU_JIT_INPUT_FATBINARY,
 
-    /**
-     * Host object with embedded device code\n
-     * Applicable options: PTX compiler options, ::CU_JIT_FALLBACK_STRATEGY
-     */
-    CU_JIT_INPUT_OBJECT,
+  /**
+   * Host object with embedded device code\n
+   * Applicable options: PTX compiler options, ::CU_JIT_FALLBACK_STRATEGY
+   */
+  CU_JIT_INPUT_OBJECT,
 
-    /**
-     * Archive of host objects with embedded device code\n
-     * Applicable options: PTX compiler options, ::CU_JIT_FALLBACK_STRATEGY
-     */
-    CU_JIT_INPUT_LIBRARY,
+  /**
+   * Archive of host objects with embedded device code\n
+   * Applicable options: PTX compiler options, ::CU_JIT_FALLBACK_STRATEGY
+   */
+  CU_JIT_INPUT_LIBRARY,
 
-    CU_JIT_NUM_INPUT_TYPES
+  CU_JIT_NUM_INPUT_TYPES
 } CUjitInputType;
 
 #if __CUDA_API_VERSION >= 5050
@@ -1048,55 +1238,59 @@ typedef struct CUlinkState_st *CUlinkState;
  * Flags to register a graphics resource
  */
 typedef enum CUgraphicsRegisterFlags_enum {
-    CU_GRAPHICS_REGISTER_FLAGS_NONE           = 0x00,
-    CU_GRAPHICS_REGISTER_FLAGS_READ_ONLY      = 0x01,
-    CU_GRAPHICS_REGISTER_FLAGS_WRITE_DISCARD  = 0x02,
-    CU_GRAPHICS_REGISTER_FLAGS_SURFACE_LDST   = 0x04,
-    CU_GRAPHICS_REGISTER_FLAGS_TEXTURE_GATHER = 0x08
+  CU_GRAPHICS_REGISTER_FLAGS_NONE = 0x00,
+  CU_GRAPHICS_REGISTER_FLAGS_READ_ONLY = 0x01,
+  CU_GRAPHICS_REGISTER_FLAGS_WRITE_DISCARD = 0x02,
+  CU_GRAPHICS_REGISTER_FLAGS_SURFACE_LDST = 0x04,
+  CU_GRAPHICS_REGISTER_FLAGS_TEXTURE_GATHER = 0x08
 } CUgraphicsRegisterFlags;
 
 /**
  * Flags for mapping and unmapping interop resources
  */
 typedef enum CUgraphicsMapResourceFlags_enum {
-    CU_GRAPHICS_MAP_RESOURCE_FLAGS_NONE          = 0x00,
-    CU_GRAPHICS_MAP_RESOURCE_FLAGS_READ_ONLY     = 0x01,
-    CU_GRAPHICS_MAP_RESOURCE_FLAGS_WRITE_DISCARD = 0x02
+  CU_GRAPHICS_MAP_RESOURCE_FLAGS_NONE = 0x00,
+  CU_GRAPHICS_MAP_RESOURCE_FLAGS_READ_ONLY = 0x01,
+  CU_GRAPHICS_MAP_RESOURCE_FLAGS_WRITE_DISCARD = 0x02
 } CUgraphicsMapResourceFlags;
 
 /**
  * Array indices for cube faces
  */
 typedef enum CUarray_cubemap_face_enum {
-    CU_CUBEMAP_FACE_POSITIVE_X  = 0x00, /**< Positive X face of cubemap */
-    CU_CUBEMAP_FACE_NEGATIVE_X  = 0x01, /**< Negative X face of cubemap */
-    CU_CUBEMAP_FACE_POSITIVE_Y  = 0x02, /**< Positive Y face of cubemap */
-    CU_CUBEMAP_FACE_NEGATIVE_Y  = 0x03, /**< Negative Y face of cubemap */
-    CU_CUBEMAP_FACE_POSITIVE_Z  = 0x04, /**< Positive Z face of cubemap */
-    CU_CUBEMAP_FACE_NEGATIVE_Z  = 0x05  /**< Negative Z face of cubemap */
+  CU_CUBEMAP_FACE_POSITIVE_X = 0x00, /**< Positive X face of cubemap */
+  CU_CUBEMAP_FACE_NEGATIVE_X = 0x01, /**< Negative X face of cubemap */
+  CU_CUBEMAP_FACE_POSITIVE_Y = 0x02, /**< Positive Y face of cubemap */
+  CU_CUBEMAP_FACE_NEGATIVE_Y = 0x03, /**< Negative Y face of cubemap */
+  CU_CUBEMAP_FACE_POSITIVE_Z = 0x04, /**< Positive Z face of cubemap */
+  CU_CUBEMAP_FACE_NEGATIVE_Z = 0x05  /**< Negative Z face of cubemap */
 } CUarray_cubemap_face;
 
 /**
  * Limits
  */
 typedef enum CUlimit_enum {
-    CU_LIMIT_STACK_SIZE                       = 0x00, /**< GPU thread stack size */
-    CU_LIMIT_PRINTF_FIFO_SIZE                 = 0x01, /**< GPU printf FIFO size */
-    CU_LIMIT_MALLOC_HEAP_SIZE                 = 0x02, /**< GPU malloc heap size */
-    CU_LIMIT_DEV_RUNTIME_SYNC_DEPTH           = 0x03, /**< GPU device runtime launch synchronize depth */
-    CU_LIMIT_DEV_RUNTIME_PENDING_LAUNCH_COUNT = 0x04, /**< GPU device runtime pending launch count */
-    CU_LIMIT_MAX_L2_FETCH_GRANULARITY         = 0x05, /**< A value between 0 and 128 that indicates the maximum fetch granularity of L2 (in Bytes). This is a hint */
-    CU_LIMIT_MAX
+  CU_LIMIT_STACK_SIZE = 0x00,       /**< GPU thread stack size */
+  CU_LIMIT_PRINTF_FIFO_SIZE = 0x01, /**< GPU printf FIFO size */
+  CU_LIMIT_MALLOC_HEAP_SIZE = 0x02, /**< GPU malloc heap size */
+  CU_LIMIT_DEV_RUNTIME_SYNC_DEPTH =
+      0x03, /**< GPU device runtime launch synchronize depth */
+  CU_LIMIT_DEV_RUNTIME_PENDING_LAUNCH_COUNT =
+      0x04, /**< GPU device runtime pending launch count */
+  CU_LIMIT_MAX_L2_FETCH_GRANULARITY =
+      0x05, /**< A value between 0 and 128 that indicates the maximum fetch
+               granularity of L2 (in Bytes). This is a hint */
+  CU_LIMIT_MAX
 } CUlimit;
 
 /**
  * Resource types
  */
 typedef enum CUresourcetype_enum {
-    CU_RESOURCE_TYPE_ARRAY           = 0x00, /**< Array resoure */
-    CU_RESOURCE_TYPE_MIPMAPPED_ARRAY = 0x01, /**< Mipmapped array resource */
-    CU_RESOURCE_TYPE_LINEAR          = 0x02, /**< Linear resource */
-    CU_RESOURCE_TYPE_PITCH2D         = 0x03  /**< Pitch 2D resource */
+  CU_RESOURCE_TYPE_ARRAY = 0x00,           /**< Array resoure */
+  CU_RESOURCE_TYPE_MIPMAPPED_ARRAY = 0x01, /**< Mipmapped array resource */
+  CU_RESOURCE_TYPE_LINEAR = 0x02,          /**< Linear resource */
+  CU_RESOURCE_TYPE_PITCH2D = 0x03          /**< Pitch 2D resource */
 } CUresourcetype;
 
 #ifdef _WIN32
@@ -1111,65 +1305,69 @@ typedef enum CUresourcetype_enum {
  * CUDA host function
  * \param userData Argument value passed to the function
  */
-typedef void (CUDA_CB *CUhostFn)(void *userData);
+typedef void(CUDA_CB *CUhostFn)(void *userData);
 
 /**
  * GPU kernel node parameters
  */
 typedef struct CUDA_KERNEL_NODE_PARAMS_st {
-    CUfunction func;             /**< Kernel to launch */
-    unsigned int gridDimX;       /**< Width of grid in blocks */
-    unsigned int gridDimY;       /**< Height of grid in blocks */
-    unsigned int gridDimZ;       /**< Depth of grid in blocks */
-    unsigned int blockDimX;      /**< X dimension of each thread block */
-    unsigned int blockDimY;      /**< Y dimension of each thread block */
-    unsigned int blockDimZ;      /**< Z dimension of each thread block */
-    unsigned int sharedMemBytes; /**< Dynamic shared-memory size per thread block in bytes */
-    void **kernelParams;         /**< Array of pointers to kernel parameters */
-    void **extra;                /**< Extra options */
+  CUfunction func;             /**< Kernel to launch */
+  unsigned int gridDimX;       /**< Width of grid in blocks */
+  unsigned int gridDimY;       /**< Height of grid in blocks */
+  unsigned int gridDimZ;       /**< Depth of grid in blocks */
+  unsigned int blockDimX;      /**< X dimension of each thread block */
+  unsigned int blockDimY;      /**< Y dimension of each thread block */
+  unsigned int blockDimZ;      /**< Z dimension of each thread block */
+  unsigned int sharedMemBytes; /**< Dynamic shared-memory size per thread block
+                                  in bytes */
+  void **kernelParams;         /**< Array of pointers to kernel parameters */
+  void **extra;                /**< Extra options */
 } CUDA_KERNEL_NODE_PARAMS;
 
 /**
  * Memset node parameters
  */
 typedef struct CUDA_MEMSET_NODE_PARAMS_st {
-    CUdeviceptr dst;                        /**< Destination device pointer */
-    size_t pitch;                           /**< Pitch of destination device pointer. Unused if height is 1 */
-    unsigned int value;                     /**< Value to be set */
-    unsigned int elementSize;               /**< Size of each element in bytes. Must be 1, 2, or 4. */
-    size_t width;                           /**< Width in bytes, of the row */
-    size_t height;                          /**< Number of rows */
+  CUdeviceptr dst; /**< Destination device pointer */
+  size_t
+      pitch; /**< Pitch of destination device pointer. Unused if height is 1 */
+  unsigned int value; /**< Value to be set */
+  unsigned int
+      elementSize; /**< Size of each element in bytes. Must be 1, 2, or 4. */
+  size_t width;    /**< Width in bytes, of the row */
+  size_t height;   /**< Number of rows */
 } CUDA_MEMSET_NODE_PARAMS;
 
 /**
  * Host node parameters
  */
 typedef struct CUDA_HOST_NODE_PARAMS_st {
-    CUhostFn fn;    /**< The function to call when the node executes */
-    void* userData; /**< Argument to pass to the function */
+  CUhostFn fn;    /**< The function to call when the node executes */
+  void *userData; /**< Argument to pass to the function */
 } CUDA_HOST_NODE_PARAMS;
 
 /**
  * Graph node types
  */
 typedef enum CUgraphNodeType_enum {
-    CU_GRAPH_NODE_TYPE_KERNEL = 0, /**< GPU kernel node */
-    CU_GRAPH_NODE_TYPE_MEMCPY = 1, /**< Memcpy node */
-    CU_GRAPH_NODE_TYPE_MEMSET = 2, /**< Memset node */
-    CU_GRAPH_NODE_TYPE_HOST   = 3, /**< Host (executable) node */
-    CU_GRAPH_NODE_TYPE_GRAPH  = 4, /**< Node which executes an embedded graph */
-    CU_GRAPH_NODE_TYPE_EMPTY  = 5, /**< Empty (no-op) node */
-    CU_GRAPH_NODE_TYPE_COUNT
+  CU_GRAPH_NODE_TYPE_KERNEL = 0, /**< GPU kernel node */
+  CU_GRAPH_NODE_TYPE_MEMCPY = 1, /**< Memcpy node */
+  CU_GRAPH_NODE_TYPE_MEMSET = 2, /**< Memset node */
+  CU_GRAPH_NODE_TYPE_HOST = 3,   /**< Host (executable) node */
+  CU_GRAPH_NODE_TYPE_GRAPH = 4,  /**< Node which executes an embedded graph */
+  CU_GRAPH_NODE_TYPE_EMPTY = 5,  /**< Empty (no-op) node */
+  CU_GRAPH_NODE_TYPE_COUNT
 } CUgraphNodeType;
 
 /**
  * Possible stream capture statuses returned by ::cuStreamIsCapturing
  */
 typedef enum CUstreamCaptureStatus_enum {
-    CU_STREAM_CAPTURE_STATUS_NONE        = 0, /**< Stream is not capturing */
-    CU_STREAM_CAPTURE_STATUS_ACTIVE      = 1, /**< Stream is actively capturing */
-    CU_STREAM_CAPTURE_STATUS_INVALIDATED = 2  /**< Stream is part of a capture sequence that
-                                                   has been invalidated, but not terminated */
+  CU_STREAM_CAPTURE_STATUS_NONE = 0,   /**< Stream is not capturing */
+  CU_STREAM_CAPTURE_STATUS_ACTIVE = 1, /**< Stream is actively capturing */
+  CU_STREAM_CAPTURE_STATUS_INVALIDATED =
+      2 /**< Stream is part of a capture sequence that
+             has been invalidated, but not terminated */
 } CUstreamCaptureStatus;
 
 #endif /* __CUDA_API_VERSION >= 10000 */
@@ -1181,9 +1379,9 @@ typedef enum CUstreamCaptureStatus_enum {
  * ::cuStreamBeginCapture and ::cuThreadExchangeStreamCaptureMode
  */
 typedef enum CUstreamCaptureMode_enum {
-    CU_STREAM_CAPTURE_MODE_GLOBAL       = 0,
-    CU_STREAM_CAPTURE_MODE_THREAD_LOCAL = 1,
-    CU_STREAM_CAPTURE_MODE_RELAXED      = 2
+  CU_STREAM_CAPTURE_MODE_GLOBAL = 0,
+  CU_STREAM_CAPTURE_MODE_THREAD_LOCAL = 1,
+  CU_STREAM_CAPTURE_MODE_RELAXED = 2
 } CUstreamCaptureMode;
 
 #endif /* __CUDA_API_VERSION >= 10010 */
@@ -1192,521 +1390,530 @@ typedef enum CUstreamCaptureMode_enum {
  * Error codes
  */
 typedef enum cudaError_enum {
-    /**
-     * The API call returned with no errors. In the case of query calls, this
-     * also means that the operation being queried is complete (see
-     * ::cuEventQuery() and ::cuStreamQuery()).
-     */
-    CUDA_SUCCESS                              = 0,
-
-    /**
-     * This indicates that one or more of the parameters passed to the API call
-     * is not within an acceptable range of values.
-     */
-    CUDA_ERROR_INVALID_VALUE                  = 1,
-
-    /**
-     * The API call failed because it was unable to allocate enough memory to
-     * perform the requested operation.
-     */
-    CUDA_ERROR_OUT_OF_MEMORY                  = 2,
-
-    /**
-     * This indicates that the CUDA driver has not been initialized with
-     * ::cuInit() or that initialization has failed.
-     */
-    CUDA_ERROR_NOT_INITIALIZED                = 3,
-
-    /**
-     * This indicates that the CUDA driver is in the process of shutting down.
-     */
-    CUDA_ERROR_DEINITIALIZED                  = 4,
-
-    /**
-     * This indicates profiler is not initialized for this run. This can
-     * happen when the application is running with external profiling tools
-     * like visual profiler.
-     */
-    CUDA_ERROR_PROFILER_DISABLED              = 5,
-
-    /**
-     * \deprecated
-     * This error return is deprecated as of CUDA 5.0. It is no longer an error
-     * to attempt to enable/disable the profiling via ::cuProfilerStart or
-     * ::cuProfilerStop without initialization.
-     */
-    CUDA_ERROR_PROFILER_NOT_INITIALIZED       = 6,
-
-    /**
-     * \deprecated
-     * This error return is deprecated as of CUDA 5.0. It is no longer an error
-     * to call cuProfilerStart() when profiling is already enabled.
-     */
-    CUDA_ERROR_PROFILER_ALREADY_STARTED       = 7,
-
-    /**
-     * \deprecated
-     * This error return is deprecated as of CUDA 5.0. It is no longer an error
-     * to call cuProfilerStop() when profiling is already disabled.
-     */
-    CUDA_ERROR_PROFILER_ALREADY_STOPPED       = 8,
-
-    /**
-     * This indicates that no CUDA-capable devices were detected by the installed
-     * CUDA driver.
-     */
-    CUDA_ERROR_NO_DEVICE                      = 100,
-
-    /**
-     * This indicates that the device ordinal supplied by the user does not
-     * correspond to a valid CUDA device.
-     */
-    CUDA_ERROR_INVALID_DEVICE                 = 101,
-
-
-    /**
-     * This indicates that the device kernel image is invalid. This can also
-     * indicate an invalid CUDA module.
-     */
-    CUDA_ERROR_INVALID_IMAGE                  = 200,
-
-    /**
-     * This most frequently indicates that there is no context bound to the
-     * current thread. This can also be returned if the context passed to an
-     * API call is not a valid handle (such as a context that has had
-     * ::cuCtxDestroy() invoked on it). This can also be returned if a user
-     * mixes different API versions (i.e. 3010 context with 3020 API calls).
-     * See ::cuCtxGetApiVersion() for more details.
-     */
-    CUDA_ERROR_INVALID_CONTEXT                = 201,
-
-    /**
-     * This indicated that the context being supplied as a parameter to the
-     * API call was already the active context.
-     * \deprecated
-     * This error return is deprecated as of CUDA 3.2. It is no longer an
-     * error to attempt to push the active context via ::cuCtxPushCurrent().
-     */
-    CUDA_ERROR_CONTEXT_ALREADY_CURRENT        = 202,
-
-    /**
-     * This indicates that a map or register operation has failed.
-     */
-    CUDA_ERROR_MAP_FAILED                     = 205,
-
-    /**
-     * This indicates that an unmap or unregister operation has failed.
-     */
-    CUDA_ERROR_UNMAP_FAILED                   = 206,
-
-    /**
-     * This indicates that the specified array is currently mapped and thus
-     * cannot be destroyed.
-     */
-    CUDA_ERROR_ARRAY_IS_MAPPED                = 207,
-
-    /**
-     * This indicates that the resource is already mapped.
-     */
-    CUDA_ERROR_ALREADY_MAPPED                 = 208,
-
-    /**
-     * This indicates that there is no kernel image available that is suitable
-     * for the device. This can occur when a user specifies code generation
-     * options for a particular CUDA source file that do not include the
-     * corresponding device configuration.
-     */
-    CUDA_ERROR_NO_BINARY_FOR_GPU              = 209,
-
-    /**
-     * This indicates that a resource has already been acquired.
-     */
-    CUDA_ERROR_ALREADY_ACQUIRED               = 210,
-
-    /**
-     * This indicates that a resource is not mapped.
-     */
-    CUDA_ERROR_NOT_MAPPED                     = 211,
-
-    /**
-     * This indicates that a mapped resource is not available for access as an
-     * array.
-     */
-    CUDA_ERROR_NOT_MAPPED_AS_ARRAY            = 212,
-
-    /**
-     * This indicates that a mapped resource is not available for access as a
-     * pointer.
-     */
-    CUDA_ERROR_NOT_MAPPED_AS_POINTER          = 213,
-
-    /**
-     * This indicates that an uncorrectable ECC error was detected during
-     * execution.
-     */
-    CUDA_ERROR_ECC_UNCORRECTABLE              = 214,
-
-    /**
-     * This indicates that the ::CUlimit passed to the API call is not
-     * supported by the active device.
-     */
-    CUDA_ERROR_UNSUPPORTED_LIMIT              = 215,
-
-    /**
-     * This indicates that the ::CUcontext passed to the API call can
-     * only be bound to a single CPU thread at a time but is already
-     * bound to a CPU thread.
-     */
-    CUDA_ERROR_CONTEXT_ALREADY_IN_USE         = 216,
-
-    /**
-     * This indicates that peer access is not supported across the given
-     * devices.
-     */
-    CUDA_ERROR_PEER_ACCESS_UNSUPPORTED        = 217,
-
-    /**
-     * This indicates that a PTX JIT compilation failed.
-     */
-    CUDA_ERROR_INVALID_PTX                    = 218,
-
-    /**
-     * This indicates an error with OpenGL or DirectX context.
-     */
-    CUDA_ERROR_INVALID_GRAPHICS_CONTEXT       = 219,
-
-    /**
-    * This indicates that an uncorrectable NVLink error was detected during the
-    * execution.
-    */
-    CUDA_ERROR_NVLINK_UNCORRECTABLE           = 220,
-
-    /**
-    * This indicates that the PTX JIT compiler library was not found.
-    */
-    CUDA_ERROR_JIT_COMPILER_NOT_FOUND         = 221,
-
-    /**
-     * This indicates that the device kernel source is invalid.
-     */
-    CUDA_ERROR_INVALID_SOURCE                 = 300,
-
-    /**
-     * This indicates that the file specified was not found.
-     */
-    CUDA_ERROR_FILE_NOT_FOUND                 = 301,
-
-    /**
-     * This indicates that a link to a shared object failed to resolve.
-     */
-    CUDA_ERROR_SHARED_OBJECT_SYMBOL_NOT_FOUND = 302,
-
-    /**
-     * This indicates that initialization of a shared object failed.
-     */
-    CUDA_ERROR_SHARED_OBJECT_INIT_FAILED      = 303,
-
-    /**
-     * This indicates that an OS call failed.
-     */
-    CUDA_ERROR_OPERATING_SYSTEM               = 304,
-
-    /**
-     * This indicates that a resource handle passed to the API call was not
-     * valid. Resource handles are opaque types like ::CUstream and ::CUevent.
-     */
-    CUDA_ERROR_INVALID_HANDLE                 = 400,
-
-    /**
-     * This indicates that a resource required by the API call is not in a
-     * valid state to perform the requested operation.
-     */
-    CUDA_ERROR_ILLEGAL_STATE                  = 401,
-
-    /**
-     * This indicates that a named symbol was not found. Examples of symbols
-     * are global/constant variable names, texture names, and surface names.
-     */
-    CUDA_ERROR_NOT_FOUND                      = 500,
-
-    /**
-     * This indicates that asynchronous operations issued previously have not
-     * completed yet. This result is not actually an error, but must be indicated
-     * differently than ::CUDA_SUCCESS (which indicates completion). Calls that
-     * may return this value include ::cuEventQuery() and ::cuStreamQuery().
-     */
-    CUDA_ERROR_NOT_READY                      = 600,
-
-    /**
-     * While executing a kernel, the device encountered a
-     * load or store instruction on an invalid memory address.
-     * This leaves the process in an inconsistent state and any further CUDA work
-     * will return the same error. To continue using CUDA, the process must be terminated
-     * and relaunched.
-     */
-    CUDA_ERROR_ILLEGAL_ADDRESS                = 700,
-
-    /**
-     * This indicates that a launch did not occur because it did not have
-     * appropriate resources. This error usually indicates that the user has
-     * attempted to pass too many arguments to the device kernel, or the
-     * kernel launch specifies too many threads for the kernel's register
-     * count. Passing arguments of the wrong size (i.e. a 64-bit pointer
-     * when a 32-bit int is expected) is equivalent to passing too many
-     * arguments and can also result in this error.
-     */
-    CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES        = 701,
-
-    /**
-     * This indicates that the device kernel took too long to execute. This can
-     * only occur if timeouts are enabled - see the device attribute
-     * ::CU_DEVICE_ATTRIBUTE_KERNEL_EXEC_TIMEOUT for more information.
-     * This leaves the process in an inconsistent state and any further CUDA work
-     * will return the same error. To continue using CUDA, the process must be terminated
-     * and relaunched.
-     */
-    CUDA_ERROR_LAUNCH_TIMEOUT                 = 702,
-
-    /**
-     * This error indicates a kernel launch that uses an incompatible texturing
-     * mode.
-     */
-    CUDA_ERROR_LAUNCH_INCOMPATIBLE_TEXTURING  = 703,
-
-    /**
-     * This error indicates that a call to ::cuCtxEnablePeerAccess() is
-     * trying to re-enable peer access to a context which has already
-     * had peer access to it enabled.
-     */
-    CUDA_ERROR_PEER_ACCESS_ALREADY_ENABLED    = 704,
-
-    /**
-     * This error indicates that ::cuCtxDisablePeerAccess() is
-     * trying to disable peer access which has not been enabled yet
-     * via ::cuCtxEnablePeerAccess().
-     */
-    CUDA_ERROR_PEER_ACCESS_NOT_ENABLED        = 705,
-
-    /**
-     * This error indicates that the primary context for the specified device
-     * has already been initialized.
-     */
-    CUDA_ERROR_PRIMARY_CONTEXT_ACTIVE         = 708,
-
-    /**
-     * This error indicates that the context current to the calling thread
-     * has been destroyed using ::cuCtxDestroy, or is a primary context which
-     * has not yet been initialized.
-     */
-    CUDA_ERROR_CONTEXT_IS_DESTROYED           = 709,
-
-    /**
-     * A device-side assert triggered during kernel execution. The context
-     * cannot be used anymore, and must be destroyed. All existing device
-     * memory allocations from this context are invalid and must be
-     * reconstructed if the program is to continue using CUDA.
-     */
-    CUDA_ERROR_ASSERT                         = 710,
-
-    /**
-     * This error indicates that the hardware resources required to enable
-     * peer access have been exhausted for one or more of the devices
-     * passed to ::cuCtxEnablePeerAccess().
-     */
-    CUDA_ERROR_TOO_MANY_PEERS                 = 711,
-
-    /**
-     * This error indicates that the memory range passed to ::cuMemHostRegister()
-     * has already been registered.
-     */
-    CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED = 712,
-
-    /**
-     * This error indicates that the pointer passed to ::cuMemHostUnregister()
-     * does not correspond to any currently registered memory region.
-     */
-    CUDA_ERROR_HOST_MEMORY_NOT_REGISTERED     = 713,
-
-    /**
-     * While executing a kernel, the device encountered a stack error.
-     * This can be due to stack corruption or exceeding the stack size limit.
-     * This leaves the process in an inconsistent state and any further CUDA work
-     * will return the same error. To continue using CUDA, the process must be terminated
-     * and relaunched.
-     */
-    CUDA_ERROR_HARDWARE_STACK_ERROR           = 714,
-
-    /**
-     * While executing a kernel, the device encountered an illegal instruction.
-     * This leaves the process in an inconsistent state and any further CUDA work
-     * will return the same error. To continue using CUDA, the process must be terminated
-     * and relaunched.
-     */
-    CUDA_ERROR_ILLEGAL_INSTRUCTION            = 715,
-
-    /**
-     * While executing a kernel, the device encountered a load or store instruction
-     * on a memory address which is not aligned.
-     * This leaves the process in an inconsistent state and any further CUDA work
-     * will return the same error. To continue using CUDA, the process must be terminated
-     * and relaunched.
-     */
-    CUDA_ERROR_MISALIGNED_ADDRESS             = 716,
-
-    /**
-     * While executing a kernel, the device encountered an instruction
-     * which can only operate on memory locations in certain address spaces
-     * (global, shared, or local), but was supplied a memory address not
-     * belonging to an allowed address space.
-     * This leaves the process in an inconsistent state and any further CUDA work
-     * will return the same error. To continue using CUDA, the process must be terminated
-     * and relaunched.
-     */
-    CUDA_ERROR_INVALID_ADDRESS_SPACE          = 717,
-
-    /**
-     * While executing a kernel, the device program counter wrapped its address space.
-     * This leaves the process in an inconsistent state and any further CUDA work
-     * will return the same error. To continue using CUDA, the process must be terminated
-     * and relaunched.
-     */
-    CUDA_ERROR_INVALID_PC                     = 718,
-
-    /**
-     * An exception occurred on the device while executing a kernel. Common
-     * causes include dereferencing an invalid device pointer and accessing
-     * out of bounds shared memory. Less common cases can be system specific - more
-     * information about these cases can be found in the system specific user guide.
-     * This leaves the process in an inconsistent state and any further CUDA work
-     * will return the same error. To continue using CUDA, the process must be terminated
-     * and relaunched.
-     */
-    CUDA_ERROR_LAUNCH_FAILED                  = 719,
-
-    /**
-     * This error indicates that the number of blocks launched per grid for a kernel that was
-     * launched via either ::cuLaunchCooperativeKernel or ::cuLaunchCooperativeKernelMultiDevice
-     * exceeds the maximum number of blocks as allowed by ::cuOccupancyMaxActiveBlocksPerMultiprocessor
-     * or ::cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags times the number of multiprocessors
-     * as specified by the device attribute ::CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT.
-     */
-    CUDA_ERROR_COOPERATIVE_LAUNCH_TOO_LARGE   = 720,
-
-    /**
-     * This error indicates that the attempted operation is not permitted.
-     */
-    CUDA_ERROR_NOT_PERMITTED                  = 800,
-
-    /**
-     * This error indicates that the attempted operation is not supported
-     * on the current system or device.
-     */
-    CUDA_ERROR_NOT_SUPPORTED                  = 801,
-
-    /**
-     * This error indicates that the system is not yet ready to start any CUDA
-     * work.  To continue using CUDA, verify the system configuration is in a
-     * valid state and all required driver daemons are actively running.
-     * More information about this error can be found in the system specific
-     * user guide.
-     */
-    CUDA_ERROR_SYSTEM_NOT_READY               = 802,
-
-    /**
-     * This error indicates that there is a mismatch between the versions of
-     * the display driver and the CUDA driver. Refer to the compatibility documentation
-     * for supported versions.
-     */
-    CUDA_ERROR_SYSTEM_DRIVER_MISMATCH         = 803,
-
-    /**
-     * This error indicates that the system was upgraded to run with forward compatibility
-     * but the visible hardware detected by CUDA does not support this configuration.
-     * Refer to the compatibility documentation for the supported hardware matrix or ensure
-     * that only supported hardware is visible during initialization via the CUDA_VISIBLE_DEVICES
-     * environment variable.
-     */
-    CUDA_ERROR_COMPAT_NOT_SUPPORTED_ON_DEVICE = 804,
-
-    /**
-     * This error indicates that the operation is not permitted when
-     * the stream is capturing.
-     */
-    CUDA_ERROR_STREAM_CAPTURE_UNSUPPORTED     = 900,
-
-    /**
-     * This error indicates that the current capture sequence on the stream
-     * has been invalidated due to a previous error.
-     */
-    CUDA_ERROR_STREAM_CAPTURE_INVALIDATED     = 901,
-
-    /**
-     * This error indicates that the operation would have resulted in a merge
-     * of two independent capture sequences.
-     */
-    CUDA_ERROR_STREAM_CAPTURE_MERGE           = 902,
-
-    /**
-     * This error indicates that the capture was not initiated in this stream.
-     */
-    CUDA_ERROR_STREAM_CAPTURE_UNMATCHED       = 903,
-
-    /**
-     * This error indicates that the capture sequence contains a fork that was
-     * not joined to the primary stream.
-     */
-    CUDA_ERROR_STREAM_CAPTURE_UNJOINED        = 904,
-
-    /**
-     * This error indicates that a dependency would have been created which
-     * crosses the capture sequence boundary. Only implicit in-stream ordering
-     * dependencies are allowed to cross the boundary.
-     */
-    CUDA_ERROR_STREAM_CAPTURE_ISOLATION       = 905,
-
-    /**
-     * This error indicates a disallowed implicit dependency on a current capture
-     * sequence from cudaStreamLegacy.
-     */
-    CUDA_ERROR_STREAM_CAPTURE_IMPLICIT        = 906,
-
-    /**
-     * This error indicates that the operation is not permitted on an event which
-     * was last recorded in a capturing stream.
-     */
-    CUDA_ERROR_CAPTURED_EVENT                 = 907,
-
-    /**
-     * A stream capture sequence not initiated with the ::CU_STREAM_CAPTURE_MODE_RELAXED
-     * argument to ::cuStreamBeginCapture was passed to ::cuStreamEndCapture in a
-     * different thread.
-     */
-    CUDA_ERROR_STREAM_CAPTURE_WRONG_THREAD    = 908,
-
-    /**
-     * This indicates that an unknown internal error has occurred.
-     */
-    CUDA_ERROR_UNKNOWN                        = 999
+  /**
+   * The API call returned with no errors. In the case of query calls, this
+   * also means that the operation being queried is complete (see
+   * ::cuEventQuery() and ::cuStreamQuery()).
+   */
+  CUDA_SUCCESS = 0,
+
+  /**
+   * This indicates that one or more of the parameters passed to the API call
+   * is not within an acceptable range of values.
+   */
+  CUDA_ERROR_INVALID_VALUE = 1,
+
+  /**
+   * The API call failed because it was unable to allocate enough memory to
+   * perform the requested operation.
+   */
+  CUDA_ERROR_OUT_OF_MEMORY = 2,
+
+  /**
+   * This indicates that the CUDA driver has not been initialized with
+   * ::cuInit() or that initialization has failed.
+   */
+  CUDA_ERROR_NOT_INITIALIZED = 3,
+
+  /**
+   * This indicates that the CUDA driver is in the process of shutting down.
+   */
+  CUDA_ERROR_DEINITIALIZED = 4,
+
+  /**
+   * This indicates profiler is not initialized for this run. This can
+   * happen when the application is running with external profiling tools
+   * like visual profiler.
+   */
+  CUDA_ERROR_PROFILER_DISABLED = 5,
+
+  /**
+   * \deprecated
+   * This error return is deprecated as of CUDA 5.0. It is no longer an error
+   * to attempt to enable/disable the profiling via ::cuProfilerStart or
+   * ::cuProfilerStop without initialization.
+   */
+  CUDA_ERROR_PROFILER_NOT_INITIALIZED = 6,
+
+  /**
+   * \deprecated
+   * This error return is deprecated as of CUDA 5.0. It is no longer an error
+   * to call cuProfilerStart() when profiling is already enabled.
+   */
+  CUDA_ERROR_PROFILER_ALREADY_STARTED = 7,
+
+  /**
+   * \deprecated
+   * This error return is deprecated as of CUDA 5.0. It is no longer an error
+   * to call cuProfilerStop() when profiling is already disabled.
+   */
+  CUDA_ERROR_PROFILER_ALREADY_STOPPED = 8,
+
+  /**
+   * This indicates that no CUDA-capable devices were detected by the installed
+   * CUDA driver.
+   */
+  CUDA_ERROR_NO_DEVICE = 100,
+
+  /**
+   * This indicates that the device ordinal supplied by the user does not
+   * correspond to a valid CUDA device.
+   */
+  CUDA_ERROR_INVALID_DEVICE = 101,
+
+  /**
+   * This indicates that the device kernel image is invalid. This can also
+   * indicate an invalid CUDA module.
+   */
+  CUDA_ERROR_INVALID_IMAGE = 200,
+
+  /**
+   * This most frequently indicates that there is no context bound to the
+   * current thread. This can also be returned if the context passed to an
+   * API call is not a valid handle (such as a context that has had
+   * ::cuCtxDestroy() invoked on it). This can also be returned if a user
+   * mixes different API versions (i.e. 3010 context with 3020 API calls).
+   * See ::cuCtxGetApiVersion() for more details.
+   */
+  CUDA_ERROR_INVALID_CONTEXT = 201,
+
+  /**
+   * This indicated that the context being supplied as a parameter to the
+   * API call was already the active context.
+   * \deprecated
+   * This error return is deprecated as of CUDA 3.2. It is no longer an
+   * error to attempt to push the active context via ::cuCtxPushCurrent().
+   */
+  CUDA_ERROR_CONTEXT_ALREADY_CURRENT = 202,
+
+  /**
+   * This indicates that a map or register operation has failed.
+   */
+  CUDA_ERROR_MAP_FAILED = 205,
+
+  /**
+   * This indicates that an unmap or unregister operation has failed.
+   */
+  CUDA_ERROR_UNMAP_FAILED = 206,
+
+  /**
+   * This indicates that the specified array is currently mapped and thus
+   * cannot be destroyed.
+   */
+  CUDA_ERROR_ARRAY_IS_MAPPED = 207,
+
+  /**
+   * This indicates that the resource is already mapped.
+   */
+  CUDA_ERROR_ALREADY_MAPPED = 208,
+
+  /**
+   * This indicates that there is no kernel image available that is suitable
+   * for the device. This can occur when a user specifies code generation
+   * options for a particular CUDA source file that do not include the
+   * corresponding device configuration.
+   */
+  CUDA_ERROR_NO_BINARY_FOR_GPU = 209,
+
+  /**
+   * This indicates that a resource has already been acquired.
+   */
+  CUDA_ERROR_ALREADY_ACQUIRED = 210,
+
+  /**
+   * This indicates that a resource is not mapped.
+   */
+  CUDA_ERROR_NOT_MAPPED = 211,
+
+  /**
+   * This indicates that a mapped resource is not available for access as an
+   * array.
+   */
+  CUDA_ERROR_NOT_MAPPED_AS_ARRAY = 212,
+
+  /**
+   * This indicates that a mapped resource is not available for access as a
+   * pointer.
+   */
+  CUDA_ERROR_NOT_MAPPED_AS_POINTER = 213,
+
+  /**
+   * This indicates that an uncorrectable ECC error was detected during
+   * execution.
+   */
+  CUDA_ERROR_ECC_UNCORRECTABLE = 214,
+
+  /**
+   * This indicates that the ::CUlimit passed to the API call is not
+   * supported by the active device.
+   */
+  CUDA_ERROR_UNSUPPORTED_LIMIT = 215,
+
+  /**
+   * This indicates that the ::CUcontext passed to the API call can
+   * only be bound to a single CPU thread at a time but is already
+   * bound to a CPU thread.
+   */
+  CUDA_ERROR_CONTEXT_ALREADY_IN_USE = 216,
+
+  /**
+   * This indicates that peer access is not supported across the given
+   * devices.
+   */
+  CUDA_ERROR_PEER_ACCESS_UNSUPPORTED = 217,
+
+  /**
+   * This indicates that a PTX JIT compilation failed.
+   */
+  CUDA_ERROR_INVALID_PTX = 218,
+
+  /**
+   * This indicates an error with OpenGL or DirectX context.
+   */
+  CUDA_ERROR_INVALID_GRAPHICS_CONTEXT = 219,
+
+  /**
+   * This indicates that an uncorrectable NVLink error was detected during the
+   * execution.
+   */
+  CUDA_ERROR_NVLINK_UNCORRECTABLE = 220,
+
+  /**
+   * This indicates that the PTX JIT compiler library was not found.
+   */
+  CUDA_ERROR_JIT_COMPILER_NOT_FOUND = 221,
+
+  /**
+   * This indicates that the device kernel source is invalid.
+   */
+  CUDA_ERROR_INVALID_SOURCE = 300,
+
+  /**
+   * This indicates that the file specified was not found.
+   */
+  CUDA_ERROR_FILE_NOT_FOUND = 301,
+
+  /**
+   * This indicates that a link to a shared object failed to resolve.
+   */
+  CUDA_ERROR_SHARED_OBJECT_SYMBOL_NOT_FOUND = 302,
+
+  /**
+   * This indicates that initialization of a shared object failed.
+   */
+  CUDA_ERROR_SHARED_OBJECT_INIT_FAILED = 303,
+
+  /**
+   * This indicates that an OS call failed.
+   */
+  CUDA_ERROR_OPERATING_SYSTEM = 304,
+
+  /**
+   * This indicates that a resource handle passed to the API call was not
+   * valid. Resource handles are opaque types like ::CUstream and ::CUevent.
+   */
+  CUDA_ERROR_INVALID_HANDLE = 400,
+
+  /**
+   * This indicates that a resource required by the API call is not in a
+   * valid state to perform the requested operation.
+   */
+  CUDA_ERROR_ILLEGAL_STATE = 401,
+
+  /**
+   * This indicates that a named symbol was not found. Examples of symbols
+   * are global/constant variable names, texture names, and surface names.
+   */
+  CUDA_ERROR_NOT_FOUND = 500,
+
+  /**
+   * This indicates that asynchronous operations issued previously have not
+   * completed yet. This result is not actually an error, but must be indicated
+   * differently than ::CUDA_SUCCESS (which indicates completion). Calls that
+   * may return this value include ::cuEventQuery() and ::cuStreamQuery().
+   */
+  CUDA_ERROR_NOT_READY = 600,
+
+  /**
+   * While executing a kernel, the device encountered a
+   * load or store instruction on an invalid memory address.
+   * This leaves the process in an inconsistent state and any further CUDA work
+   * will return the same error. To continue using CUDA, the process must be
+   * terminated and relaunched.
+   */
+  CUDA_ERROR_ILLEGAL_ADDRESS = 700,
+
+  /**
+   * This indicates that a launch did not occur because it did not have
+   * appropriate resources. This error usually indicates that the user has
+   * attempted to pass too many arguments to the device kernel, or the
+   * kernel launch specifies too many threads for the kernel's register
+   * count. Passing arguments of the wrong size (i.e. a 64-bit pointer
+   * when a 32-bit int is expected) is equivalent to passing too many
+   * arguments and can also result in this error.
+   */
+  CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES = 701,
+
+  /**
+   * This indicates that the device kernel took too long to execute. This can
+   * only occur if timeouts are enabled - see the device attribute
+   * ::CU_DEVICE_ATTRIBUTE_KERNEL_EXEC_TIMEOUT for more information.
+   * This leaves the process in an inconsistent state and any further CUDA work
+   * will return the same error. To continue using CUDA, the process must be
+   * terminated and relaunched.
+   */
+  CUDA_ERROR_LAUNCH_TIMEOUT = 702,
+
+  /**
+   * This error indicates a kernel launch that uses an incompatible texturing
+   * mode.
+   */
+  CUDA_ERROR_LAUNCH_INCOMPATIBLE_TEXTURING = 703,
+
+  /**
+   * This error indicates that a call to ::cuCtxEnablePeerAccess() is
+   * trying to re-enable peer access to a context which has already
+   * had peer access to it enabled.
+   */
+  CUDA_ERROR_PEER_ACCESS_ALREADY_ENABLED = 704,
+
+  /**
+   * This error indicates that ::cuCtxDisablePeerAccess() is
+   * trying to disable peer access which has not been enabled yet
+   * via ::cuCtxEnablePeerAccess().
+   */
+  CUDA_ERROR_PEER_ACCESS_NOT_ENABLED = 705,
+
+  /**
+   * This error indicates that the primary context for the specified device
+   * has already been initialized.
+   */
+  CUDA_ERROR_PRIMARY_CONTEXT_ACTIVE = 708,
+
+  /**
+   * This error indicates that the context current to the calling thread
+   * has been destroyed using ::cuCtxDestroy, or is a primary context which
+   * has not yet been initialized.
+   */
+  CUDA_ERROR_CONTEXT_IS_DESTROYED = 709,
+
+  /**
+   * A device-side assert triggered during kernel execution. The context
+   * cannot be used anymore, and must be destroyed. All existing device
+   * memory allocations from this context are invalid and must be
+   * reconstructed if the program is to continue using CUDA.
+   */
+  CUDA_ERROR_ASSERT = 710,
+
+  /**
+   * This error indicates that the hardware resources required to enable
+   * peer access have been exhausted for one or more of the devices
+   * passed to ::cuCtxEnablePeerAccess().
+   */
+  CUDA_ERROR_TOO_MANY_PEERS = 711,
+
+  /**
+   * This error indicates that the memory range passed to ::cuMemHostRegister()
+   * has already been registered.
+   */
+  CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED = 712,
+
+  /**
+   * This error indicates that the pointer passed to ::cuMemHostUnregister()
+   * does not correspond to any currently registered memory region.
+   */
+  CUDA_ERROR_HOST_MEMORY_NOT_REGISTERED = 713,
+
+  /**
+   * While executing a kernel, the device encountered a stack error.
+   * This can be due to stack corruption or exceeding the stack size limit.
+   * This leaves the process in an inconsistent state and any further CUDA work
+   * will return the same error. To continue using CUDA, the process must be
+   * terminated and relaunched.
+   */
+  CUDA_ERROR_HARDWARE_STACK_ERROR = 714,
+
+  /**
+   * While executing a kernel, the device encountered an illegal instruction.
+   * This leaves the process in an inconsistent state and any further CUDA work
+   * will return the same error. To continue using CUDA, the process must be
+   * terminated and relaunched.
+   */
+  CUDA_ERROR_ILLEGAL_INSTRUCTION = 715,
+
+  /**
+   * While executing a kernel, the device encountered a load or store
+   * instruction on a memory address which is not aligned. This leaves the
+   * process in an inconsistent state and any further CUDA work will return the
+   * same error. To continue using CUDA, the process must be terminated and
+   * relaunched.
+   */
+  CUDA_ERROR_MISALIGNED_ADDRESS = 716,
+
+  /**
+   * While executing a kernel, the device encountered an instruction
+   * which can only operate on memory locations in certain address spaces
+   * (global, shared, or local), but was supplied a memory address not
+   * belonging to an allowed address space.
+   * This leaves the process in an inconsistent state and any further CUDA work
+   * will return the same error. To continue using CUDA, the process must be
+   * terminated and relaunched.
+   */
+  CUDA_ERROR_INVALID_ADDRESS_SPACE = 717,
+
+  /**
+   * While executing a kernel, the device program counter wrapped its address
+   * space. This leaves the process in an inconsistent state and any further
+   * CUDA work will return the same error. To continue using CUDA, the process
+   * must be terminated and relaunched.
+   */
+  CUDA_ERROR_INVALID_PC = 718,
+
+  /**
+   * An exception occurred on the device while executing a kernel. Common
+   * causes include dereferencing an invalid device pointer and accessing
+   * out of bounds shared memory. Less common cases can be system specific -
+   * more information about these cases can be found in the system specific user
+   * guide. This leaves the process in an inconsistent state and any further
+   * CUDA work will return the same error. To continue using CUDA, the process
+   * must be terminated and relaunched.
+   */
+  CUDA_ERROR_LAUNCH_FAILED = 719,
+
+  /**
+   * This error indicates that the number of blocks launched per grid for a
+   * kernel that was launched via either ::cuLaunchCooperativeKernel or
+   * ::cuLaunchCooperativeKernelMultiDevice exceeds the maximum number of blocks
+   * as allowed by ::cuOccupancyMaxActiveBlocksPerMultiprocessor or
+   * ::cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags times the number of
+   * multiprocessors as specified by the device attribute
+   * ::CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT.
+   */
+  CUDA_ERROR_COOPERATIVE_LAUNCH_TOO_LARGE = 720,
+
+  /**
+   * This error indicates that the attempted operation is not permitted.
+   */
+  CUDA_ERROR_NOT_PERMITTED = 800,
+
+  /**
+   * This error indicates that the attempted operation is not supported
+   * on the current system or device.
+   */
+  CUDA_ERROR_NOT_SUPPORTED = 801,
+
+  /**
+   * This error indicates that the system is not yet ready to start any CUDA
+   * work.  To continue using CUDA, verify the system configuration is in a
+   * valid state and all required driver daemons are actively running.
+   * More information about this error can be found in the system specific
+   * user guide.
+   */
+  CUDA_ERROR_SYSTEM_NOT_READY = 802,
+
+  /**
+   * This error indicates that there is a mismatch between the versions of
+   * the display driver and the CUDA driver. Refer to the compatibility
+   * documentation for supported versions.
+   */
+  CUDA_ERROR_SYSTEM_DRIVER_MISMATCH = 803,
+
+  /**
+   * This error indicates that the system was upgraded to run with forward
+   * compatibility but the visible hardware detected by CUDA does not support
+   * this configuration. Refer to the compatibility documentation for the
+   * supported hardware matrix or ensure that only supported hardware is visible
+   * during initialization via the CUDA_VISIBLE_DEVICES environment variable.
+   */
+  CUDA_ERROR_COMPAT_NOT_SUPPORTED_ON_DEVICE = 804,
+
+  /**
+   * This error indicates that the operation is not permitted when
+   * the stream is capturing.
+   */
+  CUDA_ERROR_STREAM_CAPTURE_UNSUPPORTED = 900,
+
+  /**
+   * This error indicates that the current capture sequence on the stream
+   * has been invalidated due to a previous error.
+   */
+  CUDA_ERROR_STREAM_CAPTURE_INVALIDATED = 901,
+
+  /**
+   * This error indicates that the operation would have resulted in a merge
+   * of two independent capture sequences.
+   */
+  CUDA_ERROR_STREAM_CAPTURE_MERGE = 902,
+
+  /**
+   * This error indicates that the capture was not initiated in this stream.
+   */
+  CUDA_ERROR_STREAM_CAPTURE_UNMATCHED = 903,
+
+  /**
+   * This error indicates that the capture sequence contains a fork that was
+   * not joined to the primary stream.
+   */
+  CUDA_ERROR_STREAM_CAPTURE_UNJOINED = 904,
+
+  /**
+   * This error indicates that a dependency would have been created which
+   * crosses the capture sequence boundary. Only implicit in-stream ordering
+   * dependencies are allowed to cross the boundary.
+   */
+  CUDA_ERROR_STREAM_CAPTURE_ISOLATION = 905,
+
+  /**
+   * This error indicates a disallowed implicit dependency on a current capture
+   * sequence from cudaStreamLegacy.
+   */
+  CUDA_ERROR_STREAM_CAPTURE_IMPLICIT = 906,
+
+  /**
+   * This error indicates that the operation is not permitted on an event which
+   * was last recorded in a capturing stream.
+   */
+  CUDA_ERROR_CAPTURED_EVENT = 907,
+
+  /**
+   * A stream capture sequence not initiated with the
+   * ::CU_STREAM_CAPTURE_MODE_RELAXED argument to ::cuStreamBeginCapture was
+   * passed to ::cuStreamEndCapture in a different thread.
+   */
+  CUDA_ERROR_STREAM_CAPTURE_WRONG_THREAD = 908,
+
+  /**
+   * This indicates that an unknown internal error has occurred.
+   */
+  CUDA_ERROR_UNKNOWN = 999
 } CUresult;
 
 /**
  * P2P Attributes
  */
 typedef enum CUdevice_P2PAttribute_enum {
-    CU_DEVICE_P2P_ATTRIBUTE_PERFORMANCE_RANK                     = 0x01,  /**< A relative value indicating the performance of the link between two devices */
-    CU_DEVICE_P2P_ATTRIBUTE_ACCESS_SUPPORTED                     = 0x02,  /**< P2P Access is enable */
-    CU_DEVICE_P2P_ATTRIBUTE_NATIVE_ATOMIC_SUPPORTED              = 0x03,  /**< Atomic operation over the link supported */
-    CU_DEVICE_P2P_ATTRIBUTE_ACCESS_ACCESS_SUPPORTED              = 0x04,  /**< \deprecated use CU_DEVICE_P2P_ATTRIBUTE_CUDA_ARRAY_ACCESS_SUPPORTED instead */
-    CU_DEVICE_P2P_ATTRIBUTE_CUDA_ARRAY_ACCESS_SUPPORTED          = 0x04   /**< Accessing CUDA arrays over the link supported */
+  CU_DEVICE_P2P_ATTRIBUTE_PERFORMANCE_RANK =
+      0x01, /**< A relative value indicating the performance of the link between
+               two devices */
+  CU_DEVICE_P2P_ATTRIBUTE_ACCESS_SUPPORTED = 0x02, /**< P2P Access is enable */
+  CU_DEVICE_P2P_ATTRIBUTE_NATIVE_ATOMIC_SUPPORTED =
+      0x03, /**< Atomic operation over the link supported */
+  CU_DEVICE_P2P_ATTRIBUTE_ACCESS_ACCESS_SUPPORTED =
+      0x04, /**< \deprecated use
+               CU_DEVICE_P2P_ATTRIBUTE_CUDA_ARRAY_ACCESS_SUPPORTED instead */
+  CU_DEVICE_P2P_ATTRIBUTE_CUDA_ARRAY_ACCESS_SUPPORTED =
+      0x04 /**< Accessing CUDA arrays over the link supported */
 } CUdevice_P2PAttribute;
 
 /**
  * CUDA stream callback
- * \param hStream The stream the callback was added to, as passed to ::cuStreamAddCallback.  May be NULL.
- * \param status ::CUDA_SUCCESS or any persistent error on the stream.
- * \param userData User parameter provided at registration.
+ * \param hStream The stream the callback was added to, as passed to
+ * ::cuStreamAddCallback.  May be NULL. \param status ::CUDA_SUCCESS or any
+ * persistent error on the stream. \param userData User parameter provided at
+ * registration.
  */
-typedef void (CUDA_CB *CUstreamCallback)(CUstream hStream, CUresult status, void *userData);
+typedef void(CUDA_CB *CUstreamCallback)(CUstream hStream, CUresult status,
+                                        void *userData);
 
 /**
  * Block size to per-block dynamic shared memory mapping for a certain
@@ -1714,20 +1921,20 @@ typedef void (CUDA_CB *CUstreamCallback)(CUstream hStream, CUresult status, void
  *
  * \return The dynamic shared memory needed by a block.
  */
-typedef size_t (CUDA_CB *CUoccupancyB2DSize)(int blockSize);
+typedef size_t(CUDA_CB *CUoccupancyB2DSize)(int blockSize);
 
 /**
  * If set, host memory is portable between CUDA contexts.
  * Flag for ::cuMemHostAlloc()
  */
-#define CU_MEMHOSTALLOC_PORTABLE        0x01
+#define CU_MEMHOSTALLOC_PORTABLE 0x01
 
 /**
  * If set, host memory is mapped into CUDA address space and
  * ::cuMemHostGetDevicePointer() may be called on the host pointer.
  * Flag for ::cuMemHostAlloc()
  */
-#define CU_MEMHOSTALLOC_DEVICEMAP       0x02
+#define CU_MEMHOSTALLOC_DEVICEMAP 0x02
 
 /**
  * If set, host memory is allocated as write-combined - fast to write,
@@ -1735,20 +1942,20 @@ typedef size_t (CUDA_CB *CUoccupancyB2DSize)(int blockSize);
  * (MOVNTDQA).
  * Flag for ::cuMemHostAlloc()
  */
-#define CU_MEMHOSTALLOC_WRITECOMBINED   0x04
+#define CU_MEMHOSTALLOC_WRITECOMBINED 0x04
 
 /**
  * If set, host memory is portable between CUDA contexts.
  * Flag for ::cuMemHostRegister()
  */
-#define CU_MEMHOSTREGISTER_PORTABLE     0x01
+#define CU_MEMHOSTREGISTER_PORTABLE 0x01
 
 /**
  * If set, host memory is mapped into CUDA address space and
  * ::cuMemHostGetDevicePointer() may be called on the host pointer.
  * Flag for ::cuMemHostRegister()
  */
-#define CU_MEMHOSTREGISTER_DEVICEMAP    0x02
+#define CU_MEMHOSTREGISTER_DEVICEMAP 0x02
 
 /**
  * If set, the passed memory pointer is treated as pointing to some
@@ -1762,7 +1969,7 @@ typedef size_t (CUDA_CB *CUoccupancyB2DSize)(int blockSize);
  * is returned.
  * Flag for ::cuMemHostRegister()
  */
-#define CU_MEMHOSTREGISTER_IOMEMORY     0x04
+#define CU_MEMHOSTREGISTER_IOMEMORY 0x04
 
 #if __CUDA_API_VERSION >= 3020
 
@@ -1770,118 +1977,125 @@ typedef size_t (CUDA_CB *CUoccupancyB2DSize)(int blockSize);
  * 2D memory copy parameters
  */
 typedef struct CUDA_MEMCPY2D_st {
-    size_t srcXInBytes;         /**< Source X in bytes */
-    size_t srcY;                /**< Source Y */
+  size_t srcXInBytes; /**< Source X in bytes */
+  size_t srcY;        /**< Source Y */
 
-    CUmemorytype srcMemoryType; /**< Source memory type (host, device, array) */
-    const void *srcHost;        /**< Source host pointer */
-    CUdeviceptr srcDevice;      /**< Source device pointer */
-    CUarray srcArray;           /**< Source array reference */
-    size_t srcPitch;            /**< Source pitch (ignored when src is array) */
+  CUmemorytype srcMemoryType; /**< Source memory type (host, device, array) */
+  const void *srcHost;        /**< Source host pointer */
+  CUdeviceptr srcDevice;      /**< Source device pointer */
+  CUarray srcArray;           /**< Source array reference */
+  size_t srcPitch;            /**< Source pitch (ignored when src is array) */
 
-    size_t dstXInBytes;         /**< Destination X in bytes */
-    size_t dstY;                /**< Destination Y */
+  size_t dstXInBytes; /**< Destination X in bytes */
+  size_t dstY;        /**< Destination Y */
 
-    CUmemorytype dstMemoryType; /**< Destination memory type (host, device, array) */
-    void *dstHost;              /**< Destination host pointer */
-    CUdeviceptr dstDevice;      /**< Destination device pointer */
-    CUarray dstArray;           /**< Destination array reference */
-    size_t dstPitch;            /**< Destination pitch (ignored when dst is array) */
+  CUmemorytype
+      dstMemoryType;     /**< Destination memory type (host, device, array) */
+  void *dstHost;         /**< Destination host pointer */
+  CUdeviceptr dstDevice; /**< Destination device pointer */
+  CUarray dstArray;      /**< Destination array reference */
+  size_t dstPitch;       /**< Destination pitch (ignored when dst is array) */
 
-    size_t WidthInBytes;        /**< Width of 2D memory copy in bytes */
-    size_t Height;              /**< Height of 2D memory copy */
+  size_t WidthInBytes; /**< Width of 2D memory copy in bytes */
+  size_t Height;       /**< Height of 2D memory copy */
 } CUDA_MEMCPY2D;
 
 /**
  * 3D memory copy parameters
  */
 typedef struct CUDA_MEMCPY3D_st {
-    size_t srcXInBytes;         /**< Source X in bytes */
-    size_t srcY;                /**< Source Y */
-    size_t srcZ;                /**< Source Z */
-    size_t srcLOD;              /**< Source LOD */
-    CUmemorytype srcMemoryType; /**< Source memory type (host, device, array) */
-    const void *srcHost;        /**< Source host pointer */
-    CUdeviceptr srcDevice;      /**< Source device pointer */
-    CUarray srcArray;           /**< Source array reference */
-    void *reserved0;            /**< Must be NULL */
-    size_t srcPitch;            /**< Source pitch (ignored when src is array) */
-    size_t srcHeight;           /**< Source height (ignored when src is array; may be 0 if Depth==1) */
+  size_t srcXInBytes;         /**< Source X in bytes */
+  size_t srcY;                /**< Source Y */
+  size_t srcZ;                /**< Source Z */
+  size_t srcLOD;              /**< Source LOD */
+  CUmemorytype srcMemoryType; /**< Source memory type (host, device, array) */
+  const void *srcHost;        /**< Source host pointer */
+  CUdeviceptr srcDevice;      /**< Source device pointer */
+  CUarray srcArray;           /**< Source array reference */
+  void *reserved0;            /**< Must be NULL */
+  size_t srcPitch;            /**< Source pitch (ignored when src is array) */
+  size_t srcHeight; /**< Source height (ignored when src is array; may be 0 if
+                       Depth==1) */
 
-    size_t dstXInBytes;         /**< Destination X in bytes */
-    size_t dstY;                /**< Destination Y */
-    size_t dstZ;                /**< Destination Z */
-    size_t dstLOD;              /**< Destination LOD */
-    CUmemorytype dstMemoryType; /**< Destination memory type (host, device, array) */
-    void *dstHost;              /**< Destination host pointer */
-    CUdeviceptr dstDevice;      /**< Destination device pointer */
-    CUarray dstArray;           /**< Destination array reference */
-    void *reserved1;            /**< Must be NULL */
-    size_t dstPitch;            /**< Destination pitch (ignored when dst is array) */
-    size_t dstHeight;           /**< Destination height (ignored when dst is array; may be 0 if Depth==1) */
+  size_t dstXInBytes; /**< Destination X in bytes */
+  size_t dstY;        /**< Destination Y */
+  size_t dstZ;        /**< Destination Z */
+  size_t dstLOD;      /**< Destination LOD */
+  CUmemorytype
+      dstMemoryType;     /**< Destination memory type (host, device, array) */
+  void *dstHost;         /**< Destination host pointer */
+  CUdeviceptr dstDevice; /**< Destination device pointer */
+  CUarray dstArray;      /**< Destination array reference */
+  void *reserved1;       /**< Must be NULL */
+  size_t dstPitch;       /**< Destination pitch (ignored when dst is array) */
+  size_t dstHeight; /**< Destination height (ignored when dst is array; may be 0
+                       if Depth==1) */
 
-    size_t WidthInBytes;        /**< Width of 3D memory copy in bytes */
-    size_t Height;              /**< Height of 3D memory copy */
-    size_t Depth;               /**< Depth of 3D memory copy */
+  size_t WidthInBytes; /**< Width of 3D memory copy in bytes */
+  size_t Height;       /**< Height of 3D memory copy */
+  size_t Depth;        /**< Depth of 3D memory copy */
 } CUDA_MEMCPY3D;
 
 /**
  * 3D memory cross-context copy parameters
  */
 typedef struct CUDA_MEMCPY3D_PEER_st {
-    size_t srcXInBytes;         /**< Source X in bytes */
-    size_t srcY;                /**< Source Y */
-    size_t srcZ;                /**< Source Z */
-    size_t srcLOD;              /**< Source LOD */
-    CUmemorytype srcMemoryType; /**< Source memory type (host, device, array) */
-    const void *srcHost;        /**< Source host pointer */
-    CUdeviceptr srcDevice;      /**< Source device pointer */
-    CUarray srcArray;           /**< Source array reference */
-    CUcontext srcContext;       /**< Source context (ignored with srcMemoryType is ::CU_MEMORYTYPE_ARRAY) */
-    size_t srcPitch;            /**< Source pitch (ignored when src is array) */
-    size_t srcHeight;           /**< Source height (ignored when src is array; may be 0 if Depth==1) */
+  size_t srcXInBytes;         /**< Source X in bytes */
+  size_t srcY;                /**< Source Y */
+  size_t srcZ;                /**< Source Z */
+  size_t srcLOD;              /**< Source LOD */
+  CUmemorytype srcMemoryType; /**< Source memory type (host, device, array) */
+  const void *srcHost;        /**< Source host pointer */
+  CUdeviceptr srcDevice;      /**< Source device pointer */
+  CUarray srcArray;           /**< Source array reference */
+  CUcontext srcContext;       /**< Source context (ignored with srcMemoryType is
+                                 ::CU_MEMORYTYPE_ARRAY) */
+  size_t srcPitch;            /**< Source pitch (ignored when src is array) */
+  size_t srcHeight; /**< Source height (ignored when src is array; may be 0 if
+                       Depth==1) */
 
-    size_t dstXInBytes;         /**< Destination X in bytes */
-    size_t dstY;                /**< Destination Y */
-    size_t dstZ;                /**< Destination Z */
-    size_t dstLOD;              /**< Destination LOD */
-    CUmemorytype dstMemoryType; /**< Destination memory type (host, device, array) */
-    void *dstHost;              /**< Destination host pointer */
-    CUdeviceptr dstDevice;      /**< Destination device pointer */
-    CUarray dstArray;           /**< Destination array reference */
-    CUcontext dstContext;       /**< Destination context (ignored with dstMemoryType is ::CU_MEMORYTYPE_ARRAY) */
-    size_t dstPitch;            /**< Destination pitch (ignored when dst is array) */
-    size_t dstHeight;           /**< Destination height (ignored when dst is array; may be 0 if Depth==1) */
+  size_t dstXInBytes; /**< Destination X in bytes */
+  size_t dstY;        /**< Destination Y */
+  size_t dstZ;        /**< Destination Z */
+  size_t dstLOD;      /**< Destination LOD */
+  CUmemorytype
+      dstMemoryType;     /**< Destination memory type (host, device, array) */
+  void *dstHost;         /**< Destination host pointer */
+  CUdeviceptr dstDevice; /**< Destination device pointer */
+  CUarray dstArray;      /**< Destination array reference */
+  CUcontext dstContext;  /**< Destination context (ignored with dstMemoryType is
+                            ::CU_MEMORYTYPE_ARRAY) */
+  size_t dstPitch;       /**< Destination pitch (ignored when dst is array) */
+  size_t dstHeight; /**< Destination height (ignored when dst is array; may be 0
+                       if Depth==1) */
 
-    size_t WidthInBytes;        /**< Width of 3D memory copy in bytes */
-    size_t Height;              /**< Height of 3D memory copy */
-    size_t Depth;               /**< Depth of 3D memory copy */
+  size_t WidthInBytes; /**< Width of 3D memory copy in bytes */
+  size_t Height;       /**< Height of 3D memory copy */
+  size_t Depth;        /**< Depth of 3D memory copy */
 } CUDA_MEMCPY3D_PEER;
 
 /**
  * Array descriptor
  */
-typedef struct CUDA_ARRAY_DESCRIPTOR_st
-{
-    size_t Width;             /**< Width of array */
-    size_t Height;            /**< Height of array */
+typedef struct CUDA_ARRAY_DESCRIPTOR_st {
+  size_t Width;  /**< Width of array */
+  size_t Height; /**< Height of array */
 
-    CUarray_format Format;    /**< Array format */
-    unsigned int NumChannels; /**< Channels per array element */
+  CUarray_format Format;    /**< Array format */
+  unsigned int NumChannels; /**< Channels per array element */
 } CUDA_ARRAY_DESCRIPTOR;
 
 /**
  * 3D array descriptor
  */
-typedef struct CUDA_ARRAY3D_DESCRIPTOR_st
-{
-    size_t Width;             /**< Width of 3D array */
-    size_t Height;            /**< Height of 3D array */
-    size_t Depth;             /**< Depth of 3D array */
+typedef struct CUDA_ARRAY3D_DESCRIPTOR_st {
+  size_t Width;  /**< Width of 3D array */
+  size_t Height; /**< Height of 3D array */
+  size_t Depth;  /**< Depth of 3D array */
 
-    CUarray_format Format;    /**< Array format */
-    unsigned int NumChannels; /**< Channels per array element */
-    unsigned int Flags;       /**< Flags */
+  CUarray_format Format;    /**< Array format */
+  unsigned int NumChannels; /**< Channels per array element */
+  unsigned int Flags;       /**< Flags */
 } CUDA_ARRAY3D_DESCRIPTOR;
 
 #endif /* __CUDA_API_VERSION >= 3020 */
@@ -1891,119 +2105,125 @@ typedef struct CUDA_ARRAY3D_DESCRIPTOR_st
 /**
  * CUDA Resource descriptor
  */
-typedef struct CUDA_RESOURCE_DESC_st
-{
-    CUresourcetype resType;                   /**< Resource type */
+typedef struct CUDA_RESOURCE_DESC_st {
+  CUresourcetype resType; /**< Resource type */
 
-    union {
-        struct {
-            CUarray hArray;                   /**< CUDA array */
-        } array;
-        struct {
-            CUmipmappedArray hMipmappedArray; /**< CUDA mipmapped array */
-        } mipmap;
-        struct {
-            CUdeviceptr devPtr;               /**< Device pointer */
-            CUarray_format format;            /**< Array format */
-            unsigned int numChannels;         /**< Channels per array element */
-            size_t sizeInBytes;               /**< Size in bytes */
-        } linear;
-        struct {
-            CUdeviceptr devPtr;               /**< Device pointer */
-            CUarray_format format;            /**< Array format */
-            unsigned int numChannels;         /**< Channels per array element */
-            size_t width;                     /**< Width of the array in elements */
-            size_t height;                    /**< Height of the array in elements */
-            size_t pitchInBytes;              /**< Pitch between two rows in bytes */
-        } pitch2D;
-        struct {
-            int reserved[32];
-        } reserved;
-    } res;
+  union {
+    struct {
+      CUarray hArray; /**< CUDA array */
+    } array;
+    struct {
+      CUmipmappedArray hMipmappedArray; /**< CUDA mipmapped array */
+    } mipmap;
+    struct {
+      CUdeviceptr devPtr;       /**< Device pointer */
+      CUarray_format format;    /**< Array format */
+      unsigned int numChannels; /**< Channels per array element */
+      size_t sizeInBytes;       /**< Size in bytes */
+    } linear;
+    struct {
+      CUdeviceptr devPtr;       /**< Device pointer */
+      CUarray_format format;    /**< Array format */
+      unsigned int numChannels; /**< Channels per array element */
+      size_t width;             /**< Width of the array in elements */
+      size_t height;            /**< Height of the array in elements */
+      size_t pitchInBytes;      /**< Pitch between two rows in bytes */
+    } pitch2D;
+    struct {
+      int reserved[32];
+    } reserved;
+  } res;
 
-    unsigned int flags;                       /**< Flags (must be zero) */
+  unsigned int flags; /**< Flags (must be zero) */
 } CUDA_RESOURCE_DESC;
 
 /**
  * Texture descriptor
  */
 typedef struct CUDA_TEXTURE_DESC_st {
-    CUaddress_mode addressMode[3];  /**< Address modes */
-    CUfilter_mode filterMode;       /**< Filter mode */
-    unsigned int flags;             /**< Flags */
-    unsigned int maxAnisotropy;     /**< Maximum anisotropy ratio */
-    CUfilter_mode mipmapFilterMode; /**< Mipmap filter mode */
-    float mipmapLevelBias;          /**< Mipmap level bias */
-    float minMipmapLevelClamp;      /**< Mipmap minimum level clamp */
-    float maxMipmapLevelClamp;      /**< Mipmap maximum level clamp */
-    float borderColor[4];           /**< Border Color */
-    int reserved[12];
+  CUaddress_mode addressMode[3];  /**< Address modes */
+  CUfilter_mode filterMode;       /**< Filter mode */
+  unsigned int flags;             /**< Flags */
+  unsigned int maxAnisotropy;     /**< Maximum anisotropy ratio */
+  CUfilter_mode mipmapFilterMode; /**< Mipmap filter mode */
+  float mipmapLevelBias;          /**< Mipmap level bias */
+  float minMipmapLevelClamp;      /**< Mipmap minimum level clamp */
+  float maxMipmapLevelClamp;      /**< Mipmap maximum level clamp */
+  float borderColor[4];           /**< Border Color */
+  int reserved[12];
 } CUDA_TEXTURE_DESC;
 
 /**
  * Resource view format
  */
-typedef enum CUresourceViewFormat_enum
-{
-    CU_RES_VIEW_FORMAT_NONE          = 0x00, /**< No resource view format (use underlying resource format) */
-    CU_RES_VIEW_FORMAT_UINT_1X8      = 0x01, /**< 1 channel unsigned 8-bit integers */
-    CU_RES_VIEW_FORMAT_UINT_2X8      = 0x02, /**< 2 channel unsigned 8-bit integers */
-    CU_RES_VIEW_FORMAT_UINT_4X8      = 0x03, /**< 4 channel unsigned 8-bit integers */
-    CU_RES_VIEW_FORMAT_SINT_1X8      = 0x04, /**< 1 channel signed 8-bit integers */
-    CU_RES_VIEW_FORMAT_SINT_2X8      = 0x05, /**< 2 channel signed 8-bit integers */
-    CU_RES_VIEW_FORMAT_SINT_4X8      = 0x06, /**< 4 channel signed 8-bit integers */
-    CU_RES_VIEW_FORMAT_UINT_1X16     = 0x07, /**< 1 channel unsigned 16-bit integers */
-    CU_RES_VIEW_FORMAT_UINT_2X16     = 0x08, /**< 2 channel unsigned 16-bit integers */
-    CU_RES_VIEW_FORMAT_UINT_4X16     = 0x09, /**< 4 channel unsigned 16-bit integers */
-    CU_RES_VIEW_FORMAT_SINT_1X16     = 0x0a, /**< 1 channel signed 16-bit integers */
-    CU_RES_VIEW_FORMAT_SINT_2X16     = 0x0b, /**< 2 channel signed 16-bit integers */
-    CU_RES_VIEW_FORMAT_SINT_4X16     = 0x0c, /**< 4 channel signed 16-bit integers */
-    CU_RES_VIEW_FORMAT_UINT_1X32     = 0x0d, /**< 1 channel unsigned 32-bit integers */
-    CU_RES_VIEW_FORMAT_UINT_2X32     = 0x0e, /**< 2 channel unsigned 32-bit integers */
-    CU_RES_VIEW_FORMAT_UINT_4X32     = 0x0f, /**< 4 channel unsigned 32-bit integers */
-    CU_RES_VIEW_FORMAT_SINT_1X32     = 0x10, /**< 1 channel signed 32-bit integers */
-    CU_RES_VIEW_FORMAT_SINT_2X32     = 0x11, /**< 2 channel signed 32-bit integers */
-    CU_RES_VIEW_FORMAT_SINT_4X32     = 0x12, /**< 4 channel signed 32-bit integers */
-    CU_RES_VIEW_FORMAT_FLOAT_1X16    = 0x13, /**< 1 channel 16-bit floating point */
-    CU_RES_VIEW_FORMAT_FLOAT_2X16    = 0x14, /**< 2 channel 16-bit floating point */
-    CU_RES_VIEW_FORMAT_FLOAT_4X16    = 0x15, /**< 4 channel 16-bit floating point */
-    CU_RES_VIEW_FORMAT_FLOAT_1X32    = 0x16, /**< 1 channel 32-bit floating point */
-    CU_RES_VIEW_FORMAT_FLOAT_2X32    = 0x17, /**< 2 channel 32-bit floating point */
-    CU_RES_VIEW_FORMAT_FLOAT_4X32    = 0x18, /**< 4 channel 32-bit floating point */
-    CU_RES_VIEW_FORMAT_UNSIGNED_BC1  = 0x19, /**< Block compressed 1 */
-    CU_RES_VIEW_FORMAT_UNSIGNED_BC2  = 0x1a, /**< Block compressed 2 */
-    CU_RES_VIEW_FORMAT_UNSIGNED_BC3  = 0x1b, /**< Block compressed 3 */
-    CU_RES_VIEW_FORMAT_UNSIGNED_BC4  = 0x1c, /**< Block compressed 4 unsigned */
-    CU_RES_VIEW_FORMAT_SIGNED_BC4    = 0x1d, /**< Block compressed 4 signed */
-    CU_RES_VIEW_FORMAT_UNSIGNED_BC5  = 0x1e, /**< Block compressed 5 unsigned */
-    CU_RES_VIEW_FORMAT_SIGNED_BC5    = 0x1f, /**< Block compressed 5 signed */
-    CU_RES_VIEW_FORMAT_UNSIGNED_BC6H = 0x20, /**< Block compressed 6 unsigned half-float */
-    CU_RES_VIEW_FORMAT_SIGNED_BC6H   = 0x21, /**< Block compressed 6 signed half-float */
-    CU_RES_VIEW_FORMAT_UNSIGNED_BC7  = 0x22  /**< Block compressed 7 */
+typedef enum CUresourceViewFormat_enum {
+  CU_RES_VIEW_FORMAT_NONE =
+      0x00, /**< No resource view format (use underlying resource format) */
+  CU_RES_VIEW_FORMAT_UINT_1X8 = 0x01, /**< 1 channel unsigned 8-bit integers */
+  CU_RES_VIEW_FORMAT_UINT_2X8 = 0x02, /**< 2 channel unsigned 8-bit integers */
+  CU_RES_VIEW_FORMAT_UINT_4X8 = 0x03, /**< 4 channel unsigned 8-bit integers */
+  CU_RES_VIEW_FORMAT_SINT_1X8 = 0x04, /**< 1 channel signed 8-bit integers */
+  CU_RES_VIEW_FORMAT_SINT_2X8 = 0x05, /**< 2 channel signed 8-bit integers */
+  CU_RES_VIEW_FORMAT_SINT_4X8 = 0x06, /**< 4 channel signed 8-bit integers */
+  CU_RES_VIEW_FORMAT_UINT_1X16 =
+      0x07, /**< 1 channel unsigned 16-bit integers */
+  CU_RES_VIEW_FORMAT_UINT_2X16 =
+      0x08, /**< 2 channel unsigned 16-bit integers */
+  CU_RES_VIEW_FORMAT_UINT_4X16 =
+      0x09, /**< 4 channel unsigned 16-bit integers */
+  CU_RES_VIEW_FORMAT_SINT_1X16 = 0x0a, /**< 1 channel signed 16-bit integers */
+  CU_RES_VIEW_FORMAT_SINT_2X16 = 0x0b, /**< 2 channel signed 16-bit integers */
+  CU_RES_VIEW_FORMAT_SINT_4X16 = 0x0c, /**< 4 channel signed 16-bit integers */
+  CU_RES_VIEW_FORMAT_UINT_1X32 =
+      0x0d, /**< 1 channel unsigned 32-bit integers */
+  CU_RES_VIEW_FORMAT_UINT_2X32 =
+      0x0e, /**< 2 channel unsigned 32-bit integers */
+  CU_RES_VIEW_FORMAT_UINT_4X32 =
+      0x0f, /**< 4 channel unsigned 32-bit integers */
+  CU_RES_VIEW_FORMAT_SINT_1X32 = 0x10,  /**< 1 channel signed 32-bit integers */
+  CU_RES_VIEW_FORMAT_SINT_2X32 = 0x11,  /**< 2 channel signed 32-bit integers */
+  CU_RES_VIEW_FORMAT_SINT_4X32 = 0x12,  /**< 4 channel signed 32-bit integers */
+  CU_RES_VIEW_FORMAT_FLOAT_1X16 = 0x13, /**< 1 channel 16-bit floating point */
+  CU_RES_VIEW_FORMAT_FLOAT_2X16 = 0x14, /**< 2 channel 16-bit floating point */
+  CU_RES_VIEW_FORMAT_FLOAT_4X16 = 0x15, /**< 4 channel 16-bit floating point */
+  CU_RES_VIEW_FORMAT_FLOAT_1X32 = 0x16, /**< 1 channel 32-bit floating point */
+  CU_RES_VIEW_FORMAT_FLOAT_2X32 = 0x17, /**< 2 channel 32-bit floating point */
+  CU_RES_VIEW_FORMAT_FLOAT_4X32 = 0x18, /**< 4 channel 32-bit floating point */
+  CU_RES_VIEW_FORMAT_UNSIGNED_BC1 = 0x19, /**< Block compressed 1 */
+  CU_RES_VIEW_FORMAT_UNSIGNED_BC2 = 0x1a, /**< Block compressed 2 */
+  CU_RES_VIEW_FORMAT_UNSIGNED_BC3 = 0x1b, /**< Block compressed 3 */
+  CU_RES_VIEW_FORMAT_UNSIGNED_BC4 = 0x1c, /**< Block compressed 4 unsigned */
+  CU_RES_VIEW_FORMAT_SIGNED_BC4 = 0x1d,   /**< Block compressed 4 signed */
+  CU_RES_VIEW_FORMAT_UNSIGNED_BC5 = 0x1e, /**< Block compressed 5 unsigned */
+  CU_RES_VIEW_FORMAT_SIGNED_BC5 = 0x1f,   /**< Block compressed 5 signed */
+  CU_RES_VIEW_FORMAT_UNSIGNED_BC6H =
+      0x20, /**< Block compressed 6 unsigned half-float */
+  CU_RES_VIEW_FORMAT_SIGNED_BC6H =
+      0x21, /**< Block compressed 6 signed half-float */
+  CU_RES_VIEW_FORMAT_UNSIGNED_BC7 = 0x22 /**< Block compressed 7 */
 } CUresourceViewFormat;
 
 /**
  * Resource view descriptor
  */
-typedef struct CUDA_RESOURCE_VIEW_DESC_st
-{
-    CUresourceViewFormat format;   /**< Resource view format */
-    size_t width;                  /**< Width of the resource view */
-    size_t height;                 /**< Height of the resource view */
-    size_t depth;                  /**< Depth of the resource view */
-    unsigned int firstMipmapLevel; /**< First defined mipmap level */
-    unsigned int lastMipmapLevel;  /**< Last defined mipmap level */
-    unsigned int firstLayer;       /**< First layer index */
-    unsigned int lastLayer;        /**< Last layer index */
-    unsigned int reserved[16];
+typedef struct CUDA_RESOURCE_VIEW_DESC_st {
+  CUresourceViewFormat format;   /**< Resource view format */
+  size_t width;                  /**< Width of the resource view */
+  size_t height;                 /**< Height of the resource view */
+  size_t depth;                  /**< Depth of the resource view */
+  unsigned int firstMipmapLevel; /**< First defined mipmap level */
+  unsigned int lastMipmapLevel;  /**< Last defined mipmap level */
+  unsigned int firstLayer;       /**< First layer index */
+  unsigned int lastLayer;        /**< Last layer index */
+  unsigned int reserved[16];
 } CUDA_RESOURCE_VIEW_DESC;
 
 /**
  * GPU Direct v3 tokens
  */
 typedef struct CUDA_POINTER_ATTRIBUTE_P2P_TOKENS_st {
-    unsigned long long p2pToken;
-    unsigned int vaSpaceToken;
+  unsigned long long p2pToken;
+  unsigned int vaSpaceToken;
 } CUDA_POINTER_ATTRIBUTE_P2P_TOKENS;
 
 #endif /* __CUDA_API_VERSION >= 5000 */
@@ -2014,16 +2234,17 @@ typedef struct CUDA_POINTER_ATTRIBUTE_P2P_TOKENS_st {
  * Kernel launch parameters
  */
 typedef struct CUDA_LAUNCH_PARAMS_st {
-    CUfunction function;         /**< Kernel to launch */
-    unsigned int gridDimX;       /**< Width of grid in blocks */
-    unsigned int gridDimY;       /**< Height of grid in blocks */
-    unsigned int gridDimZ;       /**< Depth of grid in blocks */
-    unsigned int blockDimX;      /**< X dimension of each thread block */
-    unsigned int blockDimY;      /**< Y dimension of each thread block */
-    unsigned int blockDimZ;      /**< Z dimension of each thread block */
-    unsigned int sharedMemBytes; /**< Dynamic shared-memory size per thread block in bytes */
-    CUstream hStream;            /**< Stream identifier */
-    void **kernelParams;         /**< Array of pointers to kernel parameters */
+  CUfunction function;         /**< Kernel to launch */
+  unsigned int gridDimX;       /**< Width of grid in blocks */
+  unsigned int gridDimY;       /**< Height of grid in blocks */
+  unsigned int gridDimZ;       /**< Depth of grid in blocks */
+  unsigned int blockDimX;      /**< X dimension of each thread block */
+  unsigned int blockDimY;      /**< Y dimension of each thread block */
+  unsigned int blockDimZ;      /**< Z dimension of each thread block */
+  unsigned int sharedMemBytes; /**< Dynamic shared-memory size per thread block
+                                  in bytes */
+  CUstream hStream;            /**< Stream identifier */
+  void **kernelParams;         /**< Array of pointers to kernel parameters */
 } CUDA_LAUNCH_PARAMS;
 
 #endif /* __CUDA_API_VERSION >= 9000 */
@@ -2034,277 +2255,278 @@ typedef struct CUDA_LAUNCH_PARAMS_st {
  * External memory handle types
  */
 typedef enum CUexternalMemoryHandleType_enum {
-    /**
-     * Handle is an opaque file descriptor
-     */
-    CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD        = 1,
-    /**
-     * Handle is an opaque shared NT handle
-     */
-    CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32     = 2,
-    /**
-     * Handle is an opaque, globally shared handle
-     */
-    CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT = 3,
-    /**
-     * Handle is a D3D12 heap object
-     */
-    CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP       = 4,
-    /**
-     * Handle is a D3D12 committed resource
-     */
-    CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE   = 5
+  /**
+   * Handle is an opaque file descriptor
+   */
+  CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD = 1,
+  /**
+   * Handle is an opaque shared NT handle
+   */
+  CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32 = 2,
+  /**
+   * Handle is an opaque, globally shared handle
+   */
+  CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT = 3,
+  /**
+   * Handle is a D3D12 heap object
+   */
+  CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP = 4,
+  /**
+   * Handle is a D3D12 committed resource
+   */
+  CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE = 5
 } CUexternalMemoryHandleType;
 
 /**
  * Indicates that the external memory object is a dedicated resource
  */
-#define CUDA_EXTERNAL_MEMORY_DEDICATED   0x1
+#define CUDA_EXTERNAL_MEMORY_DEDICATED 0x1
 
 /**
  * External memory handle descriptor
  */
 typedef struct CUDA_EXTERNAL_MEMORY_HANDLE_DESC_st {
+  /**
+   * Type of the handle
+   */
+  CUexternalMemoryHandleType type;
+  union {
     /**
-     * Type of the handle
+     * File descriptor referencing the memory object. Valid
+     * when type is
+     * ::CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD
      */
-    CUexternalMemoryHandleType type;
-    union {
-        /**
-         * File descriptor referencing the memory object. Valid
-         * when type is
-         * ::CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD
-         */
-        int fd;
-        /**
-         * Win32 handle referencing the semaphore object. Valid when
-         * type is one of the following:
-         * - ::CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32
-         * - ::CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT
-         * - ::CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP
-         * - ::CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE
-         * Exactly one of 'handle' and 'name' must be non-NULL. If
-         * type is
-         * ::CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT
-         * then 'name' must be NULL.
-         */
-        struct {
-            /**
-             * Valid NT handle. Must be NULL if 'name' is non-NULL
-             */
-            void *handle;
-            /**
-             * Name of a valid memory object.
-             * Must be NULL if 'handle' is non-NULL.
-             */
-            const void *name;
-        } win32;
-    } handle;
+    int fd;
     /**
-     * Size of the memory allocation
+     * Win32 handle referencing the semaphore object. Valid when
+     * type is one of the following:
+     * - ::CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32
+     * - ::CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT
+     * - ::CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP
+     * - ::CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE
+     * Exactly one of 'handle' and 'name' must be non-NULL. If
+     * type is
+     * ::CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT
+     * then 'name' must be NULL.
      */
-    unsigned long long size;
-    /**
-     * Flags must either be zero or ::CUDA_EXTERNAL_MEMORY_DEDICATED
-     */
-    unsigned int flags;
-    unsigned int reserved[16];
+    struct {
+      /**
+       * Valid NT handle. Must be NULL if 'name' is non-NULL
+       */
+      void *handle;
+      /**
+       * Name of a valid memory object.
+       * Must be NULL if 'handle' is non-NULL.
+       */
+      const void *name;
+    } win32;
+  } handle;
+  /**
+   * Size of the memory allocation
+   */
+  unsigned long long size;
+  /**
+   * Flags must either be zero or ::CUDA_EXTERNAL_MEMORY_DEDICATED
+   */
+  unsigned int flags;
+  unsigned int reserved[16];
 } CUDA_EXTERNAL_MEMORY_HANDLE_DESC;
 
 /**
  * External memory buffer descriptor
  */
 typedef struct CUDA_EXTERNAL_MEMORY_BUFFER_DESC_st {
-    /**
-     * Offset into the memory object where the buffer's base is
-     */
-    unsigned long long offset;
-    /**
-     * Size of the buffer
-     */
-    unsigned long long size;
-    /**
-     * Flags reserved for future use. Must be zero.
-     */
-    unsigned int flags;
-    unsigned int reserved[16];
+  /**
+   * Offset into the memory object where the buffer's base is
+   */
+  unsigned long long offset;
+  /**
+   * Size of the buffer
+   */
+  unsigned long long size;
+  /**
+   * Flags reserved for future use. Must be zero.
+   */
+  unsigned int flags;
+  unsigned int reserved[16];
 } CUDA_EXTERNAL_MEMORY_BUFFER_DESC;
 
 /**
  * External memory mipmap descriptor
  */
 typedef struct CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC_st {
-    /**
-     * Offset into the memory object where the base level of the
-     * mipmap chain is.
-     */
-    unsigned long long offset;
-    /**
-     * Format, dimension and type of base level of the mipmap chain
-     */
-    CUDA_ARRAY3D_DESCRIPTOR arrayDesc;
-    /**
-     * Total number of levels in the mipmap chain
-     */
-    unsigned int numLevels;
-    unsigned int reserved[16];
+  /**
+   * Offset into the memory object where the base level of the
+   * mipmap chain is.
+   */
+  unsigned long long offset;
+  /**
+   * Format, dimension and type of base level of the mipmap chain
+   */
+  CUDA_ARRAY3D_DESCRIPTOR arrayDesc;
+  /**
+   * Total number of levels in the mipmap chain
+   */
+  unsigned int numLevels;
+  unsigned int reserved[16];
 } CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC;
 
 /**
  * External semaphore handle types
  */
 typedef enum CUexternalSemaphoreHandleType_enum {
-    /**
-     * Handle is an opaque file descriptor
-     */
-    CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD        = 1,
-    /**
-     * Handle is an opaque shared NT handle
-     */
-    CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32     = 2,
-    /**
-     * Handle is an opaque, globally shared handle
-     */
-    CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT = 3,
-    /**
-     * Handle is a shared NT handle referencing a D3D12 fence object
-     */
-    CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE     = 4
+  /**
+   * Handle is an opaque file descriptor
+   */
+  CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD = 1,
+  /**
+   * Handle is an opaque shared NT handle
+   */
+  CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32 = 2,
+  /**
+   * Handle is an opaque, globally shared handle
+   */
+  CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT = 3,
+  /**
+   * Handle is a shared NT handle referencing a D3D12 fence object
+   */
+  CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE = 4
 } CUexternalSemaphoreHandleType;
 
 /**
  * External semaphore handle descriptor
  */
 typedef struct CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC_st {
+  /**
+   * Type of the handle
+   */
+  CUexternalSemaphoreHandleType type;
+  union {
     /**
-     * Type of the handle
+     * File descriptor referencing the semaphore object. Valid
+     * when type is
+     * ::CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD
      */
-    CUexternalSemaphoreHandleType type;
-    union {
-        /**
-         * File descriptor referencing the semaphore object. Valid
-         * when type is
-         * ::CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD
-         */
-        int fd;
-        /**
-         * Win32 handle referencing the semaphore object. Valid when
-         * type is one of the following:
-         * - ::CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32
-         * - ::CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT
-         * - ::CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE
-         * Exactly one of 'handle' and 'name' must be non-NULL. If
-         * type is
-         * ::CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT
-         * then 'name' must be NULL.
-         */
-        struct {
-            /**
-             * Valid NT handle. Must be NULL if 'name' is non-NULL
-             */
-            void *handle;
-            /**
-             * Name of a valid synchronization primitive.
-             * Must be NULL if 'handle' is non-NULL.
-             */
-            const void *name;
-        } win32;
-    } handle;
+    int fd;
     /**
-     * Flags reserved for the future. Must be zero.
+     * Win32 handle referencing the semaphore object. Valid when
+     * type is one of the following:
+     * - ::CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32
+     * - ::CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT
+     * - ::CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE
+     * Exactly one of 'handle' and 'name' must be non-NULL. If
+     * type is
+     * ::CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT
+     * then 'name' must be NULL.
      */
-    unsigned int flags;
-    unsigned int reserved[16];
+    struct {
+      /**
+       * Valid NT handle. Must be NULL if 'name' is non-NULL
+       */
+      void *handle;
+      /**
+       * Name of a valid synchronization primitive.
+       * Must be NULL if 'handle' is non-NULL.
+       */
+      const void *name;
+    } win32;
+  } handle;
+  /**
+   * Flags reserved for the future. Must be zero.
+   */
+  unsigned int flags;
+  unsigned int reserved[16];
 } CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC;
 
 /**
  * External semaphore signal parameters
  */
 typedef struct CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS_st {
-    struct {
-        /**
-         * Parameters for fence objects
-         */
-        struct {
-            /**
-             * Value of fence to be signaled
-             */
-            unsigned long long value;
-        } fence;
-        unsigned int reserved[16];
-    } params;
+  struct {
     /**
-     * Flags reserved for the future. Must be zero.
+     * Parameters for fence objects
      */
-    unsigned int flags;
+    struct {
+      /**
+       * Value of fence to be signaled
+       */
+      unsigned long long value;
+    } fence;
     unsigned int reserved[16];
+  } params;
+  /**
+   * Flags reserved for the future. Must be zero.
+   */
+  unsigned int flags;
+  unsigned int reserved[16];
 } CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS;
 
 /**
  * External semaphore wait parameters
  */
 typedef struct CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS_st {
-    struct {
-        /**
-         * Parameters for fence objects
-         */
-        struct {
-            /**
-             * Value of fence to be waited on
-             */
-            unsigned long long value;
-        } fence;
-        unsigned int reserved[16];
-    } params;
+  struct {
     /**
-     * Flags reserved for the future. Must be zero.
+     * Parameters for fence objects
      */
-    unsigned int flags;
+    struct {
+      /**
+       * Value of fence to be waited on
+       */
+      unsigned long long value;
+    } fence;
     unsigned int reserved[16];
+  } params;
+  /**
+   * Flags reserved for the future. Must be zero.
+   */
+  unsigned int flags;
+  unsigned int reserved[16];
 } CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS;
-
 
 #endif /* __CUDA_API_VERSION >= 10000 */
 
 /**
- * If set, each kernel launched as part of ::cuLaunchCooperativeKernelMultiDevice only
- * waits for prior work in the stream corresponding to that GPU to complete before the
- * kernel begins execution.
+ * If set, each kernel launched as part of
+ * ::cuLaunchCooperativeKernelMultiDevice only waits for prior work in the
+ * stream corresponding to that GPU to complete before the kernel begins
+ * execution.
  */
-#define CUDA_COOPERATIVE_LAUNCH_MULTI_DEVICE_NO_PRE_LAUNCH_SYNC   0x01
+#define CUDA_COOPERATIVE_LAUNCH_MULTI_DEVICE_NO_PRE_LAUNCH_SYNC 0x01
 
 /**
  * If set, any subsequent work pushed in a stream that participated in a call to
- * ::cuLaunchCooperativeKernelMultiDevice will only wait for the kernel launched on
- * the GPU corresponding to that stream to complete before it begins execution.
+ * ::cuLaunchCooperativeKernelMultiDevice will only wait for the kernel launched
+ * on the GPU corresponding to that stream to complete before it begins
+ * execution.
  */
-#define CUDA_COOPERATIVE_LAUNCH_MULTI_DEVICE_NO_POST_LAUNCH_SYNC  0x02
+#define CUDA_COOPERATIVE_LAUNCH_MULTI_DEVICE_NO_POST_LAUNCH_SYNC 0x02
 
 /**
- * If set, the CUDA array is a collection of layers, where each layer is either a 1D
- * or a 2D array and the Depth member of CUDA_ARRAY3D_DESCRIPTOR specifies the number
- * of layers, not the depth of a 3D array.
+ * If set, the CUDA array is a collection of layers, where each layer is either
+ * a 1D or a 2D array and the Depth member of CUDA_ARRAY3D_DESCRIPTOR specifies
+ * the number of layers, not the depth of a 3D array.
  */
-#define CUDA_ARRAY3D_LAYERED        0x01
+#define CUDA_ARRAY3D_LAYERED 0x01
 
 /**
  * Deprecated, use CUDA_ARRAY3D_LAYERED
  */
-#define CUDA_ARRAY3D_2DARRAY        0x01
+#define CUDA_ARRAY3D_2DARRAY 0x01
 
 /**
  * This flag must be set in order to bind a surface reference
  * to the CUDA array
  */
-#define CUDA_ARRAY3D_SURFACE_LDST   0x02
+#define CUDA_ARRAY3D_SURFACE_LDST 0x02
 
 /**
- * If set, the CUDA array is a collection of six 2D arrays, representing faces of a cube. The
- * width of such a CUDA array must be equal to its height, and Depth must be six.
- * If ::CUDA_ARRAY3D_LAYERED flag is also set, then the CUDA array is a collection of cubemaps
- * and Depth must be a multiple of six.
+ * If set, the CUDA array is a collection of six 2D arrays, representing faces
+ * of a cube. The width of such a CUDA array must be equal to its height, and
+ * Depth must be six. If ::CUDA_ARRAY3D_LAYERED flag is also set, then the CUDA
+ * array is a collection of cubemaps and Depth must be a multiple of six.
  */
-#define CUDA_ARRAY3D_CUBEMAP        0x04
+#define CUDA_ARRAY3D_CUBEMAP 0x04
 
 /**
  * This flag must be set in order to perform texture gather operations
@@ -2335,25 +2557,25 @@ typedef struct CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS_st {
  * in the range [0,1].
  * Flag for ::cuTexRefSetFlags()
  */
-#define CU_TRSF_READ_AS_INTEGER         0x01
+#define CU_TRSF_READ_AS_INTEGER 0x01
 
 /**
  * Use normalized texture coordinates in the range [0,1) instead of [0,dim).
  * Flag for ::cuTexRefSetFlags()
  */
-#define CU_TRSF_NORMALIZED_COORDINATES  0x02
+#define CU_TRSF_NORMALIZED_COORDINATES 0x02
 
 /**
  * Perform sRGB->linear conversion during texture read.
  * Flag for ::cuTexRefSetFlags()
  */
-#define CU_TRSF_SRGB  0x10
+#define CU_TRSF_SRGB 0x10
 
 /**
  * End of array terminator for the \p extra parameter to
  * ::cuLaunchKernel
  */
-#define CU_LAUNCH_PARAM_END            ((void*)0x00)
+#define CU_LAUNCH_PARAM_END ((void *)0x00)
 
 /**
  * Indicator that the next value in the \p extra parameter to
@@ -2364,7 +2586,7 @@ typedef struct CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS_st {
  * \p extra array, then ::CU_LAUNCH_PARAM_BUFFER_POINTER will have no
  * effect.
  */
-#define CU_LAUNCH_PARAM_BUFFER_POINTER ((void*)0x01)
+#define CU_LAUNCH_PARAM_BUFFER_POINTER ((void *)0x01)
 
 /**
  * Indicator that the next value in the \p extra parameter to
@@ -2374,7 +2596,7 @@ typedef struct CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS_st {
  * in the \p extra array if the value associated with
  * ::CU_LAUNCH_PARAM_BUFFER_SIZE is not zero.
  */
-#define CU_LAUNCH_PARAM_BUFFER_SIZE    ((void*)0x02)
+#define CU_LAUNCH_PARAM_BUFFER_SIZE ((void *)0x02)
 
 /**
  * For texture references loaded into the module, use default texunit from
@@ -2385,12 +2607,12 @@ typedef struct CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS_st {
 /**
  * Device that represents the CPU
  */
-#define CU_DEVICE_CPU               ((CUdevice)-1)
+#define CU_DEVICE_CPU ((CUdevice)-1)
 
 /**
  * Device that represents an invalid device
  */
-#define CU_DEVICE_INVALID           ((CUdevice)-2)
+#define CU_DEVICE_INVALID ((CUdevice)-2)
 
 /** @} */ /* END CUDA_TYPES */
 
@@ -2684,7 +2906,8 @@ CUresult CUDAAPI cuDeviceGetUuid(CUuuid *uuid, CUdevice dev);
  * ::cuDeviceTotalMem,
  * ::cudaGetDeviceProperties
  */
-CUresult CUDAAPI cuDeviceGetLuid(char *luid, unsigned int *deviceNodeMask, CUdevice dev);
+CUresult CUDAAPI cuDeviceGetLuid(char *luid, unsigned int *deviceNodeMask,
+                                 CUdevice dev);
 #endif
 
 #if __CUDA_API_VERSION >= 3020
@@ -2841,8 +3064,8 @@ CUresult CUDAAPI cuDeviceTotalMem(size_t *bytes, CUdevice dev);
  *     can have multiple CUDA contexts present at a single time.
  *   - ::CU_COMPUTEMODE_PROHIBITED: Compute-prohibited mode - Device is
  *     prohibited from creating new CUDA contexts.
- *   - ::CU_COMPUTEMODE_EXCLUSIVE_PROCESS:  Compute-exclusive-process mode - Device
- *     can have only one context used by a single process at a time.
+ *   - ::CU_COMPUTEMODE_EXCLUSIVE_PROCESS:  Compute-exclusive-process mode -
+ * Device can have only one context used by a single process at a time.
  * - ::CU_DEVICE_ATTRIBUTE_CONCURRENT_KERNELS: 1 if the device supports
  *   executing multiple kernels within the same context simultaneously, or 0 if
  *   not. It is not guaranteed that multiple kernels will be resident
@@ -2851,51 +3074,66 @@ CUresult CUDAAPI cuDeviceTotalMem(size_t *bytes, CUdevice dev);
  * - ::CU_DEVICE_ATTRIBUTE_ECC_ENABLED: 1 if error correction is enabled on the
  *    device, 0 if error correction is disabled or not supported by the device;
  * - ::CU_DEVICE_ATTRIBUTE_PCI_BUS_ID: PCI bus identifier of the device;
- * - ::CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID: PCI device (also known as slot) identifier
- *   of the device;
+ * - ::CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID: PCI device (also known as slot)
+ * identifier of the device;
  * - ::CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID: PCI domain identifier of the device
- * - ::CU_DEVICE_ATTRIBUTE_TCC_DRIVER: 1 if the device is using a TCC driver. TCC
- *    is only available on Tesla hardware running Windows Vista or later;
- * - ::CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE: Peak memory clock frequency in kilohertz;
- * - ::CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH: Global memory bus width in bits;
- * - ::CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE: Size of L2 cache in bytes. 0 if the device doesn't have L2 cache;
- * - ::CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR: Maximum resident threads per multiprocessor;
- * - ::CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING: 1 if the device shares a unified address space with
- *   the host, or 0 if not;
- * - ::CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR: Major compute capability version number;
- * - ::CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR: Minor compute capability version number;
- * - ::CU_DEVICE_ATTRIBUTE_GLOBAL_L1_CACHE_SUPPORTED: 1 if device supports caching globals
- *    in L1 cache, 0 if caching globals in L1 cache is not supported by the device;
- * - ::CU_DEVICE_ATTRIBUTE_LOCAL_L1_CACHE_SUPPORTED: 1 if device supports caching locals
- *    in L1 cache, 0 if caching locals in L1 cache is not supported by the device;
- * - ::CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR: Maximum amount of
- *   shared memory available to a multiprocessor in bytes; this amount is shared
- *   by all thread blocks simultaneously resident on a multiprocessor;
- * - ::CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_MULTIPROCESSOR: Maximum number of 32-bit
- *   registers available to a multiprocessor; this number is shared by all thread
- *   blocks simultaneously resident on a multiprocessor;
- * - ::CU_DEVICE_ATTRIBUTE_MANAGED_MEMORY: 1 if device supports allocating managed memory
- *   on this system, 0 if allocating managed memory is not supported by the device on this system.
- * - ::CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD: 1 if device is on a multi-GPU board, 0 if not.
- * - ::CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD_GROUP_ID: Unique identifier for a group of devices
- *   associated with the same board. Devices on the same multi-GPU board will share the same identifier.
- * - ::CU_DEVICE_ATTRIBUTE_HOST_NATIVE_ATOMIC_SUPPORTED: 1 if Link between the device and the host
- *   supports native atomic operations.
- * - ::CU_DEVICE_ATTRIBUTE_SINGLE_TO_DOUBLE_PRECISION_PERF_RATIO: Ratio of single precision performance
- *   (in floating-point operations per second) to double precision performance.
- * - ::CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS: Device suppports coherently accessing
- *   pageable memory without calling cudaHostRegister on it.
- * - ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS: Device can coherently access managed memory
- *   concurrently with the CPU.
- * - ::CU_DEVICE_ATTRIBUTE_COMPUTE_PREEMPTION_SUPPORTED: Device supports Compute Preemption.
- * - ::CU_DEVICE_ATTRIBUTE_CAN_USE_HOST_POINTER_FOR_REGISTERED_MEM: Device can access host registered
- *   memory at the same virtual address as the CPU.
- * -  ::CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN: The maximum per block shared memory size
- *    suported on this device. This is the maximum value that can be opted into when using the cuFuncSetAttribute() call.
- *    For more details see ::CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES
- * - ::CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES: Device accesses pageable memory via the host's
- *   page tables.
- * - ::CU_DEVICE_ATTRIBUTE_DIRECT_MANAGED_MEM_ACCESS_FROM_HOST: The host can directly access managed memory on the device without migration.
+ * - ::CU_DEVICE_ATTRIBUTE_TCC_DRIVER: 1 if the device is using a TCC driver.
+ * TCC is only available on Tesla hardware running Windows Vista or later;
+ * - ::CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE: Peak memory clock frequency in
+ * kilohertz;
+ * - ::CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH: Global memory bus width in
+ * bits;
+ * - ::CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE: Size of L2 cache in bytes. 0 if the
+ * device doesn't have L2 cache;
+ * - ::CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR: Maximum resident
+ * threads per multiprocessor;
+ * - ::CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING: 1 if the device shares a unified
+ * address space with the host, or 0 if not;
+ * - ::CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR: Major compute capability
+ * version number;
+ * - ::CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR: Minor compute capability
+ * version number;
+ * - ::CU_DEVICE_ATTRIBUTE_GLOBAL_L1_CACHE_SUPPORTED: 1 if device supports
+ * caching globals in L1 cache, 0 if caching globals in L1 cache is not
+ * supported by the device;
+ * - ::CU_DEVICE_ATTRIBUTE_LOCAL_L1_CACHE_SUPPORTED: 1 if device supports
+ * caching locals in L1 cache, 0 if caching locals in L1 cache is not supported
+ * by the device;
+ * - ::CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR: Maximum amount
+ * of shared memory available to a multiprocessor in bytes; this amount is
+ * shared by all thread blocks simultaneously resident on a multiprocessor;
+ * - ::CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_MULTIPROCESSOR: Maximum number of
+ * 32-bit registers available to a multiprocessor; this number is shared by all
+ * thread blocks simultaneously resident on a multiprocessor;
+ * - ::CU_DEVICE_ATTRIBUTE_MANAGED_MEMORY: 1 if device supports allocating
+ * managed memory on this system, 0 if allocating managed memory is not
+ * supported by the device on this system.
+ * - ::CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD: 1 if device is on a multi-GPU board,
+ * 0 if not.
+ * - ::CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD_GROUP_ID: Unique identifier for a
+ * group of devices associated with the same board. Devices on the same
+ * multi-GPU board will share the same identifier.
+ * - ::CU_DEVICE_ATTRIBUTE_HOST_NATIVE_ATOMIC_SUPPORTED: 1 if Link between the
+ * device and the host supports native atomic operations.
+ * - ::CU_DEVICE_ATTRIBUTE_SINGLE_TO_DOUBLE_PRECISION_PERF_RATIO: Ratio of
+ * single precision performance (in floating-point operations per second) to
+ * double precision performance.
+ * - ::CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS: Device suppports coherently
+ * accessing pageable memory without calling cudaHostRegister on it.
+ * - ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS: Device can coherently
+ * access managed memory concurrently with the CPU.
+ * - ::CU_DEVICE_ATTRIBUTE_COMPUTE_PREEMPTION_SUPPORTED: Device supports Compute
+ * Preemption.
+ * - ::CU_DEVICE_ATTRIBUTE_CAN_USE_HOST_POINTER_FOR_REGISTERED_MEM: Device can
+ * access host registered memory at the same virtual address as the CPU.
+ * -  ::CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN: The maximum per
+ * block shared memory size suported on this device. This is the maximum value
+ * that can be opted into when using the cuFuncSetAttribute() call. For more
+ * details see ::CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES
+ * - ::CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES: Device
+ * accesses pageable memory via the host's page tables.
+ * - ::CU_DEVICE_ATTRIBUTE_DIRECT_MANAGED_MEM_ACCESS_FROM_HOST: The host can
+ * directly access managed memory on the device without migration.
  *
  * \param pi     - Returned device attribute value
  * \param attrib - Device attribute to query
@@ -2919,7 +3157,8 @@ CUresult CUDAAPI cuDeviceTotalMem(size_t *bytes, CUdevice dev);
  * ::cudaDeviceGetAttribute,
  * ::cudaGetDeviceProperties
  */
-CUresult CUDAAPI cuDeviceGetAttribute(int *pi, CUdevice_attribute attrib, CUdevice dev);
+CUresult CUDAAPI cuDeviceGetAttribute(int *pi, CUdevice_attribute attrib,
+                                      CUdevice dev);
 
 /** @} */ /* END CUDA_DEVICE */
 
@@ -2940,7 +3179,8 @@ CUresult CUDAAPI cuDeviceGetAttribute(int *pi, CUdevice_attribute attrib, CUdevi
  *
  * \deprecated
  *
- * This function was deprecated as of CUDA 5.0 and replaced by ::cuDeviceGetAttribute().
+ * This function was deprecated as of CUDA 5.0 and replaced by
+ ::cuDeviceGetAttribute().
  *
  * Returns in \p *prop the properties of device \p dev. The ::CUdevprop
  * structure is defined as:
@@ -2997,7 +3237,8 @@ CUresult CUDAAPI cuDeviceGetAttribute(int *pi, CUdevice_attribute attrib, CUdevi
  * ::cuDeviceGet,
  * ::cuDeviceTotalMem
  */
-__CUDA_DEPRECATED CUresult CUDAAPI cuDeviceGetProperties(CUdevprop *prop, CUdevice dev);
+__CUDA_DEPRECATED CUresult CUDAAPI cuDeviceGetProperties(CUdevprop *prop,
+                                                         CUdevice dev);
 
 /**
  * \brief Returns the compute capability of the device
@@ -3031,21 +3272,23 @@ __CUDA_DEPRECATED CUresult CUDAAPI cuDeviceGetProperties(CUdevprop *prop, CUdevi
  * ::cuDeviceGet,
  * ::cuDeviceTotalMem
  */
-__CUDA_DEPRECATED CUresult CUDAAPI cuDeviceComputeCapability(int *major, int *minor, CUdevice dev);
+__CUDA_DEPRECATED CUresult CUDAAPI cuDeviceComputeCapability(int *major,
+                                                             int *minor,
+                                                             CUdevice dev);
 
 /** @} */ /* END CUDA_DEVICE_DEPRECATED */
 
 /**
  * \defgroup CUDA_PRIMARY_CTX Primary Context Management
  *
- * ___MANBRIEF___ primary context management functions of the low-level CUDA driver
- * API (___CURRENT_FILE___) ___ENDMANBRIEF___
+ * ___MANBRIEF___ primary context management functions of the low-level CUDA
+ * driver API (___CURRENT_FILE___) ___ENDMANBRIEF___
  *
- * This section describes the primary context management functions of the low-level
- * CUDA driver application programming interface.
+ * This section describes the primary context management functions of the
+ * low-level CUDA driver application programming interface.
  *
- * The primary context is unique per device and shared with the CUDA runtime API.
- * These functions allow integration with other libraries using CUDA.
+ * The primary context is unique per device and shared with the CUDA runtime
+ * API. These functions allow integration with other libraries using CUDA.
  *
  * @{
  */
@@ -3058,18 +3301,18 @@ __CUDA_DEPRECATED CUresult CUDAAPI cuDeviceComputeCapability(int *major, int *mi
  * Retains the primary context on the device, creating it if necessary,
  * increasing its usage count. The caller must call
  * ::cuDevicePrimaryCtxRelease() when done using the context.
- * Unlike ::cuCtxCreate() the newly created context is not pushed onto the stack.
+ * Unlike ::cuCtxCreate() the newly created context is not pushed onto the
+ * stack.
  *
  * Context creation will fail with ::CUDA_ERROR_UNKNOWN if the compute mode of
- * the device is ::CU_COMPUTEMODE_PROHIBITED.  The function ::cuDeviceGetAttribute()
- * can be used with ::CU_DEVICE_ATTRIBUTE_COMPUTE_MODE to determine the compute mode
- * of the device.
- * The <i>nvidia-smi</i> tool can be used to set the compute mode for
- * devices. Documentation for <i>nvidia-smi</i> can be obtained by passing a
- * -h option to it.
+ * the device is ::CU_COMPUTEMODE_PROHIBITED.  The function
+ * ::cuDeviceGetAttribute() can be used with ::CU_DEVICE_ATTRIBUTE_COMPUTE_MODE
+ * to determine the compute mode of the device. The <i>nvidia-smi</i> tool can
+ * be used to set the compute mode for devices. Documentation for
+ * <i>nvidia-smi</i> can be obtained by passing a -h option to it.
  *
- * Please note that the primary context always supports pinned allocations. Other
- * flags can be specified by ::cuDevicePrimaryCtxSetFlags().
+ * Please note that the primary context always supports pinned allocations.
+ * Other flags can be specified by ::cuDevicePrimaryCtxSetFlags().
  *
  * \param pctx  - Returned context handle of the new context
  * \param dev   - Device for which primary context is requested
@@ -3224,7 +3467,8 @@ CUresult CUDAAPI cuDevicePrimaryCtxSetFlags(CUdevice dev, unsigned int flags);
  * ::cuCtxGetFlags,
  * ::cudaGetDeviceFlags
  */
-CUresult CUDAAPI cuDevicePrimaryCtxGetState(CUdevice dev, unsigned int *flags, int *active);
+CUresult CUDAAPI cuDevicePrimaryCtxGetState(CUdevice dev, unsigned int *flags,
+                                            int *active);
 
 /**
  * \brief Destroy all allocations and reset all state on the primary context
@@ -3268,7 +3512,6 @@ CUresult CUDAAPI cuDevicePrimaryCtxReset(CUdevice dev);
 
 /** @} */ /* END CUDA_PRIMARY_CTX */
 
-
 /**
  * \defgroup CUDA_CTX Context Management
  *
@@ -3294,8 +3537,8 @@ CUresult CUDAAPI cuDevicePrimaryCtxReset(CUdevice dev);
  * \p flags parameter is described below. The context is created with a usage
  * count of 1 and the caller of ::cuCtxCreate() must call ::cuCtxDestroy()
  * when done using the context. If a context is already current to the thread,
- * it is supplanted by the newly created context and may be restored by a subsequent
- * call to ::cuCtxPopCurrent().
+ * it is supplanted by the newly created context and may be restored by a
+ * subsequent call to ::cuCtxPopCurrent().
  *
  * The three LSBs of the \p flags parameter can be used to control how the OS
  * thread, which owns the CUDA context at the time of an API call, interacts
@@ -3340,12 +3583,11 @@ CUresult CUDAAPI cuDevicePrimaryCtxReset(CUdevice dev);
  * memory usage at the cost of potentially increased memory usage.
  *
  * Context creation will fail with ::CUDA_ERROR_UNKNOWN if the compute mode of
- * the device is ::CU_COMPUTEMODE_PROHIBITED. The function ::cuDeviceGetAttribute()
- * can be used with ::CU_DEVICE_ATTRIBUTE_COMPUTE_MODE to determine the
- * compute mode of the device. The <i>nvidia-smi</i> tool can be used to set
- * the compute mode for * devices.
- * Documentation for <i>nvidia-smi</i> can be obtained by passing a
- * -h option to it.
+ * the device is ::CU_COMPUTEMODE_PROHIBITED. The function
+ * ::cuDeviceGetAttribute() can be used with ::CU_DEVICE_ATTRIBUTE_COMPUTE_MODE
+ * to determine the compute mode of the device. The <i>nvidia-smi</i> tool can
+ * be used to set the compute mode for * devices. Documentation for
+ * <i>nvidia-smi</i> can be obtained by passing a -h option to it.
  *
  * \param pctx  - Returned context handle of the new context
  * \param flags - Context creation flags
@@ -3692,9 +3934,9 @@ CUresult CUDAAPI cuCtxSynchronize(void);
  *   than 3.5 will result in the error ::CUDA_ERROR_UNSUPPORTED_LIMIT being
  *   returned.
  *
- * - ::CU_LIMIT_MAX_L2_FETCH_GRANULARITY controls the L2 cache fetch granularity.
- *   Values can range from 0B to 128B. This is purely a performance hint and
- *   it can be ignored or clamped depending on the platform.
+ * - ::CU_LIMIT_MAX_L2_FETCH_GRANULARITY controls the L2 cache fetch
+ * granularity. Values can range from 0B to 128B. This is purely a performance
+ * hint and it can be ignored or clamped depending on the platform.
  *
  * \param limit - Limit to set
  * \param value - Size of limit
@@ -3767,17 +4009,19 @@ CUresult CUDAAPI cuCtxGetLimit(size_t *pvalue, CUlimit limit);
  * \brief Returns the preferred cache configuration for the current context.
  *
  * On devices where the L1 cache and shared memory use the same hardware
- * resources, this function returns through \p pconfig the preferred cache configuration
- * for the current context. This is only a preference. The driver will use
- * the requested configuration if possible, but it is free to choose a different
- * configuration if required to execute functions.
+ * resources, this function returns through \p pconfig the preferred cache
+ * configuration for the current context. This is only a preference. The driver
+ * will use the requested configuration if possible, but it is free to choose a
+ * different configuration if required to execute functions.
  *
  * This will return a \p pconfig of ::CU_FUNC_CACHE_PREFER_NONE on devices
  * where the size of the L1 cache and shared memory are fixed.
  *
  * The supported cache configurations are:
- * - ::CU_FUNC_CACHE_PREFER_NONE: no preference for shared memory or L1 (default)
- * - ::CU_FUNC_CACHE_PREFER_SHARED: prefer larger shared memory and smaller L1 cache
+ * - ::CU_FUNC_CACHE_PREFER_NONE: no preference for shared memory or L1
+ * (default)
+ * - ::CU_FUNC_CACHE_PREFER_SHARED: prefer larger shared memory and smaller L1
+ * cache
  * - ::CU_FUNC_CACHE_PREFER_L1: prefer larger L1 cache and smaller shared memory
  * - ::CU_FUNC_CACHE_PREFER_EQUAL: prefer equal sized L1 cache and shared memory
  *
@@ -3827,8 +4071,10 @@ CUresult CUDAAPI cuCtxGetCacheConfig(CUfunc_cache *pconfig);
  * preference setting may insert a device-side synchronization point.
  *
  * The supported cache configurations are:
- * - ::CU_FUNC_CACHE_PREFER_NONE: no preference for shared memory or L1 (default)
- * - ::CU_FUNC_CACHE_PREFER_SHARED: prefer larger shared memory and smaller L1 cache
+ * - ::CU_FUNC_CACHE_PREFER_NONE: no preference for shared memory or L1
+ * (default)
+ * - ::CU_FUNC_CACHE_PREFER_SHARED: prefer larger shared memory and smaller L1
+ * cache
  * - ::CU_FUNC_CACHE_PREFER_L1: prefer larger L1 cache and smaller shared memory
  * - ::CU_FUNC_CACHE_PREFER_EQUAL: prefer equal sized L1 cache and shared memory
  *
@@ -3860,10 +4106,12 @@ CUresult CUDAAPI cuCtxSetCacheConfig(CUfunc_cache config);
 
 #if __CUDA_API_VERSION >= 4020
 /**
- * \brief Returns the current shared memory configuration for the current context.
+ * \brief Returns the current shared memory configuration for the current
+ * context.
  *
- * This function will return in \p pConfig the current size of shared memory banks
- * in the current context. On devices with configurable shared memory banks,
+ * This function will return in \p pConfig the current size of shared memory
+ * banks in the current context. On devices with configurable shared memory
+ * banks,
  * ::cuCtxSetSharedMemConfig can be used to change this setting, so that all
  * subsequent kernel launches will by default use the new bank size. When
  * ::cuCtxGetSharedMemConfig is called on devices without configurable shared
@@ -3913,19 +4161,19 @@ CUresult CUDAAPI cuCtxGetSharedMemConfig(CUsharedconfig *pConfig);
  *
  * Changing the shared memory bank size will not increase shared memory usage
  * or affect occupancy of kernels, but may have major effects on performance.
- * Larger bank sizes will allow for greater potential bandwidth to shared memory,
- * but will change what kinds of accesses to shared memory will result in bank
- * conflicts.
+ * Larger bank sizes will allow for greater potential bandwidth to shared
+ * memory, but will change what kinds of accesses to shared memory will result
+ * in bank conflicts.
  *
  * This function will do nothing on devices with fixed shared memory bank size.
  *
  * The supported bank configurations are:
- * - ::CU_SHARED_MEM_CONFIG_DEFAULT_BANK_SIZE: set bank width to the default initial
- *   setting (currently, four bytes).
+ * - ::CU_SHARED_MEM_CONFIG_DEFAULT_BANK_SIZE: set bank width to the default
+ * initial setting (currently, four bytes).
  * - ::CU_SHARED_MEM_CONFIG_FOUR_BYTE_BANK_SIZE: set shared memory bank width to
  *   be natively four bytes.
- * - ::CU_SHARED_MEM_CONFIG_EIGHT_BYTE_BANK_SIZE: set shared memory bank width to
- *   be natively eight bytes.
+ * - ::CU_SHARED_MEM_CONFIG_EIGHT_BYTE_BANK_SIZE: set shared memory bank width
+ * to be natively eight bytes.
  *
  * \param config - requested shared memory configuration
  *
@@ -3964,9 +4212,9 @@ CUresult CUDAAPI cuCtxSetSharedMemConfig(CUsharedconfig config);
  * used to create the currently bound context.
  *
  * Note that new API versions are only introduced when context capabilities are
- * changed that break binary compatibility, so the API version and driver version
- * may be different. For example, it is valid for the API version to be 3020 while
- * the driver version is 4020.
+ * changed that break binary compatibility, so the API version and driver
+ * version may be different. For example, it is valid for the API version to be
+ * 3020 while the driver version is 4020.
  *
  * \param ctx     - Context to check
  * \param version - Pointer to version
@@ -3997,26 +4245,25 @@ CUresult CUDAAPI cuCtxGetApiVersion(CUcontext ctx, unsigned int *version);
  * \brief Returns numerical values that correspond to the least and
  * greatest stream priorities.
  *
- * Returns in \p *leastPriority and \p *greatestPriority the numerical values that correspond
- * to the least and greatest stream priorities respectively. Stream priorities
- * follow a convention where lower numbers imply greater priorities. The range of
- * meaningful stream priorities is given by [\p *greatestPriority, \p *leastPriority].
- * If the user attempts to create a stream with a priority value that is
- * outside the meaningful range as specified by this API, the priority is
- * automatically clamped down or up to either \p *leastPriority or \p *greatestPriority
- * respectively. See ::cuStreamCreateWithPriority for details on creating a
- * priority stream.
- * A NULL may be passed in for \p *leastPriority or \p *greatestPriority if the value
- * is not desired.
+ * Returns in \p *leastPriority and \p *greatestPriority the numerical values
+ * that correspond to the least and greatest stream priorities respectively.
+ * Stream priorities follow a convention where lower numbers imply greater
+ * priorities. The range of meaningful stream priorities is given by [\p
+ * *greatestPriority, \p *leastPriority]. If the user attempts to create a
+ * stream with a priority value that is outside the meaningful range as
+ * specified by this API, the priority is automatically clamped down or up to
+ * either \p *leastPriority or \p *greatestPriority respectively. See
+ * ::cuStreamCreateWithPriority for details on creating a priority stream. A
+ * NULL may be passed in for \p *leastPriority or \p *greatestPriority if the
+ * value is not desired.
  *
- * This function will return '0' in both \p *leastPriority and \p *greatestPriority if
- * the current context's device does not support stream priorities
- * (see ::cuDeviceGetAttribute).
+ * This function will return '0' in both \p *leastPriority and \p
+ * *greatestPriority if the current context's device does not support stream
+ * priorities (see ::cuDeviceGetAttribute).
  *
- * \param leastPriority    - Pointer to an int in which the numerical value for least
- *                           stream priority is returned
- * \param greatestPriority - Pointer to an int in which the numerical value for greatest
- *                           stream priority is returned
+ * \param leastPriority    - Pointer to an int in which the numerical value for
+ * least stream priority is returned \param greatestPriority - Pointer to an int
+ * in which the numerical value for greatest stream priority is returned
  *
  * \return
  * ::CUDA_SUCCESS,
@@ -4031,7 +4278,8 @@ CUresult CUDAAPI cuCtxGetApiVersion(CUcontext ctx, unsigned int *version);
  * ::cuCtxSynchronize,
  * ::cudaDeviceGetStreamPriorityRange
  */
-CUresult CUDAAPI cuCtxGetStreamPriorityRange(int *leastPriority, int *greatestPriority);
+CUresult CUDAAPI cuCtxGetStreamPriorityRange(int *leastPriority,
+                                             int *greatestPriority);
 
 /** @} */ /* END CUDA_CTX */
 
@@ -4041,8 +4289,8 @@ CUresult CUDAAPI cuCtxGetStreamPriorityRange(int *leastPriority, int *greatestPr
  * ___MANBRIEF___ deprecated context management functions of the low-level CUDA
  * driver API (___CURRENT_FILE___) ___ENDMANBRIEF___
  *
- * This section describes the deprecated context management functions of the low-level
- * CUDA driver application programming interface.
+ * This section describes the deprecated context management functions of the
+ * low-level CUDA driver application programming interface.
  *
  * @{
  */
@@ -4086,7 +4334,8 @@ CUresult CUDAAPI cuCtxGetStreamPriorityRange(int *leastPriority, int *greatestPr
  * ::cuCtxSetLimit,
  * ::cuCtxSynchronize
  */
-__CUDA_DEPRECATED CUresult CUDAAPI cuCtxAttach(CUcontext *pctx, unsigned int flags);
+__CUDA_DEPRECATED CUresult CUDAAPI cuCtxAttach(CUcontext *pctx,
+                                               unsigned int flags);
 
 /**
  * \brief Decrement a context's usage-count
@@ -4125,7 +4374,6 @@ __CUDA_DEPRECATED CUresult CUDAAPI cuCtxAttach(CUcontext *pctx, unsigned int fla
 __CUDA_DEPRECATED CUresult CUDAAPI cuCtxDetach(CUcontext ctx);
 
 /** @} */ /* END CUDA_CTX_DEPRECATED */
-
 
 /**
  * \defgroup CUDA_MODULE Module Management
@@ -4257,7 +4505,9 @@ CUresult CUDAAPI cuModuleLoadData(CUmodule *module, const void *image);
  * ::cuModuleLoadFatBinary,
  * ::cuModuleUnload
  */
-CUresult CUDAAPI cuModuleLoadDataEx(CUmodule *module, const void *image, unsigned int numOptions, CUjit_option *options, void **optionValues);
+CUresult CUDAAPI cuModuleLoadDataEx(CUmodule *module, const void *image,
+                                    unsigned int numOptions,
+                                    CUjit_option *options, void **optionValues);
 
 /**
  * \brief Load a module's data
@@ -4354,7 +4604,8 @@ CUresult CUDAAPI cuModuleUnload(CUmodule hmod);
  * ::cuModuleLoadFatBinary,
  * ::cuModuleUnload
  */
-CUresult CUDAAPI cuModuleGetFunction(CUfunction *hfunc, CUmodule hmod, const char *name);
+CUresult CUDAAPI cuModuleGetFunction(CUfunction *hfunc, CUmodule hmod,
+                                     const char *name);
 
 #if __CUDA_API_VERSION >= 3020
 /**
@@ -4390,7 +4641,8 @@ CUresult CUDAAPI cuModuleGetFunction(CUfunction *hfunc, CUmodule hmod, const cha
  * ::cudaGetSymbolAddress,
  * ::cudaGetSymbolSize
  */
-CUresult CUDAAPI cuModuleGetGlobal(CUdeviceptr *dptr, size_t *bytes, CUmodule hmod, const char *name);
+CUresult CUDAAPI cuModuleGetGlobal(CUdeviceptr *dptr, size_t *bytes,
+                                   CUmodule hmod, const char *name);
 #endif /* __CUDA_API_VERSION >= 3020 */
 
 /**
@@ -4425,7 +4677,8 @@ CUresult CUDAAPI cuModuleGetGlobal(CUdeviceptr *dptr, size_t *bytes, CUmodule hm
  * ::cuModuleUnload,
  * ::cudaGetTextureReference
  */
-CUresult CUDAAPI cuModuleGetTexRef(CUtexref *pTexRef, CUmodule hmod, const char *name);
+CUresult CUDAAPI cuModuleGetTexRef(CUtexref *pTexRef, CUmodule hmod,
+                                   const char *name);
 
 /**
  * \brief Returns a handle to a surface reference
@@ -4457,7 +4710,8 @@ CUresult CUDAAPI cuModuleGetTexRef(CUtexref *pTexRef, CUmodule hmod, const char 
  * ::cuModuleUnload,
  * ::cudaGetSurfaceReference
  */
-CUresult CUDAAPI cuModuleGetSurfRef(CUsurfref *pSurfRef, CUmodule hmod, const char *name);
+CUresult CUDAAPI cuModuleGetSurfRef(CUsurfref *pSurfRef, CUmodule hmod,
+                                    const char *name);
 
 #if __CUDA_API_VERSION >= 5050
 
@@ -4499,14 +4753,14 @@ CUresult CUDAAPI cuModuleGetSurfRef(CUsurfref *pSurfRef, CUmodule hmod, const ch
  * ::cuLinkComplete,
  * ::cuLinkDestroy
  */
-CUresult CUDAAPI
-cuLinkCreate(unsigned int numOptions, CUjit_option *options, void **optionValues, CUlinkState *stateOut);
+CUresult CUDAAPI cuLinkCreate(unsigned int numOptions, CUjit_option *options,
+                              void **optionValues, CUlinkState *stateOut);
 
 /**
  * \brief Add an input to a pending linker invocation
  *
- * Ownership of \p data is retained by the caller.  No reference is retained to any
- * inputs after this call returns.
+ * Ownership of \p data is retained by the caller.  No reference is retained to
+ * any inputs after this call returns.
  *
  * This method accepts only compiler options, which are used if the data must
  * be compiled from PTX, and does not accept any of
@@ -4519,8 +4773,9 @@ cuLinkCreate(unsigned int numOptions, CUjit_option *options, void **optionValues
  * \param size         The length of the input data.
  * \param name         An optional name for this input in log messages.
  * \param numOptions   Size of options.
- * \param options      Options to be applied only for this input (overrides options from ::cuLinkCreate).
- * \param optionValues Array of option values, each cast to void *.
+ * \param options      Options to be applied only for this input (overrides
+ * options from ::cuLinkCreate). \param optionValues Array of option values,
+ * each cast to void *.
  *
  * \return
  * ::CUDA_SUCCESS,
@@ -4536,9 +4791,10 @@ cuLinkCreate(unsigned int numOptions, CUjit_option *options, void **optionValues
  * ::cuLinkComplete,
  * ::cuLinkDestroy
  */
-CUresult CUDAAPI
-cuLinkAddData(CUlinkState state, CUjitInputType type, void *data, size_t size, const char *name,
-    unsigned int numOptions, CUjit_option *options, void **optionValues);
+CUresult CUDAAPI cuLinkAddData(CUlinkState state, CUjitInputType type,
+                               void *data, size_t size, const char *name,
+                               unsigned int numOptions, CUjit_option *options,
+                               void **optionValues);
 
 /**
  * \brief Add a file input to a pending linker invocation
@@ -4557,8 +4813,9 @@ cuLinkAddData(CUlinkState state, CUjitInputType type, void *data, size_t size, c
  * \param type         The type of the input data
  * \param path         Path to the input file
  * \param numOptions   Size of options
- * \param options      Options to be applied only for this input (overrides options from ::cuLinkCreate)
- * \param optionValues Array of option values, each cast to void *
+ * \param options      Options to be applied only for this input (overrides
+ * options from ::cuLinkCreate) \param optionValues Array of option values, each
+ * cast to void *
  *
  * \return
  * ::CUDA_SUCCESS,
@@ -4575,17 +4832,17 @@ cuLinkAddData(CUlinkState state, CUjitInputType type, void *data, size_t size, c
  * ::cuLinkComplete,
  * ::cuLinkDestroy
  */
-CUresult CUDAAPI
-cuLinkAddFile(CUlinkState state, CUjitInputType type, const char *path,
-    unsigned int numOptions, CUjit_option *options, void **optionValues);
+CUresult CUDAAPI cuLinkAddFile(CUlinkState state, CUjitInputType type,
+                               const char *path, unsigned int numOptions,
+                               CUjit_option *options, void **optionValues);
 
 /**
  * \brief Complete a pending linker invocation
  *
- * Completes the pending linker action and returns the cubin image for the linked
- * device code, which can be used with ::cuModuleLoadData.  The cubin is owned by
- * \p state, so it should be loaded before \p state is destroyed via ::cuLinkDestroy.
- * This call does not destroy \p state.
+ * Completes the pending linker action and returns the cubin image for the
+ * linked device code, which can be used with ::cuModuleLoadData.  The cubin is
+ * owned by \p state, so it should be loaded before \p state is destroyed via
+ * ::cuLinkDestroy. This call does not destroy \p state.
  *
  * \param state    A pending linker invocation
  * \param cubinOut On success, this will point to the output image
@@ -4602,8 +4859,8 @@ cuLinkAddFile(CUlinkState state, CUjitInputType type, const char *path,
  * ::cuLinkDestroy,
  * ::cuModuleLoadData
  */
-CUresult CUDAAPI
-cuLinkComplete(CUlinkState state, void **cubinOut, size_t *sizeOut);
+CUresult CUDAAPI cuLinkComplete(CUlinkState state, void **cubinOut,
+                                size_t *sizeOut);
 
 /**
  * \brief Destroys state for a JIT linker invocation.
@@ -4616,13 +4873,11 @@ cuLinkComplete(CUlinkState state, void **cubinOut, size_t *sizeOut);
  *
  * \sa ::cuLinkCreate
  */
-CUresult CUDAAPI
-cuLinkDestroy(CUlinkState state);
+CUresult CUDAAPI cuLinkDestroy(CUlinkState state);
 
 #endif /* __CUDA_API_VERSION >= 5050 */
 
 /** @} */ /* END CUDA_MODULE */
-
 
 /**
  * \defgroup CUDA_MEM Memory Management
@@ -4658,7 +4913,8 @@ cuLinkDestroy(CUlinkState state);
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemHostAlloc,
@@ -4692,7 +4948,8 @@ CUresult CUDAAPI cuMemGetInfo(size_t *free, size_t *total);
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -4754,7 +5011,8 @@ CUresult CUDAAPI cuMemAlloc(CUdeviceptr *dptr, size_t bytesize);
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -4762,7 +5020,9 @@ CUresult CUDAAPI cuMemAlloc(CUdeviceptr *dptr, size_t bytesize);
  * ::cuMemsetD2D32, ::cuMemsetD8, ::cuMemsetD16, ::cuMemsetD32,
  * ::cudaMallocPitch
  */
-CUresult CUDAAPI cuMemAllocPitch(CUdeviceptr *dptr, size_t *pPitch, size_t WidthInBytes, size_t Height, unsigned int ElementSizeBytes);
+CUresult CUDAAPI cuMemAllocPitch(CUdeviceptr *dptr, size_t *pPitch,
+                                 size_t WidthInBytes, size_t Height,
+                                 unsigned int ElementSizeBytes);
 
 /**
  * \brief Frees device memory
@@ -4784,7 +5044,8 @@ CUresult CUDAAPI cuMemAllocPitch(CUdeviceptr *dptr, size_t *pPitch, size_t Width
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -4819,14 +5080,16 @@ CUresult CUDAAPI cuMemFree(CUdeviceptr dptr);
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetInfo, ::cuMemHostAlloc,
  * ::cuMemHostGetDevicePointer, ::cuMemsetD2D8, ::cuMemsetD2D16,
  * ::cuMemsetD2D32, ::cuMemsetD8, ::cuMemsetD16, ::cuMemsetD32
  */
-CUresult CUDAAPI cuMemGetAddressRange(CUdeviceptr *pbase, size_t *psize, CUdeviceptr dptr);
+CUresult CUDAAPI cuMemGetAddressRange(CUdeviceptr *pbase, size_t *psize,
+                                      CUdeviceptr dptr);
 
 /**
  * \brief Allocates page-locked host memory
@@ -4843,11 +5106,11 @@ CUresult CUDAAPI cuMemGetAddressRange(CUdeviceptr *pbase, size_t *psize, CUdevic
  * staging areas for data exchange between host and device.
  *
  * Note all host memory allocated using ::cuMemHostAlloc() will automatically
- * be immediately accessible to all contexts on all devices which support unified
- * addressing (as may be queried using ::CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING).
- * The device pointer that may be used to access this host memory from those
- * contexts is always equal to the returned host pointer \p *pp.
- * See \ref CUDA_UNIFIED for additional details.
+ * be immediately accessible to all contexts on all devices which support
+ * unified addressing (as may be queried using
+ * ::CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING). The device pointer that may be
+ * used to access this host memory from those contexts is always equal to the
+ * returned host pointer \p *pp. See \ref CUDA_UNIFIED for additional details.
  *
  * \param pp       - Returned host pointer to page-locked memory
  * \param bytesize - Requested allocation size in bytes
@@ -4865,7 +5128,8 @@ CUresult CUDAAPI cuMemGetAddressRange(CUdeviceptr *pbase, size_t *psize, CUdevic
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -4896,7 +5160,8 @@ CUresult CUDAAPI cuMemAllocHost(void **pp, size_t bytesize);
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -4952,13 +5217,14 @@ CUresult CUDAAPI cuMemFreeHost(void *p);
  * The memory allocated by this function must be freed with ::cuMemFreeHost().
  *
  * Note all host memory allocated using ::cuMemHostAlloc() will automatically
- * be immediately accessible to all contexts on all devices which support unified
- * addressing (as may be queried using ::CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING).
- * Unless the flag ::CU_MEMHOSTALLOC_WRITECOMBINED is specified, the device pointer
- * that may be used to access this host memory from those contexts is always equal
- * to the returned host pointer \p *pp.  If the flag ::CU_MEMHOSTALLOC_WRITECOMBINED
- * is specified, then the function ::cuMemHostGetDevicePointer() must be used
- * to query the device pointer, even if the context supports unified addressing.
+ * be immediately accessible to all contexts on all devices which support
+ * unified addressing (as may be queried using
+ * ::CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING). Unless the flag
+ * ::CU_MEMHOSTALLOC_WRITECOMBINED is specified, the device pointer that may be
+ * used to access this host memory from those contexts is always equal to the
+ * returned host pointer \p *pp.  If the flag ::CU_MEMHOSTALLOC_WRITECOMBINED is
+ * specified, then the function ::cuMemHostGetDevicePointer() must be used to
+ * query the device pointer, even if the context supports unified addressing.
  * See \ref CUDA_UNIFIED for additional details.
  *
  * \param pp       - Returned host pointer to page-locked memory
@@ -4978,7 +5244,8 @@ CUresult CUDAAPI cuMemFreeHost(void *p);
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo,
@@ -5003,16 +5270,18 @@ CUresult CUDAAPI cuMemHostAlloc(void **pp, size_t bytesize, unsigned int Flags);
  * ::CU_DEVICE_ATTRIBUTE_CAN_USE_HOST_POINTER_FOR_REGISTERED_MEM, the memory
  * can also be accessed from the device using the host pointer \p p.
  * The device pointer returned by ::cuMemHostGetDevicePointer() may or may not
- * match the original host pointer \p p and depends on the devices visible to the
- * application. If all devices visible to the application have a non-zero value for the
- * device attribute, the device pointer returned by ::cuMemHostGetDevicePointer()
- * will match the original pointer \p p. If any device visible to the application
- * has a zero value for the device attribute, the device pointer returned by
+ * match the original host pointer \p p and depends on the devices visible to
+ * the application. If all devices visible to the application have a non-zero
+ * value for the device attribute, the device pointer returned by
+ * ::cuMemHostGetDevicePointer() will match the original pointer \p p. If any
+ * device visible to the application has a zero value for the device attribute,
+ * the device pointer returned by
  * ::cuMemHostGetDevicePointer() will not match the original host pointer \p p,
- * but it will be suitable for use on all devices provided Unified Virtual Addressing
- * is enabled. In such systems, it is valid to access the memory using either pointer
- * on devices that have a non-zero value for the device attribute. Note however that
- * such devices should access the memory using only of the two pointers and not both.
+ * but it will be suitable for use on all devices provided Unified Virtual
+ * Addressing is enabled. In such systems, it is valid to access the memory
+ * using either pointer on devices that have a non-zero value for the device
+ * attribute. Note however that such devices should access the memory using only
+ * of the two pointers and not both.
  *
  * \p Flags provides for future releases. For now, it must be set to 0.
  *
@@ -5032,7 +5301,8 @@ CUresult CUDAAPI cuMemHostAlloc(void **pp, size_t bytesize, unsigned int Flags);
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -5040,7 +5310,8 @@ CUresult CUDAAPI cuMemHostAlloc(void **pp, size_t bytesize, unsigned int Flags);
  * ::cuMemsetD2D32, ::cuMemsetD8, ::cuMemsetD16, ::cuMemsetD32,
  * ::cudaHostGetDevicePointer
  */
-CUresult CUDAAPI cuMemHostGetDevicePointer(CUdeviceptr *pdptr, void *p, unsigned int Flags);
+CUresult CUDAAPI cuMemHostGetDevicePointer(CUdeviceptr *pdptr, void *p,
+                                           unsigned int Flags);
 #endif /* __CUDA_API_VERSION >= 3020 */
 
 /**
@@ -5073,7 +5344,8 @@ CUresult CUDAAPI cuMemHostGetFlags(unsigned int *pFlags, void *p);
 #if __CUDA_API_VERSION >= 6000
 
 /**
- * \brief Allocates memory that will be automatically managed by the Unified Memory system
+ * \brief Allocates memory that will be automatically managed by the Unified
+ * Memory system
  *
  * Allocates \p bytesize bytes of managed memory on the device and returns in
  * \p *dptr a pointer to the allocated memory. If the device doesn't support
@@ -5082,80 +5354,97 @@ CUresult CUDAAPI cuMemHostGetFlags(unsigned int *pFlags, void *p);
  * ::CU_DEVICE_ATTRIBUTE_MANAGED_MEMORY. The allocated memory is suitably
  * aligned for any kind of variable. The memory is not cleared. If \p bytesize
  * is 0, ::cuMemAllocManaged returns ::CUDA_ERROR_INVALID_VALUE. The pointer
- * is valid on the CPU and on all GPUs in the system that support managed memory.
- * All accesses to this pointer must obey the Unified Memory programming model.
+ * is valid on the CPU and on all GPUs in the system that support managed
+ * memory. All accesses to this pointer must obey the Unified Memory programming
+ * model.
  *
  * \p flags specifies the default stream association for this allocation.
  * \p flags must be one of ::CU_MEM_ATTACH_GLOBAL or ::CU_MEM_ATTACH_HOST. If
  * ::CU_MEM_ATTACH_GLOBAL is specified, then this memory is accessible from
  * any stream on any device. If ::CU_MEM_ATTACH_HOST is specified, then the
  * allocation should not be accessed from devices that have a zero value for the
- * device attribute ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS; an explicit call to
+ * device attribute ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS; an explicit
+ * call to
  * ::cuStreamAttachMemAsync will be required to enable access on such devices.
  *
  * If the association is later changed via ::cuStreamAttachMemAsync to
- * a single stream, the default association as specifed during ::cuMemAllocManaged
- * is restored when that stream is destroyed. For __managed__ variables, the
- * default association is always ::CU_MEM_ATTACH_GLOBAL. Note that destroying a
- * stream is an asynchronous operation, and as a result, the change to default
- * association won't happen until all work in the stream has completed.
+ * a single stream, the default association as specifed during
+ * ::cuMemAllocManaged is restored when that stream is destroyed. For
+ * __managed__ variables, the default association is always
+ * ::CU_MEM_ATTACH_GLOBAL. Note that destroying a stream is an asynchronous
+ * operation, and as a result, the change to default association won't happen
+ * until all work in the stream has completed.
  *
- * Memory allocated with ::cuMemAllocManaged should be released with ::cuMemFree.
+ * Memory allocated with ::cuMemAllocManaged should be released with
+ * ::cuMemFree.
  *
- * Device memory oversubscription is possible for GPUs that have a non-zero value for the
- * device attribute ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS. Managed memory on
- * such GPUs may be evicted from device memory to host memory at any time by the Unified
+ * Device memory oversubscription is possible for GPUs that have a non-zero
+ * value for the device attribute
+ * ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS. Managed memory on such GPUs
+ * may be evicted from device memory to host memory at any time by the Unified
  * Memory driver in order to make room for other allocations.
  *
- * In a multi-GPU system where all GPUs have a non-zero value for the device attribute
- * ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS, managed memory may not be populated when this
- * API returns and instead may be populated on access. In such systems, managed memory can
- * migrate to any processor's memory at any time. The Unified Memory driver will employ heuristics to
- * maintain data locality and prevent excessive page faults to the extent possible. The application
- * can also guide the driver about memory usage patterns via ::cuMemAdvise. The application
- * can also explicitly migrate memory to a desired processor's memory via
+ * In a multi-GPU system where all GPUs have a non-zero value for the device
+ * attribute
+ * ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS, managed memory may not be
+ * populated when this API returns and instead may be populated on access. In
+ * such systems, managed memory can migrate to any processor's memory at any
+ * time. The Unified Memory driver will employ heuristics to maintain data
+ * locality and prevent excessive page faults to the extent possible. The
+ * application can also guide the driver about memory usage patterns via
+ * ::cuMemAdvise. The application can also explicitly migrate memory to a
+ * desired processor's memory via
  * ::cuMemPrefetchAsync.
  *
- * In a multi-GPU system where all of the GPUs have a zero value for the device attribute
- * ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS and all the GPUs have peer-to-peer support
- * with each other, the physical storage for managed memory is created on the GPU which is active
- * at the time ::cuMemAllocManaged is called. All other GPUs will reference the data at reduced
- * bandwidth via peer mappings over the PCIe bus. The Unified Memory driver does not migrate
- * memory among such GPUs.
+ * In a multi-GPU system where all of the GPUs have a zero value for the device
+ * attribute
+ * ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS and all the GPUs have
+ * peer-to-peer support with each other, the physical storage for managed memory
+ * is created on the GPU which is active at the time ::cuMemAllocManaged is
+ * called. All other GPUs will reference the data at reduced bandwidth via peer
+ * mappings over the PCIe bus. The Unified Memory driver does not migrate memory
+ * among such GPUs.
  *
- * In a multi-GPU system where not all GPUs have peer-to-peer support with each other and
- * where the value of the device attribute ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS
- * is zero for at least one of those GPUs, the location chosen for physical storage of managed
- * memory is system-dependent.
- * - On Linux, the location chosen will be device memory as long as the current set of active
- * contexts are on devices that either have peer-to-peer support with each other or have a
- * non-zero value for the device attribute ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS.
- * If there is an active context on a GPU that does not have a non-zero value for that device
- * attribute and it does not have peer-to-peer support with the other devices that have active
- * contexts on them, then the location for physical storage will be 'zero-copy' or host memory.
- * Note that this means that managed memory that is located in device memory is migrated to
- * host memory if a new context is created on a GPU that doesn't have a non-zero value for
- * the device attribute and does not support peer-to-peer with at least one of the other devices
- * that has an active context. This in turn implies that context creation may fail if there is
- * insufficient host memory to migrate all managed allocations.
- * - On Windows, the physical storage is always created in 'zero-copy' or host memory.
- * All GPUs will reference the data at reduced bandwidth over the PCIe bus. In these
- * circumstances, use of the environment variable CUDA_VISIBLE_DEVICES is recommended to
- * restrict CUDA to only use those GPUs that have peer-to-peer support.
- * Alternatively, users can also set CUDA_MANAGED_FORCE_DEVICE_ALLOC to a
- * non-zero value to force the driver to always use device memory for physical storage.
- * When this environment variable is set to a non-zero value, all contexts created in
- * that process on devices that support managed memory have to be peer-to-peer compatible
- * with each other. Context creation will fail if a context is created on a device that
- * supports managed memory and is not peer-to-peer compatible with any of the other
- * managed memory supporting devices on which contexts were previously created, even if
- * those contexts have been destroyed. These environment variables are described
- * in the CUDA programming guide under the "CUDA environment variables" section.
+ * In a multi-GPU system where not all GPUs have peer-to-peer support with each
+ * other and where the value of the device attribute
+ * ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS is zero for at least one of
+ * those GPUs, the location chosen for physical storage of managed memory is
+ * system-dependent.
+ * - On Linux, the location chosen will be device memory as long as the current
+ * set of active contexts are on devices that either have peer-to-peer support
+ * with each other or have a non-zero value for the device attribute
+ * ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS. If there is an active
+ * context on a GPU that does not have a non-zero value for that device
+ * attribute and it does not have peer-to-peer support with the other devices
+ * that have active contexts on them, then the location for physical storage
+ * will be 'zero-copy' or host memory. Note that this means that managed memory
+ * that is located in device memory is migrated to host memory if a new context
+ * is created on a GPU that doesn't have a non-zero value for the device
+ * attribute and does not support peer-to-peer with at least one of the other
+ * devices that has an active context. This in turn implies that context
+ * creation may fail if there is insufficient host memory to migrate all managed
+ * allocations.
+ * - On Windows, the physical storage is always created in 'zero-copy' or host
+ * memory. All GPUs will reference the data at reduced bandwidth over the PCIe
+ * bus. In these circumstances, use of the environment variable
+ * CUDA_VISIBLE_DEVICES is recommended to restrict CUDA to only use those GPUs
+ * that have peer-to-peer support. Alternatively, users can also set
+ * CUDA_MANAGED_FORCE_DEVICE_ALLOC to a non-zero value to force the driver to
+ * always use device memory for physical storage. When this environment variable
+ * is set to a non-zero value, all contexts created in that process on devices
+ * that support managed memory have to be peer-to-peer compatible with each
+ * other. Context creation will fail if a context is created on a device that
+ * supports managed memory and is not peer-to-peer compatible with any of the
+ * other managed memory supporting devices on which contexts were previously
+ * created, even if those contexts have been destroyed. These environment
+ * variables are described in the CUDA programming guide under the "CUDA
+ * environment variables" section.
  * - On ARM, managed memory is not available on discrete gpu with Drive PX-2.
  *
  * \param dptr     - Returned device pointer
  * \param bytesize - Requested allocation size in bytes
- * \param flags    - Must be one of ::CU_MEM_ATTACH_GLOBAL or ::CU_MEM_ATTACH_HOST
+ * \param flags    - Must be one of ::CU_MEM_ATTACH_GLOBAL or
+ * ::CU_MEM_ATTACH_HOST
  *
  * \return
  * ::CUDA_SUCCESS,
@@ -5171,7 +5460,8 @@ CUresult CUDAAPI cuMemHostGetFlags(unsigned int *pFlags, void *p);
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -5180,7 +5470,8 @@ CUresult CUDAAPI cuMemHostGetFlags(unsigned int *pFlags, void *p);
  * ::cuDeviceGetAttribute, ::cuStreamAttachMemAsync,
  * ::cudaMallocManaged
  */
-CUresult CUDAAPI cuMemAllocManaged(CUdeviceptr *dptr, size_t bytesize, unsigned int flags);
+CUresult CUDAAPI cuMemAllocManaged(CUdeviceptr *dptr, size_t bytesize,
+                                   unsigned int flags);
 
 #endif /* __CUDA_API_VERSION >= 6000 */
 
@@ -5197,7 +5488,8 @@ CUresult CUDAAPI cuMemAllocManaged(CUdeviceptr *dptr, size_t bytesize, unsigned 
  * [domain]:[bus]:[device].[function]
  * [domain]:[bus]:[device]
  * [bus]:[device].[function]
- * where \p domain, \p bus, \p device, and \p function are all hexadecimal values
+ * where \p domain, \p bus, \p device, and \p function are all hexadecimal
+ * values
  *
  * \return
  * ::CUDA_SUCCESS,
@@ -5222,10 +5514,10 @@ CUresult CUDAAPI cuDeviceGetByPCIBusId(CUdevice *dev, const char *pciBusId);
  * string pointed to by \p pciBusId. \p len specifies the maximum length of the
  * string that may be returned.
  *
- * \param pciBusId - Returned identifier string for the device in the following format
- * [domain]:[bus]:[device].[function]
- * where \p domain, \p bus, \p device, and \p function are all hexadecimal values.
- * pciBusId should be large enough to store 13 characters including the NULL-terminator.
+ * \param pciBusId - Returned identifier string for the device in the following
+ * format [domain]:[bus]:[device].[function] where \p domain, \p bus, \p device,
+ * and \p function are all hexadecimal values. pciBusId should be large enough
+ * to store 13 characters including the NULL-terminator.
  *
  * \param len      - Maximum length of string to store in \p name
  *
@@ -5330,7 +5622,8 @@ CUresult CUDAAPI cuIpcGetEventHandle(CUipcEventHandle *pHandle, CUevent event);
  * ::cuIpcCloseMemHandle,
  * ::cudaIpcOpenEventHandle
  */
-CUresult CUDAAPI cuIpcOpenEventHandle(CUevent *phEvent, CUipcEventHandle handle);
+CUresult CUDAAPI cuIpcOpenEventHandle(CUevent *phEvent,
+                                      CUipcEventHandle handle);
 
 /**
  * \brief Gets an interprocess memory handle for an existing device memory
@@ -5403,7 +5696,8 @@ CUresult CUDAAPI cuIpcGetMemHandle(CUipcMemHandle *pHandle, CUdeviceptr dptr);
  *
  * \param pdptr  - Returned device pointer
  * \param handle - ::CUipcMemHandle to open
- * \param Flags  - Flags for this operation. Must be specified as ::CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS
+ * \param Flags  - Flags for this operation. Must be specified as
+ * ::CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS
  *
  * \returns
  * ::CUDA_SUCCESS,
@@ -5414,7 +5708,8 @@ CUresult CUDAAPI cuIpcGetMemHandle(CUipcMemHandle *pHandle, CUdeviceptr dptr);
  * ::CUDA_ERROR_INVALID_VALUE
  *
  * \note No guarantees are made about the address returned in \p *pdptr.
- * In particular, multiple processes may not receive the same address for the same \p handle.
+ * In particular, multiple processes may not receive the same address for the
+ * same \p handle.
  *
  * \sa
  * ::cuMemAlloc,
@@ -5427,7 +5722,8 @@ CUresult CUDAAPI cuIpcGetMemHandle(CUipcMemHandle *pHandle, CUdeviceptr dptr);
  * ::cuDeviceCanAccessPeer,
  * ::cudaIpcOpenMemHandle
  */
-CUresult CUDAAPI cuIpcOpenMemHandle(CUdeviceptr *pdptr, CUipcMemHandle handle, unsigned int Flags);
+CUresult CUDAAPI cuIpcOpenMemHandle(CUdeviceptr *pdptr, CUipcMemHandle handle,
+                                    unsigned int Flags);
 
 /**
  * \brief Close memory mapped with ::cuIpcOpenMemHandle
@@ -5470,14 +5766,14 @@ CUresult CUDAAPI cuIpcCloseMemHandle(CUdeviceptr dptr);
  *
  * Page-locks the memory range specified by \p p and \p bytesize and maps it
  * for the device(s) as specified by \p Flags. This memory range also is added
- * to the same tracking mechanism as ::cuMemHostAlloc to automatically accelerate
- * calls to functions such as ::cuMemcpyHtoD(). Since the memory can be accessed
- * directly by the device, it can be read or written with much higher bandwidth
- * than pageable memory that has not been registered.  Page-locking excessive
- * amounts of memory may degrade system performance, since it reduces the amount
- * of memory available to the system for paging. As a result, this function is
- * best used sparingly to register staging areas for data exchange between
- * host and device.
+ * to the same tracking mechanism as ::cuMemHostAlloc to automatically
+ * accelerate calls to functions such as ::cuMemcpyHtoD(). Since the memory can
+ * be accessed directly by the device, it can be read or written with much
+ * higher bandwidth than pageable memory that has not been registered.
+ * Page-locking excessive amounts of memory may degrade system performance,
+ * since it reduces the amount of memory available to the system for paging. As
+ * a result, this function is best used sparingly to register staging areas for
+ * data exchange between host and device.
  *
  * This function has limited support on Mac OS X. OS 10.7 or higher is required.
  *
@@ -5510,16 +5806,18 @@ CUresult CUDAAPI cuIpcCloseMemHandle(CUdeviceptr dptr);
  * ::CU_DEVICE_ATTRIBUTE_CAN_USE_HOST_POINTER_FOR_REGISTERED_MEM, the memory
  * can also be accessed from the device using the host pointer \p p.
  * The device pointer returned by ::cuMemHostGetDevicePointer() may or may not
- * match the original host pointer \p ptr and depends on the devices visible to the
- * application. If all devices visible to the application have a non-zero value for the
- * device attribute, the device pointer returned by ::cuMemHostGetDevicePointer()
- * will match the original pointer \p ptr. If any device visible to the application
- * has a zero value for the device attribute, the device pointer returned by
- * ::cuMemHostGetDevicePointer() will not match the original host pointer \p ptr,
- * but it will be suitable for use on all devices provided Unified Virtual Addressing
- * is enabled. In such systems, it is valid to access the memory using either pointer
- * on devices that have a non-zero value for the device attribute. Note however that
- * such devices should access the memory using only of the two pointers and not both.
+ * match the original host pointer \p ptr and depends on the devices visible to
+ * the application. If all devices visible to the application have a non-zero
+ * value for the device attribute, the device pointer returned by
+ * ::cuMemHostGetDevicePointer() will match the original pointer \p ptr. If any
+ * device visible to the application has a zero value for the device attribute,
+ * the device pointer returned by
+ * ::cuMemHostGetDevicePointer() will not match the original host pointer \p
+ * ptr, but it will be suitable for use on all devices provided Unified Virtual
+ * Addressing is enabled. In such systems, it is valid to access the memory
+ * using either pointer on devices that have a non-zero value for the device
+ * attribute. Note however that such devices should access the memory using only
+ * of the two pointers and not both.
  *
  * The memory page-locked by this function must be unregistered with
  * ::cuMemHostUnregister().
@@ -5546,7 +5844,8 @@ CUresult CUDAAPI cuIpcCloseMemHandle(CUdeviceptr dptr);
  * ::cuMemHostGetDevicePointer,
  * ::cudaHostRegister
  */
-CUresult CUDAAPI cuMemHostRegister(void *p, size_t bytesize, unsigned int Flags);
+CUresult CUDAAPI cuMemHostRegister(void *p, size_t bytesize,
+                                   unsigned int Flags);
 
 /**
  * \brief Unregisters a memory range that was registered with cuMemHostRegister.
@@ -5578,11 +5877,11 @@ CUresult CUDAAPI cuMemHostUnregister(void *p);
  * \brief Copies memory
  *
  * Copies data between two pointers.
- * \p dst and \p src are base pointers of the destination and source, respectively.
- * \p ByteCount specifies the number of bytes to copy.
- * Note that this function infers the type of the transfer (host to host, host to
- *   device, device to device, or device to host) from the pointer values.  This
- *   function is only allowed in contexts which support unified addressing.
+ * \p dst and \p src are base pointers of the destination and source,
+ * respectively. \p ByteCount specifies the number of bytes to copy. Note that
+ * this function infers the type of the transfer (host to host, host to device,
+ * device to device, or device to host) from the pointer values.  This function
+ * is only allowed in contexts which support unified addressing.
  *
  * \param dst - Destination unified virtual address space pointer
  * \param src - Source unified virtual address space pointer
@@ -5637,11 +5936,14 @@ CUresult CUDAAPI cuMemcpy(CUdeviceptr dst, CUdeviceptr src, size_t ByteCount);
  * \notefnerr
  * \note_sync
  *
- * \sa ::cuMemcpyDtoD, ::cuMemcpy3DPeer, ::cuMemcpyDtoDAsync, ::cuMemcpyPeerAsync,
+ * \sa ::cuMemcpyDtoD, ::cuMemcpy3DPeer, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyPeerAsync,
  * ::cuMemcpy3DPeerAsync,
  * ::cudaMemcpyPeer
  */
-CUresult CUDAAPI cuMemcpyPeer(CUdeviceptr dstDevice, CUcontext dstContext, CUdeviceptr srcDevice, CUcontext srcContext, size_t ByteCount);
+CUresult CUDAAPI cuMemcpyPeer(CUdeviceptr dstDevice, CUcontext dstContext,
+                              CUdeviceptr srcDevice, CUcontext srcContext,
+                              size_t ByteCount);
 
 #endif /* __CUDA_API_VERSION >= 4000 */
 
@@ -5670,7 +5972,8 @@ CUresult CUDAAPI cuMemcpyPeer(CUdeviceptr dstDevice, CUcontext dstContext, CUdev
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -5679,7 +5982,8 @@ CUresult CUDAAPI cuMemcpyPeer(CUdeviceptr dstDevice, CUcontext dstContext, CUdev
  * ::cudaMemcpy,
  * ::cudaMemcpyToSymbol
  */
-CUresult CUDAAPI cuMemcpyHtoD(CUdeviceptr dstDevice, const void *srcHost, size_t ByteCount);
+CUresult CUDAAPI cuMemcpyHtoD(CUdeviceptr dstDevice, const void *srcHost,
+                              size_t ByteCount);
 
 /**
  * \brief Copies memory from Device to Host
@@ -5705,7 +6009,8 @@ CUresult CUDAAPI cuMemcpyHtoD(CUdeviceptr dstDevice, const void *srcHost, size_t
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -5714,7 +6019,8 @@ CUresult CUDAAPI cuMemcpyHtoD(CUdeviceptr dstDevice, const void *srcHost, size_t
  * ::cudaMemcpy,
  * ::cudaMemcpyFromSymbol
  */
-CUresult CUDAAPI cuMemcpyDtoH(void *dstHost, CUdeviceptr srcDevice, size_t ByteCount);
+CUresult CUDAAPI cuMemcpyDtoH(void *dstHost, CUdeviceptr srcDevice,
+                              size_t ByteCount);
 
 /**
  * \brief Copies memory from Device to Device
@@ -5750,7 +6056,8 @@ CUresult CUDAAPI cuMemcpyDtoH(void *dstHost, CUdeviceptr srcDevice, size_t ByteC
  * ::cudaMemcpyToSymbol,
  * ::cudaMemcpyFromSymbol
  */
-CUresult CUDAAPI cuMemcpyDtoD(CUdeviceptr dstDevice, CUdeviceptr srcDevice, size_t ByteCount);
+CUresult CUDAAPI cuMemcpyDtoD(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
+                              size_t ByteCount);
 
 /**
  * \brief Copies memory from Device to Array
@@ -5786,7 +6093,8 @@ CUresult CUDAAPI cuMemcpyDtoD(CUdeviceptr dstDevice, CUdeviceptr srcDevice, size
  * ::cuMemsetD2D32, ::cuMemsetD8, ::cuMemsetD16, ::cuMemsetD32,
  * ::cudaMemcpyToArray
  */
-CUresult CUDAAPI cuMemcpyDtoA(CUarray dstArray, size_t dstOffset, CUdeviceptr srcDevice, size_t ByteCount);
+CUresult CUDAAPI cuMemcpyDtoA(CUarray dstArray, size_t dstOffset,
+                              CUdeviceptr srcDevice, size_t ByteCount);
 
 /**
  * \brief Copies memory from Array to Device
@@ -5816,7 +6124,8 @@ CUresult CUDAAPI cuMemcpyDtoA(CUarray dstArray, size_t dstOffset, CUdeviceptr sr
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -5824,15 +6133,16 @@ CUresult CUDAAPI cuMemcpyDtoA(CUarray dstArray, size_t dstOffset, CUdeviceptr sr
  * ::cuMemsetD2D32, ::cuMemsetD8, ::cuMemsetD16, ::cuMemsetD32,
  * ::cudaMemcpyFromArray
  */
-CUresult CUDAAPI cuMemcpyAtoD(CUdeviceptr dstDevice, CUarray srcArray, size_t srcOffset, size_t ByteCount);
+CUresult CUDAAPI cuMemcpyAtoD(CUdeviceptr dstDevice, CUarray srcArray,
+                              size_t srcOffset, size_t ByteCount);
 
 /**
  * \brief Copies memory from Host to Array
  *
  * Copies from host memory to a 1D CUDA array. \p dstArray and \p dstOffset
  * specify the CUDA array handle and starting offset in bytes of the destination
- * data.  \p pSrc specifies the base address of the source. \p ByteCount specifies
- * the number of bytes to copy.
+ * data.  \p pSrc specifies the base address of the source. \p ByteCount
+ * specifies the number of bytes to copy.
  *
  * \param dstArray  - Destination array
  * \param dstOffset - Offset in bytes of destination array
@@ -5852,7 +6162,8 @@ CUresult CUDAAPI cuMemcpyAtoD(CUdeviceptr dstDevice, CUarray srcArray, size_t sr
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -5860,7 +6171,8 @@ CUresult CUDAAPI cuMemcpyAtoD(CUdeviceptr dstDevice, CUarray srcArray, size_t sr
  * ::cuMemsetD2D32, ::cuMemsetD8, ::cuMemsetD16, ::cuMemsetD32,
  * ::cudaMemcpyToArray
  */
-CUresult CUDAAPI cuMemcpyHtoA(CUarray dstArray, size_t dstOffset, const void *srcHost, size_t ByteCount);
+CUresult CUDAAPI cuMemcpyHtoA(CUarray dstArray, size_t dstOffset,
+                              const void *srcHost, size_t ByteCount);
 
 /**
  * \brief Copies memory from Array to Host
@@ -5896,7 +6208,8 @@ CUresult CUDAAPI cuMemcpyHtoA(CUarray dstArray, size_t dstOffset, const void *sr
  * ::cuMemsetD2D32, ::cuMemsetD8, ::cuMemsetD16, ::cuMemsetD32,
  * ::cudaMemcpyFromArray
  */
-CUresult CUDAAPI cuMemcpyAtoH(void *dstHost, CUarray srcArray, size_t srcOffset, size_t ByteCount);
+CUresult CUDAAPI cuMemcpyAtoH(void *dstHost, CUarray srcArray, size_t srcOffset,
+                              size_t ByteCount);
 
 /**
  * \brief Copies memory from Array to Array
@@ -5928,7 +6241,8 @@ CUresult CUDAAPI cuMemcpyAtoH(void *dstHost, CUarray srcArray, size_t srcOffset,
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -5936,7 +6250,9 @@ CUresult CUDAAPI cuMemcpyAtoH(void *dstHost, CUarray srcArray, size_t srcOffset,
  * ::cuMemsetD2D32, ::cuMemsetD8, ::cuMemsetD16, ::cuMemsetD32,
  * ::cudaMemcpyArrayToArray
  */
-CUresult CUDAAPI cuMemcpyAtoA(CUarray dstArray, size_t dstOffset, CUarray srcArray, size_t srcOffset, size_t ByteCount);
+CUresult CUDAAPI cuMemcpyAtoA(CUarray dstArray, size_t dstOffset,
+                              CUarray srcArray, size_t srcOffset,
+                              size_t ByteCount);
 
 /**
  * \brief Copies memory for 2D arrays
@@ -6090,7 +6406,8 @@ CUresult CUDAAPI cuMemcpyAtoA(CUarray dstArray, size_t dstOffset, CUarray srcArr
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -6252,7 +6569,8 @@ CUresult CUDAAPI cuMemcpy2D(const CUDA_MEMCPY2D *pCopy);
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -6280,7 +6598,8 @@ CUresult CUDAAPI cuMemcpy2DUnaligned(const CUDA_MEMCPY2D *pCopy);
                 CUdeviceptr srcDevice;
                 CUarray srcArray;
                 unsigned int srcPitch;  // ignored when src is array
-                unsigned int srcHeight; // ignored when src is array; may be 0 if Depth==1
+                unsigned int srcHeight; // ignored when src is array; may be 0
+ if Depth==1
 
             unsigned int dstXInBytes, dstY, dstZ;
             unsigned int dstLOD;
@@ -6289,7 +6608,8 @@ CUresult CUDAAPI cuMemcpy2DUnaligned(const CUDA_MEMCPY2D *pCopy);
                 CUdeviceptr dstDevice;
                 CUarray dstArray;
                 unsigned int dstPitch;  // ignored when dst is array
-                unsigned int dstHeight; // ignored when dst is array; may be 0 if Depth==1
+                unsigned int dstHeight; // ignored when dst is array; may be 0
+ if Depth==1
 
             unsigned int WidthInBytes;
             unsigned int Height;
@@ -6361,7 +6681,8 @@ CUresult CUDAAPI cuMemcpy2DUnaligned(const CUDA_MEMCPY2D *pCopy);
  * \par
  * For host pointers, the starting address is
  * \code
-  void* Start = (void*)((char*)srcHost+(srcZ*srcHeight+srcY)*srcPitch + srcXInBytes);
+  void* Start = (void*)((char*)srcHost+(srcZ*srcHeight+srcY)*srcPitch +
+ srcXInBytes);
  * \endcode
  *
  * \par
@@ -6380,7 +6701,8 @@ CUresult CUDAAPI cuMemcpy2DUnaligned(const CUDA_MEMCPY2D *pCopy);
  * \par
  * For host pointers, the base address is
  * \code
-  void* dstStart = (void*)((char*)dstHost+(dstZ*dstHeight+dstY)*dstPitch + dstXInBytes);
+  void* dstStart = (void*)((char*)dstHost+(dstZ*dstHeight+dstY)*dstPitch +
+ dstXInBytes);
  * \endcode
  *
  * \par
@@ -6423,7 +6745,8 @@ CUresult CUDAAPI cuMemcpy2DUnaligned(const CUDA_MEMCPY2D *pCopy);
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -6463,11 +6786,11 @@ CUresult CUDAAPI cuMemcpy3DPeer(const CUDA_MEMCPY3D_PEER *pCopy);
  * \brief Copies memory asynchronously
  *
  * Copies data between two pointers.
- * \p dst and \p src are base pointers of the destination and source, respectively.
- * \p ByteCount specifies the number of bytes to copy.
- * Note that this function infers the type of the transfer (host to host, host to
- *   device, device to device, or device to host) from the pointer values.  This
- *   function is only allowed in contexts which support unified addressing.
+ * \p dst and \p src are base pointers of the destination and source,
+ * respectively. \p ByteCount specifies the number of bytes to copy. Note that
+ * this function infers the type of the transfer (host to host, host to device,
+ * device to device, or device to host) from the pointer values.  This function
+ * is only allowed in contexts which support unified addressing.
  *
  * \param dst       - Destination unified virtual address space pointer
  * \param src       - Source unified virtual address space pointer
@@ -6501,7 +6824,8 @@ CUresult CUDAAPI cuMemcpy3DPeer(const CUDA_MEMCPY3D_PEER *pCopy);
  * ::cudaMemcpyToSymbolAsync,
  * ::cudaMemcpyFromSymbolAsync
  */
-CUresult CUDAAPI cuMemcpyAsync(CUdeviceptr dst, CUdeviceptr src, size_t ByteCount, CUstream hStream);
+CUresult CUDAAPI cuMemcpyAsync(CUdeviceptr dst, CUdeviceptr src,
+                               size_t ByteCount, CUstream hStream);
 
 /**
  * \brief Copies device memory between two contexts asynchronously.
@@ -6534,7 +6858,9 @@ CUresult CUDAAPI cuMemcpyAsync(CUdeviceptr dst, CUdeviceptr src, size_t ByteCoun
  * ::cuMemcpy3DPeerAsync,
  * ::cudaMemcpyPeerAsync
  */
-CUresult CUDAAPI cuMemcpyPeerAsync(CUdeviceptr dstDevice, CUcontext dstContext, CUdeviceptr srcDevice, CUcontext srcContext, size_t ByteCount, CUstream hStream);
+CUresult CUDAAPI cuMemcpyPeerAsync(CUdeviceptr dstDevice, CUcontext dstContext,
+                                   CUdeviceptr srcDevice, CUcontext srcContext,
+                                   size_t ByteCount, CUstream hStream);
 #endif /* __CUDA_API_VERSION >= 4000 */
 
 #if __CUDA_API_VERSION >= 3020
@@ -6565,7 +6891,8 @@ CUresult CUDAAPI cuMemcpyPeerAsync(CUdeviceptr dstDevice, CUcontext dstContext, 
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -6576,7 +6903,8 @@ CUresult CUDAAPI cuMemcpyPeerAsync(CUdeviceptr dstDevice, CUcontext dstContext, 
  * ::cudaMemcpyAsync,
  * ::cudaMemcpyToSymbolAsync
  */
-CUresult CUDAAPI cuMemcpyHtoDAsync(CUdeviceptr dstDevice, const void *srcHost, size_t ByteCount, CUstream hStream);
+CUresult CUDAAPI cuMemcpyHtoDAsync(CUdeviceptr dstDevice, const void *srcHost,
+                                   size_t ByteCount, CUstream hStream);
 
 /**
  * \brief Copies memory from Device to Host
@@ -6605,7 +6933,8 @@ CUresult CUDAAPI cuMemcpyHtoDAsync(CUdeviceptr dstDevice, const void *srcHost, s
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -6616,7 +6945,8 @@ CUresult CUDAAPI cuMemcpyHtoDAsync(CUdeviceptr dstDevice, const void *srcHost, s
  * ::cudaMemcpyAsync,
  * ::cudaMemcpyFromSymbolAsync
  */
-CUresult CUDAAPI cuMemcpyDtoHAsync(void *dstHost, CUdeviceptr srcDevice, size_t ByteCount, CUstream hStream);
+CUresult CUDAAPI cuMemcpyDtoHAsync(void *dstHost, CUdeviceptr srcDevice,
+                                   size_t ByteCount, CUstream hStream);
 
 /**
  * \brief Copies memory from Device to Device
@@ -6657,7 +6987,8 @@ CUresult CUDAAPI cuMemcpyDtoHAsync(void *dstHost, CUdeviceptr srcDevice, size_t 
  * ::cudaMemcpyToSymbolAsync,
  * ::cudaMemcpyFromSymbolAsync
  */
-CUresult CUDAAPI cuMemcpyDtoDAsync(CUdeviceptr dstDevice, CUdeviceptr srcDevice, size_t ByteCount, CUstream hStream);
+CUresult CUDAAPI cuMemcpyDtoDAsync(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
+                                   size_t ByteCount, CUstream hStream);
 
 /**
  * \brief Copies memory from Host to Array
@@ -6688,7 +7019,8 @@ CUresult CUDAAPI cuMemcpyDtoDAsync(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -6698,7 +7030,9 @@ CUresult CUDAAPI cuMemcpyDtoDAsync(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
  * ::cuMemsetD32, ::cuMemsetD32Async,
  * ::cudaMemcpyToArrayAsync
  */
-CUresult CUDAAPI cuMemcpyHtoAAsync(CUarray dstArray, size_t dstOffset, const void *srcHost, size_t ByteCount, CUstream hStream);
+CUresult CUDAAPI cuMemcpyHtoAAsync(CUarray dstArray, size_t dstOffset,
+                                   const void *srcHost, size_t ByteCount,
+                                   CUstream hStream);
 
 /**
  * \brief Copies memory from Array to Host
@@ -6739,7 +7073,9 @@ CUresult CUDAAPI cuMemcpyHtoAAsync(CUarray dstArray, size_t dstOffset, const voi
  * ::cuMemsetD32, ::cuMemsetD32Async,
  * ::cudaMemcpyFromArrayAsync
  */
-CUresult CUDAAPI cuMemcpyAtoHAsync(void *dstHost, CUarray srcArray, size_t srcOffset, size_t ByteCount, CUstream hStream);
+CUresult CUDAAPI cuMemcpyAtoHAsync(void *dstHost, CUarray srcArray,
+                                   size_t srcOffset, size_t ByteCount,
+                                   CUstream hStream);
 
 /**
  * \brief Copies memory for 2D arrays
@@ -6896,7 +7232,8 @@ CUresult CUDAAPI cuMemcpyAtoHAsync(void *dstHost, CUarray srcArray, size_t srcOf
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -6926,7 +7263,8 @@ CUresult CUDAAPI cuMemcpy2DAsync(const CUDA_MEMCPY2D *pCopy, CUstream hStream);
                 CUdeviceptr srcDevice;
                 CUarray srcArray;
                 unsigned int srcPitch;  // ignored when src is array
-                unsigned int srcHeight; // ignored when src is array; may be 0 if Depth==1
+                unsigned int srcHeight; // ignored when src is array; may be 0
+ if Depth==1
 
             unsigned int dstXInBytes, dstY, dstZ;
             unsigned int dstLOD;
@@ -6935,7 +7273,8 @@ CUresult CUDAAPI cuMemcpy2DAsync(const CUDA_MEMCPY2D *pCopy, CUstream hStream);
                 CUdeviceptr dstDevice;
                 CUarray dstArray;
                 unsigned int dstPitch;  // ignored when dst is array
-                unsigned int dstHeight; // ignored when dst is array; may be 0 if Depth==1
+                unsigned int dstHeight; // ignored when dst is array; may be 0
+ if Depth==1
 
             unsigned int WidthInBytes;
             unsigned int Height;
@@ -7007,7 +7346,8 @@ CUresult CUDAAPI cuMemcpy2DAsync(const CUDA_MEMCPY2D *pCopy, CUstream hStream);
  * \par
  * For host pointers, the starting address is
  * \code
-  void* Start = (void*)((char*)srcHost+(srcZ*srcHeight+srcY)*srcPitch + srcXInBytes);
+  void* Start = (void*)((char*)srcHost+(srcZ*srcHeight+srcY)*srcPitch +
+ srcXInBytes);
  * \endcode
  *
  * \par
@@ -7026,7 +7366,8 @@ CUresult CUDAAPI cuMemcpy2DAsync(const CUDA_MEMCPY2D *pCopy, CUstream hStream);
  * \par
  * For host pointers, the base address is
  * \code
-  void* dstStart = (void*)((char*)dstHost+(dstZ*dstHeight+dstY)*dstPitch + dstXInBytes);
+  void* dstStart = (void*)((char*)dstHost+(dstZ*dstHeight+dstY)*dstPitch +
+ dstXInBytes);
  * \endcode
  *
  * \par
@@ -7072,7 +7413,8 @@ CUresult CUDAAPI cuMemcpy2DAsync(const CUDA_MEMCPY2D *pCopy, CUstream hStream);
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -7110,7 +7452,8 @@ CUresult CUDAAPI cuMemcpy3DAsync(const CUDA_MEMCPY3D *pCopy, CUstream hStream);
  * ::cuMemcpy3DPeerAsync,
  * ::cudaMemcpy3DPeerAsync
  */
-CUresult CUDAAPI cuMemcpy3DPeerAsync(const CUDA_MEMCPY3D_PEER *pCopy, CUstream hStream);
+CUresult CUDAAPI cuMemcpy3DPeerAsync(const CUDA_MEMCPY3D_PEER *pCopy,
+                                     CUstream hStream);
 #endif /* __CUDA_API_VERSION >= 4000 */
 
 #if __CUDA_API_VERSION >= 3020
@@ -7137,7 +7480,8 @@ CUresult CUDAAPI cuMemcpy3DPeerAsync(const CUDA_MEMCPY3D_PEER *pCopy, CUstream h
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -7172,7 +7516,8 @@ CUresult CUDAAPI cuMemsetD8(CUdeviceptr dstDevice, unsigned char uc, size_t N);
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -7182,7 +7527,8 @@ CUresult CUDAAPI cuMemsetD8(CUdeviceptr dstDevice, unsigned char uc, size_t N);
  * ::cuMemsetD32, ::cuMemsetD32Async,
  * ::cudaMemset
  */
-CUresult CUDAAPI cuMemsetD16(CUdeviceptr dstDevice, unsigned short us, size_t N);
+CUresult CUDAAPI cuMemsetD16(CUdeviceptr dstDevice, unsigned short us,
+                             size_t N);
 
 /**
  * \brief Initializes device memory
@@ -7207,7 +7553,8 @@ CUresult CUDAAPI cuMemsetD16(CUdeviceptr dstDevice, unsigned short us, size_t N)
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -7247,7 +7594,8 @@ CUresult CUDAAPI cuMemsetD32(CUdeviceptr dstDevice, unsigned int ui, size_t N);
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -7257,7 +7605,8 @@ CUresult CUDAAPI cuMemsetD32(CUdeviceptr dstDevice, unsigned int ui, size_t N);
  * ::cuMemsetD32, ::cuMemsetD32Async,
  * ::cudaMemset2D
  */
-CUresult CUDAAPI cuMemsetD2D8(CUdeviceptr dstDevice, size_t dstPitch, unsigned char uc, size_t Width, size_t Height);
+CUresult CUDAAPI cuMemsetD2D8(CUdeviceptr dstDevice, size_t dstPitch,
+                              unsigned char uc, size_t Width, size_t Height);
 
 /**
  * \brief Initializes device memory
@@ -7288,7 +7637,8 @@ CUresult CUDAAPI cuMemsetD2D8(CUdeviceptr dstDevice, size_t dstPitch, unsigned c
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -7298,7 +7648,8 @@ CUresult CUDAAPI cuMemsetD2D8(CUdeviceptr dstDevice, size_t dstPitch, unsigned c
  * ::cuMemsetD32, ::cuMemsetD32Async,
  * ::cudaMemset2D
  */
-CUresult CUDAAPI cuMemsetD2D16(CUdeviceptr dstDevice, size_t dstPitch, unsigned short us, size_t Width, size_t Height);
+CUresult CUDAAPI cuMemsetD2D16(CUdeviceptr dstDevice, size_t dstPitch,
+                               unsigned short us, size_t Width, size_t Height);
 
 /**
  * \brief Initializes device memory
@@ -7329,7 +7680,8 @@ CUresult CUDAAPI cuMemsetD2D16(CUdeviceptr dstDevice, size_t dstPitch, unsigned 
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -7339,7 +7691,8 @@ CUresult CUDAAPI cuMemsetD2D16(CUdeviceptr dstDevice, size_t dstPitch, unsigned 
  * ::cuMemsetD32, ::cuMemsetD32Async,
  * ::cudaMemset2D
  */
-CUresult CUDAAPI cuMemsetD2D32(CUdeviceptr dstDevice, size_t dstPitch, unsigned int ui, size_t Width, size_t Height);
+CUresult CUDAAPI cuMemsetD2D32(CUdeviceptr dstDevice, size_t dstPitch,
+                               unsigned int ui, size_t Width, size_t Height);
 
 /**
  * \brief Sets device memory
@@ -7366,7 +7719,8 @@ CUresult CUDAAPI cuMemsetD2D32(CUdeviceptr dstDevice, size_t dstPitch, unsigned 
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -7376,7 +7730,8 @@ CUresult CUDAAPI cuMemsetD2D32(CUdeviceptr dstDevice, size_t dstPitch, unsigned 
  * ::cuMemsetD32, ::cuMemsetD32Async,
  * ::cudaMemsetAsync
  */
-CUresult CUDAAPI cuMemsetD8Async(CUdeviceptr dstDevice, unsigned char uc, size_t N, CUstream hStream);
+CUresult CUDAAPI cuMemsetD8Async(CUdeviceptr dstDevice, unsigned char uc,
+                                 size_t N, CUstream hStream);
 
 /**
  * \brief Sets device memory
@@ -7403,7 +7758,8 @@ CUresult CUDAAPI cuMemsetD8Async(CUdeviceptr dstDevice, unsigned char uc, size_t
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -7413,7 +7769,8 @@ CUresult CUDAAPI cuMemsetD8Async(CUdeviceptr dstDevice, unsigned char uc, size_t
  * ::cuMemsetD32, ::cuMemsetD32Async,
  * ::cudaMemsetAsync
  */
-CUresult CUDAAPI cuMemsetD16Async(CUdeviceptr dstDevice, unsigned short us, size_t N, CUstream hStream);
+CUresult CUDAAPI cuMemsetD16Async(CUdeviceptr dstDevice, unsigned short us,
+                                  size_t N, CUstream hStream);
 
 /**
  * \brief Sets device memory
@@ -7440,16 +7797,19 @@ CUresult CUDAAPI cuMemsetD16Async(CUdeviceptr dstDevice, unsigned short us, size
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
  * ::cuMemHostGetDevicePointer, ::cuMemsetD2D8, ::cuMemsetD2D8Async,
  * ::cuMemsetD2D16, ::cuMemsetD2D16Async, ::cuMemsetD2D32, ::cuMemsetD2D32Async,
- * ::cuMemsetD8, ::cuMemsetD8Async, ::cuMemsetD16, ::cuMemsetD16Async, ::cuMemsetD32,
+ * ::cuMemsetD8, ::cuMemsetD8Async, ::cuMemsetD16, ::cuMemsetD16Async,
+ * ::cuMemsetD32,
  * ::cudaMemsetAsync
  */
-CUresult CUDAAPI cuMemsetD32Async(CUdeviceptr dstDevice, unsigned int ui, size_t N, CUstream hStream);
+CUresult CUDAAPI cuMemsetD32Async(CUdeviceptr dstDevice, unsigned int ui,
+                                  size_t N, CUstream hStream);
 
 /**
  * \brief Sets device memory
@@ -7481,7 +7841,8 @@ CUresult CUDAAPI cuMemsetD32Async(CUdeviceptr dstDevice, unsigned int ui, size_t
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -7491,7 +7852,9 @@ CUresult CUDAAPI cuMemsetD32Async(CUdeviceptr dstDevice, unsigned int ui, size_t
  * ::cuMemsetD32, ::cuMemsetD32Async,
  * ::cudaMemset2DAsync
  */
-CUresult CUDAAPI cuMemsetD2D8Async(CUdeviceptr dstDevice, size_t dstPitch, unsigned char uc, size_t Width, size_t Height, CUstream hStream);
+CUresult CUDAAPI cuMemsetD2D8Async(CUdeviceptr dstDevice, size_t dstPitch,
+                                   unsigned char uc, size_t Width,
+                                   size_t Height, CUstream hStream);
 
 /**
  * \brief Sets device memory
@@ -7524,7 +7887,8 @@ CUresult CUDAAPI cuMemsetD2D8Async(CUdeviceptr dstDevice, size_t dstPitch, unsig
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -7534,7 +7898,9 @@ CUresult CUDAAPI cuMemsetD2D8Async(CUdeviceptr dstDevice, size_t dstPitch, unsig
  * ::cuMemsetD32, ::cuMemsetD32Async,
  * ::cudaMemset2DAsync
  */
-CUresult CUDAAPI cuMemsetD2D16Async(CUdeviceptr dstDevice, size_t dstPitch, unsigned short us, size_t Width, size_t Height, CUstream hStream);
+CUresult CUDAAPI cuMemsetD2D16Async(CUdeviceptr dstDevice, size_t dstPitch,
+                                    unsigned short us, size_t Width,
+                                    size_t Height, CUstream hStream);
 
 /**
  * \brief Sets device memory
@@ -7567,7 +7933,8 @@ CUresult CUDAAPI cuMemsetD2D16Async(CUdeviceptr dstDevice, size_t dstPitch, unsi
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -7577,7 +7944,9 @@ CUresult CUDAAPI cuMemsetD2D16Async(CUdeviceptr dstDevice, size_t dstPitch, unsi
  * ::cuMemsetD32, ::cuMemsetD32Async,
  * ::cudaMemset2DAsync
  */
-CUresult CUDAAPI cuMemsetD2D32Async(CUdeviceptr dstDevice, size_t dstPitch, unsigned int ui, size_t Width, size_t Height, CUstream hStream);
+CUresult CUDAAPI cuMemsetD2D32Async(CUdeviceptr dstDevice, size_t dstPitch,
+                                    unsigned int ui, size_t Width,
+                                    size_t Height, CUstream hStream);
 
 /**
  * \brief Creates a 1D or 2D CUDA array
@@ -7673,7 +8042,8 @@ CUresult CUDAAPI cuMemsetD2D32Async(CUdeviceptr dstDevice, size_t dstPitch, unsi
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -7681,7 +8051,8 @@ CUresult CUDAAPI cuMemsetD2D32Async(CUdeviceptr dstDevice, size_t dstPitch, unsi
  * ::cuMemsetD2D32, ::cuMemsetD8, ::cuMemsetD16, ::cuMemsetD32,
  * ::cudaMallocArray
  */
-CUresult CUDAAPI cuArrayCreate(CUarray *pHandle, const CUDA_ARRAY_DESCRIPTOR *pAllocateArray);
+CUresult CUDAAPI cuArrayCreate(CUarray *pHandle,
+                               const CUDA_ARRAY_DESCRIPTOR *pAllocateArray);
 
 /**
  * \brief Get a 1D or 2D CUDA array descriptor
@@ -7707,7 +8078,8 @@ CUresult CUDAAPI cuArrayCreate(CUarray *pHandle, const CUDA_ARRAY_DESCRIPTOR *pA
  * ::cuArrayDestroy, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -7715,9 +8087,9 @@ CUresult CUDAAPI cuArrayCreate(CUarray *pHandle, const CUDA_ARRAY_DESCRIPTOR *pA
  * ::cuMemsetD2D32, ::cuMemsetD8, ::cuMemsetD16, ::cuMemsetD32,
  * ::cudaArrayGetInfo
  */
-CUresult CUDAAPI cuArrayGetDescriptor(CUDA_ARRAY_DESCRIPTOR *pArrayDescriptor, CUarray hArray);
+CUresult CUDAAPI cuArrayGetDescriptor(CUDA_ARRAY_DESCRIPTOR *pArrayDescriptor,
+                                      CUarray hArray);
 #endif /* __CUDA_API_VERSION >= 3020 */
-
 
 /**
  * \brief Destroys a CUDA array
@@ -7740,7 +8112,8 @@ CUresult CUDAAPI cuArrayGetDescriptor(CUDA_ARRAY_DESCRIPTOR *pArrayDescriptor, C
  * ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -7771,26 +8144,40 @@ CUresult CUDAAPI cuArrayDestroy(CUarray hArray);
  * where:
  *
  * - \p Width, \p Height, and \p Depth are the width, height, and depth of the
- * CUDA array (in elements); the following types of CUDA arrays can be allocated:
- *     - A 1D array is allocated if \p Height and \p Depth extents are both zero.
+ * CUDA array (in elements); the following types of CUDA arrays can be
+ allocated:
+ *     - A 1D array is allocated if \p Height and \p Depth extents are both
+ zero.
  *     - A 2D array is allocated if only \p Depth extent is zero.
  *     - A 3D array is allocated if all three extents are non-zero.
  *     - A 1D layered CUDA array is allocated if only \p Height is zero and the
- *       ::CUDA_ARRAY3D_LAYERED flag is set. Each layer is a 1D array. The number
+ *       ::CUDA_ARRAY3D_LAYERED flag is set. Each layer is a 1D array. The
+ number
  *       of layers is determined by the depth extent.
- *     - A 2D layered CUDA array is allocated if all three extents are non-zero and
- *       the ::CUDA_ARRAY3D_LAYERED flag is set. Each layer is a 2D array. The number
+ *     - A 2D layered CUDA array is allocated if all three extents are non-zero
+ and
+ *       the ::CUDA_ARRAY3D_LAYERED flag is set. Each layer is a 2D array. The
+ number
  *       of layers is determined by the depth extent.
- *     - A cubemap CUDA array is allocated if all three extents are non-zero and the
- *       ::CUDA_ARRAY3D_CUBEMAP flag is set. \p Width must be equal to \p Height, and
- *       \p Depth must be six. A cubemap is a special type of 2D layered CUDA array,
- *       where the six layers represent the six faces of a cube. The order of the six
+ *     - A cubemap CUDA array is allocated if all three extents are non-zero and
+ the
+ *       ::CUDA_ARRAY3D_CUBEMAP flag is set. \p Width must be equal to \p
+ Height, and
+ *       \p Depth must be six. A cubemap is a special type of 2D layered CUDA
+ array,
+ *       where the six layers represent the six faces of a cube. The order of
+ the six
  *       layers in memory is the same as that listed in ::CUarray_cubemap_face.
- *     - A cubemap layered CUDA array is allocated if all three extents are non-zero,
- *       and both, ::CUDA_ARRAY3D_CUBEMAP and ::CUDA_ARRAY3D_LAYERED flags are set.
- *       \p Width must be equal to \p Height, and \p Depth must be a multiple of six.
- *       A cubemap layered CUDA array is a special type of 2D layered CUDA array that
- *       consists of a collection of cubemaps. The first six layers represent the first
+ *     - A cubemap layered CUDA array is allocated if all three extents are
+ non-zero,
+ *       and both, ::CUDA_ARRAY3D_CUBEMAP and ::CUDA_ARRAY3D_LAYERED flags are
+ set.
+ *       \p Width must be equal to \p Height, and \p Depth must be a multiple of
+ six.
+ *       A cubemap layered CUDA array is a special type of 2D layered CUDA array
+ that
+ *       consists of a collection of cubemaps. The first six layers represent
+ the first
  *       cubemap, the next six layers form the second cubemap, and so on.
  *
  * - ::Format specifies the format of the elements; ::CUarray_format is
@@ -7812,29 +8199,41 @@ CUresult CUDAAPI cuArrayDestroy(CUarray hArray);
  * element; it may be 1, 2, or 4;
  *
  * - ::Flags may be set to
- *   - ::CUDA_ARRAY3D_LAYERED to enable creation of layered CUDA arrays. If this flag is set,
+ *   - ::CUDA_ARRAY3D_LAYERED to enable creation of layered CUDA arrays. If this
+ flag is set,
  *     \p Depth specifies the number of layers, not the depth of a 3D array.
- *   - ::CUDA_ARRAY3D_SURFACE_LDST to enable surface references to be bound to the CUDA array.
- *     If this flag is not set, ::cuSurfRefSetArray will fail when attempting to bind the CUDA array
+ *   - ::CUDA_ARRAY3D_SURFACE_LDST to enable surface references to be bound to
+ the CUDA array.
+ *     If this flag is not set, ::cuSurfRefSetArray will fail when attempting to
+ bind the CUDA array
  *     to a surface reference.
- *   - ::CUDA_ARRAY3D_CUBEMAP to enable creation of cubemaps. If this flag is set, \p Width must be
- *     equal to \p Height, and \p Depth must be six. If the ::CUDA_ARRAY3D_LAYERED flag is also set,
+ *   - ::CUDA_ARRAY3D_CUBEMAP to enable creation of cubemaps. If this flag is
+ set, \p Width must be
+ *     equal to \p Height, and \p Depth must be six. If the
+ ::CUDA_ARRAY3D_LAYERED flag is also set,
  *     then \p Depth must be a multiple of six.
- *   - ::CUDA_ARRAY3D_TEXTURE_GATHER to indicate that the CUDA array will be used for texture gather.
+ *   - ::CUDA_ARRAY3D_TEXTURE_GATHER to indicate that the CUDA array will be
+ used for texture gather.
  *     Texture gather can only be performed on 2D CUDA arrays.
  *
- * \p Width, \p Height and \p Depth must meet certain size requirements as listed in the following table.
- * All values are specified in elements. Note that for brevity's sake, the full name of the device attribute
+ * \p Width, \p Height and \p Depth must meet certain size requirements as
+ listed in the following table.
+ * All values are specified in elements. Note that for brevity's sake, the full
+ name of the device attribute
  * is not specified. For ex., TEXTURE1D_WIDTH refers to the device attribute
  * ::CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_WIDTH.
  *
- * Note that 2D CUDA arrays have different size requirements if the ::CUDA_ARRAY3D_TEXTURE_GATHER flag
- * is set. \p Width and \p Height must not be greater than ::CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_GATHER_WIDTH
- * and ::CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_GATHER_HEIGHT respectively, in that case.
+ * Note that 2D CUDA arrays have different size requirements if the
+ ::CUDA_ARRAY3D_TEXTURE_GATHER flag
+ * is set. \p Width and \p Height must not be greater than
+ ::CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_GATHER_WIDTH
+ * and ::CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_GATHER_HEIGHT respectively, in
+ that case.
  *
  * <table>
  * <tr><td><b>CUDA array type</b></td>
- * <td><b>Valid extents that must always be met<br>{(width range in elements), (height range),
+ * <td><b>Valid extents that must always be met<br>{(width range in elements),
+ (height range),
  * (depth range)}</b></td>
  * <td><b>Valid extents with CUDA_ARRAY3D_SURFACE_LDST set<br>
  * {(width range in elements), (height range), (depth range)}</b></td></tr>
@@ -7861,13 +8260,16 @@ CUresult CUDAAPI cuArrayDestroy(CUarray hArray);
  * <td><small>{ (1,SURFACE2D_LAYERED_WIDTH), (1,SURFACE2D_LAYERED_HEIGHT),
  * (1,SURFACE2D_LAYERED_LAYERS) }</small></td></tr>
  * <tr><td>Cubemap</td>
- * <td><small>{ (1,TEXTURECUBEMAP_WIDTH), (1,TEXTURECUBEMAP_WIDTH), 6 }</small></td>
+ * <td><small>{ (1,TEXTURECUBEMAP_WIDTH), (1,TEXTURECUBEMAP_WIDTH), 6
+ }</small></td>
  * <td><small>{ (1,SURFACECUBEMAP_WIDTH),
  * (1,SURFACECUBEMAP_WIDTH), 6 }</small></td></tr>
  * <tr><td>Cubemap Layered</td>
- * <td><small>{ (1,TEXTURECUBEMAP_LAYERED_WIDTH), (1,TEXTURECUBEMAP_LAYERED_WIDTH),
+ * <td><small>{ (1,TEXTURECUBEMAP_LAYERED_WIDTH),
+ (1,TEXTURECUBEMAP_LAYERED_WIDTH),
  * (1,TEXTURECUBEMAP_LAYERED_LAYERS) }</small></td>
- * <td><small>{ (1,SURFACECUBEMAP_LAYERED_WIDTH), (1,SURFACECUBEMAP_LAYERED_WIDTH),
+ * <td><small>{ (1,SURFACECUBEMAP_LAYERED_WIDTH),
+ (1,SURFACECUBEMAP_LAYERED_WIDTH),
  * (1,SURFACECUBEMAP_LAYERED_LAYERS) }</small></td></tr>
  * </table>
  *
@@ -7921,7 +8323,8 @@ CUresult CUDAAPI cuArrayDestroy(CUarray hArray);
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -7929,7 +8332,8 @@ CUresult CUDAAPI cuArrayDestroy(CUarray hArray);
  * ::cuMemsetD2D32, ::cuMemsetD8, ::cuMemsetD16, ::cuMemsetD32,
  * ::cudaMalloc3DArray
  */
-CUresult CUDAAPI cuArray3DCreate(CUarray *pHandle, const CUDA_ARRAY3D_DESCRIPTOR *pAllocateArray);
+CUresult CUDAAPI cuArray3DCreate(CUarray *pHandle,
+                                 const CUDA_ARRAY3D_DESCRIPTOR *pAllocateArray);
 
 /**
  * \brief Get a 3D CUDA array descriptor
@@ -7959,7 +8363,8 @@ CUresult CUDAAPI cuArray3DCreate(CUarray *pHandle, const CUDA_ARRAY3D_DESCRIPTOR
  * ::cuArrayDestroy, ::cuArrayGetDescriptor, ::cuMemAlloc, ::cuMemAllocHost,
  * ::cuMemAllocPitch, ::cuMemcpy2D, ::cuMemcpy2DAsync, ::cuMemcpy2DUnaligned,
  * ::cuMemcpy3D, ::cuMemcpy3DAsync, ::cuMemcpyAtoA, ::cuMemcpyAtoD,
- * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD, ::cuMemcpyDtoDAsync,
+ * ::cuMemcpyAtoH, ::cuMemcpyAtoHAsync, ::cuMemcpyDtoA, ::cuMemcpyDtoD,
+ * ::cuMemcpyDtoDAsync,
  * ::cuMemcpyDtoH, ::cuMemcpyDtoHAsync, ::cuMemcpyHtoA, ::cuMemcpyHtoAAsync,
  * ::cuMemcpyHtoD, ::cuMemcpyHtoDAsync, ::cuMemFree, ::cuMemFreeHost,
  * ::cuMemGetAddressRange, ::cuMemGetInfo, ::cuMemHostAlloc,
@@ -7967,7 +8372,8 @@ CUresult CUDAAPI cuArray3DCreate(CUarray *pHandle, const CUDA_ARRAY3D_DESCRIPTOR
  * ::cuMemsetD2D32, ::cuMemsetD8, ::cuMemsetD16, ::cuMemsetD32,
  * ::cudaArrayGetInfo
  */
-CUresult CUDAAPI cuArray3DGetDescriptor(CUDA_ARRAY3D_DESCRIPTOR *pArrayDescriptor, CUarray hArray);
+CUresult CUDAAPI cuArray3DGetDescriptor(
+    CUDA_ARRAY3D_DESCRIPTOR *pArrayDescriptor, CUarray hArray);
 #endif /* __CUDA_API_VERSION >= 3020 */
 
 #if __CUDA_API_VERSION >= 5000
@@ -7975,9 +8381,12 @@ CUresult CUDAAPI cuArray3DGetDescriptor(CUDA_ARRAY3D_DESCRIPTOR *pArrayDescripto
 /**
  * \brief Creates a CUDA mipmapped array
  *
- * Creates a CUDA mipmapped array according to the ::CUDA_ARRAY3D_DESCRIPTOR structure
- * \p pMipmappedArrayDesc and returns a handle to the new CUDA mipmapped array in \p *pHandle.
- * \p numMipmapLevels specifies the number of mipmap levels to be allocated. This value is
+ * Creates a CUDA mipmapped array according to the ::CUDA_ARRAY3D_DESCRIPTOR
+ structure
+ * \p pMipmappedArrayDesc and returns a handle to the new CUDA mipmapped array
+ in \p *pHandle.
+ * \p numMipmapLevels specifies the number of mipmap levels to be allocated.
+ This value is
  * clamped to the range [1, 1 + floor(log2(max(width, height, depth)))].
  *
  * The ::CUDA_ARRAY3D_DESCRIPTOR is defined as:
@@ -7995,26 +8404,41 @@ CUresult CUDAAPI cuArray3DGetDescriptor(CUDA_ARRAY3D_DESCRIPTOR *pArrayDescripto
  * where:
  *
  * - \p Width, \p Height, and \p Depth are the width, height, and depth of the
- * CUDA array (in elements); the following types of CUDA arrays can be allocated:
- *     - A 1D mipmapped array is allocated if \p Height and \p Depth extents are both zero.
+ * CUDA array (in elements); the following types of CUDA arrays can be
+ allocated:
+ *     - A 1D mipmapped array is allocated if \p Height and \p Depth extents are
+ both zero.
  *     - A 2D mipmapped array is allocated if only \p Depth extent is zero.
  *     - A 3D mipmapped array is allocated if all three extents are non-zero.
- *     - A 1D layered CUDA mipmapped array is allocated if only \p Height is zero and the
- *       ::CUDA_ARRAY3D_LAYERED flag is set. Each layer is a 1D array. The number
+ *     - A 1D layered CUDA mipmapped array is allocated if only \p Height is
+ zero and the
+ *       ::CUDA_ARRAY3D_LAYERED flag is set. Each layer is a 1D array. The
+ number
  *       of layers is determined by the depth extent.
- *     - A 2D layered CUDA mipmapped array is allocated if all three extents are non-zero and
- *       the ::CUDA_ARRAY3D_LAYERED flag is set. Each layer is a 2D array. The number
+ *     - A 2D layered CUDA mipmapped array is allocated if all three extents are
+ non-zero and
+ *       the ::CUDA_ARRAY3D_LAYERED flag is set. Each layer is a 2D array. The
+ number
  *       of layers is determined by the depth extent.
- *     - A cubemap CUDA mipmapped array is allocated if all three extents are non-zero and the
- *       ::CUDA_ARRAY3D_CUBEMAP flag is set. \p Width must be equal to \p Height, and
- *       \p Depth must be six. A cubemap is a special type of 2D layered CUDA array,
- *       where the six layers represent the six faces of a cube. The order of the six
+ *     - A cubemap CUDA mipmapped array is allocated if all three extents are
+ non-zero and the
+ *       ::CUDA_ARRAY3D_CUBEMAP flag is set. \p Width must be equal to \p
+ Height, and
+ *       \p Depth must be six. A cubemap is a special type of 2D layered CUDA
+ array,
+ *       where the six layers represent the six faces of a cube. The order of
+ the six
  *       layers in memory is the same as that listed in ::CUarray_cubemap_face.
- *     - A cubemap layered CUDA mipmapped array is allocated if all three extents are non-zero,
- *       and both, ::CUDA_ARRAY3D_CUBEMAP and ::CUDA_ARRAY3D_LAYERED flags are set.
- *       \p Width must be equal to \p Height, and \p Depth must be a multiple of six.
- *       A cubemap layered CUDA array is a special type of 2D layered CUDA array that
- *       consists of a collection of cubemaps. The first six layers represent the first
+ *     - A cubemap layered CUDA mipmapped array is allocated if all three
+ extents are non-zero,
+ *       and both, ::CUDA_ARRAY3D_CUBEMAP and ::CUDA_ARRAY3D_LAYERED flags are
+ set.
+ *       \p Width must be equal to \p Height, and \p Depth must be a multiple of
+ six.
+ *       A cubemap layered CUDA array is a special type of 2D layered CUDA array
+ that
+ *       consists of a collection of cubemaps. The first six layers represent
+ the first
  *       cubemap, the next six layers form the second cubemap, and so on.
  *
  * - ::Format specifies the format of the elements; ::CUarray_format is
@@ -8036,25 +8460,35 @@ CUresult CUDAAPI cuArray3DGetDescriptor(CUDA_ARRAY3D_DESCRIPTOR *pArrayDescripto
  * element; it may be 1, 2, or 4;
  *
  * - ::Flags may be set to
- *   - ::CUDA_ARRAY3D_LAYERED to enable creation of layered CUDA mipmapped arrays. If this flag is set,
+ *   - ::CUDA_ARRAY3D_LAYERED to enable creation of layered CUDA mipmapped
+ arrays. If this flag is set,
  *     \p Depth specifies the number of layers, not the depth of a 3D array.
- *   - ::CUDA_ARRAY3D_SURFACE_LDST to enable surface references to be bound to individual mipmap levels of
- *     the CUDA mipmapped array. If this flag is not set, ::cuSurfRefSetArray will fail when attempting to
+ *   - ::CUDA_ARRAY3D_SURFACE_LDST to enable surface references to be bound to
+ individual mipmap levels of
+ *     the CUDA mipmapped array. If this flag is not set, ::cuSurfRefSetArray
+ will fail when attempting to
  *     bind a mipmap level of the CUDA mipmapped array to a surface reference.
-  *   - ::CUDA_ARRAY3D_CUBEMAP to enable creation of mipmapped cubemaps. If this flag is set, \p Width must be
- *     equal to \p Height, and \p Depth must be six. If the ::CUDA_ARRAY3D_LAYERED flag is also set,
+  *   - ::CUDA_ARRAY3D_CUBEMAP to enable creation of mipmapped cubemaps. If this
+ flag is set, \p Width must be
+ *     equal to \p Height, and \p Depth must be six. If the
+ ::CUDA_ARRAY3D_LAYERED flag is also set,
  *     then \p Depth must be a multiple of six.
- *   - ::CUDA_ARRAY3D_TEXTURE_GATHER to indicate that the CUDA mipmapped array will be used for texture gather.
+ *   - ::CUDA_ARRAY3D_TEXTURE_GATHER to indicate that the CUDA mipmapped array
+ will be used for texture gather.
  *     Texture gather can only be performed on 2D CUDA mipmapped arrays.
  *
- * \p Width, \p Height and \p Depth must meet certain size requirements as listed in the following table.
- * All values are specified in elements. Note that for brevity's sake, the full name of the device attribute
- * is not specified. For ex., TEXTURE1D_MIPMAPPED_WIDTH refers to the device attribute
+ * \p Width, \p Height and \p Depth must meet certain size requirements as
+ listed in the following table.
+ * All values are specified in elements. Note that for brevity's sake, the full
+ name of the device attribute
+ * is not specified. For ex., TEXTURE1D_MIPMAPPED_WIDTH refers to the device
+ attribute
  * ::CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_MIPMAPPED_WIDTH.
  *
  * <table>
  * <tr><td><b>CUDA array type</b></td>
- * <td><b>Valid extents that must always be met<br>{(width range in elements), (height range),
+ * <td><b>Valid extents that must always be met<br>{(width range in elements),
+ (height range),
  * (depth range)}</b></td>
  * <td><b>Valid extents with CUDA_ARRAY3D_SURFACE_LDST set<br>
  * {(width range in elements), (height range), (depth range)}</b></td></tr>
@@ -8062,7 +8496,8 @@ CUresult CUDAAPI cuArray3DGetDescriptor(CUDA_ARRAY3D_DESCRIPTOR *pArrayDescripto
  * <td><small>{ (1,TEXTURE1D_MIPMAPPED_WIDTH), 0, 0 }</small></td>
  * <td><small>{ (1,SURFACE1D_WIDTH), 0, 0 }</small></td></tr>
  * <tr><td>2D</td>
- * <td><small>{ (1,TEXTURE2D_MIPMAPPED_WIDTH), (1,TEXTURE2D_MIPMAPPED_HEIGHT), 0 }</small></td>
+ * <td><small>{ (1,TEXTURE2D_MIPMAPPED_WIDTH), (1,TEXTURE2D_MIPMAPPED_HEIGHT), 0
+ }</small></td>
  * <td><small>{ (1,SURFACE2D_WIDTH), (1,SURFACE2D_HEIGHT), 0 }</small></td></tr>
  * <tr><td>3D</td>
  * <td><small>{ (1,TEXTURE3D_WIDTH), (1,TEXTURE3D_HEIGHT), (1,TEXTURE3D_DEPTH) }
@@ -8081,13 +8516,16 @@ CUresult CUDAAPI cuArray3DGetDescriptor(CUDA_ARRAY3D_DESCRIPTOR *pArrayDescripto
  * <td><small>{ (1,SURFACE2D_LAYERED_WIDTH), (1,SURFACE2D_LAYERED_HEIGHT),
  * (1,SURFACE2D_LAYERED_LAYERS) }</small></td></tr>
  * <tr><td>Cubemap</td>
- * <td><small>{ (1,TEXTURECUBEMAP_WIDTH), (1,TEXTURECUBEMAP_WIDTH), 6 }</small></td>
+ * <td><small>{ (1,TEXTURECUBEMAP_WIDTH), (1,TEXTURECUBEMAP_WIDTH), 6
+ }</small></td>
  * <td><small>{ (1,SURFACECUBEMAP_WIDTH),
  * (1,SURFACECUBEMAP_WIDTH), 6 }</small></td></tr>
  * <tr><td>Cubemap Layered</td>
- * <td><small>{ (1,TEXTURECUBEMAP_LAYERED_WIDTH), (1,TEXTURECUBEMAP_LAYERED_WIDTH),
+ * <td><small>{ (1,TEXTURECUBEMAP_LAYERED_WIDTH),
+ (1,TEXTURECUBEMAP_LAYERED_WIDTH),
  * (1,TEXTURECUBEMAP_LAYERED_LAYERS) }</small></td>
- * <td><small>{ (1,SURFACECUBEMAP_LAYERED_WIDTH), (1,SURFACECUBEMAP_LAYERED_WIDTH),
+ * <td><small>{ (1,SURFACECUBEMAP_LAYERED_WIDTH),
+ (1,SURFACECUBEMAP_LAYERED_WIDTH),
  * (1,SURFACECUBEMAP_LAYERED_LAYERS) }</small></td></tr>
  * </table>
  *
@@ -8112,7 +8550,10 @@ CUresult CUDAAPI cuArray3DGetDescriptor(CUDA_ARRAY3D_DESCRIPTOR *pArrayDescripto
  * ::cuArrayCreate,
  * ::cudaMallocMipmappedArray
  */
-CUresult CUDAAPI cuMipmappedArrayCreate(CUmipmappedArray *pHandle, const CUDA_ARRAY3D_DESCRIPTOR *pMipmappedArrayDesc, unsigned int numMipmapLevels);
+CUresult CUDAAPI
+cuMipmappedArrayCreate(CUmipmappedArray *pHandle,
+                       const CUDA_ARRAY3D_DESCRIPTOR *pMipmappedArrayDesc,
+                       unsigned int numMipmapLevels);
 
 /**
  * \brief Gets a mipmap level of a CUDA mipmapped array
@@ -8120,7 +8561,8 @@ CUresult CUDAAPI cuMipmappedArrayCreate(CUmipmappedArray *pHandle, const CUDA_AR
  * Returns in \p *pLevelArray a CUDA array that represents a single mipmap level
  * of the CUDA mipmapped array \p hMipmappedArray.
  *
- * If \p level is greater than the maximum number of levels in this mipmapped array,
+ * If \p level is greater than the maximum number of levels in this mipmapped
+ * array,
  * ::CUDA_ERROR_INVALID_VALUE is returned.
  *
  * \param pLevelArray     - Returned mipmap level CUDA array
@@ -8142,7 +8584,9 @@ CUresult CUDAAPI cuMipmappedArrayCreate(CUmipmappedArray *pHandle, const CUDA_AR
  * ::cuArrayCreate,
  * ::cudaGetMipmappedArrayLevel
  */
-CUresult CUDAAPI cuMipmappedArrayGetLevel(CUarray *pLevelArray, CUmipmappedArray hMipmappedArray, unsigned int level);
+CUresult CUDAAPI cuMipmappedArrayGetLevel(CUarray *pLevelArray,
+                                          CUmipmappedArray hMipmappedArray,
+                                          unsigned int level);
 
 /**
  * \brief Destroys a CUDA mipmapped array
@@ -8219,7 +8663,8 @@ CUresult CUDAAPI cuMipmappedArrayDestroy(CUmipmappedArray hMipmappedArray);
  * used to specify that the CUDA driver should infer the location of the
  * pointer from its value.
  *
- * \section CUDA_UNIFIED_automaphost Automatic Mapping of Host Allocated Host Memory
+ * \section CUDA_UNIFIED_automaphost Automatic Mapping of Host Allocated Host
+ * Memory
  *
  * All host memory allocated in all contexts using ::cuMemAllocHost() and
  * ::cuMemHostAlloc() is always directly accessible from all contexts on
@@ -8230,8 +8675,8 @@ CUresult CUDAAPI cuMipmappedArrayDestroy(CUmipmappedArray hMipmappedArray);
  * The pointer value through which allocated host memory may be accessed
  * in kernels on all devices that support unified addressing is the same
  * as the pointer value through which that memory is accessed on the host,
- * so it is not necessary to call ::cuMemHostGetDevicePointer() to get the device
- * pointer for these allocations.
+ * so it is not necessary to call ::cuMemHostGetDevicePointer() to get the
+ * device pointer for these allocations.
  *
  * Note that this is not the case for memory allocated using the flag
  * ::CU_MEMHOSTALLOC_WRITECOMBINED, as discussed below.
@@ -8350,32 +8795,33 @@ CUresult CUDAAPI cuMipmappedArrayDestroy(CUmipmappedArray hMipmappedArray);
  *
  * - ::CU_POINTER_ATTRIBUTE_SYNC_MEMOPS:
  *
- *      A boolean attribute which when set, ensures that synchronous memory operations
- *      initiated on the region of memory that \p ptr points to will always synchronize.
- *      See further documentation in the section titled "API synchronization behavior"
- *      to learn more about cases when synchronous memory operations can
- *      exhibit asynchronous behavior.
+ *      A boolean attribute which when set, ensures that synchronous memory
+ * operations initiated on the region of memory that \p ptr points to will
+ * always synchronize. See further documentation in the section titled "API
+ * synchronization behavior" to learn more about cases when synchronous memory
+ * operations can exhibit asynchronous behavior.
  *
  * - ::CU_POINTER_ATTRIBUTE_BUFFER_ID:
  *
- *      Returns in \p *data a buffer ID which is guaranteed to be unique within the process.
- *      \p data must point to an unsigned long long.
+ *      Returns in \p *data a buffer ID which is guaranteed to be unique within
+ * the process. \p data must point to an unsigned long long.
  *
- *      \p ptr must be a pointer to memory obtained from a CUDA memory allocation API.
- *      Every memory allocation from any of the CUDA memory allocation APIs will
- *      have a unique ID over a process lifetime. Subsequent allocations do not reuse IDs
- *      from previous freed allocations. IDs are only unique within a single process.
+ *      \p ptr must be a pointer to memory obtained from a CUDA memory
+ * allocation API. Every memory allocation from any of the CUDA memory
+ * allocation APIs will have a unique ID over a process lifetime. Subsequent
+ * allocations do not reuse IDs from previous freed allocations. IDs are only
+ * unique within a single process.
  *
  *
  * - ::CU_POINTER_ATTRIBUTE_IS_MANAGED:
  *
- *      Returns in \p *data a boolean that indicates whether the pointer points to
- *      managed memory or not.
+ *      Returns in \p *data a boolean that indicates whether the pointer points
+ * to managed memory or not.
  *
  * - ::CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL:
  *
- *      Returns in \p *data an integer representing a device ordinal of a device against
- *      which the memory was allocated or registered.
+ *      Returns in \p *data an integer representing a device ordinal of a device
+ * against which the memory was allocated or registered.
  *
  * \par
  *
@@ -8419,7 +8865,9 @@ CUresult CUDAAPI cuMipmappedArrayDestroy(CUmipmappedArray hMipmappedArray);
  * ::cuMemHostUnregister,
  * ::cudaPointerGetAttributes
  */
-CUresult CUDAAPI cuPointerGetAttribute(void *data, CUpointer_attribute attribute, CUdeviceptr ptr);
+CUresult CUDAAPI cuPointerGetAttribute(void *data,
+                                       CUpointer_attribute attribute,
+                                       CUdeviceptr ptr);
 #endif /* __CUDA_API_VERSION >= 4000 */
 
 #if __CUDA_API_VERSION >= 8000
@@ -8428,46 +8876,51 @@ CUresult CUDAAPI cuPointerGetAttribute(void *data, CUpointer_attribute attribute
  *
  * Prefetches memory to the specified destination device.  \p devPtr is the
  * base device pointer of the memory to be prefetched and \p dstDevice is the
- * destination device. \p count specifies the number of bytes to copy. \p hStream
- * is the stream in which the operation is enqueued. The memory range must refer
- * to managed memory allocated via ::cuMemAllocManaged or declared via __managed__ variables.
+ * destination device. \p count specifies the number of bytes to copy. \p
+ * hStream is the stream in which the operation is enqueued. The memory range
+ * must refer to managed memory allocated via ::cuMemAllocManaged or declared
+ * via __managed__ variables.
  *
- * Passing in CU_DEVICE_CPU for \p dstDevice will prefetch the data to host memory. If
- * \p dstDevice is a GPU, then the device attribute ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS
- * must be non-zero. Additionally, \p hStream must be associated with a device that has a
- * non-zero value for the device attribute ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS.
+ * Passing in CU_DEVICE_CPU for \p dstDevice will prefetch the data to host
+ * memory. If \p dstDevice is a GPU, then the device attribute
+ * ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS must be non-zero.
+ * Additionally, \p hStream must be associated with a device that has a non-zero
+ * value for the device attribute
+ * ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS.
  *
- * The start address and end address of the memory range will be rounded down and rounded up
- * respectively to be aligned to CPU page size before the prefetch operation is enqueued
- * in the stream.
+ * The start address and end address of the memory range will be rounded down
+ * and rounded up respectively to be aligned to CPU page size before the
+ * prefetch operation is enqueued in the stream.
  *
- * If no physical memory has been allocated for this region, then this memory region
- * will be populated and mapped on the destination device. If there's insufficient
- * memory to prefetch the desired region, the Unified Memory driver may evict pages from other
- * ::cuMemAllocManaged allocations to host memory in order to make room. Device memory
- * allocated using ::cuMemAlloc or ::cuArrayCreate will not be evicted.
+ * If no physical memory has been allocated for this region, then this memory
+ * region will be populated and mapped on the destination device. If there's
+ * insufficient memory to prefetch the desired region, the Unified Memory driver
+ * may evict pages from other
+ * ::cuMemAllocManaged allocations to host memory in order to make room. Device
+ * memory allocated using ::cuMemAlloc or ::cuArrayCreate will not be evicted.
  *
- * By default, any mappings to the previous location of the migrated pages are removed and
- * mappings for the new location are only setup on \p dstDevice. The exact behavior however
- * also depends on the settings applied to this memory range via ::cuMemAdvise as described
- * below:
+ * By default, any mappings to the previous location of the migrated pages are
+ * removed and mappings for the new location are only setup on \p dstDevice. The
+ * exact behavior however also depends on the settings applied to this memory
+ * range via ::cuMemAdvise as described below:
  *
- * If ::CU_MEM_ADVISE_SET_READ_MOSTLY was set on any subset of this memory range,
- * then that subset will create a read-only copy of the pages on \p dstDevice.
+ * If ::CU_MEM_ADVISE_SET_READ_MOSTLY was set on any subset of this memory
+ * range, then that subset will create a read-only copy of the pages on \p
+ * dstDevice.
  *
- * If ::CU_MEM_ADVISE_SET_PREFERRED_LOCATION was called on any subset of this memory
- * range, then the pages will be migrated to \p dstDevice even if \p dstDevice is not the
- * preferred location of any pages in the memory range.
+ * If ::CU_MEM_ADVISE_SET_PREFERRED_LOCATION was called on any subset of this
+ * memory range, then the pages will be migrated to \p dstDevice even if \p
+ * dstDevice is not the preferred location of any pages in the memory range.
  *
- * If ::CU_MEM_ADVISE_SET_ACCESSED_BY was called on any subset of this memory range,
- * then mappings to those pages from all the appropriate processors are updated to
- * refer to the new location if establishing such a mapping is possible. Otherwise,
- * those mappings are cleared.
+ * If ::CU_MEM_ADVISE_SET_ACCESSED_BY was called on any subset of this memory
+ * range, then mappings to those pages from all the appropriate processors are
+ * updated to refer to the new location if establishing such a mapping is
+ * possible. Otherwise, those mappings are cleared.
  *
- * Note that this API is not required for functionality and only serves to improve performance
- * by allowing the application to migrate data to a suitable location before it is accessed.
- * Memory accesses to this range are always coherent and are allowed even when the data is
- * actively being migrated.
+ * Note that this API is not required for functionality and only serves to
+ * improve performance by allowing the application to migrate data to a suitable
+ * location before it is accessed. Memory accesses to this range are always
+ * coherent and are allowed even when the data is actively being migrated.
  *
  * Note that this function is asynchronous with respect to the host and all work
  * on other devices.
@@ -8489,102 +8942,131 @@ CUresult CUDAAPI cuPointerGetAttribute(void *data, CUpointer_attribute attribute
  * ::cuMemcpy3DPeerAsync, ::cuMemAdvise,
  * ::cudaMemPrefetchAsync
  */
-CUresult CUDAAPI cuMemPrefetchAsync(CUdeviceptr devPtr, size_t count, CUdevice dstDevice, CUstream hStream);
+CUresult CUDAAPI cuMemPrefetchAsync(CUdeviceptr devPtr, size_t count,
+                                    CUdevice dstDevice, CUstream hStream);
 
 /**
  * \brief Advise about the usage of a given memory range
  *
- * Advise the Unified Memory subsystem about the usage pattern for the memory range
- * starting at \p devPtr with a size of \p count bytes. The start address and end address of the memory
- * range will be rounded down and rounded up respectively to be aligned to CPU page size before the
- * advice is applied. The memory range must refer to managed memory allocated via ::cuMemAllocManaged
- * or declared via __managed__ variables. The memory range could also refer to system-allocated pageable
- * memory provided it represents a valid, host-accessible region of memory and all additional constraints
- * imposed by \p advice as outlined below are also satisfied. Specifying an invalid system-allocated pageable
- * memory range results in an error being returned.
+ * Advise the Unified Memory subsystem about the usage pattern for the memory
+ * range starting at \p devPtr with a size of \p count bytes. The start address
+ * and end address of the memory range will be rounded down and rounded up
+ * respectively to be aligned to CPU page size before the advice is applied. The
+ * memory range must refer to managed memory allocated via ::cuMemAllocManaged
+ * or declared via __managed__ variables. The memory range could also refer to
+ * system-allocated pageable memory provided it represents a valid,
+ * host-accessible region of memory and all additional constraints imposed by \p
+ * advice as outlined below are also satisfied. Specifying an invalid
+ * system-allocated pageable memory range results in an error being returned.
  *
  * The \p advice parameter can take the following values:
- * - ::CU_MEM_ADVISE_SET_READ_MOSTLY: This implies that the data is mostly going to be read
- * from and only occasionally written to. Any read accesses from any processor to this region will create a
- * read-only copy of at least the accessed pages in that processor's memory. Additionally, if ::cuMemPrefetchAsync
- * is called on this region, it will create a read-only copy of the data on the destination processor.
- * If any processor writes to this region, all copies of the corresponding page will be invalidated
- * except for the one where the write occurred. The \p device argument is ignored for this advice.
- * Note that for a page to be read-duplicated, the accessing processor must either be the CPU or a GPU
- * that has a non-zero value for the device attribute ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS.
- * Also, if a context is created on a device that does not have the device attribute
- * ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS set, then read-duplication will not occur until
- * all such contexts are destroyed.
- * If the memory region refers to valid system-allocated pageable memory, then the accessing device must
- * have a non-zero value for the device attribute ::CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS for a read-only
- * copy to be created on that device. Note however that if the accessing device also has a non-zero value for the
- * device attribute ::CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES, then setting this advice
- * will not create a read-only copy when that device accesses this memory region.
+ * - ::CU_MEM_ADVISE_SET_READ_MOSTLY: This implies that the data is mostly going
+ * to be read from and only occasionally written to. Any read accesses from any
+ * processor to this region will create a read-only copy of at least the
+ * accessed pages in that processor's memory. Additionally, if
+ * ::cuMemPrefetchAsync is called on this region, it will create a read-only
+ * copy of the data on the destination processor. If any processor writes to
+ * this region, all copies of the corresponding page will be invalidated except
+ * for the one where the write occurred. The \p device argument is ignored for
+ * this advice. Note that for a page to be read-duplicated, the accessing
+ * processor must either be the CPU or a GPU that has a non-zero value for the
+ * device attribute ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS. Also, if a
+ * context is created on a device that does not have the device attribute
+ * ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS set, then read-duplication
+ * will not occur until all such contexts are destroyed. If the memory region
+ * refers to valid system-allocated pageable memory, then the accessing device
+ * must have a non-zero value for the device attribute
+ * ::CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS for a read-only copy to be
+ * created on that device. Note however that if the accessing device also has a
+ * non-zero value for the device attribute
+ * ::CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES, then
+ * setting this advice will not create a read-only copy when that device
+ * accesses this memory region.
  *
- * - ::CU_MEM_ADVISE_UNSET_READ_MOSTLY:  Undoes the effect of ::CU_MEM_ADVISE_SET_READ_MOSTLY and also prevents the
- * Unified Memory driver from attempting heuristic read-duplication on the memory range. Any read-duplicated
- * copies of the data will be collapsed into a single copy. The location for the collapsed
- * copy will be the preferred location if the page has a preferred location and one of the read-duplicated
- * copies was resident at that location. Otherwise, the location chosen is arbitrary.
+ * - ::CU_MEM_ADVISE_UNSET_READ_MOSTLY:  Undoes the effect of
+ * ::CU_MEM_ADVISE_SET_READ_MOSTLY and also prevents the Unified Memory driver
+ * from attempting heuristic read-duplication on the memory range. Any
+ * read-duplicated copies of the data will be collapsed into a single copy. The
+ * location for the collapsed copy will be the preferred location if the page
+ * has a preferred location and one of the read-duplicated copies was resident
+ * at that location. Otherwise, the location chosen is arbitrary.
  *
- * - ::CU_MEM_ADVISE_SET_PREFERRED_LOCATION: This advice sets the preferred location for the
- * data to be the memory belonging to \p device. Passing in CU_DEVICE_CPU for \p device sets the
- * preferred location as host memory. If \p device is a GPU, then it must have a non-zero value for the
- * device attribute ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS. Setting the preferred location
- * does not cause data to migrate to that location immediately. Instead, it guides the migration policy
- * when a fault occurs on that memory region. If the data is already in its preferred location and the
- * faulting processor can establish a mapping without requiring the data to be migrated, then
- * data migration will be avoided. On the other hand, if the data is not in its preferred location
- * or if a direct mapping cannot be established, then it will be migrated to the processor accessing
- * it. It is important to note that setting the preferred location does not prevent data prefetching
- * done using ::cuMemPrefetchAsync.
- * Having a preferred location can override the page thrash detection and resolution logic in the Unified
- * Memory driver. Normally, if a page is detected to be constantly thrashing between for example host and device
- * memory, the page may eventually be pinned to host memory by the Unified Memory driver. But
- * if the preferred location is set as device memory, then the page will continue to thrash indefinitely.
- * If ::CU_MEM_ADVISE_SET_READ_MOSTLY is also set on this memory region or any subset of it, then the
- * policies associated with that advice will override the policies of this advice, unless read accesses from
- * \p device will not result in a read-only copy being created on that device as outlined in description for
- * the advice ::CU_MEM_ADVISE_SET_READ_MOSTLY.
- * If the memory region refers to valid system-allocated pageable memory, then \p device must have a non-zero
- * value for the device attribute ::CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS. Additionally, if \p device has
- * a non-zero value for the device attribute ::CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES,
- * then this call has no effect. Note however that this behavior may change in the future.
+ * - ::CU_MEM_ADVISE_SET_PREFERRED_LOCATION: This advice sets the preferred
+ * location for the data to be the memory belonging to \p device. Passing in
+ * CU_DEVICE_CPU for \p device sets the preferred location as host memory. If \p
+ * device is a GPU, then it must have a non-zero value for the device attribute
+ * ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS. Setting the preferred
+ * location does not cause data to migrate to that location immediately.
+ * Instead, it guides the migration policy when a fault occurs on that memory
+ * region. If the data is already in its preferred location and the faulting
+ * processor can establish a mapping without requiring the data to be migrated,
+ * then data migration will be avoided. On the other hand, if the data is not in
+ * its preferred location or if a direct mapping cannot be established, then it
+ * will be migrated to the processor accessing it. It is important to note that
+ * setting the preferred location does not prevent data prefetching done using
+ * ::cuMemPrefetchAsync. Having a preferred location can override the page
+ * thrash detection and resolution logic in the Unified Memory driver. Normally,
+ * if a page is detected to be constantly thrashing between for example host and
+ * device memory, the page may eventually be pinned to host memory by the
+ * Unified Memory driver. But if the preferred location is set as device memory,
+ * then the page will continue to thrash indefinitely. If
+ * ::CU_MEM_ADVISE_SET_READ_MOSTLY is also set on this memory region or any
+ * subset of it, then the policies associated with that advice will override the
+ * policies of this advice, unless read accesses from \p device will not result
+ * in a read-only copy being created on that device as outlined in description
+ * for the advice ::CU_MEM_ADVISE_SET_READ_MOSTLY. If the memory region refers
+ * to valid system-allocated pageable memory, then \p device must have a
+ * non-zero value for the device attribute
+ * ::CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS. Additionally, if \p device has
+ * a non-zero value for the device attribute
+ * ::CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES, then this
+ * call has no effect. Note however that this behavior may change in the future.
  *
- * - ::CU_MEM_ADVISE_UNSET_PREFERRED_LOCATION: Undoes the effect of ::CU_MEM_ADVISE_SET_PREFERRED_LOCATION
- * and changes the preferred location to none.
+ * - ::CU_MEM_ADVISE_UNSET_PREFERRED_LOCATION: Undoes the effect of
+ * ::CU_MEM_ADVISE_SET_PREFERRED_LOCATION and changes the preferred location to
+ * none.
  *
- * - ::CU_MEM_ADVISE_SET_ACCESSED_BY: This advice implies that the data will be accessed by \p device.
- * Passing in ::CU_DEVICE_CPU for \p device will set the advice for the CPU. If \p device is a GPU, then
- * the device attribute ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS must be non-zero.
- * This advice does not cause data migration and has no impact on the location of the data per se. Instead,
- * it causes the data to always be mapped in the specified processor's page tables, as long as the
- * location of the data permits a mapping to be established. If the data gets migrated for any reason,
- * the mappings are updated accordingly.
- * This advice is recommended in scenarios where data locality is not important, but avoiding faults is.
- * Consider for example a system containing multiple GPUs with peer-to-peer access enabled, where the
- * data located on one GPU is occasionally accessed by peer GPUs. In such scenarios, migrating data
- * over to the other GPUs is not as important because the accesses are infrequent and the overhead of
- * migration may be too high. But preventing faults can still help improve performance, and so having
- * a mapping set up in advance is useful. Note that on CPU access of this data, the data may be migrated
- * to host memory because the CPU typically cannot access device memory directly. Any GPU that had the
- * ::CU_MEM_ADVISE_SET_ACCESSED_BY flag set for this data will now have its mapping updated to point to the
- * page in host memory.
- * If ::CU_MEM_ADVISE_SET_READ_MOSTLY is also set on this memory region or any subset of it, then the
- * policies associated with that advice will override the policies of this advice. Additionally, if the
- * preferred location of this memory region or any subset of it is also \p device, then the policies
- * associated with ::CU_MEM_ADVISE_SET_PREFERRED_LOCATION will override the policies of this advice.
- * If the memory region refers to valid system-allocated pageable memory, then \p device must have a non-zero
- * value for the device attribute ::CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS. Additionally, if \p device has
- * a non-zero value for the device attribute ::CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES,
- * then this call has no effect.
+ * - ::CU_MEM_ADVISE_SET_ACCESSED_BY: This advice implies that the data will be
+ * accessed by \p device. Passing in ::CU_DEVICE_CPU for \p device will set the
+ * advice for the CPU. If \p device is a GPU, then the device attribute
+ * ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS must be non-zero. This advice
+ * does not cause data migration and has no impact on the location of the data
+ * per se. Instead, it causes the data to always be mapped in the specified
+ * processor's page tables, as long as the location of the data permits a
+ * mapping to be established. If the data gets migrated for any reason, the
+ * mappings are updated accordingly. This advice is recommended in scenarios
+ * where data locality is not important, but avoiding faults is. Consider for
+ * example a system containing multiple GPUs with peer-to-peer access enabled,
+ * where the data located on one GPU is occasionally accessed by peer GPUs. In
+ * such scenarios, migrating data over to the other GPUs is not as important
+ * because the accesses are infrequent and the overhead of migration may be too
+ * high. But preventing faults can still help improve performance, and so having
+ * a mapping set up in advance is useful. Note that on CPU access of this data,
+ * the data may be migrated to host memory because the CPU typically cannot
+ * access device memory directly. Any GPU that had the
+ * ::CU_MEM_ADVISE_SET_ACCESSED_BY flag set for this data will now have its
+ * mapping updated to point to the page in host memory. If
+ * ::CU_MEM_ADVISE_SET_READ_MOSTLY is also set on this memory region or any
+ * subset of it, then the policies associated with that advice will override the
+ * policies of this advice. Additionally, if the preferred location of this
+ * memory region or any subset of it is also \p device, then the policies
+ * associated with ::CU_MEM_ADVISE_SET_PREFERRED_LOCATION will override the
+ * policies of this advice. If the memory region refers to valid
+ * system-allocated pageable memory, then \p device must have a non-zero value
+ * for the device attribute ::CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS.
+ * Additionally, if \p device has a non-zero value for the device attribute
+ * ::CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES, then this
+ * call has no effect.
  *
- * - ::CU_MEM_ADVISE_UNSET_ACCESSED_BY: Undoes the effect of ::CU_MEM_ADVISE_SET_ACCESSED_BY. Any mappings to
- * the data from \p device may be removed at any time causing accesses to result in non-fatal page faults.
- * If the memory region refers to valid system-allocated pageable memory, then \p device must have a non-zero
- * value for the device attribute ::CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS. Additionally, if \p device has
- * a non-zero value for the device attribute ::CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES,
- * then this call has no effect.
+ * - ::CU_MEM_ADVISE_UNSET_ACCESSED_BY: Undoes the effect of
+ * ::CU_MEM_ADVISE_SET_ACCESSED_BY. Any mappings to the data from \p device may
+ * be removed at any time causing accesses to result in non-fatal page faults.
+ * If the memory region refers to valid system-allocated pageable memory, then
+ * \p device must have a non-zero value for the device attribute
+ * ::CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS. Additionally, if \p device has
+ * a non-zero value for the device attribute
+ * ::CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES, then this
+ * call has no effect.
  *
  * \param devPtr - Pointer to memory to set the advice for
  * \param count  - Size in bytes of the memory range
@@ -8603,44 +9085,56 @@ CUresult CUDAAPI cuMemPrefetchAsync(CUdeviceptr devPtr, size_t count, CUdevice d
  * ::cuMemcpy3DPeerAsync, ::cuMemPrefetchAsync,
  * ::cudaMemAdvise
  */
-CUresult CUDAAPI cuMemAdvise(CUdeviceptr devPtr, size_t count, CUmem_advise advice, CUdevice device);
+CUresult CUDAAPI cuMemAdvise(CUdeviceptr devPtr, size_t count,
+                             CUmem_advise advice, CUdevice device);
 
 /**
  * \brief Query an attribute of a given memory range
  *
- * Query an attribute about the memory range starting at \p devPtr with a size of \p count bytes. The
- * memory range must refer to managed memory allocated via ::cuMemAllocManaged or declared via
+ * Query an attribute about the memory range starting at \p devPtr with a size
+ * of \p count bytes. The memory range must refer to managed memory allocated
+ * via ::cuMemAllocManaged or declared via
  * __managed__ variables.
  *
  * The \p attribute parameter can take the following values:
- * - ::CU_MEM_RANGE_ATTRIBUTE_READ_MOSTLY: If this attribute is specified, \p data will be interpreted
- * as a 32-bit integer, and \p dataSize must be 4. The result returned will be 1 if all pages in the given
- * memory range have read-duplication enabled, or 0 otherwise.
- * - ::CU_MEM_RANGE_ATTRIBUTE_PREFERRED_LOCATION: If this attribute is specified, \p data will be
- * interpreted as a 32-bit integer, and \p dataSize must be 4. The result returned will be a GPU device
- * id if all pages in the memory range have that GPU as their preferred location, or it will be CU_DEVICE_CPU
- * if all pages in the memory range have the CPU as their preferred location, or it will be CU_DEVICE_INVALID
- * if either all the pages don't have the same preferred location or some of the pages don't have a
- * preferred location at all. Note that the actual location of the pages in the memory range at the time of
- * the query may be different from the preferred location.
- * - ::CU_MEM_RANGE_ATTRIBUTE_ACCESSED_BY: If this attribute is specified, \p data will be interpreted
- * as an array of 32-bit integers, and \p dataSize must be a non-zero multiple of 4. The result returned
- * will be a list of device ids that had ::CU_MEM_ADVISE_SET_ACCESSED_BY set for that entire memory range.
- * If any device does not have that advice set for the entire memory range, that device will not be included.
- * If \p data is larger than the number of devices that have that advice set for that memory range,
- * CU_DEVICE_INVALID will be returned in all the extra space provided. For ex., if \p dataSize is 12
- * (i.e. \p data has 3 elements) and only device 0 has the advice set, then the result returned will be
- * { 0, CU_DEVICE_INVALID, CU_DEVICE_INVALID }. If \p data is smaller than the number of devices that have
- * that advice set, then only as many devices will be returned as can fit in the array. There is no
- * guarantee on which specific devices will be returned, however.
- * - ::CU_MEM_RANGE_ATTRIBUTE_LAST_PREFETCH_LOCATION: If this attribute is specified, \p data will be
- * interpreted as a 32-bit integer, and \p dataSize must be 4. The result returned will be the last location
- * to which all pages in the memory range were prefetched explicitly via ::cuMemPrefetchAsync. This will either be
- * a GPU id or CU_DEVICE_CPU depending on whether the last location for prefetch was a GPU or the CPU
- * respectively. If any page in the memory range was never explicitly prefetched or if all pages were not
- * prefetched to the same location, CU_DEVICE_INVALID will be returned. Note that this simply returns the
- * last location that the applicaton requested to prefetch the memory range to. It gives no indication as to
- * whether the prefetch operation to that location has completed or even begun.
+ * - ::CU_MEM_RANGE_ATTRIBUTE_READ_MOSTLY: If this attribute is specified, \p
+ * data will be interpreted as a 32-bit integer, and \p dataSize must be 4. The
+ * result returned will be 1 if all pages in the given memory range have
+ * read-duplication enabled, or 0 otherwise.
+ * - ::CU_MEM_RANGE_ATTRIBUTE_PREFERRED_LOCATION: If this attribute is
+ * specified, \p data will be interpreted as a 32-bit integer, and \p dataSize
+ * must be 4. The result returned will be a GPU device id if all pages in the
+ * memory range have that GPU as their preferred location, or it will be
+ * CU_DEVICE_CPU if all pages in the memory range have the CPU as their
+ * preferred location, or it will be CU_DEVICE_INVALID if either all the pages
+ * don't have the same preferred location or some of the pages don't have a
+ * preferred location at all. Note that the actual location of the pages in the
+ * memory range at the time of the query may be different from the preferred
+ * location.
+ * - ::CU_MEM_RANGE_ATTRIBUTE_ACCESSED_BY: If this attribute is specified, \p
+ * data will be interpreted as an array of 32-bit integers, and \p dataSize must
+ * be a non-zero multiple of 4. The result returned will be a list of device ids
+ * that had ::CU_MEM_ADVISE_SET_ACCESSED_BY set for that entire memory range. If
+ * any device does not have that advice set for the entire memory range, that
+ * device will not be included. If \p data is larger than the number of devices
+ * that have that advice set for that memory range, CU_DEVICE_INVALID will be
+ * returned in all the extra space provided. For ex., if \p dataSize is 12 (i.e.
+ * \p data has 3 elements) and only device 0 has the advice set, then the result
+ * returned will be { 0, CU_DEVICE_INVALID, CU_DEVICE_INVALID }. If \p data is
+ * smaller than the number of devices that have that advice set, then only as
+ * many devices will be returned as can fit in the array. There is no guarantee
+ * on which specific devices will be returned, however.
+ * - ::CU_MEM_RANGE_ATTRIBUTE_LAST_PREFETCH_LOCATION: If this attribute is
+ * specified, \p data will be interpreted as a 32-bit integer, and \p dataSize
+ * must be 4. The result returned will be the last location to which all pages
+ * in the memory range were prefetched explicitly via ::cuMemPrefetchAsync. This
+ * will either be a GPU id or CU_DEVICE_CPU depending on whether the last
+ * location for prefetch was a GPU or the CPU respectively. If any page in the
+ * memory range was never explicitly prefetched or if all pages were not
+ * prefetched to the same location, CU_DEVICE_INVALID will be returned. Note
+ * that this simply returns the last location that the applicaton requested to
+ * prefetch the memory range to. It gives no indication as to whether the
+ * prefetch operation to that location has completed or even begun.
  *
  * \param data      - A pointers to a memory location where the result
  *                    of each attribute query will be written to.
@@ -8661,19 +9155,23 @@ CUresult CUDAAPI cuMemAdvise(CUdeviceptr devPtr, size_t count, CUmem_advise advi
  * ::cuMemAdvise,
  * ::cudaMemRangeGetAttribute
  */
-CUresult CUDAAPI cuMemRangeGetAttribute(void *data, size_t dataSize, CUmem_range_attribute attribute, CUdeviceptr devPtr, size_t count);
+CUresult CUDAAPI cuMemRangeGetAttribute(void *data, size_t dataSize,
+                                        CUmem_range_attribute attribute,
+                                        CUdeviceptr devPtr, size_t count);
 
 /**
  * \brief Query attributes of a given memory range.
  *
- * Query attributes of the memory range starting at \p devPtr with a size of \p count bytes. The
- * memory range must refer to managed memory allocated via ::cuMemAllocManaged or declared via
- * __managed__ variables. The \p attributes array will be interpreted to have \p numAttributes
- * entries. The \p dataSizes array will also be interpreted to have \p numAttributes entries.
- * The results of the query will be stored in \p data.
+ * Query attributes of the memory range starting at \p devPtr with a size of \p
+ * count bytes. The memory range must refer to managed memory allocated via
+ * ::cuMemAllocManaged or declared via
+ * __managed__ variables. The \p attributes array will be interpreted to have \p
+ * numAttributes entries. The \p dataSizes array will also be interpreted to
+ * have \p numAttributes entries. The results of the query will be stored in \p
+ * data.
  *
- * The list of supported attributes are given below. Please refer to ::cuMemRangeGetAttribute for
- * attribute descriptions and restrictions.
+ * The list of supported attributes are given below. Please refer to
+ * ::cuMemRangeGetAttribute for attribute descriptions and restrictions.
  *
  * - ::CU_MEM_RANGE_ATTRIBUTE_READ_MOSTLY
  * - ::CU_MEM_RANGE_ATTRIBUTE_PREFERRED_LOCATION
@@ -8681,13 +9179,12 @@ CUresult CUDAAPI cuMemRangeGetAttribute(void *data, size_t dataSize, CUmem_range
  * - ::CU_MEM_RANGE_ATTRIBUTE_LAST_PREFETCH_LOCATION
  *
  * \param data          - A two-dimensional array containing pointers to memory
- *                        locations where the result of each attribute query will be written to.
- * \param dataSizes     - Array containing the sizes of each result
- * \param attributes    - An array of attributes to query
- *                        (numAttributes and the number of attributes in this array should match)
- * \param numAttributes - Number of attributes to query
- * \param devPtr        - Start of the range to query
- * \param count         - Size of the range to query
+ *                        locations where the result of each attribute query
+ * will be written to. \param dataSizes     - Array containing the sizes of each
+ * result \param attributes    - An array of attributes to query (numAttributes
+ * and the number of attributes in this array should match) \param numAttributes
+ * - Number of attributes to query \param devPtr        - Start of the range to
+ * query \param count         - Size of the range to query
  *
  * \return
  * ::CUDA_SUCCESS,
@@ -8701,7 +9198,10 @@ CUresult CUDAAPI cuMemRangeGetAttribute(void *data, size_t dataSize, CUmem_range
  * ::cuMemPrefetchAsync,
  * ::cudaMemRangeGetAttributes
  */
-CUresult CUDAAPI cuMemRangeGetAttributes(void **data, size_t *dataSizes, CUmem_range_attribute *attributes, size_t numAttributes, CUdeviceptr devPtr, size_t count);
+CUresult CUDAAPI cuMemRangeGetAttributes(void **data, size_t *dataSizes,
+                                         CUmem_range_attribute *attributes,
+                                         size_t numAttributes,
+                                         CUdeviceptr devPtr, size_t count);
 #endif /* __CUDA_API_VERSION >= 8000 */
 
 #if __CUDA_API_VERSION >= 6000
@@ -8713,18 +9213,19 @@ CUresult CUDAAPI cuMemRangeGetAttributes(void **data, size_t *dataSizes, CUmem_r
  * - ::CU_POINTER_ATTRIBUTE_SYNC_MEMOPS:
  *
  *      A boolean attribute that can either be set (1) or unset (0). When set,
- *      the region of memory that \p ptr points to is guaranteed to always synchronize
- *      memory operations that are synchronous. If there are some previously initiated
- *      synchronous memory operations that are pending when this attribute is set, the
- *      function does not return until those memory operations are complete.
- *      See further documentation in the section titled "API synchronization behavior"
- *      to learn more about cases when synchronous memory operations can
- *      exhibit asynchronous behavior.
- *      \p value will be considered as a pointer to an unsigned integer to which this attribute is to be set.
+ *      the region of memory that \p ptr points to is guaranteed to always
+ * synchronize memory operations that are synchronous. If there are some
+ * previously initiated synchronous memory operations that are pending when this
+ * attribute is set, the function does not return until those memory operations
+ * are complete. See further documentation in the section titled "API
+ * synchronization behavior" to learn more about cases when synchronous memory
+ * operations can exhibit asynchronous behavior. \p value will be considered as
+ * a pointer to an unsigned integer to which this attribute is to be set.
  *
  * \param value     - Pointer to memory containing the value to be set
  * \param attribute - Pointer attribute to set
- * \param ptr       - Pointer to a memory region allocated using CUDA memory allocation APIs
+ * \param ptr       - Pointer to a memory region allocated using CUDA memory
+ * allocation APIs
  *
  * \return
  * ::CUDA_SUCCESS,
@@ -8745,14 +9246,17 @@ CUresult CUDAAPI cuMemRangeGetAttributes(void **data, size_t *dataSizes, CUmem_r
  * ::cuMemHostRegister,
  * ::cuMemHostUnregister
  */
-CUresult CUDAAPI cuPointerSetAttribute(const void *value, CUpointer_attribute attribute, CUdeviceptr ptr);
+CUresult CUDAAPI cuPointerSetAttribute(const void *value,
+                                       CUpointer_attribute attribute,
+                                       CUdeviceptr ptr);
 #endif /* __CUDA_API_VERSION >= 6000 */
 
 #if __CUDA_API_VERSION >= 7000
 /**
  * \brief Returns information about a pointer.
  *
- * The supported attributes are (refer to ::cuPointerGetAttribute for attribute descriptions and restrictions):
+ * The supported attributes are (refer to ::cuPointerGetAttribute for attribute
+ * descriptions and restrictions):
  *
  * - ::CU_POINTER_ATTRIBUTE_CONTEXT
  * - ::CU_POINTER_ATTRIBUTE_MEMORY_TYPE
@@ -8765,17 +9269,18 @@ CUresult CUDAAPI cuPointerSetAttribute(const void *value, CUpointer_attribute at
  *
  * \param numAttributes - Number of attributes to query
  * \param attributes    - An array of attributes to query
- *                      (numAttributes and the number of attributes in this array should match)
- * \param data          - A two-dimensional array containing pointers to memory
- *                      locations where the result of each attribute query will be written to.
- * \param ptr           - Pointer to query
+ *                      (numAttributes and the number of attributes in this
+ * array should match) \param data          - A two-dimensional array containing
+ * pointers to memory locations where the result of each attribute query will be
+ * written to. \param ptr           - Pointer to query
  *
- * Unlike ::cuPointerGetAttribute, this function will not return an error when the \p ptr
- * encountered is not a valid CUDA pointer. Instead, the attributes are assigned default NULL values
- * and CUDA_SUCCESS is returned.
+ * Unlike ::cuPointerGetAttribute, this function will not return an error when
+ * the \p ptr encountered is not a valid CUDA pointer. Instead, the attributes
+ * are assigned default NULL values and CUDA_SUCCESS is returned.
  *
- * If \p ptr was not allocated by, mapped by, or registered with a ::CUcontext which uses UVA
- * (Unified Virtual Addressing), ::CUDA_ERROR_INVALID_CONTEXT is returned.
+ * If \p ptr was not allocated by, mapped by, or registered with a ::CUcontext
+ * which uses UVA (Unified Virtual Addressing), ::CUDA_ERROR_INVALID_CONTEXT is
+ * returned.
  *
  * \return
  * ::CUDA_SUCCESS,
@@ -8790,7 +9295,9 @@ CUresult CUDAAPI cuPointerSetAttribute(const void *value, CUpointer_attribute at
  * ::cuPointerSetAttribute,
  * ::cudaPointerGetAttributes
  */
-CUresult CUDAAPI cuPointerGetAttributes(unsigned int numAttributes, CUpointer_attribute *attributes, void **data, CUdeviceptr ptr);
+CUresult CUDAAPI cuPointerGetAttributes(unsigned int numAttributes,
+                                        CUpointer_attribute *attributes,
+                                        void **data, CUdeviceptr ptr);
 #endif /* __CUDA_API_VERSION >= 7000 */
 
 /** @} */ /* END CUDA_UNIFIED */
@@ -8814,8 +9321,9 @@ CUresult CUDAAPI cuPointerGetAttributes(unsigned int numAttributes, CUpointer_at
  * determines behaviors of the stream.  Valid values for \p Flags are:
  * - ::CU_STREAM_DEFAULT: Default stream creation flag.
  * - ::CU_STREAM_NON_BLOCKING: Specifies that work running in the created
- *   stream may run concurrently with work in stream 0 (the NULL stream), and that
- *   the created stream should perform no implicit synchronization with stream 0.
+ *   stream may run concurrently with work in stream 0 (the NULL stream), and
+ * that the created stream should perform no implicit synchronization with
+ * stream 0.
  *
  * \param phStream - Returned newly created stream
  * \param Flags    - Parameters for stream creation
@@ -8845,22 +9353,23 @@ CUresult CUDAAPI cuStreamCreate(CUstream *phStream, unsigned int Flags);
 /**
  * \brief Create a stream with the given priority
  *
- * Creates a stream with the specified priority and returns a handle in \p phStream.
- * This API alters the scheduler priority of work in the stream. Work in a higher
- * priority stream may preempt work already executing in a low priority stream.
+ * Creates a stream with the specified priority and returns a handle in \p
+ * phStream. This API alters the scheduler priority of work in the stream. Work
+ * in a higher priority stream may preempt work already executing in a low
+ * priority stream.
  *
- * \p priority follows a convention where lower numbers represent higher priorities.
- * '0' represents default priority. The range of meaningful numerical priorities can
- * be queried using ::cuCtxGetStreamPriorityRange. If the specified priority is
- * outside the numerical range returned by ::cuCtxGetStreamPriorityRange,
- * it will automatically be clamped to the lowest or the highest number in the range.
+ * \p priority follows a convention where lower numbers represent higher
+ * priorities. '0' represents default priority. The range of meaningful
+ * numerical priorities can be queried using ::cuCtxGetStreamPriorityRange. If
+ * the specified priority is outside the numerical range returned by
+ * ::cuCtxGetStreamPriorityRange, it will automatically be clamped to the lowest
+ * or the highest number in the range.
  *
  * \param phStream    - Returned newly created stream
- * \param flags       - Flags for stream creation. See ::cuStreamCreate for a list of
- *                      valid flags
- * \param priority    - Stream priority. Lower numbers represent higher priorities.
- *                      See ::cuCtxGetStreamPriorityRange for more information about
- *                      meaningful stream priorities that can be passed.
+ * \param flags       - Flags for stream creation. See ::cuStreamCreate for a
+ * list of valid flags \param priority    - Stream priority. Lower numbers
+ * represent higher priorities. See ::cuCtxGetStreamPriorityRange for more
+ * information about meaningful stream priorities that can be passed.
  *
  * \return
  * ::CUDA_SUCCESS,
@@ -8875,8 +9384,8 @@ CUresult CUDAAPI cuStreamCreate(CUstream *phStream, unsigned int Flags);
  * with compute capability 3.5 or higher.
  *
  * \note In the current implementation, only compute kernels launched in
- * priority streams are affected by the stream's priority. Stream priorities have
- * no effect on host-to-device and device-to-host memory operations.
+ * priority streams are affected by the stream's priority. Stream priorities
+ * have no effect on host-to-device and device-to-host memory operations.
  *
  * \sa ::cuStreamDestroy,
  * ::cuStreamCreate,
@@ -8889,21 +9398,22 @@ CUresult CUDAAPI cuStreamCreate(CUstream *phStream, unsigned int Flags);
  * ::cuStreamAddCallback,
  * ::cudaStreamCreateWithPriority
  */
-CUresult CUDAAPI cuStreamCreateWithPriority(CUstream *phStream, unsigned int flags, int priority);
-
+CUresult CUDAAPI cuStreamCreateWithPriority(CUstream *phStream,
+                                            unsigned int flags, int priority);
 
 /**
  * \brief Query the priority of a given stream
  *
- * Query the priority of a stream created using ::cuStreamCreate or ::cuStreamCreateWithPriority
- * and return the priority in \p priority. Note that if the stream was created with a
- * priority outside the numerical range returned by ::cuCtxGetStreamPriorityRange,
- * this function returns the clamped priority.
- * See ::cuStreamCreateWithPriority for details about priority clamping.
+ * Query the priority of a stream created using ::cuStreamCreate or
+ * ::cuStreamCreateWithPriority and return the priority in \p priority. Note
+ * that if the stream was created with a priority outside the numerical range
+ * returned by ::cuCtxGetStreamPriorityRange, this function returns the clamped
+ * priority. See ::cuStreamCreateWithPriority for details about priority
+ * clamping.
  *
  * \param hStream    - Handle to the stream to be queried
- * \param priority   - Pointer to a signed integer in which the stream's priority is returned
- * \return
+ * \param priority   - Pointer to a signed integer in which the stream's
+ * priority is returned \return
  * ::CUDA_SUCCESS,
  * ::CUDA_ERROR_DEINITIALIZED,
  * ::CUDA_ERROR_NOT_INITIALIZED,
@@ -8925,15 +9435,14 @@ CUresult CUDAAPI cuStreamGetPriority(CUstream hStream, int *priority);
 /**
  * \brief Query the flags of a given stream
  *
- * Query the flags of a stream created using ::cuStreamCreate or ::cuStreamCreateWithPriority
- * and return the flags in \p flags.
+ * Query the flags of a stream created using ::cuStreamCreate or
+ * ::cuStreamCreateWithPriority and return the flags in \p flags.
  *
  * \param hStream    - Handle to the stream to be queried
- * \param flags      - Pointer to an unsigned integer in which the stream's flags are returned
- *                     The value returned in \p flags is a logical 'OR' of all flags that
- *                     were used while creating this stream. See ::cuStreamCreate for the list
- *                     of valid flags
- * \return
+ * \param flags      - Pointer to an unsigned integer in which the stream's
+ * flags are returned The value returned in \p flags is a logical 'OR' of all
+ * flags that were used while creating this stream. See ::cuStreamCreate for the
+ * list of valid flags \return
  * ::CUDA_SUCCESS,
  * ::CUDA_ERROR_DEINITIALIZED,
  * ::CUDA_ERROR_NOT_INITIALIZED,
@@ -8959,16 +9468,19 @@ CUresult CUDAAPI cuStreamGetFlags(CUstream hStream, unsigned int *flags);
  *
  * The stream handle \p hStream can refer to any of the following:
  * <ul>
- *   <li>a stream created via any of the CUDA driver APIs such as ::cuStreamCreate
- *   and ::cuStreamCreateWithPriority, or their runtime API equivalents such as
- *   ::cudaStreamCreate, ::cudaStreamCreateWithFlags and ::cudaStreamCreateWithPriority.
- *   The returned context is the context that was active in the calling thread when the
- *   stream was created. Passing an invalid handle will result in undefined behavior.</li>
- *   <li>any of the special streams such as the NULL stream, ::CU_STREAM_LEGACY and
- *   ::CU_STREAM_PER_THREAD. The runtime API equivalents of these are also accepted,
- *   which are NULL, ::cudaStreamLegacy and ::cudaStreamPerThread respectively.
- *   Specifying any of the special handles will return the context current to the
- *   calling thread. If no context is current to the calling thread,
+ *   <li>a stream created via any of the CUDA driver APIs such as
+ * ::cuStreamCreate and ::cuStreamCreateWithPriority, or their runtime API
+ * equivalents such as
+ *   ::cudaStreamCreate, ::cudaStreamCreateWithFlags and
+ * ::cudaStreamCreateWithPriority. The returned context is the context that was
+ * active in the calling thread when the stream was created. Passing an invalid
+ * handle will result in undefined behavior.</li> <li>any of the special streams
+ * such as the NULL stream, ::CU_STREAM_LEGACY and
+ *   ::CU_STREAM_PER_THREAD. The runtime API equivalents of these are also
+ * accepted, which are NULL, ::cudaStreamLegacy and ::cudaStreamPerThread
+ * respectively. Specifying any of the special handles will return the context
+ * current to the calling thread. If no context is current to the calling
+ * thread,
  *   ::CUDA_ERROR_INVALID_CONTEXT is returned.</li>
  * </ul>
  *
@@ -9002,9 +9514,10 @@ CUresult CUDAAPI cuStreamGetCtx(CUstream hStream, CUcontext *pctx);
  * \brief Make a compute stream wait on an event
  *
  * Makes all future work submitted to \p hStream wait for all work captured in
- * \p hEvent.  See ::cuEventRecord() for details on what is captured by an event.
- * The synchronization will be performed efficiently on the device when applicable.
- * \p hEvent may be from a different context or device than \p hStream.
+ * \p hEvent.  See ::cuEventRecord() for details on what is captured by an
+ * event. The synchronization will be performed efficiently on the device when
+ * applicable. \p hEvent may be from a different context or device than \p
+ * hStream.
  *
  * \param hStream - Stream to wait
  * \param hEvent  - Event to wait on (may not be NULL)
@@ -9027,7 +9540,8 @@ CUresult CUDAAPI cuStreamGetCtx(CUstream hStream, CUcontext *pctx);
  * ::cuStreamDestroy,
  * ::cudaStreamWaitEvent
  */
-CUresult CUDAAPI cuStreamWaitEvent(CUstream hStream, CUevent hEvent, unsigned int Flags);
+CUresult CUDAAPI cuStreamWaitEvent(CUstream hStream, CUevent hEvent,
+                                   unsigned int Flags);
 
 /**
  * \brief Add a callback to a compute stream
@@ -9078,9 +9592,9 @@ CUresult CUDAAPI cuStreamWaitEvent(CUstream hStream, CUevent hEvent, unsigned in
  * </ul>
  *
  * \param hStream  - Stream to add callback to
- * \param callback - The function to call once preceding stream operations are complete
- * \param userData - User specified data to be passed to the callback function
- * \param flags    - Reserved for future use, must be 0
+ * \param callback - The function to call once preceding stream operations are
+ * complete \param userData - User specified data to be passed to the callback
+ * function \param flags    - Reserved for future use, must be 0
  *
  * \return
  * ::CUDA_SUCCESS,
@@ -9102,32 +9616,36 @@ CUresult CUDAAPI cuStreamWaitEvent(CUstream hStream, CUevent hEvent, unsigned in
  * ::cuStreamLaunchHostFunc,
  * ::cudaStreamAddCallback
  */
-CUresult CUDAAPI cuStreamAddCallback(CUstream hStream, CUstreamCallback callback, void *userData, unsigned int flags);
+CUresult CUDAAPI cuStreamAddCallback(CUstream hStream,
+                                     CUstreamCallback callback, void *userData,
+                                     unsigned int flags);
 
 #if __CUDA_API_VERSION >= 10000
 
 /**
  * \brief Begins graph capture on a stream
  *
- * Begin graph capture on \p hStream. When a stream is in capture mode, all operations
- * pushed into the stream will not be executed, but will instead be captured into
- * a graph, which will be returned via ::cuStreamEndCapture. Capture may not be initiated
- * if \p stream is CU_STREAM_LEGACY. Capture must be ended on the same stream in which
- * it was initiated, and it may only be initiated if the stream is not already in capture
- * mode. The capture mode may be queried via ::cuStreamIsCapturing. A unique id
- * representing the capture sequence may be queried via ::cuStreamGetCaptureInfo.
+ * Begin graph capture on \p hStream. When a stream is in capture mode, all
+ * operations pushed into the stream will not be executed, but will instead be
+ * captured into a graph, which will be returned via ::cuStreamEndCapture.
+ * Capture may not be initiated if \p stream is CU_STREAM_LEGACY. Capture must
+ * be ended on the same stream in which it was initiated, and it may only be
+ * initiated if the stream is not already in capture mode. The capture mode may
+ * be queried via ::cuStreamIsCapturing. A unique id representing the capture
+ * sequence may be queried via ::cuStreamGetCaptureInfo.
  *
- * If \p mode is not ::CU_STREAM_CAPTURE_MODE_RELAXED, ::cuStreamEndCapture must be
- * called on this stream from the same thread.
+ * If \p mode is not ::CU_STREAM_CAPTURE_MODE_RELAXED, ::cuStreamEndCapture must
+ * be called on this stream from the same thread.
  *
  * \param hStream - Stream in which to initiate capture
- * \param mode    - Controls the interaction of this capture sequence with other API
- *                  calls that are potentially unsafe. For more details see
+ * \param mode    - Controls the interaction of this capture sequence with other
+ * API calls that are potentially unsafe. For more details see
  *                  ::cuThreadExchangeStreamCaptureMode.
  *
- * \note Kernels captured using this API must not use texture and surface references.
- *       Reading or writing through any texture or surface reference is undefined
- *       behavior. This restriction does not apply to texture and surface objects.
+ * \note Kernels captured using this API must not use texture and surface
+ * references. Reading or writing through any texture or surface reference is
+ * undefined behavior. This restriction does not apply to texture and surface
+ * objects.
  *
  * \return
  * ::CUDA_SUCCESS,
@@ -9142,7 +9660,8 @@ CUresult CUDAAPI cuStreamAddCallback(CUstream hStream, CUstreamCallback callback
  * ::cuStreamEndCapture,
  * ::cuThreadExchangeStreamCaptureMode
  */
-CUresult CUDAAPI cuStreamBeginCapture(CUstream hStream, CUstreamCaptureMode mode);
+CUresult CUDAAPI cuStreamBeginCapture(CUstream hStream,
+                                      CUstreamCaptureMode mode);
 
 #endif /* __CUDA_API_VERSION >= 10000 */
 #if __CUDA_API_VERSION >= 10010
@@ -9150,9 +9669,12 @@ CUresult CUDAAPI cuStreamBeginCapture(CUstream hStream, CUstreamCaptureMode mode
 /**
  * \brief Swaps the stream capture interaction mode for a thread
  *
- * Sets the calling thread's stream capture interaction mode to the value contained
- * in \p *mode, and overwrites \p *mode with the previous mode for the thread. To
- * facilitate deterministic behavior across function or module boundaries, callers
+ * Sets the calling thread's stream capture interaction mode to the value
+ contained
+ * in \p *mode, and overwrites \p *mode with the previous mode for the thread.
+ To
+ * facilitate deterministic behavior across function or module boundaries,
+ callers
  * are encouraged to use this API in a push-pop fashion: \code
      CUstreamCaptureMode mode = desiredMode;
      cuThreadExchangeStreamCaptureMode(&mode);
@@ -9160,30 +9682,43 @@ CUresult CUDAAPI cuStreamBeginCapture(CUstream hStream, CUstreamCaptureMode mode
      cuThreadExchangeStreamCaptureMode(&mode); // restore previous mode
  * \endcode
  *
- * During stream capture (see ::cuStreamBeginCapture), some actions, such as a call
+ * During stream capture (see ::cuStreamBeginCapture), some actions, such as a
+ call
  * to ::cudaMalloc, may be unsafe. In the case of ::cudaMalloc, the operation is
- * not enqueued asynchronously to a stream, and is not observed by stream capture.
+ * not enqueued asynchronously to a stream, and is not observed by stream
+ capture.
  * Therefore, if the sequence of operations captured via ::cuStreamBeginCapture
  * depended on the allocation being replayed whenever the graph is launched, the
  * captured graph would be invalid.
  *
- * Therefore, stream capture places restrictions on API calls that can be made within
- * or concurrently to a ::cuStreamBeginCapture-::cuStreamEndCapture sequence. This
+ * Therefore, stream capture places restrictions on API calls that can be made
+ within
+ * or concurrently to a ::cuStreamBeginCapture-::cuStreamEndCapture sequence.
+ This
  * behavior can be controlled via this API and flags to ::cuStreamBeginCapture.
  *
  * A thread's mode is one of the following:
- * - \p CU_STREAM_CAPTURE_MODE_GLOBAL: This is the default mode. If the local thread has
+ * - \p CU_STREAM_CAPTURE_MODE_GLOBAL: This is the default mode. If the local
+ thread has
  *   an ongoing capture sequence that was not initiated with
- *   \p CU_STREAM_CAPTURE_MODE_RELAXED at \p cuStreamBeginCapture, or if any other thread
- *   has a concurrent capture sequence initiated with \p CU_STREAM_CAPTURE_MODE_GLOBAL,
+ *   \p CU_STREAM_CAPTURE_MODE_RELAXED at \p cuStreamBeginCapture, or if any
+ other thread
+ *   has a concurrent capture sequence initiated with \p
+ CU_STREAM_CAPTURE_MODE_GLOBAL,
  *   this thread is prohibited from potentially unsafe API calls.
- * - \p CU_STREAM_CAPTURE_MODE_THREAD_LOCAL: If the local thread has an ongoing capture
- *   sequence not initiated with \p CU_STREAM_CAPTURE_MODE_RELAXED, it is prohibited
- *   from potentially unsafe API calls. Concurrent capture sequences in other threads
+ * - \p CU_STREAM_CAPTURE_MODE_THREAD_LOCAL: If the local thread has an ongoing
+ capture
+ *   sequence not initiated with \p CU_STREAM_CAPTURE_MODE_RELAXED, it is
+ prohibited
+ *   from potentially unsafe API calls. Concurrent capture sequences in other
+ threads
  *   are ignored.
- * - \p CU_STREAM_CAPTURE_MODE_RELAXED: The local thread is not prohibited from potentially
- *   unsafe API calls. Note that the thread is still prohibited from API calls which
- *   necessarily conflict with stream capture, for example, attempting ::cuEventQuery
+ * - \p CU_STREAM_CAPTURE_MODE_RELAXED: The local thread is not prohibited from
+ potentially
+ *   unsafe API calls. Note that the thread is still prohibited from API calls
+ which
+ *   necessarily conflict with stream capture, for example, attempting
+ ::cuEventQuery
  *   on an event that was last recorded inside a capture sequence.
  *
  * \param mode - Pointer to mode value to swap with the current mode
@@ -9207,9 +9742,9 @@ CUresult CUDAAPI cuThreadExchangeStreamCaptureMode(CUstreamCaptureMode *mode);
  * \brief Ends capture on a stream, returning the captured graph
  *
  * End capture on \p hStream, returning the captured graph via \p phGraph.
- * Capture must have been initiated on \p hStream via a call to ::cuStreamBeginCapture.
- * If capture was invalidated, due to a violation of the rules of stream capture, then
- * a NULL graph will be returned.
+ * Capture must have been initiated on \p hStream via a call to
+ * ::cuStreamBeginCapture. If capture was invalidated, due to a violation of the
+ * rules of stream capture, then a NULL graph will be returned.
  *
  * If the \p mode argument to ::cuStreamBeginCapture was not
  * ::CU_STREAM_CAPTURE_MODE_RELAXED, this call must be from the same thread as
@@ -9236,14 +9771,14 @@ CUresult CUDAAPI cuStreamEndCapture(CUstream hStream, CUgraph *phGraph);
 /**
  * \brief Returns a stream's capture status
  *
- * Return the capture status of \p hStream via \p captureStatus. After a successful
- * call, \p *captureStatus will contain one of the following:
+ * Return the capture status of \p hStream via \p captureStatus. After a
+ * successful call, \p *captureStatus will contain one of the following:
  * - ::CU_STREAM_CAPTURE_STATUS_NONE: The stream is not capturing.
  * - ::CU_STREAM_CAPTURE_STATUS_ACTIVE: The stream is capturing.
- * - ::CU_STREAM_CAPTURE_STATUS_INVALIDATED: The stream was capturing but an error
- *   has invalidated the capture sequence. The capture sequence must be terminated
- *   with ::cuStreamEndCapture on the stream where it was initiated in order to
- *   continue using \p hStream.
+ * - ::CU_STREAM_CAPTURE_STATUS_INVALIDATED: The stream was capturing but an
+ * error has invalidated the capture sequence. The capture sequence must be
+ * terminated with ::cuStreamEndCapture on the stream where it was initiated in
+ * order to continue using \p hStream.
  *
  * Note that, if this is called on ::CU_STREAM_LEGACY (the "null stream") while
  * a blocking stream in the same context is capturing, it will return
@@ -9271,7 +9806,8 @@ CUresult CUDAAPI cuStreamEndCapture(CUstream hStream, CUgraph *phGraph);
  * ::cuStreamBeginCapture,
  * ::cuStreamEndCapture
  */
-CUresult CUDAAPI cuStreamIsCapturing(CUstream hStream, CUstreamCaptureStatus *captureStatus);
+CUresult CUDAAPI cuStreamIsCapturing(CUstream hStream,
+                                     CUstreamCaptureStatus *captureStatus);
 
 #endif /* __CUDA_API_VERSION >= 10000 */
 
@@ -9283,8 +9819,9 @@ CUresult CUDAAPI cuStreamIsCapturing(CUstream hStream, CUstreamCaptureStatus *ca
  * Query the capture status of a stream and and get an id for
  * the capture sequence, which is unique over the lifetime of the process.
  *
- * If called on ::CU_STREAM_LEGACY (the "null stream") while a stream not created
- * with ::CU_STREAM_NON_BLOCKING is capturing, returns ::CUDA_ERROR_STREAM_CAPTURE_IMPLICIT.
+ * If called on ::CU_STREAM_LEGACY (the "null stream") while a stream not
+ * created with ::CU_STREAM_NON_BLOCKING is capturing, returns
+ * ::CUDA_ERROR_STREAM_CAPTURE_IMPLICIT.
  *
  * A valid id is returned only if both of the following are true:
  * - the call returns CUDA_SUCCESS
@@ -9299,7 +9836,9 @@ CUresult CUDAAPI cuStreamIsCapturing(CUstream hStream, CUstreamCaptureStatus *ca
  * ::cuStreamBeginCapture,
  * ::cuStreamIsCapturing
  */
- CUresult CUDAAPI cuStreamGetCaptureInfo(CUstream hStream, CUstreamCaptureStatus *captureStatus, cuuint64_t *id);
+CUresult CUDAAPI cuStreamGetCaptureInfo(CUstream hStream,
+                                        CUstreamCaptureStatus *captureStatus,
+                                        cuuint64_t *id);
 
 #endif /* __CUDA_API_VERSION >= 10010 */
 
@@ -9334,19 +9873,21 @@ CUresult CUDAAPI cuStreamIsCapturing(CUstream hStream, CUstreamCaptureStatus *ca
  * If the ::CU_MEM_ATTACH_GLOBAL flag is specified, the memory can be accessed
  * by any stream on any device.
  * If the ::CU_MEM_ATTACH_HOST flag is specified, the program makes a guarantee
- * that it won't access the memory on the device from any stream on a device that
- * has a zero value for the device attribute ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS.
- * If the ::CU_MEM_ATTACH_SINGLE flag is specified and \p hStream is associated with
- * a device that has a zero value for the device attribute ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS,
- * the program makes a guarantee that it will only access the memory on the device
- * from \p hStream. It is illegal to attach singly to the NULL stream, because the
- * NULL stream is a virtual global stream and not a specific stream. An error will
- * be returned in this case.
+ * that it won't access the memory on the device from any stream on a device
+ * that has a zero value for the device attribute
+ * ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS. If the
+ * ::CU_MEM_ATTACH_SINGLE flag is specified and \p hStream is associated with a
+ * device that has a zero value for the device attribute
+ * ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS, the program makes a
+ * guarantee that it will only access the memory on the device from \p hStream.
+ * It is illegal to attach singly to the NULL stream, because the NULL stream is
+ * a virtual global stream and not a specific stream. An error will be returned
+ * in this case.
  *
- * When memory is associated with a single stream, the Unified Memory system will
- * allow CPU access to this memory region so long as all operations in \p hStream
- * have completed, regardless of whether other streams are active. In effect,
- * this constrains exclusive ownership of the managed memory region by
+ * When memory is associated with a single stream, the Unified Memory system
+ * will allow CPU access to this memory region so long as all operations in \p
+ * hStream have completed, regardless of whether other streams are active. In
+ * effect, this constrains exclusive ownership of the managed memory region by
  * an active GPU to per-stream activity instead of whole-GPU activity.
  *
  * Accessing memory on the device from streams that are not associated with
@@ -9359,12 +9900,13 @@ CUresult CUDAAPI cuStreamIsCapturing(CUstream hStream, CUstreamCaptureStatus *ca
  * at all times. Data visibility and coherency will be changed appropriately
  * for all kernels which follow a stream-association change.
  *
- * If \p hStream is destroyed while data is associated with it, the association is
- * removed and the association reverts to the default visibility of the allocation
- * as specified at ::cuMemAllocManaged. For __managed__ variables, the default
- * association is always ::CU_MEM_ATTACH_GLOBAL. Note that destroying a stream is an
- * asynchronous operation, and as a result, the change to default association won't
- * happen until all work in the stream has completed.
+ * If \p hStream is destroyed while data is associated with it, the association
+ * is removed and the association reverts to the default visibility of the
+ * allocation as specified at ::cuMemAllocManaged. For __managed__ variables,
+ * the default association is always ::CU_MEM_ATTACH_GLOBAL. Note that
+ * destroying a stream is an asynchronous operation, and as a result, the change
+ * to default association won't happen until all work in the stream has
+ * completed.
  *
  * \param hStream - Stream in which to enqueue the attach operation
  * \param dptr    - Pointer to memory (must be a pointer to managed memory or
@@ -9391,7 +9933,8 @@ CUresult CUDAAPI cuStreamIsCapturing(CUstream hStream, CUstreamCaptureStatus *ca
  * ::cuMemAllocManaged,
  * ::cudaStreamAttachMemAsync
  */
-CUresult CUDAAPI cuStreamAttachMemAsync(CUstream hStream, CUdeviceptr dptr, size_t length, unsigned int flags);
+CUresult CUDAAPI cuStreamAttachMemAsync(CUstream hStream, CUdeviceptr dptr,
+                                        size_t length, unsigned int flags);
 
 #endif /* __CUDA_API_VERSION >= 6000 */
 
@@ -9488,7 +10031,6 @@ CUresult CUDAAPI cuStreamDestroy(CUstream hStream);
 
 /** @} */ /* END CUDA_STREAM */
 
-
 /**
  * \defgroup CUDA_EVENT Event Management
  *
@@ -9504,13 +10046,13 @@ CUresult CUDAAPI cuStreamDestroy(CUstream hStream);
 /**
  * \brief Creates an event
  *
- * Creates an event *phEvent for the current context with the flags specified via
- * \p Flags. Valid flags include:
+ * Creates an event *phEvent for the current context with the flags specified
+ * via \p Flags. Valid flags include:
  * - ::CU_EVENT_DEFAULT: Default event creation flag.
- * - ::CU_EVENT_BLOCKING_SYNC: Specifies that the created event should use blocking
- *   synchronization.  A CPU thread that uses ::cuEventSynchronize() to wait on
- *   an event created with this flag will block until the event has actually
- *   been recorded.
+ * - ::CU_EVENT_BLOCKING_SYNC: Specifies that the created event should use
+ * blocking synchronization.  A CPU thread that uses ::cuEventSynchronize() to
+ * wait on an event created with this flag will block until the event has
+ * actually been recorded.
  * - ::CU_EVENT_DISABLE_TIMING: Specifies that the created event does not need
  *   to record timing data.  Events created with this flag specified and
  *   the ::CU_EVENT_BLOCKING_SYNC flag not specified will provide the best
@@ -9719,147 +10261,152 @@ CUresult CUDAAPI cuEventDestroy(CUevent hEvent);
  * ::cuEventDestroy,
  * ::cudaEventElapsedTime
  */
-CUresult CUDAAPI cuEventElapsedTime(float *pMilliseconds, CUevent hStart, CUevent hEnd);
+CUresult CUDAAPI cuEventElapsedTime(float *pMilliseconds, CUevent hStart,
+                                    CUevent hEnd);
 
 /** @} */ /* END CUDA_EVENT */
 
 /**
  * \defgroup CUDA_EXTRES_INTEROP External Resource Interoperability
  *
- * ___MANBRIEF___ External resource interoperability functions of the low-level CUDA driver API
+ * ___MANBRIEF___ External resource interoperability functions of the low-level
+ * CUDA driver API
  * (___CURRENT_FILE___) ___ENDMANBRIEF___
  *
- * This section describes the external resource interoperability functions of the low-level CUDA
- * driver application programming interface.
+ * This section describes the external resource interoperability functions of
+ * the low-level CUDA driver application programming interface.
  *
  * @{
  */
 
 #if __CUDA_API_VERSION >= 10000
 
- /**
- * \brief Imports an external memory object
- *
- * Imports an externally allocated memory object and returns
- * a handle to that in \p extMem_out.
- *
- * The properties of the handle being imported must be described in
- * \p memHandleDesc. The ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC structure
- * is defined as follows:
- *
- * \code
-        typedef struct CUDA_EXTERNAL_MEMORY_HANDLE_DESC_st {
-            CUexternalMemoryHandleType type;
-            union {
-                int fd;
-                struct {
-                    void *handle;
-                    const void *name;
-                } win32;
-            } handle;
-            unsigned long long size;
-            unsigned int flags;
-        } CUDA_EXTERNAL_MEMORY_HANDLE_DESC;
- * \endcode
- *
- * where ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::type specifies the type
- * of handle being imported. ::CUexternalMemoryHandleType is
- * defined as:
- *
- * \code
-        typedef enum CUexternalMemoryHandleType_enum {
-            CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD        = 1,
-            CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32     = 2,
-            CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT = 3,
-            CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP       = 4,
-            CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE   = 5
-        } CUexternalMemoryHandleType;
- * \endcode
- *
- * If ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::type is
- * ::CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD, then
- * ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::fd must be a valid
- * file descriptor referencing a memory object. Ownership of
- * the file descriptor is transferred to the CUDA driver when the
- * handle is imported successfully. Performing any operations on the
- * file descriptor after it is imported results in undefined behavior.
- *
- * If ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::type is
- * ::CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32, then exactly one
- * of ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::win32::handle and
- * ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::win32::name must not be
- * NULL. If ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::win32::handle
- * is not NULL, then it must represent a valid shared NT handle that
- * references a memory object. Ownership of this handle is
- * not transferred to CUDA after the import operation, so the
- * application must release the handle using the appropriate system
- * call. If ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::win32::name
- * is not NULL, then it must point to a NULL-terminated array of
- * UTF-16 characters that refers to a memory object.
- *
- * If ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::type is
- * ::CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT, then
- * ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::win32::handle must
- * be non-NULL and
- * ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::win32::name
- * must be NULL. The handle specified must be a globally shared KMT
- * handle. This handle does not hold a reference to the underlying
- * object, and thus will be invalid when all references to the
- * memory object are destroyed.
- *
- * If ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::type is
- * ::CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP, then exactly one
- * of ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::win32::handle and
- * ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::win32::name must not be
- * NULL. If ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::win32::handle
- * is not NULL, then it must represent a valid shared NT handle that
- * is returned by ID3DDevice::CreateSharedHandle when referring to a
- * ID3D12Heap object. This handle holds a reference to the underlying
- * object. If ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::win32::name
- * is not NULL, then it must point to a NULL-terminated array of
- * UTF-16 characters that refers to a ID3D12Heap object.
- *
- * If ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::type is
- * ::CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE, then exactly one
- * of ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::win32::handle and
- * ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::win32::name must not be
- * NULL. If ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::win32::handle
- * is not NULL, then it must represent a valid shared NT handle that
- * is returned by ID3DDevice::CreateSharedHandle when referring to a
- * ID3D12Resource object. This handle holds a reference to the
- * underlying object. If
- * ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::win32::name
- * is not NULL, then it must point to a NULL-terminated array of
- * UTF-16 characters that refers to a ID3D12Resource object.
- *
- * The size of the memory object must be specified in
- * ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::size.
- *
- * Specifying the flag ::CUDA_EXTERNAL_MEMORY_DEDICATED in
- * ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::flags indicates that the
- * resource is a dedicated resource. The definition of what a
- * dedicated resource is outside the scope of this extension.
- *
- * \param extMem_out    - Returned handle to an external memory object
- * \param memHandleDesc - Memory import handle descriptor
- *
- * \return
- * ::CUDA_SUCCESS,
- * ::CUDA_ERROR_NOT_INITIALIZED,
- * ::CUDA_ERROR_INVALID_HANDLE
- * \notefnerr
- *
- * \note If the Vulkan memory imported into CUDA is mapped on the CPU then the
- * application must use vkInvalidateMappedMemoryRanges/vkFlushMappedMemoryRanges
- * as well as appropriate Vulkan pipeline barriers to maintain coherence between
- * CPU and GPU. For more information on these APIs, please refer to "Synchronization
- * and Cache Control" chapter from Vulkan specification.
- *
- * \sa ::cuDestroyExternalMemory,
- * ::cuExternalMemoryGetMappedBuffer,
- * ::cuExternalMemoryGetMappedMipmappedArray
- */
-CUresult CUDAAPI cuImportExternalMemory(CUexternalMemory *extMem_out, const CUDA_EXTERNAL_MEMORY_HANDLE_DESC *memHandleDesc);
+/**
+* \brief Imports an external memory object
+*
+* Imports an externally allocated memory object and returns
+* a handle to that in \p extMem_out.
+*
+* The properties of the handle being imported must be described in
+* \p memHandleDesc. The ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC structure
+* is defined as follows:
+*
+* \code
+       typedef struct CUDA_EXTERNAL_MEMORY_HANDLE_DESC_st {
+           CUexternalMemoryHandleType type;
+           union {
+               int fd;
+               struct {
+                   void *handle;
+                   const void *name;
+               } win32;
+           } handle;
+           unsigned long long size;
+           unsigned int flags;
+       } CUDA_EXTERNAL_MEMORY_HANDLE_DESC;
+* \endcode
+*
+* where ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::type specifies the type
+* of handle being imported. ::CUexternalMemoryHandleType is
+* defined as:
+*
+* \code
+       typedef enum CUexternalMemoryHandleType_enum {
+           CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD        = 1,
+           CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32     = 2,
+           CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT = 3,
+           CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP       = 4,
+           CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE   = 5
+       } CUexternalMemoryHandleType;
+* \endcode
+*
+* If ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::type is
+* ::CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD, then
+* ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::fd must be a valid
+* file descriptor referencing a memory object. Ownership of
+* the file descriptor is transferred to the CUDA driver when the
+* handle is imported successfully. Performing any operations on the
+* file descriptor after it is imported results in undefined behavior.
+*
+* If ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::type is
+* ::CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32, then exactly one
+* of ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::win32::handle and
+* ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::win32::name must not be
+* NULL. If ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::win32::handle
+* is not NULL, then it must represent a valid shared NT handle that
+* references a memory object. Ownership of this handle is
+* not transferred to CUDA after the import operation, so the
+* application must release the handle using the appropriate system
+* call. If ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::win32::name
+* is not NULL, then it must point to a NULL-terminated array of
+* UTF-16 characters that refers to a memory object.
+*
+* If ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::type is
+* ::CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT, then
+* ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::win32::handle must
+* be non-NULL and
+* ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::win32::name
+* must be NULL. The handle specified must be a globally shared KMT
+* handle. This handle does not hold a reference to the underlying
+* object, and thus will be invalid when all references to the
+* memory object are destroyed.
+*
+* If ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::type is
+* ::CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP, then exactly one
+* of ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::win32::handle and
+* ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::win32::name must not be
+* NULL. If ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::win32::handle
+* is not NULL, then it must represent a valid shared NT handle that
+* is returned by ID3DDevice::CreateSharedHandle when referring to a
+* ID3D12Heap object. This handle holds a reference to the underlying
+* object. If ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::win32::name
+* is not NULL, then it must point to a NULL-terminated array of
+* UTF-16 characters that refers to a ID3D12Heap object.
+*
+* If ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::type is
+* ::CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE, then exactly one
+* of ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::win32::handle and
+* ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::win32::name must not be
+* NULL. If ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::win32::handle
+* is not NULL, then it must represent a valid shared NT handle that
+* is returned by ID3DDevice::CreateSharedHandle when referring to a
+* ID3D12Resource object. This handle holds a reference to the
+* underlying object. If
+* ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::handle::win32::name
+* is not NULL, then it must point to a NULL-terminated array of
+* UTF-16 characters that refers to a ID3D12Resource object.
+*
+* The size of the memory object must be specified in
+* ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::size.
+*
+* Specifying the flag ::CUDA_EXTERNAL_MEMORY_DEDICATED in
+* ::CUDA_EXTERNAL_MEMORY_HANDLE_DESC::flags indicates that the
+* resource is a dedicated resource. The definition of what a
+* dedicated resource is outside the scope of this extension.
+*
+* \param extMem_out    - Returned handle to an external memory object
+* \param memHandleDesc - Memory import handle descriptor
+*
+* \return
+* ::CUDA_SUCCESS,
+* ::CUDA_ERROR_NOT_INITIALIZED,
+* ::CUDA_ERROR_INVALID_HANDLE
+* \notefnerr
+*
+* \note If the Vulkan memory imported into CUDA is mapped on the CPU then the
+* application must use vkInvalidateMappedMemoryRanges/vkFlushMappedMemoryRanges
+* as well as appropriate Vulkan pipeline barriers to maintain coherence between
+* CPU and GPU. For more information on these APIs, please refer to
+"Synchronization
+* and Cache Control" chapter from Vulkan specification.
+*
+* \sa ::cuDestroyExternalMemory,
+* ::cuExternalMemoryGetMappedBuffer,
+* ::cuExternalMemoryGetMappedMipmappedArray
+*/
+CUresult CUDAAPI
+cuImportExternalMemory(CUexternalMemory *extMem_out,
+                       const CUDA_EXTERNAL_MEMORY_HANDLE_DESC *memHandleDesc);
 
 /**
  * \brief Maps a buffer onto an imported memory object
@@ -9912,7 +10459,9 @@ CUresult CUDAAPI cuImportExternalMemory(CUexternalMemory *extMem_out, const CUDA
  * ::cuDestroyExternalMemory,
  * ::cuExternalMemoryGetMappedMipmappedArray
  */
-CUresult CUDAAPI cuExternalMemoryGetMappedBuffer(CUdeviceptr *devPtr, CUexternalMemory extMem, const CUDA_EXTERNAL_MEMORY_BUFFER_DESC *bufferDesc);
+CUresult CUDAAPI cuExternalMemoryGetMappedBuffer(
+    CUdeviceptr *devPtr, CUexternalMemory extMem,
+    const CUDA_EXTERNAL_MEMORY_BUFFER_DESC *bufferDesc);
 
 /**
  * \brief Maps a CUDA mipmapped array onto an external memory object
@@ -9945,7 +10494,8 @@ CUresult CUDAAPI cuExternalMemoryGetMappedBuffer(CUdeviceptr *devPtr, CUexternal
  * ::CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC::numLevels specifies
  * the total number of levels in the mipmap chain.
  *
- * The returned CUDA mipmapped array must be freed using ::cuMipmappedArrayDestroy.
+ * The returned CUDA mipmapped array must be freed using
+ ::cuMipmappedArrayDestroy.
  *
  * \param mipmap     - Returned CUDA mipmapped array
  * \param extMem     - Handle to external memory object
@@ -9961,7 +10511,9 @@ CUresult CUDAAPI cuExternalMemoryGetMappedBuffer(CUdeviceptr *devPtr, CUexternal
  * ::cuDestroyExternalMemory,
  * ::cuExternalMemoryGetMappedBuffer
  */
-CUresult CUDAAPI cuExternalMemoryGetMappedMipmappedArray(CUmipmappedArray *mipmap, CUexternalMemory extMem, const CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC *mipmapDesc);
+CUresult CUDAAPI cuExternalMemoryGetMappedMipmappedArray(
+    CUmipmappedArray *mipmap, CUexternalMemory extMem,
+    const CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC *mipmapDesc);
 
 /**
  * \brief Destroys an external memory object.
@@ -10080,7 +10632,9 @@ CUresult CUDAAPI cuDestroyExternalMemory(CUexternalMemory extMem);
  * ::cuSignalExternalSemaphoresAsync,
  * ::cuWaitExternalSemaphoresAsync
  */
-CUresult CUDAAPI cuImportExternalSemaphore(CUexternalSemaphore *extSem_out, const CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC *semHandleDesc);
+CUresult CUDAAPI cuImportExternalSemaphore(
+    CUexternalSemaphore *extSem_out,
+    const CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC *semHandleDesc);
 
 /**
  * \brief Signals a set of external semaphore objects
@@ -10118,7 +10672,10 @@ CUresult CUDAAPI cuImportExternalSemaphore(CUexternalSemaphore *extSem_out, cons
  * ::cuDestroyExternalSemaphore,
  * ::cuWaitExternalSemaphoresAsync
  */
-CUresult CUDAAPI cuSignalExternalSemaphoresAsync(const CUexternalSemaphore *extSemArray, const CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS *paramsArray, unsigned int numExtSems, CUstream stream);
+CUresult CUDAAPI cuSignalExternalSemaphoresAsync(
+    const CUexternalSemaphore *extSemArray,
+    const CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS *paramsArray,
+    unsigned int numExtSems, CUstream stream);
 
 /**
  * \brief Waits on a set of external semaphore objects
@@ -10160,7 +10717,10 @@ CUresult CUDAAPI cuSignalExternalSemaphoresAsync(const CUexternalSemaphore *extS
  * ::cuDestroyExternalSemaphore,
  * ::cuSignalExternalSemaphoresAsync
  */
-CUresult CUDAAPI cuWaitExternalSemaphoresAsync(const CUexternalSemaphore *extSemArray, const CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS *paramsArray, unsigned int numExtSems, CUstream stream);
+CUresult CUDAAPI cuWaitExternalSemaphoresAsync(
+    const CUexternalSemaphore *extSemArray,
+    const CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS *paramsArray,
+    unsigned int numExtSems, CUstream stream);
 
 /**
  * \brief Destroys an external semaphore
@@ -10247,7 +10807,8 @@ CUresult CUDAAPI cuDestroyExternalSemaphore(CUexternalSemaphore extSem);
  * Support for this can be queried with ::cuDeviceGetAttribute() and
  * ::CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS.
  *
- * Support for CU_STREAM_WAIT_VALUE_NOR can be queried with ::cuDeviceGetAttribute() and
+ * Support for CU_STREAM_WAIT_VALUE_NOR can be queried with
+ * ::cuDeviceGetAttribute() and
  * ::CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_WAIT_VALUE_NOR.
  *
  * \param stream The stream to synchronize on the memory location.
@@ -10268,7 +10829,8 @@ CUresult CUDAAPI cuDestroyExternalSemaphore(CUexternalSemaphore extSem);
  * ::cuMemHostRegister,
  * ::cuStreamWaitEvent
  */
-CUresult CUDAAPI cuStreamWaitValue32(CUstream stream, CUdeviceptr addr, cuuint32_t value, unsigned int flags);
+CUresult CUDAAPI cuStreamWaitValue32(CUstream stream, CUdeviceptr addr,
+                                     cuuint32_t value, unsigned int flags);
 
 /**
  * \brief Wait on a memory location
@@ -10303,7 +10865,8 @@ CUresult CUDAAPI cuStreamWaitValue32(CUstream stream, CUdeviceptr addr, cuuint32
  * ::cuMemHostRegister,
  * ::cuStreamWaitEvent
  */
-CUresult CUDAAPI cuStreamWaitValue64(CUstream stream, CUdeviceptr addr, cuuint64_t value, unsigned int flags);
+CUresult CUDAAPI cuStreamWaitValue64(CUstream stream, CUdeviceptr addr,
+                                     cuuint64_t value, unsigned int flags);
 
 /**
  * \brief Write a value to memory
@@ -10338,7 +10901,8 @@ CUresult CUDAAPI cuStreamWaitValue64(CUstream stream, CUdeviceptr addr, cuuint64
  * ::cuMemHostRegister,
  * ::cuEventRecord
  */
-CUresult CUDAAPI cuStreamWriteValue32(CUstream stream, CUdeviceptr addr, cuuint32_t value, unsigned int flags);
+CUresult CUDAAPI cuStreamWriteValue32(CUstream stream, CUdeviceptr addr,
+                                      cuuint32_t value, unsigned int flags);
 
 /**
  * \brief Write a value to memory
@@ -10372,15 +10936,17 @@ CUresult CUDAAPI cuStreamWriteValue32(CUstream stream, CUdeviceptr addr, cuuint3
  * ::cuMemHostRegister,
  * ::cuEventRecord
  */
-CUresult CUDAAPI cuStreamWriteValue64(CUstream stream, CUdeviceptr addr, cuuint64_t value, unsigned int flags);
+CUresult CUDAAPI cuStreamWriteValue64(CUstream stream, CUdeviceptr addr,
+                                      cuuint64_t value, unsigned int flags);
 
 /**
  * \brief Batch operations to synchronize the stream via memory operations
  *
- * This is a batch version of ::cuStreamWaitValue32() and ::cuStreamWriteValue32().
- * Batching operations may avoid some performance overhead in both the API call
- * and the device execution versus adding them to the stream in separate API
- * calls. The operations are enqueued in the order they appear in the array.
+ * This is a batch version of ::cuStreamWaitValue32() and
+ * ::cuStreamWriteValue32(). Batching operations may avoid some performance
+ * overhead in both the API call and the device execution versus adding them to
+ * the stream in separate API calls. The operations are enqueued in the order
+ * they appear in the array.
  *
  * See ::CUstreamBatchMemOpType for the full set of supported operations, and
  * ::cuStreamWaitValue32(), ::cuStreamWaitValue64(), ::cuStreamWriteValue32(),
@@ -10407,7 +10973,9 @@ CUresult CUDAAPI cuStreamWriteValue64(CUstream stream, CUdeviceptr addr, cuuint6
  * ::cuStreamWriteValue64,
  * ::cuMemHostRegister
  */
-CUresult CUDAAPI cuStreamBatchMemOp(CUstream stream, unsigned int count, CUstreamBatchMemOpParams *paramArray, unsigned int flags);
+CUresult CUDAAPI cuStreamBatchMemOp(CUstream stream, unsigned int count,
+                                    CUstreamBatchMemOpParams *paramArray,
+                                    unsigned int flags);
 #endif /* __CUDA_API_VERSION >= 8000 */
 
 /** @} */ /* END CUDA_MEMOP */
@@ -10456,10 +11024,10 @@ CUresult CUDAAPI cuStreamBatchMemOp(CUstream stream, unsigned int count, CUstrea
  *   version.
  * - ::CU_FUNC_CACHE_MODE_CA: The attribute to indicate whether the function has
  *   been compiled with user specified option "-Xptxas --dlcm=ca" set .
- * - ::CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES: The maximum size in bytes of
- *   dynamically-allocated shared memory.
- * - ::CU_FUNC_ATTRIBUTE_PREFERRED_SHARED_MEMORY_CARVEOUT: Preferred shared memory-L1
- *   cache split ratio in percent of total shared memory.
+ * - ::CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES: The maximum size in
+ * bytes of dynamically-allocated shared memory.
+ * - ::CU_FUNC_ATTRIBUTE_PREFERRED_SHARED_MEMORY_CARVEOUT: Preferred shared
+ * memory-L1 cache split ratio in percent of total shared memory.
  *
  * \param pi     - Returned attribute value
  * \param attrib - Attribute requested
@@ -10481,33 +11049,35 @@ CUresult CUDAAPI cuStreamBatchMemOp(CUstream stream, unsigned int count, CUstrea
  * ::cudaFuncGetAttributes
  * ::cudaFuncSetAttribute
  */
-CUresult CUDAAPI cuFuncGetAttribute(int *pi, CUfunction_attribute attrib, CUfunction hfunc);
+CUresult CUDAAPI cuFuncGetAttribute(int *pi, CUfunction_attribute attrib,
+                                    CUfunction hfunc);
 
 #if __CUDA_API_VERSION >= 9000
 
 /**
  * \brief Sets information about a function
  *
- * This call sets the value of a specified attribute \p attrib on the kernel given
- * by \p hfunc to an integer value specified by \p val
- * This function returns CUDA_SUCCESS if the new value of the attribute could be
- * successfully set. If the set fails, this call will return an error.
- * Not all attributes can have values set. Attempting to set a value on a read-only
- * attribute will result in an error (CUDA_ERROR_INVALID_VALUE)
+ * This call sets the value of a specified attribute \p attrib on the kernel
+ * given by \p hfunc to an integer value specified by \p val This function
+ * returns CUDA_SUCCESS if the new value of the attribute could be successfully
+ * set. If the set fails, this call will return an error. Not all attributes can
+ * have values set. Attempting to set a value on a read-only attribute will
+ * result in an error (CUDA_ERROR_INVALID_VALUE)
  *
  * Supported attributes for the cuFuncSetAttribute call are:
- * - ::CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES: This maximum size in bytes of
- *   dynamically-allocated shared memory. The value should contain the requested
- *   maximum size of dynamically-allocated shared memory. The sum of this value and
- *   the function attribute ::CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES cannot exceed the
- *   device attribute ::CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN.
- *   The maximal size of requestable dynamic shared memory may differ by GPU
- *   architecture.
- * - ::CU_FUNC_ATTRIBUTE_PREFERRED_SHARED_MEMORY_CARVEOUT: On devices where the L1
- *   cache and shared memory use the same hardware resources, this sets the shared memory
- *   carveout preference, in percent of the total shared memory.
- *   See ::CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR
- *   This is only a hint, and the driver can choose a different ratio if required to execute the function.
+ * - ::CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES: This maximum size in
+ * bytes of dynamically-allocated shared memory. The value should contain the
+ * requested maximum size of dynamically-allocated shared memory. The sum of
+ * this value and the function attribute ::CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES
+ * cannot exceed the device attribute
+ * ::CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN. The maximal size of
+ * requestable dynamic shared memory may differ by GPU architecture.
+ * - ::CU_FUNC_ATTRIBUTE_PREFERRED_SHARED_MEMORY_CARVEOUT: On devices where the
+ * L1 cache and shared memory use the same hardware resources, this sets the
+ * shared memory carveout preference, in percent of the total shared memory. See
+ * ::CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR This is only a
+ * hint, and the driver can choose a different ratio if required to execute the
+ * function.
  *
  * \param hfunc  - Function to query attribute of
  * \param attrib - Attribute requested
@@ -10529,8 +11099,9 @@ CUresult CUDAAPI cuFuncGetAttribute(int *pi, CUfunction_attribute attrib, CUfunc
  * ::cudaFuncGetAttributes
  * ::cudaFuncSetAttribute
  */
-CUresult CUDAAPI cuFuncSetAttribute(CUfunction hfunc, CUfunction_attribute attrib, int value);
-#endif // __CUDA_API_VERSION >= 9000
+CUresult CUDAAPI cuFuncSetAttribute(CUfunction hfunc,
+                                    CUfunction_attribute attrib, int value);
+#endif  // __CUDA_API_VERSION >= 9000
 
 /**
  * \brief Sets the preferred cache configuration for a device function
@@ -10552,8 +11123,10 @@ CUresult CUDAAPI cuFuncSetAttribute(CUfunction hfunc, CUfunction_attribute attri
  *
  *
  * The supported cache configurations are:
- * - ::CU_FUNC_CACHE_PREFER_NONE: no preference for shared memory or L1 (default)
- * - ::CU_FUNC_CACHE_PREFER_SHARED: prefer larger shared memory and smaller L1 cache
+ * - ::CU_FUNC_CACHE_PREFER_NONE: no preference for shared memory or L1
+ * (default)
+ * - ::CU_FUNC_CACHE_PREFER_SHARED: prefer larger shared memory and smaller L1
+ * cache
  * - ::CU_FUNC_CACHE_PREFER_L1: prefer larger L1 cache and smaller shared memory
  * - ::CU_FUNC_CACHE_PREFER_EQUAL: prefer equal sized L1 cache and shared memory
  *
@@ -10594,9 +11167,9 @@ CUresult CUDAAPI cuFuncSetCacheConfig(CUfunction hfunc, CUfunc_cache config);
  *
  * Changing the shared memory bank size will not increase shared memory usage
  * or affect occupancy of kernels, but may have major effects on performance.
- * Larger bank sizes will allow for greater potential bandwidth to shared memory,
- * but will change what kinds of accesses to shared memory will result in bank
- * conflicts.
+ * Larger bank sizes will allow for greater potential bandwidth to shared
+ * memory, but will change what kinds of accesses to shared memory will result
+ * in bank conflicts.
  *
  * This function will do nothing on devices with fixed shared memory bank size.
  *
@@ -10605,8 +11178,8 @@ CUresult CUDAAPI cuFuncSetCacheConfig(CUfunction hfunc, CUfunc_cache config);
  *   configuration when launching this function.
  * - ::CU_SHARED_MEM_CONFIG_FOUR_BYTE_BANK_SIZE: set shared memory bank width to
  *   be natively four bytes when launching this function.
- * - ::CU_SHARED_MEM_CONFIG_EIGHT_BYTE_BANK_SIZE: set shared memory bank width to
- *   be natively eight bytes when launching this function.
+ * - ::CU_SHARED_MEM_CONFIG_EIGHT_BYTE_BANK_SIZE: set shared memory bank width
+ * to be natively eight bytes when launching this function.
  *
  * \param hfunc  - kernel to be given a shared memory config
  * \param config - requested shared memory configuration
@@ -10627,7 +11200,8 @@ CUresult CUDAAPI cuFuncSetCacheConfig(CUfunction hfunc, CUfunc_cache config);
  * ::cuLaunchKernel,
  * ::cudaFuncSetSharedMemConfig
  */
-CUresult CUDAAPI cuFuncSetSharedMemConfig(CUfunction hfunc, CUsharedconfig config);
+CUresult CUDAAPI cuFuncSetSharedMemConfig(CUfunction hfunc,
+                                          CUsharedconfig config);
 #endif
 
 #if __CUDA_API_VERSION >= 4000
@@ -10742,21 +11316,17 @@ CUresult CUDAAPI cuFuncSetSharedMemConfig(CUfunction hfunc, CUsharedconfig confi
  * ::cuFuncGetAttribute,
  * ::cudaLaunchKernel
  */
-CUresult CUDAAPI cuLaunchKernel(CUfunction f,
-                                unsigned int gridDimX,
-                                unsigned int gridDimY,
-                                unsigned int gridDimZ,
-                                unsigned int blockDimX,
-                                unsigned int blockDimY,
+CUresult CUDAAPI cuLaunchKernel(CUfunction f, unsigned int gridDimX,
+                                unsigned int gridDimY, unsigned int gridDimZ,
+                                unsigned int blockDimX, unsigned int blockDimY,
                                 unsigned int blockDimZ,
-                                unsigned int sharedMemBytes,
-                                CUstream hStream,
-                                void **kernelParams,
-                                void **extra);
+                                unsigned int sharedMemBytes, CUstream hStream,
+                                void **kernelParams, void **extra);
 #endif /* __CUDA_API_VERSION >= 4000 */
 #if __CUDA_API_VERSION >= 9000
 /**
- * \brief Launches a CUDA function where thread blocks can cooperate and synchronize as they execute
+ * \brief Launches a CUDA function where thread blocks can cooperate and
+ * synchronize as they execute
  *
  * Invokes the kernel \p f on a \p gridDimX x \p gridDimY x \p gridDimZ
  * grid of blocks. Each block contains \p blockDimX x \p blockDimY x
@@ -10768,10 +11338,12 @@ CUresult CUDAAPI cuLaunchKernel(CUfunction f,
  * The device on which this kernel is invoked must have a non-zero value for
  * the device attribute ::CU_DEVICE_ATTRIBUTE_COOPERATIVE_LAUNCH.
  *
- * The total number of blocks launched cannot exceed the maximum number of blocks per
- * multiprocessor as returned by ::cuOccupancyMaxActiveBlocksPerMultiprocessor (or
- * ::cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags) times the number of multiprocessors
- * as specified by the device attribute ::CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT.
+ * The total number of blocks launched cannot exceed the maximum number of
+ * blocks per multiprocessor as returned by
+ * ::cuOccupancyMaxActiveBlocksPerMultiprocessor (or
+ * ::cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags) times the number of
+ * multiprocessors as specified by the device attribute
+ * ::CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT.
  *
  * The kernel cannot make use of CUDA dynamic parallelism.
  *
@@ -10786,15 +11358,15 @@ CUresult CUDAAPI cuLaunchKernel(CUfunction f,
  * Calling ::cuLaunchCooperativeKernel() sets persistent function state that is
  * the same as function state set through ::cuLaunchKernel API
  *
- * When the kernel \p f is launched via ::cuLaunchCooperativeKernel(), the previous
- * block shape, shared size and parameter info associated with \p f
- * is overwritten.
+ * When the kernel \p f is launched via ::cuLaunchCooperativeKernel(), the
+ * previous block shape, shared size and parameter info associated with \p f is
+ * overwritten.
  *
- * Note that to use ::cuLaunchCooperativeKernel(), the kernel \p f must either have
- * been compiled with toolchain version 3.2 or later so that it will
+ * Note that to use ::cuLaunchCooperativeKernel(), the kernel \p f must either
+ * have been compiled with toolchain version 3.2 or later so that it will
  * contain kernel parameter information, or have no kernel parameters.
- * If either of these conditions is not met, then ::cuLaunchCooperativeKernel() will
- * return ::CUDA_ERROR_INVALID_IMAGE.
+ * If either of these conditions is not met, then ::cuLaunchCooperativeKernel()
+ * will return ::CUDA_ERROR_INVALID_IMAGE.
  *
  * \param f              - Kernel to launch
  * \param gridDimX       - Width of grid in blocks
@@ -10831,49 +11403,64 @@ CUresult CUDAAPI cuLaunchKernel(CUfunction f,
  * ::cuLaunchCooperativeKernelMultiDevice,
  * ::cudaLaunchCooperativeKernel
  */
-CUresult CUDAAPI cuLaunchCooperativeKernel(CUfunction f,
-                                unsigned int gridDimX,
-                                unsigned int gridDimY,
-                                unsigned int gridDimZ,
-                                unsigned int blockDimX,
-                                unsigned int blockDimY,
-                                unsigned int blockDimZ,
-                                unsigned int sharedMemBytes,
-                                CUstream hStream,
-                                void **kernelParams);
+CUresult CUDAAPI cuLaunchCooperativeKernel(
+    CUfunction f, unsigned int gridDimX, unsigned int gridDimY,
+    unsigned int gridDimZ, unsigned int blockDimX, unsigned int blockDimY,
+    unsigned int blockDimZ, unsigned int sharedMemBytes, CUstream hStream,
+    void **kernelParams);
 
 /**
- * \brief Launches CUDA functions on multiple devices where thread blocks can cooperate and synchronize as they execute
+ * \brief Launches CUDA functions on multiple devices where thread blocks can
+ cooperate and synchronize as they execute
  *
- * Invokes kernels as specified in the \p launchParamsList array where each element
- * of the array specifies all the parameters required to perform a single kernel launch.
- * These kernels can cooperate and synchronize as they execute. The size of the array is
+ * Invokes kernels as specified in the \p launchParamsList array where each
+ element
+ * of the array specifies all the parameters required to perform a single kernel
+ launch.
+ * These kernels can cooperate and synchronize as they execute. The size of the
+ array is
  * specified by \p numDevices.
  *
- * No two kernels can be launched on the same device. All the devices targeted by this
- * multi-device launch must be identical. All devices must have a non-zero value for the
+ * No two kernels can be launched on the same device. All the devices targeted
+ by this
+ * multi-device launch must be identical. All devices must have a non-zero value
+ for the
  * device attribute ::CU_DEVICE_ATTRIBUTE_COOPERATIVE_MULTI_DEVICE_LAUNCH.
  *
- * All kernels launched must be identical with respect to the compiled code. Note that
- * any __device__, __constant__ or __managed__ variables present in the module that owns
- * the kernel launched on each device, are independently instantiated on every device.
- * It is the application's responsiblity to ensure these variables are initialized and
+ * All kernels launched must be identical with respect to the compiled code.
+ Note that
+ * any __device__, __constant__ or __managed__ variables present in the module
+ that owns
+ * the kernel launched on each device, are independently instantiated on every
+ device.
+ * It is the application's responsiblity to ensure these variables are
+ initialized and
  * used appropriately.
  *
- * The size of the grids as specified in blocks, the size of the blocks themselves
- * and the amount of shared memory used by each thread block must also match across
+ * The size of the grids as specified in blocks, the size of the blocks
+ themselves
+ * and the amount of shared memory used by each thread block must also match
+ across
  * all launched kernels.
  *
- * The streams used to launch these kernels must have been created via either ::cuStreamCreate
- * or ::cuStreamCreateWithPriority. The NULL stream or ::CU_STREAM_LEGACY or ::CU_STREAM_PER_THREAD
+ * The streams used to launch these kernels must have been created via either
+ ::cuStreamCreate
+ * or ::cuStreamCreateWithPriority. The NULL stream or ::CU_STREAM_LEGACY or
+ ::CU_STREAM_PER_THREAD
  * cannot be used.
  *
- * The total number of blocks launched per kernel cannot exceed the maximum number of blocks
- * per multiprocessor as returned by ::cuOccupancyMaxActiveBlocksPerMultiprocessor (or
- * ::cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags) times the number of multiprocessors
- * as specified by the device attribute ::CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT. Since the
- * total number of blocks launched per device has to match across all devices, the maximum
- * number of blocks that can be launched per device will be limited by the device with the
+ * The total number of blocks launched per kernel cannot exceed the maximum
+ number of blocks
+ * per multiprocessor as returned by
+ ::cuOccupancyMaxActiveBlocksPerMultiprocessor (or
+ * ::cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags) times the number of
+ multiprocessors
+ * as specified by the device attribute
+ ::CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT. Since the
+ * total number of blocks launched per device has to match across all devices,
+ the maximum
+ * number of blocks that can be launched per device will be limited by the
+ device with the
  * least number of multiprocessors.
  *
  * The kernels cannot make use of CUDA dynamic parallelism.
@@ -10895,56 +11482,87 @@ CUresult CUDAAPI cuLaunchCooperativeKernel(CUfunction f,
         } CUDA_LAUNCH_PARAMS;
  * \endcode
  * where:
- * - ::CUDA_LAUNCH_PARAMS::function specifies the kernel to be launched. All functions must
+ * - ::CUDA_LAUNCH_PARAMS::function specifies the kernel to be launched. All
+ functions must
  *   be identical with respect to the compiled code.
- * - ::CUDA_LAUNCH_PARAMS::gridDimX is the width of the grid in blocks. This must match across
+ * - ::CUDA_LAUNCH_PARAMS::gridDimX is the width of the grid in blocks. This
+ must match across
  *   all kernels launched.
- * - ::CUDA_LAUNCH_PARAMS::gridDimY is the height of the grid in blocks. This must match across
+ * - ::CUDA_LAUNCH_PARAMS::gridDimY is the height of the grid in blocks. This
+ must match across
  *   all kernels launched.
- * - ::CUDA_LAUNCH_PARAMS::gridDimZ is the depth of the grid in blocks. This must match across
+ * - ::CUDA_LAUNCH_PARAMS::gridDimZ is the depth of the grid in blocks. This
+ must match across
  *   all kernels launched.
- * - ::CUDA_LAUNCH_PARAMS::blockDimX is the X dimension of each thread block. This must match across
+ * - ::CUDA_LAUNCH_PARAMS::blockDimX is the X dimension of each thread block.
+ This must match across
  *   all kernels launched.
- * - ::CUDA_LAUNCH_PARAMS::blockDimX is the Y dimension of each thread block. This must match across
+ * - ::CUDA_LAUNCH_PARAMS::blockDimX is the Y dimension of each thread block.
+ This must match across
  *   all kernels launched.
- * - ::CUDA_LAUNCH_PARAMS::blockDimZ is the Z dimension of each thread block. This must match across
+ * - ::CUDA_LAUNCH_PARAMS::blockDimZ is the Z dimension of each thread block.
+ This must match across
  *   all kernels launched.
- * - ::CUDA_LAUNCH_PARAMS::sharedMemBytes is the dynamic shared-memory size per thread block in bytes.
+ * - ::CUDA_LAUNCH_PARAMS::sharedMemBytes is the dynamic shared-memory size per
+ thread block in bytes.
  *   This must match across all kernels launched.
- * - ::CUDA_LAUNCH_PARAMS::hStream is the handle to the stream to perform the launch in. This cannot
- *   be the NULL stream or ::CU_STREAM_LEGACY or ::CU_STREAM_PER_THREAD. The CUDA context associated
- *   with this stream must match that associated with ::CUDA_LAUNCH_PARAMS::function.
- * - ::CUDA_LAUNCH_PARAMS::kernelParams is an array of pointers to kernel parameters. If
- *   ::CUDA_LAUNCH_PARAMS::function has N parameters, then ::CUDA_LAUNCH_PARAMS::kernelParams
- *   needs to be an array of N pointers. Each of ::CUDA_LAUNCH_PARAMS::kernelParams[0] through
- *   ::CUDA_LAUNCH_PARAMS::kernelParams[N-1] must point to a region of memory from which the actual
- *   kernel parameter will be copied. The number of kernel parameters and their offsets and sizes
- *   do not need to be specified as that information is retrieved directly from the kernel's image.
+ * - ::CUDA_LAUNCH_PARAMS::hStream is the handle to the stream to perform the
+ launch in. This cannot
+ *   be the NULL stream or ::CU_STREAM_LEGACY or ::CU_STREAM_PER_THREAD. The
+ CUDA context associated
+ *   with this stream must match that associated with
+ ::CUDA_LAUNCH_PARAMS::function.
+ * - ::CUDA_LAUNCH_PARAMS::kernelParams is an array of pointers to kernel
+ parameters. If
+ *   ::CUDA_LAUNCH_PARAMS::function has N parameters, then
+ ::CUDA_LAUNCH_PARAMS::kernelParams
+ *   needs to be an array of N pointers. Each of
+ ::CUDA_LAUNCH_PARAMS::kernelParams[0] through
+ *   ::CUDA_LAUNCH_PARAMS::kernelParams[N-1] must point to a region of memory
+ from which the actual
+ *   kernel parameter will be copied. The number of kernel parameters and their
+ offsets and sizes
+ *   do not need to be specified as that information is retrieved directly from
+ the kernel's image.
  *
- * By default, the kernel won't begin execution on any GPU until all prior work in all the specified
+ * By default, the kernel won't begin execution on any GPU until all prior work
+ in all the specified
  * streams has completed. This behavior can be overridden by specifying the flag
- * ::CUDA_COOPERATIVE_LAUNCH_MULTI_DEVICE_NO_PRE_LAUNCH_SYNC. When this flag is specified, each kernel
- * will only wait for prior work in the stream corresponding to that GPU to complete before it begins
+ * ::CUDA_COOPERATIVE_LAUNCH_MULTI_DEVICE_NO_PRE_LAUNCH_SYNC. When this flag is
+ specified, each kernel
+ * will only wait for prior work in the stream corresponding to that GPU to
+ complete before it begins
  * execution.
  *
- * Similarly, by default, any subsequent work pushed in any of the specified streams will not begin
- * execution until the kernels on all GPUs have completed. This behavior can be overridden by specifying
- * the flag ::CUDA_COOPERATIVE_LAUNCH_MULTI_DEVICE_NO_POST_LAUNCH_SYNC. When this flag is specified,
- * any subsequent work pushed in any of the specified streams will only wait for the kernel launched
- * on the GPU corresponding to that stream to complete before it begins execution.
+ * Similarly, by default, any subsequent work pushed in any of the specified
+ streams will not begin
+ * execution until the kernels on all GPUs have completed. This behavior can be
+ overridden by specifying
+ * the flag ::CUDA_COOPERATIVE_LAUNCH_MULTI_DEVICE_NO_POST_LAUNCH_SYNC. When
+ this flag is specified,
+ * any subsequent work pushed in any of the specified streams will only wait for
+ the kernel launched
+ * on the GPU corresponding to that stream to complete before it begins
+ execution.
  *
- * Calling ::cuLaunchCooperativeKernelMultiDevice() sets persistent function state that is
- * the same as function state set through ::cuLaunchKernel API when called individually for each
+ * Calling ::cuLaunchCooperativeKernelMultiDevice() sets persistent function
+ state that is
+ * the same as function state set through ::cuLaunchKernel API when called
+ individually for each
  * element in \p launchParamsList.
  *
- * When kernels are launched via ::cuLaunchCooperativeKernelMultiDevice(), the previous
- * block shape, shared size and parameter info associated with each ::CUDA_LAUNCH_PARAMS::function
+ * When kernels are launched via ::cuLaunchCooperativeKernelMultiDevice(), the
+ previous
+ * block shape, shared size and parameter info associated with each
+ ::CUDA_LAUNCH_PARAMS::function
  * in \p launchParamsList is overwritten.
  *
- * Note that to use ::cuLaunchCooperativeKernelMultiDevice(), the kernels must either have
+ * Note that to use ::cuLaunchCooperativeKernelMultiDevice(), the kernels must
+ either have
  * been compiled with toolchain version 3.2 or later so that it will
  * contain kernel parameter information, or have no kernel parameters.
- * If either of these conditions is not met, then ::cuLaunchCooperativeKernelMultiDevice() will
+ * If either of these conditions is not met, then
+ ::cuLaunchCooperativeKernelMultiDevice() will
  * return ::CUDA_ERROR_INVALID_IMAGE.
  *
  * \param launchParamsList - List of launch parameters, one per device
@@ -10975,7 +11593,9 @@ CUresult CUDAAPI cuLaunchCooperativeKernel(CUfunction f,
  * ::cuLaunchCooperativeKernel,
  * ::cudaLaunchCooperativeKernelMultiDevice
  */
-CUresult CUDAAPI cuLaunchCooperativeKernelMultiDevice(CUDA_LAUNCH_PARAMS *launchParamsList, unsigned int numDevices, unsigned int flags);
+CUresult CUDAAPI cuLaunchCooperativeKernelMultiDevice(
+    CUDA_LAUNCH_PARAMS *launchParamsList, unsigned int numDevices,
+    unsigned int flags);
 
 #endif /* __CUDA_API_VERSION >= 9000 */
 
@@ -11022,8 +11642,8 @@ CUresult CUDAAPI cuLaunchCooperativeKernelMultiDevice(CUDA_LAUNCH_PARAMS *launch
  * called in the event of an error in the CUDA context.
  *
  * \param hStream  - Stream to enqueue function call in
- * \param fn       - The function to call once preceding stream operations are complete
- * \param userData - User-specified data to be passed to the function
+ * \param fn       - The function to call once preceding stream operations are
+ * complete \param userData - User-specified data to be passed to the function
  *
  * \return
  * ::CUDA_SUCCESS,
@@ -11044,7 +11664,8 @@ CUresult CUDAAPI cuLaunchCooperativeKernelMultiDevice(CUDA_LAUNCH_PARAMS *launch
  * ::cuStreamAttachMemAsync,
  * ::cuStreamAddCallback
  */
-CUresult CUDAAPI cuLaunchHostFunc(CUstream hStream, CUhostFn fn, void *userData);
+CUresult CUDAAPI cuLaunchHostFunc(CUstream hStream, CUhostFn fn,
+                                  void *userData);
 
 #endif /* __CUDA_API_VERSION >= 10000 */
 
@@ -11096,7 +11717,8 @@ CUresult CUDAAPI cuLaunchHostFunc(CUstream hStream, CUhostFn fn, void *userData)
  * ::cuLaunchGridAsync,
  * ::cuLaunchKernel
  */
-__CUDA_DEPRECATED CUresult CUDAAPI cuFuncSetBlockShape(CUfunction hfunc, int x, int y, int z);
+__CUDA_DEPRECATED CUresult CUDAAPI cuFuncSetBlockShape(CUfunction hfunc, int x,
+                                                       int y, int z);
 
 /**
  * \brief Sets the dynamic shared-memory size for the function
@@ -11130,7 +11752,8 @@ __CUDA_DEPRECATED CUresult CUDAAPI cuFuncSetBlockShape(CUfunction hfunc, int x, 
  * ::cuLaunchGridAsync,
  * ::cuLaunchKernel
  */
-__CUDA_DEPRECATED CUresult CUDAAPI cuFuncSetSharedSize(CUfunction hfunc, unsigned int bytes);
+__CUDA_DEPRECATED CUresult CUDAAPI cuFuncSetSharedSize(CUfunction hfunc,
+                                                       unsigned int bytes);
 
 /**
  * \brief Sets the parameter size for the function
@@ -11162,7 +11785,8 @@ __CUDA_DEPRECATED CUresult CUDAAPI cuFuncSetSharedSize(CUfunction hfunc, unsigne
  * ::cuLaunchGridAsync,
  * ::cuLaunchKernel
  */
-__CUDA_DEPRECATED CUresult CUDAAPI cuParamSetSize(CUfunction hfunc, unsigned int numbytes);
+__CUDA_DEPRECATED CUresult CUDAAPI cuParamSetSize(CUfunction hfunc,
+                                                  unsigned int numbytes);
 
 /**
  * \brief Adds an integer parameter to the function's argument list
@@ -11195,7 +11819,8 @@ __CUDA_DEPRECATED CUresult CUDAAPI cuParamSetSize(CUfunction hfunc, unsigned int
  * ::cuLaunchGridAsync,
  * ::cuLaunchKernel
  */
-__CUDA_DEPRECATED CUresult CUDAAPI cuParamSeti(CUfunction hfunc, int offset, unsigned int value);
+__CUDA_DEPRECATED CUresult CUDAAPI cuParamSeti(CUfunction hfunc, int offset,
+                                               unsigned int value);
 
 /**
  * \brief Adds a floating-point parameter to the function's argument list
@@ -11228,7 +11853,8 @@ __CUDA_DEPRECATED CUresult CUDAAPI cuParamSeti(CUfunction hfunc, int offset, uns
  * ::cuLaunchGridAsync,
  * ::cuLaunchKernel
  */
-__CUDA_DEPRECATED CUresult CUDAAPI cuParamSetf(CUfunction hfunc, int offset, float value);
+__CUDA_DEPRECATED CUresult CUDAAPI cuParamSetf(CUfunction hfunc, int offset,
+                                               float value);
 
 /**
  * \brief Adds arbitrary data to the function's argument list
@@ -11263,7 +11889,9 @@ __CUDA_DEPRECATED CUresult CUDAAPI cuParamSetf(CUfunction hfunc, int offset, flo
  * ::cuLaunchGridAsync,
  * ::cuLaunchKernel
  */
-__CUDA_DEPRECATED CUresult CUDAAPI cuParamSetv(CUfunction hfunc, int offset, void *ptr, unsigned int numbytes);
+__CUDA_DEPRECATED CUresult CUDAAPI cuParamSetv(CUfunction hfunc, int offset,
+                                               void *ptr,
+                                               unsigned int numbytes);
 
 /**
  * \brief Launches a CUDA function
@@ -11339,7 +11967,8 @@ __CUDA_DEPRECATED CUresult CUDAAPI cuLaunch(CUfunction f);
  * ::cuLaunchGridAsync,
  * ::cuLaunchKernel
  */
-__CUDA_DEPRECATED CUresult CUDAAPI cuLaunchGrid(CUfunction f, int grid_width, int grid_height);
+__CUDA_DEPRECATED CUresult CUDAAPI cuLaunchGrid(CUfunction f, int grid_width,
+                                                int grid_height);
 
 /**
  * \brief Launches a CUDA function
@@ -11368,9 +11997,10 @@ __CUDA_DEPRECATED CUresult CUDAAPI cuLaunchGrid(CUfunction f, int grid_width, in
  * ::CUDA_ERROR_LAUNCH_INCOMPATIBLE_TEXTURING,
  * ::CUDA_ERROR_SHARED_OBJECT_INIT_FAILED
  *
- * \note In certain cases where cubins are created with no ABI (i.e., using \p ptxas \p --abi-compile \p no),
- *       this function may serialize kernel launches. In order to force the CUDA driver to retain
- *       asynchronous behavior, set the ::CU_CTX_LMEM_RESIZE_TO_MAX flag during context creation (see ::cuCtxCreate).
+ * \note In certain cases where cubins are created with no ABI (i.e., using \p
+ * ptxas \p --abi-compile \p no), this function may serialize kernel launches.
+ * In order to force the CUDA driver to retain asynchronous behavior, set the
+ * ::CU_CTX_LMEM_RESIZE_TO_MAX flag during context creation (see ::cuCtxCreate).
  *
  * \note_null_stream
  * \notefnerr
@@ -11386,8 +12016,10 @@ __CUDA_DEPRECATED CUresult CUDAAPI cuLaunchGrid(CUfunction f, int grid_width, in
  * ::cuLaunchGrid,
  * ::cuLaunchKernel
  */
-__CUDA_DEPRECATED CUresult CUDAAPI cuLaunchGridAsync(CUfunction f, int grid_width, int grid_height, CUstream hStream);
-
+__CUDA_DEPRECATED CUresult CUDAAPI cuLaunchGridAsync(CUfunction f,
+                                                     int grid_width,
+                                                     int grid_height,
+                                                     CUstream hStream);
 
 /**
  * \brief Adds a texture-reference to the function's argument list
@@ -11411,7 +12043,9 @@ __CUDA_DEPRECATED CUresult CUDAAPI cuLaunchGridAsync(CUfunction f, int grid_widt
  * ::CUDA_ERROR_INVALID_VALUE
  * \notefnerr
  */
-__CUDA_DEPRECATED CUresult CUDAAPI cuParamSetTexRef(CUfunction hfunc, int texunit, CUtexref hTexRef);
+__CUDA_DEPRECATED CUresult CUDAAPI cuParamSetTexRef(CUfunction hfunc,
+                                                    int texunit,
+                                                    CUtexref hTexRef);
 /** @} */ /* END CUDA_EXEC_DEPRECATED */
 
 #if __CUDA_API_VERSION >= 10000
@@ -11463,11 +12097,12 @@ CUresult CUDAAPI cuGraphCreate(CUgraph *phGraph, unsigned int flags);
 /**
  * \brief Creates a kernel execution node and adds it to a graph
  *
- * Creates a new kernel execution node and adds it to \p hGraph with \p numDependencies
- * dependencies specified via \p dependencies and arguments specified in \p nodeParams.
- * It is possible for \p numDependencies to be 0, in which case the node will be placed
- * at the root of the graph. \p dependencies may not have any duplicate entries.
- * A handle to the new node will be returned in \p phGraphNode.
+ * Creates a new kernel execution node and adds it to \p hGraph with \p
+ * numDependencies dependencies specified via \p dependencies and arguments
+ * specified in \p nodeParams. It is possible for \p numDependencies to be 0, in
+ * which case the node will be placed at the root of the graph. \p dependencies
+ * may not have any duplicate entries. A handle to the new node will be returned
+ * in \p phGraphNode.
  *
  * The CUDA_KERNEL_NODE_PARAMS structure is defined as:
  *
@@ -11486,8 +12121,8 @@ CUresult CUDAAPI cuGraphCreate(CUgraph *phGraph, unsigned int flags);
  *  } CUDA_KERNEL_NODE_PARAMS;
  * \endcode
  *
- * When the graph is launched, the node will invoke kernel \p func on a (\p gridDimX x
- * \p gridDimY x \p gridDimZ) grid of blocks. Each block contains
+ * When the graph is launched, the node will invoke kernel \p func on a (\p
+ * gridDimX x \p gridDimY x \p gridDimZ) grid of blocks. Each block contains
  * (\p blockDimX x \p blockDimY x \p blockDimZ) threads.
  *
  * \p sharedMemBytes sets the amount of dynamic shared memory that will be
@@ -11495,19 +12130,21 @@ CUresult CUDAAPI cuGraphCreate(CUgraph *phGraph, unsigned int flags);
  *
  * Kernel parameters to \p func can be specified in one of two ways:
  *
- * 1) Kernel parameters can be specified via \p kernelParams. If the kernel has N
- * parameters, then \p kernelParams needs to be an array of N pointers. Each pointer,
- * from \p kernelParams[0] to \p kernelParams[N-1], points to the region of memory from which the actual
- * parameter will be copied. The number of kernel parameters and their offsets and sizes do not need
- * to be specified as that information is retrieved directly from the kernel's image.
+ * 1) Kernel parameters can be specified via \p kernelParams. If the kernel has
+ * N parameters, then \p kernelParams needs to be an array of N pointers. Each
+ * pointer, from \p kernelParams[0] to \p kernelParams[N-1], points to the
+ * region of memory from which the actual parameter will be copied. The number
+ * of kernel parameters and their offsets and sizes do not need to be specified
+ * as that information is retrieved directly from the kernel's image.
  *
- * 2) Kernel parameters can also be packaged by the application into a single buffer that is passed in
- * via \p extra. This places the burden on the application of knowing each kernel
- * parameter's size and alignment/padding within the buffer. The \p extra parameter exists
- * to allow this function to take additional less commonly used arguments. \p extra specifies
- * a list of names of extra settings and their corresponding values. Each extra setting name is
- * immediately followed by the corresponding value. The list must be terminated with either NULL or
- * CU_LAUNCH_PARAM_END.
+ * 2) Kernel parameters can also be packaged by the application into a single
+ * buffer that is passed in via \p extra. This places the burden on the
+ * application of knowing each kernel parameter's size and alignment/padding
+ * within the buffer. The \p extra parameter exists to allow this function to
+ * take additional less commonly used arguments. \p extra specifies a list of
+ * names of extra settings and their corresponding values. Each extra setting
+ * name is immediately followed by the corresponding value. The list must be
+ * terminated with either NULL or CU_LAUNCH_PARAM_END.
  *
  * - ::CU_LAUNCH_PARAM_END, which indicates the end of the \p extra
  *   array;
@@ -11520,16 +12157,17 @@ CUresult CUDAAPI cuGraphCreate(CUgraph *phGraph, unsigned int flags);
  *   containing the size of the buffer specified with
  *   ::CU_LAUNCH_PARAM_BUFFER_POINTER;
  *
- * The error ::CUDA_ERROR_INVALID_VALUE will be returned if kernel parameters are specified with both
- * \p kernelParams and \p extra (i.e. both \p kernelParams and
- * \p extra are non-NULL).
+ * The error ::CUDA_ERROR_INVALID_VALUE will be returned if kernel parameters
+ * are specified with both \p kernelParams and \p extra (i.e. both \p
+ * kernelParams and \p extra are non-NULL).
  *
- * The \p kernelParams or \p extra array, as well as the argument values it points to,
- * are copied during this call.
+ * The \p kernelParams or \p extra array, as well as the argument values it
+ * points to, are copied during this call.
  *
- * \note Kernels launched using graphs must not use texture and surface references. Reading or
- *       writing through any texture or surface reference is undefined behavior.
- *       This restriction does not apply to texture and surface objects.
+ * \note Kernels launched using graphs must not use texture and surface
+ * references. Reading or writing through any texture or surface reference is
+ * undefined behavior. This restriction does not apply to texture and surface
+ * objects.
  *
  * \param phGraphNode     - Returns newly created node
  * \param hGraph          - Graph to which to add the node
@@ -11557,7 +12195,9 @@ CUresult CUDAAPI cuGraphCreate(CUgraph *phGraph, unsigned int flags);
  * ::cuGraphAddMemcpyNode,
  * ::cuGraphAddMemsetNode
  */
-CUresult CUDAAPI cuGraphAddKernelNode(CUgraphNode *phGraphNode, CUgraph hGraph, const CUgraphNode *dependencies, size_t numDependencies, const CUDA_KERNEL_NODE_PARAMS *nodeParams);
+CUresult CUDAAPI cuGraphAddKernelNode(
+    CUgraphNode *phGraphNode, CUgraph hGraph, const CUgraphNode *dependencies,
+    size_t numDependencies, const CUDA_KERNEL_NODE_PARAMS *nodeParams);
 
 /**
  * \brief Returns a kernel node's parameters
@@ -11589,7 +12229,8 @@ CUresult CUDAAPI cuGraphAddKernelNode(CUgraphNode *phGraphNode, CUgraph hGraph, 
  * ::cuGraphAddKernelNode,
  * ::cuGraphKernelNodeSetParams
  */
-CUresult CUDAAPI cuGraphKernelNodeGetParams(CUgraphNode hNode, CUDA_KERNEL_NODE_PARAMS *nodeParams);
+CUresult CUDAAPI cuGraphKernelNodeGetParams(
+    CUgraphNode hNode, CUDA_KERNEL_NODE_PARAMS *nodeParams);
 
 /**
  * \brief Sets a kernel node's parameters
@@ -11612,26 +12253,30 @@ CUresult CUDAAPI cuGraphKernelNodeGetParams(CUgraphNode hNode, CUDA_KERNEL_NODE_
  * ::cuGraphAddKernelNode,
  * ::cuGraphKernelNodeGetParams
  */
-CUresult CUDAAPI cuGraphKernelNodeSetParams(CUgraphNode hNode, const CUDA_KERNEL_NODE_PARAMS *nodeParams);
+CUresult CUDAAPI cuGraphKernelNodeSetParams(
+    CUgraphNode hNode, const CUDA_KERNEL_NODE_PARAMS *nodeParams);
 
 /**
  * \brief Creates a memcpy node and adds it to a graph
  *
  * Creates a new memcpy node and adds it to \p hGraph with \p numDependencies
  * dependencies specified via \p dependencies.
- * It is possible for \p numDependencies to be 0, in which case the node will be placed
- * at the root of the graph. \p dependencies may not have any duplicate entries.
- * A handle to the new node will be returned in \p phGraphNode.
+ * It is possible for \p numDependencies to be 0, in which case the node will be
+ * placed at the root of the graph. \p dependencies may not have any duplicate
+ * entries. A handle to the new node will be returned in \p phGraphNode.
  *
- * When the graph is launched, the node will perform the memcpy described by \p copyParams.
- * See ::cuMemcpy3D() for a description of the structure and its restrictions.
+ * When the graph is launched, the node will perform the memcpy described by \p
+ * copyParams. See ::cuMemcpy3D() for a description of the structure and its
+ * restrictions.
  *
- * Memcpy nodes have some additional restrictions with regards to managed memory, if the
- * system contains at least one device which has a zero value for the device attribute
- * ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS. If one or more of the operands refer
- * to managed memory, then using the memory type ::CU_MEMORYTYPE_UNIFIED is disallowed
- * for those operand(s). The managed memory will be treated as residing on either the
- * host or the device, depending on which memory type is specified.
+ * Memcpy nodes have some additional restrictions with regards to managed
+ * memory, if the system contains at least one device which has a zero value for
+ * the device attribute
+ * ::CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS. If one or more of the
+ * operands refer to managed memory, then using the memory type
+ * ::CU_MEMORYTYPE_UNIFIED is disallowed for those operand(s). The managed
+ * memory will be treated as residing on either the host or the device,
+ * depending on which memory type is specified.
  *
  * \param phGraphNode     - Returns newly created node
  * \param hGraph          - Graph to which to add the node
@@ -11660,7 +12305,11 @@ CUresult CUDAAPI cuGraphKernelNodeSetParams(CUgraphNode hNode, const CUDA_KERNEL
  * ::cuGraphAddHostNode,
  * ::cuGraphAddMemsetNode
  */
-CUresult CUDAAPI cuGraphAddMemcpyNode(CUgraphNode *phGraphNode, CUgraph hGraph, const CUgraphNode *dependencies, size_t numDependencies, const CUDA_MEMCPY3D *copyParams, CUcontext ctx);
+CUresult CUDAAPI cuGraphAddMemcpyNode(CUgraphNode *phGraphNode, CUgraph hGraph,
+                                      const CUgraphNode *dependencies,
+                                      size_t numDependencies,
+                                      const CUDA_MEMCPY3D *copyParams,
+                                      CUcontext ctx);
 
 /**
  * \brief Returns a memcpy node's parameters
@@ -11683,7 +12332,8 @@ CUresult CUDAAPI cuGraphAddMemcpyNode(CUgraphNode *phGraphNode, CUgraph hGraph, 
  * ::cuGraphAddMemcpyNode,
  * ::cuGraphMemcpyNodeSetParams
  */
-CUresult CUDAAPI cuGraphMemcpyNodeGetParams(CUgraphNode hNode, CUDA_MEMCPY3D *nodeParams);
+CUresult CUDAAPI cuGraphMemcpyNodeGetParams(CUgraphNode hNode,
+                                            CUDA_MEMCPY3D *nodeParams);
 
 /**
  * \brief Sets a memcpy node's parameters
@@ -11706,19 +12356,21 @@ CUresult CUDAAPI cuGraphMemcpyNodeGetParams(CUgraphNode hNode, CUDA_MEMCPY3D *no
  * ::cuGraphAddMemcpyNode,
  * ::cuGraphMemcpyNodeGetParams
  */
-CUresult CUDAAPI cuGraphMemcpyNodeSetParams(CUgraphNode hNode, const CUDA_MEMCPY3D *nodeParams);
+CUresult CUDAAPI cuGraphMemcpyNodeSetParams(CUgraphNode hNode,
+                                            const CUDA_MEMCPY3D *nodeParams);
 
 /**
  * \brief Creates a memset node and adds it to a graph
  *
  * Creates a new memset node and adds it to \p hGraph with \p numDependencies
  * dependencies specified via \p dependencies.
- * It is possible for \p numDependencies to be 0, in which case the node will be placed
- * at the root of the graph. \p dependencies may not have any duplicate entries.
- * A handle to the new node will be returned in \p phGraphNode.
+ * It is possible for \p numDependencies to be 0, in which case the node will be
+ * placed at the root of the graph. \p dependencies may not have any duplicate
+ * entries. A handle to the new node will be returned in \p phGraphNode.
  *
  * The element size must be 1, 2, or 4 bytes.
- * When the graph is launched, the node will perform the memset described by \p memsetParams.
+ * When the graph is launched, the node will perform the memset described by \p
+ * memsetParams.
  *
  * \param phGraphNode     - Returns newly created node
  * \param hGraph          - Graph to which to add the node
@@ -11748,7 +12400,10 @@ CUresult CUDAAPI cuGraphMemcpyNodeSetParams(CUgraphNode hNode, const CUDA_MEMCPY
  * ::cuGraphAddHostNode,
  * ::cuGraphAddMemcpyNode
  */
-CUresult CUDAAPI cuGraphAddMemsetNode(CUgraphNode *phGraphNode, CUgraph hGraph, const CUgraphNode *dependencies, size_t numDependencies, const CUDA_MEMSET_NODE_PARAMS *memsetParams, CUcontext ctx);
+CUresult CUDAAPI cuGraphAddMemsetNode(
+    CUgraphNode *phGraphNode, CUgraph hGraph, const CUgraphNode *dependencies,
+    size_t numDependencies, const CUDA_MEMSET_NODE_PARAMS *memsetParams,
+    CUcontext ctx);
 
 /**
  * \brief Returns a memset node's parameters
@@ -11771,7 +12426,8 @@ CUresult CUDAAPI cuGraphAddMemsetNode(CUgraphNode *phGraphNode, CUgraph hGraph, 
  * ::cuGraphAddMemsetNode,
  * ::cuGraphMemsetNodeSetParams
  */
-CUresult CUDAAPI cuGraphMemsetNodeGetParams(CUgraphNode hNode, CUDA_MEMSET_NODE_PARAMS *nodeParams);
+CUresult CUDAAPI cuGraphMemsetNodeGetParams(
+    CUgraphNode hNode, CUDA_MEMSET_NODE_PARAMS *nodeParams);
 
 /**
  * \brief Sets a memset node's parameters
@@ -11794,16 +12450,18 @@ CUresult CUDAAPI cuGraphMemsetNodeGetParams(CUgraphNode hNode, CUDA_MEMSET_NODE_
  * ::cuGraphAddMemsetNode,
  * ::cuGraphMemsetNodeGetParams
  */
-CUresult CUDAAPI cuGraphMemsetNodeSetParams(CUgraphNode hNode, const CUDA_MEMSET_NODE_PARAMS *nodeParams);
+CUresult CUDAAPI cuGraphMemsetNodeSetParams(
+    CUgraphNode hNode, const CUDA_MEMSET_NODE_PARAMS *nodeParams);
 
 /**
  * \brief Creates a host execution node and adds it to a graph
  *
- * Creates a new CPU execution node and adds it to \p hGraph with \p numDependencies
- * dependencies specified via \p dependencies and arguments specified in \p nodeParams.
- * It is possible for \p numDependencies to be 0, in which case the node will be placed
- * at the root of the graph. \p dependencies may not have any duplicate entries.
- * A handle to the new node will be returned in \p phGraphNode.
+ * Creates a new CPU execution node and adds it to \p hGraph with \p
+ * numDependencies dependencies specified via \p dependencies and arguments
+ * specified in \p nodeParams. It is possible for \p numDependencies to be 0, in
+ * which case the node will be placed at the root of the graph. \p dependencies
+ * may not have any duplicate entries. A handle to the new node will be returned
+ * in \p phGraphNode.
  *
  * When the graph is launched, the node will invoke the specified CPU function.
  * Host nodes are not supported under MPS with pre-Volta GPUs.
@@ -11835,7 +12493,10 @@ CUresult CUDAAPI cuGraphMemsetNodeSetParams(CUgraphNode hNode, const CUDA_MEMSET
  * ::cuGraphAddMemcpyNode,
  * ::cuGraphAddMemsetNode
  */
-CUresult CUDAAPI cuGraphAddHostNode(CUgraphNode *phGraphNode, CUgraph hGraph, const CUgraphNode *dependencies, size_t numDependencies, const CUDA_HOST_NODE_PARAMS *nodeParams);
+CUresult CUDAAPI cuGraphAddHostNode(CUgraphNode *phGraphNode, CUgraph hGraph,
+                                    const CUgraphNode *dependencies,
+                                    size_t numDependencies,
+                                    const CUDA_HOST_NODE_PARAMS *nodeParams);
 
 /**
  * \brief Returns a host node's parameters
@@ -11858,7 +12519,8 @@ CUresult CUDAAPI cuGraphAddHostNode(CUgraphNode *phGraphNode, CUgraph hGraph, co
  * ::cuGraphAddHostNode,
  * ::cuGraphHostNodeSetParams
  */
-CUresult CUDAAPI cuGraphHostNodeGetParams(CUgraphNode hNode, CUDA_HOST_NODE_PARAMS *nodeParams);
+CUresult CUDAAPI cuGraphHostNodeGetParams(CUgraphNode hNode,
+                                          CUDA_HOST_NODE_PARAMS *nodeParams);
 
 /**
  * \brief Sets a host node's parameters
@@ -11881,18 +12543,20 @@ CUresult CUDAAPI cuGraphHostNodeGetParams(CUgraphNode hNode, CUDA_HOST_NODE_PARA
  * ::cuGraphAddHostNode,
  * ::cuGraphHostNodeGetParams
  */
-CUresult CUDAAPI cuGraphHostNodeSetParams(CUgraphNode hNode, const CUDA_HOST_NODE_PARAMS *nodeParams);
+CUresult CUDAAPI cuGraphHostNodeSetParams(
+    CUgraphNode hNode, const CUDA_HOST_NODE_PARAMS *nodeParams);
 
 /**
  * \brief Creates a child graph node and adds it to a graph
  *
- * Creates a new node which executes an embedded graph, and adds it to \p hGraph with
- * \p numDependencies dependencies specified via \p dependencies.
- * It is possible for \p numDependencies to be 0, in which case the node will be placed
- * at the root of the graph. \p dependencies may not have any duplicate entries.
- * A handle to the new node will be returned in \p phGraphNode.
+ * Creates a new node which executes an embedded graph, and adds it to \p hGraph
+ * with \p numDependencies dependencies specified via \p dependencies. It is
+ * possible for \p numDependencies to be 0, in which case the node will be
+ * placed at the root of the graph. \p dependencies may not have any duplicate
+ * entries. A handle to the new node will be returned in \p phGraphNode.
  *
- * The node executes an embedded child graph. The child graph is cloned in this call.
+ * The node executes an embedded child graph. The child graph is cloned in this
+ * call.
  *
  * \param phGraphNode     - Returns newly created node
  * \param hGraph          - Graph to which to add the node
@@ -11919,7 +12583,11 @@ CUresult CUDAAPI cuGraphHostNodeSetParams(CUgraphNode hNode, const CUDA_HOST_NOD
  * ::cuGraphAddMemsetNode,
  * ::cuGraphClone
  */
-CUresult CUDAAPI cuGraphAddChildGraphNode(CUgraphNode *phGraphNode, CUgraph hGraph, const CUgraphNode *dependencies, size_t numDependencies, CUgraph childGraph);
+CUresult CUDAAPI cuGraphAddChildGraphNode(CUgraphNode *phGraphNode,
+                                          CUgraph hGraph,
+                                          const CUgraphNode *dependencies,
+                                          size_t numDependencies,
+                                          CUgraph childGraph);
 
 /**
  * \brief Gets a handle to the embedded graph of a child graph node
@@ -11943,16 +12611,17 @@ CUresult CUDAAPI cuGraphAddChildGraphNode(CUgraphNode *phGraphNode, CUgraph hGra
  * ::cuGraphAddChildGraphNode,
  * ::cuGraphNodeFindInClone
  */
-CUresult CUDAAPI cuGraphChildGraphNodeGetGraph(CUgraphNode hNode, CUgraph *phGraph);
+CUresult CUDAAPI cuGraphChildGraphNodeGetGraph(CUgraphNode hNode,
+                                               CUgraph *phGraph);
 
 /**
  * \brief Creates an empty node and adds it to a graph
  *
  * Creates a new node which performs no operation, and adds it to \p hGraph with
  * \p numDependencies dependencies specified via \p dependencies.
- * It is possible for \p numDependencies to be 0, in which case the node will be placed
- * at the root of the graph. \p dependencies may not have any duplicate entries.
- * A handle to the new node will be returned in \p phGraphNode.
+ * It is possible for \p numDependencies to be 0, in which case the node will be
+ * placed at the root of the graph. \p dependencies may not have any duplicate
+ * entries. A handle to the new node will be returned in \p phGraphNode.
  *
  * An empty node performs no operation during execution, but can be used for
  * transitive ordering. For example, a phased execution graph with 2 groups of n
@@ -11981,16 +12650,19 @@ CUresult CUDAAPI cuGraphChildGraphNodeGetGraph(CUgraphNode hNode, CUgraph *phGra
  * ::cuGraphAddMemcpyNode,
  * ::cuGraphAddMemsetNode
  */
-CUresult CUDAAPI cuGraphAddEmptyNode(CUgraphNode *phGraphNode, CUgraph hGraph, const CUgraphNode *dependencies, size_t numDependencies);
+CUresult CUDAAPI cuGraphAddEmptyNode(CUgraphNode *phGraphNode, CUgraph hGraph,
+                                     const CUgraphNode *dependencies,
+                                     size_t numDependencies);
 
 /**
  * \brief Clones a graph
  *
- * This function creates a copy of \p originalGraph and returns it in \p * phGraphClone.
- * All parameters are copied into the cloned graph. The original graph may be modified
- * after this call without affecting the clone.
+ * This function creates a copy of \p originalGraph and returns it in \p *
+ * phGraphClone. All parameters are copied into the cloned graph. The original
+ * graph may be modified after this call without affecting the clone.
  *
- * Child graph nodes in the original graph are recursively copied into the clone.
+ * Child graph nodes in the original graph are recursively copied into the
+ * clone.
  *
  * \param phGraphClone  - Returns newly created cloned graph
  * \param originalGraph - Graph to clone
@@ -12011,13 +12683,14 @@ CUresult CUDAAPI cuGraphClone(CUgraph *phGraphClone, CUgraph originalGraph);
 /**
  * \brief Finds a cloned version of a node
  *
- * This function returns the node in \p hClonedGraph corresponding to \p hOriginalNode
- * in the original graph.
+ * This function returns the node in \p hClonedGraph corresponding to \p
+ * hOriginalNode in the original graph.
  *
- * \p hClonedGraph must have been cloned from \p hOriginalGraph via ::cuGraphClone.
- * \p hOriginalNode must have been in \p hOriginalGraph at the time of the call to
- * ::cuGraphClone, and the corresponding cloned node in \p hClonedGraph must not have
- * been removed. The cloned node is then returned via \p phClonedNode.
+ * \p hClonedGraph must have been cloned from \p hOriginalGraph via
+ * ::cuGraphClone. \p hOriginalNode must have been in \p hOriginalGraph at the
+ * time of the call to
+ * ::cuGraphClone, and the corresponding cloned node in \p hClonedGraph must not
+ * have been removed. The cloned node is then returned via \p phClonedNode.
  *
  * \param phNode  - Returns handle to the cloned node
  * \param hOriginalNode - Handle to the original node
@@ -12032,7 +12705,9 @@ CUresult CUDAAPI cuGraphClone(CUgraph *phGraphClone, CUgraph originalGraph);
  * \sa
  * ::cuGraphClone
  */
-CUresult CUDAAPI cuGraphNodeFindInClone(CUgraphNode *phNode, CUgraphNode hOriginalNode, CUgraph hClonedGraph);
+CUresult CUDAAPI cuGraphNodeFindInClone(CUgraphNode *phNode,
+                                        CUgraphNode hOriginalNode,
+                                        CUgraph hClonedGraph);
 
 /**
  * \brief Returns a node's type
@@ -12070,9 +12745,10 @@ CUresult CUDAAPI cuGraphNodeGetType(CUgraphNode hNode, CUgraphNodeType *type);
  *
  * Returns a list of \p hGraph's nodes. \p nodes may be NULL, in which case this
  * function will return the number of nodes in \p numNodes. Otherwise,
- * \p numNodes entries will be filled in. If \p numNodes is higher than the actual
- * number of nodes, the remaining entries in \p nodes will be set to NULL, and the
- * number of nodes actually obtained will be returned in \p numNodes.
+ * \p numNodes entries will be filled in. If \p numNodes is higher than the
+ * actual number of nodes, the remaining entries in \p nodes will be set to
+ * NULL, and the number of nodes actually obtained will be returned in \p
+ * numNodes.
  *
  * \param hGraph   - Graph to query
  * \param nodes    - Pointer to return the nodes
@@ -12094,16 +12770,18 @@ CUresult CUDAAPI cuGraphNodeGetType(CUgraphNode hNode, CUgraphNodeType *type);
  * ::cuGraphNodeGetDependencies,
  * ::cuGraphNodeGetDependentNodes
  */
-CUresult CUDAAPI cuGraphGetNodes(CUgraph hGraph, CUgraphNode *nodes, size_t *numNodes);
+CUresult CUDAAPI cuGraphGetNodes(CUgraph hGraph, CUgraphNode *nodes,
+                                 size_t *numNodes);
 
 /**
  * \brief Returns a graph's root nodes
  *
- * Returns a list of \p hGraph's root nodes. \p rootNodes may be NULL, in which case this
- * function will return the number of root nodes in \p numRootNodes. Otherwise,
- * \p numRootNodes entries will be filled in. If \p numRootNodes is higher than the actual
- * number of root nodes, the remaining entries in \p rootNodes will be set to NULL, and the
- * number of nodes actually obtained will be returned in \p numRootNodes.
+ * Returns a list of \p hGraph's root nodes. \p rootNodes may be NULL, in which
+ * case this function will return the number of root nodes in \p numRootNodes.
+ * Otherwise, \p numRootNodes entries will be filled in. If \p numRootNodes is
+ * higher than the actual number of root nodes, the remaining entries in \p
+ * rootNodes will be set to NULL, and the number of nodes actually obtained will
+ * be returned in \p numRootNodes.
  *
  * \param hGraph       - Graph to query
  * \param rootNodes    - Pointer to return the root nodes
@@ -12125,18 +12803,20 @@ CUresult CUDAAPI cuGraphGetNodes(CUgraph hGraph, CUgraphNode *nodes, size_t *num
  * ::cuGraphNodeGetDependencies,
  * ::cuGraphNodeGetDependentNodes
  */
-CUresult CUDAAPI cuGraphGetRootNodes(CUgraph hGraph, CUgraphNode *rootNodes, size_t *numRootNodes);
+CUresult CUDAAPI cuGraphGetRootNodes(CUgraph hGraph, CUgraphNode *rootNodes,
+                                     size_t *numRootNodes);
 
 /**
  * \brief Returns a graph's dependency edges
  *
- * Returns a list of \p hGraph's dependency edges. Edges are returned via corresponding
- * indices in \p from and \p to; that is, the node in \p to[i] has a dependency on the
- * node in \p from[i]. \p from and \p to may both be NULL, in which
- * case this function only returns the number of edges in \p numEdges. Otherwise,
- * \p numEdges entries will be filled in. If \p numEdges is higher than the actual
- * number of edges, the remaining entries in \p from and \p to will be set to NULL, and
- * the number of edges actually returned will be written to \p numEdges.
+ * Returns a list of \p hGraph's dependency edges. Edges are returned via
+ * corresponding indices in \p from and \p to; that is, the node in \p to[i] has
+ * a dependency on the node in \p from[i]. \p from and \p to may both be NULL,
+ * in which case this function only returns the number of edges in \p numEdges.
+ * Otherwise, \p numEdges entries will be filled in. If \p numEdges is higher
+ * than the actual number of edges, the remaining entries in \p from and \p to
+ * will be set to NULL, and the number of edges actually returned will be
+ * written to \p numEdges.
  *
  * \param hGraph   - Graph to get the edges from
  * \param from     - Location to return edge endpoints
@@ -12159,16 +12839,18 @@ CUresult CUDAAPI cuGraphGetRootNodes(CUgraph hGraph, CUgraphNode *rootNodes, siz
  * ::cuGraphNodeGetDependencies,
  * ::cuGraphNodeGetDependentNodes
  */
-CUresult CUDAAPI cuGraphGetEdges(CUgraph hGraph, CUgraphNode *from, CUgraphNode *to, size_t *numEdges);
+CUresult CUDAAPI cuGraphGetEdges(CUgraph hGraph, CUgraphNode *from,
+                                 CUgraphNode *to, size_t *numEdges);
 
 /**
  * \brief Returns a node's dependencies
  *
- * Returns a list of \p node's dependencies. \p dependencies may be NULL, in which case this
- * function will return the number of dependencies in \p numDependencies. Otherwise,
- * \p numDependencies entries will be filled in. If \p numDependencies is higher than the actual
- * number of dependencies, the remaining entries in \p dependencies will be set to NULL, and the
- * number of nodes actually obtained will be returned in \p numDependencies.
+ * Returns a list of \p node's dependencies. \p dependencies may be NULL, in
+ * which case this function will return the number of dependencies in \p
+ * numDependencies. Otherwise, \p numDependencies entries will be filled in. If
+ * \p numDependencies is higher than the actual number of dependencies, the
+ * remaining entries in \p dependencies will be set to NULL, and the number of
+ * nodes actually obtained will be returned in \p numDependencies.
  *
  * \param hNode           - Node to query
  * \param dependencies    - Pointer to return the dependencies
@@ -12190,17 +12872,19 @@ CUresult CUDAAPI cuGraphGetEdges(CUgraph hGraph, CUgraphNode *from, CUgraphNode 
  * ::cuGraphAddDependencies,
  * ::cuGraphRemoveDependencies
  */
-CUresult CUDAAPI cuGraphNodeGetDependencies(CUgraphNode hNode, CUgraphNode *dependencies, size_t *numDependencies);
+CUresult CUDAAPI cuGraphNodeGetDependencies(CUgraphNode hNode,
+                                            CUgraphNode *dependencies,
+                                            size_t *numDependencies);
 
 /**
  * \brief Returns a node's dependent nodes
  *
- * Returns a list of \p node's dependent nodes. \p dependentNodes may be NULL, in which
- * case this function will return the number of dependent nodes in \p numDependentNodes.
- * Otherwise, \p numDependentNodes entries will be filled in. If \p numDependentNodes is
- * higher than the actual number of dependent nodes, the remaining entries in
- * \p dependentNodes will be set to NULL, and the number of nodes actually obtained will
- * be returned in \p numDependentNodes.
+ * Returns a list of \p node's dependent nodes. \p dependentNodes may be NULL,
+ * in which case this function will return the number of dependent nodes in \p
+ * numDependentNodes. Otherwise, \p numDependentNodes entries will be filled in.
+ * If \p numDependentNodes is higher than the actual number of dependent nodes,
+ * the remaining entries in \p dependentNodes will be set to NULL, and the
+ * number of nodes actually obtained will be returned in \p numDependentNodes.
  *
  * \param hNode             - Node to query
  * \param dependentNodes    - Pointer to return the dependent nodes
@@ -12222,7 +12906,9 @@ CUresult CUDAAPI cuGraphNodeGetDependencies(CUgraphNode hNode, CUgraphNode *depe
  * ::cuGraphAddDependencies,
  * ::cuGraphRemoveDependencies
  */
-CUresult CUDAAPI cuGraphNodeGetDependentNodes(CUgraphNode hNode, CUgraphNode *dependentNodes, size_t *numDependentNodes);
+CUresult CUDAAPI cuGraphNodeGetDependentNodes(CUgraphNode hNode,
+                                              CUgraphNode *dependentNodes,
+                                              size_t *numDependentNodes);
 
 /**
  * \brief Adds dependency edges to a graph
@@ -12251,7 +12937,9 @@ CUresult CUDAAPI cuGraphNodeGetDependentNodes(CUgraphNode hNode, CUgraphNode *de
  * ::cuGraphNodeGetDependencies,
  * ::cuGraphNodeGetDependentNodes
  */
-CUresult CUDAAPI cuGraphAddDependencies(CUgraph hGraph, const CUgraphNode *from, const CUgraphNode *to, size_t numDependencies);
+CUresult CUDAAPI cuGraphAddDependencies(CUgraph hGraph, const CUgraphNode *from,
+                                        const CUgraphNode *to,
+                                        size_t numDependencies);
 
 /**
  * \brief Removes dependency edges from a graph
@@ -12280,13 +12968,16 @@ CUresult CUDAAPI cuGraphAddDependencies(CUgraph hGraph, const CUgraphNode *from,
  * ::cuGraphNodeGetDependencies,
  * ::cuGraphNodeGetDependentNodes
  */
-CUresult CUDAAPI cuGraphRemoveDependencies(CUgraph hGraph, const CUgraphNode *from, const CUgraphNode *to, size_t numDependencies);
+CUresult CUDAAPI cuGraphRemoveDependencies(CUgraph hGraph,
+                                           const CUgraphNode *from,
+                                           const CUgraphNode *to,
+                                           size_t numDependencies);
 
 /**
  * \brief Remove a node from the graph
  *
- * Removes \p hNode from its graph. This operation also severs any dependencies of other nodes
- * on \p hNode and vice versa.
+ * Removes \p hNode from its graph. This operation also severs any dependencies
+ * of other nodes on \p hNode and vice versa.
  *
  * \param hNode  - Node to remove
  *
@@ -12314,18 +13005,18 @@ CUresult CUDAAPI cuGraphDestroyNode(CUgraphNode hNode);
  * validated. If instantiation is successful, a handle to the instantiated graph
  * is returned in \p graphExec.
  *
- * If there are any errors, diagnostic information may be returned in \p errorNode and
- * \p logBuffer. This is the primary way to inspect instantiation errors. The output
- * will be null terminated unless the diagnostics overflow
+ * If there are any errors, diagnostic information may be returned in \p
+ * errorNode and \p logBuffer. This is the primary way to inspect instantiation
+ * errors. The output will be null terminated unless the diagnostics overflow
  * the buffer. In this case, they will be truncated, and the last byte can be
  * inspected to determine if truncation occurred.
  *
  * \param phGraphExec - Returns instantiated graph
  * \param hGraph      - Graph to instantiate
- * \param phErrorNode - In case of an instantiation error, this may be modified to
- *                      indicate a node contributing to the error
- * \param logBuffer   - A character buffer to store diagnostic messages
- * \param bufferSize  - Size of the log buffer in bytes
+ * \param phErrorNode - In case of an instantiation error, this may be modified
+ * to indicate a node contributing to the error \param logBuffer   - A character
+ * buffer to store diagnostic messages \param bufferSize  - Size of the log
+ * buffer in bytes
  *
  * \return
  * ::CUDA_SUCCESS,
@@ -12340,8 +13031,9 @@ CUresult CUDAAPI cuGraphDestroyNode(CUgraphNode hNode);
  * ::cuGraphLaunch,
  * ::cuGraphExecDestroy
  */
-CUresult CUDAAPI cuGraphInstantiate(CUgraphExec *phGraphExec, CUgraph hGraph, CUgraphNode *phErrorNode, char *logBuffer, size_t bufferSize);
-
+CUresult CUDAAPI cuGraphInstantiate(CUgraphExec *phGraphExec, CUgraph hGraph,
+                                    CUgraphNode *phErrorNode, char *logBuffer,
+                                    size_t bufferSize);
 
 #if __CUDA_API_VERSION >= 10010
 /**
@@ -12351,8 +13043,8 @@ CUresult CUDAAPI cuGraphInstantiate(CUgraphExec *phGraphExec, CUgraph hGraph, CU
  * The node is identified by the corresponding node \p hNode in the
  * non-executable graph, from which the executable graph was instantiated.
  *
- * \p hNode must not have been removed from the original graph. The \p func field
- * of \p nodeParams cannot be modified and must match the original value.
+ * \p hNode must not have been removed from the original graph. The \p func
+ * field of \p nodeParams cannot be modified and must match the original value.
  * All other values can be modified.
  *
  * The modifications take effect at the next launch of \p hGraphExec. Already
@@ -12360,8 +13052,8 @@ CUresult CUDAAPI cuGraphInstantiate(CUgraphExec *phGraphExec, CUgraph hGraph, CU
  * \p hNode is also not modified by this call.
  *
  * \param hGraphExec  - The executable graph in which to set the specified node
- * \param hNode       - kernel node from the graph from which graphExec was instantiated
- * \param nodeParams  - Updated Parameters to set
+ * \param hNode       - kernel node from the graph from which graphExec was
+ * instantiated \param nodeParams  - Updated Parameters to set
  *
  * \return
  * ::CUDA_SUCCESS,
@@ -12374,17 +13066,20 @@ CUresult CUDAAPI cuGraphInstantiate(CUgraphExec *phGraphExec, CUgraph hGraph, CU
  * ::cuGraphKernelNodeSetParams,
  * ::cuGraphInstantiate
  */
- CUresult CUDAAPI cuGraphExecKernelNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode, const CUDA_KERNEL_NODE_PARAMS *nodeParams);
+CUresult CUDAAPI
+cuGraphExecKernelNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode,
+                               const CUDA_KERNEL_NODE_PARAMS *nodeParams);
 
 #endif /* __CUDA_API_VERSION >= 10010 */
 
 /**
  * \brief Launches an executable graph in a stream
  *
- * Executes \p hGraphExec in \p hStream. Only one instance of \p hGraphExec may be executing
- * at a time. Each launch is ordered behind both any previous work in \p hStream
- * and any previous launches of \p hGraphExec. To execute a graph concurrently, it must be
- * instantiated multiple times into multiple executable graphs.
+ * Executes \p hGraphExec in \p hStream. Only one instance of \p hGraphExec may
+ * be executing at a time. Each launch is ordered behind both any previous work
+ * in \p hStream and any previous launches of \p hGraphExec. To execute a graph
+ * concurrently, it must be instantiated multiple times into multiple executable
+ * graphs.
  *
  * \param hGraphExec - Executable graph to launch
  * \param hStream    - Stream in which to launch the graph
@@ -12447,7 +13142,7 @@ CUresult CUDAAPI cuGraphExecDestroy(CUgraphExec hGraphExec);
  */
 CUresult CUDAAPI cuGraphDestroy(CUgraph hGraph);
 /** @} */ /* END CUDA_GRAPH */
-#endif /* __CUDA_API_VERSION >= 10000 */
+#endif    /* __CUDA_API_VERSION >= 10000 */
 
 #if __CUDA_API_VERSION >= 6050
 /**
@@ -12456,8 +13151,8 @@ CUresult CUDAAPI cuGraphDestroy(CUgraph hGraph);
  * ___MANBRIEF___ occupancy calculation functions of the low-level CUDA driver
  * API (___CURRENT_FILE___) ___ENDMANBRIEF___
  *
- * This section describes the occupancy calculation functions of the low-level CUDA
- * driver application programming interface.
+ * This section describes the occupancy calculation functions of the low-level
+ * CUDA driver application programming interface.
  *
  * @{
  */
@@ -12470,8 +13165,9 @@ CUresult CUDAAPI cuGraphDestroy(CUgraph hGraph);
  *
  * \param numBlocks       - Returned occupancy
  * \param func            - Kernel for which occupancy is calculated
- * \param blockSize       - Block size the kernel is intended to be launched with
- * \param dynamicSMemSize - Per-block dynamic shared memory usage intended, in bytes
+ * \param blockSize       - Block size the kernel is intended to be launched
+ * with \param dynamicSMemSize - Per-block dynamic shared memory usage intended,
+ * in bytes
  *
  * \return
  * ::CUDA_SUCCESS,
@@ -12485,7 +13181,8 @@ CUresult CUDAAPI cuGraphDestroy(CUgraph hGraph);
  * \sa
  * ::cudaOccupancyMaxActiveBlocksPerMultiprocessor
  */
-CUresult CUDAAPI cuOccupancyMaxActiveBlocksPerMultiprocessor(int *numBlocks, CUfunction func, int blockSize, size_t dynamicSMemSize);
+CUresult CUDAAPI cuOccupancyMaxActiveBlocksPerMultiprocessor(
+    int *numBlocks, CUfunction func, int blockSize, size_t dynamicSMemSize);
 
 /**
  * \brief Returns occupancy of a function
@@ -12511,9 +13208,10 @@ CUresult CUDAAPI cuOccupancyMaxActiveBlocksPerMultiprocessor(int *numBlocks, CUf
  *
  * \param numBlocks       - Returned occupancy
  * \param func            - Kernel for which occupancy is calculated
- * \param blockSize       - Block size the kernel is intended to be launched with
- * \param dynamicSMemSize - Per-block dynamic shared memory usage intended, in bytes
- * \param flags           - Requested behavior for the occupancy calculator
+ * \param blockSize       - Block size the kernel is intended to be launched
+ * with \param dynamicSMemSize - Per-block dynamic shared memory usage intended,
+ * in bytes \param flags           - Requested behavior for the occupancy
+ * calculator
  *
  * \return
  * ::CUDA_SUCCESS,
@@ -12527,7 +13225,9 @@ CUresult CUDAAPI cuOccupancyMaxActiveBlocksPerMultiprocessor(int *numBlocks, CUf
  * \sa
  * ::cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags
  */
-CUresult CUDAAPI cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(int *numBlocks, CUfunction func, int blockSize, size_t dynamicSMemSize, unsigned int flags);
+CUresult CUDAAPI cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(
+    int *numBlocks, CUfunction func, int blockSize, size_t dynamicSMemSize,
+    unsigned int flags);
 
 /**
  * \brief Suggest a launch configuration with reasonable occupancy
@@ -12560,12 +13260,14 @@ CUresult CUDAAPI cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(int *numBl
  *    size_t blockToSmem(int blockSize);
  * \endcode
  *
- * \param minGridSize - Returned minimum grid size needed to achieve the maximum occupancy
- * \param blockSize   - Returned maximum block size that can achieve the maximum occupancy
- * \param func        - Kernel for which launch configuration is calculated
- * \param blockSizeToDynamicSMemSize - A function that calculates how much per-block dynamic shared memory \p func uses based on the block size
- * \param dynamicSMemSize - Dynamic shared memory usage intended, in bytes
- * \param blockSizeLimit  - The maximum block size \p func is designed to handle
+ * \param minGridSize - Returned minimum grid size needed to achieve the maximum
+ * occupancy \param blockSize   - Returned maximum block size that can achieve
+ * the maximum occupancy \param func        - Kernel for which launch
+ * configuration is calculated \param blockSizeToDynamicSMemSize - A function
+ * that calculates how much per-block dynamic shared memory \p func uses based
+ * on the block size \param dynamicSMemSize - Dynamic shared memory usage
+ * intended, in bytes \param blockSizeLimit  - The maximum block size \p func is
+ * designed to handle
  *
  * \return
  * ::CUDA_SUCCESS,
@@ -12579,7 +13281,10 @@ CUresult CUDAAPI cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(int *numBl
  * \sa
  * ::cudaOccupancyMaxPotentialBlockSize
  */
-CUresult CUDAAPI cuOccupancyMaxPotentialBlockSize(int *minGridSize, int *blockSize, CUfunction func, CUoccupancyB2DSize blockSizeToDynamicSMemSize, size_t dynamicSMemSize, int blockSizeLimit);
+CUresult CUDAAPI cuOccupancyMaxPotentialBlockSize(
+    int *minGridSize, int *blockSize, CUfunction func,
+    CUoccupancyB2DSize blockSizeToDynamicSMemSize, size_t dynamicSMemSize,
+    int blockSizeLimit);
 
 /**
  * \brief Suggest a launch configuration with reasonable occupancy
@@ -12605,13 +13310,14 @@ CUresult CUDAAPI cuOccupancyMaxPotentialBlockSize(int *minGridSize, int *blockSi
  *   can be found about this feature in the "Unified L1/Texture Cache"
  *   section of the Maxwell tuning guide.
  *
- * \param minGridSize - Returned minimum grid size needed to achieve the maximum occupancy
- * \param blockSize   - Returned maximum block size that can achieve the maximum occupancy
- * \param func        - Kernel for which launch configuration is calculated
- * \param blockSizeToDynamicSMemSize - A function that calculates how much per-block dynamic shared memory \p func uses based on the block size
- * \param dynamicSMemSize - Dynamic shared memory usage intended, in bytes
- * \param blockSizeLimit  - The maximum block size \p func is designed to handle
- * \param flags       - Options
+ * \param minGridSize - Returned minimum grid size needed to achieve the maximum
+ * occupancy \param blockSize   - Returned maximum block size that can achieve
+ * the maximum occupancy \param func        - Kernel for which launch
+ * configuration is calculated \param blockSizeToDynamicSMemSize - A function
+ * that calculates how much per-block dynamic shared memory \p func uses based
+ * on the block size \param dynamicSMemSize - Dynamic shared memory usage
+ * intended, in bytes \param blockSizeLimit  - The maximum block size \p func is
+ * designed to handle \param flags       - Options
  *
  * \return
  * ::CUDA_SUCCESS,
@@ -12625,10 +13331,13 @@ CUresult CUDAAPI cuOccupancyMaxPotentialBlockSize(int *minGridSize, int *blockSi
  * \sa
  * ::cudaOccupancyMaxPotentialBlockSizeWithFlags
  */
-CUresult CUDAAPI cuOccupancyMaxPotentialBlockSizeWithFlags(int *minGridSize, int *blockSize, CUfunction func, CUoccupancyB2DSize blockSizeToDynamicSMemSize, size_t dynamicSMemSize, int blockSizeLimit, unsigned int flags);
+CUresult CUDAAPI cuOccupancyMaxPotentialBlockSizeWithFlags(
+    int *minGridSize, int *blockSize, CUfunction func,
+    CUoccupancyB2DSize blockSizeToDynamicSMemSize, size_t dynamicSMemSize,
+    int blockSizeLimit, unsigned int flags);
 
 /** @} */ /* END CUDA_OCCUPANCY */
-#endif /* __CUDA_API_VERSION >= 6050 */
+#endif    /* __CUDA_API_VERSION >= 6050 */
 
 /**
  * \defgroup CUDA_TEXREF_DEPRECATED Texture Reference Management [DEPRECATED]
@@ -12671,17 +13380,19 @@ CUresult CUDAAPI cuOccupancyMaxPotentialBlockSizeWithFlags(int *minGridSize, int
  * ::cuTexRefGetFilterMode, ::cuTexRefGetFlags, ::cuTexRefGetFormat,
  * ::cudaBindTextureToArray
  */
-CUresult CUDAAPI cuTexRefSetArray(CUtexref hTexRef, CUarray hArray, unsigned int Flags);
+CUresult CUDAAPI cuTexRefSetArray(CUtexref hTexRef, CUarray hArray,
+                                  unsigned int Flags);
 
 /**
  * \brief Binds a mipmapped array to a texture reference
  *
  * \deprecated
  *
- * Binds the CUDA mipmapped array \p hMipmappedArray to the texture reference \p hTexRef.
- * Any previous address or CUDA array state associated with the texture reference
- * is superseded by this function. \p Flags must be set to ::CU_TRSA_OVERRIDE_FORMAT.
- * Any CUDA array previously bound to \p hTexRef is unbound.
+ * Binds the CUDA mipmapped array \p hMipmappedArray to the texture reference \p
+ * hTexRef. Any previous address or CUDA array state associated with the texture
+ * reference is superseded by this function. \p Flags must be set to
+ * ::CU_TRSA_OVERRIDE_FORMAT. Any CUDA array previously bound to \p hTexRef is
+ * unbound.
  *
  * \param hTexRef         - Texture reference to bind
  * \param hMipmappedArray - Mipmapped array to bind
@@ -12701,7 +13412,9 @@ CUresult CUDAAPI cuTexRefSetArray(CUtexref hTexRef, CUarray hArray, unsigned int
  * ::cuTexRefGetFilterMode, ::cuTexRefGetFlags, ::cuTexRefGetFormat,
  * ::cudaBindTextureToMipmappedArray
  */
-CUresult CUDAAPI cuTexRefSetMipmappedArray(CUtexref hTexRef, CUmipmappedArray hMipmappedArray, unsigned int Flags);
+CUresult CUDAAPI cuTexRefSetMipmappedArray(CUtexref hTexRef,
+                                           CUmipmappedArray hMipmappedArray,
+                                           unsigned int Flags);
 
 #if __CUDA_API_VERSION >= 3020
 /**
@@ -12748,7 +13461,8 @@ CUresult CUDAAPI cuTexRefSetMipmappedArray(CUtexref hTexRef, CUmipmappedArray hM
  * ::cuTexRefGetFilterMode, ::cuTexRefGetFlags, ::cuTexRefGetFormat,
  * ::cudaBindTexture
  */
-CUresult CUDAAPI cuTexRefSetAddress(size_t *ByteOffset, CUtexref hTexRef, CUdeviceptr dptr, size_t bytes);
+CUresult CUDAAPI cuTexRefSetAddress(size_t *ByteOffset, CUtexref hTexRef,
+                                    CUdeviceptr dptr, size_t bytes);
 
 /**
  * \brief Binds an address as a 2D texture reference
@@ -12803,7 +13517,9 @@ CUresult CUDAAPI cuTexRefSetAddress(size_t *ByteOffset, CUtexref hTexRef, CUdevi
  * ::cuTexRefGetFilterMode, ::cuTexRefGetFlags, ::cuTexRefGetFormat,
  * ::cudaBindTexture2D
  */
-CUresult CUDAAPI cuTexRefSetAddress2D(CUtexref hTexRef, const CUDA_ARRAY_DESCRIPTOR *desc, CUdeviceptr dptr, size_t Pitch);
+CUresult CUDAAPI cuTexRefSetAddress2D(CUtexref hTexRef,
+                                      const CUDA_ARRAY_DESCRIPTOR *desc,
+                                      CUdeviceptr dptr, size_t Pitch);
 #endif /* __CUDA_API_VERSION >= 3020 */
 
 /**
@@ -12839,7 +13555,8 @@ CUresult CUDAAPI cuTexRefSetAddress2D(CUtexref hTexRef, const CUDA_ARRAY_DESCRIP
  * ::cudaBindTextureToArray,
  * ::cudaBindTextureToMipmappedArray
  */
-CUresult CUDAAPI cuTexRefSetFormat(CUtexref hTexRef, CUarray_format fmt, int NumPackedComponents);
+CUresult CUDAAPI cuTexRefSetFormat(CUtexref hTexRef, CUarray_format fmt,
+                                   int NumPackedComponents);
 
 /**
  * \brief Sets the addressing mode for a texture reference
@@ -12885,7 +13602,8 @@ CUresult CUDAAPI cuTexRefSetFormat(CUtexref hTexRef, CUarray_format fmt, int Num
  * ::cudaBindTextureToArray,
  * ::cudaBindTextureToMipmappedArray
  */
-CUresult CUDAAPI cuTexRefSetAddressMode(CUtexref hTexRef, int dim, CUaddress_mode am);
+CUresult CUDAAPI cuTexRefSetAddressMode(CUtexref hTexRef, int dim,
+                                        CUaddress_mode am);
 
 /**
  * \brief Sets the filtering mode for a texture reference
@@ -12928,7 +13646,8 @@ CUresult CUDAAPI cuTexRefSetFilterMode(CUtexref hTexRef, CUfilter_mode fm);
  *
  * \deprecated
  *
- * Specifies the mipmap filtering mode \p fm to be used when reading memory through
+ * Specifies the mipmap filtering mode \p fm to be used when reading memory
+ through
  * the texture reference \p hTexRef. ::CUfilter_mode_enum is defined as:
  *
  * \code
@@ -12938,7 +13657,8 @@ CUresult CUDAAPI cuTexRefSetFilterMode(CUtexref hTexRef, CUfilter_mode fm);
    } CUfilter_mode;
  * \endcode
  *
- * Note that this call has no effect if \p hTexRef is not bound to a mipmapped array.
+ * Note that this call has no effect if \p hTexRef is not bound to a mipmapped
+ array.
  *
  * \param hTexRef - Texture reference
  * \param fm      - Filtering mode to set
@@ -12957,17 +13677,19 @@ CUresult CUDAAPI cuTexRefSetFilterMode(CUtexref hTexRef, CUfilter_mode fm);
  * ::cuTexRefGetFilterMode, ::cuTexRefGetFlags, ::cuTexRefGetFormat,
  * ::cudaBindTextureToMipmappedArray
  */
-CUresult CUDAAPI cuTexRefSetMipmapFilterMode(CUtexref hTexRef, CUfilter_mode fm);
+CUresult CUDAAPI cuTexRefSetMipmapFilterMode(CUtexref hTexRef,
+                                             CUfilter_mode fm);
 
 /**
  * \brief Sets the mipmap level bias for a texture reference
  *
  * \deprecated
  *
- * Specifies the mipmap level bias \p bias to be added to the specified mipmap level when
- * reading memory through the texture reference \p hTexRef.
+ * Specifies the mipmap level bias \p bias to be added to the specified mipmap
+ * level when reading memory through the texture reference \p hTexRef.
  *
- * Note that this call has no effect if \p hTexRef is not bound to a mipmapped array.
+ * Note that this call has no effect if \p hTexRef is not bound to a mipmapped
+ * array.
  *
  * \param hTexRef - Texture reference
  * \param bias    - Mipmap level bias
@@ -12993,11 +13715,12 @@ CUresult CUDAAPI cuTexRefSetMipmapLevelBias(CUtexref hTexRef, float bias);
  *
  * \deprecated
  *
- * Specifies the min/max mipmap level clamps, \p minMipmapLevelClamp and \p maxMipmapLevelClamp
- * respectively, to be used when reading memory through the texture reference
- * \p hTexRef.
+ * Specifies the min/max mipmap level clamps, \p minMipmapLevelClamp and \p
+ * maxMipmapLevelClamp respectively, to be used when reading memory through the
+ * texture reference \p hTexRef.
  *
- * Note that this call has no effect if \p hTexRef is not bound to a mipmapped array.
+ * Note that this call has no effect if \p hTexRef is not bound to a mipmapped
+ * array.
  *
  * \param hTexRef        - Texture reference
  * \param minMipmapLevelClamp - Mipmap min level clamp
@@ -13017,15 +13740,17 @@ CUresult CUDAAPI cuTexRefSetMipmapLevelBias(CUtexref hTexRef, float bias);
  * ::cuTexRefGetFilterMode, ::cuTexRefGetFlags, ::cuTexRefGetFormat,
  * ::cudaBindTextureToMipmappedArray
  */
-CUresult CUDAAPI cuTexRefSetMipmapLevelClamp(CUtexref hTexRef, float minMipmapLevelClamp, float maxMipmapLevelClamp);
+CUresult CUDAAPI cuTexRefSetMipmapLevelClamp(CUtexref hTexRef,
+                                             float minMipmapLevelClamp,
+                                             float maxMipmapLevelClamp);
 
 /**
  * \brief Sets the maximum anisotropy for a texture reference
  *
  * \deprecated
  *
- * Specifies the maximum anisotropy \p maxAniso to be used when reading memory through
- * the texture reference \p hTexRef.
+ * Specifies the maximum anisotropy \p maxAniso to be used when reading memory
+ * through the texture reference \p hTexRef.
  *
  * Note that this call has no effect if \p hTexRef is bound to linear memory.
  *
@@ -13047,24 +13772,24 @@ CUresult CUDAAPI cuTexRefSetMipmapLevelClamp(CUtexref hTexRef, float minMipmapLe
  * ::cudaBindTextureToArray,
  * ::cudaBindTextureToMipmappedArray
  */
-CUresult CUDAAPI cuTexRefSetMaxAnisotropy(CUtexref hTexRef, unsigned int maxAniso);
+CUresult CUDAAPI cuTexRefSetMaxAnisotropy(CUtexref hTexRef,
+                                          unsigned int maxAniso);
 
 /**
  * \brief Sets the border color for a texture reference
  *
  * \deprecated
  *
- * Specifies the value of the RGBA color via the \p pBorderColor to the texture reference
- * \p hTexRef. The color value supports only float type and holds color components in
- * the following sequence:
- * pBorderColor[0] holds 'R' component
- * pBorderColor[1] holds 'G' component
- * pBorderColor[2] holds 'B' component
- * pBorderColor[3] holds 'A' component
+ * Specifies the value of the RGBA color via the \p pBorderColor to the texture
+ * reference \p hTexRef. The color value supports only float type and holds
+ * color components in the following sequence: pBorderColor[0] holds 'R'
+ * component pBorderColor[1] holds 'G' component pBorderColor[2] holds 'B'
+ * component pBorderColor[3] holds 'A' component
  *
  * Note that the color values can be set only when the Address mode is set to
  * CU_TR_ADDRESS_MODE_BORDER using ::cuTexRefSetAddressMode.
- * Applications using integer border color values have to "reinterpret_cast" their values to float.
+ * Applications using integer border color values have to "reinterpret_cast"
+ * their values to float.
  *
  * \param hTexRef       - Texture reference
  * \param pBorderColor  - RGBA color
@@ -13188,8 +13913,8 @@ CUresult CUDAAPI cuTexRefGetArray(CUarray *phArray, CUtexref hTexRef);
  * \deprecated
  *
  * Returns in \p *phMipmappedArray the CUDA mipmapped array bound to the texture
- * reference \p hTexRef, or returns ::CUDA_ERROR_INVALID_VALUE if the texture reference
- * is not bound to any CUDA mipmapped array.
+ * reference \p hTexRef, or returns ::CUDA_ERROR_INVALID_VALUE if the texture
+ * reference is not bound to any CUDA mipmapped array.
  *
  * \param phMipmappedArray - Returned mipmapped array
  * \param hTexRef          - Texture reference
@@ -13207,7 +13932,8 @@ CUresult CUDAAPI cuTexRefGetArray(CUarray *phArray, CUtexref hTexRef);
  * ::cuTexRefGetAddress, ::cuTexRefGetAddressMode,
  * ::cuTexRefGetFilterMode, ::cuTexRefGetFlags, ::cuTexRefGetFormat
  */
-CUresult CUDAAPI cuTexRefGetMipmappedArray(CUmipmappedArray *phMipmappedArray, CUtexref hTexRef);
+CUresult CUDAAPI cuTexRefGetMipmappedArray(CUmipmappedArray *phMipmappedArray,
+                                           CUtexref hTexRef);
 
 /**
  * \brief Gets the addressing mode used by a texture reference
@@ -13235,7 +13961,8 @@ CUresult CUDAAPI cuTexRefGetMipmappedArray(CUmipmappedArray *phMipmappedArray, C
  * ::cuTexRefGetAddress, ::cuTexRefGetArray,
  * ::cuTexRefGetFilterMode, ::cuTexRefGetFlags, ::cuTexRefGetFormat
  */
-CUresult CUDAAPI cuTexRefGetAddressMode(CUaddress_mode *pam, CUtexref hTexRef, int dim);
+CUresult CUDAAPI cuTexRefGetAddressMode(CUaddress_mode *pam, CUtexref hTexRef,
+                                        int dim);
 
 /**
  * \brief Gets the filter-mode used by a texture reference
@@ -13289,15 +14016,16 @@ CUresult CUDAAPI cuTexRefGetFilterMode(CUfilter_mode *pfm, CUtexref hTexRef);
  * ::cuTexRefGetAddress, ::cuTexRefGetAddressMode, ::cuTexRefGetArray,
  * ::cuTexRefGetFilterMode, ::cuTexRefGetFlags
  */
-CUresult CUDAAPI cuTexRefGetFormat(CUarray_format *pFormat, int *pNumChannels, CUtexref hTexRef);
+CUresult CUDAAPI cuTexRefGetFormat(CUarray_format *pFormat, int *pNumChannels,
+                                   CUtexref hTexRef);
 
 /**
  * \brief Gets the mipmap filtering mode for a texture reference
  *
  * \deprecated
  *
- * Returns the mipmap filtering mode in \p pfm that's used when reading memory through
- * the texture reference \p hTexRef.
+ * Returns the mipmap filtering mode in \p pfm that's used when reading memory
+ * through the texture reference \p hTexRef.
  *
  * \param pfm     - Returned mipmap filtering mode
  * \param hTexRef - Texture reference
@@ -13315,15 +14043,16 @@ CUresult CUDAAPI cuTexRefGetFormat(CUarray_format *pFormat, int *pNumChannels, C
  * ::cuTexRefGetAddress, ::cuTexRefGetAddressMode, ::cuTexRefGetArray,
  * ::cuTexRefGetFilterMode, ::cuTexRefGetFlags, ::cuTexRefGetFormat
  */
-CUresult CUDAAPI cuTexRefGetMipmapFilterMode(CUfilter_mode *pfm, CUtexref hTexRef);
+CUresult CUDAAPI cuTexRefGetMipmapFilterMode(CUfilter_mode *pfm,
+                                             CUtexref hTexRef);
 
 /**
  * \brief Gets the mipmap level bias for a texture reference
  *
  * \deprecated
  *
- * Returns the mipmap level bias in \p pBias that's added to the specified mipmap
- * level when reading memory through the texture reference \p hTexRef.
+ * Returns the mipmap level bias in \p pBias that's added to the specified
+ * mipmap level when reading memory through the texture reference \p hTexRef.
  *
  * \param pbias   - Returned mipmap level bias
  * \param hTexRef - Texture reference
@@ -13348,8 +14077,9 @@ CUresult CUDAAPI cuTexRefGetMipmapLevelBias(float *pbias, CUtexref hTexRef);
  *
  * \deprecated
  *
- * Returns the min/max mipmap level clamps in \p pminMipmapLevelClamp and \p pmaxMipmapLevelClamp
- * that's used when reading memory through the texture reference \p hTexRef.
+ * Returns the min/max mipmap level clamps in \p pminMipmapLevelClamp and \p
+ * pmaxMipmapLevelClamp that's used when reading memory through the texture
+ * reference \p hTexRef.
  *
  * \param pminMipmapLevelClamp - Returned mipmap min level clamp
  * \param pmaxMipmapLevelClamp - Returned mipmap max level clamp
@@ -13368,15 +14098,17 @@ CUresult CUDAAPI cuTexRefGetMipmapLevelBias(float *pbias, CUtexref hTexRef);
  * ::cuTexRefGetAddress, ::cuTexRefGetAddressMode, ::cuTexRefGetArray,
  * ::cuTexRefGetFilterMode, ::cuTexRefGetFlags, ::cuTexRefGetFormat
  */
-CUresult CUDAAPI cuTexRefGetMipmapLevelClamp(float *pminMipmapLevelClamp, float *pmaxMipmapLevelClamp, CUtexref hTexRef);
+CUresult CUDAAPI cuTexRefGetMipmapLevelClamp(float *pminMipmapLevelClamp,
+                                             float *pmaxMipmapLevelClamp,
+                                             CUtexref hTexRef);
 
 /**
  * \brief Gets the maximum anisotropy for a texture reference
  *
  * \deprecated
  *
- * Returns the maximum anisotropy in \p pmaxAniso that's used when reading memory through
- * the texture reference \p hTexRef.
+ * Returns the maximum anisotropy in \p pmaxAniso that's used when reading
+ * memory through the texture reference \p hTexRef.
  *
  * \param pmaxAniso - Returned maximum anisotropy
  * \param hTexRef   - Texture reference
@@ -13497,7 +14229,6 @@ CUresult CUDAAPI cuTexRefDestroy(CUtexref hTexRef);
 
 /** @} */ /* END CUDA_TEXREF_DEPRECATED */
 
-
 /**
  * \defgroup CUDA_SURFREF_DEPRECATED Surface Reference Management [DEPRECATED]
  *
@@ -13537,7 +14268,8 @@ CUresult CUDAAPI cuTexRefDestroy(CUtexref hTexRef);
  * ::cuSurfRefGetArray,
  * ::cudaBindSurfaceToArray
  */
-CUresult CUDAAPI cuSurfRefSetArray(CUsurfref hSurfRef, CUarray hArray, unsigned int Flags);
+CUresult CUDAAPI cuSurfRefSetArray(CUsurfref hSurfRef, CUarray hArray,
+                                   unsigned int Flags);
 
 /**
  * \brief Passes back the CUDA array bound to a surface reference.
@@ -13581,15 +14313,21 @@ CUresult CUDAAPI cuSurfRefGetArray(CUarray *phArray, CUsurfref hSurfRef);
 /**
  * \brief Creates a texture object
  *
- * Creates a texture object and returns it in \p pTexObject. \p pResDesc describes
- * the data to texture from. \p pTexDesc describes how the data should be sampled.
- * \p pResViewDesc is an optional argument that specifies an alternate format for
+ * Creates a texture object and returns it in \p pTexObject. \p pResDesc
+ describes
+ * the data to texture from. \p pTexDesc describes how the data should be
+ sampled.
+ * \p pResViewDesc is an optional argument that specifies an alternate format
+ for
  * the data described by \p pResDesc, and also describes the subresource region
- * to restrict access to when texturing. \p pResViewDesc can only be specified if
+ * to restrict access to when texturing. \p pResViewDesc can only be specified
+ if
  * the type of resource is a CUDA array or a CUDA mipmapped array.
  *
- * Texture objects are only supported on devices of compute capability 3.0 or higher.
- * Additionally, a texture object is an opaque value, and, as such, should only be
+ * Texture objects are only supported on devices of compute capability 3.0 or
+ higher.
+ * Additionally, a texture object is an opaque value, and, as such, should only
+ be
  * accessed through CUDA API calls.
  *
  * The ::CUDA_RESOURCE_DESC structure is defined as:
@@ -13626,7 +14364,8 @@ CUresult CUDAAPI cuSurfRefGetArray(CUarray *phArray, CUsurfref hSurfRef);
 
  * \endcode
  * where:
- * - ::CUDA_RESOURCE_DESC::resType specifies the type of resource to texture from.
+ * - ::CUDA_RESOURCE_DESC::resType specifies the type of resource to texture
+ from.
  * CUresourceType is defined as:
  * \code
         typedef enum CUresourcetype_enum {
@@ -13638,30 +14377,47 @@ CUresult CUDAAPI cuSurfRefGetArray(CUarray *phArray, CUsurfref hSurfRef);
  * \endcode
  *
  * \par
- * If ::CUDA_RESOURCE_DESC::resType is set to ::CU_RESOURCE_TYPE_ARRAY, ::CUDA_RESOURCE_DESC::res::array::hArray
+ * If ::CUDA_RESOURCE_DESC::resType is set to ::CU_RESOURCE_TYPE_ARRAY,
+ ::CUDA_RESOURCE_DESC::res::array::hArray
  * must be set to a valid CUDA array handle.
  *
  * \par
- * If ::CUDA_RESOURCE_DESC::resType is set to ::CU_RESOURCE_TYPE_MIPMAPPED_ARRAY, ::CUDA_RESOURCE_DESC::res::mipmap::hMipmappedArray
+ * If ::CUDA_RESOURCE_DESC::resType is set to
+ ::CU_RESOURCE_TYPE_MIPMAPPED_ARRAY,
+ ::CUDA_RESOURCE_DESC::res::mipmap::hMipmappedArray
  * must be set to a valid CUDA mipmapped array handle.
  *
  * \par
- * If ::CUDA_RESOURCE_DESC::resType is set to ::CU_RESOURCE_TYPE_LINEAR, ::CUDA_RESOURCE_DESC::res::linear::devPtr
- * must be set to a valid device pointer, that is aligned to ::CU_DEVICE_ATTRIBUTE_TEXTURE_ALIGNMENT.
- * ::CUDA_RESOURCE_DESC::res::linear::format and ::CUDA_RESOURCE_DESC::res::linear::numChannels
- * describe the format of each component and the number of components per array element. ::CUDA_RESOURCE_DESC::res::linear::sizeInBytes
- * specifies the size of the array in bytes. The total number of elements in the linear address range cannot exceed
- * ::CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LINEAR_WIDTH. The number of elements is computed as (sizeInBytes / (sizeof(format) * numChannels)).
+ * If ::CUDA_RESOURCE_DESC::resType is set to ::CU_RESOURCE_TYPE_LINEAR,
+ ::CUDA_RESOURCE_DESC::res::linear::devPtr
+ * must be set to a valid device pointer, that is aligned to
+ ::CU_DEVICE_ATTRIBUTE_TEXTURE_ALIGNMENT.
+ * ::CUDA_RESOURCE_DESC::res::linear::format and
+ ::CUDA_RESOURCE_DESC::res::linear::numChannels
+ * describe the format of each component and the number of components per array
+ element. ::CUDA_RESOURCE_DESC::res::linear::sizeInBytes
+ * specifies the size of the array in bytes. The total number of elements in the
+ linear address range cannot exceed
+ * ::CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LINEAR_WIDTH. The number of elements
+ is computed as (sizeInBytes / (sizeof(format) * numChannels)).
  *
  * \par
- * If ::CUDA_RESOURCE_DESC::resType is set to ::CU_RESOURCE_TYPE_PITCH2D, ::CUDA_RESOURCE_DESC::res::pitch2D::devPtr
- * must be set to a valid device pointer, that is aligned to ::CU_DEVICE_ATTRIBUTE_TEXTURE_ALIGNMENT.
- * ::CUDA_RESOURCE_DESC::res::pitch2D::format and ::CUDA_RESOURCE_DESC::res::pitch2D::numChannels
- * describe the format of each component and the number of components per array element. ::CUDA_RESOURCE_DESC::res::pitch2D::width
- * and ::CUDA_RESOURCE_DESC::res::pitch2D::height specify the width and height of the array in elements, and cannot exceed
- * ::CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_WIDTH and ::CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_HEIGHT respectively.
- * ::CUDA_RESOURCE_DESC::res::pitch2D::pitchInBytes specifies the pitch between two rows in bytes and has to be aligned to
- * ::CU_DEVICE_ATTRIBUTE_TEXTURE_PITCH_ALIGNMENT. Pitch cannot exceed ::CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_PITCH.
+ * If ::CUDA_RESOURCE_DESC::resType is set to ::CU_RESOURCE_TYPE_PITCH2D,
+ ::CUDA_RESOURCE_DESC::res::pitch2D::devPtr
+ * must be set to a valid device pointer, that is aligned to
+ ::CU_DEVICE_ATTRIBUTE_TEXTURE_ALIGNMENT.
+ * ::CUDA_RESOURCE_DESC::res::pitch2D::format and
+ ::CUDA_RESOURCE_DESC::res::pitch2D::numChannels
+ * describe the format of each component and the number of components per array
+ element. ::CUDA_RESOURCE_DESC::res::pitch2D::width
+ * and ::CUDA_RESOURCE_DESC::res::pitch2D::height specify the width and height
+ of the array in elements, and cannot exceed
+ * ::CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_WIDTH and
+ ::CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_HEIGHT respectively.
+ * ::CUDA_RESOURCE_DESC::res::pitch2D::pitchInBytes specifies the pitch between
+ two rows in bytes and has to be aligned to
+ * ::CU_DEVICE_ATTRIBUTE_TEXTURE_PITCH_ALIGNMENT. Pitch cannot exceed
+ ::CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_PITCH.
  *
  * - ::flags must be set to zero.
  *
@@ -13680,7 +14436,8 @@ CUresult CUDAAPI cuSurfRefGetArray(CUarray *phArray, CUsurfref hSurfRef);
         } CUDA_TEXTURE_DESC;
  * \endcode
  * where
- * - ::CUDA_TEXTURE_DESC::addressMode specifies the addressing mode for each dimension of the texture data. ::CUaddress_mode is defined as:
+ * - ::CUDA_TEXTURE_DESC::addressMode specifies the addressing mode for each
+ dimension of the texture data. ::CUaddress_mode is defined as:
  *   \code
         typedef enum CUaddress_mode_enum {
             CU_TR_ADDRESS_MODE_WRAP = 0,
@@ -13689,35 +14446,47 @@ CUresult CUDAAPI cuSurfRefGetArray(CUarray *phArray, CUsurfref hSurfRef);
             CU_TR_ADDRESS_MODE_BORDER = 3
         } CUaddress_mode;
  *   \endcode
- *   This is ignored if ::CUDA_RESOURCE_DESC::resType is ::CU_RESOURCE_TYPE_LINEAR. Also, if the flag, ::CU_TRSF_NORMALIZED_COORDINATES
+ *   This is ignored if ::CUDA_RESOURCE_DESC::resType is
+ ::CU_RESOURCE_TYPE_LINEAR. Also, if the flag, ::CU_TRSF_NORMALIZED_COORDINATES
  *   is not set, the only supported address mode is ::CU_TR_ADDRESS_MODE_CLAMP.
  *
- * - ::CUDA_TEXTURE_DESC::filterMode specifies the filtering mode to be used when fetching from the texture. CUfilter_mode is defined as:
+ * - ::CUDA_TEXTURE_DESC::filterMode specifies the filtering mode to be used
+ when fetching from the texture. CUfilter_mode is defined as:
  *   \code
         typedef enum CUfilter_mode_enum {
             CU_TR_FILTER_MODE_POINT = 0,
             CU_TR_FILTER_MODE_LINEAR = 1
         } CUfilter_mode;
  *   \endcode
- *   This is ignored if ::CUDA_RESOURCE_DESC::resType is ::CU_RESOURCE_TYPE_LINEAR.
+ *   This is ignored if ::CUDA_RESOURCE_DESC::resType is
+ ::CU_RESOURCE_TYPE_LINEAR.
  *
  * - ::CUDA_TEXTURE_DESC::flags can be any combination of the following:
- *   - ::CU_TRSF_READ_AS_INTEGER, which suppresses the default behavior of having the texture promote integer data to floating point data in the
- *     range [0, 1]. Note that texture with 32-bit integer format would not be promoted, regardless of whether or not this flag is specified.
- *   - ::CU_TRSF_NORMALIZED_COORDINATES, which suppresses the default behavior of having the texture coordinates range from [0, Dim) where Dim is
- *     the width or height of the CUDA array. Instead, the texture coordinates [0, 1.0) reference the entire breadth of the array dimension; Note
+ *   - ::CU_TRSF_READ_AS_INTEGER, which suppresses the default behavior of
+ having the texture promote integer data to floating point data in the
+ *     range [0, 1]. Note that texture with 32-bit integer format would not be
+ promoted, regardless of whether or not this flag is specified.
+ *   - ::CU_TRSF_NORMALIZED_COORDINATES, which suppresses the default behavior
+ of having the texture coordinates range from [0, Dim) where Dim is
+ *     the width or height of the CUDA array. Instead, the texture coordinates
+ [0, 1.0) reference the entire breadth of the array dimension; Note
  *     that for CUDA mipmapped arrays, this flag has to be set.
  *
- * - ::CUDA_TEXTURE_DESC::maxAnisotropy specifies the maximum anisotropy ratio to be used when doing anisotropic filtering. This value will be
+ * - ::CUDA_TEXTURE_DESC::maxAnisotropy specifies the maximum anisotropy ratio
+ to be used when doing anisotropic filtering. This value will be
  *   clamped to the range [1,16].
  *
- * - ::CUDA_TEXTURE_DESC::mipmapFilterMode specifies the filter mode when the calculated mipmap level lies between two defined mipmap levels.
+ * - ::CUDA_TEXTURE_DESC::mipmapFilterMode specifies the filter mode when the
+ calculated mipmap level lies between two defined mipmap levels.
  *
- * - ::CUDA_TEXTURE_DESC::mipmapLevelBias specifies the offset to be applied to the calculated mipmap level.
+ * - ::CUDA_TEXTURE_DESC::mipmapLevelBias specifies the offset to be applied to
+ the calculated mipmap level.
  *
- * - ::CUDA_TEXTURE_DESC::minMipmapLevelClamp specifies the lower end of the mipmap level range to clamp access to.
+ * - ::CUDA_TEXTURE_DESC::minMipmapLevelClamp specifies the lower end of the
+ mipmap level range to clamp access to.
  *
- * - ::CUDA_TEXTURE_DESC::maxMipmapLevelClamp specifies the upper end of the mipmap level range to clamp access to.
+ * - ::CUDA_TEXTURE_DESC::maxMipmapLevelClamp specifies the upper end of the
+ mipmap level range to clamp access to.
  *
  *
  * The ::CUDA_RESOURCE_VIEW_DESC struct is defined as
@@ -13735,36 +14504,53 @@ CUresult CUDAAPI cuSurfRefGetArray(CUarray *phArray, CUsurfref hSurfRef);
         } CUDA_RESOURCE_VIEW_DESC;
  * \endcode
  * where:
- * - ::CUDA_RESOURCE_VIEW_DESC::format specifies how the data contained in the CUDA array or CUDA mipmapped array should
- *   be interpreted. Note that this can incur a change in size of the texture data. If the resource view format is a block
- *   compressed format, then the underlying CUDA array or CUDA mipmapped array has to have a base of format ::CU_AD_FORMAT_UNSIGNED_INT32.
- *   with 2 or 4 channels, depending on the block compressed format. For ex., BC1 and BC4 require the underlying CUDA array to have
- *   a format of ::CU_AD_FORMAT_UNSIGNED_INT32 with 2 channels. The other BC formats require the underlying resource to have the same base
+ * - ::CUDA_RESOURCE_VIEW_DESC::format specifies how the data contained in the
+ CUDA array or CUDA mipmapped array should
+ *   be interpreted. Note that this can incur a change in size of the texture
+ data. If the resource view format is a block
+ *   compressed format, then the underlying CUDA array or CUDA mipmapped array
+ has to have a base of format ::CU_AD_FORMAT_UNSIGNED_INT32.
+ *   with 2 or 4 channels, depending on the block compressed format. For ex.,
+ BC1 and BC4 require the underlying CUDA array to have
+ *   a format of ::CU_AD_FORMAT_UNSIGNED_INT32 with 2 channels. The other BC
+ formats require the underlying resource to have the same base
  *   format but with 4 channels.
  *
- * - ::CUDA_RESOURCE_VIEW_DESC::width specifies the new width of the texture data. If the resource view format is a block
- *   compressed format, this value has to be 4 times the original width of the resource. For non block compressed formats,
+ * - ::CUDA_RESOURCE_VIEW_DESC::width specifies the new width of the texture
+ data. If the resource view format is a block
+ *   compressed format, this value has to be 4 times the original width of the
+ resource. For non block compressed formats,
  *   this value has to be equal to that of the original resource.
  *
- * - ::CUDA_RESOURCE_VIEW_DESC::height specifies the new height of the texture data. If the resource view format is a block
- *   compressed format, this value has to be 4 times the original height of the resource. For non block compressed formats,
+ * - ::CUDA_RESOURCE_VIEW_DESC::height specifies the new height of the texture
+ data. If the resource view format is a block
+ *   compressed format, this value has to be 4 times the original height of the
+ resource. For non block compressed formats,
  *   this value has to be equal to that of the original resource.
  *
- * - ::CUDA_RESOURCE_VIEW_DESC::depth specifies the new depth of the texture data. This value has to be equal to that of the
+ * - ::CUDA_RESOURCE_VIEW_DESC::depth specifies the new depth of the texture
+ data. This value has to be equal to that of the
  *   original resource.
  *
- * - ::CUDA_RESOURCE_VIEW_DESC::firstMipmapLevel specifies the most detailed mipmap level. This will be the new mipmap level zero.
- *   For non-mipmapped resources, this value has to be zero.::CUDA_TEXTURE_DESC::minMipmapLevelClamp and ::CUDA_TEXTURE_DESC::maxMipmapLevelClamp
- *   will be relative to this value. For ex., if the firstMipmapLevel is set to 2, and a minMipmapLevelClamp of 1.2 is specified,
+ * - ::CUDA_RESOURCE_VIEW_DESC::firstMipmapLevel specifies the most detailed
+ mipmap level. This will be the new mipmap level zero.
+ *   For non-mipmapped resources, this value has to be
+ zero.::CUDA_TEXTURE_DESC::minMipmapLevelClamp and
+ ::CUDA_TEXTURE_DESC::maxMipmapLevelClamp
+ *   will be relative to this value. For ex., if the firstMipmapLevel is set to
+ 2, and a minMipmapLevelClamp of 1.2 is specified,
  *   then the actual minimum mipmap level clamp will be 3.2.
  *
- * - ::CUDA_RESOURCE_VIEW_DESC::lastMipmapLevel specifies the least detailed mipmap level. For non-mipmapped resources, this value
+ * - ::CUDA_RESOURCE_VIEW_DESC::lastMipmapLevel specifies the least detailed
+ mipmap level. For non-mipmapped resources, this value
  *   has to be zero.
  *
- * - ::CUDA_RESOURCE_VIEW_DESC::firstLayer specifies the first layer index for layered textures. This will be the new layer zero.
+ * - ::CUDA_RESOURCE_VIEW_DESC::firstLayer specifies the first layer index for
+ layered textures. This will be the new layer zero.
  *   For non-layered resources, this value has to be zero.
  *
- * - ::CUDA_RESOURCE_VIEW_DESC::lastLayer specifies the last layer index for layered textures. For non-layered resources,
+ * - ::CUDA_RESOURCE_VIEW_DESC::lastLayer specifies the last layer index for
+ layered textures. For non-layered resources,
  *   this value has to be zero.
  *
  *
@@ -13784,7 +14570,10 @@ CUresult CUDAAPI cuSurfRefGetArray(CUarray *phArray, CUsurfref hSurfRef);
  * ::cuTexObjectDestroy,
  * ::cudaCreateTextureObject
  */
-CUresult CUDAAPI cuTexObjectCreate(CUtexObject *pTexObject, const CUDA_RESOURCE_DESC *pResDesc, const CUDA_TEXTURE_DESC *pTexDesc, const CUDA_RESOURCE_VIEW_DESC *pResViewDesc);
+CUresult CUDAAPI cuTexObjectCreate(CUtexObject *pTexObject,
+                                   const CUDA_RESOURCE_DESC *pResDesc,
+                                   const CUDA_TEXTURE_DESC *pTexDesc,
+                                   const CUDA_RESOURCE_VIEW_DESC *pResViewDesc);
 
 /**
  * \brief Destroys a texture object
@@ -13809,7 +14598,8 @@ CUresult CUDAAPI cuTexObjectDestroy(CUtexObject texObject);
 /**
  * \brief Returns a texture object's resource descriptor
  *
- * Returns the resource descriptor for the texture object specified by \p texObject.
+ * Returns the resource descriptor for the texture object specified by \p
+ * texObject.
  *
  * \param pResDesc  - Resource descriptor
  * \param texObject - Texture object
@@ -13825,12 +14615,14 @@ CUresult CUDAAPI cuTexObjectDestroy(CUtexObject texObject);
  * ::cuTexObjectCreate,
  * ::cudaGetTextureObjectResourceDesc,
  */
-CUresult CUDAAPI cuTexObjectGetResourceDesc(CUDA_RESOURCE_DESC *pResDesc, CUtexObject texObject);
+CUresult CUDAAPI cuTexObjectGetResourceDesc(CUDA_RESOURCE_DESC *pResDesc,
+                                            CUtexObject texObject);
 
 /**
  * \brief Returns a texture object's texture descriptor
  *
- * Returns the texture descriptor for the texture object specified by \p texObject.
+ * Returns the texture descriptor for the texture object specified by \p
+ * texObject.
  *
  * \param pTexDesc  - Texture descriptor
  * \param texObject - Texture object
@@ -13846,13 +14638,15 @@ CUresult CUDAAPI cuTexObjectGetResourceDesc(CUDA_RESOURCE_DESC *pResDesc, CUtexO
  * ::cuTexObjectCreate,
  * ::cudaGetTextureObjectTextureDesc
  */
-CUresult CUDAAPI cuTexObjectGetTextureDesc(CUDA_TEXTURE_DESC *pTexDesc, CUtexObject texObject);
+CUresult CUDAAPI cuTexObjectGetTextureDesc(CUDA_TEXTURE_DESC *pTexDesc,
+                                           CUtexObject texObject);
 
 /**
  * \brief Returns a texture object's resource view descriptor
  *
- * Returns the resource view descriptor for the texture object specified by \p texObject.
- * If no resource view was set for \p texObject, the ::CUDA_ERROR_INVALID_VALUE is returned.
+ * Returns the resource view descriptor for the texture object specified by \p
+ * texObject. If no resource view was set for \p texObject, the
+ * ::CUDA_ERROR_INVALID_VALUE is returned.
  *
  * \param pResViewDesc - Resource view descriptor
  * \param texObject    - Texture object
@@ -13868,7 +14662,8 @@ CUresult CUDAAPI cuTexObjectGetTextureDesc(CUDA_TEXTURE_DESC *pTexDesc, CUtexObj
  * ::cuTexObjectCreate,
  * ::cudaGetTextureObjectResourceViewDesc
  */
-CUresult CUDAAPI cuTexObjectGetResourceViewDesc(CUDA_RESOURCE_VIEW_DESC *pResViewDesc, CUtexObject texObject);
+CUresult CUDAAPI cuTexObjectGetResourceViewDesc(
+    CUDA_RESOURCE_VIEW_DESC *pResViewDesc, CUtexObject texObject);
 
 /** @} */ /* END CUDA_TEXOBJECT */
 
@@ -13888,14 +14683,16 @@ CUresult CUDAAPI cuTexObjectGetResourceViewDesc(CUDA_RESOURCE_VIEW_DESC *pResVie
 /**
  * \brief Creates a surface object
  *
- * Creates a surface object and returns it in \p pSurfObject. \p pResDesc describes
- * the data to perform surface load/stores on. ::CUDA_RESOURCE_DESC::resType must be
+ * Creates a surface object and returns it in \p pSurfObject. \p pResDesc
+ * describes the data to perform surface load/stores on.
+ * ::CUDA_RESOURCE_DESC::resType must be
  * ::CU_RESOURCE_TYPE_ARRAY and  ::CUDA_RESOURCE_DESC::res::array::hArray
- * must be set to a valid CUDA array handle. ::CUDA_RESOURCE_DESC::flags must be set to zero.
+ * must be set to a valid CUDA array handle. ::CUDA_RESOURCE_DESC::flags must be
+ * set to zero.
  *
- * Surface objects are only supported on devices of compute capability 3.0 or higher.
- * Additionally, a surface object is an opaque value, and, as such, should only be
- * accessed through CUDA API calls.
+ * Surface objects are only supported on devices of compute capability 3.0 or
+ * higher. Additionally, a surface object is an opaque value, and, as such,
+ * should only be accessed through CUDA API calls.
  *
  * \param pSurfObject - Surface object to create
  * \param pResDesc    - Resource descriptor
@@ -13911,7 +14708,8 @@ CUresult CUDAAPI cuTexObjectGetResourceViewDesc(CUDA_RESOURCE_VIEW_DESC *pResVie
  * ::cuSurfObjectDestroy,
  * ::cudaCreateSurfaceObject
  */
-CUresult CUDAAPI cuSurfObjectCreate(CUsurfObject *pSurfObject, const CUDA_RESOURCE_DESC *pResDesc);
+CUresult CUDAAPI cuSurfObjectCreate(CUsurfObject *pSurfObject,
+                                    const CUDA_RESOURCE_DESC *pResDesc);
 
 /**
  * \brief Destroys a surface object
@@ -13936,7 +14734,8 @@ CUresult CUDAAPI cuSurfObjectDestroy(CUsurfObject surfObject);
 /**
  * \brief Returns a surface object's resource descriptor
  *
- * Returns the resource descriptor for the surface object specified by \p surfObject.
+ * Returns the resource descriptor for the surface object specified by \p
+ * surfObject.
  *
  * \param pResDesc   - Resource descriptor
  * \param surfObject - Surface object
@@ -13952,10 +14751,11 @@ CUresult CUDAAPI cuSurfObjectDestroy(CUsurfObject surfObject);
  * ::cuSurfObjectCreate,
  * ::cudaGetSurfaceObjectResourceDesc
  */
-CUresult CUDAAPI cuSurfObjectGetResourceDesc(CUDA_RESOURCE_DESC *pResDesc, CUsurfObject surfObject);
+CUresult CUDAAPI cuSurfObjectGetResourceDesc(CUDA_RESOURCE_DESC *pResDesc,
+                                             CUsurfObject surfObject);
 
 /** @} */ /* END CUDA_SURFOBJECT */
-#endif /* __CUDA_API_VERSION >= 5000 */
+#endif    /* __CUDA_API_VERSION >= 5000 */
 
 /**
  * \defgroup CUDA_PEER_ACCESS Peer Context Memory Access
@@ -13974,16 +14774,16 @@ CUresult CUDAAPI cuSurfObjectGetResourceDesc(CUDA_RESOURCE_DESC *pResDesc, CUsur
 /**
  * \brief Queries if a device may directly access a peer device's memory.
  *
- * Returns in \p *canAccessPeer a value of 1 if contexts on \p dev are capable of
- * directly accessing memory from contexts on \p peerDev and 0 otherwise.
- * If direct access of \p peerDev from \p dev is possible, then access may be
+ * Returns in \p *canAccessPeer a value of 1 if contexts on \p dev are capable
+ * of directly accessing memory from contexts on \p peerDev and 0 otherwise. If
+ * direct access of \p peerDev from \p dev is possible, then access may be
  * enabled on two specific contexts by calling ::cuCtxEnablePeerAccess().
  *
  * \param canAccessPeer - Returned access capability
  * \param dev           - Device from which allocations on \p peerDev are to
  *                        be directly accessed.
- * \param peerDev       - Device on which the allocations to be directly accessed
- *                        by \p dev reside.
+ * \param peerDev       - Device on which the allocations to be directly
+ * accessed by \p dev reside.
  *
  * \return
  * ::CUDA_SUCCESS,
@@ -13997,26 +14797,28 @@ CUresult CUDAAPI cuSurfObjectGetResourceDesc(CUDA_RESOURCE_DESC *pResDesc, CUsur
  * ::cuCtxDisablePeerAccess,
  * ::cudaDeviceCanAccessPeer
  */
-CUresult CUDAAPI cuDeviceCanAccessPeer(int *canAccessPeer, CUdevice dev, CUdevice peerDev);
+CUresult CUDAAPI cuDeviceCanAccessPeer(int *canAccessPeer, CUdevice dev,
+                                       CUdevice peerDev);
 
 /**
  * \brief Enables direct access to memory allocations in a peer context.
  *
- * If both the current context and \p peerContext are on devices which support unified
- * addressing (as may be queried using ::CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING) and same
- * major compute capability, then on success all allocations from \p peerContext will
- * immediately be accessible by the current context.  See \ref CUDA_UNIFIED for additional
+ * If both the current context and \p peerContext are on devices which support
+ * unified addressing (as may be queried using
+ * ::CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING) and same major compute capability,
+ * then on success all allocations from \p peerContext will immediately be
+ * accessible by the current context.  See \ref CUDA_UNIFIED for additional
  * details.
  *
- * Note that access granted by this call is unidirectional and that in order to access
- * memory from the current context in \p peerContext, a separate symmetric call
- * to ::cuCtxEnablePeerAccess() is required.
+ * Note that access granted by this call is unidirectional and that in order to
+ * access memory from the current context in \p peerContext, a separate
+ * symmetric call to ::cuCtxEnablePeerAccess() is required.
  *
  * There is a system-wide maximum of eight peer connections per device.
  *
- * Returns ::CUDA_ERROR_PEER_ACCESS_UNSUPPORTED if ::cuDeviceCanAccessPeer() indicates
- * that the ::CUdevice of the current context cannot directly access memory
- * from the ::CUdevice of \p peerContext.
+ * Returns ::CUDA_ERROR_PEER_ACCESS_UNSUPPORTED if ::cuDeviceCanAccessPeer()
+ * indicates that the ::CUdevice of the current context cannot directly access
+ * memory from the ::CUdevice of \p peerContext.
  *
  * Returns ::CUDA_ERROR_PEER_ACCESS_ALREADY_ENABLED if direct access of
  * \p peerContext from the current context has already been enabled.
@@ -14024,13 +14826,14 @@ CUresult CUDAAPI cuDeviceCanAccessPeer(int *canAccessPeer, CUdevice dev, CUdevic
  * Returns ::CUDA_ERROR_TOO_MANY_PEERS if direct peer access is not possible
  * because hardware resources required for peer access have been exhausted.
  *
- * Returns ::CUDA_ERROR_INVALID_CONTEXT if there is no current context, \p peerContext
- * is not a valid context, or if the current context is \p peerContext.
+ * Returns ::CUDA_ERROR_INVALID_CONTEXT if there is no current context, \p
+ * peerContext is not a valid context, or if the current context is \p
+ * peerContext.
  *
  * Returns ::CUDA_ERROR_INVALID_VALUE if \p Flags is not 0.
  *
- * \param peerContext - Peer context to enable direct access to from the current context
- * \param Flags       - Reserved for future use and must be set to 0
+ * \param peerContext - Peer context to enable direct access to from the current
+ * context \param Flags       - Reserved for future use and must be set to 0
  *
  * \return
  * ::CUDA_SUCCESS,
@@ -14048,7 +14851,8 @@ CUresult CUDAAPI cuDeviceCanAccessPeer(int *canAccessPeer, CUdevice dev, CUdevic
  * ::cuCtxDisablePeerAccess,
  * ::cudaDeviceEnablePeerAccess
  */
-CUresult CUDAAPI cuCtxEnablePeerAccess(CUcontext peerContext, unsigned int Flags);
+CUresult CUDAAPI cuCtxEnablePeerAccess(CUcontext peerContext,
+                                       unsigned int Flags);
 
 /**
  * \brief Disables direct access to memory allocations in a peer context and
@@ -14089,21 +14893,22 @@ CUresult CUDAAPI cuCtxDisablePeerAccess(CUcontext peerContext);
  * - ::CU_DEVICE_P2P_ATTRIBUTE_PERFORMANCE_RANK: A relative value indicating the
  *   performance of the link between two devices.
  * - ::CU_DEVICE_P2P_ATTRIBUTE_ACCESS_SUPPORTED P2P: 1 if P2P Access is enable.
- * - ::CU_DEVICE_P2P_ATTRIBUTE_NATIVE_ATOMIC_SUPPORTED: 1 if Atomic operations over
- *   the link are supported.
+ * - ::CU_DEVICE_P2P_ATTRIBUTE_NATIVE_ATOMIC_SUPPORTED: 1 if Atomic operations
+ * over the link are supported.
  * - ::CU_DEVICE_P2P_ATTRIBUTE_CUDA_ARRAY_ACCESS_SUPPORTED: 1 if cudaArray can
  *   be accessed over the link.
  *
- * Returns ::CUDA_ERROR_INVALID_DEVICE if \p srcDevice or \p dstDevice are not valid
- * or if they represent the same device.
+ * Returns ::CUDA_ERROR_INVALID_DEVICE if \p srcDevice or \p dstDevice are not
+ * valid or if they represent the same device.
  *
- * Returns ::CUDA_ERROR_INVALID_VALUE if \p attrib is not valid or if \p value is
- * a null pointer.
+ * Returns ::CUDA_ERROR_INVALID_VALUE if \p attrib is not valid or if \p value
+ * is a null pointer.
  *
  * \param value         - Returned value of the requested attribute
- * \param attrib        - The requested attribute of the link between \p srcDevice and \p dstDevice.
- * \param srcDevice     - The source device of the target link.
- * \param dstDevice     - The destination device of the target link.
+ * \param attrib        - The requested attribute of the link between \p
+ * srcDevice and \p dstDevice. \param srcDevice     - The source device of the
+ * target link. \param dstDevice     - The destination device of the target
+ * link.
  *
  * \return
  * ::CUDA_SUCCESS,
@@ -14119,7 +14924,10 @@ CUresult CUDAAPI cuCtxDisablePeerAccess(CUcontext peerContext);
  * ::cuDeviceCanAccessPeer,
  * ::cudaDeviceGetP2PAttribute
  */
-CUresult CUDAAPI cuDeviceGetP2PAttribute(int* value, CUdevice_P2PAttribute attrib, CUdevice srcDevice, CUdevice dstDevice);
+CUresult CUDAAPI cuDeviceGetP2PAttribute(int *value,
+                                         CUdevice_P2PAttribute attrib,
+                                         CUdevice srcDevice,
+                                         CUdevice dstDevice);
 
 #endif /* __CUDA_API_VERSION >= 8000 */
 
@@ -14168,12 +14976,13 @@ CUresult CUDAAPI cuDeviceGetP2PAttribute(int* value, CUdevice_P2PAttribute attri
 CUresult CUDAAPI cuGraphicsUnregisterResource(CUgraphicsResource resource);
 
 /**
- * \brief Get an array through which to access a subresource of a mapped graphics resource.
+ * \brief Get an array through which to access a subresource of a mapped
+ * graphics resource.
  *
  * Returns in \p *pArray an array through which the subresource of the mapped
  * graphics resource \p resource which corresponds to array index \p arrayIndex
- * and mipmap level \p mipLevel may be accessed.  The value set in \p *pArray may
- * change every time that \p resource is mapped.
+ * and mipmap level \p mipLevel may be accessed.  The value set in \p *pArray
+ * may change every time that \p resource is mapped.
  *
  * If \p resource is not a texture then it cannot be accessed via an array and
  * ::CUDA_ERROR_NOT_MAPPED_AS_ARRAY is returned.
@@ -14183,8 +14992,8 @@ CUresult CUDAAPI cuGraphicsUnregisterResource(CUgraphicsResource resource);
  * ::CUDA_ERROR_INVALID_VALUE is returned.
  * If \p resource is not mapped then ::CUDA_ERROR_NOT_MAPPED is returned.
  *
- * \param pArray      - Returned array through which a subresource of \p resource may be accessed
- * \param resource    - Mapped resource to access
+ * \param pArray      - Returned array through which a subresource of \p
+ * resource may be accessed \param resource    - Mapped resource to access
  * \param arrayIndex  - Array index for array textures or cubemap face
  *                      index as defined by ::CUarray_cubemap_face for
  *                      cubemap textures for the subresource to access
@@ -14205,23 +15014,27 @@ CUresult CUDAAPI cuGraphicsUnregisterResource(CUgraphicsResource resource);
  * ::cuGraphicsResourceGetMappedPointer,
  * ::cudaGraphicsSubResourceGetMappedArray
  */
-CUresult CUDAAPI cuGraphicsSubResourceGetMappedArray(CUarray *pArray, CUgraphicsResource resource, unsigned int arrayIndex, unsigned int mipLevel);
+CUresult CUDAAPI cuGraphicsSubResourceGetMappedArray(
+    CUarray *pArray, CUgraphicsResource resource, unsigned int arrayIndex,
+    unsigned int mipLevel);
 
 #if __CUDA_API_VERSION >= 5000
 
 /**
- * \brief Get a mipmapped array through which to access a mapped graphics resource.
+ * \brief Get a mipmapped array through which to access a mapped graphics
+ * resource.
  *
- * Returns in \p *pMipmappedArray a mipmapped array through which the mapped graphics
- * resource \p resource. The value set in \p *pMipmappedArray may change every time
- * that \p resource is mapped.
+ * Returns in \p *pMipmappedArray a mipmapped array through which the mapped
+ * graphics resource \p resource. The value set in \p *pMipmappedArray may
+ * change every time that \p resource is mapped.
  *
- * If \p resource is not a texture then it cannot be accessed via a mipmapped array and
+ * If \p resource is not a texture then it cannot be accessed via a mipmapped
+ * array and
  * ::CUDA_ERROR_NOT_MAPPED_AS_ARRAY is returned.
  * If \p resource is not mapped then ::CUDA_ERROR_NOT_MAPPED is returned.
  *
- * \param pMipmappedArray - Returned mipmapped array through which \p resource may be accessed
- * \param resource        - Mapped resource to access
+ * \param pMipmappedArray - Returned mipmapped array through which \p resource
+ * may be accessed \param resource        - Mapped resource to access
  *
  * \return
  * ::CUDA_SUCCESS,
@@ -14238,26 +15051,29 @@ CUresult CUDAAPI cuGraphicsSubResourceGetMappedArray(CUarray *pArray, CUgraphics
  * ::cuGraphicsResourceGetMappedPointer,
  * ::cudaGraphicsResourceGetMappedMipmappedArray
  */
-CUresult CUDAAPI cuGraphicsResourceGetMappedMipmappedArray(CUmipmappedArray *pMipmappedArray, CUgraphicsResource resource);
+CUresult CUDAAPI cuGraphicsResourceGetMappedMipmappedArray(
+    CUmipmappedArray *pMipmappedArray, CUgraphicsResource resource);
 
 #endif /* __CUDA_API_VERSION >= 5000 */
 
 #if __CUDA_API_VERSION >= 3020
 /**
- * \brief Get a device pointer through which to access a mapped graphics resource.
+ * \brief Get a device pointer through which to access a mapped graphics
+ * resource.
  *
  * Returns in \p *pDevPtr a pointer through which the mapped graphics resource
  * \p resource may be accessed.
- * Returns in \p pSize the size of the memory in bytes which may be accessed from that pointer.
- * The value set in \p pPointer may change every time that \p resource is mapped.
+ * Returns in \p pSize the size of the memory in bytes which may be accessed
+ * from that pointer. The value set in \p pPointer may change every time that \p
+ * resource is mapped.
  *
  * If \p resource is not a buffer then it cannot be accessed via a pointer and
  * ::CUDA_ERROR_NOT_MAPPED_AS_POINTER is returned.
  * If \p resource is not mapped then ::CUDA_ERROR_NOT_MAPPED is returned.
  * *
- * \param pDevPtr    - Returned pointer through which \p resource may be accessed
- * \param pSize      - Returned size of the buffer accessible starting at \p *pPointer
- * \param resource   - Mapped resource to access
+ * \param pDevPtr    - Returned pointer through which \p resource may be
+ * accessed \param pSize      - Returned size of the buffer accessible starting
+ * at \p *pPointer \param resource   - Mapped resource to access
  *
  * \return
  * ::CUDA_SUCCESS,
@@ -14275,7 +15091,8 @@ CUresult CUDAAPI cuGraphicsResourceGetMappedMipmappedArray(CUmipmappedArray *pMi
  * ::cuGraphicsSubResourceGetMappedArray,
  * ::cudaGraphicsResourceGetMappedPointer
  */
-CUresult CUDAAPI cuGraphicsResourceGetMappedPointer(CUdeviceptr *pDevPtr, size_t *pSize, CUgraphicsResource resource);
+CUresult CUDAAPI cuGraphicsResourceGetMappedPointer(
+    CUdeviceptr *pDevPtr, size_t *pSize, CUgraphicsResource resource);
 #endif /* __CUDA_API_VERSION >= 3020 */
 
 /**
@@ -14289,7 +15106,8 @@ CUresult CUDAAPI cuGraphicsResourceGetMappedPointer(CUdeviceptr *pDevPtr, size_t
  * - ::CU_GRAPHICS_MAP_RESOURCE_FLAGS_NONE: Specifies no hints about how this
  *   resource will be used. It is therefore assumed that this resource will be
  *   read from and written to by CUDA kernels.  This is the default value.
- * - ::CU_GRAPHICS_MAP_RESOURCE_FLAGS_READONLY: Specifies that CUDA kernels which
+ * - ::CU_GRAPHICS_MAP_RESOURCE_FLAGS_READONLY: Specifies that CUDA kernels
+ which
  *   access this resource will not write to this resource.
  * - ::CU_GRAPHICS_MAP_RESOURCE_FLAGS_WRITEDISCARD: Specifies that CUDA kernels
  *   which access this resource will not read from this resource and will
@@ -14298,7 +15116,8 @@ CUresult CUDAAPI cuGraphicsResourceGetMappedPointer(CUdeviceptr *pDevPtr, size_t
  *
  * If \p resource is presently mapped for access by CUDA then
  * ::CUDA_ERROR_ALREADY_MAPPED is returned.
- * If \p flags is not one of the above values then ::CUDA_ERROR_INVALID_VALUE is returned.
+ * If \p flags is not one of the above values then ::CUDA_ERROR_INVALID_VALUE is
+ returned.
  *
  * \param resource - Registered resource to set flags for
  * \param flags    - Parameters for resource mapping
@@ -14317,7 +15136,8 @@ CUresult CUDAAPI cuGraphicsResourceGetMappedPointer(CUdeviceptr *pDevPtr, size_t
  * ::cuGraphicsMapResources,
  * ::cudaGraphicsResourceSetMapFlags
  */
-CUresult CUDAAPI cuGraphicsResourceSetMapFlags(CUgraphicsResource resource, unsigned int flags);
+CUresult CUDAAPI cuGraphicsResourceSetMapFlags(CUgraphicsResource resource,
+                                               unsigned int flags);
 
 /**
  * \brief Map graphics resources for access by CUDA
@@ -14330,11 +15150,12 @@ CUresult CUDAAPI cuGraphicsResourceSetMapFlags(CUgraphicsResource resource, unsi
  * application does so, the results are undefined.
  *
  * This function provides the synchronization guarantee that any graphics calls
- * issued before ::cuGraphicsMapResources() will complete before any subsequent CUDA
- * work issued in \p stream begins.
+ * issued before ::cuGraphicsMapResources() will complete before any subsequent
+ * CUDA work issued in \p stream begins.
  *
- * If \p resources includes any duplicate entries then ::CUDA_ERROR_INVALID_HANDLE is returned.
- * If any of \p resources are presently mapped for access by CUDA then ::CUDA_ERROR_ALREADY_MAPPED is returned.
+ * If \p resources includes any duplicate entries then
+ * ::CUDA_ERROR_INVALID_HANDLE is returned. If any of \p resources are presently
+ * mapped for access by CUDA then ::CUDA_ERROR_ALREADY_MAPPED is returned.
  *
  * \param count      - Number of resources to map
  * \param resources  - Resources to map for CUDA usage
@@ -14357,7 +15178,9 @@ CUresult CUDAAPI cuGraphicsResourceSetMapFlags(CUgraphicsResource resource, unsi
  * ::cuGraphicsUnmapResources,
  * ::cudaGraphicsMapResources
  */
-CUresult CUDAAPI cuGraphicsMapResources(unsigned int count, CUgraphicsResource *resources, CUstream hStream);
+CUresult CUDAAPI cuGraphicsMapResources(unsigned int count,
+                                        CUgraphicsResource *resources,
+                                        CUstream hStream);
 
 /**
  * \brief Unmap graphics resources.
@@ -14367,13 +15190,14 @@ CUresult CUDAAPI cuGraphicsMapResources(unsigned int count, CUgraphicsResource *
  * Once unmapped, the resources in \p resources may not be accessed by CUDA
  * until they are mapped again.
  *
- * This function provides the synchronization guarantee that any CUDA work issued
- * in \p stream before ::cuGraphicsUnmapResources() will complete before any
- * subsequently issued graphics work begins.
+ * This function provides the synchronization guarantee that any CUDA work
+ * issued in \p stream before ::cuGraphicsUnmapResources() will complete before
+ * any subsequently issued graphics work begins.
  *
  *
- * If \p resources includes any duplicate entries then ::CUDA_ERROR_INVALID_HANDLE is returned.
- * If any of \p resources are not presently mapped for access by CUDA then ::CUDA_ERROR_NOT_MAPPED is returned.
+ * If \p resources includes any duplicate entries then
+ * ::CUDA_ERROR_INVALID_HANDLE is returned. If any of \p resources are not
+ * presently mapped for access by CUDA then ::CUDA_ERROR_NOT_MAPPED is returned.
  *
  * \param count      - Number of resources to unmap
  * \param resources  - Resources to unmap
@@ -14394,264 +15218,318 @@ CUresult CUDAAPI cuGraphicsMapResources(unsigned int count, CUgraphicsResource *
  * ::cuGraphicsMapResources,
  * ::cudaGraphicsUnmapResources
  */
-CUresult CUDAAPI cuGraphicsUnmapResources(unsigned int count, CUgraphicsResource *resources, CUstream hStream);
+CUresult CUDAAPI cuGraphicsUnmapResources(unsigned int count,
+                                          CUgraphicsResource *resources,
+                                          CUstream hStream);
 
 /** @} */ /* END CUDA_GRAPHICS */
 
-CUresult CUDAAPI cuGetExportTable(const void **ppExportTable, const CUuuid *pExportTableId);
-
+CUresult CUDAAPI cuGetExportTable(const void **ppExportTable,
+                                  const CUuuid *pExportTableId);
 
 /**
  * CUDA API versioning support
  */
 #if defined(__CUDA_API_VERSION_INTERNAL)
-    #undef cuMemHostRegister
-    #undef cuGraphicsResourceSetMapFlags
-    #undef cuLinkCreate
-    #undef cuLinkAddData
-    #undef cuLinkAddFile
-    #undef cuDeviceTotalMem
-    #undef cuCtxCreate
-    #undef cuModuleGetGlobal
-    #undef cuMemGetInfo
-    #undef cuMemAlloc
-    #undef cuMemAllocPitch
-    #undef cuMemFree
-    #undef cuMemGetAddressRange
-    #undef cuMemAllocHost
-    #undef cuMemHostGetDevicePointer
-    #undef cuMemcpyHtoD
-    #undef cuMemcpyDtoH
-    #undef cuMemcpyDtoD
-    #undef cuMemcpyDtoA
-    #undef cuMemcpyAtoD
-    #undef cuMemcpyHtoA
-    #undef cuMemcpyAtoH
-    #undef cuMemcpyAtoA
-    #undef cuMemcpyHtoAAsync
-    #undef cuMemcpyAtoHAsync
-    #undef cuMemcpy2D
-    #undef cuMemcpy2DUnaligned
-    #undef cuMemcpy3D
-    #undef cuMemcpyHtoDAsync
-    #undef cuMemcpyDtoHAsync
-    #undef cuMemcpyDtoDAsync
-    #undef cuMemcpy2DAsync
-    #undef cuMemcpy3DAsync
-    #undef cuMemsetD8
-    #undef cuMemsetD16
-    #undef cuMemsetD32
-    #undef cuMemsetD2D8
-    #undef cuMemsetD2D16
-    #undef cuMemsetD2D32
-    #undef cuArrayCreate
-    #undef cuArrayGetDescriptor
-    #undef cuArray3DCreate
-    #undef cuArray3DGetDescriptor
-    #undef cuTexRefSetAddress
-    #undef cuTexRefSetAddress2D
-    #undef cuTexRefGetAddress
-    #undef cuGraphicsResourceGetMappedPointer
-    #undef cuCtxDestroy
-    #undef cuCtxPopCurrent
-    #undef cuCtxPushCurrent
-    #undef cuStreamDestroy
-    #undef cuEventDestroy
-    #undef cuMemcpy
-    #undef cuMemcpyAsync
-    #undef cuMemcpyPeer
-    #undef cuMemcpyPeerAsync
-    #undef cuMemcpy3DPeer
-    #undef cuMemcpy3DPeerAsync
-    #undef cuMemsetD8Async
-    #undef cuMemsetD16Async
-    #undef cuMemsetD32Async
-    #undef cuMemsetD2D8Async
-    #undef cuMemsetD2D16Async
-    #undef cuMemsetD2D32Async
-    #undef cuStreamGetPriority
-    #undef cuStreamGetFlags
-    #undef cuStreamGetCtx
-    #undef cuStreamWaitEvent
-    #undef cuStreamAddCallback
-    #undef cuStreamAttachMemAsync
-    #undef cuStreamQuery
-    #undef cuStreamSynchronize
-    #undef cuEventRecord
-    #undef cuLaunchKernel
-    #undef cuLaunchHostFunc
-    #undef cuGraphicsMapResources
-    #undef cuGraphicsUnmapResources
-    #undef cuStreamWriteValue32
-    #undef cuStreamWaitValue32
-    #undef cuStreamWriteValue64
-    #undef cuStreamWaitValue64
-    #undef cuStreamBatchMemOp
-    #undef cuMemPrefetchAsync
-    #undef cuLaunchCooperativeKernel
-    #undef cuSignalExternalSemaphoresAsync
-    #undef cuWaitExternalSemaphoresAsync
-    #undef cuStreamBeginCapture
-    #undef cuStreamEndCapture
-    #undef cuStreamIsCapturing
-    #undef cuStreamGetCaptureInfo
-    #undef cuGraphLaunch
+#undef cuMemHostRegister
+#undef cuGraphicsResourceSetMapFlags
+#undef cuLinkCreate
+#undef cuLinkAddData
+#undef cuLinkAddFile
+#undef cuDeviceTotalMem
+#undef cuCtxCreate
+#undef cuModuleGetGlobal
+#undef cuMemGetInfo
+#undef cuMemAlloc
+#undef cuMemAllocPitch
+#undef cuMemFree
+#undef cuMemGetAddressRange
+#undef cuMemAllocHost
+#undef cuMemHostGetDevicePointer
+#undef cuMemcpyHtoD
+#undef cuMemcpyDtoH
+#undef cuMemcpyDtoD
+#undef cuMemcpyDtoA
+#undef cuMemcpyAtoD
+#undef cuMemcpyHtoA
+#undef cuMemcpyAtoH
+#undef cuMemcpyAtoA
+#undef cuMemcpyHtoAAsync
+#undef cuMemcpyAtoHAsync
+#undef cuMemcpy2D
+#undef cuMemcpy2DUnaligned
+#undef cuMemcpy3D
+#undef cuMemcpyHtoDAsync
+#undef cuMemcpyDtoHAsync
+#undef cuMemcpyDtoDAsync
+#undef cuMemcpy2DAsync
+#undef cuMemcpy3DAsync
+#undef cuMemsetD8
+#undef cuMemsetD16
+#undef cuMemsetD32
+#undef cuMemsetD2D8
+#undef cuMemsetD2D16
+#undef cuMemsetD2D32
+#undef cuArrayCreate
+#undef cuArrayGetDescriptor
+#undef cuArray3DCreate
+#undef cuArray3DGetDescriptor
+#undef cuTexRefSetAddress
+#undef cuTexRefSetAddress2D
+#undef cuTexRefGetAddress
+#undef cuGraphicsResourceGetMappedPointer
+#undef cuCtxDestroy
+#undef cuCtxPopCurrent
+#undef cuCtxPushCurrent
+#undef cuStreamDestroy
+#undef cuEventDestroy
+#undef cuMemcpy
+#undef cuMemcpyAsync
+#undef cuMemcpyPeer
+#undef cuMemcpyPeerAsync
+#undef cuMemcpy3DPeer
+#undef cuMemcpy3DPeerAsync
+#undef cuMemsetD8Async
+#undef cuMemsetD16Async
+#undef cuMemsetD32Async
+#undef cuMemsetD2D8Async
+#undef cuMemsetD2D16Async
+#undef cuMemsetD2D32Async
+#undef cuStreamGetPriority
+#undef cuStreamGetFlags
+#undef cuStreamGetCtx
+#undef cuStreamWaitEvent
+#undef cuStreamAddCallback
+#undef cuStreamAttachMemAsync
+#undef cuStreamQuery
+#undef cuStreamSynchronize
+#undef cuEventRecord
+#undef cuLaunchKernel
+#undef cuLaunchHostFunc
+#undef cuGraphicsMapResources
+#undef cuGraphicsUnmapResources
+#undef cuStreamWriteValue32
+#undef cuStreamWaitValue32
+#undef cuStreamWriteValue64
+#undef cuStreamWaitValue64
+#undef cuStreamBatchMemOp
+#undef cuMemPrefetchAsync
+#undef cuLaunchCooperativeKernel
+#undef cuSignalExternalSemaphoresAsync
+#undef cuWaitExternalSemaphoresAsync
+#undef cuStreamBeginCapture
+#undef cuStreamEndCapture
+#undef cuStreamIsCapturing
+#undef cuStreamGetCaptureInfo
+#undef cuGraphLaunch
 #endif /* __CUDA_API_VERSION_INTERNAL */
 
-#if defined(__CUDA_API_VERSION_INTERNAL) || (__CUDA_API_VERSION >= 4000 && __CUDA_API_VERSION < 6050)
-CUresult CUDAAPI cuMemHostRegister(void *p, size_t bytesize, unsigned int Flags);
-#endif /* defined(__CUDA_API_VERSION_INTERNAL) || (__CUDA_API_VERSION >= 4000 && __CUDA_API_VERSION < 6050) */
+#if defined(__CUDA_API_VERSION_INTERNAL) || \
+    (__CUDA_API_VERSION >= 4000 && __CUDA_API_VERSION < 6050)
+CUresult CUDAAPI cuMemHostRegister(void *p, size_t bytesize,
+                                   unsigned int Flags);
+#endif /* defined(__CUDA_API_VERSION_INTERNAL) || (__CUDA_API_VERSION >= 4000 \
+          && __CUDA_API_VERSION < 6050) */
 
 #if defined(__CUDA_API_VERSION_INTERNAL) || __CUDA_API_VERSION < 6050
-CUresult CUDAAPI cuGraphicsResourceSetMapFlags(CUgraphicsResource resource, unsigned int flags);
+CUresult CUDAAPI cuGraphicsResourceSetMapFlags(CUgraphicsResource resource,
+                                               unsigned int flags);
 #endif /* defined(__CUDA_API_VERSION_INTERNAL) || __CUDA_API_VERSION < 6050 */
 
-#if defined(__CUDA_API_VERSION_INTERNAL) || (__CUDA_API_VERSION >= 5050 && __CUDA_API_VERSION < 6050)
-CUresult CUDAAPI cuLinkCreate(unsigned int numOptions, CUjit_option *options, void **optionValues, CUlinkState *stateOut);
-CUresult CUDAAPI cuLinkAddData(CUlinkState state, CUjitInputType type, void *data, size_t size, const char *name,
-    unsigned int numOptions, CUjit_option *options, void **optionValues);
-CUresult CUDAAPI cuLinkAddFile(CUlinkState state, CUjitInputType type, const char *path,
-    unsigned int numOptions, CUjit_option *options, void **optionValues);
-#endif /* __CUDA_API_VERSION_INTERNAL || (__CUDA_API_VERSION >= 5050 && __CUDA_API_VERSION < 6050) */
+#if defined(__CUDA_API_VERSION_INTERNAL) || \
+    (__CUDA_API_VERSION >= 5050 && __CUDA_API_VERSION < 6050)
+CUresult CUDAAPI cuLinkCreate(unsigned int numOptions, CUjit_option *options,
+                              void **optionValues, CUlinkState *stateOut);
+CUresult CUDAAPI cuLinkAddData(CUlinkState state, CUjitInputType type,
+                               void *data, size_t size, const char *name,
+                               unsigned int numOptions, CUjit_option *options,
+                               void **optionValues);
+CUresult CUDAAPI cuLinkAddFile(CUlinkState state, CUjitInputType type,
+                               const char *path, unsigned int numOptions,
+                               CUjit_option *options, void **optionValues);
+#endif /* __CUDA_API_VERSION_INTERNAL || (__CUDA_API_VERSION >= 5050 && \
+          __CUDA_API_VERSION < 6050) */
 
-#if defined(__CUDA_API_VERSION_INTERNAL) || (__CUDA_API_VERSION >= 3020 && __CUDA_API_VERSION < 4010)
-CUresult CUDAAPI cuTexRefSetAddress2D_v2(CUtexref hTexRef, const CUDA_ARRAY_DESCRIPTOR *desc, CUdeviceptr dptr, size_t Pitch);
-#endif /* __CUDA_API_VERSION_INTERNAL || (__CUDA_API_VERSION >= 3020 && __CUDA_API_VERSION < 4010) */
+#if defined(__CUDA_API_VERSION_INTERNAL) || \
+    (__CUDA_API_VERSION >= 3020 && __CUDA_API_VERSION < 4010)
+CUresult CUDAAPI cuTexRefSetAddress2D_v2(CUtexref hTexRef,
+                                         const CUDA_ARRAY_DESCRIPTOR *desc,
+                                         CUdeviceptr dptr, size_t Pitch);
+#endif /* __CUDA_API_VERSION_INTERNAL || (__CUDA_API_VERSION >= 3020 && \
+          __CUDA_API_VERSION < 4010) */
 
 /**
  * CUDA API made obselete at API version 3020
  */
 #if defined(__CUDA_API_VERSION_INTERNAL)
-    #define CUdeviceptr                  CUdeviceptr_v1
-    #define CUDA_MEMCPY2D_st             CUDA_MEMCPY2D_v1_st
-    #define CUDA_MEMCPY2D                CUDA_MEMCPY2D_v1
-    #define CUDA_MEMCPY3D_st             CUDA_MEMCPY3D_v1_st
-    #define CUDA_MEMCPY3D                CUDA_MEMCPY3D_v1
-    #define CUDA_ARRAY_DESCRIPTOR_st     CUDA_ARRAY_DESCRIPTOR_v1_st
-    #define CUDA_ARRAY_DESCRIPTOR        CUDA_ARRAY_DESCRIPTOR_v1
-    #define CUDA_ARRAY3D_DESCRIPTOR_st   CUDA_ARRAY3D_DESCRIPTOR_v1_st
-    #define CUDA_ARRAY3D_DESCRIPTOR      CUDA_ARRAY3D_DESCRIPTOR_v1
+#define CUdeviceptr CUdeviceptr_v1
+#define CUDA_MEMCPY2D_st CUDA_MEMCPY2D_v1_st
+#define CUDA_MEMCPY2D CUDA_MEMCPY2D_v1
+#define CUDA_MEMCPY3D_st CUDA_MEMCPY3D_v1_st
+#define CUDA_MEMCPY3D CUDA_MEMCPY3D_v1
+#define CUDA_ARRAY_DESCRIPTOR_st CUDA_ARRAY_DESCRIPTOR_v1_st
+#define CUDA_ARRAY_DESCRIPTOR CUDA_ARRAY_DESCRIPTOR_v1
+#define CUDA_ARRAY3D_DESCRIPTOR_st CUDA_ARRAY3D_DESCRIPTOR_v1_st
+#define CUDA_ARRAY3D_DESCRIPTOR CUDA_ARRAY3D_DESCRIPTOR_v1
 #endif /* CUDA_FORCE_LEGACY32_INTERNAL */
 
 #if defined(__CUDA_API_VERSION_INTERNAL) || __CUDA_API_VERSION < 3020
 
 typedef unsigned int CUdeviceptr;
 
-typedef struct CUDA_MEMCPY2D_st
-{
-    unsigned int srcXInBytes;   /**< Source X in bytes */
-    unsigned int srcY;          /**< Source Y */
-    CUmemorytype srcMemoryType; /**< Source memory type (host, device, array) */
-    const void *srcHost;        /**< Source host pointer */
-    CUdeviceptr srcDevice;      /**< Source device pointer */
-    CUarray srcArray;           /**< Source array reference */
-    unsigned int srcPitch;      /**< Source pitch (ignored when src is array) */
+typedef struct CUDA_MEMCPY2D_st {
+  unsigned int srcXInBytes;   /**< Source X in bytes */
+  unsigned int srcY;          /**< Source Y */
+  CUmemorytype srcMemoryType; /**< Source memory type (host, device, array) */
+  const void *srcHost;        /**< Source host pointer */
+  CUdeviceptr srcDevice;      /**< Source device pointer */
+  CUarray srcArray;           /**< Source array reference */
+  unsigned int srcPitch;      /**< Source pitch (ignored when src is array) */
 
-    unsigned int dstXInBytes;   /**< Destination X in bytes */
-    unsigned int dstY;          /**< Destination Y */
-    CUmemorytype dstMemoryType; /**< Destination memory type (host, device, array) */
-    void *dstHost;              /**< Destination host pointer */
-    CUdeviceptr dstDevice;      /**< Destination device pointer */
-    CUarray dstArray;           /**< Destination array reference */
-    unsigned int dstPitch;      /**< Destination pitch (ignored when dst is array) */
+  unsigned int dstXInBytes; /**< Destination X in bytes */
+  unsigned int dstY;        /**< Destination Y */
+  CUmemorytype
+      dstMemoryType;     /**< Destination memory type (host, device, array) */
+  void *dstHost;         /**< Destination host pointer */
+  CUdeviceptr dstDevice; /**< Destination device pointer */
+  CUarray dstArray;      /**< Destination array reference */
+  unsigned int dstPitch; /**< Destination pitch (ignored when dst is array) */
 
-    unsigned int WidthInBytes;  /**< Width of 2D memory copy in bytes */
-    unsigned int Height;        /**< Height of 2D memory copy */
+  unsigned int WidthInBytes; /**< Width of 2D memory copy in bytes */
+  unsigned int Height;       /**< Height of 2D memory copy */
 } CUDA_MEMCPY2D;
 
-typedef struct CUDA_MEMCPY3D_st
-{
-    unsigned int srcXInBytes;   /**< Source X in bytes */
-    unsigned int srcY;          /**< Source Y */
-    unsigned int srcZ;          /**< Source Z */
-    unsigned int srcLOD;        /**< Source LOD */
-    CUmemorytype srcMemoryType; /**< Source memory type (host, device, array) */
-    const void *srcHost;        /**< Source host pointer */
-    CUdeviceptr srcDevice;      /**< Source device pointer */
-    CUarray srcArray;           /**< Source array reference */
-    void *reserved0;            /**< Must be NULL */
-    unsigned int srcPitch;      /**< Source pitch (ignored when src is array) */
-    unsigned int srcHeight;     /**< Source height (ignored when src is array; may be 0 if Depth==1) */
+typedef struct CUDA_MEMCPY3D_st {
+  unsigned int srcXInBytes;   /**< Source X in bytes */
+  unsigned int srcY;          /**< Source Y */
+  unsigned int srcZ;          /**< Source Z */
+  unsigned int srcLOD;        /**< Source LOD */
+  CUmemorytype srcMemoryType; /**< Source memory type (host, device, array) */
+  const void *srcHost;        /**< Source host pointer */
+  CUdeviceptr srcDevice;      /**< Source device pointer */
+  CUarray srcArray;           /**< Source array reference */
+  void *reserved0;            /**< Must be NULL */
+  unsigned int srcPitch;      /**< Source pitch (ignored when src is array) */
+  unsigned int srcHeight; /**< Source height (ignored when src is array; may be
+                             0 if Depth==1) */
 
-    unsigned int dstXInBytes;   /**< Destination X in bytes */
-    unsigned int dstY;          /**< Destination Y */
-    unsigned int dstZ;          /**< Destination Z */
-    unsigned int dstLOD;        /**< Destination LOD */
-    CUmemorytype dstMemoryType; /**< Destination memory type (host, device, array) */
-    void *dstHost;              /**< Destination host pointer */
-    CUdeviceptr dstDevice;      /**< Destination device pointer */
-    CUarray dstArray;           /**< Destination array reference */
-    void *reserved1;            /**< Must be NULL */
-    unsigned int dstPitch;      /**< Destination pitch (ignored when dst is array) */
-    unsigned int dstHeight;     /**< Destination height (ignored when dst is array; may be 0 if Depth==1) */
+  unsigned int dstXInBytes; /**< Destination X in bytes */
+  unsigned int dstY;        /**< Destination Y */
+  unsigned int dstZ;        /**< Destination Z */
+  unsigned int dstLOD;      /**< Destination LOD */
+  CUmemorytype
+      dstMemoryType;      /**< Destination memory type (host, device, array) */
+  void *dstHost;          /**< Destination host pointer */
+  CUdeviceptr dstDevice;  /**< Destination device pointer */
+  CUarray dstArray;       /**< Destination array reference */
+  void *reserved1;        /**< Must be NULL */
+  unsigned int dstPitch;  /**< Destination pitch (ignored when dst is array) */
+  unsigned int dstHeight; /**< Destination height (ignored when dst is array;
+                             may be 0 if Depth==1) */
 
-    unsigned int WidthInBytes;  /**< Width of 3D memory copy in bytes */
-    unsigned int Height;        /**< Height of 3D memory copy */
-    unsigned int Depth;         /**< Depth of 3D memory copy */
+  unsigned int WidthInBytes; /**< Width of 3D memory copy in bytes */
+  unsigned int Height;       /**< Height of 3D memory copy */
+  unsigned int Depth;        /**< Depth of 3D memory copy */
 } CUDA_MEMCPY3D;
 
-typedef struct CUDA_ARRAY_DESCRIPTOR_st
-{
-    unsigned int Width;         /**< Width of array */
-    unsigned int Height;        /**< Height of array */
+typedef struct CUDA_ARRAY_DESCRIPTOR_st {
+  unsigned int Width;  /**< Width of array */
+  unsigned int Height; /**< Height of array */
 
-    CUarray_format Format;      /**< Array format */
-    unsigned int NumChannels;   /**< Channels per array element */
+  CUarray_format Format;    /**< Array format */
+  unsigned int NumChannels; /**< Channels per array element */
 } CUDA_ARRAY_DESCRIPTOR;
 
-typedef struct CUDA_ARRAY3D_DESCRIPTOR_st
-{
-    unsigned int Width;         /**< Width of 3D array */
-    unsigned int Height;        /**< Height of 3D array */
-    unsigned int Depth;         /**< Depth of 3D array */
+typedef struct CUDA_ARRAY3D_DESCRIPTOR_st {
+  unsigned int Width;  /**< Width of 3D array */
+  unsigned int Height; /**< Height of 3D array */
+  unsigned int Depth;  /**< Depth of 3D array */
 
-    CUarray_format Format;      /**< Array format */
-    unsigned int NumChannels;   /**< Channels per array element */
-    unsigned int Flags;         /**< Flags */
+  CUarray_format Format;    /**< Array format */
+  unsigned int NumChannels; /**< Channels per array element */
+  unsigned int Flags;       /**< Flags */
 } CUDA_ARRAY3D_DESCRIPTOR;
 
 CUresult CUDAAPI cuDeviceTotalMem(unsigned int *bytes, CUdevice dev);
 CUresult CUDAAPI cuCtxCreate(CUcontext *pctx, unsigned int flags, CUdevice dev);
-CUresult CUDAAPI cuModuleGetGlobal(CUdeviceptr *dptr, unsigned int *bytes, CUmodule hmod, const char *name);
+CUresult CUDAAPI cuModuleGetGlobal(CUdeviceptr *dptr, unsigned int *bytes,
+                                   CUmodule hmod, const char *name);
 CUresult CUDAAPI cuMemGetInfo(unsigned int *free, unsigned int *total);
 CUresult CUDAAPI cuMemAlloc(CUdeviceptr *dptr, unsigned int bytesize);
-CUresult CUDAAPI cuMemAllocPitch(CUdeviceptr *dptr, unsigned int *pPitch, unsigned int WidthInBytes, unsigned int Height, unsigned int ElementSizeBytes);
+CUresult CUDAAPI cuMemAllocPitch(CUdeviceptr *dptr, unsigned int *pPitch,
+                                 unsigned int WidthInBytes, unsigned int Height,
+                                 unsigned int ElementSizeBytes);
 CUresult CUDAAPI cuMemFree(CUdeviceptr dptr);
-CUresult CUDAAPI cuMemGetAddressRange(CUdeviceptr *pbase, unsigned int *psize, CUdeviceptr dptr);
+CUresult CUDAAPI cuMemGetAddressRange(CUdeviceptr *pbase, unsigned int *psize,
+                                      CUdeviceptr dptr);
 CUresult CUDAAPI cuMemAllocHost(void **pp, unsigned int bytesize);
-CUresult CUDAAPI cuMemHostGetDevicePointer(CUdeviceptr *pdptr, void *p, unsigned int Flags);
-CUresult CUDAAPI cuMemcpyHtoD(CUdeviceptr dstDevice, const void *srcHost, unsigned int ByteCount);
-CUresult CUDAAPI cuMemcpyDtoH(void *dstHost, CUdeviceptr srcDevice, unsigned int ByteCount);
-CUresult CUDAAPI cuMemcpyDtoD(CUdeviceptr dstDevice, CUdeviceptr srcDevice, unsigned int ByteCount);
-CUresult CUDAAPI cuMemcpyDtoA(CUarray dstArray, unsigned int dstOffset, CUdeviceptr srcDevice, unsigned int ByteCount);
-CUresult CUDAAPI cuMemcpyAtoD(CUdeviceptr dstDevice, CUarray srcArray, unsigned int srcOffset, unsigned int ByteCount);
-CUresult CUDAAPI cuMemcpyHtoA(CUarray dstArray, unsigned int dstOffset, const void *srcHost, unsigned int ByteCount);
-CUresult CUDAAPI cuMemcpyAtoH(void *dstHost, CUarray srcArray, unsigned int srcOffset, unsigned int ByteCount);
-CUresult CUDAAPI cuMemcpyAtoA(CUarray dstArray, unsigned int dstOffset, CUarray srcArray, unsigned int srcOffset, unsigned int ByteCount);
-CUresult CUDAAPI cuMemcpyHtoAAsync(CUarray dstArray, unsigned int dstOffset, const void *srcHost, unsigned int ByteCount, CUstream hStream);
-CUresult CUDAAPI cuMemcpyAtoHAsync(void *dstHost, CUarray srcArray, unsigned int srcOffset, unsigned int ByteCount, CUstream hStream);
+CUresult CUDAAPI cuMemHostGetDevicePointer(CUdeviceptr *pdptr, void *p,
+                                           unsigned int Flags);
+CUresult CUDAAPI cuMemcpyHtoD(CUdeviceptr dstDevice, const void *srcHost,
+                              unsigned int ByteCount);
+CUresult CUDAAPI cuMemcpyDtoH(void *dstHost, CUdeviceptr srcDevice,
+                              unsigned int ByteCount);
+CUresult CUDAAPI cuMemcpyDtoD(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
+                              unsigned int ByteCount);
+CUresult CUDAAPI cuMemcpyDtoA(CUarray dstArray, unsigned int dstOffset,
+                              CUdeviceptr srcDevice, unsigned int ByteCount);
+CUresult CUDAAPI cuMemcpyAtoD(CUdeviceptr dstDevice, CUarray srcArray,
+                              unsigned int srcOffset, unsigned int ByteCount);
+CUresult CUDAAPI cuMemcpyHtoA(CUarray dstArray, unsigned int dstOffset,
+                              const void *srcHost, unsigned int ByteCount);
+CUresult CUDAAPI cuMemcpyAtoH(void *dstHost, CUarray srcArray,
+                              unsigned int srcOffset, unsigned int ByteCount);
+CUresult CUDAAPI cuMemcpyAtoA(CUarray dstArray, unsigned int dstOffset,
+                              CUarray srcArray, unsigned int srcOffset,
+                              unsigned int ByteCount);
+CUresult CUDAAPI cuMemcpyHtoAAsync(CUarray dstArray, unsigned int dstOffset,
+                                   const void *srcHost, unsigned int ByteCount,
+                                   CUstream hStream);
+CUresult CUDAAPI cuMemcpyAtoHAsync(void *dstHost, CUarray srcArray,
+                                   unsigned int srcOffset,
+                                   unsigned int ByteCount, CUstream hStream);
 CUresult CUDAAPI cuMemcpy2D(const CUDA_MEMCPY2D *pCopy);
 CUresult CUDAAPI cuMemcpy2DUnaligned(const CUDA_MEMCPY2D *pCopy);
 CUresult CUDAAPI cuMemcpy3D(const CUDA_MEMCPY3D *pCopy);
-CUresult CUDAAPI cuMemcpyHtoDAsync(CUdeviceptr dstDevice, const void *srcHost, unsigned int ByteCount, CUstream hStream);
-CUresult CUDAAPI cuMemcpyDtoHAsync(void *dstHost, CUdeviceptr srcDevice, unsigned int ByteCount, CUstream hStream);
-CUresult CUDAAPI cuMemcpyDtoDAsync(CUdeviceptr dstDevice, CUdeviceptr srcDevice, unsigned int ByteCount, CUstream hStream);
+CUresult CUDAAPI cuMemcpyHtoDAsync(CUdeviceptr dstDevice, const void *srcHost,
+                                   unsigned int ByteCount, CUstream hStream);
+CUresult CUDAAPI cuMemcpyDtoHAsync(void *dstHost, CUdeviceptr srcDevice,
+                                   unsigned int ByteCount, CUstream hStream);
+CUresult CUDAAPI cuMemcpyDtoDAsync(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
+                                   unsigned int ByteCount, CUstream hStream);
 CUresult CUDAAPI cuMemcpy2DAsync(const CUDA_MEMCPY2D *pCopy, CUstream hStream);
 CUresult CUDAAPI cuMemcpy3DAsync(const CUDA_MEMCPY3D *pCopy, CUstream hStream);
-CUresult CUDAAPI cuMemsetD8(CUdeviceptr dstDevice, unsigned char uc, unsigned int N);
-CUresult CUDAAPI cuMemsetD16(CUdeviceptr dstDevice, unsigned short us, unsigned int N);
-CUresult CUDAAPI cuMemsetD32(CUdeviceptr dstDevice, unsigned int ui, unsigned int N);
-CUresult CUDAAPI cuMemsetD2D8(CUdeviceptr dstDevice, unsigned int dstPitch, unsigned char uc, unsigned int Width, unsigned int Height);
-CUresult CUDAAPI cuMemsetD2D16(CUdeviceptr dstDevice, unsigned int dstPitch, unsigned short us, unsigned int Width, unsigned int Height);
-CUresult CUDAAPI cuMemsetD2D32(CUdeviceptr dstDevice, unsigned int dstPitch, unsigned int ui, unsigned int Width, unsigned int Height);
-CUresult CUDAAPI cuArrayCreate(CUarray *pHandle, const CUDA_ARRAY_DESCRIPTOR *pAllocateArray);
-CUresult CUDAAPI cuArrayGetDescriptor(CUDA_ARRAY_DESCRIPTOR *pArrayDescriptor, CUarray hArray);
-CUresult CUDAAPI cuArray3DCreate(CUarray *pHandle, const CUDA_ARRAY3D_DESCRIPTOR *pAllocateArray);
-CUresult CUDAAPI cuArray3DGetDescriptor(CUDA_ARRAY3D_DESCRIPTOR *pArrayDescriptor, CUarray hArray);
-CUresult CUDAAPI cuTexRefSetAddress(unsigned int *ByteOffset, CUtexref hTexRef, CUdeviceptr dptr, unsigned int bytes);
-CUresult CUDAAPI cuTexRefSetAddress2D(CUtexref hTexRef, const CUDA_ARRAY_DESCRIPTOR *desc, CUdeviceptr dptr, unsigned int Pitch);
+CUresult CUDAAPI cuMemsetD8(CUdeviceptr dstDevice, unsigned char uc,
+                            unsigned int N);
+CUresult CUDAAPI cuMemsetD16(CUdeviceptr dstDevice, unsigned short us,
+                             unsigned int N);
+CUresult CUDAAPI cuMemsetD32(CUdeviceptr dstDevice, unsigned int ui,
+                             unsigned int N);
+CUresult CUDAAPI cuMemsetD2D8(CUdeviceptr dstDevice, unsigned int dstPitch,
+                              unsigned char uc, unsigned int Width,
+                              unsigned int Height);
+CUresult CUDAAPI cuMemsetD2D16(CUdeviceptr dstDevice, unsigned int dstPitch,
+                               unsigned short us, unsigned int Width,
+                               unsigned int Height);
+CUresult CUDAAPI cuMemsetD2D32(CUdeviceptr dstDevice, unsigned int dstPitch,
+                               unsigned int ui, unsigned int Width,
+                               unsigned int Height);
+CUresult CUDAAPI cuArrayCreate(CUarray *pHandle,
+                               const CUDA_ARRAY_DESCRIPTOR *pAllocateArray);
+CUresult CUDAAPI cuArrayGetDescriptor(CUDA_ARRAY_DESCRIPTOR *pArrayDescriptor,
+                                      CUarray hArray);
+CUresult CUDAAPI cuArray3DCreate(CUarray *pHandle,
+                                 const CUDA_ARRAY3D_DESCRIPTOR *pAllocateArray);
+CUresult CUDAAPI cuArray3DGetDescriptor(
+    CUDA_ARRAY3D_DESCRIPTOR *pArrayDescriptor, CUarray hArray);
+CUresult CUDAAPI cuTexRefSetAddress(unsigned int *ByteOffset, CUtexref hTexRef,
+                                    CUdeviceptr dptr, unsigned int bytes);
+CUresult CUDAAPI cuTexRefSetAddress2D(CUtexref hTexRef,
+                                      const CUDA_ARRAY_DESCRIPTOR *desc,
+                                      CUdeviceptr dptr, unsigned int Pitch);
 CUresult CUDAAPI cuTexRefGetAddress(CUdeviceptr *pdptr, CUtexref hTexRef);
-CUresult CUDAAPI cuGraphicsResourceGetMappedPointer(CUdeviceptr *pDevPtr, unsigned int *pSize, CUgraphicsResource resource);
+CUresult CUDAAPI cuGraphicsResourceGetMappedPointer(
+    CUdeviceptr *pDevPtr, unsigned int *pSize, CUgraphicsResource resource);
 #endif /* __CUDA_API_VERSION_INTERNAL || __CUDA_API_VERSION < 3020 */
 #if defined(__CUDA_API_VERSION_INTERNAL) || __CUDA_API_VERSION < 4000
 CUresult CUDAAPI cuCtxDestroy(CUcontext ctx);
@@ -14661,85 +15539,162 @@ CUresult CUDAAPI cuStreamDestroy(CUstream hStream);
 CUresult CUDAAPI cuEventDestroy(CUevent hEvent);
 #endif /* __CUDA_API_VERSION_INTERNAL || __CUDA_API_VERSION < 4000 */
 #if defined(__CUDA_API_VERSION_INTERNAL)
-    #undef CUdeviceptr
-    #undef CUDA_MEMCPY2D_st
-    #undef CUDA_MEMCPY2D
-    #undef CUDA_MEMCPY3D_st
-    #undef CUDA_MEMCPY3D
-    #undef CUDA_ARRAY_DESCRIPTOR_st
-    #undef CUDA_ARRAY_DESCRIPTOR
-    #undef CUDA_ARRAY3D_DESCRIPTOR_st
-    #undef CUDA_ARRAY3D_DESCRIPTOR
+#undef CUdeviceptr
+#undef CUDA_MEMCPY2D_st
+#undef CUDA_MEMCPY2D
+#undef CUDA_MEMCPY3D_st
+#undef CUDA_MEMCPY3D
+#undef CUDA_ARRAY_DESCRIPTOR_st
+#undef CUDA_ARRAY_DESCRIPTOR
+#undef CUDA_ARRAY3D_DESCRIPTOR_st
+#undef CUDA_ARRAY3D_DESCRIPTOR
 #endif /* __CUDA_API_VERSION_INTERNAL */
 
 #if defined(__CUDA_API_VERSION_INTERNAL)
-    CUresult CUDAAPI cuMemcpyHtoD_v2(CUdeviceptr dstDevice, const void *srcHost, size_t ByteCount);
-    CUresult CUDAAPI cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice, size_t ByteCount);
-    CUresult CUDAAPI cuMemcpyDtoD_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice, size_t ByteCount);
-    CUresult CUDAAPI cuMemcpyDtoA_v2(CUarray dstArray, size_t dstOffset, CUdeviceptr srcDevice, size_t ByteCount);
-    CUresult CUDAAPI cuMemcpyAtoD_v2(CUdeviceptr dstDevice, CUarray srcArray, size_t srcOffset, size_t ByteCount);
-    CUresult CUDAAPI cuMemcpyHtoA_v2(CUarray dstArray, size_t dstOffset, const void *srcHost, size_t ByteCount);
-    CUresult CUDAAPI cuMemcpyAtoH_v2(void *dstHost, CUarray srcArray, size_t srcOffset, size_t ByteCount);
-    CUresult CUDAAPI cuMemcpyAtoA_v2(CUarray dstArray, size_t dstOffset, CUarray srcArray, size_t srcOffset, size_t ByteCount);
-    CUresult CUDAAPI cuMemcpyHtoAAsync_v2(CUarray dstArray, size_t dstOffset, const void *srcHost, size_t ByteCount, CUstream hStream);
-    CUresult CUDAAPI cuMemcpyAtoHAsync_v2(void *dstHost, CUarray srcArray, size_t srcOffset, size_t ByteCount, CUstream hStream);
-    CUresult CUDAAPI cuMemcpy2D_v2(const CUDA_MEMCPY2D *pCopy);
-    CUresult CUDAAPI cuMemcpy2DUnaligned_v2(const CUDA_MEMCPY2D *pCopy);
-    CUresult CUDAAPI cuMemcpy3D_v2(const CUDA_MEMCPY3D *pCopy);
-    CUresult CUDAAPI cuMemcpyHtoDAsync_v2(CUdeviceptr dstDevice, const void *srcHost, size_t ByteCount, CUstream hStream);
-    CUresult CUDAAPI cuMemcpyDtoHAsync_v2(void *dstHost, CUdeviceptr srcDevice, size_t ByteCount, CUstream hStream);
-    CUresult CUDAAPI cuMemcpyDtoDAsync_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice, size_t ByteCount, CUstream hStream);
-    CUresult CUDAAPI cuMemcpy2DAsync_v2(const CUDA_MEMCPY2D *pCopy, CUstream hStream);
-    CUresult CUDAAPI cuMemcpy3DAsync_v2(const CUDA_MEMCPY3D *pCopy, CUstream hStream);
-    CUresult CUDAAPI cuMemsetD8_v2(CUdeviceptr dstDevice, unsigned char uc, size_t N);
-    CUresult CUDAAPI cuMemsetD16_v2(CUdeviceptr dstDevice, unsigned short us, size_t N);
-    CUresult CUDAAPI cuMemsetD32_v2(CUdeviceptr dstDevice, unsigned int ui, size_t N);
-    CUresult CUDAAPI cuMemsetD2D8_v2(CUdeviceptr dstDevice, size_t dstPitch, unsigned char uc, size_t Width, size_t Height);
-    CUresult CUDAAPI cuMemsetD2D16_v2(CUdeviceptr dstDevice, size_t dstPitch, unsigned short us, size_t Width, size_t Height);
-    CUresult CUDAAPI cuMemsetD2D32_v2(CUdeviceptr dstDevice, size_t dstPitch, unsigned int ui, size_t Width, size_t Height);
-    CUresult CUDAAPI cuMemcpy(CUdeviceptr dst, CUdeviceptr src, size_t ByteCount);
-    CUresult CUDAAPI cuMemcpyAsync(CUdeviceptr dst, CUdeviceptr src, size_t ByteCount, CUstream hStream);
-    CUresult CUDAAPI cuMemcpyPeer(CUdeviceptr dstDevice, CUcontext dstContext, CUdeviceptr srcDevice, CUcontext srcContext, size_t ByteCount);
-    CUresult CUDAAPI cuMemcpyPeerAsync(CUdeviceptr dstDevice, CUcontext dstContext, CUdeviceptr srcDevice, CUcontext srcContext, size_t ByteCount, CUstream hStream);
-    CUresult CUDAAPI cuMemcpy3DPeer(const CUDA_MEMCPY3D_PEER *pCopy);
-    CUresult CUDAAPI cuMemcpy3DPeerAsync(const CUDA_MEMCPY3D_PEER *pCopy, CUstream hStream);
+CUresult CUDAAPI cuMemcpyHtoD_v2(CUdeviceptr dstDevice, const void *srcHost,
+                                 size_t ByteCount);
+CUresult CUDAAPI cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
+                                 size_t ByteCount);
+CUresult CUDAAPI cuMemcpyDtoD_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
+                                 size_t ByteCount);
+CUresult CUDAAPI cuMemcpyDtoA_v2(CUarray dstArray, size_t dstOffset,
+                                 CUdeviceptr srcDevice, size_t ByteCount);
+CUresult CUDAAPI cuMemcpyAtoD_v2(CUdeviceptr dstDevice, CUarray srcArray,
+                                 size_t srcOffset, size_t ByteCount);
+CUresult CUDAAPI cuMemcpyHtoA_v2(CUarray dstArray, size_t dstOffset,
+                                 const void *srcHost, size_t ByteCount);
+CUresult CUDAAPI cuMemcpyAtoH_v2(void *dstHost, CUarray srcArray,
+                                 size_t srcOffset, size_t ByteCount);
+CUresult CUDAAPI cuMemcpyAtoA_v2(CUarray dstArray, size_t dstOffset,
+                                 CUarray srcArray, size_t srcOffset,
+                                 size_t ByteCount);
+CUresult CUDAAPI cuMemcpyHtoAAsync_v2(CUarray dstArray, size_t dstOffset,
+                                      const void *srcHost, size_t ByteCount,
+                                      CUstream hStream);
+CUresult CUDAAPI cuMemcpyAtoHAsync_v2(void *dstHost, CUarray srcArray,
+                                      size_t srcOffset, size_t ByteCount,
+                                      CUstream hStream);
+CUresult CUDAAPI cuMemcpy2D_v2(const CUDA_MEMCPY2D *pCopy);
+CUresult CUDAAPI cuMemcpy2DUnaligned_v2(const CUDA_MEMCPY2D *pCopy);
+CUresult CUDAAPI cuMemcpy3D_v2(const CUDA_MEMCPY3D *pCopy);
+CUresult CUDAAPI cuMemcpyHtoDAsync_v2(CUdeviceptr dstDevice,
+                                      const void *srcHost, size_t ByteCount,
+                                      CUstream hStream);
+CUresult CUDAAPI cuMemcpyDtoHAsync_v2(void *dstHost, CUdeviceptr srcDevice,
+                                      size_t ByteCount, CUstream hStream);
+CUresult CUDAAPI cuMemcpyDtoDAsync_v2(CUdeviceptr dstDevice,
+                                      CUdeviceptr srcDevice, size_t ByteCount,
+                                      CUstream hStream);
+CUresult CUDAAPI cuMemcpy2DAsync_v2(const CUDA_MEMCPY2D *pCopy,
+                                    CUstream hStream);
+CUresult CUDAAPI cuMemcpy3DAsync_v2(const CUDA_MEMCPY3D *pCopy,
+                                    CUstream hStream);
+CUresult CUDAAPI cuMemsetD8_v2(CUdeviceptr dstDevice, unsigned char uc,
+                               size_t N);
+CUresult CUDAAPI cuMemsetD16_v2(CUdeviceptr dstDevice, unsigned short us,
+                                size_t N);
+CUresult CUDAAPI cuMemsetD32_v2(CUdeviceptr dstDevice, unsigned int ui,
+                                size_t N);
+CUresult CUDAAPI cuMemsetD2D8_v2(CUdeviceptr dstDevice, size_t dstPitch,
+                                 unsigned char uc, size_t Width, size_t Height);
+CUresult CUDAAPI cuMemsetD2D16_v2(CUdeviceptr dstDevice, size_t dstPitch,
+                                  unsigned short us, size_t Width,
+                                  size_t Height);
+CUresult CUDAAPI cuMemsetD2D32_v2(CUdeviceptr dstDevice, size_t dstPitch,
+                                  unsigned int ui, size_t Width, size_t Height);
+CUresult CUDAAPI cuMemcpy(CUdeviceptr dst, CUdeviceptr src, size_t ByteCount);
+CUresult CUDAAPI cuMemcpyAsync(CUdeviceptr dst, CUdeviceptr src,
+                               size_t ByteCount, CUstream hStream);
+CUresult CUDAAPI cuMemcpyPeer(CUdeviceptr dstDevice, CUcontext dstContext,
+                              CUdeviceptr srcDevice, CUcontext srcContext,
+                              size_t ByteCount);
+CUresult CUDAAPI cuMemcpyPeerAsync(CUdeviceptr dstDevice, CUcontext dstContext,
+                                   CUdeviceptr srcDevice, CUcontext srcContext,
+                                   size_t ByteCount, CUstream hStream);
+CUresult CUDAAPI cuMemcpy3DPeer(const CUDA_MEMCPY3D_PEER *pCopy);
+CUresult CUDAAPI cuMemcpy3DPeerAsync(const CUDA_MEMCPY3D_PEER *pCopy,
+                                     CUstream hStream);
 
-    CUresult CUDAAPI cuMemsetD8Async(CUdeviceptr dstDevice, unsigned char uc, size_t N, CUstream hStream);
-    CUresult CUDAAPI cuMemsetD16Async(CUdeviceptr dstDevice, unsigned short us, size_t N, CUstream hStream);
-    CUresult CUDAAPI cuMemsetD32Async(CUdeviceptr dstDevice, unsigned int ui, size_t N, CUstream hStream);
-    CUresult CUDAAPI cuMemsetD2D8Async(CUdeviceptr dstDevice, size_t dstPitch, unsigned char uc, size_t Width, size_t Height, CUstream hStream);
-    CUresult CUDAAPI cuMemsetD2D16Async(CUdeviceptr dstDevice, size_t dstPitch, unsigned short us, size_t Width, size_t Height, CUstream hStream);
-    CUresult CUDAAPI cuMemsetD2D32Async(CUdeviceptr dstDevice, size_t dstPitch, unsigned int ui, size_t Width, size_t Height, CUstream hStream);
+CUresult CUDAAPI cuMemsetD8Async(CUdeviceptr dstDevice, unsigned char uc,
+                                 size_t N, CUstream hStream);
+CUresult CUDAAPI cuMemsetD16Async(CUdeviceptr dstDevice, unsigned short us,
+                                  size_t N, CUstream hStream);
+CUresult CUDAAPI cuMemsetD32Async(CUdeviceptr dstDevice, unsigned int ui,
+                                  size_t N, CUstream hStream);
+CUresult CUDAAPI cuMemsetD2D8Async(CUdeviceptr dstDevice, size_t dstPitch,
+                                   unsigned char uc, size_t Width,
+                                   size_t Height, CUstream hStream);
+CUresult CUDAAPI cuMemsetD2D16Async(CUdeviceptr dstDevice, size_t dstPitch,
+                                    unsigned short us, size_t Width,
+                                    size_t Height, CUstream hStream);
+CUresult CUDAAPI cuMemsetD2D32Async(CUdeviceptr dstDevice, size_t dstPitch,
+                                    unsigned int ui, size_t Width,
+                                    size_t Height, CUstream hStream);
 
-    CUresult CUDAAPI cuStreamGetPriority(CUstream hStream, int *priority);
-    CUresult CUDAAPI cuStreamGetFlags(CUstream hStream, unsigned int *flags);
-    CUresult CUDAAPI cuStreamGetCtx(CUstream hStream, CUcontext *pctx);
-    CUresult CUDAAPI cuStreamWaitEvent(CUstream hStream, CUevent hEvent, unsigned int Flags);
-    CUresult CUDAAPI cuStreamAddCallback(CUstream hStream, CUstreamCallback callback, void *userData, unsigned int flags);
-    CUresult CUDAAPI cuStreamAttachMemAsync(CUstream hStream, CUdeviceptr dptr, size_t length, unsigned int flags);
-    CUresult CUDAAPI cuStreamQuery(CUstream hStream);
-    CUresult CUDAAPI cuStreamSynchronize(CUstream hStream);
-    CUresult CUDAAPI cuEventRecord(CUevent hEvent, CUstream hStream);
-    CUresult CUDAAPI cuLaunchKernel(CUfunction f, unsigned int gridDimX, unsigned int gridDimY, unsigned int gridDimZ, unsigned int blockDimX, unsigned int blockDimY, unsigned int blockDimZ, unsigned int sharedMemBytes, CUstream hStream, void **kernelParams, void **extra);
-    CUresult CUDAAPI cuLaunchHostFunc(CUstream hStream, CUhostFn fn, void *userData);
-    CUresult CUDAAPI cuGraphicsMapResources(unsigned int count, CUgraphicsResource *resources, CUstream hStream);
-    CUresult CUDAAPI cuGraphicsUnmapResources(unsigned int count, CUgraphicsResource *resources, CUstream hStream);
-    CUresult CUDAAPI cuStreamWriteValue32(CUstream stream, CUdeviceptr addr, cuuint32_t value, unsigned int flags);
-    CUresult CUDAAPI cuStreamWaitValue32(CUstream stream, CUdeviceptr addr, cuuint32_t value, unsigned int flags);
-    CUresult CUDAAPI cuStreamWriteValue64(CUstream stream, CUdeviceptr addr, cuuint64_t value, unsigned int flags);
-    CUresult CUDAAPI cuStreamWaitValue64(CUstream stream, CUdeviceptr addr, cuuint64_t value, unsigned int flags);
-    CUresult CUDAAPI cuStreamBatchMemOp(CUstream stream, unsigned int count, CUstreamBatchMemOpParams *paramArray, unsigned int flags);
-    CUresult CUDAAPI cuMemPrefetchAsync(CUdeviceptr devPtr, size_t count, CUdevice dstDevice, CUstream hStream);
-    CUresult CUDAAPI cuLaunchCooperativeKernel(CUfunction f, unsigned int gridDimX, unsigned int gridDimY, unsigned int gridDimZ, unsigned int blockDimX, unsigned int blockDimY, unsigned int blockDimZ, unsigned int sharedMemBytes, CUstream hStream, void **kernelParams);
-    CUresult CUDAAPI cuSignalExternalSemaphoresAsync(const CUexternalSemaphore *extSemArray, const CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS *paramsArray, unsigned int numExtSems, CUstream stream);
-    CUresult CUDAAPI cuWaitExternalSemaphoresAsync(const CUexternalSemaphore *extSemArray, const CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS *paramsArray, unsigned int numExtSems, CUstream stream);
-    CUresult CUDAAPI cuStreamBeginCapture(CUstream hStream);
-    CUresult CUDAAPI cuStreamBeginCapture_ptsz(CUstream hStream);
-    CUresult CUDAAPI cuStreamBeginCapture_v2(CUstream hStream, CUstreamCaptureMode mode);
-    CUresult CUDAAPI cuStreamEndCapture(CUstream hStream, CUgraph *phGraph);
-    CUresult CUDAAPI cuStreamIsCapturing(CUstream hStream, CUstreamCaptureStatus *captureStatus);
-    CUresult CUDAAPI cuStreamGetCaptureInfo(CUstream hStream, CUstreamCaptureStatus *captureStatus, cuuint64_t *id);
-    CUresult CUDAAPI cuGraphLaunch(CUgraphExec hGraph, CUstream hStream);
+CUresult CUDAAPI cuStreamGetPriority(CUstream hStream, int *priority);
+CUresult CUDAAPI cuStreamGetFlags(CUstream hStream, unsigned int *flags);
+CUresult CUDAAPI cuStreamGetCtx(CUstream hStream, CUcontext *pctx);
+CUresult CUDAAPI cuStreamWaitEvent(CUstream hStream, CUevent hEvent,
+                                   unsigned int Flags);
+CUresult CUDAAPI cuStreamAddCallback(CUstream hStream,
+                                     CUstreamCallback callback, void *userData,
+                                     unsigned int flags);
+CUresult CUDAAPI cuStreamAttachMemAsync(CUstream hStream, CUdeviceptr dptr,
+                                        size_t length, unsigned int flags);
+CUresult CUDAAPI cuStreamQuery(CUstream hStream);
+CUresult CUDAAPI cuStreamSynchronize(CUstream hStream);
+CUresult CUDAAPI cuEventRecord(CUevent hEvent, CUstream hStream);
+CUresult CUDAAPI cuLaunchKernel(CUfunction f, unsigned int gridDimX,
+                                unsigned int gridDimY, unsigned int gridDimZ,
+                                unsigned int blockDimX, unsigned int blockDimY,
+                                unsigned int blockDimZ,
+                                unsigned int sharedMemBytes, CUstream hStream,
+                                void **kernelParams, void **extra);
+CUresult CUDAAPI cuLaunchHostFunc(CUstream hStream, CUhostFn fn,
+                                  void *userData);
+CUresult CUDAAPI cuGraphicsMapResources(unsigned int count,
+                                        CUgraphicsResource *resources,
+                                        CUstream hStream);
+CUresult CUDAAPI cuGraphicsUnmapResources(unsigned int count,
+                                          CUgraphicsResource *resources,
+                                          CUstream hStream);
+CUresult CUDAAPI cuStreamWriteValue32(CUstream stream, CUdeviceptr addr,
+                                      cuuint32_t value, unsigned int flags);
+CUresult CUDAAPI cuStreamWaitValue32(CUstream stream, CUdeviceptr addr,
+                                     cuuint32_t value, unsigned int flags);
+CUresult CUDAAPI cuStreamWriteValue64(CUstream stream, CUdeviceptr addr,
+                                      cuuint64_t value, unsigned int flags);
+CUresult CUDAAPI cuStreamWaitValue64(CUstream stream, CUdeviceptr addr,
+                                     cuuint64_t value, unsigned int flags);
+CUresult CUDAAPI cuStreamBatchMemOp(CUstream stream, unsigned int count,
+                                    CUstreamBatchMemOpParams *paramArray,
+                                    unsigned int flags);
+CUresult CUDAAPI cuMemPrefetchAsync(CUdeviceptr devPtr, size_t count,
+                                    CUdevice dstDevice, CUstream hStream);
+CUresult CUDAAPI cuLaunchCooperativeKernel(
+    CUfunction f, unsigned int gridDimX, unsigned int gridDimY,
+    unsigned int gridDimZ, unsigned int blockDimX, unsigned int blockDimY,
+    unsigned int blockDimZ, unsigned int sharedMemBytes, CUstream hStream,
+    void **kernelParams);
+CUresult CUDAAPI cuSignalExternalSemaphoresAsync(
+    const CUexternalSemaphore *extSemArray,
+    const CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS *paramsArray,
+    unsigned int numExtSems, CUstream stream);
+CUresult CUDAAPI cuWaitExternalSemaphoresAsync(
+    const CUexternalSemaphore *extSemArray,
+    const CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS *paramsArray,
+    unsigned int numExtSems, CUstream stream);
+CUresult CUDAAPI cuStreamBeginCapture(CUstream hStream);
+CUresult CUDAAPI cuStreamBeginCapture_ptsz(CUstream hStream);
+CUresult CUDAAPI cuStreamBeginCapture_v2(CUstream hStream,
+                                         CUstreamCaptureMode mode);
+CUresult CUDAAPI cuStreamEndCapture(CUstream hStream, CUgraph *phGraph);
+CUresult CUDAAPI cuStreamIsCapturing(CUstream hStream,
+                                     CUstreamCaptureStatus *captureStatus);
+CUresult CUDAAPI cuStreamGetCaptureInfo(CUstream hStream,
+                                        CUstreamCaptureStatus *captureStatus,
+                                        cuuint64_t *id);
+CUresult CUDAAPI cuGraphLaunch(CUgraphExec hGraph, CUstream hStream);
 #endif
 
 #ifdef __cplusplus

--- a/libcuda/cuda_api_object.h
+++ b/libcuda/cuda_api_object.h
@@ -8,9 +8,9 @@
 
 #include "builtin_types.h"
 
-#include "../src/gpgpu-sim/gpu-sim.h"
-#include "../src/cuda-sim/ptx_ir.h"
 #include "../src/abstract_hardware_model.h"
+#include "../src/cuda-sim/ptx_ir.h"
+#include "../src/gpgpu-sim/gpu-sim.h"
 #include "cuobjdump.h"
 
 typedef std::list<gpgpu_ptx_sim_arg> gpgpu_ptx_sim_arg_list_t;
@@ -20,194 +20,198 @@ typedef unsigned long GLuint;
 #endif
 
 struct glbmap_entry {
-	GLuint m_bufferObj;
-	void *m_devPtr;
-	size_t m_size;
-	struct glbmap_entry *m_next;
+  GLuint m_bufferObj;
+  void *m_devPtr;
+  size_t m_size;
+  struct glbmap_entry *m_next;
 };
 
 typedef struct glbmap_entry glbmap_entry_t;
 
 struct _cuda_device_id {
-	_cuda_device_id(gpgpu_sim* gpu) {m_id = 0; m_next = NULL; m_gpgpu=gpu;}
-	struct _cuda_device_id *next() { return m_next; }
-	unsigned num_shader() const { return m_gpgpu->get_config().num_shader(); }
-	int num_devices() const {
-		if( m_next == NULL ) return 1;
-		else return 1 + m_next->num_devices();
-	}
-	struct _cuda_device_id *get_device( unsigned n )
-	{
-		assert( n < (unsigned)num_devices() );
-		struct _cuda_device_id *p=this;
-		for(unsigned i=0; i<n; i++)
-			p = p->m_next;
-		return p;
-	}
-	const struct cudaDeviceProp *get_prop() const
-	{
-		return m_gpgpu->get_prop();
-	}
-	unsigned get_id() const { return m_id; }
+  _cuda_device_id(gpgpu_sim *gpu) {
+    m_id = 0;
+    m_next = NULL;
+    m_gpgpu = gpu;
+  }
+  struct _cuda_device_id *next() {
+    return m_next;
+  }
+  unsigned num_shader() const { return m_gpgpu->get_config().num_shader(); }
+  int num_devices() const {
+    if (m_next == NULL)
+      return 1;
+    else
+      return 1 + m_next->num_devices();
+  }
+  struct _cuda_device_id *get_device(unsigned n) {
+    assert(n < (unsigned)num_devices());
+    struct _cuda_device_id *p = this;
+    for (unsigned i = 0; i < n; i++) p = p->m_next;
+    return p;
+  }
+  const struct cudaDeviceProp *get_prop() const { return m_gpgpu->get_prop(); }
+  unsigned get_id() const { return m_id; }
 
-	gpgpu_sim *get_gpgpu() { return m_gpgpu; }
-private:
-	unsigned m_id;
-	class gpgpu_sim *m_gpgpu;
-	struct _cuda_device_id *m_next;
+  gpgpu_sim *get_gpgpu() { return m_gpgpu; }
+
+ private:
+  unsigned m_id;
+  class gpgpu_sim *m_gpgpu;
+  struct _cuda_device_id *m_next;
 };
 
 struct CUctx_st {
-	CUctx_st( _cuda_device_id *gpu )
-	{
-		m_gpu = gpu;
-		m_binary_info.cmem = 0;
-		m_binary_info.gmem = 0;
-		no_of_ptx=0;
-	}
+  CUctx_st(_cuda_device_id *gpu) {
+    m_gpu = gpu;
+    m_binary_info.cmem = 0;
+    m_binary_info.gmem = 0;
+    no_of_ptx = 0;
+  }
 
-	_cuda_device_id *get_device() { return m_gpu; }
+  _cuda_device_id *get_device() { return m_gpu; }
 
-	void add_binary( symbol_table *symtab, unsigned fat_cubin_handle )
-	{
-		m_code[fat_cubin_handle] = symtab;
-		m_last_fat_cubin_handle = fat_cubin_handle;
-	}
+  void add_binary(symbol_table *symtab, unsigned fat_cubin_handle) {
+    m_code[fat_cubin_handle] = symtab;
+    m_last_fat_cubin_handle = fat_cubin_handle;
+  }
 
-	void add_ptxinfo( const char *deviceFun, const struct gpgpu_ptx_sim_info &info )
-	{
-		symbol *s = m_code[m_last_fat_cubin_handle]->lookup(deviceFun);
-		assert( s != NULL );
-		function_info *f = s->get_pc();
-		assert( f != NULL );
-		f->set_kernel_info(info);
-	}
+  void add_ptxinfo(const char *deviceFun,
+                   const struct gpgpu_ptx_sim_info &info) {
+    symbol *s = m_code[m_last_fat_cubin_handle]->lookup(deviceFun);
+    assert(s != NULL);
+    function_info *f = s->get_pc();
+    assert(f != NULL);
+    f->set_kernel_info(info);
+  }
 
-	void add_ptxinfo( const struct gpgpu_ptx_sim_info &info )
-	{
-		m_binary_info = info;
-	}
+  void add_ptxinfo(const struct gpgpu_ptx_sim_info &info) {
+    m_binary_info = info;
+  }
 
-	void register_function( unsigned fat_cubin_handle, const char *hostFun, const char *deviceFun )
-	{
-		if( m_code.find(fat_cubin_handle) != m_code.end() ) {
-			symbol *s = m_code[fat_cubin_handle]->lookup(deviceFun);
-			if(s != NULL) {
-				function_info *f = s->get_pc();
-				assert( f != NULL );
-				m_kernel_lookup[hostFun] = f;
-			}
-			else {
-				printf("Warning: cannot find deviceFun %s\n", deviceFun);
-				m_kernel_lookup[hostFun] = NULL;
-			}
-	//		assert( s != NULL );
-	//		function_info *f = s->get_pc();
-	//		assert( f != NULL );
-	//		m_kernel_lookup[hostFun] = f;
-		} else {
-			m_kernel_lookup[hostFun] = NULL;
-		}
-	}
-
-    void register_hostFun_function( const char*hostFun, function_info* f){
+  void register_function(unsigned fat_cubin_handle, const char *hostFun,
+                         const char *deviceFun) {
+    if (m_code.find(fat_cubin_handle) != m_code.end()) {
+      symbol *s = m_code[fat_cubin_handle]->lookup(deviceFun);
+      if (s != NULL) {
+        function_info *f = s->get_pc();
+        assert(f != NULL);
         m_kernel_lookup[hostFun] = f;
+      } else {
+        printf("Warning: cannot find deviceFun %s\n", deviceFun);
+        m_kernel_lookup[hostFun] = NULL;
+      }
+      //		assert( s != NULL );
+      //		function_info *f = s->get_pc();
+      //		assert( f != NULL );
+      //		m_kernel_lookup[hostFun] = f;
+    } else {
+      m_kernel_lookup[hostFun] = NULL;
     }
+  }
 
-	function_info *get_kernel(const char *hostFun)
-	{
-		std::map<const void*,function_info*>::iterator i=m_kernel_lookup.find(hostFun);
-		assert( i != m_kernel_lookup.end() );
-		return i->second;
-	}
+  void register_hostFun_function(const char *hostFun, function_info *f) {
+    m_kernel_lookup[hostFun] = f;
+  }
 
-	int no_of_ptx;
+  function_info *get_kernel(const char *hostFun) {
+    std::map<const void *, function_info *>::iterator i =
+        m_kernel_lookup.find(hostFun);
+    assert(i != m_kernel_lookup.end());
+    return i->second;
+  }
 
-private:
-	_cuda_device_id *m_gpu; // selected gpu
-	std::map<unsigned,symbol_table*> m_code; // fat binary handle => global symbol table
-	unsigned m_last_fat_cubin_handle;
-	std::map<const void*,function_info*> m_kernel_lookup; // unique id (CUDA app function address) => kernel entry point
-	struct gpgpu_ptx_sim_info m_binary_info;
+  int no_of_ptx;
 
+ private:
+  _cuda_device_id *m_gpu;  // selected gpu
+  std::map<unsigned, symbol_table *>
+      m_code;  // fat binary handle => global symbol table
+  unsigned m_last_fat_cubin_handle;
+  std::map<const void *, function_info *>
+      m_kernel_lookup;  // unique id (CUDA app function address) => kernel entry
+                        // point
+  struct gpgpu_ptx_sim_info m_binary_info;
 };
 
 class kernel_config {
-public:
-	kernel_config( dim3 GridDim, dim3 BlockDim, size_t sharedMem, struct CUstream_st *stream )
-	{
-		m_GridDim=GridDim;
-		m_BlockDim=BlockDim;
-		m_sharedMem=sharedMem;
-		m_stream = stream;
-	}
-	kernel_config()
-	{
-		m_GridDim=dim3(-1,-1,-1);
-		m_BlockDim=dim3(-1,-1,-1);
-		m_sharedMem=0;
-		m_stream =NULL;
-	}
-	void set_arg( const void *arg, size_t size, size_t offset )
-	{
-		m_args.push_front( gpgpu_ptx_sim_arg(arg,size,offset) );
-	}
-	dim3 grid_dim() const { return m_GridDim; }
-	dim3 block_dim() const { return m_BlockDim; }
-	void set_grid_dim(dim3 *d) { m_GridDim = *d; }
-	void set_block_dim(dim3 *d) { m_BlockDim = *d; }
-	gpgpu_ptx_sim_arg_list_t get_args() { return m_args; }
-	struct CUstream_st *get_stream() { return m_stream; }
+ public:
+  kernel_config(dim3 GridDim, dim3 BlockDim, size_t sharedMem,
+                struct CUstream_st *stream) {
+    m_GridDim = GridDim;
+    m_BlockDim = BlockDim;
+    m_sharedMem = sharedMem;
+    m_stream = stream;
+  }
+  kernel_config() {
+    m_GridDim = dim3(-1, -1, -1);
+    m_BlockDim = dim3(-1, -1, -1);
+    m_sharedMem = 0;
+    m_stream = NULL;
+  }
+  void set_arg(const void *arg, size_t size, size_t offset) {
+    m_args.push_front(gpgpu_ptx_sim_arg(arg, size, offset));
+  }
+  dim3 grid_dim() const { return m_GridDim; }
+  dim3 block_dim() const { return m_BlockDim; }
+  void set_grid_dim(dim3 *d) { m_GridDim = *d; }
+  void set_block_dim(dim3 *d) { m_BlockDim = *d; }
+  gpgpu_ptx_sim_arg_list_t get_args() { return m_args; }
+  struct CUstream_st *get_stream() {
+    return m_stream;
+  }
 
-private:
-	dim3 m_GridDim;
-	dim3 m_BlockDim;
-	size_t m_sharedMem;
-	struct CUstream_st *m_stream;
-	gpgpu_ptx_sim_arg_list_t m_args;
+ private:
+  dim3 m_GridDim;
+  dim3 m_BlockDim;
+  size_t m_sharedMem;
+  struct CUstream_st *m_stream;
+  gpgpu_ptx_sim_arg_list_t m_args;
 };
 
 class cuda_runtime_api {
-    public:
-	cuda_runtime_api( gpgpu_context* ctx ) {
-	    g_glbmap = NULL;
-	    g_active_device = 0; //active gpu that runs the code
-	    gpgpu_ctx = ctx;
-	}
-	// global list
-	std::list<cuobjdumpSection*> cuobjdumpSectionList;
-	std::list<cuobjdumpSection*> libSectionList;
-	std::list<kernel_config> g_cuda_launch_stack;
-	std::map<int, bool>fatbin_registered;
-	std::map<int, std::string> fatbinmap;
-	std::map<std::string, symbol_table*> name_symtab;
-	std::map<unsigned long long, size_t> g_mallocPtr_Size;
-	//maps sm version number to set of filenames
-	std::map<unsigned, std::set<std::string> > version_filename;
-	std::map<void *,void **> pinned_memory; //support for pinned memories added
-	std::map<void *, size_t> pinned_memory_size;
-	glbmap_entry_t* g_glbmap;
-	int g_active_device; //active gpu that runs the code
-	// backward pointer
-	class gpgpu_context* gpgpu_ctx;
-	// member function list
-	void cuobjdumpInit();
-	void extract_code_using_cuobjdump();
-	void extract_ptx_files_using_cuobjdump(CUctx_st *context);
-	std::list<cuobjdumpSection*> pruneSectionList(CUctx_st *context);
-	std::list<cuobjdumpSection*> mergeMatchingSections(std::string identifier);
-	std::list<cuobjdumpSection*> mergeSections();
-	cuobjdumpELFSection* findELFSection(const std::string identifier);
-	cuobjdumpPTXSection* findPTXSection(const std::string identifier);
-	cuobjdumpPTXSection* findPTXSectionInList(std::list<cuobjdumpSection*> &sectionlist, const std::string identifier);
-	void cuobjdumpRegisterFatBinary(unsigned int handle, const char* filename, CUctx_st *context);
-	kernel_info_t *gpgpu_cuda_ptx_sim_init_grid( const char *kernel_key,
-		gpgpu_ptx_sim_arg_list_t args,
-		struct dim3 gridDim,
-		struct dim3 blockDim,
-		struct CUctx_st* context );
-	int load_static_globals( symbol_table *symtab, unsigned min_gaddr, unsigned max_gaddr, gpgpu_t *gpu );
-	int load_constants( symbol_table *symtab, addr_t min_gaddr, gpgpu_t *gpu );
-
+ public:
+  cuda_runtime_api(gpgpu_context *ctx) {
+    g_glbmap = NULL;
+    g_active_device = 0;  // active gpu that runs the code
+    gpgpu_ctx = ctx;
+  }
+  // global list
+  std::list<cuobjdumpSection *> cuobjdumpSectionList;
+  std::list<cuobjdumpSection *> libSectionList;
+  std::list<kernel_config> g_cuda_launch_stack;
+  std::map<int, bool> fatbin_registered;
+  std::map<int, std::string> fatbinmap;
+  std::map<std::string, symbol_table *> name_symtab;
+  std::map<unsigned long long, size_t> g_mallocPtr_Size;
+  // maps sm version number to set of filenames
+  std::map<unsigned, std::set<std::string> > version_filename;
+  std::map<void *, void **> pinned_memory;  // support for pinned memories added
+  std::map<void *, size_t> pinned_memory_size;
+  glbmap_entry_t *g_glbmap;
+  int g_active_device;  // active gpu that runs the code
+  // backward pointer
+  class gpgpu_context *gpgpu_ctx;
+  // member function list
+  void cuobjdumpInit();
+  void extract_code_using_cuobjdump();
+  void extract_ptx_files_using_cuobjdump(CUctx_st *context);
+  std::list<cuobjdumpSection *> pruneSectionList(CUctx_st *context);
+  std::list<cuobjdumpSection *> mergeMatchingSections(std::string identifier);
+  std::list<cuobjdumpSection *> mergeSections();
+  cuobjdumpELFSection *findELFSection(const std::string identifier);
+  cuobjdumpPTXSection *findPTXSection(const std::string identifier);
+  cuobjdumpPTXSection *findPTXSectionInList(
+      std::list<cuobjdumpSection *> &sectionlist, const std::string identifier);
+  void cuobjdumpRegisterFatBinary(unsigned int handle, const char *filename,
+                                  CUctx_st *context);
+  kernel_info_t *gpgpu_cuda_ptx_sim_init_grid(const char *kernel_key,
+                                              gpgpu_ptx_sim_arg_list_t args,
+                                              struct dim3 gridDim,
+                                              struct dim3 blockDim,
+                                              struct CUctx_st *context);
+  int load_static_globals(symbol_table *symtab, unsigned min_gaddr,
+                          unsigned max_gaddr, gpgpu_t *gpu);
+  int load_constants(symbol_table *symtab, addr_t min_gaddr, gpgpu_t *gpu);
 };
 #endif /* __cuda_api_object_h__ */

--- a/libcuda/cuda_runtime_api.cc
+++ b/libcuda/cuda_runtime_api.cc
@@ -122,12 +122,13 @@
 #endif
 
 #define __CUDA_RUNTIME_API_H__
-
+// clang-format off
 #include "host_defines.h"
 #include "builtin_types.h"
 #include "driver_types.h"
 #include "cuda_api.h"
 #include "cudaProfiler.h"
+// clang-format on
 #if (CUDART_VERSION < 8000)
 #include "__cudaFatFormat.h"
 #endif

--- a/libcuda/cuda_runtime_api.cc
+++ b/libcuda/cuda_runtime_api.cc
@@ -2,16 +2,16 @@
 // Changes Copyright 2009,  Tor M. Aamodt, Ali Bakhoda and George L. Yuan
 // University of British Columbia
 
-/* 
+/*
  * cuda_runtime_api.cc
  *
- * Copyright © 2009 by Tor M. Aamodt, Wilson W. L. Fung, Ali Bakhoda, 
- * George L. Yuan and the University of British Columbia, Vancouver, 
+ * Copyright © 2009 by Tor M. Aamodt, Wilson W. L. Fung, Ali Bakhoda,
+ * George L. Yuan and the University of British Columbia, Vancouver,
  * BC V6T 1Z4, All Rights Reserved.
- * 
+ *
  * THIS IS A LEGAL DOCUMENT BY DOWNLOADING GPGPU-SIM, YOU ARE AGREEING TO THESE
  * TERMS AND CONDITIONS.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -23,99 +23,100 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  * NOTE: The files libcuda/cuda_runtime_api.c and src/cuda-sim/cuda-math.h
  * are derived from the CUDA Toolset available from http://www.nvidia.com/cuda
- * (property of NVIDIA).  The files benchmarks/BlackScholes/ and 
- * benchmarks/template/ are derived from the CUDA SDK available from 
- * http://www.nvidia.com/cuda (also property of NVIDIA).  The files from 
- * src/intersim/ are derived from Booksim (a simulator provided with the 
- * textbook "Principles and Practices of Interconnection Networks" available 
- * from http://cva.stanford.edu/books/ppin/). As such, those files are bound by 
- * the corresponding legal terms and conditions set forth separately (original 
- * copyright notices are left in files from these sources and where we have 
- * modified a file our copyright notice appears before the original copyright 
- * notice).  
- * 
- * Using this version of GPGPU-Sim requires a complete installation of CUDA 
- * which is distributed seperately by NVIDIA under separate terms and 
+ * (property of NVIDIA).  The files benchmarks/BlackScholes/ and
+ * benchmarks/template/ are derived from the CUDA SDK available from
+ * http://www.nvidia.com/cuda (also property of NVIDIA).  The files from
+ * src/intersim/ are derived from Booksim (a simulator provided with the
+ * textbook "Principles and Practices of Interconnection Networks" available
+ * from http://cva.stanford.edu/books/ppin/). As such, those files are bound by
+ * the corresponding legal terms and conditions set forth separately (original
+ * copyright notices are left in files from these sources and where we have
+ * modified a file our copyright notice appears before the original copyright
+ * notice).
+ *
+ * Using this version of GPGPU-Sim requires a complete installation of CUDA
+ * which is distributed seperately by NVIDIA under separate terms and
  * conditions.  To use this version of GPGPU-Sim with OpenCL requires a
  * recent version of NVIDIA's drivers which support OpenCL.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of the University of British Columbia nor the names of
  * its contributors may be used to endorse or promote products derived from
  * this software without specific prior written permission.
- * 
- * 4. This version of GPGPU-SIM is distributed freely for non-commercial use only.  
- *  
+ *
+ * 4. This version of GPGPU-SIM is distributed freely for non-commercial use
+ * only.
+ *
  * 5. No nonprofit user may place any restrictions on the use of this software,
  * including as modified by the user, by any other authorized user.
- * 
- * 6. GPGPU-SIM was developed primarily by Tor M. Aamodt, Wilson W. L. Fung, 
- * Ali Bakhoda, George L. Yuan, at the University of British Columbia, 
+ *
+ * 6. GPGPU-SIM was developed primarily by Tor M. Aamodt, Wilson W. L. Fung,
+ * Ali Bakhoda, George L. Yuan, at the University of British Columbia,
  * Vancouver, BC V6T 1Z4
  */
 
 /*
  * Copyright 1993-2007 NVIDIA Corporation.  All rights reserved.
  *
- * NOTICE TO USER:   
+ * NOTICE TO USER:
  *
- * This source code is subject to NVIDIA ownership rights under U.S. and 
- * international Copyright laws.  Users and possessors of this source code 
- * are hereby granted a nonexclusive, royalty-free license to use this code 
+ * This source code is subject to NVIDIA ownership rights under U.S. and
+ * international Copyright laws.  Users and possessors of this source code
+ * are hereby granted a nonexclusive, royalty-free license to use this code
  * in individual and commercial software.
  *
- * NVIDIA MAKES NO REPRESENTATION ABOUT THE SUITABILITY OF THIS SOURCE 
- * CODE FOR ANY PURPOSE.  IT IS PROVIDED "AS IS" WITHOUT EXPRESS OR 
- * IMPLIED WARRANTY OF ANY KIND.  NVIDIA DISCLAIMS ALL WARRANTIES WITH 
- * REGARD TO THIS SOURCE CODE, INCLUDING ALL IMPLIED WARRANTIES OF 
+ * NVIDIA MAKES NO REPRESENTATION ABOUT THE SUITABILITY OF THIS SOURCE
+ * CODE FOR ANY PURPOSE.  IT IS PROVIDED "AS IS" WITHOUT EXPRESS OR
+ * IMPLIED WARRANTY OF ANY KIND.  NVIDIA DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOURCE CODE, INCLUDING ALL IMPLIED WARRANTIES OF
  * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE.
- * IN NO EVENT SHALL NVIDIA BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL, 
- * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS 
- * OF USE, DATA OR PROFITS,  WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE 
- * OR OTHER TORTIOUS ACTION,  ARISING OUT OF OR IN CONNECTION WITH THE USE 
- * OR PERFORMANCE OF THIS SOURCE CODE.  
+ * IN NO EVENT SHALL NVIDIA BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL,
+ * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS,  WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+ * OR OTHER TORTIOUS ACTION,  ARISING OUT OF OR IN CONNECTION WITH THE USE
+ * OR PERFORMANCE OF THIS SOURCE CODE.
  *
- * U.S. Government End Users.   This source code is a "commercial item" as 
- * that term is defined at  48 C.F.R. 2.101 (OCT 1995), consisting  of 
- * "commercial computer  software"  and "commercial computer software 
- * documentation" as such terms are  used in 48 C.F.R. 12.212 (SEPT 1995) 
- * and is provided to the U.S. Government only as a commercial end item.  
- * Consistent with 48 C.F.R.12.212 and 48 C.F.R. 227.7202-1 through 
- * 227.7202-4 (JUNE 1995), all U.S. Government End Users acquire the 
- * source code with only those rights set forth herein. 
+ * U.S. Government End Users.   This source code is a "commercial item" as
+ * that term is defined at  48 C.F.R. 2.101 (OCT 1995), consisting  of
+ * "commercial computer  software"  and "commercial computer software
+ * documentation" as such terms are  used in 48 C.F.R. 12.212 (SEPT 1995)
+ * and is provided to the U.S. Government only as a commercial end item.
+ * Consistent with 48 C.F.R.12.212 and 48 C.F.R. 227.7202-1 through
+ * 227.7202-4 (JUNE 1995), all U.S. Government End Users acquire the
+ * source code with only those rights set forth herein.
  *
- * Any use of this source code in individual and commercial software must 
+ * Any use of this source code in individual and commercial software must
  * include, in the user documentation and internal comments to the code,
  * the above Disclaimer and U.S. Government End Users Notice.
  */
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
 #include <assert.h>
-#include <time.h>
 #include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <fstream>
 #include <iostream>
-#include <string>
 #include <regex>
 #include <sstream>
-#include <fstream>
+#include <string>
 #ifdef OPENGL_SUPPORT
 #define GL_GLEXT_PROTOTYPES
 #ifdef __APPLE__
-#include <GLUT/glut.h> // Apple's version of GLUT is here
+#include <GLUT/glut.h>  // Apple's version of GLUT is here
 #else
 #include <GL/gl.h>
 #endif
@@ -150,23 +151,20 @@
 #include <mach-o/dyld.h>
 #endif
 
-
 /*DEVICE_BUILTIN*/
-struct cudaArray
-{
-	void *devPtr;
-	int devPtr32;
-	struct cudaChannelFormatDesc desc;
-	int width;
-	int height;
-	int size; //in bytes
-	unsigned dimensions;
+struct cudaArray {
+  void *devPtr;
+  int devPtr32;
+  struct cudaChannelFormatDesc desc;
+  int width;
+  int height;
+  int size;  // in bytes
+  unsigned dimensions;
 };
 
 #if !defined(__dv)
 #if defined(__cplusplus)
-#define __dv(v) \
-		= v
+#define __dv(v) = v
 #else /* __cplusplus */
 #define __dv(v)
 #endif /* __cplusplus */
@@ -174,1308 +172,1445 @@ struct cudaArray
 
 cudaError_t g_last_cudaError = cudaSuccess;
 
-void register_ptx_function( const char *name, function_info *impl )
-{
-	// no longer need this
+void register_ptx_function(const char *name, function_info *impl) {
+  // no longer need this
 }
 
 #if defined __APPLE__
-#   define __my_func__    __PRETTY_FUNCTION__
+#define __my_func__ __PRETTY_FUNCTION__
 #else
-# if defined __cplusplus ? __GNUC_PREREQ (2, 6) : __GNUC_PREREQ (2, 4)
-#   define __my_func__    __PRETTY_FUNCTION__
-# else
-#  if defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L
-#   define __my_func__    __func__
-#  else
-#   define __my_func__    ((__const char *) 0)
-#  endif
-# endif
+#if defined __cplusplus ? __GNUC_PREREQ(2, 6) : __GNUC_PREREQ(2, 4)
+#define __my_func__ __PRETTY_FUNCTION__
+#else
+#if defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L
+#define __my_func__ __func__
+#else
+#define __my_func__ ((__const char *)0)
+#endif
+#endif
 #endif
 
-struct _cuda_device_id *gpgpu_context::GPGPUSim_Init()
-{
-	_cuda_device_id *the_device = the_gpgpusim->the_cude_device;
-	if( !the_device ) {
-		gpgpu_sim *the_gpu = gpgpu_ptx_sim_init_perf();
+struct _cuda_device_id *gpgpu_context::GPGPUSim_Init() {
+  _cuda_device_id *the_device = the_gpgpusim->the_cude_device;
+  if (!the_device) {
+    gpgpu_sim *the_gpu = gpgpu_ptx_sim_init_perf();
 
-		cudaDeviceProp *prop = (cudaDeviceProp *) calloc(sizeof(cudaDeviceProp),1);
-		snprintf(prop->name,256,"GPGPU-Sim_v%s", g_gpgpusim_version_string );
-		prop->major = the_gpu->compute_capability_major();
-		prop->minor = the_gpu->compute_capability_minor();
-		prop->totalGlobalMem = 0x80000000 /* 2 GB */;
-		prop->memPitch = 0;
-		if(prop->major >= 2) {
-			prop->maxThreadsPerBlock = 1024;
-			prop->maxThreadsDim[0] = 1024;
-			prop->maxThreadsDim[1] = 1024;
-		}
-		else
-		{
-			prop->maxThreadsPerBlock = 512;
-			prop->maxThreadsDim[0] = 512;
-			prop->maxThreadsDim[1] = 512;
-		}
+    cudaDeviceProp *prop = (cudaDeviceProp *)calloc(sizeof(cudaDeviceProp), 1);
+    snprintf(prop->name, 256, "GPGPU-Sim_v%s", g_gpgpusim_version_string);
+    prop->major = the_gpu->compute_capability_major();
+    prop->minor = the_gpu->compute_capability_minor();
+    prop->totalGlobalMem = 0x80000000 /* 2 GB */;
+    prop->memPitch = 0;
+    if (prop->major >= 2) {
+      prop->maxThreadsPerBlock = 1024;
+      prop->maxThreadsDim[0] = 1024;
+      prop->maxThreadsDim[1] = 1024;
+    } else {
+      prop->maxThreadsPerBlock = 512;
+      prop->maxThreadsDim[0] = 512;
+      prop->maxThreadsDim[1] = 512;
+    }
 
-		prop->maxThreadsDim[2] = 64;
-		prop->maxGridSize[0] = 0x40000000;
-		prop->maxGridSize[1] = 0x40000000;
-		prop->maxGridSize[2] = 0x40000000;
-		prop->totalConstMem = 0x40000000;
-		prop->textureAlignment = 0;
-//        * TODO: Update the .config and xml files of all GPU config files with new value of sharedMemPerBlock and regsPerBlock 
-	        prop->sharedMemPerBlock = the_gpu->shared_mem_per_block();
+    prop->maxThreadsDim[2] = 64;
+    prop->maxGridSize[0] = 0x40000000;
+    prop->maxGridSize[1] = 0x40000000;
+    prop->maxGridSize[2] = 0x40000000;
+    prop->totalConstMem = 0x40000000;
+    prop->textureAlignment = 0;
+    //        * TODO: Update the .config and xml files of all GPU config files
+    //        with new value of sharedMemPerBlock and regsPerBlock
+    prop->sharedMemPerBlock = the_gpu->shared_mem_per_block();
 #if (CUDART_VERSION > 5050)
-		prop->regsPerMultiprocessor = the_gpu->num_registers_per_core();
-  	        prop->sharedMemPerMultiprocessor = the_gpu->shared_mem_size();
-#endif	
-		prop->sharedMemPerBlock = the_gpu->shared_mem_per_block();
-		prop->regsPerBlock = the_gpu->num_registers_per_block();
-		prop->warpSize = the_gpu->wrp_size();
-		prop->clockRate = the_gpu->shader_clock();
+    prop->regsPerMultiprocessor = the_gpu->num_registers_per_core();
+    prop->sharedMemPerMultiprocessor = the_gpu->shared_mem_size();
+#endif
+    prop->sharedMemPerBlock = the_gpu->shared_mem_per_block();
+    prop->regsPerBlock = the_gpu->num_registers_per_block();
+    prop->warpSize = the_gpu->wrp_size();
+    prop->clockRate = the_gpu->shader_clock();
 #if (CUDART_VERSION >= 2010)
-		prop->multiProcessorCount = the_gpu->get_config().num_shader();
+    prop->multiProcessorCount = the_gpu->get_config().num_shader();
 #endif
 #if (CUDART_VERSION >= 4000)
-		prop->maxThreadsPerMultiProcessor = the_gpu->threads_per_core();
+    prop->maxThreadsPerMultiProcessor = the_gpu->threads_per_core();
 #endif
-		the_gpu->set_prop(prop);
-		the_gpgpusim->the_cude_device = new _cuda_device_id(the_gpu);
-		the_device = the_gpgpusim->the_cude_device;
-	}
-	start_sim_thread(1);
-	return the_device;
+    the_gpu->set_prop(prop);
+    the_gpgpusim->the_cude_device = new _cuda_device_id(the_gpu);
+    the_device = the_gpgpusim->the_cude_device;
+  }
+  start_sim_thread(1);
+  return the_device;
 }
 
-CUctx_st* GPGPUSim_Context(gpgpu_context * ctx)
-{
-	//static CUctx_st *the_context = NULL;
-	CUctx_st *the_context = ctx->the_gpgpusim->the_context;
-	if( the_context == NULL ) {
-		_cuda_device_id *the_gpu = ctx->GPGPUSim_Init();
-		ctx->the_gpgpusim->the_context = new CUctx_st(the_gpu);
-		the_context = ctx->the_gpgpusim->the_context;
-	}
-	return the_context;
+CUctx_st *GPGPUSim_Context(gpgpu_context *ctx) {
+  // static CUctx_st *the_context = NULL;
+  CUctx_st *the_context = ctx->the_gpgpusim->the_context;
+  if (the_context == NULL) {
+    _cuda_device_id *the_gpu = ctx->GPGPUSim_Init();
+    ctx->the_gpgpusim->the_context = new CUctx_st(the_gpu);
+    the_context = ctx->the_gpgpusim->the_context;
+  }
+  return the_context;
 }
 
-gpgpu_context* GPGPU_Context()
-{
-	static gpgpu_context *gpgpu_ctx = NULL;
-	if( gpgpu_ctx == NULL ) {
-	    gpgpu_ctx = new gpgpu_context();
-	}
-	return gpgpu_ctx;
+gpgpu_context *GPGPU_Context() {
+  static gpgpu_context *gpgpu_ctx = NULL;
+  if (gpgpu_ctx == NULL) {
+    gpgpu_ctx = new gpgpu_context();
+  }
+  return gpgpu_ctx;
 }
 
- void ptxinfo_data::ptxinfo_addinfo()
-{
-	CUctx_st *context = GPGPUSim_Context(gpgpu_ctx);
-	 if(!get_ptxinfo_kname()){
-		 /* This info is not per kernel (since CUDA 5.0 some info (e.g. gmem, and cmem) is added at the beginning for the whole binary ) */
-		print_ptxinfo();
-		context->add_ptxinfo(get_ptxinfo());
-		clear_ptxinfo();
-		return;
-	 }
-	 if( !strcmp("__cuda_dummy_entry__",get_ptxinfo_kname()) ) {
-		// this string produced by ptxas for empty ptx files (e.g., bandwidth test)
-		clear_ptxinfo();
-		return;
-	}
-	print_ptxinfo();
-	context->add_ptxinfo( get_ptxinfo_kname(), get_ptxinfo() );
-	clear_ptxinfo();
+void ptxinfo_data::ptxinfo_addinfo() {
+  CUctx_st *context = GPGPUSim_Context(gpgpu_ctx);
+  if (!get_ptxinfo_kname()) {
+    /* This info is not per kernel (since CUDA 5.0 some info (e.g. gmem, and
+     * cmem) is added at the beginning for the whole binary ) */
+    print_ptxinfo();
+    context->add_ptxinfo(get_ptxinfo());
+    clear_ptxinfo();
+    return;
+  }
+  if (!strcmp("__cuda_dummy_entry__", get_ptxinfo_kname())) {
+    // this string produced by ptxas for empty ptx files (e.g., bandwidth test)
+    clear_ptxinfo();
+    return;
+  }
+  print_ptxinfo();
+  context->add_ptxinfo(get_ptxinfo_kname(), get_ptxinfo());
+  clear_ptxinfo();
 }
 
-void cuda_not_implemented( const char* func, unsigned line )
-{
-	fflush(stdout);
-	fflush(stderr);
-	printf("\n\nGPGPU-Sim PTX: Execution error: CUDA API function \"%s()\" has not been implemented yet.\n"
-			"                 [$GPGPUSIM_ROOT/libcuda/%s around line %u]\n\n\n",
-			func,__FILE__, line );
-	fflush(stdout);
-	abort();
+void cuda_not_implemented(const char *func, unsigned line) {
+  fflush(stdout);
+  fflush(stderr);
+  printf(
+      "\n\nGPGPU-Sim PTX: Execution error: CUDA API function \"%s()\" has not "
+      "been implemented yet.\n"
+      "                 [$GPGPUSIM_ROOT/libcuda/%s around line %u]\n\n\n",
+      func, __FILE__, line);
+  fflush(stdout);
+  abort();
 }
 
-void announce_call( const char* func )
-{
-	printf("\n\nGPGPU-Sim PTX: CUDA API function \"%s\" has been called.\n", func);
-	fflush(stdout);
+void announce_call(const char *func) {
+  printf("\n\nGPGPU-Sim PTX: CUDA API function \"%s\" has been called.\n",
+         func);
+  fflush(stdout);
 }
 
-#define gpgpusim_ptx_error(msg, ...) gpgpusim_ptx_error_impl(__func__, __FILE__,__LINE__, msg, ##__VA_ARGS__)
-#define gpgpusim_ptx_assert(cond,msg, ...) gpgpusim_ptx_assert_impl((cond),__func__, __FILE__,__LINE__, msg, ##__VA_ARGS__)
+#define gpgpusim_ptx_error(msg, ...) \
+  gpgpusim_ptx_error_impl(__func__, __FILE__, __LINE__, msg, ##__VA_ARGS__)
+#define gpgpusim_ptx_assert(cond, msg, ...)                           \
+  gpgpusim_ptx_assert_impl((cond), __func__, __FILE__, __LINE__, msg, \
+                           ##__VA_ARGS__)
 
-void gpgpusim_ptx_error_impl( const char *func, const char *file, unsigned line, const char *msg, ... )
-{
-	va_list ap;
-	char buf[1024];
-	va_start(ap,msg);
-	vsnprintf(buf,1024,msg,ap);
-	va_end(ap);
+void gpgpusim_ptx_error_impl(const char *func, const char *file, unsigned line,
+                             const char *msg, ...) {
+  va_list ap;
+  char buf[1024];
+  va_start(ap, msg);
+  vsnprintf(buf, 1024, msg, ap);
+  va_end(ap);
 
-	printf("GPGPU-Sim CUDA API: %s\n", buf);
-	printf("                    [%s:%u : %s]\n", file, line, func );
-	abort();
+  printf("GPGPU-Sim CUDA API: %s\n", buf);
+  printf("                    [%s:%u : %s]\n", file, line, func);
+  abort();
 }
 
-void gpgpusim_ptx_assert_impl( int test_value, const char *func, const char *file, unsigned line, const char *msg, ... )
-{
-	va_list ap;
-	char buf[1024];
-	va_start(ap,msg);
-	vsnprintf(buf,1024,msg,ap);
-	va_end(ap);
+void gpgpusim_ptx_assert_impl(int test_value, const char *func,
+                              const char *file, unsigned line, const char *msg,
+                              ...) {
+  va_list ap;
+  char buf[1024];
+  va_start(ap, msg);
+  vsnprintf(buf, 1024, msg, ap);
+  va_end(ap);
 
-	if ( test_value == 0 )
-		gpgpusim_ptx_error_impl(func, file, line, msg);
+  if (test_value == 0) gpgpusim_ptx_error_impl(func, file, line, msg);
 }
 
-
-typedef std::map<unsigned,CUevent_st*> event_tracker_t;
+typedef std::map<unsigned, CUevent_st *> event_tracker_t;
 
 int CUevent_st::m_next_event_uid;
 event_tracker_t g_timer_events;
 
-extern int cuobjdump_lex_init(yyscan_t* scanner);
-extern void cuobjdump_set_in  (FILE * _in_str ,yyscan_t yyscanner );
-extern int cuobjdump_parse(yyscan_t scanner, struct cuobjdump_parser* parser, std::list<cuobjdumpSection*> &cuobjdumpSectionList);
+extern int cuobjdump_lex_init(yyscan_t *scanner);
+extern void cuobjdump_set_in(FILE *_in_str, yyscan_t yyscanner);
+extern int cuobjdump_parse(yyscan_t scanner, struct cuobjdump_parser *parser,
+                           std::list<cuobjdumpSection *> &cuobjdumpSectionList);
 extern int cuobjdump_lex_destroy(yyscan_t scanner);
 
-enum cuobjdumpSectionType {
-	PTXSECTION=0,
-	ELFSECTION
-};
-
+enum cuobjdumpSectionType { PTXSECTION = 0, ELFSECTION };
 
 // sectiontype: 0 for ptx, 1 for elf
-void addCuobjdumpSection(int sectiontype, std::list<cuobjdumpSection*> &cuobjdumpSectionList){
-	if (sectiontype)
-		cuobjdumpSectionList.push_front(new cuobjdumpELFSection());
-	else
-		cuobjdumpSectionList.push_front(new cuobjdumpPTXSection());
-	printf("## Adding new section %s\n", sectiontype?"ELF":"PTX");
+void addCuobjdumpSection(int sectiontype,
+                         std::list<cuobjdumpSection *> &cuobjdumpSectionList) {
+  if (sectiontype)
+    cuobjdumpSectionList.push_front(new cuobjdumpELFSection());
+  else
+    cuobjdumpSectionList.push_front(new cuobjdumpPTXSection());
+  printf("## Adding new section %s\n", sectiontype ? "ELF" : "PTX");
 }
 
-void setCuobjdumparch(const char* arch, std::list<cuobjdumpSection*> &cuobjdumpSectionList){
-	unsigned archnum;
-	sscanf(arch, "sm_%u", &archnum);
-	assert (archnum && "cannot have sm_0");
-	printf("Adding arch: %s\n", arch);
-	cuobjdumpSectionList.front()->setArch(archnum);
+void setCuobjdumparch(const char *arch,
+                      std::list<cuobjdumpSection *> &cuobjdumpSectionList) {
+  unsigned archnum;
+  sscanf(arch, "sm_%u", &archnum);
+  assert(archnum && "cannot have sm_0");
+  printf("Adding arch: %s\n", arch);
+  cuobjdumpSectionList.front()->setArch(archnum);
 }
 
-void setCuobjdumpidentifier(const char* identifier, std::list<cuobjdumpSection*> &cuobjdumpSectionList){
-	printf("Adding identifier: %s\n", identifier);
-	cuobjdumpSectionList.front()->setIdentifier(identifier);
+void setCuobjdumpidentifier(
+    const char *identifier,
+    std::list<cuobjdumpSection *> &cuobjdumpSectionList) {
+  printf("Adding identifier: %s\n", identifier);
+  cuobjdumpSectionList.front()->setIdentifier(identifier);
 }
 
-void setCuobjdumpptxfilename(const char* filename, std::list<cuobjdumpSection*> &cuobjdumpSectionList){
-	printf("Adding ptx filename: %s\n", filename);
-	cuobjdumpSection* x = cuobjdumpSectionList.front();
-	if (dynamic_cast<cuobjdumpPTXSection*>(x) == NULL){
-		assert (0 && "You shouldn't be trying to add a ptxfilename to an elf section");
-	}
-	(dynamic_cast<cuobjdumpPTXSection*>(x))->setPTXfilename(filename);
+void setCuobjdumpptxfilename(
+    const char *filename, std::list<cuobjdumpSection *> &cuobjdumpSectionList) {
+  printf("Adding ptx filename: %s\n", filename);
+  cuobjdumpSection *x = cuobjdumpSectionList.front();
+  if (dynamic_cast<cuobjdumpPTXSection *>(x) == NULL) {
+    assert(0 &&
+           "You shouldn't be trying to add a ptxfilename to an elf section");
+  }
+  (dynamic_cast<cuobjdumpPTXSection *>(x))->setPTXfilename(filename);
 }
 
-void setCuobjdumpelffilename(const char* filename, std::list<cuobjdumpSection*> &cuobjdumpSectionList){
-	if (dynamic_cast<cuobjdumpELFSection*>(cuobjdumpSectionList.front()) == NULL){
-		assert (0 && "You shouldn't be trying to add a elffilename to an ptx section");
-	}
-	(dynamic_cast<cuobjdumpELFSection*>(cuobjdumpSectionList.front()))->setELFfilename(filename);
+void setCuobjdumpelffilename(
+    const char *filename, std::list<cuobjdumpSection *> &cuobjdumpSectionList) {
+  if (dynamic_cast<cuobjdumpELFSection *>(cuobjdumpSectionList.front()) ==
+      NULL) {
+    assert(0 &&
+           "You shouldn't be trying to add a elffilename to an ptx section");
+  }
+  (dynamic_cast<cuobjdumpELFSection *>(cuobjdumpSectionList.front()))
+      ->setELFfilename(filename);
 }
 
-void setCuobjdumpsassfilename(const char* filename, std::list<cuobjdumpSection*> &cuobjdumpSectionList){
-	if (dynamic_cast<cuobjdumpELFSection*>(cuobjdumpSectionList.front()) == NULL){
-		assert (0 && "You shouldn't be trying to add a sassfilename to an ptx section");
-	}
-	(dynamic_cast<cuobjdumpELFSection*>(cuobjdumpSectionList.front()))->setSASSfilename(filename);
+void setCuobjdumpsassfilename(
+    const char *filename, std::list<cuobjdumpSection *> &cuobjdumpSectionList) {
+  if (dynamic_cast<cuobjdumpELFSection *>(cuobjdumpSectionList.front()) ==
+      NULL) {
+    assert(0 &&
+           "You shouldn't be trying to add a sassfilename to an ptx section");
+  }
+  (dynamic_cast<cuobjdumpELFSection *>(cuobjdumpSectionList.front()))
+      ->setSASSfilename(filename);
 }
 
-//! Return the executable file of the process containing the PTX/SASS code 
+//! Return the executable file of the process containing the PTX/SASS code
 //!
 //! This Function returns the executable file ran by the process.  This
 //! executable is supposed to contain the PTX/SASS code.  It provides workaround
-//! for processes running on valgrind by dereferencing /proc/<pid>/exe within the
-//! GPGPU-Sim process before calling cuobjdump to extract PTX/SASS.  This is
+//! for processes running on valgrind by dereferencing /proc/<pid>/exe within
+//! the GPGPU-Sim process before calling cuobjdump to extract PTX/SASS.  This is
 //! needed because valgrind uses x86 emulation to detect memory leak.  Other
 //! processes (e.g. cuobjdump) reading /proc/<pid>/exe will see the emulator
-//! executable instead of the application binary.  
-//! 
-std::string get_app_binary(){
-   char self_exe_path[1025];
+//! executable instead of the application binary.
+//!
+std::string get_app_binary() {
+  char self_exe_path[1025];
 #ifdef __APPLE__
-   uint32_t size = sizeof(self_exe_path);
-   if( _NSGetExecutablePath(self_exe_path,&size) != 0 ) {
-	   printf("GPGPU-Sim ** ERROR: _NSGetExecutablePath input buffer too small\n");
-	   exit(1);
-   }
+  uint32_t size = sizeof(self_exe_path);
+  if (_NSGetExecutablePath(self_exe_path, &size) != 0) {
+    printf("GPGPU-Sim ** ERROR: _NSGetExecutablePath input buffer too small\n");
+    exit(1);
+  }
 #else
-   std::stringstream exec_link;
-   exec_link << "/proc/self/exe";
+  std::stringstream exec_link;
+  exec_link << "/proc/self/exe";
 
-   ssize_t path_length = readlink(exec_link.str().c_str(), self_exe_path, 1024); 
-   assert(path_length != -1); 
-   self_exe_path[path_length] = '\0'; 
+  ssize_t path_length = readlink(exec_link.str().c_str(), self_exe_path, 1024);
+  assert(path_length != -1);
+  self_exe_path[path_length] = '\0';
 #endif
 
-   printf("self exe links to: %s\n", self_exe_path); 
-   return self_exe_path; 
+  printf("self exe links to: %s\n", self_exe_path);
+  return self_exe_path;
 }
 
-//above func gives abs path whereas this give just the name of application.
-char* get_app_binary_name(std::string abs_path){
-   char *self_exe_path;
+// above func gives abs path whereas this give just the name of application.
+char *get_app_binary_name(std::string abs_path) {
+  char *self_exe_path;
 #ifdef __APPLE__
-   //TODO: get apple device and check the result.
-   printf("WARNING: not tested for Apple-mac devices \n");
-   abort();
+  // TODO: get apple device and check the result.
+  printf("WARNING: not tested for Apple-mac devices \n");
+  abort();
 #else
-   char* buf = strdup(abs_path.c_str());
-   char *token = strtok(buf, "/");
-   while(token !=NULL){
-	self_exe_path = token;
-	token = strtok(NULL,"/");
-   }
+  char *buf = strdup(abs_path.c_str());
+  char *token = strtok(buf, "/");
+  while (token != NULL) {
+    self_exe_path = token;
+    token = strtok(NULL, "/");
+  }
 #endif
-   self_exe_path = strtok(self_exe_path, ".");
-   printf("self exe links to: %s\n", self_exe_path);
-   return self_exe_path;
+  self_exe_path = strtok(self_exe_path, ".");
+  printf("self exe links to: %s\n", self_exe_path);
+  return self_exe_path;
 }
 
 static int get_app_cuda_version() {
-    int app_cuda_version = 0;
-    char fname[1024];
-    snprintf(fname,1024,"_app_cuda_version_XXXXXX");
-    int fd=mkstemp(fname);
-    close(fd);
-    std::string app_cuda_version_command = "ldd " + get_app_binary() + " | grep libcudart.so | sed  's/.*libcudart.so.\\(.*\\) =>.*/\\1/' > " + fname;
-    system(app_cuda_version_command.c_str());
-    FILE * cmd = fopen(fname, "r");
-    char buf[256];
-    while (fgets(buf, sizeof(buf), cmd) != 0) {
-        std::cout << buf;
-        app_cuda_version = atoi(buf);
-    }
-    fclose(cmd);
-    if ( app_cuda_version == 0 ) {
-        printf( "Error - Cannot detect the app's CUDA version.\n" );
-        exit(1);
-    }
-    return app_cuda_version;
+  int app_cuda_version = 0;
+  char fname[1024];
+  snprintf(fname, 1024, "_app_cuda_version_XXXXXX");
+  int fd = mkstemp(fname);
+  close(fd);
+  std::string app_cuda_version_command =
+      "ldd " + get_app_binary() +
+      " | grep libcudart.so | sed  's/.*libcudart.so.\\(.*\\) =>.*/\\1/' > " +
+      fname;
+  system(app_cuda_version_command.c_str());
+  FILE *cmd = fopen(fname, "r");
+  char buf[256];
+  while (fgets(buf, sizeof(buf), cmd) != 0) {
+    std::cout << buf;
+    app_cuda_version = atoi(buf);
+  }
+  fclose(cmd);
+  if (app_cuda_version == 0) {
+    printf("Error - Cannot detect the app's CUDA version.\n");
+    exit(1);
+  }
+  return app_cuda_version;
 }
 
 //! Keep track of the association between filename and cubin handle
-void cuda_runtime_api::cuobjdumpRegisterFatBinary(unsigned int handle, const char* filename, CUctx_st *context){
-	fatbinmap[handle] = filename;
+void cuda_runtime_api::cuobjdumpRegisterFatBinary(unsigned int handle,
+                                                  const char *filename,
+                                                  CUctx_st *context) {
+  fatbinmap[handle] = filename;
 }
-
-
 
 /*******************************************************************************
- * Add internal cuda runtime API call to accept gpgpu_context                   *
+ * Add internal cuda runtime API call to accept gpgpu_context *
  *******************************************************************************/
-cudaError_t cudaSetDeviceInternal(int device, gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	//set the active device to run cuda
-	if ( device <= ctx->GPGPUSim_Init()->num_devices() ) {
-		ctx->api->g_active_device = device;
-		return g_last_cudaError = cudaSuccess;
-	} else {
-		return g_last_cudaError = cudaErrorInvalidDevice;
-	}
-}
-
-cudaError_t cudaGetDeviceInternal(int *device, gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	*device = ctx->api->g_active_device;
-	return g_last_cudaError = cudaSuccess;
-}
-
-__host__ cudaError_t CUDARTAPI cudaDeviceGetLimitInternal( size_t* pValue, cudaLimit limit, gpgpu_context* gpgpu_ctx = NULL )
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-    if(g_debug_execution >= 3){
-	announce_call(__my_func__);
-    }
-    _cuda_device_id *dev = ctx->GPGPUSim_Init();
-    const struct cudaDeviceProp *prop = dev->get_prop();
-    const gpgpu_sim_config& config=dev->get_gpgpu()->get_config();
-    switch(limit) {
-	case 0:  // cudaLimitStackSize
-	    *pValue=config.stack_limit();
-	    break;
-	case 2:  // cudaLimitMallocHeapSize
-	    *pValue=config.heap_limit();
-	    break;
-#if (CUDART_VERSION > 5050)
-	case 3: // cudaLimitDevRuntimeSyncDepth
-	    if(prop->major > 2){
-		*pValue=config.sync_depth_limit();
-		break;
-	    }
-	    else{
-		printf("ERROR:Limit %d is not supported on this architecture \n", limit);
-		abort();
-	    }
-	case 4: // cudaLimitDevRuntimePendingLaunchCount
-	    if(prop->major > 2){
-		*pValue=config.pending_launch_count_limit();
-		break;
-	    }
-	    else{
-		printf("ERROR:Limit %d is not supported on this architecture \n",limit);
-		abort();
-	    }
-#endif
-	default:
-	    printf("ERROR:Limit %d unimplemented \n",limit);
-	    abort();
-    }
+cudaError_t cudaSetDeviceInternal(int device, gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  // set the active device to run cuda
+  if (device <= ctx->GPGPUSim_Init()->num_devices()) {
+    ctx->api->g_active_device = device;
     return g_last_cudaError = cudaSuccess;
-
+  } else {
+    return g_last_cudaError = cudaErrorInvalidDevice;
+  }
 }
 
+cudaError_t cudaGetDeviceInternal(int *device,
+                                  gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  *device = ctx->api->g_active_device;
+  return g_last_cudaError = cudaSuccess;
+}
 
-void** cudaRegisterFatBinaryInternal( void *fatCubin, gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
+__host__ cudaError_t CUDARTAPI cudaDeviceGetLimitInternal(
+    size_t *pValue, cudaLimit limit, gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  _cuda_device_id *dev = ctx->GPGPUSim_Init();
+  const struct cudaDeviceProp *prop = dev->get_prop();
+  const gpgpu_sim_config &config = dev->get_gpgpu()->get_config();
+  switch (limit) {
+    case 0:  // cudaLimitStackSize
+      *pValue = config.stack_limit();
+      break;
+    case 2:  // cudaLimitMallocHeapSize
+      *pValue = config.heap_limit();
+      break;
+#if (CUDART_VERSION > 5050)
+    case 3:  // cudaLimitDevRuntimeSyncDepth
+      if (prop->major > 2) {
+        *pValue = config.sync_depth_limit();
+        break;
+      } else {
+        printf("ERROR:Limit %d is not supported on this architecture \n",
+               limit);
+        abort();
+      }
+    case 4:  // cudaLimitDevRuntimePendingLaunchCount
+      if (prop->major > 2) {
+        *pValue = config.pending_launch_count_limit();
+        break;
+      } else {
+        printf("ERROR:Limit %d is not supported on this architecture \n",
+               limit);
+        abort();
+      }
+#endif
+    default:
+      printf("ERROR:Limit %d unimplemented \n", limit);
+      abort();
+  }
+  return g_last_cudaError = cudaSuccess;
+}
+
+void **cudaRegisterFatBinaryInternal(void *fatCubin,
+                                     gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
 #if (CUDART_VERSION < 2010)
-	printf("GPGPU-Sim PTX: ERROR ** this version of GPGPU-Sim requires CUDA 2.1 or higher\n");
-	exit(1);
+  printf(
+      "GPGPU-Sim PTX: ERROR ** this version of GPGPU-Sim requires CUDA 2.1 or "
+      "higher\n");
+  exit(1);
 #endif
-	CUctx_st *context = GPGPUSim_Context(ctx);
-	static unsigned next_fat_bin_handle = 1;
-	if(context->get_device()->get_gpgpu()->get_config().use_cuobjdump()) {
-		// The following workaround has only been verified on 64-bit systems. 
-		if (sizeof(void*) == 4) 
-			printf("GPGPU-Sim PTX: FatBin file name extraction has not been tested on 32-bit system.\n"); 
+  CUctx_st *context = GPGPUSim_Context(ctx);
+  static unsigned next_fat_bin_handle = 1;
+  if (context->get_device()->get_gpgpu()->get_config().use_cuobjdump()) {
+    // The following workaround has only been verified on 64-bit systems.
+    if (sizeof(void *) == 4)
+      printf(
+          "GPGPU-Sim PTX: FatBin file name extraction has not been tested on "
+          "32-bit system.\n");
 
-        // This code will get the CUDA version the app was compiled with.
-        // We need this to determine how to handle the parsing of the binary.
-        // Making this a runtime variable based on the app, enables GPGPU-Sim compiled
-        // with a newer version of CUDA to run apps compiled with older versions of
-        // CUDA. This is especially useful for PTXPLUS execution.
-        //Skip cuda version check for pytorch application
-	std::string app_binary_path =  get_app_binary();
-        int pos = app_binary_path.find("python");
-        if (pos==std::string::npos){
-        	// Not pytorch app : checking cuda version
-		int app_cuda_version = get_app_cuda_version();
-        	assert( app_cuda_version == CUDART_VERSION / 1000  && "The app must be compiled with same major version as the simulator." );
-        }
+    // This code will get the CUDA version the app was compiled with.
+    // We need this to determine how to handle the parsing of the binary.
+    // Making this a runtime variable based on the app, enables GPGPU-Sim
+    // compiled with a newer version of CUDA to run apps compiled with older
+    // versions of CUDA. This is especially useful for PTXPLUS execution.
+    // Skip cuda version check for pytorch application
+    std::string app_binary_path = get_app_binary();
+    int pos = app_binary_path.find("python");
+    if (pos == std::string::npos) {
+      // Not pytorch app : checking cuda version
+      int app_cuda_version = get_app_cuda_version();
+      assert(
+          app_cuda_version == CUDART_VERSION / 1000 &&
+          "The app must be compiled with same major version as the simulator.");
+    }
 
-	//int app_cuda_version = get_app_cuda_version();
-        //assert( app_cuda_version == CUDART_VERSION / 1000  && "The app must be compiled with same major version as the simulator." );
-        const char* filename;
+    // int app_cuda_version = get_app_cuda_version();
+    // assert( app_cuda_version == CUDART_VERSION / 1000  && "The app must be
+    // compiled with same major version as the simulator." );
+    const char *filename;
 #if CUDART_VERSION < 6000
-            // FatBin handle from the .fatbin.c file (one of the intermediate files generated by NVCC)
-            typedef struct {int m; int v; const unsigned long long* d; char* f;} __fatDeviceText __attribute__ ((aligned (8))); 
-            __fatDeviceText * fatDeviceText = (__fatDeviceText *) fatCubin;
+    // FatBin handle from the .fatbin.c file (one of the intermediate files
+    // generated by NVCC)
+    typedef struct {
+      int m;
+      int v;
+      const unsigned long long *d;
+      char *f;
+    } __fatDeviceText __attribute__((aligned(8)));
+    __fatDeviceText *fatDeviceText = (__fatDeviceText *)fatCubin;
 
-            // Extract the source code file name that generate the given FatBin. 
-            // - Obtains the pointer to the actual fatbin structure from the FatBin handle (fatCubin).
-            // - An integer inside the fatbin structure contains the relative offset to the source code file name.
-            // - This offset differs among different CUDA and GCC versions. 
-            char * pfatbin = (char*) fatDeviceText->d; 
-            int offset = *((int*)(pfatbin+48)); 
-            filename = (pfatbin+16+offset);
+    // Extract the source code file name that generate the given FatBin.
+    // - Obtains the pointer to the actual fatbin structure from the FatBin
+    // handle (fatCubin).
+    // - An integer inside the fatbin structure contains the relative offset to
+    // the source code file name.
+    // - This offset differs among different CUDA and GCC versions.
+    char *pfatbin = (char *)fatDeviceText->d;
+    int offset = *((int *)(pfatbin + 48));
+    filename = (pfatbin + 16 + offset);
 #else
-            filename = "default";
+    filename = "default";
 #endif
 
-		// The extracted file name is associated with a fat_cubin_handle passed
-		// into cudaLaunch().  Inside cudaLaunch(), the associated file name is
-		// used to find the PTX/SASS section from cuobjdump, which contains the
-		// PTX/SASS code for the launched kernel function.  
-		// This allows us to work around the fact that cuobjdump only outputs the
-		// file name associated with each section. 
-		unsigned long long fat_cubin_handle = next_fat_bin_handle;
-		next_fat_bin_handle++;
-		printf("GPGPU-Sim PTX: __cudaRegisterFatBinary, fat_cubin_handle = %llu, filename=%s\n", fat_cubin_handle, filename);
-		/*!
-		 * This function extracts all data from all files in first call
-		 * then for next calls, only returns the appropriate number
-		 */
-		assert(fat_cubin_handle >= 1);
-		if (fat_cubin_handle==1) ctx->api->cuobjdumpInit();
-		ctx->api->cuobjdumpRegisterFatBinary(fat_cubin_handle, filename, context);
+    // The extracted file name is associated with a fat_cubin_handle passed
+    // into cudaLaunch().  Inside cudaLaunch(), the associated file name is
+    // used to find the PTX/SASS section from cuobjdump, which contains the
+    // PTX/SASS code for the launched kernel function.
+    // This allows us to work around the fact that cuobjdump only outputs the
+    // file name associated with each section.
+    unsigned long long fat_cubin_handle = next_fat_bin_handle;
+    next_fat_bin_handle++;
+    printf(
+        "GPGPU-Sim PTX: __cudaRegisterFatBinary, fat_cubin_handle = %llu, "
+        "filename=%s\n",
+        fat_cubin_handle, filename);
+    /*!
+     * This function extracts all data from all files in first call
+     * then for next calls, only returns the appropriate number
+     */
+    assert(fat_cubin_handle >= 1);
+    if (fat_cubin_handle == 1) ctx->api->cuobjdumpInit();
+    ctx->api->cuobjdumpRegisterFatBinary(fat_cubin_handle, filename, context);
 
-		return (void**)fat_cubin_handle;
-	} 
+    return (void **)fat_cubin_handle;
+  }
 #if (CUDART_VERSION < 8000)
-	else {
-		static unsigned source_num=1;
-		unsigned long long fat_cubin_handle = next_fat_bin_handle++;
-		__cudaFatCudaBinary *info =   (__cudaFatCudaBinary *)fatCubin;
-		assert( info->version >= 3 );
-		unsigned num_ptx_versions=0;
-		unsigned max_capability=0;
-		unsigned selected_capability=0;
-		bool found=false;
-		unsigned forced_max_capability = context->get_device()->get_gpgpu()->get_config().get_forced_max_capability();
-		if (!info->ptx){
-			printf("ERROR: Cannot find ptx code in cubin file\n"
-					"\tIf you are using CUDA 4.0 or higher, please enable -gpgpu_ptx_use_cuobjdump or downgrade to CUDA 3.1\n");
-			exit(1);
-		}
-		while( info->ptx[num_ptx_versions].gpuProfileName != NULL ) {
-			unsigned capability=0;
-			sscanf(info->ptx[num_ptx_versions].gpuProfileName,"compute_%u",&capability);
-			printf("GPGPU-Sim PTX: __cudaRegisterFatBinary found PTX versions for '%s', ", info->ident);
-			printf("capability = %s\n", info->ptx[num_ptx_versions].gpuProfileName );
-			if( forced_max_capability ) {
-				if( capability > max_capability && capability <= forced_max_capability ) {
-					found = true;
-					max_capability=capability;
-					selected_capability = num_ptx_versions;
-				}
-			} else {
-				if( capability > max_capability ) {
-					found = true;
-					max_capability=capability;
-					selected_capability = num_ptx_versions;
-				}
-			}
-			num_ptx_versions++;
-		}
-		if( found  ) {
-			printf("GPGPU-Sim PTX: Loading PTX for %s, capability = %s\n",
-					info->ident, info->ptx[selected_capability].gpuProfileName );
-			symbol_table *symtab;
-			const char *ptx = info->ptx[selected_capability].ptx;
-			if(context->get_device()->get_gpgpu()->get_config().convert_to_ptxplus() ) {
-				printf("GPGPU-Sim PTX: ERROR ** PTXPlus is only supported through cuobjdump\n"
-						"\tEither enable cuobjdump or disable PTXPlus in your configuration file\n");
-				exit(1);
-			} else {
-				symtab=ctx->gpgpu_ptx_sim_load_ptx_from_string(ptx,source_num);
-				context->add_binary(symtab,fat_cubin_handle);
-				ctx->gpgpu_ptxinfo_load_from_string( ptx, source_num, max_capability, context->no_of_ptx );
-			}
-			source_num++;
-			ctx->api->load_static_globals(symtab,STATIC_ALLOC_LIMIT,0xFFFFFFFF,context->get_device()->get_gpgpu());
-			ctx->api->load_constants(symtab,STATIC_ALLOC_LIMIT,context->get_device()->get_gpgpu());
-		} else {
-			printf("GPGPU-Sim PTX: warning -- did not find an appropriate PTX in cubin\n");
-		}
-		return (void**)fat_cubin_handle;
-	}
-#else
-        else {
-		printf("ERROR **  __cudaRegisterFatBinary() needs to be updated\n");
-		abort();
+  else {
+    static unsigned source_num = 1;
+    unsigned long long fat_cubin_handle = next_fat_bin_handle++;
+    __cudaFatCudaBinary *info = (__cudaFatCudaBinary *)fatCubin;
+    assert(info->version >= 3);
+    unsigned num_ptx_versions = 0;
+    unsigned max_capability = 0;
+    unsigned selected_capability = 0;
+    bool found = false;
+    unsigned forced_max_capability = context->get_device()
+                                         ->get_gpgpu()
+                                         ->get_config()
+                                         .get_forced_max_capability();
+    if (!info->ptx) {
+      printf(
+          "ERROR: Cannot find ptx code in cubin file\n"
+          "\tIf you are using CUDA 4.0 or higher, please enable "
+          "-gpgpu_ptx_use_cuobjdump or downgrade to CUDA 3.1\n");
+      exit(1);
+    }
+    while (info->ptx[num_ptx_versions].gpuProfileName != NULL) {
+      unsigned capability = 0;
+      sscanf(info->ptx[num_ptx_versions].gpuProfileName, "compute_%u",
+             &capability);
+      printf(
+          "GPGPU-Sim PTX: __cudaRegisterFatBinary found PTX versions for "
+          "'%s', ",
+          info->ident);
+      printf("capability = %s\n", info->ptx[num_ptx_versions].gpuProfileName);
+      if (forced_max_capability) {
+        if (capability > max_capability &&
+            capability <= forced_max_capability) {
+          found = true;
+          max_capability = capability;
+          selected_capability = num_ptx_versions;
         }
+      } else {
+        if (capability > max_capability) {
+          found = true;
+          max_capability = capability;
+          selected_capability = num_ptx_versions;
+        }
+      }
+      num_ptx_versions++;
+    }
+    if (found) {
+      printf("GPGPU-Sim PTX: Loading PTX for %s, capability = %s\n",
+             info->ident, info->ptx[selected_capability].gpuProfileName);
+      symbol_table *symtab;
+      const char *ptx = info->ptx[selected_capability].ptx;
+      if (context->get_device()
+              ->get_gpgpu()
+              ->get_config()
+              .convert_to_ptxplus()) {
+        printf(
+            "GPGPU-Sim PTX: ERROR ** PTXPlus is only supported through "
+            "cuobjdump\n"
+            "\tEither enable cuobjdump or disable PTXPlus in your "
+            "configuration file\n");
+        exit(1);
+      } else {
+        symtab = ctx->gpgpu_ptx_sim_load_ptx_from_string(ptx, source_num);
+        context->add_binary(symtab, fat_cubin_handle);
+        ctx->gpgpu_ptxinfo_load_from_string(ptx, source_num, max_capability,
+                                            context->no_of_ptx);
+      }
+      source_num++;
+      ctx->api->load_static_globals(symtab, STATIC_ALLOC_LIMIT, 0xFFFFFFFF,
+                                    context->get_device()->get_gpgpu());
+      ctx->api->load_constants(symtab, STATIC_ALLOC_LIMIT,
+                               context->get_device()->get_gpgpu());
+    } else {
+      printf(
+          "GPGPU-Sim PTX: warning -- did not find an appropriate PTX in "
+          "cubin\n");
+    }
+    return (void **)fat_cubin_handle;
+  }
+#else
+  else {
+    printf("ERROR **  __cudaRegisterFatBinary() needs to be updated\n");
+    abort();
+  }
 #endif
 }
 
-void cudaRegisterFunctionInternal(
-		void   **fatCubinHandle,
-		const char    *hostFun,
-		char    *deviceFun,
-		const char    *deviceName,
-		int      thread_limit,
-		uint3   *tid,
-		uint3   *bid,
-		dim3    *bDim,
-		dim3    *gDim,
-		gpgpu_context *gpgpu_ctx = NULL
-)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	CUctx_st *context = GPGPUSim_Context(ctx);
-	unsigned fat_cubin_handle = (unsigned)(unsigned long long)fatCubinHandle;
-	printf("GPGPU-Sim PTX: __cudaRegisterFunction %s : hostFun 0x%p, fat_cubin_handle = %u\n",
-			deviceFun, hostFun, fat_cubin_handle);
-	if(context->get_device()->get_gpgpu()->get_config().use_cuobjdump())
-		ctx->cuobjdumpParseBinary(fat_cubin_handle);
-	context->register_function( fat_cubin_handle, hostFun, deviceFun );
+void cudaRegisterFunctionInternal(void **fatCubinHandle, const char *hostFun,
+                                  char *deviceFun, const char *deviceName,
+                                  int thread_limit, uint3 *tid, uint3 *bid,
+                                  dim3 *bDim, dim3 *gDim,
+                                  gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  CUctx_st *context = GPGPUSim_Context(ctx);
+  unsigned fat_cubin_handle = (unsigned)(unsigned long long)fatCubinHandle;
+  printf(
+      "GPGPU-Sim PTX: __cudaRegisterFunction %s : hostFun 0x%p, "
+      "fat_cubin_handle = %u\n",
+      deviceFun, hostFun, fat_cubin_handle);
+  if (context->get_device()->get_gpgpu()->get_config().use_cuobjdump())
+    ctx->cuobjdumpParseBinary(fat_cubin_handle);
+  context->register_function(fat_cubin_handle, hostFun, deviceFun);
 }
 
 void cudaRegisterVarInternal(
-		void **fatCubinHandle,
-		char *hostVar, //pointer to...something
-		char *deviceAddress, //name of variable
-		const char *deviceName, //name of variable (same as above)
-		int ext,
-		int size,
-		int constant,
-		int global,
-		gpgpu_context *gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("GPGPU-Sim PTX: __cudaRegisterVar: hostVar = %p; deviceAddress = %s; deviceName = %s\n", hostVar, deviceAddress, deviceName);
-	printf("GPGPU-Sim PTX: __cudaRegisterVar: Registering const memory space of %d bytes\n", size);
-	if(GPGPUSim_Context(ctx)->get_device()->get_gpgpu()->get_config().use_cuobjdump())
-		ctx->cuobjdumpParseBinary((unsigned)(unsigned long long)fatCubinHandle);
-	fflush(stdout);
-	if ( constant && !global && !ext ) {
-		ctx->func_sim->gpgpu_ptx_sim_register_const_variable(hostVar,deviceName,size);
-	} else if ( !constant && !global && !ext ) {
-		ctx->func_sim->gpgpu_ptx_sim_register_global_variable(hostVar,deviceName,size);
-	} else cuda_not_implemented(__my_func__,__LINE__);
+    void **fatCubinHandle,
+    char *hostVar,           // pointer to...something
+    char *deviceAddress,     // name of variable
+    const char *deviceName,  // name of variable (same as above)
+    int ext, int size, int constant, int global,
+    gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf(
+      "GPGPU-Sim PTX: __cudaRegisterVar: hostVar = %p; deviceAddress = %s; "
+      "deviceName = %s\n",
+      hostVar, deviceAddress, deviceName);
+  printf(
+      "GPGPU-Sim PTX: __cudaRegisterVar: Registering const memory space of %d "
+      "bytes\n",
+      size);
+  if (GPGPUSim_Context(ctx)
+          ->get_device()
+          ->get_gpgpu()
+          ->get_config()
+          .use_cuobjdump())
+    ctx->cuobjdumpParseBinary((unsigned)(unsigned long long)fatCubinHandle);
+  fflush(stdout);
+  if (constant && !global && !ext) {
+    ctx->func_sim->gpgpu_ptx_sim_register_const_variable(hostVar, deviceName,
+                                                         size);
+  } else if (!constant && !global && !ext) {
+    ctx->func_sim->gpgpu_ptx_sim_register_global_variable(hostVar, deviceName,
+                                                          size);
+  } else
+    cuda_not_implemented(__my_func__, __LINE__);
 }
 
-cudaError_t cudaConfigureCallInternal(dim3 gridDim, dim3 blockDim, size_t sharedMem, cudaStream_t stream, gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	struct CUstream_st *s = (struct CUstream_st *)stream;
-	ctx->api->g_cuda_launch_stack.push_back( kernel_config(gridDim,blockDim,sharedMem,s) );
-	return g_last_cudaError = cudaSuccess;
+cudaError_t cudaConfigureCallInternal(dim3 gridDim, dim3 blockDim,
+                                      size_t sharedMem, cudaStream_t stream,
+                                      gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  struct CUstream_st *s = (struct CUstream_st *)stream;
+  ctx->api->g_cuda_launch_stack.push_back(
+      kernel_config(gridDim, blockDim, sharedMem, s));
+  return g_last_cudaError = cudaSuccess;
 }
 
-__host__ cudaError_t CUDARTAPI cudaGetDeviceCountInternal(int *count, gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-    if(g_debug_execution >= 3){
-	announce_call(__my_func__);
-    }
-    _cuda_device_id *dev = ctx->GPGPUSim_Init();
-    *count = dev->num_devices();
+__host__ cudaError_t CUDARTAPI
+cudaGetDeviceCountInternal(int *count, gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  _cuda_device_id *dev = ctx->GPGPUSim_Init();
+  *count = dev->num_devices();
+  return g_last_cudaError = cudaSuccess;
+}
+
+__host__ cudaError_t CUDARTAPI cudaGetDevicePropertiesInternal(
+    struct cudaDeviceProp *prop, int device, gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  _cuda_device_id *dev = ctx->GPGPUSim_Init();
+  if (device <= dev->num_devices()) {
+    *prop = *dev->get_prop();
     return g_last_cudaError = cudaSuccess;
+  } else {
+    return g_last_cudaError = cudaErrorInvalidDevice;
+  }
 }
 
-__host__ cudaError_t CUDARTAPI cudaGetDevicePropertiesInternal(struct cudaDeviceProp *prop, int device, gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-    if(g_debug_execution >= 3){
-	announce_call(__my_func__);
-    }
-    _cuda_device_id *dev = ctx->GPGPUSim_Init();
-    if (device <= dev->num_devices() )  {
-	*prop= *dev->get_prop();
-	return g_last_cudaError = cudaSuccess;
-    } else {
-	return g_last_cudaError = cudaErrorInvalidDevice;
-    }
+__host__ cudaError_t CUDARTAPI
+cudaChooseDeviceInternal(int *device, const struct cudaDeviceProp *prop,
+                         gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  _cuda_device_id *dev = ctx->GPGPUSim_Init();
+  *device = dev->get_id();
+  return g_last_cudaError = cudaSuccess;
 }
 
+cudaError_t cudaSetupArgumentInternal(const void *arg, size_t size,
+                                      size_t offset,
+                                      gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  gpgpusim_ptx_assert(!ctx->api->g_cuda_launch_stack.empty(),
+                      "empty launch stack");
+  kernel_config &config = ctx->api->g_cuda_launch_stack.back();
+  config.set_arg(arg, size, offset);
+  printf(
+      "GPGPU-Sim PTX: Setting up arguments for %zu bytes starting at "
+      "0x%llx..\n",
+      size, (unsigned long long)arg);
 
-__host__ cudaError_t CUDARTAPI cudaChooseDeviceInternal(int *device, const struct cudaDeviceProp *prop, gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	_cuda_device_id *dev = ctx->GPGPUSim_Init();
-	*device = dev->get_id();
-	return g_last_cudaError = cudaSuccess;
+  return g_last_cudaError = cudaSuccess;
 }
 
-cudaError_t cudaSetupArgumentInternal(const void *arg, size_t size, size_t offset, gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
+cudaError_t cudaLaunchInternal(const char *hostFun,
+                               gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  CUctx_st *context = GPGPUSim_Context(ctx);
+  char *mode = getenv("PTX_SIM_MODE_FUNC");
+  if (mode) sscanf(mode, "%u", &(ctx->func_sim->g_ptx_sim_mode));
+  gpgpusim_ptx_assert(!ctx->api->g_cuda_launch_stack.empty(),
+                      "empty launch stack");
+  kernel_config config = ctx->api->g_cuda_launch_stack.back();
+  {
+    dim3 gridDim = config.grid_dim();
+    dim3 blockDim = config.block_dim();
+    if (gridDim.x * gridDim.y * gridDim.z == 0 ||
+        blockDim.x * blockDim.y * blockDim.z == 0) {
+      // can't launch
+      printf("can't launch a empty kernel\n");
+      ctx->api->g_cuda_launch_stack.pop_back();
+      return g_last_cudaError = cudaErrorInvalidConfiguration;
     }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	gpgpusim_ptx_assert( !ctx->api->g_cuda_launch_stack.empty(), "empty launch stack" );
-	kernel_config &config = ctx->api->g_cuda_launch_stack.back();
-	config.set_arg(arg,size,offset);
-	printf("GPGPU-Sim PTX: Setting up arguments for %zu bytes starting at 0x%llx..\n",size, (unsigned long long) arg);
+  }
+  struct CUstream_st *stream = config.get_stream();
 
-	return g_last_cudaError = cudaSuccess;
+  printf("\nGPGPU-Sim PTX: cudaLaunch for 0x%p (mode=%s) on stream %u\n",
+         hostFun,
+         (ctx->func_sim->g_ptx_sim_mode) ? "functional simulation"
+                                         : "performance simulation",
+         stream ? stream->get_uid() : 0);
+  kernel_info_t *grid = ctx->api->gpgpu_cuda_ptx_sim_init_grid(
+      hostFun, config.get_args(), config.grid_dim(), config.block_dim(),
+      context);
+  // do dynamic PDOM analysis for performance simulation scenario
+  std::string kname = grid->name();
+  function_info *kernel_func_info = grid->entry();
+  if (kernel_func_info->is_pdom_set()) {
+    printf("GPGPU-Sim PTX: PDOM analysis already done for %s \n",
+           kname.c_str());
+  } else {
+    printf("GPGPU-Sim PTX: finding reconvergence points for \'%s\'...\n",
+           kname.c_str());
+    kernel_func_info->do_pdom();
+    kernel_func_info->set_pdom();
+  }
+  dim3 gridDim = config.grid_dim();
+  dim3 blockDim = config.block_dim();
+
+  gpgpu_t *gpu = context->get_device()->get_gpgpu();
+  checkpoint *g_checkpoint;
+  g_checkpoint = new checkpoint();
+  class memory_space *global_mem;
+  global_mem = gpu->get_global_memory();
+
+  if (gpu->resume_option == 1 && (grid->get_uid() == gpu->resume_kernel)) {
+    char f1name[2048];
+    snprintf(f1name, 2048, "checkpoint_files/global_mem_%d.txt",
+             grid->get_uid());
+
+    g_checkpoint->load_global_mem(global_mem, f1name);
+    for (int i = 0; i < gpu->resume_CTA; i++) grid->increment_cta_id();
+  }
+  if (gpu->resume_option == 1 && (grid->get_uid() < gpu->resume_kernel)) {
+    char f1name[2048];
+    snprintf(f1name, 2048, "checkpoint_files/global_mem_%d.txt",
+             grid->get_uid());
+
+    g_checkpoint->load_global_mem(global_mem, f1name);
+    printf("Skipping kernel %d as resuming from kernel %d\n", grid->get_uid(),
+           gpu->resume_kernel);
+    ctx->api->g_cuda_launch_stack.pop_back();
+    return g_last_cudaError = cudaSuccess;
+  }
+  if (gpu->checkpoint_option == 1 &&
+      (grid->get_uid() > gpu->checkpoint_kernel)) {
+    printf("Skipping kernel %d as checkpoint from kernel %d\n", grid->get_uid(),
+           gpu->checkpoint_kernel);
+    ctx->api->g_cuda_launch_stack.pop_back();
+    return g_last_cudaError = cudaSuccess;
+  }
+  printf(
+      "GPGPU-Sim PTX: pushing kernel \'%s\' to stream %u, gridDim= (%u,%u,%u) "
+      "blockDim = (%u,%u,%u) \n",
+      kname.c_str(), stream ? stream->get_uid() : 0, gridDim.x, gridDim.y,
+      gridDim.z, blockDim.x, blockDim.y, blockDim.z);
+  stream_operation op(grid, ctx->func_sim->g_ptx_sim_mode, stream);
+  ctx->the_gpgpusim->g_stream_manager->push(op);
+  ctx->api->g_cuda_launch_stack.pop_back();
+  return g_last_cudaError = cudaSuccess;
 }
 
-cudaError_t cudaLaunchInternal( const char *hostFun, gpgpu_context* gpgpu_ctx = NULL )
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	CUctx_st* context = GPGPUSim_Context(ctx);
-	char *mode = getenv("PTX_SIM_MODE_FUNC");
-	if( mode )
-		sscanf(mode,"%u", &(ctx->func_sim->g_ptx_sim_mode));
-	gpgpusim_ptx_assert( !ctx->api->g_cuda_launch_stack.empty(), "empty launch stack" );
-	kernel_config config = ctx->api->g_cuda_launch_stack.back();
-	{
-		dim3 gridDim = config.grid_dim();
-		dim3 blockDim = config.block_dim();
-		if (gridDim.x * gridDim.y * gridDim.z == 0 || blockDim.x * blockDim.y * blockDim.z == 0)
-		{
-			//can't launch
-			printf("can't launch a empty kernel\n");
-			ctx->api->g_cuda_launch_stack.pop_back();
-			return g_last_cudaError = cudaErrorInvalidConfiguration;
-		}
-	}
-	struct CUstream_st *stream = config.get_stream();
-
-	printf("\nGPGPU-Sim PTX: cudaLaunch for 0x%p (mode=%s) on stream %u\n", hostFun,
-			(ctx->func_sim->g_ptx_sim_mode)?"functional simulation":"performance simulation", stream?stream->get_uid():0 );
-	kernel_info_t *grid = ctx->api->gpgpu_cuda_ptx_sim_init_grid(hostFun,config.get_args(),config.grid_dim(),config.block_dim(),context);
-        //do dynamic PDOM analysis for performance simulation scenario
-	std::string kname = grid->name();
-	function_info *kernel_func_info = grid->entry();
-	if (kernel_func_info->is_pdom_set()) {
-    		printf("GPGPU-Sim PTX: PDOM analysis already done for %s \n", kname.c_str() );
-    	} else {
-    		printf("GPGPU-Sim PTX: finding reconvergence points for \'%s\'...\n", kname.c_str() );
-		kernel_func_info->do_pdom();
-		kernel_func_info->set_pdom();
-    	} 
-	dim3 gridDim = config.grid_dim();
-	dim3 blockDim = config.block_dim();
-		
-	gpgpu_t *gpu = context->get_device()->get_gpgpu();
-	checkpoint *g_checkpoint;
-	g_checkpoint = new checkpoint();
-	class memory_space *global_mem;
-	global_mem = gpu->get_global_memory();
-
-	if(gpu->resume_option ==1 && (grid->get_uid()==gpu->resume_kernel))
-	{
-		
-	    char f1name[2048];
-	    snprintf(f1name,2048,"checkpoint_files/global_mem_%d.txt", grid->get_uid());
-
-	    g_checkpoint->load_global_mem(global_mem, f1name);	
-		for (int i=0;i<gpu->resume_CTA;i++)
-			grid->increment_cta_id();
-	}
-	if(gpu->resume_option==1 && (grid->get_uid()<gpu->resume_kernel))
-	{
-		char f1name[2048];
-	    snprintf(f1name,2048,"checkpoint_files/global_mem_%d.txt", grid->get_uid());
-
-	    g_checkpoint->load_global_mem(global_mem, f1name);	
-		printf("Skipping kernel %d as resuming from kernel %d\n",grid->get_uid(),gpu->resume_kernel );
-		ctx->api->g_cuda_launch_stack.pop_back();
-		return g_last_cudaError = cudaSuccess;
-		
-	}
-	if(gpu->checkpoint_option==1 && (grid->get_uid()>gpu->checkpoint_kernel))
-	{
-		printf("Skipping kernel %d as checkpoint from kernel %d\n",grid->get_uid(),gpu->checkpoint_kernel );
-		ctx->api->g_cuda_launch_stack.pop_back();
-		return g_last_cudaError = cudaSuccess;
-		
-	}
-	printf("GPGPU-Sim PTX: pushing kernel \'%s\' to stream %u, gridDim= (%u,%u,%u) blockDim = (%u,%u,%u) \n",
-			kname.c_str(), stream?stream->get_uid():0, gridDim.x,gridDim.y,gridDim.z,blockDim.x,blockDim.y,blockDim.z );
-	stream_operation op(grid,ctx->func_sim->g_ptx_sim_mode,stream);
-	ctx->the_gpgpusim->g_stream_manager->push(op);
-	ctx->api->g_cuda_launch_stack.pop_back();
-	return g_last_cudaError = cudaSuccess;
+cudaError_t cudaMallocInternal(void **devPtr, size_t size,
+                               gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  CUctx_st *context = GPGPUSim_Context(ctx);
+  *devPtr = context->get_device()->get_gpgpu()->gpu_malloc(size);
+  if (g_debug_execution >= 3) {
+    printf("GPGPU-Sim PTX: cudaMallocing %zu bytes starting at 0x%llx..\n",
+           size, (unsigned long long)*devPtr);
+    ctx->api->g_mallocPtr_Size[(unsigned long long)*devPtr] = size;
+  }
+  if (*devPtr) {
+    return g_last_cudaError = cudaSuccess;
+  } else {
+    return g_last_cudaError = cudaErrorMemoryAllocation;
+  }
 }
 
-cudaError_t cudaMallocInternal(void **devPtr, size_t size, gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	CUctx_st* context = GPGPUSim_Context(ctx);
-	*devPtr = context->get_device()->get_gpgpu()->gpu_malloc(size);
-	if(g_debug_execution >= 3){
-		printf("GPGPU-Sim PTX: cudaMallocing %zu bytes starting at 0x%llx..\n",size, (unsigned long long) *devPtr);
-        ctx->api->g_mallocPtr_Size[(unsigned long long)*devPtr] = size;
-    }
-	if ( *devPtr  ) {
-		return g_last_cudaError = cudaSuccess;
-	} else {
-		return g_last_cudaError = cudaErrorMemoryAllocation;
-	}
+cudaError_t cudaMallocHostInternal(void **ptr, size_t size,
+                                   gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  *ptr = malloc(size);
+  if (*ptr) {
+    // track pinned memory size allocated in the host so that same amount of
+    // memory is also allocated in GPU.
+    ctx->api->pinned_memory_size[*ptr] = size;
+    return g_last_cudaError = cudaSuccess;
+  } else {
+    return g_last_cudaError = cudaErrorMemoryAllocation;
+  }
 }
 
-cudaError_t cudaMallocHostInternal(void **ptr, size_t size, gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	*ptr = malloc(size);
-	if ( *ptr  ) {
-		//track pinned memory size allocated in the host so that same amount of memory is also allocated in GPU.
-		ctx->api->pinned_memory_size[*ptr]=size;
-		return g_last_cudaError = cudaSuccess;
-	} else {
-		return g_last_cudaError = cudaErrorMemoryAllocation;
-	}
+__host__ cudaError_t CUDARTAPI
+cudaMallocPitchInternal(void **devPtr, size_t *pitch, size_t width,
+                        size_t height, gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  unsigned malloc_width_inbytes = width;
+  printf("GPGPU-Sim PTX: cudaMallocPitch (width = %d)\n", malloc_width_inbytes);
+  CUctx_st *context = GPGPUSim_Context(ctx);
+  *devPtr = context->get_device()->get_gpgpu()->gpu_malloc(
+      malloc_width_inbytes * height);
+  pitch[0] = malloc_width_inbytes;
+  if (*devPtr) {
+    return g_last_cudaError = cudaSuccess;
+  } else {
+    return g_last_cudaError = cudaErrorMemoryAllocation;
+  }
 }
 
-__host__ cudaError_t CUDARTAPI cudaMallocPitchInternal(void **devPtr, size_t *pitch, size_t width, size_t height, gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	unsigned malloc_width_inbytes = width;
-	printf("GPGPU-Sim PTX: cudaMallocPitch (width = %d)\n", malloc_width_inbytes);
-	CUctx_st* context = GPGPUSim_Context(ctx);
-	*devPtr = context->get_device()->get_gpgpu()->gpu_malloc(malloc_width_inbytes*height);
-	pitch[0] = malloc_width_inbytes;
-	if ( *devPtr  ) {
-		return g_last_cudaError = cudaSuccess;
-	} else {
-		return g_last_cudaError = cudaErrorMemoryAllocation;
-	}
+cudaError_t cudaHostGetDevicePointerInternal(void **pDevice, void *pHost,
+                                             unsigned int flags,
+                                             gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  // only cpu memory allocation happens in cudaHostAlloc. Linking with device
+  // pointer to pinned memory happens here.
+  // TODO: once kernel is executed, the contents in global pointer of GPU must
+  // be copied back to CPU host pointer!
+  flags = 0;
+  CUctx_st *context = GPGPUSim_Context(ctx);
+  gpgpu_t *gpu = context->get_device()->get_gpgpu();
+  std::map<void *, size_t>::const_iterator i =
+      ctx->api->pinned_memory_size.find(pHost);
+  assert(i != ctx->api->pinned_memory_size.end());
+  size_t size = i->second;
+  *pDevice = gpu->gpu_malloc(size);
+  if (g_debug_execution >= 3) {
+    printf("GPGPU-Sim PTX: cudaMallocing %zu bytes starting at 0x%llx..\n",
+           size, (unsigned long long)*pDevice);
+    ctx->api->g_mallocPtr_Size[(unsigned long long)*pDevice] = size;
+  }
+  if (*pDevice) {
+    ctx->api->pinned_memory[pHost] = pDevice;
+    // Copy contents in cpu to gpu
+    gpu->memcpy_to_gpu((size_t)*pDevice, pHost, size);
+    return g_last_cudaError = cudaSuccess;
+  } else {
+    return g_last_cudaError = cudaErrorMemoryAllocation;
+  }
 }
 
-cudaError_t cudaHostGetDevicePointerInternal(void **pDevice, void *pHost, unsigned int flags, gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	//only cpu memory allocation happens in cudaHostAlloc. Linking with device pointer to pinned memory happens here.
-	//TODO: once kernel is executed, the contents in global pointer of GPU must be copied back to CPU host pointer!
-	flags=0;
-	CUctx_st* context = GPGPUSim_Context(ctx);
-	gpgpu_t *gpu = context->get_device()->get_gpgpu();
-	std::map<void *, size_t>::const_iterator i = ctx->api->pinned_memory_size.find(pHost);
-	assert(i != ctx->api->pinned_memory_size.end());
-	size_t size = i->second;
-	*pDevice = gpu->gpu_malloc(size);
-	if(g_debug_execution >= 3){
-		printf("GPGPU-Sim PTX: cudaMallocing %zu bytes starting at 0x%llx..\n",size, (unsigned long long) *pDevice);
-        ctx->api->g_mallocPtr_Size[(unsigned long long)*pDevice] = size;
-    }
-	if ( *pDevice  ) {
-		ctx->api->pinned_memory[pHost]=pDevice;
-		//Copy contents in cpu to gpu
-		gpu->memcpy_to_gpu((size_t)*pDevice,pHost,size);
-		return g_last_cudaError = cudaSuccess;
-	} else {
-		return g_last_cudaError = cudaErrorMemoryAllocation;
-	}
+__host__ cudaError_t CUDARTAPI cudaMallocArrayInternal(
+    struct cudaArray **array, const struct cudaChannelFormatDesc *desc,
+    size_t width, size_t height __dv(1), gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  unsigned size =
+      width * height * ((desc->x + desc->y + desc->z + desc->w) / 8);
+  CUctx_st *context = GPGPUSim_Context(ctx);
+  (*array) = (struct cudaArray *)malloc(sizeof(struct cudaArray));
+  (*array)->desc = *desc;
+  (*array)->width = width;
+  (*array)->height = height;
+  (*array)->size = size;
+  (*array)->dimensions = 2;
+  ((*array)->devPtr32) =
+      (int)(long long)context->get_device()->get_gpgpu()->gpu_mallocarray(size);
+  printf("GPGPU-Sim PTX: cudaMallocArray: devPtr32 = %d\n",
+         ((*array)->devPtr32));
+  ((*array)->devPtr) = (void *)(long long)((*array)->devPtr32);
+  if (((*array)->devPtr)) {
+    return g_last_cudaError = cudaSuccess;
+  } else {
+    return g_last_cudaError = cudaErrorMemoryAllocation;
+  }
 }
 
-__host__ cudaError_t CUDARTAPI cudaMallocArrayInternal(struct cudaArray **array, const struct cudaChannelFormatDesc *desc, size_t width, size_t height __dv(1), gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
+__host__ cudaError_t CUDARTAPI
+cudaMemcpyInternal(void *dst, const void *src, size_t count,
+                   enum cudaMemcpyKind kind, gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  // CUctx_st *context = GPGPUSim_Context();
+  // gpgpu_t *gpu = context->get_device()->get_gpgpu();
+  if (g_debug_execution >= 3)
+    printf("GPGPU-Sim PTX: cudaMemcpy(): devPtr = %p\n", dst);
+  if (kind == cudaMemcpyHostToDevice)
+    ctx->the_gpgpusim->g_stream_manager->push(
+        stream_operation(src, (size_t)dst, count, 0));
+  else if (kind == cudaMemcpyDeviceToHost)
+    ctx->the_gpgpusim->g_stream_manager->push(
+        stream_operation((size_t)src, dst, count, 0));
+  else if (kind == cudaMemcpyDeviceToDevice)
+    ctx->the_gpgpusim->g_stream_manager->push(
+        stream_operation((size_t)src, (size_t)dst, count, 0));
+  else if (kind == cudaMemcpyDefault) {
+    if ((size_t)src >= GLOBAL_HEAP_START) {
+      if ((size_t)dst >= GLOBAL_HEAP_START)
+        ctx->the_gpgpusim->g_stream_manager->push(stream_operation(
+            (size_t)src, (size_t)dst, count, 0));  // device to device
+      else
+        ctx->the_gpgpusim->g_stream_manager->push(
+            stream_operation((size_t)src, dst, count, 0));  // device to host
     } else {
-	ctx = GPGPU_Context();
+      if ((size_t)dst >= GLOBAL_HEAP_START)
+        ctx->the_gpgpusim->g_stream_manager->push(
+            stream_operation(src, (size_t)dst, count, 0));
+      else {
+        printf(
+            "GPGPU-Sim PTX: cudaMemcpy - ERROR : unsupported transfer: host to "
+            "host\n");
+        abort();
+      }
     }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	unsigned size = width * height * ((desc->x + desc->y + desc->z + desc->w)/8);
-	CUctx_st* context = GPGPUSim_Context(ctx);
-	(*array) = (struct cudaArray*) malloc(sizeof(struct cudaArray));
-	(*array)->desc = *desc;
-	(*array)->width = width;
-	(*array)->height = height;
-	(*array)->size = size;
-	(*array)->dimensions = 2;
-	((*array)->devPtr32)= (int) (long long)context->get_device()->get_gpgpu()->gpu_mallocarray(size);
-	printf("GPGPU-Sim PTX: cudaMallocArray: devPtr32 = %d\n", ((*array)->devPtr32));
-	((*array)->devPtr) = (void*) (long long) ((*array)->devPtr32);
-	if ( ((*array)->devPtr) ) {
-		return g_last_cudaError = cudaSuccess;
-	} else {
-		return g_last_cudaError = cudaErrorMemoryAllocation;
-	}
+  } else {
+    printf("GPGPU-Sim PTX: cudaMemcpy - ERROR : unsupported cudaMemcpyKind\n");
+    abort();
+  }
+  return g_last_cudaError = cudaSuccess;
 }
 
-__host__ cudaError_t CUDARTAPI cudaMemcpyInternal(void *dst, const void *src, size_t count, enum cudaMemcpyKind kind, gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	//CUctx_st *context = GPGPUSim_Context();
-	//gpgpu_t *gpu = context->get_device()->get_gpgpu();
-	if(g_debug_execution >= 3)
-		printf("GPGPU-Sim PTX: cudaMemcpy(): devPtr = %p\n", dst);
-	if( kind == cudaMemcpyHostToDevice )
-		ctx->the_gpgpusim->g_stream_manager->push( stream_operation(src,(size_t)dst,count,0) );
-	else if( kind == cudaMemcpyDeviceToHost )
-		ctx->the_gpgpusim->g_stream_manager->push( stream_operation((size_t)src,dst,count,0) );
-	else if( kind == cudaMemcpyDeviceToDevice )
-		ctx->the_gpgpusim->g_stream_manager->push( stream_operation((size_t)src,(size_t)dst,count,0) );
-	else if ( kind == cudaMemcpyDefault ) {
-		if ((size_t)src >= GLOBAL_HEAP_START) {
-			if ((size_t)dst >= GLOBAL_HEAP_START)
-				ctx->the_gpgpusim->g_stream_manager->push( stream_operation((size_t)src,(size_t)dst,count,0) ); // device to device
-			else
-				ctx->the_gpgpusim->g_stream_manager->push( stream_operation((size_t)src,dst,count,0) ); // device to host
-		}
-		else {
-			if ((size_t)dst >= GLOBAL_HEAP_START)
-				ctx->the_gpgpusim->g_stream_manager->push( stream_operation(src,(size_t)dst,count,0) );
-			else {
-				printf("GPGPU-Sim PTX: cudaMemcpy - ERROR : unsupported transfer: host to host\n");
-				abort();
-			}
-		}
-	}
-	else {
-		printf("GPGPU-Sim PTX: cudaMemcpy - ERROR : unsupported cudaMemcpyKind\n");
-		abort();
-	}
-	return g_last_cudaError = cudaSuccess;
+__host__ cudaError_t CUDARTAPI cudaMemcpyToArrayInternal(
+    struct cudaArray *dst, size_t wOffset, size_t hOffset, const void *src,
+    size_t count, enum cudaMemcpyKind kind, gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  CUctx_st *context = GPGPUSim_Context(ctx);
+  gpgpu_t *gpu = context->get_device()->get_gpgpu();
+  size_t size = count;
+  printf("GPGPU-Sim PTX: cudaMemcpyToArray\n");
+  if (kind == cudaMemcpyHostToDevice)
+    gpu->memcpy_to_gpu((size_t)(dst->devPtr), src, size);
+  else if (kind == cudaMemcpyDeviceToHost)
+    gpu->memcpy_from_gpu(dst->devPtr, (size_t)src, size);
+  else if (kind == cudaMemcpyDeviceToDevice)
+    gpu->memcpy_gpu_to_gpu((size_t)(dst->devPtr), (size_t)src, size);
+  else {
+    printf(
+        "GPGPU-Sim PTX: cudaMemcpyToArray - ERROR : unsupported "
+        "cudaMemcpyKind\n");
+    abort();
+  }
+  dst->devPtr32 = (unsigned)(size_t)(dst->devPtr);
+  return g_last_cudaError = cudaSuccess;
 }
 
-__host__ cudaError_t CUDARTAPI cudaMemcpyToArrayInternal(struct cudaArray *dst, size_t wOffset, size_t hOffset, const void *src, size_t count, enum cudaMemcpyKind kind, gpgpu_context* gpgpu_ctx = NULL)
-{ 
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	CUctx_st *context = GPGPUSim_Context(ctx);
-	gpgpu_t *gpu = context->get_device()->get_gpgpu();
-	size_t size = count;
-	printf("GPGPU-Sim PTX: cudaMemcpyToArray\n");
-	if( kind == cudaMemcpyHostToDevice )
-		gpu->memcpy_to_gpu( (size_t)(dst->devPtr), src, size);
-	else if( kind == cudaMemcpyDeviceToHost )
-		gpu->memcpy_from_gpu( dst->devPtr, (size_t)src, size);
-	else if( kind == cudaMemcpyDeviceToDevice )
-		gpu->memcpy_gpu_to_gpu( (size_t)(dst->devPtr), (size_t)src, size);
-	else {
-		printf("GPGPU-Sim PTX: cudaMemcpyToArray - ERROR : unsupported cudaMemcpyKind\n");
-		abort();
-	}
-	dst->devPtr32 = (unsigned) (size_t)(dst->devPtr);
-	return g_last_cudaError = cudaSuccess;
+__host__ cudaError_t CUDARTAPI cudaMemcpy2DInternal(
+    void *dst, size_t dpitch, const void *src, size_t spitch, size_t width,
+    size_t height, enum cudaMemcpyKind kind, gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  CUctx_st *context = GPGPUSim_Context(ctx);
+  gpgpu_t *gpu = context->get_device()->get_gpgpu();
+  size_t size = spitch * height;
+  gpgpusim_ptx_assert((dpitch == spitch),
+                      "different src and dst pitch not supported yet");
+  if (kind == cudaMemcpyHostToDevice)
+    gpu->memcpy_to_gpu((size_t)dst, src, size);
+  else if (kind == cudaMemcpyDeviceToHost)
+    gpu->memcpy_from_gpu(dst, (size_t)src, size);
+  else if (kind == cudaMemcpyDeviceToDevice)
+    gpu->memcpy_gpu_to_gpu((size_t)dst, (size_t)src, size);
+  else {
+    printf(
+        "GPGPU-Sim PTX: cudaMemcpy2D - ERROR : unsupported cudaMemcpyKind\n");
+    abort();
+  }
+  return g_last_cudaError = cudaSuccess;
 }
 
-__host__ cudaError_t CUDARTAPI cudaMemcpy2DInternal(void *dst, size_t dpitch, const void *src, size_t spitch, size_t width, size_t height, enum cudaMemcpyKind kind, gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	CUctx_st *context = GPGPUSim_Context(ctx);
-	gpgpu_t *gpu = context->get_device()->get_gpgpu();
-	size_t size = spitch*height;
-	gpgpusim_ptx_assert( (dpitch==spitch), "different src and dst pitch not supported yet" );
-	if( kind == cudaMemcpyHostToDevice )
-		gpu->memcpy_to_gpu( (size_t)dst, src, size );
-	else if( kind == cudaMemcpyDeviceToHost )
-		gpu->memcpy_from_gpu( dst, (size_t)src, size );
-	else if( kind == cudaMemcpyDeviceToDevice )
-		gpu->memcpy_gpu_to_gpu( (size_t)dst, (size_t)src, size);
-	else {
-		printf("GPGPU-Sim PTX: cudaMemcpy2D - ERROR : unsupported cudaMemcpyKind\n");
-		abort();
-	}
-	return g_last_cudaError = cudaSuccess;
+__host__ cudaError_t CUDARTAPI cudaMemcpy2DToArrayInternal(
+    struct cudaArray *dst, size_t wOffset, size_t hOffset, const void *src,
+    size_t spitch, size_t width, size_t height, enum cudaMemcpyKind kind,
+    gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  CUctx_st *context = GPGPUSim_Context(ctx);
+  gpgpu_t *gpu = context->get_device()->get_gpgpu();
+  size_t size = spitch * height;
+  size_t channel_size = dst->desc.w + dst->desc.x + dst->desc.y + dst->desc.z;
+  gpgpusim_ptx_assert(
+      ((channel_size % 8) == 0),
+      "none byte multiple destination channel size not supported (sz=%u)",
+      channel_size);
+  unsigned elem_size = channel_size / 8;
+  gpgpusim_ptx_assert((dst->dimensions == 2),
+                      "copy to none 2D array not supported");
+  gpgpusim_ptx_assert((wOffset == 0), "non-zero wOffset not yet supported");
+  gpgpusim_ptx_assert((hOffset == 0), "non-zero hOffset not yet supported");
+  gpgpusim_ptx_assert((dst->height == (int)height),
+                      "partial copy not supported");
+  gpgpusim_ptx_assert((elem_size * dst->width == width),
+                      "partial copy not supported");
+  gpgpusim_ptx_assert((spitch == width), "spitch != width not supported");
+  if (kind == cudaMemcpyHostToDevice)
+    gpu->memcpy_to_gpu((size_t)(dst->devPtr), src, size);
+  else if (kind == cudaMemcpyDeviceToHost)
+    gpu->memcpy_from_gpu(dst->devPtr, (size_t)src, size);
+  else if (kind == cudaMemcpyDeviceToDevice)
+    gpu->memcpy_gpu_to_gpu((size_t)dst->devPtr, (size_t)src, size);
+  else {
+    printf(
+        "GPGPU-Sim PTX: cudaMemcpy2D - ERROR : unsupported cudaMemcpyKind\n");
+    abort();
+  }
+  dst->devPtr32 = (unsigned)(size_t)(dst->devPtr);
+  return g_last_cudaError = cudaSuccess;
 }
 
-__host__ cudaError_t CUDARTAPI cudaMemcpy2DToArrayInternal(struct cudaArray *dst, size_t wOffset, size_t hOffset, const void *src, size_t spitch, size_t width, size_t height, enum cudaMemcpyKind kind, gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	CUctx_st *context = GPGPUSim_Context(ctx);
-	gpgpu_t *gpu = context->get_device()->get_gpgpu();
-	size_t size = spitch*height;
-	size_t channel_size = dst->desc.w+dst->desc.x+dst->desc.y+dst->desc.z;
-	gpgpusim_ptx_assert( ((channel_size%8) == 0), "none byte multiple destination channel size not supported (sz=%u)", channel_size );
-	unsigned elem_size = channel_size/8;
-	gpgpusim_ptx_assert( (dst->dimensions==2), "copy to none 2D array not supported" );
-	gpgpusim_ptx_assert( (wOffset==0), "non-zero wOffset not yet supported" );
-	gpgpusim_ptx_assert( (hOffset==0), "non-zero hOffset not yet supported" );
-	gpgpusim_ptx_assert( (dst->height == (int)height), "partial copy not supported" );
-	gpgpusim_ptx_assert( (elem_size*dst->width == width), "partial copy not supported" );
-	gpgpusim_ptx_assert( (spitch == width), "spitch != width not supported" );
-	if( kind == cudaMemcpyHostToDevice )
-		gpu->memcpy_to_gpu( (size_t)(dst->devPtr), src, size);
-	else if( kind == cudaMemcpyDeviceToHost )
-		gpu->memcpy_from_gpu( dst->devPtr, (size_t)src, size);
-	else if( kind == cudaMemcpyDeviceToDevice )
-		gpu->memcpy_gpu_to_gpu( (size_t)dst->devPtr, (size_t)src, size);
-	else {
-		printf("GPGPU-Sim PTX: cudaMemcpy2D - ERROR : unsupported cudaMemcpyKind\n");
-		abort();
-	}
-	dst->devPtr32 = (unsigned) (size_t)(dst->devPtr);
-	return g_last_cudaError = cudaSuccess;
+__host__ cudaError_t CUDARTAPI cudaMemcpyToSymbolInternal(
+    const char *symbol, const void *src, size_t count, size_t offset __dv(0),
+    enum cudaMemcpyKind kind __dv(cudaMemcpyHostToDevice),
+    gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  // CUctx_st *context = GPGPUSim_Context();
+  assert(kind == cudaMemcpyHostToDevice);
+  printf("GPGPU-Sim PTX: cudaMemcpyToSymbol: symbol = %p\n", symbol);
+  // stream_operation( const char *symbol, const void *src, size_t count, size_t
+  // offset )
+  ctx->the_gpgpusim->g_stream_manager->push(
+      stream_operation(src, symbol, count, offset, 0));
+  // gpgpu_ptx_sim_memcpy_symbol(symbol,src,count,offset,1,context->get_device()->get_gpgpu());
+  return g_last_cudaError = cudaSuccess;
 }
 
-__host__ cudaError_t CUDARTAPI cudaMemcpyToSymbolInternal(const char *symbol, const void *src, size_t count, size_t offset __dv(0), enum cudaMemcpyKind kind __dv(cudaMemcpyHostToDevice), gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	//CUctx_st *context = GPGPUSim_Context();
-	assert(kind == cudaMemcpyHostToDevice);
-	printf("GPGPU-Sim PTX: cudaMemcpyToSymbol: symbol = %p\n", symbol);
-	//stream_operation( const char *symbol, const void *src, size_t count, size_t offset )
-	ctx->the_gpgpusim->g_stream_manager->push( stream_operation(src,symbol,count,offset,0) );
-	//gpgpu_ptx_sim_memcpy_symbol(symbol,src,count,offset,1,context->get_device()->get_gpgpu());
-	return g_last_cudaError = cudaSuccess;
+__host__ cudaError_t CUDARTAPI cudaMemcpyFromSymbolInternal(
+    void *dst, const char *symbol, size_t count, size_t offset __dv(0),
+    enum cudaMemcpyKind kind __dv(cudaMemcpyDeviceToHost),
+    gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  // CUctx_st *context = GPGPUSim_Context();
+  assert(kind == cudaMemcpyDeviceToHost);
+  printf("GPGPU-Sim PTX: cudaMemcpyFromSymbol: symbol = %p\n", symbol);
+  ctx->the_gpgpusim->g_stream_manager->push(
+      stream_operation(symbol, dst, count, offset, 0));
+  // gpgpu_ptx_sim_memcpy_symbol(symbol,dst,count,offset,0,context->get_device()->get_gpgpu());
+  return g_last_cudaError = cudaSuccess;
 }
 
-
-__host__ cudaError_t CUDARTAPI cudaMemcpyFromSymbolInternal(void *dst, const char *symbol, size_t count, size_t offset __dv(0), enum cudaMemcpyKind kind __dv(cudaMemcpyDeviceToHost), gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	//CUctx_st *context = GPGPUSim_Context();
-	assert(kind == cudaMemcpyDeviceToHost);
-	printf("GPGPU-Sim PTX: cudaMemcpyFromSymbol: symbol = %p\n", symbol);
-	ctx->the_gpgpusim->g_stream_manager->push( stream_operation(symbol,dst,count,offset,0) );
-	//gpgpu_ptx_sim_memcpy_symbol(symbol,dst,count,offset,0,context->get_device()->get_gpgpu());
-	return g_last_cudaError = cudaSuccess;
+__host__ cudaError_t CUDARTAPI cudaMemcpyAsyncInternal(
+    void *dst, const void *src, size_t count, enum cudaMemcpyKind kind,
+    cudaStream_t stream, gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  struct CUstream_st *s = (struct CUstream_st *)stream;
+  switch (kind) {
+    case cudaMemcpyHostToDevice:
+      ctx->the_gpgpusim->g_stream_manager->push(
+          stream_operation(src, (size_t)dst, count, s));
+      break;
+    case cudaMemcpyDeviceToHost:
+      ctx->the_gpgpusim->g_stream_manager->push(
+          stream_operation((size_t)src, dst, count, s));
+      break;
+    case cudaMemcpyDeviceToDevice:
+      ctx->the_gpgpusim->g_stream_manager->push(
+          stream_operation((size_t)src, (size_t)dst, count, s));
+      break;
+    default:
+      abort();
+  }
+  return g_last_cudaError = cudaSuccess;
 }
-
-__host__ cudaError_t CUDARTAPI cudaMemcpyAsyncInternal(void *dst, const void *src, size_t count, enum cudaMemcpyKind kind, cudaStream_t stream, gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	struct CUstream_st *s = (struct CUstream_st *)stream;
-	switch( kind ) {
-	case cudaMemcpyHostToDevice: ctx->the_gpgpusim->g_stream_manager->push( stream_operation(src,(size_t)dst,count,s) ); break;
-	case cudaMemcpyDeviceToHost: ctx->the_gpgpusim->g_stream_manager->push( stream_operation((size_t)src,dst,count,s) ); break;
-	case cudaMemcpyDeviceToDevice: ctx->the_gpgpusim->g_stream_manager->push( stream_operation((size_t)src,(size_t)dst,count,s) ); break;
-	default:
-		abort();
-	}
-	return g_last_cudaError = cudaSuccess;
-}
-
 
 #if (CUDART_VERSION >= 8000)
-cudaError_t CUDARTAPI cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlagsInternal(int* numBlocks, const char *hostFunc, int blockSize, size_t dynamicSMemSize, unsigned int flags, gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	printf("GPGPU-Sim PTX: cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags %p\n", hostFunc);
-	CUctx_st *context = GPGPUSim_Context(ctx);
-	function_info *entry = context->get_kernel(hostFunc);
-	printf("Calculate Maxium Active Block with function ptr=%p, blockSize=%d, SMemSize=%d\n", hostFunc, blockSize, dynamicSMemSize);
-	if (flags == cudaOccupancyDefault) {
-		//create kernel_info based on entry
-		dim3 gridDim(context->get_device()->get_gpgpu()->max_cta_per_core()
-                        * context->get_device()->get_gpgpu()->get_config().num_shader());
-		dim3 blockDim(blockSize);
-		kernel_info_t result(gridDim, blockDim, entry);
-		//if(entry == NULL){
-		//	*numBlocks = 1;
-		//	return g_last_cudaError = cudaErrorUnknown;
-		//}
-		*numBlocks = context->get_device()->get_gpgpu()->get_max_cta(result);
-		printf("Maximum size is %d with gridDim %d and blockDim %d\n", *numBlocks, gridDim.x, blockDim.x);
-		return g_last_cudaError = cudaSuccess;
-	} else {
-		cuda_not_implemented(__my_func__,__LINE__);
-		return g_last_cudaError = cudaErrorUnknown;
-	}
+cudaError_t CUDARTAPI
+cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlagsInternal(
+    int *numBlocks, const char *hostFunc, int blockSize, size_t dynamicSMemSize,
+    unsigned int flags, gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  printf(
+      "GPGPU-Sim PTX: cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags "
+      "%p\n",
+      hostFunc);
+  CUctx_st *context = GPGPUSim_Context(ctx);
+  function_info *entry = context->get_kernel(hostFunc);
+  printf(
+      "Calculate Maxium Active Block with function ptr=%p, blockSize=%d, "
+      "SMemSize=%d\n",
+      hostFunc, blockSize, dynamicSMemSize);
+  if (flags == cudaOccupancyDefault) {
+    // create kernel_info based on entry
+    dim3 gridDim(context->get_device()->get_gpgpu()->max_cta_per_core() *
+                 context->get_device()->get_gpgpu()->get_config().num_shader());
+    dim3 blockDim(blockSize);
+    kernel_info_t result(gridDim, blockDim, entry);
+    // if(entry == NULL){
+    //	*numBlocks = 1;
+    //	return g_last_cudaError = cudaErrorUnknown;
+    //}
+    *numBlocks = context->get_device()->get_gpgpu()->get_max_cta(result);
+    printf("Maximum size is %d with gridDim %d and blockDim %d\n", *numBlocks,
+           gridDim.x, blockDim.x);
+    return g_last_cudaError = cudaSuccess;
+  } else {
+    cuda_not_implemented(__my_func__, __LINE__);
+    return g_last_cudaError = cudaErrorUnknown;
+  }
 }
 
 #endif
 
-__host__ cudaError_t CUDARTAPI cudaMemsetInternal(void *mem, int c, size_t count, gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	CUctx_st *context = GPGPUSim_Context(ctx);
-	gpgpu_t *gpu = context->get_device()->get_gpgpu();
-	gpu->gpu_memset((size_t)mem, c, count);
-	return g_last_cudaError = cudaSuccess;
+__host__ cudaError_t CUDARTAPI cudaMemsetInternal(
+    void *mem, int c, size_t count, gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  CUctx_st *context = GPGPUSim_Context(ctx);
+  gpgpu_t *gpu = context->get_device()->get_gpgpu();
+  gpu->gpu_memset((size_t)mem, c, count);
+  return g_last_cudaError = cudaSuccess;
 }
 
-//memset operation is done but i think its not async?
-__host__ cudaError_t CUDARTAPI cudaMemsetAsyncInternal(void *mem, int c, size_t count, 	cudaStream_t stream=0, gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("GPGPU-Sim PTX: WARNING: Asynchronous memset not supported (%s)\n", __my_func__);
-	CUctx_st *context = GPGPUSim_Context(ctx);
-	gpgpu_t *gpu = context->get_device()->get_gpgpu();
-	gpu->gpu_memset((size_t)mem, c, count);
-	return g_last_cudaError = cudaSuccess;
+// memset operation is done but i think its not async?
+__host__ cudaError_t CUDARTAPI
+cudaMemsetAsyncInternal(void *mem, int c, size_t count, cudaStream_t stream = 0,
+                        gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("GPGPU-Sim PTX: WARNING: Asynchronous memset not supported (%s)\n",
+         __my_func__);
+  CUctx_st *context = GPGPUSim_Context(ctx);
+  gpgpu_t *gpu = context->get_device()->get_gpgpu();
+  gpu->gpu_memset((size_t)mem, c, count);
+  return g_last_cudaError = cudaSuccess;
 }
 
-cudaError_t cudaGLMapBufferObjectInternal(void** devPtr, GLuint bufferObj, gpgpu_context* gpgpu_ctx = NULL)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
+cudaError_t cudaGLMapBufferObjectInternal(void **devPtr, GLuint bufferObj,
+                                          gpgpu_context *gpgpu_ctx = NULL) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
 #ifdef OPENGL_SUPPORT
-	gpgpu_context *ctx;
-	if (gpgpu_ctx){
-	    ctx = gpgpu_ctx;
-	} else {
-	    ctx = GPGPU_Context();
-	}
-	GLint buffer_size=0;
-	CUctx_st* context = GPGPUSim_Context(ctx);
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  GLint buffer_size = 0;
+  CUctx_st *context = GPGPUSim_Context(ctx);
 
-	glbmap_entry_t *p = ctx->api->g_glbmap;
-	while ( p && p->m_bufferObj != bufferObj )
-		p = p->m_next;
-	if ( p == NULL ) {
-		glBindBuffer(GL_ARRAY_BUFFER,bufferObj);
-		glGetBufferParameteriv(GL_ARRAY_BUFFER,GL_BUFFER_SIZE,&buffer_size);
-		assert( buffer_size != 0 );
-		*devPtr = context->get_device()->get_gpgpu()->gpu_malloc(buffer_size);
+  glbmap_entry_t *p = ctx->api->g_glbmap;
+  while (p && p->m_bufferObj != bufferObj) p = p->m_next;
+  if (p == NULL) {
+    glBindBuffer(GL_ARRAY_BUFFER, bufferObj);
+    glGetBufferParameteriv(GL_ARRAY_BUFFER, GL_BUFFER_SIZE, &buffer_size);
+    assert(buffer_size != 0);
+    *devPtr = context->get_device()->get_gpgpu()->gpu_malloc(buffer_size);
 
-		// create entry and insert to front of list
-		glbmap_entry_t *n = (glbmap_entry_t *) calloc(1,sizeof(glbmap_entry_t));
-		n->m_next = ctx->api->g_glbmap;
-		ctx->api->g_glbmap = n;
+    // create entry and insert to front of list
+    glbmap_entry_t *n = (glbmap_entry_t *)calloc(1, sizeof(glbmap_entry_t));
+    n->m_next = ctx->api->g_glbmap;
+    ctx->api->g_glbmap = n;
 
-		// initialize entry
-		n->m_bufferObj = bufferObj;
-		n->m_devPtr = *devPtr;
-		n->m_size = buffer_size;
+    // initialize entry
+    n->m_bufferObj = bufferObj;
+    n->m_devPtr = *devPtr;
+    n->m_size = buffer_size;
 
-		p = n;
-	} else {
-		buffer_size = p->m_size;
-		*devPtr = p->m_devPtr;
-	}
+    p = n;
+  } else {
+    buffer_size = p->m_size;
+    *devPtr = p->m_devPtr;
+  }
 
-	if ( *devPtr  ) {
-		char *data = (char *) calloc(p->m_size,1);
-		glGetBufferSubData(GL_ARRAY_BUFFER,0,buffer_size,data);
-		memcpy_to_gpu( (size_t) *devPtr, data, buffer_size );
-		free(data);
-		printf("GPGPU-Sim PTX: cudaGLMapBufferObject %zu bytes starting at 0x%llx..\n", (size_t)buffer_size,
-				(unsigned long long) *devPtr);
-		return g_last_cudaError = cudaSuccess;
-	} else {
-		return g_last_cudaError = cudaErrorMemoryAllocation;
-	}
+  if (*devPtr) {
+    char *data = (char *)calloc(p->m_size, 1);
+    glGetBufferSubData(GL_ARRAY_BUFFER, 0, buffer_size, data);
+    memcpy_to_gpu((size_t)*devPtr, data, buffer_size);
+    free(data);
+    printf(
+        "GPGPU-Sim PTX: cudaGLMapBufferObject %zu bytes starting at 0x%llx..\n",
+        (size_t)buffer_size, (unsigned long long)*devPtr);
+    return g_last_cudaError = cudaSuccess;
+  } else {
+    return g_last_cudaError = cudaErrorMemoryAllocation;
+  }
 
-	return g_last_cudaError = cudaSuccess;
+  return g_last_cudaError = cudaSuccess;
 #else
-	fflush(stdout);
-	fflush(stderr);
-	printf("GPGPU-Sim PTX: GPGPU-Sim support for OpenGL integration disabled -- exiting\n");
-	fflush(stdout);
-	exit(50);
+  fflush(stdout);
+  fflush(stderr);
+  printf(
+      "GPGPU-Sim PTX: GPGPU-Sim support for OpenGL integration disabled -- "
+      "exiting\n");
+  fflush(stdout);
+  exit(50);
 #endif
 }
 
 #if CUDART_VERSION >= 6050
-CUresult
-cuLinkAddFileInternal(CUlinkState state, CUjitInputType type, const char *path,
-    unsigned int numOptions, CUjit_option *options, void **optionValues, gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-    static bool addedFile = false;
-    if (addedFile){
-        printf("GPGPU-Sim PTX: ERROR: cuLinkAddFile does not support multiple files\n");
-        abort();
-    }
+CUresult cuLinkAddFileInternal(CUlinkState state, CUjitInputType type,
+                               const char *path, unsigned int numOptions,
+                               CUjit_option *options, void **optionValues,
+                               gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  static bool addedFile = false;
+  if (addedFile) {
+    printf(
+        "GPGPU-Sim PTX: ERROR: cuLinkAddFile does not support multiple "
+        "files\n");
+    abort();
+  }
 
-    //blocking
-    assert(type==CU_JIT_INPUT_PTX);
-	CUctx_st *context = GPGPUSim_Context(ctx);
-    char *file = getenv("PTX_JIT_PATH");
-    if(file==NULL){
-        printf("GPGPU-Sim PTX: ERROR: PTX_JIT_PATH has not been set\n");
-        abort();
-    }
-    strcat(file,"/");
-    strcat(file,path);
-	symbol_table *symtab = ctx->gpgpu_ptx_sim_load_ptx_from_filename( file );
-    std::string fname(path);
-    ctx->api->name_symtab[fname] = symtab;
-    context->add_binary(symtab, 1);
-    ctx->api->load_static_globals(symtab,STATIC_ALLOC_LIMIT,0xFFFFFFFF,context->get_device()->get_gpgpu());
-    ctx->api->load_constants(symtab,STATIC_ALLOC_LIMIT,context->get_device()->get_gpgpu());
-    addedFile = true;
-	return CUDA_SUCCESS;
+  // blocking
+  assert(type == CU_JIT_INPUT_PTX);
+  CUctx_st *context = GPGPUSim_Context(ctx);
+  char *file = getenv("PTX_JIT_PATH");
+  if (file == NULL) {
+    printf("GPGPU-Sim PTX: ERROR: PTX_JIT_PATH has not been set\n");
+    abort();
+  }
+  strcat(file, "/");
+  strcat(file, path);
+  symbol_table *symtab = ctx->gpgpu_ptx_sim_load_ptx_from_filename(file);
+  std::string fname(path);
+  ctx->api->name_symtab[fname] = symtab;
+  context->add_binary(symtab, 1);
+  ctx->api->load_static_globals(symtab, STATIC_ALLOC_LIMIT, 0xFFFFFFFF,
+                                context->get_device()->get_gpgpu());
+  ctx->api->load_constants(symtab, STATIC_ALLOC_LIMIT,
+                           context->get_device()->get_gpgpu());
+  addedFile = true;
+  return CUDA_SUCCESS;
 }
 #endif
 
 #if (CUDART_VERSION >= 2010)
 
-cudaError_t cudaHostAllocInternal(void **pHost,  size_t bytes, unsigned int flags, gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	*pHost = malloc(bytes);
-	//need to track the size allocated so that cudaHostGetDevicePointer() can function properly.
-	//TODO: vary this function behavior based on flags value (following nvidia documentation)
-	ctx->api->pinned_memory_size[*pHost]=bytes;
-	if( *pHost )
-		return g_last_cudaError = cudaSuccess;
-	else
-		return g_last_cudaError = cudaErrorMemoryAllocation;
+cudaError_t cudaHostAllocInternal(void **pHost, size_t bytes,
+                                  unsigned int flags,
+                                  gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  *pHost = malloc(bytes);
+  // need to track the size allocated so that cudaHostGetDevicePointer() can
+  // function properly.
+  // TODO: vary this function behavior based on flags value (following nvidia
+  // documentation)
+  ctx->api->pinned_memory_size[*pHost] = bytes;
+  if (*pHost)
+    return g_last_cudaError = cudaSuccess;
+  else
+    return g_last_cudaError = cudaErrorMemoryAllocation;
 }
 
 #endif
 
-size_t getMaxThreadsPerBlock(struct cudaFuncAttributes *attr, gpgpu_context *ctx) {
+size_t getMaxThreadsPerBlock(struct cudaFuncAttributes *attr,
+                             gpgpu_context *ctx) {
   _cuda_device_id *dev = ctx->GPGPUSim_Init();
   struct cudaDeviceProp prop;
 
@@ -1486,650 +1621,666 @@ size_t getMaxThreadsPerBlock(struct cudaFuncAttributes *attr, gpgpu_context *ctx
   if (attr->numRegs && (prop.regsPerBlock / attr->numRegs) < max)
     max = prop.regsPerBlock / attr->numRegs;
 
-  if (attr->sharedSizeBytes && (prop.sharedMemPerBlock / attr->sharedSizeBytes) < max)
-      max = prop.sharedMemPerBlock / attr->sharedSizeBytes;
+  if (attr->sharedSizeBytes &&
+      (prop.sharedMemPerBlock / attr->sharedSizeBytes) < max)
+    max = prop.sharedMemPerBlock / attr->sharedSizeBytes;
 
   return max;
 }
 
-cudaError_t CUDARTAPI cudaFuncGetAttributesInternal(struct cudaFuncAttributes *attr, const char *hostFun, gpgpu_context* gpgpu_ctx = NULL )
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	CUctx_st *context = GPGPUSim_Context(ctx);
-	function_info *entry = context->get_kernel(hostFun);
-	if( entry ) {
-		const struct gpgpu_ptx_sim_info *kinfo = entry->get_kernel_info();
-		attr->sharedSizeBytes = kinfo->smem;
-		attr->constSizeBytes  = kinfo->cmem;
-		attr->localSizeBytes  = kinfo->lmem;
-		attr->numRegs         = kinfo->regs;
-		if(kinfo->maxthreads > 0)
-		  attr->maxThreadsPerBlock = kinfo->maxthreads;
-		else
-		  attr->maxThreadsPerBlock = getMaxThreadsPerBlock(attr, ctx);
+cudaError_t CUDARTAPI cudaFuncGetAttributesInternal(
+    struct cudaFuncAttributes *attr, const char *hostFun,
+    gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  CUctx_st *context = GPGPUSim_Context(ctx);
+  function_info *entry = context->get_kernel(hostFun);
+  if (entry) {
+    const struct gpgpu_ptx_sim_info *kinfo = entry->get_kernel_info();
+    attr->sharedSizeBytes = kinfo->smem;
+    attr->constSizeBytes = kinfo->cmem;
+    attr->localSizeBytes = kinfo->lmem;
+    attr->numRegs = kinfo->regs;
+    if (kinfo->maxthreads > 0)
+      attr->maxThreadsPerBlock = kinfo->maxthreads;
+    else
+      attr->maxThreadsPerBlock = getMaxThreadsPerBlock(attr, ctx);
 #if CUDART_VERSION >= 3000
-		attr->ptxVersion      = kinfo->ptx_version;
-		attr->binaryVersion   = kinfo->sm_target;
+    attr->ptxVersion = kinfo->ptx_version;
+    attr->binaryVersion = kinfo->sm_target;
 #endif
-	}
-	return g_last_cudaError = cudaSuccess;
+  }
+  return g_last_cudaError = cudaSuccess;
 }
 
 #if (CUDART_VERSION > 5000)
-__host__ cudaError_t CUDARTAPI cudaDeviceGetAttributeInternal(int *value, enum cudaDeviceAttr attr, int device, gpgpu_context* gpgpu_ctx = NULL)
-{
-	    gpgpu_context *ctx;
-		if (gpgpu_ctx){
-		ctx = gpgpu_ctx;
-		} else {
-		ctx = GPGPU_Context();
-		}
-		if(g_debug_execution >= 3){
-			announce_call(__my_func__);
-		}
+__host__ cudaError_t CUDARTAPI
+cudaDeviceGetAttributeInternal(int *value, enum cudaDeviceAttr attr, int device,
+                               gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
 
-        const struct cudaDeviceProp *prop;
-        _cuda_device_id *dev = ctx->GPGPUSim_Init();
+  const struct cudaDeviceProp *prop;
+  _cuda_device_id *dev = ctx->GPGPUSim_Init();
 
-        if (device <= dev->num_devices() )  {
-                prop = dev->get_prop();
-                switch (attr) {
-                case 1:
-                        *value= prop->maxThreadsPerBlock;
-                        break;
-                case 2:
-                        *value= prop->maxThreadsDim[0];
-                        break;
-                case 3:
-                        *value= prop->maxThreadsDim[1];
-                        break;
-                case 4:
-                        *value= prop->maxThreadsDim[2];
-                        break; 
-		case 5:
-                        *value= prop->maxGridSize[0];
-                        break;
-                case 6:
-                        *value= prop->maxGridSize[1];
-                        break;
-                case 7:
-                        *value= prop->maxGridSize[2];
-                        break;
-		case 8:
-                        *value= prop->sharedMemPerBlock;
-                        break;
-		case 9:
-                        *value= prop->totalConstMem;
-                        break;
-                case 10:
-                        *value= prop->warpSize;
-                        break;
-                case 11:
-                        *value= 16;//dummy value
-                        break;
-                case 12:
-                        *value= prop->regsPerBlock;
-                        break;
-                case 13:
-                        *value= 1480000;//for 1080ti
-                        break;
-                case 14:
-                        *value= prop->textureAlignment ;
-                        break;
-                case 15:
-                        *value = 0;
-                        break;
-                case 16:
-                        *value= prop->multiProcessorCount ;
-                        break;
-                case 17:
-                case 18:
-                case 19:
-                        *value = 0;
-                        break;
-                case 21:
-                case 22:
-                case 23:
-                case 24:
-                case 25:
-                case 26:
-                case 27:
-                case 28:
-                case 42:
-                case 45:
-                case 46:
-                case 47:
-                case 48:
-                case 49:
-                case 52:
-                case 53:
-                case 55:
-                case 56:
-                case 57:
-                case 58:
-                case 59:
-                case 60:
-                case 61:
-                case 62:
-                case 63:
-                case 64:
-                case 66:
-                case 67:
-                case 69:
-                case 70:
-                case 71:
-                case 73:
-                case 74:
-                case 77:
-                        *value = 1000;//dummy value
-                        break;
-                case 29:
-                case 43:
-                case 54:
-                case 65:
-                case 68:
-                case 72:
-                        *value = 10;//dummy value
-                        break;
-                case 30:
-                case 51:
-                        *value = 128;//dummy value
-                        break;
-                case 31:
-                        *value = 1;
-                        break;
-                case 32:
-                        *value = 0;
-                        break;
-                case 33:
-                case 50:
-                        *value = 0;//dummy value
-                        break;
-		        case 34:
-                        *value= 0;
-                        break;
-                case 35:
-                        *value = 0;
-                        break;
-                case 36:
-                        *value = 1250000;//CK value for 1080ti
-                        break;
-                case 37:
-                        *value = 352;//value for 1080ti
-                        break;
-                case 38:
-                        *value = 3000000;//value for 1080ti
-                        break;
-                case 39:
-                        *value= dev->get_gpgpu()->threads_per_core();
-                        break;
-                case 40:
-                        *value= 0;
-                        break;
-                case 41:
-                        *value= 0;
-                        break;
-                case 75://cudaDevAttrComputeCapabilityMajor
-                        *value= prop->major ;
-                        break;
-                case 76://cudaDevAttrComputeCapabilityMinor
-                        *value= prop->minor ;
-                        break;
-                case 78:
-                        *value= 0 ; //TODO: as of now, we dont support stream priorities.
-                        break;
-                case 79:
-                        *value= 0;
-                        break;
-                case 80:
-                        *value= 0;
-                        break;
-		#if (CUDART_VERSION > 5050)
-		case 81:
-                        *value= prop->sharedMemPerMultiprocessor;
-                        break;
-                case 82:
-                        *value= prop->regsPerMultiprocessor;
-                        break;
-		#endif
-                case 83:
-                case 84:
-                case 85:
-                case 86:
-                        *value= 0;
-                        break;
-                case 87:
-                        *value= 4;//dummy value
-                        break;
-                case 88:
-                case 89:
-                        *value= 0;
-                        break;
-		default:
-			printf("ERROR: Attribute number %d unimplemented \n",attr);
-			abort();
-                }
-                return g_last_cudaError = cudaSuccess;
-        } else {
-                return g_last_cudaError = cudaErrorInvalidDevice;
-        }
-}
+  if (device <= dev->num_devices()) {
+    prop = dev->get_prop();
+    switch (attr) {
+      case 1:
+        *value = prop->maxThreadsPerBlock;
+        break;
+      case 2:
+        *value = prop->maxThreadsDim[0];
+        break;
+      case 3:
+        *value = prop->maxThreadsDim[1];
+        break;
+      case 4:
+        *value = prop->maxThreadsDim[2];
+        break;
+      case 5:
+        *value = prop->maxGridSize[0];
+        break;
+      case 6:
+        *value = prop->maxGridSize[1];
+        break;
+      case 7:
+        *value = prop->maxGridSize[2];
+        break;
+      case 8:
+        *value = prop->sharedMemPerBlock;
+        break;
+      case 9:
+        *value = prop->totalConstMem;
+        break;
+      case 10:
+        *value = prop->warpSize;
+        break;
+      case 11:
+        *value = 16;  // dummy value
+        break;
+      case 12:
+        *value = prop->regsPerBlock;
+        break;
+      case 13:
+        *value = 1480000;  // for 1080ti
+        break;
+      case 14:
+        *value = prop->textureAlignment;
+        break;
+      case 15:
+        *value = 0;
+        break;
+      case 16:
+        *value = prop->multiProcessorCount;
+        break;
+      case 17:
+      case 18:
+      case 19:
+        *value = 0;
+        break;
+      case 21:
+      case 22:
+      case 23:
+      case 24:
+      case 25:
+      case 26:
+      case 27:
+      case 28:
+      case 42:
+      case 45:
+      case 46:
+      case 47:
+      case 48:
+      case 49:
+      case 52:
+      case 53:
+      case 55:
+      case 56:
+      case 57:
+      case 58:
+      case 59:
+      case 60:
+      case 61:
+      case 62:
+      case 63:
+      case 64:
+      case 66:
+      case 67:
+      case 69:
+      case 70:
+      case 71:
+      case 73:
+      case 74:
+      case 77:
+        *value = 1000;  // dummy value
+        break;
+      case 29:
+      case 43:
+      case 54:
+      case 65:
+      case 68:
+      case 72:
+        *value = 10;  // dummy value
+        break;
+      case 30:
+      case 51:
+        *value = 128;  // dummy value
+        break;
+      case 31:
+        *value = 1;
+        break;
+      case 32:
+        *value = 0;
+        break;
+      case 33:
+      case 50:
+        *value = 0;  // dummy value
+        break;
+      case 34:
+        *value = 0;
+        break;
+      case 35:
+        *value = 0;
+        break;
+      case 36:
+        *value = 1250000;  // CK value for 1080ti
+        break;
+      case 37:
+        *value = 352;  // value for 1080ti
+        break;
+      case 38:
+        *value = 3000000;  // value for 1080ti
+        break;
+      case 39:
+        *value = dev->get_gpgpu()->threads_per_core();
+        break;
+      case 40:
+        *value = 0;
+        break;
+      case 41:
+        *value = 0;
+        break;
+      case 75:  // cudaDevAttrComputeCapabilityMajor
+        *value = prop->major;
+        break;
+      case 76:  // cudaDevAttrComputeCapabilityMinor
+        *value = prop->minor;
+        break;
+      case 78:
+        *value = 0;  // TODO: as of now, we dont support stream priorities.
+        break;
+      case 79:
+        *value = 0;
+        break;
+      case 80:
+        *value = 0;
+        break;
+#if (CUDART_VERSION > 5050)
+      case 81:
+        *value = prop->sharedMemPerMultiprocessor;
+        break;
+      case 82:
+        *value = prop->regsPerMultiprocessor;
+        break;
 #endif
-
-__host__ cudaError_t CUDARTAPI cudaBindTextureInternal(size_t *offset,
-		const struct textureReference *texref,
-		const void *devPtr,
-		const struct cudaChannelFormatDesc *desc,
-		size_t size __dv(UINT_MAX),
-		gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
+      case 83:
+      case 84:
+      case 85:
+      case 86:
+        *value = 0;
+        break;
+      case 87:
+        *value = 4;  // dummy value
+        break;
+      case 88:
+      case 89:
+        *value = 0;
+        break;
+      default:
+        printf("ERROR: Attribute number %d unimplemented \n", attr);
+        abort();
     }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	CUctx_st *context = GPGPUSim_Context(ctx);
-	gpgpu_t *gpu = context->get_device()->get_gpgpu();
-	printf("GPGPU-Sim PTX: in cudaBindTexture: sizeof(struct textureReference) = %zu\n", sizeof(struct textureReference));
-	struct cudaArray *array;
-	array = (struct cudaArray*) malloc(sizeof(struct cudaArray));
-	array->desc = *desc;
-	array->size = size;
-	array->width = size;
-	array->height = 1;
-	array->dimensions = 1;
-	array->devPtr = (void*)devPtr;
-	array->devPtr32 = (int)(long long)devPtr;
-	offset = 0;
-	printf("GPGPU-Sim PTX:   size = %zu\n", size);
-	printf("GPGPU-Sim PTX:   texref = %p, array = %p\n", texref, array);
-	printf("GPGPU-Sim PTX:   devPtr32 = %x\n", array->devPtr32);
-	printf("GPGPU-Sim PTX:   Name corresponding to textureReference: %s\n", gpu->gpgpu_ptx_sim_findNamefromTexture(texref));
-	printf("GPGPU-Sim PTX:   ChannelFormatDesc: x=%d, y=%d, z=%d, w=%d\n", desc->x, desc->y, desc->z, desc->w);
-	printf("GPGPU-Sim PTX:   Texture Normalized? = %d\n", texref->normalized);
-	gpu->gpgpu_ptx_sim_bindTextureToArray(texref, array);
-	devPtr = (void*)(long long)array->devPtr32;
-	printf("GPGPU-Sim PTX: devPtr = %p\n", devPtr);
-	return g_last_cudaError = cudaSuccess;
-}
-
-__host__ cudaError_t CUDARTAPI cudaBindTextureToArrayInternal(const struct textureReference *texref, const struct cudaArray *array, const struct cudaChannelFormatDesc *desc, gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	CUctx_st *context = GPGPUSim_Context(ctx);
-	gpgpu_t *gpu = context->get_device()->get_gpgpu();
-	printf("GPGPU-Sim PTX: in cudaBindTextureToArray: %p %p\n", texref, array);
-	printf("GPGPU-Sim PTX:   devPtr32 = %x\n", array->devPtr32);
-	printf("GPGPU-Sim PTX:   Name corresponding to textureReference: %s\n", gpu->gpgpu_ptx_sim_findNamefromTexture(texref));
-	printf("GPGPU-Sim PTX:   Texture Normalized? = %d\n", texref->normalized);
-	gpu->gpgpu_ptx_sim_bindTextureToArray(texref, array);
-	return g_last_cudaError = cudaSuccess;
-}
-
-__host__ cudaError_t CUDARTAPI cudaUnbindTextureInternal(const struct textureReference *texref, gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-   CUctx_st *context = GPGPUSim_Context(ctx);
-   gpgpu_t *gpu = context->get_device()->get_gpgpu();
-   printf("GPGPU-Sim PTX: in cudaUnbindTexture: sizeof(struct textureReference) = %zu\n", sizeof(struct textureReference));
-   printf("GPGPU-Sim PTX:   Name corresponding to textureReference: %s\n", gpu->gpgpu_ptx_sim_findNamefromTexture(texref));
-
-   gpu->gpgpu_ptx_sim_unbindTexture(texref);
-   return g_last_cudaError = cudaSuccess;
-}
-
-__host__ cudaError_t CUDARTAPI cudaLaunchKernelInternal( const char* hostFun, dim3 gridDim, dim3 blockDim, const void** args, size_t sharedMem, cudaStream_t stream, gpgpu_context* gpgpu_ctx = NULL )
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-
-    if(g_debug_execution >= 3){
-        announce_call(__my_func__);
-    }
-    CUctx_st *context = GPGPUSim_Context(ctx);
-    function_info *entry = context->get_kernel(hostFun);
-#if CUDART_VERSION < 10000
-    cudaConfigureCallInternal(gridDim, blockDim, sharedMem, stream, ctx);
-#endif
-    for(unsigned i = 0; i < entry->num_args(); i++){
-        std::pair<size_t, unsigned> p = entry->get_param_config(i);
-        cudaSetupArgumentInternal(args[i], p.first, p.second);
-    }
-
-    cudaLaunchInternal(hostFun);
     return g_last_cudaError = cudaSuccess;
+  } else {
+    return g_last_cudaError = cudaErrorInvalidDevice;
+  }
+}
+#endif
+
+__host__ cudaError_t CUDARTAPI cudaBindTextureInternal(
+    size_t *offset, const struct textureReference *texref, const void *devPtr,
+    const struct cudaChannelFormatDesc *desc, size_t size __dv(UINT_MAX),
+    gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  CUctx_st *context = GPGPUSim_Context(ctx);
+  gpgpu_t *gpu = context->get_device()->get_gpgpu();
+  printf(
+      "GPGPU-Sim PTX: in cudaBindTexture: sizeof(struct textureReference) = "
+      "%zu\n",
+      sizeof(struct textureReference));
+  struct cudaArray *array;
+  array = (struct cudaArray *)malloc(sizeof(struct cudaArray));
+  array->desc = *desc;
+  array->size = size;
+  array->width = size;
+  array->height = 1;
+  array->dimensions = 1;
+  array->devPtr = (void *)devPtr;
+  array->devPtr32 = (int)(long long)devPtr;
+  offset = 0;
+  printf("GPGPU-Sim PTX:   size = %zu\n", size);
+  printf("GPGPU-Sim PTX:   texref = %p, array = %p\n", texref, array);
+  printf("GPGPU-Sim PTX:   devPtr32 = %x\n", array->devPtr32);
+  printf("GPGPU-Sim PTX:   Name corresponding to textureReference: %s\n",
+         gpu->gpgpu_ptx_sim_findNamefromTexture(texref));
+  printf("GPGPU-Sim PTX:   ChannelFormatDesc: x=%d, y=%d, z=%d, w=%d\n",
+         desc->x, desc->y, desc->z, desc->w);
+  printf("GPGPU-Sim PTX:   Texture Normalized? = %d\n", texref->normalized);
+  gpu->gpgpu_ptx_sim_bindTextureToArray(texref, array);
+  devPtr = (void *)(long long)array->devPtr32;
+  printf("GPGPU-Sim PTX: devPtr = %p\n", devPtr);
+  return g_last_cudaError = cudaSuccess;
 }
 
-__host__ cudaError_t CUDARTAPI cudaStreamCreateInternal(cudaStream_t *stream, gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("GPGPU-Sim PTX: cudaStreamCreate\n");
+__host__ cudaError_t CUDARTAPI cudaBindTextureToArrayInternal(
+    const struct textureReference *texref, const struct cudaArray *array,
+    const struct cudaChannelFormatDesc *desc, gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  CUctx_st *context = GPGPUSim_Context(ctx);
+  gpgpu_t *gpu = context->get_device()->get_gpgpu();
+  printf("GPGPU-Sim PTX: in cudaBindTextureToArray: %p %p\n", texref, array);
+  printf("GPGPU-Sim PTX:   devPtr32 = %x\n", array->devPtr32);
+  printf("GPGPU-Sim PTX:   Name corresponding to textureReference: %s\n",
+         gpu->gpgpu_ptx_sim_findNamefromTexture(texref));
+  printf("GPGPU-Sim PTX:   Texture Normalized? = %d\n", texref->normalized);
+  gpu->gpgpu_ptx_sim_bindTextureToArray(texref, array);
+  return g_last_cudaError = cudaSuccess;
+}
+
+__host__ cudaError_t CUDARTAPI cudaUnbindTextureInternal(
+    const struct textureReference *texref, gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  CUctx_st *context = GPGPUSim_Context(ctx);
+  gpgpu_t *gpu = context->get_device()->get_gpgpu();
+  printf(
+      "GPGPU-Sim PTX: in cudaUnbindTexture: sizeof(struct textureReference) = "
+      "%zu\n",
+      sizeof(struct textureReference));
+  printf("GPGPU-Sim PTX:   Name corresponding to textureReference: %s\n",
+         gpu->gpgpu_ptx_sim_findNamefromTexture(texref));
+
+  gpu->gpgpu_ptx_sim_unbindTexture(texref);
+  return g_last_cudaError = cudaSuccess;
+}
+
+__host__ cudaError_t CUDARTAPI cudaLaunchKernelInternal(
+    const char *hostFun, dim3 gridDim, dim3 blockDim, const void **args,
+    size_t sharedMem, cudaStream_t stream, gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  CUctx_st *context = GPGPUSim_Context(ctx);
+  function_info *entry = context->get_kernel(hostFun);
+#if CUDART_VERSION < 10000
+  cudaConfigureCallInternal(gridDim, blockDim, sharedMem, stream, ctx);
+#endif
+  for (unsigned i = 0; i < entry->num_args(); i++) {
+    std::pair<size_t, unsigned> p = entry->get_param_config(i);
+    cudaSetupArgumentInternal(args[i], p.first, p.second);
+  }
+
+  cudaLaunchInternal(hostFun);
+  return g_last_cudaError = cudaSuccess;
+}
+
+__host__ cudaError_t CUDARTAPI cudaStreamCreateInternal(
+    cudaStream_t *stream, gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("GPGPU-Sim PTX: cudaStreamCreate\n");
 #if (CUDART_VERSION >= 3000)
-	*stream = new struct CUstream_st();
-	ctx->the_gpgpusim->g_stream_manager->add_stream(*stream);
+  *stream = new struct CUstream_st();
+  ctx->the_gpgpusim->g_stream_manager->add_stream(*stream);
 #else
-	*stream = 0;
-	printf("GPGPU-Sim PTX: WARNING: Asynchronous kernel execution not supported (%s)\n", __my_func__);
+  *stream = 0;
+  printf(
+      "GPGPU-Sim PTX: WARNING: Asynchronous kernel execution not supported "
+      "(%s)\n",
+      __my_func__);
 #endif
-	return g_last_cudaError = cudaSuccess;
+  return g_last_cudaError = cudaSuccess;
 }
 
-__host__ cudaError_t CUDARTAPI cudaStreamDestroyInternal(cudaStream_t stream, gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
+__host__ cudaError_t CUDARTAPI cudaStreamDestroyInternal(
+    cudaStream_t stream, gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
 #if (CUDART_VERSION >= 3000)
-	//per-stream synchronization required for application using external libraries without explicit synchronization in the code to 
-	//avoid the stream_manager from spinning forever to destroy non-empty streams without making any forward progress. 
-	stream->synchronize();
-	ctx->the_gpgpusim->g_stream_manager->destroy_stream(stream);
+  // per-stream synchronization required for application using external
+  // libraries without explicit synchronization in the code to avoid the
+  // stream_manager from spinning forever to destroy non-empty streams without
+  // making any forward progress.
+  stream->synchronize();
+  ctx->the_gpgpusim->g_stream_manager->destroy_stream(stream);
 #endif
-	return g_last_cudaError = cudaSuccess;
+  return g_last_cudaError = cudaSuccess;
 }
 
-__host__ cudaError_t CUDARTAPI cudaStreamSynchronizeInternal(cudaStream_t stream, gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
+__host__ cudaError_t CUDARTAPI cudaStreamSynchronizeInternal(
+    cudaStream_t stream, gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
 #if (CUDART_VERSION >= 3000)
-	if( stream == NULL )
-		ctx->synchronize();
-		return g_last_cudaError = cudaSuccess;
-	stream->synchronize();
+  if (stream == NULL) ctx->synchronize();
+  return g_last_cudaError = cudaSuccess;
+  stream->synchronize();
 #else
-	printf("GPGPU-Sim PTX: WARNING: Asynchronous kernel execution not supported (%s)\n", __my_func__);
+  printf(
+      "GPGPU-Sim PTX: WARNING: Asynchronous kernel execution not supported "
+      "(%s)\n",
+      __my_func__);
 #endif
-	return g_last_cudaError = cudaSuccess;
+  return g_last_cudaError = cudaSuccess;
 }
 
 void __cudaRegisterTextureInternal(
-		void **fatCubinHandle,
-		const struct textureReference *hostVar,
-		const void **deviceAddress,
-		const char *deviceName,
-		int dim,
-		int norm,
-		int ext,
-		gpgpu_context* gpgpu_ctx = NULL
-) //passes in a newly created textureReference
+    void **fatCubinHandle, const struct textureReference *hostVar,
+    const void **deviceAddress, const char *deviceName, int dim, int norm,
+    int ext,
+    gpgpu_context *gpgpu_ctx =
+        NULL)  // passes in a newly created textureReference
 {
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	std::string devStr (deviceName);
-	#if (CUDART_VERSION > 4020)
-	if (devStr.size() > 2 && devStr.data()[0] == ':' && devStr.data()[1] == ':')
-		devStr = devStr.replace(0, 2, "");
-	#endif
-	CUctx_st *context = GPGPUSim_Context(ctx);
-	gpgpu_t *gpu = context->get_device()->get_gpgpu();
-	printf("GPGPU-Sim PTX: in __cudaRegisterTexture:\n");
-	gpu->gpgpu_ptx_sim_bindNameToTexture(devStr.data(), hostVar, dim, norm, ext);
-	printf("GPGPU-Sim PTX:   int dim = %d\n", dim);
-	printf("GPGPU-Sim PTX:   int norm = %d\n", norm);
-	printf("GPGPU-Sim PTX:   int ext = %d\n", ext);
-	printf("GPGPU-Sim PTX:   Execution warning: Not finished implementing \"%s\"\n", __my_func__ );
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  std::string devStr(deviceName);
+#if (CUDART_VERSION > 4020)
+  if (devStr.size() > 2 && devStr.data()[0] == ':' && devStr.data()[1] == ':')
+    devStr = devStr.replace(0, 2, "");
+#endif
+  CUctx_st *context = GPGPUSim_Context(ctx);
+  gpgpu_t *gpu = context->get_device()->get_gpgpu();
+  printf("GPGPU-Sim PTX: in __cudaRegisterTexture:\n");
+  gpu->gpgpu_ptx_sim_bindNameToTexture(devStr.data(), hostVar, dim, norm, ext);
+  printf("GPGPU-Sim PTX:   int dim = %d\n", dim);
+  printf("GPGPU-Sim PTX:   int norm = %d\n", norm);
+  printf("GPGPU-Sim PTX:   int ext = %d\n", ext);
+  printf(
+      "GPGPU-Sim PTX:   Execution warning: Not finished implementing \"%s\"\n",
+      __my_func__);
 }
 
-cudaError_t cudaGLUnmapBufferObjectInternal(GLuint bufferObj, gpgpu_context* gpgpu_ctx = NULL)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
+cudaError_t cudaGLUnmapBufferObjectInternal(GLuint bufferObj,
+                                            gpgpu_context *gpgpu_ctx = NULL) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
 #ifdef OPENGL_SUPPORT
-	gpgpu_context *ctx;
-	if (gpgpu_ctx){
-	    ctx = gpgpu_ctx;
-	} else {
-	    ctx = GPGPU_Context();
-	}
-	CUctx_st* ctx = GPGPUSim_Context(ctx);
-	glbmap_entry_t *p = ctx->api->g_glbmap;
-	while ( p && p->m_bufferObj != bufferObj )
-		p = p->m_next;
-	if ( p == NULL )
-		return g_last_cudaError = cudaErrorUnknown;
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  CUctx_st *ctx = GPGPUSim_Context(ctx);
+  glbmap_entry_t *p = ctx->api->g_glbmap;
+  while (p && p->m_bufferObj != bufferObj) p = p->m_next;
+  if (p == NULL) return g_last_cudaError = cudaErrorUnknown;
 
-	char *data = (char *) calloc(p->m_size,1);
-	memcpy_from_gpu( data,(size_t)p->m_devPtr,p->m_size );
-	glBufferSubData(GL_ARRAY_BUFFER,0,p->m_size,data);
-	free(data);
+  char *data = (char *)calloc(p->m_size, 1);
+  memcpy_from_gpu(data, (size_t)p->m_devPtr, p->m_size);
+  glBufferSubData(GL_ARRAY_BUFFER, 0, p->m_size, data);
+  free(data);
 
-	return g_last_cudaError = cudaSuccess;
+  return g_last_cudaError = cudaSuccess;
 #else
-	fflush(stdout);
-	fflush(stderr);
-	printf("GPGPU-Sim PTX: support for OpenGL integration disabled -- exiting\n");
-	fflush(stdout);
-	exit(50);
+  fflush(stdout);
+  fflush(stderr);
+  printf("GPGPU-Sim PTX: support for OpenGL integration disabled -- exiting\n");
+  fflush(stdout);
+  exit(50);
 #endif
 }
 
 #if CUDART_VERSION >= 3000
 
-__host__ cudaError_t CUDARTAPI cudaFuncSetCacheConfigInternal(const char *func, enum cudaFuncCache  cacheConfig, gpgpu_context* gpgpu_ctx = NULL )
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	CUctx_st *context = GPGPUSim_Context(ctx);
-	context->get_device()->get_gpgpu()->set_cache_config(context->get_kernel(func)->get_name(), (FuncCache)cacheConfig);
-	return g_last_cudaError = cudaSuccess;
+__host__ cudaError_t CUDARTAPI
+cudaFuncSetCacheConfigInternal(const char *func, enum cudaFuncCache cacheConfig,
+                               gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  CUctx_st *context = GPGPUSim_Context(ctx);
+  context->get_device()->get_gpgpu()->set_cache_config(
+      context->get_kernel(func)->get_name(), (FuncCache)cacheConfig);
+  return g_last_cudaError = cudaSuccess;
 }
 
 #endif
 
 #if CUDART_VERSION >= 4000
-CUresult CUDAAPI cuLaunchKernelInternal(CUfunction f,
-                                unsigned int gridDimX,
-                                unsigned int gridDimY,
-                                unsigned int gridDimZ,
-                                unsigned int blockDimX,
-                                unsigned int blockDimY,
-                                unsigned int blockDimZ,
-                                unsigned int sharedMemBytes,
-                                CUstream hStream,
-                                void **kernelParams,
-                                void **extra,
-				gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-    if (extra!=NULL){
-	    printf("GPGPU-Sim CUDA DRIVER API: ERROR: Currently do not support void** extra.\n");
-        abort();
-    }
-    const char *hostFun = (const char*) f;
-	CUctx_st *context = GPGPUSim_Context(ctx);
-	function_info *entry = context->get_kernel(hostFun);
-    cudaConfigureCallInternal(dim3(gridDimX, gridDimY, gridDimZ), dim3(blockDimX, blockDimY, blockDimZ), sharedMemBytes, (cudaStream_t) hStream, ctx);
-    for(unsigned i = 0; i < entry->num_args(); i++){
-        std::pair<size_t, unsigned> p = entry->get_param_config(i);
-        cudaSetupArgumentInternal(kernelParams[i], p.first, p.second, ctx);
-    }
-    cudaLaunchInternal(hostFun, ctx);
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuLaunchKernelInternal(
+    CUfunction f, unsigned int gridDimX, unsigned int gridDimY,
+    unsigned int gridDimZ, unsigned int blockDimX, unsigned int blockDimY,
+    unsigned int blockDimZ, unsigned int sharedMemBytes, CUstream hStream,
+    void **kernelParams, void **extra, gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  if (extra != NULL) {
+    printf(
+        "GPGPU-Sim CUDA DRIVER API: ERROR: Currently do not support void** "
+        "extra.\n");
+    abort();
+  }
+  const char *hostFun = (const char *)f;
+  CUctx_st *context = GPGPUSim_Context(ctx);
+  function_info *entry = context->get_kernel(hostFun);
+  cudaConfigureCallInternal(dim3(gridDimX, gridDimY, gridDimZ),
+                            dim3(blockDimX, blockDimY, blockDimZ),
+                            sharedMemBytes, (cudaStream_t)hStream, ctx);
+  for (unsigned i = 0; i < entry->num_args(); i++) {
+    std::pair<size_t, unsigned> p = entry->get_param_config(i);
+    cudaSetupArgumentInternal(kernelParams[i], p.first, p.second, ctx);
+  }
+  cudaLaunchInternal(hostFun, ctx);
+  return CUDA_SUCCESS;
 }
 #endif /* CUDART_VERSION >= 4000 */
 
-CUevent_st *get_event(cudaEvent_t event)
-{
-	unsigned event_uid;
+CUevent_st *get_event(cudaEvent_t event) {
+  unsigned event_uid;
 #if CUDART_VERSION >= 3000
-	event_uid = event->get_uid();
+  event_uid = event->get_uid();
 #else
-	event_uid = event;
+  event_uid = event;
 #endif
-	event_tracker_t::iterator e = g_timer_events.find(event_uid);
-	if( e == g_timer_events.end() )
-		return NULL;
-	return e->second;
+  event_tracker_t::iterator e = g_timer_events.find(event_uid);
+  if (e == g_timer_events.end()) return NULL;
+  return e->second;
 }
 
-__host__ cudaError_t CUDARTAPI cudaEventRecordInternal(cudaEvent_t event, cudaStream_t stream, gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	CUevent_st *e = get_event(event);
-	if( !e ) return g_last_cudaError = cudaErrorUnknown;
-	struct CUstream_st *s = (struct CUstream_st *)stream;
-	stream_operation op(e,s);
-	ctx->the_gpgpusim->g_stream_manager->push(op);
-	return g_last_cudaError = cudaSuccess;
+__host__ cudaError_t CUDARTAPI cudaEventRecordInternal(
+    cudaEvent_t event, cudaStream_t stream, gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  CUevent_st *e = get_event(event);
+  if (!e) return g_last_cudaError = cudaErrorUnknown;
+  struct CUstream_st *s = (struct CUstream_st *)stream;
+  stream_operation op(e, s);
+  ctx->the_gpgpusim->g_stream_manager->push(op);
+  return g_last_cudaError = cudaSuccess;
 }
 
-__host__ cudaError_t CUDARTAPI cudaStreamWaitEventInternal(cudaStream_t stream, cudaEvent_t event, unsigned int flags, gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-   //reference: https://www.cs.cmu.edu/afs/cs/academic/class/15668-s11/www/cuda-doc/html/group__CUDART__STREAM_gfe68d207dc965685d92d3f03d77b0876.html 
-	CUevent_st *e = get_event(event);
-	if( !e ){
-	   printf("GPGPU-Sim API: Warning: cudaEventRecord has not been called on event before calling cudaStreamWaitEvent.\nNothing to be done.\n");
-      return g_last_cudaError = cudaSuccess;
-   }
-   if (!stream){
-     ctx->the_gpgpusim->g_stream_manager->pushCudaStreamWaitEventToAllStreams(e, flags);
-   } else {
-	   struct CUstream_st *s = (struct CUstream_st *)stream;
-	   stream_operation op(s,e,flags);
-	   ctx->the_gpgpusim->g_stream_manager->push(op);
-   }
-	return g_last_cudaError = cudaSuccess;
+__host__ cudaError_t CUDARTAPI cudaStreamWaitEventInternal(
+    cudaStream_t stream, cudaEvent_t event, unsigned int flags,
+    gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  // reference:
+  // https://www.cs.cmu.edu/afs/cs/academic/class/15668-s11/www/cuda-doc/html/group__CUDART__STREAM_gfe68d207dc965685d92d3f03d77b0876.html
+  CUevent_st *e = get_event(event);
+  if (!e) {
+    printf(
+        "GPGPU-Sim API: Warning: cudaEventRecord has not been called on event "
+        "before calling cudaStreamWaitEvent.\nNothing to be done.\n");
+    return g_last_cudaError = cudaSuccess;
+  }
+  if (!stream) {
+    ctx->the_gpgpusim->g_stream_manager->pushCudaStreamWaitEventToAllStreams(
+        e, flags);
+  } else {
+    struct CUstream_st *s = (struct CUstream_st *)stream;
+    stream_operation op(s, e, flags);
+    ctx->the_gpgpusim->g_stream_manager->push(op);
+  }
+  return g_last_cudaError = cudaSuccess;
 }
 
-__host__ cudaError_t CUDARTAPI cudaThreadExitInternal(gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	ctx->exit_simulation();
-	return g_last_cudaError = cudaSuccess;
+__host__ cudaError_t CUDARTAPI
+cudaThreadExitInternal(gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  ctx->exit_simulation();
+  return g_last_cudaError = cudaSuccess;
 }
 
-__host__ cudaError_t CUDARTAPI cudaThreadSynchronizeInternal(gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	//Called on host side
-	ctx->synchronize();
-	return g_last_cudaError = cudaSuccess;
+__host__ cudaError_t CUDARTAPI
+cudaThreadSynchronizeInternal(gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  // Called on host side
+  ctx->synchronize();
+  return g_last_cudaError = cudaSuccess;
 }
 
-cudaError_t CUDARTAPI cudaDeviceSynchronizeInternal(gpgpu_context* gpgpu_ctx = NULL)
-{
-    gpgpu_context *ctx;
-    if (gpgpu_ctx){
-	ctx = gpgpu_ctx;
-    } else {
-	ctx = GPGPU_Context();
-    }
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	//Blocks until the device has completed all preceding requested tasks
-	ctx->synchronize();
-	return g_last_cudaError = cudaSuccess;
+cudaError_t CUDARTAPI
+cudaDeviceSynchronizeInternal(gpgpu_context *gpgpu_ctx = NULL) {
+  gpgpu_context *ctx;
+  if (gpgpu_ctx) {
+    ctx = gpgpu_ctx;
+  } else {
+    ctx = GPGPU_Context();
+  }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  // Blocks until the device has completed all preceding requested tasks
+  ctx->synchronize();
+  return g_last_cudaError = cudaSuccess;
 }
 
 /*******************************************************************************
@@ -2145,56 +2296,149 @@ extern "C" {
  *                                                                              *
  *                                                                              *
  *******************************************************************************/
-cudaError_t cudaPeekAtLastError(void)
-{
-	return g_last_cudaError;
+cudaError_t cudaPeekAtLastError(void) { return g_last_cudaError; }
+
+__host__ cudaError_t CUDARTAPI cudaMalloc(void **devPtr, size_t size) {
+  return cudaMallocInternal(devPtr, size);
 }
 
-__host__ cudaError_t CUDARTAPI cudaMalloc(void **devPtr, size_t size) 
-{
-    return cudaMallocInternal(devPtr, size);
+__host__ cudaError_t CUDARTAPI cudaMallocHost(void **ptr, size_t size) {
+  return cudaMallocHostInternal(ptr, size);
+}
+__host__ cudaError_t CUDARTAPI cudaMallocPitch(void **devPtr, size_t *pitch,
+                                               size_t width, size_t height) {
+  return cudaMallocPitchInternal(devPtr, pitch, width, height);
 }
 
-__host__ cudaError_t CUDARTAPI cudaMallocHost(void **ptr, size_t size)
-{
-    return cudaMallocHostInternal(ptr, size);
-}
-__host__ cudaError_t CUDARTAPI cudaMallocPitch(void **devPtr, size_t *pitch, size_t width, size_t height)
-{
-    return cudaMallocPitchInternal(devPtr, pitch, width, height);
+__host__ cudaError_t CUDARTAPI cudaMallocArray(
+    struct cudaArray **array, const struct cudaChannelFormatDesc *desc,
+    size_t width, size_t height __dv(1)) {
+  return cudaMallocArrayInternal(array, desc, width, height);
 }
 
-__host__ cudaError_t CUDARTAPI cudaMallocArray(struct cudaArray **array, const struct cudaChannelFormatDesc *desc, size_t width, size_t height __dv(1))
-{
-    return cudaMallocArrayInternal(array, desc, width, height);
+__host__ cudaError_t CUDARTAPI cudaFree(void *devPtr) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  // TODO...  manage g_global_mem space?
+  return g_last_cudaError = cudaSuccess;
+}
+__host__ cudaError_t CUDARTAPI cudaFreeHost(void *ptr) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  free(ptr);  // this will crash the system if called twice
+  return g_last_cudaError = cudaSuccess;
 }
 
-__host__ cudaError_t CUDARTAPI cudaFree(void *devPtr)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	// TODO...  manage g_global_mem space?
-	return g_last_cudaError = cudaSuccess;
-}
-__host__ cudaError_t CUDARTAPI cudaFreeHost(void *ptr)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	free (ptr);  // this will crash the system if called twice
-	return g_last_cudaError = cudaSuccess;
-}
-
-__host__ cudaError_t CUDARTAPI cudaFreeArray(struct cudaArray *array)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	// TODO...  manage g_global_mem space?
-	return g_last_cudaError = cudaSuccess;
+__host__ cudaError_t CUDARTAPI cudaFreeArray(struct cudaArray *array) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  // TODO...  manage g_global_mem space?
+  return g_last_cudaError = cudaSuccess;
 };
 
+/*******************************************************************************
+ *                                                                              *
+ *                                                                              *
+ *                                                                              *
+ *******************************************************************************/
+
+__host__ cudaError_t CUDARTAPI cudaMemcpy(void *dst, const void *src,
+                                          size_t count,
+                                          enum cudaMemcpyKind kind) {
+  return cudaMemcpyInternal(dst, src, count, kind);
+}
+
+__host__ cudaError_t CUDARTAPI cudaMemcpyToArray(struct cudaArray *dst,
+                                                 size_t wOffset, size_t hOffset,
+                                                 const void *src, size_t count,
+                                                 enum cudaMemcpyKind kind) {
+  return cudaMemcpyToArrayInternal(dst, wOffset, hOffset, src, count, kind);
+}
+
+__host__ cudaError_t CUDARTAPI cudaMemcpyFromArray(void *dst,
+                                                   const struct cudaArray *src,
+                                                   size_t wOffset,
+                                                   size_t hOffset, size_t count,
+                                                   enum cudaMemcpyKind kind) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
+  return g_last_cudaError = cudaErrorUnknown;
+}
+
+__host__ cudaError_t CUDARTAPI cudaMemcpyArrayToArray(
+    struct cudaArray *dst, size_t wOffsetDst, size_t hOffsetDst,
+    const struct cudaArray *src, size_t wOffsetSrc, size_t hOffsetSrc,
+    size_t count, enum cudaMemcpyKind kind __dv(cudaMemcpyDeviceToDevice)) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
+  return g_last_cudaError = cudaErrorUnknown;
+}
+
+__host__ cudaError_t CUDARTAPI cudaMemcpy2D(void *dst, size_t dpitch,
+                                            const void *src, size_t spitch,
+                                            size_t width, size_t height,
+                                            enum cudaMemcpyKind kind) {
+  return cudaMemcpy2DInternal(dst, dpitch, src, spitch, width, height, kind);
+}
+
+__host__ cudaError_t CUDARTAPI cudaMemcpy2DToArray(
+    struct cudaArray *dst, size_t wOffset, size_t hOffset, const void *src,
+    size_t spitch, size_t width, size_t height, enum cudaMemcpyKind kind) {
+  return cudaMemcpy2DToArrayInternal(dst, wOffset, hOffset, src, spitch, width,
+                                     height, kind);
+}
+
+__host__ cudaError_t CUDARTAPI cudaMemcpy2DFromArray(
+    void *dst, size_t dpitch, const struct cudaArray *src, size_t wOffset,
+    size_t hOffset, size_t width, size_t height, enum cudaMemcpyKind kind) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
+  return g_last_cudaError = cudaErrorUnknown;
+}
+
+__host__ cudaError_t CUDARTAPI cudaMemcpy2DArrayToArray(
+    struct cudaArray *dst, size_t wOffsetDst, size_t hOffsetDst,
+    const struct cudaArray *src, size_t wOffsetSrc, size_t hOffsetSrc,
+    size_t width, size_t height,
+    enum cudaMemcpyKind kind __dv(cudaMemcpyDeviceToDevice)) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
+  return g_last_cudaError = cudaErrorUnknown;
+}
+
+__host__ cudaError_t CUDARTAPI cudaMemcpyToSymbol(
+    const char *symbol, const void *src, size_t count, size_t offset __dv(0),
+    enum cudaMemcpyKind kind __dv(cudaMemcpyHostToDevice)) {
+  return cudaMemcpyToSymbolInternal(symbol, src, count, offset, kind);
+}
+
+__host__ cudaError_t CUDARTAPI cudaMemcpyFromSymbol(
+    void *dst, const char *symbol, size_t count, size_t offset __dv(0),
+    enum cudaMemcpyKind kind __dv(cudaMemcpyDeviceToHost)) {
+  return cudaMemcpyFromSymbolInternal(dst, symbol, count, offset, kind);
+}
+
+__host__ cudaError_t CUDARTAPI cudaMemGetInfo(size_t *free, size_t *total) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  // placeholder; should interact with cudaMalloc and cudaFree?
+  *free = 10000000000;
+  *total = 10000000000;
+
+  return g_last_cudaError = cudaSuccess;
+}
 
 /*******************************************************************************
  *                                                                              *
@@ -2202,308 +2446,210 @@ __host__ cudaError_t CUDARTAPI cudaFreeArray(struct cudaArray *array)
  *                                                                              *
  *******************************************************************************/
 
-__host__ cudaError_t CUDARTAPI cudaMemcpy(void *dst, const void *src, size_t count, enum cudaMemcpyKind kind)
-{
-    return cudaMemcpyInternal(dst, src, count, kind);
+__host__ cudaError_t CUDARTAPI cudaMemcpyAsync(void *dst, const void *src,
+                                               size_t count,
+                                               enum cudaMemcpyKind kind,
+                                               cudaStream_t stream) {
+  return cudaMemcpyAsyncInternal(dst, src, count, kind, stream);
 }
 
-__host__ cudaError_t CUDARTAPI cudaMemcpyToArray(struct cudaArray *dst, size_t wOffset, size_t hOffset, const void *src, size_t count, enum cudaMemcpyKind kind)
-{ 
-    return cudaMemcpyToArrayInternal(dst, wOffset, hOffset, src, count, kind);
+__host__ cudaError_t CUDARTAPI cudaMemcpyToArrayAsync(
+    struct cudaArray *dst, size_t wOffset, size_t hOffset, const void *src,
+    size_t count, enum cudaMemcpyKind kind, cudaStream_t stream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
+  return g_last_cudaError = cudaErrorUnknown;
 }
 
-
-__host__ cudaError_t CUDARTAPI cudaMemcpyFromArray(void *dst, const struct cudaArray *src, size_t wOffset, size_t hOffset, size_t count, enum cudaMemcpyKind kind)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	cuda_not_implemented(__my_func__,__LINE__);
-	return g_last_cudaError = cudaErrorUnknown;
+__host__ cudaError_t CUDARTAPI cudaMemcpyFromArrayAsync(
+    void *dst, const struct cudaArray *src, size_t wOffset, size_t hOffset,
+    size_t count, enum cudaMemcpyKind kind, cudaStream_t stream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
+  return g_last_cudaError = cudaErrorUnknown;
 }
 
-
-__host__ cudaError_t CUDARTAPI cudaMemcpyArrayToArray(struct cudaArray *dst, size_t wOffsetDst, size_t hOffsetDst, const struct cudaArray *src, size_t wOffsetSrc, size_t hOffsetSrc, size_t count, enum cudaMemcpyKind kind __dv(cudaMemcpyDeviceToDevice))
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	cuda_not_implemented(__my_func__,__LINE__);
-	return g_last_cudaError = cudaErrorUnknown;
+__host__ cudaError_t CUDARTAPI cudaMemcpy2DAsync(void *dst, size_t dpitch,
+                                                 const void *src, size_t spitch,
+                                                 size_t width, size_t height,
+                                                 enum cudaMemcpyKind kind,
+                                                 cudaStream_t stream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
+  return g_last_cudaError = cudaErrorUnknown;
 }
 
-
-__host__ cudaError_t CUDARTAPI cudaMemcpy2D(void *dst, size_t dpitch, const void *src, size_t spitch, size_t width, size_t height, enum cudaMemcpyKind kind)
-{
-    return cudaMemcpy2DInternal(dst, dpitch, src, spitch, width, height, kind);
+__host__ cudaError_t CUDARTAPI cudaMemcpy2DToArrayAsync(
+    struct cudaArray *dst, size_t wOffset, size_t hOffset, const void *src,
+    size_t spitch, size_t width, size_t height, enum cudaMemcpyKind kind,
+    cudaStream_t stream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
+  return g_last_cudaError = cudaErrorUnknown;
 }
 
-__host__ cudaError_t CUDARTAPI cudaMemcpy2DToArray(struct cudaArray *dst, size_t wOffset, size_t hOffset, const void *src, size_t spitch, size_t width, size_t height, enum cudaMemcpyKind kind)
-{
-    return cudaMemcpy2DToArrayInternal(dst, wOffset, hOffset, src, spitch, width, height, kind);
-}
-
-__host__ cudaError_t CUDARTAPI cudaMemcpy2DFromArray(void *dst, size_t dpitch, const struct cudaArray *src, size_t wOffset, size_t hOffset, size_t width, size_t height, enum cudaMemcpyKind kind)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	cuda_not_implemented(__my_func__,__LINE__);
-	return g_last_cudaError = cudaErrorUnknown;
-}
-
-__host__ cudaError_t CUDARTAPI cudaMemcpy2DArrayToArray(struct cudaArray *dst, size_t wOffsetDst, size_t hOffsetDst, const struct cudaArray *src, size_t wOffsetSrc, size_t hOffsetSrc, size_t width, size_t height, enum cudaMemcpyKind kind __dv(cudaMemcpyDeviceToDevice))
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	cuda_not_implemented(__my_func__,__LINE__);
-	return g_last_cudaError = cudaErrorUnknown;
-}
-
-__host__ cudaError_t CUDARTAPI cudaMemcpyToSymbol(const char *symbol, const void *src, size_t count, size_t offset __dv(0), enum cudaMemcpyKind kind __dv(cudaMemcpyHostToDevice))
-{
-    return cudaMemcpyToSymbolInternal(symbol, src, count, offset, kind);
-}
-
-
-__host__ cudaError_t CUDARTAPI cudaMemcpyFromSymbol(void *dst, const char *symbol, size_t count, size_t offset __dv(0), enum cudaMemcpyKind kind __dv(cudaMemcpyDeviceToHost))
-{
-    return cudaMemcpyFromSymbolInternal(dst, symbol, count, offset, kind);
-}
-
-__host__ cudaError_t CUDARTAPI cudaMemGetInfo (size_t *free, size_t *total){
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	//placeholder; should interact with cudaMalloc and cudaFree?
-	*free = 10000000000;
-	*total = 10000000000;
-
-	return g_last_cudaError = cudaSuccess;
-}
-
-/*******************************************************************************
- *                                                                              *
- *                                                                              *
- *                                                                              *
- *******************************************************************************/
-
-__host__ cudaError_t CUDARTAPI cudaMemcpyAsync(void *dst, const void *src, size_t count, enum cudaMemcpyKind kind, cudaStream_t stream)
-{
-    return cudaMemcpyAsyncInternal(dst, src, count, kind, stream);
-}
-
-
-__host__ cudaError_t CUDARTAPI cudaMemcpyToArrayAsync(struct cudaArray *dst, size_t wOffset, size_t hOffset, const void *src, size_t count, enum cudaMemcpyKind kind, cudaStream_t stream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	cuda_not_implemented(__my_func__,__LINE__);
-	return g_last_cudaError = cudaErrorUnknown;
-}
-
-
-__host__ cudaError_t CUDARTAPI cudaMemcpyFromArrayAsync(void *dst, const struct cudaArray *src, size_t wOffset, size_t hOffset, size_t count, enum cudaMemcpyKind kind, cudaStream_t stream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	cuda_not_implemented(__my_func__,__LINE__);
-	return g_last_cudaError = cudaErrorUnknown;
-}
-
-
-__host__ cudaError_t CUDARTAPI cudaMemcpy2DAsync(void *dst, size_t dpitch, const void *src, size_t spitch, size_t width, size_t height, enum cudaMemcpyKind kind, cudaStream_t stream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	cuda_not_implemented(__my_func__,__LINE__);
-	return g_last_cudaError = cudaErrorUnknown;
-}
-
-
-__host__ cudaError_t CUDARTAPI cudaMemcpy2DToArrayAsync(struct cudaArray *dst, size_t wOffset, size_t hOffset, const void *src, size_t spitch, size_t width, size_t height, enum cudaMemcpyKind kind, cudaStream_t stream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	cuda_not_implemented(__my_func__,__LINE__);
-	return g_last_cudaError = cudaErrorUnknown;
-}
-
-
-__host__ cudaError_t CUDARTAPI cudaMemcpy2DFromArrayAsync(void *dst, size_t dpitch, const struct cudaArray *src, size_t wOffset, size_t hOffset, size_t width, size_t height, enum cudaMemcpyKind kind, cudaStream_t stream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	cuda_not_implemented(__my_func__,__LINE__);
-	return g_last_cudaError = cudaErrorUnknown;
+__host__ cudaError_t CUDARTAPI cudaMemcpy2DFromArrayAsync(
+    void *dst, size_t dpitch, const struct cudaArray *src, size_t wOffset,
+    size_t hOffset, size_t width, size_t height, enum cudaMemcpyKind kind,
+    cudaStream_t stream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
+  return g_last_cudaError = cudaErrorUnknown;
 }
 
 #if (CUDART_VERSION >= 8000)
-cudaError_t CUDARTAPI cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(int* numBlocks, const char *hostFunc, int blockSize, size_t dynamicSMemSize, unsigned int flags)
-{
-    return cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlagsInternal(numBlocks, hostFunc, blockSize, dynamicSMemSize, flags);
+cudaError_t CUDARTAPI cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(
+    int *numBlocks, const char *hostFunc, int blockSize, size_t dynamicSMemSize,
+    unsigned int flags) {
+  return cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlagsInternal(
+      numBlocks, hostFunc, blockSize, dynamicSMemSize, flags);
 }
 
 #endif
 
+/*******************************************************************************
+ *                                                                              *
+ *                                                                              *
+ *                                                                              *
+ *******************************************************************************/
+__host__ cudaError_t CUDARTAPI cudaMemset(void *mem, int c, size_t count) {
+  return cudaMemsetInternal(mem, c, count);
+}
 
+// memset operation is done but i think its not async?
+__host__ cudaError_t CUDARTAPI cudaMemsetAsync(void *mem, int c, size_t count,
+                                               cudaStream_t stream = 0) {
+  return cudaMemsetAsyncInternal(mem, c, count, stream = 0);
+}
+
+__host__ cudaError_t CUDARTAPI cudaMemset2D(void *mem, size_t pitch, int c,
+                                            size_t width, size_t height) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
+  return g_last_cudaError = cudaErrorUnknown;
+}
 
 /*******************************************************************************
  *                                                                              *
  *                                                                              *
  *                                                                              *
  *******************************************************************************/
-__host__ cudaError_t CUDARTAPI cudaMemset(void *mem, int c, size_t count)
-{
-    return cudaMemsetInternal(mem, c, count);
+
+__host__ cudaError_t CUDARTAPI cudaGetSymbolAddress(void **devPtr,
+                                                    const char *symbol) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
+  return g_last_cudaError = cudaErrorUnknown;
 }
 
-//memset operation is done but i think its not async?
-__host__ cudaError_t CUDARTAPI cudaMemsetAsync(void *mem, int c, size_t count, 	cudaStream_t stream=0)
-{
-    return cudaMemsetAsyncInternal(mem, c, count, stream=0);
+__host__ cudaError_t CUDARTAPI cudaGetSymbolSize(size_t *size,
+                                                 const char *symbol) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
+  return g_last_cudaError = cudaErrorUnknown;
 }
-
-__host__ cudaError_t CUDARTAPI cudaMemset2D(void *mem, size_t pitch, int c, size_t width, size_t height)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	cuda_not_implemented(__my_func__,__LINE__);
-	return g_last_cudaError = cudaErrorUnknown;
-}
-
-
 
 /*******************************************************************************
  *                                                                              *
  *                                                                              *
  *                                                                              *
  *******************************************************************************/
-
-__host__ cudaError_t CUDARTAPI cudaGetSymbolAddress(void **devPtr, const char *symbol)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	cuda_not_implemented(__my_func__,__LINE__);
-	return g_last_cudaError = cudaErrorUnknown;
+__host__ cudaError_t CUDARTAPI cudaGetDeviceCount(int *count) {
+  return cudaGetDeviceCountInternal(count);
 }
 
-
-__host__ cudaError_t CUDARTAPI cudaGetSymbolSize(size_t *size, const char *symbol)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	cuda_not_implemented(__my_func__,__LINE__);
-	return g_last_cudaError = cudaErrorUnknown;
-}
-
-
-
-/*******************************************************************************
- *                                                                              *
- *                                                                              *
- *                                                                              *
- *******************************************************************************/
-__host__ cudaError_t CUDARTAPI cudaGetDeviceCount(int *count)
-{
-    return cudaGetDeviceCountInternal(count);
-}
-
-__host__ cudaError_t CUDARTAPI cudaGetDeviceProperties(struct cudaDeviceProp *prop, int device)
-{
-    return cudaGetDevicePropertiesInternal(prop, device);
+__host__ cudaError_t CUDARTAPI
+cudaGetDeviceProperties(struct cudaDeviceProp *prop, int device) {
+  return cudaGetDevicePropertiesInternal(prop, device);
 }
 
 #if (CUDART_VERSION > 5000)
-__host__ cudaError_t CUDARTAPI cudaDeviceGetAttribute(int *value, enum cudaDeviceAttr attr, int device)
-{
-    return cudaDeviceGetAttributeInternal(value, attr, device);
+__host__ cudaError_t CUDARTAPI cudaDeviceGetAttribute(int *value,
+                                                      enum cudaDeviceAttr attr,
+                                                      int device) {
+  return cudaDeviceGetAttributeInternal(value, attr, device);
 }
 #endif
 
-__host__ cudaError_t CUDARTAPI cudaChooseDevice(int *device, const struct cudaDeviceProp *prop)
-{
-    return cudaChooseDeviceInternal(device, prop);
+__host__ cudaError_t CUDARTAPI
+cudaChooseDevice(int *device, const struct cudaDeviceProp *prop) {
+  return cudaChooseDeviceInternal(device, prop);
 }
 
-__host__ cudaError_t CUDARTAPI cudaSetDevice(int device)
-{
-    return cudaSetDeviceInternal(device);
+__host__ cudaError_t CUDARTAPI cudaSetDevice(int device) {
+  return cudaSetDeviceInternal(device);
 }
 
-__host__ cudaError_t CUDARTAPI cudaGetDevice(int *device)
-{
-    return cudaGetDeviceInternal(device);
+__host__ cudaError_t CUDARTAPI cudaGetDevice(int *device) {
+  return cudaGetDeviceInternal(device);
 }
 
-__host__ cudaError_t CUDARTAPI cudaDeviceGetLimit( size_t* pValue, cudaLimit limit )
-{
-    return cudaDeviceGetLimitInternal( pValue, limit );
+__host__ cudaError_t CUDARTAPI cudaDeviceGetLimit(size_t *pValue,
+                                                  cudaLimit limit) {
+  return cudaDeviceGetLimitInternal(pValue, limit);
 }
 
-__host__ cudaError_t CUDARTAPI cudaStreamGetPriority ( cudaStream_t hStream, int* priority )
-{
-        if(g_debug_execution >= 3){
-            announce_call(__my_func__);
-   	 }
-        cuda_not_implemented(__my_func__,__LINE__);
-        return g_last_cudaError = cudaSuccess;
-
+__host__ cudaError_t CUDARTAPI cudaStreamGetPriority(cudaStream_t hStream,
+                                                     int *priority) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
+  return g_last_cudaError = cudaSuccess;
 }
 
-__host__ cudaError_t CUDARTAPI cudaDeviceGetPCIBusId (
-		char *pciBusId,
-		int len,
-		int device
-) 
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	cuda_not_implemented(__my_func__,__LINE__);
-	return g_last_cudaError = cudaErrorUnknown;
+__host__ cudaError_t CUDARTAPI cudaDeviceGetPCIBusId(char *pciBusId, int len,
+                                                     int device) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
+  return g_last_cudaError = cudaErrorUnknown;
 }
 
-__host__ cudaError_t CUDARTAPI cudaIpcGetMemHandle( cudaIpcMemHandle_t* handle, void* devPtr )
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	cuda_not_implemented(__my_func__,__LINE__);
-	return g_last_cudaError = cudaErrorUnknown;
+__host__ cudaError_t CUDARTAPI cudaIpcGetMemHandle(cudaIpcMemHandle_t *handle,
+                                                   void *devPtr) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
+  return g_last_cudaError = cudaErrorUnknown;
 }
 
-__host__ cudaError_t cudaIpcOpenMemHandle(
-		void **devPtr,
-		cudaIpcMemHandle_t handle,
-		unsigned int flags
-)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	cuda_not_implemented(__my_func__,__LINE__);
-	return g_last_cudaError = cudaErrorUnknown;
+__host__ cudaError_t cudaIpcOpenMemHandle(void **devPtr,
+                                          cudaIpcMemHandle_t handle,
+                                          unsigned int flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
+  return g_last_cudaError = cudaErrorUnknown;
 }
 
-__host__ cudaError_t CUDARTAPI cudaDestroyTextureObject(cudaTextureObject_t texObject)
-{
-        if(g_debug_execution >= 3){
-            announce_call(__my_func__);
-   	 }
-        cuda_not_implemented(__my_func__,__LINE__);
-        return g_last_cudaError = cudaErrorUnknown;
+__host__ cudaError_t CUDARTAPI
+cudaDestroyTextureObject(cudaTextureObject_t texObject) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
+  return g_last_cudaError = cudaErrorUnknown;
 }
-
 
 /*******************************************************************************
  *                                                                              *
@@ -2511,113 +2657,108 @@ __host__ cudaError_t CUDARTAPI cudaDestroyTextureObject(cudaTextureObject_t texO
  *                                                                              *
  *******************************************************************************/
 
-__host__ cudaError_t CUDARTAPI cudaBindTexture(size_t *offset,
-		const struct textureReference *texref,
-		const void *devPtr,
-		const struct cudaChannelFormatDesc *desc,
-		size_t size __dv(UINT_MAX))
-{
-    return cudaBindTextureInternal(offset, texref, devPtr, desc, size __dv(UINT_MAX));
+__host__ cudaError_t CUDARTAPI cudaBindTexture(
+    size_t *offset, const struct textureReference *texref, const void *devPtr,
+    const struct cudaChannelFormatDesc *desc, size_t size __dv(UINT_MAX)) {
+  return cudaBindTextureInternal(offset, texref, devPtr, desc,
+                                 size __dv(UINT_MAX));
 }
 
-
-__host__ cudaError_t CUDARTAPI cudaBindTextureToArray(const struct textureReference *texref, const struct cudaArray *array, const struct cudaChannelFormatDesc *desc)
-{
-    return cudaBindTextureToArrayInternal(texref, array, desc);
+__host__ cudaError_t CUDARTAPI cudaBindTextureToArray(
+    const struct textureReference *texref, const struct cudaArray *array,
+    const struct cudaChannelFormatDesc *desc) {
+  return cudaBindTextureToArrayInternal(texref, array, desc);
 }
 
-__host__ cudaError_t CUDARTAPI cudaUnbindTexture(const struct textureReference *texref)
-{
-    return cudaUnbindTextureInternal(texref);
+__host__ cudaError_t CUDARTAPI
+cudaUnbindTexture(const struct textureReference *texref) {
+  return cudaUnbindTextureInternal(texref);
 }
 
-__host__ cudaError_t CUDARTAPI cudaGetTextureAlignmentOffset(size_t *offset, const struct textureReference *texref)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	cuda_not_implemented(__my_func__,__LINE__);
-	return g_last_cudaError = cudaErrorUnknown;
+__host__ cudaError_t CUDARTAPI cudaGetTextureAlignmentOffset(
+    size_t *offset, const struct textureReference *texref) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
+  return g_last_cudaError = cudaErrorUnknown;
 }
 
-__host__ cudaError_t CUDARTAPI cudaGetTextureReference(const struct textureReference **texref, const char *symbol)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	cuda_not_implemented(__my_func__,__LINE__);
-	return g_last_cudaError = cudaErrorUnknown;
+__host__ cudaError_t CUDARTAPI cudaGetTextureReference(
+    const struct textureReference **texref, const char *symbol) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
+  return g_last_cudaError = cudaErrorUnknown;
 }
 
-__host__ cudaError_t CUDARTAPI cudaGetChannelDesc(struct cudaChannelFormatDesc *desc, const struct cudaArray *array)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	*desc = array->desc;
-	return g_last_cudaError = cudaSuccess;
+__host__ cudaError_t CUDARTAPI cudaGetChannelDesc(
+    struct cudaChannelFormatDesc *desc, const struct cudaArray *array) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  *desc = array->desc;
+  return g_last_cudaError = cudaSuccess;
 }
 
-
-__host__ struct cudaChannelFormatDesc CUDARTAPI cudaCreateChannelDesc(int x, int y, int z, int w, enum cudaChannelFormatKind f)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	struct cudaChannelFormatDesc dummy;
-	dummy.x = x;
-	dummy.y = y;
-	dummy.z = z;
-	dummy.w = w;
-	dummy.f = f;
-	return dummy;
+__host__ struct cudaChannelFormatDesc CUDARTAPI cudaCreateChannelDesc(
+    int x, int y, int z, int w, enum cudaChannelFormatKind f) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  struct cudaChannelFormatDesc dummy;
+  dummy.x = x;
+  dummy.y = y;
+  dummy.z = z;
+  dummy.w = w;
+  dummy.f = f;
+  return dummy;
 }
 
-__host__ cudaError_t CUDARTAPI cudaGetLastError(void)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	return g_last_cudaError;
+__host__ cudaError_t CUDARTAPI cudaGetLastError(void) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  return g_last_cudaError;
 }
 
-__host__ const char *cudaGetErrorName(cudaError_t error)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	cuda_not_implemented(__my_func__,__LINE__);
-	return NULL;
+__host__ const char *cudaGetErrorName(cudaError_t error) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
+  return NULL;
 }
 
-__host__ const char* CUDARTAPI cudaGetErrorString(cudaError_t error)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	if( g_last_cudaError == cudaSuccess )
-		return "no error";
-	char buf[1024];
-	snprintf(buf,1024,"<<GPGPU-Sim PTX: there was an error (code = %d)>>", g_last_cudaError);
-	return strdup(buf);
+__host__ const char *CUDARTAPI cudaGetErrorString(cudaError_t error) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  if (g_last_cudaError == cudaSuccess) return "no error";
+  char buf[1024];
+  snprintf(buf, 1024, "<<GPGPU-Sim PTX: there was an error (code = %d)>>",
+           g_last_cudaError);
+  return strdup(buf);
 }
 
-__host__ cudaError_t CUDARTAPI cudaSetupArgument(const void *arg, size_t size, size_t offset)
-{
-    return cudaSetupArgumentInternal(arg, size, offset);
+__host__ cudaError_t CUDARTAPI cudaSetupArgument(const void *arg, size_t size,
+                                                 size_t offset) {
+  return cudaSetupArgumentInternal(arg, size, offset);
 }
 
-
-__host__ cudaError_t CUDARTAPI cudaLaunch( const char *hostFun )
-{
-    return cudaLaunchInternal( hostFun );
+__host__ cudaError_t CUDARTAPI cudaLaunch(const char *hostFun) {
+  return cudaLaunchInternal(hostFun);
 }
 
-__host__ cudaError_t CUDARTAPI cudaLaunchKernel( const char* hostFun, dim3 gridDim, dim3 blockDim, const void** args, size_t sharedMem, cudaStream_t stream )
-{
-    return cudaLaunchKernelInternal(hostFun, gridDim, blockDim, args, sharedMem, stream);
+__host__ cudaError_t CUDARTAPI cudaLaunchKernel(const char *hostFun,
+                                                dim3 gridDim, dim3 blockDim,
+                                                const void **args,
+                                                size_t sharedMem,
+                                                cudaStream_t stream) {
+  return cudaLaunchKernelInternal(hostFun, gridDim, blockDim, args, sharedMem,
+                                  stream);
 }
-
 
 /*******************************************************************************
  *                                                                              *
@@ -2625,55 +2766,57 @@ __host__ cudaError_t CUDARTAPI cudaLaunchKernel( const char* hostFun, dim3 gridD
  *                                                                              *
  *******************************************************************************/
 
-__host__ cudaError_t CUDARTAPI cudaStreamCreate(cudaStream_t *stream)
-{
-    return cudaStreamCreateInternal(stream);
+__host__ cudaError_t CUDARTAPI cudaStreamCreate(cudaStream_t *stream) {
+  return cudaStreamCreateInternal(stream);
 }
 
-//TODO: introduce priorities
-__host__ cudaError_t CUDARTAPI cudaStreamCreateWithPriority(cudaStream_t *stream, unsigned int flags, int  priority) {
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-        return cudaStreamCreate(stream);
+// TODO: introduce priorities
+__host__ cudaError_t CUDARTAPI cudaStreamCreateWithPriority(
+    cudaStream_t *stream, unsigned int flags, int priority) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  return cudaStreamCreate(stream);
 }
 
-__host__ cudaError_t CUDARTAPI cudaDeviceGetStreamPriorityRange(int* leastPriority, int* greatestPriority) {
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-       	return cudaSuccess;	
+__host__ cudaError_t CUDARTAPI
+cudaDeviceGetStreamPriorityRange(int *leastPriority, int *greatestPriority) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  return cudaSuccess;
 }
 
-__host__ __device__ cudaError_t CUDARTAPI cudaStreamCreateWithFlags(cudaStream_t *stream, unsigned int flags) {
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	return cudaStreamCreate(stream);
+__host__ __device__ cudaError_t CUDARTAPI
+cudaStreamCreateWithFlags(cudaStream_t *stream, unsigned int flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  return cudaStreamCreate(stream);
 }
 
-__host__ cudaError_t CUDARTAPI cudaStreamDestroy(cudaStream_t stream)
-{
-    return cudaStreamDestroyInternal(stream);
+__host__ cudaError_t CUDARTAPI cudaStreamDestroy(cudaStream_t stream) {
+  return cudaStreamDestroyInternal(stream);
 }
 
-__host__ cudaError_t CUDARTAPI cudaStreamSynchronize(cudaStream_t stream)
-{
-    return cudaStreamSynchronizeInternal(stream);
+__host__ cudaError_t CUDARTAPI cudaStreamSynchronize(cudaStream_t stream) {
+  return cudaStreamSynchronizeInternal(stream);
 }
 
-__host__ cudaError_t CUDARTAPI cudaStreamQuery(cudaStream_t stream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
+__host__ cudaError_t CUDARTAPI cudaStreamQuery(cudaStream_t stream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
 #if (CUDART_VERSION >= 3000)
-	if( stream == NULL )
-		return g_last_cudaError = cudaErrorInvalidResourceHandle;
-	return g_last_cudaError = stream->empty()?cudaSuccess:cudaErrorNotReady;
+  if (stream == NULL) return g_last_cudaError = cudaErrorInvalidResourceHandle;
+  return g_last_cudaError = stream->empty() ? cudaSuccess : cudaErrorNotReady;
 #else
-	printf("GPGPU-Sim PTX: WARNING: Asynchronous kernel execution not supported (%s)\n", __my_func__);
-	return g_last_cudaError = cudaSuccess; // it is always success because all cuda calls are synchronous
+  printf(
+      "GPGPU-Sim PTX: WARNING: Asynchronous kernel execution not supported "
+      "(%s)\n",
+      __my_func__);
+  return g_last_cudaError = cudaSuccess;  // it is always success because all
+                                          // cuda calls are synchronous
 #endif
 }
 
@@ -2683,92 +2826,86 @@ __host__ cudaError_t CUDARTAPI cudaStreamQuery(cudaStream_t stream)
  *                                                                              *
  *******************************************************************************/
 
-__host__ cudaError_t CUDARTAPI cudaEventCreate(cudaEvent_t *event)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	CUevent_st *e = new CUevent_st(false);
-	g_timer_events[e->get_uid()] = e;
+__host__ cudaError_t CUDARTAPI cudaEventCreate(cudaEvent_t *event) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  CUevent_st *e = new CUevent_st(false);
+  g_timer_events[e->get_uid()] = e;
 #if CUDART_VERSION >= 3000
-	*event = e;
+  *event = e;
 #else
-	*event = e->get_uid();
+  *event = e->get_uid();
 #endif
-	return g_last_cudaError = cudaSuccess;
+  return g_last_cudaError = cudaSuccess;
 }
 
-__host__ cudaError_t CUDARTAPI cudaEventRecord(cudaEvent_t event, cudaStream_t stream)
-{
-    return cudaEventRecordInternal(event, stream);
+__host__ cudaError_t CUDARTAPI cudaEventRecord(cudaEvent_t event,
+                                               cudaStream_t stream) {
+  return cudaEventRecordInternal(event, stream);
 }
 
-__host__ cudaError_t CUDARTAPI cudaStreamWaitEvent(cudaStream_t stream, cudaEvent_t event, unsigned int flags)
-{
-    return cudaStreamWaitEventInternal(stream, event, flags);
+__host__ cudaError_t CUDARTAPI cudaStreamWaitEvent(cudaStream_t stream,
+                                                   cudaEvent_t event,
+                                                   unsigned int flags) {
+  return cudaStreamWaitEventInternal(stream, event, flags);
 }
 
-__host__ cudaError_t CUDARTAPI cudaEventQuery(cudaEvent_t event)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	CUevent_st *e = get_event(event);
-	if( e == NULL ) {
-		return g_last_cudaError = cudaErrorInvalidValue;
-	} else if( e->done() ) {
-		return g_last_cudaError = cudaSuccess;
-	} else {
-		return g_last_cudaError = cudaErrorNotReady;
-	}
+__host__ cudaError_t CUDARTAPI cudaEventQuery(cudaEvent_t event) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  CUevent_st *e = get_event(event);
+  if (e == NULL) {
+    return g_last_cudaError = cudaErrorInvalidValue;
+  } else if (e->done()) {
+    return g_last_cudaError = cudaSuccess;
+  } else {
+    return g_last_cudaError = cudaErrorNotReady;
+  }
 }
 
-__host__ cudaError_t CUDARTAPI cudaEventSynchronize(cudaEvent_t event)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("GPGPU-Sim API: cudaEventSynchronize ** waiting for event\n");
-	fflush(stdout);
-	CUevent_st *e = (CUevent_st*) event;
-	while( !e->done() )
-		;
-	printf("GPGPU-Sim API: cudaEventSynchronize ** event detected\n");
-	fflush(stdout);
-	return g_last_cudaError = cudaSuccess;
+__host__ cudaError_t CUDARTAPI cudaEventSynchronize(cudaEvent_t event) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("GPGPU-Sim API: cudaEventSynchronize ** waiting for event\n");
+  fflush(stdout);
+  CUevent_st *e = (CUevent_st *)event;
+  while (!e->done())
+    ;
+  printf("GPGPU-Sim API: cudaEventSynchronize ** event detected\n");
+  fflush(stdout);
+  return g_last_cudaError = cudaSuccess;
 }
 
-__host__ cudaError_t CUDARTAPI cudaEventDestroy(cudaEvent_t event)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	CUevent_st *e = get_event(event);
-	unsigned event_uid = e->get_uid();
-	event_tracker_t::iterator pe = g_timer_events.find(event_uid);
-	if( pe == g_timer_events.end() )
-		return g_last_cudaError = cudaErrorInvalidValue;
-	g_timer_events.erase(pe);
-	return g_last_cudaError = cudaSuccess;
+__host__ cudaError_t CUDARTAPI cudaEventDestroy(cudaEvent_t event) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  CUevent_st *e = get_event(event);
+  unsigned event_uid = e->get_uid();
+  event_tracker_t::iterator pe = g_timer_events.find(event_uid);
+  if (pe == g_timer_events.end())
+    return g_last_cudaError = cudaErrorInvalidValue;
+  g_timer_events.erase(pe);
+  return g_last_cudaError = cudaSuccess;
 }
 
-
-__host__ cudaError_t CUDARTAPI cudaEventElapsedTime(float *ms, cudaEvent_t start, cudaEvent_t end)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	time_t elapsed_time;
-	CUevent_st *s = get_event(start);
-	CUevent_st *e = get_event(end);
-	if( s==NULL || e==NULL )
-		return g_last_cudaError = cudaErrorUnknown;
-	elapsed_time = e->clock() - s->clock();
-	*ms = 1000*elapsed_time;
-	return g_last_cudaError = cudaSuccess;
+__host__ cudaError_t CUDARTAPI cudaEventElapsedTime(float *ms,
+                                                    cudaEvent_t start,
+                                                    cudaEvent_t end) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  time_t elapsed_time;
+  CUevent_st *s = get_event(start);
+  CUevent_st *e = get_event(end);
+  if (s == NULL || e == NULL) return g_last_cudaError = cudaErrorUnknown;
+  elapsed_time = e->clock() - s->clock();
+  *ms = 1000 * elapsed_time;
+  return g_last_cudaError = cudaSuccess;
 }
-
-
 
 /*******************************************************************************
  *                                                                              *
@@ -2776,25 +2913,20 @@ __host__ cudaError_t CUDARTAPI cudaEventElapsedTime(float *ms, cudaEvent_t start
  *                                                                              *
  *******************************************************************************/
 
-__host__ cudaError_t CUDARTAPI cudaThreadExit(void)
-{
-    return cudaThreadExitInternal();
+__host__ cudaError_t CUDARTAPI cudaThreadExit(void) {
+  return cudaThreadExitInternal();
 }
 
-__host__ cudaError_t CUDARTAPI cudaThreadSynchronize(void)
-{
-    return cudaThreadSynchronizeInternal();
+__host__ cudaError_t CUDARTAPI cudaThreadSynchronize(void) {
+  return cudaThreadSynchronizeInternal();
 }
 
-int CUDARTAPI __cudaSynchronizeThreads(void**, void*)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	return cudaThreadExit();
+int CUDARTAPI __cudaSynchronizeThreads(void **, void *) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  return cudaThreadExit();
 }
-
-
 
 /*******************************************************************************
  *                                                                              *
@@ -2804,38 +2936,39 @@ int CUDARTAPI __cudaSynchronizeThreads(void**, void*)
 
 #if (CUDART_VERSION >= 3010)
 int dummy0() {
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-return 0; }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  return 0;
+}
 
 int dummy1() {
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-return 2 << 20; }
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  return 2 << 20;
+}
 
 typedef int (*ExportedFunction)();
 
 static ExportedFunction exportTable[3] = {&dummy0, &dummy0, &dummy0};
 
-__host__ cudaError_t CUDARTAPI cudaGetExportTable(const void **ppExportTable, const cudaUUID_t *pExportTableId)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("cudaGetExportTable: UUID = "); 
-	for (int s = 0; s < 16; s++) {
-		printf("%#2x ", (unsigned char) (pExportTableId->bytes[s])); 
-	}
-	*ppExportTable = &exportTable;
+__host__ cudaError_t CUDARTAPI cudaGetExportTable(
+    const void **ppExportTable, const cudaUUID_t *pExportTableId) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("cudaGetExportTable: UUID = ");
+  for (int s = 0; s < 16; s++) {
+    printf("%#2x ", (unsigned char)(pExportTableId->bytes[s]));
+  }
+  *ppExportTable = &exportTable;
 
-	printf("\n"); 
-	return g_last_cudaError = cudaSuccess;
+  printf("\n");
+  return g_last_cudaError = cudaSuccess;
 }
 
 #endif
-
 
 /*******************************************************************************
  *                                                                              *
@@ -2845,859 +2978,843 @@ __host__ cudaError_t CUDARTAPI cudaGetExportTable(const void **ppExportTable, co
 
 //#include "../../cuobjdump_to_ptxplus/cuobjdump_parser.h"
 
-//extracts all ptx files from binary and dumps into prog_name.unique_no.sm_<>.ptx files
-void cuda_runtime_api::extract_ptx_files_using_cuobjdump(CUctx_st *context){
-    char command[1000];
-    char *pytorch_bin = getenv("PYTORCH_BIN");
-    std::string app_binary = get_app_binary(); 
+// extracts all ptx files from binary and dumps into
+// prog_name.unique_no.sm_<>.ptx files
+void cuda_runtime_api::extract_ptx_files_using_cuobjdump(CUctx_st *context) {
+  char command[1000];
+  char *pytorch_bin = getenv("PYTORCH_BIN");
+  std::string app_binary = get_app_binary();
 
+  char ptx_list_file_name[1024];
+  snprintf(ptx_list_file_name, 1024, "_cuobjdump_list_ptx_XXXXXX");
+  int fd2 = mkstemp(ptx_list_file_name);
+  close(fd2);
 
-    char ptx_list_file_name[1024];
-    snprintf(ptx_list_file_name,1024,"_cuobjdump_list_ptx_XXXXXX");
-    int fd2=mkstemp(ptx_list_file_name);
-    close(fd2);
+  if (pytorch_bin != NULL && strlen(pytorch_bin) != 0) {
+    app_binary = std::string(pytorch_bin);
+  }
 
-    if (pytorch_bin!=NULL && strlen(pytorch_bin)!=0){
-        app_binary = std::string(pytorch_bin);
-    }
-
-    //only want file names
-    snprintf(command,1000,"$CUDA_INSTALL_PATH/bin/cuobjdump -lptx %s  | cut -d \":\" -f 2 | awk '{$1=$1}1' > %s", app_binary.c_str(), ptx_list_file_name);
-    if( system(command) != 0 ) {
-        printf("WARNING: Failed to execute cuobjdump to get list of ptx files \n");
-        exit(0);
-    }   
-    if(!gpgpu_ctx->device_runtime->g_cdp_enabled) {
-        //based on the list above, dump ptx files individually. Format of dumped ptx file is prog_name.unique_no.sm_<>.ptx
-
-       std::ifstream infile(ptx_list_file_name);
-       std::string line;
-       while (std::getline(infile, line))
-       {
-            //int pos = line.find(std::string(get_app_binary_name(app_binary)));
-            const char *ptx_file = line.c_str();
-            printf("Extracting specific PTX file named %s \n",ptx_file);
-            snprintf(command,1000,"$CUDA_INSTALL_PATH/bin/cuobjdump -xptx %s %s", ptx_file, app_binary.c_str());
-            if (system(command)!=0) {
-                printf("ERROR: command: %s failed \n",command);
-                exit(0);
-            }
-            context->no_of_ptx++;
-       }
-    }
-
-	 if(!context->no_of_ptx){
-	 	printf("WARNING: Number of ptx in the executable file are 0. One of the reasons might be\n");
-	 	printf("\t1. CDP is enabled\n");
-	 	printf("\t2. When using PyTorch, PYTORCH_BIN is not set correctly\n");
-	 }
+  // only want file names
+  snprintf(command, 1000,
+           "$CUDA_INSTALL_PATH/bin/cuobjdump -lptx %s  | cut -d \":\" -f 2 | "
+           "awk '{$1=$1}1' > %s",
+           app_binary.c_str(), ptx_list_file_name);
+  if (system(command) != 0) {
+    printf("WARNING: Failed to execute cuobjdump to get list of ptx files \n");
+    exit(0);
+  }
+  if (!gpgpu_ctx->device_runtime->g_cdp_enabled) {
+    // based on the list above, dump ptx files individually. Format of dumped
+    // ptx file is prog_name.unique_no.sm_<>.ptx
 
     std::ifstream infile(ptx_list_file_name);
     std::string line;
-    while (std::getline(infile, line))
-    {
-         //int pos = line.find(std::string(get_app_binary_name(app_binary)));
-         int pos1 = line.find("sm_");
-         int pos2 = line.find_last_of(".");
-         if (pos1==std::string::npos&&pos2==std::string::npos){
-             printf("ERROR: PTX list is not in correct format");
-             exit(0);
-         }
-         std::string vstr = line.substr(pos1+3,pos2-pos1-3);
-         int version = atoi(vstr.c_str());
-         if (version_filename.find(version)==version_filename.end()){
-            version_filename[version] = std::set<std::string>();
-         }
-         version_filename[version].insert(line);
+    while (std::getline(infile, line)) {
+      // int pos = line.find(std::string(get_app_binary_name(app_binary)));
+      const char *ptx_file = line.c_str();
+      printf("Extracting specific PTX file named %s \n", ptx_file);
+      snprintf(command, 1000, "$CUDA_INSTALL_PATH/bin/cuobjdump -xptx %s %s",
+               ptx_file, app_binary.c_str());
+      if (system(command) != 0) {
+        printf("ERROR: command: %s failed \n", command);
+        exit(0);
+      }
+      context->no_of_ptx++;
     }
+  }
 
+  if (!context->no_of_ptx) {
+    printf(
+        "WARNING: Number of ptx in the executable file are 0. One of the "
+        "reasons might be\n");
+    printf("\t1. CDP is enabled\n");
+    printf("\t2. When using PyTorch, PYTORCH_BIN is not set correctly\n");
+  }
+
+  std::ifstream infile(ptx_list_file_name);
+  std::string line;
+  while (std::getline(infile, line)) {
+    // int pos = line.find(std::string(get_app_binary_name(app_binary)));
+    int pos1 = line.find("sm_");
+    int pos2 = line.find_last_of(".");
+    if (pos1 == std::string::npos && pos2 == std::string::npos) {
+      printf("ERROR: PTX list is not in correct format");
+      exit(0);
+    }
+    std::string vstr = line.substr(pos1 + 3, pos2 - pos1 - 3);
+    int version = atoi(vstr.c_str());
+    if (version_filename.find(version) == version_filename.end()) {
+      version_filename[version] = std::set<std::string>();
+    }
+    version_filename[version].insert(line);
+  }
 }
-
 
 //! Call cuobjdump to extract everything (-elf -sass -ptx)
 /*!
  *	This Function extract the whole PTX (for all the files) using cuobjdump
- *	to _cuobjdump_complete_output_XXXXXX then runs a parser to chop it up with each binary in
- *	its own file
- *	It is also responsible for extracting the libraries linked to the binary if the option is
- *	enabled
+ *	to _cuobjdump_complete_output_XXXXXX then runs a parser to chop it up
+ *with each binary in its own file It is also responsible for extracting the
+ *libraries linked to the binary if the option is enabled
  * */
-void cuda_runtime_api::extract_code_using_cuobjdump(){
-    CUctx_st *context = GPGPUSim_Context(gpgpu_ctx);
+void cuda_runtime_api::extract_code_using_cuobjdump() {
+  CUctx_st *context = GPGPUSim_Context(gpgpu_ctx);
 
-    //prevent the dumping by cuobjdump everytime we execute the code!
-    const char *override_cuobjdump = getenv("CUOBJDUMP_SIM_FILE"); 
-    char command[1000];
-    std::string app_binary = get_app_binary(); 
-    //Running cuobjdump using dynamic link to current process
-    snprintf(command,1000,"md5sum %s ", app_binary.c_str());
-    printf("Running md5sum using \"%s\"\n", command);
-    if(system(command)){
-        std::cout << "Failed to execute: " << command << std::endl;
-        exit(1);
-    }
-    // Running cuobjdump using dynamic link to current process
-    // Needs the option '-all' to extract PTX from CDP-enabled binary 
+  // prevent the dumping by cuobjdump everytime we execute the code!
+  const char *override_cuobjdump = getenv("CUOBJDUMP_SIM_FILE");
+  char command[1000];
+  std::string app_binary = get_app_binary();
+  // Running cuobjdump using dynamic link to current process
+  snprintf(command, 1000, "md5sum %s ", app_binary.c_str());
+  printf("Running md5sum using \"%s\"\n", command);
+  if (system(command)) {
+    std::cout << "Failed to execute: " << command << std::endl;
+    exit(1);
+  }
+  // Running cuobjdump using dynamic link to current process
+  // Needs the option '-all' to extract PTX from CDP-enabled binary
 
-    //dump ptx for all individial ptx files into sepearte files which is later used by ptxas.
-    int result=0;
+  // dump ptx for all individial ptx files into sepearte files which is later
+  // used by ptxas.
+  int result = 0;
 #if (CUDART_VERSION >= 6000)
-    extract_ptx_files_using_cuobjdump(context);
-    return;
+  extract_ptx_files_using_cuobjdump(context);
+  return;
 #endif
-    //TODO: redundant to dump twice. how can it be prevented?
-    //dump only for specific arch
-    char fname[1024];
-    if ((override_cuobjdump == NULL) || (strlen(override_cuobjdump)==0)) {
-	snprintf(fname,1024,"_cuobjdump_complete_output_XXXXXX");
-	int fd=mkstemp(fname);
-	close(fd);
-	if(!gpgpu_ctx->device_runtime->g_cdp_enabled)
-            snprintf(command,1000,"$CUDA_INSTALL_PATH/bin/cuobjdump -ptx -elf -sass %s > %s", app_binary.c_str(), fname);
-	else
-            snprintf(command,1000,"$CUDA_INSTALL_PATH/bin/cuobjdump -ptx -elf -sass -all %s > %s", app_binary.c_str(), fname);
-	bool parse_output = true; 
-	result = system(command);
-	if(result) {
-            if (context->get_device()->get_gpgpu()->get_config().experimental_lib_support() && (result == 65280)) {  
-                // Some CUDA application may exclusively use kernels provided by CUDA
-                // libraries (e.g. CUBLAS).  Skipping cuobjdump extraction from the
-                // executable for this case. 
-                // 65280 is the return code from cuobjdump denoting the specific error (tested on CUDA 4.0/4.1/4.2)
-                printf("WARNING: Failed to execute: %s\n", command); 
-                printf("         Executable binary does not contain any GPU kernel.\n"); 
-                parse_output = false; 
-            } else {
-                printf("ERROR: Failed to execute: %s\n", command); 
-                exit(1);
-            }
-        }
-
-        if (parse_output) {
-            printf("Parsing file %s\n", fname);
-	    FILE *cuobjdump_in;
-            cuobjdump_in = fopen(fname, "r");
-
-	    struct cuobjdump_parser parser;
-	    parser.elfserial = 1;
-	    parser.ptxserial = 1;
-	    cuobjdump_lex_init(&(parser.scanner));
-	    cuobjdump_set_in(cuobjdump_in, (parser.scanner));
-	    cuobjdump_parse(parser.scanner, &parser, cuobjdumpSectionList);
-	    cuobjdump_lex_destroy(parser.scanner);
-            fclose(cuobjdump_in);
-            printf("Done parsing!!!\n");
-        } else {
-            printf("Parsing skipped for %s\n", fname); 
-        }
-
-        if (context->get_device()->get_gpgpu()->get_config().experimental_lib_support()){
-            //Experimental library support
-            //Currently only for cufft
-
-            std::stringstream cmd;
-            cmd << "ldd " << app_binary << " | grep $CUDA_INSTALL_PATH | awk \'{print $3}\' > _tempfile_.txt";
-            int result = system(cmd.str().c_str());
-            if(result){
-                std::cout << "Failed to execute: " << cmd.str() << std::endl;
-                exit(1);
-            }
-            std::ifstream libsf;
-            libsf.open("_tempfile_.txt");
-            if(!libsf.is_open()) {
-                std::cout << "Failed to open: _tempfile_.txt" << std::endl;
-                exit(1);
-            }
-
-            //Save the original section list
-            std::list<cuobjdumpSection*> tmpsl = cuobjdumpSectionList;
-            cuobjdumpSectionList.clear();
-
-            std::string line;
-            std::getline(libsf, line);
-            std::cout << "DOING: " << line << std::endl;
-            int cnt=1;
-            while(libsf.good()){
-                std::stringstream libcodfn;
-                libcodfn << "_cuobjdump_complete_lib_" << cnt << "_";
-                cmd.str(""); //resetting
-                cmd << "$CUDA_INSTALL_PATH/bin/cuobjdump -ptx -elf -sass ";
-                cmd << line;
-                cmd << " > ";
-                cmd << libcodfn.str();
-                std::cout << "Running cuobjdump on " << line << std::endl;
-                std::cout << "Using command: " << cmd.str() << std::endl;
-                result = system(cmd.str().c_str());
-                if(result) {printf("ERROR: Failed to execute: %s\n", command); exit(1);}
-                    std::cout << "Done" << std::endl;
-
-                    std::cout << "Trying to parse " << libcodfn.str() << std::endl;
-		    FILE *cuobjdump_in;
-                    cuobjdump_in = fopen(libcodfn.str().c_str(), "r");
-		    struct cuobjdump_parser parser;
-		    parser.elfserial = 1;
-		    parser.ptxserial = 1;
-		    cuobjdump_lex_init(&(parser.scanner));
-		    cuobjdump_set_in(cuobjdump_in, (parser.scanner));
-		    cuobjdump_parse(parser.scanner, &parser, cuobjdumpSectionList);
-		    cuobjdump_lex_destroy(parser.scanner);
-                    fclose(cuobjdump_in);
-                    std::getline(libsf, line);
-            }
-            libSectionList = cuobjdumpSectionList;
-
-            //Restore the original section list
-            cuobjdumpSectionList = tmpsl;
-        }
-    } else {
-        printf("GPGPU-Sim PTX: overriding cuobjdump with '%s' (CUOBJDUMP_SIM_FILE is set)\n", override_cuobjdump);
-        snprintf(fname,1024, "%s",override_cuobjdump);
+  // TODO: redundant to dump twice. how can it be prevented?
+  // dump only for specific arch
+  char fname[1024];
+  if ((override_cuobjdump == NULL) || (strlen(override_cuobjdump) == 0)) {
+    snprintf(fname, 1024, "_cuobjdump_complete_output_XXXXXX");
+    int fd = mkstemp(fname);
+    close(fd);
+    if (!gpgpu_ctx->device_runtime->g_cdp_enabled)
+      snprintf(command, 1000,
+               "$CUDA_INSTALL_PATH/bin/cuobjdump -ptx -elf -sass %s > %s",
+               app_binary.c_str(), fname);
+    else
+      snprintf(command, 1000,
+               "$CUDA_INSTALL_PATH/bin/cuobjdump -ptx -elf -sass -all %s > %s",
+               app_binary.c_str(), fname);
+    bool parse_output = true;
+    result = system(command);
+    if (result) {
+      if (context->get_device()
+              ->get_gpgpu()
+              ->get_config()
+              .experimental_lib_support() &&
+          (result == 65280)) {
+        // Some CUDA application may exclusively use kernels provided by CUDA
+        // libraries (e.g. CUBLAS).  Skipping cuobjdump extraction from the
+        // executable for this case.
+        // 65280 is the return code from cuobjdump denoting the specific error
+        // (tested on CUDA 4.0/4.1/4.2)
+        printf("WARNING: Failed to execute: %s\n", command);
+        printf("         Executable binary does not contain any GPU kernel.\n");
+        parse_output = false;
+      } else {
+        printf("ERROR: Failed to execute: %s\n", command);
+        exit(1);
+      }
     }
+
+    if (parse_output) {
+      printf("Parsing file %s\n", fname);
+      FILE *cuobjdump_in;
+      cuobjdump_in = fopen(fname, "r");
+
+      struct cuobjdump_parser parser;
+      parser.elfserial = 1;
+      parser.ptxserial = 1;
+      cuobjdump_lex_init(&(parser.scanner));
+      cuobjdump_set_in(cuobjdump_in, (parser.scanner));
+      cuobjdump_parse(parser.scanner, &parser, cuobjdumpSectionList);
+      cuobjdump_lex_destroy(parser.scanner);
+      fclose(cuobjdump_in);
+      printf("Done parsing!!!\n");
+    } else {
+      printf("Parsing skipped for %s\n", fname);
+    }
+
+    if (context->get_device()
+            ->get_gpgpu()
+            ->get_config()
+            .experimental_lib_support()) {
+      // Experimental library support
+      // Currently only for cufft
+
+      std::stringstream cmd;
+      cmd << "ldd " << app_binary
+          << " | grep $CUDA_INSTALL_PATH | awk \'{print $3}\' > _tempfile_.txt";
+      int result = system(cmd.str().c_str());
+      if (result) {
+        std::cout << "Failed to execute: " << cmd.str() << std::endl;
+        exit(1);
+      }
+      std::ifstream libsf;
+      libsf.open("_tempfile_.txt");
+      if (!libsf.is_open()) {
+        std::cout << "Failed to open: _tempfile_.txt" << std::endl;
+        exit(1);
+      }
+
+      // Save the original section list
+      std::list<cuobjdumpSection *> tmpsl = cuobjdumpSectionList;
+      cuobjdumpSectionList.clear();
+
+      std::string line;
+      std::getline(libsf, line);
+      std::cout << "DOING: " << line << std::endl;
+      int cnt = 1;
+      while (libsf.good()) {
+        std::stringstream libcodfn;
+        libcodfn << "_cuobjdump_complete_lib_" << cnt << "_";
+        cmd.str("");  // resetting
+        cmd << "$CUDA_INSTALL_PATH/bin/cuobjdump -ptx -elf -sass ";
+        cmd << line;
+        cmd << " > ";
+        cmd << libcodfn.str();
+        std::cout << "Running cuobjdump on " << line << std::endl;
+        std::cout << "Using command: " << cmd.str() << std::endl;
+        result = system(cmd.str().c_str());
+        if (result) {
+          printf("ERROR: Failed to execute: %s\n", command);
+          exit(1);
+        }
+        std::cout << "Done" << std::endl;
+
+        std::cout << "Trying to parse " << libcodfn.str() << std::endl;
+        FILE *cuobjdump_in;
+        cuobjdump_in = fopen(libcodfn.str().c_str(), "r");
+        struct cuobjdump_parser parser;
+        parser.elfserial = 1;
+        parser.ptxserial = 1;
+        cuobjdump_lex_init(&(parser.scanner));
+        cuobjdump_set_in(cuobjdump_in, (parser.scanner));
+        cuobjdump_parse(parser.scanner, &parser, cuobjdumpSectionList);
+        cuobjdump_lex_destroy(parser.scanner);
+        fclose(cuobjdump_in);
+        std::getline(libsf, line);
+      }
+      libSectionList = cuobjdumpSectionList;
+
+      // Restore the original section list
+      cuobjdumpSectionList = tmpsl;
+    }
+  } else {
+    printf(
+        "GPGPU-Sim PTX: overriding cuobjdump with '%s' (CUOBJDUMP_SIM_FILE is "
+        "set)\n",
+        override_cuobjdump);
+    snprintf(fname, 1024, "%s", override_cuobjdump);
+  }
 }
 
 //! Read file into char*
-//TODO: convert this to C++ streams, will be way cleaner
-char* readfile (const std::string filename){
-	assert (filename != "");
-	FILE* fp = fopen(filename.c_str(),"r");
-	if (!fp) {
-		std::cout << "ERROR: Could not open file %s for reading\n" << filename << std::endl;
-		assert (0);
-	}
-	// finding size of the file
-	int filesize= 0;
-	fseek (fp , 0 , SEEK_END);
+// TODO: convert this to C++ streams, will be way cleaner
+char *readfile(const std::string filename) {
+  assert(filename != "");
+  FILE *fp = fopen(filename.c_str(), "r");
+  if (!fp) {
+    std::cout << "ERROR: Could not open file %s for reading\n"
+              << filename << std::endl;
+    assert(0);
+  }
+  // finding size of the file
+  int filesize = 0;
+  fseek(fp, 0, SEEK_END);
 
-	filesize = ftell (fp);
-	fseek (fp, 0, SEEK_SET);
-	// allocate and copy the entire ptx
-	char* ret = (char*)malloc((filesize +1)* sizeof(char));
-	fread(ret,1,filesize,fp);
-	ret[filesize]='\0';
-	fclose(fp);
-	return ret;
+  filesize = ftell(fp);
+  fseek(fp, 0, SEEK_SET);
+  // allocate and copy the entire ptx
+  char *ret = (char *)malloc((filesize + 1) * sizeof(char));
+  fread(ret, 1, filesize, fp);
+  ret[filesize] = '\0';
+  fclose(fp);
+  return ret;
 }
 
 //! Function that helps debugging
-void printSectionList(std::list<cuobjdumpSection*> sl) {
-	std::list<cuobjdumpSection*>::iterator iter;
-	for (	iter = sl.begin();
-			iter != sl.end();
-			iter++
-	){
-		(*iter)->print();
-	}
+void printSectionList(std::list<cuobjdumpSection *> sl) {
+  std::list<cuobjdumpSection *>::iterator iter;
+  for (iter = sl.begin(); iter != sl.end(); iter++) {
+    (*iter)->print();
+  }
 }
 
 //! Remove unecessary sm versions from the section list
-std::list<cuobjdumpSection*> cuda_runtime_api::pruneSectionList(CUctx_st *context) {
-	unsigned forced_max_capability = context->get_device()->get_gpgpu()->get_config().get_forced_max_capability();
+std::list<cuobjdumpSection *> cuda_runtime_api::pruneSectionList(
+    CUctx_st *context) {
+  unsigned forced_max_capability = context->get_device()
+                                       ->get_gpgpu()
+                                       ->get_config()
+                                       .get_forced_max_capability();
 
-	//For ptxplus, force the max capability to 19 if it's higher or unspecified(0)
-	if (context->get_device()->get_gpgpu()->get_config().convert_to_ptxplus()){
-		if (	(forced_max_capability == 0) ||
-				(forced_max_capability >= 20)){
-			printf("GPGPU-Sim: WARNING: Capability >= 20 are not supported in PTXPlus\n\tSetting forced_max_capability to 19\n");
-			forced_max_capability = 19;
-		}
-	}
+  // For ptxplus, force the max capability to 19 if it's higher or
+  // unspecified(0)
+  if (context->get_device()->get_gpgpu()->get_config().convert_to_ptxplus()) {
+    if ((forced_max_capability == 0) || (forced_max_capability >= 20)) {
+      printf(
+          "GPGPU-Sim: WARNING: Capability >= 20 are not supported in "
+          "PTXPlus\n\tSetting forced_max_capability to 19\n");
+      forced_max_capability = 19;
+    }
+  }
 
-	std::list<cuobjdumpSection*> prunedList;
+  std::list<cuobjdumpSection *> prunedList;
 
-	//Find the highest capability (that is lower than the forced maximum) for each cubin file
-	//and set it in cuobjdumpSectionMap. Do this only for ptx sections
-	std::map<std::string, unsigned> cuobjdumpSectionMap;
-	int min_ptx_capability_found=0;
-	for (	std::list<cuobjdumpSection*>::iterator iter = cuobjdumpSectionList.begin();
-			iter != cuobjdumpSectionList.end();
-			iter++){
-		unsigned capability = (*iter)->getArch();
-		if(dynamic_cast<cuobjdumpPTXSection*>(*iter) != NULL){
-			if(capability<min_ptx_capability_found || min_ptx_capability_found==0)
-				min_ptx_capability_found=capability;
-			if (capability <= forced_max_capability ||	forced_max_capability==0) {
-				if((cuobjdumpSectionMap.find((*iter)->getIdentifier())==cuobjdumpSectionMap.end())
-						|| (cuobjdumpSectionMap[(*iter)->getIdentifier()] < capability))
-						cuobjdumpSectionMap[(*iter)->getIdentifier()] = capability;
-			}
-		}
-	}
+  // Find the highest capability (that is lower than the forced maximum) for
+  // each cubin file and set it in cuobjdumpSectionMap. Do this only for ptx
+  // sections
+  std::map<std::string, unsigned> cuobjdumpSectionMap;
+  int min_ptx_capability_found = 0;
+  for (std::list<cuobjdumpSection *>::iterator iter =
+           cuobjdumpSectionList.begin();
+       iter != cuobjdumpSectionList.end(); iter++) {
+    unsigned capability = (*iter)->getArch();
+    if (dynamic_cast<cuobjdumpPTXSection *>(*iter) != NULL) {
+      if (capability < min_ptx_capability_found ||
+          min_ptx_capability_found == 0)
+        min_ptx_capability_found = capability;
+      if (capability <= forced_max_capability || forced_max_capability == 0) {
+        if ((cuobjdumpSectionMap.find((*iter)->getIdentifier()) ==
+             cuobjdumpSectionMap.end()) ||
+            (cuobjdumpSectionMap[(*iter)->getIdentifier()] < capability))
+          cuobjdumpSectionMap[(*iter)->getIdentifier()] = capability;
+      }
+    }
+  }
 
-	//Throw away the sections with the lower capabilites and push those with the highest in
-	//the pruned list
-	for (	std::list<cuobjdumpSection*>::iterator iter = cuobjdumpSectionList.begin();
-			iter != cuobjdumpSectionList.end();
-			iter++){
-		unsigned capability = (*iter)->getArch();
-		if(capability == cuobjdumpSectionMap[(*iter)->getIdentifier()]){
-			prunedList.push_back(*iter);
-		} else {
-			delete *iter;
-		}
-	}
-	if(prunedList.empty()){
-		printf("Error: No PTX sections found with sm capability that is lower than current forced maximum capability \n minimum ptx capability found = %u, maximum forced ptx capability = %u \n User might want to change either the forced maximum capability from gpgpusim configuration or update the compilation to generate the required PTX version\n",min_ptx_capability_found,forced_max_capability);
-		abort();
-	}
-	return prunedList;
+  // Throw away the sections with the lower capabilites and push those with the
+  // highest in the pruned list
+  for (std::list<cuobjdumpSection *>::iterator iter =
+           cuobjdumpSectionList.begin();
+       iter != cuobjdumpSectionList.end(); iter++) {
+    unsigned capability = (*iter)->getArch();
+    if (capability == cuobjdumpSectionMap[(*iter)->getIdentifier()]) {
+      prunedList.push_back(*iter);
+    } else {
+      delete *iter;
+    }
+  }
+  if (prunedList.empty()) {
+    printf(
+        "Error: No PTX sections found with sm capability that is lower than "
+        "current forced maximum capability \n minimum ptx capability found = "
+        "%u, maximum forced ptx capability = %u \n User might want to change "
+        "either the forced maximum capability from gpgpusim configuration or "
+        "update the compilation to generate the required PTX version\n",
+        min_ptx_capability_found, forced_max_capability);
+    abort();
+  }
+  return prunedList;
 }
 
 //! Merge all PTX sections that have a specific identifier into one file
-std::list<cuobjdumpSection*> cuda_runtime_api::mergeMatchingSections(std::string identifier){
-	const char *ptxcode = "";
-	std::list<cuobjdumpSection*>::iterator old_iter;
-	cuobjdumpPTXSection* old_ptxsection = NULL;
-	cuobjdumpPTXSection* ptxsection;
-	std::list<cuobjdumpSection*> mergedList;
+std::list<cuobjdumpSection *> cuda_runtime_api::mergeMatchingSections(
+    std::string identifier) {
+  const char *ptxcode = "";
+  std::list<cuobjdumpSection *>::iterator old_iter;
+  cuobjdumpPTXSection *old_ptxsection = NULL;
+  cuobjdumpPTXSection *ptxsection;
+  std::list<cuobjdumpSection *> mergedList;
 
-	for (	std::list<cuobjdumpSection*>::iterator iter = cuobjdumpSectionList.begin();
-			iter != cuobjdumpSectionList.end();
-			iter++){
-		if((ptxsection=dynamic_cast<cuobjdumpPTXSection*>(*iter)) != NULL &&
-			strcmp(ptxsection->getIdentifier().c_str(), identifier.c_str()) == 0){
-			// Read and remove the last PTX section
-			if (old_ptxsection != NULL) {
-				ptxcode = readfile(old_ptxsection->getPTXfilename());
-				// remove ptx file?
-				delete *old_iter;
-			}
+  for (std::list<cuobjdumpSection *>::iterator iter =
+           cuobjdumpSectionList.begin();
+       iter != cuobjdumpSectionList.end(); iter++) {
+    if ((ptxsection = dynamic_cast<cuobjdumpPTXSection *>(*iter)) != NULL &&
+        strcmp(ptxsection->getIdentifier().c_str(), identifier.c_str()) == 0) {
+      // Read and remove the last PTX section
+      if (old_ptxsection != NULL) {
+        ptxcode = readfile(old_ptxsection->getPTXfilename());
+        // remove ptx file?
+        delete *old_iter;
+      }
 
-			// Append all the PTX from the last PTX section into the current PTX section
-			// Add 50 to ptxcode to ignore the information regarding version/target/address_size
-			if (strlen(ptxcode) >= 50) {
-				FILE *ptxfile = fopen((ptxsection->getPTXfilename()).c_str(), "a");
-				fprintf(ptxfile, "%s", ptxcode + 50);
-				fclose(ptxfile);
-			}
+      // Append all the PTX from the last PTX section into the current PTX
+      // section Add 50 to ptxcode to ignore the information regarding
+      // version/target/address_size
+      if (strlen(ptxcode) >= 50) {
+        FILE *ptxfile = fopen((ptxsection->getPTXfilename()).c_str(), "a");
+        fprintf(ptxfile, "%s", ptxcode + 50);
+        fclose(ptxfile);
+      }
 
-			old_iter = iter;
-			old_ptxsection = ptxsection;
-		}
-		// Store all non-PTX sections and PTX sections with non-matching identifiers
-		else {
-			mergedList.push_back(*iter);
-		}
-	}
+      old_iter = iter;
+      old_ptxsection = ptxsection;
+    }
+    // Store all non-PTX sections and PTX sections with non-matching identifiers
+    else {
+      mergedList.push_back(*iter);
+    }
+  }
 
-	// Store the final PTX section
-	mergedList.push_back(*old_iter);
+  // Store the final PTX section
+  mergedList.push_back(*old_iter);
 
-	return mergedList;
+  return mergedList;
 }
 
 //! Merge any PTX sections with matching identifiers
-std::list<cuobjdumpSection*> cuda_runtime_api::mergeSections(){
-	std::vector<std::string> identifier;
-	cuobjdumpPTXSection* ptxsection;
+std::list<cuobjdumpSection *> cuda_runtime_api::mergeSections() {
+  std::vector<std::string> identifier;
+  cuobjdumpPTXSection *ptxsection;
 
-	// Add all identifiers present in PTX sections to a vector
-	for (	std::list<cuobjdumpSection*>::iterator iter = cuobjdumpSectionList.begin();
-			iter != cuobjdumpSectionList.end();
-			iter++){
-		if((ptxsection=dynamic_cast<cuobjdumpPTXSection*>(*iter)) != NULL){
-			std::string current_id = ptxsection->getIdentifier();
+  // Add all identifiers present in PTX sections to a vector
+  for (std::list<cuobjdumpSection *>::iterator iter =
+           cuobjdumpSectionList.begin();
+       iter != cuobjdumpSectionList.end(); iter++) {
+    if ((ptxsection = dynamic_cast<cuobjdumpPTXSection *>(*iter)) != NULL) {
+      std::string current_id = ptxsection->getIdentifier();
 
-			// If we haven't yet seen a given identifier, add it to the vector
-			if (std::find(identifier.begin(), identifier.end(), current_id) == identifier.end()) {
-				identifier.push_back(current_id);
-			}
-		}
-	}
+      // If we haven't yet seen a given identifier, add it to the vector
+      if (std::find(identifier.begin(), identifier.end(), current_id) ==
+          identifier.end()) {
+        identifier.push_back(current_id);
+      }
+    }
+  }
 
-	// Call mergeMatchingSections on all identifiers in the vector
-	for (	std::vector<std::string>::iterator iter = identifier.begin();
-			iter != identifier.end();
-			iter++) {
-		cuobjdumpSectionList = mergeMatchingSections(*iter);
-	}
+  // Call mergeMatchingSections on all identifiers in the vector
+  for (std::vector<std::string>::iterator iter = identifier.begin();
+       iter != identifier.end(); iter++) {
+    cuobjdumpSectionList = mergeMatchingSections(*iter);
+  }
 
-	return cuobjdumpSectionList;
+  return cuobjdumpSectionList;
 }
 
-
-//! Within the section list, find the ELF section corresponding to a given identifier
-cuobjdumpELFSection* findELFSectionInList(std::list<cuobjdumpSection*> sectionlist, const std::string identifier){
-
-	std::list<cuobjdumpSection*>::iterator iter;
-	for (	iter = sectionlist.begin();
-			iter != sectionlist.end();
-			iter++
-	){
-		cuobjdumpELFSection* elfsection;
-		if((elfsection=dynamic_cast<cuobjdumpELFSection*>(*iter)) != NULL){
-			if(elfsection->getIdentifier() == identifier)
-				return elfsection;
-		}
-	}
-	return NULL;
+//! Within the section list, find the ELF section corresponding to a given
+//! identifier
+cuobjdumpELFSection *findELFSectionInList(
+    std::list<cuobjdumpSection *> sectionlist, const std::string identifier) {
+  std::list<cuobjdumpSection *>::iterator iter;
+  for (iter = sectionlist.begin(); iter != sectionlist.end(); iter++) {
+    cuobjdumpELFSection *elfsection;
+    if ((elfsection = dynamic_cast<cuobjdumpELFSection *>(*iter)) != NULL) {
+      if (elfsection->getIdentifier() == identifier) return elfsection;
+    }
+  }
+  return NULL;
 }
 
 //! Find an ELF section in all the known lists
-cuobjdumpELFSection* cuda_runtime_api::findELFSection(const std::string identifier){
-	cuobjdumpELFSection* sec = findELFSectionInList(cuobjdumpSectionList, identifier);
-	if (sec!=NULL)return sec;
-	sec = findELFSectionInList(libSectionList, identifier);
-	if (sec!=NULL)return sec;
-	std::cout << "Could not find " << identifier << std::endl;
-	assert(0 && "Could not find the required ELF section");
-	return NULL;
+cuobjdumpELFSection *cuda_runtime_api::findELFSection(
+    const std::string identifier) {
+  cuobjdumpELFSection *sec =
+      findELFSectionInList(cuobjdumpSectionList, identifier);
+  if (sec != NULL) return sec;
+  sec = findELFSectionInList(libSectionList, identifier);
+  if (sec != NULL) return sec;
+  std::cout << "Could not find " << identifier << std::endl;
+  assert(0 && "Could not find the required ELF section");
+  return NULL;
 }
 
-//! Within the section list, find the PTX section corresponding to a given identifier
-cuobjdumpPTXSection* cuda_runtime_api::findPTXSectionInList(std::list<cuobjdumpSection*> &sectionlist, const std::string identifier){
-	std::list<cuobjdumpSection*>::iterator iter;
-	for (	iter = sectionlist.begin();
-			iter != sectionlist.end();
-			iter++
-	){
-		cuobjdumpPTXSection* ptxsection;
-		if((ptxsection=dynamic_cast<cuobjdumpPTXSection*>(*iter)) != NULL){
-			if(ptxsection->getIdentifier() == identifier)
-				return ptxsection;
-			else {
-				if(gpgpu_ctx->device_runtime->g_cdp_enabled) {
-					printf("Warning: __cudaRegisterFatBinary needs %s, but find PTX section with %s\n",
-						identifier.c_str(), ptxsection->getIdentifier().c_str());
-					return ptxsection;
-				}
-			}
-		}
-	}
-	return NULL;
+//! Within the section list, find the PTX section corresponding to a given
+//! identifier
+cuobjdumpPTXSection *cuda_runtime_api::findPTXSectionInList(
+    std::list<cuobjdumpSection *> &sectionlist, const std::string identifier) {
+  std::list<cuobjdumpSection *>::iterator iter;
+  for (iter = sectionlist.begin(); iter != sectionlist.end(); iter++) {
+    cuobjdumpPTXSection *ptxsection;
+    if ((ptxsection = dynamic_cast<cuobjdumpPTXSection *>(*iter)) != NULL) {
+      if (ptxsection->getIdentifier() == identifier)
+        return ptxsection;
+      else {
+        if (gpgpu_ctx->device_runtime->g_cdp_enabled) {
+          printf(
+              "Warning: __cudaRegisterFatBinary needs %s, but find PTX section "
+              "with %s\n",
+              identifier.c_str(), ptxsection->getIdentifier().c_str());
+          return ptxsection;
+        }
+      }
+    }
+  }
+  return NULL;
 }
 
 //! Find an PTX section in all the known lists
-cuobjdumpPTXSection* cuda_runtime_api::findPTXSection(const std::string identifier){
-	cuobjdumpPTXSection* sec = findPTXSectionInList(cuobjdumpSectionList, identifier);
-	if (sec!=NULL)return sec;
-	sec = findPTXSectionInList(libSectionList, identifier);
-	if (sec!=NULL)return sec;
-	std::cout << "Could not find " << identifier << std::endl;
-	assert(0 && "Could not find the required PTX section");
-	return NULL;
+cuobjdumpPTXSection *cuda_runtime_api::findPTXSection(
+    const std::string identifier) {
+  cuobjdumpPTXSection *sec =
+      findPTXSectionInList(cuobjdumpSectionList, identifier);
+  if (sec != NULL) return sec;
+  sec = findPTXSectionInList(libSectionList, identifier);
+  if (sec != NULL) return sec;
+  std::cout << "Could not find " << identifier << std::endl;
+  assert(0 && "Could not find the required PTX section");
+  return NULL;
 }
-
-
 
 //! Extract the code using cuobjdump and remove unnecessary sections
-void cuda_runtime_api::cuobjdumpInit(){
-	CUctx_st *context = GPGPUSim_Context(gpgpu_ctx);
-	extract_code_using_cuobjdump(); //extract all the output of cuobjdump to _cuobjdump_*.*
-	const char* pre_load = getenv("CUOBJDUMP_SIM_FILE");
-	if (pre_load ==NULL || strlen(pre_load)==0){
-		cuobjdumpSectionList = pruneSectionList(context);
-		cuobjdumpSectionList = mergeSections();
-	}
+void cuda_runtime_api::cuobjdumpInit() {
+  CUctx_st *context = GPGPUSim_Context(gpgpu_ctx);
+  extract_code_using_cuobjdump();  // extract all the output of cuobjdump to
+                                   // _cuobjdump_*.*
+  const char *pre_load = getenv("CUOBJDUMP_SIM_FILE");
+  if (pre_load == NULL || strlen(pre_load) == 0) {
+    cuobjdumpSectionList = pruneSectionList(context);
+    cuobjdumpSectionList = mergeSections();
+  }
 }
 
-
 //! Either submit PTX for simulation or convert SASS to PTXPlus and submit it
-void gpgpu_context::cuobjdumpParseBinary(unsigned int handle){
+void gpgpu_context::cuobjdumpParseBinary(unsigned int handle) {
+  CUctx_st *context = GPGPUSim_Context(this);
+  if (api->fatbin_registered[handle]) return;
+  api->fatbin_registered[handle] = true;
+  std::string fname = api->fatbinmap[handle];
 
-	CUctx_st *context = GPGPUSim_Context(this);
-	if(api->fatbin_registered[handle]) return;
-	api->fatbin_registered[handle] = true;
-	std::string fname = api->fatbinmap[handle];
-
-	if (api->name_symtab.find(fname) != api->name_symtab.end()) {
-		symbol_table *symtab = api->name_symtab[fname];
-		context->add_binary(symtab, handle);
-		return;
-	}
-	symbol_table *symtab;
+  if (api->name_symtab.find(fname) != api->name_symtab.end()) {
+    symbol_table *symtab = api->name_symtab[fname];
+    context->add_binary(symtab, handle);
+    return;
+  }
+  symbol_table *symtab;
 
 #if (CUDART_VERSION >= 6000)
-   //loops through all ptx files from smallest sm version to largest
-   std::map<unsigned,std::set<std::string> >::iterator itr_m;
-   for (itr_m = api->version_filename.begin(); itr_m!=api->version_filename.end(); itr_m++){
-      std::set<std::string>::iterator itr_s;
-      for (itr_s = itr_m->second.begin(); itr_s!=itr_m->second.end(); itr_s++){
-          std::string ptx_filename = *itr_s;
-          printf("GPGPU-Sim PTX: Parsing %s\n",ptx_filename.c_str());
-          symtab = gpgpu_ptx_sim_load_ptx_from_filename( ptx_filename.c_str() );
-      }
-   }
-   api->name_symtab[fname] = symtab;
-   context->add_binary(symtab, handle);
-   api->load_static_globals(symtab,STATIC_ALLOC_LIMIT,0xFFFFFFFF,context->get_device()->get_gpgpu());
-   api->load_constants(symtab,STATIC_ALLOC_LIMIT,context->get_device()->get_gpgpu());
-   for (itr_m = api->version_filename.begin(); itr_m!=api->version_filename.end(); itr_m++){
-      std::set<std::string>::iterator itr_s;
-      for (itr_s = itr_m->second.begin(); itr_s!=itr_m->second.end(); itr_s++){
-          std::string ptx_filename = *itr_s;
-          printf("GPGPU-Sim PTX: Loading PTXInfo from %s\n",ptx_filename.c_str());
-          gpgpu_ptx_info_load_from_filename( ptx_filename.c_str(), itr_m->first );
-      }
-   }
-   return;
+  // loops through all ptx files from smallest sm version to largest
+  std::map<unsigned, std::set<std::string> >::iterator itr_m;
+  for (itr_m = api->version_filename.begin();
+       itr_m != api->version_filename.end(); itr_m++) {
+    std::set<std::string>::iterator itr_s;
+    for (itr_s = itr_m->second.begin(); itr_s != itr_m->second.end(); itr_s++) {
+      std::string ptx_filename = *itr_s;
+      printf("GPGPU-Sim PTX: Parsing %s\n", ptx_filename.c_str());
+      symtab = gpgpu_ptx_sim_load_ptx_from_filename(ptx_filename.c_str());
+    }
+  }
+  api->name_symtab[fname] = symtab;
+  context->add_binary(symtab, handle);
+  api->load_static_globals(symtab, STATIC_ALLOC_LIMIT, 0xFFFFFFFF,
+                           context->get_device()->get_gpgpu());
+  api->load_constants(symtab, STATIC_ALLOC_LIMIT,
+                      context->get_device()->get_gpgpu());
+  for (itr_m = api->version_filename.begin();
+       itr_m != api->version_filename.end(); itr_m++) {
+    std::set<std::string>::iterator itr_s;
+    for (itr_s = itr_m->second.begin(); itr_s != itr_m->second.end(); itr_s++) {
+      std::string ptx_filename = *itr_s;
+      printf("GPGPU-Sim PTX: Loading PTXInfo from %s\n", ptx_filename.c_str());
+      gpgpu_ptx_info_load_from_filename(ptx_filename.c_str(), itr_m->first);
+    }
+  }
+  return;
 #endif
 
-	unsigned max_capability = 0;
-	for (	std::list<cuobjdumpSection*>::iterator iter = api->cuobjdumpSectionList.begin();
-			iter != api->cuobjdumpSectionList.end();
-			iter++){
-		unsigned capability = (*iter)->getArch();
-		if (capability > max_capability) max_capability = capability;
-	}
-	if (max_capability > 20) printf("WARNING: No guarantee that PTX will be parsed for SM version %u\n", max_capability);
-	if (max_capability == 0) max_capability=context->get_device()->get_gpgpu()->get_config().get_forced_max_capability();
+  unsigned max_capability = 0;
+  for (std::list<cuobjdumpSection *>::iterator iter =
+           api->cuobjdumpSectionList.begin();
+       iter != api->cuobjdumpSectionList.end(); iter++) {
+    unsigned capability = (*iter)->getArch();
+    if (capability > max_capability) max_capability = capability;
+  }
+  if (max_capability > 20)
+    printf("WARNING: No guarantee that PTX will be parsed for SM version %u\n",
+           max_capability);
+  if (max_capability == 0)
+    max_capability = context->get_device()
+                         ->get_gpgpu()
+                         ->get_config()
+                         .get_forced_max_capability();
 
-	cuobjdumpPTXSection* ptx = NULL;
-	const char* pre_load = getenv("CUOBJDUMP_SIM_FILE");
-	if(pre_load==NULL || strlen(pre_load)==0)
-		ptx = api->findPTXSection(fname);
-	char *ptxcode;
-	const char *override_ptx_name = getenv("PTX_SIM_KERNELFILE"); 
-	if (override_ptx_name == NULL or getenv("PTX_SIM_USE_PTX_FILE") == NULL or strlen(getenv("PTX_SIM_USE_PTX_FILE"))==0) {
-		ptxcode = readfile(ptx->getPTXfilename());
-	} else {
-		printf("GPGPU-Sim PTX: overriding embedded ptx with '%s' (PTX_SIM_USE_PTX_FILE is set)\n", override_ptx_name);
-		ptxcode = readfile(override_ptx_name);
-	}
-	if(context->get_device()->get_gpgpu()->get_config().convert_to_ptxplus() ) {
-		cuobjdumpELFSection* elfsection = api->findELFSection(ptx->getIdentifier());
-		assert (elfsection!= NULL);
-		char *ptxplus_str = ptxinfo->gpgpu_ptx_sim_convert_ptx_and_sass_to_ptxplus(
-				ptx->getPTXfilename(),
-				elfsection->getELFfilename(),
-				elfsection->getSASSfilename());
-		symtab=gpgpu_ptx_sim_load_ptx_from_string(ptxplus_str, handle);
-		printf("Adding %s with cubin handle %u\n", ptx->getPTXfilename().c_str(), handle);
-		context->add_binary(symtab, handle);
-		gpgpu_ptxinfo_load_from_string( ptxcode, handle, max_capability, context->no_of_ptx );
-		delete[] ptxplus_str;
-	} else {
-		symtab=gpgpu_ptx_sim_load_ptx_from_string(ptxcode, handle);
-		//if CUOBJDUMP_SIM_FILE is not set, ptx is NULL. So comment below.
-		//printf("Adding %s with cubin handle %u\n", ptx->getPTXfilename().c_str(), handle);
-		context->add_binary(symtab, handle);
-		gpgpu_ptxinfo_load_from_string( ptxcode, handle, max_capability, context->no_of_ptx );
-	}
-	api->load_static_globals(symtab,STATIC_ALLOC_LIMIT,0xFFFFFFFF,context->get_device()->get_gpgpu());
-	api->load_constants(symtab,STATIC_ALLOC_LIMIT,context->get_device()->get_gpgpu());
-	api->name_symtab[fname] = symtab;
+  cuobjdumpPTXSection *ptx = NULL;
+  const char *pre_load = getenv("CUOBJDUMP_SIM_FILE");
+  if (pre_load == NULL || strlen(pre_load) == 0)
+    ptx = api->findPTXSection(fname);
+  char *ptxcode;
+  const char *override_ptx_name = getenv("PTX_SIM_KERNELFILE");
+  if (override_ptx_name == NULL or getenv("PTX_SIM_USE_PTX_FILE") == NULL or
+      strlen(getenv("PTX_SIM_USE_PTX_FILE")) == 0) {
+    ptxcode = readfile(ptx->getPTXfilename());
+  } else {
+    printf(
+        "GPGPU-Sim PTX: overriding embedded ptx with '%s' "
+        "(PTX_SIM_USE_PTX_FILE is set)\n",
+        override_ptx_name);
+    ptxcode = readfile(override_ptx_name);
+  }
+  if (context->get_device()->get_gpgpu()->get_config().convert_to_ptxplus()) {
+    cuobjdumpELFSection *elfsection = api->findELFSection(ptx->getIdentifier());
+    assert(elfsection != NULL);
+    char *ptxplus_str = ptxinfo->gpgpu_ptx_sim_convert_ptx_and_sass_to_ptxplus(
+        ptx->getPTXfilename(), elfsection->getELFfilename(),
+        elfsection->getSASSfilename());
+    symtab = gpgpu_ptx_sim_load_ptx_from_string(ptxplus_str, handle);
+    printf("Adding %s with cubin handle %u\n", ptx->getPTXfilename().c_str(),
+           handle);
+    context->add_binary(symtab, handle);
+    gpgpu_ptxinfo_load_from_string(ptxcode, handle, max_capability,
+                                   context->no_of_ptx);
+    delete[] ptxplus_str;
+  } else {
+    symtab = gpgpu_ptx_sim_load_ptx_from_string(ptxcode, handle);
+    // if CUOBJDUMP_SIM_FILE is not set, ptx is NULL. So comment below.
+    // printf("Adding %s with cubin handle %u\n", ptx->getPTXfilename().c_str(),
+    // handle);
+    context->add_binary(symtab, handle);
+    gpgpu_ptxinfo_load_from_string(ptxcode, handle, max_capability,
+                                   context->no_of_ptx);
+  }
+  api->load_static_globals(symtab, STATIC_ALLOC_LIMIT, 0xFFFFFFFF,
+                           context->get_device()->get_gpgpu());
+  api->load_constants(symtab, STATIC_ALLOC_LIMIT,
+                      context->get_device()->get_gpgpu());
+  api->name_symtab[fname] = symtab;
 
-	//TODO: Remove temporarily files as per configurations
+  // TODO: Remove temporarily files as per configurations
 }
 }
 
 extern "C" {
 
-void** CUDARTAPI __cudaRegisterFatBinary( void *fatCubin )
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-    return cudaRegisterFatBinaryInternal(fatCubin);
+void **CUDARTAPI __cudaRegisterFatBinary(void *fatCubin) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  return cudaRegisterFatBinaryInternal(fatCubin);
 }
 
-void CUDARTAPI __cudaRegisterFatBinaryEnd( void **fatCubinHandle )
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
+void CUDARTAPI __cudaRegisterFatBinaryEnd(void **fatCubinHandle) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
 }
 
-unsigned CUDARTAPI __cudaPushCallConfiguration(dim3 gridDim,
-                                      dim3 blockDim, 
-                                      size_t sharedMem = 0, 
-                                      struct CUstream_st *stream = 0)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-    cudaConfigureCallInternal(gridDim, blockDim, sharedMem, stream);
+unsigned CUDARTAPI __cudaPushCallConfiguration(dim3 gridDim, dim3 blockDim,
+                                               size_t sharedMem = 0,
+                                               struct CUstream_st *stream = 0) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cudaConfigureCallInternal(gridDim, blockDim, sharedMem, stream);
 }
 
-cudaError_t CUDARTAPI __cudaPopCallConfiguration(
-  dim3         *gridDim,
-  dim3         *blockDim,
-  size_t       *sharedMem,
-  void         *stream
-)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-    return g_last_cudaError = cudaSuccess;
+cudaError_t CUDARTAPI __cudaPopCallConfiguration(dim3 *gridDim, dim3 *blockDim,
+                                                 size_t *sharedMem,
+                                                 void *stream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  return g_last_cudaError = cudaSuccess;
 }
 
-
-void CUDARTAPI __cudaRegisterFunction(
-		void   **fatCubinHandle,
-		const char    *hostFun,
-		char    *deviceFun,
-		const char    *deviceName,
-		int      thread_limit,
-		uint3   *tid,
-		uint3   *bid,
-		dim3    *bDim,
-		dim3    *gDim
-) {
-    cudaRegisterFunctionInternal(
-	    fatCubinHandle,
-	    hostFun,
-	    deviceFun,
-	    deviceName,
-	    thread_limit,
-	    tid,
-	    bid,
-	    bDim,
-	    gDim
-	    );
-
+void CUDARTAPI __cudaRegisterFunction(void **fatCubinHandle,
+                                      const char *hostFun, char *deviceFun,
+                                      const char *deviceName, int thread_limit,
+                                      uint3 *tid, uint3 *bid, dim3 *bDim,
+                                      dim3 *gDim) {
+  cudaRegisterFunctionInternal(fatCubinHandle, hostFun, deviceFun, deviceName,
+                               thread_limit, tid, bid, bDim, gDim);
 }
 
 extern void __cudaRegisterVar(
-		void **fatCubinHandle,
-		char *hostVar, //pointer to...something
-		char *deviceAddress, //name of variable
-		const char *deviceName, //name of variable (same as above)
-		int ext,
-		int size,
-		int constant,
-		int global )
-{
-    cudaRegisterVarInternal(
-	    fatCubinHandle,
-	    hostVar,
-	    deviceAddress,
-	    deviceName,
-	    ext,
-	    size,
-	    constant,
-	    global );
+    void **fatCubinHandle,
+    char *hostVar,           // pointer to...something
+    char *deviceAddress,     // name of variable
+    const char *deviceName,  // name of variable (same as above)
+    int ext, int size, int constant, int global) {
+  cudaRegisterVarInternal(fatCubinHandle, hostVar, deviceAddress, deviceName,
+                          ext, size, constant, global);
 }
 
-__host__ cudaError_t CUDARTAPI cudaConfigureCall(dim3 gridDim, dim3 blockDim, size_t sharedMem, cudaStream_t stream)
-{
-    return cudaConfigureCallInternal(gridDim, blockDim, sharedMem, stream);
+__host__ cudaError_t CUDARTAPI cudaConfigureCall(dim3 gridDim, dim3 blockDim,
+                                                 size_t sharedMem,
+                                                 cudaStream_t stream) {
+  return cudaConfigureCallInternal(gridDim, blockDim, sharedMem, stream);
 }
 
-void __cudaUnregisterFatBinary(void **fatCubinHandle)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
+void __cudaUnregisterFatBinary(void **fatCubinHandle) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
 }
 
-cudaError_t cudaDeviceReset ( void ) {
-	// Should reset the simulated GPU
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	return g_last_cudaError = cudaSuccess;
+cudaError_t cudaDeviceReset(void) {
+  // Should reset the simulated GPU
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  return g_last_cudaError = cudaSuccess;
 }
 
-cudaError_t CUDARTAPI cudaDeviceSynchronize(void)
-{
-    return cudaDeviceSynchronizeInternal();
+cudaError_t CUDARTAPI cudaDeviceSynchronize(void) {
+  return cudaDeviceSynchronizeInternal();
 }
 
-void __cudaRegisterShared(
-		void **fatCubinHandle,
-		void **devicePtr
-)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	// we don't do anything here
-	printf("GPGPU-Sim PTX: __cudaRegisterShared\n" );
+void __cudaRegisterShared(void **fatCubinHandle, void **devicePtr) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  // we don't do anything here
+  printf("GPGPU-Sim PTX: __cudaRegisterShared\n");
 }
 
-void CUDARTAPI __cudaRegisterSharedVar(
-		void   **fatCubinHandle,
-		void   **devicePtr,
-		size_t   size,
-		size_t   alignment,
-		int      storage
-)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	// we don't do anything here
-	printf("GPGPU-Sim PTX: __cudaRegisterSharedVar\n" );
+void CUDARTAPI __cudaRegisterSharedVar(void **fatCubinHandle, void **devicePtr,
+                                       size_t size, size_t alignment,
+                                       int storage) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  // we don't do anything here
+  printf("GPGPU-Sim PTX: __cudaRegisterSharedVar\n");
 }
 
 void __cudaRegisterTexture(
-		void **fatCubinHandle,
-		const struct textureReference *hostVar,
-		const void **deviceAddress,
-		const char *deviceName,
-		int dim,
-		int norm,
-		int ext
-) //passes in a newly created textureReference
+    void **fatCubinHandle, const struct textureReference *hostVar,
+    const void **deviceAddress, const char *deviceName, int dim, int norm,
+    int ext)  // passes in a newly created textureReference
 {
-    __cudaRegisterTextureInternal(fatCubinHandle, hostVar, deviceAddress, deviceName, dim, norm, ext);
+  __cudaRegisterTextureInternal(fatCubinHandle, hostVar, deviceAddress,
+                                deviceName, dim, norm, ext);
 }
 
-
-char __cudaInitModule(
-		void **fatCubinHandle
-)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	cuda_not_implemented(__my_func__,__LINE__);
-	return g_last_cudaError = cudaErrorUnknown;
+char __cudaInitModule(void **fatCubinHandle) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
+  return g_last_cudaError = cudaErrorUnknown;
 }
 
-
-cudaError_t cudaGLRegisterBufferObject(GLuint bufferObj)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("GPGPU-Sim PTX: Execution warning: ignoring call to \"%s\"\n", __my_func__ );
-	return g_last_cudaError = cudaSuccess;
+cudaError_t cudaGLRegisterBufferObject(GLuint bufferObj) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("GPGPU-Sim PTX: Execution warning: ignoring call to \"%s\"\n",
+         __my_func__);
+  return g_last_cudaError = cudaSuccess;
 }
 
-cudaError_t cudaGLMapBufferObject(void** devPtr, GLuint bufferObj) 
-{
-    return cudaGLMapBufferObjectInternal(devPtr, bufferObj);
+cudaError_t cudaGLMapBufferObject(void **devPtr, GLuint bufferObj) {
+  return cudaGLMapBufferObjectInternal(devPtr, bufferObj);
 }
 
-cudaError_t cudaGLUnmapBufferObject(GLuint bufferObj)
-{
-    return cudaGLUnmapBufferObjectInternal(bufferObj);
+cudaError_t cudaGLUnmapBufferObject(GLuint bufferObj) {
+  return cudaGLUnmapBufferObjectInternal(bufferObj);
 }
 
-cudaError_t cudaGLUnregisterBufferObject(GLuint bufferObj) 
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("GPGPU-Sim PTX: Execution warning: ignoring call to \"%s\"\n", __my_func__ );
-	return g_last_cudaError = cudaSuccess;
+cudaError_t cudaGLUnregisterBufferObject(GLuint bufferObj) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("GPGPU-Sim PTX: Execution warning: ignoring call to \"%s\"\n",
+         __my_func__);
+  return g_last_cudaError = cudaSuccess;
 }
 
 #if (CUDART_VERSION >= 2010)
 
-cudaError_t CUDARTAPI cudaHostAlloc(void **pHost,  size_t bytes, unsigned int flags)
-{
-    return cudaHostAllocInternal(pHost, bytes, flags);
+cudaError_t CUDARTAPI cudaHostAlloc(void **pHost, size_t bytes,
+                                    unsigned int flags) {
+  return cudaHostAllocInternal(pHost, bytes, flags);
 }
 
-cudaError_t CUDARTAPI cudaHostGetDevicePointer(void **pDevice, void *pHost, unsigned int flags)
-{
-    return cudaHostGetDevicePointerInternal(pDevice, pHost, flags);
+cudaError_t CUDARTAPI cudaHostGetDevicePointer(void **pDevice, void *pHost,
+                                               unsigned int flags) {
+  return cudaHostGetDevicePointerInternal(pDevice, pHost, flags);
 }
 
-__host__ cudaError_t CUDARTAPI cudaPointerGetAttributes(
-		cudaPointerAttributes *attributes, 
-		const void *ptr
-)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	cuda_not_implemented(__my_func__,__LINE__);
-	return g_last_cudaError = cudaErrorUnknown;
+__host__ cudaError_t CUDARTAPI
+cudaPointerGetAttributes(cudaPointerAttributes *attributes, const void *ptr) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
+  return g_last_cudaError = cudaErrorUnknown;
 }
 
-__host__ cudaError_t CUDARTAPI cudaDeviceCanAccessPeer(
-		int *canAccessPeer,
-		int device,
-		int peerDevice
-)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	cuda_not_implemented(__my_func__,__LINE__);
-	return g_last_cudaError = cudaErrorUnknown;
+__host__ cudaError_t CUDARTAPI cudaDeviceCanAccessPeer(int *canAccessPeer,
+                                                       int device,
+                                                       int peerDevice) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
+  return g_last_cudaError = cudaErrorUnknown;
 }
 
-__host__ cudaError_t CUDARTAPI cudaDeviceEnablePeerAccess(
-		int peerDevice,
-		unsigned int flags
-)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	cuda_not_implemented(__my_func__,__LINE__);
-	return g_last_cudaError = cudaErrorUnknown;
+__host__ cudaError_t CUDARTAPI cudaDeviceEnablePeerAccess(int peerDevice,
+                                                          unsigned int flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
+  return g_last_cudaError = cudaErrorUnknown;
 }
 
-cudaError_t CUDARTAPI cudaSetValidDevices(int *device_arr, int len)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	cuda_not_implemented(__my_func__,__LINE__);
-	return g_last_cudaError = cudaErrorUnknown;
+cudaError_t CUDARTAPI cudaSetValidDevices(int *device_arr, int len) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
+  return g_last_cudaError = cudaErrorUnknown;
 }
 
-cudaError_t CUDARTAPI cudaSetDeviceFlags( int flags )
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-    // This flag is implicitly always on (unless you are using the driver API). It is safe for GPGPU-Sim to
-    // just ignore it.
-    if ( cudaDeviceMapHost == flags ) {
-		return g_last_cudaError = cudaSuccess;
-    } else {
-	    cuda_not_implemented(__my_func__,__LINE__);
-	    return g_last_cudaError = cudaErrorUnknown;
-    }
+cudaError_t CUDARTAPI cudaSetDeviceFlags(int flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  // This flag is implicitly always on (unless you are using the driver API). It
+  // is safe for GPGPU-Sim to just ignore it.
+  if (cudaDeviceMapHost == flags) {
+    return g_last_cudaError = cudaSuccess;
+  } else {
+    cuda_not_implemented(__my_func__, __LINE__);
+    return g_last_cudaError = cudaErrorUnknown;
+  }
 }
 
-
-cudaError_t CUDARTAPI cudaFuncGetAttributes(struct cudaFuncAttributes *attr, const char *hostFun )
-{
-    return cudaFuncGetAttributesInternal(attr, hostFun );
+cudaError_t CUDARTAPI cudaFuncGetAttributes(struct cudaFuncAttributes *attr,
+                                            const char *hostFun) {
+  return cudaFuncGetAttributesInternal(attr, hostFun);
 }
 
-cudaError_t CUDARTAPI cudaDriverGetVersion(int *driverVersion)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	*driverVersion = CUDART_VERSION;
-	return g_last_cudaError = cudaSuccess;
+cudaError_t CUDARTAPI cudaDriverGetVersion(int *driverVersion) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  *driverVersion = CUDART_VERSION;
+  return g_last_cudaError = cudaSuccess;
 }
 
-cudaError_t CUDARTAPI cudaRuntimeGetVersion(int *runtimeVersion)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	*runtimeVersion = CUDART_VERSION;
-	return g_last_cudaError = cudaSuccess;
+cudaError_t CUDARTAPI cudaRuntimeGetVersion(int *runtimeVersion) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  *runtimeVersion = CUDART_VERSION;
+  return g_last_cudaError = cudaSuccess;
 }
 
 #if CUDART_VERSION >= 3000
-__host__ cudaError_t CUDARTAPI cudaFuncSetCacheConfig(const char *func, enum cudaFuncCache  cacheConfig )
-{
-    return cudaFuncSetCacheConfigInternal(func, cacheConfig);
+__host__ cudaError_t CUDARTAPI
+cudaFuncSetCacheConfig(const char *func, enum cudaFuncCache cacheConfig) {
+  return cudaFuncSetCacheConfigInternal(func, cacheConfig);
 }
 
-//Jin: hack for cdp
-__host__ cudaError_t CUDARTAPI cudaDeviceSetLimit(enum cudaLimit limit, size_t value) {
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-    return g_last_cudaError = cudaSuccess;
+// Jin: hack for cdp
+__host__ cudaError_t CUDARTAPI cudaDeviceSetLimit(enum cudaLimit limit,
+                                                  size_t value) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  return g_last_cudaError = cudaSuccess;
 }
 
 //#if CUDART_VERSION >= 9000
-//__host__  cudaError_t cudaFuncSetAttribute ( const void* func, enum cudaFuncAttribute attr, int value ) {
+//__host__  cudaError_t cudaFuncSetAttribute ( const void* func, enum
+// cudaFuncAttribute attr, int value ) {
 
-	//ignore this Attribute for now, and the default is that carveout = cudaSharedmemCarveoutDefault;   //  (-1)
+// ignore this Attribute for now, and the default is that carveout =
+// cudaSharedmemCarveoutDefault;   //  (-1)
 //	return g_last_cudaError = cudaSuccess;
 //}
 
-
 #endif
 
 #endif
-
 
 #if CUDART_VERSION >= 9000
 /**
@@ -3705,15 +3822,18 @@ __host__ cudaError_t CUDARTAPI cudaDeviceSetLimit(enum cudaLimit limit, size_t v
  *
  * This function sets the attributes of a function specified via \p entry.
  * The parameter \p entry must be a pointer to a function that executes
- * on the device. The parameter specified by \p entry must be declared as a \p __global__
- * function. The enumeration defined by \p attr is set to the value defined by \p value
- * If the specified function does not exist, then ::cudaErrorInvalidDeviceFunction is returned.
- * If the specified attribute cannot be written, or if the value is incorrect, 
- * then ::cudaErrorInvalidValue is returned.
+ * on the device. The parameter specified by \p entry must be declared as a \p
+ * __global__ function. The enumeration defined by \p attr is set to the value
+ * defined by \p value If the specified function does not exist, then
+ * ::cudaErrorInvalidDeviceFunction is returned. If the specified attribute
+ * cannot be written, or if the value is incorrect, then ::cudaErrorInvalidValue
+ * is returned.
  *
  * Valid values for \p attr are:
- * ::cuFuncAttrMaxDynamicSharedMem - Maximum size of dynamic shared memory per block
- * ::cudaFuncAttributePreferredSharedMemoryCarveout - Preferred shared memory-L1 cache split ratio
+ * ::cuFuncAttrMaxDynamicSharedMem - Maximum size of dynamic shared memory per
+ * block
+ * ::cudaFuncAttributePreferredSharedMemoryCarveout - Preferred shared memory-L1
+ * cache split ratio
  *
  * \param entry - Function to get attributes of
  * \param attr  - Attribute to set
@@ -3726,216 +3846,235 @@ __host__ cudaError_t CUDARTAPI cudaDeviceSetLimit(enum cudaLimit limit, size_t v
  * ::cudaErrorInvalidValue
  * \notefnerr
  *
- * \ref ::cudaLaunchKernel(const T *func, dim3 gridDim, dim3 blockDim, void **args, size_t sharedMem, cudaStream_t stream) "cudaLaunchKernel (C++ API)",
- * \ref ::cudaFuncSetCacheConfig(T*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C++ API)",
- * \ref ::cudaFuncGetAttributes(struct cudaFuncAttributes*, const void*) "cudaFuncGetAttributes (C API)",
+ * \ref ::cudaLaunchKernel(const T *func, dim3 gridDim, dim3 blockDim, void
+ * **args, size_t sharedMem, cudaStream_t stream) "cudaLaunchKernel (C++ API)",
+ * \ref ::cudaFuncSetCacheConfig(T*, enum cudaFuncCache) "cudaFuncSetCacheConfig
+ * (C++ API)", \ref ::cudaFuncGetAttributes(struct cudaFuncAttributes*, const
+ * void*) "cudaFuncGetAttributes (C API)",
  * ::cudaSetDoubleForDevice,
  * ::cudaSetDoubleForHost,
  * \ref ::cudaSetupArgument(T, size_t) "cudaSetupArgument (C++ API)"
  */
-cudaError_t CUDARTAPI cudaFuncSetAttribute(const void *func, enum cudaFuncAttribute attr, int value)
-{
-   	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("GPGPU-Sim PTX: Execution warning: ignoring call to \"%s ( func=%p, attr=%d, value=%d )\"\n",
-        __my_func__, func, attr, value );
-    return g_last_cudaError = cudaSuccess;
+cudaError_t CUDARTAPI cudaFuncSetAttribute(const void *func,
+                                           enum cudaFuncAttribute attr,
+                                           int value) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf(
+      "GPGPU-Sim PTX: Execution warning: ignoring call to \"%s ( func=%p, "
+      "attr=%d, value=%d )\"\n",
+      __my_func__, func, attr, value);
+  return g_last_cudaError = cudaSuccess;
 }
 #endif
 
-cudaError_t CUDARTAPI cudaGLSetGLDevice(int device)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("GPGPU-Sim PTX: Execution warning: ignoring call to \"%s\"\n", __my_func__ );
-	return g_last_cudaError = cudaErrorUnknown;
+cudaError_t CUDARTAPI cudaGLSetGLDevice(int device) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("GPGPU-Sim PTX: Execution warning: ignoring call to \"%s\"\n",
+         __my_func__);
+  return g_last_cudaError = cudaErrorUnknown;
 }
 
-typedef void* HGPUNV;
+typedef void *HGPUNV;
 
-cudaError_t CUDARTAPI cudaWGLGetDevice(int *device, HGPUNV hGpu)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	cuda_not_implemented(__my_func__,__LINE__);
-	return g_last_cudaError = cudaErrorUnknown;
+cudaError_t CUDARTAPI cudaWGLGetDevice(int *device, HGPUNV hGpu) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
+  return g_last_cudaError = cudaErrorUnknown;
 }
 
-void CUDARTAPI __cudaMutexOperation(int lock)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	cuda_not_implemented(__my_func__,__LINE__);
+void CUDARTAPI __cudaMutexOperation(int lock) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
 }
 
-void  CUDARTAPI __cudaTextureFetch(const void *tex, void *index, int integer, void *val) 
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	cuda_not_implemented(__my_func__,__LINE__);
+void CUDARTAPI __cudaTextureFetch(const void *tex, void *index, int integer,
+                                  void *val) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
 }
-
 }
 
 namespace cuda_math {
 
-void CUDARTAPI __cudaMutexOperation(int lock)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	cuda_not_implemented(__my_func__,__LINE__);
+void CUDARTAPI __cudaMutexOperation(int lock) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
 }
 
-void  CUDARTAPI __cudaTextureFetch(const void *tex, void *index, int integer, void *val) 
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	cuda_not_implemented(__my_func__,__LINE__);
+void CUDARTAPI __cudaTextureFetch(const void *tex, void *index, int integer,
+                                  void *val) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
 }
 
-int CUDARTAPI __cudaSynchronizeThreads(void**, void*)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	//TODO This function should syncronize if we support Asyn kernel calls
-	return g_last_cudaError = cudaSuccess;
+int CUDARTAPI __cudaSynchronizeThreads(void **, void *) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  // TODO This function should syncronize if we support Asyn kernel calls
+  return g_last_cudaError = cudaSuccess;
 }
 
-}
+}  // namespace cuda_math
 
 ////////
 
 /// static functions
 
-int cuda_runtime_api::load_static_globals( symbol_table *symtab, unsigned min_gaddr, unsigned max_gaddr, gpgpu_t *gpu ) 
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf( "GPGPU-Sim PTX: loading globals with explicit initializers... \n" );
-	fflush(stdout);
-	int ng_bytes=0;
-	symbol_table::iterator g=symtab->global_iterator_begin();
+int cuda_runtime_api::load_static_globals(symbol_table *symtab,
+                                          unsigned min_gaddr,
+                                          unsigned max_gaddr, gpgpu_t *gpu) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("GPGPU-Sim PTX: loading globals with explicit initializers... \n");
+  fflush(stdout);
+  int ng_bytes = 0;
+  symbol_table::iterator g = symtab->global_iterator_begin();
 
-	for ( ; g!=symtab->global_iterator_end(); g++) {
-		symbol *global = *g;
-		if ( global->has_initializer() ) {
-			printf( "GPGPU-Sim PTX:     initializing '%s' ... ", global->name().c_str() );
-			unsigned addr=global->get_address();
-			const type_info *type = global->type();
-			type_info_key ti=type->get_key();
-			size_t size;
-			int t;
-			ti.type_decode(size,t);
-			int nbytes = size/8;
-			int offset=0;
-			std::list<operand_info> init_list = global->get_initializer();
-			for ( std::list<operand_info>::iterator i=init_list.begin(); i!=init_list.end(); i++ ) {
-				operand_info op = *i;
-				ptx_reg_t value = op.get_literal_value();
-				assert( (addr+offset+nbytes) < min_gaddr ); // min_gaddr is start of "heap" for cudaMalloc
-				gpu->get_global_memory()->write(addr+offset,nbytes,&value,NULL,NULL); // assuming little endian here
-				offset+=nbytes;
-				ng_bytes+=nbytes;
-			}
-			printf(" wrote %u bytes\n", offset );
-		}
-	}
-	printf( "GPGPU-Sim PTX: finished loading globals (%u bytes total).\n", ng_bytes );
-	fflush(stdout);
-	return ng_bytes;
+  for (; g != symtab->global_iterator_end(); g++) {
+    symbol *global = *g;
+    if (global->has_initializer()) {
+      printf("GPGPU-Sim PTX:     initializing '%s' ... ",
+             global->name().c_str());
+      unsigned addr = global->get_address();
+      const type_info *type = global->type();
+      type_info_key ti = type->get_key();
+      size_t size;
+      int t;
+      ti.type_decode(size, t);
+      int nbytes = size / 8;
+      int offset = 0;
+      std::list<operand_info> init_list = global->get_initializer();
+      for (std::list<operand_info>::iterator i = init_list.begin();
+           i != init_list.end(); i++) {
+        operand_info op = *i;
+        ptx_reg_t value = op.get_literal_value();
+        assert((addr + offset + nbytes) <
+               min_gaddr);  // min_gaddr is start of "heap" for cudaMalloc
+        gpu->get_global_memory()->write(addr + offset, nbytes, &value, NULL,
+                                        NULL);  // assuming little endian here
+        offset += nbytes;
+        ng_bytes += nbytes;
+      }
+      printf(" wrote %u bytes\n", offset);
+    }
+  }
+  printf("GPGPU-Sim PTX: finished loading globals (%u bytes total).\n",
+         ng_bytes);
+  fflush(stdout);
+  return ng_bytes;
 }
 
-int cuda_runtime_api::load_constants( symbol_table *symtab, addr_t min_gaddr, gpgpu_t *gpu ) 
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
+int cuda_runtime_api::load_constants(symbol_table *symtab, addr_t min_gaddr,
+                                     gpgpu_t *gpu) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("GPGPU-Sim PTX: loading constants with explicit initializers... ");
+  fflush(stdout);
+  int nc_bytes = 0;
+  symbol_table::iterator g = symtab->const_iterator_begin();
+
+  for (; g != symtab->const_iterator_end(); g++) {
+    symbol *constant = *g;
+    if (constant->is_const() && constant->has_initializer()) {
+      // get the constant element data size
+      int basic_type;
+      size_t num_bits;
+      constant->type()->get_key().type_decode(num_bits, basic_type);
+
+      std::list<operand_info> init_list = constant->get_initializer();
+      int nbytes_written = 0;
+      for (std::list<operand_info>::iterator i = init_list.begin();
+           i != init_list.end(); i++) {
+        operand_info op = *i;
+        ptx_reg_t value = op.get_literal_value();
+        int nbytes = num_bits / 8;
+        switch (op.get_type()) {
+          case int_t:
+            assert(nbytes >= 1);
+            break;
+          case float_op_t:
+            assert(nbytes == 4);
+            break;
+          case double_op_t:
+            assert(nbytes >= 4);
+            break;  // account for double DEMOTING
+          default:
+            abort();
+        }
+        unsigned addr = constant->get_address() + nbytes_written;
+        assert(addr + nbytes < min_gaddr);
+
+        gpu->get_global_memory()->write(
+            addr, nbytes, &value, NULL,
+            NULL);  // assume little endian (so u8 is the first byte in u32)
+        nc_bytes += nbytes;
+        nbytes_written += nbytes;
+      }
     }
-	printf( "GPGPU-Sim PTX: loading constants with explicit initializers... " );
-	fflush(stdout);
-	int nc_bytes = 0;
-	symbol_table::iterator g=symtab->const_iterator_begin();
-
-	for ( ; g!=symtab->const_iterator_end(); g++) {
-		symbol *constant = *g;
-		if ( constant->is_const() && constant->has_initializer() ) {
-
-			// get the constant element data size
-			int basic_type;
-			size_t num_bits;
-			constant->type()->get_key().type_decode(num_bits,basic_type);
-
-			std::list<operand_info> init_list = constant->get_initializer();
-			int nbytes_written = 0;
-			for ( std::list<operand_info>::iterator i=init_list.begin(); i!=init_list.end(); i++ ) {
-				operand_info op = *i;
-				ptx_reg_t value = op.get_literal_value();
-				int nbytes = num_bits/8;
-				switch ( op.get_type() ) {
-				case int_t: assert(nbytes >= 1); break;
-				case float_op_t: assert(nbytes == 4); break;
-				case double_op_t: assert(nbytes >= 4); break; // account for double DEMOTING
-				default:
-					abort();
-				}
-				unsigned addr=constant->get_address() + nbytes_written;
-				assert( addr+nbytes < min_gaddr );
-
-				gpu->get_global_memory()->write(addr,nbytes,&value,NULL,NULL); // assume little endian (so u8 is the first byte in u32)
-				nc_bytes+=nbytes;
-				nbytes_written += nbytes;
-			}
-		}
-	}
-	printf( " done.\n");
-	fflush(stdout);
-	return nc_bytes;
+  }
+  printf(" done.\n");
+  fflush(stdout);
+  return nc_bytes;
 }
 
-kernel_info_t * cuda_runtime_api::gpgpu_cuda_ptx_sim_init_grid( const char *hostFun,
-		gpgpu_ptx_sim_arg_list_t args,
-		struct dim3 gridDim,
-		struct dim3 blockDim,
-		CUctx_st* context )
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	function_info *entry = context->get_kernel(hostFun);
-	gpgpu_t* gpu= context->get_device()->get_gpgpu();
-	/*
-	Passing a snapshot of the GPU's current texture mapping to the kernel's info
-	as kernels should use texture bindings present at the time of their launch.
-	*/
-	kernel_info_t *result = new kernel_info_t(gridDim,blockDim,entry,gpu->getNameArrayMapping(),gpu->getNameInfoMapping());
-	if( entry == NULL ) {
-		printf("GPGPU-Sim PTX: ERROR launching kernel -- no PTX implementation found for %p\n", hostFun);
-		abort();
-	}
-	unsigned argcount=args.size();
-	unsigned argn=1;
-	for( gpgpu_ptx_sim_arg_list_t::iterator a = args.begin(); a != args.end(); a++ ) {
-		entry->add_param_data(argcount-argn,&(*a));
-		argn++;
-	}
+kernel_info_t *cuda_runtime_api::gpgpu_cuda_ptx_sim_init_grid(
+    const char *hostFun, gpgpu_ptx_sim_arg_list_t args, struct dim3 gridDim,
+    struct dim3 blockDim, CUctx_st *context) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  function_info *entry = context->get_kernel(hostFun);
+  gpgpu_t *gpu = context->get_device()->get_gpgpu();
+  /*
+  Passing a snapshot of the GPU's current texture mapping to the kernel's info
+  as kernels should use texture bindings present at the time of their launch.
+  */
+  kernel_info_t *result =
+      new kernel_info_t(gridDim, blockDim, entry, gpu->getNameArrayMapping(),
+                        gpu->getNameInfoMapping());
+  if (entry == NULL) {
+    printf(
+        "GPGPU-Sim PTX: ERROR launching kernel -- no PTX implementation found "
+        "for %p\n",
+        hostFun);
+    abort();
+  }
+  unsigned argcount = args.size();
+  unsigned argn = 1;
+  for (gpgpu_ptx_sim_arg_list_t::iterator a = args.begin(); a != args.end();
+       a++) {
+    entry->add_param_data(argcount - argn, &(*a));
+    argn++;
+  }
 
-	entry->finalize(result->get_param_memory());
-	gpgpu_ctx->func_sim->g_ptx_kernel_count++;
-	fflush(stdout);
-	
-	if(g_debug_execution >= 4){
-        entry->ptx_jit_config(g_mallocPtr_Size, result->get_param_memory(), (gpgpu_t *) context->get_device()->get_gpgpu(), gridDim, blockDim);
-    }
+  entry->finalize(result->get_param_memory());
+  gpgpu_ctx->func_sim->g_ptx_kernel_count++;
+  fflush(stdout);
 
-	return result;
+  if (g_debug_execution >= 4) {
+    entry->ptx_jit_config(g_mallocPtr_Size, result->get_param_memory(),
+                          (gpgpu_t *)context->get_device()->get_gpgpu(),
+                          gridDim, blockDim);
+  }
+
+  return result;
 }
 
 /*******************************************************************************
@@ -3945,2934 +4084,2912 @@ kernel_info_t * cuda_runtime_api::gpgpu_cuda_ptx_sim_init_grid( const char *host
  *******************************************************************************/
 //***extra api for pytorch***
 
-CUresult CUDAAPI cuGetErrorString(CUresult error, const char **pStr)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuGetErrorString(CUresult error, const char **pStr) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuGetErrorName(CUresult error, const char **pStr)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuGetErrorName(CUresult error, const char **pStr) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuInit(unsigned int Flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuInit(unsigned int Flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuDriverGetVersion(int *driverVersion)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-    cudaError_t e = cudaDriverGetVersion(driverVersion);
-    assert(e == cudaSuccess);
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuDriverGetVersion(int *driverVersion) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cudaError_t e = cudaDriverGetVersion(driverVersion);
+  assert(e == cudaSuccess);
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuDeviceGet(CUdevice *device, int ordinal)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	int deviceI = -1;
-	cudaError_t e = cudaGetDevice(&deviceI);
-    assert(e == cudaSuccess);
-	assert(deviceI!=-1);
-    *device = deviceI;
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuDeviceGet(CUdevice *device, int ordinal) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  int deviceI = -1;
+  cudaError_t e = cudaGetDevice(&deviceI);
+  assert(e == cudaSuccess);
+  assert(deviceI != -1);
+  *device = deviceI;
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuDeviceGetCount(int *count)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-    cudaError_t e = cudaGetDeviceCount(count);
-    assert(e == cudaSuccess);
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuDeviceGetCount(int *count) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cudaError_t e = cudaGetDeviceCount(count);
+  assert(e == cudaSuccess);
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuDeviceGetName(char *name, int len, CUdevice dev)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-    assert(len>=10);
-    strcpy(name, "GPGPU-Sim");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuDeviceGetName(char *name, int len, CUdevice dev) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  assert(len >= 10);
+  strcpy(name, "GPGPU-Sim");
+  return CUDA_SUCCESS;
 }
 
 #if CUDART_VERSION >= 3020
-CUresult CUDAAPI cuDeviceTotalMem(size_t *bytes, CUdevice dev)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-    *bytes = 20000000000;//dummy value
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuDeviceTotalMem(size_t *bytes, CUdevice dev) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  *bytes = 20000000000;  // dummy value
+  return CUDA_SUCCESS;
 }
 #endif /* CUDART_VERSION >= 3020 */
 #if (CUDART_VERSION > 5000)
-CUresult CUDAAPI cuDeviceGetAttribute(int *pi, CUdevice_attribute attrib, CUdevice dev)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-    cudaError_t e = cudaDeviceGetAttribute(pi, (cudaDeviceAttr)attrib, dev);
-    assert(e == cudaSuccess);
+CUresult CUDAAPI cuDeviceGetAttribute(int *pi, CUdevice_attribute attrib,
+                                      CUdevice dev) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cudaError_t e = cudaDeviceGetAttribute(pi, (cudaDeviceAttr)attrib, dev);
+  assert(e == cudaSuccess);
 
-	return CUDA_SUCCESS;
+  return CUDA_SUCCESS;
 }
 #endif
-CUresult CUDAAPI cuDeviceGetProperties(CUdevprop *prop, CUdevice dev)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuDeviceGetProperties(CUdevprop *prop, CUdevice dev) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuDeviceComputeCapability(int *major, int *minor, CUdevice dev)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuDeviceComputeCapability(int *major, int *minor,
+                                           CUdevice dev) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 #if CUDART_VERSION >= 7000
 
-CUresult CUDAAPI cuDevicePrimaryCtxRetain(CUcontext *pctx, CUdevice dev)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuDevicePrimaryCtxRetain(CUcontext *pctx, CUdevice dev) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuDevicePrimaryCtxRelease(CUdevice dev)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuDevicePrimaryCtxRelease(CUdevice dev) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuDevicePrimaryCtxSetFlags(CUdevice dev, unsigned int flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuDevicePrimaryCtxSetFlags(CUdevice dev, unsigned int flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuDevicePrimaryCtxGetState(CUdevice dev, unsigned int *flags, int *active)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuDevicePrimaryCtxGetState(CUdevice dev, unsigned int *flags,
+                                            int *active) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuDevicePrimaryCtxReset(CUdevice dev)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuDevicePrimaryCtxReset(CUdevice dev) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 #endif /* CUDART_VERSION >= 7000 */
 
 #if CUDART_VERSION >= 3020
-CUresult CUDAAPI cuCtxCreate(CUcontext *pctx, unsigned int flags, CUdevice dev)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuCtxCreate(CUcontext *pctx, unsigned int flags,
+                             CUdevice dev) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 #endif /* CUDART_VERSION >= 3020 */
 
 #if CUDART_VERSION >= 4000
-CUresult CUDAAPI cuCtxDestroy(CUcontext ctx)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuCtxDestroy(CUcontext ctx) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 #endif /* CUDART_VERSION >= 4000 */
 
 #if CUDART_VERSION >= 4000
-CUresult CUDAAPI cuCtxPushCurrent(CUcontext ctx)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuCtxPushCurrent(CUcontext ctx) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuCtxPopCurrent(CUcontext *pctx)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuCtxPopCurrent(CUcontext *pctx) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuCtxSetCurrent(CUcontext ctx)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuCtxSetCurrent(CUcontext ctx) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuCtxGetCurrent(CUcontext *pctx)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuCtxGetCurrent(CUcontext *pctx) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 #endif /* CUDART_VERSION >= 4000 */
 
-CUresult CUDAAPI cuCtxGetDevice(CUdevice *device)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuCtxGetDevice(CUdevice *device) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 #if CUDART_VERSION >= 7000
-CUresult CUDAAPI cuCtxGetFlags(unsigned int *flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuCtxGetFlags(unsigned int *flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 #endif /* CUDART_VERSION >= 7000 */
 
-CUresult CUDAAPI cuCtxSynchronize(void)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuCtxSynchronize(void) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuCtxSetLimit(CUlimit limit, size_t value)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuCtxSetLimit(CUlimit limit, size_t value) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuCtxGetLimit(size_t *pvalue, CUlimit limit)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuCtxGetLimit(size_t *pvalue, CUlimit limit) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuCtxGetCacheConfig(CUfunc_cache *pconfig)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuCtxGetCacheConfig(CUfunc_cache *pconfig) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuCtxSetCacheConfig(CUfunc_cache config)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuCtxSetCacheConfig(CUfunc_cache config) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 #if CUDART_VERSION >= 4020
-CUresult CUDAAPI cuCtxGetSharedMemConfig(CUsharedconfig *pConfig)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuCtxGetSharedMemConfig(CUsharedconfig *pConfig) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuCtxSetSharedMemConfig(CUsharedconfig config)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuCtxSetSharedMemConfig(CUsharedconfig config) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 #endif
 
-CUresult CUDAAPI cuCtxGetApiVersion(CUcontext ctx, unsigned int *version)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuCtxGetApiVersion(CUcontext ctx, unsigned int *version) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuCtxGetStreamPriorityRange(int *leastPriority, int *greatestPriority)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuCtxGetStreamPriorityRange(int *leastPriority,
+                                             int *greatestPriority) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuCtxAttach(CUcontext *pctx, unsigned int flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuCtxAttach(CUcontext *pctx, unsigned int flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuCtxDetach(CUcontext ctx)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuCtxDetach(CUcontext ctx) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuModuleLoad(CUmodule *module, const char *fname)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuModuleLoad(CUmodule *module, const char *fname) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuModuleLoadData(CUmodule *module, const void *image)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuModuleLoadData(CUmodule *module, const void *image) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuModuleLoadDataEx(CUmodule *module, const void *image, unsigned int numOptions, CUjit_option *options, void **optionValues)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuModuleLoadDataEx(CUmodule *module, const void *image,
+                                    unsigned int numOptions,
+                                    CUjit_option *options,
+                                    void **optionValues) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuModuleLoadFatBinary(CUmodule *module, const void *fatCubin)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuModuleLoadFatBinary(CUmodule *module, const void *fatCubin) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuModuleUnload(CUmodule hmod)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuModuleUnload(CUmodule hmod) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuModuleGetFunction(CUfunction *hfunc, CUmodule hmod, const char *name)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuModuleGetFunction(CUfunction *hfunc, CUmodule hmod,
+                                     const char *name) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 #if CUDART_VERSION >= 3020
-CUresult CUDAAPI cuModuleGetGlobal(CUdeviceptr *dptr, size_t *bytes, CUmodule hmod, const char *name)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuModuleGetGlobal(CUdeviceptr *dptr, size_t *bytes,
+                                   CUmodule hmod, const char *name) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 #endif /* CUDART_VERSION >= 3020 */
 
-CUresult CUDAAPI cuModuleGetTexRef(CUtexref *pTexRef, CUmodule hmod, const char *name)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuModuleGetTexRef(CUtexref *pTexRef, CUmodule hmod,
+                                   const char *name) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuModuleGetSurfRef(CUsurfref *pSurfRef, CUmodule hmod, const char *name)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuModuleGetSurfRef(CUsurfref *pSurfRef, CUmodule hmod,
+                                    const char *name) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 #if CUDART_VERSION >= 6050
 
-CUresult CUDAAPI
-cuLinkCreate(unsigned int numOptions, CUjit_option *options, void **optionValues, CUlinkState *stateOut)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-    //currently do not support options or multiple CUlinkStates
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuLinkCreate(unsigned int numOptions, CUjit_option *options,
+                              void **optionValues, CUlinkState *stateOut) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  // currently do not support options or multiple CUlinkStates
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI
-cuLinkAddData(CUlinkState state, CUjitInputType type, void *data, size_t size, const char *name,
-    unsigned int numOptions, CUjit_option *options, void **optionValues)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-    assert(type==CU_JIT_INPUT_PTX);
-	cuda_not_implemented(__my_func__,__LINE__);
-	return CUDA_ERROR_UNKNOWN;
+CUresult CUDAAPI cuLinkAddData(CUlinkState state, CUjitInputType type,
+                               void *data, size_t size, const char *name,
+                               unsigned int numOptions, CUjit_option *options,
+                               void **optionValues) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  assert(type == CU_JIT_INPUT_PTX);
+  cuda_not_implemented(__my_func__, __LINE__);
+  return CUDA_ERROR_UNKNOWN;
 }
 
-CUresult CUDAAPI
-cuLinkAddFile(CUlinkState state, CUjitInputType type, const char *path,
-    unsigned int numOptions, CUjit_option *options, void **optionValues)
-{
-    return cuLinkAddFileInternal(state, type, path,
-	    numOptions, options, optionValues);
+CUresult CUDAAPI cuLinkAddFile(CUlinkState state, CUjitInputType type,
+                               const char *path, unsigned int numOptions,
+                               CUjit_option *options, void **optionValues) {
+  return cuLinkAddFileInternal(state, type, path, numOptions, options,
+                               optionValues);
 }
 #endif
 
 #if CUDART_VERSION >= 5050
 
-CUresult CUDAAPI
-cuLinkComplete(CUlinkState state, void **cubinOut, size_t *sizeOut)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-    //all cuLink* function are implemented to block until completion so nothing to do here
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuLinkComplete(CUlinkState state, void **cubinOut,
+                                size_t *sizeOut) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  // all cuLink* function are implemented to block until completion so nothing
+  // to do here
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI
-cuLinkDestroy(CUlinkState state)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-    //currently do not support options or multiple CUlinkStates
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuLinkDestroy(CUlinkState state) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  // currently do not support options or multiple CUlinkStates
+  return CUDA_SUCCESS;
 }
 
 #endif /* CUDART_VERSION >= 5050 */
 
 #if CUDART_VERSION >= 3020
-CUresult CUDAAPI cuMemGetInfo(size_t *free, size_t *total)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemGetInfo(size_t *free, size_t *total) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemAlloc(CUdeviceptr *dptr, size_t bytesize)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemAlloc(CUdeviceptr *dptr, size_t bytesize) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemAllocPitch(CUdeviceptr *dptr, size_t *pPitch, size_t WidthInBytes, size_t Height, unsigned int ElementSizeBytes)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemAllocPitch(CUdeviceptr *dptr, size_t *pPitch,
+                                 size_t WidthInBytes, size_t Height,
+                                 unsigned int ElementSizeBytes) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemFree(CUdeviceptr dptr)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemFree(CUdeviceptr dptr) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemGetAddressRange(CUdeviceptr *pbase, size_t *psize, CUdeviceptr dptr)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemGetAddressRange(CUdeviceptr *pbase, size_t *psize,
+                                      CUdeviceptr dptr) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemAllocHost(void **pp, size_t bytesize)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemAllocHost(void **pp, size_t bytesize) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 #endif /* CUDART_VERSION >= 3020 */
 
-CUresult CUDAAPI cuMemFreeHost(void *p)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemFreeHost(void *p) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemHostAlloc(void **pp, size_t bytesize, unsigned int Flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemHostAlloc(void **pp, size_t bytesize,
+                                unsigned int Flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 #if CUDART_VERSION >= 3020
-CUresult CUDAAPI cuMemHostGetDevicePointer(CUdeviceptr *pdptr, void *p, unsigned int Flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemHostGetDevicePointer(CUdeviceptr *pdptr, void *p,
+                                           unsigned int Flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 #endif /* CUDART_VERSION >= 3020 */
 
-CUresult CUDAAPI cuMemHostGetFlags(unsigned int *pFlags, void *p)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemHostGetFlags(unsigned int *pFlags, void *p) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 #if CUDART_VERSION >= 6000
 
-CUresult CUDAAPI cuMemAllocManaged(CUdeviceptr *dptr, size_t bytesize, unsigned int flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemAllocManaged(CUdeviceptr *dptr, size_t bytesize,
+                                   unsigned int flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 #endif /* CUDART_VERSION >= 6000 */
 
 #if CUDART_VERSION >= 4010
 
-CUresult CUDAAPI cuDeviceGetByPCIBusId(CUdevice *dev, const char *pciBusId)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuDeviceGetByPCIBusId(CUdevice *dev, const char *pciBusId) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuDeviceGetPCIBusId(char *pciBusId, int len, CUdevice dev)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuDeviceGetPCIBusId(char *pciBusId, int len, CUdevice dev) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuIpcGetEventHandle(CUipcEventHandle *pHandle, CUevent event)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuIpcGetEventHandle(CUipcEventHandle *pHandle, CUevent event) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuIpcOpenEventHandle(CUevent *phEvent, CUipcEventHandle handle)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuIpcOpenEventHandle(CUevent *phEvent,
+                                      CUipcEventHandle handle) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuIpcGetMemHandle(CUipcMemHandle *pHandle, CUdeviceptr dptr)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuIpcGetMemHandle(CUipcMemHandle *pHandle, CUdeviceptr dptr) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuIpcOpenMemHandle(CUdeviceptr *pdptr, CUipcMemHandle handle, unsigned int Flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuIpcOpenMemHandle(CUdeviceptr *pdptr, CUipcMemHandle handle,
+                                    unsigned int Flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuIpcCloseMemHandle(CUdeviceptr dptr)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuIpcCloseMemHandle(CUdeviceptr dptr) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 #endif /* CUDART_VERSION >= 4010 */
 
 #if CUDART_VERSION >= 6050
-CUresult CUDAAPI cuMemHostRegister(void *p, size_t bytesize, unsigned int Flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemHostRegister(void *p, size_t bytesize,
+                                   unsigned int Flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-__host__ cudaError_t cudaHostRegister(void* ptr, size_t size, unsigned int flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return g_last_cudaError = cudaSuccess;
-}
-
-__host__ cudaError_t cudaProfilerStart ( )
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return g_last_cudaError = cudaSuccess;
+__host__ cudaError_t cudaHostRegister(void *ptr, size_t size,
+                                      unsigned int flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return g_last_cudaError = cudaSuccess;
 }
 
-__host__ cudaError_t cudaProfilerStop ( )
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return g_last_cudaError = cudaSuccess;
+__host__ cudaError_t cudaProfilerStart() {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return g_last_cudaError = cudaSuccess;
+}
+
+__host__ cudaError_t cudaProfilerStop() {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return g_last_cudaError = cudaSuccess;
 }
 
 #endif
 #if CUDART_VERSION >= 4000
 
-CUresult CUDAAPI cuMemHostUnregister(void *p)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemHostUnregister(void *p) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemcpy(CUdeviceptr dst, CUdeviceptr src, size_t ByteCount)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpy(CUdeviceptr dst, CUdeviceptr src, size_t ByteCount) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemcpyPeer(CUdeviceptr dstDevice, CUcontext dstContext, CUdeviceptr srcDevice, CUcontext srcContext, size_t ByteCount)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyPeer(CUdeviceptr dstDevice, CUcontext dstContext,
+                              CUdeviceptr srcDevice, CUcontext srcContext,
+                              size_t ByteCount) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 #endif /* CUDART_VERSION >= 4000 */
 
 #if CUDART_VERSION >= 3020
-CUresult CUDAAPI cuMemcpyHtoD(CUdeviceptr dstDevice, const void *srcHost, size_t ByteCount)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyHtoD(CUdeviceptr dstDevice, const void *srcHost,
+                              size_t ByteCount) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemcpyDtoH(void *dstHost, CUdeviceptr srcDevice, size_t ByteCount)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyDtoH(void *dstHost, CUdeviceptr srcDevice,
+                              size_t ByteCount) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemcpyDtoD(CUdeviceptr dstDevice, CUdeviceptr srcDevice, size_t ByteCount)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyDtoD(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
+                              size_t ByteCount) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemcpyDtoA(CUarray dstArray, size_t dstOffset, CUdeviceptr srcDevice, size_t ByteCount)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyDtoA(CUarray dstArray, size_t dstOffset,
+                              CUdeviceptr srcDevice, size_t ByteCount) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemcpyAtoD(CUdeviceptr dstDevice, CUarray srcArray, size_t srcOffset, size_t ByteCount)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyAtoD(CUdeviceptr dstDevice, CUarray srcArray,
+                              size_t srcOffset, size_t ByteCount) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemcpyHtoA(CUarray dstArray, size_t dstOffset, const void *srcHost, size_t ByteCount)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyHtoA(CUarray dstArray, size_t dstOffset,
+                              const void *srcHost, size_t ByteCount) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemcpyAtoH(void *dstHost, CUarray srcArray, size_t srcOffset, size_t ByteCount)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyAtoH(void *dstHost, CUarray srcArray, size_t srcOffset,
+                              size_t ByteCount) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemcpyAtoA(CUarray dstArray, size_t dstOffset, CUarray srcArray, size_t srcOffset, size_t ByteCount)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyAtoA(CUarray dstArray, size_t dstOffset,
+                              CUarray srcArray, size_t srcOffset,
+                              size_t ByteCount) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemcpy2D(const CUDA_MEMCPY2D *pCopy)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpy2D(const CUDA_MEMCPY2D *pCopy) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemcpy2DUnaligned(const CUDA_MEMCPY2D *pCopy)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpy2DUnaligned(const CUDA_MEMCPY2D *pCopy) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemcpy3D(const CUDA_MEMCPY3D *pCopy)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpy3D(const CUDA_MEMCPY3D *pCopy) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 #endif /* CUDART_VERSION >= 3020 */
 
 #if CUDART_VERSION >= 4000
-CUresult CUDAAPI cuMemcpy3DPeer(const CUDA_MEMCPY3D_PEER *pCopy)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpy3DPeer(const CUDA_MEMCPY3D_PEER *pCopy) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemcpyAsync(CUdeviceptr dst, CUdeviceptr src, size_t ByteCount, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyAsync(CUdeviceptr dst, CUdeviceptr src,
+                               size_t ByteCount, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemcpyPeerAsync(CUdeviceptr dstDevice, CUcontext dstContext, CUdeviceptr srcDevice, CUcontext srcContext, size_t ByteCount, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyPeerAsync(CUdeviceptr dstDevice, CUcontext dstContext,
+                                   CUdeviceptr srcDevice, CUcontext srcContext,
+                                   size_t ByteCount, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 #endif /* CUDART_VERSION >= 4000 */
 
 #if CUDART_VERSION >= 3020
-CUresult CUDAAPI cuMemcpyHtoDAsync(CUdeviceptr dstDevice, const void *srcHost, size_t ByteCount, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyHtoDAsync(CUdeviceptr dstDevice, const void *srcHost,
+                                   size_t ByteCount, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemcpyDtoHAsync(void *dstHost, CUdeviceptr srcDevice, size_t ByteCount, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyDtoHAsync(void *dstHost, CUdeviceptr srcDevice,
+                                   size_t ByteCount, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemcpyDtoDAsync(CUdeviceptr dstDevice, CUdeviceptr srcDevice, size_t ByteCount, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyDtoDAsync(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
+                                   size_t ByteCount, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemcpyHtoAAsync(CUarray dstArray, size_t dstOffset, const void *srcHost, size_t ByteCount, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyHtoAAsync(CUarray dstArray, size_t dstOffset,
+                                   const void *srcHost, size_t ByteCount,
+                                   CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemcpyAtoHAsync(void *dstHost, CUarray srcArray, size_t srcOffset, size_t ByteCount, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyAtoHAsync(void *dstHost, CUarray srcArray,
+                                   size_t srcOffset, size_t ByteCount,
+                                   CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemcpy2DAsync(const CUDA_MEMCPY2D *pCopy, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpy2DAsync(const CUDA_MEMCPY2D *pCopy, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemcpy3DAsync(const CUDA_MEMCPY3D *pCopy, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpy3DAsync(const CUDA_MEMCPY3D *pCopy, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 #endif /* CUDART_VERSION >= 3020 */
 
 #if CUDART_VERSION >= 4000
-CUresult CUDAAPI cuMemcpy3DPeerAsync(const CUDA_MEMCPY3D_PEER *pCopy, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpy3DPeerAsync(const CUDA_MEMCPY3D_PEER *pCopy,
+                                     CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 #endif /* CUDART_VERSION >= 4000 */
 
 #if CUDART_VERSION >= 3020
-CUresult CUDAAPI cuMemsetD8(CUdeviceptr dstDevice, unsigned char uc, size_t N)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemsetD8(CUdeviceptr dstDevice, unsigned char uc, size_t N) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemsetD16(CUdeviceptr dstDevice, unsigned short us, size_t N)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemsetD16(CUdeviceptr dstDevice, unsigned short us,
+                             size_t N) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemsetD32(CUdeviceptr dstDevice, unsigned int ui, size_t N)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemsetD32(CUdeviceptr dstDevice, unsigned int ui, size_t N) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemsetD2D8(CUdeviceptr dstDevice, size_t dstPitch, unsigned char uc, size_t Width, size_t Height)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemsetD2D8(CUdeviceptr dstDevice, size_t dstPitch,
+                              unsigned char uc, size_t Width, size_t Height) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemsetD2D16(CUdeviceptr dstDevice, size_t dstPitch, unsigned short us, size_t Width, size_t Height)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemsetD2D16(CUdeviceptr dstDevice, size_t dstPitch,
+                               unsigned short us, size_t Width, size_t Height) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemsetD2D32(CUdeviceptr dstDevice, size_t dstPitch, unsigned int ui, size_t Width, size_t Height)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemsetD2D32(CUdeviceptr dstDevice, size_t dstPitch,
+                               unsigned int ui, size_t Width, size_t Height) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemsetD8Async(CUdeviceptr dstDevice, unsigned char uc, size_t N, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemsetD8Async(CUdeviceptr dstDevice, unsigned char uc,
+                                 size_t N, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemsetD16Async(CUdeviceptr dstDevice, unsigned short us, size_t N, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemsetD16Async(CUdeviceptr dstDevice, unsigned short us,
+                                  size_t N, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemsetD32Async(CUdeviceptr dstDevice, unsigned int ui, size_t N, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemsetD32Async(CUdeviceptr dstDevice, unsigned int ui,
+                                  size_t N, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemsetD2D8Async(CUdeviceptr dstDevice, size_t dstPitch, unsigned char uc, size_t Width, size_t Height, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemsetD2D8Async(CUdeviceptr dstDevice, size_t dstPitch,
+                                   unsigned char uc, size_t Width,
+                                   size_t Height, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemsetD2D16Async(CUdeviceptr dstDevice, size_t dstPitch, unsigned short us, size_t Width, size_t Height, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemsetD2D16Async(CUdeviceptr dstDevice, size_t dstPitch,
+                                    unsigned short us, size_t Width,
+                                    size_t Height, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemsetD2D32Async(CUdeviceptr dstDevice, size_t dstPitch, unsigned int ui, size_t Width, size_t Height, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemsetD2D32Async(CUdeviceptr dstDevice, size_t dstPitch,
+                                    unsigned int ui, size_t Width,
+                                    size_t Height, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuArrayCreate(CUarray *pHandle, const CUDA_ARRAY_DESCRIPTOR *pAllocateArray)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuArrayCreate(CUarray *pHandle,
+                               const CUDA_ARRAY_DESCRIPTOR *pAllocateArray) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuArrayGetDescriptor(CUDA_ARRAY_DESCRIPTOR *pArrayDescriptor, CUarray hArray)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuArrayGetDescriptor(CUDA_ARRAY_DESCRIPTOR *pArrayDescriptor,
+                                      CUarray hArray) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 #endif /* CUDART_VERSION >= 3020 */
 
-
-CUresult CUDAAPI cuArrayDestroy(CUarray hArray)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuArrayDestroy(CUarray hArray) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 #if CUDART_VERSION >= 3020
-CUresult CUDAAPI cuArray3DCreate(CUarray *pHandle, const CUDA_ARRAY3D_DESCRIPTOR *pAllocateArray)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuArray3DCreate(
+    CUarray *pHandle, const CUDA_ARRAY3D_DESCRIPTOR *pAllocateArray) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuArray3DGetDescriptor(CUDA_ARRAY3D_DESCRIPTOR *pArrayDescriptor, CUarray hArray)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuArray3DGetDescriptor(
+    CUDA_ARRAY3D_DESCRIPTOR *pArrayDescriptor, CUarray hArray) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 #endif /* CUDART_VERSION >= 3020 */
 
 #if CUDART_VERSION >= 5000
 
-CUresult CUDAAPI cuMipmappedArrayCreate(CUmipmappedArray *pHandle, const CUDA_ARRAY3D_DESCRIPTOR *pMipmappedArrayDesc, unsigned int numMipmapLevels)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI
+cuMipmappedArrayCreate(CUmipmappedArray *pHandle,
+                       const CUDA_ARRAY3D_DESCRIPTOR *pMipmappedArrayDesc,
+                       unsigned int numMipmapLevels) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMipmappedArrayGetLevel(CUarray *pLevelArray, CUmipmappedArray hMipmappedArray, unsigned int level)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMipmappedArrayGetLevel(CUarray *pLevelArray,
+                                          CUmipmappedArray hMipmappedArray,
+                                          unsigned int level) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMipmappedArrayDestroy(CUmipmappedArray hMipmappedArray)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMipmappedArrayDestroy(CUmipmappedArray hMipmappedArray) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 #endif /* CUDART_VERSION >= 5000 */
 
 /** @} */ /* END CUDA_MEM */
 
-
 #if CUDART_VERSION >= 4000
-CUresult CUDAAPI cuPointerGetAttribute(void *data, CUpointer_attribute attribute, CUdeviceptr ptr)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuPointerGetAttribute(void *data,
+                                       CUpointer_attribute attribute,
+                                       CUdeviceptr ptr) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 #endif /* CUDART_VERSION >= 4000 */
 
 #if CUDART_VERSION >= 8000
-__host__ cudaError_t CUDARTAPI cudaCreateTextureObject ( cudaTextureObject_t* pTexObject, const cudaResourceDesc* pResDesc, const cudaTextureDesc* pTexDesc, const cudaResourceViewDesc* pResViewDesc )
-{
-         if(g_debug_execution >= 3){
-            announce_call(__my_func__);
-        }
-        cuda_not_implemented(__my_func__,__LINE__);
-        return g_last_cudaError = cudaSuccess;
-
+__host__ cudaError_t CUDARTAPI cudaCreateTextureObject(
+    cudaTextureObject_t *pTexObject, const cudaResourceDesc *pResDesc,
+    const cudaTextureDesc *pTexDesc, const cudaResourceViewDesc *pResViewDesc) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cuda_not_implemented(__my_func__, __LINE__);
+  return g_last_cudaError = cudaSuccess;
 }
 
-CUresult CUDAAPI cuMemPrefetchAsync(CUdeviceptr devPtr, size_t count, CUdevice dstDevice, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemPrefetchAsync(CUdeviceptr devPtr, size_t count,
+                                    CUdevice dstDevice, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemAdvise(CUdeviceptr devPtr, size_t count, CUmem_advise advice, CUdevice device)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemAdvise(CUdeviceptr devPtr, size_t count,
+                             CUmem_advise advice, CUdevice device) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemRangeGetAttribute(void *data, size_t dataSize, CUmem_range_attribute attribute, CUdeviceptr devPtr, size_t count)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemRangeGetAttribute(void *data, size_t dataSize,
+                                        CUmem_range_attribute attribute,
+                                        CUdeviceptr devPtr, size_t count) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuMemRangeGetAttributes(void **data, size_t *dataSizes, CUmem_range_attribute *attributes, size_t numAttributes, CUdeviceptr devPtr, size_t count)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemRangeGetAttributes(void **data, size_t *dataSizes,
+                                         CUmem_range_attribute *attributes,
+                                         size_t numAttributes,
+                                         CUdeviceptr devPtr, size_t count) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 #endif /* CUDART_VERSION >= 8000 */
 
 #if CUDART_VERSION >= 6000
-CUresult CUDAAPI cuPointerSetAttribute(const void *value, CUpointer_attribute attribute, CUdeviceptr ptr)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuPointerSetAttribute(const void *value,
+                                       CUpointer_attribute attribute,
+                                       CUdeviceptr ptr) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 #endif /* CUDART_VERSION >= 6000 */
 
 #if CUDART_VERSION >= 7000
-CUresult CUDAAPI cuPointerGetAttributes(unsigned int numAttributes, CUpointer_attribute *attributes, void **data, CUdeviceptr ptr)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuPointerGetAttributes(unsigned int numAttributes,
+                                        CUpointer_attribute *attributes,
+                                        void **data, CUdeviceptr ptr) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 #endif /* CUDART_VERSION >= 7000 */
 
 /** @} */ /* END CUDA_UNIFIED */
 
-
-CUresult CUDAAPI cuStreamCreate(CUstream *phStream, unsigned int Flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuStreamCreate(CUstream *phStream, unsigned int Flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuStreamCreateWithPriority(CUstream *phStream, unsigned int flags, int priority)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuStreamCreateWithPriority(CUstream *phStream,
+                                            unsigned int flags, int priority) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-
-CUresult CUDAAPI cuStreamGetPriority(CUstream hStream, int *priority)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuStreamGetPriority(CUstream hStream, int *priority) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuStreamGetFlags(CUstream hStream, unsigned int *flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuStreamGetFlags(CUstream hStream, unsigned int *flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-
-CUresult CUDAAPI cuStreamWaitEvent(CUstream hStream, CUevent hEvent, unsigned int Flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuStreamWaitEvent(CUstream hStream, CUevent hEvent,
+                                   unsigned int Flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuStreamAddCallback(CUstream hStream, CUstreamCallback callback, void *userData, unsigned int flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuStreamAddCallback(CUstream hStream,
+                                     CUstreamCallback callback, void *userData,
+                                     unsigned int flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 #if CUDART_VERSION >= 6000
 
-CUresult CUDAAPI cuStreamAttachMemAsync(CUstream hStream, CUdeviceptr dptr, size_t length, unsigned int flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuStreamAttachMemAsync(CUstream hStream, CUdeviceptr dptr,
+                                        size_t length, unsigned int flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 #endif /* CUDART_VERSION >= 6000 */
 
-CUresult CUDAAPI cuStreamQuery(CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuStreamQuery(CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuStreamSynchronize(CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuStreamSynchronize(CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 #if CUDART_VERSION >= 4000
-CUresult CUDAAPI cuStreamDestroy(CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuStreamDestroy(CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 #endif /* CUDART_VERSION >= 4000 */
 
 /** @} */ /* END CUDA_STREAM */
 
-
-
-CUresult CUDAAPI cuEventCreate(CUevent *phEvent, unsigned int Flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuEventCreate(CUevent *phEvent, unsigned int Flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuEventRecord(CUevent hEvent, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuEventRecord(CUevent hEvent, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuEventQuery(CUevent hEvent)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuEventQuery(CUevent hEvent) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuEventSynchronize(CUevent hEvent)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuEventSynchronize(CUevent hEvent) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 #if CUDART_VERSION >= 4000
-CUresult CUDAAPI cuEventDestroy(CUevent hEvent)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuEventDestroy(CUevent hEvent) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 #endif /* CUDART_VERSION >= 4000 */
 
-CUresult CUDAAPI cuEventElapsedTime(float *pMilliseconds, CUevent hStart, CUevent hEnd)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuEventElapsedTime(float *pMilliseconds, CUevent hStart,
+                                    CUevent hEnd) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 #if CUDART_VERSION >= 8000
-CUresult CUDAAPI cuStreamWaitValue32(CUstream stream, CUdeviceptr addr, cuuint32_t value, unsigned int flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuStreamWaitValue32(CUstream stream, CUdeviceptr addr,
+                                     cuuint32_t value, unsigned int flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuStreamWriteValue32(CUstream stream, CUdeviceptr addr, cuuint32_t value, unsigned int flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuStreamWriteValue32(CUstream stream, CUdeviceptr addr,
+                                      cuuint32_t value, unsigned int flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuStreamBatchMemOp(CUstream stream, unsigned int count, CUstreamBatchMemOpParams *paramArray, unsigned int flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuStreamBatchMemOp(CUstream stream, unsigned int count,
+                                    CUstreamBatchMemOpParams *paramArray,
+                                    unsigned int flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 #endif /* CUDART_VERSION >= 8000 */
 
 /** @} */ /* END CUDA_EVENT */
 
-
-CUresult CUDAAPI cuFuncGetAttribute(int *pi, CUfunction_attribute attrib, CUfunction hfunc)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuFuncGetAttribute(int *pi, CUfunction_attribute attrib,
+                                    CUfunction hfunc) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuFuncSetCacheConfig(CUfunction hfunc, CUfunc_cache config)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuFuncSetCacheConfig(CUfunction hfunc, CUfunc_cache config) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 #if CUDART_VERSION >= 4020
-CUresult CUDAAPI cuFuncSetSharedMemConfig(CUfunction hfunc, CUsharedconfig config)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuFuncSetSharedMemConfig(CUfunction hfunc,
+                                          CUsharedconfig config) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 #endif
 
 #if CUDART_VERSION >= 4000
-CUresult CUDAAPI cuLaunchKernel(CUfunction f,
-                                unsigned int gridDimX,
-                                unsigned int gridDimY,
-                                unsigned int gridDimZ,
-                                unsigned int blockDimX,
-                                unsigned int blockDimY,
+CUresult CUDAAPI cuLaunchKernel(CUfunction f, unsigned int gridDimX,
+                                unsigned int gridDimY, unsigned int gridDimZ,
+                                unsigned int blockDimX, unsigned int blockDimY,
                                 unsigned int blockDimZ,
-                                unsigned int sharedMemBytes,
-                                CUstream hStream,
-                                void **kernelParams,
-                                void **extra)
-{
-    return cuLaunchKernelInternal(f, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY, blockDimZ, sharedMemBytes, hStream, kernelParams, extra);
+                                unsigned int sharedMemBytes, CUstream hStream,
+                                void **kernelParams, void **extra) {
+  return cuLaunchKernelInternal(f, gridDimX, gridDimY, gridDimZ, blockDimX,
+                                blockDimY, blockDimZ, sharedMemBytes, hStream,
+                                kernelParams, extra);
 }
 #endif /* CUDART_VERSION >= 4000 */
 
 /** @} */ /* END CUDA_EXEC */
 
-
-CUresult CUDAAPI cuFuncSetBlockShape(CUfunction hfunc, int x, int y, int z)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuFuncSetBlockShape(CUfunction hfunc, int x, int y, int z) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuFuncSetSharedSize(CUfunction hfunc, unsigned int bytes)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuFuncSetSharedSize(CUfunction hfunc, unsigned int bytes) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuParamSetSize(CUfunction hfunc, unsigned int numbytes)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuParamSetSize(CUfunction hfunc, unsigned int numbytes) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuParamSeti(CUfunction hfunc, int offset, unsigned int value)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuParamSeti(CUfunction hfunc, int offset, unsigned int value) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuParamSetf(CUfunction hfunc, int offset, float value)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuParamSetf(CUfunction hfunc, int offset, float value) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuParamSetv(CUfunction hfunc, int offset, void *ptr, unsigned int numbytes)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuParamSetv(CUfunction hfunc, int offset, void *ptr,
+                             unsigned int numbytes) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuLaunch(CUfunction f)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuLaunch(CUfunction f) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuLaunchGrid(CUfunction f, int grid_width, int grid_height)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuLaunchGrid(CUfunction f, int grid_width, int grid_height) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuLaunchGridAsync(CUfunction f, int grid_width, int grid_height, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuLaunchGridAsync(CUfunction f, int grid_width,
+                                   int grid_height, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-
-CUresult CUDAAPI cuParamSetTexRef(CUfunction hfunc, int texunit, CUtexref hTexRef)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuParamSetTexRef(CUfunction hfunc, int texunit,
+                                  CUtexref hTexRef) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 /** @} */ /* END CUDA_EXEC_DEPRECATED */
 
-
 #if CUDART_VERSION >= 6050
 
-CUresult CUDAAPI cuOccupancyMaxActiveBlocksPerMultiprocessor(int *numBlocks, CUfunction func, int blockSize, size_t dynamicSMemSize)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuOccupancyMaxActiveBlocksPerMultiprocessor(
+    int *numBlocks, CUfunction func, int blockSize, size_t dynamicSMemSize) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(int *numBlocks, CUfunction func, int blockSize, size_t dynamicSMemSize, unsigned int flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(
+    int *numBlocks, CUfunction func, int blockSize, size_t dynamicSMemSize,
+    unsigned int flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuOccupancyMaxPotentialBlockSize(int *minGridSize, int *blockSize, CUfunction func, CUoccupancyB2DSize blockSizeToDynamicSMemSize, size_t dynamicSMemSize, int blockSizeLimit)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuOccupancyMaxPotentialBlockSize(
+    int *minGridSize, int *blockSize, CUfunction func,
+    CUoccupancyB2DSize blockSizeToDynamicSMemSize, size_t dynamicSMemSize,
+    int blockSizeLimit) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuOccupancyMaxPotentialBlockSizeWithFlags(int *minGridSize, int *blockSize, CUfunction func, CUoccupancyB2DSize blockSizeToDynamicSMemSize, size_t dynamicSMemSize, int blockSizeLimit, unsigned int flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuOccupancyMaxPotentialBlockSizeWithFlags(
+    int *minGridSize, int *blockSize, CUfunction func,
+    CUoccupancyB2DSize blockSizeToDynamicSMemSize, size_t dynamicSMemSize,
+    int blockSizeLimit, unsigned int flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 /** @} */ /* END CUDA_OCCUPANCY */
-#endif /* CUDART_VERSION >= 6050 */
+#endif    /* CUDART_VERSION >= 6050 */
 
-CUresult CUDAAPI cuTexRefSetArray(CUtexref hTexRef, CUarray hArray, unsigned int Flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuTexRefSetArray(CUtexref hTexRef, CUarray hArray,
+                                  unsigned int Flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuTexRefSetMipmappedArray(CUtexref hTexRef, CUmipmappedArray hMipmappedArray, unsigned int Flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-
-#if CUDART_VERSION >= 3020
-CUresult CUDAAPI cuTexRefSetAddress(size_t *ByteOffset, CUtexref hTexRef, CUdeviceptr dptr, size_t bytes)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-
-CUresult CUDAAPI cuTexRefSetAddress2D(CUtexref hTexRef, const CUDA_ARRAY_DESCRIPTOR *desc, CUdeviceptr dptr, size_t Pitch)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-#endif /* CUDART_VERSION >= 3020 */
-
-CUresult CUDAAPI cuTexRefSetFormat(CUtexref hTexRef, CUarray_format fmt, int NumPackedComponents)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-
-CUresult CUDAAPI cuTexRefSetAddressMode(CUtexref hTexRef, int dim, CUaddress_mode am)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-
-CUresult CUDAAPI cuTexRefSetFilterMode(CUtexref hTexRef, CUfilter_mode fm)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-
-CUresult CUDAAPI cuTexRefSetMipmapFilterMode(CUtexref hTexRef, CUfilter_mode fm)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-
-CUresult CUDAAPI cuTexRefSetMipmapLevelBias(CUtexref hTexRef, float bias)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-
-CUresult CUDAAPI cuTexRefSetMipmapLevelClamp(CUtexref hTexRef, float minMipmapLevelClamp, float maxMipmapLevelClamp)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-
-CUresult CUDAAPI cuTexRefSetMaxAnisotropy(CUtexref hTexRef, unsigned int maxAniso)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-
-CUresult CUDAAPI cuTexRefSetBorderColor(CUtexref hTexRef, float *pBorderColor)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-
-CUresult CUDAAPI cuTexRefSetFlags(CUtexref hTexRef, unsigned int Flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuTexRefSetMipmappedArray(CUtexref hTexRef,
+                                           CUmipmappedArray hMipmappedArray,
+                                           unsigned int Flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 #if CUDART_VERSION >= 3020
-CUresult CUDAAPI cuTexRefGetAddress(CUdeviceptr *pdptr, CUtexref hTexRef)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuTexRefSetAddress(size_t *ByteOffset, CUtexref hTexRef,
+                                    CUdeviceptr dptr, size_t bytes) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI cuTexRefSetAddress2D(CUtexref hTexRef,
+                                      const CUDA_ARRAY_DESCRIPTOR *desc,
+                                      CUdeviceptr dptr, size_t Pitch) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 #endif /* CUDART_VERSION >= 3020 */
 
-CUresult CUDAAPI cuTexRefGetArray(CUarray *phArray, CUtexref hTexRef)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuTexRefSetFormat(CUtexref hTexRef, CUarray_format fmt,
+                                   int NumPackedComponents) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuTexRefGetMipmappedArray(CUmipmappedArray *phMipmappedArray, CUtexref hTexRef)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuTexRefSetAddressMode(CUtexref hTexRef, int dim,
+                                        CUaddress_mode am) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuTexRefGetAddressMode(CUaddress_mode *pam, CUtexref hTexRef, int dim)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuTexRefSetFilterMode(CUtexref hTexRef, CUfilter_mode fm) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuTexRefGetFilterMode(CUfilter_mode *pfm, CUtexref hTexRef)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuTexRefSetMipmapFilterMode(CUtexref hTexRef,
+                                             CUfilter_mode fm) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuTexRefGetFormat(CUarray_format *pFormat, int *pNumChannels, CUtexref hTexRef)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuTexRefSetMipmapLevelBias(CUtexref hTexRef, float bias) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuTexRefGetMipmapFilterMode(CUfilter_mode *pfm, CUtexref hTexRef)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuTexRefSetMipmapLevelClamp(CUtexref hTexRef,
+                                             float minMipmapLevelClamp,
+                                             float maxMipmapLevelClamp) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuTexRefGetMipmapLevelBias(float *pbias, CUtexref hTexRef)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuTexRefSetMaxAnisotropy(CUtexref hTexRef,
+                                          unsigned int maxAniso) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuTexRefGetMipmapLevelClamp(float *pminMipmapLevelClamp, float *pmaxMipmapLevelClamp, CUtexref hTexRef)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuTexRefSetBorderColor(CUtexref hTexRef, float *pBorderColor) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuTexRefGetMaxAnisotropy(int *pmaxAniso, CUtexref hTexRef)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuTexRefSetFlags(CUtexref hTexRef, unsigned int Flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuTexRefGetBorderColor(float *pBorderColor, CUtexref hTexRef)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-} 
+#if CUDART_VERSION >= 3020
+CUresult CUDAAPI cuTexRefGetAddress(CUdeviceptr *pdptr, CUtexref hTexRef) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+#endif /* CUDART_VERSION >= 3020 */
 
-CUresult CUDAAPI cuTexRefGetFlags(unsigned int *pFlags, CUtexref hTexRef)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuTexRefGetArray(CUarray *phArray, CUtexref hTexRef) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuTexRefCreate(CUtexref *pTexRef)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuTexRefGetMipmappedArray(CUmipmappedArray *phMipmappedArray,
+                                           CUtexref hTexRef) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuTexRefDestroy(CUtexref hTexRef)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuTexRefGetAddressMode(CUaddress_mode *pam, CUtexref hTexRef,
+                                        int dim) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuSurfRefSetArray(CUsurfref hSurfRef, CUarray hArray, unsigned int Flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuTexRefGetFilterMode(CUfilter_mode *pfm, CUtexref hTexRef) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuSurfRefGetArray(CUarray *phArray, CUsurfref hSurfRef)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuTexRefGetFormat(CUarray_format *pFormat, int *pNumChannels,
+                                   CUtexref hTexRef) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI cuTexRefGetMipmapFilterMode(CUfilter_mode *pfm,
+                                             CUtexref hTexRef) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI cuTexRefGetMipmapLevelBias(float *pbias, CUtexref hTexRef) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI cuTexRefGetMipmapLevelClamp(float *pminMipmapLevelClamp,
+                                             float *pmaxMipmapLevelClamp,
+                                             CUtexref hTexRef) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI cuTexRefGetMaxAnisotropy(int *pmaxAniso, CUtexref hTexRef) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI cuTexRefGetBorderColor(float *pBorderColor, CUtexref hTexRef) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI cuTexRefGetFlags(unsigned int *pFlags, CUtexref hTexRef) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI cuTexRefCreate(CUtexref *pTexRef) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI cuTexRefDestroy(CUtexref hTexRef) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI cuSurfRefSetArray(CUsurfref hSurfRef, CUarray hArray,
+                                   unsigned int Flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+
+CUresult CUDAAPI cuSurfRefGetArray(CUarray *phArray, CUsurfref hSurfRef) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 /** @} */ /* END CUDA_SURFREF */
 
 #if CUDART_VERSION >= 5000
-CUresult CUDAAPI cuTexObjectCreate(CUtexObject *pTexObject, const CUDA_RESOURCE_DESC *pResDesc, const CUDA_TEXTURE_DESC *pTexDesc, const CUDA_RESOURCE_VIEW_DESC *pResViewDesc)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI
+cuTexObjectCreate(CUtexObject *pTexObject, const CUDA_RESOURCE_DESC *pResDesc,
+                  const CUDA_TEXTURE_DESC *pTexDesc,
+                  const CUDA_RESOURCE_VIEW_DESC *pResViewDesc) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuTexObjectDestroy(CUtexObject texObject)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuTexObjectDestroy(CUtexObject texObject) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuTexObjectGetResourceDesc(CUDA_RESOURCE_DESC *pResDesc, CUtexObject texObject)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuTexObjectGetResourceDesc(CUDA_RESOURCE_DESC *pResDesc,
+                                            CUtexObject texObject) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuTexObjectGetTextureDesc(CUDA_TEXTURE_DESC *pTexDesc, CUtexObject texObject)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuTexObjectGetTextureDesc(CUDA_TEXTURE_DESC *pTexDesc,
+                                           CUtexObject texObject) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuTexObjectGetResourceViewDesc(CUDA_RESOURCE_VIEW_DESC *pResViewDesc, CUtexObject texObject)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuTexObjectGetResourceViewDesc(
+    CUDA_RESOURCE_VIEW_DESC *pResViewDesc, CUtexObject texObject) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 /** @} */ /* END CUDA_TEXOBJECT */
 
-
-CUresult CUDAAPI cuSurfObjectCreate(CUsurfObject *pSurfObject, const CUDA_RESOURCE_DESC *pResDesc)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuSurfObjectCreate(CUsurfObject *pSurfObject,
+                                    const CUDA_RESOURCE_DESC *pResDesc) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuSurfObjectDestroy(CUsurfObject surfObject)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuSurfObjectDestroy(CUsurfObject surfObject) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuSurfObjectGetResourceDesc(CUDA_RESOURCE_DESC *pResDesc, CUsurfObject surfObject)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuSurfObjectGetResourceDesc(CUDA_RESOURCE_DESC *pResDesc,
+                                             CUsurfObject surfObject) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 #endif /* CUDART_VERSION >= 5000 */
 
 #if CUDART_VERSION >= 4000
-CUresult CUDAAPI cuDeviceCanAccessPeer(int *canAccessPeer, CUdevice dev, CUdevice peerDev)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuDeviceCanAccessPeer(int *canAccessPeer, CUdevice dev,
+                                       CUdevice peerDev) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuDeviceGetP2PAttribute(int* value, CUdevice_P2PAttribute attrib, CUdevice srcDevice, CUdevice dstDevice)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuDeviceGetP2PAttribute(int *value,
+                                         CUdevice_P2PAttribute attrib,
+                                         CUdevice srcDevice,
+                                         CUdevice dstDevice) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuCtxEnablePeerAccess(CUcontext peerContext, unsigned int Flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuCtxEnablePeerAccess(CUcontext peerContext,
+                                       unsigned int Flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuCtxDisablePeerAccess(CUcontext peerContext)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuCtxDisablePeerAccess(CUcontext peerContext) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 /** @} */ /* END CUDA_PEER_ACCESS */
-#endif /* CUDART_VERSION >= 4000 */
+#endif    /* CUDART_VERSION >= 4000 */
 
-
-CUresult CUDAAPI cuGraphicsUnregisterResource(CUgraphicsResource resource)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuGraphicsUnregisterResource(CUgraphicsResource resource) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuGraphicsSubResourceGetMappedArray(CUarray *pArray, CUgraphicsResource resource, unsigned int arrayIndex, unsigned int mipLevel)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuGraphicsSubResourceGetMappedArray(
+    CUarray *pArray, CUgraphicsResource resource, unsigned int arrayIndex,
+    unsigned int mipLevel) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 #if CUDART_VERSION >= 5000
 
-CUresult CUDAAPI cuGraphicsResourceGetMappedMipmappedArray(CUmipmappedArray *pMipmappedArray, CUgraphicsResource resource)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuGraphicsResourceGetMappedMipmappedArray(
+    CUmipmappedArray *pMipmappedArray, CUgraphicsResource resource) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 #endif /* CUDART_VERSION >= 5000 */
 
 #if CUDART_VERSION >= 3020
-CUresult CUDAAPI cuGraphicsResourceGetMappedPointer(CUdeviceptr *pDevPtr, size_t *pSize, CUgraphicsResource resource)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuGraphicsResourceGetMappedPointer(
+    CUdeviceptr *pDevPtr, size_t *pSize, CUgraphicsResource resource) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 #endif /* CUDART_VERSION >= 3020 */
 
-CUresult CUDAAPI cuGraphicsResourceSetMapFlags(CUgraphicsResource resource, unsigned int flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuGraphicsResourceSetMapFlags(CUgraphicsResource resource,
+                                               unsigned int flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuGraphicsMapResources(unsigned int count, CUgraphicsResource *resources, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuGraphicsMapResources(unsigned int count,
+                                        CUgraphicsResource *resources,
+                                        CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-CUresult CUDAAPI cuGraphicsUnmapResources(unsigned int count, CUgraphicsResource *resources, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuGraphicsUnmapResources(unsigned int count,
+                                          CUgraphicsResource *resources,
+                                          CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 /** @} */ /* END CUDA_GRAPHICS */
 
-CUresult CUDAAPI cuGetExportTable(const void **ppExportTable, const CUuuid *pExportTableId)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-    cudaError_t e = cudaGetExportTable(ppExportTable, pExportTableId);
-    assert(e == cudaSuccess);
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuGetExportTable(const void **ppExportTable,
+                                  const CUuuid *pExportTableId) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  cudaError_t e = cudaGetExportTable(ppExportTable, pExportTableId);
+  assert(e == cudaSuccess);
+  return CUDA_SUCCESS;
 }
 
+#if defined(CUDART_VERSION_INTERNAL) || \
+    (CUDART_VERSION >= 4000 && CUDART_VERSION < 6050)
+CUresult CUDAAPI cuMemHostRegister(void *p, size_t bytesize,
+                                   unsigned int Flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+#endif /* defined(CUDART_VERSION_INTERNAL) || (CUDART_VERSION >= 4000 && \
+          CUDART_VERSION < 6050) */
 
-#if defined(CUDART_VERSION_INTERNAL) || (CUDART_VERSION >= 4000 && CUDART_VERSION < 6050)
-CUresult CUDAAPI cuMemHostRegister(void *p, size_t bytesize, unsigned int Flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+#if defined(CUDART_VERSION_INTERNAL) || \
+    (CUDART_VERSION >= 5050 && CUDART_VERSION < 6050)
+CUresult CUDAAPI cuLinkCreate(unsigned int numOptions, CUjit_option *options,
+                              void **optionValues, CUlinkState *stateOut) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-#endif /* defined(CUDART_VERSION_INTERNAL) || (CUDART_VERSION >= 4000 && CUDART_VERSION < 6050) */
+CUresult CUDAAPI cuLinkAddData(CUlinkState state, CUjitInputType type,
+                               void *data, size_t size, const char *name,
+                               unsigned int numOptions, CUjit_option *options,
+                               void **optionValues) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+CUresult CUDAAPI cuLinkAddFile(CUlinkState state, CUjitInputType type,
+                               const char *path, unsigned int numOptions,
+                               CUjit_option *options, void **optionValues) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+#endif /* CUDART_VERSION_INTERNAL || (CUDART_VERSION >= 5050 && CUDART_VERSION \
+          < 6050) */
 
-#if defined(CUDART_VERSION_INTERNAL) || (CUDART_VERSION >= 5050 && CUDART_VERSION < 6050)
-CUresult CUDAAPI cuLinkCreate(unsigned int numOptions, CUjit_option *options, void **optionValues, CUlinkState *stateOut)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+#if defined(CUDART_VERSION_INTERNAL) || \
+    (CUDART_VERSION >= 3020 && CUDART_VERSION < 4010)
+CUresult CUDAAPI cuTexRefSetAddress2D_v2(CUtexref hTexRef,
+                                         const CUDA_ARRAY_DESCRIPTOR *desc,
+                                         CUdeviceptr dptr, size_t Pitch) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-CUresult CUDAAPI cuLinkAddData(CUlinkState state, CUjitInputType type, void *data, size_t size, const char *name,
-    unsigned int numOptions, CUjit_option *options, void **optionValues)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-CUresult CUDAAPI cuLinkAddFile(CUlinkState state, CUjitInputType type, const char *path,
-    unsigned int numOptions, CUjit_option *options, void **optionValues)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-#endif /* CUDART_VERSION_INTERNAL || (CUDART_VERSION >= 5050 && CUDART_VERSION < 6050) */
-
-#if defined(CUDART_VERSION_INTERNAL) || (CUDART_VERSION >= 3020 && CUDART_VERSION < 4010)
-CUresult CUDAAPI cuTexRefSetAddress2D_v2(CUtexref hTexRef, const CUDA_ARRAY_DESCRIPTOR *desc, CUdeviceptr dptr, size_t Pitch)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-#endif /* CUDART_VERSION_INTERNAL || (CUDART_VERSION >= 3020 && CUDART_VERSION < 4010) */
+#endif /* CUDART_VERSION_INTERNAL || (CUDART_VERSION >= 3020 && CUDART_VERSION \
+          < 4010) */
 
 #if defined(CUDART_VERSION_INTERNAL) || CUDART_VERSION < 4000
-CUresult CUDAAPI cuCtxDestroy(CUcontext ctx)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuCtxDestroy(CUcontext ctx) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-CUresult CUDAAPI cuCtxPopCurrent(CUcontext *pctx)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuCtxPopCurrent(CUcontext *pctx) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-CUresult CUDAAPI cuCtxPushCurrent(CUcontext ctx)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuCtxPushCurrent(CUcontext ctx) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-CUresult CUDAAPI cuStreamDestroy(CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuStreamDestroy(CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-CUresult CUDAAPI cuEventDestroy(CUevent hEvent)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuEventDestroy(CUevent hEvent) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 #endif /* CUDART_VERSION_INTERNAL || CUDART_VERSION < 4000 */
 
 #if defined(CUDART_VERSION_INTERNAL)
-    CUresult CUDAAPI cuMemcpyHtoD_v2(CUdeviceptr dstDevice, const void *srcHost, size_t ByteCount)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyHtoD_v2(CUdeviceptr dstDevice, const void *srcHost,
+                                 size_t ByteCount) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice, size_t ByteCount)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
+                                 size_t ByteCount) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemcpyDtoD_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice, size_t ByteCount)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyDtoD_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
+                                 size_t ByteCount) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemcpyDtoA_v2(CUarray dstArray, size_t dstOffset, CUdeviceptr srcDevice, size_t ByteCount)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyDtoA_v2(CUarray dstArray, size_t dstOffset,
+                                 CUdeviceptr srcDevice, size_t ByteCount) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemcpyAtoD_v2(CUdeviceptr dstDevice, CUarray srcArray, size_t srcOffset, size_t ByteCount)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyAtoD_v2(CUdeviceptr dstDevice, CUarray srcArray,
+                                 size_t srcOffset, size_t ByteCount) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemcpyHtoA_v2(CUarray dstArray, size_t dstOffset, const void *srcHost, size_t ByteCount)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyHtoA_v2(CUarray dstArray, size_t dstOffset,
+                                 const void *srcHost, size_t ByteCount) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemcpyAtoH_v2(void *dstHost, CUarray srcArray, size_t srcOffset, size_t ByteCount)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyAtoH_v2(void *dstHost, CUarray srcArray,
+                                 size_t srcOffset, size_t ByteCount) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemcpyAtoA_v2(CUarray dstArray, size_t dstOffset, CUarray srcArray, size_t srcOffset, size_t ByteCount)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyAtoA_v2(CUarray dstArray, size_t dstOffset,
+                                 CUarray srcArray, size_t srcOffset,
+                                 size_t ByteCount) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemcpyHtoAAsync_v2(CUarray dstArray, size_t dstOffset, const void *srcHost, size_t ByteCount, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyHtoAAsync_v2(CUarray dstArray, size_t dstOffset,
+                                      const void *srcHost, size_t ByteCount,
+                                      CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemcpyAtoHAsync_v2(void *dstHost, CUarray srcArray, size_t srcOffset, size_t ByteCount, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyAtoHAsync_v2(void *dstHost, CUarray srcArray,
+                                      size_t srcOffset, size_t ByteCount,
+                                      CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemcpy2D_v2(const CUDA_MEMCPY2D *pCopy)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpy2D_v2(const CUDA_MEMCPY2D *pCopy) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemcpy2DUnaligned_v2(const CUDA_MEMCPY2D *pCopy)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpy2DUnaligned_v2(const CUDA_MEMCPY2D *pCopy) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemcpy3D_v2(const CUDA_MEMCPY3D *pCopy)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpy3D_v2(const CUDA_MEMCPY3D *pCopy) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemcpyHtoDAsync_v2(CUdeviceptr dstDevice, const void *srcHost, size_t ByteCount, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyHtoDAsync_v2(CUdeviceptr dstDevice,
+                                      const void *srcHost, size_t ByteCount,
+                                      CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemcpyDtoHAsync_v2(void *dstHost, CUdeviceptr srcDevice, size_t ByteCount, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyDtoHAsync_v2(void *dstHost, CUdeviceptr srcDevice,
+                                      size_t ByteCount, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemcpyDtoDAsync_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice, size_t ByteCount, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyDtoDAsync_v2(CUdeviceptr dstDevice,
+                                      CUdeviceptr srcDevice, size_t ByteCount,
+                                      CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemcpy2DAsync_v2(const CUDA_MEMCPY2D *pCopy, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpy2DAsync_v2(const CUDA_MEMCPY2D *pCopy,
+                                    CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemcpy3DAsync_v2(const CUDA_MEMCPY3D *pCopy, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpy3DAsync_v2(const CUDA_MEMCPY3D *pCopy,
+                                    CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemsetD8_v2(CUdeviceptr dstDevice, unsigned char uc, size_t N)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemsetD8_v2(CUdeviceptr dstDevice, unsigned char uc,
+                               size_t N) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemsetD16_v2(CUdeviceptr dstDevice, unsigned short us, size_t N)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemsetD16_v2(CUdeviceptr dstDevice, unsigned short us,
+                                size_t N) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemsetD32_v2(CUdeviceptr dstDevice, unsigned int ui, size_t N)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemsetD32_v2(CUdeviceptr dstDevice, unsigned int ui,
+                                size_t N) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemsetD2D8_v2(CUdeviceptr dstDevice, size_t dstPitch, unsigned char uc, size_t Width, size_t Height)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemsetD2D8_v2(CUdeviceptr dstDevice, size_t dstPitch,
+                                 unsigned char uc, size_t Width,
+                                 size_t Height) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemsetD2D16_v2(CUdeviceptr dstDevice, size_t dstPitch, unsigned short us, size_t Width, size_t Height)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemsetD2D16_v2(CUdeviceptr dstDevice, size_t dstPitch,
+                                  unsigned short us, size_t Width,
+                                  size_t Height) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemsetD2D32_v2(CUdeviceptr dstDevice, size_t dstPitch, unsigned int ui, size_t Width, size_t Height)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemsetD2D32_v2(CUdeviceptr dstDevice, size_t dstPitch,
+                                  unsigned int ui, size_t Width,
+                                  size_t Height) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemcpy(CUdeviceptr dst, CUdeviceptr src, size_t ByteCount)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpy(CUdeviceptr dst, CUdeviceptr src, size_t ByteCount) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemcpyAsync(CUdeviceptr dst, CUdeviceptr src, size_t ByteCount, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyAsync(CUdeviceptr dst, CUdeviceptr src,
+                               size_t ByteCount, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemcpyPeer(CUdeviceptr dstDevice, CUcontext dstContext, CUdeviceptr srcDevice, CUcontext srcContext, size_t ByteCount)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyPeer(CUdeviceptr dstDevice, CUcontext dstContext,
+                              CUdeviceptr srcDevice, CUcontext srcContext,
+                              size_t ByteCount) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemcpyPeerAsync(CUdeviceptr dstDevice, CUcontext dstContext, CUdeviceptr srcDevice, CUcontext srcContext, size_t ByteCount, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpyPeerAsync(CUdeviceptr dstDevice, CUcontext dstContext,
+                                   CUdeviceptr srcDevice, CUcontext srcContext,
+                                   size_t ByteCount, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemcpy3DPeer(const CUDA_MEMCPY3D_PEER *pCopy)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpy3DPeer(const CUDA_MEMCPY3D_PEER *pCopy) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemcpy3DPeerAsync(const CUDA_MEMCPY3D_PEER *pCopy, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-
-    CUresult CUDAAPI cuMemsetD8Async(CUdeviceptr dstDevice, unsigned char uc, size_t N, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-    CUresult CUDAAPI cuMemsetD16Async(CUdeviceptr dstDevice, unsigned short us, size_t N, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-    CUresult CUDAAPI cuMemsetD32Async(CUdeviceptr dstDevice, unsigned int ui, size_t N, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-    CUresult CUDAAPI cuMemsetD2D8Async(CUdeviceptr dstDevice, size_t dstPitch, unsigned char uc, size_t Width, size_t Height, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-    CUresult CUDAAPI cuMemsetD2D16Async(CUdeviceptr dstDevice, size_t dstPitch, unsigned short us, size_t Width, size_t Height, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-    CUresult CUDAAPI cuMemsetD2D32Async(CUdeviceptr dstDevice, size_t dstPitch, unsigned int ui, size_t Width, size_t Height, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemcpy3DPeerAsync(const CUDA_MEMCPY3D_PEER *pCopy,
+                                     CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-    CUresult CUDAAPI cuStreamGetPriority(CUstream hStream, int *priority)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemsetD8Async(CUdeviceptr dstDevice, unsigned char uc,
+                                 size_t N, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuStreamGetFlags(CUstream hStream, unsigned int *flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemsetD16Async(CUdeviceptr dstDevice, unsigned short us,
+                                  size_t N, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuStreamWaitEvent(CUstream hStream, CUevent hEvent, unsigned int Flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemsetD32Async(CUdeviceptr dstDevice, unsigned int ui,
+                                  size_t N, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuStreamAddCallback(CUstream hStream, CUstreamCallback callback, void *userData, unsigned int flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemsetD2D8Async(CUdeviceptr dstDevice, size_t dstPitch,
+                                   unsigned char uc, size_t Width,
+                                   size_t Height, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuStreamAttachMemAsync(CUstream hStream, CUdeviceptr dptr, size_t length, unsigned int flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemsetD2D16Async(CUdeviceptr dstDevice, size_t dstPitch,
+                                    unsigned short us, size_t Width,
+                                    size_t Height, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuStreamQuery(CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuMemsetD2D32Async(CUdeviceptr dstDevice, size_t dstPitch,
+                                    unsigned int ui, size_t Width,
+                                    size_t Height, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuStreamSynchronize(CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+
+CUresult CUDAAPI cuStreamGetPriority(CUstream hStream, int *priority) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuEventRecord(CUevent hEvent, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuStreamGetFlags(CUstream hStream, unsigned int *flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuLaunchKernel(CUfunction f, unsigned int gridDimX, unsigned int gridDimY, unsigned int gridDimZ, unsigned int blockDimX, unsigned int blockDimY, unsigned int blockDimZ, unsigned int sharedMemBytes, CUstream hStream, void **kernelParams, void **extra)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuStreamWaitEvent(CUstream hStream, CUevent hEvent,
+                                   unsigned int Flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuGraphicsMapResources(unsigned int count, CUgraphicsResource *resources, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuStreamAddCallback(CUstream hStream,
+                                     CUstreamCallback callback, void *userData,
+                                     unsigned int flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuGraphicsUnmapResources(unsigned int count, CUgraphicsResource *resources, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuStreamAttachMemAsync(CUstream hStream, CUdeviceptr dptr,
+                                        size_t length, unsigned int flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuMemPrefetchAsync(CUdeviceptr devPtr, size_t count, CUdevice dstDevice, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuStreamQuery(CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuStreamWriteValue32(CUstream stream, CUdeviceptr addr, cuuint32_t value, unsigned int flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuStreamSynchronize(CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuStreamWaitValue32(CUstream stream, CUdeviceptr addr, cuuint32_t value, unsigned int flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuEventRecord(CUevent hEvent, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    CUresult CUDAAPI cuStreamBatchMemOp(CUstream stream, unsigned int count, CUstreamBatchMemOpParams *paramArray, unsigned int flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult CUDAAPI cuLaunchKernel(CUfunction f, unsigned int gridDimX,
+                                unsigned int gridDimY, unsigned int gridDimZ,
+                                unsigned int blockDimX, unsigned int blockDimY,
+                                unsigned int blockDimZ,
+                                unsigned int sharedMemBytes, CUstream hStream,
+                                void **kernelParams, void **extra) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+CUresult CUDAAPI cuGraphicsMapResources(unsigned int count,
+                                        CUgraphicsResource *resources,
+                                        CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+CUresult CUDAAPI cuGraphicsUnmapResources(unsigned int count,
+                                          CUgraphicsResource *resources,
+                                          CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+CUresult CUDAAPI cuMemPrefetchAsync(CUdeviceptr devPtr, size_t count,
+                                    CUdevice dstDevice, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+CUresult CUDAAPI cuStreamWriteValue32(CUstream stream, CUdeviceptr addr,
+                                      cuuint32_t value, unsigned int flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+CUresult CUDAAPI cuStreamWaitValue32(CUstream stream, CUdeviceptr addr,
+                                     cuuint32_t value, unsigned int flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+CUresult CUDAAPI cuStreamBatchMemOp(CUstream stream, unsigned int count,
+                                    CUstreamBatchMemOpParams *paramArray,
+                                    unsigned int flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 #endif
 
-CUresult cuProfilerInitialize ( const char* configFile, const char* outputFile, CUoutput_mode outputMode )
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult cuProfilerInitialize(const char *configFile, const char *outputFile,
+                              CUoutput_mode outputMode) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-CUresult cuProfilerStart ( void )
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult cuProfilerStart(void) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-CUresult cuProfilerStop ( void )
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+CUresult cuProfilerStop(void) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 //_ptds
 
-extern "C" CUresult CUDAAPI cuMemcpy_ptds(CUdeviceptr dst, CUdeviceptr src, size_t ByteCount)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI cuMemcpy_ptds(CUdeviceptr dst, CUdeviceptr src,
+                                          size_t ByteCount) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-extern "C" CUresult CUDAAPI cuMemcpyPeer_ptds(CUdeviceptr dstDevice, CUcontext dstContext, CUdeviceptr srcDevice, CUcontext srcContext, size_t ByteCount)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI cuMemcpyPeer_ptds(CUdeviceptr dstDevice,
+                                              CUcontext dstContext,
+                                              CUdeviceptr srcDevice,
+                                              CUcontext srcContext,
+                                              size_t ByteCount) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-    extern "C" CUresult CUDAAPI cuMemcpyHtoD_v2_ptds(CUdeviceptr dstDevice, const void *srcHost, size_t ByteCount)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI cuMemcpyHtoD_v2_ptds(CUdeviceptr dstDevice,
+                                                 const void *srcHost,
+                                                 size_t ByteCount) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    extern "C" CUresult CUDAAPI cuMemcpyDtoH_v2_ptds(void *dstHost, CUdeviceptr srcDevice, size_t ByteCount)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI cuMemcpyDtoH_v2_ptds(void *dstHost,
+                                                 CUdeviceptr srcDevice,
+                                                 size_t ByteCount) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    extern "C" CUresult CUDAAPI cuMemcpyDtoD_v2_ptds(CUdeviceptr dstDevice, CUdeviceptr srcDevice, size_t ByteCount)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI cuMemcpyDtoD_v2_ptds(CUdeviceptr dstDevice,
+                                                 CUdeviceptr srcDevice,
+                                                 size_t ByteCount) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    extern "C" CUresult CUDAAPI cuMemcpy2DUnaligned_v2_ptds(const CUDA_MEMCPY2D *pCopy)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI
+cuMemcpy2DUnaligned_v2_ptds(const CUDA_MEMCPY2D *pCopy) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    extern "C" CUresult CUDAAPI cuMemcpy3D_v2_ptds(const CUDA_MEMCPY3D *pCopy)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI cuMemcpy3D_v2_ptds(const CUDA_MEMCPY3D *pCopy) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    extern "C" CUresult CUDAAPI cuMemcpy3DPeer_ptds(const CUDA_MEMCPY3D_PEER *pCopy)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI
+cuMemcpy3DPeer_ptds(const CUDA_MEMCPY3D_PEER *pCopy) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-extern "C" CUresult CUDAAPI cuMemsetD8_v2_ptds(CUdeviceptr dstDevice, unsigned char uc, unsigned int N)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI cuMemsetD8_v2_ptds(CUdeviceptr dstDevice,
+                                               unsigned char uc,
+                                               unsigned int N) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-extern "C" CUresult CUDAAPI cuMemsetD16_v2_ptds(CUdeviceptr dstDevice, unsigned short us, unsigned int N)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI cuMemsetD16_v2_ptds(CUdeviceptr dstDevice,
+                                                unsigned short us,
+                                                unsigned int N) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-extern "C" CUresult CUDAAPI cuMemsetD32_v2_ptds(CUdeviceptr dstDevice, unsigned int ui, unsigned int N)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI cuMemsetD32_v2_ptds(CUdeviceptr dstDevice,
+                                                unsigned int ui,
+                                                unsigned int N) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-extern "C" CUresult CUDAAPI cuMemsetD2D8_v2_ptds(CUdeviceptr dstDevice, unsigned int dstPitch, unsigned char uc, unsigned int Width, unsigned int Height)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI cuMemsetD2D8_v2_ptds(CUdeviceptr dstDevice,
+                                                 unsigned int dstPitch,
+                                                 unsigned char uc,
+                                                 unsigned int Width,
+                                                 unsigned int Height) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-extern "C" CUresult CUDAAPI cuMemsetD2D16_v2_ptds(CUdeviceptr dstDevice, unsigned int dstPitch, unsigned short us, unsigned int Width, unsigned int Height)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI cuMemsetD2D16_v2_ptds(CUdeviceptr dstDevice,
+                                                  unsigned int dstPitch,
+                                                  unsigned short us,
+                                                  unsigned int Width,
+                                                  unsigned int Height) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-extern "C" CUresult CUDAAPI cuMemsetD2D32_v2_ptds(CUdeviceptr dstDevice, unsigned int dstPitch, unsigned int ui, unsigned int Width, unsigned int Height)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI cuMemsetD2D32_v2_ptds(CUdeviceptr dstDevice,
+                                                  unsigned int dstPitch,
+                                                  unsigned int ui,
+                                                  unsigned int Width,
+                                                  unsigned int Height) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
 //_ptsz
-extern "C" CUresult CUDAAPI cuMemcpy3DPeer_ptsz(const CUDA_MEMCPY3D_PEER *pCopy)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI
+cuMemcpy3DPeer_ptsz(const CUDA_MEMCPY3D_PEER *pCopy) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-extern "C" CUresult CUDAAPI cuMemcpyAsync_ptsz(CUdeviceptr dst, CUdeviceptr src, size_t ByteCount, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI cuMemcpyAsync_ptsz(CUdeviceptr dst, CUdeviceptr src,
+                                               size_t ByteCount,
+                                               CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-extern "C" CUresult CUDAAPI cuMemcpyPeerAsync_ptsz(CUdeviceptr dstDevice, CUcontext dstContext, CUdeviceptr srcDevice, CUcontext srcContext, size_t ByteCount, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI cuMemcpyPeerAsync_ptsz(
+    CUdeviceptr dstDevice, CUcontext dstContext, CUdeviceptr srcDevice,
+    CUcontext srcContext, size_t ByteCount, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    extern "C" CUresult CUDAAPI cuMemcpyHtoAAsync_v2_ptsz(CUarray dstArray, size_t dstOffset, const void *srcHost, size_t ByteCount, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI cuMemcpyHtoAAsync_v2_ptsz(CUarray dstArray,
+                                                      size_t dstOffset,
+                                                      const void *srcHost,
+                                                      size_t ByteCount,
+                                                      CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    extern "C" CUresult CUDAAPI cuMemcpyAtoHAsync_v2_ptsz(void *dstHost, CUarray srcArray, size_t srcOffset, size_t ByteCount, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI cuMemcpyAtoHAsync_v2_ptsz(void *dstHost,
+                                                      CUarray srcArray,
+                                                      size_t srcOffset,
+                                                      size_t ByteCount,
+                                                      CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    extern "C" CUresult CUDAAPI cuMemcpyHtoDAsync_v2_ptsz(CUdeviceptr dstDevice, const void *srcHost, size_t ByteCount, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI cuMemcpyHtoDAsync_v2_ptsz(CUdeviceptr dstDevice,
+                                                      const void *srcHost,
+                                                      size_t ByteCount,
+                                                      CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    extern "C" CUresult CUDAAPI cuMemcpyDtoHAsync_v2_ptsz(void *dstHost, CUdeviceptr srcDevice, size_t ByteCount, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI cuMemcpyDtoHAsync_v2_ptsz(void *dstHost,
+                                                      CUdeviceptr srcDevice,
+                                                      size_t ByteCount,
+                                                      CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    extern "C" CUresult CUDAAPI cuMemcpyDtoDAsync_v2_ptsz(CUdeviceptr dstDevice, CUdeviceptr srcDevice, size_t ByteCount, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI cuMemcpyDtoDAsync_v2_ptsz(CUdeviceptr dstDevice,
+                                                      CUdeviceptr srcDevice,
+                                                      size_t ByteCount,
+                                                      CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    extern "C" CUresult CUDAAPI cuMemcpy2DAsync_v2_ptsz(const CUDA_MEMCPY2D *pCopy, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI cuMemcpy2DAsync_v2_ptsz(const CUDA_MEMCPY2D *pCopy,
+                                                    CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    extern "C" CUresult CUDAAPI cuMemcpy3DAsync_v2_ptsz(const CUDA_MEMCPY3D *pCopy, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI cuMemcpy3DAsync_v2_ptsz(const CUDA_MEMCPY3D *pCopy,
+                                                    CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
-    extern "C" CUresult CUDAAPI cuMemcpy3DPeerAsync_ptsz(const CUDA_MEMCPY3D_PEER *pCopy, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-
-    extern "C" CUresult CUDAAPI cuMemsetD8Async_ptsz(CUdeviceptr dstDevice, unsigned char uc, size_t N, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-    extern "C" CUresult CUDAAPI cuMemsetD2D8Async_ptsz(CUdeviceptr dstDevice, size_t dstPitch, unsigned char uc, size_t Width, size_t Height, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-    extern "C" CUresult CUDAAPI cuLaunchKernel_ptsz(CUfunction f, unsigned int gridDimX, unsigned int gridDimY, unsigned int gridDimZ, unsigned int blockDimX, unsigned int blockDimY, unsigned int blockDimZ, unsigned int sharedMemBytes, CUstream hStream, void **kernelParams, void **extra)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-    extern "C" CUresult CUDAAPI cuEventRecord_ptsz(CUevent hEvent, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-    extern "C" CUresult CUDAAPI cuStreamWriteValue32_ptsz(CUstream stream, CUdeviceptr addr, cuuint32_t value, unsigned int flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-    extern "C" CUresult CUDAAPI cuStreamWaitValue32_ptsz(CUstream stream, CUdeviceptr addr, cuuint32_t value, unsigned int flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-    extern "C" CUresult CUDAAPI cuStreamBatchMemOp_ptsz(CUstream stream, unsigned int count, CUstreamBatchMemOpParams *paramArray, unsigned int flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-extern "C" CUresult CUDAAPI cuStreamGetPriority_ptsz(CUstream hStream, int *priority)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-extern "C" CUresult CUDAAPI cuStreamGetFlags_ptsz(CUstream hStream, unsigned int *flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI
+cuMemcpy3DPeerAsync_ptsz(const CUDA_MEMCPY3D_PEER *pCopy, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-
-extern "C" CUresult CUDAAPI cuStreamWaitEvent_ptsz(CUstream hStream, CUevent hEvent, unsigned int Flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI cuMemsetD8Async_ptsz(CUdeviceptr dstDevice,
+                                                 unsigned char uc, size_t N,
+                                                 CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+extern "C" CUresult CUDAAPI cuMemsetD2D8Async_ptsz(CUdeviceptr dstDevice,
+                                                   size_t dstPitch,
+                                                   unsigned char uc,
+                                                   size_t Width, size_t Height,
+                                                   CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+extern "C" CUresult CUDAAPI cuLaunchKernel_ptsz(
+    CUfunction f, unsigned int gridDimX, unsigned int gridDimY,
+    unsigned int gridDimZ, unsigned int blockDimX, unsigned int blockDimY,
+    unsigned int blockDimZ, unsigned int sharedMemBytes, CUstream hStream,
+    void **kernelParams, void **extra) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+extern "C" CUresult CUDAAPI cuEventRecord_ptsz(CUevent hEvent,
+                                               CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+extern "C" CUresult CUDAAPI cuStreamWriteValue32_ptsz(CUstream stream,
+                                                      CUdeviceptr addr,
+                                                      cuuint32_t value,
+                                                      unsigned int flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+extern "C" CUresult CUDAAPI cuStreamWaitValue32_ptsz(CUstream stream,
+                                                     CUdeviceptr addr,
+                                                     cuuint32_t value,
+                                                     unsigned int flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+extern "C" CUresult CUDAAPI cuStreamBatchMemOp_ptsz(
+    CUstream stream, unsigned int count, CUstreamBatchMemOpParams *paramArray,
+    unsigned int flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+extern "C" CUresult CUDAAPI cuStreamGetPriority_ptsz(CUstream hStream,
+                                                     int *priority) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+extern "C" CUresult CUDAAPI cuStreamGetFlags_ptsz(CUstream hStream,
+                                                  unsigned int *flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-extern "C" CUresult CUDAAPI cuStreamAddCallback_ptsz(CUstream hStream, CUstreamCallback callback, void *userData, unsigned int flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI cuStreamWaitEvent_ptsz(CUstream hStream,
+                                                   CUevent hEvent,
+                                                   unsigned int Flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-extern "C" CUresult CUDAAPI cuStreamSynchronize_ptsz(CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI cuStreamAddCallback_ptsz(CUstream hStream,
+                                                     CUstreamCallback callback,
+                                                     void *userData,
+                                                     unsigned int flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-    extern "C" CUresult CUDAAPI cuStreamQuery_ptsz(CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
-}
-extern "C" CUresult CUDAAPI cuStreamAttachMemAsync_ptsz(CUstream hStream, CUdeviceptr dptr, size_t length, unsigned int flags)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI cuStreamSynchronize_ptsz(CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-extern "C" CUresult CUDAAPI cuGraphicsMapResources_ptsz(unsigned int count, CUgraphicsResource *resources, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI cuStreamQuery_ptsz(CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+extern "C" CUresult CUDAAPI cuStreamAttachMemAsync_ptsz(CUstream hStream,
+                                                        CUdeviceptr dptr,
+                                                        size_t length,
+                                                        unsigned int flags) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-
-extern "C" CUresult CUDAAPI cuGraphicsUnmapResources_ptsz(unsigned int count, CUgraphicsResource *resources, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI cuGraphicsMapResources_ptsz(
+    unsigned int count, CUgraphicsResource *resources, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }
 
-    extern "C" CUresult CUDAAPI cuMemPrefetchAsync_ptsz(CUdeviceptr devPtr, size_t count, CUdevice dstDevice, CUstream hStream)
-{
-	if(g_debug_execution >= 3){
-	    announce_call(__my_func__);
-    }
-	printf("WARNING: this function has not been implemented yet.");
-	return CUDA_SUCCESS;
+extern "C" CUresult CUDAAPI cuGraphicsUnmapResources_ptsz(
+    unsigned int count, CUgraphicsResource *resources, CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
+}
+
+extern "C" CUresult CUDAAPI cuMemPrefetchAsync_ptsz(CUdeviceptr devPtr,
+                                                    size_t count,
+                                                    CUdevice dstDevice,
+                                                    CUstream hStream) {
+  if (g_debug_execution >= 3) {
+    announce_call(__my_func__);
+  }
+  printf("WARNING: this function has not been implemented yet.");
+  return CUDA_SUCCESS;
 }

--- a/libcuda/cuobjdump.h
+++ b/libcuda/cuobjdump.h
@@ -1,80 +1,81 @@
 #ifndef __cuobjdump_h__
 #define __cuobjdump_h__
-#include <string>
-#include <list>
 #include <iostream>
+#include <list>
+#include <string>
 
-typedef void * yyscan_t;
+typedef void *yyscan_t;
 struct cuobjdump_parser {
-    yyscan_t scanner;
-    int elfserial;
-    int ptxserial;
-    FILE *ptxfile;
-    FILE *elffile;
-    FILE *sassfile;
-    char filename [1024];
+  yyscan_t scanner;
+  int elfserial;
+  int ptxserial;
+  FILE *ptxfile;
+  FILE *elffile;
+  FILE *sassfile;
+  char filename[1024];
 };
 
 class cuobjdumpSection {
-public:
-	//Constructor
-	cuobjdumpSection() {
-		arch = 0;
-		identifier = "";
-	}
-	virtual ~cuobjdumpSection() {}
-	unsigned getArch() {return arch;}
-	void setArch(unsigned a) {arch = a;}
-	std::string getIdentifier() {return identifier;}
-	void setIdentifier(std::string i) {identifier = i;}
-	virtual void print(){std::cout << "cuobjdump Section: unknown type" << std::endl;}
-private:
-	unsigned arch;
-	std::string identifier;
+ public:
+  // Constructor
+  cuobjdumpSection() {
+    arch = 0;
+    identifier = "";
+  }
+  virtual ~cuobjdumpSection() {}
+  unsigned getArch() { return arch; }
+  void setArch(unsigned a) { arch = a; }
+  std::string getIdentifier() { return identifier; }
+  void setIdentifier(std::string i) { identifier = i; }
+  virtual void print() {
+    std::cout << "cuobjdump Section: unknown type" << std::endl;
+  }
+
+ private:
+  unsigned arch;
+  std::string identifier;
 };
 
-class cuobjdumpELFSection : public cuobjdumpSection
-{
-public:
-	cuobjdumpELFSection() {}
-	virtual ~cuobjdumpELFSection() {
-		elffilename = "";
-		sassfilename = "";
-	}
-	std::string getELFfilename() {return elffilename;}
-	void setELFfilename(std::string f) {elffilename = f;}
-	std::string getSASSfilename() {return sassfilename;}
-	void setSASSfilename(std::string f) {sassfilename = f;}
-	virtual void print() {
-		std::cout << "ELF Section:" << std::endl;
-		std::cout << "arch: sm_" << getArch() << std::endl;
-		std::cout << "identifier: " << getIdentifier() << std::endl;
-		std::cout << "elf filename: " << getELFfilename() << std::endl;
-		std::cout << "sass filename: " << getSASSfilename() << std::endl;
-		std::cout << std::endl;
-	}
-private:
-	std::string elffilename;
-	std::string sassfilename;
+class cuobjdumpELFSection : public cuobjdumpSection {
+ public:
+  cuobjdumpELFSection() {}
+  virtual ~cuobjdumpELFSection() {
+    elffilename = "";
+    sassfilename = "";
+  }
+  std::string getELFfilename() { return elffilename; }
+  void setELFfilename(std::string f) { elffilename = f; }
+  std::string getSASSfilename() { return sassfilename; }
+  void setSASSfilename(std::string f) { sassfilename = f; }
+  virtual void print() {
+    std::cout << "ELF Section:" << std::endl;
+    std::cout << "arch: sm_" << getArch() << std::endl;
+    std::cout << "identifier: " << getIdentifier() << std::endl;
+    std::cout << "elf filename: " << getELFfilename() << std::endl;
+    std::cout << "sass filename: " << getSASSfilename() << std::endl;
+    std::cout << std::endl;
+  }
+
+ private:
+  std::string elffilename;
+  std::string sassfilename;
 };
 
-class cuobjdumpPTXSection : public cuobjdumpSection
-{
-public:
-	cuobjdumpPTXSection(){
-		ptxfilename = "";
-	}
-	std::string getPTXfilename() {return ptxfilename;}
-	void setPTXfilename(std::string f) {ptxfilename = f;}
-	virtual void print() {
-		std::cout << "PTX Section:" << std::endl;
-		std::cout << "arch: sm_" << getArch() << std::endl;
-		std::cout << "identifier: " << getIdentifier() << std::endl;
-		std::cout << "ptx filename: " << getPTXfilename() << std::endl;
-		std::cout << std::endl;
-	}
-private:
-	std::string ptxfilename;
+class cuobjdumpPTXSection : public cuobjdumpSection {
+ public:
+  cuobjdumpPTXSection() { ptxfilename = ""; }
+  std::string getPTXfilename() { return ptxfilename; }
+  void setPTXfilename(std::string f) { ptxfilename = f; }
+  virtual void print() {
+    std::cout << "PTX Section:" << std::endl;
+    std::cout << "arch: sm_" << getArch() << std::endl;
+    std::cout << "identifier: " << getIdentifier() << std::endl;
+    std::cout << "ptx filename: " << getPTXfilename() << std::endl;
+    std::cout << std::endl;
+  }
+
+ private:
+  std::string ptxfilename;
 };
 
 #endif /* __cuobjdump_h__ */

--- a/libcuda/gpgpu_context.h
+++ b/libcuda/gpgpu_context.h
@@ -1,76 +1,83 @@
 #ifndef __gpgpu_context_h__
 #define __gpgpu_context_h__
-#include "cuda_api_object.h"
-#include "../src/cuda-sim/ptx_loader.h"
-#include "../src/cuda-sim/ptx_parser.h"
-#include "../src/gpgpusim_entrypoint.h"
 #include "../src/cuda-sim/cuda-sim.h"
 #include "../src/cuda-sim/cuda_device_runtime.h"
 #include "../src/cuda-sim/ptx-stats.h"
+#include "../src/cuda-sim/ptx_loader.h"
+#include "../src/cuda-sim/ptx_parser.h"
+#include "../src/gpgpusim_entrypoint.h"
+#include "cuda_api_object.h"
 
 class gpgpu_context {
-    public:
-	gpgpu_context() {
-	    g_global_allfiles_symbol_table = NULL;
-	    sm_next_access_uid=0;
-	    warp_inst_sm_next_uid=0;
-	    operand_info_sm_next_uid = 1;
-	    kernel_info_m_next_uid = 1;
-	    g_num_ptx_inst_uid = 0;
-	    g_ptx_cta_info_uid = 1;
-	    symbol_sm_next_uid = 1;
-	    function_info_sm_next_uid = 1;
-	    debug_tensorcore = 0;
-	    api = new cuda_runtime_api(this);
-	    ptxinfo = new ptxinfo_data(this);
-	    ptx_parser = new ptx_recognizer(this);
-	    the_gpgpusim = new GPGPUsim_ctx(this);
-	    func_sim = new cuda_sim(this);
-	    device_runtime = new cuda_device_runtime(this);
-	    stats = new ptx_stats(this);
-	}
-	// global list
-	symbol_table *g_global_allfiles_symbol_table;
-	const char *g_filename;
-	unsigned sm_next_access_uid;
-	unsigned warp_inst_sm_next_uid;
-	unsigned operand_info_sm_next_uid;//uid for operand_info
-	unsigned kernel_info_m_next_uid;//uid for kernel_info_t
-	unsigned g_num_ptx_inst_uid; //uid for ptx inst inside ptx_instruction
-	unsigned long long g_ptx_cta_info_uid;
-	unsigned symbol_sm_next_uid; //uid for symbol
-	unsigned function_info_sm_next_uid;
-	std::vector<ptx_instruction*> s_g_pc_to_insn; // a direct mapping from PC to instruction
-	bool debug_tensorcore;
+ public:
+  gpgpu_context() {
+    g_global_allfiles_symbol_table = NULL;
+    sm_next_access_uid = 0;
+    warp_inst_sm_next_uid = 0;
+    operand_info_sm_next_uid = 1;
+    kernel_info_m_next_uid = 1;
+    g_num_ptx_inst_uid = 0;
+    g_ptx_cta_info_uid = 1;
+    symbol_sm_next_uid = 1;
+    function_info_sm_next_uid = 1;
+    debug_tensorcore = 0;
+    api = new cuda_runtime_api(this);
+    ptxinfo = new ptxinfo_data(this);
+    ptx_parser = new ptx_recognizer(this);
+    the_gpgpusim = new GPGPUsim_ctx(this);
+    func_sim = new cuda_sim(this);
+    device_runtime = new cuda_device_runtime(this);
+    stats = new ptx_stats(this);
+  }
+  // global list
+  symbol_table *g_global_allfiles_symbol_table;
+  const char *g_filename;
+  unsigned sm_next_access_uid;
+  unsigned warp_inst_sm_next_uid;
+  unsigned operand_info_sm_next_uid;  // uid for operand_info
+  unsigned kernel_info_m_next_uid;    // uid for kernel_info_t
+  unsigned g_num_ptx_inst_uid;        // uid for ptx inst inside ptx_instruction
+  unsigned long long g_ptx_cta_info_uid;
+  unsigned symbol_sm_next_uid;  // uid for symbol
+  unsigned function_info_sm_next_uid;
+  std::vector<ptx_instruction *>
+      s_g_pc_to_insn;  // a direct mapping from PC to instruction
+  bool debug_tensorcore;
 
-	// objects pointers for each file
-	cuda_runtime_api* api;
-	ptxinfo_data* ptxinfo;
-	ptx_recognizer* ptx_parser;
-	GPGPUsim_ctx* the_gpgpusim;
-	cuda_sim* func_sim;
-	cuda_device_runtime* device_runtime;
-	ptx_stats* stats;
-	// member function list
-	void synchronize();
-	void exit_simulation();
-	void print_simulation_time();
-	int gpgpu_opencl_ptx_sim_main_perf( kernel_info_t *grid );
-	void cuobjdumpParseBinary(unsigned int handle);
-	class symbol_table *gpgpu_ptx_sim_load_ptx_from_string( const char *p, unsigned source_num );
-	class symbol_table *gpgpu_ptx_sim_load_ptx_from_filename( const char *filename );
-	void gpgpu_ptx_info_load_from_filename( const char *filename, unsigned sm_version);
-	void gpgpu_ptxinfo_load_from_string( const char *p_for_info, unsigned source_num, unsigned sm_version=20, int no_of_ptx=0 );
-	void print_ptx_file( const char *p, unsigned source_num, const char *filename );
-	class symbol_table* init_parser(const char*);
-	class gpgpu_sim *gpgpu_ptx_sim_init_perf();
-	void start_sim_thread(int api);
-	struct _cuda_device_id *GPGPUSim_Init();
-	void ptx_reg_options(option_parser_t opp);
-	const ptx_instruction* pc_to_instruction(unsigned pc); 
-	const warp_inst_t *ptx_fetch_inst( address_type pc );
-	unsigned translate_pc_to_ptxlineno(unsigned pc);
+  // objects pointers for each file
+  cuda_runtime_api *api;
+  ptxinfo_data *ptxinfo;
+  ptx_recognizer *ptx_parser;
+  GPGPUsim_ctx *the_gpgpusim;
+  cuda_sim *func_sim;
+  cuda_device_runtime *device_runtime;
+  ptx_stats *stats;
+  // member function list
+  void synchronize();
+  void exit_simulation();
+  void print_simulation_time();
+  int gpgpu_opencl_ptx_sim_main_perf(kernel_info_t *grid);
+  void cuobjdumpParseBinary(unsigned int handle);
+  class symbol_table *gpgpu_ptx_sim_load_ptx_from_string(const char *p,
+                                                         unsigned source_num);
+  class symbol_table *gpgpu_ptx_sim_load_ptx_from_filename(
+      const char *filename);
+  void gpgpu_ptx_info_load_from_filename(const char *filename,
+                                         unsigned sm_version);
+  void gpgpu_ptxinfo_load_from_string(const char *p_for_info,
+                                      unsigned source_num,
+                                      unsigned sm_version = 20,
+                                      int no_of_ptx = 0);
+  void print_ptx_file(const char *p, unsigned source_num, const char *filename);
+  class symbol_table *init_parser(const char *);
+  class gpgpu_sim *gpgpu_ptx_sim_init_perf();
+  void start_sim_thread(int api);
+  struct _cuda_device_id *GPGPUSim_Init();
+  void ptx_reg_options(option_parser_t opp);
+  const ptx_instruction *pc_to_instruction(unsigned pc);
+  const warp_inst_t *ptx_fetch_inst(address_type pc);
+  unsigned translate_pc_to_ptxlineno(unsigned pc);
 };
-gpgpu_context* GPGPU_Context();
+gpgpu_context *GPGPU_Context();
 
 #endif /* __gpgpu_context_h__ */

--- a/run-clang-format.py
+++ b/run-clang-format.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python
+"""A wrapper script around clang-format, suitable for linting multiple files
+and to use for continuous integration.
+
+This is an alternative API for the clang-format command line.
+It runs over multiple files and directories in parallel.
+A diff output is produced and a sensible exit code is returned.
+
+"""
+
+from __future__ import print_function, unicode_literals
+
+import argparse
+import codecs
+import difflib
+import fnmatch
+import io
+import multiprocessing
+import os
+import signal
+import subprocess
+import sys
+import traceback
+
+from functools import partial
+
+try:
+    from subprocess import DEVNULL  # py3k
+except ImportError:
+    DEVNULL = open(os.devnull, "wb")
+
+
+DEFAULT_EXTENSIONS = 'c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx'
+
+
+class ExitStatus:
+    SUCCESS = 0
+    DIFF = 1
+    TROUBLE = 2
+
+
+def list_files(files, recursive=False, extensions=None, exclude=None):
+    if extensions is None:
+        extensions = []
+    if exclude is None:
+        exclude = []
+
+    out = []
+    for file in files:
+        if recursive and os.path.isdir(file):
+            for dirpath, dnames, fnames in os.walk(file):
+                fpaths = [os.path.join(dirpath, fname) for fname in fnames]
+                for pattern in exclude:
+                    # os.walk() supports trimming down the dnames list
+                    # by modifying it in-place,
+                    # to avoid unnecessary directory listings.
+                    dnames[:] = [
+                        x for x in dnames
+                        if
+                        not fnmatch.fnmatch(os.path.join(dirpath, x), pattern)
+                    ]
+                    fpaths = [
+                        x for x in fpaths if not fnmatch.fnmatch(x, pattern)
+                    ]
+                for f in fpaths:
+                    ext = os.path.splitext(f)[1][1:]
+                    if ext in extensions:
+                        out.append(f)
+        else:
+            out.append(file)
+    return out
+
+
+def make_diff(file, original, reformatted):
+    return list(
+        difflib.unified_diff(
+            original,
+            reformatted,
+            fromfile='{}\t(original)'.format(file),
+            tofile='{}\t(reformatted)'.format(file),
+            n=3))
+
+
+class DiffError(Exception):
+    def __init__(self, message, errs=None):
+        super(DiffError, self).__init__(message)
+        self.errs = errs or []
+
+
+class UnexpectedError(Exception):
+    def __init__(self, message, exc=None):
+        super(UnexpectedError, self).__init__(message)
+        self.formatted_traceback = traceback.format_exc()
+        self.exc = exc
+
+
+def run_clang_format_diff_wrapper(args, file):
+    try:
+        ret = run_clang_format_diff(args, file)
+        return ret
+    except DiffError:
+        raise
+    except Exception as e:
+        raise UnexpectedError('{}: {}: {}'.format(file, e.__class__.__name__,
+                                                  e), e)
+
+
+def run_clang_format_diff(args, file):
+    try:
+        with io.open(file, 'r', encoding='utf-8') as f:
+            original = f.readlines()
+    except IOError as exc:
+        raise DiffError(str(exc))
+    invocation = [args.clang_format_executable, file]
+
+    # Use of utf-8 to decode the process output.
+    #
+    # Hopefully, this is the correct thing to do.
+    #
+    # It's done due to the following assumptions (which may be incorrect):
+    # - clang-format will returns the bytes read from the files as-is,
+    #   without conversion, and it is already assumed that the files use utf-8.
+    # - if the diagnostics were internationalized, they would use utf-8:
+    #   > Adding Translations to Clang
+    #   >
+    #   > Not possible yet!
+    #   > Diagnostic strings should be written in UTF-8,
+    #   > the client can translate to the relevant code page if needed.
+    #   > Each translation completely replaces the format string
+    #   > for the diagnostic.
+    #   > -- http://clang.llvm.org/docs/InternalsManual.html#internals-diag-translation
+    #
+    # It's not pretty, due to Python 2 & 3 compatibility.
+    encoding_py3 = {}
+    if sys.version_info[0] >= 3:
+        encoding_py3['encoding'] = 'utf-8'
+
+    try:
+        proc = subprocess.Popen(
+            invocation,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+            **encoding_py3)
+    except OSError as exc:
+        raise DiffError(
+            "Command '{}' failed to start: {}".format(
+                subprocess.list2cmdline(invocation), exc
+            )
+        )
+    proc_stdout = proc.stdout
+    proc_stderr = proc.stderr
+    if sys.version_info[0] < 3:
+        # make the pipes compatible with Python 3,
+        # reading lines should output unicode
+        encoding = 'utf-8'
+        proc_stdout = codecs.getreader(encoding)(proc_stdout)
+        proc_stderr = codecs.getreader(encoding)(proc_stderr)
+    # hopefully the stderr pipe won't get full and block the process
+    outs = list(proc_stdout.readlines())
+    errs = list(proc_stderr.readlines())
+    proc.wait()
+    if proc.returncode:
+        raise DiffError(
+            "Command '{}' returned non-zero exit status {}".format(
+                subprocess.list2cmdline(invocation), proc.returncode
+            ),
+            errs,
+        )
+    return make_diff(file, original, outs), errs
+
+
+def bold_red(s):
+    return '\x1b[1m\x1b[31m' + s + '\x1b[0m'
+
+
+def colorize(diff_lines):
+    def bold(s):
+        return '\x1b[1m' + s + '\x1b[0m'
+
+    def cyan(s):
+        return '\x1b[36m' + s + '\x1b[0m'
+
+    def green(s):
+        return '\x1b[32m' + s + '\x1b[0m'
+
+    def red(s):
+        return '\x1b[31m' + s + '\x1b[0m'
+
+    for line in diff_lines:
+        if line[:4] in ['--- ', '+++ ']:
+            yield bold(line)
+        elif line.startswith('@@ '):
+            yield cyan(line)
+        elif line.startswith('+'):
+            yield green(line)
+        elif line.startswith('-'):
+            yield red(line)
+        else:
+            yield line
+
+
+def print_diff(diff_lines, use_color):
+    if use_color:
+        diff_lines = colorize(diff_lines)
+    if sys.version_info[0] < 3:
+        sys.stdout.writelines((l.encode('utf-8') for l in diff_lines))
+    else:
+        sys.stdout.writelines(diff_lines)
+
+
+def print_trouble(prog, message, use_colors):
+    error_text = 'error:'
+    if use_colors:
+        error_text = bold_red(error_text)
+    print("{}: {} {}".format(prog, error_text, message), file=sys.stderr)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--clang-format-executable',
+        metavar='EXECUTABLE',
+        help='path to the clang-format executable',
+        default='clang-format')
+    parser.add_argument(
+        '--extensions',
+        help='comma separated list of file extensions (default: {})'.format(
+            DEFAULT_EXTENSIONS),
+        default=DEFAULT_EXTENSIONS)
+    parser.add_argument(
+        '-r',
+        '--recursive',
+        action='store_true',
+        help='run recursively over directories')
+    parser.add_argument('files', metavar='file', nargs='+')
+    parser.add_argument(
+        '-q',
+        '--quiet',
+        action='store_true')
+    parser.add_argument(
+        '-j',
+        metavar='N',
+        type=int,
+        default=0,
+        help='run N clang-format jobs in parallel'
+        ' (default number of cpus + 1)')
+    parser.add_argument(
+        '--color',
+        default='auto',
+        choices=['auto', 'always', 'never'],
+        help='show colored diff (default: auto)')
+    parser.add_argument(
+        '-e',
+        '--exclude',
+        metavar='PATTERN',
+        action='append',
+        default=[],
+        help='exclude paths matching the given glob-like pattern(s)'
+        ' from recursive search')
+
+    args = parser.parse_args()
+
+    # use default signal handling, like diff return SIGINT value on ^C
+    # https://bugs.python.org/issue14229#msg156446
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    try:
+        signal.SIGPIPE
+    except AttributeError:
+        # compatibility, SIGPIPE does not exist on Windows
+        pass
+    else:
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+    colored_stdout = False
+    colored_stderr = False
+    if args.color == 'always':
+        colored_stdout = True
+        colored_stderr = True
+    elif args.color == 'auto':
+        colored_stdout = sys.stdout.isatty()
+        colored_stderr = sys.stderr.isatty()
+    """
+    version_invocation = [args.clang_format_executable, str("--version")]
+    try:
+        subprocess.check_call(version_invocation, stdout=DEVNULL)
+    except subprocess.CalledProcessError as e:
+        print_trouble(parser.prog, str(e), use_colors=colored_stderr)
+        return ExitStatus.TROUBLE
+    except OSError as e:
+        print_trouble(
+            parser.prog,
+            "Command '{}' failed to start: {}".format(
+                subprocess.list2cmdline(version_invocation), e
+            ),
+            use_colors=colored_stderr,
+        )
+        return ExitStatus.TROUBLE
+    """
+    retcode = ExitStatus.SUCCESS
+    files = list_files(
+        args.files,
+        recursive=args.recursive,
+        exclude=args.exclude,
+        extensions=args.extensions.split(','))
+
+    if not files:
+        return
+
+    njobs = args.j
+    if njobs == 0:
+        njobs = multiprocessing.cpu_count() + 1
+    njobs = min(len(files), njobs)
+
+    if njobs == 1:
+        # execute directly instead of in a pool,
+        # less overhead, simpler stacktraces
+        it = (run_clang_format_diff_wrapper(args, file) for file in files)
+        pool = None
+    else:
+        pool = multiprocessing.Pool(njobs)
+        it = pool.imap_unordered(
+            partial(run_clang_format_diff_wrapper, args), files)
+    while True:
+        try:
+            outs, errs = next(it)
+        except StopIteration:
+            break
+        except DiffError as e:
+            print_trouble(parser.prog, str(e), use_colors=colored_stderr)
+            retcode = ExitStatus.TROUBLE
+            sys.stderr.writelines(e.errs)
+        except UnexpectedError as e:
+            print_trouble(parser.prog, str(e), use_colors=colored_stderr)
+            sys.stderr.write(e.formatted_traceback)
+            retcode = ExitStatus.TROUBLE
+            # stop at the first unexpected error,
+            # something could be very wrong,
+            # don't process all files unnecessarily
+            if pool:
+                pool.terminate()
+            break
+        else:
+            sys.stderr.writelines(errs)
+            if outs == []:
+                continue
+            if not args.quiet:
+                print_diff(outs, use_color=colored_stdout)
+            if retcode == ExitStatus.SUCCESS:
+                retcode = ExitStatus.DIFF
+    return retcode
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/abstract_hardware_model.cc
+++ b/src/abstract_hardware_model.cc
@@ -7,1203 +7,1210 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #include "abstract_hardware_model.h"
-#include "cuda-sim/memory.h"
-#include "cuda-sim/ptx_ir.h"
-#include "cuda-sim/ptx-stats.h"
-#include "cuda-sim/cuda-sim.h"
-#include "gpgpu-sim/gpu-sim.h"
-#include "option_parser.h"
-#include "gpgpusim_entrypoint.h"
-#include <algorithm>
 #include <sys/stat.h>
-#include <sstream>
+#include <algorithm>
 #include <iostream>
+#include <sstream>
 #include "../libcuda/gpgpu_context.h"
+#include "cuda-sim/cuda-sim.h"
+#include "cuda-sim/memory.h"
+#include "cuda-sim/ptx-stats.h"
+#include "cuda-sim/ptx_ir.h"
+#include "gpgpu-sim/gpu-sim.h"
+#include "gpgpusim_entrypoint.h"
+#include "option_parser.h"
 
-void mem_access_t::init(gpgpu_context* ctx)
-{
-      gpgpu_ctx = ctx;
-      m_uid=++(gpgpu_ctx->sm_next_access_uid);
-      m_addr=0;
-      m_req_size=0;
+void mem_access_t::init(gpgpu_context *ctx) {
+  gpgpu_ctx = ctx;
+  m_uid = ++(gpgpu_ctx->sm_next_access_uid);
+  m_addr = 0;
+  m_req_size = 0;
 }
-void warp_inst_t::issue( const active_mask_t &mask, unsigned warp_id, unsigned long long cycle, int dynamic_warp_id, int sch_id )
-{
-    m_warp_active_mask = mask;
-    m_warp_issued_mask = mask; 
-    m_uid = ++(m_config->gpgpu_ctx->warp_inst_sm_next_uid);
-    m_warp_id = warp_id;
-    m_dynamic_warp_id = dynamic_warp_id;
-    issue_cycle = cycle;
-    cycles = initiation_interval;
-    m_cache_hit=false;
-    m_empty=false;
-    m_scheduler_id=sch_id;
+void warp_inst_t::issue(const active_mask_t &mask, unsigned warp_id,
+                        unsigned long long cycle, int dynamic_warp_id,
+                        int sch_id) {
+  m_warp_active_mask = mask;
+  m_warp_issued_mask = mask;
+  m_uid = ++(m_config->gpgpu_ctx->warp_inst_sm_next_uid);
+  m_warp_id = warp_id;
+  m_dynamic_warp_id = dynamic_warp_id;
+  issue_cycle = cycle;
+  cycles = initiation_interval;
+  m_cache_hit = false;
+  m_empty = false;
+  m_scheduler_id = sch_id;
 }
 
-checkpoint::checkpoint()
-{
+checkpoint::checkpoint() {
+  struct stat st = {0};
 
-    struct stat st = {0};
+  if (stat("checkpoint_files", &st) == -1) {
+    mkdir("checkpoint_files", 0777);
+  }
+}
+void checkpoint::load_global_mem(class memory_space *temp_mem, char *f1name) {
+  FILE *fp2 = fopen(f1name, "r");
+  assert(fp2 != NULL);
+  char line[128]; /* or other suitable maximum line size */
+  unsigned int offset;
+  while (fgets(line, sizeof line, fp2) != NULL) /* read a line */
+  {
+    unsigned int index;
+    char *pch;
+    pch = strtok(line, " ");
+    if (pch[0] == 'g' || pch[0] == 's' || pch[0] == 'l') {
+      pch = strtok(NULL, " ");
 
-    if (stat("checkpoint_files", &st) == -1) {
-        mkdir("checkpoint_files", 0777);
+      std::stringstream ss;
+      ss << std::hex << pch;
+      ss >> index;
+
+      offset = 0;
+    } else {
+      unsigned int data;
+      std::stringstream ss;
+      ss << std::hex << pch;
+      ss >> data;
+      temp_mem->write_only(offset, index, 4, &data);
+      offset = offset + 4;
     }
-
-}
-void checkpoint::load_global_mem(class memory_space *temp_mem, char * f1name)
-{
-
-    FILE * fp2 = fopen(f1name, "r");
-    assert(fp2!=NULL);
-      char line [ 128 ]; /* or other suitable maximum line size */
-      unsigned int offset ;
-      while ( fgets ( line, sizeof line, fp2 ) != NULL ) /* read a line */
-      {
-         unsigned int index;
-         char * pch;
-         pch = strtok (line," ");
-         if (pch[0]=='g' || pch[0]=='s' || pch[0]=='l')
-         {
-
-           pch = strtok (NULL, " ");
-           
-           std::stringstream ss;
-            ss << std::hex << pch;
-            ss >> index;
-
-           offset=0;
-         }
-         else {
-            unsigned int  data;
-            std::stringstream ss;
-            ss << std::hex << pch;
-            ss >> data;
-            temp_mem->write_only(offset,index, 4,&data);
-            offset= offset+4;
-         }
-         //fputs ( line, stdout ); /* write the line */
-      }
-      fclose ( fp2 );
+    // fputs ( line, stdout ); /* write the line */
+  }
+  fclose(fp2);
 }
 
-void checkpoint::store_global_mem(class memory_space * mem, char *fname, char * format)
-{
-
-      FILE * fp3 = fopen(fname, "w");
-      assert(fp3!=NULL);
-      mem->print(format,fp3);
-      fclose(fp3);
+void checkpoint::store_global_mem(class memory_space *mem, char *fname,
+                                  char *format) {
+  FILE *fp3 = fopen(fname, "w");
+  assert(fp3 != NULL);
+  mem->print(format, fp3);
+  fclose(fp3);
 }
 
-void move_warp( warp_inst_t *&dst, warp_inst_t *&src )
-{
-   assert( dst->empty() );
-   warp_inst_t* temp = dst;
-   dst = src;
-   src = temp;
-   src->clear();
+void move_warp(warp_inst_t *&dst, warp_inst_t *&src) {
+  assert(dst->empty());
+  warp_inst_t *temp = dst;
+  dst = src;
+  src = temp;
+  src->clear();
 }
 
-
-void gpgpu_functional_sim_config::reg_options(class OptionParser * opp)
-{
-	option_parser_register(opp, "-gpgpu_ptx_use_cuobjdump", OPT_BOOL,
-                 &m_ptx_use_cuobjdump,
-                 "Use cuobjdump to extract ptx and sass from binaries",
+void gpgpu_functional_sim_config::reg_options(class OptionParser *opp) {
+  option_parser_register(opp, "-gpgpu_ptx_use_cuobjdump", OPT_BOOL,
+                         &m_ptx_use_cuobjdump,
+                         "Use cuobjdump to extract ptx and sass from binaries",
 #if (CUDART_VERSION >= 4000)
-                 "1"
+                         "1"
 #else
-                 "0"
+                         "0"
 #endif
-                 );
-	option_parser_register(opp, "-gpgpu_experimental_lib_support", OPT_BOOL,
-	                 &m_experimental_lib_support,
-	                 "Try to extract code from cuda libraries [Broken because of unknown cudaGetExportTable]",
-	                 "0");
-  option_parser_register(opp, "-checkpoint_option", OPT_INT32, &checkpoint_option, 
-               " checkpointing flag (0 = no checkpoint)",
-               "0");
-  option_parser_register(opp, "-checkpoint_kernel", OPT_INT32, &checkpoint_kernel, 
-               " checkpointing during execution of which kernel (1- 1st kernel)",
-               "1");
-  option_parser_register(opp, "-checkpoint_CTA", OPT_INT32, &checkpoint_CTA, 
-               " checkpointing after # of CTA (< less than total CTA)",
-               "0");
-  option_parser_register(opp, "-resume_option", OPT_INT32, &resume_option, 
-               " resume flag (0 = no resume)",
-               "0");
-  option_parser_register(opp, "-resume_kernel", OPT_INT32, &resume_kernel, 
-               " Resume from which kernel (1= 1st kernel)",
-               "0");
-   option_parser_register(opp, "-resume_CTA", OPT_INT32, &resume_CTA, 
-               " resume from which CTA ",
-               "0");
-      option_parser_register(opp, "-checkpoint_CTA_t", OPT_INT32, &checkpoint_CTA_t, 
-               " resume from which CTA ",
-               "0");
-         option_parser_register(opp, "-checkpoint_insn_Y", OPT_INT32, &checkpoint_insn_Y, 
-               " resume from which CTA ",
-               "0");
+  );
+  option_parser_register(opp, "-gpgpu_experimental_lib_support", OPT_BOOL,
+                         &m_experimental_lib_support,
+                         "Try to extract code from cuda libraries [Broken "
+                         "because of unknown cudaGetExportTable]",
+                         "0");
+  option_parser_register(opp, "-checkpoint_option", OPT_INT32,
+                         &checkpoint_option,
+                         " checkpointing flag (0 = no checkpoint)", "0");
+  option_parser_register(
+      opp, "-checkpoint_kernel", OPT_INT32, &checkpoint_kernel,
+      " checkpointing during execution of which kernel (1- 1st kernel)", "1");
+  option_parser_register(
+      opp, "-checkpoint_CTA", OPT_INT32, &checkpoint_CTA,
+      " checkpointing after # of CTA (< less than total CTA)", "0");
+  option_parser_register(opp, "-resume_option", OPT_INT32, &resume_option,
+                         " resume flag (0 = no resume)", "0");
+  option_parser_register(opp, "-resume_kernel", OPT_INT32, &resume_kernel,
+                         " Resume from which kernel (1= 1st kernel)", "0");
+  option_parser_register(opp, "-resume_CTA", OPT_INT32, &resume_CTA,
+                         " resume from which CTA ", "0");
+  option_parser_register(opp, "-checkpoint_CTA_t", OPT_INT32, &checkpoint_CTA_t,
+                         " resume from which CTA ", "0");
+  option_parser_register(opp, "-checkpoint_insn_Y", OPT_INT32,
+                         &checkpoint_insn_Y, " resume from which CTA ", "0");
 
-    option_parser_register(opp, "-gpgpu_ptx_convert_to_ptxplus", OPT_BOOL,
-                 &m_ptx_convert_to_ptxplus,
-                 "Convert SASS (native ISA) to ptxplus and run ptxplus",
-                 "0");
-    option_parser_register(opp, "-gpgpu_ptx_force_max_capability", OPT_UINT32,
-                 &m_ptx_force_max_capability,
-                 "Force maximum compute capability",
-                 "0");
-   option_parser_register(opp, "-gpgpu_ptx_inst_debug_to_file", OPT_BOOL, 
-                &g_ptx_inst_debug_to_file, 
-                "Dump executed instructions' debug information to file", 
-                "0");
-   option_parser_register(opp, "-gpgpu_ptx_inst_debug_file", OPT_CSTR, &g_ptx_inst_debug_file, 
-                  "Executed instructions' debug output file",
-                  "inst_debug.txt");
-   option_parser_register(opp, "-gpgpu_ptx_inst_debug_thread_uid", OPT_INT32, &g_ptx_inst_debug_thread_uid, 
-               "Thread UID for executed instructions' debug output", 
-               "1");
+  option_parser_register(
+      opp, "-gpgpu_ptx_convert_to_ptxplus", OPT_BOOL, &m_ptx_convert_to_ptxplus,
+      "Convert SASS (native ISA) to ptxplus and run ptxplus", "0");
+  option_parser_register(opp, "-gpgpu_ptx_force_max_capability", OPT_UINT32,
+                         &m_ptx_force_max_capability,
+                         "Force maximum compute capability", "0");
+  option_parser_register(
+      opp, "-gpgpu_ptx_inst_debug_to_file", OPT_BOOL, &g_ptx_inst_debug_to_file,
+      "Dump executed instructions' debug information to file", "0");
+  option_parser_register(
+      opp, "-gpgpu_ptx_inst_debug_file", OPT_CSTR, &g_ptx_inst_debug_file,
+      "Executed instructions' debug output file", "inst_debug.txt");
+  option_parser_register(opp, "-gpgpu_ptx_inst_debug_thread_uid", OPT_INT32,
+                         &g_ptx_inst_debug_thread_uid,
+                         "Thread UID for executed instructions' debug output",
+                         "1");
 }
 
-void gpgpu_functional_sim_config::ptx_set_tex_cache_linesize(unsigned linesize)
-{
-   m_texcache_linesize = linesize;
+void gpgpu_functional_sim_config::ptx_set_tex_cache_linesize(
+    unsigned linesize) {
+  m_texcache_linesize = linesize;
 }
 
-gpgpu_t::gpgpu_t( const gpgpu_functional_sim_config &config, gpgpu_context* ctx )
-    : m_function_model_config(config)
-{
-   gpgpu_ctx = ctx;
-   m_global_mem = new memory_space_impl<8192>("global",64*1024);
-   
-   m_tex_mem = new memory_space_impl<8192>("tex",64*1024);
-   m_surf_mem = new memory_space_impl<8192>("surf",64*1024);
+gpgpu_t::gpgpu_t(const gpgpu_functional_sim_config &config, gpgpu_context *ctx)
+    : m_function_model_config(config) {
+  gpgpu_ctx = ctx;
+  m_global_mem = new memory_space_impl<8192>("global", 64 * 1024);
 
-   m_dev_malloc=GLOBAL_HEAP_START; 
-   checkpoint_option = m_function_model_config.get_checkpoint_option();
-   checkpoint_kernel = m_function_model_config.get_checkpoint_kernel();
-   checkpoint_CTA = m_function_model_config.get_checkpoint_CTA();
-   resume_option = m_function_model_config.get_resume_option();
-   resume_kernel = m_function_model_config.get_resume_kernel();
-   resume_CTA = m_function_model_config.get_resume_CTA();
-   checkpoint_CTA_t = m_function_model_config.get_checkpoint_CTA_t();
-   checkpoint_insn_Y = m_function_model_config.get_checkpoint_insn_Y();
+  m_tex_mem = new memory_space_impl<8192>("tex", 64 * 1024);
+  m_surf_mem = new memory_space_impl<8192>("surf", 64 * 1024);
 
-   // initialize texture mappings to empty
-   m_NameToTextureInfo.clear();
-   m_NameToCudaArray.clear();
-   m_TextureRefToName.clear();
-   m_NameToAttribute.clear();
+  m_dev_malloc = GLOBAL_HEAP_START;
+  checkpoint_option = m_function_model_config.get_checkpoint_option();
+  checkpoint_kernel = m_function_model_config.get_checkpoint_kernel();
+  checkpoint_CTA = m_function_model_config.get_checkpoint_CTA();
+  resume_option = m_function_model_config.get_resume_option();
+  resume_kernel = m_function_model_config.get_resume_kernel();
+  resume_CTA = m_function_model_config.get_resume_CTA();
+  checkpoint_CTA_t = m_function_model_config.get_checkpoint_CTA_t();
+  checkpoint_insn_Y = m_function_model_config.get_checkpoint_insn_Y();
 
-   if(m_function_model_config.get_ptx_inst_debug_to_file() != 0) 
-      ptx_inst_debug_file = fopen(m_function_model_config.get_ptx_inst_debug_file(), "w");
+  // initialize texture mappings to empty
+  m_NameToTextureInfo.clear();
+  m_NameToCudaArray.clear();
+  m_TextureRefToName.clear();
+  m_NameToAttribute.clear();
 
-   gpu_sim_cycle=0;
-   gpu_tot_sim_cycle=0;
+  if (m_function_model_config.get_ptx_inst_debug_to_file() != 0)
+    ptx_inst_debug_file =
+        fopen(m_function_model_config.get_ptx_inst_debug_file(), "w");
+
+  gpu_sim_cycle = 0;
+  gpu_tot_sim_cycle = 0;
 }
 
-address_type line_size_based_tag_func(new_addr_type address, new_addr_type line_size)
-{
-   //gives the tag for an address based on a given line size
-   return address & ~(line_size-1);
+address_type line_size_based_tag_func(new_addr_type address,
+                                      new_addr_type line_size) {
+  // gives the tag for an address based on a given line size
+  return address & ~(line_size - 1);
 }
 
-const char * mem_access_type_str(enum mem_access_type access_type)
-{
-   #define MA_TUP_BEGIN(X) static const char* access_type_str[] = {
-   #define MA_TUP(X) #X
-   #define MA_TUP_END(X) };
-   MEM_ACCESS_TYPE_TUP_DEF
-   #undef MA_TUP_BEGIN
-   #undef MA_TUP
-   #undef MA_TUP_END
+const char *mem_access_type_str(enum mem_access_type access_type) {
+#define MA_TUP_BEGIN(X) static const char *access_type_str[] = {
+#define MA_TUP(X) #X
+#define MA_TUP_END(X) \
+  }                   \
+  ;
+  MEM_ACCESS_TYPE_TUP_DEF
+#undef MA_TUP_BEGIN
+#undef MA_TUP
+#undef MA_TUP_END
 
-   assert(access_type < NUM_MEM_ACCESS_TYPE); 
+  assert(access_type < NUM_MEM_ACCESS_TYPE);
 
-   return access_type_str[access_type]; 
+  return access_type_str[access_type];
 }
 
-
-void warp_inst_t::clear_active( const active_mask_t &inactive ) {
-    active_mask_t test = m_warp_active_mask;
-    test &= inactive;
-    assert( test == inactive ); // verify threads being disabled were active
-    m_warp_active_mask &= ~inactive;
+void warp_inst_t::clear_active(const active_mask_t &inactive) {
+  active_mask_t test = m_warp_active_mask;
+  test &= inactive;
+  assert(test == inactive);  // verify threads being disabled were active
+  m_warp_active_mask &= ~inactive;
 }
 
-void warp_inst_t::set_not_active( unsigned lane_id ) {
-    m_warp_active_mask.reset(lane_id);
+void warp_inst_t::set_not_active(unsigned lane_id) {
+  m_warp_active_mask.reset(lane_id);
 }
 
-void warp_inst_t::set_active( const active_mask_t &active ) {
-   m_warp_active_mask = active;
-   if( m_isatomic ) {
-      for( unsigned i=0; i < m_config->warp_size; i++ ) {
-         if( !m_warp_active_mask.test(i) ) {
-             m_per_scalar_thread[i].callback.function = NULL;
-             m_per_scalar_thread[i].callback.instruction = NULL;
-             m_per_scalar_thread[i].callback.thread = NULL;
-         }
+void warp_inst_t::set_active(const active_mask_t &active) {
+  m_warp_active_mask = active;
+  if (m_isatomic) {
+    for (unsigned i = 0; i < m_config->warp_size; i++) {
+      if (!m_warp_active_mask.test(i)) {
+        m_per_scalar_thread[i].callback.function = NULL;
+        m_per_scalar_thread[i].callback.instruction = NULL;
+        m_per_scalar_thread[i].callback.thread = NULL;
       }
-   }
+    }
+  }
 }
 
 void warp_inst_t::do_atomic(bool forceDo) {
-    do_atomic( m_warp_active_mask,forceDo );
+  do_atomic(m_warp_active_mask, forceDo);
 }
 
-
-void warp_inst_t::do_atomic( const active_mask_t& access_mask,bool forceDo ) {
-    assert( m_isatomic && (!m_empty||forceDo) );
-    for( unsigned i=0; i < m_config->warp_size; i++ )
-    {
-        if( access_mask.test(i) )
-        {
-            dram_callback_t &cb = m_per_scalar_thread[i].callback;
-            if( cb.thread )
-                cb.function(cb.instruction, cb.thread);
-        }
+void warp_inst_t::do_atomic(const active_mask_t &access_mask, bool forceDo) {
+  assert(m_isatomic && (!m_empty || forceDo));
+  for (unsigned i = 0; i < m_config->warp_size; i++) {
+    if (access_mask.test(i)) {
+      dram_callback_t &cb = m_per_scalar_thread[i].callback;
+      if (cb.thread) cb.function(cb.instruction, cb.thread);
     }
+  }
 }
 
-void warp_inst_t::broadcast_barrier_reduction(const active_mask_t& access_mask)
-{
-	for( unsigned i=0; i < m_config->warp_size; i++ )
-    {
-        if( access_mask.test(i) )
-        {
-            dram_callback_t &cb = m_per_scalar_thread[i].callback;
-            if( cb.thread ){
-                cb.function(cb.instruction, cb.thread);
-            }
-        }
+void warp_inst_t::broadcast_barrier_reduction(
+    const active_mask_t &access_mask) {
+  for (unsigned i = 0; i < m_config->warp_size; i++) {
+    if (access_mask.test(i)) {
+      dram_callback_t &cb = m_per_scalar_thread[i].callback;
+      if (cb.thread) {
+        cb.function(cb.instruction, cb.thread);
+      }
     }
+  }
 }
 
-void warp_inst_t::generate_mem_accesses()
-{
-    if( empty() || op == MEMORY_BARRIER_OP || m_mem_accesses_created ) 
-        return;
-    if (!((op == LOAD_OP) || (op==TENSOR_CORE_LOAD_OP)   || (op == STORE_OP)||(op==TENSOR_CORE_STORE_OP)))
-        return; 
-    if( m_warp_active_mask.count() == 0 ) 
-        return; // predicated off
+void warp_inst_t::generate_mem_accesses() {
+  if (empty() || op == MEMORY_BARRIER_OP || m_mem_accesses_created) return;
+  if (!((op == LOAD_OP) || (op == TENSOR_CORE_LOAD_OP) || (op == STORE_OP) ||
+        (op == TENSOR_CORE_STORE_OP)))
+    return;
+  if (m_warp_active_mask.count() == 0) return;  // predicated off
 
-    const size_t starting_queue_size = m_accessq.size();
+  const size_t starting_queue_size = m_accessq.size();
 
-    assert( is_load() || is_store() );
-    assert( m_per_scalar_thread_valid ); // need address information per thread
+  assert(is_load() || is_store());
+  assert(m_per_scalar_thread_valid);  // need address information per thread
 
-    bool is_write = is_store();
+  bool is_write = is_store();
 
-    mem_access_type access_type;
-    switch (space.get_type()) {
+  mem_access_type access_type;
+  switch (space.get_type()) {
     case const_space:
-    case param_space_kernel: 
-        access_type = CONST_ACC_R; 
-        break;
-    case tex_space: 
-        access_type = TEXTURE_ACC_R;   
-        break;
-    case global_space:       
-        access_type = is_write? GLOBAL_ACC_W: GLOBAL_ACC_R;   
-        break;
+    case param_space_kernel:
+      access_type = CONST_ACC_R;
+      break;
+    case tex_space:
+      access_type = TEXTURE_ACC_R;
+      break;
+    case global_space:
+      access_type = is_write ? GLOBAL_ACC_W : GLOBAL_ACC_R;
+      break;
     case local_space:
-    case param_space_local:  
-        access_type = is_write? LOCAL_ACC_W: LOCAL_ACC_R;   
-        break;
-    case shared_space: break;
-    case sstarr_space: break;
-    default: assert(0); break; 
-    }
+    case param_space_local:
+      access_type = is_write ? LOCAL_ACC_W : LOCAL_ACC_R;
+      break;
+    case shared_space:
+      break;
+    case sstarr_space:
+      break;
+    default:
+      assert(0);
+      break;
+  }
 
-    // Calculate memory accesses generated by this warp
-    new_addr_type cache_block_size = 0; // in bytes 
+  // Calculate memory accesses generated by this warp
+  new_addr_type cache_block_size = 0;  // in bytes
 
-    switch( space.get_type() ) {
+  switch (space.get_type()) {
     case shared_space:
     case sstarr_space: {
-        unsigned subwarp_size = m_config->warp_size / m_config->mem_warp_parts;
-        unsigned total_accesses=0;
-        for( unsigned subwarp=0; subwarp <  m_config->mem_warp_parts; subwarp++ ) {
+      unsigned subwarp_size = m_config->warp_size / m_config->mem_warp_parts;
+      unsigned total_accesses = 0;
+      for (unsigned subwarp = 0; subwarp < m_config->mem_warp_parts;
+           subwarp++) {
+        // data structures used per part warp
+        std::map<unsigned, std::map<new_addr_type, unsigned> >
+            bank_accs;  // bank -> word address -> access count
 
-            // data structures used per part warp 
-            std::map<unsigned,std::map<new_addr_type,unsigned> > bank_accs; // bank -> word address -> access count
-
-            // step 1: compute accesses to words in banks
-            for( unsigned thread=subwarp*subwarp_size; thread < (subwarp+1)*subwarp_size; thread++ ) {
-                if( !active(thread) ) 
-                    continue;
-                new_addr_type addr = m_per_scalar_thread[thread].memreqaddr[0];
-                //FIXME: deferred allocation of shared memory should not accumulate across kernel launches
-                //assert( addr < m_config->gpgpu_shmem_size ); 
-                unsigned bank = m_config->shmem_bank_func(addr);
-                new_addr_type word = line_size_based_tag_func(addr,m_config->WORD_SIZE);
-                bank_accs[bank][word]++;
-            }
-
-            if (m_config->shmem_limited_broadcast) {
-                // step 2: look for and select a broadcast bank/word if one occurs
-                bool broadcast_detected = false;
-                new_addr_type broadcast_word=(new_addr_type)-1;
-                unsigned broadcast_bank=(unsigned)-1;
-                std::map<unsigned,std::map<new_addr_type,unsigned> >::iterator b;
-                for( b=bank_accs.begin(); b != bank_accs.end(); b++ ) {
-                    unsigned bank = b->first;
-                    std::map<new_addr_type,unsigned> &access_set = b->second;
-                    std::map<new_addr_type,unsigned>::iterator w;
-                    for( w=access_set.begin(); w != access_set.end(); ++w ) {
-                        if( w->second > 1 ) {
-                            // found a broadcast
-                            broadcast_detected=true;
-                            broadcast_bank=bank;
-                            broadcast_word=w->first;
-                            break;
-                        }
-                    }
-                    if( broadcast_detected ) 
-                        break;
-                }
-            
-                // step 3: figure out max bank accesses performed, taking account of broadcast case
-                unsigned max_bank_accesses=0;
-                for( b=bank_accs.begin(); b != bank_accs.end(); b++ ) {
-                    unsigned bank_accesses=0;
-                    std::map<new_addr_type,unsigned> &access_set = b->second;
-                    std::map<new_addr_type,unsigned>::iterator w;
-                    for( w=access_set.begin(); w != access_set.end(); ++w ) 
-                        bank_accesses += w->second;
-                    if( broadcast_detected && broadcast_bank == b->first ) {
-                        for( w=access_set.begin(); w != access_set.end(); ++w ) {
-                            if( w->first == broadcast_word ) {
-                                unsigned n = w->second;
-                                assert(n > 1); // or this wasn't a broadcast
-                                assert(bank_accesses >= (n-1));
-                                bank_accesses -= (n-1);
-                                break;
-                            }
-                        }
-                    }
-                    if( bank_accesses > max_bank_accesses ) 
-                        max_bank_accesses = bank_accesses;
-                }
-
-                // step 4: accumulate
-                total_accesses+= max_bank_accesses;
-            } else {
-                // step 2: look for the bank with the maximum number of access to different words 
-                unsigned max_bank_accesses=0;
-                std::map<unsigned,std::map<new_addr_type,unsigned> >::iterator b;
-                for( b=bank_accs.begin(); b != bank_accs.end(); b++ ) {
-                    max_bank_accesses = std::max(max_bank_accesses, (unsigned)b->second.size());
-                }
-
-                // step 3: accumulate
-                total_accesses+= max_bank_accesses;
-            }
+        // step 1: compute accesses to words in banks
+        for (unsigned thread = subwarp * subwarp_size;
+             thread < (subwarp + 1) * subwarp_size; thread++) {
+          if (!active(thread)) continue;
+          new_addr_type addr = m_per_scalar_thread[thread].memreqaddr[0];
+          // FIXME: deferred allocation of shared memory should not accumulate
+          // across kernel launches assert( addr < m_config->gpgpu_shmem_size );
+          unsigned bank = m_config->shmem_bank_func(addr);
+          new_addr_type word =
+              line_size_based_tag_func(addr, m_config->WORD_SIZE);
+          bank_accs[bank][word]++;
         }
-        assert( total_accesses > 0 && total_accesses <= m_config->warp_size );
-        cycles = total_accesses; // shared memory conflicts modeled as larger initiation interval 
-        m_config->gpgpu_ctx->stats->ptx_file_line_stats_add_smem_bank_conflict( pc, total_accesses );
-        break;
+
+        if (m_config->shmem_limited_broadcast) {
+          // step 2: look for and select a broadcast bank/word if one occurs
+          bool broadcast_detected = false;
+          new_addr_type broadcast_word = (new_addr_type)-1;
+          unsigned broadcast_bank = (unsigned)-1;
+          std::map<unsigned, std::map<new_addr_type, unsigned> >::iterator b;
+          for (b = bank_accs.begin(); b != bank_accs.end(); b++) {
+            unsigned bank = b->first;
+            std::map<new_addr_type, unsigned> &access_set = b->second;
+            std::map<new_addr_type, unsigned>::iterator w;
+            for (w = access_set.begin(); w != access_set.end(); ++w) {
+              if (w->second > 1) {
+                // found a broadcast
+                broadcast_detected = true;
+                broadcast_bank = bank;
+                broadcast_word = w->first;
+                break;
+              }
+            }
+            if (broadcast_detected) break;
+          }
+
+          // step 3: figure out max bank accesses performed, taking account of
+          // broadcast case
+          unsigned max_bank_accesses = 0;
+          for (b = bank_accs.begin(); b != bank_accs.end(); b++) {
+            unsigned bank_accesses = 0;
+            std::map<new_addr_type, unsigned> &access_set = b->second;
+            std::map<new_addr_type, unsigned>::iterator w;
+            for (w = access_set.begin(); w != access_set.end(); ++w)
+              bank_accesses += w->second;
+            if (broadcast_detected && broadcast_bank == b->first) {
+              for (w = access_set.begin(); w != access_set.end(); ++w) {
+                if (w->first == broadcast_word) {
+                  unsigned n = w->second;
+                  assert(n > 1);  // or this wasn't a broadcast
+                  assert(bank_accesses >= (n - 1));
+                  bank_accesses -= (n - 1);
+                  break;
+                }
+              }
+            }
+            if (bank_accesses > max_bank_accesses)
+              max_bank_accesses = bank_accesses;
+          }
+
+          // step 4: accumulate
+          total_accesses += max_bank_accesses;
+        } else {
+          // step 2: look for the bank with the maximum number of access to
+          // different words
+          unsigned max_bank_accesses = 0;
+          std::map<unsigned, std::map<new_addr_type, unsigned> >::iterator b;
+          for (b = bank_accs.begin(); b != bank_accs.end(); b++) {
+            max_bank_accesses =
+                std::max(max_bank_accesses, (unsigned)b->second.size());
+          }
+
+          // step 3: accumulate
+          total_accesses += max_bank_accesses;
+        }
+      }
+      assert(total_accesses > 0 && total_accesses <= m_config->warp_size);
+      cycles = total_accesses;  // shared memory conflicts modeled as larger
+                                // initiation interval
+      m_config->gpgpu_ctx->stats->ptx_file_line_stats_add_smem_bank_conflict(
+          pc, total_accesses);
+      break;
     }
 
-    case tex_space: 
-        cache_block_size = m_config->gpgpu_cache_texl1_linesize;
-        break;
-    case const_space:  case param_space_kernel:
-        cache_block_size = m_config->gpgpu_cache_constl1_linesize; 
-        break;
+    case tex_space:
+      cache_block_size = m_config->gpgpu_cache_texl1_linesize;
+      break;
+    case const_space:
+    case param_space_kernel:
+      cache_block_size = m_config->gpgpu_cache_constl1_linesize;
+      break;
 
-    case global_space: case local_space: case param_space_local:
-    	 if( m_config->gpgpu_coalesce_arch >= 13) {
-            if(isatomic())
-                memory_coalescing_arch_atomic(is_write, access_type);
-            else
-                memory_coalescing_arch(is_write, access_type);
-         } else abort();
+    case global_space:
+    case local_space:
+    case param_space_local:
+      if (m_config->gpgpu_coalesce_arch >= 13) {
+        if (isatomic())
+          memory_coalescing_arch_atomic(is_write, access_type);
+        else
+          memory_coalescing_arch(is_write, access_type);
+      } else
+        abort();
 
-        break;
+      break;
 
     default:
-        abort();
-    }
+      abort();
+  }
 
-    if( cache_block_size ) {
-        assert( m_accessq.empty() );
-        mem_access_byte_mask_t byte_mask; 
-        std::map<new_addr_type,active_mask_t> accesses; // block address -> set of thread offsets in warp
-        std::map<new_addr_type,active_mask_t>::iterator a;
-        for( unsigned thread=0; thread < m_config->warp_size; thread++ ) {
-            if( !active(thread) ) 
-                continue;
-            new_addr_type addr = m_per_scalar_thread[thread].memreqaddr[0];
-            unsigned block_address = line_size_based_tag_func(addr,cache_block_size);
-            accesses[block_address].set(thread);
-            unsigned idx = addr-block_address; 
-            for( unsigned i=0; i < data_size; i++ ) 
-                byte_mask.set(idx+i);
+  if (cache_block_size) {
+    assert(m_accessq.empty());
+    mem_access_byte_mask_t byte_mask;
+    std::map<new_addr_type, active_mask_t>
+        accesses;  // block address -> set of thread offsets in warp
+    std::map<new_addr_type, active_mask_t>::iterator a;
+    for (unsigned thread = 0; thread < m_config->warp_size; thread++) {
+      if (!active(thread)) continue;
+      new_addr_type addr = m_per_scalar_thread[thread].memreqaddr[0];
+      unsigned block_address = line_size_based_tag_func(addr, cache_block_size);
+      accesses[block_address].set(thread);
+      unsigned idx = addr - block_address;
+      for (unsigned i = 0; i < data_size; i++) byte_mask.set(idx + i);
+    }
+    for (a = accesses.begin(); a != accesses.end(); ++a)
+      m_accessq.push_back(mem_access_t(
+          access_type, a->first, cache_block_size, is_write, a->second,
+          byte_mask, mem_access_sector_mask_t(), m_config->gpgpu_ctx));
+  }
+
+  if (space.get_type() == global_space) {
+    m_config->gpgpu_ctx->stats->ptx_file_line_stats_add_uncoalesced_gmem(
+        pc, m_accessq.size() - starting_queue_size);
+  }
+  m_mem_accesses_created = true;
+}
+
+void warp_inst_t::memory_coalescing_arch(bool is_write,
+                                         mem_access_type access_type) {
+  // see the CUDA manual where it discusses coalescing rules before reading this
+  unsigned segment_size = 0;
+  unsigned warp_parts = m_config->mem_warp_parts;
+  bool sector_segment_size = false;
+
+  if (m_config->gpgpu_coalesce_arch >= 20 &&
+      m_config->gpgpu_coalesce_arch < 39) {
+    // Fermi and Kepler, L1 is normal and L2 is sector
+    if (m_config->gmem_skip_L1D || cache_op == CACHE_GLOBAL)
+      sector_segment_size = true;
+    else
+      sector_segment_size = false;
+  } else if (m_config->gpgpu_coalesce_arch >= 40) {
+    // Maxwell, Pascal and Volta, L1 and L2 are sectors
+    // all requests should be 32 bytes
+    sector_segment_size = true;
+  }
+
+  switch (data_size) {
+    case 1:
+      segment_size = 32;
+      break;
+    case 2:
+      segment_size = sector_segment_size ? 32 : 64;
+      break;
+    case 4:
+    case 8:
+    case 16:
+      segment_size = sector_segment_size ? 32 : 128;
+      break;
+  }
+  unsigned subwarp_size = m_config->warp_size / warp_parts;
+
+  for (unsigned subwarp = 0; subwarp < warp_parts; subwarp++) {
+    std::map<new_addr_type, transaction_info> subwarp_transactions;
+
+    // step 1: find all transactions generated by this subwarp
+    for (unsigned thread = subwarp * subwarp_size;
+         thread < subwarp_size * (subwarp + 1); thread++) {
+      if (!active(thread)) continue;
+
+      unsigned data_size_coales = data_size;
+      unsigned num_accesses = 1;
+
+      if (space.get_type() == local_space ||
+          space.get_type() == param_space_local) {
+        // Local memory accesses >4B were split into 4B chunks
+        if (data_size >= 4) {
+          data_size_coales = 4;
+          num_accesses = data_size / 4;
         }
-        for( a=accesses.begin(); a != accesses.end(); ++a ) 
-            m_accessq.push_back( mem_access_t(access_type,a->first,cache_block_size,is_write,a->second, byte_mask, mem_access_sector_mask_t(), m_config->gpgpu_ctx));
+        // Otherwise keep the same data_size for sub-4B access to local memory
+      }
+
+      assert(num_accesses <= MAX_ACCESSES_PER_INSN_PER_THREAD);
+
+      //            for(unsigned access=0; access<num_accesses; access++) {
+      for (unsigned access = 0;
+           (access < MAX_ACCESSES_PER_INSN_PER_THREAD) &&
+           (m_per_scalar_thread[thread].memreqaddr[access] != 0);
+           access++) {
+        new_addr_type addr = m_per_scalar_thread[thread].memreqaddr[access];
+        unsigned block_address = line_size_based_tag_func(addr, segment_size);
+        unsigned chunk =
+            (addr & 127) / 32;  // which 32-byte chunk within in a 128-byte
+                                // chunk does this thread access?
+        transaction_info &info = subwarp_transactions[block_address];
+
+        // can only write to one segment
+        assert(block_address == line_size_based_tag_func(
+                                    addr + data_size_coales - 1, segment_size));
+
+        info.chunks.set(chunk);
+        info.active.set(thread);
+        unsigned idx = (addr & 127);
+        for (unsigned i = 0; i < data_size_coales; i++) info.bytes.set(idx + i);
+      }
     }
 
-    if ( space.get_type() == global_space ) {
-        m_config->gpgpu_ctx->stats->ptx_file_line_stats_add_uncoalesced_gmem( pc, m_accessq.size() - starting_queue_size );
+    // step 2: reduce each transaction size, if possible
+    std::map<new_addr_type, transaction_info>::iterator t;
+    for (t = subwarp_transactions.begin(); t != subwarp_transactions.end();
+         t++) {
+      new_addr_type addr = t->first;
+      const transaction_info &info = t->second;
+
+      memory_coalescing_arch_reduce_and_send(is_write, access_type, info, addr,
+                                             segment_size);
     }
-    m_mem_accesses_created=true;
+  }
 }
 
-void warp_inst_t::memory_coalescing_arch( bool is_write, mem_access_type access_type )
-{
-    // see the CUDA manual where it discusses coalescing rules before reading this
-    unsigned segment_size = 0;
-    unsigned warp_parts = m_config->mem_warp_parts;
-    bool sector_segment_size = false;
+void warp_inst_t::memory_coalescing_arch_atomic(bool is_write,
+                                                mem_access_type access_type) {
+  assert(space.get_type() ==
+         global_space);  // Atomics allowed only for global memory
 
-    if(m_config->gpgpu_coalesce_arch >= 20 && m_config->gpgpu_coalesce_arch < 39)
-    {
-    	//Fermi and Kepler, L1 is normal and L2 is sector
-    	if(m_config->gmem_skip_L1D || cache_op == CACHE_GLOBAL)
-    		sector_segment_size = true;
-    	else
-    		sector_segment_size = false;
-    }
-    else if(m_config->gpgpu_coalesce_arch >= 40)
-    {
-    	//Maxwell, Pascal and Volta, L1 and L2 are sectors
-    	//all requests should be 32 bytes
-    	sector_segment_size = true;
-    }
+  // see the CUDA manual where it discusses coalescing rules before reading this
+  unsigned segment_size = 0;
+  unsigned warp_parts = m_config->mem_warp_parts;
+  bool sector_segment_size = false;
 
-    switch( data_size ) {
-    case 1: segment_size = 32; break;
-    case 2: segment_size = sector_segment_size? 32 : 64; break;
-    case 4: case 8: case 16: segment_size = sector_segment_size? 32 : 128; break;
-    }
-    unsigned subwarp_size = m_config->warp_size / warp_parts;
+  if (m_config->gpgpu_coalesce_arch >= 20 &&
+      m_config->gpgpu_coalesce_arch < 39) {
+    // Fermi and Kepler, L1 is normal and L2 is sector
+    if (m_config->gmem_skip_L1D || cache_op == CACHE_GLOBAL)
+      sector_segment_size = true;
+    else
+      sector_segment_size = false;
+  } else if (m_config->gpgpu_coalesce_arch >= 40) {
+    // Maxwell, Pascal and Volta, L1 and L2 are sectors
+    // all requests should be 32 bytes
+    sector_segment_size = true;
+  }
 
-    for( unsigned subwarp=0; subwarp <  warp_parts; subwarp++ ) {
-        std::map<new_addr_type,transaction_info> subwarp_transactions;
+  switch (data_size) {
+    case 1:
+      segment_size = 32;
+      break;
+    case 2:
+      segment_size = sector_segment_size ? 32 : 64;
+      break;
+    case 4:
+    case 8:
+    case 16:
+      segment_size = sector_segment_size ? 32 : 128;
+      break;
+  }
+  unsigned subwarp_size = m_config->warp_size / warp_parts;
 
-        // step 1: find all transactions generated by this subwarp
-        for( unsigned thread=subwarp*subwarp_size; thread<subwarp_size*(subwarp+1); thread++ ) {
-            if( !active(thread) )
-                continue;
+  for (unsigned subwarp = 0; subwarp < warp_parts; subwarp++) {
+    std::map<new_addr_type, std::list<transaction_info> >
+        subwarp_transactions;  // each block addr maps to a list of transactions
 
-            unsigned data_size_coales = data_size;
-            unsigned num_accesses = 1;
+    // step 1: find all transactions generated by this subwarp
+    for (unsigned thread = subwarp * subwarp_size;
+         thread < subwarp_size * (subwarp + 1); thread++) {
+      if (!active(thread)) continue;
 
-            if( space.get_type() == local_space || space.get_type() == param_space_local ) {
-               // Local memory accesses >4B were split into 4B chunks
-               if(data_size >= 4) {
-                  data_size_coales = 4;
-                  num_accesses = data_size/4;
-               }
-               // Otherwise keep the same data_size for sub-4B access to local memory
-            }
+      new_addr_type addr = m_per_scalar_thread[thread].memreqaddr[0];
+      unsigned block_address = line_size_based_tag_func(addr, segment_size);
+      unsigned chunk =
+          (addr & 127) / 32;  // which 32-byte chunk within in a 128-byte chunk
+                              // does this thread access?
 
+      // can only write to one segment
+      assert(block_address ==
+             line_size_based_tag_func(addr + data_size - 1, segment_size));
 
-            assert(num_accesses <= MAX_ACCESSES_PER_INSN_PER_THREAD);
-
-//            for(unsigned access=0; access<num_accesses; access++) {
-            for(unsigned access=0; (access<MAX_ACCESSES_PER_INSN_PER_THREAD)&&(m_per_scalar_thread[thread].memreqaddr[access]!=0); access++) {
-                new_addr_type addr = m_per_scalar_thread[thread].memreqaddr[access];
-                unsigned block_address = line_size_based_tag_func(addr,segment_size);
-                unsigned chunk = (addr&127)/32; // which 32-byte chunk within in a 128-byte chunk does this thread access?
-                transaction_info &info = subwarp_transactions[block_address];
-
-                // can only write to one segment
-                assert(block_address == line_size_based_tag_func(addr+data_size_coales-1,segment_size));
-
-                info.chunks.set(chunk);
-                info.active.set(thread);
-                unsigned idx = (addr&127);
-                for( unsigned i=0; i < data_size_coales; i++ )
-                    info.bytes.set(idx+i);
-            }
+      // Find a transaction that does not conflict with this thread's accesses
+      bool new_transaction = true;
+      std::list<transaction_info>::iterator it;
+      transaction_info *info;
+      for (it = subwarp_transactions[block_address].begin();
+           it != subwarp_transactions[block_address].end(); it++) {
+        unsigned idx = (addr & 127);
+        if (not it->test_bytes(idx, idx + data_size - 1)) {
+          new_transaction = false;
+          info = &(*it);
+          break;
         }
+      }
+      if (new_transaction) {
+        // Need a new transaction
+        subwarp_transactions[block_address].push_back(transaction_info());
+        info = &subwarp_transactions[block_address].back();
+      }
+      assert(info);
 
-        // step 2: reduce each transaction size, if possible
-        std::map< new_addr_type, transaction_info >::iterator t;
-        for( t=subwarp_transactions.begin(); t !=subwarp_transactions.end(); t++ ) {
-            new_addr_type addr = t->first;
-            const transaction_info &info = t->second;
-
-            memory_coalescing_arch_reduce_and_send(is_write, access_type, info, addr, segment_size);
-
-        }
+      info->chunks.set(chunk);
+      info->active.set(thread);
+      unsigned idx = (addr & 127);
+      for (unsigned i = 0; i < data_size; i++) {
+        assert(!info->bytes.test(idx + i));
+        info->bytes.set(idx + i);
+      }
     }
+
+    // step 2: reduce each transaction size, if possible
+    std::map<new_addr_type, std::list<transaction_info> >::iterator t_list;
+    for (t_list = subwarp_transactions.begin();
+         t_list != subwarp_transactions.end(); t_list++) {
+      // For each block addr
+      new_addr_type addr = t_list->first;
+      const std::list<transaction_info> &transaction_list = t_list->second;
+
+      std::list<transaction_info>::const_iterator t;
+      for (t = transaction_list.begin(); t != transaction_list.end(); t++) {
+        // For each transaction
+        const transaction_info &info = *t;
+        memory_coalescing_arch_reduce_and_send(is_write, access_type, info,
+                                               addr, segment_size);
+      }
+    }
+  }
 }
 
-void warp_inst_t::memory_coalescing_arch_atomic( bool is_write, mem_access_type access_type )
-{
+void warp_inst_t::memory_coalescing_arch_reduce_and_send(
+    bool is_write, mem_access_type access_type, const transaction_info &info,
+    new_addr_type addr, unsigned segment_size) {
+  assert((addr & (segment_size - 1)) == 0);
 
-   assert(space.get_type() == global_space); // Atomics allowed only for global memory
+  const std::bitset<4> &q = info.chunks;
+  assert(q.count() >= 1);
+  std::bitset<2> h;  // halves (used to check if 64 byte segment can be
+                     // compressed into a single 32 byte segment)
 
-   // see the CUDA manual where it discusses coalescing rules before reading this
-   unsigned segment_size = 0;
-   unsigned warp_parts = m_config->mem_warp_parts;
-   bool sector_segment_size = false;
-
-   if(m_config->gpgpu_coalesce_arch >= 20 && m_config->gpgpu_coalesce_arch < 39)
-   {
-	//Fermi and Kepler, L1 is normal and L2 is sector
-	if(m_config->gmem_skip_L1D || cache_op == CACHE_GLOBAL)
-		sector_segment_size = true;
-	else
-		sector_segment_size = false;
-   }
-   else if(m_config->gpgpu_coalesce_arch >= 40)
-   {
-	//Maxwell, Pascal and Volta, L1 and L2 are sectors
-	//all requests should be 32 bytes
-	sector_segment_size = true;
-   }
-
-   switch( data_size ) {
-   case 1: segment_size = 32; break;
-   case 2: segment_size = sector_segment_size? 32 : 64; break;
-   case 4: case 8: case 16: segment_size = sector_segment_size? 32 : 128; break;
-   }
-   unsigned subwarp_size = m_config->warp_size / warp_parts;
-
-   for( unsigned subwarp=0; subwarp <  warp_parts; subwarp++ ) {
-       std::map<new_addr_type,std::list<transaction_info> > subwarp_transactions; // each block addr maps to a list of transactions
-
-       // step 1: find all transactions generated by this subwarp
-       for( unsigned thread=subwarp*subwarp_size; thread<subwarp_size*(subwarp+1); thread++ ) {
-           if( !active(thread) )
-               continue;
-
-           new_addr_type addr = m_per_scalar_thread[thread].memreqaddr[0];
-           unsigned block_address = line_size_based_tag_func(addr,segment_size);
-           unsigned chunk = (addr&127)/32; // which 32-byte chunk within in a 128-byte chunk does this thread access?
-
-           // can only write to one segment
-           assert(block_address == line_size_based_tag_func(addr+data_size-1,segment_size));
-
-           // Find a transaction that does not conflict with this thread's accesses
-           bool new_transaction = true;
-           std::list<transaction_info>::iterator it;
-           transaction_info* info;
-           for(it=subwarp_transactions[block_address].begin(); it!=subwarp_transactions[block_address].end(); it++) {
-              unsigned idx = (addr&127);
-              if(not it->test_bytes(idx,idx+data_size-1)) {
-                 new_transaction = false;
-                 info = &(*it);
-                 break;
-              }
-           }
-           if(new_transaction) {
-              // Need a new transaction
-              subwarp_transactions[block_address].push_back(transaction_info());
-              info = &subwarp_transactions[block_address].back();
-           }
-           assert(info);
-
-           info->chunks.set(chunk);
-           info->active.set(thread);
-           unsigned idx = (addr&127);
-           for( unsigned i=0; i < data_size; i++ ) {
-               assert(!info->bytes.test(idx+i));
-               info->bytes.set(idx+i);
-           }
-       }
-
-       // step 2: reduce each transaction size, if possible
-       std::map< new_addr_type, std::list<transaction_info> >::iterator t_list;
-       for( t_list=subwarp_transactions.begin(); t_list !=subwarp_transactions.end(); t_list++ ) {
-           // For each block addr
-           new_addr_type addr = t_list->first;
-           const std::list<transaction_info>& transaction_list = t_list->second;
-
-           std::list<transaction_info>::const_iterator t;
-           for(t=transaction_list.begin(); t!=transaction_list.end(); t++) {
-               // For each transaction
-               const transaction_info &info = *t;
-               memory_coalescing_arch_reduce_and_send(is_write, access_type, info, addr, segment_size);
-           }
-       }
-   }
+  unsigned size = segment_size;
+  if (segment_size == 128) {
+    bool lower_half_used = q[0] || q[1];
+    bool upper_half_used = q[2] || q[3];
+    if (lower_half_used && !upper_half_used) {
+      // only lower 64 bytes used
+      size = 64;
+      if (q[0]) h.set(0);
+      if (q[1]) h.set(1);
+    } else if ((!lower_half_used) && upper_half_used) {
+      // only upper 64 bytes used
+      addr = addr + 64;
+      size = 64;
+      if (q[2]) h.set(0);
+      if (q[3]) h.set(1);
+    } else {
+      assert(lower_half_used && upper_half_used);
+    }
+  } else if (segment_size == 64) {
+    // need to set halves
+    if ((addr % 128) == 0) {
+      if (q[0]) h.set(0);
+      if (q[1]) h.set(1);
+    } else {
+      assert((addr % 128) == 64);
+      if (q[2]) h.set(0);
+      if (q[3]) h.set(1);
+    }
+  }
+  if (size == 64) {
+    bool lower_half_used = h[0];
+    bool upper_half_used = h[1];
+    if (lower_half_used && !upper_half_used) {
+      size = 32;
+    } else if ((!lower_half_used) && upper_half_used) {
+      addr = addr + 32;
+      size = 32;
+    } else {
+      assert(lower_half_used && upper_half_used);
+    }
+  }
+  m_accessq.push_back(mem_access_t(access_type, addr, size, is_write,
+                                   info.active, info.bytes, info.chunks,
+                                   m_config->gpgpu_ctx));
 }
 
-void warp_inst_t::memory_coalescing_arch_reduce_and_send( bool is_write, mem_access_type access_type, const transaction_info &info, new_addr_type addr, unsigned segment_size )
-{
-   assert( (addr & (segment_size-1)) == 0 );
-
-   const std::bitset<4> &q = info.chunks;
-   assert( q.count() >= 1 );
-   std::bitset<2> h; // halves (used to check if 64 byte segment can be compressed into a single 32 byte segment)
-
-   unsigned size=segment_size;
-   if( segment_size == 128 ) {
-       bool lower_half_used = q[0] || q[1];
-       bool upper_half_used = q[2] || q[3];
-       if( lower_half_used && !upper_half_used ) {
-           // only lower 64 bytes used
-           size = 64;
-           if(q[0]) h.set(0);
-           if(q[1]) h.set(1);
-       } else if ( (!lower_half_used) && upper_half_used ) {
-           // only upper 64 bytes used
-           addr = addr+64;
-           size = 64;
-           if(q[2]) h.set(0);
-           if(q[3]) h.set(1);
-       } else {
-           assert(lower_half_used && upper_half_used);
-       }
-   } else if( segment_size == 64 ) {
-       // need to set halves
-       if( (addr % 128) == 0 ) {
-           if(q[0]) h.set(0);
-           if(q[1]) h.set(1);
-       } else {
-           assert( (addr % 128) == 64 );
-           if(q[2]) h.set(0);
-           if(q[3]) h.set(1);
-       }
-   }
-   if( size == 64 ) {
-       bool lower_half_used = h[0];
-       bool upper_half_used = h[1];
-       if( lower_half_used && !upper_half_used ) {
-           size = 32;
-       } else if ( (!lower_half_used) && upper_half_used ) {
-           addr = addr+32;
-           size = 32;
-       } else {
-           assert(lower_half_used && upper_half_used);
-       }
-   }
-   m_accessq.push_back( mem_access_t(access_type,addr,size,is_write,info.active,info.bytes, info.chunks,m_config->gpgpu_ctx) );
+void warp_inst_t::completed(unsigned long long cycle) const {
+  unsigned long long latency = cycle - issue_cycle;
+  assert(latency <= cycle);  // underflow detection
+  m_config->gpgpu_ctx->stats->ptx_file_line_stats_add_latency(
+      pc, latency * active_count());
 }
 
-void warp_inst_t::completed( unsigned long long cycle ) const 
-{
-   unsigned long long latency = cycle - issue_cycle; 
-   assert(latency <= cycle); // underflow detection 
-   m_config->gpgpu_ctx->stats->ptx_file_line_stats_add_latency(pc, latency * active_count());  
+kernel_info_t::kernel_info_t(dim3 gridDim, dim3 blockDim,
+                             class function_info *entry) {
+  m_kernel_entry = entry;
+  m_grid_dim = gridDim;
+  m_block_dim = blockDim;
+  m_next_cta.x = 0;
+  m_next_cta.y = 0;
+  m_next_cta.z = 0;
+  m_next_tid = m_next_cta;
+  m_num_cores_running = 0;
+  m_uid = (entry->gpgpu_ctx->kernel_info_m_next_uid)++;
+  m_param_mem = new memory_space_impl<8192>("param", 64 * 1024);
+
+  // Jin: parent and child kernel management for CDP
+  m_parent_kernel = NULL;
+
+  // Jin: launch latency management
+  m_launch_latency = entry->gpgpu_ctx->device_runtime->g_kernel_launch_latency;
+
+  volta_cache_config_set = false;
 }
 
-
-kernel_info_t::kernel_info_t( dim3 gridDim, dim3 blockDim, class function_info *entry)
-{
-    m_kernel_entry=entry;
-    m_grid_dim=gridDim;
-    m_block_dim=blockDim;
-    m_next_cta.x=0;
-    m_next_cta.y=0;
-    m_next_cta.z=0;
-    m_next_tid=m_next_cta;
-    m_num_cores_running=0;
-    m_uid = (entry->gpgpu_ctx->kernel_info_m_next_uid)++;
-    m_param_mem = new memory_space_impl<8192>("param",64*1024);
-
-    //Jin: parent and child kernel management for CDP
-    m_parent_kernel = NULL;
-
-    //Jin: launch latency management
-    m_launch_latency = entry->gpgpu_ctx->device_runtime->g_kernel_launch_latency;
-
-    volta_cache_config_set=false;
-}
-
-/*A snapshot of the texture mappings needs to be stored in the kernel's info as 
+/*A snapshot of the texture mappings needs to be stored in the kernel's info as
 kernels should use the texture bindings seen at the time of launch and textures
  can be bound/unbound asynchronously with respect to streams. */
-kernel_info_t::kernel_info_t( dim3 gridDim, dim3 blockDim, class function_info *entry, std::map<std::string, const struct cudaArray*> nameToCudaArray, std::map<std::string, const struct textureInfo*> nameToTextureInfo)   
-{
-    m_kernel_entry=entry;
-    m_grid_dim=gridDim;
-    m_block_dim=blockDim;
-    m_next_cta.x=0;
-    m_next_cta.y=0;
-    m_next_cta.z=0;
-    m_next_tid=m_next_cta;
-    m_num_cores_running=0;
-    m_uid = (entry->gpgpu_ctx->kernel_info_m_next_uid)++;
-    m_param_mem = new memory_space_impl<8192>("param",64*1024);
+kernel_info_t::kernel_info_t(
+    dim3 gridDim, dim3 blockDim, class function_info *entry,
+    std::map<std::string, const struct cudaArray *> nameToCudaArray,
+    std::map<std::string, const struct textureInfo *> nameToTextureInfo) {
+  m_kernel_entry = entry;
+  m_grid_dim = gridDim;
+  m_block_dim = blockDim;
+  m_next_cta.x = 0;
+  m_next_cta.y = 0;
+  m_next_cta.z = 0;
+  m_next_tid = m_next_cta;
+  m_num_cores_running = 0;
+  m_uid = (entry->gpgpu_ctx->kernel_info_m_next_uid)++;
+  m_param_mem = new memory_space_impl<8192>("param", 64 * 1024);
 
-    //Jin: parent and child kernel management for CDP
-    m_parent_kernel = NULL;
-   
-    //Jin: launch latency management
-    m_launch_latency = entry->gpgpu_ctx->device_runtime->g_kernel_launch_latency;
+  // Jin: parent and child kernel management for CDP
+  m_parent_kernel = NULL;
 
-    volta_cache_config_set=false;
-    m_NameToCudaArray = nameToCudaArray;
-    m_NameToTextureInfo = nameToTextureInfo;
+  // Jin: launch latency management
+  m_launch_latency = entry->gpgpu_ctx->device_runtime->g_kernel_launch_latency;
+
+  volta_cache_config_set = false;
+  m_NameToCudaArray = nameToCudaArray;
+  m_NameToTextureInfo = nameToTextureInfo;
 }
 
-kernel_info_t::~kernel_info_t()
-{
-    assert( m_active_threads.empty() );
-    destroy_cta_streams();
-    delete m_param_mem;
+kernel_info_t::~kernel_info_t() {
+  assert(m_active_threads.empty());
+  destroy_cta_streams();
+  delete m_param_mem;
 }
 
-std::string kernel_info_t::name() const
-{
-    return m_kernel_entry->get_name();
+std::string kernel_info_t::name() const { return m_kernel_entry->get_name(); }
+
+// Jin: parent and child kernel management for CDP
+void kernel_info_t::set_parent(kernel_info_t *parent, dim3 parent_ctaid,
+                               dim3 parent_tid) {
+  m_parent_kernel = parent;
+  m_parent_ctaid = parent_ctaid;
+  m_parent_tid = parent_tid;
+  parent->set_child(this);
 }
 
-//Jin: parent and child kernel management for CDP
-void kernel_info_t::set_parent(kernel_info_t * parent, 
-    dim3 parent_ctaid, dim3 parent_tid) {
-    m_parent_kernel = parent;
-    m_parent_ctaid = parent_ctaid;
-    m_parent_tid = parent_tid;
-    parent->set_child(this);
+void kernel_info_t::set_child(kernel_info_t *child) {
+  m_child_kernels.push_back(child);
 }
 
-void kernel_info_t::set_child(kernel_info_t * child) {
-    m_child_kernels.push_back(child);
-}
-
-void kernel_info_t::remove_child(kernel_info_t * child) {
-    assert(std::find(m_child_kernels.begin(), m_child_kernels.end(), child)
-        != m_child_kernels.end());
-    m_child_kernels.remove(child);
+void kernel_info_t::remove_child(kernel_info_t *child) {
+  assert(std::find(m_child_kernels.begin(), m_child_kernels.end(), child) !=
+         m_child_kernels.end());
+  m_child_kernels.remove(child);
 }
 
 bool kernel_info_t::is_finished() {
-  if(done() && children_all_finished())
-     return true;
+  if (done() && children_all_finished())
+    return true;
   else
-     return false;
+    return false;
 }
 
 bool kernel_info_t::children_all_finished() {
-   if(!m_child_kernels.empty())
-         return false;
-   
-   return true;
+  if (!m_child_kernels.empty()) return false;
+
+  return true;
 }
 
 void kernel_info_t::notify_parent_finished() {
-   if(m_parent_kernel) {
-       m_kernel_entry->gpgpu_ctx->device_runtime->g_total_param_size -= ((m_kernel_entry->get_args_aligned_size() + 255)/256*256);
-       m_parent_kernel->remove_child(this);
-       m_kernel_entry->gpgpu_ctx->the_gpgpusim->g_stream_manager->register_finished_kernel(m_parent_kernel->get_uid());
-   }
+  if (m_parent_kernel) {
+    m_kernel_entry->gpgpu_ctx->device_runtime->g_total_param_size -=
+        ((m_kernel_entry->get_args_aligned_size() + 255) / 256 * 256);
+    m_parent_kernel->remove_child(this);
+    m_kernel_entry->gpgpu_ctx->the_gpgpusim->g_stream_manager
+        ->register_finished_kernel(m_parent_kernel->get_uid());
+  }
 }
 
-CUstream_st * kernel_info_t::create_stream_cta(dim3 ctaid) {
-    assert(get_default_stream_cta(ctaid));
-    CUstream_st * stream = new CUstream_st();
-    m_kernel_entry->gpgpu_ctx->the_gpgpusim->g_stream_manager->add_stream(stream);
-    assert(m_cta_streams.find(ctaid) != m_cta_streams.end());
-    assert(m_cta_streams[ctaid].size() >= 1); //must have default stream
+CUstream_st *kernel_info_t::create_stream_cta(dim3 ctaid) {
+  assert(get_default_stream_cta(ctaid));
+  CUstream_st *stream = new CUstream_st();
+  m_kernel_entry->gpgpu_ctx->the_gpgpusim->g_stream_manager->add_stream(stream);
+  assert(m_cta_streams.find(ctaid) != m_cta_streams.end());
+  assert(m_cta_streams[ctaid].size() >= 1);  // must have default stream
+  m_cta_streams[ctaid].push_back(stream);
+
+  return stream;
+}
+
+CUstream_st *kernel_info_t::get_default_stream_cta(dim3 ctaid) {
+  if (m_cta_streams.find(ctaid) != m_cta_streams.end()) {
+    assert(m_cta_streams[ctaid].size() >=
+           1);  // already created, must have default stream
+    return *(m_cta_streams[ctaid].begin());
+  } else {
+    m_cta_streams[ctaid] = std::list<CUstream_st *>();
+    CUstream_st *stream = new CUstream_st();
+    m_kernel_entry->gpgpu_ctx->the_gpgpusim->g_stream_manager->add_stream(
+        stream);
     m_cta_streams[ctaid].push_back(stream);
-
     return stream;
+  }
 }
 
-CUstream_st * kernel_info_t::get_default_stream_cta(dim3 ctaid) {
-    if(m_cta_streams.find(ctaid) != m_cta_streams.end()) {
-       assert(m_cta_streams[ctaid].size() >= 1); //already created, must have default stream
-       return *(m_cta_streams[ctaid].begin());
-    }
-    else {
-      m_cta_streams[ctaid] = std::list<CUstream_st *>();
-      CUstream_st * stream = new CUstream_st();
-      m_kernel_entry->gpgpu_ctx->the_gpgpusim->g_stream_manager->add_stream(stream);
-      m_cta_streams[ctaid].push_back(stream);
-      return stream;
-    }
-}
+bool kernel_info_t::cta_has_stream(dim3 ctaid, CUstream_st *stream) {
+  if (m_cta_streams.find(ctaid) == m_cta_streams.end()) return false;
 
-bool kernel_info_t::cta_has_stream(dim3 ctaid, CUstream_st* stream) {
-    if(m_cta_streams.find(ctaid) == m_cta_streams.end())
-       return false;
-
-    std::list<CUstream_st *> &stream_list = m_cta_streams[ctaid];
-    if(std::find(stream_list.begin(), stream_list.end(), stream) 
-         == stream_list.end())
-       return false;
-    else
-       return true;
+  std::list<CUstream_st *> &stream_list = m_cta_streams[ctaid];
+  if (std::find(stream_list.begin(), stream_list.end(), stream) ==
+      stream_list.end())
+    return false;
+  else
+    return true;
 }
 
 void kernel_info_t::print_parent_info() {
-    if(m_parent_kernel) {
-        printf("Parent %d: \'%s\', Block (%d, %d, %d), Thread (%d, %d, %d)\n", 
-            m_parent_kernel->get_uid(), m_parent_kernel->name().c_str(), 
-            m_parent_ctaid.x, m_parent_ctaid.y, m_parent_ctaid.z,
-            m_parent_tid.x, m_parent_tid.y, m_parent_tid.z);
-    }
+  if (m_parent_kernel) {
+    printf("Parent %d: \'%s\', Block (%d, %d, %d), Thread (%d, %d, %d)\n",
+           m_parent_kernel->get_uid(), m_parent_kernel->name().c_str(),
+           m_parent_ctaid.x, m_parent_ctaid.y, m_parent_ctaid.z, m_parent_tid.x,
+           m_parent_tid.y, m_parent_tid.z);
+  }
 }
 
 void kernel_info_t::destroy_cta_streams() {
-     printf("Destroy streams for kernel %d: ", get_uid()); size_t stream_size = 0;
-     for(auto s = m_cta_streams.begin(); s != m_cta_streams.end(); s++) {
-        stream_size += s->second.size();
-        for(auto ss = s->second.begin(); ss != s->second.end(); ss++)
-        m_kernel_entry->gpgpu_ctx->the_gpgpusim->g_stream_manager->destroy_stream(*ss);
-        s->second.clear();
-     }
-     printf("size %lu\n", stream_size);
-     m_cta_streams.clear();
+  printf("Destroy streams for kernel %d: ", get_uid());
+  size_t stream_size = 0;
+  for (auto s = m_cta_streams.begin(); s != m_cta_streams.end(); s++) {
+    stream_size += s->second.size();
+    for (auto ss = s->second.begin(); ss != s->second.end(); ss++)
+      m_kernel_entry->gpgpu_ctx->the_gpgpusim->g_stream_manager->destroy_stream(
+          *ss);
+    s->second.clear();
+  }
+  printf("size %lu\n", stream_size);
+  m_cta_streams.clear();
 }
 
-simt_stack::simt_stack( unsigned wid, unsigned warpSize,  class gpgpu_sim * gpu)
-{
-    m_warp_id=wid;
-    m_warp_size = warpSize;
-    m_gpu=gpu;
-    reset();
+simt_stack::simt_stack(unsigned wid, unsigned warpSize, class gpgpu_sim *gpu) {
+  m_warp_id = wid;
+  m_warp_size = warpSize;
+  m_gpu = gpu;
+  reset();
 }
 
-void simt_stack::reset()
-{
-    m_stack.clear();
+void simt_stack::reset() { m_stack.clear(); }
+
+void simt_stack::launch(address_type start_pc, const simt_mask_t &active_mask) {
+  reset();
+  simt_stack_entry new_stack_entry;
+  new_stack_entry.m_pc = start_pc;
+  new_stack_entry.m_calldepth = 1;
+  new_stack_entry.m_active_mask = active_mask;
+  new_stack_entry.m_type = STACK_ENTRY_TYPE_NORMAL;
+  m_stack.push_back(new_stack_entry);
 }
 
-void simt_stack::launch( address_type start_pc, const simt_mask_t &active_mask )
-{
-    reset();
+void simt_stack::resume(char *fname) {
+  reset();
+
+  FILE *fp2 = fopen(fname, "r");
+  assert(fp2 != NULL);
+
+  char line[200]; /* or other suitable maximum line size */
+
+  while (fgets(line, sizeof line, fp2) != NULL) /* read a line */
+  {
     simt_stack_entry new_stack_entry;
-    new_stack_entry.m_pc = start_pc;
-    new_stack_entry.m_calldepth = 1;
-    new_stack_entry.m_active_mask = active_mask;
-    new_stack_entry.m_type = STACK_ENTRY_TYPE_NORMAL;
+    char *pch;
+    pch = strtok(line, " ");
+    for (unsigned j = 0; j < m_warp_size; j++) {
+      if (pch[0] == '1')
+        new_stack_entry.m_active_mask.set(j);
+      else
+        new_stack_entry.m_active_mask.reset(j);
+      pch = strtok(NULL, " ");
+    }
+
+    new_stack_entry.m_pc = atoi(pch);
+    pch = strtok(NULL, " ");
+    new_stack_entry.m_calldepth = atoi(pch);
+    pch = strtok(NULL, " ");
+    new_stack_entry.m_recvg_pc = atoi(pch);
+    pch = strtok(NULL, " ");
+    new_stack_entry.m_branch_div_cycle = atoi(pch);
+    pch = strtok(NULL, " ");
+    if (pch[0] == '0')
+      new_stack_entry.m_type = STACK_ENTRY_TYPE_NORMAL;
+    else
+      new_stack_entry.m_type = STACK_ENTRY_TYPE_CALL;
     m_stack.push_back(new_stack_entry);
+  }
+  fclose(fp2);
 }
 
-void simt_stack::resume( char * fname )
-{
-    reset();    
+const simt_mask_t &simt_stack::get_active_mask() const {
+  assert(m_stack.size() > 0);
+  return m_stack.back().m_active_mask;
+}
 
+void simt_stack::get_pdom_stack_top_info(unsigned *pc, unsigned *rpc) const {
+  assert(m_stack.size() > 0);
+  *pc = m_stack.back().m_pc;
+  *rpc = m_stack.back().m_recvg_pc;
+}
 
+unsigned simt_stack::get_rp() const {
+  assert(m_stack.size() > 0);
+  return m_stack.back().m_recvg_pc;
+}
 
-      FILE * fp2 = fopen(fname, "r");
-      assert(fp2!=NULL);
+void simt_stack::print(FILE *fout) const {
+  for (unsigned k = 0; k < m_stack.size(); k++) {
+    simt_stack_entry stack_entry = m_stack[k];
+    if (k == 0) {
+      fprintf(fout, "w%02d %1u ", m_warp_id, k);
+    } else {
+      fprintf(fout, "    %1u ", k);
+    }
+    for (unsigned j = 0; j < m_warp_size; j++)
+      fprintf(fout, "%c", (stack_entry.m_active_mask.test(j) ? '1' : '0'));
+    fprintf(fout, " pc: 0x%03x", stack_entry.m_pc);
+    if (stack_entry.m_recvg_pc == (unsigned)-1) {
+      fprintf(fout, " rp: ---- tp: %s cd: %2u ",
+              (stack_entry.m_type == STACK_ENTRY_TYPE_CALL ? "C" : "N"),
+              stack_entry.m_calldepth);
+    } else {
+      fprintf(fout, " rp: %4u tp: %s cd: %2u ", stack_entry.m_recvg_pc,
+              (stack_entry.m_type == STACK_ENTRY_TYPE_CALL ? "C" : "N"),
+              stack_entry.m_calldepth);
+    }
+    if (stack_entry.m_branch_div_cycle != 0) {
+      fprintf(fout, " bd@%6u ", (unsigned)stack_entry.m_branch_div_cycle);
+    } else {
+      fprintf(fout, " ");
+    }
+    m_gpu->gpgpu_ctx->func_sim->ptx_print_insn(stack_entry.m_pc, fout);
+    fprintf(fout, "\n");
+  }
+}
 
-      char line [ 200 ]; /* or other suitable maximum line size */
+void simt_stack::print_checkpoint(FILE *fout) const {
+  for (unsigned k = 0; k < m_stack.size(); k++) {
+    simt_stack_entry stack_entry = m_stack[k];
 
-      while ( fgets ( line, sizeof line, fp2 ) != NULL ) /* read a line */
-      {
-          simt_stack_entry new_stack_entry;
-          char * pch;
-          pch = strtok (line," ");
-          for (unsigned j=0; j<m_warp_size; j++)
-          {
-                if (pch[0]=='1')
-                    new_stack_entry.m_active_mask.set(j);
-                else
-                    new_stack_entry.m_active_mask.reset(j);
-                pch = strtok (NULL," ");
-                
-          }  
-          
-         new_stack_entry.m_pc=atoi(pch);
-         pch = strtok (NULL," "); 
-         new_stack_entry.m_calldepth=atoi(pch);
-         pch = strtok (NULL," "); 
-         new_stack_entry.m_recvg_pc=atoi(pch);
-         pch = strtok (NULL," "); 
-         new_stack_entry.m_branch_div_cycle=atoi(pch);
-         pch = strtok (NULL," "); 
-         if(pch[0]=='0')
-            new_stack_entry.m_type= STACK_ENTRY_TYPE_NORMAL;
-         else
-            new_stack_entry.m_type= STACK_ENTRY_TYPE_CALL;
-         m_stack.push_back(new_stack_entry);
+    for (unsigned j = 0; j < m_warp_size; j++)
+      fprintf(fout, "%c ", (stack_entry.m_active_mask.test(j) ? '1' : '0'));
+    fprintf(fout, "%d %d %d %lld %d ", stack_entry.m_pc,
+            stack_entry.m_calldepth, stack_entry.m_recvg_pc,
+            stack_entry.m_branch_div_cycle, stack_entry.m_type);
+    fprintf(fout, "%d %d\n", m_warp_id, m_warp_size);
+  }
+}
+
+void simt_stack::update(simt_mask_t &thread_done, addr_vector_t &next_pc,
+                        address_type recvg_pc, op_type next_inst_op,
+                        unsigned next_inst_size, address_type next_inst_pc) {
+  assert(m_stack.size() > 0);
+
+  assert(next_pc.size() == m_warp_size);
+
+  simt_mask_t top_active_mask = m_stack.back().m_active_mask;
+  address_type top_recvg_pc = m_stack.back().m_recvg_pc;
+  address_type top_pc =
+      m_stack.back().m_pc;  // the pc of the instruction just executed
+  stack_entry_type top_type = m_stack.back().m_type;
+  assert(top_pc == next_inst_pc);
+  assert(top_active_mask.any());
+
+  const address_type null_pc = -1;
+  bool warp_diverged = false;
+  address_type new_recvg_pc = null_pc;
+  unsigned num_divergent_paths = 0;
+
+  std::map<address_type, simt_mask_t> divergent_paths;
+  while (top_active_mask.any()) {
+    // extract a group of threads with the same next PC among the active threads
+    // in the warp
+    address_type tmp_next_pc = null_pc;
+    simt_mask_t tmp_active_mask;
+    for (int i = m_warp_size - 1; i >= 0; i--) {
+      if (top_active_mask.test(i)) {  // is this thread active?
+        if (thread_done.test(i)) {
+          top_active_mask.reset(i);  // remove completed thread from active mask
+        } else if (tmp_next_pc == null_pc) {
+          tmp_next_pc = next_pc[i];
+          tmp_active_mask.set(i);
+          top_active_mask.reset(i);
+        } else if (tmp_next_pc == next_pc[i]) {
+          tmp_active_mask.set(i);
+          top_active_mask.reset(i);
+        }
       }
-      fclose ( fp2 );
-
-    
-}
-
-const simt_mask_t &simt_stack::get_active_mask() const
-{
-    assert(m_stack.size() > 0);
-    return m_stack.back().m_active_mask;
-}
-
-void simt_stack::get_pdom_stack_top_info( unsigned *pc, unsigned *rpc ) const
-{
-   assert(m_stack.size() > 0);
-   *pc = m_stack.back().m_pc;
-   *rpc = m_stack.back().m_recvg_pc;
-}
-
-unsigned simt_stack::get_rp() const 
-{ 
-    assert(m_stack.size() > 0);
-    return m_stack.back().m_recvg_pc;
-}
-
-void simt_stack::print (FILE *fout) const
-{
-    for ( unsigned k=0; k < m_stack.size(); k++ ) {
-        simt_stack_entry stack_entry = m_stack[k];
-        if ( k==0 ) {
-            fprintf(fout, "w%02d %1u ", m_warp_id, k );
-        } else {
-            fprintf(fout, "    %1u ", k );
-        }
-        for (unsigned j=0; j<m_warp_size; j++)
-            fprintf(fout, "%c", (stack_entry.m_active_mask.test(j)?'1':'0') );
-        fprintf(fout, " pc: 0x%03x", stack_entry.m_pc );
-        if ( stack_entry.m_recvg_pc == (unsigned)-1 ) {
-            fprintf(fout," rp: ---- tp: %s cd: %2u ", (stack_entry.m_type==STACK_ENTRY_TYPE_CALL?"C":"N"), stack_entry.m_calldepth );
-        } else {
-            fprintf(fout," rp: %4u tp: %s cd: %2u ", stack_entry.m_recvg_pc, (stack_entry.m_type==STACK_ENTRY_TYPE_CALL?"C":"N"), stack_entry.m_calldepth );
-        }
-        if ( stack_entry.m_branch_div_cycle != 0 ) {
-            fprintf(fout," bd@%6u ", (unsigned) stack_entry.m_branch_div_cycle );
-        } else {
-            fprintf(fout," " );
-        }
-        m_gpu->gpgpu_ctx->func_sim->ptx_print_insn( stack_entry.m_pc, fout );
-        fprintf(fout,"\n");
     }
 
-}
-
-void simt_stack::print_checkpoint (FILE *fout) const
-{
-    for ( unsigned k=0; k < m_stack.size(); k++ ) {
-        simt_stack_entry stack_entry = m_stack[k];
-       
-        for (unsigned j=0; j<m_warp_size; j++)
-            fprintf(fout, "%c ", (stack_entry.m_active_mask.test(j)?'1':'0') );
-        fprintf(fout, "%d %d %d %lld %d ", stack_entry.m_pc,stack_entry.m_calldepth,stack_entry.m_recvg_pc,stack_entry.m_branch_div_cycle,stack_entry.m_type );
-        fprintf(fout, "%d %d\n",m_warp_id, m_warp_size );
-        
-    }
-}
-
-void simt_stack::update( simt_mask_t &thread_done, addr_vector_t &next_pc, address_type recvg_pc, op_type next_inst_op,unsigned next_inst_size, address_type next_inst_pc )
-{
-    assert(m_stack.size() > 0);
-
-    assert( next_pc.size() == m_warp_size );
-
-    simt_mask_t  top_active_mask = m_stack.back().m_active_mask;
-    address_type top_recvg_pc = m_stack.back().m_recvg_pc;
-    address_type top_pc = m_stack.back().m_pc; // the pc of the instruction just executed
-    stack_entry_type top_type = m_stack.back().m_type;
-    assert(top_pc==next_inst_pc);
-    assert(top_active_mask.any());
-
-    const address_type null_pc = -1;
-    bool warp_diverged = false;
-    address_type new_recvg_pc = null_pc;
-    unsigned num_divergent_paths=0;
-
-    std::map<address_type,simt_mask_t> divergent_paths;
-    while (top_active_mask.any()) {
-
-        // extract a group of threads with the same next PC among the active threads in the warp
-        address_type tmp_next_pc = null_pc;
-        simt_mask_t tmp_active_mask;
-        for (int i = m_warp_size - 1; i >= 0; i--) {
-            if ( top_active_mask.test(i) ) { // is this thread active?
-                if (thread_done.test(i)) {
-                    top_active_mask.reset(i); // remove completed thread from active mask
-                } else if (tmp_next_pc == null_pc) {
-                    tmp_next_pc = next_pc[i];
-                    tmp_active_mask.set(i);
-                    top_active_mask.reset(i);
-                } else if (tmp_next_pc == next_pc[i]) {
-                    tmp_active_mask.set(i);
-                    top_active_mask.reset(i);
-                }
-            }
-        }
-
-        if(tmp_next_pc == null_pc) {
-            assert(!top_active_mask.any()); // all threads done
-            continue;
-        }
-
-        divergent_paths[tmp_next_pc]=tmp_active_mask;
-        num_divergent_paths++;
+    if (tmp_next_pc == null_pc) {
+      assert(!top_active_mask.any());  // all threads done
+      continue;
     }
 
+    divergent_paths[tmp_next_pc] = tmp_active_mask;
+    num_divergent_paths++;
+  }
 
-    address_type not_taken_pc = next_inst_pc+next_inst_size;
-    assert(num_divergent_paths<=2);
-    for(unsigned i=0; i<num_divergent_paths; i++){
-    	address_type tmp_next_pc = null_pc;
-    	simt_mask_t tmp_active_mask;
-    	tmp_active_mask.reset();
-    	if(divergent_paths.find(not_taken_pc)!=divergent_paths.end()){
-    		assert(i==0);
-    		tmp_next_pc=not_taken_pc;
-    		tmp_active_mask=divergent_paths[tmp_next_pc];
-    		divergent_paths.erase(tmp_next_pc);
-    	}else{
-    		std::map<address_type,simt_mask_t>:: iterator it=divergent_paths.begin();
-    		tmp_next_pc=it->first;
-    		tmp_active_mask=divergent_paths[tmp_next_pc];
-    		divergent_paths.erase(tmp_next_pc);
-    	}
+  address_type not_taken_pc = next_inst_pc + next_inst_size;
+  assert(num_divergent_paths <= 2);
+  for (unsigned i = 0; i < num_divergent_paths; i++) {
+    address_type tmp_next_pc = null_pc;
+    simt_mask_t tmp_active_mask;
+    tmp_active_mask.reset();
+    if (divergent_paths.find(not_taken_pc) != divergent_paths.end()) {
+      assert(i == 0);
+      tmp_next_pc = not_taken_pc;
+      tmp_active_mask = divergent_paths[tmp_next_pc];
+      divergent_paths.erase(tmp_next_pc);
+    } else {
+      std::map<address_type, simt_mask_t>::iterator it =
+          divergent_paths.begin();
+      tmp_next_pc = it->first;
+      tmp_active_mask = divergent_paths[tmp_next_pc];
+      divergent_paths.erase(tmp_next_pc);
+    }
 
-        // HANDLE THE SPECIAL CASES FIRST
-    	if (next_inst_op== CALL_OPS){
-    		// Since call is not a divergent instruction, all threads should have executed a call instruction
-    		assert(num_divergent_paths == 1);
+    // HANDLE THE SPECIAL CASES FIRST
+    if (next_inst_op == CALL_OPS) {
+      // Since call is not a divergent instruction, all threads should have
+      // executed a call instruction
+      assert(num_divergent_paths == 1);
 
-    		simt_stack_entry new_stack_entry;
-    		new_stack_entry.m_pc = tmp_next_pc;
-    		new_stack_entry.m_active_mask = tmp_active_mask;
-    		new_stack_entry.m_branch_div_cycle = m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle;
-    		new_stack_entry.m_type = STACK_ENTRY_TYPE_CALL;
-    		m_stack.push_back(new_stack_entry);
-    		return;
-    	}else if(next_inst_op == RET_OPS && top_type==STACK_ENTRY_TYPE_CALL){
-    		// pop the CALL Entry
-    		assert(num_divergent_paths == 1);
-    		m_stack.pop_back();
+      simt_stack_entry new_stack_entry;
+      new_stack_entry.m_pc = tmp_next_pc;
+      new_stack_entry.m_active_mask = tmp_active_mask;
+      new_stack_entry.m_branch_div_cycle =
+          m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle;
+      new_stack_entry.m_type = STACK_ENTRY_TYPE_CALL;
+      m_stack.push_back(new_stack_entry);
+      return;
+    } else if (next_inst_op == RET_OPS && top_type == STACK_ENTRY_TYPE_CALL) {
+      // pop the CALL Entry
+      assert(num_divergent_paths == 1);
+      m_stack.pop_back();
 
-    		assert(m_stack.size() > 0);
-    		m_stack.back().m_pc=tmp_next_pc;// set the PC of the stack top entry to return PC from  the call stack;
-            // Check if the New top of the stack is reconverging
-            if (tmp_next_pc == m_stack.back().m_recvg_pc && m_stack.back().m_type!=STACK_ENTRY_TYPE_CALL){
-            	assert(m_stack.back().m_type==STACK_ENTRY_TYPE_NORMAL);
-            	m_stack.pop_back();
-            }
-            return;
-    	}
+      assert(m_stack.size() > 0);
+      m_stack.back().m_pc = tmp_next_pc;  // set the PC of the stack top entry
+                                          // to return PC from  the call stack;
+      // Check if the New top of the stack is reconverging
+      if (tmp_next_pc == m_stack.back().m_recvg_pc &&
+          m_stack.back().m_type != STACK_ENTRY_TYPE_CALL) {
+        assert(m_stack.back().m_type == STACK_ENTRY_TYPE_NORMAL);
+        m_stack.pop_back();
+      }
+      return;
+    }
 
-        // discard the new entry if its PC matches with reconvergence PC
-        // that automatically reconverges the entry
-        // If the top stack entry is CALL, dont reconverge.
-        if (tmp_next_pc == top_recvg_pc && (top_type != STACK_ENTRY_TYPE_CALL)) continue;
+    // discard the new entry if its PC matches with reconvergence PC
+    // that automatically reconverges the entry
+    // If the top stack entry is CALL, dont reconverge.
+    if (tmp_next_pc == top_recvg_pc && (top_type != STACK_ENTRY_TYPE_CALL))
+      continue;
 
-        // this new entry is not converging
-        // if this entry does not include thread from the warp, divergence occurs
-        if ((num_divergent_paths>1) && !warp_diverged ) {
-            warp_diverged = true;
-            // modify the existing top entry into a reconvergence entry in the pdom stack
-            new_recvg_pc = recvg_pc;
-            if (new_recvg_pc != top_recvg_pc) {
-                m_stack.back().m_pc = new_recvg_pc;
-                m_stack.back().m_branch_div_cycle = m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle;
-
-                m_stack.push_back(simt_stack_entry());
-            }
-        }
-
-        // discard the new entry if its PC matches with reconvergence PC
-        if (warp_diverged && tmp_next_pc == new_recvg_pc) continue;
-
-        // update the current top of pdom stack
-        m_stack.back().m_pc = tmp_next_pc;
-        m_stack.back().m_active_mask = tmp_active_mask;
-        if (warp_diverged) {
-            m_stack.back().m_calldepth = 0;
-            m_stack.back().m_recvg_pc = new_recvg_pc;
-        } else {
-            m_stack.back().m_recvg_pc = top_recvg_pc;
-        }
+    // this new entry is not converging
+    // if this entry does not include thread from the warp, divergence occurs
+    if ((num_divergent_paths > 1) && !warp_diverged) {
+      warp_diverged = true;
+      // modify the existing top entry into a reconvergence entry in the pdom
+      // stack
+      new_recvg_pc = recvg_pc;
+      if (new_recvg_pc != top_recvg_pc) {
+        m_stack.back().m_pc = new_recvg_pc;
+        m_stack.back().m_branch_div_cycle =
+            m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle;
 
         m_stack.push_back(simt_stack_entry());
+      }
     }
-    assert(m_stack.size() > 0);
-    m_stack.pop_back();
 
+    // discard the new entry if its PC matches with reconvergence PC
+    if (warp_diverged && tmp_next_pc == new_recvg_pc) continue;
 
+    // update the current top of pdom stack
+    m_stack.back().m_pc = tmp_next_pc;
+    m_stack.back().m_active_mask = tmp_active_mask;
     if (warp_diverged) {
-        m_gpu->gpgpu_ctx->stats->ptx_file_line_stats_add_warp_divergence(top_pc, 1); 
+      m_stack.back().m_calldepth = 0;
+      m_stack.back().m_recvg_pc = new_recvg_pc;
+    } else {
+      m_stack.back().m_recvg_pc = top_recvg_pc;
     }
+
+    m_stack.push_back(simt_stack_entry());
+  }
+  assert(m_stack.size() > 0);
+  m_stack.pop_back();
+
+  if (warp_diverged) {
+    m_gpu->gpgpu_ctx->stats->ptx_file_line_stats_add_warp_divergence(top_pc, 1);
+  }
 }
 
-void core_t::execute_warp_inst_t(warp_inst_t &inst, unsigned warpId)
-{
-    for ( unsigned t=0; t < m_warp_size; t++ ) {
-        if( inst.active(t) ) {
-            if(warpId==(unsigned (-1)))
-                warpId = inst.warp_id();
-            unsigned tid=m_warp_size*warpId+t;
-            m_thread[tid]->ptx_exec_inst(inst,t);
-            
-            //virtual function
-            checkExecutionStatusAndUpdate(inst,t,tid);
-        }
-    } 
-}
-  
-bool  core_t::ptx_thread_done( unsigned hw_thread_id ) const  
-{
-    return ((m_thread[ hw_thread_id ]==NULL) || m_thread[ hw_thread_id ]->is_done());
-}
-  
-void core_t::updateSIMTStack(unsigned warpId, warp_inst_t * inst)
-{
-    simt_mask_t thread_done;
-    addr_vector_t next_pc;
-    unsigned wtid = warpId * m_warp_size;
-    for (unsigned i = 0; i < m_warp_size; i++) {
-        if( ptx_thread_done(wtid+i) ) {
-            thread_done.set(i);
-            next_pc.push_back( (address_type)-1 );
-        } else {
-            if( inst->reconvergence_pc == RECONVERGE_RETURN_PC ) 
-                inst->reconvergence_pc = get_return_pc(m_thread[wtid+i]);
-            next_pc.push_back( m_thread[wtid+i]->get_pc() );
-        }
+void core_t::execute_warp_inst_t(warp_inst_t &inst, unsigned warpId) {
+  for (unsigned t = 0; t < m_warp_size; t++) {
+    if (inst.active(t)) {
+      if (warpId == (unsigned(-1))) warpId = inst.warp_id();
+      unsigned tid = m_warp_size * warpId + t;
+      m_thread[tid]->ptx_exec_inst(inst, t);
+
+      // virtual function
+      checkExecutionStatusAndUpdate(inst, t, tid);
     }
-    m_simt_stack[warpId]->update(thread_done,next_pc,inst->reconvergence_pc, inst->op,inst->isize,inst->pc);
+  }
+}
+
+bool core_t::ptx_thread_done(unsigned hw_thread_id) const {
+  return ((m_thread[hw_thread_id] == NULL) ||
+          m_thread[hw_thread_id]->is_done());
+}
+
+void core_t::updateSIMTStack(unsigned warpId, warp_inst_t *inst) {
+  simt_mask_t thread_done;
+  addr_vector_t next_pc;
+  unsigned wtid = warpId * m_warp_size;
+  for (unsigned i = 0; i < m_warp_size; i++) {
+    if (ptx_thread_done(wtid + i)) {
+      thread_done.set(i);
+      next_pc.push_back((address_type)-1);
+    } else {
+      if (inst->reconvergence_pc == RECONVERGE_RETURN_PC)
+        inst->reconvergence_pc = get_return_pc(m_thread[wtid + i]);
+      next_pc.push_back(m_thread[wtid + i]->get_pc());
+    }
+  }
+  m_simt_stack[warpId]->update(thread_done, next_pc, inst->reconvergence_pc,
+                               inst->op, inst->isize, inst->pc);
 }
 
 //! Get the warp to be executed using the data taken form the SIMT stack
-warp_inst_t core_t::getExecuteWarp(unsigned warpId)
-{
-    unsigned pc,rpc;
-    m_simt_stack[warpId]->get_pdom_stack_top_info(&pc,&rpc);
-    warp_inst_t wi= *(m_gpu->gpgpu_ctx->ptx_fetch_inst(pc));
-    wi.set_active(m_simt_stack[warpId]->get_active_mask());
-    return wi;
+warp_inst_t core_t::getExecuteWarp(unsigned warpId) {
+  unsigned pc, rpc;
+  m_simt_stack[warpId]->get_pdom_stack_top_info(&pc, &rpc);
+  warp_inst_t wi = *(m_gpu->gpgpu_ctx->ptx_fetch_inst(pc));
+  wi.set_active(m_simt_stack[warpId]->get_active_mask());
+  return wi;
 }
 
-void core_t::deleteSIMTStack()
-{
-    if ( m_simt_stack ) {
-        for (unsigned i = 0; i < m_warp_count; ++i) 
-            delete m_simt_stack[i];
-        delete[] m_simt_stack;
-        m_simt_stack = NULL;
-    }
+void core_t::deleteSIMTStack() {
+  if (m_simt_stack) {
+    for (unsigned i = 0; i < m_warp_count; ++i) delete m_simt_stack[i];
+    delete[] m_simt_stack;
+    m_simt_stack = NULL;
+  }
 }
 
-void core_t::initilizeSIMTStack(unsigned warp_count, unsigned warp_size)
-{ 
-    m_simt_stack = new simt_stack*[warp_count];
-    for (unsigned i = 0; i < warp_count; ++i) 
-        m_simt_stack[i] = new simt_stack(i,warp_size,m_gpu);
-    m_warp_size = warp_size;
-    m_warp_count = warp_count;
+void core_t::initilizeSIMTStack(unsigned warp_count, unsigned warp_size) {
+  m_simt_stack = new simt_stack *[warp_count];
+  for (unsigned i = 0; i < warp_count; ++i)
+    m_simt_stack[i] = new simt_stack(i, warp_size, m_gpu);
+  m_warp_size = warp_size;
+  m_warp_count = warp_count;
 }
 
-void core_t::get_pdom_stack_top_info( unsigned warpId, unsigned *pc, unsigned *rpc ) const
-{
-    m_simt_stack[warpId]->get_pdom_stack_top_info(pc,rpc);
+void core_t::get_pdom_stack_top_info(unsigned warpId, unsigned *pc,
+                                     unsigned *rpc) const {
+  m_simt_stack[warpId]->get_pdom_stack_top_info(pc, rpc);
 }

--- a/src/abstract_hardware_model.cc
+++ b/src/abstract_hardware_model.cc
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -25,1185 +27,1192 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
-
 #include "abstract_hardware_model.h"
-#include "cuda-sim/memory.h"
-#include "cuda-sim/ptx_ir.h"
-#include "cuda-sim/ptx-stats.h"
-#include "cuda-sim/cuda-sim.h"
-#include "gpgpu-sim/gpu-sim.h"
-#include "option_parser.h"
-#include "gpgpusim_entrypoint.h"
-#include <algorithm>
 #include <sys/stat.h>
-#include <sstream>
+#include <algorithm>
 #include <iostream>
+#include <sstream>
 #include "../libcuda/gpgpu_context.h"
+#include "cuda-sim/cuda-sim.h"
+#include "cuda-sim/memory.h"
+#include "cuda-sim/ptx-stats.h"
+#include "cuda-sim/ptx_ir.h"
+#include "gpgpu-sim/gpu-sim.h"
+#include "gpgpusim_entrypoint.h"
+#include "option_parser.h"
 
-void mem_access_t::init(gpgpu_context* ctx)
-{
-      gpgpu_ctx = ctx;
-      m_uid=++(gpgpu_ctx->sm_next_access_uid);
-      m_addr=0;
-      m_req_size=0;
+void mem_access_t::init(gpgpu_context *ctx) {
+  gpgpu_ctx = ctx;
+  m_uid = ++(gpgpu_ctx->sm_next_access_uid);
+  m_addr = 0;
+  m_req_size = 0;
 }
-void warp_inst_t::issue( const active_mask_t &mask, unsigned warp_id, unsigned long long cycle, int dynamic_warp_id, int sch_id )
-{
-    m_warp_active_mask = mask;
-    m_warp_issued_mask = mask; 
-    m_uid = ++(m_config->gpgpu_ctx->warp_inst_sm_next_uid);
-    m_warp_id = warp_id;
-    m_dynamic_warp_id = dynamic_warp_id;
-    issue_cycle = cycle;
-    cycles = initiation_interval;
-    m_cache_hit=false;
-    m_empty=false;
-    m_scheduler_id=sch_id;
+void warp_inst_t::issue(const active_mask_t &mask, unsigned warp_id,
+                        unsigned long long cycle, int dynamic_warp_id,
+                        int sch_id) {
+  m_warp_active_mask = mask;
+  m_warp_issued_mask = mask;
+  m_uid = ++(m_config->gpgpu_ctx->warp_inst_sm_next_uid);
+  m_warp_id = warp_id;
+  m_dynamic_warp_id = dynamic_warp_id;
+  issue_cycle = cycle;
+  cycles = initiation_interval;
+  m_cache_hit = false;
+  m_empty = false;
+  m_scheduler_id = sch_id;
 }
 
-checkpoint::checkpoint()
-{
+checkpoint::checkpoint() {
+  struct stat st = {0};
 
-    struct stat st = {0};
+  if (stat("checkpoint_files", &st) == -1) {
+    mkdir("checkpoint_files", 0777);
+  }
+}
+void checkpoint::load_global_mem(class memory_space *temp_mem, char *f1name) {
+  FILE *fp2 = fopen(f1name, "r");
+  assert(fp2 != NULL);
+  char line[128]; /* or other suitable maximum line size */
+  unsigned int offset;
+  while (fgets(line, sizeof line, fp2) != NULL) /* read a line */
+  {
+    unsigned int index;
+    char *pch;
+    pch = strtok(line, " ");
+    if (pch[0] == 'g' || pch[0] == 's' || pch[0] == 'l') {
+      pch = strtok(NULL, " ");
 
-    if (stat("checkpoint_files", &st) == -1) {
-        mkdir("checkpoint_files", 0777);
+      std::stringstream ss;
+      ss << std::hex << pch;
+      ss >> index;
+
+      offset = 0;
+    } else {
+      unsigned int data;
+      std::stringstream ss;
+      ss << std::hex << pch;
+      ss >> data;
+      temp_mem->write_only(offset, index, 4, &data);
+      offset = offset + 4;
     }
-
-}
-void checkpoint::load_global_mem(class memory_space *temp_mem, char * f1name)
-{
-
-    FILE * fp2 = fopen(f1name, "r");
-    assert(fp2!=NULL);
-      char line [ 128 ]; /* or other suitable maximum line size */
-      unsigned int offset ;
-      while ( fgets ( line, sizeof line, fp2 ) != NULL ) /* read a line */
-      {
-         unsigned int index;
-         char * pch;
-         pch = strtok (line," ");
-         if (pch[0]=='g' || pch[0]=='s' || pch[0]=='l')
-         {
-
-           pch = strtok (NULL, " ");
-           
-           std::stringstream ss;
-            ss << std::hex << pch;
-            ss >> index;
-
-           offset=0;
-         }
-         else {
-            unsigned int  data;
-            std::stringstream ss;
-            ss << std::hex << pch;
-            ss >> data;
-            temp_mem->write_only(offset,index, 4,&data);
-            offset= offset+4;
-         }
-         //fputs ( line, stdout ); /* write the line */
-      }
-      fclose ( fp2 );
+    // fputs ( line, stdout ); /* write the line */
+  }
+  fclose(fp2);
 }
 
-void checkpoint::store_global_mem(class memory_space * mem, char *fname, char * format)
-{
-
-      FILE * fp3 = fopen(fname, "w");
-      assert(fp3!=NULL);
-      mem->print(format,fp3);
-      fclose(fp3);
+void checkpoint::store_global_mem(class memory_space *mem, char *fname,
+                                  char *format) {
+  FILE *fp3 = fopen(fname, "w");
+  assert(fp3 != NULL);
+  mem->print(format, fp3);
+  fclose(fp3);
 }
 
-void move_warp( warp_inst_t *&dst, warp_inst_t *&src )
-{
-   assert( dst->empty() );
-   warp_inst_t* temp = dst;
-   dst = src;
-   src = temp;
-   src->clear();
+void move_warp(warp_inst_t *&dst, warp_inst_t *&src) {
+  assert(dst->empty());
+  warp_inst_t *temp = dst;
+  dst = src;
+  src = temp;
+  src->clear();
 }
 
-
-void gpgpu_functional_sim_config::reg_options(class OptionParser * opp)
-{
-	option_parser_register(opp, "-gpgpu_ptx_use_cuobjdump", OPT_BOOL,
-                 &m_ptx_use_cuobjdump,
-                 "Use cuobjdump to extract ptx and sass from binaries",
+void gpgpu_functional_sim_config::reg_options(class OptionParser *opp) {
+  option_parser_register(opp, "-gpgpu_ptx_use_cuobjdump", OPT_BOOL,
+                         &m_ptx_use_cuobjdump,
+                         "Use cuobjdump to extract ptx and sass from binaries",
 #if (CUDART_VERSION >= 4000)
-                 "1"
+                         "1"
 #else
-                 "0"
+                         "0"
 #endif
-                 );
-	option_parser_register(opp, "-gpgpu_experimental_lib_support", OPT_BOOL,
-	                 &m_experimental_lib_support,
-	                 "Try to extract code from cuda libraries [Broken because of unknown cudaGetExportTable]",
-	                 "0");
-  option_parser_register(opp, "-checkpoint_option", OPT_INT32, &checkpoint_option, 
-               " checkpointing flag (0 = no checkpoint)",
-               "0");
-  option_parser_register(opp, "-checkpoint_kernel", OPT_INT32, &checkpoint_kernel, 
-               " checkpointing during execution of which kernel (1- 1st kernel)",
-               "1");
-  option_parser_register(opp, "-checkpoint_CTA", OPT_INT32, &checkpoint_CTA, 
-               " checkpointing after # of CTA (< less than total CTA)",
-               "0");
-  option_parser_register(opp, "-resume_option", OPT_INT32, &resume_option, 
-               " resume flag (0 = no resume)",
-               "0");
-  option_parser_register(opp, "-resume_kernel", OPT_INT32, &resume_kernel, 
-               " Resume from which kernel (1= 1st kernel)",
-               "0");
-   option_parser_register(opp, "-resume_CTA", OPT_INT32, &resume_CTA, 
-               " resume from which CTA ",
-               "0");
-      option_parser_register(opp, "-checkpoint_CTA_t", OPT_INT32, &checkpoint_CTA_t, 
-               " resume from which CTA ",
-               "0");
-         option_parser_register(opp, "-checkpoint_insn_Y", OPT_INT32, &checkpoint_insn_Y, 
-               " resume from which CTA ",
-               "0");
+                         );
+  option_parser_register(opp, "-gpgpu_experimental_lib_support", OPT_BOOL,
+                         &m_experimental_lib_support,
+                         "Try to extract code from cuda libraries [Broken "
+                         "because of unknown cudaGetExportTable]",
+                         "0");
+  option_parser_register(opp, "-checkpoint_option", OPT_INT32,
+                         &checkpoint_option,
+                         " checkpointing flag (0 = no checkpoint)", "0");
+  option_parser_register(
+      opp, "-checkpoint_kernel", OPT_INT32, &checkpoint_kernel,
+      " checkpointing during execution of which kernel (1- 1st kernel)", "1");
+  option_parser_register(
+      opp, "-checkpoint_CTA", OPT_INT32, &checkpoint_CTA,
+      " checkpointing after # of CTA (< less than total CTA)", "0");
+  option_parser_register(opp, "-resume_option", OPT_INT32, &resume_option,
+                         " resume flag (0 = no resume)", "0");
+  option_parser_register(opp, "-resume_kernel", OPT_INT32, &resume_kernel,
+                         " Resume from which kernel (1= 1st kernel)", "0");
+  option_parser_register(opp, "-resume_CTA", OPT_INT32, &resume_CTA,
+                         " resume from which CTA ", "0");
+  option_parser_register(opp, "-checkpoint_CTA_t", OPT_INT32, &checkpoint_CTA_t,
+                         " resume from which CTA ", "0");
+  option_parser_register(opp, "-checkpoint_insn_Y", OPT_INT32,
+                         &checkpoint_insn_Y, " resume from which CTA ", "0");
 
-    option_parser_register(opp, "-gpgpu_ptx_convert_to_ptxplus", OPT_BOOL,
-                 &m_ptx_convert_to_ptxplus,
-                 "Convert SASS (native ISA) to ptxplus and run ptxplus",
-                 "0");
-    option_parser_register(opp, "-gpgpu_ptx_force_max_capability", OPT_UINT32,
-                 &m_ptx_force_max_capability,
-                 "Force maximum compute capability",
-                 "0");
-   option_parser_register(opp, "-gpgpu_ptx_inst_debug_to_file", OPT_BOOL, 
-                &g_ptx_inst_debug_to_file, 
-                "Dump executed instructions' debug information to file", 
-                "0");
-   option_parser_register(opp, "-gpgpu_ptx_inst_debug_file", OPT_CSTR, &g_ptx_inst_debug_file, 
-                  "Executed instructions' debug output file",
-                  "inst_debug.txt");
-   option_parser_register(opp, "-gpgpu_ptx_inst_debug_thread_uid", OPT_INT32, &g_ptx_inst_debug_thread_uid, 
-               "Thread UID for executed instructions' debug output", 
-               "1");
+  option_parser_register(
+      opp, "-gpgpu_ptx_convert_to_ptxplus", OPT_BOOL, &m_ptx_convert_to_ptxplus,
+      "Convert SASS (native ISA) to ptxplus and run ptxplus", "0");
+  option_parser_register(opp, "-gpgpu_ptx_force_max_capability", OPT_UINT32,
+                         &m_ptx_force_max_capability,
+                         "Force maximum compute capability", "0");
+  option_parser_register(
+      opp, "-gpgpu_ptx_inst_debug_to_file", OPT_BOOL, &g_ptx_inst_debug_to_file,
+      "Dump executed instructions' debug information to file", "0");
+  option_parser_register(
+      opp, "-gpgpu_ptx_inst_debug_file", OPT_CSTR, &g_ptx_inst_debug_file,
+      "Executed instructions' debug output file", "inst_debug.txt");
+  option_parser_register(opp, "-gpgpu_ptx_inst_debug_thread_uid", OPT_INT32,
+                         &g_ptx_inst_debug_thread_uid,
+                         "Thread UID for executed instructions' debug output",
+                         "1");
 }
 
-void gpgpu_functional_sim_config::ptx_set_tex_cache_linesize(unsigned linesize)
-{
-   m_texcache_linesize = linesize;
+void gpgpu_functional_sim_config::ptx_set_tex_cache_linesize(
+    unsigned linesize) {
+  m_texcache_linesize = linesize;
 }
 
-gpgpu_t::gpgpu_t( const gpgpu_functional_sim_config &config, gpgpu_context* ctx )
-    : m_function_model_config(config)
-{
-   gpgpu_ctx = ctx;
-   m_global_mem = new memory_space_impl<8192>("global",64*1024);
-   
-   m_tex_mem = new memory_space_impl<8192>("tex",64*1024);
-   m_surf_mem = new memory_space_impl<8192>("surf",64*1024);
+gpgpu_t::gpgpu_t(const gpgpu_functional_sim_config &config, gpgpu_context *ctx)
+    : m_function_model_config(config) {
+  gpgpu_ctx = ctx;
+  m_global_mem = new memory_space_impl<8192>("global", 64 * 1024);
 
-   m_dev_malloc=GLOBAL_HEAP_START; 
-   checkpoint_option = m_function_model_config.get_checkpoint_option();
-   checkpoint_kernel = m_function_model_config.get_checkpoint_kernel();
-   checkpoint_CTA = m_function_model_config.get_checkpoint_CTA();
-   resume_option = m_function_model_config.get_resume_option();
-   resume_kernel = m_function_model_config.get_resume_kernel();
-   resume_CTA = m_function_model_config.get_resume_CTA();
-   checkpoint_CTA_t = m_function_model_config.get_checkpoint_CTA_t();
-   checkpoint_insn_Y = m_function_model_config.get_checkpoint_insn_Y();
+  m_tex_mem = new memory_space_impl<8192>("tex", 64 * 1024);
+  m_surf_mem = new memory_space_impl<8192>("surf", 64 * 1024);
 
-   // initialize texture mappings to empty
-   m_NameToTextureInfo.clear();
-   m_NameToCudaArray.clear();
-   m_TextureRefToName.clear();
-   m_NameToAttribute.clear();
+  m_dev_malloc = GLOBAL_HEAP_START;
+  checkpoint_option = m_function_model_config.get_checkpoint_option();
+  checkpoint_kernel = m_function_model_config.get_checkpoint_kernel();
+  checkpoint_CTA = m_function_model_config.get_checkpoint_CTA();
+  resume_option = m_function_model_config.get_resume_option();
+  resume_kernel = m_function_model_config.get_resume_kernel();
+  resume_CTA = m_function_model_config.get_resume_CTA();
+  checkpoint_CTA_t = m_function_model_config.get_checkpoint_CTA_t();
+  checkpoint_insn_Y = m_function_model_config.get_checkpoint_insn_Y();
 
-   if(m_function_model_config.get_ptx_inst_debug_to_file() != 0) 
-      ptx_inst_debug_file = fopen(m_function_model_config.get_ptx_inst_debug_file(), "w");
+  // initialize texture mappings to empty
+  m_NameToTextureInfo.clear();
+  m_NameToCudaArray.clear();
+  m_TextureRefToName.clear();
+  m_NameToAttribute.clear();
 
-   gpu_sim_cycle=0;
-   gpu_tot_sim_cycle=0;
+  if (m_function_model_config.get_ptx_inst_debug_to_file() != 0)
+    ptx_inst_debug_file =
+        fopen(m_function_model_config.get_ptx_inst_debug_file(), "w");
+
+  gpu_sim_cycle = 0;
+  gpu_tot_sim_cycle = 0;
 }
 
-address_type line_size_based_tag_func(new_addr_type address, new_addr_type line_size)
-{
-   //gives the tag for an address based on a given line size
-   return address & ~(line_size-1);
+address_type line_size_based_tag_func(new_addr_type address,
+                                      new_addr_type line_size) {
+  // gives the tag for an address based on a given line size
+  return address & ~(line_size - 1);
 }
 
-const char * mem_access_type_str(enum mem_access_type access_type)
-{
-   #define MA_TUP_BEGIN(X) static const char* access_type_str[] = {
-   #define MA_TUP(X) #X
-   #define MA_TUP_END(X) };
-   MEM_ACCESS_TYPE_TUP_DEF
-   #undef MA_TUP_BEGIN
-   #undef MA_TUP
-   #undef MA_TUP_END
+const char *mem_access_type_str(enum mem_access_type access_type) {
+#define MA_TUP_BEGIN(X) static const char *access_type_str[] = {
+#define MA_TUP(X) #X
+#define MA_TUP_END(X) \
+  }                   \
+  ;
+  MEM_ACCESS_TYPE_TUP_DEF
+#undef MA_TUP_BEGIN
+#undef MA_TUP
+#undef MA_TUP_END
 
-   assert(access_type < NUM_MEM_ACCESS_TYPE); 
+  assert(access_type < NUM_MEM_ACCESS_TYPE);
 
-   return access_type_str[access_type]; 
+  return access_type_str[access_type];
 }
 
-
-void warp_inst_t::clear_active( const active_mask_t &inactive ) {
-    active_mask_t test = m_warp_active_mask;
-    test &= inactive;
-    assert( test == inactive ); // verify threads being disabled were active
-    m_warp_active_mask &= ~inactive;
+void warp_inst_t::clear_active(const active_mask_t &inactive) {
+  active_mask_t test = m_warp_active_mask;
+  test &= inactive;
+  assert(test == inactive);  // verify threads being disabled were active
+  m_warp_active_mask &= ~inactive;
 }
 
-void warp_inst_t::set_not_active( unsigned lane_id ) {
-    m_warp_active_mask.reset(lane_id);
+void warp_inst_t::set_not_active(unsigned lane_id) {
+  m_warp_active_mask.reset(lane_id);
 }
 
-void warp_inst_t::set_active( const active_mask_t &active ) {
-   m_warp_active_mask = active;
-   if( m_isatomic ) {
-      for( unsigned i=0; i < m_config->warp_size; i++ ) {
-         if( !m_warp_active_mask.test(i) ) {
-             m_per_scalar_thread[i].callback.function = NULL;
-             m_per_scalar_thread[i].callback.instruction = NULL;
-             m_per_scalar_thread[i].callback.thread = NULL;
-         }
+void warp_inst_t::set_active(const active_mask_t &active) {
+  m_warp_active_mask = active;
+  if (m_isatomic) {
+    for (unsigned i = 0; i < m_config->warp_size; i++) {
+      if (!m_warp_active_mask.test(i)) {
+        m_per_scalar_thread[i].callback.function = NULL;
+        m_per_scalar_thread[i].callback.instruction = NULL;
+        m_per_scalar_thread[i].callback.thread = NULL;
       }
-   }
+    }
+  }
 }
 
 void warp_inst_t::do_atomic(bool forceDo) {
-    do_atomic( m_warp_active_mask,forceDo );
+  do_atomic(m_warp_active_mask, forceDo);
 }
 
-
-void warp_inst_t::do_atomic( const active_mask_t& access_mask,bool forceDo ) {
-    assert( m_isatomic && (!m_empty||forceDo) );
-    for( unsigned i=0; i < m_config->warp_size; i++ )
-    {
-        if( access_mask.test(i) )
-        {
-            dram_callback_t &cb = m_per_scalar_thread[i].callback;
-            if( cb.thread )
-                cb.function(cb.instruction, cb.thread);
-        }
+void warp_inst_t::do_atomic(const active_mask_t &access_mask, bool forceDo) {
+  assert(m_isatomic && (!m_empty || forceDo));
+  for (unsigned i = 0; i < m_config->warp_size; i++) {
+    if (access_mask.test(i)) {
+      dram_callback_t &cb = m_per_scalar_thread[i].callback;
+      if (cb.thread) cb.function(cb.instruction, cb.thread);
     }
+  }
 }
 
-void warp_inst_t::broadcast_barrier_reduction(const active_mask_t& access_mask)
-{
-	for( unsigned i=0; i < m_config->warp_size; i++ )
-    {
-        if( access_mask.test(i) )
-        {
-            dram_callback_t &cb = m_per_scalar_thread[i].callback;
-            if( cb.thread ){
-                cb.function(cb.instruction, cb.thread);
-            }
-        }
+void warp_inst_t::broadcast_barrier_reduction(
+    const active_mask_t &access_mask) {
+  for (unsigned i = 0; i < m_config->warp_size; i++) {
+    if (access_mask.test(i)) {
+      dram_callback_t &cb = m_per_scalar_thread[i].callback;
+      if (cb.thread) {
+        cb.function(cb.instruction, cb.thread);
+      }
     }
+  }
 }
 
-void warp_inst_t::generate_mem_accesses()
-{
-    if( empty() || op == MEMORY_BARRIER_OP || m_mem_accesses_created ) 
-        return;
-    if (!((op == LOAD_OP) || (op==TENSOR_CORE_LOAD_OP)   || (op == STORE_OP)||(op==TENSOR_CORE_STORE_OP)))
-        return; 
-    if( m_warp_active_mask.count() == 0 ) 
-        return; // predicated off
+void warp_inst_t::generate_mem_accesses() {
+  if (empty() || op == MEMORY_BARRIER_OP || m_mem_accesses_created) return;
+  if (!((op == LOAD_OP) || (op == TENSOR_CORE_LOAD_OP) || (op == STORE_OP) ||
+        (op == TENSOR_CORE_STORE_OP)))
+    return;
+  if (m_warp_active_mask.count() == 0) return;  // predicated off
 
-    const size_t starting_queue_size = m_accessq.size();
+  const size_t starting_queue_size = m_accessq.size();
 
-    assert( is_load() || is_store() );
-    assert( m_per_scalar_thread_valid ); // need address information per thread
+  assert(is_load() || is_store());
+  assert(m_per_scalar_thread_valid);  // need address information per thread
 
-    bool is_write = is_store();
+  bool is_write = is_store();
 
-    mem_access_type access_type;
-    switch (space.get_type()) {
+  mem_access_type access_type;
+  switch (space.get_type()) {
     case const_space:
-    case param_space_kernel: 
-        access_type = CONST_ACC_R; 
-        break;
-    case tex_space: 
-        access_type = TEXTURE_ACC_R;   
-        break;
-    case global_space:       
-        access_type = is_write? GLOBAL_ACC_W: GLOBAL_ACC_R;   
-        break;
+    case param_space_kernel:
+      access_type = CONST_ACC_R;
+      break;
+    case tex_space:
+      access_type = TEXTURE_ACC_R;
+      break;
+    case global_space:
+      access_type = is_write ? GLOBAL_ACC_W : GLOBAL_ACC_R;
+      break;
     case local_space:
-    case param_space_local:  
-        access_type = is_write? LOCAL_ACC_W: LOCAL_ACC_R;   
-        break;
-    case shared_space: break;
-    case sstarr_space: break;
-    default: assert(0); break; 
-    }
+    case param_space_local:
+      access_type = is_write ? LOCAL_ACC_W : LOCAL_ACC_R;
+      break;
+    case shared_space:
+      break;
+    case sstarr_space:
+      break;
+    default:
+      assert(0);
+      break;
+  }
 
-    // Calculate memory accesses generated by this warp
-    new_addr_type cache_block_size = 0; // in bytes 
+  // Calculate memory accesses generated by this warp
+  new_addr_type cache_block_size = 0;  // in bytes
 
-    switch( space.get_type() ) {
+  switch (space.get_type()) {
     case shared_space:
     case sstarr_space: {
-        unsigned subwarp_size = m_config->warp_size / m_config->mem_warp_parts;
-        unsigned total_accesses=0;
-        for( unsigned subwarp=0; subwarp <  m_config->mem_warp_parts; subwarp++ ) {
+      unsigned subwarp_size = m_config->warp_size / m_config->mem_warp_parts;
+      unsigned total_accesses = 0;
+      for (unsigned subwarp = 0; subwarp < m_config->mem_warp_parts;
+           subwarp++) {
+        // data structures used per part warp
+        std::map<unsigned, std::map<new_addr_type, unsigned> >
+            bank_accs;  // bank -> word address -> access count
 
-            // data structures used per part warp 
-            std::map<unsigned,std::map<new_addr_type,unsigned> > bank_accs; // bank -> word address -> access count
-
-            // step 1: compute accesses to words in banks
-            for( unsigned thread=subwarp*subwarp_size; thread < (subwarp+1)*subwarp_size; thread++ ) {
-                if( !active(thread) ) 
-                    continue;
-                new_addr_type addr = m_per_scalar_thread[thread].memreqaddr[0];
-                //FIXME: deferred allocation of shared memory should not accumulate across kernel launches
-                //assert( addr < m_config->gpgpu_shmem_size ); 
-                unsigned bank = m_config->shmem_bank_func(addr);
-                new_addr_type word = line_size_based_tag_func(addr,m_config->WORD_SIZE);
-                bank_accs[bank][word]++;
-            }
-
-            if (m_config->shmem_limited_broadcast) {
-                // step 2: look for and select a broadcast bank/word if one occurs
-                bool broadcast_detected = false;
-                new_addr_type broadcast_word=(new_addr_type)-1;
-                unsigned broadcast_bank=(unsigned)-1;
-                std::map<unsigned,std::map<new_addr_type,unsigned> >::iterator b;
-                for( b=bank_accs.begin(); b != bank_accs.end(); b++ ) {
-                    unsigned bank = b->first;
-                    std::map<new_addr_type,unsigned> &access_set = b->second;
-                    std::map<new_addr_type,unsigned>::iterator w;
-                    for( w=access_set.begin(); w != access_set.end(); ++w ) {
-                        if( w->second > 1 ) {
-                            // found a broadcast
-                            broadcast_detected=true;
-                            broadcast_bank=bank;
-                            broadcast_word=w->first;
-                            break;
-                        }
-                    }
-                    if( broadcast_detected ) 
-                        break;
-                }
-            
-                // step 3: figure out max bank accesses performed, taking account of broadcast case
-                unsigned max_bank_accesses=0;
-                for( b=bank_accs.begin(); b != bank_accs.end(); b++ ) {
-                    unsigned bank_accesses=0;
-                    std::map<new_addr_type,unsigned> &access_set = b->second;
-                    std::map<new_addr_type,unsigned>::iterator w;
-                    for( w=access_set.begin(); w != access_set.end(); ++w ) 
-                        bank_accesses += w->second;
-                    if( broadcast_detected && broadcast_bank == b->first ) {
-                        for( w=access_set.begin(); w != access_set.end(); ++w ) {
-                            if( w->first == broadcast_word ) {
-                                unsigned n = w->second;
-                                assert(n > 1); // or this wasn't a broadcast
-                                assert(bank_accesses >= (n-1));
-                                bank_accesses -= (n-1);
-                                break;
-                            }
-                        }
-                    }
-                    if( bank_accesses > max_bank_accesses ) 
-                        max_bank_accesses = bank_accesses;
-                }
-
-                // step 4: accumulate
-                total_accesses+= max_bank_accesses;
-            } else {
-                // step 2: look for the bank with the maximum number of access to different words 
-                unsigned max_bank_accesses=0;
-                std::map<unsigned,std::map<new_addr_type,unsigned> >::iterator b;
-                for( b=bank_accs.begin(); b != bank_accs.end(); b++ ) {
-                    max_bank_accesses = std::max(max_bank_accesses, (unsigned)b->second.size());
-                }
-
-                // step 3: accumulate
-                total_accesses+= max_bank_accesses;
-            }
+        // step 1: compute accesses to words in banks
+        for (unsigned thread = subwarp * subwarp_size;
+             thread < (subwarp + 1) * subwarp_size; thread++) {
+          if (!active(thread)) continue;
+          new_addr_type addr = m_per_scalar_thread[thread].memreqaddr[0];
+          // FIXME: deferred allocation of shared memory should not accumulate
+          // across kernel launches
+          // assert( addr < m_config->gpgpu_shmem_size );
+          unsigned bank = m_config->shmem_bank_func(addr);
+          new_addr_type word =
+              line_size_based_tag_func(addr, m_config->WORD_SIZE);
+          bank_accs[bank][word]++;
         }
-        assert( total_accesses > 0 && total_accesses <= m_config->warp_size );
-        cycles = total_accesses; // shared memory conflicts modeled as larger initiation interval 
-        m_config->gpgpu_ctx->stats->ptx_file_line_stats_add_smem_bank_conflict( pc, total_accesses );
-        break;
+
+        if (m_config->shmem_limited_broadcast) {
+          // step 2: look for and select a broadcast bank/word if one occurs
+          bool broadcast_detected = false;
+          new_addr_type broadcast_word = (new_addr_type)-1;
+          unsigned broadcast_bank = (unsigned)-1;
+          std::map<unsigned, std::map<new_addr_type, unsigned> >::iterator b;
+          for (b = bank_accs.begin(); b != bank_accs.end(); b++) {
+            unsigned bank = b->first;
+            std::map<new_addr_type, unsigned> &access_set = b->second;
+            std::map<new_addr_type, unsigned>::iterator w;
+            for (w = access_set.begin(); w != access_set.end(); ++w) {
+              if (w->second > 1) {
+                // found a broadcast
+                broadcast_detected = true;
+                broadcast_bank = bank;
+                broadcast_word = w->first;
+                break;
+              }
+            }
+            if (broadcast_detected) break;
+          }
+
+          // step 3: figure out max bank accesses performed, taking account of
+          // broadcast case
+          unsigned max_bank_accesses = 0;
+          for (b = bank_accs.begin(); b != bank_accs.end(); b++) {
+            unsigned bank_accesses = 0;
+            std::map<new_addr_type, unsigned> &access_set = b->second;
+            std::map<new_addr_type, unsigned>::iterator w;
+            for (w = access_set.begin(); w != access_set.end(); ++w)
+              bank_accesses += w->second;
+            if (broadcast_detected && broadcast_bank == b->first) {
+              for (w = access_set.begin(); w != access_set.end(); ++w) {
+                if (w->first == broadcast_word) {
+                  unsigned n = w->second;
+                  assert(n > 1);  // or this wasn't a broadcast
+                  assert(bank_accesses >= (n - 1));
+                  bank_accesses -= (n - 1);
+                  break;
+                }
+              }
+            }
+            if (bank_accesses > max_bank_accesses)
+              max_bank_accesses = bank_accesses;
+          }
+
+          // step 4: accumulate
+          total_accesses += max_bank_accesses;
+        } else {
+          // step 2: look for the bank with the maximum number of access to
+          // different words
+          unsigned max_bank_accesses = 0;
+          std::map<unsigned, std::map<new_addr_type, unsigned> >::iterator b;
+          for (b = bank_accs.begin(); b != bank_accs.end(); b++) {
+            max_bank_accesses =
+                std::max(max_bank_accesses, (unsigned)b->second.size());
+          }
+
+          // step 3: accumulate
+          total_accesses += max_bank_accesses;
+        }
+      }
+      assert(total_accesses > 0 && total_accesses <= m_config->warp_size);
+      cycles = total_accesses;  // shared memory conflicts modeled as larger
+                                // initiation interval
+      m_config->gpgpu_ctx->stats->ptx_file_line_stats_add_smem_bank_conflict(
+          pc, total_accesses);
+      break;
     }
 
-    case tex_space: 
-        cache_block_size = m_config->gpgpu_cache_texl1_linesize;
-        break;
-    case const_space:  case param_space_kernel:
-        cache_block_size = m_config->gpgpu_cache_constl1_linesize; 
-        break;
+    case tex_space:
+      cache_block_size = m_config->gpgpu_cache_texl1_linesize;
+      break;
+    case const_space:
+    case param_space_kernel:
+      cache_block_size = m_config->gpgpu_cache_constl1_linesize;
+      break;
 
-    case global_space: case local_space: case param_space_local:
-    	 if( m_config->gpgpu_coalesce_arch >= 13) {
-            if(isatomic())
-                memory_coalescing_arch_atomic(is_write, access_type);
-            else
-                memory_coalescing_arch(is_write, access_type);
-         } else abort();
+    case global_space:
+    case local_space:
+    case param_space_local:
+      if (m_config->gpgpu_coalesce_arch >= 13) {
+        if (isatomic())
+          memory_coalescing_arch_atomic(is_write, access_type);
+        else
+          memory_coalescing_arch(is_write, access_type);
+      } else
+        abort();
 
-        break;
+      break;
 
     default:
-        abort();
-    }
+      abort();
+  }
 
-    if( cache_block_size ) {
-        assert( m_accessq.empty() );
-        mem_access_byte_mask_t byte_mask; 
-        std::map<new_addr_type,active_mask_t> accesses; // block address -> set of thread offsets in warp
-        std::map<new_addr_type,active_mask_t>::iterator a;
-        for( unsigned thread=0; thread < m_config->warp_size; thread++ ) {
-            if( !active(thread) ) 
-                continue;
-            new_addr_type addr = m_per_scalar_thread[thread].memreqaddr[0];
-            unsigned block_address = line_size_based_tag_func(addr,cache_block_size);
-            accesses[block_address].set(thread);
-            unsigned idx = addr-block_address; 
-            for( unsigned i=0; i < data_size; i++ ) 
-                byte_mask.set(idx+i);
+  if (cache_block_size) {
+    assert(m_accessq.empty());
+    mem_access_byte_mask_t byte_mask;
+    std::map<new_addr_type, active_mask_t>
+        accesses;  // block address -> set of thread offsets in warp
+    std::map<new_addr_type, active_mask_t>::iterator a;
+    for (unsigned thread = 0; thread < m_config->warp_size; thread++) {
+      if (!active(thread)) continue;
+      new_addr_type addr = m_per_scalar_thread[thread].memreqaddr[0];
+      unsigned block_address = line_size_based_tag_func(addr, cache_block_size);
+      accesses[block_address].set(thread);
+      unsigned idx = addr - block_address;
+      for (unsigned i = 0; i < data_size; i++) byte_mask.set(idx + i);
+    }
+    for (a = accesses.begin(); a != accesses.end(); ++a)
+      m_accessq.push_back(mem_access_t(
+          access_type, a->first, cache_block_size, is_write, a->second,
+          byte_mask, mem_access_sector_mask_t(), m_config->gpgpu_ctx));
+  }
+
+  if (space.get_type() == global_space) {
+    m_config->gpgpu_ctx->stats->ptx_file_line_stats_add_uncoalesced_gmem(
+        pc, m_accessq.size() - starting_queue_size);
+  }
+  m_mem_accesses_created = true;
+}
+
+void warp_inst_t::memory_coalescing_arch(bool is_write,
+                                         mem_access_type access_type) {
+  // see the CUDA manual where it discusses coalescing rules before reading this
+  unsigned segment_size = 0;
+  unsigned warp_parts = m_config->mem_warp_parts;
+  bool sector_segment_size = false;
+
+  if (m_config->gpgpu_coalesce_arch >= 20 &&
+      m_config->gpgpu_coalesce_arch < 39) {
+    // Fermi and Kepler, L1 is normal and L2 is sector
+    if (m_config->gmem_skip_L1D || cache_op == CACHE_GLOBAL)
+      sector_segment_size = true;
+    else
+      sector_segment_size = false;
+  } else if (m_config->gpgpu_coalesce_arch >= 40) {
+    // Maxwell, Pascal and Volta, L1 and L2 are sectors
+    // all requests should be 32 bytes
+    sector_segment_size = true;
+  }
+
+  switch (data_size) {
+    case 1:
+      segment_size = 32;
+      break;
+    case 2:
+      segment_size = sector_segment_size ? 32 : 64;
+      break;
+    case 4:
+    case 8:
+    case 16:
+      segment_size = sector_segment_size ? 32 : 128;
+      break;
+  }
+  unsigned subwarp_size = m_config->warp_size / warp_parts;
+
+  for (unsigned subwarp = 0; subwarp < warp_parts; subwarp++) {
+    std::map<new_addr_type, transaction_info> subwarp_transactions;
+
+    // step 1: find all transactions generated by this subwarp
+    for (unsigned thread = subwarp * subwarp_size;
+         thread < subwarp_size * (subwarp + 1); thread++) {
+      if (!active(thread)) continue;
+
+      unsigned data_size_coales = data_size;
+      unsigned num_accesses = 1;
+
+      if (space.get_type() == local_space ||
+          space.get_type() == param_space_local) {
+        // Local memory accesses >4B were split into 4B chunks
+        if (data_size >= 4) {
+          data_size_coales = 4;
+          num_accesses = data_size / 4;
         }
-        for( a=accesses.begin(); a != accesses.end(); ++a ) 
-            m_accessq.push_back( mem_access_t(access_type,a->first,cache_block_size,is_write,a->second, byte_mask, mem_access_sector_mask_t(), m_config->gpgpu_ctx));
+        // Otherwise keep the same data_size for sub-4B access to local memory
+      }
+
+      assert(num_accesses <= MAX_ACCESSES_PER_INSN_PER_THREAD);
+
+      //            for(unsigned access=0; access<num_accesses; access++) {
+      for (unsigned access = 0;
+           (access < MAX_ACCESSES_PER_INSN_PER_THREAD) &&
+           (m_per_scalar_thread[thread].memreqaddr[access] != 0);
+           access++) {
+        new_addr_type addr = m_per_scalar_thread[thread].memreqaddr[access];
+        unsigned block_address = line_size_based_tag_func(addr, segment_size);
+        unsigned chunk = (addr & 127) / 32;  // which 32-byte chunk within in a
+                                             // 128-byte chunk does this thread
+                                             // access?
+        transaction_info &info = subwarp_transactions[block_address];
+
+        // can only write to one segment
+        assert(block_address == line_size_based_tag_func(
+                                    addr + data_size_coales - 1, segment_size));
+
+        info.chunks.set(chunk);
+        info.active.set(thread);
+        unsigned idx = (addr & 127);
+        for (unsigned i = 0; i < data_size_coales; i++) info.bytes.set(idx + i);
+      }
     }
 
-    if ( space.get_type() == global_space ) {
-        m_config->gpgpu_ctx->stats->ptx_file_line_stats_add_uncoalesced_gmem( pc, m_accessq.size() - starting_queue_size );
+    // step 2: reduce each transaction size, if possible
+    std::map<new_addr_type, transaction_info>::iterator t;
+    for (t = subwarp_transactions.begin(); t != subwarp_transactions.end();
+         t++) {
+      new_addr_type addr = t->first;
+      const transaction_info &info = t->second;
+
+      memory_coalescing_arch_reduce_and_send(is_write, access_type, info, addr,
+                                             segment_size);
     }
-    m_mem_accesses_created=true;
+  }
 }
 
-void warp_inst_t::memory_coalescing_arch( bool is_write, mem_access_type access_type )
-{
-    // see the CUDA manual where it discusses coalescing rules before reading this
-    unsigned segment_size = 0;
-    unsigned warp_parts = m_config->mem_warp_parts;
-    bool sector_segment_size = false;
+void warp_inst_t::memory_coalescing_arch_atomic(bool is_write,
+                                                mem_access_type access_type) {
+  assert(space.get_type() ==
+         global_space);  // Atomics allowed only for global memory
 
-    if(m_config->gpgpu_coalesce_arch >= 20 && m_config->gpgpu_coalesce_arch < 39)
-    {
-    	//Fermi and Kepler, L1 is normal and L2 is sector
-    	if(m_config->gmem_skip_L1D || cache_op == CACHE_GLOBAL)
-    		sector_segment_size = true;
-    	else
-    		sector_segment_size = false;
-    }
-    else if(m_config->gpgpu_coalesce_arch >= 40)
-    {
-    	//Maxwell, Pascal and Volta, L1 and L2 are sectors
-    	//all requests should be 32 bytes
-    	sector_segment_size = true;
-    }
+  // see the CUDA manual where it discusses coalescing rules before reading this
+  unsigned segment_size = 0;
+  unsigned warp_parts = m_config->mem_warp_parts;
+  bool sector_segment_size = false;
 
-    switch( data_size ) {
-    case 1: segment_size = 32; break;
-    case 2: segment_size = sector_segment_size? 32 : 64; break;
-    case 4: case 8: case 16: segment_size = sector_segment_size? 32 : 128; break;
-    }
-    unsigned subwarp_size = m_config->warp_size / warp_parts;
+  if (m_config->gpgpu_coalesce_arch >= 20 &&
+      m_config->gpgpu_coalesce_arch < 39) {
+    // Fermi and Kepler, L1 is normal and L2 is sector
+    if (m_config->gmem_skip_L1D || cache_op == CACHE_GLOBAL)
+      sector_segment_size = true;
+    else
+      sector_segment_size = false;
+  } else if (m_config->gpgpu_coalesce_arch >= 40) {
+    // Maxwell, Pascal and Volta, L1 and L2 are sectors
+    // all requests should be 32 bytes
+    sector_segment_size = true;
+  }
 
-    for( unsigned subwarp=0; subwarp <  warp_parts; subwarp++ ) {
-        std::map<new_addr_type,transaction_info> subwarp_transactions;
+  switch (data_size) {
+    case 1:
+      segment_size = 32;
+      break;
+    case 2:
+      segment_size = sector_segment_size ? 32 : 64;
+      break;
+    case 4:
+    case 8:
+    case 16:
+      segment_size = sector_segment_size ? 32 : 128;
+      break;
+  }
+  unsigned subwarp_size = m_config->warp_size / warp_parts;
 
-        // step 1: find all transactions generated by this subwarp
-        for( unsigned thread=subwarp*subwarp_size; thread<subwarp_size*(subwarp+1); thread++ ) {
-            if( !active(thread) )
-                continue;
+  for (unsigned subwarp = 0; subwarp < warp_parts; subwarp++) {
+    std::map<new_addr_type, std::list<transaction_info> >
+        subwarp_transactions;  // each block addr maps to a list of transactions
 
-            unsigned data_size_coales = data_size;
-            unsigned num_accesses = 1;
+    // step 1: find all transactions generated by this subwarp
+    for (unsigned thread = subwarp * subwarp_size;
+         thread < subwarp_size * (subwarp + 1); thread++) {
+      if (!active(thread)) continue;
 
-            if( space.get_type() == local_space || space.get_type() == param_space_local ) {
-               // Local memory accesses >4B were split into 4B chunks
-               if(data_size >= 4) {
-                  data_size_coales = 4;
-                  num_accesses = data_size/4;
-               }
-               // Otherwise keep the same data_size for sub-4B access to local memory
-            }
+      new_addr_type addr = m_per_scalar_thread[thread].memreqaddr[0];
+      unsigned block_address = line_size_based_tag_func(addr, segment_size);
+      unsigned chunk = (addr & 127) / 32;  // which 32-byte chunk within in a
+                                           // 128-byte chunk does this thread
+                                           // access?
 
+      // can only write to one segment
+      assert(block_address ==
+             line_size_based_tag_func(addr + data_size - 1, segment_size));
 
-            assert(num_accesses <= MAX_ACCESSES_PER_INSN_PER_THREAD);
-
-//            for(unsigned access=0; access<num_accesses; access++) {
-            for(unsigned access=0; (access<MAX_ACCESSES_PER_INSN_PER_THREAD)&&(m_per_scalar_thread[thread].memreqaddr[access]!=0); access++) {
-                new_addr_type addr = m_per_scalar_thread[thread].memreqaddr[access];
-                unsigned block_address = line_size_based_tag_func(addr,segment_size);
-                unsigned chunk = (addr&127)/32; // which 32-byte chunk within in a 128-byte chunk does this thread access?
-                transaction_info &info = subwarp_transactions[block_address];
-
-                // can only write to one segment
-                assert(block_address == line_size_based_tag_func(addr+data_size_coales-1,segment_size));
-
-                info.chunks.set(chunk);
-                info.active.set(thread);
-                unsigned idx = (addr&127);
-                for( unsigned i=0; i < data_size_coales; i++ )
-                    info.bytes.set(idx+i);
-            }
+      // Find a transaction that does not conflict with this thread's accesses
+      bool new_transaction = true;
+      std::list<transaction_info>::iterator it;
+      transaction_info *info;
+      for (it = subwarp_transactions[block_address].begin();
+           it != subwarp_transactions[block_address].end(); it++) {
+        unsigned idx = (addr & 127);
+        if (not it->test_bytes(idx, idx + data_size - 1)) {
+          new_transaction = false;
+          info = &(*it);
+          break;
         }
+      }
+      if (new_transaction) {
+        // Need a new transaction
+        subwarp_transactions[block_address].push_back(transaction_info());
+        info = &subwarp_transactions[block_address].back();
+      }
+      assert(info);
 
-        // step 2: reduce each transaction size, if possible
-        std::map< new_addr_type, transaction_info >::iterator t;
-        for( t=subwarp_transactions.begin(); t !=subwarp_transactions.end(); t++ ) {
-            new_addr_type addr = t->first;
-            const transaction_info &info = t->second;
-
-            memory_coalescing_arch_reduce_and_send(is_write, access_type, info, addr, segment_size);
-
-        }
+      info->chunks.set(chunk);
+      info->active.set(thread);
+      unsigned idx = (addr & 127);
+      for (unsigned i = 0; i < data_size; i++) {
+        assert(!info->bytes.test(idx + i));
+        info->bytes.set(idx + i);
+      }
     }
+
+    // step 2: reduce each transaction size, if possible
+    std::map<new_addr_type, std::list<transaction_info> >::iterator t_list;
+    for (t_list = subwarp_transactions.begin();
+         t_list != subwarp_transactions.end(); t_list++) {
+      // For each block addr
+      new_addr_type addr = t_list->first;
+      const std::list<transaction_info> &transaction_list = t_list->second;
+
+      std::list<transaction_info>::const_iterator t;
+      for (t = transaction_list.begin(); t != transaction_list.end(); t++) {
+        // For each transaction
+        const transaction_info &info = *t;
+        memory_coalescing_arch_reduce_and_send(is_write, access_type, info,
+                                               addr, segment_size);
+      }
+    }
+  }
 }
 
-void warp_inst_t::memory_coalescing_arch_atomic( bool is_write, mem_access_type access_type )
-{
+void warp_inst_t::memory_coalescing_arch_reduce_and_send(
+    bool is_write, mem_access_type access_type, const transaction_info &info,
+    new_addr_type addr, unsigned segment_size) {
+  assert((addr & (segment_size - 1)) == 0);
 
-   assert(space.get_type() == global_space); // Atomics allowed only for global memory
+  const std::bitset<4> &q = info.chunks;
+  assert(q.count() >= 1);
+  std::bitset<2> h;  // halves (used to check if 64 byte segment can be
+                     // compressed into a single 32 byte segment)
 
-   // see the CUDA manual where it discusses coalescing rules before reading this
-   unsigned segment_size = 0;
-   unsigned warp_parts = m_config->mem_warp_parts;
-   bool sector_segment_size = false;
-
-   if(m_config->gpgpu_coalesce_arch >= 20 && m_config->gpgpu_coalesce_arch < 39)
-   {
-	//Fermi and Kepler, L1 is normal and L2 is sector
-	if(m_config->gmem_skip_L1D || cache_op == CACHE_GLOBAL)
-		sector_segment_size = true;
-	else
-		sector_segment_size = false;
-   }
-   else if(m_config->gpgpu_coalesce_arch >= 40)
-   {
-	//Maxwell, Pascal and Volta, L1 and L2 are sectors
-	//all requests should be 32 bytes
-	sector_segment_size = true;
-   }
-
-   switch( data_size ) {
-   case 1: segment_size = 32; break;
-   case 2: segment_size = sector_segment_size? 32 : 64; break;
-   case 4: case 8: case 16: segment_size = sector_segment_size? 32 : 128; break;
-   }
-   unsigned subwarp_size = m_config->warp_size / warp_parts;
-
-   for( unsigned subwarp=0; subwarp <  warp_parts; subwarp++ ) {
-       std::map<new_addr_type,std::list<transaction_info> > subwarp_transactions; // each block addr maps to a list of transactions
-
-       // step 1: find all transactions generated by this subwarp
-       for( unsigned thread=subwarp*subwarp_size; thread<subwarp_size*(subwarp+1); thread++ ) {
-           if( !active(thread) )
-               continue;
-
-           new_addr_type addr = m_per_scalar_thread[thread].memreqaddr[0];
-           unsigned block_address = line_size_based_tag_func(addr,segment_size);
-           unsigned chunk = (addr&127)/32; // which 32-byte chunk within in a 128-byte chunk does this thread access?
-
-           // can only write to one segment
-           assert(block_address == line_size_based_tag_func(addr+data_size-1,segment_size));
-
-           // Find a transaction that does not conflict with this thread's accesses
-           bool new_transaction = true;
-           std::list<transaction_info>::iterator it;
-           transaction_info* info;
-           for(it=subwarp_transactions[block_address].begin(); it!=subwarp_transactions[block_address].end(); it++) {
-              unsigned idx = (addr&127);
-              if(not it->test_bytes(idx,idx+data_size-1)) {
-                 new_transaction = false;
-                 info = &(*it);
-                 break;
-              }
-           }
-           if(new_transaction) {
-              // Need a new transaction
-              subwarp_transactions[block_address].push_back(transaction_info());
-              info = &subwarp_transactions[block_address].back();
-           }
-           assert(info);
-
-           info->chunks.set(chunk);
-           info->active.set(thread);
-           unsigned idx = (addr&127);
-           for( unsigned i=0; i < data_size; i++ ) {
-               assert(!info->bytes.test(idx+i));
-               info->bytes.set(idx+i);
-           }
-       }
-
-       // step 2: reduce each transaction size, if possible
-       std::map< new_addr_type, std::list<transaction_info> >::iterator t_list;
-       for( t_list=subwarp_transactions.begin(); t_list !=subwarp_transactions.end(); t_list++ ) {
-           // For each block addr
-           new_addr_type addr = t_list->first;
-           const std::list<transaction_info>& transaction_list = t_list->second;
-
-           std::list<transaction_info>::const_iterator t;
-           for(t=transaction_list.begin(); t!=transaction_list.end(); t++) {
-               // For each transaction
-               const transaction_info &info = *t;
-               memory_coalescing_arch_reduce_and_send(is_write, access_type, info, addr, segment_size);
-           }
-       }
-   }
+  unsigned size = segment_size;
+  if (segment_size == 128) {
+    bool lower_half_used = q[0] || q[1];
+    bool upper_half_used = q[2] || q[3];
+    if (lower_half_used && !upper_half_used) {
+      // only lower 64 bytes used
+      size = 64;
+      if (q[0]) h.set(0);
+      if (q[1]) h.set(1);
+    } else if ((!lower_half_used) && upper_half_used) {
+      // only upper 64 bytes used
+      addr = addr + 64;
+      size = 64;
+      if (q[2]) h.set(0);
+      if (q[3]) h.set(1);
+    } else {
+      assert(lower_half_used && upper_half_used);
+    }
+  } else if (segment_size == 64) {
+    // need to set halves
+    if ((addr % 128) == 0) {
+      if (q[0]) h.set(0);
+      if (q[1]) h.set(1);
+    } else {
+      assert((addr % 128) == 64);
+      if (q[2]) h.set(0);
+      if (q[3]) h.set(1);
+    }
+  }
+  if (size == 64) {
+    bool lower_half_used = h[0];
+    bool upper_half_used = h[1];
+    if (lower_half_used && !upper_half_used) {
+      size = 32;
+    } else if ((!lower_half_used) && upper_half_used) {
+      addr = addr + 32;
+      size = 32;
+    } else {
+      assert(lower_half_used && upper_half_used);
+    }
+  }
+  m_accessq.push_back(mem_access_t(access_type, addr, size, is_write,
+                                   info.active, info.bytes, info.chunks,
+                                   m_config->gpgpu_ctx));
 }
 
-void warp_inst_t::memory_coalescing_arch_reduce_and_send( bool is_write, mem_access_type access_type, const transaction_info &info, new_addr_type addr, unsigned segment_size )
-{
-   assert( (addr & (segment_size-1)) == 0 );
-
-   const std::bitset<4> &q = info.chunks;
-   assert( q.count() >= 1 );
-   std::bitset<2> h; // halves (used to check if 64 byte segment can be compressed into a single 32 byte segment)
-
-   unsigned size=segment_size;
-   if( segment_size == 128 ) {
-       bool lower_half_used = q[0] || q[1];
-       bool upper_half_used = q[2] || q[3];
-       if( lower_half_used && !upper_half_used ) {
-           // only lower 64 bytes used
-           size = 64;
-           if(q[0]) h.set(0);
-           if(q[1]) h.set(1);
-       } else if ( (!lower_half_used) && upper_half_used ) {
-           // only upper 64 bytes used
-           addr = addr+64;
-           size = 64;
-           if(q[2]) h.set(0);
-           if(q[3]) h.set(1);
-       } else {
-           assert(lower_half_used && upper_half_used);
-       }
-   } else if( segment_size == 64 ) {
-       // need to set halves
-       if( (addr % 128) == 0 ) {
-           if(q[0]) h.set(0);
-           if(q[1]) h.set(1);
-       } else {
-           assert( (addr % 128) == 64 );
-           if(q[2]) h.set(0);
-           if(q[3]) h.set(1);
-       }
-   }
-   if( size == 64 ) {
-       bool lower_half_used = h[0];
-       bool upper_half_used = h[1];
-       if( lower_half_used && !upper_half_used ) {
-           size = 32;
-       } else if ( (!lower_half_used) && upper_half_used ) {
-           addr = addr+32;
-           size = 32;
-       } else {
-           assert(lower_half_used && upper_half_used);
-       }
-   }
-   m_accessq.push_back( mem_access_t(access_type,addr,size,is_write,info.active,info.bytes, info.chunks,m_config->gpgpu_ctx) );
+void warp_inst_t::completed(unsigned long long cycle) const {
+  unsigned long long latency = cycle - issue_cycle;
+  assert(latency <= cycle);  // underflow detection
+  m_config->gpgpu_ctx->stats->ptx_file_line_stats_add_latency(
+      pc, latency * active_count());
 }
 
-void warp_inst_t::completed( unsigned long long cycle ) const 
-{
-   unsigned long long latency = cycle - issue_cycle; 
-   assert(latency <= cycle); // underflow detection 
-   m_config->gpgpu_ctx->stats->ptx_file_line_stats_add_latency(pc, latency * active_count());  
+kernel_info_t::kernel_info_t(dim3 gridDim, dim3 blockDim,
+                             class function_info *entry) {
+  m_kernel_entry = entry;
+  m_grid_dim = gridDim;
+  m_block_dim = blockDim;
+  m_next_cta.x = 0;
+  m_next_cta.y = 0;
+  m_next_cta.z = 0;
+  m_next_tid = m_next_cta;
+  m_num_cores_running = 0;
+  m_uid = (entry->gpgpu_ctx->kernel_info_m_next_uid)++;
+  m_param_mem = new memory_space_impl<8192>("param", 64 * 1024);
+
+  // Jin: parent and child kernel management for CDP
+  m_parent_kernel = NULL;
+
+  // Jin: launch latency management
+  m_launch_latency = entry->gpgpu_ctx->device_runtime->g_kernel_launch_latency;
+
+  volta_cache_config_set = false;
 }
 
-
-kernel_info_t::kernel_info_t( dim3 gridDim, dim3 blockDim, class function_info *entry)
-{
-    m_kernel_entry=entry;
-    m_grid_dim=gridDim;
-    m_block_dim=blockDim;
-    m_next_cta.x=0;
-    m_next_cta.y=0;
-    m_next_cta.z=0;
-    m_next_tid=m_next_cta;
-    m_num_cores_running=0;
-    m_uid = (entry->gpgpu_ctx->kernel_info_m_next_uid)++;
-    m_param_mem = new memory_space_impl<8192>("param",64*1024);
-
-    //Jin: parent and child kernel management for CDP
-    m_parent_kernel = NULL;
-
-    //Jin: launch latency management
-    m_launch_latency = entry->gpgpu_ctx->device_runtime->g_kernel_launch_latency;
-
-    volta_cache_config_set=false;
-}
-
-/*A snapshot of the texture mappings needs to be stored in the kernel's info as 
+/*A snapshot of the texture mappings needs to be stored in the kernel's info as
 kernels should use the texture bindings seen at the time of launch and textures
  can be bound/unbound asynchronously with respect to streams. */
-kernel_info_t::kernel_info_t( dim3 gridDim, dim3 blockDim, class function_info *entry, std::map<std::string, const struct cudaArray*> nameToCudaArray, std::map<std::string, const struct textureInfo*> nameToTextureInfo)   
-{
-    m_kernel_entry=entry;
-    m_grid_dim=gridDim;
-    m_block_dim=blockDim;
-    m_next_cta.x=0;
-    m_next_cta.y=0;
-    m_next_cta.z=0;
-    m_next_tid=m_next_cta;
-    m_num_cores_running=0;
-    m_uid = (entry->gpgpu_ctx->kernel_info_m_next_uid)++;
-    m_param_mem = new memory_space_impl<8192>("param",64*1024);
+kernel_info_t::kernel_info_t(
+    dim3 gridDim, dim3 blockDim, class function_info *entry,
+    std::map<std::string, const struct cudaArray *> nameToCudaArray,
+    std::map<std::string, const struct textureInfo *> nameToTextureInfo) {
+  m_kernel_entry = entry;
+  m_grid_dim = gridDim;
+  m_block_dim = blockDim;
+  m_next_cta.x = 0;
+  m_next_cta.y = 0;
+  m_next_cta.z = 0;
+  m_next_tid = m_next_cta;
+  m_num_cores_running = 0;
+  m_uid = (entry->gpgpu_ctx->kernel_info_m_next_uid)++;
+  m_param_mem = new memory_space_impl<8192>("param", 64 * 1024);
 
-    //Jin: parent and child kernel management for CDP
-    m_parent_kernel = NULL;
-   
-    //Jin: launch latency management
-    m_launch_latency = entry->gpgpu_ctx->device_runtime->g_kernel_launch_latency;
+  // Jin: parent and child kernel management for CDP
+  m_parent_kernel = NULL;
 
-    volta_cache_config_set=false;
-    m_NameToCudaArray = nameToCudaArray;
-    m_NameToTextureInfo = nameToTextureInfo;
+  // Jin: launch latency management
+  m_launch_latency = entry->gpgpu_ctx->device_runtime->g_kernel_launch_latency;
+
+  volta_cache_config_set = false;
+  m_NameToCudaArray = nameToCudaArray;
+  m_NameToTextureInfo = nameToTextureInfo;
 }
 
-kernel_info_t::~kernel_info_t()
-{
-    assert( m_active_threads.empty() );
-    destroy_cta_streams();
-    delete m_param_mem;
+kernel_info_t::~kernel_info_t() {
+  assert(m_active_threads.empty());
+  destroy_cta_streams();
+  delete m_param_mem;
 }
 
-std::string kernel_info_t::name() const
-{
-    return m_kernel_entry->get_name();
+std::string kernel_info_t::name() const { return m_kernel_entry->get_name(); }
+
+// Jin: parent and child kernel management for CDP
+void kernel_info_t::set_parent(kernel_info_t *parent, dim3 parent_ctaid,
+                               dim3 parent_tid) {
+  m_parent_kernel = parent;
+  m_parent_ctaid = parent_ctaid;
+  m_parent_tid = parent_tid;
+  parent->set_child(this);
 }
 
-//Jin: parent and child kernel management for CDP
-void kernel_info_t::set_parent(kernel_info_t * parent, 
-    dim3 parent_ctaid, dim3 parent_tid) {
-    m_parent_kernel = parent;
-    m_parent_ctaid = parent_ctaid;
-    m_parent_tid = parent_tid;
-    parent->set_child(this);
+void kernel_info_t::set_child(kernel_info_t *child) {
+  m_child_kernels.push_back(child);
 }
 
-void kernel_info_t::set_child(kernel_info_t * child) {
-    m_child_kernels.push_back(child);
-}
-
-void kernel_info_t::remove_child(kernel_info_t * child) {
-    assert(std::find(m_child_kernels.begin(), m_child_kernels.end(), child)
-        != m_child_kernels.end());
-    m_child_kernels.remove(child);
+void kernel_info_t::remove_child(kernel_info_t *child) {
+  assert(std::find(m_child_kernels.begin(), m_child_kernels.end(), child) !=
+         m_child_kernels.end());
+  m_child_kernels.remove(child);
 }
 
 bool kernel_info_t::is_finished() {
-  if(done() && children_all_finished())
-     return true;
+  if (done() && children_all_finished())
+    return true;
   else
-     return false;
+    return false;
 }
 
 bool kernel_info_t::children_all_finished() {
-   if(!m_child_kernels.empty())
-         return false;
-   
-   return true;
+  if (!m_child_kernels.empty()) return false;
+
+  return true;
 }
 
 void kernel_info_t::notify_parent_finished() {
-   if(m_parent_kernel) {
-       m_kernel_entry->gpgpu_ctx->device_runtime->g_total_param_size -= ((m_kernel_entry->get_args_aligned_size() + 255)/256*256);
-       m_parent_kernel->remove_child(this);
-       m_kernel_entry->gpgpu_ctx->the_gpgpusim->g_stream_manager->register_finished_kernel(m_parent_kernel->get_uid());
-   }
+  if (m_parent_kernel) {
+    m_kernel_entry->gpgpu_ctx->device_runtime->g_total_param_size -=
+        ((m_kernel_entry->get_args_aligned_size() + 255) / 256 * 256);
+    m_parent_kernel->remove_child(this);
+    m_kernel_entry->gpgpu_ctx->the_gpgpusim->g_stream_manager
+        ->register_finished_kernel(m_parent_kernel->get_uid());
+  }
 }
 
-CUstream_st * kernel_info_t::create_stream_cta(dim3 ctaid) {
-    assert(get_default_stream_cta(ctaid));
-    CUstream_st * stream = new CUstream_st();
-    m_kernel_entry->gpgpu_ctx->the_gpgpusim->g_stream_manager->add_stream(stream);
-    assert(m_cta_streams.find(ctaid) != m_cta_streams.end());
-    assert(m_cta_streams[ctaid].size() >= 1); //must have default stream
+CUstream_st *kernel_info_t::create_stream_cta(dim3 ctaid) {
+  assert(get_default_stream_cta(ctaid));
+  CUstream_st *stream = new CUstream_st();
+  m_kernel_entry->gpgpu_ctx->the_gpgpusim->g_stream_manager->add_stream(stream);
+  assert(m_cta_streams.find(ctaid) != m_cta_streams.end());
+  assert(m_cta_streams[ctaid].size() >= 1);  // must have default stream
+  m_cta_streams[ctaid].push_back(stream);
+
+  return stream;
+}
+
+CUstream_st *kernel_info_t::get_default_stream_cta(dim3 ctaid) {
+  if (m_cta_streams.find(ctaid) != m_cta_streams.end()) {
+    assert(m_cta_streams[ctaid].size() >=
+           1);  // already created, must have default stream
+    return *(m_cta_streams[ctaid].begin());
+  } else {
+    m_cta_streams[ctaid] = std::list<CUstream_st *>();
+    CUstream_st *stream = new CUstream_st();
+    m_kernel_entry->gpgpu_ctx->the_gpgpusim->g_stream_manager->add_stream(
+        stream);
     m_cta_streams[ctaid].push_back(stream);
-
     return stream;
+  }
 }
 
-CUstream_st * kernel_info_t::get_default_stream_cta(dim3 ctaid) {
-    if(m_cta_streams.find(ctaid) != m_cta_streams.end()) {
-       assert(m_cta_streams[ctaid].size() >= 1); //already created, must have default stream
-       return *(m_cta_streams[ctaid].begin());
-    }
-    else {
-      m_cta_streams[ctaid] = std::list<CUstream_st *>();
-      CUstream_st * stream = new CUstream_st();
-      m_kernel_entry->gpgpu_ctx->the_gpgpusim->g_stream_manager->add_stream(stream);
-      m_cta_streams[ctaid].push_back(stream);
-      return stream;
-    }
-}
+bool kernel_info_t::cta_has_stream(dim3 ctaid, CUstream_st *stream) {
+  if (m_cta_streams.find(ctaid) == m_cta_streams.end()) return false;
 
-bool kernel_info_t::cta_has_stream(dim3 ctaid, CUstream_st* stream) {
-    if(m_cta_streams.find(ctaid) == m_cta_streams.end())
-       return false;
-
-    std::list<CUstream_st *> &stream_list = m_cta_streams[ctaid];
-    if(std::find(stream_list.begin(), stream_list.end(), stream) 
-         == stream_list.end())
-       return false;
-    else
-       return true;
+  std::list<CUstream_st *> &stream_list = m_cta_streams[ctaid];
+  if (std::find(stream_list.begin(), stream_list.end(), stream) ==
+      stream_list.end())
+    return false;
+  else
+    return true;
 }
 
 void kernel_info_t::print_parent_info() {
-    if(m_parent_kernel) {
-        printf("Parent %d: \'%s\', Block (%d, %d, %d), Thread (%d, %d, %d)\n", 
-            m_parent_kernel->get_uid(), m_parent_kernel->name().c_str(), 
-            m_parent_ctaid.x, m_parent_ctaid.y, m_parent_ctaid.z,
-            m_parent_tid.x, m_parent_tid.y, m_parent_tid.z);
-    }
+  if (m_parent_kernel) {
+    printf("Parent %d: \'%s\', Block (%d, %d, %d), Thread (%d, %d, %d)\n",
+           m_parent_kernel->get_uid(), m_parent_kernel->name().c_str(),
+           m_parent_ctaid.x, m_parent_ctaid.y, m_parent_ctaid.z, m_parent_tid.x,
+           m_parent_tid.y, m_parent_tid.z);
+  }
 }
 
 void kernel_info_t::destroy_cta_streams() {
-     printf("Destroy streams for kernel %d: ", get_uid()); size_t stream_size = 0;
-     for(auto s = m_cta_streams.begin(); s != m_cta_streams.end(); s++) {
-        stream_size += s->second.size();
-        for(auto ss = s->second.begin(); ss != s->second.end(); ss++)
-        m_kernel_entry->gpgpu_ctx->the_gpgpusim->g_stream_manager->destroy_stream(*ss);
-        s->second.clear();
-     }
-     printf("size %lu\n", stream_size);
-     m_cta_streams.clear();
+  printf("Destroy streams for kernel %d: ", get_uid());
+  size_t stream_size = 0;
+  for (auto s = m_cta_streams.begin(); s != m_cta_streams.end(); s++) {
+    stream_size += s->second.size();
+    for (auto ss = s->second.begin(); ss != s->second.end(); ss++)
+      m_kernel_entry->gpgpu_ctx->the_gpgpusim->g_stream_manager->destroy_stream(
+          *ss);
+    s->second.clear();
+  }
+  printf("size %lu\n", stream_size);
+  m_cta_streams.clear();
 }
 
-simt_stack::simt_stack( unsigned wid, unsigned warpSize,  class gpgpu_sim * gpu)
-{
-    m_warp_id=wid;
-    m_warp_size = warpSize;
-    m_gpu=gpu;
-    reset();
+simt_stack::simt_stack(unsigned wid, unsigned warpSize, class gpgpu_sim *gpu) {
+  m_warp_id = wid;
+  m_warp_size = warpSize;
+  m_gpu = gpu;
+  reset();
 }
 
-void simt_stack::reset()
-{
-    m_stack.clear();
+void simt_stack::reset() { m_stack.clear(); }
+
+void simt_stack::launch(address_type start_pc, const simt_mask_t &active_mask) {
+  reset();
+  simt_stack_entry new_stack_entry;
+  new_stack_entry.m_pc = start_pc;
+  new_stack_entry.m_calldepth = 1;
+  new_stack_entry.m_active_mask = active_mask;
+  new_stack_entry.m_type = STACK_ENTRY_TYPE_NORMAL;
+  m_stack.push_back(new_stack_entry);
 }
 
-void simt_stack::launch( address_type start_pc, const simt_mask_t &active_mask )
-{
-    reset();
+void simt_stack::resume(char *fname) {
+  reset();
+
+  FILE *fp2 = fopen(fname, "r");
+  assert(fp2 != NULL);
+
+  char line[200]; /* or other suitable maximum line size */
+
+  while (fgets(line, sizeof line, fp2) != NULL) /* read a line */
+  {
     simt_stack_entry new_stack_entry;
-    new_stack_entry.m_pc = start_pc;
-    new_stack_entry.m_calldepth = 1;
-    new_stack_entry.m_active_mask = active_mask;
-    new_stack_entry.m_type = STACK_ENTRY_TYPE_NORMAL;
+    char *pch;
+    pch = strtok(line, " ");
+    for (unsigned j = 0; j < m_warp_size; j++) {
+      if (pch[0] == '1')
+        new_stack_entry.m_active_mask.set(j);
+      else
+        new_stack_entry.m_active_mask.reset(j);
+      pch = strtok(NULL, " ");
+    }
+
+    new_stack_entry.m_pc = atoi(pch);
+    pch = strtok(NULL, " ");
+    new_stack_entry.m_calldepth = atoi(pch);
+    pch = strtok(NULL, " ");
+    new_stack_entry.m_recvg_pc = atoi(pch);
+    pch = strtok(NULL, " ");
+    new_stack_entry.m_branch_div_cycle = atoi(pch);
+    pch = strtok(NULL, " ");
+    if (pch[0] == '0')
+      new_stack_entry.m_type = STACK_ENTRY_TYPE_NORMAL;
+    else
+      new_stack_entry.m_type = STACK_ENTRY_TYPE_CALL;
     m_stack.push_back(new_stack_entry);
+  }
+  fclose(fp2);
 }
 
-void simt_stack::resume( char * fname )
-{
-    reset();    
+const simt_mask_t &simt_stack::get_active_mask() const {
+  assert(m_stack.size() > 0);
+  return m_stack.back().m_active_mask;
+}
 
+void simt_stack::get_pdom_stack_top_info(unsigned *pc, unsigned *rpc) const {
+  assert(m_stack.size() > 0);
+  *pc = m_stack.back().m_pc;
+  *rpc = m_stack.back().m_recvg_pc;
+}
 
+unsigned simt_stack::get_rp() const {
+  assert(m_stack.size() > 0);
+  return m_stack.back().m_recvg_pc;
+}
 
-      FILE * fp2 = fopen(fname, "r");
-      assert(fp2!=NULL);
+void simt_stack::print(FILE *fout) const {
+  for (unsigned k = 0; k < m_stack.size(); k++) {
+    simt_stack_entry stack_entry = m_stack[k];
+    if (k == 0) {
+      fprintf(fout, "w%02d %1u ", m_warp_id, k);
+    } else {
+      fprintf(fout, "    %1u ", k);
+    }
+    for (unsigned j = 0; j < m_warp_size; j++)
+      fprintf(fout, "%c", (stack_entry.m_active_mask.test(j) ? '1' : '0'));
+    fprintf(fout, " pc: 0x%03x", stack_entry.m_pc);
+    if (stack_entry.m_recvg_pc == (unsigned)-1) {
+      fprintf(fout, " rp: ---- tp: %s cd: %2u ",
+              (stack_entry.m_type == STACK_ENTRY_TYPE_CALL ? "C" : "N"),
+              stack_entry.m_calldepth);
+    } else {
+      fprintf(fout, " rp: %4u tp: %s cd: %2u ", stack_entry.m_recvg_pc,
+              (stack_entry.m_type == STACK_ENTRY_TYPE_CALL ? "C" : "N"),
+              stack_entry.m_calldepth);
+    }
+    if (stack_entry.m_branch_div_cycle != 0) {
+      fprintf(fout, " bd@%6u ", (unsigned)stack_entry.m_branch_div_cycle);
+    } else {
+      fprintf(fout, " ");
+    }
+    m_gpu->gpgpu_ctx->func_sim->ptx_print_insn(stack_entry.m_pc, fout);
+    fprintf(fout, "\n");
+  }
+}
 
-      char line [ 200 ]; /* or other suitable maximum line size */
+void simt_stack::print_checkpoint(FILE *fout) const {
+  for (unsigned k = 0; k < m_stack.size(); k++) {
+    simt_stack_entry stack_entry = m_stack[k];
 
-      while ( fgets ( line, sizeof line, fp2 ) != NULL ) /* read a line */
-      {
-          simt_stack_entry new_stack_entry;
-          char * pch;
-          pch = strtok (line," ");
-          for (unsigned j=0; j<m_warp_size; j++)
-          {
-                if (pch[0]=='1')
-                    new_stack_entry.m_active_mask.set(j);
-                else
-                    new_stack_entry.m_active_mask.reset(j);
-                pch = strtok (NULL," ");
-                
-          }  
-          
-         new_stack_entry.m_pc=atoi(pch);
-         pch = strtok (NULL," "); 
-         new_stack_entry.m_calldepth=atoi(pch);
-         pch = strtok (NULL," "); 
-         new_stack_entry.m_recvg_pc=atoi(pch);
-         pch = strtok (NULL," "); 
-         new_stack_entry.m_branch_div_cycle=atoi(pch);
-         pch = strtok (NULL," "); 
-         if(pch[0]=='0')
-            new_stack_entry.m_type= STACK_ENTRY_TYPE_NORMAL;
-         else
-            new_stack_entry.m_type= STACK_ENTRY_TYPE_CALL;
-         m_stack.push_back(new_stack_entry);
+    for (unsigned j = 0; j < m_warp_size; j++)
+      fprintf(fout, "%c ", (stack_entry.m_active_mask.test(j) ? '1' : '0'));
+    fprintf(fout, "%d %d %d %lld %d ", stack_entry.m_pc,
+            stack_entry.m_calldepth, stack_entry.m_recvg_pc,
+            stack_entry.m_branch_div_cycle, stack_entry.m_type);
+    fprintf(fout, "%d %d\n", m_warp_id, m_warp_size);
+  }
+}
+
+void simt_stack::update(simt_mask_t &thread_done, addr_vector_t &next_pc,
+                        address_type recvg_pc, op_type next_inst_op,
+                        unsigned next_inst_size, address_type next_inst_pc) {
+  assert(m_stack.size() > 0);
+
+  assert(next_pc.size() == m_warp_size);
+
+  simt_mask_t top_active_mask = m_stack.back().m_active_mask;
+  address_type top_recvg_pc = m_stack.back().m_recvg_pc;
+  address_type top_pc =
+      m_stack.back().m_pc;  // the pc of the instruction just executed
+  stack_entry_type top_type = m_stack.back().m_type;
+  assert(top_pc == next_inst_pc);
+  assert(top_active_mask.any());
+
+  const address_type null_pc = -1;
+  bool warp_diverged = false;
+  address_type new_recvg_pc = null_pc;
+  unsigned num_divergent_paths = 0;
+
+  std::map<address_type, simt_mask_t> divergent_paths;
+  while (top_active_mask.any()) {
+    // extract a group of threads with the same next PC among the active threads
+    // in the warp
+    address_type tmp_next_pc = null_pc;
+    simt_mask_t tmp_active_mask;
+    for (int i = m_warp_size - 1; i >= 0; i--) {
+      if (top_active_mask.test(i)) {  // is this thread active?
+        if (thread_done.test(i)) {
+          top_active_mask.reset(i);  // remove completed thread from active mask
+        } else if (tmp_next_pc == null_pc) {
+          tmp_next_pc = next_pc[i];
+          tmp_active_mask.set(i);
+          top_active_mask.reset(i);
+        } else if (tmp_next_pc == next_pc[i]) {
+          tmp_active_mask.set(i);
+          top_active_mask.reset(i);
+        }
       }
-      fclose ( fp2 );
-
-    
-}
-
-const simt_mask_t &simt_stack::get_active_mask() const
-{
-    assert(m_stack.size() > 0);
-    return m_stack.back().m_active_mask;
-}
-
-void simt_stack::get_pdom_stack_top_info( unsigned *pc, unsigned *rpc ) const
-{
-   assert(m_stack.size() > 0);
-   *pc = m_stack.back().m_pc;
-   *rpc = m_stack.back().m_recvg_pc;
-}
-
-unsigned simt_stack::get_rp() const 
-{ 
-    assert(m_stack.size() > 0);
-    return m_stack.back().m_recvg_pc;
-}
-
-void simt_stack::print (FILE *fout) const
-{
-    for ( unsigned k=0; k < m_stack.size(); k++ ) {
-        simt_stack_entry stack_entry = m_stack[k];
-        if ( k==0 ) {
-            fprintf(fout, "w%02d %1u ", m_warp_id, k );
-        } else {
-            fprintf(fout, "    %1u ", k );
-        }
-        for (unsigned j=0; j<m_warp_size; j++)
-            fprintf(fout, "%c", (stack_entry.m_active_mask.test(j)?'1':'0') );
-        fprintf(fout, " pc: 0x%03x", stack_entry.m_pc );
-        if ( stack_entry.m_recvg_pc == (unsigned)-1 ) {
-            fprintf(fout," rp: ---- tp: %s cd: %2u ", (stack_entry.m_type==STACK_ENTRY_TYPE_CALL?"C":"N"), stack_entry.m_calldepth );
-        } else {
-            fprintf(fout," rp: %4u tp: %s cd: %2u ", stack_entry.m_recvg_pc, (stack_entry.m_type==STACK_ENTRY_TYPE_CALL?"C":"N"), stack_entry.m_calldepth );
-        }
-        if ( stack_entry.m_branch_div_cycle != 0 ) {
-            fprintf(fout," bd@%6u ", (unsigned) stack_entry.m_branch_div_cycle );
-        } else {
-            fprintf(fout," " );
-        }
-        m_gpu->gpgpu_ctx->func_sim->ptx_print_insn( stack_entry.m_pc, fout );
-        fprintf(fout,"\n");
     }
 
-}
-
-void simt_stack::print_checkpoint (FILE *fout) const
-{
-    for ( unsigned k=0; k < m_stack.size(); k++ ) {
-        simt_stack_entry stack_entry = m_stack[k];
-       
-        for (unsigned j=0; j<m_warp_size; j++)
-            fprintf(fout, "%c ", (stack_entry.m_active_mask.test(j)?'1':'0') );
-        fprintf(fout, "%d %d %d %lld %d ", stack_entry.m_pc,stack_entry.m_calldepth,stack_entry.m_recvg_pc,stack_entry.m_branch_div_cycle,stack_entry.m_type );
-        fprintf(fout, "%d %d\n",m_warp_id, m_warp_size );
-        
-    }
-}
-
-void simt_stack::update( simt_mask_t &thread_done, addr_vector_t &next_pc, address_type recvg_pc, op_type next_inst_op,unsigned next_inst_size, address_type next_inst_pc )
-{
-    assert(m_stack.size() > 0);
-
-    assert( next_pc.size() == m_warp_size );
-
-    simt_mask_t  top_active_mask = m_stack.back().m_active_mask;
-    address_type top_recvg_pc = m_stack.back().m_recvg_pc;
-    address_type top_pc = m_stack.back().m_pc; // the pc of the instruction just executed
-    stack_entry_type top_type = m_stack.back().m_type;
-    assert(top_pc==next_inst_pc);
-    assert(top_active_mask.any());
-
-    const address_type null_pc = -1;
-    bool warp_diverged = false;
-    address_type new_recvg_pc = null_pc;
-    unsigned num_divergent_paths=0;
-
-    std::map<address_type,simt_mask_t> divergent_paths;
-    while (top_active_mask.any()) {
-
-        // extract a group of threads with the same next PC among the active threads in the warp
-        address_type tmp_next_pc = null_pc;
-        simt_mask_t tmp_active_mask;
-        for (int i = m_warp_size - 1; i >= 0; i--) {
-            if ( top_active_mask.test(i) ) { // is this thread active?
-                if (thread_done.test(i)) {
-                    top_active_mask.reset(i); // remove completed thread from active mask
-                } else if (tmp_next_pc == null_pc) {
-                    tmp_next_pc = next_pc[i];
-                    tmp_active_mask.set(i);
-                    top_active_mask.reset(i);
-                } else if (tmp_next_pc == next_pc[i]) {
-                    tmp_active_mask.set(i);
-                    top_active_mask.reset(i);
-                }
-            }
-        }
-
-        if(tmp_next_pc == null_pc) {
-            assert(!top_active_mask.any()); // all threads done
-            continue;
-        }
-
-        divergent_paths[tmp_next_pc]=tmp_active_mask;
-        num_divergent_paths++;
+    if (tmp_next_pc == null_pc) {
+      assert(!top_active_mask.any());  // all threads done
+      continue;
     }
 
+    divergent_paths[tmp_next_pc] = tmp_active_mask;
+    num_divergent_paths++;
+  }
 
-    address_type not_taken_pc = next_inst_pc+next_inst_size;
-    assert(num_divergent_paths<=2);
-    for(unsigned i=0; i<num_divergent_paths; i++){
-    	address_type tmp_next_pc = null_pc;
-    	simt_mask_t tmp_active_mask;
-    	tmp_active_mask.reset();
-    	if(divergent_paths.find(not_taken_pc)!=divergent_paths.end()){
-    		assert(i==0);
-    		tmp_next_pc=not_taken_pc;
-    		tmp_active_mask=divergent_paths[tmp_next_pc];
-    		divergent_paths.erase(tmp_next_pc);
-    	}else{
-    		std::map<address_type,simt_mask_t>:: iterator it=divergent_paths.begin();
-    		tmp_next_pc=it->first;
-    		tmp_active_mask=divergent_paths[tmp_next_pc];
-    		divergent_paths.erase(tmp_next_pc);
-    	}
+  address_type not_taken_pc = next_inst_pc + next_inst_size;
+  assert(num_divergent_paths <= 2);
+  for (unsigned i = 0; i < num_divergent_paths; i++) {
+    address_type tmp_next_pc = null_pc;
+    simt_mask_t tmp_active_mask;
+    tmp_active_mask.reset();
+    if (divergent_paths.find(not_taken_pc) != divergent_paths.end()) {
+      assert(i == 0);
+      tmp_next_pc = not_taken_pc;
+      tmp_active_mask = divergent_paths[tmp_next_pc];
+      divergent_paths.erase(tmp_next_pc);
+    } else {
+      std::map<address_type, simt_mask_t>::iterator it =
+          divergent_paths.begin();
+      tmp_next_pc = it->first;
+      tmp_active_mask = divergent_paths[tmp_next_pc];
+      divergent_paths.erase(tmp_next_pc);
+    }
 
-        // HANDLE THE SPECIAL CASES FIRST
-    	if (next_inst_op== CALL_OPS){
-    		// Since call is not a divergent instruction, all threads should have executed a call instruction
-    		assert(num_divergent_paths == 1);
+    // HANDLE THE SPECIAL CASES FIRST
+    if (next_inst_op == CALL_OPS) {
+      // Since call is not a divergent instruction, all threads should have
+      // executed a call instruction
+      assert(num_divergent_paths == 1);
 
-    		simt_stack_entry new_stack_entry;
-    		new_stack_entry.m_pc = tmp_next_pc;
-    		new_stack_entry.m_active_mask = tmp_active_mask;
-    		new_stack_entry.m_branch_div_cycle = m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle;
-    		new_stack_entry.m_type = STACK_ENTRY_TYPE_CALL;
-    		m_stack.push_back(new_stack_entry);
-    		return;
-    	}else if(next_inst_op == RET_OPS && top_type==STACK_ENTRY_TYPE_CALL){
-    		// pop the CALL Entry
-    		assert(num_divergent_paths == 1);
-    		m_stack.pop_back();
+      simt_stack_entry new_stack_entry;
+      new_stack_entry.m_pc = tmp_next_pc;
+      new_stack_entry.m_active_mask = tmp_active_mask;
+      new_stack_entry.m_branch_div_cycle =
+          m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle;
+      new_stack_entry.m_type = STACK_ENTRY_TYPE_CALL;
+      m_stack.push_back(new_stack_entry);
+      return;
+    } else if (next_inst_op == RET_OPS && top_type == STACK_ENTRY_TYPE_CALL) {
+      // pop the CALL Entry
+      assert(num_divergent_paths == 1);
+      m_stack.pop_back();
 
-    		assert(m_stack.size() > 0);
-    		m_stack.back().m_pc=tmp_next_pc;// set the PC of the stack top entry to return PC from  the call stack;
-            // Check if the New top of the stack is reconverging
-            if (tmp_next_pc == m_stack.back().m_recvg_pc && m_stack.back().m_type!=STACK_ENTRY_TYPE_CALL){
-            	assert(m_stack.back().m_type==STACK_ENTRY_TYPE_NORMAL);
-            	m_stack.pop_back();
-            }
-            return;
-    	}
+      assert(m_stack.size() > 0);
+      m_stack.back().m_pc = tmp_next_pc;  // set the PC of the stack top entry
+                                          // to return PC from  the call stack;
+      // Check if the New top of the stack is reconverging
+      if (tmp_next_pc == m_stack.back().m_recvg_pc &&
+          m_stack.back().m_type != STACK_ENTRY_TYPE_CALL) {
+        assert(m_stack.back().m_type == STACK_ENTRY_TYPE_NORMAL);
+        m_stack.pop_back();
+      }
+      return;
+    }
 
-        // discard the new entry if its PC matches with reconvergence PC
-        // that automatically reconverges the entry
-        // If the top stack entry is CALL, dont reconverge.
-        if (tmp_next_pc == top_recvg_pc && (top_type != STACK_ENTRY_TYPE_CALL)) continue;
+    // discard the new entry if its PC matches with reconvergence PC
+    // that automatically reconverges the entry
+    // If the top stack entry is CALL, dont reconverge.
+    if (tmp_next_pc == top_recvg_pc && (top_type != STACK_ENTRY_TYPE_CALL))
+      continue;
 
-        // this new entry is not converging
-        // if this entry does not include thread from the warp, divergence occurs
-        if ((num_divergent_paths>1) && !warp_diverged ) {
-            warp_diverged = true;
-            // modify the existing top entry into a reconvergence entry in the pdom stack
-            new_recvg_pc = recvg_pc;
-            if (new_recvg_pc != top_recvg_pc) {
-                m_stack.back().m_pc = new_recvg_pc;
-                m_stack.back().m_branch_div_cycle = m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle;
-
-                m_stack.push_back(simt_stack_entry());
-            }
-        }
-
-        // discard the new entry if its PC matches with reconvergence PC
-        if (warp_diverged && tmp_next_pc == new_recvg_pc) continue;
-
-        // update the current top of pdom stack
-        m_stack.back().m_pc = tmp_next_pc;
-        m_stack.back().m_active_mask = tmp_active_mask;
-        if (warp_diverged) {
-            m_stack.back().m_calldepth = 0;
-            m_stack.back().m_recvg_pc = new_recvg_pc;
-        } else {
-            m_stack.back().m_recvg_pc = top_recvg_pc;
-        }
+    // this new entry is not converging
+    // if this entry does not include thread from the warp, divergence occurs
+    if ((num_divergent_paths > 1) && !warp_diverged) {
+      warp_diverged = true;
+      // modify the existing top entry into a reconvergence entry in the pdom
+      // stack
+      new_recvg_pc = recvg_pc;
+      if (new_recvg_pc != top_recvg_pc) {
+        m_stack.back().m_pc = new_recvg_pc;
+        m_stack.back().m_branch_div_cycle =
+            m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle;
 
         m_stack.push_back(simt_stack_entry());
+      }
     }
-    assert(m_stack.size() > 0);
-    m_stack.pop_back();
 
+    // discard the new entry if its PC matches with reconvergence PC
+    if (warp_diverged && tmp_next_pc == new_recvg_pc) continue;
 
+    // update the current top of pdom stack
+    m_stack.back().m_pc = tmp_next_pc;
+    m_stack.back().m_active_mask = tmp_active_mask;
     if (warp_diverged) {
-        m_gpu->gpgpu_ctx->stats->ptx_file_line_stats_add_warp_divergence(top_pc, 1); 
+      m_stack.back().m_calldepth = 0;
+      m_stack.back().m_recvg_pc = new_recvg_pc;
+    } else {
+      m_stack.back().m_recvg_pc = top_recvg_pc;
     }
+
+    m_stack.push_back(simt_stack_entry());
+  }
+  assert(m_stack.size() > 0);
+  m_stack.pop_back();
+
+  if (warp_diverged) {
+    m_gpu->gpgpu_ctx->stats->ptx_file_line_stats_add_warp_divergence(top_pc, 1);
+  }
 }
 
-void core_t::execute_warp_inst_t(warp_inst_t &inst, unsigned warpId)
-{
-    for ( unsigned t=0; t < m_warp_size; t++ ) {
-        if( inst.active(t) ) {
-            if(warpId==(unsigned (-1)))
-                warpId = inst.warp_id();
-            unsigned tid=m_warp_size*warpId+t;
-            m_thread[tid]->ptx_exec_inst(inst,t);
-            
-            //virtual function
-            checkExecutionStatusAndUpdate(inst,t,tid);
-        }
-    } 
-}
-  
-bool  core_t::ptx_thread_done( unsigned hw_thread_id ) const  
-{
-    return ((m_thread[ hw_thread_id ]==NULL) || m_thread[ hw_thread_id ]->is_done());
-}
-  
-void core_t::updateSIMTStack(unsigned warpId, warp_inst_t * inst)
-{
-    simt_mask_t thread_done;
-    addr_vector_t next_pc;
-    unsigned wtid = warpId * m_warp_size;
-    for (unsigned i = 0; i < m_warp_size; i++) {
-        if( ptx_thread_done(wtid+i) ) {
-            thread_done.set(i);
-            next_pc.push_back( (address_type)-1 );
-        } else {
-            if( inst->reconvergence_pc == RECONVERGE_RETURN_PC ) 
-                inst->reconvergence_pc = get_return_pc(m_thread[wtid+i]);
-            next_pc.push_back( m_thread[wtid+i]->get_pc() );
-        }
+void core_t::execute_warp_inst_t(warp_inst_t &inst, unsigned warpId) {
+  for (unsigned t = 0; t < m_warp_size; t++) {
+    if (inst.active(t)) {
+      if (warpId == (unsigned(-1))) warpId = inst.warp_id();
+      unsigned tid = m_warp_size * warpId + t;
+      m_thread[tid]->ptx_exec_inst(inst, t);
+
+      // virtual function
+      checkExecutionStatusAndUpdate(inst, t, tid);
     }
-    m_simt_stack[warpId]->update(thread_done,next_pc,inst->reconvergence_pc, inst->op,inst->isize,inst->pc);
+  }
+}
+
+bool core_t::ptx_thread_done(unsigned hw_thread_id) const {
+  return ((m_thread[hw_thread_id] == NULL) ||
+          m_thread[hw_thread_id]->is_done());
+}
+
+void core_t::updateSIMTStack(unsigned warpId, warp_inst_t *inst) {
+  simt_mask_t thread_done;
+  addr_vector_t next_pc;
+  unsigned wtid = warpId * m_warp_size;
+  for (unsigned i = 0; i < m_warp_size; i++) {
+    if (ptx_thread_done(wtid + i)) {
+      thread_done.set(i);
+      next_pc.push_back((address_type)-1);
+    } else {
+      if (inst->reconvergence_pc == RECONVERGE_RETURN_PC)
+        inst->reconvergence_pc = get_return_pc(m_thread[wtid + i]);
+      next_pc.push_back(m_thread[wtid + i]->get_pc());
+    }
+  }
+  m_simt_stack[warpId]->update(thread_done, next_pc, inst->reconvergence_pc,
+                               inst->op, inst->isize, inst->pc);
 }
 
 //! Get the warp to be executed using the data taken form the SIMT stack
-warp_inst_t core_t::getExecuteWarp(unsigned warpId)
-{
-    unsigned pc,rpc;
-    m_simt_stack[warpId]->get_pdom_stack_top_info(&pc,&rpc);
-    warp_inst_t wi= *(m_gpu->gpgpu_ctx->ptx_fetch_inst(pc));
-    wi.set_active(m_simt_stack[warpId]->get_active_mask());
-    return wi;
+warp_inst_t core_t::getExecuteWarp(unsigned warpId) {
+  unsigned pc, rpc;
+  m_simt_stack[warpId]->get_pdom_stack_top_info(&pc, &rpc);
+  warp_inst_t wi = *(m_gpu->gpgpu_ctx->ptx_fetch_inst(pc));
+  wi.set_active(m_simt_stack[warpId]->get_active_mask());
+  return wi;
 }
 
-void core_t::deleteSIMTStack()
-{
-    if ( m_simt_stack ) {
-        for (unsigned i = 0; i < m_warp_count; ++i) 
-            delete m_simt_stack[i];
-        delete[] m_simt_stack;
-        m_simt_stack = NULL;
-    }
+void core_t::deleteSIMTStack() {
+  if (m_simt_stack) {
+    for (unsigned i = 0; i < m_warp_count; ++i) delete m_simt_stack[i];
+    delete[] m_simt_stack;
+    m_simt_stack = NULL;
+  }
 }
 
-void core_t::initilizeSIMTStack(unsigned warp_count, unsigned warp_size)
-{ 
-    m_simt_stack = new simt_stack*[warp_count];
-    for (unsigned i = 0; i < warp_count; ++i) 
-        m_simt_stack[i] = new simt_stack(i,warp_size,m_gpu);
-    m_warp_size = warp_size;
-    m_warp_count = warp_count;
+void core_t::initilizeSIMTStack(unsigned warp_count, unsigned warp_size) {
+  m_simt_stack = new simt_stack *[warp_count];
+  for (unsigned i = 0; i < warp_count; ++i)
+    m_simt_stack[i] = new simt_stack(i, warp_size, m_gpu);
+  m_warp_size = warp_size;
+  m_warp_count = warp_count;
 }
 
-void core_t::get_pdom_stack_top_info( unsigned warpId, unsigned *pc, unsigned *rpc ) const
-{
-    m_simt_stack[warpId]->get_pdom_stack_top_info(pc,rpc);
+void core_t::get_pdom_stack_top_info(unsigned warpId, unsigned *pc,
+                                     unsigned *rpc) const {
+  m_simt_stack[warpId]->get_pdom_stack_top_info(pc, rpc);
 }

--- a/src/abstract_hardware_model.cc
+++ b/src/abstract_hardware_model.cc
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -27,1192 +25,1185 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+
 #include "abstract_hardware_model.h"
-#include <sys/stat.h>
-#include <algorithm>
-#include <iostream>
-#include <sstream>
-#include "../libcuda/gpgpu_context.h"
-#include "cuda-sim/cuda-sim.h"
 #include "cuda-sim/memory.h"
-#include "cuda-sim/ptx-stats.h"
 #include "cuda-sim/ptx_ir.h"
+#include "cuda-sim/ptx-stats.h"
+#include "cuda-sim/cuda-sim.h"
 #include "gpgpu-sim/gpu-sim.h"
-#include "gpgpusim_entrypoint.h"
 #include "option_parser.h"
+#include "gpgpusim_entrypoint.h"
+#include <algorithm>
+#include <sys/stat.h>
+#include <sstream>
+#include <iostream>
+#include "../libcuda/gpgpu_context.h"
 
-void mem_access_t::init(gpgpu_context *ctx) {
-  gpgpu_ctx = ctx;
-  m_uid = ++(gpgpu_ctx->sm_next_access_uid);
-  m_addr = 0;
-  m_req_size = 0;
+void mem_access_t::init(gpgpu_context* ctx)
+{
+      gpgpu_ctx = ctx;
+      m_uid=++(gpgpu_ctx->sm_next_access_uid);
+      m_addr=0;
+      m_req_size=0;
 }
-void warp_inst_t::issue(const active_mask_t &mask, unsigned warp_id,
-                        unsigned long long cycle, int dynamic_warp_id,
-                        int sch_id) {
-  m_warp_active_mask = mask;
-  m_warp_issued_mask = mask;
-  m_uid = ++(m_config->gpgpu_ctx->warp_inst_sm_next_uid);
-  m_warp_id = warp_id;
-  m_dynamic_warp_id = dynamic_warp_id;
-  issue_cycle = cycle;
-  cycles = initiation_interval;
-  m_cache_hit = false;
-  m_empty = false;
-  m_scheduler_id = sch_id;
+void warp_inst_t::issue( const active_mask_t &mask, unsigned warp_id, unsigned long long cycle, int dynamic_warp_id, int sch_id )
+{
+    m_warp_active_mask = mask;
+    m_warp_issued_mask = mask; 
+    m_uid = ++(m_config->gpgpu_ctx->warp_inst_sm_next_uid);
+    m_warp_id = warp_id;
+    m_dynamic_warp_id = dynamic_warp_id;
+    issue_cycle = cycle;
+    cycles = initiation_interval;
+    m_cache_hit=false;
+    m_empty=false;
+    m_scheduler_id=sch_id;
 }
 
-checkpoint::checkpoint() {
-  struct stat st = {0};
+checkpoint::checkpoint()
+{
 
-  if (stat("checkpoint_files", &st) == -1) {
-    mkdir("checkpoint_files", 0777);
-  }
-}
-void checkpoint::load_global_mem(class memory_space *temp_mem, char *f1name) {
-  FILE *fp2 = fopen(f1name, "r");
-  assert(fp2 != NULL);
-  char line[128]; /* or other suitable maximum line size */
-  unsigned int offset;
-  while (fgets(line, sizeof line, fp2) != NULL) /* read a line */
-  {
-    unsigned int index;
-    char *pch;
-    pch = strtok(line, " ");
-    if (pch[0] == 'g' || pch[0] == 's' || pch[0] == 'l') {
-      pch = strtok(NULL, " ");
+    struct stat st = {0};
 
-      std::stringstream ss;
-      ss << std::hex << pch;
-      ss >> index;
-
-      offset = 0;
-    } else {
-      unsigned int data;
-      std::stringstream ss;
-      ss << std::hex << pch;
-      ss >> data;
-      temp_mem->write_only(offset, index, 4, &data);
-      offset = offset + 4;
+    if (stat("checkpoint_files", &st) == -1) {
+        mkdir("checkpoint_files", 0777);
     }
-    // fputs ( line, stdout ); /* write the line */
-  }
-  fclose(fp2);
+
 }
+void checkpoint::load_global_mem(class memory_space *temp_mem, char * f1name)
+{
 
-void checkpoint::store_global_mem(class memory_space *mem, char *fname,
-                                  char *format) {
-  FILE *fp3 = fopen(fname, "w");
-  assert(fp3 != NULL);
-  mem->print(format, fp3);
-  fclose(fp3);
-}
+    FILE * fp2 = fopen(f1name, "r");
+    assert(fp2!=NULL);
+      char line [ 128 ]; /* or other suitable maximum line size */
+      unsigned int offset ;
+      while ( fgets ( line, sizeof line, fp2 ) != NULL ) /* read a line */
+      {
+         unsigned int index;
+         char * pch;
+         pch = strtok (line," ");
+         if (pch[0]=='g' || pch[0]=='s' || pch[0]=='l')
+         {
 
-void move_warp(warp_inst_t *&dst, warp_inst_t *&src) {
-  assert(dst->empty());
-  warp_inst_t *temp = dst;
-  dst = src;
-  src = temp;
-  src->clear();
-}
+           pch = strtok (NULL, " ");
+           
+           std::stringstream ss;
+            ss << std::hex << pch;
+            ss >> index;
 
-void gpgpu_functional_sim_config::reg_options(class OptionParser *opp) {
-  option_parser_register(opp, "-gpgpu_ptx_use_cuobjdump", OPT_BOOL,
-                         &m_ptx_use_cuobjdump,
-                         "Use cuobjdump to extract ptx and sass from binaries",
-#if (CUDART_VERSION >= 4000)
-                         "1"
-#else
-                         "0"
-#endif
-                         );
-  option_parser_register(opp, "-gpgpu_experimental_lib_support", OPT_BOOL,
-                         &m_experimental_lib_support,
-                         "Try to extract code from cuda libraries [Broken "
-                         "because of unknown cudaGetExportTable]",
-                         "0");
-  option_parser_register(opp, "-checkpoint_option", OPT_INT32,
-                         &checkpoint_option,
-                         " checkpointing flag (0 = no checkpoint)", "0");
-  option_parser_register(
-      opp, "-checkpoint_kernel", OPT_INT32, &checkpoint_kernel,
-      " checkpointing during execution of which kernel (1- 1st kernel)", "1");
-  option_parser_register(
-      opp, "-checkpoint_CTA", OPT_INT32, &checkpoint_CTA,
-      " checkpointing after # of CTA (< less than total CTA)", "0");
-  option_parser_register(opp, "-resume_option", OPT_INT32, &resume_option,
-                         " resume flag (0 = no resume)", "0");
-  option_parser_register(opp, "-resume_kernel", OPT_INT32, &resume_kernel,
-                         " Resume from which kernel (1= 1st kernel)", "0");
-  option_parser_register(opp, "-resume_CTA", OPT_INT32, &resume_CTA,
-                         " resume from which CTA ", "0");
-  option_parser_register(opp, "-checkpoint_CTA_t", OPT_INT32, &checkpoint_CTA_t,
-                         " resume from which CTA ", "0");
-  option_parser_register(opp, "-checkpoint_insn_Y", OPT_INT32,
-                         &checkpoint_insn_Y, " resume from which CTA ", "0");
-
-  option_parser_register(
-      opp, "-gpgpu_ptx_convert_to_ptxplus", OPT_BOOL, &m_ptx_convert_to_ptxplus,
-      "Convert SASS (native ISA) to ptxplus and run ptxplus", "0");
-  option_parser_register(opp, "-gpgpu_ptx_force_max_capability", OPT_UINT32,
-                         &m_ptx_force_max_capability,
-                         "Force maximum compute capability", "0");
-  option_parser_register(
-      opp, "-gpgpu_ptx_inst_debug_to_file", OPT_BOOL, &g_ptx_inst_debug_to_file,
-      "Dump executed instructions' debug information to file", "0");
-  option_parser_register(
-      opp, "-gpgpu_ptx_inst_debug_file", OPT_CSTR, &g_ptx_inst_debug_file,
-      "Executed instructions' debug output file", "inst_debug.txt");
-  option_parser_register(opp, "-gpgpu_ptx_inst_debug_thread_uid", OPT_INT32,
-                         &g_ptx_inst_debug_thread_uid,
-                         "Thread UID for executed instructions' debug output",
-                         "1");
-}
-
-void gpgpu_functional_sim_config::ptx_set_tex_cache_linesize(
-    unsigned linesize) {
-  m_texcache_linesize = linesize;
-}
-
-gpgpu_t::gpgpu_t(const gpgpu_functional_sim_config &config, gpgpu_context *ctx)
-    : m_function_model_config(config) {
-  gpgpu_ctx = ctx;
-  m_global_mem = new memory_space_impl<8192>("global", 64 * 1024);
-
-  m_tex_mem = new memory_space_impl<8192>("tex", 64 * 1024);
-  m_surf_mem = new memory_space_impl<8192>("surf", 64 * 1024);
-
-  m_dev_malloc = GLOBAL_HEAP_START;
-  checkpoint_option = m_function_model_config.get_checkpoint_option();
-  checkpoint_kernel = m_function_model_config.get_checkpoint_kernel();
-  checkpoint_CTA = m_function_model_config.get_checkpoint_CTA();
-  resume_option = m_function_model_config.get_resume_option();
-  resume_kernel = m_function_model_config.get_resume_kernel();
-  resume_CTA = m_function_model_config.get_resume_CTA();
-  checkpoint_CTA_t = m_function_model_config.get_checkpoint_CTA_t();
-  checkpoint_insn_Y = m_function_model_config.get_checkpoint_insn_Y();
-
-  // initialize texture mappings to empty
-  m_NameToTextureInfo.clear();
-  m_NameToCudaArray.clear();
-  m_TextureRefToName.clear();
-  m_NameToAttribute.clear();
-
-  if (m_function_model_config.get_ptx_inst_debug_to_file() != 0)
-    ptx_inst_debug_file =
-        fopen(m_function_model_config.get_ptx_inst_debug_file(), "w");
-
-  gpu_sim_cycle = 0;
-  gpu_tot_sim_cycle = 0;
-}
-
-address_type line_size_based_tag_func(new_addr_type address,
-                                      new_addr_type line_size) {
-  // gives the tag for an address based on a given line size
-  return address & ~(line_size - 1);
-}
-
-const char *mem_access_type_str(enum mem_access_type access_type) {
-#define MA_TUP_BEGIN(X) static const char *access_type_str[] = {
-#define MA_TUP(X) #X
-#define MA_TUP_END(X) \
-  }                   \
-  ;
-  MEM_ACCESS_TYPE_TUP_DEF
-#undef MA_TUP_BEGIN
-#undef MA_TUP
-#undef MA_TUP_END
-
-  assert(access_type < NUM_MEM_ACCESS_TYPE);
-
-  return access_type_str[access_type];
-}
-
-void warp_inst_t::clear_active(const active_mask_t &inactive) {
-  active_mask_t test = m_warp_active_mask;
-  test &= inactive;
-  assert(test == inactive);  // verify threads being disabled were active
-  m_warp_active_mask &= ~inactive;
-}
-
-void warp_inst_t::set_not_active(unsigned lane_id) {
-  m_warp_active_mask.reset(lane_id);
-}
-
-void warp_inst_t::set_active(const active_mask_t &active) {
-  m_warp_active_mask = active;
-  if (m_isatomic) {
-    for (unsigned i = 0; i < m_config->warp_size; i++) {
-      if (!m_warp_active_mask.test(i)) {
-        m_per_scalar_thread[i].callback.function = NULL;
-        m_per_scalar_thread[i].callback.instruction = NULL;
-        m_per_scalar_thread[i].callback.thread = NULL;
+           offset=0;
+         }
+         else {
+            unsigned int  data;
+            std::stringstream ss;
+            ss << std::hex << pch;
+            ss >> data;
+            temp_mem->write_only(offset,index, 4,&data);
+            offset= offset+4;
+         }
+         //fputs ( line, stdout ); /* write the line */
       }
-    }
-  }
+      fclose ( fp2 );
+}
+
+void checkpoint::store_global_mem(class memory_space * mem, char *fname, char * format)
+{
+
+      FILE * fp3 = fopen(fname, "w");
+      assert(fp3!=NULL);
+      mem->print(format,fp3);
+      fclose(fp3);
+}
+
+void move_warp( warp_inst_t *&dst, warp_inst_t *&src )
+{
+   assert( dst->empty() );
+   warp_inst_t* temp = dst;
+   dst = src;
+   src = temp;
+   src->clear();
+}
+
+
+void gpgpu_functional_sim_config::reg_options(class OptionParser * opp)
+{
+	option_parser_register(opp, "-gpgpu_ptx_use_cuobjdump", OPT_BOOL,
+                 &m_ptx_use_cuobjdump,
+                 "Use cuobjdump to extract ptx and sass from binaries",
+#if (CUDART_VERSION >= 4000)
+                 "1"
+#else
+                 "0"
+#endif
+                 );
+	option_parser_register(opp, "-gpgpu_experimental_lib_support", OPT_BOOL,
+	                 &m_experimental_lib_support,
+	                 "Try to extract code from cuda libraries [Broken because of unknown cudaGetExportTable]",
+	                 "0");
+  option_parser_register(opp, "-checkpoint_option", OPT_INT32, &checkpoint_option, 
+               " checkpointing flag (0 = no checkpoint)",
+               "0");
+  option_parser_register(opp, "-checkpoint_kernel", OPT_INT32, &checkpoint_kernel, 
+               " checkpointing during execution of which kernel (1- 1st kernel)",
+               "1");
+  option_parser_register(opp, "-checkpoint_CTA", OPT_INT32, &checkpoint_CTA, 
+               " checkpointing after # of CTA (< less than total CTA)",
+               "0");
+  option_parser_register(opp, "-resume_option", OPT_INT32, &resume_option, 
+               " resume flag (0 = no resume)",
+               "0");
+  option_parser_register(opp, "-resume_kernel", OPT_INT32, &resume_kernel, 
+               " Resume from which kernel (1= 1st kernel)",
+               "0");
+   option_parser_register(opp, "-resume_CTA", OPT_INT32, &resume_CTA, 
+               " resume from which CTA ",
+               "0");
+      option_parser_register(opp, "-checkpoint_CTA_t", OPT_INT32, &checkpoint_CTA_t, 
+               " resume from which CTA ",
+               "0");
+         option_parser_register(opp, "-checkpoint_insn_Y", OPT_INT32, &checkpoint_insn_Y, 
+               " resume from which CTA ",
+               "0");
+
+    option_parser_register(opp, "-gpgpu_ptx_convert_to_ptxplus", OPT_BOOL,
+                 &m_ptx_convert_to_ptxplus,
+                 "Convert SASS (native ISA) to ptxplus and run ptxplus",
+                 "0");
+    option_parser_register(opp, "-gpgpu_ptx_force_max_capability", OPT_UINT32,
+                 &m_ptx_force_max_capability,
+                 "Force maximum compute capability",
+                 "0");
+   option_parser_register(opp, "-gpgpu_ptx_inst_debug_to_file", OPT_BOOL, 
+                &g_ptx_inst_debug_to_file, 
+                "Dump executed instructions' debug information to file", 
+                "0");
+   option_parser_register(opp, "-gpgpu_ptx_inst_debug_file", OPT_CSTR, &g_ptx_inst_debug_file, 
+                  "Executed instructions' debug output file",
+                  "inst_debug.txt");
+   option_parser_register(opp, "-gpgpu_ptx_inst_debug_thread_uid", OPT_INT32, &g_ptx_inst_debug_thread_uid, 
+               "Thread UID for executed instructions' debug output", 
+               "1");
+}
+
+void gpgpu_functional_sim_config::ptx_set_tex_cache_linesize(unsigned linesize)
+{
+   m_texcache_linesize = linesize;
+}
+
+gpgpu_t::gpgpu_t( const gpgpu_functional_sim_config &config, gpgpu_context* ctx )
+    : m_function_model_config(config)
+{
+   gpgpu_ctx = ctx;
+   m_global_mem = new memory_space_impl<8192>("global",64*1024);
+   
+   m_tex_mem = new memory_space_impl<8192>("tex",64*1024);
+   m_surf_mem = new memory_space_impl<8192>("surf",64*1024);
+
+   m_dev_malloc=GLOBAL_HEAP_START; 
+   checkpoint_option = m_function_model_config.get_checkpoint_option();
+   checkpoint_kernel = m_function_model_config.get_checkpoint_kernel();
+   checkpoint_CTA = m_function_model_config.get_checkpoint_CTA();
+   resume_option = m_function_model_config.get_resume_option();
+   resume_kernel = m_function_model_config.get_resume_kernel();
+   resume_CTA = m_function_model_config.get_resume_CTA();
+   checkpoint_CTA_t = m_function_model_config.get_checkpoint_CTA_t();
+   checkpoint_insn_Y = m_function_model_config.get_checkpoint_insn_Y();
+
+   // initialize texture mappings to empty
+   m_NameToTextureInfo.clear();
+   m_NameToCudaArray.clear();
+   m_TextureRefToName.clear();
+   m_NameToAttribute.clear();
+
+   if(m_function_model_config.get_ptx_inst_debug_to_file() != 0) 
+      ptx_inst_debug_file = fopen(m_function_model_config.get_ptx_inst_debug_file(), "w");
+
+   gpu_sim_cycle=0;
+   gpu_tot_sim_cycle=0;
+}
+
+address_type line_size_based_tag_func(new_addr_type address, new_addr_type line_size)
+{
+   //gives the tag for an address based on a given line size
+   return address & ~(line_size-1);
+}
+
+const char * mem_access_type_str(enum mem_access_type access_type)
+{
+   #define MA_TUP_BEGIN(X) static const char* access_type_str[] = {
+   #define MA_TUP(X) #X
+   #define MA_TUP_END(X) };
+   MEM_ACCESS_TYPE_TUP_DEF
+   #undef MA_TUP_BEGIN
+   #undef MA_TUP
+   #undef MA_TUP_END
+
+   assert(access_type < NUM_MEM_ACCESS_TYPE); 
+
+   return access_type_str[access_type]; 
+}
+
+
+void warp_inst_t::clear_active( const active_mask_t &inactive ) {
+    active_mask_t test = m_warp_active_mask;
+    test &= inactive;
+    assert( test == inactive ); // verify threads being disabled were active
+    m_warp_active_mask &= ~inactive;
+}
+
+void warp_inst_t::set_not_active( unsigned lane_id ) {
+    m_warp_active_mask.reset(lane_id);
+}
+
+void warp_inst_t::set_active( const active_mask_t &active ) {
+   m_warp_active_mask = active;
+   if( m_isatomic ) {
+      for( unsigned i=0; i < m_config->warp_size; i++ ) {
+         if( !m_warp_active_mask.test(i) ) {
+             m_per_scalar_thread[i].callback.function = NULL;
+             m_per_scalar_thread[i].callback.instruction = NULL;
+             m_per_scalar_thread[i].callback.thread = NULL;
+         }
+      }
+   }
 }
 
 void warp_inst_t::do_atomic(bool forceDo) {
-  do_atomic(m_warp_active_mask, forceDo);
+    do_atomic( m_warp_active_mask,forceDo );
 }
 
-void warp_inst_t::do_atomic(const active_mask_t &access_mask, bool forceDo) {
-  assert(m_isatomic && (!m_empty || forceDo));
-  for (unsigned i = 0; i < m_config->warp_size; i++) {
-    if (access_mask.test(i)) {
-      dram_callback_t &cb = m_per_scalar_thread[i].callback;
-      if (cb.thread) cb.function(cb.instruction, cb.thread);
+
+void warp_inst_t::do_atomic( const active_mask_t& access_mask,bool forceDo ) {
+    assert( m_isatomic && (!m_empty||forceDo) );
+    for( unsigned i=0; i < m_config->warp_size; i++ )
+    {
+        if( access_mask.test(i) )
+        {
+            dram_callback_t &cb = m_per_scalar_thread[i].callback;
+            if( cb.thread )
+                cb.function(cb.instruction, cb.thread);
+        }
     }
-  }
 }
 
-void warp_inst_t::broadcast_barrier_reduction(
-    const active_mask_t &access_mask) {
-  for (unsigned i = 0; i < m_config->warp_size; i++) {
-    if (access_mask.test(i)) {
-      dram_callback_t &cb = m_per_scalar_thread[i].callback;
-      if (cb.thread) {
-        cb.function(cb.instruction, cb.thread);
-      }
+void warp_inst_t::broadcast_barrier_reduction(const active_mask_t& access_mask)
+{
+	for( unsigned i=0; i < m_config->warp_size; i++ )
+    {
+        if( access_mask.test(i) )
+        {
+            dram_callback_t &cb = m_per_scalar_thread[i].callback;
+            if( cb.thread ){
+                cb.function(cb.instruction, cb.thread);
+            }
+        }
     }
-  }
 }
 
-void warp_inst_t::generate_mem_accesses() {
-  if (empty() || op == MEMORY_BARRIER_OP || m_mem_accesses_created) return;
-  if (!((op == LOAD_OP) || (op == TENSOR_CORE_LOAD_OP) || (op == STORE_OP) ||
-        (op == TENSOR_CORE_STORE_OP)))
-    return;
-  if (m_warp_active_mask.count() == 0) return;  // predicated off
+void warp_inst_t::generate_mem_accesses()
+{
+    if( empty() || op == MEMORY_BARRIER_OP || m_mem_accesses_created ) 
+        return;
+    if (!((op == LOAD_OP) || (op==TENSOR_CORE_LOAD_OP)   || (op == STORE_OP)||(op==TENSOR_CORE_STORE_OP)))
+        return; 
+    if( m_warp_active_mask.count() == 0 ) 
+        return; // predicated off
 
-  const size_t starting_queue_size = m_accessq.size();
+    const size_t starting_queue_size = m_accessq.size();
 
-  assert(is_load() || is_store());
-  assert(m_per_scalar_thread_valid);  // need address information per thread
+    assert( is_load() || is_store() );
+    assert( m_per_scalar_thread_valid ); // need address information per thread
 
-  bool is_write = is_store();
+    bool is_write = is_store();
 
-  mem_access_type access_type;
-  switch (space.get_type()) {
+    mem_access_type access_type;
+    switch (space.get_type()) {
     case const_space:
-    case param_space_kernel:
-      access_type = CONST_ACC_R;
-      break;
-    case tex_space:
-      access_type = TEXTURE_ACC_R;
-      break;
-    case global_space:
-      access_type = is_write ? GLOBAL_ACC_W : GLOBAL_ACC_R;
-      break;
+    case param_space_kernel: 
+        access_type = CONST_ACC_R; 
+        break;
+    case tex_space: 
+        access_type = TEXTURE_ACC_R;   
+        break;
+    case global_space:       
+        access_type = is_write? GLOBAL_ACC_W: GLOBAL_ACC_R;   
+        break;
     case local_space:
-    case param_space_local:
-      access_type = is_write ? LOCAL_ACC_W : LOCAL_ACC_R;
-      break;
-    case shared_space:
-      break;
-    case sstarr_space:
-      break;
-    default:
-      assert(0);
-      break;
-  }
+    case param_space_local:  
+        access_type = is_write? LOCAL_ACC_W: LOCAL_ACC_R;   
+        break;
+    case shared_space: break;
+    case sstarr_space: break;
+    default: assert(0); break; 
+    }
 
-  // Calculate memory accesses generated by this warp
-  new_addr_type cache_block_size = 0;  // in bytes
+    // Calculate memory accesses generated by this warp
+    new_addr_type cache_block_size = 0; // in bytes 
 
-  switch (space.get_type()) {
+    switch( space.get_type() ) {
     case shared_space:
     case sstarr_space: {
-      unsigned subwarp_size = m_config->warp_size / m_config->mem_warp_parts;
-      unsigned total_accesses = 0;
-      for (unsigned subwarp = 0; subwarp < m_config->mem_warp_parts;
-           subwarp++) {
-        // data structures used per part warp
-        std::map<unsigned, std::map<new_addr_type, unsigned> >
-            bank_accs;  // bank -> word address -> access count
+        unsigned subwarp_size = m_config->warp_size / m_config->mem_warp_parts;
+        unsigned total_accesses=0;
+        for( unsigned subwarp=0; subwarp <  m_config->mem_warp_parts; subwarp++ ) {
 
-        // step 1: compute accesses to words in banks
-        for (unsigned thread = subwarp * subwarp_size;
-             thread < (subwarp + 1) * subwarp_size; thread++) {
-          if (!active(thread)) continue;
-          new_addr_type addr = m_per_scalar_thread[thread].memreqaddr[0];
-          // FIXME: deferred allocation of shared memory should not accumulate
-          // across kernel launches
-          // assert( addr < m_config->gpgpu_shmem_size );
-          unsigned bank = m_config->shmem_bank_func(addr);
-          new_addr_type word =
-              line_size_based_tag_func(addr, m_config->WORD_SIZE);
-          bank_accs[bank][word]++;
-        }
+            // data structures used per part warp 
+            std::map<unsigned,std::map<new_addr_type,unsigned> > bank_accs; // bank -> word address -> access count
 
-        if (m_config->shmem_limited_broadcast) {
-          // step 2: look for and select a broadcast bank/word if one occurs
-          bool broadcast_detected = false;
-          new_addr_type broadcast_word = (new_addr_type)-1;
-          unsigned broadcast_bank = (unsigned)-1;
-          std::map<unsigned, std::map<new_addr_type, unsigned> >::iterator b;
-          for (b = bank_accs.begin(); b != bank_accs.end(); b++) {
-            unsigned bank = b->first;
-            std::map<new_addr_type, unsigned> &access_set = b->second;
-            std::map<new_addr_type, unsigned>::iterator w;
-            for (w = access_set.begin(); w != access_set.end(); ++w) {
-              if (w->second > 1) {
-                // found a broadcast
-                broadcast_detected = true;
-                broadcast_bank = bank;
-                broadcast_word = w->first;
-                break;
-              }
+            // step 1: compute accesses to words in banks
+            for( unsigned thread=subwarp*subwarp_size; thread < (subwarp+1)*subwarp_size; thread++ ) {
+                if( !active(thread) ) 
+                    continue;
+                new_addr_type addr = m_per_scalar_thread[thread].memreqaddr[0];
+                //FIXME: deferred allocation of shared memory should not accumulate across kernel launches
+                //assert( addr < m_config->gpgpu_shmem_size ); 
+                unsigned bank = m_config->shmem_bank_func(addr);
+                new_addr_type word = line_size_based_tag_func(addr,m_config->WORD_SIZE);
+                bank_accs[bank][word]++;
             }
-            if (broadcast_detected) break;
-          }
 
-          // step 3: figure out max bank accesses performed, taking account of
-          // broadcast case
-          unsigned max_bank_accesses = 0;
-          for (b = bank_accs.begin(); b != bank_accs.end(); b++) {
-            unsigned bank_accesses = 0;
-            std::map<new_addr_type, unsigned> &access_set = b->second;
-            std::map<new_addr_type, unsigned>::iterator w;
-            for (w = access_set.begin(); w != access_set.end(); ++w)
-              bank_accesses += w->second;
-            if (broadcast_detected && broadcast_bank == b->first) {
-              for (w = access_set.begin(); w != access_set.end(); ++w) {
-                if (w->first == broadcast_word) {
-                  unsigned n = w->second;
-                  assert(n > 1);  // or this wasn't a broadcast
-                  assert(bank_accesses >= (n - 1));
-                  bank_accesses -= (n - 1);
-                  break;
+            if (m_config->shmem_limited_broadcast) {
+                // step 2: look for and select a broadcast bank/word if one occurs
+                bool broadcast_detected = false;
+                new_addr_type broadcast_word=(new_addr_type)-1;
+                unsigned broadcast_bank=(unsigned)-1;
+                std::map<unsigned,std::map<new_addr_type,unsigned> >::iterator b;
+                for( b=bank_accs.begin(); b != bank_accs.end(); b++ ) {
+                    unsigned bank = b->first;
+                    std::map<new_addr_type,unsigned> &access_set = b->second;
+                    std::map<new_addr_type,unsigned>::iterator w;
+                    for( w=access_set.begin(); w != access_set.end(); ++w ) {
+                        if( w->second > 1 ) {
+                            // found a broadcast
+                            broadcast_detected=true;
+                            broadcast_bank=bank;
+                            broadcast_word=w->first;
+                            break;
+                        }
+                    }
+                    if( broadcast_detected ) 
+                        break;
                 }
-              }
+            
+                // step 3: figure out max bank accesses performed, taking account of broadcast case
+                unsigned max_bank_accesses=0;
+                for( b=bank_accs.begin(); b != bank_accs.end(); b++ ) {
+                    unsigned bank_accesses=0;
+                    std::map<new_addr_type,unsigned> &access_set = b->second;
+                    std::map<new_addr_type,unsigned>::iterator w;
+                    for( w=access_set.begin(); w != access_set.end(); ++w ) 
+                        bank_accesses += w->second;
+                    if( broadcast_detected && broadcast_bank == b->first ) {
+                        for( w=access_set.begin(); w != access_set.end(); ++w ) {
+                            if( w->first == broadcast_word ) {
+                                unsigned n = w->second;
+                                assert(n > 1); // or this wasn't a broadcast
+                                assert(bank_accesses >= (n-1));
+                                bank_accesses -= (n-1);
+                                break;
+                            }
+                        }
+                    }
+                    if( bank_accesses > max_bank_accesses ) 
+                        max_bank_accesses = bank_accesses;
+                }
+
+                // step 4: accumulate
+                total_accesses+= max_bank_accesses;
+            } else {
+                // step 2: look for the bank with the maximum number of access to different words 
+                unsigned max_bank_accesses=0;
+                std::map<unsigned,std::map<new_addr_type,unsigned> >::iterator b;
+                for( b=bank_accs.begin(); b != bank_accs.end(); b++ ) {
+                    max_bank_accesses = std::max(max_bank_accesses, (unsigned)b->second.size());
+                }
+
+                // step 3: accumulate
+                total_accesses+= max_bank_accesses;
             }
-            if (bank_accesses > max_bank_accesses)
-              max_bank_accesses = bank_accesses;
-          }
-
-          // step 4: accumulate
-          total_accesses += max_bank_accesses;
-        } else {
-          // step 2: look for the bank with the maximum number of access to
-          // different words
-          unsigned max_bank_accesses = 0;
-          std::map<unsigned, std::map<new_addr_type, unsigned> >::iterator b;
-          for (b = bank_accs.begin(); b != bank_accs.end(); b++) {
-            max_bank_accesses =
-                std::max(max_bank_accesses, (unsigned)b->second.size());
-          }
-
-          // step 3: accumulate
-          total_accesses += max_bank_accesses;
         }
-      }
-      assert(total_accesses > 0 && total_accesses <= m_config->warp_size);
-      cycles = total_accesses;  // shared memory conflicts modeled as larger
-                                // initiation interval
-      m_config->gpgpu_ctx->stats->ptx_file_line_stats_add_smem_bank_conflict(
-          pc, total_accesses);
-      break;
+        assert( total_accesses > 0 && total_accesses <= m_config->warp_size );
+        cycles = total_accesses; // shared memory conflicts modeled as larger initiation interval 
+        m_config->gpgpu_ctx->stats->ptx_file_line_stats_add_smem_bank_conflict( pc, total_accesses );
+        break;
     }
 
-    case tex_space:
-      cache_block_size = m_config->gpgpu_cache_texl1_linesize;
-      break;
-    case const_space:
-    case param_space_kernel:
-      cache_block_size = m_config->gpgpu_cache_constl1_linesize;
-      break;
+    case tex_space: 
+        cache_block_size = m_config->gpgpu_cache_texl1_linesize;
+        break;
+    case const_space:  case param_space_kernel:
+        cache_block_size = m_config->gpgpu_cache_constl1_linesize; 
+        break;
 
-    case global_space:
-    case local_space:
-    case param_space_local:
-      if (m_config->gpgpu_coalesce_arch >= 13) {
-        if (isatomic())
-          memory_coalescing_arch_atomic(is_write, access_type);
-        else
-          memory_coalescing_arch(is_write, access_type);
-      } else
-        abort();
+    case global_space: case local_space: case param_space_local:
+    	 if( m_config->gpgpu_coalesce_arch >= 13) {
+            if(isatomic())
+                memory_coalescing_arch_atomic(is_write, access_type);
+            else
+                memory_coalescing_arch(is_write, access_type);
+         } else abort();
 
-      break;
+        break;
 
     default:
-      abort();
-  }
-
-  if (cache_block_size) {
-    assert(m_accessq.empty());
-    mem_access_byte_mask_t byte_mask;
-    std::map<new_addr_type, active_mask_t>
-        accesses;  // block address -> set of thread offsets in warp
-    std::map<new_addr_type, active_mask_t>::iterator a;
-    for (unsigned thread = 0; thread < m_config->warp_size; thread++) {
-      if (!active(thread)) continue;
-      new_addr_type addr = m_per_scalar_thread[thread].memreqaddr[0];
-      unsigned block_address = line_size_based_tag_func(addr, cache_block_size);
-      accesses[block_address].set(thread);
-      unsigned idx = addr - block_address;
-      for (unsigned i = 0; i < data_size; i++) byte_mask.set(idx + i);
+        abort();
     }
-    for (a = accesses.begin(); a != accesses.end(); ++a)
-      m_accessq.push_back(mem_access_t(
-          access_type, a->first, cache_block_size, is_write, a->second,
-          byte_mask, mem_access_sector_mask_t(), m_config->gpgpu_ctx));
-  }
 
-  if (space.get_type() == global_space) {
-    m_config->gpgpu_ctx->stats->ptx_file_line_stats_add_uncoalesced_gmem(
-        pc, m_accessq.size() - starting_queue_size);
-  }
-  m_mem_accesses_created = true;
-}
-
-void warp_inst_t::memory_coalescing_arch(bool is_write,
-                                         mem_access_type access_type) {
-  // see the CUDA manual where it discusses coalescing rules before reading this
-  unsigned segment_size = 0;
-  unsigned warp_parts = m_config->mem_warp_parts;
-  bool sector_segment_size = false;
-
-  if (m_config->gpgpu_coalesce_arch >= 20 &&
-      m_config->gpgpu_coalesce_arch < 39) {
-    // Fermi and Kepler, L1 is normal and L2 is sector
-    if (m_config->gmem_skip_L1D || cache_op == CACHE_GLOBAL)
-      sector_segment_size = true;
-    else
-      sector_segment_size = false;
-  } else if (m_config->gpgpu_coalesce_arch >= 40) {
-    // Maxwell, Pascal and Volta, L1 and L2 are sectors
-    // all requests should be 32 bytes
-    sector_segment_size = true;
-  }
-
-  switch (data_size) {
-    case 1:
-      segment_size = 32;
-      break;
-    case 2:
-      segment_size = sector_segment_size ? 32 : 64;
-      break;
-    case 4:
-    case 8:
-    case 16:
-      segment_size = sector_segment_size ? 32 : 128;
-      break;
-  }
-  unsigned subwarp_size = m_config->warp_size / warp_parts;
-
-  for (unsigned subwarp = 0; subwarp < warp_parts; subwarp++) {
-    std::map<new_addr_type, transaction_info> subwarp_transactions;
-
-    // step 1: find all transactions generated by this subwarp
-    for (unsigned thread = subwarp * subwarp_size;
-         thread < subwarp_size * (subwarp + 1); thread++) {
-      if (!active(thread)) continue;
-
-      unsigned data_size_coales = data_size;
-      unsigned num_accesses = 1;
-
-      if (space.get_type() == local_space ||
-          space.get_type() == param_space_local) {
-        // Local memory accesses >4B were split into 4B chunks
-        if (data_size >= 4) {
-          data_size_coales = 4;
-          num_accesses = data_size / 4;
+    if( cache_block_size ) {
+        assert( m_accessq.empty() );
+        mem_access_byte_mask_t byte_mask; 
+        std::map<new_addr_type,active_mask_t> accesses; // block address -> set of thread offsets in warp
+        std::map<new_addr_type,active_mask_t>::iterator a;
+        for( unsigned thread=0; thread < m_config->warp_size; thread++ ) {
+            if( !active(thread) ) 
+                continue;
+            new_addr_type addr = m_per_scalar_thread[thread].memreqaddr[0];
+            unsigned block_address = line_size_based_tag_func(addr,cache_block_size);
+            accesses[block_address].set(thread);
+            unsigned idx = addr-block_address; 
+            for( unsigned i=0; i < data_size; i++ ) 
+                byte_mask.set(idx+i);
         }
-        // Otherwise keep the same data_size for sub-4B access to local memory
-      }
-
-      assert(num_accesses <= MAX_ACCESSES_PER_INSN_PER_THREAD);
-
-      //            for(unsigned access=0; access<num_accesses; access++) {
-      for (unsigned access = 0;
-           (access < MAX_ACCESSES_PER_INSN_PER_THREAD) &&
-           (m_per_scalar_thread[thread].memreqaddr[access] != 0);
-           access++) {
-        new_addr_type addr = m_per_scalar_thread[thread].memreqaddr[access];
-        unsigned block_address = line_size_based_tag_func(addr, segment_size);
-        unsigned chunk = (addr & 127) / 32;  // which 32-byte chunk within in a
-                                             // 128-byte chunk does this thread
-                                             // access?
-        transaction_info &info = subwarp_transactions[block_address];
-
-        // can only write to one segment
-        assert(block_address == line_size_based_tag_func(
-                                    addr + data_size_coales - 1, segment_size));
-
-        info.chunks.set(chunk);
-        info.active.set(thread);
-        unsigned idx = (addr & 127);
-        for (unsigned i = 0; i < data_size_coales; i++) info.bytes.set(idx + i);
-      }
+        for( a=accesses.begin(); a != accesses.end(); ++a ) 
+            m_accessq.push_back( mem_access_t(access_type,a->first,cache_block_size,is_write,a->second, byte_mask, mem_access_sector_mask_t(), m_config->gpgpu_ctx));
     }
 
-    // step 2: reduce each transaction size, if possible
-    std::map<new_addr_type, transaction_info>::iterator t;
-    for (t = subwarp_transactions.begin(); t != subwarp_transactions.end();
-         t++) {
-      new_addr_type addr = t->first;
-      const transaction_info &info = t->second;
-
-      memory_coalescing_arch_reduce_and_send(is_write, access_type, info, addr,
-                                             segment_size);
+    if ( space.get_type() == global_space ) {
+        m_config->gpgpu_ctx->stats->ptx_file_line_stats_add_uncoalesced_gmem( pc, m_accessq.size() - starting_queue_size );
     }
-  }
+    m_mem_accesses_created=true;
 }
 
-void warp_inst_t::memory_coalescing_arch_atomic(bool is_write,
-                                                mem_access_type access_type) {
-  assert(space.get_type() ==
-         global_space);  // Atomics allowed only for global memory
+void warp_inst_t::memory_coalescing_arch( bool is_write, mem_access_type access_type )
+{
+    // see the CUDA manual where it discusses coalescing rules before reading this
+    unsigned segment_size = 0;
+    unsigned warp_parts = m_config->mem_warp_parts;
+    bool sector_segment_size = false;
 
-  // see the CUDA manual where it discusses coalescing rules before reading this
-  unsigned segment_size = 0;
-  unsigned warp_parts = m_config->mem_warp_parts;
-  bool sector_segment_size = false;
+    if(m_config->gpgpu_coalesce_arch >= 20 && m_config->gpgpu_coalesce_arch < 39)
+    {
+    	//Fermi and Kepler, L1 is normal and L2 is sector
+    	if(m_config->gmem_skip_L1D || cache_op == CACHE_GLOBAL)
+    		sector_segment_size = true;
+    	else
+    		sector_segment_size = false;
+    }
+    else if(m_config->gpgpu_coalesce_arch >= 40)
+    {
+    	//Maxwell, Pascal and Volta, L1 and L2 are sectors
+    	//all requests should be 32 bytes
+    	sector_segment_size = true;
+    }
 
-  if (m_config->gpgpu_coalesce_arch >= 20 &&
-      m_config->gpgpu_coalesce_arch < 39) {
-    // Fermi and Kepler, L1 is normal and L2 is sector
-    if (m_config->gmem_skip_L1D || cache_op == CACHE_GLOBAL)
-      sector_segment_size = true;
-    else
-      sector_segment_size = false;
-  } else if (m_config->gpgpu_coalesce_arch >= 40) {
-    // Maxwell, Pascal and Volta, L1 and L2 are sectors
-    // all requests should be 32 bytes
-    sector_segment_size = true;
-  }
+    switch( data_size ) {
+    case 1: segment_size = 32; break;
+    case 2: segment_size = sector_segment_size? 32 : 64; break;
+    case 4: case 8: case 16: segment_size = sector_segment_size? 32 : 128; break;
+    }
+    unsigned subwarp_size = m_config->warp_size / warp_parts;
 
-  switch (data_size) {
-    case 1:
-      segment_size = 32;
-      break;
-    case 2:
-      segment_size = sector_segment_size ? 32 : 64;
-      break;
-    case 4:
-    case 8:
-    case 16:
-      segment_size = sector_segment_size ? 32 : 128;
-      break;
-  }
-  unsigned subwarp_size = m_config->warp_size / warp_parts;
+    for( unsigned subwarp=0; subwarp <  warp_parts; subwarp++ ) {
+        std::map<new_addr_type,transaction_info> subwarp_transactions;
 
-  for (unsigned subwarp = 0; subwarp < warp_parts; subwarp++) {
-    std::map<new_addr_type, std::list<transaction_info> >
-        subwarp_transactions;  // each block addr maps to a list of transactions
+        // step 1: find all transactions generated by this subwarp
+        for( unsigned thread=subwarp*subwarp_size; thread<subwarp_size*(subwarp+1); thread++ ) {
+            if( !active(thread) )
+                continue;
 
-    // step 1: find all transactions generated by this subwarp
-    for (unsigned thread = subwarp * subwarp_size;
-         thread < subwarp_size * (subwarp + 1); thread++) {
-      if (!active(thread)) continue;
+            unsigned data_size_coales = data_size;
+            unsigned num_accesses = 1;
 
-      new_addr_type addr = m_per_scalar_thread[thread].memreqaddr[0];
-      unsigned block_address = line_size_based_tag_func(addr, segment_size);
-      unsigned chunk = (addr & 127) / 32;  // which 32-byte chunk within in a
-                                           // 128-byte chunk does this thread
-                                           // access?
+            if( space.get_type() == local_space || space.get_type() == param_space_local ) {
+               // Local memory accesses >4B were split into 4B chunks
+               if(data_size >= 4) {
+                  data_size_coales = 4;
+                  num_accesses = data_size/4;
+               }
+               // Otherwise keep the same data_size for sub-4B access to local memory
+            }
 
-      // can only write to one segment
-      assert(block_address ==
-             line_size_based_tag_func(addr + data_size - 1, segment_size));
 
-      // Find a transaction that does not conflict with this thread's accesses
-      bool new_transaction = true;
-      std::list<transaction_info>::iterator it;
-      transaction_info *info;
-      for (it = subwarp_transactions[block_address].begin();
-           it != subwarp_transactions[block_address].end(); it++) {
-        unsigned idx = (addr & 127);
-        if (not it->test_bytes(idx, idx + data_size - 1)) {
-          new_transaction = false;
-          info = &(*it);
-          break;
+            assert(num_accesses <= MAX_ACCESSES_PER_INSN_PER_THREAD);
+
+//            for(unsigned access=0; access<num_accesses; access++) {
+            for(unsigned access=0; (access<MAX_ACCESSES_PER_INSN_PER_THREAD)&&(m_per_scalar_thread[thread].memreqaddr[access]!=0); access++) {
+                new_addr_type addr = m_per_scalar_thread[thread].memreqaddr[access];
+                unsigned block_address = line_size_based_tag_func(addr,segment_size);
+                unsigned chunk = (addr&127)/32; // which 32-byte chunk within in a 128-byte chunk does this thread access?
+                transaction_info &info = subwarp_transactions[block_address];
+
+                // can only write to one segment
+                assert(block_address == line_size_based_tag_func(addr+data_size_coales-1,segment_size));
+
+                info.chunks.set(chunk);
+                info.active.set(thread);
+                unsigned idx = (addr&127);
+                for( unsigned i=0; i < data_size_coales; i++ )
+                    info.bytes.set(idx+i);
+            }
         }
-      }
-      if (new_transaction) {
-        // Need a new transaction
-        subwarp_transactions[block_address].push_back(transaction_info());
-        info = &subwarp_transactions[block_address].back();
-      }
-      assert(info);
 
-      info->chunks.set(chunk);
-      info->active.set(thread);
-      unsigned idx = (addr & 127);
-      for (unsigned i = 0; i < data_size; i++) {
-        assert(!info->bytes.test(idx + i));
-        info->bytes.set(idx + i);
-      }
+        // step 2: reduce each transaction size, if possible
+        std::map< new_addr_type, transaction_info >::iterator t;
+        for( t=subwarp_transactions.begin(); t !=subwarp_transactions.end(); t++ ) {
+            new_addr_type addr = t->first;
+            const transaction_info &info = t->second;
+
+            memory_coalescing_arch_reduce_and_send(is_write, access_type, info, addr, segment_size);
+
+        }
     }
-
-    // step 2: reduce each transaction size, if possible
-    std::map<new_addr_type, std::list<transaction_info> >::iterator t_list;
-    for (t_list = subwarp_transactions.begin();
-         t_list != subwarp_transactions.end(); t_list++) {
-      // For each block addr
-      new_addr_type addr = t_list->first;
-      const std::list<transaction_info> &transaction_list = t_list->second;
-
-      std::list<transaction_info>::const_iterator t;
-      for (t = transaction_list.begin(); t != transaction_list.end(); t++) {
-        // For each transaction
-        const transaction_info &info = *t;
-        memory_coalescing_arch_reduce_and_send(is_write, access_type, info,
-                                               addr, segment_size);
-      }
-    }
-  }
 }
 
-void warp_inst_t::memory_coalescing_arch_reduce_and_send(
-    bool is_write, mem_access_type access_type, const transaction_info &info,
-    new_addr_type addr, unsigned segment_size) {
-  assert((addr & (segment_size - 1)) == 0);
+void warp_inst_t::memory_coalescing_arch_atomic( bool is_write, mem_access_type access_type )
+{
 
-  const std::bitset<4> &q = info.chunks;
-  assert(q.count() >= 1);
-  std::bitset<2> h;  // halves (used to check if 64 byte segment can be
-                     // compressed into a single 32 byte segment)
+   assert(space.get_type() == global_space); // Atomics allowed only for global memory
 
-  unsigned size = segment_size;
-  if (segment_size == 128) {
-    bool lower_half_used = q[0] || q[1];
-    bool upper_half_used = q[2] || q[3];
-    if (lower_half_used && !upper_half_used) {
-      // only lower 64 bytes used
-      size = 64;
-      if (q[0]) h.set(0);
-      if (q[1]) h.set(1);
-    } else if ((!lower_half_used) && upper_half_used) {
-      // only upper 64 bytes used
-      addr = addr + 64;
-      size = 64;
-      if (q[2]) h.set(0);
-      if (q[3]) h.set(1);
-    } else {
-      assert(lower_half_used && upper_half_used);
-    }
-  } else if (segment_size == 64) {
-    // need to set halves
-    if ((addr % 128) == 0) {
-      if (q[0]) h.set(0);
-      if (q[1]) h.set(1);
-    } else {
-      assert((addr % 128) == 64);
-      if (q[2]) h.set(0);
-      if (q[3]) h.set(1);
-    }
-  }
-  if (size == 64) {
-    bool lower_half_used = h[0];
-    bool upper_half_used = h[1];
-    if (lower_half_used && !upper_half_used) {
-      size = 32;
-    } else if ((!lower_half_used) && upper_half_used) {
-      addr = addr + 32;
-      size = 32;
-    } else {
-      assert(lower_half_used && upper_half_used);
-    }
-  }
-  m_accessq.push_back(mem_access_t(access_type, addr, size, is_write,
-                                   info.active, info.bytes, info.chunks,
-                                   m_config->gpgpu_ctx));
+   // see the CUDA manual where it discusses coalescing rules before reading this
+   unsigned segment_size = 0;
+   unsigned warp_parts = m_config->mem_warp_parts;
+   bool sector_segment_size = false;
+
+   if(m_config->gpgpu_coalesce_arch >= 20 && m_config->gpgpu_coalesce_arch < 39)
+   {
+	//Fermi and Kepler, L1 is normal and L2 is sector
+	if(m_config->gmem_skip_L1D || cache_op == CACHE_GLOBAL)
+		sector_segment_size = true;
+	else
+		sector_segment_size = false;
+   }
+   else if(m_config->gpgpu_coalesce_arch >= 40)
+   {
+	//Maxwell, Pascal and Volta, L1 and L2 are sectors
+	//all requests should be 32 bytes
+	sector_segment_size = true;
+   }
+
+   switch( data_size ) {
+   case 1: segment_size = 32; break;
+   case 2: segment_size = sector_segment_size? 32 : 64; break;
+   case 4: case 8: case 16: segment_size = sector_segment_size? 32 : 128; break;
+   }
+   unsigned subwarp_size = m_config->warp_size / warp_parts;
+
+   for( unsigned subwarp=0; subwarp <  warp_parts; subwarp++ ) {
+       std::map<new_addr_type,std::list<transaction_info> > subwarp_transactions; // each block addr maps to a list of transactions
+
+       // step 1: find all transactions generated by this subwarp
+       for( unsigned thread=subwarp*subwarp_size; thread<subwarp_size*(subwarp+1); thread++ ) {
+           if( !active(thread) )
+               continue;
+
+           new_addr_type addr = m_per_scalar_thread[thread].memreqaddr[0];
+           unsigned block_address = line_size_based_tag_func(addr,segment_size);
+           unsigned chunk = (addr&127)/32; // which 32-byte chunk within in a 128-byte chunk does this thread access?
+
+           // can only write to one segment
+           assert(block_address == line_size_based_tag_func(addr+data_size-1,segment_size));
+
+           // Find a transaction that does not conflict with this thread's accesses
+           bool new_transaction = true;
+           std::list<transaction_info>::iterator it;
+           transaction_info* info;
+           for(it=subwarp_transactions[block_address].begin(); it!=subwarp_transactions[block_address].end(); it++) {
+              unsigned idx = (addr&127);
+              if(not it->test_bytes(idx,idx+data_size-1)) {
+                 new_transaction = false;
+                 info = &(*it);
+                 break;
+              }
+           }
+           if(new_transaction) {
+              // Need a new transaction
+              subwarp_transactions[block_address].push_back(transaction_info());
+              info = &subwarp_transactions[block_address].back();
+           }
+           assert(info);
+
+           info->chunks.set(chunk);
+           info->active.set(thread);
+           unsigned idx = (addr&127);
+           for( unsigned i=0; i < data_size; i++ ) {
+               assert(!info->bytes.test(idx+i));
+               info->bytes.set(idx+i);
+           }
+       }
+
+       // step 2: reduce each transaction size, if possible
+       std::map< new_addr_type, std::list<transaction_info> >::iterator t_list;
+       for( t_list=subwarp_transactions.begin(); t_list !=subwarp_transactions.end(); t_list++ ) {
+           // For each block addr
+           new_addr_type addr = t_list->first;
+           const std::list<transaction_info>& transaction_list = t_list->second;
+
+           std::list<transaction_info>::const_iterator t;
+           for(t=transaction_list.begin(); t!=transaction_list.end(); t++) {
+               // For each transaction
+               const transaction_info &info = *t;
+               memory_coalescing_arch_reduce_and_send(is_write, access_type, info, addr, segment_size);
+           }
+       }
+   }
 }
 
-void warp_inst_t::completed(unsigned long long cycle) const {
-  unsigned long long latency = cycle - issue_cycle;
-  assert(latency <= cycle);  // underflow detection
-  m_config->gpgpu_ctx->stats->ptx_file_line_stats_add_latency(
-      pc, latency * active_count());
+void warp_inst_t::memory_coalescing_arch_reduce_and_send( bool is_write, mem_access_type access_type, const transaction_info &info, new_addr_type addr, unsigned segment_size )
+{
+   assert( (addr & (segment_size-1)) == 0 );
+
+   const std::bitset<4> &q = info.chunks;
+   assert( q.count() >= 1 );
+   std::bitset<2> h; // halves (used to check if 64 byte segment can be compressed into a single 32 byte segment)
+
+   unsigned size=segment_size;
+   if( segment_size == 128 ) {
+       bool lower_half_used = q[0] || q[1];
+       bool upper_half_used = q[2] || q[3];
+       if( lower_half_used && !upper_half_used ) {
+           // only lower 64 bytes used
+           size = 64;
+           if(q[0]) h.set(0);
+           if(q[1]) h.set(1);
+       } else if ( (!lower_half_used) && upper_half_used ) {
+           // only upper 64 bytes used
+           addr = addr+64;
+           size = 64;
+           if(q[2]) h.set(0);
+           if(q[3]) h.set(1);
+       } else {
+           assert(lower_half_used && upper_half_used);
+       }
+   } else if( segment_size == 64 ) {
+       // need to set halves
+       if( (addr % 128) == 0 ) {
+           if(q[0]) h.set(0);
+           if(q[1]) h.set(1);
+       } else {
+           assert( (addr % 128) == 64 );
+           if(q[2]) h.set(0);
+           if(q[3]) h.set(1);
+       }
+   }
+   if( size == 64 ) {
+       bool lower_half_used = h[0];
+       bool upper_half_used = h[1];
+       if( lower_half_used && !upper_half_used ) {
+           size = 32;
+       } else if ( (!lower_half_used) && upper_half_used ) {
+           addr = addr+32;
+           size = 32;
+       } else {
+           assert(lower_half_used && upper_half_used);
+       }
+   }
+   m_accessq.push_back( mem_access_t(access_type,addr,size,is_write,info.active,info.bytes, info.chunks,m_config->gpgpu_ctx) );
 }
 
-kernel_info_t::kernel_info_t(dim3 gridDim, dim3 blockDim,
-                             class function_info *entry) {
-  m_kernel_entry = entry;
-  m_grid_dim = gridDim;
-  m_block_dim = blockDim;
-  m_next_cta.x = 0;
-  m_next_cta.y = 0;
-  m_next_cta.z = 0;
-  m_next_tid = m_next_cta;
-  m_num_cores_running = 0;
-  m_uid = (entry->gpgpu_ctx->kernel_info_m_next_uid)++;
-  m_param_mem = new memory_space_impl<8192>("param", 64 * 1024);
-
-  // Jin: parent and child kernel management for CDP
-  m_parent_kernel = NULL;
-
-  // Jin: launch latency management
-  m_launch_latency = entry->gpgpu_ctx->device_runtime->g_kernel_launch_latency;
-
-  volta_cache_config_set = false;
+void warp_inst_t::completed( unsigned long long cycle ) const 
+{
+   unsigned long long latency = cycle - issue_cycle; 
+   assert(latency <= cycle); // underflow detection 
+   m_config->gpgpu_ctx->stats->ptx_file_line_stats_add_latency(pc, latency * active_count());  
 }
 
-/*A snapshot of the texture mappings needs to be stored in the kernel's info as
+
+kernel_info_t::kernel_info_t( dim3 gridDim, dim3 blockDim, class function_info *entry)
+{
+    m_kernel_entry=entry;
+    m_grid_dim=gridDim;
+    m_block_dim=blockDim;
+    m_next_cta.x=0;
+    m_next_cta.y=0;
+    m_next_cta.z=0;
+    m_next_tid=m_next_cta;
+    m_num_cores_running=0;
+    m_uid = (entry->gpgpu_ctx->kernel_info_m_next_uid)++;
+    m_param_mem = new memory_space_impl<8192>("param",64*1024);
+
+    //Jin: parent and child kernel management for CDP
+    m_parent_kernel = NULL;
+
+    //Jin: launch latency management
+    m_launch_latency = entry->gpgpu_ctx->device_runtime->g_kernel_launch_latency;
+
+    volta_cache_config_set=false;
+}
+
+/*A snapshot of the texture mappings needs to be stored in the kernel's info as 
 kernels should use the texture bindings seen at the time of launch and textures
  can be bound/unbound asynchronously with respect to streams. */
-kernel_info_t::kernel_info_t(
-    dim3 gridDim, dim3 blockDim, class function_info *entry,
-    std::map<std::string, const struct cudaArray *> nameToCudaArray,
-    std::map<std::string, const struct textureInfo *> nameToTextureInfo) {
-  m_kernel_entry = entry;
-  m_grid_dim = gridDim;
-  m_block_dim = blockDim;
-  m_next_cta.x = 0;
-  m_next_cta.y = 0;
-  m_next_cta.z = 0;
-  m_next_tid = m_next_cta;
-  m_num_cores_running = 0;
-  m_uid = (entry->gpgpu_ctx->kernel_info_m_next_uid)++;
-  m_param_mem = new memory_space_impl<8192>("param", 64 * 1024);
+kernel_info_t::kernel_info_t( dim3 gridDim, dim3 blockDim, class function_info *entry, std::map<std::string, const struct cudaArray*> nameToCudaArray, std::map<std::string, const struct textureInfo*> nameToTextureInfo)   
+{
+    m_kernel_entry=entry;
+    m_grid_dim=gridDim;
+    m_block_dim=blockDim;
+    m_next_cta.x=0;
+    m_next_cta.y=0;
+    m_next_cta.z=0;
+    m_next_tid=m_next_cta;
+    m_num_cores_running=0;
+    m_uid = (entry->gpgpu_ctx->kernel_info_m_next_uid)++;
+    m_param_mem = new memory_space_impl<8192>("param",64*1024);
 
-  // Jin: parent and child kernel management for CDP
-  m_parent_kernel = NULL;
+    //Jin: parent and child kernel management for CDP
+    m_parent_kernel = NULL;
+   
+    //Jin: launch latency management
+    m_launch_latency = entry->gpgpu_ctx->device_runtime->g_kernel_launch_latency;
 
-  // Jin: launch latency management
-  m_launch_latency = entry->gpgpu_ctx->device_runtime->g_kernel_launch_latency;
-
-  volta_cache_config_set = false;
-  m_NameToCudaArray = nameToCudaArray;
-  m_NameToTextureInfo = nameToTextureInfo;
+    volta_cache_config_set=false;
+    m_NameToCudaArray = nameToCudaArray;
+    m_NameToTextureInfo = nameToTextureInfo;
 }
 
-kernel_info_t::~kernel_info_t() {
-  assert(m_active_threads.empty());
-  destroy_cta_streams();
-  delete m_param_mem;
+kernel_info_t::~kernel_info_t()
+{
+    assert( m_active_threads.empty() );
+    destroy_cta_streams();
+    delete m_param_mem;
 }
 
-std::string kernel_info_t::name() const { return m_kernel_entry->get_name(); }
-
-// Jin: parent and child kernel management for CDP
-void kernel_info_t::set_parent(kernel_info_t *parent, dim3 parent_ctaid,
-                               dim3 parent_tid) {
-  m_parent_kernel = parent;
-  m_parent_ctaid = parent_ctaid;
-  m_parent_tid = parent_tid;
-  parent->set_child(this);
+std::string kernel_info_t::name() const
+{
+    return m_kernel_entry->get_name();
 }
 
-void kernel_info_t::set_child(kernel_info_t *child) {
-  m_child_kernels.push_back(child);
+//Jin: parent and child kernel management for CDP
+void kernel_info_t::set_parent(kernel_info_t * parent, 
+    dim3 parent_ctaid, dim3 parent_tid) {
+    m_parent_kernel = parent;
+    m_parent_ctaid = parent_ctaid;
+    m_parent_tid = parent_tid;
+    parent->set_child(this);
 }
 
-void kernel_info_t::remove_child(kernel_info_t *child) {
-  assert(std::find(m_child_kernels.begin(), m_child_kernels.end(), child) !=
-         m_child_kernels.end());
-  m_child_kernels.remove(child);
+void kernel_info_t::set_child(kernel_info_t * child) {
+    m_child_kernels.push_back(child);
+}
+
+void kernel_info_t::remove_child(kernel_info_t * child) {
+    assert(std::find(m_child_kernels.begin(), m_child_kernels.end(), child)
+        != m_child_kernels.end());
+    m_child_kernels.remove(child);
 }
 
 bool kernel_info_t::is_finished() {
-  if (done() && children_all_finished())
-    return true;
+  if(done() && children_all_finished())
+     return true;
   else
-    return false;
+     return false;
 }
 
 bool kernel_info_t::children_all_finished() {
-  if (!m_child_kernels.empty()) return false;
-
-  return true;
+   if(!m_child_kernels.empty())
+         return false;
+   
+   return true;
 }
 
 void kernel_info_t::notify_parent_finished() {
-  if (m_parent_kernel) {
-    m_kernel_entry->gpgpu_ctx->device_runtime->g_total_param_size -=
-        ((m_kernel_entry->get_args_aligned_size() + 255) / 256 * 256);
-    m_parent_kernel->remove_child(this);
-    m_kernel_entry->gpgpu_ctx->the_gpgpusim->g_stream_manager
-        ->register_finished_kernel(m_parent_kernel->get_uid());
-  }
+   if(m_parent_kernel) {
+       m_kernel_entry->gpgpu_ctx->device_runtime->g_total_param_size -= ((m_kernel_entry->get_args_aligned_size() + 255)/256*256);
+       m_parent_kernel->remove_child(this);
+       m_kernel_entry->gpgpu_ctx->the_gpgpusim->g_stream_manager->register_finished_kernel(m_parent_kernel->get_uid());
+   }
 }
 
-CUstream_st *kernel_info_t::create_stream_cta(dim3 ctaid) {
-  assert(get_default_stream_cta(ctaid));
-  CUstream_st *stream = new CUstream_st();
-  m_kernel_entry->gpgpu_ctx->the_gpgpusim->g_stream_manager->add_stream(stream);
-  assert(m_cta_streams.find(ctaid) != m_cta_streams.end());
-  assert(m_cta_streams[ctaid].size() >= 1);  // must have default stream
-  m_cta_streams[ctaid].push_back(stream);
-
-  return stream;
-}
-
-CUstream_st *kernel_info_t::get_default_stream_cta(dim3 ctaid) {
-  if (m_cta_streams.find(ctaid) != m_cta_streams.end()) {
-    assert(m_cta_streams[ctaid].size() >=
-           1);  // already created, must have default stream
-    return *(m_cta_streams[ctaid].begin());
-  } else {
-    m_cta_streams[ctaid] = std::list<CUstream_st *>();
-    CUstream_st *stream = new CUstream_st();
-    m_kernel_entry->gpgpu_ctx->the_gpgpusim->g_stream_manager->add_stream(
-        stream);
+CUstream_st * kernel_info_t::create_stream_cta(dim3 ctaid) {
+    assert(get_default_stream_cta(ctaid));
+    CUstream_st * stream = new CUstream_st();
+    m_kernel_entry->gpgpu_ctx->the_gpgpusim->g_stream_manager->add_stream(stream);
+    assert(m_cta_streams.find(ctaid) != m_cta_streams.end());
+    assert(m_cta_streams[ctaid].size() >= 1); //must have default stream
     m_cta_streams[ctaid].push_back(stream);
+
     return stream;
-  }
 }
 
-bool kernel_info_t::cta_has_stream(dim3 ctaid, CUstream_st *stream) {
-  if (m_cta_streams.find(ctaid) == m_cta_streams.end()) return false;
+CUstream_st * kernel_info_t::get_default_stream_cta(dim3 ctaid) {
+    if(m_cta_streams.find(ctaid) != m_cta_streams.end()) {
+       assert(m_cta_streams[ctaid].size() >= 1); //already created, must have default stream
+       return *(m_cta_streams[ctaid].begin());
+    }
+    else {
+      m_cta_streams[ctaid] = std::list<CUstream_st *>();
+      CUstream_st * stream = new CUstream_st();
+      m_kernel_entry->gpgpu_ctx->the_gpgpusim->g_stream_manager->add_stream(stream);
+      m_cta_streams[ctaid].push_back(stream);
+      return stream;
+    }
+}
 
-  std::list<CUstream_st *> &stream_list = m_cta_streams[ctaid];
-  if (std::find(stream_list.begin(), stream_list.end(), stream) ==
-      stream_list.end())
-    return false;
-  else
-    return true;
+bool kernel_info_t::cta_has_stream(dim3 ctaid, CUstream_st* stream) {
+    if(m_cta_streams.find(ctaid) == m_cta_streams.end())
+       return false;
+
+    std::list<CUstream_st *> &stream_list = m_cta_streams[ctaid];
+    if(std::find(stream_list.begin(), stream_list.end(), stream) 
+         == stream_list.end())
+       return false;
+    else
+       return true;
 }
 
 void kernel_info_t::print_parent_info() {
-  if (m_parent_kernel) {
-    printf("Parent %d: \'%s\', Block (%d, %d, %d), Thread (%d, %d, %d)\n",
-           m_parent_kernel->get_uid(), m_parent_kernel->name().c_str(),
-           m_parent_ctaid.x, m_parent_ctaid.y, m_parent_ctaid.z, m_parent_tid.x,
-           m_parent_tid.y, m_parent_tid.z);
-  }
+    if(m_parent_kernel) {
+        printf("Parent %d: \'%s\', Block (%d, %d, %d), Thread (%d, %d, %d)\n", 
+            m_parent_kernel->get_uid(), m_parent_kernel->name().c_str(), 
+            m_parent_ctaid.x, m_parent_ctaid.y, m_parent_ctaid.z,
+            m_parent_tid.x, m_parent_tid.y, m_parent_tid.z);
+    }
 }
 
 void kernel_info_t::destroy_cta_streams() {
-  printf("Destroy streams for kernel %d: ", get_uid());
-  size_t stream_size = 0;
-  for (auto s = m_cta_streams.begin(); s != m_cta_streams.end(); s++) {
-    stream_size += s->second.size();
-    for (auto ss = s->second.begin(); ss != s->second.end(); ss++)
-      m_kernel_entry->gpgpu_ctx->the_gpgpusim->g_stream_manager->destroy_stream(
-          *ss);
-    s->second.clear();
-  }
-  printf("size %lu\n", stream_size);
-  m_cta_streams.clear();
+     printf("Destroy streams for kernel %d: ", get_uid()); size_t stream_size = 0;
+     for(auto s = m_cta_streams.begin(); s != m_cta_streams.end(); s++) {
+        stream_size += s->second.size();
+        for(auto ss = s->second.begin(); ss != s->second.end(); ss++)
+        m_kernel_entry->gpgpu_ctx->the_gpgpusim->g_stream_manager->destroy_stream(*ss);
+        s->second.clear();
+     }
+     printf("size %lu\n", stream_size);
+     m_cta_streams.clear();
 }
 
-simt_stack::simt_stack(unsigned wid, unsigned warpSize, class gpgpu_sim *gpu) {
-  m_warp_id = wid;
-  m_warp_size = warpSize;
-  m_gpu = gpu;
-  reset();
+simt_stack::simt_stack( unsigned wid, unsigned warpSize,  class gpgpu_sim * gpu)
+{
+    m_warp_id=wid;
+    m_warp_size = warpSize;
+    m_gpu=gpu;
+    reset();
 }
 
-void simt_stack::reset() { m_stack.clear(); }
-
-void simt_stack::launch(address_type start_pc, const simt_mask_t &active_mask) {
-  reset();
-  simt_stack_entry new_stack_entry;
-  new_stack_entry.m_pc = start_pc;
-  new_stack_entry.m_calldepth = 1;
-  new_stack_entry.m_active_mask = active_mask;
-  new_stack_entry.m_type = STACK_ENTRY_TYPE_NORMAL;
-  m_stack.push_back(new_stack_entry);
+void simt_stack::reset()
+{
+    m_stack.clear();
 }
 
-void simt_stack::resume(char *fname) {
-  reset();
-
-  FILE *fp2 = fopen(fname, "r");
-  assert(fp2 != NULL);
-
-  char line[200]; /* or other suitable maximum line size */
-
-  while (fgets(line, sizeof line, fp2) != NULL) /* read a line */
-  {
+void simt_stack::launch( address_type start_pc, const simt_mask_t &active_mask )
+{
+    reset();
     simt_stack_entry new_stack_entry;
-    char *pch;
-    pch = strtok(line, " ");
-    for (unsigned j = 0; j < m_warp_size; j++) {
-      if (pch[0] == '1')
-        new_stack_entry.m_active_mask.set(j);
-      else
-        new_stack_entry.m_active_mask.reset(j);
-      pch = strtok(NULL, " ");
-    }
-
-    new_stack_entry.m_pc = atoi(pch);
-    pch = strtok(NULL, " ");
-    new_stack_entry.m_calldepth = atoi(pch);
-    pch = strtok(NULL, " ");
-    new_stack_entry.m_recvg_pc = atoi(pch);
-    pch = strtok(NULL, " ");
-    new_stack_entry.m_branch_div_cycle = atoi(pch);
-    pch = strtok(NULL, " ");
-    if (pch[0] == '0')
-      new_stack_entry.m_type = STACK_ENTRY_TYPE_NORMAL;
-    else
-      new_stack_entry.m_type = STACK_ENTRY_TYPE_CALL;
+    new_stack_entry.m_pc = start_pc;
+    new_stack_entry.m_calldepth = 1;
+    new_stack_entry.m_active_mask = active_mask;
+    new_stack_entry.m_type = STACK_ENTRY_TYPE_NORMAL;
     m_stack.push_back(new_stack_entry);
-  }
-  fclose(fp2);
 }
 
-const simt_mask_t &simt_stack::get_active_mask() const {
-  assert(m_stack.size() > 0);
-  return m_stack.back().m_active_mask;
+void simt_stack::resume( char * fname )
+{
+    reset();    
+
+
+
+      FILE * fp2 = fopen(fname, "r");
+      assert(fp2!=NULL);
+
+      char line [ 200 ]; /* or other suitable maximum line size */
+
+      while ( fgets ( line, sizeof line, fp2 ) != NULL ) /* read a line */
+      {
+          simt_stack_entry new_stack_entry;
+          char * pch;
+          pch = strtok (line," ");
+          for (unsigned j=0; j<m_warp_size; j++)
+          {
+                if (pch[0]=='1')
+                    new_stack_entry.m_active_mask.set(j);
+                else
+                    new_stack_entry.m_active_mask.reset(j);
+                pch = strtok (NULL," ");
+                
+          }  
+          
+         new_stack_entry.m_pc=atoi(pch);
+         pch = strtok (NULL," "); 
+         new_stack_entry.m_calldepth=atoi(pch);
+         pch = strtok (NULL," "); 
+         new_stack_entry.m_recvg_pc=atoi(pch);
+         pch = strtok (NULL," "); 
+         new_stack_entry.m_branch_div_cycle=atoi(pch);
+         pch = strtok (NULL," "); 
+         if(pch[0]=='0')
+            new_stack_entry.m_type= STACK_ENTRY_TYPE_NORMAL;
+         else
+            new_stack_entry.m_type= STACK_ENTRY_TYPE_CALL;
+         m_stack.push_back(new_stack_entry);
+      }
+      fclose ( fp2 );
+
+    
 }
 
-void simt_stack::get_pdom_stack_top_info(unsigned *pc, unsigned *rpc) const {
-  assert(m_stack.size() > 0);
-  *pc = m_stack.back().m_pc;
-  *rpc = m_stack.back().m_recvg_pc;
+const simt_mask_t &simt_stack::get_active_mask() const
+{
+    assert(m_stack.size() > 0);
+    return m_stack.back().m_active_mask;
 }
 
-unsigned simt_stack::get_rp() const {
-  assert(m_stack.size() > 0);
-  return m_stack.back().m_recvg_pc;
+void simt_stack::get_pdom_stack_top_info( unsigned *pc, unsigned *rpc ) const
+{
+   assert(m_stack.size() > 0);
+   *pc = m_stack.back().m_pc;
+   *rpc = m_stack.back().m_recvg_pc;
 }
 
-void simt_stack::print(FILE *fout) const {
-  for (unsigned k = 0; k < m_stack.size(); k++) {
-    simt_stack_entry stack_entry = m_stack[k];
-    if (k == 0) {
-      fprintf(fout, "w%02d %1u ", m_warp_id, k);
-    } else {
-      fprintf(fout, "    %1u ", k);
-    }
-    for (unsigned j = 0; j < m_warp_size; j++)
-      fprintf(fout, "%c", (stack_entry.m_active_mask.test(j) ? '1' : '0'));
-    fprintf(fout, " pc: 0x%03x", stack_entry.m_pc);
-    if (stack_entry.m_recvg_pc == (unsigned)-1) {
-      fprintf(fout, " rp: ---- tp: %s cd: %2u ",
-              (stack_entry.m_type == STACK_ENTRY_TYPE_CALL ? "C" : "N"),
-              stack_entry.m_calldepth);
-    } else {
-      fprintf(fout, " rp: %4u tp: %s cd: %2u ", stack_entry.m_recvg_pc,
-              (stack_entry.m_type == STACK_ENTRY_TYPE_CALL ? "C" : "N"),
-              stack_entry.m_calldepth);
-    }
-    if (stack_entry.m_branch_div_cycle != 0) {
-      fprintf(fout, " bd@%6u ", (unsigned)stack_entry.m_branch_div_cycle);
-    } else {
-      fprintf(fout, " ");
-    }
-    m_gpu->gpgpu_ctx->func_sim->ptx_print_insn(stack_entry.m_pc, fout);
-    fprintf(fout, "\n");
-  }
+unsigned simt_stack::get_rp() const 
+{ 
+    assert(m_stack.size() > 0);
+    return m_stack.back().m_recvg_pc;
 }
 
-void simt_stack::print_checkpoint(FILE *fout) const {
-  for (unsigned k = 0; k < m_stack.size(); k++) {
-    simt_stack_entry stack_entry = m_stack[k];
-
-    for (unsigned j = 0; j < m_warp_size; j++)
-      fprintf(fout, "%c ", (stack_entry.m_active_mask.test(j) ? '1' : '0'));
-    fprintf(fout, "%d %d %d %lld %d ", stack_entry.m_pc,
-            stack_entry.m_calldepth, stack_entry.m_recvg_pc,
-            stack_entry.m_branch_div_cycle, stack_entry.m_type);
-    fprintf(fout, "%d %d\n", m_warp_id, m_warp_size);
-  }
-}
-
-void simt_stack::update(simt_mask_t &thread_done, addr_vector_t &next_pc,
-                        address_type recvg_pc, op_type next_inst_op,
-                        unsigned next_inst_size, address_type next_inst_pc) {
-  assert(m_stack.size() > 0);
-
-  assert(next_pc.size() == m_warp_size);
-
-  simt_mask_t top_active_mask = m_stack.back().m_active_mask;
-  address_type top_recvg_pc = m_stack.back().m_recvg_pc;
-  address_type top_pc =
-      m_stack.back().m_pc;  // the pc of the instruction just executed
-  stack_entry_type top_type = m_stack.back().m_type;
-  assert(top_pc == next_inst_pc);
-  assert(top_active_mask.any());
-
-  const address_type null_pc = -1;
-  bool warp_diverged = false;
-  address_type new_recvg_pc = null_pc;
-  unsigned num_divergent_paths = 0;
-
-  std::map<address_type, simt_mask_t> divergent_paths;
-  while (top_active_mask.any()) {
-    // extract a group of threads with the same next PC among the active threads
-    // in the warp
-    address_type tmp_next_pc = null_pc;
-    simt_mask_t tmp_active_mask;
-    for (int i = m_warp_size - 1; i >= 0; i--) {
-      if (top_active_mask.test(i)) {  // is this thread active?
-        if (thread_done.test(i)) {
-          top_active_mask.reset(i);  // remove completed thread from active mask
-        } else if (tmp_next_pc == null_pc) {
-          tmp_next_pc = next_pc[i];
-          tmp_active_mask.set(i);
-          top_active_mask.reset(i);
-        } else if (tmp_next_pc == next_pc[i]) {
-          tmp_active_mask.set(i);
-          top_active_mask.reset(i);
+void simt_stack::print (FILE *fout) const
+{
+    for ( unsigned k=0; k < m_stack.size(); k++ ) {
+        simt_stack_entry stack_entry = m_stack[k];
+        if ( k==0 ) {
+            fprintf(fout, "w%02d %1u ", m_warp_id, k );
+        } else {
+            fprintf(fout, "    %1u ", k );
         }
-      }
+        for (unsigned j=0; j<m_warp_size; j++)
+            fprintf(fout, "%c", (stack_entry.m_active_mask.test(j)?'1':'0') );
+        fprintf(fout, " pc: 0x%03x", stack_entry.m_pc );
+        if ( stack_entry.m_recvg_pc == (unsigned)-1 ) {
+            fprintf(fout," rp: ---- tp: %s cd: %2u ", (stack_entry.m_type==STACK_ENTRY_TYPE_CALL?"C":"N"), stack_entry.m_calldepth );
+        } else {
+            fprintf(fout," rp: %4u tp: %s cd: %2u ", stack_entry.m_recvg_pc, (stack_entry.m_type==STACK_ENTRY_TYPE_CALL?"C":"N"), stack_entry.m_calldepth );
+        }
+        if ( stack_entry.m_branch_div_cycle != 0 ) {
+            fprintf(fout," bd@%6u ", (unsigned) stack_entry.m_branch_div_cycle );
+        } else {
+            fprintf(fout," " );
+        }
+        m_gpu->gpgpu_ctx->func_sim->ptx_print_insn( stack_entry.m_pc, fout );
+        fprintf(fout,"\n");
     }
 
-    if (tmp_next_pc == null_pc) {
-      assert(!top_active_mask.any());  // all threads done
-      continue;
+}
+
+void simt_stack::print_checkpoint (FILE *fout) const
+{
+    for ( unsigned k=0; k < m_stack.size(); k++ ) {
+        simt_stack_entry stack_entry = m_stack[k];
+       
+        for (unsigned j=0; j<m_warp_size; j++)
+            fprintf(fout, "%c ", (stack_entry.m_active_mask.test(j)?'1':'0') );
+        fprintf(fout, "%d %d %d %lld %d ", stack_entry.m_pc,stack_entry.m_calldepth,stack_entry.m_recvg_pc,stack_entry.m_branch_div_cycle,stack_entry.m_type );
+        fprintf(fout, "%d %d\n",m_warp_id, m_warp_size );
+        
+    }
+}
+
+void simt_stack::update( simt_mask_t &thread_done, addr_vector_t &next_pc, address_type recvg_pc, op_type next_inst_op,unsigned next_inst_size, address_type next_inst_pc )
+{
+    assert(m_stack.size() > 0);
+
+    assert( next_pc.size() == m_warp_size );
+
+    simt_mask_t  top_active_mask = m_stack.back().m_active_mask;
+    address_type top_recvg_pc = m_stack.back().m_recvg_pc;
+    address_type top_pc = m_stack.back().m_pc; // the pc of the instruction just executed
+    stack_entry_type top_type = m_stack.back().m_type;
+    assert(top_pc==next_inst_pc);
+    assert(top_active_mask.any());
+
+    const address_type null_pc = -1;
+    bool warp_diverged = false;
+    address_type new_recvg_pc = null_pc;
+    unsigned num_divergent_paths=0;
+
+    std::map<address_type,simt_mask_t> divergent_paths;
+    while (top_active_mask.any()) {
+
+        // extract a group of threads with the same next PC among the active threads in the warp
+        address_type tmp_next_pc = null_pc;
+        simt_mask_t tmp_active_mask;
+        for (int i = m_warp_size - 1; i >= 0; i--) {
+            if ( top_active_mask.test(i) ) { // is this thread active?
+                if (thread_done.test(i)) {
+                    top_active_mask.reset(i); // remove completed thread from active mask
+                } else if (tmp_next_pc == null_pc) {
+                    tmp_next_pc = next_pc[i];
+                    tmp_active_mask.set(i);
+                    top_active_mask.reset(i);
+                } else if (tmp_next_pc == next_pc[i]) {
+                    tmp_active_mask.set(i);
+                    top_active_mask.reset(i);
+                }
+            }
+        }
+
+        if(tmp_next_pc == null_pc) {
+            assert(!top_active_mask.any()); // all threads done
+            continue;
+        }
+
+        divergent_paths[tmp_next_pc]=tmp_active_mask;
+        num_divergent_paths++;
     }
 
-    divergent_paths[tmp_next_pc] = tmp_active_mask;
-    num_divergent_paths++;
-  }
 
-  address_type not_taken_pc = next_inst_pc + next_inst_size;
-  assert(num_divergent_paths <= 2);
-  for (unsigned i = 0; i < num_divergent_paths; i++) {
-    address_type tmp_next_pc = null_pc;
-    simt_mask_t tmp_active_mask;
-    tmp_active_mask.reset();
-    if (divergent_paths.find(not_taken_pc) != divergent_paths.end()) {
-      assert(i == 0);
-      tmp_next_pc = not_taken_pc;
-      tmp_active_mask = divergent_paths[tmp_next_pc];
-      divergent_paths.erase(tmp_next_pc);
-    } else {
-      std::map<address_type, simt_mask_t>::iterator it =
-          divergent_paths.begin();
-      tmp_next_pc = it->first;
-      tmp_active_mask = divergent_paths[tmp_next_pc];
-      divergent_paths.erase(tmp_next_pc);
-    }
+    address_type not_taken_pc = next_inst_pc+next_inst_size;
+    assert(num_divergent_paths<=2);
+    for(unsigned i=0; i<num_divergent_paths; i++){
+    	address_type tmp_next_pc = null_pc;
+    	simt_mask_t tmp_active_mask;
+    	tmp_active_mask.reset();
+    	if(divergent_paths.find(not_taken_pc)!=divergent_paths.end()){
+    		assert(i==0);
+    		tmp_next_pc=not_taken_pc;
+    		tmp_active_mask=divergent_paths[tmp_next_pc];
+    		divergent_paths.erase(tmp_next_pc);
+    	}else{
+    		std::map<address_type,simt_mask_t>:: iterator it=divergent_paths.begin();
+    		tmp_next_pc=it->first;
+    		tmp_active_mask=divergent_paths[tmp_next_pc];
+    		divergent_paths.erase(tmp_next_pc);
+    	}
 
-    // HANDLE THE SPECIAL CASES FIRST
-    if (next_inst_op == CALL_OPS) {
-      // Since call is not a divergent instruction, all threads should have
-      // executed a call instruction
-      assert(num_divergent_paths == 1);
+        // HANDLE THE SPECIAL CASES FIRST
+    	if (next_inst_op== CALL_OPS){
+    		// Since call is not a divergent instruction, all threads should have executed a call instruction
+    		assert(num_divergent_paths == 1);
 
-      simt_stack_entry new_stack_entry;
-      new_stack_entry.m_pc = tmp_next_pc;
-      new_stack_entry.m_active_mask = tmp_active_mask;
-      new_stack_entry.m_branch_div_cycle =
-          m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle;
-      new_stack_entry.m_type = STACK_ENTRY_TYPE_CALL;
-      m_stack.push_back(new_stack_entry);
-      return;
-    } else if (next_inst_op == RET_OPS && top_type == STACK_ENTRY_TYPE_CALL) {
-      // pop the CALL Entry
-      assert(num_divergent_paths == 1);
-      m_stack.pop_back();
+    		simt_stack_entry new_stack_entry;
+    		new_stack_entry.m_pc = tmp_next_pc;
+    		new_stack_entry.m_active_mask = tmp_active_mask;
+    		new_stack_entry.m_branch_div_cycle = m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle;
+    		new_stack_entry.m_type = STACK_ENTRY_TYPE_CALL;
+    		m_stack.push_back(new_stack_entry);
+    		return;
+    	}else if(next_inst_op == RET_OPS && top_type==STACK_ENTRY_TYPE_CALL){
+    		// pop the CALL Entry
+    		assert(num_divergent_paths == 1);
+    		m_stack.pop_back();
 
-      assert(m_stack.size() > 0);
-      m_stack.back().m_pc = tmp_next_pc;  // set the PC of the stack top entry
-                                          // to return PC from  the call stack;
-      // Check if the New top of the stack is reconverging
-      if (tmp_next_pc == m_stack.back().m_recvg_pc &&
-          m_stack.back().m_type != STACK_ENTRY_TYPE_CALL) {
-        assert(m_stack.back().m_type == STACK_ENTRY_TYPE_NORMAL);
-        m_stack.pop_back();
-      }
-      return;
-    }
+    		assert(m_stack.size() > 0);
+    		m_stack.back().m_pc=tmp_next_pc;// set the PC of the stack top entry to return PC from  the call stack;
+            // Check if the New top of the stack is reconverging
+            if (tmp_next_pc == m_stack.back().m_recvg_pc && m_stack.back().m_type!=STACK_ENTRY_TYPE_CALL){
+            	assert(m_stack.back().m_type==STACK_ENTRY_TYPE_NORMAL);
+            	m_stack.pop_back();
+            }
+            return;
+    	}
 
-    // discard the new entry if its PC matches with reconvergence PC
-    // that automatically reconverges the entry
-    // If the top stack entry is CALL, dont reconverge.
-    if (tmp_next_pc == top_recvg_pc && (top_type != STACK_ENTRY_TYPE_CALL))
-      continue;
+        // discard the new entry if its PC matches with reconvergence PC
+        // that automatically reconverges the entry
+        // If the top stack entry is CALL, dont reconverge.
+        if (tmp_next_pc == top_recvg_pc && (top_type != STACK_ENTRY_TYPE_CALL)) continue;
 
-    // this new entry is not converging
-    // if this entry does not include thread from the warp, divergence occurs
-    if ((num_divergent_paths > 1) && !warp_diverged) {
-      warp_diverged = true;
-      // modify the existing top entry into a reconvergence entry in the pdom
-      // stack
-      new_recvg_pc = recvg_pc;
-      if (new_recvg_pc != top_recvg_pc) {
-        m_stack.back().m_pc = new_recvg_pc;
-        m_stack.back().m_branch_div_cycle =
-            m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle;
+        // this new entry is not converging
+        // if this entry does not include thread from the warp, divergence occurs
+        if ((num_divergent_paths>1) && !warp_diverged ) {
+            warp_diverged = true;
+            // modify the existing top entry into a reconvergence entry in the pdom stack
+            new_recvg_pc = recvg_pc;
+            if (new_recvg_pc != top_recvg_pc) {
+                m_stack.back().m_pc = new_recvg_pc;
+                m_stack.back().m_branch_div_cycle = m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle;
+
+                m_stack.push_back(simt_stack_entry());
+            }
+        }
+
+        // discard the new entry if its PC matches with reconvergence PC
+        if (warp_diverged && tmp_next_pc == new_recvg_pc) continue;
+
+        // update the current top of pdom stack
+        m_stack.back().m_pc = tmp_next_pc;
+        m_stack.back().m_active_mask = tmp_active_mask;
+        if (warp_diverged) {
+            m_stack.back().m_calldepth = 0;
+            m_stack.back().m_recvg_pc = new_recvg_pc;
+        } else {
+            m_stack.back().m_recvg_pc = top_recvg_pc;
+        }
 
         m_stack.push_back(simt_stack_entry());
-      }
     }
+    assert(m_stack.size() > 0);
+    m_stack.pop_back();
 
-    // discard the new entry if its PC matches with reconvergence PC
-    if (warp_diverged && tmp_next_pc == new_recvg_pc) continue;
 
-    // update the current top of pdom stack
-    m_stack.back().m_pc = tmp_next_pc;
-    m_stack.back().m_active_mask = tmp_active_mask;
     if (warp_diverged) {
-      m_stack.back().m_calldepth = 0;
-      m_stack.back().m_recvg_pc = new_recvg_pc;
-    } else {
-      m_stack.back().m_recvg_pc = top_recvg_pc;
+        m_gpu->gpgpu_ctx->stats->ptx_file_line_stats_add_warp_divergence(top_pc, 1); 
     }
-
-    m_stack.push_back(simt_stack_entry());
-  }
-  assert(m_stack.size() > 0);
-  m_stack.pop_back();
-
-  if (warp_diverged) {
-    m_gpu->gpgpu_ctx->stats->ptx_file_line_stats_add_warp_divergence(top_pc, 1);
-  }
 }
 
-void core_t::execute_warp_inst_t(warp_inst_t &inst, unsigned warpId) {
-  for (unsigned t = 0; t < m_warp_size; t++) {
-    if (inst.active(t)) {
-      if (warpId == (unsigned(-1))) warpId = inst.warp_id();
-      unsigned tid = m_warp_size * warpId + t;
-      m_thread[tid]->ptx_exec_inst(inst, t);
-
-      // virtual function
-      checkExecutionStatusAndUpdate(inst, t, tid);
-    }
-  }
+void core_t::execute_warp_inst_t(warp_inst_t &inst, unsigned warpId)
+{
+    for ( unsigned t=0; t < m_warp_size; t++ ) {
+        if( inst.active(t) ) {
+            if(warpId==(unsigned (-1)))
+                warpId = inst.warp_id();
+            unsigned tid=m_warp_size*warpId+t;
+            m_thread[tid]->ptx_exec_inst(inst,t);
+            
+            //virtual function
+            checkExecutionStatusAndUpdate(inst,t,tid);
+        }
+    } 
 }
-
-bool core_t::ptx_thread_done(unsigned hw_thread_id) const {
-  return ((m_thread[hw_thread_id] == NULL) ||
-          m_thread[hw_thread_id]->is_done());
+  
+bool  core_t::ptx_thread_done( unsigned hw_thread_id ) const  
+{
+    return ((m_thread[ hw_thread_id ]==NULL) || m_thread[ hw_thread_id ]->is_done());
 }
-
-void core_t::updateSIMTStack(unsigned warpId, warp_inst_t *inst) {
-  simt_mask_t thread_done;
-  addr_vector_t next_pc;
-  unsigned wtid = warpId * m_warp_size;
-  for (unsigned i = 0; i < m_warp_size; i++) {
-    if (ptx_thread_done(wtid + i)) {
-      thread_done.set(i);
-      next_pc.push_back((address_type)-1);
-    } else {
-      if (inst->reconvergence_pc == RECONVERGE_RETURN_PC)
-        inst->reconvergence_pc = get_return_pc(m_thread[wtid + i]);
-      next_pc.push_back(m_thread[wtid + i]->get_pc());
+  
+void core_t::updateSIMTStack(unsigned warpId, warp_inst_t * inst)
+{
+    simt_mask_t thread_done;
+    addr_vector_t next_pc;
+    unsigned wtid = warpId * m_warp_size;
+    for (unsigned i = 0; i < m_warp_size; i++) {
+        if( ptx_thread_done(wtid+i) ) {
+            thread_done.set(i);
+            next_pc.push_back( (address_type)-1 );
+        } else {
+            if( inst->reconvergence_pc == RECONVERGE_RETURN_PC ) 
+                inst->reconvergence_pc = get_return_pc(m_thread[wtid+i]);
+            next_pc.push_back( m_thread[wtid+i]->get_pc() );
+        }
     }
-  }
-  m_simt_stack[warpId]->update(thread_done, next_pc, inst->reconvergence_pc,
-                               inst->op, inst->isize, inst->pc);
+    m_simt_stack[warpId]->update(thread_done,next_pc,inst->reconvergence_pc, inst->op,inst->isize,inst->pc);
 }
 
 //! Get the warp to be executed using the data taken form the SIMT stack
-warp_inst_t core_t::getExecuteWarp(unsigned warpId) {
-  unsigned pc, rpc;
-  m_simt_stack[warpId]->get_pdom_stack_top_info(&pc, &rpc);
-  warp_inst_t wi = *(m_gpu->gpgpu_ctx->ptx_fetch_inst(pc));
-  wi.set_active(m_simt_stack[warpId]->get_active_mask());
-  return wi;
+warp_inst_t core_t::getExecuteWarp(unsigned warpId)
+{
+    unsigned pc,rpc;
+    m_simt_stack[warpId]->get_pdom_stack_top_info(&pc,&rpc);
+    warp_inst_t wi= *(m_gpu->gpgpu_ctx->ptx_fetch_inst(pc));
+    wi.set_active(m_simt_stack[warpId]->get_active_mask());
+    return wi;
 }
 
-void core_t::deleteSIMTStack() {
-  if (m_simt_stack) {
-    for (unsigned i = 0; i < m_warp_count; ++i) delete m_simt_stack[i];
-    delete[] m_simt_stack;
-    m_simt_stack = NULL;
-  }
+void core_t::deleteSIMTStack()
+{
+    if ( m_simt_stack ) {
+        for (unsigned i = 0; i < m_warp_count; ++i) 
+            delete m_simt_stack[i];
+        delete[] m_simt_stack;
+        m_simt_stack = NULL;
+    }
 }
 
-void core_t::initilizeSIMTStack(unsigned warp_count, unsigned warp_size) {
-  m_simt_stack = new simt_stack *[warp_count];
-  for (unsigned i = 0; i < warp_count; ++i)
-    m_simt_stack[i] = new simt_stack(i, warp_size, m_gpu);
-  m_warp_size = warp_size;
-  m_warp_count = warp_count;
+void core_t::initilizeSIMTStack(unsigned warp_count, unsigned warp_size)
+{ 
+    m_simt_stack = new simt_stack*[warp_count];
+    for (unsigned i = 0; i < warp_count; ++i) 
+        m_simt_stack[i] = new simt_stack(i,warp_size,m_gpu);
+    m_warp_size = warp_size;
+    m_warp_count = warp_count;
 }
 
-void core_t::get_pdom_stack_top_info(unsigned warpId, unsigned *pc,
-                                     unsigned *rpc) const {
-  m_simt_stack[warpId]->get_pdom_stack_top_info(pc, rpc);
+void core_t::get_pdom_stack_top_info( unsigned warpId, unsigned *pc, unsigned *rpc ) const
+{
+    m_simt_stack[warpId]->get_pdom_stack_top_info(pc,rpc);
 }

--- a/src/abstract_hardware_model.h
+++ b/src/abstract_hardware_model.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -35,41 +33,45 @@ class gpgpu_sim;
 class kernel_info_t;
 class gpgpu_context;
 
-// Set a hard limit of 32 CTAs per shader [cuda only has 8]
+
+//Set a hard limit of 32 CTAs per shader [cuda only has 8]
 #define MAX_CTA_PER_SHADER 32
 #define MAX_BARRIERS_PER_CTA 16
 
-// After expanding the vector input and output operands
+//After expanding the vector input and output operands 
 #define MAX_INPUT_VALUES 24
 #define MAX_OUTPUT_VALUES 8
 
 enum _memory_space_t {
-  undefined_space = 0,
-  reg_space,
-  local_space,
-  shared_space,
-  sstarr_space,
-  param_space_unclassified,
-  param_space_kernel, /* global to all threads in a kernel : read-only */
-  param_space_local,  /* local to a thread : read-writable */
-  const_space,
-  tex_space,
-  surf_space,
-  global_space,
-  generic_space,
-  instruction_space
+   undefined_space=0,
+   reg_space,
+   local_space,
+   shared_space,
+   sstarr_space,
+   param_space_unclassified,
+   param_space_kernel,  /* global to all threads in a kernel : read-only */
+   param_space_local,   /* local to a thread : read-writable */
+   const_space,
+   tex_space,
+   surf_space,
+   global_space,
+   generic_space,
+   instruction_space
 };
 
-enum FuncCache {
+
+enum FuncCache
+{
   FuncCachePreferNone = 0,
   FuncCachePreferShared = 1,
   FuncCachePreferL1 = 2
 };
 
+
 #ifdef __cplusplus
 
-#include <stdio.h>
 #include <string.h>
+#include <stdio.h>
 #include <set>
 
 typedef unsigned long long new_addr_type;
@@ -77,357 +79,371 @@ typedef unsigned long long cudaTextureObject_t;
 typedef unsigned address_type;
 typedef unsigned addr_t;
 
-// the following are operations the timing model can see
+// the following are operations the timing model can see 
 
 enum uarch_op_t {
-  NO_OP = -1,
-  ALU_OP = 1,
-  SFU_OP,
-  TENSOR_CORE_OP,
-  DP_OP,
-  SP_OP,
-  INTP_OP,
-  ALU_SFU_OP,
-  LOAD_OP,
-  TENSOR_CORE_LOAD_OP,
-  TENSOR_CORE_STORE_OP,
-  STORE_OP,
-  BRANCH_OP,
-  BARRIER_OP,
-  MEMORY_BARRIER_OP,
-  CALL_OPS,
-  RET_OPS
+   NO_OP=-1,
+   ALU_OP=1,
+   SFU_OP,
+   TENSOR_CORE_OP,
+   DP_OP,
+   SP_OP,
+   INTP_OP,
+   ALU_SFU_OP,
+   LOAD_OP,
+   TENSOR_CORE_LOAD_OP,
+   TENSOR_CORE_STORE_OP,
+   STORE_OP,
+   BRANCH_OP,
+   BARRIER_OP,
+   MEMORY_BARRIER_OP,
+   CALL_OPS,
+   RET_OPS
 };
 typedef enum uarch_op_t op_type;
 
-enum uarch_bar_t { NOT_BAR = -1, SYNC = 1, ARRIVE, RED };
+
+enum uarch_bar_t {
+   NOT_BAR=-1,
+   SYNC=1,
+   ARRIVE,
+   RED
+};
 typedef enum uarch_bar_t barrier_type;
 
-enum uarch_red_t { NOT_RED = -1, POPC_RED = 1, AND_RED, OR_RED };
+enum uarch_red_t {
+   NOT_RED=-1,
+   POPC_RED=1,
+   AND_RED,
+   OR_RED
+};
 typedef enum uarch_red_t reduction_type;
 
-enum uarch_operand_type_t { UN_OP = -1, INT_OP, FP_OP };
+
+enum uarch_operand_type_t {
+	UN_OP=-1,
+    INT_OP,
+    FP_OP
+};
 typedef enum uarch_operand_type_t types_of_operands;
 
 enum special_operations_t {
-  OTHER_OP,
-  INT__OP,
-  INT_MUL24_OP,
-  INT_MUL32_OP,
-  INT_MUL_OP,
-  INT_DIV_OP,
-  FP_MUL_OP,
-  FP_DIV_OP,
-  FP__OP,
-  FP_SQRT_OP,
-  FP_LG_OP,
-  FP_SIN_OP,
-  FP_EXP_OP
+    OTHER_OP,
+    INT__OP,
+	INT_MUL24_OP,
+	INT_MUL32_OP,
+	INT_MUL_OP,
+    INT_DIV_OP,
+    FP_MUL_OP,
+    FP_DIV_OP,
+    FP__OP,
+	FP_SQRT_OP,
+	FP_LG_OP,
+	FP_SIN_OP,
+	FP_EXP_OP
 };
-typedef enum special_operations_t
-    special_ops;  // Required to identify for the power model
+typedef enum special_operations_t special_ops; // Required to identify for the power model
 enum operation_pipeline_t {
-  UNKOWN_OP,
-  SP__OP,
-  DP__OP,
-  INTP__OP,
-  SFU__OP,
-  TENSOR_CORE__OP,
-  MEM__OP
+    UNKOWN_OP,
+    SP__OP,
+	DP__OP,
+	INTP__OP,
+    SFU__OP,
+    TENSOR_CORE__OP,
+    MEM__OP
 };
 typedef enum operation_pipeline_t operation_pipeline;
-enum mem_operation_t { NOT_TEX, TEX };
+enum mem_operation_t {
+    NOT_TEX,
+    TEX
+};
 typedef enum mem_operation_t mem_operation;
 
-enum _memory_op_t { no_memory_op = 0, memory_load, memory_store };
+enum _memory_op_t {
+	no_memory_op = 0,
+	memory_load,
+	memory_store
+};
 
+#include <bitset>
+#include <list>
+#include <vector>
 #include <assert.h>
 #include <stdlib.h>
-#include <algorithm>
-#include <bitset>
-#include <deque>
-#include <list>
 #include <map>
-#include <vector>
+#include <deque>
+#include <algorithm>
 
 #if !defined(__VECTOR_TYPES_H__)
 #include "vector_types.h"
 #endif
 struct dim3comp {
-  bool operator()(const dim3 &a, const dim3 &b) const {
-    if (a.z < b.z)
-      return true;
-    else if (a.y < b.y)
-      return true;
-    else if (a.x < b.x)
-      return true;
-    else
-      return false;
-  }
+    bool operator() (const dim3 & a, const dim3 & b) const
+    {    
+        if(a.z < b.z)
+            return true;
+        else if(a.y < b.y)
+            return true;
+        else if (a.x < b.x)
+            return true;
+        else
+            return false;
+    }
 };
 
-void increment_x_then_y_then_z(dim3 &i, const dim3 &bound);
+void increment_x_then_y_then_z( dim3 &i, const dim3 &bound);
 
-// Jin: child kernel information for CDP
+//Jin: child kernel information for CDP
 #include "stream_manager.h"
 class stream_manager;
 struct CUstream_st;
-// extern stream_manager * g_stream_manager;
-// support for pinned memories added
-extern std::map<void *, void **> pinned_memory;
+//extern stream_manager * g_stream_manager;
+//support for pinned memories added
+extern std::map<void *,void **> pinned_memory;
 extern std::map<void *, size_t> pinned_memory_size;
 
 class kernel_info_t {
- public:
-  //   kernel_info_t()
-  //   {
-  //      m_valid=false;
-  //      m_kernel_entry=NULL;
-  //      m_uid=0;
-  //      m_num_cores_running=0;
-  //      m_param_mem=NULL;
-  //   }
-  kernel_info_t(dim3 gridDim, dim3 blockDim, class function_info *entry);
-  kernel_info_t(
-      dim3 gridDim, dim3 blockDim, class function_info *entry,
-      std::map<std::string, const struct cudaArray *> nameToCudaArray,
-      std::map<std::string, const struct textureInfo *> nameToTextureInfo);
-  ~kernel_info_t();
+public:
+//   kernel_info_t()
+//   {
+//      m_valid=false;
+//      m_kernel_entry=NULL;
+//      m_uid=0;
+//      m_num_cores_running=0;
+//      m_param_mem=NULL;
+//   }
+   kernel_info_t( dim3 gridDim, dim3 blockDim, class function_info *entry);
+   kernel_info_t( dim3 gridDim, dim3 blockDim, class function_info *entry, std::map<std::string, const struct cudaArray*> nameToCudaArray, std::map<std::string, const struct textureInfo*> nameToTextureInfo);
+   ~kernel_info_t();
 
-  void inc_running() { m_num_cores_running++; }
-  void dec_running() {
-    assert(m_num_cores_running > 0);
-    m_num_cores_running--;
-  }
-  bool running() const { return m_num_cores_running > 0; }
-  bool done() const { return no_more_ctas_to_run() && !running(); }
-  class function_info *entry() {
-    return m_kernel_entry;
-  }
-  const class function_info *entry() const { return m_kernel_entry; }
+   void inc_running() { m_num_cores_running++; }
+   void dec_running()
+   {
+       assert( m_num_cores_running > 0 );
+       m_num_cores_running--; 
+   }
+   bool running() const { return m_num_cores_running>0; }
+   bool done() const 
+   {
+       return no_more_ctas_to_run() && !running();
+   }
+   class function_info *entry() { return m_kernel_entry; }
+   const class function_info *entry() const { return m_kernel_entry; }
 
-  size_t num_blocks() const {
-    return m_grid_dim.x * m_grid_dim.y * m_grid_dim.z;
-  }
+   size_t num_blocks() const
+   {
+      return m_grid_dim.x * m_grid_dim.y * m_grid_dim.z;
+   }
 
-  size_t threads_per_cta() const {
-    return m_block_dim.x * m_block_dim.y * m_block_dim.z;
-  }
+   size_t threads_per_cta() const
+   {
+      return m_block_dim.x * m_block_dim.y * m_block_dim.z;
+   } 
 
-  dim3 get_grid_dim() const { return m_grid_dim; }
-  dim3 get_cta_dim() const { return m_block_dim; }
+   dim3 get_grid_dim() const { return m_grid_dim; }
+   dim3 get_cta_dim() const { return m_block_dim; }
 
-  void increment_cta_id() {
-    increment_x_then_y_then_z(m_next_cta, m_grid_dim);
-    m_next_tid.x = 0;
-    m_next_tid.y = 0;
-    m_next_tid.z = 0;
-  }
-  dim3 get_next_cta_id() const { return m_next_cta; }
-  unsigned get_next_cta_id_single() const {
-    return m_next_cta.x + m_grid_dim.x * m_next_cta.y +
-           m_grid_dim.x * m_grid_dim.y * m_next_cta.z;
-  }
-  bool no_more_ctas_to_run() const {
-    return (m_next_cta.x >= m_grid_dim.x || m_next_cta.y >= m_grid_dim.y ||
-            m_next_cta.z >= m_grid_dim.z);
-  }
+   void increment_cta_id() 
+   { 
+      increment_x_then_y_then_z(m_next_cta,m_grid_dim); 
+      m_next_tid.x=0;
+      m_next_tid.y=0;
+      m_next_tid.z=0;
+   }
+   dim3 get_next_cta_id() const { return m_next_cta; }
+   unsigned get_next_cta_id_single() const 
+   {
+      return m_next_cta.x + m_grid_dim.x*m_next_cta.y + m_grid_dim.x*m_grid_dim.y*m_next_cta.z;
+    }
+   bool no_more_ctas_to_run() const 
+   {
+      return (m_next_cta.x >= m_grid_dim.x || m_next_cta.y >= m_grid_dim.y || m_next_cta.z >= m_grid_dim.z );
+   }
 
-  void increment_thread_id() {
-    increment_x_then_y_then_z(m_next_tid, m_block_dim);
-  }
-  dim3 get_next_thread_id_3d() const { return m_next_tid; }
-  unsigned get_next_thread_id() const {
-    return m_next_tid.x + m_block_dim.x * m_next_tid.y +
-           m_block_dim.x * m_block_dim.y * m_next_tid.z;
-  }
-  bool more_threads_in_cta() const {
-    return m_next_tid.z < m_block_dim.z && m_next_tid.y < m_block_dim.y &&
-           m_next_tid.x < m_block_dim.x;
-  }
-  unsigned get_uid() const { return m_uid; }
-  std::string name() const;
+   void increment_thread_id() { increment_x_then_y_then_z(m_next_tid,m_block_dim); }
+   dim3 get_next_thread_id_3d() const  { return m_next_tid; }
+   unsigned get_next_thread_id() const 
+   { 
+      return m_next_tid.x + m_block_dim.x*m_next_tid.y + m_block_dim.x*m_block_dim.y*m_next_tid.z;
+   }
+   bool more_threads_in_cta() const 
+   {
+      return m_next_tid.z < m_block_dim.z && m_next_tid.y < m_block_dim.y && m_next_tid.x < m_block_dim.x;
+   }
+   unsigned get_uid() const { return m_uid; }
+   std::string name() const;
 
-  std::list<class ptx_thread_info *> &active_threads() {
-    return m_active_threads;
-  }
-  class memory_space *get_param_memory() {
-    return m_param_mem;
-  }
+   std::list<class ptx_thread_info *> &active_threads() { return m_active_threads; }
+   class memory_space *get_param_memory() { return m_param_mem; }
 
-  // The following functions access texture bindings present at the kernel's
-  // launch
+   
+   //The following functions access texture bindings present at the kernel's launch
+   
+   const struct cudaArray* get_texarray( const std::string &texname ) const
+   {
+      std::map<std::string,const struct cudaArray*>::const_iterator t=m_NameToCudaArray.find(texname);
+      assert(t != m_NameToCudaArray.end());
+      return t->second;
+   }
 
-  const struct cudaArray *get_texarray(const std::string &texname) const {
-    std::map<std::string, const struct cudaArray *>::const_iterator t =
-        m_NameToCudaArray.find(texname);
-    assert(t != m_NameToCudaArray.end());
-    return t->second;
-  }
+   const struct textureInfo* get_texinfo( const std::string &texname ) const
+   {
+      std::map<std::string, const struct textureInfo*>::const_iterator t=m_NameToTextureInfo.find(texname);
+      assert(t != m_NameToTextureInfo.end());
+      return t->second;
+   }
 
-  const struct textureInfo *get_texinfo(const std::string &texname) const {
-    std::map<std::string, const struct textureInfo *>::const_iterator t =
-        m_NameToTextureInfo.find(texname);
-    assert(t != m_NameToTextureInfo.end());
-    return t->second;
-  }
+private:
+   kernel_info_t( const kernel_info_t & ); // disable copy constructor
+   void operator=( const kernel_info_t & ); // disable copy operator
 
- private:
-  kernel_info_t(const kernel_info_t &);   // disable copy constructor
-  void operator=(const kernel_info_t &);  // disable copy operator
+   class function_info *m_kernel_entry;
 
-  class function_info *m_kernel_entry;
+   unsigned m_uid;
+   
+   //These maps contain the snapshot of the texture mappings at kernel launch
+   std::map<std::string, const struct cudaArray*> m_NameToCudaArray;
+   std::map<std::string, const struct textureInfo*> m_NameToTextureInfo;
 
-  unsigned m_uid;
+   dim3 m_grid_dim;
+   dim3 m_block_dim;
+   dim3 m_next_cta;
+   dim3 m_next_tid;
 
-  // These maps contain the snapshot of the texture mappings at kernel launch
-  std::map<std::string, const struct cudaArray *> m_NameToCudaArray;
-  std::map<std::string, const struct textureInfo *> m_NameToTextureInfo;
+   unsigned m_num_cores_running;
 
-  dim3 m_grid_dim;
-  dim3 m_block_dim;
-  dim3 m_next_cta;
-  dim3 m_next_tid;
+   std::list<class ptx_thread_info *> m_active_threads;
+   class memory_space *m_param_mem;
 
-  unsigned m_num_cores_running;
+public:
+   //Jin: parent and child kernel management for CDP
+   void set_parent(kernel_info_t * parent, dim3 parent_ctaid, dim3 parent_tid);
+   void set_child(kernel_info_t * child);
+   void remove_child(kernel_info_t * child);
+   bool is_finished();
+   bool children_all_finished();
+   void notify_parent_finished();
+   CUstream_st * create_stream_cta(dim3 ctaid);
+   CUstream_st * get_default_stream_cta(dim3 ctaid);
+   bool cta_has_stream(dim3 ctaid, CUstream_st* stream);
+   void destroy_cta_streams();
+   void print_parent_info();
+   kernel_info_t * get_parent() { return m_parent_kernel; }
 
-  std::list<class ptx_thread_info *> m_active_threads;
-  class memory_space *m_param_mem;
+private:
+   kernel_info_t * m_parent_kernel;
+   dim3 m_parent_ctaid;
+   dim3 m_parent_tid;
+   std::list<kernel_info_t *> m_child_kernels; //child kernel launched
+   std::map< dim3, std::list<CUstream_st *>, dim3comp > m_cta_streams; //streams created in each CTA
 
- public:
-  // Jin: parent and child kernel management for CDP
-  void set_parent(kernel_info_t *parent, dim3 parent_ctaid, dim3 parent_tid);
-  void set_child(kernel_info_t *child);
-  void remove_child(kernel_info_t *child);
-  bool is_finished();
-  bool children_all_finished();
-  void notify_parent_finished();
-  CUstream_st *create_stream_cta(dim3 ctaid);
-  CUstream_st *get_default_stream_cta(dim3 ctaid);
-  bool cta_has_stream(dim3 ctaid, CUstream_st *stream);
-  void destroy_cta_streams();
-  void print_parent_info();
-  kernel_info_t *get_parent() { return m_parent_kernel; }
+//Jin: kernel timing
+public:
+   unsigned long long launch_cycle;
+   unsigned long long start_cycle;
+   unsigned long long end_cycle;
+   unsigned m_launch_latency;
 
- private:
-  kernel_info_t *m_parent_kernel;
-  dim3 m_parent_ctaid;
-  dim3 m_parent_tid;
-  std::list<kernel_info_t *> m_child_kernels;  // child kernel launched
-  std::map<dim3, std::list<CUstream_st *>, dim3comp>
-      m_cta_streams;  // streams created in each CTA
-
-  // Jin: kernel timing
- public:
-  unsigned long long launch_cycle;
-  unsigned long long start_cycle;
-  unsigned long long end_cycle;
-  unsigned m_launch_latency;
-
-  mutable bool volta_cache_config_set;
+   mutable bool volta_cache_config_set;
 };
 
 class core_config {
- public:
-  core_config(gpgpu_context *ctx) {
-    gpgpu_ctx = ctx;
-    m_valid = false;
-    num_shmem_bank = 16;
-    shmem_limited_broadcast = false;
-    gpgpu_shmem_sizeDefault = (unsigned)-1;
-    gpgpu_shmem_sizePrefL1 = (unsigned)-1;
-    gpgpu_shmem_sizePrefShared = (unsigned)-1;
-  }
-  virtual void init() = 0;
+    public:
+    core_config(gpgpu_context* ctx)
+    {
+	gpgpu_ctx = ctx;
+        m_valid = false; 
+        num_shmem_bank=16; 
+        shmem_limited_broadcast = false; 
+        gpgpu_shmem_sizeDefault=(unsigned)-1;
+        gpgpu_shmem_sizePrefL1=(unsigned)-1;
+        gpgpu_shmem_sizePrefShared=(unsigned)-1;
+    }
+    virtual void init() = 0;
 
-  bool m_valid;
-  unsigned warp_size;
-  // backward pointer
-  class gpgpu_context *gpgpu_ctx;
+    bool m_valid;
+    unsigned warp_size;
+    // backward pointer
+    class gpgpu_context* gpgpu_ctx;
 
-  // off-chip memory request architecture parameters
-  int gpgpu_coalesce_arch;
+    // off-chip memory request architecture parameters
+    int gpgpu_coalesce_arch;
 
-  // shared memory bank conflict checking parameters
-  bool shmem_limited_broadcast;
-  static const address_type WORD_SIZE = 4;
-  unsigned num_shmem_bank;
-  unsigned shmem_bank_func(address_type addr) const {
-    return ((addr / WORD_SIZE) % num_shmem_bank);
-  }
-  unsigned mem_warp_parts;
-  mutable unsigned gpgpu_shmem_size;
-  unsigned gpgpu_shmem_sizeDefault;
-  unsigned gpgpu_shmem_sizePrefL1;
-  unsigned gpgpu_shmem_sizePrefShared;
-  unsigned mem_unit_ports;
+    // shared memory bank conflict checking parameters
+    bool shmem_limited_broadcast;
+    static const address_type WORD_SIZE=4;
+    unsigned num_shmem_bank;
+    unsigned shmem_bank_func(address_type addr) const
+    {
+        return ((addr/WORD_SIZE) % num_shmem_bank);
+    }
+    unsigned mem_warp_parts;  
+    mutable unsigned gpgpu_shmem_size;
+    unsigned gpgpu_shmem_sizeDefault;
+    unsigned gpgpu_shmem_sizePrefL1;
+    unsigned gpgpu_shmem_sizePrefShared;
+    unsigned mem_unit_ports;
 
-  // texture and constant cache line sizes (used to determine number of memory
-  // accesses)
-  unsigned gpgpu_cache_texl1_linesize;
-  unsigned gpgpu_cache_constl1_linesize;
+    // texture and constant cache line sizes (used to determine number of memory accesses)
+    unsigned gpgpu_cache_texl1_linesize;
+    unsigned gpgpu_cache_constl1_linesize;
 
-  unsigned gpgpu_max_insn_issue_per_warp;
-  bool gmem_skip_L1D;  // on = global memory access always skip the L1 cache
+	unsigned gpgpu_max_insn_issue_per_warp;
+	bool gmem_skip_L1D; // on = global memory access always skip the L1 cache
 
-  bool adaptive_volta_cache_config;
+	bool adaptive_volta_cache_config;
 };
 
-// bounded stack that implements simt reconvergence using pdom mechanism from
-// MICRO'07 paper
+// bounded stack that implements simt reconvergence using pdom mechanism from MICRO'07 paper
 const unsigned MAX_WARP_SIZE = 32;
 typedef std::bitset<MAX_WARP_SIZE> active_mask_t;
-#define MAX_WARP_SIZE_SIMT_STACK MAX_WARP_SIZE
+#define MAX_WARP_SIZE_SIMT_STACK  MAX_WARP_SIZE
 typedef std::bitset<MAX_WARP_SIZE_SIMT_STACK> simt_mask_t;
 typedef std::vector<address_type> addr_vector_t;
 
 class simt_stack {
- public:
-  simt_stack(unsigned wid, unsigned warpSize, class gpgpu_sim *gpu);
+public:
+    simt_stack( unsigned wid,  unsigned warpSize, class gpgpu_sim * gpu);
 
-  void reset();
-  void launch(address_type start_pc, const simt_mask_t &active_mask);
-  void update(simt_mask_t &thread_done, addr_vector_t &next_pc,
-              address_type recvg_pc, op_type next_inst_op,
-              unsigned next_inst_size, address_type next_inst_pc);
+    void reset();
+    void launch( address_type start_pc, const simt_mask_t &active_mask );
+    void update( simt_mask_t &thread_done, addr_vector_t &next_pc, address_type recvg_pc, op_type next_inst_op,unsigned next_inst_size, address_type next_inst_pc );
 
-  const simt_mask_t &get_active_mask() const;
-  void get_pdom_stack_top_info(unsigned *pc, unsigned *rpc) const;
-  unsigned get_rp() const;
-  void print(FILE *fp) const;
-  void resume(char *fname);
-  void print_checkpoint(FILE *fout) const;
+    const simt_mask_t &get_active_mask() const;
+    void     get_pdom_stack_top_info( unsigned *pc, unsigned *rpc ) const;
+    unsigned get_rp() const;
+    void     print(FILE *fp) const;
+    void     resume(char * fname) ;
+    void    print_checkpoint (FILE *fout) const;
 
- protected:
-  unsigned m_warp_id;
-  unsigned m_warp_size;
+protected:
+    unsigned m_warp_id;
+    unsigned m_warp_size;
 
-  enum stack_entry_type { STACK_ENTRY_TYPE_NORMAL = 0, STACK_ENTRY_TYPE_CALL };
 
-  struct simt_stack_entry {
-    address_type m_pc;
-    unsigned int m_calldepth;
-    simt_mask_t m_active_mask;
-    address_type m_recvg_pc;
-    unsigned long long m_branch_div_cycle;
-    stack_entry_type m_type;
-    simt_stack_entry()
-        : m_pc(-1),
-          m_calldepth(0),
-          m_active_mask(),
-          m_recvg_pc(-1),
-          m_branch_div_cycle(0),
-          m_type(STACK_ENTRY_TYPE_NORMAL){};
-  };
+    enum stack_entry_type {
+        STACK_ENTRY_TYPE_NORMAL = 0,
+        STACK_ENTRY_TYPE_CALL
+    };
 
-  std::deque<simt_stack_entry> m_stack;
+    struct simt_stack_entry {
+        address_type m_pc;
+        unsigned int m_calldepth;
+        simt_mask_t m_active_mask;
+        address_type m_recvg_pc;
+        unsigned long long m_branch_div_cycle;
+        stack_entry_type m_type;
+        simt_stack_entry() :
+            m_pc(-1), m_calldepth(0), m_active_mask(), m_recvg_pc(-1), m_branch_div_cycle(0), m_type(STACK_ENTRY_TYPE_NORMAL) { };
+    };
 
-  class gpgpu_sim *m_gpu;
+    std::deque<simt_stack_entry> m_stack;
+
+    class gpgpu_sim * m_gpu;
 };
 
 // Let's just upgrade to C++11 so we can use constexpr here...
-// start allocating from this address (lower values used for allocating globals
-// in .ptx file)
+// start allocating from this address (lower values used for allocating globals in .ptx file)
 const unsigned long long GLOBAL_HEAP_START = 0xC0000000;
 // Volta max shmem size is 96kB
 const unsigned long long SHARED_MEM_SIZE_MAX = 96 * (1 << 10);
@@ -439,931 +455,873 @@ const unsigned MAX_STREAMING_MULTIPROCESSORS = 80;
 const unsigned MAX_THREAD_PER_SM = 1 << 11;
 // MAX 64 warps / SM
 const unsigned MAX_WARP_PER_SM = 1 << 6;
-const unsigned long long TOTAL_LOCAL_MEM_PER_SM =
-    MAX_THREAD_PER_SM * LOCAL_MEM_SIZE_MAX;
-const unsigned long long TOTAL_SHARED_MEM =
-    MAX_STREAMING_MULTIPROCESSORS * SHARED_MEM_SIZE_MAX;
-const unsigned long long TOTAL_LOCAL_MEM =
-    MAX_STREAMING_MULTIPROCESSORS * MAX_THREAD_PER_SM * LOCAL_MEM_SIZE_MAX;
-const unsigned long long SHARED_GENERIC_START =
-    GLOBAL_HEAP_START - TOTAL_SHARED_MEM;
-const unsigned long long LOCAL_GENERIC_START =
-    SHARED_GENERIC_START - TOTAL_LOCAL_MEM;
-const unsigned long long STATIC_ALLOC_LIMIT =
-    GLOBAL_HEAP_START - (TOTAL_LOCAL_MEM + TOTAL_SHARED_MEM);
+const unsigned long long TOTAL_LOCAL_MEM_PER_SM = MAX_THREAD_PER_SM * LOCAL_MEM_SIZE_MAX;
+const unsigned long long TOTAL_SHARED_MEM = MAX_STREAMING_MULTIPROCESSORS * SHARED_MEM_SIZE_MAX;
+const unsigned long long TOTAL_LOCAL_MEM = MAX_STREAMING_MULTIPROCESSORS * MAX_THREAD_PER_SM * LOCAL_MEM_SIZE_MAX;
+const unsigned long long SHARED_GENERIC_START = GLOBAL_HEAP_START - TOTAL_SHARED_MEM;
+const unsigned long long LOCAL_GENERIC_START = SHARED_GENERIC_START - TOTAL_LOCAL_MEM;
+const unsigned long long STATIC_ALLOC_LIMIT = GLOBAL_HEAP_START - (TOTAL_LOCAL_MEM + TOTAL_SHARED_MEM);
 
 #if !defined(__CUDA_RUNTIME_API_H__)
 
 #include "builtin_types.h"
 
 struct cudaArray {
-  void *devPtr;
-  int devPtr32;
-  struct cudaChannelFormatDesc desc;
-  int width;
-  int height;
-  int size;  // in bytes
-  unsigned dimensions;
+   void *devPtr;
+   int devPtr32;
+   struct cudaChannelFormatDesc desc;
+   int width;
+   int height;
+   int size; //in bytes
+   unsigned dimensions;
 };
 
 #endif
 
-// Struct that record other attributes in the textureReference declaration
+// Struct that record other attributes in the textureReference declaration 
 // - These attributes are passed thru __cudaRegisterTexture()
 struct textureReferenceAttr {
-  const struct textureReference *m_texref;
-  int m_dim;
-  enum cudaTextureReadMode m_readmode;
-  int m_ext;
-  textureReferenceAttr(const struct textureReference *texref, int dim,
-                       enum cudaTextureReadMode readmode, int ext)
-      : m_texref(texref), m_dim(dim), m_readmode(readmode), m_ext(ext) {}
+    const struct textureReference *m_texref; 
+    int m_dim; 
+    enum cudaTextureReadMode m_readmode; 
+    int m_ext; 
+    textureReferenceAttr(const struct textureReference *texref, 
+                         int dim, 
+                         enum cudaTextureReadMode readmode, 
+                         int ext)
+    : m_texref(texref), m_dim(dim), m_readmode(readmode), m_ext(ext) 
+    {  }
 };
 
-class gpgpu_functional_sim_config {
- public:
-  void reg_options(class OptionParser *opp);
+class gpgpu_functional_sim_config 
+{
+public:
+    void reg_options(class OptionParser * opp);
 
-  void ptx_set_tex_cache_linesize(unsigned linesize);
+    void ptx_set_tex_cache_linesize(unsigned linesize);
 
-  unsigned get_forced_max_capability() const {
-    return m_ptx_force_max_capability;
-  }
-  bool convert_to_ptxplus() const { return m_ptx_convert_to_ptxplus; }
-  bool use_cuobjdump() const { return m_ptx_use_cuobjdump; }
-  bool experimental_lib_support() const { return m_experimental_lib_support; }
+    unsigned get_forced_max_capability() const { return m_ptx_force_max_capability; }
+    bool convert_to_ptxplus() const { return m_ptx_convert_to_ptxplus; }
+    bool use_cuobjdump() const { return m_ptx_use_cuobjdump; }
+    bool experimental_lib_support() const { return m_experimental_lib_support; }
 
-  int get_ptx_inst_debug_to_file() const { return g_ptx_inst_debug_to_file; }
-  const char *get_ptx_inst_debug_file() const { return g_ptx_inst_debug_file; }
-  int get_ptx_inst_debug_thread_uid() const {
-    return g_ptx_inst_debug_thread_uid;
-  }
-  unsigned get_texcache_linesize() const { return m_texcache_linesize; }
-  int get_checkpoint_option() const { return checkpoint_option; }
-  int get_checkpoint_kernel() const { return checkpoint_kernel; }
-  int get_checkpoint_CTA() const { return checkpoint_CTA; }
-  int get_resume_option() const { return resume_option; }
-  int get_resume_kernel() const { return resume_kernel; }
-  int get_resume_CTA() const { return resume_CTA; }
-  int get_checkpoint_CTA_t() const { return checkpoint_CTA_t; }
-  int get_checkpoint_insn_Y() const { return checkpoint_insn_Y; }
+    int         get_ptx_inst_debug_to_file() const { return g_ptx_inst_debug_to_file; }
+    const char* get_ptx_inst_debug_file() const  { return g_ptx_inst_debug_file; }
+    int         get_ptx_inst_debug_thread_uid() const { return g_ptx_inst_debug_thread_uid; }
+    unsigned    get_texcache_linesize() const { return m_texcache_linesize; }
+    int get_checkpoint_option() const {return checkpoint_option; }
+    int get_checkpoint_kernel() const {return checkpoint_kernel; }
+    int get_checkpoint_CTA() const {return checkpoint_CTA; }
+    int get_resume_option() const {return resume_option; }
+    int get_resume_kernel() const {return resume_kernel; }
+    int get_resume_CTA() const {return resume_CTA; }
+    int get_checkpoint_CTA_t() const {return checkpoint_CTA_t; }
+    int get_checkpoint_insn_Y() const {return checkpoint_insn_Y; }
+private:
+    // PTX options
+    int m_ptx_convert_to_ptxplus;
+    int m_ptx_use_cuobjdump;
+    int m_experimental_lib_support;
+    unsigned m_ptx_force_max_capability;
+    int checkpoint_option;
+    int checkpoint_kernel;
+    int checkpoint_CTA;
+    unsigned resume_option;
+    unsigned resume_kernel;
+    unsigned resume_CTA;
+    unsigned checkpoint_CTA_t;
+    int checkpoint_insn_Y;
+    int   g_ptx_inst_debug_to_file;
+    char* g_ptx_inst_debug_file;
+    int   g_ptx_inst_debug_thread_uid;
 
- private:
-  // PTX options
-  int m_ptx_convert_to_ptxplus;
-  int m_ptx_use_cuobjdump;
-  int m_experimental_lib_support;
-  unsigned m_ptx_force_max_capability;
-  int checkpoint_option;
-  int checkpoint_kernel;
-  int checkpoint_CTA;
-  unsigned resume_option;
-  unsigned resume_kernel;
-  unsigned resume_CTA;
-  unsigned checkpoint_CTA_t;
-  int checkpoint_insn_Y;
-  int g_ptx_inst_debug_to_file;
-  char *g_ptx_inst_debug_file;
-  int g_ptx_inst_debug_thread_uid;
-
-  unsigned m_texcache_linesize;
+    unsigned m_texcache_linesize;
 };
+
 
 class gpgpu_t {
- public:
-  gpgpu_t(const gpgpu_functional_sim_config &config, gpgpu_context *ctx);
-  // backward pointer
-  class gpgpu_context *gpgpu_ctx;
-  int checkpoint_option;
-  int checkpoint_kernel;
-  int checkpoint_CTA;
-  unsigned resume_option;
-  unsigned resume_kernel;
-  unsigned resume_CTA;
-  unsigned checkpoint_CTA_t;
-  int checkpoint_insn_Y;
+public:
+    gpgpu_t( const gpgpu_functional_sim_config &config, gpgpu_context* ctx );
+    // backward pointer
+    class gpgpu_context* gpgpu_ctx;
+    int checkpoint_option;
+    int checkpoint_kernel;
+    int checkpoint_CTA;
+    unsigned resume_option;
+    unsigned resume_kernel;
+    unsigned resume_CTA;
+    unsigned checkpoint_CTA_t;
+    int checkpoint_insn_Y;
 
-  // Move some cycle core stats here instead of being global
-  unsigned long long gpu_sim_cycle;
-  unsigned long long gpu_tot_sim_cycle;
+    //Move some cycle core stats here instead of being global
+    unsigned long long  gpu_sim_cycle;
+    unsigned long long  gpu_tot_sim_cycle;
 
-  void *gpu_malloc(size_t size);
-  void *gpu_mallocarray(size_t count);
-  void gpu_memset(size_t dst_start_addr, int c, size_t count);
-  void memcpy_to_gpu(size_t dst_start_addr, const void *src, size_t count);
-  void memcpy_from_gpu(void *dst, size_t src_start_addr, size_t count);
-  void memcpy_gpu_to_gpu(size_t dst, size_t src, size_t count);
 
-  class memory_space *get_global_memory() {
-    return m_global_mem;
-  }
-  class memory_space *get_tex_memory() {
-    return m_tex_mem;
-  }
-  class memory_space *get_surf_memory() {
-    return m_surf_mem;
-  }
+    void* gpu_malloc( size_t size );
+    void* gpu_mallocarray( size_t count );
+    void  gpu_memset( size_t dst_start_addr, int c, size_t count );
+    void  memcpy_to_gpu( size_t dst_start_addr, const void *src, size_t count );
+    void  memcpy_from_gpu( void *dst, size_t src_start_addr, size_t count );
+    void  memcpy_gpu_to_gpu( size_t dst, size_t src, size_t count );
+    
+    class memory_space *get_global_memory() { return m_global_mem; }
+    class memory_space *get_tex_memory() { return m_tex_mem; }
+    class memory_space *get_surf_memory() { return m_surf_mem; }
 
-  void gpgpu_ptx_sim_bindTextureToArray(const struct textureReference *texref,
-                                        const struct cudaArray *array);
-  void gpgpu_ptx_sim_bindNameToTexture(const char *name,
-                                       const struct textureReference *texref,
-                                       int dim, int readmode, int ext);
-  void gpgpu_ptx_sim_unbindTexture(const struct textureReference *texref);
-  const char *gpgpu_ptx_sim_findNamefromTexture(
-      const struct textureReference *texref);
+    void gpgpu_ptx_sim_bindTextureToArray(const struct textureReference* texref, const struct cudaArray* array);
+    void gpgpu_ptx_sim_bindNameToTexture(const char* name, const struct textureReference* texref, int dim, int readmode, int ext);
+    void gpgpu_ptx_sim_unbindTexture(const struct textureReference* texref);
+    const char* gpgpu_ptx_sim_findNamefromTexture(const struct textureReference* texref);
 
-  const struct textureReference *get_texref(const std::string &texname) const {
-    std::map<std::string,
-             std::set<const struct textureReference *> >::const_iterator t =
-        m_NameToTextureRef.find(texname);
-    assert(t != m_NameToTextureRef.end());
-    return *(t->second.begin());
-  }
+    const struct textureReference* get_texref( const std::string &texname ) const
+    {
+        std::map<std::string, std::set<const struct textureReference*> >::const_iterator t=m_NameToTextureRef.find(texname);
+        assert( t != m_NameToTextureRef.end() );
+        return *(t->second.begin());
+    }
 
-  const struct cudaArray *get_texarray(const std::string &texname) const {
-    std::map<std::string, const struct cudaArray *>::const_iterator t =
-        m_NameToCudaArray.find(texname);
-    assert(t != m_NameToCudaArray.end());
-    return t->second;
-  }
+    const struct cudaArray* get_texarray( const std::string &texname ) const
+    {
+        std::map<std::string,const struct cudaArray*>::const_iterator t=m_NameToCudaArray.find(texname);
+        assert(t != m_NameToCudaArray.end());
+        return t->second;
+    }
 
-  const struct textureInfo *get_texinfo(const std::string &texname) const {
-    std::map<std::string, const struct textureInfo *>::const_iterator t =
-        m_NameToTextureInfo.find(texname);
-    assert(t != m_NameToTextureInfo.end());
-    return t->second;
-  }
+    const struct textureInfo* get_texinfo( const std::string &texname ) const
+    {
+        std::map<std::string, const struct textureInfo*>::const_iterator t=m_NameToTextureInfo.find(texname);
+        assert(t != m_NameToTextureInfo.end());
+        return t->second;
+    }
 
-  const struct textureReferenceAttr *get_texattr(
-      const std::string &texname) const {
-    std::map<std::string, const struct textureReferenceAttr *>::const_iterator
-        t = m_NameToAttribute.find(texname);
-    assert(t != m_NameToAttribute.end());
-    return t->second;
-  }
+    const struct textureReferenceAttr* get_texattr( const std::string &texname ) const
+    {
+        std::map<std::string, const struct textureReferenceAttr*>::const_iterator t=m_NameToAttribute.find(texname);
+        assert(t != m_NameToAttribute.end());
+        return t->second;
+    }
 
-  const gpgpu_functional_sim_config &get_config() const {
-    return m_function_model_config;
-  }
-  FILE *get_ptx_inst_debug_file() { return ptx_inst_debug_file; }
+    const gpgpu_functional_sim_config &get_config() const { return m_function_model_config; }
+    FILE* get_ptx_inst_debug_file() { return ptx_inst_debug_file; }
+    
+    //  These maps return the current texture mappings for the GPU at any given time.
+    std::map<std::string, const struct cudaArray*> getNameArrayMapping() {return m_NameToCudaArray;}
+    std::map<std::string, const struct textureInfo*> getNameInfoMapping() {return m_NameToTextureInfo;}
 
-  //  These maps return the current texture mappings for the GPU at any given
-  //  time.
-  std::map<std::string, const struct cudaArray *> getNameArrayMapping() {
-    return m_NameToCudaArray;
-  }
-  std::map<std::string, const struct textureInfo *> getNameInfoMapping() {
-    return m_NameToTextureInfo;
-  }
+protected:
+    const gpgpu_functional_sim_config &m_function_model_config;
+    FILE* ptx_inst_debug_file;
 
- protected:
-  const gpgpu_functional_sim_config &m_function_model_config;
-  FILE *ptx_inst_debug_file;
+    class memory_space *m_global_mem;
+    class memory_space *m_tex_mem;
+    class memory_space *m_surf_mem;
 
-  class memory_space *m_global_mem;
-  class memory_space *m_tex_mem;
-  class memory_space *m_surf_mem;
-
-  unsigned long long m_dev_malloc;
-  //  These maps contain the current texture mappings for the GPU at any given
-  //  time.
-  std::map<std::string, std::set<const struct textureReference *> >
-      m_NameToTextureRef;
-  std::map<const struct textureReference *, std::string> m_TextureRefToName;
-  std::map<std::string, const struct cudaArray *> m_NameToCudaArray;
-  std::map<std::string, const struct textureInfo *> m_NameToTextureInfo;
-  std::map<std::string, const struct textureReferenceAttr *> m_NameToAttribute;
+    unsigned long long m_dev_malloc;
+    //  These maps contain the current texture mappings for the GPU at any given time. 
+    std::map<std::string, std::set<const struct textureReference*> > m_NameToTextureRef;
+    std::map<const struct textureReference*, std::string> m_TextureRefToName;
+    std::map<std::string, const struct cudaArray*> m_NameToCudaArray;
+    std::map<std::string, const struct textureInfo*> m_NameToTextureInfo;
+    std::map<std::string, const struct textureReferenceAttr*> m_NameToAttribute;
 };
 
-struct gpgpu_ptx_sim_info {
-  // Holds properties of the kernel (Kernel's resource use).
-  // These will be set to zero if a ptxinfo file is not present.
-  int lmem;
-  int smem;
-  int cmem;
-  int gmem;
-  int regs;
-  unsigned maxthreads;
-  unsigned ptx_version;
-  unsigned sm_target;
+struct gpgpu_ptx_sim_info
+{
+   // Holds properties of the kernel (Kernel's resource use). 
+   // These will be set to zero if a ptxinfo file is not present.
+   int lmem;
+   int smem;
+   int cmem;
+   int gmem;
+   int regs;
+   unsigned maxthreads;
+   unsigned ptx_version;
+   unsigned sm_target;
 };
+
 
 struct gpgpu_ptx_sim_arg {
-  gpgpu_ptx_sim_arg() { m_start = NULL; }
-  gpgpu_ptx_sim_arg(const void *arg, size_t size, size_t offset) {
-    m_start = arg;
-    m_nbytes = size;
-    m_offset = offset;
-  }
-  const void *m_start;
-  size_t m_nbytes;
-  size_t m_offset;
+   gpgpu_ptx_sim_arg() { m_start=NULL; }
+   gpgpu_ptx_sim_arg(const void *arg, size_t size, size_t offset)
+   {
+      m_start=arg;
+      m_nbytes=size;
+      m_offset=offset;
+   }
+   const void *m_start;
+   size_t m_nbytes;
+   size_t m_offset;
 };
 
 typedef std::list<gpgpu_ptx_sim_arg> gpgpu_ptx_sim_arg_list_t;
 
 class memory_space_t {
- public:
-  memory_space_t() {
-    m_type = undefined_space;
-    m_bank = 0;
-  }
-  memory_space_t(const enum _memory_space_t &from) {
-    m_type = from;
-    m_bank = 0;
-  }
-  bool operator==(const memory_space_t &x) const {
-    return (m_bank == x.m_bank) && (m_type == x.m_type);
-  }
-  bool operator!=(const memory_space_t &x) const { return !(*this == x); }
-  bool operator<(const memory_space_t &x) const {
-    if (m_type < x.m_type)
-      return true;
-    else if (m_type > x.m_type)
+public:
+   memory_space_t() { m_type = undefined_space; m_bank=0; }
+   memory_space_t( const enum _memory_space_t &from ) { m_type = from; m_bank = 0; }
+   bool operator==( const memory_space_t &x ) const { return (m_bank == x.m_bank) && (m_type == x.m_type); }
+   bool operator!=( const memory_space_t &x ) const { return !(*this == x); }
+   bool operator<( const memory_space_t &x ) const 
+   { 
+      if(m_type < x.m_type)
+         return true;
+      else if(m_type > x.m_type)
+         return false;
+      else if( m_bank < x.m_bank )
+         return true; 
       return false;
-    else if (m_bank < x.m_bank)
-      return true;
-    return false;
-  }
-  enum _memory_space_t get_type() const { return m_type; }
-  void set_type(enum _memory_space_t t) { m_type = t; }
-  unsigned get_bank() const { return m_bank; }
-  void set_bank(unsigned b) { m_bank = b; }
-  bool is_const() const {
-    return (m_type == const_space) || (m_type == param_space_kernel);
-  }
-  bool is_local() const {
-    return (m_type == local_space) || (m_type == param_space_local);
-  }
-  bool is_global() const { return (m_type == global_space); }
+   }
+   enum _memory_space_t get_type() const { return m_type; }
+   void set_type( enum _memory_space_t t ) { m_type = t; }
+   unsigned get_bank() const { return m_bank; }
+   void set_bank( unsigned b ) { m_bank = b; }
+   bool is_const() const { return (m_type == const_space) || (m_type == param_space_kernel); }
+   bool is_local() const { return (m_type == local_space) || (m_type == param_space_local); }
+   bool is_global() const { return (m_type == global_space); }
 
- private:
-  enum _memory_space_t m_type;
-  unsigned m_bank;  // n in ".const[n]"; note .const == .const[0] (see PTX 2.1
-                    // manual, sec. 5.1.3)
+private:
+   enum _memory_space_t m_type;
+   unsigned m_bank; // n in ".const[n]"; note .const == .const[0] (see PTX 2.1 manual, sec. 5.1.3)
 };
 
 const unsigned MAX_MEMORY_ACCESS_SIZE = 128;
 typedef std::bitset<MAX_MEMORY_ACCESS_SIZE> mem_access_byte_mask_t;
-const unsigned SECTOR_CHUNCK_SIZE = 4;  // four sectors
-const unsigned SECTOR_SIZE = 32;        // sector is 32 bytes width
+const unsigned SECTOR_CHUNCK_SIZE = 4;   //four sectors
+const unsigned SECTOR_SIZE = 32 ;        //sector is 32 bytes width
 typedef std::bitset<SECTOR_CHUNCK_SIZE> mem_access_sector_mask_t;
 #define NO_PARTIAL_WRITE (mem_access_byte_mask_t())
 
-#define MEM_ACCESS_TYPE_TUP_DEF                                       \
-  MA_TUP_BEGIN(mem_access_type)                                       \
-  MA_TUP(GLOBAL_ACC_R)                                                \
-  , MA_TUP(LOCAL_ACC_R), MA_TUP(CONST_ACC_R), MA_TUP(TEXTURE_ACC_R),  \
-      MA_TUP(GLOBAL_ACC_W), MA_TUP(LOCAL_ACC_W), MA_TUP(L1_WRBK_ACC), \
-      MA_TUP(L2_WRBK_ACC), MA_TUP(INST_ACC_R), MA_TUP(L1_WR_ALLOC_R), \
-      MA_TUP(L2_WR_ALLOC_R),                                          \
-      MA_TUP(NUM_MEM_ACCESS_TYPE) MA_TUP_END(mem_access_type)
+#define MEM_ACCESS_TYPE_TUP_DEF \
+MA_TUP_BEGIN( mem_access_type ) \
+   MA_TUP( GLOBAL_ACC_R ), \
+   MA_TUP( LOCAL_ACC_R ), \
+   MA_TUP( CONST_ACC_R ), \
+   MA_TUP( TEXTURE_ACC_R ), \
+   MA_TUP( GLOBAL_ACC_W ), \
+   MA_TUP( LOCAL_ACC_W ), \
+   MA_TUP( L1_WRBK_ACC ), \
+   MA_TUP( L2_WRBK_ACC ), \
+   MA_TUP( INST_ACC_R ), \
+   MA_TUP( L1_WR_ALLOC_R ), \
+   MA_TUP( L2_WR_ALLOC_R ), \
+   MA_TUP( NUM_MEM_ACCESS_TYPE ) \
+MA_TUP_END( mem_access_type ) 
 
 #define MA_TUP_BEGIN(X) enum X {
 #define MA_TUP(X) X
-#define MA_TUP_END(X) \
-  }                   \
-  ;
+#define MA_TUP_END(X) };
 MEM_ACCESS_TYPE_TUP_DEF
 #undef MA_TUP_BEGIN
 #undef MA_TUP
 #undef MA_TUP_END
 
-const char *mem_access_type_str(enum mem_access_type access_type);
+const char * mem_access_type_str(enum mem_access_type access_type); 
 
 enum cache_operator_type {
-  CACHE_UNDEFINED,
+    CACHE_UNDEFINED, 
 
-  // loads
-  CACHE_ALL,       // .ca
-  CACHE_LAST_USE,  // .lu
-  CACHE_VOLATILE,  // .cv
-  CACHE_L1,        // .nc
+    // loads
+    CACHE_ALL,          // .ca
+    CACHE_LAST_USE,     // .lu
+    CACHE_VOLATILE,     // .cv
+    CACHE_L1,     // .nc
+                       
+    // loads and stores 
+    CACHE_STREAMING,    // .cs
+    CACHE_GLOBAL,       // .cg
 
-  // loads and stores
-  CACHE_STREAMING,  // .cs
-  CACHE_GLOBAL,     // .cg
-
-  // stores
-  CACHE_WRITE_BACK,    // .wb
-  CACHE_WRITE_THROUGH  // .wt
+    // stores
+    CACHE_WRITE_BACK,   // .wb
+    CACHE_WRITE_THROUGH // .wt
 };
 
 class mem_access_t {
- public:
-  mem_access_t(gpgpu_context *ctx) { init(ctx); }
-  mem_access_t(mem_access_type type, new_addr_type address, unsigned size,
-               bool wr, gpgpu_context *ctx) {
-    init(ctx);
-    m_type = type;
-    m_addr = address;
-    m_req_size = size;
-    m_write = wr;
-  }
-  mem_access_t(mem_access_type type, new_addr_type address, unsigned size,
-               bool wr, const active_mask_t &active_mask,
-               const mem_access_byte_mask_t &byte_mask,
-               const mem_access_sector_mask_t &sector_mask, gpgpu_context *ctx)
-      : m_warp_mask(active_mask),
-        m_byte_mask(byte_mask),
-        m_sector_mask(sector_mask) {
-    init(ctx);
-    m_type = type;
-    m_addr = address;
-    m_req_size = size;
-    m_write = wr;
-  }
+public:
+   mem_access_t(gpgpu_context* ctx) { init(ctx); }
+   mem_access_t( mem_access_type type, 
+                 new_addr_type address, 
+                 unsigned size,
+                 bool wr,
+		 gpgpu_context* ctx)
+   {
+       init(ctx);
+       m_type = type;
+       m_addr = address;
+       m_req_size = size;
+       m_write = wr;
+   }
+   mem_access_t( mem_access_type type, 
+                 new_addr_type address, 
+                 unsigned size, 
+                 bool wr, 
+                 const active_mask_t &active_mask,
+                 const mem_access_byte_mask_t &byte_mask,
+		 const mem_access_sector_mask_t &sector_mask,
+		 gpgpu_context* ctx)
+    : m_warp_mask(active_mask), m_byte_mask(byte_mask), m_sector_mask(sector_mask)
+   {
+      init(ctx);
+      m_type = type;
+      m_addr = address;
+      m_req_size = size;
+      m_write = wr;
+   }
 
-  new_addr_type get_addr() const { return m_addr; }
-  void set_addr(new_addr_type addr) { m_addr = addr; }
-  unsigned get_size() const { return m_req_size; }
-  const active_mask_t &get_warp_mask() const { return m_warp_mask; }
-  bool is_write() const { return m_write; }
-  enum mem_access_type get_type() const { return m_type; }
-  mem_access_byte_mask_t get_byte_mask() const { return m_byte_mask; }
-  mem_access_sector_mask_t get_sector_mask() const { return m_sector_mask; }
+   new_addr_type get_addr() const { return m_addr; }
+   void set_addr(new_addr_type addr) {m_addr=addr;}
+   unsigned get_size() const { return m_req_size; }
+   const active_mask_t &get_warp_mask() const { return m_warp_mask; }
+   bool is_write() const { return m_write; }
+   enum mem_access_type get_type() const { return m_type; }
+   mem_access_byte_mask_t get_byte_mask() const { return m_byte_mask; }
+   mem_access_sector_mask_t get_sector_mask() const { return m_sector_mask; }
 
-  void print(FILE *fp) const {
-    fprintf(fp, "addr=0x%llx, %s, size=%u, ", m_addr,
-            m_write ? "store" : "load ", m_req_size);
-    switch (m_type) {
-      case GLOBAL_ACC_R:
-        fprintf(fp, "GLOBAL_R");
-        break;
-      case LOCAL_ACC_R:
-        fprintf(fp, "LOCAL_R ");
-        break;
-      case CONST_ACC_R:
-        fprintf(fp, "CONST   ");
-        break;
-      case TEXTURE_ACC_R:
-        fprintf(fp, "TEXTURE ");
-        break;
-      case GLOBAL_ACC_W:
-        fprintf(fp, "GLOBAL_W");
-        break;
-      case LOCAL_ACC_W:
-        fprintf(fp, "LOCAL_W ");
-        break;
-      case L2_WRBK_ACC:
-        fprintf(fp, "L2_WRBK ");
-        break;
-      case INST_ACC_R:
-        fprintf(fp, "INST    ");
-        break;
-      case L1_WRBK_ACC:
-        fprintf(fp, "L1_WRBK ");
-        break;
-      default:
-        fprintf(fp, "unknown ");
-        break;
-    }
-  }
+   void print(FILE *fp) const
+   {
+       fprintf(fp,"addr=0x%llx, %s, size=%u, ", m_addr, m_write?"store":"load ", m_req_size );
+       switch(m_type) {
+       case GLOBAL_ACC_R:  fprintf(fp,"GLOBAL_R"); break;
+       case LOCAL_ACC_R:   fprintf(fp,"LOCAL_R "); break;
+       case CONST_ACC_R:   fprintf(fp,"CONST   "); break;
+       case TEXTURE_ACC_R: fprintf(fp,"TEXTURE "); break;
+       case GLOBAL_ACC_W:  fprintf(fp,"GLOBAL_W"); break;
+       case LOCAL_ACC_W:   fprintf(fp,"LOCAL_W "); break;
+       case L2_WRBK_ACC:   fprintf(fp,"L2_WRBK "); break;
+       case INST_ACC_R:    fprintf(fp,"INST    "); break;
+       case L1_WRBK_ACC:   fprintf(fp,"L1_WRBK "); break;
+       default:            fprintf(fp,"unknown "); break;
+       }
+   }
 
-  gpgpu_context *gpgpu_ctx;
+   gpgpu_context* gpgpu_ctx;
+private:
+   void init(gpgpu_context* ctx);
 
- private:
-  void init(gpgpu_context *ctx);
-
-  unsigned m_uid;
-  new_addr_type m_addr;  // request address
-  bool m_write;
-  unsigned m_req_size;  // bytes
-  mem_access_type m_type;
-  active_mask_t m_warp_mask;
-  mem_access_byte_mask_t m_byte_mask;
-  mem_access_sector_mask_t m_sector_mask;
+   unsigned      m_uid;
+   new_addr_type m_addr;     // request address
+   bool          m_write;
+   unsigned      m_req_size; // bytes
+   mem_access_type m_type;
+   active_mask_t m_warp_mask;
+   mem_access_byte_mask_t m_byte_mask;
+   mem_access_sector_mask_t m_sector_mask;
 };
 
 class mem_fetch;
 
 class mem_fetch_interface {
- public:
-  virtual bool full(unsigned size, bool write) const = 0;
-  virtual void push(mem_fetch *mf) = 0;
+public:
+    virtual bool full( unsigned size, bool write ) const = 0;
+    virtual void push( mem_fetch *mf ) = 0;
 };
 
 class mem_fetch_allocator {
- public:
-  virtual mem_fetch *alloc(new_addr_type addr, mem_access_type type,
-                           unsigned size, bool wr,
-                           unsigned long long cycle) const = 0;
-  virtual mem_fetch *alloc(const class warp_inst_t &inst,
-                           const mem_access_t &access,
-                           unsigned long long cycle) const = 0;
+public:
+    virtual mem_fetch *alloc( new_addr_type addr, mem_access_type type, unsigned size, bool wr, unsigned long long cycle ) const = 0;
+    virtual mem_fetch *alloc( const class warp_inst_t &inst, const mem_access_t &access, unsigned long long cycle ) const = 0;
 };
 
-// the maximum number of destination, source, or address uarch operands in a
-// instruction
-#define MAX_REG_OPERANDS 32
+// the maximum number of destination, source, or address uarch operands in a instruction
+#define MAX_REG_OPERANDS 32 
 
 struct dram_callback_t {
-  dram_callback_t() {
-    function = NULL;
-    instruction = NULL;
-    thread = NULL;
-  }
-  void (*function)(const class inst_t *, class ptx_thread_info *);
+   dram_callback_t() { function=NULL; instruction=NULL; thread=NULL; }
+   void (*function)(const class inst_t*, class ptx_thread_info*);
 
-  const class inst_t *instruction;
-  class ptx_thread_info *thread;
+   const class inst_t* instruction;
+   class ptx_thread_info *thread;
 };
 
 class inst_t {
- public:
-  inst_t() {
-    m_decoded = false;
-    pc = (address_type)-1;
-    reconvergence_pc = (address_type)-1;
-    op = NO_OP;
-    bar_type = NOT_BAR;
-    red_type = NOT_RED;
-    bar_id = (unsigned)-1;
-    bar_count = (unsigned)-1;
-    oprnd_type = UN_OP;
-    sp_op = OTHER_OP;
-    op_pipe = UNKOWN_OP;
-    mem_op = NOT_TEX;
-    num_operands = 0;
-    num_regs = 0;
-    memset(out, 0, sizeof(unsigned));
-    memset(in, 0, sizeof(unsigned));
-    is_vectorin = 0;
-    is_vectorout = 0;
-    space = memory_space_t();
-    cache_op = CACHE_UNDEFINED;
-    latency = 1;
-    initiation_interval = 1;
-    for (unsigned i = 0; i < MAX_REG_OPERANDS; i++) {
-      arch_reg.src[i] = -1;
-      arch_reg.dst[i] = -1;
+public:
+    inst_t()
+    {
+        m_decoded=false;
+        pc=(address_type)-1;
+        reconvergence_pc=(address_type)-1;
+        op=NO_OP;
+        bar_type=NOT_BAR;
+        red_type=NOT_RED;
+        bar_id=(unsigned)-1;
+        bar_count=(unsigned)-1;
+        oprnd_type=UN_OP;
+        sp_op=OTHER_OP;
+        op_pipe=UNKOWN_OP;
+        mem_op=NOT_TEX;
+        num_operands=0;
+        num_regs=0;
+        memset(out, 0, sizeof(unsigned)); 
+        memset(in, 0, sizeof(unsigned)); 
+        is_vectorin=0; 
+        is_vectorout=0;
+        space = memory_space_t();
+        cache_op = CACHE_UNDEFINED;
+        latency = 1;
+        initiation_interval = 1;
+        for( unsigned i=0; i < MAX_REG_OPERANDS; i++ ) {
+            arch_reg.src[i] = -1;
+            arch_reg.dst[i] = -1;
+        }
+        isize=0;
     }
-    isize = 0;
-  }
-  bool valid() const { return m_decoded; }
-  virtual void print_insn(FILE *fp) const {
-    fprintf(fp, " [inst @ pc=0x%04x] ", pc);
-  }
-  bool is_load() const {
-    return (op == LOAD_OP || op == TENSOR_CORE_LOAD_OP ||
-            memory_op == memory_load);
-  }
-  bool is_store() const {
-    return (op == STORE_OP || op == TENSOR_CORE_STORE_OP ||
-            memory_op == memory_store);
-  }
-  unsigned get_num_operands() const { return num_operands; }
-  unsigned get_num_regs() const { return num_regs; }
-  void set_num_regs(unsigned num) { num_regs = num; }
-  void set_num_operands(unsigned num) { num_operands = num; }
-  void set_bar_id(unsigned id) { bar_id = id; }
-  void set_bar_count(unsigned count) { bar_count = count; }
+    bool valid() const { return m_decoded; }
+    virtual void print_insn( FILE *fp ) const 
+    {
+        fprintf(fp," [inst @ pc=0x%04x] ", pc );
+    }
+    bool is_load() const { return (op == LOAD_OP ||op==TENSOR_CORE_LOAD_OP || memory_op == memory_load); }
+    bool is_store() const { return (op == STORE_OP ||op==TENSOR_CORE_STORE_OP || memory_op == memory_store); }
+    unsigned get_num_operands() const {return num_operands;}
+    unsigned get_num_regs() const {return num_regs;}
+    void set_num_regs(unsigned num) {num_regs=num;}
+    void set_num_operands(unsigned num) {num_operands=num;}
+    void set_bar_id(unsigned id) {bar_id=id;}
+    void set_bar_count(unsigned count) {bar_count=count;}
 
-  address_type pc;  // program counter address of instruction
-  unsigned isize;   // size of instruction in bytes
-  op_type op;       // opcode (uarch visible)
+    address_type pc;        // program counter address of instruction
+    unsigned isize;         // size of instruction in bytes 
+    op_type op;             // opcode (uarch visible)
 
-  barrier_type bar_type;
-  reduction_type red_type;
-  unsigned bar_id;
-  unsigned bar_count;
+    barrier_type bar_type;
+    reduction_type red_type;
+    unsigned bar_id;
+    unsigned bar_count;
 
-  types_of_operands oprnd_type;  // code (uarch visible) identify if the
-                                 // operation is an interger or a floating point
-  special_ops
-      sp_op;  // code (uarch visible) identify if int_alu, fp_alu, int_mul ....
-  operation_pipeline op_pipe;  // code (uarch visible) identify the pipeline of
-                               // the operation (SP, SFU or MEM)
-  mem_operation mem_op;        // code (uarch visible) identify memory type
-  _memory_op_t memory_op;      // memory_op used by ptxplus
-  unsigned num_operands;
-  unsigned num_regs;  // count vector operand as one register operand
+    types_of_operands oprnd_type;     // code (uarch visible) identify if the operation is an interger or a floating point
+    special_ops sp_op;           // code (uarch visible) identify if int_alu, fp_alu, int_mul ....
+    operation_pipeline op_pipe;  // code (uarch visible) identify the pipeline of the operation (SP, SFU or MEM)
+    mem_operation mem_op;        // code (uarch visible) identify memory type
+    _memory_op_t memory_op; // memory_op used by ptxplus 
+    unsigned num_operands;
+    unsigned num_regs; // count vector operand as one register operand
 
-  address_type reconvergence_pc;  // -1 => not a branch, -2 => use function
-                                  // return address
+    address_type reconvergence_pc; // -1 => not a branch, -2 => use function return address
+    
+    unsigned out[8];
+    unsigned outcount;
+    unsigned in[24];
+    unsigned incount;
+    unsigned char is_vectorin;
+    unsigned char is_vectorout;
+    int pred; // predicate register number
+    int ar1, ar2;
+    // register number for bank conflict evaluation
+    struct {
+        int dst[MAX_REG_OPERANDS];
+        int src[MAX_REG_OPERANDS];
+    } arch_reg;
+    //int arch_reg[MAX_REG_OPERANDS]; // register number for bank conflict evaluation
+    unsigned latency; // operation latency
+    unsigned initiation_interval;
 
-  unsigned out[8];
-  unsigned outcount;
-  unsigned in[24];
-  unsigned incount;
-  unsigned char is_vectorin;
-  unsigned char is_vectorout;
-  int pred;  // predicate register number
-  int ar1, ar2;
-  // register number for bank conflict evaluation
-  struct {
-    int dst[MAX_REG_OPERANDS];
-    int src[MAX_REG_OPERANDS];
-  } arch_reg;
-  // int arch_reg[MAX_REG_OPERANDS]; // register number for bank conflict
-  // evaluation
-  unsigned latency;  // operation latency
-  unsigned initiation_interval;
+    unsigned data_size; // what is the size of the word being operated on?
+    memory_space_t space;
+    cache_operator_type cache_op;
 
-  unsigned data_size;  // what is the size of the word being operated on?
-  memory_space_t space;
-  cache_operator_type cache_op;
-
- protected:
-  bool m_decoded;
-  virtual void pre_decode() {}
+protected:
+    bool m_decoded;
+    virtual void pre_decode() {}
 };
 
-enum divergence_support_t { POST_DOMINATOR = 1, NUM_SIMD_MODEL };
+enum divergence_support_t {
+   POST_DOMINATOR = 1,
+   NUM_SIMD_MODEL
+};
 
 const unsigned MAX_ACCESSES_PER_INSN_PER_THREAD = 8;
 
-class warp_inst_t : public inst_t {
- public:
-  // constructors
-  warp_inst_t() {
-    m_uid = 0;
-    m_empty = true;
-    m_config = NULL;
-  }
-  warp_inst_t(const core_config *config) {
-    m_uid = 0;
-    assert(config->warp_size <= MAX_WARP_SIZE);
-    m_config = config;
-    m_empty = true;
-    m_isatomic = false;
-    m_per_scalar_thread_valid = false;
-    m_mem_accesses_created = false;
-    m_cache_hit = false;
-    m_is_printf = false;
-    m_is_cdp = 0;
-  }
-  virtual ~warp_inst_t() {}
-
-  // modifiers
-  void broadcast_barrier_reduction(const active_mask_t &access_mask);
-  void do_atomic(bool forceDo = false);
-  void do_atomic(const active_mask_t &access_mask, bool forceDo = false);
-  void clear() { m_empty = true; }
-
-  void issue(const active_mask_t &mask, unsigned warp_id,
-             unsigned long long cycle, int dynamic_warp_id, int sch_id);
-
-  const active_mask_t &get_active_mask() const { return m_warp_active_mask; }
-  void completed(unsigned long long cycle)
-      const;  // stat collection: called when the instruction is completed
-
-  void set_addr(unsigned n, new_addr_type addr) {
-    if (!m_per_scalar_thread_valid) {
-      m_per_scalar_thread.resize(m_config->warp_size);
-      m_per_scalar_thread_valid = true;
+class warp_inst_t: public inst_t {
+public:
+    // constructors
+    warp_inst_t() 
+    {
+        m_uid=0;
+        m_empty=true; 
+        m_config=NULL; 
     }
-    m_per_scalar_thread[n].memreqaddr[0] = addr;
-  }
-  void set_addr(unsigned n, new_addr_type *addr, unsigned num_addrs) {
-    if (!m_per_scalar_thread_valid) {
-      m_per_scalar_thread.resize(m_config->warp_size);
-      m_per_scalar_thread_valid = true;
+    warp_inst_t( const core_config *config )
+    { 
+        m_uid=0;
+        assert(config->warp_size<=MAX_WARP_SIZE); 
+        m_config=config;
+        m_empty=true; 
+        m_isatomic=false;
+        m_per_scalar_thread_valid=false;
+        m_mem_accesses_created=false;
+        m_cache_hit=false;
+        m_is_printf=false;
+        m_is_cdp = 0;
     }
-    assert(num_addrs <= MAX_ACCESSES_PER_INSN_PER_THREAD);
-    for (unsigned i = 0; i < num_addrs; i++)
-      m_per_scalar_thread[n].memreqaddr[i] = addr[i];
-  }
-  void print_m_accessq() {
-    if (accessq_empty())
-      return;
-    else {
-      printf("Printing mem access generated\n");
-      std::list<mem_access_t>::iterator it;
-      for (it = m_accessq.begin(); it != m_accessq.end(); ++it) {
-        printf("MEM_TXN_GEN:%s:%llx, Size:%d \n",
-               mem_access_type_str(it->get_type()), it->get_addr(),
-               it->get_size());
-      }
+    virtual ~warp_inst_t(){
     }
-  }
-  struct transaction_info {
-    std::bitset<4> chunks;  // bitmask: 32-byte chunks accessed
-    mem_access_byte_mask_t bytes;
-    active_mask_t active;  // threads in this transaction
 
-    bool test_bytes(unsigned start_bit, unsigned end_bit) {
-      for (unsigned i = start_bit; i <= end_bit; i++)
-        if (bytes.test(i)) return true;
-      return false;
+    // modifiers
+    void broadcast_barrier_reduction( const active_mask_t& access_mask);
+    void do_atomic(bool forceDo=false);
+    void do_atomic( const active_mask_t& access_mask, bool forceDo=false );
+    void clear() 
+    { 
+        m_empty=true; 
     }
-  };
 
-  void generate_mem_accesses();
-  void memory_coalescing_arch(bool is_write, mem_access_type access_type);
-  void memory_coalescing_arch_atomic(bool is_write,
-                                     mem_access_type access_type);
-  void memory_coalescing_arch_reduce_and_send(bool is_write,
-                                              mem_access_type access_type,
-                                              const transaction_info &info,
-                                              new_addr_type addr,
-                                              unsigned segment_size);
+    void issue( const active_mask_t &mask, unsigned warp_id, unsigned long long cycle, int dynamic_warp_id, int sch_id );
 
-  void add_callback(unsigned lane_id, void (*function)(const class inst_t *,
-                                                       class ptx_thread_info *),
-                    const inst_t *inst, class ptx_thread_info *thread,
-                    bool atomic) {
-    if (!m_per_scalar_thread_valid) {
-      m_per_scalar_thread.resize(m_config->warp_size);
-      m_per_scalar_thread_valid = true;
-      if (atomic) m_isatomic = true;
+    const active_mask_t & get_active_mask() const
+    {
+    	return m_warp_active_mask;
     }
-    m_per_scalar_thread[lane_id].callback.function = function;
-    m_per_scalar_thread[lane_id].callback.instruction = inst;
-    m_per_scalar_thread[lane_id].callback.thread = thread;
-  }
-  void set_active(const active_mask_t &active);
+    void completed( unsigned long long cycle ) const;  // stat collection: called when the instruction is completed  
 
-  void clear_active(const active_mask_t &inactive);
-  void set_not_active(unsigned lane_id);
-
-  // accessors
-  virtual void print_insn(FILE *fp) const {
-    fprintf(fp, " [inst @ pc=0x%04x] ", pc);
-    for (int i = (int)m_config->warp_size - 1; i >= 0; i--)
-      fprintf(fp, "%c", ((m_warp_active_mask[i]) ? '1' : '0'));
-  }
-  bool active(unsigned thread) const { return m_warp_active_mask.test(thread); }
-  unsigned active_count() const { return m_warp_active_mask.count(); }
-  unsigned issued_count() const {
-    assert(m_empty == false);
-    return m_warp_issued_mask.count();
-  }  // for instruction counting
-  bool empty() const { return m_empty; }
-  unsigned warp_id() const {
-    assert(!m_empty);
-    return m_warp_id;
-  }
-  unsigned warp_id_func() const  // to be used in functional simulations only
-  {
-    return m_warp_id;
-  }
-  unsigned dynamic_warp_id() const {
-    assert(!m_empty);
-    return m_dynamic_warp_id;
-  }
-  bool has_callback(unsigned n) const {
-    return m_warp_active_mask[n] && m_per_scalar_thread_valid &&
-           (m_per_scalar_thread[n].callback.function != NULL);
-  }
-  new_addr_type get_addr(unsigned n) const {
-    assert(m_per_scalar_thread_valid);
-    return m_per_scalar_thread[n].memreqaddr[0];
-  }
-
-  bool isatomic() const { return m_isatomic; }
-
-  unsigned warp_size() const { return m_config->warp_size; }
-
-  bool accessq_empty() const { return m_accessq.empty(); }
-  unsigned accessq_count() const { return m_accessq.size(); }
-  const mem_access_t &accessq_back() { return m_accessq.back(); }
-  void accessq_pop_back() { m_accessq.pop_back(); }
-
-  bool dispatch_delay() {
-    if (cycles > 0) cycles--;
-    return cycles > 0;
-  }
-
-  bool has_dispatch_delay() { return cycles > 0; }
-
-  void print(FILE *fout) const;
-  unsigned get_uid() const { return m_uid; }
-  unsigned get_schd_id() const { return m_scheduler_id; }
-
- protected:
-  unsigned m_uid;
-  bool m_empty;
-  bool m_cache_hit;
-  unsigned long long issue_cycle;
-  unsigned cycles;  // used for implementing initiation interval delay
-  bool m_isatomic;
-  bool m_is_printf;
-  unsigned m_warp_id;
-  unsigned m_dynamic_warp_id;
-  const core_config *m_config;
-  active_mask_t m_warp_active_mask;  // dynamic active mask for timing model
-                                     // (after predication)
-  active_mask_t m_warp_issued_mask;  // active mask at issue (prior to
-                                     // predication test) -- for instruction
-                                     // counting
-
-  struct per_thread_info {
-    per_thread_info() {
-      for (unsigned i = 0; i < MAX_ACCESSES_PER_INSN_PER_THREAD; i++)
-        memreqaddr[i] = 0;
+    void set_addr( unsigned n, new_addr_type addr ) 
+    {
+        if( !m_per_scalar_thread_valid ) {
+            m_per_scalar_thread.resize(m_config->warp_size);
+            m_per_scalar_thread_valid=true;
+        }
+        m_per_scalar_thread[n].memreqaddr[0] = addr;
     }
-    dram_callback_t callback;
-    new_addr_type memreqaddr[MAX_ACCESSES_PER_INSN_PER_THREAD];  // effective
-                                                                 // address,
-                                                                 // upto 8
-                                                                 // different
-                                                                 // requests (to
-                                                                 // support 32B
-                                                                 // access in 8
-                                                                 // chunks of 4B
-                                                                 // each)
-  };
-  bool m_per_scalar_thread_valid;
-  std::vector<per_thread_info> m_per_scalar_thread;
-  bool m_mem_accesses_created;
-  std::list<mem_access_t> m_accessq;
+    void set_addr( unsigned n, new_addr_type* addr, unsigned num_addrs )
+    {
+        if( !m_per_scalar_thread_valid ) {
+            m_per_scalar_thread.resize(m_config->warp_size);
+            m_per_scalar_thread_valid=true;
+        }
+        assert(num_addrs <= MAX_ACCESSES_PER_INSN_PER_THREAD);
+        for(unsigned i=0; i<num_addrs; i++)
+            m_per_scalar_thread[n].memreqaddr[i] = addr[i];
+    }
+    void print_m_accessq(){
+    		
+		if(accessq_empty())
+			return;
+		else{
+			printf("Printing mem access generated\n");
+			std::list<mem_access_t>::iterator it;	
+			for (it = m_accessq.begin(); it != m_accessq.end(); ++it){
+   				 printf("MEM_TXN_GEN:%s:%llx, Size:%d \n",mem_access_type_str(it->get_type()), it->get_addr(),it->get_size());
+			}	
+		}
+    }   
+    struct transaction_info {
+        std::bitset<4> chunks; // bitmask: 32-byte chunks accessed
+        mem_access_byte_mask_t bytes;
+        active_mask_t active; // threads in this transaction
 
-  unsigned m_scheduler_id;  // the scheduler that issues this inst
+        bool test_bytes(unsigned start_bit, unsigned end_bit) {
+           for( unsigned i=start_bit; i<=end_bit; i++ )
+              if(bytes.test(i))
+                 return true;
+           return false;
+        }
+    };
 
-  // Jin: cdp support
- public:
-  int m_is_cdp;
+    void generate_mem_accesses();
+    void memory_coalescing_arch( bool is_write, mem_access_type access_type );
+    void memory_coalescing_arch_atomic( bool is_write, mem_access_type access_type );
+    void memory_coalescing_arch_reduce_and_send( bool is_write, mem_access_type access_type, const transaction_info &info, new_addr_type addr, unsigned segment_size );
+
+    void add_callback( unsigned lane_id, 
+                       void (*function)(const class inst_t*, class ptx_thread_info*),
+                       const inst_t *inst, 
+                       class ptx_thread_info *thread,
+                       bool atomic)
+    {
+        if( !m_per_scalar_thread_valid ) {
+            m_per_scalar_thread.resize(m_config->warp_size);
+            m_per_scalar_thread_valid=true;
+            if(atomic) m_isatomic=true;
+        }
+        m_per_scalar_thread[lane_id].callback.function = function;
+        m_per_scalar_thread[lane_id].callback.instruction = inst;
+        m_per_scalar_thread[lane_id].callback.thread = thread;
+    }
+    void set_active( const active_mask_t &active );
+
+    void clear_active( const active_mask_t &inactive );
+    void set_not_active( unsigned lane_id );
+
+    // accessors
+    virtual void print_insn(FILE *fp) const 
+    {
+        fprintf(fp," [inst @ pc=0x%04x] ", pc );
+        for (int i=(int)m_config->warp_size-1; i>=0; i--)
+            fprintf(fp, "%c", ((m_warp_active_mask[i])?'1':'0') );
+    }
+    bool active( unsigned thread ) const { return m_warp_active_mask.test(thread); }
+    unsigned active_count() const { return m_warp_active_mask.count(); }
+    unsigned issued_count() const { assert(m_empty == false); return m_warp_issued_mask.count(); }  // for instruction counting 
+    bool empty() const { return m_empty; }
+    unsigned warp_id() const 
+    { 
+        assert( !m_empty );
+        return m_warp_id; 
+    }
+    unsigned warp_id_func() const // to be used in functional simulations only
+    { 
+        return m_warp_id; 
+    }
+    unsigned dynamic_warp_id() const 
+    { 
+        assert( !m_empty );
+        return m_dynamic_warp_id; 
+    }
+    bool has_callback( unsigned n ) const
+    {
+        return m_warp_active_mask[n] && m_per_scalar_thread_valid && 
+            (m_per_scalar_thread[n].callback.function!=NULL);
+    }
+    new_addr_type get_addr( unsigned n ) const
+    {
+        assert( m_per_scalar_thread_valid );
+        return m_per_scalar_thread[n].memreqaddr[0];
+    }
+
+    bool isatomic() const { return m_isatomic; }
+
+    unsigned warp_size() const { return m_config->warp_size; }
+
+    bool accessq_empty() const { return m_accessq.empty(); }
+    unsigned accessq_count() const { return m_accessq.size(); }
+    const mem_access_t &accessq_back() { return m_accessq.back(); }
+    void accessq_pop_back() { m_accessq.pop_back(); }
+
+    bool dispatch_delay()
+    { 
+        if( cycles > 0 ) 
+            cycles--;
+        return cycles > 0;
+    }
+
+    bool has_dispatch_delay(){
+    	return cycles > 0;
+    }
+
+    void print( FILE *fout ) const;
+    unsigned get_uid() const { return m_uid; }
+    unsigned get_schd_id() const { return m_scheduler_id; }
+
+protected:
+
+    unsigned m_uid;
+    bool m_empty;
+    bool m_cache_hit;
+    unsigned long long issue_cycle;
+    unsigned cycles; // used for implementing initiation interval delay
+    bool m_isatomic;
+    bool m_is_printf;
+    unsigned m_warp_id;
+    unsigned m_dynamic_warp_id; 
+    const core_config *m_config; 
+    active_mask_t m_warp_active_mask; // dynamic active mask for timing model (after predication)
+    active_mask_t m_warp_issued_mask; // active mask at issue (prior to predication test) -- for instruction counting
+
+    struct per_thread_info {
+        per_thread_info() {
+            for(unsigned i=0; i<MAX_ACCESSES_PER_INSN_PER_THREAD; i++)
+                memreqaddr[i] = 0;
+        }
+        dram_callback_t callback;
+        new_addr_type memreqaddr[MAX_ACCESSES_PER_INSN_PER_THREAD]; // effective address, upto 8 different requests (to support 32B access in 8 chunks of 4B each)
+    };
+    bool m_per_scalar_thread_valid;
+    std::vector<per_thread_info> m_per_scalar_thread;
+    bool m_mem_accesses_created;
+    std::list<mem_access_t> m_accessq;
+
+    unsigned m_scheduler_id;  //the scheduler that issues this inst
+
+    //Jin: cdp support
+public:
+    int m_is_cdp;
+    
 };
 
-void move_warp(warp_inst_t *&dst, warp_inst_t *&src);
+void move_warp( warp_inst_t *&dst, warp_inst_t *&src );
 
-size_t get_kernel_code_size(class function_info *entry);
-class checkpoint {
- public:
-  checkpoint();
-  ~checkpoint() { printf("clasfsfss destructed\n"); }
+size_t get_kernel_code_size( class function_info *entry );
+class checkpoint
+{    
+public:
 
-  void load_global_mem(class memory_space *temp_mem, char *f1name);
-  void store_global_mem(class memory_space *mem, char *fname, char *format);
-  unsigned radnom;
+     checkpoint();
+    ~checkpoint(){
+      printf("clasfsfss destructed\n");
+    }
+
+    void load_global_mem(class memory_space *temp_mem, char * f1name);
+    void store_global_mem(class memory_space *mem, char * fname , char * format);
+    unsigned radnom;
+
+
 };
 /*
- * This abstract class used as a base for functional and performance and
- * simulation, it has basic functional simulation
- * data structures and procedures.
+ * This abstract class used as a base for functional and performance and simulation, it has basic functional simulation
+ * data structures and procedures. 
  */
 class core_t {
- public:
-  core_t(gpgpu_sim *gpu, kernel_info_t *kernel, unsigned warp_size,
-         unsigned threads_per_shader)
-      : m_gpu(gpu),
-        m_kernel(kernel),
-        m_simt_stack(NULL),
-        m_thread(NULL),
-        m_warp_size(warp_size) {
-    m_warp_count = threads_per_shader / m_warp_size;
-    // Handle the case where the number of threads is not a
-    // multiple of the warp size
-    if (threads_per_shader % m_warp_size != 0) {
-      m_warp_count += 1;
-    }
-    assert(m_warp_count * m_warp_size > 0);
-    m_thread = (ptx_thread_info **)calloc(m_warp_count * m_warp_size,
-                                          sizeof(ptx_thread_info *));
-    initilizeSIMTStack(m_warp_count, m_warp_size);
+    public:
+        core_t( gpgpu_sim *gpu, 
+                kernel_info_t *kernel,
+                unsigned warp_size,
+                unsigned threads_per_shader )
+            : m_gpu( gpu ),
+              m_kernel( kernel ),
+              m_simt_stack( NULL ),
+              m_thread( NULL ),
+              m_warp_size( warp_size )
+        {
+            m_warp_count = threads_per_shader/m_warp_size;
+            // Handle the case where the number of threads is not a
+            // multiple of the warp size
+            if ( threads_per_shader % m_warp_size != 0 ) {
+                m_warp_count += 1;
+            }
+            assert( m_warp_count * m_warp_size > 0 );
+            m_thread = ( ptx_thread_info** )
+                     calloc( m_warp_count * m_warp_size,
+                             sizeof( ptx_thread_info* ) );
+            initilizeSIMTStack(m_warp_count,m_warp_size);
 
-    for (unsigned i = 0; i < MAX_CTA_PER_SHADER; i++) {
-      for (unsigned j = 0; j < MAX_BARRIERS_PER_CTA; j++) {
-        reduction_storage[i][j] = 0;
-      }
-    }
-  }
-  virtual ~core_t() { free(m_thread); }
-  virtual void warp_exit(unsigned warp_id) = 0;
-  virtual bool warp_waiting_at_barrier(unsigned warp_id) const = 0;
-  virtual void checkExecutionStatusAndUpdate(warp_inst_t &inst, unsigned t,
-                                             unsigned tid) = 0;
-  class gpgpu_sim *get_gpu() {
-    return m_gpu;
-  }
-  void execute_warp_inst_t(warp_inst_t &inst, unsigned warpId = (unsigned)-1);
-  bool ptx_thread_done(unsigned hw_thread_id) const;
-  void updateSIMTStack(unsigned warpId, warp_inst_t *inst);
-  void initilizeSIMTStack(unsigned warp_count, unsigned warps_size);
-  void deleteSIMTStack();
-  warp_inst_t getExecuteWarp(unsigned warpId);
-  void get_pdom_stack_top_info(unsigned warpId, unsigned *pc,
-                               unsigned *rpc) const;
-  kernel_info_t *get_kernel_info() { return m_kernel; }
-  class ptx_thread_info **get_thread_info() {
-    return m_thread;
-  }
-  unsigned get_warp_size() const { return m_warp_size; }
-  void and_reduction(unsigned ctaid, unsigned barid, bool value) {
-    reduction_storage[ctaid][barid] &= value;
-  }
-  void or_reduction(unsigned ctaid, unsigned barid, bool value) {
-    reduction_storage[ctaid][barid] |= value;
-  }
-  void popc_reduction(unsigned ctaid, unsigned barid, bool value) {
-    reduction_storage[ctaid][barid] += value;
-  }
-  unsigned get_reduction_value(unsigned ctaid, unsigned barid) {
-    return reduction_storage[ctaid][barid];
-  }
+            for(unsigned i=0; i<MAX_CTA_PER_SHADER; i++){
+            	for(unsigned j=0; j<MAX_BARRIERS_PER_CTA; j++){
+            		reduction_storage[i][j]=0;
+            	}
+            }
 
- protected:
-  class gpgpu_sim *m_gpu;
-  kernel_info_t *m_kernel;
-  simt_stack **m_simt_stack;  // pdom based reconvergence context for each warp
-  class ptx_thread_info **m_thread;
-  unsigned m_warp_size;
-  unsigned m_warp_count;
-  unsigned reduction_storage[MAX_CTA_PER_SHADER][MAX_BARRIERS_PER_CTA];
-};
-
-// register that can hold multiple instructions.
-class register_set {
- public:
-  register_set(unsigned num, const char *name) {
-    for (unsigned i = 0; i < num; i++) {
-      regs.push_back(new warp_inst_t());
-    }
-    m_name = name;
-  }
-  bool has_free() {
-    for (unsigned i = 0; i < regs.size(); i++) {
-      if (regs[i]->empty()) {
-        return true;
-      }
-    }
-    return false;
-  }
-  bool has_free(bool sub_core_model, unsigned reg_id) {
-    // in subcore model, each sched has a one specific reg to use (based on
-    // sched id)
-    if (!sub_core_model) return has_free();
-
-    assert(reg_id < regs.size());
-    return regs[reg_id]->empty();
-  }
-  bool has_ready() {
-    for (unsigned i = 0; i < regs.size(); i++) {
-      if (not regs[i]->empty()) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  void move_in(warp_inst_t *&src) {
-    warp_inst_t **free = get_free();
-    move_warp(*free, src);
-  }
-  // void copy_in( warp_inst_t* src ){
-  //   src->copy_contents_to(*get_free());
-  //}
-  void move_out_to(warp_inst_t *&dest) {
-    warp_inst_t **ready = get_ready();
-    move_warp(dest, *ready);
-  }
-
-  warp_inst_t **get_ready() {
-    warp_inst_t **ready;
-    ready = NULL;
-    for (unsigned i = 0; i < regs.size(); i++) {
-      if (not regs[i]->empty()) {
-        if (ready and (*ready)->get_uid() < regs[i]->get_uid()) {
-          // ready is oldest
-        } else {
-          ready = &regs[i];
         }
-      }
-    }
-    return ready;
-  }
-
-  void print(FILE *fp) const {
-    fprintf(fp, "%s : @%p\n", m_name, this);
-    for (unsigned i = 0; i < regs.size(); i++) {
-      fprintf(fp, "     ");
-      regs[i]->print(fp);
-      fprintf(fp, "\n");
-    }
-  }
-
-  warp_inst_t **get_free() {
-    for (unsigned i = 0; i < regs.size(); i++) {
-      if (regs[i]->empty()) {
-        return &regs[i];
-      }
-    }
-    assert(0 && "No free registers found");
-    return NULL;
-  }
-
-  warp_inst_t **get_free(bool sub_core_model, unsigned reg_id) {
-    // in subcore model, each sched has a one specific reg to use (based on
-    // sched id)
-    if (!sub_core_model) return get_free();
-
-    assert(reg_id < regs.size());
-    if (regs[reg_id]->empty()) {
-      return &regs[reg_id];
-    }
-    assert(0 && "No free register found");
-    return NULL;
-  }
-
-  unsigned get_size() { return regs.size(); }
-
- private:
-  std::vector<warp_inst_t *> regs;
-  const char *m_name;
+        virtual ~core_t() { free(m_thread); }
+        virtual void warp_exit( unsigned warp_id ) = 0;
+        virtual bool warp_waiting_at_barrier( unsigned warp_id ) const = 0;
+        virtual void checkExecutionStatusAndUpdate(warp_inst_t &inst, unsigned t, unsigned tid)=0;
+        class gpgpu_sim * get_gpu() {return m_gpu;}
+        void execute_warp_inst_t(warp_inst_t &inst, unsigned warpId =(unsigned)-1);
+        bool  ptx_thread_done( unsigned hw_thread_id ) const ;
+        void updateSIMTStack(unsigned warpId, warp_inst_t * inst);
+        void initilizeSIMTStack(unsigned warp_count, unsigned warps_size);
+        void deleteSIMTStack();
+        warp_inst_t getExecuteWarp(unsigned warpId);
+        void get_pdom_stack_top_info( unsigned warpId, unsigned *pc, unsigned *rpc ) const;
+        kernel_info_t * get_kernel_info(){ return m_kernel;}
+        class ptx_thread_info ** get_thread_info() { return m_thread; }
+        unsigned get_warp_size() const { return m_warp_size; }
+        void and_reduction(unsigned ctaid, unsigned barid, bool value) { reduction_storage[ctaid][barid] &= value; }
+        void or_reduction(unsigned ctaid, unsigned barid, bool value) { reduction_storage[ctaid][barid] |= value; }
+        void popc_reduction(unsigned ctaid, unsigned barid, bool value) { reduction_storage[ctaid][barid] += value;}
+        unsigned get_reduction_value(unsigned ctaid, unsigned barid) {return reduction_storage[ctaid][barid];}
+    protected:
+        class gpgpu_sim *m_gpu;
+        kernel_info_t *m_kernel;
+        simt_stack  **m_simt_stack; // pdom based reconvergence context for each warp
+        class ptx_thread_info ** m_thread;
+        unsigned m_warp_size;
+        unsigned m_warp_count;
+        unsigned reduction_storage[MAX_CTA_PER_SHADER][MAX_BARRIERS_PER_CTA];
 };
 
-#endif  // #ifdef __cplusplus
 
-#endif  // #ifndef ABSTRACT_HARDWARE_MODEL_INCLUDED
+//register that can hold multiple instructions.
+class register_set {
+public:
+	register_set(unsigned num, const char* name){
+		for( unsigned i = 0; i < num; i++ ) {
+			regs.push_back(new warp_inst_t());
+		}
+		m_name = name;
+	}
+	bool has_free(){
+		for( unsigned i = 0; i < regs.size(); i++ ) {
+			if( regs[i]->empty() ) {
+				return true;
+			}
+		}
+		return false;
+	}
+	bool has_free(bool sub_core_model, unsigned reg_id){
+		//in subcore model, each sched has a one specific reg to use (based on sched id)
+		if(!sub_core_model)
+			return has_free();
+
+		assert(reg_id < regs.size());
+		return regs[reg_id]->empty();
+	}
+	bool has_ready(){
+		for( unsigned i = 0; i < regs.size(); i++ ) {
+			if( not regs[i]->empty() ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	void move_in( warp_inst_t *&src ){
+		warp_inst_t** free = get_free();
+		move_warp(*free, src);
+	}
+	//void copy_in( warp_inst_t* src ){
+		//   src->copy_contents_to(*get_free());
+		//}
+	void move_out_to( warp_inst_t *&dest ){
+		warp_inst_t **ready=get_ready();
+		move_warp(dest, *ready);
+	}
+
+	warp_inst_t** get_ready(){
+		warp_inst_t** ready;
+		ready = NULL;
+		for( unsigned i = 0; i < regs.size(); i++ ) {
+			if( not regs[i]->empty() ) {
+				if( ready and (*ready)->get_uid() < regs[i]->get_uid() ) {
+					// ready is oldest
+				} else {
+					ready = &regs[i];
+				}
+			}
+		}
+		return ready;
+	}
+
+	void print(FILE* fp) const{
+		fprintf(fp, "%s : @%p\n", m_name, this);
+		for( unsigned i = 0; i < regs.size(); i++ ) {
+			fprintf(fp, "     ");
+			regs[i]->print(fp);
+			fprintf(fp, "\n");
+		}
+	}
+
+	warp_inst_t ** get_free(){
+		for( unsigned i = 0; i < regs.size(); i++ ) {
+			if( regs[i]->empty() ) {
+				return &regs[i];
+			}
+		}
+		assert(0 && "No free registers found");
+		return NULL;
+	}
+
+	warp_inst_t ** get_free(bool sub_core_model, unsigned reg_id){
+		//in subcore model, each sched has a one specific reg to use (based on sched id)
+		if(!sub_core_model)
+			return get_free();
+
+		assert(reg_id < regs.size());
+		if( regs[reg_id]->empty() ) {
+			return &regs[reg_id];
+		}
+		assert(0 && "No free register found");
+		return NULL;
+	}
+
+	unsigned get_size(){
+		return regs.size();
+	}
+
+private:
+	std::vector<warp_inst_t*> regs;
+	const char* m_name;
+};
+
+#endif // #ifdef __cplusplus
+
+#endif // #ifndef ABSTRACT_HARDWARE_MODEL_INCLUDED

--- a/src/abstract_hardware_model.h
+++ b/src/abstract_hardware_model.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -33,45 +35,41 @@ class gpgpu_sim;
 class kernel_info_t;
 class gpgpu_context;
 
-
-//Set a hard limit of 32 CTAs per shader [cuda only has 8]
+// Set a hard limit of 32 CTAs per shader [cuda only has 8]
 #define MAX_CTA_PER_SHADER 32
 #define MAX_BARRIERS_PER_CTA 16
 
-//After expanding the vector input and output operands 
+// After expanding the vector input and output operands
 #define MAX_INPUT_VALUES 24
 #define MAX_OUTPUT_VALUES 8
 
 enum _memory_space_t {
-   undefined_space=0,
-   reg_space,
-   local_space,
-   shared_space,
-   sstarr_space,
-   param_space_unclassified,
-   param_space_kernel,  /* global to all threads in a kernel : read-only */
-   param_space_local,   /* local to a thread : read-writable */
-   const_space,
-   tex_space,
-   surf_space,
-   global_space,
-   generic_space,
-   instruction_space
+  undefined_space = 0,
+  reg_space,
+  local_space,
+  shared_space,
+  sstarr_space,
+  param_space_unclassified,
+  param_space_kernel, /* global to all threads in a kernel : read-only */
+  param_space_local,  /* local to a thread : read-writable */
+  const_space,
+  tex_space,
+  surf_space,
+  global_space,
+  generic_space,
+  instruction_space
 };
 
-
-enum FuncCache
-{
+enum FuncCache {
   FuncCachePreferNone = 0,
   FuncCachePreferShared = 1,
   FuncCachePreferL1 = 2
 };
 
-
 #ifdef __cplusplus
 
-#include <string.h>
 #include <stdio.h>
+#include <string.h>
 #include <set>
 
 typedef unsigned long long new_addr_type;
@@ -79,371 +77,357 @@ typedef unsigned long long cudaTextureObject_t;
 typedef unsigned address_type;
 typedef unsigned addr_t;
 
-// the following are operations the timing model can see 
+// the following are operations the timing model can see
 
 enum uarch_op_t {
-   NO_OP=-1,
-   ALU_OP=1,
-   SFU_OP,
-   TENSOR_CORE_OP,
-   DP_OP,
-   SP_OP,
-   INTP_OP,
-   ALU_SFU_OP,
-   LOAD_OP,
-   TENSOR_CORE_LOAD_OP,
-   TENSOR_CORE_STORE_OP,
-   STORE_OP,
-   BRANCH_OP,
-   BARRIER_OP,
-   MEMORY_BARRIER_OP,
-   CALL_OPS,
-   RET_OPS
+  NO_OP = -1,
+  ALU_OP = 1,
+  SFU_OP,
+  TENSOR_CORE_OP,
+  DP_OP,
+  SP_OP,
+  INTP_OP,
+  ALU_SFU_OP,
+  LOAD_OP,
+  TENSOR_CORE_LOAD_OP,
+  TENSOR_CORE_STORE_OP,
+  STORE_OP,
+  BRANCH_OP,
+  BARRIER_OP,
+  MEMORY_BARRIER_OP,
+  CALL_OPS,
+  RET_OPS
 };
 typedef enum uarch_op_t op_type;
 
-
-enum uarch_bar_t {
-   NOT_BAR=-1,
-   SYNC=1,
-   ARRIVE,
-   RED
-};
+enum uarch_bar_t { NOT_BAR = -1, SYNC = 1, ARRIVE, RED };
 typedef enum uarch_bar_t barrier_type;
 
-enum uarch_red_t {
-   NOT_RED=-1,
-   POPC_RED=1,
-   AND_RED,
-   OR_RED
-};
+enum uarch_red_t { NOT_RED = -1, POPC_RED = 1, AND_RED, OR_RED };
 typedef enum uarch_red_t reduction_type;
 
-
-enum uarch_operand_type_t {
-	UN_OP=-1,
-    INT_OP,
-    FP_OP
-};
+enum uarch_operand_type_t { UN_OP = -1, INT_OP, FP_OP };
 typedef enum uarch_operand_type_t types_of_operands;
 
 enum special_operations_t {
-    OTHER_OP,
-    INT__OP,
-	INT_MUL24_OP,
-	INT_MUL32_OP,
-	INT_MUL_OP,
-    INT_DIV_OP,
-    FP_MUL_OP,
-    FP_DIV_OP,
-    FP__OP,
-	FP_SQRT_OP,
-	FP_LG_OP,
-	FP_SIN_OP,
-	FP_EXP_OP
+  OTHER_OP,
+  INT__OP,
+  INT_MUL24_OP,
+  INT_MUL32_OP,
+  INT_MUL_OP,
+  INT_DIV_OP,
+  FP_MUL_OP,
+  FP_DIV_OP,
+  FP__OP,
+  FP_SQRT_OP,
+  FP_LG_OP,
+  FP_SIN_OP,
+  FP_EXP_OP
 };
-typedef enum special_operations_t special_ops; // Required to identify for the power model
+typedef enum special_operations_t
+    special_ops;  // Required to identify for the power model
 enum operation_pipeline_t {
-    UNKOWN_OP,
-    SP__OP,
-	DP__OP,
-	INTP__OP,
-    SFU__OP,
-    TENSOR_CORE__OP,
-    MEM__OP
+  UNKOWN_OP,
+  SP__OP,
+  DP__OP,
+  INTP__OP,
+  SFU__OP,
+  TENSOR_CORE__OP,
+  MEM__OP
 };
 typedef enum operation_pipeline_t operation_pipeline;
-enum mem_operation_t {
-    NOT_TEX,
-    TEX
-};
+enum mem_operation_t { NOT_TEX, TEX };
 typedef enum mem_operation_t mem_operation;
 
-enum _memory_op_t {
-	no_memory_op = 0,
-	memory_load,
-	memory_store
-};
+enum _memory_op_t { no_memory_op = 0, memory_load, memory_store };
 
-#include <bitset>
-#include <list>
-#include <vector>
 #include <assert.h>
 #include <stdlib.h>
-#include <map>
-#include <deque>
 #include <algorithm>
+#include <bitset>
+#include <deque>
+#include <list>
+#include <map>
+#include <vector>
 
 #if !defined(__VECTOR_TYPES_H__)
 #include "vector_types.h"
 #endif
 struct dim3comp {
-    bool operator() (const dim3 & a, const dim3 & b) const
-    {    
-        if(a.z < b.z)
-            return true;
-        else if(a.y < b.y)
-            return true;
-        else if (a.x < b.x)
-            return true;
-        else
-            return false;
-    }
+  bool operator()(const dim3 &a, const dim3 &b) const {
+    if (a.z < b.z)
+      return true;
+    else if (a.y < b.y)
+      return true;
+    else if (a.x < b.x)
+      return true;
+    else
+      return false;
+  }
 };
 
-void increment_x_then_y_then_z( dim3 &i, const dim3 &bound);
+void increment_x_then_y_then_z(dim3 &i, const dim3 &bound);
 
-//Jin: child kernel information for CDP
+// Jin: child kernel information for CDP
 #include "stream_manager.h"
 class stream_manager;
 struct CUstream_st;
-//extern stream_manager * g_stream_manager;
-//support for pinned memories added
-extern std::map<void *,void **> pinned_memory;
+// extern stream_manager * g_stream_manager;
+// support for pinned memories added
+extern std::map<void *, void **> pinned_memory;
 extern std::map<void *, size_t> pinned_memory_size;
 
 class kernel_info_t {
-public:
-//   kernel_info_t()
-//   {
-//      m_valid=false;
-//      m_kernel_entry=NULL;
-//      m_uid=0;
-//      m_num_cores_running=0;
-//      m_param_mem=NULL;
-//   }
-   kernel_info_t( dim3 gridDim, dim3 blockDim, class function_info *entry);
-   kernel_info_t( dim3 gridDim, dim3 blockDim, class function_info *entry, std::map<std::string, const struct cudaArray*> nameToCudaArray, std::map<std::string, const struct textureInfo*> nameToTextureInfo);
-   ~kernel_info_t();
+ public:
+  //   kernel_info_t()
+  //   {
+  //      m_valid=false;
+  //      m_kernel_entry=NULL;
+  //      m_uid=0;
+  //      m_num_cores_running=0;
+  //      m_param_mem=NULL;
+  //   }
+  kernel_info_t(dim3 gridDim, dim3 blockDim, class function_info *entry);
+  kernel_info_t(
+      dim3 gridDim, dim3 blockDim, class function_info *entry,
+      std::map<std::string, const struct cudaArray *> nameToCudaArray,
+      std::map<std::string, const struct textureInfo *> nameToTextureInfo);
+  ~kernel_info_t();
 
-   void inc_running() { m_num_cores_running++; }
-   void dec_running()
-   {
-       assert( m_num_cores_running > 0 );
-       m_num_cores_running--; 
-   }
-   bool running() const { return m_num_cores_running>0; }
-   bool done() const 
-   {
-       return no_more_ctas_to_run() && !running();
-   }
-   class function_info *entry() { return m_kernel_entry; }
-   const class function_info *entry() const { return m_kernel_entry; }
+  void inc_running() { m_num_cores_running++; }
+  void dec_running() {
+    assert(m_num_cores_running > 0);
+    m_num_cores_running--;
+  }
+  bool running() const { return m_num_cores_running > 0; }
+  bool done() const { return no_more_ctas_to_run() && !running(); }
+  class function_info *entry() {
+    return m_kernel_entry;
+  }
+  const class function_info *entry() const { return m_kernel_entry; }
 
-   size_t num_blocks() const
-   {
-      return m_grid_dim.x * m_grid_dim.y * m_grid_dim.z;
-   }
+  size_t num_blocks() const {
+    return m_grid_dim.x * m_grid_dim.y * m_grid_dim.z;
+  }
 
-   size_t threads_per_cta() const
-   {
-      return m_block_dim.x * m_block_dim.y * m_block_dim.z;
-   } 
+  size_t threads_per_cta() const {
+    return m_block_dim.x * m_block_dim.y * m_block_dim.z;
+  }
 
-   dim3 get_grid_dim() const { return m_grid_dim; }
-   dim3 get_cta_dim() const { return m_block_dim; }
+  dim3 get_grid_dim() const { return m_grid_dim; }
+  dim3 get_cta_dim() const { return m_block_dim; }
 
-   void increment_cta_id() 
-   { 
-      increment_x_then_y_then_z(m_next_cta,m_grid_dim); 
-      m_next_tid.x=0;
-      m_next_tid.y=0;
-      m_next_tid.z=0;
-   }
-   dim3 get_next_cta_id() const { return m_next_cta; }
-   unsigned get_next_cta_id_single() const 
-   {
-      return m_next_cta.x + m_grid_dim.x*m_next_cta.y + m_grid_dim.x*m_grid_dim.y*m_next_cta.z;
-    }
-   bool no_more_ctas_to_run() const 
-   {
-      return (m_next_cta.x >= m_grid_dim.x || m_next_cta.y >= m_grid_dim.y || m_next_cta.z >= m_grid_dim.z );
-   }
+  void increment_cta_id() {
+    increment_x_then_y_then_z(m_next_cta, m_grid_dim);
+    m_next_tid.x = 0;
+    m_next_tid.y = 0;
+    m_next_tid.z = 0;
+  }
+  dim3 get_next_cta_id() const { return m_next_cta; }
+  unsigned get_next_cta_id_single() const {
+    return m_next_cta.x + m_grid_dim.x * m_next_cta.y +
+           m_grid_dim.x * m_grid_dim.y * m_next_cta.z;
+  }
+  bool no_more_ctas_to_run() const {
+    return (m_next_cta.x >= m_grid_dim.x || m_next_cta.y >= m_grid_dim.y ||
+            m_next_cta.z >= m_grid_dim.z);
+  }
 
-   void increment_thread_id() { increment_x_then_y_then_z(m_next_tid,m_block_dim); }
-   dim3 get_next_thread_id_3d() const  { return m_next_tid; }
-   unsigned get_next_thread_id() const 
-   { 
-      return m_next_tid.x + m_block_dim.x*m_next_tid.y + m_block_dim.x*m_block_dim.y*m_next_tid.z;
-   }
-   bool more_threads_in_cta() const 
-   {
-      return m_next_tid.z < m_block_dim.z && m_next_tid.y < m_block_dim.y && m_next_tid.x < m_block_dim.x;
-   }
-   unsigned get_uid() const { return m_uid; }
-   std::string name() const;
+  void increment_thread_id() {
+    increment_x_then_y_then_z(m_next_tid, m_block_dim);
+  }
+  dim3 get_next_thread_id_3d() const { return m_next_tid; }
+  unsigned get_next_thread_id() const {
+    return m_next_tid.x + m_block_dim.x * m_next_tid.y +
+           m_block_dim.x * m_block_dim.y * m_next_tid.z;
+  }
+  bool more_threads_in_cta() const {
+    return m_next_tid.z < m_block_dim.z && m_next_tid.y < m_block_dim.y &&
+           m_next_tid.x < m_block_dim.x;
+  }
+  unsigned get_uid() const { return m_uid; }
+  std::string name() const;
 
-   std::list<class ptx_thread_info *> &active_threads() { return m_active_threads; }
-   class memory_space *get_param_memory() { return m_param_mem; }
+  std::list<class ptx_thread_info *> &active_threads() {
+    return m_active_threads;
+  }
+  class memory_space *get_param_memory() {
+    return m_param_mem;
+  }
 
-   
-   //The following functions access texture bindings present at the kernel's launch
-   
-   const struct cudaArray* get_texarray( const std::string &texname ) const
-   {
-      std::map<std::string,const struct cudaArray*>::const_iterator t=m_NameToCudaArray.find(texname);
-      assert(t != m_NameToCudaArray.end());
-      return t->second;
-   }
+  // The following functions access texture bindings present at the kernel's
+  // launch
 
-   const struct textureInfo* get_texinfo( const std::string &texname ) const
-   {
-      std::map<std::string, const struct textureInfo*>::const_iterator t=m_NameToTextureInfo.find(texname);
-      assert(t != m_NameToTextureInfo.end());
-      return t->second;
-   }
+  const struct cudaArray *get_texarray(const std::string &texname) const {
+    std::map<std::string, const struct cudaArray *>::const_iterator t =
+        m_NameToCudaArray.find(texname);
+    assert(t != m_NameToCudaArray.end());
+    return t->second;
+  }
 
-private:
-   kernel_info_t( const kernel_info_t & ); // disable copy constructor
-   void operator=( const kernel_info_t & ); // disable copy operator
+  const struct textureInfo *get_texinfo(const std::string &texname) const {
+    std::map<std::string, const struct textureInfo *>::const_iterator t =
+        m_NameToTextureInfo.find(texname);
+    assert(t != m_NameToTextureInfo.end());
+    return t->second;
+  }
 
-   class function_info *m_kernel_entry;
+ private:
+  kernel_info_t(const kernel_info_t &);   // disable copy constructor
+  void operator=(const kernel_info_t &);  // disable copy operator
 
-   unsigned m_uid;
-   
-   //These maps contain the snapshot of the texture mappings at kernel launch
-   std::map<std::string, const struct cudaArray*> m_NameToCudaArray;
-   std::map<std::string, const struct textureInfo*> m_NameToTextureInfo;
+  class function_info *m_kernel_entry;
 
-   dim3 m_grid_dim;
-   dim3 m_block_dim;
-   dim3 m_next_cta;
-   dim3 m_next_tid;
+  unsigned m_uid;
 
-   unsigned m_num_cores_running;
+  // These maps contain the snapshot of the texture mappings at kernel launch
+  std::map<std::string, const struct cudaArray *> m_NameToCudaArray;
+  std::map<std::string, const struct textureInfo *> m_NameToTextureInfo;
 
-   std::list<class ptx_thread_info *> m_active_threads;
-   class memory_space *m_param_mem;
+  dim3 m_grid_dim;
+  dim3 m_block_dim;
+  dim3 m_next_cta;
+  dim3 m_next_tid;
 
-public:
-   //Jin: parent and child kernel management for CDP
-   void set_parent(kernel_info_t * parent, dim3 parent_ctaid, dim3 parent_tid);
-   void set_child(kernel_info_t * child);
-   void remove_child(kernel_info_t * child);
-   bool is_finished();
-   bool children_all_finished();
-   void notify_parent_finished();
-   CUstream_st * create_stream_cta(dim3 ctaid);
-   CUstream_st * get_default_stream_cta(dim3 ctaid);
-   bool cta_has_stream(dim3 ctaid, CUstream_st* stream);
-   void destroy_cta_streams();
-   void print_parent_info();
-   kernel_info_t * get_parent() { return m_parent_kernel; }
+  unsigned m_num_cores_running;
 
-private:
-   kernel_info_t * m_parent_kernel;
-   dim3 m_parent_ctaid;
-   dim3 m_parent_tid;
-   std::list<kernel_info_t *> m_child_kernels; //child kernel launched
-   std::map< dim3, std::list<CUstream_st *>, dim3comp > m_cta_streams; //streams created in each CTA
+  std::list<class ptx_thread_info *> m_active_threads;
+  class memory_space *m_param_mem;
 
-//Jin: kernel timing
-public:
-   unsigned long long launch_cycle;
-   unsigned long long start_cycle;
-   unsigned long long end_cycle;
-   unsigned m_launch_latency;
+ public:
+  // Jin: parent and child kernel management for CDP
+  void set_parent(kernel_info_t *parent, dim3 parent_ctaid, dim3 parent_tid);
+  void set_child(kernel_info_t *child);
+  void remove_child(kernel_info_t *child);
+  bool is_finished();
+  bool children_all_finished();
+  void notify_parent_finished();
+  CUstream_st *create_stream_cta(dim3 ctaid);
+  CUstream_st *get_default_stream_cta(dim3 ctaid);
+  bool cta_has_stream(dim3 ctaid, CUstream_st *stream);
+  void destroy_cta_streams();
+  void print_parent_info();
+  kernel_info_t *get_parent() { return m_parent_kernel; }
 
-   mutable bool volta_cache_config_set;
+ private:
+  kernel_info_t *m_parent_kernel;
+  dim3 m_parent_ctaid;
+  dim3 m_parent_tid;
+  std::list<kernel_info_t *> m_child_kernels;  // child kernel launched
+  std::map<dim3, std::list<CUstream_st *>, dim3comp>
+      m_cta_streams;  // streams created in each CTA
+
+  // Jin: kernel timing
+ public:
+  unsigned long long launch_cycle;
+  unsigned long long start_cycle;
+  unsigned long long end_cycle;
+  unsigned m_launch_latency;
+
+  mutable bool volta_cache_config_set;
 };
 
 class core_config {
-    public:
-    core_config(gpgpu_context* ctx)
-    {
-	gpgpu_ctx = ctx;
-        m_valid = false; 
-        num_shmem_bank=16; 
-        shmem_limited_broadcast = false; 
-        gpgpu_shmem_sizeDefault=(unsigned)-1;
-        gpgpu_shmem_sizePrefL1=(unsigned)-1;
-        gpgpu_shmem_sizePrefShared=(unsigned)-1;
-    }
-    virtual void init() = 0;
+ public:
+  core_config(gpgpu_context *ctx) {
+    gpgpu_ctx = ctx;
+    m_valid = false;
+    num_shmem_bank = 16;
+    shmem_limited_broadcast = false;
+    gpgpu_shmem_sizeDefault = (unsigned)-1;
+    gpgpu_shmem_sizePrefL1 = (unsigned)-1;
+    gpgpu_shmem_sizePrefShared = (unsigned)-1;
+  }
+  virtual void init() = 0;
 
-    bool m_valid;
-    unsigned warp_size;
-    // backward pointer
-    class gpgpu_context* gpgpu_ctx;
+  bool m_valid;
+  unsigned warp_size;
+  // backward pointer
+  class gpgpu_context *gpgpu_ctx;
 
-    // off-chip memory request architecture parameters
-    int gpgpu_coalesce_arch;
+  // off-chip memory request architecture parameters
+  int gpgpu_coalesce_arch;
 
-    // shared memory bank conflict checking parameters
-    bool shmem_limited_broadcast;
-    static const address_type WORD_SIZE=4;
-    unsigned num_shmem_bank;
-    unsigned shmem_bank_func(address_type addr) const
-    {
-        return ((addr/WORD_SIZE) % num_shmem_bank);
-    }
-    unsigned mem_warp_parts;  
-    mutable unsigned gpgpu_shmem_size;
-    unsigned gpgpu_shmem_sizeDefault;
-    unsigned gpgpu_shmem_sizePrefL1;
-    unsigned gpgpu_shmem_sizePrefShared;
-    unsigned mem_unit_ports;
+  // shared memory bank conflict checking parameters
+  bool shmem_limited_broadcast;
+  static const address_type WORD_SIZE = 4;
+  unsigned num_shmem_bank;
+  unsigned shmem_bank_func(address_type addr) const {
+    return ((addr / WORD_SIZE) % num_shmem_bank);
+  }
+  unsigned mem_warp_parts;
+  mutable unsigned gpgpu_shmem_size;
+  unsigned gpgpu_shmem_sizeDefault;
+  unsigned gpgpu_shmem_sizePrefL1;
+  unsigned gpgpu_shmem_sizePrefShared;
+  unsigned mem_unit_ports;
 
-    // texture and constant cache line sizes (used to determine number of memory accesses)
-    unsigned gpgpu_cache_texl1_linesize;
-    unsigned gpgpu_cache_constl1_linesize;
+  // texture and constant cache line sizes (used to determine number of memory
+  // accesses)
+  unsigned gpgpu_cache_texl1_linesize;
+  unsigned gpgpu_cache_constl1_linesize;
 
-	unsigned gpgpu_max_insn_issue_per_warp;
-	bool gmem_skip_L1D; // on = global memory access always skip the L1 cache
+  unsigned gpgpu_max_insn_issue_per_warp;
+  bool gmem_skip_L1D;  // on = global memory access always skip the L1 cache
 
-	bool adaptive_volta_cache_config;
+  bool adaptive_volta_cache_config;
 };
 
-// bounded stack that implements simt reconvergence using pdom mechanism from MICRO'07 paper
+// bounded stack that implements simt reconvergence using pdom mechanism from
+// MICRO'07 paper
 const unsigned MAX_WARP_SIZE = 32;
 typedef std::bitset<MAX_WARP_SIZE> active_mask_t;
-#define MAX_WARP_SIZE_SIMT_STACK  MAX_WARP_SIZE
+#define MAX_WARP_SIZE_SIMT_STACK MAX_WARP_SIZE
 typedef std::bitset<MAX_WARP_SIZE_SIMT_STACK> simt_mask_t;
 typedef std::vector<address_type> addr_vector_t;
 
 class simt_stack {
-public:
-    simt_stack( unsigned wid,  unsigned warpSize, class gpgpu_sim * gpu);
+ public:
+  simt_stack(unsigned wid, unsigned warpSize, class gpgpu_sim *gpu);
 
-    void reset();
-    void launch( address_type start_pc, const simt_mask_t &active_mask );
-    void update( simt_mask_t &thread_done, addr_vector_t &next_pc, address_type recvg_pc, op_type next_inst_op,unsigned next_inst_size, address_type next_inst_pc );
+  void reset();
+  void launch(address_type start_pc, const simt_mask_t &active_mask);
+  void update(simt_mask_t &thread_done, addr_vector_t &next_pc,
+              address_type recvg_pc, op_type next_inst_op,
+              unsigned next_inst_size, address_type next_inst_pc);
 
-    const simt_mask_t &get_active_mask() const;
-    void     get_pdom_stack_top_info( unsigned *pc, unsigned *rpc ) const;
-    unsigned get_rp() const;
-    void     print(FILE *fp) const;
-    void     resume(char * fname) ;
-    void    print_checkpoint (FILE *fout) const;
+  const simt_mask_t &get_active_mask() const;
+  void get_pdom_stack_top_info(unsigned *pc, unsigned *rpc) const;
+  unsigned get_rp() const;
+  void print(FILE *fp) const;
+  void resume(char *fname);
+  void print_checkpoint(FILE *fout) const;
 
-protected:
-    unsigned m_warp_id;
-    unsigned m_warp_size;
+ protected:
+  unsigned m_warp_id;
+  unsigned m_warp_size;
 
+  enum stack_entry_type { STACK_ENTRY_TYPE_NORMAL = 0, STACK_ENTRY_TYPE_CALL };
 
-    enum stack_entry_type {
-        STACK_ENTRY_TYPE_NORMAL = 0,
-        STACK_ENTRY_TYPE_CALL
-    };
+  struct simt_stack_entry {
+    address_type m_pc;
+    unsigned int m_calldepth;
+    simt_mask_t m_active_mask;
+    address_type m_recvg_pc;
+    unsigned long long m_branch_div_cycle;
+    stack_entry_type m_type;
+    simt_stack_entry()
+        : m_pc(-1),
+          m_calldepth(0),
+          m_active_mask(),
+          m_recvg_pc(-1),
+          m_branch_div_cycle(0),
+          m_type(STACK_ENTRY_TYPE_NORMAL){};
+  };
 
-    struct simt_stack_entry {
-        address_type m_pc;
-        unsigned int m_calldepth;
-        simt_mask_t m_active_mask;
-        address_type m_recvg_pc;
-        unsigned long long m_branch_div_cycle;
-        stack_entry_type m_type;
-        simt_stack_entry() :
-            m_pc(-1), m_calldepth(0), m_active_mask(), m_recvg_pc(-1), m_branch_div_cycle(0), m_type(STACK_ENTRY_TYPE_NORMAL) { };
-    };
+  std::deque<simt_stack_entry> m_stack;
 
-    std::deque<simt_stack_entry> m_stack;
-
-    class gpgpu_sim * m_gpu;
+  class gpgpu_sim *m_gpu;
 };
 
 // Let's just upgrade to C++11 so we can use constexpr here...
-// start allocating from this address (lower values used for allocating globals in .ptx file)
+// start allocating from this address (lower values used for allocating globals
+// in .ptx file)
 const unsigned long long GLOBAL_HEAP_START = 0xC0000000;
 // Volta max shmem size is 96kB
 const unsigned long long SHARED_MEM_SIZE_MAX = 96 * (1 << 10);
@@ -455,873 +439,931 @@ const unsigned MAX_STREAMING_MULTIPROCESSORS = 80;
 const unsigned MAX_THREAD_PER_SM = 1 << 11;
 // MAX 64 warps / SM
 const unsigned MAX_WARP_PER_SM = 1 << 6;
-const unsigned long long TOTAL_LOCAL_MEM_PER_SM = MAX_THREAD_PER_SM * LOCAL_MEM_SIZE_MAX;
-const unsigned long long TOTAL_SHARED_MEM = MAX_STREAMING_MULTIPROCESSORS * SHARED_MEM_SIZE_MAX;
-const unsigned long long TOTAL_LOCAL_MEM = MAX_STREAMING_MULTIPROCESSORS * MAX_THREAD_PER_SM * LOCAL_MEM_SIZE_MAX;
-const unsigned long long SHARED_GENERIC_START = GLOBAL_HEAP_START - TOTAL_SHARED_MEM;
-const unsigned long long LOCAL_GENERIC_START = SHARED_GENERIC_START - TOTAL_LOCAL_MEM;
-const unsigned long long STATIC_ALLOC_LIMIT = GLOBAL_HEAP_START - (TOTAL_LOCAL_MEM + TOTAL_SHARED_MEM);
+const unsigned long long TOTAL_LOCAL_MEM_PER_SM =
+    MAX_THREAD_PER_SM * LOCAL_MEM_SIZE_MAX;
+const unsigned long long TOTAL_SHARED_MEM =
+    MAX_STREAMING_MULTIPROCESSORS * SHARED_MEM_SIZE_MAX;
+const unsigned long long TOTAL_LOCAL_MEM =
+    MAX_STREAMING_MULTIPROCESSORS * MAX_THREAD_PER_SM * LOCAL_MEM_SIZE_MAX;
+const unsigned long long SHARED_GENERIC_START =
+    GLOBAL_HEAP_START - TOTAL_SHARED_MEM;
+const unsigned long long LOCAL_GENERIC_START =
+    SHARED_GENERIC_START - TOTAL_LOCAL_MEM;
+const unsigned long long STATIC_ALLOC_LIMIT =
+    GLOBAL_HEAP_START - (TOTAL_LOCAL_MEM + TOTAL_SHARED_MEM);
 
 #if !defined(__CUDA_RUNTIME_API_H__)
 
 #include "builtin_types.h"
 
 struct cudaArray {
-   void *devPtr;
-   int devPtr32;
-   struct cudaChannelFormatDesc desc;
-   int width;
-   int height;
-   int size; //in bytes
-   unsigned dimensions;
+  void *devPtr;
+  int devPtr32;
+  struct cudaChannelFormatDesc desc;
+  int width;
+  int height;
+  int size;  // in bytes
+  unsigned dimensions;
 };
 
 #endif
 
-// Struct that record other attributes in the textureReference declaration 
+// Struct that record other attributes in the textureReference declaration
 // - These attributes are passed thru __cudaRegisterTexture()
 struct textureReferenceAttr {
-    const struct textureReference *m_texref; 
-    int m_dim; 
-    enum cudaTextureReadMode m_readmode; 
-    int m_ext; 
-    textureReferenceAttr(const struct textureReference *texref, 
-                         int dim, 
-                         enum cudaTextureReadMode readmode, 
-                         int ext)
-    : m_texref(texref), m_dim(dim), m_readmode(readmode), m_ext(ext) 
-    {  }
+  const struct textureReference *m_texref;
+  int m_dim;
+  enum cudaTextureReadMode m_readmode;
+  int m_ext;
+  textureReferenceAttr(const struct textureReference *texref, int dim,
+                       enum cudaTextureReadMode readmode, int ext)
+      : m_texref(texref), m_dim(dim), m_readmode(readmode), m_ext(ext) {}
 };
 
-class gpgpu_functional_sim_config 
-{
-public:
-    void reg_options(class OptionParser * opp);
+class gpgpu_functional_sim_config {
+ public:
+  void reg_options(class OptionParser *opp);
 
-    void ptx_set_tex_cache_linesize(unsigned linesize);
+  void ptx_set_tex_cache_linesize(unsigned linesize);
 
-    unsigned get_forced_max_capability() const { return m_ptx_force_max_capability; }
-    bool convert_to_ptxplus() const { return m_ptx_convert_to_ptxplus; }
-    bool use_cuobjdump() const { return m_ptx_use_cuobjdump; }
-    bool experimental_lib_support() const { return m_experimental_lib_support; }
+  unsigned get_forced_max_capability() const {
+    return m_ptx_force_max_capability;
+  }
+  bool convert_to_ptxplus() const { return m_ptx_convert_to_ptxplus; }
+  bool use_cuobjdump() const { return m_ptx_use_cuobjdump; }
+  bool experimental_lib_support() const { return m_experimental_lib_support; }
 
-    int         get_ptx_inst_debug_to_file() const { return g_ptx_inst_debug_to_file; }
-    const char* get_ptx_inst_debug_file() const  { return g_ptx_inst_debug_file; }
-    int         get_ptx_inst_debug_thread_uid() const { return g_ptx_inst_debug_thread_uid; }
-    unsigned    get_texcache_linesize() const { return m_texcache_linesize; }
-    int get_checkpoint_option() const {return checkpoint_option; }
-    int get_checkpoint_kernel() const {return checkpoint_kernel; }
-    int get_checkpoint_CTA() const {return checkpoint_CTA; }
-    int get_resume_option() const {return resume_option; }
-    int get_resume_kernel() const {return resume_kernel; }
-    int get_resume_CTA() const {return resume_CTA; }
-    int get_checkpoint_CTA_t() const {return checkpoint_CTA_t; }
-    int get_checkpoint_insn_Y() const {return checkpoint_insn_Y; }
-private:
-    // PTX options
-    int m_ptx_convert_to_ptxplus;
-    int m_ptx_use_cuobjdump;
-    int m_experimental_lib_support;
-    unsigned m_ptx_force_max_capability;
-    int checkpoint_option;
-    int checkpoint_kernel;
-    int checkpoint_CTA;
-    unsigned resume_option;
-    unsigned resume_kernel;
-    unsigned resume_CTA;
-    unsigned checkpoint_CTA_t;
-    int checkpoint_insn_Y;
-    int   g_ptx_inst_debug_to_file;
-    char* g_ptx_inst_debug_file;
-    int   g_ptx_inst_debug_thread_uid;
+  int get_ptx_inst_debug_to_file() const { return g_ptx_inst_debug_to_file; }
+  const char *get_ptx_inst_debug_file() const { return g_ptx_inst_debug_file; }
+  int get_ptx_inst_debug_thread_uid() const {
+    return g_ptx_inst_debug_thread_uid;
+  }
+  unsigned get_texcache_linesize() const { return m_texcache_linesize; }
+  int get_checkpoint_option() const { return checkpoint_option; }
+  int get_checkpoint_kernel() const { return checkpoint_kernel; }
+  int get_checkpoint_CTA() const { return checkpoint_CTA; }
+  int get_resume_option() const { return resume_option; }
+  int get_resume_kernel() const { return resume_kernel; }
+  int get_resume_CTA() const { return resume_CTA; }
+  int get_checkpoint_CTA_t() const { return checkpoint_CTA_t; }
+  int get_checkpoint_insn_Y() const { return checkpoint_insn_Y; }
 
-    unsigned m_texcache_linesize;
+ private:
+  // PTX options
+  int m_ptx_convert_to_ptxplus;
+  int m_ptx_use_cuobjdump;
+  int m_experimental_lib_support;
+  unsigned m_ptx_force_max_capability;
+  int checkpoint_option;
+  int checkpoint_kernel;
+  int checkpoint_CTA;
+  unsigned resume_option;
+  unsigned resume_kernel;
+  unsigned resume_CTA;
+  unsigned checkpoint_CTA_t;
+  int checkpoint_insn_Y;
+  int g_ptx_inst_debug_to_file;
+  char *g_ptx_inst_debug_file;
+  int g_ptx_inst_debug_thread_uid;
+
+  unsigned m_texcache_linesize;
 };
-
 
 class gpgpu_t {
-public:
-    gpgpu_t( const gpgpu_functional_sim_config &config, gpgpu_context* ctx );
-    // backward pointer
-    class gpgpu_context* gpgpu_ctx;
-    int checkpoint_option;
-    int checkpoint_kernel;
-    int checkpoint_CTA;
-    unsigned resume_option;
-    unsigned resume_kernel;
-    unsigned resume_CTA;
-    unsigned checkpoint_CTA_t;
-    int checkpoint_insn_Y;
+ public:
+  gpgpu_t(const gpgpu_functional_sim_config &config, gpgpu_context *ctx);
+  // backward pointer
+  class gpgpu_context *gpgpu_ctx;
+  int checkpoint_option;
+  int checkpoint_kernel;
+  int checkpoint_CTA;
+  unsigned resume_option;
+  unsigned resume_kernel;
+  unsigned resume_CTA;
+  unsigned checkpoint_CTA_t;
+  int checkpoint_insn_Y;
 
-    //Move some cycle core stats here instead of being global
-    unsigned long long  gpu_sim_cycle;
-    unsigned long long  gpu_tot_sim_cycle;
+  // Move some cycle core stats here instead of being global
+  unsigned long long gpu_sim_cycle;
+  unsigned long long gpu_tot_sim_cycle;
 
+  void *gpu_malloc(size_t size);
+  void *gpu_mallocarray(size_t count);
+  void gpu_memset(size_t dst_start_addr, int c, size_t count);
+  void memcpy_to_gpu(size_t dst_start_addr, const void *src, size_t count);
+  void memcpy_from_gpu(void *dst, size_t src_start_addr, size_t count);
+  void memcpy_gpu_to_gpu(size_t dst, size_t src, size_t count);
 
-    void* gpu_malloc( size_t size );
-    void* gpu_mallocarray( size_t count );
-    void  gpu_memset( size_t dst_start_addr, int c, size_t count );
-    void  memcpy_to_gpu( size_t dst_start_addr, const void *src, size_t count );
-    void  memcpy_from_gpu( void *dst, size_t src_start_addr, size_t count );
-    void  memcpy_gpu_to_gpu( size_t dst, size_t src, size_t count );
-    
-    class memory_space *get_global_memory() { return m_global_mem; }
-    class memory_space *get_tex_memory() { return m_tex_mem; }
-    class memory_space *get_surf_memory() { return m_surf_mem; }
+  class memory_space *get_global_memory() {
+    return m_global_mem;
+  }
+  class memory_space *get_tex_memory() {
+    return m_tex_mem;
+  }
+  class memory_space *get_surf_memory() {
+    return m_surf_mem;
+  }
 
-    void gpgpu_ptx_sim_bindTextureToArray(const struct textureReference* texref, const struct cudaArray* array);
-    void gpgpu_ptx_sim_bindNameToTexture(const char* name, const struct textureReference* texref, int dim, int readmode, int ext);
-    void gpgpu_ptx_sim_unbindTexture(const struct textureReference* texref);
-    const char* gpgpu_ptx_sim_findNamefromTexture(const struct textureReference* texref);
+  void gpgpu_ptx_sim_bindTextureToArray(const struct textureReference *texref,
+                                        const struct cudaArray *array);
+  void gpgpu_ptx_sim_bindNameToTexture(const char *name,
+                                       const struct textureReference *texref,
+                                       int dim, int readmode, int ext);
+  void gpgpu_ptx_sim_unbindTexture(const struct textureReference *texref);
+  const char *gpgpu_ptx_sim_findNamefromTexture(
+      const struct textureReference *texref);
 
-    const struct textureReference* get_texref( const std::string &texname ) const
-    {
-        std::map<std::string, std::set<const struct textureReference*> >::const_iterator t=m_NameToTextureRef.find(texname);
-        assert( t != m_NameToTextureRef.end() );
-        return *(t->second.begin());
-    }
+  const struct textureReference *get_texref(const std::string &texname) const {
+    std::map<std::string,
+             std::set<const struct textureReference *> >::const_iterator t =
+        m_NameToTextureRef.find(texname);
+    assert(t != m_NameToTextureRef.end());
+    return *(t->second.begin());
+  }
 
-    const struct cudaArray* get_texarray( const std::string &texname ) const
-    {
-        std::map<std::string,const struct cudaArray*>::const_iterator t=m_NameToCudaArray.find(texname);
-        assert(t != m_NameToCudaArray.end());
-        return t->second;
-    }
+  const struct cudaArray *get_texarray(const std::string &texname) const {
+    std::map<std::string, const struct cudaArray *>::const_iterator t =
+        m_NameToCudaArray.find(texname);
+    assert(t != m_NameToCudaArray.end());
+    return t->second;
+  }
 
-    const struct textureInfo* get_texinfo( const std::string &texname ) const
-    {
-        std::map<std::string, const struct textureInfo*>::const_iterator t=m_NameToTextureInfo.find(texname);
-        assert(t != m_NameToTextureInfo.end());
-        return t->second;
-    }
+  const struct textureInfo *get_texinfo(const std::string &texname) const {
+    std::map<std::string, const struct textureInfo *>::const_iterator t =
+        m_NameToTextureInfo.find(texname);
+    assert(t != m_NameToTextureInfo.end());
+    return t->second;
+  }
 
-    const struct textureReferenceAttr* get_texattr( const std::string &texname ) const
-    {
-        std::map<std::string, const struct textureReferenceAttr*>::const_iterator t=m_NameToAttribute.find(texname);
-        assert(t != m_NameToAttribute.end());
-        return t->second;
-    }
+  const struct textureReferenceAttr *get_texattr(
+      const std::string &texname) const {
+    std::map<std::string, const struct textureReferenceAttr *>::const_iterator
+        t = m_NameToAttribute.find(texname);
+    assert(t != m_NameToAttribute.end());
+    return t->second;
+  }
 
-    const gpgpu_functional_sim_config &get_config() const { return m_function_model_config; }
-    FILE* get_ptx_inst_debug_file() { return ptx_inst_debug_file; }
-    
-    //  These maps return the current texture mappings for the GPU at any given time.
-    std::map<std::string, const struct cudaArray*> getNameArrayMapping() {return m_NameToCudaArray;}
-    std::map<std::string, const struct textureInfo*> getNameInfoMapping() {return m_NameToTextureInfo;}
+  const gpgpu_functional_sim_config &get_config() const {
+    return m_function_model_config;
+  }
+  FILE *get_ptx_inst_debug_file() { return ptx_inst_debug_file; }
 
-protected:
-    const gpgpu_functional_sim_config &m_function_model_config;
-    FILE* ptx_inst_debug_file;
+  //  These maps return the current texture mappings for the GPU at any given
+  //  time.
+  std::map<std::string, const struct cudaArray *> getNameArrayMapping() {
+    return m_NameToCudaArray;
+  }
+  std::map<std::string, const struct textureInfo *> getNameInfoMapping() {
+    return m_NameToTextureInfo;
+  }
 
-    class memory_space *m_global_mem;
-    class memory_space *m_tex_mem;
-    class memory_space *m_surf_mem;
+ protected:
+  const gpgpu_functional_sim_config &m_function_model_config;
+  FILE *ptx_inst_debug_file;
 
-    unsigned long long m_dev_malloc;
-    //  These maps contain the current texture mappings for the GPU at any given time. 
-    std::map<std::string, std::set<const struct textureReference*> > m_NameToTextureRef;
-    std::map<const struct textureReference*, std::string> m_TextureRefToName;
-    std::map<std::string, const struct cudaArray*> m_NameToCudaArray;
-    std::map<std::string, const struct textureInfo*> m_NameToTextureInfo;
-    std::map<std::string, const struct textureReferenceAttr*> m_NameToAttribute;
+  class memory_space *m_global_mem;
+  class memory_space *m_tex_mem;
+  class memory_space *m_surf_mem;
+
+  unsigned long long m_dev_malloc;
+  //  These maps contain the current texture mappings for the GPU at any given
+  //  time.
+  std::map<std::string, std::set<const struct textureReference *> >
+      m_NameToTextureRef;
+  std::map<const struct textureReference *, std::string> m_TextureRefToName;
+  std::map<std::string, const struct cudaArray *> m_NameToCudaArray;
+  std::map<std::string, const struct textureInfo *> m_NameToTextureInfo;
+  std::map<std::string, const struct textureReferenceAttr *> m_NameToAttribute;
 };
 
-struct gpgpu_ptx_sim_info
-{
-   // Holds properties of the kernel (Kernel's resource use). 
-   // These will be set to zero if a ptxinfo file is not present.
-   int lmem;
-   int smem;
-   int cmem;
-   int gmem;
-   int regs;
-   unsigned maxthreads;
-   unsigned ptx_version;
-   unsigned sm_target;
+struct gpgpu_ptx_sim_info {
+  // Holds properties of the kernel (Kernel's resource use).
+  // These will be set to zero if a ptxinfo file is not present.
+  int lmem;
+  int smem;
+  int cmem;
+  int gmem;
+  int regs;
+  unsigned maxthreads;
+  unsigned ptx_version;
+  unsigned sm_target;
 };
-
 
 struct gpgpu_ptx_sim_arg {
-   gpgpu_ptx_sim_arg() { m_start=NULL; }
-   gpgpu_ptx_sim_arg(const void *arg, size_t size, size_t offset)
-   {
-      m_start=arg;
-      m_nbytes=size;
-      m_offset=offset;
-   }
-   const void *m_start;
-   size_t m_nbytes;
-   size_t m_offset;
+  gpgpu_ptx_sim_arg() { m_start = NULL; }
+  gpgpu_ptx_sim_arg(const void *arg, size_t size, size_t offset) {
+    m_start = arg;
+    m_nbytes = size;
+    m_offset = offset;
+  }
+  const void *m_start;
+  size_t m_nbytes;
+  size_t m_offset;
 };
 
 typedef std::list<gpgpu_ptx_sim_arg> gpgpu_ptx_sim_arg_list_t;
 
 class memory_space_t {
-public:
-   memory_space_t() { m_type = undefined_space; m_bank=0; }
-   memory_space_t( const enum _memory_space_t &from ) { m_type = from; m_bank = 0; }
-   bool operator==( const memory_space_t &x ) const { return (m_bank == x.m_bank) && (m_type == x.m_type); }
-   bool operator!=( const memory_space_t &x ) const { return !(*this == x); }
-   bool operator<( const memory_space_t &x ) const 
-   { 
-      if(m_type < x.m_type)
-         return true;
-      else if(m_type > x.m_type)
-         return false;
-      else if( m_bank < x.m_bank )
-         return true; 
+ public:
+  memory_space_t() {
+    m_type = undefined_space;
+    m_bank = 0;
+  }
+  memory_space_t(const enum _memory_space_t &from) {
+    m_type = from;
+    m_bank = 0;
+  }
+  bool operator==(const memory_space_t &x) const {
+    return (m_bank == x.m_bank) && (m_type == x.m_type);
+  }
+  bool operator!=(const memory_space_t &x) const { return !(*this == x); }
+  bool operator<(const memory_space_t &x) const {
+    if (m_type < x.m_type)
+      return true;
+    else if (m_type > x.m_type)
       return false;
-   }
-   enum _memory_space_t get_type() const { return m_type; }
-   void set_type( enum _memory_space_t t ) { m_type = t; }
-   unsigned get_bank() const { return m_bank; }
-   void set_bank( unsigned b ) { m_bank = b; }
-   bool is_const() const { return (m_type == const_space) || (m_type == param_space_kernel); }
-   bool is_local() const { return (m_type == local_space) || (m_type == param_space_local); }
-   bool is_global() const { return (m_type == global_space); }
+    else if (m_bank < x.m_bank)
+      return true;
+    return false;
+  }
+  enum _memory_space_t get_type() const { return m_type; }
+  void set_type(enum _memory_space_t t) { m_type = t; }
+  unsigned get_bank() const { return m_bank; }
+  void set_bank(unsigned b) { m_bank = b; }
+  bool is_const() const {
+    return (m_type == const_space) || (m_type == param_space_kernel);
+  }
+  bool is_local() const {
+    return (m_type == local_space) || (m_type == param_space_local);
+  }
+  bool is_global() const { return (m_type == global_space); }
 
-private:
-   enum _memory_space_t m_type;
-   unsigned m_bank; // n in ".const[n]"; note .const == .const[0] (see PTX 2.1 manual, sec. 5.1.3)
+ private:
+  enum _memory_space_t m_type;
+  unsigned m_bank;  // n in ".const[n]"; note .const == .const[0] (see PTX 2.1
+                    // manual, sec. 5.1.3)
 };
 
 const unsigned MAX_MEMORY_ACCESS_SIZE = 128;
 typedef std::bitset<MAX_MEMORY_ACCESS_SIZE> mem_access_byte_mask_t;
-const unsigned SECTOR_CHUNCK_SIZE = 4;   //four sectors
-const unsigned SECTOR_SIZE = 32 ;        //sector is 32 bytes width
+const unsigned SECTOR_CHUNCK_SIZE = 4;  // four sectors
+const unsigned SECTOR_SIZE = 32;        // sector is 32 bytes width
 typedef std::bitset<SECTOR_CHUNCK_SIZE> mem_access_sector_mask_t;
 #define NO_PARTIAL_WRITE (mem_access_byte_mask_t())
 
-#define MEM_ACCESS_TYPE_TUP_DEF \
-MA_TUP_BEGIN( mem_access_type ) \
-   MA_TUP( GLOBAL_ACC_R ), \
-   MA_TUP( LOCAL_ACC_R ), \
-   MA_TUP( CONST_ACC_R ), \
-   MA_TUP( TEXTURE_ACC_R ), \
-   MA_TUP( GLOBAL_ACC_W ), \
-   MA_TUP( LOCAL_ACC_W ), \
-   MA_TUP( L1_WRBK_ACC ), \
-   MA_TUP( L2_WRBK_ACC ), \
-   MA_TUP( INST_ACC_R ), \
-   MA_TUP( L1_WR_ALLOC_R ), \
-   MA_TUP( L2_WR_ALLOC_R ), \
-   MA_TUP( NUM_MEM_ACCESS_TYPE ) \
-MA_TUP_END( mem_access_type ) 
+#define MEM_ACCESS_TYPE_TUP_DEF                                       \
+  MA_TUP_BEGIN(mem_access_type)                                       \
+  MA_TUP(GLOBAL_ACC_R)                                                \
+  , MA_TUP(LOCAL_ACC_R), MA_TUP(CONST_ACC_R), MA_TUP(TEXTURE_ACC_R),  \
+      MA_TUP(GLOBAL_ACC_W), MA_TUP(LOCAL_ACC_W), MA_TUP(L1_WRBK_ACC), \
+      MA_TUP(L2_WRBK_ACC), MA_TUP(INST_ACC_R), MA_TUP(L1_WR_ALLOC_R), \
+      MA_TUP(L2_WR_ALLOC_R),                                          \
+      MA_TUP(NUM_MEM_ACCESS_TYPE) MA_TUP_END(mem_access_type)
 
 #define MA_TUP_BEGIN(X) enum X {
 #define MA_TUP(X) X
-#define MA_TUP_END(X) };
+#define MA_TUP_END(X) \
+  }                   \
+  ;
 MEM_ACCESS_TYPE_TUP_DEF
 #undef MA_TUP_BEGIN
 #undef MA_TUP
 #undef MA_TUP_END
 
-const char * mem_access_type_str(enum mem_access_type access_type); 
+const char *mem_access_type_str(enum mem_access_type access_type);
 
 enum cache_operator_type {
-    CACHE_UNDEFINED, 
+  CACHE_UNDEFINED,
 
-    // loads
-    CACHE_ALL,          // .ca
-    CACHE_LAST_USE,     // .lu
-    CACHE_VOLATILE,     // .cv
-    CACHE_L1,     // .nc
-                       
-    // loads and stores 
-    CACHE_STREAMING,    // .cs
-    CACHE_GLOBAL,       // .cg
+  // loads
+  CACHE_ALL,       // .ca
+  CACHE_LAST_USE,  // .lu
+  CACHE_VOLATILE,  // .cv
+  CACHE_L1,        // .nc
 
-    // stores
-    CACHE_WRITE_BACK,   // .wb
-    CACHE_WRITE_THROUGH // .wt
+  // loads and stores
+  CACHE_STREAMING,  // .cs
+  CACHE_GLOBAL,     // .cg
+
+  // stores
+  CACHE_WRITE_BACK,    // .wb
+  CACHE_WRITE_THROUGH  // .wt
 };
 
 class mem_access_t {
-public:
-   mem_access_t(gpgpu_context* ctx) { init(ctx); }
-   mem_access_t( mem_access_type type, 
-                 new_addr_type address, 
-                 unsigned size,
-                 bool wr,
-		 gpgpu_context* ctx)
-   {
-       init(ctx);
-       m_type = type;
-       m_addr = address;
-       m_req_size = size;
-       m_write = wr;
-   }
-   mem_access_t( mem_access_type type, 
-                 new_addr_type address, 
-                 unsigned size, 
-                 bool wr, 
-                 const active_mask_t &active_mask,
-                 const mem_access_byte_mask_t &byte_mask,
-		 const mem_access_sector_mask_t &sector_mask,
-		 gpgpu_context* ctx)
-    : m_warp_mask(active_mask), m_byte_mask(byte_mask), m_sector_mask(sector_mask)
-   {
-      init(ctx);
-      m_type = type;
-      m_addr = address;
-      m_req_size = size;
-      m_write = wr;
-   }
+ public:
+  mem_access_t(gpgpu_context *ctx) { init(ctx); }
+  mem_access_t(mem_access_type type, new_addr_type address, unsigned size,
+               bool wr, gpgpu_context *ctx) {
+    init(ctx);
+    m_type = type;
+    m_addr = address;
+    m_req_size = size;
+    m_write = wr;
+  }
+  mem_access_t(mem_access_type type, new_addr_type address, unsigned size,
+               bool wr, const active_mask_t &active_mask,
+               const mem_access_byte_mask_t &byte_mask,
+               const mem_access_sector_mask_t &sector_mask, gpgpu_context *ctx)
+      : m_warp_mask(active_mask),
+        m_byte_mask(byte_mask),
+        m_sector_mask(sector_mask) {
+    init(ctx);
+    m_type = type;
+    m_addr = address;
+    m_req_size = size;
+    m_write = wr;
+  }
 
-   new_addr_type get_addr() const { return m_addr; }
-   void set_addr(new_addr_type addr) {m_addr=addr;}
-   unsigned get_size() const { return m_req_size; }
-   const active_mask_t &get_warp_mask() const { return m_warp_mask; }
-   bool is_write() const { return m_write; }
-   enum mem_access_type get_type() const { return m_type; }
-   mem_access_byte_mask_t get_byte_mask() const { return m_byte_mask; }
-   mem_access_sector_mask_t get_sector_mask() const { return m_sector_mask; }
+  new_addr_type get_addr() const { return m_addr; }
+  void set_addr(new_addr_type addr) { m_addr = addr; }
+  unsigned get_size() const { return m_req_size; }
+  const active_mask_t &get_warp_mask() const { return m_warp_mask; }
+  bool is_write() const { return m_write; }
+  enum mem_access_type get_type() const { return m_type; }
+  mem_access_byte_mask_t get_byte_mask() const { return m_byte_mask; }
+  mem_access_sector_mask_t get_sector_mask() const { return m_sector_mask; }
 
-   void print(FILE *fp) const
-   {
-       fprintf(fp,"addr=0x%llx, %s, size=%u, ", m_addr, m_write?"store":"load ", m_req_size );
-       switch(m_type) {
-       case GLOBAL_ACC_R:  fprintf(fp,"GLOBAL_R"); break;
-       case LOCAL_ACC_R:   fprintf(fp,"LOCAL_R "); break;
-       case CONST_ACC_R:   fprintf(fp,"CONST   "); break;
-       case TEXTURE_ACC_R: fprintf(fp,"TEXTURE "); break;
-       case GLOBAL_ACC_W:  fprintf(fp,"GLOBAL_W"); break;
-       case LOCAL_ACC_W:   fprintf(fp,"LOCAL_W "); break;
-       case L2_WRBK_ACC:   fprintf(fp,"L2_WRBK "); break;
-       case INST_ACC_R:    fprintf(fp,"INST    "); break;
-       case L1_WRBK_ACC:   fprintf(fp,"L1_WRBK "); break;
-       default:            fprintf(fp,"unknown "); break;
-       }
-   }
+  void print(FILE *fp) const {
+    fprintf(fp, "addr=0x%llx, %s, size=%u, ", m_addr,
+            m_write ? "store" : "load ", m_req_size);
+    switch (m_type) {
+      case GLOBAL_ACC_R:
+        fprintf(fp, "GLOBAL_R");
+        break;
+      case LOCAL_ACC_R:
+        fprintf(fp, "LOCAL_R ");
+        break;
+      case CONST_ACC_R:
+        fprintf(fp, "CONST   ");
+        break;
+      case TEXTURE_ACC_R:
+        fprintf(fp, "TEXTURE ");
+        break;
+      case GLOBAL_ACC_W:
+        fprintf(fp, "GLOBAL_W");
+        break;
+      case LOCAL_ACC_W:
+        fprintf(fp, "LOCAL_W ");
+        break;
+      case L2_WRBK_ACC:
+        fprintf(fp, "L2_WRBK ");
+        break;
+      case INST_ACC_R:
+        fprintf(fp, "INST    ");
+        break;
+      case L1_WRBK_ACC:
+        fprintf(fp, "L1_WRBK ");
+        break;
+      default:
+        fprintf(fp, "unknown ");
+        break;
+    }
+  }
 
-   gpgpu_context* gpgpu_ctx;
-private:
-   void init(gpgpu_context* ctx);
+  gpgpu_context *gpgpu_ctx;
 
-   unsigned      m_uid;
-   new_addr_type m_addr;     // request address
-   bool          m_write;
-   unsigned      m_req_size; // bytes
-   mem_access_type m_type;
-   active_mask_t m_warp_mask;
-   mem_access_byte_mask_t m_byte_mask;
-   mem_access_sector_mask_t m_sector_mask;
+ private:
+  void init(gpgpu_context *ctx);
+
+  unsigned m_uid;
+  new_addr_type m_addr;  // request address
+  bool m_write;
+  unsigned m_req_size;  // bytes
+  mem_access_type m_type;
+  active_mask_t m_warp_mask;
+  mem_access_byte_mask_t m_byte_mask;
+  mem_access_sector_mask_t m_sector_mask;
 };
 
 class mem_fetch;
 
 class mem_fetch_interface {
-public:
-    virtual bool full( unsigned size, bool write ) const = 0;
-    virtual void push( mem_fetch *mf ) = 0;
+ public:
+  virtual bool full(unsigned size, bool write) const = 0;
+  virtual void push(mem_fetch *mf) = 0;
 };
 
 class mem_fetch_allocator {
-public:
-    virtual mem_fetch *alloc( new_addr_type addr, mem_access_type type, unsigned size, bool wr, unsigned long long cycle ) const = 0;
-    virtual mem_fetch *alloc( const class warp_inst_t &inst, const mem_access_t &access, unsigned long long cycle ) const = 0;
+ public:
+  virtual mem_fetch *alloc(new_addr_type addr, mem_access_type type,
+                           unsigned size, bool wr,
+                           unsigned long long cycle) const = 0;
+  virtual mem_fetch *alloc(const class warp_inst_t &inst,
+                           const mem_access_t &access,
+                           unsigned long long cycle) const = 0;
 };
 
-// the maximum number of destination, source, or address uarch operands in a instruction
-#define MAX_REG_OPERANDS 32 
+// the maximum number of destination, source, or address uarch operands in a
+// instruction
+#define MAX_REG_OPERANDS 32
 
 struct dram_callback_t {
-   dram_callback_t() { function=NULL; instruction=NULL; thread=NULL; }
-   void (*function)(const class inst_t*, class ptx_thread_info*);
+  dram_callback_t() {
+    function = NULL;
+    instruction = NULL;
+    thread = NULL;
+  }
+  void (*function)(const class inst_t *, class ptx_thread_info *);
 
-   const class inst_t* instruction;
-   class ptx_thread_info *thread;
+  const class inst_t *instruction;
+  class ptx_thread_info *thread;
 };
 
 class inst_t {
-public:
-    inst_t()
-    {
-        m_decoded=false;
-        pc=(address_type)-1;
-        reconvergence_pc=(address_type)-1;
-        op=NO_OP;
-        bar_type=NOT_BAR;
-        red_type=NOT_RED;
-        bar_id=(unsigned)-1;
-        bar_count=(unsigned)-1;
-        oprnd_type=UN_OP;
-        sp_op=OTHER_OP;
-        op_pipe=UNKOWN_OP;
-        mem_op=NOT_TEX;
-        num_operands=0;
-        num_regs=0;
-        memset(out, 0, sizeof(unsigned)); 
-        memset(in, 0, sizeof(unsigned)); 
-        is_vectorin=0; 
-        is_vectorout=0;
-        space = memory_space_t();
-        cache_op = CACHE_UNDEFINED;
-        latency = 1;
-        initiation_interval = 1;
-        for( unsigned i=0; i < MAX_REG_OPERANDS; i++ ) {
-            arch_reg.src[i] = -1;
-            arch_reg.dst[i] = -1;
-        }
-        isize=0;
+ public:
+  inst_t() {
+    m_decoded = false;
+    pc = (address_type)-1;
+    reconvergence_pc = (address_type)-1;
+    op = NO_OP;
+    bar_type = NOT_BAR;
+    red_type = NOT_RED;
+    bar_id = (unsigned)-1;
+    bar_count = (unsigned)-1;
+    oprnd_type = UN_OP;
+    sp_op = OTHER_OP;
+    op_pipe = UNKOWN_OP;
+    mem_op = NOT_TEX;
+    num_operands = 0;
+    num_regs = 0;
+    memset(out, 0, sizeof(unsigned));
+    memset(in, 0, sizeof(unsigned));
+    is_vectorin = 0;
+    is_vectorout = 0;
+    space = memory_space_t();
+    cache_op = CACHE_UNDEFINED;
+    latency = 1;
+    initiation_interval = 1;
+    for (unsigned i = 0; i < MAX_REG_OPERANDS; i++) {
+      arch_reg.src[i] = -1;
+      arch_reg.dst[i] = -1;
     }
-    bool valid() const { return m_decoded; }
-    virtual void print_insn( FILE *fp ) const 
-    {
-        fprintf(fp," [inst @ pc=0x%04x] ", pc );
-    }
-    bool is_load() const { return (op == LOAD_OP ||op==TENSOR_CORE_LOAD_OP || memory_op == memory_load); }
-    bool is_store() const { return (op == STORE_OP ||op==TENSOR_CORE_STORE_OP || memory_op == memory_store); }
-    unsigned get_num_operands() const {return num_operands;}
-    unsigned get_num_regs() const {return num_regs;}
-    void set_num_regs(unsigned num) {num_regs=num;}
-    void set_num_operands(unsigned num) {num_operands=num;}
-    void set_bar_id(unsigned id) {bar_id=id;}
-    void set_bar_count(unsigned count) {bar_count=count;}
+    isize = 0;
+  }
+  bool valid() const { return m_decoded; }
+  virtual void print_insn(FILE *fp) const {
+    fprintf(fp, " [inst @ pc=0x%04x] ", pc);
+  }
+  bool is_load() const {
+    return (op == LOAD_OP || op == TENSOR_CORE_LOAD_OP ||
+            memory_op == memory_load);
+  }
+  bool is_store() const {
+    return (op == STORE_OP || op == TENSOR_CORE_STORE_OP ||
+            memory_op == memory_store);
+  }
+  unsigned get_num_operands() const { return num_operands; }
+  unsigned get_num_regs() const { return num_regs; }
+  void set_num_regs(unsigned num) { num_regs = num; }
+  void set_num_operands(unsigned num) { num_operands = num; }
+  void set_bar_id(unsigned id) { bar_id = id; }
+  void set_bar_count(unsigned count) { bar_count = count; }
 
-    address_type pc;        // program counter address of instruction
-    unsigned isize;         // size of instruction in bytes 
-    op_type op;             // opcode (uarch visible)
+  address_type pc;  // program counter address of instruction
+  unsigned isize;   // size of instruction in bytes
+  op_type op;       // opcode (uarch visible)
 
-    barrier_type bar_type;
-    reduction_type red_type;
-    unsigned bar_id;
-    unsigned bar_count;
+  barrier_type bar_type;
+  reduction_type red_type;
+  unsigned bar_id;
+  unsigned bar_count;
 
-    types_of_operands oprnd_type;     // code (uarch visible) identify if the operation is an interger or a floating point
-    special_ops sp_op;           // code (uarch visible) identify if int_alu, fp_alu, int_mul ....
-    operation_pipeline op_pipe;  // code (uarch visible) identify the pipeline of the operation (SP, SFU or MEM)
-    mem_operation mem_op;        // code (uarch visible) identify memory type
-    _memory_op_t memory_op; // memory_op used by ptxplus 
-    unsigned num_operands;
-    unsigned num_regs; // count vector operand as one register operand
+  types_of_operands oprnd_type;  // code (uarch visible) identify if the
+                                 // operation is an interger or a floating point
+  special_ops
+      sp_op;  // code (uarch visible) identify if int_alu, fp_alu, int_mul ....
+  operation_pipeline op_pipe;  // code (uarch visible) identify the pipeline of
+                               // the operation (SP, SFU or MEM)
+  mem_operation mem_op;        // code (uarch visible) identify memory type
+  _memory_op_t memory_op;      // memory_op used by ptxplus
+  unsigned num_operands;
+  unsigned num_regs;  // count vector operand as one register operand
 
-    address_type reconvergence_pc; // -1 => not a branch, -2 => use function return address
-    
-    unsigned out[8];
-    unsigned outcount;
-    unsigned in[24];
-    unsigned incount;
-    unsigned char is_vectorin;
-    unsigned char is_vectorout;
-    int pred; // predicate register number
-    int ar1, ar2;
-    // register number for bank conflict evaluation
-    struct {
-        int dst[MAX_REG_OPERANDS];
-        int src[MAX_REG_OPERANDS];
-    } arch_reg;
-    //int arch_reg[MAX_REG_OPERANDS]; // register number for bank conflict evaluation
-    unsigned latency; // operation latency
-    unsigned initiation_interval;
+  address_type reconvergence_pc;  // -1 => not a branch, -2 => use function
+                                  // return address
 
-    unsigned data_size; // what is the size of the word being operated on?
-    memory_space_t space;
-    cache_operator_type cache_op;
+  unsigned out[8];
+  unsigned outcount;
+  unsigned in[24];
+  unsigned incount;
+  unsigned char is_vectorin;
+  unsigned char is_vectorout;
+  int pred;  // predicate register number
+  int ar1, ar2;
+  // register number for bank conflict evaluation
+  struct {
+    int dst[MAX_REG_OPERANDS];
+    int src[MAX_REG_OPERANDS];
+  } arch_reg;
+  // int arch_reg[MAX_REG_OPERANDS]; // register number for bank conflict
+  // evaluation
+  unsigned latency;  // operation latency
+  unsigned initiation_interval;
 
-protected:
-    bool m_decoded;
-    virtual void pre_decode() {}
+  unsigned data_size;  // what is the size of the word being operated on?
+  memory_space_t space;
+  cache_operator_type cache_op;
+
+ protected:
+  bool m_decoded;
+  virtual void pre_decode() {}
 };
 
-enum divergence_support_t {
-   POST_DOMINATOR = 1,
-   NUM_SIMD_MODEL
-};
+enum divergence_support_t { POST_DOMINATOR = 1, NUM_SIMD_MODEL };
 
 const unsigned MAX_ACCESSES_PER_INSN_PER_THREAD = 8;
 
-class warp_inst_t: public inst_t {
-public:
-    // constructors
-    warp_inst_t() 
-    {
-        m_uid=0;
-        m_empty=true; 
-        m_config=NULL; 
+class warp_inst_t : public inst_t {
+ public:
+  // constructors
+  warp_inst_t() {
+    m_uid = 0;
+    m_empty = true;
+    m_config = NULL;
+  }
+  warp_inst_t(const core_config *config) {
+    m_uid = 0;
+    assert(config->warp_size <= MAX_WARP_SIZE);
+    m_config = config;
+    m_empty = true;
+    m_isatomic = false;
+    m_per_scalar_thread_valid = false;
+    m_mem_accesses_created = false;
+    m_cache_hit = false;
+    m_is_printf = false;
+    m_is_cdp = 0;
+  }
+  virtual ~warp_inst_t() {}
+
+  // modifiers
+  void broadcast_barrier_reduction(const active_mask_t &access_mask);
+  void do_atomic(bool forceDo = false);
+  void do_atomic(const active_mask_t &access_mask, bool forceDo = false);
+  void clear() { m_empty = true; }
+
+  void issue(const active_mask_t &mask, unsigned warp_id,
+             unsigned long long cycle, int dynamic_warp_id, int sch_id);
+
+  const active_mask_t &get_active_mask() const { return m_warp_active_mask; }
+  void completed(unsigned long long cycle)
+      const;  // stat collection: called when the instruction is completed
+
+  void set_addr(unsigned n, new_addr_type addr) {
+    if (!m_per_scalar_thread_valid) {
+      m_per_scalar_thread.resize(m_config->warp_size);
+      m_per_scalar_thread_valid = true;
     }
-    warp_inst_t( const core_config *config )
-    { 
-        m_uid=0;
-        assert(config->warp_size<=MAX_WARP_SIZE); 
-        m_config=config;
-        m_empty=true; 
-        m_isatomic=false;
-        m_per_scalar_thread_valid=false;
-        m_mem_accesses_created=false;
-        m_cache_hit=false;
-        m_is_printf=false;
-        m_is_cdp = 0;
+    m_per_scalar_thread[n].memreqaddr[0] = addr;
+  }
+  void set_addr(unsigned n, new_addr_type *addr, unsigned num_addrs) {
+    if (!m_per_scalar_thread_valid) {
+      m_per_scalar_thread.resize(m_config->warp_size);
+      m_per_scalar_thread_valid = true;
     }
-    virtual ~warp_inst_t(){
+    assert(num_addrs <= MAX_ACCESSES_PER_INSN_PER_THREAD);
+    for (unsigned i = 0; i < num_addrs; i++)
+      m_per_scalar_thread[n].memreqaddr[i] = addr[i];
+  }
+  void print_m_accessq() {
+    if (accessq_empty())
+      return;
+    else {
+      printf("Printing mem access generated\n");
+      std::list<mem_access_t>::iterator it;
+      for (it = m_accessq.begin(); it != m_accessq.end(); ++it) {
+        printf("MEM_TXN_GEN:%s:%llx, Size:%d \n",
+               mem_access_type_str(it->get_type()), it->get_addr(),
+               it->get_size());
+      }
     }
+  }
+  struct transaction_info {
+    std::bitset<4> chunks;  // bitmask: 32-byte chunks accessed
+    mem_access_byte_mask_t bytes;
+    active_mask_t active;  // threads in this transaction
 
-    // modifiers
-    void broadcast_barrier_reduction( const active_mask_t& access_mask);
-    void do_atomic(bool forceDo=false);
-    void do_atomic( const active_mask_t& access_mask, bool forceDo=false );
-    void clear() 
-    { 
-        m_empty=true; 
+    bool test_bytes(unsigned start_bit, unsigned end_bit) {
+      for (unsigned i = start_bit; i <= end_bit; i++)
+        if (bytes.test(i)) return true;
+      return false;
     }
+  };
 
-    void issue( const active_mask_t &mask, unsigned warp_id, unsigned long long cycle, int dynamic_warp_id, int sch_id );
+  void generate_mem_accesses();
+  void memory_coalescing_arch(bool is_write, mem_access_type access_type);
+  void memory_coalescing_arch_atomic(bool is_write,
+                                     mem_access_type access_type);
+  void memory_coalescing_arch_reduce_and_send(bool is_write,
+                                              mem_access_type access_type,
+                                              const transaction_info &info,
+                                              new_addr_type addr,
+                                              unsigned segment_size);
 
-    const active_mask_t & get_active_mask() const
-    {
-    	return m_warp_active_mask;
+  void add_callback(unsigned lane_id, void (*function)(const class inst_t *,
+                                                       class ptx_thread_info *),
+                    const inst_t *inst, class ptx_thread_info *thread,
+                    bool atomic) {
+    if (!m_per_scalar_thread_valid) {
+      m_per_scalar_thread.resize(m_config->warp_size);
+      m_per_scalar_thread_valid = true;
+      if (atomic) m_isatomic = true;
     }
-    void completed( unsigned long long cycle ) const;  // stat collection: called when the instruction is completed  
+    m_per_scalar_thread[lane_id].callback.function = function;
+    m_per_scalar_thread[lane_id].callback.instruction = inst;
+    m_per_scalar_thread[lane_id].callback.thread = thread;
+  }
+  void set_active(const active_mask_t &active);
 
-    void set_addr( unsigned n, new_addr_type addr ) 
-    {
-        if( !m_per_scalar_thread_valid ) {
-            m_per_scalar_thread.resize(m_config->warp_size);
-            m_per_scalar_thread_valid=true;
-        }
-        m_per_scalar_thread[n].memreqaddr[0] = addr;
+  void clear_active(const active_mask_t &inactive);
+  void set_not_active(unsigned lane_id);
+
+  // accessors
+  virtual void print_insn(FILE *fp) const {
+    fprintf(fp, " [inst @ pc=0x%04x] ", pc);
+    for (int i = (int)m_config->warp_size - 1; i >= 0; i--)
+      fprintf(fp, "%c", ((m_warp_active_mask[i]) ? '1' : '0'));
+  }
+  bool active(unsigned thread) const { return m_warp_active_mask.test(thread); }
+  unsigned active_count() const { return m_warp_active_mask.count(); }
+  unsigned issued_count() const {
+    assert(m_empty == false);
+    return m_warp_issued_mask.count();
+  }  // for instruction counting
+  bool empty() const { return m_empty; }
+  unsigned warp_id() const {
+    assert(!m_empty);
+    return m_warp_id;
+  }
+  unsigned warp_id_func() const  // to be used in functional simulations only
+  {
+    return m_warp_id;
+  }
+  unsigned dynamic_warp_id() const {
+    assert(!m_empty);
+    return m_dynamic_warp_id;
+  }
+  bool has_callback(unsigned n) const {
+    return m_warp_active_mask[n] && m_per_scalar_thread_valid &&
+           (m_per_scalar_thread[n].callback.function != NULL);
+  }
+  new_addr_type get_addr(unsigned n) const {
+    assert(m_per_scalar_thread_valid);
+    return m_per_scalar_thread[n].memreqaddr[0];
+  }
+
+  bool isatomic() const { return m_isatomic; }
+
+  unsigned warp_size() const { return m_config->warp_size; }
+
+  bool accessq_empty() const { return m_accessq.empty(); }
+  unsigned accessq_count() const { return m_accessq.size(); }
+  const mem_access_t &accessq_back() { return m_accessq.back(); }
+  void accessq_pop_back() { m_accessq.pop_back(); }
+
+  bool dispatch_delay() {
+    if (cycles > 0) cycles--;
+    return cycles > 0;
+  }
+
+  bool has_dispatch_delay() { return cycles > 0; }
+
+  void print(FILE *fout) const;
+  unsigned get_uid() const { return m_uid; }
+  unsigned get_schd_id() const { return m_scheduler_id; }
+
+ protected:
+  unsigned m_uid;
+  bool m_empty;
+  bool m_cache_hit;
+  unsigned long long issue_cycle;
+  unsigned cycles;  // used for implementing initiation interval delay
+  bool m_isatomic;
+  bool m_is_printf;
+  unsigned m_warp_id;
+  unsigned m_dynamic_warp_id;
+  const core_config *m_config;
+  active_mask_t m_warp_active_mask;  // dynamic active mask for timing model
+                                     // (after predication)
+  active_mask_t m_warp_issued_mask;  // active mask at issue (prior to
+                                     // predication test) -- for instruction
+                                     // counting
+
+  struct per_thread_info {
+    per_thread_info() {
+      for (unsigned i = 0; i < MAX_ACCESSES_PER_INSN_PER_THREAD; i++)
+        memreqaddr[i] = 0;
     }
-    void set_addr( unsigned n, new_addr_type* addr, unsigned num_addrs )
-    {
-        if( !m_per_scalar_thread_valid ) {
-            m_per_scalar_thread.resize(m_config->warp_size);
-            m_per_scalar_thread_valid=true;
-        }
-        assert(num_addrs <= MAX_ACCESSES_PER_INSN_PER_THREAD);
-        for(unsigned i=0; i<num_addrs; i++)
-            m_per_scalar_thread[n].memreqaddr[i] = addr[i];
-    }
-    void print_m_accessq(){
-    		
-		if(accessq_empty())
-			return;
-		else{
-			printf("Printing mem access generated\n");
-			std::list<mem_access_t>::iterator it;	
-			for (it = m_accessq.begin(); it != m_accessq.end(); ++it){
-   				 printf("MEM_TXN_GEN:%s:%llx, Size:%d \n",mem_access_type_str(it->get_type()), it->get_addr(),it->get_size());
-			}	
-		}
-    }   
-    struct transaction_info {
-        std::bitset<4> chunks; // bitmask: 32-byte chunks accessed
-        mem_access_byte_mask_t bytes;
-        active_mask_t active; // threads in this transaction
+    dram_callback_t callback;
+    new_addr_type memreqaddr[MAX_ACCESSES_PER_INSN_PER_THREAD];  // effective
+                                                                 // address,
+                                                                 // upto 8
+                                                                 // different
+                                                                 // requests (to
+                                                                 // support 32B
+                                                                 // access in 8
+                                                                 // chunks of 4B
+                                                                 // each)
+  };
+  bool m_per_scalar_thread_valid;
+  std::vector<per_thread_info> m_per_scalar_thread;
+  bool m_mem_accesses_created;
+  std::list<mem_access_t> m_accessq;
 
-        bool test_bytes(unsigned start_bit, unsigned end_bit) {
-           for( unsigned i=start_bit; i<=end_bit; i++ )
-              if(bytes.test(i))
-                 return true;
-           return false;
-        }
-    };
+  unsigned m_scheduler_id;  // the scheduler that issues this inst
 
-    void generate_mem_accesses();
-    void memory_coalescing_arch( bool is_write, mem_access_type access_type );
-    void memory_coalescing_arch_atomic( bool is_write, mem_access_type access_type );
-    void memory_coalescing_arch_reduce_and_send( bool is_write, mem_access_type access_type, const transaction_info &info, new_addr_type addr, unsigned segment_size );
-
-    void add_callback( unsigned lane_id, 
-                       void (*function)(const class inst_t*, class ptx_thread_info*),
-                       const inst_t *inst, 
-                       class ptx_thread_info *thread,
-                       bool atomic)
-    {
-        if( !m_per_scalar_thread_valid ) {
-            m_per_scalar_thread.resize(m_config->warp_size);
-            m_per_scalar_thread_valid=true;
-            if(atomic) m_isatomic=true;
-        }
-        m_per_scalar_thread[lane_id].callback.function = function;
-        m_per_scalar_thread[lane_id].callback.instruction = inst;
-        m_per_scalar_thread[lane_id].callback.thread = thread;
-    }
-    void set_active( const active_mask_t &active );
-
-    void clear_active( const active_mask_t &inactive );
-    void set_not_active( unsigned lane_id );
-
-    // accessors
-    virtual void print_insn(FILE *fp) const 
-    {
-        fprintf(fp," [inst @ pc=0x%04x] ", pc );
-        for (int i=(int)m_config->warp_size-1; i>=0; i--)
-            fprintf(fp, "%c", ((m_warp_active_mask[i])?'1':'0') );
-    }
-    bool active( unsigned thread ) const { return m_warp_active_mask.test(thread); }
-    unsigned active_count() const { return m_warp_active_mask.count(); }
-    unsigned issued_count() const { assert(m_empty == false); return m_warp_issued_mask.count(); }  // for instruction counting 
-    bool empty() const { return m_empty; }
-    unsigned warp_id() const 
-    { 
-        assert( !m_empty );
-        return m_warp_id; 
-    }
-    unsigned warp_id_func() const // to be used in functional simulations only
-    { 
-        return m_warp_id; 
-    }
-    unsigned dynamic_warp_id() const 
-    { 
-        assert( !m_empty );
-        return m_dynamic_warp_id; 
-    }
-    bool has_callback( unsigned n ) const
-    {
-        return m_warp_active_mask[n] && m_per_scalar_thread_valid && 
-            (m_per_scalar_thread[n].callback.function!=NULL);
-    }
-    new_addr_type get_addr( unsigned n ) const
-    {
-        assert( m_per_scalar_thread_valid );
-        return m_per_scalar_thread[n].memreqaddr[0];
-    }
-
-    bool isatomic() const { return m_isatomic; }
-
-    unsigned warp_size() const { return m_config->warp_size; }
-
-    bool accessq_empty() const { return m_accessq.empty(); }
-    unsigned accessq_count() const { return m_accessq.size(); }
-    const mem_access_t &accessq_back() { return m_accessq.back(); }
-    void accessq_pop_back() { m_accessq.pop_back(); }
-
-    bool dispatch_delay()
-    { 
-        if( cycles > 0 ) 
-            cycles--;
-        return cycles > 0;
-    }
-
-    bool has_dispatch_delay(){
-    	return cycles > 0;
-    }
-
-    void print( FILE *fout ) const;
-    unsigned get_uid() const { return m_uid; }
-    unsigned get_schd_id() const { return m_scheduler_id; }
-
-protected:
-
-    unsigned m_uid;
-    bool m_empty;
-    bool m_cache_hit;
-    unsigned long long issue_cycle;
-    unsigned cycles; // used for implementing initiation interval delay
-    bool m_isatomic;
-    bool m_is_printf;
-    unsigned m_warp_id;
-    unsigned m_dynamic_warp_id; 
-    const core_config *m_config; 
-    active_mask_t m_warp_active_mask; // dynamic active mask for timing model (after predication)
-    active_mask_t m_warp_issued_mask; // active mask at issue (prior to predication test) -- for instruction counting
-
-    struct per_thread_info {
-        per_thread_info() {
-            for(unsigned i=0; i<MAX_ACCESSES_PER_INSN_PER_THREAD; i++)
-                memreqaddr[i] = 0;
-        }
-        dram_callback_t callback;
-        new_addr_type memreqaddr[MAX_ACCESSES_PER_INSN_PER_THREAD]; // effective address, upto 8 different requests (to support 32B access in 8 chunks of 4B each)
-    };
-    bool m_per_scalar_thread_valid;
-    std::vector<per_thread_info> m_per_scalar_thread;
-    bool m_mem_accesses_created;
-    std::list<mem_access_t> m_accessq;
-
-    unsigned m_scheduler_id;  //the scheduler that issues this inst
-
-    //Jin: cdp support
-public:
-    int m_is_cdp;
-    
+  // Jin: cdp support
+ public:
+  int m_is_cdp;
 };
 
-void move_warp( warp_inst_t *&dst, warp_inst_t *&src );
+void move_warp(warp_inst_t *&dst, warp_inst_t *&src);
 
-size_t get_kernel_code_size( class function_info *entry );
-class checkpoint
-{    
-public:
+size_t get_kernel_code_size(class function_info *entry);
+class checkpoint {
+ public:
+  checkpoint();
+  ~checkpoint() { printf("clasfsfss destructed\n"); }
 
-     checkpoint();
-    ~checkpoint(){
-      printf("clasfsfss destructed\n");
-    }
-
-    void load_global_mem(class memory_space *temp_mem, char * f1name);
-    void store_global_mem(class memory_space *mem, char * fname , char * format);
-    unsigned radnom;
-
-
+  void load_global_mem(class memory_space *temp_mem, char *f1name);
+  void store_global_mem(class memory_space *mem, char *fname, char *format);
+  unsigned radnom;
 };
 /*
- * This abstract class used as a base for functional and performance and simulation, it has basic functional simulation
- * data structures and procedures. 
+ * This abstract class used as a base for functional and performance and
+ * simulation, it has basic functional simulation
+ * data structures and procedures.
  */
 class core_t {
-    public:
-        core_t( gpgpu_sim *gpu, 
-                kernel_info_t *kernel,
-                unsigned warp_size,
-                unsigned threads_per_shader )
-            : m_gpu( gpu ),
-              m_kernel( kernel ),
-              m_simt_stack( NULL ),
-              m_thread( NULL ),
-              m_warp_size( warp_size )
-        {
-            m_warp_count = threads_per_shader/m_warp_size;
-            // Handle the case where the number of threads is not a
-            // multiple of the warp size
-            if ( threads_per_shader % m_warp_size != 0 ) {
-                m_warp_count += 1;
-            }
-            assert( m_warp_count * m_warp_size > 0 );
-            m_thread = ( ptx_thread_info** )
-                     calloc( m_warp_count * m_warp_size,
-                             sizeof( ptx_thread_info* ) );
-            initilizeSIMTStack(m_warp_count,m_warp_size);
+ public:
+  core_t(gpgpu_sim *gpu, kernel_info_t *kernel, unsigned warp_size,
+         unsigned threads_per_shader)
+      : m_gpu(gpu),
+        m_kernel(kernel),
+        m_simt_stack(NULL),
+        m_thread(NULL),
+        m_warp_size(warp_size) {
+    m_warp_count = threads_per_shader / m_warp_size;
+    // Handle the case where the number of threads is not a
+    // multiple of the warp size
+    if (threads_per_shader % m_warp_size != 0) {
+      m_warp_count += 1;
+    }
+    assert(m_warp_count * m_warp_size > 0);
+    m_thread = (ptx_thread_info **)calloc(m_warp_count * m_warp_size,
+                                          sizeof(ptx_thread_info *));
+    initilizeSIMTStack(m_warp_count, m_warp_size);
 
-            for(unsigned i=0; i<MAX_CTA_PER_SHADER; i++){
-            	for(unsigned j=0; j<MAX_BARRIERS_PER_CTA; j++){
-            		reduction_storage[i][j]=0;
-            	}
-            }
+    for (unsigned i = 0; i < MAX_CTA_PER_SHADER; i++) {
+      for (unsigned j = 0; j < MAX_BARRIERS_PER_CTA; j++) {
+        reduction_storage[i][j] = 0;
+      }
+    }
+  }
+  virtual ~core_t() { free(m_thread); }
+  virtual void warp_exit(unsigned warp_id) = 0;
+  virtual bool warp_waiting_at_barrier(unsigned warp_id) const = 0;
+  virtual void checkExecutionStatusAndUpdate(warp_inst_t &inst, unsigned t,
+                                             unsigned tid) = 0;
+  class gpgpu_sim *get_gpu() {
+    return m_gpu;
+  }
+  void execute_warp_inst_t(warp_inst_t &inst, unsigned warpId = (unsigned)-1);
+  bool ptx_thread_done(unsigned hw_thread_id) const;
+  void updateSIMTStack(unsigned warpId, warp_inst_t *inst);
+  void initilizeSIMTStack(unsigned warp_count, unsigned warps_size);
+  void deleteSIMTStack();
+  warp_inst_t getExecuteWarp(unsigned warpId);
+  void get_pdom_stack_top_info(unsigned warpId, unsigned *pc,
+                               unsigned *rpc) const;
+  kernel_info_t *get_kernel_info() { return m_kernel; }
+  class ptx_thread_info **get_thread_info() {
+    return m_thread;
+  }
+  unsigned get_warp_size() const { return m_warp_size; }
+  void and_reduction(unsigned ctaid, unsigned barid, bool value) {
+    reduction_storage[ctaid][barid] &= value;
+  }
+  void or_reduction(unsigned ctaid, unsigned barid, bool value) {
+    reduction_storage[ctaid][barid] |= value;
+  }
+  void popc_reduction(unsigned ctaid, unsigned barid, bool value) {
+    reduction_storage[ctaid][barid] += value;
+  }
+  unsigned get_reduction_value(unsigned ctaid, unsigned barid) {
+    return reduction_storage[ctaid][barid];
+  }
 
-        }
-        virtual ~core_t() { free(m_thread); }
-        virtual void warp_exit( unsigned warp_id ) = 0;
-        virtual bool warp_waiting_at_barrier( unsigned warp_id ) const = 0;
-        virtual void checkExecutionStatusAndUpdate(warp_inst_t &inst, unsigned t, unsigned tid)=0;
-        class gpgpu_sim * get_gpu() {return m_gpu;}
-        void execute_warp_inst_t(warp_inst_t &inst, unsigned warpId =(unsigned)-1);
-        bool  ptx_thread_done( unsigned hw_thread_id ) const ;
-        void updateSIMTStack(unsigned warpId, warp_inst_t * inst);
-        void initilizeSIMTStack(unsigned warp_count, unsigned warps_size);
-        void deleteSIMTStack();
-        warp_inst_t getExecuteWarp(unsigned warpId);
-        void get_pdom_stack_top_info( unsigned warpId, unsigned *pc, unsigned *rpc ) const;
-        kernel_info_t * get_kernel_info(){ return m_kernel;}
-        class ptx_thread_info ** get_thread_info() { return m_thread; }
-        unsigned get_warp_size() const { return m_warp_size; }
-        void and_reduction(unsigned ctaid, unsigned barid, bool value) { reduction_storage[ctaid][barid] &= value; }
-        void or_reduction(unsigned ctaid, unsigned barid, bool value) { reduction_storage[ctaid][barid] |= value; }
-        void popc_reduction(unsigned ctaid, unsigned barid, bool value) { reduction_storage[ctaid][barid] += value;}
-        unsigned get_reduction_value(unsigned ctaid, unsigned barid) {return reduction_storage[ctaid][barid];}
-    protected:
-        class gpgpu_sim *m_gpu;
-        kernel_info_t *m_kernel;
-        simt_stack  **m_simt_stack; // pdom based reconvergence context for each warp
-        class ptx_thread_info ** m_thread;
-        unsigned m_warp_size;
-        unsigned m_warp_count;
-        unsigned reduction_storage[MAX_CTA_PER_SHADER][MAX_BARRIERS_PER_CTA];
+ protected:
+  class gpgpu_sim *m_gpu;
+  kernel_info_t *m_kernel;
+  simt_stack **m_simt_stack;  // pdom based reconvergence context for each warp
+  class ptx_thread_info **m_thread;
+  unsigned m_warp_size;
+  unsigned m_warp_count;
+  unsigned reduction_storage[MAX_CTA_PER_SHADER][MAX_BARRIERS_PER_CTA];
 };
 
-
-//register that can hold multiple instructions.
+// register that can hold multiple instructions.
 class register_set {
-public:
-	register_set(unsigned num, const char* name){
-		for( unsigned i = 0; i < num; i++ ) {
-			regs.push_back(new warp_inst_t());
-		}
-		m_name = name;
-	}
-	bool has_free(){
-		for( unsigned i = 0; i < regs.size(); i++ ) {
-			if( regs[i]->empty() ) {
-				return true;
-			}
-		}
-		return false;
-	}
-	bool has_free(bool sub_core_model, unsigned reg_id){
-		//in subcore model, each sched has a one specific reg to use (based on sched id)
-		if(!sub_core_model)
-			return has_free();
+ public:
+  register_set(unsigned num, const char *name) {
+    for (unsigned i = 0; i < num; i++) {
+      regs.push_back(new warp_inst_t());
+    }
+    m_name = name;
+  }
+  bool has_free() {
+    for (unsigned i = 0; i < regs.size(); i++) {
+      if (regs[i]->empty()) {
+        return true;
+      }
+    }
+    return false;
+  }
+  bool has_free(bool sub_core_model, unsigned reg_id) {
+    // in subcore model, each sched has a one specific reg to use (based on
+    // sched id)
+    if (!sub_core_model) return has_free();
 
-		assert(reg_id < regs.size());
-		return regs[reg_id]->empty();
-	}
-	bool has_ready(){
-		for( unsigned i = 0; i < regs.size(); i++ ) {
-			if( not regs[i]->empty() ) {
-				return true;
-			}
-		}
-		return false;
-	}
+    assert(reg_id < regs.size());
+    return regs[reg_id]->empty();
+  }
+  bool has_ready() {
+    for (unsigned i = 0; i < regs.size(); i++) {
+      if (not regs[i]->empty()) {
+        return true;
+      }
+    }
+    return false;
+  }
 
-	void move_in( warp_inst_t *&src ){
-		warp_inst_t** free = get_free();
-		move_warp(*free, src);
-	}
-	//void copy_in( warp_inst_t* src ){
-		//   src->copy_contents_to(*get_free());
-		//}
-	void move_out_to( warp_inst_t *&dest ){
-		warp_inst_t **ready=get_ready();
-		move_warp(dest, *ready);
-	}
+  void move_in(warp_inst_t *&src) {
+    warp_inst_t **free = get_free();
+    move_warp(*free, src);
+  }
+  // void copy_in( warp_inst_t* src ){
+  //   src->copy_contents_to(*get_free());
+  //}
+  void move_out_to(warp_inst_t *&dest) {
+    warp_inst_t **ready = get_ready();
+    move_warp(dest, *ready);
+  }
 
-	warp_inst_t** get_ready(){
-		warp_inst_t** ready;
-		ready = NULL;
-		for( unsigned i = 0; i < regs.size(); i++ ) {
-			if( not regs[i]->empty() ) {
-				if( ready and (*ready)->get_uid() < regs[i]->get_uid() ) {
-					// ready is oldest
-				} else {
-					ready = &regs[i];
-				}
-			}
-		}
-		return ready;
-	}
+  warp_inst_t **get_ready() {
+    warp_inst_t **ready;
+    ready = NULL;
+    for (unsigned i = 0; i < regs.size(); i++) {
+      if (not regs[i]->empty()) {
+        if (ready and (*ready)->get_uid() < regs[i]->get_uid()) {
+          // ready is oldest
+        } else {
+          ready = &regs[i];
+        }
+      }
+    }
+    return ready;
+  }
 
-	void print(FILE* fp) const{
-		fprintf(fp, "%s : @%p\n", m_name, this);
-		for( unsigned i = 0; i < regs.size(); i++ ) {
-			fprintf(fp, "     ");
-			regs[i]->print(fp);
-			fprintf(fp, "\n");
-		}
-	}
+  void print(FILE *fp) const {
+    fprintf(fp, "%s : @%p\n", m_name, this);
+    for (unsigned i = 0; i < regs.size(); i++) {
+      fprintf(fp, "     ");
+      regs[i]->print(fp);
+      fprintf(fp, "\n");
+    }
+  }
 
-	warp_inst_t ** get_free(){
-		for( unsigned i = 0; i < regs.size(); i++ ) {
-			if( regs[i]->empty() ) {
-				return &regs[i];
-			}
-		}
-		assert(0 && "No free registers found");
-		return NULL;
-	}
+  warp_inst_t **get_free() {
+    for (unsigned i = 0; i < regs.size(); i++) {
+      if (regs[i]->empty()) {
+        return &regs[i];
+      }
+    }
+    assert(0 && "No free registers found");
+    return NULL;
+  }
 
-	warp_inst_t ** get_free(bool sub_core_model, unsigned reg_id){
-		//in subcore model, each sched has a one specific reg to use (based on sched id)
-		if(!sub_core_model)
-			return get_free();
+  warp_inst_t **get_free(bool sub_core_model, unsigned reg_id) {
+    // in subcore model, each sched has a one specific reg to use (based on
+    // sched id)
+    if (!sub_core_model) return get_free();
 
-		assert(reg_id < regs.size());
-		if( regs[reg_id]->empty() ) {
-			return &regs[reg_id];
-		}
-		assert(0 && "No free register found");
-		return NULL;
-	}
+    assert(reg_id < regs.size());
+    if (regs[reg_id]->empty()) {
+      return &regs[reg_id];
+    }
+    assert(0 && "No free register found");
+    return NULL;
+  }
 
-	unsigned get_size(){
-		return regs.size();
-	}
+  unsigned get_size() { return regs.size(); }
 
-private:
-	std::vector<warp_inst_t*> regs;
-	const char* m_name;
+ private:
+  std::vector<warp_inst_t *> regs;
+  const char *m_name;
 };
 
-#endif // #ifdef __cplusplus
+#endif  // #ifdef __cplusplus
 
-#endif // #ifndef ABSTRACT_HARDWARE_MODEL_INCLUDED
+#endif  // #ifndef ABSTRACT_HARDWARE_MODEL_INCLUDED

--- a/src/abstract_hardware_model.h
+++ b/src/abstract_hardware_model.h
@@ -7,23 +7,24 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef ABSTRACT_HARDWARE_MODEL_INCLUDED
 #define ABSTRACT_HARDWARE_MODEL_INCLUDED
@@ -33,45 +34,41 @@ class gpgpu_sim;
 class kernel_info_t;
 class gpgpu_context;
 
-
-//Set a hard limit of 32 CTAs per shader [cuda only has 8]
+// Set a hard limit of 32 CTAs per shader [cuda only has 8]
 #define MAX_CTA_PER_SHADER 32
 #define MAX_BARRIERS_PER_CTA 16
 
-//After expanding the vector input and output operands 
+// After expanding the vector input and output operands
 #define MAX_INPUT_VALUES 24
 #define MAX_OUTPUT_VALUES 8
 
 enum _memory_space_t {
-   undefined_space=0,
-   reg_space,
-   local_space,
-   shared_space,
-   sstarr_space,
-   param_space_unclassified,
-   param_space_kernel,  /* global to all threads in a kernel : read-only */
-   param_space_local,   /* local to a thread : read-writable */
-   const_space,
-   tex_space,
-   surf_space,
-   global_space,
-   generic_space,
-   instruction_space
+  undefined_space = 0,
+  reg_space,
+  local_space,
+  shared_space,
+  sstarr_space,
+  param_space_unclassified,
+  param_space_kernel, /* global to all threads in a kernel : read-only */
+  param_space_local,  /* local to a thread : read-writable */
+  const_space,
+  tex_space,
+  surf_space,
+  global_space,
+  generic_space,
+  instruction_space
 };
 
-
-enum FuncCache
-{
+enum FuncCache {
   FuncCachePreferNone = 0,
   FuncCachePreferShared = 1,
   FuncCachePreferL1 = 2
 };
 
-
 #ifdef __cplusplus
 
-#include <string.h>
 #include <stdio.h>
+#include <string.h>
 #include <set>
 
 typedef unsigned long long new_addr_type;
@@ -79,371 +76,357 @@ typedef unsigned long long cudaTextureObject_t;
 typedef unsigned address_type;
 typedef unsigned addr_t;
 
-// the following are operations the timing model can see 
+// the following are operations the timing model can see
 
 enum uarch_op_t {
-   NO_OP=-1,
-   ALU_OP=1,
-   SFU_OP,
-   TENSOR_CORE_OP,
-   DP_OP,
-   SP_OP,
-   INTP_OP,
-   ALU_SFU_OP,
-   LOAD_OP,
-   TENSOR_CORE_LOAD_OP,
-   TENSOR_CORE_STORE_OP,
-   STORE_OP,
-   BRANCH_OP,
-   BARRIER_OP,
-   MEMORY_BARRIER_OP,
-   CALL_OPS,
-   RET_OPS
+  NO_OP = -1,
+  ALU_OP = 1,
+  SFU_OP,
+  TENSOR_CORE_OP,
+  DP_OP,
+  SP_OP,
+  INTP_OP,
+  ALU_SFU_OP,
+  LOAD_OP,
+  TENSOR_CORE_LOAD_OP,
+  TENSOR_CORE_STORE_OP,
+  STORE_OP,
+  BRANCH_OP,
+  BARRIER_OP,
+  MEMORY_BARRIER_OP,
+  CALL_OPS,
+  RET_OPS
 };
 typedef enum uarch_op_t op_type;
 
-
-enum uarch_bar_t {
-   NOT_BAR=-1,
-   SYNC=1,
-   ARRIVE,
-   RED
-};
+enum uarch_bar_t { NOT_BAR = -1, SYNC = 1, ARRIVE, RED };
 typedef enum uarch_bar_t barrier_type;
 
-enum uarch_red_t {
-   NOT_RED=-1,
-   POPC_RED=1,
-   AND_RED,
-   OR_RED
-};
+enum uarch_red_t { NOT_RED = -1, POPC_RED = 1, AND_RED, OR_RED };
 typedef enum uarch_red_t reduction_type;
 
-
-enum uarch_operand_type_t {
-	UN_OP=-1,
-    INT_OP,
-    FP_OP
-};
+enum uarch_operand_type_t { UN_OP = -1, INT_OP, FP_OP };
 typedef enum uarch_operand_type_t types_of_operands;
 
 enum special_operations_t {
-    OTHER_OP,
-    INT__OP,
-	INT_MUL24_OP,
-	INT_MUL32_OP,
-	INT_MUL_OP,
-    INT_DIV_OP,
-    FP_MUL_OP,
-    FP_DIV_OP,
-    FP__OP,
-	FP_SQRT_OP,
-	FP_LG_OP,
-	FP_SIN_OP,
-	FP_EXP_OP
+  OTHER_OP,
+  INT__OP,
+  INT_MUL24_OP,
+  INT_MUL32_OP,
+  INT_MUL_OP,
+  INT_DIV_OP,
+  FP_MUL_OP,
+  FP_DIV_OP,
+  FP__OP,
+  FP_SQRT_OP,
+  FP_LG_OP,
+  FP_SIN_OP,
+  FP_EXP_OP
 };
-typedef enum special_operations_t special_ops; // Required to identify for the power model
+typedef enum special_operations_t
+    special_ops;  // Required to identify for the power model
 enum operation_pipeline_t {
-    UNKOWN_OP,
-    SP__OP,
-	DP__OP,
-	INTP__OP,
-    SFU__OP,
-    TENSOR_CORE__OP,
-    MEM__OP
+  UNKOWN_OP,
+  SP__OP,
+  DP__OP,
+  INTP__OP,
+  SFU__OP,
+  TENSOR_CORE__OP,
+  MEM__OP
 };
 typedef enum operation_pipeline_t operation_pipeline;
-enum mem_operation_t {
-    NOT_TEX,
-    TEX
-};
+enum mem_operation_t { NOT_TEX, TEX };
 typedef enum mem_operation_t mem_operation;
 
-enum _memory_op_t {
-	no_memory_op = 0,
-	memory_load,
-	memory_store
-};
+enum _memory_op_t { no_memory_op = 0, memory_load, memory_store };
 
-#include <bitset>
-#include <list>
-#include <vector>
 #include <assert.h>
 #include <stdlib.h>
-#include <map>
-#include <deque>
 #include <algorithm>
+#include <bitset>
+#include <deque>
+#include <list>
+#include <map>
+#include <vector>
 
 #if !defined(__VECTOR_TYPES_H__)
 #include "vector_types.h"
 #endif
 struct dim3comp {
-    bool operator() (const dim3 & a, const dim3 & b) const
-    {    
-        if(a.z < b.z)
-            return true;
-        else if(a.y < b.y)
-            return true;
-        else if (a.x < b.x)
-            return true;
-        else
-            return false;
-    }
+  bool operator()(const dim3 &a, const dim3 &b) const {
+    if (a.z < b.z)
+      return true;
+    else if (a.y < b.y)
+      return true;
+    else if (a.x < b.x)
+      return true;
+    else
+      return false;
+  }
 };
 
-void increment_x_then_y_then_z( dim3 &i, const dim3 &bound);
+void increment_x_then_y_then_z(dim3 &i, const dim3 &bound);
 
-//Jin: child kernel information for CDP
+// Jin: child kernel information for CDP
 #include "stream_manager.h"
 class stream_manager;
 struct CUstream_st;
-//extern stream_manager * g_stream_manager;
-//support for pinned memories added
-extern std::map<void *,void **> pinned_memory;
+// extern stream_manager * g_stream_manager;
+// support for pinned memories added
+extern std::map<void *, void **> pinned_memory;
 extern std::map<void *, size_t> pinned_memory_size;
 
 class kernel_info_t {
-public:
-//   kernel_info_t()
-//   {
-//      m_valid=false;
-//      m_kernel_entry=NULL;
-//      m_uid=0;
-//      m_num_cores_running=0;
-//      m_param_mem=NULL;
-//   }
-   kernel_info_t( dim3 gridDim, dim3 blockDim, class function_info *entry);
-   kernel_info_t( dim3 gridDim, dim3 blockDim, class function_info *entry, std::map<std::string, const struct cudaArray*> nameToCudaArray, std::map<std::string, const struct textureInfo*> nameToTextureInfo);
-   ~kernel_info_t();
+ public:
+  //   kernel_info_t()
+  //   {
+  //      m_valid=false;
+  //      m_kernel_entry=NULL;
+  //      m_uid=0;
+  //      m_num_cores_running=0;
+  //      m_param_mem=NULL;
+  //   }
+  kernel_info_t(dim3 gridDim, dim3 blockDim, class function_info *entry);
+  kernel_info_t(
+      dim3 gridDim, dim3 blockDim, class function_info *entry,
+      std::map<std::string, const struct cudaArray *> nameToCudaArray,
+      std::map<std::string, const struct textureInfo *> nameToTextureInfo);
+  ~kernel_info_t();
 
-   void inc_running() { m_num_cores_running++; }
-   void dec_running()
-   {
-       assert( m_num_cores_running > 0 );
-       m_num_cores_running--; 
-   }
-   bool running() const { return m_num_cores_running>0; }
-   bool done() const 
-   {
-       return no_more_ctas_to_run() && !running();
-   }
-   class function_info *entry() { return m_kernel_entry; }
-   const class function_info *entry() const { return m_kernel_entry; }
+  void inc_running() { m_num_cores_running++; }
+  void dec_running() {
+    assert(m_num_cores_running > 0);
+    m_num_cores_running--;
+  }
+  bool running() const { return m_num_cores_running > 0; }
+  bool done() const { return no_more_ctas_to_run() && !running(); }
+  class function_info *entry() {
+    return m_kernel_entry;
+  }
+  const class function_info *entry() const { return m_kernel_entry; }
 
-   size_t num_blocks() const
-   {
-      return m_grid_dim.x * m_grid_dim.y * m_grid_dim.z;
-   }
+  size_t num_blocks() const {
+    return m_grid_dim.x * m_grid_dim.y * m_grid_dim.z;
+  }
 
-   size_t threads_per_cta() const
-   {
-      return m_block_dim.x * m_block_dim.y * m_block_dim.z;
-   } 
+  size_t threads_per_cta() const {
+    return m_block_dim.x * m_block_dim.y * m_block_dim.z;
+  }
 
-   dim3 get_grid_dim() const { return m_grid_dim; }
-   dim3 get_cta_dim() const { return m_block_dim; }
+  dim3 get_grid_dim() const { return m_grid_dim; }
+  dim3 get_cta_dim() const { return m_block_dim; }
 
-   void increment_cta_id() 
-   { 
-      increment_x_then_y_then_z(m_next_cta,m_grid_dim); 
-      m_next_tid.x=0;
-      m_next_tid.y=0;
-      m_next_tid.z=0;
-   }
-   dim3 get_next_cta_id() const { return m_next_cta; }
-   unsigned get_next_cta_id_single() const 
-   {
-      return m_next_cta.x + m_grid_dim.x*m_next_cta.y + m_grid_dim.x*m_grid_dim.y*m_next_cta.z;
-    }
-   bool no_more_ctas_to_run() const 
-   {
-      return (m_next_cta.x >= m_grid_dim.x || m_next_cta.y >= m_grid_dim.y || m_next_cta.z >= m_grid_dim.z );
-   }
+  void increment_cta_id() {
+    increment_x_then_y_then_z(m_next_cta, m_grid_dim);
+    m_next_tid.x = 0;
+    m_next_tid.y = 0;
+    m_next_tid.z = 0;
+  }
+  dim3 get_next_cta_id() const { return m_next_cta; }
+  unsigned get_next_cta_id_single() const {
+    return m_next_cta.x + m_grid_dim.x * m_next_cta.y +
+           m_grid_dim.x * m_grid_dim.y * m_next_cta.z;
+  }
+  bool no_more_ctas_to_run() const {
+    return (m_next_cta.x >= m_grid_dim.x || m_next_cta.y >= m_grid_dim.y ||
+            m_next_cta.z >= m_grid_dim.z);
+  }
 
-   void increment_thread_id() { increment_x_then_y_then_z(m_next_tid,m_block_dim); }
-   dim3 get_next_thread_id_3d() const  { return m_next_tid; }
-   unsigned get_next_thread_id() const 
-   { 
-      return m_next_tid.x + m_block_dim.x*m_next_tid.y + m_block_dim.x*m_block_dim.y*m_next_tid.z;
-   }
-   bool more_threads_in_cta() const 
-   {
-      return m_next_tid.z < m_block_dim.z && m_next_tid.y < m_block_dim.y && m_next_tid.x < m_block_dim.x;
-   }
-   unsigned get_uid() const { return m_uid; }
-   std::string name() const;
+  void increment_thread_id() {
+    increment_x_then_y_then_z(m_next_tid, m_block_dim);
+  }
+  dim3 get_next_thread_id_3d() const { return m_next_tid; }
+  unsigned get_next_thread_id() const {
+    return m_next_tid.x + m_block_dim.x * m_next_tid.y +
+           m_block_dim.x * m_block_dim.y * m_next_tid.z;
+  }
+  bool more_threads_in_cta() const {
+    return m_next_tid.z < m_block_dim.z && m_next_tid.y < m_block_dim.y &&
+           m_next_tid.x < m_block_dim.x;
+  }
+  unsigned get_uid() const { return m_uid; }
+  std::string name() const;
 
-   std::list<class ptx_thread_info *> &active_threads() { return m_active_threads; }
-   class memory_space *get_param_memory() { return m_param_mem; }
+  std::list<class ptx_thread_info *> &active_threads() {
+    return m_active_threads;
+  }
+  class memory_space *get_param_memory() {
+    return m_param_mem;
+  }
 
-   
-   //The following functions access texture bindings present at the kernel's launch
-   
-   const struct cudaArray* get_texarray( const std::string &texname ) const
-   {
-      std::map<std::string,const struct cudaArray*>::const_iterator t=m_NameToCudaArray.find(texname);
-      assert(t != m_NameToCudaArray.end());
-      return t->second;
-   }
+  // The following functions access texture bindings present at the kernel's
+  // launch
 
-   const struct textureInfo* get_texinfo( const std::string &texname ) const
-   {
-      std::map<std::string, const struct textureInfo*>::const_iterator t=m_NameToTextureInfo.find(texname);
-      assert(t != m_NameToTextureInfo.end());
-      return t->second;
-   }
+  const struct cudaArray *get_texarray(const std::string &texname) const {
+    std::map<std::string, const struct cudaArray *>::const_iterator t =
+        m_NameToCudaArray.find(texname);
+    assert(t != m_NameToCudaArray.end());
+    return t->second;
+  }
 
-private:
-   kernel_info_t( const kernel_info_t & ); // disable copy constructor
-   void operator=( const kernel_info_t & ); // disable copy operator
+  const struct textureInfo *get_texinfo(const std::string &texname) const {
+    std::map<std::string, const struct textureInfo *>::const_iterator t =
+        m_NameToTextureInfo.find(texname);
+    assert(t != m_NameToTextureInfo.end());
+    return t->second;
+  }
 
-   class function_info *m_kernel_entry;
+ private:
+  kernel_info_t(const kernel_info_t &);   // disable copy constructor
+  void operator=(const kernel_info_t &);  // disable copy operator
 
-   unsigned m_uid;
-   
-   //These maps contain the snapshot of the texture mappings at kernel launch
-   std::map<std::string, const struct cudaArray*> m_NameToCudaArray;
-   std::map<std::string, const struct textureInfo*> m_NameToTextureInfo;
+  class function_info *m_kernel_entry;
 
-   dim3 m_grid_dim;
-   dim3 m_block_dim;
-   dim3 m_next_cta;
-   dim3 m_next_tid;
+  unsigned m_uid;
 
-   unsigned m_num_cores_running;
+  // These maps contain the snapshot of the texture mappings at kernel launch
+  std::map<std::string, const struct cudaArray *> m_NameToCudaArray;
+  std::map<std::string, const struct textureInfo *> m_NameToTextureInfo;
 
-   std::list<class ptx_thread_info *> m_active_threads;
-   class memory_space *m_param_mem;
+  dim3 m_grid_dim;
+  dim3 m_block_dim;
+  dim3 m_next_cta;
+  dim3 m_next_tid;
 
-public:
-   //Jin: parent and child kernel management for CDP
-   void set_parent(kernel_info_t * parent, dim3 parent_ctaid, dim3 parent_tid);
-   void set_child(kernel_info_t * child);
-   void remove_child(kernel_info_t * child);
-   bool is_finished();
-   bool children_all_finished();
-   void notify_parent_finished();
-   CUstream_st * create_stream_cta(dim3 ctaid);
-   CUstream_st * get_default_stream_cta(dim3 ctaid);
-   bool cta_has_stream(dim3 ctaid, CUstream_st* stream);
-   void destroy_cta_streams();
-   void print_parent_info();
-   kernel_info_t * get_parent() { return m_parent_kernel; }
+  unsigned m_num_cores_running;
 
-private:
-   kernel_info_t * m_parent_kernel;
-   dim3 m_parent_ctaid;
-   dim3 m_parent_tid;
-   std::list<kernel_info_t *> m_child_kernels; //child kernel launched
-   std::map< dim3, std::list<CUstream_st *>, dim3comp > m_cta_streams; //streams created in each CTA
+  std::list<class ptx_thread_info *> m_active_threads;
+  class memory_space *m_param_mem;
 
-//Jin: kernel timing
-public:
-   unsigned long long launch_cycle;
-   unsigned long long start_cycle;
-   unsigned long long end_cycle;
-   unsigned m_launch_latency;
+ public:
+  // Jin: parent and child kernel management for CDP
+  void set_parent(kernel_info_t *parent, dim3 parent_ctaid, dim3 parent_tid);
+  void set_child(kernel_info_t *child);
+  void remove_child(kernel_info_t *child);
+  bool is_finished();
+  bool children_all_finished();
+  void notify_parent_finished();
+  CUstream_st *create_stream_cta(dim3 ctaid);
+  CUstream_st *get_default_stream_cta(dim3 ctaid);
+  bool cta_has_stream(dim3 ctaid, CUstream_st *stream);
+  void destroy_cta_streams();
+  void print_parent_info();
+  kernel_info_t *get_parent() { return m_parent_kernel; }
 
-   mutable bool volta_cache_config_set;
+ private:
+  kernel_info_t *m_parent_kernel;
+  dim3 m_parent_ctaid;
+  dim3 m_parent_tid;
+  std::list<kernel_info_t *> m_child_kernels;  // child kernel launched
+  std::map<dim3, std::list<CUstream_st *>, dim3comp>
+      m_cta_streams;  // streams created in each CTA
+
+  // Jin: kernel timing
+ public:
+  unsigned long long launch_cycle;
+  unsigned long long start_cycle;
+  unsigned long long end_cycle;
+  unsigned m_launch_latency;
+
+  mutable bool volta_cache_config_set;
 };
 
 class core_config {
-    public:
-    core_config(gpgpu_context* ctx)
-    {
-	gpgpu_ctx = ctx;
-        m_valid = false; 
-        num_shmem_bank=16; 
-        shmem_limited_broadcast = false; 
-        gpgpu_shmem_sizeDefault=(unsigned)-1;
-        gpgpu_shmem_sizePrefL1=(unsigned)-1;
-        gpgpu_shmem_sizePrefShared=(unsigned)-1;
-    }
-    virtual void init() = 0;
+ public:
+  core_config(gpgpu_context *ctx) {
+    gpgpu_ctx = ctx;
+    m_valid = false;
+    num_shmem_bank = 16;
+    shmem_limited_broadcast = false;
+    gpgpu_shmem_sizeDefault = (unsigned)-1;
+    gpgpu_shmem_sizePrefL1 = (unsigned)-1;
+    gpgpu_shmem_sizePrefShared = (unsigned)-1;
+  }
+  virtual void init() = 0;
 
-    bool m_valid;
-    unsigned warp_size;
-    // backward pointer
-    class gpgpu_context* gpgpu_ctx;
+  bool m_valid;
+  unsigned warp_size;
+  // backward pointer
+  class gpgpu_context *gpgpu_ctx;
 
-    // off-chip memory request architecture parameters
-    int gpgpu_coalesce_arch;
+  // off-chip memory request architecture parameters
+  int gpgpu_coalesce_arch;
 
-    // shared memory bank conflict checking parameters
-    bool shmem_limited_broadcast;
-    static const address_type WORD_SIZE=4;
-    unsigned num_shmem_bank;
-    unsigned shmem_bank_func(address_type addr) const
-    {
-        return ((addr/WORD_SIZE) % num_shmem_bank);
-    }
-    unsigned mem_warp_parts;  
-    mutable unsigned gpgpu_shmem_size;
-    unsigned gpgpu_shmem_sizeDefault;
-    unsigned gpgpu_shmem_sizePrefL1;
-    unsigned gpgpu_shmem_sizePrefShared;
-    unsigned mem_unit_ports;
+  // shared memory bank conflict checking parameters
+  bool shmem_limited_broadcast;
+  static const address_type WORD_SIZE = 4;
+  unsigned num_shmem_bank;
+  unsigned shmem_bank_func(address_type addr) const {
+    return ((addr / WORD_SIZE) % num_shmem_bank);
+  }
+  unsigned mem_warp_parts;
+  mutable unsigned gpgpu_shmem_size;
+  unsigned gpgpu_shmem_sizeDefault;
+  unsigned gpgpu_shmem_sizePrefL1;
+  unsigned gpgpu_shmem_sizePrefShared;
+  unsigned mem_unit_ports;
 
-    // texture and constant cache line sizes (used to determine number of memory accesses)
-    unsigned gpgpu_cache_texl1_linesize;
-    unsigned gpgpu_cache_constl1_linesize;
+  // texture and constant cache line sizes (used to determine number of memory
+  // accesses)
+  unsigned gpgpu_cache_texl1_linesize;
+  unsigned gpgpu_cache_constl1_linesize;
 
-	unsigned gpgpu_max_insn_issue_per_warp;
-	bool gmem_skip_L1D; // on = global memory access always skip the L1 cache
+  unsigned gpgpu_max_insn_issue_per_warp;
+  bool gmem_skip_L1D;  // on = global memory access always skip the L1 cache
 
-	bool adaptive_volta_cache_config;
+  bool adaptive_volta_cache_config;
 };
 
-// bounded stack that implements simt reconvergence using pdom mechanism from MICRO'07 paper
+// bounded stack that implements simt reconvergence using pdom mechanism from
+// MICRO'07 paper
 const unsigned MAX_WARP_SIZE = 32;
 typedef std::bitset<MAX_WARP_SIZE> active_mask_t;
-#define MAX_WARP_SIZE_SIMT_STACK  MAX_WARP_SIZE
+#define MAX_WARP_SIZE_SIMT_STACK MAX_WARP_SIZE
 typedef std::bitset<MAX_WARP_SIZE_SIMT_STACK> simt_mask_t;
 typedef std::vector<address_type> addr_vector_t;
 
 class simt_stack {
-public:
-    simt_stack( unsigned wid,  unsigned warpSize, class gpgpu_sim * gpu);
+ public:
+  simt_stack(unsigned wid, unsigned warpSize, class gpgpu_sim *gpu);
 
-    void reset();
-    void launch( address_type start_pc, const simt_mask_t &active_mask );
-    void update( simt_mask_t &thread_done, addr_vector_t &next_pc, address_type recvg_pc, op_type next_inst_op,unsigned next_inst_size, address_type next_inst_pc );
+  void reset();
+  void launch(address_type start_pc, const simt_mask_t &active_mask);
+  void update(simt_mask_t &thread_done, addr_vector_t &next_pc,
+              address_type recvg_pc, op_type next_inst_op,
+              unsigned next_inst_size, address_type next_inst_pc);
 
-    const simt_mask_t &get_active_mask() const;
-    void     get_pdom_stack_top_info( unsigned *pc, unsigned *rpc ) const;
-    unsigned get_rp() const;
-    void     print(FILE *fp) const;
-    void     resume(char * fname) ;
-    void    print_checkpoint (FILE *fout) const;
+  const simt_mask_t &get_active_mask() const;
+  void get_pdom_stack_top_info(unsigned *pc, unsigned *rpc) const;
+  unsigned get_rp() const;
+  void print(FILE *fp) const;
+  void resume(char *fname);
+  void print_checkpoint(FILE *fout) const;
 
-protected:
-    unsigned m_warp_id;
-    unsigned m_warp_size;
+ protected:
+  unsigned m_warp_id;
+  unsigned m_warp_size;
 
+  enum stack_entry_type { STACK_ENTRY_TYPE_NORMAL = 0, STACK_ENTRY_TYPE_CALL };
 
-    enum stack_entry_type {
-        STACK_ENTRY_TYPE_NORMAL = 0,
-        STACK_ENTRY_TYPE_CALL
-    };
+  struct simt_stack_entry {
+    address_type m_pc;
+    unsigned int m_calldepth;
+    simt_mask_t m_active_mask;
+    address_type m_recvg_pc;
+    unsigned long long m_branch_div_cycle;
+    stack_entry_type m_type;
+    simt_stack_entry()
+        : m_pc(-1),
+          m_calldepth(0),
+          m_active_mask(),
+          m_recvg_pc(-1),
+          m_branch_div_cycle(0),
+          m_type(STACK_ENTRY_TYPE_NORMAL){};
+  };
 
-    struct simt_stack_entry {
-        address_type m_pc;
-        unsigned int m_calldepth;
-        simt_mask_t m_active_mask;
-        address_type m_recvg_pc;
-        unsigned long long m_branch_div_cycle;
-        stack_entry_type m_type;
-        simt_stack_entry() :
-            m_pc(-1), m_calldepth(0), m_active_mask(), m_recvg_pc(-1), m_branch_div_cycle(0), m_type(STACK_ENTRY_TYPE_NORMAL) { };
-    };
+  std::deque<simt_stack_entry> m_stack;
 
-    std::deque<simt_stack_entry> m_stack;
-
-    class gpgpu_sim * m_gpu;
+  class gpgpu_sim *m_gpu;
 };
 
 // Let's just upgrade to C++11 so we can use constexpr here...
-// start allocating from this address (lower values used for allocating globals in .ptx file)
+// start allocating from this address (lower values used for allocating globals
+// in .ptx file)
 const unsigned long long GLOBAL_HEAP_START = 0xC0000000;
 // Volta max shmem size is 96kB
 const unsigned long long SHARED_MEM_SIZE_MAX = 96 * (1 << 10);
@@ -455,873 +438,928 @@ const unsigned MAX_STREAMING_MULTIPROCESSORS = 80;
 const unsigned MAX_THREAD_PER_SM = 1 << 11;
 // MAX 64 warps / SM
 const unsigned MAX_WARP_PER_SM = 1 << 6;
-const unsigned long long TOTAL_LOCAL_MEM_PER_SM = MAX_THREAD_PER_SM * LOCAL_MEM_SIZE_MAX;
-const unsigned long long TOTAL_SHARED_MEM = MAX_STREAMING_MULTIPROCESSORS * SHARED_MEM_SIZE_MAX;
-const unsigned long long TOTAL_LOCAL_MEM = MAX_STREAMING_MULTIPROCESSORS * MAX_THREAD_PER_SM * LOCAL_MEM_SIZE_MAX;
-const unsigned long long SHARED_GENERIC_START = GLOBAL_HEAP_START - TOTAL_SHARED_MEM;
-const unsigned long long LOCAL_GENERIC_START = SHARED_GENERIC_START - TOTAL_LOCAL_MEM;
-const unsigned long long STATIC_ALLOC_LIMIT = GLOBAL_HEAP_START - (TOTAL_LOCAL_MEM + TOTAL_SHARED_MEM);
+const unsigned long long TOTAL_LOCAL_MEM_PER_SM =
+    MAX_THREAD_PER_SM * LOCAL_MEM_SIZE_MAX;
+const unsigned long long TOTAL_SHARED_MEM =
+    MAX_STREAMING_MULTIPROCESSORS * SHARED_MEM_SIZE_MAX;
+const unsigned long long TOTAL_LOCAL_MEM =
+    MAX_STREAMING_MULTIPROCESSORS * MAX_THREAD_PER_SM * LOCAL_MEM_SIZE_MAX;
+const unsigned long long SHARED_GENERIC_START =
+    GLOBAL_HEAP_START - TOTAL_SHARED_MEM;
+const unsigned long long LOCAL_GENERIC_START =
+    SHARED_GENERIC_START - TOTAL_LOCAL_MEM;
+const unsigned long long STATIC_ALLOC_LIMIT =
+    GLOBAL_HEAP_START - (TOTAL_LOCAL_MEM + TOTAL_SHARED_MEM);
 
 #if !defined(__CUDA_RUNTIME_API_H__)
 
 #include "builtin_types.h"
 
 struct cudaArray {
-   void *devPtr;
-   int devPtr32;
-   struct cudaChannelFormatDesc desc;
-   int width;
-   int height;
-   int size; //in bytes
-   unsigned dimensions;
+  void *devPtr;
+  int devPtr32;
+  struct cudaChannelFormatDesc desc;
+  int width;
+  int height;
+  int size;  // in bytes
+  unsigned dimensions;
 };
 
 #endif
 
-// Struct that record other attributes in the textureReference declaration 
+// Struct that record other attributes in the textureReference declaration
 // - These attributes are passed thru __cudaRegisterTexture()
 struct textureReferenceAttr {
-    const struct textureReference *m_texref; 
-    int m_dim; 
-    enum cudaTextureReadMode m_readmode; 
-    int m_ext; 
-    textureReferenceAttr(const struct textureReference *texref, 
-                         int dim, 
-                         enum cudaTextureReadMode readmode, 
-                         int ext)
-    : m_texref(texref), m_dim(dim), m_readmode(readmode), m_ext(ext) 
-    {  }
+  const struct textureReference *m_texref;
+  int m_dim;
+  enum cudaTextureReadMode m_readmode;
+  int m_ext;
+  textureReferenceAttr(const struct textureReference *texref, int dim,
+                       enum cudaTextureReadMode readmode, int ext)
+      : m_texref(texref), m_dim(dim), m_readmode(readmode), m_ext(ext) {}
 };
 
-class gpgpu_functional_sim_config 
-{
-public:
-    void reg_options(class OptionParser * opp);
+class gpgpu_functional_sim_config {
+ public:
+  void reg_options(class OptionParser *opp);
 
-    void ptx_set_tex_cache_linesize(unsigned linesize);
+  void ptx_set_tex_cache_linesize(unsigned linesize);
 
-    unsigned get_forced_max_capability() const { return m_ptx_force_max_capability; }
-    bool convert_to_ptxplus() const { return m_ptx_convert_to_ptxplus; }
-    bool use_cuobjdump() const { return m_ptx_use_cuobjdump; }
-    bool experimental_lib_support() const { return m_experimental_lib_support; }
+  unsigned get_forced_max_capability() const {
+    return m_ptx_force_max_capability;
+  }
+  bool convert_to_ptxplus() const { return m_ptx_convert_to_ptxplus; }
+  bool use_cuobjdump() const { return m_ptx_use_cuobjdump; }
+  bool experimental_lib_support() const { return m_experimental_lib_support; }
 
-    int         get_ptx_inst_debug_to_file() const { return g_ptx_inst_debug_to_file; }
-    const char* get_ptx_inst_debug_file() const  { return g_ptx_inst_debug_file; }
-    int         get_ptx_inst_debug_thread_uid() const { return g_ptx_inst_debug_thread_uid; }
-    unsigned    get_texcache_linesize() const { return m_texcache_linesize; }
-    int get_checkpoint_option() const {return checkpoint_option; }
-    int get_checkpoint_kernel() const {return checkpoint_kernel; }
-    int get_checkpoint_CTA() const {return checkpoint_CTA; }
-    int get_resume_option() const {return resume_option; }
-    int get_resume_kernel() const {return resume_kernel; }
-    int get_resume_CTA() const {return resume_CTA; }
-    int get_checkpoint_CTA_t() const {return checkpoint_CTA_t; }
-    int get_checkpoint_insn_Y() const {return checkpoint_insn_Y; }
-private:
-    // PTX options
-    int m_ptx_convert_to_ptxplus;
-    int m_ptx_use_cuobjdump;
-    int m_experimental_lib_support;
-    unsigned m_ptx_force_max_capability;
-    int checkpoint_option;
-    int checkpoint_kernel;
-    int checkpoint_CTA;
-    unsigned resume_option;
-    unsigned resume_kernel;
-    unsigned resume_CTA;
-    unsigned checkpoint_CTA_t;
-    int checkpoint_insn_Y;
-    int   g_ptx_inst_debug_to_file;
-    char* g_ptx_inst_debug_file;
-    int   g_ptx_inst_debug_thread_uid;
+  int get_ptx_inst_debug_to_file() const { return g_ptx_inst_debug_to_file; }
+  const char *get_ptx_inst_debug_file() const { return g_ptx_inst_debug_file; }
+  int get_ptx_inst_debug_thread_uid() const {
+    return g_ptx_inst_debug_thread_uid;
+  }
+  unsigned get_texcache_linesize() const { return m_texcache_linesize; }
+  int get_checkpoint_option() const { return checkpoint_option; }
+  int get_checkpoint_kernel() const { return checkpoint_kernel; }
+  int get_checkpoint_CTA() const { return checkpoint_CTA; }
+  int get_resume_option() const { return resume_option; }
+  int get_resume_kernel() const { return resume_kernel; }
+  int get_resume_CTA() const { return resume_CTA; }
+  int get_checkpoint_CTA_t() const { return checkpoint_CTA_t; }
+  int get_checkpoint_insn_Y() const { return checkpoint_insn_Y; }
 
-    unsigned m_texcache_linesize;
+ private:
+  // PTX options
+  int m_ptx_convert_to_ptxplus;
+  int m_ptx_use_cuobjdump;
+  int m_experimental_lib_support;
+  unsigned m_ptx_force_max_capability;
+  int checkpoint_option;
+  int checkpoint_kernel;
+  int checkpoint_CTA;
+  unsigned resume_option;
+  unsigned resume_kernel;
+  unsigned resume_CTA;
+  unsigned checkpoint_CTA_t;
+  int checkpoint_insn_Y;
+  int g_ptx_inst_debug_to_file;
+  char *g_ptx_inst_debug_file;
+  int g_ptx_inst_debug_thread_uid;
+
+  unsigned m_texcache_linesize;
 };
-
 
 class gpgpu_t {
-public:
-    gpgpu_t( const gpgpu_functional_sim_config &config, gpgpu_context* ctx );
-    // backward pointer
-    class gpgpu_context* gpgpu_ctx;
-    int checkpoint_option;
-    int checkpoint_kernel;
-    int checkpoint_CTA;
-    unsigned resume_option;
-    unsigned resume_kernel;
-    unsigned resume_CTA;
-    unsigned checkpoint_CTA_t;
-    int checkpoint_insn_Y;
+ public:
+  gpgpu_t(const gpgpu_functional_sim_config &config, gpgpu_context *ctx);
+  // backward pointer
+  class gpgpu_context *gpgpu_ctx;
+  int checkpoint_option;
+  int checkpoint_kernel;
+  int checkpoint_CTA;
+  unsigned resume_option;
+  unsigned resume_kernel;
+  unsigned resume_CTA;
+  unsigned checkpoint_CTA_t;
+  int checkpoint_insn_Y;
 
-    //Move some cycle core stats here instead of being global
-    unsigned long long  gpu_sim_cycle;
-    unsigned long long  gpu_tot_sim_cycle;
+  // Move some cycle core stats here instead of being global
+  unsigned long long gpu_sim_cycle;
+  unsigned long long gpu_tot_sim_cycle;
 
+  void *gpu_malloc(size_t size);
+  void *gpu_mallocarray(size_t count);
+  void gpu_memset(size_t dst_start_addr, int c, size_t count);
+  void memcpy_to_gpu(size_t dst_start_addr, const void *src, size_t count);
+  void memcpy_from_gpu(void *dst, size_t src_start_addr, size_t count);
+  void memcpy_gpu_to_gpu(size_t dst, size_t src, size_t count);
 
-    void* gpu_malloc( size_t size );
-    void* gpu_mallocarray( size_t count );
-    void  gpu_memset( size_t dst_start_addr, int c, size_t count );
-    void  memcpy_to_gpu( size_t dst_start_addr, const void *src, size_t count );
-    void  memcpy_from_gpu( void *dst, size_t src_start_addr, size_t count );
-    void  memcpy_gpu_to_gpu( size_t dst, size_t src, size_t count );
-    
-    class memory_space *get_global_memory() { return m_global_mem; }
-    class memory_space *get_tex_memory() { return m_tex_mem; }
-    class memory_space *get_surf_memory() { return m_surf_mem; }
+  class memory_space *get_global_memory() {
+    return m_global_mem;
+  }
+  class memory_space *get_tex_memory() {
+    return m_tex_mem;
+  }
+  class memory_space *get_surf_memory() {
+    return m_surf_mem;
+  }
 
-    void gpgpu_ptx_sim_bindTextureToArray(const struct textureReference* texref, const struct cudaArray* array);
-    void gpgpu_ptx_sim_bindNameToTexture(const char* name, const struct textureReference* texref, int dim, int readmode, int ext);
-    void gpgpu_ptx_sim_unbindTexture(const struct textureReference* texref);
-    const char* gpgpu_ptx_sim_findNamefromTexture(const struct textureReference* texref);
+  void gpgpu_ptx_sim_bindTextureToArray(const struct textureReference *texref,
+                                        const struct cudaArray *array);
+  void gpgpu_ptx_sim_bindNameToTexture(const char *name,
+                                       const struct textureReference *texref,
+                                       int dim, int readmode, int ext);
+  void gpgpu_ptx_sim_unbindTexture(const struct textureReference *texref);
+  const char *gpgpu_ptx_sim_findNamefromTexture(
+      const struct textureReference *texref);
 
-    const struct textureReference* get_texref( const std::string &texname ) const
-    {
-        std::map<std::string, std::set<const struct textureReference*> >::const_iterator t=m_NameToTextureRef.find(texname);
-        assert( t != m_NameToTextureRef.end() );
-        return *(t->second.begin());
-    }
+  const struct textureReference *get_texref(const std::string &texname) const {
+    std::map<std::string,
+             std::set<const struct textureReference *> >::const_iterator t =
+        m_NameToTextureRef.find(texname);
+    assert(t != m_NameToTextureRef.end());
+    return *(t->second.begin());
+  }
 
-    const struct cudaArray* get_texarray( const std::string &texname ) const
-    {
-        std::map<std::string,const struct cudaArray*>::const_iterator t=m_NameToCudaArray.find(texname);
-        assert(t != m_NameToCudaArray.end());
-        return t->second;
-    }
+  const struct cudaArray *get_texarray(const std::string &texname) const {
+    std::map<std::string, const struct cudaArray *>::const_iterator t =
+        m_NameToCudaArray.find(texname);
+    assert(t != m_NameToCudaArray.end());
+    return t->second;
+  }
 
-    const struct textureInfo* get_texinfo( const std::string &texname ) const
-    {
-        std::map<std::string, const struct textureInfo*>::const_iterator t=m_NameToTextureInfo.find(texname);
-        assert(t != m_NameToTextureInfo.end());
-        return t->second;
-    }
+  const struct textureInfo *get_texinfo(const std::string &texname) const {
+    std::map<std::string, const struct textureInfo *>::const_iterator t =
+        m_NameToTextureInfo.find(texname);
+    assert(t != m_NameToTextureInfo.end());
+    return t->second;
+  }
 
-    const struct textureReferenceAttr* get_texattr( const std::string &texname ) const
-    {
-        std::map<std::string, const struct textureReferenceAttr*>::const_iterator t=m_NameToAttribute.find(texname);
-        assert(t != m_NameToAttribute.end());
-        return t->second;
-    }
+  const struct textureReferenceAttr *get_texattr(
+      const std::string &texname) const {
+    std::map<std::string, const struct textureReferenceAttr *>::const_iterator
+        t = m_NameToAttribute.find(texname);
+    assert(t != m_NameToAttribute.end());
+    return t->second;
+  }
 
-    const gpgpu_functional_sim_config &get_config() const { return m_function_model_config; }
-    FILE* get_ptx_inst_debug_file() { return ptx_inst_debug_file; }
-    
-    //  These maps return the current texture mappings for the GPU at any given time.
-    std::map<std::string, const struct cudaArray*> getNameArrayMapping() {return m_NameToCudaArray;}
-    std::map<std::string, const struct textureInfo*> getNameInfoMapping() {return m_NameToTextureInfo;}
+  const gpgpu_functional_sim_config &get_config() const {
+    return m_function_model_config;
+  }
+  FILE *get_ptx_inst_debug_file() { return ptx_inst_debug_file; }
 
-protected:
-    const gpgpu_functional_sim_config &m_function_model_config;
-    FILE* ptx_inst_debug_file;
+  //  These maps return the current texture mappings for the GPU at any given
+  //  time.
+  std::map<std::string, const struct cudaArray *> getNameArrayMapping() {
+    return m_NameToCudaArray;
+  }
+  std::map<std::string, const struct textureInfo *> getNameInfoMapping() {
+    return m_NameToTextureInfo;
+  }
 
-    class memory_space *m_global_mem;
-    class memory_space *m_tex_mem;
-    class memory_space *m_surf_mem;
+ protected:
+  const gpgpu_functional_sim_config &m_function_model_config;
+  FILE *ptx_inst_debug_file;
 
-    unsigned long long m_dev_malloc;
-    //  These maps contain the current texture mappings for the GPU at any given time. 
-    std::map<std::string, std::set<const struct textureReference*> > m_NameToTextureRef;
-    std::map<const struct textureReference*, std::string> m_TextureRefToName;
-    std::map<std::string, const struct cudaArray*> m_NameToCudaArray;
-    std::map<std::string, const struct textureInfo*> m_NameToTextureInfo;
-    std::map<std::string, const struct textureReferenceAttr*> m_NameToAttribute;
+  class memory_space *m_global_mem;
+  class memory_space *m_tex_mem;
+  class memory_space *m_surf_mem;
+
+  unsigned long long m_dev_malloc;
+  //  These maps contain the current texture mappings for the GPU at any given
+  //  time.
+  std::map<std::string, std::set<const struct textureReference *> >
+      m_NameToTextureRef;
+  std::map<const struct textureReference *, std::string> m_TextureRefToName;
+  std::map<std::string, const struct cudaArray *> m_NameToCudaArray;
+  std::map<std::string, const struct textureInfo *> m_NameToTextureInfo;
+  std::map<std::string, const struct textureReferenceAttr *> m_NameToAttribute;
 };
 
-struct gpgpu_ptx_sim_info
-{
-   // Holds properties of the kernel (Kernel's resource use). 
-   // These will be set to zero if a ptxinfo file is not present.
-   int lmem;
-   int smem;
-   int cmem;
-   int gmem;
-   int regs;
-   unsigned maxthreads;
-   unsigned ptx_version;
-   unsigned sm_target;
+struct gpgpu_ptx_sim_info {
+  // Holds properties of the kernel (Kernel's resource use).
+  // These will be set to zero if a ptxinfo file is not present.
+  int lmem;
+  int smem;
+  int cmem;
+  int gmem;
+  int regs;
+  unsigned maxthreads;
+  unsigned ptx_version;
+  unsigned sm_target;
 };
-
 
 struct gpgpu_ptx_sim_arg {
-   gpgpu_ptx_sim_arg() { m_start=NULL; }
-   gpgpu_ptx_sim_arg(const void *arg, size_t size, size_t offset)
-   {
-      m_start=arg;
-      m_nbytes=size;
-      m_offset=offset;
-   }
-   const void *m_start;
-   size_t m_nbytes;
-   size_t m_offset;
+  gpgpu_ptx_sim_arg() { m_start = NULL; }
+  gpgpu_ptx_sim_arg(const void *arg, size_t size, size_t offset) {
+    m_start = arg;
+    m_nbytes = size;
+    m_offset = offset;
+  }
+  const void *m_start;
+  size_t m_nbytes;
+  size_t m_offset;
 };
 
 typedef std::list<gpgpu_ptx_sim_arg> gpgpu_ptx_sim_arg_list_t;
 
 class memory_space_t {
-public:
-   memory_space_t() { m_type = undefined_space; m_bank=0; }
-   memory_space_t( const enum _memory_space_t &from ) { m_type = from; m_bank = 0; }
-   bool operator==( const memory_space_t &x ) const { return (m_bank == x.m_bank) && (m_type == x.m_type); }
-   bool operator!=( const memory_space_t &x ) const { return !(*this == x); }
-   bool operator<( const memory_space_t &x ) const 
-   { 
-      if(m_type < x.m_type)
-         return true;
-      else if(m_type > x.m_type)
-         return false;
-      else if( m_bank < x.m_bank )
-         return true; 
+ public:
+  memory_space_t() {
+    m_type = undefined_space;
+    m_bank = 0;
+  }
+  memory_space_t(const enum _memory_space_t &from) {
+    m_type = from;
+    m_bank = 0;
+  }
+  bool operator==(const memory_space_t &x) const {
+    return (m_bank == x.m_bank) && (m_type == x.m_type);
+  }
+  bool operator!=(const memory_space_t &x) const { return !(*this == x); }
+  bool operator<(const memory_space_t &x) const {
+    if (m_type < x.m_type)
+      return true;
+    else if (m_type > x.m_type)
       return false;
-   }
-   enum _memory_space_t get_type() const { return m_type; }
-   void set_type( enum _memory_space_t t ) { m_type = t; }
-   unsigned get_bank() const { return m_bank; }
-   void set_bank( unsigned b ) { m_bank = b; }
-   bool is_const() const { return (m_type == const_space) || (m_type == param_space_kernel); }
-   bool is_local() const { return (m_type == local_space) || (m_type == param_space_local); }
-   bool is_global() const { return (m_type == global_space); }
+    else if (m_bank < x.m_bank)
+      return true;
+    return false;
+  }
+  enum _memory_space_t get_type() const { return m_type; }
+  void set_type(enum _memory_space_t t) { m_type = t; }
+  unsigned get_bank() const { return m_bank; }
+  void set_bank(unsigned b) { m_bank = b; }
+  bool is_const() const {
+    return (m_type == const_space) || (m_type == param_space_kernel);
+  }
+  bool is_local() const {
+    return (m_type == local_space) || (m_type == param_space_local);
+  }
+  bool is_global() const { return (m_type == global_space); }
 
-private:
-   enum _memory_space_t m_type;
-   unsigned m_bank; // n in ".const[n]"; note .const == .const[0] (see PTX 2.1 manual, sec. 5.1.3)
+ private:
+  enum _memory_space_t m_type;
+  unsigned m_bank;  // n in ".const[n]"; note .const == .const[0] (see PTX 2.1
+                    // manual, sec. 5.1.3)
 };
 
 const unsigned MAX_MEMORY_ACCESS_SIZE = 128;
 typedef std::bitset<MAX_MEMORY_ACCESS_SIZE> mem_access_byte_mask_t;
-const unsigned SECTOR_CHUNCK_SIZE = 4;   //four sectors
-const unsigned SECTOR_SIZE = 32 ;        //sector is 32 bytes width
+const unsigned SECTOR_CHUNCK_SIZE = 4;  // four sectors
+const unsigned SECTOR_SIZE = 32;        // sector is 32 bytes width
 typedef std::bitset<SECTOR_CHUNCK_SIZE> mem_access_sector_mask_t;
 #define NO_PARTIAL_WRITE (mem_access_byte_mask_t())
 
-#define MEM_ACCESS_TYPE_TUP_DEF \
-MA_TUP_BEGIN( mem_access_type ) \
-   MA_TUP( GLOBAL_ACC_R ), \
-   MA_TUP( LOCAL_ACC_R ), \
-   MA_TUP( CONST_ACC_R ), \
-   MA_TUP( TEXTURE_ACC_R ), \
-   MA_TUP( GLOBAL_ACC_W ), \
-   MA_TUP( LOCAL_ACC_W ), \
-   MA_TUP( L1_WRBK_ACC ), \
-   MA_TUP( L2_WRBK_ACC ), \
-   MA_TUP( INST_ACC_R ), \
-   MA_TUP( L1_WR_ALLOC_R ), \
-   MA_TUP( L2_WR_ALLOC_R ), \
-   MA_TUP( NUM_MEM_ACCESS_TYPE ) \
-MA_TUP_END( mem_access_type ) 
+#define MEM_ACCESS_TYPE_TUP_DEF                                         \
+  MA_TUP_BEGIN(mem_access_type)                                         \
+  MA_TUP(GLOBAL_ACC_R), MA_TUP(LOCAL_ACC_R), MA_TUP(CONST_ACC_R),       \
+      MA_TUP(TEXTURE_ACC_R), MA_TUP(GLOBAL_ACC_W), MA_TUP(LOCAL_ACC_W), \
+      MA_TUP(L1_WRBK_ACC), MA_TUP(L2_WRBK_ACC), MA_TUP(INST_ACC_R),     \
+      MA_TUP(L1_WR_ALLOC_R), MA_TUP(L2_WR_ALLOC_R),                     \
+      MA_TUP(NUM_MEM_ACCESS_TYPE) MA_TUP_END(mem_access_type)
 
 #define MA_TUP_BEGIN(X) enum X {
 #define MA_TUP(X) X
-#define MA_TUP_END(X) };
+#define MA_TUP_END(X) \
+  }                   \
+  ;
 MEM_ACCESS_TYPE_TUP_DEF
 #undef MA_TUP_BEGIN
 #undef MA_TUP
 #undef MA_TUP_END
 
-const char * mem_access_type_str(enum mem_access_type access_type); 
+const char *mem_access_type_str(enum mem_access_type access_type);
 
 enum cache_operator_type {
-    CACHE_UNDEFINED, 
+  CACHE_UNDEFINED,
 
-    // loads
-    CACHE_ALL,          // .ca
-    CACHE_LAST_USE,     // .lu
-    CACHE_VOLATILE,     // .cv
-    CACHE_L1,     // .nc
-                       
-    // loads and stores 
-    CACHE_STREAMING,    // .cs
-    CACHE_GLOBAL,       // .cg
+  // loads
+  CACHE_ALL,       // .ca
+  CACHE_LAST_USE,  // .lu
+  CACHE_VOLATILE,  // .cv
+  CACHE_L1,        // .nc
 
-    // stores
-    CACHE_WRITE_BACK,   // .wb
-    CACHE_WRITE_THROUGH // .wt
+  // loads and stores
+  CACHE_STREAMING,  // .cs
+  CACHE_GLOBAL,     // .cg
+
+  // stores
+  CACHE_WRITE_BACK,    // .wb
+  CACHE_WRITE_THROUGH  // .wt
 };
 
 class mem_access_t {
-public:
-   mem_access_t(gpgpu_context* ctx) { init(ctx); }
-   mem_access_t( mem_access_type type, 
-                 new_addr_type address, 
-                 unsigned size,
-                 bool wr,
-		 gpgpu_context* ctx)
-   {
-       init(ctx);
-       m_type = type;
-       m_addr = address;
-       m_req_size = size;
-       m_write = wr;
-   }
-   mem_access_t( mem_access_type type, 
-                 new_addr_type address, 
-                 unsigned size, 
-                 bool wr, 
-                 const active_mask_t &active_mask,
-                 const mem_access_byte_mask_t &byte_mask,
-		 const mem_access_sector_mask_t &sector_mask,
-		 gpgpu_context* ctx)
-    : m_warp_mask(active_mask), m_byte_mask(byte_mask), m_sector_mask(sector_mask)
-   {
-      init(ctx);
-      m_type = type;
-      m_addr = address;
-      m_req_size = size;
-      m_write = wr;
-   }
+ public:
+  mem_access_t(gpgpu_context *ctx) { init(ctx); }
+  mem_access_t(mem_access_type type, new_addr_type address, unsigned size,
+               bool wr, gpgpu_context *ctx) {
+    init(ctx);
+    m_type = type;
+    m_addr = address;
+    m_req_size = size;
+    m_write = wr;
+  }
+  mem_access_t(mem_access_type type, new_addr_type address, unsigned size,
+               bool wr, const active_mask_t &active_mask,
+               const mem_access_byte_mask_t &byte_mask,
+               const mem_access_sector_mask_t &sector_mask, gpgpu_context *ctx)
+      : m_warp_mask(active_mask),
+        m_byte_mask(byte_mask),
+        m_sector_mask(sector_mask) {
+    init(ctx);
+    m_type = type;
+    m_addr = address;
+    m_req_size = size;
+    m_write = wr;
+  }
 
-   new_addr_type get_addr() const { return m_addr; }
-   void set_addr(new_addr_type addr) {m_addr=addr;}
-   unsigned get_size() const { return m_req_size; }
-   const active_mask_t &get_warp_mask() const { return m_warp_mask; }
-   bool is_write() const { return m_write; }
-   enum mem_access_type get_type() const { return m_type; }
-   mem_access_byte_mask_t get_byte_mask() const { return m_byte_mask; }
-   mem_access_sector_mask_t get_sector_mask() const { return m_sector_mask; }
+  new_addr_type get_addr() const { return m_addr; }
+  void set_addr(new_addr_type addr) { m_addr = addr; }
+  unsigned get_size() const { return m_req_size; }
+  const active_mask_t &get_warp_mask() const { return m_warp_mask; }
+  bool is_write() const { return m_write; }
+  enum mem_access_type get_type() const { return m_type; }
+  mem_access_byte_mask_t get_byte_mask() const { return m_byte_mask; }
+  mem_access_sector_mask_t get_sector_mask() const { return m_sector_mask; }
 
-   void print(FILE *fp) const
-   {
-       fprintf(fp,"addr=0x%llx, %s, size=%u, ", m_addr, m_write?"store":"load ", m_req_size );
-       switch(m_type) {
-       case GLOBAL_ACC_R:  fprintf(fp,"GLOBAL_R"); break;
-       case LOCAL_ACC_R:   fprintf(fp,"LOCAL_R "); break;
-       case CONST_ACC_R:   fprintf(fp,"CONST   "); break;
-       case TEXTURE_ACC_R: fprintf(fp,"TEXTURE "); break;
-       case GLOBAL_ACC_W:  fprintf(fp,"GLOBAL_W"); break;
-       case LOCAL_ACC_W:   fprintf(fp,"LOCAL_W "); break;
-       case L2_WRBK_ACC:   fprintf(fp,"L2_WRBK "); break;
-       case INST_ACC_R:    fprintf(fp,"INST    "); break;
-       case L1_WRBK_ACC:   fprintf(fp,"L1_WRBK "); break;
-       default:            fprintf(fp,"unknown "); break;
-       }
-   }
+  void print(FILE *fp) const {
+    fprintf(fp, "addr=0x%llx, %s, size=%u, ", m_addr,
+            m_write ? "store" : "load ", m_req_size);
+    switch (m_type) {
+      case GLOBAL_ACC_R:
+        fprintf(fp, "GLOBAL_R");
+        break;
+      case LOCAL_ACC_R:
+        fprintf(fp, "LOCAL_R ");
+        break;
+      case CONST_ACC_R:
+        fprintf(fp, "CONST   ");
+        break;
+      case TEXTURE_ACC_R:
+        fprintf(fp, "TEXTURE ");
+        break;
+      case GLOBAL_ACC_W:
+        fprintf(fp, "GLOBAL_W");
+        break;
+      case LOCAL_ACC_W:
+        fprintf(fp, "LOCAL_W ");
+        break;
+      case L2_WRBK_ACC:
+        fprintf(fp, "L2_WRBK ");
+        break;
+      case INST_ACC_R:
+        fprintf(fp, "INST    ");
+        break;
+      case L1_WRBK_ACC:
+        fprintf(fp, "L1_WRBK ");
+        break;
+      default:
+        fprintf(fp, "unknown ");
+        break;
+    }
+  }
 
-   gpgpu_context* gpgpu_ctx;
-private:
-   void init(gpgpu_context* ctx);
+  gpgpu_context *gpgpu_ctx;
 
-   unsigned      m_uid;
-   new_addr_type m_addr;     // request address
-   bool          m_write;
-   unsigned      m_req_size; // bytes
-   mem_access_type m_type;
-   active_mask_t m_warp_mask;
-   mem_access_byte_mask_t m_byte_mask;
-   mem_access_sector_mask_t m_sector_mask;
+ private:
+  void init(gpgpu_context *ctx);
+
+  unsigned m_uid;
+  new_addr_type m_addr;  // request address
+  bool m_write;
+  unsigned m_req_size;  // bytes
+  mem_access_type m_type;
+  active_mask_t m_warp_mask;
+  mem_access_byte_mask_t m_byte_mask;
+  mem_access_sector_mask_t m_sector_mask;
 };
 
 class mem_fetch;
 
 class mem_fetch_interface {
-public:
-    virtual bool full( unsigned size, bool write ) const = 0;
-    virtual void push( mem_fetch *mf ) = 0;
+ public:
+  virtual bool full(unsigned size, bool write) const = 0;
+  virtual void push(mem_fetch *mf) = 0;
 };
 
 class mem_fetch_allocator {
-public:
-    virtual mem_fetch *alloc( new_addr_type addr, mem_access_type type, unsigned size, bool wr, unsigned long long cycle ) const = 0;
-    virtual mem_fetch *alloc( const class warp_inst_t &inst, const mem_access_t &access, unsigned long long cycle ) const = 0;
+ public:
+  virtual mem_fetch *alloc(new_addr_type addr, mem_access_type type,
+                           unsigned size, bool wr,
+                           unsigned long long cycle) const = 0;
+  virtual mem_fetch *alloc(const class warp_inst_t &inst,
+                           const mem_access_t &access,
+                           unsigned long long cycle) const = 0;
 };
 
-// the maximum number of destination, source, or address uarch operands in a instruction
-#define MAX_REG_OPERANDS 32 
+// the maximum number of destination, source, or address uarch operands in a
+// instruction
+#define MAX_REG_OPERANDS 32
 
 struct dram_callback_t {
-   dram_callback_t() { function=NULL; instruction=NULL; thread=NULL; }
-   void (*function)(const class inst_t*, class ptx_thread_info*);
+  dram_callback_t() {
+    function = NULL;
+    instruction = NULL;
+    thread = NULL;
+  }
+  void (*function)(const class inst_t *, class ptx_thread_info *);
 
-   const class inst_t* instruction;
-   class ptx_thread_info *thread;
+  const class inst_t *instruction;
+  class ptx_thread_info *thread;
 };
 
 class inst_t {
-public:
-    inst_t()
-    {
-        m_decoded=false;
-        pc=(address_type)-1;
-        reconvergence_pc=(address_type)-1;
-        op=NO_OP;
-        bar_type=NOT_BAR;
-        red_type=NOT_RED;
-        bar_id=(unsigned)-1;
-        bar_count=(unsigned)-1;
-        oprnd_type=UN_OP;
-        sp_op=OTHER_OP;
-        op_pipe=UNKOWN_OP;
-        mem_op=NOT_TEX;
-        num_operands=0;
-        num_regs=0;
-        memset(out, 0, sizeof(unsigned)); 
-        memset(in, 0, sizeof(unsigned)); 
-        is_vectorin=0; 
-        is_vectorout=0;
-        space = memory_space_t();
-        cache_op = CACHE_UNDEFINED;
-        latency = 1;
-        initiation_interval = 1;
-        for( unsigned i=0; i < MAX_REG_OPERANDS; i++ ) {
-            arch_reg.src[i] = -1;
-            arch_reg.dst[i] = -1;
-        }
-        isize=0;
+ public:
+  inst_t() {
+    m_decoded = false;
+    pc = (address_type)-1;
+    reconvergence_pc = (address_type)-1;
+    op = NO_OP;
+    bar_type = NOT_BAR;
+    red_type = NOT_RED;
+    bar_id = (unsigned)-1;
+    bar_count = (unsigned)-1;
+    oprnd_type = UN_OP;
+    sp_op = OTHER_OP;
+    op_pipe = UNKOWN_OP;
+    mem_op = NOT_TEX;
+    num_operands = 0;
+    num_regs = 0;
+    memset(out, 0, sizeof(unsigned));
+    memset(in, 0, sizeof(unsigned));
+    is_vectorin = 0;
+    is_vectorout = 0;
+    space = memory_space_t();
+    cache_op = CACHE_UNDEFINED;
+    latency = 1;
+    initiation_interval = 1;
+    for (unsigned i = 0; i < MAX_REG_OPERANDS; i++) {
+      arch_reg.src[i] = -1;
+      arch_reg.dst[i] = -1;
     }
-    bool valid() const { return m_decoded; }
-    virtual void print_insn( FILE *fp ) const 
-    {
-        fprintf(fp," [inst @ pc=0x%04x] ", pc );
-    }
-    bool is_load() const { return (op == LOAD_OP ||op==TENSOR_CORE_LOAD_OP || memory_op == memory_load); }
-    bool is_store() const { return (op == STORE_OP ||op==TENSOR_CORE_STORE_OP || memory_op == memory_store); }
-    unsigned get_num_operands() const {return num_operands;}
-    unsigned get_num_regs() const {return num_regs;}
-    void set_num_regs(unsigned num) {num_regs=num;}
-    void set_num_operands(unsigned num) {num_operands=num;}
-    void set_bar_id(unsigned id) {bar_id=id;}
-    void set_bar_count(unsigned count) {bar_count=count;}
+    isize = 0;
+  }
+  bool valid() const { return m_decoded; }
+  virtual void print_insn(FILE *fp) const {
+    fprintf(fp, " [inst @ pc=0x%04x] ", pc);
+  }
+  bool is_load() const {
+    return (op == LOAD_OP || op == TENSOR_CORE_LOAD_OP ||
+            memory_op == memory_load);
+  }
+  bool is_store() const {
+    return (op == STORE_OP || op == TENSOR_CORE_STORE_OP ||
+            memory_op == memory_store);
+  }
+  unsigned get_num_operands() const { return num_operands; }
+  unsigned get_num_regs() const { return num_regs; }
+  void set_num_regs(unsigned num) { num_regs = num; }
+  void set_num_operands(unsigned num) { num_operands = num; }
+  void set_bar_id(unsigned id) { bar_id = id; }
+  void set_bar_count(unsigned count) { bar_count = count; }
 
-    address_type pc;        // program counter address of instruction
-    unsigned isize;         // size of instruction in bytes 
-    op_type op;             // opcode (uarch visible)
+  address_type pc;  // program counter address of instruction
+  unsigned isize;   // size of instruction in bytes
+  op_type op;       // opcode (uarch visible)
 
-    barrier_type bar_type;
-    reduction_type red_type;
-    unsigned bar_id;
-    unsigned bar_count;
+  barrier_type bar_type;
+  reduction_type red_type;
+  unsigned bar_id;
+  unsigned bar_count;
 
-    types_of_operands oprnd_type;     // code (uarch visible) identify if the operation is an interger or a floating point
-    special_ops sp_op;           // code (uarch visible) identify if int_alu, fp_alu, int_mul ....
-    operation_pipeline op_pipe;  // code (uarch visible) identify the pipeline of the operation (SP, SFU or MEM)
-    mem_operation mem_op;        // code (uarch visible) identify memory type
-    _memory_op_t memory_op; // memory_op used by ptxplus 
-    unsigned num_operands;
-    unsigned num_regs; // count vector operand as one register operand
+  types_of_operands oprnd_type;  // code (uarch visible) identify if the
+                                 // operation is an interger or a floating point
+  special_ops
+      sp_op;  // code (uarch visible) identify if int_alu, fp_alu, int_mul ....
+  operation_pipeline op_pipe;  // code (uarch visible) identify the pipeline of
+                               // the operation (SP, SFU or MEM)
+  mem_operation mem_op;        // code (uarch visible) identify memory type
+  _memory_op_t memory_op;      // memory_op used by ptxplus
+  unsigned num_operands;
+  unsigned num_regs;  // count vector operand as one register operand
 
-    address_type reconvergence_pc; // -1 => not a branch, -2 => use function return address
-    
-    unsigned out[8];
-    unsigned outcount;
-    unsigned in[24];
-    unsigned incount;
-    unsigned char is_vectorin;
-    unsigned char is_vectorout;
-    int pred; // predicate register number
-    int ar1, ar2;
-    // register number for bank conflict evaluation
-    struct {
-        int dst[MAX_REG_OPERANDS];
-        int src[MAX_REG_OPERANDS];
-    } arch_reg;
-    //int arch_reg[MAX_REG_OPERANDS]; // register number for bank conflict evaluation
-    unsigned latency; // operation latency
-    unsigned initiation_interval;
+  address_type reconvergence_pc;  // -1 => not a branch, -2 => use function
+                                  // return address
 
-    unsigned data_size; // what is the size of the word being operated on?
-    memory_space_t space;
-    cache_operator_type cache_op;
+  unsigned out[8];
+  unsigned outcount;
+  unsigned in[24];
+  unsigned incount;
+  unsigned char is_vectorin;
+  unsigned char is_vectorout;
+  int pred;  // predicate register number
+  int ar1, ar2;
+  // register number for bank conflict evaluation
+  struct {
+    int dst[MAX_REG_OPERANDS];
+    int src[MAX_REG_OPERANDS];
+  } arch_reg;
+  // int arch_reg[MAX_REG_OPERANDS]; // register number for bank conflict
+  // evaluation
+  unsigned latency;  // operation latency
+  unsigned initiation_interval;
 
-protected:
-    bool m_decoded;
-    virtual void pre_decode() {}
+  unsigned data_size;  // what is the size of the word being operated on?
+  memory_space_t space;
+  cache_operator_type cache_op;
+
+ protected:
+  bool m_decoded;
+  virtual void pre_decode() {}
 };
 
-enum divergence_support_t {
-   POST_DOMINATOR = 1,
-   NUM_SIMD_MODEL
-};
+enum divergence_support_t { POST_DOMINATOR = 1, NUM_SIMD_MODEL };
 
 const unsigned MAX_ACCESSES_PER_INSN_PER_THREAD = 8;
 
-class warp_inst_t: public inst_t {
-public:
-    // constructors
-    warp_inst_t() 
-    {
-        m_uid=0;
-        m_empty=true; 
-        m_config=NULL; 
+class warp_inst_t : public inst_t {
+ public:
+  // constructors
+  warp_inst_t() {
+    m_uid = 0;
+    m_empty = true;
+    m_config = NULL;
+  }
+  warp_inst_t(const core_config *config) {
+    m_uid = 0;
+    assert(config->warp_size <= MAX_WARP_SIZE);
+    m_config = config;
+    m_empty = true;
+    m_isatomic = false;
+    m_per_scalar_thread_valid = false;
+    m_mem_accesses_created = false;
+    m_cache_hit = false;
+    m_is_printf = false;
+    m_is_cdp = 0;
+  }
+  virtual ~warp_inst_t() {}
+
+  // modifiers
+  void broadcast_barrier_reduction(const active_mask_t &access_mask);
+  void do_atomic(bool forceDo = false);
+  void do_atomic(const active_mask_t &access_mask, bool forceDo = false);
+  void clear() { m_empty = true; }
+
+  void issue(const active_mask_t &mask, unsigned warp_id,
+             unsigned long long cycle, int dynamic_warp_id, int sch_id);
+
+  const active_mask_t &get_active_mask() const { return m_warp_active_mask; }
+  void completed(unsigned long long cycle)
+      const;  // stat collection: called when the instruction is completed
+
+  void set_addr(unsigned n, new_addr_type addr) {
+    if (!m_per_scalar_thread_valid) {
+      m_per_scalar_thread.resize(m_config->warp_size);
+      m_per_scalar_thread_valid = true;
     }
-    warp_inst_t( const core_config *config )
-    { 
-        m_uid=0;
-        assert(config->warp_size<=MAX_WARP_SIZE); 
-        m_config=config;
-        m_empty=true; 
-        m_isatomic=false;
-        m_per_scalar_thread_valid=false;
-        m_mem_accesses_created=false;
-        m_cache_hit=false;
-        m_is_printf=false;
-        m_is_cdp = 0;
+    m_per_scalar_thread[n].memreqaddr[0] = addr;
+  }
+  void set_addr(unsigned n, new_addr_type *addr, unsigned num_addrs) {
+    if (!m_per_scalar_thread_valid) {
+      m_per_scalar_thread.resize(m_config->warp_size);
+      m_per_scalar_thread_valid = true;
     }
-    virtual ~warp_inst_t(){
+    assert(num_addrs <= MAX_ACCESSES_PER_INSN_PER_THREAD);
+    for (unsigned i = 0; i < num_addrs; i++)
+      m_per_scalar_thread[n].memreqaddr[i] = addr[i];
+  }
+  void print_m_accessq() {
+    if (accessq_empty())
+      return;
+    else {
+      printf("Printing mem access generated\n");
+      std::list<mem_access_t>::iterator it;
+      for (it = m_accessq.begin(); it != m_accessq.end(); ++it) {
+        printf("MEM_TXN_GEN:%s:%llx, Size:%d \n",
+               mem_access_type_str(it->get_type()), it->get_addr(),
+               it->get_size());
+      }
     }
+  }
+  struct transaction_info {
+    std::bitset<4> chunks;  // bitmask: 32-byte chunks accessed
+    mem_access_byte_mask_t bytes;
+    active_mask_t active;  // threads in this transaction
 
-    // modifiers
-    void broadcast_barrier_reduction( const active_mask_t& access_mask);
-    void do_atomic(bool forceDo=false);
-    void do_atomic( const active_mask_t& access_mask, bool forceDo=false );
-    void clear() 
-    { 
-        m_empty=true; 
+    bool test_bytes(unsigned start_bit, unsigned end_bit) {
+      for (unsigned i = start_bit; i <= end_bit; i++)
+        if (bytes.test(i)) return true;
+      return false;
     }
+  };
 
-    void issue( const active_mask_t &mask, unsigned warp_id, unsigned long long cycle, int dynamic_warp_id, int sch_id );
+  void generate_mem_accesses();
+  void memory_coalescing_arch(bool is_write, mem_access_type access_type);
+  void memory_coalescing_arch_atomic(bool is_write,
+                                     mem_access_type access_type);
+  void memory_coalescing_arch_reduce_and_send(bool is_write,
+                                              mem_access_type access_type,
+                                              const transaction_info &info,
+                                              new_addr_type addr,
+                                              unsigned segment_size);
 
-    const active_mask_t & get_active_mask() const
-    {
-    	return m_warp_active_mask;
+  void add_callback(unsigned lane_id,
+                    void (*function)(const class inst_t *,
+                                     class ptx_thread_info *),
+                    const inst_t *inst, class ptx_thread_info *thread,
+                    bool atomic) {
+    if (!m_per_scalar_thread_valid) {
+      m_per_scalar_thread.resize(m_config->warp_size);
+      m_per_scalar_thread_valid = true;
+      if (atomic) m_isatomic = true;
     }
-    void completed( unsigned long long cycle ) const;  // stat collection: called when the instruction is completed  
+    m_per_scalar_thread[lane_id].callback.function = function;
+    m_per_scalar_thread[lane_id].callback.instruction = inst;
+    m_per_scalar_thread[lane_id].callback.thread = thread;
+  }
+  void set_active(const active_mask_t &active);
 
-    void set_addr( unsigned n, new_addr_type addr ) 
-    {
-        if( !m_per_scalar_thread_valid ) {
-            m_per_scalar_thread.resize(m_config->warp_size);
-            m_per_scalar_thread_valid=true;
-        }
-        m_per_scalar_thread[n].memreqaddr[0] = addr;
+  void clear_active(const active_mask_t &inactive);
+  void set_not_active(unsigned lane_id);
+
+  // accessors
+  virtual void print_insn(FILE *fp) const {
+    fprintf(fp, " [inst @ pc=0x%04x] ", pc);
+    for (int i = (int)m_config->warp_size - 1; i >= 0; i--)
+      fprintf(fp, "%c", ((m_warp_active_mask[i]) ? '1' : '0'));
+  }
+  bool active(unsigned thread) const { return m_warp_active_mask.test(thread); }
+  unsigned active_count() const { return m_warp_active_mask.count(); }
+  unsigned issued_count() const {
+    assert(m_empty == false);
+    return m_warp_issued_mask.count();
+  }  // for instruction counting
+  bool empty() const { return m_empty; }
+  unsigned warp_id() const {
+    assert(!m_empty);
+    return m_warp_id;
+  }
+  unsigned warp_id_func() const  // to be used in functional simulations only
+  {
+    return m_warp_id;
+  }
+  unsigned dynamic_warp_id() const {
+    assert(!m_empty);
+    return m_dynamic_warp_id;
+  }
+  bool has_callback(unsigned n) const {
+    return m_warp_active_mask[n] && m_per_scalar_thread_valid &&
+           (m_per_scalar_thread[n].callback.function != NULL);
+  }
+  new_addr_type get_addr(unsigned n) const {
+    assert(m_per_scalar_thread_valid);
+    return m_per_scalar_thread[n].memreqaddr[0];
+  }
+
+  bool isatomic() const { return m_isatomic; }
+
+  unsigned warp_size() const { return m_config->warp_size; }
+
+  bool accessq_empty() const { return m_accessq.empty(); }
+  unsigned accessq_count() const { return m_accessq.size(); }
+  const mem_access_t &accessq_back() { return m_accessq.back(); }
+  void accessq_pop_back() { m_accessq.pop_back(); }
+
+  bool dispatch_delay() {
+    if (cycles > 0) cycles--;
+    return cycles > 0;
+  }
+
+  bool has_dispatch_delay() { return cycles > 0; }
+
+  void print(FILE *fout) const;
+  unsigned get_uid() const { return m_uid; }
+  unsigned get_schd_id() const { return m_scheduler_id; }
+
+ protected:
+  unsigned m_uid;
+  bool m_empty;
+  bool m_cache_hit;
+  unsigned long long issue_cycle;
+  unsigned cycles;  // used for implementing initiation interval delay
+  bool m_isatomic;
+  bool m_is_printf;
+  unsigned m_warp_id;
+  unsigned m_dynamic_warp_id;
+  const core_config *m_config;
+  active_mask_t m_warp_active_mask;  // dynamic active mask for timing model
+                                     // (after predication)
+  active_mask_t
+      m_warp_issued_mask;  // active mask at issue (prior to predication test)
+                           // -- for instruction counting
+
+  struct per_thread_info {
+    per_thread_info() {
+      for (unsigned i = 0; i < MAX_ACCESSES_PER_INSN_PER_THREAD; i++)
+        memreqaddr[i] = 0;
     }
-    void set_addr( unsigned n, new_addr_type* addr, unsigned num_addrs )
-    {
-        if( !m_per_scalar_thread_valid ) {
-            m_per_scalar_thread.resize(m_config->warp_size);
-            m_per_scalar_thread_valid=true;
-        }
-        assert(num_addrs <= MAX_ACCESSES_PER_INSN_PER_THREAD);
-        for(unsigned i=0; i<num_addrs; i++)
-            m_per_scalar_thread[n].memreqaddr[i] = addr[i];
-    }
-    void print_m_accessq(){
-    		
-		if(accessq_empty())
-			return;
-		else{
-			printf("Printing mem access generated\n");
-			std::list<mem_access_t>::iterator it;	
-			for (it = m_accessq.begin(); it != m_accessq.end(); ++it){
-   				 printf("MEM_TXN_GEN:%s:%llx, Size:%d \n",mem_access_type_str(it->get_type()), it->get_addr(),it->get_size());
-			}	
-		}
-    }   
-    struct transaction_info {
-        std::bitset<4> chunks; // bitmask: 32-byte chunks accessed
-        mem_access_byte_mask_t bytes;
-        active_mask_t active; // threads in this transaction
+    dram_callback_t callback;
+    new_addr_type
+        memreqaddr[MAX_ACCESSES_PER_INSN_PER_THREAD];  // effective address,
+                                                       // upto 8 different
+                                                       // requests (to support
+                                                       // 32B access in 8 chunks
+                                                       // of 4B each)
+  };
+  bool m_per_scalar_thread_valid;
+  std::vector<per_thread_info> m_per_scalar_thread;
+  bool m_mem_accesses_created;
+  std::list<mem_access_t> m_accessq;
 
-        bool test_bytes(unsigned start_bit, unsigned end_bit) {
-           for( unsigned i=start_bit; i<=end_bit; i++ )
-              if(bytes.test(i))
-                 return true;
-           return false;
-        }
-    };
+  unsigned m_scheduler_id;  // the scheduler that issues this inst
 
-    void generate_mem_accesses();
-    void memory_coalescing_arch( bool is_write, mem_access_type access_type );
-    void memory_coalescing_arch_atomic( bool is_write, mem_access_type access_type );
-    void memory_coalescing_arch_reduce_and_send( bool is_write, mem_access_type access_type, const transaction_info &info, new_addr_type addr, unsigned segment_size );
-
-    void add_callback( unsigned lane_id, 
-                       void (*function)(const class inst_t*, class ptx_thread_info*),
-                       const inst_t *inst, 
-                       class ptx_thread_info *thread,
-                       bool atomic)
-    {
-        if( !m_per_scalar_thread_valid ) {
-            m_per_scalar_thread.resize(m_config->warp_size);
-            m_per_scalar_thread_valid=true;
-            if(atomic) m_isatomic=true;
-        }
-        m_per_scalar_thread[lane_id].callback.function = function;
-        m_per_scalar_thread[lane_id].callback.instruction = inst;
-        m_per_scalar_thread[lane_id].callback.thread = thread;
-    }
-    void set_active( const active_mask_t &active );
-
-    void clear_active( const active_mask_t &inactive );
-    void set_not_active( unsigned lane_id );
-
-    // accessors
-    virtual void print_insn(FILE *fp) const 
-    {
-        fprintf(fp," [inst @ pc=0x%04x] ", pc );
-        for (int i=(int)m_config->warp_size-1; i>=0; i--)
-            fprintf(fp, "%c", ((m_warp_active_mask[i])?'1':'0') );
-    }
-    bool active( unsigned thread ) const { return m_warp_active_mask.test(thread); }
-    unsigned active_count() const { return m_warp_active_mask.count(); }
-    unsigned issued_count() const { assert(m_empty == false); return m_warp_issued_mask.count(); }  // for instruction counting 
-    bool empty() const { return m_empty; }
-    unsigned warp_id() const 
-    { 
-        assert( !m_empty );
-        return m_warp_id; 
-    }
-    unsigned warp_id_func() const // to be used in functional simulations only
-    { 
-        return m_warp_id; 
-    }
-    unsigned dynamic_warp_id() const 
-    { 
-        assert( !m_empty );
-        return m_dynamic_warp_id; 
-    }
-    bool has_callback( unsigned n ) const
-    {
-        return m_warp_active_mask[n] && m_per_scalar_thread_valid && 
-            (m_per_scalar_thread[n].callback.function!=NULL);
-    }
-    new_addr_type get_addr( unsigned n ) const
-    {
-        assert( m_per_scalar_thread_valid );
-        return m_per_scalar_thread[n].memreqaddr[0];
-    }
-
-    bool isatomic() const { return m_isatomic; }
-
-    unsigned warp_size() const { return m_config->warp_size; }
-
-    bool accessq_empty() const { return m_accessq.empty(); }
-    unsigned accessq_count() const { return m_accessq.size(); }
-    const mem_access_t &accessq_back() { return m_accessq.back(); }
-    void accessq_pop_back() { m_accessq.pop_back(); }
-
-    bool dispatch_delay()
-    { 
-        if( cycles > 0 ) 
-            cycles--;
-        return cycles > 0;
-    }
-
-    bool has_dispatch_delay(){
-    	return cycles > 0;
-    }
-
-    void print( FILE *fout ) const;
-    unsigned get_uid() const { return m_uid; }
-    unsigned get_schd_id() const { return m_scheduler_id; }
-
-protected:
-
-    unsigned m_uid;
-    bool m_empty;
-    bool m_cache_hit;
-    unsigned long long issue_cycle;
-    unsigned cycles; // used for implementing initiation interval delay
-    bool m_isatomic;
-    bool m_is_printf;
-    unsigned m_warp_id;
-    unsigned m_dynamic_warp_id; 
-    const core_config *m_config; 
-    active_mask_t m_warp_active_mask; // dynamic active mask for timing model (after predication)
-    active_mask_t m_warp_issued_mask; // active mask at issue (prior to predication test) -- for instruction counting
-
-    struct per_thread_info {
-        per_thread_info() {
-            for(unsigned i=0; i<MAX_ACCESSES_PER_INSN_PER_THREAD; i++)
-                memreqaddr[i] = 0;
-        }
-        dram_callback_t callback;
-        new_addr_type memreqaddr[MAX_ACCESSES_PER_INSN_PER_THREAD]; // effective address, upto 8 different requests (to support 32B access in 8 chunks of 4B each)
-    };
-    bool m_per_scalar_thread_valid;
-    std::vector<per_thread_info> m_per_scalar_thread;
-    bool m_mem_accesses_created;
-    std::list<mem_access_t> m_accessq;
-
-    unsigned m_scheduler_id;  //the scheduler that issues this inst
-
-    //Jin: cdp support
-public:
-    int m_is_cdp;
-    
+  // Jin: cdp support
+ public:
+  int m_is_cdp;
 };
 
-void move_warp( warp_inst_t *&dst, warp_inst_t *&src );
+void move_warp(warp_inst_t *&dst, warp_inst_t *&src);
 
-size_t get_kernel_code_size( class function_info *entry );
-class checkpoint
-{    
-public:
+size_t get_kernel_code_size(class function_info *entry);
+class checkpoint {
+ public:
+  checkpoint();
+  ~checkpoint() { printf("clasfsfss destructed\n"); }
 
-     checkpoint();
-    ~checkpoint(){
-      printf("clasfsfss destructed\n");
-    }
-
-    void load_global_mem(class memory_space *temp_mem, char * f1name);
-    void store_global_mem(class memory_space *mem, char * fname , char * format);
-    unsigned radnom;
-
-
+  void load_global_mem(class memory_space *temp_mem, char *f1name);
+  void store_global_mem(class memory_space *mem, char *fname, char *format);
+  unsigned radnom;
 };
 /*
- * This abstract class used as a base for functional and performance and simulation, it has basic functional simulation
- * data structures and procedures. 
+ * This abstract class used as a base for functional and performance and
+ * simulation, it has basic functional simulation data structures and
+ * procedures.
  */
 class core_t {
-    public:
-        core_t( gpgpu_sim *gpu, 
-                kernel_info_t *kernel,
-                unsigned warp_size,
-                unsigned threads_per_shader )
-            : m_gpu( gpu ),
-              m_kernel( kernel ),
-              m_simt_stack( NULL ),
-              m_thread( NULL ),
-              m_warp_size( warp_size )
-        {
-            m_warp_count = threads_per_shader/m_warp_size;
-            // Handle the case where the number of threads is not a
-            // multiple of the warp size
-            if ( threads_per_shader % m_warp_size != 0 ) {
-                m_warp_count += 1;
-            }
-            assert( m_warp_count * m_warp_size > 0 );
-            m_thread = ( ptx_thread_info** )
-                     calloc( m_warp_count * m_warp_size,
-                             sizeof( ptx_thread_info* ) );
-            initilizeSIMTStack(m_warp_count,m_warp_size);
+ public:
+  core_t(gpgpu_sim *gpu, kernel_info_t *kernel, unsigned warp_size,
+         unsigned threads_per_shader)
+      : m_gpu(gpu),
+        m_kernel(kernel),
+        m_simt_stack(NULL),
+        m_thread(NULL),
+        m_warp_size(warp_size) {
+    m_warp_count = threads_per_shader / m_warp_size;
+    // Handle the case where the number of threads is not a
+    // multiple of the warp size
+    if (threads_per_shader % m_warp_size != 0) {
+      m_warp_count += 1;
+    }
+    assert(m_warp_count * m_warp_size > 0);
+    m_thread = (ptx_thread_info **)calloc(m_warp_count * m_warp_size,
+                                          sizeof(ptx_thread_info *));
+    initilizeSIMTStack(m_warp_count, m_warp_size);
 
-            for(unsigned i=0; i<MAX_CTA_PER_SHADER; i++){
-            	for(unsigned j=0; j<MAX_BARRIERS_PER_CTA; j++){
-            		reduction_storage[i][j]=0;
-            	}
-            }
+    for (unsigned i = 0; i < MAX_CTA_PER_SHADER; i++) {
+      for (unsigned j = 0; j < MAX_BARRIERS_PER_CTA; j++) {
+        reduction_storage[i][j] = 0;
+      }
+    }
+  }
+  virtual ~core_t() { free(m_thread); }
+  virtual void warp_exit(unsigned warp_id) = 0;
+  virtual bool warp_waiting_at_barrier(unsigned warp_id) const = 0;
+  virtual void checkExecutionStatusAndUpdate(warp_inst_t &inst, unsigned t,
+                                             unsigned tid) = 0;
+  class gpgpu_sim *get_gpu() {
+    return m_gpu;
+  }
+  void execute_warp_inst_t(warp_inst_t &inst, unsigned warpId = (unsigned)-1);
+  bool ptx_thread_done(unsigned hw_thread_id) const;
+  void updateSIMTStack(unsigned warpId, warp_inst_t *inst);
+  void initilizeSIMTStack(unsigned warp_count, unsigned warps_size);
+  void deleteSIMTStack();
+  warp_inst_t getExecuteWarp(unsigned warpId);
+  void get_pdom_stack_top_info(unsigned warpId, unsigned *pc,
+                               unsigned *rpc) const;
+  kernel_info_t *get_kernel_info() { return m_kernel; }
+  class ptx_thread_info **get_thread_info() {
+    return m_thread;
+  }
+  unsigned get_warp_size() const { return m_warp_size; }
+  void and_reduction(unsigned ctaid, unsigned barid, bool value) {
+    reduction_storage[ctaid][barid] &= value;
+  }
+  void or_reduction(unsigned ctaid, unsigned barid, bool value) {
+    reduction_storage[ctaid][barid] |= value;
+  }
+  void popc_reduction(unsigned ctaid, unsigned barid, bool value) {
+    reduction_storage[ctaid][barid] += value;
+  }
+  unsigned get_reduction_value(unsigned ctaid, unsigned barid) {
+    return reduction_storage[ctaid][barid];
+  }
 
-        }
-        virtual ~core_t() { free(m_thread); }
-        virtual void warp_exit( unsigned warp_id ) = 0;
-        virtual bool warp_waiting_at_barrier( unsigned warp_id ) const = 0;
-        virtual void checkExecutionStatusAndUpdate(warp_inst_t &inst, unsigned t, unsigned tid)=0;
-        class gpgpu_sim * get_gpu() {return m_gpu;}
-        void execute_warp_inst_t(warp_inst_t &inst, unsigned warpId =(unsigned)-1);
-        bool  ptx_thread_done( unsigned hw_thread_id ) const ;
-        void updateSIMTStack(unsigned warpId, warp_inst_t * inst);
-        void initilizeSIMTStack(unsigned warp_count, unsigned warps_size);
-        void deleteSIMTStack();
-        warp_inst_t getExecuteWarp(unsigned warpId);
-        void get_pdom_stack_top_info( unsigned warpId, unsigned *pc, unsigned *rpc ) const;
-        kernel_info_t * get_kernel_info(){ return m_kernel;}
-        class ptx_thread_info ** get_thread_info() { return m_thread; }
-        unsigned get_warp_size() const { return m_warp_size; }
-        void and_reduction(unsigned ctaid, unsigned barid, bool value) { reduction_storage[ctaid][barid] &= value; }
-        void or_reduction(unsigned ctaid, unsigned barid, bool value) { reduction_storage[ctaid][barid] |= value; }
-        void popc_reduction(unsigned ctaid, unsigned barid, bool value) { reduction_storage[ctaid][barid] += value;}
-        unsigned get_reduction_value(unsigned ctaid, unsigned barid) {return reduction_storage[ctaid][barid];}
-    protected:
-        class gpgpu_sim *m_gpu;
-        kernel_info_t *m_kernel;
-        simt_stack  **m_simt_stack; // pdom based reconvergence context for each warp
-        class ptx_thread_info ** m_thread;
-        unsigned m_warp_size;
-        unsigned m_warp_count;
-        unsigned reduction_storage[MAX_CTA_PER_SHADER][MAX_BARRIERS_PER_CTA];
+ protected:
+  class gpgpu_sim *m_gpu;
+  kernel_info_t *m_kernel;
+  simt_stack **m_simt_stack;  // pdom based reconvergence context for each warp
+  class ptx_thread_info **m_thread;
+  unsigned m_warp_size;
+  unsigned m_warp_count;
+  unsigned reduction_storage[MAX_CTA_PER_SHADER][MAX_BARRIERS_PER_CTA];
 };
 
-
-//register that can hold multiple instructions.
+// register that can hold multiple instructions.
 class register_set {
-public:
-	register_set(unsigned num, const char* name){
-		for( unsigned i = 0; i < num; i++ ) {
-			regs.push_back(new warp_inst_t());
-		}
-		m_name = name;
-	}
-	bool has_free(){
-		for( unsigned i = 0; i < regs.size(); i++ ) {
-			if( regs[i]->empty() ) {
-				return true;
-			}
-		}
-		return false;
-	}
-	bool has_free(bool sub_core_model, unsigned reg_id){
-		//in subcore model, each sched has a one specific reg to use (based on sched id)
-		if(!sub_core_model)
-			return has_free();
+ public:
+  register_set(unsigned num, const char *name) {
+    for (unsigned i = 0; i < num; i++) {
+      regs.push_back(new warp_inst_t());
+    }
+    m_name = name;
+  }
+  bool has_free() {
+    for (unsigned i = 0; i < regs.size(); i++) {
+      if (regs[i]->empty()) {
+        return true;
+      }
+    }
+    return false;
+  }
+  bool has_free(bool sub_core_model, unsigned reg_id) {
+    // in subcore model, each sched has a one specific reg to use (based on
+    // sched id)
+    if (!sub_core_model) return has_free();
 
-		assert(reg_id < regs.size());
-		return regs[reg_id]->empty();
-	}
-	bool has_ready(){
-		for( unsigned i = 0; i < regs.size(); i++ ) {
-			if( not regs[i]->empty() ) {
-				return true;
-			}
-		}
-		return false;
-	}
+    assert(reg_id < regs.size());
+    return regs[reg_id]->empty();
+  }
+  bool has_ready() {
+    for (unsigned i = 0; i < regs.size(); i++) {
+      if (not regs[i]->empty()) {
+        return true;
+      }
+    }
+    return false;
+  }
 
-	void move_in( warp_inst_t *&src ){
-		warp_inst_t** free = get_free();
-		move_warp(*free, src);
-	}
-	//void copy_in( warp_inst_t* src ){
-		//   src->copy_contents_to(*get_free());
-		//}
-	void move_out_to( warp_inst_t *&dest ){
-		warp_inst_t **ready=get_ready();
-		move_warp(dest, *ready);
-	}
+  void move_in(warp_inst_t *&src) {
+    warp_inst_t **free = get_free();
+    move_warp(*free, src);
+  }
+  // void copy_in( warp_inst_t* src ){
+  //   src->copy_contents_to(*get_free());
+  //}
+  void move_out_to(warp_inst_t *&dest) {
+    warp_inst_t **ready = get_ready();
+    move_warp(dest, *ready);
+  }
 
-	warp_inst_t** get_ready(){
-		warp_inst_t** ready;
-		ready = NULL;
-		for( unsigned i = 0; i < regs.size(); i++ ) {
-			if( not regs[i]->empty() ) {
-				if( ready and (*ready)->get_uid() < regs[i]->get_uid() ) {
-					// ready is oldest
-				} else {
-					ready = &regs[i];
-				}
-			}
-		}
-		return ready;
-	}
+  warp_inst_t **get_ready() {
+    warp_inst_t **ready;
+    ready = NULL;
+    for (unsigned i = 0; i < regs.size(); i++) {
+      if (not regs[i]->empty()) {
+        if (ready and (*ready)->get_uid() < regs[i]->get_uid()) {
+          // ready is oldest
+        } else {
+          ready = &regs[i];
+        }
+      }
+    }
+    return ready;
+  }
 
-	void print(FILE* fp) const{
-		fprintf(fp, "%s : @%p\n", m_name, this);
-		for( unsigned i = 0; i < regs.size(); i++ ) {
-			fprintf(fp, "     ");
-			regs[i]->print(fp);
-			fprintf(fp, "\n");
-		}
-	}
+  void print(FILE *fp) const {
+    fprintf(fp, "%s : @%p\n", m_name, this);
+    for (unsigned i = 0; i < regs.size(); i++) {
+      fprintf(fp, "     ");
+      regs[i]->print(fp);
+      fprintf(fp, "\n");
+    }
+  }
 
-	warp_inst_t ** get_free(){
-		for( unsigned i = 0; i < regs.size(); i++ ) {
-			if( regs[i]->empty() ) {
-				return &regs[i];
-			}
-		}
-		assert(0 && "No free registers found");
-		return NULL;
-	}
+  warp_inst_t **get_free() {
+    for (unsigned i = 0; i < regs.size(); i++) {
+      if (regs[i]->empty()) {
+        return &regs[i];
+      }
+    }
+    assert(0 && "No free registers found");
+    return NULL;
+  }
 
-	warp_inst_t ** get_free(bool sub_core_model, unsigned reg_id){
-		//in subcore model, each sched has a one specific reg to use (based on sched id)
-		if(!sub_core_model)
-			return get_free();
+  warp_inst_t **get_free(bool sub_core_model, unsigned reg_id) {
+    // in subcore model, each sched has a one specific reg to use (based on
+    // sched id)
+    if (!sub_core_model) return get_free();
 
-		assert(reg_id < regs.size());
-		if( regs[reg_id]->empty() ) {
-			return &regs[reg_id];
-		}
-		assert(0 && "No free register found");
-		return NULL;
-	}
+    assert(reg_id < regs.size());
+    if (regs[reg_id]->empty()) {
+      return &regs[reg_id];
+    }
+    assert(0 && "No free register found");
+    return NULL;
+  }
 
-	unsigned get_size(){
-		return regs.size();
-	}
+  unsigned get_size() { return regs.size(); }
 
-private:
-	std::vector<warp_inst_t*> regs;
-	const char* m_name;
+ private:
+  std::vector<warp_inst_t *> regs;
+  const char *m_name;
 };
 
-#endif // #ifdef __cplusplus
+#endif  // #ifdef __cplusplus
 
-#endif // #ifndef ABSTRACT_HARDWARE_MODEL_INCLUDED
+#endif  // #ifndef ABSTRACT_HARDWARE_MODEL_INCLUDED

--- a/src/cuda-sim/cuda-math.h
+++ b/src/cuda-sim/cuda-math.h
@@ -1,6 +1,6 @@
 // This file created from vector_types.h distributed with CUDA 1.1
 // (see original copyright notice below)
-// 
+//
 // Changes Copyright (c) 2009-2011, Tor M. Aamodt, Wilson W.L. Fung
 // The University of British Columbia
 // All rights reserved.
@@ -10,14 +10,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -28,42 +30,40 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
 /*
  * Copyright 1993-2007 NVIDIA Corporation.  All rights reserved.
  *
- * NOTICE TO USER:   
+ * NOTICE TO USER:
  *
- * This source code is subject to NVIDIA ownership rights under U.S. and 
- * international Copyright laws.  Users and possessors of this source code 
- * are hereby granted a nonexclusive, royalty-free license to use this code 
+ * This source code is subject to NVIDIA ownership rights under U.S. and
+ * international Copyright laws.  Users and possessors of this source code
+ * are hereby granted a nonexclusive, royalty-free license to use this code
  * in individual and commercial software.
  *
- * NVIDIA MAKES NO REPRESENTATION ABOUT THE SUITABILITY OF THIS SOURCE 
- * CODE FOR ANY PURPOSE.  IT IS PROVIDED "AS IS" WITHOUT EXPRESS OR 
- * IMPLIED WARRANTY OF ANY KIND.  NVIDIA DISCLAIMS ALL WARRANTIES WITH 
- * REGARD TO THIS SOURCE CODE, INCLUDING ALL IMPLIED WARRANTIES OF 
+ * NVIDIA MAKES NO REPRESENTATION ABOUT THE SUITABILITY OF THIS SOURCE
+ * CODE FOR ANY PURPOSE.  IT IS PROVIDED "AS IS" WITHOUT EXPRESS OR
+ * IMPLIED WARRANTY OF ANY KIND.  NVIDIA DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOURCE CODE, INCLUDING ALL IMPLIED WARRANTIES OF
  * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE.
- * IN NO EVENT SHALL NVIDIA BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL, 
- * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS 
- * OF USE, DATA OR PROFITS,  WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE 
- * OR OTHER TORTIOUS ACTION,  ARISING OUT OF OR IN CONNECTION WITH THE USE 
- * OR PERFORMANCE OF THIS SOURCE CODE.  
+ * IN NO EVENT SHALL NVIDIA BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL,
+ * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS,  WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+ * OR OTHER TORTIOUS ACTION,  ARISING OUT OF OR IN CONNECTION WITH THE USE
+ * OR PERFORMANCE OF THIS SOURCE CODE.
  *
- * U.S. Government End Users.   This source code is a "commercial item" as 
- * that term is defined at  48 C.F.R. 2.101 (OCT 1995), consisting  of 
- * "commercial computer  software"  and "commercial computer software 
- * documentation" as such terms are  used in 48 C.F.R. 12.212 (SEPT 1995) 
- * and is provided to the U.S. Government only as a commercial end item.  
- * Consistent with 48 C.F.R.12.212 and 48 C.F.R. 227.7202-1 through 
- * 227.7202-4 (JUNE 1995), all U.S. Government End Users acquire the 
- * source code with only those rights set forth herein. 
+ * U.S. Government End Users.   This source code is a "commercial item" as
+ * that term is defined at  48 C.F.R. 2.101 (OCT 1995), consisting  of
+ * "commercial computer  software"  and "commercial computer software
+ * documentation" as such terms are  used in 48 C.F.R. 12.212 (SEPT 1995)
+ * and is provided to the U.S. Government only as a commercial end item.
+ * Consistent with 48 C.F.R.12.212 and 48 C.F.R. 227.7202-1 through
+ * 227.7202-4 (JUNE 1995), all U.S. Government End Users acquire the
+ * source code with only those rights set forth herein.
  *
- * Any use of this source code in individual and commercial software must 
+ * Any use of this source code in individual and commercial software must
  * include, in the user documentation and internal comments to the code,
  * the above Disclaimer and U.S. Government End Users Notice.
  */
-
 
 #ifndef CUDA_MATH
 #define CUDA_MATH
@@ -74,32 +74,31 @@
 #undef max
 #undef min
 namespace cuda_math {
-#define __attribute__(a) // to remove warnings inside math_functions.h
+#define __attribute__(a)  // to remove warnings inside math_functions.h
 #undef INT_MAX
 
 #if CUDART_VERSION < 3000
 // DEVICE_BUILTIN
-   struct int4 {
-      int x, y, z, w;
-   };
-   struct uint4 {
-      unsigned int x, y, z, w;
-   };
-   struct float4 {
-      float x, y, z, w;
-   };
-   struct float2 {
-      float x, y;
-   };
-    
+struct int4 {
+  int x, y, z, w;
+};
+struct uint4 {
+  unsigned int x, y, z, w;
+};
+struct float4 {
+  float x, y, z, w;
+};
+struct float2 {
+  float x, y;
+};
 
 // DEVICE_BUILTIN
-   typedef struct int4 int4;
-   typedef struct uint4 uint4;
-   typedef struct float4 float4;
-   typedef struct float2 float2;
+typedef struct int4 int4;
+typedef struct uint4 uint4;
+typedef struct float4 float4;
+typedef struct float2 float2;
 
-extern float rsqrtf(float); // CUDA 2.3 beta
+extern float rsqrtf(float);  // CUDA 2.3 beta
 
 #define CUDA_FLOAT_MATH_FUNCTIONS
 #include <device_types.h>
@@ -108,38 +107,36 @@ extern float rsqrtf(float); // CUDA 2.3 beta
 #undef __CUDA_INTERNAL_COMPILATION__
 #undef __attribute__
 
-// float to integer conversion 
-int float2int(float a, enum cudaRoundMode mode)
-{
-   return __internal_float2uint(a, mode); 
+// float to integer conversion
+int float2int(float a, enum cudaRoundMode mode) {
+  return __internal_float2uint(a, mode);
 }
 
-// float to unsigned integer conversion 
-unsigned int float2uint(float a, enum cudaRoundMode mode)
-{
-   return __internal_float2uint(a, mode); 
+// float to unsigned integer conversion
+unsigned int float2uint(float a, enum cudaRoundMode mode) {
+  return __internal_float2uint(a, mode);
 }
 
 float __ll2float_rz(long long int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_TOWARDZERO); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_TOWARDZERO);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 float __ll2float_ru(long long int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_UPWARD); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_UPWARD);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 float __ll2float_rd(long long int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_DOWNWARD); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_DOWNWARD);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 
 #else
@@ -147,205 +144,211 @@ float __ll2float_rd(long long int a) {
 #define CUDA_FLOAT_MATH_FUNCTIONS
 #define __CUDACC__
 
-// implementing int to float intrinsics with different rounding modes 
+// implementing int to float intrinsics with different rounding modes
 #include <device_types.h>
 #include <fenv.h>
 
-
 // 32-bit integer to float
 float __int2float_rn(int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_TONEAREST); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_TONEAREST);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 float __int2float_rz(int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_TOWARDZERO); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_TOWARDZERO);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 float __int2float_ru(int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_UPWARD); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_UPWARD);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 float __int2float_rd(int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_DOWNWARD); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_DOWNWARD);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 
 // 32-bit unsigned integer to float
 float __uint2float_rn(unsigned int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_TONEAREST); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_TONEAREST);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 float __uint2float_rz(unsigned int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_TOWARDZERO); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_TOWARDZERO);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 float __uint2float_ru(unsigned int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_UPWARD); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_UPWARD);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 float __uint2float_rd(unsigned int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_DOWNWARD); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_DOWNWARD);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 
 // 64-bit integer to float
 float __ll2float_rn(long long int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_TONEAREST); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_TONEAREST);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 float __ll2float_rz(long long int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_TOWARDZERO); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_TOWARDZERO);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 float __ll2float_ru(long long int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_UPWARD); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_UPWARD);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 float __ll2float_rd(long long int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_DOWNWARD); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_DOWNWARD);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 
-// 64-bit unsigned integer to float 
+// 64-bit unsigned integer to float
 float __ull2float_rn(unsigned long long int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_TONEAREST); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_TONEAREST);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 float __ull2float_rz(unsigned long long int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_TOWARDZERO); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_TOWARDZERO);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 float __ull2float_ru(unsigned long long int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_UPWARD); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_UPWARD);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 float __ull2float_rd(unsigned long long int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_DOWNWARD); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_DOWNWARD);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 
-// float to integer conversion 
-int float2int(float a, enum cudaRoundMode mode)
-{
-   int tmp;
-   switch (mode) {
-   case cudaRoundZero: tmp = truncf(a);     break;
-   case cudaRoundNearest: tmp = nearbyintf(a); break;
-   case cudaRoundMinInf: tmp = floorf(a);     break;
-   case cudaRoundPosInf: tmp = ceilf(a);      break;
-   default: abort();
-   }
-   return tmp; 
+// float to integer conversion
+int float2int(float a, enum cudaRoundMode mode) {
+  int tmp;
+  switch (mode) {
+    case cudaRoundZero:
+      tmp = truncf(a);
+      break;
+    case cudaRoundNearest:
+      tmp = nearbyintf(a);
+      break;
+    case cudaRoundMinInf:
+      tmp = floorf(a);
+      break;
+    case cudaRoundPosInf:
+      tmp = ceilf(a);
+      break;
+    default:
+      abort();
+  }
+  return tmp;
 }
 
-int __internal_float2int(float a, enum cudaRoundMode mode) 
-{
-   return float2int(a, mode); 
+int __internal_float2int(float a, enum cudaRoundMode mode) {
+  return float2int(a, mode);
 }
 
-// float to unsigned integer conversion 
-unsigned int float2uint(float a, enum cudaRoundMode mode)
-{
-   unsigned int tmp;
-   switch (mode) {
-   case cudaRoundZero: tmp = truncf(a);     break;
-   case cudaRoundNearest: tmp = nearbyintf(a); break;
-   case cudaRoundMinInf: tmp = floorf(a);     break;
-   case cudaRoundPosInf: tmp = ceilf(a);      break;
-   default: abort();
-   }
-   return tmp; 
+// float to unsigned integer conversion
+unsigned int float2uint(float a, enum cudaRoundMode mode) {
+  unsigned int tmp;
+  switch (mode) {
+    case cudaRoundZero:
+      tmp = truncf(a);
+      break;
+    case cudaRoundNearest:
+      tmp = nearbyintf(a);
+      break;
+    case cudaRoundMinInf:
+      tmp = floorf(a);
+      break;
+    case cudaRoundPosInf:
+      tmp = ceilf(a);
+      break;
+    default:
+      abort();
+  }
+  return tmp;
 }
 
-unsigned int __internal_float2uint(float a, enum cudaRoundMode mode) 
-{
-   return float2uint(a, mode); 
+unsigned int __internal_float2uint(float a, enum cudaRoundMode mode) {
+  return float2uint(a, mode);
 }
 
-// intrinsic for division 
-float fdividef(float a, float b)
-{
-   return (a / b); 
-}
+// intrinsic for division
+float fdividef(float a, float b) { return (a / b); }
 
-float __internal_accurate_fdividef(float a, float b)
-{
-   return fdividef(a, b); 
-}
+float __internal_accurate_fdividef(float a, float b) { return fdividef(a, b); }
 
 // intrinsic for saturate  (clamp values beyond 0 and 1)
-float __saturatef(float a)
-{
-   float b; 
-   if (std::isnan(a)) b = 0.0f; 
-   else if (a >= 1.0f) b = 1.0f;
-   else if (a <= 0.0f) b = 0.0f; 
-   else b = a; 
-   return b; 
+float __saturatef(float a) {
+  float b;
+  if (std::isnan(a))
+    b = 0.0f;
+  else if (a >= 1.0f)
+    b = 1.0f;
+  else if (a <= 0.0f)
+    b = 0.0f;
+  else
+    b = a;
+  return b;
 }
 
-// intrinsic for power 
-float __powf(float a, float b)
-{
-   return powf(a, b);
-}
+// intrinsic for power
+float __powf(float a, float b) { return powf(a, b); }
 
 // math functions missing in Mac OSX GCC
 #ifdef __APPLE__
-int __signbitd(double d)
-{
-   unsigned long long int u = *((unsigned long long int*)&d); 
-   return ((u & 0x8000000000000000ULL) != 0);
+int __signbitd(double d) {
+  unsigned long long int u = *((unsigned long long int*)&d);
+  return ((u & 0x8000000000000000ULL) != 0);
 }
-#endif 
+#endif
 
 #undef __CUDACC__
 #define __CUDA_INTERNAL_COMPILATION__
@@ -354,15 +357,11 @@ int __signbitd(double d)
 #undef __attribute__
 
 #endif
-
 }
 
 // math functions missing in Mac OSX GCC
 #ifdef __APPLE__
-int isnanf(float a) 
-{
-   return (std::isnan(a)); 
-}
-#endif 
+int isnanf(float a) { return (std::isnan(a)); }
+#endif
 
 #endif

--- a/src/cuda-sim/cuda-math.h
+++ b/src/cuda-sim/cuda-math.h
@@ -1,6 +1,6 @@
 // This file created from vector_types.h distributed with CUDA 1.1
 // (see original copyright notice below)
-//
+// 
 // Changes Copyright (c) 2009-2011, Tor M. Aamodt, Wilson W.L. Fung
 // The University of British Columbia
 // All rights reserved.
@@ -10,16 +10,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -30,40 +28,42 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
 /*
  * Copyright 1993-2007 NVIDIA Corporation.  All rights reserved.
  *
- * NOTICE TO USER:
+ * NOTICE TO USER:   
  *
- * This source code is subject to NVIDIA ownership rights under U.S. and
- * international Copyright laws.  Users and possessors of this source code
- * are hereby granted a nonexclusive, royalty-free license to use this code
+ * This source code is subject to NVIDIA ownership rights under U.S. and 
+ * international Copyright laws.  Users and possessors of this source code 
+ * are hereby granted a nonexclusive, royalty-free license to use this code 
  * in individual and commercial software.
  *
- * NVIDIA MAKES NO REPRESENTATION ABOUT THE SUITABILITY OF THIS SOURCE
- * CODE FOR ANY PURPOSE.  IT IS PROVIDED "AS IS" WITHOUT EXPRESS OR
- * IMPLIED WARRANTY OF ANY KIND.  NVIDIA DISCLAIMS ALL WARRANTIES WITH
- * REGARD TO THIS SOURCE CODE, INCLUDING ALL IMPLIED WARRANTIES OF
+ * NVIDIA MAKES NO REPRESENTATION ABOUT THE SUITABILITY OF THIS SOURCE 
+ * CODE FOR ANY PURPOSE.  IT IS PROVIDED "AS IS" WITHOUT EXPRESS OR 
+ * IMPLIED WARRANTY OF ANY KIND.  NVIDIA DISCLAIMS ALL WARRANTIES WITH 
+ * REGARD TO THIS SOURCE CODE, INCLUDING ALL IMPLIED WARRANTIES OF 
  * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE.
- * IN NO EVENT SHALL NVIDIA BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL,
- * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
- * OF USE, DATA OR PROFITS,  WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
- * OR OTHER TORTIOUS ACTION,  ARISING OUT OF OR IN CONNECTION WITH THE USE
- * OR PERFORMANCE OF THIS SOURCE CODE.
+ * IN NO EVENT SHALL NVIDIA BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL, 
+ * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS 
+ * OF USE, DATA OR PROFITS,  WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE 
+ * OR OTHER TORTIOUS ACTION,  ARISING OUT OF OR IN CONNECTION WITH THE USE 
+ * OR PERFORMANCE OF THIS SOURCE CODE.  
  *
- * U.S. Government End Users.   This source code is a "commercial item" as
- * that term is defined at  48 C.F.R. 2.101 (OCT 1995), consisting  of
- * "commercial computer  software"  and "commercial computer software
- * documentation" as such terms are  used in 48 C.F.R. 12.212 (SEPT 1995)
- * and is provided to the U.S. Government only as a commercial end item.
- * Consistent with 48 C.F.R.12.212 and 48 C.F.R. 227.7202-1 through
- * 227.7202-4 (JUNE 1995), all U.S. Government End Users acquire the
- * source code with only those rights set forth herein.
+ * U.S. Government End Users.   This source code is a "commercial item" as 
+ * that term is defined at  48 C.F.R. 2.101 (OCT 1995), consisting  of 
+ * "commercial computer  software"  and "commercial computer software 
+ * documentation" as such terms are  used in 48 C.F.R. 12.212 (SEPT 1995) 
+ * and is provided to the U.S. Government only as a commercial end item.  
+ * Consistent with 48 C.F.R.12.212 and 48 C.F.R. 227.7202-1 through 
+ * 227.7202-4 (JUNE 1995), all U.S. Government End Users acquire the 
+ * source code with only those rights set forth herein. 
  *
- * Any use of this source code in individual and commercial software must
+ * Any use of this source code in individual and commercial software must 
  * include, in the user documentation and internal comments to the code,
  * the above Disclaimer and U.S. Government End Users Notice.
  */
+
 
 #ifndef CUDA_MATH
 #define CUDA_MATH
@@ -74,31 +74,32 @@
 #undef max
 #undef min
 namespace cuda_math {
-#define __attribute__(a)  // to remove warnings inside math_functions.h
+#define __attribute__(a) // to remove warnings inside math_functions.h
 #undef INT_MAX
 
 #if CUDART_VERSION < 3000
 // DEVICE_BUILTIN
-struct int4 {
-  int x, y, z, w;
-};
-struct uint4 {
-  unsigned int x, y, z, w;
-};
-struct float4 {
-  float x, y, z, w;
-};
-struct float2 {
-  float x, y;
-};
+   struct int4 {
+      int x, y, z, w;
+   };
+   struct uint4 {
+      unsigned int x, y, z, w;
+   };
+   struct float4 {
+      float x, y, z, w;
+   };
+   struct float2 {
+      float x, y;
+   };
+    
 
 // DEVICE_BUILTIN
-typedef struct int4 int4;
-typedef struct uint4 uint4;
-typedef struct float4 float4;
-typedef struct float2 float2;
+   typedef struct int4 int4;
+   typedef struct uint4 uint4;
+   typedef struct float4 float4;
+   typedef struct float2 float2;
 
-extern float rsqrtf(float);  // CUDA 2.3 beta
+extern float rsqrtf(float); // CUDA 2.3 beta
 
 #define CUDA_FLOAT_MATH_FUNCTIONS
 #include <device_types.h>
@@ -107,36 +108,38 @@ extern float rsqrtf(float);  // CUDA 2.3 beta
 #undef __CUDA_INTERNAL_COMPILATION__
 #undef __attribute__
 
-// float to integer conversion
-int float2int(float a, enum cudaRoundMode mode) {
-  return __internal_float2uint(a, mode);
+// float to integer conversion 
+int float2int(float a, enum cudaRoundMode mode)
+{
+   return __internal_float2uint(a, mode); 
 }
 
-// float to unsigned integer conversion
-unsigned int float2uint(float a, enum cudaRoundMode mode) {
-  return __internal_float2uint(a, mode);
+// float to unsigned integer conversion 
+unsigned int float2uint(float a, enum cudaRoundMode mode)
+{
+   return __internal_float2uint(a, mode); 
 }
 
 float __ll2float_rz(long long int a) {
-  int orig_rnd_mode = fegetround();
-  fesetround(FE_TOWARDZERO);
-  float b = a;
-  fesetround(orig_rnd_mode);
-  return b;
+   int orig_rnd_mode = fegetround();
+   fesetround(FE_TOWARDZERO); 
+   float b = a;
+   fesetround(orig_rnd_mode); 
+   return b;
 }
 float __ll2float_ru(long long int a) {
-  int orig_rnd_mode = fegetround();
-  fesetround(FE_UPWARD);
-  float b = a;
-  fesetround(orig_rnd_mode);
-  return b;
+   int orig_rnd_mode = fegetround();
+   fesetround(FE_UPWARD); 
+   float b = a;
+   fesetround(orig_rnd_mode); 
+   return b;
 }
 float __ll2float_rd(long long int a) {
-  int orig_rnd_mode = fegetround();
-  fesetround(FE_DOWNWARD);
-  float b = a;
-  fesetround(orig_rnd_mode);
-  return b;
+   int orig_rnd_mode = fegetround();
+   fesetround(FE_DOWNWARD); 
+   float b = a;
+   fesetround(orig_rnd_mode); 
+   return b;
 }
 
 #else
@@ -144,211 +147,205 @@ float __ll2float_rd(long long int a) {
 #define CUDA_FLOAT_MATH_FUNCTIONS
 #define __CUDACC__
 
-// implementing int to float intrinsics with different rounding modes
+// implementing int to float intrinsics with different rounding modes 
 #include <device_types.h>
 #include <fenv.h>
 
+
 // 32-bit integer to float
 float __int2float_rn(int a) {
-  int orig_rnd_mode = fegetround();
-  fesetround(FE_TONEAREST);
-  float b = a;
-  fesetround(orig_rnd_mode);
-  return b;
+   int orig_rnd_mode = fegetround();
+   fesetround(FE_TONEAREST); 
+   float b = a;
+   fesetround(orig_rnd_mode); 
+   return b;
 }
 float __int2float_rz(int a) {
-  int orig_rnd_mode = fegetround();
-  fesetround(FE_TOWARDZERO);
-  float b = a;
-  fesetround(orig_rnd_mode);
-  return b;
+   int orig_rnd_mode = fegetround();
+   fesetround(FE_TOWARDZERO); 
+   float b = a;
+   fesetround(orig_rnd_mode); 
+   return b;
 }
 float __int2float_ru(int a) {
-  int orig_rnd_mode = fegetround();
-  fesetround(FE_UPWARD);
-  float b = a;
-  fesetround(orig_rnd_mode);
-  return b;
+   int orig_rnd_mode = fegetround();
+   fesetround(FE_UPWARD); 
+   float b = a;
+   fesetround(orig_rnd_mode); 
+   return b;
 }
 float __int2float_rd(int a) {
-  int orig_rnd_mode = fegetround();
-  fesetround(FE_DOWNWARD);
-  float b = a;
-  fesetround(orig_rnd_mode);
-  return b;
+   int orig_rnd_mode = fegetround();
+   fesetround(FE_DOWNWARD); 
+   float b = a;
+   fesetround(orig_rnd_mode); 
+   return b;
 }
 
 // 32-bit unsigned integer to float
 float __uint2float_rn(unsigned int a) {
-  int orig_rnd_mode = fegetround();
-  fesetround(FE_TONEAREST);
-  float b = a;
-  fesetround(orig_rnd_mode);
-  return b;
+   int orig_rnd_mode = fegetround();
+   fesetround(FE_TONEAREST); 
+   float b = a;
+   fesetround(orig_rnd_mode); 
+   return b;
 }
 float __uint2float_rz(unsigned int a) {
-  int orig_rnd_mode = fegetround();
-  fesetround(FE_TOWARDZERO);
-  float b = a;
-  fesetround(orig_rnd_mode);
-  return b;
+   int orig_rnd_mode = fegetround();
+   fesetround(FE_TOWARDZERO); 
+   float b = a;
+   fesetround(orig_rnd_mode); 
+   return b;
 }
 float __uint2float_ru(unsigned int a) {
-  int orig_rnd_mode = fegetround();
-  fesetround(FE_UPWARD);
-  float b = a;
-  fesetround(orig_rnd_mode);
-  return b;
+   int orig_rnd_mode = fegetround();
+   fesetround(FE_UPWARD); 
+   float b = a;
+   fesetround(orig_rnd_mode); 
+   return b;
 }
 float __uint2float_rd(unsigned int a) {
-  int orig_rnd_mode = fegetround();
-  fesetround(FE_DOWNWARD);
-  float b = a;
-  fesetround(orig_rnd_mode);
-  return b;
+   int orig_rnd_mode = fegetround();
+   fesetround(FE_DOWNWARD); 
+   float b = a;
+   fesetround(orig_rnd_mode); 
+   return b;
 }
 
 // 64-bit integer to float
 float __ll2float_rn(long long int a) {
-  int orig_rnd_mode = fegetround();
-  fesetround(FE_TONEAREST);
-  float b = a;
-  fesetround(orig_rnd_mode);
-  return b;
+   int orig_rnd_mode = fegetround();
+   fesetround(FE_TONEAREST); 
+   float b = a;
+   fesetround(orig_rnd_mode); 
+   return b;
 }
 float __ll2float_rz(long long int a) {
-  int orig_rnd_mode = fegetround();
-  fesetround(FE_TOWARDZERO);
-  float b = a;
-  fesetround(orig_rnd_mode);
-  return b;
+   int orig_rnd_mode = fegetround();
+   fesetround(FE_TOWARDZERO); 
+   float b = a;
+   fesetround(orig_rnd_mode); 
+   return b;
 }
 float __ll2float_ru(long long int a) {
-  int orig_rnd_mode = fegetround();
-  fesetround(FE_UPWARD);
-  float b = a;
-  fesetround(orig_rnd_mode);
-  return b;
+   int orig_rnd_mode = fegetround();
+   fesetround(FE_UPWARD); 
+   float b = a;
+   fesetround(orig_rnd_mode); 
+   return b;
 }
 float __ll2float_rd(long long int a) {
-  int orig_rnd_mode = fegetround();
-  fesetround(FE_DOWNWARD);
-  float b = a;
-  fesetround(orig_rnd_mode);
-  return b;
+   int orig_rnd_mode = fegetround();
+   fesetround(FE_DOWNWARD); 
+   float b = a;
+   fesetround(orig_rnd_mode); 
+   return b;
 }
 
-// 64-bit unsigned integer to float
+// 64-bit unsigned integer to float 
 float __ull2float_rn(unsigned long long int a) {
-  int orig_rnd_mode = fegetround();
-  fesetround(FE_TONEAREST);
-  float b = a;
-  fesetround(orig_rnd_mode);
-  return b;
+   int orig_rnd_mode = fegetround();
+   fesetround(FE_TONEAREST); 
+   float b = a;
+   fesetround(orig_rnd_mode); 
+   return b;
 }
 float __ull2float_rz(unsigned long long int a) {
-  int orig_rnd_mode = fegetround();
-  fesetround(FE_TOWARDZERO);
-  float b = a;
-  fesetround(orig_rnd_mode);
-  return b;
+   int orig_rnd_mode = fegetround();
+   fesetround(FE_TOWARDZERO); 
+   float b = a;
+   fesetround(orig_rnd_mode); 
+   return b;
 }
 float __ull2float_ru(unsigned long long int a) {
-  int orig_rnd_mode = fegetround();
-  fesetround(FE_UPWARD);
-  float b = a;
-  fesetround(orig_rnd_mode);
-  return b;
+   int orig_rnd_mode = fegetround();
+   fesetround(FE_UPWARD); 
+   float b = a;
+   fesetround(orig_rnd_mode); 
+   return b;
 }
 float __ull2float_rd(unsigned long long int a) {
-  int orig_rnd_mode = fegetround();
-  fesetround(FE_DOWNWARD);
-  float b = a;
-  fesetround(orig_rnd_mode);
-  return b;
+   int orig_rnd_mode = fegetround();
+   fesetround(FE_DOWNWARD); 
+   float b = a;
+   fesetround(orig_rnd_mode); 
+   return b;
 }
 
-// float to integer conversion
-int float2int(float a, enum cudaRoundMode mode) {
-  int tmp;
-  switch (mode) {
-    case cudaRoundZero:
-      tmp = truncf(a);
-      break;
-    case cudaRoundNearest:
-      tmp = nearbyintf(a);
-      break;
-    case cudaRoundMinInf:
-      tmp = floorf(a);
-      break;
-    case cudaRoundPosInf:
-      tmp = ceilf(a);
-      break;
-    default:
-      abort();
-  }
-  return tmp;
+// float to integer conversion 
+int float2int(float a, enum cudaRoundMode mode)
+{
+   int tmp;
+   switch (mode) {
+   case cudaRoundZero: tmp = truncf(a);     break;
+   case cudaRoundNearest: tmp = nearbyintf(a); break;
+   case cudaRoundMinInf: tmp = floorf(a);     break;
+   case cudaRoundPosInf: tmp = ceilf(a);      break;
+   default: abort();
+   }
+   return tmp; 
 }
 
-int __internal_float2int(float a, enum cudaRoundMode mode) {
-  return float2int(a, mode);
+int __internal_float2int(float a, enum cudaRoundMode mode) 
+{
+   return float2int(a, mode); 
 }
 
-// float to unsigned integer conversion
-unsigned int float2uint(float a, enum cudaRoundMode mode) {
-  unsigned int tmp;
-  switch (mode) {
-    case cudaRoundZero:
-      tmp = truncf(a);
-      break;
-    case cudaRoundNearest:
-      tmp = nearbyintf(a);
-      break;
-    case cudaRoundMinInf:
-      tmp = floorf(a);
-      break;
-    case cudaRoundPosInf:
-      tmp = ceilf(a);
-      break;
-    default:
-      abort();
-  }
-  return tmp;
+// float to unsigned integer conversion 
+unsigned int float2uint(float a, enum cudaRoundMode mode)
+{
+   unsigned int tmp;
+   switch (mode) {
+   case cudaRoundZero: tmp = truncf(a);     break;
+   case cudaRoundNearest: tmp = nearbyintf(a); break;
+   case cudaRoundMinInf: tmp = floorf(a);     break;
+   case cudaRoundPosInf: tmp = ceilf(a);      break;
+   default: abort();
+   }
+   return tmp; 
 }
 
-unsigned int __internal_float2uint(float a, enum cudaRoundMode mode) {
-  return float2uint(a, mode);
+unsigned int __internal_float2uint(float a, enum cudaRoundMode mode) 
+{
+   return float2uint(a, mode); 
 }
 
-// intrinsic for division
-float fdividef(float a, float b) { return (a / b); }
+// intrinsic for division 
+float fdividef(float a, float b)
+{
+   return (a / b); 
+}
 
-float __internal_accurate_fdividef(float a, float b) { return fdividef(a, b); }
+float __internal_accurate_fdividef(float a, float b)
+{
+   return fdividef(a, b); 
+}
 
 // intrinsic for saturate  (clamp values beyond 0 and 1)
-float __saturatef(float a) {
-  float b;
-  if (std::isnan(a))
-    b = 0.0f;
-  else if (a >= 1.0f)
-    b = 1.0f;
-  else if (a <= 0.0f)
-    b = 0.0f;
-  else
-    b = a;
-  return b;
+float __saturatef(float a)
+{
+   float b; 
+   if (std::isnan(a)) b = 0.0f; 
+   else if (a >= 1.0f) b = 1.0f;
+   else if (a <= 0.0f) b = 0.0f; 
+   else b = a; 
+   return b; 
 }
 
-// intrinsic for power
-float __powf(float a, float b) { return powf(a, b); }
+// intrinsic for power 
+float __powf(float a, float b)
+{
+   return powf(a, b);
+}
 
 // math functions missing in Mac OSX GCC
 #ifdef __APPLE__
-int __signbitd(double d) {
-  unsigned long long int u = *((unsigned long long int*)&d);
-  return ((u & 0x8000000000000000ULL) != 0);
+int __signbitd(double d)
+{
+   unsigned long long int u = *((unsigned long long int*)&d); 
+   return ((u & 0x8000000000000000ULL) != 0);
 }
-#endif
+#endif 
 
 #undef __CUDACC__
 #define __CUDA_INTERNAL_COMPILATION__
@@ -357,11 +354,15 @@ int __signbitd(double d) {
 #undef __attribute__
 
 #endif
+
 }
 
 // math functions missing in Mac OSX GCC
 #ifdef __APPLE__
-int isnanf(float a) { return (std::isnan(a)); }
-#endif
+int isnanf(float a) 
+{
+   return (std::isnan(a)); 
+}
+#endif 
 
 #endif

--- a/src/cuda-sim/cuda-math.h
+++ b/src/cuda-sim/cuda-math.h
@@ -1,6 +1,6 @@
 // This file created from vector_types.h distributed with CUDA 1.1
 // (see original copyright notice below)
-// 
+//
 // Changes Copyright (c) 2009-2011, Tor M. Aamodt, Wilson W.L. Fung
 // The University of British Columbia
 // All rights reserved.
@@ -10,60 +10,59 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 /*
  * Copyright 1993-2007 NVIDIA Corporation.  All rights reserved.
  *
- * NOTICE TO USER:   
+ * NOTICE TO USER:
  *
- * This source code is subject to NVIDIA ownership rights under U.S. and 
- * international Copyright laws.  Users and possessors of this source code 
- * are hereby granted a nonexclusive, royalty-free license to use this code 
+ * This source code is subject to NVIDIA ownership rights under U.S. and
+ * international Copyright laws.  Users and possessors of this source code
+ * are hereby granted a nonexclusive, royalty-free license to use this code
  * in individual and commercial software.
  *
- * NVIDIA MAKES NO REPRESENTATION ABOUT THE SUITABILITY OF THIS SOURCE 
- * CODE FOR ANY PURPOSE.  IT IS PROVIDED "AS IS" WITHOUT EXPRESS OR 
- * IMPLIED WARRANTY OF ANY KIND.  NVIDIA DISCLAIMS ALL WARRANTIES WITH 
- * REGARD TO THIS SOURCE CODE, INCLUDING ALL IMPLIED WARRANTIES OF 
+ * NVIDIA MAKES NO REPRESENTATION ABOUT THE SUITABILITY OF THIS SOURCE
+ * CODE FOR ANY PURPOSE.  IT IS PROVIDED "AS IS" WITHOUT EXPRESS OR
+ * IMPLIED WARRANTY OF ANY KIND.  NVIDIA DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOURCE CODE, INCLUDING ALL IMPLIED WARRANTIES OF
  * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE.
- * IN NO EVENT SHALL NVIDIA BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL, 
- * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS 
- * OF USE, DATA OR PROFITS,  WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE 
- * OR OTHER TORTIOUS ACTION,  ARISING OUT OF OR IN CONNECTION WITH THE USE 
- * OR PERFORMANCE OF THIS SOURCE CODE.  
+ * IN NO EVENT SHALL NVIDIA BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL,
+ * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS,  WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+ * OR OTHER TORTIOUS ACTION,  ARISING OUT OF OR IN CONNECTION WITH THE USE
+ * OR PERFORMANCE OF THIS SOURCE CODE.
  *
- * U.S. Government End Users.   This source code is a "commercial item" as 
- * that term is defined at  48 C.F.R. 2.101 (OCT 1995), consisting  of 
- * "commercial computer  software"  and "commercial computer software 
- * documentation" as such terms are  used in 48 C.F.R. 12.212 (SEPT 1995) 
- * and is provided to the U.S. Government only as a commercial end item.  
- * Consistent with 48 C.F.R.12.212 and 48 C.F.R. 227.7202-1 through 
- * 227.7202-4 (JUNE 1995), all U.S. Government End Users acquire the 
- * source code with only those rights set forth herein. 
+ * U.S. Government End Users.   This source code is a "commercial item" as
+ * that term is defined at  48 C.F.R. 2.101 (OCT 1995), consisting  of
+ * "commercial computer  software"  and "commercial computer software
+ * documentation" as such terms are  used in 48 C.F.R. 12.212 (SEPT 1995)
+ * and is provided to the U.S. Government only as a commercial end item.
+ * Consistent with 48 C.F.R.12.212 and 48 C.F.R. 227.7202-1 through
+ * 227.7202-4 (JUNE 1995), all U.S. Government End Users acquire the
+ * source code with only those rights set forth herein.
  *
- * Any use of this source code in individual and commercial software must 
+ * Any use of this source code in individual and commercial software must
  * include, in the user documentation and internal comments to the code,
  * the above Disclaimer and U.S. Government End Users Notice.
  */
-
 
 #ifndef CUDA_MATH
 #define CUDA_MATH
@@ -74,32 +73,31 @@
 #undef max
 #undef min
 namespace cuda_math {
-#define __attribute__(a) // to remove warnings inside math_functions.h
+#define __attribute__(a)  // to remove warnings inside math_functions.h
 #undef INT_MAX
 
 #if CUDART_VERSION < 3000
 // DEVICE_BUILTIN
-   struct int4 {
-      int x, y, z, w;
-   };
-   struct uint4 {
-      unsigned int x, y, z, w;
-   };
-   struct float4 {
-      float x, y, z, w;
-   };
-   struct float2 {
-      float x, y;
-   };
-    
+struct int4 {
+  int x, y, z, w;
+};
+struct uint4 {
+  unsigned int x, y, z, w;
+};
+struct float4 {
+  float x, y, z, w;
+};
+struct float2 {
+  float x, y;
+};
 
 // DEVICE_BUILTIN
-   typedef struct int4 int4;
-   typedef struct uint4 uint4;
-   typedef struct float4 float4;
-   typedef struct float2 float2;
+typedef struct int4 int4;
+typedef struct uint4 uint4;
+typedef struct float4 float4;
+typedef struct float2 float2;
 
-extern float rsqrtf(float); // CUDA 2.3 beta
+extern float rsqrtf(float);  // CUDA 2.3 beta
 
 #define CUDA_FLOAT_MATH_FUNCTIONS
 #include <device_types.h>
@@ -108,38 +106,36 @@ extern float rsqrtf(float); // CUDA 2.3 beta
 #undef __CUDA_INTERNAL_COMPILATION__
 #undef __attribute__
 
-// float to integer conversion 
-int float2int(float a, enum cudaRoundMode mode)
-{
-   return __internal_float2uint(a, mode); 
+// float to integer conversion
+int float2int(float a, enum cudaRoundMode mode) {
+  return __internal_float2uint(a, mode);
 }
 
-// float to unsigned integer conversion 
-unsigned int float2uint(float a, enum cudaRoundMode mode)
-{
-   return __internal_float2uint(a, mode); 
+// float to unsigned integer conversion
+unsigned int float2uint(float a, enum cudaRoundMode mode) {
+  return __internal_float2uint(a, mode);
 }
 
 float __ll2float_rz(long long int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_TOWARDZERO); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_TOWARDZERO);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 float __ll2float_ru(long long int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_UPWARD); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_UPWARD);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 float __ll2float_rd(long long int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_DOWNWARD); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_DOWNWARD);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 
 #else
@@ -147,205 +143,211 @@ float __ll2float_rd(long long int a) {
 #define CUDA_FLOAT_MATH_FUNCTIONS
 #define __CUDACC__
 
-// implementing int to float intrinsics with different rounding modes 
+// implementing int to float intrinsics with different rounding modes
 #include <device_types.h>
 #include <fenv.h>
 
-
 // 32-bit integer to float
 float __int2float_rn(int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_TONEAREST); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_TONEAREST);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 float __int2float_rz(int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_TOWARDZERO); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_TOWARDZERO);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 float __int2float_ru(int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_UPWARD); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_UPWARD);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 float __int2float_rd(int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_DOWNWARD); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_DOWNWARD);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 
 // 32-bit unsigned integer to float
 float __uint2float_rn(unsigned int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_TONEAREST); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_TONEAREST);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 float __uint2float_rz(unsigned int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_TOWARDZERO); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_TOWARDZERO);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 float __uint2float_ru(unsigned int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_UPWARD); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_UPWARD);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 float __uint2float_rd(unsigned int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_DOWNWARD); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_DOWNWARD);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 
 // 64-bit integer to float
 float __ll2float_rn(long long int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_TONEAREST); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_TONEAREST);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 float __ll2float_rz(long long int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_TOWARDZERO); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_TOWARDZERO);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 float __ll2float_ru(long long int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_UPWARD); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_UPWARD);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 float __ll2float_rd(long long int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_DOWNWARD); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_DOWNWARD);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 
-// 64-bit unsigned integer to float 
+// 64-bit unsigned integer to float
 float __ull2float_rn(unsigned long long int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_TONEAREST); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_TONEAREST);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 float __ull2float_rz(unsigned long long int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_TOWARDZERO); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_TOWARDZERO);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 float __ull2float_ru(unsigned long long int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_UPWARD); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_UPWARD);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 float __ull2float_rd(unsigned long long int a) {
-   int orig_rnd_mode = fegetround();
-   fesetround(FE_DOWNWARD); 
-   float b = a;
-   fesetround(orig_rnd_mode); 
-   return b;
+  int orig_rnd_mode = fegetround();
+  fesetround(FE_DOWNWARD);
+  float b = a;
+  fesetround(orig_rnd_mode);
+  return b;
 }
 
-// float to integer conversion 
-int float2int(float a, enum cudaRoundMode mode)
-{
-   int tmp;
-   switch (mode) {
-   case cudaRoundZero: tmp = truncf(a);     break;
-   case cudaRoundNearest: tmp = nearbyintf(a); break;
-   case cudaRoundMinInf: tmp = floorf(a);     break;
-   case cudaRoundPosInf: tmp = ceilf(a);      break;
-   default: abort();
-   }
-   return tmp; 
+// float to integer conversion
+int float2int(float a, enum cudaRoundMode mode) {
+  int tmp;
+  switch (mode) {
+    case cudaRoundZero:
+      tmp = truncf(a);
+      break;
+    case cudaRoundNearest:
+      tmp = nearbyintf(a);
+      break;
+    case cudaRoundMinInf:
+      tmp = floorf(a);
+      break;
+    case cudaRoundPosInf:
+      tmp = ceilf(a);
+      break;
+    default:
+      abort();
+  }
+  return tmp;
 }
 
-int __internal_float2int(float a, enum cudaRoundMode mode) 
-{
-   return float2int(a, mode); 
+int __internal_float2int(float a, enum cudaRoundMode mode) {
+  return float2int(a, mode);
 }
 
-// float to unsigned integer conversion 
-unsigned int float2uint(float a, enum cudaRoundMode mode)
-{
-   unsigned int tmp;
-   switch (mode) {
-   case cudaRoundZero: tmp = truncf(a);     break;
-   case cudaRoundNearest: tmp = nearbyintf(a); break;
-   case cudaRoundMinInf: tmp = floorf(a);     break;
-   case cudaRoundPosInf: tmp = ceilf(a);      break;
-   default: abort();
-   }
-   return tmp; 
+// float to unsigned integer conversion
+unsigned int float2uint(float a, enum cudaRoundMode mode) {
+  unsigned int tmp;
+  switch (mode) {
+    case cudaRoundZero:
+      tmp = truncf(a);
+      break;
+    case cudaRoundNearest:
+      tmp = nearbyintf(a);
+      break;
+    case cudaRoundMinInf:
+      tmp = floorf(a);
+      break;
+    case cudaRoundPosInf:
+      tmp = ceilf(a);
+      break;
+    default:
+      abort();
+  }
+  return tmp;
 }
 
-unsigned int __internal_float2uint(float a, enum cudaRoundMode mode) 
-{
-   return float2uint(a, mode); 
+unsigned int __internal_float2uint(float a, enum cudaRoundMode mode) {
+  return float2uint(a, mode);
 }
 
-// intrinsic for division 
-float fdividef(float a, float b)
-{
-   return (a / b); 
-}
+// intrinsic for division
+float fdividef(float a, float b) { return (a / b); }
 
-float __internal_accurate_fdividef(float a, float b)
-{
-   return fdividef(a, b); 
-}
+float __internal_accurate_fdividef(float a, float b) { return fdividef(a, b); }
 
 // intrinsic for saturate  (clamp values beyond 0 and 1)
-float __saturatef(float a)
-{
-   float b; 
-   if (std::isnan(a)) b = 0.0f; 
-   else if (a >= 1.0f) b = 1.0f;
-   else if (a <= 0.0f) b = 0.0f; 
-   else b = a; 
-   return b; 
+float __saturatef(float a) {
+  float b;
+  if (std::isnan(a))
+    b = 0.0f;
+  else if (a >= 1.0f)
+    b = 1.0f;
+  else if (a <= 0.0f)
+    b = 0.0f;
+  else
+    b = a;
+  return b;
 }
 
-// intrinsic for power 
-float __powf(float a, float b)
-{
-   return powf(a, b);
-}
+// intrinsic for power
+float __powf(float a, float b) { return powf(a, b); }
 
 // math functions missing in Mac OSX GCC
 #ifdef __APPLE__
-int __signbitd(double d)
-{
-   unsigned long long int u = *((unsigned long long int*)&d); 
-   return ((u & 0x8000000000000000ULL) != 0);
+int __signbitd(double d) {
+  unsigned long long int u = *((unsigned long long int*)&d);
+  return ((u & 0x8000000000000000ULL) != 0);
 }
-#endif 
+#endif
 
 #undef __CUDACC__
 #define __CUDA_INTERNAL_COMPILATION__
@@ -355,14 +357,11 @@ int __signbitd(double d)
 
 #endif
 
-}
+}  // namespace cuda_math
 
 // math functions missing in Mac OSX GCC
 #ifdef __APPLE__
-int isnanf(float a) 
-{
-   return (std::isnan(a)); 
-}
-#endif 
+int isnanf(float a) { return (std::isnan(a)); }
+#endif
 
 #endif

--- a/src/cuda-sim/cuda-sim.cc
+++ b/src/cuda-sim/cuda-sim.cc
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2011, Tor M. Aamodt, Ali Bakhoda, Wilson W.L. Fung,
-// George L. Yuan, Jimmy Kwa
+// George L. Yuan, Jimmy Kwa 
 // The University of British Columbia
 // All rights reserved.
 //
@@ -8,16 +8,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -33,318 +31,260 @@
 #include "instructions.h"
 #include "ptx_ir.h"
 class ptx_recognizer;
-typedef void *yyscan_t;
-#include <stdio.h>
-#include <map>
-#include <set>
-#include <sstream>
-#include "../../libcuda/gpgpu_context.h"
-#include "../abstract_hardware_model.h"
-#include "../gpgpu-sim/gpu-sim.h"
-#include "../gpgpusim_entrypoint.h"
-#include "../statwrapper.h"
-#include "../stream_manager.h"
-#include "cuda_device_runtime.h"
-#include "decuda_pred_table/decuda_pred_table.h"
-#include "memory.h"
-#include "opcodes.h"
-#include "ptx-stats.h"
+typedef void * yyscan_t;
 #include "ptx.tab.h"
+#include "ptx_sim.h"
+#include <stdio.h>
+#include <sstream>
+#include "opcodes.h"
+#include "../statwrapper.h"
+#include <set>
+#include <map>
+#include "../abstract_hardware_model.h"
+#include "memory.h"
+#include "ptx-stats.h"
 #include "ptx_loader.h"
 #include "ptx_parser.h"
+#include "../gpgpu-sim/gpu-sim.h"
 #include "ptx_sim.h"
-#include "ptx_sim.h"
+#include "../gpgpusim_entrypoint.h"
+#include "decuda_pred_table/decuda_pred_table.h"
+#include "../stream_manager.h"
+#include "cuda_device_runtime.h"
+#include "../../libcuda/gpgpu_context.h"
 
 int g_debug_execution = 0;
 // Output debug information to file options
 
-void cuda_sim::ptx_opcocde_latency_options(option_parser_t opp) {
-  option_parser_register(opp, "-ptx_opcode_latency_int", OPT_CSTR,
-                         &opcode_latency_int,
-                         "Opcode latencies for integers <ADD,MAX,MUL,MAD,DIV>"
-                         "Default 1,1,19,25,145",
-                         "1,1,19,25,145");
-  option_parser_register(opp, "-ptx_opcode_latency_fp", OPT_CSTR,
-                         &opcode_latency_fp,
-                         "Opcode latencies for single precision floating "
-                         "points <ADD,MAX,MUL,MAD,DIV>"
-                         "Default 1,1,1,1,30",
-                         "1,1,1,1,30");
-  option_parser_register(opp, "-ptx_opcode_latency_dp", OPT_CSTR,
-                         &opcode_latency_dp,
-                         "Opcode latencies for double precision floating "
-                         "points <ADD,MAX,MUL,MAD,DIV>"
-                         "Default 8,8,8,8,335",
-                         "8,8,8,8,335");
-  option_parser_register(opp, "-ptx_opcode_latency_sfu", OPT_CSTR,
-                         &opcode_latency_sfu,
-                         "Opcode latencies for SFU instructions"
-                         "Default 8",
-                         "8");
-  option_parser_register(opp, "-ptx_opcode_latency_tesnor", OPT_CSTR,
-                         &opcode_latency_tensor,
-                         "Opcode latencies for Tensor instructions"
-                         "Default 64",
-                         "64");
-  option_parser_register(
-      opp, "-ptx_opcode_initiation_int", OPT_CSTR, &opcode_initiation_int,
-      "Opcode initiation intervals for integers <ADD,MAX,MUL,MAD,DIV>"
-      "Default 1,1,4,4,32",
-      "1,1,4,4,32");
-  option_parser_register(opp, "-ptx_opcode_initiation_fp", OPT_CSTR,
-                         &opcode_initiation_fp,
-                         "Opcode initiation intervals for single precision "
-                         "floating points <ADD,MAX,MUL,MAD,DIV>"
-                         "Default 1,1,1,1,5",
-                         "1,1,1,1,5");
-  option_parser_register(opp, "-ptx_opcode_initiation_dp", OPT_CSTR,
-                         &opcode_initiation_dp,
-                         "Opcode initiation intervals for double precision "
-                         "floating points <ADD,MAX,MUL,MAD,DIV>"
-                         "Default 8,8,8,8,130",
-                         "8,8,8,8,130");
-  option_parser_register(opp, "-ptx_opcode_initiation_sfu", OPT_CSTR,
-                         &opcode_initiation_sfu,
-                         "Opcode initiation intervals for sfu instructions"
-                         "Default 8",
-                         "8");
-  option_parser_register(opp, "-ptx_opcode_initiation_tensor", OPT_CSTR,
-                         &opcode_initiation_tensor,
-                         "Opcode initiation intervals for tensor instructions"
-                         "Default 64",
-                         "64");
-  option_parser_register(opp, "-cdp_latency", OPT_CSTR, &cdp_latency_str,
-                         "CDP API latency <cudaStreamCreateWithFlags, \
+
+void cuda_sim::ptx_opcocde_latency_options (option_parser_t opp) {
+	option_parser_register(opp, "-ptx_opcode_latency_int", OPT_CSTR, &opcode_latency_int,
+			"Opcode latencies for integers <ADD,MAX,MUL,MAD,DIV>"
+			"Default 1,1,19,25,145",
+			"1,1,19,25,145");
+	option_parser_register(opp, "-ptx_opcode_latency_fp", OPT_CSTR, &opcode_latency_fp,
+			"Opcode latencies for single precision floating points <ADD,MAX,MUL,MAD,DIV>"
+			"Default 1,1,1,1,30",
+			"1,1,1,1,30");
+	option_parser_register(opp, "-ptx_opcode_latency_dp", OPT_CSTR, &opcode_latency_dp,
+			"Opcode latencies for double precision floating points <ADD,MAX,MUL,MAD,DIV>"
+			"Default 8,8,8,8,335",
+			"8,8,8,8,335");
+	option_parser_register(opp, "-ptx_opcode_latency_sfu", OPT_CSTR, &opcode_latency_sfu,
+			"Opcode latencies for SFU instructions"
+			"Default 8",
+			"8");
+	option_parser_register(opp, "-ptx_opcode_latency_tesnor", OPT_CSTR, &opcode_latency_tensor,
+			"Opcode latencies for Tensor instructions"
+			"Default 64",
+			"64");
+	option_parser_register(opp, "-ptx_opcode_initiation_int", OPT_CSTR, &opcode_initiation_int,
+			"Opcode initiation intervals for integers <ADD,MAX,MUL,MAD,DIV>"
+			"Default 1,1,4,4,32",
+			"1,1,4,4,32");
+	option_parser_register(opp, "-ptx_opcode_initiation_fp", OPT_CSTR, &opcode_initiation_fp,
+			"Opcode initiation intervals for single precision floating points <ADD,MAX,MUL,MAD,DIV>"
+			"Default 1,1,1,1,5",
+			"1,1,1,1,5");
+	option_parser_register(opp, "-ptx_opcode_initiation_dp", OPT_CSTR, &opcode_initiation_dp,
+			"Opcode initiation intervals for double precision floating points <ADD,MAX,MUL,MAD,DIV>"
+			"Default 8,8,8,8,130",
+			"8,8,8,8,130");
+	option_parser_register(opp, "-ptx_opcode_initiation_sfu", OPT_CSTR, &opcode_initiation_sfu,
+			"Opcode initiation intervals for sfu instructions"
+			"Default 8",
+			"8");
+	option_parser_register(opp, "-ptx_opcode_initiation_tensor", OPT_CSTR, &opcode_initiation_tensor,
+			"Opcode initiation intervals for tensor instructions"
+			"Default 64",
+			"64");
+	option_parser_register(opp, "-cdp_latency", OPT_CSTR, &cdp_latency_str,
+			"CDP API latency <cudaStreamCreateWithFlags, \
 cudaGetParameterBufferV2_init_perWarp, cudaGetParameterBufferV2_perKernel, \
 cudaLaunchDeviceV2_init_perWarp, cudaLaunchDevicV2_perKernel>"
-                         "Default 7200,8000,100,12000,1600",
-                         "7200,8000,100,12000,1600");
+			"Default 7200,8000,100,12000,1600",
+			"7200,8000,100,12000,1600");
 }
 
-void gpgpu_t::gpgpu_ptx_sim_bindNameToTexture(
-    const char *name, const struct textureReference *texref, int dim,
-    int readmode, int ext) {
-  std::string texname(name);
-  if (m_NameToTextureRef.find(texname) == m_NameToTextureRef.end()) {
-    m_NameToTextureRef[texname] = std::set<const struct textureReference *>();
-  } else {
-    const struct textureReference *tr = *m_NameToTextureRef[texname].begin();
-    assert(tr != NULL);
-    // asserts that all texrefs in set have same fields
-    assert(tr->normalized == texref->normalized &&
-           tr->filterMode == texref->filterMode &&
-           tr->addressMode[0] == texref->addressMode[0] &&
-           tr->addressMode[1] == texref->addressMode[1] &&
-           tr->addressMode[2] == texref->addressMode[2] &&
-           tr->channelDesc.x == texref->channelDesc.x &&
-           tr->channelDesc.y == texref->channelDesc.y &&
-           tr->channelDesc.z == texref->channelDesc.z &&
-           tr->channelDesc.w == texref->channelDesc.w &&
-           tr->channelDesc.f == texref->channelDesc.f);
-  }
-  m_NameToTextureRef[texname].insert(texref);
-  m_TextureRefToName[texref] = texname;
-  const textureReferenceAttr *texAttr = new textureReferenceAttr(
-      texref, dim, (enum cudaTextureReadMode)readmode, ext);
-  m_NameToAttribute[texname] = texAttr;
+void gpgpu_t::gpgpu_ptx_sim_bindNameToTexture(const char* name, const struct textureReference* texref, int dim, int readmode, int ext)
+{
+   std::string texname(name);
+   if (m_NameToTextureRef.find(texname)==m_NameToTextureRef.end()){
+      m_NameToTextureRef[texname] = std::set<const struct textureReference*>();
+   }else{
+     const struct textureReference* tr = *m_NameToTextureRef[texname].begin();
+     assert(tr!=NULL);
+     //asserts that all texrefs in set have same fields
+     assert(tr->normalized==texref->normalized&&
+            tr->filterMode==texref->filterMode&&
+            tr->addressMode[0]==texref->addressMode[0]&&
+            tr->addressMode[1]==texref->addressMode[1]&&
+            tr->addressMode[2]==texref->addressMode[2]&&
+            tr->channelDesc.x==texref->channelDesc.x&&
+            tr->channelDesc.y==texref->channelDesc.y&&
+            tr->channelDesc.z==texref->channelDesc.z&&
+            tr->channelDesc.w==texref->channelDesc.w&&
+            tr->channelDesc.f==texref->channelDesc.f  
+           );
+   }
+   m_NameToTextureRef[texname].insert(texref);
+   m_TextureRefToName[texref] = texname;
+   const textureReferenceAttr *texAttr = new textureReferenceAttr(texref, dim, (enum cudaTextureReadMode)readmode, ext); 
+   m_NameToAttribute[texname] = texAttr; 
 }
 
-const char *gpgpu_t::gpgpu_ptx_sim_findNamefromTexture(
-    const struct textureReference *texref) {
-  std::map<const struct textureReference *, std::string>::const_iterator t =
-      m_TextureRefToName.find(texref);
-  assert(t != m_TextureRefToName.end());
-  return t->second.c_str();
+const char* gpgpu_t::gpgpu_ptx_sim_findNamefromTexture(const struct textureReference* texref)
+{
+   std::map<const struct textureReference*, std::string>::const_iterator t=m_TextureRefToName.find(texref);
+   assert( t != m_TextureRefToName.end() );
+   return t->second.c_str();
 }
 
-unsigned int intLOGB2(unsigned int v) {
-  unsigned int shift;
-  unsigned int r;
+unsigned int intLOGB2( unsigned int v ) {
+   unsigned int shift;
+   unsigned int r;
 
-  r = 0;
+   r = 0;
 
-  shift = ((v & 0xFFFF0000) != 0) << 4;
-  v >>= shift;
-  r |= shift;
-  shift = ((v & 0xFF00) != 0) << 3;
-  v >>= shift;
-  r |= shift;
-  shift = ((v & 0xF0) != 0) << 2;
-  v >>= shift;
-  r |= shift;
-  shift = ((v & 0xC) != 0) << 1;
-  v >>= shift;
-  r |= shift;
-  shift = ((v & 0x2) != 0) << 0;
-  v >>= shift;
-  r |= shift;
+   shift = (( v & 0xFFFF0000) != 0 ) << 4; v >>= shift; r |= shift;
+   shift = (( v & 0xFF00    ) != 0 ) << 3; v >>= shift; r |= shift;
+   shift = (( v & 0xF0      ) != 0 ) << 2; v >>= shift; r |= shift;
+   shift = (( v & 0xC       ) != 0 ) << 1; v >>= shift; r |= shift;
+   shift = (( v & 0x2       ) != 0 ) << 0; v >>= shift; r |= shift;
 
-  return r;
+   return r;
 }
 
-void gpgpu_t::gpgpu_ptx_sim_bindTextureToArray(
-    const struct textureReference *texref, const struct cudaArray *array) {
-  std::string texname = gpgpu_ptx_sim_findNamefromTexture(texref);
+void gpgpu_t::gpgpu_ptx_sim_bindTextureToArray(const struct textureReference* texref, const struct cudaArray* array)
+{
+   std::string texname = gpgpu_ptx_sim_findNamefromTexture(texref);
 
-  std::map<std::string, const struct cudaArray *>::const_iterator t =
-      m_NameToCudaArray.find(texname);
-  // check that there's nothing there first
-  if (t != m_NameToCudaArray.end()) {
-    printf(
-        "GPGPU-Sim PTX:   Warning: binding to texref associated with %s, which "
-        "was previously bound.\nImplicitly unbinding texref associated to %s "
-        "first\n",
-        texname.c_str(), texname.c_str());
-  }
-  m_NameToCudaArray[texname] = array;
-  unsigned int texel_size_bits =
-      array->desc.w + array->desc.x + array->desc.y + array->desc.z;
-  unsigned int texel_size = texel_size_bits / 8;
-  unsigned int Tx, Ty;
-  int r;
+   std::map<std::string,const struct cudaArray*>::const_iterator t=m_NameToCudaArray.find(texname);
+   //check that there's nothing there first
+   if(t != m_NameToCudaArray.end()){
+      printf("GPGPU-Sim PTX:   Warning: binding to texref associated with %s, which was previously bound.\nImplicitly unbinding texref associated to %s first\n", texname.c_str(), texname.c_str());
+   }
+   m_NameToCudaArray[texname] = array;
+   unsigned int texel_size_bits = array->desc.w + array->desc.x + array->desc.y + array->desc.z;
+   unsigned int texel_size = texel_size_bits/8;
+   unsigned int Tx, Ty;
+   int r;
 
-  printf("GPGPU-Sim PTX:   texel size = %d\n", texel_size);
-  printf("GPGPU-Sim PTX:   texture cache linesize = %d\n",
-         m_function_model_config.get_texcache_linesize());
-  // first determine base Tx size for given linesize
-  switch (m_function_model_config.get_texcache_linesize()) {
-    case 16:
-      Tx = 4;
-      break;
-    case 32:
-      Tx = 8;
-      break;
-    case 64:
-      Tx = 8;
-      break;
-    case 128:
-      Tx = 16;
-      break;
-    case 256:
-      Tx = 16;
-      break;
-    default:
-      printf(
-          "GPGPU-Sim PTX:   Line size of %d bytes currently not supported.\n",
-          m_function_model_config.get_texcache_linesize());
+   printf("GPGPU-Sim PTX:   texel size = %d\n", texel_size);
+   printf("GPGPU-Sim PTX:   texture cache linesize = %d\n", m_function_model_config.get_texcache_linesize());
+   //first determine base Tx size for given linesize
+   switch (m_function_model_config.get_texcache_linesize()) {
+   case 16:  Tx = 4; break;
+   case 32:  Tx = 8; break;
+   case 64:  Tx = 8; break;
+   case 128: Tx = 16; break;
+   case 256: Tx = 16; break;
+   default:
+      printf("GPGPU-Sim PTX:   Line size of %d bytes currently not supported.\n", m_function_model_config.get_texcache_linesize());
       assert(0);
       break;
-  }
-  r = texel_size >> 2;
-  // modify base Tx size to take into account size of each texel in bytes
-  while (r != 0) {
-    Tx = Tx >> 1;
-    r = r >> 2;
-  }
-  // by now, got the correct Tx size, calculate correct Ty size
-  Ty = m_function_model_config.get_texcache_linesize() / (Tx * texel_size);
+   }
+   r = texel_size >> 2;
+   //modify base Tx size to take into account size of each texel in bytes
+   while (r != 0) {
+      Tx = Tx >> 1;
+      r = r >> 2;
+   }
+   //by now, got the correct Tx size, calculate correct Ty size
+   Ty = m_function_model_config.get_texcache_linesize()/(Tx*texel_size);
 
-  printf(
-      "GPGPU-Sim PTX:   Tx = %d; Ty = %d, Tx_numbits = %d, Ty_numbits = %d\n",
-      Tx, Ty, intLOGB2(Tx), intLOGB2(Ty));
-  printf("GPGPU-Sim PTX:   Texel size = %d bytes; texel_size_numbits = %d\n",
-         texel_size, intLOGB2(texel_size));
-  printf(
-      "GPGPU-Sim PTX:   Binding texture to array starting at devPtr32 = 0x%x\n",
-      array->devPtr32);
-  printf("GPGPU-Sim PTX:   Texel size = %d bytes\n", texel_size);
-  struct textureInfo *texInfo =
-      (struct textureInfo *)malloc(sizeof(struct textureInfo));
-  texInfo->Tx = Tx;
-  texInfo->Ty = Ty;
-  texInfo->Tx_numbits = intLOGB2(Tx);
-  texInfo->Ty_numbits = intLOGB2(Ty);
-  texInfo->texel_size = texel_size;
-  texInfo->texel_size_numbits = intLOGB2(texel_size);
-  m_NameToTextureInfo[texname] = texInfo;
+   printf("GPGPU-Sim PTX:   Tx = %d; Ty = %d, Tx_numbits = %d, Ty_numbits = %d\n", Tx, Ty, intLOGB2(Tx), intLOGB2(Ty));
+   printf("GPGPU-Sim PTX:   Texel size = %d bytes; texel_size_numbits = %d\n", texel_size, intLOGB2(texel_size));
+   printf("GPGPU-Sim PTX:   Binding texture to array starting at devPtr32 = 0x%x\n", array->devPtr32);
+   printf("GPGPU-Sim PTX:   Texel size = %d bytes\n", texel_size);
+   struct textureInfo* texInfo = (struct textureInfo*) malloc(sizeof(struct textureInfo)); 
+   texInfo->Tx = Tx;
+   texInfo->Ty = Ty;
+   texInfo->Tx_numbits = intLOGB2(Tx);
+   texInfo->Ty_numbits = intLOGB2(Ty);
+   texInfo->texel_size = texel_size;
+   texInfo->texel_size_numbits = intLOGB2(texel_size);
+   m_NameToTextureInfo[texname] = texInfo;
 }
 
-void gpgpu_t::gpgpu_ptx_sim_unbindTexture(
-    const struct textureReference *texref) {
-  // assumes bind-use-unbind-bind-use-unbind pattern
-  std::string texname = gpgpu_ptx_sim_findNamefromTexture(texref);
-  m_NameToCudaArray.erase(texname);
-  m_NameToTextureInfo.erase(texname);
+void gpgpu_t::gpgpu_ptx_sim_unbindTexture(const struct textureReference* texref)
+{
+   //assumes bind-use-unbind-bind-use-unbind pattern
+   std::string texname = gpgpu_ptx_sim_findNamefromTexture(texref);
+   m_NameToCudaArray.erase(texname);
+   m_NameToTextureInfo.erase(texname);
 }
 
 #define MAX_INST_SIZE 8 /*bytes*/
 
-void function_info::ptx_assemble() {
-  if (m_assembled) {
-    return;
-  }
+void function_info::ptx_assemble()
+{
+   if( m_assembled ) {
+      return;
+   }
 
-  // get the instructions into instruction memory...
-  unsigned num_inst = m_instructions.size();
-  m_instr_mem_size = MAX_INST_SIZE * (num_inst + 1);
-  m_instr_mem = new ptx_instruction *[m_instr_mem_size];
+   // get the instructions into instruction memory...
+   unsigned num_inst = m_instructions.size();
+   m_instr_mem_size = MAX_INST_SIZE*(num_inst+1);
+   m_instr_mem = new ptx_instruction*[ m_instr_mem_size ];
 
-  printf("GPGPU-Sim PTX: instruction assembly for function \'%s\'... ",
-         m_name.c_str());
-  fflush(stdout);
-  std::list<ptx_instruction *>::iterator i;
+   printf("GPGPU-Sim PTX: instruction assembly for function \'%s\'... ", m_name.c_str() );
+   fflush(stdout);
+   std::list<ptx_instruction*>::iterator i;
 
-  addr_t PC = gpgpu_ctx->func_sim->g_assemble_code_next_pc;  // globally unique
-                                                             // address (across
-                                                             // functions)
-  // start function on an aligned address
-  for (unsigned i = 0; i < (PC % MAX_INST_SIZE); i++)
-    gpgpu_ctx->s_g_pc_to_insn.push_back((ptx_instruction *)NULL);
-  PC += PC % MAX_INST_SIZE;
-  m_start_PC = PC;
+   addr_t PC = gpgpu_ctx->func_sim->g_assemble_code_next_pc; // globally unique address (across functions)
+   // start function on an aligned address
+   for( unsigned i=0; i < (PC%MAX_INST_SIZE); i++ ) 
+      gpgpu_ctx->s_g_pc_to_insn.push_back((ptx_instruction*)NULL);
+   PC += PC%MAX_INST_SIZE; 
+   m_start_PC = PC;
 
-  addr_t n = 0;  // offset in m_instr_mem
-  // Why s_g_pc_to_insn.size() is needed to reserve additional memory for insts?
-  // reserve is cumulative.
-  // s_g_pc_to_insn.reserve(s_g_pc_to_insn.size() +
-  // MAX_INST_SIZE*m_instructions.size());
-  gpgpu_ctx->s_g_pc_to_insn.reserve(MAX_INST_SIZE * m_instructions.size());
-  for (i = m_instructions.begin(); i != m_instructions.end(); i++) {
-    ptx_instruction *pI = *i;
-    if (pI->is_label()) {
-      const symbol *l = pI->get_label();
-      labels[l->name()] = n;
-    } else {
-      gpgpu_ctx->func_sim->g_pc_to_finfo[PC] = this;
-      m_instr_mem[n] = pI;
-      gpgpu_ctx->s_g_pc_to_insn.push_back(pI);
-      assert(pI == gpgpu_ctx->s_g_pc_to_insn[PC]);
-      pI->set_m_instr_mem_index(n);
-      pI->set_PC(PC);
-      assert(pI->inst_size() <= MAX_INST_SIZE);
-      for (unsigned i = 1; i < pI->inst_size(); i++) {
-        gpgpu_ctx->s_g_pc_to_insn.push_back((ptx_instruction *)NULL);
-        m_instr_mem[n + i] = NULL;
+   addr_t n=0; // offset in m_instr_mem
+   //Why s_g_pc_to_insn.size() is needed to reserve additional memory for insts? reserve is cumulative.
+   //s_g_pc_to_insn.reserve(s_g_pc_to_insn.size() + MAX_INST_SIZE*m_instructions.size());
+   gpgpu_ctx->s_g_pc_to_insn.reserve(MAX_INST_SIZE*m_instructions.size());
+   for ( i=m_instructions.begin(); i != m_instructions.end(); i++ ) {
+      ptx_instruction *pI = *i;
+      if ( pI->is_label() ) {
+         const symbol *l = pI->get_label();
+         labels[l->name()] = n;
+      } else {
+         gpgpu_ctx->func_sim->g_pc_to_finfo[PC] = this;
+         m_instr_mem[n] = pI;
+         gpgpu_ctx->s_g_pc_to_insn.push_back(pI);
+         assert(pI == gpgpu_ctx->s_g_pc_to_insn[PC]);
+         pI->set_m_instr_mem_index(n);
+         pI->set_PC(PC);
+         assert( pI->inst_size() <= MAX_INST_SIZE );
+         for( unsigned i=1; i < pI->inst_size(); i++ ) {
+            gpgpu_ctx->s_g_pc_to_insn.push_back((ptx_instruction*)NULL);
+            m_instr_mem[n+i]=NULL;
+         }
+         n  += pI->inst_size();
+         PC += pI->inst_size();
       }
-      n += pI->inst_size();
-      PC += pI->inst_size();
-    }
-  }
-  gpgpu_ctx->func_sim->g_assemble_code_next_pc = PC;
-  for (unsigned ii = 0; ii < n;
-       ii += m_instr_mem[ii]->inst_size()) {  // handle branch instructions
-    ptx_instruction *pI = m_instr_mem[ii];
-    if (pI->get_opcode() == BRA_OP || pI->get_opcode() == BREAKADDR_OP ||
-        pI->get_opcode() == CALLP_OP) {
-      operand_info &target = pI->dst();  // get operand, e.g. target name
-      if (labels.find(target.name()) == labels.end()) {
-        printf(
-            "GPGPU-Sim PTX: Loader error (%s:%u): Branch label \"%s\" does not "
-            "appear in assembly code.",
-            pI->source_file(), pI->source_line(), target.name().c_str());
-        abort();
+   }
+   gpgpu_ctx->func_sim->g_assemble_code_next_pc=PC;
+   for ( unsigned ii=0; ii < n; ii += m_instr_mem[ii]->inst_size() ) { // handle branch instructions
+      ptx_instruction *pI = m_instr_mem[ii];
+      if ( pI->get_opcode() == BRA_OP || pI->get_opcode() == BREAKADDR_OP  || pI->get_opcode() == CALLP_OP) {
+         operand_info &target = pI->dst(); //get operand, e.g. target name
+         if ( labels.find(target.name()) == labels.end() ) {
+            printf("GPGPU-Sim PTX: Loader error (%s:%u): Branch label \"%s\" does not appear in assembly code.",
+                   pI->source_file(),pI->source_line(), target.name().c_str() );
+            abort();
+         }
+         unsigned index = labels[ target.name() ]; //determine address from name
+         unsigned PC = m_instr_mem[index]->get_PC();
+         m_symtab->set_label_address( target.get_symbol(), PC );
+         target.set_type(label_t);
       }
-      unsigned index = labels[target.name()];  // determine address from name
-      unsigned PC = m_instr_mem[index]->get_PC();
-      m_symtab->set_label_address(target.get_symbol(), PC);
-      target.set_type(label_t);
-    }
-  }
-  m_n = n;
-  printf("  done.\n");
-  fflush(stdout);
+   }
+   m_n = n;
+   printf("  done.\n");
+   fflush(stdout);
 
-// disable pdom analysis  here and do it at runtime
+   //disable pdom analysis  here and do it at runtime
 #if 0
    printf("GPGPU-Sim PTX: finding reconvergence points for \'%s\'...\n", m_name.c_str() );
    create_basic_blocks();
@@ -383,2448 +323,2247 @@ void function_info::ptx_assemble() {
 #endif
 }
 
-addr_t shared_to_generic(unsigned smid, addr_t addr) {
-  assert(addr < SHARED_MEM_SIZE_MAX);
-  return SHARED_GENERIC_START + smid * SHARED_MEM_SIZE_MAX + addr;
+addr_t shared_to_generic( unsigned smid, addr_t addr )
+{
+   assert( addr < SHARED_MEM_SIZE_MAX );
+   return SHARED_GENERIC_START + smid*SHARED_MEM_SIZE_MAX + addr;
 }
 
-addr_t global_to_generic(addr_t addr) { return addr; }
-
-bool isspace_shared(unsigned smid, addr_t addr) {
-  addr_t start = SHARED_GENERIC_START + smid * SHARED_MEM_SIZE_MAX;
-  addr_t end = SHARED_GENERIC_START + (smid + 1) * SHARED_MEM_SIZE_MAX;
-  if ((addr >= end) || (addr < start)) return false;
-  return true;
+addr_t global_to_generic( addr_t addr )
+{
+   return addr;
 }
 
-bool isspace_global(addr_t addr) {
-  return (addr >= GLOBAL_HEAP_START) || (addr < STATIC_ALLOC_LIMIT);
+bool isspace_shared( unsigned smid, addr_t addr )
+{
+   addr_t start = SHARED_GENERIC_START + smid*SHARED_MEM_SIZE_MAX;
+   addr_t end = SHARED_GENERIC_START + (smid+1)*SHARED_MEM_SIZE_MAX;
+   if( (addr >= end) || (addr < start) ) 
+      return false;
+   return true;
 }
 
-memory_space_t whichspace(addr_t addr) {
-  if ((addr >= GLOBAL_HEAP_START) || (addr < STATIC_ALLOC_LIMIT)) {
-    return global_space;
-  } else if (addr >= SHARED_GENERIC_START) {
-    return shared_space;
-  } else {
-    return local_space;
-  }
+bool isspace_global( addr_t addr )
+{
+   return (addr >= GLOBAL_HEAP_START) || (addr < STATIC_ALLOC_LIMIT);
 }
 
-addr_t generic_to_shared(unsigned smid, addr_t addr) {
-  assert(isspace_shared(smid, addr));
-  return addr - (SHARED_GENERIC_START + smid * SHARED_MEM_SIZE_MAX);
+memory_space_t whichspace( addr_t addr )
+{
+   if( (addr >= GLOBAL_HEAP_START) || (addr < STATIC_ALLOC_LIMIT) ) {
+      return global_space;
+   } else if( addr >= SHARED_GENERIC_START ) {
+      return shared_space;
+   } else {
+      return local_space;
+   }
 }
 
-addr_t local_to_generic(unsigned smid, unsigned hwtid, addr_t addr) {
-  assert(addr < LOCAL_MEM_SIZE_MAX);
-  return LOCAL_GENERIC_START + (TOTAL_LOCAL_MEM_PER_SM * smid) +
-         (LOCAL_MEM_SIZE_MAX * hwtid) + addr;
+addr_t generic_to_shared( unsigned smid, addr_t addr )
+{
+   assert(isspace_shared(smid,addr));
+   return addr - (SHARED_GENERIC_START + smid*SHARED_MEM_SIZE_MAX);
 }
 
-bool isspace_local(unsigned smid, unsigned hwtid, addr_t addr) {
-  addr_t start = LOCAL_GENERIC_START + (TOTAL_LOCAL_MEM_PER_SM * smid) +
-                 (LOCAL_MEM_SIZE_MAX * hwtid);
-  addr_t end = LOCAL_GENERIC_START + (TOTAL_LOCAL_MEM_PER_SM * smid) +
-               (LOCAL_MEM_SIZE_MAX * (hwtid + 1));
-  if ((addr >= end) || (addr < start)) return false;
-  return true;
+addr_t local_to_generic( unsigned smid, unsigned hwtid, addr_t addr )
+{
+   assert(addr < LOCAL_MEM_SIZE_MAX); 
+   return LOCAL_GENERIC_START + (TOTAL_LOCAL_MEM_PER_SM * smid) + (LOCAL_MEM_SIZE_MAX * hwtid) + addr;
 }
 
-addr_t generic_to_local(unsigned smid, unsigned hwtid, addr_t addr) {
-  assert(isspace_local(smid, hwtid, addr));
-  return addr - (LOCAL_GENERIC_START + (TOTAL_LOCAL_MEM_PER_SM * smid) +
-                 (LOCAL_MEM_SIZE_MAX * hwtid));
+bool isspace_local( unsigned smid, unsigned hwtid, addr_t addr )
+{
+   addr_t start = LOCAL_GENERIC_START + (TOTAL_LOCAL_MEM_PER_SM * smid) + (LOCAL_MEM_SIZE_MAX * hwtid);
+   addr_t end   = LOCAL_GENERIC_START + (TOTAL_LOCAL_MEM_PER_SM * smid) + (LOCAL_MEM_SIZE_MAX * (hwtid+1));
+   if( (addr >= end) || (addr < start) ) 
+      return false;
+   return true;
 }
 
-addr_t generic_to_global(addr_t addr) { return addr; }
-
-void *gpgpu_t::gpu_malloc(size_t size) {
-  unsigned long long result = m_dev_malloc;
-  if (g_debug_execution >= 3) {
-    printf(
-        "GPGPU-Sim PTX: allocating %zu bytes on GPU starting at address "
-        "0x%Lx\n",
-        size, m_dev_malloc);
-    fflush(stdout);
-  }
-  m_dev_malloc += size;
-  if (size % 256)
-    m_dev_malloc += (256 - size % 256);  // align to 256 byte boundaries
-  return (void *)result;
+addr_t generic_to_local( unsigned smid, unsigned hwtid, addr_t addr )
+{
+   assert(isspace_local(smid,hwtid,addr));
+   return addr - (LOCAL_GENERIC_START + (TOTAL_LOCAL_MEM_PER_SM * smid) + (LOCAL_MEM_SIZE_MAX * hwtid));
 }
 
-void *gpgpu_t::gpu_mallocarray(size_t size) {
-  unsigned long long result = m_dev_malloc;
-  if (g_debug_execution >= 3) {
-    printf(
-        "GPGPU-Sim PTX: allocating %zu bytes on GPU starting at address "
-        "0x%Lx\n",
-        size, m_dev_malloc);
-    fflush(stdout);
-  }
-  m_dev_malloc += size;
-  if (size % 256)
-    m_dev_malloc += (256 - size % 256);  // align to 256 byte boundaries
-  return (void *)result;
+addr_t generic_to_global( addr_t addr )
+{
+   return addr;
 }
 
-void gpgpu_t::memcpy_to_gpu(size_t dst_start_addr, const void *src,
-                            size_t count) {
-  if (g_debug_execution >= 3) {
-    printf(
-        "GPGPU-Sim PTX: copying %zu bytes from CPU[0x%Lx] to GPU[0x%Lx] ... ",
-        count, (unsigned long long)src, (unsigned long long)dst_start_addr);
-    fflush(stdout);
-  }
-  char *src_data = (char *)src;
-  for (unsigned n = 0; n < count; n++)
-    m_global_mem->write(dst_start_addr + n, 1, src_data + n, NULL, NULL);
 
-  // Copy into the performance model.
-  // extern gpgpu_sim* g_the_gpu;
-  gpgpu_ctx->the_gpgpusim->g_the_gpu->perf_memcpy_to_gpu(dst_start_addr, count);
-  if (g_debug_execution >= 3) {
-    printf(" done.\n");
-    fflush(stdout);
-  }
+void* gpgpu_t::gpu_malloc( size_t size )
+{
+   unsigned long long result = m_dev_malloc;
+   if(g_debug_execution >= 3) {
+      printf("GPGPU-Sim PTX: allocating %zu bytes on GPU starting at address 0x%Lx\n", size, m_dev_malloc );
+      fflush(stdout);
+   }
+   m_dev_malloc += size;
+   if (size%256) m_dev_malloc += (256 - size%256); //align to 256 byte boundaries
+   return(void*) result;
 }
 
-void gpgpu_t::memcpy_from_gpu(void *dst, size_t src_start_addr, size_t count) {
-  if (g_debug_execution >= 3) {
-    printf("GPGPU-Sim PTX: copying %zu bytes from GPU[0x%Lx] to CPU[0x%Lx] ...",
-           count, (unsigned long long)src_start_addr, (unsigned long long)dst);
-    fflush(stdout);
-  }
-  unsigned char *dst_data = (unsigned char *)dst;
-  for (unsigned n = 0; n < count; n++)
-    m_global_mem->read(src_start_addr + n, 1, dst_data + n);
-
-  // Copy into the performance model.
-  // extern gpgpu_sim* g_the_gpu;
-  gpgpu_ctx->the_gpgpusim->g_the_gpu->perf_memcpy_to_gpu(src_start_addr, count);
-  if (g_debug_execution >= 3) {
-    printf(" done.\n");
-    fflush(stdout);
-  }
+void* gpgpu_t::gpu_mallocarray( size_t size )
+{
+   unsigned long long result = m_dev_malloc;
+   if(g_debug_execution >= 3) {
+      printf("GPGPU-Sim PTX: allocating %zu bytes on GPU starting at address 0x%Lx\n", size, m_dev_malloc );
+      fflush(stdout);
+   }
+   m_dev_malloc += size;
+   if (size%256) m_dev_malloc += (256 - size%256); //align to 256 byte boundaries
+   return(void*) result;
 }
 
-void gpgpu_t::memcpy_gpu_to_gpu(size_t dst, size_t src, size_t count) {
-  if (g_debug_execution >= 3) {
-    printf("GPGPU-Sim PTX: copying %zu bytes from GPU[0x%Lx] to GPU[0x%Lx] ...",
-           count, (unsigned long long)src, (unsigned long long)dst);
-    fflush(stdout);
-  }
-  for (unsigned n = 0; n < count; n++) {
-    unsigned char tmp;
-    m_global_mem->read(src + n, 1, &tmp);
-    m_global_mem->write(dst + n, 1, &tmp, NULL, NULL);
-  }
-  if (g_debug_execution >= 3) {
-    printf(" done.\n");
-    fflush(stdout);
-  }
+
+void gpgpu_t::memcpy_to_gpu( size_t dst_start_addr, const void *src, size_t count )
+{
+   if(g_debug_execution >= 3) {
+      printf("GPGPU-Sim PTX: copying %zu bytes from CPU[0x%Lx] to GPU[0x%Lx] ... ", count, (unsigned long long) src, (unsigned long long) dst_start_addr );
+      fflush(stdout);
+   }
+   char *src_data = (char*)src;
+   for (unsigned n=0; n < count; n ++ ) 
+      m_global_mem->write(dst_start_addr+n,1, src_data+n,NULL,NULL);
+
+   // Copy into the performance model.
+   //extern gpgpu_sim* g_the_gpu;
+   gpgpu_ctx->the_gpgpusim->g_the_gpu->perf_memcpy_to_gpu(dst_start_addr, count);
+   if(g_debug_execution >= 3) {
+      printf( " done.\n");
+      fflush(stdout);
+   }
 }
 
-void gpgpu_t::gpu_memset(size_t dst_start_addr, int c, size_t count) {
-  if (g_debug_execution >= 3) {
-    printf(
-        "GPGPU-Sim PTX: setting %zu bytes of memory to 0x%x starting at "
-        "0x%Lx... ",
-        count, (unsigned char)c, (unsigned long long)dst_start_addr);
-    fflush(stdout);
-  }
-  unsigned char c_value = (unsigned char)c;
-  for (unsigned n = 0; n < count; n++)
-    m_global_mem->write(dst_start_addr + n, 1, &c_value, NULL, NULL);
-  if (g_debug_execution >= 3) {
-    printf(" done.\n");
-    fflush(stdout);
-  }
+void gpgpu_t::memcpy_from_gpu( void *dst, size_t src_start_addr, size_t count )
+{
+   if(g_debug_execution >= 3) {
+      printf("GPGPU-Sim PTX: copying %zu bytes from GPU[0x%Lx] to CPU[0x%Lx] ...", count, (unsigned long long) src_start_addr, (unsigned long long) dst );
+      fflush(stdout);
+   }
+   unsigned char *dst_data = (unsigned char*)dst;
+   for (unsigned n=0; n < count; n ++ ) 
+      m_global_mem->read(src_start_addr+n,1,dst_data+n);
+
+   // Copy into the performance model.
+   //extern gpgpu_sim* g_the_gpu;
+   gpgpu_ctx->the_gpgpusim->g_the_gpu->perf_memcpy_to_gpu(src_start_addr, count);
+   if(g_debug_execution >= 3) {
+      printf( " done.\n");
+      fflush(stdout);
+   }
 }
 
-void cuda_sim::ptx_print_insn(address_type pc, FILE *fp) {
-  std::map<unsigned, function_info *>::iterator f = g_pc_to_finfo.find(pc);
-  if (f == g_pc_to_finfo.end()) {
-    fprintf(fp, "<no instruction at address 0x%x>", pc);
-    return;
-  }
-  function_info *finfo = f->second;
-  assert(finfo);
-  finfo->print_insn(pc, fp);
+void gpgpu_t::memcpy_gpu_to_gpu( size_t dst, size_t src, size_t count )
+{
+   if(g_debug_execution >= 3) {
+      printf("GPGPU-Sim PTX: copying %zu bytes from GPU[0x%Lx] to GPU[0x%Lx] ...", count,
+          (unsigned long long) src, (unsigned long long) dst );
+      fflush(stdout);
+   }
+   for (unsigned n=0; n < count; n ++ ) {
+      unsigned char tmp;
+      m_global_mem->read(src+n,1,&tmp); 
+      m_global_mem->write(dst+n,1, &tmp,NULL,NULL);
+   }
+   if(g_debug_execution >= 3) {
+      printf( " done.\n");
+      fflush(stdout);
+   }
 }
 
-std::string cuda_sim::ptx_get_insn_str(address_type pc) {
-  std::map<unsigned, function_info *>::iterator f = g_pc_to_finfo.find(pc);
-  if (f == g_pc_to_finfo.end()) {
-#define STR_SIZE 255
-    char buff[STR_SIZE];
-    buff[STR_SIZE - 1] = '\0';
-    snprintf(buff, STR_SIZE, "<no instruction at address 0x%x>", pc);
-    return std::string(buff);
-  }
-  function_info *finfo = f->second;
-  assert(finfo);
-  return finfo->get_insn_str(pc);
+void gpgpu_t::gpu_memset( size_t dst_start_addr, int c, size_t count )
+{
+   if(g_debug_execution >= 3) {
+      printf("GPGPU-Sim PTX: setting %zu bytes of memory to 0x%x starting at 0x%Lx... ",
+          count, (unsigned char) c, (unsigned long long) dst_start_addr );
+      fflush(stdout);
+   }
+   unsigned char c_value = (unsigned char)c;
+   for (unsigned n=0; n < count; n ++ ) 
+      m_global_mem->write(dst_start_addr+n,1,&c_value,NULL,NULL);
+   if(g_debug_execution >= 3) {
+      printf( " done.\n");
+      fflush(stdout);
+   }
 }
 
-void ptx_instruction::set_fp_or_int_archop() {
-  oprnd_type = UN_OP;
-  if ((m_opcode == MEMBAR_OP) || (m_opcode == SSY_OP) || (m_opcode == BRA_OP) ||
-      (m_opcode == BAR_OP) || (m_opcode == RET_OP) || (m_opcode == RETP_OP) ||
-      (m_opcode == NOP_OP) || (m_opcode == EXIT_OP) || (m_opcode == CALLP_OP) ||
-      (m_opcode == CALL_OP)) {
-    // do nothing
-  } else if ((m_opcode == CVT_OP || m_opcode == SET_OP ||
-              m_opcode == SLCT_OP)) {
-    if (get_type2() == F16_TYPE || get_type2() == F32_TYPE ||
-        get_type2() == F64_TYPE || get_type2() == FF64_TYPE) {
-      oprnd_type = FP_OP;
-    } else
-      oprnd_type = INT_OP;
-
-  } else {
-    if (get_type() == F16_TYPE || get_type() == F32_TYPE ||
-        get_type() == F64_TYPE || get_type() == FF64_TYPE) {
-      oprnd_type = FP_OP;
-    } else
-      oprnd_type = INT_OP;
-  }
-}
-void ptx_instruction::set_mul_div_or_other_archop() {
-  sp_op = OTHER_OP;
-  if ((m_opcode != MEMBAR_OP) && (m_opcode != SSY_OP) && (m_opcode != BRA_OP) &&
-      (m_opcode != BAR_OP) && (m_opcode != EXIT_OP) && (m_opcode != NOP_OP) &&
-      (m_opcode != RETP_OP) && (m_opcode != RET_OP) && (m_opcode != CALLP_OP) &&
-      (m_opcode != CALL_OP)) {
-    if (get_type() == F32_TYPE || get_type() == F64_TYPE ||
-        get_type() == FF64_TYPE) {
-      switch (get_opcode()) {
-        case MUL_OP:
-        case MAD_OP:
-          sp_op = FP_MUL_OP;
-          break;
-        case DIV_OP:
-          sp_op = FP_DIV_OP;
-          break;
-        case LG2_OP:
-          sp_op = FP_LG_OP;
-          break;
-        case RSQRT_OP:
-        case SQRT_OP:
-          sp_op = FP_SQRT_OP;
-          break;
-        case RCP_OP:
-          sp_op = FP_DIV_OP;
-          break;
-        case SIN_OP:
-        case COS_OP:
-          sp_op = FP_SIN_OP;
-          break;
-        case EX2_OP:
-          sp_op = FP_EXP_OP;
-          break;
-        default:
-          if ((op == ALU_OP) || (op == TENSOR_CORE_OP)) sp_op = FP__OP;
-          break;
-      }
-    } else {
-      switch (get_opcode()) {
-        case MUL24_OP:
-        case MAD24_OP:
-          sp_op = INT_MUL24_OP;
-          break;
-        case MUL_OP:
-        case MAD_OP:
-          if (get_type() == U32_TYPE || get_type() == S32_TYPE ||
-              get_type() == B32_TYPE)
-            sp_op = INT_MUL32_OP;
-          else
-            sp_op = INT_MUL_OP;
-          break;
-        case DIV_OP:
-          sp_op = INT_DIV_OP;
-          break;
-        default:
-          if ((op == ALU_OP)) sp_op = INT__OP;
-          break;
-      }
-    }
-  }
+void cuda_sim::ptx_print_insn( address_type pc, FILE *fp )
+{
+   std::map<unsigned,function_info*>::iterator f = g_pc_to_finfo.find(pc);
+   if( f == g_pc_to_finfo.end() ) {
+       fprintf(fp,"<no instruction at address 0x%x>", pc );
+       return;
+   }
+   function_info *finfo = f->second;
+   assert( finfo );
+   finfo->print_insn(pc,fp);
 }
 
-void ptx_instruction::set_bar_type() {
-  if (m_opcode == BAR_OP) {
-    switch (m_barrier_op) {
-      case SYNC_OPTION:
-        bar_type = SYNC;
-        break;
-      case ARRIVE_OPTION:
-        bar_type = ARRIVE;
-        break;
-      case RED_OPTION:
-        bar_type = RED;
-        switch (m_atomic_spec) {
-          case ATOMIC_POPC:
-            red_type = POPC_RED;
-            break;
-          case ATOMIC_AND:
-            red_type = AND_RED;
-            break;
-          case ATOMIC_OR:
-            red_type = OR_RED;
-            break;
-        }
-        break;
-      default:
-        abort();
-    }
-  } else if (m_opcode == SST_OP) {
-    bar_type = SYNC;
-  }
+std::string cuda_sim::ptx_get_insn_str( address_type pc )
+{
+   std::map<unsigned,function_info*>::iterator f = g_pc_to_finfo.find(pc);
+   if( f == g_pc_to_finfo.end() ) {
+       #define STR_SIZE 255
+       char buff[STR_SIZE];
+       buff[STR_SIZE - 1] = '\0';
+       snprintf(buff, STR_SIZE,"<no instruction at address 0x%x>", pc );
+       return std::string(buff);
+   }
+   function_info *finfo = f->second;
+   assert( finfo );
+   return finfo->get_insn_str(pc);
 }
 
-void ptx_instruction::set_opcode_and_latency() {
-  unsigned int_latency[5];
-  unsigned fp_latency[5];
-  unsigned dp_latency[5];
-  unsigned sfu_latency;
-  unsigned tensor_latency;
-  unsigned int_init[5];
-  unsigned fp_init[5];
-  unsigned dp_init[5];
-  unsigned sfu_init;
-  unsigned tensor_init;
-  /*
-   * [0] ADD,SUB
-   * [1] MAX,Min
-   * [2] MUL
-   * [3] MAD
-   * [4] DIV
-   */
-  sscanf(gpgpu_ctx->func_sim->opcode_latency_int, "%u,%u,%u,%u,%u",
-         &int_latency[0], &int_latency[1], &int_latency[2], &int_latency[3],
-         &int_latency[4]);
-  sscanf(gpgpu_ctx->func_sim->opcode_latency_fp, "%u,%u,%u,%u,%u",
-         &fp_latency[0], &fp_latency[1], &fp_latency[2], &fp_latency[3],
-         &fp_latency[4]);
-  sscanf(gpgpu_ctx->func_sim->opcode_latency_dp, "%u,%u,%u,%u,%u",
-         &dp_latency[0], &dp_latency[1], &dp_latency[2], &dp_latency[3],
-         &dp_latency[4]);
-  sscanf(gpgpu_ctx->func_sim->opcode_latency_sfu, "%u", &sfu_latency);
-  sscanf(gpgpu_ctx->func_sim->opcode_latency_tensor, "%u", &tensor_latency);
-  sscanf(gpgpu_ctx->func_sim->opcode_initiation_int, "%u,%u,%u,%u,%u",
-         &int_init[0], &int_init[1], &int_init[2], &int_init[3], &int_init[4]);
-  sscanf(gpgpu_ctx->func_sim->opcode_initiation_fp, "%u,%u,%u,%u,%u",
-         &fp_init[0], &fp_init[1], &fp_init[2], &fp_init[3], &fp_init[4]);
-  sscanf(gpgpu_ctx->func_sim->opcode_initiation_dp, "%u,%u,%u,%u,%u",
-         &dp_init[0], &dp_init[1], &dp_init[2], &dp_init[3], &dp_init[4]);
-  sscanf(gpgpu_ctx->func_sim->opcode_initiation_sfu, "%u", &sfu_init);
-  sscanf(gpgpu_ctx->func_sim->opcode_initiation_tensor, "%u", &tensor_init);
-  sscanf(gpgpu_ctx->func_sim->cdp_latency_str, "%u,%u,%u,%u,%u",
-         &gpgpu_ctx->func_sim->cdp_latency[0],
-         &gpgpu_ctx->func_sim->cdp_latency[1],
-         &gpgpu_ctx->func_sim->cdp_latency[2],
-         &gpgpu_ctx->func_sim->cdp_latency[3],
-         &gpgpu_ctx->func_sim->cdp_latency[4]);
+void ptx_instruction::set_fp_or_int_archop(){
+    oprnd_type=UN_OP;
+	if((m_opcode == MEMBAR_OP)||(m_opcode == SSY_OP )||(m_opcode == BRA_OP) || (m_opcode == BAR_OP) || (m_opcode == RET_OP) || (m_opcode == RETP_OP) || (m_opcode == NOP_OP) || (m_opcode == EXIT_OP) || (m_opcode == CALLP_OP) || (m_opcode == CALL_OP)){
+			// do nothing
+	}else if((m_opcode == CVT_OP || m_opcode == SET_OP || m_opcode == SLCT_OP)){
+		if(get_type2()==F16_TYPE || get_type2()==F32_TYPE || get_type2() == F64_TYPE || get_type2() == FF64_TYPE){
+		    oprnd_type= FP_OP;
+		}else oprnd_type=INT_OP;
 
-  if (!m_operands.empty()) {
-    std::vector<operand_info>::iterator it;
-    for (it = ++m_operands.begin(); it != m_operands.end(); it++) {
-      num_operands++;
-      if ((it->is_reg() || it->is_vector())) {
-        num_regs++;
-      }
-    }
-  }
-  op = ALU_OP;
-  mem_op = NOT_TEX;
-  initiation_interval = latency = 1;
-  switch (m_opcode) {
-    case MOV_OP:
-      assert(!(has_memory_read() && has_memory_write()));
-      if (has_memory_read()) op = LOAD_OP;
-      if (has_memory_write()) op = STORE_OP;
-      break;
-    case LD_OP:
-      op = LOAD_OP;
-      break;
-    case MMA_LD_OP:
-      op = TENSOR_CORE_LOAD_OP;
-      break;
-    case LDU_OP:
-      op = LOAD_OP;
-      break;
-    case ST_OP:
-      op = STORE_OP;
-      break;
-    case MMA_ST_OP:
-      op = TENSOR_CORE_STORE_OP;
-      break;
-    case BRA_OP:
-      op = BRANCH_OP;
-      break;
-    case BREAKADDR_OP:
-      op = BRANCH_OP;
-      break;
-    case TEX_OP:
-      op = LOAD_OP;
-      mem_op = TEX;
-      break;
-    case ATOM_OP:
-      op = LOAD_OP;
-      break;
-    case BAR_OP:
-      op = BARRIER_OP;
-      break;
-    case SST_OP:
-      op = BARRIER_OP;
-      break;
-    case MEMBAR_OP:
-      op = MEMORY_BARRIER_OP;
-      break;
-    case CALL_OP: {
-      if (m_is_printf || m_is_cdp) {
-        op = ALU_OP;
-      } else
-        op = CALL_OPS;
-      break;
-    }
-    case CALLP_OP: {
-      if (m_is_printf || m_is_cdp) {
-        op = ALU_OP;
-      } else
-        op = CALL_OPS;
-      break;
-    }
-    case RET_OP:
-    case RETP_OP:
-      op = RET_OPS;
-      break;
-    case ADD_OP:
-    case ADDP_OP:
-    case ADDC_OP:
-    case SUB_OP:
-    case SUBC_OP:
-      // ADD,SUB latency
-      switch (get_type()) {
-        case F32_TYPE:
-          latency = fp_latency[0];
-          initiation_interval = fp_init[0];
-          op = SP_OP;
-          break;
-        case F64_TYPE:
-        case FF64_TYPE:
-          latency = dp_latency[0];
-          initiation_interval = dp_init[0];
-          op = DP_OP;
-          break;
-        case B32_TYPE:
-        case U32_TYPE:
-        case S32_TYPE:
-        default:  // Use int settings for default
-          latency = int_latency[0];
-          initiation_interval = int_init[0];
-          op = INTP_OP;
-          break;
-      }
-      break;
-    case MAX_OP:
-    case MIN_OP:
-      // MAX,MIN latency
-      switch (get_type()) {
-        case F32_TYPE:
-          latency = fp_latency[1];
-          initiation_interval = fp_init[1];
-          op = SP_OP;
-          break;
-        case F64_TYPE:
-        case FF64_TYPE:
-          latency = dp_latency[1];
-          initiation_interval = dp_init[1];
-          op = DP_OP;
-          break;
-        case B32_TYPE:
-        case U32_TYPE:
-        case S32_TYPE:
-        default:  // Use int settings for default
-          latency = int_latency[1];
-          initiation_interval = int_init[1];
-          op = INTP_OP;
-          break;
-      }
-      break;
-    case MUL_OP:
-      // MUL latency
-      switch (get_type()) {
-        case F32_TYPE:
-          latency = fp_latency[2];
-          initiation_interval = fp_init[2];
-          op = SP_OP;
-          break;
-        case F64_TYPE:
-        case FF64_TYPE:
-          latency = dp_latency[2];
-          initiation_interval = dp_init[2];
-          op = DP_OP;
-          break;
-        case B32_TYPE:
-        case U32_TYPE:
-        case S32_TYPE:
-        default:  // Use int settings for default
-          latency = int_latency[2];
-          initiation_interval = int_init[2];
-          op = INTP_OP;
-          break;
-      }
-      break;
-    case MAD_OP:
-    case MADC_OP:
-    case MADP_OP:
-      // MAD latency
-      switch (get_type()) {
-        case F32_TYPE:
-          latency = fp_latency[3];
-          initiation_interval = fp_init[3];
-          op = SP_OP;
-          break;
-        case F64_TYPE:
-        case FF64_TYPE:
-          latency = dp_latency[3];
-          initiation_interval = dp_init[3];
-          op = DP_OP;
-          break;
-        case B32_TYPE:
-        case U32_TYPE:
-        case S32_TYPE:
-        default:  // Use int settings for default
-          latency = int_latency[3];
-          initiation_interval = int_init[3];
-          op = INTP_OP;
-          break;
-      }
-      break;
-    case DIV_OP:
-      // Floating point only
-      op = SFU_OP;
-      switch (get_type()) {
-        case F32_TYPE:
-          latency = fp_latency[4];
-          initiation_interval = fp_init[4];
-          break;
-        case F64_TYPE:
-        case FF64_TYPE:
-          latency = dp_latency[4];
-          initiation_interval = dp_init[4];
-          break;
-        case B32_TYPE:
-        case U32_TYPE:
-        case S32_TYPE:
-        default:  // Use int settings for default
-          latency = int_latency[4];
-          initiation_interval = int_init[4];
-          break;
-      }
-      break;
-    case SQRT_OP:
-    case SIN_OP:
-    case COS_OP:
-    case EX2_OP:
-    case LG2_OP:
-    case RSQRT_OP:
-    case RCP_OP:
-      latency = sfu_latency;
-      initiation_interval = sfu_init;
+	}else{
+		if(get_type()==F16_TYPE || get_type()==F32_TYPE || get_type() == F64_TYPE || get_type() == FF64_TYPE){
+		    oprnd_type= FP_OP;
+		}else oprnd_type=INT_OP;
+	}
+}
+void ptx_instruction::set_mul_div_or_other_archop(){
+    sp_op=OTHER_OP;
+	if((m_opcode != MEMBAR_OP) && (m_opcode != SSY_OP) && (m_opcode != BRA_OP) && (m_opcode != BAR_OP) && (m_opcode != EXIT_OP) && (m_opcode != NOP_OP) && (m_opcode != RETP_OP) && (m_opcode != RET_OP) && (m_opcode != CALLP_OP) && (m_opcode != CALL_OP)){
+		if(get_type()==F32_TYPE || get_type() == F64_TYPE || get_type() == FF64_TYPE){
+			switch(get_opcode()){
+				case MUL_OP:
+				case MAD_OP:
+				    sp_op=FP_MUL_OP;
+					break;
+				case DIV_OP:
+				    sp_op=FP_DIV_OP;
+					break;
+				case LG2_OP:
+				    sp_op=FP_LG_OP;
+					break;
+				case RSQRT_OP:
+				case SQRT_OP:
+				    sp_op=FP_SQRT_OP;
+					break;
+				case RCP_OP:
+				    sp_op=FP_DIV_OP;
+					break;
+				case SIN_OP:
+				case COS_OP:
+				    sp_op=FP_SIN_OP;
+					break;
+				case EX2_OP:
+				    sp_op=FP_EXP_OP;
+					break;
+				default:
+					if((op==ALU_OP)||(op==TENSOR_CORE_OP))
+					    sp_op=FP__OP;
+					break;
+
+			}
+		}else {
+			switch(get_opcode()){
+				case MUL24_OP:
+				case MAD24_OP:
+				    sp_op=INT_MUL24_OP;
+				break;
+				case MUL_OP:
+				case MAD_OP:
+					if(get_type()==U32_TYPE || get_type()==S32_TYPE || get_type()==B32_TYPE)
+					    sp_op=INT_MUL32_OP;
+					else
+					    sp_op=INT_MUL_OP;
+				break;
+				case DIV_OP:
+				    sp_op=INT_DIV_OP;
+				break;
+				default:
+					if((op==ALU_OP))
+					    sp_op=INT__OP;
+					break;
+			}
+		}
+	}
+
+}
+
+
+
+void ptx_instruction::set_bar_type()
+{
+	   if(m_opcode==BAR_OP) {
+		   switch(m_barrier_op){
+		   	   case SYNC_OPTION:
+		   		   bar_type = SYNC;
+		   		   break;
+		   	   case ARRIVE_OPTION:
+		   		   bar_type = ARRIVE;
+		   		   break;
+		   	   case RED_OPTION:
+		   		   bar_type = RED;
+		   		   switch(m_atomic_spec){
+		   		   	   case ATOMIC_POPC:
+				   		   red_type = POPC_RED;
+				   		   break;
+		   		   	   case ATOMIC_AND:
+				   		   red_type = AND_RED;
+				   		   break;
+		   		   	   case ATOMIC_OR:
+				   		   red_type = OR_RED;
+				   		   break;
+		   		   }
+		   		break;
+		   	   default:
+		   		   abort();
+		   }
+	   }
+	   else if(m_opcode==SST_OP) {
+		   bar_type = SYNC;
+	   }
+}
+
+
+void ptx_instruction::set_opcode_and_latency()
+{
+	unsigned int_latency[5];
+	unsigned fp_latency[5];
+	unsigned dp_latency[5];
+	unsigned sfu_latency;
+	unsigned tensor_latency;
+	unsigned int_init[5];
+	unsigned fp_init[5];
+	unsigned dp_init[5];
+	unsigned sfu_init;
+	unsigned tensor_init;
+	/*
+	 * [0] ADD,SUB
+	 * [1] MAX,Min
+	 * [2] MUL
+	 * [3] MAD
+	 * [4] DIV
+	 */
+	sscanf(gpgpu_ctx->func_sim->opcode_latency_int, "%u,%u,%u,%u,%u",
+			&int_latency[0],&int_latency[1],&int_latency[2],
+			&int_latency[3],&int_latency[4]);
+	sscanf(gpgpu_ctx->func_sim->opcode_latency_fp, "%u,%u,%u,%u,%u",
+			&fp_latency[0],&fp_latency[1],&fp_latency[2],
+			&fp_latency[3],&fp_latency[4]);
+	sscanf(gpgpu_ctx->func_sim->opcode_latency_dp, "%u,%u,%u,%u,%u",
+			&dp_latency[0],&dp_latency[1],&dp_latency[2],
+			&dp_latency[3],&dp_latency[4]);
+	sscanf(gpgpu_ctx->func_sim->opcode_latency_sfu, "%u",
+			&sfu_latency);
+	sscanf(gpgpu_ctx->func_sim->opcode_latency_tensor, "%u",
+			&tensor_latency);
+	sscanf(gpgpu_ctx->func_sim->opcode_initiation_int, "%u,%u,%u,%u,%u",
+			&int_init[0],&int_init[1],&int_init[2],
+			&int_init[3],&int_init[4]);
+	sscanf(gpgpu_ctx->func_sim->opcode_initiation_fp, "%u,%u,%u,%u,%u",
+			&fp_init[0],&fp_init[1],&fp_init[2],
+			&fp_init[3],&fp_init[4]);
+	sscanf(gpgpu_ctx->func_sim->opcode_initiation_dp, "%u,%u,%u,%u,%u",
+			&dp_init[0],&dp_init[1],&dp_init[2],
+			&dp_init[3],&dp_init[4]);
+	sscanf(gpgpu_ctx->func_sim->opcode_initiation_sfu, "%u",
+			&sfu_init);
+	sscanf(gpgpu_ctx->func_sim->opcode_initiation_tensor, "%u",
+			&tensor_init);
+	sscanf(gpgpu_ctx->func_sim->cdp_latency_str, "%u,%u,%u,%u,%u",
+			&gpgpu_ctx->func_sim->cdp_latency[0],
+			&gpgpu_ctx->func_sim->cdp_latency[1],
+			&gpgpu_ctx->func_sim->cdp_latency[2],
+			&gpgpu_ctx->func_sim->cdp_latency[3],
+			&gpgpu_ctx->func_sim->cdp_latency[4]);
+
+	if(!m_operands.empty()){
+		std::vector<operand_info>::iterator it;
+	   	for(it=++m_operands.begin();it!=m_operands.end();it++){
+	   		num_operands++;
+	   		if((it->is_reg() || it->is_vector())){
+	   			   num_regs++;
+	   		}
+	   	 }
+	}
+   op = ALU_OP;
+   mem_op= NOT_TEX;
+   initiation_interval = latency = 1;
+   switch( m_opcode ) {
+   case MOV_OP:
+       assert( !(has_memory_read() && has_memory_write()) );
+       if ( has_memory_read() ) op = LOAD_OP;
+       if ( has_memory_write() ) op = STORE_OP;
+       break;
+   case LD_OP: op = LOAD_OP; break;
+   case MMA_LD_OP: op = TENSOR_CORE_LOAD_OP; break;
+   case LDU_OP: op = LOAD_OP; break;
+   case ST_OP: op = STORE_OP; break;
+   case MMA_ST_OP: op = TENSOR_CORE_STORE_OP; break;
+   case BRA_OP: op = BRANCH_OP; break;
+   case BREAKADDR_OP: op = BRANCH_OP; break;
+   case TEX_OP: op = LOAD_OP; mem_op=TEX; break;
+   case ATOM_OP: op = LOAD_OP; break;
+   case BAR_OP: op = BARRIER_OP; break;
+   case SST_OP: op = BARRIER_OP; break;
+   case MEMBAR_OP: op = MEMORY_BARRIER_OP; break;
+   case CALL_OP:
+   {
+       if(m_is_printf || m_is_cdp) {
+           op = ALU_OP;
+       }
+       else
+           op = CALL_OPS;
+       break;
+   }
+   case CALLP_OP:
+   {
+       if(m_is_printf || m_is_cdp) {
+               op = ALU_OP;
+       }
+       else
+           op = CALL_OPS;
+       break;
+   }
+   case RET_OP: case RETP_OP:  op = RET_OPS;break;
+   case ADD_OP: case ADDP_OP: case ADDC_OP: case SUB_OP: case SUBC_OP:
+	   //ADD,SUB latency
+	   switch(get_type()){
+	   case F32_TYPE:
+		   latency = fp_latency[0];
+		   initiation_interval = fp_init[0];
+		   op = SP_OP;
+		   break;
+	   case F64_TYPE:
+	   case FF64_TYPE:
+		   latency = dp_latency[0];
+		   initiation_interval = dp_init[0];
+		   op = DP_OP;
+		   break;
+	   case B32_TYPE:
+	   case U32_TYPE:
+	   case S32_TYPE:
+	   default: //Use int settings for default
+		   latency = int_latency[0];
+		   initiation_interval = int_init[0];
+		   op = INTP_OP;
+		   break;
+	   }
+	   break;
+   case MAX_OP: case MIN_OP:
+	   //MAX,MIN latency
+	   switch(get_type()){
+	   case F32_TYPE:
+		   latency = fp_latency[1];
+		   initiation_interval = fp_init[1];
+		   op = SP_OP;
+		   break;
+	   case F64_TYPE:
+	   case FF64_TYPE:
+		   latency = dp_latency[1];
+		   initiation_interval = dp_init[1];
+		   op = DP_OP;
+		   break;
+	   case B32_TYPE:
+	   case U32_TYPE:
+	   case S32_TYPE:
+	   default: //Use int settings for default
+		   latency = int_latency[1];
+		   initiation_interval = int_init[1];
+		   op = INTP_OP;
+		   break;
+	   }
+	   break;
+   case MUL_OP:
+	   //MUL latency
+	   switch(get_type()){
+	   case F32_TYPE:
+		   latency = fp_latency[2];
+		   initiation_interval = fp_init[2];
+		   op = SP_OP;
+		   break;
+	   case F64_TYPE:
+	   case FF64_TYPE:
+		   latency = dp_latency[2];
+		   initiation_interval = dp_init[2];
+		   op = DP_OP;
+		   break;
+	   case B32_TYPE:
+	   case U32_TYPE:
+	   case S32_TYPE:
+	   default: //Use int settings for default
+		   latency = int_latency[2];
+		   initiation_interval = int_init[2];
+		   op = INTP_OP;
+		   break;
+	   }
+	   break;
+   case MAD_OP: case MADC_OP: case MADP_OP:
+	   //MAD latency
+	   switch(get_type()){
+	   case F32_TYPE:
+		   latency = fp_latency[3];
+		   initiation_interval = fp_init[3];
+		   op = SP_OP;
+		   break;
+	   case F64_TYPE:
+	   case FF64_TYPE:
+		   latency = dp_latency[3];
+		   initiation_interval = dp_init[3];
+		   op = DP_OP;
+		   break;
+	   case B32_TYPE:
+	   case U32_TYPE:
+	   case S32_TYPE:
+	   default: //Use int settings for default
+		   latency = int_latency[3];
+		   initiation_interval = int_init[3];
+		   op = INTP_OP;
+		   break;
+	   }
+	   break;
+   case DIV_OP:
+	   // Floating point only
+	   op = SFU_OP;
+	   switch(get_type()){
+	   case F32_TYPE:
+		   latency = fp_latency[4];
+		   initiation_interval = fp_init[4];
+		   break;
+	   case F64_TYPE:
+	   case FF64_TYPE:
+		   latency = dp_latency[4];
+		   initiation_interval = dp_init[4];
+		   break;
+	   case B32_TYPE:
+	   case U32_TYPE:
+	   case S32_TYPE:
+	   default: //Use int settings for default
+		   latency = int_latency[4];
+		   initiation_interval = int_init[4];
+		   break;
+	   }
+	   break;
+   case SQRT_OP: case SIN_OP: case COS_OP: case EX2_OP: case LG2_OP: case RSQRT_OP: case RCP_OP:
+	  latency = sfu_latency;
+	  initiation_interval = sfu_init;
       op = SFU_OP;
       break;
-    case MMA_OP:
-      latency = tensor_latency;
-      initiation_interval = tensor_init;
-      op = TENSOR_CORE_OP;
-      break;
-    case SHFL_OP:
-      latency = 4;
-      initiation_interval = 4;
-      break;
-    default:
-      break;
-  }
-  set_fp_or_int_archop();
-  set_mul_div_or_other_archop();
+   case MMA_OP:
+	   latency = tensor_latency;
+	   initiation_interval = tensor_init;
+       op=TENSOR_CORE_OP;
+	   break;
+   case SHFL_OP:
+	   latency = 4;
+	   initiation_interval = 4;
+	   break;
+   default: 
+       break;
+   }
+	set_fp_or_int_archop();
+	set_mul_div_or_other_archop();
+
 }
 
-void ptx_thread_info::ptx_fetch_inst(inst_t &inst) const {
-  addr_t pc = get_pc();
-  const ptx_instruction *pI = m_func_info->get_instruction(pc);
-  inst = (const inst_t &)*pI;
-  assert(inst.valid());
+void ptx_thread_info::ptx_fetch_inst( inst_t &inst ) const
+{
+   addr_t pc = get_pc();
+   const ptx_instruction *pI = m_func_info->get_instruction(pc);
+   inst = (const inst_t&)*pI;
+   assert( inst.valid() );
 }
 
-static unsigned datatype2size(unsigned data_type) {
-  unsigned data_size;
-  switch (data_type) {
-    case B8_TYPE:
-    case S8_TYPE:
-    case U8_TYPE:
-      data_size = 1;
-      break;
-    case B16_TYPE:
-    case S16_TYPE:
-    case U16_TYPE:
-    case F16_TYPE:
-      data_size = 2;
-      break;
-    case B32_TYPE:
-    case S32_TYPE:
-    case U32_TYPE:
-    case F32_TYPE:
-      data_size = 4;
-      break;
-    case B64_TYPE:
-    case BB64_TYPE:
-    case S64_TYPE:
-    case U64_TYPE:
-    case F64_TYPE:
-    case FF64_TYPE:
-      data_size = 8;
-      break;
-    case BB128_TYPE:
-      data_size = 16;
-      break;
-    default:
-      assert(0);
-      break;
-  }
-  return data_size;
+static unsigned datatype2size( unsigned data_type )
+{
+   unsigned data_size;
+   switch ( data_type ) {
+      case B8_TYPE:
+      case S8_TYPE:
+      case U8_TYPE: 
+         data_size = 1; break;
+      case B16_TYPE:
+      case S16_TYPE:
+      case U16_TYPE:
+      case F16_TYPE: 
+         data_size = 2; break;
+      case B32_TYPE:
+      case S32_TYPE:
+      case U32_TYPE:
+      case F32_TYPE: 
+         data_size = 4; break;
+      case B64_TYPE:
+      case BB64_TYPE:
+      case S64_TYPE:
+      case U64_TYPE:
+      case F64_TYPE: 
+      case FF64_TYPE:
+         data_size = 8; break;
+      case BB128_TYPE: 
+         data_size = 16; break;
+      default: assert(0); break;
+   }
+   return data_size; 
 }
 
-void ptx_instruction::pre_decode() {
-  pc = m_PC;
-  isize = m_inst_size;
-  for (unsigned i = 0; i < MAX_OUTPUT_VALUES; i++) {
-    out[i] = 0;
-  }
-  for (unsigned i = 0; i < MAX_INPUT_VALUES; i++) {
-    in[i] = 0;
-  }
-  incount = 0;
-  outcount = 0;
-  is_vectorin = 0;
-  is_vectorout = 0;
-  std::fill_n(arch_reg.src, MAX_REG_OPERANDS, -1);
-  std::fill_n(arch_reg.dst, MAX_REG_OPERANDS, -1);
-  pred = 0;
-  ar1 = 0;
-  ar2 = 0;
-  space = m_space_spec;
-  memory_op = no_memory_op;
-  data_size = 0;
-  if (has_memory_read() || has_memory_write()) {
-    unsigned to_type = get_type();
-    data_size = datatype2size(to_type);
-    memory_op = has_memory_read() ? memory_load : memory_store;
-  }
+void ptx_instruction::pre_decode()
+{
+   pc = m_PC;
+   isize = m_inst_size;
+   for(unsigned i=0; i<MAX_OUTPUT_VALUES; i++) {
+       out[i] = 0;
+   }
+   for(unsigned i=0; i<MAX_INPUT_VALUES; i++) {
+       in[i] = 0;
+   }
+   incount=0;
+   outcount=0;
+   is_vectorin = 0;
+   is_vectorout = 0;
+   std::fill_n(arch_reg.src, MAX_REG_OPERANDS, -1);
+   std::fill_n(arch_reg.dst, MAX_REG_OPERANDS, -1);
+   pred = 0;
+   ar1 = 0;
+   ar2 = 0;
+   space = m_space_spec;
+   memory_op = no_memory_op;
+   data_size = 0;
+   if ( has_memory_read() || has_memory_write() ) {
+      unsigned to_type = get_type();
+      data_size = datatype2size(to_type);
+      memory_op = has_memory_read() ? memory_load : memory_store;
+   }
 
-  bool has_dst = false;
+   bool has_dst = false ;
 
-  switch (get_opcode()) {
-#define OP_DEF(OP, FUNC, STR, DST, CLASSIFICATION) \
-  case OP:                                         \
-    has_dst = (DST != 0);                          \
-    break;
-#define OP_W_DEF(OP, FUNC, STR, DST, CLASSIFICATION) \
-  case OP:                                           \
-    has_dst = (DST != 0);                            \
-    break;
+   switch ( get_opcode() ) {
+#define OP_DEF(OP,FUNC,STR,DST,CLASSIFICATION) case OP: has_dst = (DST!=0); break;
+#define OP_W_DEF(OP,FUNC,STR,DST,CLASSIFICATION) case OP: has_dst = (DST!=0); break;
 #include "opcodes.def"
 #undef OP_DEF
 #undef OP_W_DEF
-    default:
-      printf("Execution error: Invalid opcode (0x%x)\n", get_opcode());
+   default:
+      printf( "Execution error: Invalid opcode (0x%x)\n", get_opcode() );
       break;
-  }
+   }
 
-  switch (m_cache_option) {
-    case CA_OPTION:
-      cache_op = CACHE_ALL;
+   switch( m_cache_option ) {
+   case CA_OPTION: cache_op = CACHE_ALL; break;
+   case NC_OPTION: cache_op = CACHE_L1; break;
+   case CG_OPTION: cache_op = CACHE_GLOBAL; break;
+   case CS_OPTION: cache_op = CACHE_STREAMING; break;
+   case LU_OPTION: cache_op = CACHE_LAST_USE; break;
+   case CV_OPTION: cache_op = CACHE_VOLATILE; break;
+   case WB_OPTION: cache_op = CACHE_WRITE_BACK; break;
+   case WT_OPTION: cache_op = CACHE_WRITE_THROUGH; break;
+   default: 
+      //if( m_opcode == LD_OP || m_opcode == LDU_OP ) 
+      if(  m_opcode == MMA_LD_OP || m_opcode == LD_OP || m_opcode == LDU_OP ) 
+         cache_op = CACHE_ALL;
+      //else if( m_opcode == ST_OP ) 
+      else if( m_opcode == MMA_ST_OP || m_opcode == ST_OP ) 
+         cache_op = CACHE_WRITE_BACK;
+      else if( m_opcode == ATOM_OP ) 
+         cache_op = CACHE_GLOBAL;
       break;
-    case NC_OPTION:
-      cache_op = CACHE_L1;
-      break;
-    case CG_OPTION:
-      cache_op = CACHE_GLOBAL;
-      break;
-    case CS_OPTION:
-      cache_op = CACHE_STREAMING;
-      break;
-    case LU_OPTION:
-      cache_op = CACHE_LAST_USE;
-      break;
-    case CV_OPTION:
-      cache_op = CACHE_VOLATILE;
-      break;
-    case WB_OPTION:
-      cache_op = CACHE_WRITE_BACK;
-      break;
-    case WT_OPTION:
-      cache_op = CACHE_WRITE_THROUGH;
-      break;
-    default:
-      // if( m_opcode == LD_OP || m_opcode == LDU_OP )
-      if (m_opcode == MMA_LD_OP || m_opcode == LD_OP || m_opcode == LDU_OP)
-        cache_op = CACHE_ALL;
-      // else if( m_opcode == ST_OP )
-      else if (m_opcode == MMA_ST_OP || m_opcode == ST_OP)
-        cache_op = CACHE_WRITE_BACK;
-      else if (m_opcode == ATOM_OP)
-        cache_op = CACHE_GLOBAL;
-      break;
-  }
+   }
 
-  set_opcode_and_latency();
-  set_bar_type();
-  // Get register operands
-  int n = 0, m = 0;
-  ptx_instruction::const_iterator opr = op_iter_begin();
-  for (; opr != op_iter_end(); opr++, n++) {  // process operands
-    const operand_info &o = *opr;
-    if (has_dst && n == 0) {
-      // Do not set the null register "_" as an architectural register
-      if (o.is_reg() && !o.is_non_arch_reg()) {
-        out[0] = o.reg_num();
-        arch_reg.dst[0] = o.arch_reg_num();
-      } else if (o.is_vector()) {
-        is_vectorin = 1;
-        unsigned num_elem = o.get_vect_nelem();
-        if (num_elem >= 1) out[0] = o.reg1_num();
-        if (num_elem >= 2) out[1] = o.reg2_num();
-        if (num_elem >= 3) out[2] = o.reg3_num();
-        if (num_elem >= 4) out[3] = o.reg4_num();
-        if (num_elem >= 5) out[4] = o.reg5_num();
-        if (num_elem >= 6) out[5] = o.reg6_num();
-        if (num_elem >= 7) out[6] = o.reg7_num();
-        if (num_elem >= 8) out[7] = o.reg8_num();
-        for (int i = 0; i < num_elem; i++) arch_reg.dst[i] = o.arch_reg_num(i);
+   set_opcode_and_latency();
+   set_bar_type();
+   // Get register operands
+   int n=0,m=0;
+   ptx_instruction::const_iterator opr=op_iter_begin();
+   for ( ; opr != op_iter_end(); opr++, n++ ) { //process operands
+      const operand_info &o = *opr;
+      if ( has_dst && n==0 ) {
+         // Do not set the null register "_" as an architectural register
+         if ( o.is_reg() && !o.is_non_arch_reg() ) {
+            out[0] = o.reg_num();
+            arch_reg.dst[0] = o.arch_reg_num();
+         } else if ( o.is_vector() ) {
+            is_vectorin = 1;
+            unsigned num_elem = o.get_vect_nelem();
+            if( num_elem >= 1 ) out[0] = o.reg1_num();
+            if( num_elem >= 2 ) out[1] = o.reg2_num();
+            if( num_elem >= 3 ) out[2] = o.reg3_num();
+            if( num_elem >= 4 ) out[3] = o.reg4_num();
+            if( num_elem >= 5 ) out[4] = o.reg5_num();
+            if( num_elem >= 6 ) out[5] = o.reg6_num();
+            if( num_elem >= 7 ) out[6] = o.reg7_num();
+            if( num_elem >= 8 ) out[7] = o.reg8_num();
+            for (int i = 0; i < num_elem; i++) 
+               arch_reg.dst[i] = o.arch_reg_num(i);
+         }
+      } else {
+         if ( o.is_reg() && !o.is_non_arch_reg() ) {
+            int reg_num = o.reg_num();
+            arch_reg.src[m] = o.arch_reg_num();
+            switch ( m ) {
+            case 0: in[0] = reg_num; break;
+            case 1: in[1] = reg_num; break;
+            case 2: in[2] = reg_num; break;
+            default: break; 
+            }
+            m++;
+         } else if ( o.is_vector() ) {
+            //assert(m == 0); //only support 1 vector operand (for textures) right now
+            is_vectorout = 1;
+            unsigned num_elem = o.get_vect_nelem();
+            if( num_elem >= 1 ) in[m+0] = o.reg1_num();
+            if( num_elem >= 2 ) in[m+1] = o.reg2_num();
+            if( num_elem >= 3 ) in[m+2] = o.reg3_num();
+            if( num_elem >= 4 ) in[m+3] = o.reg4_num();
+            if( num_elem >= 5 ) in[m+4] = o.reg5_num();
+            if( num_elem >= 6 ) in[m+5] = o.reg6_num();
+            if( num_elem >= 7 ) in[m+6] = o.reg7_num();
+            if( num_elem >= 8 ) in[m+7] = o.reg8_num();
+            for (int i = 0; i < num_elem; i++) 
+               arch_reg.src[m+i] = o.arch_reg_num(i);
+            m+=num_elem;
+         }
       }
-    } else {
-      if (o.is_reg() && !o.is_non_arch_reg()) {
-        int reg_num = o.reg_num();
-        arch_reg.src[m] = o.arch_reg_num();
-        switch (m) {
-          case 0:
-            in[0] = reg_num;
-            break;
-          case 1:
-            in[1] = reg_num;
-            break;
-          case 2:
-            in[2] = reg_num;
-            break;
-          default:
-            break;
-        }
-        m++;
-      } else if (o.is_vector()) {
-        // assert(m == 0); //only support 1 vector operand (for textures) right
-        // now
-        is_vectorout = 1;
-        unsigned num_elem = o.get_vect_nelem();
-        if (num_elem >= 1) in[m + 0] = o.reg1_num();
-        if (num_elem >= 2) in[m + 1] = o.reg2_num();
-        if (num_elem >= 3) in[m + 2] = o.reg3_num();
-        if (num_elem >= 4) in[m + 3] = o.reg4_num();
-        if (num_elem >= 5) in[m + 4] = o.reg5_num();
-        if (num_elem >= 6) in[m + 5] = o.reg6_num();
-        if (num_elem >= 7) in[m + 6] = o.reg7_num();
-        if (num_elem >= 8) in[m + 7] = o.reg8_num();
-        for (int i = 0; i < num_elem; i++)
-          arch_reg.src[m + i] = o.arch_reg_num(i);
-        m += num_elem;
+   }
+   
+   //Setting number of input and output operands which is required for scoreboard check
+   for(int i=0;i<MAX_OUTPUT_VALUES;i++)
+	if(out[i]>0)
+		outcount++;   
+ 
+   for(int i=0;i<MAX_INPUT_VALUES;i++)
+	if(in[i]>0)
+		incount++;   
+
+   // Get predicate
+   if(has_pred()) {
+	   const operand_info &p = get_pred();
+	   pred = p.reg_num();
+   }
+
+   // Get address registers inside memory operands.
+   // Assuming only one memory operand per instruction,
+   //  and maximum of two address registers for one memory operand.
+   if( has_memory_read() || has_memory_write() ) {
+      ptx_instruction::const_iterator op=op_iter_begin();
+      for ( ; op != op_iter_end(); op++, n++ ) { //process operands
+         const operand_info &o = *op;
+
+         if(o.is_memory_operand()) {
+             // We do not support the null register as a memory operand
+             assert( !o.is_non_arch_reg() );
+
+            // Check PTXPlus-type operand
+            // memory operand with addressing (ex. s[0x4] or g[$r1])
+            if(o.is_memory_operand2()) {
+
+               // memory operand with one address register (ex. g[$r1+0x4] or s[$r2+=0x4])
+               if(o.get_double_operand_type() == 0 || o.get_double_operand_type() == 3){
+                  ar1 = o.reg_num();
+                  arch_reg.src[4] = o.arch_reg_num();
+                  // TODO: address register in $r2+=0x4 should be an output register as well
+               }
+               // memory operand with two address register (ex. s[$r1+$r1] or g[$r1+=$r2])
+               else if(o.get_double_operand_type() == 1 || o.get_double_operand_type() == 2) {
+                  ar1 = o.reg1_num();
+                  arch_reg.src[4] = o.arch_reg_num();
+                  ar2 = o.reg2_num();
+                  arch_reg.src[5] = o.arch_reg_num();
+                  // TODO: first address register in $r1+=$r2 should be an output register as well
+               }
+            }
+            else if(o.is_immediate_address()){
+
+            }
+            // Regular PTX operand
+            else if (o.get_symbol()->type()->get_key().is_reg()) { // Memory operand contains a register
+              ar1 = o.reg_num();
+              arch_reg.src[4] = o.arch_reg_num();
+            }
+
+         }
       }
-    }
-  }
+   }
 
-  // Setting number of input and output operands which is required for
-  // scoreboard check
-  for (int i = 0; i < MAX_OUTPUT_VALUES; i++)
-    if (out[i] > 0) outcount++;
+   // get reconvergence pc
+   reconvergence_pc = gpgpu_ctx->func_sim->get_converge_point(pc);
 
-  for (int i = 0; i < MAX_INPUT_VALUES; i++)
-    if (in[i] > 0) incount++;
-
-  // Get predicate
-  if (has_pred()) {
-    const operand_info &p = get_pred();
-    pred = p.reg_num();
-  }
-
-  // Get address registers inside memory operands.
-  // Assuming only one memory operand per instruction,
-  //  and maximum of two address registers for one memory operand.
-  if (has_memory_read() || has_memory_write()) {
-    ptx_instruction::const_iterator op = op_iter_begin();
-    for (; op != op_iter_end(); op++, n++) {  // process operands
-      const operand_info &o = *op;
-
-      if (o.is_memory_operand()) {
-        // We do not support the null register as a memory operand
-        assert(!o.is_non_arch_reg());
-
-        // Check PTXPlus-type operand
-        // memory operand with addressing (ex. s[0x4] or g[$r1])
-        if (o.is_memory_operand2()) {
-          // memory operand with one address register (ex. g[$r1+0x4] or
-          // s[$r2+=0x4])
-          if (o.get_double_operand_type() == 0 ||
-              o.get_double_operand_type() == 3) {
-            ar1 = o.reg_num();
-            arch_reg.src[4] = o.arch_reg_num();
-            // TODO: address register in $r2+=0x4 should be an output register
-            // as well
-          }
-          // memory operand with two address register (ex. s[$r1+$r1] or
-          // g[$r1+=$r2])
-          else if (o.get_double_operand_type() == 1 ||
-                   o.get_double_operand_type() == 2) {
-            ar1 = o.reg1_num();
-            arch_reg.src[4] = o.arch_reg_num();
-            ar2 = o.reg2_num();
-            arch_reg.src[5] = o.arch_reg_num();
-            // TODO: first address register in $r1+=$r2 should be an output
-            // register as well
-          }
-        } else if (o.is_immediate_address()) {
-        }
-        // Regular PTX operand
-        else if (o.get_symbol()
-                     ->type()
-                     ->get_key()
-                     .is_reg()) {  // Memory operand contains a register
-          ar1 = o.reg_num();
-          arch_reg.src[4] = o.arch_reg_num();
-        }
-      }
-    }
-  }
-
-  // get reconvergence pc
-  reconvergence_pc = gpgpu_ctx->func_sim->get_converge_point(pc);
-
-  m_decoded = true;
+   m_decoded=true;
 }
 
-void function_info::add_param_name_type_size(unsigned index, std::string name,
-                                             int type, size_t size, bool ptr,
-                                             memory_space_t space) {
-  unsigned parsed_index;
-  char buffer[2048];
-  snprintf(buffer, 2048, "%s_param_%%u", m_name.c_str());
-  int ntokens = sscanf(name.c_str(), buffer, &parsed_index);
-  if (ntokens == 1) {
-    assert(m_ptx_kernel_param_info.find(parsed_index) ==
-           m_ptx_kernel_param_info.end());
-    m_ptx_kernel_param_info[parsed_index] =
-        param_info(name, type, size, ptr, space);
-  } else {
-    assert(m_ptx_kernel_param_info.find(index) ==
-           m_ptx_kernel_param_info.end());
-    m_ptx_kernel_param_info[index] = param_info(name, type, size, ptr, space);
-  }
+void function_info::add_param_name_type_size( unsigned index, std::string name, int type, size_t size, bool ptr, memory_space_t space )
+{
+   unsigned parsed_index;
+   char buffer[2048];
+   snprintf(buffer,2048,"%s_param_%%u", m_name.c_str() );
+   int ntokens = sscanf(name.c_str(),buffer,&parsed_index);
+   if( ntokens == 1 ) {
+      assert( m_ptx_kernel_param_info.find(parsed_index) == m_ptx_kernel_param_info.end() );
+      m_ptx_kernel_param_info[parsed_index] = param_info(name, type, size, ptr, space);
+   } else {
+      assert( m_ptx_kernel_param_info.find(index) == m_ptx_kernel_param_info.end() );
+      m_ptx_kernel_param_info[index] = param_info(name, type, size, ptr, space);
+   }
 }
 
-void function_info::add_param_data(unsigned argn,
-                                   struct gpgpu_ptx_sim_arg *args) {
-  const void *data = args->m_start;
+void function_info::add_param_data( unsigned argn, struct gpgpu_ptx_sim_arg *args )
+{
+   const void *data = args->m_start;
 
-  bool scratchpad_memory_param =
-      false;  // Is this parameter in CUDA shared memory or OpenCL local memory
+   bool scratchpad_memory_param = false; // Is this parameter in CUDA shared memory or OpenCL local memory 
 
-  std::map<unsigned, param_info>::iterator i =
-      m_ptx_kernel_param_info.find(argn);
-  if (i != m_ptx_kernel_param_info.end()) {
-    if (i->second.is_ptr_shared()) {
-      assert(
-          args->m_start == NULL &&
-          "OpenCL parameter pointer to local memory must have NULL as value");
-      scratchpad_memory_param = true;
-    } else {
-      param_t tmp;
-      tmp.pdata = args->m_start;
-      tmp.size = args->m_nbytes;
-      tmp.offset = args->m_offset;
-      tmp.type = 0;
-      i->second.add_data(tmp);
-      i->second.add_offset((unsigned)args->m_offset);
-    }
-  } else {
-    scratchpad_memory_param = true;
-  }
-
-  if (scratchpad_memory_param) {
-    // This should only happen for OpenCL:
-    //
-    // The LLVM PTX compiler in NVIDIA's driver (version 190.29)
-    // does not generate an argument in the function declaration
-    // for __constant arguments.
-    //
-    // The associated constant memory space can be allocated in two
-    // ways. It can be explicitly initialized in the .ptx file where
-    // it is declared.  Or, it can be allocated using the clCreateBuffer
-    // on the host. In this later case, the .ptx file will contain
-    // a global declaration of the parameter, but it will have an unknown
-    // array size.  Thus, the symbol's address will not be set and we need
-    // to set it here before executing the PTX.
-
-    char buffer[2048];
-    snprintf(buffer, 2048, "%s_param_%u", m_name.c_str(), argn);
-
-    symbol *p = m_symtab->lookup(buffer);
-    if (p == NULL) {
-      printf(
-          "GPGPU-Sim PTX: ERROR ** could not locate symbol for \'%s\' : cannot "
-          "bind buffer\n",
-          buffer);
-      abort();
-    }
-    if (data)
-      p->set_address((addr_t) * (size_t *)data);
-    else {
-      // clSetKernelArg was passed NULL pointer for data...
-      // this is used for dynamically sized shared memory on NVIDIA platforms
-      bool is_ptr_shared = false;
-      if (i != m_ptx_kernel_param_info.end()) {
-        is_ptr_shared = i->second.is_ptr_shared();
+   std::map<unsigned,param_info>::iterator i=m_ptx_kernel_param_info.find(argn);
+   if( i != m_ptx_kernel_param_info.end() ) {
+      if (i->second.is_ptr_shared()) {
+         assert(args->m_start == NULL && "OpenCL parameter pointer to local memory must have NULL as value"); 
+         scratchpad_memory_param = true; 
+      } else {
+         param_t tmp;
+         tmp.pdata = args->m_start;
+         tmp.size = args->m_nbytes;
+         tmp.offset = args->m_offset;
+         tmp.type = 0;
+         i->second.add_data(tmp);
+         i->second.add_offset((unsigned) args->m_offset);
       }
+   } else {
+      scratchpad_memory_param = true; 
+   }
 
-      if (!is_ptr_shared and !p->is_shared()) {
-        printf(
-            "GPGPU-Sim PTX: ERROR ** clSetKernelArg passed NULL but arg not "
-            "shared memory\n");
-        abort();
+   if (scratchpad_memory_param) {
+      // This should only happen for OpenCL:
+      // 
+      // The LLVM PTX compiler in NVIDIA's driver (version 190.29)
+      // does not generate an argument in the function declaration 
+      // for __constant arguments.
+      //
+      // The associated constant memory space can be allocated in two 
+      // ways. It can be explicitly initialized in the .ptx file where
+      // it is declared.  Or, it can be allocated using the clCreateBuffer
+      // on the host. In this later case, the .ptx file will contain 
+      // a global declaration of the parameter, but it will have an unknown
+      // array size.  Thus, the symbol's address will not be set and we need
+      // to set it here before executing the PTX.
+      
+      char buffer[2048];
+      snprintf(buffer,2048,"%s_param_%u",m_name.c_str(),argn);
+      
+      symbol *p = m_symtab->lookup(buffer);
+      if( p == NULL ) {
+         printf("GPGPU-Sim PTX: ERROR ** could not locate symbol for \'%s\' : cannot bind buffer\n", buffer);
+         abort();
       }
-      unsigned num_bits = 8 * args->m_nbytes;
-      printf(
-          "GPGPU-Sim PTX: deferred allocation of shared region for \"%s\" from "
-          "0x%x to 0x%x (shared memory space)\n",
-          p->name().c_str(), m_symtab->get_shared_next(),
-          m_symtab->get_shared_next() + num_bits / 8);
-      fflush(stdout);
-      assert((num_bits % 8) == 0);
-      addr_t addr = m_symtab->get_shared_next();
-      addr_t addr_pad =
-          num_bits
-              ? (((num_bits / 8) - (addr % (num_bits / 8))) % (num_bits / 8))
-              : 0;
-      p->set_address(addr + addr_pad);
-      m_symtab->alloc_shared(num_bits / 8 + addr_pad);
-    }
-  }
+      if( data ) 
+         p->set_address((addr_t)*(size_t*)data);
+      else {
+         // clSetKernelArg was passed NULL pointer for data...
+         // this is used for dynamically sized shared memory on NVIDIA platforms
+         bool is_ptr_shared = false; 
+         if( i != m_ptx_kernel_param_info.end() ) {
+            is_ptr_shared = i->second.is_ptr_shared(); 
+         }
+
+         if( !is_ptr_shared and !p->is_shared() ) {
+            printf("GPGPU-Sim PTX: ERROR ** clSetKernelArg passed NULL but arg not shared memory\n");
+            abort();     
+         }
+         unsigned num_bits = 8*args->m_nbytes;
+         printf("GPGPU-Sim PTX: deferred allocation of shared region for \"%s\" from 0x%x to 0x%x (shared memory space)\n",
+                p->name().c_str(),
+                m_symtab->get_shared_next(),
+                m_symtab->get_shared_next() + num_bits/8 );
+         fflush(stdout);
+         assert( (num_bits%8) == 0  );
+         addr_t addr = m_symtab->get_shared_next();
+         addr_t addr_pad = num_bits ? (((num_bits/8) - (addr % (num_bits/8))) % (num_bits/8)) : 0;
+         p->set_address( addr+addr_pad );
+         m_symtab->alloc_shared( num_bits/8 + addr_pad );
+      }
+   } 
 }
 
 unsigned function_info::get_args_aligned_size() {
-  if (m_args_aligned_size >= 0) return m_args_aligned_size;
+ 
+   if(m_args_aligned_size >= 0)
+      return m_args_aligned_size;
+ 
+   unsigned param_address = 0;
+   unsigned int total_size = 0;
+   for( std::map<unsigned,param_info>::iterator i=m_ptx_kernel_param_info.begin(); i!=m_ptx_kernel_param_info.end(); i++ ) {
+      param_info &p = i->second;
+      std::string name = p.get_name();
+      symbol *param = m_symtab->lookup(name.c_str());
 
-  unsigned param_address = 0;
-  unsigned int total_size = 0;
-  for (std::map<unsigned, param_info>::iterator i =
-           m_ptx_kernel_param_info.begin();
-       i != m_ptx_kernel_param_info.end(); i++) {
-    param_info &p = i->second;
-    std::string name = p.get_name();
-    symbol *param = m_symtab->lookup(name.c_str());
+      size_t arg_size = p.get_size() / 8; // size of param in bytes
+      total_size = (total_size + arg_size - 1) / arg_size * arg_size; //aligned
+      p.add_offset(total_size);
+      param->set_address(param_address + total_size);
+      total_size += arg_size;
+   }
 
-    size_t arg_size = p.get_size() / 8;  // size of param in bytes
-    total_size = (total_size + arg_size - 1) / arg_size * arg_size;  // aligned
-    p.add_offset(total_size);
-    param->set_address(param_address + total_size);
-    total_size += arg_size;
-  }
+   m_args_aligned_size = (total_size + 3) / 4 * 4; //final size aligned to word
 
-  m_args_aligned_size = (total_size + 3) / 4 * 4;  // final size aligned to word
+   return m_args_aligned_size;
 
-  return m_args_aligned_size;
 }
 
-void function_info::finalize(memory_space *param_mem) {
-  unsigned param_address = 0;
-  for (std::map<unsigned, param_info>::iterator i =
-           m_ptx_kernel_param_info.begin();
-       i != m_ptx_kernel_param_info.end(); i++) {
-    param_info &p = i->second;
-    if (p.is_ptr_shared())
-      continue;  // Pointer to local memory: Should we pass the allocated shared
-                 // memory address to the param memory space?
-    std::string name = p.get_name();
-    int type = p.get_type();
-    param_t param_value = p.get_value();
-    param_value.type = type;
-    symbol *param = m_symtab->lookup(name.c_str());
-    unsigned xtype = param->type()->get_key().scalar_type();
-    assert(xtype == (unsigned)type);
-    size_t size;
-    size = param_value.size;  // size of param in bytes
-    // assert(param_value.offset == param_address);
-    if (size != p.get_size() / 8) {
-      printf(
-          "GPGPU-Sim PTX: WARNING actual kernel paramter size = %zu bytes vs. "
-          "formal size = %zu (using smaller of two)\n",
-          size, p.get_size() / 8);
-      size = (size < (p.get_size() / 8)) ? size : (p.get_size() / 8);
-    }
-    // copy the parameter over word-by-word so that parameter that crosses a
-    // memory page can be copied over
-    // Jin: copy parameter using aligned rules
-    const type_info *paramtype = param->type();
-    int align_amount = paramtype->get_key().get_alignment_spec();
-    align_amount = (align_amount == -1) ? size : align_amount;
-    param_address = (param_address + align_amount - 1) / align_amount *
-                    align_amount;  // aligned
 
-    const size_t word_size = 4;
-    // param_address = (param_address + size - 1) / size * size; //aligned with
-    // size
-    for (size_t idx = 0; idx < size; idx += word_size) {
-      const char *pdata = reinterpret_cast<const char *>(param_value.pdata) +
-                          idx;  // cast to char * for ptr arithmetic
-      param_mem->write(param_address + idx, word_size, pdata, NULL, NULL);
-    }
-    unsigned offset = p.get_offset();
-    assert(offset == param_address);
-    param->set_address(param_address);
-    param_address += size;
-  }
-}
+void function_info::finalize( memory_space *param_mem ) 
+{
+   unsigned param_address = 0;
+   for( std::map<unsigned,param_info>::iterator i=m_ptx_kernel_param_info.begin(); i!=m_ptx_kernel_param_info.end(); i++ ) {
+      param_info &p = i->second;
+      if (p.is_ptr_shared()) continue; // Pointer to local memory: Should we pass the allocated shared memory address to the param memory space? 
+      std::string name = p.get_name();
+      int type = p.get_type();
+      param_t param_value = p.get_value();
+      param_value.type = type;
+      symbol *param = m_symtab->lookup(name.c_str());
+      unsigned xtype = param->type()->get_key().scalar_type();
+      assert(xtype==(unsigned)type);
+      size_t size;
+      size = param_value.size; // size of param in bytes
+      // assert(param_value.offset == param_address);
+      if( size != p.get_size() / 8) {
+         printf("GPGPU-Sim PTX: WARNING actual kernel paramter size = %zu bytes vs. formal size = %zu (using smaller of two)\n",
+                size, p.get_size()/8);
+         size = (size<(p.get_size()/8))?size:(p.get_size()/8);
+      } 
+      // copy the parameter over word-by-word so that parameter that crosses a memory page can be copied over
+      //Jin: copy parameter using aligned rules
+      const type_info *paramtype = param->type();
+      int align_amount = paramtype->get_key().get_alignment_spec();
+      align_amount = (align_amount == -1) ? size : align_amount;
+      param_address = (param_address + align_amount - 1) / align_amount * align_amount; //aligned
 
-void function_info::param_to_shared(memory_space *shared_mem,
-                                    symbol_table *symtab) {
-  // TODO: call this only for PTXPlus with GT200 models
-  // extern gpgpu_sim* g_the_gpu;
-  if (not gpgpu_ctx->the_gpgpusim->g_the_gpu->get_config().convert_to_ptxplus())
-    return;
-
-  // copies parameters into simulated shared memory
-  for (std::map<unsigned, param_info>::iterator i =
-           m_ptx_kernel_param_info.begin();
-       i != m_ptx_kernel_param_info.end(); i++) {
-    param_info &p = i->second;
-    if (p.is_ptr_shared())
-      continue;  // Pointer to local memory: Should we pass the allocated shared
-                 // memory address to the param memory space?
-    std::string name = p.get_name();
-    int type = p.get_type();
-    param_t value = p.get_value();
-    value.type = type;
-    symbol *param = symtab->lookup(name.c_str());
-    unsigned xtype = param->type()->get_key().scalar_type();
-    assert(xtype == (unsigned)type);
-
-    int tmp;
-    size_t size;
-    unsigned offset = p.get_offset();
-    type_info_key::type_decode(xtype, size, tmp);
-
-    // Write to shared memory - offset + 0x10
-    shared_mem->write(offset + 0x10, size / 8, value.pdata, NULL, NULL);
-  }
-}
-
-void function_info::list_param(FILE *fout) const {
-  for (std::map<unsigned, param_info>::const_iterator i =
-           m_ptx_kernel_param_info.begin();
-       i != m_ptx_kernel_param_info.end(); i++) {
-    const param_info &p = i->second;
-    std::string name = p.get_name();
-    symbol *param = m_symtab->lookup(name.c_str());
-    addr_t param_addr = param->get_address();
-    fprintf(fout, "%s: %#08x\n", name.c_str(), param_addr);
-  }
-  fflush(fout);
-}
-
-void function_info::ptx_jit_config(
-    std::map<unsigned long long, size_t> mallocPtr_Size,
-    memory_space *param_mem, gpgpu_t *gpu, dim3 gridDim, dim3 blockDim) {
-  static unsigned long long counter = 0;
-  std::vector<std::pair<size_t, unsigned char *> > param_data;
-  std::vector<unsigned> offsets;
-  std::vector<bool> paramIsPointer;
-
-  char *gpgpusim_path = getenv("GPGPUSIM_ROOT");
-  assert(gpgpusim_path != NULL);
-  char *wys_exec_path = getenv("WYS_EXEC_PATH");
-  assert(wys_exec_path != NULL);
-  std::string command =
-      std::string("mkdir ") + gpgpusim_path + "/debug_tools/WatchYourStep/data";
-  std::string filename(std::string(gpgpusim_path) +
-                       "/debug_tools/WatchYourStep/data/params.config" +
-                       std::to_string(counter));
-
-  // initialize paramList
-  char buff[1024];
-  std::string filename_c(filename + "_c");
-  snprintf(buff, 1024, "c++filt %s > %s", get_name().c_str(),
-           filename_c.c_str());
-  assert(system(buff) != NULL);
-  FILE *fp = fopen(filename_c.c_str(), "r");
-  fgets(buff, 1024, fp);
-  fclose(fp);
-  std::string fn(buff);
-  size_t pos1, pos2;
-  pos1 = fn.find_last_of("(");
-  pos2 = fn.find(")", pos1);
-  assert(pos2 > pos1 && pos1 > 0);
-  strcpy(buff, fn.substr(pos1 + 1, pos2 - pos1 - 1).c_str());
-  char *tok;
-  tok = strtok(buff, ",");
-  std::string tmp;
-  while (tok != NULL) {
-    std::string param(tok);
-    if (param.find("<") != std::string::npos) {
-      assert(param.find(">") == std::string::npos);
-      assert(param.find("*") == std::string::npos);
-      tmp = param;
-    } else {
-      if (tmp.length() > 0) {
-        tmp = "";
-        assert(param.find(">") != std::string::npos);
-        assert(param.find("<") == std::string::npos);
-        assert(param.find("*") == std::string::npos);
+      const size_t word_size = 4; 
+      //param_address = (param_address + size - 1) / size * size; //aligned with size 
+      for (size_t idx = 0; idx < size; idx += word_size) {
+         const char *pdata = reinterpret_cast<const char*>(param_value.pdata) + idx; // cast to char * for ptr arithmetic
+         param_mem->write(param_address + idx, word_size, pdata,NULL,NULL); 
       }
-      printf("%s\n", param.c_str());
-      if (param.find("*") != std::string::npos) {
-        paramIsPointer.push_back(true);
-      } else {
-        paramIsPointer.push_back(false);
-      }
-    }
-    tok = strtok(NULL, ",");
-  }
+      unsigned offset = p.get_offset();
+      assert(offset == param_address);
+      param->set_address(param_address);
+      param_address += size;
+   }
+}
 
-  for (std::map<unsigned, param_info>::iterator i =
-           m_ptx_kernel_param_info.begin();
-       i != m_ptx_kernel_param_info.end(); i++) {
-    param_info &p = i->second;
-    std::string name = p.get_name();
-    symbol *param = m_symtab->lookup(name.c_str());
-    addr_t param_addr = param->get_address();
-    param_t param_value = p.get_value();
-    offsets.push_back((unsigned)p.get_offset());
+void function_info::param_to_shared( memory_space *shared_mem, symbol_table *symtab ) 
+{
+   // TODO: call this only for PTXPlus with GT200 models 
+   //extern gpgpu_sim* g_the_gpu;
+   if (not gpgpu_ctx->the_gpgpusim->g_the_gpu->get_config().convert_to_ptxplus()) return;
 
-    if (paramIsPointer[i->first] &&
-        (*(unsigned long long *)param_value.pdata != 0)) {
-      // is pointer
-      assert(param_value.size == sizeof(void *) &&
-             "MisID'd this param as pointer");
-      size_t array_size = 0;
-      unsigned long long param_pointer =
-          *(unsigned long long *)param_value.pdata;
-      if (mallocPtr_Size.find(param_pointer) != mallocPtr_Size.end()) {
-        array_size = mallocPtr_Size[param_pointer];
-      } else {
-        for (std::map<unsigned long long, size_t>::iterator j =
-                 mallocPtr_Size.begin();
-             j != mallocPtr_Size.end(); j++) {
-          if (param_pointer > j->first &&
-              param_pointer < j->first + j->second) {
-            array_size = j->first + j->second - param_pointer;
-            break;
-          }
+   // copies parameters into simulated shared memory
+   for( std::map<unsigned,param_info>::iterator i=m_ptx_kernel_param_info.begin(); i!=m_ptx_kernel_param_info.end(); i++ ) {
+      param_info &p = i->second;
+      if (p.is_ptr_shared()) continue; // Pointer to local memory: Should we pass the allocated shared memory address to the param memory space? 
+      std::string name = p.get_name();
+      int type = p.get_type();
+      param_t value = p.get_value();
+      value.type = type;
+      symbol *param = symtab->lookup(name.c_str());
+      unsigned xtype = param->type()->get_key().scalar_type();
+      assert(xtype==(unsigned)type);
+
+      int tmp;
+      size_t size;
+      unsigned offset = p.get_offset();
+      type_info_key::type_decode(xtype,size,tmp);
+
+      // Write to shared memory - offset + 0x10
+      shared_mem->write(offset+0x10,size/8,value.pdata,NULL,NULL);
+   }
+}
+
+
+void function_info::list_param( FILE *fout ) const
+{
+   for( std::map<unsigned,param_info>::const_iterator i=m_ptx_kernel_param_info.begin(); i!=m_ptx_kernel_param_info.end(); i++ ) {
+      const param_info &p = i->second;
+      std::string name = p.get_name();
+      symbol *param = m_symtab->lookup(name.c_str());
+      addr_t param_addr = param->get_address();
+      fprintf(fout, "%s: %#08x\n", name.c_str(), param_addr);
+   }
+   fflush(fout);
+}
+
+void function_info::ptx_jit_config(std::map<unsigned long long, size_t> mallocPtr_Size, memory_space *param_mem, gpgpu_t* gpu, dim3 gridDim, dim3 blockDim) 
+{
+    static unsigned long long counter = 0;
+    std::vector< std::pair<size_t, unsigned char*> > param_data;
+    std::vector<unsigned> offsets;
+    std::vector<bool> paramIsPointer;
+
+    char * gpgpusim_path = getenv("GPGPUSIM_ROOT");
+    assert(gpgpusim_path!=NULL);
+    char * wys_exec_path = getenv("WYS_EXEC_PATH");
+    assert(wys_exec_path!=NULL);
+    std::string command = std::string("mkdir ") + gpgpusim_path + "/debug_tools/WatchYourStep/data";
+    std::string filename(std::string(gpgpusim_path) + "/debug_tools/WatchYourStep/data/params.config" + std::to_string(counter));
+
+    //initialize paramList
+    char buff[1024];
+    std::string filename_c(filename+"_c");
+    snprintf(buff,1024,"c++filt %s > %s", get_name().c_str(), filename_c.c_str());
+    assert(system(buff) != NULL);
+    FILE *fp = fopen(filename_c.c_str(), "r");
+    fgets(buff, 1024, fp);
+    fclose(fp);
+    std::string fn(buff);
+    size_t pos1, pos2;
+    pos1 = fn.find_last_of("(");
+    pos2 = fn.find(")", pos1);
+    assert(pos2>pos1&&pos1>0);
+    strcpy(buff, fn.substr(pos1 + 1, pos2 - pos1 - 1).c_str());
+    char *tok;
+    tok = strtok(buff, ",");
+    std::string tmp;
+    while(tok!=NULL){
+        std::string param(tok);
+        if(param.find("<")!=std::string::npos){
+            assert(param.find(">")==std::string::npos);
+            assert(param.find("*")==std::string::npos);
+            tmp = param;
+        } else {
+            if (tmp.length()>0){
+                tmp = ""; 
+                assert(param.find(">")!=std::string::npos);
+                assert(param.find("<")==std::string::npos);
+                assert(param.find("*")==std::string::npos);
+            }   
+            printf("%s\n", param.c_str());
+            if(param.find("*")!=std::string::npos){
+                paramIsPointer.push_back(true);
+            }else{                                                                                 
+                paramIsPointer.push_back(false);
+            }   
         }
-        assert(array_size > 0 && "pointer was not previously malloc'd");
+        tok = strtok(NULL, ",");
+    }
+
+
+    for( std::map<unsigned,param_info>::iterator i=m_ptx_kernel_param_info.begin(); i!=m_ptx_kernel_param_info.end(); i++ ) {
+        param_info &p = i->second;
+        std::string name = p.get_name();
+        symbol *param = m_symtab->lookup(name.c_str());
+        addr_t param_addr = param->get_address();
+        param_t param_value = p.get_value();
+        offsets.push_back((unsigned)p.get_offset());
+
+        if (paramIsPointer[i->first] && (*(unsigned long long*)param_value.pdata != 0)){
+            //is pointer
+            assert(param_value.size==sizeof(void*)&&"MisID'd this param as pointer");
+            size_t array_size = 0;
+            unsigned long long param_pointer = *(unsigned long long*)param_value.pdata;
+            if(mallocPtr_Size.find(param_pointer)!=mallocPtr_Size.end()){
+                array_size = mallocPtr_Size[param_pointer];
+            }else{
+                for( std::map<unsigned long long, size_t>::iterator j=mallocPtr_Size.begin(); j!=mallocPtr_Size.end(); j++ ) {
+                    if(param_pointer>j->first&&param_pointer<j->first + j->second){
+                        array_size = j->first + j->second - param_pointer;
+                        break;
+                    }
+                }
+                assert(array_size>0&&"pointer was not previously malloc'd");
+            }
+
+            unsigned char* val = (unsigned char*) malloc(param_value.size);
+            param_mem->read(param_addr,param_value.size,(void*)val);
+            unsigned char* array_val = (unsigned char*) malloc(array_size);
+            gpu->get_global_memory()->read(*(unsigned*)((void*)val),array_size,(void*)array_val);
+            param_data.push_back(std::pair<size_t, unsigned char*>(array_size,array_val));
+            paramIsPointer.push_back(true);
+        }else{
+            unsigned char* val = (unsigned char*) malloc(param_value.size);
+            param_mem->read(param_addr,param_value.size,(void*)val);
+            param_data.push_back(std::pair<size_t, unsigned char*>(param_value.size,val));
+            paramIsPointer.push_back(false);
+        }
+    }
+
+    FILE *fout  = fopen (filename.c_str(), "w");
+    printf("Writing data to %s ...\n", filename.c_str());
+    fprintf(fout, "%s\n", get_name().c_str());
+    fprintf(fout, "%u,%u,%u %u,%u,%u\n", gridDim.x, gridDim.y, gridDim.z, blockDim.x, blockDim.y, blockDim.z);
+    size_t index = 0;
+    for( std::vector< std::pair<size_t,unsigned char*> >::const_iterator i=param_data.begin(); i!=param_data.end(); i++ ) {
+        if (paramIsPointer[index]){
+            fprintf(fout, "*");
+        }
+        fprintf(fout, "%lu :", i->first);
+        for (size_t j = 0; j<i->first; j++){
+            fprintf(fout, " %u", i->second[j]);
+        }
+        fprintf(fout, " : %u", offsets[index]);
+        free (i->second);
+        fprintf(fout, "\n");
+        index++;
+    }
+    fflush(fout);
+    fclose(fout);
+    
+    //ptx config
+    std::string ptx_config_fn(std::string(gpgpusim_path) + "/debug_tools/WatchYourStep/data/ptx.config" + std::to_string(counter));
+    snprintf(buff, 1024, "grep -rn \".entry %s\" %s/*.ptx | cut -d \":\" -f 1-2 > %s", get_name().c_str(), wys_exec_path, ptx_config_fn.c_str());
+    if (system(buff)!=0){
+        printf("WARNING: Failed to execute grep to find ptx source \n");
+        printf("Problematic call: %s", buff);
+        abort();
+    }
+    FILE *fin = fopen(ptx_config_fn.c_str(), "r");
+    char ptx_source[256];
+    unsigned line_number;
+    int numscanned = fscanf(fin, "%[^:]:%u", ptx_source, &line_number);
+    assert(numscanned == 2);
+    fclose(fin);
+    snprintf(buff, 1024, "grep -rn \".version\" %s | cut -d \":\" -f 1 | xargs -I \"{}\" awk \"NR>={}&&NR<={}+2\" %s > %s", ptx_source, ptx_source, ptx_config_fn.c_str());
+    if (system(buff)!=0){
+        printf("WARNING: Failed to execute grep to find ptx header \n");
+        printf("Problematic call: %s", buff);
+        abort();
+    }
+    fin = fopen(ptx_source, "r");
+    assert(fin!=NULL);
+    printf("Writing data to %s ...\n", ptx_config_fn.c_str());
+    fout = fopen(ptx_config_fn.c_str(), "a");
+    assert(fout!=NULL);
+    for (unsigned i = 0; i<line_number; i++){
+        assert(fgets(buff, 1024, fin) != NULL);
+        assert(!feof(fin));
+    }
+    fprintf(fout, "\n\n");
+    do{
+        fprintf(fout, "%s", buff);
+        assert(fgets(buff, 1024, fin) != NULL);
+        if(feof(fin)){
+            break;
+        }
+    } while(strstr(buff, "entry")==NULL);
+
+    fclose(fin);
+    fflush(fout);
+    fclose(fout);
+    counter++;
+}
+
+template<int activate_level> 
+bool cuda_sim::ptx_debug_exec_dump_cond(int thd_uid, addr_t pc)
+{
+   if (g_debug_execution >= activate_level) {
+      // check each type of debug dump constraint to filter out dumps
+      if ( (g_debug_thread_uid != 0) && (thd_uid != (unsigned)g_debug_thread_uid) ) {
+         return false;
+      }
+      if ( (g_debug_pc != 0xBEEF1518) && (pc != g_debug_pc) ) {
+         return false;
       }
 
-      unsigned char *val = (unsigned char *)malloc(param_value.size);
-      param_mem->read(param_addr, param_value.size, (void *)val);
-      unsigned char *array_val = (unsigned char *)malloc(array_size);
-      gpu->get_global_memory()->read(*(unsigned *)((void *)val), array_size,
-                                     (void *)array_val);
-      param_data.push_back(
-          std::pair<size_t, unsigned char *>(array_size, array_val));
-      paramIsPointer.push_back(true);
-    } else {
-      unsigned char *val = (unsigned char *)malloc(param_value.size);
-      param_mem->read(param_addr, param_value.size, (void *)val);
-      param_data.push_back(
-          std::pair<size_t, unsigned char *>(param_value.size, val));
-      paramIsPointer.push_back(false);
-    }
-  }
-
-  FILE *fout = fopen(filename.c_str(), "w");
-  printf("Writing data to %s ...\n", filename.c_str());
-  fprintf(fout, "%s\n", get_name().c_str());
-  fprintf(fout, "%u,%u,%u %u,%u,%u\n", gridDim.x, gridDim.y, gridDim.z,
-          blockDim.x, blockDim.y, blockDim.z);
-  size_t index = 0;
-  for (std::vector<std::pair<size_t, unsigned char *> >::const_iterator i =
-           param_data.begin();
-       i != param_data.end(); i++) {
-    if (paramIsPointer[index]) {
-      fprintf(fout, "*");
-    }
-    fprintf(fout, "%lu :", i->first);
-    for (size_t j = 0; j < i->first; j++) {
-      fprintf(fout, " %u", i->second[j]);
-    }
-    fprintf(fout, " : %u", offsets[index]);
-    free(i->second);
-    fprintf(fout, "\n");
-    index++;
-  }
-  fflush(fout);
-  fclose(fout);
-
-  // ptx config
-  std::string ptx_config_fn(std::string(gpgpusim_path) +
-                            "/debug_tools/WatchYourStep/data/ptx.config" +
-                            std::to_string(counter));
-  snprintf(buff, 1024,
-           "grep -rn \".entry %s\" %s/*.ptx | cut -d \":\" -f 1-2 > %s",
-           get_name().c_str(), wys_exec_path, ptx_config_fn.c_str());
-  if (system(buff) != 0) {
-    printf("WARNING: Failed to execute grep to find ptx source \n");
-    printf("Problematic call: %s", buff);
-    abort();
-  }
-  FILE *fin = fopen(ptx_config_fn.c_str(), "r");
-  char ptx_source[256];
-  unsigned line_number;
-  int numscanned = fscanf(fin, "%[^:]:%u", ptx_source, &line_number);
-  assert(numscanned == 2);
-  fclose(fin);
-  snprintf(buff, 1024,
-           "grep -rn \".version\" %s | cut -d \":\" -f 1 | xargs -I \"{}\" awk "
-           "\"NR>={}&&NR<={}+2\" %s > %s",
-           ptx_source, ptx_source, ptx_config_fn.c_str());
-  if (system(buff) != 0) {
-    printf("WARNING: Failed to execute grep to find ptx header \n");
-    printf("Problematic call: %s", buff);
-    abort();
-  }
-  fin = fopen(ptx_source, "r");
-  assert(fin != NULL);
-  printf("Writing data to %s ...\n", ptx_config_fn.c_str());
-  fout = fopen(ptx_config_fn.c_str(), "a");
-  assert(fout != NULL);
-  for (unsigned i = 0; i < line_number; i++) {
-    assert(fgets(buff, 1024, fin) != NULL);
-    assert(!feof(fin));
-  }
-  fprintf(fout, "\n\n");
-  do {
-    fprintf(fout, "%s", buff);
-    assert(fgets(buff, 1024, fin) != NULL);
-    if (feof(fin)) {
-      break;
-    }
-  } while (strstr(buff, "entry") == NULL);
-
-  fclose(fin);
-  fflush(fout);
-  fclose(fout);
-  counter++;
+      return true;
+   } 
+   
+   return false;
 }
 
-template <int activate_level>
-bool cuda_sim::ptx_debug_exec_dump_cond(int thd_uid, addr_t pc) {
-  if (g_debug_execution >= activate_level) {
-    // check each type of debug dump constraint to filter out dumps
-    if ((g_debug_thread_uid != 0) &&
-        (thd_uid != (unsigned)g_debug_thread_uid)) {
-      return false;
-    }
-    if ((g_debug_pc != 0xBEEF1518) && (pc != g_debug_pc)) {
-      return false;
-    }
+void cuda_sim::init_inst_classification_stat()
+{
+   static std::set<unsigned> init;
+   if( init.find(g_ptx_kernel_count) != init.end() ) 
+      return;
+   init.insert(g_ptx_kernel_count);
 
-    return true;
-  }
-
-  return false;
+   #define MAX_CLASS_KER 1024
+   char kernelname[MAX_CLASS_KER] ="";
+   if (!g_inst_classification_stat) g_inst_classification_stat = (void**)calloc(MAX_CLASS_KER, sizeof(void*));
+   snprintf(kernelname, MAX_CLASS_KER, "Kernel %d Classification\n",g_ptx_kernel_count  );         
+   assert( g_ptx_kernel_count < MAX_CLASS_KER ) ; // a static limit on number of kernels increase it if it fails! 
+   g_inst_classification_stat[g_ptx_kernel_count] = StatCreate(kernelname,1,20);
+   if (!g_inst_op_classification_stat) g_inst_op_classification_stat = (void**)calloc(MAX_CLASS_KER, sizeof(void*));
+   snprintf(kernelname, MAX_CLASS_KER, "Kernel %d OP Classification\n",g_ptx_kernel_count  );         
+   g_inst_op_classification_stat[g_ptx_kernel_count] = StatCreate(kernelname,1,100);
 }
 
-void cuda_sim::init_inst_classification_stat() {
-  static std::set<unsigned> init;
-  if (init.find(g_ptx_kernel_count) != init.end()) return;
-  init.insert(g_ptx_kernel_count);
+static unsigned get_tex_datasize( const ptx_instruction *pI, ptx_thread_info *thread )
+{
+   const operand_info &src1 = pI->src1(); //the name of the texture
+   std::string texname = src1.name();
 
-#define MAX_CLASS_KER 1024
-  char kernelname[MAX_CLASS_KER] = "";
-  if (!g_inst_classification_stat)
-    g_inst_classification_stat = (void **)calloc(MAX_CLASS_KER, sizeof(void *));
-  snprintf(kernelname, MAX_CLASS_KER, "Kernel %d Classification\n",
-           g_ptx_kernel_count);
-  assert(g_ptx_kernel_count < MAX_CLASS_KER);  // a static limit on number of
-                                               // kernels increase it if it
-                                               // fails!
-  g_inst_classification_stat[g_ptx_kernel_count] =
-      StatCreate(kernelname, 1, 20);
-  if (!g_inst_op_classification_stat)
-    g_inst_op_classification_stat =
-        (void **)calloc(MAX_CLASS_KER, sizeof(void *));
-  snprintf(kernelname, MAX_CLASS_KER, "Kernel %d OP Classification\n",
-           g_ptx_kernel_count);
-  g_inst_op_classification_stat[g_ptx_kernel_count] =
-      StatCreate(kernelname, 1, 100);
+   /*
+     For programs with many streams, textures can be bound and unbound
+     asynchronously.  This means we need to use the kernel's "snapshot" of
+     the state of the texture mappings when it was launched (so that we
+     don't try to access the incorrect texture mapping if it's been updated,
+     or that we don't access a mapping that has been unbound).
+    */
+   kernel_info_t& k = thread->get_kernel();
+   const struct textureInfo* texInfo = k.get_texinfo(texname);
+
+   unsigned data_size = texInfo->texel_size;
+   return data_size; 
 }
 
-static unsigned get_tex_datasize(const ptx_instruction *pI,
-                                 ptx_thread_info *thread) {
-  const operand_info &src1 = pI->src1();  // the name of the texture
-  std::string texname = src1.name();
-
-  /*
-    For programs with many streams, textures can be bound and unbound
-    asynchronously.  This means we need to use the kernel's "snapshot" of
-    the state of the texture mappings when it was launched (so that we
-    don't try to access the incorrect texture mapping if it's been updated,
-    or that we don't access a mapping that has been unbound).
-   */
-  kernel_info_t &k = thread->get_kernel();
-  const struct textureInfo *texInfo = k.get_texinfo(texname);
-
-  unsigned data_size = texInfo->texel_size;
-  return data_size;
+int tensorcore_op(int inst_opcode){
+	
+       if((inst_opcode==MMA_OP)||(inst_opcode==MMA_LD_OP)||(inst_opcode==MMA_ST_OP))
+		return 1;
+       else	
+		return 0;
 }
+void ptx_thread_info::ptx_exec_inst( warp_inst_t &inst, unsigned lane_id)
+{
+    
+   bool skip = false;
+   int op_classification = 0;
+   addr_t pc = next_instr();
+   assert( pc == inst.pc ); // make sure timing model and functional model are in sync
+   const ptx_instruction *pI = m_func_info->get_instruction(pc);
+   
+   set_npc( pc + pI->inst_size() );
+   
 
-int tensorcore_op(int inst_opcode) {
-  if ((inst_opcode == MMA_OP) || (inst_opcode == MMA_LD_OP) ||
-      (inst_opcode == MMA_ST_OP))
-    return 1;
-  else
-    return 0;
-}
-void ptx_thread_info::ptx_exec_inst(warp_inst_t &inst, unsigned lane_id) {
-  bool skip = false;
-  int op_classification = 0;
-  addr_t pc = next_instr();
-  assert(pc ==
-         inst.pc);  // make sure timing model and functional model are in sync
-  const ptx_instruction *pI = m_func_info->get_instruction(pc);
+   try {
 
-  set_npc(pc + pI->inst_size());
+   clearRPC();
+   m_last_set_operand_value.u64 = 0;
 
-  try {
-    clearRPC();
-    m_last_set_operand_value.u64 = 0;
-
-    if (is_done()) {
-      printf(
-          "attempted to execute instruction on a thread that is already "
-          "done.\n");
+   if(is_done())
+   {
+      printf("attempted to execute instruction on a thread that is already done.\n");
       assert(0);
-    }
-
-    if (g_debug_execution >= 6 ||
-        m_gpu->get_config().get_ptx_inst_debug_to_file()) {
-      if ((m_gpu->gpgpu_ctx->func_sim->g_debug_thread_uid == 0) ||
-          (get_uid() ==
-           (unsigned)(m_gpu->gpgpu_ctx->func_sim->g_debug_thread_uid))) {
-        clear_modifiedregs();
-        enable_debug_trace();
+   }
+   
+   if ( g_debug_execution >= 6 || m_gpu->get_config().get_ptx_inst_debug_to_file()) {
+      if ( (m_gpu->gpgpu_ctx->func_sim->g_debug_thread_uid==0)
+	      || (get_uid() == (unsigned)(m_gpu->gpgpu_ctx->func_sim->g_debug_thread_uid)) ) {
+        
+          clear_modifiedregs();
+         enable_debug_trace();
       }
-    }
-
-    if (pI->has_pred()) {
+   }
+   
+   
+   if( pI->has_pred() ) {
       const operand_info &pred = pI->get_pred();
       ptx_reg_t pred_value = get_operand_value(pred, pred, PRED_TYPE, this, 0);
-      if (pI->get_pred_mod() == -1) {
-        skip = (pred_value.pred & 0x0001) ^
-               pI->get_pred_neg();  // ptxplus inverts the zero flag
+      if(pI->get_pred_mod() == -1) {
+            skip = (pred_value.pred & 0x0001) ^ pI->get_pred_neg(); //ptxplus inverts the zero flag
       } else {
-        skip = !pred_lookup(pI->get_pred_mod(), pred_value.pred & 0x000F);
+            skip = !pred_lookup(pI->get_pred_mod(), pred_value.pred & 0x000F);
       }
-    }
-    int inst_opcode = pI->get_opcode();
-
-    if (skip) {
+   }
+   int inst_opcode=pI->get_opcode();
+   
+   if( skip ) {
       inst.set_not_active(lane_id);
-    } else {
+   } else {
       const ptx_instruction *pI_saved = pI;
       ptx_instruction *pJ = NULL;
-      if (pI->get_opcode() == VOTE_OP) {
-        pJ = new ptx_instruction(*pI);
-        *((warp_inst_t *)pJ) = inst;  // copy active mask information
-        pI = pJ;
+      if( pI->get_opcode() == VOTE_OP ) {
+         pJ = new ptx_instruction(*pI);
+         *((warp_inst_t*)pJ) = inst; // copy active mask information
+         pI = pJ;
       }
-
-      if (((inst_opcode == MMA_OP || inst_opcode == MMA_LD_OP ||
-            inst_opcode == MMA_ST_OP))) {
-        if (inst.active_count() != MAX_WARP_SIZE) {
-          printf(
-              "Tensor Core operation are warp synchronous operation. All the "
-              "threads needs to be active.");
-          assert(0);
-        }
+     
+      if(((inst_opcode==MMA_OP||inst_opcode==MMA_LD_OP||inst_opcode==MMA_ST_OP))){
+      		if(inst.active_count()!=MAX_WARP_SIZE)
+		{	
+			printf("Tensor Core operation are warp synchronous operation. All the threads needs to be active.");
+			assert(0);
+		}
       }
-
-      // Tensorcore is warp synchronous operation. So these instructions needs
-      // to be executed only once. To make the simulation faster removing the
-      // redundant tensorcore operation
-      if (!tensorcore_op(inst_opcode) ||
-          ((tensorcore_op(inst_opcode)) && (lane_id == 0))) {
-        switch (inst_opcode) {
-#define OP_DEF(OP, FUNC, STR, DST, CLASSIFICATION) \
-  case OP:                                         \
-    FUNC(pI, this);                                \
-    op_classification = CLASSIFICATION;            \
-    break;
-#define OP_W_DEF(OP, FUNC, STR, DST, CLASSIFICATION) \
-  case OP:                                           \
-    FUNC(pI, get_core(), inst);                      \
-    op_classification = CLASSIFICATION;              \
-    break;
-#include "opcodes.def"
-#undef OP_DEF
-#undef OP_W_DEF
-          default:
-            printf("Execution error: Invalid opcode (0x%x)\n",
-                   pI->get_opcode());
-            break;
-        }
+      
+      //Tensorcore is warp synchronous operation. So these instructions needs to be executed only once. To make the simulation faster removing the redundant tensorcore operation
+      if(!tensorcore_op(inst_opcode)||((tensorcore_op(inst_opcode))&&(lane_id==0))){
+	      switch ( inst_opcode ) {
+	#define OP_DEF(OP,FUNC,STR,DST,CLASSIFICATION) case OP: FUNC(pI,this); op_classification = CLASSIFICATION; break;
+	#define OP_W_DEF(OP,FUNC,STR,DST,CLASSIFICATION) case OP: FUNC(pI,get_core(),inst); op_classification = CLASSIFICATION; break;
+	#include "opcodes.def"
+	#undef OP_DEF
+	#undef OP_W_DEF
+	      default: printf( "Execution error: Invalid opcode (0x%x)\n", pI->get_opcode() ); break;
+	      }
       }
       delete pJ;
       pI = pI_saved;
-
+      
       // Run exit instruction if exit option included
-      if (pI->is_exit()) exit_impl(pI, this);
-    }
+      if(pI->is_exit())
+         exit_impl(pI,this);
+   }
+   
 
-    const gpgpu_functional_sim_config &config = m_gpu->get_config();
 
-    // Output instruction information to file and stdout
-    if (config.get_ptx_inst_debug_to_file() != 0 &&
-        (config.get_ptx_inst_debug_thread_uid() == 0 ||
-         config.get_ptx_inst_debug_thread_uid() == get_uid())) {
-      fprintf(m_gpu->get_ptx_inst_debug_file(), "[thd=%u] : (%s:%u - %s)\n",
-              get_uid(), pI->source_file(), pI->source_line(),
-              pI->get_source());
-      // fprintf(ptx_inst_debug_file, "has memory read=%d, has memory
-      // write=%d\n", pI->has_memory_read(), pI->has_memory_write());
+   const gpgpu_functional_sim_config &config = m_gpu->get_config();
+   
+   // Output instruction information to file and stdout
+   if( config.get_ptx_inst_debug_to_file() != 0 && 
+        (config.get_ptx_inst_debug_thread_uid() == 0 || config.get_ptx_inst_debug_thread_uid() == get_uid()) ) {
+      fprintf(m_gpu->get_ptx_inst_debug_file(),
+             "[thd=%u] : (%s:%u - %s)\n",
+             get_uid(),
+             pI->source_file(), pI->source_line(), pI->get_source() );
+      //fprintf(ptx_inst_debug_file, "has memory read=%d, has memory write=%d\n", pI->has_memory_read(), pI->has_memory_write());
       fflush(m_gpu->get_ptx_inst_debug_file());
-    }
+   }
 
-    if (m_gpu->gpgpu_ctx->func_sim->ptx_debug_exec_dump_cond<5>(get_uid(),
-                                                                pc)) {
+   if ( m_gpu->gpgpu_ctx->func_sim->ptx_debug_exec_dump_cond<5>(get_uid(), pc) ) {
       dim3 ctaid = get_ctaid();
       dim3 tid = get_tid();
-      printf(
-          "%u [thd=%u][i=%u] : ctaid=(%u,%u,%u) tid=(%u,%u,%u) icount=%u "
-          "[pc=%u] (%s:%u - %s)  [0x%llx]\n",
-          m_gpu->gpgpu_ctx->func_sim->g_ptx_sim_num_insn, get_uid(), pI->uid(),
-          ctaid.x, ctaid.y, ctaid.z, tid.x, tid.y, tid.z, get_icount(), pc,
-          pI->source_file(), pI->source_line(), pI->get_source(),
-          m_last_set_operand_value.u64);
+      printf("%u [thd=%u][i=%u] : ctaid=(%u,%u,%u) tid=(%u,%u,%u) icount=%u [pc=%u] (%s:%u - %s)  [0x%llx]\n", 
+             m_gpu->gpgpu_ctx->func_sim->g_ptx_sim_num_insn,
+             get_uid(),
+             pI->uid(), ctaid.x,ctaid.y,ctaid.z,tid.x,tid.y,tid.z,
+             get_icount(),
+             pc, pI->source_file(), pI->source_line(), pI->get_source(),
+             m_last_set_operand_value.u64 );
       fflush(stdout);
-    }
-
-    addr_t insn_memaddr = 0xFEEBDAED;
-    memory_space_t insn_space = undefined_space;
-    _memory_op_t insn_memory_op = no_memory_op;
-    unsigned insn_data_size = 0;
-    if ((pI->has_memory_read() || pI->has_memory_write())) {
-      if (!((inst_opcode == MMA_LD_OP || inst_opcode == MMA_ST_OP))) {
+   }
+   
+   addr_t insn_memaddr = 0xFEEBDAED;
+   memory_space_t insn_space = undefined_space;
+   _memory_op_t insn_memory_op = no_memory_op;
+   unsigned insn_data_size = 0;
+   if ( (pI->has_memory_read()  || pI->has_memory_write()) ) {
+      if(!((inst_opcode==MMA_LD_OP||inst_opcode==MMA_ST_OP)))
+      {
         insn_memaddr = last_eaddr();
         insn_space = last_space();
         unsigned to_type = pI->get_type();
         insn_data_size = datatype2size(to_type);
         insn_memory_op = pI->has_memory_read() ? memory_load : memory_store;
-      }
-    }
+      }	
+   }
+  
+   if ( pI->get_opcode() == BAR_OP && pI->barrier_op() == RED_OPTION) {
+	   inst.add_callback( lane_id, last_callback().function, last_callback().instruction, this,false /*not atomic*/);
+   }
 
-    if (pI->get_opcode() == BAR_OP && pI->barrier_op() == RED_OPTION) {
-      inst.add_callback(lane_id, last_callback().function,
-                        last_callback().instruction, this,
-                        false /*not atomic*/);
-    }
-
-    if (pI->get_opcode() == ATOM_OP) {
+   if ( pI->get_opcode() == ATOM_OP ) {
       insn_memaddr = last_eaddr();
       insn_space = last_space();
-      inst.add_callback(lane_id, last_callback().function,
-                        last_callback().instruction, this, true /*atomic*/);
+      inst.add_callback( lane_id, last_callback().function, last_callback().instruction, this,true /*atomic*/);
       unsigned to_type = pI->get_type();
       insn_data_size = datatype2size(to_type);
-    }
+   }
 
-    if (pI->get_opcode() == TEX_OP) {
-      inst.set_addr(lane_id, last_eaddr());
-      assert(inst.space == last_space());
-      insn_data_size = get_tex_datasize(
-          pI,
-          this);  // texture obtain its data granularity from the texture info
-    }
+   if (pI->get_opcode() == TEX_OP) {
+      inst.set_addr(lane_id, last_eaddr() );
+      assert( inst.space == last_space() );
+      insn_data_size = get_tex_datasize(pI, this); // texture obtain its data granularity from the texture info 
+   }
 
-    // Output register information to file and stdout
-    if (config.get_ptx_inst_debug_to_file() != 0 &&
-        (config.get_ptx_inst_debug_thread_uid() == 0 ||
-         config.get_ptx_inst_debug_thread_uid() == get_uid())) {
+   // Output register information to file and stdout
+   if( config.get_ptx_inst_debug_to_file()!=0 && 
+       (config.get_ptx_inst_debug_thread_uid()==0||config.get_ptx_inst_debug_thread_uid()==get_uid()) ) {
       dump_modifiedregs(m_gpu->get_ptx_inst_debug_file());
       dump_regs(m_gpu->get_ptx_inst_debug_file());
-    }
+   }
 
-    if (g_debug_execution >= 6) {
-      if (m_gpu->gpgpu_ctx->func_sim->ptx_debug_exec_dump_cond<6>(get_uid(),
-                                                                  pc))
-        dump_modifiedregs(stdout);
-    }
-    if (g_debug_execution >= 10) {
-      if (m_gpu->gpgpu_ctx->func_sim->ptx_debug_exec_dump_cond<10>(get_uid(),
-                                                                   pc))
-        dump_regs(stdout);
-    }
-    update_pc();
-    m_gpu->gpgpu_ctx->func_sim->g_ptx_sim_num_insn++;
-
-    // not using it with functional simulation mode
-    if (!(this->m_functionalSimulationMode))
-      ptx_file_line_stats_add_exec_count(pI);
-
-    if (m_gpu->gpgpu_ctx->func_sim->gpgpu_ptx_instruction_classification) {
+   if ( g_debug_execution >= 6 ) {
+      if ( m_gpu->gpgpu_ctx->func_sim->ptx_debug_exec_dump_cond<6>(get_uid(), pc) )
+         dump_modifiedregs(stdout);
+   }
+   if ( g_debug_execution >= 10 ) {
+      if ( m_gpu->gpgpu_ctx->func_sim->ptx_debug_exec_dump_cond<10>(get_uid(), pc) )
+         dump_regs(stdout);
+   }
+   update_pc();
+   m_gpu->gpgpu_ctx->func_sim->g_ptx_sim_num_insn++;
+   
+   //not using it with functional simulation mode
+   if(!(this->m_functionalSimulationMode))
+       ptx_file_line_stats_add_exec_count(pI);
+   
+   if ( m_gpu->gpgpu_ctx->func_sim->gpgpu_ptx_instruction_classification ) {
       m_gpu->gpgpu_ctx->func_sim->init_inst_classification_stat();
-      unsigned space_type = 0;
-      switch (pI->get_space().get_type()) {
-        case global_space:
-          space_type = 10;
-          break;
-        case local_space:
-          space_type = 11;
-          break;
-        case tex_space:
-          space_type = 12;
-          break;
-        case surf_space:
-          space_type = 13;
-          break;
-        case param_space_kernel:
-        case param_space_local:
-          space_type = 14;
-          break;
-        case shared_space:
-          space_type = 15;
-          break;
-        case const_space:
-          space_type = 16;
-          break;
-        default:
-          space_type = 0;
-          break;
+      unsigned space_type=0;
+      switch ( pI->get_space().get_type() ) {
+      case global_space: space_type = 10; break;
+      case local_space:  space_type = 11; break; 
+      case tex_space:    space_type = 12; break; 
+      case surf_space:   space_type = 13; break; 
+      case param_space_kernel:
+      case param_space_local:
+                         space_type = 14; break; 
+      case shared_space: space_type = 15; break; 
+      case const_space:  space_type = 16; break;
+      default: 
+         space_type = 0 ;
+         break;
       }
-      StatAddSample(m_gpu->gpgpu_ctx->func_sim->g_inst_classification_stat
-                        [m_gpu->gpgpu_ctx->func_sim->g_ptx_kernel_count],
-                    op_classification);
-      if (space_type)
-        StatAddSample(m_gpu->gpgpu_ctx->func_sim->g_inst_classification_stat
-                          [m_gpu->gpgpu_ctx->func_sim->g_ptx_kernel_count],
-                      (int)space_type);
-      StatAddSample(m_gpu->gpgpu_ctx->func_sim->g_inst_op_classification_stat
-                        [m_gpu->gpgpu_ctx->func_sim->g_ptx_kernel_count],
-                    (int)pI->get_opcode());
-    }
-    if ((m_gpu->gpgpu_ctx->func_sim->g_ptx_sim_num_insn % 100000) == 0) {
+      StatAddSample( m_gpu->gpgpu_ctx->func_sim->g_inst_classification_stat[m_gpu->gpgpu_ctx->func_sim->g_ptx_kernel_count],  op_classification);
+      if (space_type) StatAddSample( m_gpu->gpgpu_ctx->func_sim->g_inst_classification_stat[m_gpu->gpgpu_ctx->func_sim->g_ptx_kernel_count], ( int )space_type);
+      StatAddSample( m_gpu->gpgpu_ctx->func_sim->g_inst_op_classification_stat[m_gpu->gpgpu_ctx->func_sim->g_ptx_kernel_count], (int)  pI->get_opcode() );
+   }
+   if ( (m_gpu->gpgpu_ctx->func_sim->g_ptx_sim_num_insn % 100000) == 0 ) {
       dim3 ctaid = get_ctaid();
       dim3 tid = get_tid();
-      DPRINTF(LIVENESS,
-              "GPGPU-Sim PTX: %u instructions simulated : ctaid=(%u,%u,%u) "
-              "tid=(%u,%u,%u)\n",
-              m_gpu->gpgpu_ctx->func_sim->g_ptx_sim_num_insn, ctaid.x, ctaid.y,
-              ctaid.z, tid.x, tid.y, tid.z);
+      DPRINTF(LIVENESS, "GPGPU-Sim PTX: %u instructions simulated : ctaid=(%u,%u,%u) tid=(%u,%u,%u)\n",
+             m_gpu->gpgpu_ctx->func_sim->g_ptx_sim_num_insn, ctaid.x,ctaid.y,ctaid.z,tid.x,tid.y,tid.z );
       fflush(stdout);
-    }
+   }
+   
+   // "Return values"
+   if(!skip) {
+      if(!((inst_opcode==MMA_LD_OP||inst_opcode==MMA_ST_OP)))
+      {
+   	  inst.space = insn_space;
+          inst.set_addr(lane_id, insn_memaddr);
+          inst.data_size = insn_data_size; // simpleAtomicIntrinsics
+          assert( inst.memory_op == insn_memory_op );
+      } 
+   }
+ 
+   } catch ( int x  ) {
+      printf("GPGPU-Sim PTX: ERROR (%d) executing intruction (%s:%u)\n", x, pI->source_file(), pI->source_line() );
+      printf("GPGPU-Sim PTX:       '%s'\n", pI->get_source() );
+      abort();
+   }
+      
+}
 
-    // "Return values"
-    if (!skip) {
-      if (!((inst_opcode == MMA_LD_OP || inst_opcode == MMA_ST_OP))) {
-        inst.space = insn_space;
-        inst.set_addr(lane_id, insn_memaddr);
-        inst.data_size = insn_data_size;  // simpleAtomicIntrinsics
-        assert(inst.memory_op == insn_memory_op);
+void cuda_sim::set_param_gpgpu_num_shaders(int num_shaders)
+{
+   gpgpu_param_num_shaders = num_shaders;
+}
+
+const struct gpgpu_ptx_sim_info* ptx_sim_kernel_info(const function_info *kernel)
+{
+   return kernel->get_kernel_info();
+}
+
+const warp_inst_t *gpgpu_context::ptx_fetch_inst( address_type pc )
+{
+    return pc_to_instruction(pc);
+}
+
+unsigned ptx_sim_init_thread( kernel_info_t &kernel,
+                              ptx_thread_info** thread_info,
+                              int sid,
+                              unsigned tid,
+                              unsigned threads_left,
+                              unsigned num_threads, 
+                              core_t *core, 
+                              unsigned hw_cta_id, 
+                              unsigned hw_warp_id,
+                              gpgpu_t *gpu,
+                              bool isInFunctionalSimulationMode)
+{
+   std::list<ptx_thread_info *> &active_threads = kernel.active_threads();
+
+   static std::map<unsigned,memory_space*> shared_memory_lookup;
+   static std::map<unsigned,memory_space*> sstarr_memory_lookup;
+   static std::map<unsigned,ptx_cta_info*> ptx_cta_lookup;
+   static std::map<unsigned,ptx_warp_info*> ptx_warp_lookup;
+   static std::map<unsigned,std::map<unsigned,memory_space*> > local_memory_lookup;
+
+   if ( *thread_info != NULL ) {
+      ptx_thread_info *thd = *thread_info;
+      assert( thd->is_done() );
+      if ( g_debug_execution==-1 ) {
+         dim3 ctaid = thd->get_ctaid();
+         dim3 t = thd->get_tid();
+         printf("GPGPU-Sim PTX simulator:  thread exiting ctaid=(%u,%u,%u) tid=(%u,%u,%u) uid=%u\n",
+                ctaid.x,ctaid.y,ctaid.z,t.x,t.y,t.z, thd->get_uid() );
+         fflush(stdout);
       }
-    }
+      thd->m_cta_info->register_deleted_thread(thd);
+      delete thd;
+      *thread_info = NULL;
+   }
 
-  } catch (int x) {
-    printf("GPGPU-Sim PTX: ERROR (%d) executing intruction (%s:%u)\n", x,
-           pI->source_file(), pI->source_line());
-    printf("GPGPU-Sim PTX:       '%s'\n", pI->get_source());
-    abort();
-  }
-}
+   if ( !active_threads.empty() ) {
+      assert( active_threads.size() <= threads_left );
+      ptx_thread_info *thd = active_threads.front(); 
+      active_threads.pop_front();
+      *thread_info = thd;
+      thd->init(gpu, core, sid, hw_cta_id, hw_warp_id, tid, isInFunctionalSimulationMode );
+      return 1;
+   }
 
-void cuda_sim::set_param_gpgpu_num_shaders(int num_shaders) {
-  gpgpu_param_num_shaders = num_shaders;
-}
+   if ( kernel.no_more_ctas_to_run() ) {
+      return 0; //finished!
+   }
 
-const struct gpgpu_ptx_sim_info *ptx_sim_kernel_info(
-    const function_info *kernel) {
-  return kernel->get_kernel_info();
-}
+   if ( threads_left < kernel.threads_per_cta() ) {
+      return 0;
+   }
 
-const warp_inst_t *gpgpu_context::ptx_fetch_inst(address_type pc) {
-  return pc_to_instruction(pc);
-}
-
-unsigned ptx_sim_init_thread(kernel_info_t &kernel,
-                             ptx_thread_info **thread_info, int sid,
-                             unsigned tid, unsigned threads_left,
-                             unsigned num_threads, core_t *core,
-                             unsigned hw_cta_id, unsigned hw_warp_id,
-                             gpgpu_t *gpu, bool isInFunctionalSimulationMode) {
-  std::list<ptx_thread_info *> &active_threads = kernel.active_threads();
-
-  static std::map<unsigned, memory_space *> shared_memory_lookup;
-  static std::map<unsigned, memory_space *> sstarr_memory_lookup;
-  static std::map<unsigned, ptx_cta_info *> ptx_cta_lookup;
-  static std::map<unsigned, ptx_warp_info *> ptx_warp_lookup;
-  static std::map<unsigned, std::map<unsigned, memory_space *> >
-      local_memory_lookup;
-
-  if (*thread_info != NULL) {
-    ptx_thread_info *thd = *thread_info;
-    assert(thd->is_done());
-    if (g_debug_execution == -1) {
-      dim3 ctaid = thd->get_ctaid();
-      dim3 t = thd->get_tid();
-      printf(
-          "GPGPU-Sim PTX simulator:  thread exiting ctaid=(%u,%u,%u) "
-          "tid=(%u,%u,%u) uid=%u\n",
-          ctaid.x, ctaid.y, ctaid.z, t.x, t.y, t.z, thd->get_uid());
+   if ( g_debug_execution==-1 ) {
+      printf("GPGPU-Sim PTX simulator:  STARTING THREAD ALLOCATION --> \n");
       fflush(stdout);
-    }
-    thd->m_cta_info->register_deleted_thread(thd);
-    delete thd;
-    *thread_info = NULL;
-  }
+   }
 
-  if (!active_threads.empty()) {
-    assert(active_threads.size() <= threads_left);
-    ptx_thread_info *thd = active_threads.front();
-    active_threads.pop_front();
-    *thread_info = thd;
-    thd->init(gpu, core, sid, hw_cta_id, hw_warp_id, tid,
-              isInFunctionalSimulationMode);
-    return 1;
-  }
+   //initializing new CTA
+   ptx_cta_info *cta_info = NULL;
+   memory_space *shared_mem = NULL;
+   memory_space *sstarr_mem = NULL;
 
-  if (kernel.no_more_ctas_to_run()) {
-    return 0;  // finished!
-  }
+   unsigned cta_size = kernel.threads_per_cta();
+   unsigned max_cta_per_sm = num_threads/cta_size; // e.g., 256 / 48 = 5 
+   assert( max_cta_per_sm > 0 );
 
-  if (threads_left < kernel.threads_per_cta()) {
-    return 0;
-  }
+   //unsigned sm_idx = (tid/cta_size)*gpgpu_param_num_shaders + sid;
+   unsigned sm_idx = hw_cta_id*gpu->gpgpu_ctx->func_sim->gpgpu_param_num_shaders + sid;
 
-  if (g_debug_execution == -1) {
-    printf("GPGPU-Sim PTX simulator:  STARTING THREAD ALLOCATION --> \n");
-    fflush(stdout);
-  }
-
-  // initializing new CTA
-  ptx_cta_info *cta_info = NULL;
-  memory_space *shared_mem = NULL;
-  memory_space *sstarr_mem = NULL;
-
-  unsigned cta_size = kernel.threads_per_cta();
-  unsigned max_cta_per_sm = num_threads / cta_size;  // e.g., 256 / 48 = 5
-  assert(max_cta_per_sm > 0);
-
-  // unsigned sm_idx = (tid/cta_size)*gpgpu_param_num_shaders + sid;
-  unsigned sm_idx =
-      hw_cta_id * gpu->gpgpu_ctx->func_sim->gpgpu_param_num_shaders + sid;
-
-  if (shared_memory_lookup.find(sm_idx) == shared_memory_lookup.end()) {
-    if (g_debug_execution >= 1) {
-      printf("  <CTA alloc> : sm_idx=%u sid=%u max_cta_per_sm=%u\n", sm_idx,
-             sid, max_cta_per_sm);
-    }
-    char buf[512];
-    snprintf(buf, 512, "shared_%u", sid);
-    shared_mem = new memory_space_impl<16 * 1024>(buf, 4);
-    shared_memory_lookup[sm_idx] = shared_mem;
-    snprintf(buf, 512, "sstarr_%u", sid);
-    sstarr_mem = new memory_space_impl<16 * 1024>(buf, 4);
-    sstarr_memory_lookup[sm_idx] = sstarr_mem;
-    cta_info = new ptx_cta_info(sm_idx, gpu->gpgpu_ctx);
-    ptx_cta_lookup[sm_idx] = cta_info;
-  } else {
-    if (g_debug_execution >= 1) {
-      printf("  <CTA realloc> : sm_idx=%u sid=%u max_cta_per_sm=%u\n", sm_idx,
-             sid, max_cta_per_sm);
-    }
-    shared_mem = shared_memory_lookup[sm_idx];
-    sstarr_mem = sstarr_memory_lookup[sm_idx];
-    cta_info = ptx_cta_lookup[sm_idx];
-    cta_info->check_cta_thread_status_and_reset();
-  }
-
-  std::map<unsigned, memory_space *> &local_mem_lookup =
-      local_memory_lookup[sid];
-  while (kernel.more_threads_in_cta()) {
-    dim3 ctaid3d = kernel.get_next_cta_id();
-    unsigned new_tid = kernel.get_next_thread_id();
-    dim3 tid3d = kernel.get_next_thread_id_3d();
-    kernel.increment_thread_id();
-    new_tid += tid;
-    ptx_thread_info *thd = new ptx_thread_info(kernel);
-    ptx_warp_info *warp_info = NULL;
-    if (ptx_warp_lookup.find(hw_warp_id) == ptx_warp_lookup.end()) {
-      warp_info = new ptx_warp_info();
-      ptx_warp_lookup[hw_warp_id] = warp_info;
-    } else {
-      warp_info = ptx_warp_lookup[hw_warp_id];
-    }
-    thd->m_warp_info = warp_info;
-
-    memory_space *local_mem = NULL;
-    std::map<unsigned, memory_space *>::iterator l =
-        local_mem_lookup.find(new_tid);
-    if (l != local_mem_lookup.end()) {
-      local_mem = l->second;
-    } else {
+   if ( shared_memory_lookup.find(sm_idx) == shared_memory_lookup.end() ) {
+      if ( g_debug_execution >= 1 ) {
+         printf("  <CTA alloc> : sm_idx=%u sid=%u max_cta_per_sm=%u\n", 
+                sm_idx, sid, max_cta_per_sm );
+      }
       char buf[512];
-      snprintf(buf, 512, "local_%u_%u", sid, new_tid);
-      local_mem = new memory_space_impl<32>(buf, 32);
-      local_mem_lookup[new_tid] = local_mem;
-    }
-    thd->set_info(kernel.entry());
-    thd->set_nctaid(kernel.get_grid_dim());
-    thd->set_ntid(kernel.get_cta_dim());
-    thd->set_ctaid(ctaid3d);
-    thd->set_tid(tid3d);
-    if (kernel.entry()->get_ptx_version().extensions())
-      thd->cpy_tid_to_reg(tid3d);
-    thd->set_valid();
-    thd->m_shared_mem = shared_mem;
-    thd->m_sstarr_mem = sstarr_mem;
-    function_info *finfo = thd->func_info();
-    symbol_table *st = finfo->get_symtab();
-    thd->func_info()->param_to_shared(thd->m_shared_mem, st);
-    thd->func_info()->param_to_shared(thd->m_sstarr_mem, st);
-    thd->m_cta_info = cta_info;
-    cta_info->add_thread(thd);
-    thd->m_local_mem = local_mem;
-    if (g_debug_execution == -1) {
-      printf(
-          "GPGPU-Sim PTX simulator:  allocating thread ctaid=(%u,%u,%u) "
-          "tid=(%u,%u,%u) @ 0x%Lx\n",
-          ctaid3d.x, ctaid3d.y, ctaid3d.z, tid3d.x, tid3d.y, tid3d.z,
-          (unsigned long long)thd);
+      snprintf(buf,512,"shared_%u", sid);
+      shared_mem = new memory_space_impl<16*1024>(buf,4);
+      shared_memory_lookup[sm_idx] = shared_mem;
+      snprintf(buf,512,"sstarr_%u", sid);
+      sstarr_mem = new memory_space_impl<16*1024>(buf,4);
+      sstarr_memory_lookup[sm_idx] = sstarr_mem;
+      cta_info = new ptx_cta_info(sm_idx, gpu->gpgpu_ctx);
+      ptx_cta_lookup[sm_idx] = cta_info;
+   } else {
+      if ( g_debug_execution >= 1 ) {
+         printf("  <CTA realloc> : sm_idx=%u sid=%u max_cta_per_sm=%u\n", 
+                sm_idx, sid, max_cta_per_sm );
+      }
+      shared_mem = shared_memory_lookup[sm_idx];
+      sstarr_mem = sstarr_memory_lookup[sm_idx];
+      cta_info = ptx_cta_lookup[sm_idx];
+      cta_info->check_cta_thread_status_and_reset();
+   }
+
+   std::map<unsigned,memory_space*> &local_mem_lookup = local_memory_lookup[sid];
+   while( kernel.more_threads_in_cta() ) {
+      dim3 ctaid3d = kernel.get_next_cta_id();
+      unsigned new_tid = kernel.get_next_thread_id();
+      dim3 tid3d = kernel.get_next_thread_id_3d();
+      kernel.increment_thread_id();
+      new_tid += tid;
+      ptx_thread_info *thd = new ptx_thread_info(kernel);
+      ptx_warp_info *warp_info = NULL;
+      if ( ptx_warp_lookup.find(hw_warp_id) == ptx_warp_lookup.end() ) {
+    	  warp_info = new ptx_warp_info();
+    	  ptx_warp_lookup[hw_warp_id] = warp_info;
+      } else {
+    	  warp_info = ptx_warp_lookup[hw_warp_id];
+      }
+      thd->m_warp_info = warp_info;
+
+      memory_space *local_mem = NULL;
+      std::map<unsigned,memory_space*>::iterator l = local_mem_lookup.find(new_tid);
+      if ( l != local_mem_lookup.end() ) {
+         local_mem = l->second;
+      } else {
+         char buf[512];
+         snprintf(buf,512,"local_%u_%u", sid, new_tid);
+         local_mem = new memory_space_impl<32>(buf,32);
+         local_mem_lookup[new_tid] = local_mem;
+      }
+      thd->set_info(kernel.entry());
+      thd->set_nctaid(kernel.get_grid_dim());
+      thd->set_ntid(kernel.get_cta_dim());
+      thd->set_ctaid(ctaid3d);
+      thd->set_tid(tid3d);
+      if( kernel.entry()->get_ptx_version().extensions() ) 
+         thd->cpy_tid_to_reg(tid3d);
+      thd->set_valid();
+      thd->m_shared_mem = shared_mem;
+      thd->m_sstarr_mem = sstarr_mem;
+      function_info *finfo = thd->func_info();
+      symbol_table *st = finfo->get_symtab();
+      thd->func_info()->param_to_shared(thd->m_shared_mem,st);
+      thd->func_info()->param_to_shared(thd->m_sstarr_mem,st);
+      thd->m_cta_info = cta_info;
+      cta_info->add_thread(thd);
+      thd->m_local_mem = local_mem;
+      if ( g_debug_execution==-1 ) {
+         printf("GPGPU-Sim PTX simulator:  allocating thread ctaid=(%u,%u,%u) tid=(%u,%u,%u) @ 0x%Lx\n",
+                ctaid3d.x,ctaid3d.y,ctaid3d.z,tid3d.x,tid3d.y,tid3d.z, (unsigned long long)thd );
+         fflush(stdout);
+      }
+      active_threads.push_back(thd);
+   }
+   if ( g_debug_execution==-1 ) {
+      printf("GPGPU-Sim PTX simulator:  <-- FINISHING THREAD ALLOCATION\n");
       fflush(stdout);
-    }
-    active_threads.push_back(thd);
-  }
-  if (g_debug_execution == -1) {
-    printf("GPGPU-Sim PTX simulator:  <-- FINISHING THREAD ALLOCATION\n");
-    fflush(stdout);
-  }
+   }
 
-  kernel.increment_cta_id();
+   kernel.increment_cta_id();
 
-  assert(active_threads.size() <= threads_left);
-  *thread_info = active_threads.front();
-  (*thread_info)
-      ->init(gpu, core, sid, hw_cta_id, hw_warp_id, tid,
-             isInFunctionalSimulationMode);
-  active_threads.pop_front();
-  return 1;
+   assert( active_threads.size() <= threads_left );
+   *thread_info = active_threads.front();
+   (*thread_info)->init(gpu, core, sid, hw_cta_id, hw_warp_id, tid,isInFunctionalSimulationMode );
+   active_threads.pop_front();
+   return 1;
 }
 
-size_t get_kernel_code_size(class function_info *entry) {
-  return entry->get_function_size();
+size_t get_kernel_code_size( class function_info *entry )
+{
+   return entry->get_function_size();
 }
 
-kernel_info_t *cuda_sim::gpgpu_opencl_ptx_sim_init_grid(
-    class function_info *entry, gpgpu_ptx_sim_arg_list_t args,
-    struct dim3 gridDim, struct dim3 blockDim, gpgpu_t *gpu) {
-  kernel_info_t *result =
-      new kernel_info_t(gridDim, blockDim, entry, gpu->getNameArrayMapping(),
-                        gpu->getNameInfoMapping());
-  unsigned argcount = args.size();
-  unsigned argn = 1;
-  for (gpgpu_ptx_sim_arg_list_t::iterator a = args.begin(); a != args.end();
-       a++) {
-    entry->add_param_data(argcount - argn, &(*a));
-    argn++;
-  }
-  entry->finalize(result->get_param_memory());
-  g_ptx_kernel_count++;
-  fflush(stdout);
 
-  return result;
+kernel_info_t *cuda_sim::gpgpu_opencl_ptx_sim_init_grid(class function_info *entry,
+                                             gpgpu_ptx_sim_arg_list_t args, 
+                                             struct dim3 gridDim,
+                                             struct dim3 blockDim,
+                                             gpgpu_t *gpu )
+{
+   kernel_info_t *result = new kernel_info_t(gridDim,blockDim,entry,gpu->getNameArrayMapping(),gpu->getNameInfoMapping());
+   unsigned argcount=args.size();
+   unsigned argn=1;
+   for( gpgpu_ptx_sim_arg_list_t::iterator a = args.begin(); a != args.end(); a++ ) {
+      entry->add_param_data(argcount-argn,&(*a));
+      argn++;
+   }
+   entry->finalize(result->get_param_memory());
+   g_ptx_kernel_count++; 
+   fflush(stdout);
+
+   return result;
 }
 
 #include "../../version"
 #include "detailed_version"
 
-void print_splash() {
-  static int splash_printed = 0;
-  if (!splash_printed) {
-    fprintf(stdout, "\n\n        *** %s [build %s] ***\n\n\n",
-            g_gpgpusim_version_string, g_gpgpusim_build_string);
-    splash_printed = 1;
-  }
+void print_splash()
+{
+   static int splash_printed=0;
+   if ( !splash_printed ) {
+      fprintf(stdout, "\n\n        *** %s [build %s] ***\n\n\n", g_gpgpusim_version_string, g_gpgpusim_build_string );
+      splash_printed=1;
+   }
 }
 
-void cuda_sim::gpgpu_ptx_sim_register_const_variable(void *hostVar,
-                                                     const char *deviceName,
-                                                     size_t size) {
-  printf("GPGPU-Sim PTX registering constant %s (%zu bytes) to name mapping\n",
-         deviceName, size);
-  g_const_name_lookup[hostVar] = deviceName;
+void cuda_sim::gpgpu_ptx_sim_register_const_variable(void *hostVar, const char *deviceName, size_t size )
+{
+   printf("GPGPU-Sim PTX registering constant %s (%zu bytes) to name mapping\n", deviceName, size );
+   g_const_name_lookup[hostVar] = deviceName;
 }
 
-void cuda_sim::gpgpu_ptx_sim_register_global_variable(void *hostVar,
-                                                      const char *deviceName,
-                                                      size_t size) {
-  printf("GPGPU-Sim PTX registering global %s hostVar to name mapping\n",
-         deviceName);
-  g_global_name_lookup[hostVar] = deviceName;
+void cuda_sim::gpgpu_ptx_sim_register_global_variable(void *hostVar, const char *deviceName, size_t size )
+{
+   printf("GPGPU-Sim PTX registering global %s hostVar to name mapping\n", deviceName );
+   g_global_name_lookup[hostVar] = deviceName;
 }
 
-void cuda_sim::gpgpu_ptx_sim_memcpy_symbol(const char *hostVar, const void *src,
-                                           size_t count, size_t offset, int to,
-                                           gpgpu_t *gpu) {
-  printf(
-      "GPGPU-Sim PTX: starting gpgpu_ptx_sim_memcpy_symbol with hostVar 0x%p\n",
-      hostVar);
-  bool found_sym = false;
-  memory_space_t mem_region = undefined_space;
-  std::string sym_name;
+void cuda_sim::gpgpu_ptx_sim_memcpy_symbol(const char *hostVar, const void *src, size_t count, size_t offset, int to, gpgpu_t *gpu )
+{
+   printf("GPGPU-Sim PTX: starting gpgpu_ptx_sim_memcpy_symbol with hostVar 0x%p\n", hostVar);
+   bool found_sym = false;
+   memory_space_t mem_region = undefined_space;
+   std::string sym_name;
 
-  std::map<const void *, std::string>::iterator c =
-      gpu->gpgpu_ctx->func_sim->g_const_name_lookup.find(hostVar);
-  if (c != gpu->gpgpu_ctx->func_sim->g_const_name_lookup.end()) {
-    found_sym = true;
-    sym_name = c->second;
-    mem_region = const_space;
-  }
-  std::map<const void *, std::string>::iterator g =
-      gpu->gpgpu_ctx->func_sim->g_global_name_lookup.find(hostVar);
-  if (g != gpu->gpgpu_ctx->func_sim->g_global_name_lookup.end()) {
-    if (found_sym) {
-      printf(
-          "Execution error: PTX symbol \"%s\" w/ hostVar=0x%Lx is declared "
-          "both const and global?\n",
-          sym_name.c_str(), (unsigned long long)hostVar);
+   std::map<const void*,std::string>::iterator c=gpu->gpgpu_ctx->func_sim->g_const_name_lookup.find(hostVar);
+   if ( c!=gpu->gpgpu_ctx->func_sim->g_const_name_lookup.end() ) {
+      found_sym = true;
+      sym_name = c->second;
+      mem_region = const_space;
+   }
+   std::map<const void*,std::string>::iterator g=gpu->gpgpu_ctx->func_sim->g_global_name_lookup.find(hostVar);
+   if ( g!=gpu->gpgpu_ctx->func_sim->g_global_name_lookup.end() ) {
+      if ( found_sym ) {
+         printf("Execution error: PTX symbol \"%s\" w/ hostVar=0x%Lx is declared both const and global?\n", 
+                sym_name.c_str(), (unsigned long long)hostVar );
+         abort();
+      }
+      found_sym = true;
+      sym_name = g->second;
+      mem_region = global_space;
+   }
+   if( g_globals.find(hostVar) != g_globals.end() ) {
+      found_sym = true;
+      sym_name = hostVar;
+      mem_region = global_space;
+   }
+   if( g_constants.find(hostVar) != g_constants.end() ) {
+      found_sym = true;
+      sym_name = hostVar;
+      mem_region = const_space;
+   }
+
+   if ( !found_sym ) {
+      printf("Execution error: No information for PTX symbol w/ hostVar=0x%Lx\n", (unsigned long long)hostVar );
       abort();
-    }
-    found_sym = true;
-    sym_name = g->second;
-    mem_region = global_space;
-  }
-  if (g_globals.find(hostVar) != g_globals.end()) {
-    found_sym = true;
-    sym_name = hostVar;
-    mem_region = global_space;
-  }
-  if (g_constants.find(hostVar) != g_constants.end()) {
-    found_sym = true;
-    sym_name = hostVar;
-    mem_region = const_space;
-  }
+   } else printf("GPGPU-Sim PTX: gpgpu_ptx_sim_memcpy_symbol: Found PTX symbol w/ hostVar=0x%Lx\n", (unsigned long long)hostVar ); 
+   const char *mem_name = NULL;
+   memory_space *mem = NULL;
 
-  if (!found_sym) {
-    printf("Execution error: No information for PTX symbol w/ hostVar=0x%Lx\n",
-           (unsigned long long)hostVar);
-    abort();
-  } else
-    printf(
-        "GPGPU-Sim PTX: gpgpu_ptx_sim_memcpy_symbol: Found PTX symbol w/ "
-        "hostVar=0x%Lx\n",
-        (unsigned long long)hostVar);
-  const char *mem_name = NULL;
-  memory_space *mem = NULL;
+   std::map<std::string,symbol_table*>::iterator st = gpgpu_ctx->ptx_parser->g_sym_name_to_symbol_table.find(sym_name.c_str());
+   assert( st != gpgpu_ctx->ptx_parser->g_sym_name_to_symbol_table.end() );
+   symbol_table *symtab = st->second;
 
-  std::map<std::string, symbol_table *>::iterator st =
-      gpgpu_ctx->ptx_parser->g_sym_name_to_symbol_table.find(sym_name.c_str());
-  assert(st != gpgpu_ctx->ptx_parser->g_sym_name_to_symbol_table.end());
-  symbol_table *symtab = st->second;
-
-  symbol *sym = symtab->lookup(sym_name.c_str());
-  assert(sym);
-  unsigned dst = sym->get_address() + offset;
-  switch (mem_region.get_type()) {
-    case const_space:
+   symbol *sym = symtab->lookup(sym_name.c_str());
+   assert(sym);
+   unsigned dst = sym->get_address() + offset; 
+   switch (mem_region.get_type()) {
+   case const_space:
       mem = gpu->get_global_memory();
       mem_name = "const";
       break;
-    case global_space:
+   case global_space:
       mem = gpu->get_global_memory();
       mem_name = "global";
       break;
-    default:
+   default:
       abort();
-  }
-  printf(
-      "GPGPU-Sim PTX: gpgpu_ptx_sim_memcpy_symbol: copying %s memory %zu bytes "
-      "%s symbol %s+%zu @0x%x ...\n",
-      mem_name, count, (to ? " to " : "from"), sym_name.c_str(), offset, dst);
-  for (unsigned n = 0; n < count; n++) {
-    if (to)
-      mem->write(dst + n, 1, ((char *)src) + n, NULL, NULL);
-    else
-      mem->read(dst + n, 1, ((char *)src) + n);
-  }
-  fflush(stdout);
+   }
+   printf("GPGPU-Sim PTX: gpgpu_ptx_sim_memcpy_symbol: copying %s memory %zu bytes %s symbol %s+%zu @0x%x ...\n", 
+          mem_name, count, (to?" to ":"from"), sym_name.c_str(), offset, dst );
+   for ( unsigned n=0; n < count; n++ ) {
+      if( to ) mem->write(dst+n,1,((char*)src)+n,NULL,NULL); 
+      else mem->read(dst+n,1,((char*)src)+n); 
+   }
+   fflush(stdout);
 }
 
 extern int ptx_debug;
 
-void cuda_sim::read_sim_environment_variables() {
-  ptx_debug = 0;
-  g_debug_execution = 0;
-  g_interactive_debugger_enabled = false;
+void cuda_sim::read_sim_environment_variables()
+{
+   ptx_debug = 0;
+   g_debug_execution = 0;
+   g_interactive_debugger_enabled = false;
 
-  char *mode = getenv("PTX_SIM_MODE_FUNC");
-  if (mode) sscanf(mode, "%u", &g_ptx_sim_mode);
-  printf(
-      "GPGPU-Sim PTX: simulation mode %d (can change with PTX_SIM_MODE_FUNC "
-      "environment variable:\n",
-      g_ptx_sim_mode);
-  printf(
-      "               1=functional simulation only, 0=detailed performance "
-      "simulator)\n");
-  char *dbg_inter = getenv("GPGPUSIM_DEBUG");
-  if (dbg_inter && strlen(dbg_inter)) {
-    printf("GPGPU-Sim PTX: enabling interactive debugger\n");
-    fflush(stdout);
-    g_interactive_debugger_enabled = true;
-  }
-  char *dbg_level = getenv("PTX_SIM_DEBUG");
-  if (dbg_level && strlen(dbg_level)) {
-    printf("GPGPU-Sim PTX: setting debug level to %s\n", dbg_level);
-    fflush(stdout);
-    sscanf(dbg_level, "%d", &g_debug_execution);
-  }
-  char *dbg_thread = getenv("PTX_SIM_DEBUG_THREAD_UID");
-  if (dbg_thread && strlen(dbg_thread)) {
-    printf("GPGPU-Sim PTX: printing debug information for thread uid %s\n",
-           dbg_thread);
-    fflush(stdout);
-    sscanf(dbg_thread, "%d", &g_debug_thread_uid);
-  }
-  char *dbg_pc = getenv("PTX_SIM_DEBUG_PC");
-  if (dbg_pc && strlen(dbg_pc)) {
-    printf(
-        "GPGPU-Sim PTX: printing debug information for instruction with PC = "
-        "%s\n",
-        dbg_pc);
-    fflush(stdout);
-    sscanf(dbg_pc, "%d", &g_debug_pc);
-  }
+   char *mode = getenv("PTX_SIM_MODE_FUNC");
+   if ( mode )
+      sscanf(mode,"%u", &g_ptx_sim_mode);
+   printf("GPGPU-Sim PTX: simulation mode %d (can change with PTX_SIM_MODE_FUNC environment variable:\n", g_ptx_sim_mode);
+   printf("               1=functional simulation only, 0=detailed performance simulator)\n");
+   char *dbg_inter = getenv("GPGPUSIM_DEBUG");
+   if ( dbg_inter && strlen(dbg_inter) ) {
+      printf("GPGPU-Sim PTX: enabling interactive debugger\n");
+      fflush(stdout);
+      g_interactive_debugger_enabled = true;
+   }
+   char *dbg_level = getenv("PTX_SIM_DEBUG");
+   if ( dbg_level && strlen(dbg_level) ) {
+      printf("GPGPU-Sim PTX: setting debug level to %s\n", dbg_level );
+      fflush(stdout);
+      sscanf(dbg_level,"%d", &g_debug_execution);
+   }
+   char *dbg_thread = getenv("PTX_SIM_DEBUG_THREAD_UID");
+   if ( dbg_thread && strlen(dbg_thread) ) {
+      printf("GPGPU-Sim PTX: printing debug information for thread uid %s\n", dbg_thread );
+      fflush(stdout);
+      sscanf(dbg_thread,"%d", &g_debug_thread_uid);
+   }
+   char *dbg_pc = getenv("PTX_SIM_DEBUG_PC");
+   if ( dbg_pc && strlen(dbg_pc) ) {
+      printf("GPGPU-Sim PTX: printing debug information for instruction with PC = %s\n", dbg_pc );
+      fflush(stdout);
+      sscanf(dbg_pc,"%d", &g_debug_pc);
+   }
 
 #if CUDART_VERSION > 1010
-  g_override_embedded_ptx = false;
-  char *usefile = getenv("PTX_SIM_USE_PTX_FILE");
-  if (usefile && strlen(usefile)) {
-    printf(
-        "GPGPU-Sim PTX: overriding embedded ptx with ptx file "
-        "(PTX_SIM_USE_PTX_FILE is set)\n");
-    fflush(stdout);
-    g_override_embedded_ptx = true;
-  }
-  char *blocking = getenv("CUDA_LAUNCH_BLOCKING");
-  if (blocking && !strcmp(blocking, "1")) {
-    g_cuda_launch_blocking = true;
-  }
+    g_override_embedded_ptx = false;
+    char *usefile = getenv("PTX_SIM_USE_PTX_FILE");
+    if (usefile && strlen(usefile)) {
+        printf("GPGPU-Sim PTX: overriding embedded ptx with ptx file (PTX_SIM_USE_PTX_FILE is set)\n");
+        fflush(stdout);
+        g_override_embedded_ptx = true;
+    }
+    char *blocking = getenv("CUDA_LAUNCH_BLOCKING");
+    if( blocking && !strcmp(blocking,"1") ) {
+        g_cuda_launch_blocking = true;
+    }
 #else
-  g_cuda_launch_blocking = true;
-  g_override_embedded_ptx = true;
+   g_cuda_launch_blocking = true;
+   g_override_embedded_ptx = true;
 #endif
 
-  if (g_debug_execution >= 40) {
-    ptx_debug = 1;
-  }
+   if ( g_debug_execution >= 40 ) {
+      ptx_debug = 1;
+   }
 }
 
-#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#define MAX(a,b) (((a)>(b))?(a):(b))
 
-unsigned max_cta(const struct gpgpu_ptx_sim_info *kernel_info,
-                 unsigned threads_per_cta, unsigned int warp_size,
-                 unsigned int n_thread_per_shader,
-                 unsigned int gpgpu_shmem_size,
-                 unsigned int gpgpu_shader_registers,
-                 unsigned int max_cta_per_core) {
-  unsigned int padded_cta_size = threads_per_cta;
-  if (padded_cta_size % warp_size)
-    padded_cta_size = ((padded_cta_size / warp_size) + 1) * (warp_size);
-  unsigned int result_thread = n_thread_per_shader / padded_cta_size;
+unsigned max_cta (const struct gpgpu_ptx_sim_info *kernel_info, unsigned threads_per_cta, unsigned int warp_size, unsigned int n_thread_per_shader, unsigned int gpgpu_shmem_size, unsigned int gpgpu_shader_registers, unsigned int max_cta_per_core)
+{
+   
+    unsigned int padded_cta_size = threads_per_cta;
+    if (padded_cta_size%warp_size) 
+        padded_cta_size = ((padded_cta_size/warp_size)+1)*(warp_size);
+     unsigned int result_thread = n_thread_per_shader / padded_cta_size;
 
-  unsigned int result_shmem = (unsigned)-1;
-  if (kernel_info->smem > 0)
-    result_shmem = gpgpu_shmem_size / kernel_info->smem;
-  unsigned int result_regs = (unsigned)-1;
-  if (kernel_info->regs > 0)
-    result_regs = gpgpu_shader_registers /
-                  (padded_cta_size * ((kernel_info->regs + 3) & ~3));
-  printf("padded cta size is %d and %d and %d", padded_cta_size,
-         kernel_info->regs, ((kernel_info->regs + 3) & ~3));
-  // Limit by CTA
-  unsigned int result_cta = max_cta_per_core;
+     unsigned int result_shmem = (unsigned)-1;
+     if (kernel_info->smem > 0)
+        result_shmem = gpgpu_shmem_size / kernel_info->smem;
+     unsigned int result_regs = (unsigned)-1;
+     if (kernel_info->regs > 0)
+        result_regs = gpgpu_shader_registers / (padded_cta_size * ((kernel_info->regs+3)&~3));
+     printf("padded cta size is %d and %d and %d",padded_cta_size, kernel_info->regs, ((kernel_info->regs+3)&~3) );
+     //Limit by CTA
+     unsigned int result_cta = max_cta_per_core;
 
-  unsigned result = result_thread;
-  result = gs_min2(result, result_shmem);
-  result = gs_min2(result, result_regs);
-  result = gs_min2(result, result_cta);
+     unsigned result = result_thread;
+     result = gs_min2(result, result_shmem);
+     result = gs_min2(result, result_regs);
+     result = gs_min2(result, result_cta);
 
-  printf("GPGPU-Sim uArch: CTA/core = %u, limited by:", result);
-  if (result == result_thread) printf(" threads");
-  if (result == result_shmem) printf(" shmem");
-  if (result == result_regs) printf(" regs");
-  if (result == result_cta) printf(" cta_limit");
-  printf("\n");
+     printf ("GPGPU-Sim uArch: CTA/core = %u, limited by:", result);
+     if (result == result_thread) printf (" threads");
+     if (result == result_shmem) printf (" shmem");
+     if (result == result_regs) printf (" regs");
+     if (result == result_cta) printf (" cta_limit");
+     printf ("\n");
 
-  return result;
+     return result;
 }
 /*!
-This function simulates the CUDA code functionally, it takes a kernel_info_t
-parameter
+This function simulates the CUDA code functionally, it takes a kernel_info_t parameter 
 which holds the data for the CUDA kernel to be executed
 !*/
-void cuda_sim::gpgpu_cuda_ptx_sim_main_func(kernel_info_t &kernel,
-                                            bool openCL) {
-  printf(
-      "GPGPU-Sim: Performing Functional Simulation, executing kernel %s...\n",
-      kernel.name().c_str());
+void cuda_sim::gpgpu_cuda_ptx_sim_main_func( kernel_info_t &kernel, bool openCL )
+{
+     printf("GPGPU-Sim: Performing Functional Simulation, executing kernel %s...\n",kernel.name().c_str());
 
-  // using a shader core object for book keeping, it is not needed but as most
-  // function built for performance simulation need it we use it here
-  // extern gpgpu_sim *g_the_gpu;
-  // before we execute, we should do PDOM analysis for functional simulation
-  // scenario.
-  function_info *kernel_func_info = kernel.entry();
-  const struct gpgpu_ptx_sim_info *kernel_info =
-      ptx_sim_kernel_info(kernel_func_info);
-  checkpoint *g_checkpoint;
-  g_checkpoint = new checkpoint();
+     //using a shader core object for book keeping, it is not needed but as most function built for performance simulation need it we use it here
+    //extern gpgpu_sim *g_the_gpu;
+    //before we execute, we should do PDOM analysis for functional simulation scenario.
+    function_info *kernel_func_info = kernel.entry();
+    const struct gpgpu_ptx_sim_info *kernel_info = ptx_sim_kernel_info(kernel_func_info);
+    checkpoint *g_checkpoint;
+    g_checkpoint = new checkpoint();
 
-  if (kernel_func_info->is_pdom_set()) {
-    printf("GPGPU-Sim PTX: PDOM analysis already done for %s \n",
-           kernel.name().c_str());
-  } else {
-    printf("GPGPU-Sim PTX: finding reconvergence points for \'%s\'...\n",
-           kernel.name().c_str());
-    kernel_func_info->do_pdom();
-    kernel_func_info->set_pdom();
-  }
-
-  unsigned max_cta_tot = max_cta(
-      kernel_info, kernel.threads_per_cta(),
-      gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()->warp_size,
-      gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()
-          ->n_thread_per_shader,
-      gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()
-          ->gpgpu_shmem_size,
-      gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()
-          ->gpgpu_shader_registers,
-      gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()
-          ->max_cta_per_core);
-  printf("Max CTA : %d\n", max_cta_tot);
-
-  int cp_op = gpgpu_ctx->the_gpgpusim->g_the_gpu->checkpoint_option;
-  int cp_kernel = gpgpu_ctx->the_gpgpusim->g_the_gpu->checkpoint_kernel;
-  cp_count = gpgpu_ctx->the_gpgpusim->g_the_gpu->checkpoint_insn_Y;
-  cp_cta_resume = gpgpu_ctx->the_gpgpusim->g_the_gpu->checkpoint_CTA_t;
-  int cta_launched = 0;
-
-  // we excute the kernel one CTA (Block) at the time, as synchronization
-  // functions work block wise
-  while (!kernel.no_more_ctas_to_run()) {
-    unsigned temp = kernel.get_next_cta_id_single();
-
-    if (cp_op == 0 || (cp_op == 1 && cta_launched < cp_cta_resume &&
-                       kernel.get_uid() == cp_kernel) ||
-        kernel.get_uid() < cp_kernel)  // just fro testing
-    {
-      functionalCoreSim cta(
-          &kernel, gpgpu_ctx->the_gpgpusim->g_the_gpu,
-          gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()->warp_size);
-      cta.execute(cp_count, temp);
-
-#if (CUDART_VERSION >= 5000)
-      gpgpu_ctx->device_runtime->launch_all_device_kernels();
-#endif
+    if (kernel_func_info->is_pdom_set()) {
+    	printf("GPGPU-Sim PTX: PDOM analysis already done for %s \n", kernel.name().c_str() );
     } else {
-      kernel.increment_cta_id();
+	 printf("GPGPU-Sim PTX: finding reconvergence points for \'%s\'...\n", kernel.name().c_str() );
+	 kernel_func_info->do_pdom();
+	 kernel_func_info->set_pdom();
     }
+
+    unsigned max_cta_tot = max_cta(kernel_info,kernel.threads_per_cta(), gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()->warp_size, gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()->n_thread_per_shader, gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()->gpgpu_shmem_size, gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()->gpgpu_shader_registers, gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()->max_cta_per_core);
+    printf("Max CTA : %d\n",max_cta_tot);
+
+    int cp_op= gpgpu_ctx->the_gpgpusim->g_the_gpu->checkpoint_option;
+    int cp_kernel= gpgpu_ctx->the_gpgpusim->g_the_gpu->checkpoint_kernel;
+    cp_count= gpgpu_ctx->the_gpgpusim->g_the_gpu->checkpoint_insn_Y;
+    cp_cta_resume= gpgpu_ctx->the_gpgpusim->g_the_gpu->checkpoint_CTA_t;
+    int cta_launched =0;
+
+    //we excute the kernel one CTA (Block) at the time, as synchronization functions work block wise
+    while(!kernel.no_more_ctas_to_run()){
+        unsigned temp=kernel.get_next_cta_id_single();
+        
+
+        if(cp_op==0 || (cp_op==1 && cta_launched<cp_cta_resume && kernel.get_uid()==cp_kernel) || kernel.get_uid()< cp_kernel) // just fro testing
+        {
+           functionalCoreSim cta(
+               &kernel,
+               gpgpu_ctx->the_gpgpusim->g_the_gpu,
+               gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()->warp_size
+           );
+           cta.execute(cp_count,temp);
+
+            #if (CUDART_VERSION >= 5000)
+               gpgpu_ctx->device_runtime->launch_all_device_kernels();
+            #endif
+         }
+         else
+         {
+            kernel.increment_cta_id();
+         }
     cta_launched++;
-  }
-
-  if (cp_op == 1) {
-    char f1name[2048];
-    snprintf(f1name, 2048, "checkpoint_files/global_mem_%d.txt",
-             kernel.get_uid());
-    g_checkpoint->store_global_mem(
-        gpgpu_ctx->the_gpgpusim->g_the_gpu->get_global_memory(), f1name,
-        (char *)"%08x");
-  }
-
-  // registering this kernel as done
-
-  // openCL kernel simulation calls don't register the kernel so we don't
-  // register its exit
-  if (!openCL) {
-    // extern stream_manager *g_stream_manager;
-    gpgpu_ctx->the_gpgpusim->g_stream_manager->register_finished_kernel(
-        kernel.get_uid());
-  }
-
-  //******PRINTING*******
-  printf("GPGPU-Sim: Done functional simulation (%u instructions simulated).\n",
-         g_ptx_sim_num_insn);
-  if (gpgpu_ptx_instruction_classification) {
-    StatDisp(g_inst_classification_stat[g_ptx_kernel_count]);
-    StatDisp(g_inst_op_classification_stat[g_ptx_kernel_count]);
-  }
-
-  // time_t variables used to calculate the total simulation time
-  // the start time of simulation is hold by the global variable
-  // g_simulation_starttime
-  // g_simulation_starttime is initilized by gpgpu_ptx_sim_init_perf() in
-  // gpgpusim_entrypoint.cc upon starting gpgpu-sim
-  time_t end_time, elapsed_time, days, hrs, minutes, sec;
-  end_time = time((time_t *)NULL);
-  elapsed_time =
-      MAX(end_time - gpgpu_ctx->the_gpgpusim->g_simulation_starttime, 1);
-
-  // calculating and printing simulation time in terms of days, hours, minutes
-  // and seconds
-  days = elapsed_time / (3600 * 24);
-  hrs = elapsed_time / 3600 - 24 * days;
-  minutes = elapsed_time / 60 - 60 * (hrs + 24 * days);
-  sec = elapsed_time - 60 * (minutes + 60 * (hrs + 24 * days));
-
-  fflush(stderr);
-  printf(
-      "\n\ngpgpu_simulation_time = %u days, %u hrs, %u min, %u sec (%u sec)\n",
-      (unsigned)days, (unsigned)hrs, (unsigned)minutes, (unsigned)sec,
-      (unsigned)elapsed_time);
-  printf("gpgpu_simulation_rate = %u (inst/sec)\n",
-         (unsigned)(g_ptx_sim_num_insn / elapsed_time));
-  fflush(stdout);
-}
-
-void functionalCoreSim::initializeCTA(unsigned ctaid_cp) {
-  int ctaLiveThreads = 0;
-  symbol_table *symtab = m_kernel->entry()->get_symtab();
-
-  for (int i = 0; i < m_warp_count; i++) {
-    m_warpAtBarrier[i] = false;
-    m_liveThreadCount[i] = 0;
-  }
-  for (int i = 0; i < m_warp_count * m_warp_size; i++) m_thread[i] = NULL;
-
-  // get threads for a cta
-  for (unsigned i = 0; i < m_kernel->threads_per_cta(); i++) {
-    ptx_sim_init_thread(*m_kernel, &m_thread[i], 0, i,
-                        m_kernel->threads_per_cta() - i,
-                        m_kernel->threads_per_cta(), this, 0, i / m_warp_size,
-                        (gpgpu_t *)m_gpu, true);
-    assert(m_thread[i] != NULL && !m_thread[i]->is_done());
-    char fname[2048];
-    snprintf(fname, 2048, "checkpoint_files/thread_%d_0_reg.txt", i);
-    if (m_gpu->gpgpu_ctx->func_sim->cp_cta_resume == 1)
-      m_thread[i]->resume_reg_thread(fname, symtab);
-    ctaLiveThreads++;
-  }
-
-  for (int k = 0; k < m_warp_count; k++) createWarp(k);
-}
-
-void functionalCoreSim::createWarp(unsigned warpId) {
-  simt_mask_t initialMask;
-  unsigned liveThreadsCount = 0;
-  initialMask.set();
-  for (int i = warpId * m_warp_size; i < warpId * m_warp_size + m_warp_size;
-       i++) {
-    if (m_thread[i] == NULL)
-      initialMask.reset(i - warpId * m_warp_size);
-    else
-      liveThreadsCount++;
-  }
-
-  assert(m_thread[warpId * m_warp_size] != NULL);
-  m_simt_stack[warpId]->launch(m_thread[warpId * m_warp_size]->get_pc(),
-                               initialMask);
-  char fname[2048];
-  snprintf(fname, 2048, "checkpoint_files/warp_%d_0_simt.txt", warpId);
-
-  if (m_gpu->gpgpu_ctx->func_sim->cp_cta_resume == 1) {
-    unsigned pc, rpc;
-    m_simt_stack[warpId]->resume(fname);
-    m_simt_stack[warpId]->get_pdom_stack_top_info(&pc, &rpc);
-    for (int i = warpId * m_warp_size; i < warpId * m_warp_size + m_warp_size;
-         i++) {
-      m_thread[i]->set_npc(pc);
-      m_thread[i]->update_pc();
-    }
-  }
-  m_liveThreadCount[warpId] = liveThreadsCount;
-}
-
-void functionalCoreSim::execute(int inst_count, unsigned ctaid_cp) {
-  m_gpu->gpgpu_ctx->func_sim->cp_count = m_gpu->checkpoint_insn_Y;
-  m_gpu->gpgpu_ctx->func_sim->cp_cta_resume = m_gpu->checkpoint_CTA_t;
-  initializeCTA(ctaid_cp);
-
-  int count = 0;
-  while (true) {
-    bool someOneLive = false;
-    bool allAtBarrier = true;
-    for (unsigned i = 0; i < m_warp_count; i++) {
-      executeWarp(i, allAtBarrier, someOneLive);
-      count++;
     }
 
-    if (inst_count > 0 && count > inst_count &&
-        (m_kernel->get_uid() == m_gpu->checkpoint_kernel) &&
-        (ctaid_cp >= m_gpu->checkpoint_CTA) &&
-        (ctaid_cp < m_gpu->checkpoint_CTA_t) && m_gpu->checkpoint_option == 1) {
-      someOneLive = false;
-      break;
-    }
-    if (!someOneLive) break;
-    if (allAtBarrier) {
-      for (unsigned i = 0; i < m_warp_count; i++) m_warpAtBarrier[i] = false;
-    }
-  }
-
-  checkpoint *g_checkpoint;
-  g_checkpoint = new checkpoint();
-
-  ptx_reg_t regval;
-  regval.u64 = 123;
-
-  unsigned ctaid = m_kernel->get_next_cta_id_single();
-  if (m_gpu->checkpoint_option == 1 &&
-      (m_kernel->get_uid() == m_gpu->checkpoint_kernel) &&
-      (ctaid_cp >= m_gpu->checkpoint_CTA) &&
-      (ctaid_cp < m_gpu->checkpoint_CTA_t)) {
-    char fname[2048];
-    snprintf(fname, 2048, "checkpoint_files/shared_mem_%d.txt", ctaid - 1);
-    g_checkpoint->store_global_mem(m_thread[0]->m_shared_mem, fname,
-                                   (char *)"%08x");
-    for (int i = 0; i < 32 * m_warp_count; i++) {
-      char fname[2048];
-      snprintf(fname, 2048, "checkpoint_files/thread_%d_%d_reg.txt", i,
-               ctaid - 1);
-      m_thread[i]->print_reg_thread(fname);
+      
+      
+     if(cp_op==1)
+	{
       char f1name[2048];
-      snprintf(f1name, 2048, "checkpoint_files/local_mem_thread_%d_%d_reg.txt",
-               i, ctaid - 1);
-      g_checkpoint->store_global_mem(m_thread[i]->m_local_mem, f1name,
-                                     (char *)"%08x");
-      m_thread[i]->set_done();
-      m_thread[i]->exitCore();
-      m_thread[i]->registerExit();
-    }
+      snprintf(f1name,2048,"checkpoint_files/global_mem_%d.txt", kernel.get_uid() );
+      g_checkpoint->store_global_mem(gpgpu_ctx->the_gpgpusim->g_the_gpu->get_global_memory(), f1name , (char *)"%08x");
+	}
 
-    for (int i = 0; i < m_warp_count; i++) {
-      char fname[2048];
-      snprintf(fname, 2048, "checkpoint_files/warp_%d_%d_simt.txt", i,
-               ctaid - 1);
-      FILE *fp = fopen(fname, "w");
-      assert(fp != NULL);
-      m_simt_stack[i]->print_checkpoint(fp);
-      fclose(fp);
-    }
-  }
+
+      
+    
+   //registering this kernel as done      
+   
+   //openCL kernel simulation calls don't register the kernel so we don't register its exit
+   if(!openCL) {
+      //extern stream_manager *g_stream_manager;
+      gpgpu_ctx->the_gpgpusim->g_stream_manager->register_finished_kernel(kernel.get_uid());
+   }
+
+   //******PRINTING*******
+   printf( "GPGPU-Sim: Done functional simulation (%u instructions simulated).\n", g_ptx_sim_num_insn );
+   if ( gpgpu_ptx_instruction_classification ) {
+      StatDisp( g_inst_classification_stat[g_ptx_kernel_count]);
+      StatDisp ( g_inst_op_classification_stat[g_ptx_kernel_count]);
+   }
+
+   //time_t variables used to calculate the total simulation time
+   //the start time of simulation is hold by the global variable g_simulation_starttime
+   //g_simulation_starttime is initilized by gpgpu_ptx_sim_init_perf() in gpgpusim_entrypoint.cc upon starting gpgpu-sim
+   time_t end_time, elapsed_time, days, hrs, minutes, sec;
+   end_time = time((time_t *)NULL);
+   elapsed_time = MAX(end_time - gpgpu_ctx->the_gpgpusim->g_simulation_starttime, 1);
+	
+
+   //calculating and printing simulation time in terms of days, hours, minutes and seconds
+   days    = elapsed_time/(3600*24);
+   hrs     = elapsed_time/3600 - 24*days;
+   minutes = elapsed_time/60 - 60*(hrs + 24*days);
+   sec = elapsed_time - 60*(minutes + 60*(hrs + 24*days));
+
+   fflush(stderr);
+   printf("\n\ngpgpu_simulation_time = %u days, %u hrs, %u min, %u sec (%u sec)\n",
+          (unsigned)days, (unsigned)hrs, (unsigned)minutes, (unsigned)sec, (unsigned)elapsed_time );
+   printf("gpgpu_simulation_rate = %u (inst/sec)\n", (unsigned)(g_ptx_sim_num_insn / elapsed_time) );
+   fflush(stdout); 
 }
 
-void functionalCoreSim::executeWarp(unsigned i, bool &allAtBarrier,
-                                    bool &someOneLive) {
-  if (!m_warpAtBarrier[i] && m_liveThreadCount[i] != 0) {
-    warp_inst_t inst = getExecuteWarp(i);
-    execute_warp_inst_t(inst, i);
-    if (inst.isatomic()) inst.do_atomic(true);
-    if (inst.op == BARRIER_OP || inst.op == MEMORY_BARRIER_OP)
-      m_warpAtBarrier[i] = true;
-    updateSIMTStack(i, &inst);
-  }
-  if (m_liveThreadCount[i] > 0) someOneLive = true;
-  if (!m_warpAtBarrier[i] && m_liveThreadCount[i] > 0) allAtBarrier = false;
+void functionalCoreSim::initializeCTA(unsigned ctaid_cp)
+{
+    int ctaLiveThreads=0;
+    symbol_table * symtab= m_kernel->entry()->get_symtab();
+    
+    for(int i=0; i< m_warp_count; i++){
+        m_warpAtBarrier[i]=false;
+        m_liveThreadCount[i]=0;
+    }
+    for(int i=0; i< m_warp_count*m_warp_size;i++)
+        m_thread[i]=NULL;
+    
+    //get threads for a cta
+    for(unsigned i=0; i<m_kernel->threads_per_cta();i++) {
+        ptx_sim_init_thread(*m_kernel,&m_thread[i],0,i,m_kernel->threads_per_cta()-i,m_kernel->threads_per_cta(),this,0,i/m_warp_size,(gpgpu_t*)m_gpu, true);
+        assert(m_thread[i]!=NULL && !m_thread[i]->is_done());
+        char fname[2048];
+        snprintf(fname,2048,"checkpoint_files/thread_%d_0_reg.txt",i );
+        if(m_gpu->gpgpu_ctx->func_sim->cp_cta_resume==1)
+            m_thread[i]->resume_reg_thread(fname,symtab);
+        ctaLiveThreads++;
+    }
+
+    for(int k=0;k<m_warp_count;k++)
+        createWarp(k);
 }
 
-unsigned gpgpu_context::translate_pc_to_ptxlineno(unsigned pc) {
-  // this function assumes that the kernel fits inside a single PTX file
-  // function_info *pFunc = g_func_info; // assume that the current kernel is
-  // the one in query
-  const ptx_instruction *pInsn = pc_to_instruction(pc);
-  unsigned ptx_line_number = pInsn->source_line();
+void  functionalCoreSim::createWarp(unsigned warpId)
+{
+   simt_mask_t initialMask;
+   unsigned liveThreadsCount=0;
+   initialMask.set();
+    for(int i=warpId*m_warp_size; i<warpId*m_warp_size+m_warp_size;i++){
+        if(m_thread[i]==NULL) initialMask.reset(i-warpId*m_warp_size);
+        else liveThreadsCount++;
+    }   
+   
+   assert(m_thread[warpId*m_warp_size]!=NULL);
+   m_simt_stack[warpId]->launch(m_thread[warpId*m_warp_size]->get_pc(),initialMask);
+   char fname[2048];
+   snprintf(fname,2048,"checkpoint_files/warp_%d_0_simt.txt",warpId );
 
-  return ptx_line_number;
+   if(m_gpu->gpgpu_ctx->func_sim->cp_cta_resume==1)
+   {
+      unsigned pc,rpc;
+      m_simt_stack[warpId]->resume(fname);
+      m_simt_stack[warpId]->get_pdom_stack_top_info(&pc,&rpc);
+      for(int i=warpId*m_warp_size; i<warpId*m_warp_size+m_warp_size;i++){
+        m_thread[i]->set_npc(pc);
+        m_thread[i]->update_pc();
+    }   
+
+   }
+   m_liveThreadCount[warpId]= liveThreadsCount;
+}
+
+void functionalCoreSim::execute(int inst_count, unsigned ctaid_cp)
+ {
+     m_gpu->gpgpu_ctx->func_sim->cp_count= m_gpu->checkpoint_insn_Y;
+     m_gpu->gpgpu_ctx->func_sim->cp_cta_resume= m_gpu->checkpoint_CTA_t;
+    initializeCTA(ctaid_cp);
+    
+    int count=0;
+    while(true){
+        bool someOneLive= false;
+        bool allAtBarrier = true;
+        for(unsigned i=0;i<m_warp_count;i++){
+            executeWarp(i,allAtBarrier,someOneLive);
+            count++;
+        }
+        
+        if(inst_count>0 && count>inst_count && (m_kernel->get_uid()==m_gpu->checkpoint_kernel) && (ctaid_cp>=m_gpu->checkpoint_CTA) && (ctaid_cp<m_gpu->checkpoint_CTA_t) && m_gpu->checkpoint_option==1) 
+         {
+            someOneLive=false;
+            break;
+         }
+        if(!someOneLive) break;
+        if(allAtBarrier){
+             for(unsigned i=0;i<m_warp_count;i++)
+                 m_warpAtBarrier[i]=false;
+        }
+    }
+
+    checkpoint *g_checkpoint;
+    g_checkpoint = new checkpoint();
+    
+    ptx_reg_t regval;
+    regval.u64= 123;
+
+    unsigned ctaid =m_kernel->get_next_cta_id_single();
+    if(m_gpu->checkpoint_option==1 && (m_kernel->get_uid()==m_gpu->checkpoint_kernel) && (ctaid_cp>=m_gpu->checkpoint_CTA) && (ctaid_cp<m_gpu->checkpoint_CTA_t))
+   {
+       char fname[2048];
+       snprintf(fname,2048,"checkpoint_files/shared_mem_%d.txt",ctaid-1 );
+       g_checkpoint->store_global_mem(m_thread[0]->m_shared_mem, fname , (char *)"%08x");
+      for(int i=0; i<32*m_warp_count;i++)
+      {
+         char fname[2048];
+         snprintf(fname,2048,"checkpoint_files/thread_%d_%d_reg.txt",i,ctaid-1 );
+          m_thread[i]->print_reg_thread(fname);
+          char f1name[2048];
+         snprintf(f1name,2048,"checkpoint_files/local_mem_thread_%d_%d_reg.txt",i,ctaid-1 );
+         g_checkpoint->store_global_mem(m_thread[i]->m_local_mem, f1name , (char *)"%08x");
+         m_thread[i]->set_done();
+         m_thread[i]->exitCore();
+         m_thread[i]->registerExit();
+      }
+   
+      for(int i=0;i<m_warp_count;i++)
+      {
+         
+         char fname[2048];
+         snprintf(fname,2048,"checkpoint_files/warp_%d_%d_simt.txt",i,ctaid-1 );
+         FILE * fp = fopen(fname,"w");
+         assert(fp!=NULL);
+         m_simt_stack[i]->print_checkpoint(fp);
+         fclose(fp);
+      }
+   }
+
+}
+
+void functionalCoreSim::executeWarp(unsigned i, bool &allAtBarrier, bool & someOneLive)
+{
+    if(!m_warpAtBarrier[i] && m_liveThreadCount[i]!=0){
+        warp_inst_t inst =getExecuteWarp(i);
+        execute_warp_inst_t(inst,i);
+        if(inst.isatomic()) inst.do_atomic(true);
+        if(inst.op==BARRIER_OP || inst.op==MEMORY_BARRIER_OP ) m_warpAtBarrier[i]=true;
+        updateSIMTStack( i, &inst );
+    }
+    if(m_liveThreadCount[i]>0) someOneLive=true;
+    if(!m_warpAtBarrier[i]&& m_liveThreadCount[i]>0) allAtBarrier = false;
+}
+
+unsigned gpgpu_context::translate_pc_to_ptxlineno(unsigned pc)
+{
+   // this function assumes that the kernel fits inside a single PTX file
+   // function_info *pFunc = g_func_info; // assume that the current kernel is the one in query
+   const ptx_instruction *pInsn = pc_to_instruction(pc);
+   unsigned ptx_line_number = pInsn->source_line();
+
+   return ptx_line_number;
 }
 
 // ptxinfo parser
 
-extern std::map<unsigned, const char *> get_duplicate();
+extern std::map<unsigned,const char*> get_duplicate();
 
 static char *g_ptxinfo_kname = NULL;
 static struct gpgpu_ptx_sim_info g_ptxinfo;
-static std::map<unsigned, const char *> g_duplicate;
+static std::map<unsigned,const char*> g_duplicate;
 static const char *g_last_dup_type;
 
-const char *get_ptxinfo_kname() { return g_ptxinfo_kname; }
-
-void print_ptxinfo() {
-  if (!get_ptxinfo_kname()) {
-    printf("GPGPU-Sim PTX: Binary info : gmem=%u, cmem=%u\n", g_ptxinfo.gmem,
-           g_ptxinfo.cmem);
-  }
-  if (get_ptxinfo_kname()) {
-    printf(
-        "GPGPU-Sim PTX: Kernel \'%s\' : regs=%u, lmem=%u, smem=%u, cmem=%u\n",
-        get_ptxinfo_kname(), g_ptxinfo.regs, g_ptxinfo.lmem, g_ptxinfo.smem,
-        g_ptxinfo.cmem);
-  }
+const char *get_ptxinfo_kname() 
+{ 
+    return g_ptxinfo_kname; 
 }
 
-struct gpgpu_ptx_sim_info get_ptxinfo() {
-  return g_ptxinfo;
-}
-
-std::map<unsigned, const char *> get_duplicate() { return g_duplicate; }
-
-void ptxinfo_linenum(unsigned linenum) {
-  g_duplicate[linenum] = g_last_dup_type;
-}
-
-void ptxinfo_dup_type(const char *dup_type) { g_last_dup_type = dup_type; }
-
-void ptxinfo_function(const char *fname) {
-  clear_ptxinfo();
-  g_ptxinfo_kname = strdup(fname);
-}
-
-void ptxinfo_regs(unsigned nregs) { g_ptxinfo.regs = nregs; }
-
-void ptxinfo_lmem(unsigned declared, unsigned system) {
-  g_ptxinfo.lmem = declared + system;
-}
-
-void ptxinfo_gmem(unsigned declared, unsigned system) {
-  g_ptxinfo.gmem = declared + system;
-}
-
-void ptxinfo_smem(unsigned declared, unsigned system) {
-  g_ptxinfo.smem = declared + system;
-}
-
-void ptxinfo_cmem(unsigned nbytes, unsigned bank) { g_ptxinfo.cmem += nbytes; }
-
-void clear_ptxinfo() {
-  free(g_ptxinfo_kname);
-  g_ptxinfo_kname = NULL;
-  g_ptxinfo.regs = 0;
-  g_ptxinfo.lmem = 0;
-  g_ptxinfo.smem = 0;
-  g_ptxinfo.cmem = 0;
-  g_ptxinfo.gmem = 0;
-  g_ptxinfo.ptx_version = 0;
-  g_ptxinfo.sm_target = 0;
-}
-
-void ptxinfo_opencl_addinfo(std::map<std::string, function_info *> &kernels) {
-  if (!g_ptxinfo_kname) {
-    printf("GPGPU-Sim PTX: Binary info : gmem=%u, cmem=%u\n", g_ptxinfo.gmem,
-           g_ptxinfo.cmem);
-    clear_ptxinfo();
-    return;
-  }
-
-  if (!strcmp("__cuda_dummy_entry__", g_ptxinfo_kname)) {
-    // this string produced by ptxas for empty ptx files (e.g., bandwidth test)
-    clear_ptxinfo();
-    return;
-  }
-  std::map<std::string, function_info *>::iterator k =
-      kernels.find(g_ptxinfo_kname);
-  if (k == kernels.end()) {
-    printf("GPGPU-Sim PTX: ERROR ** implementation for '%s' not found.\n",
-           g_ptxinfo_kname);
-    abort();
-  } else {
-    printf(
-        "GPGPU-Sim PTX: Kernel \'%s\' : regs=%u, lmem=%u, smem=%u, cmem=%u\n",
-        g_ptxinfo_kname, g_ptxinfo.regs, g_ptxinfo.lmem, g_ptxinfo.smem,
-        g_ptxinfo.cmem);
-    function_info *finfo = k->second;
-    assert(finfo != NULL);
-    finfo->set_kernel_info(g_ptxinfo);
-  }
-  clear_ptxinfo();
-}
-
-struct rec_pts cuda_sim::find_reconvergence_points(function_info *finfo) {
-  rec_pts tmp;
-  std::map<function_info *, rec_pts>::iterator r = g_rpts.find(finfo);
-
-  if (r == g_rpts.end()) {
-    int num_recon = finfo->get_num_reconvergence_pairs();
-
-    gpgpu_recon_t *kernel_recon_points =
-        (struct gpgpu_recon_t *)calloc(num_recon, sizeof(struct gpgpu_recon_t));
-    finfo->get_reconvergence_pairs(kernel_recon_points);
-    printf("GPGPU-Sim PTX: reconvergence points for %s...\n",
-           finfo->get_name().c_str());
-    for (int i = 0; i < num_recon; i++) {
-      printf("GPGPU-Sim PTX: %2u (potential) branch divergence @ ", i + 1);
-      kernel_recon_points[i].source_inst->print_insn();
-      printf("\n");
-      printf("GPGPU-Sim PTX:    immediate post dominator      @ ");
-      if (kernel_recon_points[i].target_inst)
-        kernel_recon_points[i].target_inst->print_insn();
-      printf("\n");
+void print_ptxinfo()
+{
+    if(! get_ptxinfo_kname()){
+    	printf ("GPGPU-Sim PTX: Binary info : gmem=%u, cmem=%u\n",
+    			g_ptxinfo.gmem,
+    			g_ptxinfo.cmem);
     }
-    printf("GPGPU-Sim PTX: ... end of reconvergence points for %s\n",
-           finfo->get_name().c_str());
-
-    tmp.s_kernel_recon_points = kernel_recon_points;
-    tmp.s_num_recon = num_recon;
-    g_rpts[finfo] = tmp;
-  } else {
-    tmp = r->second;
-  }
-  return tmp;
+    if(get_ptxinfo_kname()){
+    	printf ("GPGPU-Sim PTX: Kernel \'%s\' : regs=%u, lmem=%u, smem=%u, cmem=%u\n",
+    			get_ptxinfo_kname(),
+    			g_ptxinfo.regs,
+    			g_ptxinfo.lmem,
+    			g_ptxinfo.smem,
+    			g_ptxinfo.cmem );
+    }
 }
 
-address_type get_return_pc(void *thd) {
-  // function call return
-  ptx_thread_info *the_thread = (ptx_thread_info *)thd;
-  assert(the_thread != NULL);
-  return the_thread->get_return_PC();
+
+struct gpgpu_ptx_sim_info get_ptxinfo()
+{
+    return g_ptxinfo;
 }
 
-address_type cuda_sim::get_converge_point(address_type pc) {
-  // the branch could encode the reconvergence point and/or a bit that indicates
-  // the
-  // reconvergence point is the return PC on the call stack in the case the
-  // branch has
-  // no immediate postdominator in the function (i.e., due to multiple return
-  // points).
+std::map<unsigned,const char*> get_duplicate()
+{
+	return g_duplicate;
+}
 
-  std::map<unsigned, function_info *>::iterator f = g_pc_to_finfo.find(pc);
-  assert(f != g_pc_to_finfo.end());
-  function_info *finfo = f->second;
-  rec_pts tmp = find_reconvergence_points(finfo);
+void ptxinfo_linenum( unsigned linenum )
+{
+	g_duplicate[linenum] = g_last_dup_type;
+}
 
-  int i = 0;
-  for (; i < tmp.s_num_recon; ++i) {
-    if (tmp.s_kernel_recon_points[i].source_pc == pc) {
-      if (tmp.s_kernel_recon_points[i].target_pc == (unsigned)-2) {
-        return RECONVERGE_RETURN_PC;
-      } else {
-        return tmp.s_kernel_recon_points[i].target_pc;
+void ptxinfo_dup_type( const char *dup_type )
+{
+	g_last_dup_type = dup_type;
+}
+
+void ptxinfo_function(const char *fname )
+{
+    clear_ptxinfo();
+    g_ptxinfo_kname = strdup(fname);
+}
+
+void ptxinfo_regs( unsigned nregs )
+{
+    g_ptxinfo.regs=nregs;
+}
+
+void ptxinfo_lmem( unsigned declared, unsigned system )
+{
+    g_ptxinfo.lmem=declared+system;
+}
+
+void ptxinfo_gmem( unsigned declared, unsigned system )
+{
+    g_ptxinfo.gmem=declared+system;
+}
+
+void ptxinfo_smem( unsigned declared, unsigned system )
+{
+    g_ptxinfo.smem=declared+system;
+}
+
+void ptxinfo_cmem( unsigned nbytes, unsigned bank )
+{
+    g_ptxinfo.cmem+=nbytes;
+}
+
+void clear_ptxinfo()
+{
+    free(g_ptxinfo_kname);
+    g_ptxinfo_kname=NULL;
+    g_ptxinfo.regs=0;
+    g_ptxinfo.lmem=0;
+    g_ptxinfo.smem=0;
+    g_ptxinfo.cmem=0;
+    g_ptxinfo.gmem=0;
+    g_ptxinfo.ptx_version=0;
+    g_ptxinfo.sm_target=0;
+}
+
+
+void ptxinfo_opencl_addinfo( std::map<std::string,function_info*> &kernels )
+{
+
+   if(! g_ptxinfo_kname) {
+	  printf ("GPGPU-Sim PTX: Binary info : gmem=%u, cmem=%u\n",
+			  g_ptxinfo.gmem,
+			  g_ptxinfo.cmem);
+	  clear_ptxinfo();
+	  return;
+   }
+
+   if( !strcmp("__cuda_dummy_entry__",g_ptxinfo_kname) ) {
+      // this string produced by ptxas for empty ptx files (e.g., bandwidth test)
+      clear_ptxinfo();
+      return;
+   }
+   std::map<std::string,function_info*>::iterator k=kernels.find(g_ptxinfo_kname);
+   if( k==kernels.end() ) {
+      printf ("GPGPU-Sim PTX: ERROR ** implementation for '%s' not found.\n", g_ptxinfo_kname );
+      abort();
+   } else {
+      printf ("GPGPU-Sim PTX: Kernel \'%s\' : regs=%u, lmem=%u, smem=%u, cmem=%u\n", 
+              g_ptxinfo_kname,
+              g_ptxinfo.regs,
+              g_ptxinfo.lmem,
+              g_ptxinfo.smem,
+              g_ptxinfo.cmem );
+      function_info *finfo = k->second;
+      assert(finfo!=NULL);
+      finfo->set_kernel_info( g_ptxinfo );
+   }
+   clear_ptxinfo();
+}
+
+struct rec_pts cuda_sim::find_reconvergence_points( function_info *finfo )
+{
+   rec_pts tmp;
+   std::map<function_info*,rec_pts>::iterator r=g_rpts.find(finfo);
+ 
+   if( r==g_rpts.end() ) {
+      int num_recon = finfo->get_num_reconvergence_pairs();
+      
+      gpgpu_recon_t *kernel_recon_points = (struct gpgpu_recon_t*) calloc(num_recon, sizeof(struct gpgpu_recon_t));
+      finfo->get_reconvergence_pairs(kernel_recon_points);
+      printf("GPGPU-Sim PTX: reconvergence points for %s...\n", finfo->get_name().c_str() );
+      for (int i=0;i<num_recon;i++) {
+         printf("GPGPU-Sim PTX: %2u (potential) branch divergence @ ", i+1 );
+         kernel_recon_points[i].source_inst->print_insn();
+         printf("\n");
+         printf("GPGPU-Sim PTX:    immediate post dominator      @ " ); 
+         if( kernel_recon_points[i].target_inst )
+            kernel_recon_points[i].target_inst->print_insn();
+         printf("\n");
       }
-    }
-  }
-  return NO_BRANCH_DIVERGENCE;
+      printf("GPGPU-Sim PTX: ... end of reconvergence points for %s\n", finfo->get_name().c_str() );
+
+      tmp.s_kernel_recon_points = kernel_recon_points;
+      tmp.s_num_recon = num_recon;
+      g_rpts[finfo] = tmp;
+   } else {
+      tmp = r->second;
+   }
+   return tmp;
 }
 
-void functionalCoreSim::warp_exit(unsigned warp_id) {
-  for (int i = 0; i < m_warp_count * m_warp_size; i++) {
-    if (m_thread[i] != NULL) {
-      m_thread[i]->m_cta_info->register_deleted_thread(m_thread[i]);
-      delete m_thread[i];
+address_type get_return_pc( void *thd )
+{
+    // function call return
+    ptx_thread_info *the_thread = (ptx_thread_info*)thd;
+    assert( the_thread != NULL );
+    return the_thread->get_return_PC();
+}
+
+address_type cuda_sim::get_converge_point( address_type pc )
+{
+   // the branch could encode the reconvergence point and/or a bit that indicates the 
+   // reconvergence point is the return PC on the call stack in the case the branch has 
+   // no immediate postdominator in the function (i.e., due to multiple return points). 
+
+   std::map<unsigned,function_info*>::iterator f=g_pc_to_finfo.find(pc);
+   assert( f != g_pc_to_finfo.end() );
+   function_info *finfo = f->second;
+   rec_pts tmp = find_reconvergence_points(finfo);
+
+   int i=0;
+   for (; i < tmp.s_num_recon; ++i) {
+      if (tmp.s_kernel_recon_points[i].source_pc == pc) {
+          if( tmp.s_kernel_recon_points[i].target_pc == (unsigned) -2 ) {
+              return RECONVERGE_RETURN_PC;
+          } else {
+              return tmp.s_kernel_recon_points[i].target_pc;
+          }
+      }
+   }
+   return NO_BRANCH_DIVERGENCE;
+}
+
+void functionalCoreSim::warp_exit( unsigned warp_id )
+{
+    for(int i=0;i<m_warp_count*m_warp_size;i++){
+        if(m_thread[i]!=NULL){
+             m_thread[i]->m_cta_info->register_deleted_thread(m_thread[i]);
+             delete m_thread[i];
+        }
     }
-  }
 }

--- a/src/cuda-sim/cuda-sim.cc
+++ b/src/cuda-sim/cuda-sim.cc
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2011, Tor M. Aamodt, Ali Bakhoda, Wilson W.L. Fung,
-// George L. Yuan, Jimmy Kwa 
+// George L. Yuan, Jimmy Kwa
 // The University of British Columbia
 // All rights reserved.
 //
@@ -8,14 +8,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -31,260 +33,318 @@
 #include "instructions.h"
 #include "ptx_ir.h"
 class ptx_recognizer;
-typedef void * yyscan_t;
-#include "ptx.tab.h"
-#include "ptx_sim.h"
+typedef void *yyscan_t;
 #include <stdio.h>
-#include <sstream>
-#include "opcodes.h"
-#include "../statwrapper.h"
-#include <set>
 #include <map>
+#include <set>
+#include <sstream>
+#include "../../libcuda/gpgpu_context.h"
 #include "../abstract_hardware_model.h"
-#include "memory.h"
-#include "ptx-stats.h"
-#include "ptx_loader.h"
-#include "ptx_parser.h"
 #include "../gpgpu-sim/gpu-sim.h"
-#include "ptx_sim.h"
 #include "../gpgpusim_entrypoint.h"
-#include "decuda_pred_table/decuda_pred_table.h"
+#include "../statwrapper.h"
 #include "../stream_manager.h"
 #include "cuda_device_runtime.h"
-#include "../../libcuda/gpgpu_context.h"
+#include "decuda_pred_table/decuda_pred_table.h"
+#include "memory.h"
+#include "opcodes.h"
+#include "ptx-stats.h"
+#include "ptx.tab.h"
+#include "ptx_loader.h"
+#include "ptx_parser.h"
+#include "ptx_sim.h"
+#include "ptx_sim.h"
 
 int g_debug_execution = 0;
 // Output debug information to file options
 
-
-void cuda_sim::ptx_opcocde_latency_options (option_parser_t opp) {
-	option_parser_register(opp, "-ptx_opcode_latency_int", OPT_CSTR, &opcode_latency_int,
-			"Opcode latencies for integers <ADD,MAX,MUL,MAD,DIV>"
-			"Default 1,1,19,25,145",
-			"1,1,19,25,145");
-	option_parser_register(opp, "-ptx_opcode_latency_fp", OPT_CSTR, &opcode_latency_fp,
-			"Opcode latencies for single precision floating points <ADD,MAX,MUL,MAD,DIV>"
-			"Default 1,1,1,1,30",
-			"1,1,1,1,30");
-	option_parser_register(opp, "-ptx_opcode_latency_dp", OPT_CSTR, &opcode_latency_dp,
-			"Opcode latencies for double precision floating points <ADD,MAX,MUL,MAD,DIV>"
-			"Default 8,8,8,8,335",
-			"8,8,8,8,335");
-	option_parser_register(opp, "-ptx_opcode_latency_sfu", OPT_CSTR, &opcode_latency_sfu,
-			"Opcode latencies for SFU instructions"
-			"Default 8",
-			"8");
-	option_parser_register(opp, "-ptx_opcode_latency_tesnor", OPT_CSTR, &opcode_latency_tensor,
-			"Opcode latencies for Tensor instructions"
-			"Default 64",
-			"64");
-	option_parser_register(opp, "-ptx_opcode_initiation_int", OPT_CSTR, &opcode_initiation_int,
-			"Opcode initiation intervals for integers <ADD,MAX,MUL,MAD,DIV>"
-			"Default 1,1,4,4,32",
-			"1,1,4,4,32");
-	option_parser_register(opp, "-ptx_opcode_initiation_fp", OPT_CSTR, &opcode_initiation_fp,
-			"Opcode initiation intervals for single precision floating points <ADD,MAX,MUL,MAD,DIV>"
-			"Default 1,1,1,1,5",
-			"1,1,1,1,5");
-	option_parser_register(opp, "-ptx_opcode_initiation_dp", OPT_CSTR, &opcode_initiation_dp,
-			"Opcode initiation intervals for double precision floating points <ADD,MAX,MUL,MAD,DIV>"
-			"Default 8,8,8,8,130",
-			"8,8,8,8,130");
-	option_parser_register(opp, "-ptx_opcode_initiation_sfu", OPT_CSTR, &opcode_initiation_sfu,
-			"Opcode initiation intervals for sfu instructions"
-			"Default 8",
-			"8");
-	option_parser_register(opp, "-ptx_opcode_initiation_tensor", OPT_CSTR, &opcode_initiation_tensor,
-			"Opcode initiation intervals for tensor instructions"
-			"Default 64",
-			"64");
-	option_parser_register(opp, "-cdp_latency", OPT_CSTR, &cdp_latency_str,
-			"CDP API latency <cudaStreamCreateWithFlags, \
+void cuda_sim::ptx_opcocde_latency_options(option_parser_t opp) {
+  option_parser_register(opp, "-ptx_opcode_latency_int", OPT_CSTR,
+                         &opcode_latency_int,
+                         "Opcode latencies for integers <ADD,MAX,MUL,MAD,DIV>"
+                         "Default 1,1,19,25,145",
+                         "1,1,19,25,145");
+  option_parser_register(opp, "-ptx_opcode_latency_fp", OPT_CSTR,
+                         &opcode_latency_fp,
+                         "Opcode latencies for single precision floating "
+                         "points <ADD,MAX,MUL,MAD,DIV>"
+                         "Default 1,1,1,1,30",
+                         "1,1,1,1,30");
+  option_parser_register(opp, "-ptx_opcode_latency_dp", OPT_CSTR,
+                         &opcode_latency_dp,
+                         "Opcode latencies for double precision floating "
+                         "points <ADD,MAX,MUL,MAD,DIV>"
+                         "Default 8,8,8,8,335",
+                         "8,8,8,8,335");
+  option_parser_register(opp, "-ptx_opcode_latency_sfu", OPT_CSTR,
+                         &opcode_latency_sfu,
+                         "Opcode latencies for SFU instructions"
+                         "Default 8",
+                         "8");
+  option_parser_register(opp, "-ptx_opcode_latency_tesnor", OPT_CSTR,
+                         &opcode_latency_tensor,
+                         "Opcode latencies for Tensor instructions"
+                         "Default 64",
+                         "64");
+  option_parser_register(
+      opp, "-ptx_opcode_initiation_int", OPT_CSTR, &opcode_initiation_int,
+      "Opcode initiation intervals for integers <ADD,MAX,MUL,MAD,DIV>"
+      "Default 1,1,4,4,32",
+      "1,1,4,4,32");
+  option_parser_register(opp, "-ptx_opcode_initiation_fp", OPT_CSTR,
+                         &opcode_initiation_fp,
+                         "Opcode initiation intervals for single precision "
+                         "floating points <ADD,MAX,MUL,MAD,DIV>"
+                         "Default 1,1,1,1,5",
+                         "1,1,1,1,5");
+  option_parser_register(opp, "-ptx_opcode_initiation_dp", OPT_CSTR,
+                         &opcode_initiation_dp,
+                         "Opcode initiation intervals for double precision "
+                         "floating points <ADD,MAX,MUL,MAD,DIV>"
+                         "Default 8,8,8,8,130",
+                         "8,8,8,8,130");
+  option_parser_register(opp, "-ptx_opcode_initiation_sfu", OPT_CSTR,
+                         &opcode_initiation_sfu,
+                         "Opcode initiation intervals for sfu instructions"
+                         "Default 8",
+                         "8");
+  option_parser_register(opp, "-ptx_opcode_initiation_tensor", OPT_CSTR,
+                         &opcode_initiation_tensor,
+                         "Opcode initiation intervals for tensor instructions"
+                         "Default 64",
+                         "64");
+  option_parser_register(opp, "-cdp_latency", OPT_CSTR, &cdp_latency_str,
+                         "CDP API latency <cudaStreamCreateWithFlags, \
 cudaGetParameterBufferV2_init_perWarp, cudaGetParameterBufferV2_perKernel, \
 cudaLaunchDeviceV2_init_perWarp, cudaLaunchDevicV2_perKernel>"
-			"Default 7200,8000,100,12000,1600",
-			"7200,8000,100,12000,1600");
+                         "Default 7200,8000,100,12000,1600",
+                         "7200,8000,100,12000,1600");
 }
 
-void gpgpu_t::gpgpu_ptx_sim_bindNameToTexture(const char* name, const struct textureReference* texref, int dim, int readmode, int ext)
-{
-   std::string texname(name);
-   if (m_NameToTextureRef.find(texname)==m_NameToTextureRef.end()){
-      m_NameToTextureRef[texname] = std::set<const struct textureReference*>();
-   }else{
-     const struct textureReference* tr = *m_NameToTextureRef[texname].begin();
-     assert(tr!=NULL);
-     //asserts that all texrefs in set have same fields
-     assert(tr->normalized==texref->normalized&&
-            tr->filterMode==texref->filterMode&&
-            tr->addressMode[0]==texref->addressMode[0]&&
-            tr->addressMode[1]==texref->addressMode[1]&&
-            tr->addressMode[2]==texref->addressMode[2]&&
-            tr->channelDesc.x==texref->channelDesc.x&&
-            tr->channelDesc.y==texref->channelDesc.y&&
-            tr->channelDesc.z==texref->channelDesc.z&&
-            tr->channelDesc.w==texref->channelDesc.w&&
-            tr->channelDesc.f==texref->channelDesc.f  
-           );
-   }
-   m_NameToTextureRef[texname].insert(texref);
-   m_TextureRefToName[texref] = texname;
-   const textureReferenceAttr *texAttr = new textureReferenceAttr(texref, dim, (enum cudaTextureReadMode)readmode, ext); 
-   m_NameToAttribute[texname] = texAttr; 
+void gpgpu_t::gpgpu_ptx_sim_bindNameToTexture(
+    const char *name, const struct textureReference *texref, int dim,
+    int readmode, int ext) {
+  std::string texname(name);
+  if (m_NameToTextureRef.find(texname) == m_NameToTextureRef.end()) {
+    m_NameToTextureRef[texname] = std::set<const struct textureReference *>();
+  } else {
+    const struct textureReference *tr = *m_NameToTextureRef[texname].begin();
+    assert(tr != NULL);
+    // asserts that all texrefs in set have same fields
+    assert(tr->normalized == texref->normalized &&
+           tr->filterMode == texref->filterMode &&
+           tr->addressMode[0] == texref->addressMode[0] &&
+           tr->addressMode[1] == texref->addressMode[1] &&
+           tr->addressMode[2] == texref->addressMode[2] &&
+           tr->channelDesc.x == texref->channelDesc.x &&
+           tr->channelDesc.y == texref->channelDesc.y &&
+           tr->channelDesc.z == texref->channelDesc.z &&
+           tr->channelDesc.w == texref->channelDesc.w &&
+           tr->channelDesc.f == texref->channelDesc.f);
+  }
+  m_NameToTextureRef[texname].insert(texref);
+  m_TextureRefToName[texref] = texname;
+  const textureReferenceAttr *texAttr = new textureReferenceAttr(
+      texref, dim, (enum cudaTextureReadMode)readmode, ext);
+  m_NameToAttribute[texname] = texAttr;
 }
 
-const char* gpgpu_t::gpgpu_ptx_sim_findNamefromTexture(const struct textureReference* texref)
-{
-   std::map<const struct textureReference*, std::string>::const_iterator t=m_TextureRefToName.find(texref);
-   assert( t != m_TextureRefToName.end() );
-   return t->second.c_str();
+const char *gpgpu_t::gpgpu_ptx_sim_findNamefromTexture(
+    const struct textureReference *texref) {
+  std::map<const struct textureReference *, std::string>::const_iterator t =
+      m_TextureRefToName.find(texref);
+  assert(t != m_TextureRefToName.end());
+  return t->second.c_str();
 }
 
-unsigned int intLOGB2( unsigned int v ) {
-   unsigned int shift;
-   unsigned int r;
+unsigned int intLOGB2(unsigned int v) {
+  unsigned int shift;
+  unsigned int r;
 
-   r = 0;
+  r = 0;
 
-   shift = (( v & 0xFFFF0000) != 0 ) << 4; v >>= shift; r |= shift;
-   shift = (( v & 0xFF00    ) != 0 ) << 3; v >>= shift; r |= shift;
-   shift = (( v & 0xF0      ) != 0 ) << 2; v >>= shift; r |= shift;
-   shift = (( v & 0xC       ) != 0 ) << 1; v >>= shift; r |= shift;
-   shift = (( v & 0x2       ) != 0 ) << 0; v >>= shift; r |= shift;
+  shift = ((v & 0xFFFF0000) != 0) << 4;
+  v >>= shift;
+  r |= shift;
+  shift = ((v & 0xFF00) != 0) << 3;
+  v >>= shift;
+  r |= shift;
+  shift = ((v & 0xF0) != 0) << 2;
+  v >>= shift;
+  r |= shift;
+  shift = ((v & 0xC) != 0) << 1;
+  v >>= shift;
+  r |= shift;
+  shift = ((v & 0x2) != 0) << 0;
+  v >>= shift;
+  r |= shift;
 
-   return r;
+  return r;
 }
 
-void gpgpu_t::gpgpu_ptx_sim_bindTextureToArray(const struct textureReference* texref, const struct cudaArray* array)
-{
-   std::string texname = gpgpu_ptx_sim_findNamefromTexture(texref);
+void gpgpu_t::gpgpu_ptx_sim_bindTextureToArray(
+    const struct textureReference *texref, const struct cudaArray *array) {
+  std::string texname = gpgpu_ptx_sim_findNamefromTexture(texref);
 
-   std::map<std::string,const struct cudaArray*>::const_iterator t=m_NameToCudaArray.find(texname);
-   //check that there's nothing there first
-   if(t != m_NameToCudaArray.end()){
-      printf("GPGPU-Sim PTX:   Warning: binding to texref associated with %s, which was previously bound.\nImplicitly unbinding texref associated to %s first\n", texname.c_str(), texname.c_str());
-   }
-   m_NameToCudaArray[texname] = array;
-   unsigned int texel_size_bits = array->desc.w + array->desc.x + array->desc.y + array->desc.z;
-   unsigned int texel_size = texel_size_bits/8;
-   unsigned int Tx, Ty;
-   int r;
+  std::map<std::string, const struct cudaArray *>::const_iterator t =
+      m_NameToCudaArray.find(texname);
+  // check that there's nothing there first
+  if (t != m_NameToCudaArray.end()) {
+    printf(
+        "GPGPU-Sim PTX:   Warning: binding to texref associated with %s, which "
+        "was previously bound.\nImplicitly unbinding texref associated to %s "
+        "first\n",
+        texname.c_str(), texname.c_str());
+  }
+  m_NameToCudaArray[texname] = array;
+  unsigned int texel_size_bits =
+      array->desc.w + array->desc.x + array->desc.y + array->desc.z;
+  unsigned int texel_size = texel_size_bits / 8;
+  unsigned int Tx, Ty;
+  int r;
 
-   printf("GPGPU-Sim PTX:   texel size = %d\n", texel_size);
-   printf("GPGPU-Sim PTX:   texture cache linesize = %d\n", m_function_model_config.get_texcache_linesize());
-   //first determine base Tx size for given linesize
-   switch (m_function_model_config.get_texcache_linesize()) {
-   case 16:  Tx = 4; break;
-   case 32:  Tx = 8; break;
-   case 64:  Tx = 8; break;
-   case 128: Tx = 16; break;
-   case 256: Tx = 16; break;
-   default:
-      printf("GPGPU-Sim PTX:   Line size of %d bytes currently not supported.\n", m_function_model_config.get_texcache_linesize());
+  printf("GPGPU-Sim PTX:   texel size = %d\n", texel_size);
+  printf("GPGPU-Sim PTX:   texture cache linesize = %d\n",
+         m_function_model_config.get_texcache_linesize());
+  // first determine base Tx size for given linesize
+  switch (m_function_model_config.get_texcache_linesize()) {
+    case 16:
+      Tx = 4;
+      break;
+    case 32:
+      Tx = 8;
+      break;
+    case 64:
+      Tx = 8;
+      break;
+    case 128:
+      Tx = 16;
+      break;
+    case 256:
+      Tx = 16;
+      break;
+    default:
+      printf(
+          "GPGPU-Sim PTX:   Line size of %d bytes currently not supported.\n",
+          m_function_model_config.get_texcache_linesize());
       assert(0);
       break;
-   }
-   r = texel_size >> 2;
-   //modify base Tx size to take into account size of each texel in bytes
-   while (r != 0) {
-      Tx = Tx >> 1;
-      r = r >> 2;
-   }
-   //by now, got the correct Tx size, calculate correct Ty size
-   Ty = m_function_model_config.get_texcache_linesize()/(Tx*texel_size);
+  }
+  r = texel_size >> 2;
+  // modify base Tx size to take into account size of each texel in bytes
+  while (r != 0) {
+    Tx = Tx >> 1;
+    r = r >> 2;
+  }
+  // by now, got the correct Tx size, calculate correct Ty size
+  Ty = m_function_model_config.get_texcache_linesize() / (Tx * texel_size);
 
-   printf("GPGPU-Sim PTX:   Tx = %d; Ty = %d, Tx_numbits = %d, Ty_numbits = %d\n", Tx, Ty, intLOGB2(Tx), intLOGB2(Ty));
-   printf("GPGPU-Sim PTX:   Texel size = %d bytes; texel_size_numbits = %d\n", texel_size, intLOGB2(texel_size));
-   printf("GPGPU-Sim PTX:   Binding texture to array starting at devPtr32 = 0x%x\n", array->devPtr32);
-   printf("GPGPU-Sim PTX:   Texel size = %d bytes\n", texel_size);
-   struct textureInfo* texInfo = (struct textureInfo*) malloc(sizeof(struct textureInfo)); 
-   texInfo->Tx = Tx;
-   texInfo->Ty = Ty;
-   texInfo->Tx_numbits = intLOGB2(Tx);
-   texInfo->Ty_numbits = intLOGB2(Ty);
-   texInfo->texel_size = texel_size;
-   texInfo->texel_size_numbits = intLOGB2(texel_size);
-   m_NameToTextureInfo[texname] = texInfo;
+  printf(
+      "GPGPU-Sim PTX:   Tx = %d; Ty = %d, Tx_numbits = %d, Ty_numbits = %d\n",
+      Tx, Ty, intLOGB2(Tx), intLOGB2(Ty));
+  printf("GPGPU-Sim PTX:   Texel size = %d bytes; texel_size_numbits = %d\n",
+         texel_size, intLOGB2(texel_size));
+  printf(
+      "GPGPU-Sim PTX:   Binding texture to array starting at devPtr32 = 0x%x\n",
+      array->devPtr32);
+  printf("GPGPU-Sim PTX:   Texel size = %d bytes\n", texel_size);
+  struct textureInfo *texInfo =
+      (struct textureInfo *)malloc(sizeof(struct textureInfo));
+  texInfo->Tx = Tx;
+  texInfo->Ty = Ty;
+  texInfo->Tx_numbits = intLOGB2(Tx);
+  texInfo->Ty_numbits = intLOGB2(Ty);
+  texInfo->texel_size = texel_size;
+  texInfo->texel_size_numbits = intLOGB2(texel_size);
+  m_NameToTextureInfo[texname] = texInfo;
 }
 
-void gpgpu_t::gpgpu_ptx_sim_unbindTexture(const struct textureReference* texref)
-{
-   //assumes bind-use-unbind-bind-use-unbind pattern
-   std::string texname = gpgpu_ptx_sim_findNamefromTexture(texref);
-   m_NameToCudaArray.erase(texname);
-   m_NameToTextureInfo.erase(texname);
+void gpgpu_t::gpgpu_ptx_sim_unbindTexture(
+    const struct textureReference *texref) {
+  // assumes bind-use-unbind-bind-use-unbind pattern
+  std::string texname = gpgpu_ptx_sim_findNamefromTexture(texref);
+  m_NameToCudaArray.erase(texname);
+  m_NameToTextureInfo.erase(texname);
 }
 
 #define MAX_INST_SIZE 8 /*bytes*/
 
-void function_info::ptx_assemble()
-{
-   if( m_assembled ) {
-      return;
-   }
+void function_info::ptx_assemble() {
+  if (m_assembled) {
+    return;
+  }
 
-   // get the instructions into instruction memory...
-   unsigned num_inst = m_instructions.size();
-   m_instr_mem_size = MAX_INST_SIZE*(num_inst+1);
-   m_instr_mem = new ptx_instruction*[ m_instr_mem_size ];
+  // get the instructions into instruction memory...
+  unsigned num_inst = m_instructions.size();
+  m_instr_mem_size = MAX_INST_SIZE * (num_inst + 1);
+  m_instr_mem = new ptx_instruction *[m_instr_mem_size];
 
-   printf("GPGPU-Sim PTX: instruction assembly for function \'%s\'... ", m_name.c_str() );
-   fflush(stdout);
-   std::list<ptx_instruction*>::iterator i;
+  printf("GPGPU-Sim PTX: instruction assembly for function \'%s\'... ",
+         m_name.c_str());
+  fflush(stdout);
+  std::list<ptx_instruction *>::iterator i;
 
-   addr_t PC = gpgpu_ctx->func_sim->g_assemble_code_next_pc; // globally unique address (across functions)
-   // start function on an aligned address
-   for( unsigned i=0; i < (PC%MAX_INST_SIZE); i++ ) 
-      gpgpu_ctx->s_g_pc_to_insn.push_back((ptx_instruction*)NULL);
-   PC += PC%MAX_INST_SIZE; 
-   m_start_PC = PC;
+  addr_t PC = gpgpu_ctx->func_sim->g_assemble_code_next_pc;  // globally unique
+                                                             // address (across
+                                                             // functions)
+  // start function on an aligned address
+  for (unsigned i = 0; i < (PC % MAX_INST_SIZE); i++)
+    gpgpu_ctx->s_g_pc_to_insn.push_back((ptx_instruction *)NULL);
+  PC += PC % MAX_INST_SIZE;
+  m_start_PC = PC;
 
-   addr_t n=0; // offset in m_instr_mem
-   //Why s_g_pc_to_insn.size() is needed to reserve additional memory for insts? reserve is cumulative.
-   //s_g_pc_to_insn.reserve(s_g_pc_to_insn.size() + MAX_INST_SIZE*m_instructions.size());
-   gpgpu_ctx->s_g_pc_to_insn.reserve(MAX_INST_SIZE*m_instructions.size());
-   for ( i=m_instructions.begin(); i != m_instructions.end(); i++ ) {
-      ptx_instruction *pI = *i;
-      if ( pI->is_label() ) {
-         const symbol *l = pI->get_label();
-         labels[l->name()] = n;
-      } else {
-         gpgpu_ctx->func_sim->g_pc_to_finfo[PC] = this;
-         m_instr_mem[n] = pI;
-         gpgpu_ctx->s_g_pc_to_insn.push_back(pI);
-         assert(pI == gpgpu_ctx->s_g_pc_to_insn[PC]);
-         pI->set_m_instr_mem_index(n);
-         pI->set_PC(PC);
-         assert( pI->inst_size() <= MAX_INST_SIZE );
-         for( unsigned i=1; i < pI->inst_size(); i++ ) {
-            gpgpu_ctx->s_g_pc_to_insn.push_back((ptx_instruction*)NULL);
-            m_instr_mem[n+i]=NULL;
-         }
-         n  += pI->inst_size();
-         PC += pI->inst_size();
+  addr_t n = 0;  // offset in m_instr_mem
+  // Why s_g_pc_to_insn.size() is needed to reserve additional memory for insts?
+  // reserve is cumulative.
+  // s_g_pc_to_insn.reserve(s_g_pc_to_insn.size() +
+  // MAX_INST_SIZE*m_instructions.size());
+  gpgpu_ctx->s_g_pc_to_insn.reserve(MAX_INST_SIZE * m_instructions.size());
+  for (i = m_instructions.begin(); i != m_instructions.end(); i++) {
+    ptx_instruction *pI = *i;
+    if (pI->is_label()) {
+      const symbol *l = pI->get_label();
+      labels[l->name()] = n;
+    } else {
+      gpgpu_ctx->func_sim->g_pc_to_finfo[PC] = this;
+      m_instr_mem[n] = pI;
+      gpgpu_ctx->s_g_pc_to_insn.push_back(pI);
+      assert(pI == gpgpu_ctx->s_g_pc_to_insn[PC]);
+      pI->set_m_instr_mem_index(n);
+      pI->set_PC(PC);
+      assert(pI->inst_size() <= MAX_INST_SIZE);
+      for (unsigned i = 1; i < pI->inst_size(); i++) {
+        gpgpu_ctx->s_g_pc_to_insn.push_back((ptx_instruction *)NULL);
+        m_instr_mem[n + i] = NULL;
       }
-   }
-   gpgpu_ctx->func_sim->g_assemble_code_next_pc=PC;
-   for ( unsigned ii=0; ii < n; ii += m_instr_mem[ii]->inst_size() ) { // handle branch instructions
-      ptx_instruction *pI = m_instr_mem[ii];
-      if ( pI->get_opcode() == BRA_OP || pI->get_opcode() == BREAKADDR_OP  || pI->get_opcode() == CALLP_OP) {
-         operand_info &target = pI->dst(); //get operand, e.g. target name
-         if ( labels.find(target.name()) == labels.end() ) {
-            printf("GPGPU-Sim PTX: Loader error (%s:%u): Branch label \"%s\" does not appear in assembly code.",
-                   pI->source_file(),pI->source_line(), target.name().c_str() );
-            abort();
-         }
-         unsigned index = labels[ target.name() ]; //determine address from name
-         unsigned PC = m_instr_mem[index]->get_PC();
-         m_symtab->set_label_address( target.get_symbol(), PC );
-         target.set_type(label_t);
+      n += pI->inst_size();
+      PC += pI->inst_size();
+    }
+  }
+  gpgpu_ctx->func_sim->g_assemble_code_next_pc = PC;
+  for (unsigned ii = 0; ii < n;
+       ii += m_instr_mem[ii]->inst_size()) {  // handle branch instructions
+    ptx_instruction *pI = m_instr_mem[ii];
+    if (pI->get_opcode() == BRA_OP || pI->get_opcode() == BREAKADDR_OP ||
+        pI->get_opcode() == CALLP_OP) {
+      operand_info &target = pI->dst();  // get operand, e.g. target name
+      if (labels.find(target.name()) == labels.end()) {
+        printf(
+            "GPGPU-Sim PTX: Loader error (%s:%u): Branch label \"%s\" does not "
+            "appear in assembly code.",
+            pI->source_file(), pI->source_line(), target.name().c_str());
+        abort();
       }
-   }
-   m_n = n;
-   printf("  done.\n");
-   fflush(stdout);
+      unsigned index = labels[target.name()];  // determine address from name
+      unsigned PC = m_instr_mem[index]->get_PC();
+      m_symtab->set_label_address(target.get_symbol(), PC);
+      target.set_type(label_t);
+    }
+  }
+  m_n = n;
+  printf("  done.\n");
+  fflush(stdout);
 
-   //disable pdom analysis  here and do it at runtime
+// disable pdom analysis  here and do it at runtime
 #if 0
    printf("GPGPU-Sim PTX: finding reconvergence points for \'%s\'...\n", m_name.c_str() );
    create_basic_blocks();
@@ -323,2247 +383,2448 @@ void function_info::ptx_assemble()
 #endif
 }
 
-addr_t shared_to_generic( unsigned smid, addr_t addr )
-{
-   assert( addr < SHARED_MEM_SIZE_MAX );
-   return SHARED_GENERIC_START + smid*SHARED_MEM_SIZE_MAX + addr;
+addr_t shared_to_generic(unsigned smid, addr_t addr) {
+  assert(addr < SHARED_MEM_SIZE_MAX);
+  return SHARED_GENERIC_START + smid * SHARED_MEM_SIZE_MAX + addr;
 }
 
-addr_t global_to_generic( addr_t addr )
-{
-   return addr;
+addr_t global_to_generic(addr_t addr) { return addr; }
+
+bool isspace_shared(unsigned smid, addr_t addr) {
+  addr_t start = SHARED_GENERIC_START + smid * SHARED_MEM_SIZE_MAX;
+  addr_t end = SHARED_GENERIC_START + (smid + 1) * SHARED_MEM_SIZE_MAX;
+  if ((addr >= end) || (addr < start)) return false;
+  return true;
 }
 
-bool isspace_shared( unsigned smid, addr_t addr )
-{
-   addr_t start = SHARED_GENERIC_START + smid*SHARED_MEM_SIZE_MAX;
-   addr_t end = SHARED_GENERIC_START + (smid+1)*SHARED_MEM_SIZE_MAX;
-   if( (addr >= end) || (addr < start) ) 
-      return false;
-   return true;
+bool isspace_global(addr_t addr) {
+  return (addr >= GLOBAL_HEAP_START) || (addr < STATIC_ALLOC_LIMIT);
 }
 
-bool isspace_global( addr_t addr )
-{
-   return (addr >= GLOBAL_HEAP_START) || (addr < STATIC_ALLOC_LIMIT);
+memory_space_t whichspace(addr_t addr) {
+  if ((addr >= GLOBAL_HEAP_START) || (addr < STATIC_ALLOC_LIMIT)) {
+    return global_space;
+  } else if (addr >= SHARED_GENERIC_START) {
+    return shared_space;
+  } else {
+    return local_space;
+  }
 }
 
-memory_space_t whichspace( addr_t addr )
-{
-   if( (addr >= GLOBAL_HEAP_START) || (addr < STATIC_ALLOC_LIMIT) ) {
-      return global_space;
-   } else if( addr >= SHARED_GENERIC_START ) {
-      return shared_space;
-   } else {
-      return local_space;
-   }
+addr_t generic_to_shared(unsigned smid, addr_t addr) {
+  assert(isspace_shared(smid, addr));
+  return addr - (SHARED_GENERIC_START + smid * SHARED_MEM_SIZE_MAX);
 }
 
-addr_t generic_to_shared( unsigned smid, addr_t addr )
-{
-   assert(isspace_shared(smid,addr));
-   return addr - (SHARED_GENERIC_START + smid*SHARED_MEM_SIZE_MAX);
+addr_t local_to_generic(unsigned smid, unsigned hwtid, addr_t addr) {
+  assert(addr < LOCAL_MEM_SIZE_MAX);
+  return LOCAL_GENERIC_START + (TOTAL_LOCAL_MEM_PER_SM * smid) +
+         (LOCAL_MEM_SIZE_MAX * hwtid) + addr;
 }
 
-addr_t local_to_generic( unsigned smid, unsigned hwtid, addr_t addr )
-{
-   assert(addr < LOCAL_MEM_SIZE_MAX); 
-   return LOCAL_GENERIC_START + (TOTAL_LOCAL_MEM_PER_SM * smid) + (LOCAL_MEM_SIZE_MAX * hwtid) + addr;
+bool isspace_local(unsigned smid, unsigned hwtid, addr_t addr) {
+  addr_t start = LOCAL_GENERIC_START + (TOTAL_LOCAL_MEM_PER_SM * smid) +
+                 (LOCAL_MEM_SIZE_MAX * hwtid);
+  addr_t end = LOCAL_GENERIC_START + (TOTAL_LOCAL_MEM_PER_SM * smid) +
+               (LOCAL_MEM_SIZE_MAX * (hwtid + 1));
+  if ((addr >= end) || (addr < start)) return false;
+  return true;
 }
 
-bool isspace_local( unsigned smid, unsigned hwtid, addr_t addr )
-{
-   addr_t start = LOCAL_GENERIC_START + (TOTAL_LOCAL_MEM_PER_SM * smid) + (LOCAL_MEM_SIZE_MAX * hwtid);
-   addr_t end   = LOCAL_GENERIC_START + (TOTAL_LOCAL_MEM_PER_SM * smid) + (LOCAL_MEM_SIZE_MAX * (hwtid+1));
-   if( (addr >= end) || (addr < start) ) 
-      return false;
-   return true;
+addr_t generic_to_local(unsigned smid, unsigned hwtid, addr_t addr) {
+  assert(isspace_local(smid, hwtid, addr));
+  return addr - (LOCAL_GENERIC_START + (TOTAL_LOCAL_MEM_PER_SM * smid) +
+                 (LOCAL_MEM_SIZE_MAX * hwtid));
 }
 
-addr_t generic_to_local( unsigned smid, unsigned hwtid, addr_t addr )
-{
-   assert(isspace_local(smid,hwtid,addr));
-   return addr - (LOCAL_GENERIC_START + (TOTAL_LOCAL_MEM_PER_SM * smid) + (LOCAL_MEM_SIZE_MAX * hwtid));
+addr_t generic_to_global(addr_t addr) { return addr; }
+
+void *gpgpu_t::gpu_malloc(size_t size) {
+  unsigned long long result = m_dev_malloc;
+  if (g_debug_execution >= 3) {
+    printf(
+        "GPGPU-Sim PTX: allocating %zu bytes on GPU starting at address "
+        "0x%Lx\n",
+        size, m_dev_malloc);
+    fflush(stdout);
+  }
+  m_dev_malloc += size;
+  if (size % 256)
+    m_dev_malloc += (256 - size % 256);  // align to 256 byte boundaries
+  return (void *)result;
 }
 
-addr_t generic_to_global( addr_t addr )
-{
-   return addr;
+void *gpgpu_t::gpu_mallocarray(size_t size) {
+  unsigned long long result = m_dev_malloc;
+  if (g_debug_execution >= 3) {
+    printf(
+        "GPGPU-Sim PTX: allocating %zu bytes on GPU starting at address "
+        "0x%Lx\n",
+        size, m_dev_malloc);
+    fflush(stdout);
+  }
+  m_dev_malloc += size;
+  if (size % 256)
+    m_dev_malloc += (256 - size % 256);  // align to 256 byte boundaries
+  return (void *)result;
 }
 
+void gpgpu_t::memcpy_to_gpu(size_t dst_start_addr, const void *src,
+                            size_t count) {
+  if (g_debug_execution >= 3) {
+    printf(
+        "GPGPU-Sim PTX: copying %zu bytes from CPU[0x%Lx] to GPU[0x%Lx] ... ",
+        count, (unsigned long long)src, (unsigned long long)dst_start_addr);
+    fflush(stdout);
+  }
+  char *src_data = (char *)src;
+  for (unsigned n = 0; n < count; n++)
+    m_global_mem->write(dst_start_addr + n, 1, src_data + n, NULL, NULL);
 
-void* gpgpu_t::gpu_malloc( size_t size )
-{
-   unsigned long long result = m_dev_malloc;
-   if(g_debug_execution >= 3) {
-      printf("GPGPU-Sim PTX: allocating %zu bytes on GPU starting at address 0x%Lx\n", size, m_dev_malloc );
-      fflush(stdout);
-   }
-   m_dev_malloc += size;
-   if (size%256) m_dev_malloc += (256 - size%256); //align to 256 byte boundaries
-   return(void*) result;
+  // Copy into the performance model.
+  // extern gpgpu_sim* g_the_gpu;
+  gpgpu_ctx->the_gpgpusim->g_the_gpu->perf_memcpy_to_gpu(dst_start_addr, count);
+  if (g_debug_execution >= 3) {
+    printf(" done.\n");
+    fflush(stdout);
+  }
 }
 
-void* gpgpu_t::gpu_mallocarray( size_t size )
-{
-   unsigned long long result = m_dev_malloc;
-   if(g_debug_execution >= 3) {
-      printf("GPGPU-Sim PTX: allocating %zu bytes on GPU starting at address 0x%Lx\n", size, m_dev_malloc );
-      fflush(stdout);
-   }
-   m_dev_malloc += size;
-   if (size%256) m_dev_malloc += (256 - size%256); //align to 256 byte boundaries
-   return(void*) result;
+void gpgpu_t::memcpy_from_gpu(void *dst, size_t src_start_addr, size_t count) {
+  if (g_debug_execution >= 3) {
+    printf("GPGPU-Sim PTX: copying %zu bytes from GPU[0x%Lx] to CPU[0x%Lx] ...",
+           count, (unsigned long long)src_start_addr, (unsigned long long)dst);
+    fflush(stdout);
+  }
+  unsigned char *dst_data = (unsigned char *)dst;
+  for (unsigned n = 0; n < count; n++)
+    m_global_mem->read(src_start_addr + n, 1, dst_data + n);
+
+  // Copy into the performance model.
+  // extern gpgpu_sim* g_the_gpu;
+  gpgpu_ctx->the_gpgpusim->g_the_gpu->perf_memcpy_to_gpu(src_start_addr, count);
+  if (g_debug_execution >= 3) {
+    printf(" done.\n");
+    fflush(stdout);
+  }
 }
 
-
-void gpgpu_t::memcpy_to_gpu( size_t dst_start_addr, const void *src, size_t count )
-{
-   if(g_debug_execution >= 3) {
-      printf("GPGPU-Sim PTX: copying %zu bytes from CPU[0x%Lx] to GPU[0x%Lx] ... ", count, (unsigned long long) src, (unsigned long long) dst_start_addr );
-      fflush(stdout);
-   }
-   char *src_data = (char*)src;
-   for (unsigned n=0; n < count; n ++ ) 
-      m_global_mem->write(dst_start_addr+n,1, src_data+n,NULL,NULL);
-
-   // Copy into the performance model.
-   //extern gpgpu_sim* g_the_gpu;
-   gpgpu_ctx->the_gpgpusim->g_the_gpu->perf_memcpy_to_gpu(dst_start_addr, count);
-   if(g_debug_execution >= 3) {
-      printf( " done.\n");
-      fflush(stdout);
-   }
+void gpgpu_t::memcpy_gpu_to_gpu(size_t dst, size_t src, size_t count) {
+  if (g_debug_execution >= 3) {
+    printf("GPGPU-Sim PTX: copying %zu bytes from GPU[0x%Lx] to GPU[0x%Lx] ...",
+           count, (unsigned long long)src, (unsigned long long)dst);
+    fflush(stdout);
+  }
+  for (unsigned n = 0; n < count; n++) {
+    unsigned char tmp;
+    m_global_mem->read(src + n, 1, &tmp);
+    m_global_mem->write(dst + n, 1, &tmp, NULL, NULL);
+  }
+  if (g_debug_execution >= 3) {
+    printf(" done.\n");
+    fflush(stdout);
+  }
 }
 
-void gpgpu_t::memcpy_from_gpu( void *dst, size_t src_start_addr, size_t count )
-{
-   if(g_debug_execution >= 3) {
-      printf("GPGPU-Sim PTX: copying %zu bytes from GPU[0x%Lx] to CPU[0x%Lx] ...", count, (unsigned long long) src_start_addr, (unsigned long long) dst );
-      fflush(stdout);
-   }
-   unsigned char *dst_data = (unsigned char*)dst;
-   for (unsigned n=0; n < count; n ++ ) 
-      m_global_mem->read(src_start_addr+n,1,dst_data+n);
-
-   // Copy into the performance model.
-   //extern gpgpu_sim* g_the_gpu;
-   gpgpu_ctx->the_gpgpusim->g_the_gpu->perf_memcpy_to_gpu(src_start_addr, count);
-   if(g_debug_execution >= 3) {
-      printf( " done.\n");
-      fflush(stdout);
-   }
+void gpgpu_t::gpu_memset(size_t dst_start_addr, int c, size_t count) {
+  if (g_debug_execution >= 3) {
+    printf(
+        "GPGPU-Sim PTX: setting %zu bytes of memory to 0x%x starting at "
+        "0x%Lx... ",
+        count, (unsigned char)c, (unsigned long long)dst_start_addr);
+    fflush(stdout);
+  }
+  unsigned char c_value = (unsigned char)c;
+  for (unsigned n = 0; n < count; n++)
+    m_global_mem->write(dst_start_addr + n, 1, &c_value, NULL, NULL);
+  if (g_debug_execution >= 3) {
+    printf(" done.\n");
+    fflush(stdout);
+  }
 }
 
-void gpgpu_t::memcpy_gpu_to_gpu( size_t dst, size_t src, size_t count )
-{
-   if(g_debug_execution >= 3) {
-      printf("GPGPU-Sim PTX: copying %zu bytes from GPU[0x%Lx] to GPU[0x%Lx] ...", count,
-          (unsigned long long) src, (unsigned long long) dst );
-      fflush(stdout);
-   }
-   for (unsigned n=0; n < count; n ++ ) {
-      unsigned char tmp;
-      m_global_mem->read(src+n,1,&tmp); 
-      m_global_mem->write(dst+n,1, &tmp,NULL,NULL);
-   }
-   if(g_debug_execution >= 3) {
-      printf( " done.\n");
-      fflush(stdout);
-   }
+void cuda_sim::ptx_print_insn(address_type pc, FILE *fp) {
+  std::map<unsigned, function_info *>::iterator f = g_pc_to_finfo.find(pc);
+  if (f == g_pc_to_finfo.end()) {
+    fprintf(fp, "<no instruction at address 0x%x>", pc);
+    return;
+  }
+  function_info *finfo = f->second;
+  assert(finfo);
+  finfo->print_insn(pc, fp);
 }
 
-void gpgpu_t::gpu_memset( size_t dst_start_addr, int c, size_t count )
-{
-   if(g_debug_execution >= 3) {
-      printf("GPGPU-Sim PTX: setting %zu bytes of memory to 0x%x starting at 0x%Lx... ",
-          count, (unsigned char) c, (unsigned long long) dst_start_addr );
-      fflush(stdout);
-   }
-   unsigned char c_value = (unsigned char)c;
-   for (unsigned n=0; n < count; n ++ ) 
-      m_global_mem->write(dst_start_addr+n,1,&c_value,NULL,NULL);
-   if(g_debug_execution >= 3) {
-      printf( " done.\n");
-      fflush(stdout);
-   }
+std::string cuda_sim::ptx_get_insn_str(address_type pc) {
+  std::map<unsigned, function_info *>::iterator f = g_pc_to_finfo.find(pc);
+  if (f == g_pc_to_finfo.end()) {
+#define STR_SIZE 255
+    char buff[STR_SIZE];
+    buff[STR_SIZE - 1] = '\0';
+    snprintf(buff, STR_SIZE, "<no instruction at address 0x%x>", pc);
+    return std::string(buff);
+  }
+  function_info *finfo = f->second;
+  assert(finfo);
+  return finfo->get_insn_str(pc);
 }
 
-void cuda_sim::ptx_print_insn( address_type pc, FILE *fp )
-{
-   std::map<unsigned,function_info*>::iterator f = g_pc_to_finfo.find(pc);
-   if( f == g_pc_to_finfo.end() ) {
-       fprintf(fp,"<no instruction at address 0x%x>", pc );
-       return;
-   }
-   function_info *finfo = f->second;
-   assert( finfo );
-   finfo->print_insn(pc,fp);
+void ptx_instruction::set_fp_or_int_archop() {
+  oprnd_type = UN_OP;
+  if ((m_opcode == MEMBAR_OP) || (m_opcode == SSY_OP) || (m_opcode == BRA_OP) ||
+      (m_opcode == BAR_OP) || (m_opcode == RET_OP) || (m_opcode == RETP_OP) ||
+      (m_opcode == NOP_OP) || (m_opcode == EXIT_OP) || (m_opcode == CALLP_OP) ||
+      (m_opcode == CALL_OP)) {
+    // do nothing
+  } else if ((m_opcode == CVT_OP || m_opcode == SET_OP ||
+              m_opcode == SLCT_OP)) {
+    if (get_type2() == F16_TYPE || get_type2() == F32_TYPE ||
+        get_type2() == F64_TYPE || get_type2() == FF64_TYPE) {
+      oprnd_type = FP_OP;
+    } else
+      oprnd_type = INT_OP;
+
+  } else {
+    if (get_type() == F16_TYPE || get_type() == F32_TYPE ||
+        get_type() == F64_TYPE || get_type() == FF64_TYPE) {
+      oprnd_type = FP_OP;
+    } else
+      oprnd_type = INT_OP;
+  }
+}
+void ptx_instruction::set_mul_div_or_other_archop() {
+  sp_op = OTHER_OP;
+  if ((m_opcode != MEMBAR_OP) && (m_opcode != SSY_OP) && (m_opcode != BRA_OP) &&
+      (m_opcode != BAR_OP) && (m_opcode != EXIT_OP) && (m_opcode != NOP_OP) &&
+      (m_opcode != RETP_OP) && (m_opcode != RET_OP) && (m_opcode != CALLP_OP) &&
+      (m_opcode != CALL_OP)) {
+    if (get_type() == F32_TYPE || get_type() == F64_TYPE ||
+        get_type() == FF64_TYPE) {
+      switch (get_opcode()) {
+        case MUL_OP:
+        case MAD_OP:
+          sp_op = FP_MUL_OP;
+          break;
+        case DIV_OP:
+          sp_op = FP_DIV_OP;
+          break;
+        case LG2_OP:
+          sp_op = FP_LG_OP;
+          break;
+        case RSQRT_OP:
+        case SQRT_OP:
+          sp_op = FP_SQRT_OP;
+          break;
+        case RCP_OP:
+          sp_op = FP_DIV_OP;
+          break;
+        case SIN_OP:
+        case COS_OP:
+          sp_op = FP_SIN_OP;
+          break;
+        case EX2_OP:
+          sp_op = FP_EXP_OP;
+          break;
+        default:
+          if ((op == ALU_OP) || (op == TENSOR_CORE_OP)) sp_op = FP__OP;
+          break;
+      }
+    } else {
+      switch (get_opcode()) {
+        case MUL24_OP:
+        case MAD24_OP:
+          sp_op = INT_MUL24_OP;
+          break;
+        case MUL_OP:
+        case MAD_OP:
+          if (get_type() == U32_TYPE || get_type() == S32_TYPE ||
+              get_type() == B32_TYPE)
+            sp_op = INT_MUL32_OP;
+          else
+            sp_op = INT_MUL_OP;
+          break;
+        case DIV_OP:
+          sp_op = INT_DIV_OP;
+          break;
+        default:
+          if ((op == ALU_OP)) sp_op = INT__OP;
+          break;
+      }
+    }
+  }
 }
 
-std::string cuda_sim::ptx_get_insn_str( address_type pc )
-{
-   std::map<unsigned,function_info*>::iterator f = g_pc_to_finfo.find(pc);
-   if( f == g_pc_to_finfo.end() ) {
-       #define STR_SIZE 255
-       char buff[STR_SIZE];
-       buff[STR_SIZE - 1] = '\0';
-       snprintf(buff, STR_SIZE,"<no instruction at address 0x%x>", pc );
-       return std::string(buff);
-   }
-   function_info *finfo = f->second;
-   assert( finfo );
-   return finfo->get_insn_str(pc);
+void ptx_instruction::set_bar_type() {
+  if (m_opcode == BAR_OP) {
+    switch (m_barrier_op) {
+      case SYNC_OPTION:
+        bar_type = SYNC;
+        break;
+      case ARRIVE_OPTION:
+        bar_type = ARRIVE;
+        break;
+      case RED_OPTION:
+        bar_type = RED;
+        switch (m_atomic_spec) {
+          case ATOMIC_POPC:
+            red_type = POPC_RED;
+            break;
+          case ATOMIC_AND:
+            red_type = AND_RED;
+            break;
+          case ATOMIC_OR:
+            red_type = OR_RED;
+            break;
+        }
+        break;
+      default:
+        abort();
+    }
+  } else if (m_opcode == SST_OP) {
+    bar_type = SYNC;
+  }
 }
 
-void ptx_instruction::set_fp_or_int_archop(){
-    oprnd_type=UN_OP;
-	if((m_opcode == MEMBAR_OP)||(m_opcode == SSY_OP )||(m_opcode == BRA_OP) || (m_opcode == BAR_OP) || (m_opcode == RET_OP) || (m_opcode == RETP_OP) || (m_opcode == NOP_OP) || (m_opcode == EXIT_OP) || (m_opcode == CALLP_OP) || (m_opcode == CALL_OP)){
-			// do nothing
-	}else if((m_opcode == CVT_OP || m_opcode == SET_OP || m_opcode == SLCT_OP)){
-		if(get_type2()==F16_TYPE || get_type2()==F32_TYPE || get_type2() == F64_TYPE || get_type2() == FF64_TYPE){
-		    oprnd_type= FP_OP;
-		}else oprnd_type=INT_OP;
+void ptx_instruction::set_opcode_and_latency() {
+  unsigned int_latency[5];
+  unsigned fp_latency[5];
+  unsigned dp_latency[5];
+  unsigned sfu_latency;
+  unsigned tensor_latency;
+  unsigned int_init[5];
+  unsigned fp_init[5];
+  unsigned dp_init[5];
+  unsigned sfu_init;
+  unsigned tensor_init;
+  /*
+   * [0] ADD,SUB
+   * [1] MAX,Min
+   * [2] MUL
+   * [3] MAD
+   * [4] DIV
+   */
+  sscanf(gpgpu_ctx->func_sim->opcode_latency_int, "%u,%u,%u,%u,%u",
+         &int_latency[0], &int_latency[1], &int_latency[2], &int_latency[3],
+         &int_latency[4]);
+  sscanf(gpgpu_ctx->func_sim->opcode_latency_fp, "%u,%u,%u,%u,%u",
+         &fp_latency[0], &fp_latency[1], &fp_latency[2], &fp_latency[3],
+         &fp_latency[4]);
+  sscanf(gpgpu_ctx->func_sim->opcode_latency_dp, "%u,%u,%u,%u,%u",
+         &dp_latency[0], &dp_latency[1], &dp_latency[2], &dp_latency[3],
+         &dp_latency[4]);
+  sscanf(gpgpu_ctx->func_sim->opcode_latency_sfu, "%u", &sfu_latency);
+  sscanf(gpgpu_ctx->func_sim->opcode_latency_tensor, "%u", &tensor_latency);
+  sscanf(gpgpu_ctx->func_sim->opcode_initiation_int, "%u,%u,%u,%u,%u",
+         &int_init[0], &int_init[1], &int_init[2], &int_init[3], &int_init[4]);
+  sscanf(gpgpu_ctx->func_sim->opcode_initiation_fp, "%u,%u,%u,%u,%u",
+         &fp_init[0], &fp_init[1], &fp_init[2], &fp_init[3], &fp_init[4]);
+  sscanf(gpgpu_ctx->func_sim->opcode_initiation_dp, "%u,%u,%u,%u,%u",
+         &dp_init[0], &dp_init[1], &dp_init[2], &dp_init[3], &dp_init[4]);
+  sscanf(gpgpu_ctx->func_sim->opcode_initiation_sfu, "%u", &sfu_init);
+  sscanf(gpgpu_ctx->func_sim->opcode_initiation_tensor, "%u", &tensor_init);
+  sscanf(gpgpu_ctx->func_sim->cdp_latency_str, "%u,%u,%u,%u,%u",
+         &gpgpu_ctx->func_sim->cdp_latency[0],
+         &gpgpu_ctx->func_sim->cdp_latency[1],
+         &gpgpu_ctx->func_sim->cdp_latency[2],
+         &gpgpu_ctx->func_sim->cdp_latency[3],
+         &gpgpu_ctx->func_sim->cdp_latency[4]);
 
-	}else{
-		if(get_type()==F16_TYPE || get_type()==F32_TYPE || get_type() == F64_TYPE || get_type() == FF64_TYPE){
-		    oprnd_type= FP_OP;
-		}else oprnd_type=INT_OP;
-	}
-}
-void ptx_instruction::set_mul_div_or_other_archop(){
-    sp_op=OTHER_OP;
-	if((m_opcode != MEMBAR_OP) && (m_opcode != SSY_OP) && (m_opcode != BRA_OP) && (m_opcode != BAR_OP) && (m_opcode != EXIT_OP) && (m_opcode != NOP_OP) && (m_opcode != RETP_OP) && (m_opcode != RET_OP) && (m_opcode != CALLP_OP) && (m_opcode != CALL_OP)){
-		if(get_type()==F32_TYPE || get_type() == F64_TYPE || get_type() == FF64_TYPE){
-			switch(get_opcode()){
-				case MUL_OP:
-				case MAD_OP:
-				    sp_op=FP_MUL_OP;
-					break;
-				case DIV_OP:
-				    sp_op=FP_DIV_OP;
-					break;
-				case LG2_OP:
-				    sp_op=FP_LG_OP;
-					break;
-				case RSQRT_OP:
-				case SQRT_OP:
-				    sp_op=FP_SQRT_OP;
-					break;
-				case RCP_OP:
-				    sp_op=FP_DIV_OP;
-					break;
-				case SIN_OP:
-				case COS_OP:
-				    sp_op=FP_SIN_OP;
-					break;
-				case EX2_OP:
-				    sp_op=FP_EXP_OP;
-					break;
-				default:
-					if((op==ALU_OP)||(op==TENSOR_CORE_OP))
-					    sp_op=FP__OP;
-					break;
-
-			}
-		}else {
-			switch(get_opcode()){
-				case MUL24_OP:
-				case MAD24_OP:
-				    sp_op=INT_MUL24_OP;
-				break;
-				case MUL_OP:
-				case MAD_OP:
-					if(get_type()==U32_TYPE || get_type()==S32_TYPE || get_type()==B32_TYPE)
-					    sp_op=INT_MUL32_OP;
-					else
-					    sp_op=INT_MUL_OP;
-				break;
-				case DIV_OP:
-				    sp_op=INT_DIV_OP;
-				break;
-				default:
-					if((op==ALU_OP))
-					    sp_op=INT__OP;
-					break;
-			}
-		}
-	}
-
-}
-
-
-
-void ptx_instruction::set_bar_type()
-{
-	   if(m_opcode==BAR_OP) {
-		   switch(m_barrier_op){
-		   	   case SYNC_OPTION:
-		   		   bar_type = SYNC;
-		   		   break;
-		   	   case ARRIVE_OPTION:
-		   		   bar_type = ARRIVE;
-		   		   break;
-		   	   case RED_OPTION:
-		   		   bar_type = RED;
-		   		   switch(m_atomic_spec){
-		   		   	   case ATOMIC_POPC:
-				   		   red_type = POPC_RED;
-				   		   break;
-		   		   	   case ATOMIC_AND:
-				   		   red_type = AND_RED;
-				   		   break;
-		   		   	   case ATOMIC_OR:
-				   		   red_type = OR_RED;
-				   		   break;
-		   		   }
-		   		break;
-		   	   default:
-		   		   abort();
-		   }
-	   }
-	   else if(m_opcode==SST_OP) {
-		   bar_type = SYNC;
-	   }
-}
-
-
-void ptx_instruction::set_opcode_and_latency()
-{
-	unsigned int_latency[5];
-	unsigned fp_latency[5];
-	unsigned dp_latency[5];
-	unsigned sfu_latency;
-	unsigned tensor_latency;
-	unsigned int_init[5];
-	unsigned fp_init[5];
-	unsigned dp_init[5];
-	unsigned sfu_init;
-	unsigned tensor_init;
-	/*
-	 * [0] ADD,SUB
-	 * [1] MAX,Min
-	 * [2] MUL
-	 * [3] MAD
-	 * [4] DIV
-	 */
-	sscanf(gpgpu_ctx->func_sim->opcode_latency_int, "%u,%u,%u,%u,%u",
-			&int_latency[0],&int_latency[1],&int_latency[2],
-			&int_latency[3],&int_latency[4]);
-	sscanf(gpgpu_ctx->func_sim->opcode_latency_fp, "%u,%u,%u,%u,%u",
-			&fp_latency[0],&fp_latency[1],&fp_latency[2],
-			&fp_latency[3],&fp_latency[4]);
-	sscanf(gpgpu_ctx->func_sim->opcode_latency_dp, "%u,%u,%u,%u,%u",
-			&dp_latency[0],&dp_latency[1],&dp_latency[2],
-			&dp_latency[3],&dp_latency[4]);
-	sscanf(gpgpu_ctx->func_sim->opcode_latency_sfu, "%u",
-			&sfu_latency);
-	sscanf(gpgpu_ctx->func_sim->opcode_latency_tensor, "%u",
-			&tensor_latency);
-	sscanf(gpgpu_ctx->func_sim->opcode_initiation_int, "%u,%u,%u,%u,%u",
-			&int_init[0],&int_init[1],&int_init[2],
-			&int_init[3],&int_init[4]);
-	sscanf(gpgpu_ctx->func_sim->opcode_initiation_fp, "%u,%u,%u,%u,%u",
-			&fp_init[0],&fp_init[1],&fp_init[2],
-			&fp_init[3],&fp_init[4]);
-	sscanf(gpgpu_ctx->func_sim->opcode_initiation_dp, "%u,%u,%u,%u,%u",
-			&dp_init[0],&dp_init[1],&dp_init[2],
-			&dp_init[3],&dp_init[4]);
-	sscanf(gpgpu_ctx->func_sim->opcode_initiation_sfu, "%u",
-			&sfu_init);
-	sscanf(gpgpu_ctx->func_sim->opcode_initiation_tensor, "%u",
-			&tensor_init);
-	sscanf(gpgpu_ctx->func_sim->cdp_latency_str, "%u,%u,%u,%u,%u",
-			&gpgpu_ctx->func_sim->cdp_latency[0],
-			&gpgpu_ctx->func_sim->cdp_latency[1],
-			&gpgpu_ctx->func_sim->cdp_latency[2],
-			&gpgpu_ctx->func_sim->cdp_latency[3],
-			&gpgpu_ctx->func_sim->cdp_latency[4]);
-
-	if(!m_operands.empty()){
-		std::vector<operand_info>::iterator it;
-	   	for(it=++m_operands.begin();it!=m_operands.end();it++){
-	   		num_operands++;
-	   		if((it->is_reg() || it->is_vector())){
-	   			   num_regs++;
-	   		}
-	   	 }
-	}
-   op = ALU_OP;
-   mem_op= NOT_TEX;
-   initiation_interval = latency = 1;
-   switch( m_opcode ) {
-   case MOV_OP:
-       assert( !(has_memory_read() && has_memory_write()) );
-       if ( has_memory_read() ) op = LOAD_OP;
-       if ( has_memory_write() ) op = STORE_OP;
-       break;
-   case LD_OP: op = LOAD_OP; break;
-   case MMA_LD_OP: op = TENSOR_CORE_LOAD_OP; break;
-   case LDU_OP: op = LOAD_OP; break;
-   case ST_OP: op = STORE_OP; break;
-   case MMA_ST_OP: op = TENSOR_CORE_STORE_OP; break;
-   case BRA_OP: op = BRANCH_OP; break;
-   case BREAKADDR_OP: op = BRANCH_OP; break;
-   case TEX_OP: op = LOAD_OP; mem_op=TEX; break;
-   case ATOM_OP: op = LOAD_OP; break;
-   case BAR_OP: op = BARRIER_OP; break;
-   case SST_OP: op = BARRIER_OP; break;
-   case MEMBAR_OP: op = MEMORY_BARRIER_OP; break;
-   case CALL_OP:
-   {
-       if(m_is_printf || m_is_cdp) {
-           op = ALU_OP;
-       }
-       else
-           op = CALL_OPS;
-       break;
-   }
-   case CALLP_OP:
-   {
-       if(m_is_printf || m_is_cdp) {
-               op = ALU_OP;
-       }
-       else
-           op = CALL_OPS;
-       break;
-   }
-   case RET_OP: case RETP_OP:  op = RET_OPS;break;
-   case ADD_OP: case ADDP_OP: case ADDC_OP: case SUB_OP: case SUBC_OP:
-	   //ADD,SUB latency
-	   switch(get_type()){
-	   case F32_TYPE:
-		   latency = fp_latency[0];
-		   initiation_interval = fp_init[0];
-		   op = SP_OP;
-		   break;
-	   case F64_TYPE:
-	   case FF64_TYPE:
-		   latency = dp_latency[0];
-		   initiation_interval = dp_init[0];
-		   op = DP_OP;
-		   break;
-	   case B32_TYPE:
-	   case U32_TYPE:
-	   case S32_TYPE:
-	   default: //Use int settings for default
-		   latency = int_latency[0];
-		   initiation_interval = int_init[0];
-		   op = INTP_OP;
-		   break;
-	   }
-	   break;
-   case MAX_OP: case MIN_OP:
-	   //MAX,MIN latency
-	   switch(get_type()){
-	   case F32_TYPE:
-		   latency = fp_latency[1];
-		   initiation_interval = fp_init[1];
-		   op = SP_OP;
-		   break;
-	   case F64_TYPE:
-	   case FF64_TYPE:
-		   latency = dp_latency[1];
-		   initiation_interval = dp_init[1];
-		   op = DP_OP;
-		   break;
-	   case B32_TYPE:
-	   case U32_TYPE:
-	   case S32_TYPE:
-	   default: //Use int settings for default
-		   latency = int_latency[1];
-		   initiation_interval = int_init[1];
-		   op = INTP_OP;
-		   break;
-	   }
-	   break;
-   case MUL_OP:
-	   //MUL latency
-	   switch(get_type()){
-	   case F32_TYPE:
-		   latency = fp_latency[2];
-		   initiation_interval = fp_init[2];
-		   op = SP_OP;
-		   break;
-	   case F64_TYPE:
-	   case FF64_TYPE:
-		   latency = dp_latency[2];
-		   initiation_interval = dp_init[2];
-		   op = DP_OP;
-		   break;
-	   case B32_TYPE:
-	   case U32_TYPE:
-	   case S32_TYPE:
-	   default: //Use int settings for default
-		   latency = int_latency[2];
-		   initiation_interval = int_init[2];
-		   op = INTP_OP;
-		   break;
-	   }
-	   break;
-   case MAD_OP: case MADC_OP: case MADP_OP:
-	   //MAD latency
-	   switch(get_type()){
-	   case F32_TYPE:
-		   latency = fp_latency[3];
-		   initiation_interval = fp_init[3];
-		   op = SP_OP;
-		   break;
-	   case F64_TYPE:
-	   case FF64_TYPE:
-		   latency = dp_latency[3];
-		   initiation_interval = dp_init[3];
-		   op = DP_OP;
-		   break;
-	   case B32_TYPE:
-	   case U32_TYPE:
-	   case S32_TYPE:
-	   default: //Use int settings for default
-		   latency = int_latency[3];
-		   initiation_interval = int_init[3];
-		   op = INTP_OP;
-		   break;
-	   }
-	   break;
-   case DIV_OP:
-	   // Floating point only
-	   op = SFU_OP;
-	   switch(get_type()){
-	   case F32_TYPE:
-		   latency = fp_latency[4];
-		   initiation_interval = fp_init[4];
-		   break;
-	   case F64_TYPE:
-	   case FF64_TYPE:
-		   latency = dp_latency[4];
-		   initiation_interval = dp_init[4];
-		   break;
-	   case B32_TYPE:
-	   case U32_TYPE:
-	   case S32_TYPE:
-	   default: //Use int settings for default
-		   latency = int_latency[4];
-		   initiation_interval = int_init[4];
-		   break;
-	   }
-	   break;
-   case SQRT_OP: case SIN_OP: case COS_OP: case EX2_OP: case LG2_OP: case RSQRT_OP: case RCP_OP:
-	  latency = sfu_latency;
-	  initiation_interval = sfu_init;
+  if (!m_operands.empty()) {
+    std::vector<operand_info>::iterator it;
+    for (it = ++m_operands.begin(); it != m_operands.end(); it++) {
+      num_operands++;
+      if ((it->is_reg() || it->is_vector())) {
+        num_regs++;
+      }
+    }
+  }
+  op = ALU_OP;
+  mem_op = NOT_TEX;
+  initiation_interval = latency = 1;
+  switch (m_opcode) {
+    case MOV_OP:
+      assert(!(has_memory_read() && has_memory_write()));
+      if (has_memory_read()) op = LOAD_OP;
+      if (has_memory_write()) op = STORE_OP;
+      break;
+    case LD_OP:
+      op = LOAD_OP;
+      break;
+    case MMA_LD_OP:
+      op = TENSOR_CORE_LOAD_OP;
+      break;
+    case LDU_OP:
+      op = LOAD_OP;
+      break;
+    case ST_OP:
+      op = STORE_OP;
+      break;
+    case MMA_ST_OP:
+      op = TENSOR_CORE_STORE_OP;
+      break;
+    case BRA_OP:
+      op = BRANCH_OP;
+      break;
+    case BREAKADDR_OP:
+      op = BRANCH_OP;
+      break;
+    case TEX_OP:
+      op = LOAD_OP;
+      mem_op = TEX;
+      break;
+    case ATOM_OP:
+      op = LOAD_OP;
+      break;
+    case BAR_OP:
+      op = BARRIER_OP;
+      break;
+    case SST_OP:
+      op = BARRIER_OP;
+      break;
+    case MEMBAR_OP:
+      op = MEMORY_BARRIER_OP;
+      break;
+    case CALL_OP: {
+      if (m_is_printf || m_is_cdp) {
+        op = ALU_OP;
+      } else
+        op = CALL_OPS;
+      break;
+    }
+    case CALLP_OP: {
+      if (m_is_printf || m_is_cdp) {
+        op = ALU_OP;
+      } else
+        op = CALL_OPS;
+      break;
+    }
+    case RET_OP:
+    case RETP_OP:
+      op = RET_OPS;
+      break;
+    case ADD_OP:
+    case ADDP_OP:
+    case ADDC_OP:
+    case SUB_OP:
+    case SUBC_OP:
+      // ADD,SUB latency
+      switch (get_type()) {
+        case F32_TYPE:
+          latency = fp_latency[0];
+          initiation_interval = fp_init[0];
+          op = SP_OP;
+          break;
+        case F64_TYPE:
+        case FF64_TYPE:
+          latency = dp_latency[0];
+          initiation_interval = dp_init[0];
+          op = DP_OP;
+          break;
+        case B32_TYPE:
+        case U32_TYPE:
+        case S32_TYPE:
+        default:  // Use int settings for default
+          latency = int_latency[0];
+          initiation_interval = int_init[0];
+          op = INTP_OP;
+          break;
+      }
+      break;
+    case MAX_OP:
+    case MIN_OP:
+      // MAX,MIN latency
+      switch (get_type()) {
+        case F32_TYPE:
+          latency = fp_latency[1];
+          initiation_interval = fp_init[1];
+          op = SP_OP;
+          break;
+        case F64_TYPE:
+        case FF64_TYPE:
+          latency = dp_latency[1];
+          initiation_interval = dp_init[1];
+          op = DP_OP;
+          break;
+        case B32_TYPE:
+        case U32_TYPE:
+        case S32_TYPE:
+        default:  // Use int settings for default
+          latency = int_latency[1];
+          initiation_interval = int_init[1];
+          op = INTP_OP;
+          break;
+      }
+      break;
+    case MUL_OP:
+      // MUL latency
+      switch (get_type()) {
+        case F32_TYPE:
+          latency = fp_latency[2];
+          initiation_interval = fp_init[2];
+          op = SP_OP;
+          break;
+        case F64_TYPE:
+        case FF64_TYPE:
+          latency = dp_latency[2];
+          initiation_interval = dp_init[2];
+          op = DP_OP;
+          break;
+        case B32_TYPE:
+        case U32_TYPE:
+        case S32_TYPE:
+        default:  // Use int settings for default
+          latency = int_latency[2];
+          initiation_interval = int_init[2];
+          op = INTP_OP;
+          break;
+      }
+      break;
+    case MAD_OP:
+    case MADC_OP:
+    case MADP_OP:
+      // MAD latency
+      switch (get_type()) {
+        case F32_TYPE:
+          latency = fp_latency[3];
+          initiation_interval = fp_init[3];
+          op = SP_OP;
+          break;
+        case F64_TYPE:
+        case FF64_TYPE:
+          latency = dp_latency[3];
+          initiation_interval = dp_init[3];
+          op = DP_OP;
+          break;
+        case B32_TYPE:
+        case U32_TYPE:
+        case S32_TYPE:
+        default:  // Use int settings for default
+          latency = int_latency[3];
+          initiation_interval = int_init[3];
+          op = INTP_OP;
+          break;
+      }
+      break;
+    case DIV_OP:
+      // Floating point only
+      op = SFU_OP;
+      switch (get_type()) {
+        case F32_TYPE:
+          latency = fp_latency[4];
+          initiation_interval = fp_init[4];
+          break;
+        case F64_TYPE:
+        case FF64_TYPE:
+          latency = dp_latency[4];
+          initiation_interval = dp_init[4];
+          break;
+        case B32_TYPE:
+        case U32_TYPE:
+        case S32_TYPE:
+        default:  // Use int settings for default
+          latency = int_latency[4];
+          initiation_interval = int_init[4];
+          break;
+      }
+      break;
+    case SQRT_OP:
+    case SIN_OP:
+    case COS_OP:
+    case EX2_OP:
+    case LG2_OP:
+    case RSQRT_OP:
+    case RCP_OP:
+      latency = sfu_latency;
+      initiation_interval = sfu_init;
       op = SFU_OP;
       break;
-   case MMA_OP:
-	   latency = tensor_latency;
-	   initiation_interval = tensor_init;
-       op=TENSOR_CORE_OP;
-	   break;
-   case SHFL_OP:
-	   latency = 4;
-	   initiation_interval = 4;
-	   break;
-   default: 
-       break;
-   }
-	set_fp_or_int_archop();
-	set_mul_div_or_other_archop();
-
+    case MMA_OP:
+      latency = tensor_latency;
+      initiation_interval = tensor_init;
+      op = TENSOR_CORE_OP;
+      break;
+    case SHFL_OP:
+      latency = 4;
+      initiation_interval = 4;
+      break;
+    default:
+      break;
+  }
+  set_fp_or_int_archop();
+  set_mul_div_or_other_archop();
 }
 
-void ptx_thread_info::ptx_fetch_inst( inst_t &inst ) const
-{
-   addr_t pc = get_pc();
-   const ptx_instruction *pI = m_func_info->get_instruction(pc);
-   inst = (const inst_t&)*pI;
-   assert( inst.valid() );
+void ptx_thread_info::ptx_fetch_inst(inst_t &inst) const {
+  addr_t pc = get_pc();
+  const ptx_instruction *pI = m_func_info->get_instruction(pc);
+  inst = (const inst_t &)*pI;
+  assert(inst.valid());
 }
 
-static unsigned datatype2size( unsigned data_type )
-{
-   unsigned data_size;
-   switch ( data_type ) {
-      case B8_TYPE:
-      case S8_TYPE:
-      case U8_TYPE: 
-         data_size = 1; break;
-      case B16_TYPE:
-      case S16_TYPE:
-      case U16_TYPE:
-      case F16_TYPE: 
-         data_size = 2; break;
-      case B32_TYPE:
-      case S32_TYPE:
-      case U32_TYPE:
-      case F32_TYPE: 
-         data_size = 4; break;
-      case B64_TYPE:
-      case BB64_TYPE:
-      case S64_TYPE:
-      case U64_TYPE:
-      case F64_TYPE: 
-      case FF64_TYPE:
-         data_size = 8; break;
-      case BB128_TYPE: 
-         data_size = 16; break;
-      default: assert(0); break;
-   }
-   return data_size; 
+static unsigned datatype2size(unsigned data_type) {
+  unsigned data_size;
+  switch (data_type) {
+    case B8_TYPE:
+    case S8_TYPE:
+    case U8_TYPE:
+      data_size = 1;
+      break;
+    case B16_TYPE:
+    case S16_TYPE:
+    case U16_TYPE:
+    case F16_TYPE:
+      data_size = 2;
+      break;
+    case B32_TYPE:
+    case S32_TYPE:
+    case U32_TYPE:
+    case F32_TYPE:
+      data_size = 4;
+      break;
+    case B64_TYPE:
+    case BB64_TYPE:
+    case S64_TYPE:
+    case U64_TYPE:
+    case F64_TYPE:
+    case FF64_TYPE:
+      data_size = 8;
+      break;
+    case BB128_TYPE:
+      data_size = 16;
+      break;
+    default:
+      assert(0);
+      break;
+  }
+  return data_size;
 }
 
-void ptx_instruction::pre_decode()
-{
-   pc = m_PC;
-   isize = m_inst_size;
-   for(unsigned i=0; i<MAX_OUTPUT_VALUES; i++) {
-       out[i] = 0;
-   }
-   for(unsigned i=0; i<MAX_INPUT_VALUES; i++) {
-       in[i] = 0;
-   }
-   incount=0;
-   outcount=0;
-   is_vectorin = 0;
-   is_vectorout = 0;
-   std::fill_n(arch_reg.src, MAX_REG_OPERANDS, -1);
-   std::fill_n(arch_reg.dst, MAX_REG_OPERANDS, -1);
-   pred = 0;
-   ar1 = 0;
-   ar2 = 0;
-   space = m_space_spec;
-   memory_op = no_memory_op;
-   data_size = 0;
-   if ( has_memory_read() || has_memory_write() ) {
-      unsigned to_type = get_type();
-      data_size = datatype2size(to_type);
-      memory_op = has_memory_read() ? memory_load : memory_store;
-   }
+void ptx_instruction::pre_decode() {
+  pc = m_PC;
+  isize = m_inst_size;
+  for (unsigned i = 0; i < MAX_OUTPUT_VALUES; i++) {
+    out[i] = 0;
+  }
+  for (unsigned i = 0; i < MAX_INPUT_VALUES; i++) {
+    in[i] = 0;
+  }
+  incount = 0;
+  outcount = 0;
+  is_vectorin = 0;
+  is_vectorout = 0;
+  std::fill_n(arch_reg.src, MAX_REG_OPERANDS, -1);
+  std::fill_n(arch_reg.dst, MAX_REG_OPERANDS, -1);
+  pred = 0;
+  ar1 = 0;
+  ar2 = 0;
+  space = m_space_spec;
+  memory_op = no_memory_op;
+  data_size = 0;
+  if (has_memory_read() || has_memory_write()) {
+    unsigned to_type = get_type();
+    data_size = datatype2size(to_type);
+    memory_op = has_memory_read() ? memory_load : memory_store;
+  }
 
-   bool has_dst = false ;
+  bool has_dst = false;
 
-   switch ( get_opcode() ) {
-#define OP_DEF(OP,FUNC,STR,DST,CLASSIFICATION) case OP: has_dst = (DST!=0); break;
-#define OP_W_DEF(OP,FUNC,STR,DST,CLASSIFICATION) case OP: has_dst = (DST!=0); break;
+  switch (get_opcode()) {
+#define OP_DEF(OP, FUNC, STR, DST, CLASSIFICATION) \
+  case OP:                                         \
+    has_dst = (DST != 0);                          \
+    break;
+#define OP_W_DEF(OP, FUNC, STR, DST, CLASSIFICATION) \
+  case OP:                                           \
+    has_dst = (DST != 0);                            \
+    break;
 #include "opcodes.def"
 #undef OP_DEF
 #undef OP_W_DEF
-   default:
-      printf( "Execution error: Invalid opcode (0x%x)\n", get_opcode() );
+    default:
+      printf("Execution error: Invalid opcode (0x%x)\n", get_opcode());
       break;
-   }
+  }
 
-   switch( m_cache_option ) {
-   case CA_OPTION: cache_op = CACHE_ALL; break;
-   case NC_OPTION: cache_op = CACHE_L1; break;
-   case CG_OPTION: cache_op = CACHE_GLOBAL; break;
-   case CS_OPTION: cache_op = CACHE_STREAMING; break;
-   case LU_OPTION: cache_op = CACHE_LAST_USE; break;
-   case CV_OPTION: cache_op = CACHE_VOLATILE; break;
-   case WB_OPTION: cache_op = CACHE_WRITE_BACK; break;
-   case WT_OPTION: cache_op = CACHE_WRITE_THROUGH; break;
-   default: 
-      //if( m_opcode == LD_OP || m_opcode == LDU_OP ) 
-      if(  m_opcode == MMA_LD_OP || m_opcode == LD_OP || m_opcode == LDU_OP ) 
-         cache_op = CACHE_ALL;
-      //else if( m_opcode == ST_OP ) 
-      else if( m_opcode == MMA_ST_OP || m_opcode == ST_OP ) 
-         cache_op = CACHE_WRITE_BACK;
-      else if( m_opcode == ATOM_OP ) 
-         cache_op = CACHE_GLOBAL;
+  switch (m_cache_option) {
+    case CA_OPTION:
+      cache_op = CACHE_ALL;
       break;
-   }
+    case NC_OPTION:
+      cache_op = CACHE_L1;
+      break;
+    case CG_OPTION:
+      cache_op = CACHE_GLOBAL;
+      break;
+    case CS_OPTION:
+      cache_op = CACHE_STREAMING;
+      break;
+    case LU_OPTION:
+      cache_op = CACHE_LAST_USE;
+      break;
+    case CV_OPTION:
+      cache_op = CACHE_VOLATILE;
+      break;
+    case WB_OPTION:
+      cache_op = CACHE_WRITE_BACK;
+      break;
+    case WT_OPTION:
+      cache_op = CACHE_WRITE_THROUGH;
+      break;
+    default:
+      // if( m_opcode == LD_OP || m_opcode == LDU_OP )
+      if (m_opcode == MMA_LD_OP || m_opcode == LD_OP || m_opcode == LDU_OP)
+        cache_op = CACHE_ALL;
+      // else if( m_opcode == ST_OP )
+      else if (m_opcode == MMA_ST_OP || m_opcode == ST_OP)
+        cache_op = CACHE_WRITE_BACK;
+      else if (m_opcode == ATOM_OP)
+        cache_op = CACHE_GLOBAL;
+      break;
+  }
 
-   set_opcode_and_latency();
-   set_bar_type();
-   // Get register operands
-   int n=0,m=0;
-   ptx_instruction::const_iterator opr=op_iter_begin();
-   for ( ; opr != op_iter_end(); opr++, n++ ) { //process operands
-      const operand_info &o = *opr;
-      if ( has_dst && n==0 ) {
-         // Do not set the null register "_" as an architectural register
-         if ( o.is_reg() && !o.is_non_arch_reg() ) {
-            out[0] = o.reg_num();
-            arch_reg.dst[0] = o.arch_reg_num();
-         } else if ( o.is_vector() ) {
-            is_vectorin = 1;
-            unsigned num_elem = o.get_vect_nelem();
-            if( num_elem >= 1 ) out[0] = o.reg1_num();
-            if( num_elem >= 2 ) out[1] = o.reg2_num();
-            if( num_elem >= 3 ) out[2] = o.reg3_num();
-            if( num_elem >= 4 ) out[3] = o.reg4_num();
-            if( num_elem >= 5 ) out[4] = o.reg5_num();
-            if( num_elem >= 6 ) out[5] = o.reg6_num();
-            if( num_elem >= 7 ) out[6] = o.reg7_num();
-            if( num_elem >= 8 ) out[7] = o.reg8_num();
-            for (int i = 0; i < num_elem; i++) 
-               arch_reg.dst[i] = o.arch_reg_num(i);
-         }
-      } else {
-         if ( o.is_reg() && !o.is_non_arch_reg() ) {
-            int reg_num = o.reg_num();
-            arch_reg.src[m] = o.arch_reg_num();
-            switch ( m ) {
-            case 0: in[0] = reg_num; break;
-            case 1: in[1] = reg_num; break;
-            case 2: in[2] = reg_num; break;
-            default: break; 
-            }
-            m++;
-         } else if ( o.is_vector() ) {
-            //assert(m == 0); //only support 1 vector operand (for textures) right now
-            is_vectorout = 1;
-            unsigned num_elem = o.get_vect_nelem();
-            if( num_elem >= 1 ) in[m+0] = o.reg1_num();
-            if( num_elem >= 2 ) in[m+1] = o.reg2_num();
-            if( num_elem >= 3 ) in[m+2] = o.reg3_num();
-            if( num_elem >= 4 ) in[m+3] = o.reg4_num();
-            if( num_elem >= 5 ) in[m+4] = o.reg5_num();
-            if( num_elem >= 6 ) in[m+5] = o.reg6_num();
-            if( num_elem >= 7 ) in[m+6] = o.reg7_num();
-            if( num_elem >= 8 ) in[m+7] = o.reg8_num();
-            for (int i = 0; i < num_elem; i++) 
-               arch_reg.src[m+i] = o.arch_reg_num(i);
-            m+=num_elem;
-         }
+  set_opcode_and_latency();
+  set_bar_type();
+  // Get register operands
+  int n = 0, m = 0;
+  ptx_instruction::const_iterator opr = op_iter_begin();
+  for (; opr != op_iter_end(); opr++, n++) {  // process operands
+    const operand_info &o = *opr;
+    if (has_dst && n == 0) {
+      // Do not set the null register "_" as an architectural register
+      if (o.is_reg() && !o.is_non_arch_reg()) {
+        out[0] = o.reg_num();
+        arch_reg.dst[0] = o.arch_reg_num();
+      } else if (o.is_vector()) {
+        is_vectorin = 1;
+        unsigned num_elem = o.get_vect_nelem();
+        if (num_elem >= 1) out[0] = o.reg1_num();
+        if (num_elem >= 2) out[1] = o.reg2_num();
+        if (num_elem >= 3) out[2] = o.reg3_num();
+        if (num_elem >= 4) out[3] = o.reg4_num();
+        if (num_elem >= 5) out[4] = o.reg5_num();
+        if (num_elem >= 6) out[5] = o.reg6_num();
+        if (num_elem >= 7) out[6] = o.reg7_num();
+        if (num_elem >= 8) out[7] = o.reg8_num();
+        for (int i = 0; i < num_elem; i++) arch_reg.dst[i] = o.arch_reg_num(i);
       }
-   }
-   
-   //Setting number of input and output operands which is required for scoreboard check
-   for(int i=0;i<MAX_OUTPUT_VALUES;i++)
-	if(out[i]>0)
-		outcount++;   
- 
-   for(int i=0;i<MAX_INPUT_VALUES;i++)
-	if(in[i]>0)
-		incount++;   
-
-   // Get predicate
-   if(has_pred()) {
-	   const operand_info &p = get_pred();
-	   pred = p.reg_num();
-   }
-
-   // Get address registers inside memory operands.
-   // Assuming only one memory operand per instruction,
-   //  and maximum of two address registers for one memory operand.
-   if( has_memory_read() || has_memory_write() ) {
-      ptx_instruction::const_iterator op=op_iter_begin();
-      for ( ; op != op_iter_end(); op++, n++ ) { //process operands
-         const operand_info &o = *op;
-
-         if(o.is_memory_operand()) {
-             // We do not support the null register as a memory operand
-             assert( !o.is_non_arch_reg() );
-
-            // Check PTXPlus-type operand
-            // memory operand with addressing (ex. s[0x4] or g[$r1])
-            if(o.is_memory_operand2()) {
-
-               // memory operand with one address register (ex. g[$r1+0x4] or s[$r2+=0x4])
-               if(o.get_double_operand_type() == 0 || o.get_double_operand_type() == 3){
-                  ar1 = o.reg_num();
-                  arch_reg.src[4] = o.arch_reg_num();
-                  // TODO: address register in $r2+=0x4 should be an output register as well
-               }
-               // memory operand with two address register (ex. s[$r1+$r1] or g[$r1+=$r2])
-               else if(o.get_double_operand_type() == 1 || o.get_double_operand_type() == 2) {
-                  ar1 = o.reg1_num();
-                  arch_reg.src[4] = o.arch_reg_num();
-                  ar2 = o.reg2_num();
-                  arch_reg.src[5] = o.arch_reg_num();
-                  // TODO: first address register in $r1+=$r2 should be an output register as well
-               }
-            }
-            else if(o.is_immediate_address()){
-
-            }
-            // Regular PTX operand
-            else if (o.get_symbol()->type()->get_key().is_reg()) { // Memory operand contains a register
-              ar1 = o.reg_num();
-              arch_reg.src[4] = o.arch_reg_num();
-            }
-
-         }
+    } else {
+      if (o.is_reg() && !o.is_non_arch_reg()) {
+        int reg_num = o.reg_num();
+        arch_reg.src[m] = o.arch_reg_num();
+        switch (m) {
+          case 0:
+            in[0] = reg_num;
+            break;
+          case 1:
+            in[1] = reg_num;
+            break;
+          case 2:
+            in[2] = reg_num;
+            break;
+          default:
+            break;
+        }
+        m++;
+      } else if (o.is_vector()) {
+        // assert(m == 0); //only support 1 vector operand (for textures) right
+        // now
+        is_vectorout = 1;
+        unsigned num_elem = o.get_vect_nelem();
+        if (num_elem >= 1) in[m + 0] = o.reg1_num();
+        if (num_elem >= 2) in[m + 1] = o.reg2_num();
+        if (num_elem >= 3) in[m + 2] = o.reg3_num();
+        if (num_elem >= 4) in[m + 3] = o.reg4_num();
+        if (num_elem >= 5) in[m + 4] = o.reg5_num();
+        if (num_elem >= 6) in[m + 5] = o.reg6_num();
+        if (num_elem >= 7) in[m + 6] = o.reg7_num();
+        if (num_elem >= 8) in[m + 7] = o.reg8_num();
+        for (int i = 0; i < num_elem; i++)
+          arch_reg.src[m + i] = o.arch_reg_num(i);
+        m += num_elem;
       }
-   }
+    }
+  }
 
-   // get reconvergence pc
-   reconvergence_pc = gpgpu_ctx->func_sim->get_converge_point(pc);
+  // Setting number of input and output operands which is required for
+  // scoreboard check
+  for (int i = 0; i < MAX_OUTPUT_VALUES; i++)
+    if (out[i] > 0) outcount++;
 
-   m_decoded=true;
+  for (int i = 0; i < MAX_INPUT_VALUES; i++)
+    if (in[i] > 0) incount++;
+
+  // Get predicate
+  if (has_pred()) {
+    const operand_info &p = get_pred();
+    pred = p.reg_num();
+  }
+
+  // Get address registers inside memory operands.
+  // Assuming only one memory operand per instruction,
+  //  and maximum of two address registers for one memory operand.
+  if (has_memory_read() || has_memory_write()) {
+    ptx_instruction::const_iterator op = op_iter_begin();
+    for (; op != op_iter_end(); op++, n++) {  // process operands
+      const operand_info &o = *op;
+
+      if (o.is_memory_operand()) {
+        // We do not support the null register as a memory operand
+        assert(!o.is_non_arch_reg());
+
+        // Check PTXPlus-type operand
+        // memory operand with addressing (ex. s[0x4] or g[$r1])
+        if (o.is_memory_operand2()) {
+          // memory operand with one address register (ex. g[$r1+0x4] or
+          // s[$r2+=0x4])
+          if (o.get_double_operand_type() == 0 ||
+              o.get_double_operand_type() == 3) {
+            ar1 = o.reg_num();
+            arch_reg.src[4] = o.arch_reg_num();
+            // TODO: address register in $r2+=0x4 should be an output register
+            // as well
+          }
+          // memory operand with two address register (ex. s[$r1+$r1] or
+          // g[$r1+=$r2])
+          else if (o.get_double_operand_type() == 1 ||
+                   o.get_double_operand_type() == 2) {
+            ar1 = o.reg1_num();
+            arch_reg.src[4] = o.arch_reg_num();
+            ar2 = o.reg2_num();
+            arch_reg.src[5] = o.arch_reg_num();
+            // TODO: first address register in $r1+=$r2 should be an output
+            // register as well
+          }
+        } else if (o.is_immediate_address()) {
+        }
+        // Regular PTX operand
+        else if (o.get_symbol()
+                     ->type()
+                     ->get_key()
+                     .is_reg()) {  // Memory operand contains a register
+          ar1 = o.reg_num();
+          arch_reg.src[4] = o.arch_reg_num();
+        }
+      }
+    }
+  }
+
+  // get reconvergence pc
+  reconvergence_pc = gpgpu_ctx->func_sim->get_converge_point(pc);
+
+  m_decoded = true;
 }
 
-void function_info::add_param_name_type_size( unsigned index, std::string name, int type, size_t size, bool ptr, memory_space_t space )
-{
-   unsigned parsed_index;
-   char buffer[2048];
-   snprintf(buffer,2048,"%s_param_%%u", m_name.c_str() );
-   int ntokens = sscanf(name.c_str(),buffer,&parsed_index);
-   if( ntokens == 1 ) {
-      assert( m_ptx_kernel_param_info.find(parsed_index) == m_ptx_kernel_param_info.end() );
-      m_ptx_kernel_param_info[parsed_index] = param_info(name, type, size, ptr, space);
-   } else {
-      assert( m_ptx_kernel_param_info.find(index) == m_ptx_kernel_param_info.end() );
-      m_ptx_kernel_param_info[index] = param_info(name, type, size, ptr, space);
-   }
+void function_info::add_param_name_type_size(unsigned index, std::string name,
+                                             int type, size_t size, bool ptr,
+                                             memory_space_t space) {
+  unsigned parsed_index;
+  char buffer[2048];
+  snprintf(buffer, 2048, "%s_param_%%u", m_name.c_str());
+  int ntokens = sscanf(name.c_str(), buffer, &parsed_index);
+  if (ntokens == 1) {
+    assert(m_ptx_kernel_param_info.find(parsed_index) ==
+           m_ptx_kernel_param_info.end());
+    m_ptx_kernel_param_info[parsed_index] =
+        param_info(name, type, size, ptr, space);
+  } else {
+    assert(m_ptx_kernel_param_info.find(index) ==
+           m_ptx_kernel_param_info.end());
+    m_ptx_kernel_param_info[index] = param_info(name, type, size, ptr, space);
+  }
 }
 
-void function_info::add_param_data( unsigned argn, struct gpgpu_ptx_sim_arg *args )
-{
-   const void *data = args->m_start;
+void function_info::add_param_data(unsigned argn,
+                                   struct gpgpu_ptx_sim_arg *args) {
+  const void *data = args->m_start;
 
-   bool scratchpad_memory_param = false; // Is this parameter in CUDA shared memory or OpenCL local memory 
+  bool scratchpad_memory_param =
+      false;  // Is this parameter in CUDA shared memory or OpenCL local memory
 
-   std::map<unsigned,param_info>::iterator i=m_ptx_kernel_param_info.find(argn);
-   if( i != m_ptx_kernel_param_info.end() ) {
-      if (i->second.is_ptr_shared()) {
-         assert(args->m_start == NULL && "OpenCL parameter pointer to local memory must have NULL as value"); 
-         scratchpad_memory_param = true; 
-      } else {
-         param_t tmp;
-         tmp.pdata = args->m_start;
-         tmp.size = args->m_nbytes;
-         tmp.offset = args->m_offset;
-         tmp.type = 0;
-         i->second.add_data(tmp);
-         i->second.add_offset((unsigned) args->m_offset);
+  std::map<unsigned, param_info>::iterator i =
+      m_ptx_kernel_param_info.find(argn);
+  if (i != m_ptx_kernel_param_info.end()) {
+    if (i->second.is_ptr_shared()) {
+      assert(
+          args->m_start == NULL &&
+          "OpenCL parameter pointer to local memory must have NULL as value");
+      scratchpad_memory_param = true;
+    } else {
+      param_t tmp;
+      tmp.pdata = args->m_start;
+      tmp.size = args->m_nbytes;
+      tmp.offset = args->m_offset;
+      tmp.type = 0;
+      i->second.add_data(tmp);
+      i->second.add_offset((unsigned)args->m_offset);
+    }
+  } else {
+    scratchpad_memory_param = true;
+  }
+
+  if (scratchpad_memory_param) {
+    // This should only happen for OpenCL:
+    //
+    // The LLVM PTX compiler in NVIDIA's driver (version 190.29)
+    // does not generate an argument in the function declaration
+    // for __constant arguments.
+    //
+    // The associated constant memory space can be allocated in two
+    // ways. It can be explicitly initialized in the .ptx file where
+    // it is declared.  Or, it can be allocated using the clCreateBuffer
+    // on the host. In this later case, the .ptx file will contain
+    // a global declaration of the parameter, but it will have an unknown
+    // array size.  Thus, the symbol's address will not be set and we need
+    // to set it here before executing the PTX.
+
+    char buffer[2048];
+    snprintf(buffer, 2048, "%s_param_%u", m_name.c_str(), argn);
+
+    symbol *p = m_symtab->lookup(buffer);
+    if (p == NULL) {
+      printf(
+          "GPGPU-Sim PTX: ERROR ** could not locate symbol for \'%s\' : cannot "
+          "bind buffer\n",
+          buffer);
+      abort();
+    }
+    if (data)
+      p->set_address((addr_t) * (size_t *)data);
+    else {
+      // clSetKernelArg was passed NULL pointer for data...
+      // this is used for dynamically sized shared memory on NVIDIA platforms
+      bool is_ptr_shared = false;
+      if (i != m_ptx_kernel_param_info.end()) {
+        is_ptr_shared = i->second.is_ptr_shared();
       }
-   } else {
-      scratchpad_memory_param = true; 
-   }
 
-   if (scratchpad_memory_param) {
-      // This should only happen for OpenCL:
-      // 
-      // The LLVM PTX compiler in NVIDIA's driver (version 190.29)
-      // does not generate an argument in the function declaration 
-      // for __constant arguments.
-      //
-      // The associated constant memory space can be allocated in two 
-      // ways. It can be explicitly initialized in the .ptx file where
-      // it is declared.  Or, it can be allocated using the clCreateBuffer
-      // on the host. In this later case, the .ptx file will contain 
-      // a global declaration of the parameter, but it will have an unknown
-      // array size.  Thus, the symbol's address will not be set and we need
-      // to set it here before executing the PTX.
-      
-      char buffer[2048];
-      snprintf(buffer,2048,"%s_param_%u",m_name.c_str(),argn);
-      
-      symbol *p = m_symtab->lookup(buffer);
-      if( p == NULL ) {
-         printf("GPGPU-Sim PTX: ERROR ** could not locate symbol for \'%s\' : cannot bind buffer\n", buffer);
-         abort();
+      if (!is_ptr_shared and !p->is_shared()) {
+        printf(
+            "GPGPU-Sim PTX: ERROR ** clSetKernelArg passed NULL but arg not "
+            "shared memory\n");
+        abort();
       }
-      if( data ) 
-         p->set_address((addr_t)*(size_t*)data);
-      else {
-         // clSetKernelArg was passed NULL pointer for data...
-         // this is used for dynamically sized shared memory on NVIDIA platforms
-         bool is_ptr_shared = false; 
-         if( i != m_ptx_kernel_param_info.end() ) {
-            is_ptr_shared = i->second.is_ptr_shared(); 
-         }
-
-         if( !is_ptr_shared and !p->is_shared() ) {
-            printf("GPGPU-Sim PTX: ERROR ** clSetKernelArg passed NULL but arg not shared memory\n");
-            abort();     
-         }
-         unsigned num_bits = 8*args->m_nbytes;
-         printf("GPGPU-Sim PTX: deferred allocation of shared region for \"%s\" from 0x%x to 0x%x (shared memory space)\n",
-                p->name().c_str(),
-                m_symtab->get_shared_next(),
-                m_symtab->get_shared_next() + num_bits/8 );
-         fflush(stdout);
-         assert( (num_bits%8) == 0  );
-         addr_t addr = m_symtab->get_shared_next();
-         addr_t addr_pad = num_bits ? (((num_bits/8) - (addr % (num_bits/8))) % (num_bits/8)) : 0;
-         p->set_address( addr+addr_pad );
-         m_symtab->alloc_shared( num_bits/8 + addr_pad );
-      }
-   } 
+      unsigned num_bits = 8 * args->m_nbytes;
+      printf(
+          "GPGPU-Sim PTX: deferred allocation of shared region for \"%s\" from "
+          "0x%x to 0x%x (shared memory space)\n",
+          p->name().c_str(), m_symtab->get_shared_next(),
+          m_symtab->get_shared_next() + num_bits / 8);
+      fflush(stdout);
+      assert((num_bits % 8) == 0);
+      addr_t addr = m_symtab->get_shared_next();
+      addr_t addr_pad =
+          num_bits
+              ? (((num_bits / 8) - (addr % (num_bits / 8))) % (num_bits / 8))
+              : 0;
+      p->set_address(addr + addr_pad);
+      m_symtab->alloc_shared(num_bits / 8 + addr_pad);
+    }
+  }
 }
 
 unsigned function_info::get_args_aligned_size() {
- 
-   if(m_args_aligned_size >= 0)
-      return m_args_aligned_size;
- 
-   unsigned param_address = 0;
-   unsigned int total_size = 0;
-   for( std::map<unsigned,param_info>::iterator i=m_ptx_kernel_param_info.begin(); i!=m_ptx_kernel_param_info.end(); i++ ) {
-      param_info &p = i->second;
-      std::string name = p.get_name();
-      symbol *param = m_symtab->lookup(name.c_str());
+  if (m_args_aligned_size >= 0) return m_args_aligned_size;
 
-      size_t arg_size = p.get_size() / 8; // size of param in bytes
-      total_size = (total_size + arg_size - 1) / arg_size * arg_size; //aligned
-      p.add_offset(total_size);
-      param->set_address(param_address + total_size);
-      total_size += arg_size;
-   }
+  unsigned param_address = 0;
+  unsigned int total_size = 0;
+  for (std::map<unsigned, param_info>::iterator i =
+           m_ptx_kernel_param_info.begin();
+       i != m_ptx_kernel_param_info.end(); i++) {
+    param_info &p = i->second;
+    std::string name = p.get_name();
+    symbol *param = m_symtab->lookup(name.c_str());
 
-   m_args_aligned_size = (total_size + 3) / 4 * 4; //final size aligned to word
+    size_t arg_size = p.get_size() / 8;  // size of param in bytes
+    total_size = (total_size + arg_size - 1) / arg_size * arg_size;  // aligned
+    p.add_offset(total_size);
+    param->set_address(param_address + total_size);
+    total_size += arg_size;
+  }
 
-   return m_args_aligned_size;
+  m_args_aligned_size = (total_size + 3) / 4 * 4;  // final size aligned to word
 
+  return m_args_aligned_size;
 }
 
+void function_info::finalize(memory_space *param_mem) {
+  unsigned param_address = 0;
+  for (std::map<unsigned, param_info>::iterator i =
+           m_ptx_kernel_param_info.begin();
+       i != m_ptx_kernel_param_info.end(); i++) {
+    param_info &p = i->second;
+    if (p.is_ptr_shared())
+      continue;  // Pointer to local memory: Should we pass the allocated shared
+                 // memory address to the param memory space?
+    std::string name = p.get_name();
+    int type = p.get_type();
+    param_t param_value = p.get_value();
+    param_value.type = type;
+    symbol *param = m_symtab->lookup(name.c_str());
+    unsigned xtype = param->type()->get_key().scalar_type();
+    assert(xtype == (unsigned)type);
+    size_t size;
+    size = param_value.size;  // size of param in bytes
+    // assert(param_value.offset == param_address);
+    if (size != p.get_size() / 8) {
+      printf(
+          "GPGPU-Sim PTX: WARNING actual kernel paramter size = %zu bytes vs. "
+          "formal size = %zu (using smaller of two)\n",
+          size, p.get_size() / 8);
+      size = (size < (p.get_size() / 8)) ? size : (p.get_size() / 8);
+    }
+    // copy the parameter over word-by-word so that parameter that crosses a
+    // memory page can be copied over
+    // Jin: copy parameter using aligned rules
+    const type_info *paramtype = param->type();
+    int align_amount = paramtype->get_key().get_alignment_spec();
+    align_amount = (align_amount == -1) ? size : align_amount;
+    param_address = (param_address + align_amount - 1) / align_amount *
+                    align_amount;  // aligned
 
-void function_info::finalize( memory_space *param_mem ) 
-{
-   unsigned param_address = 0;
-   for( std::map<unsigned,param_info>::iterator i=m_ptx_kernel_param_info.begin(); i!=m_ptx_kernel_param_info.end(); i++ ) {
-      param_info &p = i->second;
-      if (p.is_ptr_shared()) continue; // Pointer to local memory: Should we pass the allocated shared memory address to the param memory space? 
-      std::string name = p.get_name();
-      int type = p.get_type();
-      param_t param_value = p.get_value();
-      param_value.type = type;
-      symbol *param = m_symtab->lookup(name.c_str());
-      unsigned xtype = param->type()->get_key().scalar_type();
-      assert(xtype==(unsigned)type);
-      size_t size;
-      size = param_value.size; // size of param in bytes
-      // assert(param_value.offset == param_address);
-      if( size != p.get_size() / 8) {
-         printf("GPGPU-Sim PTX: WARNING actual kernel paramter size = %zu bytes vs. formal size = %zu (using smaller of two)\n",
-                size, p.get_size()/8);
-         size = (size<(p.get_size()/8))?size:(p.get_size()/8);
-      } 
-      // copy the parameter over word-by-word so that parameter that crosses a memory page can be copied over
-      //Jin: copy parameter using aligned rules
-      const type_info *paramtype = param->type();
-      int align_amount = paramtype->get_key().get_alignment_spec();
-      align_amount = (align_amount == -1) ? size : align_amount;
-      param_address = (param_address + align_amount - 1) / align_amount * align_amount; //aligned
+    const size_t word_size = 4;
+    // param_address = (param_address + size - 1) / size * size; //aligned with
+    // size
+    for (size_t idx = 0; idx < size; idx += word_size) {
+      const char *pdata = reinterpret_cast<const char *>(param_value.pdata) +
+                          idx;  // cast to char * for ptr arithmetic
+      param_mem->write(param_address + idx, word_size, pdata, NULL, NULL);
+    }
+    unsigned offset = p.get_offset();
+    assert(offset == param_address);
+    param->set_address(param_address);
+    param_address += size;
+  }
+}
 
-      const size_t word_size = 4; 
-      //param_address = (param_address + size - 1) / size * size; //aligned with size 
-      for (size_t idx = 0; idx < size; idx += word_size) {
-         const char *pdata = reinterpret_cast<const char*>(param_value.pdata) + idx; // cast to char * for ptr arithmetic
-         param_mem->write(param_address + idx, word_size, pdata,NULL,NULL); 
+void function_info::param_to_shared(memory_space *shared_mem,
+                                    symbol_table *symtab) {
+  // TODO: call this only for PTXPlus with GT200 models
+  // extern gpgpu_sim* g_the_gpu;
+  if (not gpgpu_ctx->the_gpgpusim->g_the_gpu->get_config().convert_to_ptxplus())
+    return;
+
+  // copies parameters into simulated shared memory
+  for (std::map<unsigned, param_info>::iterator i =
+           m_ptx_kernel_param_info.begin();
+       i != m_ptx_kernel_param_info.end(); i++) {
+    param_info &p = i->second;
+    if (p.is_ptr_shared())
+      continue;  // Pointer to local memory: Should we pass the allocated shared
+                 // memory address to the param memory space?
+    std::string name = p.get_name();
+    int type = p.get_type();
+    param_t value = p.get_value();
+    value.type = type;
+    symbol *param = symtab->lookup(name.c_str());
+    unsigned xtype = param->type()->get_key().scalar_type();
+    assert(xtype == (unsigned)type);
+
+    int tmp;
+    size_t size;
+    unsigned offset = p.get_offset();
+    type_info_key::type_decode(xtype, size, tmp);
+
+    // Write to shared memory - offset + 0x10
+    shared_mem->write(offset + 0x10, size / 8, value.pdata, NULL, NULL);
+  }
+}
+
+void function_info::list_param(FILE *fout) const {
+  for (std::map<unsigned, param_info>::const_iterator i =
+           m_ptx_kernel_param_info.begin();
+       i != m_ptx_kernel_param_info.end(); i++) {
+    const param_info &p = i->second;
+    std::string name = p.get_name();
+    symbol *param = m_symtab->lookup(name.c_str());
+    addr_t param_addr = param->get_address();
+    fprintf(fout, "%s: %#08x\n", name.c_str(), param_addr);
+  }
+  fflush(fout);
+}
+
+void function_info::ptx_jit_config(
+    std::map<unsigned long long, size_t> mallocPtr_Size,
+    memory_space *param_mem, gpgpu_t *gpu, dim3 gridDim, dim3 blockDim) {
+  static unsigned long long counter = 0;
+  std::vector<std::pair<size_t, unsigned char *> > param_data;
+  std::vector<unsigned> offsets;
+  std::vector<bool> paramIsPointer;
+
+  char *gpgpusim_path = getenv("GPGPUSIM_ROOT");
+  assert(gpgpusim_path != NULL);
+  char *wys_exec_path = getenv("WYS_EXEC_PATH");
+  assert(wys_exec_path != NULL);
+  std::string command =
+      std::string("mkdir ") + gpgpusim_path + "/debug_tools/WatchYourStep/data";
+  std::string filename(std::string(gpgpusim_path) +
+                       "/debug_tools/WatchYourStep/data/params.config" +
+                       std::to_string(counter));
+
+  // initialize paramList
+  char buff[1024];
+  std::string filename_c(filename + "_c");
+  snprintf(buff, 1024, "c++filt %s > %s", get_name().c_str(),
+           filename_c.c_str());
+  assert(system(buff) != NULL);
+  FILE *fp = fopen(filename_c.c_str(), "r");
+  fgets(buff, 1024, fp);
+  fclose(fp);
+  std::string fn(buff);
+  size_t pos1, pos2;
+  pos1 = fn.find_last_of("(");
+  pos2 = fn.find(")", pos1);
+  assert(pos2 > pos1 && pos1 > 0);
+  strcpy(buff, fn.substr(pos1 + 1, pos2 - pos1 - 1).c_str());
+  char *tok;
+  tok = strtok(buff, ",");
+  std::string tmp;
+  while (tok != NULL) {
+    std::string param(tok);
+    if (param.find("<") != std::string::npos) {
+      assert(param.find(">") == std::string::npos);
+      assert(param.find("*") == std::string::npos);
+      tmp = param;
+    } else {
+      if (tmp.length() > 0) {
+        tmp = "";
+        assert(param.find(">") != std::string::npos);
+        assert(param.find("<") == std::string::npos);
+        assert(param.find("*") == std::string::npos);
       }
-      unsigned offset = p.get_offset();
-      assert(offset == param_address);
-      param->set_address(param_address);
-      param_address += size;
-   }
-}
-
-void function_info::param_to_shared( memory_space *shared_mem, symbol_table *symtab ) 
-{
-   // TODO: call this only for PTXPlus with GT200 models 
-   //extern gpgpu_sim* g_the_gpu;
-   if (not gpgpu_ctx->the_gpgpusim->g_the_gpu->get_config().convert_to_ptxplus()) return;
-
-   // copies parameters into simulated shared memory
-   for( std::map<unsigned,param_info>::iterator i=m_ptx_kernel_param_info.begin(); i!=m_ptx_kernel_param_info.end(); i++ ) {
-      param_info &p = i->second;
-      if (p.is_ptr_shared()) continue; // Pointer to local memory: Should we pass the allocated shared memory address to the param memory space? 
-      std::string name = p.get_name();
-      int type = p.get_type();
-      param_t value = p.get_value();
-      value.type = type;
-      symbol *param = symtab->lookup(name.c_str());
-      unsigned xtype = param->type()->get_key().scalar_type();
-      assert(xtype==(unsigned)type);
-
-      int tmp;
-      size_t size;
-      unsigned offset = p.get_offset();
-      type_info_key::type_decode(xtype,size,tmp);
-
-      // Write to shared memory - offset + 0x10
-      shared_mem->write(offset+0x10,size/8,value.pdata,NULL,NULL);
-   }
-}
-
-
-void function_info::list_param( FILE *fout ) const
-{
-   for( std::map<unsigned,param_info>::const_iterator i=m_ptx_kernel_param_info.begin(); i!=m_ptx_kernel_param_info.end(); i++ ) {
-      const param_info &p = i->second;
-      std::string name = p.get_name();
-      symbol *param = m_symtab->lookup(name.c_str());
-      addr_t param_addr = param->get_address();
-      fprintf(fout, "%s: %#08x\n", name.c_str(), param_addr);
-   }
-   fflush(fout);
-}
-
-void function_info::ptx_jit_config(std::map<unsigned long long, size_t> mallocPtr_Size, memory_space *param_mem, gpgpu_t* gpu, dim3 gridDim, dim3 blockDim) 
-{
-    static unsigned long long counter = 0;
-    std::vector< std::pair<size_t, unsigned char*> > param_data;
-    std::vector<unsigned> offsets;
-    std::vector<bool> paramIsPointer;
-
-    char * gpgpusim_path = getenv("GPGPUSIM_ROOT");
-    assert(gpgpusim_path!=NULL);
-    char * wys_exec_path = getenv("WYS_EXEC_PATH");
-    assert(wys_exec_path!=NULL);
-    std::string command = std::string("mkdir ") + gpgpusim_path + "/debug_tools/WatchYourStep/data";
-    std::string filename(std::string(gpgpusim_path) + "/debug_tools/WatchYourStep/data/params.config" + std::to_string(counter));
-
-    //initialize paramList
-    char buff[1024];
-    std::string filename_c(filename+"_c");
-    snprintf(buff,1024,"c++filt %s > %s", get_name().c_str(), filename_c.c_str());
-    assert(system(buff) != NULL);
-    FILE *fp = fopen(filename_c.c_str(), "r");
-    fgets(buff, 1024, fp);
-    fclose(fp);
-    std::string fn(buff);
-    size_t pos1, pos2;
-    pos1 = fn.find_last_of("(");
-    pos2 = fn.find(")", pos1);
-    assert(pos2>pos1&&pos1>0);
-    strcpy(buff, fn.substr(pos1 + 1, pos2 - pos1 - 1).c_str());
-    char *tok;
-    tok = strtok(buff, ",");
-    std::string tmp;
-    while(tok!=NULL){
-        std::string param(tok);
-        if(param.find("<")!=std::string::npos){
-            assert(param.find(">")==std::string::npos);
-            assert(param.find("*")==std::string::npos);
-            tmp = param;
-        } else {
-            if (tmp.length()>0){
-                tmp = ""; 
-                assert(param.find(">")!=std::string::npos);
-                assert(param.find("<")==std::string::npos);
-                assert(param.find("*")==std::string::npos);
-            }   
-            printf("%s\n", param.c_str());
-            if(param.find("*")!=std::string::npos){
-                paramIsPointer.push_back(true);
-            }else{                                                                                 
-                paramIsPointer.push_back(false);
-            }   
-        }
-        tok = strtok(NULL, ",");
+      printf("%s\n", param.c_str());
+      if (param.find("*") != std::string::npos) {
+        paramIsPointer.push_back(true);
+      } else {
+        paramIsPointer.push_back(false);
+      }
     }
+    tok = strtok(NULL, ",");
+  }
 
+  for (std::map<unsigned, param_info>::iterator i =
+           m_ptx_kernel_param_info.begin();
+       i != m_ptx_kernel_param_info.end(); i++) {
+    param_info &p = i->second;
+    std::string name = p.get_name();
+    symbol *param = m_symtab->lookup(name.c_str());
+    addr_t param_addr = param->get_address();
+    param_t param_value = p.get_value();
+    offsets.push_back((unsigned)p.get_offset());
 
-    for( std::map<unsigned,param_info>::iterator i=m_ptx_kernel_param_info.begin(); i!=m_ptx_kernel_param_info.end(); i++ ) {
-        param_info &p = i->second;
-        std::string name = p.get_name();
-        symbol *param = m_symtab->lookup(name.c_str());
-        addr_t param_addr = param->get_address();
-        param_t param_value = p.get_value();
-        offsets.push_back((unsigned)p.get_offset());
-
-        if (paramIsPointer[i->first] && (*(unsigned long long*)param_value.pdata != 0)){
-            //is pointer
-            assert(param_value.size==sizeof(void*)&&"MisID'd this param as pointer");
-            size_t array_size = 0;
-            unsigned long long param_pointer = *(unsigned long long*)param_value.pdata;
-            if(mallocPtr_Size.find(param_pointer)!=mallocPtr_Size.end()){
-                array_size = mallocPtr_Size[param_pointer];
-            }else{
-                for( std::map<unsigned long long, size_t>::iterator j=mallocPtr_Size.begin(); j!=mallocPtr_Size.end(); j++ ) {
-                    if(param_pointer>j->first&&param_pointer<j->first + j->second){
-                        array_size = j->first + j->second - param_pointer;
-                        break;
-                    }
-                }
-                assert(array_size>0&&"pointer was not previously malloc'd");
-            }
-
-            unsigned char* val = (unsigned char*) malloc(param_value.size);
-            param_mem->read(param_addr,param_value.size,(void*)val);
-            unsigned char* array_val = (unsigned char*) malloc(array_size);
-            gpu->get_global_memory()->read(*(unsigned*)((void*)val),array_size,(void*)array_val);
-            param_data.push_back(std::pair<size_t, unsigned char*>(array_size,array_val));
-            paramIsPointer.push_back(true);
-        }else{
-            unsigned char* val = (unsigned char*) malloc(param_value.size);
-            param_mem->read(param_addr,param_value.size,(void*)val);
-            param_data.push_back(std::pair<size_t, unsigned char*>(param_value.size,val));
-            paramIsPointer.push_back(false);
-        }
-    }
-
-    FILE *fout  = fopen (filename.c_str(), "w");
-    printf("Writing data to %s ...\n", filename.c_str());
-    fprintf(fout, "%s\n", get_name().c_str());
-    fprintf(fout, "%u,%u,%u %u,%u,%u\n", gridDim.x, gridDim.y, gridDim.z, blockDim.x, blockDim.y, blockDim.z);
-    size_t index = 0;
-    for( std::vector< std::pair<size_t,unsigned char*> >::const_iterator i=param_data.begin(); i!=param_data.end(); i++ ) {
-        if (paramIsPointer[index]){
-            fprintf(fout, "*");
-        }
-        fprintf(fout, "%lu :", i->first);
-        for (size_t j = 0; j<i->first; j++){
-            fprintf(fout, " %u", i->second[j]);
-        }
-        fprintf(fout, " : %u", offsets[index]);
-        free (i->second);
-        fprintf(fout, "\n");
-        index++;
-    }
-    fflush(fout);
-    fclose(fout);
-    
-    //ptx config
-    std::string ptx_config_fn(std::string(gpgpusim_path) + "/debug_tools/WatchYourStep/data/ptx.config" + std::to_string(counter));
-    snprintf(buff, 1024, "grep -rn \".entry %s\" %s/*.ptx | cut -d \":\" -f 1-2 > %s", get_name().c_str(), wys_exec_path, ptx_config_fn.c_str());
-    if (system(buff)!=0){
-        printf("WARNING: Failed to execute grep to find ptx source \n");
-        printf("Problematic call: %s", buff);
-        abort();
-    }
-    FILE *fin = fopen(ptx_config_fn.c_str(), "r");
-    char ptx_source[256];
-    unsigned line_number;
-    int numscanned = fscanf(fin, "%[^:]:%u", ptx_source, &line_number);
-    assert(numscanned == 2);
-    fclose(fin);
-    snprintf(buff, 1024, "grep -rn \".version\" %s | cut -d \":\" -f 1 | xargs -I \"{}\" awk \"NR>={}&&NR<={}+2\" %s > %s", ptx_source, ptx_source, ptx_config_fn.c_str());
-    if (system(buff)!=0){
-        printf("WARNING: Failed to execute grep to find ptx header \n");
-        printf("Problematic call: %s", buff);
-        abort();
-    }
-    fin = fopen(ptx_source, "r");
-    assert(fin!=NULL);
-    printf("Writing data to %s ...\n", ptx_config_fn.c_str());
-    fout = fopen(ptx_config_fn.c_str(), "a");
-    assert(fout!=NULL);
-    for (unsigned i = 0; i<line_number; i++){
-        assert(fgets(buff, 1024, fin) != NULL);
-        assert(!feof(fin));
-    }
-    fprintf(fout, "\n\n");
-    do{
-        fprintf(fout, "%s", buff);
-        assert(fgets(buff, 1024, fin) != NULL);
-        if(feof(fin)){
+    if (paramIsPointer[i->first] &&
+        (*(unsigned long long *)param_value.pdata != 0)) {
+      // is pointer
+      assert(param_value.size == sizeof(void *) &&
+             "MisID'd this param as pointer");
+      size_t array_size = 0;
+      unsigned long long param_pointer =
+          *(unsigned long long *)param_value.pdata;
+      if (mallocPtr_Size.find(param_pointer) != mallocPtr_Size.end()) {
+        array_size = mallocPtr_Size[param_pointer];
+      } else {
+        for (std::map<unsigned long long, size_t>::iterator j =
+                 mallocPtr_Size.begin();
+             j != mallocPtr_Size.end(); j++) {
+          if (param_pointer > j->first &&
+              param_pointer < j->first + j->second) {
+            array_size = j->first + j->second - param_pointer;
             break;
+          }
         }
-    } while(strstr(buff, "entry")==NULL);
-
-    fclose(fin);
-    fflush(fout);
-    fclose(fout);
-    counter++;
-}
-
-template<int activate_level> 
-bool cuda_sim::ptx_debug_exec_dump_cond(int thd_uid, addr_t pc)
-{
-   if (g_debug_execution >= activate_level) {
-      // check each type of debug dump constraint to filter out dumps
-      if ( (g_debug_thread_uid != 0) && (thd_uid != (unsigned)g_debug_thread_uid) ) {
-         return false;
-      }
-      if ( (g_debug_pc != 0xBEEF1518) && (pc != g_debug_pc) ) {
-         return false;
+        assert(array_size > 0 && "pointer was not previously malloc'd");
       }
 
-      return true;
-   } 
-   
-   return false;
+      unsigned char *val = (unsigned char *)malloc(param_value.size);
+      param_mem->read(param_addr, param_value.size, (void *)val);
+      unsigned char *array_val = (unsigned char *)malloc(array_size);
+      gpu->get_global_memory()->read(*(unsigned *)((void *)val), array_size,
+                                     (void *)array_val);
+      param_data.push_back(
+          std::pair<size_t, unsigned char *>(array_size, array_val));
+      paramIsPointer.push_back(true);
+    } else {
+      unsigned char *val = (unsigned char *)malloc(param_value.size);
+      param_mem->read(param_addr, param_value.size, (void *)val);
+      param_data.push_back(
+          std::pair<size_t, unsigned char *>(param_value.size, val));
+      paramIsPointer.push_back(false);
+    }
+  }
+
+  FILE *fout = fopen(filename.c_str(), "w");
+  printf("Writing data to %s ...\n", filename.c_str());
+  fprintf(fout, "%s\n", get_name().c_str());
+  fprintf(fout, "%u,%u,%u %u,%u,%u\n", gridDim.x, gridDim.y, gridDim.z,
+          blockDim.x, blockDim.y, blockDim.z);
+  size_t index = 0;
+  for (std::vector<std::pair<size_t, unsigned char *> >::const_iterator i =
+           param_data.begin();
+       i != param_data.end(); i++) {
+    if (paramIsPointer[index]) {
+      fprintf(fout, "*");
+    }
+    fprintf(fout, "%lu :", i->first);
+    for (size_t j = 0; j < i->first; j++) {
+      fprintf(fout, " %u", i->second[j]);
+    }
+    fprintf(fout, " : %u", offsets[index]);
+    free(i->second);
+    fprintf(fout, "\n");
+    index++;
+  }
+  fflush(fout);
+  fclose(fout);
+
+  // ptx config
+  std::string ptx_config_fn(std::string(gpgpusim_path) +
+                            "/debug_tools/WatchYourStep/data/ptx.config" +
+                            std::to_string(counter));
+  snprintf(buff, 1024,
+           "grep -rn \".entry %s\" %s/*.ptx | cut -d \":\" -f 1-2 > %s",
+           get_name().c_str(), wys_exec_path, ptx_config_fn.c_str());
+  if (system(buff) != 0) {
+    printf("WARNING: Failed to execute grep to find ptx source \n");
+    printf("Problematic call: %s", buff);
+    abort();
+  }
+  FILE *fin = fopen(ptx_config_fn.c_str(), "r");
+  char ptx_source[256];
+  unsigned line_number;
+  int numscanned = fscanf(fin, "%[^:]:%u", ptx_source, &line_number);
+  assert(numscanned == 2);
+  fclose(fin);
+  snprintf(buff, 1024,
+           "grep -rn \".version\" %s | cut -d \":\" -f 1 | xargs -I \"{}\" awk "
+           "\"NR>={}&&NR<={}+2\" %s > %s",
+           ptx_source, ptx_source, ptx_config_fn.c_str());
+  if (system(buff) != 0) {
+    printf("WARNING: Failed to execute grep to find ptx header \n");
+    printf("Problematic call: %s", buff);
+    abort();
+  }
+  fin = fopen(ptx_source, "r");
+  assert(fin != NULL);
+  printf("Writing data to %s ...\n", ptx_config_fn.c_str());
+  fout = fopen(ptx_config_fn.c_str(), "a");
+  assert(fout != NULL);
+  for (unsigned i = 0; i < line_number; i++) {
+    assert(fgets(buff, 1024, fin) != NULL);
+    assert(!feof(fin));
+  }
+  fprintf(fout, "\n\n");
+  do {
+    fprintf(fout, "%s", buff);
+    assert(fgets(buff, 1024, fin) != NULL);
+    if (feof(fin)) {
+      break;
+    }
+  } while (strstr(buff, "entry") == NULL);
+
+  fclose(fin);
+  fflush(fout);
+  fclose(fout);
+  counter++;
 }
 
-void cuda_sim::init_inst_classification_stat()
-{
-   static std::set<unsigned> init;
-   if( init.find(g_ptx_kernel_count) != init.end() ) 
-      return;
-   init.insert(g_ptx_kernel_count);
+template <int activate_level>
+bool cuda_sim::ptx_debug_exec_dump_cond(int thd_uid, addr_t pc) {
+  if (g_debug_execution >= activate_level) {
+    // check each type of debug dump constraint to filter out dumps
+    if ((g_debug_thread_uid != 0) &&
+        (thd_uid != (unsigned)g_debug_thread_uid)) {
+      return false;
+    }
+    if ((g_debug_pc != 0xBEEF1518) && (pc != g_debug_pc)) {
+      return false;
+    }
 
-   #define MAX_CLASS_KER 1024
-   char kernelname[MAX_CLASS_KER] ="";
-   if (!g_inst_classification_stat) g_inst_classification_stat = (void**)calloc(MAX_CLASS_KER, sizeof(void*));
-   snprintf(kernelname, MAX_CLASS_KER, "Kernel %d Classification\n",g_ptx_kernel_count  );         
-   assert( g_ptx_kernel_count < MAX_CLASS_KER ) ; // a static limit on number of kernels increase it if it fails! 
-   g_inst_classification_stat[g_ptx_kernel_count] = StatCreate(kernelname,1,20);
-   if (!g_inst_op_classification_stat) g_inst_op_classification_stat = (void**)calloc(MAX_CLASS_KER, sizeof(void*));
-   snprintf(kernelname, MAX_CLASS_KER, "Kernel %d OP Classification\n",g_ptx_kernel_count  );         
-   g_inst_op_classification_stat[g_ptx_kernel_count] = StatCreate(kernelname,1,100);
+    return true;
+  }
+
+  return false;
 }
 
-static unsigned get_tex_datasize( const ptx_instruction *pI, ptx_thread_info *thread )
-{
-   const operand_info &src1 = pI->src1(); //the name of the texture
-   std::string texname = src1.name();
+void cuda_sim::init_inst_classification_stat() {
+  static std::set<unsigned> init;
+  if (init.find(g_ptx_kernel_count) != init.end()) return;
+  init.insert(g_ptx_kernel_count);
 
-   /*
-     For programs with many streams, textures can be bound and unbound
-     asynchronously.  This means we need to use the kernel's "snapshot" of
-     the state of the texture mappings when it was launched (so that we
-     don't try to access the incorrect texture mapping if it's been updated,
-     or that we don't access a mapping that has been unbound).
-    */
-   kernel_info_t& k = thread->get_kernel();
-   const struct textureInfo* texInfo = k.get_texinfo(texname);
-
-   unsigned data_size = texInfo->texel_size;
-   return data_size; 
+#define MAX_CLASS_KER 1024
+  char kernelname[MAX_CLASS_KER] = "";
+  if (!g_inst_classification_stat)
+    g_inst_classification_stat = (void **)calloc(MAX_CLASS_KER, sizeof(void *));
+  snprintf(kernelname, MAX_CLASS_KER, "Kernel %d Classification\n",
+           g_ptx_kernel_count);
+  assert(g_ptx_kernel_count < MAX_CLASS_KER);  // a static limit on number of
+                                               // kernels increase it if it
+                                               // fails!
+  g_inst_classification_stat[g_ptx_kernel_count] =
+      StatCreate(kernelname, 1, 20);
+  if (!g_inst_op_classification_stat)
+    g_inst_op_classification_stat =
+        (void **)calloc(MAX_CLASS_KER, sizeof(void *));
+  snprintf(kernelname, MAX_CLASS_KER, "Kernel %d OP Classification\n",
+           g_ptx_kernel_count);
+  g_inst_op_classification_stat[g_ptx_kernel_count] =
+      StatCreate(kernelname, 1, 100);
 }
 
-int tensorcore_op(int inst_opcode){
-	
-       if((inst_opcode==MMA_OP)||(inst_opcode==MMA_LD_OP)||(inst_opcode==MMA_ST_OP))
-		return 1;
-       else	
-		return 0;
+static unsigned get_tex_datasize(const ptx_instruction *pI,
+                                 ptx_thread_info *thread) {
+  const operand_info &src1 = pI->src1();  // the name of the texture
+  std::string texname = src1.name();
+
+  /*
+    For programs with many streams, textures can be bound and unbound
+    asynchronously.  This means we need to use the kernel's "snapshot" of
+    the state of the texture mappings when it was launched (so that we
+    don't try to access the incorrect texture mapping if it's been updated,
+    or that we don't access a mapping that has been unbound).
+   */
+  kernel_info_t &k = thread->get_kernel();
+  const struct textureInfo *texInfo = k.get_texinfo(texname);
+
+  unsigned data_size = texInfo->texel_size;
+  return data_size;
 }
-void ptx_thread_info::ptx_exec_inst( warp_inst_t &inst, unsigned lane_id)
-{
-    
-   bool skip = false;
-   int op_classification = 0;
-   addr_t pc = next_instr();
-   assert( pc == inst.pc ); // make sure timing model and functional model are in sync
-   const ptx_instruction *pI = m_func_info->get_instruction(pc);
-   
-   set_npc( pc + pI->inst_size() );
-   
 
-   try {
+int tensorcore_op(int inst_opcode) {
+  if ((inst_opcode == MMA_OP) || (inst_opcode == MMA_LD_OP) ||
+      (inst_opcode == MMA_ST_OP))
+    return 1;
+  else
+    return 0;
+}
+void ptx_thread_info::ptx_exec_inst(warp_inst_t &inst, unsigned lane_id) {
+  bool skip = false;
+  int op_classification = 0;
+  addr_t pc = next_instr();
+  assert(pc ==
+         inst.pc);  // make sure timing model and functional model are in sync
+  const ptx_instruction *pI = m_func_info->get_instruction(pc);
 
-   clearRPC();
-   m_last_set_operand_value.u64 = 0;
+  set_npc(pc + pI->inst_size());
 
-   if(is_done())
-   {
-      printf("attempted to execute instruction on a thread that is already done.\n");
+  try {
+    clearRPC();
+    m_last_set_operand_value.u64 = 0;
+
+    if (is_done()) {
+      printf(
+          "attempted to execute instruction on a thread that is already "
+          "done.\n");
       assert(0);
-   }
-   
-   if ( g_debug_execution >= 6 || m_gpu->get_config().get_ptx_inst_debug_to_file()) {
-      if ( (m_gpu->gpgpu_ctx->func_sim->g_debug_thread_uid==0)
-	      || (get_uid() == (unsigned)(m_gpu->gpgpu_ctx->func_sim->g_debug_thread_uid)) ) {
-        
-          clear_modifiedregs();
-         enable_debug_trace();
+    }
+
+    if (g_debug_execution >= 6 ||
+        m_gpu->get_config().get_ptx_inst_debug_to_file()) {
+      if ((m_gpu->gpgpu_ctx->func_sim->g_debug_thread_uid == 0) ||
+          (get_uid() ==
+           (unsigned)(m_gpu->gpgpu_ctx->func_sim->g_debug_thread_uid))) {
+        clear_modifiedregs();
+        enable_debug_trace();
       }
-   }
-   
-   
-   if( pI->has_pred() ) {
+    }
+
+    if (pI->has_pred()) {
       const operand_info &pred = pI->get_pred();
       ptx_reg_t pred_value = get_operand_value(pred, pred, PRED_TYPE, this, 0);
-      if(pI->get_pred_mod() == -1) {
-            skip = (pred_value.pred & 0x0001) ^ pI->get_pred_neg(); //ptxplus inverts the zero flag
+      if (pI->get_pred_mod() == -1) {
+        skip = (pred_value.pred & 0x0001) ^
+               pI->get_pred_neg();  // ptxplus inverts the zero flag
       } else {
-            skip = !pred_lookup(pI->get_pred_mod(), pred_value.pred & 0x000F);
+        skip = !pred_lookup(pI->get_pred_mod(), pred_value.pred & 0x000F);
       }
-   }
-   int inst_opcode=pI->get_opcode();
-   
-   if( skip ) {
+    }
+    int inst_opcode = pI->get_opcode();
+
+    if (skip) {
       inst.set_not_active(lane_id);
-   } else {
+    } else {
       const ptx_instruction *pI_saved = pI;
       ptx_instruction *pJ = NULL;
-      if( pI->get_opcode() == VOTE_OP ) {
-         pJ = new ptx_instruction(*pI);
-         *((warp_inst_t*)pJ) = inst; // copy active mask information
-         pI = pJ;
+      if (pI->get_opcode() == VOTE_OP) {
+        pJ = new ptx_instruction(*pI);
+        *((warp_inst_t *)pJ) = inst;  // copy active mask information
+        pI = pJ;
       }
-     
-      if(((inst_opcode==MMA_OP||inst_opcode==MMA_LD_OP||inst_opcode==MMA_ST_OP))){
-      		if(inst.active_count()!=MAX_WARP_SIZE)
-		{	
-			printf("Tensor Core operation are warp synchronous operation. All the threads needs to be active.");
-			assert(0);
-		}
+
+      if (((inst_opcode == MMA_OP || inst_opcode == MMA_LD_OP ||
+            inst_opcode == MMA_ST_OP))) {
+        if (inst.active_count() != MAX_WARP_SIZE) {
+          printf(
+              "Tensor Core operation are warp synchronous operation. All the "
+              "threads needs to be active.");
+          assert(0);
+        }
       }
-      
-      //Tensorcore is warp synchronous operation. So these instructions needs to be executed only once. To make the simulation faster removing the redundant tensorcore operation
-      if(!tensorcore_op(inst_opcode)||((tensorcore_op(inst_opcode))&&(lane_id==0))){
-	      switch ( inst_opcode ) {
-	#define OP_DEF(OP,FUNC,STR,DST,CLASSIFICATION) case OP: FUNC(pI,this); op_classification = CLASSIFICATION; break;
-	#define OP_W_DEF(OP,FUNC,STR,DST,CLASSIFICATION) case OP: FUNC(pI,get_core(),inst); op_classification = CLASSIFICATION; break;
-	#include "opcodes.def"
-	#undef OP_DEF
-	#undef OP_W_DEF
-	      default: printf( "Execution error: Invalid opcode (0x%x)\n", pI->get_opcode() ); break;
-	      }
+
+      // Tensorcore is warp synchronous operation. So these instructions needs
+      // to be executed only once. To make the simulation faster removing the
+      // redundant tensorcore operation
+      if (!tensorcore_op(inst_opcode) ||
+          ((tensorcore_op(inst_opcode)) && (lane_id == 0))) {
+        switch (inst_opcode) {
+#define OP_DEF(OP, FUNC, STR, DST, CLASSIFICATION) \
+  case OP:                                         \
+    FUNC(pI, this);                                \
+    op_classification = CLASSIFICATION;            \
+    break;
+#define OP_W_DEF(OP, FUNC, STR, DST, CLASSIFICATION) \
+  case OP:                                           \
+    FUNC(pI, get_core(), inst);                      \
+    op_classification = CLASSIFICATION;              \
+    break;
+#include "opcodes.def"
+#undef OP_DEF
+#undef OP_W_DEF
+          default:
+            printf("Execution error: Invalid opcode (0x%x)\n",
+                   pI->get_opcode());
+            break;
+        }
       }
       delete pJ;
       pI = pI_saved;
-      
+
       // Run exit instruction if exit option included
-      if(pI->is_exit())
-         exit_impl(pI,this);
-   }
-   
+      if (pI->is_exit()) exit_impl(pI, this);
+    }
 
+    const gpgpu_functional_sim_config &config = m_gpu->get_config();
 
-   const gpgpu_functional_sim_config &config = m_gpu->get_config();
-   
-   // Output instruction information to file and stdout
-   if( config.get_ptx_inst_debug_to_file() != 0 && 
-        (config.get_ptx_inst_debug_thread_uid() == 0 || config.get_ptx_inst_debug_thread_uid() == get_uid()) ) {
-      fprintf(m_gpu->get_ptx_inst_debug_file(),
-             "[thd=%u] : (%s:%u - %s)\n",
-             get_uid(),
-             pI->source_file(), pI->source_line(), pI->get_source() );
-      //fprintf(ptx_inst_debug_file, "has memory read=%d, has memory write=%d\n", pI->has_memory_read(), pI->has_memory_write());
+    // Output instruction information to file and stdout
+    if (config.get_ptx_inst_debug_to_file() != 0 &&
+        (config.get_ptx_inst_debug_thread_uid() == 0 ||
+         config.get_ptx_inst_debug_thread_uid() == get_uid())) {
+      fprintf(m_gpu->get_ptx_inst_debug_file(), "[thd=%u] : (%s:%u - %s)\n",
+              get_uid(), pI->source_file(), pI->source_line(),
+              pI->get_source());
+      // fprintf(ptx_inst_debug_file, "has memory read=%d, has memory
+      // write=%d\n", pI->has_memory_read(), pI->has_memory_write());
       fflush(m_gpu->get_ptx_inst_debug_file());
-   }
+    }
 
-   if ( m_gpu->gpgpu_ctx->func_sim->ptx_debug_exec_dump_cond<5>(get_uid(), pc) ) {
+    if (m_gpu->gpgpu_ctx->func_sim->ptx_debug_exec_dump_cond<5>(get_uid(),
+                                                                pc)) {
       dim3 ctaid = get_ctaid();
       dim3 tid = get_tid();
-      printf("%u [thd=%u][i=%u] : ctaid=(%u,%u,%u) tid=(%u,%u,%u) icount=%u [pc=%u] (%s:%u - %s)  [0x%llx]\n", 
-             m_gpu->gpgpu_ctx->func_sim->g_ptx_sim_num_insn,
-             get_uid(),
-             pI->uid(), ctaid.x,ctaid.y,ctaid.z,tid.x,tid.y,tid.z,
-             get_icount(),
-             pc, pI->source_file(), pI->source_line(), pI->get_source(),
-             m_last_set_operand_value.u64 );
+      printf(
+          "%u [thd=%u][i=%u] : ctaid=(%u,%u,%u) tid=(%u,%u,%u) icount=%u "
+          "[pc=%u] (%s:%u - %s)  [0x%llx]\n",
+          m_gpu->gpgpu_ctx->func_sim->g_ptx_sim_num_insn, get_uid(), pI->uid(),
+          ctaid.x, ctaid.y, ctaid.z, tid.x, tid.y, tid.z, get_icount(), pc,
+          pI->source_file(), pI->source_line(), pI->get_source(),
+          m_last_set_operand_value.u64);
       fflush(stdout);
-   }
-   
-   addr_t insn_memaddr = 0xFEEBDAED;
-   memory_space_t insn_space = undefined_space;
-   _memory_op_t insn_memory_op = no_memory_op;
-   unsigned insn_data_size = 0;
-   if ( (pI->has_memory_read()  || pI->has_memory_write()) ) {
-      if(!((inst_opcode==MMA_LD_OP||inst_opcode==MMA_ST_OP)))
-      {
+    }
+
+    addr_t insn_memaddr = 0xFEEBDAED;
+    memory_space_t insn_space = undefined_space;
+    _memory_op_t insn_memory_op = no_memory_op;
+    unsigned insn_data_size = 0;
+    if ((pI->has_memory_read() || pI->has_memory_write())) {
+      if (!((inst_opcode == MMA_LD_OP || inst_opcode == MMA_ST_OP))) {
         insn_memaddr = last_eaddr();
         insn_space = last_space();
         unsigned to_type = pI->get_type();
         insn_data_size = datatype2size(to_type);
         insn_memory_op = pI->has_memory_read() ? memory_load : memory_store;
-      }	
-   }
-  
-   if ( pI->get_opcode() == BAR_OP && pI->barrier_op() == RED_OPTION) {
-	   inst.add_callback( lane_id, last_callback().function, last_callback().instruction, this,false /*not atomic*/);
-   }
+      }
+    }
 
-   if ( pI->get_opcode() == ATOM_OP ) {
+    if (pI->get_opcode() == BAR_OP && pI->barrier_op() == RED_OPTION) {
+      inst.add_callback(lane_id, last_callback().function,
+                        last_callback().instruction, this,
+                        false /*not atomic*/);
+    }
+
+    if (pI->get_opcode() == ATOM_OP) {
       insn_memaddr = last_eaddr();
       insn_space = last_space();
-      inst.add_callback( lane_id, last_callback().function, last_callback().instruction, this,true /*atomic*/);
+      inst.add_callback(lane_id, last_callback().function,
+                        last_callback().instruction, this, true /*atomic*/);
       unsigned to_type = pI->get_type();
       insn_data_size = datatype2size(to_type);
-   }
+    }
 
-   if (pI->get_opcode() == TEX_OP) {
-      inst.set_addr(lane_id, last_eaddr() );
-      assert( inst.space == last_space() );
-      insn_data_size = get_tex_datasize(pI, this); // texture obtain its data granularity from the texture info 
-   }
+    if (pI->get_opcode() == TEX_OP) {
+      inst.set_addr(lane_id, last_eaddr());
+      assert(inst.space == last_space());
+      insn_data_size = get_tex_datasize(
+          pI,
+          this);  // texture obtain its data granularity from the texture info
+    }
 
-   // Output register information to file and stdout
-   if( config.get_ptx_inst_debug_to_file()!=0 && 
-       (config.get_ptx_inst_debug_thread_uid()==0||config.get_ptx_inst_debug_thread_uid()==get_uid()) ) {
+    // Output register information to file and stdout
+    if (config.get_ptx_inst_debug_to_file() != 0 &&
+        (config.get_ptx_inst_debug_thread_uid() == 0 ||
+         config.get_ptx_inst_debug_thread_uid() == get_uid())) {
       dump_modifiedregs(m_gpu->get_ptx_inst_debug_file());
       dump_regs(m_gpu->get_ptx_inst_debug_file());
-   }
+    }
 
-   if ( g_debug_execution >= 6 ) {
-      if ( m_gpu->gpgpu_ctx->func_sim->ptx_debug_exec_dump_cond<6>(get_uid(), pc) )
-         dump_modifiedregs(stdout);
-   }
-   if ( g_debug_execution >= 10 ) {
-      if ( m_gpu->gpgpu_ctx->func_sim->ptx_debug_exec_dump_cond<10>(get_uid(), pc) )
-         dump_regs(stdout);
-   }
-   update_pc();
-   m_gpu->gpgpu_ctx->func_sim->g_ptx_sim_num_insn++;
-   
-   //not using it with functional simulation mode
-   if(!(this->m_functionalSimulationMode))
-       ptx_file_line_stats_add_exec_count(pI);
-   
-   if ( m_gpu->gpgpu_ctx->func_sim->gpgpu_ptx_instruction_classification ) {
+    if (g_debug_execution >= 6) {
+      if (m_gpu->gpgpu_ctx->func_sim->ptx_debug_exec_dump_cond<6>(get_uid(),
+                                                                  pc))
+        dump_modifiedregs(stdout);
+    }
+    if (g_debug_execution >= 10) {
+      if (m_gpu->gpgpu_ctx->func_sim->ptx_debug_exec_dump_cond<10>(get_uid(),
+                                                                   pc))
+        dump_regs(stdout);
+    }
+    update_pc();
+    m_gpu->gpgpu_ctx->func_sim->g_ptx_sim_num_insn++;
+
+    // not using it with functional simulation mode
+    if (!(this->m_functionalSimulationMode))
+      ptx_file_line_stats_add_exec_count(pI);
+
+    if (m_gpu->gpgpu_ctx->func_sim->gpgpu_ptx_instruction_classification) {
       m_gpu->gpgpu_ctx->func_sim->init_inst_classification_stat();
-      unsigned space_type=0;
-      switch ( pI->get_space().get_type() ) {
-      case global_space: space_type = 10; break;
-      case local_space:  space_type = 11; break; 
-      case tex_space:    space_type = 12; break; 
-      case surf_space:   space_type = 13; break; 
-      case param_space_kernel:
-      case param_space_local:
-                         space_type = 14; break; 
-      case shared_space: space_type = 15; break; 
-      case const_space:  space_type = 16; break;
-      default: 
-         space_type = 0 ;
-         break;
+      unsigned space_type = 0;
+      switch (pI->get_space().get_type()) {
+        case global_space:
+          space_type = 10;
+          break;
+        case local_space:
+          space_type = 11;
+          break;
+        case tex_space:
+          space_type = 12;
+          break;
+        case surf_space:
+          space_type = 13;
+          break;
+        case param_space_kernel:
+        case param_space_local:
+          space_type = 14;
+          break;
+        case shared_space:
+          space_type = 15;
+          break;
+        case const_space:
+          space_type = 16;
+          break;
+        default:
+          space_type = 0;
+          break;
       }
-      StatAddSample( m_gpu->gpgpu_ctx->func_sim->g_inst_classification_stat[m_gpu->gpgpu_ctx->func_sim->g_ptx_kernel_count],  op_classification);
-      if (space_type) StatAddSample( m_gpu->gpgpu_ctx->func_sim->g_inst_classification_stat[m_gpu->gpgpu_ctx->func_sim->g_ptx_kernel_count], ( int )space_type);
-      StatAddSample( m_gpu->gpgpu_ctx->func_sim->g_inst_op_classification_stat[m_gpu->gpgpu_ctx->func_sim->g_ptx_kernel_count], (int)  pI->get_opcode() );
-   }
-   if ( (m_gpu->gpgpu_ctx->func_sim->g_ptx_sim_num_insn % 100000) == 0 ) {
+      StatAddSample(m_gpu->gpgpu_ctx->func_sim->g_inst_classification_stat
+                        [m_gpu->gpgpu_ctx->func_sim->g_ptx_kernel_count],
+                    op_classification);
+      if (space_type)
+        StatAddSample(m_gpu->gpgpu_ctx->func_sim->g_inst_classification_stat
+                          [m_gpu->gpgpu_ctx->func_sim->g_ptx_kernel_count],
+                      (int)space_type);
+      StatAddSample(m_gpu->gpgpu_ctx->func_sim->g_inst_op_classification_stat
+                        [m_gpu->gpgpu_ctx->func_sim->g_ptx_kernel_count],
+                    (int)pI->get_opcode());
+    }
+    if ((m_gpu->gpgpu_ctx->func_sim->g_ptx_sim_num_insn % 100000) == 0) {
       dim3 ctaid = get_ctaid();
       dim3 tid = get_tid();
-      DPRINTF(LIVENESS, "GPGPU-Sim PTX: %u instructions simulated : ctaid=(%u,%u,%u) tid=(%u,%u,%u)\n",
-             m_gpu->gpgpu_ctx->func_sim->g_ptx_sim_num_insn, ctaid.x,ctaid.y,ctaid.z,tid.x,tid.y,tid.z );
+      DPRINTF(LIVENESS,
+              "GPGPU-Sim PTX: %u instructions simulated : ctaid=(%u,%u,%u) "
+              "tid=(%u,%u,%u)\n",
+              m_gpu->gpgpu_ctx->func_sim->g_ptx_sim_num_insn, ctaid.x, ctaid.y,
+              ctaid.z, tid.x, tid.y, tid.z);
       fflush(stdout);
-   }
-   
-   // "Return values"
-   if(!skip) {
-      if(!((inst_opcode==MMA_LD_OP||inst_opcode==MMA_ST_OP)))
-      {
-   	  inst.space = insn_space;
-          inst.set_addr(lane_id, insn_memaddr);
-          inst.data_size = insn_data_size; // simpleAtomicIntrinsics
-          assert( inst.memory_op == insn_memory_op );
-      } 
-   }
- 
-   } catch ( int x  ) {
-      printf("GPGPU-Sim PTX: ERROR (%d) executing intruction (%s:%u)\n", x, pI->source_file(), pI->source_line() );
-      printf("GPGPU-Sim PTX:       '%s'\n", pI->get_source() );
-      abort();
-   }
-      
-}
+    }
 
-void cuda_sim::set_param_gpgpu_num_shaders(int num_shaders)
-{
-   gpgpu_param_num_shaders = num_shaders;
-}
-
-const struct gpgpu_ptx_sim_info* ptx_sim_kernel_info(const function_info *kernel)
-{
-   return kernel->get_kernel_info();
-}
-
-const warp_inst_t *gpgpu_context::ptx_fetch_inst( address_type pc )
-{
-    return pc_to_instruction(pc);
-}
-
-unsigned ptx_sim_init_thread( kernel_info_t &kernel,
-                              ptx_thread_info** thread_info,
-                              int sid,
-                              unsigned tid,
-                              unsigned threads_left,
-                              unsigned num_threads, 
-                              core_t *core, 
-                              unsigned hw_cta_id, 
-                              unsigned hw_warp_id,
-                              gpgpu_t *gpu,
-                              bool isInFunctionalSimulationMode)
-{
-   std::list<ptx_thread_info *> &active_threads = kernel.active_threads();
-
-   static std::map<unsigned,memory_space*> shared_memory_lookup;
-   static std::map<unsigned,memory_space*> sstarr_memory_lookup;
-   static std::map<unsigned,ptx_cta_info*> ptx_cta_lookup;
-   static std::map<unsigned,ptx_warp_info*> ptx_warp_lookup;
-   static std::map<unsigned,std::map<unsigned,memory_space*> > local_memory_lookup;
-
-   if ( *thread_info != NULL ) {
-      ptx_thread_info *thd = *thread_info;
-      assert( thd->is_done() );
-      if ( g_debug_execution==-1 ) {
-         dim3 ctaid = thd->get_ctaid();
-         dim3 t = thd->get_tid();
-         printf("GPGPU-Sim PTX simulator:  thread exiting ctaid=(%u,%u,%u) tid=(%u,%u,%u) uid=%u\n",
-                ctaid.x,ctaid.y,ctaid.z,t.x,t.y,t.z, thd->get_uid() );
-         fflush(stdout);
+    // "Return values"
+    if (!skip) {
+      if (!((inst_opcode == MMA_LD_OP || inst_opcode == MMA_ST_OP))) {
+        inst.space = insn_space;
+        inst.set_addr(lane_id, insn_memaddr);
+        inst.data_size = insn_data_size;  // simpleAtomicIntrinsics
+        assert(inst.memory_op == insn_memory_op);
       }
-      thd->m_cta_info->register_deleted_thread(thd);
-      delete thd;
-      *thread_info = NULL;
-   }
+    }
 
-   if ( !active_threads.empty() ) {
-      assert( active_threads.size() <= threads_left );
-      ptx_thread_info *thd = active_threads.front(); 
-      active_threads.pop_front();
-      *thread_info = thd;
-      thd->init(gpu, core, sid, hw_cta_id, hw_warp_id, tid, isInFunctionalSimulationMode );
-      return 1;
-   }
+  } catch (int x) {
+    printf("GPGPU-Sim PTX: ERROR (%d) executing intruction (%s:%u)\n", x,
+           pI->source_file(), pI->source_line());
+    printf("GPGPU-Sim PTX:       '%s'\n", pI->get_source());
+    abort();
+  }
+}
 
-   if ( kernel.no_more_ctas_to_run() ) {
-      return 0; //finished!
-   }
+void cuda_sim::set_param_gpgpu_num_shaders(int num_shaders) {
+  gpgpu_param_num_shaders = num_shaders;
+}
 
-   if ( threads_left < kernel.threads_per_cta() ) {
-      return 0;
-   }
+const struct gpgpu_ptx_sim_info *ptx_sim_kernel_info(
+    const function_info *kernel) {
+  return kernel->get_kernel_info();
+}
 
-   if ( g_debug_execution==-1 ) {
-      printf("GPGPU-Sim PTX simulator:  STARTING THREAD ALLOCATION --> \n");
+const warp_inst_t *gpgpu_context::ptx_fetch_inst(address_type pc) {
+  return pc_to_instruction(pc);
+}
+
+unsigned ptx_sim_init_thread(kernel_info_t &kernel,
+                             ptx_thread_info **thread_info, int sid,
+                             unsigned tid, unsigned threads_left,
+                             unsigned num_threads, core_t *core,
+                             unsigned hw_cta_id, unsigned hw_warp_id,
+                             gpgpu_t *gpu, bool isInFunctionalSimulationMode) {
+  std::list<ptx_thread_info *> &active_threads = kernel.active_threads();
+
+  static std::map<unsigned, memory_space *> shared_memory_lookup;
+  static std::map<unsigned, memory_space *> sstarr_memory_lookup;
+  static std::map<unsigned, ptx_cta_info *> ptx_cta_lookup;
+  static std::map<unsigned, ptx_warp_info *> ptx_warp_lookup;
+  static std::map<unsigned, std::map<unsigned, memory_space *> >
+      local_memory_lookup;
+
+  if (*thread_info != NULL) {
+    ptx_thread_info *thd = *thread_info;
+    assert(thd->is_done());
+    if (g_debug_execution == -1) {
+      dim3 ctaid = thd->get_ctaid();
+      dim3 t = thd->get_tid();
+      printf(
+          "GPGPU-Sim PTX simulator:  thread exiting ctaid=(%u,%u,%u) "
+          "tid=(%u,%u,%u) uid=%u\n",
+          ctaid.x, ctaid.y, ctaid.z, t.x, t.y, t.z, thd->get_uid());
       fflush(stdout);
-   }
+    }
+    thd->m_cta_info->register_deleted_thread(thd);
+    delete thd;
+    *thread_info = NULL;
+  }
 
-   //initializing new CTA
-   ptx_cta_info *cta_info = NULL;
-   memory_space *shared_mem = NULL;
-   memory_space *sstarr_mem = NULL;
+  if (!active_threads.empty()) {
+    assert(active_threads.size() <= threads_left);
+    ptx_thread_info *thd = active_threads.front();
+    active_threads.pop_front();
+    *thread_info = thd;
+    thd->init(gpu, core, sid, hw_cta_id, hw_warp_id, tid,
+              isInFunctionalSimulationMode);
+    return 1;
+  }
 
-   unsigned cta_size = kernel.threads_per_cta();
-   unsigned max_cta_per_sm = num_threads/cta_size; // e.g., 256 / 48 = 5 
-   assert( max_cta_per_sm > 0 );
+  if (kernel.no_more_ctas_to_run()) {
+    return 0;  // finished!
+  }
 
-   //unsigned sm_idx = (tid/cta_size)*gpgpu_param_num_shaders + sid;
-   unsigned sm_idx = hw_cta_id*gpu->gpgpu_ctx->func_sim->gpgpu_param_num_shaders + sid;
+  if (threads_left < kernel.threads_per_cta()) {
+    return 0;
+  }
 
-   if ( shared_memory_lookup.find(sm_idx) == shared_memory_lookup.end() ) {
-      if ( g_debug_execution >= 1 ) {
-         printf("  <CTA alloc> : sm_idx=%u sid=%u max_cta_per_sm=%u\n", 
-                sm_idx, sid, max_cta_per_sm );
-      }
+  if (g_debug_execution == -1) {
+    printf("GPGPU-Sim PTX simulator:  STARTING THREAD ALLOCATION --> \n");
+    fflush(stdout);
+  }
+
+  // initializing new CTA
+  ptx_cta_info *cta_info = NULL;
+  memory_space *shared_mem = NULL;
+  memory_space *sstarr_mem = NULL;
+
+  unsigned cta_size = kernel.threads_per_cta();
+  unsigned max_cta_per_sm = num_threads / cta_size;  // e.g., 256 / 48 = 5
+  assert(max_cta_per_sm > 0);
+
+  // unsigned sm_idx = (tid/cta_size)*gpgpu_param_num_shaders + sid;
+  unsigned sm_idx =
+      hw_cta_id * gpu->gpgpu_ctx->func_sim->gpgpu_param_num_shaders + sid;
+
+  if (shared_memory_lookup.find(sm_idx) == shared_memory_lookup.end()) {
+    if (g_debug_execution >= 1) {
+      printf("  <CTA alloc> : sm_idx=%u sid=%u max_cta_per_sm=%u\n", sm_idx,
+             sid, max_cta_per_sm);
+    }
+    char buf[512];
+    snprintf(buf, 512, "shared_%u", sid);
+    shared_mem = new memory_space_impl<16 * 1024>(buf, 4);
+    shared_memory_lookup[sm_idx] = shared_mem;
+    snprintf(buf, 512, "sstarr_%u", sid);
+    sstarr_mem = new memory_space_impl<16 * 1024>(buf, 4);
+    sstarr_memory_lookup[sm_idx] = sstarr_mem;
+    cta_info = new ptx_cta_info(sm_idx, gpu->gpgpu_ctx);
+    ptx_cta_lookup[sm_idx] = cta_info;
+  } else {
+    if (g_debug_execution >= 1) {
+      printf("  <CTA realloc> : sm_idx=%u sid=%u max_cta_per_sm=%u\n", sm_idx,
+             sid, max_cta_per_sm);
+    }
+    shared_mem = shared_memory_lookup[sm_idx];
+    sstarr_mem = sstarr_memory_lookup[sm_idx];
+    cta_info = ptx_cta_lookup[sm_idx];
+    cta_info->check_cta_thread_status_and_reset();
+  }
+
+  std::map<unsigned, memory_space *> &local_mem_lookup =
+      local_memory_lookup[sid];
+  while (kernel.more_threads_in_cta()) {
+    dim3 ctaid3d = kernel.get_next_cta_id();
+    unsigned new_tid = kernel.get_next_thread_id();
+    dim3 tid3d = kernel.get_next_thread_id_3d();
+    kernel.increment_thread_id();
+    new_tid += tid;
+    ptx_thread_info *thd = new ptx_thread_info(kernel);
+    ptx_warp_info *warp_info = NULL;
+    if (ptx_warp_lookup.find(hw_warp_id) == ptx_warp_lookup.end()) {
+      warp_info = new ptx_warp_info();
+      ptx_warp_lookup[hw_warp_id] = warp_info;
+    } else {
+      warp_info = ptx_warp_lookup[hw_warp_id];
+    }
+    thd->m_warp_info = warp_info;
+
+    memory_space *local_mem = NULL;
+    std::map<unsigned, memory_space *>::iterator l =
+        local_mem_lookup.find(new_tid);
+    if (l != local_mem_lookup.end()) {
+      local_mem = l->second;
+    } else {
       char buf[512];
-      snprintf(buf,512,"shared_%u", sid);
-      shared_mem = new memory_space_impl<16*1024>(buf,4);
-      shared_memory_lookup[sm_idx] = shared_mem;
-      snprintf(buf,512,"sstarr_%u", sid);
-      sstarr_mem = new memory_space_impl<16*1024>(buf,4);
-      sstarr_memory_lookup[sm_idx] = sstarr_mem;
-      cta_info = new ptx_cta_info(sm_idx, gpu->gpgpu_ctx);
-      ptx_cta_lookup[sm_idx] = cta_info;
-   } else {
-      if ( g_debug_execution >= 1 ) {
-         printf("  <CTA realloc> : sm_idx=%u sid=%u max_cta_per_sm=%u\n", 
-                sm_idx, sid, max_cta_per_sm );
-      }
-      shared_mem = shared_memory_lookup[sm_idx];
-      sstarr_mem = sstarr_memory_lookup[sm_idx];
-      cta_info = ptx_cta_lookup[sm_idx];
-      cta_info->check_cta_thread_status_and_reset();
-   }
-
-   std::map<unsigned,memory_space*> &local_mem_lookup = local_memory_lookup[sid];
-   while( kernel.more_threads_in_cta() ) {
-      dim3 ctaid3d = kernel.get_next_cta_id();
-      unsigned new_tid = kernel.get_next_thread_id();
-      dim3 tid3d = kernel.get_next_thread_id_3d();
-      kernel.increment_thread_id();
-      new_tid += tid;
-      ptx_thread_info *thd = new ptx_thread_info(kernel);
-      ptx_warp_info *warp_info = NULL;
-      if ( ptx_warp_lookup.find(hw_warp_id) == ptx_warp_lookup.end() ) {
-    	  warp_info = new ptx_warp_info();
-    	  ptx_warp_lookup[hw_warp_id] = warp_info;
-      } else {
-    	  warp_info = ptx_warp_lookup[hw_warp_id];
-      }
-      thd->m_warp_info = warp_info;
-
-      memory_space *local_mem = NULL;
-      std::map<unsigned,memory_space*>::iterator l = local_mem_lookup.find(new_tid);
-      if ( l != local_mem_lookup.end() ) {
-         local_mem = l->second;
-      } else {
-         char buf[512];
-         snprintf(buf,512,"local_%u_%u", sid, new_tid);
-         local_mem = new memory_space_impl<32>(buf,32);
-         local_mem_lookup[new_tid] = local_mem;
-      }
-      thd->set_info(kernel.entry());
-      thd->set_nctaid(kernel.get_grid_dim());
-      thd->set_ntid(kernel.get_cta_dim());
-      thd->set_ctaid(ctaid3d);
-      thd->set_tid(tid3d);
-      if( kernel.entry()->get_ptx_version().extensions() ) 
-         thd->cpy_tid_to_reg(tid3d);
-      thd->set_valid();
-      thd->m_shared_mem = shared_mem;
-      thd->m_sstarr_mem = sstarr_mem;
-      function_info *finfo = thd->func_info();
-      symbol_table *st = finfo->get_symtab();
-      thd->func_info()->param_to_shared(thd->m_shared_mem,st);
-      thd->func_info()->param_to_shared(thd->m_sstarr_mem,st);
-      thd->m_cta_info = cta_info;
-      cta_info->add_thread(thd);
-      thd->m_local_mem = local_mem;
-      if ( g_debug_execution==-1 ) {
-         printf("GPGPU-Sim PTX simulator:  allocating thread ctaid=(%u,%u,%u) tid=(%u,%u,%u) @ 0x%Lx\n",
-                ctaid3d.x,ctaid3d.y,ctaid3d.z,tid3d.x,tid3d.y,tid3d.z, (unsigned long long)thd );
-         fflush(stdout);
-      }
-      active_threads.push_back(thd);
-   }
-   if ( g_debug_execution==-1 ) {
-      printf("GPGPU-Sim PTX simulator:  <-- FINISHING THREAD ALLOCATION\n");
+      snprintf(buf, 512, "local_%u_%u", sid, new_tid);
+      local_mem = new memory_space_impl<32>(buf, 32);
+      local_mem_lookup[new_tid] = local_mem;
+    }
+    thd->set_info(kernel.entry());
+    thd->set_nctaid(kernel.get_grid_dim());
+    thd->set_ntid(kernel.get_cta_dim());
+    thd->set_ctaid(ctaid3d);
+    thd->set_tid(tid3d);
+    if (kernel.entry()->get_ptx_version().extensions())
+      thd->cpy_tid_to_reg(tid3d);
+    thd->set_valid();
+    thd->m_shared_mem = shared_mem;
+    thd->m_sstarr_mem = sstarr_mem;
+    function_info *finfo = thd->func_info();
+    symbol_table *st = finfo->get_symtab();
+    thd->func_info()->param_to_shared(thd->m_shared_mem, st);
+    thd->func_info()->param_to_shared(thd->m_sstarr_mem, st);
+    thd->m_cta_info = cta_info;
+    cta_info->add_thread(thd);
+    thd->m_local_mem = local_mem;
+    if (g_debug_execution == -1) {
+      printf(
+          "GPGPU-Sim PTX simulator:  allocating thread ctaid=(%u,%u,%u) "
+          "tid=(%u,%u,%u) @ 0x%Lx\n",
+          ctaid3d.x, ctaid3d.y, ctaid3d.z, tid3d.x, tid3d.y, tid3d.z,
+          (unsigned long long)thd);
       fflush(stdout);
-   }
+    }
+    active_threads.push_back(thd);
+  }
+  if (g_debug_execution == -1) {
+    printf("GPGPU-Sim PTX simulator:  <-- FINISHING THREAD ALLOCATION\n");
+    fflush(stdout);
+  }
 
-   kernel.increment_cta_id();
+  kernel.increment_cta_id();
 
-   assert( active_threads.size() <= threads_left );
-   *thread_info = active_threads.front();
-   (*thread_info)->init(gpu, core, sid, hw_cta_id, hw_warp_id, tid,isInFunctionalSimulationMode );
-   active_threads.pop_front();
-   return 1;
+  assert(active_threads.size() <= threads_left);
+  *thread_info = active_threads.front();
+  (*thread_info)
+      ->init(gpu, core, sid, hw_cta_id, hw_warp_id, tid,
+             isInFunctionalSimulationMode);
+  active_threads.pop_front();
+  return 1;
 }
 
-size_t get_kernel_code_size( class function_info *entry )
-{
-   return entry->get_function_size();
+size_t get_kernel_code_size(class function_info *entry) {
+  return entry->get_function_size();
 }
 
+kernel_info_t *cuda_sim::gpgpu_opencl_ptx_sim_init_grid(
+    class function_info *entry, gpgpu_ptx_sim_arg_list_t args,
+    struct dim3 gridDim, struct dim3 blockDim, gpgpu_t *gpu) {
+  kernel_info_t *result =
+      new kernel_info_t(gridDim, blockDim, entry, gpu->getNameArrayMapping(),
+                        gpu->getNameInfoMapping());
+  unsigned argcount = args.size();
+  unsigned argn = 1;
+  for (gpgpu_ptx_sim_arg_list_t::iterator a = args.begin(); a != args.end();
+       a++) {
+    entry->add_param_data(argcount - argn, &(*a));
+    argn++;
+  }
+  entry->finalize(result->get_param_memory());
+  g_ptx_kernel_count++;
+  fflush(stdout);
 
-kernel_info_t *cuda_sim::gpgpu_opencl_ptx_sim_init_grid(class function_info *entry,
-                                             gpgpu_ptx_sim_arg_list_t args, 
-                                             struct dim3 gridDim,
-                                             struct dim3 blockDim,
-                                             gpgpu_t *gpu )
-{
-   kernel_info_t *result = new kernel_info_t(gridDim,blockDim,entry,gpu->getNameArrayMapping(),gpu->getNameInfoMapping());
-   unsigned argcount=args.size();
-   unsigned argn=1;
-   for( gpgpu_ptx_sim_arg_list_t::iterator a = args.begin(); a != args.end(); a++ ) {
-      entry->add_param_data(argcount-argn,&(*a));
-      argn++;
-   }
-   entry->finalize(result->get_param_memory());
-   g_ptx_kernel_count++; 
-   fflush(stdout);
-
-   return result;
+  return result;
 }
 
 #include "../../version"
 #include "detailed_version"
 
-void print_splash()
-{
-   static int splash_printed=0;
-   if ( !splash_printed ) {
-      fprintf(stdout, "\n\n        *** %s [build %s] ***\n\n\n", g_gpgpusim_version_string, g_gpgpusim_build_string );
-      splash_printed=1;
-   }
+void print_splash() {
+  static int splash_printed = 0;
+  if (!splash_printed) {
+    fprintf(stdout, "\n\n        *** %s [build %s] ***\n\n\n",
+            g_gpgpusim_version_string, g_gpgpusim_build_string);
+    splash_printed = 1;
+  }
 }
 
-void cuda_sim::gpgpu_ptx_sim_register_const_variable(void *hostVar, const char *deviceName, size_t size )
-{
-   printf("GPGPU-Sim PTX registering constant %s (%zu bytes) to name mapping\n", deviceName, size );
-   g_const_name_lookup[hostVar] = deviceName;
+void cuda_sim::gpgpu_ptx_sim_register_const_variable(void *hostVar,
+                                                     const char *deviceName,
+                                                     size_t size) {
+  printf("GPGPU-Sim PTX registering constant %s (%zu bytes) to name mapping\n",
+         deviceName, size);
+  g_const_name_lookup[hostVar] = deviceName;
 }
 
-void cuda_sim::gpgpu_ptx_sim_register_global_variable(void *hostVar, const char *deviceName, size_t size )
-{
-   printf("GPGPU-Sim PTX registering global %s hostVar to name mapping\n", deviceName );
-   g_global_name_lookup[hostVar] = deviceName;
+void cuda_sim::gpgpu_ptx_sim_register_global_variable(void *hostVar,
+                                                      const char *deviceName,
+                                                      size_t size) {
+  printf("GPGPU-Sim PTX registering global %s hostVar to name mapping\n",
+         deviceName);
+  g_global_name_lookup[hostVar] = deviceName;
 }
 
-void cuda_sim::gpgpu_ptx_sim_memcpy_symbol(const char *hostVar, const void *src, size_t count, size_t offset, int to, gpgpu_t *gpu )
-{
-   printf("GPGPU-Sim PTX: starting gpgpu_ptx_sim_memcpy_symbol with hostVar 0x%p\n", hostVar);
-   bool found_sym = false;
-   memory_space_t mem_region = undefined_space;
-   std::string sym_name;
+void cuda_sim::gpgpu_ptx_sim_memcpy_symbol(const char *hostVar, const void *src,
+                                           size_t count, size_t offset, int to,
+                                           gpgpu_t *gpu) {
+  printf(
+      "GPGPU-Sim PTX: starting gpgpu_ptx_sim_memcpy_symbol with hostVar 0x%p\n",
+      hostVar);
+  bool found_sym = false;
+  memory_space_t mem_region = undefined_space;
+  std::string sym_name;
 
-   std::map<const void*,std::string>::iterator c=gpu->gpgpu_ctx->func_sim->g_const_name_lookup.find(hostVar);
-   if ( c!=gpu->gpgpu_ctx->func_sim->g_const_name_lookup.end() ) {
-      found_sym = true;
-      sym_name = c->second;
-      mem_region = const_space;
-   }
-   std::map<const void*,std::string>::iterator g=gpu->gpgpu_ctx->func_sim->g_global_name_lookup.find(hostVar);
-   if ( g!=gpu->gpgpu_ctx->func_sim->g_global_name_lookup.end() ) {
-      if ( found_sym ) {
-         printf("Execution error: PTX symbol \"%s\" w/ hostVar=0x%Lx is declared both const and global?\n", 
-                sym_name.c_str(), (unsigned long long)hostVar );
-         abort();
-      }
-      found_sym = true;
-      sym_name = g->second;
-      mem_region = global_space;
-   }
-   if( g_globals.find(hostVar) != g_globals.end() ) {
-      found_sym = true;
-      sym_name = hostVar;
-      mem_region = global_space;
-   }
-   if( g_constants.find(hostVar) != g_constants.end() ) {
-      found_sym = true;
-      sym_name = hostVar;
-      mem_region = const_space;
-   }
-
-   if ( !found_sym ) {
-      printf("Execution error: No information for PTX symbol w/ hostVar=0x%Lx\n", (unsigned long long)hostVar );
+  std::map<const void *, std::string>::iterator c =
+      gpu->gpgpu_ctx->func_sim->g_const_name_lookup.find(hostVar);
+  if (c != gpu->gpgpu_ctx->func_sim->g_const_name_lookup.end()) {
+    found_sym = true;
+    sym_name = c->second;
+    mem_region = const_space;
+  }
+  std::map<const void *, std::string>::iterator g =
+      gpu->gpgpu_ctx->func_sim->g_global_name_lookup.find(hostVar);
+  if (g != gpu->gpgpu_ctx->func_sim->g_global_name_lookup.end()) {
+    if (found_sym) {
+      printf(
+          "Execution error: PTX symbol \"%s\" w/ hostVar=0x%Lx is declared "
+          "both const and global?\n",
+          sym_name.c_str(), (unsigned long long)hostVar);
       abort();
-   } else printf("GPGPU-Sim PTX: gpgpu_ptx_sim_memcpy_symbol: Found PTX symbol w/ hostVar=0x%Lx\n", (unsigned long long)hostVar ); 
-   const char *mem_name = NULL;
-   memory_space *mem = NULL;
+    }
+    found_sym = true;
+    sym_name = g->second;
+    mem_region = global_space;
+  }
+  if (g_globals.find(hostVar) != g_globals.end()) {
+    found_sym = true;
+    sym_name = hostVar;
+    mem_region = global_space;
+  }
+  if (g_constants.find(hostVar) != g_constants.end()) {
+    found_sym = true;
+    sym_name = hostVar;
+    mem_region = const_space;
+  }
 
-   std::map<std::string,symbol_table*>::iterator st = gpgpu_ctx->ptx_parser->g_sym_name_to_symbol_table.find(sym_name.c_str());
-   assert( st != gpgpu_ctx->ptx_parser->g_sym_name_to_symbol_table.end() );
-   symbol_table *symtab = st->second;
+  if (!found_sym) {
+    printf("Execution error: No information for PTX symbol w/ hostVar=0x%Lx\n",
+           (unsigned long long)hostVar);
+    abort();
+  } else
+    printf(
+        "GPGPU-Sim PTX: gpgpu_ptx_sim_memcpy_symbol: Found PTX symbol w/ "
+        "hostVar=0x%Lx\n",
+        (unsigned long long)hostVar);
+  const char *mem_name = NULL;
+  memory_space *mem = NULL;
 
-   symbol *sym = symtab->lookup(sym_name.c_str());
-   assert(sym);
-   unsigned dst = sym->get_address() + offset; 
-   switch (mem_region.get_type()) {
-   case const_space:
+  std::map<std::string, symbol_table *>::iterator st =
+      gpgpu_ctx->ptx_parser->g_sym_name_to_symbol_table.find(sym_name.c_str());
+  assert(st != gpgpu_ctx->ptx_parser->g_sym_name_to_symbol_table.end());
+  symbol_table *symtab = st->second;
+
+  symbol *sym = symtab->lookup(sym_name.c_str());
+  assert(sym);
+  unsigned dst = sym->get_address() + offset;
+  switch (mem_region.get_type()) {
+    case const_space:
       mem = gpu->get_global_memory();
       mem_name = "const";
       break;
-   case global_space:
+    case global_space:
       mem = gpu->get_global_memory();
       mem_name = "global";
       break;
-   default:
+    default:
       abort();
-   }
-   printf("GPGPU-Sim PTX: gpgpu_ptx_sim_memcpy_symbol: copying %s memory %zu bytes %s symbol %s+%zu @0x%x ...\n", 
-          mem_name, count, (to?" to ":"from"), sym_name.c_str(), offset, dst );
-   for ( unsigned n=0; n < count; n++ ) {
-      if( to ) mem->write(dst+n,1,((char*)src)+n,NULL,NULL); 
-      else mem->read(dst+n,1,((char*)src)+n); 
-   }
-   fflush(stdout);
+  }
+  printf(
+      "GPGPU-Sim PTX: gpgpu_ptx_sim_memcpy_symbol: copying %s memory %zu bytes "
+      "%s symbol %s+%zu @0x%x ...\n",
+      mem_name, count, (to ? " to " : "from"), sym_name.c_str(), offset, dst);
+  for (unsigned n = 0; n < count; n++) {
+    if (to)
+      mem->write(dst + n, 1, ((char *)src) + n, NULL, NULL);
+    else
+      mem->read(dst + n, 1, ((char *)src) + n);
+  }
+  fflush(stdout);
 }
 
 extern int ptx_debug;
 
-void cuda_sim::read_sim_environment_variables()
-{
-   ptx_debug = 0;
-   g_debug_execution = 0;
-   g_interactive_debugger_enabled = false;
+void cuda_sim::read_sim_environment_variables() {
+  ptx_debug = 0;
+  g_debug_execution = 0;
+  g_interactive_debugger_enabled = false;
 
-   char *mode = getenv("PTX_SIM_MODE_FUNC");
-   if ( mode )
-      sscanf(mode,"%u", &g_ptx_sim_mode);
-   printf("GPGPU-Sim PTX: simulation mode %d (can change with PTX_SIM_MODE_FUNC environment variable:\n", g_ptx_sim_mode);
-   printf("               1=functional simulation only, 0=detailed performance simulator)\n");
-   char *dbg_inter = getenv("GPGPUSIM_DEBUG");
-   if ( dbg_inter && strlen(dbg_inter) ) {
-      printf("GPGPU-Sim PTX: enabling interactive debugger\n");
-      fflush(stdout);
-      g_interactive_debugger_enabled = true;
-   }
-   char *dbg_level = getenv("PTX_SIM_DEBUG");
-   if ( dbg_level && strlen(dbg_level) ) {
-      printf("GPGPU-Sim PTX: setting debug level to %s\n", dbg_level );
-      fflush(stdout);
-      sscanf(dbg_level,"%d", &g_debug_execution);
-   }
-   char *dbg_thread = getenv("PTX_SIM_DEBUG_THREAD_UID");
-   if ( dbg_thread && strlen(dbg_thread) ) {
-      printf("GPGPU-Sim PTX: printing debug information for thread uid %s\n", dbg_thread );
-      fflush(stdout);
-      sscanf(dbg_thread,"%d", &g_debug_thread_uid);
-   }
-   char *dbg_pc = getenv("PTX_SIM_DEBUG_PC");
-   if ( dbg_pc && strlen(dbg_pc) ) {
-      printf("GPGPU-Sim PTX: printing debug information for instruction with PC = %s\n", dbg_pc );
-      fflush(stdout);
-      sscanf(dbg_pc,"%d", &g_debug_pc);
-   }
+  char *mode = getenv("PTX_SIM_MODE_FUNC");
+  if (mode) sscanf(mode, "%u", &g_ptx_sim_mode);
+  printf(
+      "GPGPU-Sim PTX: simulation mode %d (can change with PTX_SIM_MODE_FUNC "
+      "environment variable:\n",
+      g_ptx_sim_mode);
+  printf(
+      "               1=functional simulation only, 0=detailed performance "
+      "simulator)\n");
+  char *dbg_inter = getenv("GPGPUSIM_DEBUG");
+  if (dbg_inter && strlen(dbg_inter)) {
+    printf("GPGPU-Sim PTX: enabling interactive debugger\n");
+    fflush(stdout);
+    g_interactive_debugger_enabled = true;
+  }
+  char *dbg_level = getenv("PTX_SIM_DEBUG");
+  if (dbg_level && strlen(dbg_level)) {
+    printf("GPGPU-Sim PTX: setting debug level to %s\n", dbg_level);
+    fflush(stdout);
+    sscanf(dbg_level, "%d", &g_debug_execution);
+  }
+  char *dbg_thread = getenv("PTX_SIM_DEBUG_THREAD_UID");
+  if (dbg_thread && strlen(dbg_thread)) {
+    printf("GPGPU-Sim PTX: printing debug information for thread uid %s\n",
+           dbg_thread);
+    fflush(stdout);
+    sscanf(dbg_thread, "%d", &g_debug_thread_uid);
+  }
+  char *dbg_pc = getenv("PTX_SIM_DEBUG_PC");
+  if (dbg_pc && strlen(dbg_pc)) {
+    printf(
+        "GPGPU-Sim PTX: printing debug information for instruction with PC = "
+        "%s\n",
+        dbg_pc);
+    fflush(stdout);
+    sscanf(dbg_pc, "%d", &g_debug_pc);
+  }
 
 #if CUDART_VERSION > 1010
-    g_override_embedded_ptx = false;
-    char *usefile = getenv("PTX_SIM_USE_PTX_FILE");
-    if (usefile && strlen(usefile)) {
-        printf("GPGPU-Sim PTX: overriding embedded ptx with ptx file (PTX_SIM_USE_PTX_FILE is set)\n");
-        fflush(stdout);
-        g_override_embedded_ptx = true;
-    }
-    char *blocking = getenv("CUDA_LAUNCH_BLOCKING");
-    if( blocking && !strcmp(blocking,"1") ) {
-        g_cuda_launch_blocking = true;
-    }
+  g_override_embedded_ptx = false;
+  char *usefile = getenv("PTX_SIM_USE_PTX_FILE");
+  if (usefile && strlen(usefile)) {
+    printf(
+        "GPGPU-Sim PTX: overriding embedded ptx with ptx file "
+        "(PTX_SIM_USE_PTX_FILE is set)\n");
+    fflush(stdout);
+    g_override_embedded_ptx = true;
+  }
+  char *blocking = getenv("CUDA_LAUNCH_BLOCKING");
+  if (blocking && !strcmp(blocking, "1")) {
+    g_cuda_launch_blocking = true;
+  }
 #else
-   g_cuda_launch_blocking = true;
-   g_override_embedded_ptx = true;
+  g_cuda_launch_blocking = true;
+  g_override_embedded_ptx = true;
 #endif
 
-   if ( g_debug_execution >= 40 ) {
-      ptx_debug = 1;
-   }
+  if (g_debug_execution >= 40) {
+    ptx_debug = 1;
+  }
 }
 
-#define MAX(a,b) (((a)>(b))?(a):(b))
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
 
-unsigned max_cta (const struct gpgpu_ptx_sim_info *kernel_info, unsigned threads_per_cta, unsigned int warp_size, unsigned int n_thread_per_shader, unsigned int gpgpu_shmem_size, unsigned int gpgpu_shader_registers, unsigned int max_cta_per_core)
-{
-   
-    unsigned int padded_cta_size = threads_per_cta;
-    if (padded_cta_size%warp_size) 
-        padded_cta_size = ((padded_cta_size/warp_size)+1)*(warp_size);
-     unsigned int result_thread = n_thread_per_shader / padded_cta_size;
+unsigned max_cta(const struct gpgpu_ptx_sim_info *kernel_info,
+                 unsigned threads_per_cta, unsigned int warp_size,
+                 unsigned int n_thread_per_shader,
+                 unsigned int gpgpu_shmem_size,
+                 unsigned int gpgpu_shader_registers,
+                 unsigned int max_cta_per_core) {
+  unsigned int padded_cta_size = threads_per_cta;
+  if (padded_cta_size % warp_size)
+    padded_cta_size = ((padded_cta_size / warp_size) + 1) * (warp_size);
+  unsigned int result_thread = n_thread_per_shader / padded_cta_size;
 
-     unsigned int result_shmem = (unsigned)-1;
-     if (kernel_info->smem > 0)
-        result_shmem = gpgpu_shmem_size / kernel_info->smem;
-     unsigned int result_regs = (unsigned)-1;
-     if (kernel_info->regs > 0)
-        result_regs = gpgpu_shader_registers / (padded_cta_size * ((kernel_info->regs+3)&~3));
-     printf("padded cta size is %d and %d and %d",padded_cta_size, kernel_info->regs, ((kernel_info->regs+3)&~3) );
-     //Limit by CTA
-     unsigned int result_cta = max_cta_per_core;
+  unsigned int result_shmem = (unsigned)-1;
+  if (kernel_info->smem > 0)
+    result_shmem = gpgpu_shmem_size / kernel_info->smem;
+  unsigned int result_regs = (unsigned)-1;
+  if (kernel_info->regs > 0)
+    result_regs = gpgpu_shader_registers /
+                  (padded_cta_size * ((kernel_info->regs + 3) & ~3));
+  printf("padded cta size is %d and %d and %d", padded_cta_size,
+         kernel_info->regs, ((kernel_info->regs + 3) & ~3));
+  // Limit by CTA
+  unsigned int result_cta = max_cta_per_core;
 
-     unsigned result = result_thread;
-     result = gs_min2(result, result_shmem);
-     result = gs_min2(result, result_regs);
-     result = gs_min2(result, result_cta);
+  unsigned result = result_thread;
+  result = gs_min2(result, result_shmem);
+  result = gs_min2(result, result_regs);
+  result = gs_min2(result, result_cta);
 
-     printf ("GPGPU-Sim uArch: CTA/core = %u, limited by:", result);
-     if (result == result_thread) printf (" threads");
-     if (result == result_shmem) printf (" shmem");
-     if (result == result_regs) printf (" regs");
-     if (result == result_cta) printf (" cta_limit");
-     printf ("\n");
+  printf("GPGPU-Sim uArch: CTA/core = %u, limited by:", result);
+  if (result == result_thread) printf(" threads");
+  if (result == result_shmem) printf(" shmem");
+  if (result == result_regs) printf(" regs");
+  if (result == result_cta) printf(" cta_limit");
+  printf("\n");
 
-     return result;
+  return result;
 }
 /*!
-This function simulates the CUDA code functionally, it takes a kernel_info_t parameter 
+This function simulates the CUDA code functionally, it takes a kernel_info_t
+parameter
 which holds the data for the CUDA kernel to be executed
 !*/
-void cuda_sim::gpgpu_cuda_ptx_sim_main_func( kernel_info_t &kernel, bool openCL )
-{
-     printf("GPGPU-Sim: Performing Functional Simulation, executing kernel %s...\n",kernel.name().c_str());
+void cuda_sim::gpgpu_cuda_ptx_sim_main_func(kernel_info_t &kernel,
+                                            bool openCL) {
+  printf(
+      "GPGPU-Sim: Performing Functional Simulation, executing kernel %s...\n",
+      kernel.name().c_str());
 
-     //using a shader core object for book keeping, it is not needed but as most function built for performance simulation need it we use it here
-    //extern gpgpu_sim *g_the_gpu;
-    //before we execute, we should do PDOM analysis for functional simulation scenario.
-    function_info *kernel_func_info = kernel.entry();
-    const struct gpgpu_ptx_sim_info *kernel_info = ptx_sim_kernel_info(kernel_func_info);
-    checkpoint *g_checkpoint;
-    g_checkpoint = new checkpoint();
+  // using a shader core object for book keeping, it is not needed but as most
+  // function built for performance simulation need it we use it here
+  // extern gpgpu_sim *g_the_gpu;
+  // before we execute, we should do PDOM analysis for functional simulation
+  // scenario.
+  function_info *kernel_func_info = kernel.entry();
+  const struct gpgpu_ptx_sim_info *kernel_info =
+      ptx_sim_kernel_info(kernel_func_info);
+  checkpoint *g_checkpoint;
+  g_checkpoint = new checkpoint();
 
-    if (kernel_func_info->is_pdom_set()) {
-    	printf("GPGPU-Sim PTX: PDOM analysis already done for %s \n", kernel.name().c_str() );
+  if (kernel_func_info->is_pdom_set()) {
+    printf("GPGPU-Sim PTX: PDOM analysis already done for %s \n",
+           kernel.name().c_str());
+  } else {
+    printf("GPGPU-Sim PTX: finding reconvergence points for \'%s\'...\n",
+           kernel.name().c_str());
+    kernel_func_info->do_pdom();
+    kernel_func_info->set_pdom();
+  }
+
+  unsigned max_cta_tot = max_cta(
+      kernel_info, kernel.threads_per_cta(),
+      gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()->warp_size,
+      gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()
+          ->n_thread_per_shader,
+      gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()
+          ->gpgpu_shmem_size,
+      gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()
+          ->gpgpu_shader_registers,
+      gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()
+          ->max_cta_per_core);
+  printf("Max CTA : %d\n", max_cta_tot);
+
+  int cp_op = gpgpu_ctx->the_gpgpusim->g_the_gpu->checkpoint_option;
+  int cp_kernel = gpgpu_ctx->the_gpgpusim->g_the_gpu->checkpoint_kernel;
+  cp_count = gpgpu_ctx->the_gpgpusim->g_the_gpu->checkpoint_insn_Y;
+  cp_cta_resume = gpgpu_ctx->the_gpgpusim->g_the_gpu->checkpoint_CTA_t;
+  int cta_launched = 0;
+
+  // we excute the kernel one CTA (Block) at the time, as synchronization
+  // functions work block wise
+  while (!kernel.no_more_ctas_to_run()) {
+    unsigned temp = kernel.get_next_cta_id_single();
+
+    if (cp_op == 0 || (cp_op == 1 && cta_launched < cp_cta_resume &&
+                       kernel.get_uid() == cp_kernel) ||
+        kernel.get_uid() < cp_kernel)  // just fro testing
+    {
+      functionalCoreSim cta(
+          &kernel, gpgpu_ctx->the_gpgpusim->g_the_gpu,
+          gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()->warp_size);
+      cta.execute(cp_count, temp);
+
+#if (CUDART_VERSION >= 5000)
+      gpgpu_ctx->device_runtime->launch_all_device_kernels();
+#endif
     } else {
-	 printf("GPGPU-Sim PTX: finding reconvergence points for \'%s\'...\n", kernel.name().c_str() );
-	 kernel_func_info->do_pdom();
-	 kernel_func_info->set_pdom();
+      kernel.increment_cta_id();
     }
-
-    unsigned max_cta_tot = max_cta(kernel_info,kernel.threads_per_cta(), gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()->warp_size, gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()->n_thread_per_shader, gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()->gpgpu_shmem_size, gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()->gpgpu_shader_registers, gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()->max_cta_per_core);
-    printf("Max CTA : %d\n",max_cta_tot);
-
-    int cp_op= gpgpu_ctx->the_gpgpusim->g_the_gpu->checkpoint_option;
-    int cp_kernel= gpgpu_ctx->the_gpgpusim->g_the_gpu->checkpoint_kernel;
-    cp_count= gpgpu_ctx->the_gpgpusim->g_the_gpu->checkpoint_insn_Y;
-    cp_cta_resume= gpgpu_ctx->the_gpgpusim->g_the_gpu->checkpoint_CTA_t;
-    int cta_launched =0;
-
-    //we excute the kernel one CTA (Block) at the time, as synchronization functions work block wise
-    while(!kernel.no_more_ctas_to_run()){
-        unsigned temp=kernel.get_next_cta_id_single();
-        
-
-        if(cp_op==0 || (cp_op==1 && cta_launched<cp_cta_resume && kernel.get_uid()==cp_kernel) || kernel.get_uid()< cp_kernel) // just fro testing
-        {
-           functionalCoreSim cta(
-               &kernel,
-               gpgpu_ctx->the_gpgpusim->g_the_gpu,
-               gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()->warp_size
-           );
-           cta.execute(cp_count,temp);
-
-            #if (CUDART_VERSION >= 5000)
-               gpgpu_ctx->device_runtime->launch_all_device_kernels();
-            #endif
-         }
-         else
-         {
-            kernel.increment_cta_id();
-         }
     cta_launched++;
+  }
+
+  if (cp_op == 1) {
+    char f1name[2048];
+    snprintf(f1name, 2048, "checkpoint_files/global_mem_%d.txt",
+             kernel.get_uid());
+    g_checkpoint->store_global_mem(
+        gpgpu_ctx->the_gpgpusim->g_the_gpu->get_global_memory(), f1name,
+        (char *)"%08x");
+  }
+
+  // registering this kernel as done
+
+  // openCL kernel simulation calls don't register the kernel so we don't
+  // register its exit
+  if (!openCL) {
+    // extern stream_manager *g_stream_manager;
+    gpgpu_ctx->the_gpgpusim->g_stream_manager->register_finished_kernel(
+        kernel.get_uid());
+  }
+
+  //******PRINTING*******
+  printf("GPGPU-Sim: Done functional simulation (%u instructions simulated).\n",
+         g_ptx_sim_num_insn);
+  if (gpgpu_ptx_instruction_classification) {
+    StatDisp(g_inst_classification_stat[g_ptx_kernel_count]);
+    StatDisp(g_inst_op_classification_stat[g_ptx_kernel_count]);
+  }
+
+  // time_t variables used to calculate the total simulation time
+  // the start time of simulation is hold by the global variable
+  // g_simulation_starttime
+  // g_simulation_starttime is initilized by gpgpu_ptx_sim_init_perf() in
+  // gpgpusim_entrypoint.cc upon starting gpgpu-sim
+  time_t end_time, elapsed_time, days, hrs, minutes, sec;
+  end_time = time((time_t *)NULL);
+  elapsed_time =
+      MAX(end_time - gpgpu_ctx->the_gpgpusim->g_simulation_starttime, 1);
+
+  // calculating and printing simulation time in terms of days, hours, minutes
+  // and seconds
+  days = elapsed_time / (3600 * 24);
+  hrs = elapsed_time / 3600 - 24 * days;
+  minutes = elapsed_time / 60 - 60 * (hrs + 24 * days);
+  sec = elapsed_time - 60 * (minutes + 60 * (hrs + 24 * days));
+
+  fflush(stderr);
+  printf(
+      "\n\ngpgpu_simulation_time = %u days, %u hrs, %u min, %u sec (%u sec)\n",
+      (unsigned)days, (unsigned)hrs, (unsigned)minutes, (unsigned)sec,
+      (unsigned)elapsed_time);
+  printf("gpgpu_simulation_rate = %u (inst/sec)\n",
+         (unsigned)(g_ptx_sim_num_insn / elapsed_time));
+  fflush(stdout);
+}
+
+void functionalCoreSim::initializeCTA(unsigned ctaid_cp) {
+  int ctaLiveThreads = 0;
+  symbol_table *symtab = m_kernel->entry()->get_symtab();
+
+  for (int i = 0; i < m_warp_count; i++) {
+    m_warpAtBarrier[i] = false;
+    m_liveThreadCount[i] = 0;
+  }
+  for (int i = 0; i < m_warp_count * m_warp_size; i++) m_thread[i] = NULL;
+
+  // get threads for a cta
+  for (unsigned i = 0; i < m_kernel->threads_per_cta(); i++) {
+    ptx_sim_init_thread(*m_kernel, &m_thread[i], 0, i,
+                        m_kernel->threads_per_cta() - i,
+                        m_kernel->threads_per_cta(), this, 0, i / m_warp_size,
+                        (gpgpu_t *)m_gpu, true);
+    assert(m_thread[i] != NULL && !m_thread[i]->is_done());
+    char fname[2048];
+    snprintf(fname, 2048, "checkpoint_files/thread_%d_0_reg.txt", i);
+    if (m_gpu->gpgpu_ctx->func_sim->cp_cta_resume == 1)
+      m_thread[i]->resume_reg_thread(fname, symtab);
+    ctaLiveThreads++;
+  }
+
+  for (int k = 0; k < m_warp_count; k++) createWarp(k);
+}
+
+void functionalCoreSim::createWarp(unsigned warpId) {
+  simt_mask_t initialMask;
+  unsigned liveThreadsCount = 0;
+  initialMask.set();
+  for (int i = warpId * m_warp_size; i < warpId * m_warp_size + m_warp_size;
+       i++) {
+    if (m_thread[i] == NULL)
+      initialMask.reset(i - warpId * m_warp_size);
+    else
+      liveThreadsCount++;
+  }
+
+  assert(m_thread[warpId * m_warp_size] != NULL);
+  m_simt_stack[warpId]->launch(m_thread[warpId * m_warp_size]->get_pc(),
+                               initialMask);
+  char fname[2048];
+  snprintf(fname, 2048, "checkpoint_files/warp_%d_0_simt.txt", warpId);
+
+  if (m_gpu->gpgpu_ctx->func_sim->cp_cta_resume == 1) {
+    unsigned pc, rpc;
+    m_simt_stack[warpId]->resume(fname);
+    m_simt_stack[warpId]->get_pdom_stack_top_info(&pc, &rpc);
+    for (int i = warpId * m_warp_size; i < warpId * m_warp_size + m_warp_size;
+         i++) {
+      m_thread[i]->set_npc(pc);
+      m_thread[i]->update_pc();
+    }
+  }
+  m_liveThreadCount[warpId] = liveThreadsCount;
+}
+
+void functionalCoreSim::execute(int inst_count, unsigned ctaid_cp) {
+  m_gpu->gpgpu_ctx->func_sim->cp_count = m_gpu->checkpoint_insn_Y;
+  m_gpu->gpgpu_ctx->func_sim->cp_cta_resume = m_gpu->checkpoint_CTA_t;
+  initializeCTA(ctaid_cp);
+
+  int count = 0;
+  while (true) {
+    bool someOneLive = false;
+    bool allAtBarrier = true;
+    for (unsigned i = 0; i < m_warp_count; i++) {
+      executeWarp(i, allAtBarrier, someOneLive);
+      count++;
     }
 
-      
-      
-     if(cp_op==1)
-	{
+    if (inst_count > 0 && count > inst_count &&
+        (m_kernel->get_uid() == m_gpu->checkpoint_kernel) &&
+        (ctaid_cp >= m_gpu->checkpoint_CTA) &&
+        (ctaid_cp < m_gpu->checkpoint_CTA_t) && m_gpu->checkpoint_option == 1) {
+      someOneLive = false;
+      break;
+    }
+    if (!someOneLive) break;
+    if (allAtBarrier) {
+      for (unsigned i = 0; i < m_warp_count; i++) m_warpAtBarrier[i] = false;
+    }
+  }
+
+  checkpoint *g_checkpoint;
+  g_checkpoint = new checkpoint();
+
+  ptx_reg_t regval;
+  regval.u64 = 123;
+
+  unsigned ctaid = m_kernel->get_next_cta_id_single();
+  if (m_gpu->checkpoint_option == 1 &&
+      (m_kernel->get_uid() == m_gpu->checkpoint_kernel) &&
+      (ctaid_cp >= m_gpu->checkpoint_CTA) &&
+      (ctaid_cp < m_gpu->checkpoint_CTA_t)) {
+    char fname[2048];
+    snprintf(fname, 2048, "checkpoint_files/shared_mem_%d.txt", ctaid - 1);
+    g_checkpoint->store_global_mem(m_thread[0]->m_shared_mem, fname,
+                                   (char *)"%08x");
+    for (int i = 0; i < 32 * m_warp_count; i++) {
+      char fname[2048];
+      snprintf(fname, 2048, "checkpoint_files/thread_%d_%d_reg.txt", i,
+               ctaid - 1);
+      m_thread[i]->print_reg_thread(fname);
       char f1name[2048];
-      snprintf(f1name,2048,"checkpoint_files/global_mem_%d.txt", kernel.get_uid() );
-      g_checkpoint->store_global_mem(gpgpu_ctx->the_gpgpusim->g_the_gpu->get_global_memory(), f1name , (char *)"%08x");
-	}
-
-
-      
-    
-   //registering this kernel as done      
-   
-   //openCL kernel simulation calls don't register the kernel so we don't register its exit
-   if(!openCL) {
-      //extern stream_manager *g_stream_manager;
-      gpgpu_ctx->the_gpgpusim->g_stream_manager->register_finished_kernel(kernel.get_uid());
-   }
-
-   //******PRINTING*******
-   printf( "GPGPU-Sim: Done functional simulation (%u instructions simulated).\n", g_ptx_sim_num_insn );
-   if ( gpgpu_ptx_instruction_classification ) {
-      StatDisp( g_inst_classification_stat[g_ptx_kernel_count]);
-      StatDisp ( g_inst_op_classification_stat[g_ptx_kernel_count]);
-   }
-
-   //time_t variables used to calculate the total simulation time
-   //the start time of simulation is hold by the global variable g_simulation_starttime
-   //g_simulation_starttime is initilized by gpgpu_ptx_sim_init_perf() in gpgpusim_entrypoint.cc upon starting gpgpu-sim
-   time_t end_time, elapsed_time, days, hrs, minutes, sec;
-   end_time = time((time_t *)NULL);
-   elapsed_time = MAX(end_time - gpgpu_ctx->the_gpgpusim->g_simulation_starttime, 1);
-	
-
-   //calculating and printing simulation time in terms of days, hours, minutes and seconds
-   days    = elapsed_time/(3600*24);
-   hrs     = elapsed_time/3600 - 24*days;
-   minutes = elapsed_time/60 - 60*(hrs + 24*days);
-   sec = elapsed_time - 60*(minutes + 60*(hrs + 24*days));
-
-   fflush(stderr);
-   printf("\n\ngpgpu_simulation_time = %u days, %u hrs, %u min, %u sec (%u sec)\n",
-          (unsigned)days, (unsigned)hrs, (unsigned)minutes, (unsigned)sec, (unsigned)elapsed_time );
-   printf("gpgpu_simulation_rate = %u (inst/sec)\n", (unsigned)(g_ptx_sim_num_insn / elapsed_time) );
-   fflush(stdout); 
-}
-
-void functionalCoreSim::initializeCTA(unsigned ctaid_cp)
-{
-    int ctaLiveThreads=0;
-    symbol_table * symtab= m_kernel->entry()->get_symtab();
-    
-    for(int i=0; i< m_warp_count; i++){
-        m_warpAtBarrier[i]=false;
-        m_liveThreadCount[i]=0;
-    }
-    for(int i=0; i< m_warp_count*m_warp_size;i++)
-        m_thread[i]=NULL;
-    
-    //get threads for a cta
-    for(unsigned i=0; i<m_kernel->threads_per_cta();i++) {
-        ptx_sim_init_thread(*m_kernel,&m_thread[i],0,i,m_kernel->threads_per_cta()-i,m_kernel->threads_per_cta(),this,0,i/m_warp_size,(gpgpu_t*)m_gpu, true);
-        assert(m_thread[i]!=NULL && !m_thread[i]->is_done());
-        char fname[2048];
-        snprintf(fname,2048,"checkpoint_files/thread_%d_0_reg.txt",i );
-        if(m_gpu->gpgpu_ctx->func_sim->cp_cta_resume==1)
-            m_thread[i]->resume_reg_thread(fname,symtab);
-        ctaLiveThreads++;
+      snprintf(f1name, 2048, "checkpoint_files/local_mem_thread_%d_%d_reg.txt",
+               i, ctaid - 1);
+      g_checkpoint->store_global_mem(m_thread[i]->m_local_mem, f1name,
+                                     (char *)"%08x");
+      m_thread[i]->set_done();
+      m_thread[i]->exitCore();
+      m_thread[i]->registerExit();
     }
 
-    for(int k=0;k<m_warp_count;k++)
-        createWarp(k);
-}
-
-void  functionalCoreSim::createWarp(unsigned warpId)
-{
-   simt_mask_t initialMask;
-   unsigned liveThreadsCount=0;
-   initialMask.set();
-    for(int i=warpId*m_warp_size; i<warpId*m_warp_size+m_warp_size;i++){
-        if(m_thread[i]==NULL) initialMask.reset(i-warpId*m_warp_size);
-        else liveThreadsCount++;
-    }   
-   
-   assert(m_thread[warpId*m_warp_size]!=NULL);
-   m_simt_stack[warpId]->launch(m_thread[warpId*m_warp_size]->get_pc(),initialMask);
-   char fname[2048];
-   snprintf(fname,2048,"checkpoint_files/warp_%d_0_simt.txt",warpId );
-
-   if(m_gpu->gpgpu_ctx->func_sim->cp_cta_resume==1)
-   {
-      unsigned pc,rpc;
-      m_simt_stack[warpId]->resume(fname);
-      m_simt_stack[warpId]->get_pdom_stack_top_info(&pc,&rpc);
-      for(int i=warpId*m_warp_size; i<warpId*m_warp_size+m_warp_size;i++){
-        m_thread[i]->set_npc(pc);
-        m_thread[i]->update_pc();
-    }   
-
-   }
-   m_liveThreadCount[warpId]= liveThreadsCount;
-}
-
-void functionalCoreSim::execute(int inst_count, unsigned ctaid_cp)
- {
-     m_gpu->gpgpu_ctx->func_sim->cp_count= m_gpu->checkpoint_insn_Y;
-     m_gpu->gpgpu_ctx->func_sim->cp_cta_resume= m_gpu->checkpoint_CTA_t;
-    initializeCTA(ctaid_cp);
-    
-    int count=0;
-    while(true){
-        bool someOneLive= false;
-        bool allAtBarrier = true;
-        for(unsigned i=0;i<m_warp_count;i++){
-            executeWarp(i,allAtBarrier,someOneLive);
-            count++;
-        }
-        
-        if(inst_count>0 && count>inst_count && (m_kernel->get_uid()==m_gpu->checkpoint_kernel) && (ctaid_cp>=m_gpu->checkpoint_CTA) && (ctaid_cp<m_gpu->checkpoint_CTA_t) && m_gpu->checkpoint_option==1) 
-         {
-            someOneLive=false;
-            break;
-         }
-        if(!someOneLive) break;
-        if(allAtBarrier){
-             for(unsigned i=0;i<m_warp_count;i++)
-                 m_warpAtBarrier[i]=false;
-        }
+    for (int i = 0; i < m_warp_count; i++) {
+      char fname[2048];
+      snprintf(fname, 2048, "checkpoint_files/warp_%d_%d_simt.txt", i,
+               ctaid - 1);
+      FILE *fp = fopen(fname, "w");
+      assert(fp != NULL);
+      m_simt_stack[i]->print_checkpoint(fp);
+      fclose(fp);
     }
-
-    checkpoint *g_checkpoint;
-    g_checkpoint = new checkpoint();
-    
-    ptx_reg_t regval;
-    regval.u64= 123;
-
-    unsigned ctaid =m_kernel->get_next_cta_id_single();
-    if(m_gpu->checkpoint_option==1 && (m_kernel->get_uid()==m_gpu->checkpoint_kernel) && (ctaid_cp>=m_gpu->checkpoint_CTA) && (ctaid_cp<m_gpu->checkpoint_CTA_t))
-   {
-       char fname[2048];
-       snprintf(fname,2048,"checkpoint_files/shared_mem_%d.txt",ctaid-1 );
-       g_checkpoint->store_global_mem(m_thread[0]->m_shared_mem, fname , (char *)"%08x");
-      for(int i=0; i<32*m_warp_count;i++)
-      {
-         char fname[2048];
-         snprintf(fname,2048,"checkpoint_files/thread_%d_%d_reg.txt",i,ctaid-1 );
-          m_thread[i]->print_reg_thread(fname);
-          char f1name[2048];
-         snprintf(f1name,2048,"checkpoint_files/local_mem_thread_%d_%d_reg.txt",i,ctaid-1 );
-         g_checkpoint->store_global_mem(m_thread[i]->m_local_mem, f1name , (char *)"%08x");
-         m_thread[i]->set_done();
-         m_thread[i]->exitCore();
-         m_thread[i]->registerExit();
-      }
-   
-      for(int i=0;i<m_warp_count;i++)
-      {
-         
-         char fname[2048];
-         snprintf(fname,2048,"checkpoint_files/warp_%d_%d_simt.txt",i,ctaid-1 );
-         FILE * fp = fopen(fname,"w");
-         assert(fp!=NULL);
-         m_simt_stack[i]->print_checkpoint(fp);
-         fclose(fp);
-      }
-   }
-
+  }
 }
 
-void functionalCoreSim::executeWarp(unsigned i, bool &allAtBarrier, bool & someOneLive)
-{
-    if(!m_warpAtBarrier[i] && m_liveThreadCount[i]!=0){
-        warp_inst_t inst =getExecuteWarp(i);
-        execute_warp_inst_t(inst,i);
-        if(inst.isatomic()) inst.do_atomic(true);
-        if(inst.op==BARRIER_OP || inst.op==MEMORY_BARRIER_OP ) m_warpAtBarrier[i]=true;
-        updateSIMTStack( i, &inst );
-    }
-    if(m_liveThreadCount[i]>0) someOneLive=true;
-    if(!m_warpAtBarrier[i]&& m_liveThreadCount[i]>0) allAtBarrier = false;
+void functionalCoreSim::executeWarp(unsigned i, bool &allAtBarrier,
+                                    bool &someOneLive) {
+  if (!m_warpAtBarrier[i] && m_liveThreadCount[i] != 0) {
+    warp_inst_t inst = getExecuteWarp(i);
+    execute_warp_inst_t(inst, i);
+    if (inst.isatomic()) inst.do_atomic(true);
+    if (inst.op == BARRIER_OP || inst.op == MEMORY_BARRIER_OP)
+      m_warpAtBarrier[i] = true;
+    updateSIMTStack(i, &inst);
+  }
+  if (m_liveThreadCount[i] > 0) someOneLive = true;
+  if (!m_warpAtBarrier[i] && m_liveThreadCount[i] > 0) allAtBarrier = false;
 }
 
-unsigned gpgpu_context::translate_pc_to_ptxlineno(unsigned pc)
-{
-   // this function assumes that the kernel fits inside a single PTX file
-   // function_info *pFunc = g_func_info; // assume that the current kernel is the one in query
-   const ptx_instruction *pInsn = pc_to_instruction(pc);
-   unsigned ptx_line_number = pInsn->source_line();
+unsigned gpgpu_context::translate_pc_to_ptxlineno(unsigned pc) {
+  // this function assumes that the kernel fits inside a single PTX file
+  // function_info *pFunc = g_func_info; // assume that the current kernel is
+  // the one in query
+  const ptx_instruction *pInsn = pc_to_instruction(pc);
+  unsigned ptx_line_number = pInsn->source_line();
 
-   return ptx_line_number;
+  return ptx_line_number;
 }
 
 // ptxinfo parser
 
-extern std::map<unsigned,const char*> get_duplicate();
+extern std::map<unsigned, const char *> get_duplicate();
 
 static char *g_ptxinfo_kname = NULL;
 static struct gpgpu_ptx_sim_info g_ptxinfo;
-static std::map<unsigned,const char*> g_duplicate;
+static std::map<unsigned, const char *> g_duplicate;
 static const char *g_last_dup_type;
 
-const char *get_ptxinfo_kname() 
-{ 
-    return g_ptxinfo_kname; 
+const char *get_ptxinfo_kname() { return g_ptxinfo_kname; }
+
+void print_ptxinfo() {
+  if (!get_ptxinfo_kname()) {
+    printf("GPGPU-Sim PTX: Binary info : gmem=%u, cmem=%u\n", g_ptxinfo.gmem,
+           g_ptxinfo.cmem);
+  }
+  if (get_ptxinfo_kname()) {
+    printf(
+        "GPGPU-Sim PTX: Kernel \'%s\' : regs=%u, lmem=%u, smem=%u, cmem=%u\n",
+        get_ptxinfo_kname(), g_ptxinfo.regs, g_ptxinfo.lmem, g_ptxinfo.smem,
+        g_ptxinfo.cmem);
+  }
 }
 
-void print_ptxinfo()
-{
-    if(! get_ptxinfo_kname()){
-    	printf ("GPGPU-Sim PTX: Binary info : gmem=%u, cmem=%u\n",
-    			g_ptxinfo.gmem,
-    			g_ptxinfo.cmem);
-    }
-    if(get_ptxinfo_kname()){
-    	printf ("GPGPU-Sim PTX: Kernel \'%s\' : regs=%u, lmem=%u, smem=%u, cmem=%u\n",
-    			get_ptxinfo_kname(),
-    			g_ptxinfo.regs,
-    			g_ptxinfo.lmem,
-    			g_ptxinfo.smem,
-    			g_ptxinfo.cmem );
-    }
+struct gpgpu_ptx_sim_info get_ptxinfo() {
+  return g_ptxinfo;
 }
 
+std::map<unsigned, const char *> get_duplicate() { return g_duplicate; }
 
-struct gpgpu_ptx_sim_info get_ptxinfo()
-{
-    return g_ptxinfo;
+void ptxinfo_linenum(unsigned linenum) {
+  g_duplicate[linenum] = g_last_dup_type;
 }
 
-std::map<unsigned,const char*> get_duplicate()
-{
-	return g_duplicate;
+void ptxinfo_dup_type(const char *dup_type) { g_last_dup_type = dup_type; }
+
+void ptxinfo_function(const char *fname) {
+  clear_ptxinfo();
+  g_ptxinfo_kname = strdup(fname);
 }
 
-void ptxinfo_linenum( unsigned linenum )
-{
-	g_duplicate[linenum] = g_last_dup_type;
+void ptxinfo_regs(unsigned nregs) { g_ptxinfo.regs = nregs; }
+
+void ptxinfo_lmem(unsigned declared, unsigned system) {
+  g_ptxinfo.lmem = declared + system;
 }
 
-void ptxinfo_dup_type( const char *dup_type )
-{
-	g_last_dup_type = dup_type;
+void ptxinfo_gmem(unsigned declared, unsigned system) {
+  g_ptxinfo.gmem = declared + system;
 }
 
-void ptxinfo_function(const char *fname )
-{
+void ptxinfo_smem(unsigned declared, unsigned system) {
+  g_ptxinfo.smem = declared + system;
+}
+
+void ptxinfo_cmem(unsigned nbytes, unsigned bank) { g_ptxinfo.cmem += nbytes; }
+
+void clear_ptxinfo() {
+  free(g_ptxinfo_kname);
+  g_ptxinfo_kname = NULL;
+  g_ptxinfo.regs = 0;
+  g_ptxinfo.lmem = 0;
+  g_ptxinfo.smem = 0;
+  g_ptxinfo.cmem = 0;
+  g_ptxinfo.gmem = 0;
+  g_ptxinfo.ptx_version = 0;
+  g_ptxinfo.sm_target = 0;
+}
+
+void ptxinfo_opencl_addinfo(std::map<std::string, function_info *> &kernels) {
+  if (!g_ptxinfo_kname) {
+    printf("GPGPU-Sim PTX: Binary info : gmem=%u, cmem=%u\n", g_ptxinfo.gmem,
+           g_ptxinfo.cmem);
     clear_ptxinfo();
-    g_ptxinfo_kname = strdup(fname);
+    return;
+  }
+
+  if (!strcmp("__cuda_dummy_entry__", g_ptxinfo_kname)) {
+    // this string produced by ptxas for empty ptx files (e.g., bandwidth test)
+    clear_ptxinfo();
+    return;
+  }
+  std::map<std::string, function_info *>::iterator k =
+      kernels.find(g_ptxinfo_kname);
+  if (k == kernels.end()) {
+    printf("GPGPU-Sim PTX: ERROR ** implementation for '%s' not found.\n",
+           g_ptxinfo_kname);
+    abort();
+  } else {
+    printf(
+        "GPGPU-Sim PTX: Kernel \'%s\' : regs=%u, lmem=%u, smem=%u, cmem=%u\n",
+        g_ptxinfo_kname, g_ptxinfo.regs, g_ptxinfo.lmem, g_ptxinfo.smem,
+        g_ptxinfo.cmem);
+    function_info *finfo = k->second;
+    assert(finfo != NULL);
+    finfo->set_kernel_info(g_ptxinfo);
+  }
+  clear_ptxinfo();
 }
 
-void ptxinfo_regs( unsigned nregs )
-{
-    g_ptxinfo.regs=nregs;
-}
+struct rec_pts cuda_sim::find_reconvergence_points(function_info *finfo) {
+  rec_pts tmp;
+  std::map<function_info *, rec_pts>::iterator r = g_rpts.find(finfo);
 
-void ptxinfo_lmem( unsigned declared, unsigned system )
-{
-    g_ptxinfo.lmem=declared+system;
-}
+  if (r == g_rpts.end()) {
+    int num_recon = finfo->get_num_reconvergence_pairs();
 
-void ptxinfo_gmem( unsigned declared, unsigned system )
-{
-    g_ptxinfo.gmem=declared+system;
-}
-
-void ptxinfo_smem( unsigned declared, unsigned system )
-{
-    g_ptxinfo.smem=declared+system;
-}
-
-void ptxinfo_cmem( unsigned nbytes, unsigned bank )
-{
-    g_ptxinfo.cmem+=nbytes;
-}
-
-void clear_ptxinfo()
-{
-    free(g_ptxinfo_kname);
-    g_ptxinfo_kname=NULL;
-    g_ptxinfo.regs=0;
-    g_ptxinfo.lmem=0;
-    g_ptxinfo.smem=0;
-    g_ptxinfo.cmem=0;
-    g_ptxinfo.gmem=0;
-    g_ptxinfo.ptx_version=0;
-    g_ptxinfo.sm_target=0;
-}
-
-
-void ptxinfo_opencl_addinfo( std::map<std::string,function_info*> &kernels )
-{
-
-   if(! g_ptxinfo_kname) {
-	  printf ("GPGPU-Sim PTX: Binary info : gmem=%u, cmem=%u\n",
-			  g_ptxinfo.gmem,
-			  g_ptxinfo.cmem);
-	  clear_ptxinfo();
-	  return;
-   }
-
-   if( !strcmp("__cuda_dummy_entry__",g_ptxinfo_kname) ) {
-      // this string produced by ptxas for empty ptx files (e.g., bandwidth test)
-      clear_ptxinfo();
-      return;
-   }
-   std::map<std::string,function_info*>::iterator k=kernels.find(g_ptxinfo_kname);
-   if( k==kernels.end() ) {
-      printf ("GPGPU-Sim PTX: ERROR ** implementation for '%s' not found.\n", g_ptxinfo_kname );
-      abort();
-   } else {
-      printf ("GPGPU-Sim PTX: Kernel \'%s\' : regs=%u, lmem=%u, smem=%u, cmem=%u\n", 
-              g_ptxinfo_kname,
-              g_ptxinfo.regs,
-              g_ptxinfo.lmem,
-              g_ptxinfo.smem,
-              g_ptxinfo.cmem );
-      function_info *finfo = k->second;
-      assert(finfo!=NULL);
-      finfo->set_kernel_info( g_ptxinfo );
-   }
-   clear_ptxinfo();
-}
-
-struct rec_pts cuda_sim::find_reconvergence_points( function_info *finfo )
-{
-   rec_pts tmp;
-   std::map<function_info*,rec_pts>::iterator r=g_rpts.find(finfo);
- 
-   if( r==g_rpts.end() ) {
-      int num_recon = finfo->get_num_reconvergence_pairs();
-      
-      gpgpu_recon_t *kernel_recon_points = (struct gpgpu_recon_t*) calloc(num_recon, sizeof(struct gpgpu_recon_t));
-      finfo->get_reconvergence_pairs(kernel_recon_points);
-      printf("GPGPU-Sim PTX: reconvergence points for %s...\n", finfo->get_name().c_str() );
-      for (int i=0;i<num_recon;i++) {
-         printf("GPGPU-Sim PTX: %2u (potential) branch divergence @ ", i+1 );
-         kernel_recon_points[i].source_inst->print_insn();
-         printf("\n");
-         printf("GPGPU-Sim PTX:    immediate post dominator      @ " ); 
-         if( kernel_recon_points[i].target_inst )
-            kernel_recon_points[i].target_inst->print_insn();
-         printf("\n");
-      }
-      printf("GPGPU-Sim PTX: ... end of reconvergence points for %s\n", finfo->get_name().c_str() );
-
-      tmp.s_kernel_recon_points = kernel_recon_points;
-      tmp.s_num_recon = num_recon;
-      g_rpts[finfo] = tmp;
-   } else {
-      tmp = r->second;
-   }
-   return tmp;
-}
-
-address_type get_return_pc( void *thd )
-{
-    // function call return
-    ptx_thread_info *the_thread = (ptx_thread_info*)thd;
-    assert( the_thread != NULL );
-    return the_thread->get_return_PC();
-}
-
-address_type cuda_sim::get_converge_point( address_type pc )
-{
-   // the branch could encode the reconvergence point and/or a bit that indicates the 
-   // reconvergence point is the return PC on the call stack in the case the branch has 
-   // no immediate postdominator in the function (i.e., due to multiple return points). 
-
-   std::map<unsigned,function_info*>::iterator f=g_pc_to_finfo.find(pc);
-   assert( f != g_pc_to_finfo.end() );
-   function_info *finfo = f->second;
-   rec_pts tmp = find_reconvergence_points(finfo);
-
-   int i=0;
-   for (; i < tmp.s_num_recon; ++i) {
-      if (tmp.s_kernel_recon_points[i].source_pc == pc) {
-          if( tmp.s_kernel_recon_points[i].target_pc == (unsigned) -2 ) {
-              return RECONVERGE_RETURN_PC;
-          } else {
-              return tmp.s_kernel_recon_points[i].target_pc;
-          }
-      }
-   }
-   return NO_BRANCH_DIVERGENCE;
-}
-
-void functionalCoreSim::warp_exit( unsigned warp_id )
-{
-    for(int i=0;i<m_warp_count*m_warp_size;i++){
-        if(m_thread[i]!=NULL){
-             m_thread[i]->m_cta_info->register_deleted_thread(m_thread[i]);
-             delete m_thread[i];
-        }
+    gpgpu_recon_t *kernel_recon_points =
+        (struct gpgpu_recon_t *)calloc(num_recon, sizeof(struct gpgpu_recon_t));
+    finfo->get_reconvergence_pairs(kernel_recon_points);
+    printf("GPGPU-Sim PTX: reconvergence points for %s...\n",
+           finfo->get_name().c_str());
+    for (int i = 0; i < num_recon; i++) {
+      printf("GPGPU-Sim PTX: %2u (potential) branch divergence @ ", i + 1);
+      kernel_recon_points[i].source_inst->print_insn();
+      printf("\n");
+      printf("GPGPU-Sim PTX:    immediate post dominator      @ ");
+      if (kernel_recon_points[i].target_inst)
+        kernel_recon_points[i].target_inst->print_insn();
+      printf("\n");
     }
+    printf("GPGPU-Sim PTX: ... end of reconvergence points for %s\n",
+           finfo->get_name().c_str());
+
+    tmp.s_kernel_recon_points = kernel_recon_points;
+    tmp.s_num_recon = num_recon;
+    g_rpts[finfo] = tmp;
+  } else {
+    tmp = r->second;
+  }
+  return tmp;
+}
+
+address_type get_return_pc(void *thd) {
+  // function call return
+  ptx_thread_info *the_thread = (ptx_thread_info *)thd;
+  assert(the_thread != NULL);
+  return the_thread->get_return_PC();
+}
+
+address_type cuda_sim::get_converge_point(address_type pc) {
+  // the branch could encode the reconvergence point and/or a bit that indicates
+  // the
+  // reconvergence point is the return PC on the call stack in the case the
+  // branch has
+  // no immediate postdominator in the function (i.e., due to multiple return
+  // points).
+
+  std::map<unsigned, function_info *>::iterator f = g_pc_to_finfo.find(pc);
+  assert(f != g_pc_to_finfo.end());
+  function_info *finfo = f->second;
+  rec_pts tmp = find_reconvergence_points(finfo);
+
+  int i = 0;
+  for (; i < tmp.s_num_recon; ++i) {
+    if (tmp.s_kernel_recon_points[i].source_pc == pc) {
+      if (tmp.s_kernel_recon_points[i].target_pc == (unsigned)-2) {
+        return RECONVERGE_RETURN_PC;
+      } else {
+        return tmp.s_kernel_recon_points[i].target_pc;
+      }
+    }
+  }
+  return NO_BRANCH_DIVERGENCE;
+}
+
+void functionalCoreSim::warp_exit(unsigned warp_id) {
+  for (int i = 0; i < m_warp_count * m_warp_size; i++) {
+    if (m_thread[i] != NULL) {
+      m_thread[i]->m_cta_info->register_deleted_thread(m_thread[i]);
+      delete m_thread[i];
+    }
+  }
 }

--- a/src/cuda-sim/cuda-sim.cc
+++ b/src/cuda-sim/cuda-sim.cc
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2011, Tor M. Aamodt, Ali Bakhoda, Wilson W.L. Fung,
-// George L. Yuan, Jimmy Kwa 
+// George L. Yuan, Jimmy Kwa
 // The University of British Columbia
 // All rights reserved.
 //
@@ -8,283 +8,340 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #include "cuda-sim.h"
 
 #include "instructions.h"
 #include "ptx_ir.h"
 class ptx_recognizer;
-typedef void * yyscan_t;
-#include "ptx.tab.h"
-#include "ptx_sim.h"
+typedef void *yyscan_t;
 #include <stdio.h>
-#include <sstream>
-#include "opcodes.h"
-#include "../statwrapper.h"
-#include <set>
 #include <map>
+#include <set>
+#include <sstream>
+#include "../../libcuda/gpgpu_context.h"
 #include "../abstract_hardware_model.h"
-#include "memory.h"
-#include "ptx-stats.h"
-#include "ptx_loader.h"
-#include "ptx_parser.h"
 #include "../gpgpu-sim/gpu-sim.h"
-#include "ptx_sim.h"
 #include "../gpgpusim_entrypoint.h"
-#include "decuda_pred_table/decuda_pred_table.h"
+#include "../statwrapper.h"
 #include "../stream_manager.h"
 #include "cuda_device_runtime.h"
-#include "../../libcuda/gpgpu_context.h"
+#include "decuda_pred_table/decuda_pred_table.h"
+#include "memory.h"
+#include "opcodes.h"
+#include "ptx-stats.h"
+#include "ptx.tab.h"
+#include "ptx_loader.h"
+#include "ptx_parser.h"
+#include "ptx_sim.h"
 
 int g_debug_execution = 0;
 // Output debug information to file options
 
-
-void cuda_sim::ptx_opcocde_latency_options (option_parser_t opp) {
-	option_parser_register(opp, "-ptx_opcode_latency_int", OPT_CSTR, &opcode_latency_int,
-			"Opcode latencies for integers <ADD,MAX,MUL,MAD,DIV>"
-			"Default 1,1,19,25,145",
-			"1,1,19,25,145");
-	option_parser_register(opp, "-ptx_opcode_latency_fp", OPT_CSTR, &opcode_latency_fp,
-			"Opcode latencies for single precision floating points <ADD,MAX,MUL,MAD,DIV>"
-			"Default 1,1,1,1,30",
-			"1,1,1,1,30");
-	option_parser_register(opp, "-ptx_opcode_latency_dp", OPT_CSTR, &opcode_latency_dp,
-			"Opcode latencies for double precision floating points <ADD,MAX,MUL,MAD,DIV>"
-			"Default 8,8,8,8,335",
-			"8,8,8,8,335");
-	option_parser_register(opp, "-ptx_opcode_latency_sfu", OPT_CSTR, &opcode_latency_sfu,
-			"Opcode latencies for SFU instructions"
-			"Default 8",
-			"8");
-	option_parser_register(opp, "-ptx_opcode_latency_tesnor", OPT_CSTR, &opcode_latency_tensor,
-			"Opcode latencies for Tensor instructions"
-			"Default 64",
-			"64");
-	option_parser_register(opp, "-ptx_opcode_initiation_int", OPT_CSTR, &opcode_initiation_int,
-			"Opcode initiation intervals for integers <ADD,MAX,MUL,MAD,DIV>"
-			"Default 1,1,4,4,32",
-			"1,1,4,4,32");
-	option_parser_register(opp, "-ptx_opcode_initiation_fp", OPT_CSTR, &opcode_initiation_fp,
-			"Opcode initiation intervals for single precision floating points <ADD,MAX,MUL,MAD,DIV>"
-			"Default 1,1,1,1,5",
-			"1,1,1,1,5");
-	option_parser_register(opp, "-ptx_opcode_initiation_dp", OPT_CSTR, &opcode_initiation_dp,
-			"Opcode initiation intervals for double precision floating points <ADD,MAX,MUL,MAD,DIV>"
-			"Default 8,8,8,8,130",
-			"8,8,8,8,130");
-	option_parser_register(opp, "-ptx_opcode_initiation_sfu", OPT_CSTR, &opcode_initiation_sfu,
-			"Opcode initiation intervals for sfu instructions"
-			"Default 8",
-			"8");
-	option_parser_register(opp, "-ptx_opcode_initiation_tensor", OPT_CSTR, &opcode_initiation_tensor,
-			"Opcode initiation intervals for tensor instructions"
-			"Default 64",
-			"64");
-	option_parser_register(opp, "-cdp_latency", OPT_CSTR, &cdp_latency_str,
-			"CDP API latency <cudaStreamCreateWithFlags, \
+void cuda_sim::ptx_opcocde_latency_options(option_parser_t opp) {
+  option_parser_register(opp, "-ptx_opcode_latency_int", OPT_CSTR,
+                         &opcode_latency_int,
+                         "Opcode latencies for integers <ADD,MAX,MUL,MAD,DIV>"
+                         "Default 1,1,19,25,145",
+                         "1,1,19,25,145");
+  option_parser_register(opp, "-ptx_opcode_latency_fp", OPT_CSTR,
+                         &opcode_latency_fp,
+                         "Opcode latencies for single precision floating "
+                         "points <ADD,MAX,MUL,MAD,DIV>"
+                         "Default 1,1,1,1,30",
+                         "1,1,1,1,30");
+  option_parser_register(opp, "-ptx_opcode_latency_dp", OPT_CSTR,
+                         &opcode_latency_dp,
+                         "Opcode latencies for double precision floating "
+                         "points <ADD,MAX,MUL,MAD,DIV>"
+                         "Default 8,8,8,8,335",
+                         "8,8,8,8,335");
+  option_parser_register(opp, "-ptx_opcode_latency_sfu", OPT_CSTR,
+                         &opcode_latency_sfu,
+                         "Opcode latencies for SFU instructions"
+                         "Default 8",
+                         "8");
+  option_parser_register(opp, "-ptx_opcode_latency_tesnor", OPT_CSTR,
+                         &opcode_latency_tensor,
+                         "Opcode latencies for Tensor instructions"
+                         "Default 64",
+                         "64");
+  option_parser_register(
+      opp, "-ptx_opcode_initiation_int", OPT_CSTR, &opcode_initiation_int,
+      "Opcode initiation intervals for integers <ADD,MAX,MUL,MAD,DIV>"
+      "Default 1,1,4,4,32",
+      "1,1,4,4,32");
+  option_parser_register(opp, "-ptx_opcode_initiation_fp", OPT_CSTR,
+                         &opcode_initiation_fp,
+                         "Opcode initiation intervals for single precision "
+                         "floating points <ADD,MAX,MUL,MAD,DIV>"
+                         "Default 1,1,1,1,5",
+                         "1,1,1,1,5");
+  option_parser_register(opp, "-ptx_opcode_initiation_dp", OPT_CSTR,
+                         &opcode_initiation_dp,
+                         "Opcode initiation intervals for double precision "
+                         "floating points <ADD,MAX,MUL,MAD,DIV>"
+                         "Default 8,8,8,8,130",
+                         "8,8,8,8,130");
+  option_parser_register(opp, "-ptx_opcode_initiation_sfu", OPT_CSTR,
+                         &opcode_initiation_sfu,
+                         "Opcode initiation intervals for sfu instructions"
+                         "Default 8",
+                         "8");
+  option_parser_register(opp, "-ptx_opcode_initiation_tensor", OPT_CSTR,
+                         &opcode_initiation_tensor,
+                         "Opcode initiation intervals for tensor instructions"
+                         "Default 64",
+                         "64");
+  option_parser_register(opp, "-cdp_latency", OPT_CSTR, &cdp_latency_str,
+                         "CDP API latency <cudaStreamCreateWithFlags, \
 cudaGetParameterBufferV2_init_perWarp, cudaGetParameterBufferV2_perKernel, \
 cudaLaunchDeviceV2_init_perWarp, cudaLaunchDevicV2_perKernel>"
-			"Default 7200,8000,100,12000,1600",
-			"7200,8000,100,12000,1600");
+                         "Default 7200,8000,100,12000,1600",
+                         "7200,8000,100,12000,1600");
 }
 
-void gpgpu_t::gpgpu_ptx_sim_bindNameToTexture(const char* name, const struct textureReference* texref, int dim, int readmode, int ext)
-{
-   std::string texname(name);
-   if (m_NameToTextureRef.find(texname)==m_NameToTextureRef.end()){
-      m_NameToTextureRef[texname] = std::set<const struct textureReference*>();
-   }else{
-     const struct textureReference* tr = *m_NameToTextureRef[texname].begin();
-     assert(tr!=NULL);
-     //asserts that all texrefs in set have same fields
-     assert(tr->normalized==texref->normalized&&
-            tr->filterMode==texref->filterMode&&
-            tr->addressMode[0]==texref->addressMode[0]&&
-            tr->addressMode[1]==texref->addressMode[1]&&
-            tr->addressMode[2]==texref->addressMode[2]&&
-            tr->channelDesc.x==texref->channelDesc.x&&
-            tr->channelDesc.y==texref->channelDesc.y&&
-            tr->channelDesc.z==texref->channelDesc.z&&
-            tr->channelDesc.w==texref->channelDesc.w&&
-            tr->channelDesc.f==texref->channelDesc.f  
-           );
-   }
-   m_NameToTextureRef[texname].insert(texref);
-   m_TextureRefToName[texref] = texname;
-   const textureReferenceAttr *texAttr = new textureReferenceAttr(texref, dim, (enum cudaTextureReadMode)readmode, ext); 
-   m_NameToAttribute[texname] = texAttr; 
+void gpgpu_t::gpgpu_ptx_sim_bindNameToTexture(
+    const char *name, const struct textureReference *texref, int dim,
+    int readmode, int ext) {
+  std::string texname(name);
+  if (m_NameToTextureRef.find(texname) == m_NameToTextureRef.end()) {
+    m_NameToTextureRef[texname] = std::set<const struct textureReference *>();
+  } else {
+    const struct textureReference *tr = *m_NameToTextureRef[texname].begin();
+    assert(tr != NULL);
+    // asserts that all texrefs in set have same fields
+    assert(tr->normalized == texref->normalized &&
+           tr->filterMode == texref->filterMode &&
+           tr->addressMode[0] == texref->addressMode[0] &&
+           tr->addressMode[1] == texref->addressMode[1] &&
+           tr->addressMode[2] == texref->addressMode[2] &&
+           tr->channelDesc.x == texref->channelDesc.x &&
+           tr->channelDesc.y == texref->channelDesc.y &&
+           tr->channelDesc.z == texref->channelDesc.z &&
+           tr->channelDesc.w == texref->channelDesc.w &&
+           tr->channelDesc.f == texref->channelDesc.f);
+  }
+  m_NameToTextureRef[texname].insert(texref);
+  m_TextureRefToName[texref] = texname;
+  const textureReferenceAttr *texAttr = new textureReferenceAttr(
+      texref, dim, (enum cudaTextureReadMode)readmode, ext);
+  m_NameToAttribute[texname] = texAttr;
 }
 
-const char* gpgpu_t::gpgpu_ptx_sim_findNamefromTexture(const struct textureReference* texref)
-{
-   std::map<const struct textureReference*, std::string>::const_iterator t=m_TextureRefToName.find(texref);
-   assert( t != m_TextureRefToName.end() );
-   return t->second.c_str();
+const char *gpgpu_t::gpgpu_ptx_sim_findNamefromTexture(
+    const struct textureReference *texref) {
+  std::map<const struct textureReference *, std::string>::const_iterator t =
+      m_TextureRefToName.find(texref);
+  assert(t != m_TextureRefToName.end());
+  return t->second.c_str();
 }
 
-unsigned int intLOGB2( unsigned int v ) {
-   unsigned int shift;
-   unsigned int r;
+unsigned int intLOGB2(unsigned int v) {
+  unsigned int shift;
+  unsigned int r;
 
-   r = 0;
+  r = 0;
 
-   shift = (( v & 0xFFFF0000) != 0 ) << 4; v >>= shift; r |= shift;
-   shift = (( v & 0xFF00    ) != 0 ) << 3; v >>= shift; r |= shift;
-   shift = (( v & 0xF0      ) != 0 ) << 2; v >>= shift; r |= shift;
-   shift = (( v & 0xC       ) != 0 ) << 1; v >>= shift; r |= shift;
-   shift = (( v & 0x2       ) != 0 ) << 0; v >>= shift; r |= shift;
+  shift = ((v & 0xFFFF0000) != 0) << 4;
+  v >>= shift;
+  r |= shift;
+  shift = ((v & 0xFF00) != 0) << 3;
+  v >>= shift;
+  r |= shift;
+  shift = ((v & 0xF0) != 0) << 2;
+  v >>= shift;
+  r |= shift;
+  shift = ((v & 0xC) != 0) << 1;
+  v >>= shift;
+  r |= shift;
+  shift = ((v & 0x2) != 0) << 0;
+  v >>= shift;
+  r |= shift;
 
-   return r;
+  return r;
 }
 
-void gpgpu_t::gpgpu_ptx_sim_bindTextureToArray(const struct textureReference* texref, const struct cudaArray* array)
-{
-   std::string texname = gpgpu_ptx_sim_findNamefromTexture(texref);
+void gpgpu_t::gpgpu_ptx_sim_bindTextureToArray(
+    const struct textureReference *texref, const struct cudaArray *array) {
+  std::string texname = gpgpu_ptx_sim_findNamefromTexture(texref);
 
-   std::map<std::string,const struct cudaArray*>::const_iterator t=m_NameToCudaArray.find(texname);
-   //check that there's nothing there first
-   if(t != m_NameToCudaArray.end()){
-      printf("GPGPU-Sim PTX:   Warning: binding to texref associated with %s, which was previously bound.\nImplicitly unbinding texref associated to %s first\n", texname.c_str(), texname.c_str());
-   }
-   m_NameToCudaArray[texname] = array;
-   unsigned int texel_size_bits = array->desc.w + array->desc.x + array->desc.y + array->desc.z;
-   unsigned int texel_size = texel_size_bits/8;
-   unsigned int Tx, Ty;
-   int r;
+  std::map<std::string, const struct cudaArray *>::const_iterator t =
+      m_NameToCudaArray.find(texname);
+  // check that there's nothing there first
+  if (t != m_NameToCudaArray.end()) {
+    printf(
+        "GPGPU-Sim PTX:   Warning: binding to texref associated with %s, which "
+        "was previously bound.\nImplicitly unbinding texref associated to %s "
+        "first\n",
+        texname.c_str(), texname.c_str());
+  }
+  m_NameToCudaArray[texname] = array;
+  unsigned int texel_size_bits =
+      array->desc.w + array->desc.x + array->desc.y + array->desc.z;
+  unsigned int texel_size = texel_size_bits / 8;
+  unsigned int Tx, Ty;
+  int r;
 
-   printf("GPGPU-Sim PTX:   texel size = %d\n", texel_size);
-   printf("GPGPU-Sim PTX:   texture cache linesize = %d\n", m_function_model_config.get_texcache_linesize());
-   //first determine base Tx size for given linesize
-   switch (m_function_model_config.get_texcache_linesize()) {
-   case 16:  Tx = 4; break;
-   case 32:  Tx = 8; break;
-   case 64:  Tx = 8; break;
-   case 128: Tx = 16; break;
-   case 256: Tx = 16; break;
-   default:
-      printf("GPGPU-Sim PTX:   Line size of %d bytes currently not supported.\n", m_function_model_config.get_texcache_linesize());
+  printf("GPGPU-Sim PTX:   texel size = %d\n", texel_size);
+  printf("GPGPU-Sim PTX:   texture cache linesize = %d\n",
+         m_function_model_config.get_texcache_linesize());
+  // first determine base Tx size for given linesize
+  switch (m_function_model_config.get_texcache_linesize()) {
+    case 16:
+      Tx = 4;
+      break;
+    case 32:
+      Tx = 8;
+      break;
+    case 64:
+      Tx = 8;
+      break;
+    case 128:
+      Tx = 16;
+      break;
+    case 256:
+      Tx = 16;
+      break;
+    default:
+      printf(
+          "GPGPU-Sim PTX:   Line size of %d bytes currently not supported.\n",
+          m_function_model_config.get_texcache_linesize());
       assert(0);
       break;
-   }
-   r = texel_size >> 2;
-   //modify base Tx size to take into account size of each texel in bytes
-   while (r != 0) {
-      Tx = Tx >> 1;
-      r = r >> 2;
-   }
-   //by now, got the correct Tx size, calculate correct Ty size
-   Ty = m_function_model_config.get_texcache_linesize()/(Tx*texel_size);
+  }
+  r = texel_size >> 2;
+  // modify base Tx size to take into account size of each texel in bytes
+  while (r != 0) {
+    Tx = Tx >> 1;
+    r = r >> 2;
+  }
+  // by now, got the correct Tx size, calculate correct Ty size
+  Ty = m_function_model_config.get_texcache_linesize() / (Tx * texel_size);
 
-   printf("GPGPU-Sim PTX:   Tx = %d; Ty = %d, Tx_numbits = %d, Ty_numbits = %d\n", Tx, Ty, intLOGB2(Tx), intLOGB2(Ty));
-   printf("GPGPU-Sim PTX:   Texel size = %d bytes; texel_size_numbits = %d\n", texel_size, intLOGB2(texel_size));
-   printf("GPGPU-Sim PTX:   Binding texture to array starting at devPtr32 = 0x%x\n", array->devPtr32);
-   printf("GPGPU-Sim PTX:   Texel size = %d bytes\n", texel_size);
-   struct textureInfo* texInfo = (struct textureInfo*) malloc(sizeof(struct textureInfo)); 
-   texInfo->Tx = Tx;
-   texInfo->Ty = Ty;
-   texInfo->Tx_numbits = intLOGB2(Tx);
-   texInfo->Ty_numbits = intLOGB2(Ty);
-   texInfo->texel_size = texel_size;
-   texInfo->texel_size_numbits = intLOGB2(texel_size);
-   m_NameToTextureInfo[texname] = texInfo;
+  printf(
+      "GPGPU-Sim PTX:   Tx = %d; Ty = %d, Tx_numbits = %d, Ty_numbits = %d\n",
+      Tx, Ty, intLOGB2(Tx), intLOGB2(Ty));
+  printf("GPGPU-Sim PTX:   Texel size = %d bytes; texel_size_numbits = %d\n",
+         texel_size, intLOGB2(texel_size));
+  printf(
+      "GPGPU-Sim PTX:   Binding texture to array starting at devPtr32 = 0x%x\n",
+      array->devPtr32);
+  printf("GPGPU-Sim PTX:   Texel size = %d bytes\n", texel_size);
+  struct textureInfo *texInfo =
+      (struct textureInfo *)malloc(sizeof(struct textureInfo));
+  texInfo->Tx = Tx;
+  texInfo->Ty = Ty;
+  texInfo->Tx_numbits = intLOGB2(Tx);
+  texInfo->Ty_numbits = intLOGB2(Ty);
+  texInfo->texel_size = texel_size;
+  texInfo->texel_size_numbits = intLOGB2(texel_size);
+  m_NameToTextureInfo[texname] = texInfo;
 }
 
-void gpgpu_t::gpgpu_ptx_sim_unbindTexture(const struct textureReference* texref)
-{
-   //assumes bind-use-unbind-bind-use-unbind pattern
-   std::string texname = gpgpu_ptx_sim_findNamefromTexture(texref);
-   m_NameToCudaArray.erase(texname);
-   m_NameToTextureInfo.erase(texname);
+void gpgpu_t::gpgpu_ptx_sim_unbindTexture(
+    const struct textureReference *texref) {
+  // assumes bind-use-unbind-bind-use-unbind pattern
+  std::string texname = gpgpu_ptx_sim_findNamefromTexture(texref);
+  m_NameToCudaArray.erase(texname);
+  m_NameToTextureInfo.erase(texname);
 }
 
 #define MAX_INST_SIZE 8 /*bytes*/
 
-void function_info::ptx_assemble()
-{
-   if( m_assembled ) {
-      return;
-   }
+void function_info::ptx_assemble() {
+  if (m_assembled) {
+    return;
+  }
 
-   // get the instructions into instruction memory...
-   unsigned num_inst = m_instructions.size();
-   m_instr_mem_size = MAX_INST_SIZE*(num_inst+1);
-   m_instr_mem = new ptx_instruction*[ m_instr_mem_size ];
+  // get the instructions into instruction memory...
+  unsigned num_inst = m_instructions.size();
+  m_instr_mem_size = MAX_INST_SIZE * (num_inst + 1);
+  m_instr_mem = new ptx_instruction *[m_instr_mem_size];
 
-   printf("GPGPU-Sim PTX: instruction assembly for function \'%s\'... ", m_name.c_str() );
-   fflush(stdout);
-   std::list<ptx_instruction*>::iterator i;
+  printf("GPGPU-Sim PTX: instruction assembly for function \'%s\'... ",
+         m_name.c_str());
+  fflush(stdout);
+  std::list<ptx_instruction *>::iterator i;
 
-   addr_t PC = gpgpu_ctx->func_sim->g_assemble_code_next_pc; // globally unique address (across functions)
-   // start function on an aligned address
-   for( unsigned i=0; i < (PC%MAX_INST_SIZE); i++ ) 
-      gpgpu_ctx->s_g_pc_to_insn.push_back((ptx_instruction*)NULL);
-   PC += PC%MAX_INST_SIZE; 
-   m_start_PC = PC;
+  addr_t PC =
+      gpgpu_ctx->func_sim->g_assemble_code_next_pc;  // globally unique address
+                                                     // (across functions)
+  // start function on an aligned address
+  for (unsigned i = 0; i < (PC % MAX_INST_SIZE); i++)
+    gpgpu_ctx->s_g_pc_to_insn.push_back((ptx_instruction *)NULL);
+  PC += PC % MAX_INST_SIZE;
+  m_start_PC = PC;
 
-   addr_t n=0; // offset in m_instr_mem
-   //Why s_g_pc_to_insn.size() is needed to reserve additional memory for insts? reserve is cumulative.
-   //s_g_pc_to_insn.reserve(s_g_pc_to_insn.size() + MAX_INST_SIZE*m_instructions.size());
-   gpgpu_ctx->s_g_pc_to_insn.reserve(MAX_INST_SIZE*m_instructions.size());
-   for ( i=m_instructions.begin(); i != m_instructions.end(); i++ ) {
-      ptx_instruction *pI = *i;
-      if ( pI->is_label() ) {
-         const symbol *l = pI->get_label();
-         labels[l->name()] = n;
-      } else {
-         gpgpu_ctx->func_sim->g_pc_to_finfo[PC] = this;
-         m_instr_mem[n] = pI;
-         gpgpu_ctx->s_g_pc_to_insn.push_back(pI);
-         assert(pI == gpgpu_ctx->s_g_pc_to_insn[PC]);
-         pI->set_m_instr_mem_index(n);
-         pI->set_PC(PC);
-         assert( pI->inst_size() <= MAX_INST_SIZE );
-         for( unsigned i=1; i < pI->inst_size(); i++ ) {
-            gpgpu_ctx->s_g_pc_to_insn.push_back((ptx_instruction*)NULL);
-            m_instr_mem[n+i]=NULL;
-         }
-         n  += pI->inst_size();
-         PC += pI->inst_size();
+  addr_t n = 0;  // offset in m_instr_mem
+  // Why s_g_pc_to_insn.size() is needed to reserve additional memory for insts?
+  // reserve is cumulative. s_g_pc_to_insn.reserve(s_g_pc_to_insn.size() +
+  // MAX_INST_SIZE*m_instructions.size());
+  gpgpu_ctx->s_g_pc_to_insn.reserve(MAX_INST_SIZE * m_instructions.size());
+  for (i = m_instructions.begin(); i != m_instructions.end(); i++) {
+    ptx_instruction *pI = *i;
+    if (pI->is_label()) {
+      const symbol *l = pI->get_label();
+      labels[l->name()] = n;
+    } else {
+      gpgpu_ctx->func_sim->g_pc_to_finfo[PC] = this;
+      m_instr_mem[n] = pI;
+      gpgpu_ctx->s_g_pc_to_insn.push_back(pI);
+      assert(pI == gpgpu_ctx->s_g_pc_to_insn[PC]);
+      pI->set_m_instr_mem_index(n);
+      pI->set_PC(PC);
+      assert(pI->inst_size() <= MAX_INST_SIZE);
+      for (unsigned i = 1; i < pI->inst_size(); i++) {
+        gpgpu_ctx->s_g_pc_to_insn.push_back((ptx_instruction *)NULL);
+        m_instr_mem[n + i] = NULL;
       }
-   }
-   gpgpu_ctx->func_sim->g_assemble_code_next_pc=PC;
-   for ( unsigned ii=0; ii < n; ii += m_instr_mem[ii]->inst_size() ) { // handle branch instructions
-      ptx_instruction *pI = m_instr_mem[ii];
-      if ( pI->get_opcode() == BRA_OP || pI->get_opcode() == BREAKADDR_OP  || pI->get_opcode() == CALLP_OP) {
-         operand_info &target = pI->dst(); //get operand, e.g. target name
-         if ( labels.find(target.name()) == labels.end() ) {
-            printf("GPGPU-Sim PTX: Loader error (%s:%u): Branch label \"%s\" does not appear in assembly code.",
-                   pI->source_file(),pI->source_line(), target.name().c_str() );
-            abort();
-         }
-         unsigned index = labels[ target.name() ]; //determine address from name
-         unsigned PC = m_instr_mem[index]->get_PC();
-         m_symtab->set_label_address( target.get_symbol(), PC );
-         target.set_type(label_t);
+      n += pI->inst_size();
+      PC += pI->inst_size();
+    }
+  }
+  gpgpu_ctx->func_sim->g_assemble_code_next_pc = PC;
+  for (unsigned ii = 0; ii < n;
+       ii += m_instr_mem[ii]->inst_size()) {  // handle branch instructions
+    ptx_instruction *pI = m_instr_mem[ii];
+    if (pI->get_opcode() == BRA_OP || pI->get_opcode() == BREAKADDR_OP ||
+        pI->get_opcode() == CALLP_OP) {
+      operand_info &target = pI->dst();  // get operand, e.g. target name
+      if (labels.find(target.name()) == labels.end()) {
+        printf(
+            "GPGPU-Sim PTX: Loader error (%s:%u): Branch label \"%s\" does not "
+            "appear in assembly code.",
+            pI->source_file(), pI->source_line(), target.name().c_str());
+        abort();
       }
-   }
-   m_n = n;
-   printf("  done.\n");
-   fflush(stdout);
+      unsigned index = labels[target.name()];  // determine address from name
+      unsigned PC = m_instr_mem[index]->get_PC();
+      m_symtab->set_label_address(target.get_symbol(), PC);
+      target.set_type(label_t);
+    }
+  }
+  m_n = n;
+  printf("  done.\n");
+  fflush(stdout);
 
-   //disable pdom analysis  here and do it at runtime
+  // disable pdom analysis  here and do it at runtime
 #if 0
    printf("GPGPU-Sim PTX: finding reconvergence points for \'%s\'...\n", m_name.c_str() );
    create_basic_blocks();
@@ -323,2247 +380,2445 @@ void function_info::ptx_assemble()
 #endif
 }
 
-addr_t shared_to_generic( unsigned smid, addr_t addr )
-{
-   assert( addr < SHARED_MEM_SIZE_MAX );
-   return SHARED_GENERIC_START + smid*SHARED_MEM_SIZE_MAX + addr;
+addr_t shared_to_generic(unsigned smid, addr_t addr) {
+  assert(addr < SHARED_MEM_SIZE_MAX);
+  return SHARED_GENERIC_START + smid * SHARED_MEM_SIZE_MAX + addr;
 }
 
-addr_t global_to_generic( addr_t addr )
-{
-   return addr;
+addr_t global_to_generic(addr_t addr) { return addr; }
+
+bool isspace_shared(unsigned smid, addr_t addr) {
+  addr_t start = SHARED_GENERIC_START + smid * SHARED_MEM_SIZE_MAX;
+  addr_t end = SHARED_GENERIC_START + (smid + 1) * SHARED_MEM_SIZE_MAX;
+  if ((addr >= end) || (addr < start)) return false;
+  return true;
 }
 
-bool isspace_shared( unsigned smid, addr_t addr )
-{
-   addr_t start = SHARED_GENERIC_START + smid*SHARED_MEM_SIZE_MAX;
-   addr_t end = SHARED_GENERIC_START + (smid+1)*SHARED_MEM_SIZE_MAX;
-   if( (addr >= end) || (addr < start) ) 
-      return false;
-   return true;
+bool isspace_global(addr_t addr) {
+  return (addr >= GLOBAL_HEAP_START) || (addr < STATIC_ALLOC_LIMIT);
 }
 
-bool isspace_global( addr_t addr )
-{
-   return (addr >= GLOBAL_HEAP_START) || (addr < STATIC_ALLOC_LIMIT);
+memory_space_t whichspace(addr_t addr) {
+  if ((addr >= GLOBAL_HEAP_START) || (addr < STATIC_ALLOC_LIMIT)) {
+    return global_space;
+  } else if (addr >= SHARED_GENERIC_START) {
+    return shared_space;
+  } else {
+    return local_space;
+  }
 }
 
-memory_space_t whichspace( addr_t addr )
-{
-   if( (addr >= GLOBAL_HEAP_START) || (addr < STATIC_ALLOC_LIMIT) ) {
-      return global_space;
-   } else if( addr >= SHARED_GENERIC_START ) {
-      return shared_space;
-   } else {
-      return local_space;
-   }
+addr_t generic_to_shared(unsigned smid, addr_t addr) {
+  assert(isspace_shared(smid, addr));
+  return addr - (SHARED_GENERIC_START + smid * SHARED_MEM_SIZE_MAX);
 }
 
-addr_t generic_to_shared( unsigned smid, addr_t addr )
-{
-   assert(isspace_shared(smid,addr));
-   return addr - (SHARED_GENERIC_START + smid*SHARED_MEM_SIZE_MAX);
+addr_t local_to_generic(unsigned smid, unsigned hwtid, addr_t addr) {
+  assert(addr < LOCAL_MEM_SIZE_MAX);
+  return LOCAL_GENERIC_START + (TOTAL_LOCAL_MEM_PER_SM * smid) +
+         (LOCAL_MEM_SIZE_MAX * hwtid) + addr;
 }
 
-addr_t local_to_generic( unsigned smid, unsigned hwtid, addr_t addr )
-{
-   assert(addr < LOCAL_MEM_SIZE_MAX); 
-   return LOCAL_GENERIC_START + (TOTAL_LOCAL_MEM_PER_SM * smid) + (LOCAL_MEM_SIZE_MAX * hwtid) + addr;
+bool isspace_local(unsigned smid, unsigned hwtid, addr_t addr) {
+  addr_t start = LOCAL_GENERIC_START + (TOTAL_LOCAL_MEM_PER_SM * smid) +
+                 (LOCAL_MEM_SIZE_MAX * hwtid);
+  addr_t end = LOCAL_GENERIC_START + (TOTAL_LOCAL_MEM_PER_SM * smid) +
+               (LOCAL_MEM_SIZE_MAX * (hwtid + 1));
+  if ((addr >= end) || (addr < start)) return false;
+  return true;
 }
 
-bool isspace_local( unsigned smid, unsigned hwtid, addr_t addr )
-{
-   addr_t start = LOCAL_GENERIC_START + (TOTAL_LOCAL_MEM_PER_SM * smid) + (LOCAL_MEM_SIZE_MAX * hwtid);
-   addr_t end   = LOCAL_GENERIC_START + (TOTAL_LOCAL_MEM_PER_SM * smid) + (LOCAL_MEM_SIZE_MAX * (hwtid+1));
-   if( (addr >= end) || (addr < start) ) 
-      return false;
-   return true;
+addr_t generic_to_local(unsigned smid, unsigned hwtid, addr_t addr) {
+  assert(isspace_local(smid, hwtid, addr));
+  return addr - (LOCAL_GENERIC_START + (TOTAL_LOCAL_MEM_PER_SM * smid) +
+                 (LOCAL_MEM_SIZE_MAX * hwtid));
 }
 
-addr_t generic_to_local( unsigned smid, unsigned hwtid, addr_t addr )
-{
-   assert(isspace_local(smid,hwtid,addr));
-   return addr - (LOCAL_GENERIC_START + (TOTAL_LOCAL_MEM_PER_SM * smid) + (LOCAL_MEM_SIZE_MAX * hwtid));
+addr_t generic_to_global(addr_t addr) { return addr; }
+
+void *gpgpu_t::gpu_malloc(size_t size) {
+  unsigned long long result = m_dev_malloc;
+  if (g_debug_execution >= 3) {
+    printf(
+        "GPGPU-Sim PTX: allocating %zu bytes on GPU starting at address "
+        "0x%Lx\n",
+        size, m_dev_malloc);
+    fflush(stdout);
+  }
+  m_dev_malloc += size;
+  if (size % 256)
+    m_dev_malloc += (256 - size % 256);  // align to 256 byte boundaries
+  return (void *)result;
 }
 
-addr_t generic_to_global( addr_t addr )
-{
-   return addr;
+void *gpgpu_t::gpu_mallocarray(size_t size) {
+  unsigned long long result = m_dev_malloc;
+  if (g_debug_execution >= 3) {
+    printf(
+        "GPGPU-Sim PTX: allocating %zu bytes on GPU starting at address "
+        "0x%Lx\n",
+        size, m_dev_malloc);
+    fflush(stdout);
+  }
+  m_dev_malloc += size;
+  if (size % 256)
+    m_dev_malloc += (256 - size % 256);  // align to 256 byte boundaries
+  return (void *)result;
 }
 
+void gpgpu_t::memcpy_to_gpu(size_t dst_start_addr, const void *src,
+                            size_t count) {
+  if (g_debug_execution >= 3) {
+    printf(
+        "GPGPU-Sim PTX: copying %zu bytes from CPU[0x%Lx] to GPU[0x%Lx] ... ",
+        count, (unsigned long long)src, (unsigned long long)dst_start_addr);
+    fflush(stdout);
+  }
+  char *src_data = (char *)src;
+  for (unsigned n = 0; n < count; n++)
+    m_global_mem->write(dst_start_addr + n, 1, src_data + n, NULL, NULL);
 
-void* gpgpu_t::gpu_malloc( size_t size )
-{
-   unsigned long long result = m_dev_malloc;
-   if(g_debug_execution >= 3) {
-      printf("GPGPU-Sim PTX: allocating %zu bytes on GPU starting at address 0x%Lx\n", size, m_dev_malloc );
-      fflush(stdout);
-   }
-   m_dev_malloc += size;
-   if (size%256) m_dev_malloc += (256 - size%256); //align to 256 byte boundaries
-   return(void*) result;
+  // Copy into the performance model.
+  // extern gpgpu_sim* g_the_gpu;
+  gpgpu_ctx->the_gpgpusim->g_the_gpu->perf_memcpy_to_gpu(dst_start_addr, count);
+  if (g_debug_execution >= 3) {
+    printf(" done.\n");
+    fflush(stdout);
+  }
 }
 
-void* gpgpu_t::gpu_mallocarray( size_t size )
-{
-   unsigned long long result = m_dev_malloc;
-   if(g_debug_execution >= 3) {
-      printf("GPGPU-Sim PTX: allocating %zu bytes on GPU starting at address 0x%Lx\n", size, m_dev_malloc );
-      fflush(stdout);
-   }
-   m_dev_malloc += size;
-   if (size%256) m_dev_malloc += (256 - size%256); //align to 256 byte boundaries
-   return(void*) result;
+void gpgpu_t::memcpy_from_gpu(void *dst, size_t src_start_addr, size_t count) {
+  if (g_debug_execution >= 3) {
+    printf("GPGPU-Sim PTX: copying %zu bytes from GPU[0x%Lx] to CPU[0x%Lx] ...",
+           count, (unsigned long long)src_start_addr, (unsigned long long)dst);
+    fflush(stdout);
+  }
+  unsigned char *dst_data = (unsigned char *)dst;
+  for (unsigned n = 0; n < count; n++)
+    m_global_mem->read(src_start_addr + n, 1, dst_data + n);
+
+  // Copy into the performance model.
+  // extern gpgpu_sim* g_the_gpu;
+  gpgpu_ctx->the_gpgpusim->g_the_gpu->perf_memcpy_to_gpu(src_start_addr, count);
+  if (g_debug_execution >= 3) {
+    printf(" done.\n");
+    fflush(stdout);
+  }
 }
 
-
-void gpgpu_t::memcpy_to_gpu( size_t dst_start_addr, const void *src, size_t count )
-{
-   if(g_debug_execution >= 3) {
-      printf("GPGPU-Sim PTX: copying %zu bytes from CPU[0x%Lx] to GPU[0x%Lx] ... ", count, (unsigned long long) src, (unsigned long long) dst_start_addr );
-      fflush(stdout);
-   }
-   char *src_data = (char*)src;
-   for (unsigned n=0; n < count; n ++ ) 
-      m_global_mem->write(dst_start_addr+n,1, src_data+n,NULL,NULL);
-
-   // Copy into the performance model.
-   //extern gpgpu_sim* g_the_gpu;
-   gpgpu_ctx->the_gpgpusim->g_the_gpu->perf_memcpy_to_gpu(dst_start_addr, count);
-   if(g_debug_execution >= 3) {
-      printf( " done.\n");
-      fflush(stdout);
-   }
+void gpgpu_t::memcpy_gpu_to_gpu(size_t dst, size_t src, size_t count) {
+  if (g_debug_execution >= 3) {
+    printf("GPGPU-Sim PTX: copying %zu bytes from GPU[0x%Lx] to GPU[0x%Lx] ...",
+           count, (unsigned long long)src, (unsigned long long)dst);
+    fflush(stdout);
+  }
+  for (unsigned n = 0; n < count; n++) {
+    unsigned char tmp;
+    m_global_mem->read(src + n, 1, &tmp);
+    m_global_mem->write(dst + n, 1, &tmp, NULL, NULL);
+  }
+  if (g_debug_execution >= 3) {
+    printf(" done.\n");
+    fflush(stdout);
+  }
 }
 
-void gpgpu_t::memcpy_from_gpu( void *dst, size_t src_start_addr, size_t count )
-{
-   if(g_debug_execution >= 3) {
-      printf("GPGPU-Sim PTX: copying %zu bytes from GPU[0x%Lx] to CPU[0x%Lx] ...", count, (unsigned long long) src_start_addr, (unsigned long long) dst );
-      fflush(stdout);
-   }
-   unsigned char *dst_data = (unsigned char*)dst;
-   for (unsigned n=0; n < count; n ++ ) 
-      m_global_mem->read(src_start_addr+n,1,dst_data+n);
-
-   // Copy into the performance model.
-   //extern gpgpu_sim* g_the_gpu;
-   gpgpu_ctx->the_gpgpusim->g_the_gpu->perf_memcpy_to_gpu(src_start_addr, count);
-   if(g_debug_execution >= 3) {
-      printf( " done.\n");
-      fflush(stdout);
-   }
+void gpgpu_t::gpu_memset(size_t dst_start_addr, int c, size_t count) {
+  if (g_debug_execution >= 3) {
+    printf(
+        "GPGPU-Sim PTX: setting %zu bytes of memory to 0x%x starting at "
+        "0x%Lx... ",
+        count, (unsigned char)c, (unsigned long long)dst_start_addr);
+    fflush(stdout);
+  }
+  unsigned char c_value = (unsigned char)c;
+  for (unsigned n = 0; n < count; n++)
+    m_global_mem->write(dst_start_addr + n, 1, &c_value, NULL, NULL);
+  if (g_debug_execution >= 3) {
+    printf(" done.\n");
+    fflush(stdout);
+  }
 }
 
-void gpgpu_t::memcpy_gpu_to_gpu( size_t dst, size_t src, size_t count )
-{
-   if(g_debug_execution >= 3) {
-      printf("GPGPU-Sim PTX: copying %zu bytes from GPU[0x%Lx] to GPU[0x%Lx] ...", count,
-          (unsigned long long) src, (unsigned long long) dst );
-      fflush(stdout);
-   }
-   for (unsigned n=0; n < count; n ++ ) {
-      unsigned char tmp;
-      m_global_mem->read(src+n,1,&tmp); 
-      m_global_mem->write(dst+n,1, &tmp,NULL,NULL);
-   }
-   if(g_debug_execution >= 3) {
-      printf( " done.\n");
-      fflush(stdout);
-   }
+void cuda_sim::ptx_print_insn(address_type pc, FILE *fp) {
+  std::map<unsigned, function_info *>::iterator f = g_pc_to_finfo.find(pc);
+  if (f == g_pc_to_finfo.end()) {
+    fprintf(fp, "<no instruction at address 0x%x>", pc);
+    return;
+  }
+  function_info *finfo = f->second;
+  assert(finfo);
+  finfo->print_insn(pc, fp);
 }
 
-void gpgpu_t::gpu_memset( size_t dst_start_addr, int c, size_t count )
-{
-   if(g_debug_execution >= 3) {
-      printf("GPGPU-Sim PTX: setting %zu bytes of memory to 0x%x starting at 0x%Lx... ",
-          count, (unsigned char) c, (unsigned long long) dst_start_addr );
-      fflush(stdout);
-   }
-   unsigned char c_value = (unsigned char)c;
-   for (unsigned n=0; n < count; n ++ ) 
-      m_global_mem->write(dst_start_addr+n,1,&c_value,NULL,NULL);
-   if(g_debug_execution >= 3) {
-      printf( " done.\n");
-      fflush(stdout);
-   }
+std::string cuda_sim::ptx_get_insn_str(address_type pc) {
+  std::map<unsigned, function_info *>::iterator f = g_pc_to_finfo.find(pc);
+  if (f == g_pc_to_finfo.end()) {
+#define STR_SIZE 255
+    char buff[STR_SIZE];
+    buff[STR_SIZE - 1] = '\0';
+    snprintf(buff, STR_SIZE, "<no instruction at address 0x%x>", pc);
+    return std::string(buff);
+  }
+  function_info *finfo = f->second;
+  assert(finfo);
+  return finfo->get_insn_str(pc);
 }
 
-void cuda_sim::ptx_print_insn( address_type pc, FILE *fp )
-{
-   std::map<unsigned,function_info*>::iterator f = g_pc_to_finfo.find(pc);
-   if( f == g_pc_to_finfo.end() ) {
-       fprintf(fp,"<no instruction at address 0x%x>", pc );
-       return;
-   }
-   function_info *finfo = f->second;
-   assert( finfo );
-   finfo->print_insn(pc,fp);
+void ptx_instruction::set_fp_or_int_archop() {
+  oprnd_type = UN_OP;
+  if ((m_opcode == MEMBAR_OP) || (m_opcode == SSY_OP) || (m_opcode == BRA_OP) ||
+      (m_opcode == BAR_OP) || (m_opcode == RET_OP) || (m_opcode == RETP_OP) ||
+      (m_opcode == NOP_OP) || (m_opcode == EXIT_OP) || (m_opcode == CALLP_OP) ||
+      (m_opcode == CALL_OP)) {
+    // do nothing
+  } else if ((m_opcode == CVT_OP || m_opcode == SET_OP ||
+              m_opcode == SLCT_OP)) {
+    if (get_type2() == F16_TYPE || get_type2() == F32_TYPE ||
+        get_type2() == F64_TYPE || get_type2() == FF64_TYPE) {
+      oprnd_type = FP_OP;
+    } else
+      oprnd_type = INT_OP;
+
+  } else {
+    if (get_type() == F16_TYPE || get_type() == F32_TYPE ||
+        get_type() == F64_TYPE || get_type() == FF64_TYPE) {
+      oprnd_type = FP_OP;
+    } else
+      oprnd_type = INT_OP;
+  }
+}
+void ptx_instruction::set_mul_div_or_other_archop() {
+  sp_op = OTHER_OP;
+  if ((m_opcode != MEMBAR_OP) && (m_opcode != SSY_OP) && (m_opcode != BRA_OP) &&
+      (m_opcode != BAR_OP) && (m_opcode != EXIT_OP) && (m_opcode != NOP_OP) &&
+      (m_opcode != RETP_OP) && (m_opcode != RET_OP) && (m_opcode != CALLP_OP) &&
+      (m_opcode != CALL_OP)) {
+    if (get_type() == F32_TYPE || get_type() == F64_TYPE ||
+        get_type() == FF64_TYPE) {
+      switch (get_opcode()) {
+        case MUL_OP:
+        case MAD_OP:
+          sp_op = FP_MUL_OP;
+          break;
+        case DIV_OP:
+          sp_op = FP_DIV_OP;
+          break;
+        case LG2_OP:
+          sp_op = FP_LG_OP;
+          break;
+        case RSQRT_OP:
+        case SQRT_OP:
+          sp_op = FP_SQRT_OP;
+          break;
+        case RCP_OP:
+          sp_op = FP_DIV_OP;
+          break;
+        case SIN_OP:
+        case COS_OP:
+          sp_op = FP_SIN_OP;
+          break;
+        case EX2_OP:
+          sp_op = FP_EXP_OP;
+          break;
+        default:
+          if ((op == ALU_OP) || (op == TENSOR_CORE_OP)) sp_op = FP__OP;
+          break;
+      }
+    } else {
+      switch (get_opcode()) {
+        case MUL24_OP:
+        case MAD24_OP:
+          sp_op = INT_MUL24_OP;
+          break;
+        case MUL_OP:
+        case MAD_OP:
+          if (get_type() == U32_TYPE || get_type() == S32_TYPE ||
+              get_type() == B32_TYPE)
+            sp_op = INT_MUL32_OP;
+          else
+            sp_op = INT_MUL_OP;
+          break;
+        case DIV_OP:
+          sp_op = INT_DIV_OP;
+          break;
+        default:
+          if ((op == ALU_OP)) sp_op = INT__OP;
+          break;
+      }
+    }
+  }
 }
 
-std::string cuda_sim::ptx_get_insn_str( address_type pc )
-{
-   std::map<unsigned,function_info*>::iterator f = g_pc_to_finfo.find(pc);
-   if( f == g_pc_to_finfo.end() ) {
-       #define STR_SIZE 255
-       char buff[STR_SIZE];
-       buff[STR_SIZE - 1] = '\0';
-       snprintf(buff, STR_SIZE,"<no instruction at address 0x%x>", pc );
-       return std::string(buff);
-   }
-   function_info *finfo = f->second;
-   assert( finfo );
-   return finfo->get_insn_str(pc);
+void ptx_instruction::set_bar_type() {
+  if (m_opcode == BAR_OP) {
+    switch (m_barrier_op) {
+      case SYNC_OPTION:
+        bar_type = SYNC;
+        break;
+      case ARRIVE_OPTION:
+        bar_type = ARRIVE;
+        break;
+      case RED_OPTION:
+        bar_type = RED;
+        switch (m_atomic_spec) {
+          case ATOMIC_POPC:
+            red_type = POPC_RED;
+            break;
+          case ATOMIC_AND:
+            red_type = AND_RED;
+            break;
+          case ATOMIC_OR:
+            red_type = OR_RED;
+            break;
+        }
+        break;
+      default:
+        abort();
+    }
+  } else if (m_opcode == SST_OP) {
+    bar_type = SYNC;
+  }
 }
 
-void ptx_instruction::set_fp_or_int_archop(){
-    oprnd_type=UN_OP;
-	if((m_opcode == MEMBAR_OP)||(m_opcode == SSY_OP )||(m_opcode == BRA_OP) || (m_opcode == BAR_OP) || (m_opcode == RET_OP) || (m_opcode == RETP_OP) || (m_opcode == NOP_OP) || (m_opcode == EXIT_OP) || (m_opcode == CALLP_OP) || (m_opcode == CALL_OP)){
-			// do nothing
-	}else if((m_opcode == CVT_OP || m_opcode == SET_OP || m_opcode == SLCT_OP)){
-		if(get_type2()==F16_TYPE || get_type2()==F32_TYPE || get_type2() == F64_TYPE || get_type2() == FF64_TYPE){
-		    oprnd_type= FP_OP;
-		}else oprnd_type=INT_OP;
+void ptx_instruction::set_opcode_and_latency() {
+  unsigned int_latency[5];
+  unsigned fp_latency[5];
+  unsigned dp_latency[5];
+  unsigned sfu_latency;
+  unsigned tensor_latency;
+  unsigned int_init[5];
+  unsigned fp_init[5];
+  unsigned dp_init[5];
+  unsigned sfu_init;
+  unsigned tensor_init;
+  /*
+   * [0] ADD,SUB
+   * [1] MAX,Min
+   * [2] MUL
+   * [3] MAD
+   * [4] DIV
+   */
+  sscanf(gpgpu_ctx->func_sim->opcode_latency_int, "%u,%u,%u,%u,%u",
+         &int_latency[0], &int_latency[1], &int_latency[2], &int_latency[3],
+         &int_latency[4]);
+  sscanf(gpgpu_ctx->func_sim->opcode_latency_fp, "%u,%u,%u,%u,%u",
+         &fp_latency[0], &fp_latency[1], &fp_latency[2], &fp_latency[3],
+         &fp_latency[4]);
+  sscanf(gpgpu_ctx->func_sim->opcode_latency_dp, "%u,%u,%u,%u,%u",
+         &dp_latency[0], &dp_latency[1], &dp_latency[2], &dp_latency[3],
+         &dp_latency[4]);
+  sscanf(gpgpu_ctx->func_sim->opcode_latency_sfu, "%u", &sfu_latency);
+  sscanf(gpgpu_ctx->func_sim->opcode_latency_tensor, "%u", &tensor_latency);
+  sscanf(gpgpu_ctx->func_sim->opcode_initiation_int, "%u,%u,%u,%u,%u",
+         &int_init[0], &int_init[1], &int_init[2], &int_init[3], &int_init[4]);
+  sscanf(gpgpu_ctx->func_sim->opcode_initiation_fp, "%u,%u,%u,%u,%u",
+         &fp_init[0], &fp_init[1], &fp_init[2], &fp_init[3], &fp_init[4]);
+  sscanf(gpgpu_ctx->func_sim->opcode_initiation_dp, "%u,%u,%u,%u,%u",
+         &dp_init[0], &dp_init[1], &dp_init[2], &dp_init[3], &dp_init[4]);
+  sscanf(gpgpu_ctx->func_sim->opcode_initiation_sfu, "%u", &sfu_init);
+  sscanf(gpgpu_ctx->func_sim->opcode_initiation_tensor, "%u", &tensor_init);
+  sscanf(gpgpu_ctx->func_sim->cdp_latency_str, "%u,%u,%u,%u,%u",
+         &gpgpu_ctx->func_sim->cdp_latency[0],
+         &gpgpu_ctx->func_sim->cdp_latency[1],
+         &gpgpu_ctx->func_sim->cdp_latency[2],
+         &gpgpu_ctx->func_sim->cdp_latency[3],
+         &gpgpu_ctx->func_sim->cdp_latency[4]);
 
-	}else{
-		if(get_type()==F16_TYPE || get_type()==F32_TYPE || get_type() == F64_TYPE || get_type() == FF64_TYPE){
-		    oprnd_type= FP_OP;
-		}else oprnd_type=INT_OP;
-	}
-}
-void ptx_instruction::set_mul_div_or_other_archop(){
-    sp_op=OTHER_OP;
-	if((m_opcode != MEMBAR_OP) && (m_opcode != SSY_OP) && (m_opcode != BRA_OP) && (m_opcode != BAR_OP) && (m_opcode != EXIT_OP) && (m_opcode != NOP_OP) && (m_opcode != RETP_OP) && (m_opcode != RET_OP) && (m_opcode != CALLP_OP) && (m_opcode != CALL_OP)){
-		if(get_type()==F32_TYPE || get_type() == F64_TYPE || get_type() == FF64_TYPE){
-			switch(get_opcode()){
-				case MUL_OP:
-				case MAD_OP:
-				    sp_op=FP_MUL_OP;
-					break;
-				case DIV_OP:
-				    sp_op=FP_DIV_OP;
-					break;
-				case LG2_OP:
-				    sp_op=FP_LG_OP;
-					break;
-				case RSQRT_OP:
-				case SQRT_OP:
-				    sp_op=FP_SQRT_OP;
-					break;
-				case RCP_OP:
-				    sp_op=FP_DIV_OP;
-					break;
-				case SIN_OP:
-				case COS_OP:
-				    sp_op=FP_SIN_OP;
-					break;
-				case EX2_OP:
-				    sp_op=FP_EXP_OP;
-					break;
-				default:
-					if((op==ALU_OP)||(op==TENSOR_CORE_OP))
-					    sp_op=FP__OP;
-					break;
-
-			}
-		}else {
-			switch(get_opcode()){
-				case MUL24_OP:
-				case MAD24_OP:
-				    sp_op=INT_MUL24_OP;
-				break;
-				case MUL_OP:
-				case MAD_OP:
-					if(get_type()==U32_TYPE || get_type()==S32_TYPE || get_type()==B32_TYPE)
-					    sp_op=INT_MUL32_OP;
-					else
-					    sp_op=INT_MUL_OP;
-				break;
-				case DIV_OP:
-				    sp_op=INT_DIV_OP;
-				break;
-				default:
-					if((op==ALU_OP))
-					    sp_op=INT__OP;
-					break;
-			}
-		}
-	}
-
-}
-
-
-
-void ptx_instruction::set_bar_type()
-{
-	   if(m_opcode==BAR_OP) {
-		   switch(m_barrier_op){
-		   	   case SYNC_OPTION:
-		   		   bar_type = SYNC;
-		   		   break;
-		   	   case ARRIVE_OPTION:
-		   		   bar_type = ARRIVE;
-		   		   break;
-		   	   case RED_OPTION:
-		   		   bar_type = RED;
-		   		   switch(m_atomic_spec){
-		   		   	   case ATOMIC_POPC:
-				   		   red_type = POPC_RED;
-				   		   break;
-		   		   	   case ATOMIC_AND:
-				   		   red_type = AND_RED;
-				   		   break;
-		   		   	   case ATOMIC_OR:
-				   		   red_type = OR_RED;
-				   		   break;
-		   		   }
-		   		break;
-		   	   default:
-		   		   abort();
-		   }
-	   }
-	   else if(m_opcode==SST_OP) {
-		   bar_type = SYNC;
-	   }
-}
-
-
-void ptx_instruction::set_opcode_and_latency()
-{
-	unsigned int_latency[5];
-	unsigned fp_latency[5];
-	unsigned dp_latency[5];
-	unsigned sfu_latency;
-	unsigned tensor_latency;
-	unsigned int_init[5];
-	unsigned fp_init[5];
-	unsigned dp_init[5];
-	unsigned sfu_init;
-	unsigned tensor_init;
-	/*
-	 * [0] ADD,SUB
-	 * [1] MAX,Min
-	 * [2] MUL
-	 * [3] MAD
-	 * [4] DIV
-	 */
-	sscanf(gpgpu_ctx->func_sim->opcode_latency_int, "%u,%u,%u,%u,%u",
-			&int_latency[0],&int_latency[1],&int_latency[2],
-			&int_latency[3],&int_latency[4]);
-	sscanf(gpgpu_ctx->func_sim->opcode_latency_fp, "%u,%u,%u,%u,%u",
-			&fp_latency[0],&fp_latency[1],&fp_latency[2],
-			&fp_latency[3],&fp_latency[4]);
-	sscanf(gpgpu_ctx->func_sim->opcode_latency_dp, "%u,%u,%u,%u,%u",
-			&dp_latency[0],&dp_latency[1],&dp_latency[2],
-			&dp_latency[3],&dp_latency[4]);
-	sscanf(gpgpu_ctx->func_sim->opcode_latency_sfu, "%u",
-			&sfu_latency);
-	sscanf(gpgpu_ctx->func_sim->opcode_latency_tensor, "%u",
-			&tensor_latency);
-	sscanf(gpgpu_ctx->func_sim->opcode_initiation_int, "%u,%u,%u,%u,%u",
-			&int_init[0],&int_init[1],&int_init[2],
-			&int_init[3],&int_init[4]);
-	sscanf(gpgpu_ctx->func_sim->opcode_initiation_fp, "%u,%u,%u,%u,%u",
-			&fp_init[0],&fp_init[1],&fp_init[2],
-			&fp_init[3],&fp_init[4]);
-	sscanf(gpgpu_ctx->func_sim->opcode_initiation_dp, "%u,%u,%u,%u,%u",
-			&dp_init[0],&dp_init[1],&dp_init[2],
-			&dp_init[3],&dp_init[4]);
-	sscanf(gpgpu_ctx->func_sim->opcode_initiation_sfu, "%u",
-			&sfu_init);
-	sscanf(gpgpu_ctx->func_sim->opcode_initiation_tensor, "%u",
-			&tensor_init);
-	sscanf(gpgpu_ctx->func_sim->cdp_latency_str, "%u,%u,%u,%u,%u",
-			&gpgpu_ctx->func_sim->cdp_latency[0],
-			&gpgpu_ctx->func_sim->cdp_latency[1],
-			&gpgpu_ctx->func_sim->cdp_latency[2],
-			&gpgpu_ctx->func_sim->cdp_latency[3],
-			&gpgpu_ctx->func_sim->cdp_latency[4]);
-
-	if(!m_operands.empty()){
-		std::vector<operand_info>::iterator it;
-	   	for(it=++m_operands.begin();it!=m_operands.end();it++){
-	   		num_operands++;
-	   		if((it->is_reg() || it->is_vector())){
-	   			   num_regs++;
-	   		}
-	   	 }
-	}
-   op = ALU_OP;
-   mem_op= NOT_TEX;
-   initiation_interval = latency = 1;
-   switch( m_opcode ) {
-   case MOV_OP:
-       assert( !(has_memory_read() && has_memory_write()) );
-       if ( has_memory_read() ) op = LOAD_OP;
-       if ( has_memory_write() ) op = STORE_OP;
-       break;
-   case LD_OP: op = LOAD_OP; break;
-   case MMA_LD_OP: op = TENSOR_CORE_LOAD_OP; break;
-   case LDU_OP: op = LOAD_OP; break;
-   case ST_OP: op = STORE_OP; break;
-   case MMA_ST_OP: op = TENSOR_CORE_STORE_OP; break;
-   case BRA_OP: op = BRANCH_OP; break;
-   case BREAKADDR_OP: op = BRANCH_OP; break;
-   case TEX_OP: op = LOAD_OP; mem_op=TEX; break;
-   case ATOM_OP: op = LOAD_OP; break;
-   case BAR_OP: op = BARRIER_OP; break;
-   case SST_OP: op = BARRIER_OP; break;
-   case MEMBAR_OP: op = MEMORY_BARRIER_OP; break;
-   case CALL_OP:
-   {
-       if(m_is_printf || m_is_cdp) {
-           op = ALU_OP;
-       }
-       else
-           op = CALL_OPS;
-       break;
-   }
-   case CALLP_OP:
-   {
-       if(m_is_printf || m_is_cdp) {
-               op = ALU_OP;
-       }
-       else
-           op = CALL_OPS;
-       break;
-   }
-   case RET_OP: case RETP_OP:  op = RET_OPS;break;
-   case ADD_OP: case ADDP_OP: case ADDC_OP: case SUB_OP: case SUBC_OP:
-	   //ADD,SUB latency
-	   switch(get_type()){
-	   case F32_TYPE:
-		   latency = fp_latency[0];
-		   initiation_interval = fp_init[0];
-		   op = SP_OP;
-		   break;
-	   case F64_TYPE:
-	   case FF64_TYPE:
-		   latency = dp_latency[0];
-		   initiation_interval = dp_init[0];
-		   op = DP_OP;
-		   break;
-	   case B32_TYPE:
-	   case U32_TYPE:
-	   case S32_TYPE:
-	   default: //Use int settings for default
-		   latency = int_latency[0];
-		   initiation_interval = int_init[0];
-		   op = INTP_OP;
-		   break;
-	   }
-	   break;
-   case MAX_OP: case MIN_OP:
-	   //MAX,MIN latency
-	   switch(get_type()){
-	   case F32_TYPE:
-		   latency = fp_latency[1];
-		   initiation_interval = fp_init[1];
-		   op = SP_OP;
-		   break;
-	   case F64_TYPE:
-	   case FF64_TYPE:
-		   latency = dp_latency[1];
-		   initiation_interval = dp_init[1];
-		   op = DP_OP;
-		   break;
-	   case B32_TYPE:
-	   case U32_TYPE:
-	   case S32_TYPE:
-	   default: //Use int settings for default
-		   latency = int_latency[1];
-		   initiation_interval = int_init[1];
-		   op = INTP_OP;
-		   break;
-	   }
-	   break;
-   case MUL_OP:
-	   //MUL latency
-	   switch(get_type()){
-	   case F32_TYPE:
-		   latency = fp_latency[2];
-		   initiation_interval = fp_init[2];
-		   op = SP_OP;
-		   break;
-	   case F64_TYPE:
-	   case FF64_TYPE:
-		   latency = dp_latency[2];
-		   initiation_interval = dp_init[2];
-		   op = DP_OP;
-		   break;
-	   case B32_TYPE:
-	   case U32_TYPE:
-	   case S32_TYPE:
-	   default: //Use int settings for default
-		   latency = int_latency[2];
-		   initiation_interval = int_init[2];
-		   op = INTP_OP;
-		   break;
-	   }
-	   break;
-   case MAD_OP: case MADC_OP: case MADP_OP:
-	   //MAD latency
-	   switch(get_type()){
-	   case F32_TYPE:
-		   latency = fp_latency[3];
-		   initiation_interval = fp_init[3];
-		   op = SP_OP;
-		   break;
-	   case F64_TYPE:
-	   case FF64_TYPE:
-		   latency = dp_latency[3];
-		   initiation_interval = dp_init[3];
-		   op = DP_OP;
-		   break;
-	   case B32_TYPE:
-	   case U32_TYPE:
-	   case S32_TYPE:
-	   default: //Use int settings for default
-		   latency = int_latency[3];
-		   initiation_interval = int_init[3];
-		   op = INTP_OP;
-		   break;
-	   }
-	   break;
-   case DIV_OP:
-	   // Floating point only
-	   op = SFU_OP;
-	   switch(get_type()){
-	   case F32_TYPE:
-		   latency = fp_latency[4];
-		   initiation_interval = fp_init[4];
-		   break;
-	   case F64_TYPE:
-	   case FF64_TYPE:
-		   latency = dp_latency[4];
-		   initiation_interval = dp_init[4];
-		   break;
-	   case B32_TYPE:
-	   case U32_TYPE:
-	   case S32_TYPE:
-	   default: //Use int settings for default
-		   latency = int_latency[4];
-		   initiation_interval = int_init[4];
-		   break;
-	   }
-	   break;
-   case SQRT_OP: case SIN_OP: case COS_OP: case EX2_OP: case LG2_OP: case RSQRT_OP: case RCP_OP:
-	  latency = sfu_latency;
-	  initiation_interval = sfu_init;
+  if (!m_operands.empty()) {
+    std::vector<operand_info>::iterator it;
+    for (it = ++m_operands.begin(); it != m_operands.end(); it++) {
+      num_operands++;
+      if ((it->is_reg() || it->is_vector())) {
+        num_regs++;
+      }
+    }
+  }
+  op = ALU_OP;
+  mem_op = NOT_TEX;
+  initiation_interval = latency = 1;
+  switch (m_opcode) {
+    case MOV_OP:
+      assert(!(has_memory_read() && has_memory_write()));
+      if (has_memory_read()) op = LOAD_OP;
+      if (has_memory_write()) op = STORE_OP;
+      break;
+    case LD_OP:
+      op = LOAD_OP;
+      break;
+    case MMA_LD_OP:
+      op = TENSOR_CORE_LOAD_OP;
+      break;
+    case LDU_OP:
+      op = LOAD_OP;
+      break;
+    case ST_OP:
+      op = STORE_OP;
+      break;
+    case MMA_ST_OP:
+      op = TENSOR_CORE_STORE_OP;
+      break;
+    case BRA_OP:
+      op = BRANCH_OP;
+      break;
+    case BREAKADDR_OP:
+      op = BRANCH_OP;
+      break;
+    case TEX_OP:
+      op = LOAD_OP;
+      mem_op = TEX;
+      break;
+    case ATOM_OP:
+      op = LOAD_OP;
+      break;
+    case BAR_OP:
+      op = BARRIER_OP;
+      break;
+    case SST_OP:
+      op = BARRIER_OP;
+      break;
+    case MEMBAR_OP:
+      op = MEMORY_BARRIER_OP;
+      break;
+    case CALL_OP: {
+      if (m_is_printf || m_is_cdp) {
+        op = ALU_OP;
+      } else
+        op = CALL_OPS;
+      break;
+    }
+    case CALLP_OP: {
+      if (m_is_printf || m_is_cdp) {
+        op = ALU_OP;
+      } else
+        op = CALL_OPS;
+      break;
+    }
+    case RET_OP:
+    case RETP_OP:
+      op = RET_OPS;
+      break;
+    case ADD_OP:
+    case ADDP_OP:
+    case ADDC_OP:
+    case SUB_OP:
+    case SUBC_OP:
+      // ADD,SUB latency
+      switch (get_type()) {
+        case F32_TYPE:
+          latency = fp_latency[0];
+          initiation_interval = fp_init[0];
+          op = SP_OP;
+          break;
+        case F64_TYPE:
+        case FF64_TYPE:
+          latency = dp_latency[0];
+          initiation_interval = dp_init[0];
+          op = DP_OP;
+          break;
+        case B32_TYPE:
+        case U32_TYPE:
+        case S32_TYPE:
+        default:  // Use int settings for default
+          latency = int_latency[0];
+          initiation_interval = int_init[0];
+          op = INTP_OP;
+          break;
+      }
+      break;
+    case MAX_OP:
+    case MIN_OP:
+      // MAX,MIN latency
+      switch (get_type()) {
+        case F32_TYPE:
+          latency = fp_latency[1];
+          initiation_interval = fp_init[1];
+          op = SP_OP;
+          break;
+        case F64_TYPE:
+        case FF64_TYPE:
+          latency = dp_latency[1];
+          initiation_interval = dp_init[1];
+          op = DP_OP;
+          break;
+        case B32_TYPE:
+        case U32_TYPE:
+        case S32_TYPE:
+        default:  // Use int settings for default
+          latency = int_latency[1];
+          initiation_interval = int_init[1];
+          op = INTP_OP;
+          break;
+      }
+      break;
+    case MUL_OP:
+      // MUL latency
+      switch (get_type()) {
+        case F32_TYPE:
+          latency = fp_latency[2];
+          initiation_interval = fp_init[2];
+          op = SP_OP;
+          break;
+        case F64_TYPE:
+        case FF64_TYPE:
+          latency = dp_latency[2];
+          initiation_interval = dp_init[2];
+          op = DP_OP;
+          break;
+        case B32_TYPE:
+        case U32_TYPE:
+        case S32_TYPE:
+        default:  // Use int settings for default
+          latency = int_latency[2];
+          initiation_interval = int_init[2];
+          op = INTP_OP;
+          break;
+      }
+      break;
+    case MAD_OP:
+    case MADC_OP:
+    case MADP_OP:
+      // MAD latency
+      switch (get_type()) {
+        case F32_TYPE:
+          latency = fp_latency[3];
+          initiation_interval = fp_init[3];
+          op = SP_OP;
+          break;
+        case F64_TYPE:
+        case FF64_TYPE:
+          latency = dp_latency[3];
+          initiation_interval = dp_init[3];
+          op = DP_OP;
+          break;
+        case B32_TYPE:
+        case U32_TYPE:
+        case S32_TYPE:
+        default:  // Use int settings for default
+          latency = int_latency[3];
+          initiation_interval = int_init[3];
+          op = INTP_OP;
+          break;
+      }
+      break;
+    case DIV_OP:
+      // Floating point only
+      op = SFU_OP;
+      switch (get_type()) {
+        case F32_TYPE:
+          latency = fp_latency[4];
+          initiation_interval = fp_init[4];
+          break;
+        case F64_TYPE:
+        case FF64_TYPE:
+          latency = dp_latency[4];
+          initiation_interval = dp_init[4];
+          break;
+        case B32_TYPE:
+        case U32_TYPE:
+        case S32_TYPE:
+        default:  // Use int settings for default
+          latency = int_latency[4];
+          initiation_interval = int_init[4];
+          break;
+      }
+      break;
+    case SQRT_OP:
+    case SIN_OP:
+    case COS_OP:
+    case EX2_OP:
+    case LG2_OP:
+    case RSQRT_OP:
+    case RCP_OP:
+      latency = sfu_latency;
+      initiation_interval = sfu_init;
       op = SFU_OP;
       break;
-   case MMA_OP:
-	   latency = tensor_latency;
-	   initiation_interval = tensor_init;
-       op=TENSOR_CORE_OP;
-	   break;
-   case SHFL_OP:
-	   latency = 4;
-	   initiation_interval = 4;
-	   break;
-   default: 
-       break;
-   }
-	set_fp_or_int_archop();
-	set_mul_div_or_other_archop();
-
+    case MMA_OP:
+      latency = tensor_latency;
+      initiation_interval = tensor_init;
+      op = TENSOR_CORE_OP;
+      break;
+    case SHFL_OP:
+      latency = 4;
+      initiation_interval = 4;
+      break;
+    default:
+      break;
+  }
+  set_fp_or_int_archop();
+  set_mul_div_or_other_archop();
 }
 
-void ptx_thread_info::ptx_fetch_inst( inst_t &inst ) const
-{
-   addr_t pc = get_pc();
-   const ptx_instruction *pI = m_func_info->get_instruction(pc);
-   inst = (const inst_t&)*pI;
-   assert( inst.valid() );
+void ptx_thread_info::ptx_fetch_inst(inst_t &inst) const {
+  addr_t pc = get_pc();
+  const ptx_instruction *pI = m_func_info->get_instruction(pc);
+  inst = (const inst_t &)*pI;
+  assert(inst.valid());
 }
 
-static unsigned datatype2size( unsigned data_type )
-{
-   unsigned data_size;
-   switch ( data_type ) {
-      case B8_TYPE:
-      case S8_TYPE:
-      case U8_TYPE: 
-         data_size = 1; break;
-      case B16_TYPE:
-      case S16_TYPE:
-      case U16_TYPE:
-      case F16_TYPE: 
-         data_size = 2; break;
-      case B32_TYPE:
-      case S32_TYPE:
-      case U32_TYPE:
-      case F32_TYPE: 
-         data_size = 4; break;
-      case B64_TYPE:
-      case BB64_TYPE:
-      case S64_TYPE:
-      case U64_TYPE:
-      case F64_TYPE: 
-      case FF64_TYPE:
-         data_size = 8; break;
-      case BB128_TYPE: 
-         data_size = 16; break;
-      default: assert(0); break;
-   }
-   return data_size; 
+static unsigned datatype2size(unsigned data_type) {
+  unsigned data_size;
+  switch (data_type) {
+    case B8_TYPE:
+    case S8_TYPE:
+    case U8_TYPE:
+      data_size = 1;
+      break;
+    case B16_TYPE:
+    case S16_TYPE:
+    case U16_TYPE:
+    case F16_TYPE:
+      data_size = 2;
+      break;
+    case B32_TYPE:
+    case S32_TYPE:
+    case U32_TYPE:
+    case F32_TYPE:
+      data_size = 4;
+      break;
+    case B64_TYPE:
+    case BB64_TYPE:
+    case S64_TYPE:
+    case U64_TYPE:
+    case F64_TYPE:
+    case FF64_TYPE:
+      data_size = 8;
+      break;
+    case BB128_TYPE:
+      data_size = 16;
+      break;
+    default:
+      assert(0);
+      break;
+  }
+  return data_size;
 }
 
-void ptx_instruction::pre_decode()
-{
-   pc = m_PC;
-   isize = m_inst_size;
-   for(unsigned i=0; i<MAX_OUTPUT_VALUES; i++) {
-       out[i] = 0;
-   }
-   for(unsigned i=0; i<MAX_INPUT_VALUES; i++) {
-       in[i] = 0;
-   }
-   incount=0;
-   outcount=0;
-   is_vectorin = 0;
-   is_vectorout = 0;
-   std::fill_n(arch_reg.src, MAX_REG_OPERANDS, -1);
-   std::fill_n(arch_reg.dst, MAX_REG_OPERANDS, -1);
-   pred = 0;
-   ar1 = 0;
-   ar2 = 0;
-   space = m_space_spec;
-   memory_op = no_memory_op;
-   data_size = 0;
-   if ( has_memory_read() || has_memory_write() ) {
-      unsigned to_type = get_type();
-      data_size = datatype2size(to_type);
-      memory_op = has_memory_read() ? memory_load : memory_store;
-   }
+void ptx_instruction::pre_decode() {
+  pc = m_PC;
+  isize = m_inst_size;
+  for (unsigned i = 0; i < MAX_OUTPUT_VALUES; i++) {
+    out[i] = 0;
+  }
+  for (unsigned i = 0; i < MAX_INPUT_VALUES; i++) {
+    in[i] = 0;
+  }
+  incount = 0;
+  outcount = 0;
+  is_vectorin = 0;
+  is_vectorout = 0;
+  std::fill_n(arch_reg.src, MAX_REG_OPERANDS, -1);
+  std::fill_n(arch_reg.dst, MAX_REG_OPERANDS, -1);
+  pred = 0;
+  ar1 = 0;
+  ar2 = 0;
+  space = m_space_spec;
+  memory_op = no_memory_op;
+  data_size = 0;
+  if (has_memory_read() || has_memory_write()) {
+    unsigned to_type = get_type();
+    data_size = datatype2size(to_type);
+    memory_op = has_memory_read() ? memory_load : memory_store;
+  }
 
-   bool has_dst = false ;
+  bool has_dst = false;
 
-   switch ( get_opcode() ) {
-#define OP_DEF(OP,FUNC,STR,DST,CLASSIFICATION) case OP: has_dst = (DST!=0); break;
-#define OP_W_DEF(OP,FUNC,STR,DST,CLASSIFICATION) case OP: has_dst = (DST!=0); break;
+  switch (get_opcode()) {
+#define OP_DEF(OP, FUNC, STR, DST, CLASSIFICATION) \
+  case OP:                                         \
+    has_dst = (DST != 0);                          \
+    break;
+#define OP_W_DEF(OP, FUNC, STR, DST, CLASSIFICATION) \
+  case OP:                                           \
+    has_dst = (DST != 0);                            \
+    break;
 #include "opcodes.def"
 #undef OP_DEF
 #undef OP_W_DEF
-   default:
-      printf( "Execution error: Invalid opcode (0x%x)\n", get_opcode() );
+    default:
+      printf("Execution error: Invalid opcode (0x%x)\n", get_opcode());
       break;
-   }
+  }
 
-   switch( m_cache_option ) {
-   case CA_OPTION: cache_op = CACHE_ALL; break;
-   case NC_OPTION: cache_op = CACHE_L1; break;
-   case CG_OPTION: cache_op = CACHE_GLOBAL; break;
-   case CS_OPTION: cache_op = CACHE_STREAMING; break;
-   case LU_OPTION: cache_op = CACHE_LAST_USE; break;
-   case CV_OPTION: cache_op = CACHE_VOLATILE; break;
-   case WB_OPTION: cache_op = CACHE_WRITE_BACK; break;
-   case WT_OPTION: cache_op = CACHE_WRITE_THROUGH; break;
-   default: 
-      //if( m_opcode == LD_OP || m_opcode == LDU_OP ) 
-      if(  m_opcode == MMA_LD_OP || m_opcode == LD_OP || m_opcode == LDU_OP ) 
-         cache_op = CACHE_ALL;
-      //else if( m_opcode == ST_OP ) 
-      else if( m_opcode == MMA_ST_OP || m_opcode == ST_OP ) 
-         cache_op = CACHE_WRITE_BACK;
-      else if( m_opcode == ATOM_OP ) 
-         cache_op = CACHE_GLOBAL;
+  switch (m_cache_option) {
+    case CA_OPTION:
+      cache_op = CACHE_ALL;
       break;
-   }
+    case NC_OPTION:
+      cache_op = CACHE_L1;
+      break;
+    case CG_OPTION:
+      cache_op = CACHE_GLOBAL;
+      break;
+    case CS_OPTION:
+      cache_op = CACHE_STREAMING;
+      break;
+    case LU_OPTION:
+      cache_op = CACHE_LAST_USE;
+      break;
+    case CV_OPTION:
+      cache_op = CACHE_VOLATILE;
+      break;
+    case WB_OPTION:
+      cache_op = CACHE_WRITE_BACK;
+      break;
+    case WT_OPTION:
+      cache_op = CACHE_WRITE_THROUGH;
+      break;
+    default:
+      // if( m_opcode == LD_OP || m_opcode == LDU_OP )
+      if (m_opcode == MMA_LD_OP || m_opcode == LD_OP || m_opcode == LDU_OP)
+        cache_op = CACHE_ALL;
+      // else if( m_opcode == ST_OP )
+      else if (m_opcode == MMA_ST_OP || m_opcode == ST_OP)
+        cache_op = CACHE_WRITE_BACK;
+      else if (m_opcode == ATOM_OP)
+        cache_op = CACHE_GLOBAL;
+      break;
+  }
 
-   set_opcode_and_latency();
-   set_bar_type();
-   // Get register operands
-   int n=0,m=0;
-   ptx_instruction::const_iterator opr=op_iter_begin();
-   for ( ; opr != op_iter_end(); opr++, n++ ) { //process operands
-      const operand_info &o = *opr;
-      if ( has_dst && n==0 ) {
-         // Do not set the null register "_" as an architectural register
-         if ( o.is_reg() && !o.is_non_arch_reg() ) {
-            out[0] = o.reg_num();
-            arch_reg.dst[0] = o.arch_reg_num();
-         } else if ( o.is_vector() ) {
-            is_vectorin = 1;
-            unsigned num_elem = o.get_vect_nelem();
-            if( num_elem >= 1 ) out[0] = o.reg1_num();
-            if( num_elem >= 2 ) out[1] = o.reg2_num();
-            if( num_elem >= 3 ) out[2] = o.reg3_num();
-            if( num_elem >= 4 ) out[3] = o.reg4_num();
-            if( num_elem >= 5 ) out[4] = o.reg5_num();
-            if( num_elem >= 6 ) out[5] = o.reg6_num();
-            if( num_elem >= 7 ) out[6] = o.reg7_num();
-            if( num_elem >= 8 ) out[7] = o.reg8_num();
-            for (int i = 0; i < num_elem; i++) 
-               arch_reg.dst[i] = o.arch_reg_num(i);
-         }
-      } else {
-         if ( o.is_reg() && !o.is_non_arch_reg() ) {
-            int reg_num = o.reg_num();
-            arch_reg.src[m] = o.arch_reg_num();
-            switch ( m ) {
-            case 0: in[0] = reg_num; break;
-            case 1: in[1] = reg_num; break;
-            case 2: in[2] = reg_num; break;
-            default: break; 
-            }
-            m++;
-         } else if ( o.is_vector() ) {
-            //assert(m == 0); //only support 1 vector operand (for textures) right now
-            is_vectorout = 1;
-            unsigned num_elem = o.get_vect_nelem();
-            if( num_elem >= 1 ) in[m+0] = o.reg1_num();
-            if( num_elem >= 2 ) in[m+1] = o.reg2_num();
-            if( num_elem >= 3 ) in[m+2] = o.reg3_num();
-            if( num_elem >= 4 ) in[m+3] = o.reg4_num();
-            if( num_elem >= 5 ) in[m+4] = o.reg5_num();
-            if( num_elem >= 6 ) in[m+5] = o.reg6_num();
-            if( num_elem >= 7 ) in[m+6] = o.reg7_num();
-            if( num_elem >= 8 ) in[m+7] = o.reg8_num();
-            for (int i = 0; i < num_elem; i++) 
-               arch_reg.src[m+i] = o.arch_reg_num(i);
-            m+=num_elem;
-         }
+  set_opcode_and_latency();
+  set_bar_type();
+  // Get register operands
+  int n = 0, m = 0;
+  ptx_instruction::const_iterator opr = op_iter_begin();
+  for (; opr != op_iter_end(); opr++, n++) {  // process operands
+    const operand_info &o = *opr;
+    if (has_dst && n == 0) {
+      // Do not set the null register "_" as an architectural register
+      if (o.is_reg() && !o.is_non_arch_reg()) {
+        out[0] = o.reg_num();
+        arch_reg.dst[0] = o.arch_reg_num();
+      } else if (o.is_vector()) {
+        is_vectorin = 1;
+        unsigned num_elem = o.get_vect_nelem();
+        if (num_elem >= 1) out[0] = o.reg1_num();
+        if (num_elem >= 2) out[1] = o.reg2_num();
+        if (num_elem >= 3) out[2] = o.reg3_num();
+        if (num_elem >= 4) out[3] = o.reg4_num();
+        if (num_elem >= 5) out[4] = o.reg5_num();
+        if (num_elem >= 6) out[5] = o.reg6_num();
+        if (num_elem >= 7) out[6] = o.reg7_num();
+        if (num_elem >= 8) out[7] = o.reg8_num();
+        for (int i = 0; i < num_elem; i++) arch_reg.dst[i] = o.arch_reg_num(i);
       }
-   }
-   
-   //Setting number of input and output operands which is required for scoreboard check
-   for(int i=0;i<MAX_OUTPUT_VALUES;i++)
-	if(out[i]>0)
-		outcount++;   
- 
-   for(int i=0;i<MAX_INPUT_VALUES;i++)
-	if(in[i]>0)
-		incount++;   
-
-   // Get predicate
-   if(has_pred()) {
-	   const operand_info &p = get_pred();
-	   pred = p.reg_num();
-   }
-
-   // Get address registers inside memory operands.
-   // Assuming only one memory operand per instruction,
-   //  and maximum of two address registers for one memory operand.
-   if( has_memory_read() || has_memory_write() ) {
-      ptx_instruction::const_iterator op=op_iter_begin();
-      for ( ; op != op_iter_end(); op++, n++ ) { //process operands
-         const operand_info &o = *op;
-
-         if(o.is_memory_operand()) {
-             // We do not support the null register as a memory operand
-             assert( !o.is_non_arch_reg() );
-
-            // Check PTXPlus-type operand
-            // memory operand with addressing (ex. s[0x4] or g[$r1])
-            if(o.is_memory_operand2()) {
-
-               // memory operand with one address register (ex. g[$r1+0x4] or s[$r2+=0x4])
-               if(o.get_double_operand_type() == 0 || o.get_double_operand_type() == 3){
-                  ar1 = o.reg_num();
-                  arch_reg.src[4] = o.arch_reg_num();
-                  // TODO: address register in $r2+=0x4 should be an output register as well
-               }
-               // memory operand with two address register (ex. s[$r1+$r1] or g[$r1+=$r2])
-               else if(o.get_double_operand_type() == 1 || o.get_double_operand_type() == 2) {
-                  ar1 = o.reg1_num();
-                  arch_reg.src[4] = o.arch_reg_num();
-                  ar2 = o.reg2_num();
-                  arch_reg.src[5] = o.arch_reg_num();
-                  // TODO: first address register in $r1+=$r2 should be an output register as well
-               }
-            }
-            else if(o.is_immediate_address()){
-
-            }
-            // Regular PTX operand
-            else if (o.get_symbol()->type()->get_key().is_reg()) { // Memory operand contains a register
-              ar1 = o.reg_num();
-              arch_reg.src[4] = o.arch_reg_num();
-            }
-
-         }
+    } else {
+      if (o.is_reg() && !o.is_non_arch_reg()) {
+        int reg_num = o.reg_num();
+        arch_reg.src[m] = o.arch_reg_num();
+        switch (m) {
+          case 0:
+            in[0] = reg_num;
+            break;
+          case 1:
+            in[1] = reg_num;
+            break;
+          case 2:
+            in[2] = reg_num;
+            break;
+          default:
+            break;
+        }
+        m++;
+      } else if (o.is_vector()) {
+        // assert(m == 0); //only support 1 vector operand (for textures) right
+        // now
+        is_vectorout = 1;
+        unsigned num_elem = o.get_vect_nelem();
+        if (num_elem >= 1) in[m + 0] = o.reg1_num();
+        if (num_elem >= 2) in[m + 1] = o.reg2_num();
+        if (num_elem >= 3) in[m + 2] = o.reg3_num();
+        if (num_elem >= 4) in[m + 3] = o.reg4_num();
+        if (num_elem >= 5) in[m + 4] = o.reg5_num();
+        if (num_elem >= 6) in[m + 5] = o.reg6_num();
+        if (num_elem >= 7) in[m + 6] = o.reg7_num();
+        if (num_elem >= 8) in[m + 7] = o.reg8_num();
+        for (int i = 0; i < num_elem; i++)
+          arch_reg.src[m + i] = o.arch_reg_num(i);
+        m += num_elem;
       }
-   }
+    }
+  }
 
-   // get reconvergence pc
-   reconvergence_pc = gpgpu_ctx->func_sim->get_converge_point(pc);
+  // Setting number of input and output operands which is required for
+  // scoreboard check
+  for (int i = 0; i < MAX_OUTPUT_VALUES; i++)
+    if (out[i] > 0) outcount++;
 
-   m_decoded=true;
+  for (int i = 0; i < MAX_INPUT_VALUES; i++)
+    if (in[i] > 0) incount++;
+
+  // Get predicate
+  if (has_pred()) {
+    const operand_info &p = get_pred();
+    pred = p.reg_num();
+  }
+
+  // Get address registers inside memory operands.
+  // Assuming only one memory operand per instruction,
+  //  and maximum of two address registers for one memory operand.
+  if (has_memory_read() || has_memory_write()) {
+    ptx_instruction::const_iterator op = op_iter_begin();
+    for (; op != op_iter_end(); op++, n++) {  // process operands
+      const operand_info &o = *op;
+
+      if (o.is_memory_operand()) {
+        // We do not support the null register as a memory operand
+        assert(!o.is_non_arch_reg());
+
+        // Check PTXPlus-type operand
+        // memory operand with addressing (ex. s[0x4] or g[$r1])
+        if (o.is_memory_operand2()) {
+          // memory operand with one address register (ex. g[$r1+0x4] or
+          // s[$r2+=0x4])
+          if (o.get_double_operand_type() == 0 ||
+              o.get_double_operand_type() == 3) {
+            ar1 = o.reg_num();
+            arch_reg.src[4] = o.arch_reg_num();
+            // TODO: address register in $r2+=0x4 should be an output register
+            // as well
+          }
+          // memory operand with two address register (ex. s[$r1+$r1] or
+          // g[$r1+=$r2])
+          else if (o.get_double_operand_type() == 1 ||
+                   o.get_double_operand_type() == 2) {
+            ar1 = o.reg1_num();
+            arch_reg.src[4] = o.arch_reg_num();
+            ar2 = o.reg2_num();
+            arch_reg.src[5] = o.arch_reg_num();
+            // TODO: first address register in $r1+=$r2 should be an output
+            // register as well
+          }
+        } else if (o.is_immediate_address()) {
+        }
+        // Regular PTX operand
+        else if (o.get_symbol()
+                     ->type()
+                     ->get_key()
+                     .is_reg()) {  // Memory operand contains a register
+          ar1 = o.reg_num();
+          arch_reg.src[4] = o.arch_reg_num();
+        }
+      }
+    }
+  }
+
+  // get reconvergence pc
+  reconvergence_pc = gpgpu_ctx->func_sim->get_converge_point(pc);
+
+  m_decoded = true;
 }
 
-void function_info::add_param_name_type_size( unsigned index, std::string name, int type, size_t size, bool ptr, memory_space_t space )
-{
-   unsigned parsed_index;
-   char buffer[2048];
-   snprintf(buffer,2048,"%s_param_%%u", m_name.c_str() );
-   int ntokens = sscanf(name.c_str(),buffer,&parsed_index);
-   if( ntokens == 1 ) {
-      assert( m_ptx_kernel_param_info.find(parsed_index) == m_ptx_kernel_param_info.end() );
-      m_ptx_kernel_param_info[parsed_index] = param_info(name, type, size, ptr, space);
-   } else {
-      assert( m_ptx_kernel_param_info.find(index) == m_ptx_kernel_param_info.end() );
-      m_ptx_kernel_param_info[index] = param_info(name, type, size, ptr, space);
-   }
+void function_info::add_param_name_type_size(unsigned index, std::string name,
+                                             int type, size_t size, bool ptr,
+                                             memory_space_t space) {
+  unsigned parsed_index;
+  char buffer[2048];
+  snprintf(buffer, 2048, "%s_param_%%u", m_name.c_str());
+  int ntokens = sscanf(name.c_str(), buffer, &parsed_index);
+  if (ntokens == 1) {
+    assert(m_ptx_kernel_param_info.find(parsed_index) ==
+           m_ptx_kernel_param_info.end());
+    m_ptx_kernel_param_info[parsed_index] =
+        param_info(name, type, size, ptr, space);
+  } else {
+    assert(m_ptx_kernel_param_info.find(index) ==
+           m_ptx_kernel_param_info.end());
+    m_ptx_kernel_param_info[index] = param_info(name, type, size, ptr, space);
+  }
 }
 
-void function_info::add_param_data( unsigned argn, struct gpgpu_ptx_sim_arg *args )
-{
-   const void *data = args->m_start;
+void function_info::add_param_data(unsigned argn,
+                                   struct gpgpu_ptx_sim_arg *args) {
+  const void *data = args->m_start;
 
-   bool scratchpad_memory_param = false; // Is this parameter in CUDA shared memory or OpenCL local memory 
+  bool scratchpad_memory_param =
+      false;  // Is this parameter in CUDA shared memory or OpenCL local memory
 
-   std::map<unsigned,param_info>::iterator i=m_ptx_kernel_param_info.find(argn);
-   if( i != m_ptx_kernel_param_info.end() ) {
-      if (i->second.is_ptr_shared()) {
-         assert(args->m_start == NULL && "OpenCL parameter pointer to local memory must have NULL as value"); 
-         scratchpad_memory_param = true; 
-      } else {
-         param_t tmp;
-         tmp.pdata = args->m_start;
-         tmp.size = args->m_nbytes;
-         tmp.offset = args->m_offset;
-         tmp.type = 0;
-         i->second.add_data(tmp);
-         i->second.add_offset((unsigned) args->m_offset);
+  std::map<unsigned, param_info>::iterator i =
+      m_ptx_kernel_param_info.find(argn);
+  if (i != m_ptx_kernel_param_info.end()) {
+    if (i->second.is_ptr_shared()) {
+      assert(
+          args->m_start == NULL &&
+          "OpenCL parameter pointer to local memory must have NULL as value");
+      scratchpad_memory_param = true;
+    } else {
+      param_t tmp;
+      tmp.pdata = args->m_start;
+      tmp.size = args->m_nbytes;
+      tmp.offset = args->m_offset;
+      tmp.type = 0;
+      i->second.add_data(tmp);
+      i->second.add_offset((unsigned)args->m_offset);
+    }
+  } else {
+    scratchpad_memory_param = true;
+  }
+
+  if (scratchpad_memory_param) {
+    // This should only happen for OpenCL:
+    //
+    // The LLVM PTX compiler in NVIDIA's driver (version 190.29)
+    // does not generate an argument in the function declaration
+    // for __constant arguments.
+    //
+    // The associated constant memory space can be allocated in two
+    // ways. It can be explicitly initialized in the .ptx file where
+    // it is declared.  Or, it can be allocated using the clCreateBuffer
+    // on the host. In this later case, the .ptx file will contain
+    // a global declaration of the parameter, but it will have an unknown
+    // array size.  Thus, the symbol's address will not be set and we need
+    // to set it here before executing the PTX.
+
+    char buffer[2048];
+    snprintf(buffer, 2048, "%s_param_%u", m_name.c_str(), argn);
+
+    symbol *p = m_symtab->lookup(buffer);
+    if (p == NULL) {
+      printf(
+          "GPGPU-Sim PTX: ERROR ** could not locate symbol for \'%s\' : cannot "
+          "bind buffer\n",
+          buffer);
+      abort();
+    }
+    if (data)
+      p->set_address((addr_t) * (size_t *)data);
+    else {
+      // clSetKernelArg was passed NULL pointer for data...
+      // this is used for dynamically sized shared memory on NVIDIA platforms
+      bool is_ptr_shared = false;
+      if (i != m_ptx_kernel_param_info.end()) {
+        is_ptr_shared = i->second.is_ptr_shared();
       }
-   } else {
-      scratchpad_memory_param = true; 
-   }
 
-   if (scratchpad_memory_param) {
-      // This should only happen for OpenCL:
-      // 
-      // The LLVM PTX compiler in NVIDIA's driver (version 190.29)
-      // does not generate an argument in the function declaration 
-      // for __constant arguments.
-      //
-      // The associated constant memory space can be allocated in two 
-      // ways. It can be explicitly initialized in the .ptx file where
-      // it is declared.  Or, it can be allocated using the clCreateBuffer
-      // on the host. In this later case, the .ptx file will contain 
-      // a global declaration of the parameter, but it will have an unknown
-      // array size.  Thus, the symbol's address will not be set and we need
-      // to set it here before executing the PTX.
-      
-      char buffer[2048];
-      snprintf(buffer,2048,"%s_param_%u",m_name.c_str(),argn);
-      
-      symbol *p = m_symtab->lookup(buffer);
-      if( p == NULL ) {
-         printf("GPGPU-Sim PTX: ERROR ** could not locate symbol for \'%s\' : cannot bind buffer\n", buffer);
-         abort();
+      if (!is_ptr_shared and !p->is_shared()) {
+        printf(
+            "GPGPU-Sim PTX: ERROR ** clSetKernelArg passed NULL but arg not "
+            "shared memory\n");
+        abort();
       }
-      if( data ) 
-         p->set_address((addr_t)*(size_t*)data);
-      else {
-         // clSetKernelArg was passed NULL pointer for data...
-         // this is used for dynamically sized shared memory on NVIDIA platforms
-         bool is_ptr_shared = false; 
-         if( i != m_ptx_kernel_param_info.end() ) {
-            is_ptr_shared = i->second.is_ptr_shared(); 
-         }
-
-         if( !is_ptr_shared and !p->is_shared() ) {
-            printf("GPGPU-Sim PTX: ERROR ** clSetKernelArg passed NULL but arg not shared memory\n");
-            abort();     
-         }
-         unsigned num_bits = 8*args->m_nbytes;
-         printf("GPGPU-Sim PTX: deferred allocation of shared region for \"%s\" from 0x%x to 0x%x (shared memory space)\n",
-                p->name().c_str(),
-                m_symtab->get_shared_next(),
-                m_symtab->get_shared_next() + num_bits/8 );
-         fflush(stdout);
-         assert( (num_bits%8) == 0  );
-         addr_t addr = m_symtab->get_shared_next();
-         addr_t addr_pad = num_bits ? (((num_bits/8) - (addr % (num_bits/8))) % (num_bits/8)) : 0;
-         p->set_address( addr+addr_pad );
-         m_symtab->alloc_shared( num_bits/8 + addr_pad );
-      }
-   } 
+      unsigned num_bits = 8 * args->m_nbytes;
+      printf(
+          "GPGPU-Sim PTX: deferred allocation of shared region for \"%s\" from "
+          "0x%x to 0x%x (shared memory space)\n",
+          p->name().c_str(), m_symtab->get_shared_next(),
+          m_symtab->get_shared_next() + num_bits / 8);
+      fflush(stdout);
+      assert((num_bits % 8) == 0);
+      addr_t addr = m_symtab->get_shared_next();
+      addr_t addr_pad =
+          num_bits
+              ? (((num_bits / 8) - (addr % (num_bits / 8))) % (num_bits / 8))
+              : 0;
+      p->set_address(addr + addr_pad);
+      m_symtab->alloc_shared(num_bits / 8 + addr_pad);
+    }
+  }
 }
 
 unsigned function_info::get_args_aligned_size() {
- 
-   if(m_args_aligned_size >= 0)
-      return m_args_aligned_size;
- 
-   unsigned param_address = 0;
-   unsigned int total_size = 0;
-   for( std::map<unsigned,param_info>::iterator i=m_ptx_kernel_param_info.begin(); i!=m_ptx_kernel_param_info.end(); i++ ) {
-      param_info &p = i->second;
-      std::string name = p.get_name();
-      symbol *param = m_symtab->lookup(name.c_str());
+  if (m_args_aligned_size >= 0) return m_args_aligned_size;
 
-      size_t arg_size = p.get_size() / 8; // size of param in bytes
-      total_size = (total_size + arg_size - 1) / arg_size * arg_size; //aligned
-      p.add_offset(total_size);
-      param->set_address(param_address + total_size);
-      total_size += arg_size;
-   }
+  unsigned param_address = 0;
+  unsigned int total_size = 0;
+  for (std::map<unsigned, param_info>::iterator i =
+           m_ptx_kernel_param_info.begin();
+       i != m_ptx_kernel_param_info.end(); i++) {
+    param_info &p = i->second;
+    std::string name = p.get_name();
+    symbol *param = m_symtab->lookup(name.c_str());
 
-   m_args_aligned_size = (total_size + 3) / 4 * 4; //final size aligned to word
+    size_t arg_size = p.get_size() / 8;  // size of param in bytes
+    total_size = (total_size + arg_size - 1) / arg_size * arg_size;  // aligned
+    p.add_offset(total_size);
+    param->set_address(param_address + total_size);
+    total_size += arg_size;
+  }
 
-   return m_args_aligned_size;
+  m_args_aligned_size = (total_size + 3) / 4 * 4;  // final size aligned to word
 
+  return m_args_aligned_size;
 }
 
+void function_info::finalize(memory_space *param_mem) {
+  unsigned param_address = 0;
+  for (std::map<unsigned, param_info>::iterator i =
+           m_ptx_kernel_param_info.begin();
+       i != m_ptx_kernel_param_info.end(); i++) {
+    param_info &p = i->second;
+    if (p.is_ptr_shared())
+      continue;  // Pointer to local memory: Should we pass the allocated shared
+                 // memory address to the param memory space?
+    std::string name = p.get_name();
+    int type = p.get_type();
+    param_t param_value = p.get_value();
+    param_value.type = type;
+    symbol *param = m_symtab->lookup(name.c_str());
+    unsigned xtype = param->type()->get_key().scalar_type();
+    assert(xtype == (unsigned)type);
+    size_t size;
+    size = param_value.size;  // size of param in bytes
+    // assert(param_value.offset == param_address);
+    if (size != p.get_size() / 8) {
+      printf(
+          "GPGPU-Sim PTX: WARNING actual kernel paramter size = %zu bytes vs. "
+          "formal size = %zu (using smaller of two)\n",
+          size, p.get_size() / 8);
+      size = (size < (p.get_size() / 8)) ? size : (p.get_size() / 8);
+    }
+    // copy the parameter over word-by-word so that parameter that crosses a
+    // memory page can be copied over
+    // Jin: copy parameter using aligned rules
+    const type_info *paramtype = param->type();
+    int align_amount = paramtype->get_key().get_alignment_spec();
+    align_amount = (align_amount == -1) ? size : align_amount;
+    param_address = (param_address + align_amount - 1) / align_amount *
+                    align_amount;  // aligned
 
-void function_info::finalize( memory_space *param_mem ) 
-{
-   unsigned param_address = 0;
-   for( std::map<unsigned,param_info>::iterator i=m_ptx_kernel_param_info.begin(); i!=m_ptx_kernel_param_info.end(); i++ ) {
-      param_info &p = i->second;
-      if (p.is_ptr_shared()) continue; // Pointer to local memory: Should we pass the allocated shared memory address to the param memory space? 
-      std::string name = p.get_name();
-      int type = p.get_type();
-      param_t param_value = p.get_value();
-      param_value.type = type;
-      symbol *param = m_symtab->lookup(name.c_str());
-      unsigned xtype = param->type()->get_key().scalar_type();
-      assert(xtype==(unsigned)type);
-      size_t size;
-      size = param_value.size; // size of param in bytes
-      // assert(param_value.offset == param_address);
-      if( size != p.get_size() / 8) {
-         printf("GPGPU-Sim PTX: WARNING actual kernel paramter size = %zu bytes vs. formal size = %zu (using smaller of two)\n",
-                size, p.get_size()/8);
-         size = (size<(p.get_size()/8))?size:(p.get_size()/8);
-      } 
-      // copy the parameter over word-by-word so that parameter that crosses a memory page can be copied over
-      //Jin: copy parameter using aligned rules
-      const type_info *paramtype = param->type();
-      int align_amount = paramtype->get_key().get_alignment_spec();
-      align_amount = (align_amount == -1) ? size : align_amount;
-      param_address = (param_address + align_amount - 1) / align_amount * align_amount; //aligned
+    const size_t word_size = 4;
+    // param_address = (param_address + size - 1) / size * size; //aligned with
+    // size
+    for (size_t idx = 0; idx < size; idx += word_size) {
+      const char *pdata = reinterpret_cast<const char *>(param_value.pdata) +
+                          idx;  // cast to char * for ptr arithmetic
+      param_mem->write(param_address + idx, word_size, pdata, NULL, NULL);
+    }
+    unsigned offset = p.get_offset();
+    assert(offset == param_address);
+    param->set_address(param_address);
+    param_address += size;
+  }
+}
 
-      const size_t word_size = 4; 
-      //param_address = (param_address + size - 1) / size * size; //aligned with size 
-      for (size_t idx = 0; idx < size; idx += word_size) {
-         const char *pdata = reinterpret_cast<const char*>(param_value.pdata) + idx; // cast to char * for ptr arithmetic
-         param_mem->write(param_address + idx, word_size, pdata,NULL,NULL); 
+void function_info::param_to_shared(memory_space *shared_mem,
+                                    symbol_table *symtab) {
+  // TODO: call this only for PTXPlus with GT200 models
+  // extern gpgpu_sim* g_the_gpu;
+  if (not gpgpu_ctx->the_gpgpusim->g_the_gpu->get_config().convert_to_ptxplus())
+    return;
+
+  // copies parameters into simulated shared memory
+  for (std::map<unsigned, param_info>::iterator i =
+           m_ptx_kernel_param_info.begin();
+       i != m_ptx_kernel_param_info.end(); i++) {
+    param_info &p = i->second;
+    if (p.is_ptr_shared())
+      continue;  // Pointer to local memory: Should we pass the allocated shared
+                 // memory address to the param memory space?
+    std::string name = p.get_name();
+    int type = p.get_type();
+    param_t value = p.get_value();
+    value.type = type;
+    symbol *param = symtab->lookup(name.c_str());
+    unsigned xtype = param->type()->get_key().scalar_type();
+    assert(xtype == (unsigned)type);
+
+    int tmp;
+    size_t size;
+    unsigned offset = p.get_offset();
+    type_info_key::type_decode(xtype, size, tmp);
+
+    // Write to shared memory - offset + 0x10
+    shared_mem->write(offset + 0x10, size / 8, value.pdata, NULL, NULL);
+  }
+}
+
+void function_info::list_param(FILE *fout) const {
+  for (std::map<unsigned, param_info>::const_iterator i =
+           m_ptx_kernel_param_info.begin();
+       i != m_ptx_kernel_param_info.end(); i++) {
+    const param_info &p = i->second;
+    std::string name = p.get_name();
+    symbol *param = m_symtab->lookup(name.c_str());
+    addr_t param_addr = param->get_address();
+    fprintf(fout, "%s: %#08x\n", name.c_str(), param_addr);
+  }
+  fflush(fout);
+}
+
+void function_info::ptx_jit_config(
+    std::map<unsigned long long, size_t> mallocPtr_Size,
+    memory_space *param_mem, gpgpu_t *gpu, dim3 gridDim, dim3 blockDim) {
+  static unsigned long long counter = 0;
+  std::vector<std::pair<size_t, unsigned char *> > param_data;
+  std::vector<unsigned> offsets;
+  std::vector<bool> paramIsPointer;
+
+  char *gpgpusim_path = getenv("GPGPUSIM_ROOT");
+  assert(gpgpusim_path != NULL);
+  char *wys_exec_path = getenv("WYS_EXEC_PATH");
+  assert(wys_exec_path != NULL);
+  std::string command =
+      std::string("mkdir ") + gpgpusim_path + "/debug_tools/WatchYourStep/data";
+  std::string filename(std::string(gpgpusim_path) +
+                       "/debug_tools/WatchYourStep/data/params.config" +
+                       std::to_string(counter));
+
+  // initialize paramList
+  char buff[1024];
+  std::string filename_c(filename + "_c");
+  snprintf(buff, 1024, "c++filt %s > %s", get_name().c_str(),
+           filename_c.c_str());
+  assert(system(buff) != NULL);
+  FILE *fp = fopen(filename_c.c_str(), "r");
+  fgets(buff, 1024, fp);
+  fclose(fp);
+  std::string fn(buff);
+  size_t pos1, pos2;
+  pos1 = fn.find_last_of("(");
+  pos2 = fn.find(")", pos1);
+  assert(pos2 > pos1 && pos1 > 0);
+  strcpy(buff, fn.substr(pos1 + 1, pos2 - pos1 - 1).c_str());
+  char *tok;
+  tok = strtok(buff, ",");
+  std::string tmp;
+  while (tok != NULL) {
+    std::string param(tok);
+    if (param.find("<") != std::string::npos) {
+      assert(param.find(">") == std::string::npos);
+      assert(param.find("*") == std::string::npos);
+      tmp = param;
+    } else {
+      if (tmp.length() > 0) {
+        tmp = "";
+        assert(param.find(">") != std::string::npos);
+        assert(param.find("<") == std::string::npos);
+        assert(param.find("*") == std::string::npos);
       }
-      unsigned offset = p.get_offset();
-      assert(offset == param_address);
-      param->set_address(param_address);
-      param_address += size;
-   }
-}
-
-void function_info::param_to_shared( memory_space *shared_mem, symbol_table *symtab ) 
-{
-   // TODO: call this only for PTXPlus with GT200 models 
-   //extern gpgpu_sim* g_the_gpu;
-   if (not gpgpu_ctx->the_gpgpusim->g_the_gpu->get_config().convert_to_ptxplus()) return;
-
-   // copies parameters into simulated shared memory
-   for( std::map<unsigned,param_info>::iterator i=m_ptx_kernel_param_info.begin(); i!=m_ptx_kernel_param_info.end(); i++ ) {
-      param_info &p = i->second;
-      if (p.is_ptr_shared()) continue; // Pointer to local memory: Should we pass the allocated shared memory address to the param memory space? 
-      std::string name = p.get_name();
-      int type = p.get_type();
-      param_t value = p.get_value();
-      value.type = type;
-      symbol *param = symtab->lookup(name.c_str());
-      unsigned xtype = param->type()->get_key().scalar_type();
-      assert(xtype==(unsigned)type);
-
-      int tmp;
-      size_t size;
-      unsigned offset = p.get_offset();
-      type_info_key::type_decode(xtype,size,tmp);
-
-      // Write to shared memory - offset + 0x10
-      shared_mem->write(offset+0x10,size/8,value.pdata,NULL,NULL);
-   }
-}
-
-
-void function_info::list_param( FILE *fout ) const
-{
-   for( std::map<unsigned,param_info>::const_iterator i=m_ptx_kernel_param_info.begin(); i!=m_ptx_kernel_param_info.end(); i++ ) {
-      const param_info &p = i->second;
-      std::string name = p.get_name();
-      symbol *param = m_symtab->lookup(name.c_str());
-      addr_t param_addr = param->get_address();
-      fprintf(fout, "%s: %#08x\n", name.c_str(), param_addr);
-   }
-   fflush(fout);
-}
-
-void function_info::ptx_jit_config(std::map<unsigned long long, size_t> mallocPtr_Size, memory_space *param_mem, gpgpu_t* gpu, dim3 gridDim, dim3 blockDim) 
-{
-    static unsigned long long counter = 0;
-    std::vector< std::pair<size_t, unsigned char*> > param_data;
-    std::vector<unsigned> offsets;
-    std::vector<bool> paramIsPointer;
-
-    char * gpgpusim_path = getenv("GPGPUSIM_ROOT");
-    assert(gpgpusim_path!=NULL);
-    char * wys_exec_path = getenv("WYS_EXEC_PATH");
-    assert(wys_exec_path!=NULL);
-    std::string command = std::string("mkdir ") + gpgpusim_path + "/debug_tools/WatchYourStep/data";
-    std::string filename(std::string(gpgpusim_path) + "/debug_tools/WatchYourStep/data/params.config" + std::to_string(counter));
-
-    //initialize paramList
-    char buff[1024];
-    std::string filename_c(filename+"_c");
-    snprintf(buff,1024,"c++filt %s > %s", get_name().c_str(), filename_c.c_str());
-    assert(system(buff) != NULL);
-    FILE *fp = fopen(filename_c.c_str(), "r");
-    fgets(buff, 1024, fp);
-    fclose(fp);
-    std::string fn(buff);
-    size_t pos1, pos2;
-    pos1 = fn.find_last_of("(");
-    pos2 = fn.find(")", pos1);
-    assert(pos2>pos1&&pos1>0);
-    strcpy(buff, fn.substr(pos1 + 1, pos2 - pos1 - 1).c_str());
-    char *tok;
-    tok = strtok(buff, ",");
-    std::string tmp;
-    while(tok!=NULL){
-        std::string param(tok);
-        if(param.find("<")!=std::string::npos){
-            assert(param.find(">")==std::string::npos);
-            assert(param.find("*")==std::string::npos);
-            tmp = param;
-        } else {
-            if (tmp.length()>0){
-                tmp = ""; 
-                assert(param.find(">")!=std::string::npos);
-                assert(param.find("<")==std::string::npos);
-                assert(param.find("*")==std::string::npos);
-            }   
-            printf("%s\n", param.c_str());
-            if(param.find("*")!=std::string::npos){
-                paramIsPointer.push_back(true);
-            }else{                                                                                 
-                paramIsPointer.push_back(false);
-            }   
-        }
-        tok = strtok(NULL, ",");
+      printf("%s\n", param.c_str());
+      if (param.find("*") != std::string::npos) {
+        paramIsPointer.push_back(true);
+      } else {
+        paramIsPointer.push_back(false);
+      }
     }
+    tok = strtok(NULL, ",");
+  }
 
+  for (std::map<unsigned, param_info>::iterator i =
+           m_ptx_kernel_param_info.begin();
+       i != m_ptx_kernel_param_info.end(); i++) {
+    param_info &p = i->second;
+    std::string name = p.get_name();
+    symbol *param = m_symtab->lookup(name.c_str());
+    addr_t param_addr = param->get_address();
+    param_t param_value = p.get_value();
+    offsets.push_back((unsigned)p.get_offset());
 
-    for( std::map<unsigned,param_info>::iterator i=m_ptx_kernel_param_info.begin(); i!=m_ptx_kernel_param_info.end(); i++ ) {
-        param_info &p = i->second;
-        std::string name = p.get_name();
-        symbol *param = m_symtab->lookup(name.c_str());
-        addr_t param_addr = param->get_address();
-        param_t param_value = p.get_value();
-        offsets.push_back((unsigned)p.get_offset());
-
-        if (paramIsPointer[i->first] && (*(unsigned long long*)param_value.pdata != 0)){
-            //is pointer
-            assert(param_value.size==sizeof(void*)&&"MisID'd this param as pointer");
-            size_t array_size = 0;
-            unsigned long long param_pointer = *(unsigned long long*)param_value.pdata;
-            if(mallocPtr_Size.find(param_pointer)!=mallocPtr_Size.end()){
-                array_size = mallocPtr_Size[param_pointer];
-            }else{
-                for( std::map<unsigned long long, size_t>::iterator j=mallocPtr_Size.begin(); j!=mallocPtr_Size.end(); j++ ) {
-                    if(param_pointer>j->first&&param_pointer<j->first + j->second){
-                        array_size = j->first + j->second - param_pointer;
-                        break;
-                    }
-                }
-                assert(array_size>0&&"pointer was not previously malloc'd");
-            }
-
-            unsigned char* val = (unsigned char*) malloc(param_value.size);
-            param_mem->read(param_addr,param_value.size,(void*)val);
-            unsigned char* array_val = (unsigned char*) malloc(array_size);
-            gpu->get_global_memory()->read(*(unsigned*)((void*)val),array_size,(void*)array_val);
-            param_data.push_back(std::pair<size_t, unsigned char*>(array_size,array_val));
-            paramIsPointer.push_back(true);
-        }else{
-            unsigned char* val = (unsigned char*) malloc(param_value.size);
-            param_mem->read(param_addr,param_value.size,(void*)val);
-            param_data.push_back(std::pair<size_t, unsigned char*>(param_value.size,val));
-            paramIsPointer.push_back(false);
-        }
-    }
-
-    FILE *fout  = fopen (filename.c_str(), "w");
-    printf("Writing data to %s ...\n", filename.c_str());
-    fprintf(fout, "%s\n", get_name().c_str());
-    fprintf(fout, "%u,%u,%u %u,%u,%u\n", gridDim.x, gridDim.y, gridDim.z, blockDim.x, blockDim.y, blockDim.z);
-    size_t index = 0;
-    for( std::vector< std::pair<size_t,unsigned char*> >::const_iterator i=param_data.begin(); i!=param_data.end(); i++ ) {
-        if (paramIsPointer[index]){
-            fprintf(fout, "*");
-        }
-        fprintf(fout, "%lu :", i->first);
-        for (size_t j = 0; j<i->first; j++){
-            fprintf(fout, " %u", i->second[j]);
-        }
-        fprintf(fout, " : %u", offsets[index]);
-        free (i->second);
-        fprintf(fout, "\n");
-        index++;
-    }
-    fflush(fout);
-    fclose(fout);
-    
-    //ptx config
-    std::string ptx_config_fn(std::string(gpgpusim_path) + "/debug_tools/WatchYourStep/data/ptx.config" + std::to_string(counter));
-    snprintf(buff, 1024, "grep -rn \".entry %s\" %s/*.ptx | cut -d \":\" -f 1-2 > %s", get_name().c_str(), wys_exec_path, ptx_config_fn.c_str());
-    if (system(buff)!=0){
-        printf("WARNING: Failed to execute grep to find ptx source \n");
-        printf("Problematic call: %s", buff);
-        abort();
-    }
-    FILE *fin = fopen(ptx_config_fn.c_str(), "r");
-    char ptx_source[256];
-    unsigned line_number;
-    int numscanned = fscanf(fin, "%[^:]:%u", ptx_source, &line_number);
-    assert(numscanned == 2);
-    fclose(fin);
-    snprintf(buff, 1024, "grep -rn \".version\" %s | cut -d \":\" -f 1 | xargs -I \"{}\" awk \"NR>={}&&NR<={}+2\" %s > %s", ptx_source, ptx_source, ptx_config_fn.c_str());
-    if (system(buff)!=0){
-        printf("WARNING: Failed to execute grep to find ptx header \n");
-        printf("Problematic call: %s", buff);
-        abort();
-    }
-    fin = fopen(ptx_source, "r");
-    assert(fin!=NULL);
-    printf("Writing data to %s ...\n", ptx_config_fn.c_str());
-    fout = fopen(ptx_config_fn.c_str(), "a");
-    assert(fout!=NULL);
-    for (unsigned i = 0; i<line_number; i++){
-        assert(fgets(buff, 1024, fin) != NULL);
-        assert(!feof(fin));
-    }
-    fprintf(fout, "\n\n");
-    do{
-        fprintf(fout, "%s", buff);
-        assert(fgets(buff, 1024, fin) != NULL);
-        if(feof(fin)){
+    if (paramIsPointer[i->first] &&
+        (*(unsigned long long *)param_value.pdata != 0)) {
+      // is pointer
+      assert(param_value.size == sizeof(void *) &&
+             "MisID'd this param as pointer");
+      size_t array_size = 0;
+      unsigned long long param_pointer =
+          *(unsigned long long *)param_value.pdata;
+      if (mallocPtr_Size.find(param_pointer) != mallocPtr_Size.end()) {
+        array_size = mallocPtr_Size[param_pointer];
+      } else {
+        for (std::map<unsigned long long, size_t>::iterator j =
+                 mallocPtr_Size.begin();
+             j != mallocPtr_Size.end(); j++) {
+          if (param_pointer > j->first &&
+              param_pointer < j->first + j->second) {
+            array_size = j->first + j->second - param_pointer;
             break;
+          }
         }
-    } while(strstr(buff, "entry")==NULL);
-
-    fclose(fin);
-    fflush(fout);
-    fclose(fout);
-    counter++;
-}
-
-template<int activate_level> 
-bool cuda_sim::ptx_debug_exec_dump_cond(int thd_uid, addr_t pc)
-{
-   if (g_debug_execution >= activate_level) {
-      // check each type of debug dump constraint to filter out dumps
-      if ( (g_debug_thread_uid != 0) && (thd_uid != (unsigned)g_debug_thread_uid) ) {
-         return false;
-      }
-      if ( (g_debug_pc != 0xBEEF1518) && (pc != g_debug_pc) ) {
-         return false;
+        assert(array_size > 0 && "pointer was not previously malloc'd");
       }
 
-      return true;
-   } 
-   
-   return false;
+      unsigned char *val = (unsigned char *)malloc(param_value.size);
+      param_mem->read(param_addr, param_value.size, (void *)val);
+      unsigned char *array_val = (unsigned char *)malloc(array_size);
+      gpu->get_global_memory()->read(*(unsigned *)((void *)val), array_size,
+                                     (void *)array_val);
+      param_data.push_back(
+          std::pair<size_t, unsigned char *>(array_size, array_val));
+      paramIsPointer.push_back(true);
+    } else {
+      unsigned char *val = (unsigned char *)malloc(param_value.size);
+      param_mem->read(param_addr, param_value.size, (void *)val);
+      param_data.push_back(
+          std::pair<size_t, unsigned char *>(param_value.size, val));
+      paramIsPointer.push_back(false);
+    }
+  }
+
+  FILE *fout = fopen(filename.c_str(), "w");
+  printf("Writing data to %s ...\n", filename.c_str());
+  fprintf(fout, "%s\n", get_name().c_str());
+  fprintf(fout, "%u,%u,%u %u,%u,%u\n", gridDim.x, gridDim.y, gridDim.z,
+          blockDim.x, blockDim.y, blockDim.z);
+  size_t index = 0;
+  for (std::vector<std::pair<size_t, unsigned char *> >::const_iterator i =
+           param_data.begin();
+       i != param_data.end(); i++) {
+    if (paramIsPointer[index]) {
+      fprintf(fout, "*");
+    }
+    fprintf(fout, "%lu :", i->first);
+    for (size_t j = 0; j < i->first; j++) {
+      fprintf(fout, " %u", i->second[j]);
+    }
+    fprintf(fout, " : %u", offsets[index]);
+    free(i->second);
+    fprintf(fout, "\n");
+    index++;
+  }
+  fflush(fout);
+  fclose(fout);
+
+  // ptx config
+  std::string ptx_config_fn(std::string(gpgpusim_path) +
+                            "/debug_tools/WatchYourStep/data/ptx.config" +
+                            std::to_string(counter));
+  snprintf(buff, 1024,
+           "grep -rn \".entry %s\" %s/*.ptx | cut -d \":\" -f 1-2 > %s",
+           get_name().c_str(), wys_exec_path, ptx_config_fn.c_str());
+  if (system(buff) != 0) {
+    printf("WARNING: Failed to execute grep to find ptx source \n");
+    printf("Problematic call: %s", buff);
+    abort();
+  }
+  FILE *fin = fopen(ptx_config_fn.c_str(), "r");
+  char ptx_source[256];
+  unsigned line_number;
+  int numscanned = fscanf(fin, "%[^:]:%u", ptx_source, &line_number);
+  assert(numscanned == 2);
+  fclose(fin);
+  snprintf(buff, 1024,
+           "grep -rn \".version\" %s | cut -d \":\" -f 1 | xargs -I \"{}\" awk "
+           "\"NR>={}&&NR<={}+2\" %s > %s",
+           ptx_source, ptx_source, ptx_config_fn.c_str());
+  if (system(buff) != 0) {
+    printf("WARNING: Failed to execute grep to find ptx header \n");
+    printf("Problematic call: %s", buff);
+    abort();
+  }
+  fin = fopen(ptx_source, "r");
+  assert(fin != NULL);
+  printf("Writing data to %s ...\n", ptx_config_fn.c_str());
+  fout = fopen(ptx_config_fn.c_str(), "a");
+  assert(fout != NULL);
+  for (unsigned i = 0; i < line_number; i++) {
+    assert(fgets(buff, 1024, fin) != NULL);
+    assert(!feof(fin));
+  }
+  fprintf(fout, "\n\n");
+  do {
+    fprintf(fout, "%s", buff);
+    assert(fgets(buff, 1024, fin) != NULL);
+    if (feof(fin)) {
+      break;
+    }
+  } while (strstr(buff, "entry") == NULL);
+
+  fclose(fin);
+  fflush(fout);
+  fclose(fout);
+  counter++;
 }
 
-void cuda_sim::init_inst_classification_stat()
-{
-   static std::set<unsigned> init;
-   if( init.find(g_ptx_kernel_count) != init.end() ) 
-      return;
-   init.insert(g_ptx_kernel_count);
+template <int activate_level>
+bool cuda_sim::ptx_debug_exec_dump_cond(int thd_uid, addr_t pc) {
+  if (g_debug_execution >= activate_level) {
+    // check each type of debug dump constraint to filter out dumps
+    if ((g_debug_thread_uid != 0) &&
+        (thd_uid != (unsigned)g_debug_thread_uid)) {
+      return false;
+    }
+    if ((g_debug_pc != 0xBEEF1518) && (pc != g_debug_pc)) {
+      return false;
+    }
 
-   #define MAX_CLASS_KER 1024
-   char kernelname[MAX_CLASS_KER] ="";
-   if (!g_inst_classification_stat) g_inst_classification_stat = (void**)calloc(MAX_CLASS_KER, sizeof(void*));
-   snprintf(kernelname, MAX_CLASS_KER, "Kernel %d Classification\n",g_ptx_kernel_count  );         
-   assert( g_ptx_kernel_count < MAX_CLASS_KER ) ; // a static limit on number of kernels increase it if it fails! 
-   g_inst_classification_stat[g_ptx_kernel_count] = StatCreate(kernelname,1,20);
-   if (!g_inst_op_classification_stat) g_inst_op_classification_stat = (void**)calloc(MAX_CLASS_KER, sizeof(void*));
-   snprintf(kernelname, MAX_CLASS_KER, "Kernel %d OP Classification\n",g_ptx_kernel_count  );         
-   g_inst_op_classification_stat[g_ptx_kernel_count] = StatCreate(kernelname,1,100);
+    return true;
+  }
+
+  return false;
 }
 
-static unsigned get_tex_datasize( const ptx_instruction *pI, ptx_thread_info *thread )
-{
-   const operand_info &src1 = pI->src1(); //the name of the texture
-   std::string texname = src1.name();
+void cuda_sim::init_inst_classification_stat() {
+  static std::set<unsigned> init;
+  if (init.find(g_ptx_kernel_count) != init.end()) return;
+  init.insert(g_ptx_kernel_count);
 
-   /*
-     For programs with many streams, textures can be bound and unbound
-     asynchronously.  This means we need to use the kernel's "snapshot" of
-     the state of the texture mappings when it was launched (so that we
-     don't try to access the incorrect texture mapping if it's been updated,
-     or that we don't access a mapping that has been unbound).
-    */
-   kernel_info_t& k = thread->get_kernel();
-   const struct textureInfo* texInfo = k.get_texinfo(texname);
-
-   unsigned data_size = texInfo->texel_size;
-   return data_size; 
+#define MAX_CLASS_KER 1024
+  char kernelname[MAX_CLASS_KER] = "";
+  if (!g_inst_classification_stat)
+    g_inst_classification_stat = (void **)calloc(MAX_CLASS_KER, sizeof(void *));
+  snprintf(kernelname, MAX_CLASS_KER, "Kernel %d Classification\n",
+           g_ptx_kernel_count);
+  assert(g_ptx_kernel_count <
+         MAX_CLASS_KER);  // a static limit on number of kernels increase it if
+                          // it fails!
+  g_inst_classification_stat[g_ptx_kernel_count] =
+      StatCreate(kernelname, 1, 20);
+  if (!g_inst_op_classification_stat)
+    g_inst_op_classification_stat =
+        (void **)calloc(MAX_CLASS_KER, sizeof(void *));
+  snprintf(kernelname, MAX_CLASS_KER, "Kernel %d OP Classification\n",
+           g_ptx_kernel_count);
+  g_inst_op_classification_stat[g_ptx_kernel_count] =
+      StatCreate(kernelname, 1, 100);
 }
 
-int tensorcore_op(int inst_opcode){
-	
-       if((inst_opcode==MMA_OP)||(inst_opcode==MMA_LD_OP)||(inst_opcode==MMA_ST_OP))
-		return 1;
-       else	
-		return 0;
+static unsigned get_tex_datasize(const ptx_instruction *pI,
+                                 ptx_thread_info *thread) {
+  const operand_info &src1 = pI->src1();  // the name of the texture
+  std::string texname = src1.name();
+
+  /*
+    For programs with many streams, textures can be bound and unbound
+    asynchronously.  This means we need to use the kernel's "snapshot" of
+    the state of the texture mappings when it was launched (so that we
+    don't try to access the incorrect texture mapping if it's been updated,
+    or that we don't access a mapping that has been unbound).
+   */
+  kernel_info_t &k = thread->get_kernel();
+  const struct textureInfo *texInfo = k.get_texinfo(texname);
+
+  unsigned data_size = texInfo->texel_size;
+  return data_size;
 }
-void ptx_thread_info::ptx_exec_inst( warp_inst_t &inst, unsigned lane_id)
-{
-    
-   bool skip = false;
-   int op_classification = 0;
-   addr_t pc = next_instr();
-   assert( pc == inst.pc ); // make sure timing model and functional model are in sync
-   const ptx_instruction *pI = m_func_info->get_instruction(pc);
-   
-   set_npc( pc + pI->inst_size() );
-   
 
-   try {
+int tensorcore_op(int inst_opcode) {
+  if ((inst_opcode == MMA_OP) || (inst_opcode == MMA_LD_OP) ||
+      (inst_opcode == MMA_ST_OP))
+    return 1;
+  else
+    return 0;
+}
+void ptx_thread_info::ptx_exec_inst(warp_inst_t &inst, unsigned lane_id) {
+  bool skip = false;
+  int op_classification = 0;
+  addr_t pc = next_instr();
+  assert(pc ==
+         inst.pc);  // make sure timing model and functional model are in sync
+  const ptx_instruction *pI = m_func_info->get_instruction(pc);
 
-   clearRPC();
-   m_last_set_operand_value.u64 = 0;
+  set_npc(pc + pI->inst_size());
 
-   if(is_done())
-   {
-      printf("attempted to execute instruction on a thread that is already done.\n");
+  try {
+    clearRPC();
+    m_last_set_operand_value.u64 = 0;
+
+    if (is_done()) {
+      printf(
+          "attempted to execute instruction on a thread that is already "
+          "done.\n");
       assert(0);
-   }
-   
-   if ( g_debug_execution >= 6 || m_gpu->get_config().get_ptx_inst_debug_to_file()) {
-      if ( (m_gpu->gpgpu_ctx->func_sim->g_debug_thread_uid==0)
-	      || (get_uid() == (unsigned)(m_gpu->gpgpu_ctx->func_sim->g_debug_thread_uid)) ) {
-        
-          clear_modifiedregs();
-         enable_debug_trace();
+    }
+
+    if (g_debug_execution >= 6 ||
+        m_gpu->get_config().get_ptx_inst_debug_to_file()) {
+      if ((m_gpu->gpgpu_ctx->func_sim->g_debug_thread_uid == 0) ||
+          (get_uid() ==
+           (unsigned)(m_gpu->gpgpu_ctx->func_sim->g_debug_thread_uid))) {
+        clear_modifiedregs();
+        enable_debug_trace();
       }
-   }
-   
-   
-   if( pI->has_pred() ) {
+    }
+
+    if (pI->has_pred()) {
       const operand_info &pred = pI->get_pred();
       ptx_reg_t pred_value = get_operand_value(pred, pred, PRED_TYPE, this, 0);
-      if(pI->get_pred_mod() == -1) {
-            skip = (pred_value.pred & 0x0001) ^ pI->get_pred_neg(); //ptxplus inverts the zero flag
+      if (pI->get_pred_mod() == -1) {
+        skip = (pred_value.pred & 0x0001) ^
+               pI->get_pred_neg();  // ptxplus inverts the zero flag
       } else {
-            skip = !pred_lookup(pI->get_pred_mod(), pred_value.pred & 0x000F);
+        skip = !pred_lookup(pI->get_pred_mod(), pred_value.pred & 0x000F);
       }
-   }
-   int inst_opcode=pI->get_opcode();
-   
-   if( skip ) {
+    }
+    int inst_opcode = pI->get_opcode();
+
+    if (skip) {
       inst.set_not_active(lane_id);
-   } else {
+    } else {
       const ptx_instruction *pI_saved = pI;
       ptx_instruction *pJ = NULL;
-      if( pI->get_opcode() == VOTE_OP ) {
-         pJ = new ptx_instruction(*pI);
-         *((warp_inst_t*)pJ) = inst; // copy active mask information
-         pI = pJ;
+      if (pI->get_opcode() == VOTE_OP) {
+        pJ = new ptx_instruction(*pI);
+        *((warp_inst_t *)pJ) = inst;  // copy active mask information
+        pI = pJ;
       }
-     
-      if(((inst_opcode==MMA_OP||inst_opcode==MMA_LD_OP||inst_opcode==MMA_ST_OP))){
-      		if(inst.active_count()!=MAX_WARP_SIZE)
-		{	
-			printf("Tensor Core operation are warp synchronous operation. All the threads needs to be active.");
-			assert(0);
-		}
+
+      if (((inst_opcode == MMA_OP || inst_opcode == MMA_LD_OP ||
+            inst_opcode == MMA_ST_OP))) {
+        if (inst.active_count() != MAX_WARP_SIZE) {
+          printf(
+              "Tensor Core operation are warp synchronous operation. All the "
+              "threads needs to be active.");
+          assert(0);
+        }
       }
-      
-      //Tensorcore is warp synchronous operation. So these instructions needs to be executed only once. To make the simulation faster removing the redundant tensorcore operation
-      if(!tensorcore_op(inst_opcode)||((tensorcore_op(inst_opcode))&&(lane_id==0))){
-	      switch ( inst_opcode ) {
-	#define OP_DEF(OP,FUNC,STR,DST,CLASSIFICATION) case OP: FUNC(pI,this); op_classification = CLASSIFICATION; break;
-	#define OP_W_DEF(OP,FUNC,STR,DST,CLASSIFICATION) case OP: FUNC(pI,get_core(),inst); op_classification = CLASSIFICATION; break;
-	#include "opcodes.def"
-	#undef OP_DEF
-	#undef OP_W_DEF
-	      default: printf( "Execution error: Invalid opcode (0x%x)\n", pI->get_opcode() ); break;
-	      }
+
+      // Tensorcore is warp synchronous operation. So these instructions needs
+      // to be executed only once. To make the simulation faster removing the
+      // redundant tensorcore operation
+      if (!tensorcore_op(inst_opcode) ||
+          ((tensorcore_op(inst_opcode)) && (lane_id == 0))) {
+        switch (inst_opcode) {
+#define OP_DEF(OP, FUNC, STR, DST, CLASSIFICATION) \
+  case OP:                                         \
+    FUNC(pI, this);                                \
+    op_classification = CLASSIFICATION;            \
+    break;
+#define OP_W_DEF(OP, FUNC, STR, DST, CLASSIFICATION) \
+  case OP:                                           \
+    FUNC(pI, get_core(), inst);                      \
+    op_classification = CLASSIFICATION;              \
+    break;
+#include "opcodes.def"
+#undef OP_DEF
+#undef OP_W_DEF
+          default:
+            printf("Execution error: Invalid opcode (0x%x)\n",
+                   pI->get_opcode());
+            break;
+        }
       }
       delete pJ;
       pI = pI_saved;
-      
+
       // Run exit instruction if exit option included
-      if(pI->is_exit())
-         exit_impl(pI,this);
-   }
-   
+      if (pI->is_exit()) exit_impl(pI, this);
+    }
 
+    const gpgpu_functional_sim_config &config = m_gpu->get_config();
 
-   const gpgpu_functional_sim_config &config = m_gpu->get_config();
-   
-   // Output instruction information to file and stdout
-   if( config.get_ptx_inst_debug_to_file() != 0 && 
-        (config.get_ptx_inst_debug_thread_uid() == 0 || config.get_ptx_inst_debug_thread_uid() == get_uid()) ) {
-      fprintf(m_gpu->get_ptx_inst_debug_file(),
-             "[thd=%u] : (%s:%u - %s)\n",
-             get_uid(),
-             pI->source_file(), pI->source_line(), pI->get_source() );
-      //fprintf(ptx_inst_debug_file, "has memory read=%d, has memory write=%d\n", pI->has_memory_read(), pI->has_memory_write());
+    // Output instruction information to file and stdout
+    if (config.get_ptx_inst_debug_to_file() != 0 &&
+        (config.get_ptx_inst_debug_thread_uid() == 0 ||
+         config.get_ptx_inst_debug_thread_uid() == get_uid())) {
+      fprintf(m_gpu->get_ptx_inst_debug_file(), "[thd=%u] : (%s:%u - %s)\n",
+              get_uid(), pI->source_file(), pI->source_line(),
+              pI->get_source());
+      // fprintf(ptx_inst_debug_file, "has memory read=%d, has memory
+      // write=%d\n", pI->has_memory_read(), pI->has_memory_write());
       fflush(m_gpu->get_ptx_inst_debug_file());
-   }
+    }
 
-   if ( m_gpu->gpgpu_ctx->func_sim->ptx_debug_exec_dump_cond<5>(get_uid(), pc) ) {
+    if (m_gpu->gpgpu_ctx->func_sim->ptx_debug_exec_dump_cond<5>(get_uid(),
+                                                                pc)) {
       dim3 ctaid = get_ctaid();
       dim3 tid = get_tid();
-      printf("%u [thd=%u][i=%u] : ctaid=(%u,%u,%u) tid=(%u,%u,%u) icount=%u [pc=%u] (%s:%u - %s)  [0x%llx]\n", 
-             m_gpu->gpgpu_ctx->func_sim->g_ptx_sim_num_insn,
-             get_uid(),
-             pI->uid(), ctaid.x,ctaid.y,ctaid.z,tid.x,tid.y,tid.z,
-             get_icount(),
-             pc, pI->source_file(), pI->source_line(), pI->get_source(),
-             m_last_set_operand_value.u64 );
+      printf(
+          "%u [thd=%u][i=%u] : ctaid=(%u,%u,%u) tid=(%u,%u,%u) icount=%u "
+          "[pc=%u] (%s:%u - %s)  [0x%llx]\n",
+          m_gpu->gpgpu_ctx->func_sim->g_ptx_sim_num_insn, get_uid(), pI->uid(),
+          ctaid.x, ctaid.y, ctaid.z, tid.x, tid.y, tid.z, get_icount(), pc,
+          pI->source_file(), pI->source_line(), pI->get_source(),
+          m_last_set_operand_value.u64);
       fflush(stdout);
-   }
-   
-   addr_t insn_memaddr = 0xFEEBDAED;
-   memory_space_t insn_space = undefined_space;
-   _memory_op_t insn_memory_op = no_memory_op;
-   unsigned insn_data_size = 0;
-   if ( (pI->has_memory_read()  || pI->has_memory_write()) ) {
-      if(!((inst_opcode==MMA_LD_OP||inst_opcode==MMA_ST_OP)))
-      {
+    }
+
+    addr_t insn_memaddr = 0xFEEBDAED;
+    memory_space_t insn_space = undefined_space;
+    _memory_op_t insn_memory_op = no_memory_op;
+    unsigned insn_data_size = 0;
+    if ((pI->has_memory_read() || pI->has_memory_write())) {
+      if (!((inst_opcode == MMA_LD_OP || inst_opcode == MMA_ST_OP))) {
         insn_memaddr = last_eaddr();
         insn_space = last_space();
         unsigned to_type = pI->get_type();
         insn_data_size = datatype2size(to_type);
         insn_memory_op = pI->has_memory_read() ? memory_load : memory_store;
-      }	
-   }
-  
-   if ( pI->get_opcode() == BAR_OP && pI->barrier_op() == RED_OPTION) {
-	   inst.add_callback( lane_id, last_callback().function, last_callback().instruction, this,false /*not atomic*/);
-   }
+      }
+    }
 
-   if ( pI->get_opcode() == ATOM_OP ) {
+    if (pI->get_opcode() == BAR_OP && pI->barrier_op() == RED_OPTION) {
+      inst.add_callback(lane_id, last_callback().function,
+                        last_callback().instruction, this,
+                        false /*not atomic*/);
+    }
+
+    if (pI->get_opcode() == ATOM_OP) {
       insn_memaddr = last_eaddr();
       insn_space = last_space();
-      inst.add_callback( lane_id, last_callback().function, last_callback().instruction, this,true /*atomic*/);
+      inst.add_callback(lane_id, last_callback().function,
+                        last_callback().instruction, this, true /*atomic*/);
       unsigned to_type = pI->get_type();
       insn_data_size = datatype2size(to_type);
-   }
+    }
 
-   if (pI->get_opcode() == TEX_OP) {
-      inst.set_addr(lane_id, last_eaddr() );
-      assert( inst.space == last_space() );
-      insn_data_size = get_tex_datasize(pI, this); // texture obtain its data granularity from the texture info 
-   }
+    if (pI->get_opcode() == TEX_OP) {
+      inst.set_addr(lane_id, last_eaddr());
+      assert(inst.space == last_space());
+      insn_data_size = get_tex_datasize(
+          pI,
+          this);  // texture obtain its data granularity from the texture info
+    }
 
-   // Output register information to file and stdout
-   if( config.get_ptx_inst_debug_to_file()!=0 && 
-       (config.get_ptx_inst_debug_thread_uid()==0||config.get_ptx_inst_debug_thread_uid()==get_uid()) ) {
+    // Output register information to file and stdout
+    if (config.get_ptx_inst_debug_to_file() != 0 &&
+        (config.get_ptx_inst_debug_thread_uid() == 0 ||
+         config.get_ptx_inst_debug_thread_uid() == get_uid())) {
       dump_modifiedregs(m_gpu->get_ptx_inst_debug_file());
       dump_regs(m_gpu->get_ptx_inst_debug_file());
-   }
+    }
 
-   if ( g_debug_execution >= 6 ) {
-      if ( m_gpu->gpgpu_ctx->func_sim->ptx_debug_exec_dump_cond<6>(get_uid(), pc) )
-         dump_modifiedregs(stdout);
-   }
-   if ( g_debug_execution >= 10 ) {
-      if ( m_gpu->gpgpu_ctx->func_sim->ptx_debug_exec_dump_cond<10>(get_uid(), pc) )
-         dump_regs(stdout);
-   }
-   update_pc();
-   m_gpu->gpgpu_ctx->func_sim->g_ptx_sim_num_insn++;
-   
-   //not using it with functional simulation mode
-   if(!(this->m_functionalSimulationMode))
-       ptx_file_line_stats_add_exec_count(pI);
-   
-   if ( m_gpu->gpgpu_ctx->func_sim->gpgpu_ptx_instruction_classification ) {
+    if (g_debug_execution >= 6) {
+      if (m_gpu->gpgpu_ctx->func_sim->ptx_debug_exec_dump_cond<6>(get_uid(),
+                                                                  pc))
+        dump_modifiedregs(stdout);
+    }
+    if (g_debug_execution >= 10) {
+      if (m_gpu->gpgpu_ctx->func_sim->ptx_debug_exec_dump_cond<10>(get_uid(),
+                                                                   pc))
+        dump_regs(stdout);
+    }
+    update_pc();
+    m_gpu->gpgpu_ctx->func_sim->g_ptx_sim_num_insn++;
+
+    // not using it with functional simulation mode
+    if (!(this->m_functionalSimulationMode))
+      ptx_file_line_stats_add_exec_count(pI);
+
+    if (m_gpu->gpgpu_ctx->func_sim->gpgpu_ptx_instruction_classification) {
       m_gpu->gpgpu_ctx->func_sim->init_inst_classification_stat();
-      unsigned space_type=0;
-      switch ( pI->get_space().get_type() ) {
-      case global_space: space_type = 10; break;
-      case local_space:  space_type = 11; break; 
-      case tex_space:    space_type = 12; break; 
-      case surf_space:   space_type = 13; break; 
-      case param_space_kernel:
-      case param_space_local:
-                         space_type = 14; break; 
-      case shared_space: space_type = 15; break; 
-      case const_space:  space_type = 16; break;
-      default: 
-         space_type = 0 ;
-         break;
+      unsigned space_type = 0;
+      switch (pI->get_space().get_type()) {
+        case global_space:
+          space_type = 10;
+          break;
+        case local_space:
+          space_type = 11;
+          break;
+        case tex_space:
+          space_type = 12;
+          break;
+        case surf_space:
+          space_type = 13;
+          break;
+        case param_space_kernel:
+        case param_space_local:
+          space_type = 14;
+          break;
+        case shared_space:
+          space_type = 15;
+          break;
+        case const_space:
+          space_type = 16;
+          break;
+        default:
+          space_type = 0;
+          break;
       }
-      StatAddSample( m_gpu->gpgpu_ctx->func_sim->g_inst_classification_stat[m_gpu->gpgpu_ctx->func_sim->g_ptx_kernel_count],  op_classification);
-      if (space_type) StatAddSample( m_gpu->gpgpu_ctx->func_sim->g_inst_classification_stat[m_gpu->gpgpu_ctx->func_sim->g_ptx_kernel_count], ( int )space_type);
-      StatAddSample( m_gpu->gpgpu_ctx->func_sim->g_inst_op_classification_stat[m_gpu->gpgpu_ctx->func_sim->g_ptx_kernel_count], (int)  pI->get_opcode() );
-   }
-   if ( (m_gpu->gpgpu_ctx->func_sim->g_ptx_sim_num_insn % 100000) == 0 ) {
+      StatAddSample(m_gpu->gpgpu_ctx->func_sim->g_inst_classification_stat
+                        [m_gpu->gpgpu_ctx->func_sim->g_ptx_kernel_count],
+                    op_classification);
+      if (space_type)
+        StatAddSample(m_gpu->gpgpu_ctx->func_sim->g_inst_classification_stat
+                          [m_gpu->gpgpu_ctx->func_sim->g_ptx_kernel_count],
+                      (int)space_type);
+      StatAddSample(m_gpu->gpgpu_ctx->func_sim->g_inst_op_classification_stat
+                        [m_gpu->gpgpu_ctx->func_sim->g_ptx_kernel_count],
+                    (int)pI->get_opcode());
+    }
+    if ((m_gpu->gpgpu_ctx->func_sim->g_ptx_sim_num_insn % 100000) == 0) {
       dim3 ctaid = get_ctaid();
       dim3 tid = get_tid();
-      DPRINTF(LIVENESS, "GPGPU-Sim PTX: %u instructions simulated : ctaid=(%u,%u,%u) tid=(%u,%u,%u)\n",
-             m_gpu->gpgpu_ctx->func_sim->g_ptx_sim_num_insn, ctaid.x,ctaid.y,ctaid.z,tid.x,tid.y,tid.z );
+      DPRINTF(LIVENESS,
+              "GPGPU-Sim PTX: %u instructions simulated : ctaid=(%u,%u,%u) "
+              "tid=(%u,%u,%u)\n",
+              m_gpu->gpgpu_ctx->func_sim->g_ptx_sim_num_insn, ctaid.x, ctaid.y,
+              ctaid.z, tid.x, tid.y, tid.z);
       fflush(stdout);
-   }
-   
-   // "Return values"
-   if(!skip) {
-      if(!((inst_opcode==MMA_LD_OP||inst_opcode==MMA_ST_OP)))
-      {
-   	  inst.space = insn_space;
-          inst.set_addr(lane_id, insn_memaddr);
-          inst.data_size = insn_data_size; // simpleAtomicIntrinsics
-          assert( inst.memory_op == insn_memory_op );
-      } 
-   }
- 
-   } catch ( int x  ) {
-      printf("GPGPU-Sim PTX: ERROR (%d) executing intruction (%s:%u)\n", x, pI->source_file(), pI->source_line() );
-      printf("GPGPU-Sim PTX:       '%s'\n", pI->get_source() );
-      abort();
-   }
-      
-}
+    }
 
-void cuda_sim::set_param_gpgpu_num_shaders(int num_shaders)
-{
-   gpgpu_param_num_shaders = num_shaders;
-}
-
-const struct gpgpu_ptx_sim_info* ptx_sim_kernel_info(const function_info *kernel)
-{
-   return kernel->get_kernel_info();
-}
-
-const warp_inst_t *gpgpu_context::ptx_fetch_inst( address_type pc )
-{
-    return pc_to_instruction(pc);
-}
-
-unsigned ptx_sim_init_thread( kernel_info_t &kernel,
-                              ptx_thread_info** thread_info,
-                              int sid,
-                              unsigned tid,
-                              unsigned threads_left,
-                              unsigned num_threads, 
-                              core_t *core, 
-                              unsigned hw_cta_id, 
-                              unsigned hw_warp_id,
-                              gpgpu_t *gpu,
-                              bool isInFunctionalSimulationMode)
-{
-   std::list<ptx_thread_info *> &active_threads = kernel.active_threads();
-
-   static std::map<unsigned,memory_space*> shared_memory_lookup;
-   static std::map<unsigned,memory_space*> sstarr_memory_lookup;
-   static std::map<unsigned,ptx_cta_info*> ptx_cta_lookup;
-   static std::map<unsigned,ptx_warp_info*> ptx_warp_lookup;
-   static std::map<unsigned,std::map<unsigned,memory_space*> > local_memory_lookup;
-
-   if ( *thread_info != NULL ) {
-      ptx_thread_info *thd = *thread_info;
-      assert( thd->is_done() );
-      if ( g_debug_execution==-1 ) {
-         dim3 ctaid = thd->get_ctaid();
-         dim3 t = thd->get_tid();
-         printf("GPGPU-Sim PTX simulator:  thread exiting ctaid=(%u,%u,%u) tid=(%u,%u,%u) uid=%u\n",
-                ctaid.x,ctaid.y,ctaid.z,t.x,t.y,t.z, thd->get_uid() );
-         fflush(stdout);
+    // "Return values"
+    if (!skip) {
+      if (!((inst_opcode == MMA_LD_OP || inst_opcode == MMA_ST_OP))) {
+        inst.space = insn_space;
+        inst.set_addr(lane_id, insn_memaddr);
+        inst.data_size = insn_data_size;  // simpleAtomicIntrinsics
+        assert(inst.memory_op == insn_memory_op);
       }
-      thd->m_cta_info->register_deleted_thread(thd);
-      delete thd;
-      *thread_info = NULL;
-   }
+    }
 
-   if ( !active_threads.empty() ) {
-      assert( active_threads.size() <= threads_left );
-      ptx_thread_info *thd = active_threads.front(); 
-      active_threads.pop_front();
-      *thread_info = thd;
-      thd->init(gpu, core, sid, hw_cta_id, hw_warp_id, tid, isInFunctionalSimulationMode );
-      return 1;
-   }
+  } catch (int x) {
+    printf("GPGPU-Sim PTX: ERROR (%d) executing intruction (%s:%u)\n", x,
+           pI->source_file(), pI->source_line());
+    printf("GPGPU-Sim PTX:       '%s'\n", pI->get_source());
+    abort();
+  }
+}
 
-   if ( kernel.no_more_ctas_to_run() ) {
-      return 0; //finished!
-   }
+void cuda_sim::set_param_gpgpu_num_shaders(int num_shaders) {
+  gpgpu_param_num_shaders = num_shaders;
+}
 
-   if ( threads_left < kernel.threads_per_cta() ) {
-      return 0;
-   }
+const struct gpgpu_ptx_sim_info *ptx_sim_kernel_info(
+    const function_info *kernel) {
+  return kernel->get_kernel_info();
+}
 
-   if ( g_debug_execution==-1 ) {
-      printf("GPGPU-Sim PTX simulator:  STARTING THREAD ALLOCATION --> \n");
+const warp_inst_t *gpgpu_context::ptx_fetch_inst(address_type pc) {
+  return pc_to_instruction(pc);
+}
+
+unsigned ptx_sim_init_thread(kernel_info_t &kernel,
+                             ptx_thread_info **thread_info, int sid,
+                             unsigned tid, unsigned threads_left,
+                             unsigned num_threads, core_t *core,
+                             unsigned hw_cta_id, unsigned hw_warp_id,
+                             gpgpu_t *gpu, bool isInFunctionalSimulationMode) {
+  std::list<ptx_thread_info *> &active_threads = kernel.active_threads();
+
+  static std::map<unsigned, memory_space *> shared_memory_lookup;
+  static std::map<unsigned, memory_space *> sstarr_memory_lookup;
+  static std::map<unsigned, ptx_cta_info *> ptx_cta_lookup;
+  static std::map<unsigned, ptx_warp_info *> ptx_warp_lookup;
+  static std::map<unsigned, std::map<unsigned, memory_space *> >
+      local_memory_lookup;
+
+  if (*thread_info != NULL) {
+    ptx_thread_info *thd = *thread_info;
+    assert(thd->is_done());
+    if (g_debug_execution == -1) {
+      dim3 ctaid = thd->get_ctaid();
+      dim3 t = thd->get_tid();
+      printf(
+          "GPGPU-Sim PTX simulator:  thread exiting ctaid=(%u,%u,%u) "
+          "tid=(%u,%u,%u) uid=%u\n",
+          ctaid.x, ctaid.y, ctaid.z, t.x, t.y, t.z, thd->get_uid());
       fflush(stdout);
-   }
+    }
+    thd->m_cta_info->register_deleted_thread(thd);
+    delete thd;
+    *thread_info = NULL;
+  }
 
-   //initializing new CTA
-   ptx_cta_info *cta_info = NULL;
-   memory_space *shared_mem = NULL;
-   memory_space *sstarr_mem = NULL;
+  if (!active_threads.empty()) {
+    assert(active_threads.size() <= threads_left);
+    ptx_thread_info *thd = active_threads.front();
+    active_threads.pop_front();
+    *thread_info = thd;
+    thd->init(gpu, core, sid, hw_cta_id, hw_warp_id, tid,
+              isInFunctionalSimulationMode);
+    return 1;
+  }
 
-   unsigned cta_size = kernel.threads_per_cta();
-   unsigned max_cta_per_sm = num_threads/cta_size; // e.g., 256 / 48 = 5 
-   assert( max_cta_per_sm > 0 );
+  if (kernel.no_more_ctas_to_run()) {
+    return 0;  // finished!
+  }
 
-   //unsigned sm_idx = (tid/cta_size)*gpgpu_param_num_shaders + sid;
-   unsigned sm_idx = hw_cta_id*gpu->gpgpu_ctx->func_sim->gpgpu_param_num_shaders + sid;
+  if (threads_left < kernel.threads_per_cta()) {
+    return 0;
+  }
 
-   if ( shared_memory_lookup.find(sm_idx) == shared_memory_lookup.end() ) {
-      if ( g_debug_execution >= 1 ) {
-         printf("  <CTA alloc> : sm_idx=%u sid=%u max_cta_per_sm=%u\n", 
-                sm_idx, sid, max_cta_per_sm );
-      }
+  if (g_debug_execution == -1) {
+    printf("GPGPU-Sim PTX simulator:  STARTING THREAD ALLOCATION --> \n");
+    fflush(stdout);
+  }
+
+  // initializing new CTA
+  ptx_cta_info *cta_info = NULL;
+  memory_space *shared_mem = NULL;
+  memory_space *sstarr_mem = NULL;
+
+  unsigned cta_size = kernel.threads_per_cta();
+  unsigned max_cta_per_sm = num_threads / cta_size;  // e.g., 256 / 48 = 5
+  assert(max_cta_per_sm > 0);
+
+  // unsigned sm_idx = (tid/cta_size)*gpgpu_param_num_shaders + sid;
+  unsigned sm_idx =
+      hw_cta_id * gpu->gpgpu_ctx->func_sim->gpgpu_param_num_shaders + sid;
+
+  if (shared_memory_lookup.find(sm_idx) == shared_memory_lookup.end()) {
+    if (g_debug_execution >= 1) {
+      printf("  <CTA alloc> : sm_idx=%u sid=%u max_cta_per_sm=%u\n", sm_idx,
+             sid, max_cta_per_sm);
+    }
+    char buf[512];
+    snprintf(buf, 512, "shared_%u", sid);
+    shared_mem = new memory_space_impl<16 * 1024>(buf, 4);
+    shared_memory_lookup[sm_idx] = shared_mem;
+    snprintf(buf, 512, "sstarr_%u", sid);
+    sstarr_mem = new memory_space_impl<16 * 1024>(buf, 4);
+    sstarr_memory_lookup[sm_idx] = sstarr_mem;
+    cta_info = new ptx_cta_info(sm_idx, gpu->gpgpu_ctx);
+    ptx_cta_lookup[sm_idx] = cta_info;
+  } else {
+    if (g_debug_execution >= 1) {
+      printf("  <CTA realloc> : sm_idx=%u sid=%u max_cta_per_sm=%u\n", sm_idx,
+             sid, max_cta_per_sm);
+    }
+    shared_mem = shared_memory_lookup[sm_idx];
+    sstarr_mem = sstarr_memory_lookup[sm_idx];
+    cta_info = ptx_cta_lookup[sm_idx];
+    cta_info->check_cta_thread_status_and_reset();
+  }
+
+  std::map<unsigned, memory_space *> &local_mem_lookup =
+      local_memory_lookup[sid];
+  while (kernel.more_threads_in_cta()) {
+    dim3 ctaid3d = kernel.get_next_cta_id();
+    unsigned new_tid = kernel.get_next_thread_id();
+    dim3 tid3d = kernel.get_next_thread_id_3d();
+    kernel.increment_thread_id();
+    new_tid += tid;
+    ptx_thread_info *thd = new ptx_thread_info(kernel);
+    ptx_warp_info *warp_info = NULL;
+    if (ptx_warp_lookup.find(hw_warp_id) == ptx_warp_lookup.end()) {
+      warp_info = new ptx_warp_info();
+      ptx_warp_lookup[hw_warp_id] = warp_info;
+    } else {
+      warp_info = ptx_warp_lookup[hw_warp_id];
+    }
+    thd->m_warp_info = warp_info;
+
+    memory_space *local_mem = NULL;
+    std::map<unsigned, memory_space *>::iterator l =
+        local_mem_lookup.find(new_tid);
+    if (l != local_mem_lookup.end()) {
+      local_mem = l->second;
+    } else {
       char buf[512];
-      snprintf(buf,512,"shared_%u", sid);
-      shared_mem = new memory_space_impl<16*1024>(buf,4);
-      shared_memory_lookup[sm_idx] = shared_mem;
-      snprintf(buf,512,"sstarr_%u", sid);
-      sstarr_mem = new memory_space_impl<16*1024>(buf,4);
-      sstarr_memory_lookup[sm_idx] = sstarr_mem;
-      cta_info = new ptx_cta_info(sm_idx, gpu->gpgpu_ctx);
-      ptx_cta_lookup[sm_idx] = cta_info;
-   } else {
-      if ( g_debug_execution >= 1 ) {
-         printf("  <CTA realloc> : sm_idx=%u sid=%u max_cta_per_sm=%u\n", 
-                sm_idx, sid, max_cta_per_sm );
-      }
-      shared_mem = shared_memory_lookup[sm_idx];
-      sstarr_mem = sstarr_memory_lookup[sm_idx];
-      cta_info = ptx_cta_lookup[sm_idx];
-      cta_info->check_cta_thread_status_and_reset();
-   }
-
-   std::map<unsigned,memory_space*> &local_mem_lookup = local_memory_lookup[sid];
-   while( kernel.more_threads_in_cta() ) {
-      dim3 ctaid3d = kernel.get_next_cta_id();
-      unsigned new_tid = kernel.get_next_thread_id();
-      dim3 tid3d = kernel.get_next_thread_id_3d();
-      kernel.increment_thread_id();
-      new_tid += tid;
-      ptx_thread_info *thd = new ptx_thread_info(kernel);
-      ptx_warp_info *warp_info = NULL;
-      if ( ptx_warp_lookup.find(hw_warp_id) == ptx_warp_lookup.end() ) {
-    	  warp_info = new ptx_warp_info();
-    	  ptx_warp_lookup[hw_warp_id] = warp_info;
-      } else {
-    	  warp_info = ptx_warp_lookup[hw_warp_id];
-      }
-      thd->m_warp_info = warp_info;
-
-      memory_space *local_mem = NULL;
-      std::map<unsigned,memory_space*>::iterator l = local_mem_lookup.find(new_tid);
-      if ( l != local_mem_lookup.end() ) {
-         local_mem = l->second;
-      } else {
-         char buf[512];
-         snprintf(buf,512,"local_%u_%u", sid, new_tid);
-         local_mem = new memory_space_impl<32>(buf,32);
-         local_mem_lookup[new_tid] = local_mem;
-      }
-      thd->set_info(kernel.entry());
-      thd->set_nctaid(kernel.get_grid_dim());
-      thd->set_ntid(kernel.get_cta_dim());
-      thd->set_ctaid(ctaid3d);
-      thd->set_tid(tid3d);
-      if( kernel.entry()->get_ptx_version().extensions() ) 
-         thd->cpy_tid_to_reg(tid3d);
-      thd->set_valid();
-      thd->m_shared_mem = shared_mem;
-      thd->m_sstarr_mem = sstarr_mem;
-      function_info *finfo = thd->func_info();
-      symbol_table *st = finfo->get_symtab();
-      thd->func_info()->param_to_shared(thd->m_shared_mem,st);
-      thd->func_info()->param_to_shared(thd->m_sstarr_mem,st);
-      thd->m_cta_info = cta_info;
-      cta_info->add_thread(thd);
-      thd->m_local_mem = local_mem;
-      if ( g_debug_execution==-1 ) {
-         printf("GPGPU-Sim PTX simulator:  allocating thread ctaid=(%u,%u,%u) tid=(%u,%u,%u) @ 0x%Lx\n",
-                ctaid3d.x,ctaid3d.y,ctaid3d.z,tid3d.x,tid3d.y,tid3d.z, (unsigned long long)thd );
-         fflush(stdout);
-      }
-      active_threads.push_back(thd);
-   }
-   if ( g_debug_execution==-1 ) {
-      printf("GPGPU-Sim PTX simulator:  <-- FINISHING THREAD ALLOCATION\n");
+      snprintf(buf, 512, "local_%u_%u", sid, new_tid);
+      local_mem = new memory_space_impl<32>(buf, 32);
+      local_mem_lookup[new_tid] = local_mem;
+    }
+    thd->set_info(kernel.entry());
+    thd->set_nctaid(kernel.get_grid_dim());
+    thd->set_ntid(kernel.get_cta_dim());
+    thd->set_ctaid(ctaid3d);
+    thd->set_tid(tid3d);
+    if (kernel.entry()->get_ptx_version().extensions())
+      thd->cpy_tid_to_reg(tid3d);
+    thd->set_valid();
+    thd->m_shared_mem = shared_mem;
+    thd->m_sstarr_mem = sstarr_mem;
+    function_info *finfo = thd->func_info();
+    symbol_table *st = finfo->get_symtab();
+    thd->func_info()->param_to_shared(thd->m_shared_mem, st);
+    thd->func_info()->param_to_shared(thd->m_sstarr_mem, st);
+    thd->m_cta_info = cta_info;
+    cta_info->add_thread(thd);
+    thd->m_local_mem = local_mem;
+    if (g_debug_execution == -1) {
+      printf(
+          "GPGPU-Sim PTX simulator:  allocating thread ctaid=(%u,%u,%u) "
+          "tid=(%u,%u,%u) @ 0x%Lx\n",
+          ctaid3d.x, ctaid3d.y, ctaid3d.z, tid3d.x, tid3d.y, tid3d.z,
+          (unsigned long long)thd);
       fflush(stdout);
-   }
+    }
+    active_threads.push_back(thd);
+  }
+  if (g_debug_execution == -1) {
+    printf("GPGPU-Sim PTX simulator:  <-- FINISHING THREAD ALLOCATION\n");
+    fflush(stdout);
+  }
 
-   kernel.increment_cta_id();
+  kernel.increment_cta_id();
 
-   assert( active_threads.size() <= threads_left );
-   *thread_info = active_threads.front();
-   (*thread_info)->init(gpu, core, sid, hw_cta_id, hw_warp_id, tid,isInFunctionalSimulationMode );
-   active_threads.pop_front();
-   return 1;
+  assert(active_threads.size() <= threads_left);
+  *thread_info = active_threads.front();
+  (*thread_info)
+      ->init(gpu, core, sid, hw_cta_id, hw_warp_id, tid,
+             isInFunctionalSimulationMode);
+  active_threads.pop_front();
+  return 1;
 }
 
-size_t get_kernel_code_size( class function_info *entry )
-{
-   return entry->get_function_size();
+size_t get_kernel_code_size(class function_info *entry) {
+  return entry->get_function_size();
 }
 
+kernel_info_t *cuda_sim::gpgpu_opencl_ptx_sim_init_grid(
+    class function_info *entry, gpgpu_ptx_sim_arg_list_t args,
+    struct dim3 gridDim, struct dim3 blockDim, gpgpu_t *gpu) {
+  kernel_info_t *result =
+      new kernel_info_t(gridDim, blockDim, entry, gpu->getNameArrayMapping(),
+                        gpu->getNameInfoMapping());
+  unsigned argcount = args.size();
+  unsigned argn = 1;
+  for (gpgpu_ptx_sim_arg_list_t::iterator a = args.begin(); a != args.end();
+       a++) {
+    entry->add_param_data(argcount - argn, &(*a));
+    argn++;
+  }
+  entry->finalize(result->get_param_memory());
+  g_ptx_kernel_count++;
+  fflush(stdout);
 
-kernel_info_t *cuda_sim::gpgpu_opencl_ptx_sim_init_grid(class function_info *entry,
-                                             gpgpu_ptx_sim_arg_list_t args, 
-                                             struct dim3 gridDim,
-                                             struct dim3 blockDim,
-                                             gpgpu_t *gpu )
-{
-   kernel_info_t *result = new kernel_info_t(gridDim,blockDim,entry,gpu->getNameArrayMapping(),gpu->getNameInfoMapping());
-   unsigned argcount=args.size();
-   unsigned argn=1;
-   for( gpgpu_ptx_sim_arg_list_t::iterator a = args.begin(); a != args.end(); a++ ) {
-      entry->add_param_data(argcount-argn,&(*a));
-      argn++;
-   }
-   entry->finalize(result->get_param_memory());
-   g_ptx_kernel_count++; 
-   fflush(stdout);
-
-   return result;
+  return result;
 }
 
 #include "../../version"
 #include "detailed_version"
 
-void print_splash()
-{
-   static int splash_printed=0;
-   if ( !splash_printed ) {
-      fprintf(stdout, "\n\n        *** %s [build %s] ***\n\n\n", g_gpgpusim_version_string, g_gpgpusim_build_string );
-      splash_printed=1;
-   }
+void print_splash() {
+  static int splash_printed = 0;
+  if (!splash_printed) {
+    fprintf(stdout, "\n\n        *** %s [build %s] ***\n\n\n",
+            g_gpgpusim_version_string, g_gpgpusim_build_string);
+    splash_printed = 1;
+  }
 }
 
-void cuda_sim::gpgpu_ptx_sim_register_const_variable(void *hostVar, const char *deviceName, size_t size )
-{
-   printf("GPGPU-Sim PTX registering constant %s (%zu bytes) to name mapping\n", deviceName, size );
-   g_const_name_lookup[hostVar] = deviceName;
+void cuda_sim::gpgpu_ptx_sim_register_const_variable(void *hostVar,
+                                                     const char *deviceName,
+                                                     size_t size) {
+  printf("GPGPU-Sim PTX registering constant %s (%zu bytes) to name mapping\n",
+         deviceName, size);
+  g_const_name_lookup[hostVar] = deviceName;
 }
 
-void cuda_sim::gpgpu_ptx_sim_register_global_variable(void *hostVar, const char *deviceName, size_t size )
-{
-   printf("GPGPU-Sim PTX registering global %s hostVar to name mapping\n", deviceName );
-   g_global_name_lookup[hostVar] = deviceName;
+void cuda_sim::gpgpu_ptx_sim_register_global_variable(void *hostVar,
+                                                      const char *deviceName,
+                                                      size_t size) {
+  printf("GPGPU-Sim PTX registering global %s hostVar to name mapping\n",
+         deviceName);
+  g_global_name_lookup[hostVar] = deviceName;
 }
 
-void cuda_sim::gpgpu_ptx_sim_memcpy_symbol(const char *hostVar, const void *src, size_t count, size_t offset, int to, gpgpu_t *gpu )
-{
-   printf("GPGPU-Sim PTX: starting gpgpu_ptx_sim_memcpy_symbol with hostVar 0x%p\n", hostVar);
-   bool found_sym = false;
-   memory_space_t mem_region = undefined_space;
-   std::string sym_name;
+void cuda_sim::gpgpu_ptx_sim_memcpy_symbol(const char *hostVar, const void *src,
+                                           size_t count, size_t offset, int to,
+                                           gpgpu_t *gpu) {
+  printf(
+      "GPGPU-Sim PTX: starting gpgpu_ptx_sim_memcpy_symbol with hostVar 0x%p\n",
+      hostVar);
+  bool found_sym = false;
+  memory_space_t mem_region = undefined_space;
+  std::string sym_name;
 
-   std::map<const void*,std::string>::iterator c=gpu->gpgpu_ctx->func_sim->g_const_name_lookup.find(hostVar);
-   if ( c!=gpu->gpgpu_ctx->func_sim->g_const_name_lookup.end() ) {
-      found_sym = true;
-      sym_name = c->second;
-      mem_region = const_space;
-   }
-   std::map<const void*,std::string>::iterator g=gpu->gpgpu_ctx->func_sim->g_global_name_lookup.find(hostVar);
-   if ( g!=gpu->gpgpu_ctx->func_sim->g_global_name_lookup.end() ) {
-      if ( found_sym ) {
-         printf("Execution error: PTX symbol \"%s\" w/ hostVar=0x%Lx is declared both const and global?\n", 
-                sym_name.c_str(), (unsigned long long)hostVar );
-         abort();
-      }
-      found_sym = true;
-      sym_name = g->second;
-      mem_region = global_space;
-   }
-   if( g_globals.find(hostVar) != g_globals.end() ) {
-      found_sym = true;
-      sym_name = hostVar;
-      mem_region = global_space;
-   }
-   if( g_constants.find(hostVar) != g_constants.end() ) {
-      found_sym = true;
-      sym_name = hostVar;
-      mem_region = const_space;
-   }
-
-   if ( !found_sym ) {
-      printf("Execution error: No information for PTX symbol w/ hostVar=0x%Lx\n", (unsigned long long)hostVar );
+  std::map<const void *, std::string>::iterator c =
+      gpu->gpgpu_ctx->func_sim->g_const_name_lookup.find(hostVar);
+  if (c != gpu->gpgpu_ctx->func_sim->g_const_name_lookup.end()) {
+    found_sym = true;
+    sym_name = c->second;
+    mem_region = const_space;
+  }
+  std::map<const void *, std::string>::iterator g =
+      gpu->gpgpu_ctx->func_sim->g_global_name_lookup.find(hostVar);
+  if (g != gpu->gpgpu_ctx->func_sim->g_global_name_lookup.end()) {
+    if (found_sym) {
+      printf(
+          "Execution error: PTX symbol \"%s\" w/ hostVar=0x%Lx is declared "
+          "both const and global?\n",
+          sym_name.c_str(), (unsigned long long)hostVar);
       abort();
-   } else printf("GPGPU-Sim PTX: gpgpu_ptx_sim_memcpy_symbol: Found PTX symbol w/ hostVar=0x%Lx\n", (unsigned long long)hostVar ); 
-   const char *mem_name = NULL;
-   memory_space *mem = NULL;
+    }
+    found_sym = true;
+    sym_name = g->second;
+    mem_region = global_space;
+  }
+  if (g_globals.find(hostVar) != g_globals.end()) {
+    found_sym = true;
+    sym_name = hostVar;
+    mem_region = global_space;
+  }
+  if (g_constants.find(hostVar) != g_constants.end()) {
+    found_sym = true;
+    sym_name = hostVar;
+    mem_region = const_space;
+  }
 
-   std::map<std::string,symbol_table*>::iterator st = gpgpu_ctx->ptx_parser->g_sym_name_to_symbol_table.find(sym_name.c_str());
-   assert( st != gpgpu_ctx->ptx_parser->g_sym_name_to_symbol_table.end() );
-   symbol_table *symtab = st->second;
+  if (!found_sym) {
+    printf("Execution error: No information for PTX symbol w/ hostVar=0x%Lx\n",
+           (unsigned long long)hostVar);
+    abort();
+  } else
+    printf(
+        "GPGPU-Sim PTX: gpgpu_ptx_sim_memcpy_symbol: Found PTX symbol w/ "
+        "hostVar=0x%Lx\n",
+        (unsigned long long)hostVar);
+  const char *mem_name = NULL;
+  memory_space *mem = NULL;
 
-   symbol *sym = symtab->lookup(sym_name.c_str());
-   assert(sym);
-   unsigned dst = sym->get_address() + offset; 
-   switch (mem_region.get_type()) {
-   case const_space:
+  std::map<std::string, symbol_table *>::iterator st =
+      gpgpu_ctx->ptx_parser->g_sym_name_to_symbol_table.find(sym_name.c_str());
+  assert(st != gpgpu_ctx->ptx_parser->g_sym_name_to_symbol_table.end());
+  symbol_table *symtab = st->second;
+
+  symbol *sym = symtab->lookup(sym_name.c_str());
+  assert(sym);
+  unsigned dst = sym->get_address() + offset;
+  switch (mem_region.get_type()) {
+    case const_space:
       mem = gpu->get_global_memory();
       mem_name = "const";
       break;
-   case global_space:
+    case global_space:
       mem = gpu->get_global_memory();
       mem_name = "global";
       break;
-   default:
+    default:
       abort();
-   }
-   printf("GPGPU-Sim PTX: gpgpu_ptx_sim_memcpy_symbol: copying %s memory %zu bytes %s symbol %s+%zu @0x%x ...\n", 
-          mem_name, count, (to?" to ":"from"), sym_name.c_str(), offset, dst );
-   for ( unsigned n=0; n < count; n++ ) {
-      if( to ) mem->write(dst+n,1,((char*)src)+n,NULL,NULL); 
-      else mem->read(dst+n,1,((char*)src)+n); 
-   }
-   fflush(stdout);
+  }
+  printf(
+      "GPGPU-Sim PTX: gpgpu_ptx_sim_memcpy_symbol: copying %s memory %zu bytes "
+      "%s symbol %s+%zu @0x%x ...\n",
+      mem_name, count, (to ? " to " : "from"), sym_name.c_str(), offset, dst);
+  for (unsigned n = 0; n < count; n++) {
+    if (to)
+      mem->write(dst + n, 1, ((char *)src) + n, NULL, NULL);
+    else
+      mem->read(dst + n, 1, ((char *)src) + n);
+  }
+  fflush(stdout);
 }
 
 extern int ptx_debug;
 
-void cuda_sim::read_sim_environment_variables()
-{
-   ptx_debug = 0;
-   g_debug_execution = 0;
-   g_interactive_debugger_enabled = false;
+void cuda_sim::read_sim_environment_variables() {
+  ptx_debug = 0;
+  g_debug_execution = 0;
+  g_interactive_debugger_enabled = false;
 
-   char *mode = getenv("PTX_SIM_MODE_FUNC");
-   if ( mode )
-      sscanf(mode,"%u", &g_ptx_sim_mode);
-   printf("GPGPU-Sim PTX: simulation mode %d (can change with PTX_SIM_MODE_FUNC environment variable:\n", g_ptx_sim_mode);
-   printf("               1=functional simulation only, 0=detailed performance simulator)\n");
-   char *dbg_inter = getenv("GPGPUSIM_DEBUG");
-   if ( dbg_inter && strlen(dbg_inter) ) {
-      printf("GPGPU-Sim PTX: enabling interactive debugger\n");
-      fflush(stdout);
-      g_interactive_debugger_enabled = true;
-   }
-   char *dbg_level = getenv("PTX_SIM_DEBUG");
-   if ( dbg_level && strlen(dbg_level) ) {
-      printf("GPGPU-Sim PTX: setting debug level to %s\n", dbg_level );
-      fflush(stdout);
-      sscanf(dbg_level,"%d", &g_debug_execution);
-   }
-   char *dbg_thread = getenv("PTX_SIM_DEBUG_THREAD_UID");
-   if ( dbg_thread && strlen(dbg_thread) ) {
-      printf("GPGPU-Sim PTX: printing debug information for thread uid %s\n", dbg_thread );
-      fflush(stdout);
-      sscanf(dbg_thread,"%d", &g_debug_thread_uid);
-   }
-   char *dbg_pc = getenv("PTX_SIM_DEBUG_PC");
-   if ( dbg_pc && strlen(dbg_pc) ) {
-      printf("GPGPU-Sim PTX: printing debug information for instruction with PC = %s\n", dbg_pc );
-      fflush(stdout);
-      sscanf(dbg_pc,"%d", &g_debug_pc);
-   }
+  char *mode = getenv("PTX_SIM_MODE_FUNC");
+  if (mode) sscanf(mode, "%u", &g_ptx_sim_mode);
+  printf(
+      "GPGPU-Sim PTX: simulation mode %d (can change with PTX_SIM_MODE_FUNC "
+      "environment variable:\n",
+      g_ptx_sim_mode);
+  printf(
+      "               1=functional simulation only, 0=detailed performance "
+      "simulator)\n");
+  char *dbg_inter = getenv("GPGPUSIM_DEBUG");
+  if (dbg_inter && strlen(dbg_inter)) {
+    printf("GPGPU-Sim PTX: enabling interactive debugger\n");
+    fflush(stdout);
+    g_interactive_debugger_enabled = true;
+  }
+  char *dbg_level = getenv("PTX_SIM_DEBUG");
+  if (dbg_level && strlen(dbg_level)) {
+    printf("GPGPU-Sim PTX: setting debug level to %s\n", dbg_level);
+    fflush(stdout);
+    sscanf(dbg_level, "%d", &g_debug_execution);
+  }
+  char *dbg_thread = getenv("PTX_SIM_DEBUG_THREAD_UID");
+  if (dbg_thread && strlen(dbg_thread)) {
+    printf("GPGPU-Sim PTX: printing debug information for thread uid %s\n",
+           dbg_thread);
+    fflush(stdout);
+    sscanf(dbg_thread, "%d", &g_debug_thread_uid);
+  }
+  char *dbg_pc = getenv("PTX_SIM_DEBUG_PC");
+  if (dbg_pc && strlen(dbg_pc)) {
+    printf(
+        "GPGPU-Sim PTX: printing debug information for instruction with PC = "
+        "%s\n",
+        dbg_pc);
+    fflush(stdout);
+    sscanf(dbg_pc, "%d", &g_debug_pc);
+  }
 
 #if CUDART_VERSION > 1010
-    g_override_embedded_ptx = false;
-    char *usefile = getenv("PTX_SIM_USE_PTX_FILE");
-    if (usefile && strlen(usefile)) {
-        printf("GPGPU-Sim PTX: overriding embedded ptx with ptx file (PTX_SIM_USE_PTX_FILE is set)\n");
-        fflush(stdout);
-        g_override_embedded_ptx = true;
-    }
-    char *blocking = getenv("CUDA_LAUNCH_BLOCKING");
-    if( blocking && !strcmp(blocking,"1") ) {
-        g_cuda_launch_blocking = true;
-    }
+  g_override_embedded_ptx = false;
+  char *usefile = getenv("PTX_SIM_USE_PTX_FILE");
+  if (usefile && strlen(usefile)) {
+    printf(
+        "GPGPU-Sim PTX: overriding embedded ptx with ptx file "
+        "(PTX_SIM_USE_PTX_FILE is set)\n");
+    fflush(stdout);
+    g_override_embedded_ptx = true;
+  }
+  char *blocking = getenv("CUDA_LAUNCH_BLOCKING");
+  if (blocking && !strcmp(blocking, "1")) {
+    g_cuda_launch_blocking = true;
+  }
 #else
-   g_cuda_launch_blocking = true;
-   g_override_embedded_ptx = true;
+  g_cuda_launch_blocking = true;
+  g_override_embedded_ptx = true;
 #endif
 
-   if ( g_debug_execution >= 40 ) {
-      ptx_debug = 1;
-   }
+  if (g_debug_execution >= 40) {
+    ptx_debug = 1;
+  }
 }
 
-#define MAX(a,b) (((a)>(b))?(a):(b))
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
 
-unsigned max_cta (const struct gpgpu_ptx_sim_info *kernel_info, unsigned threads_per_cta, unsigned int warp_size, unsigned int n_thread_per_shader, unsigned int gpgpu_shmem_size, unsigned int gpgpu_shader_registers, unsigned int max_cta_per_core)
-{
-   
-    unsigned int padded_cta_size = threads_per_cta;
-    if (padded_cta_size%warp_size) 
-        padded_cta_size = ((padded_cta_size/warp_size)+1)*(warp_size);
-     unsigned int result_thread = n_thread_per_shader / padded_cta_size;
+unsigned max_cta(const struct gpgpu_ptx_sim_info *kernel_info,
+                 unsigned threads_per_cta, unsigned int warp_size,
+                 unsigned int n_thread_per_shader,
+                 unsigned int gpgpu_shmem_size,
+                 unsigned int gpgpu_shader_registers,
+                 unsigned int max_cta_per_core) {
+  unsigned int padded_cta_size = threads_per_cta;
+  if (padded_cta_size % warp_size)
+    padded_cta_size = ((padded_cta_size / warp_size) + 1) * (warp_size);
+  unsigned int result_thread = n_thread_per_shader / padded_cta_size;
 
-     unsigned int result_shmem = (unsigned)-1;
-     if (kernel_info->smem > 0)
-        result_shmem = gpgpu_shmem_size / kernel_info->smem;
-     unsigned int result_regs = (unsigned)-1;
-     if (kernel_info->regs > 0)
-        result_regs = gpgpu_shader_registers / (padded_cta_size * ((kernel_info->regs+3)&~3));
-     printf("padded cta size is %d and %d and %d",padded_cta_size, kernel_info->regs, ((kernel_info->regs+3)&~3) );
-     //Limit by CTA
-     unsigned int result_cta = max_cta_per_core;
+  unsigned int result_shmem = (unsigned)-1;
+  if (kernel_info->smem > 0)
+    result_shmem = gpgpu_shmem_size / kernel_info->smem;
+  unsigned int result_regs = (unsigned)-1;
+  if (kernel_info->regs > 0)
+    result_regs = gpgpu_shader_registers /
+                  (padded_cta_size * ((kernel_info->regs + 3) & ~3));
+  printf("padded cta size is %d and %d and %d", padded_cta_size,
+         kernel_info->regs, ((kernel_info->regs + 3) & ~3));
+  // Limit by CTA
+  unsigned int result_cta = max_cta_per_core;
 
-     unsigned result = result_thread;
-     result = gs_min2(result, result_shmem);
-     result = gs_min2(result, result_regs);
-     result = gs_min2(result, result_cta);
+  unsigned result = result_thread;
+  result = gs_min2(result, result_shmem);
+  result = gs_min2(result, result_regs);
+  result = gs_min2(result, result_cta);
 
-     printf ("GPGPU-Sim uArch: CTA/core = %u, limited by:", result);
-     if (result == result_thread) printf (" threads");
-     if (result == result_shmem) printf (" shmem");
-     if (result == result_regs) printf (" regs");
-     if (result == result_cta) printf (" cta_limit");
-     printf ("\n");
+  printf("GPGPU-Sim uArch: CTA/core = %u, limited by:", result);
+  if (result == result_thread) printf(" threads");
+  if (result == result_shmem) printf(" shmem");
+  if (result == result_regs) printf(" regs");
+  if (result == result_cta) printf(" cta_limit");
+  printf("\n");
 
-     return result;
+  return result;
 }
 /*!
-This function simulates the CUDA code functionally, it takes a kernel_info_t parameter 
-which holds the data for the CUDA kernel to be executed
+This function simulates the CUDA code functionally, it takes a kernel_info_t
+parameter which holds the data for the CUDA kernel to be executed
 !*/
-void cuda_sim::gpgpu_cuda_ptx_sim_main_func( kernel_info_t &kernel, bool openCL )
-{
-     printf("GPGPU-Sim: Performing Functional Simulation, executing kernel %s...\n",kernel.name().c_str());
+void cuda_sim::gpgpu_cuda_ptx_sim_main_func(kernel_info_t &kernel,
+                                            bool openCL) {
+  printf(
+      "GPGPU-Sim: Performing Functional Simulation, executing kernel %s...\n",
+      kernel.name().c_str());
 
-     //using a shader core object for book keeping, it is not needed but as most function built for performance simulation need it we use it here
-    //extern gpgpu_sim *g_the_gpu;
-    //before we execute, we should do PDOM analysis for functional simulation scenario.
-    function_info *kernel_func_info = kernel.entry();
-    const struct gpgpu_ptx_sim_info *kernel_info = ptx_sim_kernel_info(kernel_func_info);
-    checkpoint *g_checkpoint;
-    g_checkpoint = new checkpoint();
+  // using a shader core object for book keeping, it is not needed but as most
+  // function built for performance simulation need it we use it here
+  // extern gpgpu_sim *g_the_gpu;
+  // before we execute, we should do PDOM analysis for functional simulation
+  // scenario.
+  function_info *kernel_func_info = kernel.entry();
+  const struct gpgpu_ptx_sim_info *kernel_info =
+      ptx_sim_kernel_info(kernel_func_info);
+  checkpoint *g_checkpoint;
+  g_checkpoint = new checkpoint();
 
-    if (kernel_func_info->is_pdom_set()) {
-    	printf("GPGPU-Sim PTX: PDOM analysis already done for %s \n", kernel.name().c_str() );
+  if (kernel_func_info->is_pdom_set()) {
+    printf("GPGPU-Sim PTX: PDOM analysis already done for %s \n",
+           kernel.name().c_str());
+  } else {
+    printf("GPGPU-Sim PTX: finding reconvergence points for \'%s\'...\n",
+           kernel.name().c_str());
+    kernel_func_info->do_pdom();
+    kernel_func_info->set_pdom();
+  }
+
+  unsigned max_cta_tot = max_cta(
+      kernel_info, kernel.threads_per_cta(),
+      gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()->warp_size,
+      gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()
+          ->n_thread_per_shader,
+      gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()
+          ->gpgpu_shmem_size,
+      gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()
+          ->gpgpu_shader_registers,
+      gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()
+          ->max_cta_per_core);
+  printf("Max CTA : %d\n", max_cta_tot);
+
+  int cp_op = gpgpu_ctx->the_gpgpusim->g_the_gpu->checkpoint_option;
+  int cp_kernel = gpgpu_ctx->the_gpgpusim->g_the_gpu->checkpoint_kernel;
+  cp_count = gpgpu_ctx->the_gpgpusim->g_the_gpu->checkpoint_insn_Y;
+  cp_cta_resume = gpgpu_ctx->the_gpgpusim->g_the_gpu->checkpoint_CTA_t;
+  int cta_launched = 0;
+
+  // we excute the kernel one CTA (Block) at the time, as synchronization
+  // functions work block wise
+  while (!kernel.no_more_ctas_to_run()) {
+    unsigned temp = kernel.get_next_cta_id_single();
+
+    if (cp_op == 0 ||
+        (cp_op == 1 && cta_launched < cp_cta_resume &&
+         kernel.get_uid() == cp_kernel) ||
+        kernel.get_uid() < cp_kernel)  // just fro testing
+    {
+      functionalCoreSim cta(
+          &kernel, gpgpu_ctx->the_gpgpusim->g_the_gpu,
+          gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()->warp_size);
+      cta.execute(cp_count, temp);
+
+#if (CUDART_VERSION >= 5000)
+      gpgpu_ctx->device_runtime->launch_all_device_kernels();
+#endif
     } else {
-	 printf("GPGPU-Sim PTX: finding reconvergence points for \'%s\'...\n", kernel.name().c_str() );
-	 kernel_func_info->do_pdom();
-	 kernel_func_info->set_pdom();
+      kernel.increment_cta_id();
     }
-
-    unsigned max_cta_tot = max_cta(kernel_info,kernel.threads_per_cta(), gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()->warp_size, gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()->n_thread_per_shader, gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()->gpgpu_shmem_size, gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()->gpgpu_shader_registers, gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()->max_cta_per_core);
-    printf("Max CTA : %d\n",max_cta_tot);
-
-    int cp_op= gpgpu_ctx->the_gpgpusim->g_the_gpu->checkpoint_option;
-    int cp_kernel= gpgpu_ctx->the_gpgpusim->g_the_gpu->checkpoint_kernel;
-    cp_count= gpgpu_ctx->the_gpgpusim->g_the_gpu->checkpoint_insn_Y;
-    cp_cta_resume= gpgpu_ctx->the_gpgpusim->g_the_gpu->checkpoint_CTA_t;
-    int cta_launched =0;
-
-    //we excute the kernel one CTA (Block) at the time, as synchronization functions work block wise
-    while(!kernel.no_more_ctas_to_run()){
-        unsigned temp=kernel.get_next_cta_id_single();
-        
-
-        if(cp_op==0 || (cp_op==1 && cta_launched<cp_cta_resume && kernel.get_uid()==cp_kernel) || kernel.get_uid()< cp_kernel) // just fro testing
-        {
-           functionalCoreSim cta(
-               &kernel,
-               gpgpu_ctx->the_gpgpusim->g_the_gpu,
-               gpgpu_ctx->the_gpgpusim->g_the_gpu->getShaderCoreConfig()->warp_size
-           );
-           cta.execute(cp_count,temp);
-
-            #if (CUDART_VERSION >= 5000)
-               gpgpu_ctx->device_runtime->launch_all_device_kernels();
-            #endif
-         }
-         else
-         {
-            kernel.increment_cta_id();
-         }
     cta_launched++;
+  }
+
+  if (cp_op == 1) {
+    char f1name[2048];
+    snprintf(f1name, 2048, "checkpoint_files/global_mem_%d.txt",
+             kernel.get_uid());
+    g_checkpoint->store_global_mem(
+        gpgpu_ctx->the_gpgpusim->g_the_gpu->get_global_memory(), f1name,
+        (char *)"%08x");
+  }
+
+  // registering this kernel as done
+
+  // openCL kernel simulation calls don't register the kernel so we don't
+  // register its exit
+  if (!openCL) {
+    // extern stream_manager *g_stream_manager;
+    gpgpu_ctx->the_gpgpusim->g_stream_manager->register_finished_kernel(
+        kernel.get_uid());
+  }
+
+  //******PRINTING*******
+  printf("GPGPU-Sim: Done functional simulation (%u instructions simulated).\n",
+         g_ptx_sim_num_insn);
+  if (gpgpu_ptx_instruction_classification) {
+    StatDisp(g_inst_classification_stat[g_ptx_kernel_count]);
+    StatDisp(g_inst_op_classification_stat[g_ptx_kernel_count]);
+  }
+
+  // time_t variables used to calculate the total simulation time
+  // the start time of simulation is hold by the global variable
+  // g_simulation_starttime g_simulation_starttime is initilized by
+  // gpgpu_ptx_sim_init_perf() in gpgpusim_entrypoint.cc upon starting gpgpu-sim
+  time_t end_time, elapsed_time, days, hrs, minutes, sec;
+  end_time = time((time_t *)NULL);
+  elapsed_time =
+      MAX(end_time - gpgpu_ctx->the_gpgpusim->g_simulation_starttime, 1);
+
+  // calculating and printing simulation time in terms of days, hours, minutes
+  // and seconds
+  days = elapsed_time / (3600 * 24);
+  hrs = elapsed_time / 3600 - 24 * days;
+  minutes = elapsed_time / 60 - 60 * (hrs + 24 * days);
+  sec = elapsed_time - 60 * (minutes + 60 * (hrs + 24 * days));
+
+  fflush(stderr);
+  printf(
+      "\n\ngpgpu_simulation_time = %u days, %u hrs, %u min, %u sec (%u sec)\n",
+      (unsigned)days, (unsigned)hrs, (unsigned)minutes, (unsigned)sec,
+      (unsigned)elapsed_time);
+  printf("gpgpu_simulation_rate = %u (inst/sec)\n",
+         (unsigned)(g_ptx_sim_num_insn / elapsed_time));
+  fflush(stdout);
+}
+
+void functionalCoreSim::initializeCTA(unsigned ctaid_cp) {
+  int ctaLiveThreads = 0;
+  symbol_table *symtab = m_kernel->entry()->get_symtab();
+
+  for (int i = 0; i < m_warp_count; i++) {
+    m_warpAtBarrier[i] = false;
+    m_liveThreadCount[i] = 0;
+  }
+  for (int i = 0; i < m_warp_count * m_warp_size; i++) m_thread[i] = NULL;
+
+  // get threads for a cta
+  for (unsigned i = 0; i < m_kernel->threads_per_cta(); i++) {
+    ptx_sim_init_thread(*m_kernel, &m_thread[i], 0, i,
+                        m_kernel->threads_per_cta() - i,
+                        m_kernel->threads_per_cta(), this, 0, i / m_warp_size,
+                        (gpgpu_t *)m_gpu, true);
+    assert(m_thread[i] != NULL && !m_thread[i]->is_done());
+    char fname[2048];
+    snprintf(fname, 2048, "checkpoint_files/thread_%d_0_reg.txt", i);
+    if (m_gpu->gpgpu_ctx->func_sim->cp_cta_resume == 1)
+      m_thread[i]->resume_reg_thread(fname, symtab);
+    ctaLiveThreads++;
+  }
+
+  for (int k = 0; k < m_warp_count; k++) createWarp(k);
+}
+
+void functionalCoreSim::createWarp(unsigned warpId) {
+  simt_mask_t initialMask;
+  unsigned liveThreadsCount = 0;
+  initialMask.set();
+  for (int i = warpId * m_warp_size; i < warpId * m_warp_size + m_warp_size;
+       i++) {
+    if (m_thread[i] == NULL)
+      initialMask.reset(i - warpId * m_warp_size);
+    else
+      liveThreadsCount++;
+  }
+
+  assert(m_thread[warpId * m_warp_size] != NULL);
+  m_simt_stack[warpId]->launch(m_thread[warpId * m_warp_size]->get_pc(),
+                               initialMask);
+  char fname[2048];
+  snprintf(fname, 2048, "checkpoint_files/warp_%d_0_simt.txt", warpId);
+
+  if (m_gpu->gpgpu_ctx->func_sim->cp_cta_resume == 1) {
+    unsigned pc, rpc;
+    m_simt_stack[warpId]->resume(fname);
+    m_simt_stack[warpId]->get_pdom_stack_top_info(&pc, &rpc);
+    for (int i = warpId * m_warp_size; i < warpId * m_warp_size + m_warp_size;
+         i++) {
+      m_thread[i]->set_npc(pc);
+      m_thread[i]->update_pc();
+    }
+  }
+  m_liveThreadCount[warpId] = liveThreadsCount;
+}
+
+void functionalCoreSim::execute(int inst_count, unsigned ctaid_cp) {
+  m_gpu->gpgpu_ctx->func_sim->cp_count = m_gpu->checkpoint_insn_Y;
+  m_gpu->gpgpu_ctx->func_sim->cp_cta_resume = m_gpu->checkpoint_CTA_t;
+  initializeCTA(ctaid_cp);
+
+  int count = 0;
+  while (true) {
+    bool someOneLive = false;
+    bool allAtBarrier = true;
+    for (unsigned i = 0; i < m_warp_count; i++) {
+      executeWarp(i, allAtBarrier, someOneLive);
+      count++;
     }
 
-      
-      
-     if(cp_op==1)
-	{
+    if (inst_count > 0 && count > inst_count &&
+        (m_kernel->get_uid() == m_gpu->checkpoint_kernel) &&
+        (ctaid_cp >= m_gpu->checkpoint_CTA) &&
+        (ctaid_cp < m_gpu->checkpoint_CTA_t) && m_gpu->checkpoint_option == 1) {
+      someOneLive = false;
+      break;
+    }
+    if (!someOneLive) break;
+    if (allAtBarrier) {
+      for (unsigned i = 0; i < m_warp_count; i++) m_warpAtBarrier[i] = false;
+    }
+  }
+
+  checkpoint *g_checkpoint;
+  g_checkpoint = new checkpoint();
+
+  ptx_reg_t regval;
+  regval.u64 = 123;
+
+  unsigned ctaid = m_kernel->get_next_cta_id_single();
+  if (m_gpu->checkpoint_option == 1 &&
+      (m_kernel->get_uid() == m_gpu->checkpoint_kernel) &&
+      (ctaid_cp >= m_gpu->checkpoint_CTA) &&
+      (ctaid_cp < m_gpu->checkpoint_CTA_t)) {
+    char fname[2048];
+    snprintf(fname, 2048, "checkpoint_files/shared_mem_%d.txt", ctaid - 1);
+    g_checkpoint->store_global_mem(m_thread[0]->m_shared_mem, fname,
+                                   (char *)"%08x");
+    for (int i = 0; i < 32 * m_warp_count; i++) {
+      char fname[2048];
+      snprintf(fname, 2048, "checkpoint_files/thread_%d_%d_reg.txt", i,
+               ctaid - 1);
+      m_thread[i]->print_reg_thread(fname);
       char f1name[2048];
-      snprintf(f1name,2048,"checkpoint_files/global_mem_%d.txt", kernel.get_uid() );
-      g_checkpoint->store_global_mem(gpgpu_ctx->the_gpgpusim->g_the_gpu->get_global_memory(), f1name , (char *)"%08x");
-	}
-
-
-      
-    
-   //registering this kernel as done      
-   
-   //openCL kernel simulation calls don't register the kernel so we don't register its exit
-   if(!openCL) {
-      //extern stream_manager *g_stream_manager;
-      gpgpu_ctx->the_gpgpusim->g_stream_manager->register_finished_kernel(kernel.get_uid());
-   }
-
-   //******PRINTING*******
-   printf( "GPGPU-Sim: Done functional simulation (%u instructions simulated).\n", g_ptx_sim_num_insn );
-   if ( gpgpu_ptx_instruction_classification ) {
-      StatDisp( g_inst_classification_stat[g_ptx_kernel_count]);
-      StatDisp ( g_inst_op_classification_stat[g_ptx_kernel_count]);
-   }
-
-   //time_t variables used to calculate the total simulation time
-   //the start time of simulation is hold by the global variable g_simulation_starttime
-   //g_simulation_starttime is initilized by gpgpu_ptx_sim_init_perf() in gpgpusim_entrypoint.cc upon starting gpgpu-sim
-   time_t end_time, elapsed_time, days, hrs, minutes, sec;
-   end_time = time((time_t *)NULL);
-   elapsed_time = MAX(end_time - gpgpu_ctx->the_gpgpusim->g_simulation_starttime, 1);
-	
-
-   //calculating and printing simulation time in terms of days, hours, minutes and seconds
-   days    = elapsed_time/(3600*24);
-   hrs     = elapsed_time/3600 - 24*days;
-   minutes = elapsed_time/60 - 60*(hrs + 24*days);
-   sec = elapsed_time - 60*(minutes + 60*(hrs + 24*days));
-
-   fflush(stderr);
-   printf("\n\ngpgpu_simulation_time = %u days, %u hrs, %u min, %u sec (%u sec)\n",
-          (unsigned)days, (unsigned)hrs, (unsigned)minutes, (unsigned)sec, (unsigned)elapsed_time );
-   printf("gpgpu_simulation_rate = %u (inst/sec)\n", (unsigned)(g_ptx_sim_num_insn / elapsed_time) );
-   fflush(stdout); 
-}
-
-void functionalCoreSim::initializeCTA(unsigned ctaid_cp)
-{
-    int ctaLiveThreads=0;
-    symbol_table * symtab= m_kernel->entry()->get_symtab();
-    
-    for(int i=0; i< m_warp_count; i++){
-        m_warpAtBarrier[i]=false;
-        m_liveThreadCount[i]=0;
-    }
-    for(int i=0; i< m_warp_count*m_warp_size;i++)
-        m_thread[i]=NULL;
-    
-    //get threads for a cta
-    for(unsigned i=0; i<m_kernel->threads_per_cta();i++) {
-        ptx_sim_init_thread(*m_kernel,&m_thread[i],0,i,m_kernel->threads_per_cta()-i,m_kernel->threads_per_cta(),this,0,i/m_warp_size,(gpgpu_t*)m_gpu, true);
-        assert(m_thread[i]!=NULL && !m_thread[i]->is_done());
-        char fname[2048];
-        snprintf(fname,2048,"checkpoint_files/thread_%d_0_reg.txt",i );
-        if(m_gpu->gpgpu_ctx->func_sim->cp_cta_resume==1)
-            m_thread[i]->resume_reg_thread(fname,symtab);
-        ctaLiveThreads++;
+      snprintf(f1name, 2048, "checkpoint_files/local_mem_thread_%d_%d_reg.txt",
+               i, ctaid - 1);
+      g_checkpoint->store_global_mem(m_thread[i]->m_local_mem, f1name,
+                                     (char *)"%08x");
+      m_thread[i]->set_done();
+      m_thread[i]->exitCore();
+      m_thread[i]->registerExit();
     }
 
-    for(int k=0;k<m_warp_count;k++)
-        createWarp(k);
-}
-
-void  functionalCoreSim::createWarp(unsigned warpId)
-{
-   simt_mask_t initialMask;
-   unsigned liveThreadsCount=0;
-   initialMask.set();
-    for(int i=warpId*m_warp_size; i<warpId*m_warp_size+m_warp_size;i++){
-        if(m_thread[i]==NULL) initialMask.reset(i-warpId*m_warp_size);
-        else liveThreadsCount++;
-    }   
-   
-   assert(m_thread[warpId*m_warp_size]!=NULL);
-   m_simt_stack[warpId]->launch(m_thread[warpId*m_warp_size]->get_pc(),initialMask);
-   char fname[2048];
-   snprintf(fname,2048,"checkpoint_files/warp_%d_0_simt.txt",warpId );
-
-   if(m_gpu->gpgpu_ctx->func_sim->cp_cta_resume==1)
-   {
-      unsigned pc,rpc;
-      m_simt_stack[warpId]->resume(fname);
-      m_simt_stack[warpId]->get_pdom_stack_top_info(&pc,&rpc);
-      for(int i=warpId*m_warp_size; i<warpId*m_warp_size+m_warp_size;i++){
-        m_thread[i]->set_npc(pc);
-        m_thread[i]->update_pc();
-    }   
-
-   }
-   m_liveThreadCount[warpId]= liveThreadsCount;
-}
-
-void functionalCoreSim::execute(int inst_count, unsigned ctaid_cp)
- {
-     m_gpu->gpgpu_ctx->func_sim->cp_count= m_gpu->checkpoint_insn_Y;
-     m_gpu->gpgpu_ctx->func_sim->cp_cta_resume= m_gpu->checkpoint_CTA_t;
-    initializeCTA(ctaid_cp);
-    
-    int count=0;
-    while(true){
-        bool someOneLive= false;
-        bool allAtBarrier = true;
-        for(unsigned i=0;i<m_warp_count;i++){
-            executeWarp(i,allAtBarrier,someOneLive);
-            count++;
-        }
-        
-        if(inst_count>0 && count>inst_count && (m_kernel->get_uid()==m_gpu->checkpoint_kernel) && (ctaid_cp>=m_gpu->checkpoint_CTA) && (ctaid_cp<m_gpu->checkpoint_CTA_t) && m_gpu->checkpoint_option==1) 
-         {
-            someOneLive=false;
-            break;
-         }
-        if(!someOneLive) break;
-        if(allAtBarrier){
-             for(unsigned i=0;i<m_warp_count;i++)
-                 m_warpAtBarrier[i]=false;
-        }
+    for (int i = 0; i < m_warp_count; i++) {
+      char fname[2048];
+      snprintf(fname, 2048, "checkpoint_files/warp_%d_%d_simt.txt", i,
+               ctaid - 1);
+      FILE *fp = fopen(fname, "w");
+      assert(fp != NULL);
+      m_simt_stack[i]->print_checkpoint(fp);
+      fclose(fp);
     }
-
-    checkpoint *g_checkpoint;
-    g_checkpoint = new checkpoint();
-    
-    ptx_reg_t regval;
-    regval.u64= 123;
-
-    unsigned ctaid =m_kernel->get_next_cta_id_single();
-    if(m_gpu->checkpoint_option==1 && (m_kernel->get_uid()==m_gpu->checkpoint_kernel) && (ctaid_cp>=m_gpu->checkpoint_CTA) && (ctaid_cp<m_gpu->checkpoint_CTA_t))
-   {
-       char fname[2048];
-       snprintf(fname,2048,"checkpoint_files/shared_mem_%d.txt",ctaid-1 );
-       g_checkpoint->store_global_mem(m_thread[0]->m_shared_mem, fname , (char *)"%08x");
-      for(int i=0; i<32*m_warp_count;i++)
-      {
-         char fname[2048];
-         snprintf(fname,2048,"checkpoint_files/thread_%d_%d_reg.txt",i,ctaid-1 );
-          m_thread[i]->print_reg_thread(fname);
-          char f1name[2048];
-         snprintf(f1name,2048,"checkpoint_files/local_mem_thread_%d_%d_reg.txt",i,ctaid-1 );
-         g_checkpoint->store_global_mem(m_thread[i]->m_local_mem, f1name , (char *)"%08x");
-         m_thread[i]->set_done();
-         m_thread[i]->exitCore();
-         m_thread[i]->registerExit();
-      }
-   
-      for(int i=0;i<m_warp_count;i++)
-      {
-         
-         char fname[2048];
-         snprintf(fname,2048,"checkpoint_files/warp_%d_%d_simt.txt",i,ctaid-1 );
-         FILE * fp = fopen(fname,"w");
-         assert(fp!=NULL);
-         m_simt_stack[i]->print_checkpoint(fp);
-         fclose(fp);
-      }
-   }
-
+  }
 }
 
-void functionalCoreSim::executeWarp(unsigned i, bool &allAtBarrier, bool & someOneLive)
-{
-    if(!m_warpAtBarrier[i] && m_liveThreadCount[i]!=0){
-        warp_inst_t inst =getExecuteWarp(i);
-        execute_warp_inst_t(inst,i);
-        if(inst.isatomic()) inst.do_atomic(true);
-        if(inst.op==BARRIER_OP || inst.op==MEMORY_BARRIER_OP ) m_warpAtBarrier[i]=true;
-        updateSIMTStack( i, &inst );
-    }
-    if(m_liveThreadCount[i]>0) someOneLive=true;
-    if(!m_warpAtBarrier[i]&& m_liveThreadCount[i]>0) allAtBarrier = false;
+void functionalCoreSim::executeWarp(unsigned i, bool &allAtBarrier,
+                                    bool &someOneLive) {
+  if (!m_warpAtBarrier[i] && m_liveThreadCount[i] != 0) {
+    warp_inst_t inst = getExecuteWarp(i);
+    execute_warp_inst_t(inst, i);
+    if (inst.isatomic()) inst.do_atomic(true);
+    if (inst.op == BARRIER_OP || inst.op == MEMORY_BARRIER_OP)
+      m_warpAtBarrier[i] = true;
+    updateSIMTStack(i, &inst);
+  }
+  if (m_liveThreadCount[i] > 0) someOneLive = true;
+  if (!m_warpAtBarrier[i] && m_liveThreadCount[i] > 0) allAtBarrier = false;
 }
 
-unsigned gpgpu_context::translate_pc_to_ptxlineno(unsigned pc)
-{
-   // this function assumes that the kernel fits inside a single PTX file
-   // function_info *pFunc = g_func_info; // assume that the current kernel is the one in query
-   const ptx_instruction *pInsn = pc_to_instruction(pc);
-   unsigned ptx_line_number = pInsn->source_line();
+unsigned gpgpu_context::translate_pc_to_ptxlineno(unsigned pc) {
+  // this function assumes that the kernel fits inside a single PTX file
+  // function_info *pFunc = g_func_info; // assume that the current kernel is
+  // the one in query
+  const ptx_instruction *pInsn = pc_to_instruction(pc);
+  unsigned ptx_line_number = pInsn->source_line();
 
-   return ptx_line_number;
+  return ptx_line_number;
 }
 
 // ptxinfo parser
 
-extern std::map<unsigned,const char*> get_duplicate();
+extern std::map<unsigned, const char *> get_duplicate();
 
 static char *g_ptxinfo_kname = NULL;
 static struct gpgpu_ptx_sim_info g_ptxinfo;
-static std::map<unsigned,const char*> g_duplicate;
+static std::map<unsigned, const char *> g_duplicate;
 static const char *g_last_dup_type;
 
-const char *get_ptxinfo_kname() 
-{ 
-    return g_ptxinfo_kname; 
+const char *get_ptxinfo_kname() { return g_ptxinfo_kname; }
+
+void print_ptxinfo() {
+  if (!get_ptxinfo_kname()) {
+    printf("GPGPU-Sim PTX: Binary info : gmem=%u, cmem=%u\n", g_ptxinfo.gmem,
+           g_ptxinfo.cmem);
+  }
+  if (get_ptxinfo_kname()) {
+    printf(
+        "GPGPU-Sim PTX: Kernel \'%s\' : regs=%u, lmem=%u, smem=%u, cmem=%u\n",
+        get_ptxinfo_kname(), g_ptxinfo.regs, g_ptxinfo.lmem, g_ptxinfo.smem,
+        g_ptxinfo.cmem);
+  }
 }
 
-void print_ptxinfo()
-{
-    if(! get_ptxinfo_kname()){
-    	printf ("GPGPU-Sim PTX: Binary info : gmem=%u, cmem=%u\n",
-    			g_ptxinfo.gmem,
-    			g_ptxinfo.cmem);
-    }
-    if(get_ptxinfo_kname()){
-    	printf ("GPGPU-Sim PTX: Kernel \'%s\' : regs=%u, lmem=%u, smem=%u, cmem=%u\n",
-    			get_ptxinfo_kname(),
-    			g_ptxinfo.regs,
-    			g_ptxinfo.lmem,
-    			g_ptxinfo.smem,
-    			g_ptxinfo.cmem );
-    }
+struct gpgpu_ptx_sim_info get_ptxinfo() {
+  return g_ptxinfo;
 }
 
+std::map<unsigned, const char *> get_duplicate() { return g_duplicate; }
 
-struct gpgpu_ptx_sim_info get_ptxinfo()
-{
-    return g_ptxinfo;
+void ptxinfo_linenum(unsigned linenum) {
+  g_duplicate[linenum] = g_last_dup_type;
 }
 
-std::map<unsigned,const char*> get_duplicate()
-{
-	return g_duplicate;
+void ptxinfo_dup_type(const char *dup_type) { g_last_dup_type = dup_type; }
+
+void ptxinfo_function(const char *fname) {
+  clear_ptxinfo();
+  g_ptxinfo_kname = strdup(fname);
 }
 
-void ptxinfo_linenum( unsigned linenum )
-{
-	g_duplicate[linenum] = g_last_dup_type;
+void ptxinfo_regs(unsigned nregs) { g_ptxinfo.regs = nregs; }
+
+void ptxinfo_lmem(unsigned declared, unsigned system) {
+  g_ptxinfo.lmem = declared + system;
 }
 
-void ptxinfo_dup_type( const char *dup_type )
-{
-	g_last_dup_type = dup_type;
+void ptxinfo_gmem(unsigned declared, unsigned system) {
+  g_ptxinfo.gmem = declared + system;
 }
 
-void ptxinfo_function(const char *fname )
-{
+void ptxinfo_smem(unsigned declared, unsigned system) {
+  g_ptxinfo.smem = declared + system;
+}
+
+void ptxinfo_cmem(unsigned nbytes, unsigned bank) { g_ptxinfo.cmem += nbytes; }
+
+void clear_ptxinfo() {
+  free(g_ptxinfo_kname);
+  g_ptxinfo_kname = NULL;
+  g_ptxinfo.regs = 0;
+  g_ptxinfo.lmem = 0;
+  g_ptxinfo.smem = 0;
+  g_ptxinfo.cmem = 0;
+  g_ptxinfo.gmem = 0;
+  g_ptxinfo.ptx_version = 0;
+  g_ptxinfo.sm_target = 0;
+}
+
+void ptxinfo_opencl_addinfo(std::map<std::string, function_info *> &kernels) {
+  if (!g_ptxinfo_kname) {
+    printf("GPGPU-Sim PTX: Binary info : gmem=%u, cmem=%u\n", g_ptxinfo.gmem,
+           g_ptxinfo.cmem);
     clear_ptxinfo();
-    g_ptxinfo_kname = strdup(fname);
+    return;
+  }
+
+  if (!strcmp("__cuda_dummy_entry__", g_ptxinfo_kname)) {
+    // this string produced by ptxas for empty ptx files (e.g., bandwidth test)
+    clear_ptxinfo();
+    return;
+  }
+  std::map<std::string, function_info *>::iterator k =
+      kernels.find(g_ptxinfo_kname);
+  if (k == kernels.end()) {
+    printf("GPGPU-Sim PTX: ERROR ** implementation for '%s' not found.\n",
+           g_ptxinfo_kname);
+    abort();
+  } else {
+    printf(
+        "GPGPU-Sim PTX: Kernel \'%s\' : regs=%u, lmem=%u, smem=%u, cmem=%u\n",
+        g_ptxinfo_kname, g_ptxinfo.regs, g_ptxinfo.lmem, g_ptxinfo.smem,
+        g_ptxinfo.cmem);
+    function_info *finfo = k->second;
+    assert(finfo != NULL);
+    finfo->set_kernel_info(g_ptxinfo);
+  }
+  clear_ptxinfo();
 }
 
-void ptxinfo_regs( unsigned nregs )
-{
-    g_ptxinfo.regs=nregs;
-}
+struct rec_pts cuda_sim::find_reconvergence_points(function_info *finfo) {
+  rec_pts tmp;
+  std::map<function_info *, rec_pts>::iterator r = g_rpts.find(finfo);
 
-void ptxinfo_lmem( unsigned declared, unsigned system )
-{
-    g_ptxinfo.lmem=declared+system;
-}
+  if (r == g_rpts.end()) {
+    int num_recon = finfo->get_num_reconvergence_pairs();
 
-void ptxinfo_gmem( unsigned declared, unsigned system )
-{
-    g_ptxinfo.gmem=declared+system;
-}
-
-void ptxinfo_smem( unsigned declared, unsigned system )
-{
-    g_ptxinfo.smem=declared+system;
-}
-
-void ptxinfo_cmem( unsigned nbytes, unsigned bank )
-{
-    g_ptxinfo.cmem+=nbytes;
-}
-
-void clear_ptxinfo()
-{
-    free(g_ptxinfo_kname);
-    g_ptxinfo_kname=NULL;
-    g_ptxinfo.regs=0;
-    g_ptxinfo.lmem=0;
-    g_ptxinfo.smem=0;
-    g_ptxinfo.cmem=0;
-    g_ptxinfo.gmem=0;
-    g_ptxinfo.ptx_version=0;
-    g_ptxinfo.sm_target=0;
-}
-
-
-void ptxinfo_opencl_addinfo( std::map<std::string,function_info*> &kernels )
-{
-
-   if(! g_ptxinfo_kname) {
-	  printf ("GPGPU-Sim PTX: Binary info : gmem=%u, cmem=%u\n",
-			  g_ptxinfo.gmem,
-			  g_ptxinfo.cmem);
-	  clear_ptxinfo();
-	  return;
-   }
-
-   if( !strcmp("__cuda_dummy_entry__",g_ptxinfo_kname) ) {
-      // this string produced by ptxas for empty ptx files (e.g., bandwidth test)
-      clear_ptxinfo();
-      return;
-   }
-   std::map<std::string,function_info*>::iterator k=kernels.find(g_ptxinfo_kname);
-   if( k==kernels.end() ) {
-      printf ("GPGPU-Sim PTX: ERROR ** implementation for '%s' not found.\n", g_ptxinfo_kname );
-      abort();
-   } else {
-      printf ("GPGPU-Sim PTX: Kernel \'%s\' : regs=%u, lmem=%u, smem=%u, cmem=%u\n", 
-              g_ptxinfo_kname,
-              g_ptxinfo.regs,
-              g_ptxinfo.lmem,
-              g_ptxinfo.smem,
-              g_ptxinfo.cmem );
-      function_info *finfo = k->second;
-      assert(finfo!=NULL);
-      finfo->set_kernel_info( g_ptxinfo );
-   }
-   clear_ptxinfo();
-}
-
-struct rec_pts cuda_sim::find_reconvergence_points( function_info *finfo )
-{
-   rec_pts tmp;
-   std::map<function_info*,rec_pts>::iterator r=g_rpts.find(finfo);
- 
-   if( r==g_rpts.end() ) {
-      int num_recon = finfo->get_num_reconvergence_pairs();
-      
-      gpgpu_recon_t *kernel_recon_points = (struct gpgpu_recon_t*) calloc(num_recon, sizeof(struct gpgpu_recon_t));
-      finfo->get_reconvergence_pairs(kernel_recon_points);
-      printf("GPGPU-Sim PTX: reconvergence points for %s...\n", finfo->get_name().c_str() );
-      for (int i=0;i<num_recon;i++) {
-         printf("GPGPU-Sim PTX: %2u (potential) branch divergence @ ", i+1 );
-         kernel_recon_points[i].source_inst->print_insn();
-         printf("\n");
-         printf("GPGPU-Sim PTX:    immediate post dominator      @ " ); 
-         if( kernel_recon_points[i].target_inst )
-            kernel_recon_points[i].target_inst->print_insn();
-         printf("\n");
-      }
-      printf("GPGPU-Sim PTX: ... end of reconvergence points for %s\n", finfo->get_name().c_str() );
-
-      tmp.s_kernel_recon_points = kernel_recon_points;
-      tmp.s_num_recon = num_recon;
-      g_rpts[finfo] = tmp;
-   } else {
-      tmp = r->second;
-   }
-   return tmp;
-}
-
-address_type get_return_pc( void *thd )
-{
-    // function call return
-    ptx_thread_info *the_thread = (ptx_thread_info*)thd;
-    assert( the_thread != NULL );
-    return the_thread->get_return_PC();
-}
-
-address_type cuda_sim::get_converge_point( address_type pc )
-{
-   // the branch could encode the reconvergence point and/or a bit that indicates the 
-   // reconvergence point is the return PC on the call stack in the case the branch has 
-   // no immediate postdominator in the function (i.e., due to multiple return points). 
-
-   std::map<unsigned,function_info*>::iterator f=g_pc_to_finfo.find(pc);
-   assert( f != g_pc_to_finfo.end() );
-   function_info *finfo = f->second;
-   rec_pts tmp = find_reconvergence_points(finfo);
-
-   int i=0;
-   for (; i < tmp.s_num_recon; ++i) {
-      if (tmp.s_kernel_recon_points[i].source_pc == pc) {
-          if( tmp.s_kernel_recon_points[i].target_pc == (unsigned) -2 ) {
-              return RECONVERGE_RETURN_PC;
-          } else {
-              return tmp.s_kernel_recon_points[i].target_pc;
-          }
-      }
-   }
-   return NO_BRANCH_DIVERGENCE;
-}
-
-void functionalCoreSim::warp_exit( unsigned warp_id )
-{
-    for(int i=0;i<m_warp_count*m_warp_size;i++){
-        if(m_thread[i]!=NULL){
-             m_thread[i]->m_cta_info->register_deleted_thread(m_thread[i]);
-             delete m_thread[i];
-        }
+    gpgpu_recon_t *kernel_recon_points =
+        (struct gpgpu_recon_t *)calloc(num_recon, sizeof(struct gpgpu_recon_t));
+    finfo->get_reconvergence_pairs(kernel_recon_points);
+    printf("GPGPU-Sim PTX: reconvergence points for %s...\n",
+           finfo->get_name().c_str());
+    for (int i = 0; i < num_recon; i++) {
+      printf("GPGPU-Sim PTX: %2u (potential) branch divergence @ ", i + 1);
+      kernel_recon_points[i].source_inst->print_insn();
+      printf("\n");
+      printf("GPGPU-Sim PTX:    immediate post dominator      @ ");
+      if (kernel_recon_points[i].target_inst)
+        kernel_recon_points[i].target_inst->print_insn();
+      printf("\n");
     }
+    printf("GPGPU-Sim PTX: ... end of reconvergence points for %s\n",
+           finfo->get_name().c_str());
+
+    tmp.s_kernel_recon_points = kernel_recon_points;
+    tmp.s_num_recon = num_recon;
+    g_rpts[finfo] = tmp;
+  } else {
+    tmp = r->second;
+  }
+  return tmp;
+}
+
+address_type get_return_pc(void *thd) {
+  // function call return
+  ptx_thread_info *the_thread = (ptx_thread_info *)thd;
+  assert(the_thread != NULL);
+  return the_thread->get_return_PC();
+}
+
+address_type cuda_sim::get_converge_point(address_type pc) {
+  // the branch could encode the reconvergence point and/or a bit that indicates
+  // the reconvergence point is the return PC on the call stack in the case the
+  // branch has no immediate postdominator in the function (i.e., due to
+  // multiple return points).
+
+  std::map<unsigned, function_info *>::iterator f = g_pc_to_finfo.find(pc);
+  assert(f != g_pc_to_finfo.end());
+  function_info *finfo = f->second;
+  rec_pts tmp = find_reconvergence_points(finfo);
+
+  int i = 0;
+  for (; i < tmp.s_num_recon; ++i) {
+    if (tmp.s_kernel_recon_points[i].source_pc == pc) {
+      if (tmp.s_kernel_recon_points[i].target_pc == (unsigned)-2) {
+        return RECONVERGE_RETURN_PC;
+      } else {
+        return tmp.s_kernel_recon_points[i].target_pc;
+      }
+    }
+  }
+  return NO_BRANCH_DIVERGENCE;
+}
+
+void functionalCoreSim::warp_exit(unsigned warp_id) {
+  for (int i = 0; i < m_warp_count * m_warp_size; i++) {
+    if (m_thread[i] != NULL) {
+      m_thread[i]->m_cta_info->register_deleted_thread(m_thread[i]);
+      delete m_thread[i];
+    }
+  }
 }

--- a/src/cuda-sim/cuda-sim.h
+++ b/src/cuda-sim/cuda-sim.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -30,13 +28,13 @@
 #ifndef CUDASIM_H_INCLUDED
 #define CUDASIM_H_INCLUDED
 
+#include "../abstract_hardware_model.h"
+#include"../gpgpu-sim/shader.h"
 #include <stdlib.h>
 #include <map>
-#include <string>
 #include <vector>
-#include "../abstract_hardware_model.h"
-#include "../gpgpu-sim/shader.h"
-#include "ptx_sim.h"
+#include <string>
+#include"ptx_sim.h"
 
 class gpgpu_context;
 class memory_space;
@@ -46,65 +44,69 @@ class symbol_table;
 extern const char *g_gpgpusim_version_string;
 extern int g_debug_execution;
 
-extern void print_splash();
+extern void   print_splash();
 
-extern void ptxinfo_opencl_addinfo(
-    std::map<std::string, function_info *> &kernels);
-unsigned ptx_sim_init_thread(kernel_info_t &kernel,
-                             class ptx_thread_info **thread_info, int sid,
-                             unsigned tid, unsigned threads_left,
-                             unsigned num_threads, class core_t *core,
-                             unsigned hw_cta_id, unsigned hw_warp_id,
-                             gpgpu_t *gpu,
-                             bool functionalSimulationMode = false);
-const struct gpgpu_ptx_sim_info *ptx_sim_kernel_info(
-    const class function_info *kernel);
+extern void ptxinfo_opencl_addinfo( std::map<std::string,function_info*> &kernels );
+unsigned ptx_sim_init_thread( kernel_info_t &kernel,
+                              class ptx_thread_info** thread_info,
+                              int sid,
+                              unsigned tid,
+                              unsigned threads_left,
+                              unsigned num_threads, 
+                              class core_t *core, 
+                              unsigned hw_cta_id, 
+                              unsigned hw_warp_id,
+                              gpgpu_t *gpu,
+                              bool functionalSimulationMode = false);
+const struct gpgpu_ptx_sim_info* ptx_sim_kernel_info(const class function_info *kernel);
 
 /*!
- * This class functionally executes a kernel. It uses the basic data structures
- * and procedures in core_t
+ * This class functionally executes a kernel. It uses the basic data structures and procedures in core_t 
  */
-class functionalCoreSim : public core_t {
- public:
-  functionalCoreSim(kernel_info_t *kernel, gpgpu_sim *g, unsigned warp_size)
-      : core_t(g, kernel, warp_size, kernel->threads_per_cta()) {
-    m_warpAtBarrier = new bool[m_warp_count];
-    m_liveThreadCount = new unsigned[m_warp_count];
-  }
-  virtual ~functionalCoreSim() {
-    warp_exit(0);
-    delete[] m_liveThreadCount;
-    delete[] m_warpAtBarrier;
-  }
-  //! executes all warps till completion
-  void execute(int inst_count, unsigned ctaid_cp);
-  virtual void warp_exit(unsigned warp_id);
-  virtual bool warp_waiting_at_barrier(unsigned warp_id) const {
-    return (m_warpAtBarrier[warp_id] || !(m_liveThreadCount[warp_id] > 0));
-  }
-
- private:
-  void executeWarp(unsigned, bool &, bool &);
-  // initializes threads in the CTA block which we are executing
-  void initializeCTA(unsigned ctaid_cp);
-  virtual void checkExecutionStatusAndUpdate(warp_inst_t &inst, unsigned t,
-                                             unsigned tid) {
-    if (m_thread[tid] == NULL || m_thread[tid]->is_done()) {
-      m_liveThreadCount[tid / m_warp_size]--;
+class functionalCoreSim: public core_t
+{    
+public:
+    functionalCoreSim(kernel_info_t * kernel, gpgpu_sim *g, unsigned warp_size)
+        : core_t( g, kernel, warp_size, kernel->threads_per_cta() )
+    {
+        m_warpAtBarrier =  new bool [m_warp_count];
+        m_liveThreadCount = new unsigned [m_warp_count];
     }
-  }
-
-  // lunches the stack and set the threads count
-  void createWarp(unsigned warpId);
-
-  // each warp live thread count and barrier indicator
-  unsigned *m_liveThreadCount;
-  bool *m_warpAtBarrier;
+    virtual ~functionalCoreSim(){
+        warp_exit(0);
+        delete[] m_liveThreadCount;
+        delete[] m_warpAtBarrier;
+    }
+    //! executes all warps till completion 
+    void execute(int inst_count, unsigned ctaid_cp);
+    virtual void warp_exit( unsigned warp_id );
+    virtual bool warp_waiting_at_barrier( unsigned warp_id ) const  
+    {
+        return (m_warpAtBarrier[warp_id] || !(m_liveThreadCount[warp_id]>0));
+    }
+    
+private:
+    void executeWarp(unsigned, bool &, bool &);
+    //initializes threads in the CTA block which we are executing
+    void initializeCTA(unsigned ctaid_cp);
+    virtual void checkExecutionStatusAndUpdate(warp_inst_t &inst, unsigned t, unsigned tid)
+    {
+    if(m_thread[tid]==NULL || m_thread[tid]->is_done()){
+        m_liveThreadCount[tid/m_warp_size]--;
+        }
+    }
+    
+    // lunches the stack and set the threads count
+    void  createWarp(unsigned warpId);
+    
+    //each warp live thread count and barrier indicator
+    unsigned * m_liveThreadCount;
+    bool* m_warpAtBarrier;
 };
 
 #define RECONVERGE_RETURN_PC ((address_type)-2)
 #define NO_BRANCH_DIVERGENCE ((address_type)-1)
-address_type get_return_pc(void *thd);
+address_type get_return_pc( void *thd );
 const char *get_ptxinfo_kname();
 void print_ptxinfo();
 void clear_ptxinfo();
@@ -112,98 +114,89 @@ struct gpgpu_ptx_sim_info get_ptxinfo();
 
 class gpgpu_recon_t;
 struct rec_pts {
-  gpgpu_recon_t *s_kernel_recon_points;
-  int s_num_recon;
+   gpgpu_recon_t *s_kernel_recon_points;
+   int s_num_recon;
 };
 
+
 class cuda_sim {
- public:
-  cuda_sim(gpgpu_context *ctx) {
-    g_ptx_sim_num_insn = 0;
-    g_ptx_kernel_count =
-        -1;  // used for classification stat collection purposes
-    gpgpu_param_num_shaders = 0;
-    g_cuda_launch_blocking = false;
-    g_inst_classification_stat = NULL;
-    g_inst_op_classification_stat = NULL;
-    g_assemble_code_next_pc = 0;
-    g_debug_thread_uid = 0;
-    g_override_embedded_ptx = false;
-    ptx_tex_regs = NULL;
-    g_ptx_thread_info_delete_count = 0;
-    g_ptx_thread_info_uid_next = 1;
-    g_debug_pc = 0xBEEF1518;
-    gpgpu_ctx = ctx;
-  }
-  // global variables
-  char *opcode_latency_int;
-  char *opcode_latency_fp;
-  char *opcode_latency_dp;
-  char *opcode_latency_sfu;
-  char *opcode_latency_tensor;
-  char *opcode_initiation_int;
-  char *opcode_initiation_fp;
-  char *opcode_initiation_dp;
-  char *opcode_initiation_sfu;
-  char *opcode_initiation_tensor;
-  int cp_count;
-  int cp_cta_resume;
-  int g_ptxinfo_error_detected;
-  unsigned g_ptx_sim_num_insn;
-  char *cdp_latency_str;
-  int g_ptx_kernel_count;  // used for classification stat collection purposes
-  std::map<const void *, std::string>
-      g_global_name_lookup;  // indexed by hostVar
-  std::map<const void *, std::string>
-      g_const_name_lookup;  // indexed by hostVar
-  int g_ptx_sim_mode;  // if non-zero run functional simulation only (i.e., no
-                       // notion of a clock cycle)
-  unsigned gpgpu_param_num_shaders;
-  class std::map<function_info *, rec_pts> g_rpts;
-  bool g_cuda_launch_blocking;
-  void **g_inst_classification_stat;
-  void **g_inst_op_classification_stat;
-  std::set<std::string> g_globals;
-  std::set<std::string> g_constants;
-  std::map<unsigned, function_info *> g_pc_to_finfo;
-  int gpgpu_ptx_instruction_classification;
-  unsigned cdp_latency[5];
-  unsigned g_assemble_code_next_pc;
-  int g_debug_thread_uid;
-  bool g_override_embedded_ptx;
-  std::set<unsigned long long> g_ptx_cta_info_sm_idx_used;
-  ptx_reg_t *ptx_tex_regs;
-  unsigned g_ptx_thread_info_delete_count;
-  unsigned g_ptx_thread_info_uid_next;
-  addr_t g_debug_pc;
-  // backward pointer
-  class gpgpu_context *gpgpu_ctx;
-  // global functions
-  void ptx_opcocde_latency_options(option_parser_t opp);
-  void gpgpu_cuda_ptx_sim_main_func(kernel_info_t &kernel, bool openCL = false);
-  int gpgpu_opencl_ptx_sim_main_func(kernel_info_t *grid);
-  void init_inst_classification_stat();
-  kernel_info_t *gpgpu_opencl_ptx_sim_init_grid(class function_info *entry,
-                                                gpgpu_ptx_sim_arg_list_t args,
-                                                struct dim3 gridDim,
-                                                struct dim3 blockDim,
-                                                gpgpu_t *gpu);
-  void gpgpu_ptx_sim_register_global_variable(void *hostVar,
-                                              const char *deviceName,
-                                              size_t size);
-  void gpgpu_ptx_sim_register_const_variable(void *, const char *deviceName,
-                                             size_t size);
-  void read_sim_environment_variables();
-  void set_param_gpgpu_num_shaders(int num_shaders);
-  struct rec_pts find_reconvergence_points(function_info *finfo);
-  address_type get_converge_point(address_type pc);
-  void gpgpu_ptx_sim_memcpy_symbol(const char *hostVar, const void *src,
-                                   size_t count, size_t offset, int to,
-                                   gpgpu_t *gpu);
-  void ptx_print_insn(address_type pc, FILE *fp);
-  std::string ptx_get_insn_str(address_type pc);
-  template <int activate_level>
-  bool ptx_debug_exec_dump_cond(int thd_uid, addr_t pc);
+    public:
+	cuda_sim( gpgpu_context* ctx ) {
+	    g_ptx_sim_num_insn = 0;
+	    g_ptx_kernel_count = -1; // used for classification stat collection purposes
+	    gpgpu_param_num_shaders = 0;
+	    g_cuda_launch_blocking = false;
+	    g_inst_classification_stat = NULL;
+	    g_inst_op_classification_stat= NULL;
+	    g_assemble_code_next_pc=0;
+	    g_debug_thread_uid = 0;
+	    g_override_embedded_ptx = false;
+	    ptx_tex_regs = NULL;
+	    g_ptx_thread_info_delete_count=0;
+	    g_ptx_thread_info_uid_next=1;
+	    g_debug_pc = 0xBEEF1518;
+	    gpgpu_ctx = ctx;
+	}
+	//global variables
+	char *opcode_latency_int;
+	char *opcode_latency_fp;
+	char *opcode_latency_dp;
+	char *opcode_latency_sfu;
+	char *opcode_latency_tensor;
+	char *opcode_initiation_int;
+	char *opcode_initiation_fp;
+	char *opcode_initiation_dp;
+	char *opcode_initiation_sfu;
+	char *opcode_initiation_tensor;
+	int cp_count;
+	int cp_cta_resume;
+	int g_ptxinfo_error_detected;
+	unsigned g_ptx_sim_num_insn;
+	char *cdp_latency_str;
+	int g_ptx_kernel_count; // used for classification stat collection purposes
+	std::map<const void*,std::string>   g_global_name_lookup; // indexed by hostVar
+	std::map<const void*,std::string>   g_const_name_lookup; // indexed by hostVar
+	int g_ptx_sim_mode; // if non-zero run functional simulation only (i.e., no notion of a clock cycle)
+	unsigned gpgpu_param_num_shaders;
+	class std::map<function_info*,rec_pts> g_rpts;
+	bool g_cuda_launch_blocking;
+	void ** g_inst_classification_stat;
+	void ** g_inst_op_classification_stat;
+	std::set<std::string>   g_globals;
+	std::set<std::string>   g_constants;
+	std::map<unsigned,function_info*> g_pc_to_finfo;
+	int gpgpu_ptx_instruction_classification;
+	unsigned cdp_latency[5];
+	unsigned g_assemble_code_next_pc;
+	int g_debug_thread_uid;
+	bool g_override_embedded_ptx;
+	std::set<unsigned long long> g_ptx_cta_info_sm_idx_used;
+	ptx_reg_t* ptx_tex_regs;
+	unsigned g_ptx_thread_info_delete_count;
+	unsigned g_ptx_thread_info_uid_next;
+	addr_t g_debug_pc;
+	// backward pointer
+	class gpgpu_context* gpgpu_ctx;
+	//global functions
+	void ptx_opcocde_latency_options (option_parser_t opp);
+	void gpgpu_cuda_ptx_sim_main_func( kernel_info_t &kernel, bool openCL = false );
+	int gpgpu_opencl_ptx_sim_main_func( kernel_info_t *grid );
+	void init_inst_classification_stat();
+	kernel_info_t *gpgpu_opencl_ptx_sim_init_grid(class function_info *entry,
+		gpgpu_ptx_sim_arg_list_t args,
+		struct dim3 gridDim,
+		struct dim3 blockDim,
+		gpgpu_t *gpu );
+	void   gpgpu_ptx_sim_register_global_variable(void *hostVar, const char *deviceName, size_t size );
+	void   gpgpu_ptx_sim_register_const_variable(void*, const char *deviceName, size_t size );
+	void read_sim_environment_variables();
+	void set_param_gpgpu_num_shaders(int num_shaders);
+	struct rec_pts find_reconvergence_points( function_info *finfo );
+	address_type get_converge_point( address_type pc );
+	void   gpgpu_ptx_sim_memcpy_symbol(const char *hostVar, const void *src, size_t count, size_t offset, int to, gpgpu_t *gpu );
+	void ptx_print_insn( address_type pc, FILE *fp );
+	std::string ptx_get_insn_str( address_type pc );
+	template<int activate_level> bool ptx_debug_exec_dump_cond(int thd_uid, addr_t pc);
 };
 
 #endif

--- a/src/cuda-sim/cuda-sim.h
+++ b/src/cuda-sim/cuda-sim.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -28,13 +30,13 @@
 #ifndef CUDASIM_H_INCLUDED
 #define CUDASIM_H_INCLUDED
 
-#include "../abstract_hardware_model.h"
-#include"../gpgpu-sim/shader.h"
 #include <stdlib.h>
 #include <map>
-#include <vector>
 #include <string>
-#include"ptx_sim.h"
+#include <vector>
+#include "../abstract_hardware_model.h"
+#include "../gpgpu-sim/shader.h"
+#include "ptx_sim.h"
 
 class gpgpu_context;
 class memory_space;
@@ -44,69 +46,65 @@ class symbol_table;
 extern const char *g_gpgpusim_version_string;
 extern int g_debug_execution;
 
-extern void   print_splash();
+extern void print_splash();
 
-extern void ptxinfo_opencl_addinfo( std::map<std::string,function_info*> &kernels );
-unsigned ptx_sim_init_thread( kernel_info_t &kernel,
-                              class ptx_thread_info** thread_info,
-                              int sid,
-                              unsigned tid,
-                              unsigned threads_left,
-                              unsigned num_threads, 
-                              class core_t *core, 
-                              unsigned hw_cta_id, 
-                              unsigned hw_warp_id,
-                              gpgpu_t *gpu,
-                              bool functionalSimulationMode = false);
-const struct gpgpu_ptx_sim_info* ptx_sim_kernel_info(const class function_info *kernel);
+extern void ptxinfo_opencl_addinfo(
+    std::map<std::string, function_info *> &kernels);
+unsigned ptx_sim_init_thread(kernel_info_t &kernel,
+                             class ptx_thread_info **thread_info, int sid,
+                             unsigned tid, unsigned threads_left,
+                             unsigned num_threads, class core_t *core,
+                             unsigned hw_cta_id, unsigned hw_warp_id,
+                             gpgpu_t *gpu,
+                             bool functionalSimulationMode = false);
+const struct gpgpu_ptx_sim_info *ptx_sim_kernel_info(
+    const class function_info *kernel);
 
 /*!
- * This class functionally executes a kernel. It uses the basic data structures and procedures in core_t 
+ * This class functionally executes a kernel. It uses the basic data structures
+ * and procedures in core_t
  */
-class functionalCoreSim: public core_t
-{    
-public:
-    functionalCoreSim(kernel_info_t * kernel, gpgpu_sim *g, unsigned warp_size)
-        : core_t( g, kernel, warp_size, kernel->threads_per_cta() )
-    {
-        m_warpAtBarrier =  new bool [m_warp_count];
-        m_liveThreadCount = new unsigned [m_warp_count];
+class functionalCoreSim : public core_t {
+ public:
+  functionalCoreSim(kernel_info_t *kernel, gpgpu_sim *g, unsigned warp_size)
+      : core_t(g, kernel, warp_size, kernel->threads_per_cta()) {
+    m_warpAtBarrier = new bool[m_warp_count];
+    m_liveThreadCount = new unsigned[m_warp_count];
+  }
+  virtual ~functionalCoreSim() {
+    warp_exit(0);
+    delete[] m_liveThreadCount;
+    delete[] m_warpAtBarrier;
+  }
+  //! executes all warps till completion
+  void execute(int inst_count, unsigned ctaid_cp);
+  virtual void warp_exit(unsigned warp_id);
+  virtual bool warp_waiting_at_barrier(unsigned warp_id) const {
+    return (m_warpAtBarrier[warp_id] || !(m_liveThreadCount[warp_id] > 0));
+  }
+
+ private:
+  void executeWarp(unsigned, bool &, bool &);
+  // initializes threads in the CTA block which we are executing
+  void initializeCTA(unsigned ctaid_cp);
+  virtual void checkExecutionStatusAndUpdate(warp_inst_t &inst, unsigned t,
+                                             unsigned tid) {
+    if (m_thread[tid] == NULL || m_thread[tid]->is_done()) {
+      m_liveThreadCount[tid / m_warp_size]--;
     }
-    virtual ~functionalCoreSim(){
-        warp_exit(0);
-        delete[] m_liveThreadCount;
-        delete[] m_warpAtBarrier;
-    }
-    //! executes all warps till completion 
-    void execute(int inst_count, unsigned ctaid_cp);
-    virtual void warp_exit( unsigned warp_id );
-    virtual bool warp_waiting_at_barrier( unsigned warp_id ) const  
-    {
-        return (m_warpAtBarrier[warp_id] || !(m_liveThreadCount[warp_id]>0));
-    }
-    
-private:
-    void executeWarp(unsigned, bool &, bool &);
-    //initializes threads in the CTA block which we are executing
-    void initializeCTA(unsigned ctaid_cp);
-    virtual void checkExecutionStatusAndUpdate(warp_inst_t &inst, unsigned t, unsigned tid)
-    {
-    if(m_thread[tid]==NULL || m_thread[tid]->is_done()){
-        m_liveThreadCount[tid/m_warp_size]--;
-        }
-    }
-    
-    // lunches the stack and set the threads count
-    void  createWarp(unsigned warpId);
-    
-    //each warp live thread count and barrier indicator
-    unsigned * m_liveThreadCount;
-    bool* m_warpAtBarrier;
+  }
+
+  // lunches the stack and set the threads count
+  void createWarp(unsigned warpId);
+
+  // each warp live thread count and barrier indicator
+  unsigned *m_liveThreadCount;
+  bool *m_warpAtBarrier;
 };
 
 #define RECONVERGE_RETURN_PC ((address_type)-2)
 #define NO_BRANCH_DIVERGENCE ((address_type)-1)
-address_type get_return_pc( void *thd );
+address_type get_return_pc(void *thd);
 const char *get_ptxinfo_kname();
 void print_ptxinfo();
 void clear_ptxinfo();
@@ -114,89 +112,98 @@ struct gpgpu_ptx_sim_info get_ptxinfo();
 
 class gpgpu_recon_t;
 struct rec_pts {
-   gpgpu_recon_t *s_kernel_recon_points;
-   int s_num_recon;
+  gpgpu_recon_t *s_kernel_recon_points;
+  int s_num_recon;
 };
 
-
 class cuda_sim {
-    public:
-	cuda_sim( gpgpu_context* ctx ) {
-	    g_ptx_sim_num_insn = 0;
-	    g_ptx_kernel_count = -1; // used for classification stat collection purposes
-	    gpgpu_param_num_shaders = 0;
-	    g_cuda_launch_blocking = false;
-	    g_inst_classification_stat = NULL;
-	    g_inst_op_classification_stat= NULL;
-	    g_assemble_code_next_pc=0;
-	    g_debug_thread_uid = 0;
-	    g_override_embedded_ptx = false;
-	    ptx_tex_regs = NULL;
-	    g_ptx_thread_info_delete_count=0;
-	    g_ptx_thread_info_uid_next=1;
-	    g_debug_pc = 0xBEEF1518;
-	    gpgpu_ctx = ctx;
-	}
-	//global variables
-	char *opcode_latency_int;
-	char *opcode_latency_fp;
-	char *opcode_latency_dp;
-	char *opcode_latency_sfu;
-	char *opcode_latency_tensor;
-	char *opcode_initiation_int;
-	char *opcode_initiation_fp;
-	char *opcode_initiation_dp;
-	char *opcode_initiation_sfu;
-	char *opcode_initiation_tensor;
-	int cp_count;
-	int cp_cta_resume;
-	int g_ptxinfo_error_detected;
-	unsigned g_ptx_sim_num_insn;
-	char *cdp_latency_str;
-	int g_ptx_kernel_count; // used for classification stat collection purposes
-	std::map<const void*,std::string>   g_global_name_lookup; // indexed by hostVar
-	std::map<const void*,std::string>   g_const_name_lookup; // indexed by hostVar
-	int g_ptx_sim_mode; // if non-zero run functional simulation only (i.e., no notion of a clock cycle)
-	unsigned gpgpu_param_num_shaders;
-	class std::map<function_info*,rec_pts> g_rpts;
-	bool g_cuda_launch_blocking;
-	void ** g_inst_classification_stat;
-	void ** g_inst_op_classification_stat;
-	std::set<std::string>   g_globals;
-	std::set<std::string>   g_constants;
-	std::map<unsigned,function_info*> g_pc_to_finfo;
-	int gpgpu_ptx_instruction_classification;
-	unsigned cdp_latency[5];
-	unsigned g_assemble_code_next_pc;
-	int g_debug_thread_uid;
-	bool g_override_embedded_ptx;
-	std::set<unsigned long long> g_ptx_cta_info_sm_idx_used;
-	ptx_reg_t* ptx_tex_regs;
-	unsigned g_ptx_thread_info_delete_count;
-	unsigned g_ptx_thread_info_uid_next;
-	addr_t g_debug_pc;
-	// backward pointer
-	class gpgpu_context* gpgpu_ctx;
-	//global functions
-	void ptx_opcocde_latency_options (option_parser_t opp);
-	void gpgpu_cuda_ptx_sim_main_func( kernel_info_t &kernel, bool openCL = false );
-	int gpgpu_opencl_ptx_sim_main_func( kernel_info_t *grid );
-	void init_inst_classification_stat();
-	kernel_info_t *gpgpu_opencl_ptx_sim_init_grid(class function_info *entry,
-		gpgpu_ptx_sim_arg_list_t args,
-		struct dim3 gridDim,
-		struct dim3 blockDim,
-		gpgpu_t *gpu );
-	void   gpgpu_ptx_sim_register_global_variable(void *hostVar, const char *deviceName, size_t size );
-	void   gpgpu_ptx_sim_register_const_variable(void*, const char *deviceName, size_t size );
-	void read_sim_environment_variables();
-	void set_param_gpgpu_num_shaders(int num_shaders);
-	struct rec_pts find_reconvergence_points( function_info *finfo );
-	address_type get_converge_point( address_type pc );
-	void   gpgpu_ptx_sim_memcpy_symbol(const char *hostVar, const void *src, size_t count, size_t offset, int to, gpgpu_t *gpu );
-	void ptx_print_insn( address_type pc, FILE *fp );
-	std::string ptx_get_insn_str( address_type pc );
-	template<int activate_level> bool ptx_debug_exec_dump_cond(int thd_uid, addr_t pc);
+ public:
+  cuda_sim(gpgpu_context *ctx) {
+    g_ptx_sim_num_insn = 0;
+    g_ptx_kernel_count =
+        -1;  // used for classification stat collection purposes
+    gpgpu_param_num_shaders = 0;
+    g_cuda_launch_blocking = false;
+    g_inst_classification_stat = NULL;
+    g_inst_op_classification_stat = NULL;
+    g_assemble_code_next_pc = 0;
+    g_debug_thread_uid = 0;
+    g_override_embedded_ptx = false;
+    ptx_tex_regs = NULL;
+    g_ptx_thread_info_delete_count = 0;
+    g_ptx_thread_info_uid_next = 1;
+    g_debug_pc = 0xBEEF1518;
+    gpgpu_ctx = ctx;
+  }
+  // global variables
+  char *opcode_latency_int;
+  char *opcode_latency_fp;
+  char *opcode_latency_dp;
+  char *opcode_latency_sfu;
+  char *opcode_latency_tensor;
+  char *opcode_initiation_int;
+  char *opcode_initiation_fp;
+  char *opcode_initiation_dp;
+  char *opcode_initiation_sfu;
+  char *opcode_initiation_tensor;
+  int cp_count;
+  int cp_cta_resume;
+  int g_ptxinfo_error_detected;
+  unsigned g_ptx_sim_num_insn;
+  char *cdp_latency_str;
+  int g_ptx_kernel_count;  // used for classification stat collection purposes
+  std::map<const void *, std::string>
+      g_global_name_lookup;  // indexed by hostVar
+  std::map<const void *, std::string>
+      g_const_name_lookup;  // indexed by hostVar
+  int g_ptx_sim_mode;  // if non-zero run functional simulation only (i.e., no
+                       // notion of a clock cycle)
+  unsigned gpgpu_param_num_shaders;
+  class std::map<function_info *, rec_pts> g_rpts;
+  bool g_cuda_launch_blocking;
+  void **g_inst_classification_stat;
+  void **g_inst_op_classification_stat;
+  std::set<std::string> g_globals;
+  std::set<std::string> g_constants;
+  std::map<unsigned, function_info *> g_pc_to_finfo;
+  int gpgpu_ptx_instruction_classification;
+  unsigned cdp_latency[5];
+  unsigned g_assemble_code_next_pc;
+  int g_debug_thread_uid;
+  bool g_override_embedded_ptx;
+  std::set<unsigned long long> g_ptx_cta_info_sm_idx_used;
+  ptx_reg_t *ptx_tex_regs;
+  unsigned g_ptx_thread_info_delete_count;
+  unsigned g_ptx_thread_info_uid_next;
+  addr_t g_debug_pc;
+  // backward pointer
+  class gpgpu_context *gpgpu_ctx;
+  // global functions
+  void ptx_opcocde_latency_options(option_parser_t opp);
+  void gpgpu_cuda_ptx_sim_main_func(kernel_info_t &kernel, bool openCL = false);
+  int gpgpu_opencl_ptx_sim_main_func(kernel_info_t *grid);
+  void init_inst_classification_stat();
+  kernel_info_t *gpgpu_opencl_ptx_sim_init_grid(class function_info *entry,
+                                                gpgpu_ptx_sim_arg_list_t args,
+                                                struct dim3 gridDim,
+                                                struct dim3 blockDim,
+                                                gpgpu_t *gpu);
+  void gpgpu_ptx_sim_register_global_variable(void *hostVar,
+                                              const char *deviceName,
+                                              size_t size);
+  void gpgpu_ptx_sim_register_const_variable(void *, const char *deviceName,
+                                             size_t size);
+  void read_sim_environment_variables();
+  void set_param_gpgpu_num_shaders(int num_shaders);
+  struct rec_pts find_reconvergence_points(function_info *finfo);
+  address_type get_converge_point(address_type pc);
+  void gpgpu_ptx_sim_memcpy_symbol(const char *hostVar, const void *src,
+                                   size_t count, size_t offset, int to,
+                                   gpgpu_t *gpu);
+  void ptx_print_insn(address_type pc, FILE *fp);
+  std::string ptx_get_insn_str(address_type pc);
+  template <int activate_level>
+  bool ptx_debug_exec_dump_cond(int thd_uid, addr_t pc);
 };
 
 #endif

--- a/src/cuda-sim/cuda-sim.h
+++ b/src/cuda-sim/cuda-sim.h
@@ -7,34 +7,35 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef CUDASIM_H_INCLUDED
 #define CUDASIM_H_INCLUDED
 
-#include "../abstract_hardware_model.h"
-#include"../gpgpu-sim/shader.h"
 #include <stdlib.h>
 #include <map>
-#include <vector>
 #include <string>
-#include"ptx_sim.h"
+#include <vector>
+#include "../abstract_hardware_model.h"
+#include "../gpgpu-sim/shader.h"
+#include "ptx_sim.h"
 
 class gpgpu_context;
 class memory_space;
@@ -44,69 +45,65 @@ class symbol_table;
 extern const char *g_gpgpusim_version_string;
 extern int g_debug_execution;
 
-extern void   print_splash();
+extern void print_splash();
 
-extern void ptxinfo_opencl_addinfo( std::map<std::string,function_info*> &kernels );
-unsigned ptx_sim_init_thread( kernel_info_t &kernel,
-                              class ptx_thread_info** thread_info,
-                              int sid,
-                              unsigned tid,
-                              unsigned threads_left,
-                              unsigned num_threads, 
-                              class core_t *core, 
-                              unsigned hw_cta_id, 
-                              unsigned hw_warp_id,
-                              gpgpu_t *gpu,
-                              bool functionalSimulationMode = false);
-const struct gpgpu_ptx_sim_info* ptx_sim_kernel_info(const class function_info *kernel);
+extern void ptxinfo_opencl_addinfo(
+    std::map<std::string, function_info *> &kernels);
+unsigned ptx_sim_init_thread(kernel_info_t &kernel,
+                             class ptx_thread_info **thread_info, int sid,
+                             unsigned tid, unsigned threads_left,
+                             unsigned num_threads, class core_t *core,
+                             unsigned hw_cta_id, unsigned hw_warp_id,
+                             gpgpu_t *gpu,
+                             bool functionalSimulationMode = false);
+const struct gpgpu_ptx_sim_info *ptx_sim_kernel_info(
+    const class function_info *kernel);
 
 /*!
- * This class functionally executes a kernel. It uses the basic data structures and procedures in core_t 
+ * This class functionally executes a kernel. It uses the basic data structures
+ * and procedures in core_t
  */
-class functionalCoreSim: public core_t
-{    
-public:
-    functionalCoreSim(kernel_info_t * kernel, gpgpu_sim *g, unsigned warp_size)
-        : core_t( g, kernel, warp_size, kernel->threads_per_cta() )
-    {
-        m_warpAtBarrier =  new bool [m_warp_count];
-        m_liveThreadCount = new unsigned [m_warp_count];
+class functionalCoreSim : public core_t {
+ public:
+  functionalCoreSim(kernel_info_t *kernel, gpgpu_sim *g, unsigned warp_size)
+      : core_t(g, kernel, warp_size, kernel->threads_per_cta()) {
+    m_warpAtBarrier = new bool[m_warp_count];
+    m_liveThreadCount = new unsigned[m_warp_count];
+  }
+  virtual ~functionalCoreSim() {
+    warp_exit(0);
+    delete[] m_liveThreadCount;
+    delete[] m_warpAtBarrier;
+  }
+  //! executes all warps till completion
+  void execute(int inst_count, unsigned ctaid_cp);
+  virtual void warp_exit(unsigned warp_id);
+  virtual bool warp_waiting_at_barrier(unsigned warp_id) const {
+    return (m_warpAtBarrier[warp_id] || !(m_liveThreadCount[warp_id] > 0));
+  }
+
+ private:
+  void executeWarp(unsigned, bool &, bool &);
+  // initializes threads in the CTA block which we are executing
+  void initializeCTA(unsigned ctaid_cp);
+  virtual void checkExecutionStatusAndUpdate(warp_inst_t &inst, unsigned t,
+                                             unsigned tid) {
+    if (m_thread[tid] == NULL || m_thread[tid]->is_done()) {
+      m_liveThreadCount[tid / m_warp_size]--;
     }
-    virtual ~functionalCoreSim(){
-        warp_exit(0);
-        delete[] m_liveThreadCount;
-        delete[] m_warpAtBarrier;
-    }
-    //! executes all warps till completion 
-    void execute(int inst_count, unsigned ctaid_cp);
-    virtual void warp_exit( unsigned warp_id );
-    virtual bool warp_waiting_at_barrier( unsigned warp_id ) const  
-    {
-        return (m_warpAtBarrier[warp_id] || !(m_liveThreadCount[warp_id]>0));
-    }
-    
-private:
-    void executeWarp(unsigned, bool &, bool &);
-    //initializes threads in the CTA block which we are executing
-    void initializeCTA(unsigned ctaid_cp);
-    virtual void checkExecutionStatusAndUpdate(warp_inst_t &inst, unsigned t, unsigned tid)
-    {
-    if(m_thread[tid]==NULL || m_thread[tid]->is_done()){
-        m_liveThreadCount[tid/m_warp_size]--;
-        }
-    }
-    
-    // lunches the stack and set the threads count
-    void  createWarp(unsigned warpId);
-    
-    //each warp live thread count and barrier indicator
-    unsigned * m_liveThreadCount;
-    bool* m_warpAtBarrier;
+  }
+
+  // lunches the stack and set the threads count
+  void createWarp(unsigned warpId);
+
+  // each warp live thread count and barrier indicator
+  unsigned *m_liveThreadCount;
+  bool *m_warpAtBarrier;
 };
 
 #define RECONVERGE_RETURN_PC ((address_type)-2)
 #define NO_BRANCH_DIVERGENCE ((address_type)-1)
-address_type get_return_pc( void *thd );
+address_type get_return_pc(void *thd);
 const char *get_ptxinfo_kname();
 void print_ptxinfo();
 void clear_ptxinfo();
@@ -114,89 +111,98 @@ struct gpgpu_ptx_sim_info get_ptxinfo();
 
 class gpgpu_recon_t;
 struct rec_pts {
-   gpgpu_recon_t *s_kernel_recon_points;
-   int s_num_recon;
+  gpgpu_recon_t *s_kernel_recon_points;
+  int s_num_recon;
 };
 
-
 class cuda_sim {
-    public:
-	cuda_sim( gpgpu_context* ctx ) {
-	    g_ptx_sim_num_insn = 0;
-	    g_ptx_kernel_count = -1; // used for classification stat collection purposes
-	    gpgpu_param_num_shaders = 0;
-	    g_cuda_launch_blocking = false;
-	    g_inst_classification_stat = NULL;
-	    g_inst_op_classification_stat= NULL;
-	    g_assemble_code_next_pc=0;
-	    g_debug_thread_uid = 0;
-	    g_override_embedded_ptx = false;
-	    ptx_tex_regs = NULL;
-	    g_ptx_thread_info_delete_count=0;
-	    g_ptx_thread_info_uid_next=1;
-	    g_debug_pc = 0xBEEF1518;
-	    gpgpu_ctx = ctx;
-	}
-	//global variables
-	char *opcode_latency_int;
-	char *opcode_latency_fp;
-	char *opcode_latency_dp;
-	char *opcode_latency_sfu;
-	char *opcode_latency_tensor;
-	char *opcode_initiation_int;
-	char *opcode_initiation_fp;
-	char *opcode_initiation_dp;
-	char *opcode_initiation_sfu;
-	char *opcode_initiation_tensor;
-	int cp_count;
-	int cp_cta_resume;
-	int g_ptxinfo_error_detected;
-	unsigned g_ptx_sim_num_insn;
-	char *cdp_latency_str;
-	int g_ptx_kernel_count; // used for classification stat collection purposes
-	std::map<const void*,std::string>   g_global_name_lookup; // indexed by hostVar
-	std::map<const void*,std::string>   g_const_name_lookup; // indexed by hostVar
-	int g_ptx_sim_mode; // if non-zero run functional simulation only (i.e., no notion of a clock cycle)
-	unsigned gpgpu_param_num_shaders;
-	class std::map<function_info*,rec_pts> g_rpts;
-	bool g_cuda_launch_blocking;
-	void ** g_inst_classification_stat;
-	void ** g_inst_op_classification_stat;
-	std::set<std::string>   g_globals;
-	std::set<std::string>   g_constants;
-	std::map<unsigned,function_info*> g_pc_to_finfo;
-	int gpgpu_ptx_instruction_classification;
-	unsigned cdp_latency[5];
-	unsigned g_assemble_code_next_pc;
-	int g_debug_thread_uid;
-	bool g_override_embedded_ptx;
-	std::set<unsigned long long> g_ptx_cta_info_sm_idx_used;
-	ptx_reg_t* ptx_tex_regs;
-	unsigned g_ptx_thread_info_delete_count;
-	unsigned g_ptx_thread_info_uid_next;
-	addr_t g_debug_pc;
-	// backward pointer
-	class gpgpu_context* gpgpu_ctx;
-	//global functions
-	void ptx_opcocde_latency_options (option_parser_t opp);
-	void gpgpu_cuda_ptx_sim_main_func( kernel_info_t &kernel, bool openCL = false );
-	int gpgpu_opencl_ptx_sim_main_func( kernel_info_t *grid );
-	void init_inst_classification_stat();
-	kernel_info_t *gpgpu_opencl_ptx_sim_init_grid(class function_info *entry,
-		gpgpu_ptx_sim_arg_list_t args,
-		struct dim3 gridDim,
-		struct dim3 blockDim,
-		gpgpu_t *gpu );
-	void   gpgpu_ptx_sim_register_global_variable(void *hostVar, const char *deviceName, size_t size );
-	void   gpgpu_ptx_sim_register_const_variable(void*, const char *deviceName, size_t size );
-	void read_sim_environment_variables();
-	void set_param_gpgpu_num_shaders(int num_shaders);
-	struct rec_pts find_reconvergence_points( function_info *finfo );
-	address_type get_converge_point( address_type pc );
-	void   gpgpu_ptx_sim_memcpy_symbol(const char *hostVar, const void *src, size_t count, size_t offset, int to, gpgpu_t *gpu );
-	void ptx_print_insn( address_type pc, FILE *fp );
-	std::string ptx_get_insn_str( address_type pc );
-	template<int activate_level> bool ptx_debug_exec_dump_cond(int thd_uid, addr_t pc);
+ public:
+  cuda_sim(gpgpu_context *ctx) {
+    g_ptx_sim_num_insn = 0;
+    g_ptx_kernel_count =
+        -1;  // used for classification stat collection purposes
+    gpgpu_param_num_shaders = 0;
+    g_cuda_launch_blocking = false;
+    g_inst_classification_stat = NULL;
+    g_inst_op_classification_stat = NULL;
+    g_assemble_code_next_pc = 0;
+    g_debug_thread_uid = 0;
+    g_override_embedded_ptx = false;
+    ptx_tex_regs = NULL;
+    g_ptx_thread_info_delete_count = 0;
+    g_ptx_thread_info_uid_next = 1;
+    g_debug_pc = 0xBEEF1518;
+    gpgpu_ctx = ctx;
+  }
+  // global variables
+  char *opcode_latency_int;
+  char *opcode_latency_fp;
+  char *opcode_latency_dp;
+  char *opcode_latency_sfu;
+  char *opcode_latency_tensor;
+  char *opcode_initiation_int;
+  char *opcode_initiation_fp;
+  char *opcode_initiation_dp;
+  char *opcode_initiation_sfu;
+  char *opcode_initiation_tensor;
+  int cp_count;
+  int cp_cta_resume;
+  int g_ptxinfo_error_detected;
+  unsigned g_ptx_sim_num_insn;
+  char *cdp_latency_str;
+  int g_ptx_kernel_count;  // used for classification stat collection purposes
+  std::map<const void *, std::string>
+      g_global_name_lookup;  // indexed by hostVar
+  std::map<const void *, std::string>
+      g_const_name_lookup;  // indexed by hostVar
+  int g_ptx_sim_mode;  // if non-zero run functional simulation only (i.e., no
+                       // notion of a clock cycle)
+  unsigned gpgpu_param_num_shaders;
+  class std::map<function_info *, rec_pts> g_rpts;
+  bool g_cuda_launch_blocking;
+  void **g_inst_classification_stat;
+  void **g_inst_op_classification_stat;
+  std::set<std::string> g_globals;
+  std::set<std::string> g_constants;
+  std::map<unsigned, function_info *> g_pc_to_finfo;
+  int gpgpu_ptx_instruction_classification;
+  unsigned cdp_latency[5];
+  unsigned g_assemble_code_next_pc;
+  int g_debug_thread_uid;
+  bool g_override_embedded_ptx;
+  std::set<unsigned long long> g_ptx_cta_info_sm_idx_used;
+  ptx_reg_t *ptx_tex_regs;
+  unsigned g_ptx_thread_info_delete_count;
+  unsigned g_ptx_thread_info_uid_next;
+  addr_t g_debug_pc;
+  // backward pointer
+  class gpgpu_context *gpgpu_ctx;
+  // global functions
+  void ptx_opcocde_latency_options(option_parser_t opp);
+  void gpgpu_cuda_ptx_sim_main_func(kernel_info_t &kernel, bool openCL = false);
+  int gpgpu_opencl_ptx_sim_main_func(kernel_info_t *grid);
+  void init_inst_classification_stat();
+  kernel_info_t *gpgpu_opencl_ptx_sim_init_grid(class function_info *entry,
+                                                gpgpu_ptx_sim_arg_list_t args,
+                                                struct dim3 gridDim,
+                                                struct dim3 blockDim,
+                                                gpgpu_t *gpu);
+  void gpgpu_ptx_sim_register_global_variable(void *hostVar,
+                                              const char *deviceName,
+                                              size_t size);
+  void gpgpu_ptx_sim_register_const_variable(void *, const char *deviceName,
+                                             size_t size);
+  void read_sim_environment_variables();
+  void set_param_gpgpu_num_shaders(int num_shaders);
+  struct rec_pts find_reconvergence_points(function_info *finfo);
+  address_type get_converge_point(address_type pc);
+  void gpgpu_ptx_sim_memcpy_symbol(const char *hostVar, const void *src,
+                                   size_t count, size_t offset, int to,
+                                   gpgpu_t *gpu);
+  void ptx_print_insn(address_type pc, FILE *fp);
+  std::string ptx_get_insn_str(address_type pc);
+  template <int activate_level>
+  bool ptx_debug_exec_dump_cond(int thd_uid, addr_t pc);
 };
 
 #endif

--- a/src/cuda-sim/cuda_device_printf.cc
+++ b/src/cuda-sim/cuda_device_printf.cc
@@ -7,108 +7,112 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #include "cuda_device_printf.h"
 #include "ptx_ir.h"
 
-void decode_space( memory_space_t &space, ptx_thread_info *thread, const operand_info &op, memory_space *&mem, addr_t &addr);
+void decode_space(memory_space_t &space, ptx_thread_info *thread,
+                  const operand_info &op, memory_space *&mem, addr_t &addr);
 
-void my_cuda_printf(const char *fmtstr,const char *arg_list)
-{
-   FILE *fp = stdout;
-   unsigned i=0,j=0;
-   unsigned arg_offset=0;
-   char buf[64];
-   bool in_fmt=false;
-   while( fmtstr[i] ) {
-      char c = fmtstr[i++];
-      if( !in_fmt ) {
-         if( c != '%' ) {
-            fprintf(fp,"%c",c);
-         } else {
-            in_fmt=true;
-            buf[0] = c;
-            j=1;
-         }
+void my_cuda_printf(const char *fmtstr, const char *arg_list) {
+  FILE *fp = stdout;
+  unsigned i = 0, j = 0;
+  unsigned arg_offset = 0;
+  char buf[64];
+  bool in_fmt = false;
+  while (fmtstr[i]) {
+    char c = fmtstr[i++];
+    if (!in_fmt) {
+      if (c != '%') {
+        fprintf(fp, "%c", c);
       } else {
-         if(!( c == 'u' || c == 'f' || c == 'd' )) {
-            printf("GPGPU-Sim PTX: ERROR ** printf parsing support is limited to %%u, %%f, %%d at present");
-            abort();
-         }
-         buf[j] = c;
-         buf[j+1] = 0;
-         void* ptr = (void*)&arg_list[arg_offset];
-         //unsigned long long value = ((unsigned long long*)arg_list)[arg_offset];
-         if( c == 'u' || c == 'd' ) {
-            fprintf(fp,buf,*((unsigned long long*)ptr));
-         } else if( c == 'f' ) {
-            double tmp = *((double*)ptr);
-            fprintf(fp,buf,tmp);
-         }
-         arg_offset++;
-         in_fmt=false;
+        in_fmt = true;
+        buf[0] = c;
+        j = 1;
       }
-   }
+    } else {
+      if (!(c == 'u' || c == 'f' || c == 'd')) {
+        printf(
+            "GPGPU-Sim PTX: ERROR ** printf parsing support is limited to %%u, "
+            "%%f, %%d at present");
+        abort();
+      }
+      buf[j] = c;
+      buf[j + 1] = 0;
+      void *ptr = (void *)&arg_list[arg_offset];
+      // unsigned long long value = ((unsigned long long*)arg_list)[arg_offset];
+      if (c == 'u' || c == 'd') {
+        fprintf(fp, buf, *((unsigned long long *)ptr));
+      } else if (c == 'f') {
+        double tmp = *((double *)ptr);
+        fprintf(fp, buf, tmp);
+      }
+      arg_offset++;
+      in_fmt = false;
+    }
+  }
 }
 
-void gpgpusim_cuda_vprintf(const ptx_instruction * pI, ptx_thread_info * thread, const function_info * target_func ) 
-{
-      char *fmtstr = NULL;
-      char *arg_list = NULL;
-      unsigned n_return = target_func->has_return();
-      unsigned n_args = target_func->num_args();
-      assert( n_args == 2 );
-      for( unsigned arg=0; arg < n_args; arg ++ ) {
-         const operand_info &actual_param_op = pI->operand_lookup(n_return+1+arg);
-         const symbol *formal_param = target_func->get_arg(arg);
-         unsigned size=formal_param->get_size_in_bytes();
-         assert( formal_param->is_param_local() );
-         assert( actual_param_op.is_param_local() );
-         addr_t from_addr = actual_param_op.get_symbol()->get_address();
-         unsigned long long buffer[1024];
-         assert(size<1024*sizeof(unsigned long long));
-         thread->m_local_mem->read(from_addr,size,buffer);
-         addr_t addr = (addr_t)buffer[0]; // should be pointer to generic memory location
-         memory_space *mem=NULL;
-         memory_space_t space = generic_space;
-         decode_space(space,thread,actual_param_op,mem,addr); // figure out which space
-         if( arg == 0 ) {
-            unsigned len = 0;
-            char b = 0;
-            do { // figure out length
-               mem->read(addr+len,1,&b);
-               len++;
-            } while(b);
-            fmtstr = (char*)malloc(len+64);
-            for( int i=0; i < len; i++ ) 
-               mem->read(addr+i,1,fmtstr+i);
-            //mem->read(addr,len,fmtstr);
-         } else {
-            unsigned len = thread->get_finfo()->local_mem_framesize();
-            arg_list = (char*)malloc(len+64);
-            for( int i=0; i < len; i++ ) 
-               mem->read(addr+i,1,arg_list+i);
-            //mem->read(addr,len,arg_list);
-         }
-      }
-      my_cuda_printf(fmtstr,arg_list);
-      free(fmtstr);
-      free(arg_list);
+void gpgpusim_cuda_vprintf(const ptx_instruction *pI, ptx_thread_info *thread,
+                           const function_info *target_func) {
+  char *fmtstr = NULL;
+  char *arg_list = NULL;
+  unsigned n_return = target_func->has_return();
+  unsigned n_args = target_func->num_args();
+  assert(n_args == 2);
+  for (unsigned arg = 0; arg < n_args; arg++) {
+    const operand_info &actual_param_op =
+        pI->operand_lookup(n_return + 1 + arg);
+    const symbol *formal_param = target_func->get_arg(arg);
+    unsigned size = formal_param->get_size_in_bytes();
+    assert(formal_param->is_param_local());
+    assert(actual_param_op.is_param_local());
+    addr_t from_addr = actual_param_op.get_symbol()->get_address();
+    unsigned long long buffer[1024];
+    assert(size < 1024 * sizeof(unsigned long long));
+    thread->m_local_mem->read(from_addr, size, buffer);
+    addr_t addr =
+        (addr_t)buffer[0];  // should be pointer to generic memory location
+    memory_space *mem = NULL;
+    memory_space_t space = generic_space;
+    decode_space(space, thread, actual_param_op, mem,
+                 addr);  // figure out which space
+    if (arg == 0) {
+      unsigned len = 0;
+      char b = 0;
+      do {  // figure out length
+        mem->read(addr + len, 1, &b);
+        len++;
+      } while (b);
+      fmtstr = (char *)malloc(len + 64);
+      for (int i = 0; i < len; i++) mem->read(addr + i, 1, fmtstr + i);
+      // mem->read(addr,len,fmtstr);
+    } else {
+      unsigned len = thread->get_finfo()->local_mem_framesize();
+      arg_list = (char *)malloc(len + 64);
+      for (int i = 0; i < len; i++) mem->read(addr + i, 1, arg_list + i);
+      // mem->read(addr,len,arg_list);
+    }
+  }
+  my_cuda_printf(fmtstr, arg_list);
+  free(fmtstr);
+  free(arg_list);
 }

--- a/src/cuda-sim/cuda_device_printf.cc
+++ b/src/cuda-sim/cuda_device_printf.cc
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -28,87 +30,90 @@
 #include "cuda_device_printf.h"
 #include "ptx_ir.h"
 
-void decode_space( memory_space_t &space, ptx_thread_info *thread, const operand_info &op, memory_space *&mem, addr_t &addr);
+void decode_space(memory_space_t &space, ptx_thread_info *thread,
+                  const operand_info &op, memory_space *&mem, addr_t &addr);
 
-void my_cuda_printf(const char *fmtstr,const char *arg_list)
-{
-   FILE *fp = stdout;
-   unsigned i=0,j=0;
-   unsigned arg_offset=0;
-   char buf[64];
-   bool in_fmt=false;
-   while( fmtstr[i] ) {
-      char c = fmtstr[i++];
-      if( !in_fmt ) {
-         if( c != '%' ) {
-            fprintf(fp,"%c",c);
-         } else {
-            in_fmt=true;
-            buf[0] = c;
-            j=1;
-         }
+void my_cuda_printf(const char *fmtstr, const char *arg_list) {
+  FILE *fp = stdout;
+  unsigned i = 0, j = 0;
+  unsigned arg_offset = 0;
+  char buf[64];
+  bool in_fmt = false;
+  while (fmtstr[i]) {
+    char c = fmtstr[i++];
+    if (!in_fmt) {
+      if (c != '%') {
+        fprintf(fp, "%c", c);
       } else {
-         if(!( c == 'u' || c == 'f' || c == 'd' )) {
-            printf("GPGPU-Sim PTX: ERROR ** printf parsing support is limited to %%u, %%f, %%d at present");
-            abort();
-         }
-         buf[j] = c;
-         buf[j+1] = 0;
-         void* ptr = (void*)&arg_list[arg_offset];
-         //unsigned long long value = ((unsigned long long*)arg_list)[arg_offset];
-         if( c == 'u' || c == 'd' ) {
-            fprintf(fp,buf,*((unsigned long long*)ptr));
-         } else if( c == 'f' ) {
-            double tmp = *((double*)ptr);
-            fprintf(fp,buf,tmp);
-         }
-         arg_offset++;
-         in_fmt=false;
+        in_fmt = true;
+        buf[0] = c;
+        j = 1;
       }
-   }
+    } else {
+      if (!(c == 'u' || c == 'f' || c == 'd')) {
+        printf(
+            "GPGPU-Sim PTX: ERROR ** printf parsing support is limited to %%u, "
+            "%%f, %%d at present");
+        abort();
+      }
+      buf[j] = c;
+      buf[j + 1] = 0;
+      void *ptr = (void *)&arg_list[arg_offset];
+      // unsigned long long value = ((unsigned long long*)arg_list)[arg_offset];
+      if (c == 'u' || c == 'd') {
+        fprintf(fp, buf, *((unsigned long long *)ptr));
+      } else if (c == 'f') {
+        double tmp = *((double *)ptr);
+        fprintf(fp, buf, tmp);
+      }
+      arg_offset++;
+      in_fmt = false;
+    }
+  }
 }
 
-void gpgpusim_cuda_vprintf(const ptx_instruction * pI, ptx_thread_info * thread, const function_info * target_func ) 
-{
-      char *fmtstr = NULL;
-      char *arg_list = NULL;
-      unsigned n_return = target_func->has_return();
-      unsigned n_args = target_func->num_args();
-      assert( n_args == 2 );
-      for( unsigned arg=0; arg < n_args; arg ++ ) {
-         const operand_info &actual_param_op = pI->operand_lookup(n_return+1+arg);
-         const symbol *formal_param = target_func->get_arg(arg);
-         unsigned size=formal_param->get_size_in_bytes();
-         assert( formal_param->is_param_local() );
-         assert( actual_param_op.is_param_local() );
-         addr_t from_addr = actual_param_op.get_symbol()->get_address();
-         unsigned long long buffer[1024];
-         assert(size<1024*sizeof(unsigned long long));
-         thread->m_local_mem->read(from_addr,size,buffer);
-         addr_t addr = (addr_t)buffer[0]; // should be pointer to generic memory location
-         memory_space *mem=NULL;
-         memory_space_t space = generic_space;
-         decode_space(space,thread,actual_param_op,mem,addr); // figure out which space
-         if( arg == 0 ) {
-            unsigned len = 0;
-            char b = 0;
-            do { // figure out length
-               mem->read(addr+len,1,&b);
-               len++;
-            } while(b);
-            fmtstr = (char*)malloc(len+64);
-            for( int i=0; i < len; i++ ) 
-               mem->read(addr+i,1,fmtstr+i);
-            //mem->read(addr,len,fmtstr);
-         } else {
-            unsigned len = thread->get_finfo()->local_mem_framesize();
-            arg_list = (char*)malloc(len+64);
-            for( int i=0; i < len; i++ ) 
-               mem->read(addr+i,1,arg_list+i);
-            //mem->read(addr,len,arg_list);
-         }
-      }
-      my_cuda_printf(fmtstr,arg_list);
-      free(fmtstr);
-      free(arg_list);
+void gpgpusim_cuda_vprintf(const ptx_instruction *pI, ptx_thread_info *thread,
+                           const function_info *target_func) {
+  char *fmtstr = NULL;
+  char *arg_list = NULL;
+  unsigned n_return = target_func->has_return();
+  unsigned n_args = target_func->num_args();
+  assert(n_args == 2);
+  for (unsigned arg = 0; arg < n_args; arg++) {
+    const operand_info &actual_param_op =
+        pI->operand_lookup(n_return + 1 + arg);
+    const symbol *formal_param = target_func->get_arg(arg);
+    unsigned size = formal_param->get_size_in_bytes();
+    assert(formal_param->is_param_local());
+    assert(actual_param_op.is_param_local());
+    addr_t from_addr = actual_param_op.get_symbol()->get_address();
+    unsigned long long buffer[1024];
+    assert(size < 1024 * sizeof(unsigned long long));
+    thread->m_local_mem->read(from_addr, size, buffer);
+    addr_t addr =
+        (addr_t)buffer[0];  // should be pointer to generic memory location
+    memory_space *mem = NULL;
+    memory_space_t space = generic_space;
+    decode_space(space, thread, actual_param_op, mem,
+                 addr);  // figure out which space
+    if (arg == 0) {
+      unsigned len = 0;
+      char b = 0;
+      do {  // figure out length
+        mem->read(addr + len, 1, &b);
+        len++;
+      } while (b);
+      fmtstr = (char *)malloc(len + 64);
+      for (int i = 0; i < len; i++) mem->read(addr + i, 1, fmtstr + i);
+      // mem->read(addr,len,fmtstr);
+    } else {
+      unsigned len = thread->get_finfo()->local_mem_framesize();
+      arg_list = (char *)malloc(len + 64);
+      for (int i = 0; i < len; i++) mem->read(addr + i, 1, arg_list + i);
+      // mem->read(addr,len,arg_list);
+    }
+  }
+  my_cuda_printf(fmtstr, arg_list);
+  free(fmtstr);
+  free(arg_list);
 }

--- a/src/cuda-sim/cuda_device_printf.cc
+++ b/src/cuda-sim/cuda_device_printf.cc
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -30,90 +28,87 @@
 #include "cuda_device_printf.h"
 #include "ptx_ir.h"
 
-void decode_space(memory_space_t &space, ptx_thread_info *thread,
-                  const operand_info &op, memory_space *&mem, addr_t &addr);
+void decode_space( memory_space_t &space, ptx_thread_info *thread, const operand_info &op, memory_space *&mem, addr_t &addr);
 
-void my_cuda_printf(const char *fmtstr, const char *arg_list) {
-  FILE *fp = stdout;
-  unsigned i = 0, j = 0;
-  unsigned arg_offset = 0;
-  char buf[64];
-  bool in_fmt = false;
-  while (fmtstr[i]) {
-    char c = fmtstr[i++];
-    if (!in_fmt) {
-      if (c != '%') {
-        fprintf(fp, "%c", c);
+void my_cuda_printf(const char *fmtstr,const char *arg_list)
+{
+   FILE *fp = stdout;
+   unsigned i=0,j=0;
+   unsigned arg_offset=0;
+   char buf[64];
+   bool in_fmt=false;
+   while( fmtstr[i] ) {
+      char c = fmtstr[i++];
+      if( !in_fmt ) {
+         if( c != '%' ) {
+            fprintf(fp,"%c",c);
+         } else {
+            in_fmt=true;
+            buf[0] = c;
+            j=1;
+         }
       } else {
-        in_fmt = true;
-        buf[0] = c;
-        j = 1;
+         if(!( c == 'u' || c == 'f' || c == 'd' )) {
+            printf("GPGPU-Sim PTX: ERROR ** printf parsing support is limited to %%u, %%f, %%d at present");
+            abort();
+         }
+         buf[j] = c;
+         buf[j+1] = 0;
+         void* ptr = (void*)&arg_list[arg_offset];
+         //unsigned long long value = ((unsigned long long*)arg_list)[arg_offset];
+         if( c == 'u' || c == 'd' ) {
+            fprintf(fp,buf,*((unsigned long long*)ptr));
+         } else if( c == 'f' ) {
+            double tmp = *((double*)ptr);
+            fprintf(fp,buf,tmp);
+         }
+         arg_offset++;
+         in_fmt=false;
       }
-    } else {
-      if (!(c == 'u' || c == 'f' || c == 'd')) {
-        printf(
-            "GPGPU-Sim PTX: ERROR ** printf parsing support is limited to %%u, "
-            "%%f, %%d at present");
-        abort();
-      }
-      buf[j] = c;
-      buf[j + 1] = 0;
-      void *ptr = (void *)&arg_list[arg_offset];
-      // unsigned long long value = ((unsigned long long*)arg_list)[arg_offset];
-      if (c == 'u' || c == 'd') {
-        fprintf(fp, buf, *((unsigned long long *)ptr));
-      } else if (c == 'f') {
-        double tmp = *((double *)ptr);
-        fprintf(fp, buf, tmp);
-      }
-      arg_offset++;
-      in_fmt = false;
-    }
-  }
+   }
 }
 
-void gpgpusim_cuda_vprintf(const ptx_instruction *pI, ptx_thread_info *thread,
-                           const function_info *target_func) {
-  char *fmtstr = NULL;
-  char *arg_list = NULL;
-  unsigned n_return = target_func->has_return();
-  unsigned n_args = target_func->num_args();
-  assert(n_args == 2);
-  for (unsigned arg = 0; arg < n_args; arg++) {
-    const operand_info &actual_param_op =
-        pI->operand_lookup(n_return + 1 + arg);
-    const symbol *formal_param = target_func->get_arg(arg);
-    unsigned size = formal_param->get_size_in_bytes();
-    assert(formal_param->is_param_local());
-    assert(actual_param_op.is_param_local());
-    addr_t from_addr = actual_param_op.get_symbol()->get_address();
-    unsigned long long buffer[1024];
-    assert(size < 1024 * sizeof(unsigned long long));
-    thread->m_local_mem->read(from_addr, size, buffer);
-    addr_t addr =
-        (addr_t)buffer[0];  // should be pointer to generic memory location
-    memory_space *mem = NULL;
-    memory_space_t space = generic_space;
-    decode_space(space, thread, actual_param_op, mem,
-                 addr);  // figure out which space
-    if (arg == 0) {
-      unsigned len = 0;
-      char b = 0;
-      do {  // figure out length
-        mem->read(addr + len, 1, &b);
-        len++;
-      } while (b);
-      fmtstr = (char *)malloc(len + 64);
-      for (int i = 0; i < len; i++) mem->read(addr + i, 1, fmtstr + i);
-      // mem->read(addr,len,fmtstr);
-    } else {
-      unsigned len = thread->get_finfo()->local_mem_framesize();
-      arg_list = (char *)malloc(len + 64);
-      for (int i = 0; i < len; i++) mem->read(addr + i, 1, arg_list + i);
-      // mem->read(addr,len,arg_list);
-    }
-  }
-  my_cuda_printf(fmtstr, arg_list);
-  free(fmtstr);
-  free(arg_list);
+void gpgpusim_cuda_vprintf(const ptx_instruction * pI, ptx_thread_info * thread, const function_info * target_func ) 
+{
+      char *fmtstr = NULL;
+      char *arg_list = NULL;
+      unsigned n_return = target_func->has_return();
+      unsigned n_args = target_func->num_args();
+      assert( n_args == 2 );
+      for( unsigned arg=0; arg < n_args; arg ++ ) {
+         const operand_info &actual_param_op = pI->operand_lookup(n_return+1+arg);
+         const symbol *formal_param = target_func->get_arg(arg);
+         unsigned size=formal_param->get_size_in_bytes();
+         assert( formal_param->is_param_local() );
+         assert( actual_param_op.is_param_local() );
+         addr_t from_addr = actual_param_op.get_symbol()->get_address();
+         unsigned long long buffer[1024];
+         assert(size<1024*sizeof(unsigned long long));
+         thread->m_local_mem->read(from_addr,size,buffer);
+         addr_t addr = (addr_t)buffer[0]; // should be pointer to generic memory location
+         memory_space *mem=NULL;
+         memory_space_t space = generic_space;
+         decode_space(space,thread,actual_param_op,mem,addr); // figure out which space
+         if( arg == 0 ) {
+            unsigned len = 0;
+            char b = 0;
+            do { // figure out length
+               mem->read(addr+len,1,&b);
+               len++;
+            } while(b);
+            fmtstr = (char*)malloc(len+64);
+            for( int i=0; i < len; i++ ) 
+               mem->read(addr+i,1,fmtstr+i);
+            //mem->read(addr,len,fmtstr);
+         } else {
+            unsigned len = thread->get_finfo()->local_mem_framesize();
+            arg_list = (char*)malloc(len+64);
+            for( int i=0; i < len; i++ ) 
+               mem->read(addr+i,1,arg_list+i);
+            //mem->read(addr,len,arg_list);
+         }
+      }
+      my_cuda_printf(fmtstr,arg_list);
+      free(fmtstr);
+      free(arg_list);
 }

--- a/src/cuda-sim/cuda_device_printf.h
+++ b/src/cuda-sim/cuda_device_printf.h
@@ -7,27 +7,30 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef CUDA_DEVICE_PRINTF_INCLUDED
 #define CUDA_DEVICE_PRINTF_INCLUDED
 
-void gpgpusim_cuda_vprintf(const class ptx_instruction * pI, class ptx_thread_info * thread, const class function_info * target_func );
+void gpgpusim_cuda_vprintf(const class ptx_instruction* pI,
+                           class ptx_thread_info* thread,
+                           const class function_info* target_func);
 
 #endif

--- a/src/cuda-sim/cuda_device_printf.h
+++ b/src/cuda-sim/cuda_device_printf.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -30,8 +28,6 @@
 #ifndef CUDA_DEVICE_PRINTF_INCLUDED
 #define CUDA_DEVICE_PRINTF_INCLUDED
 
-void gpgpusim_cuda_vprintf(const class ptx_instruction* pI,
-                           class ptx_thread_info* thread,
-                           const class function_info* target_func);
+void gpgpusim_cuda_vprintf(const class ptx_instruction * pI, class ptx_thread_info * thread, const class function_info * target_func );
 
 #endif

--- a/src/cuda-sim/cuda_device_printf.h
+++ b/src/cuda-sim/cuda_device_printf.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -28,6 +30,8 @@
 #ifndef CUDA_DEVICE_PRINTF_INCLUDED
 #define CUDA_DEVICE_PRINTF_INCLUDED
 
-void gpgpusim_cuda_vprintf(const class ptx_instruction * pI, class ptx_thread_info * thread, const class function_info * target_func );
+void gpgpusim_cuda_vprintf(const class ptx_instruction* pI,
+                           class ptx_thread_info* thread,
+                           const class function_info* target_func);
 
 #endif

--- a/src/cuda-sim/cuda_device_runtime.cc
+++ b/src/cuda-sim/cuda_device_runtime.cc
@@ -1,297 +1,329 @@
-//Jin: cuda_device_runtime.cc
-//Defines CUDA device runtime APIs for CDP support
-
+// Jin: cuda_device_runtime.cc
+// Defines CUDA device runtime APIs for CDP support
 
 #include <iostream>
 #include <map>
-
-
 
 #if (CUDART_VERSION >= 5000)
 #define __CUDA_RUNTIME_API_H__
 
 #include <builtin_types.h>
 #include <driver_types.h>
-#include "../gpgpu-sim/gpu-sim.h"
-#include "cuda-sim.h"
-#include "ptx_ir.h"
-#include "../stream_manager.h"
-#include "../gpgpusim_entrypoint.h"
-#include "cuda_device_runtime.h"
 #include "../../libcuda/gpgpu_context.h"
+#include "../gpgpu-sim/gpu-sim.h"
+#include "../gpgpusim_entrypoint.h"
+#include "../stream_manager.h"
+#include "cuda-sim.h"
+#include "cuda_device_runtime.h"
+#include "ptx_ir.h"
 
-#define DEV_RUNTIME_REPORT(a) \
-   if( g_debug_execution ) { \
-      std::cout << __FILE__ << ", " << __LINE__ << ": " << a << "\n"; \
-      std::cout.flush(); \
-   }
+#define DEV_RUNTIME_REPORT(a)                                       \
+  if (g_debug_execution) {                                          \
+    std::cout << __FILE__ << ", " << __LINE__ << ": " << a << "\n"; \
+    std::cout.flush();                                              \
+  }
 
+// Handling device runtime api:
+// void * cudaGetParameterBufferV2(void *func, dim3 gridDimension, dim3
+// blockDimension, unsigned int sharedMemSize)
+void cuda_device_runtime::gpgpusim_cuda_getParameterBufferV2(
+    const ptx_instruction *pI, ptx_thread_info *thread,
+    const function_info *target_func) {
+  DEV_RUNTIME_REPORT("Calling cudaGetParameterBufferV2");
 
+  unsigned n_return = target_func->has_return();
+  assert(n_return);
+  unsigned n_args = target_func->num_args();
+  assert(n_args == 4);
 
-//Handling device runtime api:
-//void * cudaGetParameterBufferV2(void *func, dim3 gridDimension, dim3 blockDimension, unsigned int sharedMemSize)
-void cuda_device_runtime::gpgpusim_cuda_getParameterBufferV2(const ptx_instruction * pI, ptx_thread_info * thread, const function_info * target_func)
-{
-    DEV_RUNTIME_REPORT("Calling cudaGetParameterBufferV2");
-      
-    unsigned n_return = target_func->has_return();
-    assert(n_return);
-    unsigned n_args = target_func->num_args();
-    assert( n_args == 4 );
+  function_info *child_kernel_entry;
+  struct dim3 grid_dim, block_dim;
+  unsigned int shared_mem;
 
-    function_info * child_kernel_entry;
-    struct dim3 grid_dim, block_dim;
-    unsigned int shared_mem;
+  for (unsigned arg = 0; arg < n_args; arg++) {
+    const operand_info &actual_param_op =
+        pI->operand_lookup(n_return + 1 + arg);  // param#
+    const symbol *formal_param =
+        target_func->get_arg(arg);  // cudaGetParameterBufferV2_param_#
+    unsigned size = formal_param->get_size_in_bytes();
+    assert(formal_param->is_param_local());
+    assert(actual_param_op.is_param_local());
+    addr_t from_addr = actual_param_op.get_symbol()->get_address();
 
-    for( unsigned arg=0; arg < n_args; arg ++ ) {
-        const operand_info &actual_param_op = pI->operand_lookup(n_return+1+arg); //param#
-        const symbol *formal_param = target_func->get_arg(arg); //cudaGetParameterBufferV2_param_#
-        unsigned size=formal_param->get_size_in_bytes();
-        assert( formal_param->is_param_local() );
-        assert( actual_param_op.is_param_local() );
-        addr_t from_addr = actual_param_op.get_symbol()->get_address();
-
-        if(arg == 0) {//function_info* for the child kernel
-            unsigned long long buf;
-            assert(size == sizeof(function_info *));
-            thread->m_local_mem->read(from_addr, size, &buf);
-            child_kernel_entry = (function_info *)buf;
-            assert(child_kernel_entry);
-            DEV_RUNTIME_REPORT("child kernel name " << child_kernel_entry->get_name());
-        }
-        else if(arg == 1) { //dim3 grid_dim for the child kernel
-            assert(size == sizeof(struct dim3));
-            thread->m_local_mem->read(from_addr, size, & grid_dim);
-            DEV_RUNTIME_REPORT("grid (" << grid_dim.x << ", " << grid_dim.y << ", " << grid_dim.z << ")");
-        }
-        else if(arg == 2) { //dim3 block_dim for the child kernel
-            assert(size == sizeof(struct dim3));
-            thread->m_local_mem->read(from_addr, size, & block_dim);
-            DEV_RUNTIME_REPORT("block (" << block_dim.x << ", " << block_dim.y << ", " << block_dim.z << ")");
-        }
-        else if(arg == 3) { //unsigned int shared_mem
-            assert(size == sizeof(unsigned int));
-            thread->m_local_mem->read(from_addr, size, & shared_mem);
-            DEV_RUNTIME_REPORT("shared memory " << shared_mem);
-        }
+    if (arg == 0) {  // function_info* for the child kernel
+      unsigned long long buf;
+      assert(size == sizeof(function_info *));
+      thread->m_local_mem->read(from_addr, size, &buf);
+      child_kernel_entry = (function_info *)buf;
+      assert(child_kernel_entry);
+      DEV_RUNTIME_REPORT("child kernel name "
+                         << child_kernel_entry->get_name());
+    } else if (arg == 1) {  // dim3 grid_dim for the child kernel
+      assert(size == sizeof(struct dim3));
+      thread->m_local_mem->read(from_addr, size, &grid_dim);
+      DEV_RUNTIME_REPORT("grid (" << grid_dim.x << ", " << grid_dim.y << ", "
+                                  << grid_dim.z << ")");
+    } else if (arg == 2) {  // dim3 block_dim for the child kernel
+      assert(size == sizeof(struct dim3));
+      thread->m_local_mem->read(from_addr, size, &block_dim);
+      DEV_RUNTIME_REPORT("block (" << block_dim.x << ", " << block_dim.y << ", "
+                                   << block_dim.z << ")");
+    } else if (arg == 3) {  // unsigned int shared_mem
+      assert(size == sizeof(unsigned int));
+      thread->m_local_mem->read(from_addr, size, &shared_mem);
+      DEV_RUNTIME_REPORT("shared memory " << shared_mem);
     }
+  }
 
-    //get total child kernel argument size and malloc buffer in global memory
-    unsigned child_kernel_arg_size = child_kernel_entry->get_args_aligned_size();
-    void * param_buffer = thread->get_gpu()->gpu_malloc(child_kernel_arg_size);
-    g_total_param_size += ((child_kernel_arg_size + 255) / 256 * 256);
-    DEV_RUNTIME_REPORT("child kernel arg size total " << child_kernel_arg_size << ", parameter buffer allocated at " << param_buffer);
-    if(g_total_param_size > g_max_total_param_size)
-        g_max_total_param_size = g_total_param_size;
+  // get total child kernel argument size and malloc buffer in global memory
+  unsigned child_kernel_arg_size = child_kernel_entry->get_args_aligned_size();
+  void *param_buffer = thread->get_gpu()->gpu_malloc(child_kernel_arg_size);
+  g_total_param_size += ((child_kernel_arg_size + 255) / 256 * 256);
+  DEV_RUNTIME_REPORT("child kernel arg size total "
+                     << child_kernel_arg_size
+                     << ", parameter buffer allocated at " << param_buffer);
+  if (g_total_param_size > g_max_total_param_size)
+    g_max_total_param_size = g_total_param_size;
 
-    //store param buffer address and launch config
-    device_launch_config_t device_launch_config(grid_dim, block_dim, shared_mem, child_kernel_entry);
-    assert(g_cuda_device_launch_param_map.find(param_buffer) == g_cuda_device_launch_param_map.end());
-    g_cuda_device_launch_param_map[param_buffer] = device_launch_config;
+  // store param buffer address and launch config
+  device_launch_config_t device_launch_config(grid_dim, block_dim, shared_mem,
+                                              child_kernel_entry);
+  assert(g_cuda_device_launch_param_map.find(param_buffer) ==
+         g_cuda_device_launch_param_map.end());
+  g_cuda_device_launch_param_map[param_buffer] = device_launch_config;
 
-    //copy the buffer address to retval0
-    const operand_info &actual_return_op = pI->operand_lookup(0); //retval0
-    const symbol *formal_return = target_func->get_return_var(); //void *
-    unsigned int return_size = formal_return->get_size_in_bytes();
-    DEV_RUNTIME_REPORT("cudaGetParameterBufferV2 return value has size of " << return_size);
-    assert(actual_return_op.is_param_local());
-    assert(actual_return_op.get_symbol()->get_size_in_bytes() == return_size && return_size == sizeof(void *));
-    addr_t ret_param_addr = actual_return_op.get_symbol()->get_address();
-    thread->m_local_mem->write(ret_param_addr, return_size, &param_buffer, NULL, NULL);
-
+  // copy the buffer address to retval0
+  const operand_info &actual_return_op = pI->operand_lookup(0);  // retval0
+  const symbol *formal_return = target_func->get_return_var();   // void *
+  unsigned int return_size = formal_return->get_size_in_bytes();
+  DEV_RUNTIME_REPORT("cudaGetParameterBufferV2 return value has size of "
+                     << return_size);
+  assert(actual_return_op.is_param_local());
+  assert(actual_return_op.get_symbol()->get_size_in_bytes() == return_size &&
+         return_size == sizeof(void *));
+  addr_t ret_param_addr = actual_return_op.get_symbol()->get_address();
+  thread->m_local_mem->write(ret_param_addr, return_size, &param_buffer, NULL,
+                             NULL);
 }
 
-//Handling device runtime api:
-//cudaError_t cudaLaunchDeviceV2(void *parameterBuffer, cudaStream_t stream)
-void cuda_device_runtime::gpgpusim_cuda_launchDeviceV2(const ptx_instruction * pI, ptx_thread_info * thread, const function_info * target_func) {
-    DEV_RUNTIME_REPORT("Calling cudaLaunchDeviceV2");
+// Handling device runtime api:
+// cudaError_t cudaLaunchDeviceV2(void *parameterBuffer, cudaStream_t stream)
+void cuda_device_runtime::gpgpusim_cuda_launchDeviceV2(
+    const ptx_instruction *pI, ptx_thread_info *thread,
+    const function_info *target_func) {
+  DEV_RUNTIME_REPORT("Calling cudaLaunchDeviceV2");
 
-    unsigned n_return = target_func->has_return();
-    assert(n_return);
-    unsigned n_args = target_func->num_args();
-    assert( n_args == 2 );
+  unsigned n_return = target_func->has_return();
+  assert(n_return);
+  unsigned n_args = target_func->num_args();
+  assert(n_args == 2);
 
-    kernel_info_t * device_grid = NULL;
-    function_info * device_kernel_entry = NULL;
-    void * parameter_buffer;
-    struct CUstream_st * child_stream;
-    device_launch_config_t config;
-    device_launch_operation_t device_launch_op;
+  kernel_info_t *device_grid = NULL;
+  function_info *device_kernel_entry = NULL;
+  void *parameter_buffer;
+  struct CUstream_st *child_stream;
+  device_launch_config_t config;
+  device_launch_operation_t device_launch_op;
 
-    for( unsigned arg=0; arg < n_args; arg ++ ) {
-        const operand_info &actual_param_op = pI->operand_lookup(n_return+1+arg); //param#
-        const symbol *formal_param = target_func->get_arg(arg); //cudaLaunchDeviceV2_param_#
-        unsigned size=formal_param->get_size_in_bytes();
-        assert( formal_param->is_param_local() );
-        assert( actual_param_op.is_param_local() );
-        addr_t from_addr = actual_param_op.get_symbol()->get_address();
+  for (unsigned arg = 0; arg < n_args; arg++) {
+    const operand_info &actual_param_op =
+        pI->operand_lookup(n_return + 1 + arg);  // param#
+    const symbol *formal_param =
+        target_func->get_arg(arg);  // cudaLaunchDeviceV2_param_#
+    unsigned size = formal_param->get_size_in_bytes();
+    assert(formal_param->is_param_local());
+    assert(actual_param_op.is_param_local());
+    addr_t from_addr = actual_param_op.get_symbol()->get_address();
 
-        if(arg == 0) {//paramter buffer for child kernel (in global memory)
-            //get parameter_buffer from the cudaLaunchDeviceV2_param0
-            assert(size == sizeof(void *));
-            thread->m_local_mem->read(from_addr, size, &parameter_buffer);
-            assert((size_t)parameter_buffer >= GLOBAL_HEAP_START);
-            DEV_RUNTIME_REPORT("Parameter buffer locating at global memory " << parameter_buffer);
+    if (arg == 0) {  // paramter buffer for child kernel (in global memory)
+      // get parameter_buffer from the cudaLaunchDeviceV2_param0
+      assert(size == sizeof(void *));
+      thread->m_local_mem->read(from_addr, size, &parameter_buffer);
+      assert((size_t)parameter_buffer >= GLOBAL_HEAP_START);
+      DEV_RUNTIME_REPORT("Parameter buffer locating at global memory "
+                         << parameter_buffer);
 
-            //get child grid info through parameter_buffer address
-            assert(g_cuda_device_launch_param_map.find(parameter_buffer) != g_cuda_device_launch_param_map.end());
-            config = g_cuda_device_launch_param_map[parameter_buffer];
-            //device_grid = op.grid;
-            device_kernel_entry = config.entry;
-            DEV_RUNTIME_REPORT("find device kernel " << device_kernel_entry->get_name());
-	    
-	    //PDOM analysis is done for Parent kernel but not for child kernel.
-	    if (device_kernel_entry->is_pdom_set()) {
-		    printf("GPGPU-Sim PTX: PDOM analysis already done for %s \n", device_kernel_entry->get_name().c_str() );
-	    } else {
-		    printf("GPGPU-Sim PTX: finding reconvergence points for \'%s\'...\n", device_kernel_entry->get_name().c_str() );
-		    /*
-		     * Some of the instructions like printf() gives the gpgpusim the wrong impression that it is a function call.
-		     * As printf() doesnt have a body like functions do, doing pdom analysis for printf() causes a crash.
-		     */
-		    if (device_kernel_entry->get_function_size() >0)
-			    device_kernel_entry->do_pdom();
-		    device_kernel_entry->set_pdom();
-	    }
+      // get child grid info through parameter_buffer address
+      assert(g_cuda_device_launch_param_map.find(parameter_buffer) !=
+             g_cuda_device_launch_param_map.end());
+      config = g_cuda_device_launch_param_map[parameter_buffer];
+      // device_grid = op.grid;
+      device_kernel_entry = config.entry;
+      DEV_RUNTIME_REPORT("find device kernel "
+                         << device_kernel_entry->get_name());
 
-            //copy data in parameter_buffer to device kernel param memory
-            unsigned device_kernel_arg_size = device_kernel_entry->get_args_aligned_size();
-            DEV_RUNTIME_REPORT("device_kernel_arg_size " << device_kernel_arg_size);
-            memory_space *device_kernel_param_mem;
+      // PDOM analysis is done for Parent kernel but not for child kernel.
+      if (device_kernel_entry->is_pdom_set()) {
+        printf("GPGPU-Sim PTX: PDOM analysis already done for %s \n",
+               device_kernel_entry->get_name().c_str());
+      } else {
+        printf("GPGPU-Sim PTX: finding reconvergence points for \'%s\'...\n",
+               device_kernel_entry->get_name().c_str());
+        /*
+         * Some of the instructions like printf() gives the gpgpusim the wrong
+         * impression that it is a function call.
+         * As printf() doesnt have a body like functions do, doing pdom analysis
+         * for printf() causes a crash.
+         */
+        if (device_kernel_entry->get_function_size() > 0)
+          device_kernel_entry->do_pdom();
+        device_kernel_entry->set_pdom();
+      }
 
-            //create child kernel_info_t and index it with parameter_buffer address
-	    gpgpu_t* gpu=thread->get_gpu();
-            device_grid = new kernel_info_t(config.grid_dim, config.block_dim, device_kernel_entry, gpu->getNameArrayMapping(), gpu->getNameInfoMapping());
-            device_grid->launch_cycle = gpu->gpu_sim_cycle + gpu->gpu_tot_sim_cycle;
-            kernel_info_t & parent_grid = thread->get_kernel();
-            DEV_RUNTIME_REPORT("child kernel launched by " << parent_grid.name() << ", cta (" <<
-                thread->get_ctaid().x << ", " << thread->get_ctaid().y << ", " << thread->get_ctaid().z <<
-                "), thread (" << thread->get_tid().x << ", " << thread->get_tid().y << ", " << thread->get_tid().z <<
-                ")");
-            device_grid->set_parent(&parent_grid, thread->get_ctaid(), thread->get_tid());  
-            device_launch_op = device_launch_operation_t(device_grid, NULL);
-            device_kernel_param_mem = device_grid->get_param_memory(); //kernel param
-            size_t param_start_address = 0;
-            //copy in word
-            for(unsigned n = 0; n < device_kernel_arg_size; n += 4) {
-                unsigned int oneword;
-                thread->get_gpu()->get_global_memory()->read((size_t)parameter_buffer + n, 4, &oneword);
-                device_kernel_param_mem->write(param_start_address + n, 4, &oneword, NULL, NULL); 
-            }
-        }
-        else if(arg == 1) { //cudaStream for the child kernel
+      // copy data in parameter_buffer to device kernel param memory
+      unsigned device_kernel_arg_size =
+          device_kernel_entry->get_args_aligned_size();
+      DEV_RUNTIME_REPORT("device_kernel_arg_size " << device_kernel_arg_size);
+      memory_space *device_kernel_param_mem;
 
-            assert(size == sizeof(cudaStream_t));
-            thread->m_local_mem->read(from_addr, size, &child_stream);
-     
-            kernel_info_t & parent_kernel = thread->get_kernel();
-            if(child_stream == 0) { //default stream on device for current CTA
-                child_stream = parent_kernel.get_default_stream_cta(thread->get_ctaid()); 
-                DEV_RUNTIME_REPORT("launching child kernel " << device_grid->get_uid() << 
-                    " to default stream of the cta " << child_stream->get_uid() << ": " << child_stream);
-            }
-            else {
-               assert(parent_kernel.cta_has_stream(thread->get_ctaid(), child_stream)); 
-                DEV_RUNTIME_REPORT("launching child kernel " << device_grid->get_uid() << 
-                " to stream " << child_stream->get_uid() << ": " << child_stream);
-            }
-    
-            device_launch_op.stream = child_stream;
-        }
-        
+      // create child kernel_info_t and index it with parameter_buffer address
+      gpgpu_t *gpu = thread->get_gpu();
+      device_grid = new kernel_info_t(
+          config.grid_dim, config.block_dim, device_kernel_entry,
+          gpu->getNameArrayMapping(), gpu->getNameInfoMapping());
+      device_grid->launch_cycle = gpu->gpu_sim_cycle + gpu->gpu_tot_sim_cycle;
+      kernel_info_t &parent_grid = thread->get_kernel();
+      DEV_RUNTIME_REPORT(
+          "child kernel launched by "
+          << parent_grid.name() << ", cta (" << thread->get_ctaid().x << ", "
+          << thread->get_ctaid().y << ", " << thread->get_ctaid().z
+          << "), thread (" << thread->get_tid().x << ", " << thread->get_tid().y
+          << ", " << thread->get_tid().z << ")");
+      device_grid->set_parent(&parent_grid, thread->get_ctaid(),
+                              thread->get_tid());
+      device_launch_op = device_launch_operation_t(device_grid, NULL);
+      device_kernel_param_mem = device_grid->get_param_memory();  // kernel
+                                                                  // param
+      size_t param_start_address = 0;
+      // copy in word
+      for (unsigned n = 0; n < device_kernel_arg_size; n += 4) {
+        unsigned int oneword;
+        thread->get_gpu()->get_global_memory()->read(
+            (size_t)parameter_buffer + n, 4, &oneword);
+        device_kernel_param_mem->write(param_start_address + n, 4, &oneword,
+                                       NULL, NULL);
+      }
+    } else if (arg == 1) {  // cudaStream for the child kernel
+
+      assert(size == sizeof(cudaStream_t));
+      thread->m_local_mem->read(from_addr, size, &child_stream);
+
+      kernel_info_t &parent_kernel = thread->get_kernel();
+      if (child_stream == 0) {  // default stream on device for current CTA
+        child_stream =
+            parent_kernel.get_default_stream_cta(thread->get_ctaid());
+        DEV_RUNTIME_REPORT("launching child kernel "
+                           << device_grid->get_uid()
+                           << " to default stream of the cta "
+                           << child_stream->get_uid() << ": " << child_stream);
+      } else {
+        assert(parent_kernel.cta_has_stream(thread->get_ctaid(), child_stream));
+        DEV_RUNTIME_REPORT("launching child kernel "
+                           << device_grid->get_uid() << " to stream "
+                           << child_stream->get_uid() << ": " << child_stream);
+      }
+
+      device_launch_op.stream = child_stream;
     }
+  }
 
-  
-    //launch child kernel
-    g_cuda_device_launch_op.push_back(device_launch_op);
-    g_cuda_device_launch_param_map.erase(parameter_buffer);
+  // launch child kernel
+  g_cuda_device_launch_op.push_back(device_launch_op);
+  g_cuda_device_launch_param_map.erase(parameter_buffer);
 
-    //set retval0
-    const operand_info &actual_return_op = pI->operand_lookup(0); //retval0
-    const symbol *formal_return = target_func->get_return_var(); //cudaError_t
-    unsigned int return_size = formal_return->get_size_in_bytes();
-    DEV_RUNTIME_REPORT("cudaLaunchDeviceV2 return value has size of " << return_size);
-    assert(actual_return_op.is_param_local());
-    assert(actual_return_op.get_symbol()->get_size_in_bytes() == return_size 
-        && return_size == sizeof(cudaError_t));
-    cudaError_t error = cudaSuccess;
-    addr_t ret_param_addr = actual_return_op.get_symbol()->get_address();
-    thread->m_local_mem->write(ret_param_addr, return_size, &error, NULL, NULL);
-
+  // set retval0
+  const operand_info &actual_return_op = pI->operand_lookup(0);  // retval0
+  const symbol *formal_return = target_func->get_return_var();   // cudaError_t
+  unsigned int return_size = formal_return->get_size_in_bytes();
+  DEV_RUNTIME_REPORT("cudaLaunchDeviceV2 return value has size of "
+                     << return_size);
+  assert(actual_return_op.is_param_local());
+  assert(actual_return_op.get_symbol()->get_size_in_bytes() == return_size &&
+         return_size == sizeof(cudaError_t));
+  cudaError_t error = cudaSuccess;
+  addr_t ret_param_addr = actual_return_op.get_symbol()->get_address();
+  thread->m_local_mem->write(ret_param_addr, return_size, &error, NULL, NULL);
 }
 
+// Handling device runtime api:
+// cudaError_t cudaStreamCreateWithFlags ( cudaStream_t* pStream, unsigned int
+// flags)
+// flags can only be cudaStreamNonBlocking
+void cuda_device_runtime::gpgpusim_cuda_streamCreateWithFlags(
+    const ptx_instruction *pI, ptx_thread_info *thread,
+    const function_info *target_func) {
+  DEV_RUNTIME_REPORT("Calling cudaStreamCreateWithFlags");
 
-//Handling device runtime api:
-//cudaError_t cudaStreamCreateWithFlags ( cudaStream_t* pStream, unsigned int  flags)
-//flags can only be cudaStreamNonBlocking
-void cuda_device_runtime::gpgpusim_cuda_streamCreateWithFlags(const ptx_instruction * pI, ptx_thread_info * thread, const function_info * target_func) {
-    DEV_RUNTIME_REPORT("Calling cudaStreamCreateWithFlags");
+  unsigned n_return = target_func->has_return();
+  assert(n_return);
+  unsigned n_args = target_func->num_args();
+  assert(n_args == 2);
 
-    unsigned n_return = target_func->has_return();
-    assert(n_return);
-    unsigned n_args = target_func->num_args();
-    assert( n_args == 2 );
+  size_t generic_pStream_addr;
+  addr_t pStream_addr;
+  unsigned int flags;
+  for (unsigned arg = 0; arg < n_args; arg++) {
+    const operand_info &actual_param_op =
+        pI->operand_lookup(n_return + 1 + arg);  // param#
+    const symbol *formal_param =
+        target_func->get_arg(arg);  // cudaStreamCreateWithFlags_param_#
+    unsigned size = formal_param->get_size_in_bytes();
+    assert(formal_param->is_param_local());
+    assert(actual_param_op.is_param_local());
+    addr_t from_addr = actual_param_op.get_symbol()->get_address();
 
-    size_t generic_pStream_addr;
-    addr_t pStream_addr;
-    unsigned int flags;
-    for( unsigned arg=0; arg < n_args; arg ++ ) {
-        const operand_info &actual_param_op = pI->operand_lookup(n_return+1+arg); //param#
-        const symbol *formal_param = target_func->get_arg(arg); //cudaStreamCreateWithFlags_param_#
-        unsigned size=formal_param->get_size_in_bytes();
-        assert( formal_param->is_param_local() );
-        assert( actual_param_op.is_param_local() );
-        addr_t from_addr = actual_param_op.get_symbol()->get_address();
+    if (arg == 0) {  // cudaStream_t * pStream, address of cudaStream_t
+      assert(size == sizeof(cudaStream_t *));
+      thread->m_local_mem->read(from_addr, size, &generic_pStream_addr);
 
-        if(arg == 0) {//cudaStream_t * pStream, address of cudaStream_t
-            assert(size == sizeof(cudaStream_t *));
-            thread->m_local_mem->read(from_addr, size, &generic_pStream_addr);
-            
-            //pStream should be non-zero address in local memory
-            pStream_addr = generic_to_local(thread->get_hw_sid(), thread->get_hw_tid(), generic_pStream_addr);
+      // pStream should be non-zero address in local memory
+      pStream_addr = generic_to_local(
+          thread->get_hw_sid(), thread->get_hw_tid(), generic_pStream_addr);
 
-            DEV_RUNTIME_REPORT("pStream locating at local memory " << pStream_addr);
-        }
-        else if(arg == 1) { //unsigned int flags, should be cudaStreamNonBlocking
-            assert(size == sizeof(unsigned int));
-            thread->m_local_mem->read(from_addr, size, &flags);
-            assert(flags == cudaStreamNonBlocking);
-        }
+      DEV_RUNTIME_REPORT("pStream locating at local memory " << pStream_addr);
+    } else if (arg ==
+               1) {  // unsigned int flags, should be cudaStreamNonBlocking
+      assert(size == sizeof(unsigned int));
+      thread->m_local_mem->read(from_addr, size, &flags);
+      assert(flags == cudaStreamNonBlocking);
     }
+  }
 
-    //create stream and write back to param0
-    CUstream_st * stream = thread->get_kernel().create_stream_cta(thread->get_ctaid());
-    DEV_RUNTIME_REPORT("Create stream " << stream->get_uid() << ": " << stream);
-    thread->m_local_mem->write(pStream_addr, sizeof(cudaStream_t), &stream, NULL, NULL);
- 
-    //set retval0
-    const operand_info &actual_return_op = pI->operand_lookup(0); //retval0
-    const symbol *formal_return = target_func->get_return_var(); //cudaError_t
-    unsigned int return_size = formal_return->get_size_in_bytes();
-    DEV_RUNTIME_REPORT("cudaStreamCreateWithFlags return value has size of " << return_size);
-    assert(actual_return_op.is_param_local());
-    assert(actual_return_op.get_symbol()->get_size_in_bytes() == return_size 
-        && return_size == sizeof(cudaError_t));
-    cudaError_t error = cudaSuccess;
-    addr_t ret_param_addr = actual_return_op.get_symbol()->get_address();
-    thread->m_local_mem->write(ret_param_addr, return_size, &error, NULL, NULL);
+  // create stream and write back to param0
+  CUstream_st *stream =
+      thread->get_kernel().create_stream_cta(thread->get_ctaid());
+  DEV_RUNTIME_REPORT("Create stream " << stream->get_uid() << ": " << stream);
+  thread->m_local_mem->write(pStream_addr, sizeof(cudaStream_t), &stream, NULL,
+                             NULL);
 
+  // set retval0
+  const operand_info &actual_return_op = pI->operand_lookup(0);  // retval0
+  const symbol *formal_return = target_func->get_return_var();   // cudaError_t
+  unsigned int return_size = formal_return->get_size_in_bytes();
+  DEV_RUNTIME_REPORT("cudaStreamCreateWithFlags return value has size of "
+                     << return_size);
+  assert(actual_return_op.is_param_local());
+  assert(actual_return_op.get_symbol()->get_size_in_bytes() == return_size &&
+         return_size == sizeof(cudaError_t));
+  cudaError_t error = cudaSuccess;
+  addr_t ret_param_addr = actual_return_op.get_symbol()->get_address();
+  thread->m_local_mem->write(ret_param_addr, return_size, &error, NULL, NULL);
 }
-
 
 void cuda_device_runtime::launch_one_device_kernel() {
-    if(!g_cuda_device_launch_op.empty()) {
-        device_launch_operation_t &op = g_cuda_device_launch_op.front();
+  if (!g_cuda_device_launch_op.empty()) {
+    device_launch_operation_t &op = g_cuda_device_launch_op.front();
 
-        stream_operation stream_op = stream_operation(op.grid, gpgpu_ctx->func_sim->g_ptx_sim_mode, op.stream);
-        gpgpu_ctx->the_gpgpusim->g_stream_manager->push(stream_op);
-        g_cuda_device_launch_op.pop_front();
-    }
+    stream_operation stream_op = stream_operation(
+        op.grid, gpgpu_ctx->func_sim->g_ptx_sim_mode, op.stream);
+    gpgpu_ctx->the_gpgpusim->g_stream_manager->push(stream_op);
+    g_cuda_device_launch_op.pop_front();
+  }
 }
 
 void cuda_device_runtime::launch_all_device_kernels() {
-    while(!g_cuda_device_launch_op.empty()) {
-        launch_one_device_kernel();
-    }
+  while (!g_cuda_device_launch_op.empty()) {
+    launch_one_device_kernel();
+  }
 }
 #endif

--- a/src/cuda-sim/cuda_device_runtime.cc
+++ b/src/cuda-sim/cuda_device_runtime.cc
@@ -1,297 +1,327 @@
-//Jin: cuda_device_runtime.cc
-//Defines CUDA device runtime APIs for CDP support
-
+// Jin: cuda_device_runtime.cc
+// Defines CUDA device runtime APIs for CDP support
 
 #include <iostream>
 #include <map>
-
-
 
 #if (CUDART_VERSION >= 5000)
 #define __CUDA_RUNTIME_API_H__
 
 #include <builtin_types.h>
 #include <driver_types.h>
-#include "../gpgpu-sim/gpu-sim.h"
-#include "cuda-sim.h"
-#include "ptx_ir.h"
-#include "../stream_manager.h"
-#include "../gpgpusim_entrypoint.h"
-#include "cuda_device_runtime.h"
 #include "../../libcuda/gpgpu_context.h"
+#include "../gpgpu-sim/gpu-sim.h"
+#include "../gpgpusim_entrypoint.h"
+#include "../stream_manager.h"
+#include "cuda-sim.h"
+#include "cuda_device_runtime.h"
+#include "ptx_ir.h"
 
-#define DEV_RUNTIME_REPORT(a) \
-   if( g_debug_execution ) { \
-      std::cout << __FILE__ << ", " << __LINE__ << ": " << a << "\n"; \
-      std::cout.flush(); \
-   }
+#define DEV_RUNTIME_REPORT(a)                                       \
+  if (g_debug_execution) {                                          \
+    std::cout << __FILE__ << ", " << __LINE__ << ": " << a << "\n"; \
+    std::cout.flush();                                              \
+  }
 
+// Handling device runtime api:
+// void * cudaGetParameterBufferV2(void *func, dim3 gridDimension, dim3
+// blockDimension, unsigned int sharedMemSize)
+void cuda_device_runtime::gpgpusim_cuda_getParameterBufferV2(
+    const ptx_instruction *pI, ptx_thread_info *thread,
+    const function_info *target_func) {
+  DEV_RUNTIME_REPORT("Calling cudaGetParameterBufferV2");
 
+  unsigned n_return = target_func->has_return();
+  assert(n_return);
+  unsigned n_args = target_func->num_args();
+  assert(n_args == 4);
 
-//Handling device runtime api:
-//void * cudaGetParameterBufferV2(void *func, dim3 gridDimension, dim3 blockDimension, unsigned int sharedMemSize)
-void cuda_device_runtime::gpgpusim_cuda_getParameterBufferV2(const ptx_instruction * pI, ptx_thread_info * thread, const function_info * target_func)
-{
-    DEV_RUNTIME_REPORT("Calling cudaGetParameterBufferV2");
-      
-    unsigned n_return = target_func->has_return();
-    assert(n_return);
-    unsigned n_args = target_func->num_args();
-    assert( n_args == 4 );
+  function_info *child_kernel_entry;
+  struct dim3 grid_dim, block_dim;
+  unsigned int shared_mem;
 
-    function_info * child_kernel_entry;
-    struct dim3 grid_dim, block_dim;
-    unsigned int shared_mem;
+  for (unsigned arg = 0; arg < n_args; arg++) {
+    const operand_info &actual_param_op =
+        pI->operand_lookup(n_return + 1 + arg);  // param#
+    const symbol *formal_param =
+        target_func->get_arg(arg);  // cudaGetParameterBufferV2_param_#
+    unsigned size = formal_param->get_size_in_bytes();
+    assert(formal_param->is_param_local());
+    assert(actual_param_op.is_param_local());
+    addr_t from_addr = actual_param_op.get_symbol()->get_address();
 
-    for( unsigned arg=0; arg < n_args; arg ++ ) {
-        const operand_info &actual_param_op = pI->operand_lookup(n_return+1+arg); //param#
-        const symbol *formal_param = target_func->get_arg(arg); //cudaGetParameterBufferV2_param_#
-        unsigned size=formal_param->get_size_in_bytes();
-        assert( formal_param->is_param_local() );
-        assert( actual_param_op.is_param_local() );
-        addr_t from_addr = actual_param_op.get_symbol()->get_address();
-
-        if(arg == 0) {//function_info* for the child kernel
-            unsigned long long buf;
-            assert(size == sizeof(function_info *));
-            thread->m_local_mem->read(from_addr, size, &buf);
-            child_kernel_entry = (function_info *)buf;
-            assert(child_kernel_entry);
-            DEV_RUNTIME_REPORT("child kernel name " << child_kernel_entry->get_name());
-        }
-        else if(arg == 1) { //dim3 grid_dim for the child kernel
-            assert(size == sizeof(struct dim3));
-            thread->m_local_mem->read(from_addr, size, & grid_dim);
-            DEV_RUNTIME_REPORT("grid (" << grid_dim.x << ", " << grid_dim.y << ", " << grid_dim.z << ")");
-        }
-        else if(arg == 2) { //dim3 block_dim for the child kernel
-            assert(size == sizeof(struct dim3));
-            thread->m_local_mem->read(from_addr, size, & block_dim);
-            DEV_RUNTIME_REPORT("block (" << block_dim.x << ", " << block_dim.y << ", " << block_dim.z << ")");
-        }
-        else if(arg == 3) { //unsigned int shared_mem
-            assert(size == sizeof(unsigned int));
-            thread->m_local_mem->read(from_addr, size, & shared_mem);
-            DEV_RUNTIME_REPORT("shared memory " << shared_mem);
-        }
+    if (arg == 0) {  // function_info* for the child kernel
+      unsigned long long buf;
+      assert(size == sizeof(function_info *));
+      thread->m_local_mem->read(from_addr, size, &buf);
+      child_kernel_entry = (function_info *)buf;
+      assert(child_kernel_entry);
+      DEV_RUNTIME_REPORT("child kernel name "
+                         << child_kernel_entry->get_name());
+    } else if (arg == 1) {  // dim3 grid_dim for the child kernel
+      assert(size == sizeof(struct dim3));
+      thread->m_local_mem->read(from_addr, size, &grid_dim);
+      DEV_RUNTIME_REPORT("grid (" << grid_dim.x << ", " << grid_dim.y << ", "
+                                  << grid_dim.z << ")");
+    } else if (arg == 2) {  // dim3 block_dim for the child kernel
+      assert(size == sizeof(struct dim3));
+      thread->m_local_mem->read(from_addr, size, &block_dim);
+      DEV_RUNTIME_REPORT("block (" << block_dim.x << ", " << block_dim.y << ", "
+                                   << block_dim.z << ")");
+    } else if (arg == 3) {  // unsigned int shared_mem
+      assert(size == sizeof(unsigned int));
+      thread->m_local_mem->read(from_addr, size, &shared_mem);
+      DEV_RUNTIME_REPORT("shared memory " << shared_mem);
     }
+  }
 
-    //get total child kernel argument size and malloc buffer in global memory
-    unsigned child_kernel_arg_size = child_kernel_entry->get_args_aligned_size();
-    void * param_buffer = thread->get_gpu()->gpu_malloc(child_kernel_arg_size);
-    g_total_param_size += ((child_kernel_arg_size + 255) / 256 * 256);
-    DEV_RUNTIME_REPORT("child kernel arg size total " << child_kernel_arg_size << ", parameter buffer allocated at " << param_buffer);
-    if(g_total_param_size > g_max_total_param_size)
-        g_max_total_param_size = g_total_param_size;
+  // get total child kernel argument size and malloc buffer in global memory
+  unsigned child_kernel_arg_size = child_kernel_entry->get_args_aligned_size();
+  void *param_buffer = thread->get_gpu()->gpu_malloc(child_kernel_arg_size);
+  g_total_param_size += ((child_kernel_arg_size + 255) / 256 * 256);
+  DEV_RUNTIME_REPORT("child kernel arg size total "
+                     << child_kernel_arg_size
+                     << ", parameter buffer allocated at " << param_buffer);
+  if (g_total_param_size > g_max_total_param_size)
+    g_max_total_param_size = g_total_param_size;
 
-    //store param buffer address and launch config
-    device_launch_config_t device_launch_config(grid_dim, block_dim, shared_mem, child_kernel_entry);
-    assert(g_cuda_device_launch_param_map.find(param_buffer) == g_cuda_device_launch_param_map.end());
-    g_cuda_device_launch_param_map[param_buffer] = device_launch_config;
+  // store param buffer address and launch config
+  device_launch_config_t device_launch_config(grid_dim, block_dim, shared_mem,
+                                              child_kernel_entry);
+  assert(g_cuda_device_launch_param_map.find(param_buffer) ==
+         g_cuda_device_launch_param_map.end());
+  g_cuda_device_launch_param_map[param_buffer] = device_launch_config;
 
-    //copy the buffer address to retval0
-    const operand_info &actual_return_op = pI->operand_lookup(0); //retval0
-    const symbol *formal_return = target_func->get_return_var(); //void *
-    unsigned int return_size = formal_return->get_size_in_bytes();
-    DEV_RUNTIME_REPORT("cudaGetParameterBufferV2 return value has size of " << return_size);
-    assert(actual_return_op.is_param_local());
-    assert(actual_return_op.get_symbol()->get_size_in_bytes() == return_size && return_size == sizeof(void *));
-    addr_t ret_param_addr = actual_return_op.get_symbol()->get_address();
-    thread->m_local_mem->write(ret_param_addr, return_size, &param_buffer, NULL, NULL);
-
+  // copy the buffer address to retval0
+  const operand_info &actual_return_op = pI->operand_lookup(0);  // retval0
+  const symbol *formal_return = target_func->get_return_var();   // void *
+  unsigned int return_size = formal_return->get_size_in_bytes();
+  DEV_RUNTIME_REPORT("cudaGetParameterBufferV2 return value has size of "
+                     << return_size);
+  assert(actual_return_op.is_param_local());
+  assert(actual_return_op.get_symbol()->get_size_in_bytes() == return_size &&
+         return_size == sizeof(void *));
+  addr_t ret_param_addr = actual_return_op.get_symbol()->get_address();
+  thread->m_local_mem->write(ret_param_addr, return_size, &param_buffer, NULL,
+                             NULL);
 }
 
-//Handling device runtime api:
-//cudaError_t cudaLaunchDeviceV2(void *parameterBuffer, cudaStream_t stream)
-void cuda_device_runtime::gpgpusim_cuda_launchDeviceV2(const ptx_instruction * pI, ptx_thread_info * thread, const function_info * target_func) {
-    DEV_RUNTIME_REPORT("Calling cudaLaunchDeviceV2");
+// Handling device runtime api:
+// cudaError_t cudaLaunchDeviceV2(void *parameterBuffer, cudaStream_t stream)
+void cuda_device_runtime::gpgpusim_cuda_launchDeviceV2(
+    const ptx_instruction *pI, ptx_thread_info *thread,
+    const function_info *target_func) {
+  DEV_RUNTIME_REPORT("Calling cudaLaunchDeviceV2");
 
-    unsigned n_return = target_func->has_return();
-    assert(n_return);
-    unsigned n_args = target_func->num_args();
-    assert( n_args == 2 );
+  unsigned n_return = target_func->has_return();
+  assert(n_return);
+  unsigned n_args = target_func->num_args();
+  assert(n_args == 2);
 
-    kernel_info_t * device_grid = NULL;
-    function_info * device_kernel_entry = NULL;
-    void * parameter_buffer;
-    struct CUstream_st * child_stream;
-    device_launch_config_t config;
-    device_launch_operation_t device_launch_op;
+  kernel_info_t *device_grid = NULL;
+  function_info *device_kernel_entry = NULL;
+  void *parameter_buffer;
+  struct CUstream_st *child_stream;
+  device_launch_config_t config;
+  device_launch_operation_t device_launch_op;
 
-    for( unsigned arg=0; arg < n_args; arg ++ ) {
-        const operand_info &actual_param_op = pI->operand_lookup(n_return+1+arg); //param#
-        const symbol *formal_param = target_func->get_arg(arg); //cudaLaunchDeviceV2_param_#
-        unsigned size=formal_param->get_size_in_bytes();
-        assert( formal_param->is_param_local() );
-        assert( actual_param_op.is_param_local() );
-        addr_t from_addr = actual_param_op.get_symbol()->get_address();
+  for (unsigned arg = 0; arg < n_args; arg++) {
+    const operand_info &actual_param_op =
+        pI->operand_lookup(n_return + 1 + arg);  // param#
+    const symbol *formal_param =
+        target_func->get_arg(arg);  // cudaLaunchDeviceV2_param_#
+    unsigned size = formal_param->get_size_in_bytes();
+    assert(formal_param->is_param_local());
+    assert(actual_param_op.is_param_local());
+    addr_t from_addr = actual_param_op.get_symbol()->get_address();
 
-        if(arg == 0) {//paramter buffer for child kernel (in global memory)
-            //get parameter_buffer from the cudaLaunchDeviceV2_param0
-            assert(size == sizeof(void *));
-            thread->m_local_mem->read(from_addr, size, &parameter_buffer);
-            assert((size_t)parameter_buffer >= GLOBAL_HEAP_START);
-            DEV_RUNTIME_REPORT("Parameter buffer locating at global memory " << parameter_buffer);
+    if (arg == 0) {  // paramter buffer for child kernel (in global memory)
+      // get parameter_buffer from the cudaLaunchDeviceV2_param0
+      assert(size == sizeof(void *));
+      thread->m_local_mem->read(from_addr, size, &parameter_buffer);
+      assert((size_t)parameter_buffer >= GLOBAL_HEAP_START);
+      DEV_RUNTIME_REPORT("Parameter buffer locating at global memory "
+                         << parameter_buffer);
 
-            //get child grid info through parameter_buffer address
-            assert(g_cuda_device_launch_param_map.find(parameter_buffer) != g_cuda_device_launch_param_map.end());
-            config = g_cuda_device_launch_param_map[parameter_buffer];
-            //device_grid = op.grid;
-            device_kernel_entry = config.entry;
-            DEV_RUNTIME_REPORT("find device kernel " << device_kernel_entry->get_name());
-	    
-	    //PDOM analysis is done for Parent kernel but not for child kernel.
-	    if (device_kernel_entry->is_pdom_set()) {
-		    printf("GPGPU-Sim PTX: PDOM analysis already done for %s \n", device_kernel_entry->get_name().c_str() );
-	    } else {
-		    printf("GPGPU-Sim PTX: finding reconvergence points for \'%s\'...\n", device_kernel_entry->get_name().c_str() );
-		    /*
-		     * Some of the instructions like printf() gives the gpgpusim the wrong impression that it is a function call.
-		     * As printf() doesnt have a body like functions do, doing pdom analysis for printf() causes a crash.
-		     */
-		    if (device_kernel_entry->get_function_size() >0)
-			    device_kernel_entry->do_pdom();
-		    device_kernel_entry->set_pdom();
-	    }
+      // get child grid info through parameter_buffer address
+      assert(g_cuda_device_launch_param_map.find(parameter_buffer) !=
+             g_cuda_device_launch_param_map.end());
+      config = g_cuda_device_launch_param_map[parameter_buffer];
+      // device_grid = op.grid;
+      device_kernel_entry = config.entry;
+      DEV_RUNTIME_REPORT("find device kernel "
+                         << device_kernel_entry->get_name());
 
-            //copy data in parameter_buffer to device kernel param memory
-            unsigned device_kernel_arg_size = device_kernel_entry->get_args_aligned_size();
-            DEV_RUNTIME_REPORT("device_kernel_arg_size " << device_kernel_arg_size);
-            memory_space *device_kernel_param_mem;
+      // PDOM analysis is done for Parent kernel but not for child kernel.
+      if (device_kernel_entry->is_pdom_set()) {
+        printf("GPGPU-Sim PTX: PDOM analysis already done for %s \n",
+               device_kernel_entry->get_name().c_str());
+      } else {
+        printf("GPGPU-Sim PTX: finding reconvergence points for \'%s\'...\n",
+               device_kernel_entry->get_name().c_str());
+        /*
+         * Some of the instructions like printf() gives the gpgpusim the wrong
+         * impression that it is a function call. As printf() doesnt have a body
+         * like functions do, doing pdom analysis for printf() causes a crash.
+         */
+        if (device_kernel_entry->get_function_size() > 0)
+          device_kernel_entry->do_pdom();
+        device_kernel_entry->set_pdom();
+      }
 
-            //create child kernel_info_t and index it with parameter_buffer address
-	    gpgpu_t* gpu=thread->get_gpu();
-            device_grid = new kernel_info_t(config.grid_dim, config.block_dim, device_kernel_entry, gpu->getNameArrayMapping(), gpu->getNameInfoMapping());
-            device_grid->launch_cycle = gpu->gpu_sim_cycle + gpu->gpu_tot_sim_cycle;
-            kernel_info_t & parent_grid = thread->get_kernel();
-            DEV_RUNTIME_REPORT("child kernel launched by " << parent_grid.name() << ", cta (" <<
-                thread->get_ctaid().x << ", " << thread->get_ctaid().y << ", " << thread->get_ctaid().z <<
-                "), thread (" << thread->get_tid().x << ", " << thread->get_tid().y << ", " << thread->get_tid().z <<
-                ")");
-            device_grid->set_parent(&parent_grid, thread->get_ctaid(), thread->get_tid());  
-            device_launch_op = device_launch_operation_t(device_grid, NULL);
-            device_kernel_param_mem = device_grid->get_param_memory(); //kernel param
-            size_t param_start_address = 0;
-            //copy in word
-            for(unsigned n = 0; n < device_kernel_arg_size; n += 4) {
-                unsigned int oneword;
-                thread->get_gpu()->get_global_memory()->read((size_t)parameter_buffer + n, 4, &oneword);
-                device_kernel_param_mem->write(param_start_address + n, 4, &oneword, NULL, NULL); 
-            }
-        }
-        else if(arg == 1) { //cudaStream for the child kernel
+      // copy data in parameter_buffer to device kernel param memory
+      unsigned device_kernel_arg_size =
+          device_kernel_entry->get_args_aligned_size();
+      DEV_RUNTIME_REPORT("device_kernel_arg_size " << device_kernel_arg_size);
+      memory_space *device_kernel_param_mem;
 
-            assert(size == sizeof(cudaStream_t));
-            thread->m_local_mem->read(from_addr, size, &child_stream);
-     
-            kernel_info_t & parent_kernel = thread->get_kernel();
-            if(child_stream == 0) { //default stream on device for current CTA
-                child_stream = parent_kernel.get_default_stream_cta(thread->get_ctaid()); 
-                DEV_RUNTIME_REPORT("launching child kernel " << device_grid->get_uid() << 
-                    " to default stream of the cta " << child_stream->get_uid() << ": " << child_stream);
-            }
-            else {
-               assert(parent_kernel.cta_has_stream(thread->get_ctaid(), child_stream)); 
-                DEV_RUNTIME_REPORT("launching child kernel " << device_grid->get_uid() << 
-                " to stream " << child_stream->get_uid() << ": " << child_stream);
-            }
-    
-            device_launch_op.stream = child_stream;
-        }
-        
+      // create child kernel_info_t and index it with parameter_buffer address
+      gpgpu_t *gpu = thread->get_gpu();
+      device_grid = new kernel_info_t(
+          config.grid_dim, config.block_dim, device_kernel_entry,
+          gpu->getNameArrayMapping(), gpu->getNameInfoMapping());
+      device_grid->launch_cycle = gpu->gpu_sim_cycle + gpu->gpu_tot_sim_cycle;
+      kernel_info_t &parent_grid = thread->get_kernel();
+      DEV_RUNTIME_REPORT(
+          "child kernel launched by "
+          << parent_grid.name() << ", cta (" << thread->get_ctaid().x << ", "
+          << thread->get_ctaid().y << ", " << thread->get_ctaid().z
+          << "), thread (" << thread->get_tid().x << ", " << thread->get_tid().y
+          << ", " << thread->get_tid().z << ")");
+      device_grid->set_parent(&parent_grid, thread->get_ctaid(),
+                              thread->get_tid());
+      device_launch_op = device_launch_operation_t(device_grid, NULL);
+      device_kernel_param_mem = device_grid->get_param_memory();  // kernel
+                                                                  // param
+      size_t param_start_address = 0;
+      // copy in word
+      for (unsigned n = 0; n < device_kernel_arg_size; n += 4) {
+        unsigned int oneword;
+        thread->get_gpu()->get_global_memory()->read(
+            (size_t)parameter_buffer + n, 4, &oneword);
+        device_kernel_param_mem->write(param_start_address + n, 4, &oneword,
+                                       NULL, NULL);
+      }
+    } else if (arg == 1) {  // cudaStream for the child kernel
+
+      assert(size == sizeof(cudaStream_t));
+      thread->m_local_mem->read(from_addr, size, &child_stream);
+
+      kernel_info_t &parent_kernel = thread->get_kernel();
+      if (child_stream == 0) {  // default stream on device for current CTA
+        child_stream =
+            parent_kernel.get_default_stream_cta(thread->get_ctaid());
+        DEV_RUNTIME_REPORT("launching child kernel "
+                           << device_grid->get_uid()
+                           << " to default stream of the cta "
+                           << child_stream->get_uid() << ": " << child_stream);
+      } else {
+        assert(parent_kernel.cta_has_stream(thread->get_ctaid(), child_stream));
+        DEV_RUNTIME_REPORT("launching child kernel "
+                           << device_grid->get_uid() << " to stream "
+                           << child_stream->get_uid() << ": " << child_stream);
+      }
+
+      device_launch_op.stream = child_stream;
     }
+  }
 
-  
-    //launch child kernel
-    g_cuda_device_launch_op.push_back(device_launch_op);
-    g_cuda_device_launch_param_map.erase(parameter_buffer);
+  // launch child kernel
+  g_cuda_device_launch_op.push_back(device_launch_op);
+  g_cuda_device_launch_param_map.erase(parameter_buffer);
 
-    //set retval0
-    const operand_info &actual_return_op = pI->operand_lookup(0); //retval0
-    const symbol *formal_return = target_func->get_return_var(); //cudaError_t
-    unsigned int return_size = formal_return->get_size_in_bytes();
-    DEV_RUNTIME_REPORT("cudaLaunchDeviceV2 return value has size of " << return_size);
-    assert(actual_return_op.is_param_local());
-    assert(actual_return_op.get_symbol()->get_size_in_bytes() == return_size 
-        && return_size == sizeof(cudaError_t));
-    cudaError_t error = cudaSuccess;
-    addr_t ret_param_addr = actual_return_op.get_symbol()->get_address();
-    thread->m_local_mem->write(ret_param_addr, return_size, &error, NULL, NULL);
-
+  // set retval0
+  const operand_info &actual_return_op = pI->operand_lookup(0);  // retval0
+  const symbol *formal_return = target_func->get_return_var();   // cudaError_t
+  unsigned int return_size = formal_return->get_size_in_bytes();
+  DEV_RUNTIME_REPORT("cudaLaunchDeviceV2 return value has size of "
+                     << return_size);
+  assert(actual_return_op.is_param_local());
+  assert(actual_return_op.get_symbol()->get_size_in_bytes() == return_size &&
+         return_size == sizeof(cudaError_t));
+  cudaError_t error = cudaSuccess;
+  addr_t ret_param_addr = actual_return_op.get_symbol()->get_address();
+  thread->m_local_mem->write(ret_param_addr, return_size, &error, NULL, NULL);
 }
 
+// Handling device runtime api:
+// cudaError_t cudaStreamCreateWithFlags ( cudaStream_t* pStream, unsigned int
+// flags) flags can only be cudaStreamNonBlocking
+void cuda_device_runtime::gpgpusim_cuda_streamCreateWithFlags(
+    const ptx_instruction *pI, ptx_thread_info *thread,
+    const function_info *target_func) {
+  DEV_RUNTIME_REPORT("Calling cudaStreamCreateWithFlags");
 
-//Handling device runtime api:
-//cudaError_t cudaStreamCreateWithFlags ( cudaStream_t* pStream, unsigned int  flags)
-//flags can only be cudaStreamNonBlocking
-void cuda_device_runtime::gpgpusim_cuda_streamCreateWithFlags(const ptx_instruction * pI, ptx_thread_info * thread, const function_info * target_func) {
-    DEV_RUNTIME_REPORT("Calling cudaStreamCreateWithFlags");
+  unsigned n_return = target_func->has_return();
+  assert(n_return);
+  unsigned n_args = target_func->num_args();
+  assert(n_args == 2);
 
-    unsigned n_return = target_func->has_return();
-    assert(n_return);
-    unsigned n_args = target_func->num_args();
-    assert( n_args == 2 );
+  size_t generic_pStream_addr;
+  addr_t pStream_addr;
+  unsigned int flags;
+  for (unsigned arg = 0; arg < n_args; arg++) {
+    const operand_info &actual_param_op =
+        pI->operand_lookup(n_return + 1 + arg);  // param#
+    const symbol *formal_param =
+        target_func->get_arg(arg);  // cudaStreamCreateWithFlags_param_#
+    unsigned size = formal_param->get_size_in_bytes();
+    assert(formal_param->is_param_local());
+    assert(actual_param_op.is_param_local());
+    addr_t from_addr = actual_param_op.get_symbol()->get_address();
 
-    size_t generic_pStream_addr;
-    addr_t pStream_addr;
-    unsigned int flags;
-    for( unsigned arg=0; arg < n_args; arg ++ ) {
-        const operand_info &actual_param_op = pI->operand_lookup(n_return+1+arg); //param#
-        const symbol *formal_param = target_func->get_arg(arg); //cudaStreamCreateWithFlags_param_#
-        unsigned size=formal_param->get_size_in_bytes();
-        assert( formal_param->is_param_local() );
-        assert( actual_param_op.is_param_local() );
-        addr_t from_addr = actual_param_op.get_symbol()->get_address();
+    if (arg == 0) {  // cudaStream_t * pStream, address of cudaStream_t
+      assert(size == sizeof(cudaStream_t *));
+      thread->m_local_mem->read(from_addr, size, &generic_pStream_addr);
 
-        if(arg == 0) {//cudaStream_t * pStream, address of cudaStream_t
-            assert(size == sizeof(cudaStream_t *));
-            thread->m_local_mem->read(from_addr, size, &generic_pStream_addr);
-            
-            //pStream should be non-zero address in local memory
-            pStream_addr = generic_to_local(thread->get_hw_sid(), thread->get_hw_tid(), generic_pStream_addr);
+      // pStream should be non-zero address in local memory
+      pStream_addr = generic_to_local(
+          thread->get_hw_sid(), thread->get_hw_tid(), generic_pStream_addr);
 
-            DEV_RUNTIME_REPORT("pStream locating at local memory " << pStream_addr);
-        }
-        else if(arg == 1) { //unsigned int flags, should be cudaStreamNonBlocking
-            assert(size == sizeof(unsigned int));
-            thread->m_local_mem->read(from_addr, size, &flags);
-            assert(flags == cudaStreamNonBlocking);
-        }
+      DEV_RUNTIME_REPORT("pStream locating at local memory " << pStream_addr);
+    } else if (arg ==
+               1) {  // unsigned int flags, should be cudaStreamNonBlocking
+      assert(size == sizeof(unsigned int));
+      thread->m_local_mem->read(from_addr, size, &flags);
+      assert(flags == cudaStreamNonBlocking);
     }
+  }
 
-    //create stream and write back to param0
-    CUstream_st * stream = thread->get_kernel().create_stream_cta(thread->get_ctaid());
-    DEV_RUNTIME_REPORT("Create stream " << stream->get_uid() << ": " << stream);
-    thread->m_local_mem->write(pStream_addr, sizeof(cudaStream_t), &stream, NULL, NULL);
- 
-    //set retval0
-    const operand_info &actual_return_op = pI->operand_lookup(0); //retval0
-    const symbol *formal_return = target_func->get_return_var(); //cudaError_t
-    unsigned int return_size = formal_return->get_size_in_bytes();
-    DEV_RUNTIME_REPORT("cudaStreamCreateWithFlags return value has size of " << return_size);
-    assert(actual_return_op.is_param_local());
-    assert(actual_return_op.get_symbol()->get_size_in_bytes() == return_size 
-        && return_size == sizeof(cudaError_t));
-    cudaError_t error = cudaSuccess;
-    addr_t ret_param_addr = actual_return_op.get_symbol()->get_address();
-    thread->m_local_mem->write(ret_param_addr, return_size, &error, NULL, NULL);
+  // create stream and write back to param0
+  CUstream_st *stream =
+      thread->get_kernel().create_stream_cta(thread->get_ctaid());
+  DEV_RUNTIME_REPORT("Create stream " << stream->get_uid() << ": " << stream);
+  thread->m_local_mem->write(pStream_addr, sizeof(cudaStream_t), &stream, NULL,
+                             NULL);
 
+  // set retval0
+  const operand_info &actual_return_op = pI->operand_lookup(0);  // retval0
+  const symbol *formal_return = target_func->get_return_var();   // cudaError_t
+  unsigned int return_size = formal_return->get_size_in_bytes();
+  DEV_RUNTIME_REPORT("cudaStreamCreateWithFlags return value has size of "
+                     << return_size);
+  assert(actual_return_op.is_param_local());
+  assert(actual_return_op.get_symbol()->get_size_in_bytes() == return_size &&
+         return_size == sizeof(cudaError_t));
+  cudaError_t error = cudaSuccess;
+  addr_t ret_param_addr = actual_return_op.get_symbol()->get_address();
+  thread->m_local_mem->write(ret_param_addr, return_size, &error, NULL, NULL);
 }
-
 
 void cuda_device_runtime::launch_one_device_kernel() {
-    if(!g_cuda_device_launch_op.empty()) {
-        device_launch_operation_t &op = g_cuda_device_launch_op.front();
+  if (!g_cuda_device_launch_op.empty()) {
+    device_launch_operation_t &op = g_cuda_device_launch_op.front();
 
-        stream_operation stream_op = stream_operation(op.grid, gpgpu_ctx->func_sim->g_ptx_sim_mode, op.stream);
-        gpgpu_ctx->the_gpgpusim->g_stream_manager->push(stream_op);
-        g_cuda_device_launch_op.pop_front();
-    }
+    stream_operation stream_op = stream_operation(
+        op.grid, gpgpu_ctx->func_sim->g_ptx_sim_mode, op.stream);
+    gpgpu_ctx->the_gpgpusim->g_stream_manager->push(stream_op);
+    g_cuda_device_launch_op.pop_front();
+  }
 }
 
 void cuda_device_runtime::launch_all_device_kernels() {
-    while(!g_cuda_device_launch_op.empty()) {
-        launch_one_device_kernel();
-    }
+  while (!g_cuda_device_launch_op.empty()) {
+    launch_one_device_kernel();
+  }
 }
 #endif

--- a/src/cuda-sim/cuda_device_runtime.cc
+++ b/src/cuda-sim/cuda_device_runtime.cc
@@ -1,329 +1,297 @@
-// Jin: cuda_device_runtime.cc
-// Defines CUDA device runtime APIs for CDP support
+//Jin: cuda_device_runtime.cc
+//Defines CUDA device runtime APIs for CDP support
+
 
 #include <iostream>
 #include <map>
+
+
 
 #if (CUDART_VERSION >= 5000)
 #define __CUDA_RUNTIME_API_H__
 
 #include <builtin_types.h>
 #include <driver_types.h>
-#include "../../libcuda/gpgpu_context.h"
 #include "../gpgpu-sim/gpu-sim.h"
-#include "../gpgpusim_entrypoint.h"
-#include "../stream_manager.h"
 #include "cuda-sim.h"
-#include "cuda_device_runtime.h"
 #include "ptx_ir.h"
+#include "../stream_manager.h"
+#include "../gpgpusim_entrypoint.h"
+#include "cuda_device_runtime.h"
+#include "../../libcuda/gpgpu_context.h"
 
-#define DEV_RUNTIME_REPORT(a)                                       \
-  if (g_debug_execution) {                                          \
-    std::cout << __FILE__ << ", " << __LINE__ << ": " << a << "\n"; \
-    std::cout.flush();                                              \
-  }
+#define DEV_RUNTIME_REPORT(a) \
+   if( g_debug_execution ) { \
+      std::cout << __FILE__ << ", " << __LINE__ << ": " << a << "\n"; \
+      std::cout.flush(); \
+   }
 
-// Handling device runtime api:
-// void * cudaGetParameterBufferV2(void *func, dim3 gridDimension, dim3
-// blockDimension, unsigned int sharedMemSize)
-void cuda_device_runtime::gpgpusim_cuda_getParameterBufferV2(
-    const ptx_instruction *pI, ptx_thread_info *thread,
-    const function_info *target_func) {
-  DEV_RUNTIME_REPORT("Calling cudaGetParameterBufferV2");
 
-  unsigned n_return = target_func->has_return();
-  assert(n_return);
-  unsigned n_args = target_func->num_args();
-  assert(n_args == 4);
 
-  function_info *child_kernel_entry;
-  struct dim3 grid_dim, block_dim;
-  unsigned int shared_mem;
+//Handling device runtime api:
+//void * cudaGetParameterBufferV2(void *func, dim3 gridDimension, dim3 blockDimension, unsigned int sharedMemSize)
+void cuda_device_runtime::gpgpusim_cuda_getParameterBufferV2(const ptx_instruction * pI, ptx_thread_info * thread, const function_info * target_func)
+{
+    DEV_RUNTIME_REPORT("Calling cudaGetParameterBufferV2");
+      
+    unsigned n_return = target_func->has_return();
+    assert(n_return);
+    unsigned n_args = target_func->num_args();
+    assert( n_args == 4 );
 
-  for (unsigned arg = 0; arg < n_args; arg++) {
-    const operand_info &actual_param_op =
-        pI->operand_lookup(n_return + 1 + arg);  // param#
-    const symbol *formal_param =
-        target_func->get_arg(arg);  // cudaGetParameterBufferV2_param_#
-    unsigned size = formal_param->get_size_in_bytes();
-    assert(formal_param->is_param_local());
-    assert(actual_param_op.is_param_local());
-    addr_t from_addr = actual_param_op.get_symbol()->get_address();
+    function_info * child_kernel_entry;
+    struct dim3 grid_dim, block_dim;
+    unsigned int shared_mem;
 
-    if (arg == 0) {  // function_info* for the child kernel
-      unsigned long long buf;
-      assert(size == sizeof(function_info *));
-      thread->m_local_mem->read(from_addr, size, &buf);
-      child_kernel_entry = (function_info *)buf;
-      assert(child_kernel_entry);
-      DEV_RUNTIME_REPORT("child kernel name "
-                         << child_kernel_entry->get_name());
-    } else if (arg == 1) {  // dim3 grid_dim for the child kernel
-      assert(size == sizeof(struct dim3));
-      thread->m_local_mem->read(from_addr, size, &grid_dim);
-      DEV_RUNTIME_REPORT("grid (" << grid_dim.x << ", " << grid_dim.y << ", "
-                                  << grid_dim.z << ")");
-    } else if (arg == 2) {  // dim3 block_dim for the child kernel
-      assert(size == sizeof(struct dim3));
-      thread->m_local_mem->read(from_addr, size, &block_dim);
-      DEV_RUNTIME_REPORT("block (" << block_dim.x << ", " << block_dim.y << ", "
-                                   << block_dim.z << ")");
-    } else if (arg == 3) {  // unsigned int shared_mem
-      assert(size == sizeof(unsigned int));
-      thread->m_local_mem->read(from_addr, size, &shared_mem);
-      DEV_RUNTIME_REPORT("shared memory " << shared_mem);
+    for( unsigned arg=0; arg < n_args; arg ++ ) {
+        const operand_info &actual_param_op = pI->operand_lookup(n_return+1+arg); //param#
+        const symbol *formal_param = target_func->get_arg(arg); //cudaGetParameterBufferV2_param_#
+        unsigned size=formal_param->get_size_in_bytes();
+        assert( formal_param->is_param_local() );
+        assert( actual_param_op.is_param_local() );
+        addr_t from_addr = actual_param_op.get_symbol()->get_address();
+
+        if(arg == 0) {//function_info* for the child kernel
+            unsigned long long buf;
+            assert(size == sizeof(function_info *));
+            thread->m_local_mem->read(from_addr, size, &buf);
+            child_kernel_entry = (function_info *)buf;
+            assert(child_kernel_entry);
+            DEV_RUNTIME_REPORT("child kernel name " << child_kernel_entry->get_name());
+        }
+        else if(arg == 1) { //dim3 grid_dim for the child kernel
+            assert(size == sizeof(struct dim3));
+            thread->m_local_mem->read(from_addr, size, & grid_dim);
+            DEV_RUNTIME_REPORT("grid (" << grid_dim.x << ", " << grid_dim.y << ", " << grid_dim.z << ")");
+        }
+        else if(arg == 2) { //dim3 block_dim for the child kernel
+            assert(size == sizeof(struct dim3));
+            thread->m_local_mem->read(from_addr, size, & block_dim);
+            DEV_RUNTIME_REPORT("block (" << block_dim.x << ", " << block_dim.y << ", " << block_dim.z << ")");
+        }
+        else if(arg == 3) { //unsigned int shared_mem
+            assert(size == sizeof(unsigned int));
+            thread->m_local_mem->read(from_addr, size, & shared_mem);
+            DEV_RUNTIME_REPORT("shared memory " << shared_mem);
+        }
     }
-  }
 
-  // get total child kernel argument size and malloc buffer in global memory
-  unsigned child_kernel_arg_size = child_kernel_entry->get_args_aligned_size();
-  void *param_buffer = thread->get_gpu()->gpu_malloc(child_kernel_arg_size);
-  g_total_param_size += ((child_kernel_arg_size + 255) / 256 * 256);
-  DEV_RUNTIME_REPORT("child kernel arg size total "
-                     << child_kernel_arg_size
-                     << ", parameter buffer allocated at " << param_buffer);
-  if (g_total_param_size > g_max_total_param_size)
-    g_max_total_param_size = g_total_param_size;
+    //get total child kernel argument size and malloc buffer in global memory
+    unsigned child_kernel_arg_size = child_kernel_entry->get_args_aligned_size();
+    void * param_buffer = thread->get_gpu()->gpu_malloc(child_kernel_arg_size);
+    g_total_param_size += ((child_kernel_arg_size + 255) / 256 * 256);
+    DEV_RUNTIME_REPORT("child kernel arg size total " << child_kernel_arg_size << ", parameter buffer allocated at " << param_buffer);
+    if(g_total_param_size > g_max_total_param_size)
+        g_max_total_param_size = g_total_param_size;
 
-  // store param buffer address and launch config
-  device_launch_config_t device_launch_config(grid_dim, block_dim, shared_mem,
-                                              child_kernel_entry);
-  assert(g_cuda_device_launch_param_map.find(param_buffer) ==
-         g_cuda_device_launch_param_map.end());
-  g_cuda_device_launch_param_map[param_buffer] = device_launch_config;
+    //store param buffer address and launch config
+    device_launch_config_t device_launch_config(grid_dim, block_dim, shared_mem, child_kernel_entry);
+    assert(g_cuda_device_launch_param_map.find(param_buffer) == g_cuda_device_launch_param_map.end());
+    g_cuda_device_launch_param_map[param_buffer] = device_launch_config;
 
-  // copy the buffer address to retval0
-  const operand_info &actual_return_op = pI->operand_lookup(0);  // retval0
-  const symbol *formal_return = target_func->get_return_var();   // void *
-  unsigned int return_size = formal_return->get_size_in_bytes();
-  DEV_RUNTIME_REPORT("cudaGetParameterBufferV2 return value has size of "
-                     << return_size);
-  assert(actual_return_op.is_param_local());
-  assert(actual_return_op.get_symbol()->get_size_in_bytes() == return_size &&
-         return_size == sizeof(void *));
-  addr_t ret_param_addr = actual_return_op.get_symbol()->get_address();
-  thread->m_local_mem->write(ret_param_addr, return_size, &param_buffer, NULL,
-                             NULL);
+    //copy the buffer address to retval0
+    const operand_info &actual_return_op = pI->operand_lookup(0); //retval0
+    const symbol *formal_return = target_func->get_return_var(); //void *
+    unsigned int return_size = formal_return->get_size_in_bytes();
+    DEV_RUNTIME_REPORT("cudaGetParameterBufferV2 return value has size of " << return_size);
+    assert(actual_return_op.is_param_local());
+    assert(actual_return_op.get_symbol()->get_size_in_bytes() == return_size && return_size == sizeof(void *));
+    addr_t ret_param_addr = actual_return_op.get_symbol()->get_address();
+    thread->m_local_mem->write(ret_param_addr, return_size, &param_buffer, NULL, NULL);
+
 }
 
-// Handling device runtime api:
-// cudaError_t cudaLaunchDeviceV2(void *parameterBuffer, cudaStream_t stream)
-void cuda_device_runtime::gpgpusim_cuda_launchDeviceV2(
-    const ptx_instruction *pI, ptx_thread_info *thread,
-    const function_info *target_func) {
-  DEV_RUNTIME_REPORT("Calling cudaLaunchDeviceV2");
+//Handling device runtime api:
+//cudaError_t cudaLaunchDeviceV2(void *parameterBuffer, cudaStream_t stream)
+void cuda_device_runtime::gpgpusim_cuda_launchDeviceV2(const ptx_instruction * pI, ptx_thread_info * thread, const function_info * target_func) {
+    DEV_RUNTIME_REPORT("Calling cudaLaunchDeviceV2");
 
-  unsigned n_return = target_func->has_return();
-  assert(n_return);
-  unsigned n_args = target_func->num_args();
-  assert(n_args == 2);
+    unsigned n_return = target_func->has_return();
+    assert(n_return);
+    unsigned n_args = target_func->num_args();
+    assert( n_args == 2 );
 
-  kernel_info_t *device_grid = NULL;
-  function_info *device_kernel_entry = NULL;
-  void *parameter_buffer;
-  struct CUstream_st *child_stream;
-  device_launch_config_t config;
-  device_launch_operation_t device_launch_op;
+    kernel_info_t * device_grid = NULL;
+    function_info * device_kernel_entry = NULL;
+    void * parameter_buffer;
+    struct CUstream_st * child_stream;
+    device_launch_config_t config;
+    device_launch_operation_t device_launch_op;
 
-  for (unsigned arg = 0; arg < n_args; arg++) {
-    const operand_info &actual_param_op =
-        pI->operand_lookup(n_return + 1 + arg);  // param#
-    const symbol *formal_param =
-        target_func->get_arg(arg);  // cudaLaunchDeviceV2_param_#
-    unsigned size = formal_param->get_size_in_bytes();
-    assert(formal_param->is_param_local());
-    assert(actual_param_op.is_param_local());
-    addr_t from_addr = actual_param_op.get_symbol()->get_address();
+    for( unsigned arg=0; arg < n_args; arg ++ ) {
+        const operand_info &actual_param_op = pI->operand_lookup(n_return+1+arg); //param#
+        const symbol *formal_param = target_func->get_arg(arg); //cudaLaunchDeviceV2_param_#
+        unsigned size=formal_param->get_size_in_bytes();
+        assert( formal_param->is_param_local() );
+        assert( actual_param_op.is_param_local() );
+        addr_t from_addr = actual_param_op.get_symbol()->get_address();
 
-    if (arg == 0) {  // paramter buffer for child kernel (in global memory)
-      // get parameter_buffer from the cudaLaunchDeviceV2_param0
-      assert(size == sizeof(void *));
-      thread->m_local_mem->read(from_addr, size, &parameter_buffer);
-      assert((size_t)parameter_buffer >= GLOBAL_HEAP_START);
-      DEV_RUNTIME_REPORT("Parameter buffer locating at global memory "
-                         << parameter_buffer);
+        if(arg == 0) {//paramter buffer for child kernel (in global memory)
+            //get parameter_buffer from the cudaLaunchDeviceV2_param0
+            assert(size == sizeof(void *));
+            thread->m_local_mem->read(from_addr, size, &parameter_buffer);
+            assert((size_t)parameter_buffer >= GLOBAL_HEAP_START);
+            DEV_RUNTIME_REPORT("Parameter buffer locating at global memory " << parameter_buffer);
 
-      // get child grid info through parameter_buffer address
-      assert(g_cuda_device_launch_param_map.find(parameter_buffer) !=
-             g_cuda_device_launch_param_map.end());
-      config = g_cuda_device_launch_param_map[parameter_buffer];
-      // device_grid = op.grid;
-      device_kernel_entry = config.entry;
-      DEV_RUNTIME_REPORT("find device kernel "
-                         << device_kernel_entry->get_name());
+            //get child grid info through parameter_buffer address
+            assert(g_cuda_device_launch_param_map.find(parameter_buffer) != g_cuda_device_launch_param_map.end());
+            config = g_cuda_device_launch_param_map[parameter_buffer];
+            //device_grid = op.grid;
+            device_kernel_entry = config.entry;
+            DEV_RUNTIME_REPORT("find device kernel " << device_kernel_entry->get_name());
+	    
+	    //PDOM analysis is done for Parent kernel but not for child kernel.
+	    if (device_kernel_entry->is_pdom_set()) {
+		    printf("GPGPU-Sim PTX: PDOM analysis already done for %s \n", device_kernel_entry->get_name().c_str() );
+	    } else {
+		    printf("GPGPU-Sim PTX: finding reconvergence points for \'%s\'...\n", device_kernel_entry->get_name().c_str() );
+		    /*
+		     * Some of the instructions like printf() gives the gpgpusim the wrong impression that it is a function call.
+		     * As printf() doesnt have a body like functions do, doing pdom analysis for printf() causes a crash.
+		     */
+		    if (device_kernel_entry->get_function_size() >0)
+			    device_kernel_entry->do_pdom();
+		    device_kernel_entry->set_pdom();
+	    }
 
-      // PDOM analysis is done for Parent kernel but not for child kernel.
-      if (device_kernel_entry->is_pdom_set()) {
-        printf("GPGPU-Sim PTX: PDOM analysis already done for %s \n",
-               device_kernel_entry->get_name().c_str());
-      } else {
-        printf("GPGPU-Sim PTX: finding reconvergence points for \'%s\'...\n",
-               device_kernel_entry->get_name().c_str());
-        /*
-         * Some of the instructions like printf() gives the gpgpusim the wrong
-         * impression that it is a function call.
-         * As printf() doesnt have a body like functions do, doing pdom analysis
-         * for printf() causes a crash.
-         */
-        if (device_kernel_entry->get_function_size() > 0)
-          device_kernel_entry->do_pdom();
-        device_kernel_entry->set_pdom();
-      }
+            //copy data in parameter_buffer to device kernel param memory
+            unsigned device_kernel_arg_size = device_kernel_entry->get_args_aligned_size();
+            DEV_RUNTIME_REPORT("device_kernel_arg_size " << device_kernel_arg_size);
+            memory_space *device_kernel_param_mem;
 
-      // copy data in parameter_buffer to device kernel param memory
-      unsigned device_kernel_arg_size =
-          device_kernel_entry->get_args_aligned_size();
-      DEV_RUNTIME_REPORT("device_kernel_arg_size " << device_kernel_arg_size);
-      memory_space *device_kernel_param_mem;
+            //create child kernel_info_t and index it with parameter_buffer address
+	    gpgpu_t* gpu=thread->get_gpu();
+            device_grid = new kernel_info_t(config.grid_dim, config.block_dim, device_kernel_entry, gpu->getNameArrayMapping(), gpu->getNameInfoMapping());
+            device_grid->launch_cycle = gpu->gpu_sim_cycle + gpu->gpu_tot_sim_cycle;
+            kernel_info_t & parent_grid = thread->get_kernel();
+            DEV_RUNTIME_REPORT("child kernel launched by " << parent_grid.name() << ", cta (" <<
+                thread->get_ctaid().x << ", " << thread->get_ctaid().y << ", " << thread->get_ctaid().z <<
+                "), thread (" << thread->get_tid().x << ", " << thread->get_tid().y << ", " << thread->get_tid().z <<
+                ")");
+            device_grid->set_parent(&parent_grid, thread->get_ctaid(), thread->get_tid());  
+            device_launch_op = device_launch_operation_t(device_grid, NULL);
+            device_kernel_param_mem = device_grid->get_param_memory(); //kernel param
+            size_t param_start_address = 0;
+            //copy in word
+            for(unsigned n = 0; n < device_kernel_arg_size; n += 4) {
+                unsigned int oneword;
+                thread->get_gpu()->get_global_memory()->read((size_t)parameter_buffer + n, 4, &oneword);
+                device_kernel_param_mem->write(param_start_address + n, 4, &oneword, NULL, NULL); 
+            }
+        }
+        else if(arg == 1) { //cudaStream for the child kernel
 
-      // create child kernel_info_t and index it with parameter_buffer address
-      gpgpu_t *gpu = thread->get_gpu();
-      device_grid = new kernel_info_t(
-          config.grid_dim, config.block_dim, device_kernel_entry,
-          gpu->getNameArrayMapping(), gpu->getNameInfoMapping());
-      device_grid->launch_cycle = gpu->gpu_sim_cycle + gpu->gpu_tot_sim_cycle;
-      kernel_info_t &parent_grid = thread->get_kernel();
-      DEV_RUNTIME_REPORT(
-          "child kernel launched by "
-          << parent_grid.name() << ", cta (" << thread->get_ctaid().x << ", "
-          << thread->get_ctaid().y << ", " << thread->get_ctaid().z
-          << "), thread (" << thread->get_tid().x << ", " << thread->get_tid().y
-          << ", " << thread->get_tid().z << ")");
-      device_grid->set_parent(&parent_grid, thread->get_ctaid(),
-                              thread->get_tid());
-      device_launch_op = device_launch_operation_t(device_grid, NULL);
-      device_kernel_param_mem = device_grid->get_param_memory();  // kernel
-                                                                  // param
-      size_t param_start_address = 0;
-      // copy in word
-      for (unsigned n = 0; n < device_kernel_arg_size; n += 4) {
-        unsigned int oneword;
-        thread->get_gpu()->get_global_memory()->read(
-            (size_t)parameter_buffer + n, 4, &oneword);
-        device_kernel_param_mem->write(param_start_address + n, 4, &oneword,
-                                       NULL, NULL);
-      }
-    } else if (arg == 1) {  // cudaStream for the child kernel
-
-      assert(size == sizeof(cudaStream_t));
-      thread->m_local_mem->read(from_addr, size, &child_stream);
-
-      kernel_info_t &parent_kernel = thread->get_kernel();
-      if (child_stream == 0) {  // default stream on device for current CTA
-        child_stream =
-            parent_kernel.get_default_stream_cta(thread->get_ctaid());
-        DEV_RUNTIME_REPORT("launching child kernel "
-                           << device_grid->get_uid()
-                           << " to default stream of the cta "
-                           << child_stream->get_uid() << ": " << child_stream);
-      } else {
-        assert(parent_kernel.cta_has_stream(thread->get_ctaid(), child_stream));
-        DEV_RUNTIME_REPORT("launching child kernel "
-                           << device_grid->get_uid() << " to stream "
-                           << child_stream->get_uid() << ": " << child_stream);
-      }
-
-      device_launch_op.stream = child_stream;
+            assert(size == sizeof(cudaStream_t));
+            thread->m_local_mem->read(from_addr, size, &child_stream);
+     
+            kernel_info_t & parent_kernel = thread->get_kernel();
+            if(child_stream == 0) { //default stream on device for current CTA
+                child_stream = parent_kernel.get_default_stream_cta(thread->get_ctaid()); 
+                DEV_RUNTIME_REPORT("launching child kernel " << device_grid->get_uid() << 
+                    " to default stream of the cta " << child_stream->get_uid() << ": " << child_stream);
+            }
+            else {
+               assert(parent_kernel.cta_has_stream(thread->get_ctaid(), child_stream)); 
+                DEV_RUNTIME_REPORT("launching child kernel " << device_grid->get_uid() << 
+                " to stream " << child_stream->get_uid() << ": " << child_stream);
+            }
+    
+            device_launch_op.stream = child_stream;
+        }
+        
     }
-  }
 
-  // launch child kernel
-  g_cuda_device_launch_op.push_back(device_launch_op);
-  g_cuda_device_launch_param_map.erase(parameter_buffer);
+  
+    //launch child kernel
+    g_cuda_device_launch_op.push_back(device_launch_op);
+    g_cuda_device_launch_param_map.erase(parameter_buffer);
 
-  // set retval0
-  const operand_info &actual_return_op = pI->operand_lookup(0);  // retval0
-  const symbol *formal_return = target_func->get_return_var();   // cudaError_t
-  unsigned int return_size = formal_return->get_size_in_bytes();
-  DEV_RUNTIME_REPORT("cudaLaunchDeviceV2 return value has size of "
-                     << return_size);
-  assert(actual_return_op.is_param_local());
-  assert(actual_return_op.get_symbol()->get_size_in_bytes() == return_size &&
-         return_size == sizeof(cudaError_t));
-  cudaError_t error = cudaSuccess;
-  addr_t ret_param_addr = actual_return_op.get_symbol()->get_address();
-  thread->m_local_mem->write(ret_param_addr, return_size, &error, NULL, NULL);
+    //set retval0
+    const operand_info &actual_return_op = pI->operand_lookup(0); //retval0
+    const symbol *formal_return = target_func->get_return_var(); //cudaError_t
+    unsigned int return_size = formal_return->get_size_in_bytes();
+    DEV_RUNTIME_REPORT("cudaLaunchDeviceV2 return value has size of " << return_size);
+    assert(actual_return_op.is_param_local());
+    assert(actual_return_op.get_symbol()->get_size_in_bytes() == return_size 
+        && return_size == sizeof(cudaError_t));
+    cudaError_t error = cudaSuccess;
+    addr_t ret_param_addr = actual_return_op.get_symbol()->get_address();
+    thread->m_local_mem->write(ret_param_addr, return_size, &error, NULL, NULL);
+
 }
 
-// Handling device runtime api:
-// cudaError_t cudaStreamCreateWithFlags ( cudaStream_t* pStream, unsigned int
-// flags)
-// flags can only be cudaStreamNonBlocking
-void cuda_device_runtime::gpgpusim_cuda_streamCreateWithFlags(
-    const ptx_instruction *pI, ptx_thread_info *thread,
-    const function_info *target_func) {
-  DEV_RUNTIME_REPORT("Calling cudaStreamCreateWithFlags");
 
-  unsigned n_return = target_func->has_return();
-  assert(n_return);
-  unsigned n_args = target_func->num_args();
-  assert(n_args == 2);
+//Handling device runtime api:
+//cudaError_t cudaStreamCreateWithFlags ( cudaStream_t* pStream, unsigned int  flags)
+//flags can only be cudaStreamNonBlocking
+void cuda_device_runtime::gpgpusim_cuda_streamCreateWithFlags(const ptx_instruction * pI, ptx_thread_info * thread, const function_info * target_func) {
+    DEV_RUNTIME_REPORT("Calling cudaStreamCreateWithFlags");
 
-  size_t generic_pStream_addr;
-  addr_t pStream_addr;
-  unsigned int flags;
-  for (unsigned arg = 0; arg < n_args; arg++) {
-    const operand_info &actual_param_op =
-        pI->operand_lookup(n_return + 1 + arg);  // param#
-    const symbol *formal_param =
-        target_func->get_arg(arg);  // cudaStreamCreateWithFlags_param_#
-    unsigned size = formal_param->get_size_in_bytes();
-    assert(formal_param->is_param_local());
-    assert(actual_param_op.is_param_local());
-    addr_t from_addr = actual_param_op.get_symbol()->get_address();
+    unsigned n_return = target_func->has_return();
+    assert(n_return);
+    unsigned n_args = target_func->num_args();
+    assert( n_args == 2 );
 
-    if (arg == 0) {  // cudaStream_t * pStream, address of cudaStream_t
-      assert(size == sizeof(cudaStream_t *));
-      thread->m_local_mem->read(from_addr, size, &generic_pStream_addr);
+    size_t generic_pStream_addr;
+    addr_t pStream_addr;
+    unsigned int flags;
+    for( unsigned arg=0; arg < n_args; arg ++ ) {
+        const operand_info &actual_param_op = pI->operand_lookup(n_return+1+arg); //param#
+        const symbol *formal_param = target_func->get_arg(arg); //cudaStreamCreateWithFlags_param_#
+        unsigned size=formal_param->get_size_in_bytes();
+        assert( formal_param->is_param_local() );
+        assert( actual_param_op.is_param_local() );
+        addr_t from_addr = actual_param_op.get_symbol()->get_address();
 
-      // pStream should be non-zero address in local memory
-      pStream_addr = generic_to_local(
-          thread->get_hw_sid(), thread->get_hw_tid(), generic_pStream_addr);
+        if(arg == 0) {//cudaStream_t * pStream, address of cudaStream_t
+            assert(size == sizeof(cudaStream_t *));
+            thread->m_local_mem->read(from_addr, size, &generic_pStream_addr);
+            
+            //pStream should be non-zero address in local memory
+            pStream_addr = generic_to_local(thread->get_hw_sid(), thread->get_hw_tid(), generic_pStream_addr);
 
-      DEV_RUNTIME_REPORT("pStream locating at local memory " << pStream_addr);
-    } else if (arg ==
-               1) {  // unsigned int flags, should be cudaStreamNonBlocking
-      assert(size == sizeof(unsigned int));
-      thread->m_local_mem->read(from_addr, size, &flags);
-      assert(flags == cudaStreamNonBlocking);
+            DEV_RUNTIME_REPORT("pStream locating at local memory " << pStream_addr);
+        }
+        else if(arg == 1) { //unsigned int flags, should be cudaStreamNonBlocking
+            assert(size == sizeof(unsigned int));
+            thread->m_local_mem->read(from_addr, size, &flags);
+            assert(flags == cudaStreamNonBlocking);
+        }
     }
-  }
 
-  // create stream and write back to param0
-  CUstream_st *stream =
-      thread->get_kernel().create_stream_cta(thread->get_ctaid());
-  DEV_RUNTIME_REPORT("Create stream " << stream->get_uid() << ": " << stream);
-  thread->m_local_mem->write(pStream_addr, sizeof(cudaStream_t), &stream, NULL,
-                             NULL);
+    //create stream and write back to param0
+    CUstream_st * stream = thread->get_kernel().create_stream_cta(thread->get_ctaid());
+    DEV_RUNTIME_REPORT("Create stream " << stream->get_uid() << ": " << stream);
+    thread->m_local_mem->write(pStream_addr, sizeof(cudaStream_t), &stream, NULL, NULL);
+ 
+    //set retval0
+    const operand_info &actual_return_op = pI->operand_lookup(0); //retval0
+    const symbol *formal_return = target_func->get_return_var(); //cudaError_t
+    unsigned int return_size = formal_return->get_size_in_bytes();
+    DEV_RUNTIME_REPORT("cudaStreamCreateWithFlags return value has size of " << return_size);
+    assert(actual_return_op.is_param_local());
+    assert(actual_return_op.get_symbol()->get_size_in_bytes() == return_size 
+        && return_size == sizeof(cudaError_t));
+    cudaError_t error = cudaSuccess;
+    addr_t ret_param_addr = actual_return_op.get_symbol()->get_address();
+    thread->m_local_mem->write(ret_param_addr, return_size, &error, NULL, NULL);
 
-  // set retval0
-  const operand_info &actual_return_op = pI->operand_lookup(0);  // retval0
-  const symbol *formal_return = target_func->get_return_var();   // cudaError_t
-  unsigned int return_size = formal_return->get_size_in_bytes();
-  DEV_RUNTIME_REPORT("cudaStreamCreateWithFlags return value has size of "
-                     << return_size);
-  assert(actual_return_op.is_param_local());
-  assert(actual_return_op.get_symbol()->get_size_in_bytes() == return_size &&
-         return_size == sizeof(cudaError_t));
-  cudaError_t error = cudaSuccess;
-  addr_t ret_param_addr = actual_return_op.get_symbol()->get_address();
-  thread->m_local_mem->write(ret_param_addr, return_size, &error, NULL, NULL);
 }
+
 
 void cuda_device_runtime::launch_one_device_kernel() {
-  if (!g_cuda_device_launch_op.empty()) {
-    device_launch_operation_t &op = g_cuda_device_launch_op.front();
+    if(!g_cuda_device_launch_op.empty()) {
+        device_launch_operation_t &op = g_cuda_device_launch_op.front();
 
-    stream_operation stream_op = stream_operation(
-        op.grid, gpgpu_ctx->func_sim->g_ptx_sim_mode, op.stream);
-    gpgpu_ctx->the_gpgpusim->g_stream_manager->push(stream_op);
-    g_cuda_device_launch_op.pop_front();
-  }
+        stream_operation stream_op = stream_operation(op.grid, gpgpu_ctx->func_sim->g_ptx_sim_mode, op.stream);
+        gpgpu_ctx->the_gpgpusim->g_stream_manager->push(stream_op);
+        g_cuda_device_launch_op.pop_front();
+    }
 }
 
 void cuda_device_runtime::launch_all_device_kernels() {
-  while (!g_cuda_device_launch_op.empty()) {
-    launch_one_device_kernel();
-  }
+    while(!g_cuda_device_launch_op.empty()) {
+        launch_one_device_kernel();
+    }
 }
 #endif

--- a/src/cuda-sim/cuda_device_runtime.h
+++ b/src/cuda-sim/cuda_device_runtime.h
@@ -1,66 +1,67 @@
 #ifndef __cuda_device_runtime_h__
 #define __cuda_device_runtime_h__
-// Jin: cuda_device_runtime.h
-// Defines CUDA device runtime APIs for CDP support
+//Jin: cuda_device_runtime.h
+//Defines CUDA device runtime APIs for CDP support
 class device_launch_config_t {
- public:
-  device_launch_config_t() {}
 
-  device_launch_config_t(dim3 _grid_dim, dim3 _block_dim,
-                         unsigned int _shared_mem, function_info* _entry)
-      : grid_dim(_grid_dim),
-        block_dim(_block_dim),
-        shared_mem(_shared_mem),
-        entry(_entry) {}
+public:
+    device_launch_config_t() {}
 
-  dim3 grid_dim;
-  dim3 block_dim;
-  unsigned int shared_mem;
-  function_info* entry;
+    device_launch_config_t(dim3 _grid_dim,
+        dim3 _block_dim,
+        unsigned int _shared_mem,
+        function_info * _entry):
+            grid_dim(_grid_dim),
+            block_dim(_block_dim),
+            shared_mem(_shared_mem),
+            entry(_entry) {}
+
+    dim3 grid_dim;
+    dim3 block_dim;
+    unsigned int shared_mem;
+    function_info * entry;
+
 };
 
 class device_launch_operation_t {
- public:
-  device_launch_operation_t() {}
-  device_launch_operation_t(kernel_info_t* _grid, CUstream_st* _stream)
-      : grid(_grid), stream(_stream) {}
 
-  kernel_info_t* grid;  // a new child grid
+public:
+    device_launch_operation_t() {}
+    device_launch_operation_t(kernel_info_t *_grid,
+        CUstream_st * _stream) :
+            grid(_grid), stream(_stream) {}
 
-  CUstream_st* stream;
+    kernel_info_t * grid; //a new child grid
+
+    CUstream_st * stream;
+
 };
 
 class gpgpu_context;
 
 class cuda_device_runtime {
- public:
-  cuda_device_runtime(gpgpu_context* ctx) {
-    g_total_param_size = 0;
-    g_max_total_param_size = 0;
-    gpgpu_ctx = ctx;
-  }
-  unsigned long long g_total_param_size;
-  std::map<void*, device_launch_config_t> g_cuda_device_launch_param_map;
-  std::list<device_launch_operation_t> g_cuda_device_launch_op;
-  unsigned g_kernel_launch_latency;
-  unsigned long long g_max_total_param_size;
-  bool g_cdp_enabled;
+    public:
+	cuda_device_runtime( gpgpu_context* ctx ) {
+	    g_total_param_size = 0;
+	    g_max_total_param_size = 0;
+	    gpgpu_ctx = ctx;
+	}
+	unsigned long long g_total_param_size;
+	std::map<void *, device_launch_config_t> g_cuda_device_launch_param_map;
+	std::list<device_launch_operation_t> g_cuda_device_launch_op;
+	unsigned g_kernel_launch_latency;
+	unsigned long long g_max_total_param_size;
+	bool g_cdp_enabled;
 
-  // backward pointer
-  class gpgpu_context* gpgpu_ctx;
+	// backward pointer
+	class gpgpu_context* gpgpu_ctx;
 #if (CUDART_VERSION >= 5000)
 #pragma once
-  void gpgpusim_cuda_launchDeviceV2(const ptx_instruction* pI,
-                                    ptx_thread_info* thread,
-                                    const function_info* target_func);
-  void gpgpusim_cuda_streamCreateWithFlags(const ptx_instruction* pI,
-                                           ptx_thread_info* thread,
-                                           const function_info* target_func);
-  void gpgpusim_cuda_getParameterBufferV2(const ptx_instruction* pI,
-                                          ptx_thread_info* thread,
-                                          const function_info* target_func);
-  void launch_all_device_kernels();
-  void launch_one_device_kernel();
+	void gpgpusim_cuda_launchDeviceV2(const ptx_instruction * pI, ptx_thread_info * thread, const function_info * target_func);
+	void gpgpusim_cuda_streamCreateWithFlags(const ptx_instruction * pI, ptx_thread_info * thread, const function_info * target_func);
+	void gpgpusim_cuda_getParameterBufferV2(const ptx_instruction * pI, ptx_thread_info * thread, const function_info * target_func);
+	void launch_all_device_kernels();
+	void launch_one_device_kernel();
 #endif
 };
 

--- a/src/cuda-sim/cuda_device_runtime.h
+++ b/src/cuda-sim/cuda_device_runtime.h
@@ -1,67 +1,66 @@
 #ifndef __cuda_device_runtime_h__
 #define __cuda_device_runtime_h__
-//Jin: cuda_device_runtime.h
-//Defines CUDA device runtime APIs for CDP support
+// Jin: cuda_device_runtime.h
+// Defines CUDA device runtime APIs for CDP support
 class device_launch_config_t {
+ public:
+  device_launch_config_t() {}
 
-public:
-    device_launch_config_t() {}
+  device_launch_config_t(dim3 _grid_dim, dim3 _block_dim,
+                         unsigned int _shared_mem, function_info* _entry)
+      : grid_dim(_grid_dim),
+        block_dim(_block_dim),
+        shared_mem(_shared_mem),
+        entry(_entry) {}
 
-    device_launch_config_t(dim3 _grid_dim,
-        dim3 _block_dim,
-        unsigned int _shared_mem,
-        function_info * _entry):
-            grid_dim(_grid_dim),
-            block_dim(_block_dim),
-            shared_mem(_shared_mem),
-            entry(_entry) {}
-
-    dim3 grid_dim;
-    dim3 block_dim;
-    unsigned int shared_mem;
-    function_info * entry;
-
+  dim3 grid_dim;
+  dim3 block_dim;
+  unsigned int shared_mem;
+  function_info* entry;
 };
 
 class device_launch_operation_t {
+ public:
+  device_launch_operation_t() {}
+  device_launch_operation_t(kernel_info_t* _grid, CUstream_st* _stream)
+      : grid(_grid), stream(_stream) {}
 
-public:
-    device_launch_operation_t() {}
-    device_launch_operation_t(kernel_info_t *_grid,
-        CUstream_st * _stream) :
-            grid(_grid), stream(_stream) {}
+  kernel_info_t* grid;  // a new child grid
 
-    kernel_info_t * grid; //a new child grid
-
-    CUstream_st * stream;
-
+  CUstream_st* stream;
 };
 
 class gpgpu_context;
 
 class cuda_device_runtime {
-    public:
-	cuda_device_runtime( gpgpu_context* ctx ) {
-	    g_total_param_size = 0;
-	    g_max_total_param_size = 0;
-	    gpgpu_ctx = ctx;
-	}
-	unsigned long long g_total_param_size;
-	std::map<void *, device_launch_config_t> g_cuda_device_launch_param_map;
-	std::list<device_launch_operation_t> g_cuda_device_launch_op;
-	unsigned g_kernel_launch_latency;
-	unsigned long long g_max_total_param_size;
-	bool g_cdp_enabled;
+ public:
+  cuda_device_runtime(gpgpu_context* ctx) {
+    g_total_param_size = 0;
+    g_max_total_param_size = 0;
+    gpgpu_ctx = ctx;
+  }
+  unsigned long long g_total_param_size;
+  std::map<void*, device_launch_config_t> g_cuda_device_launch_param_map;
+  std::list<device_launch_operation_t> g_cuda_device_launch_op;
+  unsigned g_kernel_launch_latency;
+  unsigned long long g_max_total_param_size;
+  bool g_cdp_enabled;
 
-	// backward pointer
-	class gpgpu_context* gpgpu_ctx;
+  // backward pointer
+  class gpgpu_context* gpgpu_ctx;
 #if (CUDART_VERSION >= 5000)
 #pragma once
-	void gpgpusim_cuda_launchDeviceV2(const ptx_instruction * pI, ptx_thread_info * thread, const function_info * target_func);
-	void gpgpusim_cuda_streamCreateWithFlags(const ptx_instruction * pI, ptx_thread_info * thread, const function_info * target_func);
-	void gpgpusim_cuda_getParameterBufferV2(const ptx_instruction * pI, ptx_thread_info * thread, const function_info * target_func);
-	void launch_all_device_kernels();
-	void launch_one_device_kernel();
+  void gpgpusim_cuda_launchDeviceV2(const ptx_instruction* pI,
+                                    ptx_thread_info* thread,
+                                    const function_info* target_func);
+  void gpgpusim_cuda_streamCreateWithFlags(const ptx_instruction* pI,
+                                           ptx_thread_info* thread,
+                                           const function_info* target_func);
+  void gpgpusim_cuda_getParameterBufferV2(const ptx_instruction* pI,
+                                          ptx_thread_info* thread,
+                                          const function_info* target_func);
+  void launch_all_device_kernels();
+  void launch_one_device_kernel();
 #endif
 };
 

--- a/src/cuda-sim/half.h
+++ b/src/cuda-sim/half.h
@@ -108,7 +108,7 @@
 #define HALF_POP_WARNINGS 1
 #pragma warning(push)
 #pragma warning(disable : 4099 4127 4146)  // struct vs class, constant in if,
-                                           // negative unsigned
+// negative unsigned
 #endif
 
 // check C++11 library features
@@ -568,9 +568,9 @@ bool builtin_signbit(T arg) {
 template <std::float_round_style R>
 uint16 float2half_impl(float value, true_type) {
   typedef bits<float>::type uint32;
-  uint32
-      bits;  // = *reinterpret_cast<uint32*>(&value);		//violating
-             // strict aliasing!
+  uint32 bits;  // = *reinterpret_cast<uint32*>(&value);
+                // //violating
+                // strict aliasing!
   std::memcpy(&bits, &value, sizeof(float));
   /*			uint16 hbits = (bits>>16) & 0x8000;
 			bits &= 0x7FFFFFFF;
@@ -753,9 +753,9 @@ template <std::float_round_style R>
 uint16 float2half_impl(double value, true_type) {
   typedef bits<float>::type uint32;
   typedef bits<double>::type uint64;
-  uint64
-      bits;  // = *reinterpret_cast<uint64*>(&value);		//violating
-             // strict aliasing!
+  uint64 bits;  // = *reinterpret_cast<uint64*>(&value);
+                // //violating
+                // strict aliasing!
   std::memcpy(&bits, &value, sizeof(double));
   uint32 hi = bits >> 32, lo = bits & 0xFFFFFFFF;
   uint16 hbits = (hi >> 16) & 0x8000;
@@ -1359,8 +1359,9 @@ inline float half2float_impl(uint16 value, float, true_type) {
       1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024};
   uint32 bits = mantissa_table[offset_table[value >> 10] + (value & 0x3FF)] +
                 exponent_table[value >> 10];
-  //			return *reinterpret_cast<float*>(&bits);			//violating
-  //strict aliasing!
+  //			return *reinterpret_cast<float*>(&bits);
+  ////violating
+  // strict aliasing!
   float out;
   std::memcpy(&out, &bits, sizeof(float));
   return out;
@@ -1381,8 +1382,9 @@ inline double half2float_impl(uint16 value, double, true_type) {
     hi += static_cast<uint32>(abs) << 10;
   }
   uint64 bits = static_cast<uint64>(hi) << 32;
-  //			return *reinterpret_cast<double*>(&bits);			//violating
-  //strict aliasing!
+  //			return *reinterpret_cast<double*>(&bits);
+  ////violating
+  // strict aliasing!
   double out;
   std::memcpy(&out, &bits, sizeof(double));
   return out;
@@ -2840,7 +2842,7 @@ std::basic_istream<charT, traits> &operator>>(
 /// \param arg operand
 /// \return absolute value of \a arg
 //		template<typename T> typename enable<T,T>::type abs(T arg) {
-//return unary_specialized<T>::fabs(arg); }
+// return unary_specialized<T>::fabs(arg); }
 inline half abs(half arg) { return unary_specialized<half>::fabs(arg); }
 inline expr abs(expr arg) { return unary_specialized<expr>::fabs(arg); }
 
@@ -2848,7 +2850,7 @@ inline expr abs(expr arg) { return unary_specialized<expr>::fabs(arg); }
 /// \param arg operand
 /// \return absolute value of \a arg
 //		template<typename T> typename enable<T,T>::type fabs(T arg) {
-//return unary_specialized<T>::fabs(arg); }
+// return unary_specialized<T>::fabs(arg); }
 inline half fabs(half arg) { return unary_specialized<half>::fabs(arg); }
 inline expr fabs(expr arg) { return unary_specialized<expr>::fabs(arg); }
 
@@ -2857,7 +2859,7 @@ inline expr fabs(expr arg) { return unary_specialized<expr>::fabs(arg); }
 /// \param y second operand
 /// \return remainder of floating point division.
 //		template<typename T,typename U> typename enable<expr,T,U>::type
-//fmod(T x, U y) { return functions::fmod(x, y); }
+// fmod(T x, U y) { return functions::fmod(x, y); }
 inline expr fmod(half x, half y) { return functions::fmod(x, y); }
 inline expr fmod(half x, expr y) { return functions::fmod(x, y); }
 inline expr fmod(expr x, half y) { return functions::fmod(x, y); }
@@ -2868,7 +2870,7 @@ inline expr fmod(expr x, expr y) { return functions::fmod(x, y); }
 /// \param y second operand
 /// \return remainder of floating point division.
 //		template<typename T,typename U> typename enable<expr,T,U>::type
-//remainder(T x, U y) { return functions::remainder(x, y); }
+// remainder(T x, U y) { return functions::remainder(x, y); }
 inline expr remainder(half x, half y) { return functions::remainder(x, y); }
 inline expr remainder(half x, expr y) { return functions::remainder(x, y); }
 inline expr remainder(expr x, half y) { return functions::remainder(x, y); }
@@ -2880,7 +2882,7 @@ inline expr remainder(expr x, expr y) { return functions::remainder(x, y); }
 /// \param quo address to store some bits of quotient at
 /// \return remainder of floating point division.
 //		template<typename T,typename U> typename enable<expr,T,U>::type
-//remquo(T x, U y, int *quo) { return functions::remquo(x, y, quo); }
+// remquo(T x, U y, int *quo) { return functions::remquo(x, y, quo); }
 inline expr remquo(half x, half y, int *quo) {
   return functions::remquo(x, y, quo);
 }
@@ -2900,7 +2902,7 @@ inline expr remquo(expr x, expr y, int *quo) {
 /// \param z third operand
 /// \return ( \a x * \a y ) + \a z rounded as one operation.
 //		template<typename T,typename U,typename V> typename
-//enable<expr,T,U,V>::type fma(T x, U y, V z) { return functions::fma(x, y, z);
+// enable<expr,T,U,V>::type fma(T x, U y, V z) { return functions::fma(x, y, z);
 //}
 inline expr fma(half x, half y, half z) { return functions::fma(x, y, z); }
 inline expr fma(half x, half y, expr z) { return functions::fma(x, y, z); }
@@ -2915,8 +2917,9 @@ inline expr fma(expr x, expr y, expr z) { return functions::fma(x, y, z); }
 /// \param x first operand
 /// \param y second operand
 /// \return maximum of operands
-//		template<typename T,typename U> typename result<T,U>::type fmax(T
-//x, U y) { return binary_specialized<T,U>::fmax(x, y); }
+//		template<typename T,typename U> typename result<T,U>::type
+// fmax(T
+// x, U y) { return binary_specialized<T,U>::fmax(x, y); }
 inline half fmax(half x, half y) {
   return binary_specialized<half, half>::fmax(x, y);
 }
@@ -2934,8 +2937,9 @@ inline expr fmax(expr x, expr y) {
 /// \param x first operand
 /// \param y second operand
 /// \return minimum of operands
-//		template<typename T,typename U> typename result<T,U>::type fmin(T
-//x, U y) { return binary_specialized<T,U>::fmin(x, y); }
+//		template<typename T,typename U> typename result<T,U>::type
+// fmin(T
+// x, U y) { return binary_specialized<T,U>::fmin(x, y); }
 inline half fmin(half x, half y) {
   return binary_specialized<half, half>::fmin(x, y);
 }
@@ -2954,7 +2958,7 @@ inline expr fmin(expr x, expr y) {
 /// \param y second operand
 /// \return \a x - \a y or 0 if difference negative
 //		template<typename T,typename U> typename enable<expr,T,U>::type
-//fdim(T x, U y) { return functions::fdim(x, y); }
+// fdim(T x, U y) { return functions::fdim(x, y); }
 inline expr fdim(half x, half y) { return functions::fdim(x, y); }
 inline expr fdim(half x, expr y) { return functions::fdim(x, y); }
 inline expr fdim(expr x, half y) { return functions::fdim(x, y); }
@@ -2972,15 +2976,16 @@ inline half nanh(const char *) { return functions::nanh(); }
 /// \param arg function argument
 /// \return e raised to \a arg
 //		template<typename T> typename enable<expr,T>::type exp(T arg) {
-//return functions::exp(arg); }
+// return functions::exp(arg); }
 inline expr exp(half arg) { return functions::exp(arg); }
 inline expr exp(expr arg) { return functions::exp(arg); }
 
 /// Exponential minus one.
 /// \param arg function argument
 /// \return e raised to \a arg subtracted by 1
-//		template<typename T> typename enable<expr,T>::type expm1(T arg) {
-//return functions::expm1(arg); }
+//		template<typename T> typename enable<expr,T>::type expm1(T arg)
+//{
+// return functions::expm1(arg); }
 inline expr expm1(half arg) { return functions::expm1(arg); }
 inline expr expm1(expr arg) { return functions::expm1(arg); }
 
@@ -2988,7 +2993,7 @@ inline expr expm1(expr arg) { return functions::expm1(arg); }
 /// \param arg function argument
 /// \return 2 raised to \a arg
 //		template<typename T> typename enable<expr,T>::type exp2(T arg) {
-//return functions::exp2(arg); }
+// return functions::exp2(arg); }
 inline expr exp2(half arg) { return functions::exp2(arg); }
 inline expr exp2(expr arg) { return functions::exp2(arg); }
 
@@ -2996,23 +3001,25 @@ inline expr exp2(expr arg) { return functions::exp2(arg); }
 /// \param arg function argument
 /// \return logarithm of \a arg to base e
 //		template<typename T> typename enable<expr,T>::type log(T arg) {
-//return functions::log(arg); }
+// return functions::log(arg); }
 inline expr log(half arg) { return functions::log(arg); }
 inline expr log(expr arg) { return functions::log(arg); }
 
 /// Common logorithm.
 /// \param arg function argument
 /// \return logarithm of \a arg to base 10
-//		template<typename T> typename enable<expr,T>::type log10(T arg) {
-//return functions::log10(arg); }
+//		template<typename T> typename enable<expr,T>::type log10(T arg)
+//{
+// return functions::log10(arg); }
 inline expr log10(half arg) { return functions::log10(arg); }
 inline expr log10(expr arg) { return functions::log10(arg); }
 
 /// Natural logorithm.
 /// \param arg function argument
 /// \return logarithm of \a arg plus 1 to base e
-//		template<typename T> typename enable<expr,T>::type log1p(T arg) {
-//return functions::log1p(arg); }
+//		template<typename T> typename enable<expr,T>::type log1p(T arg)
+//{
+// return functions::log1p(arg); }
 inline expr log1p(half arg) { return functions::log1p(arg); }
 inline expr log1p(expr arg) { return functions::log1p(arg); }
 
@@ -3020,7 +3027,7 @@ inline expr log1p(expr arg) { return functions::log1p(arg); }
 /// \param arg function argument
 /// \return logarithm of \a arg to base 2
 //		template<typename T> typename enable<expr,T>::type log2(T arg) {
-//return functions::log2(arg); }
+// return functions::log2(arg); }
 inline expr log2(half arg) { return functions::log2(arg); }
 inline expr log2(expr arg) { return functions::log2(arg); }
 
@@ -3032,7 +3039,7 @@ inline expr log2(expr arg) { return functions::log2(arg); }
 /// \param arg function argument
 /// \return square root of \a arg
 //		template<typename T> typename enable<expr,T>::type sqrt(T arg) {
-//return functions::sqrt(arg); }
+// return functions::sqrt(arg); }
 inline expr sqrt(half arg) { return functions::sqrt(arg); }
 inline expr sqrt(expr arg) { return functions::sqrt(arg); }
 
@@ -3040,7 +3047,7 @@ inline expr sqrt(expr arg) { return functions::sqrt(arg); }
 /// \param arg function argument
 /// \return cubic root of \a arg
 //		template<typename T> typename enable<expr,T>::type cbrt(T arg) {
-//return functions::cbrt(arg); }
+// return functions::cbrt(arg); }
 inline expr cbrt(half arg) { return functions::cbrt(arg); }
 inline expr cbrt(expr arg) { return functions::cbrt(arg); }
 
@@ -3049,7 +3056,7 @@ inline expr cbrt(expr arg) { return functions::cbrt(arg); }
 /// \param y second argument
 /// \return square root of sum of squares without internal over- or underflows
 //		template<typename T,typename U> typename enable<expr,T,U>::type
-//hypot(T x, U y) { return functions::hypot(x, y); }
+// hypot(T x, U y) { return functions::hypot(x, y); }
 inline expr hypot(half x, half y) { return functions::hypot(x, y); }
 inline expr hypot(half x, expr y) { return functions::hypot(x, y); }
 inline expr hypot(expr x, half y) { return functions::hypot(x, y); }
@@ -3060,7 +3067,7 @@ inline expr hypot(expr x, expr y) { return functions::hypot(x, y); }
 /// \param exp second argument
 /// \return \a base raised to \a exp
 //		template<typename T,typename U> typename enable<expr,T,U>::type
-//pow(T base, U exp) { return functions::pow(base, exp); }
+// pow(T base, U exp) { return functions::pow(base, exp); }
 inline expr pow(half base, half exp) { return functions::pow(base, exp); }
 inline expr pow(half base, expr exp) { return functions::pow(base, exp); }
 inline expr pow(expr base, half exp) { return functions::pow(base, exp); }
@@ -3074,7 +3081,7 @@ inline expr pow(expr base, expr exp) { return functions::pow(base, exp); }
 /// \param arg function argument
 /// \return sine value of \a arg
 //		template<typename T> typename enable<expr,T>::type sin(T arg) {
-//return functions::sin(arg); }
+// return functions::sin(arg); }
 inline expr sin(half arg) { return functions::sin(arg); }
 inline expr sin(expr arg) { return functions::sin(arg); }
 
@@ -3082,7 +3089,7 @@ inline expr sin(expr arg) { return functions::sin(arg); }
 /// \param arg function argument
 /// \return cosine value of \a arg
 //		template<typename T> typename enable<expr,T>::type cos(T arg) {
-//return functions::cos(arg); }
+// return functions::cos(arg); }
 inline expr cos(half arg) { return functions::cos(arg); }
 inline expr cos(expr arg) { return functions::cos(arg); }
 
@@ -3090,7 +3097,7 @@ inline expr cos(expr arg) { return functions::cos(arg); }
 /// \param arg function argument
 /// \return tangent value of \a arg
 //		template<typename T> typename enable<expr,T>::type tan(T arg) {
-//return functions::tan(arg); }
+// return functions::tan(arg); }
 inline expr tan(half arg) { return functions::tan(arg); }
 inline expr tan(expr arg) { return functions::tan(arg); }
 
@@ -3098,7 +3105,7 @@ inline expr tan(expr arg) { return functions::tan(arg); }
 /// \param arg function argument
 /// \return arc sine value of \a arg
 //		template<typename T> typename enable<expr,T>::type asin(T arg) {
-//return functions::asin(arg); }
+// return functions::asin(arg); }
 inline expr asin(half arg) { return functions::asin(arg); }
 inline expr asin(expr arg) { return functions::asin(arg); }
 
@@ -3106,7 +3113,7 @@ inline expr asin(expr arg) { return functions::asin(arg); }
 /// \param arg function argument
 /// \return arc cosine value of \a arg
 //		template<typename T> typename enable<expr,T>::type acos(T arg) {
-//return functions::acos(arg); }
+// return functions::acos(arg); }
 inline expr acos(half arg) { return functions::acos(arg); }
 inline expr acos(expr arg) { return functions::acos(arg); }
 
@@ -3114,7 +3121,7 @@ inline expr acos(expr arg) { return functions::acos(arg); }
 /// \param arg function argument
 /// \return arc tangent value of \a arg
 //		template<typename T> typename enable<expr,T>::type atan(T arg) {
-//return functions::atan(arg); }
+// return functions::atan(arg); }
 inline expr atan(half arg) { return functions::atan(arg); }
 inline expr atan(expr arg) { return functions::atan(arg); }
 
@@ -3123,7 +3130,7 @@ inline expr atan(expr arg) { return functions::atan(arg); }
 /// \param y second argument
 /// \return arc tangent value
 //		template<typename T,typename U> typename enable<expr,T,U>::type
-//atan2(T x, U y) { return functions::atan2(x, y); }
+// atan2(T x, U y) { return functions::atan2(x, y); }
 inline expr atan2(half x, half y) { return functions::atan2(x, y); }
 inline expr atan2(half x, expr y) { return functions::atan2(x, y); }
 inline expr atan2(expr x, half y) { return functions::atan2(x, y); }
@@ -3137,7 +3144,7 @@ inline expr atan2(expr x, expr y) { return functions::atan2(x, y); }
 /// \param arg function argument
 /// \return hyperbolic sine value of \a arg
 //		template<typename T> typename enable<expr,T>::type sinh(T arg) {
-//return functions::sinh(arg); }
+// return functions::sinh(arg); }
 inline expr sinh(half arg) { return functions::sinh(arg); }
 inline expr sinh(expr arg) { return functions::sinh(arg); }
 
@@ -3145,7 +3152,7 @@ inline expr sinh(expr arg) { return functions::sinh(arg); }
 /// \param arg function argument
 /// \return hyperbolic cosine value of \a arg
 //		template<typename T> typename enable<expr,T>::type cosh(T arg) {
-//return functions::cosh(arg); }
+// return functions::cosh(arg); }
 inline expr cosh(half arg) { return functions::cosh(arg); }
 inline expr cosh(expr arg) { return functions::cosh(arg); }
 
@@ -3153,31 +3160,34 @@ inline expr cosh(expr arg) { return functions::cosh(arg); }
 /// \param arg function argument
 /// \return hyperbolic tangent value of \a arg
 //		template<typename T> typename enable<expr,T>::type tanh(T arg) {
-//return functions::tanh(arg); }
+// return functions::tanh(arg); }
 inline expr tanh(half arg) { return functions::tanh(arg); }
 inline expr tanh(expr arg) { return functions::tanh(arg); }
 
 /// Hyperbolic area sine.
 /// \param arg function argument
 /// \return area sine value of \a arg
-//		template<typename T> typename enable<expr,T>::type asinh(T arg) {
-//return functions::asinh(arg); }
+//		template<typename T> typename enable<expr,T>::type asinh(T arg)
+//{
+// return functions::asinh(arg); }
 inline expr asinh(half arg) { return functions::asinh(arg); }
 inline expr asinh(expr arg) { return functions::asinh(arg); }
 
 /// Hyperbolic area cosine.
 /// \param arg function argument
 /// \return area cosine value of \a arg
-//		template<typename T> typename enable<expr,T>::type acosh(T arg) {
-//return functions::acosh(arg); }
+//		template<typename T> typename enable<expr,T>::type acosh(T arg)
+//{
+// return functions::acosh(arg); }
 inline expr acosh(half arg) { return functions::acosh(arg); }
 inline expr acosh(expr arg) { return functions::acosh(arg); }
 
 /// Hyperbolic area tangent.
 /// \param arg function argument
 /// \return area tangent value of \a arg
-//		template<typename T> typename enable<expr,T>::type atanh(T arg) {
-//return functions::atanh(arg); }
+//		template<typename T> typename enable<expr,T>::type atanh(T arg)
+//{
+// return functions::atanh(arg); }
 inline expr atanh(half arg) { return functions::atanh(arg); }
 inline expr atanh(expr arg) { return functions::atanh(arg); }
 
@@ -3189,7 +3199,7 @@ inline expr atanh(expr arg) { return functions::atanh(arg); }
 /// \param arg function argument
 /// \return error function value of \a arg
 //		template<typename T> typename enable<expr,T>::type erf(T arg) {
-//return functions::erf(arg); }
+// return functions::erf(arg); }
 inline expr erf(half arg) { return functions::erf(arg); }
 inline expr erf(expr arg) { return functions::erf(arg); }
 
@@ -3197,23 +3207,25 @@ inline expr erf(expr arg) { return functions::erf(arg); }
 /// \param arg function argument
 /// \return 1 minus error function value of \a arg
 //		template<typename T> typename enable<expr,T>::type erfc(T arg) {
-//return functions::erfc(arg); }
+// return functions::erfc(arg); }
 inline expr erfc(half arg) { return functions::erfc(arg); }
 inline expr erfc(expr arg) { return functions::erfc(arg); }
 
 /// Natural logarithm of gamma function.
 /// \param arg function argument
 /// \return natural logarith of gamma function for \a arg
-//		template<typename T> typename enable<expr,T>::type lgamma(T arg) {
-//return functions::lgamma(arg); }
+//		template<typename T> typename enable<expr,T>::type lgamma(T arg)
+//{
+// return functions::lgamma(arg); }
 inline expr lgamma(half arg) { return functions::lgamma(arg); }
 inline expr lgamma(expr arg) { return functions::lgamma(arg); }
 
 /// Gamma function.
 /// \param arg function argument
 /// \return gamma function value of \a arg
-//		template<typename T> typename enable<expr,T>::type tgamma(T arg) {
-//return functions::tgamma(arg); }
+//		template<typename T> typename enable<expr,T>::type tgamma(T arg)
+//{
+// return functions::tgamma(arg); }
 inline expr tgamma(half arg) { return functions::tgamma(arg); }
 inline expr tgamma(expr arg) { return functions::tgamma(arg); }
 
@@ -3225,39 +3237,43 @@ inline expr tgamma(expr arg) { return functions::tgamma(arg); }
 /// \param arg half to round
 /// \return nearest integer not less than \a arg
 //		template<typename T> typename enable<half,T>::type ceil(T arg) {
-//return functions::ceil(arg); }
+// return functions::ceil(arg); }
 inline half ceil(half arg) { return functions::ceil(arg); }
 inline half ceil(expr arg) { return functions::ceil(arg); }
 
 /// Nearest integer not greater than half value.
 /// \param arg half to round
 /// \return nearest integer not greater than \a arg
-//		template<typename T> typename enable<half,T>::type floor(T arg) {
-//return functions::floor(arg); }
+//		template<typename T> typename enable<half,T>::type floor(T arg)
+//{
+// return functions::floor(arg); }
 inline half floor(half arg) { return functions::floor(arg); }
 inline half floor(expr arg) { return functions::floor(arg); }
 
 /// Nearest integer not greater in magnitude than half value.
 /// \param arg half to round
 /// \return nearest integer not greater in magnitude than \a arg
-//		template<typename T> typename enable<half,T>::type trunc(T arg) {
-//return functions::trunc(arg); }
+//		template<typename T> typename enable<half,T>::type trunc(T arg)
+//{
+// return functions::trunc(arg); }
 inline half trunc(half arg) { return functions::trunc(arg); }
 inline half trunc(expr arg) { return functions::trunc(arg); }
 
 /// Nearest integer.
 /// \param arg half to round
 /// \return nearest integer, rounded away from zero in half-way cases
-//		template<typename T> typename enable<half,T>::type round(T arg) {
-//return functions::round(arg); }
+//		template<typename T> typename enable<half,T>::type round(T arg)
+//{
+// return functions::round(arg); }
 inline half round(half arg) { return functions::round(arg); }
 inline half round(expr arg) { return functions::round(arg); }
 
 /// Nearest integer.
 /// \param arg half to round
 /// \return nearest integer, rounded away from zero in half-way cases
-//		template<typename T> typename enable<long,T>::type lround(T arg) {
-//return functions::lround(arg); }
+//		template<typename T> typename enable<long,T>::type lround(T arg)
+//{
+// return functions::lround(arg); }
 inline long lround(half arg) { return functions::lround(arg); }
 inline long lround(expr arg) { return functions::lround(arg); }
 
@@ -3265,7 +3281,7 @@ inline long lround(expr arg) { return functions::lround(arg); }
 /// \param arg half expression to round
 /// \return nearest integer using default rounding mode
 //		template<typename T> typename enable<half,T>::type nearbyint(T
-//arg) { return functions::nearbyint(arg); }
+// arg) { return functions::nearbyint(arg); }
 inline half nearbyint(half arg) { return functions::rint(arg); }
 inline half nearbyint(expr arg) { return functions::rint(arg); }
 
@@ -3273,23 +3289,25 @@ inline half nearbyint(expr arg) { return functions::rint(arg); }
 /// \param arg half expression to round
 /// \return nearest integer using default rounding mode
 //		template<typename T> typename enable<half,T>::type rint(T arg) {
-//return functions::rint(arg); }
+// return functions::rint(arg); }
 inline half rint(half arg) { return functions::rint(arg); }
 inline half rint(expr arg) { return functions::rint(arg); }
 
 /// Nearest integer using half's internal rounding mode.
 /// \param arg half expression to round
 /// \return nearest integer using default rounding mode
-//		template<typename T> typename enable<long,T>::type lrint(T arg) {
-//return functions::lrint(arg); }
+//		template<typename T> typename enable<long,T>::type lrint(T arg)
+//{
+// return functions::lrint(arg); }
 inline long lrint(half arg) { return functions::lrint(arg); }
 inline long lrint(expr arg) { return functions::lrint(arg); }
 #if HALF_ENABLE_CPP11_LONG_LONG
 /// Nearest integer.
 /// \param arg half to round
 /// \return nearest integer, rounded away from zero in half-way cases
-//		template<typename T> typename enable<long long,T>::type llround(T
-//arg) { return functions::llround(arg); }
+//		template<typename T> typename enable<long long,T>::type
+// llround(T
+// arg) { return functions::llround(arg); }
 inline long long llround(half arg) { return functions::llround(arg); }
 inline long long llround(expr arg) { return functions::llround(arg); }
 
@@ -3297,7 +3315,7 @@ inline long long llround(expr arg) { return functions::llround(arg); }
 /// \param arg half expression to round
 /// \return nearest integer using default rounding mode
 //		template<typename T> typename enable<long long,T>::type llrint(T
-//arg) { return functions::llrint(arg); }
+// arg) { return functions::llrint(arg); }
 inline long long llrint(half arg) { return functions::llrint(arg); }
 inline long long llrint(expr arg) { return functions::llrint(arg); }
 #endif
@@ -3311,7 +3329,7 @@ inline long long llrint(expr arg) { return functions::llrint(arg); }
 /// \param exp address to store exponent at
 /// \return significant in range [0.5, 1)
 //		template<typename T> typename enable<half,T>::type frexp(T arg,
-//int *exp) { return functions::frexp(arg, exp); }
+// int *exp) { return functions::frexp(arg, exp); }
 inline half frexp(half arg, int *exp) { return functions::frexp(arg, exp); }
 inline half frexp(expr arg, int *exp) { return functions::frexp(arg, exp); }
 
@@ -3320,7 +3338,7 @@ inline half frexp(expr arg, int *exp) { return functions::frexp(arg, exp); }
 /// \param exp power of two to multiply with
 /// \return \a arg multplied by 2 raised to \a exp
 //		template<typename T> typename enable<half,T>::type ldexp(T arg,
-//int exp) { return functions::scalbln(arg, exp); }
+// int exp) { return functions::scalbln(arg, exp); }
 inline half ldexp(half arg, int exp) { return functions::scalbln(arg, exp); }
 inline half ldexp(expr arg, int exp) { return functions::scalbln(arg, exp); }
 
@@ -3329,7 +3347,7 @@ inline half ldexp(expr arg, int exp) { return functions::scalbln(arg, exp); }
 /// \param iptr address to store integer part at
 /// \return fractional part
 //		template<typename T> typename enable<half,T>::type modf(T arg,
-//half *iptr) { return functions::modf(arg, iptr); }
+// half *iptr) { return functions::modf(arg, iptr); }
 inline half modf(half arg, half *iptr) { return functions::modf(arg, iptr); }
 inline half modf(expr arg, half *iptr) { return functions::modf(arg, iptr); }
 
@@ -3338,7 +3356,7 @@ inline half modf(expr arg, half *iptr) { return functions::modf(arg, iptr); }
 /// \param exp power of two to multiply with
 /// \return \a arg multplied by 2 raised to \a exp
 //		template<typename T> typename enable<half,T>::type scalbn(T arg,
-//int exp) { return functions::scalbln(arg, exp); }
+// int exp) { return functions::scalbln(arg, exp); }
 inline half scalbn(half arg, int exp) { return functions::scalbln(arg, exp); }
 inline half scalbn(expr arg, int exp) { return functions::scalbln(arg, exp); }
 
@@ -3346,8 +3364,9 @@ inline half scalbn(expr arg, int exp) { return functions::scalbln(arg, exp); }
 /// \param arg number to modify
 /// \param exp power of two to multiply with
 /// \return \a arg multplied by 2 raised to \a exp
-//		template<typename T> typename enable<half,T>::type scalbln(T arg,
-//long exp) { return functions::scalbln(arg, exp); }
+//		template<typename T> typename enable<half,T>::type scalbln(T
+// arg,
+// long exp) { return functions::scalbln(arg, exp); }
 inline half scalbln(half arg, long exp) { return functions::scalbln(arg, exp); }
 inline half scalbln(expr arg, long exp) { return functions::scalbln(arg, exp); }
 
@@ -3358,7 +3377,7 @@ inline half scalbln(expr arg, long exp) { return functions::scalbln(arg, exp); }
 /// \retval FP_ILOGBNAN for NaN
 /// \retval MAX_INT for infinity
 //		template<typename T> typename enable<int,T>::type ilogb(T arg) {
-//return functions::ilogb(arg); }
+// return functions::ilogb(arg); }
 inline int ilogb(half arg) { return functions::ilogb(arg); }
 inline int ilogb(expr arg) { return functions::ilogb(arg); }
 
@@ -3366,7 +3385,7 @@ inline int ilogb(expr arg) { return functions::ilogb(arg); }
 /// \param arg number to query
 /// \return floating point exponent
 //		template<typename T> typename enable<half,T>::type logb(T arg) {
-//return functions::logb(arg); }
+// return functions::logb(arg); }
 inline half logb(half arg) { return functions::logb(arg); }
 inline half logb(expr arg) { return functions::logb(arg); }
 
@@ -3375,7 +3394,7 @@ inline half logb(expr arg) { return functions::logb(arg); }
 /// \param to direction towards which to compute next value
 /// \return next representable value after \a from in direction towards \a to
 //		template<typename T,typename U> typename enable<half,T,U>::type
-//nextafter(T from, U to) { return functions::nextafter(from, to); }
+// nextafter(T from, U to) { return functions::nextafter(from, to); }
 inline half nextafter(half from, half to) {
   return functions::nextafter(from, to);
 }
@@ -3394,7 +3413,7 @@ inline half nextafter(expr from, expr to) {
 /// \param to direction towards which to compute next value
 /// \return next representable value after \a from in direction towards \a to
 //		template<typename T> typename enable<half,T>::type nexttoward(T
-//from, long double to) { return functions::nexttoward(from, to); }
+// from, long double to) { return functions::nexttoward(from, to); }
 inline half nexttoward(half from, long double to) {
   return functions::nexttoward(from, to);
 }
@@ -3407,7 +3426,7 @@ inline half nexttoward(expr from, long double to) {
 /// \param y value to take sign from
 /// \return value equal to \a x in magnitude and to \a y in sign
 //		template<typename T,typename U> typename enable<half,T,U>::type
-//copysign(T x, U y) { return functions::copysign(x, y); }
+// copysign(T x, U y) { return functions::copysign(x, y); }
 inline half copysign(half x, half y) { return functions::copysign(x, y); }
 inline half copysign(half x, expr y) { return functions::copysign(x, y); }
 inline half copysign(expr x, half y) { return functions::copysign(x, y); }
@@ -3425,7 +3444,7 @@ inline half copysign(expr x, expr y) { return functions::copysign(x, y); }
 /// \retval FP_NAN for NaNs
 /// \retval FP_NORMAL for all other (normal) values
 //		template<typename T> typename enable<int,T>::type fpclassify(T
-//arg) { return functions::fpclassify(arg); }
+// arg) { return functions::fpclassify(arg); }
 inline int fpclassify(half arg) { return functions::fpclassify(arg); }
 inline int fpclassify(expr arg) { return functions::fpclassify(arg); }
 
@@ -3433,7 +3452,8 @@ inline int fpclassify(expr arg) { return functions::fpclassify(arg); }
 /// \param arg number to check
 /// \retval true if neither infinity nor NaN
 /// \retval false else
-//		template<typename T> typename enable<bool,T>::type isfinite(T arg)
+//		template<typename T> typename enable<bool,T>::type isfinite(T
+// arg)
 //{ return functions::isfinite(arg); }
 inline bool isfinite(half arg) { return functions::isfinite(arg); }
 inline bool isfinite(expr arg) { return functions::isfinite(arg); }
@@ -3442,8 +3462,9 @@ inline bool isfinite(expr arg) { return functions::isfinite(arg); }
 /// \param arg number to check
 /// \retval true for positive or negative infinity
 /// \retval false else
-//		template<typename T> typename enable<bool,T>::type isinf(T arg) {
-//return functions::isinf(arg); }
+//		template<typename T> typename enable<bool,T>::type isinf(T arg)
+//{
+// return functions::isinf(arg); }
 inline bool isinf(half arg) { return functions::isinf(arg); }
 inline bool isinf(expr arg) { return functions::isinf(arg); }
 
@@ -3451,8 +3472,9 @@ inline bool isinf(expr arg) { return functions::isinf(arg); }
 /// \param arg number to check
 /// \retval true for NaNs
 /// \retval false else
-//		template<typename T> typename enable<bool,T>::type isnan(T arg) {
-//return functions::isnan(arg); }
+//		template<typename T> typename enable<bool,T>::type isnan(T arg)
+//{
+// return functions::isnan(arg); }
 inline bool isnan(half arg) { return functions::isnan(arg); }
 inline bool isnan(expr arg) { return functions::isnan(arg); }
 
@@ -3460,7 +3482,8 @@ inline bool isnan(expr arg) { return functions::isnan(arg); }
 /// \param arg number to check
 /// \retval true if normal number
 /// \retval false if either subnormal, zero, infinity or NaN
-//		template<typename T> typename enable<bool,T>::type isnormal(T arg)
+//		template<typename T> typename enable<bool,T>::type isnormal(T
+// arg)
 //{ return functions::isnormal(arg); }
 inline bool isnormal(half arg) { return functions::isnormal(arg); }
 inline bool isnormal(expr arg) { return functions::isnormal(arg); }
@@ -3469,7 +3492,8 @@ inline bool isnormal(expr arg) { return functions::isnormal(arg); }
 /// \param arg number to check
 /// \retval true for negative number
 /// \retval false for positive number
-//		template<typename T> typename enable<bool,T>::type signbit(T arg)
+//		template<typename T> typename enable<bool,T>::type signbit(T
+// arg)
 //{ return functions::signbit(arg); }
 inline bool signbit(half arg) { return functions::signbit(arg); }
 inline bool signbit(expr arg) { return functions::signbit(arg); }
@@ -3484,7 +3508,7 @@ inline bool signbit(expr arg) { return functions::signbit(arg); }
 /// \retval true if \a x greater than \a y
 /// \retval false else
 //		template<typename T,typename U> typename enable<bool,T,U>::type
-//isgreater(T x, U y) { return functions::isgreater(x, y); }
+// isgreater(T x, U y) { return functions::isgreater(x, y); }
 inline bool isgreater(half x, half y) { return functions::isgreater(x, y); }
 inline bool isgreater(half x, expr y) { return functions::isgreater(x, y); }
 inline bool isgreater(expr x, half y) { return functions::isgreater(x, y); }
@@ -3496,7 +3520,7 @@ inline bool isgreater(expr x, expr y) { return functions::isgreater(x, y); }
 /// \retval true if \a x greater equal \a y
 /// \retval false else
 //		template<typename T,typename U> typename enable<bool,T,U>::type
-//isgreaterequal(T x, U y) { return functions::isgreaterequal(x, y); }
+// isgreaterequal(T x, U y) { return functions::isgreaterequal(x, y); }
 inline bool isgreaterequal(half x, half y) {
   return functions::isgreaterequal(x, y);
 }
@@ -3516,7 +3540,7 @@ inline bool isgreaterequal(expr x, expr y) {
 /// \retval true if \a x less than \a y
 /// \retval false else
 //		template<typename T,typename U> typename enable<bool,T,U>::type
-//isless(T x, U y) { return functions::isless(x, y); }
+// isless(T x, U y) { return functions::isless(x, y); }
 inline bool isless(half x, half y) { return functions::isless(x, y); }
 inline bool isless(half x, expr y) { return functions::isless(x, y); }
 inline bool isless(expr x, half y) { return functions::isless(x, y); }
@@ -3528,7 +3552,7 @@ inline bool isless(expr x, expr y) { return functions::isless(x, y); }
 /// \retval true if \a x less equal \a y
 /// \retval false else
 //		template<typename T,typename U> typename enable<bool,T,U>::type
-//islessequal(T x, U y) { return functions::islessequal(x, y); }
+// islessequal(T x, U y) { return functions::islessequal(x, y); }
 inline bool islessequal(half x, half y) { return functions::islessequal(x, y); }
 inline bool islessequal(half x, expr y) { return functions::islessequal(x, y); }
 inline bool islessequal(expr x, half y) { return functions::islessequal(x, y); }
@@ -3540,7 +3564,7 @@ inline bool islessequal(expr x, expr y) { return functions::islessequal(x, y); }
 /// \retval true if either less or greater
 /// \retval false else
 //		template<typename T,typename U> typename enable<bool,T,U>::type
-//islessgreater(T x, U y) { return functions::islessgreater(x, y); }
+// islessgreater(T x, U y) { return functions::islessgreater(x, y); }
 inline bool islessgreater(half x, half y) {
   return functions::islessgreater(x, y);
 }
@@ -3560,7 +3584,7 @@ inline bool islessgreater(expr x, expr y) {
 /// \retval true if unordered (one or two NaN operands)
 /// \retval false else
 //		template<typename T,typename U> typename enable<bool,T,U>::type
-//isunordered(T x, U y) { return functions::isunordered(x, y); }
+// isunordered(T x, U y) { return functions::isunordered(x, y); }
 inline bool isunordered(half x, half y) { return functions::isunordered(x, y); }
 inline bool isunordered(half x, expr y) { return functions::isunordered(x, y); }
 inline bool isunordered(expr x, half y) { return functions::isunordered(x, y); }

--- a/src/cuda-sim/half.h
+++ b/src/cuda-sim/half.h
@@ -551,8 +551,8 @@ bool builtin_signbit(T arg) {
 template <std::float_round_style R>
 uint16 float2half_impl(float value, true_type) {
   typedef bits<float>::type uint32;
-  uint32 bits;  // = *reinterpret_cast<uint32*>(&value);		//violating
-                // strict aliasing!
+  uint32 bits;  // = *reinterpret_cast<uint32*>(&value);
+                // //violating strict aliasing!
   std::memcpy(&bits, &value, sizeof(float));
   /*			uint16 hbits = (bits>>16) & 0x8000;
                           bits &= 0x7FFFFFFF;
@@ -728,8 +728,8 @@ template <std::float_round_style R>
 uint16 float2half_impl(double value, true_type) {
   typedef bits<float>::type uint32;
   typedef bits<double>::type uint64;
-  uint64 bits;  // = *reinterpret_cast<uint64*>(&value);		//violating
-                // strict aliasing!
+  uint64 bits;  // = *reinterpret_cast<uint64*>(&value);
+                // //violating strict aliasing!
   std::memcpy(&bits, &value, sizeof(double));
   uint32 hi = bits >> 32, lo = bits & 0xFFFFFFFF;
   uint16 hbits = (hi >> 16) & 0x8000;
@@ -1257,8 +1257,8 @@ inline float half2float_impl(uint16 value, float, true_type) {
       1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024};
   uint32 bits = mantissa_table[offset_table[value >> 10] + (value & 0x3FF)] +
                 exponent_table[value >> 10];
-  //			return *reinterpret_cast<float*>(&bits);			//violating
-  //strict aliasing!
+  //			return *reinterpret_cast<float*>(&bits);
+  ////violating strict aliasing!
   float out;
   std::memcpy(&out, &bits, sizeof(float));
   return out;
@@ -1279,8 +1279,8 @@ inline double half2float_impl(uint16 value, double, true_type) {
     hi += static_cast<uint32>(abs) << 10;
   }
   uint64 bits = static_cast<uint64>(hi) << 32;
-  //			return *reinterpret_cast<double*>(&bits);			//violating
-  //strict aliasing!
+  //			return *reinterpret_cast<double*>(&bits);
+  ////violating strict aliasing!
   double out;
   std::memcpy(&out, &bits, sizeof(double));
   return out;
@@ -2719,7 +2719,7 @@ std::basic_istream<charT, traits> &operator>>(
 /// \param arg operand
 /// \return absolute value of \a arg
 //		template<typename T> typename enable<T,T>::type abs(T arg) {
-//return unary_specialized<T>::fabs(arg); }
+// return unary_specialized<T>::fabs(arg); }
 inline half abs(half arg) { return unary_specialized<half>::fabs(arg); }
 inline expr abs(expr arg) { return unary_specialized<expr>::fabs(arg); }
 
@@ -2727,7 +2727,7 @@ inline expr abs(expr arg) { return unary_specialized<expr>::fabs(arg); }
 /// \param arg operand
 /// \return absolute value of \a arg
 //		template<typename T> typename enable<T,T>::type fabs(T arg) {
-//return unary_specialized<T>::fabs(arg); }
+// return unary_specialized<T>::fabs(arg); }
 inline half fabs(half arg) { return unary_specialized<half>::fabs(arg); }
 inline expr fabs(expr arg) { return unary_specialized<expr>::fabs(arg); }
 
@@ -2736,7 +2736,7 @@ inline expr fabs(expr arg) { return unary_specialized<expr>::fabs(arg); }
 /// \param y second operand
 /// \return remainder of floating point division.
 //		template<typename T,typename U> typename enable<expr,T,U>::type
-//fmod(T x, U y) { return functions::fmod(x, y); }
+// fmod(T x, U y) { return functions::fmod(x, y); }
 inline expr fmod(half x, half y) { return functions::fmod(x, y); }
 inline expr fmod(half x, expr y) { return functions::fmod(x, y); }
 inline expr fmod(expr x, half y) { return functions::fmod(x, y); }
@@ -2747,7 +2747,7 @@ inline expr fmod(expr x, expr y) { return functions::fmod(x, y); }
 /// \param y second operand
 /// \return remainder of floating point division.
 //		template<typename T,typename U> typename enable<expr,T,U>::type
-//remainder(T x, U y) { return functions::remainder(x, y); }
+// remainder(T x, U y) { return functions::remainder(x, y); }
 inline expr remainder(half x, half y) { return functions::remainder(x, y); }
 inline expr remainder(half x, expr y) { return functions::remainder(x, y); }
 inline expr remainder(expr x, half y) { return functions::remainder(x, y); }
@@ -2759,7 +2759,7 @@ inline expr remainder(expr x, expr y) { return functions::remainder(x, y); }
 /// \param quo address to store some bits of quotient at
 /// \return remainder of floating point division.
 //		template<typename T,typename U> typename enable<expr,T,U>::type
-//remquo(T x, U y, int *quo) { return functions::remquo(x, y, quo); }
+// remquo(T x, U y, int *quo) { return functions::remquo(x, y, quo); }
 inline expr remquo(half x, half y, int *quo) {
   return functions::remquo(x, y, quo);
 }
@@ -2779,7 +2779,7 @@ inline expr remquo(expr x, expr y, int *quo) {
 /// \param z third operand
 /// \return ( \a x * \a y ) + \a z rounded as one operation.
 //		template<typename T,typename U,typename V> typename
-//enable<expr,T,U,V>::type fma(T x, U y, V z) { return functions::fma(x, y, z);
+// enable<expr,T,U,V>::type fma(T x, U y, V z) { return functions::fma(x, y, z);
 //}
 inline expr fma(half x, half y, half z) { return functions::fma(x, y, z); }
 inline expr fma(half x, half y, expr z) { return functions::fma(x, y, z); }
@@ -2794,8 +2794,8 @@ inline expr fma(expr x, expr y, expr z) { return functions::fma(x, y, z); }
 /// \param x first operand
 /// \param y second operand
 /// \return maximum of operands
-//		template<typename T,typename U> typename result<T,U>::type fmax(T
-//x, U y) { return binary_specialized<T,U>::fmax(x, y); }
+//		template<typename T,typename U> typename result<T,U>::type
+// fmax(T x, U y) { return binary_specialized<T,U>::fmax(x, y); }
 inline half fmax(half x, half y) {
   return binary_specialized<half, half>::fmax(x, y);
 }
@@ -2813,8 +2813,8 @@ inline expr fmax(expr x, expr y) {
 /// \param x first operand
 /// \param y second operand
 /// \return minimum of operands
-//		template<typename T,typename U> typename result<T,U>::type fmin(T
-//x, U y) { return binary_specialized<T,U>::fmin(x, y); }
+//		template<typename T,typename U> typename result<T,U>::type
+// fmin(T x, U y) { return binary_specialized<T,U>::fmin(x, y); }
 inline half fmin(half x, half y) {
   return binary_specialized<half, half>::fmin(x, y);
 }
@@ -2833,7 +2833,7 @@ inline expr fmin(expr x, expr y) {
 /// \param y second operand
 /// \return \a x - \a y or 0 if difference negative
 //		template<typename T,typename U> typename enable<expr,T,U>::type
-//fdim(T x, U y) { return functions::fdim(x, y); }
+// fdim(T x, U y) { return functions::fdim(x, y); }
 inline expr fdim(half x, half y) { return functions::fdim(x, y); }
 inline expr fdim(half x, expr y) { return functions::fdim(x, y); }
 inline expr fdim(expr x, half y) { return functions::fdim(x, y); }
@@ -2851,15 +2851,15 @@ inline half nanh(const char *) { return functions::nanh(); }
 /// \param arg function argument
 /// \return e raised to \a arg
 //		template<typename T> typename enable<expr,T>::type exp(T arg) {
-//return functions::exp(arg); }
+// return functions::exp(arg); }
 inline expr exp(half arg) { return functions::exp(arg); }
 inline expr exp(expr arg) { return functions::exp(arg); }
 
 /// Exponential minus one.
 /// \param arg function argument
 /// \return e raised to \a arg subtracted by 1
-//		template<typename T> typename enable<expr,T>::type expm1(T arg) {
-//return functions::expm1(arg); }
+//		template<typename T> typename enable<expr,T>::type expm1(T arg)
+//{ return functions::expm1(arg); }
 inline expr expm1(half arg) { return functions::expm1(arg); }
 inline expr expm1(expr arg) { return functions::expm1(arg); }
 
@@ -2867,7 +2867,7 @@ inline expr expm1(expr arg) { return functions::expm1(arg); }
 /// \param arg function argument
 /// \return 2 raised to \a arg
 //		template<typename T> typename enable<expr,T>::type exp2(T arg) {
-//return functions::exp2(arg); }
+// return functions::exp2(arg); }
 inline expr exp2(half arg) { return functions::exp2(arg); }
 inline expr exp2(expr arg) { return functions::exp2(arg); }
 
@@ -2875,23 +2875,23 @@ inline expr exp2(expr arg) { return functions::exp2(arg); }
 /// \param arg function argument
 /// \return logarithm of \a arg to base e
 //		template<typename T> typename enable<expr,T>::type log(T arg) {
-//return functions::log(arg); }
+// return functions::log(arg); }
 inline expr log(half arg) { return functions::log(arg); }
 inline expr log(expr arg) { return functions::log(arg); }
 
 /// Common logorithm.
 /// \param arg function argument
 /// \return logarithm of \a arg to base 10
-//		template<typename T> typename enable<expr,T>::type log10(T arg) {
-//return functions::log10(arg); }
+//		template<typename T> typename enable<expr,T>::type log10(T arg)
+//{ return functions::log10(arg); }
 inline expr log10(half arg) { return functions::log10(arg); }
 inline expr log10(expr arg) { return functions::log10(arg); }
 
 /// Natural logorithm.
 /// \param arg function argument
 /// \return logarithm of \a arg plus 1 to base e
-//		template<typename T> typename enable<expr,T>::type log1p(T arg) {
-//return functions::log1p(arg); }
+//		template<typename T> typename enable<expr,T>::type log1p(T arg)
+//{ return functions::log1p(arg); }
 inline expr log1p(half arg) { return functions::log1p(arg); }
 inline expr log1p(expr arg) { return functions::log1p(arg); }
 
@@ -2899,7 +2899,7 @@ inline expr log1p(expr arg) { return functions::log1p(arg); }
 /// \param arg function argument
 /// \return logarithm of \a arg to base 2
 //		template<typename T> typename enable<expr,T>::type log2(T arg) {
-//return functions::log2(arg); }
+// return functions::log2(arg); }
 inline expr log2(half arg) { return functions::log2(arg); }
 inline expr log2(expr arg) { return functions::log2(arg); }
 
@@ -2911,7 +2911,7 @@ inline expr log2(expr arg) { return functions::log2(arg); }
 /// \param arg function argument
 /// \return square root of \a arg
 //		template<typename T> typename enable<expr,T>::type sqrt(T arg) {
-//return functions::sqrt(arg); }
+// return functions::sqrt(arg); }
 inline expr sqrt(half arg) { return functions::sqrt(arg); }
 inline expr sqrt(expr arg) { return functions::sqrt(arg); }
 
@@ -2919,7 +2919,7 @@ inline expr sqrt(expr arg) { return functions::sqrt(arg); }
 /// \param arg function argument
 /// \return cubic root of \a arg
 //		template<typename T> typename enable<expr,T>::type cbrt(T arg) {
-//return functions::cbrt(arg); }
+// return functions::cbrt(arg); }
 inline expr cbrt(half arg) { return functions::cbrt(arg); }
 inline expr cbrt(expr arg) { return functions::cbrt(arg); }
 
@@ -2928,7 +2928,7 @@ inline expr cbrt(expr arg) { return functions::cbrt(arg); }
 /// \param y second argument
 /// \return square root of sum of squares without internal over- or underflows
 //		template<typename T,typename U> typename enable<expr,T,U>::type
-//hypot(T x, U y) { return functions::hypot(x, y); }
+// hypot(T x, U y) { return functions::hypot(x, y); }
 inline expr hypot(half x, half y) { return functions::hypot(x, y); }
 inline expr hypot(half x, expr y) { return functions::hypot(x, y); }
 inline expr hypot(expr x, half y) { return functions::hypot(x, y); }
@@ -2939,7 +2939,7 @@ inline expr hypot(expr x, expr y) { return functions::hypot(x, y); }
 /// \param exp second argument
 /// \return \a base raised to \a exp
 //		template<typename T,typename U> typename enable<expr,T,U>::type
-//pow(T base, U exp) { return functions::pow(base, exp); }
+// pow(T base, U exp) { return functions::pow(base, exp); }
 inline expr pow(half base, half exp) { return functions::pow(base, exp); }
 inline expr pow(half base, expr exp) { return functions::pow(base, exp); }
 inline expr pow(expr base, half exp) { return functions::pow(base, exp); }
@@ -2953,7 +2953,7 @@ inline expr pow(expr base, expr exp) { return functions::pow(base, exp); }
 /// \param arg function argument
 /// \return sine value of \a arg
 //		template<typename T> typename enable<expr,T>::type sin(T arg) {
-//return functions::sin(arg); }
+// return functions::sin(arg); }
 inline expr sin(half arg) { return functions::sin(arg); }
 inline expr sin(expr arg) { return functions::sin(arg); }
 
@@ -2961,7 +2961,7 @@ inline expr sin(expr arg) { return functions::sin(arg); }
 /// \param arg function argument
 /// \return cosine value of \a arg
 //		template<typename T> typename enable<expr,T>::type cos(T arg) {
-//return functions::cos(arg); }
+// return functions::cos(arg); }
 inline expr cos(half arg) { return functions::cos(arg); }
 inline expr cos(expr arg) { return functions::cos(arg); }
 
@@ -2969,7 +2969,7 @@ inline expr cos(expr arg) { return functions::cos(arg); }
 /// \param arg function argument
 /// \return tangent value of \a arg
 //		template<typename T> typename enable<expr,T>::type tan(T arg) {
-//return functions::tan(arg); }
+// return functions::tan(arg); }
 inline expr tan(half arg) { return functions::tan(arg); }
 inline expr tan(expr arg) { return functions::tan(arg); }
 
@@ -2977,7 +2977,7 @@ inline expr tan(expr arg) { return functions::tan(arg); }
 /// \param arg function argument
 /// \return arc sine value of \a arg
 //		template<typename T> typename enable<expr,T>::type asin(T arg) {
-//return functions::asin(arg); }
+// return functions::asin(arg); }
 inline expr asin(half arg) { return functions::asin(arg); }
 inline expr asin(expr arg) { return functions::asin(arg); }
 
@@ -2985,7 +2985,7 @@ inline expr asin(expr arg) { return functions::asin(arg); }
 /// \param arg function argument
 /// \return arc cosine value of \a arg
 //		template<typename T> typename enable<expr,T>::type acos(T arg) {
-//return functions::acos(arg); }
+// return functions::acos(arg); }
 inline expr acos(half arg) { return functions::acos(arg); }
 inline expr acos(expr arg) { return functions::acos(arg); }
 
@@ -2993,7 +2993,7 @@ inline expr acos(expr arg) { return functions::acos(arg); }
 /// \param arg function argument
 /// \return arc tangent value of \a arg
 //		template<typename T> typename enable<expr,T>::type atan(T arg) {
-//return functions::atan(arg); }
+// return functions::atan(arg); }
 inline expr atan(half arg) { return functions::atan(arg); }
 inline expr atan(expr arg) { return functions::atan(arg); }
 
@@ -3002,7 +3002,7 @@ inline expr atan(expr arg) { return functions::atan(arg); }
 /// \param y second argument
 /// \return arc tangent value
 //		template<typename T,typename U> typename enable<expr,T,U>::type
-//atan2(T x, U y) { return functions::atan2(x, y); }
+// atan2(T x, U y) { return functions::atan2(x, y); }
 inline expr atan2(half x, half y) { return functions::atan2(x, y); }
 inline expr atan2(half x, expr y) { return functions::atan2(x, y); }
 inline expr atan2(expr x, half y) { return functions::atan2(x, y); }
@@ -3016,7 +3016,7 @@ inline expr atan2(expr x, expr y) { return functions::atan2(x, y); }
 /// \param arg function argument
 /// \return hyperbolic sine value of \a arg
 //		template<typename T> typename enable<expr,T>::type sinh(T arg) {
-//return functions::sinh(arg); }
+// return functions::sinh(arg); }
 inline expr sinh(half arg) { return functions::sinh(arg); }
 inline expr sinh(expr arg) { return functions::sinh(arg); }
 
@@ -3024,7 +3024,7 @@ inline expr sinh(expr arg) { return functions::sinh(arg); }
 /// \param arg function argument
 /// \return hyperbolic cosine value of \a arg
 //		template<typename T> typename enable<expr,T>::type cosh(T arg) {
-//return functions::cosh(arg); }
+// return functions::cosh(arg); }
 inline expr cosh(half arg) { return functions::cosh(arg); }
 inline expr cosh(expr arg) { return functions::cosh(arg); }
 
@@ -3032,31 +3032,31 @@ inline expr cosh(expr arg) { return functions::cosh(arg); }
 /// \param arg function argument
 /// \return hyperbolic tangent value of \a arg
 //		template<typename T> typename enable<expr,T>::type tanh(T arg) {
-//return functions::tanh(arg); }
+// return functions::tanh(arg); }
 inline expr tanh(half arg) { return functions::tanh(arg); }
 inline expr tanh(expr arg) { return functions::tanh(arg); }
 
 /// Hyperbolic area sine.
 /// \param arg function argument
 /// \return area sine value of \a arg
-//		template<typename T> typename enable<expr,T>::type asinh(T arg) {
-//return functions::asinh(arg); }
+//		template<typename T> typename enable<expr,T>::type asinh(T arg)
+//{ return functions::asinh(arg); }
 inline expr asinh(half arg) { return functions::asinh(arg); }
 inline expr asinh(expr arg) { return functions::asinh(arg); }
 
 /// Hyperbolic area cosine.
 /// \param arg function argument
 /// \return area cosine value of \a arg
-//		template<typename T> typename enable<expr,T>::type acosh(T arg) {
-//return functions::acosh(arg); }
+//		template<typename T> typename enable<expr,T>::type acosh(T arg)
+//{ return functions::acosh(arg); }
 inline expr acosh(half arg) { return functions::acosh(arg); }
 inline expr acosh(expr arg) { return functions::acosh(arg); }
 
 /// Hyperbolic area tangent.
 /// \param arg function argument
 /// \return area tangent value of \a arg
-//		template<typename T> typename enable<expr,T>::type atanh(T arg) {
-//return functions::atanh(arg); }
+//		template<typename T> typename enable<expr,T>::type atanh(T arg)
+//{ return functions::atanh(arg); }
 inline expr atanh(half arg) { return functions::atanh(arg); }
 inline expr atanh(expr arg) { return functions::atanh(arg); }
 
@@ -3068,7 +3068,7 @@ inline expr atanh(expr arg) { return functions::atanh(arg); }
 /// \param arg function argument
 /// \return error function value of \a arg
 //		template<typename T> typename enable<expr,T>::type erf(T arg) {
-//return functions::erf(arg); }
+// return functions::erf(arg); }
 inline expr erf(half arg) { return functions::erf(arg); }
 inline expr erf(expr arg) { return functions::erf(arg); }
 
@@ -3076,23 +3076,23 @@ inline expr erf(expr arg) { return functions::erf(arg); }
 /// \param arg function argument
 /// \return 1 minus error function value of \a arg
 //		template<typename T> typename enable<expr,T>::type erfc(T arg) {
-//return functions::erfc(arg); }
+// return functions::erfc(arg); }
 inline expr erfc(half arg) { return functions::erfc(arg); }
 inline expr erfc(expr arg) { return functions::erfc(arg); }
 
 /// Natural logarithm of gamma function.
 /// \param arg function argument
 /// \return natural logarith of gamma function for \a arg
-//		template<typename T> typename enable<expr,T>::type lgamma(T arg) {
-//return functions::lgamma(arg); }
+//		template<typename T> typename enable<expr,T>::type lgamma(T arg)
+//{ return functions::lgamma(arg); }
 inline expr lgamma(half arg) { return functions::lgamma(arg); }
 inline expr lgamma(expr arg) { return functions::lgamma(arg); }
 
 /// Gamma function.
 /// \param arg function argument
 /// \return gamma function value of \a arg
-//		template<typename T> typename enable<expr,T>::type tgamma(T arg) {
-//return functions::tgamma(arg); }
+//		template<typename T> typename enable<expr,T>::type tgamma(T arg)
+//{ return functions::tgamma(arg); }
 inline expr tgamma(half arg) { return functions::tgamma(arg); }
 inline expr tgamma(expr arg) { return functions::tgamma(arg); }
 
@@ -3104,39 +3104,39 @@ inline expr tgamma(expr arg) { return functions::tgamma(arg); }
 /// \param arg half to round
 /// \return nearest integer not less than \a arg
 //		template<typename T> typename enable<half,T>::type ceil(T arg) {
-//return functions::ceil(arg); }
+// return functions::ceil(arg); }
 inline half ceil(half arg) { return functions::ceil(arg); }
 inline half ceil(expr arg) { return functions::ceil(arg); }
 
 /// Nearest integer not greater than half value.
 /// \param arg half to round
 /// \return nearest integer not greater than \a arg
-//		template<typename T> typename enable<half,T>::type floor(T arg) {
-//return functions::floor(arg); }
+//		template<typename T> typename enable<half,T>::type floor(T arg)
+//{ return functions::floor(arg); }
 inline half floor(half arg) { return functions::floor(arg); }
 inline half floor(expr arg) { return functions::floor(arg); }
 
 /// Nearest integer not greater in magnitude than half value.
 /// \param arg half to round
 /// \return nearest integer not greater in magnitude than \a arg
-//		template<typename T> typename enable<half,T>::type trunc(T arg) {
-//return functions::trunc(arg); }
+//		template<typename T> typename enable<half,T>::type trunc(T arg)
+//{ return functions::trunc(arg); }
 inline half trunc(half arg) { return functions::trunc(arg); }
 inline half trunc(expr arg) { return functions::trunc(arg); }
 
 /// Nearest integer.
 /// \param arg half to round
 /// \return nearest integer, rounded away from zero in half-way cases
-//		template<typename T> typename enable<half,T>::type round(T arg) {
-//return functions::round(arg); }
+//		template<typename T> typename enable<half,T>::type round(T arg)
+//{ return functions::round(arg); }
 inline half round(half arg) { return functions::round(arg); }
 inline half round(expr arg) { return functions::round(arg); }
 
 /// Nearest integer.
 /// \param arg half to round
 /// \return nearest integer, rounded away from zero in half-way cases
-//		template<typename T> typename enable<long,T>::type lround(T arg) {
-//return functions::lround(arg); }
+//		template<typename T> typename enable<long,T>::type lround(T arg)
+//{ return functions::lround(arg); }
 inline long lround(half arg) { return functions::lround(arg); }
 inline long lround(expr arg) { return functions::lround(arg); }
 
@@ -3144,7 +3144,7 @@ inline long lround(expr arg) { return functions::lround(arg); }
 /// \param arg half expression to round
 /// \return nearest integer using default rounding mode
 //		template<typename T> typename enable<half,T>::type nearbyint(T
-//arg) { return functions::nearbyint(arg); }
+// arg) { return functions::nearbyint(arg); }
 inline half nearbyint(half arg) { return functions::rint(arg); }
 inline half nearbyint(expr arg) { return functions::rint(arg); }
 
@@ -3152,23 +3152,23 @@ inline half nearbyint(expr arg) { return functions::rint(arg); }
 /// \param arg half expression to round
 /// \return nearest integer using default rounding mode
 //		template<typename T> typename enable<half,T>::type rint(T arg) {
-//return functions::rint(arg); }
+// return functions::rint(arg); }
 inline half rint(half arg) { return functions::rint(arg); }
 inline half rint(expr arg) { return functions::rint(arg); }
 
 /// Nearest integer using half's internal rounding mode.
 /// \param arg half expression to round
 /// \return nearest integer using default rounding mode
-//		template<typename T> typename enable<long,T>::type lrint(T arg) {
-//return functions::lrint(arg); }
+//		template<typename T> typename enable<long,T>::type lrint(T arg)
+//{ return functions::lrint(arg); }
 inline long lrint(half arg) { return functions::lrint(arg); }
 inline long lrint(expr arg) { return functions::lrint(arg); }
 #if HALF_ENABLE_CPP11_LONG_LONG
 /// Nearest integer.
 /// \param arg half to round
 /// \return nearest integer, rounded away from zero in half-way cases
-//		template<typename T> typename enable<long long,T>::type llround(T
-//arg) { return functions::llround(arg); }
+//		template<typename T> typename enable<long long,T>::type
+// llround(T arg) { return functions::llround(arg); }
 inline long long llround(half arg) { return functions::llround(arg); }
 inline long long llround(expr arg) { return functions::llround(arg); }
 
@@ -3176,7 +3176,7 @@ inline long long llround(expr arg) { return functions::llround(arg); }
 /// \param arg half expression to round
 /// \return nearest integer using default rounding mode
 //		template<typename T> typename enable<long long,T>::type llrint(T
-//arg) { return functions::llrint(arg); }
+// arg) { return functions::llrint(arg); }
 inline long long llrint(half arg) { return functions::llrint(arg); }
 inline long long llrint(expr arg) { return functions::llrint(arg); }
 #endif
@@ -3190,7 +3190,7 @@ inline long long llrint(expr arg) { return functions::llrint(arg); }
 /// \param exp address to store exponent at
 /// \return significant in range [0.5, 1)
 //		template<typename T> typename enable<half,T>::type frexp(T arg,
-//int *exp) { return functions::frexp(arg, exp); }
+// int *exp) { return functions::frexp(arg, exp); }
 inline half frexp(half arg, int *exp) { return functions::frexp(arg, exp); }
 inline half frexp(expr arg, int *exp) { return functions::frexp(arg, exp); }
 
@@ -3199,7 +3199,7 @@ inline half frexp(expr arg, int *exp) { return functions::frexp(arg, exp); }
 /// \param exp power of two to multiply with
 /// \return \a arg multplied by 2 raised to \a exp
 //		template<typename T> typename enable<half,T>::type ldexp(T arg,
-//int exp) { return functions::scalbln(arg, exp); }
+// int exp) { return functions::scalbln(arg, exp); }
 inline half ldexp(half arg, int exp) { return functions::scalbln(arg, exp); }
 inline half ldexp(expr arg, int exp) { return functions::scalbln(arg, exp); }
 
@@ -3208,7 +3208,7 @@ inline half ldexp(expr arg, int exp) { return functions::scalbln(arg, exp); }
 /// \param iptr address to store integer part at
 /// \return fractional part
 //		template<typename T> typename enable<half,T>::type modf(T arg,
-//half *iptr) { return functions::modf(arg, iptr); }
+// half *iptr) { return functions::modf(arg, iptr); }
 inline half modf(half arg, half *iptr) { return functions::modf(arg, iptr); }
 inline half modf(expr arg, half *iptr) { return functions::modf(arg, iptr); }
 
@@ -3217,7 +3217,7 @@ inline half modf(expr arg, half *iptr) { return functions::modf(arg, iptr); }
 /// \param exp power of two to multiply with
 /// \return \a arg multplied by 2 raised to \a exp
 //		template<typename T> typename enable<half,T>::type scalbn(T arg,
-//int exp) { return functions::scalbln(arg, exp); }
+// int exp) { return functions::scalbln(arg, exp); }
 inline half scalbn(half arg, int exp) { return functions::scalbln(arg, exp); }
 inline half scalbn(expr arg, int exp) { return functions::scalbln(arg, exp); }
 
@@ -3225,8 +3225,8 @@ inline half scalbn(expr arg, int exp) { return functions::scalbln(arg, exp); }
 /// \param arg number to modify
 /// \param exp power of two to multiply with
 /// \return \a arg multplied by 2 raised to \a exp
-//		template<typename T> typename enable<half,T>::type scalbln(T arg,
-//long exp) { return functions::scalbln(arg, exp); }
+//		template<typename T> typename enable<half,T>::type scalbln(T
+// arg, long exp) { return functions::scalbln(arg, exp); }
 inline half scalbln(half arg, long exp) { return functions::scalbln(arg, exp); }
 inline half scalbln(expr arg, long exp) { return functions::scalbln(arg, exp); }
 
@@ -3237,7 +3237,7 @@ inline half scalbln(expr arg, long exp) { return functions::scalbln(arg, exp); }
 /// \retval FP_ILOGBNAN for NaN
 /// \retval MAX_INT for infinity
 //		template<typename T> typename enable<int,T>::type ilogb(T arg) {
-//return functions::ilogb(arg); }
+// return functions::ilogb(arg); }
 inline int ilogb(half arg) { return functions::ilogb(arg); }
 inline int ilogb(expr arg) { return functions::ilogb(arg); }
 
@@ -3245,7 +3245,7 @@ inline int ilogb(expr arg) { return functions::ilogb(arg); }
 /// \param arg number to query
 /// \return floating point exponent
 //		template<typename T> typename enable<half,T>::type logb(T arg) {
-//return functions::logb(arg); }
+// return functions::logb(arg); }
 inline half logb(half arg) { return functions::logb(arg); }
 inline half logb(expr arg) { return functions::logb(arg); }
 
@@ -3254,7 +3254,7 @@ inline half logb(expr arg) { return functions::logb(arg); }
 /// \param to direction towards which to compute next value
 /// \return next representable value after \a from in direction towards \a to
 //		template<typename T,typename U> typename enable<half,T,U>::type
-//nextafter(T from, U to) { return functions::nextafter(from, to); }
+// nextafter(T from, U to) { return functions::nextafter(from, to); }
 inline half nextafter(half from, half to) {
   return functions::nextafter(from, to);
 }
@@ -3273,7 +3273,7 @@ inline half nextafter(expr from, expr to) {
 /// \param to direction towards which to compute next value
 /// \return next representable value after \a from in direction towards \a to
 //		template<typename T> typename enable<half,T>::type nexttoward(T
-//from, long double to) { return functions::nexttoward(from, to); }
+// from, long double to) { return functions::nexttoward(from, to); }
 inline half nexttoward(half from, long double to) {
   return functions::nexttoward(from, to);
 }
@@ -3286,7 +3286,7 @@ inline half nexttoward(expr from, long double to) {
 /// \param y value to take sign from
 /// \return value equal to \a x in magnitude and to \a y in sign
 //		template<typename T,typename U> typename enable<half,T,U>::type
-//copysign(T x, U y) { return functions::copysign(x, y); }
+// copysign(T x, U y) { return functions::copysign(x, y); }
 inline half copysign(half x, half y) { return functions::copysign(x, y); }
 inline half copysign(half x, expr y) { return functions::copysign(x, y); }
 inline half copysign(expr x, half y) { return functions::copysign(x, y); }
@@ -3304,7 +3304,7 @@ inline half copysign(expr x, expr y) { return functions::copysign(x, y); }
 /// \retval FP_NAN for NaNs
 /// \retval FP_NORMAL for all other (normal) values
 //		template<typename T> typename enable<int,T>::type fpclassify(T
-//arg) { return functions::fpclassify(arg); }
+// arg) { return functions::fpclassify(arg); }
 inline int fpclassify(half arg) { return functions::fpclassify(arg); }
 inline int fpclassify(expr arg) { return functions::fpclassify(arg); }
 
@@ -3312,8 +3312,8 @@ inline int fpclassify(expr arg) { return functions::fpclassify(arg); }
 /// \param arg number to check
 /// \retval true if neither infinity nor NaN
 /// \retval false else
-//		template<typename T> typename enable<bool,T>::type isfinite(T arg)
-//{ return functions::isfinite(arg); }
+//		template<typename T> typename enable<bool,T>::type isfinite(T
+// arg) { return functions::isfinite(arg); }
 inline bool isfinite(half arg) { return functions::isfinite(arg); }
 inline bool isfinite(expr arg) { return functions::isfinite(arg); }
 
@@ -3321,8 +3321,8 @@ inline bool isfinite(expr arg) { return functions::isfinite(arg); }
 /// \param arg number to check
 /// \retval true for positive or negative infinity
 /// \retval false else
-//		template<typename T> typename enable<bool,T>::type isinf(T arg) {
-//return functions::isinf(arg); }
+//		template<typename T> typename enable<bool,T>::type isinf(T arg)
+//{ return functions::isinf(arg); }
 inline bool isinf(half arg) { return functions::isinf(arg); }
 inline bool isinf(expr arg) { return functions::isinf(arg); }
 
@@ -3330,8 +3330,8 @@ inline bool isinf(expr arg) { return functions::isinf(arg); }
 /// \param arg number to check
 /// \retval true for NaNs
 /// \retval false else
-//		template<typename T> typename enable<bool,T>::type isnan(T arg) {
-//return functions::isnan(arg); }
+//		template<typename T> typename enable<bool,T>::type isnan(T arg)
+//{ return functions::isnan(arg); }
 inline bool isnan(half arg) { return functions::isnan(arg); }
 inline bool isnan(expr arg) { return functions::isnan(arg); }
 
@@ -3339,8 +3339,8 @@ inline bool isnan(expr arg) { return functions::isnan(arg); }
 /// \param arg number to check
 /// \retval true if normal number
 /// \retval false if either subnormal, zero, infinity or NaN
-//		template<typename T> typename enable<bool,T>::type isnormal(T arg)
-//{ return functions::isnormal(arg); }
+//		template<typename T> typename enable<bool,T>::type isnormal(T
+// arg) { return functions::isnormal(arg); }
 inline bool isnormal(half arg) { return functions::isnormal(arg); }
 inline bool isnormal(expr arg) { return functions::isnormal(arg); }
 
@@ -3348,8 +3348,8 @@ inline bool isnormal(expr arg) { return functions::isnormal(arg); }
 /// \param arg number to check
 /// \retval true for negative number
 /// \retval false for positive number
-//		template<typename T> typename enable<bool,T>::type signbit(T arg)
-//{ return functions::signbit(arg); }
+//		template<typename T> typename enable<bool,T>::type signbit(T
+// arg) { return functions::signbit(arg); }
 inline bool signbit(half arg) { return functions::signbit(arg); }
 inline bool signbit(expr arg) { return functions::signbit(arg); }
 
@@ -3363,7 +3363,7 @@ inline bool signbit(expr arg) { return functions::signbit(arg); }
 /// \retval true if \a x greater than \a y
 /// \retval false else
 //		template<typename T,typename U> typename enable<bool,T,U>::type
-//isgreater(T x, U y) { return functions::isgreater(x, y); }
+// isgreater(T x, U y) { return functions::isgreater(x, y); }
 inline bool isgreater(half x, half y) { return functions::isgreater(x, y); }
 inline bool isgreater(half x, expr y) { return functions::isgreater(x, y); }
 inline bool isgreater(expr x, half y) { return functions::isgreater(x, y); }
@@ -3375,7 +3375,7 @@ inline bool isgreater(expr x, expr y) { return functions::isgreater(x, y); }
 /// \retval true if \a x greater equal \a y
 /// \retval false else
 //		template<typename T,typename U> typename enable<bool,T,U>::type
-//isgreaterequal(T x, U y) { return functions::isgreaterequal(x, y); }
+// isgreaterequal(T x, U y) { return functions::isgreaterequal(x, y); }
 inline bool isgreaterequal(half x, half y) {
   return functions::isgreaterequal(x, y);
 }
@@ -3395,7 +3395,7 @@ inline bool isgreaterequal(expr x, expr y) {
 /// \retval true if \a x less than \a y
 /// \retval false else
 //		template<typename T,typename U> typename enable<bool,T,U>::type
-//isless(T x, U y) { return functions::isless(x, y); }
+// isless(T x, U y) { return functions::isless(x, y); }
 inline bool isless(half x, half y) { return functions::isless(x, y); }
 inline bool isless(half x, expr y) { return functions::isless(x, y); }
 inline bool isless(expr x, half y) { return functions::isless(x, y); }
@@ -3407,7 +3407,7 @@ inline bool isless(expr x, expr y) { return functions::isless(x, y); }
 /// \retval true if \a x less equal \a y
 /// \retval false else
 //		template<typename T,typename U> typename enable<bool,T,U>::type
-//islessequal(T x, U y) { return functions::islessequal(x, y); }
+// islessequal(T x, U y) { return functions::islessequal(x, y); }
 inline bool islessequal(half x, half y) { return functions::islessequal(x, y); }
 inline bool islessequal(half x, expr y) { return functions::islessequal(x, y); }
 inline bool islessequal(expr x, half y) { return functions::islessequal(x, y); }
@@ -3419,7 +3419,7 @@ inline bool islessequal(expr x, expr y) { return functions::islessequal(x, y); }
 /// \retval true if either less or greater
 /// \retval false else
 //		template<typename T,typename U> typename enable<bool,T,U>::type
-//islessgreater(T x, U y) { return functions::islessgreater(x, y); }
+// islessgreater(T x, U y) { return functions::islessgreater(x, y); }
 inline bool islessgreater(half x, half y) {
   return functions::islessgreater(x, y);
 }
@@ -3439,7 +3439,7 @@ inline bool islessgreater(expr x, expr y) {
 /// \retval true if unordered (one or two NaN operands)
 /// \retval false else
 //		template<typename T,typename U> typename enable<bool,T,U>::type
-//isunordered(T x, U y) { return functions::isunordered(x, y); }
+// isunordered(T x, U y) { return functions::isunordered(x, y); }
 inline bool isunordered(half x, half y) { return functions::isunordered(x, y); }
 inline bool isunordered(half x, expr y) { return functions::isunordered(x, y); }
 inline bool isunordered(expr x, half y) { return functions::isunordered(x, y); }

--- a/src/cuda-sim/half.h
+++ b/src/cuda-sim/half.h
@@ -2,17 +2,23 @@
 //
 // Copyright (c) 2012-2017 Christian Rau <rauy@users.sourceforge.net>
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation 
-// files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, 
-// modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the 
-// Software is furnished to do so, subject to the following conditions:
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
 //
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE 
-// WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
-// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, 
-// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 // Version 1.12.0
 
@@ -23,180 +29,182 @@
 #define HALF_HALF_HPP
 
 /// Combined gcc version number.
-#define HALF_GNUC_VERSION (__GNUC__*100+__GNUC_MINOR__)
+#define HALF_GNUC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
 
-//check C++11 language features
-#if defined(__clang__)										//clang
-	#if __has_feature(cxx_static_assert) && !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)
-		#define HALF_ENABLE_CPP11_STATIC_ASSERT 1
-	#endif
-	#if __has_feature(cxx_constexpr) && !defined(HALF_ENABLE_CPP11_CONSTEXPR)
-		#define HALF_ENABLE_CPP11_CONSTEXPR 1
-	#endif
-	#if __has_feature(cxx_noexcept) && !defined(HALF_ENABLE_CPP11_NOEXCEPT)
-		#define HALF_ENABLE_CPP11_NOEXCEPT 1
-	#endif
-	#if __has_feature(cxx_user_literals) && !defined(HALF_ENABLE_CPP11_USER_LITERALS)
-		#define HALF_ENABLE_CPP11_USER_LITERALS 1
-	#endif
-	#if (defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L) && !defined(HALF_ENABLE_CPP11_LONG_LONG)
-		#define HALF_ENABLE_CPP11_LONG_LONG 1
-	#endif
-/*#elif defined(__INTEL_COMPILER)								//Intel C++
-	#if __INTEL_COMPILER >= 1100 && !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)		????????
-		#define HALF_ENABLE_CPP11_STATIC_ASSERT 1
-	#endif
-	#if __INTEL_COMPILER >= 1300 && !defined(HALF_ENABLE_CPP11_CONSTEXPR)			????????
-		#define HALF_ENABLE_CPP11_CONSTEXPR 1
-	#endif
-	#if __INTEL_COMPILER >= 1300 && !defined(HALF_ENABLE_CPP11_NOEXCEPT)			????????
-		#define HALF_ENABLE_CPP11_NOEXCEPT 1
-	#endif
-	#if __INTEL_COMPILER >= 1100 && !defined(HALF_ENABLE_CPP11_LONG_LONG)			????????
-		#define HALF_ENABLE_CPP11_LONG_LONG 1
-	#endif*/
-#elif defined(__GNUC__)										//gcc
-	#if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L
-		#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)
-			#define HALF_ENABLE_CPP11_STATIC_ASSERT 1
-		#endif
-		#if HALF_GNUC_VERSION >= 406 && !defined(HALF_ENABLE_CPP11_CONSTEXPR)
-			#define HALF_ENABLE_CPP11_CONSTEXPR 1
-		#endif
-		#if HALF_GNUC_VERSION >= 406 && !defined(HALF_ENABLE_CPP11_NOEXCEPT)
-			#define HALF_ENABLE_CPP11_NOEXCEPT 1
-		#endif
-		#if HALF_GNUC_VERSION >= 407 && !defined(HALF_ENABLE_CPP11_USER_LITERALS)
-			#define HALF_ENABLE_CPP11_USER_LITERALS 1
-		#endif
-		#if !defined(HALF_ENABLE_CPP11_LONG_LONG)
-			#define HALF_ENABLE_CPP11_LONG_LONG 1
-		#endif
-	#endif
-#elif defined(_MSC_VER)										//Visual C++
-	#if _MSC_VER >= 1900 && !defined(HALF_ENABLE_CPP11_CONSTEXPR)
-		#define HALF_ENABLE_CPP11_CONSTEXPR 1
-	#endif
-	#if _MSC_VER >= 1900 && !defined(HALF_ENABLE_CPP11_NOEXCEPT)
-		#define HALF_ENABLE_CPP11_NOEXCEPT 1
-	#endif
-	#if _MSC_VER >= 1900 && !defined(HALF_ENABLE_CPP11_USER_LITERALS)
-		#define HALF_ENABLE_CPP11_USER_LITERALS 1
-	#endif
-	#if _MSC_VER >= 1600 && !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)
-		#define HALF_ENABLE_CPP11_STATIC_ASSERT 1
-	#endif
-	#if _MSC_VER >= 1310 && !defined(HALF_ENABLE_CPP11_LONG_LONG)
-		#define HALF_ENABLE_CPP11_LONG_LONG 1
-	#endif
-	#define HALF_POP_WARNINGS 1
-	#pragma warning(push)
-	#pragma warning(disable : 4099 4127 4146)	//struct vs class, constant in if, negative unsigned
+// check C++11 language features
+#if defined(__clang__)  // clang
+#if __has_feature(cxx_static_assert) && \
+    !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)
+#define HALF_ENABLE_CPP11_STATIC_ASSERT 1
+#endif
+#if __has_feature(cxx_constexpr) && !defined(HALF_ENABLE_CPP11_CONSTEXPR)
+#define HALF_ENABLE_CPP11_CONSTEXPR 1
+#endif
+#if __has_feature(cxx_noexcept) && !defined(HALF_ENABLE_CPP11_NOEXCEPT)
+#define HALF_ENABLE_CPP11_NOEXCEPT 1
+#endif
+#if __has_feature(cxx_user_literals) && \
+    !defined(HALF_ENABLE_CPP11_USER_LITERALS)
+#define HALF_ENABLE_CPP11_USER_LITERALS 1
+#endif
+#if (defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L) && \
+    !defined(HALF_ENABLE_CPP11_LONG_LONG)
+#define HALF_ENABLE_CPP11_LONG_LONG 1
+#endif
+/*#elif defined(__INTEL_COMPILER)
+   //Intel C++ #if __INTEL_COMPILER >= 1100 &&
+   !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)		???????? #define
+   HALF_ENABLE_CPP11_STATIC_ASSERT 1 #endif #if __INTEL_COMPILER >= 1300 &&
+   !defined(HALF_ENABLE_CPP11_CONSTEXPR)			???????? #define
+   HALF_ENABLE_CPP11_CONSTEXPR 1 #endif #if __INTEL_COMPILER >= 1300 &&
+   !defined(HALF_ENABLE_CPP11_NOEXCEPT)			???????? #define
+   HALF_ENABLE_CPP11_NOEXCEPT 1 #endif #if __INTEL_COMPILER >= 1100 &&
+   !defined(HALF_ENABLE_CPP11_LONG_LONG)			???????? #define
+   HALF_ENABLE_CPP11_LONG_LONG 1 #endif*/
+#elif defined(__GNUC__)  // gcc
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L
+#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)
+#define HALF_ENABLE_CPP11_STATIC_ASSERT 1
+#endif
+#if HALF_GNUC_VERSION >= 406 && !defined(HALF_ENABLE_CPP11_CONSTEXPR)
+#define HALF_ENABLE_CPP11_CONSTEXPR 1
+#endif
+#if HALF_GNUC_VERSION >= 406 && !defined(HALF_ENABLE_CPP11_NOEXCEPT)
+#define HALF_ENABLE_CPP11_NOEXCEPT 1
+#endif
+#if HALF_GNUC_VERSION >= 407 && !defined(HALF_ENABLE_CPP11_USER_LITERALS)
+#define HALF_ENABLE_CPP11_USER_LITERALS 1
+#endif
+#if !defined(HALF_ENABLE_CPP11_LONG_LONG)
+#define HALF_ENABLE_CPP11_LONG_LONG 1
+#endif
+#endif
+#elif defined(_MSC_VER)  // Visual C++
+#if _MSC_VER >= 1900 && !defined(HALF_ENABLE_CPP11_CONSTEXPR)
+#define HALF_ENABLE_CPP11_CONSTEXPR 1
+#endif
+#if _MSC_VER >= 1900 && !defined(HALF_ENABLE_CPP11_NOEXCEPT)
+#define HALF_ENABLE_CPP11_NOEXCEPT 1
+#endif
+#if _MSC_VER >= 1900 && !defined(HALF_ENABLE_CPP11_USER_LITERALS)
+#define HALF_ENABLE_CPP11_USER_LITERALS 1
+#endif
+#if _MSC_VER >= 1600 && !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)
+#define HALF_ENABLE_CPP11_STATIC_ASSERT 1
+#endif
+#if _MSC_VER >= 1310 && !defined(HALF_ENABLE_CPP11_LONG_LONG)
+#define HALF_ENABLE_CPP11_LONG_LONG 1
+#endif
+#define HALF_POP_WARNINGS 1
+#pragma warning(push)
+#pragma warning(disable : 4099 4127 4146)  // struct vs class, constant in if,
+                                           // negative unsigned
 #endif
 
-//check C++11 library features
+// check C++11 library features
 #include <utility>
-#if defined(_LIBCPP_VERSION)								//libc++
-	#if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103
-		#ifndef HALF_ENABLE_CPP11_TYPE_TRAITS
-			#define HALF_ENABLE_CPP11_TYPE_TRAITS 1
-		#endif
-		#ifndef HALF_ENABLE_CPP11_CSTDINT
-			#define HALF_ENABLE_CPP11_CSTDINT 1
-		#endif
-		#ifndef HALF_ENABLE_CPP11_CMATH
-			#define HALF_ENABLE_CPP11_CMATH 1
-		#endif
-		#ifndef HALF_ENABLE_CPP11_HASH
-			#define HALF_ENABLE_CPP11_HASH 1
-		#endif
-	#endif
-#elif defined(__GLIBCXX__)									//libstdc++
-	#if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103
-		#ifdef __clang__
-			#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_TYPE_TRAITS)
-				#define HALF_ENABLE_CPP11_TYPE_TRAITS 1
-			#endif
-			#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_CSTDINT)
-				#define HALF_ENABLE_CPP11_CSTDINT 1
-			#endif
-			#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_CMATH)
-				#define HALF_ENABLE_CPP11_CMATH 1
-			#endif
-			#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_HASH)
-				#define HALF_ENABLE_CPP11_HASH 1
-			#endif
-		#else
-			#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_CSTDINT)
-				#define HALF_ENABLE_CPP11_CSTDINT 1
-			#endif
-			#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_CMATH)
-				#define HALF_ENABLE_CPP11_CMATH 1
-			#endif
-			#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_HASH)
-				#define HALF_ENABLE_CPP11_HASH 1
-			#endif
-		#endif
-	#endif
-#elif defined(_CPPLIB_VER)									//Dinkumware/Visual C++
-	#if _CPPLIB_VER >= 520
-		#ifndef HALF_ENABLE_CPP11_TYPE_TRAITS
-			#define HALF_ENABLE_CPP11_TYPE_TRAITS 1
-		#endif
-		#ifndef HALF_ENABLE_CPP11_CSTDINT
-			#define HALF_ENABLE_CPP11_CSTDINT 1
-		#endif
-		#ifndef HALF_ENABLE_CPP11_HASH
-			#define HALF_ENABLE_CPP11_HASH 1
-		#endif
-	#endif
-	#if _CPPLIB_VER >= 610
-		#ifndef HALF_ENABLE_CPP11_CMATH
-			#define HALF_ENABLE_CPP11_CMATH 1
-		#endif
-	#endif
+#if defined(_LIBCPP_VERSION)  // libc++
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103
+#ifndef HALF_ENABLE_CPP11_TYPE_TRAITS
+#define HALF_ENABLE_CPP11_TYPE_TRAITS 1
+#endif
+#ifndef HALF_ENABLE_CPP11_CSTDINT
+#define HALF_ENABLE_CPP11_CSTDINT 1
+#endif
+#ifndef HALF_ENABLE_CPP11_CMATH
+#define HALF_ENABLE_CPP11_CMATH 1
+#endif
+#ifndef HALF_ENABLE_CPP11_HASH
+#define HALF_ENABLE_CPP11_HASH 1
+#endif
+#endif
+#elif defined(__GLIBCXX__)  // libstdc++
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103
+#ifdef __clang__
+#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_TYPE_TRAITS)
+#define HALF_ENABLE_CPP11_TYPE_TRAITS 1
+#endif
+#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_CSTDINT)
+#define HALF_ENABLE_CPP11_CSTDINT 1
+#endif
+#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_CMATH)
+#define HALF_ENABLE_CPP11_CMATH 1
+#endif
+#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_HASH)
+#define HALF_ENABLE_CPP11_HASH 1
+#endif
+#else
+#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_CSTDINT)
+#define HALF_ENABLE_CPP11_CSTDINT 1
+#endif
+#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_CMATH)
+#define HALF_ENABLE_CPP11_CMATH 1
+#endif
+#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_HASH)
+#define HALF_ENABLE_CPP11_HASH 1
+#endif
+#endif
+#endif
+#elif defined(_CPPLIB_VER)  // Dinkumware/Visual C++
+#if _CPPLIB_VER >= 520
+#ifndef HALF_ENABLE_CPP11_TYPE_TRAITS
+#define HALF_ENABLE_CPP11_TYPE_TRAITS 1
+#endif
+#ifndef HALF_ENABLE_CPP11_CSTDINT
+#define HALF_ENABLE_CPP11_CSTDINT 1
+#endif
+#ifndef HALF_ENABLE_CPP11_HASH
+#define HALF_ENABLE_CPP11_HASH 1
+#endif
+#endif
+#if _CPPLIB_VER >= 610
+#ifndef HALF_ENABLE_CPP11_CMATH
+#define HALF_ENABLE_CPP11_CMATH 1
+#endif
+#endif
 #endif
 #undef HALF_GNUC_VERSION
 
-//support constexpr
+// support constexpr
 #if HALF_ENABLE_CPP11_CONSTEXPR
-	#define HALF_CONSTEXPR			constexpr
-	#define HALF_CONSTEXPR_CONST	constexpr
+#define HALF_CONSTEXPR constexpr
+#define HALF_CONSTEXPR_CONST constexpr
 #else
-	#define HALF_CONSTEXPR
-	#define HALF_CONSTEXPR_CONST	const
+#define HALF_CONSTEXPR
+#define HALF_CONSTEXPR_CONST const
 #endif
 
-//support noexcept
+// support noexcept
 #if HALF_ENABLE_CPP11_NOEXCEPT
-	#define HALF_NOEXCEPT	noexcept
-	#define HALF_NOTHROW	noexcept
+#define HALF_NOEXCEPT noexcept
+#define HALF_NOTHROW noexcept
 #else
-	#define HALF_NOEXCEPT
-	#define HALF_NOTHROW	throw()
+#define HALF_NOEXCEPT
+#define HALF_NOTHROW throw()
 #endif
 
 #include <algorithm>
-#include <iostream>
-#include <limits>
 #include <climits>
 #include <cmath>
 #include <cstring>
+#include <iostream>
+#include <limits>
 #if HALF_ENABLE_CPP11_TYPE_TRAITS
-	#include <type_traits>
+#include <type_traits>
 #endif
 #if HALF_ENABLE_CPP11_CSTDINT
-	#include <cstdint>
+#include <cstdint>
 #endif
 #if HALF_ENABLE_CPP11_HASH
-	#include <functional>
+#include <functional>
 #endif
 
-
 /// Default rounding mode.
-/// This specifies the rounding mode used for all conversions between [half](\ref half_float::half)s and `float`s as well as 
-/// for the half_cast() if not specifying a rounding mode explicitly. It can be redefined (before including half.hpp) to one 
-/// of the standard rounding modes using their respective constants or the equivalent values of `std::float_round_style`:
+/// This specifies the rounding mode used for all conversions between
+/// [half](\ref half_float::half)s and `float`s as well as for the half_cast()
+/// if not specifying a rounding mode explicitly. It can be redefined (before
+/// including half.hpp) to one of the standard rounding modes using their
+/// respective constants or the equivalent values of `std::float_round_style`:
 ///
 /// `std::float_round_style`         | value | rounding
 /// ---------------------------------|-------|-------------------------
@@ -206,2862 +214,3509 @@
 /// `std::round_toward_infinity`     | 2     | toward positive infinity
 /// `std::round_toward_neg_infinity` | 3     | toward negative infinity
 ///
-/// By default this is set to `-1` (`std::round_indeterminate`), which uses truncation (round toward zero, but with overflows 
-/// set to infinity) and is the fastest rounding mode possible. It can even be set to `std::numeric_limits<float>::round_style` 
-/// to synchronize the rounding mode with that of the underlying single-precision implementation.
+/// By default this is set to `-1` (`std::round_indeterminate`), which uses
+/// truncation (round toward zero, but with overflows set to infinity) and is
+/// the fastest rounding mode possible. It can even be set to
+/// `std::numeric_limits<float>::round_style` to synchronize the rounding mode
+/// with that of the underlying single-precision implementation.
 #ifndef HALF_ROUND_STYLE
-	#define HALF_ROUND_STYLE	-1			// = std::round_indeterminate
+#define HALF_ROUND_STYLE -1  // = std::round_indeterminate
 #endif
 
 /// Tie-breaking behaviour for round to nearest.
-/// This specifies if ties in round to nearest should be resolved by rounding to the nearest even value. By default this is 
-/// defined to `0` resulting in the faster but slightly more biased behaviour of rounding away from zero in half-way cases (and 
-/// thus equal to the round() function), but can be redefined to `1` (before including half.hpp) if more IEEE-conformant 
+/// This specifies if ties in round to nearest should be resolved by rounding to
+/// the nearest even value. By default this is defined to `0` resulting in the
+/// faster but slightly more biased behaviour of rounding away from zero in
+/// half-way cases (and thus equal to the round() function), but can be
+/// redefined to `1` (before including half.hpp) if more IEEE-conformant
 /// behaviour is needed.
 #ifndef HALF_ROUND_TIES_TO_EVEN
-	#define HALF_ROUND_TIES_TO_EVEN	0		// ties away from zero
+#define HALF_ROUND_TIES_TO_EVEN 0  // ties away from zero
 #endif
 
 /// Value signaling overflow.
-/// In correspondence with `HUGE_VAL[F|L]` from `<cmath>` this symbol expands to a positive value signaling the overflow of an 
-/// operation, in particular it just evaluates to positive infinity.
-#define HUGE_VALH	std::numeric_limits<half_float::half>::infinity()
+/// In correspondence with `HUGE_VAL[F|L]` from `<cmath>` this symbol expands to
+/// a positive value signaling the overflow of an operation, in particular it
+/// just evaluates to positive infinity.
+#define HUGE_VALH std::numeric_limits<half_float::half>::infinity()
 
 /// Fast half-precision fma function.
-/// This symbol is only defined if the fma() function generally executes as fast as, or faster than, a separate 
-/// half-precision multiplication followed by an addition. Due to the internal single-precision implementation of all 
+/// This symbol is only defined if the fma() function generally executes as fast
+/// as, or faster than, a separate half-precision multiplication followed by an
+/// addition. Due to the internal single-precision implementation of all
 /// arithmetic operations, this is in fact always the case.
-#define FP_FAST_FMAH	1
+#define FP_FAST_FMAH 1
 
 #ifndef FP_ILOGB0
-	#define FP_ILOGB0		INT_MIN
+#define FP_ILOGB0 INT_MIN
 #endif
 #ifndef FP_ILOGBNAN
-	#define FP_ILOGBNAN		INT_MAX
+#define FP_ILOGBNAN INT_MAX
 #endif
 #ifndef FP_SUBNORMAL
-	#define FP_SUBNORMAL	0
+#define FP_SUBNORMAL 0
 #endif
 #ifndef FP_ZERO
-	#define FP_ZERO			1
+#define FP_ZERO 1
 #endif
 #ifndef FP_NAN
-	#define FP_NAN			2
+#define FP_NAN 2
 #endif
 #ifndef FP_INFINITE
-	#define FP_INFINITE		3
+#define FP_INFINITE 3
 #endif
 #ifndef FP_NORMAL
-	#define FP_NORMAL		4
+#define FP_NORMAL 4
 #endif
-
 
 /// Main namespace for half precision functionality.
 /// This namespace contains all the functionality provided by the library.
-namespace half_float
-{
-	class half;
+namespace half_float {
+class half;
 
 #if HALF_ENABLE_CPP11_USER_LITERALS
-	/// Library-defined half-precision literals.
-	/// Import this namespace to enable half-precision floating point literals:
-	/// ~~~~{.cpp}
-	/// using namespace half_float::literal;
-	/// half_float::half = 4.2_h;
-	/// ~~~~
-	namespace literal
-	{
-		half operator"" _h(long double);
-	}
+/// Library-defined half-precision literals.
+/// Import this namespace to enable half-precision floating point literals:
+/// ~~~~{.cpp}
+/// using namespace half_float::literal;
+/// half_float::half = 4.2_h;
+/// ~~~~
+namespace literal {
+half operator"" _h(long double);
+}
 #endif
 
-	/// \internal
-	/// \brief Implementation details.
-	namespace detail
-	{
-	#if HALF_ENABLE_CPP11_TYPE_TRAITS
-		/// Conditional type.
-		template<bool B,typename T,typename F> struct conditional : std::conditional<B,T,F> {};
+/// \internal
+/// \brief Implementation details.
+namespace detail {
+#if HALF_ENABLE_CPP11_TYPE_TRAITS
+/// Conditional type.
+template <bool B, typename T, typename F>
+struct conditional : std::conditional<B, T, F> {};
 
-		/// Helper for tag dispatching.
-		template<bool B> struct bool_type : std::integral_constant<bool,B> {};
-		using std::true_type;
-		using std::false_type;
+/// Helper for tag dispatching.
+template <bool B>
+struct bool_type : std::integral_constant<bool, B> {};
+using std::false_type;
+using std::true_type;
 
-		/// Type traits for floating point types.
-		template<typename T> struct is_float : std::is_floating_point<T> {};
-	#else
-		/// Conditional type.
-		template<bool,typename T,typename> struct conditional { typedef T type; };
-		template<typename T,typename F> struct conditional<false,T,F> { typedef F type; };
+/// Type traits for floating point types.
+template <typename T>
+struct is_float : std::is_floating_point<T> {};
+#else
+/// Conditional type.
+template <bool, typename T, typename>
+struct conditional {
+  typedef T type;
+};
+template <typename T, typename F>
+struct conditional<false, T, F> {
+  typedef F type;
+};
 
-		/// Helper for tag dispatching.
-		template<bool> struct bool_type {};
-		typedef bool_type<true> true_type;
-		typedef bool_type<false> false_type;
+/// Helper for tag dispatching.
+template <bool>
+struct bool_type {};
+typedef bool_type<true> true_type;
+typedef bool_type<false> false_type;
 
-		/// Type traits for floating point types.
-		template<typename> struct is_float : false_type {};
-		template<typename T> struct is_float<const T> : is_float<T> {};
-		template<typename T> struct is_float<volatile T> : is_float<T> {};
-		template<typename T> struct is_float<const volatile T> : is_float<T> {};
-		template<> struct is_float<float> : true_type {};
-		template<> struct is_float<double> : true_type {};
-		template<> struct is_float<long double> : true_type {};
-	#endif
-
-		/// Type traits for floating point bits.
-		template<typename T> struct bits { typedef unsigned char type; };
-		template<typename T> struct bits<const T> : bits<T> {};
-		template<typename T> struct bits<volatile T> : bits<T> {};
-		template<typename T> struct bits<const volatile T> : bits<T> {};
-
-	#if HALF_ENABLE_CPP11_CSTDINT
-		/// Unsigned integer of (at least) 16 bits width.
-		typedef std::uint_least16_t uint16;
-
-		/// Unsigned integer of (at least) 32 bits width.
-		template<> struct bits<float> { typedef std::uint_least32_t type; };
-
-		/// Unsigned integer of (at least) 64 bits width.
-		template<> struct bits<double> { typedef std::uint_least64_t type; };
-	#else
-		/// Unsigned integer of (at least) 16 bits width.
-		typedef unsigned short uint16;
-
-		/// Unsigned integer of (at least) 32 bits width.
-		template<> struct bits<float> : conditional<std::numeric_limits<unsigned int>::digits>=32,unsigned int,unsigned long> {};
-
-		#if HALF_ENABLE_CPP11_LONG_LONG
-			/// Unsigned integer of (at least) 64 bits width.
-			template<> struct bits<double> : conditional<std::numeric_limits<unsigned long>::digits>=64,unsigned long,unsigned long long> {};
-		#else
-			/// Unsigned integer of (at least) 64 bits width.
-			template<> struct bits<double> { typedef unsigned long type; };
-		#endif
-	#endif
-
-		/// Tag type for binary construction.
-		struct binary_t {};
-
-		/// Tag for binary construction.
-		HALF_CONSTEXPR_CONST binary_t binary = binary_t();
-
-		/// Temporary half-precision expression.
-		/// This class represents a half-precision expression which just stores a single-precision value internally.
-		struct expr
-		{
-			/// Conversion constructor.
-			/// \param f single-precision value to convert
-			explicit HALF_CONSTEXPR expr(float f) HALF_NOEXCEPT : value_(f) {}
-
-			/// Conversion to single-precision.
-			/// \return single precision value representing expression value
-			HALF_CONSTEXPR operator float() const HALF_NOEXCEPT { return value_; }
-
-		private:
-			/// Internal expression value stored in single-precision.
-			float value_;
-		};
-
-		/// SFINAE helper for generic half-precision functions.
-		/// This class template has to be specialized for each valid combination of argument types to provide a corresponding 
-		/// `type` member equivalent to \a T.
-		/// \tparam T type to return
-		template<typename T,typename,typename=void,typename=void> struct enable {};
-		template<typename T> struct enable<T,half,void,void> { typedef T type; };
-		template<typename T> struct enable<T,expr,void,void> { typedef T type; };
-		template<typename T> struct enable<T,half,half,void> { typedef T type; };
-		template<typename T> struct enable<T,half,expr,void> { typedef T type; };
-		template<typename T> struct enable<T,expr,half,void> { typedef T type; };
-		template<typename T> struct enable<T,expr,expr,void> { typedef T type; };
-		template<typename T> struct enable<T,half,half,half> { typedef T type; };
-		template<typename T> struct enable<T,half,half,expr> { typedef T type; };
-		template<typename T> struct enable<T,half,expr,half> { typedef T type; };
-		template<typename T> struct enable<T,half,expr,expr> { typedef T type; };
-		template<typename T> struct enable<T,expr,half,half> { typedef T type; };
-		template<typename T> struct enable<T,expr,half,expr> { typedef T type; };
-		template<typename T> struct enable<T,expr,expr,half> { typedef T type; };
-		template<typename T> struct enable<T,expr,expr,expr> { typedef T type; };
-
-		/// Return type for specialized generic 2-argument half-precision functions.
-		/// This class template has to be specialized for each valid combination of argument types to provide a corresponding 
-		/// `type` member denoting the appropriate return type.
-		/// \tparam T first argument type
-		/// \tparam U first argument type
-		template<typename T,typename U> struct result : enable<expr,T,U> {};
-		template<> struct result<half,half> { typedef half type; };
-
-		/// \name Classification helpers
-		/// \{
-
-		/// Check for infinity.
-		/// \tparam T argument type (builtin floating point type)
-		/// \param arg value to query
-		/// \retval true if infinity
-		/// \retval false else
-		template<typename T> bool builtin_isinf(T arg)
-		{
-		#if HALF_ENABLE_CPP11_CMATH
-			return std::isinf(arg);
-		#elif defined(_MSC_VER)
-			return !::_finite(static_cast<double>(arg)) && !::_isnan(static_cast<double>(arg));
-		#else
-			return arg == std::numeric_limits<T>::infinity() || arg == -std::numeric_limits<T>::infinity();
-		#endif
-		}
-
-		/// Check for NaN.
-		/// \tparam T argument type (builtin floating point type)
-		/// \param arg value to query
-		/// \retval true if not a number
-		/// \retval false else
-		template<typename T> bool builtin_isnan(T arg)
-		{
-		#if HALF_ENABLE_CPP11_CMATH
-			return std::isnan(arg);
-		#elif defined(_MSC_VER)
-			return ::_isnan(static_cast<double>(arg)) != 0;
-		#else
-			return arg != arg;
-		#endif
-		}
-
-		/// Check sign.
-		/// \tparam T argument type (builtin floating point type)
-		/// \param arg value to query
-		/// \retval true if signbit set
-		/// \retval false else
-		template<typename T> bool builtin_signbit(T arg)
-		{
-		#if HALF_ENABLE_CPP11_CMATH
-			return std::signbit(arg);
-		#else
-			return arg < T() || (arg == T() && T(1)/arg < T());
-		#endif
-		}
-
-		/// \}
-		/// \name Conversion
-		/// \{
-
-		/// Convert IEEE single-precision to half-precision.
-		/// Credit for this goes to [Jeroen van der Zijp](ftp://ftp.fox-toolkit.org/pub/fasthalffloatconversion.pdf).
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \param value single-precision value
-		/// \return binary representation of half-precision value
-		template<std::float_round_style R> uint16 float2half_impl(float value, true_type)
-		{
-			typedef bits<float>::type uint32;
-			uint32 bits;// = *reinterpret_cast<uint32*>(&value);		//violating strict aliasing!
-			std::memcpy(&bits, &value, sizeof(float));
-/*			uint16 hbits = (bits>>16) & 0x8000;
-			bits &= 0x7FFFFFFF;
-			int exp = bits >> 23;
-			if(exp == 255)
-				return hbits | 0x7C00 | (0x3FF&-static_cast<unsigned>((bits&0x7FFFFF)!=0));
-			if(exp > 142)
-			{
-				if(R == std::round_toward_infinity)
-					return hbits | 0x7C00 - (hbits>>15);
-				if(R == std::round_toward_neg_infinity)
-					return hbits | 0x7BFF + (hbits>>15);
-				return hbits | 0x7BFF + (R!=std::round_toward_zero);
-			}
-			int g, s;
-			if(exp > 112)
-			{
-				g = (bits>>12) & 1;
-				s = (bits&0xFFF) != 0;
-				hbits |= ((exp-112)<<10) | ((bits>>13)&0x3FF);
-			}
-			else if(exp > 101)
-			{
-				int i = 125 - exp;
-				bits = (bits&0x7FFFFF) | 0x800000;
-				g = (bits>>i) & 1;
-				s = (bits&((1L<<i)-1)) != 0;
-				hbits |= bits >> (i+1);
-			}
-			else
-			{
-				g = 0;
-				s = bits != 0;
-			}
-			if(R == std::round_to_nearest)
-				#if HALF_ROUND_TIES_TO_EVEN
-					hbits += g & (s|hbits);
-				#else
-					hbits += g;
-				#endif
-			else if(R == std::round_toward_infinity)
-				hbits += ~(hbits>>15) & (s|g);
-			else if(R == std::round_toward_neg_infinity)
-				hbits += (hbits>>15) & (g|s);
-*/			static const uint16 base_table[512] = { 
-				0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 
-				0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 
-				0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 
-				0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 
-				0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 
-				0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 
-				0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0001, 0x0002, 0x0004, 0x0008, 0x0010, 0x0020, 0x0040, 0x0080, 0x0100, 
-				0x0200, 0x0400, 0x0800, 0x0C00, 0x1000, 0x1400, 0x1800, 0x1C00, 0x2000, 0x2400, 0x2800, 0x2C00, 0x3000, 0x3400, 0x3800, 0x3C00, 
-				0x4000, 0x4400, 0x4800, 0x4C00, 0x5000, 0x5400, 0x5800, 0x5C00, 0x6000, 0x6400, 0x6800, 0x6C00, 0x7000, 0x7400, 0x7800, 0x7C00, 
-				0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 
-				0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 
-				0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 
-				0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 
-				0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 
-				0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 
-				0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 
-				0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 
-				0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 
-				0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 
-				0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 
-				0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 
-				0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 
-				0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8001, 0x8002, 0x8004, 0x8008, 0x8010, 0x8020, 0x8040, 0x8080, 0x8100, 
-				0x8200, 0x8400, 0x8800, 0x8C00, 0x9000, 0x9400, 0x9800, 0x9C00, 0xA000, 0xA400, 0xA800, 0xAC00, 0xB000, 0xB400, 0xB800, 0xBC00, 
-				0xC000, 0xC400, 0xC800, 0xCC00, 0xD000, 0xD400, 0xD800, 0xDC00, 0xE000, 0xE400, 0xE800, 0xEC00, 0xF000, 0xF400, 0xF800, 0xFC00, 
-				0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 
-				0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 
-				0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 
-				0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 
-				0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 
-				0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 
-				0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00 };
-			static const unsigned char shift_table[512] = { 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 
-				13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 13, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 
-				13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 13 };
-			uint16 hbits = base_table[bits>>23] + static_cast<uint16>((bits&0x7FFFFF)>>shift_table[bits>>23]);
-			if(R == std::round_to_nearest)
-				hbits += (((bits&0x7FFFFF)>>(shift_table[bits>>23]-1))|(((bits>>23)&0xFF)==102)) & ((hbits&0x7C00)!=0x7C00)
-				#if HALF_ROUND_TIES_TO_EVEN
-					& (((((static_cast<uint32>(1)<<(shift_table[bits>>23]-1))-1)&bits)!=0)|hbits)
-				#endif
-				;
-			else if(R == std::round_toward_zero)
-				hbits -= ((hbits&0x7FFF)==0x7C00) & ~shift_table[bits>>23];
-			else if(R == std::round_toward_infinity)
-				hbits += ((((bits&0x7FFFFF&((static_cast<uint32>(1)<<(shift_table[bits>>23]))-1))!=0)|(((bits>>23)<=102)&
-					((bits>>23)!=0)))&(hbits<0x7C00)) - ((hbits==0xFC00)&((bits>>23)!=511));
-			else if(R == std::round_toward_neg_infinity)
-				hbits += ((((bits&0x7FFFFF&((static_cast<uint32>(1)<<(shift_table[bits>>23]))-1))!=0)|(((bits>>23)<=358)&
-					((bits>>23)!=256)))&(hbits<0xFC00)&(hbits>>15)) - ((hbits==0x7C00)&((bits>>23)!=255));
-			return hbits;
-		}
-
-		/// Convert IEEE double-precision to half-precision.
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \param value double-precision value
-		/// \return binary representation of half-precision value
-		template<std::float_round_style R> uint16 float2half_impl(double value, true_type)
-		{
-			typedef bits<float>::type uint32;
-			typedef bits<double>::type uint64;
-			uint64 bits;// = *reinterpret_cast<uint64*>(&value);		//violating strict aliasing!
-			std::memcpy(&bits, &value, sizeof(double));
-			uint32 hi = bits >> 32, lo = bits & 0xFFFFFFFF;
-			uint16 hbits = (hi>>16) & 0x8000;
-			hi &= 0x7FFFFFFF;
-			int exp = hi >> 20;
-			if(exp == 2047)
-				return hbits | 0x7C00 | (0x3FF&-static_cast<unsigned>((bits&0xFFFFFFFFFFFFF)!=0));
-			if(exp > 1038)
-			{
-				if(R == std::round_toward_infinity)
-					return hbits | 0x7C00 - (hbits>>15);
-				if(R == std::round_toward_neg_infinity)
-					return hbits | 0x7BFF + (hbits>>15);
-				return hbits | 0x7BFF + (R!=std::round_toward_zero);
-			}
-			int g, s = lo != 0;
-			if(exp > 1008)
-			{
-				g = (hi>>9) & 1;
-				s |= (hi&0x1FF) != 0;
-				hbits |= ((exp-1008)<<10) | ((hi>>10)&0x3FF);
-			}
-			else if(exp > 997)
-			{
-				int i = 1018 - exp;
-				hi = (hi&0xFFFFF) | 0x100000;
-				g = (hi>>i) & 1;
-				s |= (hi&((1L<<i)-1)) != 0;
-				hbits |= hi >> (i+1);
-			}
-			else
-			{
-				g = 0;
-				s |= hi != 0;
-			}
-			if(R == std::round_to_nearest)
-				#if HALF_ROUND_TIES_TO_EVEN
-					hbits += g & (s|hbits);
-				#else
-					hbits += g;
-				#endif
-			else if(R == std::round_toward_infinity)
-				hbits += ~(hbits>>15) & (s|g);
-			else if(R == std::round_toward_neg_infinity)
-				hbits += (hbits>>15) & (g|s);
-			return hbits;
-		}
-
-		/// Convert non-IEEE floating point to half-precision.
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \tparam T source type (builtin floating point type)
-		/// \param value floating point value
-		/// \return binary representation of half-precision value
-		template<std::float_round_style R,typename T> uint16 float2half_impl(T value, ...)
-		{
-			uint16 hbits = static_cast<unsigned>(builtin_signbit(value)) << 15;
-			if(value == T())
-				return hbits;
-			if(builtin_isnan(value))
-				return hbits | 0x7FFF;
-			if(builtin_isinf(value))
-				return hbits | 0x7C00;
-			int exp;
-			std::frexp(value, &exp);
-			if(exp > 16)
-			{
-				if(R == std::round_toward_infinity)
-					return hbits | (0x7C00 - (hbits>>15));
-				else if(R == std::round_toward_neg_infinity)
-					return hbits | (0x7BFF + (hbits>>15));
-				return hbits | (0x7BFF + (R!=std::round_toward_zero));
-			}
-			if(exp < -13)
-				value = std::ldexp(value, 24);
-			else
-			{
-				value = std::ldexp(value, 11-exp);
-				hbits |= ((exp+13)<<10);
-			}
-			T ival, frac = std::modf(value, &ival);
-			hbits += static_cast<uint16>(std::abs(static_cast<int>(ival)));
-			if(R == std::round_to_nearest)
-			{
-				frac = std::abs(frac);
-				#if HALF_ROUND_TIES_TO_EVEN
-					hbits += (frac>T(0.5)) | ((frac==T(0.5))&hbits);
-				#else
-					hbits += frac >= T(0.5);
-				#endif
-			}
-			else if(R == std::round_toward_infinity)
-				hbits += frac > T();
-			else if(R == std::round_toward_neg_infinity)
-				hbits += frac < T();
-			return hbits;
-		}
-
-		/// Convert floating point to half-precision.
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \tparam T source type (builtin floating point type)
-		/// \param value floating point value
-		/// \return binary representation of half-precision value
-		template<std::float_round_style R,typename T> uint16 float2half(T value)
-		{
-			return float2half_impl<R>(value, bool_type<std::numeric_limits<T>::is_iec559&&sizeof(typename bits<T>::type)==sizeof(T)>());
-		}
-
-		/// Convert integer to half-precision floating point.
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \tparam S `true` if value negative, `false` else
-		/// \tparam T type to convert (builtin integer type)
-		/// \param value non-negative integral value
-		/// \return binary representation of half-precision value
-		template<std::float_round_style R,bool S,typename T> uint16 int2half_impl(T value)
-		{
-		#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
-			static_assert(std::is_integral<T>::value, "int to half conversion only supports builtin integer types");
-		#endif
-			if(S)
-				value = -value;
-			uint16 bits = S << 15;
-			if(value > 0xFFFF)
-			{
-				if(R == std::round_toward_infinity)
-					bits |= 0x7C00 - S;
-				else if(R == std::round_toward_neg_infinity)
-					bits |= 0x7BFF + S;
-				else
-					bits |= 0x7BFF + (R!=std::round_toward_zero);
-			}
-			else if(value)
-			{
-				unsigned int m = value, exp = 24;
-				for(; m<0x400; m<<=1,--exp) ;
-				for(; m>0x7FF; m>>=1,++exp) ;
-				bits |= (exp<<10) + m;
-				if(exp > 24)
-				{
-					if(R == std::round_to_nearest)
-						bits += (value>>(exp-25)) & 1
-						#if HALF_ROUND_TIES_TO_EVEN
-							& (((((1<<(exp-25))-1)&value)!=0)|bits)
-						#endif
-						;
-					else if(R == std::round_toward_infinity)
-						bits += ((value&((1<<(exp-24))-1))!=0) & !S;
-					else if(R == std::round_toward_neg_infinity)
-						bits += ((value&((1<<(exp-24))-1))!=0) & S;
-				}
-			}
-			return bits;
-		}
-
-		/// Convert integer to half-precision floating point.
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \tparam T type to convert (builtin integer type)
-		/// \param value integral value
-		/// \return binary representation of half-precision value
-		template<std::float_round_style R,typename T> uint16 int2half(T value)
-		{
-			return (value<0) ? int2half_impl<R,true>(value) : int2half_impl<R,false>(value);
-		}
-
-		/// Convert half-precision to IEEE single-precision.
-		/// Credit for this goes to [Jeroen van der Zijp](ftp://ftp.fox-toolkit.org/pub/fasthalffloatconversion.pdf).
-		/// \param value binary representation of half-precision value
-		/// \return single-precision value
-		inline float half2float_impl(uint16 value, float, true_type)
-		{
-			typedef bits<float>::type uint32;
-/*			uint32 bits = static_cast<uint32>(value&0x8000) << 16;
-			int abs = value & 0x7FFF;
-			if(abs)
-			{
-				bits |= 0x38000000 << static_cast<unsigned>(abs>=0x7C00);
-				for(; abs<0x400; abs<<=1,bits-=0x800000) ;
-				bits += static_cast<uint32>(abs) << 13;
-			}
-*/			static const uint32 mantissa_table[2048] = { 
-				0x00000000, 0x33800000, 0x34000000, 0x34400000, 0x34800000, 0x34A00000, 0x34C00000, 0x34E00000, 0x35000000, 0x35100000, 0x35200000, 0x35300000, 0x35400000, 0x35500000, 0x35600000, 0x35700000, 
-				0x35800000, 0x35880000, 0x35900000, 0x35980000, 0x35A00000, 0x35A80000, 0x35B00000, 0x35B80000, 0x35C00000, 0x35C80000, 0x35D00000, 0x35D80000, 0x35E00000, 0x35E80000, 0x35F00000, 0x35F80000, 
-				0x36000000, 0x36040000, 0x36080000, 0x360C0000, 0x36100000, 0x36140000, 0x36180000, 0x361C0000, 0x36200000, 0x36240000, 0x36280000, 0x362C0000, 0x36300000, 0x36340000, 0x36380000, 0x363C0000, 
-				0x36400000, 0x36440000, 0x36480000, 0x364C0000, 0x36500000, 0x36540000, 0x36580000, 0x365C0000, 0x36600000, 0x36640000, 0x36680000, 0x366C0000, 0x36700000, 0x36740000, 0x36780000, 0x367C0000, 
-				0x36800000, 0x36820000, 0x36840000, 0x36860000, 0x36880000, 0x368A0000, 0x368C0000, 0x368E0000, 0x36900000, 0x36920000, 0x36940000, 0x36960000, 0x36980000, 0x369A0000, 0x369C0000, 0x369E0000, 
-				0x36A00000, 0x36A20000, 0x36A40000, 0x36A60000, 0x36A80000, 0x36AA0000, 0x36AC0000, 0x36AE0000, 0x36B00000, 0x36B20000, 0x36B40000, 0x36B60000, 0x36B80000, 0x36BA0000, 0x36BC0000, 0x36BE0000, 
-				0x36C00000, 0x36C20000, 0x36C40000, 0x36C60000, 0x36C80000, 0x36CA0000, 0x36CC0000, 0x36CE0000, 0x36D00000, 0x36D20000, 0x36D40000, 0x36D60000, 0x36D80000, 0x36DA0000, 0x36DC0000, 0x36DE0000, 
-				0x36E00000, 0x36E20000, 0x36E40000, 0x36E60000, 0x36E80000, 0x36EA0000, 0x36EC0000, 0x36EE0000, 0x36F00000, 0x36F20000, 0x36F40000, 0x36F60000, 0x36F80000, 0x36FA0000, 0x36FC0000, 0x36FE0000, 
-				0x37000000, 0x37010000, 0x37020000, 0x37030000, 0x37040000, 0x37050000, 0x37060000, 0x37070000, 0x37080000, 0x37090000, 0x370A0000, 0x370B0000, 0x370C0000, 0x370D0000, 0x370E0000, 0x370F0000, 
-				0x37100000, 0x37110000, 0x37120000, 0x37130000, 0x37140000, 0x37150000, 0x37160000, 0x37170000, 0x37180000, 0x37190000, 0x371A0000, 0x371B0000, 0x371C0000, 0x371D0000, 0x371E0000, 0x371F0000, 
-				0x37200000, 0x37210000, 0x37220000, 0x37230000, 0x37240000, 0x37250000, 0x37260000, 0x37270000, 0x37280000, 0x37290000, 0x372A0000, 0x372B0000, 0x372C0000, 0x372D0000, 0x372E0000, 0x372F0000, 
-				0x37300000, 0x37310000, 0x37320000, 0x37330000, 0x37340000, 0x37350000, 0x37360000, 0x37370000, 0x37380000, 0x37390000, 0x373A0000, 0x373B0000, 0x373C0000, 0x373D0000, 0x373E0000, 0x373F0000, 
-				0x37400000, 0x37410000, 0x37420000, 0x37430000, 0x37440000, 0x37450000, 0x37460000, 0x37470000, 0x37480000, 0x37490000, 0x374A0000, 0x374B0000, 0x374C0000, 0x374D0000, 0x374E0000, 0x374F0000, 
-				0x37500000, 0x37510000, 0x37520000, 0x37530000, 0x37540000, 0x37550000, 0x37560000, 0x37570000, 0x37580000, 0x37590000, 0x375A0000, 0x375B0000, 0x375C0000, 0x375D0000, 0x375E0000, 0x375F0000, 
-				0x37600000, 0x37610000, 0x37620000, 0x37630000, 0x37640000, 0x37650000, 0x37660000, 0x37670000, 0x37680000, 0x37690000, 0x376A0000, 0x376B0000, 0x376C0000, 0x376D0000, 0x376E0000, 0x376F0000, 
-				0x37700000, 0x37710000, 0x37720000, 0x37730000, 0x37740000, 0x37750000, 0x37760000, 0x37770000, 0x37780000, 0x37790000, 0x377A0000, 0x377B0000, 0x377C0000, 0x377D0000, 0x377E0000, 0x377F0000, 
-				0x37800000, 0x37808000, 0x37810000, 0x37818000, 0x37820000, 0x37828000, 0x37830000, 0x37838000, 0x37840000, 0x37848000, 0x37850000, 0x37858000, 0x37860000, 0x37868000, 0x37870000, 0x37878000, 
-				0x37880000, 0x37888000, 0x37890000, 0x37898000, 0x378A0000, 0x378A8000, 0x378B0000, 0x378B8000, 0x378C0000, 0x378C8000, 0x378D0000, 0x378D8000, 0x378E0000, 0x378E8000, 0x378F0000, 0x378F8000, 
-				0x37900000, 0x37908000, 0x37910000, 0x37918000, 0x37920000, 0x37928000, 0x37930000, 0x37938000, 0x37940000, 0x37948000, 0x37950000, 0x37958000, 0x37960000, 0x37968000, 0x37970000, 0x37978000, 
-				0x37980000, 0x37988000, 0x37990000, 0x37998000, 0x379A0000, 0x379A8000, 0x379B0000, 0x379B8000, 0x379C0000, 0x379C8000, 0x379D0000, 0x379D8000, 0x379E0000, 0x379E8000, 0x379F0000, 0x379F8000, 
-				0x37A00000, 0x37A08000, 0x37A10000, 0x37A18000, 0x37A20000, 0x37A28000, 0x37A30000, 0x37A38000, 0x37A40000, 0x37A48000, 0x37A50000, 0x37A58000, 0x37A60000, 0x37A68000, 0x37A70000, 0x37A78000, 
-				0x37A80000, 0x37A88000, 0x37A90000, 0x37A98000, 0x37AA0000, 0x37AA8000, 0x37AB0000, 0x37AB8000, 0x37AC0000, 0x37AC8000, 0x37AD0000, 0x37AD8000, 0x37AE0000, 0x37AE8000, 0x37AF0000, 0x37AF8000, 
-				0x37B00000, 0x37B08000, 0x37B10000, 0x37B18000, 0x37B20000, 0x37B28000, 0x37B30000, 0x37B38000, 0x37B40000, 0x37B48000, 0x37B50000, 0x37B58000, 0x37B60000, 0x37B68000, 0x37B70000, 0x37B78000, 
-				0x37B80000, 0x37B88000, 0x37B90000, 0x37B98000, 0x37BA0000, 0x37BA8000, 0x37BB0000, 0x37BB8000, 0x37BC0000, 0x37BC8000, 0x37BD0000, 0x37BD8000, 0x37BE0000, 0x37BE8000, 0x37BF0000, 0x37BF8000, 
-				0x37C00000, 0x37C08000, 0x37C10000, 0x37C18000, 0x37C20000, 0x37C28000, 0x37C30000, 0x37C38000, 0x37C40000, 0x37C48000, 0x37C50000, 0x37C58000, 0x37C60000, 0x37C68000, 0x37C70000, 0x37C78000, 
-				0x37C80000, 0x37C88000, 0x37C90000, 0x37C98000, 0x37CA0000, 0x37CA8000, 0x37CB0000, 0x37CB8000, 0x37CC0000, 0x37CC8000, 0x37CD0000, 0x37CD8000, 0x37CE0000, 0x37CE8000, 0x37CF0000, 0x37CF8000, 
-				0x37D00000, 0x37D08000, 0x37D10000, 0x37D18000, 0x37D20000, 0x37D28000, 0x37D30000, 0x37D38000, 0x37D40000, 0x37D48000, 0x37D50000, 0x37D58000, 0x37D60000, 0x37D68000, 0x37D70000, 0x37D78000, 
-				0x37D80000, 0x37D88000, 0x37D90000, 0x37D98000, 0x37DA0000, 0x37DA8000, 0x37DB0000, 0x37DB8000, 0x37DC0000, 0x37DC8000, 0x37DD0000, 0x37DD8000, 0x37DE0000, 0x37DE8000, 0x37DF0000, 0x37DF8000, 
-				0x37E00000, 0x37E08000, 0x37E10000, 0x37E18000, 0x37E20000, 0x37E28000, 0x37E30000, 0x37E38000, 0x37E40000, 0x37E48000, 0x37E50000, 0x37E58000, 0x37E60000, 0x37E68000, 0x37E70000, 0x37E78000, 
-				0x37E80000, 0x37E88000, 0x37E90000, 0x37E98000, 0x37EA0000, 0x37EA8000, 0x37EB0000, 0x37EB8000, 0x37EC0000, 0x37EC8000, 0x37ED0000, 0x37ED8000, 0x37EE0000, 0x37EE8000, 0x37EF0000, 0x37EF8000, 
-				0x37F00000, 0x37F08000, 0x37F10000, 0x37F18000, 0x37F20000, 0x37F28000, 0x37F30000, 0x37F38000, 0x37F40000, 0x37F48000, 0x37F50000, 0x37F58000, 0x37F60000, 0x37F68000, 0x37F70000, 0x37F78000, 
-				0x37F80000, 0x37F88000, 0x37F90000, 0x37F98000, 0x37FA0000, 0x37FA8000, 0x37FB0000, 0x37FB8000, 0x37FC0000, 0x37FC8000, 0x37FD0000, 0x37FD8000, 0x37FE0000, 0x37FE8000, 0x37FF0000, 0x37FF8000, 
-				0x38000000, 0x38004000, 0x38008000, 0x3800C000, 0x38010000, 0x38014000, 0x38018000, 0x3801C000, 0x38020000, 0x38024000, 0x38028000, 0x3802C000, 0x38030000, 0x38034000, 0x38038000, 0x3803C000, 
-				0x38040000, 0x38044000, 0x38048000, 0x3804C000, 0x38050000, 0x38054000, 0x38058000, 0x3805C000, 0x38060000, 0x38064000, 0x38068000, 0x3806C000, 0x38070000, 0x38074000, 0x38078000, 0x3807C000, 
-				0x38080000, 0x38084000, 0x38088000, 0x3808C000, 0x38090000, 0x38094000, 0x38098000, 0x3809C000, 0x380A0000, 0x380A4000, 0x380A8000, 0x380AC000, 0x380B0000, 0x380B4000, 0x380B8000, 0x380BC000, 
-				0x380C0000, 0x380C4000, 0x380C8000, 0x380CC000, 0x380D0000, 0x380D4000, 0x380D8000, 0x380DC000, 0x380E0000, 0x380E4000, 0x380E8000, 0x380EC000, 0x380F0000, 0x380F4000, 0x380F8000, 0x380FC000, 
-				0x38100000, 0x38104000, 0x38108000, 0x3810C000, 0x38110000, 0x38114000, 0x38118000, 0x3811C000, 0x38120000, 0x38124000, 0x38128000, 0x3812C000, 0x38130000, 0x38134000, 0x38138000, 0x3813C000, 
-				0x38140000, 0x38144000, 0x38148000, 0x3814C000, 0x38150000, 0x38154000, 0x38158000, 0x3815C000, 0x38160000, 0x38164000, 0x38168000, 0x3816C000, 0x38170000, 0x38174000, 0x38178000, 0x3817C000, 
-				0x38180000, 0x38184000, 0x38188000, 0x3818C000, 0x38190000, 0x38194000, 0x38198000, 0x3819C000, 0x381A0000, 0x381A4000, 0x381A8000, 0x381AC000, 0x381B0000, 0x381B4000, 0x381B8000, 0x381BC000, 
-				0x381C0000, 0x381C4000, 0x381C8000, 0x381CC000, 0x381D0000, 0x381D4000, 0x381D8000, 0x381DC000, 0x381E0000, 0x381E4000, 0x381E8000, 0x381EC000, 0x381F0000, 0x381F4000, 0x381F8000, 0x381FC000, 
-				0x38200000, 0x38204000, 0x38208000, 0x3820C000, 0x38210000, 0x38214000, 0x38218000, 0x3821C000, 0x38220000, 0x38224000, 0x38228000, 0x3822C000, 0x38230000, 0x38234000, 0x38238000, 0x3823C000, 
-				0x38240000, 0x38244000, 0x38248000, 0x3824C000, 0x38250000, 0x38254000, 0x38258000, 0x3825C000, 0x38260000, 0x38264000, 0x38268000, 0x3826C000, 0x38270000, 0x38274000, 0x38278000, 0x3827C000, 
-				0x38280000, 0x38284000, 0x38288000, 0x3828C000, 0x38290000, 0x38294000, 0x38298000, 0x3829C000, 0x382A0000, 0x382A4000, 0x382A8000, 0x382AC000, 0x382B0000, 0x382B4000, 0x382B8000, 0x382BC000, 
-				0x382C0000, 0x382C4000, 0x382C8000, 0x382CC000, 0x382D0000, 0x382D4000, 0x382D8000, 0x382DC000, 0x382E0000, 0x382E4000, 0x382E8000, 0x382EC000, 0x382F0000, 0x382F4000, 0x382F8000, 0x382FC000, 
-				0x38300000, 0x38304000, 0x38308000, 0x3830C000, 0x38310000, 0x38314000, 0x38318000, 0x3831C000, 0x38320000, 0x38324000, 0x38328000, 0x3832C000, 0x38330000, 0x38334000, 0x38338000, 0x3833C000, 
-				0x38340000, 0x38344000, 0x38348000, 0x3834C000, 0x38350000, 0x38354000, 0x38358000, 0x3835C000, 0x38360000, 0x38364000, 0x38368000, 0x3836C000, 0x38370000, 0x38374000, 0x38378000, 0x3837C000, 
-				0x38380000, 0x38384000, 0x38388000, 0x3838C000, 0x38390000, 0x38394000, 0x38398000, 0x3839C000, 0x383A0000, 0x383A4000, 0x383A8000, 0x383AC000, 0x383B0000, 0x383B4000, 0x383B8000, 0x383BC000, 
-				0x383C0000, 0x383C4000, 0x383C8000, 0x383CC000, 0x383D0000, 0x383D4000, 0x383D8000, 0x383DC000, 0x383E0000, 0x383E4000, 0x383E8000, 0x383EC000, 0x383F0000, 0x383F4000, 0x383F8000, 0x383FC000, 
-				0x38400000, 0x38404000, 0x38408000, 0x3840C000, 0x38410000, 0x38414000, 0x38418000, 0x3841C000, 0x38420000, 0x38424000, 0x38428000, 0x3842C000, 0x38430000, 0x38434000, 0x38438000, 0x3843C000, 
-				0x38440000, 0x38444000, 0x38448000, 0x3844C000, 0x38450000, 0x38454000, 0x38458000, 0x3845C000, 0x38460000, 0x38464000, 0x38468000, 0x3846C000, 0x38470000, 0x38474000, 0x38478000, 0x3847C000, 
-				0x38480000, 0x38484000, 0x38488000, 0x3848C000, 0x38490000, 0x38494000, 0x38498000, 0x3849C000, 0x384A0000, 0x384A4000, 0x384A8000, 0x384AC000, 0x384B0000, 0x384B4000, 0x384B8000, 0x384BC000, 
-				0x384C0000, 0x384C4000, 0x384C8000, 0x384CC000, 0x384D0000, 0x384D4000, 0x384D8000, 0x384DC000, 0x384E0000, 0x384E4000, 0x384E8000, 0x384EC000, 0x384F0000, 0x384F4000, 0x384F8000, 0x384FC000, 
-				0x38500000, 0x38504000, 0x38508000, 0x3850C000, 0x38510000, 0x38514000, 0x38518000, 0x3851C000, 0x38520000, 0x38524000, 0x38528000, 0x3852C000, 0x38530000, 0x38534000, 0x38538000, 0x3853C000, 
-				0x38540000, 0x38544000, 0x38548000, 0x3854C000, 0x38550000, 0x38554000, 0x38558000, 0x3855C000, 0x38560000, 0x38564000, 0x38568000, 0x3856C000, 0x38570000, 0x38574000, 0x38578000, 0x3857C000, 
-				0x38580000, 0x38584000, 0x38588000, 0x3858C000, 0x38590000, 0x38594000, 0x38598000, 0x3859C000, 0x385A0000, 0x385A4000, 0x385A8000, 0x385AC000, 0x385B0000, 0x385B4000, 0x385B8000, 0x385BC000, 
-				0x385C0000, 0x385C4000, 0x385C8000, 0x385CC000, 0x385D0000, 0x385D4000, 0x385D8000, 0x385DC000, 0x385E0000, 0x385E4000, 0x385E8000, 0x385EC000, 0x385F0000, 0x385F4000, 0x385F8000, 0x385FC000, 
-				0x38600000, 0x38604000, 0x38608000, 0x3860C000, 0x38610000, 0x38614000, 0x38618000, 0x3861C000, 0x38620000, 0x38624000, 0x38628000, 0x3862C000, 0x38630000, 0x38634000, 0x38638000, 0x3863C000, 
-				0x38640000, 0x38644000, 0x38648000, 0x3864C000, 0x38650000, 0x38654000, 0x38658000, 0x3865C000, 0x38660000, 0x38664000, 0x38668000, 0x3866C000, 0x38670000, 0x38674000, 0x38678000, 0x3867C000, 
-				0x38680000, 0x38684000, 0x38688000, 0x3868C000, 0x38690000, 0x38694000, 0x38698000, 0x3869C000, 0x386A0000, 0x386A4000, 0x386A8000, 0x386AC000, 0x386B0000, 0x386B4000, 0x386B8000, 0x386BC000, 
-				0x386C0000, 0x386C4000, 0x386C8000, 0x386CC000, 0x386D0000, 0x386D4000, 0x386D8000, 0x386DC000, 0x386E0000, 0x386E4000, 0x386E8000, 0x386EC000, 0x386F0000, 0x386F4000, 0x386F8000, 0x386FC000, 
-				0x38700000, 0x38704000, 0x38708000, 0x3870C000, 0x38710000, 0x38714000, 0x38718000, 0x3871C000, 0x38720000, 0x38724000, 0x38728000, 0x3872C000, 0x38730000, 0x38734000, 0x38738000, 0x3873C000, 
-				0x38740000, 0x38744000, 0x38748000, 0x3874C000, 0x38750000, 0x38754000, 0x38758000, 0x3875C000, 0x38760000, 0x38764000, 0x38768000, 0x3876C000, 0x38770000, 0x38774000, 0x38778000, 0x3877C000, 
-				0x38780000, 0x38784000, 0x38788000, 0x3878C000, 0x38790000, 0x38794000, 0x38798000, 0x3879C000, 0x387A0000, 0x387A4000, 0x387A8000, 0x387AC000, 0x387B0000, 0x387B4000, 0x387B8000, 0x387BC000, 
-				0x387C0000, 0x387C4000, 0x387C8000, 0x387CC000, 0x387D0000, 0x387D4000, 0x387D8000, 0x387DC000, 0x387E0000, 0x387E4000, 0x387E8000, 0x387EC000, 0x387F0000, 0x387F4000, 0x387F8000, 0x387FC000, 
-				0x38000000, 0x38002000, 0x38004000, 0x38006000, 0x38008000, 0x3800A000, 0x3800C000, 0x3800E000, 0x38010000, 0x38012000, 0x38014000, 0x38016000, 0x38018000, 0x3801A000, 0x3801C000, 0x3801E000, 
-				0x38020000, 0x38022000, 0x38024000, 0x38026000, 0x38028000, 0x3802A000, 0x3802C000, 0x3802E000, 0x38030000, 0x38032000, 0x38034000, 0x38036000, 0x38038000, 0x3803A000, 0x3803C000, 0x3803E000, 
-				0x38040000, 0x38042000, 0x38044000, 0x38046000, 0x38048000, 0x3804A000, 0x3804C000, 0x3804E000, 0x38050000, 0x38052000, 0x38054000, 0x38056000, 0x38058000, 0x3805A000, 0x3805C000, 0x3805E000, 
-				0x38060000, 0x38062000, 0x38064000, 0x38066000, 0x38068000, 0x3806A000, 0x3806C000, 0x3806E000, 0x38070000, 0x38072000, 0x38074000, 0x38076000, 0x38078000, 0x3807A000, 0x3807C000, 0x3807E000, 
-				0x38080000, 0x38082000, 0x38084000, 0x38086000, 0x38088000, 0x3808A000, 0x3808C000, 0x3808E000, 0x38090000, 0x38092000, 0x38094000, 0x38096000, 0x38098000, 0x3809A000, 0x3809C000, 0x3809E000, 
-				0x380A0000, 0x380A2000, 0x380A4000, 0x380A6000, 0x380A8000, 0x380AA000, 0x380AC000, 0x380AE000, 0x380B0000, 0x380B2000, 0x380B4000, 0x380B6000, 0x380B8000, 0x380BA000, 0x380BC000, 0x380BE000, 
-				0x380C0000, 0x380C2000, 0x380C4000, 0x380C6000, 0x380C8000, 0x380CA000, 0x380CC000, 0x380CE000, 0x380D0000, 0x380D2000, 0x380D4000, 0x380D6000, 0x380D8000, 0x380DA000, 0x380DC000, 0x380DE000, 
-				0x380E0000, 0x380E2000, 0x380E4000, 0x380E6000, 0x380E8000, 0x380EA000, 0x380EC000, 0x380EE000, 0x380F0000, 0x380F2000, 0x380F4000, 0x380F6000, 0x380F8000, 0x380FA000, 0x380FC000, 0x380FE000, 
-				0x38100000, 0x38102000, 0x38104000, 0x38106000, 0x38108000, 0x3810A000, 0x3810C000, 0x3810E000, 0x38110000, 0x38112000, 0x38114000, 0x38116000, 0x38118000, 0x3811A000, 0x3811C000, 0x3811E000, 
-				0x38120000, 0x38122000, 0x38124000, 0x38126000, 0x38128000, 0x3812A000, 0x3812C000, 0x3812E000, 0x38130000, 0x38132000, 0x38134000, 0x38136000, 0x38138000, 0x3813A000, 0x3813C000, 0x3813E000, 
-				0x38140000, 0x38142000, 0x38144000, 0x38146000, 0x38148000, 0x3814A000, 0x3814C000, 0x3814E000, 0x38150000, 0x38152000, 0x38154000, 0x38156000, 0x38158000, 0x3815A000, 0x3815C000, 0x3815E000, 
-				0x38160000, 0x38162000, 0x38164000, 0x38166000, 0x38168000, 0x3816A000, 0x3816C000, 0x3816E000, 0x38170000, 0x38172000, 0x38174000, 0x38176000, 0x38178000, 0x3817A000, 0x3817C000, 0x3817E000, 
-				0x38180000, 0x38182000, 0x38184000, 0x38186000, 0x38188000, 0x3818A000, 0x3818C000, 0x3818E000, 0x38190000, 0x38192000, 0x38194000, 0x38196000, 0x38198000, 0x3819A000, 0x3819C000, 0x3819E000, 
-				0x381A0000, 0x381A2000, 0x381A4000, 0x381A6000, 0x381A8000, 0x381AA000, 0x381AC000, 0x381AE000, 0x381B0000, 0x381B2000, 0x381B4000, 0x381B6000, 0x381B8000, 0x381BA000, 0x381BC000, 0x381BE000, 
-				0x381C0000, 0x381C2000, 0x381C4000, 0x381C6000, 0x381C8000, 0x381CA000, 0x381CC000, 0x381CE000, 0x381D0000, 0x381D2000, 0x381D4000, 0x381D6000, 0x381D8000, 0x381DA000, 0x381DC000, 0x381DE000, 
-				0x381E0000, 0x381E2000, 0x381E4000, 0x381E6000, 0x381E8000, 0x381EA000, 0x381EC000, 0x381EE000, 0x381F0000, 0x381F2000, 0x381F4000, 0x381F6000, 0x381F8000, 0x381FA000, 0x381FC000, 0x381FE000, 
-				0x38200000, 0x38202000, 0x38204000, 0x38206000, 0x38208000, 0x3820A000, 0x3820C000, 0x3820E000, 0x38210000, 0x38212000, 0x38214000, 0x38216000, 0x38218000, 0x3821A000, 0x3821C000, 0x3821E000, 
-				0x38220000, 0x38222000, 0x38224000, 0x38226000, 0x38228000, 0x3822A000, 0x3822C000, 0x3822E000, 0x38230000, 0x38232000, 0x38234000, 0x38236000, 0x38238000, 0x3823A000, 0x3823C000, 0x3823E000, 
-				0x38240000, 0x38242000, 0x38244000, 0x38246000, 0x38248000, 0x3824A000, 0x3824C000, 0x3824E000, 0x38250000, 0x38252000, 0x38254000, 0x38256000, 0x38258000, 0x3825A000, 0x3825C000, 0x3825E000, 
-				0x38260000, 0x38262000, 0x38264000, 0x38266000, 0x38268000, 0x3826A000, 0x3826C000, 0x3826E000, 0x38270000, 0x38272000, 0x38274000, 0x38276000, 0x38278000, 0x3827A000, 0x3827C000, 0x3827E000, 
-				0x38280000, 0x38282000, 0x38284000, 0x38286000, 0x38288000, 0x3828A000, 0x3828C000, 0x3828E000, 0x38290000, 0x38292000, 0x38294000, 0x38296000, 0x38298000, 0x3829A000, 0x3829C000, 0x3829E000, 
-				0x382A0000, 0x382A2000, 0x382A4000, 0x382A6000, 0x382A8000, 0x382AA000, 0x382AC000, 0x382AE000, 0x382B0000, 0x382B2000, 0x382B4000, 0x382B6000, 0x382B8000, 0x382BA000, 0x382BC000, 0x382BE000, 
-				0x382C0000, 0x382C2000, 0x382C4000, 0x382C6000, 0x382C8000, 0x382CA000, 0x382CC000, 0x382CE000, 0x382D0000, 0x382D2000, 0x382D4000, 0x382D6000, 0x382D8000, 0x382DA000, 0x382DC000, 0x382DE000, 
-				0x382E0000, 0x382E2000, 0x382E4000, 0x382E6000, 0x382E8000, 0x382EA000, 0x382EC000, 0x382EE000, 0x382F0000, 0x382F2000, 0x382F4000, 0x382F6000, 0x382F8000, 0x382FA000, 0x382FC000, 0x382FE000, 
-				0x38300000, 0x38302000, 0x38304000, 0x38306000, 0x38308000, 0x3830A000, 0x3830C000, 0x3830E000, 0x38310000, 0x38312000, 0x38314000, 0x38316000, 0x38318000, 0x3831A000, 0x3831C000, 0x3831E000, 
-				0x38320000, 0x38322000, 0x38324000, 0x38326000, 0x38328000, 0x3832A000, 0x3832C000, 0x3832E000, 0x38330000, 0x38332000, 0x38334000, 0x38336000, 0x38338000, 0x3833A000, 0x3833C000, 0x3833E000, 
-				0x38340000, 0x38342000, 0x38344000, 0x38346000, 0x38348000, 0x3834A000, 0x3834C000, 0x3834E000, 0x38350000, 0x38352000, 0x38354000, 0x38356000, 0x38358000, 0x3835A000, 0x3835C000, 0x3835E000, 
-				0x38360000, 0x38362000, 0x38364000, 0x38366000, 0x38368000, 0x3836A000, 0x3836C000, 0x3836E000, 0x38370000, 0x38372000, 0x38374000, 0x38376000, 0x38378000, 0x3837A000, 0x3837C000, 0x3837E000, 
-				0x38380000, 0x38382000, 0x38384000, 0x38386000, 0x38388000, 0x3838A000, 0x3838C000, 0x3838E000, 0x38390000, 0x38392000, 0x38394000, 0x38396000, 0x38398000, 0x3839A000, 0x3839C000, 0x3839E000, 
-				0x383A0000, 0x383A2000, 0x383A4000, 0x383A6000, 0x383A8000, 0x383AA000, 0x383AC000, 0x383AE000, 0x383B0000, 0x383B2000, 0x383B4000, 0x383B6000, 0x383B8000, 0x383BA000, 0x383BC000, 0x383BE000, 
-				0x383C0000, 0x383C2000, 0x383C4000, 0x383C6000, 0x383C8000, 0x383CA000, 0x383CC000, 0x383CE000, 0x383D0000, 0x383D2000, 0x383D4000, 0x383D6000, 0x383D8000, 0x383DA000, 0x383DC000, 0x383DE000, 
-				0x383E0000, 0x383E2000, 0x383E4000, 0x383E6000, 0x383E8000, 0x383EA000, 0x383EC000, 0x383EE000, 0x383F0000, 0x383F2000, 0x383F4000, 0x383F6000, 0x383F8000, 0x383FA000, 0x383FC000, 0x383FE000, 
-				0x38400000, 0x38402000, 0x38404000, 0x38406000, 0x38408000, 0x3840A000, 0x3840C000, 0x3840E000, 0x38410000, 0x38412000, 0x38414000, 0x38416000, 0x38418000, 0x3841A000, 0x3841C000, 0x3841E000, 
-				0x38420000, 0x38422000, 0x38424000, 0x38426000, 0x38428000, 0x3842A000, 0x3842C000, 0x3842E000, 0x38430000, 0x38432000, 0x38434000, 0x38436000, 0x38438000, 0x3843A000, 0x3843C000, 0x3843E000, 
-				0x38440000, 0x38442000, 0x38444000, 0x38446000, 0x38448000, 0x3844A000, 0x3844C000, 0x3844E000, 0x38450000, 0x38452000, 0x38454000, 0x38456000, 0x38458000, 0x3845A000, 0x3845C000, 0x3845E000, 
-				0x38460000, 0x38462000, 0x38464000, 0x38466000, 0x38468000, 0x3846A000, 0x3846C000, 0x3846E000, 0x38470000, 0x38472000, 0x38474000, 0x38476000, 0x38478000, 0x3847A000, 0x3847C000, 0x3847E000, 
-				0x38480000, 0x38482000, 0x38484000, 0x38486000, 0x38488000, 0x3848A000, 0x3848C000, 0x3848E000, 0x38490000, 0x38492000, 0x38494000, 0x38496000, 0x38498000, 0x3849A000, 0x3849C000, 0x3849E000, 
-				0x384A0000, 0x384A2000, 0x384A4000, 0x384A6000, 0x384A8000, 0x384AA000, 0x384AC000, 0x384AE000, 0x384B0000, 0x384B2000, 0x384B4000, 0x384B6000, 0x384B8000, 0x384BA000, 0x384BC000, 0x384BE000, 
-				0x384C0000, 0x384C2000, 0x384C4000, 0x384C6000, 0x384C8000, 0x384CA000, 0x384CC000, 0x384CE000, 0x384D0000, 0x384D2000, 0x384D4000, 0x384D6000, 0x384D8000, 0x384DA000, 0x384DC000, 0x384DE000, 
-				0x384E0000, 0x384E2000, 0x384E4000, 0x384E6000, 0x384E8000, 0x384EA000, 0x384EC000, 0x384EE000, 0x384F0000, 0x384F2000, 0x384F4000, 0x384F6000, 0x384F8000, 0x384FA000, 0x384FC000, 0x384FE000, 
-				0x38500000, 0x38502000, 0x38504000, 0x38506000, 0x38508000, 0x3850A000, 0x3850C000, 0x3850E000, 0x38510000, 0x38512000, 0x38514000, 0x38516000, 0x38518000, 0x3851A000, 0x3851C000, 0x3851E000, 
-				0x38520000, 0x38522000, 0x38524000, 0x38526000, 0x38528000, 0x3852A000, 0x3852C000, 0x3852E000, 0x38530000, 0x38532000, 0x38534000, 0x38536000, 0x38538000, 0x3853A000, 0x3853C000, 0x3853E000, 
-				0x38540000, 0x38542000, 0x38544000, 0x38546000, 0x38548000, 0x3854A000, 0x3854C000, 0x3854E000, 0x38550000, 0x38552000, 0x38554000, 0x38556000, 0x38558000, 0x3855A000, 0x3855C000, 0x3855E000, 
-				0x38560000, 0x38562000, 0x38564000, 0x38566000, 0x38568000, 0x3856A000, 0x3856C000, 0x3856E000, 0x38570000, 0x38572000, 0x38574000, 0x38576000, 0x38578000, 0x3857A000, 0x3857C000, 0x3857E000, 
-				0x38580000, 0x38582000, 0x38584000, 0x38586000, 0x38588000, 0x3858A000, 0x3858C000, 0x3858E000, 0x38590000, 0x38592000, 0x38594000, 0x38596000, 0x38598000, 0x3859A000, 0x3859C000, 0x3859E000, 
-				0x385A0000, 0x385A2000, 0x385A4000, 0x385A6000, 0x385A8000, 0x385AA000, 0x385AC000, 0x385AE000, 0x385B0000, 0x385B2000, 0x385B4000, 0x385B6000, 0x385B8000, 0x385BA000, 0x385BC000, 0x385BE000, 
-				0x385C0000, 0x385C2000, 0x385C4000, 0x385C6000, 0x385C8000, 0x385CA000, 0x385CC000, 0x385CE000, 0x385D0000, 0x385D2000, 0x385D4000, 0x385D6000, 0x385D8000, 0x385DA000, 0x385DC000, 0x385DE000, 
-				0x385E0000, 0x385E2000, 0x385E4000, 0x385E6000, 0x385E8000, 0x385EA000, 0x385EC000, 0x385EE000, 0x385F0000, 0x385F2000, 0x385F4000, 0x385F6000, 0x385F8000, 0x385FA000, 0x385FC000, 0x385FE000, 
-				0x38600000, 0x38602000, 0x38604000, 0x38606000, 0x38608000, 0x3860A000, 0x3860C000, 0x3860E000, 0x38610000, 0x38612000, 0x38614000, 0x38616000, 0x38618000, 0x3861A000, 0x3861C000, 0x3861E000, 
-				0x38620000, 0x38622000, 0x38624000, 0x38626000, 0x38628000, 0x3862A000, 0x3862C000, 0x3862E000, 0x38630000, 0x38632000, 0x38634000, 0x38636000, 0x38638000, 0x3863A000, 0x3863C000, 0x3863E000, 
-				0x38640000, 0x38642000, 0x38644000, 0x38646000, 0x38648000, 0x3864A000, 0x3864C000, 0x3864E000, 0x38650000, 0x38652000, 0x38654000, 0x38656000, 0x38658000, 0x3865A000, 0x3865C000, 0x3865E000, 
-				0x38660000, 0x38662000, 0x38664000, 0x38666000, 0x38668000, 0x3866A000, 0x3866C000, 0x3866E000, 0x38670000, 0x38672000, 0x38674000, 0x38676000, 0x38678000, 0x3867A000, 0x3867C000, 0x3867E000, 
-				0x38680000, 0x38682000, 0x38684000, 0x38686000, 0x38688000, 0x3868A000, 0x3868C000, 0x3868E000, 0x38690000, 0x38692000, 0x38694000, 0x38696000, 0x38698000, 0x3869A000, 0x3869C000, 0x3869E000, 
-				0x386A0000, 0x386A2000, 0x386A4000, 0x386A6000, 0x386A8000, 0x386AA000, 0x386AC000, 0x386AE000, 0x386B0000, 0x386B2000, 0x386B4000, 0x386B6000, 0x386B8000, 0x386BA000, 0x386BC000, 0x386BE000, 
-				0x386C0000, 0x386C2000, 0x386C4000, 0x386C6000, 0x386C8000, 0x386CA000, 0x386CC000, 0x386CE000, 0x386D0000, 0x386D2000, 0x386D4000, 0x386D6000, 0x386D8000, 0x386DA000, 0x386DC000, 0x386DE000, 
-				0x386E0000, 0x386E2000, 0x386E4000, 0x386E6000, 0x386E8000, 0x386EA000, 0x386EC000, 0x386EE000, 0x386F0000, 0x386F2000, 0x386F4000, 0x386F6000, 0x386F8000, 0x386FA000, 0x386FC000, 0x386FE000, 
-				0x38700000, 0x38702000, 0x38704000, 0x38706000, 0x38708000, 0x3870A000, 0x3870C000, 0x3870E000, 0x38710000, 0x38712000, 0x38714000, 0x38716000, 0x38718000, 0x3871A000, 0x3871C000, 0x3871E000, 
-				0x38720000, 0x38722000, 0x38724000, 0x38726000, 0x38728000, 0x3872A000, 0x3872C000, 0x3872E000, 0x38730000, 0x38732000, 0x38734000, 0x38736000, 0x38738000, 0x3873A000, 0x3873C000, 0x3873E000, 
-				0x38740000, 0x38742000, 0x38744000, 0x38746000, 0x38748000, 0x3874A000, 0x3874C000, 0x3874E000, 0x38750000, 0x38752000, 0x38754000, 0x38756000, 0x38758000, 0x3875A000, 0x3875C000, 0x3875E000, 
-				0x38760000, 0x38762000, 0x38764000, 0x38766000, 0x38768000, 0x3876A000, 0x3876C000, 0x3876E000, 0x38770000, 0x38772000, 0x38774000, 0x38776000, 0x38778000, 0x3877A000, 0x3877C000, 0x3877E000, 
-				0x38780000, 0x38782000, 0x38784000, 0x38786000, 0x38788000, 0x3878A000, 0x3878C000, 0x3878E000, 0x38790000, 0x38792000, 0x38794000, 0x38796000, 0x38798000, 0x3879A000, 0x3879C000, 0x3879E000, 
-				0x387A0000, 0x387A2000, 0x387A4000, 0x387A6000, 0x387A8000, 0x387AA000, 0x387AC000, 0x387AE000, 0x387B0000, 0x387B2000, 0x387B4000, 0x387B6000, 0x387B8000, 0x387BA000, 0x387BC000, 0x387BE000, 
-				0x387C0000, 0x387C2000, 0x387C4000, 0x387C6000, 0x387C8000, 0x387CA000, 0x387CC000, 0x387CE000, 0x387D0000, 0x387D2000, 0x387D4000, 0x387D6000, 0x387D8000, 0x387DA000, 0x387DC000, 0x387DE000, 
-				0x387E0000, 0x387E2000, 0x387E4000, 0x387E6000, 0x387E8000, 0x387EA000, 0x387EC000, 0x387EE000, 0x387F0000, 0x387F2000, 0x387F4000, 0x387F6000, 0x387F8000, 0x387FA000, 0x387FC000, 0x387FE000 };
-			static const uint32 exponent_table[64] = { 
-				0x00000000, 0x00800000, 0x01000000, 0x01800000, 0x02000000, 0x02800000, 0x03000000, 0x03800000, 0x04000000, 0x04800000, 0x05000000, 0x05800000, 0x06000000, 0x06800000, 0x07000000, 0x07800000, 
-				0x08000000, 0x08800000, 0x09000000, 0x09800000, 0x0A000000, 0x0A800000, 0x0B000000, 0x0B800000, 0x0C000000, 0x0C800000, 0x0D000000, 0x0D800000, 0x0E000000, 0x0E800000, 0x0F000000, 0x47800000, 
-				0x80000000, 0x80800000, 0x81000000, 0x81800000, 0x82000000, 0x82800000, 0x83000000, 0x83800000, 0x84000000, 0x84800000, 0x85000000, 0x85800000, 0x86000000, 0x86800000, 0x87000000, 0x87800000, 
-				0x88000000, 0x88800000, 0x89000000, 0x89800000, 0x8A000000, 0x8A800000, 0x8B000000, 0x8B800000, 0x8C000000, 0x8C800000, 0x8D000000, 0x8D800000, 0x8E000000, 0x8E800000, 0x8F000000, 0xC7800000 };
-			static const unsigned short offset_table[64] = { 
-				   0, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 
-				   0, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024 };
-			uint32 bits = mantissa_table[offset_table[value>>10]+(value&0x3FF)] + exponent_table[value>>10];
-//			return *reinterpret_cast<float*>(&bits);			//violating strict aliasing!
-			float out;
-			std::memcpy(&out, &bits, sizeof(float));
-			return out;
-		}
-
-		/// Convert half-precision to IEEE double-precision.
-		/// \param value binary representation of half-precision value
-		/// \return double-precision value
-		inline double half2float_impl(uint16 value, double, true_type)
-		{
-			typedef bits<float>::type uint32;
-			typedef bits<double>::type uint64;
-			uint32 hi = static_cast<uint32>(value&0x8000) << 16;
-			int abs = value & 0x7FFF;
-			if(abs)
-			{
-				hi |= 0x3F000000 << static_cast<unsigned>(abs>=0x7C00);
-				for(; abs<0x400; abs<<=1,hi-=0x100000) ;
-				hi += static_cast<uint32>(abs) << 10;
-			}
-			uint64 bits = static_cast<uint64>(hi) << 32;
-//			return *reinterpret_cast<double*>(&bits);			//violating strict aliasing!
-			double out;
-			std::memcpy(&out, &bits, sizeof(double));
-			return out;
-		}
-
-		/// Convert half-precision to non-IEEE floating point.
-		/// \tparam T type to convert to (builtin integer type)
-		/// \param value binary representation of half-precision value
-		/// \return floating point value
-		template<typename T> T half2float_impl(uint16 value, T, ...)
-		{
-			T out;
-			int abs = value & 0x7FFF;
-			if(abs > 0x7C00)
-				out = std::numeric_limits<T>::has_quiet_NaN ? std::numeric_limits<T>::quiet_NaN() : T();
-			else if(abs == 0x7C00)
-				out = std::numeric_limits<T>::has_infinity ? std::numeric_limits<T>::infinity() : std::numeric_limits<T>::max();
-			else if(abs > 0x3FF)
-				out = std::ldexp(static_cast<T>((abs&0x3FF)|0x400), (abs>>10)-25);
-			else
-				out = std::ldexp(static_cast<T>(abs), -24);
-			return (value&0x8000) ? -out : out;
-		}
-
-		/// Convert half-precision to floating point.
-		/// \tparam T type to convert to (builtin integer type)
-		/// \param value binary representation of half-precision value
-		/// \return floating point value
-		template<typename T> T half2float(uint16 value)
-		{
-			return half2float_impl(value, T(), bool_type<std::numeric_limits<T>::is_iec559&&sizeof(typename bits<T>::type)==sizeof(T)>());
-		}
-
-		/// Convert half-precision floating point to integer.
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \tparam E `true` for round to even, `false` for round away from zero
-		/// \tparam T type to convert to (buitlin integer type with at least 16 bits precision, excluding any implicit sign bits)
-		/// \param value binary representation of half-precision value
-		/// \return integral value
-		template<std::float_round_style R,bool E,typename T> T half2int_impl(uint16 value)
-		{
-		#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
-			static_assert(std::is_integral<T>::value, "half to int conversion only supports builtin integer types");
-		#endif
-			unsigned int e = value & 0x7FFF;
-			if(e >= 0x7C00)
-				return (value&0x8000) ? std::numeric_limits<T>::min() : std::numeric_limits<T>::max();
-			if(e < 0x3800)
-			{
-				if(R == std::round_toward_infinity)
-					return T(~(value>>15)&(e!=0));
-				else if(R == std::round_toward_neg_infinity)
-					return -T(value>0x8000);
-				return T();
-			}
-			unsigned int m = (value&0x3FF) | 0x400;
-			e >>= 10;
-			if(e < 25)
-			{
-				if(R == std::round_to_nearest)
-					m += (1<<(24-e)) - (~(m>>(25-e))&E);
-				else if(R == std::round_toward_infinity)
-					m += ((value>>15)-1) & ((1<<(25-e))-1U);
-				else if(R == std::round_toward_neg_infinity)
-					m += -(value>>15) & ((1<<(25-e))-1U);
-				m >>= 25 - e;
-			}
-			else
-				m <<= e - 25;
-			return (value&0x8000) ? -static_cast<T>(m) : static_cast<T>(m);
-		}
-
-		/// Convert half-precision floating point to integer.
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \tparam T type to convert to (buitlin integer type with at least 16 bits precision, excluding any implicit sign bits)
-		/// \param value binary representation of half-precision value
-		/// \return integral value
-		template<std::float_round_style R,typename T> T half2int(uint16 value) { return half2int_impl<R,HALF_ROUND_TIES_TO_EVEN,T>(value); }
-
-		/// Convert half-precision floating point to integer using round-to-nearest-away-from-zero.
-		/// \tparam T type to convert to (buitlin integer type with at least 16 bits precision, excluding any implicit sign bits)
-		/// \param value binary representation of half-precision value
-		/// \return integral value
-		template<typename T> T half2int_up(uint16 value) { return half2int_impl<std::round_to_nearest,0,T>(value); }
-
-		/// Round half-precision number to nearest integer value.
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \tparam E `true` for round to even, `false` for round away from zero
-		/// \param value binary representation of half-precision value
-		/// \return half-precision bits for nearest integral value
-		template<std::float_round_style R,bool E> uint16 round_half_impl(uint16 value)
-		{
-			unsigned int e = value & 0x7FFF;
-			uint16 result = value;
-			if(e < 0x3C00)
-			{
-				result &= 0x8000;
-				if(R == std::round_to_nearest)
-					result |= 0x3C00U & -(e>=(0x3800+E));
-				else if(R == std::round_toward_infinity)
-					result |= 0x3C00U & -(~(value>>15)&(e!=0));
-				else if(R == std::round_toward_neg_infinity)
-					result |= 0x3C00U & -(value>0x8000);
-			}
-			else if(e < 0x6400)
-			{
-				e = 25 - (e>>10);
-				unsigned int mask = (1<<e) - 1;
-				if(R == std::round_to_nearest)
-					result += (1<<(e-1)) - (~(result>>e)&E);
-				else if(R == std::round_toward_infinity)
-					result += mask & ((value>>15)-1);
-				else if(R == std::round_toward_neg_infinity)
-					result += mask & -(value>>15);
-				result &= ~mask;
-			}
-			return result;
-		}
-
-		/// Round half-precision number to nearest integer value.
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \param value binary representation of half-precision value
-		/// \return half-precision bits for nearest integral value
-		template<std::float_round_style R> uint16 round_half(uint16 value) { return round_half_impl<R,HALF_ROUND_TIES_TO_EVEN>(value); }
-
-		/// Round half-precision number to nearest integer value using round-to-nearest-away-from-zero.
-		/// \param value binary representation of half-precision value
-		/// \return half-precision bits for nearest integral value
-		inline uint16 round_half_up(uint16 value) { return round_half_impl<std::round_to_nearest,0>(value); }
-		/// \}
-
-		struct functions;
-		template<typename> struct unary_specialized;
-		template<typename,typename> struct binary_specialized;
-		template<typename,typename,std::float_round_style> struct half_caster;
-	}
-
-	/// Half-precision floating point type.
-	/// This class implements an IEEE-conformant half-precision floating point type with the usual arithmetic operators and 
-	/// conversions. It is implicitly convertible to single-precision floating point, which makes artihmetic expressions and 
-	/// functions with mixed-type operands to be of the most precise operand type. Additionally all arithmetic operations 
-	/// (and many mathematical functions) are carried out in single-precision internally. All conversions from single- to 
-	/// half-precision are done using the library's default rounding mode, but temporary results inside chained arithmetic 
-	/// expressions are kept in single-precision as long as possible (while of course still maintaining a strong half-precision type).
-	///
-	/// According to the C++98/03 definition, the half type is not a POD type. But according to C++11's less strict and 
-	/// extended definitions it is both a standard layout type and a trivially copyable type (even if not a POD type), which 
-	/// means it can be standard-conformantly copied using raw binary copies. But in this context some more words about the 
-	/// actual size of the type. Although the half is representing an IEEE 16-bit type, it does not neccessarily have to be of 
-	/// exactly 16-bits size. But on any reasonable implementation the actual binary representation of this type will most 
-	/// probably not ivolve any additional "magic" or padding beyond the simple binary representation of the underlying 16-bit 
-	/// IEEE number, even if not strictly guaranteed by the standard. But even then it only has an actual size of 16 bits if 
-	/// your C++ implementation supports an unsigned integer type of exactly 16 bits width. But this should be the case on 
-	/// nearly any reasonable platform.
-	///
-	/// So if your C++ implementation is not totally exotic or imposes special alignment requirements, it is a reasonable 
-	/// assumption that the data of a half is just comprised of the 2 bytes of the underlying IEEE representation.
-	class half
-	{
-		friend struct detail::functions;
-		friend struct detail::unary_specialized<half>;
-		friend struct detail::binary_specialized<half,half>;
-		template<typename,typename,std::float_round_style> friend struct detail::half_caster;
-		friend class std::numeric_limits<half>;
-	#if HALF_ENABLE_CPP11_HASH
-		friend struct std::hash<half>;
-	#endif
-	#if HALF_ENABLE_CPP11_USER_LITERALS
-		friend half literal::operator"" _h(long double);
-	#endif
-
-	public:
-		/// Default constructor.
-		/// This initializes the half to 0. Although this does not match the builtin types' default-initialization semantics 
-		/// and may be less efficient than no initialization, it is needed to provide proper value-initialization semantics.
-		HALF_CONSTEXPR half() HALF_NOEXCEPT : data_() {}
-
-		/// Copy constructor.
-		/// \tparam T type of concrete half expression
-		/// \param rhs half expression to copy from
-		half(detail::expr rhs) : data_(detail::float2half<round_style>(static_cast<float>(rhs))) {}
-
-		/// Conversion constructor.
-		/// \param rhs float to convert
-		explicit half(float rhs) : data_(detail::float2half<round_style>(rhs)) {}
-	
-		/// Conversion to single-precision.
-		/// \return single precision value representing expression value
-		operator float() const { return detail::half2float<float>(data_); }
-
-		/// Assignment operator.
-		/// \tparam T type of concrete half expression
-		/// \param rhs half expression to copy from
-		/// \return reference to this half
-		half& operator=(detail::expr rhs) { return *this = static_cast<float>(rhs); }
-
-		/// Arithmetic assignment.
-		/// \tparam T type of concrete half expression
-		/// \param rhs half expression to add
-		/// \return reference to this half
-		template<typename T> typename detail::enable<half&,T>::type operator+=(T rhs) { return *this += static_cast<float>(rhs); }
-
-		/// Arithmetic assignment.
-		/// \tparam T type of concrete half expression
-		/// \param rhs half expression to subtract
-		/// \return reference to this half
-		template<typename T> typename detail::enable<half&,T>::type operator-=(T rhs) { return *this -= static_cast<float>(rhs); }
-
-		/// Arithmetic assignment.
-		/// \tparam T type of concrete half expression
-		/// \param rhs half expression to multiply with
-		/// \return reference to this half
-		template<typename T> typename detail::enable<half&,T>::type operator*=(T rhs) { return *this *= static_cast<float>(rhs); }
-
-		/// Arithmetic assignment.
-		/// \tparam T type of concrete half expression
-		/// \param rhs half expression to divide by
-		/// \return reference to this half
-		template<typename T> typename detail::enable<half&,T>::type operator/=(T rhs) { return *this /= static_cast<float>(rhs); }
-
-		/// Assignment operator.
-		/// \param rhs single-precision value to copy from
-		/// \return reference to this half
-		half& operator=(float rhs) { data_ = detail::float2half<round_style>(rhs); return *this; }
-
-		/// Arithmetic assignment.
-		/// \param rhs single-precision value to add
-		/// \return reference to this half
-		half& operator+=(float rhs) { data_ = detail::float2half<round_style>(detail::half2float<float>(data_)+rhs); return *this; }
-
-		/// Arithmetic assignment.
-		/// \param rhs single-precision value to subtract
-		/// \return reference to this half
-		half& operator-=(float rhs) { data_ = detail::float2half<round_style>(detail::half2float<float>(data_)-rhs); return *this; }
-
-		/// Arithmetic assignment.
-		/// \param rhs single-precision value to multiply with
-		/// \return reference to this half
-		half& operator*=(float rhs) { data_ = detail::float2half<round_style>(detail::half2float<float>(data_)*rhs); return *this; }
-
-		/// Arithmetic assignment.
-		/// \param rhs single-precision value to divide by
-		/// \return reference to this half
-		half& operator/=(float rhs) { data_ = detail::float2half<round_style>(detail::half2float<float>(data_)/rhs); return *this; }
-
-		/// Prefix increment.
-		/// \return incremented half value
-		half& operator++() { return *this += 1.0f; }
-
-		/// Prefix decrement.
-		/// \return decremented half value
-		half& operator--() { return *this -= 1.0f; }
-
-		/// Postfix increment.
-		/// \return non-incremented half value
-		half operator++(int) { half out(*this); ++*this; return out; }
-
-		/// Postfix decrement.
-		/// \return non-decremented half value
-		half operator--(int) { half out(*this); --*this; return out; }
-	
-	private:
-		/// Rounding mode to use
-		static const std::float_round_style round_style = (std::float_round_style)(HALF_ROUND_STYLE);
-
-		/// Constructor.
-		/// \param bits binary representation to set half to
-		HALF_CONSTEXPR half(detail::binary_t, detail::uint16 bits) HALF_NOEXCEPT : data_(bits) {}
-
-		/// Internal binary representation
-		detail::uint16 data_;
-	};
-
-#if HALF_ENABLE_CPP11_USER_LITERALS
-	namespace literal
-	{
-		/// Half literal.
-		/// While this returns an actual half-precision value, half literals can unfortunately not be constant expressions due 
-		/// to rather involved conversions.
-		/// \param value literal value
-		/// \return half with given value (if representable)
-		inline half operator"" _h(long double value) { return half(detail::binary, detail::float2half<half::round_style>(value)); }
-	}
+/// Type traits for floating point types.
+template <typename>
+struct is_float : false_type {};
+template <typename T>
+struct is_float<const T> : is_float<T> {};
+template <typename T>
+struct is_float<volatile T> : is_float<T> {};
+template <typename T>
+struct is_float<const volatile T> : is_float<T> {};
+template <>
+struct is_float<float> : true_type {};
+template <>
+struct is_float<double> : true_type {};
+template <>
+struct is_float<long double> : true_type {};
 #endif
 
-	namespace detail
-	{
-		/// Wrapper implementing unspecialized half-precision functions.
-		struct functions
-		{
-			/// Addition implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \return Half-precision sum stored in single-precision
-			static expr plus(float x, float y) { return expr(x+y); }
+/// Type traits for floating point bits.
+template <typename T>
+struct bits {
+  typedef unsigned char type;
+};
+template <typename T>
+struct bits<const T> : bits<T> {};
+template <typename T>
+struct bits<volatile T> : bits<T> {};
+template <typename T>
+struct bits<const volatile T> : bits<T> {};
+
+#if HALF_ENABLE_CPP11_CSTDINT
+/// Unsigned integer of (at least) 16 bits width.
+typedef std::uint_least16_t uint16;
+
+/// Unsigned integer of (at least) 32 bits width.
+template <>
+struct bits<float> {
+  typedef std::uint_least32_t type;
+};
+
+/// Unsigned integer of (at least) 64 bits width.
+template <>
+struct bits<double> {
+  typedef std::uint_least64_t type;
+};
+#else
+/// Unsigned integer of (at least) 16 bits width.
+typedef unsigned short uint16;
+
+/// Unsigned integer of (at least) 32 bits width.
+template <>
+struct bits<float>
+    : conditional<std::numeric_limits<unsigned int>::digits >= 32, unsigned int,
+                  unsigned long> {};
 
-			/// Subtraction implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \return Half-precision difference stored in single-precision
-			static expr minus(float x, float y) { return expr(x-y); }
-
-			/// Multiplication implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \return Half-precision product stored in single-precision
-			static expr multiplies(float x, float y) { return expr(x*y); }
-
-			/// Division implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \return Half-precision quotient stored in single-precision
-			static expr divides(float x, float y) { return expr(x/y); }
-
-			/// Output implementation.
-			/// \param out stream to write to
-			/// \param arg value to write
-			/// \return reference to stream
-			template<typename charT,typename traits> static std::basic_ostream<charT,traits>& write(std::basic_ostream<charT,traits> &out, float arg) { return out << arg; }
-
-			/// Input implementation.
-			/// \param in stream to read from
-			/// \param arg half to read into
-			/// \return reference to stream
-			template<typename charT,typename traits> static std::basic_istream<charT,traits>& read(std::basic_istream<charT,traits> &in, half &arg)
-			{
-				float f;
-				if(in >> f)
-					arg = f;
-				return in;
-			}
-
-			/// Modulo implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \return Half-precision division remainder stored in single-precision
-			static expr fmod(float x, float y) { return expr(std::fmod(x, y)); }
-
-			/// Remainder implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \return Half-precision division remainder stored in single-precision
-			static expr remainder(float x, float y)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::remainder(x, y));
-			#else
-				if(builtin_isnan(x) || builtin_isnan(y))
-					return expr(std::numeric_limits<float>::quiet_NaN());
-				float ax = std::fabs(x), ay = std::fabs(y);
-				if(ax >= 65536.0f || ay < std::ldexp(1.0f, -24))
-					return expr(std::numeric_limits<float>::quiet_NaN());
-				if(ay >= 65536.0f)
-					return expr(x);
-				if(ax == ay)
-					return expr(builtin_signbit(x) ? -0.0f : 0.0f);
-				ax = std::fmod(ax, ay+ay);
-				float y2 = 0.5f * ay;
-				if(ax > y2)
-				{
-					ax -= ay;
-					if(ax >= y2)
-						ax -= ay;
-				}
-				return expr(builtin_signbit(x) ? -ax : ax);
-			#endif
-			}
-
-			/// Remainder implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \param quo address to store quotient bits at
-			/// \return Half-precision division remainder stored in single-precision
-			static expr remquo(float x, float y, int *quo)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::remquo(x, y, quo));
-			#else
-				if(builtin_isnan(x) || builtin_isnan(y))
-					return expr(std::numeric_limits<float>::quiet_NaN());
-				bool sign = builtin_signbit(x), qsign = static_cast<bool>(sign^builtin_signbit(y));
-				float ax = std::fabs(x), ay = std::fabs(y);
-				if(ax >= 65536.0f || ay < std::ldexp(1.0f, -24))
-					return expr(std::numeric_limits<float>::quiet_NaN());
-				if(ay >= 65536.0f)
-					return expr(x);
-				if(ax == ay)
-					return *quo = qsign ? -1 : 1, expr(sign ? -0.0f : 0.0f);
-				ax = std::fmod(ax, 8.0f*ay);
-				int cquo = 0;
-				if(ax >= 4.0f * ay)
-				{
-					ax -= 4.0f * ay;
-					cquo += 4;
-				}
-				if(ax >= 2.0f * ay)
-				{
-					ax -= 2.0f * ay;
-					cquo += 2;
-				}
-				float y2 = 0.5f * ay;
-				if(ax > y2)
-				{
-					ax -= ay;
-					++cquo;
-					if(ax >= y2)
-					{
-						ax -= ay;
-						++cquo;
-					}
-				}
-				return *quo = qsign ? -cquo : cquo, expr(sign ? -ax : ax);
-			#endif
-			}
-
-			/// Positive difference implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \return Positive difference stored in single-precision
-			static expr fdim(float x, float y)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::fdim(x, y));
-			#else
-				return expr((x<=y) ? 0.0f : (x-y));
-			#endif
-			}
-
-			/// Fused multiply-add implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \param z third operand
-			/// \return \a x * \a y + \a z stored in single-precision
-			static expr fma(float x, float y, float z)
-			{
-			#if HALF_ENABLE_CPP11_CMATH && defined(FP_FAST_FMAF)
-				return expr(std::fma(x, y, z));
-			#else
-				return expr(x*y+z);
-			#endif
-			}
-
-			/// Get NaN.
-			/// \return Half-precision quiet NaN
-			static half nanh() { return half(binary, 0x7FFF); }
-
-			/// Exponential implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr exp(float arg) { return expr(std::exp(arg)); }
-
-			/// Exponential implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr expm1(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::expm1(arg));
-			#else
-				return expr(static_cast<float>(std::exp(static_cast<double>(arg))-1.0));
-			#endif
-			}
-
-			/// Binary exponential implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr exp2(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::exp2(arg));
-			#else
-				return expr(static_cast<float>(std::exp(arg*0.69314718055994530941723212145818)));
-			#endif
-			}
-
-			/// Logarithm implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr log(float arg) { return expr(std::log(arg)); }
-
-			/// Common logarithm implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr log10(float arg) { return expr(std::log10(arg)); }
-
-			/// Logarithm implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr log1p(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::log1p(arg));
-			#else
-				return expr(static_cast<float>(std::log(1.0+arg)));
-			#endif
-			}
-
-			/// Binary logarithm implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr log2(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::log2(arg));
-			#else
-				return expr(static_cast<float>(std::log(static_cast<double>(arg))*1.4426950408889634073599246810019));
-			#endif
-			}
-
-			/// Square root implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr sqrt(float arg) { return expr(std::sqrt(arg)); }
-
-			/// Cubic root implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr cbrt(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::cbrt(arg));
-			#else
-				if(builtin_isnan(arg) || builtin_isinf(arg))
-					return expr(arg);
-				return expr(builtin_signbit(arg) ? -static_cast<float>(std::pow(-static_cast<double>(arg), 1.0/3.0)) : 
-					static_cast<float>(std::pow(static_cast<double>(arg), 1.0/3.0)));
-			#endif
-			}
-
-			/// Hypotenuse implementation.
-			/// \param x first argument
-			/// \param y second argument
-			/// \return function value stored in single-preicision
-			static expr hypot(float x, float y)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::hypot(x, y));
-			#else
-				return expr((builtin_isinf(x) || builtin_isinf(y)) ? std::numeric_limits<float>::infinity() : 
-					static_cast<float>(std::sqrt(static_cast<double>(x)*x+static_cast<double>(y)*y)));
-			#endif
-			}
-
-			/// Power implementation.
-			/// \param base value to exponentiate
-			/// \param exp power to expontiate to
-			/// \return function value stored in single-preicision
-			static expr pow(float base, float exp) { return expr(std::pow(base, exp)); }
-
-			/// Sine implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr sin(float arg) { return expr(std::sin(arg)); }
-
-			/// Cosine implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr cos(float arg) { return expr(std::cos(arg)); }
-
-			/// Tan implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr tan(float arg) { return expr(std::tan(arg)); }
-
-			/// Arc sine implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr asin(float arg) { return expr(std::asin(arg)); }
-
-			/// Arc cosine implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr acos(float arg) { return expr(std::acos(arg)); }
-
-			/// Arc tangent implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr atan(float arg) { return expr(std::atan(arg)); }
-
-			/// Arc tangent implementation.
-			/// \param x first argument
-			/// \param y second argument
-			/// \return function value stored in single-preicision
-			static expr atan2(float x, float y) { return expr(std::atan2(x, y)); }
-
-			/// Hyperbolic sine implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr sinh(float arg) { return expr(std::sinh(arg)); }
-
-			/// Hyperbolic cosine implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr cosh(float arg) { return expr(std::cosh(arg)); }
-
-			/// Hyperbolic tangent implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr tanh(float arg) { return expr(std::tanh(arg)); }
-
-			/// Hyperbolic area sine implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr asinh(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::asinh(arg));
-			#else
-				return expr((arg==-std::numeric_limits<float>::infinity()) ? arg : static_cast<float>(std::log(arg+std::sqrt(arg*arg+1.0))));
-			#endif
-			}
-
-			/// Hyperbolic area cosine implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr acosh(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::acosh(arg));
-			#else
-				return expr((arg<-1.0f) ? std::numeric_limits<float>::quiet_NaN() : static_cast<float>(std::log(arg+std::sqrt(arg*arg-1.0))));
-			#endif
-			}
-
-			/// Hyperbolic area tangent implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr atanh(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::atanh(arg));
-			#else
-				return expr(static_cast<float>(0.5*std::log((1.0+arg)/(1.0-arg))));
-			#endif
-			}
-
-			/// Error function implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr erf(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::erf(arg));
-			#else
-				return expr(static_cast<float>(erf(static_cast<double>(arg))));
-			#endif
-			}
-
-			/// Complementary implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr erfc(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::erfc(arg));
-			#else
-				return expr(static_cast<float>(1.0-erf(static_cast<double>(arg))));
-			#endif
-			}
-
-			/// Gamma logarithm implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr lgamma(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::lgamma(arg));
-			#else
-				if(builtin_isinf(arg))
-					return expr(std::numeric_limits<float>::infinity());
-				if(arg < 0.0f)
-				{
-					float i, f = std::modf(-arg, &i);
-					if(f == 0.0f)
-						return expr(std::numeric_limits<float>::infinity());
-					return expr(static_cast<float>(1.1447298858494001741434273513531-
-						std::log(std::abs(std::sin(3.1415926535897932384626433832795*f)))-lgamma(1.0-arg)));
-				}
-				return expr(static_cast<float>(lgamma(static_cast<double>(arg))));
-			#endif
-			}
-
-			/// Gamma implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr tgamma(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::tgamma(arg));
-			#else
-				if(arg == 0.0f)
-					return builtin_signbit(arg) ? expr(-std::numeric_limits<float>::infinity()) : expr(std::numeric_limits<float>::infinity());
-				if(arg < 0.0f)
-				{
-					float i, f = std::modf(-arg, &i);
-					if(f == 0.0f)
-						return expr(std::numeric_limits<float>::quiet_NaN());
-					double value = 3.1415926535897932384626433832795 / (std::sin(3.1415926535897932384626433832795*f)*std::exp(lgamma(1.0-arg)));
-					return expr(static_cast<float>((std::fmod(i, 2.0f)==0.0f) ? -value : value));
-				}
-				if(builtin_isinf(arg))
-					return expr(arg);
-				return expr(static_cast<float>(std::exp(lgamma(static_cast<double>(arg)))));
-			#endif
-			}
-
-			/// Floor implementation.
-			/// \param arg value to round
-			/// \return rounded value
-			static half floor(half arg) { return half(binary, round_half<std::round_toward_neg_infinity>(arg.data_)); }
-
-			/// Ceiling implementation.
-			/// \param arg value to round
-			/// \return rounded value
-			static half ceil(half arg) { return half(binary, round_half<std::round_toward_infinity>(arg.data_)); }
-
-			/// Truncation implementation.
-			/// \param arg value to round
-			/// \return rounded value
-			static half trunc(half arg) { return half(binary, round_half<std::round_toward_zero>(arg.data_)); }
-
-			/// Nearest integer implementation.
-			/// \param arg value to round
-			/// \return rounded value
-			static half round(half arg) { return half(binary, round_half_up(arg.data_)); }
-
-			/// Nearest integer implementation.
-			/// \param arg value to round
-			/// \return rounded value
-			static long lround(half arg) { return detail::half2int_up<long>(arg.data_); }
-
-			/// Nearest integer implementation.
-			/// \param arg value to round
-			/// \return rounded value
-			static half rint(half arg) { return half(binary, round_half<half::round_style>(arg.data_)); }
-
-			/// Nearest integer implementation.
-			/// \param arg value to round
-			/// \return rounded value
-			static long lrint(half arg) { return detail::half2int<half::round_style,long>(arg.data_); }
-
-		#if HALF_ENABLE_CPP11_LONG_LONG
-			/// Nearest integer implementation.
-			/// \param arg value to round
-			/// \return rounded value
-			static long long llround(half arg) { return detail::half2int_up<long long>(arg.data_); }
-
-			/// Nearest integer implementation.
-			/// \param arg value to round
-			/// \return rounded value
-			static long long llrint(half arg) { return detail::half2int<half::round_style,long long>(arg.data_); }
-		#endif
-
-			/// Decompression implementation.
-			/// \param arg number to decompress
-			/// \param exp address to store exponent at
-			/// \return normalized significant
-			static half frexp(half arg, int *exp)
-			{
-				int m = arg.data_ & 0x7FFF, e = -14;
-				if(m >= 0x7C00 || !m)
-					return *exp = 0, arg;
-				for(; m<0x400; m<<=1,--e) ;
-				return *exp = e+(m>>10), half(binary, (arg.data_&0x8000)|0x3800|(m&0x3FF));
-			}
-
-			/// Decompression implementation.
-			/// \param arg number to decompress
-			/// \param iptr address to store integer part at
-			/// \return fractional part
-			static half modf(half arg, half *iptr)
-			{
-				unsigned int e = arg.data_ & 0x7FFF;
-				if(e >= 0x6400)
-					return *iptr = arg, half(binary, arg.data_&(0x8000U|-(e>0x7C00)));
-				if(e < 0x3C00)
-					return iptr->data_ = arg.data_ & 0x8000, arg;
-				e >>= 10;
-				unsigned int mask = (1<<(25-e)) - 1, m = arg.data_ & mask;
-				iptr->data_ = arg.data_ & ~mask;
-				if(!m)
-					return half(binary, arg.data_&0x8000);
-				for(; m<0x400; m<<=1,--e) ;
-				return half(binary, static_cast<uint16>((arg.data_&0x8000)|(e<<10)|(m&0x3FF)));
-			}
-
-			/// Scaling implementation.
-			/// \param arg number to scale
-			/// \param exp power of two to scale by
-			/// \return scaled number
-			static half scalbln(half arg, long exp)
-			{
-				unsigned int m = arg.data_ & 0x7FFF;
-				if(m >= 0x7C00 || !m)
-					return arg;
-				for(; m<0x400; m<<=1,--exp) ;
-				exp += m >> 10;
-				uint16 value = arg.data_ & 0x8000;
-				if(exp > 30)
-				{
-					if(half::round_style == std::round_toward_zero)
-						value |= 0x7BFF;
-					else if(half::round_style == std::round_toward_infinity)
-						value |= 0x7C00 - (value>>15);
-					else if(half::round_style == std::round_toward_neg_infinity)
-						value |= 0x7BFF + (value>>15);
-					else
-						value |= 0x7C00;
-				}
-				else if(exp > 0)
-					value |= (exp<<10) | (m&0x3FF);
-				else if(exp > -11)
-				{
-					m = (m&0x3FF) | 0x400;
-					if(half::round_style == std::round_to_nearest)
-					{
-						m += 1 << -exp;
-					#if HALF_ROUND_TIES_TO_EVEN
-						m -= (m>>(1-exp)) & 1;
-					#endif
-					}
-					else if(half::round_style == std::round_toward_infinity)
-						m += ((value>>15)-1) & ((1<<(1-exp))-1U);
-					else if(half::round_style == std::round_toward_neg_infinity)
-						m += -(value>>15) & ((1<<(1-exp))-1U);
-					value |= m >> (1-exp);
-				}
-				else if(half::round_style == std::round_toward_infinity)
-					value -= (value>>15) - 1;
-				else if(half::round_style == std::round_toward_neg_infinity)
-					value += value >> 15;
-				return half(binary, value);
-			}
-
-			/// Exponent implementation.
-			/// \param arg number to query
-			/// \return floating point exponent
-			static int ilogb(half arg)
-			{
-				int abs = arg.data_ & 0x7FFF;
-				if(!abs)
-					return FP_ILOGB0;
-				if(abs < 0x7C00)
-				{
-					int exp = (abs>>10) - 15;
-					if(abs < 0x400)
-						for(; abs<0x200; abs<<=1,--exp) ;
-					return exp;
-				}
-				if(abs > 0x7C00)
-					return FP_ILOGBNAN;
-				return INT_MAX;
-			}
-
-			/// Exponent implementation.
-			/// \param arg number to query
-			/// \return floating point exponent
-			static half logb(half arg)
-			{
-				int abs = arg.data_ & 0x7FFF;
-				if(!abs)
-					return half(binary, 0xFC00);
-				if(abs < 0x7C00)
-				{
-					int exp = (abs>>10) - 15;
-					if(abs < 0x400)
-						for(; abs<0x200; abs<<=1,--exp) ;
-					uint16 bits = (exp<0) << 15;
-					if(exp)
-					{
-						unsigned int m = std::abs(exp) << 6, e = 18;
-						for(; m<0x400; m<<=1,--e) ;
-						bits |= (e<<10) + m;
-					}
-					return half(binary, bits);
-				}
-				if(abs > 0x7C00)
-					return arg;
-				return half(binary, 0x7C00);
-			}
-
-			/// Enumeration implementation.
-			/// \param from number to increase/decrease
-			/// \param to direction to enumerate into
-			/// \return next representable number
-			static half nextafter(half from, half to)
-			{
-				uint16 fabs = from.data_ & 0x7FFF, tabs = to.data_ & 0x7FFF;
-				if(fabs > 0x7C00)
-					return from;
-				if(tabs > 0x7C00 || from.data_ == to.data_ || !(fabs|tabs))
-					return to;
-				if(!fabs)
-					return half(binary, (to.data_&0x8000)+1);
-				bool lt = ((fabs==from.data_) ? static_cast<int>(fabs) : -static_cast<int>(fabs)) < 
-					((tabs==to.data_) ? static_cast<int>(tabs) : -static_cast<int>(tabs));
-				return half(binary, from.data_+(((from.data_>>15)^static_cast<unsigned>(lt))<<1)-1);
-			}
-
-			/// Enumeration implementation.
-			/// \param from number to increase/decrease
-			/// \param to direction to enumerate into
-			/// \return next representable number
-			static half nexttoward(half from, long double to)
-			{
-				if(isnan(from))
-					return from;
-				long double lfrom = static_cast<long double>(from);
-				if(builtin_isnan(to) || lfrom == to)
-					return half(static_cast<float>(to));
-				if(!(from.data_&0x7FFF))
-					return half(binary, (static_cast<detail::uint16>(builtin_signbit(to))<<15)+1);
-				return half(binary, from.data_+(((from.data_>>15)^static_cast<unsigned>(lfrom<to))<<1)-1);
-			}
-
-			/// Sign implementation
-			/// \param x first operand
-			/// \param y second operand
-			/// \return composed value
-			static half copysign(half x, half y) { return half(binary, x.data_^((x.data_^y.data_)&0x8000)); }
-
-			/// Classification implementation.
-			/// \param arg value to classify
-			/// \retval true if infinite number
-			/// \retval false else
-			static int fpclassify(half arg)
-			{
-				unsigned int abs = arg.data_ & 0x7FFF;
-				return abs ? ((abs>0x3FF) ? ((abs>=0x7C00) ? ((abs>0x7C00) ? FP_NAN : FP_INFINITE) : FP_NORMAL) :FP_SUBNORMAL) : FP_ZERO;
-			}
-
-			/// Classification implementation.
-			/// \param arg value to classify
-			/// \retval true if finite number
-			/// \retval false else
-			static bool isfinite(half arg) { return (arg.data_&0x7C00) != 0x7C00; }
-
-			/// Classification implementation.
-			/// \param arg value to classify
-			/// \retval true if infinite number
-			/// \retval false else
-			static bool isinf(half arg) { return (arg.data_&0x7FFF) == 0x7C00; }
-
-			/// Classification implementation.
-			/// \param arg value to classify
-			/// \retval true if not a number
-			/// \retval false else
-			static bool isnan(half arg) { return (arg.data_&0x7FFF) > 0x7C00; }
-
-			/// Classification implementation.
-			/// \param arg value to classify
-			/// \retval true if normal number
-			/// \retval false else
-			static bool isnormal(half arg) { return ((arg.data_&0x7C00)!=0) & ((arg.data_&0x7C00)!=0x7C00); }
-
-			/// Sign bit implementation.
-			/// \param arg value to check
-			/// \retval true if signed
-			/// \retval false if unsigned
-			static bool signbit(half arg) { return (arg.data_&0x8000) != 0; }
-
-			/// Comparison implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \retval true if operands equal
-			/// \retval false else
-			static bool isequal(half x, half y) { return (x.data_==y.data_ || !((x.data_|y.data_)&0x7FFF)) && !isnan(x); }
-
-			/// Comparison implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \retval true if operands not equal
-			/// \retval false else
-			static bool isnotequal(half x, half y) { return (x.data_!=y.data_ && ((x.data_|y.data_)&0x7FFF)) || isnan(x); }
-
-			/// Comparison implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \retval true if \a x > \a y
-			/// \retval false else
-			static bool isgreater(half x, half y)
-			{
-				int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
-				return xabs<=0x7C00 && yabs<=0x7C00 && (((xabs==x.data_) ? xabs : -xabs) > ((yabs==y.data_) ? yabs : -yabs));
-			}
-
-			/// Comparison implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \retval true if \a x >= \a y
-			/// \retval false else
-			static bool isgreaterequal(half x, half y)
-			{
-				int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
-				return xabs<=0x7C00 && yabs<=0x7C00 && (((xabs==x.data_) ? xabs : -xabs) >= ((yabs==y.data_) ? yabs : -yabs));
-			}
-
-			/// Comparison implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \retval true if \a x < \a y
-			/// \retval false else
-			static bool isless(half x, half y)
-			{
-				int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
-				return xabs<=0x7C00 && yabs<=0x7C00 && (((xabs==x.data_) ? xabs : -xabs) < ((yabs==y.data_) ? yabs : -yabs));
-			}
-
-			/// Comparison implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \retval true if \a x <= \a y
-			/// \retval false else
-			static bool islessequal(half x, half y)
-			{
-				int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
-				return xabs<=0x7C00 && yabs<=0x7C00 && (((xabs==x.data_) ? xabs : -xabs) <= ((yabs==y.data_) ? yabs : -yabs));
-			}
-
-			/// Comparison implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \retval true if either \a x > \a y nor \a x < \a y
-			/// \retval false else
-			static bool islessgreater(half x, half y)
-			{
-				int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
-				if(xabs > 0x7C00 || yabs > 0x7C00)
-					return false;
-				int a = (xabs==x.data_) ? xabs : -xabs, b = (yabs==y.data_) ? yabs : -yabs;
-				return a < b || a > b;
-			}
-
-			/// Comparison implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \retval true if operand unordered
-			/// \retval false else
-			static bool isunordered(half x, half y) { return isnan(x) || isnan(y); }
-
-		private:
-			static double erf(double arg)
-			{
-				if(builtin_isinf(arg))
-					return (arg<0.0) ? -1.0 : 1.0;
-				double x2 = arg * arg, ax2 = 0.147 * x2, value = std::sqrt(1.0-std::exp(-x2*(1.2732395447351626861510701069801+ax2)/(1.0+ax2)));
-				return builtin_signbit(arg) ? -value : value;
-			}
-
-			static double lgamma(double arg)
-			{
-				double v = 1.0;
-				for(; arg<8.0; ++arg) v *= arg;
-				double w = 1.0 / (arg*arg);
-				return (((((((-0.02955065359477124183006535947712*w+0.00641025641025641025641025641026)*w+
-					-0.00191752691752691752691752691753)*w+8.4175084175084175084175084175084e-4)*w+
-					-5.952380952380952380952380952381e-4)*w+7.9365079365079365079365079365079e-4)*w+
-					-0.00277777777777777777777777777778)*w+0.08333333333333333333333333333333)/arg + 
-					0.91893853320467274178032973640562 - std::log(v) - arg + (arg-0.5) * std::log(arg);
-			}
-		};
-
-		/// Wrapper for unary half-precision functions needing specialization for individual argument types.
-		/// \tparam T argument type
-		template<typename T> struct unary_specialized
-		{
-			/// Negation implementation.
-			/// \param arg value to negate
-			/// \return negated value
-			static HALF_CONSTEXPR half negate(half arg) { return half(binary, arg.data_^0x8000); }
-
-			/// Absolute value implementation.
-			/// \param arg function argument
-			/// \return absolute value
-			static half fabs(half arg) { return half(binary, arg.data_&0x7FFF); }
-		};
-		template<> struct unary_specialized<expr>
-		{
-			static HALF_CONSTEXPR expr negate(float arg) { return expr(-arg); }
-			static expr fabs(float arg) { return expr(std::fabs(arg)); }
-		};
-
-		/// Wrapper for binary half-precision functions needing specialization for individual argument types.
-		/// \tparam T first argument type
-		/// \tparam U first argument type
-		template<typename T,typename U> struct binary_specialized
-		{
-			/// Minimum implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \return minimum value
-			static expr fmin(float x, float y)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::fmin(x, y));
-			#else
-				if(builtin_isnan(x))
-					return expr(y);
-				if(builtin_isnan(y))
-					return expr(x);
-				return expr(std::min(x, y));
-			#endif
-			}
-
-			/// Maximum implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \return maximum value
-			static expr fmax(float x, float y)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::fmax(x, y));
-			#else
-				if(builtin_isnan(x))
-					return expr(y);
-				if(builtin_isnan(y))
-					return expr(x);
-				return expr(std::max(x, y));
-			#endif
-			}
-		};
-		template<> struct binary_specialized<half,half>
-		{
-			static half fmin(half x, half y)
-			{
-				int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
-				if(xabs > 0x7C00)
-					return y;
-				if(yabs > 0x7C00)
-					return x;
-				return (((xabs==x.data_) ? xabs : -xabs) > ((yabs==y.data_) ? yabs : -yabs)) ? y : x;
-			}
-			static half fmax(half x, half y)
-			{
-				int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
-				if(xabs > 0x7C00)
-					return y;
-				if(yabs > 0x7C00)
-					return x;
-				return (((xabs==x.data_) ? xabs : -xabs) < ((yabs==y.data_) ? yabs : -yabs)) ? y : x;
-			}
-		};
-
-		/// Helper class for half casts.
-		/// This class template has to be specialized for all valid cast argument to define an appropriate static `cast` member 
-		/// function and a corresponding `type` member denoting its return type.
-		/// \tparam T destination type
-		/// \tparam U source type
-		/// \tparam R rounding mode to use
-		template<typename T,typename U,std::float_round_style R=(std::float_round_style)(HALF_ROUND_STYLE)> struct half_caster {};
-		template<typename U,std::float_round_style R> struct half_caster<half,U,R>
-		{
-		#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
-			static_assert(std::is_arithmetic<U>::value, "half_cast from non-arithmetic type unsupported");
-		#endif
-
-			static half cast(U arg) { return cast_impl(arg, is_float<U>()); };
-
-		private:
-			static half cast_impl(U arg, true_type) { return half(binary, float2half<R>(arg)); }
-			static half cast_impl(U arg, false_type) { return half(binary, int2half<R>(arg)); }
-		};
-		template<typename T,std::float_round_style R> struct half_caster<T,half,R>
-		{
-		#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
-			static_assert(std::is_arithmetic<T>::value, "half_cast to non-arithmetic type unsupported");
-		#endif
-
-			static T cast(half arg) { return cast_impl(arg, is_float<T>()); }
-
-		private:
-			static T cast_impl(half arg, true_type) { return half2float<T>(arg.data_); }
-			static T cast_impl(half arg, false_type) { return half2int<R,T>(arg.data_); }
-		};
-		template<typename T,std::float_round_style R> struct half_caster<T,expr,R>
-		{
-		#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
-			static_assert(std::is_arithmetic<T>::value, "half_cast to non-arithmetic type unsupported");
-		#endif
-
-			static T cast(expr arg) { return cast_impl(arg, is_float<T>()); }
-
-		private:
-			static T cast_impl(float arg, true_type) { return static_cast<T>(arg); }
-			static T cast_impl(half arg, false_type) { return half2int<R,T>(arg.data_); }
-		};
-		template<std::float_round_style R> struct half_caster<half,half,R>
-		{
-			static half cast(half arg) { return arg; }
-		};
-		template<std::float_round_style R> struct half_caster<half,expr,R> : half_caster<half,half,R> {};
-
-		/// \name Comparison operators
-		/// \{
-
-		/// Comparison for equality.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if operands equal
-		/// \retval false else
-		template<typename T,typename U> typename enable<bool,T,U>::type operator==(T x, U y) { return functions::isequal(x, y); }
-
-		/// Comparison for inequality.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if operands not equal
-		/// \retval false else
-		template<typename T,typename U> typename enable<bool,T,U>::type operator!=(T x, U y) { return functions::isnotequal(x, y); }
-
-		/// Comparison for less than.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if \a x less than \a y
-		/// \retval false else
-		template<typename T,typename U> typename enable<bool,T,U>::type operator<(T x, U y) { return functions::isless(x, y); }
-
-		/// Comparison for greater than.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if \a x greater than \a y
-		/// \retval false else
-		template<typename T,typename U> typename enable<bool,T,U>::type operator>(T x, U y) { return functions::isgreater(x, y); }
-
-		/// Comparison for less equal.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if \a x less equal \a y
-		/// \retval false else
-		template<typename T,typename U> typename enable<bool,T,U>::type operator<=(T x, U y) { return functions::islessequal(x, y); }
-
-		/// Comparison for greater equal.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if \a x greater equal \a y
-		/// \retval false else
-		template<typename T,typename U> typename enable<bool,T,U>::type operator>=(T x, U y) { return functions::isgreaterequal(x, y); }
-
-		/// \}
-		/// \name Arithmetic operators
-		/// \{
-
-		/// Add halfs.
-		/// \param x left operand
-		/// \param y right operand
-		/// \return sum of half expressions
-		template<typename T,typename U> typename enable<expr,T,U>::type operator+(T x, U y) { return functions::plus(x, y); }
-
-		/// Subtract halfs.
-		/// \param x left operand
-		/// \param y right operand
-		/// \return difference of half expressions
-		template<typename T,typename U> typename enable<expr,T,U>::type operator-(T x, U y) { return functions::minus(x, y); }
-
-		/// Multiply halfs.
-		/// \param x left operand
-		/// \param y right operand
-		/// \return product of half expressions
-		template<typename T,typename U> typename enable<expr,T,U>::type operator*(T x, U y) { return functions::multiplies(x, y); }
-
-		/// Divide halfs.
-		/// \param x left operand
-		/// \param y right operand
-		/// \return quotient of half expressions
-		template<typename T,typename U> typename enable<expr,T,U>::type operator/(T x, U y) { return functions::divides(x, y); }
-
-		/// Identity.
-		/// \param arg operand
-		/// \return uncahnged operand
-		template<typename T> HALF_CONSTEXPR typename enable<T,T>::type operator+(T arg) { return arg; }
-
-		/// Negation.
-		/// \param arg operand
-		/// \return negated operand
-		template<typename T> HALF_CONSTEXPR typename enable<T,T>::type operator-(T arg) { return unary_specialized<T>::negate(arg); }
-
-		/// \}
-		/// \name Input and output
-		/// \{
-
-		/// Output operator.
-		/// \param out output stream to write into
-		/// \param arg half expression to write
-		/// \return reference to output stream
-		template<typename T,typename charT,typename traits> typename enable<std::basic_ostream<charT,traits>&,T>::type
-			operator<<(std::basic_ostream<charT,traits> &out, T arg) { return functions::write(out, arg); }
-
-		/// Input operator.
-		/// \param in input stream to read from
-		/// \param arg half to read into
-		/// \return reference to input stream
-		template<typename charT,typename traits> std::basic_istream<charT,traits>&
-			operator>>(std::basic_istream<charT,traits> &in, half &arg) { return functions::read(in, arg); }
-
-		/// \}
-		/// \name Basic mathematical operations
-		/// \{
-
-		/// Absolute value.
-		/// \param arg operand
-		/// \return absolute value of \a arg
-//		template<typename T> typename enable<T,T>::type abs(T arg) { return unary_specialized<T>::fabs(arg); }
-		inline half abs(half arg) { return unary_specialized<half>::fabs(arg); }
-		inline expr abs(expr arg) { return unary_specialized<expr>::fabs(arg); }
-
-		/// Absolute value.
-		/// \param arg operand
-		/// \return absolute value of \a arg
-//		template<typename T> typename enable<T,T>::type fabs(T arg) { return unary_specialized<T>::fabs(arg); }
-		inline half fabs(half arg) { return unary_specialized<half>::fabs(arg); }
-		inline expr fabs(expr arg) { return unary_specialized<expr>::fabs(arg); }
-
-		/// Remainder of division.
-		/// \param x first operand
-		/// \param y second operand
-		/// \return remainder of floating point division.
-//		template<typename T,typename U> typename enable<expr,T,U>::type fmod(T x, U y) { return functions::fmod(x, y); }
-		inline expr fmod(half x, half y) { return functions::fmod(x, y); }
-		inline expr fmod(half x, expr y) { return functions::fmod(x, y); }
-		inline expr fmod(expr x, half y) { return functions::fmod(x, y); }
-		inline expr fmod(expr x, expr y) { return functions::fmod(x, y); }
-
-		/// Remainder of division.
-		/// \param x first operand
-		/// \param y second operand
-		/// \return remainder of floating point division.
-//		template<typename T,typename U> typename enable<expr,T,U>::type remainder(T x, U y) { return functions::remainder(x, y); }
-		inline expr remainder(half x, half y) { return functions::remainder(x, y); }
-		inline expr remainder(half x, expr y) { return functions::remainder(x, y); }
-		inline expr remainder(expr x, half y) { return functions::remainder(x, y); }
-		inline expr remainder(expr x, expr y) { return functions::remainder(x, y); }
-
-		/// Remainder of division.
-		/// \param x first operand
-		/// \param y second operand
-		/// \param quo address to store some bits of quotient at
-		/// \return remainder of floating point division.
-//		template<typename T,typename U> typename enable<expr,T,U>::type remquo(T x, U y, int *quo) { return functions::remquo(x, y, quo); }
-		inline expr remquo(half x, half y, int *quo) { return functions::remquo(x, y, quo); }
-		inline expr remquo(half x, expr y, int *quo) { return functions::remquo(x, y, quo); }
-		inline expr remquo(expr x, half y, int *quo) { return functions::remquo(x, y, quo); }
-		inline expr remquo(expr x, expr y, int *quo) { return functions::remquo(x, y, quo); }
-
-		/// Fused multiply add.
-		/// \param x first operand
-		/// \param y second operand
-		/// \param z third operand
-		/// \return ( \a x * \a y ) + \a z rounded as one operation.
-//		template<typename T,typename U,typename V> typename enable<expr,T,U,V>::type fma(T x, U y, V z) { return functions::fma(x, y, z); }
-		inline expr fma(half x, half y, half z) { return functions::fma(x, y, z); }
-		inline expr fma(half x, half y, expr z) { return functions::fma(x, y, z); }
-		inline expr fma(half x, expr y, half z) { return functions::fma(x, y, z); }
-		inline expr fma(half x, expr y, expr z) { return functions::fma(x, y, z); }
-		inline expr fma(expr x, half y, half z) { return functions::fma(x, y, z); }
-		inline expr fma(expr x, half y, expr z) { return functions::fma(x, y, z); }
-		inline expr fma(expr x, expr y, half z) { return functions::fma(x, y, z); }
-		inline expr fma(expr x, expr y, expr z) { return functions::fma(x, y, z); }
-
-		/// Maximum of half expressions.
-		/// \param x first operand
-		/// \param y second operand
-		/// \return maximum of operands
-//		template<typename T,typename U> typename result<T,U>::type fmax(T x, U y) { return binary_specialized<T,U>::fmax(x, y); }
-		inline half fmax(half x, half y) { return binary_specialized<half,half>::fmax(x, y); }
-		inline expr fmax(half x, expr y) { return binary_specialized<half,expr>::fmax(x, y); }
-		inline expr fmax(expr x, half y) { return binary_specialized<expr,half>::fmax(x, y); }
-		inline expr fmax(expr x, expr y) { return binary_specialized<expr,expr>::fmax(x, y); }
-
-		/// Minimum of half expressions.
-		/// \param x first operand
-		/// \param y second operand
-		/// \return minimum of operands
-//		template<typename T,typename U> typename result<T,U>::type fmin(T x, U y) { return binary_specialized<T,U>::fmin(x, y); }
-		inline half fmin(half x, half y) { return binary_specialized<half,half>::fmin(x, y); }
-		inline expr fmin(half x, expr y) { return binary_specialized<half,expr>::fmin(x, y); }
-		inline expr fmin(expr x, half y) { return binary_specialized<expr,half>::fmin(x, y); }
-		inline expr fmin(expr x, expr y) { return binary_specialized<expr,expr>::fmin(x, y); }
-
-		/// Positive difference.
-		/// \param x first operand
-		/// \param y second operand
-		/// \return \a x - \a y or 0 if difference negative
-//		template<typename T,typename U> typename enable<expr,T,U>::type fdim(T x, U y) { return functions::fdim(x, y); }
-		inline expr fdim(half x, half y) { return functions::fdim(x, y); }
-		inline expr fdim(half x, expr y) { return functions::fdim(x, y); }
-		inline expr fdim(expr x, half y) { return functions::fdim(x, y); }
-		inline expr fdim(expr x, expr y) { return functions::fdim(x, y); }
-
-		/// Get NaN value.
-		/// \return quiet NaN
-		inline half nanh(const char*) { return functions::nanh(); }
-
-		/// \}
-		/// \name Exponential functions
-		/// \{
-
-		/// Exponential function.
-		/// \param arg function argument
-		/// \return e raised to \a arg
-//		template<typename T> typename enable<expr,T>::type exp(T arg) { return functions::exp(arg); }
-		inline expr exp(half arg) { return functions::exp(arg); }
-		inline expr exp(expr arg) { return functions::exp(arg); }
-
-		/// Exponential minus one.
-		/// \param arg function argument
-		/// \return e raised to \a arg subtracted by 1
-//		template<typename T> typename enable<expr,T>::type expm1(T arg) { return functions::expm1(arg); }
-		inline expr expm1(half arg) { return functions::expm1(arg); }
-		inline expr expm1(expr arg) { return functions::expm1(arg); }
-
-		/// Binary exponential.
-		/// \param arg function argument
-		/// \return 2 raised to \a arg
-//		template<typename T> typename enable<expr,T>::type exp2(T arg) { return functions::exp2(arg); }
-		inline expr exp2(half arg) { return functions::exp2(arg); }
-		inline expr exp2(expr arg) { return functions::exp2(arg); }
-
-		/// Natural logorithm.
-		/// \param arg function argument
-		/// \return logarithm of \a arg to base e
-//		template<typename T> typename enable<expr,T>::type log(T arg) { return functions::log(arg); }
-		inline expr log(half arg) { return functions::log(arg); }
-		inline expr log(expr arg) { return functions::log(arg); }
-
-		/// Common logorithm.
-		/// \param arg function argument
-		/// \return logarithm of \a arg to base 10
-//		template<typename T> typename enable<expr,T>::type log10(T arg) { return functions::log10(arg); }
-		inline expr log10(half arg) { return functions::log10(arg); }
-		inline expr log10(expr arg) { return functions::log10(arg); }
-
-		/// Natural logorithm.
-		/// \param arg function argument
-		/// \return logarithm of \a arg plus 1 to base e
-//		template<typename T> typename enable<expr,T>::type log1p(T arg) { return functions::log1p(arg); }
-		inline expr log1p(half arg) { return functions::log1p(arg); }
-		inline expr log1p(expr arg) { return functions::log1p(arg); }
-
-		/// Binary logorithm.
-		/// \param arg function argument
-		/// \return logarithm of \a arg to base 2
-//		template<typename T> typename enable<expr,T>::type log2(T arg) { return functions::log2(arg); }
-		inline expr log2(half arg) { return functions::log2(arg); }
-		inline expr log2(expr arg) { return functions::log2(arg); }
-
-		/// \}
-		/// \name Power functions
-		/// \{
-
-		/// Square root.
-		/// \param arg function argument
-		/// \return square root of \a arg
-//		template<typename T> typename enable<expr,T>::type sqrt(T arg) { return functions::sqrt(arg); }
-		inline expr sqrt(half arg) { return functions::sqrt(arg); }
-		inline expr sqrt(expr arg) { return functions::sqrt(arg); }
-
-		/// Cubic root.
-		/// \param arg function argument
-		/// \return cubic root of \a arg
-//		template<typename T> typename enable<expr,T>::type cbrt(T arg) { return functions::cbrt(arg); }
-		inline expr cbrt(half arg) { return functions::cbrt(arg); }
-		inline expr cbrt(expr arg) { return functions::cbrt(arg); }
-
-		/// Hypotenuse function.
-		/// \param x first argument
-		/// \param y second argument
-		/// \return square root of sum of squares without internal over- or underflows
-//		template<typename T,typename U> typename enable<expr,T,U>::type hypot(T x, U y) { return functions::hypot(x, y); }
-		inline expr hypot(half x, half y) { return functions::hypot(x, y); }
-		inline expr hypot(half x, expr y) { return functions::hypot(x, y); }
-		inline expr hypot(expr x, half y) { return functions::hypot(x, y); }
-		inline expr hypot(expr x, expr y) { return functions::hypot(x, y); }
-
-		/// Power function.
-		/// \param base first argument
-		/// \param exp second argument
-		/// \return \a base raised to \a exp
-//		template<typename T,typename U> typename enable<expr,T,U>::type pow(T base, U exp) { return functions::pow(base, exp); }
-		inline expr pow(half base, half exp) { return functions::pow(base, exp); }
-		inline expr pow(half base, expr exp) { return functions::pow(base, exp); }
-		inline expr pow(expr base, half exp) { return functions::pow(base, exp); }
-		inline expr pow(expr base, expr exp) { return functions::pow(base, exp); }
-
-		/// \}
-		/// \name Trigonometric functions
-		/// \{
-
-		/// Sine function.
-		/// \param arg function argument
-		/// \return sine value of \a arg
-//		template<typename T> typename enable<expr,T>::type sin(T arg) { return functions::sin(arg); }
-		inline expr sin(half arg) { return functions::sin(arg); }
-		inline expr sin(expr arg) { return functions::sin(arg); }
-
-		/// Cosine function.
-		/// \param arg function argument
-		/// \return cosine value of \a arg
-//		template<typename T> typename enable<expr,T>::type cos(T arg) { return functions::cos(arg); }
-		inline expr cos(half arg) { return functions::cos(arg); }
-		inline expr cos(expr arg) { return functions::cos(arg); }
-
-		/// Tangent function.
-		/// \param arg function argument
-		/// \return tangent value of \a arg
-//		template<typename T> typename enable<expr,T>::type tan(T arg) { return functions::tan(arg); }
-		inline expr tan(half arg) { return functions::tan(arg); }
-		inline expr tan(expr arg) { return functions::tan(arg); }
-
-		/// Arc sine.
-		/// \param arg function argument
-		/// \return arc sine value of \a arg
-//		template<typename T> typename enable<expr,T>::type asin(T arg) { return functions::asin(arg); }
-		inline expr asin(half arg) { return functions::asin(arg); }
-		inline expr asin(expr arg) { return functions::asin(arg); }
-
-		/// Arc cosine function.
-		/// \param arg function argument
-		/// \return arc cosine value of \a arg
-//		template<typename T> typename enable<expr,T>::type acos(T arg) { return functions::acos(arg); }
-		inline expr acos(half arg) { return functions::acos(arg); }
-		inline expr acos(expr arg) { return functions::acos(arg); }
-
-		/// Arc tangent function.
-		/// \param arg function argument
-		/// \return arc tangent value of \a arg
-//		template<typename T> typename enable<expr,T>::type atan(T arg) { return functions::atan(arg); }
-		inline expr atan(half arg) { return functions::atan(arg); }
-		inline expr atan(expr arg) { return functions::atan(arg); }
-
-		/// Arc tangent function.
-		/// \param x first argument
-		/// \param y second argument
-		/// \return arc tangent value
-//		template<typename T,typename U> typename enable<expr,T,U>::type atan2(T x, U y) { return functions::atan2(x, y); }
-		inline expr atan2(half x, half y) { return functions::atan2(x, y); }
-		inline expr atan2(half x, expr y) { return functions::atan2(x, y); }
-		inline expr atan2(expr x, half y) { return functions::atan2(x, y); }
-		inline expr atan2(expr x, expr y) { return functions::atan2(x, y); }
-
-		/// \}
-		/// \name Hyperbolic functions
-		/// \{
-
-		/// Hyperbolic sine.
-		/// \param arg function argument
-		/// \return hyperbolic sine value of \a arg
-//		template<typename T> typename enable<expr,T>::type sinh(T arg) { return functions::sinh(arg); }
-		inline expr sinh(half arg) { return functions::sinh(arg); }
-		inline expr sinh(expr arg) { return functions::sinh(arg); }
-
-		/// Hyperbolic cosine.
-		/// \param arg function argument
-		/// \return hyperbolic cosine value of \a arg
-//		template<typename T> typename enable<expr,T>::type cosh(T arg) { return functions::cosh(arg); }
-		inline expr cosh(half arg) { return functions::cosh(arg); }
-		inline expr cosh(expr arg) { return functions::cosh(arg); }
-
-		/// Hyperbolic tangent.
-		/// \param arg function argument
-		/// \return hyperbolic tangent value of \a arg
-//		template<typename T> typename enable<expr,T>::type tanh(T arg) { return functions::tanh(arg); }
-		inline expr tanh(half arg) { return functions::tanh(arg); }
-		inline expr tanh(expr arg) { return functions::tanh(arg); }
-
-		/// Hyperbolic area sine.
-		/// \param arg function argument
-		/// \return area sine value of \a arg
-//		template<typename T> typename enable<expr,T>::type asinh(T arg) { return functions::asinh(arg); }
-		inline expr asinh(half arg) { return functions::asinh(arg); }
-		inline expr asinh(expr arg) { return functions::asinh(arg); }
-
-		/// Hyperbolic area cosine.
-		/// \param arg function argument
-		/// \return area cosine value of \a arg
-//		template<typename T> typename enable<expr,T>::type acosh(T arg) { return functions::acosh(arg); }
-		inline expr acosh(half arg) { return functions::acosh(arg); }
-		inline expr acosh(expr arg) { return functions::acosh(arg); }
-
-		/// Hyperbolic area tangent.
-		/// \param arg function argument
-		/// \return area tangent value of \a arg
-//		template<typename T> typename enable<expr,T>::type atanh(T arg) { return functions::atanh(arg); }
-		inline expr atanh(half arg) { return functions::atanh(arg); }
-		inline expr atanh(expr arg) { return functions::atanh(arg); }
-
-		/// \}
-		/// \name Error and gamma functions
-		/// \{
-
-		/// Error function.
-		/// \param arg function argument
-		/// \return error function value of \a arg
-//		template<typename T> typename enable<expr,T>::type erf(T arg) { return functions::erf(arg); }
-		inline expr erf(half arg) { return functions::erf(arg); }
-		inline expr erf(expr arg) { return functions::erf(arg); }
-
-		/// Complementary error function.
-		/// \param arg function argument
-		/// \return 1 minus error function value of \a arg
-//		template<typename T> typename enable<expr,T>::type erfc(T arg) { return functions::erfc(arg); }
-		inline expr erfc(half arg) { return functions::erfc(arg); }
-		inline expr erfc(expr arg) { return functions::erfc(arg); }
-
-		/// Natural logarithm of gamma function.
-		/// \param arg function argument
-		/// \return natural logarith of gamma function for \a arg
-//		template<typename T> typename enable<expr,T>::type lgamma(T arg) { return functions::lgamma(arg); }
-		inline expr lgamma(half arg) { return functions::lgamma(arg); }
-		inline expr lgamma(expr arg) { return functions::lgamma(arg); }
-
-		/// Gamma function.
-		/// \param arg function argument
-		/// \return gamma function value of \a arg
-//		template<typename T> typename enable<expr,T>::type tgamma(T arg) { return functions::tgamma(arg); }
-		inline expr tgamma(half arg) { return functions::tgamma(arg); }
-		inline expr tgamma(expr arg) { return functions::tgamma(arg); }
-
-		/// \}
-		/// \name Rounding
-		/// \{
-
-		/// Nearest integer not less than half value.
-		/// \param arg half to round
-		/// \return nearest integer not less than \a arg
-//		template<typename T> typename enable<half,T>::type ceil(T arg) { return functions::ceil(arg); }
-		inline half ceil(half arg) { return functions::ceil(arg); }
-		inline half ceil(expr arg) { return functions::ceil(arg); }
-
-		/// Nearest integer not greater than half value.
-		/// \param arg half to round
-		/// \return nearest integer not greater than \a arg
-//		template<typename T> typename enable<half,T>::type floor(T arg) { return functions::floor(arg); }
-		inline half floor(half arg) { return functions::floor(arg); }
-		inline half floor(expr arg) { return functions::floor(arg); }
-
-		/// Nearest integer not greater in magnitude than half value.
-		/// \param arg half to round
-		/// \return nearest integer not greater in magnitude than \a arg
-//		template<typename T> typename enable<half,T>::type trunc(T arg) { return functions::trunc(arg); }
-		inline half trunc(half arg) { return functions::trunc(arg); }
-		inline half trunc(expr arg) { return functions::trunc(arg); }
-
-		/// Nearest integer.
-		/// \param arg half to round
-		/// \return nearest integer, rounded away from zero in half-way cases
-//		template<typename T> typename enable<half,T>::type round(T arg) { return functions::round(arg); }
-		inline half round(half arg) { return functions::round(arg); }
-		inline half round(expr arg) { return functions::round(arg); }
-
-		/// Nearest integer.
-		/// \param arg half to round
-		/// \return nearest integer, rounded away from zero in half-way cases
-//		template<typename T> typename enable<long,T>::type lround(T arg) { return functions::lround(arg); }
-		inline long lround(half arg) { return functions::lround(arg); }
-		inline long lround(expr arg) { return functions::lround(arg); }
-
-		/// Nearest integer using half's internal rounding mode.
-		/// \param arg half expression to round
-		/// \return nearest integer using default rounding mode
-//		template<typename T> typename enable<half,T>::type nearbyint(T arg) { return functions::nearbyint(arg); }
-		inline half nearbyint(half arg) { return functions::rint(arg); }
-		inline half nearbyint(expr arg) { return functions::rint(arg); }
-
-		/// Nearest integer using half's internal rounding mode.
-		/// \param arg half expression to round
-		/// \return nearest integer using default rounding mode
-//		template<typename T> typename enable<half,T>::type rint(T arg) { return functions::rint(arg); }
-		inline half rint(half arg) { return functions::rint(arg); }
-		inline half rint(expr arg) { return functions::rint(arg); }
-
-		/// Nearest integer using half's internal rounding mode.
-		/// \param arg half expression to round
-		/// \return nearest integer using default rounding mode
-//		template<typename T> typename enable<long,T>::type lrint(T arg) { return functions::lrint(arg); }
-		inline long lrint(half arg) { return functions::lrint(arg); }
-		inline long lrint(expr arg) { return functions::lrint(arg); }
-	#if HALF_ENABLE_CPP11_LONG_LONG
-		/// Nearest integer.
-		/// \param arg half to round
-		/// \return nearest integer, rounded away from zero in half-way cases
-//		template<typename T> typename enable<long long,T>::type llround(T arg) { return functions::llround(arg); }
-		inline long long llround(half arg) { return functions::llround(arg); }
-		inline long long llround(expr arg) { return functions::llround(arg); }
-
-		/// Nearest integer using half's internal rounding mode.
-		/// \param arg half expression to round
-		/// \return nearest integer using default rounding mode
-//		template<typename T> typename enable<long long,T>::type llrint(T arg) { return functions::llrint(arg); }
-		inline long long llrint(half arg) { return functions::llrint(arg); }
-		inline long long llrint(expr arg) { return functions::llrint(arg); }
-	#endif
-
-		/// \}
-		/// \name Floating point manipulation
-		/// \{
-
-		/// Decompress floating point number.
-		/// \param arg number to decompress
-		/// \param exp address to store exponent at
-		/// \return significant in range [0.5, 1)
-//		template<typename T> typename enable<half,T>::type frexp(T arg, int *exp) { return functions::frexp(arg, exp); }
-		inline half frexp(half arg, int *exp) { return functions::frexp(arg, exp); }
-		inline half frexp(expr arg, int *exp) { return functions::frexp(arg, exp); }
-
-		/// Multiply by power of two.
-		/// \param arg number to modify
-		/// \param exp power of two to multiply with
-		/// \return \a arg multplied by 2 raised to \a exp
-//		template<typename T> typename enable<half,T>::type ldexp(T arg, int exp) { return functions::scalbln(arg, exp); }
-		inline half ldexp(half arg, int exp) { return functions::scalbln(arg, exp); }
-		inline half ldexp(expr arg, int exp) { return functions::scalbln(arg, exp); }
-
-		/// Extract integer and fractional parts.
-		/// \param arg number to decompress
-		/// \param iptr address to store integer part at
-		/// \return fractional part
-//		template<typename T> typename enable<half,T>::type modf(T arg, half *iptr) { return functions::modf(arg, iptr); }
-		inline half modf(half arg, half *iptr) { return functions::modf(arg, iptr); }
-		inline half modf(expr arg, half *iptr) { return functions::modf(arg, iptr); }
-
-		/// Multiply by power of two.
-		/// \param arg number to modify
-		/// \param exp power of two to multiply with
-		/// \return \a arg multplied by 2 raised to \a exp
-//		template<typename T> typename enable<half,T>::type scalbn(T arg, int exp) { return functions::scalbln(arg, exp); }
-		inline half scalbn(half arg, int exp) { return functions::scalbln(arg, exp); }
-		inline half scalbn(expr arg, int exp) { return functions::scalbln(arg, exp); }
-
-		/// Multiply by power of two.
-		/// \param arg number to modify
-		/// \param exp power of two to multiply with
-		/// \return \a arg multplied by 2 raised to \a exp	
-//		template<typename T> typename enable<half,T>::type scalbln(T arg, long exp) { return functions::scalbln(arg, exp); }
-		inline half scalbln(half arg, long exp) { return functions::scalbln(arg, exp); }
-		inline half scalbln(expr arg, long exp) { return functions::scalbln(arg, exp); }
-
-		/// Extract exponent.
-		/// \param arg number to query
-		/// \return floating point exponent
-		/// \retval FP_ILOGB0 for zero
-		/// \retval FP_ILOGBNAN for NaN
-		/// \retval MAX_INT for infinity
-//		template<typename T> typename enable<int,T>::type ilogb(T arg) { return functions::ilogb(arg); }
-		inline int ilogb(half arg) { return functions::ilogb(arg); }
-		inline int ilogb(expr arg) { return functions::ilogb(arg); }
-
-		/// Extract exponent.
-		/// \param arg number to query
-		/// \return floating point exponent
-//		template<typename T> typename enable<half,T>::type logb(T arg) { return functions::logb(arg); }
-		inline half logb(half arg) { return functions::logb(arg); }
-		inline half logb(expr arg) { return functions::logb(arg); }
-
-		/// Next representable value.
-		/// \param from value to compute next representable value for
-		/// \param to direction towards which to compute next value
-		/// \return next representable value after \a from in direction towards \a to
-//		template<typename T,typename U> typename enable<half,T,U>::type nextafter(T from, U to) { return functions::nextafter(from, to); }
-		inline half nextafter(half from, half to) { return functions::nextafter(from, to); }
-		inline half nextafter(half from, expr to) { return functions::nextafter(from, to); }
-		inline half nextafter(expr from, half to) { return functions::nextafter(from, to); }
-		inline half nextafter(expr from, expr to) { return functions::nextafter(from, to); }
-
-		/// Next representable value.
-		/// \param from value to compute next representable value for
-		/// \param to direction towards which to compute next value
-		/// \return next representable value after \a from in direction towards \a to
-//		template<typename T> typename enable<half,T>::type nexttoward(T from, long double to) { return functions::nexttoward(from, to); }
-		inline half nexttoward(half from, long double to) { return functions::nexttoward(from, to); }
-		inline half nexttoward(expr from, long double to) { return functions::nexttoward(from, to); }
-
-		/// Take sign.
-		/// \param x value to change sign for
-		/// \param y value to take sign from
-		/// \return value equal to \a x in magnitude and to \a y in sign
-//		template<typename T,typename U> typename enable<half,T,U>::type copysign(T x, U y) { return functions::copysign(x, y); }
-		inline half copysign(half x, half y) { return functions::copysign(x, y); }
-		inline half copysign(half x, expr y) { return functions::copysign(x, y); }
-		inline half copysign(expr x, half y) { return functions::copysign(x, y); }
-		inline half copysign(expr x, expr y) { return functions::copysign(x, y); }
-
-		/// \}
-		/// \name Floating point classification
-		/// \{
-
-
-		/// Classify floating point value.
-		/// \param arg number to classify
-		/// \retval FP_ZERO for positive and negative zero
-		/// \retval FP_SUBNORMAL for subnormal numbers
-		/// \retval FP_INFINITY for positive and negative infinity
-		/// \retval FP_NAN for NaNs
-		/// \retval FP_NORMAL for all other (normal) values
-//		template<typename T> typename enable<int,T>::type fpclassify(T arg) { return functions::fpclassify(arg); }
-		inline int fpclassify(half arg) { return functions::fpclassify(arg); }
-		inline int fpclassify(expr arg) { return functions::fpclassify(arg); }
-
-		/// Check if finite number.
-		/// \param arg number to check
-		/// \retval true if neither infinity nor NaN
-		/// \retval false else
-//		template<typename T> typename enable<bool,T>::type isfinite(T arg) { return functions::isfinite(arg); }
-		inline bool isfinite(half arg) { return functions::isfinite(arg); }
-		inline bool isfinite(expr arg) { return functions::isfinite(arg); }
-
-		/// Check for infinity.
-		/// \param arg number to check
-		/// \retval true for positive or negative infinity
-		/// \retval false else
-//		template<typename T> typename enable<bool,T>::type isinf(T arg) { return functions::isinf(arg); }
-		inline bool isinf(half arg) { return functions::isinf(arg); }
-		inline bool isinf(expr arg) { return functions::isinf(arg); }
-
-		/// Check for NaN.
-		/// \param arg number to check
-		/// \retval true for NaNs
-		/// \retval false else
-//		template<typename T> typename enable<bool,T>::type isnan(T arg) { return functions::isnan(arg); }
-		inline bool isnan(half arg) { return functions::isnan(arg); }
-		inline bool isnan(expr arg) { return functions::isnan(arg); }
-
-		/// Check if normal number.
-		/// \param arg number to check
-		/// \retval true if normal number
-		/// \retval false if either subnormal, zero, infinity or NaN
-//		template<typename T> typename enable<bool,T>::type isnormal(T arg) { return functions::isnormal(arg); }
-		inline bool isnormal(half arg) { return functions::isnormal(arg); }
-		inline bool isnormal(expr arg) { return functions::isnormal(arg); }
-
-		/// Check sign.
-		/// \param arg number to check
-		/// \retval true for negative number
-		/// \retval false for positive number
-//		template<typename T> typename enable<bool,T>::type signbit(T arg) { return functions::signbit(arg); }
-		inline bool signbit(half arg) { return functions::signbit(arg); }
-		inline bool signbit(expr arg) { return functions::signbit(arg); }
-
-		/// \}
-		/// \name Comparison
-		/// \{
-
-		/// Comparison for greater than.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if \a x greater than \a y
-		/// \retval false else
-//		template<typename T,typename U> typename enable<bool,T,U>::type isgreater(T x, U y) { return functions::isgreater(x, y); }
-		inline bool isgreater(half x, half y) { return functions::isgreater(x, y); }
-		inline bool isgreater(half x, expr y) { return functions::isgreater(x, y); }
-		inline bool isgreater(expr x, half y) { return functions::isgreater(x, y); }
-		inline bool isgreater(expr x, expr y) { return functions::isgreater(x, y); }
-
-		/// Comparison for greater equal.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if \a x greater equal \a y
-		/// \retval false else
-//		template<typename T,typename U> typename enable<bool,T,U>::type isgreaterequal(T x, U y) { return functions::isgreaterequal(x, y); }
-		inline bool isgreaterequal(half x, half y) { return functions::isgreaterequal(x, y); }
-		inline bool isgreaterequal(half x, expr y) { return functions::isgreaterequal(x, y); }
-		inline bool isgreaterequal(expr x, half y) { return functions::isgreaterequal(x, y); }
-		inline bool isgreaterequal(expr x, expr y) { return functions::isgreaterequal(x, y); }
-
-		/// Comparison for less than.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if \a x less than \a y
-		/// \retval false else
-//		template<typename T,typename U> typename enable<bool,T,U>::type isless(T x, U y) { return functions::isless(x, y); }
-		inline bool isless(half x, half y) { return functions::isless(x, y); }
-		inline bool isless(half x, expr y) { return functions::isless(x, y); }
-		inline bool isless(expr x, half y) { return functions::isless(x, y); }
-		inline bool isless(expr x, expr y) { return functions::isless(x, y); }
-
-		/// Comparison for less equal.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if \a x less equal \a y
-		/// \retval false else
-//		template<typename T,typename U> typename enable<bool,T,U>::type islessequal(T x, U y) { return functions::islessequal(x, y); }
-		inline bool islessequal(half x, half y) { return functions::islessequal(x, y); }
-		inline bool islessequal(half x, expr y) { return functions::islessequal(x, y); }
-		inline bool islessequal(expr x, half y) { return functions::islessequal(x, y); }
-		inline bool islessequal(expr x, expr y) { return functions::islessequal(x, y); }
-
-		/// Comarison for less or greater.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if either less or greater
-		/// \retval false else
-//		template<typename T,typename U> typename enable<bool,T,U>::type islessgreater(T x, U y) { return functions::islessgreater(x, y); }
-		inline bool islessgreater(half x, half y) { return functions::islessgreater(x, y); }
-		inline bool islessgreater(half x, expr y) { return functions::islessgreater(x, y); }
-		inline bool islessgreater(expr x, half y) { return functions::islessgreater(x, y); }
-		inline bool islessgreater(expr x, expr y) { return functions::islessgreater(x, y); }
-
-		/// Check if unordered.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if unordered (one or two NaN operands)
-		/// \retval false else
-//		template<typename T,typename U> typename enable<bool,T,U>::type isunordered(T x, U y) { return functions::isunordered(x, y); }
-		inline bool isunordered(half x, half y) { return functions::isunordered(x, y); }
-		inline bool isunordered(half x, expr y) { return functions::isunordered(x, y); }
-		inline bool isunordered(expr x, half y) { return functions::isunordered(x, y); }
-		inline bool isunordered(expr x, expr y) { return functions::isunordered(x, y); }
-
-		/// \name Casting
-		/// \{
-
-		/// Cast to or from half-precision floating point number.
-		/// This casts between [half](\ref half_float::half) and any built-in arithmetic type. The values are converted 
-		/// directly using the given rounding mode, without any roundtrip over `float` that a `static_cast` would otherwise do. 
-		/// It uses the default rounding mode.
-		///
-		/// Using this cast with neither of the two types being a [half](\ref half_float::half) or with any of the two types 
-		/// not being a built-in arithmetic type (apart from [half](\ref half_float::half), of course) results in a compiler 
-		/// error and casting between [half](\ref half_float::half)s is just a no-op.
-		/// \tparam T destination type (half or built-in arithmetic type)
-		/// \tparam U source type (half or built-in arithmetic type)
-		/// \param arg value to cast
-		/// \return \a arg converted to destination type
-		template<typename T,typename U> T half_cast(U arg) { return half_caster<T,U>::cast(arg); }
-
-		/// Cast to or from half-precision floating point number.
-		/// This casts between [half](\ref half_float::half) and any built-in arithmetic type. The values are converted 
-		/// directly using the given rounding mode, without any roundtrip over `float` that a `static_cast` would otherwise do.
-		///
-		/// Using this cast with neither of the two types being a [half](\ref half_float::half) or with any of the two types 
-		/// not being a built-in arithmetic type (apart from [half](\ref half_float::half), of course) results in a compiler 
-		/// error and casting between [half](\ref half_float::half)s is just a no-op.
-		/// \tparam T destination type (half or built-in arithmetic type)
-		/// \tparam R rounding mode to use.
-		/// \tparam U source type (half or built-in arithmetic type)
-		/// \param arg value to cast
-		/// \return \a arg converted to destination type
-		template<typename T,std::float_round_style R,typename U> T half_cast(U arg) { return half_caster<T,U,R>::cast(arg); }
-		/// \}
-	}
-
-	using detail::operator==;
-	using detail::operator!=;
-	using detail::operator<;
-	using detail::operator>;
-	using detail::operator<=;
-	using detail::operator>=;
-	using detail::operator+;
-	using detail::operator-;
-	using detail::operator*;
-	using detail::operator/;
-	using detail::operator<<;
-	using detail::operator>>;
-
-	using detail::abs;
-	using detail::fabs;
-	using detail::fmod;
-	using detail::remainder;
-	using detail::remquo;
-	using detail::fma;
-	using detail::fmax;
-	using detail::fmin;
-	using detail::fdim;
-	using detail::nanh;
-	using detail::exp;
-	using detail::expm1;
-	using detail::exp2;
-	using detail::log;
-	using detail::log10;
-	using detail::log1p;
-	using detail::log2;
-	using detail::sqrt;
-	using detail::cbrt;
-	using detail::hypot;
-	using detail::pow;
-	using detail::sin;
-	using detail::cos;
-	using detail::tan;
-	using detail::asin;
-	using detail::acos;
-	using detail::atan;
-	using detail::atan2;
-	using detail::sinh;
-	using detail::cosh;
-	using detail::tanh;
-	using detail::asinh;
-	using detail::acosh;
-	using detail::atanh;
-	using detail::erf;
-	using detail::erfc;
-	using detail::lgamma;
-	using detail::tgamma;
-	using detail::ceil;
-	using detail::floor;
-	using detail::trunc;
-	using detail::round;
-	using detail::lround;
-	using detail::nearbyint;
-	using detail::rint;
-	using detail::lrint;
 #if HALF_ENABLE_CPP11_LONG_LONG
-	using detail::llround;
-	using detail::llrint;
+/// Unsigned integer of (at least) 64 bits width.
+template <>
+struct bits<double>
+    : conditional<std::numeric_limits<unsigned long>::digits >= 64,
+                  unsigned long, unsigned long long> {};
+#else
+/// Unsigned integer of (at least) 64 bits width.
+template <>
+struct bits<double> {
+  typedef unsigned long type;
+};
 #endif
-	using detail::frexp;
-	using detail::ldexp;
-	using detail::modf;
-	using detail::scalbn;
-	using detail::scalbln;
-	using detail::ilogb;
-	using detail::logb;
-	using detail::nextafter;
-	using detail::nexttoward;
-	using detail::copysign;
-	using detail::fpclassify;
-	using detail::isfinite;
-	using detail::isinf;
-	using detail::isnan;
-	using detail::isnormal;
-	using detail::signbit;
-	using detail::isgreater;
-	using detail::isgreaterequal;
-	using detail::isless;
-	using detail::islessequal;
-	using detail::islessgreater;
-	using detail::isunordered;
+#endif
 
-	using detail::half_cast;
+/// Tag type for binary construction.
+struct binary_t {};
+
+/// Tag for binary construction.
+HALF_CONSTEXPR_CONST binary_t binary = binary_t();
+
+/// Temporary half-precision expression.
+/// This class represents a half-precision expression which just stores a
+/// single-precision value internally.
+struct expr {
+  /// Conversion constructor.
+  /// \param f single-precision value to convert
+  explicit HALF_CONSTEXPR expr(float f) HALF_NOEXCEPT : value_(f) {}
+
+  /// Conversion to single-precision.
+  /// \return single precision value representing expression value
+  HALF_CONSTEXPR operator float() const HALF_NOEXCEPT { return value_; }
+
+ private:
+  /// Internal expression value stored in single-precision.
+  float value_;
+};
+
+/// SFINAE helper for generic half-precision functions.
+/// This class template has to be specialized for each valid combination of
+/// argument types to provide a corresponding `type` member equivalent to \a T.
+/// \tparam T type to return
+template <typename T, typename, typename = void, typename = void>
+struct enable {};
+template <typename T>
+struct enable<T, half, void, void> {
+  typedef T type;
+};
+template <typename T>
+struct enable<T, expr, void, void> {
+  typedef T type;
+};
+template <typename T>
+struct enable<T, half, half, void> {
+  typedef T type;
+};
+template <typename T>
+struct enable<T, half, expr, void> {
+  typedef T type;
+};
+template <typename T>
+struct enable<T, expr, half, void> {
+  typedef T type;
+};
+template <typename T>
+struct enable<T, expr, expr, void> {
+  typedef T type;
+};
+template <typename T>
+struct enable<T, half, half, half> {
+  typedef T type;
+};
+template <typename T>
+struct enable<T, half, half, expr> {
+  typedef T type;
+};
+template <typename T>
+struct enable<T, half, expr, half> {
+  typedef T type;
+};
+template <typename T>
+struct enable<T, half, expr, expr> {
+  typedef T type;
+};
+template <typename T>
+struct enable<T, expr, half, half> {
+  typedef T type;
+};
+template <typename T>
+struct enable<T, expr, half, expr> {
+  typedef T type;
+};
+template <typename T>
+struct enable<T, expr, expr, half> {
+  typedef T type;
+};
+template <typename T>
+struct enable<T, expr, expr, expr> {
+  typedef T type;
+};
+
+/// Return type for specialized generic 2-argument half-precision functions.
+/// This class template has to be specialized for each valid combination of
+/// argument types to provide a corresponding `type` member denoting the
+/// appropriate return type. \tparam T first argument type \tparam U first
+/// argument type
+template <typename T, typename U>
+struct result : enable<expr, T, U> {};
+template <>
+struct result<half, half> {
+  typedef half type;
+};
+
+/// \name Classification helpers
+/// \{
+
+/// Check for infinity.
+/// \tparam T argument type (builtin floating point type)
+/// \param arg value to query
+/// \retval true if infinity
+/// \retval false else
+template <typename T>
+bool builtin_isinf(T arg) {
+#if HALF_ENABLE_CPP11_CMATH
+  return std::isinf(arg);
+#elif defined(_MSC_VER)
+  return !::_finite(static_cast<double>(arg)) &&
+         !::_isnan(static_cast<double>(arg));
+#else
+  return arg == std::numeric_limits<T>::infinity() ||
+         arg == -std::numeric_limits<T>::infinity();
+#endif
 }
 
+/// Check for NaN.
+/// \tparam T argument type (builtin floating point type)
+/// \param arg value to query
+/// \retval true if not a number
+/// \retval false else
+template <typename T>
+bool builtin_isnan(T arg) {
+#if HALF_ENABLE_CPP11_CMATH
+  return std::isnan(arg);
+#elif defined(_MSC_VER)
+  return ::_isnan(static_cast<double>(arg)) != 0;
+#else
+  return arg != arg;
+#endif
+}
+
+/// Check sign.
+/// \tparam T argument type (builtin floating point type)
+/// \param arg value to query
+/// \retval true if signbit set
+/// \retval false else
+template <typename T>
+bool builtin_signbit(T arg) {
+#if HALF_ENABLE_CPP11_CMATH
+  return std::signbit(arg);
+#else
+  return arg < T() || (arg == T() && T(1) / arg < T());
+#endif
+}
+
+/// \}
+/// \name Conversion
+/// \{
+
+/// Convert IEEE single-precision to half-precision.
+/// Credit for this goes to [Jeroen van der
+/// Zijp](ftp://ftp.fox-toolkit.org/pub/fasthalffloatconversion.pdf). \tparam R
+/// rounding mode to use, `std::round_indeterminate` for fastest rounding \param
+/// value single-precision value \return binary representation of half-precision
+/// value
+template <std::float_round_style R>
+uint16 float2half_impl(float value, true_type) {
+  typedef bits<float>::type uint32;
+  uint32 bits;  // = *reinterpret_cast<uint32*>(&value);		//violating
+                // strict aliasing!
+  std::memcpy(&bits, &value, sizeof(float));
+  /*			uint16 hbits = (bits>>16) & 0x8000;
+                          bits &= 0x7FFFFFFF;
+                          int exp = bits >> 23;
+                          if(exp == 255)
+                                  return hbits | 0x7C00 |
+     (0x3FF&-static_cast<unsigned>((bits&0x7FFFFF)!=0)); if(exp > 142)
+                          {
+                                  if(R == std::round_toward_infinity)
+                                          return hbits | 0x7C00 - (hbits>>15);
+                                  if(R == std::round_toward_neg_infinity)
+                                          return hbits | 0x7BFF + (hbits>>15);
+                                  return hbits | 0x7BFF +
+     (R!=std::round_toward_zero);
+                          }
+                          int g, s;
+                          if(exp > 112)
+                          {
+                                  g = (bits>>12) & 1;
+                                  s = (bits&0xFFF) != 0;
+                                  hbits |= ((exp-112)<<10) | ((bits>>13)&0x3FF);
+                          }
+                          else if(exp > 101)
+                          {
+                                  int i = 125 - exp;
+                                  bits = (bits&0x7FFFFF) | 0x800000;
+                                  g = (bits>>i) & 1;
+                                  s = (bits&((1L<<i)-1)) != 0;
+                                  hbits |= bits >> (i+1);
+                          }
+                          else
+                          {
+                                  g = 0;
+                                  s = bits != 0;
+                          }
+                          if(R == std::round_to_nearest)
+                                  #if HALF_ROUND_TIES_TO_EVEN
+                                          hbits += g & (s|hbits);
+                                  #else
+                                          hbits += g;
+                                  #endif
+                          else if(R == std::round_toward_infinity)
+                                  hbits += ~(hbits>>15) & (s|g);
+                          else if(R == std::round_toward_neg_infinity)
+                                  hbits += (hbits>>15) & (g|s);
+  */
+  static const uint16 base_table[512] = {
+      0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+      0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+      0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+      0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+      0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+      0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+      0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+      0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+      0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+      0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+      0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+      0x0000, 0x0000, 0x0000, 0x0000, 0x0001, 0x0002, 0x0004, 0x0008, 0x0010,
+      0x0020, 0x0040, 0x0080, 0x0100, 0x0200, 0x0400, 0x0800, 0x0C00, 0x1000,
+      0x1400, 0x1800, 0x1C00, 0x2000, 0x2400, 0x2800, 0x2C00, 0x3000, 0x3400,
+      0x3800, 0x3C00, 0x4000, 0x4400, 0x4800, 0x4C00, 0x5000, 0x5400, 0x5800,
+      0x5C00, 0x6000, 0x6400, 0x6800, 0x6C00, 0x7000, 0x7400, 0x7800, 0x7C00,
+      0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+      0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+      0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+      0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+      0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+      0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+      0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+      0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+      0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+      0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+      0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+      0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+      0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+      0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+      0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+      0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+      0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+      0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+      0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+      0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+      0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+      0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+      0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+      0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8001,
+      0x8002, 0x8004, 0x8008, 0x8010, 0x8020, 0x8040, 0x8080, 0x8100, 0x8200,
+      0x8400, 0x8800, 0x8C00, 0x9000, 0x9400, 0x9800, 0x9C00, 0xA000, 0xA400,
+      0xA800, 0xAC00, 0xB000, 0xB400, 0xB800, 0xBC00, 0xC000, 0xC400, 0xC800,
+      0xCC00, 0xD000, 0xD400, 0xD800, 0xDC00, 0xE000, 0xE400, 0xE800, 0xEC00,
+      0xF000, 0xF400, 0xF800, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+      0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+      0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+      0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+      0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+      0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+      0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+      0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+      0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+      0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+      0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+      0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+      0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00};
+  static const unsigned char shift_table[512] = {
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 23, 22, 21, 20, 19,
+      18, 17, 16, 15, 14, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
+      13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 13, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 23,
+      22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 13, 13, 13, 13, 13, 13, 13, 13,
+      13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
+      13, 13, 13, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 13};
+  uint16 hbits =
+      base_table[bits >> 23] +
+      static_cast<uint16>((bits & 0x7FFFFF) >> shift_table[bits >> 23]);
+  if (R == std::round_to_nearest)
+    hbits +=
+        (((bits & 0x7FFFFF) >> (shift_table[bits >> 23] - 1)) |
+         (((bits >> 23) & 0xFF) == 102)) &
+        ((hbits & 0x7C00) != 0x7C00)
+#if HALF_ROUND_TIES_TO_EVEN
+        & (((((static_cast<uint32>(1) << (shift_table[bits >> 23] - 1)) - 1) &
+             bits) != 0) |
+           hbits)
+#endif
+        ;
+  else if (R == std::round_toward_zero)
+    hbits -= ((hbits & 0x7FFF) == 0x7C00) & ~shift_table[bits >> 23];
+  else if (R == std::round_toward_infinity)
+    hbits +=
+        ((((bits & 0x7FFFFF &
+            ((static_cast<uint32>(1) << (shift_table[bits >> 23])) - 1)) != 0) |
+          (((bits >> 23) <= 102) & ((bits >> 23) != 0))) &
+         (hbits < 0x7C00)) -
+        ((hbits == 0xFC00) & ((bits >> 23) != 511));
+  else if (R == std::round_toward_neg_infinity)
+    hbits +=
+        ((((bits & 0x7FFFFF &
+            ((static_cast<uint32>(1) << (shift_table[bits >> 23])) - 1)) != 0) |
+          (((bits >> 23) <= 358) & ((bits >> 23) != 256))) &
+         (hbits < 0xFC00) & (hbits >> 15)) -
+        ((hbits == 0x7C00) & ((bits >> 23) != 255));
+  return hbits;
+}
+
+/// Convert IEEE double-precision to half-precision.
+/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+/// rounding \param value double-precision value \return binary representation
+/// of half-precision value
+template <std::float_round_style R>
+uint16 float2half_impl(double value, true_type) {
+  typedef bits<float>::type uint32;
+  typedef bits<double>::type uint64;
+  uint64 bits;  // = *reinterpret_cast<uint64*>(&value);		//violating
+                // strict aliasing!
+  std::memcpy(&bits, &value, sizeof(double));
+  uint32 hi = bits >> 32, lo = bits & 0xFFFFFFFF;
+  uint16 hbits = (hi >> 16) & 0x8000;
+  hi &= 0x7FFFFFFF;
+  int exp = hi >> 20;
+  if (exp == 2047)
+    return hbits | 0x7C00 |
+           (0x3FF & -static_cast<unsigned>((bits & 0xFFFFFFFFFFFFF) != 0));
+  if (exp > 1038) {
+    if (R == std::round_toward_infinity) return hbits | 0x7C00 - (hbits >> 15);
+    if (R == std::round_toward_neg_infinity)
+      return hbits | 0x7BFF + (hbits >> 15);
+    return hbits | 0x7BFF + (R != std::round_toward_zero);
+  }
+  int g, s = lo != 0;
+  if (exp > 1008) {
+    g = (hi >> 9) & 1;
+    s |= (hi & 0x1FF) != 0;
+    hbits |= ((exp - 1008) << 10) | ((hi >> 10) & 0x3FF);
+  } else if (exp > 997) {
+    int i = 1018 - exp;
+    hi = (hi & 0xFFFFF) | 0x100000;
+    g = (hi >> i) & 1;
+    s |= (hi & ((1L << i) - 1)) != 0;
+    hbits |= hi >> (i + 1);
+  } else {
+    g = 0;
+    s |= hi != 0;
+  }
+  if (R == std::round_to_nearest)
+#if HALF_ROUND_TIES_TO_EVEN
+    hbits += g & (s | hbits);
+#else
+    hbits += g;
+#endif
+  else if (R == std::round_toward_infinity)
+    hbits += ~(hbits >> 15) & (s | g);
+  else if (R == std::round_toward_neg_infinity)
+    hbits += (hbits >> 15) & (g | s);
+  return hbits;
+}
+
+/// Convert non-IEEE floating point to half-precision.
+/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+/// rounding \tparam T source type (builtin floating point type) \param value
+/// floating point value \return binary representation of half-precision value
+template <std::float_round_style R, typename T>
+uint16 float2half_impl(T value, ...) {
+  uint16 hbits = static_cast<unsigned>(builtin_signbit(value)) << 15;
+  if (value == T()) return hbits;
+  if (builtin_isnan(value)) return hbits | 0x7FFF;
+  if (builtin_isinf(value)) return hbits | 0x7C00;
+  int exp;
+  std::frexp(value, &exp);
+  if (exp > 16) {
+    if (R == std::round_toward_infinity)
+      return hbits | (0x7C00 - (hbits >> 15));
+    else if (R == std::round_toward_neg_infinity)
+      return hbits | (0x7BFF + (hbits >> 15));
+    return hbits | (0x7BFF + (R != std::round_toward_zero));
+  }
+  if (exp < -13)
+    value = std::ldexp(value, 24);
+  else {
+    value = std::ldexp(value, 11 - exp);
+    hbits |= ((exp + 13) << 10);
+  }
+  T ival, frac = std::modf(value, &ival);
+  hbits += static_cast<uint16>(std::abs(static_cast<int>(ival)));
+  if (R == std::round_to_nearest) {
+    frac = std::abs(frac);
+#if HALF_ROUND_TIES_TO_EVEN
+    hbits += (frac > T(0.5)) | ((frac == T(0.5)) & hbits);
+#else
+    hbits += frac >= T(0.5);
+#endif
+  } else if (R == std::round_toward_infinity)
+    hbits += frac > T();
+  else if (R == std::round_toward_neg_infinity)
+    hbits += frac < T();
+  return hbits;
+}
+
+/// Convert floating point to half-precision.
+/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+/// rounding \tparam T source type (builtin floating point type) \param value
+/// floating point value \return binary representation of half-precision value
+template <std::float_round_style R, typename T>
+uint16 float2half(T value) {
+  return float2half_impl<R>(
+      value, bool_type < std::numeric_limits<T>::is_iec559 &&
+                 sizeof(typename bits<T>::type) == sizeof(T) > ());
+}
+
+/// Convert integer to half-precision floating point.
+/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+/// rounding \tparam S `true` if value negative, `false` else \tparam T type to
+/// convert (builtin integer type) \param value non-negative integral value
+/// \return binary representation of half-precision value
+template <std::float_round_style R, bool S, typename T>
+uint16 int2half_impl(T value) {
+#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
+  static_assert(std::is_integral<T>::value,
+                "int to half conversion only supports builtin integer types");
+#endif
+  if (S) value = -value;
+  uint16 bits = S << 15;
+  if (value > 0xFFFF) {
+    if (R == std::round_toward_infinity)
+      bits |= 0x7C00 - S;
+    else if (R == std::round_toward_neg_infinity)
+      bits |= 0x7BFF + S;
+    else
+      bits |= 0x7BFF + (R != std::round_toward_zero);
+  } else if (value) {
+    unsigned int m = value, exp = 24;
+    for (; m < 0x400; m <<= 1, --exp)
+      ;
+    for (; m > 0x7FF; m >>= 1, ++exp)
+      ;
+    bits |= (exp << 10) + m;
+    if (exp > 24) {
+      if (R == std::round_to_nearest)
+        bits += (value >> (exp - 25)) & 1
+#if HALF_ROUND_TIES_TO_EVEN
+                & (((((1 << (exp - 25)) - 1) & value) != 0) | bits)
+#endif
+            ;
+      else if (R == std::round_toward_infinity)
+        bits += ((value & ((1 << (exp - 24)) - 1)) != 0) & !S;
+      else if (R == std::round_toward_neg_infinity)
+        bits += ((value & ((1 << (exp - 24)) - 1)) != 0) & S;
+    }
+  }
+  return bits;
+}
+
+/// Convert integer to half-precision floating point.
+/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+/// rounding \tparam T type to convert (builtin integer type) \param value
+/// integral value \return binary representation of half-precision value
+template <std::float_round_style R, typename T>
+uint16 int2half(T value) {
+  return (value < 0) ? int2half_impl<R, true>(value)
+                     : int2half_impl<R, false>(value);
+}
+
+/// Convert half-precision to IEEE single-precision.
+/// Credit for this goes to [Jeroen van der
+/// Zijp](ftp://ftp.fox-toolkit.org/pub/fasthalffloatconversion.pdf). \param
+/// value binary representation of half-precision value \return single-precision
+/// value
+inline float half2float_impl(uint16 value, float, true_type) {
+  typedef bits<float>::type uint32;
+  /*			uint32 bits = static_cast<uint32>(value&0x8000) << 16;
+                          int abs = value & 0x7FFF;
+                          if(abs)
+                          {
+                                  bits |= 0x38000000 <<
+     static_cast<unsigned>(abs>=0x7C00); for(; abs<0x400;
+     abs<<=1,bits-=0x800000) ; bits += static_cast<uint32>(abs) << 13;
+                          }
+  */
+  static const uint32 mantissa_table[2048] = {
+      0x00000000, 0x33800000, 0x34000000, 0x34400000, 0x34800000, 0x34A00000,
+      0x34C00000, 0x34E00000, 0x35000000, 0x35100000, 0x35200000, 0x35300000,
+      0x35400000, 0x35500000, 0x35600000, 0x35700000, 0x35800000, 0x35880000,
+      0x35900000, 0x35980000, 0x35A00000, 0x35A80000, 0x35B00000, 0x35B80000,
+      0x35C00000, 0x35C80000, 0x35D00000, 0x35D80000, 0x35E00000, 0x35E80000,
+      0x35F00000, 0x35F80000, 0x36000000, 0x36040000, 0x36080000, 0x360C0000,
+      0x36100000, 0x36140000, 0x36180000, 0x361C0000, 0x36200000, 0x36240000,
+      0x36280000, 0x362C0000, 0x36300000, 0x36340000, 0x36380000, 0x363C0000,
+      0x36400000, 0x36440000, 0x36480000, 0x364C0000, 0x36500000, 0x36540000,
+      0x36580000, 0x365C0000, 0x36600000, 0x36640000, 0x36680000, 0x366C0000,
+      0x36700000, 0x36740000, 0x36780000, 0x367C0000, 0x36800000, 0x36820000,
+      0x36840000, 0x36860000, 0x36880000, 0x368A0000, 0x368C0000, 0x368E0000,
+      0x36900000, 0x36920000, 0x36940000, 0x36960000, 0x36980000, 0x369A0000,
+      0x369C0000, 0x369E0000, 0x36A00000, 0x36A20000, 0x36A40000, 0x36A60000,
+      0x36A80000, 0x36AA0000, 0x36AC0000, 0x36AE0000, 0x36B00000, 0x36B20000,
+      0x36B40000, 0x36B60000, 0x36B80000, 0x36BA0000, 0x36BC0000, 0x36BE0000,
+      0x36C00000, 0x36C20000, 0x36C40000, 0x36C60000, 0x36C80000, 0x36CA0000,
+      0x36CC0000, 0x36CE0000, 0x36D00000, 0x36D20000, 0x36D40000, 0x36D60000,
+      0x36D80000, 0x36DA0000, 0x36DC0000, 0x36DE0000, 0x36E00000, 0x36E20000,
+      0x36E40000, 0x36E60000, 0x36E80000, 0x36EA0000, 0x36EC0000, 0x36EE0000,
+      0x36F00000, 0x36F20000, 0x36F40000, 0x36F60000, 0x36F80000, 0x36FA0000,
+      0x36FC0000, 0x36FE0000, 0x37000000, 0x37010000, 0x37020000, 0x37030000,
+      0x37040000, 0x37050000, 0x37060000, 0x37070000, 0x37080000, 0x37090000,
+      0x370A0000, 0x370B0000, 0x370C0000, 0x370D0000, 0x370E0000, 0x370F0000,
+      0x37100000, 0x37110000, 0x37120000, 0x37130000, 0x37140000, 0x37150000,
+      0x37160000, 0x37170000, 0x37180000, 0x37190000, 0x371A0000, 0x371B0000,
+      0x371C0000, 0x371D0000, 0x371E0000, 0x371F0000, 0x37200000, 0x37210000,
+      0x37220000, 0x37230000, 0x37240000, 0x37250000, 0x37260000, 0x37270000,
+      0x37280000, 0x37290000, 0x372A0000, 0x372B0000, 0x372C0000, 0x372D0000,
+      0x372E0000, 0x372F0000, 0x37300000, 0x37310000, 0x37320000, 0x37330000,
+      0x37340000, 0x37350000, 0x37360000, 0x37370000, 0x37380000, 0x37390000,
+      0x373A0000, 0x373B0000, 0x373C0000, 0x373D0000, 0x373E0000, 0x373F0000,
+      0x37400000, 0x37410000, 0x37420000, 0x37430000, 0x37440000, 0x37450000,
+      0x37460000, 0x37470000, 0x37480000, 0x37490000, 0x374A0000, 0x374B0000,
+      0x374C0000, 0x374D0000, 0x374E0000, 0x374F0000, 0x37500000, 0x37510000,
+      0x37520000, 0x37530000, 0x37540000, 0x37550000, 0x37560000, 0x37570000,
+      0x37580000, 0x37590000, 0x375A0000, 0x375B0000, 0x375C0000, 0x375D0000,
+      0x375E0000, 0x375F0000, 0x37600000, 0x37610000, 0x37620000, 0x37630000,
+      0x37640000, 0x37650000, 0x37660000, 0x37670000, 0x37680000, 0x37690000,
+      0x376A0000, 0x376B0000, 0x376C0000, 0x376D0000, 0x376E0000, 0x376F0000,
+      0x37700000, 0x37710000, 0x37720000, 0x37730000, 0x37740000, 0x37750000,
+      0x37760000, 0x37770000, 0x37780000, 0x37790000, 0x377A0000, 0x377B0000,
+      0x377C0000, 0x377D0000, 0x377E0000, 0x377F0000, 0x37800000, 0x37808000,
+      0x37810000, 0x37818000, 0x37820000, 0x37828000, 0x37830000, 0x37838000,
+      0x37840000, 0x37848000, 0x37850000, 0x37858000, 0x37860000, 0x37868000,
+      0x37870000, 0x37878000, 0x37880000, 0x37888000, 0x37890000, 0x37898000,
+      0x378A0000, 0x378A8000, 0x378B0000, 0x378B8000, 0x378C0000, 0x378C8000,
+      0x378D0000, 0x378D8000, 0x378E0000, 0x378E8000, 0x378F0000, 0x378F8000,
+      0x37900000, 0x37908000, 0x37910000, 0x37918000, 0x37920000, 0x37928000,
+      0x37930000, 0x37938000, 0x37940000, 0x37948000, 0x37950000, 0x37958000,
+      0x37960000, 0x37968000, 0x37970000, 0x37978000, 0x37980000, 0x37988000,
+      0x37990000, 0x37998000, 0x379A0000, 0x379A8000, 0x379B0000, 0x379B8000,
+      0x379C0000, 0x379C8000, 0x379D0000, 0x379D8000, 0x379E0000, 0x379E8000,
+      0x379F0000, 0x379F8000, 0x37A00000, 0x37A08000, 0x37A10000, 0x37A18000,
+      0x37A20000, 0x37A28000, 0x37A30000, 0x37A38000, 0x37A40000, 0x37A48000,
+      0x37A50000, 0x37A58000, 0x37A60000, 0x37A68000, 0x37A70000, 0x37A78000,
+      0x37A80000, 0x37A88000, 0x37A90000, 0x37A98000, 0x37AA0000, 0x37AA8000,
+      0x37AB0000, 0x37AB8000, 0x37AC0000, 0x37AC8000, 0x37AD0000, 0x37AD8000,
+      0x37AE0000, 0x37AE8000, 0x37AF0000, 0x37AF8000, 0x37B00000, 0x37B08000,
+      0x37B10000, 0x37B18000, 0x37B20000, 0x37B28000, 0x37B30000, 0x37B38000,
+      0x37B40000, 0x37B48000, 0x37B50000, 0x37B58000, 0x37B60000, 0x37B68000,
+      0x37B70000, 0x37B78000, 0x37B80000, 0x37B88000, 0x37B90000, 0x37B98000,
+      0x37BA0000, 0x37BA8000, 0x37BB0000, 0x37BB8000, 0x37BC0000, 0x37BC8000,
+      0x37BD0000, 0x37BD8000, 0x37BE0000, 0x37BE8000, 0x37BF0000, 0x37BF8000,
+      0x37C00000, 0x37C08000, 0x37C10000, 0x37C18000, 0x37C20000, 0x37C28000,
+      0x37C30000, 0x37C38000, 0x37C40000, 0x37C48000, 0x37C50000, 0x37C58000,
+      0x37C60000, 0x37C68000, 0x37C70000, 0x37C78000, 0x37C80000, 0x37C88000,
+      0x37C90000, 0x37C98000, 0x37CA0000, 0x37CA8000, 0x37CB0000, 0x37CB8000,
+      0x37CC0000, 0x37CC8000, 0x37CD0000, 0x37CD8000, 0x37CE0000, 0x37CE8000,
+      0x37CF0000, 0x37CF8000, 0x37D00000, 0x37D08000, 0x37D10000, 0x37D18000,
+      0x37D20000, 0x37D28000, 0x37D30000, 0x37D38000, 0x37D40000, 0x37D48000,
+      0x37D50000, 0x37D58000, 0x37D60000, 0x37D68000, 0x37D70000, 0x37D78000,
+      0x37D80000, 0x37D88000, 0x37D90000, 0x37D98000, 0x37DA0000, 0x37DA8000,
+      0x37DB0000, 0x37DB8000, 0x37DC0000, 0x37DC8000, 0x37DD0000, 0x37DD8000,
+      0x37DE0000, 0x37DE8000, 0x37DF0000, 0x37DF8000, 0x37E00000, 0x37E08000,
+      0x37E10000, 0x37E18000, 0x37E20000, 0x37E28000, 0x37E30000, 0x37E38000,
+      0x37E40000, 0x37E48000, 0x37E50000, 0x37E58000, 0x37E60000, 0x37E68000,
+      0x37E70000, 0x37E78000, 0x37E80000, 0x37E88000, 0x37E90000, 0x37E98000,
+      0x37EA0000, 0x37EA8000, 0x37EB0000, 0x37EB8000, 0x37EC0000, 0x37EC8000,
+      0x37ED0000, 0x37ED8000, 0x37EE0000, 0x37EE8000, 0x37EF0000, 0x37EF8000,
+      0x37F00000, 0x37F08000, 0x37F10000, 0x37F18000, 0x37F20000, 0x37F28000,
+      0x37F30000, 0x37F38000, 0x37F40000, 0x37F48000, 0x37F50000, 0x37F58000,
+      0x37F60000, 0x37F68000, 0x37F70000, 0x37F78000, 0x37F80000, 0x37F88000,
+      0x37F90000, 0x37F98000, 0x37FA0000, 0x37FA8000, 0x37FB0000, 0x37FB8000,
+      0x37FC0000, 0x37FC8000, 0x37FD0000, 0x37FD8000, 0x37FE0000, 0x37FE8000,
+      0x37FF0000, 0x37FF8000, 0x38000000, 0x38004000, 0x38008000, 0x3800C000,
+      0x38010000, 0x38014000, 0x38018000, 0x3801C000, 0x38020000, 0x38024000,
+      0x38028000, 0x3802C000, 0x38030000, 0x38034000, 0x38038000, 0x3803C000,
+      0x38040000, 0x38044000, 0x38048000, 0x3804C000, 0x38050000, 0x38054000,
+      0x38058000, 0x3805C000, 0x38060000, 0x38064000, 0x38068000, 0x3806C000,
+      0x38070000, 0x38074000, 0x38078000, 0x3807C000, 0x38080000, 0x38084000,
+      0x38088000, 0x3808C000, 0x38090000, 0x38094000, 0x38098000, 0x3809C000,
+      0x380A0000, 0x380A4000, 0x380A8000, 0x380AC000, 0x380B0000, 0x380B4000,
+      0x380B8000, 0x380BC000, 0x380C0000, 0x380C4000, 0x380C8000, 0x380CC000,
+      0x380D0000, 0x380D4000, 0x380D8000, 0x380DC000, 0x380E0000, 0x380E4000,
+      0x380E8000, 0x380EC000, 0x380F0000, 0x380F4000, 0x380F8000, 0x380FC000,
+      0x38100000, 0x38104000, 0x38108000, 0x3810C000, 0x38110000, 0x38114000,
+      0x38118000, 0x3811C000, 0x38120000, 0x38124000, 0x38128000, 0x3812C000,
+      0x38130000, 0x38134000, 0x38138000, 0x3813C000, 0x38140000, 0x38144000,
+      0x38148000, 0x3814C000, 0x38150000, 0x38154000, 0x38158000, 0x3815C000,
+      0x38160000, 0x38164000, 0x38168000, 0x3816C000, 0x38170000, 0x38174000,
+      0x38178000, 0x3817C000, 0x38180000, 0x38184000, 0x38188000, 0x3818C000,
+      0x38190000, 0x38194000, 0x38198000, 0x3819C000, 0x381A0000, 0x381A4000,
+      0x381A8000, 0x381AC000, 0x381B0000, 0x381B4000, 0x381B8000, 0x381BC000,
+      0x381C0000, 0x381C4000, 0x381C8000, 0x381CC000, 0x381D0000, 0x381D4000,
+      0x381D8000, 0x381DC000, 0x381E0000, 0x381E4000, 0x381E8000, 0x381EC000,
+      0x381F0000, 0x381F4000, 0x381F8000, 0x381FC000, 0x38200000, 0x38204000,
+      0x38208000, 0x3820C000, 0x38210000, 0x38214000, 0x38218000, 0x3821C000,
+      0x38220000, 0x38224000, 0x38228000, 0x3822C000, 0x38230000, 0x38234000,
+      0x38238000, 0x3823C000, 0x38240000, 0x38244000, 0x38248000, 0x3824C000,
+      0x38250000, 0x38254000, 0x38258000, 0x3825C000, 0x38260000, 0x38264000,
+      0x38268000, 0x3826C000, 0x38270000, 0x38274000, 0x38278000, 0x3827C000,
+      0x38280000, 0x38284000, 0x38288000, 0x3828C000, 0x38290000, 0x38294000,
+      0x38298000, 0x3829C000, 0x382A0000, 0x382A4000, 0x382A8000, 0x382AC000,
+      0x382B0000, 0x382B4000, 0x382B8000, 0x382BC000, 0x382C0000, 0x382C4000,
+      0x382C8000, 0x382CC000, 0x382D0000, 0x382D4000, 0x382D8000, 0x382DC000,
+      0x382E0000, 0x382E4000, 0x382E8000, 0x382EC000, 0x382F0000, 0x382F4000,
+      0x382F8000, 0x382FC000, 0x38300000, 0x38304000, 0x38308000, 0x3830C000,
+      0x38310000, 0x38314000, 0x38318000, 0x3831C000, 0x38320000, 0x38324000,
+      0x38328000, 0x3832C000, 0x38330000, 0x38334000, 0x38338000, 0x3833C000,
+      0x38340000, 0x38344000, 0x38348000, 0x3834C000, 0x38350000, 0x38354000,
+      0x38358000, 0x3835C000, 0x38360000, 0x38364000, 0x38368000, 0x3836C000,
+      0x38370000, 0x38374000, 0x38378000, 0x3837C000, 0x38380000, 0x38384000,
+      0x38388000, 0x3838C000, 0x38390000, 0x38394000, 0x38398000, 0x3839C000,
+      0x383A0000, 0x383A4000, 0x383A8000, 0x383AC000, 0x383B0000, 0x383B4000,
+      0x383B8000, 0x383BC000, 0x383C0000, 0x383C4000, 0x383C8000, 0x383CC000,
+      0x383D0000, 0x383D4000, 0x383D8000, 0x383DC000, 0x383E0000, 0x383E4000,
+      0x383E8000, 0x383EC000, 0x383F0000, 0x383F4000, 0x383F8000, 0x383FC000,
+      0x38400000, 0x38404000, 0x38408000, 0x3840C000, 0x38410000, 0x38414000,
+      0x38418000, 0x3841C000, 0x38420000, 0x38424000, 0x38428000, 0x3842C000,
+      0x38430000, 0x38434000, 0x38438000, 0x3843C000, 0x38440000, 0x38444000,
+      0x38448000, 0x3844C000, 0x38450000, 0x38454000, 0x38458000, 0x3845C000,
+      0x38460000, 0x38464000, 0x38468000, 0x3846C000, 0x38470000, 0x38474000,
+      0x38478000, 0x3847C000, 0x38480000, 0x38484000, 0x38488000, 0x3848C000,
+      0x38490000, 0x38494000, 0x38498000, 0x3849C000, 0x384A0000, 0x384A4000,
+      0x384A8000, 0x384AC000, 0x384B0000, 0x384B4000, 0x384B8000, 0x384BC000,
+      0x384C0000, 0x384C4000, 0x384C8000, 0x384CC000, 0x384D0000, 0x384D4000,
+      0x384D8000, 0x384DC000, 0x384E0000, 0x384E4000, 0x384E8000, 0x384EC000,
+      0x384F0000, 0x384F4000, 0x384F8000, 0x384FC000, 0x38500000, 0x38504000,
+      0x38508000, 0x3850C000, 0x38510000, 0x38514000, 0x38518000, 0x3851C000,
+      0x38520000, 0x38524000, 0x38528000, 0x3852C000, 0x38530000, 0x38534000,
+      0x38538000, 0x3853C000, 0x38540000, 0x38544000, 0x38548000, 0x3854C000,
+      0x38550000, 0x38554000, 0x38558000, 0x3855C000, 0x38560000, 0x38564000,
+      0x38568000, 0x3856C000, 0x38570000, 0x38574000, 0x38578000, 0x3857C000,
+      0x38580000, 0x38584000, 0x38588000, 0x3858C000, 0x38590000, 0x38594000,
+      0x38598000, 0x3859C000, 0x385A0000, 0x385A4000, 0x385A8000, 0x385AC000,
+      0x385B0000, 0x385B4000, 0x385B8000, 0x385BC000, 0x385C0000, 0x385C4000,
+      0x385C8000, 0x385CC000, 0x385D0000, 0x385D4000, 0x385D8000, 0x385DC000,
+      0x385E0000, 0x385E4000, 0x385E8000, 0x385EC000, 0x385F0000, 0x385F4000,
+      0x385F8000, 0x385FC000, 0x38600000, 0x38604000, 0x38608000, 0x3860C000,
+      0x38610000, 0x38614000, 0x38618000, 0x3861C000, 0x38620000, 0x38624000,
+      0x38628000, 0x3862C000, 0x38630000, 0x38634000, 0x38638000, 0x3863C000,
+      0x38640000, 0x38644000, 0x38648000, 0x3864C000, 0x38650000, 0x38654000,
+      0x38658000, 0x3865C000, 0x38660000, 0x38664000, 0x38668000, 0x3866C000,
+      0x38670000, 0x38674000, 0x38678000, 0x3867C000, 0x38680000, 0x38684000,
+      0x38688000, 0x3868C000, 0x38690000, 0x38694000, 0x38698000, 0x3869C000,
+      0x386A0000, 0x386A4000, 0x386A8000, 0x386AC000, 0x386B0000, 0x386B4000,
+      0x386B8000, 0x386BC000, 0x386C0000, 0x386C4000, 0x386C8000, 0x386CC000,
+      0x386D0000, 0x386D4000, 0x386D8000, 0x386DC000, 0x386E0000, 0x386E4000,
+      0x386E8000, 0x386EC000, 0x386F0000, 0x386F4000, 0x386F8000, 0x386FC000,
+      0x38700000, 0x38704000, 0x38708000, 0x3870C000, 0x38710000, 0x38714000,
+      0x38718000, 0x3871C000, 0x38720000, 0x38724000, 0x38728000, 0x3872C000,
+      0x38730000, 0x38734000, 0x38738000, 0x3873C000, 0x38740000, 0x38744000,
+      0x38748000, 0x3874C000, 0x38750000, 0x38754000, 0x38758000, 0x3875C000,
+      0x38760000, 0x38764000, 0x38768000, 0x3876C000, 0x38770000, 0x38774000,
+      0x38778000, 0x3877C000, 0x38780000, 0x38784000, 0x38788000, 0x3878C000,
+      0x38790000, 0x38794000, 0x38798000, 0x3879C000, 0x387A0000, 0x387A4000,
+      0x387A8000, 0x387AC000, 0x387B0000, 0x387B4000, 0x387B8000, 0x387BC000,
+      0x387C0000, 0x387C4000, 0x387C8000, 0x387CC000, 0x387D0000, 0x387D4000,
+      0x387D8000, 0x387DC000, 0x387E0000, 0x387E4000, 0x387E8000, 0x387EC000,
+      0x387F0000, 0x387F4000, 0x387F8000, 0x387FC000, 0x38000000, 0x38002000,
+      0x38004000, 0x38006000, 0x38008000, 0x3800A000, 0x3800C000, 0x3800E000,
+      0x38010000, 0x38012000, 0x38014000, 0x38016000, 0x38018000, 0x3801A000,
+      0x3801C000, 0x3801E000, 0x38020000, 0x38022000, 0x38024000, 0x38026000,
+      0x38028000, 0x3802A000, 0x3802C000, 0x3802E000, 0x38030000, 0x38032000,
+      0x38034000, 0x38036000, 0x38038000, 0x3803A000, 0x3803C000, 0x3803E000,
+      0x38040000, 0x38042000, 0x38044000, 0x38046000, 0x38048000, 0x3804A000,
+      0x3804C000, 0x3804E000, 0x38050000, 0x38052000, 0x38054000, 0x38056000,
+      0x38058000, 0x3805A000, 0x3805C000, 0x3805E000, 0x38060000, 0x38062000,
+      0x38064000, 0x38066000, 0x38068000, 0x3806A000, 0x3806C000, 0x3806E000,
+      0x38070000, 0x38072000, 0x38074000, 0x38076000, 0x38078000, 0x3807A000,
+      0x3807C000, 0x3807E000, 0x38080000, 0x38082000, 0x38084000, 0x38086000,
+      0x38088000, 0x3808A000, 0x3808C000, 0x3808E000, 0x38090000, 0x38092000,
+      0x38094000, 0x38096000, 0x38098000, 0x3809A000, 0x3809C000, 0x3809E000,
+      0x380A0000, 0x380A2000, 0x380A4000, 0x380A6000, 0x380A8000, 0x380AA000,
+      0x380AC000, 0x380AE000, 0x380B0000, 0x380B2000, 0x380B4000, 0x380B6000,
+      0x380B8000, 0x380BA000, 0x380BC000, 0x380BE000, 0x380C0000, 0x380C2000,
+      0x380C4000, 0x380C6000, 0x380C8000, 0x380CA000, 0x380CC000, 0x380CE000,
+      0x380D0000, 0x380D2000, 0x380D4000, 0x380D6000, 0x380D8000, 0x380DA000,
+      0x380DC000, 0x380DE000, 0x380E0000, 0x380E2000, 0x380E4000, 0x380E6000,
+      0x380E8000, 0x380EA000, 0x380EC000, 0x380EE000, 0x380F0000, 0x380F2000,
+      0x380F4000, 0x380F6000, 0x380F8000, 0x380FA000, 0x380FC000, 0x380FE000,
+      0x38100000, 0x38102000, 0x38104000, 0x38106000, 0x38108000, 0x3810A000,
+      0x3810C000, 0x3810E000, 0x38110000, 0x38112000, 0x38114000, 0x38116000,
+      0x38118000, 0x3811A000, 0x3811C000, 0x3811E000, 0x38120000, 0x38122000,
+      0x38124000, 0x38126000, 0x38128000, 0x3812A000, 0x3812C000, 0x3812E000,
+      0x38130000, 0x38132000, 0x38134000, 0x38136000, 0x38138000, 0x3813A000,
+      0x3813C000, 0x3813E000, 0x38140000, 0x38142000, 0x38144000, 0x38146000,
+      0x38148000, 0x3814A000, 0x3814C000, 0x3814E000, 0x38150000, 0x38152000,
+      0x38154000, 0x38156000, 0x38158000, 0x3815A000, 0x3815C000, 0x3815E000,
+      0x38160000, 0x38162000, 0x38164000, 0x38166000, 0x38168000, 0x3816A000,
+      0x3816C000, 0x3816E000, 0x38170000, 0x38172000, 0x38174000, 0x38176000,
+      0x38178000, 0x3817A000, 0x3817C000, 0x3817E000, 0x38180000, 0x38182000,
+      0x38184000, 0x38186000, 0x38188000, 0x3818A000, 0x3818C000, 0x3818E000,
+      0x38190000, 0x38192000, 0x38194000, 0x38196000, 0x38198000, 0x3819A000,
+      0x3819C000, 0x3819E000, 0x381A0000, 0x381A2000, 0x381A4000, 0x381A6000,
+      0x381A8000, 0x381AA000, 0x381AC000, 0x381AE000, 0x381B0000, 0x381B2000,
+      0x381B4000, 0x381B6000, 0x381B8000, 0x381BA000, 0x381BC000, 0x381BE000,
+      0x381C0000, 0x381C2000, 0x381C4000, 0x381C6000, 0x381C8000, 0x381CA000,
+      0x381CC000, 0x381CE000, 0x381D0000, 0x381D2000, 0x381D4000, 0x381D6000,
+      0x381D8000, 0x381DA000, 0x381DC000, 0x381DE000, 0x381E0000, 0x381E2000,
+      0x381E4000, 0x381E6000, 0x381E8000, 0x381EA000, 0x381EC000, 0x381EE000,
+      0x381F0000, 0x381F2000, 0x381F4000, 0x381F6000, 0x381F8000, 0x381FA000,
+      0x381FC000, 0x381FE000, 0x38200000, 0x38202000, 0x38204000, 0x38206000,
+      0x38208000, 0x3820A000, 0x3820C000, 0x3820E000, 0x38210000, 0x38212000,
+      0x38214000, 0x38216000, 0x38218000, 0x3821A000, 0x3821C000, 0x3821E000,
+      0x38220000, 0x38222000, 0x38224000, 0x38226000, 0x38228000, 0x3822A000,
+      0x3822C000, 0x3822E000, 0x38230000, 0x38232000, 0x38234000, 0x38236000,
+      0x38238000, 0x3823A000, 0x3823C000, 0x3823E000, 0x38240000, 0x38242000,
+      0x38244000, 0x38246000, 0x38248000, 0x3824A000, 0x3824C000, 0x3824E000,
+      0x38250000, 0x38252000, 0x38254000, 0x38256000, 0x38258000, 0x3825A000,
+      0x3825C000, 0x3825E000, 0x38260000, 0x38262000, 0x38264000, 0x38266000,
+      0x38268000, 0x3826A000, 0x3826C000, 0x3826E000, 0x38270000, 0x38272000,
+      0x38274000, 0x38276000, 0x38278000, 0x3827A000, 0x3827C000, 0x3827E000,
+      0x38280000, 0x38282000, 0x38284000, 0x38286000, 0x38288000, 0x3828A000,
+      0x3828C000, 0x3828E000, 0x38290000, 0x38292000, 0x38294000, 0x38296000,
+      0x38298000, 0x3829A000, 0x3829C000, 0x3829E000, 0x382A0000, 0x382A2000,
+      0x382A4000, 0x382A6000, 0x382A8000, 0x382AA000, 0x382AC000, 0x382AE000,
+      0x382B0000, 0x382B2000, 0x382B4000, 0x382B6000, 0x382B8000, 0x382BA000,
+      0x382BC000, 0x382BE000, 0x382C0000, 0x382C2000, 0x382C4000, 0x382C6000,
+      0x382C8000, 0x382CA000, 0x382CC000, 0x382CE000, 0x382D0000, 0x382D2000,
+      0x382D4000, 0x382D6000, 0x382D8000, 0x382DA000, 0x382DC000, 0x382DE000,
+      0x382E0000, 0x382E2000, 0x382E4000, 0x382E6000, 0x382E8000, 0x382EA000,
+      0x382EC000, 0x382EE000, 0x382F0000, 0x382F2000, 0x382F4000, 0x382F6000,
+      0x382F8000, 0x382FA000, 0x382FC000, 0x382FE000, 0x38300000, 0x38302000,
+      0x38304000, 0x38306000, 0x38308000, 0x3830A000, 0x3830C000, 0x3830E000,
+      0x38310000, 0x38312000, 0x38314000, 0x38316000, 0x38318000, 0x3831A000,
+      0x3831C000, 0x3831E000, 0x38320000, 0x38322000, 0x38324000, 0x38326000,
+      0x38328000, 0x3832A000, 0x3832C000, 0x3832E000, 0x38330000, 0x38332000,
+      0x38334000, 0x38336000, 0x38338000, 0x3833A000, 0x3833C000, 0x3833E000,
+      0x38340000, 0x38342000, 0x38344000, 0x38346000, 0x38348000, 0x3834A000,
+      0x3834C000, 0x3834E000, 0x38350000, 0x38352000, 0x38354000, 0x38356000,
+      0x38358000, 0x3835A000, 0x3835C000, 0x3835E000, 0x38360000, 0x38362000,
+      0x38364000, 0x38366000, 0x38368000, 0x3836A000, 0x3836C000, 0x3836E000,
+      0x38370000, 0x38372000, 0x38374000, 0x38376000, 0x38378000, 0x3837A000,
+      0x3837C000, 0x3837E000, 0x38380000, 0x38382000, 0x38384000, 0x38386000,
+      0x38388000, 0x3838A000, 0x3838C000, 0x3838E000, 0x38390000, 0x38392000,
+      0x38394000, 0x38396000, 0x38398000, 0x3839A000, 0x3839C000, 0x3839E000,
+      0x383A0000, 0x383A2000, 0x383A4000, 0x383A6000, 0x383A8000, 0x383AA000,
+      0x383AC000, 0x383AE000, 0x383B0000, 0x383B2000, 0x383B4000, 0x383B6000,
+      0x383B8000, 0x383BA000, 0x383BC000, 0x383BE000, 0x383C0000, 0x383C2000,
+      0x383C4000, 0x383C6000, 0x383C8000, 0x383CA000, 0x383CC000, 0x383CE000,
+      0x383D0000, 0x383D2000, 0x383D4000, 0x383D6000, 0x383D8000, 0x383DA000,
+      0x383DC000, 0x383DE000, 0x383E0000, 0x383E2000, 0x383E4000, 0x383E6000,
+      0x383E8000, 0x383EA000, 0x383EC000, 0x383EE000, 0x383F0000, 0x383F2000,
+      0x383F4000, 0x383F6000, 0x383F8000, 0x383FA000, 0x383FC000, 0x383FE000,
+      0x38400000, 0x38402000, 0x38404000, 0x38406000, 0x38408000, 0x3840A000,
+      0x3840C000, 0x3840E000, 0x38410000, 0x38412000, 0x38414000, 0x38416000,
+      0x38418000, 0x3841A000, 0x3841C000, 0x3841E000, 0x38420000, 0x38422000,
+      0x38424000, 0x38426000, 0x38428000, 0x3842A000, 0x3842C000, 0x3842E000,
+      0x38430000, 0x38432000, 0x38434000, 0x38436000, 0x38438000, 0x3843A000,
+      0x3843C000, 0x3843E000, 0x38440000, 0x38442000, 0x38444000, 0x38446000,
+      0x38448000, 0x3844A000, 0x3844C000, 0x3844E000, 0x38450000, 0x38452000,
+      0x38454000, 0x38456000, 0x38458000, 0x3845A000, 0x3845C000, 0x3845E000,
+      0x38460000, 0x38462000, 0x38464000, 0x38466000, 0x38468000, 0x3846A000,
+      0x3846C000, 0x3846E000, 0x38470000, 0x38472000, 0x38474000, 0x38476000,
+      0x38478000, 0x3847A000, 0x3847C000, 0x3847E000, 0x38480000, 0x38482000,
+      0x38484000, 0x38486000, 0x38488000, 0x3848A000, 0x3848C000, 0x3848E000,
+      0x38490000, 0x38492000, 0x38494000, 0x38496000, 0x38498000, 0x3849A000,
+      0x3849C000, 0x3849E000, 0x384A0000, 0x384A2000, 0x384A4000, 0x384A6000,
+      0x384A8000, 0x384AA000, 0x384AC000, 0x384AE000, 0x384B0000, 0x384B2000,
+      0x384B4000, 0x384B6000, 0x384B8000, 0x384BA000, 0x384BC000, 0x384BE000,
+      0x384C0000, 0x384C2000, 0x384C4000, 0x384C6000, 0x384C8000, 0x384CA000,
+      0x384CC000, 0x384CE000, 0x384D0000, 0x384D2000, 0x384D4000, 0x384D6000,
+      0x384D8000, 0x384DA000, 0x384DC000, 0x384DE000, 0x384E0000, 0x384E2000,
+      0x384E4000, 0x384E6000, 0x384E8000, 0x384EA000, 0x384EC000, 0x384EE000,
+      0x384F0000, 0x384F2000, 0x384F4000, 0x384F6000, 0x384F8000, 0x384FA000,
+      0x384FC000, 0x384FE000, 0x38500000, 0x38502000, 0x38504000, 0x38506000,
+      0x38508000, 0x3850A000, 0x3850C000, 0x3850E000, 0x38510000, 0x38512000,
+      0x38514000, 0x38516000, 0x38518000, 0x3851A000, 0x3851C000, 0x3851E000,
+      0x38520000, 0x38522000, 0x38524000, 0x38526000, 0x38528000, 0x3852A000,
+      0x3852C000, 0x3852E000, 0x38530000, 0x38532000, 0x38534000, 0x38536000,
+      0x38538000, 0x3853A000, 0x3853C000, 0x3853E000, 0x38540000, 0x38542000,
+      0x38544000, 0x38546000, 0x38548000, 0x3854A000, 0x3854C000, 0x3854E000,
+      0x38550000, 0x38552000, 0x38554000, 0x38556000, 0x38558000, 0x3855A000,
+      0x3855C000, 0x3855E000, 0x38560000, 0x38562000, 0x38564000, 0x38566000,
+      0x38568000, 0x3856A000, 0x3856C000, 0x3856E000, 0x38570000, 0x38572000,
+      0x38574000, 0x38576000, 0x38578000, 0x3857A000, 0x3857C000, 0x3857E000,
+      0x38580000, 0x38582000, 0x38584000, 0x38586000, 0x38588000, 0x3858A000,
+      0x3858C000, 0x3858E000, 0x38590000, 0x38592000, 0x38594000, 0x38596000,
+      0x38598000, 0x3859A000, 0x3859C000, 0x3859E000, 0x385A0000, 0x385A2000,
+      0x385A4000, 0x385A6000, 0x385A8000, 0x385AA000, 0x385AC000, 0x385AE000,
+      0x385B0000, 0x385B2000, 0x385B4000, 0x385B6000, 0x385B8000, 0x385BA000,
+      0x385BC000, 0x385BE000, 0x385C0000, 0x385C2000, 0x385C4000, 0x385C6000,
+      0x385C8000, 0x385CA000, 0x385CC000, 0x385CE000, 0x385D0000, 0x385D2000,
+      0x385D4000, 0x385D6000, 0x385D8000, 0x385DA000, 0x385DC000, 0x385DE000,
+      0x385E0000, 0x385E2000, 0x385E4000, 0x385E6000, 0x385E8000, 0x385EA000,
+      0x385EC000, 0x385EE000, 0x385F0000, 0x385F2000, 0x385F4000, 0x385F6000,
+      0x385F8000, 0x385FA000, 0x385FC000, 0x385FE000, 0x38600000, 0x38602000,
+      0x38604000, 0x38606000, 0x38608000, 0x3860A000, 0x3860C000, 0x3860E000,
+      0x38610000, 0x38612000, 0x38614000, 0x38616000, 0x38618000, 0x3861A000,
+      0x3861C000, 0x3861E000, 0x38620000, 0x38622000, 0x38624000, 0x38626000,
+      0x38628000, 0x3862A000, 0x3862C000, 0x3862E000, 0x38630000, 0x38632000,
+      0x38634000, 0x38636000, 0x38638000, 0x3863A000, 0x3863C000, 0x3863E000,
+      0x38640000, 0x38642000, 0x38644000, 0x38646000, 0x38648000, 0x3864A000,
+      0x3864C000, 0x3864E000, 0x38650000, 0x38652000, 0x38654000, 0x38656000,
+      0x38658000, 0x3865A000, 0x3865C000, 0x3865E000, 0x38660000, 0x38662000,
+      0x38664000, 0x38666000, 0x38668000, 0x3866A000, 0x3866C000, 0x3866E000,
+      0x38670000, 0x38672000, 0x38674000, 0x38676000, 0x38678000, 0x3867A000,
+      0x3867C000, 0x3867E000, 0x38680000, 0x38682000, 0x38684000, 0x38686000,
+      0x38688000, 0x3868A000, 0x3868C000, 0x3868E000, 0x38690000, 0x38692000,
+      0x38694000, 0x38696000, 0x38698000, 0x3869A000, 0x3869C000, 0x3869E000,
+      0x386A0000, 0x386A2000, 0x386A4000, 0x386A6000, 0x386A8000, 0x386AA000,
+      0x386AC000, 0x386AE000, 0x386B0000, 0x386B2000, 0x386B4000, 0x386B6000,
+      0x386B8000, 0x386BA000, 0x386BC000, 0x386BE000, 0x386C0000, 0x386C2000,
+      0x386C4000, 0x386C6000, 0x386C8000, 0x386CA000, 0x386CC000, 0x386CE000,
+      0x386D0000, 0x386D2000, 0x386D4000, 0x386D6000, 0x386D8000, 0x386DA000,
+      0x386DC000, 0x386DE000, 0x386E0000, 0x386E2000, 0x386E4000, 0x386E6000,
+      0x386E8000, 0x386EA000, 0x386EC000, 0x386EE000, 0x386F0000, 0x386F2000,
+      0x386F4000, 0x386F6000, 0x386F8000, 0x386FA000, 0x386FC000, 0x386FE000,
+      0x38700000, 0x38702000, 0x38704000, 0x38706000, 0x38708000, 0x3870A000,
+      0x3870C000, 0x3870E000, 0x38710000, 0x38712000, 0x38714000, 0x38716000,
+      0x38718000, 0x3871A000, 0x3871C000, 0x3871E000, 0x38720000, 0x38722000,
+      0x38724000, 0x38726000, 0x38728000, 0x3872A000, 0x3872C000, 0x3872E000,
+      0x38730000, 0x38732000, 0x38734000, 0x38736000, 0x38738000, 0x3873A000,
+      0x3873C000, 0x3873E000, 0x38740000, 0x38742000, 0x38744000, 0x38746000,
+      0x38748000, 0x3874A000, 0x3874C000, 0x3874E000, 0x38750000, 0x38752000,
+      0x38754000, 0x38756000, 0x38758000, 0x3875A000, 0x3875C000, 0x3875E000,
+      0x38760000, 0x38762000, 0x38764000, 0x38766000, 0x38768000, 0x3876A000,
+      0x3876C000, 0x3876E000, 0x38770000, 0x38772000, 0x38774000, 0x38776000,
+      0x38778000, 0x3877A000, 0x3877C000, 0x3877E000, 0x38780000, 0x38782000,
+      0x38784000, 0x38786000, 0x38788000, 0x3878A000, 0x3878C000, 0x3878E000,
+      0x38790000, 0x38792000, 0x38794000, 0x38796000, 0x38798000, 0x3879A000,
+      0x3879C000, 0x3879E000, 0x387A0000, 0x387A2000, 0x387A4000, 0x387A6000,
+      0x387A8000, 0x387AA000, 0x387AC000, 0x387AE000, 0x387B0000, 0x387B2000,
+      0x387B4000, 0x387B6000, 0x387B8000, 0x387BA000, 0x387BC000, 0x387BE000,
+      0x387C0000, 0x387C2000, 0x387C4000, 0x387C6000, 0x387C8000, 0x387CA000,
+      0x387CC000, 0x387CE000, 0x387D0000, 0x387D2000, 0x387D4000, 0x387D6000,
+      0x387D8000, 0x387DA000, 0x387DC000, 0x387DE000, 0x387E0000, 0x387E2000,
+      0x387E4000, 0x387E6000, 0x387E8000, 0x387EA000, 0x387EC000, 0x387EE000,
+      0x387F0000, 0x387F2000, 0x387F4000, 0x387F6000, 0x387F8000, 0x387FA000,
+      0x387FC000, 0x387FE000};
+  static const uint32 exponent_table[64] = {
+      0x00000000, 0x00800000, 0x01000000, 0x01800000, 0x02000000, 0x02800000,
+      0x03000000, 0x03800000, 0x04000000, 0x04800000, 0x05000000, 0x05800000,
+      0x06000000, 0x06800000, 0x07000000, 0x07800000, 0x08000000, 0x08800000,
+      0x09000000, 0x09800000, 0x0A000000, 0x0A800000, 0x0B000000, 0x0B800000,
+      0x0C000000, 0x0C800000, 0x0D000000, 0x0D800000, 0x0E000000, 0x0E800000,
+      0x0F000000, 0x47800000, 0x80000000, 0x80800000, 0x81000000, 0x81800000,
+      0x82000000, 0x82800000, 0x83000000, 0x83800000, 0x84000000, 0x84800000,
+      0x85000000, 0x85800000, 0x86000000, 0x86800000, 0x87000000, 0x87800000,
+      0x88000000, 0x88800000, 0x89000000, 0x89800000, 0x8A000000, 0x8A800000,
+      0x8B000000, 0x8B800000, 0x8C000000, 0x8C800000, 0x8D000000, 0x8D800000,
+      0x8E000000, 0x8E800000, 0x8F000000, 0xC7800000};
+  static const unsigned short offset_table[64] = {
+      0,    1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024,
+      1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024,
+      1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 0,
+      1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024,
+      1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024,
+      1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024};
+  uint32 bits = mantissa_table[offset_table[value >> 10] + (value & 0x3FF)] +
+                exponent_table[value >> 10];
+  //			return *reinterpret_cast<float*>(&bits);			//violating
+  //strict aliasing!
+  float out;
+  std::memcpy(&out, &bits, sizeof(float));
+  return out;
+}
+
+/// Convert half-precision to IEEE double-precision.
+/// \param value binary representation of half-precision value
+/// \return double-precision value
+inline double half2float_impl(uint16 value, double, true_type) {
+  typedef bits<float>::type uint32;
+  typedef bits<double>::type uint64;
+  uint32 hi = static_cast<uint32>(value & 0x8000) << 16;
+  int abs = value & 0x7FFF;
+  if (abs) {
+    hi |= 0x3F000000 << static_cast<unsigned>(abs >= 0x7C00);
+    for (; abs < 0x400; abs <<= 1, hi -= 0x100000)
+      ;
+    hi += static_cast<uint32>(abs) << 10;
+  }
+  uint64 bits = static_cast<uint64>(hi) << 32;
+  //			return *reinterpret_cast<double*>(&bits);			//violating
+  //strict aliasing!
+  double out;
+  std::memcpy(&out, &bits, sizeof(double));
+  return out;
+}
+
+/// Convert half-precision to non-IEEE floating point.
+/// \tparam T type to convert to (builtin integer type)
+/// \param value binary representation of half-precision value
+/// \return floating point value
+template <typename T>
+T half2float_impl(uint16 value, T, ...) {
+  T out;
+  int abs = value & 0x7FFF;
+  if (abs > 0x7C00)
+    out = std::numeric_limits<T>::has_quiet_NaN
+              ? std::numeric_limits<T>::quiet_NaN()
+              : T();
+  else if (abs == 0x7C00)
+    out = std::numeric_limits<T>::has_infinity
+              ? std::numeric_limits<T>::infinity()
+              : std::numeric_limits<T>::max();
+  else if (abs > 0x3FF)
+    out = std::ldexp(static_cast<T>((abs & 0x3FF) | 0x400), (abs >> 10) - 25);
+  else
+    out = std::ldexp(static_cast<T>(abs), -24);
+  return (value & 0x8000) ? -out : out;
+}
+
+/// Convert half-precision to floating point.
+/// \tparam T type to convert to (builtin integer type)
+/// \param value binary representation of half-precision value
+/// \return floating point value
+template <typename T>
+T half2float(uint16 value) {
+  return half2float_impl(value, T(),
+                         bool_type < std::numeric_limits<T>::is_iec559 &&
+                             sizeof(typename bits<T>::type) == sizeof(T) > ());
+}
+
+/// Convert half-precision floating point to integer.
+/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+/// rounding \tparam E `true` for round to even, `false` for round away from
+/// zero \tparam T type to convert to (buitlin integer type with at least 16
+/// bits precision, excluding any implicit sign bits) \param value binary
+/// representation of half-precision value \return integral value
+template <std::float_round_style R, bool E, typename T>
+T half2int_impl(uint16 value) {
+#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
+  static_assert(std::is_integral<T>::value,
+                "half to int conversion only supports builtin integer types");
+#endif
+  unsigned int e = value & 0x7FFF;
+  if (e >= 0x7C00)
+    return (value & 0x8000) ? std::numeric_limits<T>::min()
+                            : std::numeric_limits<T>::max();
+  if (e < 0x3800) {
+    if (R == std::round_toward_infinity)
+      return T(~(value >> 15) & (e != 0));
+    else if (R == std::round_toward_neg_infinity)
+      return -T(value > 0x8000);
+    return T();
+  }
+  unsigned int m = (value & 0x3FF) | 0x400;
+  e >>= 10;
+  if (e < 25) {
+    if (R == std::round_to_nearest)
+      m += (1 << (24 - e)) - (~(m >> (25 - e)) & E);
+    else if (R == std::round_toward_infinity)
+      m += ((value >> 15) - 1) & ((1 << (25 - e)) - 1U);
+    else if (R == std::round_toward_neg_infinity)
+      m += -(value >> 15) & ((1 << (25 - e)) - 1U);
+    m >>= 25 - e;
+  } else
+    m <<= e - 25;
+  return (value & 0x8000) ? -static_cast<T>(m) : static_cast<T>(m);
+}
+
+/// Convert half-precision floating point to integer.
+/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+/// rounding \tparam T type to convert to (buitlin integer type with at least 16
+/// bits precision, excluding any implicit sign bits) \param value binary
+/// representation of half-precision value \return integral value
+template <std::float_round_style R, typename T>
+T half2int(uint16 value) {
+  return half2int_impl<R, HALF_ROUND_TIES_TO_EVEN, T>(value);
+}
+
+/// Convert half-precision floating point to integer using
+/// round-to-nearest-away-from-zero. \tparam T type to convert to (buitlin
+/// integer type with at least 16 bits precision, excluding any implicit sign
+/// bits) \param value binary representation of half-precision value \return
+/// integral value
+template <typename T>
+T half2int_up(uint16 value) {
+  return half2int_impl<std::round_to_nearest, 0, T>(value);
+}
+
+/// Round half-precision number to nearest integer value.
+/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+/// rounding \tparam E `true` for round to even, `false` for round away from
+/// zero \param value binary representation of half-precision value \return
+/// half-precision bits for nearest integral value
+template <std::float_round_style R, bool E>
+uint16 round_half_impl(uint16 value) {
+  unsigned int e = value & 0x7FFF;
+  uint16 result = value;
+  if (e < 0x3C00) {
+    result &= 0x8000;
+    if (R == std::round_to_nearest)
+      result |= 0x3C00U & -(e >= (0x3800 + E));
+    else if (R == std::round_toward_infinity)
+      result |= 0x3C00U & -(~(value >> 15) & (e != 0));
+    else if (R == std::round_toward_neg_infinity)
+      result |= 0x3C00U & -(value > 0x8000);
+  } else if (e < 0x6400) {
+    e = 25 - (e >> 10);
+    unsigned int mask = (1 << e) - 1;
+    if (R == std::round_to_nearest)
+      result += (1 << (e - 1)) - (~(result >> e) & E);
+    else if (R == std::round_toward_infinity)
+      result += mask & ((value >> 15) - 1);
+    else if (R == std::round_toward_neg_infinity)
+      result += mask & -(value >> 15);
+    result &= ~mask;
+  }
+  return result;
+}
+
+/// Round half-precision number to nearest integer value.
+/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+/// rounding \param value binary representation of half-precision value \return
+/// half-precision bits for nearest integral value
+template <std::float_round_style R>
+uint16 round_half(uint16 value) {
+  return round_half_impl<R, HALF_ROUND_TIES_TO_EVEN>(value);
+}
+
+/// Round half-precision number to nearest integer value using
+/// round-to-nearest-away-from-zero. \param value binary representation of
+/// half-precision value \return half-precision bits for nearest integral value
+inline uint16 round_half_up(uint16 value) {
+  return round_half_impl<std::round_to_nearest, 0>(value);
+}
+/// \}
+
+struct functions;
+template <typename>
+struct unary_specialized;
+template <typename, typename>
+struct binary_specialized;
+template <typename, typename, std::float_round_style>
+struct half_caster;
+}  // namespace detail
+
+/// Half-precision floating point type.
+/// This class implements an IEEE-conformant half-precision floating point type
+/// with the usual arithmetic operators and conversions. It is implicitly
+/// convertible to single-precision floating point, which makes artihmetic
+/// expressions and functions with mixed-type operands to be of the most precise
+/// operand type. Additionally all arithmetic operations (and many mathematical
+/// functions) are carried out in single-precision internally. All conversions
+/// from single- to half-precision are done using the library's default rounding
+/// mode, but temporary results inside chained arithmetic expressions are kept
+/// in single-precision as long as possible (while of course still maintaining a
+/// strong half-precision type).
+///
+/// According to the C++98/03 definition, the half type is not a POD type. But
+/// according to C++11's less strict and extended definitions it is both a
+/// standard layout type and a trivially copyable type (even if not a POD type),
+/// which means it can be standard-conformantly copied using raw binary copies.
+/// But in this context some more words about the actual size of the type.
+/// Although the half is representing an IEEE 16-bit type, it does not
+/// neccessarily have to be of exactly 16-bits size. But on any reasonable
+/// implementation the actual binary representation of this type will most
+/// probably not ivolve any additional "magic" or padding beyond the simple
+/// binary representation of the underlying 16-bit IEEE number, even if not
+/// strictly guaranteed by the standard. But even then it only has an actual
+/// size of 16 bits if your C++ implementation supports an unsigned integer type
+/// of exactly 16 bits width. But this should be the case on nearly any
+/// reasonable platform.
+///
+/// So if your C++ implementation is not totally exotic or imposes special
+/// alignment requirements, it is a reasonable assumption that the data of a
+/// half is just comprised of the 2 bytes of the underlying IEEE representation.
+class half {
+  friend struct detail::functions;
+  friend struct detail::unary_specialized<half>;
+  friend struct detail::binary_specialized<half, half>;
+  template <typename, typename, std::float_round_style>
+  friend struct detail::half_caster;
+  friend class std::numeric_limits<half>;
+#if HALF_ENABLE_CPP11_HASH
+  friend struct std::hash<half>;
+#endif
+#if HALF_ENABLE_CPP11_USER_LITERALS
+  friend half literal::operator"" _h(long double);
+#endif
+
+ public:
+  /// Default constructor.
+  /// This initializes the half to 0. Although this does not match the builtin
+  /// types' default-initialization semantics and may be less efficient than no
+  /// initialization, it is needed to provide proper value-initialization
+  /// semantics.
+  HALF_CONSTEXPR half() HALF_NOEXCEPT : data_() {}
+
+  /// Copy constructor.
+  /// \tparam T type of concrete half expression
+  /// \param rhs half expression to copy from
+  half(detail::expr rhs)
+      : data_(detail::float2half<round_style>(static_cast<float>(rhs))) {}
+
+  /// Conversion constructor.
+  /// \param rhs float to convert
+  explicit half(float rhs) : data_(detail::float2half<round_style>(rhs)) {}
+
+  /// Conversion to single-precision.
+  /// \return single precision value representing expression value
+  operator float() const { return detail::half2float<float>(data_); }
+
+  /// Assignment operator.
+  /// \tparam T type of concrete half expression
+  /// \param rhs half expression to copy from
+  /// \return reference to this half
+  half &operator=(detail::expr rhs) { return *this = static_cast<float>(rhs); }
+
+  /// Arithmetic assignment.
+  /// \tparam T type of concrete half expression
+  /// \param rhs half expression to add
+  /// \return reference to this half
+  template <typename T>
+  typename detail::enable<half &, T>::type operator+=(T rhs) {
+    return *this += static_cast<float>(rhs);
+  }
+
+  /// Arithmetic assignment.
+  /// \tparam T type of concrete half expression
+  /// \param rhs half expression to subtract
+  /// \return reference to this half
+  template <typename T>
+  typename detail::enable<half &, T>::type operator-=(T rhs) {
+    return *this -= static_cast<float>(rhs);
+  }
+
+  /// Arithmetic assignment.
+  /// \tparam T type of concrete half expression
+  /// \param rhs half expression to multiply with
+  /// \return reference to this half
+  template <typename T>
+  typename detail::enable<half &, T>::type operator*=(T rhs) {
+    return *this *= static_cast<float>(rhs);
+  }
+
+  /// Arithmetic assignment.
+  /// \tparam T type of concrete half expression
+  /// \param rhs half expression to divide by
+  /// \return reference to this half
+  template <typename T>
+  typename detail::enable<half &, T>::type operator/=(T rhs) {
+    return *this /= static_cast<float>(rhs);
+  }
+
+  /// Assignment operator.
+  /// \param rhs single-precision value to copy from
+  /// \return reference to this half
+  half &operator=(float rhs) {
+    data_ = detail::float2half<round_style>(rhs);
+    return *this;
+  }
+
+  /// Arithmetic assignment.
+  /// \param rhs single-precision value to add
+  /// \return reference to this half
+  half &operator+=(float rhs) {
+    data_ =
+        detail::float2half<round_style>(detail::half2float<float>(data_) + rhs);
+    return *this;
+  }
+
+  /// Arithmetic assignment.
+  /// \param rhs single-precision value to subtract
+  /// \return reference to this half
+  half &operator-=(float rhs) {
+    data_ =
+        detail::float2half<round_style>(detail::half2float<float>(data_) - rhs);
+    return *this;
+  }
+
+  /// Arithmetic assignment.
+  /// \param rhs single-precision value to multiply with
+  /// \return reference to this half
+  half &operator*=(float rhs) {
+    data_ =
+        detail::float2half<round_style>(detail::half2float<float>(data_) * rhs);
+    return *this;
+  }
+
+  /// Arithmetic assignment.
+  /// \param rhs single-precision value to divide by
+  /// \return reference to this half
+  half &operator/=(float rhs) {
+    data_ =
+        detail::float2half<round_style>(detail::half2float<float>(data_) / rhs);
+    return *this;
+  }
+
+  /// Prefix increment.
+  /// \return incremented half value
+  half &operator++() { return *this += 1.0f; }
+
+  /// Prefix decrement.
+  /// \return decremented half value
+  half &operator--() { return *this -= 1.0f; }
+
+  /// Postfix increment.
+  /// \return non-incremented half value
+  half operator++(int) {
+    half out(*this);
+    ++*this;
+    return out;
+  }
+
+  /// Postfix decrement.
+  /// \return non-decremented half value
+  half operator--(int) {
+    half out(*this);
+    --*this;
+    return out;
+  }
+
+ private:
+  /// Rounding mode to use
+  static const std::float_round_style round_style =
+      (std::float_round_style)(HALF_ROUND_STYLE);
+
+  /// Constructor.
+  /// \param bits binary representation to set half to
+  HALF_CONSTEXPR half(detail::binary_t, detail::uint16 bits) HALF_NOEXCEPT
+      : data_(bits) {}
+
+  /// Internal binary representation
+  detail::uint16 data_;
+};
+
+#if HALF_ENABLE_CPP11_USER_LITERALS
+namespace literal {
+/// Half literal.
+/// While this returns an actual half-precision value, half literals can
+/// unfortunately not be constant expressions due to rather involved
+/// conversions. \param value literal value \return half with given value (if
+/// representable)
+inline half operator"" _h(long double value) {
+  return half(detail::binary, detail::float2half<half::round_style>(value));
+}
+}  // namespace literal
+#endif
+
+namespace detail {
+/// Wrapper implementing unspecialized half-precision functions.
+struct functions {
+  /// Addition implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \return Half-precision sum stored in single-precision
+  static expr plus(float x, float y) { return expr(x + y); }
+
+  /// Subtraction implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \return Half-precision difference stored in single-precision
+  static expr minus(float x, float y) { return expr(x - y); }
+
+  /// Multiplication implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \return Half-precision product stored in single-precision
+  static expr multiplies(float x, float y) { return expr(x * y); }
+
+  /// Division implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \return Half-precision quotient stored in single-precision
+  static expr divides(float x, float y) { return expr(x / y); }
+
+  /// Output implementation.
+  /// \param out stream to write to
+  /// \param arg value to write
+  /// \return reference to stream
+  template <typename charT, typename traits>
+  static std::basic_ostream<charT, traits> &write(
+      std::basic_ostream<charT, traits> &out, float arg) {
+    return out << arg;
+  }
+
+  /// Input implementation.
+  /// \param in stream to read from
+  /// \param arg half to read into
+  /// \return reference to stream
+  template <typename charT, typename traits>
+  static std::basic_istream<charT, traits> &read(
+      std::basic_istream<charT, traits> &in, half &arg) {
+    float f;
+    if (in >> f) arg = f;
+    return in;
+  }
+
+  /// Modulo implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \return Half-precision division remainder stored in single-precision
+  static expr fmod(float x, float y) { return expr(std::fmod(x, y)); }
+
+  /// Remainder implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \return Half-precision division remainder stored in single-precision
+  static expr remainder(float x, float y) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::remainder(x, y));
+#else
+    if (builtin_isnan(x) || builtin_isnan(y))
+      return expr(std::numeric_limits<float>::quiet_NaN());
+    float ax = std::fabs(x), ay = std::fabs(y);
+    if (ax >= 65536.0f || ay < std::ldexp(1.0f, -24))
+      return expr(std::numeric_limits<float>::quiet_NaN());
+    if (ay >= 65536.0f) return expr(x);
+    if (ax == ay) return expr(builtin_signbit(x) ? -0.0f : 0.0f);
+    ax = std::fmod(ax, ay + ay);
+    float y2 = 0.5f * ay;
+    if (ax > y2) {
+      ax -= ay;
+      if (ax >= y2) ax -= ay;
+    }
+    return expr(builtin_signbit(x) ? -ax : ax);
+#endif
+  }
+
+  /// Remainder implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \param quo address to store quotient bits at
+  /// \return Half-precision division remainder stored in single-precision
+  static expr remquo(float x, float y, int *quo) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::remquo(x, y, quo));
+#else
+    if (builtin_isnan(x) || builtin_isnan(y))
+      return expr(std::numeric_limits<float>::quiet_NaN());
+    bool sign = builtin_signbit(x),
+         qsign = static_cast<bool>(sign ^ builtin_signbit(y));
+    float ax = std::fabs(x), ay = std::fabs(y);
+    if (ax >= 65536.0f || ay < std::ldexp(1.0f, -24))
+      return expr(std::numeric_limits<float>::quiet_NaN());
+    if (ay >= 65536.0f) return expr(x);
+    if (ax == ay) return *quo = qsign ? -1 : 1, expr(sign ? -0.0f : 0.0f);
+    ax = std::fmod(ax, 8.0f * ay);
+    int cquo = 0;
+    if (ax >= 4.0f * ay) {
+      ax -= 4.0f * ay;
+      cquo += 4;
+    }
+    if (ax >= 2.0f * ay) {
+      ax -= 2.0f * ay;
+      cquo += 2;
+    }
+    float y2 = 0.5f * ay;
+    if (ax > y2) {
+      ax -= ay;
+      ++cquo;
+      if (ax >= y2) {
+        ax -= ay;
+        ++cquo;
+      }
+    }
+    return *quo = qsign ? -cquo : cquo, expr(sign ? -ax : ax);
+#endif
+  }
+
+  /// Positive difference implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \return Positive difference stored in single-precision
+  static expr fdim(float x, float y) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::fdim(x, y));
+#else
+    return expr((x <= y) ? 0.0f : (x - y));
+#endif
+  }
+
+  /// Fused multiply-add implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \param z third operand
+  /// \return \a x * \a y + \a z stored in single-precision
+  static expr fma(float x, float y, float z) {
+#if HALF_ENABLE_CPP11_CMATH && defined(FP_FAST_FMAF)
+    return expr(std::fma(x, y, z));
+#else
+    return expr(x * y + z);
+#endif
+  }
+
+  /// Get NaN.
+  /// \return Half-precision quiet NaN
+  static half nanh() { return half(binary, 0x7FFF); }
+
+  /// Exponential implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr exp(float arg) { return expr(std::exp(arg)); }
+
+  /// Exponential implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr expm1(float arg) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::expm1(arg));
+#else
+    return expr(static_cast<float>(std::exp(static_cast<double>(arg)) - 1.0));
+#endif
+  }
+
+  /// Binary exponential implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr exp2(float arg) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::exp2(arg));
+#else
+    return expr(
+        static_cast<float>(std::exp(arg * 0.69314718055994530941723212145818)));
+#endif
+  }
+
+  /// Logarithm implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr log(float arg) { return expr(std::log(arg)); }
+
+  /// Common logarithm implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr log10(float arg) { return expr(std::log10(arg)); }
+
+  /// Logarithm implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr log1p(float arg) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::log1p(arg));
+#else
+    return expr(static_cast<float>(std::log(1.0 + arg)));
+#endif
+  }
+
+  /// Binary logarithm implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr log2(float arg) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::log2(arg));
+#else
+    return expr(static_cast<float>(std::log(static_cast<double>(arg)) *
+                                   1.4426950408889634073599246810019));
+#endif
+  }
+
+  /// Square root implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr sqrt(float arg) { return expr(std::sqrt(arg)); }
+
+  /// Cubic root implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr cbrt(float arg) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::cbrt(arg));
+#else
+    if (builtin_isnan(arg) || builtin_isinf(arg)) return expr(arg);
+    return expr(builtin_signbit(arg)
+                    ? -static_cast<float>(
+                          std::pow(-static_cast<double>(arg), 1.0 / 3.0))
+                    : static_cast<float>(
+                          std::pow(static_cast<double>(arg), 1.0 / 3.0)));
+#endif
+  }
+
+  /// Hypotenuse implementation.
+  /// \param x first argument
+  /// \param y second argument
+  /// \return function value stored in single-preicision
+  static expr hypot(float x, float y) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::hypot(x, y));
+#else
+    return expr(
+        (builtin_isinf(x) || builtin_isinf(y))
+            ? std::numeric_limits<float>::infinity()
+            : static_cast<float>(std::sqrt(static_cast<double>(x) * x +
+                                           static_cast<double>(y) * y)));
+#endif
+  }
+
+  /// Power implementation.
+  /// \param base value to exponentiate
+  /// \param exp power to expontiate to
+  /// \return function value stored in single-preicision
+  static expr pow(float base, float exp) { return expr(std::pow(base, exp)); }
+
+  /// Sine implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr sin(float arg) { return expr(std::sin(arg)); }
+
+  /// Cosine implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr cos(float arg) { return expr(std::cos(arg)); }
+
+  /// Tan implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr tan(float arg) { return expr(std::tan(arg)); }
+
+  /// Arc sine implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr asin(float arg) { return expr(std::asin(arg)); }
+
+  /// Arc cosine implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr acos(float arg) { return expr(std::acos(arg)); }
+
+  /// Arc tangent implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr atan(float arg) { return expr(std::atan(arg)); }
+
+  /// Arc tangent implementation.
+  /// \param x first argument
+  /// \param y second argument
+  /// \return function value stored in single-preicision
+  static expr atan2(float x, float y) { return expr(std::atan2(x, y)); }
+
+  /// Hyperbolic sine implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr sinh(float arg) { return expr(std::sinh(arg)); }
+
+  /// Hyperbolic cosine implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr cosh(float arg) { return expr(std::cosh(arg)); }
+
+  /// Hyperbolic tangent implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr tanh(float arg) { return expr(std::tanh(arg)); }
+
+  /// Hyperbolic area sine implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr asinh(float arg) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::asinh(arg));
+#else
+    return expr(
+        (arg == -std::numeric_limits<float>::infinity())
+            ? arg
+            : static_cast<float>(std::log(arg + std::sqrt(arg * arg + 1.0))));
+#endif
+  }
+
+  /// Hyperbolic area cosine implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr acosh(float arg) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::acosh(arg));
+#else
+    return expr((arg < -1.0f) ? std::numeric_limits<float>::quiet_NaN()
+                              : static_cast<float>(std::log(
+                                    arg + std::sqrt(arg * arg - 1.0))));
+#endif
+  }
+
+  /// Hyperbolic area tangent implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr atanh(float arg) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::atanh(arg));
+#else
+    return expr(static_cast<float>(0.5 * std::log((1.0 + arg) / (1.0 - arg))));
+#endif
+  }
+
+  /// Error function implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr erf(float arg) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::erf(arg));
+#else
+    return expr(static_cast<float>(erf(static_cast<double>(arg))));
+#endif
+  }
+
+  /// Complementary implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr erfc(float arg) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::erfc(arg));
+#else
+    return expr(static_cast<float>(1.0 - erf(static_cast<double>(arg))));
+#endif
+  }
+
+  /// Gamma logarithm implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr lgamma(float arg) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::lgamma(arg));
+#else
+    if (builtin_isinf(arg)) return expr(std::numeric_limits<float>::infinity());
+    if (arg < 0.0f) {
+      float i, f = std::modf(-arg, &i);
+      if (f == 0.0f) return expr(std::numeric_limits<float>::infinity());
+      return expr(static_cast<float>(
+          1.1447298858494001741434273513531 -
+          std::log(std::abs(std::sin(3.1415926535897932384626433832795 * f))) -
+          lgamma(1.0 - arg)));
+    }
+    return expr(static_cast<float>(lgamma(static_cast<double>(arg))));
+#endif
+  }
+
+  /// Gamma implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr tgamma(float arg) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::tgamma(arg));
+#else
+    if (arg == 0.0f)
+      return builtin_signbit(arg)
+                 ? expr(-std::numeric_limits<float>::infinity())
+                 : expr(std::numeric_limits<float>::infinity());
+    if (arg < 0.0f) {
+      float i, f = std::modf(-arg, &i);
+      if (f == 0.0f) return expr(std::numeric_limits<float>::quiet_NaN());
+      double value = 3.1415926535897932384626433832795 /
+                     (std::sin(3.1415926535897932384626433832795 * f) *
+                      std::exp(lgamma(1.0 - arg)));
+      return expr(
+          static_cast<float>((std::fmod(i, 2.0f) == 0.0f) ? -value : value));
+    }
+    if (builtin_isinf(arg)) return expr(arg);
+    return expr(static_cast<float>(std::exp(lgamma(static_cast<double>(arg)))));
+#endif
+  }
+
+  /// Floor implementation.
+  /// \param arg value to round
+  /// \return rounded value
+  static half floor(half arg) {
+    return half(binary, round_half<std::round_toward_neg_infinity>(arg.data_));
+  }
+
+  /// Ceiling implementation.
+  /// \param arg value to round
+  /// \return rounded value
+  static half ceil(half arg) {
+    return half(binary, round_half<std::round_toward_infinity>(arg.data_));
+  }
+
+  /// Truncation implementation.
+  /// \param arg value to round
+  /// \return rounded value
+  static half trunc(half arg) {
+    return half(binary, round_half<std::round_toward_zero>(arg.data_));
+  }
+
+  /// Nearest integer implementation.
+  /// \param arg value to round
+  /// \return rounded value
+  static half round(half arg) { return half(binary, round_half_up(arg.data_)); }
+
+  /// Nearest integer implementation.
+  /// \param arg value to round
+  /// \return rounded value
+  static long lround(half arg) { return detail::half2int_up<long>(arg.data_); }
+
+  /// Nearest integer implementation.
+  /// \param arg value to round
+  /// \return rounded value
+  static half rint(half arg) {
+    return half(binary, round_half<half::round_style>(arg.data_));
+  }
+
+  /// Nearest integer implementation.
+  /// \param arg value to round
+  /// \return rounded value
+  static long lrint(half arg) {
+    return detail::half2int<half::round_style, long>(arg.data_);
+  }
+
+#if HALF_ENABLE_CPP11_LONG_LONG
+  /// Nearest integer implementation.
+  /// \param arg value to round
+  /// \return rounded value
+  static long long llround(half arg) {
+    return detail::half2int_up<long long>(arg.data_);
+  }
+
+  /// Nearest integer implementation.
+  /// \param arg value to round
+  /// \return rounded value
+  static long long llrint(half arg) {
+    return detail::half2int<half::round_style, long long>(arg.data_);
+  }
+#endif
+
+  /// Decompression implementation.
+  /// \param arg number to decompress
+  /// \param exp address to store exponent at
+  /// \return normalized significant
+  static half frexp(half arg, int *exp) {
+    int m = arg.data_ & 0x7FFF, e = -14;
+    if (m >= 0x7C00 || !m) return *exp = 0, arg;
+    for (; m < 0x400; m <<= 1, --e)
+      ;
+    return *exp = e + (m >> 10),
+           half(binary, (arg.data_ & 0x8000) | 0x3800 | (m & 0x3FF));
+  }
+
+  /// Decompression implementation.
+  /// \param arg number to decompress
+  /// \param iptr address to store integer part at
+  /// \return fractional part
+  static half modf(half arg, half *iptr) {
+    unsigned int e = arg.data_ & 0x7FFF;
+    if (e >= 0x6400)
+      return *iptr = arg, half(binary, arg.data_ & (0x8000U | -(e > 0x7C00)));
+    if (e < 0x3C00) return iptr->data_ = arg.data_ & 0x8000, arg;
+    e >>= 10;
+    unsigned int mask = (1 << (25 - e)) - 1, m = arg.data_ & mask;
+    iptr->data_ = arg.data_ & ~mask;
+    if (!m) return half(binary, arg.data_ & 0x8000);
+    for (; m < 0x400; m <<= 1, --e)
+      ;
+    return half(binary, static_cast<uint16>((arg.data_ & 0x8000) | (e << 10) |
+                                            (m & 0x3FF)));
+  }
+
+  /// Scaling implementation.
+  /// \param arg number to scale
+  /// \param exp power of two to scale by
+  /// \return scaled number
+  static half scalbln(half arg, long exp) {
+    unsigned int m = arg.data_ & 0x7FFF;
+    if (m >= 0x7C00 || !m) return arg;
+    for (; m < 0x400; m <<= 1, --exp)
+      ;
+    exp += m >> 10;
+    uint16 value = arg.data_ & 0x8000;
+    if (exp > 30) {
+      if (half::round_style == std::round_toward_zero)
+        value |= 0x7BFF;
+      else if (half::round_style == std::round_toward_infinity)
+        value |= 0x7C00 - (value >> 15);
+      else if (half::round_style == std::round_toward_neg_infinity)
+        value |= 0x7BFF + (value >> 15);
+      else
+        value |= 0x7C00;
+    } else if (exp > 0)
+      value |= (exp << 10) | (m & 0x3FF);
+    else if (exp > -11) {
+      m = (m & 0x3FF) | 0x400;
+      if (half::round_style == std::round_to_nearest) {
+        m += 1 << -exp;
+#if HALF_ROUND_TIES_TO_EVEN
+        m -= (m >> (1 - exp)) & 1;
+#endif
+      } else if (half::round_style == std::round_toward_infinity)
+        m += ((value >> 15) - 1) & ((1 << (1 - exp)) - 1U);
+      else if (half::round_style == std::round_toward_neg_infinity)
+        m += -(value >> 15) & ((1 << (1 - exp)) - 1U);
+      value |= m >> (1 - exp);
+    } else if (half::round_style == std::round_toward_infinity)
+      value -= (value >> 15) - 1;
+    else if (half::round_style == std::round_toward_neg_infinity)
+      value += value >> 15;
+    return half(binary, value);
+  }
+
+  /// Exponent implementation.
+  /// \param arg number to query
+  /// \return floating point exponent
+  static int ilogb(half arg) {
+    int abs = arg.data_ & 0x7FFF;
+    if (!abs) return FP_ILOGB0;
+    if (abs < 0x7C00) {
+      int exp = (abs >> 10) - 15;
+      if (abs < 0x400)
+        for (; abs < 0x200; abs <<= 1, --exp)
+          ;
+      return exp;
+    }
+    if (abs > 0x7C00) return FP_ILOGBNAN;
+    return INT_MAX;
+  }
+
+  /// Exponent implementation.
+  /// \param arg number to query
+  /// \return floating point exponent
+  static half logb(half arg) {
+    int abs = arg.data_ & 0x7FFF;
+    if (!abs) return half(binary, 0xFC00);
+    if (abs < 0x7C00) {
+      int exp = (abs >> 10) - 15;
+      if (abs < 0x400)
+        for (; abs < 0x200; abs <<= 1, --exp)
+          ;
+      uint16 bits = (exp < 0) << 15;
+      if (exp) {
+        unsigned int m = std::abs(exp) << 6, e = 18;
+        for (; m < 0x400; m <<= 1, --e)
+          ;
+        bits |= (e << 10) + m;
+      }
+      return half(binary, bits);
+    }
+    if (abs > 0x7C00) return arg;
+    return half(binary, 0x7C00);
+  }
+
+  /// Enumeration implementation.
+  /// \param from number to increase/decrease
+  /// \param to direction to enumerate into
+  /// \return next representable number
+  static half nextafter(half from, half to) {
+    uint16 fabs = from.data_ & 0x7FFF, tabs = to.data_ & 0x7FFF;
+    if (fabs > 0x7C00) return from;
+    if (tabs > 0x7C00 || from.data_ == to.data_ || !(fabs | tabs)) return to;
+    if (!fabs) return half(binary, (to.data_ & 0x8000) + 1);
+    bool lt =
+        ((fabs == from.data_) ? static_cast<int>(fabs)
+                              : -static_cast<int>(fabs)) <
+        ((tabs == to.data_) ? static_cast<int>(tabs) : -static_cast<int>(tabs));
+    return half(binary,
+                from.data_ +
+                    (((from.data_ >> 15) ^ static_cast<unsigned>(lt)) << 1) -
+                    1);
+  }
+
+  /// Enumeration implementation.
+  /// \param from number to increase/decrease
+  /// \param to direction to enumerate into
+  /// \return next representable number
+  static half nexttoward(half from, long double to) {
+    if (isnan(from)) return from;
+    long double lfrom = static_cast<long double>(from);
+    if (builtin_isnan(to) || lfrom == to) return half(static_cast<float>(to));
+    if (!(from.data_ & 0x7FFF))
+      return half(binary,
+                  (static_cast<detail::uint16>(builtin_signbit(to)) << 15) + 1);
+    return half(
+        binary,
+        from.data_ +
+            (((from.data_ >> 15) ^ static_cast<unsigned>(lfrom < to)) << 1) -
+            1);
+  }
+
+  /// Sign implementation
+  /// \param x first operand
+  /// \param y second operand
+  /// \return composed value
+  static half copysign(half x, half y) {
+    return half(binary, x.data_ ^ ((x.data_ ^ y.data_) & 0x8000));
+  }
+
+  /// Classification implementation.
+  /// \param arg value to classify
+  /// \retval true if infinite number
+  /// \retval false else
+  static int fpclassify(half arg) {
+    unsigned int abs = arg.data_ & 0x7FFF;
+    return abs ? ((abs > 0x3FF) ? ((abs >= 0x7C00)
+                                       ? ((abs > 0x7C00) ? FP_NAN : FP_INFINITE)
+                                       : FP_NORMAL)
+                                : FP_SUBNORMAL)
+               : FP_ZERO;
+  }
+
+  /// Classification implementation.
+  /// \param arg value to classify
+  /// \retval true if finite number
+  /// \retval false else
+  static bool isfinite(half arg) { return (arg.data_ & 0x7C00) != 0x7C00; }
+
+  /// Classification implementation.
+  /// \param arg value to classify
+  /// \retval true if infinite number
+  /// \retval false else
+  static bool isinf(half arg) { return (arg.data_ & 0x7FFF) == 0x7C00; }
+
+  /// Classification implementation.
+  /// \param arg value to classify
+  /// \retval true if not a number
+  /// \retval false else
+  static bool isnan(half arg) { return (arg.data_ & 0x7FFF) > 0x7C00; }
+
+  /// Classification implementation.
+  /// \param arg value to classify
+  /// \retval true if normal number
+  /// \retval false else
+  static bool isnormal(half arg) {
+    return ((arg.data_ & 0x7C00) != 0) & ((arg.data_ & 0x7C00) != 0x7C00);
+  }
+
+  /// Sign bit implementation.
+  /// \param arg value to check
+  /// \retval true if signed
+  /// \retval false if unsigned
+  static bool signbit(half arg) { return (arg.data_ & 0x8000) != 0; }
+
+  /// Comparison implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \retval true if operands equal
+  /// \retval false else
+  static bool isequal(half x, half y) {
+    return (x.data_ == y.data_ || !((x.data_ | y.data_) & 0x7FFF)) && !isnan(x);
+  }
+
+  /// Comparison implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \retval true if operands not equal
+  /// \retval false else
+  static bool isnotequal(half x, half y) {
+    return (x.data_ != y.data_ && ((x.data_ | y.data_) & 0x7FFF)) || isnan(x);
+  }
+
+  /// Comparison implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \retval true if \a x > \a y
+  /// \retval false else
+  static bool isgreater(half x, half y) {
+    int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
+    return xabs <= 0x7C00 && yabs <= 0x7C00 &&
+           (((xabs == x.data_) ? xabs : -xabs) >
+            ((yabs == y.data_) ? yabs : -yabs));
+  }
+
+  /// Comparison implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \retval true if \a x >= \a y
+  /// \retval false else
+  static bool isgreaterequal(half x, half y) {
+    int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
+    return xabs <= 0x7C00 && yabs <= 0x7C00 &&
+           (((xabs == x.data_) ? xabs : -xabs) >=
+            ((yabs == y.data_) ? yabs : -yabs));
+  }
+
+  /// Comparison implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \retval true if \a x < \a y
+  /// \retval false else
+  static bool isless(half x, half y) {
+    int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
+    return xabs <= 0x7C00 && yabs <= 0x7C00 &&
+           (((xabs == x.data_) ? xabs : -xabs) <
+            ((yabs == y.data_) ? yabs : -yabs));
+  }
+
+  /// Comparison implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \retval true if \a x <= \a y
+  /// \retval false else
+  static bool islessequal(half x, half y) {
+    int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
+    return xabs <= 0x7C00 && yabs <= 0x7C00 &&
+           (((xabs == x.data_) ? xabs : -xabs) <=
+            ((yabs == y.data_) ? yabs : -yabs));
+  }
+
+  /// Comparison implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \retval true if either \a x > \a y nor \a x < \a y
+  /// \retval false else
+  static bool islessgreater(half x, half y) {
+    int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
+    if (xabs > 0x7C00 || yabs > 0x7C00) return false;
+    int a = (xabs == x.data_) ? xabs : -xabs,
+        b = (yabs == y.data_) ? yabs : -yabs;
+    return a < b || a > b;
+  }
+
+  /// Comparison implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \retval true if operand unordered
+  /// \retval false else
+  static bool isunordered(half x, half y) { return isnan(x) || isnan(y); }
+
+ private:
+  static double erf(double arg) {
+    if (builtin_isinf(arg)) return (arg < 0.0) ? -1.0 : 1.0;
+    double x2 = arg * arg, ax2 = 0.147 * x2,
+           value = std::sqrt(
+               1.0 - std::exp(-x2 * (1.2732395447351626861510701069801 + ax2) /
+                              (1.0 + ax2)));
+    return builtin_signbit(arg) ? -value : value;
+  }
+
+  static double lgamma(double arg) {
+    double v = 1.0;
+    for (; arg < 8.0; ++arg) v *= arg;
+    double w = 1.0 / (arg * arg);
+    return (((((((-0.02955065359477124183006535947712 * w +
+                  0.00641025641025641025641025641026) *
+                     w +
+                 -0.00191752691752691752691752691753) *
+                    w +
+                8.4175084175084175084175084175084e-4) *
+                   w +
+               -5.952380952380952380952380952381e-4) *
+                  w +
+              7.9365079365079365079365079365079e-4) *
+                 w +
+             -0.00277777777777777777777777777778) *
+                w +
+            0.08333333333333333333333333333333) /
+               arg +
+           0.91893853320467274178032973640562 - std::log(v) - arg +
+           (arg - 0.5) * std::log(arg);
+  }
+};
+
+/// Wrapper for unary half-precision functions needing specialization for
+/// individual argument types. \tparam T argument type
+template <typename T>
+struct unary_specialized {
+  /// Negation implementation.
+  /// \param arg value to negate
+  /// \return negated value
+  static HALF_CONSTEXPR half negate(half arg) {
+    return half(binary, arg.data_ ^ 0x8000);
+  }
+
+  /// Absolute value implementation.
+  /// \param arg function argument
+  /// \return absolute value
+  static half fabs(half arg) { return half(binary, arg.data_ & 0x7FFF); }
+};
+template <>
+struct unary_specialized<expr> {
+  static HALF_CONSTEXPR expr negate(float arg) { return expr(-arg); }
+  static expr fabs(float arg) { return expr(std::fabs(arg)); }
+};
+
+/// Wrapper for binary half-precision functions needing specialization for
+/// individual argument types. \tparam T first argument type \tparam U first
+/// argument type
+template <typename T, typename U>
+struct binary_specialized {
+  /// Minimum implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \return minimum value
+  static expr fmin(float x, float y) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::fmin(x, y));
+#else
+    if (builtin_isnan(x)) return expr(y);
+    if (builtin_isnan(y)) return expr(x);
+    return expr(std::min(x, y));
+#endif
+  }
+
+  /// Maximum implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \return maximum value
+  static expr fmax(float x, float y) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::fmax(x, y));
+#else
+    if (builtin_isnan(x)) return expr(y);
+    if (builtin_isnan(y)) return expr(x);
+    return expr(std::max(x, y));
+#endif
+  }
+};
+template <>
+struct binary_specialized<half, half> {
+  static half fmin(half x, half y) {
+    int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
+    if (xabs > 0x7C00) return y;
+    if (yabs > 0x7C00) return x;
+    return (((xabs == x.data_) ? xabs : -xabs) >
+            ((yabs == y.data_) ? yabs : -yabs))
+               ? y
+               : x;
+  }
+  static half fmax(half x, half y) {
+    int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
+    if (xabs > 0x7C00) return y;
+    if (yabs > 0x7C00) return x;
+    return (((xabs == x.data_) ? xabs : -xabs) <
+            ((yabs == y.data_) ? yabs : -yabs))
+               ? y
+               : x;
+  }
+};
+
+/// Helper class for half casts.
+/// This class template has to be specialized for all valid cast argument to
+/// define an appropriate static `cast` member function and a corresponding
+/// `type` member denoting its return type. \tparam T destination type \tparam U
+/// source type \tparam R rounding mode to use
+template <typename T, typename U,
+          std::float_round_style R = (std::float_round_style)(HALF_ROUND_STYLE)>
+struct half_caster {};
+template <typename U, std::float_round_style R>
+struct half_caster<half, U, R> {
+#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
+  static_assert(std::is_arithmetic<U>::value,
+                "half_cast from non-arithmetic type unsupported");
+#endif
+
+  static half cast(U arg) { return cast_impl(arg, is_float<U>()); };
+
+ private:
+  static half cast_impl(U arg, true_type) {
+    return half(binary, float2half<R>(arg));
+  }
+  static half cast_impl(U arg, false_type) {
+    return half(binary, int2half<R>(arg));
+  }
+};
+template <typename T, std::float_round_style R>
+struct half_caster<T, half, R> {
+#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
+  static_assert(std::is_arithmetic<T>::value,
+                "half_cast to non-arithmetic type unsupported");
+#endif
+
+  static T cast(half arg) { return cast_impl(arg, is_float<T>()); }
+
+ private:
+  static T cast_impl(half arg, true_type) { return half2float<T>(arg.data_); }
+  static T cast_impl(half arg, false_type) { return half2int<R, T>(arg.data_); }
+};
+template <typename T, std::float_round_style R>
+struct half_caster<T, expr, R> {
+#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
+  static_assert(std::is_arithmetic<T>::value,
+                "half_cast to non-arithmetic type unsupported");
+#endif
+
+  static T cast(expr arg) { return cast_impl(arg, is_float<T>()); }
+
+ private:
+  static T cast_impl(float arg, true_type) { return static_cast<T>(arg); }
+  static T cast_impl(half arg, false_type) { return half2int<R, T>(arg.data_); }
+};
+template <std::float_round_style R>
+struct half_caster<half, half, R> {
+  static half cast(half arg) { return arg; }
+};
+template <std::float_round_style R>
+struct half_caster<half, expr, R> : half_caster<half, half, R> {};
+
+/// \name Comparison operators
+/// \{
+
+/// Comparison for equality.
+/// \param x first operand
+/// \param y second operand
+/// \retval true if operands equal
+/// \retval false else
+template <typename T, typename U>
+typename enable<bool, T, U>::type operator==(T x, U y) {
+  return functions::isequal(x, y);
+}
+
+/// Comparison for inequality.
+/// \param x first operand
+/// \param y second operand
+/// \retval true if operands not equal
+/// \retval false else
+template <typename T, typename U>
+typename enable<bool, T, U>::type operator!=(T x, U y) {
+  return functions::isnotequal(x, y);
+}
+
+/// Comparison for less than.
+/// \param x first operand
+/// \param y second operand
+/// \retval true if \a x less than \a y
+/// \retval false else
+template <typename T, typename U>
+typename enable<bool, T, U>::type operator<(T x, U y) {
+  return functions::isless(x, y);
+}
+
+/// Comparison for greater than.
+/// \param x first operand
+/// \param y second operand
+/// \retval true if \a x greater than \a y
+/// \retval false else
+template <typename T, typename U>
+typename enable<bool, T, U>::type operator>(T x, U y) {
+  return functions::isgreater(x, y);
+}
+
+/// Comparison for less equal.
+/// \param x first operand
+/// \param y second operand
+/// \retval true if \a x less equal \a y
+/// \retval false else
+template <typename T, typename U>
+typename enable<bool, T, U>::type operator<=(T x, U y) {
+  return functions::islessequal(x, y);
+}
+
+/// Comparison for greater equal.
+/// \param x first operand
+/// \param y second operand
+/// \retval true if \a x greater equal \a y
+/// \retval false else
+template <typename T, typename U>
+typename enable<bool, T, U>::type operator>=(T x, U y) {
+  return functions::isgreaterequal(x, y);
+}
+
+/// \}
+/// \name Arithmetic operators
+/// \{
+
+/// Add halfs.
+/// \param x left operand
+/// \param y right operand
+/// \return sum of half expressions
+template <typename T, typename U>
+typename enable<expr, T, U>::type operator+(T x, U y) {
+  return functions::plus(x, y);
+}
+
+/// Subtract halfs.
+/// \param x left operand
+/// \param y right operand
+/// \return difference of half expressions
+template <typename T, typename U>
+typename enable<expr, T, U>::type operator-(T x, U y) {
+  return functions::minus(x, y);
+}
+
+/// Multiply halfs.
+/// \param x left operand
+/// \param y right operand
+/// \return product of half expressions
+template <typename T, typename U>
+typename enable<expr, T, U>::type operator*(T x, U y) {
+  return functions::multiplies(x, y);
+}
+
+/// Divide halfs.
+/// \param x left operand
+/// \param y right operand
+/// \return quotient of half expressions
+template <typename T, typename U>
+typename enable<expr, T, U>::type operator/(T x, U y) {
+  return functions::divides(x, y);
+}
+
+/// Identity.
+/// \param arg operand
+/// \return uncahnged operand
+template <typename T>
+HALF_CONSTEXPR typename enable<T, T>::type operator+(T arg) {
+  return arg;
+}
+
+/// Negation.
+/// \param arg operand
+/// \return negated operand
+template <typename T>
+HALF_CONSTEXPR typename enable<T, T>::type operator-(T arg) {
+  return unary_specialized<T>::negate(arg);
+}
+
+/// \}
+/// \name Input and output
+/// \{
+
+/// Output operator.
+/// \param out output stream to write into
+/// \param arg half expression to write
+/// \return reference to output stream
+template <typename T, typename charT, typename traits>
+typename enable<std::basic_ostream<charT, traits> &, T>::type operator<<(
+    std::basic_ostream<charT, traits> &out, T arg) {
+  return functions::write(out, arg);
+}
+
+/// Input operator.
+/// \param in input stream to read from
+/// \param arg half to read into
+/// \return reference to input stream
+template <typename charT, typename traits>
+std::basic_istream<charT, traits> &operator>>(
+    std::basic_istream<charT, traits> &in, half &arg) {
+  return functions::read(in, arg);
+}
+
+/// \}
+/// \name Basic mathematical operations
+/// \{
+
+/// Absolute value.
+/// \param arg operand
+/// \return absolute value of \a arg
+//		template<typename T> typename enable<T,T>::type abs(T arg) {
+//return unary_specialized<T>::fabs(arg); }
+inline half abs(half arg) { return unary_specialized<half>::fabs(arg); }
+inline expr abs(expr arg) { return unary_specialized<expr>::fabs(arg); }
+
+/// Absolute value.
+/// \param arg operand
+/// \return absolute value of \a arg
+//		template<typename T> typename enable<T,T>::type fabs(T arg) {
+//return unary_specialized<T>::fabs(arg); }
+inline half fabs(half arg) { return unary_specialized<half>::fabs(arg); }
+inline expr fabs(expr arg) { return unary_specialized<expr>::fabs(arg); }
+
+/// Remainder of division.
+/// \param x first operand
+/// \param y second operand
+/// \return remainder of floating point division.
+//		template<typename T,typename U> typename enable<expr,T,U>::type
+//fmod(T x, U y) { return functions::fmod(x, y); }
+inline expr fmod(half x, half y) { return functions::fmod(x, y); }
+inline expr fmod(half x, expr y) { return functions::fmod(x, y); }
+inline expr fmod(expr x, half y) { return functions::fmod(x, y); }
+inline expr fmod(expr x, expr y) { return functions::fmod(x, y); }
+
+/// Remainder of division.
+/// \param x first operand
+/// \param y second operand
+/// \return remainder of floating point division.
+//		template<typename T,typename U> typename enable<expr,T,U>::type
+//remainder(T x, U y) { return functions::remainder(x, y); }
+inline expr remainder(half x, half y) { return functions::remainder(x, y); }
+inline expr remainder(half x, expr y) { return functions::remainder(x, y); }
+inline expr remainder(expr x, half y) { return functions::remainder(x, y); }
+inline expr remainder(expr x, expr y) { return functions::remainder(x, y); }
+
+/// Remainder of division.
+/// \param x first operand
+/// \param y second operand
+/// \param quo address to store some bits of quotient at
+/// \return remainder of floating point division.
+//		template<typename T,typename U> typename enable<expr,T,U>::type
+//remquo(T x, U y, int *quo) { return functions::remquo(x, y, quo); }
+inline expr remquo(half x, half y, int *quo) {
+  return functions::remquo(x, y, quo);
+}
+inline expr remquo(half x, expr y, int *quo) {
+  return functions::remquo(x, y, quo);
+}
+inline expr remquo(expr x, half y, int *quo) {
+  return functions::remquo(x, y, quo);
+}
+inline expr remquo(expr x, expr y, int *quo) {
+  return functions::remquo(x, y, quo);
+}
+
+/// Fused multiply add.
+/// \param x first operand
+/// \param y second operand
+/// \param z third operand
+/// \return ( \a x * \a y ) + \a z rounded as one operation.
+//		template<typename T,typename U,typename V> typename
+//enable<expr,T,U,V>::type fma(T x, U y, V z) { return functions::fma(x, y, z);
+//}
+inline expr fma(half x, half y, half z) { return functions::fma(x, y, z); }
+inline expr fma(half x, half y, expr z) { return functions::fma(x, y, z); }
+inline expr fma(half x, expr y, half z) { return functions::fma(x, y, z); }
+inline expr fma(half x, expr y, expr z) { return functions::fma(x, y, z); }
+inline expr fma(expr x, half y, half z) { return functions::fma(x, y, z); }
+inline expr fma(expr x, half y, expr z) { return functions::fma(x, y, z); }
+inline expr fma(expr x, expr y, half z) { return functions::fma(x, y, z); }
+inline expr fma(expr x, expr y, expr z) { return functions::fma(x, y, z); }
+
+/// Maximum of half expressions.
+/// \param x first operand
+/// \param y second operand
+/// \return maximum of operands
+//		template<typename T,typename U> typename result<T,U>::type fmax(T
+//x, U y) { return binary_specialized<T,U>::fmax(x, y); }
+inline half fmax(half x, half y) {
+  return binary_specialized<half, half>::fmax(x, y);
+}
+inline expr fmax(half x, expr y) {
+  return binary_specialized<half, expr>::fmax(x, y);
+}
+inline expr fmax(expr x, half y) {
+  return binary_specialized<expr, half>::fmax(x, y);
+}
+inline expr fmax(expr x, expr y) {
+  return binary_specialized<expr, expr>::fmax(x, y);
+}
+
+/// Minimum of half expressions.
+/// \param x first operand
+/// \param y second operand
+/// \return minimum of operands
+//		template<typename T,typename U> typename result<T,U>::type fmin(T
+//x, U y) { return binary_specialized<T,U>::fmin(x, y); }
+inline half fmin(half x, half y) {
+  return binary_specialized<half, half>::fmin(x, y);
+}
+inline expr fmin(half x, expr y) {
+  return binary_specialized<half, expr>::fmin(x, y);
+}
+inline expr fmin(expr x, half y) {
+  return binary_specialized<expr, half>::fmin(x, y);
+}
+inline expr fmin(expr x, expr y) {
+  return binary_specialized<expr, expr>::fmin(x, y);
+}
+
+/// Positive difference.
+/// \param x first operand
+/// \param y second operand
+/// \return \a x - \a y or 0 if difference negative
+//		template<typename T,typename U> typename enable<expr,T,U>::type
+//fdim(T x, U y) { return functions::fdim(x, y); }
+inline expr fdim(half x, half y) { return functions::fdim(x, y); }
+inline expr fdim(half x, expr y) { return functions::fdim(x, y); }
+inline expr fdim(expr x, half y) { return functions::fdim(x, y); }
+inline expr fdim(expr x, expr y) { return functions::fdim(x, y); }
+
+/// Get NaN value.
+/// \return quiet NaN
+inline half nanh(const char *) { return functions::nanh(); }
+
+/// \}
+/// \name Exponential functions
+/// \{
+
+/// Exponential function.
+/// \param arg function argument
+/// \return e raised to \a arg
+//		template<typename T> typename enable<expr,T>::type exp(T arg) {
+//return functions::exp(arg); }
+inline expr exp(half arg) { return functions::exp(arg); }
+inline expr exp(expr arg) { return functions::exp(arg); }
+
+/// Exponential minus one.
+/// \param arg function argument
+/// \return e raised to \a arg subtracted by 1
+//		template<typename T> typename enable<expr,T>::type expm1(T arg) {
+//return functions::expm1(arg); }
+inline expr expm1(half arg) { return functions::expm1(arg); }
+inline expr expm1(expr arg) { return functions::expm1(arg); }
+
+/// Binary exponential.
+/// \param arg function argument
+/// \return 2 raised to \a arg
+//		template<typename T> typename enable<expr,T>::type exp2(T arg) {
+//return functions::exp2(arg); }
+inline expr exp2(half arg) { return functions::exp2(arg); }
+inline expr exp2(expr arg) { return functions::exp2(arg); }
+
+/// Natural logorithm.
+/// \param arg function argument
+/// \return logarithm of \a arg to base e
+//		template<typename T> typename enable<expr,T>::type log(T arg) {
+//return functions::log(arg); }
+inline expr log(half arg) { return functions::log(arg); }
+inline expr log(expr arg) { return functions::log(arg); }
+
+/// Common logorithm.
+/// \param arg function argument
+/// \return logarithm of \a arg to base 10
+//		template<typename T> typename enable<expr,T>::type log10(T arg) {
+//return functions::log10(arg); }
+inline expr log10(half arg) { return functions::log10(arg); }
+inline expr log10(expr arg) { return functions::log10(arg); }
+
+/// Natural logorithm.
+/// \param arg function argument
+/// \return logarithm of \a arg plus 1 to base e
+//		template<typename T> typename enable<expr,T>::type log1p(T arg) {
+//return functions::log1p(arg); }
+inline expr log1p(half arg) { return functions::log1p(arg); }
+inline expr log1p(expr arg) { return functions::log1p(arg); }
+
+/// Binary logorithm.
+/// \param arg function argument
+/// \return logarithm of \a arg to base 2
+//		template<typename T> typename enable<expr,T>::type log2(T arg) {
+//return functions::log2(arg); }
+inline expr log2(half arg) { return functions::log2(arg); }
+inline expr log2(expr arg) { return functions::log2(arg); }
+
+/// \}
+/// \name Power functions
+/// \{
+
+/// Square root.
+/// \param arg function argument
+/// \return square root of \a arg
+//		template<typename T> typename enable<expr,T>::type sqrt(T arg) {
+//return functions::sqrt(arg); }
+inline expr sqrt(half arg) { return functions::sqrt(arg); }
+inline expr sqrt(expr arg) { return functions::sqrt(arg); }
+
+/// Cubic root.
+/// \param arg function argument
+/// \return cubic root of \a arg
+//		template<typename T> typename enable<expr,T>::type cbrt(T arg) {
+//return functions::cbrt(arg); }
+inline expr cbrt(half arg) { return functions::cbrt(arg); }
+inline expr cbrt(expr arg) { return functions::cbrt(arg); }
+
+/// Hypotenuse function.
+/// \param x first argument
+/// \param y second argument
+/// \return square root of sum of squares without internal over- or underflows
+//		template<typename T,typename U> typename enable<expr,T,U>::type
+//hypot(T x, U y) { return functions::hypot(x, y); }
+inline expr hypot(half x, half y) { return functions::hypot(x, y); }
+inline expr hypot(half x, expr y) { return functions::hypot(x, y); }
+inline expr hypot(expr x, half y) { return functions::hypot(x, y); }
+inline expr hypot(expr x, expr y) { return functions::hypot(x, y); }
+
+/// Power function.
+/// \param base first argument
+/// \param exp second argument
+/// \return \a base raised to \a exp
+//		template<typename T,typename U> typename enable<expr,T,U>::type
+//pow(T base, U exp) { return functions::pow(base, exp); }
+inline expr pow(half base, half exp) { return functions::pow(base, exp); }
+inline expr pow(half base, expr exp) { return functions::pow(base, exp); }
+inline expr pow(expr base, half exp) { return functions::pow(base, exp); }
+inline expr pow(expr base, expr exp) { return functions::pow(base, exp); }
+
+/// \}
+/// \name Trigonometric functions
+/// \{
+
+/// Sine function.
+/// \param arg function argument
+/// \return sine value of \a arg
+//		template<typename T> typename enable<expr,T>::type sin(T arg) {
+//return functions::sin(arg); }
+inline expr sin(half arg) { return functions::sin(arg); }
+inline expr sin(expr arg) { return functions::sin(arg); }
+
+/// Cosine function.
+/// \param arg function argument
+/// \return cosine value of \a arg
+//		template<typename T> typename enable<expr,T>::type cos(T arg) {
+//return functions::cos(arg); }
+inline expr cos(half arg) { return functions::cos(arg); }
+inline expr cos(expr arg) { return functions::cos(arg); }
+
+/// Tangent function.
+/// \param arg function argument
+/// \return tangent value of \a arg
+//		template<typename T> typename enable<expr,T>::type tan(T arg) {
+//return functions::tan(arg); }
+inline expr tan(half arg) { return functions::tan(arg); }
+inline expr tan(expr arg) { return functions::tan(arg); }
+
+/// Arc sine.
+/// \param arg function argument
+/// \return arc sine value of \a arg
+//		template<typename T> typename enable<expr,T>::type asin(T arg) {
+//return functions::asin(arg); }
+inline expr asin(half arg) { return functions::asin(arg); }
+inline expr asin(expr arg) { return functions::asin(arg); }
+
+/// Arc cosine function.
+/// \param arg function argument
+/// \return arc cosine value of \a arg
+//		template<typename T> typename enable<expr,T>::type acos(T arg) {
+//return functions::acos(arg); }
+inline expr acos(half arg) { return functions::acos(arg); }
+inline expr acos(expr arg) { return functions::acos(arg); }
+
+/// Arc tangent function.
+/// \param arg function argument
+/// \return arc tangent value of \a arg
+//		template<typename T> typename enable<expr,T>::type atan(T arg) {
+//return functions::atan(arg); }
+inline expr atan(half arg) { return functions::atan(arg); }
+inline expr atan(expr arg) { return functions::atan(arg); }
+
+/// Arc tangent function.
+/// \param x first argument
+/// \param y second argument
+/// \return arc tangent value
+//		template<typename T,typename U> typename enable<expr,T,U>::type
+//atan2(T x, U y) { return functions::atan2(x, y); }
+inline expr atan2(half x, half y) { return functions::atan2(x, y); }
+inline expr atan2(half x, expr y) { return functions::atan2(x, y); }
+inline expr atan2(expr x, half y) { return functions::atan2(x, y); }
+inline expr atan2(expr x, expr y) { return functions::atan2(x, y); }
+
+/// \}
+/// \name Hyperbolic functions
+/// \{
+
+/// Hyperbolic sine.
+/// \param arg function argument
+/// \return hyperbolic sine value of \a arg
+//		template<typename T> typename enable<expr,T>::type sinh(T arg) {
+//return functions::sinh(arg); }
+inline expr sinh(half arg) { return functions::sinh(arg); }
+inline expr sinh(expr arg) { return functions::sinh(arg); }
+
+/// Hyperbolic cosine.
+/// \param arg function argument
+/// \return hyperbolic cosine value of \a arg
+//		template<typename T> typename enable<expr,T>::type cosh(T arg) {
+//return functions::cosh(arg); }
+inline expr cosh(half arg) { return functions::cosh(arg); }
+inline expr cosh(expr arg) { return functions::cosh(arg); }
+
+/// Hyperbolic tangent.
+/// \param arg function argument
+/// \return hyperbolic tangent value of \a arg
+//		template<typename T> typename enable<expr,T>::type tanh(T arg) {
+//return functions::tanh(arg); }
+inline expr tanh(half arg) { return functions::tanh(arg); }
+inline expr tanh(expr arg) { return functions::tanh(arg); }
+
+/// Hyperbolic area sine.
+/// \param arg function argument
+/// \return area sine value of \a arg
+//		template<typename T> typename enable<expr,T>::type asinh(T arg) {
+//return functions::asinh(arg); }
+inline expr asinh(half arg) { return functions::asinh(arg); }
+inline expr asinh(expr arg) { return functions::asinh(arg); }
+
+/// Hyperbolic area cosine.
+/// \param arg function argument
+/// \return area cosine value of \a arg
+//		template<typename T> typename enable<expr,T>::type acosh(T arg) {
+//return functions::acosh(arg); }
+inline expr acosh(half arg) { return functions::acosh(arg); }
+inline expr acosh(expr arg) { return functions::acosh(arg); }
+
+/// Hyperbolic area tangent.
+/// \param arg function argument
+/// \return area tangent value of \a arg
+//		template<typename T> typename enable<expr,T>::type atanh(T arg) {
+//return functions::atanh(arg); }
+inline expr atanh(half arg) { return functions::atanh(arg); }
+inline expr atanh(expr arg) { return functions::atanh(arg); }
+
+/// \}
+/// \name Error and gamma functions
+/// \{
+
+/// Error function.
+/// \param arg function argument
+/// \return error function value of \a arg
+//		template<typename T> typename enable<expr,T>::type erf(T arg) {
+//return functions::erf(arg); }
+inline expr erf(half arg) { return functions::erf(arg); }
+inline expr erf(expr arg) { return functions::erf(arg); }
+
+/// Complementary error function.
+/// \param arg function argument
+/// \return 1 minus error function value of \a arg
+//		template<typename T> typename enable<expr,T>::type erfc(T arg) {
+//return functions::erfc(arg); }
+inline expr erfc(half arg) { return functions::erfc(arg); }
+inline expr erfc(expr arg) { return functions::erfc(arg); }
+
+/// Natural logarithm of gamma function.
+/// \param arg function argument
+/// \return natural logarith of gamma function for \a arg
+//		template<typename T> typename enable<expr,T>::type lgamma(T arg) {
+//return functions::lgamma(arg); }
+inline expr lgamma(half arg) { return functions::lgamma(arg); }
+inline expr lgamma(expr arg) { return functions::lgamma(arg); }
+
+/// Gamma function.
+/// \param arg function argument
+/// \return gamma function value of \a arg
+//		template<typename T> typename enable<expr,T>::type tgamma(T arg) {
+//return functions::tgamma(arg); }
+inline expr tgamma(half arg) { return functions::tgamma(arg); }
+inline expr tgamma(expr arg) { return functions::tgamma(arg); }
+
+/// \}
+/// \name Rounding
+/// \{
+
+/// Nearest integer not less than half value.
+/// \param arg half to round
+/// \return nearest integer not less than \a arg
+//		template<typename T> typename enable<half,T>::type ceil(T arg) {
+//return functions::ceil(arg); }
+inline half ceil(half arg) { return functions::ceil(arg); }
+inline half ceil(expr arg) { return functions::ceil(arg); }
+
+/// Nearest integer not greater than half value.
+/// \param arg half to round
+/// \return nearest integer not greater than \a arg
+//		template<typename T> typename enable<half,T>::type floor(T arg) {
+//return functions::floor(arg); }
+inline half floor(half arg) { return functions::floor(arg); }
+inline half floor(expr arg) { return functions::floor(arg); }
+
+/// Nearest integer not greater in magnitude than half value.
+/// \param arg half to round
+/// \return nearest integer not greater in magnitude than \a arg
+//		template<typename T> typename enable<half,T>::type trunc(T arg) {
+//return functions::trunc(arg); }
+inline half trunc(half arg) { return functions::trunc(arg); }
+inline half trunc(expr arg) { return functions::trunc(arg); }
+
+/// Nearest integer.
+/// \param arg half to round
+/// \return nearest integer, rounded away from zero in half-way cases
+//		template<typename T> typename enable<half,T>::type round(T arg) {
+//return functions::round(arg); }
+inline half round(half arg) { return functions::round(arg); }
+inline half round(expr arg) { return functions::round(arg); }
+
+/// Nearest integer.
+/// \param arg half to round
+/// \return nearest integer, rounded away from zero in half-way cases
+//		template<typename T> typename enable<long,T>::type lround(T arg) {
+//return functions::lround(arg); }
+inline long lround(half arg) { return functions::lround(arg); }
+inline long lround(expr arg) { return functions::lround(arg); }
+
+/// Nearest integer using half's internal rounding mode.
+/// \param arg half expression to round
+/// \return nearest integer using default rounding mode
+//		template<typename T> typename enable<half,T>::type nearbyint(T
+//arg) { return functions::nearbyint(arg); }
+inline half nearbyint(half arg) { return functions::rint(arg); }
+inline half nearbyint(expr arg) { return functions::rint(arg); }
+
+/// Nearest integer using half's internal rounding mode.
+/// \param arg half expression to round
+/// \return nearest integer using default rounding mode
+//		template<typename T> typename enable<half,T>::type rint(T arg) {
+//return functions::rint(arg); }
+inline half rint(half arg) { return functions::rint(arg); }
+inline half rint(expr arg) { return functions::rint(arg); }
+
+/// Nearest integer using half's internal rounding mode.
+/// \param arg half expression to round
+/// \return nearest integer using default rounding mode
+//		template<typename T> typename enable<long,T>::type lrint(T arg) {
+//return functions::lrint(arg); }
+inline long lrint(half arg) { return functions::lrint(arg); }
+inline long lrint(expr arg) { return functions::lrint(arg); }
+#if HALF_ENABLE_CPP11_LONG_LONG
+/// Nearest integer.
+/// \param arg half to round
+/// \return nearest integer, rounded away from zero in half-way cases
+//		template<typename T> typename enable<long long,T>::type llround(T
+//arg) { return functions::llround(arg); }
+inline long long llround(half arg) { return functions::llround(arg); }
+inline long long llround(expr arg) { return functions::llround(arg); }
+
+/// Nearest integer using half's internal rounding mode.
+/// \param arg half expression to round
+/// \return nearest integer using default rounding mode
+//		template<typename T> typename enable<long long,T>::type llrint(T
+//arg) { return functions::llrint(arg); }
+inline long long llrint(half arg) { return functions::llrint(arg); }
+inline long long llrint(expr arg) { return functions::llrint(arg); }
+#endif
+
+/// \}
+/// \name Floating point manipulation
+/// \{
+
+/// Decompress floating point number.
+/// \param arg number to decompress
+/// \param exp address to store exponent at
+/// \return significant in range [0.5, 1)
+//		template<typename T> typename enable<half,T>::type frexp(T arg,
+//int *exp) { return functions::frexp(arg, exp); }
+inline half frexp(half arg, int *exp) { return functions::frexp(arg, exp); }
+inline half frexp(expr arg, int *exp) { return functions::frexp(arg, exp); }
+
+/// Multiply by power of two.
+/// \param arg number to modify
+/// \param exp power of two to multiply with
+/// \return \a arg multplied by 2 raised to \a exp
+//		template<typename T> typename enable<half,T>::type ldexp(T arg,
+//int exp) { return functions::scalbln(arg, exp); }
+inline half ldexp(half arg, int exp) { return functions::scalbln(arg, exp); }
+inline half ldexp(expr arg, int exp) { return functions::scalbln(arg, exp); }
+
+/// Extract integer and fractional parts.
+/// \param arg number to decompress
+/// \param iptr address to store integer part at
+/// \return fractional part
+//		template<typename T> typename enable<half,T>::type modf(T arg,
+//half *iptr) { return functions::modf(arg, iptr); }
+inline half modf(half arg, half *iptr) { return functions::modf(arg, iptr); }
+inline half modf(expr arg, half *iptr) { return functions::modf(arg, iptr); }
+
+/// Multiply by power of two.
+/// \param arg number to modify
+/// \param exp power of two to multiply with
+/// \return \a arg multplied by 2 raised to \a exp
+//		template<typename T> typename enable<half,T>::type scalbn(T arg,
+//int exp) { return functions::scalbln(arg, exp); }
+inline half scalbn(half arg, int exp) { return functions::scalbln(arg, exp); }
+inline half scalbn(expr arg, int exp) { return functions::scalbln(arg, exp); }
+
+/// Multiply by power of two.
+/// \param arg number to modify
+/// \param exp power of two to multiply with
+/// \return \a arg multplied by 2 raised to \a exp
+//		template<typename T> typename enable<half,T>::type scalbln(T arg,
+//long exp) { return functions::scalbln(arg, exp); }
+inline half scalbln(half arg, long exp) { return functions::scalbln(arg, exp); }
+inline half scalbln(expr arg, long exp) { return functions::scalbln(arg, exp); }
+
+/// Extract exponent.
+/// \param arg number to query
+/// \return floating point exponent
+/// \retval FP_ILOGB0 for zero
+/// \retval FP_ILOGBNAN for NaN
+/// \retval MAX_INT for infinity
+//		template<typename T> typename enable<int,T>::type ilogb(T arg) {
+//return functions::ilogb(arg); }
+inline int ilogb(half arg) { return functions::ilogb(arg); }
+inline int ilogb(expr arg) { return functions::ilogb(arg); }
+
+/// Extract exponent.
+/// \param arg number to query
+/// \return floating point exponent
+//		template<typename T> typename enable<half,T>::type logb(T arg) {
+//return functions::logb(arg); }
+inline half logb(half arg) { return functions::logb(arg); }
+inline half logb(expr arg) { return functions::logb(arg); }
+
+/// Next representable value.
+/// \param from value to compute next representable value for
+/// \param to direction towards which to compute next value
+/// \return next representable value after \a from in direction towards \a to
+//		template<typename T,typename U> typename enable<half,T,U>::type
+//nextafter(T from, U to) { return functions::nextafter(from, to); }
+inline half nextafter(half from, half to) {
+  return functions::nextafter(from, to);
+}
+inline half nextafter(half from, expr to) {
+  return functions::nextafter(from, to);
+}
+inline half nextafter(expr from, half to) {
+  return functions::nextafter(from, to);
+}
+inline half nextafter(expr from, expr to) {
+  return functions::nextafter(from, to);
+}
+
+/// Next representable value.
+/// \param from value to compute next representable value for
+/// \param to direction towards which to compute next value
+/// \return next representable value after \a from in direction towards \a to
+//		template<typename T> typename enable<half,T>::type nexttoward(T
+//from, long double to) { return functions::nexttoward(from, to); }
+inline half nexttoward(half from, long double to) {
+  return functions::nexttoward(from, to);
+}
+inline half nexttoward(expr from, long double to) {
+  return functions::nexttoward(from, to);
+}
+
+/// Take sign.
+/// \param x value to change sign for
+/// \param y value to take sign from
+/// \return value equal to \a x in magnitude and to \a y in sign
+//		template<typename T,typename U> typename enable<half,T,U>::type
+//copysign(T x, U y) { return functions::copysign(x, y); }
+inline half copysign(half x, half y) { return functions::copysign(x, y); }
+inline half copysign(half x, expr y) { return functions::copysign(x, y); }
+inline half copysign(expr x, half y) { return functions::copysign(x, y); }
+inline half copysign(expr x, expr y) { return functions::copysign(x, y); }
+
+/// \}
+/// \name Floating point classification
+/// \{
+
+/// Classify floating point value.
+/// \param arg number to classify
+/// \retval FP_ZERO for positive and negative zero
+/// \retval FP_SUBNORMAL for subnormal numbers
+/// \retval FP_INFINITY for positive and negative infinity
+/// \retval FP_NAN for NaNs
+/// \retval FP_NORMAL for all other (normal) values
+//		template<typename T> typename enable<int,T>::type fpclassify(T
+//arg) { return functions::fpclassify(arg); }
+inline int fpclassify(half arg) { return functions::fpclassify(arg); }
+inline int fpclassify(expr arg) { return functions::fpclassify(arg); }
+
+/// Check if finite number.
+/// \param arg number to check
+/// \retval true if neither infinity nor NaN
+/// \retval false else
+//		template<typename T> typename enable<bool,T>::type isfinite(T arg)
+//{ return functions::isfinite(arg); }
+inline bool isfinite(half arg) { return functions::isfinite(arg); }
+inline bool isfinite(expr arg) { return functions::isfinite(arg); }
+
+/// Check for infinity.
+/// \param arg number to check
+/// \retval true for positive or negative infinity
+/// \retval false else
+//		template<typename T> typename enable<bool,T>::type isinf(T arg) {
+//return functions::isinf(arg); }
+inline bool isinf(half arg) { return functions::isinf(arg); }
+inline bool isinf(expr arg) { return functions::isinf(arg); }
+
+/// Check for NaN.
+/// \param arg number to check
+/// \retval true for NaNs
+/// \retval false else
+//		template<typename T> typename enable<bool,T>::type isnan(T arg) {
+//return functions::isnan(arg); }
+inline bool isnan(half arg) { return functions::isnan(arg); }
+inline bool isnan(expr arg) { return functions::isnan(arg); }
+
+/// Check if normal number.
+/// \param arg number to check
+/// \retval true if normal number
+/// \retval false if either subnormal, zero, infinity or NaN
+//		template<typename T> typename enable<bool,T>::type isnormal(T arg)
+//{ return functions::isnormal(arg); }
+inline bool isnormal(half arg) { return functions::isnormal(arg); }
+inline bool isnormal(expr arg) { return functions::isnormal(arg); }
+
+/// Check sign.
+/// \param arg number to check
+/// \retval true for negative number
+/// \retval false for positive number
+//		template<typename T> typename enable<bool,T>::type signbit(T arg)
+//{ return functions::signbit(arg); }
+inline bool signbit(half arg) { return functions::signbit(arg); }
+inline bool signbit(expr arg) { return functions::signbit(arg); }
+
+/// \}
+/// \name Comparison
+/// \{
+
+/// Comparison for greater than.
+/// \param x first operand
+/// \param y second operand
+/// \retval true if \a x greater than \a y
+/// \retval false else
+//		template<typename T,typename U> typename enable<bool,T,U>::type
+//isgreater(T x, U y) { return functions::isgreater(x, y); }
+inline bool isgreater(half x, half y) { return functions::isgreater(x, y); }
+inline bool isgreater(half x, expr y) { return functions::isgreater(x, y); }
+inline bool isgreater(expr x, half y) { return functions::isgreater(x, y); }
+inline bool isgreater(expr x, expr y) { return functions::isgreater(x, y); }
+
+/// Comparison for greater equal.
+/// \param x first operand
+/// \param y second operand
+/// \retval true if \a x greater equal \a y
+/// \retval false else
+//		template<typename T,typename U> typename enable<bool,T,U>::type
+//isgreaterequal(T x, U y) { return functions::isgreaterequal(x, y); }
+inline bool isgreaterequal(half x, half y) {
+  return functions::isgreaterequal(x, y);
+}
+inline bool isgreaterequal(half x, expr y) {
+  return functions::isgreaterequal(x, y);
+}
+inline bool isgreaterequal(expr x, half y) {
+  return functions::isgreaterequal(x, y);
+}
+inline bool isgreaterequal(expr x, expr y) {
+  return functions::isgreaterequal(x, y);
+}
+
+/// Comparison for less than.
+/// \param x first operand
+/// \param y second operand
+/// \retval true if \a x less than \a y
+/// \retval false else
+//		template<typename T,typename U> typename enable<bool,T,U>::type
+//isless(T x, U y) { return functions::isless(x, y); }
+inline bool isless(half x, half y) { return functions::isless(x, y); }
+inline bool isless(half x, expr y) { return functions::isless(x, y); }
+inline bool isless(expr x, half y) { return functions::isless(x, y); }
+inline bool isless(expr x, expr y) { return functions::isless(x, y); }
+
+/// Comparison for less equal.
+/// \param x first operand
+/// \param y second operand
+/// \retval true if \a x less equal \a y
+/// \retval false else
+//		template<typename T,typename U> typename enable<bool,T,U>::type
+//islessequal(T x, U y) { return functions::islessequal(x, y); }
+inline bool islessequal(half x, half y) { return functions::islessequal(x, y); }
+inline bool islessequal(half x, expr y) { return functions::islessequal(x, y); }
+inline bool islessequal(expr x, half y) { return functions::islessequal(x, y); }
+inline bool islessequal(expr x, expr y) { return functions::islessequal(x, y); }
+
+/// Comarison for less or greater.
+/// \param x first operand
+/// \param y second operand
+/// \retval true if either less or greater
+/// \retval false else
+//		template<typename T,typename U> typename enable<bool,T,U>::type
+//islessgreater(T x, U y) { return functions::islessgreater(x, y); }
+inline bool islessgreater(half x, half y) {
+  return functions::islessgreater(x, y);
+}
+inline bool islessgreater(half x, expr y) {
+  return functions::islessgreater(x, y);
+}
+inline bool islessgreater(expr x, half y) {
+  return functions::islessgreater(x, y);
+}
+inline bool islessgreater(expr x, expr y) {
+  return functions::islessgreater(x, y);
+}
+
+/// Check if unordered.
+/// \param x first operand
+/// \param y second operand
+/// \retval true if unordered (one or two NaN operands)
+/// \retval false else
+//		template<typename T,typename U> typename enable<bool,T,U>::type
+//isunordered(T x, U y) { return functions::isunordered(x, y); }
+inline bool isunordered(half x, half y) { return functions::isunordered(x, y); }
+inline bool isunordered(half x, expr y) { return functions::isunordered(x, y); }
+inline bool isunordered(expr x, half y) { return functions::isunordered(x, y); }
+inline bool isunordered(expr x, expr y) { return functions::isunordered(x, y); }
+
+/// \name Casting
+/// \{
+
+/// Cast to or from half-precision floating point number.
+/// This casts between [half](\ref half_float::half) and any built-in arithmetic
+/// type. The values are converted directly using the given rounding mode,
+/// without any roundtrip over `float` that a `static_cast` would otherwise do.
+/// It uses the default rounding mode.
+///
+/// Using this cast with neither of the two types being a [half](\ref
+/// half_float::half) or with any of the two types not being a built-in
+/// arithmetic type (apart from [half](\ref half_float::half), of course)
+/// results in a compiler error and casting between [half](\ref
+/// half_float::half)s is just a no-op. \tparam T destination type (half or
+/// built-in arithmetic type) \tparam U source type (half or built-in arithmetic
+/// type) \param arg value to cast \return \a arg converted to destination type
+template <typename T, typename U>
+T half_cast(U arg) {
+  return half_caster<T, U>::cast(arg);
+}
+
+/// Cast to or from half-precision floating point number.
+/// This casts between [half](\ref half_float::half) and any built-in arithmetic
+/// type. The values are converted directly using the given rounding mode,
+/// without any roundtrip over `float` that a `static_cast` would otherwise do.
+///
+/// Using this cast with neither of the two types being a [half](\ref
+/// half_float::half) or with any of the two types not being a built-in
+/// arithmetic type (apart from [half](\ref half_float::half), of course)
+/// results in a compiler error and casting between [half](\ref
+/// half_float::half)s is just a no-op. \tparam T destination type (half or
+/// built-in arithmetic type) \tparam R rounding mode to use. \tparam U source
+/// type (half or built-in arithmetic type) \param arg value to cast \return \a
+/// arg converted to destination type
+template <typename T, std::float_round_style R, typename U>
+T half_cast(U arg) {
+  return half_caster<T, U, R>::cast(arg);
+}
+/// \}
+}  // namespace detail
+
+using detail::operator==;
+using detail::operator!=;
+using detail::operator<;
+using detail::operator>;
+using detail::operator<=;
+using detail::operator>=;
+using detail::operator+;
+using detail::operator-;
+using detail::operator*;
+using detail::operator/;
+using detail::operator<<;
+using detail::operator>>;
+
+using detail::abs;
+using detail::acos;
+using detail::acosh;
+using detail::asin;
+using detail::asinh;
+using detail::atan;
+using detail::atan2;
+using detail::atanh;
+using detail::cbrt;
+using detail::ceil;
+using detail::cos;
+using detail::cosh;
+using detail::erf;
+using detail::erfc;
+using detail::exp;
+using detail::exp2;
+using detail::expm1;
+using detail::fabs;
+using detail::fdim;
+using detail::floor;
+using detail::fma;
+using detail::fmax;
+using detail::fmin;
+using detail::fmod;
+using detail::hypot;
+using detail::lgamma;
+using detail::log;
+using detail::log10;
+using detail::log1p;
+using detail::log2;
+using detail::lrint;
+using detail::lround;
+using detail::nanh;
+using detail::nearbyint;
+using detail::pow;
+using detail::remainder;
+using detail::remquo;
+using detail::rint;
+using detail::round;
+using detail::sin;
+using detail::sinh;
+using detail::sqrt;
+using detail::tan;
+using detail::tanh;
+using detail::tgamma;
+using detail::trunc;
+#if HALF_ENABLE_CPP11_LONG_LONG
+using detail::llrint;
+using detail::llround;
+#endif
+using detail::copysign;
+using detail::fpclassify;
+using detail::frexp;
+using detail::ilogb;
+using detail::isfinite;
+using detail::isgreater;
+using detail::isgreaterequal;
+using detail::isinf;
+using detail::isless;
+using detail::islessequal;
+using detail::islessgreater;
+using detail::isnan;
+using detail::isnormal;
+using detail::isunordered;
+using detail::ldexp;
+using detail::logb;
+using detail::modf;
+using detail::nextafter;
+using detail::nexttoward;
+using detail::scalbln;
+using detail::scalbn;
+using detail::signbit;
+
+using detail::half_cast;
+}  // namespace half_float
 
 /// Extensions to the C++ standard library.
-namespace std
-{
-	/// Numeric limits for half-precision floats.
-	/// Because of the underlying single-precision implementation of many operations, it inherits some properties from 
-	/// `std::numeric_limits<float>`.
-	template<> class numeric_limits<half_float::half> : public numeric_limits<float>
-	{
-	public:
-		/// Supports signed values.
-		static HALF_CONSTEXPR_CONST bool is_signed = true;
+namespace std {
+/// Numeric limits for half-precision floats.
+/// Because of the underlying single-precision implementation of many
+/// operations, it inherits some properties from `std::numeric_limits<float>`.
+template <>
+class numeric_limits<half_float::half> : public numeric_limits<float> {
+ public:
+  /// Supports signed values.
+  static HALF_CONSTEXPR_CONST bool is_signed = true;
 
-		/// Is not exact.
-		static HALF_CONSTEXPR_CONST bool is_exact = false;
+  /// Is not exact.
+  static HALF_CONSTEXPR_CONST bool is_exact = false;
 
-		/// Doesn't provide modulo arithmetic.
-		static HALF_CONSTEXPR_CONST bool is_modulo = false;
+  /// Doesn't provide modulo arithmetic.
+  static HALF_CONSTEXPR_CONST bool is_modulo = false;
 
-		/// IEEE conformant.
-		static HALF_CONSTEXPR_CONST bool is_iec559 = true;
+  /// IEEE conformant.
+  static HALF_CONSTEXPR_CONST bool is_iec559 = true;
 
-		/// Supports infinity.
-		static HALF_CONSTEXPR_CONST bool has_infinity = true;
+  /// Supports infinity.
+  static HALF_CONSTEXPR_CONST bool has_infinity = true;
 
-		/// Supports quiet NaNs.
-		static HALF_CONSTEXPR_CONST bool has_quiet_NaN = true;
+  /// Supports quiet NaNs.
+  static HALF_CONSTEXPR_CONST bool has_quiet_NaN = true;
 
-		/// Supports subnormal values.
-		static HALF_CONSTEXPR_CONST float_denorm_style has_denorm = denorm_present;
+  /// Supports subnormal values.
+  static HALF_CONSTEXPR_CONST float_denorm_style has_denorm = denorm_present;
 
-		/// Rounding mode.
-		/// Due to the mix of internal single-precision computations (using the rounding mode of the underlying 
-		/// single-precision implementation) with the rounding mode of the single-to-half conversions, the actual rounding 
-		/// mode might be `std::round_indeterminate` if the default half-precision rounding mode doesn't match the 
-		/// single-precision rounding mode.
-		static HALF_CONSTEXPR_CONST float_round_style round_style = (std::numeric_limits<float>::round_style==
-			half_float::half::round_style) ? half_float::half::round_style : round_indeterminate;
+  /// Rounding mode.
+  /// Due to the mix of internal single-precision computations (using the
+  /// rounding mode of the underlying single-precision implementation) with the
+  /// rounding mode of the single-to-half conversions, the actual rounding mode
+  /// might be `std::round_indeterminate` if the default half-precision rounding
+  /// mode doesn't match the single-precision rounding mode.
+  static HALF_CONSTEXPR_CONST float_round_style round_style =
+      (std::numeric_limits<float>::round_style == half_float::half::round_style)
+          ? half_float::half::round_style
+          : round_indeterminate;
 
-		/// Significant digits.
-		static HALF_CONSTEXPR_CONST int digits = 11;
+  /// Significant digits.
+  static HALF_CONSTEXPR_CONST int digits = 11;
 
-		/// Significant decimal digits.
-		static HALF_CONSTEXPR_CONST int digits10 = 3;
+  /// Significant decimal digits.
+  static HALF_CONSTEXPR_CONST int digits10 = 3;
 
-		/// Required decimal digits to represent all possible values.
-		static HALF_CONSTEXPR_CONST int max_digits10 = 5;
+  /// Required decimal digits to represent all possible values.
+  static HALF_CONSTEXPR_CONST int max_digits10 = 5;
 
-		/// Number base.
-		static HALF_CONSTEXPR_CONST int radix = 2;
+  /// Number base.
+  static HALF_CONSTEXPR_CONST int radix = 2;
 
-		/// One more than smallest exponent.
-		static HALF_CONSTEXPR_CONST int min_exponent = -13;
+  /// One more than smallest exponent.
+  static HALF_CONSTEXPR_CONST int min_exponent = -13;
 
-		/// Smallest normalized representable power of 10.
-		static HALF_CONSTEXPR_CONST int min_exponent10 = -4;
+  /// Smallest normalized representable power of 10.
+  static HALF_CONSTEXPR_CONST int min_exponent10 = -4;
 
-		/// One more than largest exponent
-		static HALF_CONSTEXPR_CONST int max_exponent = 16;
+  /// One more than largest exponent
+  static HALF_CONSTEXPR_CONST int max_exponent = 16;
 
-		/// Largest finitely representable power of 10.
-		static HALF_CONSTEXPR_CONST int max_exponent10 = 4;
+  /// Largest finitely representable power of 10.
+  static HALF_CONSTEXPR_CONST int max_exponent10 = 4;
 
-		/// Smallest positive normal value.
-		static HALF_CONSTEXPR half_float::half min() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0x0400); }
+  /// Smallest positive normal value.
+  static HALF_CONSTEXPR half_float::half min() HALF_NOTHROW {
+    return half_float::half(half_float::detail::binary, 0x0400);
+  }
 
-		/// Smallest finite value.
-		static HALF_CONSTEXPR half_float::half lowest() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0xFBFF); }
+  /// Smallest finite value.
+  static HALF_CONSTEXPR half_float::half lowest() HALF_NOTHROW {
+    return half_float::half(half_float::detail::binary, 0xFBFF);
+  }
 
-		/// Largest finite value.
-		static HALF_CONSTEXPR half_float::half max() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0x7BFF); }
+  /// Largest finite value.
+  static HALF_CONSTEXPR half_float::half max() HALF_NOTHROW {
+    return half_float::half(half_float::detail::binary, 0x7BFF);
+  }
 
-		/// Difference between one and next representable value.
-		static HALF_CONSTEXPR half_float::half epsilon() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0x1400); }
+  /// Difference between one and next representable value.
+  static HALF_CONSTEXPR half_float::half epsilon() HALF_NOTHROW {
+    return half_float::half(half_float::detail::binary, 0x1400);
+  }
 
-		/// Maximum rounding error.
-		static HALF_CONSTEXPR half_float::half round_error() HALF_NOTHROW
-			{ return half_float::half(half_float::detail::binary, (round_style==std::round_to_nearest) ? 0x3800 : 0x3C00); }
+  /// Maximum rounding error.
+  static HALF_CONSTEXPR half_float::half round_error() HALF_NOTHROW {
+    return half_float::half(
+        half_float::detail::binary,
+        (round_style == std::round_to_nearest) ? 0x3800 : 0x3C00);
+  }
 
-		/// Positive infinity.
-		static HALF_CONSTEXPR half_float::half infinity() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0x7C00); }
+  /// Positive infinity.
+  static HALF_CONSTEXPR half_float::half infinity() HALF_NOTHROW {
+    return half_float::half(half_float::detail::binary, 0x7C00);
+  }
 
-		/// Quiet NaN.
-		static HALF_CONSTEXPR half_float::half quiet_NaN() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0x7FFF); }
+  /// Quiet NaN.
+  static HALF_CONSTEXPR half_float::half quiet_NaN() HALF_NOTHROW {
+    return half_float::half(half_float::detail::binary, 0x7FFF);
+  }
 
-		/// Signalling NaN.
-		static HALF_CONSTEXPR half_float::half signaling_NaN() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0x7DFF); }
+  /// Signalling NaN.
+  static HALF_CONSTEXPR half_float::half signaling_NaN() HALF_NOTHROW {
+    return half_float::half(half_float::detail::binary, 0x7DFF);
+  }
 
-		/// Smallest positive subnormal value.
-		static HALF_CONSTEXPR half_float::half denorm_min() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0x0001); }
-	};
+  /// Smallest positive subnormal value.
+  static HALF_CONSTEXPR half_float::half denorm_min() HALF_NOTHROW {
+    return half_float::half(half_float::detail::binary, 0x0001);
+  }
+};
 
 #if HALF_ENABLE_CPP11_HASH
-	/// Hash function for half-precision floats.
-	/// This is only defined if C++11 `std::hash` is supported and enabled.
-	template<> struct hash<half_float::half> //: unary_function<half_float::half,size_t>
-	{
-		/// Type of function argument.
-		typedef half_float::half argument_type;
+/// Hash function for half-precision floats.
+/// This is only defined if C++11 `std::hash` is supported and enabled.
+template <>
+struct hash<half_float::half>  //: unary_function<half_float::half,size_t>
+{
+  /// Type of function argument.
+  typedef half_float::half argument_type;
 
-		/// Function return type.
-		typedef size_t result_type;
+  /// Function return type.
+  typedef size_t result_type;
 
-		/// Compute hash function.
-		/// \param arg half to hash
-		/// \return hash value
-		result_type operator()(argument_type arg) const
-			{ return hash<half_float::detail::uint16>()(static_cast<unsigned>(arg.data_)&-(arg.data_!=0x8000)); }
-	};
+  /// Compute hash function.
+  /// \param arg half to hash
+  /// \return hash value
+  result_type operator()(argument_type arg) const {
+    return hash<half_float::detail::uint16>()(static_cast<unsigned>(arg.data_) &
+                                              -(arg.data_ != 0x8000));
+  }
+};
 #endif
-}
-
+}  // namespace std
 
 #undef HALF_CONSTEXPR
 #undef HALF_CONSTEXPR_CONST
 #undef HALF_NOEXCEPT
 #undef HALF_NOTHROW
 #ifdef HALF_POP_WARNINGS
-	#pragma warning(pop)
-	#undef HALF_POP_WARNINGS
+#pragma warning(pop)
+#undef HALF_POP_WARNINGS
 #endif
 
 #endif

--- a/src/cuda-sim/half.h
+++ b/src/cuda-sim/half.h
@@ -2,17 +2,25 @@
 //
 // Copyright (c) 2012-2017 Christian Rau <rauy@users.sourceforge.net>
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation 
-// files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, 
-// modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation
+// files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy,
+// modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
 //
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
 //
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE 
-// WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
-// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, 
-// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+// WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
 
 // Version 1.12.0
 
@@ -23,180 +31,191 @@
 #define HALF_HALF_HPP
 
 /// Combined gcc version number.
-#define HALF_GNUC_VERSION (__GNUC__*100+__GNUC_MINOR__)
+#define HALF_GNUC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
 
-//check C++11 language features
-#if defined(__clang__)										//clang
-	#if __has_feature(cxx_static_assert) && !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)
-		#define HALF_ENABLE_CPP11_STATIC_ASSERT 1
-	#endif
-	#if __has_feature(cxx_constexpr) && !defined(HALF_ENABLE_CPP11_CONSTEXPR)
-		#define HALF_ENABLE_CPP11_CONSTEXPR 1
-	#endif
-	#if __has_feature(cxx_noexcept) && !defined(HALF_ENABLE_CPP11_NOEXCEPT)
-		#define HALF_ENABLE_CPP11_NOEXCEPT 1
-	#endif
-	#if __has_feature(cxx_user_literals) && !defined(HALF_ENABLE_CPP11_USER_LITERALS)
-		#define HALF_ENABLE_CPP11_USER_LITERALS 1
-	#endif
-	#if (defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L) && !defined(HALF_ENABLE_CPP11_LONG_LONG)
-		#define HALF_ENABLE_CPP11_LONG_LONG 1
-	#endif
-/*#elif defined(__INTEL_COMPILER)								//Intel C++
-	#if __INTEL_COMPILER >= 1100 && !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)		????????
-		#define HALF_ENABLE_CPP11_STATIC_ASSERT 1
-	#endif
-	#if __INTEL_COMPILER >= 1300 && !defined(HALF_ENABLE_CPP11_CONSTEXPR)			????????
-		#define HALF_ENABLE_CPP11_CONSTEXPR 1
-	#endif
-	#if __INTEL_COMPILER >= 1300 && !defined(HALF_ENABLE_CPP11_NOEXCEPT)			????????
-		#define HALF_ENABLE_CPP11_NOEXCEPT 1
-	#endif
-	#if __INTEL_COMPILER >= 1100 && !defined(HALF_ENABLE_CPP11_LONG_LONG)			????????
-		#define HALF_ENABLE_CPP11_LONG_LONG 1
-	#endif*/
-#elif defined(__GNUC__)										//gcc
-	#if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L
-		#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)
-			#define HALF_ENABLE_CPP11_STATIC_ASSERT 1
-		#endif
-		#if HALF_GNUC_VERSION >= 406 && !defined(HALF_ENABLE_CPP11_CONSTEXPR)
-			#define HALF_ENABLE_CPP11_CONSTEXPR 1
-		#endif
-		#if HALF_GNUC_VERSION >= 406 && !defined(HALF_ENABLE_CPP11_NOEXCEPT)
-			#define HALF_ENABLE_CPP11_NOEXCEPT 1
-		#endif
-		#if HALF_GNUC_VERSION >= 407 && !defined(HALF_ENABLE_CPP11_USER_LITERALS)
-			#define HALF_ENABLE_CPP11_USER_LITERALS 1
-		#endif
-		#if !defined(HALF_ENABLE_CPP11_LONG_LONG)
-			#define HALF_ENABLE_CPP11_LONG_LONG 1
-		#endif
-	#endif
-#elif defined(_MSC_VER)										//Visual C++
-	#if _MSC_VER >= 1900 && !defined(HALF_ENABLE_CPP11_CONSTEXPR)
-		#define HALF_ENABLE_CPP11_CONSTEXPR 1
-	#endif
-	#if _MSC_VER >= 1900 && !defined(HALF_ENABLE_CPP11_NOEXCEPT)
-		#define HALF_ENABLE_CPP11_NOEXCEPT 1
-	#endif
-	#if _MSC_VER >= 1900 && !defined(HALF_ENABLE_CPP11_USER_LITERALS)
-		#define HALF_ENABLE_CPP11_USER_LITERALS 1
-	#endif
-	#if _MSC_VER >= 1600 && !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)
-		#define HALF_ENABLE_CPP11_STATIC_ASSERT 1
-	#endif
-	#if _MSC_VER >= 1310 && !defined(HALF_ENABLE_CPP11_LONG_LONG)
-		#define HALF_ENABLE_CPP11_LONG_LONG 1
-	#endif
-	#define HALF_POP_WARNINGS 1
-	#pragma warning(push)
-	#pragma warning(disable : 4099 4127 4146)	//struct vs class, constant in if, negative unsigned
+// check C++11 language features
+#if defined(__clang__)  // clang
+#if __has_feature(cxx_static_assert) && \
+    !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)
+#define HALF_ENABLE_CPP11_STATIC_ASSERT 1
+#endif
+#if __has_feature(cxx_constexpr) && !defined(HALF_ENABLE_CPP11_CONSTEXPR)
+#define HALF_ENABLE_CPP11_CONSTEXPR 1
+#endif
+#if __has_feature(cxx_noexcept) && !defined(HALF_ENABLE_CPP11_NOEXCEPT)
+#define HALF_ENABLE_CPP11_NOEXCEPT 1
+#endif
+#if __has_feature(cxx_user_literals) && \
+    !defined(HALF_ENABLE_CPP11_USER_LITERALS)
+#define HALF_ENABLE_CPP11_USER_LITERALS 1
+#endif
+#if (defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L) && \
+    !defined(HALF_ENABLE_CPP11_LONG_LONG)
+#define HALF_ENABLE_CPP11_LONG_LONG 1
+#endif
+/*#elif defined(__INTEL_COMPILER)
+   //Intel C++
+        #if __INTEL_COMPILER >= 1100 &&
+   !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)		????????
+                #define HALF_ENABLE_CPP11_STATIC_ASSERT 1
+        #endif
+        #if __INTEL_COMPILER >= 1300 && !defined(HALF_ENABLE_CPP11_CONSTEXPR)
+   ????????
+                #define HALF_ENABLE_CPP11_CONSTEXPR 1
+        #endif
+        #if __INTEL_COMPILER >= 1300 && !defined(HALF_ENABLE_CPP11_NOEXCEPT)
+   ????????
+                #define HALF_ENABLE_CPP11_NOEXCEPT 1
+        #endif
+        #if __INTEL_COMPILER >= 1100 && !defined(HALF_ENABLE_CPP11_LONG_LONG)
+   ????????
+                #define HALF_ENABLE_CPP11_LONG_LONG 1
+        #endif*/
+#elif defined(__GNUC__)  // gcc
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L
+#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)
+#define HALF_ENABLE_CPP11_STATIC_ASSERT 1
+#endif
+#if HALF_GNUC_VERSION >= 406 && !defined(HALF_ENABLE_CPP11_CONSTEXPR)
+#define HALF_ENABLE_CPP11_CONSTEXPR 1
+#endif
+#if HALF_GNUC_VERSION >= 406 && !defined(HALF_ENABLE_CPP11_NOEXCEPT)
+#define HALF_ENABLE_CPP11_NOEXCEPT 1
+#endif
+#if HALF_GNUC_VERSION >= 407 && !defined(HALF_ENABLE_CPP11_USER_LITERALS)
+#define HALF_ENABLE_CPP11_USER_LITERALS 1
+#endif
+#if !defined(HALF_ENABLE_CPP11_LONG_LONG)
+#define HALF_ENABLE_CPP11_LONG_LONG 1
+#endif
+#endif
+#elif defined(_MSC_VER)  // Visual C++
+#if _MSC_VER >= 1900 && !defined(HALF_ENABLE_CPP11_CONSTEXPR)
+#define HALF_ENABLE_CPP11_CONSTEXPR 1
+#endif
+#if _MSC_VER >= 1900 && !defined(HALF_ENABLE_CPP11_NOEXCEPT)
+#define HALF_ENABLE_CPP11_NOEXCEPT 1
+#endif
+#if _MSC_VER >= 1900 && !defined(HALF_ENABLE_CPP11_USER_LITERALS)
+#define HALF_ENABLE_CPP11_USER_LITERALS 1
+#endif
+#if _MSC_VER >= 1600 && !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)
+#define HALF_ENABLE_CPP11_STATIC_ASSERT 1
+#endif
+#if _MSC_VER >= 1310 && !defined(HALF_ENABLE_CPP11_LONG_LONG)
+#define HALF_ENABLE_CPP11_LONG_LONG 1
+#endif
+#define HALF_POP_WARNINGS 1
+#pragma warning(push)
+#pragma warning(disable : 4099 4127 4146)  // struct vs class, constant in if,
+                                           // negative unsigned
 #endif
 
-//check C++11 library features
+// check C++11 library features
 #include <utility>
-#if defined(_LIBCPP_VERSION)								//libc++
-	#if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103
-		#ifndef HALF_ENABLE_CPP11_TYPE_TRAITS
-			#define HALF_ENABLE_CPP11_TYPE_TRAITS 1
-		#endif
-		#ifndef HALF_ENABLE_CPP11_CSTDINT
-			#define HALF_ENABLE_CPP11_CSTDINT 1
-		#endif
-		#ifndef HALF_ENABLE_CPP11_CMATH
-			#define HALF_ENABLE_CPP11_CMATH 1
-		#endif
-		#ifndef HALF_ENABLE_CPP11_HASH
-			#define HALF_ENABLE_CPP11_HASH 1
-		#endif
-	#endif
-#elif defined(__GLIBCXX__)									//libstdc++
-	#if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103
-		#ifdef __clang__
-			#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_TYPE_TRAITS)
-				#define HALF_ENABLE_CPP11_TYPE_TRAITS 1
-			#endif
-			#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_CSTDINT)
-				#define HALF_ENABLE_CPP11_CSTDINT 1
-			#endif
-			#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_CMATH)
-				#define HALF_ENABLE_CPP11_CMATH 1
-			#endif
-			#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_HASH)
-				#define HALF_ENABLE_CPP11_HASH 1
-			#endif
-		#else
-			#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_CSTDINT)
-				#define HALF_ENABLE_CPP11_CSTDINT 1
-			#endif
-			#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_CMATH)
-				#define HALF_ENABLE_CPP11_CMATH 1
-			#endif
-			#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_HASH)
-				#define HALF_ENABLE_CPP11_HASH 1
-			#endif
-		#endif
-	#endif
-#elif defined(_CPPLIB_VER)									//Dinkumware/Visual C++
-	#if _CPPLIB_VER >= 520
-		#ifndef HALF_ENABLE_CPP11_TYPE_TRAITS
-			#define HALF_ENABLE_CPP11_TYPE_TRAITS 1
-		#endif
-		#ifndef HALF_ENABLE_CPP11_CSTDINT
-			#define HALF_ENABLE_CPP11_CSTDINT 1
-		#endif
-		#ifndef HALF_ENABLE_CPP11_HASH
-			#define HALF_ENABLE_CPP11_HASH 1
-		#endif
-	#endif
-	#if _CPPLIB_VER >= 610
-		#ifndef HALF_ENABLE_CPP11_CMATH
-			#define HALF_ENABLE_CPP11_CMATH 1
-		#endif
-	#endif
+#if defined(_LIBCPP_VERSION)  // libc++
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103
+#ifndef HALF_ENABLE_CPP11_TYPE_TRAITS
+#define HALF_ENABLE_CPP11_TYPE_TRAITS 1
+#endif
+#ifndef HALF_ENABLE_CPP11_CSTDINT
+#define HALF_ENABLE_CPP11_CSTDINT 1
+#endif
+#ifndef HALF_ENABLE_CPP11_CMATH
+#define HALF_ENABLE_CPP11_CMATH 1
+#endif
+#ifndef HALF_ENABLE_CPP11_HASH
+#define HALF_ENABLE_CPP11_HASH 1
+#endif
+#endif
+#elif defined(__GLIBCXX__)  // libstdc++
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103
+#ifdef __clang__
+#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_TYPE_TRAITS)
+#define HALF_ENABLE_CPP11_TYPE_TRAITS 1
+#endif
+#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_CSTDINT)
+#define HALF_ENABLE_CPP11_CSTDINT 1
+#endif
+#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_CMATH)
+#define HALF_ENABLE_CPP11_CMATH 1
+#endif
+#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_HASH)
+#define HALF_ENABLE_CPP11_HASH 1
+#endif
+#else
+#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_CSTDINT)
+#define HALF_ENABLE_CPP11_CSTDINT 1
+#endif
+#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_CMATH)
+#define HALF_ENABLE_CPP11_CMATH 1
+#endif
+#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_HASH)
+#define HALF_ENABLE_CPP11_HASH 1
+#endif
+#endif
+#endif
+#elif defined(_CPPLIB_VER)  // Dinkumware/Visual C++
+#if _CPPLIB_VER >= 520
+#ifndef HALF_ENABLE_CPP11_TYPE_TRAITS
+#define HALF_ENABLE_CPP11_TYPE_TRAITS 1
+#endif
+#ifndef HALF_ENABLE_CPP11_CSTDINT
+#define HALF_ENABLE_CPP11_CSTDINT 1
+#endif
+#ifndef HALF_ENABLE_CPP11_HASH
+#define HALF_ENABLE_CPP11_HASH 1
+#endif
+#endif
+#if _CPPLIB_VER >= 610
+#ifndef HALF_ENABLE_CPP11_CMATH
+#define HALF_ENABLE_CPP11_CMATH 1
+#endif
+#endif
 #endif
 #undef HALF_GNUC_VERSION
 
-//support constexpr
+// support constexpr
 #if HALF_ENABLE_CPP11_CONSTEXPR
-	#define HALF_CONSTEXPR			constexpr
-	#define HALF_CONSTEXPR_CONST	constexpr
+#define HALF_CONSTEXPR constexpr
+#define HALF_CONSTEXPR_CONST constexpr
 #else
-	#define HALF_CONSTEXPR
-	#define HALF_CONSTEXPR_CONST	const
+#define HALF_CONSTEXPR
+#define HALF_CONSTEXPR_CONST const
 #endif
 
-//support noexcept
+// support noexcept
 #if HALF_ENABLE_CPP11_NOEXCEPT
-	#define HALF_NOEXCEPT	noexcept
-	#define HALF_NOTHROW	noexcept
+#define HALF_NOEXCEPT noexcept
+#define HALF_NOTHROW noexcept
 #else
-	#define HALF_NOEXCEPT
-	#define HALF_NOTHROW	throw()
+#define HALF_NOEXCEPT
+#define HALF_NOTHROW throw()
 #endif
 
 #include <algorithm>
-#include <iostream>
-#include <limits>
 #include <climits>
 #include <cmath>
 #include <cstring>
+#include <iostream>
+#include <limits>
 #if HALF_ENABLE_CPP11_TYPE_TRAITS
-	#include <type_traits>
+#include <type_traits>
 #endif
 #if HALF_ENABLE_CPP11_CSTDINT
-	#include <cstdint>
+#include <cstdint>
 #endif
 #if HALF_ENABLE_CPP11_HASH
-	#include <functional>
+#include <functional>
 #endif
 
-
 /// Default rounding mode.
-/// This specifies the rounding mode used for all conversions between [half](\ref half_float::half)s and `float`s as well as 
-/// for the half_cast() if not specifying a rounding mode explicitly. It can be redefined (before including half.hpp) to one 
-/// of the standard rounding modes using their respective constants or the equivalent values of `std::float_round_style`:
+/// This specifies the rounding mode used for all conversions between
+/// [half](\ref half_float::half)s and `float`s as well as
+/// for the half_cast() if not specifying a rounding mode explicitly. It can be
+/// redefined (before including half.hpp) to one
+/// of the standard rounding modes using their respective constants or the
+/// equivalent values of `std::float_round_style`:
 ///
 /// `std::float_round_style`         | value | rounding
 /// ---------------------------------|-------|-------------------------
@@ -206,256 +225,354 @@
 /// `std::round_toward_infinity`     | 2     | toward positive infinity
 /// `std::round_toward_neg_infinity` | 3     | toward negative infinity
 ///
-/// By default this is set to `-1` (`std::round_indeterminate`), which uses truncation (round toward zero, but with overflows 
-/// set to infinity) and is the fastest rounding mode possible. It can even be set to `std::numeric_limits<float>::round_style` 
-/// to synchronize the rounding mode with that of the underlying single-precision implementation.
+/// By default this is set to `-1` (`std::round_indeterminate`), which uses
+/// truncation (round toward zero, but with overflows
+/// set to infinity) and is the fastest rounding mode possible. It can even be
+/// set to `std::numeric_limits<float>::round_style`
+/// to synchronize the rounding mode with that of the underlying
+/// single-precision implementation.
 #ifndef HALF_ROUND_STYLE
-	#define HALF_ROUND_STYLE	-1			// = std::round_indeterminate
+#define HALF_ROUND_STYLE -1  // = std::round_indeterminate
 #endif
 
 /// Tie-breaking behaviour for round to nearest.
-/// This specifies if ties in round to nearest should be resolved by rounding to the nearest even value. By default this is 
-/// defined to `0` resulting in the faster but slightly more biased behaviour of rounding away from zero in half-way cases (and 
-/// thus equal to the round() function), but can be redefined to `1` (before including half.hpp) if more IEEE-conformant 
+/// This specifies if ties in round to nearest should be resolved by rounding to
+/// the nearest even value. By default this is
+/// defined to `0` resulting in the faster but slightly more biased behaviour of
+/// rounding away from zero in half-way cases (and
+/// thus equal to the round() function), but can be redefined to `1` (before
+/// including half.hpp) if more IEEE-conformant
 /// behaviour is needed.
 #ifndef HALF_ROUND_TIES_TO_EVEN
-	#define HALF_ROUND_TIES_TO_EVEN	0		// ties away from zero
+#define HALF_ROUND_TIES_TO_EVEN 0  // ties away from zero
 #endif
 
 /// Value signaling overflow.
-/// In correspondence with `HUGE_VAL[F|L]` from `<cmath>` this symbol expands to a positive value signaling the overflow of an 
+/// In correspondence with `HUGE_VAL[F|L]` from `<cmath>` this symbol expands to
+/// a positive value signaling the overflow of an
 /// operation, in particular it just evaluates to positive infinity.
-#define HUGE_VALH	std::numeric_limits<half_float::half>::infinity()
+#define HUGE_VALH std::numeric_limits<half_float::half>::infinity()
 
 /// Fast half-precision fma function.
-/// This symbol is only defined if the fma() function generally executes as fast as, or faster than, a separate 
-/// half-precision multiplication followed by an addition. Due to the internal single-precision implementation of all 
+/// This symbol is only defined if the fma() function generally executes as fast
+/// as, or faster than, a separate
+/// half-precision multiplication followed by an addition. Due to the internal
+/// single-precision implementation of all
 /// arithmetic operations, this is in fact always the case.
-#define FP_FAST_FMAH	1
+#define FP_FAST_FMAH 1
 
 #ifndef FP_ILOGB0
-	#define FP_ILOGB0		INT_MIN
+#define FP_ILOGB0 INT_MIN
 #endif
 #ifndef FP_ILOGBNAN
-	#define FP_ILOGBNAN		INT_MAX
+#define FP_ILOGBNAN INT_MAX
 #endif
 #ifndef FP_SUBNORMAL
-	#define FP_SUBNORMAL	0
+#define FP_SUBNORMAL 0
 #endif
 #ifndef FP_ZERO
-	#define FP_ZERO			1
+#define FP_ZERO 1
 #endif
 #ifndef FP_NAN
-	#define FP_NAN			2
+#define FP_NAN 2
 #endif
 #ifndef FP_INFINITE
-	#define FP_INFINITE		3
+#define FP_INFINITE 3
 #endif
 #ifndef FP_NORMAL
-	#define FP_NORMAL		4
+#define FP_NORMAL 4
 #endif
-
 
 /// Main namespace for half precision functionality.
 /// This namespace contains all the functionality provided by the library.
-namespace half_float
-{
-	class half;
+namespace half_float {
+class half;
 
 #if HALF_ENABLE_CPP11_USER_LITERALS
-	/// Library-defined half-precision literals.
-	/// Import this namespace to enable half-precision floating point literals:
-	/// ~~~~{.cpp}
-	/// using namespace half_float::literal;
-	/// half_float::half = 4.2_h;
-	/// ~~~~
-	namespace literal
-	{
-		half operator"" _h(long double);
-	}
+/// Library-defined half-precision literals.
+/// Import this namespace to enable half-precision floating point literals:
+/// ~~~~{.cpp}
+/// using namespace half_float::literal;
+/// half_float::half = 4.2_h;
+/// ~~~~
+namespace literal {
+half operator"" _h(long double);
+}
 #endif
 
-	/// \internal
-	/// \brief Implementation details.
-	namespace detail
-	{
-	#if HALF_ENABLE_CPP11_TYPE_TRAITS
-		/// Conditional type.
-		template<bool B,typename T,typename F> struct conditional : std::conditional<B,T,F> {};
+/// \internal
+/// \brief Implementation details.
+namespace detail {
+#if HALF_ENABLE_CPP11_TYPE_TRAITS
+/// Conditional type.
+template <bool B, typename T, typename F>
+struct conditional : std::conditional<B, T, F> {};
 
-		/// Helper for tag dispatching.
-		template<bool B> struct bool_type : std::integral_constant<bool,B> {};
-		using std::true_type;
-		using std::false_type;
+/// Helper for tag dispatching.
+template <bool B>
+struct bool_type : std::integral_constant<bool, B> {};
+using std::true_type;
+using std::false_type;
 
-		/// Type traits for floating point types.
-		template<typename T> struct is_float : std::is_floating_point<T> {};
-	#else
-		/// Conditional type.
-		template<bool,typename T,typename> struct conditional { typedef T type; };
-		template<typename T,typename F> struct conditional<false,T,F> { typedef F type; };
+/// Type traits for floating point types.
+template <typename T>
+struct is_float : std::is_floating_point<T> {};
+#else
+/// Conditional type.
+template <bool, typename T, typename>
+struct conditional {
+  typedef T type;
+};
+template <typename T, typename F>
+struct conditional<false, T, F> {
+  typedef F type;
+};
 
-		/// Helper for tag dispatching.
-		template<bool> struct bool_type {};
-		typedef bool_type<true> true_type;
-		typedef bool_type<false> false_type;
+/// Helper for tag dispatching.
+template <bool>
+struct bool_type {};
+typedef bool_type<true> true_type;
+typedef bool_type<false> false_type;
 
-		/// Type traits for floating point types.
-		template<typename> struct is_float : false_type {};
-		template<typename T> struct is_float<const T> : is_float<T> {};
-		template<typename T> struct is_float<volatile T> : is_float<T> {};
-		template<typename T> struct is_float<const volatile T> : is_float<T> {};
-		template<> struct is_float<float> : true_type {};
-		template<> struct is_float<double> : true_type {};
-		template<> struct is_float<long double> : true_type {};
-	#endif
+/// Type traits for floating point types.
+template <typename>
+struct is_float : false_type {};
+template <typename T>
+struct is_float<const T> : is_float<T> {};
+template <typename T>
+struct is_float<volatile T> : is_float<T> {};
+template <typename T>
+struct is_float<const volatile T> : is_float<T> {};
+template <>
+struct is_float<float> : true_type {};
+template <>
+struct is_float<double> : true_type {};
+template <>
+struct is_float<long double> : true_type {};
+#endif
 
-		/// Type traits for floating point bits.
-		template<typename T> struct bits { typedef unsigned char type; };
-		template<typename T> struct bits<const T> : bits<T> {};
-		template<typename T> struct bits<volatile T> : bits<T> {};
-		template<typename T> struct bits<const volatile T> : bits<T> {};
+/// Type traits for floating point bits.
+template <typename T>
+struct bits {
+  typedef unsigned char type;
+};
+template <typename T>
+struct bits<const T> : bits<T> {};
+template <typename T>
+struct bits<volatile T> : bits<T> {};
+template <typename T>
+struct bits<const volatile T> : bits<T> {};
 
-	#if HALF_ENABLE_CPP11_CSTDINT
-		/// Unsigned integer of (at least) 16 bits width.
-		typedef std::uint_least16_t uint16;
+#if HALF_ENABLE_CPP11_CSTDINT
+/// Unsigned integer of (at least) 16 bits width.
+typedef std::uint_least16_t uint16;
 
-		/// Unsigned integer of (at least) 32 bits width.
-		template<> struct bits<float> { typedef std::uint_least32_t type; };
+/// Unsigned integer of (at least) 32 bits width.
+template <>
+struct bits<float> {
+  typedef std::uint_least32_t type;
+};
 
-		/// Unsigned integer of (at least) 64 bits width.
-		template<> struct bits<double> { typedef std::uint_least64_t type; };
-	#else
-		/// Unsigned integer of (at least) 16 bits width.
-		typedef unsigned short uint16;
+/// Unsigned integer of (at least) 64 bits width.
+template <>
+struct bits<double> {
+  typedef std::uint_least64_t type;
+};
+#else
+/// Unsigned integer of (at least) 16 bits width.
+typedef unsigned short uint16;
 
-		/// Unsigned integer of (at least) 32 bits width.
-		template<> struct bits<float> : conditional<std::numeric_limits<unsigned int>::digits>=32,unsigned int,unsigned long> {};
+/// Unsigned integer of (at least) 32 bits width.
+template <>
+struct bits<float>
+    : conditional<std::numeric_limits<unsigned int>::digits >= 32, unsigned int,
+                  unsigned long> {};
 
-		#if HALF_ENABLE_CPP11_LONG_LONG
-			/// Unsigned integer of (at least) 64 bits width.
-			template<> struct bits<double> : conditional<std::numeric_limits<unsigned long>::digits>=64,unsigned long,unsigned long long> {};
-		#else
-			/// Unsigned integer of (at least) 64 bits width.
-			template<> struct bits<double> { typedef unsigned long type; };
-		#endif
-	#endif
+#if HALF_ENABLE_CPP11_LONG_LONG
+/// Unsigned integer of (at least) 64 bits width.
+template <>
+struct bits<double>
+    : conditional<std::numeric_limits<unsigned long>::digits >= 64,
+                  unsigned long, unsigned long long> {};
+#else
+/// Unsigned integer of (at least) 64 bits width.
+template <>
+struct bits<double> {
+  typedef unsigned long type;
+};
+#endif
+#endif
 
-		/// Tag type for binary construction.
-		struct binary_t {};
+/// Tag type for binary construction.
+struct binary_t {};
 
-		/// Tag for binary construction.
-		HALF_CONSTEXPR_CONST binary_t binary = binary_t();
+/// Tag for binary construction.
+HALF_CONSTEXPR_CONST binary_t binary = binary_t();
 
-		/// Temporary half-precision expression.
-		/// This class represents a half-precision expression which just stores a single-precision value internally.
-		struct expr
-		{
-			/// Conversion constructor.
-			/// \param f single-precision value to convert
-			explicit HALF_CONSTEXPR expr(float f) HALF_NOEXCEPT : value_(f) {}
+/// Temporary half-precision expression.
+/// This class represents a half-precision expression which just stores a
+/// single-precision value internally.
+struct expr {
+  /// Conversion constructor.
+  /// \param f single-precision value to convert
+  explicit HALF_CONSTEXPR expr(float f) HALF_NOEXCEPT : value_(f) {}
 
-			/// Conversion to single-precision.
-			/// \return single precision value representing expression value
-			HALF_CONSTEXPR operator float() const HALF_NOEXCEPT { return value_; }
+  /// Conversion to single-precision.
+  /// \return single precision value representing expression value
+  HALF_CONSTEXPR operator float() const HALF_NOEXCEPT { return value_; }
 
-		private:
-			/// Internal expression value stored in single-precision.
-			float value_;
-		};
+ private:
+  /// Internal expression value stored in single-precision.
+  float value_;
+};
 
-		/// SFINAE helper for generic half-precision functions.
-		/// This class template has to be specialized for each valid combination of argument types to provide a corresponding 
-		/// `type` member equivalent to \a T.
-		/// \tparam T type to return
-		template<typename T,typename,typename=void,typename=void> struct enable {};
-		template<typename T> struct enable<T,half,void,void> { typedef T type; };
-		template<typename T> struct enable<T,expr,void,void> { typedef T type; };
-		template<typename T> struct enable<T,half,half,void> { typedef T type; };
-		template<typename T> struct enable<T,half,expr,void> { typedef T type; };
-		template<typename T> struct enable<T,expr,half,void> { typedef T type; };
-		template<typename T> struct enable<T,expr,expr,void> { typedef T type; };
-		template<typename T> struct enable<T,half,half,half> { typedef T type; };
-		template<typename T> struct enable<T,half,half,expr> { typedef T type; };
-		template<typename T> struct enable<T,half,expr,half> { typedef T type; };
-		template<typename T> struct enable<T,half,expr,expr> { typedef T type; };
-		template<typename T> struct enable<T,expr,half,half> { typedef T type; };
-		template<typename T> struct enable<T,expr,half,expr> { typedef T type; };
-		template<typename T> struct enable<T,expr,expr,half> { typedef T type; };
-		template<typename T> struct enable<T,expr,expr,expr> { typedef T type; };
+/// SFINAE helper for generic half-precision functions.
+/// This class template has to be specialized for each valid combination of
+/// argument types to provide a corresponding
+/// `type` member equivalent to \a T.
+/// \tparam T type to return
+template <typename T, typename, typename = void, typename = void>
+struct enable {};
+template <typename T>
+struct enable<T, half, void, void> {
+  typedef T type;
+};
+template <typename T>
+struct enable<T, expr, void, void> {
+  typedef T type;
+};
+template <typename T>
+struct enable<T, half, half, void> {
+  typedef T type;
+};
+template <typename T>
+struct enable<T, half, expr, void> {
+  typedef T type;
+};
+template <typename T>
+struct enable<T, expr, half, void> {
+  typedef T type;
+};
+template <typename T>
+struct enable<T, expr, expr, void> {
+  typedef T type;
+};
+template <typename T>
+struct enable<T, half, half, half> {
+  typedef T type;
+};
+template <typename T>
+struct enable<T, half, half, expr> {
+  typedef T type;
+};
+template <typename T>
+struct enable<T, half, expr, half> {
+  typedef T type;
+};
+template <typename T>
+struct enable<T, half, expr, expr> {
+  typedef T type;
+};
+template <typename T>
+struct enable<T, expr, half, half> {
+  typedef T type;
+};
+template <typename T>
+struct enable<T, expr, half, expr> {
+  typedef T type;
+};
+template <typename T>
+struct enable<T, expr, expr, half> {
+  typedef T type;
+};
+template <typename T>
+struct enable<T, expr, expr, expr> {
+  typedef T type;
+};
 
-		/// Return type for specialized generic 2-argument half-precision functions.
-		/// This class template has to be specialized for each valid combination of argument types to provide a corresponding 
-		/// `type` member denoting the appropriate return type.
-		/// \tparam T first argument type
-		/// \tparam U first argument type
-		template<typename T,typename U> struct result : enable<expr,T,U> {};
-		template<> struct result<half,half> { typedef half type; };
+/// Return type for specialized generic 2-argument half-precision functions.
+/// This class template has to be specialized for each valid combination of
+/// argument types to provide a corresponding
+/// `type` member denoting the appropriate return type.
+/// \tparam T first argument type
+/// \tparam U first argument type
+template <typename T, typename U>
+struct result : enable<expr, T, U> {};
+template <>
+struct result<half, half> {
+  typedef half type;
+};
 
-		/// \name Classification helpers
-		/// \{
+/// \name Classification helpers
+/// \{
 
-		/// Check for infinity.
-		/// \tparam T argument type (builtin floating point type)
-		/// \param arg value to query
-		/// \retval true if infinity
-		/// \retval false else
-		template<typename T> bool builtin_isinf(T arg)
-		{
-		#if HALF_ENABLE_CPP11_CMATH
-			return std::isinf(arg);
-		#elif defined(_MSC_VER)
-			return !::_finite(static_cast<double>(arg)) && !::_isnan(static_cast<double>(arg));
-		#else
-			return arg == std::numeric_limits<T>::infinity() || arg == -std::numeric_limits<T>::infinity();
-		#endif
-		}
+/// Check for infinity.
+/// \tparam T argument type (builtin floating point type)
+/// \param arg value to query
+/// \retval true if infinity
+/// \retval false else
+template <typename T>
+bool builtin_isinf(T arg) {
+#if HALF_ENABLE_CPP11_CMATH
+  return std::isinf(arg);
+#elif defined(_MSC_VER)
+  return !::_finite(static_cast<double>(arg)) &&
+         !::_isnan(static_cast<double>(arg));
+#else
+  return arg == std::numeric_limits<T>::infinity() ||
+         arg == -std::numeric_limits<T>::infinity();
+#endif
+}
 
-		/// Check for NaN.
-		/// \tparam T argument type (builtin floating point type)
-		/// \param arg value to query
-		/// \retval true if not a number
-		/// \retval false else
-		template<typename T> bool builtin_isnan(T arg)
-		{
-		#if HALF_ENABLE_CPP11_CMATH
-			return std::isnan(arg);
-		#elif defined(_MSC_VER)
-			return ::_isnan(static_cast<double>(arg)) != 0;
-		#else
-			return arg != arg;
-		#endif
-		}
+/// Check for NaN.
+/// \tparam T argument type (builtin floating point type)
+/// \param arg value to query
+/// \retval true if not a number
+/// \retval false else
+template <typename T>
+bool builtin_isnan(T arg) {
+#if HALF_ENABLE_CPP11_CMATH
+  return std::isnan(arg);
+#elif defined(_MSC_VER)
+  return ::_isnan(static_cast<double>(arg)) != 0;
+#else
+  return arg != arg;
+#endif
+}
 
-		/// Check sign.
-		/// \tparam T argument type (builtin floating point type)
-		/// \param arg value to query
-		/// \retval true if signbit set
-		/// \retval false else
-		template<typename T> bool builtin_signbit(T arg)
-		{
-		#if HALF_ENABLE_CPP11_CMATH
-			return std::signbit(arg);
-		#else
-			return arg < T() || (arg == T() && T(1)/arg < T());
-		#endif
-		}
+/// Check sign.
+/// \tparam T argument type (builtin floating point type)
+/// \param arg value to query
+/// \retval true if signbit set
+/// \retval false else
+template <typename T>
+bool builtin_signbit(T arg) {
+#if HALF_ENABLE_CPP11_CMATH
+  return std::signbit(arg);
+#else
+  return arg < T() || (arg == T() && T(1) / arg < T());
+#endif
+}
 
-		/// \}
-		/// \name Conversion
-		/// \{
+/// \}
+/// \name Conversion
+/// \{
 
-		/// Convert IEEE single-precision to half-precision.
-		/// Credit for this goes to [Jeroen van der Zijp](ftp://ftp.fox-toolkit.org/pub/fasthalffloatconversion.pdf).
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \param value single-precision value
-		/// \return binary representation of half-precision value
-		template<std::float_round_style R> uint16 float2half_impl(float value, true_type)
-		{
-			typedef bits<float>::type uint32;
-			uint32 bits;// = *reinterpret_cast<uint32*>(&value);		//violating strict aliasing!
-			std::memcpy(&bits, &value, sizeof(float));
-/*			uint16 hbits = (bits>>16) & 0x8000;
+/// Convert IEEE single-precision to half-precision.
+/// Credit for this goes to [Jeroen van der
+/// Zijp](ftp://ftp.fox-toolkit.org/pub/fasthalffloatconversion.pdf).
+/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+/// rounding
+/// \param value single-precision value
+/// \return binary representation of half-precision value
+template <std::float_round_style R>
+uint16 float2half_impl(float value, true_type) {
+  typedef bits<float>::type uint32;
+  uint32
+      bits;  // = *reinterpret_cast<uint32*>(&value);		//violating
+             // strict aliasing!
+  std::memcpy(&bits, &value, sizeof(float));
+  /*			uint16 hbits = (bits>>16) & 0x8000;
 			bits &= 0x7FFFFFFF;
 			int exp = bits >> 23;
 			if(exp == 255)
@@ -498,254 +615,310 @@ namespace half_float
 				hbits += ~(hbits>>15) & (s|g);
 			else if(R == std::round_toward_neg_infinity)
 				hbits += (hbits>>15) & (g|s);
-*/			static const uint16 base_table[512] = { 
-				0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 
-				0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 
-				0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 
-				0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 
-				0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 
-				0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 
-				0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0001, 0x0002, 0x0004, 0x0008, 0x0010, 0x0020, 0x0040, 0x0080, 0x0100, 
-				0x0200, 0x0400, 0x0800, 0x0C00, 0x1000, 0x1400, 0x1800, 0x1C00, 0x2000, 0x2400, 0x2800, 0x2C00, 0x3000, 0x3400, 0x3800, 0x3C00, 
-				0x4000, 0x4400, 0x4800, 0x4C00, 0x5000, 0x5400, 0x5800, 0x5C00, 0x6000, 0x6400, 0x6800, 0x6C00, 0x7000, 0x7400, 0x7800, 0x7C00, 
-				0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 
-				0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 
-				0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 
-				0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 
-				0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 
-				0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 
-				0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 
-				0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 
-				0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 
-				0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 
-				0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 
-				0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 
-				0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 
-				0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8001, 0x8002, 0x8004, 0x8008, 0x8010, 0x8020, 0x8040, 0x8080, 0x8100, 
-				0x8200, 0x8400, 0x8800, 0x8C00, 0x9000, 0x9400, 0x9800, 0x9C00, 0xA000, 0xA400, 0xA800, 0xAC00, 0xB000, 0xB400, 0xB800, 0xBC00, 
-				0xC000, 0xC400, 0xC800, 0xCC00, 0xD000, 0xD400, 0xD800, 0xDC00, 0xE000, 0xE400, 0xE800, 0xEC00, 0xF000, 0xF400, 0xF800, 0xFC00, 
-				0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 
-				0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 
-				0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 
-				0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 
-				0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 
-				0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 
-				0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00 };
-			static const unsigned char shift_table[512] = { 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 
-				13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 13, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 
-				13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 13 };
-			uint16 hbits = base_table[bits>>23] + static_cast<uint16>((bits&0x7FFFFF)>>shift_table[bits>>23]);
-			if(R == std::round_to_nearest)
-				hbits += (((bits&0x7FFFFF)>>(shift_table[bits>>23]-1))|(((bits>>23)&0xFF)==102)) & ((hbits&0x7C00)!=0x7C00)
-				#if HALF_ROUND_TIES_TO_EVEN
-					& (((((static_cast<uint32>(1)<<(shift_table[bits>>23]-1))-1)&bits)!=0)|hbits)
-				#endif
-				;
-			else if(R == std::round_toward_zero)
-				hbits -= ((hbits&0x7FFF)==0x7C00) & ~shift_table[bits>>23];
-			else if(R == std::round_toward_infinity)
-				hbits += ((((bits&0x7FFFFF&((static_cast<uint32>(1)<<(shift_table[bits>>23]))-1))!=0)|(((bits>>23)<=102)&
-					((bits>>23)!=0)))&(hbits<0x7C00)) - ((hbits==0xFC00)&((bits>>23)!=511));
-			else if(R == std::round_toward_neg_infinity)
-				hbits += ((((bits&0x7FFFFF&((static_cast<uint32>(1)<<(shift_table[bits>>23]))-1))!=0)|(((bits>>23)<=358)&
-					((bits>>23)!=256)))&(hbits<0xFC00)&(hbits>>15)) - ((hbits==0x7C00)&((bits>>23)!=255));
-			return hbits;
-		}
+*/ static const uint16
+      base_table[512] = {
+          0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+          0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+          0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+          0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+          0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+          0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+          0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+          0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+          0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+          0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+          0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+          0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+          0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0001,
+          0x0002, 0x0004, 0x0008, 0x0010, 0x0020, 0x0040, 0x0080, 0x0100,
+          0x0200, 0x0400, 0x0800, 0x0C00, 0x1000, 0x1400, 0x1800, 0x1C00,
+          0x2000, 0x2400, 0x2800, 0x2C00, 0x3000, 0x3400, 0x3800, 0x3C00,
+          0x4000, 0x4400, 0x4800, 0x4C00, 0x5000, 0x5400, 0x5800, 0x5C00,
+          0x6000, 0x6400, 0x6800, 0x6C00, 0x7000, 0x7400, 0x7800, 0x7C00,
+          0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+          0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+          0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+          0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+          0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+          0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+          0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+          0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+          0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+          0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+          0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+          0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+          0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+          0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+          0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+          0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+          0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+          0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+          0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+          0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+          0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+          0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+          0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+          0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+          0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+          0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+          0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8001,
+          0x8002, 0x8004, 0x8008, 0x8010, 0x8020, 0x8040, 0x8080, 0x8100,
+          0x8200, 0x8400, 0x8800, 0x8C00, 0x9000, 0x9400, 0x9800, 0x9C00,
+          0xA000, 0xA400, 0xA800, 0xAC00, 0xB000, 0xB400, 0xB800, 0xBC00,
+          0xC000, 0xC400, 0xC800, 0xCC00, 0xD000, 0xD400, 0xD800, 0xDC00,
+          0xE000, 0xE400, 0xE800, 0xEC00, 0xF000, 0xF400, 0xF800, 0xFC00,
+          0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+          0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+          0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+          0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+          0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+          0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+          0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+          0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+          0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+          0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+          0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+          0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+          0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+          0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00};
+  static const unsigned char shift_table[512] = {
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 23, 22, 21, 20, 19,
+      18, 17, 16, 15, 14, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
+      13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 13, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 23,
+      22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 13, 13, 13, 13, 13, 13, 13, 13,
+      13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
+      13, 13, 13, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+      24, 24, 24, 24, 24, 24, 24, 13};
+  uint16 hbits =
+      base_table[bits >> 23] +
+      static_cast<uint16>((bits & 0x7FFFFF) >> shift_table[bits >> 23]);
+  if (R == std::round_to_nearest)
+    hbits +=
+        (((bits & 0x7FFFFF) >> (shift_table[bits >> 23] - 1)) |
+         (((bits >> 23) & 0xFF) == 102)) &
+        ((hbits & 0x7C00) != 0x7C00)
+#if HALF_ROUND_TIES_TO_EVEN
+        & (((((static_cast<uint32>(1) << (shift_table[bits >> 23] - 1)) - 1) &
+             bits) != 0) |
+           hbits)
+#endif
+        ;
+  else if (R == std::round_toward_zero)
+    hbits -= ((hbits & 0x7FFF) == 0x7C00) & ~shift_table[bits >> 23];
+  else if (R == std::round_toward_infinity)
+    hbits +=
+        ((((bits & 0x7FFFFF &
+            ((static_cast<uint32>(1) << (shift_table[bits >> 23])) - 1)) != 0) |
+          (((bits >> 23) <= 102) & ((bits >> 23) != 0))) &
+         (hbits < 0x7C00)) -
+        ((hbits == 0xFC00) & ((bits >> 23) != 511));
+  else if (R == std::round_toward_neg_infinity)
+    hbits +=
+        ((((bits & 0x7FFFFF &
+            ((static_cast<uint32>(1) << (shift_table[bits >> 23])) - 1)) != 0) |
+          (((bits >> 23) <= 358) & ((bits >> 23) != 256))) &
+         (hbits < 0xFC00) & (hbits >> 15)) -
+        ((hbits == 0x7C00) & ((bits >> 23) != 255));
+  return hbits;
+}
 
-		/// Convert IEEE double-precision to half-precision.
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \param value double-precision value
-		/// \return binary representation of half-precision value
-		template<std::float_round_style R> uint16 float2half_impl(double value, true_type)
-		{
-			typedef bits<float>::type uint32;
-			typedef bits<double>::type uint64;
-			uint64 bits;// = *reinterpret_cast<uint64*>(&value);		//violating strict aliasing!
-			std::memcpy(&bits, &value, sizeof(double));
-			uint32 hi = bits >> 32, lo = bits & 0xFFFFFFFF;
-			uint16 hbits = (hi>>16) & 0x8000;
-			hi &= 0x7FFFFFFF;
-			int exp = hi >> 20;
-			if(exp == 2047)
-				return hbits | 0x7C00 | (0x3FF&-static_cast<unsigned>((bits&0xFFFFFFFFFFFFF)!=0));
-			if(exp > 1038)
-			{
-				if(R == std::round_toward_infinity)
-					return hbits | 0x7C00 - (hbits>>15);
-				if(R == std::round_toward_neg_infinity)
-					return hbits | 0x7BFF + (hbits>>15);
-				return hbits | 0x7BFF + (R!=std::round_toward_zero);
-			}
-			int g, s = lo != 0;
-			if(exp > 1008)
-			{
-				g = (hi>>9) & 1;
-				s |= (hi&0x1FF) != 0;
-				hbits |= ((exp-1008)<<10) | ((hi>>10)&0x3FF);
-			}
-			else if(exp > 997)
-			{
-				int i = 1018 - exp;
-				hi = (hi&0xFFFFF) | 0x100000;
-				g = (hi>>i) & 1;
-				s |= (hi&((1L<<i)-1)) != 0;
-				hbits |= hi >> (i+1);
-			}
-			else
-			{
-				g = 0;
-				s |= hi != 0;
-			}
-			if(R == std::round_to_nearest)
-				#if HALF_ROUND_TIES_TO_EVEN
-					hbits += g & (s|hbits);
-				#else
-					hbits += g;
-				#endif
-			else if(R == std::round_toward_infinity)
-				hbits += ~(hbits>>15) & (s|g);
-			else if(R == std::round_toward_neg_infinity)
-				hbits += (hbits>>15) & (g|s);
-			return hbits;
-		}
+/// Convert IEEE double-precision to half-precision.
+/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+/// rounding
+/// \param value double-precision value
+/// \return binary representation of half-precision value
+template <std::float_round_style R>
+uint16 float2half_impl(double value, true_type) {
+  typedef bits<float>::type uint32;
+  typedef bits<double>::type uint64;
+  uint64
+      bits;  // = *reinterpret_cast<uint64*>(&value);		//violating
+             // strict aliasing!
+  std::memcpy(&bits, &value, sizeof(double));
+  uint32 hi = bits >> 32, lo = bits & 0xFFFFFFFF;
+  uint16 hbits = (hi >> 16) & 0x8000;
+  hi &= 0x7FFFFFFF;
+  int exp = hi >> 20;
+  if (exp == 2047)
+    return hbits | 0x7C00 |
+           (0x3FF & -static_cast<unsigned>((bits & 0xFFFFFFFFFFFFF) != 0));
+  if (exp > 1038) {
+    if (R == std::round_toward_infinity) return hbits | 0x7C00 - (hbits >> 15);
+    if (R == std::round_toward_neg_infinity)
+      return hbits | 0x7BFF + (hbits >> 15);
+    return hbits | 0x7BFF + (R != std::round_toward_zero);
+  }
+  int g, s = lo != 0;
+  if (exp > 1008) {
+    g = (hi >> 9) & 1;
+    s |= (hi & 0x1FF) != 0;
+    hbits |= ((exp - 1008) << 10) | ((hi >> 10) & 0x3FF);
+  } else if (exp > 997) {
+    int i = 1018 - exp;
+    hi = (hi & 0xFFFFF) | 0x100000;
+    g = (hi >> i) & 1;
+    s |= (hi & ((1L << i) - 1)) != 0;
+    hbits |= hi >> (i + 1);
+  } else {
+    g = 0;
+    s |= hi != 0;
+  }
+  if (R == std::round_to_nearest)
+#if HALF_ROUND_TIES_TO_EVEN
+    hbits += g & (s | hbits);
+#else
+    hbits += g;
+#endif
+  else if (R == std::round_toward_infinity)
+    hbits += ~(hbits >> 15) & (s | g);
+  else if (R == std::round_toward_neg_infinity)
+    hbits += (hbits >> 15) & (g | s);
+  return hbits;
+}
 
-		/// Convert non-IEEE floating point to half-precision.
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \tparam T source type (builtin floating point type)
-		/// \param value floating point value
-		/// \return binary representation of half-precision value
-		template<std::float_round_style R,typename T> uint16 float2half_impl(T value, ...)
-		{
-			uint16 hbits = static_cast<unsigned>(builtin_signbit(value)) << 15;
-			if(value == T())
-				return hbits;
-			if(builtin_isnan(value))
-				return hbits | 0x7FFF;
-			if(builtin_isinf(value))
-				return hbits | 0x7C00;
-			int exp;
-			std::frexp(value, &exp);
-			if(exp > 16)
-			{
-				if(R == std::round_toward_infinity)
-					return hbits | (0x7C00 - (hbits>>15));
-				else if(R == std::round_toward_neg_infinity)
-					return hbits | (0x7BFF + (hbits>>15));
-				return hbits | (0x7BFF + (R!=std::round_toward_zero));
-			}
-			if(exp < -13)
-				value = std::ldexp(value, 24);
-			else
-			{
-				value = std::ldexp(value, 11-exp);
-				hbits |= ((exp+13)<<10);
-			}
-			T ival, frac = std::modf(value, &ival);
-			hbits += static_cast<uint16>(std::abs(static_cast<int>(ival)));
-			if(R == std::round_to_nearest)
-			{
-				frac = std::abs(frac);
-				#if HALF_ROUND_TIES_TO_EVEN
-					hbits += (frac>T(0.5)) | ((frac==T(0.5))&hbits);
-				#else
-					hbits += frac >= T(0.5);
-				#endif
-			}
-			else if(R == std::round_toward_infinity)
-				hbits += frac > T();
-			else if(R == std::round_toward_neg_infinity)
-				hbits += frac < T();
-			return hbits;
-		}
+/// Convert non-IEEE floating point to half-precision.
+/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+/// rounding
+/// \tparam T source type (builtin floating point type)
+/// \param value floating point value
+/// \return binary representation of half-precision value
+template <std::float_round_style R, typename T>
+uint16 float2half_impl(T value, ...) {
+  uint16 hbits = static_cast<unsigned>(builtin_signbit(value)) << 15;
+  if (value == T()) return hbits;
+  if (builtin_isnan(value)) return hbits | 0x7FFF;
+  if (builtin_isinf(value)) return hbits | 0x7C00;
+  int exp;
+  std::frexp(value, &exp);
+  if (exp > 16) {
+    if (R == std::round_toward_infinity)
+      return hbits | (0x7C00 - (hbits >> 15));
+    else if (R == std::round_toward_neg_infinity)
+      return hbits | (0x7BFF + (hbits >> 15));
+    return hbits | (0x7BFF + (R != std::round_toward_zero));
+  }
+  if (exp < -13)
+    value = std::ldexp(value, 24);
+  else {
+    value = std::ldexp(value, 11 - exp);
+    hbits |= ((exp + 13) << 10);
+  }
+  T ival, frac = std::modf(value, &ival);
+  hbits += static_cast<uint16>(std::abs(static_cast<int>(ival)));
+  if (R == std::round_to_nearest) {
+    frac = std::abs(frac);
+#if HALF_ROUND_TIES_TO_EVEN
+    hbits += (frac > T(0.5)) | ((frac == T(0.5)) & hbits);
+#else
+    hbits += frac >= T(0.5);
+#endif
+  } else if (R == std::round_toward_infinity)
+    hbits += frac > T();
+  else if (R == std::round_toward_neg_infinity)
+    hbits += frac < T();
+  return hbits;
+}
 
-		/// Convert floating point to half-precision.
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \tparam T source type (builtin floating point type)
-		/// \param value floating point value
-		/// \return binary representation of half-precision value
-		template<std::float_round_style R,typename T> uint16 float2half(T value)
-		{
-			return float2half_impl<R>(value, bool_type<std::numeric_limits<T>::is_iec559&&sizeof(typename bits<T>::type)==sizeof(T)>());
-		}
+/// Convert floating point to half-precision.
+/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+/// rounding
+/// \tparam T source type (builtin floating point type)
+/// \param value floating point value
+/// \return binary representation of half-precision value
+template <std::float_round_style R, typename T>
+uint16 float2half(T value) {
+  return float2half_impl<R>(
+      value, bool_type < std::numeric_limits<T>::is_iec559 &&
+                 sizeof(typename bits<T>::type) == sizeof(T) > ());
+}
 
-		/// Convert integer to half-precision floating point.
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \tparam S `true` if value negative, `false` else
-		/// \tparam T type to convert (builtin integer type)
-		/// \param value non-negative integral value
-		/// \return binary representation of half-precision value
-		template<std::float_round_style R,bool S,typename T> uint16 int2half_impl(T value)
-		{
-		#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
-			static_assert(std::is_integral<T>::value, "int to half conversion only supports builtin integer types");
-		#endif
-			if(S)
-				value = -value;
-			uint16 bits = S << 15;
-			if(value > 0xFFFF)
-			{
-				if(R == std::round_toward_infinity)
-					bits |= 0x7C00 - S;
-				else if(R == std::round_toward_neg_infinity)
-					bits |= 0x7BFF + S;
-				else
-					bits |= 0x7BFF + (R!=std::round_toward_zero);
-			}
-			else if(value)
-			{
-				unsigned int m = value, exp = 24;
-				for(; m<0x400; m<<=1,--exp) ;
-				for(; m>0x7FF; m>>=1,++exp) ;
-				bits |= (exp<<10) + m;
-				if(exp > 24)
-				{
-					if(R == std::round_to_nearest)
-						bits += (value>>(exp-25)) & 1
-						#if HALF_ROUND_TIES_TO_EVEN
-							& (((((1<<(exp-25))-1)&value)!=0)|bits)
-						#endif
-						;
-					else if(R == std::round_toward_infinity)
-						bits += ((value&((1<<(exp-24))-1))!=0) & !S;
-					else if(R == std::round_toward_neg_infinity)
-						bits += ((value&((1<<(exp-24))-1))!=0) & S;
-				}
-			}
-			return bits;
-		}
+/// Convert integer to half-precision floating point.
+/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+/// rounding
+/// \tparam S `true` if value negative, `false` else
+/// \tparam T type to convert (builtin integer type)
+/// \param value non-negative integral value
+/// \return binary representation of half-precision value
+template <std::float_round_style R, bool S, typename T>
+uint16 int2half_impl(T value) {
+#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
+  static_assert(std::is_integral<T>::value,
+                "int to half conversion only supports builtin integer types");
+#endif
+  if (S) value = -value;
+  uint16 bits = S << 15;
+  if (value > 0xFFFF) {
+    if (R == std::round_toward_infinity)
+      bits |= 0x7C00 - S;
+    else if (R == std::round_toward_neg_infinity)
+      bits |= 0x7BFF + S;
+    else
+      bits |= 0x7BFF + (R != std::round_toward_zero);
+  } else if (value) {
+    unsigned int m = value, exp = 24;
+    for (; m < 0x400; m <<= 1, --exp)
+      ;
+    for (; m > 0x7FF; m >>= 1, ++exp)
+      ;
+    bits |= (exp << 10) + m;
+    if (exp > 24) {
+      if (R == std::round_to_nearest)
+        bits += (value >> (exp - 25)) & 1
+#if HALF_ROUND_TIES_TO_EVEN
+                & (((((1 << (exp - 25)) - 1) & value) != 0) | bits)
+#endif
+            ;
+      else if (R == std::round_toward_infinity)
+        bits += ((value & ((1 << (exp - 24)) - 1)) != 0) & !S;
+      else if (R == std::round_toward_neg_infinity)
+        bits += ((value & ((1 << (exp - 24)) - 1)) != 0) & S;
+    }
+  }
+  return bits;
+}
 
-		/// Convert integer to half-precision floating point.
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \tparam T type to convert (builtin integer type)
-		/// \param value integral value
-		/// \return binary representation of half-precision value
-		template<std::float_round_style R,typename T> uint16 int2half(T value)
-		{
-			return (value<0) ? int2half_impl<R,true>(value) : int2half_impl<R,false>(value);
-		}
+/// Convert integer to half-precision floating point.
+/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+/// rounding
+/// \tparam T type to convert (builtin integer type)
+/// \param value integral value
+/// \return binary representation of half-precision value
+template <std::float_round_style R, typename T>
+uint16 int2half(T value) {
+  return (value < 0) ? int2half_impl<R, true>(value)
+                     : int2half_impl<R, false>(value);
+}
 
-		/// Convert half-precision to IEEE single-precision.
-		/// Credit for this goes to [Jeroen van der Zijp](ftp://ftp.fox-toolkit.org/pub/fasthalffloatconversion.pdf).
-		/// \param value binary representation of half-precision value
-		/// \return single-precision value
-		inline float half2float_impl(uint16 value, float, true_type)
-		{
-			typedef bits<float>::type uint32;
-/*			uint32 bits = static_cast<uint32>(value&0x8000) << 16;
+/// Convert half-precision to IEEE single-precision.
+/// Credit for this goes to [Jeroen van der
+/// Zijp](ftp://ftp.fox-toolkit.org/pub/fasthalffloatconversion.pdf).
+/// \param value binary representation of half-precision value
+/// \return single-precision value
+inline float half2float_impl(uint16 value, float, true_type) {
+  typedef bits<float>::type uint32;
+  /*			uint32 bits = static_cast<uint32>(value&0x8000) << 16;
 			int abs = value & 0x7FFF;
 			if(abs)
 			{
@@ -753,2315 +926,2927 @@ namespace half_float
 				for(; abs<0x400; abs<<=1,bits-=0x800000) ;
 				bits += static_cast<uint32>(abs) << 13;
 			}
-*/			static const uint32 mantissa_table[2048] = { 
-				0x00000000, 0x33800000, 0x34000000, 0x34400000, 0x34800000, 0x34A00000, 0x34C00000, 0x34E00000, 0x35000000, 0x35100000, 0x35200000, 0x35300000, 0x35400000, 0x35500000, 0x35600000, 0x35700000, 
-				0x35800000, 0x35880000, 0x35900000, 0x35980000, 0x35A00000, 0x35A80000, 0x35B00000, 0x35B80000, 0x35C00000, 0x35C80000, 0x35D00000, 0x35D80000, 0x35E00000, 0x35E80000, 0x35F00000, 0x35F80000, 
-				0x36000000, 0x36040000, 0x36080000, 0x360C0000, 0x36100000, 0x36140000, 0x36180000, 0x361C0000, 0x36200000, 0x36240000, 0x36280000, 0x362C0000, 0x36300000, 0x36340000, 0x36380000, 0x363C0000, 
-				0x36400000, 0x36440000, 0x36480000, 0x364C0000, 0x36500000, 0x36540000, 0x36580000, 0x365C0000, 0x36600000, 0x36640000, 0x36680000, 0x366C0000, 0x36700000, 0x36740000, 0x36780000, 0x367C0000, 
-				0x36800000, 0x36820000, 0x36840000, 0x36860000, 0x36880000, 0x368A0000, 0x368C0000, 0x368E0000, 0x36900000, 0x36920000, 0x36940000, 0x36960000, 0x36980000, 0x369A0000, 0x369C0000, 0x369E0000, 
-				0x36A00000, 0x36A20000, 0x36A40000, 0x36A60000, 0x36A80000, 0x36AA0000, 0x36AC0000, 0x36AE0000, 0x36B00000, 0x36B20000, 0x36B40000, 0x36B60000, 0x36B80000, 0x36BA0000, 0x36BC0000, 0x36BE0000, 
-				0x36C00000, 0x36C20000, 0x36C40000, 0x36C60000, 0x36C80000, 0x36CA0000, 0x36CC0000, 0x36CE0000, 0x36D00000, 0x36D20000, 0x36D40000, 0x36D60000, 0x36D80000, 0x36DA0000, 0x36DC0000, 0x36DE0000, 
-				0x36E00000, 0x36E20000, 0x36E40000, 0x36E60000, 0x36E80000, 0x36EA0000, 0x36EC0000, 0x36EE0000, 0x36F00000, 0x36F20000, 0x36F40000, 0x36F60000, 0x36F80000, 0x36FA0000, 0x36FC0000, 0x36FE0000, 
-				0x37000000, 0x37010000, 0x37020000, 0x37030000, 0x37040000, 0x37050000, 0x37060000, 0x37070000, 0x37080000, 0x37090000, 0x370A0000, 0x370B0000, 0x370C0000, 0x370D0000, 0x370E0000, 0x370F0000, 
-				0x37100000, 0x37110000, 0x37120000, 0x37130000, 0x37140000, 0x37150000, 0x37160000, 0x37170000, 0x37180000, 0x37190000, 0x371A0000, 0x371B0000, 0x371C0000, 0x371D0000, 0x371E0000, 0x371F0000, 
-				0x37200000, 0x37210000, 0x37220000, 0x37230000, 0x37240000, 0x37250000, 0x37260000, 0x37270000, 0x37280000, 0x37290000, 0x372A0000, 0x372B0000, 0x372C0000, 0x372D0000, 0x372E0000, 0x372F0000, 
-				0x37300000, 0x37310000, 0x37320000, 0x37330000, 0x37340000, 0x37350000, 0x37360000, 0x37370000, 0x37380000, 0x37390000, 0x373A0000, 0x373B0000, 0x373C0000, 0x373D0000, 0x373E0000, 0x373F0000, 
-				0x37400000, 0x37410000, 0x37420000, 0x37430000, 0x37440000, 0x37450000, 0x37460000, 0x37470000, 0x37480000, 0x37490000, 0x374A0000, 0x374B0000, 0x374C0000, 0x374D0000, 0x374E0000, 0x374F0000, 
-				0x37500000, 0x37510000, 0x37520000, 0x37530000, 0x37540000, 0x37550000, 0x37560000, 0x37570000, 0x37580000, 0x37590000, 0x375A0000, 0x375B0000, 0x375C0000, 0x375D0000, 0x375E0000, 0x375F0000, 
-				0x37600000, 0x37610000, 0x37620000, 0x37630000, 0x37640000, 0x37650000, 0x37660000, 0x37670000, 0x37680000, 0x37690000, 0x376A0000, 0x376B0000, 0x376C0000, 0x376D0000, 0x376E0000, 0x376F0000, 
-				0x37700000, 0x37710000, 0x37720000, 0x37730000, 0x37740000, 0x37750000, 0x37760000, 0x37770000, 0x37780000, 0x37790000, 0x377A0000, 0x377B0000, 0x377C0000, 0x377D0000, 0x377E0000, 0x377F0000, 
-				0x37800000, 0x37808000, 0x37810000, 0x37818000, 0x37820000, 0x37828000, 0x37830000, 0x37838000, 0x37840000, 0x37848000, 0x37850000, 0x37858000, 0x37860000, 0x37868000, 0x37870000, 0x37878000, 
-				0x37880000, 0x37888000, 0x37890000, 0x37898000, 0x378A0000, 0x378A8000, 0x378B0000, 0x378B8000, 0x378C0000, 0x378C8000, 0x378D0000, 0x378D8000, 0x378E0000, 0x378E8000, 0x378F0000, 0x378F8000, 
-				0x37900000, 0x37908000, 0x37910000, 0x37918000, 0x37920000, 0x37928000, 0x37930000, 0x37938000, 0x37940000, 0x37948000, 0x37950000, 0x37958000, 0x37960000, 0x37968000, 0x37970000, 0x37978000, 
-				0x37980000, 0x37988000, 0x37990000, 0x37998000, 0x379A0000, 0x379A8000, 0x379B0000, 0x379B8000, 0x379C0000, 0x379C8000, 0x379D0000, 0x379D8000, 0x379E0000, 0x379E8000, 0x379F0000, 0x379F8000, 
-				0x37A00000, 0x37A08000, 0x37A10000, 0x37A18000, 0x37A20000, 0x37A28000, 0x37A30000, 0x37A38000, 0x37A40000, 0x37A48000, 0x37A50000, 0x37A58000, 0x37A60000, 0x37A68000, 0x37A70000, 0x37A78000, 
-				0x37A80000, 0x37A88000, 0x37A90000, 0x37A98000, 0x37AA0000, 0x37AA8000, 0x37AB0000, 0x37AB8000, 0x37AC0000, 0x37AC8000, 0x37AD0000, 0x37AD8000, 0x37AE0000, 0x37AE8000, 0x37AF0000, 0x37AF8000, 
-				0x37B00000, 0x37B08000, 0x37B10000, 0x37B18000, 0x37B20000, 0x37B28000, 0x37B30000, 0x37B38000, 0x37B40000, 0x37B48000, 0x37B50000, 0x37B58000, 0x37B60000, 0x37B68000, 0x37B70000, 0x37B78000, 
-				0x37B80000, 0x37B88000, 0x37B90000, 0x37B98000, 0x37BA0000, 0x37BA8000, 0x37BB0000, 0x37BB8000, 0x37BC0000, 0x37BC8000, 0x37BD0000, 0x37BD8000, 0x37BE0000, 0x37BE8000, 0x37BF0000, 0x37BF8000, 
-				0x37C00000, 0x37C08000, 0x37C10000, 0x37C18000, 0x37C20000, 0x37C28000, 0x37C30000, 0x37C38000, 0x37C40000, 0x37C48000, 0x37C50000, 0x37C58000, 0x37C60000, 0x37C68000, 0x37C70000, 0x37C78000, 
-				0x37C80000, 0x37C88000, 0x37C90000, 0x37C98000, 0x37CA0000, 0x37CA8000, 0x37CB0000, 0x37CB8000, 0x37CC0000, 0x37CC8000, 0x37CD0000, 0x37CD8000, 0x37CE0000, 0x37CE8000, 0x37CF0000, 0x37CF8000, 
-				0x37D00000, 0x37D08000, 0x37D10000, 0x37D18000, 0x37D20000, 0x37D28000, 0x37D30000, 0x37D38000, 0x37D40000, 0x37D48000, 0x37D50000, 0x37D58000, 0x37D60000, 0x37D68000, 0x37D70000, 0x37D78000, 
-				0x37D80000, 0x37D88000, 0x37D90000, 0x37D98000, 0x37DA0000, 0x37DA8000, 0x37DB0000, 0x37DB8000, 0x37DC0000, 0x37DC8000, 0x37DD0000, 0x37DD8000, 0x37DE0000, 0x37DE8000, 0x37DF0000, 0x37DF8000, 
-				0x37E00000, 0x37E08000, 0x37E10000, 0x37E18000, 0x37E20000, 0x37E28000, 0x37E30000, 0x37E38000, 0x37E40000, 0x37E48000, 0x37E50000, 0x37E58000, 0x37E60000, 0x37E68000, 0x37E70000, 0x37E78000, 
-				0x37E80000, 0x37E88000, 0x37E90000, 0x37E98000, 0x37EA0000, 0x37EA8000, 0x37EB0000, 0x37EB8000, 0x37EC0000, 0x37EC8000, 0x37ED0000, 0x37ED8000, 0x37EE0000, 0x37EE8000, 0x37EF0000, 0x37EF8000, 
-				0x37F00000, 0x37F08000, 0x37F10000, 0x37F18000, 0x37F20000, 0x37F28000, 0x37F30000, 0x37F38000, 0x37F40000, 0x37F48000, 0x37F50000, 0x37F58000, 0x37F60000, 0x37F68000, 0x37F70000, 0x37F78000, 
-				0x37F80000, 0x37F88000, 0x37F90000, 0x37F98000, 0x37FA0000, 0x37FA8000, 0x37FB0000, 0x37FB8000, 0x37FC0000, 0x37FC8000, 0x37FD0000, 0x37FD8000, 0x37FE0000, 0x37FE8000, 0x37FF0000, 0x37FF8000, 
-				0x38000000, 0x38004000, 0x38008000, 0x3800C000, 0x38010000, 0x38014000, 0x38018000, 0x3801C000, 0x38020000, 0x38024000, 0x38028000, 0x3802C000, 0x38030000, 0x38034000, 0x38038000, 0x3803C000, 
-				0x38040000, 0x38044000, 0x38048000, 0x3804C000, 0x38050000, 0x38054000, 0x38058000, 0x3805C000, 0x38060000, 0x38064000, 0x38068000, 0x3806C000, 0x38070000, 0x38074000, 0x38078000, 0x3807C000, 
-				0x38080000, 0x38084000, 0x38088000, 0x3808C000, 0x38090000, 0x38094000, 0x38098000, 0x3809C000, 0x380A0000, 0x380A4000, 0x380A8000, 0x380AC000, 0x380B0000, 0x380B4000, 0x380B8000, 0x380BC000, 
-				0x380C0000, 0x380C4000, 0x380C8000, 0x380CC000, 0x380D0000, 0x380D4000, 0x380D8000, 0x380DC000, 0x380E0000, 0x380E4000, 0x380E8000, 0x380EC000, 0x380F0000, 0x380F4000, 0x380F8000, 0x380FC000, 
-				0x38100000, 0x38104000, 0x38108000, 0x3810C000, 0x38110000, 0x38114000, 0x38118000, 0x3811C000, 0x38120000, 0x38124000, 0x38128000, 0x3812C000, 0x38130000, 0x38134000, 0x38138000, 0x3813C000, 
-				0x38140000, 0x38144000, 0x38148000, 0x3814C000, 0x38150000, 0x38154000, 0x38158000, 0x3815C000, 0x38160000, 0x38164000, 0x38168000, 0x3816C000, 0x38170000, 0x38174000, 0x38178000, 0x3817C000, 
-				0x38180000, 0x38184000, 0x38188000, 0x3818C000, 0x38190000, 0x38194000, 0x38198000, 0x3819C000, 0x381A0000, 0x381A4000, 0x381A8000, 0x381AC000, 0x381B0000, 0x381B4000, 0x381B8000, 0x381BC000, 
-				0x381C0000, 0x381C4000, 0x381C8000, 0x381CC000, 0x381D0000, 0x381D4000, 0x381D8000, 0x381DC000, 0x381E0000, 0x381E4000, 0x381E8000, 0x381EC000, 0x381F0000, 0x381F4000, 0x381F8000, 0x381FC000, 
-				0x38200000, 0x38204000, 0x38208000, 0x3820C000, 0x38210000, 0x38214000, 0x38218000, 0x3821C000, 0x38220000, 0x38224000, 0x38228000, 0x3822C000, 0x38230000, 0x38234000, 0x38238000, 0x3823C000, 
-				0x38240000, 0x38244000, 0x38248000, 0x3824C000, 0x38250000, 0x38254000, 0x38258000, 0x3825C000, 0x38260000, 0x38264000, 0x38268000, 0x3826C000, 0x38270000, 0x38274000, 0x38278000, 0x3827C000, 
-				0x38280000, 0x38284000, 0x38288000, 0x3828C000, 0x38290000, 0x38294000, 0x38298000, 0x3829C000, 0x382A0000, 0x382A4000, 0x382A8000, 0x382AC000, 0x382B0000, 0x382B4000, 0x382B8000, 0x382BC000, 
-				0x382C0000, 0x382C4000, 0x382C8000, 0x382CC000, 0x382D0000, 0x382D4000, 0x382D8000, 0x382DC000, 0x382E0000, 0x382E4000, 0x382E8000, 0x382EC000, 0x382F0000, 0x382F4000, 0x382F8000, 0x382FC000, 
-				0x38300000, 0x38304000, 0x38308000, 0x3830C000, 0x38310000, 0x38314000, 0x38318000, 0x3831C000, 0x38320000, 0x38324000, 0x38328000, 0x3832C000, 0x38330000, 0x38334000, 0x38338000, 0x3833C000, 
-				0x38340000, 0x38344000, 0x38348000, 0x3834C000, 0x38350000, 0x38354000, 0x38358000, 0x3835C000, 0x38360000, 0x38364000, 0x38368000, 0x3836C000, 0x38370000, 0x38374000, 0x38378000, 0x3837C000, 
-				0x38380000, 0x38384000, 0x38388000, 0x3838C000, 0x38390000, 0x38394000, 0x38398000, 0x3839C000, 0x383A0000, 0x383A4000, 0x383A8000, 0x383AC000, 0x383B0000, 0x383B4000, 0x383B8000, 0x383BC000, 
-				0x383C0000, 0x383C4000, 0x383C8000, 0x383CC000, 0x383D0000, 0x383D4000, 0x383D8000, 0x383DC000, 0x383E0000, 0x383E4000, 0x383E8000, 0x383EC000, 0x383F0000, 0x383F4000, 0x383F8000, 0x383FC000, 
-				0x38400000, 0x38404000, 0x38408000, 0x3840C000, 0x38410000, 0x38414000, 0x38418000, 0x3841C000, 0x38420000, 0x38424000, 0x38428000, 0x3842C000, 0x38430000, 0x38434000, 0x38438000, 0x3843C000, 
-				0x38440000, 0x38444000, 0x38448000, 0x3844C000, 0x38450000, 0x38454000, 0x38458000, 0x3845C000, 0x38460000, 0x38464000, 0x38468000, 0x3846C000, 0x38470000, 0x38474000, 0x38478000, 0x3847C000, 
-				0x38480000, 0x38484000, 0x38488000, 0x3848C000, 0x38490000, 0x38494000, 0x38498000, 0x3849C000, 0x384A0000, 0x384A4000, 0x384A8000, 0x384AC000, 0x384B0000, 0x384B4000, 0x384B8000, 0x384BC000, 
-				0x384C0000, 0x384C4000, 0x384C8000, 0x384CC000, 0x384D0000, 0x384D4000, 0x384D8000, 0x384DC000, 0x384E0000, 0x384E4000, 0x384E8000, 0x384EC000, 0x384F0000, 0x384F4000, 0x384F8000, 0x384FC000, 
-				0x38500000, 0x38504000, 0x38508000, 0x3850C000, 0x38510000, 0x38514000, 0x38518000, 0x3851C000, 0x38520000, 0x38524000, 0x38528000, 0x3852C000, 0x38530000, 0x38534000, 0x38538000, 0x3853C000, 
-				0x38540000, 0x38544000, 0x38548000, 0x3854C000, 0x38550000, 0x38554000, 0x38558000, 0x3855C000, 0x38560000, 0x38564000, 0x38568000, 0x3856C000, 0x38570000, 0x38574000, 0x38578000, 0x3857C000, 
-				0x38580000, 0x38584000, 0x38588000, 0x3858C000, 0x38590000, 0x38594000, 0x38598000, 0x3859C000, 0x385A0000, 0x385A4000, 0x385A8000, 0x385AC000, 0x385B0000, 0x385B4000, 0x385B8000, 0x385BC000, 
-				0x385C0000, 0x385C4000, 0x385C8000, 0x385CC000, 0x385D0000, 0x385D4000, 0x385D8000, 0x385DC000, 0x385E0000, 0x385E4000, 0x385E8000, 0x385EC000, 0x385F0000, 0x385F4000, 0x385F8000, 0x385FC000, 
-				0x38600000, 0x38604000, 0x38608000, 0x3860C000, 0x38610000, 0x38614000, 0x38618000, 0x3861C000, 0x38620000, 0x38624000, 0x38628000, 0x3862C000, 0x38630000, 0x38634000, 0x38638000, 0x3863C000, 
-				0x38640000, 0x38644000, 0x38648000, 0x3864C000, 0x38650000, 0x38654000, 0x38658000, 0x3865C000, 0x38660000, 0x38664000, 0x38668000, 0x3866C000, 0x38670000, 0x38674000, 0x38678000, 0x3867C000, 
-				0x38680000, 0x38684000, 0x38688000, 0x3868C000, 0x38690000, 0x38694000, 0x38698000, 0x3869C000, 0x386A0000, 0x386A4000, 0x386A8000, 0x386AC000, 0x386B0000, 0x386B4000, 0x386B8000, 0x386BC000, 
-				0x386C0000, 0x386C4000, 0x386C8000, 0x386CC000, 0x386D0000, 0x386D4000, 0x386D8000, 0x386DC000, 0x386E0000, 0x386E4000, 0x386E8000, 0x386EC000, 0x386F0000, 0x386F4000, 0x386F8000, 0x386FC000, 
-				0x38700000, 0x38704000, 0x38708000, 0x3870C000, 0x38710000, 0x38714000, 0x38718000, 0x3871C000, 0x38720000, 0x38724000, 0x38728000, 0x3872C000, 0x38730000, 0x38734000, 0x38738000, 0x3873C000, 
-				0x38740000, 0x38744000, 0x38748000, 0x3874C000, 0x38750000, 0x38754000, 0x38758000, 0x3875C000, 0x38760000, 0x38764000, 0x38768000, 0x3876C000, 0x38770000, 0x38774000, 0x38778000, 0x3877C000, 
-				0x38780000, 0x38784000, 0x38788000, 0x3878C000, 0x38790000, 0x38794000, 0x38798000, 0x3879C000, 0x387A0000, 0x387A4000, 0x387A8000, 0x387AC000, 0x387B0000, 0x387B4000, 0x387B8000, 0x387BC000, 
-				0x387C0000, 0x387C4000, 0x387C8000, 0x387CC000, 0x387D0000, 0x387D4000, 0x387D8000, 0x387DC000, 0x387E0000, 0x387E4000, 0x387E8000, 0x387EC000, 0x387F0000, 0x387F4000, 0x387F8000, 0x387FC000, 
-				0x38000000, 0x38002000, 0x38004000, 0x38006000, 0x38008000, 0x3800A000, 0x3800C000, 0x3800E000, 0x38010000, 0x38012000, 0x38014000, 0x38016000, 0x38018000, 0x3801A000, 0x3801C000, 0x3801E000, 
-				0x38020000, 0x38022000, 0x38024000, 0x38026000, 0x38028000, 0x3802A000, 0x3802C000, 0x3802E000, 0x38030000, 0x38032000, 0x38034000, 0x38036000, 0x38038000, 0x3803A000, 0x3803C000, 0x3803E000, 
-				0x38040000, 0x38042000, 0x38044000, 0x38046000, 0x38048000, 0x3804A000, 0x3804C000, 0x3804E000, 0x38050000, 0x38052000, 0x38054000, 0x38056000, 0x38058000, 0x3805A000, 0x3805C000, 0x3805E000, 
-				0x38060000, 0x38062000, 0x38064000, 0x38066000, 0x38068000, 0x3806A000, 0x3806C000, 0x3806E000, 0x38070000, 0x38072000, 0x38074000, 0x38076000, 0x38078000, 0x3807A000, 0x3807C000, 0x3807E000, 
-				0x38080000, 0x38082000, 0x38084000, 0x38086000, 0x38088000, 0x3808A000, 0x3808C000, 0x3808E000, 0x38090000, 0x38092000, 0x38094000, 0x38096000, 0x38098000, 0x3809A000, 0x3809C000, 0x3809E000, 
-				0x380A0000, 0x380A2000, 0x380A4000, 0x380A6000, 0x380A8000, 0x380AA000, 0x380AC000, 0x380AE000, 0x380B0000, 0x380B2000, 0x380B4000, 0x380B6000, 0x380B8000, 0x380BA000, 0x380BC000, 0x380BE000, 
-				0x380C0000, 0x380C2000, 0x380C4000, 0x380C6000, 0x380C8000, 0x380CA000, 0x380CC000, 0x380CE000, 0x380D0000, 0x380D2000, 0x380D4000, 0x380D6000, 0x380D8000, 0x380DA000, 0x380DC000, 0x380DE000, 
-				0x380E0000, 0x380E2000, 0x380E4000, 0x380E6000, 0x380E8000, 0x380EA000, 0x380EC000, 0x380EE000, 0x380F0000, 0x380F2000, 0x380F4000, 0x380F6000, 0x380F8000, 0x380FA000, 0x380FC000, 0x380FE000, 
-				0x38100000, 0x38102000, 0x38104000, 0x38106000, 0x38108000, 0x3810A000, 0x3810C000, 0x3810E000, 0x38110000, 0x38112000, 0x38114000, 0x38116000, 0x38118000, 0x3811A000, 0x3811C000, 0x3811E000, 
-				0x38120000, 0x38122000, 0x38124000, 0x38126000, 0x38128000, 0x3812A000, 0x3812C000, 0x3812E000, 0x38130000, 0x38132000, 0x38134000, 0x38136000, 0x38138000, 0x3813A000, 0x3813C000, 0x3813E000, 
-				0x38140000, 0x38142000, 0x38144000, 0x38146000, 0x38148000, 0x3814A000, 0x3814C000, 0x3814E000, 0x38150000, 0x38152000, 0x38154000, 0x38156000, 0x38158000, 0x3815A000, 0x3815C000, 0x3815E000, 
-				0x38160000, 0x38162000, 0x38164000, 0x38166000, 0x38168000, 0x3816A000, 0x3816C000, 0x3816E000, 0x38170000, 0x38172000, 0x38174000, 0x38176000, 0x38178000, 0x3817A000, 0x3817C000, 0x3817E000, 
-				0x38180000, 0x38182000, 0x38184000, 0x38186000, 0x38188000, 0x3818A000, 0x3818C000, 0x3818E000, 0x38190000, 0x38192000, 0x38194000, 0x38196000, 0x38198000, 0x3819A000, 0x3819C000, 0x3819E000, 
-				0x381A0000, 0x381A2000, 0x381A4000, 0x381A6000, 0x381A8000, 0x381AA000, 0x381AC000, 0x381AE000, 0x381B0000, 0x381B2000, 0x381B4000, 0x381B6000, 0x381B8000, 0x381BA000, 0x381BC000, 0x381BE000, 
-				0x381C0000, 0x381C2000, 0x381C4000, 0x381C6000, 0x381C8000, 0x381CA000, 0x381CC000, 0x381CE000, 0x381D0000, 0x381D2000, 0x381D4000, 0x381D6000, 0x381D8000, 0x381DA000, 0x381DC000, 0x381DE000, 
-				0x381E0000, 0x381E2000, 0x381E4000, 0x381E6000, 0x381E8000, 0x381EA000, 0x381EC000, 0x381EE000, 0x381F0000, 0x381F2000, 0x381F4000, 0x381F6000, 0x381F8000, 0x381FA000, 0x381FC000, 0x381FE000, 
-				0x38200000, 0x38202000, 0x38204000, 0x38206000, 0x38208000, 0x3820A000, 0x3820C000, 0x3820E000, 0x38210000, 0x38212000, 0x38214000, 0x38216000, 0x38218000, 0x3821A000, 0x3821C000, 0x3821E000, 
-				0x38220000, 0x38222000, 0x38224000, 0x38226000, 0x38228000, 0x3822A000, 0x3822C000, 0x3822E000, 0x38230000, 0x38232000, 0x38234000, 0x38236000, 0x38238000, 0x3823A000, 0x3823C000, 0x3823E000, 
-				0x38240000, 0x38242000, 0x38244000, 0x38246000, 0x38248000, 0x3824A000, 0x3824C000, 0x3824E000, 0x38250000, 0x38252000, 0x38254000, 0x38256000, 0x38258000, 0x3825A000, 0x3825C000, 0x3825E000, 
-				0x38260000, 0x38262000, 0x38264000, 0x38266000, 0x38268000, 0x3826A000, 0x3826C000, 0x3826E000, 0x38270000, 0x38272000, 0x38274000, 0x38276000, 0x38278000, 0x3827A000, 0x3827C000, 0x3827E000, 
-				0x38280000, 0x38282000, 0x38284000, 0x38286000, 0x38288000, 0x3828A000, 0x3828C000, 0x3828E000, 0x38290000, 0x38292000, 0x38294000, 0x38296000, 0x38298000, 0x3829A000, 0x3829C000, 0x3829E000, 
-				0x382A0000, 0x382A2000, 0x382A4000, 0x382A6000, 0x382A8000, 0x382AA000, 0x382AC000, 0x382AE000, 0x382B0000, 0x382B2000, 0x382B4000, 0x382B6000, 0x382B8000, 0x382BA000, 0x382BC000, 0x382BE000, 
-				0x382C0000, 0x382C2000, 0x382C4000, 0x382C6000, 0x382C8000, 0x382CA000, 0x382CC000, 0x382CE000, 0x382D0000, 0x382D2000, 0x382D4000, 0x382D6000, 0x382D8000, 0x382DA000, 0x382DC000, 0x382DE000, 
-				0x382E0000, 0x382E2000, 0x382E4000, 0x382E6000, 0x382E8000, 0x382EA000, 0x382EC000, 0x382EE000, 0x382F0000, 0x382F2000, 0x382F4000, 0x382F6000, 0x382F8000, 0x382FA000, 0x382FC000, 0x382FE000, 
-				0x38300000, 0x38302000, 0x38304000, 0x38306000, 0x38308000, 0x3830A000, 0x3830C000, 0x3830E000, 0x38310000, 0x38312000, 0x38314000, 0x38316000, 0x38318000, 0x3831A000, 0x3831C000, 0x3831E000, 
-				0x38320000, 0x38322000, 0x38324000, 0x38326000, 0x38328000, 0x3832A000, 0x3832C000, 0x3832E000, 0x38330000, 0x38332000, 0x38334000, 0x38336000, 0x38338000, 0x3833A000, 0x3833C000, 0x3833E000, 
-				0x38340000, 0x38342000, 0x38344000, 0x38346000, 0x38348000, 0x3834A000, 0x3834C000, 0x3834E000, 0x38350000, 0x38352000, 0x38354000, 0x38356000, 0x38358000, 0x3835A000, 0x3835C000, 0x3835E000, 
-				0x38360000, 0x38362000, 0x38364000, 0x38366000, 0x38368000, 0x3836A000, 0x3836C000, 0x3836E000, 0x38370000, 0x38372000, 0x38374000, 0x38376000, 0x38378000, 0x3837A000, 0x3837C000, 0x3837E000, 
-				0x38380000, 0x38382000, 0x38384000, 0x38386000, 0x38388000, 0x3838A000, 0x3838C000, 0x3838E000, 0x38390000, 0x38392000, 0x38394000, 0x38396000, 0x38398000, 0x3839A000, 0x3839C000, 0x3839E000, 
-				0x383A0000, 0x383A2000, 0x383A4000, 0x383A6000, 0x383A8000, 0x383AA000, 0x383AC000, 0x383AE000, 0x383B0000, 0x383B2000, 0x383B4000, 0x383B6000, 0x383B8000, 0x383BA000, 0x383BC000, 0x383BE000, 
-				0x383C0000, 0x383C2000, 0x383C4000, 0x383C6000, 0x383C8000, 0x383CA000, 0x383CC000, 0x383CE000, 0x383D0000, 0x383D2000, 0x383D4000, 0x383D6000, 0x383D8000, 0x383DA000, 0x383DC000, 0x383DE000, 
-				0x383E0000, 0x383E2000, 0x383E4000, 0x383E6000, 0x383E8000, 0x383EA000, 0x383EC000, 0x383EE000, 0x383F0000, 0x383F2000, 0x383F4000, 0x383F6000, 0x383F8000, 0x383FA000, 0x383FC000, 0x383FE000, 
-				0x38400000, 0x38402000, 0x38404000, 0x38406000, 0x38408000, 0x3840A000, 0x3840C000, 0x3840E000, 0x38410000, 0x38412000, 0x38414000, 0x38416000, 0x38418000, 0x3841A000, 0x3841C000, 0x3841E000, 
-				0x38420000, 0x38422000, 0x38424000, 0x38426000, 0x38428000, 0x3842A000, 0x3842C000, 0x3842E000, 0x38430000, 0x38432000, 0x38434000, 0x38436000, 0x38438000, 0x3843A000, 0x3843C000, 0x3843E000, 
-				0x38440000, 0x38442000, 0x38444000, 0x38446000, 0x38448000, 0x3844A000, 0x3844C000, 0x3844E000, 0x38450000, 0x38452000, 0x38454000, 0x38456000, 0x38458000, 0x3845A000, 0x3845C000, 0x3845E000, 
-				0x38460000, 0x38462000, 0x38464000, 0x38466000, 0x38468000, 0x3846A000, 0x3846C000, 0x3846E000, 0x38470000, 0x38472000, 0x38474000, 0x38476000, 0x38478000, 0x3847A000, 0x3847C000, 0x3847E000, 
-				0x38480000, 0x38482000, 0x38484000, 0x38486000, 0x38488000, 0x3848A000, 0x3848C000, 0x3848E000, 0x38490000, 0x38492000, 0x38494000, 0x38496000, 0x38498000, 0x3849A000, 0x3849C000, 0x3849E000, 
-				0x384A0000, 0x384A2000, 0x384A4000, 0x384A6000, 0x384A8000, 0x384AA000, 0x384AC000, 0x384AE000, 0x384B0000, 0x384B2000, 0x384B4000, 0x384B6000, 0x384B8000, 0x384BA000, 0x384BC000, 0x384BE000, 
-				0x384C0000, 0x384C2000, 0x384C4000, 0x384C6000, 0x384C8000, 0x384CA000, 0x384CC000, 0x384CE000, 0x384D0000, 0x384D2000, 0x384D4000, 0x384D6000, 0x384D8000, 0x384DA000, 0x384DC000, 0x384DE000, 
-				0x384E0000, 0x384E2000, 0x384E4000, 0x384E6000, 0x384E8000, 0x384EA000, 0x384EC000, 0x384EE000, 0x384F0000, 0x384F2000, 0x384F4000, 0x384F6000, 0x384F8000, 0x384FA000, 0x384FC000, 0x384FE000, 
-				0x38500000, 0x38502000, 0x38504000, 0x38506000, 0x38508000, 0x3850A000, 0x3850C000, 0x3850E000, 0x38510000, 0x38512000, 0x38514000, 0x38516000, 0x38518000, 0x3851A000, 0x3851C000, 0x3851E000, 
-				0x38520000, 0x38522000, 0x38524000, 0x38526000, 0x38528000, 0x3852A000, 0x3852C000, 0x3852E000, 0x38530000, 0x38532000, 0x38534000, 0x38536000, 0x38538000, 0x3853A000, 0x3853C000, 0x3853E000, 
-				0x38540000, 0x38542000, 0x38544000, 0x38546000, 0x38548000, 0x3854A000, 0x3854C000, 0x3854E000, 0x38550000, 0x38552000, 0x38554000, 0x38556000, 0x38558000, 0x3855A000, 0x3855C000, 0x3855E000, 
-				0x38560000, 0x38562000, 0x38564000, 0x38566000, 0x38568000, 0x3856A000, 0x3856C000, 0x3856E000, 0x38570000, 0x38572000, 0x38574000, 0x38576000, 0x38578000, 0x3857A000, 0x3857C000, 0x3857E000, 
-				0x38580000, 0x38582000, 0x38584000, 0x38586000, 0x38588000, 0x3858A000, 0x3858C000, 0x3858E000, 0x38590000, 0x38592000, 0x38594000, 0x38596000, 0x38598000, 0x3859A000, 0x3859C000, 0x3859E000, 
-				0x385A0000, 0x385A2000, 0x385A4000, 0x385A6000, 0x385A8000, 0x385AA000, 0x385AC000, 0x385AE000, 0x385B0000, 0x385B2000, 0x385B4000, 0x385B6000, 0x385B8000, 0x385BA000, 0x385BC000, 0x385BE000, 
-				0x385C0000, 0x385C2000, 0x385C4000, 0x385C6000, 0x385C8000, 0x385CA000, 0x385CC000, 0x385CE000, 0x385D0000, 0x385D2000, 0x385D4000, 0x385D6000, 0x385D8000, 0x385DA000, 0x385DC000, 0x385DE000, 
-				0x385E0000, 0x385E2000, 0x385E4000, 0x385E6000, 0x385E8000, 0x385EA000, 0x385EC000, 0x385EE000, 0x385F0000, 0x385F2000, 0x385F4000, 0x385F6000, 0x385F8000, 0x385FA000, 0x385FC000, 0x385FE000, 
-				0x38600000, 0x38602000, 0x38604000, 0x38606000, 0x38608000, 0x3860A000, 0x3860C000, 0x3860E000, 0x38610000, 0x38612000, 0x38614000, 0x38616000, 0x38618000, 0x3861A000, 0x3861C000, 0x3861E000, 
-				0x38620000, 0x38622000, 0x38624000, 0x38626000, 0x38628000, 0x3862A000, 0x3862C000, 0x3862E000, 0x38630000, 0x38632000, 0x38634000, 0x38636000, 0x38638000, 0x3863A000, 0x3863C000, 0x3863E000, 
-				0x38640000, 0x38642000, 0x38644000, 0x38646000, 0x38648000, 0x3864A000, 0x3864C000, 0x3864E000, 0x38650000, 0x38652000, 0x38654000, 0x38656000, 0x38658000, 0x3865A000, 0x3865C000, 0x3865E000, 
-				0x38660000, 0x38662000, 0x38664000, 0x38666000, 0x38668000, 0x3866A000, 0x3866C000, 0x3866E000, 0x38670000, 0x38672000, 0x38674000, 0x38676000, 0x38678000, 0x3867A000, 0x3867C000, 0x3867E000, 
-				0x38680000, 0x38682000, 0x38684000, 0x38686000, 0x38688000, 0x3868A000, 0x3868C000, 0x3868E000, 0x38690000, 0x38692000, 0x38694000, 0x38696000, 0x38698000, 0x3869A000, 0x3869C000, 0x3869E000, 
-				0x386A0000, 0x386A2000, 0x386A4000, 0x386A6000, 0x386A8000, 0x386AA000, 0x386AC000, 0x386AE000, 0x386B0000, 0x386B2000, 0x386B4000, 0x386B6000, 0x386B8000, 0x386BA000, 0x386BC000, 0x386BE000, 
-				0x386C0000, 0x386C2000, 0x386C4000, 0x386C6000, 0x386C8000, 0x386CA000, 0x386CC000, 0x386CE000, 0x386D0000, 0x386D2000, 0x386D4000, 0x386D6000, 0x386D8000, 0x386DA000, 0x386DC000, 0x386DE000, 
-				0x386E0000, 0x386E2000, 0x386E4000, 0x386E6000, 0x386E8000, 0x386EA000, 0x386EC000, 0x386EE000, 0x386F0000, 0x386F2000, 0x386F4000, 0x386F6000, 0x386F8000, 0x386FA000, 0x386FC000, 0x386FE000, 
-				0x38700000, 0x38702000, 0x38704000, 0x38706000, 0x38708000, 0x3870A000, 0x3870C000, 0x3870E000, 0x38710000, 0x38712000, 0x38714000, 0x38716000, 0x38718000, 0x3871A000, 0x3871C000, 0x3871E000, 
-				0x38720000, 0x38722000, 0x38724000, 0x38726000, 0x38728000, 0x3872A000, 0x3872C000, 0x3872E000, 0x38730000, 0x38732000, 0x38734000, 0x38736000, 0x38738000, 0x3873A000, 0x3873C000, 0x3873E000, 
-				0x38740000, 0x38742000, 0x38744000, 0x38746000, 0x38748000, 0x3874A000, 0x3874C000, 0x3874E000, 0x38750000, 0x38752000, 0x38754000, 0x38756000, 0x38758000, 0x3875A000, 0x3875C000, 0x3875E000, 
-				0x38760000, 0x38762000, 0x38764000, 0x38766000, 0x38768000, 0x3876A000, 0x3876C000, 0x3876E000, 0x38770000, 0x38772000, 0x38774000, 0x38776000, 0x38778000, 0x3877A000, 0x3877C000, 0x3877E000, 
-				0x38780000, 0x38782000, 0x38784000, 0x38786000, 0x38788000, 0x3878A000, 0x3878C000, 0x3878E000, 0x38790000, 0x38792000, 0x38794000, 0x38796000, 0x38798000, 0x3879A000, 0x3879C000, 0x3879E000, 
-				0x387A0000, 0x387A2000, 0x387A4000, 0x387A6000, 0x387A8000, 0x387AA000, 0x387AC000, 0x387AE000, 0x387B0000, 0x387B2000, 0x387B4000, 0x387B6000, 0x387B8000, 0x387BA000, 0x387BC000, 0x387BE000, 
-				0x387C0000, 0x387C2000, 0x387C4000, 0x387C6000, 0x387C8000, 0x387CA000, 0x387CC000, 0x387CE000, 0x387D0000, 0x387D2000, 0x387D4000, 0x387D6000, 0x387D8000, 0x387DA000, 0x387DC000, 0x387DE000, 
-				0x387E0000, 0x387E2000, 0x387E4000, 0x387E6000, 0x387E8000, 0x387EA000, 0x387EC000, 0x387EE000, 0x387F0000, 0x387F2000, 0x387F4000, 0x387F6000, 0x387F8000, 0x387FA000, 0x387FC000, 0x387FE000 };
-			static const uint32 exponent_table[64] = { 
-				0x00000000, 0x00800000, 0x01000000, 0x01800000, 0x02000000, 0x02800000, 0x03000000, 0x03800000, 0x04000000, 0x04800000, 0x05000000, 0x05800000, 0x06000000, 0x06800000, 0x07000000, 0x07800000, 
-				0x08000000, 0x08800000, 0x09000000, 0x09800000, 0x0A000000, 0x0A800000, 0x0B000000, 0x0B800000, 0x0C000000, 0x0C800000, 0x0D000000, 0x0D800000, 0x0E000000, 0x0E800000, 0x0F000000, 0x47800000, 
-				0x80000000, 0x80800000, 0x81000000, 0x81800000, 0x82000000, 0x82800000, 0x83000000, 0x83800000, 0x84000000, 0x84800000, 0x85000000, 0x85800000, 0x86000000, 0x86800000, 0x87000000, 0x87800000, 
-				0x88000000, 0x88800000, 0x89000000, 0x89800000, 0x8A000000, 0x8A800000, 0x8B000000, 0x8B800000, 0x8C000000, 0x8C800000, 0x8D000000, 0x8D800000, 0x8E000000, 0x8E800000, 0x8F000000, 0xC7800000 };
-			static const unsigned short offset_table[64] = { 
-				   0, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 
-				   0, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024 };
-			uint32 bits = mantissa_table[offset_table[value>>10]+(value&0x3FF)] + exponent_table[value>>10];
-//			return *reinterpret_cast<float*>(&bits);			//violating strict aliasing!
-			float out;
-			std::memcpy(&out, &bits, sizeof(float));
-			return out;
-		}
+*/ static const uint32
+      mantissa_table[2048] = {
+          0x00000000, 0x33800000, 0x34000000, 0x34400000, 0x34800000,
+          0x34A00000, 0x34C00000, 0x34E00000, 0x35000000, 0x35100000,
+          0x35200000, 0x35300000, 0x35400000, 0x35500000, 0x35600000,
+          0x35700000, 0x35800000, 0x35880000, 0x35900000, 0x35980000,
+          0x35A00000, 0x35A80000, 0x35B00000, 0x35B80000, 0x35C00000,
+          0x35C80000, 0x35D00000, 0x35D80000, 0x35E00000, 0x35E80000,
+          0x35F00000, 0x35F80000, 0x36000000, 0x36040000, 0x36080000,
+          0x360C0000, 0x36100000, 0x36140000, 0x36180000, 0x361C0000,
+          0x36200000, 0x36240000, 0x36280000, 0x362C0000, 0x36300000,
+          0x36340000, 0x36380000, 0x363C0000, 0x36400000, 0x36440000,
+          0x36480000, 0x364C0000, 0x36500000, 0x36540000, 0x36580000,
+          0x365C0000, 0x36600000, 0x36640000, 0x36680000, 0x366C0000,
+          0x36700000, 0x36740000, 0x36780000, 0x367C0000, 0x36800000,
+          0x36820000, 0x36840000, 0x36860000, 0x36880000, 0x368A0000,
+          0x368C0000, 0x368E0000, 0x36900000, 0x36920000, 0x36940000,
+          0x36960000, 0x36980000, 0x369A0000, 0x369C0000, 0x369E0000,
+          0x36A00000, 0x36A20000, 0x36A40000, 0x36A60000, 0x36A80000,
+          0x36AA0000, 0x36AC0000, 0x36AE0000, 0x36B00000, 0x36B20000,
+          0x36B40000, 0x36B60000, 0x36B80000, 0x36BA0000, 0x36BC0000,
+          0x36BE0000, 0x36C00000, 0x36C20000, 0x36C40000, 0x36C60000,
+          0x36C80000, 0x36CA0000, 0x36CC0000, 0x36CE0000, 0x36D00000,
+          0x36D20000, 0x36D40000, 0x36D60000, 0x36D80000, 0x36DA0000,
+          0x36DC0000, 0x36DE0000, 0x36E00000, 0x36E20000, 0x36E40000,
+          0x36E60000, 0x36E80000, 0x36EA0000, 0x36EC0000, 0x36EE0000,
+          0x36F00000, 0x36F20000, 0x36F40000, 0x36F60000, 0x36F80000,
+          0x36FA0000, 0x36FC0000, 0x36FE0000, 0x37000000, 0x37010000,
+          0x37020000, 0x37030000, 0x37040000, 0x37050000, 0x37060000,
+          0x37070000, 0x37080000, 0x37090000, 0x370A0000, 0x370B0000,
+          0x370C0000, 0x370D0000, 0x370E0000, 0x370F0000, 0x37100000,
+          0x37110000, 0x37120000, 0x37130000, 0x37140000, 0x37150000,
+          0x37160000, 0x37170000, 0x37180000, 0x37190000, 0x371A0000,
+          0x371B0000, 0x371C0000, 0x371D0000, 0x371E0000, 0x371F0000,
+          0x37200000, 0x37210000, 0x37220000, 0x37230000, 0x37240000,
+          0x37250000, 0x37260000, 0x37270000, 0x37280000, 0x37290000,
+          0x372A0000, 0x372B0000, 0x372C0000, 0x372D0000, 0x372E0000,
+          0x372F0000, 0x37300000, 0x37310000, 0x37320000, 0x37330000,
+          0x37340000, 0x37350000, 0x37360000, 0x37370000, 0x37380000,
+          0x37390000, 0x373A0000, 0x373B0000, 0x373C0000, 0x373D0000,
+          0x373E0000, 0x373F0000, 0x37400000, 0x37410000, 0x37420000,
+          0x37430000, 0x37440000, 0x37450000, 0x37460000, 0x37470000,
+          0x37480000, 0x37490000, 0x374A0000, 0x374B0000, 0x374C0000,
+          0x374D0000, 0x374E0000, 0x374F0000, 0x37500000, 0x37510000,
+          0x37520000, 0x37530000, 0x37540000, 0x37550000, 0x37560000,
+          0x37570000, 0x37580000, 0x37590000, 0x375A0000, 0x375B0000,
+          0x375C0000, 0x375D0000, 0x375E0000, 0x375F0000, 0x37600000,
+          0x37610000, 0x37620000, 0x37630000, 0x37640000, 0x37650000,
+          0x37660000, 0x37670000, 0x37680000, 0x37690000, 0x376A0000,
+          0x376B0000, 0x376C0000, 0x376D0000, 0x376E0000, 0x376F0000,
+          0x37700000, 0x37710000, 0x37720000, 0x37730000, 0x37740000,
+          0x37750000, 0x37760000, 0x37770000, 0x37780000, 0x37790000,
+          0x377A0000, 0x377B0000, 0x377C0000, 0x377D0000, 0x377E0000,
+          0x377F0000, 0x37800000, 0x37808000, 0x37810000, 0x37818000,
+          0x37820000, 0x37828000, 0x37830000, 0x37838000, 0x37840000,
+          0x37848000, 0x37850000, 0x37858000, 0x37860000, 0x37868000,
+          0x37870000, 0x37878000, 0x37880000, 0x37888000, 0x37890000,
+          0x37898000, 0x378A0000, 0x378A8000, 0x378B0000, 0x378B8000,
+          0x378C0000, 0x378C8000, 0x378D0000, 0x378D8000, 0x378E0000,
+          0x378E8000, 0x378F0000, 0x378F8000, 0x37900000, 0x37908000,
+          0x37910000, 0x37918000, 0x37920000, 0x37928000, 0x37930000,
+          0x37938000, 0x37940000, 0x37948000, 0x37950000, 0x37958000,
+          0x37960000, 0x37968000, 0x37970000, 0x37978000, 0x37980000,
+          0x37988000, 0x37990000, 0x37998000, 0x379A0000, 0x379A8000,
+          0x379B0000, 0x379B8000, 0x379C0000, 0x379C8000, 0x379D0000,
+          0x379D8000, 0x379E0000, 0x379E8000, 0x379F0000, 0x379F8000,
+          0x37A00000, 0x37A08000, 0x37A10000, 0x37A18000, 0x37A20000,
+          0x37A28000, 0x37A30000, 0x37A38000, 0x37A40000, 0x37A48000,
+          0x37A50000, 0x37A58000, 0x37A60000, 0x37A68000, 0x37A70000,
+          0x37A78000, 0x37A80000, 0x37A88000, 0x37A90000, 0x37A98000,
+          0x37AA0000, 0x37AA8000, 0x37AB0000, 0x37AB8000, 0x37AC0000,
+          0x37AC8000, 0x37AD0000, 0x37AD8000, 0x37AE0000, 0x37AE8000,
+          0x37AF0000, 0x37AF8000, 0x37B00000, 0x37B08000, 0x37B10000,
+          0x37B18000, 0x37B20000, 0x37B28000, 0x37B30000, 0x37B38000,
+          0x37B40000, 0x37B48000, 0x37B50000, 0x37B58000, 0x37B60000,
+          0x37B68000, 0x37B70000, 0x37B78000, 0x37B80000, 0x37B88000,
+          0x37B90000, 0x37B98000, 0x37BA0000, 0x37BA8000, 0x37BB0000,
+          0x37BB8000, 0x37BC0000, 0x37BC8000, 0x37BD0000, 0x37BD8000,
+          0x37BE0000, 0x37BE8000, 0x37BF0000, 0x37BF8000, 0x37C00000,
+          0x37C08000, 0x37C10000, 0x37C18000, 0x37C20000, 0x37C28000,
+          0x37C30000, 0x37C38000, 0x37C40000, 0x37C48000, 0x37C50000,
+          0x37C58000, 0x37C60000, 0x37C68000, 0x37C70000, 0x37C78000,
+          0x37C80000, 0x37C88000, 0x37C90000, 0x37C98000, 0x37CA0000,
+          0x37CA8000, 0x37CB0000, 0x37CB8000, 0x37CC0000, 0x37CC8000,
+          0x37CD0000, 0x37CD8000, 0x37CE0000, 0x37CE8000, 0x37CF0000,
+          0x37CF8000, 0x37D00000, 0x37D08000, 0x37D10000, 0x37D18000,
+          0x37D20000, 0x37D28000, 0x37D30000, 0x37D38000, 0x37D40000,
+          0x37D48000, 0x37D50000, 0x37D58000, 0x37D60000, 0x37D68000,
+          0x37D70000, 0x37D78000, 0x37D80000, 0x37D88000, 0x37D90000,
+          0x37D98000, 0x37DA0000, 0x37DA8000, 0x37DB0000, 0x37DB8000,
+          0x37DC0000, 0x37DC8000, 0x37DD0000, 0x37DD8000, 0x37DE0000,
+          0x37DE8000, 0x37DF0000, 0x37DF8000, 0x37E00000, 0x37E08000,
+          0x37E10000, 0x37E18000, 0x37E20000, 0x37E28000, 0x37E30000,
+          0x37E38000, 0x37E40000, 0x37E48000, 0x37E50000, 0x37E58000,
+          0x37E60000, 0x37E68000, 0x37E70000, 0x37E78000, 0x37E80000,
+          0x37E88000, 0x37E90000, 0x37E98000, 0x37EA0000, 0x37EA8000,
+          0x37EB0000, 0x37EB8000, 0x37EC0000, 0x37EC8000, 0x37ED0000,
+          0x37ED8000, 0x37EE0000, 0x37EE8000, 0x37EF0000, 0x37EF8000,
+          0x37F00000, 0x37F08000, 0x37F10000, 0x37F18000, 0x37F20000,
+          0x37F28000, 0x37F30000, 0x37F38000, 0x37F40000, 0x37F48000,
+          0x37F50000, 0x37F58000, 0x37F60000, 0x37F68000, 0x37F70000,
+          0x37F78000, 0x37F80000, 0x37F88000, 0x37F90000, 0x37F98000,
+          0x37FA0000, 0x37FA8000, 0x37FB0000, 0x37FB8000, 0x37FC0000,
+          0x37FC8000, 0x37FD0000, 0x37FD8000, 0x37FE0000, 0x37FE8000,
+          0x37FF0000, 0x37FF8000, 0x38000000, 0x38004000, 0x38008000,
+          0x3800C000, 0x38010000, 0x38014000, 0x38018000, 0x3801C000,
+          0x38020000, 0x38024000, 0x38028000, 0x3802C000, 0x38030000,
+          0x38034000, 0x38038000, 0x3803C000, 0x38040000, 0x38044000,
+          0x38048000, 0x3804C000, 0x38050000, 0x38054000, 0x38058000,
+          0x3805C000, 0x38060000, 0x38064000, 0x38068000, 0x3806C000,
+          0x38070000, 0x38074000, 0x38078000, 0x3807C000, 0x38080000,
+          0x38084000, 0x38088000, 0x3808C000, 0x38090000, 0x38094000,
+          0x38098000, 0x3809C000, 0x380A0000, 0x380A4000, 0x380A8000,
+          0x380AC000, 0x380B0000, 0x380B4000, 0x380B8000, 0x380BC000,
+          0x380C0000, 0x380C4000, 0x380C8000, 0x380CC000, 0x380D0000,
+          0x380D4000, 0x380D8000, 0x380DC000, 0x380E0000, 0x380E4000,
+          0x380E8000, 0x380EC000, 0x380F0000, 0x380F4000, 0x380F8000,
+          0x380FC000, 0x38100000, 0x38104000, 0x38108000, 0x3810C000,
+          0x38110000, 0x38114000, 0x38118000, 0x3811C000, 0x38120000,
+          0x38124000, 0x38128000, 0x3812C000, 0x38130000, 0x38134000,
+          0x38138000, 0x3813C000, 0x38140000, 0x38144000, 0x38148000,
+          0x3814C000, 0x38150000, 0x38154000, 0x38158000, 0x3815C000,
+          0x38160000, 0x38164000, 0x38168000, 0x3816C000, 0x38170000,
+          0x38174000, 0x38178000, 0x3817C000, 0x38180000, 0x38184000,
+          0x38188000, 0x3818C000, 0x38190000, 0x38194000, 0x38198000,
+          0x3819C000, 0x381A0000, 0x381A4000, 0x381A8000, 0x381AC000,
+          0x381B0000, 0x381B4000, 0x381B8000, 0x381BC000, 0x381C0000,
+          0x381C4000, 0x381C8000, 0x381CC000, 0x381D0000, 0x381D4000,
+          0x381D8000, 0x381DC000, 0x381E0000, 0x381E4000, 0x381E8000,
+          0x381EC000, 0x381F0000, 0x381F4000, 0x381F8000, 0x381FC000,
+          0x38200000, 0x38204000, 0x38208000, 0x3820C000, 0x38210000,
+          0x38214000, 0x38218000, 0x3821C000, 0x38220000, 0x38224000,
+          0x38228000, 0x3822C000, 0x38230000, 0x38234000, 0x38238000,
+          0x3823C000, 0x38240000, 0x38244000, 0x38248000, 0x3824C000,
+          0x38250000, 0x38254000, 0x38258000, 0x3825C000, 0x38260000,
+          0x38264000, 0x38268000, 0x3826C000, 0x38270000, 0x38274000,
+          0x38278000, 0x3827C000, 0x38280000, 0x38284000, 0x38288000,
+          0x3828C000, 0x38290000, 0x38294000, 0x38298000, 0x3829C000,
+          0x382A0000, 0x382A4000, 0x382A8000, 0x382AC000, 0x382B0000,
+          0x382B4000, 0x382B8000, 0x382BC000, 0x382C0000, 0x382C4000,
+          0x382C8000, 0x382CC000, 0x382D0000, 0x382D4000, 0x382D8000,
+          0x382DC000, 0x382E0000, 0x382E4000, 0x382E8000, 0x382EC000,
+          0x382F0000, 0x382F4000, 0x382F8000, 0x382FC000, 0x38300000,
+          0x38304000, 0x38308000, 0x3830C000, 0x38310000, 0x38314000,
+          0x38318000, 0x3831C000, 0x38320000, 0x38324000, 0x38328000,
+          0x3832C000, 0x38330000, 0x38334000, 0x38338000, 0x3833C000,
+          0x38340000, 0x38344000, 0x38348000, 0x3834C000, 0x38350000,
+          0x38354000, 0x38358000, 0x3835C000, 0x38360000, 0x38364000,
+          0x38368000, 0x3836C000, 0x38370000, 0x38374000, 0x38378000,
+          0x3837C000, 0x38380000, 0x38384000, 0x38388000, 0x3838C000,
+          0x38390000, 0x38394000, 0x38398000, 0x3839C000, 0x383A0000,
+          0x383A4000, 0x383A8000, 0x383AC000, 0x383B0000, 0x383B4000,
+          0x383B8000, 0x383BC000, 0x383C0000, 0x383C4000, 0x383C8000,
+          0x383CC000, 0x383D0000, 0x383D4000, 0x383D8000, 0x383DC000,
+          0x383E0000, 0x383E4000, 0x383E8000, 0x383EC000, 0x383F0000,
+          0x383F4000, 0x383F8000, 0x383FC000, 0x38400000, 0x38404000,
+          0x38408000, 0x3840C000, 0x38410000, 0x38414000, 0x38418000,
+          0x3841C000, 0x38420000, 0x38424000, 0x38428000, 0x3842C000,
+          0x38430000, 0x38434000, 0x38438000, 0x3843C000, 0x38440000,
+          0x38444000, 0x38448000, 0x3844C000, 0x38450000, 0x38454000,
+          0x38458000, 0x3845C000, 0x38460000, 0x38464000, 0x38468000,
+          0x3846C000, 0x38470000, 0x38474000, 0x38478000, 0x3847C000,
+          0x38480000, 0x38484000, 0x38488000, 0x3848C000, 0x38490000,
+          0x38494000, 0x38498000, 0x3849C000, 0x384A0000, 0x384A4000,
+          0x384A8000, 0x384AC000, 0x384B0000, 0x384B4000, 0x384B8000,
+          0x384BC000, 0x384C0000, 0x384C4000, 0x384C8000, 0x384CC000,
+          0x384D0000, 0x384D4000, 0x384D8000, 0x384DC000, 0x384E0000,
+          0x384E4000, 0x384E8000, 0x384EC000, 0x384F0000, 0x384F4000,
+          0x384F8000, 0x384FC000, 0x38500000, 0x38504000, 0x38508000,
+          0x3850C000, 0x38510000, 0x38514000, 0x38518000, 0x3851C000,
+          0x38520000, 0x38524000, 0x38528000, 0x3852C000, 0x38530000,
+          0x38534000, 0x38538000, 0x3853C000, 0x38540000, 0x38544000,
+          0x38548000, 0x3854C000, 0x38550000, 0x38554000, 0x38558000,
+          0x3855C000, 0x38560000, 0x38564000, 0x38568000, 0x3856C000,
+          0x38570000, 0x38574000, 0x38578000, 0x3857C000, 0x38580000,
+          0x38584000, 0x38588000, 0x3858C000, 0x38590000, 0x38594000,
+          0x38598000, 0x3859C000, 0x385A0000, 0x385A4000, 0x385A8000,
+          0x385AC000, 0x385B0000, 0x385B4000, 0x385B8000, 0x385BC000,
+          0x385C0000, 0x385C4000, 0x385C8000, 0x385CC000, 0x385D0000,
+          0x385D4000, 0x385D8000, 0x385DC000, 0x385E0000, 0x385E4000,
+          0x385E8000, 0x385EC000, 0x385F0000, 0x385F4000, 0x385F8000,
+          0x385FC000, 0x38600000, 0x38604000, 0x38608000, 0x3860C000,
+          0x38610000, 0x38614000, 0x38618000, 0x3861C000, 0x38620000,
+          0x38624000, 0x38628000, 0x3862C000, 0x38630000, 0x38634000,
+          0x38638000, 0x3863C000, 0x38640000, 0x38644000, 0x38648000,
+          0x3864C000, 0x38650000, 0x38654000, 0x38658000, 0x3865C000,
+          0x38660000, 0x38664000, 0x38668000, 0x3866C000, 0x38670000,
+          0x38674000, 0x38678000, 0x3867C000, 0x38680000, 0x38684000,
+          0x38688000, 0x3868C000, 0x38690000, 0x38694000, 0x38698000,
+          0x3869C000, 0x386A0000, 0x386A4000, 0x386A8000, 0x386AC000,
+          0x386B0000, 0x386B4000, 0x386B8000, 0x386BC000, 0x386C0000,
+          0x386C4000, 0x386C8000, 0x386CC000, 0x386D0000, 0x386D4000,
+          0x386D8000, 0x386DC000, 0x386E0000, 0x386E4000, 0x386E8000,
+          0x386EC000, 0x386F0000, 0x386F4000, 0x386F8000, 0x386FC000,
+          0x38700000, 0x38704000, 0x38708000, 0x3870C000, 0x38710000,
+          0x38714000, 0x38718000, 0x3871C000, 0x38720000, 0x38724000,
+          0x38728000, 0x3872C000, 0x38730000, 0x38734000, 0x38738000,
+          0x3873C000, 0x38740000, 0x38744000, 0x38748000, 0x3874C000,
+          0x38750000, 0x38754000, 0x38758000, 0x3875C000, 0x38760000,
+          0x38764000, 0x38768000, 0x3876C000, 0x38770000, 0x38774000,
+          0x38778000, 0x3877C000, 0x38780000, 0x38784000, 0x38788000,
+          0x3878C000, 0x38790000, 0x38794000, 0x38798000, 0x3879C000,
+          0x387A0000, 0x387A4000, 0x387A8000, 0x387AC000, 0x387B0000,
+          0x387B4000, 0x387B8000, 0x387BC000, 0x387C0000, 0x387C4000,
+          0x387C8000, 0x387CC000, 0x387D0000, 0x387D4000, 0x387D8000,
+          0x387DC000, 0x387E0000, 0x387E4000, 0x387E8000, 0x387EC000,
+          0x387F0000, 0x387F4000, 0x387F8000, 0x387FC000, 0x38000000,
+          0x38002000, 0x38004000, 0x38006000, 0x38008000, 0x3800A000,
+          0x3800C000, 0x3800E000, 0x38010000, 0x38012000, 0x38014000,
+          0x38016000, 0x38018000, 0x3801A000, 0x3801C000, 0x3801E000,
+          0x38020000, 0x38022000, 0x38024000, 0x38026000, 0x38028000,
+          0x3802A000, 0x3802C000, 0x3802E000, 0x38030000, 0x38032000,
+          0x38034000, 0x38036000, 0x38038000, 0x3803A000, 0x3803C000,
+          0x3803E000, 0x38040000, 0x38042000, 0x38044000, 0x38046000,
+          0x38048000, 0x3804A000, 0x3804C000, 0x3804E000, 0x38050000,
+          0x38052000, 0x38054000, 0x38056000, 0x38058000, 0x3805A000,
+          0x3805C000, 0x3805E000, 0x38060000, 0x38062000, 0x38064000,
+          0x38066000, 0x38068000, 0x3806A000, 0x3806C000, 0x3806E000,
+          0x38070000, 0x38072000, 0x38074000, 0x38076000, 0x38078000,
+          0x3807A000, 0x3807C000, 0x3807E000, 0x38080000, 0x38082000,
+          0x38084000, 0x38086000, 0x38088000, 0x3808A000, 0x3808C000,
+          0x3808E000, 0x38090000, 0x38092000, 0x38094000, 0x38096000,
+          0x38098000, 0x3809A000, 0x3809C000, 0x3809E000, 0x380A0000,
+          0x380A2000, 0x380A4000, 0x380A6000, 0x380A8000, 0x380AA000,
+          0x380AC000, 0x380AE000, 0x380B0000, 0x380B2000, 0x380B4000,
+          0x380B6000, 0x380B8000, 0x380BA000, 0x380BC000, 0x380BE000,
+          0x380C0000, 0x380C2000, 0x380C4000, 0x380C6000, 0x380C8000,
+          0x380CA000, 0x380CC000, 0x380CE000, 0x380D0000, 0x380D2000,
+          0x380D4000, 0x380D6000, 0x380D8000, 0x380DA000, 0x380DC000,
+          0x380DE000, 0x380E0000, 0x380E2000, 0x380E4000, 0x380E6000,
+          0x380E8000, 0x380EA000, 0x380EC000, 0x380EE000, 0x380F0000,
+          0x380F2000, 0x380F4000, 0x380F6000, 0x380F8000, 0x380FA000,
+          0x380FC000, 0x380FE000, 0x38100000, 0x38102000, 0x38104000,
+          0x38106000, 0x38108000, 0x3810A000, 0x3810C000, 0x3810E000,
+          0x38110000, 0x38112000, 0x38114000, 0x38116000, 0x38118000,
+          0x3811A000, 0x3811C000, 0x3811E000, 0x38120000, 0x38122000,
+          0x38124000, 0x38126000, 0x38128000, 0x3812A000, 0x3812C000,
+          0x3812E000, 0x38130000, 0x38132000, 0x38134000, 0x38136000,
+          0x38138000, 0x3813A000, 0x3813C000, 0x3813E000, 0x38140000,
+          0x38142000, 0x38144000, 0x38146000, 0x38148000, 0x3814A000,
+          0x3814C000, 0x3814E000, 0x38150000, 0x38152000, 0x38154000,
+          0x38156000, 0x38158000, 0x3815A000, 0x3815C000, 0x3815E000,
+          0x38160000, 0x38162000, 0x38164000, 0x38166000, 0x38168000,
+          0x3816A000, 0x3816C000, 0x3816E000, 0x38170000, 0x38172000,
+          0x38174000, 0x38176000, 0x38178000, 0x3817A000, 0x3817C000,
+          0x3817E000, 0x38180000, 0x38182000, 0x38184000, 0x38186000,
+          0x38188000, 0x3818A000, 0x3818C000, 0x3818E000, 0x38190000,
+          0x38192000, 0x38194000, 0x38196000, 0x38198000, 0x3819A000,
+          0x3819C000, 0x3819E000, 0x381A0000, 0x381A2000, 0x381A4000,
+          0x381A6000, 0x381A8000, 0x381AA000, 0x381AC000, 0x381AE000,
+          0x381B0000, 0x381B2000, 0x381B4000, 0x381B6000, 0x381B8000,
+          0x381BA000, 0x381BC000, 0x381BE000, 0x381C0000, 0x381C2000,
+          0x381C4000, 0x381C6000, 0x381C8000, 0x381CA000, 0x381CC000,
+          0x381CE000, 0x381D0000, 0x381D2000, 0x381D4000, 0x381D6000,
+          0x381D8000, 0x381DA000, 0x381DC000, 0x381DE000, 0x381E0000,
+          0x381E2000, 0x381E4000, 0x381E6000, 0x381E8000, 0x381EA000,
+          0x381EC000, 0x381EE000, 0x381F0000, 0x381F2000, 0x381F4000,
+          0x381F6000, 0x381F8000, 0x381FA000, 0x381FC000, 0x381FE000,
+          0x38200000, 0x38202000, 0x38204000, 0x38206000, 0x38208000,
+          0x3820A000, 0x3820C000, 0x3820E000, 0x38210000, 0x38212000,
+          0x38214000, 0x38216000, 0x38218000, 0x3821A000, 0x3821C000,
+          0x3821E000, 0x38220000, 0x38222000, 0x38224000, 0x38226000,
+          0x38228000, 0x3822A000, 0x3822C000, 0x3822E000, 0x38230000,
+          0x38232000, 0x38234000, 0x38236000, 0x38238000, 0x3823A000,
+          0x3823C000, 0x3823E000, 0x38240000, 0x38242000, 0x38244000,
+          0x38246000, 0x38248000, 0x3824A000, 0x3824C000, 0x3824E000,
+          0x38250000, 0x38252000, 0x38254000, 0x38256000, 0x38258000,
+          0x3825A000, 0x3825C000, 0x3825E000, 0x38260000, 0x38262000,
+          0x38264000, 0x38266000, 0x38268000, 0x3826A000, 0x3826C000,
+          0x3826E000, 0x38270000, 0x38272000, 0x38274000, 0x38276000,
+          0x38278000, 0x3827A000, 0x3827C000, 0x3827E000, 0x38280000,
+          0x38282000, 0x38284000, 0x38286000, 0x38288000, 0x3828A000,
+          0x3828C000, 0x3828E000, 0x38290000, 0x38292000, 0x38294000,
+          0x38296000, 0x38298000, 0x3829A000, 0x3829C000, 0x3829E000,
+          0x382A0000, 0x382A2000, 0x382A4000, 0x382A6000, 0x382A8000,
+          0x382AA000, 0x382AC000, 0x382AE000, 0x382B0000, 0x382B2000,
+          0x382B4000, 0x382B6000, 0x382B8000, 0x382BA000, 0x382BC000,
+          0x382BE000, 0x382C0000, 0x382C2000, 0x382C4000, 0x382C6000,
+          0x382C8000, 0x382CA000, 0x382CC000, 0x382CE000, 0x382D0000,
+          0x382D2000, 0x382D4000, 0x382D6000, 0x382D8000, 0x382DA000,
+          0x382DC000, 0x382DE000, 0x382E0000, 0x382E2000, 0x382E4000,
+          0x382E6000, 0x382E8000, 0x382EA000, 0x382EC000, 0x382EE000,
+          0x382F0000, 0x382F2000, 0x382F4000, 0x382F6000, 0x382F8000,
+          0x382FA000, 0x382FC000, 0x382FE000, 0x38300000, 0x38302000,
+          0x38304000, 0x38306000, 0x38308000, 0x3830A000, 0x3830C000,
+          0x3830E000, 0x38310000, 0x38312000, 0x38314000, 0x38316000,
+          0x38318000, 0x3831A000, 0x3831C000, 0x3831E000, 0x38320000,
+          0x38322000, 0x38324000, 0x38326000, 0x38328000, 0x3832A000,
+          0x3832C000, 0x3832E000, 0x38330000, 0x38332000, 0x38334000,
+          0x38336000, 0x38338000, 0x3833A000, 0x3833C000, 0x3833E000,
+          0x38340000, 0x38342000, 0x38344000, 0x38346000, 0x38348000,
+          0x3834A000, 0x3834C000, 0x3834E000, 0x38350000, 0x38352000,
+          0x38354000, 0x38356000, 0x38358000, 0x3835A000, 0x3835C000,
+          0x3835E000, 0x38360000, 0x38362000, 0x38364000, 0x38366000,
+          0x38368000, 0x3836A000, 0x3836C000, 0x3836E000, 0x38370000,
+          0x38372000, 0x38374000, 0x38376000, 0x38378000, 0x3837A000,
+          0x3837C000, 0x3837E000, 0x38380000, 0x38382000, 0x38384000,
+          0x38386000, 0x38388000, 0x3838A000, 0x3838C000, 0x3838E000,
+          0x38390000, 0x38392000, 0x38394000, 0x38396000, 0x38398000,
+          0x3839A000, 0x3839C000, 0x3839E000, 0x383A0000, 0x383A2000,
+          0x383A4000, 0x383A6000, 0x383A8000, 0x383AA000, 0x383AC000,
+          0x383AE000, 0x383B0000, 0x383B2000, 0x383B4000, 0x383B6000,
+          0x383B8000, 0x383BA000, 0x383BC000, 0x383BE000, 0x383C0000,
+          0x383C2000, 0x383C4000, 0x383C6000, 0x383C8000, 0x383CA000,
+          0x383CC000, 0x383CE000, 0x383D0000, 0x383D2000, 0x383D4000,
+          0x383D6000, 0x383D8000, 0x383DA000, 0x383DC000, 0x383DE000,
+          0x383E0000, 0x383E2000, 0x383E4000, 0x383E6000, 0x383E8000,
+          0x383EA000, 0x383EC000, 0x383EE000, 0x383F0000, 0x383F2000,
+          0x383F4000, 0x383F6000, 0x383F8000, 0x383FA000, 0x383FC000,
+          0x383FE000, 0x38400000, 0x38402000, 0x38404000, 0x38406000,
+          0x38408000, 0x3840A000, 0x3840C000, 0x3840E000, 0x38410000,
+          0x38412000, 0x38414000, 0x38416000, 0x38418000, 0x3841A000,
+          0x3841C000, 0x3841E000, 0x38420000, 0x38422000, 0x38424000,
+          0x38426000, 0x38428000, 0x3842A000, 0x3842C000, 0x3842E000,
+          0x38430000, 0x38432000, 0x38434000, 0x38436000, 0x38438000,
+          0x3843A000, 0x3843C000, 0x3843E000, 0x38440000, 0x38442000,
+          0x38444000, 0x38446000, 0x38448000, 0x3844A000, 0x3844C000,
+          0x3844E000, 0x38450000, 0x38452000, 0x38454000, 0x38456000,
+          0x38458000, 0x3845A000, 0x3845C000, 0x3845E000, 0x38460000,
+          0x38462000, 0x38464000, 0x38466000, 0x38468000, 0x3846A000,
+          0x3846C000, 0x3846E000, 0x38470000, 0x38472000, 0x38474000,
+          0x38476000, 0x38478000, 0x3847A000, 0x3847C000, 0x3847E000,
+          0x38480000, 0x38482000, 0x38484000, 0x38486000, 0x38488000,
+          0x3848A000, 0x3848C000, 0x3848E000, 0x38490000, 0x38492000,
+          0x38494000, 0x38496000, 0x38498000, 0x3849A000, 0x3849C000,
+          0x3849E000, 0x384A0000, 0x384A2000, 0x384A4000, 0x384A6000,
+          0x384A8000, 0x384AA000, 0x384AC000, 0x384AE000, 0x384B0000,
+          0x384B2000, 0x384B4000, 0x384B6000, 0x384B8000, 0x384BA000,
+          0x384BC000, 0x384BE000, 0x384C0000, 0x384C2000, 0x384C4000,
+          0x384C6000, 0x384C8000, 0x384CA000, 0x384CC000, 0x384CE000,
+          0x384D0000, 0x384D2000, 0x384D4000, 0x384D6000, 0x384D8000,
+          0x384DA000, 0x384DC000, 0x384DE000, 0x384E0000, 0x384E2000,
+          0x384E4000, 0x384E6000, 0x384E8000, 0x384EA000, 0x384EC000,
+          0x384EE000, 0x384F0000, 0x384F2000, 0x384F4000, 0x384F6000,
+          0x384F8000, 0x384FA000, 0x384FC000, 0x384FE000, 0x38500000,
+          0x38502000, 0x38504000, 0x38506000, 0x38508000, 0x3850A000,
+          0x3850C000, 0x3850E000, 0x38510000, 0x38512000, 0x38514000,
+          0x38516000, 0x38518000, 0x3851A000, 0x3851C000, 0x3851E000,
+          0x38520000, 0x38522000, 0x38524000, 0x38526000, 0x38528000,
+          0x3852A000, 0x3852C000, 0x3852E000, 0x38530000, 0x38532000,
+          0x38534000, 0x38536000, 0x38538000, 0x3853A000, 0x3853C000,
+          0x3853E000, 0x38540000, 0x38542000, 0x38544000, 0x38546000,
+          0x38548000, 0x3854A000, 0x3854C000, 0x3854E000, 0x38550000,
+          0x38552000, 0x38554000, 0x38556000, 0x38558000, 0x3855A000,
+          0x3855C000, 0x3855E000, 0x38560000, 0x38562000, 0x38564000,
+          0x38566000, 0x38568000, 0x3856A000, 0x3856C000, 0x3856E000,
+          0x38570000, 0x38572000, 0x38574000, 0x38576000, 0x38578000,
+          0x3857A000, 0x3857C000, 0x3857E000, 0x38580000, 0x38582000,
+          0x38584000, 0x38586000, 0x38588000, 0x3858A000, 0x3858C000,
+          0x3858E000, 0x38590000, 0x38592000, 0x38594000, 0x38596000,
+          0x38598000, 0x3859A000, 0x3859C000, 0x3859E000, 0x385A0000,
+          0x385A2000, 0x385A4000, 0x385A6000, 0x385A8000, 0x385AA000,
+          0x385AC000, 0x385AE000, 0x385B0000, 0x385B2000, 0x385B4000,
+          0x385B6000, 0x385B8000, 0x385BA000, 0x385BC000, 0x385BE000,
+          0x385C0000, 0x385C2000, 0x385C4000, 0x385C6000, 0x385C8000,
+          0x385CA000, 0x385CC000, 0x385CE000, 0x385D0000, 0x385D2000,
+          0x385D4000, 0x385D6000, 0x385D8000, 0x385DA000, 0x385DC000,
+          0x385DE000, 0x385E0000, 0x385E2000, 0x385E4000, 0x385E6000,
+          0x385E8000, 0x385EA000, 0x385EC000, 0x385EE000, 0x385F0000,
+          0x385F2000, 0x385F4000, 0x385F6000, 0x385F8000, 0x385FA000,
+          0x385FC000, 0x385FE000, 0x38600000, 0x38602000, 0x38604000,
+          0x38606000, 0x38608000, 0x3860A000, 0x3860C000, 0x3860E000,
+          0x38610000, 0x38612000, 0x38614000, 0x38616000, 0x38618000,
+          0x3861A000, 0x3861C000, 0x3861E000, 0x38620000, 0x38622000,
+          0x38624000, 0x38626000, 0x38628000, 0x3862A000, 0x3862C000,
+          0x3862E000, 0x38630000, 0x38632000, 0x38634000, 0x38636000,
+          0x38638000, 0x3863A000, 0x3863C000, 0x3863E000, 0x38640000,
+          0x38642000, 0x38644000, 0x38646000, 0x38648000, 0x3864A000,
+          0x3864C000, 0x3864E000, 0x38650000, 0x38652000, 0x38654000,
+          0x38656000, 0x38658000, 0x3865A000, 0x3865C000, 0x3865E000,
+          0x38660000, 0x38662000, 0x38664000, 0x38666000, 0x38668000,
+          0x3866A000, 0x3866C000, 0x3866E000, 0x38670000, 0x38672000,
+          0x38674000, 0x38676000, 0x38678000, 0x3867A000, 0x3867C000,
+          0x3867E000, 0x38680000, 0x38682000, 0x38684000, 0x38686000,
+          0x38688000, 0x3868A000, 0x3868C000, 0x3868E000, 0x38690000,
+          0x38692000, 0x38694000, 0x38696000, 0x38698000, 0x3869A000,
+          0x3869C000, 0x3869E000, 0x386A0000, 0x386A2000, 0x386A4000,
+          0x386A6000, 0x386A8000, 0x386AA000, 0x386AC000, 0x386AE000,
+          0x386B0000, 0x386B2000, 0x386B4000, 0x386B6000, 0x386B8000,
+          0x386BA000, 0x386BC000, 0x386BE000, 0x386C0000, 0x386C2000,
+          0x386C4000, 0x386C6000, 0x386C8000, 0x386CA000, 0x386CC000,
+          0x386CE000, 0x386D0000, 0x386D2000, 0x386D4000, 0x386D6000,
+          0x386D8000, 0x386DA000, 0x386DC000, 0x386DE000, 0x386E0000,
+          0x386E2000, 0x386E4000, 0x386E6000, 0x386E8000, 0x386EA000,
+          0x386EC000, 0x386EE000, 0x386F0000, 0x386F2000, 0x386F4000,
+          0x386F6000, 0x386F8000, 0x386FA000, 0x386FC000, 0x386FE000,
+          0x38700000, 0x38702000, 0x38704000, 0x38706000, 0x38708000,
+          0x3870A000, 0x3870C000, 0x3870E000, 0x38710000, 0x38712000,
+          0x38714000, 0x38716000, 0x38718000, 0x3871A000, 0x3871C000,
+          0x3871E000, 0x38720000, 0x38722000, 0x38724000, 0x38726000,
+          0x38728000, 0x3872A000, 0x3872C000, 0x3872E000, 0x38730000,
+          0x38732000, 0x38734000, 0x38736000, 0x38738000, 0x3873A000,
+          0x3873C000, 0x3873E000, 0x38740000, 0x38742000, 0x38744000,
+          0x38746000, 0x38748000, 0x3874A000, 0x3874C000, 0x3874E000,
+          0x38750000, 0x38752000, 0x38754000, 0x38756000, 0x38758000,
+          0x3875A000, 0x3875C000, 0x3875E000, 0x38760000, 0x38762000,
+          0x38764000, 0x38766000, 0x38768000, 0x3876A000, 0x3876C000,
+          0x3876E000, 0x38770000, 0x38772000, 0x38774000, 0x38776000,
+          0x38778000, 0x3877A000, 0x3877C000, 0x3877E000, 0x38780000,
+          0x38782000, 0x38784000, 0x38786000, 0x38788000, 0x3878A000,
+          0x3878C000, 0x3878E000, 0x38790000, 0x38792000, 0x38794000,
+          0x38796000, 0x38798000, 0x3879A000, 0x3879C000, 0x3879E000,
+          0x387A0000, 0x387A2000, 0x387A4000, 0x387A6000, 0x387A8000,
+          0x387AA000, 0x387AC000, 0x387AE000, 0x387B0000, 0x387B2000,
+          0x387B4000, 0x387B6000, 0x387B8000, 0x387BA000, 0x387BC000,
+          0x387BE000, 0x387C0000, 0x387C2000, 0x387C4000, 0x387C6000,
+          0x387C8000, 0x387CA000, 0x387CC000, 0x387CE000, 0x387D0000,
+          0x387D2000, 0x387D4000, 0x387D6000, 0x387D8000, 0x387DA000,
+          0x387DC000, 0x387DE000, 0x387E0000, 0x387E2000, 0x387E4000,
+          0x387E6000, 0x387E8000, 0x387EA000, 0x387EC000, 0x387EE000,
+          0x387F0000, 0x387F2000, 0x387F4000, 0x387F6000, 0x387F8000,
+          0x387FA000, 0x387FC000, 0x387FE000};
+  static const uint32 exponent_table[64] = {
+      0x00000000, 0x00800000, 0x01000000, 0x01800000, 0x02000000, 0x02800000,
+      0x03000000, 0x03800000, 0x04000000, 0x04800000, 0x05000000, 0x05800000,
+      0x06000000, 0x06800000, 0x07000000, 0x07800000, 0x08000000, 0x08800000,
+      0x09000000, 0x09800000, 0x0A000000, 0x0A800000, 0x0B000000, 0x0B800000,
+      0x0C000000, 0x0C800000, 0x0D000000, 0x0D800000, 0x0E000000, 0x0E800000,
+      0x0F000000, 0x47800000, 0x80000000, 0x80800000, 0x81000000, 0x81800000,
+      0x82000000, 0x82800000, 0x83000000, 0x83800000, 0x84000000, 0x84800000,
+      0x85000000, 0x85800000, 0x86000000, 0x86800000, 0x87000000, 0x87800000,
+      0x88000000, 0x88800000, 0x89000000, 0x89800000, 0x8A000000, 0x8A800000,
+      0x8B000000, 0x8B800000, 0x8C000000, 0x8C800000, 0x8D000000, 0x8D800000,
+      0x8E000000, 0x8E800000, 0x8F000000, 0xC7800000};
+  static const unsigned short offset_table[64] = {
+      0,    1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024,
+      1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024,
+      1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 0,
+      1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024,
+      1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024,
+      1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024};
+  uint32 bits = mantissa_table[offset_table[value >> 10] + (value & 0x3FF)] +
+                exponent_table[value >> 10];
+  //			return *reinterpret_cast<float*>(&bits);			//violating
+  //strict aliasing!
+  float out;
+  std::memcpy(&out, &bits, sizeof(float));
+  return out;
+}
 
-		/// Convert half-precision to IEEE double-precision.
-		/// \param value binary representation of half-precision value
-		/// \return double-precision value
-		inline double half2float_impl(uint16 value, double, true_type)
-		{
-			typedef bits<float>::type uint32;
-			typedef bits<double>::type uint64;
-			uint32 hi = static_cast<uint32>(value&0x8000) << 16;
-			int abs = value & 0x7FFF;
-			if(abs)
-			{
-				hi |= 0x3F000000 << static_cast<unsigned>(abs>=0x7C00);
-				for(; abs<0x400; abs<<=1,hi-=0x100000) ;
-				hi += static_cast<uint32>(abs) << 10;
-			}
-			uint64 bits = static_cast<uint64>(hi) << 32;
-//			return *reinterpret_cast<double*>(&bits);			//violating strict aliasing!
-			double out;
-			std::memcpy(&out, &bits, sizeof(double));
-			return out;
-		}
+/// Convert half-precision to IEEE double-precision.
+/// \param value binary representation of half-precision value
+/// \return double-precision value
+inline double half2float_impl(uint16 value, double, true_type) {
+  typedef bits<float>::type uint32;
+  typedef bits<double>::type uint64;
+  uint32 hi = static_cast<uint32>(value & 0x8000) << 16;
+  int abs = value & 0x7FFF;
+  if (abs) {
+    hi |= 0x3F000000 << static_cast<unsigned>(abs >= 0x7C00);
+    for (; abs < 0x400; abs <<= 1, hi -= 0x100000)
+      ;
+    hi += static_cast<uint32>(abs) << 10;
+  }
+  uint64 bits = static_cast<uint64>(hi) << 32;
+  //			return *reinterpret_cast<double*>(&bits);			//violating
+  //strict aliasing!
+  double out;
+  std::memcpy(&out, &bits, sizeof(double));
+  return out;
+}
 
-		/// Convert half-precision to non-IEEE floating point.
-		/// \tparam T type to convert to (builtin integer type)
-		/// \param value binary representation of half-precision value
-		/// \return floating point value
-		template<typename T> T half2float_impl(uint16 value, T, ...)
-		{
-			T out;
-			int abs = value & 0x7FFF;
-			if(abs > 0x7C00)
-				out = std::numeric_limits<T>::has_quiet_NaN ? std::numeric_limits<T>::quiet_NaN() : T();
-			else if(abs == 0x7C00)
-				out = std::numeric_limits<T>::has_infinity ? std::numeric_limits<T>::infinity() : std::numeric_limits<T>::max();
-			else if(abs > 0x3FF)
-				out = std::ldexp(static_cast<T>((abs&0x3FF)|0x400), (abs>>10)-25);
-			else
-				out = std::ldexp(static_cast<T>(abs), -24);
-			return (value&0x8000) ? -out : out;
-		}
+/// Convert half-precision to non-IEEE floating point.
+/// \tparam T type to convert to (builtin integer type)
+/// \param value binary representation of half-precision value
+/// \return floating point value
+template <typename T>
+T half2float_impl(uint16 value, T, ...) {
+  T out;
+  int abs = value & 0x7FFF;
+  if (abs > 0x7C00)
+    out = std::numeric_limits<T>::has_quiet_NaN
+              ? std::numeric_limits<T>::quiet_NaN()
+              : T();
+  else if (abs == 0x7C00)
+    out = std::numeric_limits<T>::has_infinity
+              ? std::numeric_limits<T>::infinity()
+              : std::numeric_limits<T>::max();
+  else if (abs > 0x3FF)
+    out = std::ldexp(static_cast<T>((abs & 0x3FF) | 0x400), (abs >> 10) - 25);
+  else
+    out = std::ldexp(static_cast<T>(abs), -24);
+  return (value & 0x8000) ? -out : out;
+}
 
-		/// Convert half-precision to floating point.
-		/// \tparam T type to convert to (builtin integer type)
-		/// \param value binary representation of half-precision value
-		/// \return floating point value
-		template<typename T> T half2float(uint16 value)
-		{
-			return half2float_impl(value, T(), bool_type<std::numeric_limits<T>::is_iec559&&sizeof(typename bits<T>::type)==sizeof(T)>());
-		}
+/// Convert half-precision to floating point.
+/// \tparam T type to convert to (builtin integer type)
+/// \param value binary representation of half-precision value
+/// \return floating point value
+template <typename T>
+T half2float(uint16 value) {
+  return half2float_impl(value, T(),
+                         bool_type < std::numeric_limits<T>::is_iec559 &&
+                             sizeof(typename bits<T>::type) == sizeof(T) > ());
+}
 
-		/// Convert half-precision floating point to integer.
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \tparam E `true` for round to even, `false` for round away from zero
-		/// \tparam T type to convert to (buitlin integer type with at least 16 bits precision, excluding any implicit sign bits)
-		/// \param value binary representation of half-precision value
-		/// \return integral value
-		template<std::float_round_style R,bool E,typename T> T half2int_impl(uint16 value)
-		{
-		#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
-			static_assert(std::is_integral<T>::value, "half to int conversion only supports builtin integer types");
-		#endif
-			unsigned int e = value & 0x7FFF;
-			if(e >= 0x7C00)
-				return (value&0x8000) ? std::numeric_limits<T>::min() : std::numeric_limits<T>::max();
-			if(e < 0x3800)
-			{
-				if(R == std::round_toward_infinity)
-					return T(~(value>>15)&(e!=0));
-				else if(R == std::round_toward_neg_infinity)
-					return -T(value>0x8000);
-				return T();
-			}
-			unsigned int m = (value&0x3FF) | 0x400;
-			e >>= 10;
-			if(e < 25)
-			{
-				if(R == std::round_to_nearest)
-					m += (1<<(24-e)) - (~(m>>(25-e))&E);
-				else if(R == std::round_toward_infinity)
-					m += ((value>>15)-1) & ((1<<(25-e))-1U);
-				else if(R == std::round_toward_neg_infinity)
-					m += -(value>>15) & ((1<<(25-e))-1U);
-				m >>= 25 - e;
-			}
-			else
-				m <<= e - 25;
-			return (value&0x8000) ? -static_cast<T>(m) : static_cast<T>(m);
-		}
+/// Convert half-precision floating point to integer.
+/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+/// rounding
+/// \tparam E `true` for round to even, `false` for round away from zero
+/// \tparam T type to convert to (buitlin integer type with at least 16 bits
+/// precision, excluding any implicit sign bits)
+/// \param value binary representation of half-precision value
+/// \return integral value
+template <std::float_round_style R, bool E, typename T>
+T half2int_impl(uint16 value) {
+#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
+  static_assert(std::is_integral<T>::value,
+                "half to int conversion only supports builtin integer types");
+#endif
+  unsigned int e = value & 0x7FFF;
+  if (e >= 0x7C00)
+    return (value & 0x8000) ? std::numeric_limits<T>::min()
+                            : std::numeric_limits<T>::max();
+  if (e < 0x3800) {
+    if (R == std::round_toward_infinity)
+      return T(~(value >> 15) & (e != 0));
+    else if (R == std::round_toward_neg_infinity)
+      return -T(value > 0x8000);
+    return T();
+  }
+  unsigned int m = (value & 0x3FF) | 0x400;
+  e >>= 10;
+  if (e < 25) {
+    if (R == std::round_to_nearest)
+      m += (1 << (24 - e)) - (~(m >> (25 - e)) & E);
+    else if (R == std::round_toward_infinity)
+      m += ((value >> 15) - 1) & ((1 << (25 - e)) - 1U);
+    else if (R == std::round_toward_neg_infinity)
+      m += -(value >> 15) & ((1 << (25 - e)) - 1U);
+    m >>= 25 - e;
+  } else
+    m <<= e - 25;
+  return (value & 0x8000) ? -static_cast<T>(m) : static_cast<T>(m);
+}
 
-		/// Convert half-precision floating point to integer.
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \tparam T type to convert to (buitlin integer type with at least 16 bits precision, excluding any implicit sign bits)
-		/// \param value binary representation of half-precision value
-		/// \return integral value
-		template<std::float_round_style R,typename T> T half2int(uint16 value) { return half2int_impl<R,HALF_ROUND_TIES_TO_EVEN,T>(value); }
+/// Convert half-precision floating point to integer.
+/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+/// rounding
+/// \tparam T type to convert to (buitlin integer type with at least 16 bits
+/// precision, excluding any implicit sign bits)
+/// \param value binary representation of half-precision value
+/// \return integral value
+template <std::float_round_style R, typename T>
+T half2int(uint16 value) {
+  return half2int_impl<R, HALF_ROUND_TIES_TO_EVEN, T>(value);
+}
 
-		/// Convert half-precision floating point to integer using round-to-nearest-away-from-zero.
-		/// \tparam T type to convert to (buitlin integer type with at least 16 bits precision, excluding any implicit sign bits)
-		/// \param value binary representation of half-precision value
-		/// \return integral value
-		template<typename T> T half2int_up(uint16 value) { return half2int_impl<std::round_to_nearest,0,T>(value); }
+/// Convert half-precision floating point to integer using
+/// round-to-nearest-away-from-zero.
+/// \tparam T type to convert to (buitlin integer type with at least 16 bits
+/// precision, excluding any implicit sign bits)
+/// \param value binary representation of half-precision value
+/// \return integral value
+template <typename T>
+T half2int_up(uint16 value) {
+  return half2int_impl<std::round_to_nearest, 0, T>(value);
+}
 
-		/// Round half-precision number to nearest integer value.
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \tparam E `true` for round to even, `false` for round away from zero
-		/// \param value binary representation of half-precision value
-		/// \return half-precision bits for nearest integral value
-		template<std::float_round_style R,bool E> uint16 round_half_impl(uint16 value)
-		{
-			unsigned int e = value & 0x7FFF;
-			uint16 result = value;
-			if(e < 0x3C00)
-			{
-				result &= 0x8000;
-				if(R == std::round_to_nearest)
-					result |= 0x3C00U & -(e>=(0x3800+E));
-				else if(R == std::round_toward_infinity)
-					result |= 0x3C00U & -(~(value>>15)&(e!=0));
-				else if(R == std::round_toward_neg_infinity)
-					result |= 0x3C00U & -(value>0x8000);
-			}
-			else if(e < 0x6400)
-			{
-				e = 25 - (e>>10);
-				unsigned int mask = (1<<e) - 1;
-				if(R == std::round_to_nearest)
-					result += (1<<(e-1)) - (~(result>>e)&E);
-				else if(R == std::round_toward_infinity)
-					result += mask & ((value>>15)-1);
-				else if(R == std::round_toward_neg_infinity)
-					result += mask & -(value>>15);
-				result &= ~mask;
-			}
-			return result;
-		}
+/// Round half-precision number to nearest integer value.
+/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+/// rounding
+/// \tparam E `true` for round to even, `false` for round away from zero
+/// \param value binary representation of half-precision value
+/// \return half-precision bits for nearest integral value
+template <std::float_round_style R, bool E>
+uint16 round_half_impl(uint16 value) {
+  unsigned int e = value & 0x7FFF;
+  uint16 result = value;
+  if (e < 0x3C00) {
+    result &= 0x8000;
+    if (R == std::round_to_nearest)
+      result |= 0x3C00U & -(e >= (0x3800 + E));
+    else if (R == std::round_toward_infinity)
+      result |= 0x3C00U & -(~(value >> 15) & (e != 0));
+    else if (R == std::round_toward_neg_infinity)
+      result |= 0x3C00U & -(value > 0x8000);
+  } else if (e < 0x6400) {
+    e = 25 - (e >> 10);
+    unsigned int mask = (1 << e) - 1;
+    if (R == std::round_to_nearest)
+      result += (1 << (e - 1)) - (~(result >> e) & E);
+    else if (R == std::round_toward_infinity)
+      result += mask & ((value >> 15) - 1);
+    else if (R == std::round_toward_neg_infinity)
+      result += mask & -(value >> 15);
+    result &= ~mask;
+  }
+  return result;
+}
 
-		/// Round half-precision number to nearest integer value.
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \param value binary representation of half-precision value
-		/// \return half-precision bits for nearest integral value
-		template<std::float_round_style R> uint16 round_half(uint16 value) { return round_half_impl<R,HALF_ROUND_TIES_TO_EVEN>(value); }
+/// Round half-precision number to nearest integer value.
+/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+/// rounding
+/// \param value binary representation of half-precision value
+/// \return half-precision bits for nearest integral value
+template <std::float_round_style R>
+uint16 round_half(uint16 value) {
+  return round_half_impl<R, HALF_ROUND_TIES_TO_EVEN>(value);
+}
 
-		/// Round half-precision number to nearest integer value using round-to-nearest-away-from-zero.
-		/// \param value binary representation of half-precision value
-		/// \return half-precision bits for nearest integral value
-		inline uint16 round_half_up(uint16 value) { return round_half_impl<std::round_to_nearest,0>(value); }
-		/// \}
+/// Round half-precision number to nearest integer value using
+/// round-to-nearest-away-from-zero.
+/// \param value binary representation of half-precision value
+/// \return half-precision bits for nearest integral value
+inline uint16 round_half_up(uint16 value) {
+  return round_half_impl<std::round_to_nearest, 0>(value);
+}
+/// \}
 
-		struct functions;
-		template<typename> struct unary_specialized;
-		template<typename,typename> struct binary_specialized;
-		template<typename,typename,std::float_round_style> struct half_caster;
-	}
+struct functions;
+template <typename>
+struct unary_specialized;
+template <typename, typename>
+struct binary_specialized;
+template <typename, typename, std::float_round_style>
+struct half_caster;
+}
 
-	/// Half-precision floating point type.
-	/// This class implements an IEEE-conformant half-precision floating point type with the usual arithmetic operators and 
-	/// conversions. It is implicitly convertible to single-precision floating point, which makes artihmetic expressions and 
-	/// functions with mixed-type operands to be of the most precise operand type. Additionally all arithmetic operations 
-	/// (and many mathematical functions) are carried out in single-precision internally. All conversions from single- to 
-	/// half-precision are done using the library's default rounding mode, but temporary results inside chained arithmetic 
-	/// expressions are kept in single-precision as long as possible (while of course still maintaining a strong half-precision type).
-	///
-	/// According to the C++98/03 definition, the half type is not a POD type. But according to C++11's less strict and 
-	/// extended definitions it is both a standard layout type and a trivially copyable type (even if not a POD type), which 
-	/// means it can be standard-conformantly copied using raw binary copies. But in this context some more words about the 
-	/// actual size of the type. Although the half is representing an IEEE 16-bit type, it does not neccessarily have to be of 
-	/// exactly 16-bits size. But on any reasonable implementation the actual binary representation of this type will most 
-	/// probably not ivolve any additional "magic" or padding beyond the simple binary representation of the underlying 16-bit 
-	/// IEEE number, even if not strictly guaranteed by the standard. But even then it only has an actual size of 16 bits if 
-	/// your C++ implementation supports an unsigned integer type of exactly 16 bits width. But this should be the case on 
-	/// nearly any reasonable platform.
-	///
-	/// So if your C++ implementation is not totally exotic or imposes special alignment requirements, it is a reasonable 
-	/// assumption that the data of a half is just comprised of the 2 bytes of the underlying IEEE representation.
-	class half
-	{
-		friend struct detail::functions;
-		friend struct detail::unary_specialized<half>;
-		friend struct detail::binary_specialized<half,half>;
-		template<typename,typename,std::float_round_style> friend struct detail::half_caster;
-		friend class std::numeric_limits<half>;
-	#if HALF_ENABLE_CPP11_HASH
-		friend struct std::hash<half>;
-	#endif
-	#if HALF_ENABLE_CPP11_USER_LITERALS
-		friend half literal::operator"" _h(long double);
-	#endif
+/// Half-precision floating point type.
+/// This class implements an IEEE-conformant half-precision floating point type
+/// with the usual arithmetic operators and
+/// conversions. It is implicitly convertible to single-precision floating
+/// point, which makes artihmetic expressions and
+/// functions with mixed-type operands to be of the most precise operand type.
+/// Additionally all arithmetic operations
+/// (and many mathematical functions) are carried out in single-precision
+/// internally. All conversions from single- to
+/// half-precision are done using the library's default rounding mode, but
+/// temporary results inside chained arithmetic
+/// expressions are kept in single-precision as long as possible (while of
+/// course still maintaining a strong half-precision type).
+///
+/// According to the C++98/03 definition, the half type is not a POD type. But
+/// according to C++11's less strict and
+/// extended definitions it is both a standard layout type and a trivially
+/// copyable type (even if not a POD type), which
+/// means it can be standard-conformantly copied using raw binary copies. But in
+/// this context some more words about the
+/// actual size of the type. Although the half is representing an IEEE 16-bit
+/// type, it does not neccessarily have to be of
+/// exactly 16-bits size. But on any reasonable implementation the actual binary
+/// representation of this type will most
+/// probably not ivolve any additional "magic" or padding beyond the simple
+/// binary representation of the underlying 16-bit
+/// IEEE number, even if not strictly guaranteed by the standard. But even then
+/// it only has an actual size of 16 bits if
+/// your C++ implementation supports an unsigned integer type of exactly 16 bits
+/// width. But this should be the case on
+/// nearly any reasonable platform.
+///
+/// So if your C++ implementation is not totally exotic or imposes special
+/// alignment requirements, it is a reasonable
+/// assumption that the data of a half is just comprised of the 2 bytes of the
+/// underlying IEEE representation.
+class half {
+  friend struct detail::functions;
+  friend struct detail::unary_specialized<half>;
+  friend struct detail::binary_specialized<half, half>;
+  template <typename, typename, std::float_round_style>
+  friend struct detail::half_caster;
+  friend class std::numeric_limits<half>;
+#if HALF_ENABLE_CPP11_HASH
+  friend struct std::hash<half>;
+#endif
+#if HALF_ENABLE_CPP11_USER_LITERALS
+  friend half literal::operator"" _h(long double);
+#endif
 
-	public:
-		/// Default constructor.
-		/// This initializes the half to 0. Although this does not match the builtin types' default-initialization semantics 
-		/// and may be less efficient than no initialization, it is needed to provide proper value-initialization semantics.
-		HALF_CONSTEXPR half() HALF_NOEXCEPT : data_() {}
+ public:
+  /// Default constructor.
+  /// This initializes the half to 0. Although this does not match the builtin
+  /// types' default-initialization semantics
+  /// and may be less efficient than no initialization, it is needed to provide
+  /// proper value-initialization semantics.
+  HALF_CONSTEXPR half() HALF_NOEXCEPT : data_() {}
 
-		/// Copy constructor.
-		/// \tparam T type of concrete half expression
-		/// \param rhs half expression to copy from
-		half(detail::expr rhs) : data_(detail::float2half<round_style>(static_cast<float>(rhs))) {}
+  /// Copy constructor.
+  /// \tparam T type of concrete half expression
+  /// \param rhs half expression to copy from
+  half(detail::expr rhs)
+      : data_(detail::float2half<round_style>(static_cast<float>(rhs))) {}
 
-		/// Conversion constructor.
-		/// \param rhs float to convert
-		explicit half(float rhs) : data_(detail::float2half<round_style>(rhs)) {}
-	
-		/// Conversion to single-precision.
-		/// \return single precision value representing expression value
-		operator float() const { return detail::half2float<float>(data_); }
+  /// Conversion constructor.
+  /// \param rhs float to convert
+  explicit half(float rhs) : data_(detail::float2half<round_style>(rhs)) {}
 
-		/// Assignment operator.
-		/// \tparam T type of concrete half expression
-		/// \param rhs half expression to copy from
-		/// \return reference to this half
-		half& operator=(detail::expr rhs) { return *this = static_cast<float>(rhs); }
+  /// Conversion to single-precision.
+  /// \return single precision value representing expression value
+  operator float() const { return detail::half2float<float>(data_); }
 
-		/// Arithmetic assignment.
-		/// \tparam T type of concrete half expression
-		/// \param rhs half expression to add
-		/// \return reference to this half
-		template<typename T> typename detail::enable<half&,T>::type operator+=(T rhs) { return *this += static_cast<float>(rhs); }
+  /// Assignment operator.
+  /// \tparam T type of concrete half expression
+  /// \param rhs half expression to copy from
+  /// \return reference to this half
+  half &operator=(detail::expr rhs) { return *this = static_cast<float>(rhs); }
 
-		/// Arithmetic assignment.
-		/// \tparam T type of concrete half expression
-		/// \param rhs half expression to subtract
-		/// \return reference to this half
-		template<typename T> typename detail::enable<half&,T>::type operator-=(T rhs) { return *this -= static_cast<float>(rhs); }
+  /// Arithmetic assignment.
+  /// \tparam T type of concrete half expression
+  /// \param rhs half expression to add
+  /// \return reference to this half
+  template <typename T>
+  typename detail::enable<half &, T>::type operator+=(T rhs) {
+    return *this += static_cast<float>(rhs);
+  }
 
-		/// Arithmetic assignment.
-		/// \tparam T type of concrete half expression
-		/// \param rhs half expression to multiply with
-		/// \return reference to this half
-		template<typename T> typename detail::enable<half&,T>::type operator*=(T rhs) { return *this *= static_cast<float>(rhs); }
+  /// Arithmetic assignment.
+  /// \tparam T type of concrete half expression
+  /// \param rhs half expression to subtract
+  /// \return reference to this half
+  template <typename T>
+  typename detail::enable<half &, T>::type operator-=(T rhs) {
+    return *this -= static_cast<float>(rhs);
+  }
 
-		/// Arithmetic assignment.
-		/// \tparam T type of concrete half expression
-		/// \param rhs half expression to divide by
-		/// \return reference to this half
-		template<typename T> typename detail::enable<half&,T>::type operator/=(T rhs) { return *this /= static_cast<float>(rhs); }
+  /// Arithmetic assignment.
+  /// \tparam T type of concrete half expression
+  /// \param rhs half expression to multiply with
+  /// \return reference to this half
+  template <typename T>
+  typename detail::enable<half &, T>::type operator*=(T rhs) {
+    return *this *= static_cast<float>(rhs);
+  }
 
-		/// Assignment operator.
-		/// \param rhs single-precision value to copy from
-		/// \return reference to this half
-		half& operator=(float rhs) { data_ = detail::float2half<round_style>(rhs); return *this; }
+  /// Arithmetic assignment.
+  /// \tparam T type of concrete half expression
+  /// \param rhs half expression to divide by
+  /// \return reference to this half
+  template <typename T>
+  typename detail::enable<half &, T>::type operator/=(T rhs) {
+    return *this /= static_cast<float>(rhs);
+  }
 
-		/// Arithmetic assignment.
-		/// \param rhs single-precision value to add
-		/// \return reference to this half
-		half& operator+=(float rhs) { data_ = detail::float2half<round_style>(detail::half2float<float>(data_)+rhs); return *this; }
+  /// Assignment operator.
+  /// \param rhs single-precision value to copy from
+  /// \return reference to this half
+  half &operator=(float rhs) {
+    data_ = detail::float2half<round_style>(rhs);
+    return *this;
+  }
 
-		/// Arithmetic assignment.
-		/// \param rhs single-precision value to subtract
-		/// \return reference to this half
-		half& operator-=(float rhs) { data_ = detail::float2half<round_style>(detail::half2float<float>(data_)-rhs); return *this; }
+  /// Arithmetic assignment.
+  /// \param rhs single-precision value to add
+  /// \return reference to this half
+  half &operator+=(float rhs) {
+    data_ =
+        detail::float2half<round_style>(detail::half2float<float>(data_) + rhs);
+    return *this;
+  }
 
-		/// Arithmetic assignment.
-		/// \param rhs single-precision value to multiply with
-		/// \return reference to this half
-		half& operator*=(float rhs) { data_ = detail::float2half<round_style>(detail::half2float<float>(data_)*rhs); return *this; }
+  /// Arithmetic assignment.
+  /// \param rhs single-precision value to subtract
+  /// \return reference to this half
+  half &operator-=(float rhs) {
+    data_ =
+        detail::float2half<round_style>(detail::half2float<float>(data_) - rhs);
+    return *this;
+  }
 
-		/// Arithmetic assignment.
-		/// \param rhs single-precision value to divide by
-		/// \return reference to this half
-		half& operator/=(float rhs) { data_ = detail::float2half<round_style>(detail::half2float<float>(data_)/rhs); return *this; }
+  /// Arithmetic assignment.
+  /// \param rhs single-precision value to multiply with
+  /// \return reference to this half
+  half &operator*=(float rhs) {
+    data_ =
+        detail::float2half<round_style>(detail::half2float<float>(data_) * rhs);
+    return *this;
+  }
 
-		/// Prefix increment.
-		/// \return incremented half value
-		half& operator++() { return *this += 1.0f; }
+  /// Arithmetic assignment.
+  /// \param rhs single-precision value to divide by
+  /// \return reference to this half
+  half &operator/=(float rhs) {
+    data_ =
+        detail::float2half<round_style>(detail::half2float<float>(data_) / rhs);
+    return *this;
+  }
 
-		/// Prefix decrement.
-		/// \return decremented half value
-		half& operator--() { return *this -= 1.0f; }
+  /// Prefix increment.
+  /// \return incremented half value
+  half &operator++() { return *this += 1.0f; }
 
-		/// Postfix increment.
-		/// \return non-incremented half value
-		half operator++(int) { half out(*this); ++*this; return out; }
+  /// Prefix decrement.
+  /// \return decremented half value
+  half &operator--() { return *this -= 1.0f; }
 
-		/// Postfix decrement.
-		/// \return non-decremented half value
-		half operator--(int) { half out(*this); --*this; return out; }
-	
-	private:
-		/// Rounding mode to use
-		static const std::float_round_style round_style = (std::float_round_style)(HALF_ROUND_STYLE);
+  /// Postfix increment.
+  /// \return non-incremented half value
+  half operator++(int) {
+    half out(*this);
+    ++*this;
+    return out;
+  }
 
-		/// Constructor.
-		/// \param bits binary representation to set half to
-		HALF_CONSTEXPR half(detail::binary_t, detail::uint16 bits) HALF_NOEXCEPT : data_(bits) {}
+  /// Postfix decrement.
+  /// \return non-decremented half value
+  half operator--(int) {
+    half out(*this);
+    --*this;
+    return out;
+  }
 
-		/// Internal binary representation
-		detail::uint16 data_;
-	};
+ private:
+  /// Rounding mode to use
+  static const std::float_round_style round_style =
+      (std::float_round_style)(HALF_ROUND_STYLE);
+
+  /// Constructor.
+  /// \param bits binary representation to set half to
+  HALF_CONSTEXPR half(detail::binary_t, detail::uint16 bits) HALF_NOEXCEPT
+      : data_(bits) {}
+
+  /// Internal binary representation
+  detail::uint16 data_;
+};
 
 #if HALF_ENABLE_CPP11_USER_LITERALS
-	namespace literal
-	{
-		/// Half literal.
-		/// While this returns an actual half-precision value, half literals can unfortunately not be constant expressions due 
-		/// to rather involved conversions.
-		/// \param value literal value
-		/// \return half with given value (if representable)
-		inline half operator"" _h(long double value) { return half(detail::binary, detail::float2half<half::round_style>(value)); }
-	}
+namespace literal {
+/// Half literal.
+/// While this returns an actual half-precision value, half literals can
+/// unfortunately not be constant expressions due
+/// to rather involved conversions.
+/// \param value literal value
+/// \return half with given value (if representable)
+inline half operator"" _h(long double value) {
+  return half(detail::binary, detail::float2half<half::round_style>(value));
+}
+}
 #endif
 
-	namespace detail
-	{
-		/// Wrapper implementing unspecialized half-precision functions.
-		struct functions
-		{
-			/// Addition implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \return Half-precision sum stored in single-precision
-			static expr plus(float x, float y) { return expr(x+y); }
-
-			/// Subtraction implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \return Half-precision difference stored in single-precision
-			static expr minus(float x, float y) { return expr(x-y); }
-
-			/// Multiplication implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \return Half-precision product stored in single-precision
-			static expr multiplies(float x, float y) { return expr(x*y); }
-
-			/// Division implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \return Half-precision quotient stored in single-precision
-			static expr divides(float x, float y) { return expr(x/y); }
-
-			/// Output implementation.
-			/// \param out stream to write to
-			/// \param arg value to write
-			/// \return reference to stream
-			template<typename charT,typename traits> static std::basic_ostream<charT,traits>& write(std::basic_ostream<charT,traits> &out, float arg) { return out << arg; }
-
-			/// Input implementation.
-			/// \param in stream to read from
-			/// \param arg half to read into
-			/// \return reference to stream
-			template<typename charT,typename traits> static std::basic_istream<charT,traits>& read(std::basic_istream<charT,traits> &in, half &arg)
-			{
-				float f;
-				if(in >> f)
-					arg = f;
-				return in;
-			}
-
-			/// Modulo implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \return Half-precision division remainder stored in single-precision
-			static expr fmod(float x, float y) { return expr(std::fmod(x, y)); }
-
-			/// Remainder implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \return Half-precision division remainder stored in single-precision
-			static expr remainder(float x, float y)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::remainder(x, y));
-			#else
-				if(builtin_isnan(x) || builtin_isnan(y))
-					return expr(std::numeric_limits<float>::quiet_NaN());
-				float ax = std::fabs(x), ay = std::fabs(y);
-				if(ax >= 65536.0f || ay < std::ldexp(1.0f, -24))
-					return expr(std::numeric_limits<float>::quiet_NaN());
-				if(ay >= 65536.0f)
-					return expr(x);
-				if(ax == ay)
-					return expr(builtin_signbit(x) ? -0.0f : 0.0f);
-				ax = std::fmod(ax, ay+ay);
-				float y2 = 0.5f * ay;
-				if(ax > y2)
-				{
-					ax -= ay;
-					if(ax >= y2)
-						ax -= ay;
-				}
-				return expr(builtin_signbit(x) ? -ax : ax);
-			#endif
-			}
-
-			/// Remainder implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \param quo address to store quotient bits at
-			/// \return Half-precision division remainder stored in single-precision
-			static expr remquo(float x, float y, int *quo)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::remquo(x, y, quo));
-			#else
-				if(builtin_isnan(x) || builtin_isnan(y))
-					return expr(std::numeric_limits<float>::quiet_NaN());
-				bool sign = builtin_signbit(x), qsign = static_cast<bool>(sign^builtin_signbit(y));
-				float ax = std::fabs(x), ay = std::fabs(y);
-				if(ax >= 65536.0f || ay < std::ldexp(1.0f, -24))
-					return expr(std::numeric_limits<float>::quiet_NaN());
-				if(ay >= 65536.0f)
-					return expr(x);
-				if(ax == ay)
-					return *quo = qsign ? -1 : 1, expr(sign ? -0.0f : 0.0f);
-				ax = std::fmod(ax, 8.0f*ay);
-				int cquo = 0;
-				if(ax >= 4.0f * ay)
-				{
-					ax -= 4.0f * ay;
-					cquo += 4;
-				}
-				if(ax >= 2.0f * ay)
-				{
-					ax -= 2.0f * ay;
-					cquo += 2;
-				}
-				float y2 = 0.5f * ay;
-				if(ax > y2)
-				{
-					ax -= ay;
-					++cquo;
-					if(ax >= y2)
-					{
-						ax -= ay;
-						++cquo;
-					}
-				}
-				return *quo = qsign ? -cquo : cquo, expr(sign ? -ax : ax);
-			#endif
-			}
-
-			/// Positive difference implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \return Positive difference stored in single-precision
-			static expr fdim(float x, float y)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::fdim(x, y));
-			#else
-				return expr((x<=y) ? 0.0f : (x-y));
-			#endif
-			}
-
-			/// Fused multiply-add implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \param z third operand
-			/// \return \a x * \a y + \a z stored in single-precision
-			static expr fma(float x, float y, float z)
-			{
-			#if HALF_ENABLE_CPP11_CMATH && defined(FP_FAST_FMAF)
-				return expr(std::fma(x, y, z));
-			#else
-				return expr(x*y+z);
-			#endif
-			}
-
-			/// Get NaN.
-			/// \return Half-precision quiet NaN
-			static half nanh() { return half(binary, 0x7FFF); }
-
-			/// Exponential implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr exp(float arg) { return expr(std::exp(arg)); }
-
-			/// Exponential implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr expm1(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::expm1(arg));
-			#else
-				return expr(static_cast<float>(std::exp(static_cast<double>(arg))-1.0));
-			#endif
-			}
-
-			/// Binary exponential implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr exp2(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::exp2(arg));
-			#else
-				return expr(static_cast<float>(std::exp(arg*0.69314718055994530941723212145818)));
-			#endif
-			}
-
-			/// Logarithm implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr log(float arg) { return expr(std::log(arg)); }
-
-			/// Common logarithm implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr log10(float arg) { return expr(std::log10(arg)); }
-
-			/// Logarithm implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr log1p(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::log1p(arg));
-			#else
-				return expr(static_cast<float>(std::log(1.0+arg)));
-			#endif
-			}
-
-			/// Binary logarithm implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr log2(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::log2(arg));
-			#else
-				return expr(static_cast<float>(std::log(static_cast<double>(arg))*1.4426950408889634073599246810019));
-			#endif
-			}
-
-			/// Square root implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr sqrt(float arg) { return expr(std::sqrt(arg)); }
-
-			/// Cubic root implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr cbrt(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::cbrt(arg));
-			#else
-				if(builtin_isnan(arg) || builtin_isinf(arg))
-					return expr(arg);
-				return expr(builtin_signbit(arg) ? -static_cast<float>(std::pow(-static_cast<double>(arg), 1.0/3.0)) : 
-					static_cast<float>(std::pow(static_cast<double>(arg), 1.0/3.0)));
-			#endif
-			}
-
-			/// Hypotenuse implementation.
-			/// \param x first argument
-			/// \param y second argument
-			/// \return function value stored in single-preicision
-			static expr hypot(float x, float y)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::hypot(x, y));
-			#else
-				return expr((builtin_isinf(x) || builtin_isinf(y)) ? std::numeric_limits<float>::infinity() : 
-					static_cast<float>(std::sqrt(static_cast<double>(x)*x+static_cast<double>(y)*y)));
-			#endif
-			}
-
-			/// Power implementation.
-			/// \param base value to exponentiate
-			/// \param exp power to expontiate to
-			/// \return function value stored in single-preicision
-			static expr pow(float base, float exp) { return expr(std::pow(base, exp)); }
-
-			/// Sine implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr sin(float arg) { return expr(std::sin(arg)); }
-
-			/// Cosine implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr cos(float arg) { return expr(std::cos(arg)); }
-
-			/// Tan implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr tan(float arg) { return expr(std::tan(arg)); }
-
-			/// Arc sine implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr asin(float arg) { return expr(std::asin(arg)); }
-
-			/// Arc cosine implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr acos(float arg) { return expr(std::acos(arg)); }
-
-			/// Arc tangent implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr atan(float arg) { return expr(std::atan(arg)); }
-
-			/// Arc tangent implementation.
-			/// \param x first argument
-			/// \param y second argument
-			/// \return function value stored in single-preicision
-			static expr atan2(float x, float y) { return expr(std::atan2(x, y)); }
-
-			/// Hyperbolic sine implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr sinh(float arg) { return expr(std::sinh(arg)); }
-
-			/// Hyperbolic cosine implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr cosh(float arg) { return expr(std::cosh(arg)); }
-
-			/// Hyperbolic tangent implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr tanh(float arg) { return expr(std::tanh(arg)); }
-
-			/// Hyperbolic area sine implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr asinh(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::asinh(arg));
-			#else
-				return expr((arg==-std::numeric_limits<float>::infinity()) ? arg : static_cast<float>(std::log(arg+std::sqrt(arg*arg+1.0))));
-			#endif
-			}
-
-			/// Hyperbolic area cosine implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr acosh(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::acosh(arg));
-			#else
-				return expr((arg<-1.0f) ? std::numeric_limits<float>::quiet_NaN() : static_cast<float>(std::log(arg+std::sqrt(arg*arg-1.0))));
-			#endif
-			}
-
-			/// Hyperbolic area tangent implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr atanh(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::atanh(arg));
-			#else
-				return expr(static_cast<float>(0.5*std::log((1.0+arg)/(1.0-arg))));
-			#endif
-			}
-
-			/// Error function implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr erf(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::erf(arg));
-			#else
-				return expr(static_cast<float>(erf(static_cast<double>(arg))));
-			#endif
-			}
-
-			/// Complementary implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr erfc(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::erfc(arg));
-			#else
-				return expr(static_cast<float>(1.0-erf(static_cast<double>(arg))));
-			#endif
-			}
-
-			/// Gamma logarithm implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr lgamma(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::lgamma(arg));
-			#else
-				if(builtin_isinf(arg))
-					return expr(std::numeric_limits<float>::infinity());
-				if(arg < 0.0f)
-				{
-					float i, f = std::modf(-arg, &i);
-					if(f == 0.0f)
-						return expr(std::numeric_limits<float>::infinity());
-					return expr(static_cast<float>(1.1447298858494001741434273513531-
-						std::log(std::abs(std::sin(3.1415926535897932384626433832795*f)))-lgamma(1.0-arg)));
-				}
-				return expr(static_cast<float>(lgamma(static_cast<double>(arg))));
-			#endif
-			}
-
-			/// Gamma implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr tgamma(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::tgamma(arg));
-			#else
-				if(arg == 0.0f)
-					return builtin_signbit(arg) ? expr(-std::numeric_limits<float>::infinity()) : expr(std::numeric_limits<float>::infinity());
-				if(arg < 0.0f)
-				{
-					float i, f = std::modf(-arg, &i);
-					if(f == 0.0f)
-						return expr(std::numeric_limits<float>::quiet_NaN());
-					double value = 3.1415926535897932384626433832795 / (std::sin(3.1415926535897932384626433832795*f)*std::exp(lgamma(1.0-arg)));
-					return expr(static_cast<float>((std::fmod(i, 2.0f)==0.0f) ? -value : value));
-				}
-				if(builtin_isinf(arg))
-					return expr(arg);
-				return expr(static_cast<float>(std::exp(lgamma(static_cast<double>(arg)))));
-			#endif
-			}
-
-			/// Floor implementation.
-			/// \param arg value to round
-			/// \return rounded value
-			static half floor(half arg) { return half(binary, round_half<std::round_toward_neg_infinity>(arg.data_)); }
-
-			/// Ceiling implementation.
-			/// \param arg value to round
-			/// \return rounded value
-			static half ceil(half arg) { return half(binary, round_half<std::round_toward_infinity>(arg.data_)); }
-
-			/// Truncation implementation.
-			/// \param arg value to round
-			/// \return rounded value
-			static half trunc(half arg) { return half(binary, round_half<std::round_toward_zero>(arg.data_)); }
-
-			/// Nearest integer implementation.
-			/// \param arg value to round
-			/// \return rounded value
-			static half round(half arg) { return half(binary, round_half_up(arg.data_)); }
-
-			/// Nearest integer implementation.
-			/// \param arg value to round
-			/// \return rounded value
-			static long lround(half arg) { return detail::half2int_up<long>(arg.data_); }
-
-			/// Nearest integer implementation.
-			/// \param arg value to round
-			/// \return rounded value
-			static half rint(half arg) { return half(binary, round_half<half::round_style>(arg.data_)); }
-
-			/// Nearest integer implementation.
-			/// \param arg value to round
-			/// \return rounded value
-			static long lrint(half arg) { return detail::half2int<half::round_style,long>(arg.data_); }
-
-		#if HALF_ENABLE_CPP11_LONG_LONG
-			/// Nearest integer implementation.
-			/// \param arg value to round
-			/// \return rounded value
-			static long long llround(half arg) { return detail::half2int_up<long long>(arg.data_); }
-
-			/// Nearest integer implementation.
-			/// \param arg value to round
-			/// \return rounded value
-			static long long llrint(half arg) { return detail::half2int<half::round_style,long long>(arg.data_); }
-		#endif
-
-			/// Decompression implementation.
-			/// \param arg number to decompress
-			/// \param exp address to store exponent at
-			/// \return normalized significant
-			static half frexp(half arg, int *exp)
-			{
-				int m = arg.data_ & 0x7FFF, e = -14;
-				if(m >= 0x7C00 || !m)
-					return *exp = 0, arg;
-				for(; m<0x400; m<<=1,--e) ;
-				return *exp = e+(m>>10), half(binary, (arg.data_&0x8000)|0x3800|(m&0x3FF));
-			}
-
-			/// Decompression implementation.
-			/// \param arg number to decompress
-			/// \param iptr address to store integer part at
-			/// \return fractional part
-			static half modf(half arg, half *iptr)
-			{
-				unsigned int e = arg.data_ & 0x7FFF;
-				if(e >= 0x6400)
-					return *iptr = arg, half(binary, arg.data_&(0x8000U|-(e>0x7C00)));
-				if(e < 0x3C00)
-					return iptr->data_ = arg.data_ & 0x8000, arg;
-				e >>= 10;
-				unsigned int mask = (1<<(25-e)) - 1, m = arg.data_ & mask;
-				iptr->data_ = arg.data_ & ~mask;
-				if(!m)
-					return half(binary, arg.data_&0x8000);
-				for(; m<0x400; m<<=1,--e) ;
-				return half(binary, static_cast<uint16>((arg.data_&0x8000)|(e<<10)|(m&0x3FF)));
-			}
-
-			/// Scaling implementation.
-			/// \param arg number to scale
-			/// \param exp power of two to scale by
-			/// \return scaled number
-			static half scalbln(half arg, long exp)
-			{
-				unsigned int m = arg.data_ & 0x7FFF;
-				if(m >= 0x7C00 || !m)
-					return arg;
-				for(; m<0x400; m<<=1,--exp) ;
-				exp += m >> 10;
-				uint16 value = arg.data_ & 0x8000;
-				if(exp > 30)
-				{
-					if(half::round_style == std::round_toward_zero)
-						value |= 0x7BFF;
-					else if(half::round_style == std::round_toward_infinity)
-						value |= 0x7C00 - (value>>15);
-					else if(half::round_style == std::round_toward_neg_infinity)
-						value |= 0x7BFF + (value>>15);
-					else
-						value |= 0x7C00;
-				}
-				else if(exp > 0)
-					value |= (exp<<10) | (m&0x3FF);
-				else if(exp > -11)
-				{
-					m = (m&0x3FF) | 0x400;
-					if(half::round_style == std::round_to_nearest)
-					{
-						m += 1 << -exp;
-					#if HALF_ROUND_TIES_TO_EVEN
-						m -= (m>>(1-exp)) & 1;
-					#endif
-					}
-					else if(half::round_style == std::round_toward_infinity)
-						m += ((value>>15)-1) & ((1<<(1-exp))-1U);
-					else if(half::round_style == std::round_toward_neg_infinity)
-						m += -(value>>15) & ((1<<(1-exp))-1U);
-					value |= m >> (1-exp);
-				}
-				else if(half::round_style == std::round_toward_infinity)
-					value -= (value>>15) - 1;
-				else if(half::round_style == std::round_toward_neg_infinity)
-					value += value >> 15;
-				return half(binary, value);
-			}
-
-			/// Exponent implementation.
-			/// \param arg number to query
-			/// \return floating point exponent
-			static int ilogb(half arg)
-			{
-				int abs = arg.data_ & 0x7FFF;
-				if(!abs)
-					return FP_ILOGB0;
-				if(abs < 0x7C00)
-				{
-					int exp = (abs>>10) - 15;
-					if(abs < 0x400)
-						for(; abs<0x200; abs<<=1,--exp) ;
-					return exp;
-				}
-				if(abs > 0x7C00)
-					return FP_ILOGBNAN;
-				return INT_MAX;
-			}
-
-			/// Exponent implementation.
-			/// \param arg number to query
-			/// \return floating point exponent
-			static half logb(half arg)
-			{
-				int abs = arg.data_ & 0x7FFF;
-				if(!abs)
-					return half(binary, 0xFC00);
-				if(abs < 0x7C00)
-				{
-					int exp = (abs>>10) - 15;
-					if(abs < 0x400)
-						for(; abs<0x200; abs<<=1,--exp) ;
-					uint16 bits = (exp<0) << 15;
-					if(exp)
-					{
-						unsigned int m = std::abs(exp) << 6, e = 18;
-						for(; m<0x400; m<<=1,--e) ;
-						bits |= (e<<10) + m;
-					}
-					return half(binary, bits);
-				}
-				if(abs > 0x7C00)
-					return arg;
-				return half(binary, 0x7C00);
-			}
-
-			/// Enumeration implementation.
-			/// \param from number to increase/decrease
-			/// \param to direction to enumerate into
-			/// \return next representable number
-			static half nextafter(half from, half to)
-			{
-				uint16 fabs = from.data_ & 0x7FFF, tabs = to.data_ & 0x7FFF;
-				if(fabs > 0x7C00)
-					return from;
-				if(tabs > 0x7C00 || from.data_ == to.data_ || !(fabs|tabs))
-					return to;
-				if(!fabs)
-					return half(binary, (to.data_&0x8000)+1);
-				bool lt = ((fabs==from.data_) ? static_cast<int>(fabs) : -static_cast<int>(fabs)) < 
-					((tabs==to.data_) ? static_cast<int>(tabs) : -static_cast<int>(tabs));
-				return half(binary, from.data_+(((from.data_>>15)^static_cast<unsigned>(lt))<<1)-1);
-			}
-
-			/// Enumeration implementation.
-			/// \param from number to increase/decrease
-			/// \param to direction to enumerate into
-			/// \return next representable number
-			static half nexttoward(half from, long double to)
-			{
-				if(isnan(from))
-					return from;
-				long double lfrom = static_cast<long double>(from);
-				if(builtin_isnan(to) || lfrom == to)
-					return half(static_cast<float>(to));
-				if(!(from.data_&0x7FFF))
-					return half(binary, (static_cast<detail::uint16>(builtin_signbit(to))<<15)+1);
-				return half(binary, from.data_+(((from.data_>>15)^static_cast<unsigned>(lfrom<to))<<1)-1);
-			}
-
-			/// Sign implementation
-			/// \param x first operand
-			/// \param y second operand
-			/// \return composed value
-			static half copysign(half x, half y) { return half(binary, x.data_^((x.data_^y.data_)&0x8000)); }
-
-			/// Classification implementation.
-			/// \param arg value to classify
-			/// \retval true if infinite number
-			/// \retval false else
-			static int fpclassify(half arg)
-			{
-				unsigned int abs = arg.data_ & 0x7FFF;
-				return abs ? ((abs>0x3FF) ? ((abs>=0x7C00) ? ((abs>0x7C00) ? FP_NAN : FP_INFINITE) : FP_NORMAL) :FP_SUBNORMAL) : FP_ZERO;
-			}
-
-			/// Classification implementation.
-			/// \param arg value to classify
-			/// \retval true if finite number
-			/// \retval false else
-			static bool isfinite(half arg) { return (arg.data_&0x7C00) != 0x7C00; }
-
-			/// Classification implementation.
-			/// \param arg value to classify
-			/// \retval true if infinite number
-			/// \retval false else
-			static bool isinf(half arg) { return (arg.data_&0x7FFF) == 0x7C00; }
-
-			/// Classification implementation.
-			/// \param arg value to classify
-			/// \retval true if not a number
-			/// \retval false else
-			static bool isnan(half arg) { return (arg.data_&0x7FFF) > 0x7C00; }
-
-			/// Classification implementation.
-			/// \param arg value to classify
-			/// \retval true if normal number
-			/// \retval false else
-			static bool isnormal(half arg) { return ((arg.data_&0x7C00)!=0) & ((arg.data_&0x7C00)!=0x7C00); }
-
-			/// Sign bit implementation.
-			/// \param arg value to check
-			/// \retval true if signed
-			/// \retval false if unsigned
-			static bool signbit(half arg) { return (arg.data_&0x8000) != 0; }
-
-			/// Comparison implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \retval true if operands equal
-			/// \retval false else
-			static bool isequal(half x, half y) { return (x.data_==y.data_ || !((x.data_|y.data_)&0x7FFF)) && !isnan(x); }
-
-			/// Comparison implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \retval true if operands not equal
-			/// \retval false else
-			static bool isnotequal(half x, half y) { return (x.data_!=y.data_ && ((x.data_|y.data_)&0x7FFF)) || isnan(x); }
-
-			/// Comparison implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \retval true if \a x > \a y
-			/// \retval false else
-			static bool isgreater(half x, half y)
-			{
-				int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
-				return xabs<=0x7C00 && yabs<=0x7C00 && (((xabs==x.data_) ? xabs : -xabs) > ((yabs==y.data_) ? yabs : -yabs));
-			}
-
-			/// Comparison implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \retval true if \a x >= \a y
-			/// \retval false else
-			static bool isgreaterequal(half x, half y)
-			{
-				int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
-				return xabs<=0x7C00 && yabs<=0x7C00 && (((xabs==x.data_) ? xabs : -xabs) >= ((yabs==y.data_) ? yabs : -yabs));
-			}
-
-			/// Comparison implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \retval true if \a x < \a y
-			/// \retval false else
-			static bool isless(half x, half y)
-			{
-				int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
-				return xabs<=0x7C00 && yabs<=0x7C00 && (((xabs==x.data_) ? xabs : -xabs) < ((yabs==y.data_) ? yabs : -yabs));
-			}
-
-			/// Comparison implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \retval true if \a x <= \a y
-			/// \retval false else
-			static bool islessequal(half x, half y)
-			{
-				int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
-				return xabs<=0x7C00 && yabs<=0x7C00 && (((xabs==x.data_) ? xabs : -xabs) <= ((yabs==y.data_) ? yabs : -yabs));
-			}
-
-			/// Comparison implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \retval true if either \a x > \a y nor \a x < \a y
-			/// \retval false else
-			static bool islessgreater(half x, half y)
-			{
-				int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
-				if(xabs > 0x7C00 || yabs > 0x7C00)
-					return false;
-				int a = (xabs==x.data_) ? xabs : -xabs, b = (yabs==y.data_) ? yabs : -yabs;
-				return a < b || a > b;
-			}
-
-			/// Comparison implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \retval true if operand unordered
-			/// \retval false else
-			static bool isunordered(half x, half y) { return isnan(x) || isnan(y); }
-
-		private:
-			static double erf(double arg)
-			{
-				if(builtin_isinf(arg))
-					return (arg<0.0) ? -1.0 : 1.0;
-				double x2 = arg * arg, ax2 = 0.147 * x2, value = std::sqrt(1.0-std::exp(-x2*(1.2732395447351626861510701069801+ax2)/(1.0+ax2)));
-				return builtin_signbit(arg) ? -value : value;
-			}
-
-			static double lgamma(double arg)
-			{
-				double v = 1.0;
-				for(; arg<8.0; ++arg) v *= arg;
-				double w = 1.0 / (arg*arg);
-				return (((((((-0.02955065359477124183006535947712*w+0.00641025641025641025641025641026)*w+
-					-0.00191752691752691752691752691753)*w+8.4175084175084175084175084175084e-4)*w+
-					-5.952380952380952380952380952381e-4)*w+7.9365079365079365079365079365079e-4)*w+
-					-0.00277777777777777777777777777778)*w+0.08333333333333333333333333333333)/arg + 
-					0.91893853320467274178032973640562 - std::log(v) - arg + (arg-0.5) * std::log(arg);
-			}
-		};
-
-		/// Wrapper for unary half-precision functions needing specialization for individual argument types.
-		/// \tparam T argument type
-		template<typename T> struct unary_specialized
-		{
-			/// Negation implementation.
-			/// \param arg value to negate
-			/// \return negated value
-			static HALF_CONSTEXPR half negate(half arg) { return half(binary, arg.data_^0x8000); }
-
-			/// Absolute value implementation.
-			/// \param arg function argument
-			/// \return absolute value
-			static half fabs(half arg) { return half(binary, arg.data_&0x7FFF); }
-		};
-		template<> struct unary_specialized<expr>
-		{
-			static HALF_CONSTEXPR expr negate(float arg) { return expr(-arg); }
-			static expr fabs(float arg) { return expr(std::fabs(arg)); }
-		};
-
-		/// Wrapper for binary half-precision functions needing specialization for individual argument types.
-		/// \tparam T first argument type
-		/// \tparam U first argument type
-		template<typename T,typename U> struct binary_specialized
-		{
-			/// Minimum implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \return minimum value
-			static expr fmin(float x, float y)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::fmin(x, y));
-			#else
-				if(builtin_isnan(x))
-					return expr(y);
-				if(builtin_isnan(y))
-					return expr(x);
-				return expr(std::min(x, y));
-			#endif
-			}
-
-			/// Maximum implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \return maximum value
-			static expr fmax(float x, float y)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::fmax(x, y));
-			#else
-				if(builtin_isnan(x))
-					return expr(y);
-				if(builtin_isnan(y))
-					return expr(x);
-				return expr(std::max(x, y));
-			#endif
-			}
-		};
-		template<> struct binary_specialized<half,half>
-		{
-			static half fmin(half x, half y)
-			{
-				int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
-				if(xabs > 0x7C00)
-					return y;
-				if(yabs > 0x7C00)
-					return x;
-				return (((xabs==x.data_) ? xabs : -xabs) > ((yabs==y.data_) ? yabs : -yabs)) ? y : x;
-			}
-			static half fmax(half x, half y)
-			{
-				int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
-				if(xabs > 0x7C00)
-					return y;
-				if(yabs > 0x7C00)
-					return x;
-				return (((xabs==x.data_) ? xabs : -xabs) < ((yabs==y.data_) ? yabs : -yabs)) ? y : x;
-			}
-		};
-
-		/// Helper class for half casts.
-		/// This class template has to be specialized for all valid cast argument to define an appropriate static `cast` member 
-		/// function and a corresponding `type` member denoting its return type.
-		/// \tparam T destination type
-		/// \tparam U source type
-		/// \tparam R rounding mode to use
-		template<typename T,typename U,std::float_round_style R=(std::float_round_style)(HALF_ROUND_STYLE)> struct half_caster {};
-		template<typename U,std::float_round_style R> struct half_caster<half,U,R>
-		{
-		#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
-			static_assert(std::is_arithmetic<U>::value, "half_cast from non-arithmetic type unsupported");
-		#endif
-
-			static half cast(U arg) { return cast_impl(arg, is_float<U>()); };
-
-		private:
-			static half cast_impl(U arg, true_type) { return half(binary, float2half<R>(arg)); }
-			static half cast_impl(U arg, false_type) { return half(binary, int2half<R>(arg)); }
-		};
-		template<typename T,std::float_round_style R> struct half_caster<T,half,R>
-		{
-		#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
-			static_assert(std::is_arithmetic<T>::value, "half_cast to non-arithmetic type unsupported");
-		#endif
-
-			static T cast(half arg) { return cast_impl(arg, is_float<T>()); }
-
-		private:
-			static T cast_impl(half arg, true_type) { return half2float<T>(arg.data_); }
-			static T cast_impl(half arg, false_type) { return half2int<R,T>(arg.data_); }
-		};
-		template<typename T,std::float_round_style R> struct half_caster<T,expr,R>
-		{
-		#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
-			static_assert(std::is_arithmetic<T>::value, "half_cast to non-arithmetic type unsupported");
-		#endif
-
-			static T cast(expr arg) { return cast_impl(arg, is_float<T>()); }
-
-		private:
-			static T cast_impl(float arg, true_type) { return static_cast<T>(arg); }
-			static T cast_impl(half arg, false_type) { return half2int<R,T>(arg.data_); }
-		};
-		template<std::float_round_style R> struct half_caster<half,half,R>
-		{
-			static half cast(half arg) { return arg; }
-		};
-		template<std::float_round_style R> struct half_caster<half,expr,R> : half_caster<half,half,R> {};
-
-		/// \name Comparison operators
-		/// \{
-
-		/// Comparison for equality.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if operands equal
-		/// \retval false else
-		template<typename T,typename U> typename enable<bool,T,U>::type operator==(T x, U y) { return functions::isequal(x, y); }
-
-		/// Comparison for inequality.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if operands not equal
-		/// \retval false else
-		template<typename T,typename U> typename enable<bool,T,U>::type operator!=(T x, U y) { return functions::isnotequal(x, y); }
-
-		/// Comparison for less than.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if \a x less than \a y
-		/// \retval false else
-		template<typename T,typename U> typename enable<bool,T,U>::type operator<(T x, U y) { return functions::isless(x, y); }
-
-		/// Comparison for greater than.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if \a x greater than \a y
-		/// \retval false else
-		template<typename T,typename U> typename enable<bool,T,U>::type operator>(T x, U y) { return functions::isgreater(x, y); }
-
-		/// Comparison for less equal.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if \a x less equal \a y
-		/// \retval false else
-		template<typename T,typename U> typename enable<bool,T,U>::type operator<=(T x, U y) { return functions::islessequal(x, y); }
-
-		/// Comparison for greater equal.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if \a x greater equal \a y
-		/// \retval false else
-		template<typename T,typename U> typename enable<bool,T,U>::type operator>=(T x, U y) { return functions::isgreaterequal(x, y); }
-
-		/// \}
-		/// \name Arithmetic operators
-		/// \{
-
-		/// Add halfs.
-		/// \param x left operand
-		/// \param y right operand
-		/// \return sum of half expressions
-		template<typename T,typename U> typename enable<expr,T,U>::type operator+(T x, U y) { return functions::plus(x, y); }
-
-		/// Subtract halfs.
-		/// \param x left operand
-		/// \param y right operand
-		/// \return difference of half expressions
-		template<typename T,typename U> typename enable<expr,T,U>::type operator-(T x, U y) { return functions::minus(x, y); }
-
-		/// Multiply halfs.
-		/// \param x left operand
-		/// \param y right operand
-		/// \return product of half expressions
-		template<typename T,typename U> typename enable<expr,T,U>::type operator*(T x, U y) { return functions::multiplies(x, y); }
-
-		/// Divide halfs.
-		/// \param x left operand
-		/// \param y right operand
-		/// \return quotient of half expressions
-		template<typename T,typename U> typename enable<expr,T,U>::type operator/(T x, U y) { return functions::divides(x, y); }
-
-		/// Identity.
-		/// \param arg operand
-		/// \return uncahnged operand
-		template<typename T> HALF_CONSTEXPR typename enable<T,T>::type operator+(T arg) { return arg; }
-
-		/// Negation.
-		/// \param arg operand
-		/// \return negated operand
-		template<typename T> HALF_CONSTEXPR typename enable<T,T>::type operator-(T arg) { return unary_specialized<T>::negate(arg); }
-
-		/// \}
-		/// \name Input and output
-		/// \{
-
-		/// Output operator.
-		/// \param out output stream to write into
-		/// \param arg half expression to write
-		/// \return reference to output stream
-		template<typename T,typename charT,typename traits> typename enable<std::basic_ostream<charT,traits>&,T>::type
-			operator<<(std::basic_ostream<charT,traits> &out, T arg) { return functions::write(out, arg); }
-
-		/// Input operator.
-		/// \param in input stream to read from
-		/// \param arg half to read into
-		/// \return reference to input stream
-		template<typename charT,typename traits> std::basic_istream<charT,traits>&
-			operator>>(std::basic_istream<charT,traits> &in, half &arg) { return functions::read(in, arg); }
-
-		/// \}
-		/// \name Basic mathematical operations
-		/// \{
-
-		/// Absolute value.
-		/// \param arg operand
-		/// \return absolute value of \a arg
-//		template<typename T> typename enable<T,T>::type abs(T arg) { return unary_specialized<T>::fabs(arg); }
-		inline half abs(half arg) { return unary_specialized<half>::fabs(arg); }
-		inline expr abs(expr arg) { return unary_specialized<expr>::fabs(arg); }
-
-		/// Absolute value.
-		/// \param arg operand
-		/// \return absolute value of \a arg
-//		template<typename T> typename enable<T,T>::type fabs(T arg) { return unary_specialized<T>::fabs(arg); }
-		inline half fabs(half arg) { return unary_specialized<half>::fabs(arg); }
-		inline expr fabs(expr arg) { return unary_specialized<expr>::fabs(arg); }
-
-		/// Remainder of division.
-		/// \param x first operand
-		/// \param y second operand
-		/// \return remainder of floating point division.
-//		template<typename T,typename U> typename enable<expr,T,U>::type fmod(T x, U y) { return functions::fmod(x, y); }
-		inline expr fmod(half x, half y) { return functions::fmod(x, y); }
-		inline expr fmod(half x, expr y) { return functions::fmod(x, y); }
-		inline expr fmod(expr x, half y) { return functions::fmod(x, y); }
-		inline expr fmod(expr x, expr y) { return functions::fmod(x, y); }
-
-		/// Remainder of division.
-		/// \param x first operand
-		/// \param y second operand
-		/// \return remainder of floating point division.
-//		template<typename T,typename U> typename enable<expr,T,U>::type remainder(T x, U y) { return functions::remainder(x, y); }
-		inline expr remainder(half x, half y) { return functions::remainder(x, y); }
-		inline expr remainder(half x, expr y) { return functions::remainder(x, y); }
-		inline expr remainder(expr x, half y) { return functions::remainder(x, y); }
-		inline expr remainder(expr x, expr y) { return functions::remainder(x, y); }
-
-		/// Remainder of division.
-		/// \param x first operand
-		/// \param y second operand
-		/// \param quo address to store some bits of quotient at
-		/// \return remainder of floating point division.
-//		template<typename T,typename U> typename enable<expr,T,U>::type remquo(T x, U y, int *quo) { return functions::remquo(x, y, quo); }
-		inline expr remquo(half x, half y, int *quo) { return functions::remquo(x, y, quo); }
-		inline expr remquo(half x, expr y, int *quo) { return functions::remquo(x, y, quo); }
-		inline expr remquo(expr x, half y, int *quo) { return functions::remquo(x, y, quo); }
-		inline expr remquo(expr x, expr y, int *quo) { return functions::remquo(x, y, quo); }
-
-		/// Fused multiply add.
-		/// \param x first operand
-		/// \param y second operand
-		/// \param z third operand
-		/// \return ( \a x * \a y ) + \a z rounded as one operation.
-//		template<typename T,typename U,typename V> typename enable<expr,T,U,V>::type fma(T x, U y, V z) { return functions::fma(x, y, z); }
-		inline expr fma(half x, half y, half z) { return functions::fma(x, y, z); }
-		inline expr fma(half x, half y, expr z) { return functions::fma(x, y, z); }
-		inline expr fma(half x, expr y, half z) { return functions::fma(x, y, z); }
-		inline expr fma(half x, expr y, expr z) { return functions::fma(x, y, z); }
-		inline expr fma(expr x, half y, half z) { return functions::fma(x, y, z); }
-		inline expr fma(expr x, half y, expr z) { return functions::fma(x, y, z); }
-		inline expr fma(expr x, expr y, half z) { return functions::fma(x, y, z); }
-		inline expr fma(expr x, expr y, expr z) { return functions::fma(x, y, z); }
-
-		/// Maximum of half expressions.
-		/// \param x first operand
-		/// \param y second operand
-		/// \return maximum of operands
-//		template<typename T,typename U> typename result<T,U>::type fmax(T x, U y) { return binary_specialized<T,U>::fmax(x, y); }
-		inline half fmax(half x, half y) { return binary_specialized<half,half>::fmax(x, y); }
-		inline expr fmax(half x, expr y) { return binary_specialized<half,expr>::fmax(x, y); }
-		inline expr fmax(expr x, half y) { return binary_specialized<expr,half>::fmax(x, y); }
-		inline expr fmax(expr x, expr y) { return binary_specialized<expr,expr>::fmax(x, y); }
-
-		/// Minimum of half expressions.
-		/// \param x first operand
-		/// \param y second operand
-		/// \return minimum of operands
-//		template<typename T,typename U> typename result<T,U>::type fmin(T x, U y) { return binary_specialized<T,U>::fmin(x, y); }
-		inline half fmin(half x, half y) { return binary_specialized<half,half>::fmin(x, y); }
-		inline expr fmin(half x, expr y) { return binary_specialized<half,expr>::fmin(x, y); }
-		inline expr fmin(expr x, half y) { return binary_specialized<expr,half>::fmin(x, y); }
-		inline expr fmin(expr x, expr y) { return binary_specialized<expr,expr>::fmin(x, y); }
-
-		/// Positive difference.
-		/// \param x first operand
-		/// \param y second operand
-		/// \return \a x - \a y or 0 if difference negative
-//		template<typename T,typename U> typename enable<expr,T,U>::type fdim(T x, U y) { return functions::fdim(x, y); }
-		inline expr fdim(half x, half y) { return functions::fdim(x, y); }
-		inline expr fdim(half x, expr y) { return functions::fdim(x, y); }
-		inline expr fdim(expr x, half y) { return functions::fdim(x, y); }
-		inline expr fdim(expr x, expr y) { return functions::fdim(x, y); }
-
-		/// Get NaN value.
-		/// \return quiet NaN
-		inline half nanh(const char*) { return functions::nanh(); }
-
-		/// \}
-		/// \name Exponential functions
-		/// \{
-
-		/// Exponential function.
-		/// \param arg function argument
-		/// \return e raised to \a arg
-//		template<typename T> typename enable<expr,T>::type exp(T arg) { return functions::exp(arg); }
-		inline expr exp(half arg) { return functions::exp(arg); }
-		inline expr exp(expr arg) { return functions::exp(arg); }
-
-		/// Exponential minus one.
-		/// \param arg function argument
-		/// \return e raised to \a arg subtracted by 1
-//		template<typename T> typename enable<expr,T>::type expm1(T arg) { return functions::expm1(arg); }
-		inline expr expm1(half arg) { return functions::expm1(arg); }
-		inline expr expm1(expr arg) { return functions::expm1(arg); }
-
-		/// Binary exponential.
-		/// \param arg function argument
-		/// \return 2 raised to \a arg
-//		template<typename T> typename enable<expr,T>::type exp2(T arg) { return functions::exp2(arg); }
-		inline expr exp2(half arg) { return functions::exp2(arg); }
-		inline expr exp2(expr arg) { return functions::exp2(arg); }
-
-		/// Natural logorithm.
-		/// \param arg function argument
-		/// \return logarithm of \a arg to base e
-//		template<typename T> typename enable<expr,T>::type log(T arg) { return functions::log(arg); }
-		inline expr log(half arg) { return functions::log(arg); }
-		inline expr log(expr arg) { return functions::log(arg); }
-
-		/// Common logorithm.
-		/// \param arg function argument
-		/// \return logarithm of \a arg to base 10
-//		template<typename T> typename enable<expr,T>::type log10(T arg) { return functions::log10(arg); }
-		inline expr log10(half arg) { return functions::log10(arg); }
-		inline expr log10(expr arg) { return functions::log10(arg); }
-
-		/// Natural logorithm.
-		/// \param arg function argument
-		/// \return logarithm of \a arg plus 1 to base e
-//		template<typename T> typename enable<expr,T>::type log1p(T arg) { return functions::log1p(arg); }
-		inline expr log1p(half arg) { return functions::log1p(arg); }
-		inline expr log1p(expr arg) { return functions::log1p(arg); }
-
-		/// Binary logorithm.
-		/// \param arg function argument
-		/// \return logarithm of \a arg to base 2
-//		template<typename T> typename enable<expr,T>::type log2(T arg) { return functions::log2(arg); }
-		inline expr log2(half arg) { return functions::log2(arg); }
-		inline expr log2(expr arg) { return functions::log2(arg); }
-
-		/// \}
-		/// \name Power functions
-		/// \{
-
-		/// Square root.
-		/// \param arg function argument
-		/// \return square root of \a arg
-//		template<typename T> typename enable<expr,T>::type sqrt(T arg) { return functions::sqrt(arg); }
-		inline expr sqrt(half arg) { return functions::sqrt(arg); }
-		inline expr sqrt(expr arg) { return functions::sqrt(arg); }
-
-		/// Cubic root.
-		/// \param arg function argument
-		/// \return cubic root of \a arg
-//		template<typename T> typename enable<expr,T>::type cbrt(T arg) { return functions::cbrt(arg); }
-		inline expr cbrt(half arg) { return functions::cbrt(arg); }
-		inline expr cbrt(expr arg) { return functions::cbrt(arg); }
-
-		/// Hypotenuse function.
-		/// \param x first argument
-		/// \param y second argument
-		/// \return square root of sum of squares without internal over- or underflows
-//		template<typename T,typename U> typename enable<expr,T,U>::type hypot(T x, U y) { return functions::hypot(x, y); }
-		inline expr hypot(half x, half y) { return functions::hypot(x, y); }
-		inline expr hypot(half x, expr y) { return functions::hypot(x, y); }
-		inline expr hypot(expr x, half y) { return functions::hypot(x, y); }
-		inline expr hypot(expr x, expr y) { return functions::hypot(x, y); }
-
-		/// Power function.
-		/// \param base first argument
-		/// \param exp second argument
-		/// \return \a base raised to \a exp
-//		template<typename T,typename U> typename enable<expr,T,U>::type pow(T base, U exp) { return functions::pow(base, exp); }
-		inline expr pow(half base, half exp) { return functions::pow(base, exp); }
-		inline expr pow(half base, expr exp) { return functions::pow(base, exp); }
-		inline expr pow(expr base, half exp) { return functions::pow(base, exp); }
-		inline expr pow(expr base, expr exp) { return functions::pow(base, exp); }
-
-		/// \}
-		/// \name Trigonometric functions
-		/// \{
-
-		/// Sine function.
-		/// \param arg function argument
-		/// \return sine value of \a arg
-//		template<typename T> typename enable<expr,T>::type sin(T arg) { return functions::sin(arg); }
-		inline expr sin(half arg) { return functions::sin(arg); }
-		inline expr sin(expr arg) { return functions::sin(arg); }
-
-		/// Cosine function.
-		/// \param arg function argument
-		/// \return cosine value of \a arg
-//		template<typename T> typename enable<expr,T>::type cos(T arg) { return functions::cos(arg); }
-		inline expr cos(half arg) { return functions::cos(arg); }
-		inline expr cos(expr arg) { return functions::cos(arg); }
-
-		/// Tangent function.
-		/// \param arg function argument
-		/// \return tangent value of \a arg
-//		template<typename T> typename enable<expr,T>::type tan(T arg) { return functions::tan(arg); }
-		inline expr tan(half arg) { return functions::tan(arg); }
-		inline expr tan(expr arg) { return functions::tan(arg); }
-
-		/// Arc sine.
-		/// \param arg function argument
-		/// \return arc sine value of \a arg
-//		template<typename T> typename enable<expr,T>::type asin(T arg) { return functions::asin(arg); }
-		inline expr asin(half arg) { return functions::asin(arg); }
-		inline expr asin(expr arg) { return functions::asin(arg); }
-
-		/// Arc cosine function.
-		/// \param arg function argument
-		/// \return arc cosine value of \a arg
-//		template<typename T> typename enable<expr,T>::type acos(T arg) { return functions::acos(arg); }
-		inline expr acos(half arg) { return functions::acos(arg); }
-		inline expr acos(expr arg) { return functions::acos(arg); }
-
-		/// Arc tangent function.
-		/// \param arg function argument
-		/// \return arc tangent value of \a arg
-//		template<typename T> typename enable<expr,T>::type atan(T arg) { return functions::atan(arg); }
-		inline expr atan(half arg) { return functions::atan(arg); }
-		inline expr atan(expr arg) { return functions::atan(arg); }
-
-		/// Arc tangent function.
-		/// \param x first argument
-		/// \param y second argument
-		/// \return arc tangent value
-//		template<typename T,typename U> typename enable<expr,T,U>::type atan2(T x, U y) { return functions::atan2(x, y); }
-		inline expr atan2(half x, half y) { return functions::atan2(x, y); }
-		inline expr atan2(half x, expr y) { return functions::atan2(x, y); }
-		inline expr atan2(expr x, half y) { return functions::atan2(x, y); }
-		inline expr atan2(expr x, expr y) { return functions::atan2(x, y); }
-
-		/// \}
-		/// \name Hyperbolic functions
-		/// \{
-
-		/// Hyperbolic sine.
-		/// \param arg function argument
-		/// \return hyperbolic sine value of \a arg
-//		template<typename T> typename enable<expr,T>::type sinh(T arg) { return functions::sinh(arg); }
-		inline expr sinh(half arg) { return functions::sinh(arg); }
-		inline expr sinh(expr arg) { return functions::sinh(arg); }
-
-		/// Hyperbolic cosine.
-		/// \param arg function argument
-		/// \return hyperbolic cosine value of \a arg
-//		template<typename T> typename enable<expr,T>::type cosh(T arg) { return functions::cosh(arg); }
-		inline expr cosh(half arg) { return functions::cosh(arg); }
-		inline expr cosh(expr arg) { return functions::cosh(arg); }
-
-		/// Hyperbolic tangent.
-		/// \param arg function argument
-		/// \return hyperbolic tangent value of \a arg
-//		template<typename T> typename enable<expr,T>::type tanh(T arg) { return functions::tanh(arg); }
-		inline expr tanh(half arg) { return functions::tanh(arg); }
-		inline expr tanh(expr arg) { return functions::tanh(arg); }
-
-		/// Hyperbolic area sine.
-		/// \param arg function argument
-		/// \return area sine value of \a arg
-//		template<typename T> typename enable<expr,T>::type asinh(T arg) { return functions::asinh(arg); }
-		inline expr asinh(half arg) { return functions::asinh(arg); }
-		inline expr asinh(expr arg) { return functions::asinh(arg); }
-
-		/// Hyperbolic area cosine.
-		/// \param arg function argument
-		/// \return area cosine value of \a arg
-//		template<typename T> typename enable<expr,T>::type acosh(T arg) { return functions::acosh(arg); }
-		inline expr acosh(half arg) { return functions::acosh(arg); }
-		inline expr acosh(expr arg) { return functions::acosh(arg); }
-
-		/// Hyperbolic area tangent.
-		/// \param arg function argument
-		/// \return area tangent value of \a arg
-//		template<typename T> typename enable<expr,T>::type atanh(T arg) { return functions::atanh(arg); }
-		inline expr atanh(half arg) { return functions::atanh(arg); }
-		inline expr atanh(expr arg) { return functions::atanh(arg); }
-
-		/// \}
-		/// \name Error and gamma functions
-		/// \{
-
-		/// Error function.
-		/// \param arg function argument
-		/// \return error function value of \a arg
-//		template<typename T> typename enable<expr,T>::type erf(T arg) { return functions::erf(arg); }
-		inline expr erf(half arg) { return functions::erf(arg); }
-		inline expr erf(expr arg) { return functions::erf(arg); }
-
-		/// Complementary error function.
-		/// \param arg function argument
-		/// \return 1 minus error function value of \a arg
-//		template<typename T> typename enable<expr,T>::type erfc(T arg) { return functions::erfc(arg); }
-		inline expr erfc(half arg) { return functions::erfc(arg); }
-		inline expr erfc(expr arg) { return functions::erfc(arg); }
-
-		/// Natural logarithm of gamma function.
-		/// \param arg function argument
-		/// \return natural logarith of gamma function for \a arg
-//		template<typename T> typename enable<expr,T>::type lgamma(T arg) { return functions::lgamma(arg); }
-		inline expr lgamma(half arg) { return functions::lgamma(arg); }
-		inline expr lgamma(expr arg) { return functions::lgamma(arg); }
-
-		/// Gamma function.
-		/// \param arg function argument
-		/// \return gamma function value of \a arg
-//		template<typename T> typename enable<expr,T>::type tgamma(T arg) { return functions::tgamma(arg); }
-		inline expr tgamma(half arg) { return functions::tgamma(arg); }
-		inline expr tgamma(expr arg) { return functions::tgamma(arg); }
-
-		/// \}
-		/// \name Rounding
-		/// \{
-
-		/// Nearest integer not less than half value.
-		/// \param arg half to round
-		/// \return nearest integer not less than \a arg
-//		template<typename T> typename enable<half,T>::type ceil(T arg) { return functions::ceil(arg); }
-		inline half ceil(half arg) { return functions::ceil(arg); }
-		inline half ceil(expr arg) { return functions::ceil(arg); }
-
-		/// Nearest integer not greater than half value.
-		/// \param arg half to round
-		/// \return nearest integer not greater than \a arg
-//		template<typename T> typename enable<half,T>::type floor(T arg) { return functions::floor(arg); }
-		inline half floor(half arg) { return functions::floor(arg); }
-		inline half floor(expr arg) { return functions::floor(arg); }
-
-		/// Nearest integer not greater in magnitude than half value.
-		/// \param arg half to round
-		/// \return nearest integer not greater in magnitude than \a arg
-//		template<typename T> typename enable<half,T>::type trunc(T arg) { return functions::trunc(arg); }
-		inline half trunc(half arg) { return functions::trunc(arg); }
-		inline half trunc(expr arg) { return functions::trunc(arg); }
-
-		/// Nearest integer.
-		/// \param arg half to round
-		/// \return nearest integer, rounded away from zero in half-way cases
-//		template<typename T> typename enable<half,T>::type round(T arg) { return functions::round(arg); }
-		inline half round(half arg) { return functions::round(arg); }
-		inline half round(expr arg) { return functions::round(arg); }
-
-		/// Nearest integer.
-		/// \param arg half to round
-		/// \return nearest integer, rounded away from zero in half-way cases
-//		template<typename T> typename enable<long,T>::type lround(T arg) { return functions::lround(arg); }
-		inline long lround(half arg) { return functions::lround(arg); }
-		inline long lround(expr arg) { return functions::lround(arg); }
-
-		/// Nearest integer using half's internal rounding mode.
-		/// \param arg half expression to round
-		/// \return nearest integer using default rounding mode
-//		template<typename T> typename enable<half,T>::type nearbyint(T arg) { return functions::nearbyint(arg); }
-		inline half nearbyint(half arg) { return functions::rint(arg); }
-		inline half nearbyint(expr arg) { return functions::rint(arg); }
-
-		/// Nearest integer using half's internal rounding mode.
-		/// \param arg half expression to round
-		/// \return nearest integer using default rounding mode
-//		template<typename T> typename enable<half,T>::type rint(T arg) { return functions::rint(arg); }
-		inline half rint(half arg) { return functions::rint(arg); }
-		inline half rint(expr arg) { return functions::rint(arg); }
-
-		/// Nearest integer using half's internal rounding mode.
-		/// \param arg half expression to round
-		/// \return nearest integer using default rounding mode
-//		template<typename T> typename enable<long,T>::type lrint(T arg) { return functions::lrint(arg); }
-		inline long lrint(half arg) { return functions::lrint(arg); }
-		inline long lrint(expr arg) { return functions::lrint(arg); }
-	#if HALF_ENABLE_CPP11_LONG_LONG
-		/// Nearest integer.
-		/// \param arg half to round
-		/// \return nearest integer, rounded away from zero in half-way cases
-//		template<typename T> typename enable<long long,T>::type llround(T arg) { return functions::llround(arg); }
-		inline long long llround(half arg) { return functions::llround(arg); }
-		inline long long llround(expr arg) { return functions::llround(arg); }
-
-		/// Nearest integer using half's internal rounding mode.
-		/// \param arg half expression to round
-		/// \return nearest integer using default rounding mode
-//		template<typename T> typename enable<long long,T>::type llrint(T arg) { return functions::llrint(arg); }
-		inline long long llrint(half arg) { return functions::llrint(arg); }
-		inline long long llrint(expr arg) { return functions::llrint(arg); }
-	#endif
-
-		/// \}
-		/// \name Floating point manipulation
-		/// \{
-
-		/// Decompress floating point number.
-		/// \param arg number to decompress
-		/// \param exp address to store exponent at
-		/// \return significant in range [0.5, 1)
-//		template<typename T> typename enable<half,T>::type frexp(T arg, int *exp) { return functions::frexp(arg, exp); }
-		inline half frexp(half arg, int *exp) { return functions::frexp(arg, exp); }
-		inline half frexp(expr arg, int *exp) { return functions::frexp(arg, exp); }
-
-		/// Multiply by power of two.
-		/// \param arg number to modify
-		/// \param exp power of two to multiply with
-		/// \return \a arg multplied by 2 raised to \a exp
-//		template<typename T> typename enable<half,T>::type ldexp(T arg, int exp) { return functions::scalbln(arg, exp); }
-		inline half ldexp(half arg, int exp) { return functions::scalbln(arg, exp); }
-		inline half ldexp(expr arg, int exp) { return functions::scalbln(arg, exp); }
-
-		/// Extract integer and fractional parts.
-		/// \param arg number to decompress
-		/// \param iptr address to store integer part at
-		/// \return fractional part
-//		template<typename T> typename enable<half,T>::type modf(T arg, half *iptr) { return functions::modf(arg, iptr); }
-		inline half modf(half arg, half *iptr) { return functions::modf(arg, iptr); }
-		inline half modf(expr arg, half *iptr) { return functions::modf(arg, iptr); }
-
-		/// Multiply by power of two.
-		/// \param arg number to modify
-		/// \param exp power of two to multiply with
-		/// \return \a arg multplied by 2 raised to \a exp
-//		template<typename T> typename enable<half,T>::type scalbn(T arg, int exp) { return functions::scalbln(arg, exp); }
-		inline half scalbn(half arg, int exp) { return functions::scalbln(arg, exp); }
-		inline half scalbn(expr arg, int exp) { return functions::scalbln(arg, exp); }
-
-		/// Multiply by power of two.
-		/// \param arg number to modify
-		/// \param exp power of two to multiply with
-		/// \return \a arg multplied by 2 raised to \a exp	
-//		template<typename T> typename enable<half,T>::type scalbln(T arg, long exp) { return functions::scalbln(arg, exp); }
-		inline half scalbln(half arg, long exp) { return functions::scalbln(arg, exp); }
-		inline half scalbln(expr arg, long exp) { return functions::scalbln(arg, exp); }
-
-		/// Extract exponent.
-		/// \param arg number to query
-		/// \return floating point exponent
-		/// \retval FP_ILOGB0 for zero
-		/// \retval FP_ILOGBNAN for NaN
-		/// \retval MAX_INT for infinity
-//		template<typename T> typename enable<int,T>::type ilogb(T arg) { return functions::ilogb(arg); }
-		inline int ilogb(half arg) { return functions::ilogb(arg); }
-		inline int ilogb(expr arg) { return functions::ilogb(arg); }
-
-		/// Extract exponent.
-		/// \param arg number to query
-		/// \return floating point exponent
-//		template<typename T> typename enable<half,T>::type logb(T arg) { return functions::logb(arg); }
-		inline half logb(half arg) { return functions::logb(arg); }
-		inline half logb(expr arg) { return functions::logb(arg); }
-
-		/// Next representable value.
-		/// \param from value to compute next representable value for
-		/// \param to direction towards which to compute next value
-		/// \return next representable value after \a from in direction towards \a to
-//		template<typename T,typename U> typename enable<half,T,U>::type nextafter(T from, U to) { return functions::nextafter(from, to); }
-		inline half nextafter(half from, half to) { return functions::nextafter(from, to); }
-		inline half nextafter(half from, expr to) { return functions::nextafter(from, to); }
-		inline half nextafter(expr from, half to) { return functions::nextafter(from, to); }
-		inline half nextafter(expr from, expr to) { return functions::nextafter(from, to); }
-
-		/// Next representable value.
-		/// \param from value to compute next representable value for
-		/// \param to direction towards which to compute next value
-		/// \return next representable value after \a from in direction towards \a to
-//		template<typename T> typename enable<half,T>::type nexttoward(T from, long double to) { return functions::nexttoward(from, to); }
-		inline half nexttoward(half from, long double to) { return functions::nexttoward(from, to); }
-		inline half nexttoward(expr from, long double to) { return functions::nexttoward(from, to); }
-
-		/// Take sign.
-		/// \param x value to change sign for
-		/// \param y value to take sign from
-		/// \return value equal to \a x in magnitude and to \a y in sign
-//		template<typename T,typename U> typename enable<half,T,U>::type copysign(T x, U y) { return functions::copysign(x, y); }
-		inline half copysign(half x, half y) { return functions::copysign(x, y); }
-		inline half copysign(half x, expr y) { return functions::copysign(x, y); }
-		inline half copysign(expr x, half y) { return functions::copysign(x, y); }
-		inline half copysign(expr x, expr y) { return functions::copysign(x, y); }
-
-		/// \}
-		/// \name Floating point classification
-		/// \{
-
-
-		/// Classify floating point value.
-		/// \param arg number to classify
-		/// \retval FP_ZERO for positive and negative zero
-		/// \retval FP_SUBNORMAL for subnormal numbers
-		/// \retval FP_INFINITY for positive and negative infinity
-		/// \retval FP_NAN for NaNs
-		/// \retval FP_NORMAL for all other (normal) values
-//		template<typename T> typename enable<int,T>::type fpclassify(T arg) { return functions::fpclassify(arg); }
-		inline int fpclassify(half arg) { return functions::fpclassify(arg); }
-		inline int fpclassify(expr arg) { return functions::fpclassify(arg); }
-
-		/// Check if finite number.
-		/// \param arg number to check
-		/// \retval true if neither infinity nor NaN
-		/// \retval false else
-//		template<typename T> typename enable<bool,T>::type isfinite(T arg) { return functions::isfinite(arg); }
-		inline bool isfinite(half arg) { return functions::isfinite(arg); }
-		inline bool isfinite(expr arg) { return functions::isfinite(arg); }
-
-		/// Check for infinity.
-		/// \param arg number to check
-		/// \retval true for positive or negative infinity
-		/// \retval false else
-//		template<typename T> typename enable<bool,T>::type isinf(T arg) { return functions::isinf(arg); }
-		inline bool isinf(half arg) { return functions::isinf(arg); }
-		inline bool isinf(expr arg) { return functions::isinf(arg); }
-
-		/// Check for NaN.
-		/// \param arg number to check
-		/// \retval true for NaNs
-		/// \retval false else
-//		template<typename T> typename enable<bool,T>::type isnan(T arg) { return functions::isnan(arg); }
-		inline bool isnan(half arg) { return functions::isnan(arg); }
-		inline bool isnan(expr arg) { return functions::isnan(arg); }
-
-		/// Check if normal number.
-		/// \param arg number to check
-		/// \retval true if normal number
-		/// \retval false if either subnormal, zero, infinity or NaN
-//		template<typename T> typename enable<bool,T>::type isnormal(T arg) { return functions::isnormal(arg); }
-		inline bool isnormal(half arg) { return functions::isnormal(arg); }
-		inline bool isnormal(expr arg) { return functions::isnormal(arg); }
-
-		/// Check sign.
-		/// \param arg number to check
-		/// \retval true for negative number
-		/// \retval false for positive number
-//		template<typename T> typename enable<bool,T>::type signbit(T arg) { return functions::signbit(arg); }
-		inline bool signbit(half arg) { return functions::signbit(arg); }
-		inline bool signbit(expr arg) { return functions::signbit(arg); }
-
-		/// \}
-		/// \name Comparison
-		/// \{
-
-		/// Comparison for greater than.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if \a x greater than \a y
-		/// \retval false else
-//		template<typename T,typename U> typename enable<bool,T,U>::type isgreater(T x, U y) { return functions::isgreater(x, y); }
-		inline bool isgreater(half x, half y) { return functions::isgreater(x, y); }
-		inline bool isgreater(half x, expr y) { return functions::isgreater(x, y); }
-		inline bool isgreater(expr x, half y) { return functions::isgreater(x, y); }
-		inline bool isgreater(expr x, expr y) { return functions::isgreater(x, y); }
-
-		/// Comparison for greater equal.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if \a x greater equal \a y
-		/// \retval false else
-//		template<typename T,typename U> typename enable<bool,T,U>::type isgreaterequal(T x, U y) { return functions::isgreaterequal(x, y); }
-		inline bool isgreaterequal(half x, half y) { return functions::isgreaterequal(x, y); }
-		inline bool isgreaterequal(half x, expr y) { return functions::isgreaterequal(x, y); }
-		inline bool isgreaterequal(expr x, half y) { return functions::isgreaterequal(x, y); }
-		inline bool isgreaterequal(expr x, expr y) { return functions::isgreaterequal(x, y); }
-
-		/// Comparison for less than.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if \a x less than \a y
-		/// \retval false else
-//		template<typename T,typename U> typename enable<bool,T,U>::type isless(T x, U y) { return functions::isless(x, y); }
-		inline bool isless(half x, half y) { return functions::isless(x, y); }
-		inline bool isless(half x, expr y) { return functions::isless(x, y); }
-		inline bool isless(expr x, half y) { return functions::isless(x, y); }
-		inline bool isless(expr x, expr y) { return functions::isless(x, y); }
-
-		/// Comparison for less equal.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if \a x less equal \a y
-		/// \retval false else
-//		template<typename T,typename U> typename enable<bool,T,U>::type islessequal(T x, U y) { return functions::islessequal(x, y); }
-		inline bool islessequal(half x, half y) { return functions::islessequal(x, y); }
-		inline bool islessequal(half x, expr y) { return functions::islessequal(x, y); }
-		inline bool islessequal(expr x, half y) { return functions::islessequal(x, y); }
-		inline bool islessequal(expr x, expr y) { return functions::islessequal(x, y); }
-
-		/// Comarison for less or greater.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if either less or greater
-		/// \retval false else
-//		template<typename T,typename U> typename enable<bool,T,U>::type islessgreater(T x, U y) { return functions::islessgreater(x, y); }
-		inline bool islessgreater(half x, half y) { return functions::islessgreater(x, y); }
-		inline bool islessgreater(half x, expr y) { return functions::islessgreater(x, y); }
-		inline bool islessgreater(expr x, half y) { return functions::islessgreater(x, y); }
-		inline bool islessgreater(expr x, expr y) { return functions::islessgreater(x, y); }
-
-		/// Check if unordered.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if unordered (one or two NaN operands)
-		/// \retval false else
-//		template<typename T,typename U> typename enable<bool,T,U>::type isunordered(T x, U y) { return functions::isunordered(x, y); }
-		inline bool isunordered(half x, half y) { return functions::isunordered(x, y); }
-		inline bool isunordered(half x, expr y) { return functions::isunordered(x, y); }
-		inline bool isunordered(expr x, half y) { return functions::isunordered(x, y); }
-		inline bool isunordered(expr x, expr y) { return functions::isunordered(x, y); }
-
-		/// \name Casting
-		/// \{
-
-		/// Cast to or from half-precision floating point number.
-		/// This casts between [half](\ref half_float::half) and any built-in arithmetic type. The values are converted 
-		/// directly using the given rounding mode, without any roundtrip over `float` that a `static_cast` would otherwise do. 
-		/// It uses the default rounding mode.
-		///
-		/// Using this cast with neither of the two types being a [half](\ref half_float::half) or with any of the two types 
-		/// not being a built-in arithmetic type (apart from [half](\ref half_float::half), of course) results in a compiler 
-		/// error and casting between [half](\ref half_float::half)s is just a no-op.
-		/// \tparam T destination type (half or built-in arithmetic type)
-		/// \tparam U source type (half or built-in arithmetic type)
-		/// \param arg value to cast
-		/// \return \a arg converted to destination type
-		template<typename T,typename U> T half_cast(U arg) { return half_caster<T,U>::cast(arg); }
-
-		/// Cast to or from half-precision floating point number.
-		/// This casts between [half](\ref half_float::half) and any built-in arithmetic type. The values are converted 
-		/// directly using the given rounding mode, without any roundtrip over `float` that a `static_cast` would otherwise do.
-		///
-		/// Using this cast with neither of the two types being a [half](\ref half_float::half) or with any of the two types 
-		/// not being a built-in arithmetic type (apart from [half](\ref half_float::half), of course) results in a compiler 
-		/// error and casting between [half](\ref half_float::half)s is just a no-op.
-		/// \tparam T destination type (half or built-in arithmetic type)
-		/// \tparam R rounding mode to use.
-		/// \tparam U source type (half or built-in arithmetic type)
-		/// \param arg value to cast
-		/// \return \a arg converted to destination type
-		template<typename T,std::float_round_style R,typename U> T half_cast(U arg) { return half_caster<T,U,R>::cast(arg); }
-		/// \}
-	}
-
-	using detail::operator==;
-	using detail::operator!=;
-	using detail::operator<;
-	using detail::operator>;
-	using detail::operator<=;
-	using detail::operator>=;
-	using detail::operator+;
-	using detail::operator-;
-	using detail::operator*;
-	using detail::operator/;
-	using detail::operator<<;
-	using detail::operator>>;
-
-	using detail::abs;
-	using detail::fabs;
-	using detail::fmod;
-	using detail::remainder;
-	using detail::remquo;
-	using detail::fma;
-	using detail::fmax;
-	using detail::fmin;
-	using detail::fdim;
-	using detail::nanh;
-	using detail::exp;
-	using detail::expm1;
-	using detail::exp2;
-	using detail::log;
-	using detail::log10;
-	using detail::log1p;
-	using detail::log2;
-	using detail::sqrt;
-	using detail::cbrt;
-	using detail::hypot;
-	using detail::pow;
-	using detail::sin;
-	using detail::cos;
-	using detail::tan;
-	using detail::asin;
-	using detail::acos;
-	using detail::atan;
-	using detail::atan2;
-	using detail::sinh;
-	using detail::cosh;
-	using detail::tanh;
-	using detail::asinh;
-	using detail::acosh;
-	using detail::atanh;
-	using detail::erf;
-	using detail::erfc;
-	using detail::lgamma;
-	using detail::tgamma;
-	using detail::ceil;
-	using detail::floor;
-	using detail::trunc;
-	using detail::round;
-	using detail::lround;
-	using detail::nearbyint;
-	using detail::rint;
-	using detail::lrint;
+namespace detail {
+/// Wrapper implementing unspecialized half-precision functions.
+struct functions {
+  /// Addition implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \return Half-precision sum stored in single-precision
+  static expr plus(float x, float y) { return expr(x + y); }
+
+  /// Subtraction implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \return Half-precision difference stored in single-precision
+  static expr minus(float x, float y) { return expr(x - y); }
+
+  /// Multiplication implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \return Half-precision product stored in single-precision
+  static expr multiplies(float x, float y) { return expr(x * y); }
+
+  /// Division implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \return Half-precision quotient stored in single-precision
+  static expr divides(float x, float y) { return expr(x / y); }
+
+  /// Output implementation.
+  /// \param out stream to write to
+  /// \param arg value to write
+  /// \return reference to stream
+  template <typename charT, typename traits>
+  static std::basic_ostream<charT, traits> &write(
+      std::basic_ostream<charT, traits> &out, float arg) {
+    return out << arg;
+  }
+
+  /// Input implementation.
+  /// \param in stream to read from
+  /// \param arg half to read into
+  /// \return reference to stream
+  template <typename charT, typename traits>
+  static std::basic_istream<charT, traits> &read(
+      std::basic_istream<charT, traits> &in, half &arg) {
+    float f;
+    if (in >> f) arg = f;
+    return in;
+  }
+
+  /// Modulo implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \return Half-precision division remainder stored in single-precision
+  static expr fmod(float x, float y) { return expr(std::fmod(x, y)); }
+
+  /// Remainder implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \return Half-precision division remainder stored in single-precision
+  static expr remainder(float x, float y) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::remainder(x, y));
+#else
+    if (builtin_isnan(x) || builtin_isnan(y))
+      return expr(std::numeric_limits<float>::quiet_NaN());
+    float ax = std::fabs(x), ay = std::fabs(y);
+    if (ax >= 65536.0f || ay < std::ldexp(1.0f, -24))
+      return expr(std::numeric_limits<float>::quiet_NaN());
+    if (ay >= 65536.0f) return expr(x);
+    if (ax == ay) return expr(builtin_signbit(x) ? -0.0f : 0.0f);
+    ax = std::fmod(ax, ay + ay);
+    float y2 = 0.5f * ay;
+    if (ax > y2) {
+      ax -= ay;
+      if (ax >= y2) ax -= ay;
+    }
+    return expr(builtin_signbit(x) ? -ax : ax);
+#endif
+  }
+
+  /// Remainder implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \param quo address to store quotient bits at
+  /// \return Half-precision division remainder stored in single-precision
+  static expr remquo(float x, float y, int *quo) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::remquo(x, y, quo));
+#else
+    if (builtin_isnan(x) || builtin_isnan(y))
+      return expr(std::numeric_limits<float>::quiet_NaN());
+    bool sign = builtin_signbit(x),
+         qsign = static_cast<bool>(sign ^ builtin_signbit(y));
+    float ax = std::fabs(x), ay = std::fabs(y);
+    if (ax >= 65536.0f || ay < std::ldexp(1.0f, -24))
+      return expr(std::numeric_limits<float>::quiet_NaN());
+    if (ay >= 65536.0f) return expr(x);
+    if (ax == ay) return *quo = qsign ? -1 : 1, expr(sign ? -0.0f : 0.0f);
+    ax = std::fmod(ax, 8.0f * ay);
+    int cquo = 0;
+    if (ax >= 4.0f * ay) {
+      ax -= 4.0f * ay;
+      cquo += 4;
+    }
+    if (ax >= 2.0f * ay) {
+      ax -= 2.0f * ay;
+      cquo += 2;
+    }
+    float y2 = 0.5f * ay;
+    if (ax > y2) {
+      ax -= ay;
+      ++cquo;
+      if (ax >= y2) {
+        ax -= ay;
+        ++cquo;
+      }
+    }
+    return *quo = qsign ? -cquo : cquo, expr(sign ? -ax : ax);
+#endif
+  }
+
+  /// Positive difference implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \return Positive difference stored in single-precision
+  static expr fdim(float x, float y) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::fdim(x, y));
+#else
+    return expr((x <= y) ? 0.0f : (x - y));
+#endif
+  }
+
+  /// Fused multiply-add implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \param z third operand
+  /// \return \a x * \a y + \a z stored in single-precision
+  static expr fma(float x, float y, float z) {
+#if HALF_ENABLE_CPP11_CMATH && defined(FP_FAST_FMAF)
+    return expr(std::fma(x, y, z));
+#else
+    return expr(x * y + z);
+#endif
+  }
+
+  /// Get NaN.
+  /// \return Half-precision quiet NaN
+  static half nanh() { return half(binary, 0x7FFF); }
+
+  /// Exponential implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr exp(float arg) { return expr(std::exp(arg)); }
+
+  /// Exponential implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr expm1(float arg) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::expm1(arg));
+#else
+    return expr(static_cast<float>(std::exp(static_cast<double>(arg)) - 1.0));
+#endif
+  }
+
+  /// Binary exponential implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr exp2(float arg) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::exp2(arg));
+#else
+    return expr(
+        static_cast<float>(std::exp(arg * 0.69314718055994530941723212145818)));
+#endif
+  }
+
+  /// Logarithm implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr log(float arg) { return expr(std::log(arg)); }
+
+  /// Common logarithm implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr log10(float arg) { return expr(std::log10(arg)); }
+
+  /// Logarithm implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr log1p(float arg) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::log1p(arg));
+#else
+    return expr(static_cast<float>(std::log(1.0 + arg)));
+#endif
+  }
+
+  /// Binary logarithm implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr log2(float arg) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::log2(arg));
+#else
+    return expr(static_cast<float>(std::log(static_cast<double>(arg)) *
+                                   1.4426950408889634073599246810019));
+#endif
+  }
+
+  /// Square root implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr sqrt(float arg) { return expr(std::sqrt(arg)); }
+
+  /// Cubic root implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr cbrt(float arg) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::cbrt(arg));
+#else
+    if (builtin_isnan(arg) || builtin_isinf(arg)) return expr(arg);
+    return expr(builtin_signbit(arg)
+                    ? -static_cast<float>(
+                          std::pow(-static_cast<double>(arg), 1.0 / 3.0))
+                    : static_cast<float>(
+                          std::pow(static_cast<double>(arg), 1.0 / 3.0)));
+#endif
+  }
+
+  /// Hypotenuse implementation.
+  /// \param x first argument
+  /// \param y second argument
+  /// \return function value stored in single-preicision
+  static expr hypot(float x, float y) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::hypot(x, y));
+#else
+    return expr(
+        (builtin_isinf(x) || builtin_isinf(y))
+            ? std::numeric_limits<float>::infinity()
+            : static_cast<float>(std::sqrt(static_cast<double>(x) * x +
+                                           static_cast<double>(y) * y)));
+#endif
+  }
+
+  /// Power implementation.
+  /// \param base value to exponentiate
+  /// \param exp power to expontiate to
+  /// \return function value stored in single-preicision
+  static expr pow(float base, float exp) { return expr(std::pow(base, exp)); }
+
+  /// Sine implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr sin(float arg) { return expr(std::sin(arg)); }
+
+  /// Cosine implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr cos(float arg) { return expr(std::cos(arg)); }
+
+  /// Tan implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr tan(float arg) { return expr(std::tan(arg)); }
+
+  /// Arc sine implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr asin(float arg) { return expr(std::asin(arg)); }
+
+  /// Arc cosine implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr acos(float arg) { return expr(std::acos(arg)); }
+
+  /// Arc tangent implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr atan(float arg) { return expr(std::atan(arg)); }
+
+  /// Arc tangent implementation.
+  /// \param x first argument
+  /// \param y second argument
+  /// \return function value stored in single-preicision
+  static expr atan2(float x, float y) { return expr(std::atan2(x, y)); }
+
+  /// Hyperbolic sine implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr sinh(float arg) { return expr(std::sinh(arg)); }
+
+  /// Hyperbolic cosine implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr cosh(float arg) { return expr(std::cosh(arg)); }
+
+  /// Hyperbolic tangent implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr tanh(float arg) { return expr(std::tanh(arg)); }
+
+  /// Hyperbolic area sine implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr asinh(float arg) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::asinh(arg));
+#else
+    return expr(
+        (arg == -std::numeric_limits<float>::infinity())
+            ? arg
+            : static_cast<float>(std::log(arg + std::sqrt(arg * arg + 1.0))));
+#endif
+  }
+
+  /// Hyperbolic area cosine implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr acosh(float arg) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::acosh(arg));
+#else
+    return expr((arg < -1.0f) ? std::numeric_limits<float>::quiet_NaN()
+                              : static_cast<float>(std::log(
+                                    arg + std::sqrt(arg * arg - 1.0))));
+#endif
+  }
+
+  /// Hyperbolic area tangent implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr atanh(float arg) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::atanh(arg));
+#else
+    return expr(static_cast<float>(0.5 * std::log((1.0 + arg) / (1.0 - arg))));
+#endif
+  }
+
+  /// Error function implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr erf(float arg) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::erf(arg));
+#else
+    return expr(static_cast<float>(erf(static_cast<double>(arg))));
+#endif
+  }
+
+  /// Complementary implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr erfc(float arg) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::erfc(arg));
+#else
+    return expr(static_cast<float>(1.0 - erf(static_cast<double>(arg))));
+#endif
+  }
+
+  /// Gamma logarithm implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr lgamma(float arg) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::lgamma(arg));
+#else
+    if (builtin_isinf(arg)) return expr(std::numeric_limits<float>::infinity());
+    if (arg < 0.0f) {
+      float i, f = std::modf(-arg, &i);
+      if (f == 0.0f) return expr(std::numeric_limits<float>::infinity());
+      return expr(static_cast<float>(
+          1.1447298858494001741434273513531 -
+          std::log(std::abs(std::sin(3.1415926535897932384626433832795 * f))) -
+          lgamma(1.0 - arg)));
+    }
+    return expr(static_cast<float>(lgamma(static_cast<double>(arg))));
+#endif
+  }
+
+  /// Gamma implementation.
+  /// \param arg function argument
+  /// \return function value stored in single-preicision
+  static expr tgamma(float arg) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::tgamma(arg));
+#else
+    if (arg == 0.0f)
+      return builtin_signbit(arg)
+                 ? expr(-std::numeric_limits<float>::infinity())
+                 : expr(std::numeric_limits<float>::infinity());
+    if (arg < 0.0f) {
+      float i, f = std::modf(-arg, &i);
+      if (f == 0.0f) return expr(std::numeric_limits<float>::quiet_NaN());
+      double value = 3.1415926535897932384626433832795 /
+                     (std::sin(3.1415926535897932384626433832795 * f) *
+                      std::exp(lgamma(1.0 - arg)));
+      return expr(
+          static_cast<float>((std::fmod(i, 2.0f) == 0.0f) ? -value : value));
+    }
+    if (builtin_isinf(arg)) return expr(arg);
+    return expr(static_cast<float>(std::exp(lgamma(static_cast<double>(arg)))));
+#endif
+  }
+
+  /// Floor implementation.
+  /// \param arg value to round
+  /// \return rounded value
+  static half floor(half arg) {
+    return half(binary, round_half<std::round_toward_neg_infinity>(arg.data_));
+  }
+
+  /// Ceiling implementation.
+  /// \param arg value to round
+  /// \return rounded value
+  static half ceil(half arg) {
+    return half(binary, round_half<std::round_toward_infinity>(arg.data_));
+  }
+
+  /// Truncation implementation.
+  /// \param arg value to round
+  /// \return rounded value
+  static half trunc(half arg) {
+    return half(binary, round_half<std::round_toward_zero>(arg.data_));
+  }
+
+  /// Nearest integer implementation.
+  /// \param arg value to round
+  /// \return rounded value
+  static half round(half arg) { return half(binary, round_half_up(arg.data_)); }
+
+  /// Nearest integer implementation.
+  /// \param arg value to round
+  /// \return rounded value
+  static long lround(half arg) { return detail::half2int_up<long>(arg.data_); }
+
+  /// Nearest integer implementation.
+  /// \param arg value to round
+  /// \return rounded value
+  static half rint(half arg) {
+    return half(binary, round_half<half::round_style>(arg.data_));
+  }
+
+  /// Nearest integer implementation.
+  /// \param arg value to round
+  /// \return rounded value
+  static long lrint(half arg) {
+    return detail::half2int<half::round_style, long>(arg.data_);
+  }
+
 #if HALF_ENABLE_CPP11_LONG_LONG
-	using detail::llround;
-	using detail::llrint;
-#endif
-	using detail::frexp;
-	using detail::ldexp;
-	using detail::modf;
-	using detail::scalbn;
-	using detail::scalbln;
-	using detail::ilogb;
-	using detail::logb;
-	using detail::nextafter;
-	using detail::nexttoward;
-	using detail::copysign;
-	using detail::fpclassify;
-	using detail::isfinite;
-	using detail::isinf;
-	using detail::isnan;
-	using detail::isnormal;
-	using detail::signbit;
-	using detail::isgreater;
-	using detail::isgreaterequal;
-	using detail::isless;
-	using detail::islessequal;
-	using detail::islessgreater;
-	using detail::isunordered;
+  /// Nearest integer implementation.
+  /// \param arg value to round
+  /// \return rounded value
+  static long long llround(half arg) {
+    return detail::half2int_up<long long>(arg.data_);
+  }
 
-	using detail::half_cast;
+  /// Nearest integer implementation.
+  /// \param arg value to round
+  /// \return rounded value
+  static long long llrint(half arg) {
+    return detail::half2int<half::round_style, long long>(arg.data_);
+  }
+#endif
+
+  /// Decompression implementation.
+  /// \param arg number to decompress
+  /// \param exp address to store exponent at
+  /// \return normalized significant
+  static half frexp(half arg, int *exp) {
+    int m = arg.data_ & 0x7FFF, e = -14;
+    if (m >= 0x7C00 || !m) return *exp = 0, arg;
+    for (; m < 0x400; m <<= 1, --e)
+      ;
+    return *exp = e + (m >> 10),
+           half(binary, (arg.data_ & 0x8000) | 0x3800 | (m & 0x3FF));
+  }
+
+  /// Decompression implementation.
+  /// \param arg number to decompress
+  /// \param iptr address to store integer part at
+  /// \return fractional part
+  static half modf(half arg, half *iptr) {
+    unsigned int e = arg.data_ & 0x7FFF;
+    if (e >= 0x6400)
+      return *iptr = arg, half(binary, arg.data_ & (0x8000U | -(e > 0x7C00)));
+    if (e < 0x3C00) return iptr->data_ = arg.data_ & 0x8000, arg;
+    e >>= 10;
+    unsigned int mask = (1 << (25 - e)) - 1, m = arg.data_ & mask;
+    iptr->data_ = arg.data_ & ~mask;
+    if (!m) return half(binary, arg.data_ & 0x8000);
+    for (; m < 0x400; m <<= 1, --e)
+      ;
+    return half(binary, static_cast<uint16>((arg.data_ & 0x8000) | (e << 10) |
+                                            (m & 0x3FF)));
+  }
+
+  /// Scaling implementation.
+  /// \param arg number to scale
+  /// \param exp power of two to scale by
+  /// \return scaled number
+  static half scalbln(half arg, long exp) {
+    unsigned int m = arg.data_ & 0x7FFF;
+    if (m >= 0x7C00 || !m) return arg;
+    for (; m < 0x400; m <<= 1, --exp)
+      ;
+    exp += m >> 10;
+    uint16 value = arg.data_ & 0x8000;
+    if (exp > 30) {
+      if (half::round_style == std::round_toward_zero)
+        value |= 0x7BFF;
+      else if (half::round_style == std::round_toward_infinity)
+        value |= 0x7C00 - (value >> 15);
+      else if (half::round_style == std::round_toward_neg_infinity)
+        value |= 0x7BFF + (value >> 15);
+      else
+        value |= 0x7C00;
+    } else if (exp > 0)
+      value |= (exp << 10) | (m & 0x3FF);
+    else if (exp > -11) {
+      m = (m & 0x3FF) | 0x400;
+      if (half::round_style == std::round_to_nearest) {
+        m += 1 << -exp;
+#if HALF_ROUND_TIES_TO_EVEN
+        m -= (m >> (1 - exp)) & 1;
+#endif
+      } else if (half::round_style == std::round_toward_infinity)
+        m += ((value >> 15) - 1) & ((1 << (1 - exp)) - 1U);
+      else if (half::round_style == std::round_toward_neg_infinity)
+        m += -(value >> 15) & ((1 << (1 - exp)) - 1U);
+      value |= m >> (1 - exp);
+    } else if (half::round_style == std::round_toward_infinity)
+      value -= (value >> 15) - 1;
+    else if (half::round_style == std::round_toward_neg_infinity)
+      value += value >> 15;
+    return half(binary, value);
+  }
+
+  /// Exponent implementation.
+  /// \param arg number to query
+  /// \return floating point exponent
+  static int ilogb(half arg) {
+    int abs = arg.data_ & 0x7FFF;
+    if (!abs) return FP_ILOGB0;
+    if (abs < 0x7C00) {
+      int exp = (abs >> 10) - 15;
+      if (abs < 0x400)
+        for (; abs < 0x200; abs <<= 1, --exp)
+          ;
+      return exp;
+    }
+    if (abs > 0x7C00) return FP_ILOGBNAN;
+    return INT_MAX;
+  }
+
+  /// Exponent implementation.
+  /// \param arg number to query
+  /// \return floating point exponent
+  static half logb(half arg) {
+    int abs = arg.data_ & 0x7FFF;
+    if (!abs) return half(binary, 0xFC00);
+    if (abs < 0x7C00) {
+      int exp = (abs >> 10) - 15;
+      if (abs < 0x400)
+        for (; abs < 0x200; abs <<= 1, --exp)
+          ;
+      uint16 bits = (exp < 0) << 15;
+      if (exp) {
+        unsigned int m = std::abs(exp) << 6, e = 18;
+        for (; m < 0x400; m <<= 1, --e)
+          ;
+        bits |= (e << 10) + m;
+      }
+      return half(binary, bits);
+    }
+    if (abs > 0x7C00) return arg;
+    return half(binary, 0x7C00);
+  }
+
+  /// Enumeration implementation.
+  /// \param from number to increase/decrease
+  /// \param to direction to enumerate into
+  /// \return next representable number
+  static half nextafter(half from, half to) {
+    uint16 fabs = from.data_ & 0x7FFF, tabs = to.data_ & 0x7FFF;
+    if (fabs > 0x7C00) return from;
+    if (tabs > 0x7C00 || from.data_ == to.data_ || !(fabs | tabs)) return to;
+    if (!fabs) return half(binary, (to.data_ & 0x8000) + 1);
+    bool lt =
+        ((fabs == from.data_) ? static_cast<int>(fabs)
+                              : -static_cast<int>(fabs)) <
+        ((tabs == to.data_) ? static_cast<int>(tabs) : -static_cast<int>(tabs));
+    return half(binary,
+                from.data_ +
+                    (((from.data_ >> 15) ^ static_cast<unsigned>(lt)) << 1) -
+                    1);
+  }
+
+  /// Enumeration implementation.
+  /// \param from number to increase/decrease
+  /// \param to direction to enumerate into
+  /// \return next representable number
+  static half nexttoward(half from, long double to) {
+    if (isnan(from)) return from;
+    long double lfrom = static_cast<long double>(from);
+    if (builtin_isnan(to) || lfrom == to) return half(static_cast<float>(to));
+    if (!(from.data_ & 0x7FFF))
+      return half(binary,
+                  (static_cast<detail::uint16>(builtin_signbit(to)) << 15) + 1);
+    return half(
+        binary,
+        from.data_ +
+            (((from.data_ >> 15) ^ static_cast<unsigned>(lfrom < to)) << 1) -
+            1);
+  }
+
+  /// Sign implementation
+  /// \param x first operand
+  /// \param y second operand
+  /// \return composed value
+  static half copysign(half x, half y) {
+    return half(binary, x.data_ ^ ((x.data_ ^ y.data_) & 0x8000));
+  }
+
+  /// Classification implementation.
+  /// \param arg value to classify
+  /// \retval true if infinite number
+  /// \retval false else
+  static int fpclassify(half arg) {
+    unsigned int abs = arg.data_ & 0x7FFF;
+    return abs ? ((abs > 0x3FF) ? ((abs >= 0x7C00)
+                                       ? ((abs > 0x7C00) ? FP_NAN : FP_INFINITE)
+                                       : FP_NORMAL)
+                                : FP_SUBNORMAL)
+               : FP_ZERO;
+  }
+
+  /// Classification implementation.
+  /// \param arg value to classify
+  /// \retval true if finite number
+  /// \retval false else
+  static bool isfinite(half arg) { return (arg.data_ & 0x7C00) != 0x7C00; }
+
+  /// Classification implementation.
+  /// \param arg value to classify
+  /// \retval true if infinite number
+  /// \retval false else
+  static bool isinf(half arg) { return (arg.data_ & 0x7FFF) == 0x7C00; }
+
+  /// Classification implementation.
+  /// \param arg value to classify
+  /// \retval true if not a number
+  /// \retval false else
+  static bool isnan(half arg) { return (arg.data_ & 0x7FFF) > 0x7C00; }
+
+  /// Classification implementation.
+  /// \param arg value to classify
+  /// \retval true if normal number
+  /// \retval false else
+  static bool isnormal(half arg) {
+    return ((arg.data_ & 0x7C00) != 0) & ((arg.data_ & 0x7C00) != 0x7C00);
+  }
+
+  /// Sign bit implementation.
+  /// \param arg value to check
+  /// \retval true if signed
+  /// \retval false if unsigned
+  static bool signbit(half arg) { return (arg.data_ & 0x8000) != 0; }
+
+  /// Comparison implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \retval true if operands equal
+  /// \retval false else
+  static bool isequal(half x, half y) {
+    return (x.data_ == y.data_ || !((x.data_ | y.data_) & 0x7FFF)) && !isnan(x);
+  }
+
+  /// Comparison implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \retval true if operands not equal
+  /// \retval false else
+  static bool isnotequal(half x, half y) {
+    return (x.data_ != y.data_ && ((x.data_ | y.data_) & 0x7FFF)) || isnan(x);
+  }
+
+  /// Comparison implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \retval true if \a x > \a y
+  /// \retval false else
+  static bool isgreater(half x, half y) {
+    int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
+    return xabs <= 0x7C00 && yabs <= 0x7C00 &&
+           (((xabs == x.data_) ? xabs : -xabs) >
+            ((yabs == y.data_) ? yabs : -yabs));
+  }
+
+  /// Comparison implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \retval true if \a x >= \a y
+  /// \retval false else
+  static bool isgreaterequal(half x, half y) {
+    int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
+    return xabs <= 0x7C00 && yabs <= 0x7C00 &&
+           (((xabs == x.data_) ? xabs : -xabs) >=
+            ((yabs == y.data_) ? yabs : -yabs));
+  }
+
+  /// Comparison implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \retval true if \a x < \a y
+  /// \retval false else
+  static bool isless(half x, half y) {
+    int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
+    return xabs <= 0x7C00 && yabs <= 0x7C00 &&
+           (((xabs == x.data_) ? xabs : -xabs) <
+            ((yabs == y.data_) ? yabs : -yabs));
+  }
+
+  /// Comparison implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \retval true if \a x <= \a y
+  /// \retval false else
+  static bool islessequal(half x, half y) {
+    int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
+    return xabs <= 0x7C00 && yabs <= 0x7C00 &&
+           (((xabs == x.data_) ? xabs : -xabs) <=
+            ((yabs == y.data_) ? yabs : -yabs));
+  }
+
+  /// Comparison implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \retval true if either \a x > \a y nor \a x < \a y
+  /// \retval false else
+  static bool islessgreater(half x, half y) {
+    int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
+    if (xabs > 0x7C00 || yabs > 0x7C00) return false;
+    int a = (xabs == x.data_) ? xabs : -xabs,
+        b = (yabs == y.data_) ? yabs : -yabs;
+    return a < b || a > b;
+  }
+
+  /// Comparison implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \retval true if operand unordered
+  /// \retval false else
+  static bool isunordered(half x, half y) { return isnan(x) || isnan(y); }
+
+ private:
+  static double erf(double arg) {
+    if (builtin_isinf(arg)) return (arg < 0.0) ? -1.0 : 1.0;
+    double x2 = arg * arg, ax2 = 0.147 * x2,
+           value = std::sqrt(
+               1.0 - std::exp(-x2 * (1.2732395447351626861510701069801 + ax2) /
+                              (1.0 + ax2)));
+    return builtin_signbit(arg) ? -value : value;
+  }
+
+  static double lgamma(double arg) {
+    double v = 1.0;
+    for (; arg < 8.0; ++arg) v *= arg;
+    double w = 1.0 / (arg * arg);
+    return (((((((-0.02955065359477124183006535947712 * w +
+                  0.00641025641025641025641025641026) *
+                     w +
+                 -0.00191752691752691752691752691753) *
+                    w +
+                8.4175084175084175084175084175084e-4) *
+                   w +
+               -5.952380952380952380952380952381e-4) *
+                  w +
+              7.9365079365079365079365079365079e-4) *
+                 w +
+             -0.00277777777777777777777777777778) *
+                w +
+            0.08333333333333333333333333333333) /
+               arg +
+           0.91893853320467274178032973640562 - std::log(v) - arg +
+           (arg - 0.5) * std::log(arg);
+  }
+};
+
+/// Wrapper for unary half-precision functions needing specialization for
+/// individual argument types.
+/// \tparam T argument type
+template <typename T>
+struct unary_specialized {
+  /// Negation implementation.
+  /// \param arg value to negate
+  /// \return negated value
+  static HALF_CONSTEXPR half negate(half arg) {
+    return half(binary, arg.data_ ^ 0x8000);
+  }
+
+  /// Absolute value implementation.
+  /// \param arg function argument
+  /// \return absolute value
+  static half fabs(half arg) { return half(binary, arg.data_ & 0x7FFF); }
+};
+template <>
+struct unary_specialized<expr> {
+  static HALF_CONSTEXPR expr negate(float arg) { return expr(-arg); }
+  static expr fabs(float arg) { return expr(std::fabs(arg)); }
+};
+
+/// Wrapper for binary half-precision functions needing specialization for
+/// individual argument types.
+/// \tparam T first argument type
+/// \tparam U first argument type
+template <typename T, typename U>
+struct binary_specialized {
+  /// Minimum implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \return minimum value
+  static expr fmin(float x, float y) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::fmin(x, y));
+#else
+    if (builtin_isnan(x)) return expr(y);
+    if (builtin_isnan(y)) return expr(x);
+    return expr(std::min(x, y));
+#endif
+  }
+
+  /// Maximum implementation.
+  /// \param x first operand
+  /// \param y second operand
+  /// \return maximum value
+  static expr fmax(float x, float y) {
+#if HALF_ENABLE_CPP11_CMATH
+    return expr(std::fmax(x, y));
+#else
+    if (builtin_isnan(x)) return expr(y);
+    if (builtin_isnan(y)) return expr(x);
+    return expr(std::max(x, y));
+#endif
+  }
+};
+template <>
+struct binary_specialized<half, half> {
+  static half fmin(half x, half y) {
+    int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
+    if (xabs > 0x7C00) return y;
+    if (yabs > 0x7C00) return x;
+    return (((xabs == x.data_) ? xabs : -xabs) >
+            ((yabs == y.data_) ? yabs : -yabs))
+               ? y
+               : x;
+  }
+  static half fmax(half x, half y) {
+    int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
+    if (xabs > 0x7C00) return y;
+    if (yabs > 0x7C00) return x;
+    return (((xabs == x.data_) ? xabs : -xabs) <
+            ((yabs == y.data_) ? yabs : -yabs))
+               ? y
+               : x;
+  }
+};
+
+/// Helper class for half casts.
+/// This class template has to be specialized for all valid cast argument to
+/// define an appropriate static `cast` member
+/// function and a corresponding `type` member denoting its return type.
+/// \tparam T destination type
+/// \tparam U source type
+/// \tparam R rounding mode to use
+template <typename T, typename U,
+          std::float_round_style R = (std::float_round_style)(HALF_ROUND_STYLE)>
+struct half_caster {};
+template <typename U, std::float_round_style R>
+struct half_caster<half, U, R> {
+#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
+  static_assert(std::is_arithmetic<U>::value,
+                "half_cast from non-arithmetic type unsupported");
+#endif
+
+  static half cast(U arg) { return cast_impl(arg, is_float<U>()); };
+
+ private:
+  static half cast_impl(U arg, true_type) {
+    return half(binary, float2half<R>(arg));
+  }
+  static half cast_impl(U arg, false_type) {
+    return half(binary, int2half<R>(arg));
+  }
+};
+template <typename T, std::float_round_style R>
+struct half_caster<T, half, R> {
+#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
+  static_assert(std::is_arithmetic<T>::value,
+                "half_cast to non-arithmetic type unsupported");
+#endif
+
+  static T cast(half arg) { return cast_impl(arg, is_float<T>()); }
+
+ private:
+  static T cast_impl(half arg, true_type) { return half2float<T>(arg.data_); }
+  static T cast_impl(half arg, false_type) { return half2int<R, T>(arg.data_); }
+};
+template <typename T, std::float_round_style R>
+struct half_caster<T, expr, R> {
+#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
+  static_assert(std::is_arithmetic<T>::value,
+                "half_cast to non-arithmetic type unsupported");
+#endif
+
+  static T cast(expr arg) { return cast_impl(arg, is_float<T>()); }
+
+ private:
+  static T cast_impl(float arg, true_type) { return static_cast<T>(arg); }
+  static T cast_impl(half arg, false_type) { return half2int<R, T>(arg.data_); }
+};
+template <std::float_round_style R>
+struct half_caster<half, half, R> {
+  static half cast(half arg) { return arg; }
+};
+template <std::float_round_style R>
+struct half_caster<half, expr, R> : half_caster<half, half, R> {};
+
+/// \name Comparison operators
+/// \{
+
+/// Comparison for equality.
+/// \param x first operand
+/// \param y second operand
+/// \retval true if operands equal
+/// \retval false else
+template <typename T, typename U>
+typename enable<bool, T, U>::type operator==(T x, U y) {
+  return functions::isequal(x, y);
 }
 
+/// Comparison for inequality.
+/// \param x first operand
+/// \param y second operand
+/// \retval true if operands not equal
+/// \retval false else
+template <typename T, typename U>
+typename enable<bool, T, U>::type operator!=(T x, U y) {
+  return functions::isnotequal(x, y);
+}
+
+/// Comparison for less than.
+/// \param x first operand
+/// \param y second operand
+/// \retval true if \a x less than \a y
+/// \retval false else
+template <typename T, typename U>
+typename enable<bool, T, U>::type operator<(T x, U y) {
+  return functions::isless(x, y);
+}
+
+/// Comparison for greater than.
+/// \param x first operand
+/// \param y second operand
+/// \retval true if \a x greater than \a y
+/// \retval false else
+template <typename T, typename U>
+typename enable<bool, T, U>::type operator>(T x, U y) {
+  return functions::isgreater(x, y);
+}
+
+/// Comparison for less equal.
+/// \param x first operand
+/// \param y second operand
+/// \retval true if \a x less equal \a y
+/// \retval false else
+template <typename T, typename U>
+typename enable<bool, T, U>::type operator<=(T x, U y) {
+  return functions::islessequal(x, y);
+}
+
+/// Comparison for greater equal.
+/// \param x first operand
+/// \param y second operand
+/// \retval true if \a x greater equal \a y
+/// \retval false else
+template <typename T, typename U>
+typename enable<bool, T, U>::type operator>=(T x, U y) {
+  return functions::isgreaterequal(x, y);
+}
+
+/// \}
+/// \name Arithmetic operators
+/// \{
+
+/// Add halfs.
+/// \param x left operand
+/// \param y right operand
+/// \return sum of half expressions
+template <typename T, typename U>
+typename enable<expr, T, U>::type operator+(T x, U y) {
+  return functions::plus(x, y);
+}
+
+/// Subtract halfs.
+/// \param x left operand
+/// \param y right operand
+/// \return difference of half expressions
+template <typename T, typename U>
+typename enable<expr, T, U>::type operator-(T x, U y) {
+  return functions::minus(x, y);
+}
+
+/// Multiply halfs.
+/// \param x left operand
+/// \param y right operand
+/// \return product of half expressions
+template <typename T, typename U>
+typename enable<expr, T, U>::type operator*(T x, U y) {
+  return functions::multiplies(x, y);
+}
+
+/// Divide halfs.
+/// \param x left operand
+/// \param y right operand
+/// \return quotient of half expressions
+template <typename T, typename U>
+typename enable<expr, T, U>::type operator/(T x, U y) {
+  return functions::divides(x, y);
+}
+
+/// Identity.
+/// \param arg operand
+/// \return uncahnged operand
+template <typename T>
+HALF_CONSTEXPR typename enable<T, T>::type operator+(T arg) {
+  return arg;
+}
+
+/// Negation.
+/// \param arg operand
+/// \return negated operand
+template <typename T>
+HALF_CONSTEXPR typename enable<T, T>::type operator-(T arg) {
+  return unary_specialized<T>::negate(arg);
+}
+
+/// \}
+/// \name Input and output
+/// \{
+
+/// Output operator.
+/// \param out output stream to write into
+/// \param arg half expression to write
+/// \return reference to output stream
+template <typename T, typename charT, typename traits>
+typename enable<std::basic_ostream<charT, traits> &, T>::type operator<<(
+    std::basic_ostream<charT, traits> &out, T arg) {
+  return functions::write(out, arg);
+}
+
+/// Input operator.
+/// \param in input stream to read from
+/// \param arg half to read into
+/// \return reference to input stream
+template <typename charT, typename traits>
+std::basic_istream<charT, traits> &operator>>(
+    std::basic_istream<charT, traits> &in, half &arg) {
+  return functions::read(in, arg);
+}
+
+/// \}
+/// \name Basic mathematical operations
+/// \{
+
+/// Absolute value.
+/// \param arg operand
+/// \return absolute value of \a arg
+//		template<typename T> typename enable<T,T>::type abs(T arg) {
+//return unary_specialized<T>::fabs(arg); }
+inline half abs(half arg) { return unary_specialized<half>::fabs(arg); }
+inline expr abs(expr arg) { return unary_specialized<expr>::fabs(arg); }
+
+/// Absolute value.
+/// \param arg operand
+/// \return absolute value of \a arg
+//		template<typename T> typename enable<T,T>::type fabs(T arg) {
+//return unary_specialized<T>::fabs(arg); }
+inline half fabs(half arg) { return unary_specialized<half>::fabs(arg); }
+inline expr fabs(expr arg) { return unary_specialized<expr>::fabs(arg); }
+
+/// Remainder of division.
+/// \param x first operand
+/// \param y second operand
+/// \return remainder of floating point division.
+//		template<typename T,typename U> typename enable<expr,T,U>::type
+//fmod(T x, U y) { return functions::fmod(x, y); }
+inline expr fmod(half x, half y) { return functions::fmod(x, y); }
+inline expr fmod(half x, expr y) { return functions::fmod(x, y); }
+inline expr fmod(expr x, half y) { return functions::fmod(x, y); }
+inline expr fmod(expr x, expr y) { return functions::fmod(x, y); }
+
+/// Remainder of division.
+/// \param x first operand
+/// \param y second operand
+/// \return remainder of floating point division.
+//		template<typename T,typename U> typename enable<expr,T,U>::type
+//remainder(T x, U y) { return functions::remainder(x, y); }
+inline expr remainder(half x, half y) { return functions::remainder(x, y); }
+inline expr remainder(half x, expr y) { return functions::remainder(x, y); }
+inline expr remainder(expr x, half y) { return functions::remainder(x, y); }
+inline expr remainder(expr x, expr y) { return functions::remainder(x, y); }
+
+/// Remainder of division.
+/// \param x first operand
+/// \param y second operand
+/// \param quo address to store some bits of quotient at
+/// \return remainder of floating point division.
+//		template<typename T,typename U> typename enable<expr,T,U>::type
+//remquo(T x, U y, int *quo) { return functions::remquo(x, y, quo); }
+inline expr remquo(half x, half y, int *quo) {
+  return functions::remquo(x, y, quo);
+}
+inline expr remquo(half x, expr y, int *quo) {
+  return functions::remquo(x, y, quo);
+}
+inline expr remquo(expr x, half y, int *quo) {
+  return functions::remquo(x, y, quo);
+}
+inline expr remquo(expr x, expr y, int *quo) {
+  return functions::remquo(x, y, quo);
+}
+
+/// Fused multiply add.
+/// \param x first operand
+/// \param y second operand
+/// \param z third operand
+/// \return ( \a x * \a y ) + \a z rounded as one operation.
+//		template<typename T,typename U,typename V> typename
+//enable<expr,T,U,V>::type fma(T x, U y, V z) { return functions::fma(x, y, z);
+//}
+inline expr fma(half x, half y, half z) { return functions::fma(x, y, z); }
+inline expr fma(half x, half y, expr z) { return functions::fma(x, y, z); }
+inline expr fma(half x, expr y, half z) { return functions::fma(x, y, z); }
+inline expr fma(half x, expr y, expr z) { return functions::fma(x, y, z); }
+inline expr fma(expr x, half y, half z) { return functions::fma(x, y, z); }
+inline expr fma(expr x, half y, expr z) { return functions::fma(x, y, z); }
+inline expr fma(expr x, expr y, half z) { return functions::fma(x, y, z); }
+inline expr fma(expr x, expr y, expr z) { return functions::fma(x, y, z); }
+
+/// Maximum of half expressions.
+/// \param x first operand
+/// \param y second operand
+/// \return maximum of operands
+//		template<typename T,typename U> typename result<T,U>::type fmax(T
+//x, U y) { return binary_specialized<T,U>::fmax(x, y); }
+inline half fmax(half x, half y) {
+  return binary_specialized<half, half>::fmax(x, y);
+}
+inline expr fmax(half x, expr y) {
+  return binary_specialized<half, expr>::fmax(x, y);
+}
+inline expr fmax(expr x, half y) {
+  return binary_specialized<expr, half>::fmax(x, y);
+}
+inline expr fmax(expr x, expr y) {
+  return binary_specialized<expr, expr>::fmax(x, y);
+}
+
+/// Minimum of half expressions.
+/// \param x first operand
+/// \param y second operand
+/// \return minimum of operands
+//		template<typename T,typename U> typename result<T,U>::type fmin(T
+//x, U y) { return binary_specialized<T,U>::fmin(x, y); }
+inline half fmin(half x, half y) {
+  return binary_specialized<half, half>::fmin(x, y);
+}
+inline expr fmin(half x, expr y) {
+  return binary_specialized<half, expr>::fmin(x, y);
+}
+inline expr fmin(expr x, half y) {
+  return binary_specialized<expr, half>::fmin(x, y);
+}
+inline expr fmin(expr x, expr y) {
+  return binary_specialized<expr, expr>::fmin(x, y);
+}
+
+/// Positive difference.
+/// \param x first operand
+/// \param y second operand
+/// \return \a x - \a y or 0 if difference negative
+//		template<typename T,typename U> typename enable<expr,T,U>::type
+//fdim(T x, U y) { return functions::fdim(x, y); }
+inline expr fdim(half x, half y) { return functions::fdim(x, y); }
+inline expr fdim(half x, expr y) { return functions::fdim(x, y); }
+inline expr fdim(expr x, half y) { return functions::fdim(x, y); }
+inline expr fdim(expr x, expr y) { return functions::fdim(x, y); }
+
+/// Get NaN value.
+/// \return quiet NaN
+inline half nanh(const char *) { return functions::nanh(); }
+
+/// \}
+/// \name Exponential functions
+/// \{
+
+/// Exponential function.
+/// \param arg function argument
+/// \return e raised to \a arg
+//		template<typename T> typename enable<expr,T>::type exp(T arg) {
+//return functions::exp(arg); }
+inline expr exp(half arg) { return functions::exp(arg); }
+inline expr exp(expr arg) { return functions::exp(arg); }
+
+/// Exponential minus one.
+/// \param arg function argument
+/// \return e raised to \a arg subtracted by 1
+//		template<typename T> typename enable<expr,T>::type expm1(T arg) {
+//return functions::expm1(arg); }
+inline expr expm1(half arg) { return functions::expm1(arg); }
+inline expr expm1(expr arg) { return functions::expm1(arg); }
+
+/// Binary exponential.
+/// \param arg function argument
+/// \return 2 raised to \a arg
+//		template<typename T> typename enable<expr,T>::type exp2(T arg) {
+//return functions::exp2(arg); }
+inline expr exp2(half arg) { return functions::exp2(arg); }
+inline expr exp2(expr arg) { return functions::exp2(arg); }
+
+/// Natural logorithm.
+/// \param arg function argument
+/// \return logarithm of \a arg to base e
+//		template<typename T> typename enable<expr,T>::type log(T arg) {
+//return functions::log(arg); }
+inline expr log(half arg) { return functions::log(arg); }
+inline expr log(expr arg) { return functions::log(arg); }
+
+/// Common logorithm.
+/// \param arg function argument
+/// \return logarithm of \a arg to base 10
+//		template<typename T> typename enable<expr,T>::type log10(T arg) {
+//return functions::log10(arg); }
+inline expr log10(half arg) { return functions::log10(arg); }
+inline expr log10(expr arg) { return functions::log10(arg); }
+
+/// Natural logorithm.
+/// \param arg function argument
+/// \return logarithm of \a arg plus 1 to base e
+//		template<typename T> typename enable<expr,T>::type log1p(T arg) {
+//return functions::log1p(arg); }
+inline expr log1p(half arg) { return functions::log1p(arg); }
+inline expr log1p(expr arg) { return functions::log1p(arg); }
+
+/// Binary logorithm.
+/// \param arg function argument
+/// \return logarithm of \a arg to base 2
+//		template<typename T> typename enable<expr,T>::type log2(T arg) {
+//return functions::log2(arg); }
+inline expr log2(half arg) { return functions::log2(arg); }
+inline expr log2(expr arg) { return functions::log2(arg); }
+
+/// \}
+/// \name Power functions
+/// \{
+
+/// Square root.
+/// \param arg function argument
+/// \return square root of \a arg
+//		template<typename T> typename enable<expr,T>::type sqrt(T arg) {
+//return functions::sqrt(arg); }
+inline expr sqrt(half arg) { return functions::sqrt(arg); }
+inline expr sqrt(expr arg) { return functions::sqrt(arg); }
+
+/// Cubic root.
+/// \param arg function argument
+/// \return cubic root of \a arg
+//		template<typename T> typename enable<expr,T>::type cbrt(T arg) {
+//return functions::cbrt(arg); }
+inline expr cbrt(half arg) { return functions::cbrt(arg); }
+inline expr cbrt(expr arg) { return functions::cbrt(arg); }
+
+/// Hypotenuse function.
+/// \param x first argument
+/// \param y second argument
+/// \return square root of sum of squares without internal over- or underflows
+//		template<typename T,typename U> typename enable<expr,T,U>::type
+//hypot(T x, U y) { return functions::hypot(x, y); }
+inline expr hypot(half x, half y) { return functions::hypot(x, y); }
+inline expr hypot(half x, expr y) { return functions::hypot(x, y); }
+inline expr hypot(expr x, half y) { return functions::hypot(x, y); }
+inline expr hypot(expr x, expr y) { return functions::hypot(x, y); }
+
+/// Power function.
+/// \param base first argument
+/// \param exp second argument
+/// \return \a base raised to \a exp
+//		template<typename T,typename U> typename enable<expr,T,U>::type
+//pow(T base, U exp) { return functions::pow(base, exp); }
+inline expr pow(half base, half exp) { return functions::pow(base, exp); }
+inline expr pow(half base, expr exp) { return functions::pow(base, exp); }
+inline expr pow(expr base, half exp) { return functions::pow(base, exp); }
+inline expr pow(expr base, expr exp) { return functions::pow(base, exp); }
+
+/// \}
+/// \name Trigonometric functions
+/// \{
+
+/// Sine function.
+/// \param arg function argument
+/// \return sine value of \a arg
+//		template<typename T> typename enable<expr,T>::type sin(T arg) {
+//return functions::sin(arg); }
+inline expr sin(half arg) { return functions::sin(arg); }
+inline expr sin(expr arg) { return functions::sin(arg); }
+
+/// Cosine function.
+/// \param arg function argument
+/// \return cosine value of \a arg
+//		template<typename T> typename enable<expr,T>::type cos(T arg) {
+//return functions::cos(arg); }
+inline expr cos(half arg) { return functions::cos(arg); }
+inline expr cos(expr arg) { return functions::cos(arg); }
+
+/// Tangent function.
+/// \param arg function argument
+/// \return tangent value of \a arg
+//		template<typename T> typename enable<expr,T>::type tan(T arg) {
+//return functions::tan(arg); }
+inline expr tan(half arg) { return functions::tan(arg); }
+inline expr tan(expr arg) { return functions::tan(arg); }
+
+/// Arc sine.
+/// \param arg function argument
+/// \return arc sine value of \a arg
+//		template<typename T> typename enable<expr,T>::type asin(T arg) {
+//return functions::asin(arg); }
+inline expr asin(half arg) { return functions::asin(arg); }
+inline expr asin(expr arg) { return functions::asin(arg); }
+
+/// Arc cosine function.
+/// \param arg function argument
+/// \return arc cosine value of \a arg
+//		template<typename T> typename enable<expr,T>::type acos(T arg) {
+//return functions::acos(arg); }
+inline expr acos(half arg) { return functions::acos(arg); }
+inline expr acos(expr arg) { return functions::acos(arg); }
+
+/// Arc tangent function.
+/// \param arg function argument
+/// \return arc tangent value of \a arg
+//		template<typename T> typename enable<expr,T>::type atan(T arg) {
+//return functions::atan(arg); }
+inline expr atan(half arg) { return functions::atan(arg); }
+inline expr atan(expr arg) { return functions::atan(arg); }
+
+/// Arc tangent function.
+/// \param x first argument
+/// \param y second argument
+/// \return arc tangent value
+//		template<typename T,typename U> typename enable<expr,T,U>::type
+//atan2(T x, U y) { return functions::atan2(x, y); }
+inline expr atan2(half x, half y) { return functions::atan2(x, y); }
+inline expr atan2(half x, expr y) { return functions::atan2(x, y); }
+inline expr atan2(expr x, half y) { return functions::atan2(x, y); }
+inline expr atan2(expr x, expr y) { return functions::atan2(x, y); }
+
+/// \}
+/// \name Hyperbolic functions
+/// \{
+
+/// Hyperbolic sine.
+/// \param arg function argument
+/// \return hyperbolic sine value of \a arg
+//		template<typename T> typename enable<expr,T>::type sinh(T arg) {
+//return functions::sinh(arg); }
+inline expr sinh(half arg) { return functions::sinh(arg); }
+inline expr sinh(expr arg) { return functions::sinh(arg); }
+
+/// Hyperbolic cosine.
+/// \param arg function argument
+/// \return hyperbolic cosine value of \a arg
+//		template<typename T> typename enable<expr,T>::type cosh(T arg) {
+//return functions::cosh(arg); }
+inline expr cosh(half arg) { return functions::cosh(arg); }
+inline expr cosh(expr arg) { return functions::cosh(arg); }
+
+/// Hyperbolic tangent.
+/// \param arg function argument
+/// \return hyperbolic tangent value of \a arg
+//		template<typename T> typename enable<expr,T>::type tanh(T arg) {
+//return functions::tanh(arg); }
+inline expr tanh(half arg) { return functions::tanh(arg); }
+inline expr tanh(expr arg) { return functions::tanh(arg); }
+
+/// Hyperbolic area sine.
+/// \param arg function argument
+/// \return area sine value of \a arg
+//		template<typename T> typename enable<expr,T>::type asinh(T arg) {
+//return functions::asinh(arg); }
+inline expr asinh(half arg) { return functions::asinh(arg); }
+inline expr asinh(expr arg) { return functions::asinh(arg); }
+
+/// Hyperbolic area cosine.
+/// \param arg function argument
+/// \return area cosine value of \a arg
+//		template<typename T> typename enable<expr,T>::type acosh(T arg) {
+//return functions::acosh(arg); }
+inline expr acosh(half arg) { return functions::acosh(arg); }
+inline expr acosh(expr arg) { return functions::acosh(arg); }
+
+/// Hyperbolic area tangent.
+/// \param arg function argument
+/// \return area tangent value of \a arg
+//		template<typename T> typename enable<expr,T>::type atanh(T arg) {
+//return functions::atanh(arg); }
+inline expr atanh(half arg) { return functions::atanh(arg); }
+inline expr atanh(expr arg) { return functions::atanh(arg); }
+
+/// \}
+/// \name Error and gamma functions
+/// \{
+
+/// Error function.
+/// \param arg function argument
+/// \return error function value of \a arg
+//		template<typename T> typename enable<expr,T>::type erf(T arg) {
+//return functions::erf(arg); }
+inline expr erf(half arg) { return functions::erf(arg); }
+inline expr erf(expr arg) { return functions::erf(arg); }
+
+/// Complementary error function.
+/// \param arg function argument
+/// \return 1 minus error function value of \a arg
+//		template<typename T> typename enable<expr,T>::type erfc(T arg) {
+//return functions::erfc(arg); }
+inline expr erfc(half arg) { return functions::erfc(arg); }
+inline expr erfc(expr arg) { return functions::erfc(arg); }
+
+/// Natural logarithm of gamma function.
+/// \param arg function argument
+/// \return natural logarith of gamma function for \a arg
+//		template<typename T> typename enable<expr,T>::type lgamma(T arg) {
+//return functions::lgamma(arg); }
+inline expr lgamma(half arg) { return functions::lgamma(arg); }
+inline expr lgamma(expr arg) { return functions::lgamma(arg); }
+
+/// Gamma function.
+/// \param arg function argument
+/// \return gamma function value of \a arg
+//		template<typename T> typename enable<expr,T>::type tgamma(T arg) {
+//return functions::tgamma(arg); }
+inline expr tgamma(half arg) { return functions::tgamma(arg); }
+inline expr tgamma(expr arg) { return functions::tgamma(arg); }
+
+/// \}
+/// \name Rounding
+/// \{
+
+/// Nearest integer not less than half value.
+/// \param arg half to round
+/// \return nearest integer not less than \a arg
+//		template<typename T> typename enable<half,T>::type ceil(T arg) {
+//return functions::ceil(arg); }
+inline half ceil(half arg) { return functions::ceil(arg); }
+inline half ceil(expr arg) { return functions::ceil(arg); }
+
+/// Nearest integer not greater than half value.
+/// \param arg half to round
+/// \return nearest integer not greater than \a arg
+//		template<typename T> typename enable<half,T>::type floor(T arg) {
+//return functions::floor(arg); }
+inline half floor(half arg) { return functions::floor(arg); }
+inline half floor(expr arg) { return functions::floor(arg); }
+
+/// Nearest integer not greater in magnitude than half value.
+/// \param arg half to round
+/// \return nearest integer not greater in magnitude than \a arg
+//		template<typename T> typename enable<half,T>::type trunc(T arg) {
+//return functions::trunc(arg); }
+inline half trunc(half arg) { return functions::trunc(arg); }
+inline half trunc(expr arg) { return functions::trunc(arg); }
+
+/// Nearest integer.
+/// \param arg half to round
+/// \return nearest integer, rounded away from zero in half-way cases
+//		template<typename T> typename enable<half,T>::type round(T arg) {
+//return functions::round(arg); }
+inline half round(half arg) { return functions::round(arg); }
+inline half round(expr arg) { return functions::round(arg); }
+
+/// Nearest integer.
+/// \param arg half to round
+/// \return nearest integer, rounded away from zero in half-way cases
+//		template<typename T> typename enable<long,T>::type lround(T arg) {
+//return functions::lround(arg); }
+inline long lround(half arg) { return functions::lround(arg); }
+inline long lround(expr arg) { return functions::lround(arg); }
+
+/// Nearest integer using half's internal rounding mode.
+/// \param arg half expression to round
+/// \return nearest integer using default rounding mode
+//		template<typename T> typename enable<half,T>::type nearbyint(T
+//arg) { return functions::nearbyint(arg); }
+inline half nearbyint(half arg) { return functions::rint(arg); }
+inline half nearbyint(expr arg) { return functions::rint(arg); }
+
+/// Nearest integer using half's internal rounding mode.
+/// \param arg half expression to round
+/// \return nearest integer using default rounding mode
+//		template<typename T> typename enable<half,T>::type rint(T arg) {
+//return functions::rint(arg); }
+inline half rint(half arg) { return functions::rint(arg); }
+inline half rint(expr arg) { return functions::rint(arg); }
+
+/// Nearest integer using half's internal rounding mode.
+/// \param arg half expression to round
+/// \return nearest integer using default rounding mode
+//		template<typename T> typename enable<long,T>::type lrint(T arg) {
+//return functions::lrint(arg); }
+inline long lrint(half arg) { return functions::lrint(arg); }
+inline long lrint(expr arg) { return functions::lrint(arg); }
+#if HALF_ENABLE_CPP11_LONG_LONG
+/// Nearest integer.
+/// \param arg half to round
+/// \return nearest integer, rounded away from zero in half-way cases
+//		template<typename T> typename enable<long long,T>::type llround(T
+//arg) { return functions::llround(arg); }
+inline long long llround(half arg) { return functions::llround(arg); }
+inline long long llround(expr arg) { return functions::llround(arg); }
+
+/// Nearest integer using half's internal rounding mode.
+/// \param arg half expression to round
+/// \return nearest integer using default rounding mode
+//		template<typename T> typename enable<long long,T>::type llrint(T
+//arg) { return functions::llrint(arg); }
+inline long long llrint(half arg) { return functions::llrint(arg); }
+inline long long llrint(expr arg) { return functions::llrint(arg); }
+#endif
+
+/// \}
+/// \name Floating point manipulation
+/// \{
+
+/// Decompress floating point number.
+/// \param arg number to decompress
+/// \param exp address to store exponent at
+/// \return significant in range [0.5, 1)
+//		template<typename T> typename enable<half,T>::type frexp(T arg,
+//int *exp) { return functions::frexp(arg, exp); }
+inline half frexp(half arg, int *exp) { return functions::frexp(arg, exp); }
+inline half frexp(expr arg, int *exp) { return functions::frexp(arg, exp); }
+
+/// Multiply by power of two.
+/// \param arg number to modify
+/// \param exp power of two to multiply with
+/// \return \a arg multplied by 2 raised to \a exp
+//		template<typename T> typename enable<half,T>::type ldexp(T arg,
+//int exp) { return functions::scalbln(arg, exp); }
+inline half ldexp(half arg, int exp) { return functions::scalbln(arg, exp); }
+inline half ldexp(expr arg, int exp) { return functions::scalbln(arg, exp); }
+
+/// Extract integer and fractional parts.
+/// \param arg number to decompress
+/// \param iptr address to store integer part at
+/// \return fractional part
+//		template<typename T> typename enable<half,T>::type modf(T arg,
+//half *iptr) { return functions::modf(arg, iptr); }
+inline half modf(half arg, half *iptr) { return functions::modf(arg, iptr); }
+inline half modf(expr arg, half *iptr) { return functions::modf(arg, iptr); }
+
+/// Multiply by power of two.
+/// \param arg number to modify
+/// \param exp power of two to multiply with
+/// \return \a arg multplied by 2 raised to \a exp
+//		template<typename T> typename enable<half,T>::type scalbn(T arg,
+//int exp) { return functions::scalbln(arg, exp); }
+inline half scalbn(half arg, int exp) { return functions::scalbln(arg, exp); }
+inline half scalbn(expr arg, int exp) { return functions::scalbln(arg, exp); }
+
+/// Multiply by power of two.
+/// \param arg number to modify
+/// \param exp power of two to multiply with
+/// \return \a arg multplied by 2 raised to \a exp
+//		template<typename T> typename enable<half,T>::type scalbln(T arg,
+//long exp) { return functions::scalbln(arg, exp); }
+inline half scalbln(half arg, long exp) { return functions::scalbln(arg, exp); }
+inline half scalbln(expr arg, long exp) { return functions::scalbln(arg, exp); }
+
+/// Extract exponent.
+/// \param arg number to query
+/// \return floating point exponent
+/// \retval FP_ILOGB0 for zero
+/// \retval FP_ILOGBNAN for NaN
+/// \retval MAX_INT for infinity
+//		template<typename T> typename enable<int,T>::type ilogb(T arg) {
+//return functions::ilogb(arg); }
+inline int ilogb(half arg) { return functions::ilogb(arg); }
+inline int ilogb(expr arg) { return functions::ilogb(arg); }
+
+/// Extract exponent.
+/// \param arg number to query
+/// \return floating point exponent
+//		template<typename T> typename enable<half,T>::type logb(T arg) {
+//return functions::logb(arg); }
+inline half logb(half arg) { return functions::logb(arg); }
+inline half logb(expr arg) { return functions::logb(arg); }
+
+/// Next representable value.
+/// \param from value to compute next representable value for
+/// \param to direction towards which to compute next value
+/// \return next representable value after \a from in direction towards \a to
+//		template<typename T,typename U> typename enable<half,T,U>::type
+//nextafter(T from, U to) { return functions::nextafter(from, to); }
+inline half nextafter(half from, half to) {
+  return functions::nextafter(from, to);
+}
+inline half nextafter(half from, expr to) {
+  return functions::nextafter(from, to);
+}
+inline half nextafter(expr from, half to) {
+  return functions::nextafter(from, to);
+}
+inline half nextafter(expr from, expr to) {
+  return functions::nextafter(from, to);
+}
+
+/// Next representable value.
+/// \param from value to compute next representable value for
+/// \param to direction towards which to compute next value
+/// \return next representable value after \a from in direction towards \a to
+//		template<typename T> typename enable<half,T>::type nexttoward(T
+//from, long double to) { return functions::nexttoward(from, to); }
+inline half nexttoward(half from, long double to) {
+  return functions::nexttoward(from, to);
+}
+inline half nexttoward(expr from, long double to) {
+  return functions::nexttoward(from, to);
+}
+
+/// Take sign.
+/// \param x value to change sign for
+/// \param y value to take sign from
+/// \return value equal to \a x in magnitude and to \a y in sign
+//		template<typename T,typename U> typename enable<half,T,U>::type
+//copysign(T x, U y) { return functions::copysign(x, y); }
+inline half copysign(half x, half y) { return functions::copysign(x, y); }
+inline half copysign(half x, expr y) { return functions::copysign(x, y); }
+inline half copysign(expr x, half y) { return functions::copysign(x, y); }
+inline half copysign(expr x, expr y) { return functions::copysign(x, y); }
+
+/// \}
+/// \name Floating point classification
+/// \{
+
+/// Classify floating point value.
+/// \param arg number to classify
+/// \retval FP_ZERO for positive and negative zero
+/// \retval FP_SUBNORMAL for subnormal numbers
+/// \retval FP_INFINITY for positive and negative infinity
+/// \retval FP_NAN for NaNs
+/// \retval FP_NORMAL for all other (normal) values
+//		template<typename T> typename enable<int,T>::type fpclassify(T
+//arg) { return functions::fpclassify(arg); }
+inline int fpclassify(half arg) { return functions::fpclassify(arg); }
+inline int fpclassify(expr arg) { return functions::fpclassify(arg); }
+
+/// Check if finite number.
+/// \param arg number to check
+/// \retval true if neither infinity nor NaN
+/// \retval false else
+//		template<typename T> typename enable<bool,T>::type isfinite(T arg)
+//{ return functions::isfinite(arg); }
+inline bool isfinite(half arg) { return functions::isfinite(arg); }
+inline bool isfinite(expr arg) { return functions::isfinite(arg); }
+
+/// Check for infinity.
+/// \param arg number to check
+/// \retval true for positive or negative infinity
+/// \retval false else
+//		template<typename T> typename enable<bool,T>::type isinf(T arg) {
+//return functions::isinf(arg); }
+inline bool isinf(half arg) { return functions::isinf(arg); }
+inline bool isinf(expr arg) { return functions::isinf(arg); }
+
+/// Check for NaN.
+/// \param arg number to check
+/// \retval true for NaNs
+/// \retval false else
+//		template<typename T> typename enable<bool,T>::type isnan(T arg) {
+//return functions::isnan(arg); }
+inline bool isnan(half arg) { return functions::isnan(arg); }
+inline bool isnan(expr arg) { return functions::isnan(arg); }
+
+/// Check if normal number.
+/// \param arg number to check
+/// \retval true if normal number
+/// \retval false if either subnormal, zero, infinity or NaN
+//		template<typename T> typename enable<bool,T>::type isnormal(T arg)
+//{ return functions::isnormal(arg); }
+inline bool isnormal(half arg) { return functions::isnormal(arg); }
+inline bool isnormal(expr arg) { return functions::isnormal(arg); }
+
+/// Check sign.
+/// \param arg number to check
+/// \retval true for negative number
+/// \retval false for positive number
+//		template<typename T> typename enable<bool,T>::type signbit(T arg)
+//{ return functions::signbit(arg); }
+inline bool signbit(half arg) { return functions::signbit(arg); }
+inline bool signbit(expr arg) { return functions::signbit(arg); }
+
+/// \}
+/// \name Comparison
+/// \{
+
+/// Comparison for greater than.
+/// \param x first operand
+/// \param y second operand
+/// \retval true if \a x greater than \a y
+/// \retval false else
+//		template<typename T,typename U> typename enable<bool,T,U>::type
+//isgreater(T x, U y) { return functions::isgreater(x, y); }
+inline bool isgreater(half x, half y) { return functions::isgreater(x, y); }
+inline bool isgreater(half x, expr y) { return functions::isgreater(x, y); }
+inline bool isgreater(expr x, half y) { return functions::isgreater(x, y); }
+inline bool isgreater(expr x, expr y) { return functions::isgreater(x, y); }
+
+/// Comparison for greater equal.
+/// \param x first operand
+/// \param y second operand
+/// \retval true if \a x greater equal \a y
+/// \retval false else
+//		template<typename T,typename U> typename enable<bool,T,U>::type
+//isgreaterequal(T x, U y) { return functions::isgreaterequal(x, y); }
+inline bool isgreaterequal(half x, half y) {
+  return functions::isgreaterequal(x, y);
+}
+inline bool isgreaterequal(half x, expr y) {
+  return functions::isgreaterequal(x, y);
+}
+inline bool isgreaterequal(expr x, half y) {
+  return functions::isgreaterequal(x, y);
+}
+inline bool isgreaterequal(expr x, expr y) {
+  return functions::isgreaterequal(x, y);
+}
+
+/// Comparison for less than.
+/// \param x first operand
+/// \param y second operand
+/// \retval true if \a x less than \a y
+/// \retval false else
+//		template<typename T,typename U> typename enable<bool,T,U>::type
+//isless(T x, U y) { return functions::isless(x, y); }
+inline bool isless(half x, half y) { return functions::isless(x, y); }
+inline bool isless(half x, expr y) { return functions::isless(x, y); }
+inline bool isless(expr x, half y) { return functions::isless(x, y); }
+inline bool isless(expr x, expr y) { return functions::isless(x, y); }
+
+/// Comparison for less equal.
+/// \param x first operand
+/// \param y second operand
+/// \retval true if \a x less equal \a y
+/// \retval false else
+//		template<typename T,typename U> typename enable<bool,T,U>::type
+//islessequal(T x, U y) { return functions::islessequal(x, y); }
+inline bool islessequal(half x, half y) { return functions::islessequal(x, y); }
+inline bool islessequal(half x, expr y) { return functions::islessequal(x, y); }
+inline bool islessequal(expr x, half y) { return functions::islessequal(x, y); }
+inline bool islessequal(expr x, expr y) { return functions::islessequal(x, y); }
+
+/// Comarison for less or greater.
+/// \param x first operand
+/// \param y second operand
+/// \retval true if either less or greater
+/// \retval false else
+//		template<typename T,typename U> typename enable<bool,T,U>::type
+//islessgreater(T x, U y) { return functions::islessgreater(x, y); }
+inline bool islessgreater(half x, half y) {
+  return functions::islessgreater(x, y);
+}
+inline bool islessgreater(half x, expr y) {
+  return functions::islessgreater(x, y);
+}
+inline bool islessgreater(expr x, half y) {
+  return functions::islessgreater(x, y);
+}
+inline bool islessgreater(expr x, expr y) {
+  return functions::islessgreater(x, y);
+}
+
+/// Check if unordered.
+/// \param x first operand
+/// \param y second operand
+/// \retval true if unordered (one or two NaN operands)
+/// \retval false else
+//		template<typename T,typename U> typename enable<bool,T,U>::type
+//isunordered(T x, U y) { return functions::isunordered(x, y); }
+inline bool isunordered(half x, half y) { return functions::isunordered(x, y); }
+inline bool isunordered(half x, expr y) { return functions::isunordered(x, y); }
+inline bool isunordered(expr x, half y) { return functions::isunordered(x, y); }
+inline bool isunordered(expr x, expr y) { return functions::isunordered(x, y); }
+
+/// \name Casting
+/// \{
+
+/// Cast to or from half-precision floating point number.
+/// This casts between [half](\ref half_float::half) and any built-in arithmetic
+/// type. The values are converted
+/// directly using the given rounding mode, without any roundtrip over `float`
+/// that a `static_cast` would otherwise do.
+/// It uses the default rounding mode.
+///
+/// Using this cast with neither of the two types being a [half](\ref
+/// half_float::half) or with any of the two types
+/// not being a built-in arithmetic type (apart from [half](\ref
+/// half_float::half), of course) results in a compiler
+/// error and casting between [half](\ref half_float::half)s is just a no-op.
+/// \tparam T destination type (half or built-in arithmetic type)
+/// \tparam U source type (half or built-in arithmetic type)
+/// \param arg value to cast
+/// \return \a arg converted to destination type
+template <typename T, typename U>
+T half_cast(U arg) {
+  return half_caster<T, U>::cast(arg);
+}
+
+/// Cast to or from half-precision floating point number.
+/// This casts between [half](\ref half_float::half) and any built-in arithmetic
+/// type. The values are converted
+/// directly using the given rounding mode, without any roundtrip over `float`
+/// that a `static_cast` would otherwise do.
+///
+/// Using this cast with neither of the two types being a [half](\ref
+/// half_float::half) or with any of the two types
+/// not being a built-in arithmetic type (apart from [half](\ref
+/// half_float::half), of course) results in a compiler
+/// error and casting between [half](\ref half_float::half)s is just a no-op.
+/// \tparam T destination type (half or built-in arithmetic type)
+/// \tparam R rounding mode to use.
+/// \tparam U source type (half or built-in arithmetic type)
+/// \param arg value to cast
+/// \return \a arg converted to destination type
+template <typename T, std::float_round_style R, typename U>
+T half_cast(U arg) {
+  return half_caster<T, U, R>::cast(arg);
+}
+/// \}
+}
+
+using detail::operator==;
+using detail::operator!=;
+using detail::operator<;
+using detail::operator>;
+using detail::operator<=;
+using detail::operator>=;
+using detail::operator+;
+using detail::operator-;
+using detail::operator*;
+using detail::operator/;
+using detail::operator<<;
+using detail::operator>>;
+
+using detail::abs;
+using detail::fabs;
+using detail::fmod;
+using detail::remainder;
+using detail::remquo;
+using detail::fma;
+using detail::fmax;
+using detail::fmin;
+using detail::fdim;
+using detail::nanh;
+using detail::exp;
+using detail::expm1;
+using detail::exp2;
+using detail::log;
+using detail::log10;
+using detail::log1p;
+using detail::log2;
+using detail::sqrt;
+using detail::cbrt;
+using detail::hypot;
+using detail::pow;
+using detail::sin;
+using detail::cos;
+using detail::tan;
+using detail::asin;
+using detail::acos;
+using detail::atan;
+using detail::atan2;
+using detail::sinh;
+using detail::cosh;
+using detail::tanh;
+using detail::asinh;
+using detail::acosh;
+using detail::atanh;
+using detail::erf;
+using detail::erfc;
+using detail::lgamma;
+using detail::tgamma;
+using detail::ceil;
+using detail::floor;
+using detail::trunc;
+using detail::round;
+using detail::lround;
+using detail::nearbyint;
+using detail::rint;
+using detail::lrint;
+#if HALF_ENABLE_CPP11_LONG_LONG
+using detail::llround;
+using detail::llrint;
+#endif
+using detail::frexp;
+using detail::ldexp;
+using detail::modf;
+using detail::scalbn;
+using detail::scalbln;
+using detail::ilogb;
+using detail::logb;
+using detail::nextafter;
+using detail::nexttoward;
+using detail::copysign;
+using detail::fpclassify;
+using detail::isfinite;
+using detail::isinf;
+using detail::isnan;
+using detail::isnormal;
+using detail::signbit;
+using detail::isgreater;
+using detail::isgreaterequal;
+using detail::isless;
+using detail::islessequal;
+using detail::islessgreater;
+using detail::isunordered;
+
+using detail::half_cast;
+}
 
 /// Extensions to the C++ standard library.
-namespace std
-{
-	/// Numeric limits for half-precision floats.
-	/// Because of the underlying single-precision implementation of many operations, it inherits some properties from 
-	/// `std::numeric_limits<float>`.
-	template<> class numeric_limits<half_float::half> : public numeric_limits<float>
-	{
-	public:
-		/// Supports signed values.
-		static HALF_CONSTEXPR_CONST bool is_signed = true;
+namespace std {
+/// Numeric limits for half-precision floats.
+/// Because of the underlying single-precision implementation of many
+/// operations, it inherits some properties from
+/// `std::numeric_limits<float>`.
+template <>
+class numeric_limits<half_float::half> : public numeric_limits<float> {
+ public:
+  /// Supports signed values.
+  static HALF_CONSTEXPR_CONST bool is_signed = true;
 
-		/// Is not exact.
-		static HALF_CONSTEXPR_CONST bool is_exact = false;
+  /// Is not exact.
+  static HALF_CONSTEXPR_CONST bool is_exact = false;
 
-		/// Doesn't provide modulo arithmetic.
-		static HALF_CONSTEXPR_CONST bool is_modulo = false;
+  /// Doesn't provide modulo arithmetic.
+  static HALF_CONSTEXPR_CONST bool is_modulo = false;
 
-		/// IEEE conformant.
-		static HALF_CONSTEXPR_CONST bool is_iec559 = true;
+  /// IEEE conformant.
+  static HALF_CONSTEXPR_CONST bool is_iec559 = true;
 
-		/// Supports infinity.
-		static HALF_CONSTEXPR_CONST bool has_infinity = true;
+  /// Supports infinity.
+  static HALF_CONSTEXPR_CONST bool has_infinity = true;
 
-		/// Supports quiet NaNs.
-		static HALF_CONSTEXPR_CONST bool has_quiet_NaN = true;
+  /// Supports quiet NaNs.
+  static HALF_CONSTEXPR_CONST bool has_quiet_NaN = true;
 
-		/// Supports subnormal values.
-		static HALF_CONSTEXPR_CONST float_denorm_style has_denorm = denorm_present;
+  /// Supports subnormal values.
+  static HALF_CONSTEXPR_CONST float_denorm_style has_denorm = denorm_present;
 
-		/// Rounding mode.
-		/// Due to the mix of internal single-precision computations (using the rounding mode of the underlying 
-		/// single-precision implementation) with the rounding mode of the single-to-half conversions, the actual rounding 
-		/// mode might be `std::round_indeterminate` if the default half-precision rounding mode doesn't match the 
-		/// single-precision rounding mode.
-		static HALF_CONSTEXPR_CONST float_round_style round_style = (std::numeric_limits<float>::round_style==
-			half_float::half::round_style) ? half_float::half::round_style : round_indeterminate;
+  /// Rounding mode.
+  /// Due to the mix of internal single-precision computations (using the
+  /// rounding mode of the underlying
+  /// single-precision implementation) with the rounding mode of the
+  /// single-to-half conversions, the actual rounding
+  /// mode might be `std::round_indeterminate` if the default half-precision
+  /// rounding mode doesn't match the
+  /// single-precision rounding mode.
+  static HALF_CONSTEXPR_CONST float_round_style round_style =
+      (std::numeric_limits<float>::round_style == half_float::half::round_style)
+          ? half_float::half::round_style
+          : round_indeterminate;
 
-		/// Significant digits.
-		static HALF_CONSTEXPR_CONST int digits = 11;
+  /// Significant digits.
+  static HALF_CONSTEXPR_CONST int digits = 11;
 
-		/// Significant decimal digits.
-		static HALF_CONSTEXPR_CONST int digits10 = 3;
+  /// Significant decimal digits.
+  static HALF_CONSTEXPR_CONST int digits10 = 3;
 
-		/// Required decimal digits to represent all possible values.
-		static HALF_CONSTEXPR_CONST int max_digits10 = 5;
+  /// Required decimal digits to represent all possible values.
+  static HALF_CONSTEXPR_CONST int max_digits10 = 5;
 
-		/// Number base.
-		static HALF_CONSTEXPR_CONST int radix = 2;
+  /// Number base.
+  static HALF_CONSTEXPR_CONST int radix = 2;
 
-		/// One more than smallest exponent.
-		static HALF_CONSTEXPR_CONST int min_exponent = -13;
+  /// One more than smallest exponent.
+  static HALF_CONSTEXPR_CONST int min_exponent = -13;
 
-		/// Smallest normalized representable power of 10.
-		static HALF_CONSTEXPR_CONST int min_exponent10 = -4;
+  /// Smallest normalized representable power of 10.
+  static HALF_CONSTEXPR_CONST int min_exponent10 = -4;
 
-		/// One more than largest exponent
-		static HALF_CONSTEXPR_CONST int max_exponent = 16;
+  /// One more than largest exponent
+  static HALF_CONSTEXPR_CONST int max_exponent = 16;
 
-		/// Largest finitely representable power of 10.
-		static HALF_CONSTEXPR_CONST int max_exponent10 = 4;
+  /// Largest finitely representable power of 10.
+  static HALF_CONSTEXPR_CONST int max_exponent10 = 4;
 
-		/// Smallest positive normal value.
-		static HALF_CONSTEXPR half_float::half min() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0x0400); }
+  /// Smallest positive normal value.
+  static HALF_CONSTEXPR half_float::half min() HALF_NOTHROW {
+    return half_float::half(half_float::detail::binary, 0x0400);
+  }
 
-		/// Smallest finite value.
-		static HALF_CONSTEXPR half_float::half lowest() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0xFBFF); }
+  /// Smallest finite value.
+  static HALF_CONSTEXPR half_float::half lowest() HALF_NOTHROW {
+    return half_float::half(half_float::detail::binary, 0xFBFF);
+  }
 
-		/// Largest finite value.
-		static HALF_CONSTEXPR half_float::half max() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0x7BFF); }
+  /// Largest finite value.
+  static HALF_CONSTEXPR half_float::half max() HALF_NOTHROW {
+    return half_float::half(half_float::detail::binary, 0x7BFF);
+  }
 
-		/// Difference between one and next representable value.
-		static HALF_CONSTEXPR half_float::half epsilon() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0x1400); }
+  /// Difference between one and next representable value.
+  static HALF_CONSTEXPR half_float::half epsilon() HALF_NOTHROW {
+    return half_float::half(half_float::detail::binary, 0x1400);
+  }
 
-		/// Maximum rounding error.
-		static HALF_CONSTEXPR half_float::half round_error() HALF_NOTHROW
-			{ return half_float::half(half_float::detail::binary, (round_style==std::round_to_nearest) ? 0x3800 : 0x3C00); }
+  /// Maximum rounding error.
+  static HALF_CONSTEXPR half_float::half round_error() HALF_NOTHROW {
+    return half_float::half(
+        half_float::detail::binary,
+        (round_style == std::round_to_nearest) ? 0x3800 : 0x3C00);
+  }
 
-		/// Positive infinity.
-		static HALF_CONSTEXPR half_float::half infinity() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0x7C00); }
+  /// Positive infinity.
+  static HALF_CONSTEXPR half_float::half infinity() HALF_NOTHROW {
+    return half_float::half(half_float::detail::binary, 0x7C00);
+  }
 
-		/// Quiet NaN.
-		static HALF_CONSTEXPR half_float::half quiet_NaN() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0x7FFF); }
+  /// Quiet NaN.
+  static HALF_CONSTEXPR half_float::half quiet_NaN() HALF_NOTHROW {
+    return half_float::half(half_float::detail::binary, 0x7FFF);
+  }
 
-		/// Signalling NaN.
-		static HALF_CONSTEXPR half_float::half signaling_NaN() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0x7DFF); }
+  /// Signalling NaN.
+  static HALF_CONSTEXPR half_float::half signaling_NaN() HALF_NOTHROW {
+    return half_float::half(half_float::detail::binary, 0x7DFF);
+  }
 
-		/// Smallest positive subnormal value.
-		static HALF_CONSTEXPR half_float::half denorm_min() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0x0001); }
-	};
+  /// Smallest positive subnormal value.
+  static HALF_CONSTEXPR half_float::half denorm_min() HALF_NOTHROW {
+    return half_float::half(half_float::detail::binary, 0x0001);
+  }
+};
 
 #if HALF_ENABLE_CPP11_HASH
-	/// Hash function for half-precision floats.
-	/// This is only defined if C++11 `std::hash` is supported and enabled.
-	template<> struct hash<half_float::half> //: unary_function<half_float::half,size_t>
-	{
-		/// Type of function argument.
-		typedef half_float::half argument_type;
+/// Hash function for half-precision floats.
+/// This is only defined if C++11 `std::hash` is supported and enabled.
+template <>
+struct hash<half_float::half>  //: unary_function<half_float::half,size_t>
+{
+  /// Type of function argument.
+  typedef half_float::half argument_type;
 
-		/// Function return type.
-		typedef size_t result_type;
+  /// Function return type.
+  typedef size_t result_type;
 
-		/// Compute hash function.
-		/// \param arg half to hash
-		/// \return hash value
-		result_type operator()(argument_type arg) const
-			{ return hash<half_float::detail::uint16>()(static_cast<unsigned>(arg.data_)&-(arg.data_!=0x8000)); }
-	};
+  /// Compute hash function.
+  /// \param arg half to hash
+  /// \return hash value
+  result_type operator()(argument_type arg) const {
+    return hash<half_float::detail::uint16>()(static_cast<unsigned>(arg.data_) &
+                                              -(arg.data_ != 0x8000));
+  }
+};
 #endif
 }
-
 
 #undef HALF_CONSTEXPR
 #undef HALF_CONSTEXPR_CONST
 #undef HALF_NOEXCEPT
 #undef HALF_NOTHROW
 #ifdef HALF_POP_WARNINGS
-	#pragma warning(pop)
-	#undef HALF_POP_WARNINGS
+#pragma warning(pop)
+#undef HALF_POP_WARNINGS
 #endif
 
 #endif

--- a/src/cuda-sim/half.h
+++ b/src/cuda-sim/half.h
@@ -2,25 +2,17 @@
 //
 // Copyright (c) 2012-2017 Christian Rau <rauy@users.sourceforge.net>
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation
-// files (the "Software"), to deal in the Software without restriction,
-// including without limitation the rights to use, copy,
-// modify, merge, publish, distribute, sublicense, and/or sell copies of the
-// Software, and to permit persons to whom the
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation 
+// files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, 
+// modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the 
 // Software is furnished to do so, subject to the following conditions:
 //
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 //
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE
-// WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-// DEALINGS IN THE SOFTWARE.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE 
+// WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, 
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // Version 1.12.0
 
@@ -31,191 +23,180 @@
 #define HALF_HALF_HPP
 
 /// Combined gcc version number.
-#define HALF_GNUC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
+#define HALF_GNUC_VERSION (__GNUC__*100+__GNUC_MINOR__)
 
-// check C++11 language features
-#if defined(__clang__)  // clang
-#if __has_feature(cxx_static_assert) && \
-    !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)
-#define HALF_ENABLE_CPP11_STATIC_ASSERT 1
-#endif
-#if __has_feature(cxx_constexpr) && !defined(HALF_ENABLE_CPP11_CONSTEXPR)
-#define HALF_ENABLE_CPP11_CONSTEXPR 1
-#endif
-#if __has_feature(cxx_noexcept) && !defined(HALF_ENABLE_CPP11_NOEXCEPT)
-#define HALF_ENABLE_CPP11_NOEXCEPT 1
-#endif
-#if __has_feature(cxx_user_literals) && \
-    !defined(HALF_ENABLE_CPP11_USER_LITERALS)
-#define HALF_ENABLE_CPP11_USER_LITERALS 1
-#endif
-#if (defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L) && \
-    !defined(HALF_ENABLE_CPP11_LONG_LONG)
-#define HALF_ENABLE_CPP11_LONG_LONG 1
-#endif
-/*#elif defined(__INTEL_COMPILER)
-   //Intel C++
-        #if __INTEL_COMPILER >= 1100 &&
-   !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)		????????
-                #define HALF_ENABLE_CPP11_STATIC_ASSERT 1
-        #endif
-        #if __INTEL_COMPILER >= 1300 && !defined(HALF_ENABLE_CPP11_CONSTEXPR)
-   ????????
-                #define HALF_ENABLE_CPP11_CONSTEXPR 1
-        #endif
-        #if __INTEL_COMPILER >= 1300 && !defined(HALF_ENABLE_CPP11_NOEXCEPT)
-   ????????
-                #define HALF_ENABLE_CPP11_NOEXCEPT 1
-        #endif
-        #if __INTEL_COMPILER >= 1100 && !defined(HALF_ENABLE_CPP11_LONG_LONG)
-   ????????
-                #define HALF_ENABLE_CPP11_LONG_LONG 1
-        #endif*/
-#elif defined(__GNUC__)  // gcc
-#if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L
-#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)
-#define HALF_ENABLE_CPP11_STATIC_ASSERT 1
-#endif
-#if HALF_GNUC_VERSION >= 406 && !defined(HALF_ENABLE_CPP11_CONSTEXPR)
-#define HALF_ENABLE_CPP11_CONSTEXPR 1
-#endif
-#if HALF_GNUC_VERSION >= 406 && !defined(HALF_ENABLE_CPP11_NOEXCEPT)
-#define HALF_ENABLE_CPP11_NOEXCEPT 1
-#endif
-#if HALF_GNUC_VERSION >= 407 && !defined(HALF_ENABLE_CPP11_USER_LITERALS)
-#define HALF_ENABLE_CPP11_USER_LITERALS 1
-#endif
-#if !defined(HALF_ENABLE_CPP11_LONG_LONG)
-#define HALF_ENABLE_CPP11_LONG_LONG 1
-#endif
-#endif
-#elif defined(_MSC_VER)  // Visual C++
-#if _MSC_VER >= 1900 && !defined(HALF_ENABLE_CPP11_CONSTEXPR)
-#define HALF_ENABLE_CPP11_CONSTEXPR 1
-#endif
-#if _MSC_VER >= 1900 && !defined(HALF_ENABLE_CPP11_NOEXCEPT)
-#define HALF_ENABLE_CPP11_NOEXCEPT 1
-#endif
-#if _MSC_VER >= 1900 && !defined(HALF_ENABLE_CPP11_USER_LITERALS)
-#define HALF_ENABLE_CPP11_USER_LITERALS 1
-#endif
-#if _MSC_VER >= 1600 && !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)
-#define HALF_ENABLE_CPP11_STATIC_ASSERT 1
-#endif
-#if _MSC_VER >= 1310 && !defined(HALF_ENABLE_CPP11_LONG_LONG)
-#define HALF_ENABLE_CPP11_LONG_LONG 1
-#endif
-#define HALF_POP_WARNINGS 1
-#pragma warning(push)
-#pragma warning(disable : 4099 4127 4146)  // struct vs class, constant in if,
-                                           // negative unsigned
+//check C++11 language features
+#if defined(__clang__)										//clang
+	#if __has_feature(cxx_static_assert) && !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)
+		#define HALF_ENABLE_CPP11_STATIC_ASSERT 1
+	#endif
+	#if __has_feature(cxx_constexpr) && !defined(HALF_ENABLE_CPP11_CONSTEXPR)
+		#define HALF_ENABLE_CPP11_CONSTEXPR 1
+	#endif
+	#if __has_feature(cxx_noexcept) && !defined(HALF_ENABLE_CPP11_NOEXCEPT)
+		#define HALF_ENABLE_CPP11_NOEXCEPT 1
+	#endif
+	#if __has_feature(cxx_user_literals) && !defined(HALF_ENABLE_CPP11_USER_LITERALS)
+		#define HALF_ENABLE_CPP11_USER_LITERALS 1
+	#endif
+	#if (defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L) && !defined(HALF_ENABLE_CPP11_LONG_LONG)
+		#define HALF_ENABLE_CPP11_LONG_LONG 1
+	#endif
+/*#elif defined(__INTEL_COMPILER)								//Intel C++
+	#if __INTEL_COMPILER >= 1100 && !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)		????????
+		#define HALF_ENABLE_CPP11_STATIC_ASSERT 1
+	#endif
+	#if __INTEL_COMPILER >= 1300 && !defined(HALF_ENABLE_CPP11_CONSTEXPR)			????????
+		#define HALF_ENABLE_CPP11_CONSTEXPR 1
+	#endif
+	#if __INTEL_COMPILER >= 1300 && !defined(HALF_ENABLE_CPP11_NOEXCEPT)			????????
+		#define HALF_ENABLE_CPP11_NOEXCEPT 1
+	#endif
+	#if __INTEL_COMPILER >= 1100 && !defined(HALF_ENABLE_CPP11_LONG_LONG)			????????
+		#define HALF_ENABLE_CPP11_LONG_LONG 1
+	#endif*/
+#elif defined(__GNUC__)										//gcc
+	#if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L
+		#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)
+			#define HALF_ENABLE_CPP11_STATIC_ASSERT 1
+		#endif
+		#if HALF_GNUC_VERSION >= 406 && !defined(HALF_ENABLE_CPP11_CONSTEXPR)
+			#define HALF_ENABLE_CPP11_CONSTEXPR 1
+		#endif
+		#if HALF_GNUC_VERSION >= 406 && !defined(HALF_ENABLE_CPP11_NOEXCEPT)
+			#define HALF_ENABLE_CPP11_NOEXCEPT 1
+		#endif
+		#if HALF_GNUC_VERSION >= 407 && !defined(HALF_ENABLE_CPP11_USER_LITERALS)
+			#define HALF_ENABLE_CPP11_USER_LITERALS 1
+		#endif
+		#if !defined(HALF_ENABLE_CPP11_LONG_LONG)
+			#define HALF_ENABLE_CPP11_LONG_LONG 1
+		#endif
+	#endif
+#elif defined(_MSC_VER)										//Visual C++
+	#if _MSC_VER >= 1900 && !defined(HALF_ENABLE_CPP11_CONSTEXPR)
+		#define HALF_ENABLE_CPP11_CONSTEXPR 1
+	#endif
+	#if _MSC_VER >= 1900 && !defined(HALF_ENABLE_CPP11_NOEXCEPT)
+		#define HALF_ENABLE_CPP11_NOEXCEPT 1
+	#endif
+	#if _MSC_VER >= 1900 && !defined(HALF_ENABLE_CPP11_USER_LITERALS)
+		#define HALF_ENABLE_CPP11_USER_LITERALS 1
+	#endif
+	#if _MSC_VER >= 1600 && !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)
+		#define HALF_ENABLE_CPP11_STATIC_ASSERT 1
+	#endif
+	#if _MSC_VER >= 1310 && !defined(HALF_ENABLE_CPP11_LONG_LONG)
+		#define HALF_ENABLE_CPP11_LONG_LONG 1
+	#endif
+	#define HALF_POP_WARNINGS 1
+	#pragma warning(push)
+	#pragma warning(disable : 4099 4127 4146)	//struct vs class, constant in if, negative unsigned
 #endif
 
-// check C++11 library features
+//check C++11 library features
 #include <utility>
-#if defined(_LIBCPP_VERSION)  // libc++
-#if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103
-#ifndef HALF_ENABLE_CPP11_TYPE_TRAITS
-#define HALF_ENABLE_CPP11_TYPE_TRAITS 1
-#endif
-#ifndef HALF_ENABLE_CPP11_CSTDINT
-#define HALF_ENABLE_CPP11_CSTDINT 1
-#endif
-#ifndef HALF_ENABLE_CPP11_CMATH
-#define HALF_ENABLE_CPP11_CMATH 1
-#endif
-#ifndef HALF_ENABLE_CPP11_HASH
-#define HALF_ENABLE_CPP11_HASH 1
-#endif
-#endif
-#elif defined(__GLIBCXX__)  // libstdc++
-#if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103
-#ifdef __clang__
-#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_TYPE_TRAITS)
-#define HALF_ENABLE_CPP11_TYPE_TRAITS 1
-#endif
-#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_CSTDINT)
-#define HALF_ENABLE_CPP11_CSTDINT 1
-#endif
-#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_CMATH)
-#define HALF_ENABLE_CPP11_CMATH 1
-#endif
-#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_HASH)
-#define HALF_ENABLE_CPP11_HASH 1
-#endif
-#else
-#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_CSTDINT)
-#define HALF_ENABLE_CPP11_CSTDINT 1
-#endif
-#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_CMATH)
-#define HALF_ENABLE_CPP11_CMATH 1
-#endif
-#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_HASH)
-#define HALF_ENABLE_CPP11_HASH 1
-#endif
-#endif
-#endif
-#elif defined(_CPPLIB_VER)  // Dinkumware/Visual C++
-#if _CPPLIB_VER >= 520
-#ifndef HALF_ENABLE_CPP11_TYPE_TRAITS
-#define HALF_ENABLE_CPP11_TYPE_TRAITS 1
-#endif
-#ifndef HALF_ENABLE_CPP11_CSTDINT
-#define HALF_ENABLE_CPP11_CSTDINT 1
-#endif
-#ifndef HALF_ENABLE_CPP11_HASH
-#define HALF_ENABLE_CPP11_HASH 1
-#endif
-#endif
-#if _CPPLIB_VER >= 610
-#ifndef HALF_ENABLE_CPP11_CMATH
-#define HALF_ENABLE_CPP11_CMATH 1
-#endif
-#endif
+#if defined(_LIBCPP_VERSION)								//libc++
+	#if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103
+		#ifndef HALF_ENABLE_CPP11_TYPE_TRAITS
+			#define HALF_ENABLE_CPP11_TYPE_TRAITS 1
+		#endif
+		#ifndef HALF_ENABLE_CPP11_CSTDINT
+			#define HALF_ENABLE_CPP11_CSTDINT 1
+		#endif
+		#ifndef HALF_ENABLE_CPP11_CMATH
+			#define HALF_ENABLE_CPP11_CMATH 1
+		#endif
+		#ifndef HALF_ENABLE_CPP11_HASH
+			#define HALF_ENABLE_CPP11_HASH 1
+		#endif
+	#endif
+#elif defined(__GLIBCXX__)									//libstdc++
+	#if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103
+		#ifdef __clang__
+			#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_TYPE_TRAITS)
+				#define HALF_ENABLE_CPP11_TYPE_TRAITS 1
+			#endif
+			#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_CSTDINT)
+				#define HALF_ENABLE_CPP11_CSTDINT 1
+			#endif
+			#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_CMATH)
+				#define HALF_ENABLE_CPP11_CMATH 1
+			#endif
+			#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_HASH)
+				#define HALF_ENABLE_CPP11_HASH 1
+			#endif
+		#else
+			#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_CSTDINT)
+				#define HALF_ENABLE_CPP11_CSTDINT 1
+			#endif
+			#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_CMATH)
+				#define HALF_ENABLE_CPP11_CMATH 1
+			#endif
+			#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_HASH)
+				#define HALF_ENABLE_CPP11_HASH 1
+			#endif
+		#endif
+	#endif
+#elif defined(_CPPLIB_VER)									//Dinkumware/Visual C++
+	#if _CPPLIB_VER >= 520
+		#ifndef HALF_ENABLE_CPP11_TYPE_TRAITS
+			#define HALF_ENABLE_CPP11_TYPE_TRAITS 1
+		#endif
+		#ifndef HALF_ENABLE_CPP11_CSTDINT
+			#define HALF_ENABLE_CPP11_CSTDINT 1
+		#endif
+		#ifndef HALF_ENABLE_CPP11_HASH
+			#define HALF_ENABLE_CPP11_HASH 1
+		#endif
+	#endif
+	#if _CPPLIB_VER >= 610
+		#ifndef HALF_ENABLE_CPP11_CMATH
+			#define HALF_ENABLE_CPP11_CMATH 1
+		#endif
+	#endif
 #endif
 #undef HALF_GNUC_VERSION
 
-// support constexpr
+//support constexpr
 #if HALF_ENABLE_CPP11_CONSTEXPR
-#define HALF_CONSTEXPR constexpr
-#define HALF_CONSTEXPR_CONST constexpr
+	#define HALF_CONSTEXPR			constexpr
+	#define HALF_CONSTEXPR_CONST	constexpr
 #else
-#define HALF_CONSTEXPR
-#define HALF_CONSTEXPR_CONST const
+	#define HALF_CONSTEXPR
+	#define HALF_CONSTEXPR_CONST	const
 #endif
 
-// support noexcept
+//support noexcept
 #if HALF_ENABLE_CPP11_NOEXCEPT
-#define HALF_NOEXCEPT noexcept
-#define HALF_NOTHROW noexcept
+	#define HALF_NOEXCEPT	noexcept
+	#define HALF_NOTHROW	noexcept
 #else
-#define HALF_NOEXCEPT
-#define HALF_NOTHROW throw()
+	#define HALF_NOEXCEPT
+	#define HALF_NOTHROW	throw()
 #endif
 
 #include <algorithm>
+#include <iostream>
+#include <limits>
 #include <climits>
 #include <cmath>
 #include <cstring>
-#include <iostream>
-#include <limits>
 #if HALF_ENABLE_CPP11_TYPE_TRAITS
-#include <type_traits>
+	#include <type_traits>
 #endif
 #if HALF_ENABLE_CPP11_CSTDINT
-#include <cstdint>
+	#include <cstdint>
 #endif
 #if HALF_ENABLE_CPP11_HASH
-#include <functional>
+	#include <functional>
 #endif
 
+
 /// Default rounding mode.
-/// This specifies the rounding mode used for all conversions between
-/// [half](\ref half_float::half)s and `float`s as well as
-/// for the half_cast() if not specifying a rounding mode explicitly. It can be
-/// redefined (before including half.hpp) to one
-/// of the standard rounding modes using their respective constants or the
-/// equivalent values of `std::float_round_style`:
+/// This specifies the rounding mode used for all conversions between [half](\ref half_float::half)s and `float`s as well as 
+/// for the half_cast() if not specifying a rounding mode explicitly. It can be redefined (before including half.hpp) to one 
+/// of the standard rounding modes using their respective constants or the equivalent values of `std::float_round_style`:
 ///
 /// `std::float_round_style`         | value | rounding
 /// ---------------------------------|-------|-------------------------
@@ -225,354 +206,256 @@
 /// `std::round_toward_infinity`     | 2     | toward positive infinity
 /// `std::round_toward_neg_infinity` | 3     | toward negative infinity
 ///
-/// By default this is set to `-1` (`std::round_indeterminate`), which uses
-/// truncation (round toward zero, but with overflows
-/// set to infinity) and is the fastest rounding mode possible. It can even be
-/// set to `std::numeric_limits<float>::round_style`
-/// to synchronize the rounding mode with that of the underlying
-/// single-precision implementation.
+/// By default this is set to `-1` (`std::round_indeterminate`), which uses truncation (round toward zero, but with overflows 
+/// set to infinity) and is the fastest rounding mode possible. It can even be set to `std::numeric_limits<float>::round_style` 
+/// to synchronize the rounding mode with that of the underlying single-precision implementation.
 #ifndef HALF_ROUND_STYLE
-#define HALF_ROUND_STYLE -1  // = std::round_indeterminate
+	#define HALF_ROUND_STYLE	-1			// = std::round_indeterminate
 #endif
 
 /// Tie-breaking behaviour for round to nearest.
-/// This specifies if ties in round to nearest should be resolved by rounding to
-/// the nearest even value. By default this is
-/// defined to `0` resulting in the faster but slightly more biased behaviour of
-/// rounding away from zero in half-way cases (and
-/// thus equal to the round() function), but can be redefined to `1` (before
-/// including half.hpp) if more IEEE-conformant
+/// This specifies if ties in round to nearest should be resolved by rounding to the nearest even value. By default this is 
+/// defined to `0` resulting in the faster but slightly more biased behaviour of rounding away from zero in half-way cases (and 
+/// thus equal to the round() function), but can be redefined to `1` (before including half.hpp) if more IEEE-conformant 
 /// behaviour is needed.
 #ifndef HALF_ROUND_TIES_TO_EVEN
-#define HALF_ROUND_TIES_TO_EVEN 0  // ties away from zero
+	#define HALF_ROUND_TIES_TO_EVEN	0		// ties away from zero
 #endif
 
 /// Value signaling overflow.
-/// In correspondence with `HUGE_VAL[F|L]` from `<cmath>` this symbol expands to
-/// a positive value signaling the overflow of an
+/// In correspondence with `HUGE_VAL[F|L]` from `<cmath>` this symbol expands to a positive value signaling the overflow of an 
 /// operation, in particular it just evaluates to positive infinity.
-#define HUGE_VALH std::numeric_limits<half_float::half>::infinity()
+#define HUGE_VALH	std::numeric_limits<half_float::half>::infinity()
 
 /// Fast half-precision fma function.
-/// This symbol is only defined if the fma() function generally executes as fast
-/// as, or faster than, a separate
-/// half-precision multiplication followed by an addition. Due to the internal
-/// single-precision implementation of all
+/// This symbol is only defined if the fma() function generally executes as fast as, or faster than, a separate 
+/// half-precision multiplication followed by an addition. Due to the internal single-precision implementation of all 
 /// arithmetic operations, this is in fact always the case.
-#define FP_FAST_FMAH 1
+#define FP_FAST_FMAH	1
 
 #ifndef FP_ILOGB0
-#define FP_ILOGB0 INT_MIN
+	#define FP_ILOGB0		INT_MIN
 #endif
 #ifndef FP_ILOGBNAN
-#define FP_ILOGBNAN INT_MAX
+	#define FP_ILOGBNAN		INT_MAX
 #endif
 #ifndef FP_SUBNORMAL
-#define FP_SUBNORMAL 0
+	#define FP_SUBNORMAL	0
 #endif
 #ifndef FP_ZERO
-#define FP_ZERO 1
+	#define FP_ZERO			1
 #endif
 #ifndef FP_NAN
-#define FP_NAN 2
+	#define FP_NAN			2
 #endif
 #ifndef FP_INFINITE
-#define FP_INFINITE 3
+	#define FP_INFINITE		3
 #endif
 #ifndef FP_NORMAL
-#define FP_NORMAL 4
+	#define FP_NORMAL		4
 #endif
+
 
 /// Main namespace for half precision functionality.
 /// This namespace contains all the functionality provided by the library.
-namespace half_float {
-class half;
+namespace half_float
+{
+	class half;
 
 #if HALF_ENABLE_CPP11_USER_LITERALS
-/// Library-defined half-precision literals.
-/// Import this namespace to enable half-precision floating point literals:
-/// ~~~~{.cpp}
-/// using namespace half_float::literal;
-/// half_float::half = 4.2_h;
-/// ~~~~
-namespace literal {
-half operator"" _h(long double);
-}
+	/// Library-defined half-precision literals.
+	/// Import this namespace to enable half-precision floating point literals:
+	/// ~~~~{.cpp}
+	/// using namespace half_float::literal;
+	/// half_float::half = 4.2_h;
+	/// ~~~~
+	namespace literal
+	{
+		half operator"" _h(long double);
+	}
 #endif
 
-/// \internal
-/// \brief Implementation details.
-namespace detail {
-#if HALF_ENABLE_CPP11_TYPE_TRAITS
-/// Conditional type.
-template <bool B, typename T, typename F>
-struct conditional : std::conditional<B, T, F> {};
+	/// \internal
+	/// \brief Implementation details.
+	namespace detail
+	{
+	#if HALF_ENABLE_CPP11_TYPE_TRAITS
+		/// Conditional type.
+		template<bool B,typename T,typename F> struct conditional : std::conditional<B,T,F> {};
 
-/// Helper for tag dispatching.
-template <bool B>
-struct bool_type : std::integral_constant<bool, B> {};
-using std::true_type;
-using std::false_type;
+		/// Helper for tag dispatching.
+		template<bool B> struct bool_type : std::integral_constant<bool,B> {};
+		using std::true_type;
+		using std::false_type;
 
-/// Type traits for floating point types.
-template <typename T>
-struct is_float : std::is_floating_point<T> {};
-#else
-/// Conditional type.
-template <bool, typename T, typename>
-struct conditional {
-  typedef T type;
-};
-template <typename T, typename F>
-struct conditional<false, T, F> {
-  typedef F type;
-};
+		/// Type traits for floating point types.
+		template<typename T> struct is_float : std::is_floating_point<T> {};
+	#else
+		/// Conditional type.
+		template<bool,typename T,typename> struct conditional { typedef T type; };
+		template<typename T,typename F> struct conditional<false,T,F> { typedef F type; };
 
-/// Helper for tag dispatching.
-template <bool>
-struct bool_type {};
-typedef bool_type<true> true_type;
-typedef bool_type<false> false_type;
+		/// Helper for tag dispatching.
+		template<bool> struct bool_type {};
+		typedef bool_type<true> true_type;
+		typedef bool_type<false> false_type;
 
-/// Type traits for floating point types.
-template <typename>
-struct is_float : false_type {};
-template <typename T>
-struct is_float<const T> : is_float<T> {};
-template <typename T>
-struct is_float<volatile T> : is_float<T> {};
-template <typename T>
-struct is_float<const volatile T> : is_float<T> {};
-template <>
-struct is_float<float> : true_type {};
-template <>
-struct is_float<double> : true_type {};
-template <>
-struct is_float<long double> : true_type {};
-#endif
+		/// Type traits for floating point types.
+		template<typename> struct is_float : false_type {};
+		template<typename T> struct is_float<const T> : is_float<T> {};
+		template<typename T> struct is_float<volatile T> : is_float<T> {};
+		template<typename T> struct is_float<const volatile T> : is_float<T> {};
+		template<> struct is_float<float> : true_type {};
+		template<> struct is_float<double> : true_type {};
+		template<> struct is_float<long double> : true_type {};
+	#endif
 
-/// Type traits for floating point bits.
-template <typename T>
-struct bits {
-  typedef unsigned char type;
-};
-template <typename T>
-struct bits<const T> : bits<T> {};
-template <typename T>
-struct bits<volatile T> : bits<T> {};
-template <typename T>
-struct bits<const volatile T> : bits<T> {};
+		/// Type traits for floating point bits.
+		template<typename T> struct bits { typedef unsigned char type; };
+		template<typename T> struct bits<const T> : bits<T> {};
+		template<typename T> struct bits<volatile T> : bits<T> {};
+		template<typename T> struct bits<const volatile T> : bits<T> {};
 
-#if HALF_ENABLE_CPP11_CSTDINT
-/// Unsigned integer of (at least) 16 bits width.
-typedef std::uint_least16_t uint16;
+	#if HALF_ENABLE_CPP11_CSTDINT
+		/// Unsigned integer of (at least) 16 bits width.
+		typedef std::uint_least16_t uint16;
 
-/// Unsigned integer of (at least) 32 bits width.
-template <>
-struct bits<float> {
-  typedef std::uint_least32_t type;
-};
+		/// Unsigned integer of (at least) 32 bits width.
+		template<> struct bits<float> { typedef std::uint_least32_t type; };
 
-/// Unsigned integer of (at least) 64 bits width.
-template <>
-struct bits<double> {
-  typedef std::uint_least64_t type;
-};
-#else
-/// Unsigned integer of (at least) 16 bits width.
-typedef unsigned short uint16;
+		/// Unsigned integer of (at least) 64 bits width.
+		template<> struct bits<double> { typedef std::uint_least64_t type; };
+	#else
+		/// Unsigned integer of (at least) 16 bits width.
+		typedef unsigned short uint16;
 
-/// Unsigned integer of (at least) 32 bits width.
-template <>
-struct bits<float>
-    : conditional<std::numeric_limits<unsigned int>::digits >= 32, unsigned int,
-                  unsigned long> {};
+		/// Unsigned integer of (at least) 32 bits width.
+		template<> struct bits<float> : conditional<std::numeric_limits<unsigned int>::digits>=32,unsigned int,unsigned long> {};
 
-#if HALF_ENABLE_CPP11_LONG_LONG
-/// Unsigned integer of (at least) 64 bits width.
-template <>
-struct bits<double>
-    : conditional<std::numeric_limits<unsigned long>::digits >= 64,
-                  unsigned long, unsigned long long> {};
-#else
-/// Unsigned integer of (at least) 64 bits width.
-template <>
-struct bits<double> {
-  typedef unsigned long type;
-};
-#endif
-#endif
+		#if HALF_ENABLE_CPP11_LONG_LONG
+			/// Unsigned integer of (at least) 64 bits width.
+			template<> struct bits<double> : conditional<std::numeric_limits<unsigned long>::digits>=64,unsigned long,unsigned long long> {};
+		#else
+			/// Unsigned integer of (at least) 64 bits width.
+			template<> struct bits<double> { typedef unsigned long type; };
+		#endif
+	#endif
 
-/// Tag type for binary construction.
-struct binary_t {};
+		/// Tag type for binary construction.
+		struct binary_t {};
 
-/// Tag for binary construction.
-HALF_CONSTEXPR_CONST binary_t binary = binary_t();
+		/// Tag for binary construction.
+		HALF_CONSTEXPR_CONST binary_t binary = binary_t();
 
-/// Temporary half-precision expression.
-/// This class represents a half-precision expression which just stores a
-/// single-precision value internally.
-struct expr {
-  /// Conversion constructor.
-  /// \param f single-precision value to convert
-  explicit HALF_CONSTEXPR expr(float f) HALF_NOEXCEPT : value_(f) {}
+		/// Temporary half-precision expression.
+		/// This class represents a half-precision expression which just stores a single-precision value internally.
+		struct expr
+		{
+			/// Conversion constructor.
+			/// \param f single-precision value to convert
+			explicit HALF_CONSTEXPR expr(float f) HALF_NOEXCEPT : value_(f) {}
 
-  /// Conversion to single-precision.
-  /// \return single precision value representing expression value
-  HALF_CONSTEXPR operator float() const HALF_NOEXCEPT { return value_; }
+			/// Conversion to single-precision.
+			/// \return single precision value representing expression value
+			HALF_CONSTEXPR operator float() const HALF_NOEXCEPT { return value_; }
 
- private:
-  /// Internal expression value stored in single-precision.
-  float value_;
-};
+		private:
+			/// Internal expression value stored in single-precision.
+			float value_;
+		};
 
-/// SFINAE helper for generic half-precision functions.
-/// This class template has to be specialized for each valid combination of
-/// argument types to provide a corresponding
-/// `type` member equivalent to \a T.
-/// \tparam T type to return
-template <typename T, typename, typename = void, typename = void>
-struct enable {};
-template <typename T>
-struct enable<T, half, void, void> {
-  typedef T type;
-};
-template <typename T>
-struct enable<T, expr, void, void> {
-  typedef T type;
-};
-template <typename T>
-struct enable<T, half, half, void> {
-  typedef T type;
-};
-template <typename T>
-struct enable<T, half, expr, void> {
-  typedef T type;
-};
-template <typename T>
-struct enable<T, expr, half, void> {
-  typedef T type;
-};
-template <typename T>
-struct enable<T, expr, expr, void> {
-  typedef T type;
-};
-template <typename T>
-struct enable<T, half, half, half> {
-  typedef T type;
-};
-template <typename T>
-struct enable<T, half, half, expr> {
-  typedef T type;
-};
-template <typename T>
-struct enable<T, half, expr, half> {
-  typedef T type;
-};
-template <typename T>
-struct enable<T, half, expr, expr> {
-  typedef T type;
-};
-template <typename T>
-struct enable<T, expr, half, half> {
-  typedef T type;
-};
-template <typename T>
-struct enable<T, expr, half, expr> {
-  typedef T type;
-};
-template <typename T>
-struct enable<T, expr, expr, half> {
-  typedef T type;
-};
-template <typename T>
-struct enable<T, expr, expr, expr> {
-  typedef T type;
-};
+		/// SFINAE helper for generic half-precision functions.
+		/// This class template has to be specialized for each valid combination of argument types to provide a corresponding 
+		/// `type` member equivalent to \a T.
+		/// \tparam T type to return
+		template<typename T,typename,typename=void,typename=void> struct enable {};
+		template<typename T> struct enable<T,half,void,void> { typedef T type; };
+		template<typename T> struct enable<T,expr,void,void> { typedef T type; };
+		template<typename T> struct enable<T,half,half,void> { typedef T type; };
+		template<typename T> struct enable<T,half,expr,void> { typedef T type; };
+		template<typename T> struct enable<T,expr,half,void> { typedef T type; };
+		template<typename T> struct enable<T,expr,expr,void> { typedef T type; };
+		template<typename T> struct enable<T,half,half,half> { typedef T type; };
+		template<typename T> struct enable<T,half,half,expr> { typedef T type; };
+		template<typename T> struct enable<T,half,expr,half> { typedef T type; };
+		template<typename T> struct enable<T,half,expr,expr> { typedef T type; };
+		template<typename T> struct enable<T,expr,half,half> { typedef T type; };
+		template<typename T> struct enable<T,expr,half,expr> { typedef T type; };
+		template<typename T> struct enable<T,expr,expr,half> { typedef T type; };
+		template<typename T> struct enable<T,expr,expr,expr> { typedef T type; };
 
-/// Return type for specialized generic 2-argument half-precision functions.
-/// This class template has to be specialized for each valid combination of
-/// argument types to provide a corresponding
-/// `type` member denoting the appropriate return type.
-/// \tparam T first argument type
-/// \tparam U first argument type
-template <typename T, typename U>
-struct result : enable<expr, T, U> {};
-template <>
-struct result<half, half> {
-  typedef half type;
-};
+		/// Return type for specialized generic 2-argument half-precision functions.
+		/// This class template has to be specialized for each valid combination of argument types to provide a corresponding 
+		/// `type` member denoting the appropriate return type.
+		/// \tparam T first argument type
+		/// \tparam U first argument type
+		template<typename T,typename U> struct result : enable<expr,T,U> {};
+		template<> struct result<half,half> { typedef half type; };
 
-/// \name Classification helpers
-/// \{
+		/// \name Classification helpers
+		/// \{
 
-/// Check for infinity.
-/// \tparam T argument type (builtin floating point type)
-/// \param arg value to query
-/// \retval true if infinity
-/// \retval false else
-template <typename T>
-bool builtin_isinf(T arg) {
-#if HALF_ENABLE_CPP11_CMATH
-  return std::isinf(arg);
-#elif defined(_MSC_VER)
-  return !::_finite(static_cast<double>(arg)) &&
-         !::_isnan(static_cast<double>(arg));
-#else
-  return arg == std::numeric_limits<T>::infinity() ||
-         arg == -std::numeric_limits<T>::infinity();
-#endif
-}
+		/// Check for infinity.
+		/// \tparam T argument type (builtin floating point type)
+		/// \param arg value to query
+		/// \retval true if infinity
+		/// \retval false else
+		template<typename T> bool builtin_isinf(T arg)
+		{
+		#if HALF_ENABLE_CPP11_CMATH
+			return std::isinf(arg);
+		#elif defined(_MSC_VER)
+			return !::_finite(static_cast<double>(arg)) && !::_isnan(static_cast<double>(arg));
+		#else
+			return arg == std::numeric_limits<T>::infinity() || arg == -std::numeric_limits<T>::infinity();
+		#endif
+		}
 
-/// Check for NaN.
-/// \tparam T argument type (builtin floating point type)
-/// \param arg value to query
-/// \retval true if not a number
-/// \retval false else
-template <typename T>
-bool builtin_isnan(T arg) {
-#if HALF_ENABLE_CPP11_CMATH
-  return std::isnan(arg);
-#elif defined(_MSC_VER)
-  return ::_isnan(static_cast<double>(arg)) != 0;
-#else
-  return arg != arg;
-#endif
-}
+		/// Check for NaN.
+		/// \tparam T argument type (builtin floating point type)
+		/// \param arg value to query
+		/// \retval true if not a number
+		/// \retval false else
+		template<typename T> bool builtin_isnan(T arg)
+		{
+		#if HALF_ENABLE_CPP11_CMATH
+			return std::isnan(arg);
+		#elif defined(_MSC_VER)
+			return ::_isnan(static_cast<double>(arg)) != 0;
+		#else
+			return arg != arg;
+		#endif
+		}
 
-/// Check sign.
-/// \tparam T argument type (builtin floating point type)
-/// \param arg value to query
-/// \retval true if signbit set
-/// \retval false else
-template <typename T>
-bool builtin_signbit(T arg) {
-#if HALF_ENABLE_CPP11_CMATH
-  return std::signbit(arg);
-#else
-  return arg < T() || (arg == T() && T(1) / arg < T());
-#endif
-}
+		/// Check sign.
+		/// \tparam T argument type (builtin floating point type)
+		/// \param arg value to query
+		/// \retval true if signbit set
+		/// \retval false else
+		template<typename T> bool builtin_signbit(T arg)
+		{
+		#if HALF_ENABLE_CPP11_CMATH
+			return std::signbit(arg);
+		#else
+			return arg < T() || (arg == T() && T(1)/arg < T());
+		#endif
+		}
 
-/// \}
-/// \name Conversion
-/// \{
+		/// \}
+		/// \name Conversion
+		/// \{
 
-/// Convert IEEE single-precision to half-precision.
-/// Credit for this goes to [Jeroen van der
-/// Zijp](ftp://ftp.fox-toolkit.org/pub/fasthalffloatconversion.pdf).
-/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
-/// rounding
-/// \param value single-precision value
-/// \return binary representation of half-precision value
-template <std::float_round_style R>
-uint16 float2half_impl(float value, true_type) {
-  typedef bits<float>::type uint32;
-  uint32
-      bits;  // = *reinterpret_cast<uint32*>(&value);		//violating
-             // strict aliasing!
-  std::memcpy(&bits, &value, sizeof(float));
-  /*			uint16 hbits = (bits>>16) & 0x8000;
+		/// Convert IEEE single-precision to half-precision.
+		/// Credit for this goes to [Jeroen van der Zijp](ftp://ftp.fox-toolkit.org/pub/fasthalffloatconversion.pdf).
+		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
+		/// \param value single-precision value
+		/// \return binary representation of half-precision value
+		template<std::float_round_style R> uint16 float2half_impl(float value, true_type)
+		{
+			typedef bits<float>::type uint32;
+			uint32 bits;// = *reinterpret_cast<uint32*>(&value);		//violating strict aliasing!
+			std::memcpy(&bits, &value, sizeof(float));
+/*			uint16 hbits = (bits>>16) & 0x8000;
 			bits &= 0x7FFFFFFF;
 			int exp = bits >> 23;
 			if(exp == 255)
@@ -615,310 +498,254 @@ uint16 float2half_impl(float value, true_type) {
 				hbits += ~(hbits>>15) & (s|g);
 			else if(R == std::round_toward_neg_infinity)
 				hbits += (hbits>>15) & (g|s);
-*/ static const uint16
-      base_table[512] = {
-          0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
-          0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
-          0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
-          0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
-          0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
-          0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
-          0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
-          0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
-          0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
-          0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
-          0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
-          0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
-          0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0001,
-          0x0002, 0x0004, 0x0008, 0x0010, 0x0020, 0x0040, 0x0080, 0x0100,
-          0x0200, 0x0400, 0x0800, 0x0C00, 0x1000, 0x1400, 0x1800, 0x1C00,
-          0x2000, 0x2400, 0x2800, 0x2C00, 0x3000, 0x3400, 0x3800, 0x3C00,
-          0x4000, 0x4400, 0x4800, 0x4C00, 0x5000, 0x5400, 0x5800, 0x5C00,
-          0x6000, 0x6400, 0x6800, 0x6C00, 0x7000, 0x7400, 0x7800, 0x7C00,
-          0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
-          0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
-          0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
-          0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
-          0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
-          0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
-          0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
-          0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
-          0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
-          0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
-          0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
-          0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
-          0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
-          0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
-          0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
-          0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
-          0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
-          0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
-          0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
-          0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
-          0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
-          0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
-          0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
-          0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
-          0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
-          0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
-          0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8001,
-          0x8002, 0x8004, 0x8008, 0x8010, 0x8020, 0x8040, 0x8080, 0x8100,
-          0x8200, 0x8400, 0x8800, 0x8C00, 0x9000, 0x9400, 0x9800, 0x9C00,
-          0xA000, 0xA400, 0xA800, 0xAC00, 0xB000, 0xB400, 0xB800, 0xBC00,
-          0xC000, 0xC400, 0xC800, 0xCC00, 0xD000, 0xD400, 0xD800, 0xDC00,
-          0xE000, 0xE400, 0xE800, 0xEC00, 0xF000, 0xF400, 0xF800, 0xFC00,
-          0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
-          0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
-          0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
-          0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
-          0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
-          0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
-          0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
-          0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
-          0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
-          0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
-          0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
-          0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
-          0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
-          0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00};
-  static const unsigned char shift_table[512] = {
-      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
-      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
-      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
-      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
-      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
-      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 23, 22, 21, 20, 19,
-      18, 17, 16, 15, 14, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
-      13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 24,
-      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
-      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
-      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
-      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
-      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
-      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
-      24, 24, 24, 13, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
-      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
-      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
-      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
-      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
-      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 23,
-      22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 13, 13, 13, 13, 13, 13, 13, 13,
-      13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
-      13, 13, 13, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
-      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
-      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
-      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
-      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
-      24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
-      24, 24, 24, 24, 24, 24, 24, 13};
-  uint16 hbits =
-      base_table[bits >> 23] +
-      static_cast<uint16>((bits & 0x7FFFFF) >> shift_table[bits >> 23]);
-  if (R == std::round_to_nearest)
-    hbits +=
-        (((bits & 0x7FFFFF) >> (shift_table[bits >> 23] - 1)) |
-         (((bits >> 23) & 0xFF) == 102)) &
-        ((hbits & 0x7C00) != 0x7C00)
-#if HALF_ROUND_TIES_TO_EVEN
-        & (((((static_cast<uint32>(1) << (shift_table[bits >> 23] - 1)) - 1) &
-             bits) != 0) |
-           hbits)
-#endif
-        ;
-  else if (R == std::round_toward_zero)
-    hbits -= ((hbits & 0x7FFF) == 0x7C00) & ~shift_table[bits >> 23];
-  else if (R == std::round_toward_infinity)
-    hbits +=
-        ((((bits & 0x7FFFFF &
-            ((static_cast<uint32>(1) << (shift_table[bits >> 23])) - 1)) != 0) |
-          (((bits >> 23) <= 102) & ((bits >> 23) != 0))) &
-         (hbits < 0x7C00)) -
-        ((hbits == 0xFC00) & ((bits >> 23) != 511));
-  else if (R == std::round_toward_neg_infinity)
-    hbits +=
-        ((((bits & 0x7FFFFF &
-            ((static_cast<uint32>(1) << (shift_table[bits >> 23])) - 1)) != 0) |
-          (((bits >> 23) <= 358) & ((bits >> 23) != 256))) &
-         (hbits < 0xFC00) & (hbits >> 15)) -
-        ((hbits == 0x7C00) & ((bits >> 23) != 255));
-  return hbits;
-}
+*/			static const uint16 base_table[512] = { 
+				0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 
+				0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 
+				0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 
+				0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 
+				0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 
+				0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 
+				0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0001, 0x0002, 0x0004, 0x0008, 0x0010, 0x0020, 0x0040, 0x0080, 0x0100, 
+				0x0200, 0x0400, 0x0800, 0x0C00, 0x1000, 0x1400, 0x1800, 0x1C00, 0x2000, 0x2400, 0x2800, 0x2C00, 0x3000, 0x3400, 0x3800, 0x3C00, 
+				0x4000, 0x4400, 0x4800, 0x4C00, 0x5000, 0x5400, 0x5800, 0x5C00, 0x6000, 0x6400, 0x6800, 0x6C00, 0x7000, 0x7400, 0x7800, 0x7C00, 
+				0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 
+				0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 
+				0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 
+				0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 
+				0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 
+				0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 
+				0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 
+				0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 
+				0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 
+				0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 
+				0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 
+				0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 
+				0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 
+				0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8001, 0x8002, 0x8004, 0x8008, 0x8010, 0x8020, 0x8040, 0x8080, 0x8100, 
+				0x8200, 0x8400, 0x8800, 0x8C00, 0x9000, 0x9400, 0x9800, 0x9C00, 0xA000, 0xA400, 0xA800, 0xAC00, 0xB000, 0xB400, 0xB800, 0xBC00, 
+				0xC000, 0xC400, 0xC800, 0xCC00, 0xD000, 0xD400, 0xD800, 0xDC00, 0xE000, 0xE400, 0xE800, 0xEC00, 0xF000, 0xF400, 0xF800, 0xFC00, 
+				0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 
+				0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 
+				0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 
+				0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 
+				0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 
+				0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 
+				0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00 };
+			static const unsigned char shift_table[512] = { 
+				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
+				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
+				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
+				24, 24, 24, 24, 24, 24, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 
+				13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
+				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
+				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
+				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 13, 
+				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
+				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
+				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
+				24, 24, 24, 24, 24, 24, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 
+				13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
+				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
+				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
+				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 13 };
+			uint16 hbits = base_table[bits>>23] + static_cast<uint16>((bits&0x7FFFFF)>>shift_table[bits>>23]);
+			if(R == std::round_to_nearest)
+				hbits += (((bits&0x7FFFFF)>>(shift_table[bits>>23]-1))|(((bits>>23)&0xFF)==102)) & ((hbits&0x7C00)!=0x7C00)
+				#if HALF_ROUND_TIES_TO_EVEN
+					& (((((static_cast<uint32>(1)<<(shift_table[bits>>23]-1))-1)&bits)!=0)|hbits)
+				#endif
+				;
+			else if(R == std::round_toward_zero)
+				hbits -= ((hbits&0x7FFF)==0x7C00) & ~shift_table[bits>>23];
+			else if(R == std::round_toward_infinity)
+				hbits += ((((bits&0x7FFFFF&((static_cast<uint32>(1)<<(shift_table[bits>>23]))-1))!=0)|(((bits>>23)<=102)&
+					((bits>>23)!=0)))&(hbits<0x7C00)) - ((hbits==0xFC00)&((bits>>23)!=511));
+			else if(R == std::round_toward_neg_infinity)
+				hbits += ((((bits&0x7FFFFF&((static_cast<uint32>(1)<<(shift_table[bits>>23]))-1))!=0)|(((bits>>23)<=358)&
+					((bits>>23)!=256)))&(hbits<0xFC00)&(hbits>>15)) - ((hbits==0x7C00)&((bits>>23)!=255));
+			return hbits;
+		}
 
-/// Convert IEEE double-precision to half-precision.
-/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
-/// rounding
-/// \param value double-precision value
-/// \return binary representation of half-precision value
-template <std::float_round_style R>
-uint16 float2half_impl(double value, true_type) {
-  typedef bits<float>::type uint32;
-  typedef bits<double>::type uint64;
-  uint64
-      bits;  // = *reinterpret_cast<uint64*>(&value);		//violating
-             // strict aliasing!
-  std::memcpy(&bits, &value, sizeof(double));
-  uint32 hi = bits >> 32, lo = bits & 0xFFFFFFFF;
-  uint16 hbits = (hi >> 16) & 0x8000;
-  hi &= 0x7FFFFFFF;
-  int exp = hi >> 20;
-  if (exp == 2047)
-    return hbits | 0x7C00 |
-           (0x3FF & -static_cast<unsigned>((bits & 0xFFFFFFFFFFFFF) != 0));
-  if (exp > 1038) {
-    if (R == std::round_toward_infinity) return hbits | 0x7C00 - (hbits >> 15);
-    if (R == std::round_toward_neg_infinity)
-      return hbits | 0x7BFF + (hbits >> 15);
-    return hbits | 0x7BFF + (R != std::round_toward_zero);
-  }
-  int g, s = lo != 0;
-  if (exp > 1008) {
-    g = (hi >> 9) & 1;
-    s |= (hi & 0x1FF) != 0;
-    hbits |= ((exp - 1008) << 10) | ((hi >> 10) & 0x3FF);
-  } else if (exp > 997) {
-    int i = 1018 - exp;
-    hi = (hi & 0xFFFFF) | 0x100000;
-    g = (hi >> i) & 1;
-    s |= (hi & ((1L << i) - 1)) != 0;
-    hbits |= hi >> (i + 1);
-  } else {
-    g = 0;
-    s |= hi != 0;
-  }
-  if (R == std::round_to_nearest)
-#if HALF_ROUND_TIES_TO_EVEN
-    hbits += g & (s | hbits);
-#else
-    hbits += g;
-#endif
-  else if (R == std::round_toward_infinity)
-    hbits += ~(hbits >> 15) & (s | g);
-  else if (R == std::round_toward_neg_infinity)
-    hbits += (hbits >> 15) & (g | s);
-  return hbits;
-}
+		/// Convert IEEE double-precision to half-precision.
+		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
+		/// \param value double-precision value
+		/// \return binary representation of half-precision value
+		template<std::float_round_style R> uint16 float2half_impl(double value, true_type)
+		{
+			typedef bits<float>::type uint32;
+			typedef bits<double>::type uint64;
+			uint64 bits;// = *reinterpret_cast<uint64*>(&value);		//violating strict aliasing!
+			std::memcpy(&bits, &value, sizeof(double));
+			uint32 hi = bits >> 32, lo = bits & 0xFFFFFFFF;
+			uint16 hbits = (hi>>16) & 0x8000;
+			hi &= 0x7FFFFFFF;
+			int exp = hi >> 20;
+			if(exp == 2047)
+				return hbits | 0x7C00 | (0x3FF&-static_cast<unsigned>((bits&0xFFFFFFFFFFFFF)!=0));
+			if(exp > 1038)
+			{
+				if(R == std::round_toward_infinity)
+					return hbits | 0x7C00 - (hbits>>15);
+				if(R == std::round_toward_neg_infinity)
+					return hbits | 0x7BFF + (hbits>>15);
+				return hbits | 0x7BFF + (R!=std::round_toward_zero);
+			}
+			int g, s = lo != 0;
+			if(exp > 1008)
+			{
+				g = (hi>>9) & 1;
+				s |= (hi&0x1FF) != 0;
+				hbits |= ((exp-1008)<<10) | ((hi>>10)&0x3FF);
+			}
+			else if(exp > 997)
+			{
+				int i = 1018 - exp;
+				hi = (hi&0xFFFFF) | 0x100000;
+				g = (hi>>i) & 1;
+				s |= (hi&((1L<<i)-1)) != 0;
+				hbits |= hi >> (i+1);
+			}
+			else
+			{
+				g = 0;
+				s |= hi != 0;
+			}
+			if(R == std::round_to_nearest)
+				#if HALF_ROUND_TIES_TO_EVEN
+					hbits += g & (s|hbits);
+				#else
+					hbits += g;
+				#endif
+			else if(R == std::round_toward_infinity)
+				hbits += ~(hbits>>15) & (s|g);
+			else if(R == std::round_toward_neg_infinity)
+				hbits += (hbits>>15) & (g|s);
+			return hbits;
+		}
 
-/// Convert non-IEEE floating point to half-precision.
-/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
-/// rounding
-/// \tparam T source type (builtin floating point type)
-/// \param value floating point value
-/// \return binary representation of half-precision value
-template <std::float_round_style R, typename T>
-uint16 float2half_impl(T value, ...) {
-  uint16 hbits = static_cast<unsigned>(builtin_signbit(value)) << 15;
-  if (value == T()) return hbits;
-  if (builtin_isnan(value)) return hbits | 0x7FFF;
-  if (builtin_isinf(value)) return hbits | 0x7C00;
-  int exp;
-  std::frexp(value, &exp);
-  if (exp > 16) {
-    if (R == std::round_toward_infinity)
-      return hbits | (0x7C00 - (hbits >> 15));
-    else if (R == std::round_toward_neg_infinity)
-      return hbits | (0x7BFF + (hbits >> 15));
-    return hbits | (0x7BFF + (R != std::round_toward_zero));
-  }
-  if (exp < -13)
-    value = std::ldexp(value, 24);
-  else {
-    value = std::ldexp(value, 11 - exp);
-    hbits |= ((exp + 13) << 10);
-  }
-  T ival, frac = std::modf(value, &ival);
-  hbits += static_cast<uint16>(std::abs(static_cast<int>(ival)));
-  if (R == std::round_to_nearest) {
-    frac = std::abs(frac);
-#if HALF_ROUND_TIES_TO_EVEN
-    hbits += (frac > T(0.5)) | ((frac == T(0.5)) & hbits);
-#else
-    hbits += frac >= T(0.5);
-#endif
-  } else if (R == std::round_toward_infinity)
-    hbits += frac > T();
-  else if (R == std::round_toward_neg_infinity)
-    hbits += frac < T();
-  return hbits;
-}
+		/// Convert non-IEEE floating point to half-precision.
+		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
+		/// \tparam T source type (builtin floating point type)
+		/// \param value floating point value
+		/// \return binary representation of half-precision value
+		template<std::float_round_style R,typename T> uint16 float2half_impl(T value, ...)
+		{
+			uint16 hbits = static_cast<unsigned>(builtin_signbit(value)) << 15;
+			if(value == T())
+				return hbits;
+			if(builtin_isnan(value))
+				return hbits | 0x7FFF;
+			if(builtin_isinf(value))
+				return hbits | 0x7C00;
+			int exp;
+			std::frexp(value, &exp);
+			if(exp > 16)
+			{
+				if(R == std::round_toward_infinity)
+					return hbits | (0x7C00 - (hbits>>15));
+				else if(R == std::round_toward_neg_infinity)
+					return hbits | (0x7BFF + (hbits>>15));
+				return hbits | (0x7BFF + (R!=std::round_toward_zero));
+			}
+			if(exp < -13)
+				value = std::ldexp(value, 24);
+			else
+			{
+				value = std::ldexp(value, 11-exp);
+				hbits |= ((exp+13)<<10);
+			}
+			T ival, frac = std::modf(value, &ival);
+			hbits += static_cast<uint16>(std::abs(static_cast<int>(ival)));
+			if(R == std::round_to_nearest)
+			{
+				frac = std::abs(frac);
+				#if HALF_ROUND_TIES_TO_EVEN
+					hbits += (frac>T(0.5)) | ((frac==T(0.5))&hbits);
+				#else
+					hbits += frac >= T(0.5);
+				#endif
+			}
+			else if(R == std::round_toward_infinity)
+				hbits += frac > T();
+			else if(R == std::round_toward_neg_infinity)
+				hbits += frac < T();
+			return hbits;
+		}
 
-/// Convert floating point to half-precision.
-/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
-/// rounding
-/// \tparam T source type (builtin floating point type)
-/// \param value floating point value
-/// \return binary representation of half-precision value
-template <std::float_round_style R, typename T>
-uint16 float2half(T value) {
-  return float2half_impl<R>(
-      value, bool_type < std::numeric_limits<T>::is_iec559 &&
-                 sizeof(typename bits<T>::type) == sizeof(T) > ());
-}
+		/// Convert floating point to half-precision.
+		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
+		/// \tparam T source type (builtin floating point type)
+		/// \param value floating point value
+		/// \return binary representation of half-precision value
+		template<std::float_round_style R,typename T> uint16 float2half(T value)
+		{
+			return float2half_impl<R>(value, bool_type<std::numeric_limits<T>::is_iec559&&sizeof(typename bits<T>::type)==sizeof(T)>());
+		}
 
-/// Convert integer to half-precision floating point.
-/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
-/// rounding
-/// \tparam S `true` if value negative, `false` else
-/// \tparam T type to convert (builtin integer type)
-/// \param value non-negative integral value
-/// \return binary representation of half-precision value
-template <std::float_round_style R, bool S, typename T>
-uint16 int2half_impl(T value) {
-#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
-  static_assert(std::is_integral<T>::value,
-                "int to half conversion only supports builtin integer types");
-#endif
-  if (S) value = -value;
-  uint16 bits = S << 15;
-  if (value > 0xFFFF) {
-    if (R == std::round_toward_infinity)
-      bits |= 0x7C00 - S;
-    else if (R == std::round_toward_neg_infinity)
-      bits |= 0x7BFF + S;
-    else
-      bits |= 0x7BFF + (R != std::round_toward_zero);
-  } else if (value) {
-    unsigned int m = value, exp = 24;
-    for (; m < 0x400; m <<= 1, --exp)
-      ;
-    for (; m > 0x7FF; m >>= 1, ++exp)
-      ;
-    bits |= (exp << 10) + m;
-    if (exp > 24) {
-      if (R == std::round_to_nearest)
-        bits += (value >> (exp - 25)) & 1
-#if HALF_ROUND_TIES_TO_EVEN
-                & (((((1 << (exp - 25)) - 1) & value) != 0) | bits)
-#endif
-            ;
-      else if (R == std::round_toward_infinity)
-        bits += ((value & ((1 << (exp - 24)) - 1)) != 0) & !S;
-      else if (R == std::round_toward_neg_infinity)
-        bits += ((value & ((1 << (exp - 24)) - 1)) != 0) & S;
-    }
-  }
-  return bits;
-}
+		/// Convert integer to half-precision floating point.
+		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
+		/// \tparam S `true` if value negative, `false` else
+		/// \tparam T type to convert (builtin integer type)
+		/// \param value non-negative integral value
+		/// \return binary representation of half-precision value
+		template<std::float_round_style R,bool S,typename T> uint16 int2half_impl(T value)
+		{
+		#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
+			static_assert(std::is_integral<T>::value, "int to half conversion only supports builtin integer types");
+		#endif
+			if(S)
+				value = -value;
+			uint16 bits = S << 15;
+			if(value > 0xFFFF)
+			{
+				if(R == std::round_toward_infinity)
+					bits |= 0x7C00 - S;
+				else if(R == std::round_toward_neg_infinity)
+					bits |= 0x7BFF + S;
+				else
+					bits |= 0x7BFF + (R!=std::round_toward_zero);
+			}
+			else if(value)
+			{
+				unsigned int m = value, exp = 24;
+				for(; m<0x400; m<<=1,--exp) ;
+				for(; m>0x7FF; m>>=1,++exp) ;
+				bits |= (exp<<10) + m;
+				if(exp > 24)
+				{
+					if(R == std::round_to_nearest)
+						bits += (value>>(exp-25)) & 1
+						#if HALF_ROUND_TIES_TO_EVEN
+							& (((((1<<(exp-25))-1)&value)!=0)|bits)
+						#endif
+						;
+					else if(R == std::round_toward_infinity)
+						bits += ((value&((1<<(exp-24))-1))!=0) & !S;
+					else if(R == std::round_toward_neg_infinity)
+						bits += ((value&((1<<(exp-24))-1))!=0) & S;
+				}
+			}
+			return bits;
+		}
 
-/// Convert integer to half-precision floating point.
-/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
-/// rounding
-/// \tparam T type to convert (builtin integer type)
-/// \param value integral value
-/// \return binary representation of half-precision value
-template <std::float_round_style R, typename T>
-uint16 int2half(T value) {
-  return (value < 0) ? int2half_impl<R, true>(value)
-                     : int2half_impl<R, false>(value);
-}
+		/// Convert integer to half-precision floating point.
+		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
+		/// \tparam T type to convert (builtin integer type)
+		/// \param value integral value
+		/// \return binary representation of half-precision value
+		template<std::float_round_style R,typename T> uint16 int2half(T value)
+		{
+			return (value<0) ? int2half_impl<R,true>(value) : int2half_impl<R,false>(value);
+		}
 
-/// Convert half-precision to IEEE single-precision.
-/// Credit for this goes to [Jeroen van der
-/// Zijp](ftp://ftp.fox-toolkit.org/pub/fasthalffloatconversion.pdf).
-/// \param value binary representation of half-precision value
-/// \return single-precision value
-inline float half2float_impl(uint16 value, float, true_type) {
-  typedef bits<float>::type uint32;
-  /*			uint32 bits = static_cast<uint32>(value&0x8000) << 16;
+		/// Convert half-precision to IEEE single-precision.
+		/// Credit for this goes to [Jeroen van der Zijp](ftp://ftp.fox-toolkit.org/pub/fasthalffloatconversion.pdf).
+		/// \param value binary representation of half-precision value
+		/// \return single-precision value
+		inline float half2float_impl(uint16 value, float, true_type)
+		{
+			typedef bits<float>::type uint32;
+/*			uint32 bits = static_cast<uint32>(value&0x8000) << 16;
 			int abs = value & 0x7FFF;
 			if(abs)
 			{
@@ -926,2927 +753,2315 @@ inline float half2float_impl(uint16 value, float, true_type) {
 				for(; abs<0x400; abs<<=1,bits-=0x800000) ;
 				bits += static_cast<uint32>(abs) << 13;
 			}
-*/ static const uint32
-      mantissa_table[2048] = {
-          0x00000000, 0x33800000, 0x34000000, 0x34400000, 0x34800000,
-          0x34A00000, 0x34C00000, 0x34E00000, 0x35000000, 0x35100000,
-          0x35200000, 0x35300000, 0x35400000, 0x35500000, 0x35600000,
-          0x35700000, 0x35800000, 0x35880000, 0x35900000, 0x35980000,
-          0x35A00000, 0x35A80000, 0x35B00000, 0x35B80000, 0x35C00000,
-          0x35C80000, 0x35D00000, 0x35D80000, 0x35E00000, 0x35E80000,
-          0x35F00000, 0x35F80000, 0x36000000, 0x36040000, 0x36080000,
-          0x360C0000, 0x36100000, 0x36140000, 0x36180000, 0x361C0000,
-          0x36200000, 0x36240000, 0x36280000, 0x362C0000, 0x36300000,
-          0x36340000, 0x36380000, 0x363C0000, 0x36400000, 0x36440000,
-          0x36480000, 0x364C0000, 0x36500000, 0x36540000, 0x36580000,
-          0x365C0000, 0x36600000, 0x36640000, 0x36680000, 0x366C0000,
-          0x36700000, 0x36740000, 0x36780000, 0x367C0000, 0x36800000,
-          0x36820000, 0x36840000, 0x36860000, 0x36880000, 0x368A0000,
-          0x368C0000, 0x368E0000, 0x36900000, 0x36920000, 0x36940000,
-          0x36960000, 0x36980000, 0x369A0000, 0x369C0000, 0x369E0000,
-          0x36A00000, 0x36A20000, 0x36A40000, 0x36A60000, 0x36A80000,
-          0x36AA0000, 0x36AC0000, 0x36AE0000, 0x36B00000, 0x36B20000,
-          0x36B40000, 0x36B60000, 0x36B80000, 0x36BA0000, 0x36BC0000,
-          0x36BE0000, 0x36C00000, 0x36C20000, 0x36C40000, 0x36C60000,
-          0x36C80000, 0x36CA0000, 0x36CC0000, 0x36CE0000, 0x36D00000,
-          0x36D20000, 0x36D40000, 0x36D60000, 0x36D80000, 0x36DA0000,
-          0x36DC0000, 0x36DE0000, 0x36E00000, 0x36E20000, 0x36E40000,
-          0x36E60000, 0x36E80000, 0x36EA0000, 0x36EC0000, 0x36EE0000,
-          0x36F00000, 0x36F20000, 0x36F40000, 0x36F60000, 0x36F80000,
-          0x36FA0000, 0x36FC0000, 0x36FE0000, 0x37000000, 0x37010000,
-          0x37020000, 0x37030000, 0x37040000, 0x37050000, 0x37060000,
-          0x37070000, 0x37080000, 0x37090000, 0x370A0000, 0x370B0000,
-          0x370C0000, 0x370D0000, 0x370E0000, 0x370F0000, 0x37100000,
-          0x37110000, 0x37120000, 0x37130000, 0x37140000, 0x37150000,
-          0x37160000, 0x37170000, 0x37180000, 0x37190000, 0x371A0000,
-          0x371B0000, 0x371C0000, 0x371D0000, 0x371E0000, 0x371F0000,
-          0x37200000, 0x37210000, 0x37220000, 0x37230000, 0x37240000,
-          0x37250000, 0x37260000, 0x37270000, 0x37280000, 0x37290000,
-          0x372A0000, 0x372B0000, 0x372C0000, 0x372D0000, 0x372E0000,
-          0x372F0000, 0x37300000, 0x37310000, 0x37320000, 0x37330000,
-          0x37340000, 0x37350000, 0x37360000, 0x37370000, 0x37380000,
-          0x37390000, 0x373A0000, 0x373B0000, 0x373C0000, 0x373D0000,
-          0x373E0000, 0x373F0000, 0x37400000, 0x37410000, 0x37420000,
-          0x37430000, 0x37440000, 0x37450000, 0x37460000, 0x37470000,
-          0x37480000, 0x37490000, 0x374A0000, 0x374B0000, 0x374C0000,
-          0x374D0000, 0x374E0000, 0x374F0000, 0x37500000, 0x37510000,
-          0x37520000, 0x37530000, 0x37540000, 0x37550000, 0x37560000,
-          0x37570000, 0x37580000, 0x37590000, 0x375A0000, 0x375B0000,
-          0x375C0000, 0x375D0000, 0x375E0000, 0x375F0000, 0x37600000,
-          0x37610000, 0x37620000, 0x37630000, 0x37640000, 0x37650000,
-          0x37660000, 0x37670000, 0x37680000, 0x37690000, 0x376A0000,
-          0x376B0000, 0x376C0000, 0x376D0000, 0x376E0000, 0x376F0000,
-          0x37700000, 0x37710000, 0x37720000, 0x37730000, 0x37740000,
-          0x37750000, 0x37760000, 0x37770000, 0x37780000, 0x37790000,
-          0x377A0000, 0x377B0000, 0x377C0000, 0x377D0000, 0x377E0000,
-          0x377F0000, 0x37800000, 0x37808000, 0x37810000, 0x37818000,
-          0x37820000, 0x37828000, 0x37830000, 0x37838000, 0x37840000,
-          0x37848000, 0x37850000, 0x37858000, 0x37860000, 0x37868000,
-          0x37870000, 0x37878000, 0x37880000, 0x37888000, 0x37890000,
-          0x37898000, 0x378A0000, 0x378A8000, 0x378B0000, 0x378B8000,
-          0x378C0000, 0x378C8000, 0x378D0000, 0x378D8000, 0x378E0000,
-          0x378E8000, 0x378F0000, 0x378F8000, 0x37900000, 0x37908000,
-          0x37910000, 0x37918000, 0x37920000, 0x37928000, 0x37930000,
-          0x37938000, 0x37940000, 0x37948000, 0x37950000, 0x37958000,
-          0x37960000, 0x37968000, 0x37970000, 0x37978000, 0x37980000,
-          0x37988000, 0x37990000, 0x37998000, 0x379A0000, 0x379A8000,
-          0x379B0000, 0x379B8000, 0x379C0000, 0x379C8000, 0x379D0000,
-          0x379D8000, 0x379E0000, 0x379E8000, 0x379F0000, 0x379F8000,
-          0x37A00000, 0x37A08000, 0x37A10000, 0x37A18000, 0x37A20000,
-          0x37A28000, 0x37A30000, 0x37A38000, 0x37A40000, 0x37A48000,
-          0x37A50000, 0x37A58000, 0x37A60000, 0x37A68000, 0x37A70000,
-          0x37A78000, 0x37A80000, 0x37A88000, 0x37A90000, 0x37A98000,
-          0x37AA0000, 0x37AA8000, 0x37AB0000, 0x37AB8000, 0x37AC0000,
-          0x37AC8000, 0x37AD0000, 0x37AD8000, 0x37AE0000, 0x37AE8000,
-          0x37AF0000, 0x37AF8000, 0x37B00000, 0x37B08000, 0x37B10000,
-          0x37B18000, 0x37B20000, 0x37B28000, 0x37B30000, 0x37B38000,
-          0x37B40000, 0x37B48000, 0x37B50000, 0x37B58000, 0x37B60000,
-          0x37B68000, 0x37B70000, 0x37B78000, 0x37B80000, 0x37B88000,
-          0x37B90000, 0x37B98000, 0x37BA0000, 0x37BA8000, 0x37BB0000,
-          0x37BB8000, 0x37BC0000, 0x37BC8000, 0x37BD0000, 0x37BD8000,
-          0x37BE0000, 0x37BE8000, 0x37BF0000, 0x37BF8000, 0x37C00000,
-          0x37C08000, 0x37C10000, 0x37C18000, 0x37C20000, 0x37C28000,
-          0x37C30000, 0x37C38000, 0x37C40000, 0x37C48000, 0x37C50000,
-          0x37C58000, 0x37C60000, 0x37C68000, 0x37C70000, 0x37C78000,
-          0x37C80000, 0x37C88000, 0x37C90000, 0x37C98000, 0x37CA0000,
-          0x37CA8000, 0x37CB0000, 0x37CB8000, 0x37CC0000, 0x37CC8000,
-          0x37CD0000, 0x37CD8000, 0x37CE0000, 0x37CE8000, 0x37CF0000,
-          0x37CF8000, 0x37D00000, 0x37D08000, 0x37D10000, 0x37D18000,
-          0x37D20000, 0x37D28000, 0x37D30000, 0x37D38000, 0x37D40000,
-          0x37D48000, 0x37D50000, 0x37D58000, 0x37D60000, 0x37D68000,
-          0x37D70000, 0x37D78000, 0x37D80000, 0x37D88000, 0x37D90000,
-          0x37D98000, 0x37DA0000, 0x37DA8000, 0x37DB0000, 0x37DB8000,
-          0x37DC0000, 0x37DC8000, 0x37DD0000, 0x37DD8000, 0x37DE0000,
-          0x37DE8000, 0x37DF0000, 0x37DF8000, 0x37E00000, 0x37E08000,
-          0x37E10000, 0x37E18000, 0x37E20000, 0x37E28000, 0x37E30000,
-          0x37E38000, 0x37E40000, 0x37E48000, 0x37E50000, 0x37E58000,
-          0x37E60000, 0x37E68000, 0x37E70000, 0x37E78000, 0x37E80000,
-          0x37E88000, 0x37E90000, 0x37E98000, 0x37EA0000, 0x37EA8000,
-          0x37EB0000, 0x37EB8000, 0x37EC0000, 0x37EC8000, 0x37ED0000,
-          0x37ED8000, 0x37EE0000, 0x37EE8000, 0x37EF0000, 0x37EF8000,
-          0x37F00000, 0x37F08000, 0x37F10000, 0x37F18000, 0x37F20000,
-          0x37F28000, 0x37F30000, 0x37F38000, 0x37F40000, 0x37F48000,
-          0x37F50000, 0x37F58000, 0x37F60000, 0x37F68000, 0x37F70000,
-          0x37F78000, 0x37F80000, 0x37F88000, 0x37F90000, 0x37F98000,
-          0x37FA0000, 0x37FA8000, 0x37FB0000, 0x37FB8000, 0x37FC0000,
-          0x37FC8000, 0x37FD0000, 0x37FD8000, 0x37FE0000, 0x37FE8000,
-          0x37FF0000, 0x37FF8000, 0x38000000, 0x38004000, 0x38008000,
-          0x3800C000, 0x38010000, 0x38014000, 0x38018000, 0x3801C000,
-          0x38020000, 0x38024000, 0x38028000, 0x3802C000, 0x38030000,
-          0x38034000, 0x38038000, 0x3803C000, 0x38040000, 0x38044000,
-          0x38048000, 0x3804C000, 0x38050000, 0x38054000, 0x38058000,
-          0x3805C000, 0x38060000, 0x38064000, 0x38068000, 0x3806C000,
-          0x38070000, 0x38074000, 0x38078000, 0x3807C000, 0x38080000,
-          0x38084000, 0x38088000, 0x3808C000, 0x38090000, 0x38094000,
-          0x38098000, 0x3809C000, 0x380A0000, 0x380A4000, 0x380A8000,
-          0x380AC000, 0x380B0000, 0x380B4000, 0x380B8000, 0x380BC000,
-          0x380C0000, 0x380C4000, 0x380C8000, 0x380CC000, 0x380D0000,
-          0x380D4000, 0x380D8000, 0x380DC000, 0x380E0000, 0x380E4000,
-          0x380E8000, 0x380EC000, 0x380F0000, 0x380F4000, 0x380F8000,
-          0x380FC000, 0x38100000, 0x38104000, 0x38108000, 0x3810C000,
-          0x38110000, 0x38114000, 0x38118000, 0x3811C000, 0x38120000,
-          0x38124000, 0x38128000, 0x3812C000, 0x38130000, 0x38134000,
-          0x38138000, 0x3813C000, 0x38140000, 0x38144000, 0x38148000,
-          0x3814C000, 0x38150000, 0x38154000, 0x38158000, 0x3815C000,
-          0x38160000, 0x38164000, 0x38168000, 0x3816C000, 0x38170000,
-          0x38174000, 0x38178000, 0x3817C000, 0x38180000, 0x38184000,
-          0x38188000, 0x3818C000, 0x38190000, 0x38194000, 0x38198000,
-          0x3819C000, 0x381A0000, 0x381A4000, 0x381A8000, 0x381AC000,
-          0x381B0000, 0x381B4000, 0x381B8000, 0x381BC000, 0x381C0000,
-          0x381C4000, 0x381C8000, 0x381CC000, 0x381D0000, 0x381D4000,
-          0x381D8000, 0x381DC000, 0x381E0000, 0x381E4000, 0x381E8000,
-          0x381EC000, 0x381F0000, 0x381F4000, 0x381F8000, 0x381FC000,
-          0x38200000, 0x38204000, 0x38208000, 0x3820C000, 0x38210000,
-          0x38214000, 0x38218000, 0x3821C000, 0x38220000, 0x38224000,
-          0x38228000, 0x3822C000, 0x38230000, 0x38234000, 0x38238000,
-          0x3823C000, 0x38240000, 0x38244000, 0x38248000, 0x3824C000,
-          0x38250000, 0x38254000, 0x38258000, 0x3825C000, 0x38260000,
-          0x38264000, 0x38268000, 0x3826C000, 0x38270000, 0x38274000,
-          0x38278000, 0x3827C000, 0x38280000, 0x38284000, 0x38288000,
-          0x3828C000, 0x38290000, 0x38294000, 0x38298000, 0x3829C000,
-          0x382A0000, 0x382A4000, 0x382A8000, 0x382AC000, 0x382B0000,
-          0x382B4000, 0x382B8000, 0x382BC000, 0x382C0000, 0x382C4000,
-          0x382C8000, 0x382CC000, 0x382D0000, 0x382D4000, 0x382D8000,
-          0x382DC000, 0x382E0000, 0x382E4000, 0x382E8000, 0x382EC000,
-          0x382F0000, 0x382F4000, 0x382F8000, 0x382FC000, 0x38300000,
-          0x38304000, 0x38308000, 0x3830C000, 0x38310000, 0x38314000,
-          0x38318000, 0x3831C000, 0x38320000, 0x38324000, 0x38328000,
-          0x3832C000, 0x38330000, 0x38334000, 0x38338000, 0x3833C000,
-          0x38340000, 0x38344000, 0x38348000, 0x3834C000, 0x38350000,
-          0x38354000, 0x38358000, 0x3835C000, 0x38360000, 0x38364000,
-          0x38368000, 0x3836C000, 0x38370000, 0x38374000, 0x38378000,
-          0x3837C000, 0x38380000, 0x38384000, 0x38388000, 0x3838C000,
-          0x38390000, 0x38394000, 0x38398000, 0x3839C000, 0x383A0000,
-          0x383A4000, 0x383A8000, 0x383AC000, 0x383B0000, 0x383B4000,
-          0x383B8000, 0x383BC000, 0x383C0000, 0x383C4000, 0x383C8000,
-          0x383CC000, 0x383D0000, 0x383D4000, 0x383D8000, 0x383DC000,
-          0x383E0000, 0x383E4000, 0x383E8000, 0x383EC000, 0x383F0000,
-          0x383F4000, 0x383F8000, 0x383FC000, 0x38400000, 0x38404000,
-          0x38408000, 0x3840C000, 0x38410000, 0x38414000, 0x38418000,
-          0x3841C000, 0x38420000, 0x38424000, 0x38428000, 0x3842C000,
-          0x38430000, 0x38434000, 0x38438000, 0x3843C000, 0x38440000,
-          0x38444000, 0x38448000, 0x3844C000, 0x38450000, 0x38454000,
-          0x38458000, 0x3845C000, 0x38460000, 0x38464000, 0x38468000,
-          0x3846C000, 0x38470000, 0x38474000, 0x38478000, 0x3847C000,
-          0x38480000, 0x38484000, 0x38488000, 0x3848C000, 0x38490000,
-          0x38494000, 0x38498000, 0x3849C000, 0x384A0000, 0x384A4000,
-          0x384A8000, 0x384AC000, 0x384B0000, 0x384B4000, 0x384B8000,
-          0x384BC000, 0x384C0000, 0x384C4000, 0x384C8000, 0x384CC000,
-          0x384D0000, 0x384D4000, 0x384D8000, 0x384DC000, 0x384E0000,
-          0x384E4000, 0x384E8000, 0x384EC000, 0x384F0000, 0x384F4000,
-          0x384F8000, 0x384FC000, 0x38500000, 0x38504000, 0x38508000,
-          0x3850C000, 0x38510000, 0x38514000, 0x38518000, 0x3851C000,
-          0x38520000, 0x38524000, 0x38528000, 0x3852C000, 0x38530000,
-          0x38534000, 0x38538000, 0x3853C000, 0x38540000, 0x38544000,
-          0x38548000, 0x3854C000, 0x38550000, 0x38554000, 0x38558000,
-          0x3855C000, 0x38560000, 0x38564000, 0x38568000, 0x3856C000,
-          0x38570000, 0x38574000, 0x38578000, 0x3857C000, 0x38580000,
-          0x38584000, 0x38588000, 0x3858C000, 0x38590000, 0x38594000,
-          0x38598000, 0x3859C000, 0x385A0000, 0x385A4000, 0x385A8000,
-          0x385AC000, 0x385B0000, 0x385B4000, 0x385B8000, 0x385BC000,
-          0x385C0000, 0x385C4000, 0x385C8000, 0x385CC000, 0x385D0000,
-          0x385D4000, 0x385D8000, 0x385DC000, 0x385E0000, 0x385E4000,
-          0x385E8000, 0x385EC000, 0x385F0000, 0x385F4000, 0x385F8000,
-          0x385FC000, 0x38600000, 0x38604000, 0x38608000, 0x3860C000,
-          0x38610000, 0x38614000, 0x38618000, 0x3861C000, 0x38620000,
-          0x38624000, 0x38628000, 0x3862C000, 0x38630000, 0x38634000,
-          0x38638000, 0x3863C000, 0x38640000, 0x38644000, 0x38648000,
-          0x3864C000, 0x38650000, 0x38654000, 0x38658000, 0x3865C000,
-          0x38660000, 0x38664000, 0x38668000, 0x3866C000, 0x38670000,
-          0x38674000, 0x38678000, 0x3867C000, 0x38680000, 0x38684000,
-          0x38688000, 0x3868C000, 0x38690000, 0x38694000, 0x38698000,
-          0x3869C000, 0x386A0000, 0x386A4000, 0x386A8000, 0x386AC000,
-          0x386B0000, 0x386B4000, 0x386B8000, 0x386BC000, 0x386C0000,
-          0x386C4000, 0x386C8000, 0x386CC000, 0x386D0000, 0x386D4000,
-          0x386D8000, 0x386DC000, 0x386E0000, 0x386E4000, 0x386E8000,
-          0x386EC000, 0x386F0000, 0x386F4000, 0x386F8000, 0x386FC000,
-          0x38700000, 0x38704000, 0x38708000, 0x3870C000, 0x38710000,
-          0x38714000, 0x38718000, 0x3871C000, 0x38720000, 0x38724000,
-          0x38728000, 0x3872C000, 0x38730000, 0x38734000, 0x38738000,
-          0x3873C000, 0x38740000, 0x38744000, 0x38748000, 0x3874C000,
-          0x38750000, 0x38754000, 0x38758000, 0x3875C000, 0x38760000,
-          0x38764000, 0x38768000, 0x3876C000, 0x38770000, 0x38774000,
-          0x38778000, 0x3877C000, 0x38780000, 0x38784000, 0x38788000,
-          0x3878C000, 0x38790000, 0x38794000, 0x38798000, 0x3879C000,
-          0x387A0000, 0x387A4000, 0x387A8000, 0x387AC000, 0x387B0000,
-          0x387B4000, 0x387B8000, 0x387BC000, 0x387C0000, 0x387C4000,
-          0x387C8000, 0x387CC000, 0x387D0000, 0x387D4000, 0x387D8000,
-          0x387DC000, 0x387E0000, 0x387E4000, 0x387E8000, 0x387EC000,
-          0x387F0000, 0x387F4000, 0x387F8000, 0x387FC000, 0x38000000,
-          0x38002000, 0x38004000, 0x38006000, 0x38008000, 0x3800A000,
-          0x3800C000, 0x3800E000, 0x38010000, 0x38012000, 0x38014000,
-          0x38016000, 0x38018000, 0x3801A000, 0x3801C000, 0x3801E000,
-          0x38020000, 0x38022000, 0x38024000, 0x38026000, 0x38028000,
-          0x3802A000, 0x3802C000, 0x3802E000, 0x38030000, 0x38032000,
-          0x38034000, 0x38036000, 0x38038000, 0x3803A000, 0x3803C000,
-          0x3803E000, 0x38040000, 0x38042000, 0x38044000, 0x38046000,
-          0x38048000, 0x3804A000, 0x3804C000, 0x3804E000, 0x38050000,
-          0x38052000, 0x38054000, 0x38056000, 0x38058000, 0x3805A000,
-          0x3805C000, 0x3805E000, 0x38060000, 0x38062000, 0x38064000,
-          0x38066000, 0x38068000, 0x3806A000, 0x3806C000, 0x3806E000,
-          0x38070000, 0x38072000, 0x38074000, 0x38076000, 0x38078000,
-          0x3807A000, 0x3807C000, 0x3807E000, 0x38080000, 0x38082000,
-          0x38084000, 0x38086000, 0x38088000, 0x3808A000, 0x3808C000,
-          0x3808E000, 0x38090000, 0x38092000, 0x38094000, 0x38096000,
-          0x38098000, 0x3809A000, 0x3809C000, 0x3809E000, 0x380A0000,
-          0x380A2000, 0x380A4000, 0x380A6000, 0x380A8000, 0x380AA000,
-          0x380AC000, 0x380AE000, 0x380B0000, 0x380B2000, 0x380B4000,
-          0x380B6000, 0x380B8000, 0x380BA000, 0x380BC000, 0x380BE000,
-          0x380C0000, 0x380C2000, 0x380C4000, 0x380C6000, 0x380C8000,
-          0x380CA000, 0x380CC000, 0x380CE000, 0x380D0000, 0x380D2000,
-          0x380D4000, 0x380D6000, 0x380D8000, 0x380DA000, 0x380DC000,
-          0x380DE000, 0x380E0000, 0x380E2000, 0x380E4000, 0x380E6000,
-          0x380E8000, 0x380EA000, 0x380EC000, 0x380EE000, 0x380F0000,
-          0x380F2000, 0x380F4000, 0x380F6000, 0x380F8000, 0x380FA000,
-          0x380FC000, 0x380FE000, 0x38100000, 0x38102000, 0x38104000,
-          0x38106000, 0x38108000, 0x3810A000, 0x3810C000, 0x3810E000,
-          0x38110000, 0x38112000, 0x38114000, 0x38116000, 0x38118000,
-          0x3811A000, 0x3811C000, 0x3811E000, 0x38120000, 0x38122000,
-          0x38124000, 0x38126000, 0x38128000, 0x3812A000, 0x3812C000,
-          0x3812E000, 0x38130000, 0x38132000, 0x38134000, 0x38136000,
-          0x38138000, 0x3813A000, 0x3813C000, 0x3813E000, 0x38140000,
-          0x38142000, 0x38144000, 0x38146000, 0x38148000, 0x3814A000,
-          0x3814C000, 0x3814E000, 0x38150000, 0x38152000, 0x38154000,
-          0x38156000, 0x38158000, 0x3815A000, 0x3815C000, 0x3815E000,
-          0x38160000, 0x38162000, 0x38164000, 0x38166000, 0x38168000,
-          0x3816A000, 0x3816C000, 0x3816E000, 0x38170000, 0x38172000,
-          0x38174000, 0x38176000, 0x38178000, 0x3817A000, 0x3817C000,
-          0x3817E000, 0x38180000, 0x38182000, 0x38184000, 0x38186000,
-          0x38188000, 0x3818A000, 0x3818C000, 0x3818E000, 0x38190000,
-          0x38192000, 0x38194000, 0x38196000, 0x38198000, 0x3819A000,
-          0x3819C000, 0x3819E000, 0x381A0000, 0x381A2000, 0x381A4000,
-          0x381A6000, 0x381A8000, 0x381AA000, 0x381AC000, 0x381AE000,
-          0x381B0000, 0x381B2000, 0x381B4000, 0x381B6000, 0x381B8000,
-          0x381BA000, 0x381BC000, 0x381BE000, 0x381C0000, 0x381C2000,
-          0x381C4000, 0x381C6000, 0x381C8000, 0x381CA000, 0x381CC000,
-          0x381CE000, 0x381D0000, 0x381D2000, 0x381D4000, 0x381D6000,
-          0x381D8000, 0x381DA000, 0x381DC000, 0x381DE000, 0x381E0000,
-          0x381E2000, 0x381E4000, 0x381E6000, 0x381E8000, 0x381EA000,
-          0x381EC000, 0x381EE000, 0x381F0000, 0x381F2000, 0x381F4000,
-          0x381F6000, 0x381F8000, 0x381FA000, 0x381FC000, 0x381FE000,
-          0x38200000, 0x38202000, 0x38204000, 0x38206000, 0x38208000,
-          0x3820A000, 0x3820C000, 0x3820E000, 0x38210000, 0x38212000,
-          0x38214000, 0x38216000, 0x38218000, 0x3821A000, 0x3821C000,
-          0x3821E000, 0x38220000, 0x38222000, 0x38224000, 0x38226000,
-          0x38228000, 0x3822A000, 0x3822C000, 0x3822E000, 0x38230000,
-          0x38232000, 0x38234000, 0x38236000, 0x38238000, 0x3823A000,
-          0x3823C000, 0x3823E000, 0x38240000, 0x38242000, 0x38244000,
-          0x38246000, 0x38248000, 0x3824A000, 0x3824C000, 0x3824E000,
-          0x38250000, 0x38252000, 0x38254000, 0x38256000, 0x38258000,
-          0x3825A000, 0x3825C000, 0x3825E000, 0x38260000, 0x38262000,
-          0x38264000, 0x38266000, 0x38268000, 0x3826A000, 0x3826C000,
-          0x3826E000, 0x38270000, 0x38272000, 0x38274000, 0x38276000,
-          0x38278000, 0x3827A000, 0x3827C000, 0x3827E000, 0x38280000,
-          0x38282000, 0x38284000, 0x38286000, 0x38288000, 0x3828A000,
-          0x3828C000, 0x3828E000, 0x38290000, 0x38292000, 0x38294000,
-          0x38296000, 0x38298000, 0x3829A000, 0x3829C000, 0x3829E000,
-          0x382A0000, 0x382A2000, 0x382A4000, 0x382A6000, 0x382A8000,
-          0x382AA000, 0x382AC000, 0x382AE000, 0x382B0000, 0x382B2000,
-          0x382B4000, 0x382B6000, 0x382B8000, 0x382BA000, 0x382BC000,
-          0x382BE000, 0x382C0000, 0x382C2000, 0x382C4000, 0x382C6000,
-          0x382C8000, 0x382CA000, 0x382CC000, 0x382CE000, 0x382D0000,
-          0x382D2000, 0x382D4000, 0x382D6000, 0x382D8000, 0x382DA000,
-          0x382DC000, 0x382DE000, 0x382E0000, 0x382E2000, 0x382E4000,
-          0x382E6000, 0x382E8000, 0x382EA000, 0x382EC000, 0x382EE000,
-          0x382F0000, 0x382F2000, 0x382F4000, 0x382F6000, 0x382F8000,
-          0x382FA000, 0x382FC000, 0x382FE000, 0x38300000, 0x38302000,
-          0x38304000, 0x38306000, 0x38308000, 0x3830A000, 0x3830C000,
-          0x3830E000, 0x38310000, 0x38312000, 0x38314000, 0x38316000,
-          0x38318000, 0x3831A000, 0x3831C000, 0x3831E000, 0x38320000,
-          0x38322000, 0x38324000, 0x38326000, 0x38328000, 0x3832A000,
-          0x3832C000, 0x3832E000, 0x38330000, 0x38332000, 0x38334000,
-          0x38336000, 0x38338000, 0x3833A000, 0x3833C000, 0x3833E000,
-          0x38340000, 0x38342000, 0x38344000, 0x38346000, 0x38348000,
-          0x3834A000, 0x3834C000, 0x3834E000, 0x38350000, 0x38352000,
-          0x38354000, 0x38356000, 0x38358000, 0x3835A000, 0x3835C000,
-          0x3835E000, 0x38360000, 0x38362000, 0x38364000, 0x38366000,
-          0x38368000, 0x3836A000, 0x3836C000, 0x3836E000, 0x38370000,
-          0x38372000, 0x38374000, 0x38376000, 0x38378000, 0x3837A000,
-          0x3837C000, 0x3837E000, 0x38380000, 0x38382000, 0x38384000,
-          0x38386000, 0x38388000, 0x3838A000, 0x3838C000, 0x3838E000,
-          0x38390000, 0x38392000, 0x38394000, 0x38396000, 0x38398000,
-          0x3839A000, 0x3839C000, 0x3839E000, 0x383A0000, 0x383A2000,
-          0x383A4000, 0x383A6000, 0x383A8000, 0x383AA000, 0x383AC000,
-          0x383AE000, 0x383B0000, 0x383B2000, 0x383B4000, 0x383B6000,
-          0x383B8000, 0x383BA000, 0x383BC000, 0x383BE000, 0x383C0000,
-          0x383C2000, 0x383C4000, 0x383C6000, 0x383C8000, 0x383CA000,
-          0x383CC000, 0x383CE000, 0x383D0000, 0x383D2000, 0x383D4000,
-          0x383D6000, 0x383D8000, 0x383DA000, 0x383DC000, 0x383DE000,
-          0x383E0000, 0x383E2000, 0x383E4000, 0x383E6000, 0x383E8000,
-          0x383EA000, 0x383EC000, 0x383EE000, 0x383F0000, 0x383F2000,
-          0x383F4000, 0x383F6000, 0x383F8000, 0x383FA000, 0x383FC000,
-          0x383FE000, 0x38400000, 0x38402000, 0x38404000, 0x38406000,
-          0x38408000, 0x3840A000, 0x3840C000, 0x3840E000, 0x38410000,
-          0x38412000, 0x38414000, 0x38416000, 0x38418000, 0x3841A000,
-          0x3841C000, 0x3841E000, 0x38420000, 0x38422000, 0x38424000,
-          0x38426000, 0x38428000, 0x3842A000, 0x3842C000, 0x3842E000,
-          0x38430000, 0x38432000, 0x38434000, 0x38436000, 0x38438000,
-          0x3843A000, 0x3843C000, 0x3843E000, 0x38440000, 0x38442000,
-          0x38444000, 0x38446000, 0x38448000, 0x3844A000, 0x3844C000,
-          0x3844E000, 0x38450000, 0x38452000, 0x38454000, 0x38456000,
-          0x38458000, 0x3845A000, 0x3845C000, 0x3845E000, 0x38460000,
-          0x38462000, 0x38464000, 0x38466000, 0x38468000, 0x3846A000,
-          0x3846C000, 0x3846E000, 0x38470000, 0x38472000, 0x38474000,
-          0x38476000, 0x38478000, 0x3847A000, 0x3847C000, 0x3847E000,
-          0x38480000, 0x38482000, 0x38484000, 0x38486000, 0x38488000,
-          0x3848A000, 0x3848C000, 0x3848E000, 0x38490000, 0x38492000,
-          0x38494000, 0x38496000, 0x38498000, 0x3849A000, 0x3849C000,
-          0x3849E000, 0x384A0000, 0x384A2000, 0x384A4000, 0x384A6000,
-          0x384A8000, 0x384AA000, 0x384AC000, 0x384AE000, 0x384B0000,
-          0x384B2000, 0x384B4000, 0x384B6000, 0x384B8000, 0x384BA000,
-          0x384BC000, 0x384BE000, 0x384C0000, 0x384C2000, 0x384C4000,
-          0x384C6000, 0x384C8000, 0x384CA000, 0x384CC000, 0x384CE000,
-          0x384D0000, 0x384D2000, 0x384D4000, 0x384D6000, 0x384D8000,
-          0x384DA000, 0x384DC000, 0x384DE000, 0x384E0000, 0x384E2000,
-          0x384E4000, 0x384E6000, 0x384E8000, 0x384EA000, 0x384EC000,
-          0x384EE000, 0x384F0000, 0x384F2000, 0x384F4000, 0x384F6000,
-          0x384F8000, 0x384FA000, 0x384FC000, 0x384FE000, 0x38500000,
-          0x38502000, 0x38504000, 0x38506000, 0x38508000, 0x3850A000,
-          0x3850C000, 0x3850E000, 0x38510000, 0x38512000, 0x38514000,
-          0x38516000, 0x38518000, 0x3851A000, 0x3851C000, 0x3851E000,
-          0x38520000, 0x38522000, 0x38524000, 0x38526000, 0x38528000,
-          0x3852A000, 0x3852C000, 0x3852E000, 0x38530000, 0x38532000,
-          0x38534000, 0x38536000, 0x38538000, 0x3853A000, 0x3853C000,
-          0x3853E000, 0x38540000, 0x38542000, 0x38544000, 0x38546000,
-          0x38548000, 0x3854A000, 0x3854C000, 0x3854E000, 0x38550000,
-          0x38552000, 0x38554000, 0x38556000, 0x38558000, 0x3855A000,
-          0x3855C000, 0x3855E000, 0x38560000, 0x38562000, 0x38564000,
-          0x38566000, 0x38568000, 0x3856A000, 0x3856C000, 0x3856E000,
-          0x38570000, 0x38572000, 0x38574000, 0x38576000, 0x38578000,
-          0x3857A000, 0x3857C000, 0x3857E000, 0x38580000, 0x38582000,
-          0x38584000, 0x38586000, 0x38588000, 0x3858A000, 0x3858C000,
-          0x3858E000, 0x38590000, 0x38592000, 0x38594000, 0x38596000,
-          0x38598000, 0x3859A000, 0x3859C000, 0x3859E000, 0x385A0000,
-          0x385A2000, 0x385A4000, 0x385A6000, 0x385A8000, 0x385AA000,
-          0x385AC000, 0x385AE000, 0x385B0000, 0x385B2000, 0x385B4000,
-          0x385B6000, 0x385B8000, 0x385BA000, 0x385BC000, 0x385BE000,
-          0x385C0000, 0x385C2000, 0x385C4000, 0x385C6000, 0x385C8000,
-          0x385CA000, 0x385CC000, 0x385CE000, 0x385D0000, 0x385D2000,
-          0x385D4000, 0x385D6000, 0x385D8000, 0x385DA000, 0x385DC000,
-          0x385DE000, 0x385E0000, 0x385E2000, 0x385E4000, 0x385E6000,
-          0x385E8000, 0x385EA000, 0x385EC000, 0x385EE000, 0x385F0000,
-          0x385F2000, 0x385F4000, 0x385F6000, 0x385F8000, 0x385FA000,
-          0x385FC000, 0x385FE000, 0x38600000, 0x38602000, 0x38604000,
-          0x38606000, 0x38608000, 0x3860A000, 0x3860C000, 0x3860E000,
-          0x38610000, 0x38612000, 0x38614000, 0x38616000, 0x38618000,
-          0x3861A000, 0x3861C000, 0x3861E000, 0x38620000, 0x38622000,
-          0x38624000, 0x38626000, 0x38628000, 0x3862A000, 0x3862C000,
-          0x3862E000, 0x38630000, 0x38632000, 0x38634000, 0x38636000,
-          0x38638000, 0x3863A000, 0x3863C000, 0x3863E000, 0x38640000,
-          0x38642000, 0x38644000, 0x38646000, 0x38648000, 0x3864A000,
-          0x3864C000, 0x3864E000, 0x38650000, 0x38652000, 0x38654000,
-          0x38656000, 0x38658000, 0x3865A000, 0x3865C000, 0x3865E000,
-          0x38660000, 0x38662000, 0x38664000, 0x38666000, 0x38668000,
-          0x3866A000, 0x3866C000, 0x3866E000, 0x38670000, 0x38672000,
-          0x38674000, 0x38676000, 0x38678000, 0x3867A000, 0x3867C000,
-          0x3867E000, 0x38680000, 0x38682000, 0x38684000, 0x38686000,
-          0x38688000, 0x3868A000, 0x3868C000, 0x3868E000, 0x38690000,
-          0x38692000, 0x38694000, 0x38696000, 0x38698000, 0x3869A000,
-          0x3869C000, 0x3869E000, 0x386A0000, 0x386A2000, 0x386A4000,
-          0x386A6000, 0x386A8000, 0x386AA000, 0x386AC000, 0x386AE000,
-          0x386B0000, 0x386B2000, 0x386B4000, 0x386B6000, 0x386B8000,
-          0x386BA000, 0x386BC000, 0x386BE000, 0x386C0000, 0x386C2000,
-          0x386C4000, 0x386C6000, 0x386C8000, 0x386CA000, 0x386CC000,
-          0x386CE000, 0x386D0000, 0x386D2000, 0x386D4000, 0x386D6000,
-          0x386D8000, 0x386DA000, 0x386DC000, 0x386DE000, 0x386E0000,
-          0x386E2000, 0x386E4000, 0x386E6000, 0x386E8000, 0x386EA000,
-          0x386EC000, 0x386EE000, 0x386F0000, 0x386F2000, 0x386F4000,
-          0x386F6000, 0x386F8000, 0x386FA000, 0x386FC000, 0x386FE000,
-          0x38700000, 0x38702000, 0x38704000, 0x38706000, 0x38708000,
-          0x3870A000, 0x3870C000, 0x3870E000, 0x38710000, 0x38712000,
-          0x38714000, 0x38716000, 0x38718000, 0x3871A000, 0x3871C000,
-          0x3871E000, 0x38720000, 0x38722000, 0x38724000, 0x38726000,
-          0x38728000, 0x3872A000, 0x3872C000, 0x3872E000, 0x38730000,
-          0x38732000, 0x38734000, 0x38736000, 0x38738000, 0x3873A000,
-          0x3873C000, 0x3873E000, 0x38740000, 0x38742000, 0x38744000,
-          0x38746000, 0x38748000, 0x3874A000, 0x3874C000, 0x3874E000,
-          0x38750000, 0x38752000, 0x38754000, 0x38756000, 0x38758000,
-          0x3875A000, 0x3875C000, 0x3875E000, 0x38760000, 0x38762000,
-          0x38764000, 0x38766000, 0x38768000, 0x3876A000, 0x3876C000,
-          0x3876E000, 0x38770000, 0x38772000, 0x38774000, 0x38776000,
-          0x38778000, 0x3877A000, 0x3877C000, 0x3877E000, 0x38780000,
-          0x38782000, 0x38784000, 0x38786000, 0x38788000, 0x3878A000,
-          0x3878C000, 0x3878E000, 0x38790000, 0x38792000, 0x38794000,
-          0x38796000, 0x38798000, 0x3879A000, 0x3879C000, 0x3879E000,
-          0x387A0000, 0x387A2000, 0x387A4000, 0x387A6000, 0x387A8000,
-          0x387AA000, 0x387AC000, 0x387AE000, 0x387B0000, 0x387B2000,
-          0x387B4000, 0x387B6000, 0x387B8000, 0x387BA000, 0x387BC000,
-          0x387BE000, 0x387C0000, 0x387C2000, 0x387C4000, 0x387C6000,
-          0x387C8000, 0x387CA000, 0x387CC000, 0x387CE000, 0x387D0000,
-          0x387D2000, 0x387D4000, 0x387D6000, 0x387D8000, 0x387DA000,
-          0x387DC000, 0x387DE000, 0x387E0000, 0x387E2000, 0x387E4000,
-          0x387E6000, 0x387E8000, 0x387EA000, 0x387EC000, 0x387EE000,
-          0x387F0000, 0x387F2000, 0x387F4000, 0x387F6000, 0x387F8000,
-          0x387FA000, 0x387FC000, 0x387FE000};
-  static const uint32 exponent_table[64] = {
-      0x00000000, 0x00800000, 0x01000000, 0x01800000, 0x02000000, 0x02800000,
-      0x03000000, 0x03800000, 0x04000000, 0x04800000, 0x05000000, 0x05800000,
-      0x06000000, 0x06800000, 0x07000000, 0x07800000, 0x08000000, 0x08800000,
-      0x09000000, 0x09800000, 0x0A000000, 0x0A800000, 0x0B000000, 0x0B800000,
-      0x0C000000, 0x0C800000, 0x0D000000, 0x0D800000, 0x0E000000, 0x0E800000,
-      0x0F000000, 0x47800000, 0x80000000, 0x80800000, 0x81000000, 0x81800000,
-      0x82000000, 0x82800000, 0x83000000, 0x83800000, 0x84000000, 0x84800000,
-      0x85000000, 0x85800000, 0x86000000, 0x86800000, 0x87000000, 0x87800000,
-      0x88000000, 0x88800000, 0x89000000, 0x89800000, 0x8A000000, 0x8A800000,
-      0x8B000000, 0x8B800000, 0x8C000000, 0x8C800000, 0x8D000000, 0x8D800000,
-      0x8E000000, 0x8E800000, 0x8F000000, 0xC7800000};
-  static const unsigned short offset_table[64] = {
-      0,    1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024,
-      1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024,
-      1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 0,
-      1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024,
-      1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024,
-      1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024};
-  uint32 bits = mantissa_table[offset_table[value >> 10] + (value & 0x3FF)] +
-                exponent_table[value >> 10];
-  //			return *reinterpret_cast<float*>(&bits);			//violating
-  //strict aliasing!
-  float out;
-  std::memcpy(&out, &bits, sizeof(float));
-  return out;
-}
+*/			static const uint32 mantissa_table[2048] = { 
+				0x00000000, 0x33800000, 0x34000000, 0x34400000, 0x34800000, 0x34A00000, 0x34C00000, 0x34E00000, 0x35000000, 0x35100000, 0x35200000, 0x35300000, 0x35400000, 0x35500000, 0x35600000, 0x35700000, 
+				0x35800000, 0x35880000, 0x35900000, 0x35980000, 0x35A00000, 0x35A80000, 0x35B00000, 0x35B80000, 0x35C00000, 0x35C80000, 0x35D00000, 0x35D80000, 0x35E00000, 0x35E80000, 0x35F00000, 0x35F80000, 
+				0x36000000, 0x36040000, 0x36080000, 0x360C0000, 0x36100000, 0x36140000, 0x36180000, 0x361C0000, 0x36200000, 0x36240000, 0x36280000, 0x362C0000, 0x36300000, 0x36340000, 0x36380000, 0x363C0000, 
+				0x36400000, 0x36440000, 0x36480000, 0x364C0000, 0x36500000, 0x36540000, 0x36580000, 0x365C0000, 0x36600000, 0x36640000, 0x36680000, 0x366C0000, 0x36700000, 0x36740000, 0x36780000, 0x367C0000, 
+				0x36800000, 0x36820000, 0x36840000, 0x36860000, 0x36880000, 0x368A0000, 0x368C0000, 0x368E0000, 0x36900000, 0x36920000, 0x36940000, 0x36960000, 0x36980000, 0x369A0000, 0x369C0000, 0x369E0000, 
+				0x36A00000, 0x36A20000, 0x36A40000, 0x36A60000, 0x36A80000, 0x36AA0000, 0x36AC0000, 0x36AE0000, 0x36B00000, 0x36B20000, 0x36B40000, 0x36B60000, 0x36B80000, 0x36BA0000, 0x36BC0000, 0x36BE0000, 
+				0x36C00000, 0x36C20000, 0x36C40000, 0x36C60000, 0x36C80000, 0x36CA0000, 0x36CC0000, 0x36CE0000, 0x36D00000, 0x36D20000, 0x36D40000, 0x36D60000, 0x36D80000, 0x36DA0000, 0x36DC0000, 0x36DE0000, 
+				0x36E00000, 0x36E20000, 0x36E40000, 0x36E60000, 0x36E80000, 0x36EA0000, 0x36EC0000, 0x36EE0000, 0x36F00000, 0x36F20000, 0x36F40000, 0x36F60000, 0x36F80000, 0x36FA0000, 0x36FC0000, 0x36FE0000, 
+				0x37000000, 0x37010000, 0x37020000, 0x37030000, 0x37040000, 0x37050000, 0x37060000, 0x37070000, 0x37080000, 0x37090000, 0x370A0000, 0x370B0000, 0x370C0000, 0x370D0000, 0x370E0000, 0x370F0000, 
+				0x37100000, 0x37110000, 0x37120000, 0x37130000, 0x37140000, 0x37150000, 0x37160000, 0x37170000, 0x37180000, 0x37190000, 0x371A0000, 0x371B0000, 0x371C0000, 0x371D0000, 0x371E0000, 0x371F0000, 
+				0x37200000, 0x37210000, 0x37220000, 0x37230000, 0x37240000, 0x37250000, 0x37260000, 0x37270000, 0x37280000, 0x37290000, 0x372A0000, 0x372B0000, 0x372C0000, 0x372D0000, 0x372E0000, 0x372F0000, 
+				0x37300000, 0x37310000, 0x37320000, 0x37330000, 0x37340000, 0x37350000, 0x37360000, 0x37370000, 0x37380000, 0x37390000, 0x373A0000, 0x373B0000, 0x373C0000, 0x373D0000, 0x373E0000, 0x373F0000, 
+				0x37400000, 0x37410000, 0x37420000, 0x37430000, 0x37440000, 0x37450000, 0x37460000, 0x37470000, 0x37480000, 0x37490000, 0x374A0000, 0x374B0000, 0x374C0000, 0x374D0000, 0x374E0000, 0x374F0000, 
+				0x37500000, 0x37510000, 0x37520000, 0x37530000, 0x37540000, 0x37550000, 0x37560000, 0x37570000, 0x37580000, 0x37590000, 0x375A0000, 0x375B0000, 0x375C0000, 0x375D0000, 0x375E0000, 0x375F0000, 
+				0x37600000, 0x37610000, 0x37620000, 0x37630000, 0x37640000, 0x37650000, 0x37660000, 0x37670000, 0x37680000, 0x37690000, 0x376A0000, 0x376B0000, 0x376C0000, 0x376D0000, 0x376E0000, 0x376F0000, 
+				0x37700000, 0x37710000, 0x37720000, 0x37730000, 0x37740000, 0x37750000, 0x37760000, 0x37770000, 0x37780000, 0x37790000, 0x377A0000, 0x377B0000, 0x377C0000, 0x377D0000, 0x377E0000, 0x377F0000, 
+				0x37800000, 0x37808000, 0x37810000, 0x37818000, 0x37820000, 0x37828000, 0x37830000, 0x37838000, 0x37840000, 0x37848000, 0x37850000, 0x37858000, 0x37860000, 0x37868000, 0x37870000, 0x37878000, 
+				0x37880000, 0x37888000, 0x37890000, 0x37898000, 0x378A0000, 0x378A8000, 0x378B0000, 0x378B8000, 0x378C0000, 0x378C8000, 0x378D0000, 0x378D8000, 0x378E0000, 0x378E8000, 0x378F0000, 0x378F8000, 
+				0x37900000, 0x37908000, 0x37910000, 0x37918000, 0x37920000, 0x37928000, 0x37930000, 0x37938000, 0x37940000, 0x37948000, 0x37950000, 0x37958000, 0x37960000, 0x37968000, 0x37970000, 0x37978000, 
+				0x37980000, 0x37988000, 0x37990000, 0x37998000, 0x379A0000, 0x379A8000, 0x379B0000, 0x379B8000, 0x379C0000, 0x379C8000, 0x379D0000, 0x379D8000, 0x379E0000, 0x379E8000, 0x379F0000, 0x379F8000, 
+				0x37A00000, 0x37A08000, 0x37A10000, 0x37A18000, 0x37A20000, 0x37A28000, 0x37A30000, 0x37A38000, 0x37A40000, 0x37A48000, 0x37A50000, 0x37A58000, 0x37A60000, 0x37A68000, 0x37A70000, 0x37A78000, 
+				0x37A80000, 0x37A88000, 0x37A90000, 0x37A98000, 0x37AA0000, 0x37AA8000, 0x37AB0000, 0x37AB8000, 0x37AC0000, 0x37AC8000, 0x37AD0000, 0x37AD8000, 0x37AE0000, 0x37AE8000, 0x37AF0000, 0x37AF8000, 
+				0x37B00000, 0x37B08000, 0x37B10000, 0x37B18000, 0x37B20000, 0x37B28000, 0x37B30000, 0x37B38000, 0x37B40000, 0x37B48000, 0x37B50000, 0x37B58000, 0x37B60000, 0x37B68000, 0x37B70000, 0x37B78000, 
+				0x37B80000, 0x37B88000, 0x37B90000, 0x37B98000, 0x37BA0000, 0x37BA8000, 0x37BB0000, 0x37BB8000, 0x37BC0000, 0x37BC8000, 0x37BD0000, 0x37BD8000, 0x37BE0000, 0x37BE8000, 0x37BF0000, 0x37BF8000, 
+				0x37C00000, 0x37C08000, 0x37C10000, 0x37C18000, 0x37C20000, 0x37C28000, 0x37C30000, 0x37C38000, 0x37C40000, 0x37C48000, 0x37C50000, 0x37C58000, 0x37C60000, 0x37C68000, 0x37C70000, 0x37C78000, 
+				0x37C80000, 0x37C88000, 0x37C90000, 0x37C98000, 0x37CA0000, 0x37CA8000, 0x37CB0000, 0x37CB8000, 0x37CC0000, 0x37CC8000, 0x37CD0000, 0x37CD8000, 0x37CE0000, 0x37CE8000, 0x37CF0000, 0x37CF8000, 
+				0x37D00000, 0x37D08000, 0x37D10000, 0x37D18000, 0x37D20000, 0x37D28000, 0x37D30000, 0x37D38000, 0x37D40000, 0x37D48000, 0x37D50000, 0x37D58000, 0x37D60000, 0x37D68000, 0x37D70000, 0x37D78000, 
+				0x37D80000, 0x37D88000, 0x37D90000, 0x37D98000, 0x37DA0000, 0x37DA8000, 0x37DB0000, 0x37DB8000, 0x37DC0000, 0x37DC8000, 0x37DD0000, 0x37DD8000, 0x37DE0000, 0x37DE8000, 0x37DF0000, 0x37DF8000, 
+				0x37E00000, 0x37E08000, 0x37E10000, 0x37E18000, 0x37E20000, 0x37E28000, 0x37E30000, 0x37E38000, 0x37E40000, 0x37E48000, 0x37E50000, 0x37E58000, 0x37E60000, 0x37E68000, 0x37E70000, 0x37E78000, 
+				0x37E80000, 0x37E88000, 0x37E90000, 0x37E98000, 0x37EA0000, 0x37EA8000, 0x37EB0000, 0x37EB8000, 0x37EC0000, 0x37EC8000, 0x37ED0000, 0x37ED8000, 0x37EE0000, 0x37EE8000, 0x37EF0000, 0x37EF8000, 
+				0x37F00000, 0x37F08000, 0x37F10000, 0x37F18000, 0x37F20000, 0x37F28000, 0x37F30000, 0x37F38000, 0x37F40000, 0x37F48000, 0x37F50000, 0x37F58000, 0x37F60000, 0x37F68000, 0x37F70000, 0x37F78000, 
+				0x37F80000, 0x37F88000, 0x37F90000, 0x37F98000, 0x37FA0000, 0x37FA8000, 0x37FB0000, 0x37FB8000, 0x37FC0000, 0x37FC8000, 0x37FD0000, 0x37FD8000, 0x37FE0000, 0x37FE8000, 0x37FF0000, 0x37FF8000, 
+				0x38000000, 0x38004000, 0x38008000, 0x3800C000, 0x38010000, 0x38014000, 0x38018000, 0x3801C000, 0x38020000, 0x38024000, 0x38028000, 0x3802C000, 0x38030000, 0x38034000, 0x38038000, 0x3803C000, 
+				0x38040000, 0x38044000, 0x38048000, 0x3804C000, 0x38050000, 0x38054000, 0x38058000, 0x3805C000, 0x38060000, 0x38064000, 0x38068000, 0x3806C000, 0x38070000, 0x38074000, 0x38078000, 0x3807C000, 
+				0x38080000, 0x38084000, 0x38088000, 0x3808C000, 0x38090000, 0x38094000, 0x38098000, 0x3809C000, 0x380A0000, 0x380A4000, 0x380A8000, 0x380AC000, 0x380B0000, 0x380B4000, 0x380B8000, 0x380BC000, 
+				0x380C0000, 0x380C4000, 0x380C8000, 0x380CC000, 0x380D0000, 0x380D4000, 0x380D8000, 0x380DC000, 0x380E0000, 0x380E4000, 0x380E8000, 0x380EC000, 0x380F0000, 0x380F4000, 0x380F8000, 0x380FC000, 
+				0x38100000, 0x38104000, 0x38108000, 0x3810C000, 0x38110000, 0x38114000, 0x38118000, 0x3811C000, 0x38120000, 0x38124000, 0x38128000, 0x3812C000, 0x38130000, 0x38134000, 0x38138000, 0x3813C000, 
+				0x38140000, 0x38144000, 0x38148000, 0x3814C000, 0x38150000, 0x38154000, 0x38158000, 0x3815C000, 0x38160000, 0x38164000, 0x38168000, 0x3816C000, 0x38170000, 0x38174000, 0x38178000, 0x3817C000, 
+				0x38180000, 0x38184000, 0x38188000, 0x3818C000, 0x38190000, 0x38194000, 0x38198000, 0x3819C000, 0x381A0000, 0x381A4000, 0x381A8000, 0x381AC000, 0x381B0000, 0x381B4000, 0x381B8000, 0x381BC000, 
+				0x381C0000, 0x381C4000, 0x381C8000, 0x381CC000, 0x381D0000, 0x381D4000, 0x381D8000, 0x381DC000, 0x381E0000, 0x381E4000, 0x381E8000, 0x381EC000, 0x381F0000, 0x381F4000, 0x381F8000, 0x381FC000, 
+				0x38200000, 0x38204000, 0x38208000, 0x3820C000, 0x38210000, 0x38214000, 0x38218000, 0x3821C000, 0x38220000, 0x38224000, 0x38228000, 0x3822C000, 0x38230000, 0x38234000, 0x38238000, 0x3823C000, 
+				0x38240000, 0x38244000, 0x38248000, 0x3824C000, 0x38250000, 0x38254000, 0x38258000, 0x3825C000, 0x38260000, 0x38264000, 0x38268000, 0x3826C000, 0x38270000, 0x38274000, 0x38278000, 0x3827C000, 
+				0x38280000, 0x38284000, 0x38288000, 0x3828C000, 0x38290000, 0x38294000, 0x38298000, 0x3829C000, 0x382A0000, 0x382A4000, 0x382A8000, 0x382AC000, 0x382B0000, 0x382B4000, 0x382B8000, 0x382BC000, 
+				0x382C0000, 0x382C4000, 0x382C8000, 0x382CC000, 0x382D0000, 0x382D4000, 0x382D8000, 0x382DC000, 0x382E0000, 0x382E4000, 0x382E8000, 0x382EC000, 0x382F0000, 0x382F4000, 0x382F8000, 0x382FC000, 
+				0x38300000, 0x38304000, 0x38308000, 0x3830C000, 0x38310000, 0x38314000, 0x38318000, 0x3831C000, 0x38320000, 0x38324000, 0x38328000, 0x3832C000, 0x38330000, 0x38334000, 0x38338000, 0x3833C000, 
+				0x38340000, 0x38344000, 0x38348000, 0x3834C000, 0x38350000, 0x38354000, 0x38358000, 0x3835C000, 0x38360000, 0x38364000, 0x38368000, 0x3836C000, 0x38370000, 0x38374000, 0x38378000, 0x3837C000, 
+				0x38380000, 0x38384000, 0x38388000, 0x3838C000, 0x38390000, 0x38394000, 0x38398000, 0x3839C000, 0x383A0000, 0x383A4000, 0x383A8000, 0x383AC000, 0x383B0000, 0x383B4000, 0x383B8000, 0x383BC000, 
+				0x383C0000, 0x383C4000, 0x383C8000, 0x383CC000, 0x383D0000, 0x383D4000, 0x383D8000, 0x383DC000, 0x383E0000, 0x383E4000, 0x383E8000, 0x383EC000, 0x383F0000, 0x383F4000, 0x383F8000, 0x383FC000, 
+				0x38400000, 0x38404000, 0x38408000, 0x3840C000, 0x38410000, 0x38414000, 0x38418000, 0x3841C000, 0x38420000, 0x38424000, 0x38428000, 0x3842C000, 0x38430000, 0x38434000, 0x38438000, 0x3843C000, 
+				0x38440000, 0x38444000, 0x38448000, 0x3844C000, 0x38450000, 0x38454000, 0x38458000, 0x3845C000, 0x38460000, 0x38464000, 0x38468000, 0x3846C000, 0x38470000, 0x38474000, 0x38478000, 0x3847C000, 
+				0x38480000, 0x38484000, 0x38488000, 0x3848C000, 0x38490000, 0x38494000, 0x38498000, 0x3849C000, 0x384A0000, 0x384A4000, 0x384A8000, 0x384AC000, 0x384B0000, 0x384B4000, 0x384B8000, 0x384BC000, 
+				0x384C0000, 0x384C4000, 0x384C8000, 0x384CC000, 0x384D0000, 0x384D4000, 0x384D8000, 0x384DC000, 0x384E0000, 0x384E4000, 0x384E8000, 0x384EC000, 0x384F0000, 0x384F4000, 0x384F8000, 0x384FC000, 
+				0x38500000, 0x38504000, 0x38508000, 0x3850C000, 0x38510000, 0x38514000, 0x38518000, 0x3851C000, 0x38520000, 0x38524000, 0x38528000, 0x3852C000, 0x38530000, 0x38534000, 0x38538000, 0x3853C000, 
+				0x38540000, 0x38544000, 0x38548000, 0x3854C000, 0x38550000, 0x38554000, 0x38558000, 0x3855C000, 0x38560000, 0x38564000, 0x38568000, 0x3856C000, 0x38570000, 0x38574000, 0x38578000, 0x3857C000, 
+				0x38580000, 0x38584000, 0x38588000, 0x3858C000, 0x38590000, 0x38594000, 0x38598000, 0x3859C000, 0x385A0000, 0x385A4000, 0x385A8000, 0x385AC000, 0x385B0000, 0x385B4000, 0x385B8000, 0x385BC000, 
+				0x385C0000, 0x385C4000, 0x385C8000, 0x385CC000, 0x385D0000, 0x385D4000, 0x385D8000, 0x385DC000, 0x385E0000, 0x385E4000, 0x385E8000, 0x385EC000, 0x385F0000, 0x385F4000, 0x385F8000, 0x385FC000, 
+				0x38600000, 0x38604000, 0x38608000, 0x3860C000, 0x38610000, 0x38614000, 0x38618000, 0x3861C000, 0x38620000, 0x38624000, 0x38628000, 0x3862C000, 0x38630000, 0x38634000, 0x38638000, 0x3863C000, 
+				0x38640000, 0x38644000, 0x38648000, 0x3864C000, 0x38650000, 0x38654000, 0x38658000, 0x3865C000, 0x38660000, 0x38664000, 0x38668000, 0x3866C000, 0x38670000, 0x38674000, 0x38678000, 0x3867C000, 
+				0x38680000, 0x38684000, 0x38688000, 0x3868C000, 0x38690000, 0x38694000, 0x38698000, 0x3869C000, 0x386A0000, 0x386A4000, 0x386A8000, 0x386AC000, 0x386B0000, 0x386B4000, 0x386B8000, 0x386BC000, 
+				0x386C0000, 0x386C4000, 0x386C8000, 0x386CC000, 0x386D0000, 0x386D4000, 0x386D8000, 0x386DC000, 0x386E0000, 0x386E4000, 0x386E8000, 0x386EC000, 0x386F0000, 0x386F4000, 0x386F8000, 0x386FC000, 
+				0x38700000, 0x38704000, 0x38708000, 0x3870C000, 0x38710000, 0x38714000, 0x38718000, 0x3871C000, 0x38720000, 0x38724000, 0x38728000, 0x3872C000, 0x38730000, 0x38734000, 0x38738000, 0x3873C000, 
+				0x38740000, 0x38744000, 0x38748000, 0x3874C000, 0x38750000, 0x38754000, 0x38758000, 0x3875C000, 0x38760000, 0x38764000, 0x38768000, 0x3876C000, 0x38770000, 0x38774000, 0x38778000, 0x3877C000, 
+				0x38780000, 0x38784000, 0x38788000, 0x3878C000, 0x38790000, 0x38794000, 0x38798000, 0x3879C000, 0x387A0000, 0x387A4000, 0x387A8000, 0x387AC000, 0x387B0000, 0x387B4000, 0x387B8000, 0x387BC000, 
+				0x387C0000, 0x387C4000, 0x387C8000, 0x387CC000, 0x387D0000, 0x387D4000, 0x387D8000, 0x387DC000, 0x387E0000, 0x387E4000, 0x387E8000, 0x387EC000, 0x387F0000, 0x387F4000, 0x387F8000, 0x387FC000, 
+				0x38000000, 0x38002000, 0x38004000, 0x38006000, 0x38008000, 0x3800A000, 0x3800C000, 0x3800E000, 0x38010000, 0x38012000, 0x38014000, 0x38016000, 0x38018000, 0x3801A000, 0x3801C000, 0x3801E000, 
+				0x38020000, 0x38022000, 0x38024000, 0x38026000, 0x38028000, 0x3802A000, 0x3802C000, 0x3802E000, 0x38030000, 0x38032000, 0x38034000, 0x38036000, 0x38038000, 0x3803A000, 0x3803C000, 0x3803E000, 
+				0x38040000, 0x38042000, 0x38044000, 0x38046000, 0x38048000, 0x3804A000, 0x3804C000, 0x3804E000, 0x38050000, 0x38052000, 0x38054000, 0x38056000, 0x38058000, 0x3805A000, 0x3805C000, 0x3805E000, 
+				0x38060000, 0x38062000, 0x38064000, 0x38066000, 0x38068000, 0x3806A000, 0x3806C000, 0x3806E000, 0x38070000, 0x38072000, 0x38074000, 0x38076000, 0x38078000, 0x3807A000, 0x3807C000, 0x3807E000, 
+				0x38080000, 0x38082000, 0x38084000, 0x38086000, 0x38088000, 0x3808A000, 0x3808C000, 0x3808E000, 0x38090000, 0x38092000, 0x38094000, 0x38096000, 0x38098000, 0x3809A000, 0x3809C000, 0x3809E000, 
+				0x380A0000, 0x380A2000, 0x380A4000, 0x380A6000, 0x380A8000, 0x380AA000, 0x380AC000, 0x380AE000, 0x380B0000, 0x380B2000, 0x380B4000, 0x380B6000, 0x380B8000, 0x380BA000, 0x380BC000, 0x380BE000, 
+				0x380C0000, 0x380C2000, 0x380C4000, 0x380C6000, 0x380C8000, 0x380CA000, 0x380CC000, 0x380CE000, 0x380D0000, 0x380D2000, 0x380D4000, 0x380D6000, 0x380D8000, 0x380DA000, 0x380DC000, 0x380DE000, 
+				0x380E0000, 0x380E2000, 0x380E4000, 0x380E6000, 0x380E8000, 0x380EA000, 0x380EC000, 0x380EE000, 0x380F0000, 0x380F2000, 0x380F4000, 0x380F6000, 0x380F8000, 0x380FA000, 0x380FC000, 0x380FE000, 
+				0x38100000, 0x38102000, 0x38104000, 0x38106000, 0x38108000, 0x3810A000, 0x3810C000, 0x3810E000, 0x38110000, 0x38112000, 0x38114000, 0x38116000, 0x38118000, 0x3811A000, 0x3811C000, 0x3811E000, 
+				0x38120000, 0x38122000, 0x38124000, 0x38126000, 0x38128000, 0x3812A000, 0x3812C000, 0x3812E000, 0x38130000, 0x38132000, 0x38134000, 0x38136000, 0x38138000, 0x3813A000, 0x3813C000, 0x3813E000, 
+				0x38140000, 0x38142000, 0x38144000, 0x38146000, 0x38148000, 0x3814A000, 0x3814C000, 0x3814E000, 0x38150000, 0x38152000, 0x38154000, 0x38156000, 0x38158000, 0x3815A000, 0x3815C000, 0x3815E000, 
+				0x38160000, 0x38162000, 0x38164000, 0x38166000, 0x38168000, 0x3816A000, 0x3816C000, 0x3816E000, 0x38170000, 0x38172000, 0x38174000, 0x38176000, 0x38178000, 0x3817A000, 0x3817C000, 0x3817E000, 
+				0x38180000, 0x38182000, 0x38184000, 0x38186000, 0x38188000, 0x3818A000, 0x3818C000, 0x3818E000, 0x38190000, 0x38192000, 0x38194000, 0x38196000, 0x38198000, 0x3819A000, 0x3819C000, 0x3819E000, 
+				0x381A0000, 0x381A2000, 0x381A4000, 0x381A6000, 0x381A8000, 0x381AA000, 0x381AC000, 0x381AE000, 0x381B0000, 0x381B2000, 0x381B4000, 0x381B6000, 0x381B8000, 0x381BA000, 0x381BC000, 0x381BE000, 
+				0x381C0000, 0x381C2000, 0x381C4000, 0x381C6000, 0x381C8000, 0x381CA000, 0x381CC000, 0x381CE000, 0x381D0000, 0x381D2000, 0x381D4000, 0x381D6000, 0x381D8000, 0x381DA000, 0x381DC000, 0x381DE000, 
+				0x381E0000, 0x381E2000, 0x381E4000, 0x381E6000, 0x381E8000, 0x381EA000, 0x381EC000, 0x381EE000, 0x381F0000, 0x381F2000, 0x381F4000, 0x381F6000, 0x381F8000, 0x381FA000, 0x381FC000, 0x381FE000, 
+				0x38200000, 0x38202000, 0x38204000, 0x38206000, 0x38208000, 0x3820A000, 0x3820C000, 0x3820E000, 0x38210000, 0x38212000, 0x38214000, 0x38216000, 0x38218000, 0x3821A000, 0x3821C000, 0x3821E000, 
+				0x38220000, 0x38222000, 0x38224000, 0x38226000, 0x38228000, 0x3822A000, 0x3822C000, 0x3822E000, 0x38230000, 0x38232000, 0x38234000, 0x38236000, 0x38238000, 0x3823A000, 0x3823C000, 0x3823E000, 
+				0x38240000, 0x38242000, 0x38244000, 0x38246000, 0x38248000, 0x3824A000, 0x3824C000, 0x3824E000, 0x38250000, 0x38252000, 0x38254000, 0x38256000, 0x38258000, 0x3825A000, 0x3825C000, 0x3825E000, 
+				0x38260000, 0x38262000, 0x38264000, 0x38266000, 0x38268000, 0x3826A000, 0x3826C000, 0x3826E000, 0x38270000, 0x38272000, 0x38274000, 0x38276000, 0x38278000, 0x3827A000, 0x3827C000, 0x3827E000, 
+				0x38280000, 0x38282000, 0x38284000, 0x38286000, 0x38288000, 0x3828A000, 0x3828C000, 0x3828E000, 0x38290000, 0x38292000, 0x38294000, 0x38296000, 0x38298000, 0x3829A000, 0x3829C000, 0x3829E000, 
+				0x382A0000, 0x382A2000, 0x382A4000, 0x382A6000, 0x382A8000, 0x382AA000, 0x382AC000, 0x382AE000, 0x382B0000, 0x382B2000, 0x382B4000, 0x382B6000, 0x382B8000, 0x382BA000, 0x382BC000, 0x382BE000, 
+				0x382C0000, 0x382C2000, 0x382C4000, 0x382C6000, 0x382C8000, 0x382CA000, 0x382CC000, 0x382CE000, 0x382D0000, 0x382D2000, 0x382D4000, 0x382D6000, 0x382D8000, 0x382DA000, 0x382DC000, 0x382DE000, 
+				0x382E0000, 0x382E2000, 0x382E4000, 0x382E6000, 0x382E8000, 0x382EA000, 0x382EC000, 0x382EE000, 0x382F0000, 0x382F2000, 0x382F4000, 0x382F6000, 0x382F8000, 0x382FA000, 0x382FC000, 0x382FE000, 
+				0x38300000, 0x38302000, 0x38304000, 0x38306000, 0x38308000, 0x3830A000, 0x3830C000, 0x3830E000, 0x38310000, 0x38312000, 0x38314000, 0x38316000, 0x38318000, 0x3831A000, 0x3831C000, 0x3831E000, 
+				0x38320000, 0x38322000, 0x38324000, 0x38326000, 0x38328000, 0x3832A000, 0x3832C000, 0x3832E000, 0x38330000, 0x38332000, 0x38334000, 0x38336000, 0x38338000, 0x3833A000, 0x3833C000, 0x3833E000, 
+				0x38340000, 0x38342000, 0x38344000, 0x38346000, 0x38348000, 0x3834A000, 0x3834C000, 0x3834E000, 0x38350000, 0x38352000, 0x38354000, 0x38356000, 0x38358000, 0x3835A000, 0x3835C000, 0x3835E000, 
+				0x38360000, 0x38362000, 0x38364000, 0x38366000, 0x38368000, 0x3836A000, 0x3836C000, 0x3836E000, 0x38370000, 0x38372000, 0x38374000, 0x38376000, 0x38378000, 0x3837A000, 0x3837C000, 0x3837E000, 
+				0x38380000, 0x38382000, 0x38384000, 0x38386000, 0x38388000, 0x3838A000, 0x3838C000, 0x3838E000, 0x38390000, 0x38392000, 0x38394000, 0x38396000, 0x38398000, 0x3839A000, 0x3839C000, 0x3839E000, 
+				0x383A0000, 0x383A2000, 0x383A4000, 0x383A6000, 0x383A8000, 0x383AA000, 0x383AC000, 0x383AE000, 0x383B0000, 0x383B2000, 0x383B4000, 0x383B6000, 0x383B8000, 0x383BA000, 0x383BC000, 0x383BE000, 
+				0x383C0000, 0x383C2000, 0x383C4000, 0x383C6000, 0x383C8000, 0x383CA000, 0x383CC000, 0x383CE000, 0x383D0000, 0x383D2000, 0x383D4000, 0x383D6000, 0x383D8000, 0x383DA000, 0x383DC000, 0x383DE000, 
+				0x383E0000, 0x383E2000, 0x383E4000, 0x383E6000, 0x383E8000, 0x383EA000, 0x383EC000, 0x383EE000, 0x383F0000, 0x383F2000, 0x383F4000, 0x383F6000, 0x383F8000, 0x383FA000, 0x383FC000, 0x383FE000, 
+				0x38400000, 0x38402000, 0x38404000, 0x38406000, 0x38408000, 0x3840A000, 0x3840C000, 0x3840E000, 0x38410000, 0x38412000, 0x38414000, 0x38416000, 0x38418000, 0x3841A000, 0x3841C000, 0x3841E000, 
+				0x38420000, 0x38422000, 0x38424000, 0x38426000, 0x38428000, 0x3842A000, 0x3842C000, 0x3842E000, 0x38430000, 0x38432000, 0x38434000, 0x38436000, 0x38438000, 0x3843A000, 0x3843C000, 0x3843E000, 
+				0x38440000, 0x38442000, 0x38444000, 0x38446000, 0x38448000, 0x3844A000, 0x3844C000, 0x3844E000, 0x38450000, 0x38452000, 0x38454000, 0x38456000, 0x38458000, 0x3845A000, 0x3845C000, 0x3845E000, 
+				0x38460000, 0x38462000, 0x38464000, 0x38466000, 0x38468000, 0x3846A000, 0x3846C000, 0x3846E000, 0x38470000, 0x38472000, 0x38474000, 0x38476000, 0x38478000, 0x3847A000, 0x3847C000, 0x3847E000, 
+				0x38480000, 0x38482000, 0x38484000, 0x38486000, 0x38488000, 0x3848A000, 0x3848C000, 0x3848E000, 0x38490000, 0x38492000, 0x38494000, 0x38496000, 0x38498000, 0x3849A000, 0x3849C000, 0x3849E000, 
+				0x384A0000, 0x384A2000, 0x384A4000, 0x384A6000, 0x384A8000, 0x384AA000, 0x384AC000, 0x384AE000, 0x384B0000, 0x384B2000, 0x384B4000, 0x384B6000, 0x384B8000, 0x384BA000, 0x384BC000, 0x384BE000, 
+				0x384C0000, 0x384C2000, 0x384C4000, 0x384C6000, 0x384C8000, 0x384CA000, 0x384CC000, 0x384CE000, 0x384D0000, 0x384D2000, 0x384D4000, 0x384D6000, 0x384D8000, 0x384DA000, 0x384DC000, 0x384DE000, 
+				0x384E0000, 0x384E2000, 0x384E4000, 0x384E6000, 0x384E8000, 0x384EA000, 0x384EC000, 0x384EE000, 0x384F0000, 0x384F2000, 0x384F4000, 0x384F6000, 0x384F8000, 0x384FA000, 0x384FC000, 0x384FE000, 
+				0x38500000, 0x38502000, 0x38504000, 0x38506000, 0x38508000, 0x3850A000, 0x3850C000, 0x3850E000, 0x38510000, 0x38512000, 0x38514000, 0x38516000, 0x38518000, 0x3851A000, 0x3851C000, 0x3851E000, 
+				0x38520000, 0x38522000, 0x38524000, 0x38526000, 0x38528000, 0x3852A000, 0x3852C000, 0x3852E000, 0x38530000, 0x38532000, 0x38534000, 0x38536000, 0x38538000, 0x3853A000, 0x3853C000, 0x3853E000, 
+				0x38540000, 0x38542000, 0x38544000, 0x38546000, 0x38548000, 0x3854A000, 0x3854C000, 0x3854E000, 0x38550000, 0x38552000, 0x38554000, 0x38556000, 0x38558000, 0x3855A000, 0x3855C000, 0x3855E000, 
+				0x38560000, 0x38562000, 0x38564000, 0x38566000, 0x38568000, 0x3856A000, 0x3856C000, 0x3856E000, 0x38570000, 0x38572000, 0x38574000, 0x38576000, 0x38578000, 0x3857A000, 0x3857C000, 0x3857E000, 
+				0x38580000, 0x38582000, 0x38584000, 0x38586000, 0x38588000, 0x3858A000, 0x3858C000, 0x3858E000, 0x38590000, 0x38592000, 0x38594000, 0x38596000, 0x38598000, 0x3859A000, 0x3859C000, 0x3859E000, 
+				0x385A0000, 0x385A2000, 0x385A4000, 0x385A6000, 0x385A8000, 0x385AA000, 0x385AC000, 0x385AE000, 0x385B0000, 0x385B2000, 0x385B4000, 0x385B6000, 0x385B8000, 0x385BA000, 0x385BC000, 0x385BE000, 
+				0x385C0000, 0x385C2000, 0x385C4000, 0x385C6000, 0x385C8000, 0x385CA000, 0x385CC000, 0x385CE000, 0x385D0000, 0x385D2000, 0x385D4000, 0x385D6000, 0x385D8000, 0x385DA000, 0x385DC000, 0x385DE000, 
+				0x385E0000, 0x385E2000, 0x385E4000, 0x385E6000, 0x385E8000, 0x385EA000, 0x385EC000, 0x385EE000, 0x385F0000, 0x385F2000, 0x385F4000, 0x385F6000, 0x385F8000, 0x385FA000, 0x385FC000, 0x385FE000, 
+				0x38600000, 0x38602000, 0x38604000, 0x38606000, 0x38608000, 0x3860A000, 0x3860C000, 0x3860E000, 0x38610000, 0x38612000, 0x38614000, 0x38616000, 0x38618000, 0x3861A000, 0x3861C000, 0x3861E000, 
+				0x38620000, 0x38622000, 0x38624000, 0x38626000, 0x38628000, 0x3862A000, 0x3862C000, 0x3862E000, 0x38630000, 0x38632000, 0x38634000, 0x38636000, 0x38638000, 0x3863A000, 0x3863C000, 0x3863E000, 
+				0x38640000, 0x38642000, 0x38644000, 0x38646000, 0x38648000, 0x3864A000, 0x3864C000, 0x3864E000, 0x38650000, 0x38652000, 0x38654000, 0x38656000, 0x38658000, 0x3865A000, 0x3865C000, 0x3865E000, 
+				0x38660000, 0x38662000, 0x38664000, 0x38666000, 0x38668000, 0x3866A000, 0x3866C000, 0x3866E000, 0x38670000, 0x38672000, 0x38674000, 0x38676000, 0x38678000, 0x3867A000, 0x3867C000, 0x3867E000, 
+				0x38680000, 0x38682000, 0x38684000, 0x38686000, 0x38688000, 0x3868A000, 0x3868C000, 0x3868E000, 0x38690000, 0x38692000, 0x38694000, 0x38696000, 0x38698000, 0x3869A000, 0x3869C000, 0x3869E000, 
+				0x386A0000, 0x386A2000, 0x386A4000, 0x386A6000, 0x386A8000, 0x386AA000, 0x386AC000, 0x386AE000, 0x386B0000, 0x386B2000, 0x386B4000, 0x386B6000, 0x386B8000, 0x386BA000, 0x386BC000, 0x386BE000, 
+				0x386C0000, 0x386C2000, 0x386C4000, 0x386C6000, 0x386C8000, 0x386CA000, 0x386CC000, 0x386CE000, 0x386D0000, 0x386D2000, 0x386D4000, 0x386D6000, 0x386D8000, 0x386DA000, 0x386DC000, 0x386DE000, 
+				0x386E0000, 0x386E2000, 0x386E4000, 0x386E6000, 0x386E8000, 0x386EA000, 0x386EC000, 0x386EE000, 0x386F0000, 0x386F2000, 0x386F4000, 0x386F6000, 0x386F8000, 0x386FA000, 0x386FC000, 0x386FE000, 
+				0x38700000, 0x38702000, 0x38704000, 0x38706000, 0x38708000, 0x3870A000, 0x3870C000, 0x3870E000, 0x38710000, 0x38712000, 0x38714000, 0x38716000, 0x38718000, 0x3871A000, 0x3871C000, 0x3871E000, 
+				0x38720000, 0x38722000, 0x38724000, 0x38726000, 0x38728000, 0x3872A000, 0x3872C000, 0x3872E000, 0x38730000, 0x38732000, 0x38734000, 0x38736000, 0x38738000, 0x3873A000, 0x3873C000, 0x3873E000, 
+				0x38740000, 0x38742000, 0x38744000, 0x38746000, 0x38748000, 0x3874A000, 0x3874C000, 0x3874E000, 0x38750000, 0x38752000, 0x38754000, 0x38756000, 0x38758000, 0x3875A000, 0x3875C000, 0x3875E000, 
+				0x38760000, 0x38762000, 0x38764000, 0x38766000, 0x38768000, 0x3876A000, 0x3876C000, 0x3876E000, 0x38770000, 0x38772000, 0x38774000, 0x38776000, 0x38778000, 0x3877A000, 0x3877C000, 0x3877E000, 
+				0x38780000, 0x38782000, 0x38784000, 0x38786000, 0x38788000, 0x3878A000, 0x3878C000, 0x3878E000, 0x38790000, 0x38792000, 0x38794000, 0x38796000, 0x38798000, 0x3879A000, 0x3879C000, 0x3879E000, 
+				0x387A0000, 0x387A2000, 0x387A4000, 0x387A6000, 0x387A8000, 0x387AA000, 0x387AC000, 0x387AE000, 0x387B0000, 0x387B2000, 0x387B4000, 0x387B6000, 0x387B8000, 0x387BA000, 0x387BC000, 0x387BE000, 
+				0x387C0000, 0x387C2000, 0x387C4000, 0x387C6000, 0x387C8000, 0x387CA000, 0x387CC000, 0x387CE000, 0x387D0000, 0x387D2000, 0x387D4000, 0x387D6000, 0x387D8000, 0x387DA000, 0x387DC000, 0x387DE000, 
+				0x387E0000, 0x387E2000, 0x387E4000, 0x387E6000, 0x387E8000, 0x387EA000, 0x387EC000, 0x387EE000, 0x387F0000, 0x387F2000, 0x387F4000, 0x387F6000, 0x387F8000, 0x387FA000, 0x387FC000, 0x387FE000 };
+			static const uint32 exponent_table[64] = { 
+				0x00000000, 0x00800000, 0x01000000, 0x01800000, 0x02000000, 0x02800000, 0x03000000, 0x03800000, 0x04000000, 0x04800000, 0x05000000, 0x05800000, 0x06000000, 0x06800000, 0x07000000, 0x07800000, 
+				0x08000000, 0x08800000, 0x09000000, 0x09800000, 0x0A000000, 0x0A800000, 0x0B000000, 0x0B800000, 0x0C000000, 0x0C800000, 0x0D000000, 0x0D800000, 0x0E000000, 0x0E800000, 0x0F000000, 0x47800000, 
+				0x80000000, 0x80800000, 0x81000000, 0x81800000, 0x82000000, 0x82800000, 0x83000000, 0x83800000, 0x84000000, 0x84800000, 0x85000000, 0x85800000, 0x86000000, 0x86800000, 0x87000000, 0x87800000, 
+				0x88000000, 0x88800000, 0x89000000, 0x89800000, 0x8A000000, 0x8A800000, 0x8B000000, 0x8B800000, 0x8C000000, 0x8C800000, 0x8D000000, 0x8D800000, 0x8E000000, 0x8E800000, 0x8F000000, 0xC7800000 };
+			static const unsigned short offset_table[64] = { 
+				   0, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 
+				   0, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024 };
+			uint32 bits = mantissa_table[offset_table[value>>10]+(value&0x3FF)] + exponent_table[value>>10];
+//			return *reinterpret_cast<float*>(&bits);			//violating strict aliasing!
+			float out;
+			std::memcpy(&out, &bits, sizeof(float));
+			return out;
+		}
 
-/// Convert half-precision to IEEE double-precision.
-/// \param value binary representation of half-precision value
-/// \return double-precision value
-inline double half2float_impl(uint16 value, double, true_type) {
-  typedef bits<float>::type uint32;
-  typedef bits<double>::type uint64;
-  uint32 hi = static_cast<uint32>(value & 0x8000) << 16;
-  int abs = value & 0x7FFF;
-  if (abs) {
-    hi |= 0x3F000000 << static_cast<unsigned>(abs >= 0x7C00);
-    for (; abs < 0x400; abs <<= 1, hi -= 0x100000)
-      ;
-    hi += static_cast<uint32>(abs) << 10;
-  }
-  uint64 bits = static_cast<uint64>(hi) << 32;
-  //			return *reinterpret_cast<double*>(&bits);			//violating
-  //strict aliasing!
-  double out;
-  std::memcpy(&out, &bits, sizeof(double));
-  return out;
-}
+		/// Convert half-precision to IEEE double-precision.
+		/// \param value binary representation of half-precision value
+		/// \return double-precision value
+		inline double half2float_impl(uint16 value, double, true_type)
+		{
+			typedef bits<float>::type uint32;
+			typedef bits<double>::type uint64;
+			uint32 hi = static_cast<uint32>(value&0x8000) << 16;
+			int abs = value & 0x7FFF;
+			if(abs)
+			{
+				hi |= 0x3F000000 << static_cast<unsigned>(abs>=0x7C00);
+				for(; abs<0x400; abs<<=1,hi-=0x100000) ;
+				hi += static_cast<uint32>(abs) << 10;
+			}
+			uint64 bits = static_cast<uint64>(hi) << 32;
+//			return *reinterpret_cast<double*>(&bits);			//violating strict aliasing!
+			double out;
+			std::memcpy(&out, &bits, sizeof(double));
+			return out;
+		}
 
-/// Convert half-precision to non-IEEE floating point.
-/// \tparam T type to convert to (builtin integer type)
-/// \param value binary representation of half-precision value
-/// \return floating point value
-template <typename T>
-T half2float_impl(uint16 value, T, ...) {
-  T out;
-  int abs = value & 0x7FFF;
-  if (abs > 0x7C00)
-    out = std::numeric_limits<T>::has_quiet_NaN
-              ? std::numeric_limits<T>::quiet_NaN()
-              : T();
-  else if (abs == 0x7C00)
-    out = std::numeric_limits<T>::has_infinity
-              ? std::numeric_limits<T>::infinity()
-              : std::numeric_limits<T>::max();
-  else if (abs > 0x3FF)
-    out = std::ldexp(static_cast<T>((abs & 0x3FF) | 0x400), (abs >> 10) - 25);
-  else
-    out = std::ldexp(static_cast<T>(abs), -24);
-  return (value & 0x8000) ? -out : out;
-}
+		/// Convert half-precision to non-IEEE floating point.
+		/// \tparam T type to convert to (builtin integer type)
+		/// \param value binary representation of half-precision value
+		/// \return floating point value
+		template<typename T> T half2float_impl(uint16 value, T, ...)
+		{
+			T out;
+			int abs = value & 0x7FFF;
+			if(abs > 0x7C00)
+				out = std::numeric_limits<T>::has_quiet_NaN ? std::numeric_limits<T>::quiet_NaN() : T();
+			else if(abs == 0x7C00)
+				out = std::numeric_limits<T>::has_infinity ? std::numeric_limits<T>::infinity() : std::numeric_limits<T>::max();
+			else if(abs > 0x3FF)
+				out = std::ldexp(static_cast<T>((abs&0x3FF)|0x400), (abs>>10)-25);
+			else
+				out = std::ldexp(static_cast<T>(abs), -24);
+			return (value&0x8000) ? -out : out;
+		}
 
-/// Convert half-precision to floating point.
-/// \tparam T type to convert to (builtin integer type)
-/// \param value binary representation of half-precision value
-/// \return floating point value
-template <typename T>
-T half2float(uint16 value) {
-  return half2float_impl(value, T(),
-                         bool_type < std::numeric_limits<T>::is_iec559 &&
-                             sizeof(typename bits<T>::type) == sizeof(T) > ());
-}
+		/// Convert half-precision to floating point.
+		/// \tparam T type to convert to (builtin integer type)
+		/// \param value binary representation of half-precision value
+		/// \return floating point value
+		template<typename T> T half2float(uint16 value)
+		{
+			return half2float_impl(value, T(), bool_type<std::numeric_limits<T>::is_iec559&&sizeof(typename bits<T>::type)==sizeof(T)>());
+		}
 
-/// Convert half-precision floating point to integer.
-/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
-/// rounding
-/// \tparam E `true` for round to even, `false` for round away from zero
-/// \tparam T type to convert to (buitlin integer type with at least 16 bits
-/// precision, excluding any implicit sign bits)
-/// \param value binary representation of half-precision value
-/// \return integral value
-template <std::float_round_style R, bool E, typename T>
-T half2int_impl(uint16 value) {
-#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
-  static_assert(std::is_integral<T>::value,
-                "half to int conversion only supports builtin integer types");
-#endif
-  unsigned int e = value & 0x7FFF;
-  if (e >= 0x7C00)
-    return (value & 0x8000) ? std::numeric_limits<T>::min()
-                            : std::numeric_limits<T>::max();
-  if (e < 0x3800) {
-    if (R == std::round_toward_infinity)
-      return T(~(value >> 15) & (e != 0));
-    else if (R == std::round_toward_neg_infinity)
-      return -T(value > 0x8000);
-    return T();
-  }
-  unsigned int m = (value & 0x3FF) | 0x400;
-  e >>= 10;
-  if (e < 25) {
-    if (R == std::round_to_nearest)
-      m += (1 << (24 - e)) - (~(m >> (25 - e)) & E);
-    else if (R == std::round_toward_infinity)
-      m += ((value >> 15) - 1) & ((1 << (25 - e)) - 1U);
-    else if (R == std::round_toward_neg_infinity)
-      m += -(value >> 15) & ((1 << (25 - e)) - 1U);
-    m >>= 25 - e;
-  } else
-    m <<= e - 25;
-  return (value & 0x8000) ? -static_cast<T>(m) : static_cast<T>(m);
-}
+		/// Convert half-precision floating point to integer.
+		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
+		/// \tparam E `true` for round to even, `false` for round away from zero
+		/// \tparam T type to convert to (buitlin integer type with at least 16 bits precision, excluding any implicit sign bits)
+		/// \param value binary representation of half-precision value
+		/// \return integral value
+		template<std::float_round_style R,bool E,typename T> T half2int_impl(uint16 value)
+		{
+		#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
+			static_assert(std::is_integral<T>::value, "half to int conversion only supports builtin integer types");
+		#endif
+			unsigned int e = value & 0x7FFF;
+			if(e >= 0x7C00)
+				return (value&0x8000) ? std::numeric_limits<T>::min() : std::numeric_limits<T>::max();
+			if(e < 0x3800)
+			{
+				if(R == std::round_toward_infinity)
+					return T(~(value>>15)&(e!=0));
+				else if(R == std::round_toward_neg_infinity)
+					return -T(value>0x8000);
+				return T();
+			}
+			unsigned int m = (value&0x3FF) | 0x400;
+			e >>= 10;
+			if(e < 25)
+			{
+				if(R == std::round_to_nearest)
+					m += (1<<(24-e)) - (~(m>>(25-e))&E);
+				else if(R == std::round_toward_infinity)
+					m += ((value>>15)-1) & ((1<<(25-e))-1U);
+				else if(R == std::round_toward_neg_infinity)
+					m += -(value>>15) & ((1<<(25-e))-1U);
+				m >>= 25 - e;
+			}
+			else
+				m <<= e - 25;
+			return (value&0x8000) ? -static_cast<T>(m) : static_cast<T>(m);
+		}
 
-/// Convert half-precision floating point to integer.
-/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
-/// rounding
-/// \tparam T type to convert to (buitlin integer type with at least 16 bits
-/// precision, excluding any implicit sign bits)
-/// \param value binary representation of half-precision value
-/// \return integral value
-template <std::float_round_style R, typename T>
-T half2int(uint16 value) {
-  return half2int_impl<R, HALF_ROUND_TIES_TO_EVEN, T>(value);
-}
+		/// Convert half-precision floating point to integer.
+		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
+		/// \tparam T type to convert to (buitlin integer type with at least 16 bits precision, excluding any implicit sign bits)
+		/// \param value binary representation of half-precision value
+		/// \return integral value
+		template<std::float_round_style R,typename T> T half2int(uint16 value) { return half2int_impl<R,HALF_ROUND_TIES_TO_EVEN,T>(value); }
 
-/// Convert half-precision floating point to integer using
-/// round-to-nearest-away-from-zero.
-/// \tparam T type to convert to (buitlin integer type with at least 16 bits
-/// precision, excluding any implicit sign bits)
-/// \param value binary representation of half-precision value
-/// \return integral value
-template <typename T>
-T half2int_up(uint16 value) {
-  return half2int_impl<std::round_to_nearest, 0, T>(value);
-}
+		/// Convert half-precision floating point to integer using round-to-nearest-away-from-zero.
+		/// \tparam T type to convert to (buitlin integer type with at least 16 bits precision, excluding any implicit sign bits)
+		/// \param value binary representation of half-precision value
+		/// \return integral value
+		template<typename T> T half2int_up(uint16 value) { return half2int_impl<std::round_to_nearest,0,T>(value); }
 
-/// Round half-precision number to nearest integer value.
-/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
-/// rounding
-/// \tparam E `true` for round to even, `false` for round away from zero
-/// \param value binary representation of half-precision value
-/// \return half-precision bits for nearest integral value
-template <std::float_round_style R, bool E>
-uint16 round_half_impl(uint16 value) {
-  unsigned int e = value & 0x7FFF;
-  uint16 result = value;
-  if (e < 0x3C00) {
-    result &= 0x8000;
-    if (R == std::round_to_nearest)
-      result |= 0x3C00U & -(e >= (0x3800 + E));
-    else if (R == std::round_toward_infinity)
-      result |= 0x3C00U & -(~(value >> 15) & (e != 0));
-    else if (R == std::round_toward_neg_infinity)
-      result |= 0x3C00U & -(value > 0x8000);
-  } else if (e < 0x6400) {
-    e = 25 - (e >> 10);
-    unsigned int mask = (1 << e) - 1;
-    if (R == std::round_to_nearest)
-      result += (1 << (e - 1)) - (~(result >> e) & E);
-    else if (R == std::round_toward_infinity)
-      result += mask & ((value >> 15) - 1);
-    else if (R == std::round_toward_neg_infinity)
-      result += mask & -(value >> 15);
-    result &= ~mask;
-  }
-  return result;
-}
+		/// Round half-precision number to nearest integer value.
+		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
+		/// \tparam E `true` for round to even, `false` for round away from zero
+		/// \param value binary representation of half-precision value
+		/// \return half-precision bits for nearest integral value
+		template<std::float_round_style R,bool E> uint16 round_half_impl(uint16 value)
+		{
+			unsigned int e = value & 0x7FFF;
+			uint16 result = value;
+			if(e < 0x3C00)
+			{
+				result &= 0x8000;
+				if(R == std::round_to_nearest)
+					result |= 0x3C00U & -(e>=(0x3800+E));
+				else if(R == std::round_toward_infinity)
+					result |= 0x3C00U & -(~(value>>15)&(e!=0));
+				else if(R == std::round_toward_neg_infinity)
+					result |= 0x3C00U & -(value>0x8000);
+			}
+			else if(e < 0x6400)
+			{
+				e = 25 - (e>>10);
+				unsigned int mask = (1<<e) - 1;
+				if(R == std::round_to_nearest)
+					result += (1<<(e-1)) - (~(result>>e)&E);
+				else if(R == std::round_toward_infinity)
+					result += mask & ((value>>15)-1);
+				else if(R == std::round_toward_neg_infinity)
+					result += mask & -(value>>15);
+				result &= ~mask;
+			}
+			return result;
+		}
 
-/// Round half-precision number to nearest integer value.
-/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
-/// rounding
-/// \param value binary representation of half-precision value
-/// \return half-precision bits for nearest integral value
-template <std::float_round_style R>
-uint16 round_half(uint16 value) {
-  return round_half_impl<R, HALF_ROUND_TIES_TO_EVEN>(value);
-}
+		/// Round half-precision number to nearest integer value.
+		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
+		/// \param value binary representation of half-precision value
+		/// \return half-precision bits for nearest integral value
+		template<std::float_round_style R> uint16 round_half(uint16 value) { return round_half_impl<R,HALF_ROUND_TIES_TO_EVEN>(value); }
 
-/// Round half-precision number to nearest integer value using
-/// round-to-nearest-away-from-zero.
-/// \param value binary representation of half-precision value
-/// \return half-precision bits for nearest integral value
-inline uint16 round_half_up(uint16 value) {
-  return round_half_impl<std::round_to_nearest, 0>(value);
-}
-/// \}
+		/// Round half-precision number to nearest integer value using round-to-nearest-away-from-zero.
+		/// \param value binary representation of half-precision value
+		/// \return half-precision bits for nearest integral value
+		inline uint16 round_half_up(uint16 value) { return round_half_impl<std::round_to_nearest,0>(value); }
+		/// \}
 
-struct functions;
-template <typename>
-struct unary_specialized;
-template <typename, typename>
-struct binary_specialized;
-template <typename, typename, std::float_round_style>
-struct half_caster;
-}
+		struct functions;
+		template<typename> struct unary_specialized;
+		template<typename,typename> struct binary_specialized;
+		template<typename,typename,std::float_round_style> struct half_caster;
+	}
 
-/// Half-precision floating point type.
-/// This class implements an IEEE-conformant half-precision floating point type
-/// with the usual arithmetic operators and
-/// conversions. It is implicitly convertible to single-precision floating
-/// point, which makes artihmetic expressions and
-/// functions with mixed-type operands to be of the most precise operand type.
-/// Additionally all arithmetic operations
-/// (and many mathematical functions) are carried out in single-precision
-/// internally. All conversions from single- to
-/// half-precision are done using the library's default rounding mode, but
-/// temporary results inside chained arithmetic
-/// expressions are kept in single-precision as long as possible (while of
-/// course still maintaining a strong half-precision type).
-///
-/// According to the C++98/03 definition, the half type is not a POD type. But
-/// according to C++11's less strict and
-/// extended definitions it is both a standard layout type and a trivially
-/// copyable type (even if not a POD type), which
-/// means it can be standard-conformantly copied using raw binary copies. But in
-/// this context some more words about the
-/// actual size of the type. Although the half is representing an IEEE 16-bit
-/// type, it does not neccessarily have to be of
-/// exactly 16-bits size. But on any reasonable implementation the actual binary
-/// representation of this type will most
-/// probably not ivolve any additional "magic" or padding beyond the simple
-/// binary representation of the underlying 16-bit
-/// IEEE number, even if not strictly guaranteed by the standard. But even then
-/// it only has an actual size of 16 bits if
-/// your C++ implementation supports an unsigned integer type of exactly 16 bits
-/// width. But this should be the case on
-/// nearly any reasonable platform.
-///
-/// So if your C++ implementation is not totally exotic or imposes special
-/// alignment requirements, it is a reasonable
-/// assumption that the data of a half is just comprised of the 2 bytes of the
-/// underlying IEEE representation.
-class half {
-  friend struct detail::functions;
-  friend struct detail::unary_specialized<half>;
-  friend struct detail::binary_specialized<half, half>;
-  template <typename, typename, std::float_round_style>
-  friend struct detail::half_caster;
-  friend class std::numeric_limits<half>;
-#if HALF_ENABLE_CPP11_HASH
-  friend struct std::hash<half>;
-#endif
-#if HALF_ENABLE_CPP11_USER_LITERALS
-  friend half literal::operator"" _h(long double);
-#endif
+	/// Half-precision floating point type.
+	/// This class implements an IEEE-conformant half-precision floating point type with the usual arithmetic operators and 
+	/// conversions. It is implicitly convertible to single-precision floating point, which makes artihmetic expressions and 
+	/// functions with mixed-type operands to be of the most precise operand type. Additionally all arithmetic operations 
+	/// (and many mathematical functions) are carried out in single-precision internally. All conversions from single- to 
+	/// half-precision are done using the library's default rounding mode, but temporary results inside chained arithmetic 
+	/// expressions are kept in single-precision as long as possible (while of course still maintaining a strong half-precision type).
+	///
+	/// According to the C++98/03 definition, the half type is not a POD type. But according to C++11's less strict and 
+	/// extended definitions it is both a standard layout type and a trivially copyable type (even if not a POD type), which 
+	/// means it can be standard-conformantly copied using raw binary copies. But in this context some more words about the 
+	/// actual size of the type. Although the half is representing an IEEE 16-bit type, it does not neccessarily have to be of 
+	/// exactly 16-bits size. But on any reasonable implementation the actual binary representation of this type will most 
+	/// probably not ivolve any additional "magic" or padding beyond the simple binary representation of the underlying 16-bit 
+	/// IEEE number, even if not strictly guaranteed by the standard. But even then it only has an actual size of 16 bits if 
+	/// your C++ implementation supports an unsigned integer type of exactly 16 bits width. But this should be the case on 
+	/// nearly any reasonable platform.
+	///
+	/// So if your C++ implementation is not totally exotic or imposes special alignment requirements, it is a reasonable 
+	/// assumption that the data of a half is just comprised of the 2 bytes of the underlying IEEE representation.
+	class half
+	{
+		friend struct detail::functions;
+		friend struct detail::unary_specialized<half>;
+		friend struct detail::binary_specialized<half,half>;
+		template<typename,typename,std::float_round_style> friend struct detail::half_caster;
+		friend class std::numeric_limits<half>;
+	#if HALF_ENABLE_CPP11_HASH
+		friend struct std::hash<half>;
+	#endif
+	#if HALF_ENABLE_CPP11_USER_LITERALS
+		friend half literal::operator"" _h(long double);
+	#endif
 
- public:
-  /// Default constructor.
-  /// This initializes the half to 0. Although this does not match the builtin
-  /// types' default-initialization semantics
-  /// and may be less efficient than no initialization, it is needed to provide
-  /// proper value-initialization semantics.
-  HALF_CONSTEXPR half() HALF_NOEXCEPT : data_() {}
+	public:
+		/// Default constructor.
+		/// This initializes the half to 0. Although this does not match the builtin types' default-initialization semantics 
+		/// and may be less efficient than no initialization, it is needed to provide proper value-initialization semantics.
+		HALF_CONSTEXPR half() HALF_NOEXCEPT : data_() {}
 
-  /// Copy constructor.
-  /// \tparam T type of concrete half expression
-  /// \param rhs half expression to copy from
-  half(detail::expr rhs)
-      : data_(detail::float2half<round_style>(static_cast<float>(rhs))) {}
+		/// Copy constructor.
+		/// \tparam T type of concrete half expression
+		/// \param rhs half expression to copy from
+		half(detail::expr rhs) : data_(detail::float2half<round_style>(static_cast<float>(rhs))) {}
 
-  /// Conversion constructor.
-  /// \param rhs float to convert
-  explicit half(float rhs) : data_(detail::float2half<round_style>(rhs)) {}
+		/// Conversion constructor.
+		/// \param rhs float to convert
+		explicit half(float rhs) : data_(detail::float2half<round_style>(rhs)) {}
+	
+		/// Conversion to single-precision.
+		/// \return single precision value representing expression value
+		operator float() const { return detail::half2float<float>(data_); }
 
-  /// Conversion to single-precision.
-  /// \return single precision value representing expression value
-  operator float() const { return detail::half2float<float>(data_); }
+		/// Assignment operator.
+		/// \tparam T type of concrete half expression
+		/// \param rhs half expression to copy from
+		/// \return reference to this half
+		half& operator=(detail::expr rhs) { return *this = static_cast<float>(rhs); }
 
-  /// Assignment operator.
-  /// \tparam T type of concrete half expression
-  /// \param rhs half expression to copy from
-  /// \return reference to this half
-  half &operator=(detail::expr rhs) { return *this = static_cast<float>(rhs); }
+		/// Arithmetic assignment.
+		/// \tparam T type of concrete half expression
+		/// \param rhs half expression to add
+		/// \return reference to this half
+		template<typename T> typename detail::enable<half&,T>::type operator+=(T rhs) { return *this += static_cast<float>(rhs); }
 
-  /// Arithmetic assignment.
-  /// \tparam T type of concrete half expression
-  /// \param rhs half expression to add
-  /// \return reference to this half
-  template <typename T>
-  typename detail::enable<half &, T>::type operator+=(T rhs) {
-    return *this += static_cast<float>(rhs);
-  }
+		/// Arithmetic assignment.
+		/// \tparam T type of concrete half expression
+		/// \param rhs half expression to subtract
+		/// \return reference to this half
+		template<typename T> typename detail::enable<half&,T>::type operator-=(T rhs) { return *this -= static_cast<float>(rhs); }
 
-  /// Arithmetic assignment.
-  /// \tparam T type of concrete half expression
-  /// \param rhs half expression to subtract
-  /// \return reference to this half
-  template <typename T>
-  typename detail::enable<half &, T>::type operator-=(T rhs) {
-    return *this -= static_cast<float>(rhs);
-  }
+		/// Arithmetic assignment.
+		/// \tparam T type of concrete half expression
+		/// \param rhs half expression to multiply with
+		/// \return reference to this half
+		template<typename T> typename detail::enable<half&,T>::type operator*=(T rhs) { return *this *= static_cast<float>(rhs); }
 
-  /// Arithmetic assignment.
-  /// \tparam T type of concrete half expression
-  /// \param rhs half expression to multiply with
-  /// \return reference to this half
-  template <typename T>
-  typename detail::enable<half &, T>::type operator*=(T rhs) {
-    return *this *= static_cast<float>(rhs);
-  }
+		/// Arithmetic assignment.
+		/// \tparam T type of concrete half expression
+		/// \param rhs half expression to divide by
+		/// \return reference to this half
+		template<typename T> typename detail::enable<half&,T>::type operator/=(T rhs) { return *this /= static_cast<float>(rhs); }
 
-  /// Arithmetic assignment.
-  /// \tparam T type of concrete half expression
-  /// \param rhs half expression to divide by
-  /// \return reference to this half
-  template <typename T>
-  typename detail::enable<half &, T>::type operator/=(T rhs) {
-    return *this /= static_cast<float>(rhs);
-  }
+		/// Assignment operator.
+		/// \param rhs single-precision value to copy from
+		/// \return reference to this half
+		half& operator=(float rhs) { data_ = detail::float2half<round_style>(rhs); return *this; }
 
-  /// Assignment operator.
-  /// \param rhs single-precision value to copy from
-  /// \return reference to this half
-  half &operator=(float rhs) {
-    data_ = detail::float2half<round_style>(rhs);
-    return *this;
-  }
+		/// Arithmetic assignment.
+		/// \param rhs single-precision value to add
+		/// \return reference to this half
+		half& operator+=(float rhs) { data_ = detail::float2half<round_style>(detail::half2float<float>(data_)+rhs); return *this; }
 
-  /// Arithmetic assignment.
-  /// \param rhs single-precision value to add
-  /// \return reference to this half
-  half &operator+=(float rhs) {
-    data_ =
-        detail::float2half<round_style>(detail::half2float<float>(data_) + rhs);
-    return *this;
-  }
+		/// Arithmetic assignment.
+		/// \param rhs single-precision value to subtract
+		/// \return reference to this half
+		half& operator-=(float rhs) { data_ = detail::float2half<round_style>(detail::half2float<float>(data_)-rhs); return *this; }
 
-  /// Arithmetic assignment.
-  /// \param rhs single-precision value to subtract
-  /// \return reference to this half
-  half &operator-=(float rhs) {
-    data_ =
-        detail::float2half<round_style>(detail::half2float<float>(data_) - rhs);
-    return *this;
-  }
+		/// Arithmetic assignment.
+		/// \param rhs single-precision value to multiply with
+		/// \return reference to this half
+		half& operator*=(float rhs) { data_ = detail::float2half<round_style>(detail::half2float<float>(data_)*rhs); return *this; }
 
-  /// Arithmetic assignment.
-  /// \param rhs single-precision value to multiply with
-  /// \return reference to this half
-  half &operator*=(float rhs) {
-    data_ =
-        detail::float2half<round_style>(detail::half2float<float>(data_) * rhs);
-    return *this;
-  }
+		/// Arithmetic assignment.
+		/// \param rhs single-precision value to divide by
+		/// \return reference to this half
+		half& operator/=(float rhs) { data_ = detail::float2half<round_style>(detail::half2float<float>(data_)/rhs); return *this; }
 
-  /// Arithmetic assignment.
-  /// \param rhs single-precision value to divide by
-  /// \return reference to this half
-  half &operator/=(float rhs) {
-    data_ =
-        detail::float2half<round_style>(detail::half2float<float>(data_) / rhs);
-    return *this;
-  }
+		/// Prefix increment.
+		/// \return incremented half value
+		half& operator++() { return *this += 1.0f; }
 
-  /// Prefix increment.
-  /// \return incremented half value
-  half &operator++() { return *this += 1.0f; }
+		/// Prefix decrement.
+		/// \return decremented half value
+		half& operator--() { return *this -= 1.0f; }
 
-  /// Prefix decrement.
-  /// \return decremented half value
-  half &operator--() { return *this -= 1.0f; }
+		/// Postfix increment.
+		/// \return non-incremented half value
+		half operator++(int) { half out(*this); ++*this; return out; }
 
-  /// Postfix increment.
-  /// \return non-incremented half value
-  half operator++(int) {
-    half out(*this);
-    ++*this;
-    return out;
-  }
+		/// Postfix decrement.
+		/// \return non-decremented half value
+		half operator--(int) { half out(*this); --*this; return out; }
+	
+	private:
+		/// Rounding mode to use
+		static const std::float_round_style round_style = (std::float_round_style)(HALF_ROUND_STYLE);
 
-  /// Postfix decrement.
-  /// \return non-decremented half value
-  half operator--(int) {
-    half out(*this);
-    --*this;
-    return out;
-  }
+		/// Constructor.
+		/// \param bits binary representation to set half to
+		HALF_CONSTEXPR half(detail::binary_t, detail::uint16 bits) HALF_NOEXCEPT : data_(bits) {}
 
- private:
-  /// Rounding mode to use
-  static const std::float_round_style round_style =
-      (std::float_round_style)(HALF_ROUND_STYLE);
-
-  /// Constructor.
-  /// \param bits binary representation to set half to
-  HALF_CONSTEXPR half(detail::binary_t, detail::uint16 bits) HALF_NOEXCEPT
-      : data_(bits) {}
-
-  /// Internal binary representation
-  detail::uint16 data_;
-};
+		/// Internal binary representation
+		detail::uint16 data_;
+	};
 
 #if HALF_ENABLE_CPP11_USER_LITERALS
-namespace literal {
-/// Half literal.
-/// While this returns an actual half-precision value, half literals can
-/// unfortunately not be constant expressions due
-/// to rather involved conversions.
-/// \param value literal value
-/// \return half with given value (if representable)
-inline half operator"" _h(long double value) {
-  return half(detail::binary, detail::float2half<half::round_style>(value));
-}
-}
+	namespace literal
+	{
+		/// Half literal.
+		/// While this returns an actual half-precision value, half literals can unfortunately not be constant expressions due 
+		/// to rather involved conversions.
+		/// \param value literal value
+		/// \return half with given value (if representable)
+		inline half operator"" _h(long double value) { return half(detail::binary, detail::float2half<half::round_style>(value)); }
+	}
 #endif
 
-namespace detail {
-/// Wrapper implementing unspecialized half-precision functions.
-struct functions {
-  /// Addition implementation.
-  /// \param x first operand
-  /// \param y second operand
-  /// \return Half-precision sum stored in single-precision
-  static expr plus(float x, float y) { return expr(x + y); }
+	namespace detail
+	{
+		/// Wrapper implementing unspecialized half-precision functions.
+		struct functions
+		{
+			/// Addition implementation.
+			/// \param x first operand
+			/// \param y second operand
+			/// \return Half-precision sum stored in single-precision
+			static expr plus(float x, float y) { return expr(x+y); }
 
-  /// Subtraction implementation.
-  /// \param x first operand
-  /// \param y second operand
-  /// \return Half-precision difference stored in single-precision
-  static expr minus(float x, float y) { return expr(x - y); }
+			/// Subtraction implementation.
+			/// \param x first operand
+			/// \param y second operand
+			/// \return Half-precision difference stored in single-precision
+			static expr minus(float x, float y) { return expr(x-y); }
 
-  /// Multiplication implementation.
-  /// \param x first operand
-  /// \param y second operand
-  /// \return Half-precision product stored in single-precision
-  static expr multiplies(float x, float y) { return expr(x * y); }
+			/// Multiplication implementation.
+			/// \param x first operand
+			/// \param y second operand
+			/// \return Half-precision product stored in single-precision
+			static expr multiplies(float x, float y) { return expr(x*y); }
 
-  /// Division implementation.
-  /// \param x first operand
-  /// \param y second operand
-  /// \return Half-precision quotient stored in single-precision
-  static expr divides(float x, float y) { return expr(x / y); }
+			/// Division implementation.
+			/// \param x first operand
+			/// \param y second operand
+			/// \return Half-precision quotient stored in single-precision
+			static expr divides(float x, float y) { return expr(x/y); }
 
-  /// Output implementation.
-  /// \param out stream to write to
-  /// \param arg value to write
-  /// \return reference to stream
-  template <typename charT, typename traits>
-  static std::basic_ostream<charT, traits> &write(
-      std::basic_ostream<charT, traits> &out, float arg) {
-    return out << arg;
-  }
+			/// Output implementation.
+			/// \param out stream to write to
+			/// \param arg value to write
+			/// \return reference to stream
+			template<typename charT,typename traits> static std::basic_ostream<charT,traits>& write(std::basic_ostream<charT,traits> &out, float arg) { return out << arg; }
 
-  /// Input implementation.
-  /// \param in stream to read from
-  /// \param arg half to read into
-  /// \return reference to stream
-  template <typename charT, typename traits>
-  static std::basic_istream<charT, traits> &read(
-      std::basic_istream<charT, traits> &in, half &arg) {
-    float f;
-    if (in >> f) arg = f;
-    return in;
-  }
+			/// Input implementation.
+			/// \param in stream to read from
+			/// \param arg half to read into
+			/// \return reference to stream
+			template<typename charT,typename traits> static std::basic_istream<charT,traits>& read(std::basic_istream<charT,traits> &in, half &arg)
+			{
+				float f;
+				if(in >> f)
+					arg = f;
+				return in;
+			}
 
-  /// Modulo implementation.
-  /// \param x first operand
-  /// \param y second operand
-  /// \return Half-precision division remainder stored in single-precision
-  static expr fmod(float x, float y) { return expr(std::fmod(x, y)); }
+			/// Modulo implementation.
+			/// \param x first operand
+			/// \param y second operand
+			/// \return Half-precision division remainder stored in single-precision
+			static expr fmod(float x, float y) { return expr(std::fmod(x, y)); }
 
-  /// Remainder implementation.
-  /// \param x first operand
-  /// \param y second operand
-  /// \return Half-precision division remainder stored in single-precision
-  static expr remainder(float x, float y) {
-#if HALF_ENABLE_CPP11_CMATH
-    return expr(std::remainder(x, y));
-#else
-    if (builtin_isnan(x) || builtin_isnan(y))
-      return expr(std::numeric_limits<float>::quiet_NaN());
-    float ax = std::fabs(x), ay = std::fabs(y);
-    if (ax >= 65536.0f || ay < std::ldexp(1.0f, -24))
-      return expr(std::numeric_limits<float>::quiet_NaN());
-    if (ay >= 65536.0f) return expr(x);
-    if (ax == ay) return expr(builtin_signbit(x) ? -0.0f : 0.0f);
-    ax = std::fmod(ax, ay + ay);
-    float y2 = 0.5f * ay;
-    if (ax > y2) {
-      ax -= ay;
-      if (ax >= y2) ax -= ay;
-    }
-    return expr(builtin_signbit(x) ? -ax : ax);
-#endif
-  }
+			/// Remainder implementation.
+			/// \param x first operand
+			/// \param y second operand
+			/// \return Half-precision division remainder stored in single-precision
+			static expr remainder(float x, float y)
+			{
+			#if HALF_ENABLE_CPP11_CMATH
+				return expr(std::remainder(x, y));
+			#else
+				if(builtin_isnan(x) || builtin_isnan(y))
+					return expr(std::numeric_limits<float>::quiet_NaN());
+				float ax = std::fabs(x), ay = std::fabs(y);
+				if(ax >= 65536.0f || ay < std::ldexp(1.0f, -24))
+					return expr(std::numeric_limits<float>::quiet_NaN());
+				if(ay >= 65536.0f)
+					return expr(x);
+				if(ax == ay)
+					return expr(builtin_signbit(x) ? -0.0f : 0.0f);
+				ax = std::fmod(ax, ay+ay);
+				float y2 = 0.5f * ay;
+				if(ax > y2)
+				{
+					ax -= ay;
+					if(ax >= y2)
+						ax -= ay;
+				}
+				return expr(builtin_signbit(x) ? -ax : ax);
+			#endif
+			}
 
-  /// Remainder implementation.
-  /// \param x first operand
-  /// \param y second operand
-  /// \param quo address to store quotient bits at
-  /// \return Half-precision division remainder stored in single-precision
-  static expr remquo(float x, float y, int *quo) {
-#if HALF_ENABLE_CPP11_CMATH
-    return expr(std::remquo(x, y, quo));
-#else
-    if (builtin_isnan(x) || builtin_isnan(y))
-      return expr(std::numeric_limits<float>::quiet_NaN());
-    bool sign = builtin_signbit(x),
-         qsign = static_cast<bool>(sign ^ builtin_signbit(y));
-    float ax = std::fabs(x), ay = std::fabs(y);
-    if (ax >= 65536.0f || ay < std::ldexp(1.0f, -24))
-      return expr(std::numeric_limits<float>::quiet_NaN());
-    if (ay >= 65536.0f) return expr(x);
-    if (ax == ay) return *quo = qsign ? -1 : 1, expr(sign ? -0.0f : 0.0f);
-    ax = std::fmod(ax, 8.0f * ay);
-    int cquo = 0;
-    if (ax >= 4.0f * ay) {
-      ax -= 4.0f * ay;
-      cquo += 4;
-    }
-    if (ax >= 2.0f * ay) {
-      ax -= 2.0f * ay;
-      cquo += 2;
-    }
-    float y2 = 0.5f * ay;
-    if (ax > y2) {
-      ax -= ay;
-      ++cquo;
-      if (ax >= y2) {
-        ax -= ay;
-        ++cquo;
-      }
-    }
-    return *quo = qsign ? -cquo : cquo, expr(sign ? -ax : ax);
-#endif
-  }
+			/// Remainder implementation.
+			/// \param x first operand
+			/// \param y second operand
+			/// \param quo address to store quotient bits at
+			/// \return Half-precision division remainder stored in single-precision
+			static expr remquo(float x, float y, int *quo)
+			{
+			#if HALF_ENABLE_CPP11_CMATH
+				return expr(std::remquo(x, y, quo));
+			#else
+				if(builtin_isnan(x) || builtin_isnan(y))
+					return expr(std::numeric_limits<float>::quiet_NaN());
+				bool sign = builtin_signbit(x), qsign = static_cast<bool>(sign^builtin_signbit(y));
+				float ax = std::fabs(x), ay = std::fabs(y);
+				if(ax >= 65536.0f || ay < std::ldexp(1.0f, -24))
+					return expr(std::numeric_limits<float>::quiet_NaN());
+				if(ay >= 65536.0f)
+					return expr(x);
+				if(ax == ay)
+					return *quo = qsign ? -1 : 1, expr(sign ? -0.0f : 0.0f);
+				ax = std::fmod(ax, 8.0f*ay);
+				int cquo = 0;
+				if(ax >= 4.0f * ay)
+				{
+					ax -= 4.0f * ay;
+					cquo += 4;
+				}
+				if(ax >= 2.0f * ay)
+				{
+					ax -= 2.0f * ay;
+					cquo += 2;
+				}
+				float y2 = 0.5f * ay;
+				if(ax > y2)
+				{
+					ax -= ay;
+					++cquo;
+					if(ax >= y2)
+					{
+						ax -= ay;
+						++cquo;
+					}
+				}
+				return *quo = qsign ? -cquo : cquo, expr(sign ? -ax : ax);
+			#endif
+			}
 
-  /// Positive difference implementation.
-  /// \param x first operand
-  /// \param y second operand
-  /// \return Positive difference stored in single-precision
-  static expr fdim(float x, float y) {
-#if HALF_ENABLE_CPP11_CMATH
-    return expr(std::fdim(x, y));
-#else
-    return expr((x <= y) ? 0.0f : (x - y));
-#endif
-  }
+			/// Positive difference implementation.
+			/// \param x first operand
+			/// \param y second operand
+			/// \return Positive difference stored in single-precision
+			static expr fdim(float x, float y)
+			{
+			#if HALF_ENABLE_CPP11_CMATH
+				return expr(std::fdim(x, y));
+			#else
+				return expr((x<=y) ? 0.0f : (x-y));
+			#endif
+			}
 
-  /// Fused multiply-add implementation.
-  /// \param x first operand
-  /// \param y second operand
-  /// \param z third operand
-  /// \return \a x * \a y + \a z stored in single-precision
-  static expr fma(float x, float y, float z) {
-#if HALF_ENABLE_CPP11_CMATH && defined(FP_FAST_FMAF)
-    return expr(std::fma(x, y, z));
-#else
-    return expr(x * y + z);
-#endif
-  }
+			/// Fused multiply-add implementation.
+			/// \param x first operand
+			/// \param y second operand
+			/// \param z third operand
+			/// \return \a x * \a y + \a z stored in single-precision
+			static expr fma(float x, float y, float z)
+			{
+			#if HALF_ENABLE_CPP11_CMATH && defined(FP_FAST_FMAF)
+				return expr(std::fma(x, y, z));
+			#else
+				return expr(x*y+z);
+			#endif
+			}
 
-  /// Get NaN.
-  /// \return Half-precision quiet NaN
-  static half nanh() { return half(binary, 0x7FFF); }
+			/// Get NaN.
+			/// \return Half-precision quiet NaN
+			static half nanh() { return half(binary, 0x7FFF); }
 
-  /// Exponential implementation.
-  /// \param arg function argument
-  /// \return function value stored in single-preicision
-  static expr exp(float arg) { return expr(std::exp(arg)); }
+			/// Exponential implementation.
+			/// \param arg function argument
+			/// \return function value stored in single-preicision
+			static expr exp(float arg) { return expr(std::exp(arg)); }
 
-  /// Exponential implementation.
-  /// \param arg function argument
-  /// \return function value stored in single-preicision
-  static expr expm1(float arg) {
-#if HALF_ENABLE_CPP11_CMATH
-    return expr(std::expm1(arg));
-#else
-    return expr(static_cast<float>(std::exp(static_cast<double>(arg)) - 1.0));
-#endif
-  }
+			/// Exponential implementation.
+			/// \param arg function argument
+			/// \return function value stored in single-preicision
+			static expr expm1(float arg)
+			{
+			#if HALF_ENABLE_CPP11_CMATH
+				return expr(std::expm1(arg));
+			#else
+				return expr(static_cast<float>(std::exp(static_cast<double>(arg))-1.0));
+			#endif
+			}
 
-  /// Binary exponential implementation.
-  /// \param arg function argument
-  /// \return function value stored in single-preicision
-  static expr exp2(float arg) {
-#if HALF_ENABLE_CPP11_CMATH
-    return expr(std::exp2(arg));
-#else
-    return expr(
-        static_cast<float>(std::exp(arg * 0.69314718055994530941723212145818)));
-#endif
-  }
+			/// Binary exponential implementation.
+			/// \param arg function argument
+			/// \return function value stored in single-preicision
+			static expr exp2(float arg)
+			{
+			#if HALF_ENABLE_CPP11_CMATH
+				return expr(std::exp2(arg));
+			#else
+				return expr(static_cast<float>(std::exp(arg*0.69314718055994530941723212145818)));
+			#endif
+			}
 
-  /// Logarithm implementation.
-  /// \param arg function argument
-  /// \return function value stored in single-preicision
-  static expr log(float arg) { return expr(std::log(arg)); }
+			/// Logarithm implementation.
+			/// \param arg function argument
+			/// \return function value stored in single-preicision
+			static expr log(float arg) { return expr(std::log(arg)); }
 
-  /// Common logarithm implementation.
-  /// \param arg function argument
-  /// \return function value stored in single-preicision
-  static expr log10(float arg) { return expr(std::log10(arg)); }
+			/// Common logarithm implementation.
+			/// \param arg function argument
+			/// \return function value stored in single-preicision
+			static expr log10(float arg) { return expr(std::log10(arg)); }
 
-  /// Logarithm implementation.
-  /// \param arg function argument
-  /// \return function value stored in single-preicision
-  static expr log1p(float arg) {
-#if HALF_ENABLE_CPP11_CMATH
-    return expr(std::log1p(arg));
-#else
-    return expr(static_cast<float>(std::log(1.0 + arg)));
-#endif
-  }
+			/// Logarithm implementation.
+			/// \param arg function argument
+			/// \return function value stored in single-preicision
+			static expr log1p(float arg)
+			{
+			#if HALF_ENABLE_CPP11_CMATH
+				return expr(std::log1p(arg));
+			#else
+				return expr(static_cast<float>(std::log(1.0+arg)));
+			#endif
+			}
 
-  /// Binary logarithm implementation.
-  /// \param arg function argument
-  /// \return function value stored in single-preicision
-  static expr log2(float arg) {
-#if HALF_ENABLE_CPP11_CMATH
-    return expr(std::log2(arg));
-#else
-    return expr(static_cast<float>(std::log(static_cast<double>(arg)) *
-                                   1.4426950408889634073599246810019));
-#endif
-  }
+			/// Binary logarithm implementation.
+			/// \param arg function argument
+			/// \return function value stored in single-preicision
+			static expr log2(float arg)
+			{
+			#if HALF_ENABLE_CPP11_CMATH
+				return expr(std::log2(arg));
+			#else
+				return expr(static_cast<float>(std::log(static_cast<double>(arg))*1.4426950408889634073599246810019));
+			#endif
+			}
 
-  /// Square root implementation.
-  /// \param arg function argument
-  /// \return function value stored in single-preicision
-  static expr sqrt(float arg) { return expr(std::sqrt(arg)); }
+			/// Square root implementation.
+			/// \param arg function argument
+			/// \return function value stored in single-preicision
+			static expr sqrt(float arg) { return expr(std::sqrt(arg)); }
 
-  /// Cubic root implementation.
-  /// \param arg function argument
-  /// \return function value stored in single-preicision
-  static expr cbrt(float arg) {
-#if HALF_ENABLE_CPP11_CMATH
-    return expr(std::cbrt(arg));
-#else
-    if (builtin_isnan(arg) || builtin_isinf(arg)) return expr(arg);
-    return expr(builtin_signbit(arg)
-                    ? -static_cast<float>(
-                          std::pow(-static_cast<double>(arg), 1.0 / 3.0))
-                    : static_cast<float>(
-                          std::pow(static_cast<double>(arg), 1.0 / 3.0)));
-#endif
-  }
+			/// Cubic root implementation.
+			/// \param arg function argument
+			/// \return function value stored in single-preicision
+			static expr cbrt(float arg)
+			{
+			#if HALF_ENABLE_CPP11_CMATH
+				return expr(std::cbrt(arg));
+			#else
+				if(builtin_isnan(arg) || builtin_isinf(arg))
+					return expr(arg);
+				return expr(builtin_signbit(arg) ? -static_cast<float>(std::pow(-static_cast<double>(arg), 1.0/3.0)) : 
+					static_cast<float>(std::pow(static_cast<double>(arg), 1.0/3.0)));
+			#endif
+			}
 
-  /// Hypotenuse implementation.
-  /// \param x first argument
-  /// \param y second argument
-  /// \return function value stored in single-preicision
-  static expr hypot(float x, float y) {
-#if HALF_ENABLE_CPP11_CMATH
-    return expr(std::hypot(x, y));
-#else
-    return expr(
-        (builtin_isinf(x) || builtin_isinf(y))
-            ? std::numeric_limits<float>::infinity()
-            : static_cast<float>(std::sqrt(static_cast<double>(x) * x +
-                                           static_cast<double>(y) * y)));
-#endif
-  }
+			/// Hypotenuse implementation.
+			/// \param x first argument
+			/// \param y second argument
+			/// \return function value stored in single-preicision
+			static expr hypot(float x, float y)
+			{
+			#if HALF_ENABLE_CPP11_CMATH
+				return expr(std::hypot(x, y));
+			#else
+				return expr((builtin_isinf(x) || builtin_isinf(y)) ? std::numeric_limits<float>::infinity() : 
+					static_cast<float>(std::sqrt(static_cast<double>(x)*x+static_cast<double>(y)*y)));
+			#endif
+			}
 
-  /// Power implementation.
-  /// \param base value to exponentiate
-  /// \param exp power to expontiate to
-  /// \return function value stored in single-preicision
-  static expr pow(float base, float exp) { return expr(std::pow(base, exp)); }
+			/// Power implementation.
+			/// \param base value to exponentiate
+			/// \param exp power to expontiate to
+			/// \return function value stored in single-preicision
+			static expr pow(float base, float exp) { return expr(std::pow(base, exp)); }
 
-  /// Sine implementation.
-  /// \param arg function argument
-  /// \return function value stored in single-preicision
-  static expr sin(float arg) { return expr(std::sin(arg)); }
+			/// Sine implementation.
+			/// \param arg function argument
+			/// \return function value stored in single-preicision
+			static expr sin(float arg) { return expr(std::sin(arg)); }
 
-  /// Cosine implementation.
-  /// \param arg function argument
-  /// \return function value stored in single-preicision
-  static expr cos(float arg) { return expr(std::cos(arg)); }
+			/// Cosine implementation.
+			/// \param arg function argument
+			/// \return function value stored in single-preicision
+			static expr cos(float arg) { return expr(std::cos(arg)); }
 
-  /// Tan implementation.
-  /// \param arg function argument
-  /// \return function value stored in single-preicision
-  static expr tan(float arg) { return expr(std::tan(arg)); }
+			/// Tan implementation.
+			/// \param arg function argument
+			/// \return function value stored in single-preicision
+			static expr tan(float arg) { return expr(std::tan(arg)); }
 
-  /// Arc sine implementation.
-  /// \param arg function argument
-  /// \return function value stored in single-preicision
-  static expr asin(float arg) { return expr(std::asin(arg)); }
+			/// Arc sine implementation.
+			/// \param arg function argument
+			/// \return function value stored in single-preicision
+			static expr asin(float arg) { return expr(std::asin(arg)); }
 
-  /// Arc cosine implementation.
-  /// \param arg function argument
-  /// \return function value stored in single-preicision
-  static expr acos(float arg) { return expr(std::acos(arg)); }
+			/// Arc cosine implementation.
+			/// \param arg function argument
+			/// \return function value stored in single-preicision
+			static expr acos(float arg) { return expr(std::acos(arg)); }
 
-  /// Arc tangent implementation.
-  /// \param arg function argument
-  /// \return function value stored in single-preicision
-  static expr atan(float arg) { return expr(std::atan(arg)); }
+			/// Arc tangent implementation.
+			/// \param arg function argument
+			/// \return function value stored in single-preicision
+			static expr atan(float arg) { return expr(std::atan(arg)); }
 
-  /// Arc tangent implementation.
-  /// \param x first argument
-  /// \param y second argument
-  /// \return function value stored in single-preicision
-  static expr atan2(float x, float y) { return expr(std::atan2(x, y)); }
+			/// Arc tangent implementation.
+			/// \param x first argument
+			/// \param y second argument
+			/// \return function value stored in single-preicision
+			static expr atan2(float x, float y) { return expr(std::atan2(x, y)); }
 
-  /// Hyperbolic sine implementation.
-  /// \param arg function argument
-  /// \return function value stored in single-preicision
-  static expr sinh(float arg) { return expr(std::sinh(arg)); }
+			/// Hyperbolic sine implementation.
+			/// \param arg function argument
+			/// \return function value stored in single-preicision
+			static expr sinh(float arg) { return expr(std::sinh(arg)); }
 
-  /// Hyperbolic cosine implementation.
-  /// \param arg function argument
-  /// \return function value stored in single-preicision
-  static expr cosh(float arg) { return expr(std::cosh(arg)); }
+			/// Hyperbolic cosine implementation.
+			/// \param arg function argument
+			/// \return function value stored in single-preicision
+			static expr cosh(float arg) { return expr(std::cosh(arg)); }
 
-  /// Hyperbolic tangent implementation.
-  /// \param arg function argument
-  /// \return function value stored in single-preicision
-  static expr tanh(float arg) { return expr(std::tanh(arg)); }
+			/// Hyperbolic tangent implementation.
+			/// \param arg function argument
+			/// \return function value stored in single-preicision
+			static expr tanh(float arg) { return expr(std::tanh(arg)); }
 
-  /// Hyperbolic area sine implementation.
-  /// \param arg function argument
-  /// \return function value stored in single-preicision
-  static expr asinh(float arg) {
-#if HALF_ENABLE_CPP11_CMATH
-    return expr(std::asinh(arg));
-#else
-    return expr(
-        (arg == -std::numeric_limits<float>::infinity())
-            ? arg
-            : static_cast<float>(std::log(arg + std::sqrt(arg * arg + 1.0))));
-#endif
-  }
+			/// Hyperbolic area sine implementation.
+			/// \param arg function argument
+			/// \return function value stored in single-preicision
+			static expr asinh(float arg)
+			{
+			#if HALF_ENABLE_CPP11_CMATH
+				return expr(std::asinh(arg));
+			#else
+				return expr((arg==-std::numeric_limits<float>::infinity()) ? arg : static_cast<float>(std::log(arg+std::sqrt(arg*arg+1.0))));
+			#endif
+			}
 
-  /// Hyperbolic area cosine implementation.
-  /// \param arg function argument
-  /// \return function value stored in single-preicision
-  static expr acosh(float arg) {
-#if HALF_ENABLE_CPP11_CMATH
-    return expr(std::acosh(arg));
-#else
-    return expr((arg < -1.0f) ? std::numeric_limits<float>::quiet_NaN()
-                              : static_cast<float>(std::log(
-                                    arg + std::sqrt(arg * arg - 1.0))));
-#endif
-  }
+			/// Hyperbolic area cosine implementation.
+			/// \param arg function argument
+			/// \return function value stored in single-preicision
+			static expr acosh(float arg)
+			{
+			#if HALF_ENABLE_CPP11_CMATH
+				return expr(std::acosh(arg));
+			#else
+				return expr((arg<-1.0f) ? std::numeric_limits<float>::quiet_NaN() : static_cast<float>(std::log(arg+std::sqrt(arg*arg-1.0))));
+			#endif
+			}
 
-  /// Hyperbolic area tangent implementation.
-  /// \param arg function argument
-  /// \return function value stored in single-preicision
-  static expr atanh(float arg) {
-#if HALF_ENABLE_CPP11_CMATH
-    return expr(std::atanh(arg));
-#else
-    return expr(static_cast<float>(0.5 * std::log((1.0 + arg) / (1.0 - arg))));
-#endif
-  }
+			/// Hyperbolic area tangent implementation.
+			/// \param arg function argument
+			/// \return function value stored in single-preicision
+			static expr atanh(float arg)
+			{
+			#if HALF_ENABLE_CPP11_CMATH
+				return expr(std::atanh(arg));
+			#else
+				return expr(static_cast<float>(0.5*std::log((1.0+arg)/(1.0-arg))));
+			#endif
+			}
 
-  /// Error function implementation.
-  /// \param arg function argument
-  /// \return function value stored in single-preicision
-  static expr erf(float arg) {
-#if HALF_ENABLE_CPP11_CMATH
-    return expr(std::erf(arg));
-#else
-    return expr(static_cast<float>(erf(static_cast<double>(arg))));
-#endif
-  }
+			/// Error function implementation.
+			/// \param arg function argument
+			/// \return function value stored in single-preicision
+			static expr erf(float arg)
+			{
+			#if HALF_ENABLE_CPP11_CMATH
+				return expr(std::erf(arg));
+			#else
+				return expr(static_cast<float>(erf(static_cast<double>(arg))));
+			#endif
+			}
 
-  /// Complementary implementation.
-  /// \param arg function argument
-  /// \return function value stored in single-preicision
-  static expr erfc(float arg) {
-#if HALF_ENABLE_CPP11_CMATH
-    return expr(std::erfc(arg));
-#else
-    return expr(static_cast<float>(1.0 - erf(static_cast<double>(arg))));
-#endif
-  }
+			/// Complementary implementation.
+			/// \param arg function argument
+			/// \return function value stored in single-preicision
+			static expr erfc(float arg)
+			{
+			#if HALF_ENABLE_CPP11_CMATH
+				return expr(std::erfc(arg));
+			#else
+				return expr(static_cast<float>(1.0-erf(static_cast<double>(arg))));
+			#endif
+			}
 
-  /// Gamma logarithm implementation.
-  /// \param arg function argument
-  /// \return function value stored in single-preicision
-  static expr lgamma(float arg) {
-#if HALF_ENABLE_CPP11_CMATH
-    return expr(std::lgamma(arg));
-#else
-    if (builtin_isinf(arg)) return expr(std::numeric_limits<float>::infinity());
-    if (arg < 0.0f) {
-      float i, f = std::modf(-arg, &i);
-      if (f == 0.0f) return expr(std::numeric_limits<float>::infinity());
-      return expr(static_cast<float>(
-          1.1447298858494001741434273513531 -
-          std::log(std::abs(std::sin(3.1415926535897932384626433832795 * f))) -
-          lgamma(1.0 - arg)));
-    }
-    return expr(static_cast<float>(lgamma(static_cast<double>(arg))));
-#endif
-  }
+			/// Gamma logarithm implementation.
+			/// \param arg function argument
+			/// \return function value stored in single-preicision
+			static expr lgamma(float arg)
+			{
+			#if HALF_ENABLE_CPP11_CMATH
+				return expr(std::lgamma(arg));
+			#else
+				if(builtin_isinf(arg))
+					return expr(std::numeric_limits<float>::infinity());
+				if(arg < 0.0f)
+				{
+					float i, f = std::modf(-arg, &i);
+					if(f == 0.0f)
+						return expr(std::numeric_limits<float>::infinity());
+					return expr(static_cast<float>(1.1447298858494001741434273513531-
+						std::log(std::abs(std::sin(3.1415926535897932384626433832795*f)))-lgamma(1.0-arg)));
+				}
+				return expr(static_cast<float>(lgamma(static_cast<double>(arg))));
+			#endif
+			}
 
-  /// Gamma implementation.
-  /// \param arg function argument
-  /// \return function value stored in single-preicision
-  static expr tgamma(float arg) {
-#if HALF_ENABLE_CPP11_CMATH
-    return expr(std::tgamma(arg));
-#else
-    if (arg == 0.0f)
-      return builtin_signbit(arg)
-                 ? expr(-std::numeric_limits<float>::infinity())
-                 : expr(std::numeric_limits<float>::infinity());
-    if (arg < 0.0f) {
-      float i, f = std::modf(-arg, &i);
-      if (f == 0.0f) return expr(std::numeric_limits<float>::quiet_NaN());
-      double value = 3.1415926535897932384626433832795 /
-                     (std::sin(3.1415926535897932384626433832795 * f) *
-                      std::exp(lgamma(1.0 - arg)));
-      return expr(
-          static_cast<float>((std::fmod(i, 2.0f) == 0.0f) ? -value : value));
-    }
-    if (builtin_isinf(arg)) return expr(arg);
-    return expr(static_cast<float>(std::exp(lgamma(static_cast<double>(arg)))));
-#endif
-  }
+			/// Gamma implementation.
+			/// \param arg function argument
+			/// \return function value stored in single-preicision
+			static expr tgamma(float arg)
+			{
+			#if HALF_ENABLE_CPP11_CMATH
+				return expr(std::tgamma(arg));
+			#else
+				if(arg == 0.0f)
+					return builtin_signbit(arg) ? expr(-std::numeric_limits<float>::infinity()) : expr(std::numeric_limits<float>::infinity());
+				if(arg < 0.0f)
+				{
+					float i, f = std::modf(-arg, &i);
+					if(f == 0.0f)
+						return expr(std::numeric_limits<float>::quiet_NaN());
+					double value = 3.1415926535897932384626433832795 / (std::sin(3.1415926535897932384626433832795*f)*std::exp(lgamma(1.0-arg)));
+					return expr(static_cast<float>((std::fmod(i, 2.0f)==0.0f) ? -value : value));
+				}
+				if(builtin_isinf(arg))
+					return expr(arg);
+				return expr(static_cast<float>(std::exp(lgamma(static_cast<double>(arg)))));
+			#endif
+			}
 
-  /// Floor implementation.
-  /// \param arg value to round
-  /// \return rounded value
-  static half floor(half arg) {
-    return half(binary, round_half<std::round_toward_neg_infinity>(arg.data_));
-  }
+			/// Floor implementation.
+			/// \param arg value to round
+			/// \return rounded value
+			static half floor(half arg) { return half(binary, round_half<std::round_toward_neg_infinity>(arg.data_)); }
 
-  /// Ceiling implementation.
-  /// \param arg value to round
-  /// \return rounded value
-  static half ceil(half arg) {
-    return half(binary, round_half<std::round_toward_infinity>(arg.data_));
-  }
+			/// Ceiling implementation.
+			/// \param arg value to round
+			/// \return rounded value
+			static half ceil(half arg) { return half(binary, round_half<std::round_toward_infinity>(arg.data_)); }
 
-  /// Truncation implementation.
-  /// \param arg value to round
-  /// \return rounded value
-  static half trunc(half arg) {
-    return half(binary, round_half<std::round_toward_zero>(arg.data_));
-  }
+			/// Truncation implementation.
+			/// \param arg value to round
+			/// \return rounded value
+			static half trunc(half arg) { return half(binary, round_half<std::round_toward_zero>(arg.data_)); }
 
-  /// Nearest integer implementation.
-  /// \param arg value to round
-  /// \return rounded value
-  static half round(half arg) { return half(binary, round_half_up(arg.data_)); }
+			/// Nearest integer implementation.
+			/// \param arg value to round
+			/// \return rounded value
+			static half round(half arg) { return half(binary, round_half_up(arg.data_)); }
 
-  /// Nearest integer implementation.
-  /// \param arg value to round
-  /// \return rounded value
-  static long lround(half arg) { return detail::half2int_up<long>(arg.data_); }
+			/// Nearest integer implementation.
+			/// \param arg value to round
+			/// \return rounded value
+			static long lround(half arg) { return detail::half2int_up<long>(arg.data_); }
 
-  /// Nearest integer implementation.
-  /// \param arg value to round
-  /// \return rounded value
-  static half rint(half arg) {
-    return half(binary, round_half<half::round_style>(arg.data_));
-  }
+			/// Nearest integer implementation.
+			/// \param arg value to round
+			/// \return rounded value
+			static half rint(half arg) { return half(binary, round_half<half::round_style>(arg.data_)); }
 
-  /// Nearest integer implementation.
-  /// \param arg value to round
-  /// \return rounded value
-  static long lrint(half arg) {
-    return detail::half2int<half::round_style, long>(arg.data_);
-  }
+			/// Nearest integer implementation.
+			/// \param arg value to round
+			/// \return rounded value
+			static long lrint(half arg) { return detail::half2int<half::round_style,long>(arg.data_); }
 
+		#if HALF_ENABLE_CPP11_LONG_LONG
+			/// Nearest integer implementation.
+			/// \param arg value to round
+			/// \return rounded value
+			static long long llround(half arg) { return detail::half2int_up<long long>(arg.data_); }
+
+			/// Nearest integer implementation.
+			/// \param arg value to round
+			/// \return rounded value
+			static long long llrint(half arg) { return detail::half2int<half::round_style,long long>(arg.data_); }
+		#endif
+
+			/// Decompression implementation.
+			/// \param arg number to decompress
+			/// \param exp address to store exponent at
+			/// \return normalized significant
+			static half frexp(half arg, int *exp)
+			{
+				int m = arg.data_ & 0x7FFF, e = -14;
+				if(m >= 0x7C00 || !m)
+					return *exp = 0, arg;
+				for(; m<0x400; m<<=1,--e) ;
+				return *exp = e+(m>>10), half(binary, (arg.data_&0x8000)|0x3800|(m&0x3FF));
+			}
+
+			/// Decompression implementation.
+			/// \param arg number to decompress
+			/// \param iptr address to store integer part at
+			/// \return fractional part
+			static half modf(half arg, half *iptr)
+			{
+				unsigned int e = arg.data_ & 0x7FFF;
+				if(e >= 0x6400)
+					return *iptr = arg, half(binary, arg.data_&(0x8000U|-(e>0x7C00)));
+				if(e < 0x3C00)
+					return iptr->data_ = arg.data_ & 0x8000, arg;
+				e >>= 10;
+				unsigned int mask = (1<<(25-e)) - 1, m = arg.data_ & mask;
+				iptr->data_ = arg.data_ & ~mask;
+				if(!m)
+					return half(binary, arg.data_&0x8000);
+				for(; m<0x400; m<<=1,--e) ;
+				return half(binary, static_cast<uint16>((arg.data_&0x8000)|(e<<10)|(m&0x3FF)));
+			}
+
+			/// Scaling implementation.
+			/// \param arg number to scale
+			/// \param exp power of two to scale by
+			/// \return scaled number
+			static half scalbln(half arg, long exp)
+			{
+				unsigned int m = arg.data_ & 0x7FFF;
+				if(m >= 0x7C00 || !m)
+					return arg;
+				for(; m<0x400; m<<=1,--exp) ;
+				exp += m >> 10;
+				uint16 value = arg.data_ & 0x8000;
+				if(exp > 30)
+				{
+					if(half::round_style == std::round_toward_zero)
+						value |= 0x7BFF;
+					else if(half::round_style == std::round_toward_infinity)
+						value |= 0x7C00 - (value>>15);
+					else if(half::round_style == std::round_toward_neg_infinity)
+						value |= 0x7BFF + (value>>15);
+					else
+						value |= 0x7C00;
+				}
+				else if(exp > 0)
+					value |= (exp<<10) | (m&0x3FF);
+				else if(exp > -11)
+				{
+					m = (m&0x3FF) | 0x400;
+					if(half::round_style == std::round_to_nearest)
+					{
+						m += 1 << -exp;
+					#if HALF_ROUND_TIES_TO_EVEN
+						m -= (m>>(1-exp)) & 1;
+					#endif
+					}
+					else if(half::round_style == std::round_toward_infinity)
+						m += ((value>>15)-1) & ((1<<(1-exp))-1U);
+					else if(half::round_style == std::round_toward_neg_infinity)
+						m += -(value>>15) & ((1<<(1-exp))-1U);
+					value |= m >> (1-exp);
+				}
+				else if(half::round_style == std::round_toward_infinity)
+					value -= (value>>15) - 1;
+				else if(half::round_style == std::round_toward_neg_infinity)
+					value += value >> 15;
+				return half(binary, value);
+			}
+
+			/// Exponent implementation.
+			/// \param arg number to query
+			/// \return floating point exponent
+			static int ilogb(half arg)
+			{
+				int abs = arg.data_ & 0x7FFF;
+				if(!abs)
+					return FP_ILOGB0;
+				if(abs < 0x7C00)
+				{
+					int exp = (abs>>10) - 15;
+					if(abs < 0x400)
+						for(; abs<0x200; abs<<=1,--exp) ;
+					return exp;
+				}
+				if(abs > 0x7C00)
+					return FP_ILOGBNAN;
+				return INT_MAX;
+			}
+
+			/// Exponent implementation.
+			/// \param arg number to query
+			/// \return floating point exponent
+			static half logb(half arg)
+			{
+				int abs = arg.data_ & 0x7FFF;
+				if(!abs)
+					return half(binary, 0xFC00);
+				if(abs < 0x7C00)
+				{
+					int exp = (abs>>10) - 15;
+					if(abs < 0x400)
+						for(; abs<0x200; abs<<=1,--exp) ;
+					uint16 bits = (exp<0) << 15;
+					if(exp)
+					{
+						unsigned int m = std::abs(exp) << 6, e = 18;
+						for(; m<0x400; m<<=1,--e) ;
+						bits |= (e<<10) + m;
+					}
+					return half(binary, bits);
+				}
+				if(abs > 0x7C00)
+					return arg;
+				return half(binary, 0x7C00);
+			}
+
+			/// Enumeration implementation.
+			/// \param from number to increase/decrease
+			/// \param to direction to enumerate into
+			/// \return next representable number
+			static half nextafter(half from, half to)
+			{
+				uint16 fabs = from.data_ & 0x7FFF, tabs = to.data_ & 0x7FFF;
+				if(fabs > 0x7C00)
+					return from;
+				if(tabs > 0x7C00 || from.data_ == to.data_ || !(fabs|tabs))
+					return to;
+				if(!fabs)
+					return half(binary, (to.data_&0x8000)+1);
+				bool lt = ((fabs==from.data_) ? static_cast<int>(fabs) : -static_cast<int>(fabs)) < 
+					((tabs==to.data_) ? static_cast<int>(tabs) : -static_cast<int>(tabs));
+				return half(binary, from.data_+(((from.data_>>15)^static_cast<unsigned>(lt))<<1)-1);
+			}
+
+			/// Enumeration implementation.
+			/// \param from number to increase/decrease
+			/// \param to direction to enumerate into
+			/// \return next representable number
+			static half nexttoward(half from, long double to)
+			{
+				if(isnan(from))
+					return from;
+				long double lfrom = static_cast<long double>(from);
+				if(builtin_isnan(to) || lfrom == to)
+					return half(static_cast<float>(to));
+				if(!(from.data_&0x7FFF))
+					return half(binary, (static_cast<detail::uint16>(builtin_signbit(to))<<15)+1);
+				return half(binary, from.data_+(((from.data_>>15)^static_cast<unsigned>(lfrom<to))<<1)-1);
+			}
+
+			/// Sign implementation
+			/// \param x first operand
+			/// \param y second operand
+			/// \return composed value
+			static half copysign(half x, half y) { return half(binary, x.data_^((x.data_^y.data_)&0x8000)); }
+
+			/// Classification implementation.
+			/// \param arg value to classify
+			/// \retval true if infinite number
+			/// \retval false else
+			static int fpclassify(half arg)
+			{
+				unsigned int abs = arg.data_ & 0x7FFF;
+				return abs ? ((abs>0x3FF) ? ((abs>=0x7C00) ? ((abs>0x7C00) ? FP_NAN : FP_INFINITE) : FP_NORMAL) :FP_SUBNORMAL) : FP_ZERO;
+			}
+
+			/// Classification implementation.
+			/// \param arg value to classify
+			/// \retval true if finite number
+			/// \retval false else
+			static bool isfinite(half arg) { return (arg.data_&0x7C00) != 0x7C00; }
+
+			/// Classification implementation.
+			/// \param arg value to classify
+			/// \retval true if infinite number
+			/// \retval false else
+			static bool isinf(half arg) { return (arg.data_&0x7FFF) == 0x7C00; }
+
+			/// Classification implementation.
+			/// \param arg value to classify
+			/// \retval true if not a number
+			/// \retval false else
+			static bool isnan(half arg) { return (arg.data_&0x7FFF) > 0x7C00; }
+
+			/// Classification implementation.
+			/// \param arg value to classify
+			/// \retval true if normal number
+			/// \retval false else
+			static bool isnormal(half arg) { return ((arg.data_&0x7C00)!=0) & ((arg.data_&0x7C00)!=0x7C00); }
+
+			/// Sign bit implementation.
+			/// \param arg value to check
+			/// \retval true if signed
+			/// \retval false if unsigned
+			static bool signbit(half arg) { return (arg.data_&0x8000) != 0; }
+
+			/// Comparison implementation.
+			/// \param x first operand
+			/// \param y second operand
+			/// \retval true if operands equal
+			/// \retval false else
+			static bool isequal(half x, half y) { return (x.data_==y.data_ || !((x.data_|y.data_)&0x7FFF)) && !isnan(x); }
+
+			/// Comparison implementation.
+			/// \param x first operand
+			/// \param y second operand
+			/// \retval true if operands not equal
+			/// \retval false else
+			static bool isnotequal(half x, half y) { return (x.data_!=y.data_ && ((x.data_|y.data_)&0x7FFF)) || isnan(x); }
+
+			/// Comparison implementation.
+			/// \param x first operand
+			/// \param y second operand
+			/// \retval true if \a x > \a y
+			/// \retval false else
+			static bool isgreater(half x, half y)
+			{
+				int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
+				return xabs<=0x7C00 && yabs<=0x7C00 && (((xabs==x.data_) ? xabs : -xabs) > ((yabs==y.data_) ? yabs : -yabs));
+			}
+
+			/// Comparison implementation.
+			/// \param x first operand
+			/// \param y second operand
+			/// \retval true if \a x >= \a y
+			/// \retval false else
+			static bool isgreaterequal(half x, half y)
+			{
+				int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
+				return xabs<=0x7C00 && yabs<=0x7C00 && (((xabs==x.data_) ? xabs : -xabs) >= ((yabs==y.data_) ? yabs : -yabs));
+			}
+
+			/// Comparison implementation.
+			/// \param x first operand
+			/// \param y second operand
+			/// \retval true if \a x < \a y
+			/// \retval false else
+			static bool isless(half x, half y)
+			{
+				int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
+				return xabs<=0x7C00 && yabs<=0x7C00 && (((xabs==x.data_) ? xabs : -xabs) < ((yabs==y.data_) ? yabs : -yabs));
+			}
+
+			/// Comparison implementation.
+			/// \param x first operand
+			/// \param y second operand
+			/// \retval true if \a x <= \a y
+			/// \retval false else
+			static bool islessequal(half x, half y)
+			{
+				int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
+				return xabs<=0x7C00 && yabs<=0x7C00 && (((xabs==x.data_) ? xabs : -xabs) <= ((yabs==y.data_) ? yabs : -yabs));
+			}
+
+			/// Comparison implementation.
+			/// \param x first operand
+			/// \param y second operand
+			/// \retval true if either \a x > \a y nor \a x < \a y
+			/// \retval false else
+			static bool islessgreater(half x, half y)
+			{
+				int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
+				if(xabs > 0x7C00 || yabs > 0x7C00)
+					return false;
+				int a = (xabs==x.data_) ? xabs : -xabs, b = (yabs==y.data_) ? yabs : -yabs;
+				return a < b || a > b;
+			}
+
+			/// Comparison implementation.
+			/// \param x first operand
+			/// \param y second operand
+			/// \retval true if operand unordered
+			/// \retval false else
+			static bool isunordered(half x, half y) { return isnan(x) || isnan(y); }
+
+		private:
+			static double erf(double arg)
+			{
+				if(builtin_isinf(arg))
+					return (arg<0.0) ? -1.0 : 1.0;
+				double x2 = arg * arg, ax2 = 0.147 * x2, value = std::sqrt(1.0-std::exp(-x2*(1.2732395447351626861510701069801+ax2)/(1.0+ax2)));
+				return builtin_signbit(arg) ? -value : value;
+			}
+
+			static double lgamma(double arg)
+			{
+				double v = 1.0;
+				for(; arg<8.0; ++arg) v *= arg;
+				double w = 1.0 / (arg*arg);
+				return (((((((-0.02955065359477124183006535947712*w+0.00641025641025641025641025641026)*w+
+					-0.00191752691752691752691752691753)*w+8.4175084175084175084175084175084e-4)*w+
+					-5.952380952380952380952380952381e-4)*w+7.9365079365079365079365079365079e-4)*w+
+					-0.00277777777777777777777777777778)*w+0.08333333333333333333333333333333)/arg + 
+					0.91893853320467274178032973640562 - std::log(v) - arg + (arg-0.5) * std::log(arg);
+			}
+		};
+
+		/// Wrapper for unary half-precision functions needing specialization for individual argument types.
+		/// \tparam T argument type
+		template<typename T> struct unary_specialized
+		{
+			/// Negation implementation.
+			/// \param arg value to negate
+			/// \return negated value
+			static HALF_CONSTEXPR half negate(half arg) { return half(binary, arg.data_^0x8000); }
+
+			/// Absolute value implementation.
+			/// \param arg function argument
+			/// \return absolute value
+			static half fabs(half arg) { return half(binary, arg.data_&0x7FFF); }
+		};
+		template<> struct unary_specialized<expr>
+		{
+			static HALF_CONSTEXPR expr negate(float arg) { return expr(-arg); }
+			static expr fabs(float arg) { return expr(std::fabs(arg)); }
+		};
+
+		/// Wrapper for binary half-precision functions needing specialization for individual argument types.
+		/// \tparam T first argument type
+		/// \tparam U first argument type
+		template<typename T,typename U> struct binary_specialized
+		{
+			/// Minimum implementation.
+			/// \param x first operand
+			/// \param y second operand
+			/// \return minimum value
+			static expr fmin(float x, float y)
+			{
+			#if HALF_ENABLE_CPP11_CMATH
+				return expr(std::fmin(x, y));
+			#else
+				if(builtin_isnan(x))
+					return expr(y);
+				if(builtin_isnan(y))
+					return expr(x);
+				return expr(std::min(x, y));
+			#endif
+			}
+
+			/// Maximum implementation.
+			/// \param x first operand
+			/// \param y second operand
+			/// \return maximum value
+			static expr fmax(float x, float y)
+			{
+			#if HALF_ENABLE_CPP11_CMATH
+				return expr(std::fmax(x, y));
+			#else
+				if(builtin_isnan(x))
+					return expr(y);
+				if(builtin_isnan(y))
+					return expr(x);
+				return expr(std::max(x, y));
+			#endif
+			}
+		};
+		template<> struct binary_specialized<half,half>
+		{
+			static half fmin(half x, half y)
+			{
+				int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
+				if(xabs > 0x7C00)
+					return y;
+				if(yabs > 0x7C00)
+					return x;
+				return (((xabs==x.data_) ? xabs : -xabs) > ((yabs==y.data_) ? yabs : -yabs)) ? y : x;
+			}
+			static half fmax(half x, half y)
+			{
+				int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
+				if(xabs > 0x7C00)
+					return y;
+				if(yabs > 0x7C00)
+					return x;
+				return (((xabs==x.data_) ? xabs : -xabs) < ((yabs==y.data_) ? yabs : -yabs)) ? y : x;
+			}
+		};
+
+		/// Helper class for half casts.
+		/// This class template has to be specialized for all valid cast argument to define an appropriate static `cast` member 
+		/// function and a corresponding `type` member denoting its return type.
+		/// \tparam T destination type
+		/// \tparam U source type
+		/// \tparam R rounding mode to use
+		template<typename T,typename U,std::float_round_style R=(std::float_round_style)(HALF_ROUND_STYLE)> struct half_caster {};
+		template<typename U,std::float_round_style R> struct half_caster<half,U,R>
+		{
+		#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
+			static_assert(std::is_arithmetic<U>::value, "half_cast from non-arithmetic type unsupported");
+		#endif
+
+			static half cast(U arg) { return cast_impl(arg, is_float<U>()); };
+
+		private:
+			static half cast_impl(U arg, true_type) { return half(binary, float2half<R>(arg)); }
+			static half cast_impl(U arg, false_type) { return half(binary, int2half<R>(arg)); }
+		};
+		template<typename T,std::float_round_style R> struct half_caster<T,half,R>
+		{
+		#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
+			static_assert(std::is_arithmetic<T>::value, "half_cast to non-arithmetic type unsupported");
+		#endif
+
+			static T cast(half arg) { return cast_impl(arg, is_float<T>()); }
+
+		private:
+			static T cast_impl(half arg, true_type) { return half2float<T>(arg.data_); }
+			static T cast_impl(half arg, false_type) { return half2int<R,T>(arg.data_); }
+		};
+		template<typename T,std::float_round_style R> struct half_caster<T,expr,R>
+		{
+		#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
+			static_assert(std::is_arithmetic<T>::value, "half_cast to non-arithmetic type unsupported");
+		#endif
+
+			static T cast(expr arg) { return cast_impl(arg, is_float<T>()); }
+
+		private:
+			static T cast_impl(float arg, true_type) { return static_cast<T>(arg); }
+			static T cast_impl(half arg, false_type) { return half2int<R,T>(arg.data_); }
+		};
+		template<std::float_round_style R> struct half_caster<half,half,R>
+		{
+			static half cast(half arg) { return arg; }
+		};
+		template<std::float_round_style R> struct half_caster<half,expr,R> : half_caster<half,half,R> {};
+
+		/// \name Comparison operators
+		/// \{
+
+		/// Comparison for equality.
+		/// \param x first operand
+		/// \param y second operand
+		/// \retval true if operands equal
+		/// \retval false else
+		template<typename T,typename U> typename enable<bool,T,U>::type operator==(T x, U y) { return functions::isequal(x, y); }
+
+		/// Comparison for inequality.
+		/// \param x first operand
+		/// \param y second operand
+		/// \retval true if operands not equal
+		/// \retval false else
+		template<typename T,typename U> typename enable<bool,T,U>::type operator!=(T x, U y) { return functions::isnotequal(x, y); }
+
+		/// Comparison for less than.
+		/// \param x first operand
+		/// \param y second operand
+		/// \retval true if \a x less than \a y
+		/// \retval false else
+		template<typename T,typename U> typename enable<bool,T,U>::type operator<(T x, U y) { return functions::isless(x, y); }
+
+		/// Comparison for greater than.
+		/// \param x first operand
+		/// \param y second operand
+		/// \retval true if \a x greater than \a y
+		/// \retval false else
+		template<typename T,typename U> typename enable<bool,T,U>::type operator>(T x, U y) { return functions::isgreater(x, y); }
+
+		/// Comparison for less equal.
+		/// \param x first operand
+		/// \param y second operand
+		/// \retval true if \a x less equal \a y
+		/// \retval false else
+		template<typename T,typename U> typename enable<bool,T,U>::type operator<=(T x, U y) { return functions::islessequal(x, y); }
+
+		/// Comparison for greater equal.
+		/// \param x first operand
+		/// \param y second operand
+		/// \retval true if \a x greater equal \a y
+		/// \retval false else
+		template<typename T,typename U> typename enable<bool,T,U>::type operator>=(T x, U y) { return functions::isgreaterequal(x, y); }
+
+		/// \}
+		/// \name Arithmetic operators
+		/// \{
+
+		/// Add halfs.
+		/// \param x left operand
+		/// \param y right operand
+		/// \return sum of half expressions
+		template<typename T,typename U> typename enable<expr,T,U>::type operator+(T x, U y) { return functions::plus(x, y); }
+
+		/// Subtract halfs.
+		/// \param x left operand
+		/// \param y right operand
+		/// \return difference of half expressions
+		template<typename T,typename U> typename enable<expr,T,U>::type operator-(T x, U y) { return functions::minus(x, y); }
+
+		/// Multiply halfs.
+		/// \param x left operand
+		/// \param y right operand
+		/// \return product of half expressions
+		template<typename T,typename U> typename enable<expr,T,U>::type operator*(T x, U y) { return functions::multiplies(x, y); }
+
+		/// Divide halfs.
+		/// \param x left operand
+		/// \param y right operand
+		/// \return quotient of half expressions
+		template<typename T,typename U> typename enable<expr,T,U>::type operator/(T x, U y) { return functions::divides(x, y); }
+
+		/// Identity.
+		/// \param arg operand
+		/// \return uncahnged operand
+		template<typename T> HALF_CONSTEXPR typename enable<T,T>::type operator+(T arg) { return arg; }
+
+		/// Negation.
+		/// \param arg operand
+		/// \return negated operand
+		template<typename T> HALF_CONSTEXPR typename enable<T,T>::type operator-(T arg) { return unary_specialized<T>::negate(arg); }
+
+		/// \}
+		/// \name Input and output
+		/// \{
+
+		/// Output operator.
+		/// \param out output stream to write into
+		/// \param arg half expression to write
+		/// \return reference to output stream
+		template<typename T,typename charT,typename traits> typename enable<std::basic_ostream<charT,traits>&,T>::type
+			operator<<(std::basic_ostream<charT,traits> &out, T arg) { return functions::write(out, arg); }
+
+		/// Input operator.
+		/// \param in input stream to read from
+		/// \param arg half to read into
+		/// \return reference to input stream
+		template<typename charT,typename traits> std::basic_istream<charT,traits>&
+			operator>>(std::basic_istream<charT,traits> &in, half &arg) { return functions::read(in, arg); }
+
+		/// \}
+		/// \name Basic mathematical operations
+		/// \{
+
+		/// Absolute value.
+		/// \param arg operand
+		/// \return absolute value of \a arg
+//		template<typename T> typename enable<T,T>::type abs(T arg) { return unary_specialized<T>::fabs(arg); }
+		inline half abs(half arg) { return unary_specialized<half>::fabs(arg); }
+		inline expr abs(expr arg) { return unary_specialized<expr>::fabs(arg); }
+
+		/// Absolute value.
+		/// \param arg operand
+		/// \return absolute value of \a arg
+//		template<typename T> typename enable<T,T>::type fabs(T arg) { return unary_specialized<T>::fabs(arg); }
+		inline half fabs(half arg) { return unary_specialized<half>::fabs(arg); }
+		inline expr fabs(expr arg) { return unary_specialized<expr>::fabs(arg); }
+
+		/// Remainder of division.
+		/// \param x first operand
+		/// \param y second operand
+		/// \return remainder of floating point division.
+//		template<typename T,typename U> typename enable<expr,T,U>::type fmod(T x, U y) { return functions::fmod(x, y); }
+		inline expr fmod(half x, half y) { return functions::fmod(x, y); }
+		inline expr fmod(half x, expr y) { return functions::fmod(x, y); }
+		inline expr fmod(expr x, half y) { return functions::fmod(x, y); }
+		inline expr fmod(expr x, expr y) { return functions::fmod(x, y); }
+
+		/// Remainder of division.
+		/// \param x first operand
+		/// \param y second operand
+		/// \return remainder of floating point division.
+//		template<typename T,typename U> typename enable<expr,T,U>::type remainder(T x, U y) { return functions::remainder(x, y); }
+		inline expr remainder(half x, half y) { return functions::remainder(x, y); }
+		inline expr remainder(half x, expr y) { return functions::remainder(x, y); }
+		inline expr remainder(expr x, half y) { return functions::remainder(x, y); }
+		inline expr remainder(expr x, expr y) { return functions::remainder(x, y); }
+
+		/// Remainder of division.
+		/// \param x first operand
+		/// \param y second operand
+		/// \param quo address to store some bits of quotient at
+		/// \return remainder of floating point division.
+//		template<typename T,typename U> typename enable<expr,T,U>::type remquo(T x, U y, int *quo) { return functions::remquo(x, y, quo); }
+		inline expr remquo(half x, half y, int *quo) { return functions::remquo(x, y, quo); }
+		inline expr remquo(half x, expr y, int *quo) { return functions::remquo(x, y, quo); }
+		inline expr remquo(expr x, half y, int *quo) { return functions::remquo(x, y, quo); }
+		inline expr remquo(expr x, expr y, int *quo) { return functions::remquo(x, y, quo); }
+
+		/// Fused multiply add.
+		/// \param x first operand
+		/// \param y second operand
+		/// \param z third operand
+		/// \return ( \a x * \a y ) + \a z rounded as one operation.
+//		template<typename T,typename U,typename V> typename enable<expr,T,U,V>::type fma(T x, U y, V z) { return functions::fma(x, y, z); }
+		inline expr fma(half x, half y, half z) { return functions::fma(x, y, z); }
+		inline expr fma(half x, half y, expr z) { return functions::fma(x, y, z); }
+		inline expr fma(half x, expr y, half z) { return functions::fma(x, y, z); }
+		inline expr fma(half x, expr y, expr z) { return functions::fma(x, y, z); }
+		inline expr fma(expr x, half y, half z) { return functions::fma(x, y, z); }
+		inline expr fma(expr x, half y, expr z) { return functions::fma(x, y, z); }
+		inline expr fma(expr x, expr y, half z) { return functions::fma(x, y, z); }
+		inline expr fma(expr x, expr y, expr z) { return functions::fma(x, y, z); }
+
+		/// Maximum of half expressions.
+		/// \param x first operand
+		/// \param y second operand
+		/// \return maximum of operands
+//		template<typename T,typename U> typename result<T,U>::type fmax(T x, U y) { return binary_specialized<T,U>::fmax(x, y); }
+		inline half fmax(half x, half y) { return binary_specialized<half,half>::fmax(x, y); }
+		inline expr fmax(half x, expr y) { return binary_specialized<half,expr>::fmax(x, y); }
+		inline expr fmax(expr x, half y) { return binary_specialized<expr,half>::fmax(x, y); }
+		inline expr fmax(expr x, expr y) { return binary_specialized<expr,expr>::fmax(x, y); }
+
+		/// Minimum of half expressions.
+		/// \param x first operand
+		/// \param y second operand
+		/// \return minimum of operands
+//		template<typename T,typename U> typename result<T,U>::type fmin(T x, U y) { return binary_specialized<T,U>::fmin(x, y); }
+		inline half fmin(half x, half y) { return binary_specialized<half,half>::fmin(x, y); }
+		inline expr fmin(half x, expr y) { return binary_specialized<half,expr>::fmin(x, y); }
+		inline expr fmin(expr x, half y) { return binary_specialized<expr,half>::fmin(x, y); }
+		inline expr fmin(expr x, expr y) { return binary_specialized<expr,expr>::fmin(x, y); }
+
+		/// Positive difference.
+		/// \param x first operand
+		/// \param y second operand
+		/// \return \a x - \a y or 0 if difference negative
+//		template<typename T,typename U> typename enable<expr,T,U>::type fdim(T x, U y) { return functions::fdim(x, y); }
+		inline expr fdim(half x, half y) { return functions::fdim(x, y); }
+		inline expr fdim(half x, expr y) { return functions::fdim(x, y); }
+		inline expr fdim(expr x, half y) { return functions::fdim(x, y); }
+		inline expr fdim(expr x, expr y) { return functions::fdim(x, y); }
+
+		/// Get NaN value.
+		/// \return quiet NaN
+		inline half nanh(const char*) { return functions::nanh(); }
+
+		/// \}
+		/// \name Exponential functions
+		/// \{
+
+		/// Exponential function.
+		/// \param arg function argument
+		/// \return e raised to \a arg
+//		template<typename T> typename enable<expr,T>::type exp(T arg) { return functions::exp(arg); }
+		inline expr exp(half arg) { return functions::exp(arg); }
+		inline expr exp(expr arg) { return functions::exp(arg); }
+
+		/// Exponential minus one.
+		/// \param arg function argument
+		/// \return e raised to \a arg subtracted by 1
+//		template<typename T> typename enable<expr,T>::type expm1(T arg) { return functions::expm1(arg); }
+		inline expr expm1(half arg) { return functions::expm1(arg); }
+		inline expr expm1(expr arg) { return functions::expm1(arg); }
+
+		/// Binary exponential.
+		/// \param arg function argument
+		/// \return 2 raised to \a arg
+//		template<typename T> typename enable<expr,T>::type exp2(T arg) { return functions::exp2(arg); }
+		inline expr exp2(half arg) { return functions::exp2(arg); }
+		inline expr exp2(expr arg) { return functions::exp2(arg); }
+
+		/// Natural logorithm.
+		/// \param arg function argument
+		/// \return logarithm of \a arg to base e
+//		template<typename T> typename enable<expr,T>::type log(T arg) { return functions::log(arg); }
+		inline expr log(half arg) { return functions::log(arg); }
+		inline expr log(expr arg) { return functions::log(arg); }
+
+		/// Common logorithm.
+		/// \param arg function argument
+		/// \return logarithm of \a arg to base 10
+//		template<typename T> typename enable<expr,T>::type log10(T arg) { return functions::log10(arg); }
+		inline expr log10(half arg) { return functions::log10(arg); }
+		inline expr log10(expr arg) { return functions::log10(arg); }
+
+		/// Natural logorithm.
+		/// \param arg function argument
+		/// \return logarithm of \a arg plus 1 to base e
+//		template<typename T> typename enable<expr,T>::type log1p(T arg) { return functions::log1p(arg); }
+		inline expr log1p(half arg) { return functions::log1p(arg); }
+		inline expr log1p(expr arg) { return functions::log1p(arg); }
+
+		/// Binary logorithm.
+		/// \param arg function argument
+		/// \return logarithm of \a arg to base 2
+//		template<typename T> typename enable<expr,T>::type log2(T arg) { return functions::log2(arg); }
+		inline expr log2(half arg) { return functions::log2(arg); }
+		inline expr log2(expr arg) { return functions::log2(arg); }
+
+		/// \}
+		/// \name Power functions
+		/// \{
+
+		/// Square root.
+		/// \param arg function argument
+		/// \return square root of \a arg
+//		template<typename T> typename enable<expr,T>::type sqrt(T arg) { return functions::sqrt(arg); }
+		inline expr sqrt(half arg) { return functions::sqrt(arg); }
+		inline expr sqrt(expr arg) { return functions::sqrt(arg); }
+
+		/// Cubic root.
+		/// \param arg function argument
+		/// \return cubic root of \a arg
+//		template<typename T> typename enable<expr,T>::type cbrt(T arg) { return functions::cbrt(arg); }
+		inline expr cbrt(half arg) { return functions::cbrt(arg); }
+		inline expr cbrt(expr arg) { return functions::cbrt(arg); }
+
+		/// Hypotenuse function.
+		/// \param x first argument
+		/// \param y second argument
+		/// \return square root of sum of squares without internal over- or underflows
+//		template<typename T,typename U> typename enable<expr,T,U>::type hypot(T x, U y) { return functions::hypot(x, y); }
+		inline expr hypot(half x, half y) { return functions::hypot(x, y); }
+		inline expr hypot(half x, expr y) { return functions::hypot(x, y); }
+		inline expr hypot(expr x, half y) { return functions::hypot(x, y); }
+		inline expr hypot(expr x, expr y) { return functions::hypot(x, y); }
+
+		/// Power function.
+		/// \param base first argument
+		/// \param exp second argument
+		/// \return \a base raised to \a exp
+//		template<typename T,typename U> typename enable<expr,T,U>::type pow(T base, U exp) { return functions::pow(base, exp); }
+		inline expr pow(half base, half exp) { return functions::pow(base, exp); }
+		inline expr pow(half base, expr exp) { return functions::pow(base, exp); }
+		inline expr pow(expr base, half exp) { return functions::pow(base, exp); }
+		inline expr pow(expr base, expr exp) { return functions::pow(base, exp); }
+
+		/// \}
+		/// \name Trigonometric functions
+		/// \{
+
+		/// Sine function.
+		/// \param arg function argument
+		/// \return sine value of \a arg
+//		template<typename T> typename enable<expr,T>::type sin(T arg) { return functions::sin(arg); }
+		inline expr sin(half arg) { return functions::sin(arg); }
+		inline expr sin(expr arg) { return functions::sin(arg); }
+
+		/// Cosine function.
+		/// \param arg function argument
+		/// \return cosine value of \a arg
+//		template<typename T> typename enable<expr,T>::type cos(T arg) { return functions::cos(arg); }
+		inline expr cos(half arg) { return functions::cos(arg); }
+		inline expr cos(expr arg) { return functions::cos(arg); }
+
+		/// Tangent function.
+		/// \param arg function argument
+		/// \return tangent value of \a arg
+//		template<typename T> typename enable<expr,T>::type tan(T arg) { return functions::tan(arg); }
+		inline expr tan(half arg) { return functions::tan(arg); }
+		inline expr tan(expr arg) { return functions::tan(arg); }
+
+		/// Arc sine.
+		/// \param arg function argument
+		/// \return arc sine value of \a arg
+//		template<typename T> typename enable<expr,T>::type asin(T arg) { return functions::asin(arg); }
+		inline expr asin(half arg) { return functions::asin(arg); }
+		inline expr asin(expr arg) { return functions::asin(arg); }
+
+		/// Arc cosine function.
+		/// \param arg function argument
+		/// \return arc cosine value of \a arg
+//		template<typename T> typename enable<expr,T>::type acos(T arg) { return functions::acos(arg); }
+		inline expr acos(half arg) { return functions::acos(arg); }
+		inline expr acos(expr arg) { return functions::acos(arg); }
+
+		/// Arc tangent function.
+		/// \param arg function argument
+		/// \return arc tangent value of \a arg
+//		template<typename T> typename enable<expr,T>::type atan(T arg) { return functions::atan(arg); }
+		inline expr atan(half arg) { return functions::atan(arg); }
+		inline expr atan(expr arg) { return functions::atan(arg); }
+
+		/// Arc tangent function.
+		/// \param x first argument
+		/// \param y second argument
+		/// \return arc tangent value
+//		template<typename T,typename U> typename enable<expr,T,U>::type atan2(T x, U y) { return functions::atan2(x, y); }
+		inline expr atan2(half x, half y) { return functions::atan2(x, y); }
+		inline expr atan2(half x, expr y) { return functions::atan2(x, y); }
+		inline expr atan2(expr x, half y) { return functions::atan2(x, y); }
+		inline expr atan2(expr x, expr y) { return functions::atan2(x, y); }
+
+		/// \}
+		/// \name Hyperbolic functions
+		/// \{
+
+		/// Hyperbolic sine.
+		/// \param arg function argument
+		/// \return hyperbolic sine value of \a arg
+//		template<typename T> typename enable<expr,T>::type sinh(T arg) { return functions::sinh(arg); }
+		inline expr sinh(half arg) { return functions::sinh(arg); }
+		inline expr sinh(expr arg) { return functions::sinh(arg); }
+
+		/// Hyperbolic cosine.
+		/// \param arg function argument
+		/// \return hyperbolic cosine value of \a arg
+//		template<typename T> typename enable<expr,T>::type cosh(T arg) { return functions::cosh(arg); }
+		inline expr cosh(half arg) { return functions::cosh(arg); }
+		inline expr cosh(expr arg) { return functions::cosh(arg); }
+
+		/// Hyperbolic tangent.
+		/// \param arg function argument
+		/// \return hyperbolic tangent value of \a arg
+//		template<typename T> typename enable<expr,T>::type tanh(T arg) { return functions::tanh(arg); }
+		inline expr tanh(half arg) { return functions::tanh(arg); }
+		inline expr tanh(expr arg) { return functions::tanh(arg); }
+
+		/// Hyperbolic area sine.
+		/// \param arg function argument
+		/// \return area sine value of \a arg
+//		template<typename T> typename enable<expr,T>::type asinh(T arg) { return functions::asinh(arg); }
+		inline expr asinh(half arg) { return functions::asinh(arg); }
+		inline expr asinh(expr arg) { return functions::asinh(arg); }
+
+		/// Hyperbolic area cosine.
+		/// \param arg function argument
+		/// \return area cosine value of \a arg
+//		template<typename T> typename enable<expr,T>::type acosh(T arg) { return functions::acosh(arg); }
+		inline expr acosh(half arg) { return functions::acosh(arg); }
+		inline expr acosh(expr arg) { return functions::acosh(arg); }
+
+		/// Hyperbolic area tangent.
+		/// \param arg function argument
+		/// \return area tangent value of \a arg
+//		template<typename T> typename enable<expr,T>::type atanh(T arg) { return functions::atanh(arg); }
+		inline expr atanh(half arg) { return functions::atanh(arg); }
+		inline expr atanh(expr arg) { return functions::atanh(arg); }
+
+		/// \}
+		/// \name Error and gamma functions
+		/// \{
+
+		/// Error function.
+		/// \param arg function argument
+		/// \return error function value of \a arg
+//		template<typename T> typename enable<expr,T>::type erf(T arg) { return functions::erf(arg); }
+		inline expr erf(half arg) { return functions::erf(arg); }
+		inline expr erf(expr arg) { return functions::erf(arg); }
+
+		/// Complementary error function.
+		/// \param arg function argument
+		/// \return 1 minus error function value of \a arg
+//		template<typename T> typename enable<expr,T>::type erfc(T arg) { return functions::erfc(arg); }
+		inline expr erfc(half arg) { return functions::erfc(arg); }
+		inline expr erfc(expr arg) { return functions::erfc(arg); }
+
+		/// Natural logarithm of gamma function.
+		/// \param arg function argument
+		/// \return natural logarith of gamma function for \a arg
+//		template<typename T> typename enable<expr,T>::type lgamma(T arg) { return functions::lgamma(arg); }
+		inline expr lgamma(half arg) { return functions::lgamma(arg); }
+		inline expr lgamma(expr arg) { return functions::lgamma(arg); }
+
+		/// Gamma function.
+		/// \param arg function argument
+		/// \return gamma function value of \a arg
+//		template<typename T> typename enable<expr,T>::type tgamma(T arg) { return functions::tgamma(arg); }
+		inline expr tgamma(half arg) { return functions::tgamma(arg); }
+		inline expr tgamma(expr arg) { return functions::tgamma(arg); }
+
+		/// \}
+		/// \name Rounding
+		/// \{
+
+		/// Nearest integer not less than half value.
+		/// \param arg half to round
+		/// \return nearest integer not less than \a arg
+//		template<typename T> typename enable<half,T>::type ceil(T arg) { return functions::ceil(arg); }
+		inline half ceil(half arg) { return functions::ceil(arg); }
+		inline half ceil(expr arg) { return functions::ceil(arg); }
+
+		/// Nearest integer not greater than half value.
+		/// \param arg half to round
+		/// \return nearest integer not greater than \a arg
+//		template<typename T> typename enable<half,T>::type floor(T arg) { return functions::floor(arg); }
+		inline half floor(half arg) { return functions::floor(arg); }
+		inline half floor(expr arg) { return functions::floor(arg); }
+
+		/// Nearest integer not greater in magnitude than half value.
+		/// \param arg half to round
+		/// \return nearest integer not greater in magnitude than \a arg
+//		template<typename T> typename enable<half,T>::type trunc(T arg) { return functions::trunc(arg); }
+		inline half trunc(half arg) { return functions::trunc(arg); }
+		inline half trunc(expr arg) { return functions::trunc(arg); }
+
+		/// Nearest integer.
+		/// \param arg half to round
+		/// \return nearest integer, rounded away from zero in half-way cases
+//		template<typename T> typename enable<half,T>::type round(T arg) { return functions::round(arg); }
+		inline half round(half arg) { return functions::round(arg); }
+		inline half round(expr arg) { return functions::round(arg); }
+
+		/// Nearest integer.
+		/// \param arg half to round
+		/// \return nearest integer, rounded away from zero in half-way cases
+//		template<typename T> typename enable<long,T>::type lround(T arg) { return functions::lround(arg); }
+		inline long lround(half arg) { return functions::lround(arg); }
+		inline long lround(expr arg) { return functions::lround(arg); }
+
+		/// Nearest integer using half's internal rounding mode.
+		/// \param arg half expression to round
+		/// \return nearest integer using default rounding mode
+//		template<typename T> typename enable<half,T>::type nearbyint(T arg) { return functions::nearbyint(arg); }
+		inline half nearbyint(half arg) { return functions::rint(arg); }
+		inline half nearbyint(expr arg) { return functions::rint(arg); }
+
+		/// Nearest integer using half's internal rounding mode.
+		/// \param arg half expression to round
+		/// \return nearest integer using default rounding mode
+//		template<typename T> typename enable<half,T>::type rint(T arg) { return functions::rint(arg); }
+		inline half rint(half arg) { return functions::rint(arg); }
+		inline half rint(expr arg) { return functions::rint(arg); }
+
+		/// Nearest integer using half's internal rounding mode.
+		/// \param arg half expression to round
+		/// \return nearest integer using default rounding mode
+//		template<typename T> typename enable<long,T>::type lrint(T arg) { return functions::lrint(arg); }
+		inline long lrint(half arg) { return functions::lrint(arg); }
+		inline long lrint(expr arg) { return functions::lrint(arg); }
+	#if HALF_ENABLE_CPP11_LONG_LONG
+		/// Nearest integer.
+		/// \param arg half to round
+		/// \return nearest integer, rounded away from zero in half-way cases
+//		template<typename T> typename enable<long long,T>::type llround(T arg) { return functions::llround(arg); }
+		inline long long llround(half arg) { return functions::llround(arg); }
+		inline long long llround(expr arg) { return functions::llround(arg); }
+
+		/// Nearest integer using half's internal rounding mode.
+		/// \param arg half expression to round
+		/// \return nearest integer using default rounding mode
+//		template<typename T> typename enable<long long,T>::type llrint(T arg) { return functions::llrint(arg); }
+		inline long long llrint(half arg) { return functions::llrint(arg); }
+		inline long long llrint(expr arg) { return functions::llrint(arg); }
+	#endif
+
+		/// \}
+		/// \name Floating point manipulation
+		/// \{
+
+		/// Decompress floating point number.
+		/// \param arg number to decompress
+		/// \param exp address to store exponent at
+		/// \return significant in range [0.5, 1)
+//		template<typename T> typename enable<half,T>::type frexp(T arg, int *exp) { return functions::frexp(arg, exp); }
+		inline half frexp(half arg, int *exp) { return functions::frexp(arg, exp); }
+		inline half frexp(expr arg, int *exp) { return functions::frexp(arg, exp); }
+
+		/// Multiply by power of two.
+		/// \param arg number to modify
+		/// \param exp power of two to multiply with
+		/// \return \a arg multplied by 2 raised to \a exp
+//		template<typename T> typename enable<half,T>::type ldexp(T arg, int exp) { return functions::scalbln(arg, exp); }
+		inline half ldexp(half arg, int exp) { return functions::scalbln(arg, exp); }
+		inline half ldexp(expr arg, int exp) { return functions::scalbln(arg, exp); }
+
+		/// Extract integer and fractional parts.
+		/// \param arg number to decompress
+		/// \param iptr address to store integer part at
+		/// \return fractional part
+//		template<typename T> typename enable<half,T>::type modf(T arg, half *iptr) { return functions::modf(arg, iptr); }
+		inline half modf(half arg, half *iptr) { return functions::modf(arg, iptr); }
+		inline half modf(expr arg, half *iptr) { return functions::modf(arg, iptr); }
+
+		/// Multiply by power of two.
+		/// \param arg number to modify
+		/// \param exp power of two to multiply with
+		/// \return \a arg multplied by 2 raised to \a exp
+//		template<typename T> typename enable<half,T>::type scalbn(T arg, int exp) { return functions::scalbln(arg, exp); }
+		inline half scalbn(half arg, int exp) { return functions::scalbln(arg, exp); }
+		inline half scalbn(expr arg, int exp) { return functions::scalbln(arg, exp); }
+
+		/// Multiply by power of two.
+		/// \param arg number to modify
+		/// \param exp power of two to multiply with
+		/// \return \a arg multplied by 2 raised to \a exp	
+//		template<typename T> typename enable<half,T>::type scalbln(T arg, long exp) { return functions::scalbln(arg, exp); }
+		inline half scalbln(half arg, long exp) { return functions::scalbln(arg, exp); }
+		inline half scalbln(expr arg, long exp) { return functions::scalbln(arg, exp); }
+
+		/// Extract exponent.
+		/// \param arg number to query
+		/// \return floating point exponent
+		/// \retval FP_ILOGB0 for zero
+		/// \retval FP_ILOGBNAN for NaN
+		/// \retval MAX_INT for infinity
+//		template<typename T> typename enable<int,T>::type ilogb(T arg) { return functions::ilogb(arg); }
+		inline int ilogb(half arg) { return functions::ilogb(arg); }
+		inline int ilogb(expr arg) { return functions::ilogb(arg); }
+
+		/// Extract exponent.
+		/// \param arg number to query
+		/// \return floating point exponent
+//		template<typename T> typename enable<half,T>::type logb(T arg) { return functions::logb(arg); }
+		inline half logb(half arg) { return functions::logb(arg); }
+		inline half logb(expr arg) { return functions::logb(arg); }
+
+		/// Next representable value.
+		/// \param from value to compute next representable value for
+		/// \param to direction towards which to compute next value
+		/// \return next representable value after \a from in direction towards \a to
+//		template<typename T,typename U> typename enable<half,T,U>::type nextafter(T from, U to) { return functions::nextafter(from, to); }
+		inline half nextafter(half from, half to) { return functions::nextafter(from, to); }
+		inline half nextafter(half from, expr to) { return functions::nextafter(from, to); }
+		inline half nextafter(expr from, half to) { return functions::nextafter(from, to); }
+		inline half nextafter(expr from, expr to) { return functions::nextafter(from, to); }
+
+		/// Next representable value.
+		/// \param from value to compute next representable value for
+		/// \param to direction towards which to compute next value
+		/// \return next representable value after \a from in direction towards \a to
+//		template<typename T> typename enable<half,T>::type nexttoward(T from, long double to) { return functions::nexttoward(from, to); }
+		inline half nexttoward(half from, long double to) { return functions::nexttoward(from, to); }
+		inline half nexttoward(expr from, long double to) { return functions::nexttoward(from, to); }
+
+		/// Take sign.
+		/// \param x value to change sign for
+		/// \param y value to take sign from
+		/// \return value equal to \a x in magnitude and to \a y in sign
+//		template<typename T,typename U> typename enable<half,T,U>::type copysign(T x, U y) { return functions::copysign(x, y); }
+		inline half copysign(half x, half y) { return functions::copysign(x, y); }
+		inline half copysign(half x, expr y) { return functions::copysign(x, y); }
+		inline half copysign(expr x, half y) { return functions::copysign(x, y); }
+		inline half copysign(expr x, expr y) { return functions::copysign(x, y); }
+
+		/// \}
+		/// \name Floating point classification
+		/// \{
+
+
+		/// Classify floating point value.
+		/// \param arg number to classify
+		/// \retval FP_ZERO for positive and negative zero
+		/// \retval FP_SUBNORMAL for subnormal numbers
+		/// \retval FP_INFINITY for positive and negative infinity
+		/// \retval FP_NAN for NaNs
+		/// \retval FP_NORMAL for all other (normal) values
+//		template<typename T> typename enable<int,T>::type fpclassify(T arg) { return functions::fpclassify(arg); }
+		inline int fpclassify(half arg) { return functions::fpclassify(arg); }
+		inline int fpclassify(expr arg) { return functions::fpclassify(arg); }
+
+		/// Check if finite number.
+		/// \param arg number to check
+		/// \retval true if neither infinity nor NaN
+		/// \retval false else
+//		template<typename T> typename enable<bool,T>::type isfinite(T arg) { return functions::isfinite(arg); }
+		inline bool isfinite(half arg) { return functions::isfinite(arg); }
+		inline bool isfinite(expr arg) { return functions::isfinite(arg); }
+
+		/// Check for infinity.
+		/// \param arg number to check
+		/// \retval true for positive or negative infinity
+		/// \retval false else
+//		template<typename T> typename enable<bool,T>::type isinf(T arg) { return functions::isinf(arg); }
+		inline bool isinf(half arg) { return functions::isinf(arg); }
+		inline bool isinf(expr arg) { return functions::isinf(arg); }
+
+		/// Check for NaN.
+		/// \param arg number to check
+		/// \retval true for NaNs
+		/// \retval false else
+//		template<typename T> typename enable<bool,T>::type isnan(T arg) { return functions::isnan(arg); }
+		inline bool isnan(half arg) { return functions::isnan(arg); }
+		inline bool isnan(expr arg) { return functions::isnan(arg); }
+
+		/// Check if normal number.
+		/// \param arg number to check
+		/// \retval true if normal number
+		/// \retval false if either subnormal, zero, infinity or NaN
+//		template<typename T> typename enable<bool,T>::type isnormal(T arg) { return functions::isnormal(arg); }
+		inline bool isnormal(half arg) { return functions::isnormal(arg); }
+		inline bool isnormal(expr arg) { return functions::isnormal(arg); }
+
+		/// Check sign.
+		/// \param arg number to check
+		/// \retval true for negative number
+		/// \retval false for positive number
+//		template<typename T> typename enable<bool,T>::type signbit(T arg) { return functions::signbit(arg); }
+		inline bool signbit(half arg) { return functions::signbit(arg); }
+		inline bool signbit(expr arg) { return functions::signbit(arg); }
+
+		/// \}
+		/// \name Comparison
+		/// \{
+
+		/// Comparison for greater than.
+		/// \param x first operand
+		/// \param y second operand
+		/// \retval true if \a x greater than \a y
+		/// \retval false else
+//		template<typename T,typename U> typename enable<bool,T,U>::type isgreater(T x, U y) { return functions::isgreater(x, y); }
+		inline bool isgreater(half x, half y) { return functions::isgreater(x, y); }
+		inline bool isgreater(half x, expr y) { return functions::isgreater(x, y); }
+		inline bool isgreater(expr x, half y) { return functions::isgreater(x, y); }
+		inline bool isgreater(expr x, expr y) { return functions::isgreater(x, y); }
+
+		/// Comparison for greater equal.
+		/// \param x first operand
+		/// \param y second operand
+		/// \retval true if \a x greater equal \a y
+		/// \retval false else
+//		template<typename T,typename U> typename enable<bool,T,U>::type isgreaterequal(T x, U y) { return functions::isgreaterequal(x, y); }
+		inline bool isgreaterequal(half x, half y) { return functions::isgreaterequal(x, y); }
+		inline bool isgreaterequal(half x, expr y) { return functions::isgreaterequal(x, y); }
+		inline bool isgreaterequal(expr x, half y) { return functions::isgreaterequal(x, y); }
+		inline bool isgreaterequal(expr x, expr y) { return functions::isgreaterequal(x, y); }
+
+		/// Comparison for less than.
+		/// \param x first operand
+		/// \param y second operand
+		/// \retval true if \a x less than \a y
+		/// \retval false else
+//		template<typename T,typename U> typename enable<bool,T,U>::type isless(T x, U y) { return functions::isless(x, y); }
+		inline bool isless(half x, half y) { return functions::isless(x, y); }
+		inline bool isless(half x, expr y) { return functions::isless(x, y); }
+		inline bool isless(expr x, half y) { return functions::isless(x, y); }
+		inline bool isless(expr x, expr y) { return functions::isless(x, y); }
+
+		/// Comparison for less equal.
+		/// \param x first operand
+		/// \param y second operand
+		/// \retval true if \a x less equal \a y
+		/// \retval false else
+//		template<typename T,typename U> typename enable<bool,T,U>::type islessequal(T x, U y) { return functions::islessequal(x, y); }
+		inline bool islessequal(half x, half y) { return functions::islessequal(x, y); }
+		inline bool islessequal(half x, expr y) { return functions::islessequal(x, y); }
+		inline bool islessequal(expr x, half y) { return functions::islessequal(x, y); }
+		inline bool islessequal(expr x, expr y) { return functions::islessequal(x, y); }
+
+		/// Comarison for less or greater.
+		/// \param x first operand
+		/// \param y second operand
+		/// \retval true if either less or greater
+		/// \retval false else
+//		template<typename T,typename U> typename enable<bool,T,U>::type islessgreater(T x, U y) { return functions::islessgreater(x, y); }
+		inline bool islessgreater(half x, half y) { return functions::islessgreater(x, y); }
+		inline bool islessgreater(half x, expr y) { return functions::islessgreater(x, y); }
+		inline bool islessgreater(expr x, half y) { return functions::islessgreater(x, y); }
+		inline bool islessgreater(expr x, expr y) { return functions::islessgreater(x, y); }
+
+		/// Check if unordered.
+		/// \param x first operand
+		/// \param y second operand
+		/// \retval true if unordered (one or two NaN operands)
+		/// \retval false else
+//		template<typename T,typename U> typename enable<bool,T,U>::type isunordered(T x, U y) { return functions::isunordered(x, y); }
+		inline bool isunordered(half x, half y) { return functions::isunordered(x, y); }
+		inline bool isunordered(half x, expr y) { return functions::isunordered(x, y); }
+		inline bool isunordered(expr x, half y) { return functions::isunordered(x, y); }
+		inline bool isunordered(expr x, expr y) { return functions::isunordered(x, y); }
+
+		/// \name Casting
+		/// \{
+
+		/// Cast to or from half-precision floating point number.
+		/// This casts between [half](\ref half_float::half) and any built-in arithmetic type. The values are converted 
+		/// directly using the given rounding mode, without any roundtrip over `float` that a `static_cast` would otherwise do. 
+		/// It uses the default rounding mode.
+		///
+		/// Using this cast with neither of the two types being a [half](\ref half_float::half) or with any of the two types 
+		/// not being a built-in arithmetic type (apart from [half](\ref half_float::half), of course) results in a compiler 
+		/// error and casting between [half](\ref half_float::half)s is just a no-op.
+		/// \tparam T destination type (half or built-in arithmetic type)
+		/// \tparam U source type (half or built-in arithmetic type)
+		/// \param arg value to cast
+		/// \return \a arg converted to destination type
+		template<typename T,typename U> T half_cast(U arg) { return half_caster<T,U>::cast(arg); }
+
+		/// Cast to or from half-precision floating point number.
+		/// This casts between [half](\ref half_float::half) and any built-in arithmetic type. The values are converted 
+		/// directly using the given rounding mode, without any roundtrip over `float` that a `static_cast` would otherwise do.
+		///
+		/// Using this cast with neither of the two types being a [half](\ref half_float::half) or with any of the two types 
+		/// not being a built-in arithmetic type (apart from [half](\ref half_float::half), of course) results in a compiler 
+		/// error and casting between [half](\ref half_float::half)s is just a no-op.
+		/// \tparam T destination type (half or built-in arithmetic type)
+		/// \tparam R rounding mode to use.
+		/// \tparam U source type (half or built-in arithmetic type)
+		/// \param arg value to cast
+		/// \return \a arg converted to destination type
+		template<typename T,std::float_round_style R,typename U> T half_cast(U arg) { return half_caster<T,U,R>::cast(arg); }
+		/// \}
+	}
+
+	using detail::operator==;
+	using detail::operator!=;
+	using detail::operator<;
+	using detail::operator>;
+	using detail::operator<=;
+	using detail::operator>=;
+	using detail::operator+;
+	using detail::operator-;
+	using detail::operator*;
+	using detail::operator/;
+	using detail::operator<<;
+	using detail::operator>>;
+
+	using detail::abs;
+	using detail::fabs;
+	using detail::fmod;
+	using detail::remainder;
+	using detail::remquo;
+	using detail::fma;
+	using detail::fmax;
+	using detail::fmin;
+	using detail::fdim;
+	using detail::nanh;
+	using detail::exp;
+	using detail::expm1;
+	using detail::exp2;
+	using detail::log;
+	using detail::log10;
+	using detail::log1p;
+	using detail::log2;
+	using detail::sqrt;
+	using detail::cbrt;
+	using detail::hypot;
+	using detail::pow;
+	using detail::sin;
+	using detail::cos;
+	using detail::tan;
+	using detail::asin;
+	using detail::acos;
+	using detail::atan;
+	using detail::atan2;
+	using detail::sinh;
+	using detail::cosh;
+	using detail::tanh;
+	using detail::asinh;
+	using detail::acosh;
+	using detail::atanh;
+	using detail::erf;
+	using detail::erfc;
+	using detail::lgamma;
+	using detail::tgamma;
+	using detail::ceil;
+	using detail::floor;
+	using detail::trunc;
+	using detail::round;
+	using detail::lround;
+	using detail::nearbyint;
+	using detail::rint;
+	using detail::lrint;
 #if HALF_ENABLE_CPP11_LONG_LONG
-  /// Nearest integer implementation.
-  /// \param arg value to round
-  /// \return rounded value
-  static long long llround(half arg) {
-    return detail::half2int_up<long long>(arg.data_);
-  }
-
-  /// Nearest integer implementation.
-  /// \param arg value to round
-  /// \return rounded value
-  static long long llrint(half arg) {
-    return detail::half2int<half::round_style, long long>(arg.data_);
-  }
+	using detail::llround;
+	using detail::llrint;
 #endif
+	using detail::frexp;
+	using detail::ldexp;
+	using detail::modf;
+	using detail::scalbn;
+	using detail::scalbln;
+	using detail::ilogb;
+	using detail::logb;
+	using detail::nextafter;
+	using detail::nexttoward;
+	using detail::copysign;
+	using detail::fpclassify;
+	using detail::isfinite;
+	using detail::isinf;
+	using detail::isnan;
+	using detail::isnormal;
+	using detail::signbit;
+	using detail::isgreater;
+	using detail::isgreaterequal;
+	using detail::isless;
+	using detail::islessequal;
+	using detail::islessgreater;
+	using detail::isunordered;
 
-  /// Decompression implementation.
-  /// \param arg number to decompress
-  /// \param exp address to store exponent at
-  /// \return normalized significant
-  static half frexp(half arg, int *exp) {
-    int m = arg.data_ & 0x7FFF, e = -14;
-    if (m >= 0x7C00 || !m) return *exp = 0, arg;
-    for (; m < 0x400; m <<= 1, --e)
-      ;
-    return *exp = e + (m >> 10),
-           half(binary, (arg.data_ & 0x8000) | 0x3800 | (m & 0x3FF));
-  }
-
-  /// Decompression implementation.
-  /// \param arg number to decompress
-  /// \param iptr address to store integer part at
-  /// \return fractional part
-  static half modf(half arg, half *iptr) {
-    unsigned int e = arg.data_ & 0x7FFF;
-    if (e >= 0x6400)
-      return *iptr = arg, half(binary, arg.data_ & (0x8000U | -(e > 0x7C00)));
-    if (e < 0x3C00) return iptr->data_ = arg.data_ & 0x8000, arg;
-    e >>= 10;
-    unsigned int mask = (1 << (25 - e)) - 1, m = arg.data_ & mask;
-    iptr->data_ = arg.data_ & ~mask;
-    if (!m) return half(binary, arg.data_ & 0x8000);
-    for (; m < 0x400; m <<= 1, --e)
-      ;
-    return half(binary, static_cast<uint16>((arg.data_ & 0x8000) | (e << 10) |
-                                            (m & 0x3FF)));
-  }
-
-  /// Scaling implementation.
-  /// \param arg number to scale
-  /// \param exp power of two to scale by
-  /// \return scaled number
-  static half scalbln(half arg, long exp) {
-    unsigned int m = arg.data_ & 0x7FFF;
-    if (m >= 0x7C00 || !m) return arg;
-    for (; m < 0x400; m <<= 1, --exp)
-      ;
-    exp += m >> 10;
-    uint16 value = arg.data_ & 0x8000;
-    if (exp > 30) {
-      if (half::round_style == std::round_toward_zero)
-        value |= 0x7BFF;
-      else if (half::round_style == std::round_toward_infinity)
-        value |= 0x7C00 - (value >> 15);
-      else if (half::round_style == std::round_toward_neg_infinity)
-        value |= 0x7BFF + (value >> 15);
-      else
-        value |= 0x7C00;
-    } else if (exp > 0)
-      value |= (exp << 10) | (m & 0x3FF);
-    else if (exp > -11) {
-      m = (m & 0x3FF) | 0x400;
-      if (half::round_style == std::round_to_nearest) {
-        m += 1 << -exp;
-#if HALF_ROUND_TIES_TO_EVEN
-        m -= (m >> (1 - exp)) & 1;
-#endif
-      } else if (half::round_style == std::round_toward_infinity)
-        m += ((value >> 15) - 1) & ((1 << (1 - exp)) - 1U);
-      else if (half::round_style == std::round_toward_neg_infinity)
-        m += -(value >> 15) & ((1 << (1 - exp)) - 1U);
-      value |= m >> (1 - exp);
-    } else if (half::round_style == std::round_toward_infinity)
-      value -= (value >> 15) - 1;
-    else if (half::round_style == std::round_toward_neg_infinity)
-      value += value >> 15;
-    return half(binary, value);
-  }
-
-  /// Exponent implementation.
-  /// \param arg number to query
-  /// \return floating point exponent
-  static int ilogb(half arg) {
-    int abs = arg.data_ & 0x7FFF;
-    if (!abs) return FP_ILOGB0;
-    if (abs < 0x7C00) {
-      int exp = (abs >> 10) - 15;
-      if (abs < 0x400)
-        for (; abs < 0x200; abs <<= 1, --exp)
-          ;
-      return exp;
-    }
-    if (abs > 0x7C00) return FP_ILOGBNAN;
-    return INT_MAX;
-  }
-
-  /// Exponent implementation.
-  /// \param arg number to query
-  /// \return floating point exponent
-  static half logb(half arg) {
-    int abs = arg.data_ & 0x7FFF;
-    if (!abs) return half(binary, 0xFC00);
-    if (abs < 0x7C00) {
-      int exp = (abs >> 10) - 15;
-      if (abs < 0x400)
-        for (; abs < 0x200; abs <<= 1, --exp)
-          ;
-      uint16 bits = (exp < 0) << 15;
-      if (exp) {
-        unsigned int m = std::abs(exp) << 6, e = 18;
-        for (; m < 0x400; m <<= 1, --e)
-          ;
-        bits |= (e << 10) + m;
-      }
-      return half(binary, bits);
-    }
-    if (abs > 0x7C00) return arg;
-    return half(binary, 0x7C00);
-  }
-
-  /// Enumeration implementation.
-  /// \param from number to increase/decrease
-  /// \param to direction to enumerate into
-  /// \return next representable number
-  static half nextafter(half from, half to) {
-    uint16 fabs = from.data_ & 0x7FFF, tabs = to.data_ & 0x7FFF;
-    if (fabs > 0x7C00) return from;
-    if (tabs > 0x7C00 || from.data_ == to.data_ || !(fabs | tabs)) return to;
-    if (!fabs) return half(binary, (to.data_ & 0x8000) + 1);
-    bool lt =
-        ((fabs == from.data_) ? static_cast<int>(fabs)
-                              : -static_cast<int>(fabs)) <
-        ((tabs == to.data_) ? static_cast<int>(tabs) : -static_cast<int>(tabs));
-    return half(binary,
-                from.data_ +
-                    (((from.data_ >> 15) ^ static_cast<unsigned>(lt)) << 1) -
-                    1);
-  }
-
-  /// Enumeration implementation.
-  /// \param from number to increase/decrease
-  /// \param to direction to enumerate into
-  /// \return next representable number
-  static half nexttoward(half from, long double to) {
-    if (isnan(from)) return from;
-    long double lfrom = static_cast<long double>(from);
-    if (builtin_isnan(to) || lfrom == to) return half(static_cast<float>(to));
-    if (!(from.data_ & 0x7FFF))
-      return half(binary,
-                  (static_cast<detail::uint16>(builtin_signbit(to)) << 15) + 1);
-    return half(
-        binary,
-        from.data_ +
-            (((from.data_ >> 15) ^ static_cast<unsigned>(lfrom < to)) << 1) -
-            1);
-  }
-
-  /// Sign implementation
-  /// \param x first operand
-  /// \param y second operand
-  /// \return composed value
-  static half copysign(half x, half y) {
-    return half(binary, x.data_ ^ ((x.data_ ^ y.data_) & 0x8000));
-  }
-
-  /// Classification implementation.
-  /// \param arg value to classify
-  /// \retval true if infinite number
-  /// \retval false else
-  static int fpclassify(half arg) {
-    unsigned int abs = arg.data_ & 0x7FFF;
-    return abs ? ((abs > 0x3FF) ? ((abs >= 0x7C00)
-                                       ? ((abs > 0x7C00) ? FP_NAN : FP_INFINITE)
-                                       : FP_NORMAL)
-                                : FP_SUBNORMAL)
-               : FP_ZERO;
-  }
-
-  /// Classification implementation.
-  /// \param arg value to classify
-  /// \retval true if finite number
-  /// \retval false else
-  static bool isfinite(half arg) { return (arg.data_ & 0x7C00) != 0x7C00; }
-
-  /// Classification implementation.
-  /// \param arg value to classify
-  /// \retval true if infinite number
-  /// \retval false else
-  static bool isinf(half arg) { return (arg.data_ & 0x7FFF) == 0x7C00; }
-
-  /// Classification implementation.
-  /// \param arg value to classify
-  /// \retval true if not a number
-  /// \retval false else
-  static bool isnan(half arg) { return (arg.data_ & 0x7FFF) > 0x7C00; }
-
-  /// Classification implementation.
-  /// \param arg value to classify
-  /// \retval true if normal number
-  /// \retval false else
-  static bool isnormal(half arg) {
-    return ((arg.data_ & 0x7C00) != 0) & ((arg.data_ & 0x7C00) != 0x7C00);
-  }
-
-  /// Sign bit implementation.
-  /// \param arg value to check
-  /// \retval true if signed
-  /// \retval false if unsigned
-  static bool signbit(half arg) { return (arg.data_ & 0x8000) != 0; }
-
-  /// Comparison implementation.
-  /// \param x first operand
-  /// \param y second operand
-  /// \retval true if operands equal
-  /// \retval false else
-  static bool isequal(half x, half y) {
-    return (x.data_ == y.data_ || !((x.data_ | y.data_) & 0x7FFF)) && !isnan(x);
-  }
-
-  /// Comparison implementation.
-  /// \param x first operand
-  /// \param y second operand
-  /// \retval true if operands not equal
-  /// \retval false else
-  static bool isnotequal(half x, half y) {
-    return (x.data_ != y.data_ && ((x.data_ | y.data_) & 0x7FFF)) || isnan(x);
-  }
-
-  /// Comparison implementation.
-  /// \param x first operand
-  /// \param y second operand
-  /// \retval true if \a x > \a y
-  /// \retval false else
-  static bool isgreater(half x, half y) {
-    int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
-    return xabs <= 0x7C00 && yabs <= 0x7C00 &&
-           (((xabs == x.data_) ? xabs : -xabs) >
-            ((yabs == y.data_) ? yabs : -yabs));
-  }
-
-  /// Comparison implementation.
-  /// \param x first operand
-  /// \param y second operand
-  /// \retval true if \a x >= \a y
-  /// \retval false else
-  static bool isgreaterequal(half x, half y) {
-    int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
-    return xabs <= 0x7C00 && yabs <= 0x7C00 &&
-           (((xabs == x.data_) ? xabs : -xabs) >=
-            ((yabs == y.data_) ? yabs : -yabs));
-  }
-
-  /// Comparison implementation.
-  /// \param x first operand
-  /// \param y second operand
-  /// \retval true if \a x < \a y
-  /// \retval false else
-  static bool isless(half x, half y) {
-    int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
-    return xabs <= 0x7C00 && yabs <= 0x7C00 &&
-           (((xabs == x.data_) ? xabs : -xabs) <
-            ((yabs == y.data_) ? yabs : -yabs));
-  }
-
-  /// Comparison implementation.
-  /// \param x first operand
-  /// \param y second operand
-  /// \retval true if \a x <= \a y
-  /// \retval false else
-  static bool islessequal(half x, half y) {
-    int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
-    return xabs <= 0x7C00 && yabs <= 0x7C00 &&
-           (((xabs == x.data_) ? xabs : -xabs) <=
-            ((yabs == y.data_) ? yabs : -yabs));
-  }
-
-  /// Comparison implementation.
-  /// \param x first operand
-  /// \param y second operand
-  /// \retval true if either \a x > \a y nor \a x < \a y
-  /// \retval false else
-  static bool islessgreater(half x, half y) {
-    int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
-    if (xabs > 0x7C00 || yabs > 0x7C00) return false;
-    int a = (xabs == x.data_) ? xabs : -xabs,
-        b = (yabs == y.data_) ? yabs : -yabs;
-    return a < b || a > b;
-  }
-
-  /// Comparison implementation.
-  /// \param x first operand
-  /// \param y second operand
-  /// \retval true if operand unordered
-  /// \retval false else
-  static bool isunordered(half x, half y) { return isnan(x) || isnan(y); }
-
- private:
-  static double erf(double arg) {
-    if (builtin_isinf(arg)) return (arg < 0.0) ? -1.0 : 1.0;
-    double x2 = arg * arg, ax2 = 0.147 * x2,
-           value = std::sqrt(
-               1.0 - std::exp(-x2 * (1.2732395447351626861510701069801 + ax2) /
-                              (1.0 + ax2)));
-    return builtin_signbit(arg) ? -value : value;
-  }
-
-  static double lgamma(double arg) {
-    double v = 1.0;
-    for (; arg < 8.0; ++arg) v *= arg;
-    double w = 1.0 / (arg * arg);
-    return (((((((-0.02955065359477124183006535947712 * w +
-                  0.00641025641025641025641025641026) *
-                     w +
-                 -0.00191752691752691752691752691753) *
-                    w +
-                8.4175084175084175084175084175084e-4) *
-                   w +
-               -5.952380952380952380952380952381e-4) *
-                  w +
-              7.9365079365079365079365079365079e-4) *
-                 w +
-             -0.00277777777777777777777777777778) *
-                w +
-            0.08333333333333333333333333333333) /
-               arg +
-           0.91893853320467274178032973640562 - std::log(v) - arg +
-           (arg - 0.5) * std::log(arg);
-  }
-};
-
-/// Wrapper for unary half-precision functions needing specialization for
-/// individual argument types.
-/// \tparam T argument type
-template <typename T>
-struct unary_specialized {
-  /// Negation implementation.
-  /// \param arg value to negate
-  /// \return negated value
-  static HALF_CONSTEXPR half negate(half arg) {
-    return half(binary, arg.data_ ^ 0x8000);
-  }
-
-  /// Absolute value implementation.
-  /// \param arg function argument
-  /// \return absolute value
-  static half fabs(half arg) { return half(binary, arg.data_ & 0x7FFF); }
-};
-template <>
-struct unary_specialized<expr> {
-  static HALF_CONSTEXPR expr negate(float arg) { return expr(-arg); }
-  static expr fabs(float arg) { return expr(std::fabs(arg)); }
-};
-
-/// Wrapper for binary half-precision functions needing specialization for
-/// individual argument types.
-/// \tparam T first argument type
-/// \tparam U first argument type
-template <typename T, typename U>
-struct binary_specialized {
-  /// Minimum implementation.
-  /// \param x first operand
-  /// \param y second operand
-  /// \return minimum value
-  static expr fmin(float x, float y) {
-#if HALF_ENABLE_CPP11_CMATH
-    return expr(std::fmin(x, y));
-#else
-    if (builtin_isnan(x)) return expr(y);
-    if (builtin_isnan(y)) return expr(x);
-    return expr(std::min(x, y));
-#endif
-  }
-
-  /// Maximum implementation.
-  /// \param x first operand
-  /// \param y second operand
-  /// \return maximum value
-  static expr fmax(float x, float y) {
-#if HALF_ENABLE_CPP11_CMATH
-    return expr(std::fmax(x, y));
-#else
-    if (builtin_isnan(x)) return expr(y);
-    if (builtin_isnan(y)) return expr(x);
-    return expr(std::max(x, y));
-#endif
-  }
-};
-template <>
-struct binary_specialized<half, half> {
-  static half fmin(half x, half y) {
-    int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
-    if (xabs > 0x7C00) return y;
-    if (yabs > 0x7C00) return x;
-    return (((xabs == x.data_) ? xabs : -xabs) >
-            ((yabs == y.data_) ? yabs : -yabs))
-               ? y
-               : x;
-  }
-  static half fmax(half x, half y) {
-    int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
-    if (xabs > 0x7C00) return y;
-    if (yabs > 0x7C00) return x;
-    return (((xabs == x.data_) ? xabs : -xabs) <
-            ((yabs == y.data_) ? yabs : -yabs))
-               ? y
-               : x;
-  }
-};
-
-/// Helper class for half casts.
-/// This class template has to be specialized for all valid cast argument to
-/// define an appropriate static `cast` member
-/// function and a corresponding `type` member denoting its return type.
-/// \tparam T destination type
-/// \tparam U source type
-/// \tparam R rounding mode to use
-template <typename T, typename U,
-          std::float_round_style R = (std::float_round_style)(HALF_ROUND_STYLE)>
-struct half_caster {};
-template <typename U, std::float_round_style R>
-struct half_caster<half, U, R> {
-#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
-  static_assert(std::is_arithmetic<U>::value,
-                "half_cast from non-arithmetic type unsupported");
-#endif
-
-  static half cast(U arg) { return cast_impl(arg, is_float<U>()); };
-
- private:
-  static half cast_impl(U arg, true_type) {
-    return half(binary, float2half<R>(arg));
-  }
-  static half cast_impl(U arg, false_type) {
-    return half(binary, int2half<R>(arg));
-  }
-};
-template <typename T, std::float_round_style R>
-struct half_caster<T, half, R> {
-#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
-  static_assert(std::is_arithmetic<T>::value,
-                "half_cast to non-arithmetic type unsupported");
-#endif
-
-  static T cast(half arg) { return cast_impl(arg, is_float<T>()); }
-
- private:
-  static T cast_impl(half arg, true_type) { return half2float<T>(arg.data_); }
-  static T cast_impl(half arg, false_type) { return half2int<R, T>(arg.data_); }
-};
-template <typename T, std::float_round_style R>
-struct half_caster<T, expr, R> {
-#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
-  static_assert(std::is_arithmetic<T>::value,
-                "half_cast to non-arithmetic type unsupported");
-#endif
-
-  static T cast(expr arg) { return cast_impl(arg, is_float<T>()); }
-
- private:
-  static T cast_impl(float arg, true_type) { return static_cast<T>(arg); }
-  static T cast_impl(half arg, false_type) { return half2int<R, T>(arg.data_); }
-};
-template <std::float_round_style R>
-struct half_caster<half, half, R> {
-  static half cast(half arg) { return arg; }
-};
-template <std::float_round_style R>
-struct half_caster<half, expr, R> : half_caster<half, half, R> {};
-
-/// \name Comparison operators
-/// \{
-
-/// Comparison for equality.
-/// \param x first operand
-/// \param y second operand
-/// \retval true if operands equal
-/// \retval false else
-template <typename T, typename U>
-typename enable<bool, T, U>::type operator==(T x, U y) {
-  return functions::isequal(x, y);
+	using detail::half_cast;
 }
 
-/// Comparison for inequality.
-/// \param x first operand
-/// \param y second operand
-/// \retval true if operands not equal
-/// \retval false else
-template <typename T, typename U>
-typename enable<bool, T, U>::type operator!=(T x, U y) {
-  return functions::isnotequal(x, y);
-}
-
-/// Comparison for less than.
-/// \param x first operand
-/// \param y second operand
-/// \retval true if \a x less than \a y
-/// \retval false else
-template <typename T, typename U>
-typename enable<bool, T, U>::type operator<(T x, U y) {
-  return functions::isless(x, y);
-}
-
-/// Comparison for greater than.
-/// \param x first operand
-/// \param y second operand
-/// \retval true if \a x greater than \a y
-/// \retval false else
-template <typename T, typename U>
-typename enable<bool, T, U>::type operator>(T x, U y) {
-  return functions::isgreater(x, y);
-}
-
-/// Comparison for less equal.
-/// \param x first operand
-/// \param y second operand
-/// \retval true if \a x less equal \a y
-/// \retval false else
-template <typename T, typename U>
-typename enable<bool, T, U>::type operator<=(T x, U y) {
-  return functions::islessequal(x, y);
-}
-
-/// Comparison for greater equal.
-/// \param x first operand
-/// \param y second operand
-/// \retval true if \a x greater equal \a y
-/// \retval false else
-template <typename T, typename U>
-typename enable<bool, T, U>::type operator>=(T x, U y) {
-  return functions::isgreaterequal(x, y);
-}
-
-/// \}
-/// \name Arithmetic operators
-/// \{
-
-/// Add halfs.
-/// \param x left operand
-/// \param y right operand
-/// \return sum of half expressions
-template <typename T, typename U>
-typename enable<expr, T, U>::type operator+(T x, U y) {
-  return functions::plus(x, y);
-}
-
-/// Subtract halfs.
-/// \param x left operand
-/// \param y right operand
-/// \return difference of half expressions
-template <typename T, typename U>
-typename enable<expr, T, U>::type operator-(T x, U y) {
-  return functions::minus(x, y);
-}
-
-/// Multiply halfs.
-/// \param x left operand
-/// \param y right operand
-/// \return product of half expressions
-template <typename T, typename U>
-typename enable<expr, T, U>::type operator*(T x, U y) {
-  return functions::multiplies(x, y);
-}
-
-/// Divide halfs.
-/// \param x left operand
-/// \param y right operand
-/// \return quotient of half expressions
-template <typename T, typename U>
-typename enable<expr, T, U>::type operator/(T x, U y) {
-  return functions::divides(x, y);
-}
-
-/// Identity.
-/// \param arg operand
-/// \return uncahnged operand
-template <typename T>
-HALF_CONSTEXPR typename enable<T, T>::type operator+(T arg) {
-  return arg;
-}
-
-/// Negation.
-/// \param arg operand
-/// \return negated operand
-template <typename T>
-HALF_CONSTEXPR typename enable<T, T>::type operator-(T arg) {
-  return unary_specialized<T>::negate(arg);
-}
-
-/// \}
-/// \name Input and output
-/// \{
-
-/// Output operator.
-/// \param out output stream to write into
-/// \param arg half expression to write
-/// \return reference to output stream
-template <typename T, typename charT, typename traits>
-typename enable<std::basic_ostream<charT, traits> &, T>::type operator<<(
-    std::basic_ostream<charT, traits> &out, T arg) {
-  return functions::write(out, arg);
-}
-
-/// Input operator.
-/// \param in input stream to read from
-/// \param arg half to read into
-/// \return reference to input stream
-template <typename charT, typename traits>
-std::basic_istream<charT, traits> &operator>>(
-    std::basic_istream<charT, traits> &in, half &arg) {
-  return functions::read(in, arg);
-}
-
-/// \}
-/// \name Basic mathematical operations
-/// \{
-
-/// Absolute value.
-/// \param arg operand
-/// \return absolute value of \a arg
-//		template<typename T> typename enable<T,T>::type abs(T arg) {
-//return unary_specialized<T>::fabs(arg); }
-inline half abs(half arg) { return unary_specialized<half>::fabs(arg); }
-inline expr abs(expr arg) { return unary_specialized<expr>::fabs(arg); }
-
-/// Absolute value.
-/// \param arg operand
-/// \return absolute value of \a arg
-//		template<typename T> typename enable<T,T>::type fabs(T arg) {
-//return unary_specialized<T>::fabs(arg); }
-inline half fabs(half arg) { return unary_specialized<half>::fabs(arg); }
-inline expr fabs(expr arg) { return unary_specialized<expr>::fabs(arg); }
-
-/// Remainder of division.
-/// \param x first operand
-/// \param y second operand
-/// \return remainder of floating point division.
-//		template<typename T,typename U> typename enable<expr,T,U>::type
-//fmod(T x, U y) { return functions::fmod(x, y); }
-inline expr fmod(half x, half y) { return functions::fmod(x, y); }
-inline expr fmod(half x, expr y) { return functions::fmod(x, y); }
-inline expr fmod(expr x, half y) { return functions::fmod(x, y); }
-inline expr fmod(expr x, expr y) { return functions::fmod(x, y); }
-
-/// Remainder of division.
-/// \param x first operand
-/// \param y second operand
-/// \return remainder of floating point division.
-//		template<typename T,typename U> typename enable<expr,T,U>::type
-//remainder(T x, U y) { return functions::remainder(x, y); }
-inline expr remainder(half x, half y) { return functions::remainder(x, y); }
-inline expr remainder(half x, expr y) { return functions::remainder(x, y); }
-inline expr remainder(expr x, half y) { return functions::remainder(x, y); }
-inline expr remainder(expr x, expr y) { return functions::remainder(x, y); }
-
-/// Remainder of division.
-/// \param x first operand
-/// \param y second operand
-/// \param quo address to store some bits of quotient at
-/// \return remainder of floating point division.
-//		template<typename T,typename U> typename enable<expr,T,U>::type
-//remquo(T x, U y, int *quo) { return functions::remquo(x, y, quo); }
-inline expr remquo(half x, half y, int *quo) {
-  return functions::remquo(x, y, quo);
-}
-inline expr remquo(half x, expr y, int *quo) {
-  return functions::remquo(x, y, quo);
-}
-inline expr remquo(expr x, half y, int *quo) {
-  return functions::remquo(x, y, quo);
-}
-inline expr remquo(expr x, expr y, int *quo) {
-  return functions::remquo(x, y, quo);
-}
-
-/// Fused multiply add.
-/// \param x first operand
-/// \param y second operand
-/// \param z third operand
-/// \return ( \a x * \a y ) + \a z rounded as one operation.
-//		template<typename T,typename U,typename V> typename
-//enable<expr,T,U,V>::type fma(T x, U y, V z) { return functions::fma(x, y, z);
-//}
-inline expr fma(half x, half y, half z) { return functions::fma(x, y, z); }
-inline expr fma(half x, half y, expr z) { return functions::fma(x, y, z); }
-inline expr fma(half x, expr y, half z) { return functions::fma(x, y, z); }
-inline expr fma(half x, expr y, expr z) { return functions::fma(x, y, z); }
-inline expr fma(expr x, half y, half z) { return functions::fma(x, y, z); }
-inline expr fma(expr x, half y, expr z) { return functions::fma(x, y, z); }
-inline expr fma(expr x, expr y, half z) { return functions::fma(x, y, z); }
-inline expr fma(expr x, expr y, expr z) { return functions::fma(x, y, z); }
-
-/// Maximum of half expressions.
-/// \param x first operand
-/// \param y second operand
-/// \return maximum of operands
-//		template<typename T,typename U> typename result<T,U>::type fmax(T
-//x, U y) { return binary_specialized<T,U>::fmax(x, y); }
-inline half fmax(half x, half y) {
-  return binary_specialized<half, half>::fmax(x, y);
-}
-inline expr fmax(half x, expr y) {
-  return binary_specialized<half, expr>::fmax(x, y);
-}
-inline expr fmax(expr x, half y) {
-  return binary_specialized<expr, half>::fmax(x, y);
-}
-inline expr fmax(expr x, expr y) {
-  return binary_specialized<expr, expr>::fmax(x, y);
-}
-
-/// Minimum of half expressions.
-/// \param x first operand
-/// \param y second operand
-/// \return minimum of operands
-//		template<typename T,typename U> typename result<T,U>::type fmin(T
-//x, U y) { return binary_specialized<T,U>::fmin(x, y); }
-inline half fmin(half x, half y) {
-  return binary_specialized<half, half>::fmin(x, y);
-}
-inline expr fmin(half x, expr y) {
-  return binary_specialized<half, expr>::fmin(x, y);
-}
-inline expr fmin(expr x, half y) {
-  return binary_specialized<expr, half>::fmin(x, y);
-}
-inline expr fmin(expr x, expr y) {
-  return binary_specialized<expr, expr>::fmin(x, y);
-}
-
-/// Positive difference.
-/// \param x first operand
-/// \param y second operand
-/// \return \a x - \a y or 0 if difference negative
-//		template<typename T,typename U> typename enable<expr,T,U>::type
-//fdim(T x, U y) { return functions::fdim(x, y); }
-inline expr fdim(half x, half y) { return functions::fdim(x, y); }
-inline expr fdim(half x, expr y) { return functions::fdim(x, y); }
-inline expr fdim(expr x, half y) { return functions::fdim(x, y); }
-inline expr fdim(expr x, expr y) { return functions::fdim(x, y); }
-
-/// Get NaN value.
-/// \return quiet NaN
-inline half nanh(const char *) { return functions::nanh(); }
-
-/// \}
-/// \name Exponential functions
-/// \{
-
-/// Exponential function.
-/// \param arg function argument
-/// \return e raised to \a arg
-//		template<typename T> typename enable<expr,T>::type exp(T arg) {
-//return functions::exp(arg); }
-inline expr exp(half arg) { return functions::exp(arg); }
-inline expr exp(expr arg) { return functions::exp(arg); }
-
-/// Exponential minus one.
-/// \param arg function argument
-/// \return e raised to \a arg subtracted by 1
-//		template<typename T> typename enable<expr,T>::type expm1(T arg) {
-//return functions::expm1(arg); }
-inline expr expm1(half arg) { return functions::expm1(arg); }
-inline expr expm1(expr arg) { return functions::expm1(arg); }
-
-/// Binary exponential.
-/// \param arg function argument
-/// \return 2 raised to \a arg
-//		template<typename T> typename enable<expr,T>::type exp2(T arg) {
-//return functions::exp2(arg); }
-inline expr exp2(half arg) { return functions::exp2(arg); }
-inline expr exp2(expr arg) { return functions::exp2(arg); }
-
-/// Natural logorithm.
-/// \param arg function argument
-/// \return logarithm of \a arg to base e
-//		template<typename T> typename enable<expr,T>::type log(T arg) {
-//return functions::log(arg); }
-inline expr log(half arg) { return functions::log(arg); }
-inline expr log(expr arg) { return functions::log(arg); }
-
-/// Common logorithm.
-/// \param arg function argument
-/// \return logarithm of \a arg to base 10
-//		template<typename T> typename enable<expr,T>::type log10(T arg) {
-//return functions::log10(arg); }
-inline expr log10(half arg) { return functions::log10(arg); }
-inline expr log10(expr arg) { return functions::log10(arg); }
-
-/// Natural logorithm.
-/// \param arg function argument
-/// \return logarithm of \a arg plus 1 to base e
-//		template<typename T> typename enable<expr,T>::type log1p(T arg) {
-//return functions::log1p(arg); }
-inline expr log1p(half arg) { return functions::log1p(arg); }
-inline expr log1p(expr arg) { return functions::log1p(arg); }
-
-/// Binary logorithm.
-/// \param arg function argument
-/// \return logarithm of \a arg to base 2
-//		template<typename T> typename enable<expr,T>::type log2(T arg) {
-//return functions::log2(arg); }
-inline expr log2(half arg) { return functions::log2(arg); }
-inline expr log2(expr arg) { return functions::log2(arg); }
-
-/// \}
-/// \name Power functions
-/// \{
-
-/// Square root.
-/// \param arg function argument
-/// \return square root of \a arg
-//		template<typename T> typename enable<expr,T>::type sqrt(T arg) {
-//return functions::sqrt(arg); }
-inline expr sqrt(half arg) { return functions::sqrt(arg); }
-inline expr sqrt(expr arg) { return functions::sqrt(arg); }
-
-/// Cubic root.
-/// \param arg function argument
-/// \return cubic root of \a arg
-//		template<typename T> typename enable<expr,T>::type cbrt(T arg) {
-//return functions::cbrt(arg); }
-inline expr cbrt(half arg) { return functions::cbrt(arg); }
-inline expr cbrt(expr arg) { return functions::cbrt(arg); }
-
-/// Hypotenuse function.
-/// \param x first argument
-/// \param y second argument
-/// \return square root of sum of squares without internal over- or underflows
-//		template<typename T,typename U> typename enable<expr,T,U>::type
-//hypot(T x, U y) { return functions::hypot(x, y); }
-inline expr hypot(half x, half y) { return functions::hypot(x, y); }
-inline expr hypot(half x, expr y) { return functions::hypot(x, y); }
-inline expr hypot(expr x, half y) { return functions::hypot(x, y); }
-inline expr hypot(expr x, expr y) { return functions::hypot(x, y); }
-
-/// Power function.
-/// \param base first argument
-/// \param exp second argument
-/// \return \a base raised to \a exp
-//		template<typename T,typename U> typename enable<expr,T,U>::type
-//pow(T base, U exp) { return functions::pow(base, exp); }
-inline expr pow(half base, half exp) { return functions::pow(base, exp); }
-inline expr pow(half base, expr exp) { return functions::pow(base, exp); }
-inline expr pow(expr base, half exp) { return functions::pow(base, exp); }
-inline expr pow(expr base, expr exp) { return functions::pow(base, exp); }
-
-/// \}
-/// \name Trigonometric functions
-/// \{
-
-/// Sine function.
-/// \param arg function argument
-/// \return sine value of \a arg
-//		template<typename T> typename enable<expr,T>::type sin(T arg) {
-//return functions::sin(arg); }
-inline expr sin(half arg) { return functions::sin(arg); }
-inline expr sin(expr arg) { return functions::sin(arg); }
-
-/// Cosine function.
-/// \param arg function argument
-/// \return cosine value of \a arg
-//		template<typename T> typename enable<expr,T>::type cos(T arg) {
-//return functions::cos(arg); }
-inline expr cos(half arg) { return functions::cos(arg); }
-inline expr cos(expr arg) { return functions::cos(arg); }
-
-/// Tangent function.
-/// \param arg function argument
-/// \return tangent value of \a arg
-//		template<typename T> typename enable<expr,T>::type tan(T arg) {
-//return functions::tan(arg); }
-inline expr tan(half arg) { return functions::tan(arg); }
-inline expr tan(expr arg) { return functions::tan(arg); }
-
-/// Arc sine.
-/// \param arg function argument
-/// \return arc sine value of \a arg
-//		template<typename T> typename enable<expr,T>::type asin(T arg) {
-//return functions::asin(arg); }
-inline expr asin(half arg) { return functions::asin(arg); }
-inline expr asin(expr arg) { return functions::asin(arg); }
-
-/// Arc cosine function.
-/// \param arg function argument
-/// \return arc cosine value of \a arg
-//		template<typename T> typename enable<expr,T>::type acos(T arg) {
-//return functions::acos(arg); }
-inline expr acos(half arg) { return functions::acos(arg); }
-inline expr acos(expr arg) { return functions::acos(arg); }
-
-/// Arc tangent function.
-/// \param arg function argument
-/// \return arc tangent value of \a arg
-//		template<typename T> typename enable<expr,T>::type atan(T arg) {
-//return functions::atan(arg); }
-inline expr atan(half arg) { return functions::atan(arg); }
-inline expr atan(expr arg) { return functions::atan(arg); }
-
-/// Arc tangent function.
-/// \param x first argument
-/// \param y second argument
-/// \return arc tangent value
-//		template<typename T,typename U> typename enable<expr,T,U>::type
-//atan2(T x, U y) { return functions::atan2(x, y); }
-inline expr atan2(half x, half y) { return functions::atan2(x, y); }
-inline expr atan2(half x, expr y) { return functions::atan2(x, y); }
-inline expr atan2(expr x, half y) { return functions::atan2(x, y); }
-inline expr atan2(expr x, expr y) { return functions::atan2(x, y); }
-
-/// \}
-/// \name Hyperbolic functions
-/// \{
-
-/// Hyperbolic sine.
-/// \param arg function argument
-/// \return hyperbolic sine value of \a arg
-//		template<typename T> typename enable<expr,T>::type sinh(T arg) {
-//return functions::sinh(arg); }
-inline expr sinh(half arg) { return functions::sinh(arg); }
-inline expr sinh(expr arg) { return functions::sinh(arg); }
-
-/// Hyperbolic cosine.
-/// \param arg function argument
-/// \return hyperbolic cosine value of \a arg
-//		template<typename T> typename enable<expr,T>::type cosh(T arg) {
-//return functions::cosh(arg); }
-inline expr cosh(half arg) { return functions::cosh(arg); }
-inline expr cosh(expr arg) { return functions::cosh(arg); }
-
-/// Hyperbolic tangent.
-/// \param arg function argument
-/// \return hyperbolic tangent value of \a arg
-//		template<typename T> typename enable<expr,T>::type tanh(T arg) {
-//return functions::tanh(arg); }
-inline expr tanh(half arg) { return functions::tanh(arg); }
-inline expr tanh(expr arg) { return functions::tanh(arg); }
-
-/// Hyperbolic area sine.
-/// \param arg function argument
-/// \return area sine value of \a arg
-//		template<typename T> typename enable<expr,T>::type asinh(T arg) {
-//return functions::asinh(arg); }
-inline expr asinh(half arg) { return functions::asinh(arg); }
-inline expr asinh(expr arg) { return functions::asinh(arg); }
-
-/// Hyperbolic area cosine.
-/// \param arg function argument
-/// \return area cosine value of \a arg
-//		template<typename T> typename enable<expr,T>::type acosh(T arg) {
-//return functions::acosh(arg); }
-inline expr acosh(half arg) { return functions::acosh(arg); }
-inline expr acosh(expr arg) { return functions::acosh(arg); }
-
-/// Hyperbolic area tangent.
-/// \param arg function argument
-/// \return area tangent value of \a arg
-//		template<typename T> typename enable<expr,T>::type atanh(T arg) {
-//return functions::atanh(arg); }
-inline expr atanh(half arg) { return functions::atanh(arg); }
-inline expr atanh(expr arg) { return functions::atanh(arg); }
-
-/// \}
-/// \name Error and gamma functions
-/// \{
-
-/// Error function.
-/// \param arg function argument
-/// \return error function value of \a arg
-//		template<typename T> typename enable<expr,T>::type erf(T arg) {
-//return functions::erf(arg); }
-inline expr erf(half arg) { return functions::erf(arg); }
-inline expr erf(expr arg) { return functions::erf(arg); }
-
-/// Complementary error function.
-/// \param arg function argument
-/// \return 1 minus error function value of \a arg
-//		template<typename T> typename enable<expr,T>::type erfc(T arg) {
-//return functions::erfc(arg); }
-inline expr erfc(half arg) { return functions::erfc(arg); }
-inline expr erfc(expr arg) { return functions::erfc(arg); }
-
-/// Natural logarithm of gamma function.
-/// \param arg function argument
-/// \return natural logarith of gamma function for \a arg
-//		template<typename T> typename enable<expr,T>::type lgamma(T arg) {
-//return functions::lgamma(arg); }
-inline expr lgamma(half arg) { return functions::lgamma(arg); }
-inline expr lgamma(expr arg) { return functions::lgamma(arg); }
-
-/// Gamma function.
-/// \param arg function argument
-/// \return gamma function value of \a arg
-//		template<typename T> typename enable<expr,T>::type tgamma(T arg) {
-//return functions::tgamma(arg); }
-inline expr tgamma(half arg) { return functions::tgamma(arg); }
-inline expr tgamma(expr arg) { return functions::tgamma(arg); }
-
-/// \}
-/// \name Rounding
-/// \{
-
-/// Nearest integer not less than half value.
-/// \param arg half to round
-/// \return nearest integer not less than \a arg
-//		template<typename T> typename enable<half,T>::type ceil(T arg) {
-//return functions::ceil(arg); }
-inline half ceil(half arg) { return functions::ceil(arg); }
-inline half ceil(expr arg) { return functions::ceil(arg); }
-
-/// Nearest integer not greater than half value.
-/// \param arg half to round
-/// \return nearest integer not greater than \a arg
-//		template<typename T> typename enable<half,T>::type floor(T arg) {
-//return functions::floor(arg); }
-inline half floor(half arg) { return functions::floor(arg); }
-inline half floor(expr arg) { return functions::floor(arg); }
-
-/// Nearest integer not greater in magnitude than half value.
-/// \param arg half to round
-/// \return nearest integer not greater in magnitude than \a arg
-//		template<typename T> typename enable<half,T>::type trunc(T arg) {
-//return functions::trunc(arg); }
-inline half trunc(half arg) { return functions::trunc(arg); }
-inline half trunc(expr arg) { return functions::trunc(arg); }
-
-/// Nearest integer.
-/// \param arg half to round
-/// \return nearest integer, rounded away from zero in half-way cases
-//		template<typename T> typename enable<half,T>::type round(T arg) {
-//return functions::round(arg); }
-inline half round(half arg) { return functions::round(arg); }
-inline half round(expr arg) { return functions::round(arg); }
-
-/// Nearest integer.
-/// \param arg half to round
-/// \return nearest integer, rounded away from zero in half-way cases
-//		template<typename T> typename enable<long,T>::type lround(T arg) {
-//return functions::lround(arg); }
-inline long lround(half arg) { return functions::lround(arg); }
-inline long lround(expr arg) { return functions::lround(arg); }
-
-/// Nearest integer using half's internal rounding mode.
-/// \param arg half expression to round
-/// \return nearest integer using default rounding mode
-//		template<typename T> typename enable<half,T>::type nearbyint(T
-//arg) { return functions::nearbyint(arg); }
-inline half nearbyint(half arg) { return functions::rint(arg); }
-inline half nearbyint(expr arg) { return functions::rint(arg); }
-
-/// Nearest integer using half's internal rounding mode.
-/// \param arg half expression to round
-/// \return nearest integer using default rounding mode
-//		template<typename T> typename enable<half,T>::type rint(T arg) {
-//return functions::rint(arg); }
-inline half rint(half arg) { return functions::rint(arg); }
-inline half rint(expr arg) { return functions::rint(arg); }
-
-/// Nearest integer using half's internal rounding mode.
-/// \param arg half expression to round
-/// \return nearest integer using default rounding mode
-//		template<typename T> typename enable<long,T>::type lrint(T arg) {
-//return functions::lrint(arg); }
-inline long lrint(half arg) { return functions::lrint(arg); }
-inline long lrint(expr arg) { return functions::lrint(arg); }
-#if HALF_ENABLE_CPP11_LONG_LONG
-/// Nearest integer.
-/// \param arg half to round
-/// \return nearest integer, rounded away from zero in half-way cases
-//		template<typename T> typename enable<long long,T>::type llround(T
-//arg) { return functions::llround(arg); }
-inline long long llround(half arg) { return functions::llround(arg); }
-inline long long llround(expr arg) { return functions::llround(arg); }
-
-/// Nearest integer using half's internal rounding mode.
-/// \param arg half expression to round
-/// \return nearest integer using default rounding mode
-//		template<typename T> typename enable<long long,T>::type llrint(T
-//arg) { return functions::llrint(arg); }
-inline long long llrint(half arg) { return functions::llrint(arg); }
-inline long long llrint(expr arg) { return functions::llrint(arg); }
-#endif
-
-/// \}
-/// \name Floating point manipulation
-/// \{
-
-/// Decompress floating point number.
-/// \param arg number to decompress
-/// \param exp address to store exponent at
-/// \return significant in range [0.5, 1)
-//		template<typename T> typename enable<half,T>::type frexp(T arg,
-//int *exp) { return functions::frexp(arg, exp); }
-inline half frexp(half arg, int *exp) { return functions::frexp(arg, exp); }
-inline half frexp(expr arg, int *exp) { return functions::frexp(arg, exp); }
-
-/// Multiply by power of two.
-/// \param arg number to modify
-/// \param exp power of two to multiply with
-/// \return \a arg multplied by 2 raised to \a exp
-//		template<typename T> typename enable<half,T>::type ldexp(T arg,
-//int exp) { return functions::scalbln(arg, exp); }
-inline half ldexp(half arg, int exp) { return functions::scalbln(arg, exp); }
-inline half ldexp(expr arg, int exp) { return functions::scalbln(arg, exp); }
-
-/// Extract integer and fractional parts.
-/// \param arg number to decompress
-/// \param iptr address to store integer part at
-/// \return fractional part
-//		template<typename T> typename enable<half,T>::type modf(T arg,
-//half *iptr) { return functions::modf(arg, iptr); }
-inline half modf(half arg, half *iptr) { return functions::modf(arg, iptr); }
-inline half modf(expr arg, half *iptr) { return functions::modf(arg, iptr); }
-
-/// Multiply by power of two.
-/// \param arg number to modify
-/// \param exp power of two to multiply with
-/// \return \a arg multplied by 2 raised to \a exp
-//		template<typename T> typename enable<half,T>::type scalbn(T arg,
-//int exp) { return functions::scalbln(arg, exp); }
-inline half scalbn(half arg, int exp) { return functions::scalbln(arg, exp); }
-inline half scalbn(expr arg, int exp) { return functions::scalbln(arg, exp); }
-
-/// Multiply by power of two.
-/// \param arg number to modify
-/// \param exp power of two to multiply with
-/// \return \a arg multplied by 2 raised to \a exp
-//		template<typename T> typename enable<half,T>::type scalbln(T arg,
-//long exp) { return functions::scalbln(arg, exp); }
-inline half scalbln(half arg, long exp) { return functions::scalbln(arg, exp); }
-inline half scalbln(expr arg, long exp) { return functions::scalbln(arg, exp); }
-
-/// Extract exponent.
-/// \param arg number to query
-/// \return floating point exponent
-/// \retval FP_ILOGB0 for zero
-/// \retval FP_ILOGBNAN for NaN
-/// \retval MAX_INT for infinity
-//		template<typename T> typename enable<int,T>::type ilogb(T arg) {
-//return functions::ilogb(arg); }
-inline int ilogb(half arg) { return functions::ilogb(arg); }
-inline int ilogb(expr arg) { return functions::ilogb(arg); }
-
-/// Extract exponent.
-/// \param arg number to query
-/// \return floating point exponent
-//		template<typename T> typename enable<half,T>::type logb(T arg) {
-//return functions::logb(arg); }
-inline half logb(half arg) { return functions::logb(arg); }
-inline half logb(expr arg) { return functions::logb(arg); }
-
-/// Next representable value.
-/// \param from value to compute next representable value for
-/// \param to direction towards which to compute next value
-/// \return next representable value after \a from in direction towards \a to
-//		template<typename T,typename U> typename enable<half,T,U>::type
-//nextafter(T from, U to) { return functions::nextafter(from, to); }
-inline half nextafter(half from, half to) {
-  return functions::nextafter(from, to);
-}
-inline half nextafter(half from, expr to) {
-  return functions::nextafter(from, to);
-}
-inline half nextafter(expr from, half to) {
-  return functions::nextafter(from, to);
-}
-inline half nextafter(expr from, expr to) {
-  return functions::nextafter(from, to);
-}
-
-/// Next representable value.
-/// \param from value to compute next representable value for
-/// \param to direction towards which to compute next value
-/// \return next representable value after \a from in direction towards \a to
-//		template<typename T> typename enable<half,T>::type nexttoward(T
-//from, long double to) { return functions::nexttoward(from, to); }
-inline half nexttoward(half from, long double to) {
-  return functions::nexttoward(from, to);
-}
-inline half nexttoward(expr from, long double to) {
-  return functions::nexttoward(from, to);
-}
-
-/// Take sign.
-/// \param x value to change sign for
-/// \param y value to take sign from
-/// \return value equal to \a x in magnitude and to \a y in sign
-//		template<typename T,typename U> typename enable<half,T,U>::type
-//copysign(T x, U y) { return functions::copysign(x, y); }
-inline half copysign(half x, half y) { return functions::copysign(x, y); }
-inline half copysign(half x, expr y) { return functions::copysign(x, y); }
-inline half copysign(expr x, half y) { return functions::copysign(x, y); }
-inline half copysign(expr x, expr y) { return functions::copysign(x, y); }
-
-/// \}
-/// \name Floating point classification
-/// \{
-
-/// Classify floating point value.
-/// \param arg number to classify
-/// \retval FP_ZERO for positive and negative zero
-/// \retval FP_SUBNORMAL for subnormal numbers
-/// \retval FP_INFINITY for positive and negative infinity
-/// \retval FP_NAN for NaNs
-/// \retval FP_NORMAL for all other (normal) values
-//		template<typename T> typename enable<int,T>::type fpclassify(T
-//arg) { return functions::fpclassify(arg); }
-inline int fpclassify(half arg) { return functions::fpclassify(arg); }
-inline int fpclassify(expr arg) { return functions::fpclassify(arg); }
-
-/// Check if finite number.
-/// \param arg number to check
-/// \retval true if neither infinity nor NaN
-/// \retval false else
-//		template<typename T> typename enable<bool,T>::type isfinite(T arg)
-//{ return functions::isfinite(arg); }
-inline bool isfinite(half arg) { return functions::isfinite(arg); }
-inline bool isfinite(expr arg) { return functions::isfinite(arg); }
-
-/// Check for infinity.
-/// \param arg number to check
-/// \retval true for positive or negative infinity
-/// \retval false else
-//		template<typename T> typename enable<bool,T>::type isinf(T arg) {
-//return functions::isinf(arg); }
-inline bool isinf(half arg) { return functions::isinf(arg); }
-inline bool isinf(expr arg) { return functions::isinf(arg); }
-
-/// Check for NaN.
-/// \param arg number to check
-/// \retval true for NaNs
-/// \retval false else
-//		template<typename T> typename enable<bool,T>::type isnan(T arg) {
-//return functions::isnan(arg); }
-inline bool isnan(half arg) { return functions::isnan(arg); }
-inline bool isnan(expr arg) { return functions::isnan(arg); }
-
-/// Check if normal number.
-/// \param arg number to check
-/// \retval true if normal number
-/// \retval false if either subnormal, zero, infinity or NaN
-//		template<typename T> typename enable<bool,T>::type isnormal(T arg)
-//{ return functions::isnormal(arg); }
-inline bool isnormal(half arg) { return functions::isnormal(arg); }
-inline bool isnormal(expr arg) { return functions::isnormal(arg); }
-
-/// Check sign.
-/// \param arg number to check
-/// \retval true for negative number
-/// \retval false for positive number
-//		template<typename T> typename enable<bool,T>::type signbit(T arg)
-//{ return functions::signbit(arg); }
-inline bool signbit(half arg) { return functions::signbit(arg); }
-inline bool signbit(expr arg) { return functions::signbit(arg); }
-
-/// \}
-/// \name Comparison
-/// \{
-
-/// Comparison for greater than.
-/// \param x first operand
-/// \param y second operand
-/// \retval true if \a x greater than \a y
-/// \retval false else
-//		template<typename T,typename U> typename enable<bool,T,U>::type
-//isgreater(T x, U y) { return functions::isgreater(x, y); }
-inline bool isgreater(half x, half y) { return functions::isgreater(x, y); }
-inline bool isgreater(half x, expr y) { return functions::isgreater(x, y); }
-inline bool isgreater(expr x, half y) { return functions::isgreater(x, y); }
-inline bool isgreater(expr x, expr y) { return functions::isgreater(x, y); }
-
-/// Comparison for greater equal.
-/// \param x first operand
-/// \param y second operand
-/// \retval true if \a x greater equal \a y
-/// \retval false else
-//		template<typename T,typename U> typename enable<bool,T,U>::type
-//isgreaterequal(T x, U y) { return functions::isgreaterequal(x, y); }
-inline bool isgreaterequal(half x, half y) {
-  return functions::isgreaterequal(x, y);
-}
-inline bool isgreaterequal(half x, expr y) {
-  return functions::isgreaterequal(x, y);
-}
-inline bool isgreaterequal(expr x, half y) {
-  return functions::isgreaterequal(x, y);
-}
-inline bool isgreaterequal(expr x, expr y) {
-  return functions::isgreaterequal(x, y);
-}
-
-/// Comparison for less than.
-/// \param x first operand
-/// \param y second operand
-/// \retval true if \a x less than \a y
-/// \retval false else
-//		template<typename T,typename U> typename enable<bool,T,U>::type
-//isless(T x, U y) { return functions::isless(x, y); }
-inline bool isless(half x, half y) { return functions::isless(x, y); }
-inline bool isless(half x, expr y) { return functions::isless(x, y); }
-inline bool isless(expr x, half y) { return functions::isless(x, y); }
-inline bool isless(expr x, expr y) { return functions::isless(x, y); }
-
-/// Comparison for less equal.
-/// \param x first operand
-/// \param y second operand
-/// \retval true if \a x less equal \a y
-/// \retval false else
-//		template<typename T,typename U> typename enable<bool,T,U>::type
-//islessequal(T x, U y) { return functions::islessequal(x, y); }
-inline bool islessequal(half x, half y) { return functions::islessequal(x, y); }
-inline bool islessequal(half x, expr y) { return functions::islessequal(x, y); }
-inline bool islessequal(expr x, half y) { return functions::islessequal(x, y); }
-inline bool islessequal(expr x, expr y) { return functions::islessequal(x, y); }
-
-/// Comarison for less or greater.
-/// \param x first operand
-/// \param y second operand
-/// \retval true if either less or greater
-/// \retval false else
-//		template<typename T,typename U> typename enable<bool,T,U>::type
-//islessgreater(T x, U y) { return functions::islessgreater(x, y); }
-inline bool islessgreater(half x, half y) {
-  return functions::islessgreater(x, y);
-}
-inline bool islessgreater(half x, expr y) {
-  return functions::islessgreater(x, y);
-}
-inline bool islessgreater(expr x, half y) {
-  return functions::islessgreater(x, y);
-}
-inline bool islessgreater(expr x, expr y) {
-  return functions::islessgreater(x, y);
-}
-
-/// Check if unordered.
-/// \param x first operand
-/// \param y second operand
-/// \retval true if unordered (one or two NaN operands)
-/// \retval false else
-//		template<typename T,typename U> typename enable<bool,T,U>::type
-//isunordered(T x, U y) { return functions::isunordered(x, y); }
-inline bool isunordered(half x, half y) { return functions::isunordered(x, y); }
-inline bool isunordered(half x, expr y) { return functions::isunordered(x, y); }
-inline bool isunordered(expr x, half y) { return functions::isunordered(x, y); }
-inline bool isunordered(expr x, expr y) { return functions::isunordered(x, y); }
-
-/// \name Casting
-/// \{
-
-/// Cast to or from half-precision floating point number.
-/// This casts between [half](\ref half_float::half) and any built-in arithmetic
-/// type. The values are converted
-/// directly using the given rounding mode, without any roundtrip over `float`
-/// that a `static_cast` would otherwise do.
-/// It uses the default rounding mode.
-///
-/// Using this cast with neither of the two types being a [half](\ref
-/// half_float::half) or with any of the two types
-/// not being a built-in arithmetic type (apart from [half](\ref
-/// half_float::half), of course) results in a compiler
-/// error and casting between [half](\ref half_float::half)s is just a no-op.
-/// \tparam T destination type (half or built-in arithmetic type)
-/// \tparam U source type (half or built-in arithmetic type)
-/// \param arg value to cast
-/// \return \a arg converted to destination type
-template <typename T, typename U>
-T half_cast(U arg) {
-  return half_caster<T, U>::cast(arg);
-}
-
-/// Cast to or from half-precision floating point number.
-/// This casts between [half](\ref half_float::half) and any built-in arithmetic
-/// type. The values are converted
-/// directly using the given rounding mode, without any roundtrip over `float`
-/// that a `static_cast` would otherwise do.
-///
-/// Using this cast with neither of the two types being a [half](\ref
-/// half_float::half) or with any of the two types
-/// not being a built-in arithmetic type (apart from [half](\ref
-/// half_float::half), of course) results in a compiler
-/// error and casting between [half](\ref half_float::half)s is just a no-op.
-/// \tparam T destination type (half or built-in arithmetic type)
-/// \tparam R rounding mode to use.
-/// \tparam U source type (half or built-in arithmetic type)
-/// \param arg value to cast
-/// \return \a arg converted to destination type
-template <typename T, std::float_round_style R, typename U>
-T half_cast(U arg) {
-  return half_caster<T, U, R>::cast(arg);
-}
-/// \}
-}
-
-using detail::operator==;
-using detail::operator!=;
-using detail::operator<;
-using detail::operator>;
-using detail::operator<=;
-using detail::operator>=;
-using detail::operator+;
-using detail::operator-;
-using detail::operator*;
-using detail::operator/;
-using detail::operator<<;
-using detail::operator>>;
-
-using detail::abs;
-using detail::fabs;
-using detail::fmod;
-using detail::remainder;
-using detail::remquo;
-using detail::fma;
-using detail::fmax;
-using detail::fmin;
-using detail::fdim;
-using detail::nanh;
-using detail::exp;
-using detail::expm1;
-using detail::exp2;
-using detail::log;
-using detail::log10;
-using detail::log1p;
-using detail::log2;
-using detail::sqrt;
-using detail::cbrt;
-using detail::hypot;
-using detail::pow;
-using detail::sin;
-using detail::cos;
-using detail::tan;
-using detail::asin;
-using detail::acos;
-using detail::atan;
-using detail::atan2;
-using detail::sinh;
-using detail::cosh;
-using detail::tanh;
-using detail::asinh;
-using detail::acosh;
-using detail::atanh;
-using detail::erf;
-using detail::erfc;
-using detail::lgamma;
-using detail::tgamma;
-using detail::ceil;
-using detail::floor;
-using detail::trunc;
-using detail::round;
-using detail::lround;
-using detail::nearbyint;
-using detail::rint;
-using detail::lrint;
-#if HALF_ENABLE_CPP11_LONG_LONG
-using detail::llround;
-using detail::llrint;
-#endif
-using detail::frexp;
-using detail::ldexp;
-using detail::modf;
-using detail::scalbn;
-using detail::scalbln;
-using detail::ilogb;
-using detail::logb;
-using detail::nextafter;
-using detail::nexttoward;
-using detail::copysign;
-using detail::fpclassify;
-using detail::isfinite;
-using detail::isinf;
-using detail::isnan;
-using detail::isnormal;
-using detail::signbit;
-using detail::isgreater;
-using detail::isgreaterequal;
-using detail::isless;
-using detail::islessequal;
-using detail::islessgreater;
-using detail::isunordered;
-
-using detail::half_cast;
-}
 
 /// Extensions to the C++ standard library.
-namespace std {
-/// Numeric limits for half-precision floats.
-/// Because of the underlying single-precision implementation of many
-/// operations, it inherits some properties from
-/// `std::numeric_limits<float>`.
-template <>
-class numeric_limits<half_float::half> : public numeric_limits<float> {
- public:
-  /// Supports signed values.
-  static HALF_CONSTEXPR_CONST bool is_signed = true;
+namespace std
+{
+	/// Numeric limits for half-precision floats.
+	/// Because of the underlying single-precision implementation of many operations, it inherits some properties from 
+	/// `std::numeric_limits<float>`.
+	template<> class numeric_limits<half_float::half> : public numeric_limits<float>
+	{
+	public:
+		/// Supports signed values.
+		static HALF_CONSTEXPR_CONST bool is_signed = true;
 
-  /// Is not exact.
-  static HALF_CONSTEXPR_CONST bool is_exact = false;
+		/// Is not exact.
+		static HALF_CONSTEXPR_CONST bool is_exact = false;
 
-  /// Doesn't provide modulo arithmetic.
-  static HALF_CONSTEXPR_CONST bool is_modulo = false;
+		/// Doesn't provide modulo arithmetic.
+		static HALF_CONSTEXPR_CONST bool is_modulo = false;
 
-  /// IEEE conformant.
-  static HALF_CONSTEXPR_CONST bool is_iec559 = true;
+		/// IEEE conformant.
+		static HALF_CONSTEXPR_CONST bool is_iec559 = true;
 
-  /// Supports infinity.
-  static HALF_CONSTEXPR_CONST bool has_infinity = true;
+		/// Supports infinity.
+		static HALF_CONSTEXPR_CONST bool has_infinity = true;
 
-  /// Supports quiet NaNs.
-  static HALF_CONSTEXPR_CONST bool has_quiet_NaN = true;
+		/// Supports quiet NaNs.
+		static HALF_CONSTEXPR_CONST bool has_quiet_NaN = true;
 
-  /// Supports subnormal values.
-  static HALF_CONSTEXPR_CONST float_denorm_style has_denorm = denorm_present;
+		/// Supports subnormal values.
+		static HALF_CONSTEXPR_CONST float_denorm_style has_denorm = denorm_present;
 
-  /// Rounding mode.
-  /// Due to the mix of internal single-precision computations (using the
-  /// rounding mode of the underlying
-  /// single-precision implementation) with the rounding mode of the
-  /// single-to-half conversions, the actual rounding
-  /// mode might be `std::round_indeterminate` if the default half-precision
-  /// rounding mode doesn't match the
-  /// single-precision rounding mode.
-  static HALF_CONSTEXPR_CONST float_round_style round_style =
-      (std::numeric_limits<float>::round_style == half_float::half::round_style)
-          ? half_float::half::round_style
-          : round_indeterminate;
+		/// Rounding mode.
+		/// Due to the mix of internal single-precision computations (using the rounding mode of the underlying 
+		/// single-precision implementation) with the rounding mode of the single-to-half conversions, the actual rounding 
+		/// mode might be `std::round_indeterminate` if the default half-precision rounding mode doesn't match the 
+		/// single-precision rounding mode.
+		static HALF_CONSTEXPR_CONST float_round_style round_style = (std::numeric_limits<float>::round_style==
+			half_float::half::round_style) ? half_float::half::round_style : round_indeterminate;
 
-  /// Significant digits.
-  static HALF_CONSTEXPR_CONST int digits = 11;
+		/// Significant digits.
+		static HALF_CONSTEXPR_CONST int digits = 11;
 
-  /// Significant decimal digits.
-  static HALF_CONSTEXPR_CONST int digits10 = 3;
+		/// Significant decimal digits.
+		static HALF_CONSTEXPR_CONST int digits10 = 3;
 
-  /// Required decimal digits to represent all possible values.
-  static HALF_CONSTEXPR_CONST int max_digits10 = 5;
+		/// Required decimal digits to represent all possible values.
+		static HALF_CONSTEXPR_CONST int max_digits10 = 5;
 
-  /// Number base.
-  static HALF_CONSTEXPR_CONST int radix = 2;
+		/// Number base.
+		static HALF_CONSTEXPR_CONST int radix = 2;
 
-  /// One more than smallest exponent.
-  static HALF_CONSTEXPR_CONST int min_exponent = -13;
+		/// One more than smallest exponent.
+		static HALF_CONSTEXPR_CONST int min_exponent = -13;
 
-  /// Smallest normalized representable power of 10.
-  static HALF_CONSTEXPR_CONST int min_exponent10 = -4;
+		/// Smallest normalized representable power of 10.
+		static HALF_CONSTEXPR_CONST int min_exponent10 = -4;
 
-  /// One more than largest exponent
-  static HALF_CONSTEXPR_CONST int max_exponent = 16;
+		/// One more than largest exponent
+		static HALF_CONSTEXPR_CONST int max_exponent = 16;
 
-  /// Largest finitely representable power of 10.
-  static HALF_CONSTEXPR_CONST int max_exponent10 = 4;
+		/// Largest finitely representable power of 10.
+		static HALF_CONSTEXPR_CONST int max_exponent10 = 4;
 
-  /// Smallest positive normal value.
-  static HALF_CONSTEXPR half_float::half min() HALF_NOTHROW {
-    return half_float::half(half_float::detail::binary, 0x0400);
-  }
+		/// Smallest positive normal value.
+		static HALF_CONSTEXPR half_float::half min() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0x0400); }
 
-  /// Smallest finite value.
-  static HALF_CONSTEXPR half_float::half lowest() HALF_NOTHROW {
-    return half_float::half(half_float::detail::binary, 0xFBFF);
-  }
+		/// Smallest finite value.
+		static HALF_CONSTEXPR half_float::half lowest() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0xFBFF); }
 
-  /// Largest finite value.
-  static HALF_CONSTEXPR half_float::half max() HALF_NOTHROW {
-    return half_float::half(half_float::detail::binary, 0x7BFF);
-  }
+		/// Largest finite value.
+		static HALF_CONSTEXPR half_float::half max() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0x7BFF); }
 
-  /// Difference between one and next representable value.
-  static HALF_CONSTEXPR half_float::half epsilon() HALF_NOTHROW {
-    return half_float::half(half_float::detail::binary, 0x1400);
-  }
+		/// Difference between one and next representable value.
+		static HALF_CONSTEXPR half_float::half epsilon() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0x1400); }
 
-  /// Maximum rounding error.
-  static HALF_CONSTEXPR half_float::half round_error() HALF_NOTHROW {
-    return half_float::half(
-        half_float::detail::binary,
-        (round_style == std::round_to_nearest) ? 0x3800 : 0x3C00);
-  }
+		/// Maximum rounding error.
+		static HALF_CONSTEXPR half_float::half round_error() HALF_NOTHROW
+			{ return half_float::half(half_float::detail::binary, (round_style==std::round_to_nearest) ? 0x3800 : 0x3C00); }
 
-  /// Positive infinity.
-  static HALF_CONSTEXPR half_float::half infinity() HALF_NOTHROW {
-    return half_float::half(half_float::detail::binary, 0x7C00);
-  }
+		/// Positive infinity.
+		static HALF_CONSTEXPR half_float::half infinity() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0x7C00); }
 
-  /// Quiet NaN.
-  static HALF_CONSTEXPR half_float::half quiet_NaN() HALF_NOTHROW {
-    return half_float::half(half_float::detail::binary, 0x7FFF);
-  }
+		/// Quiet NaN.
+		static HALF_CONSTEXPR half_float::half quiet_NaN() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0x7FFF); }
 
-  /// Signalling NaN.
-  static HALF_CONSTEXPR half_float::half signaling_NaN() HALF_NOTHROW {
-    return half_float::half(half_float::detail::binary, 0x7DFF);
-  }
+		/// Signalling NaN.
+		static HALF_CONSTEXPR half_float::half signaling_NaN() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0x7DFF); }
 
-  /// Smallest positive subnormal value.
-  static HALF_CONSTEXPR half_float::half denorm_min() HALF_NOTHROW {
-    return half_float::half(half_float::detail::binary, 0x0001);
-  }
-};
+		/// Smallest positive subnormal value.
+		static HALF_CONSTEXPR half_float::half denorm_min() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0x0001); }
+	};
 
 #if HALF_ENABLE_CPP11_HASH
-/// Hash function for half-precision floats.
-/// This is only defined if C++11 `std::hash` is supported and enabled.
-template <>
-struct hash<half_float::half>  //: unary_function<half_float::half,size_t>
-{
-  /// Type of function argument.
-  typedef half_float::half argument_type;
+	/// Hash function for half-precision floats.
+	/// This is only defined if C++11 `std::hash` is supported and enabled.
+	template<> struct hash<half_float::half> //: unary_function<half_float::half,size_t>
+	{
+		/// Type of function argument.
+		typedef half_float::half argument_type;
 
-  /// Function return type.
-  typedef size_t result_type;
+		/// Function return type.
+		typedef size_t result_type;
 
-  /// Compute hash function.
-  /// \param arg half to hash
-  /// \return hash value
-  result_type operator()(argument_type arg) const {
-    return hash<half_float::detail::uint16>()(static_cast<unsigned>(arg.data_) &
-                                              -(arg.data_ != 0x8000));
-  }
-};
+		/// Compute hash function.
+		/// \param arg half to hash
+		/// \return hash value
+		result_type operator()(argument_type arg) const
+			{ return hash<half_float::detail::uint16>()(static_cast<unsigned>(arg.data_)&-(arg.data_!=0x8000)); }
+	};
 #endif
 }
+
 
 #undef HALF_CONSTEXPR
 #undef HALF_CONSTEXPR_CONST
 #undef HALF_NOEXCEPT
 #undef HALF_NOTHROW
 #ifdef HALF_POP_WARNINGS
-#pragma warning(pop)
-#undef HALF_POP_WARNINGS
+	#pragma warning(pop)
+	#undef HALF_POP_WARNINGS
 #endif
 
 #endif

--- a/src/cuda-sim/half.h
+++ b/src/cuda-sim/half.h
@@ -108,7 +108,7 @@
 #define HALF_POP_WARNINGS 1
 #pragma warning(push)
 #pragma warning(disable : 4099 4127 4146)  // struct vs class, constant in if,
-// negative unsigned
+                                           // negative unsigned
 #endif
 
 // check C++11 library features
@@ -568,9 +568,9 @@ bool builtin_signbit(T arg) {
 template <std::float_round_style R>
 uint16 float2half_impl(float value, true_type) {
   typedef bits<float>::type uint32;
-  uint32 bits;  // = *reinterpret_cast<uint32*>(&value);
-                // //violating
-                // strict aliasing!
+  uint32
+      bits;  // = *reinterpret_cast<uint32*>(&value);		//violating
+             // strict aliasing!
   std::memcpy(&bits, &value, sizeof(float));
   /*			uint16 hbits = (bits>>16) & 0x8000;
 			bits &= 0x7FFFFFFF;
@@ -753,9 +753,9 @@ template <std::float_round_style R>
 uint16 float2half_impl(double value, true_type) {
   typedef bits<float>::type uint32;
   typedef bits<double>::type uint64;
-  uint64 bits;  // = *reinterpret_cast<uint64*>(&value);
-                // //violating
-                // strict aliasing!
+  uint64
+      bits;  // = *reinterpret_cast<uint64*>(&value);		//violating
+             // strict aliasing!
   std::memcpy(&bits, &value, sizeof(double));
   uint32 hi = bits >> 32, lo = bits & 0xFFFFFFFF;
   uint16 hbits = (hi >> 16) & 0x8000;
@@ -1359,9 +1359,8 @@ inline float half2float_impl(uint16 value, float, true_type) {
       1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024};
   uint32 bits = mantissa_table[offset_table[value >> 10] + (value & 0x3FF)] +
                 exponent_table[value >> 10];
-  //			return *reinterpret_cast<float*>(&bits);
-  ////violating
-  // strict aliasing!
+  //			return *reinterpret_cast<float*>(&bits);			//violating
+  //strict aliasing!
   float out;
   std::memcpy(&out, &bits, sizeof(float));
   return out;
@@ -1382,9 +1381,8 @@ inline double half2float_impl(uint16 value, double, true_type) {
     hi += static_cast<uint32>(abs) << 10;
   }
   uint64 bits = static_cast<uint64>(hi) << 32;
-  //			return *reinterpret_cast<double*>(&bits);
-  ////violating
-  // strict aliasing!
+  //			return *reinterpret_cast<double*>(&bits);			//violating
+  //strict aliasing!
   double out;
   std::memcpy(&out, &bits, sizeof(double));
   return out;
@@ -2842,7 +2840,7 @@ std::basic_istream<charT, traits> &operator>>(
 /// \param arg operand
 /// \return absolute value of \a arg
 //		template<typename T> typename enable<T,T>::type abs(T arg) {
-// return unary_specialized<T>::fabs(arg); }
+//return unary_specialized<T>::fabs(arg); }
 inline half abs(half arg) { return unary_specialized<half>::fabs(arg); }
 inline expr abs(expr arg) { return unary_specialized<expr>::fabs(arg); }
 
@@ -2850,7 +2848,7 @@ inline expr abs(expr arg) { return unary_specialized<expr>::fabs(arg); }
 /// \param arg operand
 /// \return absolute value of \a arg
 //		template<typename T> typename enable<T,T>::type fabs(T arg) {
-// return unary_specialized<T>::fabs(arg); }
+//return unary_specialized<T>::fabs(arg); }
 inline half fabs(half arg) { return unary_specialized<half>::fabs(arg); }
 inline expr fabs(expr arg) { return unary_specialized<expr>::fabs(arg); }
 
@@ -2859,7 +2857,7 @@ inline expr fabs(expr arg) { return unary_specialized<expr>::fabs(arg); }
 /// \param y second operand
 /// \return remainder of floating point division.
 //		template<typename T,typename U> typename enable<expr,T,U>::type
-// fmod(T x, U y) { return functions::fmod(x, y); }
+//fmod(T x, U y) { return functions::fmod(x, y); }
 inline expr fmod(half x, half y) { return functions::fmod(x, y); }
 inline expr fmod(half x, expr y) { return functions::fmod(x, y); }
 inline expr fmod(expr x, half y) { return functions::fmod(x, y); }
@@ -2870,7 +2868,7 @@ inline expr fmod(expr x, expr y) { return functions::fmod(x, y); }
 /// \param y second operand
 /// \return remainder of floating point division.
 //		template<typename T,typename U> typename enable<expr,T,U>::type
-// remainder(T x, U y) { return functions::remainder(x, y); }
+//remainder(T x, U y) { return functions::remainder(x, y); }
 inline expr remainder(half x, half y) { return functions::remainder(x, y); }
 inline expr remainder(half x, expr y) { return functions::remainder(x, y); }
 inline expr remainder(expr x, half y) { return functions::remainder(x, y); }
@@ -2882,7 +2880,7 @@ inline expr remainder(expr x, expr y) { return functions::remainder(x, y); }
 /// \param quo address to store some bits of quotient at
 /// \return remainder of floating point division.
 //		template<typename T,typename U> typename enable<expr,T,U>::type
-// remquo(T x, U y, int *quo) { return functions::remquo(x, y, quo); }
+//remquo(T x, U y, int *quo) { return functions::remquo(x, y, quo); }
 inline expr remquo(half x, half y, int *quo) {
   return functions::remquo(x, y, quo);
 }
@@ -2902,7 +2900,7 @@ inline expr remquo(expr x, expr y, int *quo) {
 /// \param z third operand
 /// \return ( \a x * \a y ) + \a z rounded as one operation.
 //		template<typename T,typename U,typename V> typename
-// enable<expr,T,U,V>::type fma(T x, U y, V z) { return functions::fma(x, y, z);
+//enable<expr,T,U,V>::type fma(T x, U y, V z) { return functions::fma(x, y, z);
 //}
 inline expr fma(half x, half y, half z) { return functions::fma(x, y, z); }
 inline expr fma(half x, half y, expr z) { return functions::fma(x, y, z); }
@@ -2917,9 +2915,8 @@ inline expr fma(expr x, expr y, expr z) { return functions::fma(x, y, z); }
 /// \param x first operand
 /// \param y second operand
 /// \return maximum of operands
-//		template<typename T,typename U> typename result<T,U>::type
-// fmax(T
-// x, U y) { return binary_specialized<T,U>::fmax(x, y); }
+//		template<typename T,typename U> typename result<T,U>::type fmax(T
+//x, U y) { return binary_specialized<T,U>::fmax(x, y); }
 inline half fmax(half x, half y) {
   return binary_specialized<half, half>::fmax(x, y);
 }
@@ -2937,9 +2934,8 @@ inline expr fmax(expr x, expr y) {
 /// \param x first operand
 /// \param y second operand
 /// \return minimum of operands
-//		template<typename T,typename U> typename result<T,U>::type
-// fmin(T
-// x, U y) { return binary_specialized<T,U>::fmin(x, y); }
+//		template<typename T,typename U> typename result<T,U>::type fmin(T
+//x, U y) { return binary_specialized<T,U>::fmin(x, y); }
 inline half fmin(half x, half y) {
   return binary_specialized<half, half>::fmin(x, y);
 }
@@ -2958,7 +2954,7 @@ inline expr fmin(expr x, expr y) {
 /// \param y second operand
 /// \return \a x - \a y or 0 if difference negative
 //		template<typename T,typename U> typename enable<expr,T,U>::type
-// fdim(T x, U y) { return functions::fdim(x, y); }
+//fdim(T x, U y) { return functions::fdim(x, y); }
 inline expr fdim(half x, half y) { return functions::fdim(x, y); }
 inline expr fdim(half x, expr y) { return functions::fdim(x, y); }
 inline expr fdim(expr x, half y) { return functions::fdim(x, y); }
@@ -2976,16 +2972,15 @@ inline half nanh(const char *) { return functions::nanh(); }
 /// \param arg function argument
 /// \return e raised to \a arg
 //		template<typename T> typename enable<expr,T>::type exp(T arg) {
-// return functions::exp(arg); }
+//return functions::exp(arg); }
 inline expr exp(half arg) { return functions::exp(arg); }
 inline expr exp(expr arg) { return functions::exp(arg); }
 
 /// Exponential minus one.
 /// \param arg function argument
 /// \return e raised to \a arg subtracted by 1
-//		template<typename T> typename enable<expr,T>::type expm1(T arg)
-//{
-// return functions::expm1(arg); }
+//		template<typename T> typename enable<expr,T>::type expm1(T arg) {
+//return functions::expm1(arg); }
 inline expr expm1(half arg) { return functions::expm1(arg); }
 inline expr expm1(expr arg) { return functions::expm1(arg); }
 
@@ -2993,7 +2988,7 @@ inline expr expm1(expr arg) { return functions::expm1(arg); }
 /// \param arg function argument
 /// \return 2 raised to \a arg
 //		template<typename T> typename enable<expr,T>::type exp2(T arg) {
-// return functions::exp2(arg); }
+//return functions::exp2(arg); }
 inline expr exp2(half arg) { return functions::exp2(arg); }
 inline expr exp2(expr arg) { return functions::exp2(arg); }
 
@@ -3001,25 +2996,23 @@ inline expr exp2(expr arg) { return functions::exp2(arg); }
 /// \param arg function argument
 /// \return logarithm of \a arg to base e
 //		template<typename T> typename enable<expr,T>::type log(T arg) {
-// return functions::log(arg); }
+//return functions::log(arg); }
 inline expr log(half arg) { return functions::log(arg); }
 inline expr log(expr arg) { return functions::log(arg); }
 
 /// Common logorithm.
 /// \param arg function argument
 /// \return logarithm of \a arg to base 10
-//		template<typename T> typename enable<expr,T>::type log10(T arg)
-//{
-// return functions::log10(arg); }
+//		template<typename T> typename enable<expr,T>::type log10(T arg) {
+//return functions::log10(arg); }
 inline expr log10(half arg) { return functions::log10(arg); }
 inline expr log10(expr arg) { return functions::log10(arg); }
 
 /// Natural logorithm.
 /// \param arg function argument
 /// \return logarithm of \a arg plus 1 to base e
-//		template<typename T> typename enable<expr,T>::type log1p(T arg)
-//{
-// return functions::log1p(arg); }
+//		template<typename T> typename enable<expr,T>::type log1p(T arg) {
+//return functions::log1p(arg); }
 inline expr log1p(half arg) { return functions::log1p(arg); }
 inline expr log1p(expr arg) { return functions::log1p(arg); }
 
@@ -3027,7 +3020,7 @@ inline expr log1p(expr arg) { return functions::log1p(arg); }
 /// \param arg function argument
 /// \return logarithm of \a arg to base 2
 //		template<typename T> typename enable<expr,T>::type log2(T arg) {
-// return functions::log2(arg); }
+//return functions::log2(arg); }
 inline expr log2(half arg) { return functions::log2(arg); }
 inline expr log2(expr arg) { return functions::log2(arg); }
 
@@ -3039,7 +3032,7 @@ inline expr log2(expr arg) { return functions::log2(arg); }
 /// \param arg function argument
 /// \return square root of \a arg
 //		template<typename T> typename enable<expr,T>::type sqrt(T arg) {
-// return functions::sqrt(arg); }
+//return functions::sqrt(arg); }
 inline expr sqrt(half arg) { return functions::sqrt(arg); }
 inline expr sqrt(expr arg) { return functions::sqrt(arg); }
 
@@ -3047,7 +3040,7 @@ inline expr sqrt(expr arg) { return functions::sqrt(arg); }
 /// \param arg function argument
 /// \return cubic root of \a arg
 //		template<typename T> typename enable<expr,T>::type cbrt(T arg) {
-// return functions::cbrt(arg); }
+//return functions::cbrt(arg); }
 inline expr cbrt(half arg) { return functions::cbrt(arg); }
 inline expr cbrt(expr arg) { return functions::cbrt(arg); }
 
@@ -3056,7 +3049,7 @@ inline expr cbrt(expr arg) { return functions::cbrt(arg); }
 /// \param y second argument
 /// \return square root of sum of squares without internal over- or underflows
 //		template<typename T,typename U> typename enable<expr,T,U>::type
-// hypot(T x, U y) { return functions::hypot(x, y); }
+//hypot(T x, U y) { return functions::hypot(x, y); }
 inline expr hypot(half x, half y) { return functions::hypot(x, y); }
 inline expr hypot(half x, expr y) { return functions::hypot(x, y); }
 inline expr hypot(expr x, half y) { return functions::hypot(x, y); }
@@ -3067,7 +3060,7 @@ inline expr hypot(expr x, expr y) { return functions::hypot(x, y); }
 /// \param exp second argument
 /// \return \a base raised to \a exp
 //		template<typename T,typename U> typename enable<expr,T,U>::type
-// pow(T base, U exp) { return functions::pow(base, exp); }
+//pow(T base, U exp) { return functions::pow(base, exp); }
 inline expr pow(half base, half exp) { return functions::pow(base, exp); }
 inline expr pow(half base, expr exp) { return functions::pow(base, exp); }
 inline expr pow(expr base, half exp) { return functions::pow(base, exp); }
@@ -3081,7 +3074,7 @@ inline expr pow(expr base, expr exp) { return functions::pow(base, exp); }
 /// \param arg function argument
 /// \return sine value of \a arg
 //		template<typename T> typename enable<expr,T>::type sin(T arg) {
-// return functions::sin(arg); }
+//return functions::sin(arg); }
 inline expr sin(half arg) { return functions::sin(arg); }
 inline expr sin(expr arg) { return functions::sin(arg); }
 
@@ -3089,7 +3082,7 @@ inline expr sin(expr arg) { return functions::sin(arg); }
 /// \param arg function argument
 /// \return cosine value of \a arg
 //		template<typename T> typename enable<expr,T>::type cos(T arg) {
-// return functions::cos(arg); }
+//return functions::cos(arg); }
 inline expr cos(half arg) { return functions::cos(arg); }
 inline expr cos(expr arg) { return functions::cos(arg); }
 
@@ -3097,7 +3090,7 @@ inline expr cos(expr arg) { return functions::cos(arg); }
 /// \param arg function argument
 /// \return tangent value of \a arg
 //		template<typename T> typename enable<expr,T>::type tan(T arg) {
-// return functions::tan(arg); }
+//return functions::tan(arg); }
 inline expr tan(half arg) { return functions::tan(arg); }
 inline expr tan(expr arg) { return functions::tan(arg); }
 
@@ -3105,7 +3098,7 @@ inline expr tan(expr arg) { return functions::tan(arg); }
 /// \param arg function argument
 /// \return arc sine value of \a arg
 //		template<typename T> typename enable<expr,T>::type asin(T arg) {
-// return functions::asin(arg); }
+//return functions::asin(arg); }
 inline expr asin(half arg) { return functions::asin(arg); }
 inline expr asin(expr arg) { return functions::asin(arg); }
 
@@ -3113,7 +3106,7 @@ inline expr asin(expr arg) { return functions::asin(arg); }
 /// \param arg function argument
 /// \return arc cosine value of \a arg
 //		template<typename T> typename enable<expr,T>::type acos(T arg) {
-// return functions::acos(arg); }
+//return functions::acos(arg); }
 inline expr acos(half arg) { return functions::acos(arg); }
 inline expr acos(expr arg) { return functions::acos(arg); }
 
@@ -3121,7 +3114,7 @@ inline expr acos(expr arg) { return functions::acos(arg); }
 /// \param arg function argument
 /// \return arc tangent value of \a arg
 //		template<typename T> typename enable<expr,T>::type atan(T arg) {
-// return functions::atan(arg); }
+//return functions::atan(arg); }
 inline expr atan(half arg) { return functions::atan(arg); }
 inline expr atan(expr arg) { return functions::atan(arg); }
 
@@ -3130,7 +3123,7 @@ inline expr atan(expr arg) { return functions::atan(arg); }
 /// \param y second argument
 /// \return arc tangent value
 //		template<typename T,typename U> typename enable<expr,T,U>::type
-// atan2(T x, U y) { return functions::atan2(x, y); }
+//atan2(T x, U y) { return functions::atan2(x, y); }
 inline expr atan2(half x, half y) { return functions::atan2(x, y); }
 inline expr atan2(half x, expr y) { return functions::atan2(x, y); }
 inline expr atan2(expr x, half y) { return functions::atan2(x, y); }
@@ -3144,7 +3137,7 @@ inline expr atan2(expr x, expr y) { return functions::atan2(x, y); }
 /// \param arg function argument
 /// \return hyperbolic sine value of \a arg
 //		template<typename T> typename enable<expr,T>::type sinh(T arg) {
-// return functions::sinh(arg); }
+//return functions::sinh(arg); }
 inline expr sinh(half arg) { return functions::sinh(arg); }
 inline expr sinh(expr arg) { return functions::sinh(arg); }
 
@@ -3152,7 +3145,7 @@ inline expr sinh(expr arg) { return functions::sinh(arg); }
 /// \param arg function argument
 /// \return hyperbolic cosine value of \a arg
 //		template<typename T> typename enable<expr,T>::type cosh(T arg) {
-// return functions::cosh(arg); }
+//return functions::cosh(arg); }
 inline expr cosh(half arg) { return functions::cosh(arg); }
 inline expr cosh(expr arg) { return functions::cosh(arg); }
 
@@ -3160,34 +3153,31 @@ inline expr cosh(expr arg) { return functions::cosh(arg); }
 /// \param arg function argument
 /// \return hyperbolic tangent value of \a arg
 //		template<typename T> typename enable<expr,T>::type tanh(T arg) {
-// return functions::tanh(arg); }
+//return functions::tanh(arg); }
 inline expr tanh(half arg) { return functions::tanh(arg); }
 inline expr tanh(expr arg) { return functions::tanh(arg); }
 
 /// Hyperbolic area sine.
 /// \param arg function argument
 /// \return area sine value of \a arg
-//		template<typename T> typename enable<expr,T>::type asinh(T arg)
-//{
-// return functions::asinh(arg); }
+//		template<typename T> typename enable<expr,T>::type asinh(T arg) {
+//return functions::asinh(arg); }
 inline expr asinh(half arg) { return functions::asinh(arg); }
 inline expr asinh(expr arg) { return functions::asinh(arg); }
 
 /// Hyperbolic area cosine.
 /// \param arg function argument
 /// \return area cosine value of \a arg
-//		template<typename T> typename enable<expr,T>::type acosh(T arg)
-//{
-// return functions::acosh(arg); }
+//		template<typename T> typename enable<expr,T>::type acosh(T arg) {
+//return functions::acosh(arg); }
 inline expr acosh(half arg) { return functions::acosh(arg); }
 inline expr acosh(expr arg) { return functions::acosh(arg); }
 
 /// Hyperbolic area tangent.
 /// \param arg function argument
 /// \return area tangent value of \a arg
-//		template<typename T> typename enable<expr,T>::type atanh(T arg)
-//{
-// return functions::atanh(arg); }
+//		template<typename T> typename enable<expr,T>::type atanh(T arg) {
+//return functions::atanh(arg); }
 inline expr atanh(half arg) { return functions::atanh(arg); }
 inline expr atanh(expr arg) { return functions::atanh(arg); }
 
@@ -3199,7 +3189,7 @@ inline expr atanh(expr arg) { return functions::atanh(arg); }
 /// \param arg function argument
 /// \return error function value of \a arg
 //		template<typename T> typename enable<expr,T>::type erf(T arg) {
-// return functions::erf(arg); }
+//return functions::erf(arg); }
 inline expr erf(half arg) { return functions::erf(arg); }
 inline expr erf(expr arg) { return functions::erf(arg); }
 
@@ -3207,25 +3197,23 @@ inline expr erf(expr arg) { return functions::erf(arg); }
 /// \param arg function argument
 /// \return 1 minus error function value of \a arg
 //		template<typename T> typename enable<expr,T>::type erfc(T arg) {
-// return functions::erfc(arg); }
+//return functions::erfc(arg); }
 inline expr erfc(half arg) { return functions::erfc(arg); }
 inline expr erfc(expr arg) { return functions::erfc(arg); }
 
 /// Natural logarithm of gamma function.
 /// \param arg function argument
 /// \return natural logarith of gamma function for \a arg
-//		template<typename T> typename enable<expr,T>::type lgamma(T arg)
-//{
-// return functions::lgamma(arg); }
+//		template<typename T> typename enable<expr,T>::type lgamma(T arg) {
+//return functions::lgamma(arg); }
 inline expr lgamma(half arg) { return functions::lgamma(arg); }
 inline expr lgamma(expr arg) { return functions::lgamma(arg); }
 
 /// Gamma function.
 /// \param arg function argument
 /// \return gamma function value of \a arg
-//		template<typename T> typename enable<expr,T>::type tgamma(T arg)
-//{
-// return functions::tgamma(arg); }
+//		template<typename T> typename enable<expr,T>::type tgamma(T arg) {
+//return functions::tgamma(arg); }
 inline expr tgamma(half arg) { return functions::tgamma(arg); }
 inline expr tgamma(expr arg) { return functions::tgamma(arg); }
 
@@ -3237,43 +3225,39 @@ inline expr tgamma(expr arg) { return functions::tgamma(arg); }
 /// \param arg half to round
 /// \return nearest integer not less than \a arg
 //		template<typename T> typename enable<half,T>::type ceil(T arg) {
-// return functions::ceil(arg); }
+//return functions::ceil(arg); }
 inline half ceil(half arg) { return functions::ceil(arg); }
 inline half ceil(expr arg) { return functions::ceil(arg); }
 
 /// Nearest integer not greater than half value.
 /// \param arg half to round
 /// \return nearest integer not greater than \a arg
-//		template<typename T> typename enable<half,T>::type floor(T arg)
-//{
-// return functions::floor(arg); }
+//		template<typename T> typename enable<half,T>::type floor(T arg) {
+//return functions::floor(arg); }
 inline half floor(half arg) { return functions::floor(arg); }
 inline half floor(expr arg) { return functions::floor(arg); }
 
 /// Nearest integer not greater in magnitude than half value.
 /// \param arg half to round
 /// \return nearest integer not greater in magnitude than \a arg
-//		template<typename T> typename enable<half,T>::type trunc(T arg)
-//{
-// return functions::trunc(arg); }
+//		template<typename T> typename enable<half,T>::type trunc(T arg) {
+//return functions::trunc(arg); }
 inline half trunc(half arg) { return functions::trunc(arg); }
 inline half trunc(expr arg) { return functions::trunc(arg); }
 
 /// Nearest integer.
 /// \param arg half to round
 /// \return nearest integer, rounded away from zero in half-way cases
-//		template<typename T> typename enable<half,T>::type round(T arg)
-//{
-// return functions::round(arg); }
+//		template<typename T> typename enable<half,T>::type round(T arg) {
+//return functions::round(arg); }
 inline half round(half arg) { return functions::round(arg); }
 inline half round(expr arg) { return functions::round(arg); }
 
 /// Nearest integer.
 /// \param arg half to round
 /// \return nearest integer, rounded away from zero in half-way cases
-//		template<typename T> typename enable<long,T>::type lround(T arg)
-//{
-// return functions::lround(arg); }
+//		template<typename T> typename enable<long,T>::type lround(T arg) {
+//return functions::lround(arg); }
 inline long lround(half arg) { return functions::lround(arg); }
 inline long lround(expr arg) { return functions::lround(arg); }
 
@@ -3281,7 +3265,7 @@ inline long lround(expr arg) { return functions::lround(arg); }
 /// \param arg half expression to round
 /// \return nearest integer using default rounding mode
 //		template<typename T> typename enable<half,T>::type nearbyint(T
-// arg) { return functions::nearbyint(arg); }
+//arg) { return functions::nearbyint(arg); }
 inline half nearbyint(half arg) { return functions::rint(arg); }
 inline half nearbyint(expr arg) { return functions::rint(arg); }
 
@@ -3289,25 +3273,23 @@ inline half nearbyint(expr arg) { return functions::rint(arg); }
 /// \param arg half expression to round
 /// \return nearest integer using default rounding mode
 //		template<typename T> typename enable<half,T>::type rint(T arg) {
-// return functions::rint(arg); }
+//return functions::rint(arg); }
 inline half rint(half arg) { return functions::rint(arg); }
 inline half rint(expr arg) { return functions::rint(arg); }
 
 /// Nearest integer using half's internal rounding mode.
 /// \param arg half expression to round
 /// \return nearest integer using default rounding mode
-//		template<typename T> typename enable<long,T>::type lrint(T arg)
-//{
-// return functions::lrint(arg); }
+//		template<typename T> typename enable<long,T>::type lrint(T arg) {
+//return functions::lrint(arg); }
 inline long lrint(half arg) { return functions::lrint(arg); }
 inline long lrint(expr arg) { return functions::lrint(arg); }
 #if HALF_ENABLE_CPP11_LONG_LONG
 /// Nearest integer.
 /// \param arg half to round
 /// \return nearest integer, rounded away from zero in half-way cases
-//		template<typename T> typename enable<long long,T>::type
-// llround(T
-// arg) { return functions::llround(arg); }
+//		template<typename T> typename enable<long long,T>::type llround(T
+//arg) { return functions::llround(arg); }
 inline long long llround(half arg) { return functions::llround(arg); }
 inline long long llround(expr arg) { return functions::llround(arg); }
 
@@ -3315,7 +3297,7 @@ inline long long llround(expr arg) { return functions::llround(arg); }
 /// \param arg half expression to round
 /// \return nearest integer using default rounding mode
 //		template<typename T> typename enable<long long,T>::type llrint(T
-// arg) { return functions::llrint(arg); }
+//arg) { return functions::llrint(arg); }
 inline long long llrint(half arg) { return functions::llrint(arg); }
 inline long long llrint(expr arg) { return functions::llrint(arg); }
 #endif
@@ -3329,7 +3311,7 @@ inline long long llrint(expr arg) { return functions::llrint(arg); }
 /// \param exp address to store exponent at
 /// \return significant in range [0.5, 1)
 //		template<typename T> typename enable<half,T>::type frexp(T arg,
-// int *exp) { return functions::frexp(arg, exp); }
+//int *exp) { return functions::frexp(arg, exp); }
 inline half frexp(half arg, int *exp) { return functions::frexp(arg, exp); }
 inline half frexp(expr arg, int *exp) { return functions::frexp(arg, exp); }
 
@@ -3338,7 +3320,7 @@ inline half frexp(expr arg, int *exp) { return functions::frexp(arg, exp); }
 /// \param exp power of two to multiply with
 /// \return \a arg multplied by 2 raised to \a exp
 //		template<typename T> typename enable<half,T>::type ldexp(T arg,
-// int exp) { return functions::scalbln(arg, exp); }
+//int exp) { return functions::scalbln(arg, exp); }
 inline half ldexp(half arg, int exp) { return functions::scalbln(arg, exp); }
 inline half ldexp(expr arg, int exp) { return functions::scalbln(arg, exp); }
 
@@ -3347,7 +3329,7 @@ inline half ldexp(expr arg, int exp) { return functions::scalbln(arg, exp); }
 /// \param iptr address to store integer part at
 /// \return fractional part
 //		template<typename T> typename enable<half,T>::type modf(T arg,
-// half *iptr) { return functions::modf(arg, iptr); }
+//half *iptr) { return functions::modf(arg, iptr); }
 inline half modf(half arg, half *iptr) { return functions::modf(arg, iptr); }
 inline half modf(expr arg, half *iptr) { return functions::modf(arg, iptr); }
 
@@ -3356,7 +3338,7 @@ inline half modf(expr arg, half *iptr) { return functions::modf(arg, iptr); }
 /// \param exp power of two to multiply with
 /// \return \a arg multplied by 2 raised to \a exp
 //		template<typename T> typename enable<half,T>::type scalbn(T arg,
-// int exp) { return functions::scalbln(arg, exp); }
+//int exp) { return functions::scalbln(arg, exp); }
 inline half scalbn(half arg, int exp) { return functions::scalbln(arg, exp); }
 inline half scalbn(expr arg, int exp) { return functions::scalbln(arg, exp); }
 
@@ -3364,9 +3346,8 @@ inline half scalbn(expr arg, int exp) { return functions::scalbln(arg, exp); }
 /// \param arg number to modify
 /// \param exp power of two to multiply with
 /// \return \a arg multplied by 2 raised to \a exp
-//		template<typename T> typename enable<half,T>::type scalbln(T
-// arg,
-// long exp) { return functions::scalbln(arg, exp); }
+//		template<typename T> typename enable<half,T>::type scalbln(T arg,
+//long exp) { return functions::scalbln(arg, exp); }
 inline half scalbln(half arg, long exp) { return functions::scalbln(arg, exp); }
 inline half scalbln(expr arg, long exp) { return functions::scalbln(arg, exp); }
 
@@ -3377,7 +3358,7 @@ inline half scalbln(expr arg, long exp) { return functions::scalbln(arg, exp); }
 /// \retval FP_ILOGBNAN for NaN
 /// \retval MAX_INT for infinity
 //		template<typename T> typename enable<int,T>::type ilogb(T arg) {
-// return functions::ilogb(arg); }
+//return functions::ilogb(arg); }
 inline int ilogb(half arg) { return functions::ilogb(arg); }
 inline int ilogb(expr arg) { return functions::ilogb(arg); }
 
@@ -3385,7 +3366,7 @@ inline int ilogb(expr arg) { return functions::ilogb(arg); }
 /// \param arg number to query
 /// \return floating point exponent
 //		template<typename T> typename enable<half,T>::type logb(T arg) {
-// return functions::logb(arg); }
+//return functions::logb(arg); }
 inline half logb(half arg) { return functions::logb(arg); }
 inline half logb(expr arg) { return functions::logb(arg); }
 
@@ -3394,7 +3375,7 @@ inline half logb(expr arg) { return functions::logb(arg); }
 /// \param to direction towards which to compute next value
 /// \return next representable value after \a from in direction towards \a to
 //		template<typename T,typename U> typename enable<half,T,U>::type
-// nextafter(T from, U to) { return functions::nextafter(from, to); }
+//nextafter(T from, U to) { return functions::nextafter(from, to); }
 inline half nextafter(half from, half to) {
   return functions::nextafter(from, to);
 }
@@ -3413,7 +3394,7 @@ inline half nextafter(expr from, expr to) {
 /// \param to direction towards which to compute next value
 /// \return next representable value after \a from in direction towards \a to
 //		template<typename T> typename enable<half,T>::type nexttoward(T
-// from, long double to) { return functions::nexttoward(from, to); }
+//from, long double to) { return functions::nexttoward(from, to); }
 inline half nexttoward(half from, long double to) {
   return functions::nexttoward(from, to);
 }
@@ -3426,7 +3407,7 @@ inline half nexttoward(expr from, long double to) {
 /// \param y value to take sign from
 /// \return value equal to \a x in magnitude and to \a y in sign
 //		template<typename T,typename U> typename enable<half,T,U>::type
-// copysign(T x, U y) { return functions::copysign(x, y); }
+//copysign(T x, U y) { return functions::copysign(x, y); }
 inline half copysign(half x, half y) { return functions::copysign(x, y); }
 inline half copysign(half x, expr y) { return functions::copysign(x, y); }
 inline half copysign(expr x, half y) { return functions::copysign(x, y); }
@@ -3444,7 +3425,7 @@ inline half copysign(expr x, expr y) { return functions::copysign(x, y); }
 /// \retval FP_NAN for NaNs
 /// \retval FP_NORMAL for all other (normal) values
 //		template<typename T> typename enable<int,T>::type fpclassify(T
-// arg) { return functions::fpclassify(arg); }
+//arg) { return functions::fpclassify(arg); }
 inline int fpclassify(half arg) { return functions::fpclassify(arg); }
 inline int fpclassify(expr arg) { return functions::fpclassify(arg); }
 
@@ -3452,8 +3433,7 @@ inline int fpclassify(expr arg) { return functions::fpclassify(arg); }
 /// \param arg number to check
 /// \retval true if neither infinity nor NaN
 /// \retval false else
-//		template<typename T> typename enable<bool,T>::type isfinite(T
-// arg)
+//		template<typename T> typename enable<bool,T>::type isfinite(T arg)
 //{ return functions::isfinite(arg); }
 inline bool isfinite(half arg) { return functions::isfinite(arg); }
 inline bool isfinite(expr arg) { return functions::isfinite(arg); }
@@ -3462,9 +3442,8 @@ inline bool isfinite(expr arg) { return functions::isfinite(arg); }
 /// \param arg number to check
 /// \retval true for positive or negative infinity
 /// \retval false else
-//		template<typename T> typename enable<bool,T>::type isinf(T arg)
-//{
-// return functions::isinf(arg); }
+//		template<typename T> typename enable<bool,T>::type isinf(T arg) {
+//return functions::isinf(arg); }
 inline bool isinf(half arg) { return functions::isinf(arg); }
 inline bool isinf(expr arg) { return functions::isinf(arg); }
 
@@ -3472,9 +3451,8 @@ inline bool isinf(expr arg) { return functions::isinf(arg); }
 /// \param arg number to check
 /// \retval true for NaNs
 /// \retval false else
-//		template<typename T> typename enable<bool,T>::type isnan(T arg)
-//{
-// return functions::isnan(arg); }
+//		template<typename T> typename enable<bool,T>::type isnan(T arg) {
+//return functions::isnan(arg); }
 inline bool isnan(half arg) { return functions::isnan(arg); }
 inline bool isnan(expr arg) { return functions::isnan(arg); }
 
@@ -3482,8 +3460,7 @@ inline bool isnan(expr arg) { return functions::isnan(arg); }
 /// \param arg number to check
 /// \retval true if normal number
 /// \retval false if either subnormal, zero, infinity or NaN
-//		template<typename T> typename enable<bool,T>::type isnormal(T
-// arg)
+//		template<typename T> typename enable<bool,T>::type isnormal(T arg)
 //{ return functions::isnormal(arg); }
 inline bool isnormal(half arg) { return functions::isnormal(arg); }
 inline bool isnormal(expr arg) { return functions::isnormal(arg); }
@@ -3492,8 +3469,7 @@ inline bool isnormal(expr arg) { return functions::isnormal(arg); }
 /// \param arg number to check
 /// \retval true for negative number
 /// \retval false for positive number
-//		template<typename T> typename enable<bool,T>::type signbit(T
-// arg)
+//		template<typename T> typename enable<bool,T>::type signbit(T arg)
 //{ return functions::signbit(arg); }
 inline bool signbit(half arg) { return functions::signbit(arg); }
 inline bool signbit(expr arg) { return functions::signbit(arg); }
@@ -3508,7 +3484,7 @@ inline bool signbit(expr arg) { return functions::signbit(arg); }
 /// \retval true if \a x greater than \a y
 /// \retval false else
 //		template<typename T,typename U> typename enable<bool,T,U>::type
-// isgreater(T x, U y) { return functions::isgreater(x, y); }
+//isgreater(T x, U y) { return functions::isgreater(x, y); }
 inline bool isgreater(half x, half y) { return functions::isgreater(x, y); }
 inline bool isgreater(half x, expr y) { return functions::isgreater(x, y); }
 inline bool isgreater(expr x, half y) { return functions::isgreater(x, y); }
@@ -3520,7 +3496,7 @@ inline bool isgreater(expr x, expr y) { return functions::isgreater(x, y); }
 /// \retval true if \a x greater equal \a y
 /// \retval false else
 //		template<typename T,typename U> typename enable<bool,T,U>::type
-// isgreaterequal(T x, U y) { return functions::isgreaterequal(x, y); }
+//isgreaterequal(T x, U y) { return functions::isgreaterequal(x, y); }
 inline bool isgreaterequal(half x, half y) {
   return functions::isgreaterequal(x, y);
 }
@@ -3540,7 +3516,7 @@ inline bool isgreaterequal(expr x, expr y) {
 /// \retval true if \a x less than \a y
 /// \retval false else
 //		template<typename T,typename U> typename enable<bool,T,U>::type
-// isless(T x, U y) { return functions::isless(x, y); }
+//isless(T x, U y) { return functions::isless(x, y); }
 inline bool isless(half x, half y) { return functions::isless(x, y); }
 inline bool isless(half x, expr y) { return functions::isless(x, y); }
 inline bool isless(expr x, half y) { return functions::isless(x, y); }
@@ -3552,7 +3528,7 @@ inline bool isless(expr x, expr y) { return functions::isless(x, y); }
 /// \retval true if \a x less equal \a y
 /// \retval false else
 //		template<typename T,typename U> typename enable<bool,T,U>::type
-// islessequal(T x, U y) { return functions::islessequal(x, y); }
+//islessequal(T x, U y) { return functions::islessequal(x, y); }
 inline bool islessequal(half x, half y) { return functions::islessequal(x, y); }
 inline bool islessequal(half x, expr y) { return functions::islessequal(x, y); }
 inline bool islessequal(expr x, half y) { return functions::islessequal(x, y); }
@@ -3564,7 +3540,7 @@ inline bool islessequal(expr x, expr y) { return functions::islessequal(x, y); }
 /// \retval true if either less or greater
 /// \retval false else
 //		template<typename T,typename U> typename enable<bool,T,U>::type
-// islessgreater(T x, U y) { return functions::islessgreater(x, y); }
+//islessgreater(T x, U y) { return functions::islessgreater(x, y); }
 inline bool islessgreater(half x, half y) {
   return functions::islessgreater(x, y);
 }
@@ -3584,7 +3560,7 @@ inline bool islessgreater(expr x, expr y) {
 /// \retval true if unordered (one or two NaN operands)
 /// \retval false else
 //		template<typename T,typename U> typename enable<bool,T,U>::type
-// isunordered(T x, U y) { return functions::isunordered(x, y); }
+//isunordered(T x, U y) { return functions::isunordered(x, y); }
 inline bool isunordered(half x, half y) { return functions::isunordered(x, y); }
 inline bool isunordered(half x, expr y) { return functions::isunordered(x, y); }
 inline bool isunordered(expr x, half y) { return functions::isunordered(x, y); }

--- a/src/cuda-sim/instructions.cc
+++ b/src/cuda-sim/instructions.cc
@@ -8,16 +8,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -27,34 +25,34 @@
 // CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#include "instructions.h"
 #include "half.h"
 #include "half.hpp"
-#include "opcodes.h"
+#include "instructions.h"
 #include "ptx_ir.h"
+#include "opcodes.h"
 #include "ptx_sim.h"
-typedef void *yyscan_t;
+typedef void * yyscan_t;
 class ptx_recognizer;
-#include <assert.h>
-#include <fenv.h>
+#include "ptx.tab.h"
+#include <stdlib.h>
 #include <math.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <stdlib.h>
-#include <string.h>
 #include <cmath>
-#include <map>
-#include <sstream>
-#include <string>
+#include <fenv.h>
+#include "cuda-math.h"
 #include "../abstract_hardware_model.h"
+#include "ptx_loader.h"
+#include "cuda_device_printf.h"
 #include "../gpgpu-sim/gpu-sim.h"
 #include "../gpgpu-sim/shader.h"
-#include "cuda-math.h"
-#include "cuda_device_printf.h"
-#include "ptx.tab.h"
-#include "ptx_loader.h"
+#include <assert.h>
+#include <string.h>
+#include <sstream>
+#include <stdio.h>
+#include <string>
+#include <map>
+#include <stdlib.h>
 
-// Jin: include device runtime for CDP
+//Jin: include device runtime for CDP
 #include "cuda_device_runtime.h"
 
 #include <stdarg.h>
@@ -62,6425 +60,5629 @@ class ptx_recognizer;
 
 using half_float::half;
 
+
+
 const char *g_opcode_string[NUM_OPCODES] = {
-#define OP_DEF(OP, FUNC, STR, DST, CLASSIFICATION) STR,
-#define OP_W_DEF(OP, FUNC, STR, DST, CLASSIFICATION) STR,
+#define OP_DEF(OP,FUNC,STR,DST,CLASSIFICATION) STR,
+#define OP_W_DEF(OP,FUNC,STR,DST,CLASSIFICATION) STR,
 #include "opcodes.def"
 #undef OP_DEF
 #undef OP_W_DEF
 };
-// Using profiled information::check the TensorCoreMatrixArrangement.xls for
-// details
-unsigned thread_group_offset(int thread, unsigned wmma_type,
-                             unsigned wmma_layout, unsigned type, int stride) {
-  unsigned offset;
-  unsigned load_a_row[8] = {0, 128, 0, 128, 64, 192, 64, 192};
-  unsigned load_a_col[8] = {0, 8, 0, 8, 4, 12, 4, 12};
-  unsigned load_b_row[8] = {0, 8, 0, 8, 4, 12, 4, 12};
-  unsigned load_b_col[8] = {0, 128, 0, 128, 64, 192, 64, 192};
-  unsigned load_c_float_row[8] = {0, 128, 8, 136, 64, 192, 72, 200};
-  unsigned load_c_float_col[8] = {0, 8, 128, 136, 4, 12, 132, 140};
-  unsigned load_c_half_row[8] = {0, 128, 8, 136, 64, 192, 72, 200};
-  unsigned load_c_half_col[8] = {0, 8, 128, 136, 4, 12, 132, 140};
-  unsigned thread_group = thread / 4;
-  unsigned in_tg_index = thread % 4;
+//Using profiled information::check the TensorCoreMatrixArrangement.xls for details
+unsigned thread_group_offset(int thread,unsigned  wmma_type,unsigned wmma_layout,unsigned type,int stride){
 
-  switch (wmma_type) {
-    case LOAD_A:
-      if (wmma_layout == ROW)
-        offset = load_a_row[thread_group] + 16 * in_tg_index;
-      else
-        offset = load_a_col[thread_group] + 16 * in_tg_index;
-      break;
+	unsigned offset;
+	unsigned load_a_row[8]={0,128,0,128,64,192,64,192};
+	unsigned load_a_col[8]={0,8,0,8,4,12,4,12};
+	unsigned load_b_row[8]={0,8,0,8,4,12,4,12};
+	unsigned load_b_col[8]={0,128,0,128,64,192,64,192};
+	unsigned load_c_float_row[8]={0,128,8,136,64,192,72,200};	
+	unsigned load_c_float_col[8]={0,8,128,136,4,12,132,140};	
+	unsigned load_c_half_row[8]={0,128,8,136,64,192,72,200};	
+	unsigned load_c_half_col[8]={0,8,128,136,4,12,132,140};	
+	unsigned thread_group =	thread/4;
+	unsigned in_tg_index  =	thread%4;
 
-    case LOAD_B:
-      if (wmma_layout == ROW)
-        offset = load_b_row[thread_group] + 16 * in_tg_index;
-      else
-        offset = load_b_col[thread_group] + 16 * in_tg_index;
-      break;
+	switch(wmma_type){
+		case LOAD_A:
+				if(wmma_layout==ROW)
+					offset=load_a_row[thread_group]+16*in_tg_index;
+				else
+					offset=load_a_col[thread_group]+16*in_tg_index;
+			break;
 
-    case LOAD_C:
-    case STORE_D:
-      if (type == F16_TYPE) {
-        if (wmma_layout == ROW)
-          offset = load_c_half_row[thread_group] + 16 * in_tg_index;
-        else
-          offset = load_c_half_col[thread_group] + in_tg_index;
-      } else {
-        if (wmma_layout == ROW)
-          offset = load_c_float_row[thread_group];
-        else
-          offset = load_c_float_col[thread_group];
 
-        switch (in_tg_index) {
-          case 0:
-            break;
-          case 1:
-            if (wmma_layout == ROW)
-              offset += 16;
-            else
-              offset += 1;
-            break;
-          case 2:
-            if (wmma_layout == ROW)
-              offset += 2;
-            else
-              offset += 32;
-            break;
-          case 3:
-            if (wmma_layout == ROW)
-              offset += 18;
-            else
-              offset += 33;
-            break;
-          default:
-            abort();
-        }
-      }
-      break;
+		case LOAD_B:
+				if(wmma_layout==ROW)
+					offset=load_b_row[thread_group]+16*in_tg_index;
+				else	
+					offset=load_b_col[thread_group]+16*in_tg_index;
+			break;	
 
-    default:
-      abort();
-  }
-  offset = (offset / 16) * stride + offset % 16;
-  return offset;
+		case LOAD_C:
+		case STORE_D:
+			if(type==F16_TYPE){
+				if(wmma_layout==ROW)
+					offset=load_c_half_row[thread_group]+16*in_tg_index;
+				else
+					offset=load_c_half_col[thread_group]+in_tg_index;
+			}
+			else{
+				if(wmma_layout==ROW)
+					offset=load_c_float_row[thread_group];
+				else
+					offset=load_c_float_col[thread_group];
+
+				switch(in_tg_index){
+					case 0:
+						break;
+					case 1:
+						if(wmma_layout==ROW)
+							offset+=16;
+						else
+							offset+=1;
+						break;
+					case 2:
+						if(wmma_layout==ROW)
+							offset+=2;
+						else
+							offset+=32;
+						break;
+					case 3:
+						if(wmma_layout==ROW)
+							offset+=18;
+						else
+							offset+=33;
+						break;
+					default:
+						abort();
+				}
+			}
+			break;	
+
+         	default:
+         	   abort();
+		
+	}
+	offset = (offset/16)*stride+offset%16;
+	return offset;
 }
 
-int acc_float_offset(int index, int wmma_layout, int stride) {
-  int c_row_offset[] = {0, 1, 32, 33, 4, 5, 36, 37};
-  int c_col_offset[] = {0, 16, 2, 18, 64, 80, 66, 82};
-  int offset;
+int acc_float_offset(int index,int wmma_layout,int stride){
 
-  if (wmma_layout == ROW)
-    offset = c_row_offset[index];
-  else if (wmma_layout == COL)
-    offset = c_col_offset[index];
-  else {
-    printf("wrong layout");
-    abort();
-  }
-  offset = (offset / 16) * stride + offset % 16;
-  return offset;
+	int c_row_offset[]={0,1,32,33,4,5,36,37};
+	int c_col_offset[]={0,16,2,18,64,80,66,82};
+	int offset;
+	
+	
+	if(wmma_layout==ROW)
+		offset=c_row_offset[index];
+	else if(wmma_layout==COL)
+		offset=c_col_offset[index];
+	else{
+		printf("wrong layout");
+		abort();
+	}
+	offset = (offset/16)*stride+offset%16;
+	return offset;
 }
 
-void inst_not_implemented(const ptx_instruction *pI);
-ptx_reg_t srcOperandModifiers(ptx_reg_t opData, operand_info opInfo,
-                              operand_info dstInfo, unsigned type,
-                              ptx_thread_info *thread);
+void inst_not_implemented( const ptx_instruction * pI ) ;
+ptx_reg_t srcOperandModifiers(ptx_reg_t opData, operand_info opInfo, operand_info dstInfo, unsigned type, ptx_thread_info *thread);
 
-void sign_extend(ptx_reg_t &data, unsigned src_size, const operand_info &dst);
+void sign_extend( ptx_reg_t &data, unsigned src_size, const operand_info &dst );
 
-void ptx_thread_info::set_reg(const symbol *reg, const ptx_reg_t &value) {
-  assert(reg != NULL);
-  if (reg->name() == "_") return;
-  assert(!m_regs.empty());
-  assert(reg->uid() > 0);
-  m_regs.back()[reg] = value;
-  if (m_enable_debug_trace) m_debug_trace_regs_modified.back()[reg] = value;
-  m_last_set_operand_value = value;
+void ptx_thread_info::set_reg( const symbol *reg, const ptx_reg_t &value ) 
+{
+   assert( reg != NULL );
+   if( reg->name() == "_" ) return;
+   assert( !m_regs.empty() );
+   assert( reg->uid() > 0 );
+   m_regs.back()[ reg ] = value;
+   if (m_enable_debug_trace ) 
+      m_debug_trace_regs_modified.back()[ reg ] = value;
+   m_last_set_operand_value = value;
 }
 
-void ptx_thread_info::print_reg_thread(char *fname) {
-  FILE *fp = fopen(fname, "w");
-  assert(fp != NULL);
+void ptx_thread_info::print_reg_thread(char * fname)
+{
+
+  FILE *fp= fopen(fname,"w");
+  assert(fp!=NULL);
 
   int size = m_regs.size();
-
-  if (size > 0) {
-    reg_map_t reg = m_regs.back();
-
-    reg_map_t::const_iterator it;
-    for (it = reg.begin(); it != reg.end(); ++it) {
-      const std::string &name = it->first->name();
-      const std::string &dec = it->first->decl_location();
-      unsigned size = it->first->get_size_in_bytes();
-      fprintf(fp, "%s %llu %s %d\n", name.c_str(), it->second, dec.c_str(),
-              size);
-    }
-    // m_regs.pop_back();
+  
+  if(size>0)
+  {  
+  reg_map_t reg = m_regs.back();
+  
+      reg_map_t::const_iterator it;
+      for (it = reg.begin(); it != reg.end(); ++it) 
+        {
+          const std::string &name = it->first->name();
+          const std::string &dec= it->first->decl_location();
+          unsigned size = it->first->get_size_in_bytes();
+          fprintf(fp,"%s %llu %s %d\n", name.c_str(), it->second, dec.c_str(), size);
+          
+        }
+   //m_regs.pop_back();     
   }
   fclose(fp);
-}
 
-void ptx_thread_info::resume_reg_thread(char *fname, symbol_table *symtab) {
-  FILE *fp2 = fopen(fname, "r");
-  assert(fp2 != NULL);
-  // m_regs.push_back( reg_map_t() );
-  char line[200];
-  while (fgets(line, sizeof line, fp2) != NULL) {
-    symbol *reg;
-    char *pch;
-    pch = strtok(line, " ");
-    char *name = pch;
-    reg = symtab->lookup(name);
-    ptx_reg_t data;
-    pch = strtok(NULL, " ");
-    data = atoi(pch);
-    pch = strtok(NULL, " ");
-    pch = strtok(NULL, " ");
-    m_regs.back()[reg] = data;
   }
-  fclose(fp2);
-}
 
-ptx_reg_t ptx_thread_info::get_reg(const symbol *reg) {
-  static bool unfound_register_warned = false;
-  assert(reg != NULL);
-  assert(!m_regs.empty());
-  reg_map_t::iterator regs_iter = m_regs.back().find(reg);
-  if (regs_iter == m_regs.back().end()) {
-    assert(reg->type()->get_key().is_reg());
-    const std::string &name = reg->name();
-    unsigned call_uid = m_callstack.back().m_call_uid;
-    ptx_reg_t uninit_reg;
-    uninit_reg.u32 = 0x0;
-    set_reg(reg, uninit_reg);  // give it a value since we are going to warn the
-                               // user anyway
-    std::string file_loc = get_location();
-    if (!unfound_register_warned) {
-      printf(
-          "GPGPU-Sim PTX: WARNING (%s) ** reading undefined register \'%s\' "
-          "(cuid:%u). Setting to 0X00000000. This is okay if you are "
-          "simulating the native ISA"
-          "\n",
-          file_loc.c_str(), name.c_str(), call_uid);
-      unfound_register_warned = true;
-    }
-    regs_iter = m_regs.back().find(reg);
-  }
-  if (m_enable_debug_trace)
-    m_debug_trace_regs_read.back()[reg] = regs_iter->second;
-  return regs_iter->second;
-}
+void ptx_thread_info::resume_reg_thread(char * fname, symbol_table * symtab)
+{
 
-ptx_reg_t ptx_thread_info::get_operand_value(const operand_info &op,
-                                             operand_info dstInfo,
-                                             unsigned opType,
-                                             ptx_thread_info *thread,
-                                             int derefFlag) {
-  ptx_reg_t result, tmp;
 
-  if (op.get_double_operand_type() == 0) {
-    if (((opType != BB128_TYPE) && (opType != BB64_TYPE) &&
-         (opType != FF64_TYPE)) ||
-        (op.get_addr_space() != undefined_space)) {
-      if (op.is_reg()) {
-        result = get_reg(op.get_symbol());
-      } else if (op.is_builtin()) {
-        result.u32 = get_builtin(op.get_int(), op.get_addr_offset());
-      } else if (op.is_immediate_address()) {
-        result.u64 = op.get_addr_offset();
-      } else if (op.is_memory_operand()) {
-        // a few options here...
-        const symbol *sym = op.get_symbol();
-        const type_info *type = sym->type();
-        const type_info_key &info = type->get_key();
-
-        if (info.is_reg()) {
-          const symbol *name = op.get_symbol();
-          result.u64 = get_reg(name).u64 + op.get_addr_offset();
-        } else if (info.is_param_kernel()) {
-          result.u64 = sym->get_address() + op.get_addr_offset();
-        } else if (info.is_param_local()) {
-          result.u64 = sym->get_address() + op.get_addr_offset();
-        } else if (info.is_global()) {
-          assert(op.get_addr_offset() == 0);
-          result.u64 = sym->get_address();
-        } else if (info.is_local()) {
-          result.u64 = sym->get_address() + op.get_addr_offset();
-        } else if (info.is_const()) {
-          result.u64 = sym->get_address() + op.get_addr_offset();
-        } else if (op.is_shared()) {
-          result.u64 = op.get_symbol()->get_address() + op.get_addr_offset();
-        } else if (op.is_sstarr()) {
-          result.u64 = op.get_symbol()->get_address() + op.get_addr_offset();
-        } else {
-          const char *name = op.name().c_str();
-          printf(
-              "GPGPU-Sim PTX: ERROR ** get_operand_value : unknown memory "
-              "operand type for %s\n",
-              name);
-          abort();
-        }
-
-      } else if (op.is_literal()) {
-        result = op.get_literal_value();
-      } else if (op.is_label()) {
-        result.u64 = op.get_symbol()->get_address();
-      } else if (op.is_shared()) {
-        result.u64 = op.get_symbol()->get_address();
-      } else if (op.is_sstarr()) {
-        result.u64 = op.get_symbol()->get_address();
-      } else if (op.is_const()) {
-        result.u64 = op.get_symbol()->get_address();
-      } else if (op.is_global()) {
-        result.u64 = op.get_symbol()->get_address();
-      } else if (op.is_local()) {
-        result.u64 = op.get_symbol()->get_address();
-      } else if (op.is_function_address()) {
-        result.u64 = (size_t)op.get_symbol()->get_pc();
-      } else if (op.is_param_kernel()) {
-        result.u64 = op.get_symbol()->get_address();
-      } else {
-        const char *name = op.name().c_str();
-        const symbol *sym2 = op.get_symbol();
-        const type_info *type2 = sym2->type();
-        const type_info_key &info2 = type2->get_key();
-        if (info2.is_param_kernel()) {
-          result.u64 = sym2->get_address() + op.get_addr_offset();
-        } else {
-          printf(
-              "GPGPU-Sim PTX: ERROR ** get_operand_value : unknown operand "
-              "type for %s\n",
-              name);
-          assert(0);
-        }
+      FILE * fp2 = fopen(fname, "r");
+      assert(fp2!=NULL);
+      //m_regs.push_back( reg_map_t() );
+      char line [ 200 ];
+      while ( fgets ( line, sizeof line, fp2 ) != NULL )
+      {
+          symbol *reg;
+          char * pch;
+          pch = strtok (line," ");
+          char * name =pch;
+          reg= symtab->lookup(name);
+          ptx_reg_t data;
+          pch = strtok (NULL," "); 
+          data = atoi(pch);
+          pch = strtok (NULL," ");
+          pch = strtok (NULL," ");
+          m_regs.back()[reg] = data;
       }
+      fclose ( fp2 );
+}
+    
 
-      if (op.get_operand_lohi() == 1)
-        result.u64 = result.u64 & 0xFFFF;
-      else if (op.get_operand_lohi() == 2)
-        result.u64 = (result.u64 >> 16) & 0xFFFF;
-    } else if (opType == BB128_TYPE) {
-      // b128
-      result.u128.lowest = get_reg(op.vec_symbol(0)).u32;
-      result.u128.low = get_reg(op.vec_symbol(1)).u32;
-      result.u128.high = get_reg(op.vec_symbol(2)).u32;
-      result.u128.highest = get_reg(op.vec_symbol(3)).u32;
-    } else {
-      // bb64 or ff64
-      result.bits.ls = get_reg(op.vec_symbol(0)).u32;
-      result.bits.ms = get_reg(op.vec_symbol(1)).u32;
-    }
-  } else if (op.get_double_operand_type() == 1) {
-    ptx_reg_t firstHalf, secondHalf;
-    firstHalf.u64 = get_reg(op.vec_symbol(0)).u64;
-    secondHalf.u64 = get_reg(op.vec_symbol(1)).u64;
-    if (op.get_operand_lohi() == 1)
-      secondHalf.u64 = secondHalf.u64 & 0xFFFF;
-    else if (op.get_operand_lohi() == 2)
-      secondHalf.u64 = (secondHalf.u64 >> 16) & 0xFFFF;
-    result.u64 = firstHalf.u64 + secondHalf.u64;
-  } else if (op.get_double_operand_type() == 2) {
-    // s[reg1 += reg2]
-    // reg1 is incremented after value is returned: the value returned is
-    // s[reg1]
-    ptx_reg_t firstHalf, secondHalf;
-    firstHalf.u64 = get_reg(op.vec_symbol(0)).u64;
-    secondHalf.u64 = get_reg(op.vec_symbol(1)).u64;
-    if (op.get_operand_lohi() == 1)
-      secondHalf.u64 = secondHalf.u64 & 0xFFFF;
-    else if (op.get_operand_lohi() == 2)
-      secondHalf.u64 = (secondHalf.u64 >> 16) & 0xFFFF;
-    result.u64 = firstHalf.u64;
-    firstHalf.u64 = firstHalf.u64 + secondHalf.u64;
-    set_reg(op.vec_symbol(0), firstHalf);
-  } else if (op.get_double_operand_type() == 3) {
-    // s[reg += immediate]
-    // reg is incremented after value is returned: the value returned is s[reg]
-    ptx_reg_t firstHalf;
-    firstHalf.u64 = get_reg(op.get_symbol()).u64;
-    result.u64 = firstHalf.u64;
-    firstHalf.u64 = firstHalf.u64 + op.get_addr_offset();
-    set_reg(op.get_symbol(), firstHalf);
-  }
+ptx_reg_t ptx_thread_info::get_reg( const symbol *reg )
+{
+   static bool unfound_register_warned = false;
+   assert( reg != NULL );
+   assert( !m_regs.empty() );
+   reg_map_t::iterator regs_iter = m_regs.back().find(reg);
+   if (regs_iter == m_regs.back().end()) {
+      assert( reg->type()->get_key().is_reg() );
+      const std::string &name = reg->name();
+      unsigned call_uid = m_callstack.back().m_call_uid;
+      ptx_reg_t uninit_reg;
+      uninit_reg.u32 = 0x0;
+      set_reg(reg, uninit_reg); // give it a value since we are going to warn the user anyway
+      std::string file_loc = get_location();
+      if( !unfound_register_warned ) {
+          printf("GPGPU-Sim PTX: WARNING (%s) ** reading undefined register \'%s\' (cuid:%u). Setting to 0X00000000. This is okay if you are simulating the native ISA"
+        		  "\n",
+                 file_loc.c_str(), name.c_str(), call_uid );
+          unfound_register_warned = true;
+      }
+      regs_iter = m_regs.back().find(reg);
+   }
+   if (m_enable_debug_trace ) 
+      m_debug_trace_regs_read.back()[ reg ] = regs_iter->second;
+   return regs_iter->second;
+}
 
-  ptx_reg_t finalResult;
-  memory_space *mem = NULL;
-  size_t size = 0;
-  int t = 0;
-  finalResult.u64 = 0;
+ptx_reg_t ptx_thread_info::get_operand_value( const operand_info &op, operand_info dstInfo, unsigned opType, ptx_thread_info *thread, int derefFlag )
+{
+   ptx_reg_t result, tmp;
 
-  // complete other cases for reading from memory, such as reading from other
-  // const memory
-  if ((op.get_addr_space() == global_space) && (derefFlag)) {
-    // global memory - g[4], g[$r0]
-    mem = thread->get_global_memory();
-    type_info_key::type_decode(opType, size, t);
-    mem->read(result.u32, size / 8, &finalResult.u128);
-    thread->m_last_effective_address = result.u32;
-    thread->m_last_memory_space = global_space;
 
-    if (opType == S16_TYPE || opType == S32_TYPE)
-      sign_extend(finalResult, size, dstInfo);
-  } else if ((op.get_addr_space() == shared_space) && (derefFlag)) {
-    // shared memory - s[4], s[$r0]
-    mem = thread->m_shared_mem;
-    type_info_key::type_decode(opType, size, t);
-    mem->read(result.u32, size / 8, &finalResult.u128);
-    thread->m_last_effective_address = result.u32;
-    thread->m_last_memory_space = shared_space;
+   if(op.get_double_operand_type() == 0) {
+      if(((opType != BB128_TYPE) && (opType != BB64_TYPE) && (opType != FF64_TYPE)) || (op.get_addr_space() != undefined_space)) {
+         if ( op.is_reg() ) {
+            result = get_reg( op.get_symbol() );
+         } else if ( op.is_builtin()) {
+            result.u32 = get_builtin( op.get_int(), op.get_addr_offset() );
+         } else  if(op.is_immediate_address()){
+    		 result.u64 = op.get_addr_offset();
+    	 } else if ( op.is_memory_operand() ) {
+            // a few options here...
+            const symbol *sym = op.get_symbol();
+            const type_info *type = sym->type();
+            const type_info_key &info = type->get_key();
 
-    if (opType == S16_TYPE || opType == S32_TYPE)
-      sign_extend(finalResult, size, dstInfo);
-  } else if ((op.get_addr_space() == const_space) && (derefFlag)) {
-    // const memory - ce0c1[4], ce0c1[$r0]
-    mem = thread->get_global_memory();
-    type_info_key::type_decode(opType, size, t);
-    mem->read((result.u32 + op.get_const_mem_offset()), size / 8,
-              &finalResult.u128);
-    thread->m_last_effective_address = result.u32;
-    thread->m_last_memory_space = const_space;
-    if (opType == S16_TYPE || opType == S32_TYPE)
-      sign_extend(finalResult, size, dstInfo);
-  } else if ((op.get_addr_space() == local_space) && (derefFlag)) {
-    // local memory - l0[4], l0[$r0]
-    mem = thread->m_local_mem;
-    type_info_key::type_decode(opType, size, t);
-    mem->read(result.u32, size / 8, &finalResult.u128);
-    thread->m_last_effective_address = result.u32;
-    thread->m_last_memory_space = local_space;
-    if (opType == S16_TYPE || opType == S32_TYPE)
-      sign_extend(finalResult, size, dstInfo);
-  } else {
-    finalResult = result;
-  }
+            if ( info.is_reg() ) {
+               const symbol *name = op.get_symbol();
+               result.u64 = get_reg(name).u64 + op.get_addr_offset(); 
+            } else if ( info.is_param_kernel() ) {
+               result.u64 = sym->get_address() + op.get_addr_offset();
+            } else if ( info.is_param_local() ) {
+               result.u64 = sym->get_address() + op.get_addr_offset();
+            } else if ( info.is_global() ) {
+               assert( op.get_addr_offset() == 0 );
+               result.u64 = sym->get_address();
+            } else if ( info.is_local() ) {
+               result.u64 = sym->get_address() + op.get_addr_offset();
+            } else if ( info.is_const() ) {
+               result.u64 = sym->get_address() + op.get_addr_offset();
+            } else if ( op.is_shared() ) {
+               result.u64 = op.get_symbol()->get_address() + op.get_addr_offset();
+            } else if ( op.is_sstarr() ) {
+               result.u64 = op.get_symbol()->get_address() + op.get_addr_offset();
+            } else {
+                 const char *name = op.name().c_str();
+	    	printf("GPGPU-Sim PTX: ERROR ** get_operand_value : unknown memory operand type for %s\n", name );
+            	abort();
+            }
 
-  if ((op.get_operand_neg() == true) && (derefFlag)) {
-    switch (opType) {
+         } else if ( op.is_literal() ) {
+            result = op.get_literal_value();
+         } else if ( op.is_label() ) {
+            result.u64 = op.get_symbol()->get_address();
+         } else if ( op.is_shared() ) {
+            result.u64 = op.get_symbol()->get_address();
+         } else if ( op.is_sstarr() ) {
+            result.u64 = op.get_symbol()->get_address();
+         } else if ( op.is_const() ) {
+            result.u64 = op.get_symbol()->get_address();
+         } else if ( op.is_global() ) {
+            result.u64 = op.get_symbol()->get_address();
+         } else if ( op.is_local() ) {
+            result.u64 = op.get_symbol()->get_address();
+         } else if ( op.is_function_address() ) {
+            result.u64 = (size_t)op.get_symbol()->get_pc();
+	 } else if ( op.is_param_kernel()) {
+            result.u64 = op.get_symbol()->get_address();
+         }else {
+            const char *name = op.name().c_str();
+            const symbol *sym2 = op.get_symbol();
+            const type_info *type2 = sym2->type();
+            const type_info_key &info2 = type2->get_key();
+            if ( info2.is_param_kernel() ) {
+               result.u64 = sym2->get_address()+ op.get_addr_offset();
+            }
+	    else{ 
+             printf("GPGPU-Sim PTX: ERROR ** get_operand_value : unknown operand type for %s\n", name );
+             assert(0);
+	    }
+         }
+
+         if(op.get_operand_lohi() == 1) 
+              result.u64 = result.u64 & 0xFFFF;
+         else if(op.get_operand_lohi() == 2) 
+              result.u64 = (result.u64>>16) & 0xFFFF;
+      } else if (opType == BB128_TYPE) {
+          // b128
+          result.u128.lowest = get_reg( op.vec_symbol(0) ).u32;
+          result.u128.low = get_reg( op.vec_symbol(1) ).u32;
+          result.u128.high = get_reg( op.vec_symbol(2) ).u32;
+          result.u128.highest = get_reg( op.vec_symbol(3) ).u32;
+      } else {
+          // bb64 or ff64
+          result.bits.ls = get_reg( op.vec_symbol(0) ).u32;
+          result.bits.ms = get_reg( op.vec_symbol(1) ).u32;
+      }
+   } else if (op.get_double_operand_type() == 1) {
+      ptx_reg_t firstHalf, secondHalf;
+      firstHalf.u64 = get_reg( op.vec_symbol(0) ).u64;
+      secondHalf.u64 = get_reg( op.vec_symbol(1) ).u64;
+      if(op.get_operand_lohi() == 1)
+           secondHalf.u64 = secondHalf.u64 & 0xFFFF;
+      else if(op.get_operand_lohi() == 2)
+           secondHalf.u64 = (secondHalf.u64>>16) & 0xFFFF;
+      result.u64 = firstHalf.u64 + secondHalf.u64;
+   } else if (op.get_double_operand_type() == 2) {
+      // s[reg1 += reg2]
+      // reg1 is incremented after value is returned: the value returned is s[reg1]
+      ptx_reg_t firstHalf, secondHalf;
+      firstHalf.u64 = get_reg(op.vec_symbol(0)).u64;
+      secondHalf.u64 = get_reg(op.vec_symbol(1)).u64;
+      if(op.get_operand_lohi() == 1)
+           secondHalf.u64 = secondHalf.u64 & 0xFFFF;
+      else if(op.get_operand_lohi() == 2)
+           secondHalf.u64 = (secondHalf.u64>>16) & 0xFFFF;
+      result.u64 = firstHalf.u64;
+      firstHalf.u64 = firstHalf.u64 + secondHalf.u64;
+      set_reg(op.vec_symbol(0),firstHalf);
+   } else if (op.get_double_operand_type() == 3) {
+      // s[reg += immediate]
+      // reg is incremented after value is returned: the value returned is s[reg]
+      ptx_reg_t firstHalf;
+      firstHalf.u64 = get_reg(op.get_symbol()).u64;
+      result.u64 = firstHalf.u64;
+      firstHalf.u64 = firstHalf.u64 + op.get_addr_offset();
+      set_reg(op.get_symbol(),firstHalf);
+   }
+
+   ptx_reg_t finalResult;
+   memory_space *mem = NULL;
+   size_t size=0;
+   int t=0;
+   finalResult.u64=0;
+
+   //complete other cases for reading from memory, such as reading from other const memory
+   if((op.get_addr_space() == global_space)&&(derefFlag)) {
+       // global memory - g[4], g[$r0]
+       mem = thread->get_global_memory();
+       type_info_key::type_decode(opType,size,t);
+       mem->read(result.u32,size/8,&finalResult.u128);
+       thread->m_last_effective_address = result.u32;
+       thread->m_last_memory_space = global_space;
+
+       if( opType == S16_TYPE || opType == S32_TYPE )
+         sign_extend(finalResult,size,dstInfo);
+   } else if((op.get_addr_space() == shared_space)&&(derefFlag)) {
+      // shared memory - s[4], s[$r0]
+       mem = thread->m_shared_mem;
+       type_info_key::type_decode(opType,size,t);
+       mem->read(result.u32,size/8,&finalResult.u128);
+       thread->m_last_effective_address = result.u32;
+       thread->m_last_memory_space = shared_space;
+
+       if( opType == S16_TYPE || opType == S32_TYPE ) 
+         sign_extend(finalResult,size,dstInfo);
+   } else if((op.get_addr_space() == const_space)&&(derefFlag)) {
+      // const memory - ce0c1[4], ce0c1[$r0]
+       mem = thread->get_global_memory();
+       type_info_key::type_decode(opType,size,t);
+       mem->read((result.u32 + op.get_const_mem_offset()),size/8,&finalResult.u128);
+       thread->m_last_effective_address = result.u32;
+       thread->m_last_memory_space = const_space;
+       if( opType == S16_TYPE || opType == S32_TYPE )
+         sign_extend(finalResult,size,dstInfo);
+   } else if((op.get_addr_space() == local_space)&&(derefFlag)) {
+      // local memory - l0[4], l0[$r0]
+       mem = thread->m_local_mem;
+       type_info_key::type_decode(opType,size,t);
+       mem->read(result.u32,size/8,&finalResult.u128);
+       thread->m_last_effective_address = result.u32;
+       thread->m_last_memory_space = local_space;
+       if( opType == S16_TYPE || opType == S32_TYPE ) 
+         sign_extend(finalResult,size,dstInfo);
+   } else {
+       finalResult = result;
+   }
+
+   if((op.get_operand_neg() == true)&&(derefFlag)) {
+      switch( opType ) {
       // Default to f32 for now, need to add support for others
       case S8_TYPE:
       case U8_TYPE:
       case B8_TYPE:
-        finalResult.s8 = -finalResult.s8;
-        break;
+         finalResult.s8 = -finalResult.s8;
+         break;
       case S16_TYPE:
       case U16_TYPE:
       case B16_TYPE:
-        finalResult.s16 = -finalResult.s16;
-        break;
+         finalResult.s16 = -finalResult.s16;
+         break;
       case S32_TYPE:
       case U32_TYPE:
       case B32_TYPE:
-        finalResult.s32 = -finalResult.s32;
-        break;
+         finalResult.s32 = -finalResult.s32;
+         break;
       case S64_TYPE:
       case U64_TYPE:
       case B64_TYPE:
-        finalResult.s64 = -finalResult.s64;
-        break;
+         finalResult.s64 = -finalResult.s64;
+         break;
       case F16_TYPE:
-        finalResult.f16 = -finalResult.f16;
-        break;
+         finalResult.f16 = -finalResult.f16;
+         break;
       case F32_TYPE:
-        finalResult.f32 = -finalResult.f32;
-        break;
+         finalResult.f32 = -finalResult.f32;
+         break;
       case F64_TYPE:
       case FF64_TYPE:
-        finalResult.f64 = -finalResult.f64;
-        break;
+         finalResult.f64 = -finalResult.f64;
+         break;
       default:
+         assert(0);
+      }
+
+   }
+
+   return finalResult;
+
+}
+
+unsigned get_operand_nbits( const operand_info &op )
+{
+   if ( op.is_reg() ) {
+      const symbol *sym = op.get_symbol();
+      const type_info *typ = sym->type();
+      type_info_key t = typ->get_key();
+      switch( t.scalar_type() ) {
+      case PRED_TYPE: 
+         return 1;
+      case B8_TYPE: case S8_TYPE: case U8_TYPE:
+         return 8;
+      case S16_TYPE: case U16_TYPE: case F16_TYPE: case B16_TYPE:
+         return 16;
+      case S32_TYPE: case U32_TYPE: case F32_TYPE: case B32_TYPE:
+         return 32;
+      case S64_TYPE: case U64_TYPE: case F64_TYPE: case B64_TYPE:
+         return 64;
+      default:
+         printf("ERROR: unknown register type\n");
+         fflush(stdout);
+         abort();
+      }
+   } else {
+      printf("ERROR: Need to implement get_operand_nbits() for currently unsupported operand_info type\n");
+      fflush(stdout);
+      abort();
+   }
+
+   return 0;
+}
+
+void ptx_thread_info::get_vector_operand_values( const operand_info &op, ptx_reg_t* ptx_regs, unsigned num_elements )
+{
+   assert( op.is_vector() );
+   assert( num_elements <= 8 );
+
+   for (int idx = num_elements - 1; idx >= 0; --idx) {
+      const symbol *sym = NULL;
+      sym = op.vec_symbol(idx);
+      if( strcmp(sym->name().c_str(),"_") != 0) {
+         reg_map_t::iterator reg_iter = m_regs.back().find(sym);
+         assert( reg_iter != m_regs.back().end() );
+         ptx_regs[idx] = reg_iter->second;
+      }
+   }
+}
+
+void sign_extend( ptx_reg_t &data, unsigned src_size, const operand_info &dst )
+{
+   if( !dst.is_reg() )
+      return;
+   unsigned dst_size = get_operand_nbits( dst );
+   if( src_size >= dst_size ) 
+      return;
+   // src_size < dst_size
+   unsigned long long mask = 1;
+   mask <<= (src_size-1);
+   if( (mask & data.u64) == 0 ) {
+      // no need to sign extend
+      return;
+   }
+   // need to sign extend
+   mask = 1;
+   mask <<= dst_size-src_size;
+   mask -= 1;
+   mask <<= src_size;
+   data.u64 |= mask;
+}
+
+void ptx_thread_info::set_operand_value( const operand_info &dst, const ptx_reg_t &data, unsigned type, ptx_thread_info *thread, const ptx_instruction *pI, int overflow, int carry )
+{
+    thread->set_operand_value( dst, data, type, thread, pI );
+
+    if (dst.get_double_operand_type() == -2)
+    {
+        ptx_reg_t predValue;
+        
+        const symbol *sym = dst.vec_symbol(0);
+        predValue.u64 = (m_regs.back()[ sym ].u64) & ~(0x0C);
+        predValue.u64 |= ((overflow & 0x01)<<3);
+        predValue.u64 |= ((carry & 0x01)<<2);
+
+        set_reg(sym,predValue);
+    }
+    else if (dst.get_double_operand_type() == 0)
+    {
+        //intentionally do nothing
+    }
+    else
+    {
+        printf("Unexpected double destination\n");
         assert(0);
     }
-  }
 
-  return finalResult;
 }
 
-unsigned get_operand_nbits(const operand_info &op) {
-  if (op.is_reg()) {
-    const symbol *sym = op.get_symbol();
-    const type_info *typ = sym->type();
-    type_info_key t = typ->get_key();
-    switch (t.scalar_type()) {
-      case PRED_TYPE:
-        return 1;
-      case B8_TYPE:
-      case S8_TYPE:
-      case U8_TYPE:
-        return 8;
-      case S16_TYPE:
-      case U16_TYPE:
-      case F16_TYPE:
-      case B16_TYPE:
-        return 16;
-      case S32_TYPE:
-      case U32_TYPE:
-      case F32_TYPE:
-      case B32_TYPE:
-        return 32;
-      case S64_TYPE:
-      case U64_TYPE:
-      case F64_TYPE:
-      case B64_TYPE:
-        return 64;
-      default:
-        printf("ERROR: unknown register type\n");
-        fflush(stdout);
-        abort();
-    }
-  } else {
-    printf(
-        "ERROR: Need to implement get_operand_nbits() for currently "
-        "unsupported operand_info type\n");
-    fflush(stdout);
-    abort();
-  }
+void ptx_thread_info::set_operand_value( const operand_info &dst, const ptx_reg_t &data, unsigned type, ptx_thread_info *thread, const ptx_instruction *pI )
+{
+   ptx_reg_t dstData;
+   memory_space *mem = NULL;
+   size_t size;
+   int t;
 
-  return 0;
-}
+   type_info_key::type_decode(type,size,t);
 
-void ptx_thread_info::get_vector_operand_values(const operand_info &op,
-                                                ptx_reg_t *ptx_regs,
-                                                unsigned num_elements) {
-  assert(op.is_vector());
-  assert(num_elements <= 8);
+   /*complete this section for other cases*/
+   if(dst.get_addr_space() == undefined_space)
+   {
+      ptx_reg_t setValue;
+      setValue.u64 = data.u64;
 
-  for (int idx = num_elements - 1; idx >= 0; --idx) {
-    const symbol *sym = NULL;
-    sym = op.vec_symbol(idx);
-    if (strcmp(sym->name().c_str(), "_") != 0) {
-      reg_map_t::iterator reg_iter = m_regs.back().find(sym);
-      assert(reg_iter != m_regs.back().end());
-      ptx_regs[idx] = reg_iter->second;
-    }
-  }
-}
+      // Double destination in set instruction ($p0|$p1) - second is negation of first
+      if (dst.get_double_operand_type() == -1)
+      {
+          ptx_reg_t setValue2;
+          const symbol *name1 = dst.vec_symbol(0);
+          const symbol *name2 = dst.vec_symbol(1);
 
-void sign_extend(ptx_reg_t &data, unsigned src_size, const operand_info &dst) {
-  if (!dst.is_reg()) return;
-  unsigned dst_size = get_operand_nbits(dst);
-  if (src_size >= dst_size) return;
-  // src_size < dst_size
-  unsigned long long mask = 1;
-  mask <<= (src_size - 1);
-  if ((mask & data.u64) == 0) {
-    // no need to sign extend
-    return;
-  }
-  // need to sign extend
-  mask = 1;
-  mask <<= dst_size - src_size;
-  mask -= 1;
-  mask <<= src_size;
-  data.u64 |= mask;
-}
+          if ( (type==F16_TYPE)||(type==F32_TYPE)||(type==F64_TYPE)||(type==FF64_TYPE) ) {
+             setValue2.f32 = (setValue.u64==0)?1.0f:0.0f;
+          } else {
+             setValue2.u32 = (setValue.u64==0)?0xFFFFFFFF:0;
+          }
 
-void ptx_thread_info::set_operand_value(const operand_info &dst,
-                                        const ptx_reg_t &data, unsigned type,
-                                        ptx_thread_info *thread,
-                                        const ptx_instruction *pI, int overflow,
-                                        int carry) {
-  thread->set_operand_value(dst, data, type, thread, pI);
-
-  if (dst.get_double_operand_type() == -2) {
-    ptx_reg_t predValue;
-
-    const symbol *sym = dst.vec_symbol(0);
-    predValue.u64 = (m_regs.back()[sym].u64) & ~(0x0C);
-    predValue.u64 |= ((overflow & 0x01) << 3);
-    predValue.u64 |= ((carry & 0x01) << 2);
-
-    set_reg(sym, predValue);
-  } else if (dst.get_double_operand_type() == 0) {
-    // intentionally do nothing
-  } else {
-    printf("Unexpected double destination\n");
-    assert(0);
-  }
-}
-
-void ptx_thread_info::set_operand_value(const operand_info &dst,
-                                        const ptx_reg_t &data, unsigned type,
-                                        ptx_thread_info *thread,
-                                        const ptx_instruction *pI) {
-  ptx_reg_t dstData;
-  memory_space *mem = NULL;
-  size_t size;
-  int t;
-
-  type_info_key::type_decode(type, size, t);
-
-  /*complete this section for other cases*/
-  if (dst.get_addr_space() == undefined_space) {
-    ptx_reg_t setValue;
-    setValue.u64 = data.u64;
-
-    // Double destination in set instruction ($p0|$p1) - second is negation of
-    // first
-    if (dst.get_double_operand_type() == -1) {
-      ptx_reg_t setValue2;
-      const symbol *name1 = dst.vec_symbol(0);
-      const symbol *name2 = dst.vec_symbol(1);
-
-      if ((type == F16_TYPE) || (type == F32_TYPE) || (type == F64_TYPE) ||
-          (type == FF64_TYPE)) {
-        setValue2.f32 = (setValue.u64 == 0) ? 1.0f : 0.0f;
-      } else {
-        setValue2.u32 = (setValue.u64 == 0) ? 0xFFFFFFFF : 0;
+          set_reg(name1,setValue);
+          set_reg(name2,setValue2);
       }
 
-      set_reg(name1, setValue);
-      set_reg(name2, setValue2);
-    }
+      // Double destination in cvt,shr,mul,etc. instruction ($p0|$r4) - second register operand receives data, first predicate operand
+      // is set as $p0=($r4!=0)
+      // Also for Double destination in set instruction ($p0/$r1)
+      else if ((dst.get_double_operand_type() == -2)||(dst.get_double_operand_type() == -3))
+      {
+          ptx_reg_t predValue;
+          const symbol *predName = dst.vec_symbol(0);
+          const symbol *regName = dst.vec_symbol(1);
+          predValue.u64 = 0;
 
-    // Double destination in cvt,shr,mul,etc. instruction ($p0|$r4) - second
-    // register operand receives data, first predicate operand
-    // is set as $p0=($r4!=0)
-    // Also for Double destination in set instruction ($p0/$r1)
-    else if ((dst.get_double_operand_type() == -2) ||
-             (dst.get_double_operand_type() == -3)) {
-      ptx_reg_t predValue;
-      const symbol *predName = dst.vec_symbol(0);
-      const symbol *regName = dst.vec_symbol(1);
-      predValue.u64 = 0;
+          switch ( type ) {
+          case S8_TYPE:
+              if((setValue.s8 & 0x7F) == 0)
+                  predValue.u64 |= 1;
+              break;
+          case S16_TYPE:
+              if((setValue.s16 & 0x7FFF) == 0)
+                  predValue.u64 |= 1;
+              break;
+          case S32_TYPE:
+              if((setValue.s32 & 0x7FFFFFFF) == 0)
+                  predValue.u64 |= 1;
+              break;
+          case S64_TYPE:
+              if((setValue.s64 & 0x7FFFFFFFFFFFFFFF) == 0)
+                  predValue.u64 |= 1;
+              break;
+          case U8_TYPE:
+          case B8_TYPE:
+              if(setValue.u8 == 0)
+                  predValue.u64 |= 1;
+              break;
+          case U16_TYPE:
+          case B16_TYPE:
+              if(setValue.u16 == 0)
+                  predValue.u64 |= 1;
+              break;
+          case U32_TYPE:
+          case B32_TYPE:
+              if(setValue.u32 == 0)
+                  predValue.u64 |= 1;
+              break;
+          case U64_TYPE:
+          case B64_TYPE:
+              if(setValue.u64 == 0)
+                  predValue.u64 |= 1;
+              break;
+          case F16_TYPE:
+              if(setValue.f16 == 0)
+                  predValue.u64 |= 1;
+              break;
+          case F32_TYPE:
+              if(setValue.f32 == 0)
+                  predValue.u64 |= 1;
+              break;
+          case F64_TYPE:
+          case FF64_TYPE:
+              if(setValue.f64 == 0)
+                  predValue.u64 |= 1;
+              break;
+          default: assert(0); break;
+          }
 
-      switch (type) {
-        case S8_TYPE:
-          if ((setValue.s8 & 0x7F) == 0) predValue.u64 |= 1;
-          break;
-        case S16_TYPE:
-          if ((setValue.s16 & 0x7FFF) == 0) predValue.u64 |= 1;
-          break;
-        case S32_TYPE:
-          if ((setValue.s32 & 0x7FFFFFFF) == 0) predValue.u64 |= 1;
-          break;
-        case S64_TYPE:
-          if ((setValue.s64 & 0x7FFFFFFFFFFFFFFF) == 0) predValue.u64 |= 1;
-          break;
-        case U8_TYPE:
-        case B8_TYPE:
-          if (setValue.u8 == 0) predValue.u64 |= 1;
-          break;
-        case U16_TYPE:
-        case B16_TYPE:
-          if (setValue.u16 == 0) predValue.u64 |= 1;
-          break;
-        case U32_TYPE:
-        case B32_TYPE:
-          if (setValue.u32 == 0) predValue.u64 |= 1;
-          break;
-        case U64_TYPE:
-        case B64_TYPE:
-          if (setValue.u64 == 0) predValue.u64 |= 1;
-          break;
-        case F16_TYPE:
-          if (setValue.f16 == 0) predValue.u64 |= 1;
-          break;
-        case F32_TYPE:
-          if (setValue.f32 == 0) predValue.u64 |= 1;
-          break;
-        case F64_TYPE:
-        case FF64_TYPE:
-          if (setValue.f64 == 0) predValue.u64 |= 1;
-          break;
-        default:
-          assert(0);
-          break;
+
+          if ( (type==S8_TYPE)||(type==S16_TYPE)||(type==S32_TYPE)||(type==S64_TYPE)||
+               (type==U8_TYPE)||(type==U16_TYPE)||(type==U32_TYPE)||(type==U64_TYPE)||
+               (type==B8_TYPE)||(type==B16_TYPE)||(type==B32_TYPE)||(type==B64_TYPE)) {
+              if((setValue.u32 & (1<<(size-1))) != 0)
+                  predValue.u64 |= 1<<1;
+          }
+          if ( type==F32_TYPE ) {
+              if(setValue.f32 < 0)
+                  predValue.u64 |= 1<<1;
+          }
+
+          if(dst.get_operand_lohi() == 1)
+          {
+              setValue.u64 = ((m_regs.back()[ regName ].u64) & (~(0xFFFF))) + (data.u64 & 0xFFFF);
+          }
+          else if(dst.get_operand_lohi() == 2)
+          {
+              setValue.u64 = ((m_regs.back()[ regName ].u64) & (~(0xFFFF0000))) + ((data.u64<<16) & 0xFFFF0000);
+          }
+
+          set_reg(predName,predValue);
+          set_reg(regName,setValue);
       }
+      else if (type == BB128_TYPE)
+      {
+          //b128 stuff here.
+          ptx_reg_t setValue2, setValue3, setValue4;
+          setValue.u64 = 0;
+          setValue2.u64 = 0;
+          setValue3.u64 = 0;
+          setValue4.u64 = 0;
+          setValue.u32 = data.u128.lowest;
+          setValue2.u32 = data.u128.low;
+          setValue3.u32 = data.u128.high;
+          setValue4.u32 = data.u128.highest;
 
-      if ((type == S8_TYPE) || (type == S16_TYPE) || (type == S32_TYPE) ||
-          (type == S64_TYPE) || (type == U8_TYPE) || (type == U16_TYPE) ||
-          (type == U32_TYPE) || (type == U64_TYPE) || (type == B8_TYPE) ||
-          (type == B16_TYPE) || (type == B32_TYPE) || (type == B64_TYPE)) {
-        if ((setValue.u32 & (1 << (size - 1))) != 0) predValue.u64 |= 1 << 1;
+          const symbol *name1, *name2, *name3, *name4 = NULL;
+
+          name1 = dst.vec_symbol(0);
+          name2 = dst.vec_symbol(1);
+          name3 = dst.vec_symbol(2);
+          name4 = dst.vec_symbol(3);
+
+          set_reg(name1,setValue);
+          set_reg(name2,setValue2);
+          set_reg(name3,setValue3);
+          set_reg(name4,setValue4);
       }
-      if (type == F32_TYPE) {
-        if (setValue.f32 < 0) predValue.u64 |= 1 << 1;
+      else if (type == BB64_TYPE || type == FF64_TYPE)
+      {
+          //ptxplus version of storing 64 bit values to registers stores to two adjacent registers
+          ptx_reg_t setValue2;
+          setValue.u32 = 0;
+          setValue2.u32 = 0;
+
+          setValue.u32 = data.bits.ls;
+          setValue2.u32 = data.bits.ms;
+
+          const symbol *name1, *name2 = NULL;
+
+          name1 = dst.vec_symbol(0);
+          name2 = dst.vec_symbol(1);
+
+          set_reg(name1,setValue);
+          set_reg(name2,setValue2);
       }
-
-      if (dst.get_operand_lohi() == 1) {
-        setValue.u64 =
-            ((m_regs.back()[regName].u64) & (~(0xFFFF))) + (data.u64 & 0xFFFF);
-      } else if (dst.get_operand_lohi() == 2) {
-        setValue.u64 = ((m_regs.back()[regName].u64) & (~(0xFFFF0000))) +
-                       ((data.u64 << 16) & 0xFFFF0000);
+      else
+      {
+          if(dst.get_operand_lohi() == 1)
+          {
+              setValue.u64 = ((m_regs.back()[ dst.get_symbol() ].u64) & (~(0xFFFF))) + (data.u64 & 0xFFFF);
+          }
+          else if(dst.get_operand_lohi() == 2)
+          {
+              setValue.u64 = ((m_regs.back()[ dst.get_symbol() ].u64) & (~(0xFFFF0000))) + ((data.u64<<16) & 0xFFFF0000);
+          }
+          set_reg(dst.get_symbol(),setValue);
       }
+   }
 
-      set_reg(predName, predValue);
-      set_reg(regName, setValue);
-    } else if (type == BB128_TYPE) {
-      // b128 stuff here.
-      ptx_reg_t setValue2, setValue3, setValue4;
-      setValue.u64 = 0;
-      setValue2.u64 = 0;
-      setValue3.u64 = 0;
-      setValue4.u64 = 0;
-      setValue.u32 = data.u128.lowest;
-      setValue2.u32 = data.u128.low;
-      setValue3.u32 = data.u128.high;
-      setValue4.u32 = data.u128.highest;
+   // global memory - g[4], g[$r0]
+   else if(dst.get_addr_space() == global_space)
+   {
+       dstData = thread->get_operand_value(dst, dst, type, thread, 0);
+       mem = thread->get_global_memory();
+       type_info_key::type_decode(type,size,t);
 
-      const symbol *name1, *name2, *name3, *name4 = NULL;
+       mem->write(dstData.u32,size/8,&data.u128,thread,pI);
+       thread->m_last_effective_address = dstData.u32;
+       thread->m_last_memory_space = global_space;
+   }
 
-      name1 = dst.vec_symbol(0);
-      name2 = dst.vec_symbol(1);
-      name3 = dst.vec_symbol(2);
-      name4 = dst.vec_symbol(3);
+   // shared memory - s[4], s[$r0]
+   else if(dst.get_addr_space() == shared_space)
+   {
+       dstData = thread->get_operand_value(dst, dst, type, thread, 0);
+       mem = thread->m_shared_mem;
+       type_info_key::type_decode(type,size,t);
 
-      set_reg(name1, setValue);
-      set_reg(name2, setValue2);
-      set_reg(name3, setValue3);
-      set_reg(name4, setValue4);
-    } else if (type == BB64_TYPE || type == FF64_TYPE) {
-      // ptxplus version of storing 64 bit values to registers stores to two
-      // adjacent registers
-      ptx_reg_t setValue2;
-      setValue.u32 = 0;
-      setValue2.u32 = 0;
+       mem->write(dstData.u32,size/8,&data.u128,thread,pI);
+       thread->m_last_effective_address = dstData.u32;
+       thread->m_last_memory_space = shared_space;
+   }
 
-      setValue.u32 = data.bits.ls;
-      setValue2.u32 = data.bits.ms;
+   // local memory - l0[4], l0[$r0]
+   else if(dst.get_addr_space() == local_space)
+   {
+       dstData = thread->get_operand_value(dst, dst, type, thread, 0);
+       mem = thread->m_local_mem;
+       type_info_key::type_decode(type,size,t);
 
-      const symbol *name1, *name2 = NULL;
+       mem->write(dstData.u32,size/8,&data.u128,thread,pI);
+       thread->m_last_effective_address = dstData.u32;
+       thread->m_last_memory_space = local_space;
+   }
 
-      name1 = dst.vec_symbol(0);
-      name2 = dst.vec_symbol(1);
+   else
+   {
+       printf("Destination stores to unknown location.");
+       assert(0);
+   }
 
-      set_reg(name1, setValue);
-      set_reg(name2, setValue2);
-    } else {
-      if (dst.get_operand_lohi() == 1) {
-        setValue.u64 = ((m_regs.back()[dst.get_symbol()].u64) & (~(0xFFFF))) +
-                       (data.u64 & 0xFFFF);
-      } else if (dst.get_operand_lohi() == 2) {
-        setValue.u64 =
-            ((m_regs.back()[dst.get_symbol()].u64) & (~(0xFFFF0000))) +
-            ((data.u64 << 16) & 0xFFFF0000);
-      }
-      set_reg(dst.get_symbol(), setValue);
-    }
-  }
 
-  // global memory - g[4], g[$r0]
-  else if (dst.get_addr_space() == global_space) {
-    dstData = thread->get_operand_value(dst, dst, type, thread, 0);
-    mem = thread->get_global_memory();
-    type_info_key::type_decode(type, size, t);
-
-    mem->write(dstData.u32, size / 8, &data.u128, thread, pI);
-    thread->m_last_effective_address = dstData.u32;
-    thread->m_last_memory_space = global_space;
-  }
-
-  // shared memory - s[4], s[$r0]
-  else if (dst.get_addr_space() == shared_space) {
-    dstData = thread->get_operand_value(dst, dst, type, thread, 0);
-    mem = thread->m_shared_mem;
-    type_info_key::type_decode(type, size, t);
-
-    mem->write(dstData.u32, size / 8, &data.u128, thread, pI);
-    thread->m_last_effective_address = dstData.u32;
-    thread->m_last_memory_space = shared_space;
-  }
-
-  // local memory - l0[4], l0[$r0]
-  else if (dst.get_addr_space() == local_space) {
-    dstData = thread->get_operand_value(dst, dst, type, thread, 0);
-    mem = thread->m_local_mem;
-    type_info_key::type_decode(type, size, t);
-
-    mem->write(dstData.u32, size / 8, &data.u128, thread, pI);
-    thread->m_last_effective_address = dstData.u32;
-    thread->m_last_memory_space = local_space;
-  }
-
-  else {
-    printf("Destination stores to unknown location.");
-    assert(0);
-  }
 }
 
-void ptx_thread_info::set_vector_operand_values(const operand_info &dst,
-                                                const ptx_reg_t &data1,
-                                                const ptx_reg_t &data2,
-                                                const ptx_reg_t &data3,
-                                                const ptx_reg_t &data4) {
-  unsigned num_elements = dst.get_vect_nelem();
-  if (num_elements > 0) {
-    set_reg(dst.vec_symbol(0), data1);
-    if (num_elements > 1) {
-      set_reg(dst.vec_symbol(1), data2);
-      if (num_elements > 2) {
-        set_reg(dst.vec_symbol(2), data3);
-        if (num_elements > 3) {
-          set_reg(dst.vec_symbol(3), data4);
-        }
-      }
-    }
-  }
+void ptx_thread_info::set_vector_operand_values( const operand_info &dst, 
+                                                 const ptx_reg_t &data1, 
+                                                 const ptx_reg_t &data2, 
+                                                 const ptx_reg_t &data3, 
+                                                 const ptx_reg_t &data4 )
+{
+   unsigned num_elements = dst.get_vect_nelem(); 
+   if (num_elements > 0) {
+       set_reg(dst.vec_symbol(0), data1);
+       if (num_elements > 1) {
+           set_reg(dst.vec_symbol(1), data2);
+           if (num_elements > 2) {
+              set_reg(dst.vec_symbol(2), data3);
+              if (num_elements > 3) {
+                 set_reg(dst.vec_symbol(3), data4);
+              }
+           }
+       }
+   }
 
-  m_last_set_operand_value = data1;
+   m_last_set_operand_value = data1;
 }
-void ptx_thread_info::set_wmma_vector_operand_values(
-    const operand_info &dst, const ptx_reg_t &data1, const ptx_reg_t &data2,
-    const ptx_reg_t &data3, const ptx_reg_t &data4, const ptx_reg_t &data5,
-    const ptx_reg_t &data6, const ptx_reg_t &data7, const ptx_reg_t &data8) {
-  unsigned num_elements = dst.get_vect_nelem();
-  if (num_elements == 8) {
-    set_reg(dst.vec_symbol(0), data1);
-    set_reg(dst.vec_symbol(1), data2);
-    set_reg(dst.vec_symbol(2), data3);
-    set_reg(dst.vec_symbol(3), data4);
-    set_reg(dst.vec_symbol(4), data5);
-    set_reg(dst.vec_symbol(5), data6);
-    set_reg(dst.vec_symbol(6), data7);
-    set_reg(dst.vec_symbol(7), data8);
-  } else {
-    printf("error:set_wmma_vector_operands");
-  }
+void ptx_thread_info::set_wmma_vector_operand_values( const operand_info &dst, 
+                                                 const ptx_reg_t &data1, 
+                                                 const ptx_reg_t &data2, 
+                                                 const ptx_reg_t &data3, 
+                                                 const ptx_reg_t &data4, 
+                                                 const ptx_reg_t &data5, 
+                                                 const ptx_reg_t &data6, 
+                                                 const ptx_reg_t &data7, 
+                                                 const ptx_reg_t &data8 )
+{
+   unsigned num_elements = dst.get_vect_nelem(); 
+   if (num_elements == 8) {
+       set_reg(dst.vec_symbol(0), data1);
+       set_reg(dst.vec_symbol(1), data2);
+       set_reg(dst.vec_symbol(2), data3);
+       set_reg(dst.vec_symbol(3), data4);
+       set_reg(dst.vec_symbol(4), data5);
+       set_reg(dst.vec_symbol(5), data6);
+       set_reg(dst.vec_symbol(6), data7);
+       set_reg(dst.vec_symbol(7), data8);
+   }
+   else{
+	printf("error:set_wmma_vector_operands");
+   }
 
-  m_last_set_operand_value = data8;
+   m_last_set_operand_value = data8;
 }
 
-#define my_abs(a) (((a) < 0) ? (-a) : (a))
+#define my_abs(a) (((a)<0)?(-a):(a))
 
-#define MY_MAX_I(a, b) (a > b) ? a : b
-#define MY_MAX_F(a, b) isNaN(a) ? b : isNaN(b) ? a : (a > b) ? a : b
+#define MY_MAX_I(a,b) (a > b) ? a : b
+#define MY_MAX_F(a,b) isNaN(a) ? b : isNaN(b) ? a : (a > b) ? a : b
 
-#define MY_MIN_I(a, b) (a < b) ? a : b
-#define MY_MIN_F(a, b) isNaN(a) ? b : isNaN(b) ? a : (a < b) ? a : b
+#define MY_MIN_I(a,b) (a < b) ? a : b
+#define MY_MIN_F(a,b) isNaN(a) ? b : isNaN(b) ? a : (a < b) ? a : b
 
-#define MY_INC_I(a, b) (a >= b) ? 0 : a + 1
-#define MY_DEC_I(a, b) ((a == 0) || (a > b)) ? b : a - 1
+#define MY_INC_I(a,b) (a >= b) ? 0 : a+1
+#define MY_DEC_I(a,b) ((a == 0) || (a > b)) ? b : a-1
 
-#define MY_CAS_I(a, b, c) (a == b) ? c : a
+#define MY_CAS_I(a,b,c) (a == b) ? c : a
 
-#define MY_EXCH(a, b) b
+#define MY_EXCH(a,b) b
 
-void abs_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t a, d;
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
+void abs_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   ptx_reg_t a, d;
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
 
-  unsigned i_type = pI->get_type();
-  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   unsigned i_type = pI->get_type();
+   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
 
-  switch (i_type) {
-    case S16_TYPE:
-      d.s16 = my_abs(a.s16);
-      break;
-    case S32_TYPE:
-      d.s32 = my_abs(a.s32);
-      break;
-    case S64_TYPE:
-      d.s64 = my_abs(a.s64);
-      break;
-    case U16_TYPE:
-      d.s16 = my_abs(a.u16);
-      break;
-    case U32_TYPE:
-      d.s32 = my_abs(a.u32);
-      break;
-    case U64_TYPE:
-      d.s64 = my_abs(a.u64);
-      break;
-    case F32_TYPE:
-      d.f32 = my_abs(a.f32);
-      break;
-    case F64_TYPE:
-    case FF64_TYPE:
-      d.f64 = my_abs(a.f64);
-      break;
-    default:
+
+   switch ( i_type ) {
+   case S16_TYPE: d.s16 = my_abs(a.s16); break;
+   case S32_TYPE: d.s32 = my_abs(a.s32); break;
+   case S64_TYPE: d.s64 = my_abs(a.s64); break;
+   case U16_TYPE: d.s16 = my_abs(a.u16); break;
+   case U32_TYPE: d.s32 = my_abs(a.u32); break;
+   case U64_TYPE: d.s64 = my_abs(a.u64); break;
+   case F32_TYPE: d.f32 = my_abs(a.f32); break;
+   case F64_TYPE: case FF64_TYPE: d.f64 = my_abs(a.f64); break;
+   default:
       printf("Execution error: type mismatch with instruction\n");
       assert(0);
       break;
-  }
+   }
 
-  thread->set_operand_value(dst, d, i_type, thread, pI);
+   thread->set_operand_value(dst,d, i_type, thread, pI);
 }
 
-void addp_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  // PTXPlus add instruction with carry (carry is kept in a predicate) register
-  ptx_reg_t src1_data, src2_data, src3_data, data;
-  int overflow = 0;
-  int carry = 0;
+void addp_impl( const ptx_instruction *pI, ptx_thread_info *thread )
+{
+   //PTXPlus add instruction with carry (carry is kept in a predicate) register
+   ptx_reg_t src1_data, src2_data, src3_data, data;
+   int overflow = 0;
+   int carry = 0;
 
-  const operand_info &dst =
-      pI->dst();  // get operand info of sources and destination
-  const operand_info &src1 =
-      pI->src1();  // use them to determine that they are of type 'register'
-  const operand_info &src2 = pI->src2();
-  const operand_info &src3 = pI->src3();
+   const operand_info &dst  = pI->dst();  //get operand info of sources and destination
+   const operand_info &src1 = pI->src1(); //use them to determine that they are of type 'register'
+   const operand_info &src2 = pI->src2();
+   const operand_info &src3 = pI->src3();
 
-  unsigned i_type = pI->get_type();
-  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
-  src3_data = thread->get_operand_value(src3, dst, i_type, thread, 1);
+   unsigned i_type = pI->get_type();
+   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+   src3_data = thread->get_operand_value(src3, dst, i_type, thread, 1);
 
-  unsigned rounding_mode = pI->rounding_mode();
-  int orig_rm = fegetround();
-  switch (rounding_mode) {
-    case RN_OPTION:
-      break;
-    case RZ_OPTION:
-      fesetround(FE_TOWARDZERO);
-      break;
-    default:
-      assert(0);
-      break;
-  }
+   unsigned rounding_mode = pI->rounding_mode();
+   int orig_rm = fegetround();
+   switch ( rounding_mode ) {
+   case RN_OPTION: break;
+   case RZ_OPTION: fesetround( FE_TOWARDZERO ); break;
+   default: assert(0); break;
+   }
 
-  // performs addition. Sets carry and overflow if needed.
-  // src3_data.pred&0x4 is the carry flag
-  switch (i_type) {
-    case S8_TYPE:
-      data.s64 = (src1_data.s64 & 0x0000000FF) + (src2_data.s64 & 0x0000000FF) +
-                 (src3_data.pred & 0x4);
-      if (((src1_data.s64 & 0x80) - (src2_data.s64 & 0x80)) == 0) {
-        overflow = ((src1_data.s64 & 0x80) - (data.s64 & 0x80)) == 0 ? 0 : 1;
-      }
-      carry = (data.u64 & 0x000000100) >> 8;
+   //performs addition. Sets carry and overflow if needed.
+   //src3_data.pred&0x4 is the carry flag
+   switch ( i_type ) {
+   case S8_TYPE:
+      data.s64 = (src1_data.s64 & 0x0000000FF) + (src2_data.s64 & 0x0000000FF) + (src3_data.pred & 0x4);
+      if(((src1_data.s64 & 0x80)-(src2_data.s64 & 0x80)) == 0) {overflow=((src1_data.s64 & 0x80)-(data.s64 & 0x80))==0?0:1; }
+      carry = (data.u64 & 0x000000100)>>8;
       break;
-    case S16_TYPE:
-      data.s64 = (src1_data.s64 & 0x00000FFFF) + (src2_data.s64 & 0x00000FFFF) +
-                 (src3_data.pred & 0x4);
-      if (((src1_data.s64 & 0x8000) - (src2_data.s64 & 0x8000)) == 0) {
-        overflow =
-            ((src1_data.s64 & 0x8000) - (data.s64 & 0x8000)) == 0 ? 0 : 1;
-      }
-      carry = (data.u64 & 0x000010000) >> 16;
+   case S16_TYPE:
+      data.s64 = (src1_data.s64 & 0x00000FFFF) + (src2_data.s64 & 0x00000FFFF) + (src3_data.pred & 0x4);
+      if(((src1_data.s64 & 0x8000)-(src2_data.s64 & 0x8000)) == 0) {overflow=((src1_data.s64 & 0x8000)-(data.s64 & 0x8000))==0?0:1; }
+      carry = (data.u64 & 0x000010000)>>16;
       break;
-    case S32_TYPE:
-      data.s64 = (src1_data.s64 & 0x0FFFFFFFF) + (src2_data.s64 & 0x0FFFFFFFF) +
-                 (src3_data.pred & 0x4);
-      if (((src1_data.s64 & 0x80000000) - (src2_data.s64 & 0x80000000)) == 0) {
-        overflow = ((src1_data.s64 & 0x80000000) - (data.s64 & 0x80000000)) == 0
-                       ? 0
-                       : 1;
-      }
-      carry = (data.u64 & 0x100000000) >> 32;
+   case S32_TYPE:
+      data.s64 = (src1_data.s64 & 0x0FFFFFFFF) + (src2_data.s64 & 0x0FFFFFFFF) + (src3_data.pred & 0x4);
+      if(((src1_data.s64 & 0x80000000)-(src2_data.s64 & 0x80000000)) == 0) {overflow=((src1_data.s64 & 0x80000000)-(data.s64 & 0x80000000))==0?0:1; }
+      carry = (data.u64 & 0x100000000)>>32;
       break;
-    case S64_TYPE:
+   case S64_TYPE:
       data.s64 = src1_data.s64 + src2_data.s64 + (src3_data.pred & 0x4);
       break;
-    case U8_TYPE:
-      data.u64 = (src1_data.u64 & 0xFF) + (src2_data.u64 & 0xFF) +
-                 (src3_data.pred & 0x4);
-      carry = (data.u64 & 0x100) >> 8;
+   case U8_TYPE:
+      data.u64 = (src1_data.u64 & 0xFF) + (src2_data.u64 & 0xFF) + (src3_data.pred & 0x4);
+      carry = (data.u64 & 0x100)>>8;
       break;
-    case U16_TYPE:
-      data.u64 = (src1_data.u64 & 0xFFFF) + (src2_data.u64 & 0xFFFF) +
-                 (src3_data.pred & 0x4);
-      carry = (data.u64 & 0x10000) >> 16;
+   case U16_TYPE:
+      data.u64 = (src1_data.u64 & 0xFFFF) + (src2_data.u64 & 0xFFFF) + (src3_data.pred & 0x4);
+      carry = (data.u64 & 0x10000)>>16;
       break;
-    case U32_TYPE:
-      data.u64 = (src1_data.u64 & 0xFFFFFFFF) + (src2_data.u64 & 0xFFFFFFFF) +
-                 (src3_data.pred & 0x4);
-      carry = (data.u64 & 0x100000000) >> 32;
+   case U32_TYPE:
+      data.u64 = (src1_data.u64 & 0xFFFFFFFF) + (src2_data.u64 & 0xFFFFFFFF) + (src3_data.pred & 0x4);
+      carry = (data.u64 & 0x100000000)>>32;
       break;
-    case U64_TYPE:
+   case U64_TYPE:
       data.s64 = src1_data.s64 + src2_data.s64 + (src3_data.pred & 0x4);
       break;
-    case F16_TYPE:
-      data.f16 = src1_data.f16 + src2_data.f16;
-      break;  // assert(0); break;
-    case F32_TYPE:
-      data.f32 = src1_data.f32 + src2_data.f32;
-      break;
-    case F64_TYPE:
-    case FF64_TYPE:
-      data.f64 = src1_data.f64 + src2_data.f64;
-      break;
-    default:
-      assert(0);
-      break;
-  }
-  fesetround(orig_rm);
+   case F16_TYPE: data.f16=src1_data.f16+src2_data.f16; break;//assert(0); break;
+   case F32_TYPE: data.f32 = src1_data.f32 + src2_data.f32; break;
+   case F64_TYPE: case FF64_TYPE: data.f64 = src1_data.f64 + src2_data.f64; break;
+   default: assert(0); break;
+   }
+   fesetround( orig_rm );
 
-  thread->set_operand_value(dst, data, i_type, thread, pI, overflow, carry);
+   thread->set_operand_value(dst, data, i_type, thread, pI, overflow, carry  );
 }
 
-void add_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t src1_data, src2_data, data;
-  int overflow = 0;
-  int carry = 0;
+void add_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   ptx_reg_t src1_data, src2_data, data;
+   int overflow = 0;
+   int carry = 0;
 
-  const operand_info &dst =
-      pI->dst();  // get operand info of sources and destination
-  const operand_info &src1 =
-      pI->src1();  // use them to determine that they are of type 'register'
-  const operand_info &src2 = pI->src2();
+   const operand_info &dst  = pI->dst();  //get operand info of sources and destination 
+   const operand_info &src1 = pI->src1(); //use them to determine that they are of type 'register'
+   const operand_info &src2 = pI->src2();
 
-  unsigned i_type = pI->get_type();
-  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+   unsigned i_type = pI->get_type();
+   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-  unsigned rounding_mode = pI->rounding_mode();
-  int orig_rm = fegetround();
-  switch (rounding_mode) {
-    case RN_OPTION:
-      break;
-    case RZ_OPTION:
-      fesetround(FE_TOWARDZERO);
-      break;
-    default:
-      assert(0);
-      break;
-  }
+   unsigned rounding_mode = pI->rounding_mode();
+   int orig_rm = fegetround();
+   switch ( rounding_mode ) {
+   case RN_OPTION: break;
+   case RZ_OPTION: fesetround( FE_TOWARDZERO ); break;
+   default: assert(0); break;
+   }
 
-  // performs addition. Sets carry and overflow if needed.
-  switch (i_type) {
-    case S8_TYPE:
+   //performs addition. Sets carry and overflow if needed.
+   switch ( i_type ) {
+   case S8_TYPE:
       data.s64 = (src1_data.s64 & 0x0000000FF) + (src2_data.s64 & 0x0000000FF);
-      if (((src1_data.s64 & 0x80) - (src2_data.s64 & 0x80)) == 0) {
-        overflow = ((src1_data.s64 & 0x80) - (data.s64 & 0x80)) == 0 ? 0 : 1;
-      }
-      carry = (data.u64 & 0x000000100) >> 8;
+      if(((src1_data.s64 & 0x80)-(src2_data.s64 & 0x80)) == 0) {overflow=((src1_data.s64 & 0x80)-(data.s64 & 0x80))==0?0:1; }
+      carry = (data.u64 & 0x000000100)>>8;
       break;
-    case S16_TYPE:
+   case S16_TYPE:
       data.s64 = (src1_data.s64 & 0x00000FFFF) + (src2_data.s64 & 0x00000FFFF);
-      if (((src1_data.s64 & 0x8000) - (src2_data.s64 & 0x8000)) == 0) {
-        overflow =
-            ((src1_data.s64 & 0x8000) - (data.s64 & 0x8000)) == 0 ? 0 : 1;
-      }
-      carry = (data.u64 & 0x000010000) >> 16;
+      if(((src1_data.s64 & 0x8000)-(src2_data.s64 & 0x8000)) == 0) {overflow=((src1_data.s64 & 0x8000)-(data.s64 & 0x8000))==0?0:1; }
+      carry = (data.u64 & 0x000010000)>>16;
       break;
-    case S32_TYPE:
+   case S32_TYPE:
       data.s64 = (src1_data.s64 & 0x0FFFFFFFF) + (src2_data.s64 & 0x0FFFFFFFF);
-      if (((src1_data.s64 & 0x80000000) - (src2_data.s64 & 0x80000000)) == 0) {
-        overflow = ((src1_data.s64 & 0x80000000) - (data.s64 & 0x80000000)) == 0
-                       ? 0
-                       : 1;
-      }
-      carry = (data.u64 & 0x100000000) >> 32;
+      if(((src1_data.s64 & 0x80000000)-(src2_data.s64 & 0x80000000)) == 0) {overflow=((src1_data.s64 & 0x80000000)-(data.s64 & 0x80000000))==0?0:1; }
+      carry = (data.u64 & 0x100000000)>>32;
       break;
-    case S64_TYPE:
+   case S64_TYPE:
       data.s64 = src1_data.s64 + src2_data.s64;
       break;
-    case U8_TYPE:
+   case U8_TYPE:
       data.u64 = (src1_data.u64 & 0xFF) + (src2_data.u64 & 0xFF);
-      carry = (data.u64 & 0x100) >> 8;
+      carry = (data.u64 & 0x100)>>8;
       break;
-    case U16_TYPE:
+   case U16_TYPE:
       data.u64 = (src1_data.u64 & 0xFFFF) + (src2_data.u64 & 0xFFFF);
-      carry = (data.u64 & 0x10000) >> 16;
+      carry = (data.u64 & 0x10000)>>16;
       break;
-    case U32_TYPE:
+   case U32_TYPE:
       data.u64 = (src1_data.u64 & 0xFFFFFFFF) + (src2_data.u64 & 0xFFFFFFFF);
-      carry = (data.u64 & 0x100000000) >> 32;
+      carry = (data.u64 & 0x100000000)>>32;
       break;
-    case U64_TYPE:
+   case U64_TYPE:
       data.u64 = src1_data.u64 + src2_data.u64;
       break;
-    case F16_TYPE:
-      data.f16 = src1_data.f16 + src2_data.f16;
-      break;  // assert(0); break;
-    case F32_TYPE:
-      data.f32 = src1_data.f32 + src2_data.f32;
-      break;
-    case F64_TYPE:
-    case FF64_TYPE:
-      data.f64 = src1_data.f64 + src2_data.f64;
-      break;
-    default:
-      assert(0);
-      break;
-  }
-  fesetround(orig_rm);
+   case F16_TYPE: data.f16=src1_data.f16+src2_data.f16; break;//assert(0); break;
+   case F32_TYPE: data.f32 = src1_data.f32 + src2_data.f32; break;
+   case F64_TYPE: case FF64_TYPE: data.f64 = src1_data.f64 + src2_data.f64; break;
+   default: assert(0); break;
+   }
+   fesetround( orig_rm );
 
-  thread->set_operand_value(dst, data, i_type, thread, pI, overflow, carry);
+   thread->set_operand_value(dst, data, i_type, thread, pI, overflow, carry  );
 }
 
-void addc_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  inst_not_implemented(pI);
+void addc_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
+
+void and_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   ptx_reg_t src1_data, src2_data, data;
+
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
+   const operand_info &src2 = pI->src2();
+
+   unsigned i_type = pI->get_type();
+   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+
+
+   //the way ptxplus handles predicates: 1 = false and 0 = true
+   if(i_type == PRED_TYPE)
+      data.pred = ~(~(src1_data.pred) & ~(src2_data.pred));
+   else
+      data.u64 = src1_data.u64 & src2_data.u64;
+
+   thread->set_operand_value(dst,data, i_type, thread, pI);
 }
 
-void and_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t src1_data, src2_data, data;
+void andn_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   ptx_reg_t src1_data, src2_data, data;
 
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  const operand_info &src2 = pI->src2();
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
+   const operand_info &src2 = pI->src2();
 
-  unsigned i_type = pI->get_type();
-  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+   unsigned i_type = pI->get_type();
+   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-  // the way ptxplus handles predicates: 1 = false and 0 = true
-  if (i_type == PRED_TYPE)
-    data.pred = ~(~(src1_data.pred) & ~(src2_data.pred));
-  else
-    data.u64 = src1_data.u64 & src2_data.u64;
-
-  thread->set_operand_value(dst, data, i_type, thread, pI);
-}
-
-void andn_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t src1_data, src2_data, data;
-
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  const operand_info &src2 = pI->src2();
-
-  unsigned i_type = pI->get_type();
-  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
-
-  switch (i_type) {
-    case B16_TYPE:
-      src2_data.u16 = ~src2_data.u16;
-      break;
-    case B32_TYPE:
-      src2_data.u32 = ~src2_data.u32;
-      break;
-    case B64_TYPE:
-      src2_data.u64 = ~src2_data.u64;
-      break;
-    default:
+   switch ( i_type ) {
+   case B16_TYPE:  src2_data.u16  = ~src2_data.u16; break;
+   case B32_TYPE:  src2_data.u32  = ~src2_data.u32; break;
+   case B64_TYPE:  src2_data.u64  = ~src2_data.u64; break;
+   default:
       printf("Execution error: type mismatch with instruction\n");
+      assert(0); 
+      break;
+   }
+
+   data.u64 = src1_data.u64 & src2_data.u64;
+
+   thread->set_operand_value(dst,data, i_type, thread, pI);
+}
+
+void bar_callback( const inst_t* inst, ptx_thread_info* thread)
+{
+	unsigned ctaid = thread->get_cta_uid();
+	unsigned barid = inst->bar_id;
+	unsigned value = thread->get_reduction_value(ctaid,barid);
+	const ptx_instruction *pI = dynamic_cast<const ptx_instruction*>(inst);
+	const operand_info &dst  = pI->dst();
+	ptx_reg_t data;
+	data.u32 = value;
+	thread->set_operand_value(dst,value, U32_TYPE, thread, pI);
+}
+
+void atom_callback( const inst_t* inst, ptx_thread_info* thread)
+{
+   const ptx_instruction *pI = dynamic_cast<const ptx_instruction*>(inst);
+
+   // "Decode" the output type
+   unsigned to_type = pI->get_type();
+   size_t size;
+   int t;
+   type_info_key::type_decode(to_type, size, t);
+
+   // Set up operand variables
+   ptx_reg_t data;        // d
+   ptx_reg_t src1_data;   // a
+   ptx_reg_t src2_data;   // b
+   ptx_reg_t op_result;   // temp variable to hold operation result
+
+   bool data_ready = false;
+
+   // Get operand info of sources and destination
+   const operand_info &dst  = pI->dst();     // d
+   const operand_info &src1 = pI->src1();    // a
+   const operand_info &src2 = pI->src2();    // b
+
+   // Get operand values
+   src1_data = thread->get_operand_value(src1, src1, to_type, thread, 1);        // a
+   if (dst.get_symbol()->type()){
+      src2_data = thread->get_operand_value(src2, dst, to_type, thread, 1);      // b
+   } else {
+	   //This is the case whent he first argument (dest) is '_'
+      src2_data = thread->get_operand_value(src2, src1, to_type, thread, 1);     // b
+   }
+
+   // Check state space
+   addr_t effective_address = src1_data.u64;  
+   memory_space_t space = pI->get_space();
+   if (space == undefined_space) {
+      // generic space - determine space via address
+      if( whichspace(effective_address) == global_space ) {
+         effective_address = generic_to_global(effective_address);
+         space = global_space;
+      } else if( whichspace(effective_address) == shared_space ) {
+         unsigned smid = thread->get_hw_sid();
+         effective_address = generic_to_shared(smid,effective_address);
+         space = shared_space;
+      } else {
+         abort();
+      }
+   } 
+   assert( space == global_space || space == shared_space );
+
+   memory_space *mem = NULL;
+   if(space == global_space)
+       mem = thread->get_global_memory();
+   else if(space == shared_space)
+       mem = thread->m_shared_mem;
+   else
+       abort();
+
+   // Copy value pointed to in operand 'a' into register 'd'
+   // (i.e. copy src1_data to dst)
+   mem->read(effective_address,size/8,&data.s64);
+   if (dst.get_symbol()->type()){
+	   thread->set_operand_value(dst, data, to_type, thread, pI);                         // Write value into register 'd'
+   }
+
+   // Get the atomic operation to be performed
+   unsigned m_atomic_spec = pI->get_atomic();
+
+   switch ( m_atomic_spec ) {
+   // AND
+   case ATOMIC_AND:
+      {
+
+         switch ( to_type ) {
+         case B32_TYPE:
+         case U32_TYPE:
+            op_result.u32 = data.u32 & src2_data.u32;
+            data_ready = true;
+            break;
+         case S32_TYPE:
+            op_result.s32 = data.s32 & src2_data.s32;
+            data_ready = true;
+            break;
+         default:
+            printf("Execution error: type mismatch (%x) with instruction\natom.AND only accepts b32\n", to_type);
+            assert(0);
+            break;
+         }
+
+         break;
+      }
+      // OR
+   case ATOMIC_OR:
+      {
+
+         switch ( to_type ) {
+         case B32_TYPE:
+         case U32_TYPE:
+            op_result.u32 = data.u32 | src2_data.u32;
+            data_ready = true;
+            break;
+         case S32_TYPE:
+            op_result.s32 = data.s32 | src2_data.s32;
+            data_ready = true;
+            break;
+         default:
+            printf("Execution error: type mismatch (%x) with instruction\natom.OR only accepts b32\n", to_type);
+            assert(0);
+            break;
+         }
+
+         break;
+      }
+      // XOR
+   case ATOMIC_XOR:
+      {
+
+         switch ( to_type ) {
+         case B32_TYPE:
+         case U32_TYPE:
+            op_result.u32 = data.u32 ^ src2_data.u32;
+            data_ready = true;
+            break;
+         case S32_TYPE:
+            op_result.s32 = data.s32 ^ src2_data.s32;
+            data_ready = true;
+            break;
+         default:
+            printf("Execution error: type mismatch (%x) with instruction\natom.XOR only accepts b32\n", to_type);
+            assert(0);
+            break;
+         }
+
+         break;
+      }
+      // CAS
+   case ATOMIC_CAS:
+      {
+
+         ptx_reg_t src3_data;
+         const operand_info &src3 = pI->src3();
+         src3_data = thread->get_operand_value(src3, dst, to_type, thread, 1);
+
+         switch ( to_type ) {
+         case B32_TYPE:
+         case U32_TYPE:
+            op_result.u32 = MY_CAS_I(data.u32, src2_data.u32, src3_data.u32);
+            data_ready = true;
+            break;
+         case B64_TYPE:
+         case U64_TYPE:
+            op_result.u64 = MY_CAS_I(data.u64, src2_data.u64, src3_data.u64);
+            data_ready = true;
+            break;
+         case S32_TYPE:
+            op_result.s32 = MY_CAS_I(data.s32, src2_data.s32, src3_data.s32);
+            data_ready = true;
+            break;
+         default:
+            printf("Execution error: type mismatch (%x) with instruction\natom.CAS only accepts b32 and b64\n", to_type);
+            assert(0);
+            break;
+         }
+
+         break;
+      }
+      // EXCH
+   case ATOMIC_EXCH:
+      {
+         switch ( to_type ) {
+         case B32_TYPE:
+         case U32_TYPE:
+            op_result.u32 = MY_EXCH(data.u32, src2_data.u32);
+            data_ready = true;
+            break;
+         case B64_TYPE:
+         case U64_TYPE:
+            op_result.u64 = MY_EXCH(data.u64, src2_data.u64);
+            data_ready = true;
+            break;
+         case S32_TYPE:
+            op_result.s32 = MY_EXCH(data.s32, src2_data.s32);
+            data_ready = true;
+            break;
+         default:
+            printf("Execution error: type mismatch (%x) with instruction\natom.EXCH only accepts b32\n", to_type);
+            assert(0);
+            break;
+         }
+
+         break;
+      }
+      // ADD
+   case ATOMIC_ADD:
+      {
+
+         switch ( to_type ) {
+         case U32_TYPE:
+            op_result.u32 = data.u32 + src2_data.u32;
+            data_ready = true;
+            break;
+         case S32_TYPE:
+            op_result.s32 = data.s32 + src2_data.s32;
+            data_ready = true;
+            break;
+         case U64_TYPE: 
+            op_result.u64 = data.u64 + src2_data.u64; 
+            data_ready = true; 
+            break; 
+         case F32_TYPE: 
+            op_result.f32 = data.f32 + src2_data.f32; 
+            data_ready = true; 
+            break; 
+         default:
+            printf("Execution error: type mismatch with instruction\natom.ADD only accepts u32, s32, u64, and f32\n");
+            assert(0);
+            break;
+         }
+
+         break;
+      }
+      // INC
+   case ATOMIC_INC:
+      {
+         switch ( to_type ) {
+         case U32_TYPE: 
+            op_result.u32 = MY_INC_I(data.u32, src2_data.u32);
+            data_ready = true;
+            break;
+         default:
+            printf("Execution error: type mismatch with instruction\natom.INC only accepts u32 and s32\n");
+            assert(0);
+            break;
+         }
+
+         break;
+      }
+      // DEC
+   case ATOMIC_DEC:
+      {
+         switch ( to_type ) {
+         case U32_TYPE: 
+            op_result.u32 = MY_DEC_I(data.u32, src2_data.u32);
+            data_ready = true;
+            break;
+         default:
+            printf("Execution error: type mismatch with instruction\natom.DEC only accepts u32 and s32\n");
+            assert(0);
+            break;
+         }
+
+         break;
+      }
+      // MIN
+   case ATOMIC_MIN:
+      {
+         switch ( to_type ) {
+         case U32_TYPE: 
+            op_result.u32 = MY_MIN_I(data.u32, src2_data.u32);
+            data_ready = true;
+            break;
+         case S32_TYPE:
+            op_result.s32 = MY_MIN_I(data.s32, src2_data.s32);
+            data_ready = true;
+            break;
+         default:
+            printf("Execution error: type mismatch with instruction\natom.MIN only accepts u32 and s32\n");
+            assert(0);
+            break;
+         }
+
+         break;
+      }
+      // MAX
+   case ATOMIC_MAX:
+      {
+         switch ( to_type ) {
+         case U32_TYPE:
+            op_result.u32 = MY_MAX_I(data.u32, src2_data.u32);
+            data_ready = true;
+            break;
+         case S32_TYPE:
+            op_result.s32 = MY_MAX_I(data.s32, src2_data.s32);
+            data_ready = true;
+            break;
+         default:
+            printf("Execution error: type mismatch with instruction\natom.MAX only accepts u32 and s32\n");
+            assert(0);
+            break;
+         }
+
+         break;
+      }
+      // DEFAULT
+   default:
+      {
+         assert(0);
+         break;
+      }
+   }
+
+   // Write operation result into  memory
+   // (i.e. copy src1_data to dst)
+   if ( data_ready ) {
+      mem->write(effective_address,size/8,&op_result.s64,thread,pI);
+   } else {
+      printf("Execution error: data_ready not set\n");
       assert(0);
-      break;
-  }
-
-  data.u64 = src1_data.u64 & src2_data.u64;
-
-  thread->set_operand_value(dst, data, i_type, thread, pI);
+   }
 }
 
-void bar_callback(const inst_t *inst, ptx_thread_info *thread) {
-  unsigned ctaid = thread->get_cta_uid();
-  unsigned barid = inst->bar_id;
-  unsigned value = thread->get_reduction_value(ctaid, barid);
-  const ptx_instruction *pI = dynamic_cast<const ptx_instruction *>(inst);
-  const operand_info &dst = pI->dst();
-  ptx_reg_t data;
-  data.u32 = value;
-  thread->set_operand_value(dst, value, U32_TYPE, thread, pI);
-}
+// atom_impl will now result in a callback being called in mem_ctrl_pop (gpu-sim.c)
+void atom_impl( const ptx_instruction *pI, ptx_thread_info *thread )
+{   
+   // SYNTAX
+   // atom.space.operation.type d, a, b[, c]; (now read in callback)
 
-void atom_callback(const inst_t *inst, ptx_thread_info *thread) {
-  const ptx_instruction *pI = dynamic_cast<const ptx_instruction *>(inst);
+   // obtain memory space of the operation 
+   memory_space_t space = pI->get_space(); 
 
-  // "Decode" the output type
-  unsigned to_type = pI->get_type();
-  size_t size;
-  int t;
-  type_info_key::type_decode(to_type, size, t);
+   // get the memory address
+   const operand_info &src1 = pI->src1();
+   // const operand_info &dst  = pI->dst();  // not needed for effective address calculation 
+   unsigned i_type = pI->get_type();
+   ptx_reg_t src1_data;
+   src1_data = thread->get_operand_value(src1, src1, i_type, thread, 1);
+   addr_t effective_address = src1_data.u64; 
 
-  // Set up operand variables
-  ptx_reg_t data;       // d
-  ptx_reg_t src1_data;  // a
-  ptx_reg_t src2_data;  // b
-  ptx_reg_t op_result;  // temp variable to hold operation result
+   addr_t effective_address_final; 
 
-  bool data_ready = false;
-
-  // Get operand info of sources and destination
-  const operand_info &dst = pI->dst();    // d
-  const operand_info &src1 = pI->src1();  // a
-  const operand_info &src2 = pI->src2();  // b
-
-  // Get operand values
-  src1_data = thread->get_operand_value(src1, src1, to_type, thread, 1);  // a
-  if (dst.get_symbol()->type()) {
-    src2_data = thread->get_operand_value(src2, dst, to_type, thread, 1);  // b
-  } else {
-    // This is the case whent he first argument (dest) is '_'
-    src2_data = thread->get_operand_value(src2, src1, to_type, thread, 1);  // b
-  }
-
-  // Check state space
-  addr_t effective_address = src1_data.u64;
-  memory_space_t space = pI->get_space();
-  if (space == undefined_space) {
-    // generic space - determine space via address
-    if (whichspace(effective_address) == global_space) {
-      effective_address = generic_to_global(effective_address);
-      space = global_space;
-    } else if (whichspace(effective_address) == shared_space) {
-      unsigned smid = thread->get_hw_sid();
-      effective_address = generic_to_shared(smid, effective_address);
-      space = shared_space;
-    } else {
-      abort();
-    }
-  }
-  assert(space == global_space || space == shared_space);
-
-  memory_space *mem = NULL;
-  if (space == global_space)
-    mem = thread->get_global_memory();
-  else if (space == shared_space)
-    mem = thread->m_shared_mem;
-  else
-    abort();
-
-  // Copy value pointed to in operand 'a' into register 'd'
-  // (i.e. copy src1_data to dst)
-  mem->read(effective_address, size / 8, &data.s64);
-  if (dst.get_symbol()->type()) {
-    thread->set_operand_value(dst, data, to_type, thread,
-                              pI);  // Write value into register 'd'
-  }
-
-  // Get the atomic operation to be performed
-  unsigned m_atomic_spec = pI->get_atomic();
-
-  switch (m_atomic_spec) {
-    // AND
-    case ATOMIC_AND: {
-      switch (to_type) {
-        case B32_TYPE:
-        case U32_TYPE:
-          op_result.u32 = data.u32 & src2_data.u32;
-          data_ready = true;
-          break;
-        case S32_TYPE:
-          op_result.s32 = data.s32 & src2_data.s32;
-          data_ready = true;
-          break;
-        default:
-          printf(
-              "Execution error: type mismatch (%x) with instruction\natom.AND "
-              "only accepts b32\n",
-              to_type);
-          assert(0);
-          break;
-      }
-
-      break;
-    }
-    // OR
-    case ATOMIC_OR: {
-      switch (to_type) {
-        case B32_TYPE:
-        case U32_TYPE:
-          op_result.u32 = data.u32 | src2_data.u32;
-          data_ready = true;
-          break;
-        case S32_TYPE:
-          op_result.s32 = data.s32 | src2_data.s32;
-          data_ready = true;
-          break;
-        default:
-          printf(
-              "Execution error: type mismatch (%x) with instruction\natom.OR "
-              "only accepts b32\n",
-              to_type);
-          assert(0);
-          break;
-      }
-
-      break;
-    }
-    // XOR
-    case ATOMIC_XOR: {
-      switch (to_type) {
-        case B32_TYPE:
-        case U32_TYPE:
-          op_result.u32 = data.u32 ^ src2_data.u32;
-          data_ready = true;
-          break;
-        case S32_TYPE:
-          op_result.s32 = data.s32 ^ src2_data.s32;
-          data_ready = true;
-          break;
-        default:
-          printf(
-              "Execution error: type mismatch (%x) with instruction\natom.XOR "
-              "only accepts b32\n",
-              to_type);
-          assert(0);
-          break;
-      }
-
-      break;
-    }
-    // CAS
-    case ATOMIC_CAS: {
-      ptx_reg_t src3_data;
-      const operand_info &src3 = pI->src3();
-      src3_data = thread->get_operand_value(src3, dst, to_type, thread, 1);
-
-      switch (to_type) {
-        case B32_TYPE:
-        case U32_TYPE:
-          op_result.u32 = MY_CAS_I(data.u32, src2_data.u32, src3_data.u32);
-          data_ready = true;
-          break;
-        case B64_TYPE:
-        case U64_TYPE:
-          op_result.u64 = MY_CAS_I(data.u64, src2_data.u64, src3_data.u64);
-          data_ready = true;
-          break;
-        case S32_TYPE:
-          op_result.s32 = MY_CAS_I(data.s32, src2_data.s32, src3_data.s32);
-          data_ready = true;
-          break;
-        default:
-          printf(
-              "Execution error: type mismatch (%x) with instruction\natom.CAS "
-              "only accepts b32 and b64\n",
-              to_type);
-          assert(0);
-          break;
-      }
-
-      break;
-    }
-    // EXCH
-    case ATOMIC_EXCH: {
-      switch (to_type) {
-        case B32_TYPE:
-        case U32_TYPE:
-          op_result.u32 = MY_EXCH(data.u32, src2_data.u32);
-          data_ready = true;
-          break;
-        case B64_TYPE:
-        case U64_TYPE:
-          op_result.u64 = MY_EXCH(data.u64, src2_data.u64);
-          data_ready = true;
-          break;
-        case S32_TYPE:
-          op_result.s32 = MY_EXCH(data.s32, src2_data.s32);
-          data_ready = true;
-          break;
-        default:
-          printf(
-              "Execution error: type mismatch (%x) with instruction\natom.EXCH "
-              "only accepts b32\n",
-              to_type);
-          assert(0);
-          break;
-      }
-
-      break;
-    }
-    // ADD
-    case ATOMIC_ADD: {
-      switch (to_type) {
-        case U32_TYPE:
-          op_result.u32 = data.u32 + src2_data.u32;
-          data_ready = true;
-          break;
-        case S32_TYPE:
-          op_result.s32 = data.s32 + src2_data.s32;
-          data_ready = true;
-          break;
-        case U64_TYPE:
-          op_result.u64 = data.u64 + src2_data.u64;
-          data_ready = true;
-          break;
-        case F32_TYPE:
-          op_result.f32 = data.f32 + src2_data.f32;
-          data_ready = true;
-          break;
-        default:
-          printf(
-              "Execution error: type mismatch with instruction\natom.ADD only "
-              "accepts u32, s32, u64, and f32\n");
-          assert(0);
-          break;
-      }
-
-      break;
-    }
-    // INC
-    case ATOMIC_INC: {
-      switch (to_type) {
-        case U32_TYPE:
-          op_result.u32 = MY_INC_I(data.u32, src2_data.u32);
-          data_ready = true;
-          break;
-        default:
-          printf(
-              "Execution error: type mismatch with instruction\natom.INC only "
-              "accepts u32 and s32\n");
-          assert(0);
-          break;
-      }
-
-      break;
-    }
-    // DEC
-    case ATOMIC_DEC: {
-      switch (to_type) {
-        case U32_TYPE:
-          op_result.u32 = MY_DEC_I(data.u32, src2_data.u32);
-          data_ready = true;
-          break;
-        default:
-          printf(
-              "Execution error: type mismatch with instruction\natom.DEC only "
-              "accepts u32 and s32\n");
-          assert(0);
-          break;
-      }
-
-      break;
-    }
-    // MIN
-    case ATOMIC_MIN: {
-      switch (to_type) {
-        case U32_TYPE:
-          op_result.u32 = MY_MIN_I(data.u32, src2_data.u32);
-          data_ready = true;
-          break;
-        case S32_TYPE:
-          op_result.s32 = MY_MIN_I(data.s32, src2_data.s32);
-          data_ready = true;
-          break;
-        default:
-          printf(
-              "Execution error: type mismatch with instruction\natom.MIN only "
-              "accepts u32 and s32\n");
-          assert(0);
-          break;
-      }
-
-      break;
-    }
-    // MAX
-    case ATOMIC_MAX: {
-      switch (to_type) {
-        case U32_TYPE:
-          op_result.u32 = MY_MAX_I(data.u32, src2_data.u32);
-          data_ready = true;
-          break;
-        case S32_TYPE:
-          op_result.s32 = MY_MAX_I(data.s32, src2_data.s32);
-          data_ready = true;
-          break;
-        default:
-          printf(
-              "Execution error: type mismatch with instruction\natom.MAX only "
-              "accepts u32 and s32\n");
-          assert(0);
-          break;
-      }
-
-      break;
-    }
-    // DEFAULT
-    default: {
-      assert(0);
-      break;
-    }
-  }
-
-  // Write operation result into  memory
-  // (i.e. copy src1_data to dst)
-  if (data_ready) {
-    mem->write(effective_address, size / 8, &op_result.s64, thread, pI);
-  } else {
-    printf("Execution error: data_ready not set\n");
-    assert(0);
-  }
-}
-
-// atom_impl will now result in a callback being called in mem_ctrl_pop
-// (gpu-sim.c)
-void atom_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  // SYNTAX
-  // atom.space.operation.type d, a, b[, c]; (now read in callback)
-
-  // obtain memory space of the operation
-  memory_space_t space = pI->get_space();
-
-  // get the memory address
-  const operand_info &src1 = pI->src1();
-  // const operand_info &dst  = pI->dst();  // not needed for effective address
-  // calculation
-  unsigned i_type = pI->get_type();
-  ptx_reg_t src1_data;
-  src1_data = thread->get_operand_value(src1, src1, i_type, thread, 1);
-  addr_t effective_address = src1_data.u64;
-
-  addr_t effective_address_final;
-
-  // handle generic memory space by converting it to global
-  if (space == undefined_space) {
-    if (whichspace(effective_address) == global_space) {
-      effective_address_final = generic_to_global(effective_address);
-      space = global_space;
-    } else if (whichspace(effective_address) == shared_space) {
-      unsigned smid = thread->get_hw_sid();
-      effective_address_final = generic_to_shared(smid, effective_address);
-      space = shared_space;
-    } else {
-      abort();
-    }
-  } else {
-    assert(space == global_space || space == shared_space);
-    effective_address_final = effective_address;
-  }
-
-  // Check state space
-  assert(space == global_space || space == shared_space);
-
-  thread->m_last_effective_address = effective_address_final;
-  thread->m_last_memory_space = space;
-  thread->m_last_dram_callback.function = atom_callback;
-  thread->m_last_dram_callback.instruction = pI;
-}
-
-void bar_impl(const ptx_instruction *pIin, ptx_thread_info *thread) {
-  ptx_instruction *pI = const_cast<ptx_instruction *>(pIin);
-  unsigned bar_op = pI->barrier_op();
-  unsigned red_op = pI->get_atomic();
-  unsigned ctaid = thread->get_cta_uid();
-
-  switch (bar_op) {
-    case SYNC_OPTION: {
-      if (pI->get_num_operands() > 1) {
-        const operand_info &op0 = pI->dst();
-        const operand_info &op1 = pI->src1();
-        ptx_reg_t op0_data;
-        ptx_reg_t op1_data;
-        op0_data = thread->get_operand_value(op0, op0, U32_TYPE, thread, 1);
-        op1_data = thread->get_operand_value(op1, op1, U32_TYPE, thread, 1);
-        pI->set_bar_id(op0_data.u32);
-        pI->set_bar_count(op1_data.u32);
+   // handle generic memory space by converting it to global 
+   if ( space == undefined_space ) {
+      if( whichspace(effective_address) == global_space ) {
+         effective_address_final = generic_to_global(effective_address);
+         space = global_space;
+      } else if( whichspace(effective_address) == shared_space ) {
+         unsigned smid = thread->get_hw_sid();
+         effective_address_final = generic_to_shared(smid,effective_address);
+         space = shared_space;
       } else {
-        const operand_info &op0 = pI->dst();
-        ptx_reg_t op0_data;
-        op0_data = thread->get_operand_value(op0, op0, U32_TYPE, thread, 1);
-        pI->set_bar_id(op0_data.u32);
+         abort();
       }
-      break;
-    }
-    case ARRIVE_OPTION: {
-      const operand_info &op0 = pI->dst();
-      const operand_info &op1 = pI->src1();
-      ptx_reg_t op0_data;
-      ptx_reg_t op1_data;
-      op0_data = thread->get_operand_value(op0, op0, U32_TYPE, thread, 1);
-      op1_data = thread->get_operand_value(op1, op1, U32_TYPE, thread, 1);
-      pI->set_bar_id(op0_data.u32);
-      pI->set_bar_count(op1_data.u32);
-      break;
-    }
-    case RED_OPTION: {
-      if (pI->get_num_operands() > 3) {
-        const operand_info &op1 = pI->src1();
-        const operand_info &op2 = pI->src2();
-        const operand_info &op3 = pI->src3();
-        ptx_reg_t op1_data;
-        ptx_reg_t op2_data;
-        ptx_reg_t op3_data;
-        op1_data = thread->get_operand_value(op1, op1, U32_TYPE, thread, 1);
-        op2_data = thread->get_operand_value(op2, op2, U32_TYPE, thread, 1);
-        op3_data = thread->get_operand_value(op3, op3, PRED_TYPE, thread, 1);
-        op3_data.u32 = !(op3_data.pred & 0x0001);
-        pI->set_bar_id(op1_data.u32);
-        pI->set_bar_count(op2_data.u32);
-        switch (red_op) {
-          case ATOMIC_POPC:
-            thread->popc_reduction(ctaid, op1_data.u32, op3_data.u32);
-            break;
-          case ATOMIC_AND:
-            thread->and_reduction(ctaid, op1_data.u32, op3_data.u32);
-            break;
-          case ATOMIC_OR:
-            thread->or_reduction(ctaid, op1_data.u32, op3_data.u32);
-            break;
-          default:
-            abort();
-            break;
-        }
-      } else {
-        const operand_info &op1 = pI->src1();
-        const operand_info &op2 = pI->src2();
-        ptx_reg_t op1_data;
-        ptx_reg_t op2_data;
-        op1_data = thread->get_operand_value(op1, op1, U32_TYPE, thread, 1);
-        op2_data = thread->get_operand_value(op2, op2, PRED_TYPE, thread, 1);
-        op2_data.u32 = !(op2_data.pred & 0x0001);
-        pI->set_bar_id(op1_data.u32);
-        pI->set_bar_count(thread->get_ntid().x * thread->get_ntid().y *
-                          thread->get_ntid().z);
-        switch (red_op) {
-          case ATOMIC_POPC:
-            thread->popc_reduction(ctaid, op1_data.u32, op2_data.u32);
-            break;
-          case ATOMIC_AND:
-            thread->and_reduction(ctaid, op1_data.u32, op2_data.u32);
-            break;
-          case ATOMIC_OR:
-            thread->or_reduction(ctaid, op1_data.u32, op2_data.u32);
-            break;
-          default:
-            abort();
-            break;
-        }
-      }
-      break;
-    }
-    default:
-      abort();
-      break;
-  }
+   } else {
+      assert( space == global_space || space == shared_space );
+      effective_address_final = effective_address; 
+   }
 
-  thread->m_last_dram_callback.function = bar_callback;
-  thread->m_last_dram_callback.instruction = pIin;
+   // Check state space
+   assert( space == global_space || space == shared_space );
+
+   thread->m_last_effective_address = effective_address_final;
+   thread->m_last_memory_space = space;
+   thread->m_last_dram_callback.function = atom_callback;
+   thread->m_last_dram_callback.instruction = pI; 
 }
 
-void bfe_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  unsigned i_type = pI->get_type();
-  unsigned msb = (i_type == U32_TYPE || i_type == S32_TYPE) ? 31 : 63;
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  const operand_info &src2 = pI->src2();
-  const operand_info &src3 = pI->src3();
-  ptx_reg_t src = thread->get_operand_value(src1, dst, i_type, thread, 1);
-  ptx_reg_t b = thread->get_operand_value(src2, dst, i_type, thread, 1);
-  ptx_reg_t c = thread->get_operand_value(src3, dst, i_type, thread, 1);
-  ptx_reg_t data;
-  unsigned pos = b.u32 & 0xFF;
-  unsigned len = c.u32 & 0xFF;
-  switch (i_type) {
-    case U32_TYPE: {
-      unsigned mask;
-      data.u32 = src.u32 >> pos;
-      mask = 0xFFFFFFFF >> (32 - len);
-      data.u32 &= mask;
-      break;
-    }
-    case U64_TYPE: {
-      unsigned long mask;
-      data.u64 = src.u64 >> pos;
-      mask = 0xFFFFFFFFFFFFFFFF >> (64 - len);
-      data.u64 &= mask;
-      break;
-    }
-    case S32_TYPE: {
-      unsigned mask;
-      unsigned min = MY_MIN_I(pos + len - 1, msb);
-      unsigned sbit = len == 0 ? 0 : (src.s32 >> min) & 0x1;
-      data.s32 = src.s32 >> pos;
-      if (sbit > 0) {
-        mask = 0xFFFFFFFF << len;
-        data.s32 |= mask;
-      } else {
-        mask = 0xFFFFFFFF >> (32 - len);
-        data.s32 &= mask;
-      }
-      break;
-    }
-    case S64_TYPE: {
-      unsigned long mask;
-      unsigned min = MY_MIN_I(pos + len - 1, msb);
-      unsigned sbit = len == 0 ? 0 : (src.s64 >> min) & 0x1;
-      data.s64 = src.s64 >> pos;
-      if (sbit > 0) {
-        mask = 0xFFFFFFFFFFFFFFFF << len;
-        data.s64 |= mask;
-      } else {
-        mask = 0xFFFFFFFFFFFFFFFF >> (64 - len);
-        data.s64 &= mask;
-      }
-      break;
-    }
-    default:
-      printf("Operand type not supported for BFE instruction.\n");
-      abort();
-      return;
-  }
-  thread->set_operand_value(dst, data, i_type, thread, pI);
+void bar_impl( const ptx_instruction *pIin, ptx_thread_info *thread )
+{ 
+   ptx_instruction * pI = const_cast<ptx_instruction *>(pIin);
+   unsigned bar_op = pI->barrier_op();
+   unsigned red_op = pI->get_atomic();
+   unsigned ctaid = thread->get_cta_uid();
+
+   switch(bar_op){
+   	   case SYNC_OPTION:
+   	   {
+   		   if(pI->get_num_operands()>1){
+   			   const operand_info &op0 = pI->dst();
+   			   const operand_info &op1 = pI->src1();
+   			   ptx_reg_t op0_data;
+   			   ptx_reg_t op1_data;
+   			   op0_data = thread->get_operand_value(op0, op0, U32_TYPE, thread, 1);
+   			   op1_data = thread->get_operand_value(op1, op1, U32_TYPE, thread, 1);
+   			   pI->set_bar_id(op0_data.u32);
+   			   pI->set_bar_count(op1_data.u32);
+   		   }else{
+   			   const operand_info &op0 = pI->dst();
+   			   ptx_reg_t op0_data;
+   			   op0_data = thread->get_operand_value(op0, op0, U32_TYPE, thread, 1);
+   			   pI->set_bar_id(op0_data.u32);
+   		   }
+   		   break;
+   	   }
+   	   case ARRIVE_OPTION:
+   	   {
+			   const operand_info &op0 = pI->dst();
+			   const operand_info &op1 = pI->src1();
+			   ptx_reg_t op0_data;
+			   ptx_reg_t op1_data;
+			   op0_data = thread->get_operand_value(op0, op0, U32_TYPE, thread, 1);
+			   op1_data = thread->get_operand_value(op1, op1, U32_TYPE, thread, 1);
+   			   pI->set_bar_id(op0_data.u32);
+   			   pI->set_bar_count(op1_data.u32);
+   		   break;
+   	   }
+   	   case RED_OPTION:
+   	   {
+   		   if(pI->get_num_operands()>3){
+   			   const operand_info &op1 = pI->src1();
+   			   const operand_info &op2 = pI->src2();
+   			   const operand_info &op3 = pI->src3();
+   			   ptx_reg_t op1_data;
+   			   ptx_reg_t op2_data;
+   			   ptx_reg_t op3_data;
+   			   op1_data = thread->get_operand_value(op1, op1, U32_TYPE, thread, 1);
+   			   op2_data = thread->get_operand_value(op2, op2, U32_TYPE, thread, 1);
+   			   op3_data = thread->get_operand_value(op3, op3, PRED_TYPE, thread, 1);
+   			   op3_data.u32=!(op3_data.pred & 0x0001);
+   			   pI->set_bar_id(op1_data.u32);
+   			   pI->set_bar_count(op2_data.u32);
+   			   switch(red_op){
+   			   	   case ATOMIC_POPC:
+   			   		   thread->popc_reduction(ctaid,op1_data.u32,op3_data.u32);
+   			   		   break;
+   			   	   case ATOMIC_AND:
+   			   		   thread->and_reduction(ctaid,op1_data.u32,op3_data.u32);
+   			   		   break;
+   			   	   case ATOMIC_OR:
+   			   		   thread->or_reduction(ctaid,op1_data.u32,op3_data.u32);
+   			   		   break;
+   			   	   default:
+   			   		   abort();
+   			   		   break;
+   			   }
+   		   }else{
+   			   const operand_info &op1 = pI->src1();
+   			   const operand_info &op2 = pI->src2();
+   			   ptx_reg_t op1_data;
+   			   ptx_reg_t op2_data;
+   			   op1_data = thread->get_operand_value(op1, op1, U32_TYPE, thread, 1);
+   			   op2_data = thread->get_operand_value(op2, op2, PRED_TYPE, thread, 1);
+               op2_data.u32=!(op2_data.pred & 0x0001);
+   			   pI->set_bar_id(op1_data.u32);
+			   pI->set_bar_count(thread->get_ntid().x * thread->get_ntid().y * thread->get_ntid().z);
+   			   switch(red_op){
+   			   	   case ATOMIC_POPC:
+   			   		   thread->popc_reduction(ctaid,op1_data.u32,op2_data.u32);
+   			   		   break;
+   			   	   case ATOMIC_AND:
+   			   		   thread->and_reduction(ctaid,op1_data.u32,op2_data.u32);
+   			   		   break;
+   			   	   case ATOMIC_OR:
+   			   		   thread->or_reduction(ctaid,op1_data.u32,op2_data.u32);
+   			   		   break;
+   			   	   default:
+   			   		   abort();
+   			   		   break;
+   			   }
+   		   }
+   		   break;
+   	   }
+   	   default:
+   		   abort();
+   		   break;
+   }
+
+   thread->m_last_dram_callback.function = bar_callback;
+   thread->m_last_dram_callback.instruction = pIin;
 }
 
-void bfi_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  int i, max;
-  ptx_reg_t src1_data, src2_data;
-  ptx_reg_t src3_data, src4_data, data;
+void bfe_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+	unsigned i_type = pI->get_type();
+	unsigned msb = (i_type == U32_TYPE || i_type == S32_TYPE) ? 31 : 63;
+    const operand_info &dst  = pI->dst();
+    const operand_info &src1 = pI->src1();
+    const operand_info &src2 = pI->src2();
+    const operand_info &src3 = pI->src3();
+    ptx_reg_t src = thread->get_operand_value(src1, dst, i_type, thread, 1);
+    ptx_reg_t b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+    ptx_reg_t c = thread->get_operand_value(src3, dst, i_type, thread, 1);
+    ptx_reg_t data;
+	unsigned pos = b.u32 & 0xFF;
+	unsigned len = c.u32 & 0xFF;
+	switch (i_type)
+	{
+		case U32_TYPE:
+		{
+			unsigned mask;
+			data.u32 = src.u32 >> pos;
+			mask = 0xFFFFFFFF >> (32 - len);
+			data.u32 &= mask;
+			break;
+		}
+		case U64_TYPE:
+		{
+			unsigned long mask;
+			data.u64 = src.u64 >> pos;	
+			mask = 0xFFFFFFFFFFFFFFFF >> (64 - len);
+			data.u64 &= mask;
+			break;
+		}
+		case S32_TYPE:
+		{
+			unsigned mask;
+			unsigned min = MY_MIN_I(pos + len - 1, msb);
+			unsigned sbit = len == 0 ? 0 : (src.s32 >> min) & 0x1;
+			data.s32 = src.s32 >> pos;
+			if (sbit > 0)
+			{
+				mask = 0xFFFFFFFF << len;
+				data.s32 |= mask;
+			}
+			else
+			{
+				mask = 0xFFFFFFFF >> (32 - len);
+				data.s32 &= mask;
+			}
+			break;
+		}
+		case S64_TYPE:
+		{
+			unsigned long mask;
+			unsigned min = MY_MIN_I(pos + len - 1, msb);
+			unsigned sbit = len == 0 ? 0 : (src.s64 >> min) & 0x1;
+			data.s64 = src.s64 >> pos;
+			if (sbit > 0)
+			{
+				mask = 0xFFFFFFFFFFFFFFFF << len;
+				data.s64 |= mask;
+			}
+			else
+			{
+				mask = 0xFFFFFFFFFFFFFFFF >> (64 - len);
+				data.s64 &= mask;
+			}
+			break;
+		}
+		default:
+		printf("Operand type not supported for BFE instruction.\n");
+		abort();
+		return;
+	}
+    thread->set_operand_value(dst, data, i_type, thread, pI);
+}
 
-  const operand_info &dst =
-      pI->dst();  // get operand info of sources and destination
-  const operand_info &src1 =
-      pI->src1();  // use them to determine that they are of type 'register'
-  const operand_info &src2 = pI->src2();
-  const operand_info &src3 = pI->src3();
-  const operand_info &src4 = pI->src4();
+void bfi_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { 
+   int i,max;
+   ptx_reg_t src1_data, src2_data;
+   ptx_reg_t src3_data, src4_data, data;
 
-  unsigned i_type = pI->get_type();
-  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
-  src3_data = thread->get_operand_value(src3, dst, i_type, thread, 1);
-  src4_data = thread->get_operand_value(src4, dst, i_type, thread, 1);
+   const operand_info &dst  = pI->dst();  //get operand info of sources and destination 
+   const operand_info &src1 = pI->src1(); //use them to determine that they are of type 'register'
+   const operand_info &src2 = pI->src2();
+   const operand_info &src3 = pI->src3();
+   const operand_info &src4 = pI->src4();
 
-  switch (i_type) {
-    case B32_TYPE:
+   unsigned i_type = pI->get_type();
+   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+   src3_data = thread->get_operand_value(src3, dst, i_type, thread, 1);
+   src4_data = thread->get_operand_value(src4, dst, i_type, thread, 1);
+
+   switch ( i_type ) {
+   case B32_TYPE:
       max = 32;
       break;
-    case B64_TYPE:
+   case B64_TYPE:
       max = 64;
       break;
-    default:
+   default:
       printf("Execution error: type mismatch with instruction\n");
       assert(0);
       break;
-  }
-  data = src2_data;
-  unsigned pos = src3_data.u32 & 0xFF;
-  unsigned len = src4_data.u32 & 0xFF;
-  for (i = 0; i < len && pos + i < max; i++) {
-    data.u32 = (~((0x00000001) << (pos + i))) & data.u32;
-    data.u32 = data.u32 | ((src1_data.u32 & ((0x00000001) << (i))) << (pos));
-  }
-  thread->set_operand_value(dst, data, i_type, thread, pI);
+   }
+   data=src2_data;
+   unsigned pos = src3_data.u32 & 0xFF;
+   unsigned len = src4_data.u32 & 0xFF;
+   for(i=0;i<len && pos+i<max;i++){
+	data.u32=(~((0x00000001)<<(pos+i)))&data.u32;
+	data.u32=data.u32|((src1_data.u32&((0x00000001)<<(i)))<<(pos));
+   }
+   thread->set_operand_value(dst, data, i_type, thread, pI);
 }
-void bfind_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  inst_not_implemented(pI);
-}
+void bfind_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
 
-void bra_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  const operand_info &target = pI->dst();
-  ptx_reg_t target_pc =
-      thread->get_operand_value(target, target, U32_TYPE, thread, 1);
+void bra_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+   const operand_info &target  = pI->dst();
+   ptx_reg_t target_pc = thread->get_operand_value(target, target, U32_TYPE, thread, 1);
 
-  thread->m_branch_taken = true;
-  thread->set_npc(target_pc);
+   thread->m_branch_taken = true;
+   thread->set_npc(target_pc);
 }
 
-void brx_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  const operand_info &target = pI->dst();
-  ptx_reg_t target_pc =
-      thread->get_operand_value(target, target, U32_TYPE, thread, 1);
+void brx_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+   const operand_info &target  = pI->dst();
+   ptx_reg_t target_pc = thread->get_operand_value(target, target, U32_TYPE, thread, 1);
 
-  thread->m_branch_taken = true;
-  thread->set_npc(target_pc);
+   thread->m_branch_taken = true;
+   thread->set_npc(target_pc);
 }
 
-void break_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  const operand_info &target = thread->pop_breakaddr();
-  ptx_reg_t target_pc =
-      thread->get_operand_value(target, target, U32_TYPE, thread, 1);
+void break_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+   const operand_info &target  = thread->pop_breakaddr();
+   ptx_reg_t target_pc = thread->get_operand_value(target, target, U32_TYPE, thread, 1);
 
-  thread->m_branch_taken = true;
-  thread->set_npc(target_pc);
+   thread->m_branch_taken = true;
+   thread->set_npc(target_pc);
 }
 
-void breakaddr_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  const operand_info &target = pI->dst();
-  thread->push_breakaddr(target);
-  assert(
-      pI->has_pred() ==
-      false);  // pdom analysis cannot handle if this instruction is predicated
+void breakaddr_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+   const operand_info &target  = pI->dst();
+   thread->push_breakaddr(target);
+   assert(pI->has_pred() == false); // pdom analysis cannot handle if this instruction is predicated 
 }
 
-void brev_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t src1_data, data;
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  unsigned i_type = pI->get_type();
-  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+void brev_impl( const ptx_instruction *pI, ptx_thread_info *thread )
+{
+    ptx_reg_t src1_data, data;
+    const operand_info &dst  = pI->dst();
+    const operand_info &src1 = pI->src1();
+	unsigned i_type = pI->get_type();
+    src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
 
-  unsigned msb;
-  switch (i_type) {
-    case B32_TYPE:
-      msb = 31;
-      for (unsigned i = 0; i <= msb; i++) {
-        if ((src1_data.u32 & (1 << i))) data.u32 |= 1 << (msb - i);
-      }
-      break;
-    case B64_TYPE:
-      msb = 63;
-      for (unsigned i = 0; i <= msb; i++) {
-        if ((src1_data.u64 & (1 << i))) data.u64 |= 1 << (msb - i);
-      }
-      break;
-    default:
-      assert(0);
-  }
-  thread->set_operand_value(dst, data, i_type, thread, pI);
+    unsigned msb;
+    switch(i_type){
+        case B32_TYPE:
+            msb = 31;
+            for (unsigned i=0; i<=msb; i++) {
+                if((src1_data.u32 & (1 << i)))
+                    data.u32 |= 1 << (msb - i);
+            }
+            break;
+        case B64_TYPE:
+            msb = 63;
+            for (unsigned i=0; i<=msb; i++) {
+                if((src1_data.u64 & (1 << i)))
+                    data.u64 |= 1 << (msb - i);
+            }
+            break;
+        default: assert(0);
+    }
+    thread->set_operand_value(dst,data, i_type, thread, pI);
 }
-void brkpt_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  inst_not_implemented(pI);
-}
+void brkpt_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
 
 unsigned trunc(unsigned num, unsigned precision) {
-  int mask = 1, latest_one = -1;
-  unsigned data = num;
-  for (unsigned j = 0; j < sizeof(unsigned) * 8; j++) {
-    int bit = data & mask;
-    if (bit == 1) latest_one = j;
-    data >>= 1;
-  }
-  if (latest_one >= precision) {
-    // round_up is 1 if the most significant truncated digit is a 1, otherwise
-    // it is 0
-    // int round_up = (num & (1 << (latest_one-precision))) >>
-    // (latest_one-precision);
-    // unsigned shifted_output = num >> (latest_one-precision+1);
-    // if shifted_output is a number like 1111, don't round up
-    // if (shifted_output == (pow(2,precision)-1)) round_up = 0;
-    // num = shifted_output + round_up;
-    num >>= (latest_one - precision + 1);
-  }
-  return num;
+	int mask = 1, latest_one = -1;
+	unsigned data = num;
+	for (unsigned j = 0; j < sizeof(unsigned)*8; j++) {
+		int bit = data & mask;
+		if (bit == 1) latest_one = j;
+		data >>= 1;
+	}
+	if (latest_one >= precision) {
+		// round_up is 1 if the most significant truncated digit is a 1, otherwise it is 0
+		//int round_up = (num & (1 << (latest_one-precision))) >> (latest_one-precision);
+		//unsigned shifted_output = num >> (latest_one-precision+1);
+		// if shifted_output is a number like 1111, don't round up
+		//if (shifted_output == (pow(2,precision)-1)) round_up = 0;
+		//num = shifted_output + round_up;
+		num >>= (latest_one-precision+1);
+	}
+	return num;
 }
-void mapping(int thread, int wmma_type, int wmma_layout, int type, int index,
-             int stride, int &row, int &col, int &assg_offset) {
-  int offset;
-  int c_row_offset[] = {0, 8, 0, 8, 4, 12, 4, 12};
-  int c_col_offset[] = {0, 0, 8, 8, 0, 0, 8, 8};
-  int c_tg_inside_row_offset[] = {0, 1, 0, 1};
-  int c_tg_inside_col_offset[] = {0, 0, 2, 2};
-  int c_inside_row_offset[] = {0, 0, 2, 2, 0, 0, 2, 2};
-  int c_inside_col_offset[] = {0, 1, 0, 1, 4, 5, 4, 5};
+void mapping(int thread,int wmma_type,int wmma_layout,int type,int index,int stride,int &row,int &col,int &assg_offset){
+	int offset;
+	int c_row_offset[]={0,8,0,8,4,12,4,12};
+	int c_col_offset[]={0,0,8,8,0,0,8,8};
+	int c_tg_inside_row_offset[]={0,1,0,1};	
+	int c_tg_inside_col_offset[]={0,0,2,2};	
+	int c_inside_row_offset[]={0,0,2,2,0,0,2,2};
+	int c_inside_col_offset[]={0,1,0,1,4,5,4,5};
 
-  offset = thread_group_offset(thread, wmma_type, wmma_layout, type, stride);
+	offset=thread_group_offset(thread,wmma_type,wmma_layout,type,stride);
 
-  if (wmma_type == LOAD_A) {
-    if (wmma_layout == ROW) {
-      offset += index + 8 * ((thread % 16) / 8);
-    } else {
-      offset += 64 * (index / 4) + index % 4 + 128 * ((thread % 16) / 8);
-    }
-    offset = (offset / 16) * stride + offset % 16;
-    assg_offset = index + 8 * ((thread % 16) / 8);
-  } else if (wmma_type == LOAD_B) {
-    if (wmma_layout == ROW) {
-      offset += 64 * (index / 4) + index % 4 + 128 * ((thread % 16) / 8);
-    } else {
-      offset += index + 8 * ((thread % 16) / 8);
-    }
-    offset = (offset / 16) * stride + offset % 16;
-    assg_offset = index + 8 * ((thread % 16) / 8);
-  } else if (wmma_type == LOAD_C) {
-    if (type == F16_TYPE) {
-      row = c_row_offset[thread / 4] + thread % 4;
-      col = c_col_offset[thread / 4] + index;
-    } else {
-      row = c_row_offset[thread / 4] + c_tg_inside_row_offset[thread % 4] +
-            c_inside_row_offset[index];
-      col = c_col_offset[thread / 4] + c_tg_inside_col_offset[thread % 4] +
-            c_inside_col_offset[index];
-    }
-    assg_offset = index;
-  }
+	if(wmma_type==LOAD_A){
+		if(wmma_layout==ROW){
+			offset+=index+8*((thread%16)/8);
+		}
+		else{
+			offset+=64*(index/4)+index%4+128*((thread%16)/8);	
+		}
+		offset=(offset/16)*stride+offset%16;
+		assg_offset=index+8*((thread%16)/8);
+	}
+	else if(wmma_type==LOAD_B){
+		if(wmma_layout==ROW){
+			offset+=64*(index/4)+index%4+128*((thread%16)/8);	
+		}
+		else{
+			offset+=index+8*((thread%16)/8);
+		}
+		offset=(offset/16)*stride+offset%16;
+		assg_offset=index+8*((thread%16)/8);
+	}
+	else if( wmma_type==LOAD_C){
+		if(type==F16_TYPE){
+			row=c_row_offset[thread/4]+thread%4;	
+			col=c_col_offset[thread/4]+index;
+		}
+		else{
+			row=c_row_offset[thread/4]+c_tg_inside_row_offset[thread%4]+c_inside_row_offset[index];
+			col=c_col_offset[thread/4]+c_tg_inside_col_offset[thread%4]+c_inside_col_offset[index];
+		}
+		assg_offset=index;
+	}
 
-  if (wmma_type == LOAD_A || wmma_type == LOAD_B) {
-    if (wmma_layout == ROW) {
-      row = offset / 16;
-      col = offset % 16;
-    } else {
-      col = offset / 16;
-      row = offset % 16;
-    }
-  }
-}
-
-void mma_impl(const ptx_instruction *pI, core_t *core, warp_inst_t inst) {
-  int i, j, k, thrd;
-  int row, col, offset;
-  ptx_reg_t matrix_a[16][16];
-  ptx_reg_t matrix_b[16][16];
-  ptx_reg_t matrix_c[16][16];
-  ptx_reg_t matrix_d[16][16];
-  ptx_reg_t src_data;
-  ptx_thread_info *thread;
-
-  unsigned a_layout = pI->get_wmma_layout(0);
-  unsigned b_layout = pI->get_wmma_layout(1);
-  unsigned type = pI->get_type();
-  unsigned type2 = pI->get_type2();
-  int tid;
-  const operand_info &dst = pI->operand_lookup(0);
-
-  if (core->get_gpu()->is_functional_sim())
-    tid = inst.warp_id_func() * core->get_warp_size();
-  else
-    tid = inst.warp_id() * core->get_warp_size();
-  float temp;
-  half temp2;
-
-  for (thrd = 0; thrd < core->get_warp_size(); thrd++) {
-    thread = core->get_thread_info()[tid + thrd];
-    if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-      printf("THREAD=%d\n:", thrd);
-    for (int operand_num = 1; operand_num <= 3; operand_num++) {
-      const operand_info &src_a = pI->operand_lookup(operand_num);
-      unsigned nelem = src_a.get_vect_nelem();
-      ptx_reg_t v[8];
-      thread->get_vector_operand_values(src_a, v, nelem);
-      if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) {
-        printf("Thread%d_Iteration=%d\n:", thrd, operand_num);
-        for (k = 0; k < nelem; k++) {
-          printf("%llx ", v[k].u64);
-        }
-        printf("\n");
-      }
-      ptx_reg_t nw_v[16];
-      int hex_val;
-
-      if (!((operand_num == 3) && (type2 == F32_TYPE))) {
-        for (k = 0; k < 2 * nelem; k++) {
-          if (k % 2 == 1)
-            hex_val = (v[k / 2].s64 & 0xffff);
-          else
-            hex_val = ((v[k / 2].s64 & 0xffff0000) >> 16);
-          nw_v[k].f16 = *((half *)&hex_val);
-        }
-      }
-      if (!((operand_num == 3) && (type2 == F32_TYPE))) {
-        for (k = 0; k < 2 * nelem; k++) {
-          temp = nw_v[k].f16;
-          if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-            printf("%.2f ", temp);
-        }
-        if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) printf("\n");
-      } else {
-        if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) {
-          for (k = 0; k < 8; k++) {
-            printf("%.2f ", v[k].f32);
-          }
-          printf("\n");
-        }
-      }
-      switch (operand_num) {
-        case 1:  // operand 1
-          for (k = 0; k < 8; k++) {
-            mapping(thrd, LOAD_A, a_layout, F16_TYPE, k, 16, row, col, offset);
-            if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-              printf("A:thread=%d,row=%d,col=%d,offset=%d\n", thrd, row, col,
-                     offset);
-            matrix_a[row][col] = nw_v[offset];
-          }
-          break;
-        case 2:  // operand 2
-          for (k = 0; k < 8; k++) {
-            mapping(thrd, LOAD_B, b_layout, F16_TYPE, k, 16, row, col, offset);
-            if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-              printf("B:thread=%d,row=%d,col=%d,offset=%d\n", thrd, row, col,
-                     offset);
-            matrix_b[row][col] = nw_v[offset];
-          }
-          break;
-        case 3:  // operand 3
-          for (k = 0; k < 8; k++) {
-            mapping(thrd, LOAD_C, ROW, type2, k, 16, row, col, offset);
-            if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-              printf("C:thread=%d,row=%d,col=%d,offset=%d\n", thrd, row, col,
-                     offset);
-            if (type2 != F16_TYPE) {
-              matrix_c[row][col] = v[offset];
-            } else {
-              matrix_c[row][col] = nw_v[offset];
-            }
-          }
-          break;
-        default:
-          printf("Invalid Operand Index\n");
-      }
-    }
-    if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) printf("\n");
-  }
-  if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) {
-    printf("MATRIX_A\n");
-    for (i = 0; i < 16; i++) {
-      for (j = 0; j < 16; j++) {
-        temp = matrix_a[i][j].f16;
-        printf("%.2f ", temp);
-      }
-      printf("\n");
-    }
-    printf("MATRIX_B\n");
-    for (i = 0; i < 16; i++) {
-      for (j = 0; j < 16; j++) {
-        temp = matrix_b[i][j].f16;
-        printf("%.2f ", temp);
-      }
-      printf("\n");
-    }
-    printf("MATRIX_C\n");
-    for (i = 0; i < 16; i++) {
-      for (j = 0; j < 16; j++) {
-        if (type2 == F16_TYPE) {
-          temp = matrix_c[i][j].f16;
-          printf("%.2f ", temp);
-        } else
-          printf("%.2f ", matrix_c[i][j].f32);
-      }
-      printf("\n");
-    }
-  }
-  for (i = 0; i < 16; i++) {
-    for (j = 0; j < 16; j++) {
-      matrix_d[i][j].f16 = 0;
-    }
-  }
-
-  for (i = 0; i < 16; i++) {
-    for (j = 0; j < 16; j++) {
-      for (k = 0; k < 16; k++) {
-        matrix_d[i][j].f16 =
-            matrix_d[i][j].f16 + matrix_a[i][k].f16 * matrix_b[k][j].f16;
-      }
-      if ((type == F16_TYPE) && (type2 == F16_TYPE))
-        matrix_d[i][j].f16 += matrix_c[i][j].f16;
-      else if ((type == F32_TYPE) && (type2 == F16_TYPE)) {
-        temp2 = matrix_d[i][j].f16 + matrix_c[i][j].f16;
-        temp = temp2;
-        matrix_d[i][j].f32 = temp;
-      } else if ((type == F16_TYPE) && (type2 == F32_TYPE)) {
-        temp = matrix_d[i][j].f16;
-        temp += matrix_c[i][j].f32;
-        matrix_d[i][j].f16 = half(temp);
-      } else {
-        temp = matrix_d[i][j].f16;
-        temp += matrix_c[i][j].f32;
-        matrix_d[i][j].f32 = temp;
-      }
-    }
-  }
-  if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) {
-    printf("MATRIX_D\n");
-    for (i = 0; i < 16; i++) {
-      for (j = 0; j < 16; j++) {
-        if (type == F16_TYPE) {
-          temp = matrix_d[i][j].f16;
-          printf("%.2f ", temp);
-        } else
-          printf("%.2f ", matrix_d[i][j].f32);
-      }
-      printf("\n");
-    }
-  }
-  for (thrd = 0; thrd < core->get_warp_size(); thrd++) {
-    int row_t[8];
-    int col_t[8];
-    for (k = 0; k < 8; k++) {
-      mapping(thrd, LOAD_C, ROW, type, k, 16, row_t[k], col_t[k], offset);
-      if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-        printf("mma:store:row:%d,col%d\n", row_t[k], col_t[k]);
-    }
-    thread = core->get_thread_info()[tid + thrd];
-
-    if (type == F32_TYPE) {
-      thread->set_wmma_vector_operand_values(
-          dst, matrix_d[row_t[0]][col_t[0]], matrix_d[row_t[1]][col_t[1]],
-          matrix_d[row_t[2]][col_t[2]], matrix_d[row_t[3]][col_t[3]],
-          matrix_d[row_t[4]][col_t[4]], matrix_d[row_t[5]][col_t[5]],
-          matrix_d[row_t[6]][col_t[6]], matrix_d[row_t[7]][col_t[7]]);
-
-      if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) {
-        printf("thread%d:", thrd);
-        for (k = 0; k < 8; k++) {
-          printf("%.2f ", matrix_d[row_t[k]][col_t[k]].f32);
-        }
-        printf("\n");
-      }
-    } else if (type == F16_TYPE) {
-      if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) {
-        printf("thread%d:", thrd);
-        for (k = 0; k < 8; k++) {
-          temp = matrix_d[row_t[k]][col_t[k]].f16;
-          printf("%.2f ", temp);
-        }
-        printf("\n");
-
-        printf("thread%d:", thrd);
-        for (k = 0; k < 8; k++) {
-          printf("%x ", (unsigned int)matrix_d[row_t[k]][col_t[k]].f16);
-        }
-        printf("\n");
-      }
-      ptx_reg_t nw_data1, nw_data2, nw_data3, nw_data4;
-      nw_data1.s64 = ((matrix_d[row_t[0]][col_t[0]].s64 & 0xffff)) |
-                     ((matrix_d[row_t[1]][col_t[1]].s64 & 0xffff) << 16);
-      nw_data2.s64 = ((matrix_d[row_t[2]][col_t[2]].s64 & 0xffff)) |
-                     ((matrix_d[row_t[3]][col_t[3]].s64 & 0xffff) << 16);
-      nw_data3.s64 = ((matrix_d[row_t[4]][col_t[4]].s64 & 0xffff)) |
-                     ((matrix_d[row_t[5]][col_t[5]].s64 & 0xffff) << 16);
-      nw_data4.s64 = ((matrix_d[row_t[6]][col_t[6]].s64 & 0xffff)) |
-                     ((matrix_d[row_t[7]][col_t[7]].s64 & 0xffff) << 16);
-      thread->set_vector_operand_values(dst, nw_data1, nw_data2, nw_data3,
-                                        nw_data4);
-      if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-        printf("thread%d=%llx,%llx,%llx,%llx", thrd, nw_data1.s64, nw_data2.s64,
-               nw_data3.s64, nw_data4.s64);
-
-    } else {
-      printf("wmma:mma:wrong type\n");
-      abort();
-    }
-  }
+	if(wmma_type==LOAD_A||wmma_type==LOAD_B){	
+		if(wmma_layout==ROW){
+			row=offset/16;
+			col=offset%16;
+		}
+		else{
+			col=offset/16;
+			row=offset%16;
+		}
+	}
 }
 
-void call_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  static unsigned call_uid_next = 1;
+void mma_impl( const ptx_instruction *pI, core_t *core, warp_inst_t inst )
+{
+	int i,j,k,thrd;
+	int row,col,offset;
+   	ptx_reg_t matrix_a[16][16];
+   	ptx_reg_t matrix_b[16][16];
+   	ptx_reg_t matrix_c[16][16];
+   	ptx_reg_t matrix_d[16][16];
+   	ptx_reg_t src_data;
+	ptx_thread_info *thread;
 
-  const operand_info &target = pI->func_addr();
-  assert(target.is_function_address());
-  const symbol *func_addr = target.get_symbol();
-  function_info *target_func = func_addr->get_pc();
-  if (target_func->is_pdom_set()) {
-    printf("GPGPU-Sim PTX: PDOM analysis already done for %s \n",
-           target_func->get_name().c_str());
-  } else {
-    printf("GPGPU-Sim PTX: finding reconvergence points for \'%s\'...\n",
-           target_func->get_name().c_str());
-    /*
-     * Some of the instructions like printf() gives the gpgpusim the wrong
-     * impression that it is a function call.
-     * As printf() doesnt have a body like functions do, doing pdom analysis for
-     * printf() causes a crash.
-     */
-    if (target_func->get_function_size() > 0) target_func->do_pdom();
-    target_func->set_pdom();
-  }
+	unsigned a_layout = pI->get_wmma_layout(0);
+	unsigned b_layout = pI->get_wmma_layout(1);
+	unsigned type = pI->get_type();
+	unsigned type2 = pI->get_type2();
+	int tid ;
+	const operand_info &dst = pI->operand_lookup(0);
+	
+        if(core->get_gpu()->is_functional_sim())
+         	tid= inst.warp_id_func()*core->get_warp_size();
+        else
+         	tid= inst.warp_id()*core->get_warp_size();
+	float temp;
+	half temp2; 	
+	
+	for (thrd=0; thrd < core->get_warp_size(); thrd++){
+		thread = core->get_thread_info()[tid+thrd];
+		if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+			printf("THREAD=%d\n:",thrd);
+		for(int operand_num=1;operand_num<=3;operand_num++){
+			const operand_info &src_a=  pI->operand_lookup(operand_num);
+         		unsigned nelem = src_a.get_vect_nelem();
+         		ptx_reg_t v[8];
+         		thread->get_vector_operand_values( src_a, v, nelem );
+			if(core->get_gpu()->gpgpu_ctx->debug_tensorcore){
+				printf("Thread%d_Iteration=%d\n:", thrd, operand_num);
+				for(k = 0; k < nelem; k++){
+					printf("%llx ",v[k].u64);
+				}
+				printf("\n");
+			}
+			ptx_reg_t nw_v[16];
+			int hex_val;
 
-  // check that number of args and return match function requirements
-  if (pI->has_return() ^ target_func->has_return()) {
-    printf(
-        "GPGPU-Sim PTX: Execution error - mismatch in number of return values "
-        "between\n"
-        "               call instruction and function declaration\n");
-    abort();
-  }
-  unsigned n_return = target_func->has_return();
-  unsigned n_args = target_func->num_args();
-  unsigned n_operands = pI->get_num_operands();
+			if(!((operand_num==3)&&(type2==F32_TYPE))){
+					for(k=0;k<2*nelem;k++){
+					if(k%2==1)
+						hex_val=(v[k/2].s64&0xffff);
+					else
+						hex_val=((v[k/2].s64&0xffff0000)>>16);
+					nw_v[k].f16 =*((half *)&hex_val); 
+				}
+			}
+			if(!((operand_num==3)&&(type2==F32_TYPE))){
+				for(k=0;k<2*nelem;k++){
+					temp=nw_v[k].f16;
+					if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+						printf("%.2f ",temp);
+				}
+				if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+					printf("\n");
+			}
+			else{
+				if(core->get_gpu()->gpgpu_ctx->debug_tensorcore){
+					for(k=0;k<8;k++){
+						printf("%.2f ",v[k].f32);
+					}
+					printf("\n");
+				}
+			}
+			switch(operand_num) {
+			      case 1 ://operand 1
+				for(k=0;k<8;k++){
+					mapping(thrd,LOAD_A,a_layout,F16_TYPE,k,16,row,col,offset);
+					if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+						printf("A:thread=%d,row=%d,col=%d,offset=%d\n",thrd,row,col,offset);
+				 	matrix_a[row][col]=nw_v[offset];
+			        }
+			      break;
+			      case 2 ://operand 2
+				for(k=0;k<8;k++){
+					mapping(thrd,LOAD_B,b_layout,F16_TYPE,k,16,row,col,offset);
+					if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+						printf("B:thread=%d,row=%d,col=%d,offset=%d\n",thrd,row,col,offset);
+				 	matrix_b[row][col]=nw_v[offset];
+				}	
+			      break;
+			      case 3 ://operand 3
+				for(k=0;k<8;k++){
+					mapping(thrd,LOAD_C,ROW,type2,k,16,row,col,offset);
+					if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+						printf("C:thread=%d,row=%d,col=%d,offset=%d\n",thrd,row,col,offset);
+					if(type2!=F16_TYPE){
+					 	matrix_c[row][col]=v[offset];
+					}
+					else {
+				 		matrix_c[row][col]=nw_v[offset];
+					}
+				}
+			        break;
+			      default :
+			         printf("Invalid Operand Index\n" );
+			}
+		}
+		if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+			printf("\n");
+	}
+	if(core->get_gpu()->gpgpu_ctx->debug_tensorcore){
+		printf("MATRIX_A\n");
+		for (i=0;i<16;i++){
+			for(j=0;j<16;j++){
+				temp=matrix_a[i][j].f16;
+				printf("%.2f ",temp);
+			}
+			printf("\n");
+		}
+		printf("MATRIX_B\n");
+		for (i=0;i<16;i++){
+			for(j=0;j<16;j++){
+				temp=matrix_b[i][j].f16;
+				printf("%.2f ",temp);
+			}
+			printf("\n");
+		}	
+		printf("MATRIX_C\n");
+		for (i=0;i<16;i++){
+			for(j=0;j<16;j++){
+				if(type2==F16_TYPE){
+					temp=matrix_c[i][j].f16;
+					printf("%.2f ",temp);
+				}
+				else
+					printf("%.2f ",matrix_c[i][j].f32);
+			}
+			printf("\n");
+		}	
+	}
+	for (i=0;i<16;i++){
+		for(j=0;j<16;j++){
+				matrix_d[i][j].f16=0;
+		}
+	}
+	
+	for (i=0;i<16;i++){
+		for(j=0;j<16;j++){
+			for(k=0;k<16;k++){
+				matrix_d[i][j].f16=matrix_d[i][j].f16+matrix_a[i][k].f16*matrix_b[k][j].f16;
+			}
+			if((type==F16_TYPE)&&(type2==F16_TYPE))
+				matrix_d[i][j].f16+=matrix_c[i][j].f16;
+			else if((type==F32_TYPE)&&(type2==F16_TYPE)){
+				temp2=matrix_d[i][j].f16+matrix_c[i][j].f16;
+				temp=temp2;
+				matrix_d[i][j].f32=temp;
+			}
+			else if((type==F16_TYPE)&&(type2==F32_TYPE)){
+				temp=matrix_d[i][j].f16;
+				temp+=matrix_c[i][j].f32;
+				matrix_d[i][j].f16=half(temp);
+			}
+			else{
+				temp=matrix_d[i][j].f16;
+				temp+=matrix_c[i][j].f32;
+				matrix_d[i][j].f32=temp;
+			}
+		}
+	}
+	if(core->get_gpu()->gpgpu_ctx->debug_tensorcore){
+		printf("MATRIX_D\n");
+		for (i=0;i<16;i++){
+			for(j=0;j<16;j++){
+				if(type==F16_TYPE){
+					temp=matrix_d[i][j].f16;
+					printf("%.2f ",temp);
+				}
+				else
+					printf("%.2f ",matrix_d[i][j].f32);
+			}
+			printf("\n");
+		}	
+	}
+	for (thrd=0; thrd < core->get_warp_size(); thrd++){
+		int row_t[8];
+		int col_t[8];	
+		for(k=0;k<8;k++){
+			mapping(thrd,LOAD_C,ROW,type,k,16,row_t[k],col_t[k],offset);
+			if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+				printf("mma:store:row:%d,col%d\n",row_t[k],col_t[k]);
+		}
+		thread = core->get_thread_info()[tid+thrd];
+		
+	
+		if(type==F32_TYPE){
+			thread->set_wmma_vector_operand_values(dst,matrix_d[row_t[0]][col_t[0]],matrix_d[row_t[1]][col_t[1]],matrix_d[row_t[2]][col_t[2]],matrix_d[row_t[3]][col_t[3]],matrix_d[row_t[4]][col_t[4]],matrix_d[row_t[5]][col_t[5]],matrix_d[row_t[6]][col_t[6]],matrix_d[row_t[7]][col_t[7]]);
+		
+			if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+			{
+				printf("thread%d:",thrd);
+				for(k=0;k<8;k++){
+					printf("%.2f ",matrix_d[row_t[k]][col_t[k]].f32);
+				}
+				printf("\n");
+			}
+		}
+		else if(type==F16_TYPE){
+			if(core->get_gpu()->gpgpu_ctx->debug_tensorcore){	
+				printf("thread%d:",thrd);
+				for(k=0;k<8;k++){
+					temp=matrix_d[row_t[k]][col_t[k]].f16;
+					printf("%.2f ",temp);
+				}
+				printf("\n");
 
-  if (n_operands != (n_return + 1 + n_args)) {
-    printf(
-        "GPGPU-Sim PTX: Execution error - mismatch in number of arguements "
-        "between\n"
-        "               call instruction and function declaration\n");
-    abort();
-  }
+				printf("thread%d:",thrd);
+				for(k=0;k<8;k++){
+					printf("%x ", (unsigned int)matrix_d[row_t[k]][col_t[k]].f16);
+				}
+				printf("\n");
+			}
+			ptx_reg_t nw_data1, nw_data2, nw_data3, nw_data4;
+			nw_data1.s64=((matrix_d[row_t[0]][col_t[0]].s64   & 0xffff))|((matrix_d[row_t[1]][col_t[1]].s64&0xffff)<<16);
+			nw_data2.s64=((matrix_d[row_t[2]][col_t[2]].s64   & 0xffff))|((matrix_d[row_t[3]][col_t[3]].s64&0xffff)<<16);
+			nw_data3.s64=((matrix_d[row_t[4]][col_t[4]].s64   & 0xffff))|((matrix_d[row_t[5]][col_t[5]].s64&0xffff)<<16);
+			nw_data4.s64=((matrix_d[row_t[6]][col_t[6]].s64   & 0xffff))|((matrix_d[row_t[7]][col_t[7]].s64&0xffff)<<16);
+   			thread->set_vector_operand_values(dst,nw_data1,nw_data2,nw_data3,nw_data4);
+			if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+		 		printf("thread%d=%llx,%llx,%llx,%llx", thrd, nw_data1.s64, nw_data2.s64, nw_data3.s64, nw_data4.s64);
+		
+		}
+		else{
+			printf("wmma:mma:wrong type\n");
+			abort();
+		}
+	}
+}
 
-  // handle intrinsic functions
-  std::string fname = target_func->get_name();
-  if (fname == "vprintf") {
-    gpgpusim_cuda_vprintf(pI, thread, target_func);
-    return;
-  }
+void call_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+   static unsigned call_uid_next = 1;
+    
+   const operand_info &target  = pI->func_addr();
+   assert( target.is_function_address() );
+   const symbol *func_addr = target.get_symbol();
+   function_info *target_func = func_addr->get_pc();
+   if (target_func->is_pdom_set()) {
+      printf("GPGPU-Sim PTX: PDOM analysis already done for %s \n", target_func->get_name().c_str() );
+   } else {
+      printf("GPGPU-Sim PTX: finding reconvergence points for \'%s\'...\n", target_func->get_name().c_str() );
+      /*
+       * Some of the instructions like printf() gives the gpgpusim the wrong impression that it is a function call.
+       * As printf() doesnt have a body like functions do, doing pdom analysis for printf() causes a crash.
+       */
+      if (target_func->get_function_size() >0)
+          target_func->do_pdom();
+      target_func->set_pdom();
+   }
+
+   // check that number of args and return match function requirements
+   if( pI->has_return() ^ target_func->has_return() ) {
+      printf("GPGPU-Sim PTX: Execution error - mismatch in number of return values between\n"
+             "               call instruction and function declaration\n");
+      abort(); 
+   }
+   unsigned n_return = target_func->has_return();
+   unsigned n_args = target_func->num_args();
+   unsigned n_operands = pI->get_num_operands();
+
+   if( n_operands != (n_return+1+n_args) ) {
+      printf("GPGPU-Sim PTX: Execution error - mismatch in number of arguements between\n"
+             "               call instruction and function declaration\n");
+      abort(); 
+   }
+
+   // handle intrinsic functions
+   std::string fname = target_func->get_name();
+   if( fname == "vprintf" ) {
+      gpgpusim_cuda_vprintf(pI, thread, target_func);
+      return;
+   }
+
 #if (CUDART_VERSION >= 5000)
-  // Jin: handle device runtime apis for CDP
-  else if (fname == "cudaGetParameterBufferV2") {
-    target_func->gpgpu_ctx->device_runtime->gpgpusim_cuda_getParameterBufferV2(
-        pI, thread, target_func);
-    return;
-  } else if (fname == "cudaLaunchDeviceV2") {
-    target_func->gpgpu_ctx->device_runtime->gpgpusim_cuda_launchDeviceV2(
-        pI, thread, target_func);
-    return;
-  } else if (fname == "cudaStreamCreateWithFlags") {
-    target_func->gpgpu_ctx->device_runtime->gpgpusim_cuda_streamCreateWithFlags(
-        pI, thread, target_func);
-    return;
-  }
+   //Jin: handle device runtime apis for CDP
+   else if(fname == "cudaGetParameterBufferV2") {
+      target_func->gpgpu_ctx->device_runtime->gpgpusim_cuda_getParameterBufferV2(pI, thread, target_func);
+	  return;
+   }
+   else if(fname == "cudaLaunchDeviceV2") {
+      target_func->gpgpu_ctx->device_runtime->gpgpusim_cuda_launchDeviceV2(pI, thread, target_func);
+	  return;
+   }
+   else if(fname == "cudaStreamCreateWithFlags") {
+      target_func->gpgpu_ctx->device_runtime->gpgpusim_cuda_streamCreateWithFlags(pI, thread, target_func);
+	  return;
+   }
 #endif
 
-  // read source arguements into register specified in declaration of function
-  arg_buffer_list_t arg_values;
-  copy_args_into_buffer_list(pI, thread, target_func, arg_values);
+   // read source arguements into register specified in declaration of function
+   arg_buffer_list_t arg_values;
+   copy_args_into_buffer_list(pI, thread, target_func, arg_values);
 
-  // record local for return value (we only support a single return value)
-  const symbol *return_var_src = NULL;
-  const symbol *return_var_dst = NULL;
-  if (target_func->has_return()) {
-    return_var_dst = pI->dst().get_symbol();
-    return_var_src = target_func->get_return_var();
-  }
+   // record local for return value (we only support a single return value)
+   const symbol *return_var_src = NULL;
+   const symbol *return_var_dst = NULL;
+   if( target_func->has_return() ) {
+      return_var_dst = pI->dst().get_symbol();
+      return_var_src = target_func->get_return_var();
+   }
 
-  gpgpu_sim *gpu = thread->get_gpu();
-  unsigned callee_pc = 0, callee_rpc = 0;
-  if (gpu->simd_model() == POST_DOMINATOR) {
-    thread->get_core()->get_pdom_stack_top_info(thread->get_hw_wid(),
-                                                &callee_pc, &callee_rpc);
-    assert(callee_pc == thread->get_pc());
-  }
+   gpgpu_sim *gpu = thread->get_gpu();
+   unsigned callee_pc=0, callee_rpc=0;
+   if( gpu->simd_model() == POST_DOMINATOR ) {
+      thread->get_core()->get_pdom_stack_top_info(thread->get_hw_wid(),&callee_pc,&callee_rpc);
+      assert( callee_pc == thread->get_pc() );
+   }
 
-  thread->callstack_push(callee_pc + pI->inst_size(), callee_rpc,
-                         return_var_src, return_var_dst, call_uid_next++);
+   thread->callstack_push(callee_pc + pI->inst_size(), callee_rpc, return_var_src, return_var_dst, call_uid_next++);
 
-  copy_buffer_list_into_frame(thread, arg_values);
+   copy_buffer_list_into_frame(thread, arg_values);
 
-  thread->set_npc(target_func);
+   thread->set_npc(target_func);
 }
 
-// Ptxplus version of call instruction. Jumps to a label not a different Kernel.
-void callp_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  static unsigned call_uid_next = 1;
+//Ptxplus version of call instruction. Jumps to a label not a different Kernel.
+void callp_impl( const ptx_instruction *pI, ptx_thread_info *thread )
+{
+   
+   static unsigned call_uid_next = 1;
 
-  const operand_info &target = pI->dst();
-  ptx_reg_t target_pc =
-      thread->get_operand_value(target, target, U32_TYPE, thread, 1);
+   const operand_info &target  = pI->dst();
+   ptx_reg_t target_pc = thread->get_operand_value(target, target, U32_TYPE, thread, 1);
 
-  const symbol *return_var_src = NULL;
-  const symbol *return_var_dst = NULL;
+   const symbol *return_var_src = NULL;
+   const symbol *return_var_dst = NULL;
 
-  gpgpu_sim *gpu = thread->get_gpu();
-  unsigned callee_pc = 0, callee_rpc = 0;
-  if (gpu->simd_model() == POST_DOMINATOR) {
-    thread->get_core()->get_pdom_stack_top_info(thread->get_hw_wid(),
-                                                &callee_pc, &callee_rpc);
-    assert(callee_pc == thread->get_pc());
-  }
+   gpgpu_sim *gpu = thread->get_gpu();
+   unsigned callee_pc=0, callee_rpc=0;
+   if( gpu->simd_model() == POST_DOMINATOR ) {
+      thread->get_core()->get_pdom_stack_top_info(thread->get_hw_wid(),&callee_pc,&callee_rpc);
+      assert( callee_pc == thread->get_pc() );
+   } 
 
-  thread->callstack_push_plus(callee_pc + pI->inst_size(), callee_rpc,
-                              return_var_src, return_var_dst, call_uid_next++);
-  thread->set_npc(target_pc);
+   thread->callstack_push_plus(callee_pc + pI->inst_size(), callee_rpc, return_var_src, return_var_dst, call_uid_next++);
+   thread->set_npc(target_pc);
 }
 
-void clz_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t a, d;
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
+void clz_impl( const ptx_instruction *pI, ptx_thread_info *thread )
+{
+   ptx_reg_t a, d;
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
 
-  unsigned i_type = pI->get_type();
-  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   unsigned i_type = pI->get_type();
+   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
 
-  int max;
-  unsigned long long mask;
-  d.u64 = 0;
+   int max;
+   unsigned long long mask;
+   d.u64 = 0;
 
-  switch (i_type) {
-    case B32_TYPE:
+   switch ( i_type ) {
+   case B32_TYPE:
       max = 32;
       mask = 0x80000000;
       break;
-    case B64_TYPE:
+   case B64_TYPE:
       max = 64;
       mask = 0x8000000000000000;
       break;
-    default:
+   default:
       printf("Execution error: type mismatch with instruction\n");
       assert(0);
       break;
-  }
+   }
 
-  while ((d.u32 < max) && ((a.u64 & mask) == 0)) {
-    d.u32++;
-    a.u64 = a.u64 << 1;
-  }
+   while ((d.u32 < max) && ((a.u64&mask) == 0) ) {
+      d.u32++;
+      a.u64 = a.u64 << 1;
+   }
 
-  thread->set_operand_value(dst, d, B32_TYPE, thread, pI);
+   thread->set_operand_value(dst,d, B32_TYPE, thread, pI);
 }
 
-void cnot_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t a, b, d;
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
+void cnot_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   ptx_reg_t a, b, d;
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
 
-  unsigned i_type = pI->get_type();
-  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   unsigned i_type = pI->get_type();
+   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
 
-  switch (i_type) {
-    case PRED_TYPE:
-      d.pred = ((a.pred & 0x0001) == 0) ? 1 : 0;
-      break;
-    case B16_TYPE:
-      d.u16 = (a.u16 == 0) ? 1 : 0;
-      break;
-    case B32_TYPE:
-      d.u32 = (a.u32 == 0) ? 1 : 0;
-      break;
-    case B64_TYPE:
-      d.u64 = (a.u64 == 0) ? 1 : 0;
-      break;
-    default:
+   switch ( i_type ) {
+   case PRED_TYPE: d.pred = ((a.pred & 0x0001) == 0)?1:0; break;
+   case B16_TYPE:  d.u16  = (a.u16  == 0)?1:0; break;
+   case B32_TYPE:  d.u32  = (a.u32  == 0)?1:0; break;
+   case B64_TYPE:  d.u64  = (a.u64  == 0)?1:0; break;
+   default:
       printf("Execution error: type mismatch with instruction\n");
       assert(0);
       break;
-  }
+   }
 
-  thread->set_operand_value(dst, d, i_type, thread, pI);
+   thread->set_operand_value(dst,d, i_type, thread, pI);
 }
 
-void cos_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t a, d;
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
+void cos_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+   ptx_reg_t a, d;
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
 
-  unsigned i_type = pI->get_type();
-  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   unsigned i_type = pI->get_type();
+   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
 
-  switch (i_type) {
-    case F32_TYPE:
+
+   switch ( i_type ) {
+   case F32_TYPE: 
       d.f32 = cos(a.f32);
       break;
-    default:
+   default:
       printf("Execution error: type mismatch with instruction\n");
-      assert(0);
+      assert(0); 
       break;
-  }
+   }
 
-  thread->set_operand_value(dst, d, i_type, thread, pI);
+   thread->set_operand_value(dst,d, i_type, thread, pI);
 }
 
-ptx_reg_t chop(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
-               int rounding_mode, int saturation_mode) {
-  switch (to_width) {
-    case 8:
-      x.mask_and(0, 0xFF);
-      break;
-    case 16:
-      x.mask_and(0, 0xFFFF);
-      break;
-    case 32:
-      x.mask_and(0, 0xFFFFFFFF);
-      break;
-    case 64:
-      break;
-    default:
-      assert(0);
-  }
-  return x;
+ptx_reg_t chop( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
+{
+   switch ( to_width ) {
+   case 8:  x.mask_and(0,0xFF);  break;
+   case 16: x.mask_and(0,0xFFFF);      break;
+   case 32: x.mask_and(0,0xFFFFFFFF);  break;
+   case 64: break;
+   default: assert(0);
+   }
+   return x;
 }
 
-ptx_reg_t sext(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
-               int rounding_mode, int saturation_mode) {
-  x = chop(x, 0, from_width, 0, rounding_mode, saturation_mode);
-  switch (from_width) {
-    case 8:
-      if (x.get_bit(7)) x.mask_or(0xFFFFFFFF, 0xFFFFFF00);
-      break;
-    case 16:
-      if (x.get_bit(15)) x.mask_or(0xFFFFFFFF, 0xFFFF0000);
-      break;
-    case 32:
-      if (x.get_bit(31)) x.mask_or(0xFFFFFFFF, 0x00000000);
-      break;
-    case 64:
-      break;
-    default:
-      assert(0);
-  }
-  return x;
+ptx_reg_t sext( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
+{
+   x=chop(x,0,from_width,0,rounding_mode,saturation_mode);
+   switch ( from_width ) {
+   case 8: if ( x.get_bit(7) ) x.mask_or(0xFFFFFFFF,0xFFFFFF00);break;
+   case 16:if ( x.get_bit(15) ) x.mask_or(0xFFFFFFFF,0xFFFF0000);break;
+   case 32: if ( x.get_bit(31) ) x.mask_or(0xFFFFFFFF,0x00000000);break;
+   case 64: break;
+   default: assert(0);
+   }
+   return x;
 }
 
-// sign extend depending on the destination register size - hack to get
-// SobelFilter working in CUDA 4.2
-ptx_reg_t sexd(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
-               int rounding_mode, int saturation_mode) {
-  x = chop(x, 0, from_width, 0, rounding_mode, saturation_mode);
-  switch (to_width) {
-    case 8:
-      if (x.get_bit(7)) x.mask_or(0xFFFFFFFF, 0xFFFFFF00);
-      break;
-    case 16:
-      if (x.get_bit(15)) x.mask_or(0xFFFFFFFF, 0xFFFF0000);
-      break;
-    case 32:
-      if (x.get_bit(31)) x.mask_or(0xFFFFFFFF, 0x00000000);
-      break;
-    case 64:
-      break;
-    default:
-      assert(0);
-  }
-  return x;
+// sign extend depending on the destination register size - hack to get SobelFilter working in CUDA 4.2
+ptx_reg_t sexd( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
+{
+   x=chop(x,0,from_width,0,rounding_mode,saturation_mode);
+   switch ( to_width ) {
+   case 8: if ( x.get_bit(7) ) x.mask_or(0xFFFFFFFF,0xFFFFFF00);break;
+   case 16:if ( x.get_bit(15) ) x.mask_or(0xFFFFFFFF,0xFFFF0000);break;
+   case 32: if ( x.get_bit(31) ) x.mask_or(0xFFFFFFFF,0x00000000);break;
+   case 64: break;
+   default: assert(0);
+   }
+   return x;
 }
 
-ptx_reg_t zext(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
-               int rounding_mode, int saturation_mode) {
-  return chop(x, 0, from_width, 0, rounding_mode, saturation_mode);
+ptx_reg_t zext( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
+{
+   return chop(x,0,from_width,0,rounding_mode,saturation_mode);
 }
 
-int saturatei(int a, int max, int min) {
-  if (a > max)
-    a = max;
-  else if (a < min)
-    a = min;
-  return a;
+int saturatei(int a, int max, int min) 
+{
+   if (a > max) a = max;
+   else if (a < min) a = min;
+   return a;
 }
 
-unsigned int saturatei(unsigned int a, unsigned int max) {
-  if (a > max) a = max;
-  return a;
+unsigned int saturatei(unsigned int a, unsigned int max) 
+{
+   if (a > max) a = max;
+   return a;
 }
 
-ptx_reg_t f2x(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
-              int rounding_mode, int saturation_mode) {
-  half mytemp;
-  half_float::half tmp_h;
-  // assert( from_width == 32);
+ptx_reg_t f2x( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
+{
+   half mytemp;
+   half_float::half tmp_h;
+   //assert( from_width == 32); 
 
-  enum cudaRoundMode mode = cudaRoundZero;
-  switch (rounding_mode) {
-    case RZI_OPTION:
-      mode = cudaRoundZero;
-      break;
-    case RNI_OPTION:
-      mode = cudaRoundNearest;
-      break;
-    case RMI_OPTION:
-      mode = cudaRoundMinInf;
-      break;
-    case RPI_OPTION:
-      mode = cudaRoundPosInf;
-      break;
-    default:
-      break;
-  }
+   enum cudaRoundMode mode = cudaRoundZero;
+   switch (rounding_mode) {
+   case RZI_OPTION: mode = cudaRoundZero;    break;
+   case RNI_OPTION: mode = cudaRoundNearest; break;
+   case RMI_OPTION: mode = cudaRoundMinInf;  break;
+   case RPI_OPTION: mode = cudaRoundPosInf;  break;
+   default: break; 
+   }
 
-  ptx_reg_t y;
-  if (to_sign == 1) {  // convert to 64-bit number first?
-    int tmp = cuda_math::float2int(x.f32, mode);
-    if ((x.u32 & 0x7f800000) == 0) tmp = 0;  // round denorm. FP to 0
-    if (saturation_mode && to_width < 32) {
-      tmp = saturatei(tmp, (1 << to_width) - 1, -(1 << to_width));
-    }
-    switch (to_width) {
-      case 8:
-        y.s8 = (char)tmp;
-        break;
-      case 16:
-        y.s16 = (short)tmp;
-        break;
+   ptx_reg_t y;
+   if ( to_sign == 1 ) { // convert to 64-bit number first?
+      int tmp = cuda_math::float2int(x.f32, mode);
+      if ((x.u32 & 0x7f800000) == 0)
+         tmp = 0; // round denorm. FP to 0
+      if (saturation_mode && to_width < 32) {
+         tmp = saturatei(tmp, (1<<to_width) - 1, -(1<<to_width));
+      }
+      switch ( to_width ) {
+      case 8:  y.s8  = (char)tmp; break;
+      case 16: y.s16 = (short)tmp; break;
+      case 32: y.s32 = (int)tmp; break;
+      case 64: y.s64 = (long long)tmp; break;
+      default: assert(0); break;
+      }
+   } else if ( to_sign == 0 ) {
+      unsigned int tmp = cuda_math::float2uint(x.f32, mode);
+      if ((x.u32 & 0x7f800000) == 0)
+         tmp = 0; // round denorm. FP to 0
+      if (saturation_mode && to_width < 32) {
+         tmp = saturatei(tmp, (1<<to_width) - 1);
+      }
+      switch ( to_width ) {
+      case 8:  y.u8  = (unsigned char)tmp; break;
+      case 16: y.u16 = (unsigned short)tmp; break;
+      case 32: y.u32 = (unsigned int)tmp; break;
+      case 64: y.u64 = (unsigned long long)tmp; break;
+      default: assert(0); break;
+      }
+   } else {
+      switch ( to_width ) {
+      case 16: 
+	 y.f16 =half_float::half_cast<half,std::numeric_limits<float>::round_style>(x.f32);//mytemp;
+ 	 break;
+      case 32: 
+	 y.f32=float(x.f16);
+	 break; // handled by f2f
+      case 64: 
+         y.f64 = x.f32; 
+         break;
+      default: assert(0); break;
+      }
+   }
+   return y;
+}
+
+double saturated2i (double a, double max, double min) {
+   if (a > max) a = max;
+   else if (a < min) a = min;
+   return a;
+}
+
+ptx_reg_t d2x( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
+{
+   assert( from_width == 64); 
+
+   double tmp;
+   switch (rounding_mode) {
+   case RZI_OPTION: tmp = trunc(x.f64);     break;
+   case RNI_OPTION: tmp = nearbyint(x.f64); break;
+   case RMI_OPTION: tmp = floor(x.f64);     break;
+   case RPI_OPTION: tmp = ceil(x.f64);      break;
+   default: tmp = x.f64; break; 
+   }
+
+   ptx_reg_t y;
+   if ( to_sign == 1 ) {
+      tmp = saturated2i(tmp, ((1<<(to_width - 1)) - 1), (1<<(to_width - 1)) );
+      switch ( to_width ) {
+      case 8:  y.s8  = (char)tmp; break;
+      case 16: y.s16 = (short)tmp; break;
+      case 32: y.s32 = (int)tmp; break;
+      case 64: y.s64 = (long long)tmp; break;
+      default: assert(0); break;
+      }
+   } else if ( to_sign == 0 ) {
+      tmp = saturated2i(tmp, ((1<<(to_width - 1)) - 1), 0);
+      switch ( to_width ) {
+      case 8:  y.u8  = (unsigned char)tmp; break;
+      case 16: y.u16 = (unsigned short)tmp; break;
+      case 32: y.u32 = (unsigned int)tmp; break;
+      case 64: y.u64 = (unsigned long long)tmp; break;
+      default: assert(0); break;
+      }
+   } else {
+      switch ( to_width ) {
+      case 16: assert(0); break;
       case 32:
-        y.s32 = (int)tmp;
-        break;
-      case 64:
-        y.s64 = (long long)tmp;
-        break;
-      default:
-        assert(0);
-        break;
-    }
-  } else if (to_sign == 0) {
-    unsigned int tmp = cuda_math::float2uint(x.f32, mode);
-    if ((x.u32 & 0x7f800000) == 0) tmp = 0;  // round denorm. FP to 0
-    if (saturation_mode && to_width < 32) {
-      tmp = saturatei(tmp, (1 << to_width) - 1);
-    }
-    switch (to_width) {
-      case 8:
-        y.u8 = (unsigned char)tmp;
-        break;
-      case 16:
-        y.u16 = (unsigned short)tmp;
-        break;
-      case 32:
-        y.u32 = (unsigned int)tmp;
-        break;
-      case 64:
-        y.u64 = (unsigned long long)tmp;
-        break;
-      default:
-        assert(0);
-        break;
-    }
-  } else {
-    switch (to_width) {
-      case 16:
-        y.f16 = half_float::half_cast<half,
-                                      std::numeric_limits<float>::round_style>(
-            x.f32);  // mytemp;
-        break;
-      case 32:
-        y.f32 = float(x.f16);
-        break;  // handled by f2f
-      case 64:
-        y.f64 = x.f32;
-        break;
-      default:
-        assert(0);
-        break;
-    }
-  }
-  return y;
+         y.f32 = x.f64;  
+         break;
+      case 64: 
+         y.f64 = x.f64; // should be handled by d2d
+         break;
+      default: assert(0); break;
+      }
+   }
+   return y;
 }
 
-double saturated2i(double a, double max, double min) {
-  if (a > max)
-    a = max;
-  else if (a < min)
-    a = min;
-  return a;
+ptx_reg_t s2f( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
+{
+   ptx_reg_t y;
+
+   if (from_width < 64) { // 32-bit conversion
+      y = sext(x,from_width,32,0,rounding_mode,saturation_mode);
+
+      switch ( to_width ) {
+      case 16: assert(0); break;
+      case 32: 
+         switch (rounding_mode) {
+         case RZ_OPTION: y.f32 = cuda_math::__int2float_rz(y.s32); break;
+         case RN_OPTION: y.f32 = cuda_math::__int2float_rn(y.s32); break;
+         case RM_OPTION: y.f32 = cuda_math::__int2float_rd(y.s32); break;
+         case RP_OPTION: y.f32 = cuda_math::__int2float_ru(y.s32); break;
+         default: break; 
+         }
+         break;
+      case 64: y.f64 = y.s32; break; // no rounding needed
+      default: assert(0); break;
+      }
+   } else {
+      switch ( to_width ) {
+      case 16: assert(0); break;
+      case 32: 
+         switch (rounding_mode) {
+         case RZ_OPTION: y.f32 = cuda_math::__ll2float_rz(y.s64); break; 
+         case RN_OPTION: y.f32 = cuda_math::__ll2float_rn(y.s64); break;
+         case RM_OPTION: y.f32 = cuda_math::__ll2float_rd(y.s64); break; 
+         case RP_OPTION: y.f32 = cuda_math::__ll2float_ru(y.s64); break;
+         default: break; 
+         }
+         break;
+      case 64: y.f64 = y.s64; break; // no internal implementation found
+      default: assert(0); break;
+      }
+   }
+
+   // saturating an integer to 1 or 0?
+   return y;
 }
 
-ptx_reg_t d2x(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
-              int rounding_mode, int saturation_mode) {
-  assert(from_width == 64);
+ptx_reg_t u2f( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
+{
+   ptx_reg_t y;
 
-  double tmp;
-  switch (rounding_mode) {
-    case RZI_OPTION:
-      tmp = trunc(x.f64);
-      break;
-    case RNI_OPTION:
-      tmp = nearbyint(x.f64);
-      break;
-    case RMI_OPTION:
-      tmp = floor(x.f64);
-      break;
-    case RPI_OPTION:
-      tmp = ceil(x.f64);
-      break;
-    default:
-      tmp = x.f64;
-      break;
-  }
+   if (from_width < 64) { // 32-bit conversion
+      y = zext(x,from_width,32,0,rounding_mode,saturation_mode);
 
-  ptx_reg_t y;
-  if (to_sign == 1) {
-    tmp = saturated2i(tmp, ((1 << (to_width - 1)) - 1), (1 << (to_width - 1)));
-    switch (to_width) {
-      case 8:
-        y.s8 = (char)tmp;
-        break;
-      case 16:
-        y.s16 = (short)tmp;
-        break;
-      case 32:
-        y.s32 = (int)tmp;
-        break;
-      case 64:
-        y.s64 = (long long)tmp;
-        break;
-      default:
-        assert(0);
-        break;
-    }
-  } else if (to_sign == 0) {
-    tmp = saturated2i(tmp, ((1 << (to_width - 1)) - 1), 0);
-    switch (to_width) {
-      case 8:
-        y.u8 = (unsigned char)tmp;
-        break;
-      case 16:
-        y.u16 = (unsigned short)tmp;
-        break;
-      case 32:
-        y.u32 = (unsigned int)tmp;
-        break;
-      case 64:
-        y.u64 = (unsigned long long)tmp;
-        break;
-      default:
-        assert(0);
-        break;
-    }
-  } else {
-    switch (to_width) {
-      case 16:
-        assert(0);
-        break;
-      case 32:
-        y.f32 = x.f64;
-        break;
-      case 64:
-        y.f64 = x.f64;  // should be handled by d2d
-        break;
-      default:
-        assert(0);
-        break;
-    }
-  }
-  return y;
+      switch ( to_width ) {
+      case 16: assert(0); break;
+      case 32: 
+         switch (rounding_mode) {
+         case RZ_OPTION: y.f32 = cuda_math::__uint2float_rz(y.u32); break;
+         case RN_OPTION: y.f32 = cuda_math::__uint2float_rn(y.u32); break;
+         case RM_OPTION: y.f32 = cuda_math::__uint2float_rd(y.u32); break;
+         case RP_OPTION: y.f32 = cuda_math::__uint2float_ru(y.u32); break;
+         default: break; 
+         }
+         break;
+      case 64: y.f64 = y.u32; break; // no rounding needed
+      default: assert(0); break;
+      }
+   } else {
+      switch ( to_width ) {
+      case 16: assert(0); break;
+      case 32: 
+         switch (rounding_mode) {
+         case RZ_OPTION: y.f32 = cuda_math::__ull2float_rn(y.u64); break; 
+         case RN_OPTION: y.f32 = cuda_math::__ull2float_rn(y.u64); break;
+         case RM_OPTION: y.f32 = cuda_math::__ull2float_rn(y.u64); break; 
+         case RP_OPTION: y.f32 = cuda_math::__ull2float_rn(y.u64); break; 
+         default: break; 
+         }
+         break;
+      case 64: y.f64 = y.u64; break; // no internal implementation found
+      default: assert(0); break;
+      }
+   }
+
+   // saturating an integer to 1 or 0?
+   return y;
 }
 
-ptx_reg_t s2f(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
-              int rounding_mode, int saturation_mode) {
-  ptx_reg_t y;
+ptx_reg_t f2f( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
+{
+   ptx_reg_t y;
+   if (from_width == 16){
+       half_float::detail::uint16 val = x.u16;
+       y.f32 = half_float::detail::half2float<float>(val);
+   }else{
+       switch ( rounding_mode ) {
+       case RZI_OPTION: 
+          y.f32 = truncf(x.f32); 
+          break;          
+       case RNI_OPTION: 
+    #if CUDART_VERSION >= 3000
+          y.f32 = nearbyintf(x.f32); 
+    #else
+          y.f32 = cuda_math::__internal_nearbyintf(x.f32); 
+    #endif
+          break;          
+       case RMI_OPTION: 
+          if ((x.u32 & 0x7f800000) == 0) {
+             y.u32 = x.u32 & 0x80000000; // round denorm. FP to 0, keeping sign
+          } else {
+             y.f32 = floorf(x.f32); 
+          }
+          break;          
+       case RPI_OPTION: 
+          if ((x.u32 & 0x7f800000) == 0) {
+             y.u32 = x.u32 & 0x80000000; // round denorm. FP to 0, keeping sign
+          } else {
+             y.f32 = ceilf(x.f32); 
+          }
+          break;          
+       default: 
+          if ((x.u32 & 0x7f800000) == 0) {
+             y.u32 = x.u32 & 0x80000000; // round denorm. FP to 0, keeping sign
+          } else {
+             y.f32 = x.f32;
+          }
+          break; 
+       }
+    #if CUDART_VERSION >= 3000
+       if (isnanf(y.f32)) 
+    #else
+       if (cuda_math::__cuda___isnanf(y.f32)) 
+    #endif
+       {
+          y.u32 = 0x7fffffff;
+       } else if (saturation_mode) {
+          y.f32 = cuda_math::__saturatef(y.f32);
+       }
+   }
 
-  if (from_width < 64) {  // 32-bit conversion
-    y = sext(x, from_width, 32, 0, rounding_mode, saturation_mode);
-
-    switch (to_width) {
-      case 16:
-        assert(0);
-        break;
-      case 32:
-        switch (rounding_mode) {
-          case RZ_OPTION:
-            y.f32 = cuda_math::__int2float_rz(y.s32);
-            break;
-          case RN_OPTION:
-            y.f32 = cuda_math::__int2float_rn(y.s32);
-            break;
-          case RM_OPTION:
-            y.f32 = cuda_math::__int2float_rd(y.s32);
-            break;
-          case RP_OPTION:
-            y.f32 = cuda_math::__int2float_ru(y.s32);
-            break;
-          default:
-            break;
-        }
-        break;
-      case 64:
-        y.f64 = y.s32;
-        break;  // no rounding needed
-      default:
-        assert(0);
-        break;
-    }
-  } else {
-    switch (to_width) {
-      case 16:
-        assert(0);
-        break;
-      case 32:
-        switch (rounding_mode) {
-          case RZ_OPTION:
-            y.f32 = cuda_math::__ll2float_rz(y.s64);
-            break;
-          case RN_OPTION:
-            y.f32 = cuda_math::__ll2float_rn(y.s64);
-            break;
-          case RM_OPTION:
-            y.f32 = cuda_math::__ll2float_rd(y.s64);
-            break;
-          case RP_OPTION:
-            y.f32 = cuda_math::__ll2float_ru(y.s64);
-            break;
-          default:
-            break;
-        }
-        break;
-      case 64:
-        y.f64 = y.s64;
-        break;  // no internal implementation found
-      default:
-        assert(0);
-        break;
-    }
-  }
-
-  // saturating an integer to 1 or 0?
-  return y;
+   return y;
 }
 
-ptx_reg_t u2f(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
-              int rounding_mode, int saturation_mode) {
-  ptx_reg_t y;
-
-  if (from_width < 64) {  // 32-bit conversion
-    y = zext(x, from_width, 32, 0, rounding_mode, saturation_mode);
-
-    switch (to_width) {
-      case 16:
-        assert(0);
-        break;
-      case 32:
-        switch (rounding_mode) {
-          case RZ_OPTION:
-            y.f32 = cuda_math::__uint2float_rz(y.u32);
-            break;
-          case RN_OPTION:
-            y.f32 = cuda_math::__uint2float_rn(y.u32);
-            break;
-          case RM_OPTION:
-            y.f32 = cuda_math::__uint2float_rd(y.u32);
-            break;
-          case RP_OPTION:
-            y.f32 = cuda_math::__uint2float_ru(y.u32);
-            break;
-          default:
-            break;
-        }
-        break;
-      case 64:
-        y.f64 = y.u32;
-        break;  // no rounding needed
-      default:
-        assert(0);
-        break;
-    }
-  } else {
-    switch (to_width) {
-      case 16:
-        assert(0);
-        break;
-      case 32:
-        switch (rounding_mode) {
-          case RZ_OPTION:
-            y.f32 = cuda_math::__ull2float_rn(y.u64);
-            break;
-          case RN_OPTION:
-            y.f32 = cuda_math::__ull2float_rn(y.u64);
-            break;
-          case RM_OPTION:
-            y.f32 = cuda_math::__ull2float_rn(y.u64);
-            break;
-          case RP_OPTION:
-            y.f32 = cuda_math::__ull2float_rn(y.u64);
-            break;
-          default:
-            break;
-        }
-        break;
-      case 64:
-        y.f64 = y.u64;
-        break;  // no internal implementation found
-      default:
-        assert(0);
-        break;
-    }
-  }
-
-  // saturating an integer to 1 or 0?
-  return y;
-}
-
-ptx_reg_t f2f(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
-              int rounding_mode, int saturation_mode) {
-  ptx_reg_t y;
-  if (from_width == 16) {
-    half_float::detail::uint16 val = x.u16;
-    y.f32 = half_float::detail::half2float<float>(val);
-  } else {
-    switch (rounding_mode) {
-      case RZI_OPTION:
-        y.f32 = truncf(x.f32);
-        break;
-      case RNI_OPTION:
+ptx_reg_t d2d( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
+{
+   ptx_reg_t y;
+   switch ( rounding_mode ) {
+   case RZI_OPTION: 
+      y.f64 = trunc(x.f64); 
+      break;          
+   case RNI_OPTION: 
 #if CUDART_VERSION >= 3000
-        y.f32 = nearbyintf(x.f32);
+      y.f64 = nearbyint(x.f64); 
 #else
-        y.f32 = cuda_math::__internal_nearbyintf(x.f32);
+      y.f64 = cuda_math::__internal_nearbyintf(x.f64); 
 #endif
-        break;
-      case RMI_OPTION:
-        if ((x.u32 & 0x7f800000) == 0) {
-          y.u32 = x.u32 & 0x80000000;  // round denorm. FP to 0, keeping sign
-        } else {
-          y.f32 = floorf(x.f32);
-        }
-        break;
-      case RPI_OPTION:
-        if ((x.u32 & 0x7f800000) == 0) {
-          y.u32 = x.u32 & 0x80000000;  // round denorm. FP to 0, keeping sign
-        } else {
-          y.f32 = ceilf(x.f32);
-        }
-        break;
-      default:
-        if ((x.u32 & 0x7f800000) == 0) {
-          y.u32 = x.u32 & 0x80000000;  // round denorm. FP to 0, keeping sign
-        } else {
-          y.f32 = x.f32;
-        }
-        break;
-    }
-#if CUDART_VERSION >= 3000
-    if (isnanf(y.f32))
-#else
-    if (cuda_math::__cuda___isnanf(y.f32))
-#endif
-    {
-      y.u32 = 0x7fffffff;
-    } else if (saturation_mode) {
-      y.f32 = cuda_math::__saturatef(y.f32);
-    }
-  }
-
-  return y;
-}
-
-ptx_reg_t d2d(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
-              int rounding_mode, int saturation_mode) {
-  ptx_reg_t y;
-  switch (rounding_mode) {
-    case RZI_OPTION:
-      y.f64 = trunc(x.f64);
-      break;
-    case RNI_OPTION:
-#if CUDART_VERSION >= 3000
-      y.f64 = nearbyint(x.f64);
-#else
-      y.f64 = cuda_math::__internal_nearbyintf(x.f64);
-#endif
-      break;
-    case RMI_OPTION:
-      y.f64 = floor(x.f64);
-      break;
-    case RPI_OPTION:
-      y.f64 = ceil(x.f64);
-      break;
-    default:
+      break;          
+   case RMI_OPTION: 
+      y.f64 = floor(x.f64); 
+      break;          
+   case RPI_OPTION: 
+      y.f64 = ceil(x.f64); 
+      break;          
+   default: 
       y.f64 = x.f64;
-      break;
-  }
-  if (std::isnan(y.f64)) {
-    y.u64 = 0xfff8000000000000ull;
-  } else if (saturation_mode) {
-    y.f64 = cuda_math::__saturatef(y.f64);
-  }
-  return y;
+      break; 
+   }
+   if (std::isnan(y.f64)) {
+      y.u64 = 0xfff8000000000000ull;
+   } else if (saturation_mode) {
+      y.f64 = cuda_math::__saturatef(y.f64); 
+   }
+   return y;
 }
 
-ptx_reg_t (*g_cvt_fn[11][11])(ptx_reg_t x, unsigned from_width,
-                              unsigned to_width, int to_sign, int rounding_mode,
-                              int saturation_mode) = {
-    {NULL, sext, sext, sext, NULL, sext, sext, sext, s2f, s2f, s2f},
-    {chop, NULL, sext, sext, chop, NULL, sext, sext, s2f, s2f, s2f},
-    {chop, sexd, NULL, sext, chop, chop, NULL, sext, s2f, s2f, s2f},
-    {chop, chop, chop, NULL, chop, chop, chop, NULL, s2f, s2f, s2f},
-    {NULL, zext, zext, zext, NULL, zext, zext, zext, u2f, u2f, u2f},
-    {chop, NULL, zext, zext, chop, NULL, zext, zext, u2f, u2f, u2f},
-    {chop, chop, NULL, zext, chop, chop, NULL, zext, u2f, u2f, u2f},
-    {chop, chop, chop, NULL, chop, chop, chop, NULL, u2f, u2f, u2f},
-    {f2x, f2x, f2x, f2x, f2x, f2x, f2x, f2x, NULL, f2f, f2x},
-    {f2x, f2x, f2x, f2x, f2x, f2x, f2x, f2x, f2x, f2f, f2x},
-    {d2x, d2x, d2x, d2x, d2x, d2x, d2x, d2x, d2x, d2x, d2d}};
+ptx_reg_t (*g_cvt_fn[11][11])( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, 
+                               int rounding_mode, int saturation_mode ) = {
+   { NULL, sext, sext, sext, NULL, sext, sext, sext, s2f, s2f, s2f}, 
+   { chop, NULL, sext, sext, chop, NULL, sext, sext, s2f, s2f, s2f}, 
+   { chop, sexd, NULL, sext, chop, chop, NULL, sext, s2f, s2f, s2f}, 
+   { chop, chop, chop, NULL, chop, chop, chop, NULL, s2f, s2f, s2f}, 
+   { NULL, zext, zext, zext, NULL, zext, zext, zext, u2f, u2f, u2f}, 
+   { chop, NULL, zext, zext, chop, NULL, zext, zext, u2f, u2f, u2f}, 
+   { chop, chop, NULL, zext, chop, chop, NULL, zext, u2f, u2f, u2f}, 
+   { chop, chop, chop, NULL, chop, chop, chop, NULL, u2f, u2f, u2f}, 
+   { f2x , f2x , f2x , f2x , f2x , f2x , f2x , f2x , NULL,f2f, f2x}, 
+   { f2x , f2x , f2x , f2x , f2x , f2x , f2x , f2x , f2x, f2f, f2x},
+   { d2x , d2x , d2x , d2x , d2x , d2x , d2x , d2x , d2x, d2x, d2d} 
+};
 
-void ptx_round(ptx_reg_t &data, int rounding_mode, int type) {
-  if (rounding_mode == RN_OPTION) {
-    return;
-  }
-  switch (rounding_mode) {
-    case RZI_OPTION:
-      switch (type) {
-        case S8_TYPE:
-        case S16_TYPE:
-        case S32_TYPE:
-        case S64_TYPE:
-        case U8_TYPE:
-        case U16_TYPE:
-        case U32_TYPE:
-        case U64_TYPE:
-          printf("Trying to round an integer??\n");
-          assert(0);
-          break;
-        case F16_TYPE:
-          data.f16 = truncf(data.f16);
-          break;  // assert(0); break;
-        case F32_TYPE:
-          data.f32 = truncf(data.f32);
-          break;
-        case F64_TYPE:
-        case FF64_TYPE:
-          if (data.f64 < 0)
-            data.f64 = ceil(data.f64);  // negative
-          else
-            data.f64 = floor(data.f64);  // positive
-          break;
-        default:
-          assert(0);
-          break;
+void ptx_round(ptx_reg_t& data, int rounding_mode, int type)
+{
+   if (rounding_mode == RN_OPTION) {
+      return;
+   }
+   switch ( rounding_mode ) {
+   case RZI_OPTION: 
+      switch ( type ) {
+      case S8_TYPE:
+      case S16_TYPE:
+      case S32_TYPE:
+      case S64_TYPE:
+      case U8_TYPE:
+      case U16_TYPE:
+      case U32_TYPE:
+      case U64_TYPE:
+         printf("Trying to round an integer??\n"); assert(0); break;
+      case F16_TYPE: data.f16=truncf(data.f16);break;//assert(0); break;
+      case F32_TYPE:
+         data.f32 = truncf(data.f32); 
+         break;          
+      case F64_TYPE:
+      case FF64_TYPE:
+         if (data.f64 < 0) data.f64 = ceil(data.f64); //negative
+         else data.f64 = floor(data.f64); //positive
+         break; 
+      default: assert(0); break;
       }
       break;
-    case RNI_OPTION:
-      switch (type) {
-        case S8_TYPE:
-        case S16_TYPE:
-        case S32_TYPE:
-        case S64_TYPE:
-        case U8_TYPE:
-        case U16_TYPE:
-        case U32_TYPE:
-        case U64_TYPE:
-          printf("Trying to round an integer??\n");
-          assert(0);
-          break;
-        case F16_TYPE:  // assert(0); break;
+   case RNI_OPTION: 
+      switch ( type ) {
+      case S8_TYPE:
+      case S16_TYPE:
+      case S32_TYPE:
+      case S64_TYPE:
+      case U8_TYPE:
+      case U16_TYPE:
+      case U32_TYPE:
+      case U64_TYPE:
+         printf("Trying to round an integer??\n"); assert(0); break;
+      case F16_TYPE:// assert(0); break;
 #if CUDART_VERSION >= 3000
-          data.f16 = nearbyintf(data.f16);
+         data.f16 = nearbyintf(data.f16); 
 #else
-          data.f16 = cuda_math::__cuda_nearbyintf(data.f16);
+         data.f16 = cuda_math::__cuda_nearbyintf(data.f16); 
 #endif
-          break;
-        case F32_TYPE:
+         break;          
+      case F32_TYPE: 
 #if CUDART_VERSION >= 3000
-          data.f32 = nearbyintf(data.f32);
+         data.f32 = nearbyintf(data.f32); 
 #else
-          data.f32 = cuda_math::__cuda_nearbyintf(data.f32);
+         data.f32 = cuda_math::__cuda_nearbyintf(data.f32); 
 #endif
-          break;
-        case F64_TYPE:
-        case FF64_TYPE:
-          data.f64 = round(data.f64);
-          break;
-        default:
-          assert(0);
-          break;
+         break;          
+      case F64_TYPE: case FF64_TYPE: data.f64 = round(data.f64); break; 
+      default: assert(0); break;
       }
       break;
-    case RMI_OPTION:
-      switch (type) {
-        case S8_TYPE:
-        case S16_TYPE:
-        case S32_TYPE:
-        case S64_TYPE:
-        case U8_TYPE:
-        case U16_TYPE:
-        case U32_TYPE:
-        case U64_TYPE:
-          printf("Trying to round an integer??\n");
-          assert(0);
-          break;
-        case F16_TYPE:
-          data.f16 = floorf(data.f16);
-          break;  // assert(0); break;
-        case F32_TYPE:
-          data.f32 = floorf(data.f32);
-          break;
-        case F64_TYPE:
-        case FF64_TYPE:
-          data.f64 = floor(data.f64);
-          break;
-        default:
-          assert(0);
-          break;
+   case RMI_OPTION: 
+      switch ( type ) {
+      case S8_TYPE:
+      case S16_TYPE:
+      case S32_TYPE:
+      case S64_TYPE:
+      case U8_TYPE:
+      case U16_TYPE:
+      case U32_TYPE:
+      case U64_TYPE:
+         printf("Trying to round an integer??\n"); assert(0); break;
+      case F16_TYPE: data.f16=floorf(data.f16);break;//assert(0); break;
+      case F32_TYPE: 
+         data.f32 = floorf(data.f32); 
+         break;          
+      case F64_TYPE: case FF64_TYPE: data.f64 = floor(data.f64); break; 
+      default: assert(0); break;
       }
       break;
-    case RPI_OPTION:
-      switch (type) {
-        case S8_TYPE:
-        case S16_TYPE:
-        case S32_TYPE:
-        case S64_TYPE:
-        case U8_TYPE:
-        case U16_TYPE:
-        case U32_TYPE:
-        case U64_TYPE:
-          printf("Trying to round an integer??\n");
-          assert(0);
-          break;
-        case F16_TYPE:
-          data.f16 = ceilf(data.f16);
-          break;  // assert(0); break;
-        case F32_TYPE:
-          data.f32 = ceilf(data.f32);
-          break;
-        case F64_TYPE:
-        case FF64_TYPE:
-          data.f64 = ceil(data.f64);
-          break;
-        default:
-          assert(0);
-          break;
+   case RPI_OPTION: 
+      switch ( type ) {
+      case S8_TYPE:
+      case S16_TYPE:
+      case S32_TYPE:
+      case S64_TYPE:
+      case U8_TYPE:
+      case U16_TYPE:
+      case U32_TYPE:
+      case U64_TYPE:
+         printf("Trying to round an integer??\n"); assert(0); break;
+      case F16_TYPE: data.f16 = ceilf(data.f16); break;  //assert(0); break;
+      case F32_TYPE: data.f32 = ceilf(data.f32); break;          
+      case F64_TYPE: case FF64_TYPE: data.f64 = ceil(data.f64); break; 
+      default: assert(0); break;
       }
       break;
-    default:
-      break;
-  }
+   default:  break; 
+   }
 
-  if (type == F32_TYPE) {
+   if (type == F32_TYPE) {
 #if CUDART_VERSION >= 3000
-    if (isnanf(data.f32))
+      if (isnanf(data.f32)) 
 #else
-    if (cuda_math::__cuda___isnanf(data.f32))
+      if (cuda_math::__cuda___isnanf(data.f32)) 
 #endif
-    {
-      data.u32 = 0x7fffffff;
-    }
-  }
-  if ((type == F64_TYPE) || (type == FF64_TYPE)) {
-    if (std::isnan(data.f64)) {
-      data.u64 = 0xfff8000000000000ull;
-    }
-  }
+      {
+         data.u32 = 0x7fffffff;
+      }
+   }
+   if ((type == F64_TYPE)||(type == FF64_TYPE)) {
+      if (std::isnan(data.f64)) {
+         data.u64 = 0xfff8000000000000ull;
+      }
+   }
 }
 
-void ptx_saturate(ptx_reg_t &data, int saturation_mode, int type) {
-  if (!saturation_mode) {
-    return;
-  }
-  switch (type) {
-    case S8_TYPE:
-    case S16_TYPE:
-    case S32_TYPE:
-    case S64_TYPE:
-    case U8_TYPE:
-    case U16_TYPE:
-    case U32_TYPE:
-    case U64_TYPE:
-      printf("Trying to clamp an integer to 1??\n");
-      assert(0);
-      break;
-    case F16_TYPE:                           // assert(0); break;
-      if (data.f16 > 1.0f) data.f16 = 1.0f;  // negative
-      if (data.f16 < 0.0f) data.f16 = 0.0f;  // positive
-      break;
-    case F32_TYPE:
-      if (data.f32 > 1.0f) data.f32 = 1.0f;  // negative
-      if (data.f32 < 0.0f) data.f32 = 0.0f;  // positive
-      break;
-    case F64_TYPE:
-    case FF64_TYPE:
-      if (data.f64 > 1.0f) data.f64 = 1.0f;  // negative
-      if (data.f64 < 0.0f) data.f64 = 0.0f;  // positive
-      break;
-    default:
-      assert(0);
-      break;
-  }
+void ptx_saturate(ptx_reg_t& data, int saturation_mode, int type)
+{
+   if (!saturation_mode) {
+      return;
+   }
+   switch ( type ) {
+   case S8_TYPE:
+   case S16_TYPE:
+   case S32_TYPE:
+   case S64_TYPE:
+   case U8_TYPE:
+   case U16_TYPE:
+   case U32_TYPE:
+   case U64_TYPE:
+      printf("Trying to clamp an integer to 1??\n"); assert(0); break;
+   case F16_TYPE: //assert(0); break;
+      if (data.f16 > 1.0f) data.f16 = 1.0f; //negative
+      if (data.f16 < 0.0f) data.f16 = 0.0f; //positive
+      break;          
+   case F32_TYPE:
+      if (data.f32 > 1.0f) data.f32 = 1.0f; //negative
+      if (data.f32 < 0.0f) data.f32 = 0.0f; //positive
+      break;          
+   case F64_TYPE:
+   case FF64_TYPE:
+      if (data.f64 > 1.0f) data.f64 = 1.0f; //negative
+      if (data.f64 < 0.0f) data.f64 = 0.0f; //positive
+      break; 
+   default: assert(0); break;
+   }
+
 }
 
-void cvt_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  unsigned to_type = pI->get_type();
-  unsigned from_type = pI->get_type2();
-  unsigned rounding_mode = pI->rounding_mode();
-  unsigned saturation_mode = pI->saturation_mode();
+void cvt_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
+   unsigned to_type = pI->get_type();
+   unsigned from_type = pI->get_type2();
+   unsigned rounding_mode = pI->rounding_mode();
+   unsigned saturation_mode = pI->saturation_mode();
 
-  //   if ( to_type == F16_TYPE || from_type == F16_TYPE )
-  //      abort();
+//   if ( to_type == F16_TYPE || from_type == F16_TYPE )
+//      abort();
 
-  int to_sign, from_sign;
-  size_t from_width, to_width;
-  unsigned src_fmt =
-      type_info_key::type_decode(from_type, from_width, from_sign);
-  unsigned dst_fmt = type_info_key::type_decode(to_type, to_width, to_sign);
+   int to_sign, from_sign;
+   size_t from_width, to_width;
+   unsigned src_fmt = type_info_key::type_decode(from_type, from_width, from_sign);
+   unsigned dst_fmt = type_info_key::type_decode(to_type, to_width, to_sign);
 
-  ptx_reg_t data = thread->get_operand_value(src1, dst, from_type, thread, 1);
+   ptx_reg_t data = thread->get_operand_value(src1, dst, from_type, thread, 1);
 
-  if (pI->is_neg()) {
-    switch (from_type) {
+   if(pI->is_neg()){
+
+   switch( from_type ) {
       // Default to f32 for now, need to add support for others
       case S8_TYPE:
       case U8_TYPE:
       case B8_TYPE:
-        data.s8 = -data.s8;
-        break;
+         data.s8 = -data.s8;
+         break;
       case S16_TYPE:
       case U16_TYPE:
       case B16_TYPE:
-        data.s16 = -data.s16;
-        break;
+         data.s16 = -data.s16;
+         break;
       case S32_TYPE:
       case U32_TYPE:
       case B32_TYPE:
-        data.s32 = -data.s32;
-        break;
+         data.s32 = -data.s32;
+         break;
       case S64_TYPE:
       case U64_TYPE:
       case B64_TYPE:
-        data.s64 = -data.s64;
-        break;
+         data.s64 = -data.s64;
+         break;
       case F16_TYPE:
-        data.f16 = -data.f16;
-        break;
+         data.f16 = -data.f16;
+         break;
       case F32_TYPE:
-        data.f32 = -data.f32;
-        break;
+         data.f32 = -data.f32;
+         break;
       case F64_TYPE:
       case FF64_TYPE:
-        data.f64 = -data.f64;
-        break;
+         data.f64 = -data.f64;
+         break;
       default:
-        assert(0);
-    }
-  }
+         assert(0);
+      }
 
-  if (g_cvt_fn[src_fmt][dst_fmt] != NULL) {
-    ptx_reg_t result = g_cvt_fn[src_fmt][dst_fmt](
-        data, from_width, to_width, to_sign, rounding_mode, saturation_mode);
-    data = result;
-  }
+   }
 
-  thread->set_operand_value(dst, data, to_type, thread, pI);
+
+   if ( g_cvt_fn[src_fmt][dst_fmt] != NULL ) {
+      ptx_reg_t result = g_cvt_fn[src_fmt][dst_fmt](data,from_width,to_width,to_sign, rounding_mode, saturation_mode);
+      data = result;
+   }
+
+   thread->set_operand_value(dst, data, to_type, thread, pI );
 }
 
-void cvta_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t data;
+void cvta_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   ptx_reg_t data;
 
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  memory_space_t space = pI->get_space();
-  bool to_non_generic = pI->is_to();
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
+   memory_space_t space = pI->get_space();
+   bool to_non_generic = pI->is_to();
 
-  unsigned i_type = pI->get_type();
-  ptx_reg_t from_addr = thread->get_operand_value(src1, dst, i_type, thread, 1);
-  addr_t from_addr_hw = (addr_t)from_addr.u64;
-  addr_t to_addr_hw = 0;
-  unsigned smid = thread->get_hw_sid();
-  unsigned hwtid = thread->get_hw_tid();
+   unsigned i_type = pI->get_type();
+   ptx_reg_t from_addr = thread->get_operand_value(src1,dst,i_type,thread,1);
+   addr_t from_addr_hw = (addr_t)from_addr.u64;
+   addr_t to_addr_hw = 0;
+   unsigned smid = thread->get_hw_sid();
+   unsigned hwtid = thread->get_hw_tid();
 
-  if (to_non_generic) {
-    switch (space.get_type()) {
-      case shared_space:
-        to_addr_hw = generic_to_shared(smid, from_addr_hw);
-        break;
-      case local_space:
-        to_addr_hw = generic_to_local(smid, hwtid, from_addr_hw);
-        break;
-      case global_space:
-        to_addr_hw = generic_to_global(from_addr_hw);
-        break;
-      default:
-        abort();
-    }
-  } else {
-    switch (space.get_type()) {
-      case shared_space:
-        to_addr_hw = shared_to_generic(smid, from_addr_hw);
-        break;
-      case local_space:
-        to_addr_hw = local_to_generic(smid, hwtid, from_addr_hw) +
-                     thread->get_local_mem_stack_pointer();
-        break;  // add stack ptr here so that it can be passed as a pointer at
-                // function call
-      case global_space:
-        to_addr_hw = global_to_generic(from_addr_hw);
-        break;
-      default:
-        abort();
-    }
-  }
-
-  ptx_reg_t to_addr;
-  to_addr.u64 = to_addr_hw;
-  thread->set_reg(dst.get_symbol(), to_addr);
+   if( to_non_generic ) {
+      switch( space.get_type() ) {
+      case shared_space: to_addr_hw = generic_to_shared( smid, from_addr_hw ); break;
+      case local_space:  to_addr_hw = generic_to_local( smid, hwtid, from_addr_hw ); break;
+      case global_space: to_addr_hw = generic_to_global(from_addr_hw ); break;
+      default: abort();
+      }
+   } else {
+      switch( space.get_type() ) {
+      case shared_space: to_addr_hw = shared_to_generic( smid, from_addr_hw ); break;
+      case local_space:  to_addr_hw =  local_to_generic( smid, hwtid, from_addr_hw )
+                                      + thread->get_local_mem_stack_pointer(); break; // add stack ptr here so that it can be passed as a pointer at function call 
+      case global_space: to_addr_hw = global_to_generic( from_addr_hw ); break;
+      default: abort();
+      }
+   }
+   
+   ptx_reg_t to_addr;
+   to_addr.u64 = to_addr_hw;
+   thread->set_reg(dst.get_symbol(),to_addr);
 }
 
-void div_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t data;
+void div_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   ptx_reg_t data;
 
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  const operand_info &src2 = pI->src2();
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
+   const operand_info &src2 = pI->src2();
 
-  unsigned i_type = pI->get_type();
+   unsigned i_type = pI->get_type();
 
-  ptx_reg_t src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-  ptx_reg_t src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+   ptx_reg_t src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   ptx_reg_t src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-  switch (i_type) {
-    case S8_TYPE:
-      data.s8 = src1_data.s8 / src2_data.s8;
-      break;
-    case S16_TYPE:
-      data.s16 = src1_data.s16 / src2_data.s16;
-      break;
-    case S32_TYPE:
-      data.s32 = src1_data.s32 / src2_data.s32;
-      break;
-    case S64_TYPE:
-      data.s64 = src1_data.s64 / src2_data.s64;
-      break;
-    case U8_TYPE:
-      data.u8 = src1_data.u8 / src2_data.u8;
-      break;
-    case U16_TYPE:
-      data.u16 = src1_data.u16 / src2_data.u16;
-      break;
-    case U32_TYPE:
-      data.u32 = src1_data.u32 / src2_data.u32;
-      break;
-    case U64_TYPE:
-      data.u64 = src1_data.u64 / src2_data.u64;
-      break;
-    case B8_TYPE:
-      data.u8 = src1_data.u8 / src2_data.u8;
-      break;
-    case B16_TYPE:
-      data.u16 = src1_data.u16 / src2_data.u16;
-      break;
-    case B32_TYPE:
-      data.u32 = src1_data.u32 / src2_data.u32;
-      break;
-    case B64_TYPE:
-      data.u64 = src1_data.u64 / src2_data.u64;
-      break;
-    case F16_TYPE:
-      data.f16 = src1_data.f16 / src2_data.f16;
-      break;  // assert(0); break;
-    case F32_TYPE:
-      data.f32 = src1_data.f32 / src2_data.f32;
-      break;
-    case F64_TYPE:
-    case FF64_TYPE:
-      data.f64 = src1_data.f64 / src2_data.f64;
-      break;
-    default:
-      assert(0);
-      break;
-  }
-  thread->set_operand_value(dst, data, i_type, thread, pI);
+
+   switch ( i_type ) {
+   case S8_TYPE:
+      data.s8  = src1_data.s8  / src2_data.s8 ; break;
+   case S16_TYPE:
+      data.s16 = src1_data.s16 / src2_data.s16; break;
+   case S32_TYPE:
+      data.s32 = src1_data.s32 / src2_data.s32; break;
+   case S64_TYPE: 
+      data.s64 = src1_data.s64 / src2_data.s64; break;
+   case U8_TYPE:
+      data.u8  = src1_data.u8  / src2_data.u8 ; break;
+   case U16_TYPE:
+      data.u16 = src1_data.u16 / src2_data.u16; break;
+   case U32_TYPE:
+      data.u32 = src1_data.u32 / src2_data.u32; break;
+   case U64_TYPE: 
+      data.u64 = src1_data.u64 / src2_data.u64; break;
+   case B8_TYPE:
+      data.u8  = src1_data.u8  / src2_data.u8 ; break;
+   case B16_TYPE:
+      data.u16 = src1_data.u16 / src2_data.u16; break;
+   case B32_TYPE:
+      data.u32 = src1_data.u32 / src2_data.u32; break;
+   case B64_TYPE:
+      data.u64 = src1_data.u64 / src2_data.u64; break;
+   case F16_TYPE: data.f16 = src1_data.f16 / src2_data.f16; break;//assert(0); break;
+   case F32_TYPE: data.f32 = src1_data.f32 / src2_data.f32; break;
+   case F64_TYPE: case FF64_TYPE: data.f64 = src1_data.f64 / src2_data.f64; break;
+   default: assert(0); break;
+   }
+   thread->set_operand_value(dst,data, i_type, thread,pI);
 }
 
-void dp4a_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  printf("DP4A instruction not implemented yet");
-  assert(0);
+void dp4a_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   printf("DP4A instruction not implemented yet");
+   assert(0);
+
 }
 
-void ex2_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t src1_data, src2_data, data;
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
+void ex2_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   ptx_reg_t src1_data, src2_data, data;
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
 
-  unsigned i_type = pI->get_type();
+   unsigned i_type = pI->get_type();
 
-  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
 
-  switch (i_type) {
-    case F32_TYPE:
+
+   switch ( i_type ) {
+   case F32_TYPE: 
       data.f32 = cuda_math::__powf(2.0, src1_data.f32);
       break;
-    default:
+   default:
       printf("Execution error: type mismatch with instruction\n");
-      assert(0);
+      assert(0); 
       break;
-  }
-
-  thread->set_operand_value(dst, data, i_type, thread, pI);
+   }
+   
+   thread->set_operand_value(dst,data, i_type, thread,pI);
 }
 
-void exit_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  thread->set_done();
-  thread->exitCore();
-  thread->registerExit();
+void exit_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+   thread->set_done();
+   thread->exitCore();
+   thread->registerExit();
 }
 
-void mad_def(const ptx_instruction *pI, ptx_thread_info *thread,
-             bool use_carry = false);
+void mad_def( const ptx_instruction *pI, ptx_thread_info *thread, bool use_carry = false );
 
-void fma_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  mad_def(pI, thread);
+void fma_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+   mad_def(pI,thread);
 }
 
-void isspacep_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t a;
-  bool t = false;
+void isspacep_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   ptx_reg_t a;
+   bool t=false;
 
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  memory_space_t space = pI->get_space();
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
+   memory_space_t space = pI->get_space();
 
-  a = thread->get_reg(src1.get_symbol());
-  addr_t addr = (addr_t)a.u64;
-  unsigned smid = thread->get_hw_sid();
-  unsigned hwtid = thread->get_hw_tid();
+   a = thread->get_reg(src1.get_symbol());
+   addr_t addr = (addr_t)a.u64;
+   unsigned smid = thread->get_hw_sid();
+   unsigned hwtid = thread->get_hw_tid();
 
-  switch (space.get_type()) {
-    case shared_space:
-      t = isspace_shared(smid, addr);
-    case local_space:
-      t = isspace_local(smid, hwtid, addr);
-    case global_space:
-      t = isspace_global(addr);
-    default:
-      abort();
-  }
+   switch( space.get_type() ) {
+   case shared_space: t = isspace_shared( smid, addr );
+   case local_space:  t = isspace_local( smid, hwtid, addr );
+   case global_space: t = isspace_global( addr );
+   default: abort();
+   }
 
-  ptx_reg_t p;
-  p.pred = t ? 1 : 0;
+   ptx_reg_t p;
+   p.pred = t?1:0;
 
-  thread->set_reg(dst.get_symbol(), p);
+   thread->set_reg(dst.get_symbol(),p);
 }
 
-void decode_space(memory_space_t &space, ptx_thread_info *thread,
-                  const operand_info &op, memory_space *&mem, addr_t &addr) {
-  unsigned smid = thread->get_hw_sid();
-  unsigned hwtid = thread->get_hw_tid();
+void decode_space( memory_space_t &space, ptx_thread_info *thread, const operand_info &op, memory_space *&mem, addr_t &addr)
+{
+   unsigned smid = thread->get_hw_sid();
+   unsigned hwtid = thread->get_hw_tid();
 
-  if (space == param_space_unclassified) {
-    // need to op to determine whether it refers to a kernel param or local
-    // param
-    const symbol *s = op.get_symbol();
-    const type_info *t = s->type();
-    type_info_key ti = t->get_key();
-    if (ti.is_param_kernel())
-      space = param_space_kernel;
-    else if (ti.is_param_local()) {
-      space = param_space_local;
-    }
-    // mov r1, param-label
-    else if (ti.is_reg()) {
-      space = param_space_kernel;
-    } else {
-      printf("GPGPU-Sim PTX: ERROR ** cannot resolve .param space for '%s'\n",
-             s->name().c_str());
-      abort();
-    }
-  }
-  switch (space.get_type()) {
-    case global_space:
-      mem = thread->get_global_memory();
-      break;
-    case param_space_local:
-    case local_space:
-      mem = thread->m_local_mem;
+   if( space == param_space_unclassified ) {
+      // need to op to determine whether it refers to a kernel param or local param
+      const symbol *s = op.get_symbol();
+      const type_info *t = s->type();
+      type_info_key ti = t->get_key();
+      if( ti.is_param_kernel() )
+         space = param_space_kernel;
+      else if( ti.is_param_local() ) {
+         space = param_space_local;
+      }
+      //mov r1, param-label
+      else if (ti.is_reg() ){
+         space = param_space_kernel;
+      }
+      else {
+         printf("GPGPU-Sim PTX: ERROR ** cannot resolve .param space for '%s'\n", s->name().c_str() );
+         abort(); 
+      }
+   }
+   switch ( space.get_type() ) {
+   case global_space: mem = thread->get_global_memory(); break;
+   case param_space_local:
+   case local_space:
+      mem = thread->m_local_mem; 
       addr += thread->get_local_mem_stack_pointer();
-      break;
-    case tex_space:
-      mem = thread->get_tex_memory();
-      break;
-    case surf_space:
-      mem = thread->get_surf_memory();
-      break;
-    case param_space_kernel:
-      mem = thread->get_param_memory();
-      break;
-    case shared_space:
-      mem = thread->m_shared_mem;
-      break;
-    case sstarr_space:
-      mem = thread->m_sstarr_mem;
-      break;
-    case const_space:
-      mem = thread->get_global_memory();
-      break;
-    case generic_space:
-      if (thread->get_ptx_version().ver() >= 2.0) {
-        // convert generic address to memory space address
-        space = whichspace(addr);
-        switch (space.get_type()) {
-          case global_space:
-            mem = thread->get_global_memory();
-            addr = generic_to_global(addr);
-            break;
-          case local_space:
-            mem = thread->m_local_mem;
-            addr = generic_to_local(smid, hwtid, addr);
-            break;
-          case shared_space:
-            mem = thread->m_shared_mem;
-            addr = generic_to_shared(smid, addr);
-            break;
-          default:
-            abort();
-        }
+      break; 
+   case tex_space:    mem = thread->get_tex_memory(); break; 
+   case surf_space:   mem = thread->get_surf_memory(); break; 
+   case param_space_kernel:  mem = thread->get_param_memory(); break;
+   case shared_space:  mem = thread->m_shared_mem; break; 
+   case sstarr_space:	mem = thread->m_sstarr_mem; break;
+   case const_space:  mem = thread->get_global_memory(); break;
+   case generic_space:
+      if( thread->get_ptx_version().ver() >= 2.0 ) {
+         // convert generic address to memory space address
+         space = whichspace(addr);
+         switch ( space.get_type() ) {
+         case global_space: mem = thread->get_global_memory(); addr = generic_to_global(addr); break;
+         case local_space:  mem = thread->m_local_mem; addr = generic_to_local(smid,hwtid,addr); break; 
+         case shared_space: mem = thread->m_shared_mem; addr = generic_to_shared(smid,addr); break; 
+         default: abort();
+         }
       } else {
-        abort();
+         abort();
       }
       break;
-    case param_space_unclassified:
-    case undefined_space:
-    default:
+   case param_space_unclassified:
+   case undefined_space:
+   default:
       abort();
-  }
+   }
 }
 
-void ld_exec(const ptx_instruction *pI, ptx_thread_info *thread) {
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
+void ld_exec( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   const operand_info &dst = pI->dst();
+   const operand_info &src1 = pI->src1();
 
-  unsigned type = pI->get_type();
+   unsigned type = pI->get_type();
 
-  ptx_reg_t src1_data = thread->get_operand_value(src1, dst, type, thread, 1);
-  ptx_reg_t data;
-  memory_space_t space = pI->get_space();
-  unsigned vector_spec = pI->get_vector();
+   ptx_reg_t src1_data = thread->get_operand_value(src1, dst, type, thread, 1);
+   ptx_reg_t data;
+   memory_space_t space = pI->get_space();
+   unsigned vector_spec = pI->get_vector();
 
-  memory_space *mem = NULL;
-  addr_t addr = src1_data.u32;
+   memory_space *mem = NULL;
+   addr_t addr = src1_data.u32;
 
-  decode_space(space, thread, src1, mem, addr);
+   decode_space(space,thread,src1,mem,addr);
 
-  size_t size;
-  int t;
-  data.u64 = 0;
-  type_info_key::type_decode(type, size, t);
-  if (!vector_spec) {
-    mem->read(addr, size / 8, &data.s64);
-    if (type == S16_TYPE || type == S32_TYPE) sign_extend(data, size, dst);
-    thread->set_operand_value(dst, data, type, thread, pI);
-  } else {
-    ptx_reg_t data1, data2, data3, data4;
-    mem->read(addr, size / 8, &data1.s64);
-    mem->read(addr + size / 8, size / 8, &data2.s64);
-    if (vector_spec != V2_TYPE) {  // either V3 or V4
-      mem->read(addr + 2 * size / 8, size / 8, &data3.s64);
-      if (vector_spec != V3_TYPE) {  // v4
-        mem->read(addr + 3 * size / 8, size / 8, &data4.s64);
-        thread->set_vector_operand_values(dst, data1, data2, data3, data4);
-      } else  // v3
-        thread->set_vector_operand_values(dst, data1, data2, data3, data3);
-    } else  // v2
-      thread->set_vector_operand_values(dst, data1, data2, data2, data2);
-  }
-  thread->m_last_effective_address = addr;
-  thread->m_last_memory_space = space;
+   size_t size;
+   int t;
+   data.u64=0;
+   type_info_key::type_decode(type,size,t);
+   if (!vector_spec) {
+      mem->read(addr,size/8,&data.s64);
+      if( type == S16_TYPE || type == S32_TYPE ) 
+         sign_extend(data,size,dst);
+      thread->set_operand_value(dst,data, type, thread, pI);
+   } else {
+      ptx_reg_t data1, data2, data3, data4;
+      mem->read(addr,size/8,&data1.s64);
+      mem->read(addr+size/8,size/8,&data2.s64);
+      if (vector_spec != V2_TYPE) { //either V3 or V4
+         mem->read(addr+2*size/8,size/8,&data3.s64);
+         if (vector_spec != V3_TYPE) { //v4
+            mem->read(addr+3*size/8,size/8,&data4.s64);
+            thread->set_vector_operand_values(dst,data1,data2,data3,data4);
+         } else //v3
+            thread->set_vector_operand_values(dst,data1,data2,data3,data3);
+      } else //v2
+         thread->set_vector_operand_values(dst,data1,data2,data2,data2);
+   }
+   thread->m_last_effective_address = addr;
+   thread->m_last_memory_space = space; 
 }
 
-void ld_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ld_exec(pI, thread);
+void ld_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+   ld_exec(pI,thread);
 }
-void ldu_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ld_exec(pI, thread);
+void ldu_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   ld_exec(pI,thread);
 }
 
-void mma_st_impl(const ptx_instruction *pI, core_t *core, warp_inst_t &inst) {
-  size_t size;
-  unsigned smid;
-  int t;
-  int thrd, k;
-  ptx_thread_info *thread;
+void mma_st_impl( const ptx_instruction *pI, core_t *core, warp_inst_t &inst )
+{
+   size_t size;
+   unsigned smid;
+   int t;
+   int thrd, k;
+   ptx_thread_info *thread;
+   
+   const operand_info &src  = pI->operand_lookup(1);
+   const operand_info &src1 = pI->operand_lookup(0);
+   const operand_info &src2 = pI->operand_lookup(2);
+   int tid ;
+   unsigned type = pI->get_type();
+   unsigned wmma_type = pI->get_wmma_type();
+   unsigned wmma_layout = pI->get_wmma_layout(0);
+   int stride; 
 
-  const operand_info &src = pI->operand_lookup(1);
-  const operand_info &src1 = pI->operand_lookup(0);
-  const operand_info &src2 = pI->operand_lookup(2);
-  int tid;
-  unsigned type = pI->get_type();
-  unsigned wmma_type = pI->get_wmma_type();
-  unsigned wmma_layout = pI->get_wmma_layout(0);
-  int stride;
+   if(core->get_gpu()->is_functional_sim())
+    	tid= inst.warp_id_func()*core->get_warp_size();
+   else
+    	tid= inst.warp_id()*core->get_warp_size();
 
-  if (core->get_gpu()->is_functional_sim())
-    tid = inst.warp_id_func() * core->get_warp_size();
-  else
-    tid = inst.warp_id() * core->get_warp_size();
-
-  _memory_op_t insn_memory_op =
-      pI->has_memory_read() ? memory_load : memory_store;
-  for (thrd = 0; thrd < core->get_warp_size(); thrd++) {
-    thread = core->get_thread_info()[tid + thrd];
+   _memory_op_t insn_memory_op = pI->has_memory_read() ? memory_load : memory_store;
+   for (thrd=0; thrd < core->get_warp_size(); thrd++) {
+	thread = core->get_thread_info()[tid+thrd];
     ptx_reg_t addr_reg = thread->get_operand_value(src1, src, type, thread, 1);
-    ptx_reg_t src2_data = thread->get_operand_value(src2, src, type, thread, 1);
-    const operand_info &src_a = pI->operand_lookup(1);
-    unsigned nelem = src_a.get_vect_nelem();
-    ptx_reg_t *v = new ptx_reg_t[8];
-    thread->get_vector_operand_values(src_a, v, nelem);
-    stride = src2_data.u32;
+   	ptx_reg_t src2_data = thread->get_operand_value(src2, src, type, thread, 1);
+	const operand_info &src_a=  pI->operand_lookup(1);
+        unsigned nelem = src_a.get_vect_nelem();
+        ptx_reg_t* v= new ptx_reg_t[8]; 
+       	thread->get_vector_operand_values( src_a, v, nelem );
+  	stride = src2_data.u32;
+ 
+   	memory_space_t space = pI->get_space();
 
-    memory_space_t space = pI->get_space();
+   	memory_space *mem = NULL;
+   	addr_t addr = addr_reg.u32;
+	
+	new_addr_type mem_txn_addr[MAX_ACCESSES_PER_INSN_PER_THREAD];
+	int num_mem_txn=0;
+        
+        smid = thread->get_hw_sid();
+   	if( whichspace(addr) == shared_space ) {
+          addr= generic_to_shared(smid,addr);
+          space = shared_space;
+	}
+   	decode_space(space,thread,src1,mem,addr);
 
-    memory_space *mem = NULL;
-    addr_t addr = addr_reg.u32;
+   	type_info_key::type_decode(type, size, t);
+   	if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+		printf("mma_st: thrd=%d, addr=%x, fp(size=%zu), stride=%d\n", thrd, addr_reg.u32, size, src2_data.u32);
+	addr_t new_addr = addr+thread_group_offset(thrd,wmma_type,wmma_layout,type,stride)*size/8;  
+	addr_t push_addr;
 
-    new_addr_type mem_txn_addr[MAX_ACCESSES_PER_INSN_PER_THREAD];
-    int num_mem_txn = 0;
+	ptx_reg_t nw_v[8];
+	for(k=0;k<8;k++){
+		if(k%2==0)
+			nw_v[k].s64=(v[k/2].s64&0xffff);
+		else
+			nw_v[k].s64=((v[k/2].s64&0xffff0000)>>16);
+	}
 
-    smid = thread->get_hw_sid();
-    if (whichspace(addr) == shared_space) {
-      addr = generic_to_shared(smid, addr);
-      space = shared_space;
-    }
-    decode_space(space, thread, src1, mem, addr);
+	for(k=0;k<8;k++){
+		if(type==F32_TYPE){
+       			//mem->write(new_addr+4*acc_float_offset(k,wmma_layout,stride),size/8,&v[k].s64,thread,pI);
+       			push_addr=new_addr+4*acc_float_offset(k,wmma_layout,stride);
+       			mem->write(push_addr,size/8,&v[k].s64,thread,pI);
+			mem_txn_addr[num_mem_txn++]=push_addr;
+	
+			if(core->get_gpu()->gpgpu_ctx->debug_tensorcore){
+				printf("wmma:store:thread%d=%llx,%llx,%llx,%llx,%llx,%llx,%llx,%llx\n",thrd,v[0].s64,v[1].s64,v[2].s64,v[3].s64,v[4].s64,v[5].s64,v[6].s64,v[7].s64);   
+				float temp;
+				int l;
+				printf("thread=%d:",thrd);
+				for(l=0;l<8;l++){
+					temp=v[l].f32;
+					printf("%.2f",temp);	
+				}
+				printf("\n");
+			}
+		}
+		else if(type==F16_TYPE){
+			if(wmma_layout==ROW){
+       				//mem->write(new_addr+k*2,size/8,&nw_v[k].s64,thread,pI);
+       				push_addr=new_addr+k*2;
+       				mem->write(push_addr,size/8,&nw_v[k].s64,thread,pI);
+				if(k%2==0)
+					mem_txn_addr[num_mem_txn++]=push_addr;
+			}
+			else if(wmma_layout==COL){
+       				//mem->write(new_addr+k*2*stride,size/8,&nw_v[k].s64,thread,pI);
+       				push_addr=new_addr+k*2*stride;
+       				mem->write(push_addr,size/8,&nw_v[k].s64,thread,pI);
+				mem_txn_addr[num_mem_txn++]=push_addr;
+			}
+	
+			if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+				printf("wmma:store:thread%d=%llx,%llx,%llx,%llx,%llx,%llx,%llx,%llx\n",thrd,nw_v[0].s64,nw_v[1].s64,nw_v[2].s64,nw_v[3].s64,nw_v[4].s64,nw_v[5].s64,nw_v[6].s64,nw_v[7].s64);   
+		}
+	}
+   	
+	delete [] v;
+   	inst.space = space;
+   	inst.set_addr(thrd, (new_addr_type *)mem_txn_addr , num_mem_txn);
 
-    type_info_key::type_decode(type, size, t);
-    if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-      printf("mma_st: thrd=%d, addr=%x, fp(size=%zu), stride=%d\n", thrd,
-             addr_reg.u32, size, src2_data.u32);
-    addr_t new_addr =
-        addr +
-        thread_group_offset(thrd, wmma_type, wmma_layout, type, stride) * size /
-            8;
-    addr_t push_addr;
+	if((type==F16_TYPE)&&(wmma_layout==COL))//check the profiling xls for details
+   		inst.data_size = 2; // 2 byte transaction 
+   	else
+		inst.data_size = 4; // 4 byte transaction 
 
-    ptx_reg_t nw_v[8];
-    for (k = 0; k < 8; k++) {
-      if (k % 2 == 0)
-        nw_v[k].s64 = (v[k / 2].s64 & 0xffff);
-      else
-        nw_v[k].s64 = ((v[k / 2].s64 & 0xffff0000) >> 16);
-    }
-
-    for (k = 0; k < 8; k++) {
-      if (type == F32_TYPE) {
-        // mem->write(new_addr+4*acc_float_offset(k,wmma_layout,stride),size/8,&v[k].s64,thread,pI);
-        push_addr = new_addr + 4 * acc_float_offset(k, wmma_layout, stride);
-        mem->write(push_addr, size / 8, &v[k].s64, thread, pI);
-        mem_txn_addr[num_mem_txn++] = push_addr;
-
-        if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) {
-          printf(
-              "wmma:store:thread%d=%llx,%llx,%llx,%llx,%llx,%llx,%llx,%llx\n",
-              thrd, v[0].s64, v[1].s64, v[2].s64, v[3].s64, v[4].s64, v[5].s64,
-              v[6].s64, v[7].s64);
-          float temp;
-          int l;
-          printf("thread=%d:", thrd);
-          for (l = 0; l < 8; l++) {
-            temp = v[l].f32;
-            printf("%.2f", temp);
-          }
-          printf("\n");
-        }
-      } else if (type == F16_TYPE) {
-        if (wmma_layout == ROW) {
-          // mem->write(new_addr+k*2,size/8,&nw_v[k].s64,thread,pI);
-          push_addr = new_addr + k * 2;
-          mem->write(push_addr, size / 8, &nw_v[k].s64, thread, pI);
-          if (k % 2 == 0) mem_txn_addr[num_mem_txn++] = push_addr;
-        } else if (wmma_layout == COL) {
-          // mem->write(new_addr+k*2*stride,size/8,&nw_v[k].s64,thread,pI);
-          push_addr = new_addr + k * 2 * stride;
-          mem->write(push_addr, size / 8, &nw_v[k].s64, thread, pI);
-          mem_txn_addr[num_mem_txn++] = push_addr;
-        }
-
-        if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-          printf(
-              "wmma:store:thread%d=%llx,%llx,%llx,%llx,%llx,%llx,%llx,%llx\n",
-              thrd, nw_v[0].s64, nw_v[1].s64, nw_v[2].s64, nw_v[3].s64,
-              nw_v[4].s64, nw_v[5].s64, nw_v[6].s64, nw_v[7].s64);
-      }
-    }
-
-    delete[] v;
-    inst.space = space;
-    inst.set_addr(thrd, (new_addr_type *)mem_txn_addr, num_mem_txn);
-
-    if ((type == F16_TYPE) &&
-        (wmma_layout == COL))  // check the profiling xls for details
-      inst.data_size = 2;      // 2 byte transaction
-    else
-      inst.data_size = 4;  // 4 byte transaction
-
-    assert(inst.memory_op == insn_memory_op);
-    // thread->m_last_effective_address = addr;
-    // thread->m_last_memory_space = space;
-  }
+   	assert( inst.memory_op == insn_memory_op );
+   	//thread->m_last_effective_address = addr;
+   	//thread->m_last_memory_space = space;
+   } 
 }
 
-void mma_ld_impl(const ptx_instruction *pI, core_t *core, warp_inst_t &inst) {
-  size_t size;
-  int t, i;
-  unsigned smid;
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  const operand_info &src2 = pI->src2();
+void mma_ld_impl( const ptx_instruction *pI, core_t *core, warp_inst_t &inst )
+{
+   size_t size;
+   int t,i;
+   unsigned smid;
+   const operand_info &dst = pI->dst();
+   const operand_info &src1 = pI->src1();
+   const operand_info &src2 = pI->src2();
 
-  unsigned type = pI->get_type();
-  unsigned wmma_type = pI->get_wmma_type();
-  unsigned wmma_layout = pI->get_wmma_layout(0);
-  int tid;
-  int thrd, stride;
-  ptx_thread_info *thread;
+   unsigned type = pI->get_type();
+   unsigned wmma_type = pI->get_wmma_type();
+   unsigned wmma_layout = pI->get_wmma_layout(0);
+   int tid;
+   int thrd,stride;
+   ptx_thread_info *thread;
+ 
 
-  if (core->get_gpu()->is_functional_sim())
-    tid = inst.warp_id_func() * core->get_warp_size();
-  else
-    tid = inst.warp_id() * core->get_warp_size();
+   if(core->get_gpu()->is_functional_sim())
+    	tid= inst.warp_id_func()*core->get_warp_size();
+   else
+    	tid= inst.warp_id()*core->get_warp_size();
 
-  _memory_op_t insn_memory_op =
-      pI->has_memory_read() ? memory_load : memory_store;
+   _memory_op_t insn_memory_op = pI->has_memory_read() ? memory_load : memory_store;
+   
+   for (thrd=0; thrd < core->get_warp_size(); thrd++){
+   	thread = core->get_thread_info()[tid+thrd];
+   	ptx_reg_t src1_data = thread->get_operand_value(src1, dst, U32_TYPE, thread, 1);
+   	ptx_reg_t src2_data = thread->get_operand_value(src2, dst, U32_TYPE, thread, 1);
+	stride=src2_data.u32;
+   	memory_space_t space = pI->get_space();
 
-  for (thrd = 0; thrd < core->get_warp_size(); thrd++) {
-    thread = core->get_thread_info()[tid + thrd];
-    ptx_reg_t src1_data =
-        thread->get_operand_value(src1, dst, U32_TYPE, thread, 1);
-    ptx_reg_t src2_data =
-        thread->get_operand_value(src2, dst, U32_TYPE, thread, 1);
-    stride = src2_data.u32;
-    memory_space_t space = pI->get_space();
+   	memory_space *mem = NULL;
+   	addr_t addr = src1_data.u32;
+        smid = thread->get_hw_sid();
+        if( whichspace(addr) == shared_space ) {
+          addr= generic_to_shared(smid,addr);
+          space = shared_space;
+	}
 
-    memory_space *mem = NULL;
-    addr_t addr = src1_data.u32;
-    smid = thread->get_hw_sid();
-    if (whichspace(addr) == shared_space) {
-      addr = generic_to_shared(smid, addr);
-      space = shared_space;
-    }
+	decode_space(space,thread,src1,mem,addr);
+   	type_info_key::type_decode(type, size, t);
+	
+	ptx_reg_t data[16];
+   	if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)	
+		printf("mma_ld: thrd=%d,addr=%x, fpsize=%zu, stride=%d\n", thrd, src1_data.u32, size, src2_data.u32);
+	
+	addr_t new_addr = addr+thread_group_offset(thrd,wmma_type,wmma_layout,type,stride)*size/8;  
+	addr_t fetch_addr;
+	new_addr_type mem_txn_addr[MAX_ACCESSES_PER_INSN_PER_THREAD];
+	int num_mem_txn=0;
 
-    decode_space(space, thread, src1, mem, addr);
-    type_info_key::type_decode(type, size, t);
+	if(wmma_type==LOAD_A){
+		for(i=0;i<16;i++){
+			if(wmma_layout==ROW){
+				//mem->read(new_addr+2*i,size/8,&data[i].s64);
+				fetch_addr=new_addr+2*i;
+				mem->read(fetch_addr,size/8,&data[i].s64);
+			}
+			else if(wmma_layout==COL){
+				//mem->read(new_addr+2*(i%4)+2*stride*4*(i/4),size/8,&data[i].s64);
+				fetch_addr=new_addr+2*(i%4)+2*stride*4*(i/4);
+				mem->read(fetch_addr,size/8,&data[i].s64);
+			}
+			else{
+				printf("mma_ld:wrong_layout_type\n");
+				abort();
+			
+			}
+			if(i%2==0)
+				mem_txn_addr[num_mem_txn++]=fetch_addr;	
+		}
+	}
+	else if(wmma_type==LOAD_B){
+		for(i=0;i<16;i++){
+			if(wmma_layout==COL){
+				//mem->read(new_addr+2*i,size/8,&data[i].s64);
+				fetch_addr=new_addr+2*i;
+				mem->read(fetch_addr,size/8,&data[i].s64);
+			}
+			else if(wmma_layout==ROW){
+				//mem->read(new_addr+2*(i%4)+2*stride*4*(i/4),size/8,&data[i].s64);
+				fetch_addr=new_addr+2*(i%4)+2*stride*4*(i/4);
+				mem->read(fetch_addr,size/8,&data[i].s64);
+			}
+			else{
+				printf("mma_ld:wrong_layout_type\n");
+				abort();
+			}
+			if(i%2==0)
+				mem_txn_addr[num_mem_txn++]=fetch_addr;	
+		}
+	}
+	else if(wmma_type==LOAD_C){
+		for(i=0;i<8;i++){
+			if(type==F16_TYPE){
+				if(wmma_layout==ROW){
+					//mem->read(new_addr+2*i,size/8,&data[i].s64);
+					fetch_addr=new_addr+2*i;
+					mem->read(fetch_addr,size/8,&data[i].s64);
+					if(i%2==0)
+						mem_txn_addr[num_mem_txn++]=fetch_addr;	
+				}
+				else if(wmma_layout==COL){
+					//mem->read(new_addr+2*stride*i,size/8,&data[i].s64);
+					fetch_addr=new_addr+2*stride*i;
+					mem->read(fetch_addr,size/8,&data[i].s64);
+					mem_txn_addr[num_mem_txn++]=fetch_addr;	
+				}
+				else{
+					printf("mma_ld:wrong_type\n");
+					abort();
+				}
+			}
+			else if(type==F32_TYPE){
+				//mem->read(new_addr+4*acc_float_offset(i,wmma_layout,stride),size/8,&data[i].s64);
+				fetch_addr=new_addr+4*acc_float_offset(i,wmma_layout,stride);
+				mem->read(fetch_addr,size/8,&data[i].s64);
+				mem_txn_addr[num_mem_txn++]=fetch_addr;	
+			}
+			else{
+				printf("wrong type");
+				abort();
+			}
+		}
+	}
+	else{
+		printf("wrong wmma type\n");;
+		abort();
+	}
+	//generate timing memory request
+   	inst.space = space;
+   	inst.set_addr(thrd, (new_addr_type *)mem_txn_addr , num_mem_txn);
 
-    ptx_reg_t data[16];
-    if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-      printf("mma_ld: thrd=%d,addr=%x, fpsize=%zu, stride=%d\n", thrd,
-             src1_data.u32, size, src2_data.u32);
+	if((wmma_type==LOAD_C)&&(type==F16_TYPE)&&(wmma_layout==COL))//memory address is scattered, check the profiling xls for more detail.
+   		inst.data_size = 2; // 2 byte transaction 
+	else	
+   		inst.data_size = 4; // 4 byte transaction 
+   	assert( inst.memory_op == insn_memory_op );
 
-    addr_t new_addr =
-        addr +
-        thread_group_offset(thrd, wmma_type, wmma_layout, type, stride) * size /
-            8;
-    addr_t fetch_addr;
-    new_addr_type mem_txn_addr[MAX_ACCESSES_PER_INSN_PER_THREAD];
-    int num_mem_txn = 0;
+	if(core->get_gpu()->gpgpu_ctx->debug_tensorcore){
+		if(type==F16_TYPE){
+			printf("\nmma_ld:thread%d= ",thrd);
+			for(i=0;i<16;i++){
+				printf("%llx ",data[i].u64);
+			}
+			printf("\n");
+			
+			printf("\nmma_ld:thread%d= ",thrd);
+			float temp;
+			for(i=0;i<16;i++){
+			temp=data[i].f16;
+				printf("%.2f ",temp);
+			}
+			printf("\n");
+		}
+		else{
+			printf("\nmma_ld:thread%d= ",thrd);
+			for(i=0;i<8;i++){
+				printf("%.2f ",data[i].f32);
+			}
+			printf("\n");
+			printf("\nmma_ld:thread%d= ",thrd);
+			for(i=0;i<8;i++){
+				printf("%llx ",data[i].u64);
+			}
+			printf("\n");
+		}
+	}
 
-    if (wmma_type == LOAD_A) {
-      for (i = 0; i < 16; i++) {
-        if (wmma_layout == ROW) {
-          // mem->read(new_addr+2*i,size/8,&data[i].s64);
-          fetch_addr = new_addr + 2 * i;
-          mem->read(fetch_addr, size / 8, &data[i].s64);
-        } else if (wmma_layout == COL) {
-          // mem->read(new_addr+2*(i%4)+2*stride*4*(i/4),size/8,&data[i].s64);
-          fetch_addr = new_addr + 2 * (i % 4) + 2 * stride * 4 * (i / 4);
-          mem->read(fetch_addr, size / 8, &data[i].s64);
-        } else {
-          printf("mma_ld:wrong_layout_type\n");
-          abort();
-        }
-        if (i % 2 == 0) mem_txn_addr[num_mem_txn++] = fetch_addr;
-      }
-    } else if (wmma_type == LOAD_B) {
-      for (i = 0; i < 16; i++) {
-        if (wmma_layout == COL) {
-          // mem->read(new_addr+2*i,size/8,&data[i].s64);
-          fetch_addr = new_addr + 2 * i;
-          mem->read(fetch_addr, size / 8, &data[i].s64);
-        } else if (wmma_layout == ROW) {
-          // mem->read(new_addr+2*(i%4)+2*stride*4*(i/4),size/8,&data[i].s64);
-          fetch_addr = new_addr + 2 * (i % 4) + 2 * stride * 4 * (i / 4);
-          mem->read(fetch_addr, size / 8, &data[i].s64);
-        } else {
-          printf("mma_ld:wrong_layout_type\n");
-          abort();
-        }
-        if (i % 2 == 0) mem_txn_addr[num_mem_txn++] = fetch_addr;
-      }
-    } else if (wmma_type == LOAD_C) {
-      for (i = 0; i < 8; i++) {
-        if (type == F16_TYPE) {
-          if (wmma_layout == ROW) {
-            // mem->read(new_addr+2*i,size/8,&data[i].s64);
-            fetch_addr = new_addr + 2 * i;
-            mem->read(fetch_addr, size / 8, &data[i].s64);
-            if (i % 2 == 0) mem_txn_addr[num_mem_txn++] = fetch_addr;
-          } else if (wmma_layout == COL) {
-            // mem->read(new_addr+2*stride*i,size/8,&data[i].s64);
-            fetch_addr = new_addr + 2 * stride * i;
-            mem->read(fetch_addr, size / 8, &data[i].s64);
-            mem_txn_addr[num_mem_txn++] = fetch_addr;
-          } else {
-            printf("mma_ld:wrong_type\n");
-            abort();
-          }
-        } else if (type == F32_TYPE) {
-          // mem->read(new_addr+4*acc_float_offset(i,wmma_layout,stride),size/8,&data[i].s64);
-          fetch_addr = new_addr + 4 * acc_float_offset(i, wmma_layout, stride);
-          mem->read(fetch_addr, size / 8, &data[i].s64);
-          mem_txn_addr[num_mem_txn++] = fetch_addr;
-        } else {
-          printf("wrong type");
-          abort();
-        }
-      }
-    } else {
-      printf("wrong wmma type\n");
-      ;
-      abort();
-    }
-    // generate timing memory request
-    inst.space = space;
-    inst.set_addr(thrd, (new_addr_type *)mem_txn_addr, num_mem_txn);
+	if((wmma_type==LOAD_C)&&(type==F32_TYPE)){
+   		thread->set_wmma_vector_operand_values(dst,data[0],data[1],data[2],data[3],data[4],data[5],data[6],data[7]);
+	}
+	else{
+		ptx_reg_t nw_data[8];
+		int num_reg;
+		
+		if(wmma_type==LOAD_C)
+			num_reg=4;
+		else
+			num_reg=8;
 
-    if ((wmma_type == LOAD_C) && (type == F16_TYPE) &&
-        (wmma_layout == COL))  // memory address is scattered, check the
-                               // profiling xls for more detail.
-      inst.data_size = 2;  // 2 byte transaction
-    else
-      inst.data_size = 4;  // 4 byte transaction
-    assert(inst.memory_op == insn_memory_op);
+		for(i=0;i<num_reg;i++){
+			nw_data[i].s64= ((data[2*i].s64 & 0xffff)<<16)| ((data[2*i+1].s64 & 0xffff));
+		}
 
-    if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) {
-      if (type == F16_TYPE) {
-        printf("\nmma_ld:thread%d= ", thrd);
-        for (i = 0; i < 16; i++) {
-          printf("%llx ", data[i].u64);
-        }
-        printf("\n");
+		if(wmma_type==LOAD_C)
+   			thread->set_vector_operand_values(dst,nw_data[0],nw_data[1],nw_data[2],nw_data[3]);
+		else
+   			thread->set_wmma_vector_operand_values(dst,nw_data[0],nw_data[1],nw_data[2],nw_data[3],nw_data[4],nw_data[5],nw_data[6],nw_data[7]);
+		if(core->get_gpu()->gpgpu_ctx->debug_tensorcore){	
+			printf("mma_ld:data[0].s64=%llx,data[1].s64=%llx,new_data[0].s64=%llx\n",data[0].u64,data[1].u64,nw_data[0].u64);	
+			printf("mma_ld:data[2].s64=%llx,data[3].s64=%llx,new_data[1].s64=%llx\n",data[2].u64,data[3].u64,nw_data[1].u64);	
+			printf("mma_ld:data[4].s64=%llx,data[5].s64=%llx,new_data[2].s64=%llx\n",data[4].u64,data[5].u64,nw_data[2].u64);	
+			printf("mma_ld:data[6].s64=%llx,data[7].s64=%llx,new_data[3].s64=%llx\n",data[6].u64,data[7].u64,nw_data[3].u64);	
+			if(wmma_type!=LOAD_C){
+			printf("mma_ld:data[8].s64=%llx,data[9].s64=%llx,new_data[4].s64=%llx\n",data[8].u64,data[9].u64,nw_data[4].s64);	
+			printf("mma_ld:data[10].s64=%llx,data[11].s64=%llx,new_data[5].s64=%llx\n",data[10].u64,data[11].u64,nw_data[5].u64);	
+			printf("mma_ld:data[12].s64=%llx,data[13].s64=%llx,new_data[6].s64=%llx\n",data[12].u64,data[13].u64,nw_data[6].u64);	
+			printf("mma_ld:data[14].s64=%llx,data[15].s64=%llx,new_data[7].s64=%llx\n",data[14].u64,data[15].u64,nw_data[3].u64);	
+			}
+		}
+	}
 
-        printf("\nmma_ld:thread%d= ", thrd);
-        float temp;
-        for (i = 0; i < 16; i++) {
-          temp = data[i].f16;
-          printf("%.2f ", temp);
-        }
-        printf("\n");
-      } else {
-        printf("\nmma_ld:thread%d= ", thrd);
-        for (i = 0; i < 8; i++) {
-          printf("%.2f ", data[i].f32);
-        }
-        printf("\n");
-        printf("\nmma_ld:thread%d= ", thrd);
-        for (i = 0; i < 8; i++) {
-          printf("%llx ", data[i].u64);
-        }
-        printf("\n");
-      }
-    }
-
-    if ((wmma_type == LOAD_C) && (type == F32_TYPE)) {
-      thread->set_wmma_vector_operand_values(dst, data[0], data[1], data[2],
-                                             data[3], data[4], data[5], data[6],
-                                             data[7]);
-    } else {
-      ptx_reg_t nw_data[8];
-      int num_reg;
-
-      if (wmma_type == LOAD_C)
-        num_reg = 4;
-      else
-        num_reg = 8;
-
-      for (i = 0; i < num_reg; i++) {
-        nw_data[i].s64 = ((data[2 * i].s64 & 0xffff) << 16) |
-                         ((data[2 * i + 1].s64 & 0xffff));
-      }
-
-      if (wmma_type == LOAD_C)
-        thread->set_vector_operand_values(dst, nw_data[0], nw_data[1],
-                                          nw_data[2], nw_data[3]);
-      else
-        thread->set_wmma_vector_operand_values(
-            dst, nw_data[0], nw_data[1], nw_data[2], nw_data[3], nw_data[4],
-            nw_data[5], nw_data[6], nw_data[7]);
-      if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) {
-        printf(
-            "mma_ld:data[0].s64=%llx,data[1].s64=%llx,new_data[0].s64=%llx\n",
-            data[0].u64, data[1].u64, nw_data[0].u64);
-        printf(
-            "mma_ld:data[2].s64=%llx,data[3].s64=%llx,new_data[1].s64=%llx\n",
-            data[2].u64, data[3].u64, nw_data[1].u64);
-        printf(
-            "mma_ld:data[4].s64=%llx,data[5].s64=%llx,new_data[2].s64=%llx\n",
-            data[4].u64, data[5].u64, nw_data[2].u64);
-        printf(
-            "mma_ld:data[6].s64=%llx,data[7].s64=%llx,new_data[3].s64=%llx\n",
-            data[6].u64, data[7].u64, nw_data[3].u64);
-        if (wmma_type != LOAD_C) {
-          printf(
-              "mma_ld:data[8].s64=%llx,data[9].s64=%llx,new_data[4].s64=%llx\n",
-              data[8].u64, data[9].u64, nw_data[4].s64);
-          printf(
-              "mma_ld:data[10].s64=%llx,data[11].s64=%llx,new_data[5].s64=%"
-              "llx\n",
-              data[10].u64, data[11].u64, nw_data[5].u64);
-          printf(
-              "mma_ld:data[12].s64=%llx,data[13].s64=%llx,new_data[6].s64=%"
-              "llx\n",
-              data[12].u64, data[13].u64, nw_data[6].u64);
-          printf(
-              "mma_ld:data[14].s64=%llx,data[15].s64=%llx,new_data[7].s64=%"
-              "llx\n",
-              data[14].u64, data[15].u64, nw_data[3].u64);
-        }
-      }
-    }
-
-    // thread->m_last_effective_address = addr;
-    // thread->m_last_memory_space = space;
-  }
+   	//thread->m_last_effective_address = addr;
+   	//thread->m_last_memory_space = space;
+   } 
 }
 
-void lg2_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t a, d;
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
+void lg2_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   ptx_reg_t a, d;
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
 
-  unsigned i_type = pI->get_type();
+   unsigned i_type = pI->get_type();
 
-  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
 
-  switch (i_type) {
-    case F32_TYPE:
-      d.f32 = log(a.f32) / log(2);
+
+   switch ( i_type ) {
+   case F32_TYPE: 
+      d.f32 = log(a.f32)/log(2);
       break;
-    default:
+   default:
       printf("Execution error: type mismatch with instruction\n");
       assert(0);
       break;
-  }
+   }
 
-  thread->set_operand_value(dst, d, i_type, thread, pI);
+   thread->set_operand_value(dst,d, i_type, thread, pI);
 }
 
-void mad24_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  const operand_info &src2 = pI->src2();
-  const operand_info &src3 = pI->src3();
-  ptx_reg_t d, t;
+void mad24_impl( const ptx_instruction *pI, ptx_thread_info *thread )
+{
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
+   const operand_info &src2 = pI->src2();
+   const operand_info &src3 = pI->src3();
+   ptx_reg_t d, t;
 
-  unsigned i_type = pI->get_type();
-  ptx_reg_t a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-  ptx_reg_t b = thread->get_operand_value(src2, dst, i_type, thread, 1);
-  ptx_reg_t c = thread->get_operand_value(src3, dst, i_type, thread, 1);
+   unsigned i_type = pI->get_type();
+   ptx_reg_t a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   ptx_reg_t b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+   ptx_reg_t c = thread->get_operand_value(src3, dst, i_type, thread, 1);
 
-  unsigned sat_mode = pI->saturation_mode();
+   unsigned sat_mode = pI->saturation_mode();
 
-  assert(!pI->is_wide());
+   assert( !pI->is_wide() );
 
-  switch (i_type) {
-    case S32_TYPE:
+   switch ( i_type ) {
+   case S32_TYPE: 
       t.s64 = a.s32 * b.s32;
-      if (pI->is_hi()) {
-        d.s64 = (t.s64 >> 16) + c.s32;
-        if (sat_mode) {
-          if (d.s64 > (int)0x7FFFFFFF)
-            d.s64 = (int)0x7FFFFFFF;
-          else if (d.s64 < (int)0x80000000)
-            d.s64 = (int)0x80000000;
-        }
-      } else if (pI->is_lo())
-        d.s64 = t.s32 + c.s32;
-      else
-        assert(0);
+      if ( pI->is_hi() ) {
+         d.s64 = (t.s64>>16) + c.s32;
+         if ( sat_mode ) {
+            if ( d.s64 > (int)0x7FFFFFFF )
+               d.s64 = (int)0x7FFFFFFF;
+            else if ( d.s64 < (int)0x80000000 )
+               d.s64 = (int)0x80000000;
+         }
+      } else if ( pI->is_lo() ) d.s64 = t.s32 + c.s32;
+      else assert(0);
       break;
-    case U32_TYPE:
+   case U32_TYPE: 
       t.u64 = a.u32 * b.u32;
-      if (pI->is_hi())
-        d.u64 = (t.u64 >> 16) + c.u32;
-      else if (pI->is_lo())
-        d.u64 = t.u32 + c.u32;
-      else
-        assert(0);
+      if ( pI->is_hi() ) d.u64 = (t.u64>>16) + c.u32;
+      else if ( pI->is_lo() ) d.u64 = t.u32 + c.u32;
+      else assert(0);
       break;
-    default:
+   default: 
       assert(0);
       break;
-  }
+   }
 
-  thread->set_operand_value(dst, d, i_type, thread, pI);
+   thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-void mad_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  mad_def(pI, thread, false);
+void mad_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+   mad_def(pI, thread, false);
 }
 
-void madp_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  mad_def(pI, thread, true);
+void madp_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+   mad_def(pI, thread, true);
 }
 
-void madc_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  mad_def(pI, thread, true);
+void madc_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+   mad_def(pI, thread, true);
 }
 
-void mad_def(const ptx_instruction *pI, ptx_thread_info *thread,
-             bool use_carry) {
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  const operand_info &src2 = pI->src2();
-  const operand_info &src3 = pI->src3();
-  ptx_reg_t d, t;
+void mad_def( const ptx_instruction *pI, ptx_thread_info *thread, bool use_carry ) 
+{ 
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
+   const operand_info &src2 = pI->src2();
+   const operand_info &src3 = pI->src3();
+   ptx_reg_t d, t;
 
-  int carry = 0;
-  int overflow = 0;
+   int carry=0;
+   int overflow=0;
 
-  unsigned i_type = pI->get_type();
-  ptx_reg_t a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-  ptx_reg_t b = thread->get_operand_value(src2, dst, i_type, thread, 1);
-  ptx_reg_t c = thread->get_operand_value(src3, dst, i_type, thread, 1);
+   unsigned i_type = pI->get_type();
+   ptx_reg_t a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   ptx_reg_t b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+   ptx_reg_t c = thread->get_operand_value(src3, dst, i_type, thread, 1);
 
-  // take the carry bit, it should be the 4th operand
-  ptx_reg_t carry_bit;
-  carry_bit.u64 = 0;
-  if (use_carry) {
-    const operand_info &carry = pI->operand_lookup(4);
-    carry_bit = thread->get_operand_value(carry, dst, PRED_TYPE, thread, 0);
-    carry_bit.pred &= 0x4;
-    carry_bit.pred >>= 2;
-  }
+   // take the carry bit, it should be the 4th operand 
+   ptx_reg_t carry_bit; 
+   carry_bit.u64 = 0;
+   if (use_carry) {
+      const operand_info &carry = pI->operand_lookup(4);
+      carry_bit = thread->get_operand_value(carry, dst, PRED_TYPE, thread, 0);
+      carry_bit.pred &= 0x4;
+      carry_bit.pred >>=2;
+   }
 
-  unsigned rounding_mode = pI->rounding_mode();
+   unsigned rounding_mode = pI->rounding_mode();
 
-  switch (i_type) {
-    case S16_TYPE:
+   switch ( i_type ) {
+   case S16_TYPE: 
       t.s32 = a.s16 * b.s16;
-      if (pI->is_wide())
-        d.s32 = t.s32 + c.s32 + carry_bit.pred;
-      else if (pI->is_hi())
-        d.s16 = (t.s32 >> 16) + c.s16 + carry_bit.pred;
-      else if (pI->is_lo())
-        d.s16 = t.s16 + c.s16 + carry_bit.pred;
-      else
-        assert(0);
-      carry =
-          ((long long int)(t.s32 + c.s32 + carry_bit.pred) & 0x100000000) >> 32;
+      if ( pI->is_wide() ) d.s32 = t.s32 + c.s32 + carry_bit.pred;
+      else if ( pI->is_hi() ) d.s16 = (t.s32>>16) + c.s16 + carry_bit.pred;
+      else if ( pI->is_lo() ) d.s16 = t.s16 + c.s16 + carry_bit.pred;
+      else assert(0);
+      carry = ((long long int)(t.s32 + c.s32 + carry_bit.pred)&0x100000000)>>32;
       break;
-    case S32_TYPE:
+   case S32_TYPE: 
       t.s64 = a.s32 * b.s32;
-      if (pI->is_wide())
-        d.s64 = t.s64 + c.s64 + carry_bit.pred;
-      else if (pI->is_hi())
-        d.s32 = (t.s64 >> 32) + c.s32 + carry_bit.pred;
-      else if (pI->is_lo())
-        d.s32 = t.s32 + c.s32 + carry_bit.pred;
-      else
-        assert(0);
+      if ( pI->is_wide() ) d.s64 = t.s64 + c.s64 + carry_bit.pred;
+      else if ( pI->is_hi() ) d.s32 = (t.s64>>32) + c.s32 + carry_bit.pred;
+      else if ( pI->is_lo() ) d.s32 = t.s32 + c.s32 + carry_bit.pred;
+      else assert(0);
       break;
-    case S64_TYPE:
+   case S64_TYPE: 
       t.s64 = a.s64 * b.s64;
-      assert(!pI->is_wide());
-      assert(!pI->is_hi());
-      assert(use_carry == false);
-      if (pI->is_lo())
-        d.s64 = t.s64 + c.s64 + carry_bit.pred;
-      else
-        assert(0);
+      assert( !pI->is_wide() );
+      assert( !pI->is_hi() );
+      assert( use_carry == false); 
+      if ( pI->is_lo() ) d.s64 = t.s64 + c.s64 + carry_bit.pred;
+      else assert(0);
       break;
-    case U16_TYPE:
+   case U16_TYPE: 
       t.u32 = a.u16 * b.u16;
-      if (pI->is_wide())
-        d.u32 = t.u32 + c.u32 + carry_bit.pred;
-      else if (pI->is_hi())
-        d.u16 = (t.u32 + c.u16 + carry_bit.pred) >> 16;
-      else if (pI->is_lo())
-        d.u16 = t.u16 + c.u16 + carry_bit.pred;
-      else
-        assert(0);
-      carry = ((long long int)((long long int)t.u32 + c.u32 + carry_bit.pred) &
-               0x100000000) >>
-              32;
+      if ( pI->is_wide() ) d.u32 = t.u32 + c.u32 + carry_bit.pred;
+      else if ( pI->is_hi() ) d.u16 = (t.u32 + c.u16 + carry_bit.pred)>>16;
+      else if ( pI->is_lo() ) d.u16 = t.u16 + c.u16 + carry_bit.pred;
+      else assert(0);
+      carry = ((long long int)((long long int)t.u32 + c.u32 + carry_bit.pred)&0x100000000)>>32;
       break;
-    case U32_TYPE:
+   case U32_TYPE: 
       t.u64 = a.u32 * b.u32;
-      if (pI->is_wide())
-        d.u64 = t.u64 + c.u64 + carry_bit.pred;
-      else if (pI->is_hi())
-        d.u32 = (t.u64 + c.u32 + carry_bit.pred) >> 32;
-      else if (pI->is_lo())
-        d.u32 = t.u32 + c.u32 + carry_bit.pred;
-      else
-        assert(0);
+      if ( pI->is_wide() ) d.u64 = t.u64 + c.u64 + carry_bit.pred;
+      else if ( pI->is_hi() ) d.u32 = (t.u64 + c.u32 + carry_bit.pred)>>32;
+      else if ( pI->is_lo() ) d.u32 = t.u32 + c.u32 + carry_bit.pred;
+      else assert(0);
       break;
-    case U64_TYPE:
+   case U64_TYPE: 
       t.u64 = a.u64 * b.u64;
-      assert(!pI->is_wide());
-      assert(!pI->is_hi());
-      assert(use_carry == false);
-      if (pI->is_lo())
-        d.u64 = t.u64 + c.u64 + carry_bit.pred;
-      else
-        assert(0);
+      assert( !pI->is_wide() );
+      assert( !pI->is_hi() );
+      assert( use_carry == false); 
+      if ( pI->is_lo() ) d.u64 = t.u64 + c.u64 + carry_bit.pred;
+      else assert(0);
       break;
-    case F16_TYPE: {
-      // assert(0);
-      // break;
-      assert(use_carry == false);
-      int orig_rm = fegetround();
-      switch (rounding_mode) {
-        case RN_OPTION:
-          break;
-        case RZ_OPTION:
-          fesetround(FE_TOWARDZERO);
-          break;
-        default:
-          assert(0);
-          break;
+   case F16_TYPE:{ 
+     // assert(0); 
+     // break;
+         assert( use_carry == false); 
+         int orig_rm = fegetround();
+         switch ( rounding_mode ) {
+         case RN_OPTION: break;
+         case RZ_OPTION: fesetround( FE_TOWARDZERO ); break;
+         default: assert(0); break;
+         }
+         d.f16 = a.f16 * b.f16 + c.f16;
+         if ( pI->saturation_mode() ) {
+            if ( d.f16 < 0 ) d.f16 = 0;
+            else if ( d.f16 > 1.0f ) d.f16 = 1.0f;
+         }
+         fesetround( orig_rm );
+         break;
+      }  
+   case F32_TYPE: {
+         assert( use_carry == false); 
+         int orig_rm = fegetround();
+         switch ( rounding_mode ) {
+         case RN_OPTION: break;
+         case RZ_OPTION: fesetround( FE_TOWARDZERO ); break;
+         default: assert(0); break;
+         }
+         d.f32 = a.f32 * b.f32 + c.f32;
+         if ( pI->saturation_mode() ) {
+            if ( d.f32 < 0 ) d.f32 = 0;
+            else if ( d.f32 > 1.0f ) d.f32 = 1.0f;
+         }
+         fesetround( orig_rm );
+         break;
+      }  
+   case F64_TYPE: case FF64_TYPE: {
+         assert( use_carry == false); 
+         int orig_rm = fegetround();
+         switch ( rounding_mode ) {
+         case RN_OPTION: break;
+         case RZ_OPTION: fesetround( FE_TOWARDZERO ); break;
+         default: assert(0); break;
+         }
+         d.f64 = a.f64 * b.f64 + c.f64;
+         if ( pI->saturation_mode() ) {
+            if ( d.f64 < 0 ) d.f64 = 0;
+            else if ( d.f64 > 1.0f ) d.f64 = 1.0;
+         }
+         fesetround( orig_rm );
+         break;
       }
-      d.f16 = a.f16 * b.f16 + c.f16;
-      if (pI->saturation_mode()) {
-        if (d.f16 < 0)
-          d.f16 = 0;
-        else if (d.f16 > 1.0f)
-          d.f16 = 1.0f;
-      }
-      fesetround(orig_rm);
-      break;
-    }
-    case F32_TYPE: {
-      assert(use_carry == false);
-      int orig_rm = fegetround();
-      switch (rounding_mode) {
-        case RN_OPTION:
-          break;
-        case RZ_OPTION:
-          fesetround(FE_TOWARDZERO);
-          break;
-        default:
-          assert(0);
-          break;
-      }
-      d.f32 = a.f32 * b.f32 + c.f32;
-      if (pI->saturation_mode()) {
-        if (d.f32 < 0)
-          d.f32 = 0;
-        else if (d.f32 > 1.0f)
-          d.f32 = 1.0f;
-      }
-      fesetround(orig_rm);
-      break;
-    }
-    case F64_TYPE:
-    case FF64_TYPE: {
-      assert(use_carry == false);
-      int orig_rm = fegetround();
-      switch (rounding_mode) {
-        case RN_OPTION:
-          break;
-        case RZ_OPTION:
-          fesetround(FE_TOWARDZERO);
-          break;
-        default:
-          assert(0);
-          break;
-      }
-      d.f64 = a.f64 * b.f64 + c.f64;
-      if (pI->saturation_mode()) {
-        if (d.f64 < 0)
-          d.f64 = 0;
-        else if (d.f64 > 1.0f)
-          d.f64 = 1.0;
-      }
-      fesetround(orig_rm);
-      break;
-    }
-    default:
+   default: 
       assert(0);
       break;
-  }
-  thread->set_operand_value(dst, d, i_type, thread, pI, overflow, carry);
+   }
+   thread->set_operand_value(dst, d, i_type, thread, pI, overflow, carry);
 }
 
-bool isNaN(float x) { return std::isnan(x); }
+bool isNaN(float x)
+{
+   return std::isnan(x);
+}
 
-bool isNaN(double x) { return std::isnan(x); }
+bool isNaN(double x)
+{
+   return std::isnan(x);
+}
 
-void max_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t a, b, d;
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  const operand_info &src2 = pI->src2();
+void max_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   ptx_reg_t a, b, d;
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
+   const operand_info &src2 = pI->src2();
 
-  unsigned i_type = pI->get_type();
-  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-  b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+   unsigned i_type = pI->get_type();
+   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   b = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-  switch (i_type) {
-    case U16_TYPE:
-      d.u16 = MY_MAX_I(a.u16, b.u16);
+
+   switch ( i_type ) {
+   case U16_TYPE: d.u16 = MY_MAX_I(a.u16,b.u16); break;
+   case U32_TYPE: d.u32 = MY_MAX_I(a.u32,b.u32); break;
+   case U64_TYPE: d.u64 = MY_MAX_I(a.u64,b.u64); break;
+   case S16_TYPE: d.s16 = MY_MAX_I(a.s16,b.s16); break;
+   case S32_TYPE: d.s32 = MY_MAX_I(a.s32,b.s32); break;
+   case S64_TYPE: d.s64 = MY_MAX_I(a.s64,b.s64); break;
+   case F32_TYPE: d.f32 = MY_MAX_F(a.f32,b.f32); break;
+   case F64_TYPE: case FF64_TYPE: d.f64 = MY_MAX_F(a.f64,b.f64); break;
+   default:
+      printf("Execution error: type mismatch with instruction\n");
+      assert(0); 
       break;
-    case U32_TYPE:
-      d.u32 = MY_MAX_I(a.u32, b.u32);
-      break;
-    case U64_TYPE:
-      d.u64 = MY_MAX_I(a.u64, b.u64);
-      break;
-    case S16_TYPE:
-      d.s16 = MY_MAX_I(a.s16, b.s16);
-      break;
-    case S32_TYPE:
-      d.s32 = MY_MAX_I(a.s32, b.s32);
-      break;
-    case S64_TYPE:
-      d.s64 = MY_MAX_I(a.s64, b.s64);
-      break;
-    case F32_TYPE:
-      d.f32 = MY_MAX_F(a.f32, b.f32);
-      break;
-    case F64_TYPE:
-    case FF64_TYPE:
-      d.f64 = MY_MAX_F(a.f64, b.f64);
-      break;
-    default:
+   }
+
+   thread->set_operand_value(dst,d, i_type, thread, pI);
+}
+
+void membar_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   // handled by timing simulator 
+}
+
+void min_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   ptx_reg_t a, b, d;
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
+   const operand_info &src2 = pI->src2();
+
+   unsigned i_type = pI->get_type();
+   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+
+
+   switch ( i_type ) {
+   case U16_TYPE: d.u16 = MY_MIN_I(a.u16,b.u16); break;
+   case U32_TYPE: d.u32 = MY_MIN_I(a.u32,b.u32); break;
+   case U64_TYPE: d.u64 = MY_MIN_I(a.u64,b.u64); break;
+   case S16_TYPE: d.s16 = MY_MIN_I(a.s16,b.s16); break;
+   case S32_TYPE: d.s32 = MY_MIN_I(a.s32,b.s32); break;
+   case S64_TYPE: d.s64 = MY_MIN_I(a.s64,b.s64); break;
+   case F32_TYPE: d.f32 = MY_MIN_F(a.f32,b.f32); break;
+   case F64_TYPE: case FF64_TYPE: d.f64 = MY_MIN_F(a.f64,b.f64); break;
+   default:
       printf("Execution error: type mismatch with instruction\n");
       assert(0);
       break;
-  }
+   }
 
-  thread->set_operand_value(dst, d, i_type, thread, pI);
+   thread->set_operand_value(dst,d, i_type, thread, pI);
 }
 
-void membar_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  // handled by timing simulator
-}
+void mov_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+   ptx_reg_t data;
 
-void min_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t a, b, d;
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  const operand_info &src2 = pI->src2();
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
+   unsigned i_type = pI->get_type();
+   assert( src1.is_param_local() == 0 );
 
-  unsigned i_type = pI->get_type();
-  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-  b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+   if( (src1.is_vector() || dst.is_vector()) && (i_type != BB64_TYPE) && (i_type != BB128_TYPE) && (i_type != FF64_TYPE) ) {
+      // pack or unpack operation
+      unsigned nbits_to_move;
+      ptx_reg_t tmp_bits;
 
-  switch (i_type) {
-    case U16_TYPE:
-      d.u16 = MY_MIN_I(a.u16, b.u16);
-      break;
-    case U32_TYPE:
-      d.u32 = MY_MIN_I(a.u32, b.u32);
-      break;
-    case U64_TYPE:
-      d.u64 = MY_MIN_I(a.u64, b.u64);
-      break;
-    case S16_TYPE:
-      d.s16 = MY_MIN_I(a.s16, b.s16);
-      break;
-    case S32_TYPE:
-      d.s32 = MY_MIN_I(a.s32, b.s32);
-      break;
-    case S64_TYPE:
-      d.s64 = MY_MIN_I(a.s64, b.s64);
-      break;
-    case F32_TYPE:
-      d.f32 = MY_MIN_F(a.f32, b.f32);
-      break;
-    case F64_TYPE:
-    case FF64_TYPE:
-      d.f64 = MY_MIN_F(a.f64, b.f64);
-      break;
-    default:
-      printf("Execution error: type mismatch with instruction\n");
-      assert(0);
-      break;
-  }
-
-  thread->set_operand_value(dst, d, i_type, thread, pI);
-}
-
-void mov_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t data;
-
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  unsigned i_type = pI->get_type();
-  assert(src1.is_param_local() == 0);
-
-  if ((src1.is_vector() || dst.is_vector()) && (i_type != BB64_TYPE) &&
-      (i_type != BB128_TYPE) && (i_type != FF64_TYPE)) {
-    // pack or unpack operation
-    unsigned nbits_to_move;
-    ptx_reg_t tmp_bits;
-
-    switch (pI->get_type()) {
-      case B16_TYPE:
-        nbits_to_move = 16;
-        break;
-      case B32_TYPE:
-        nbits_to_move = 32;
-        break;
-      case B64_TYPE:
-        nbits_to_move = 64;
-        break;
-      default:
-        printf(
-            "Execution error: mov pack/unpack with unsupported type "
-            "qualifier\n");
-        assert(0);
-        break;
-    }
-
-    if (src1.is_vector()) {
-      unsigned nelem = src1.get_vect_nelem();
-      ptx_reg_t v[4];
-      thread->get_vector_operand_values(src1, v, nelem);
-
-      unsigned bits_per_src_elem = nbits_to_move / nelem;
-      for (unsigned i = 0; i < nelem; i++) {
-        switch (bits_per_src_elem) {
-          case 8:
-            tmp_bits.u64 |= ((unsigned long long)(v[i].u8) << (8 * i));
-            break;
-          case 16:
-            tmp_bits.u64 |= ((unsigned long long)(v[i].u16) << (16 * i));
-            break;
-          case 32:
-            tmp_bits.u64 |= ((unsigned long long)(v[i].u32) << (32 * i));
-            break;
-          default:
-            printf(
-                "Execution error: mov pack/unpack with unsupported source/dst "
-                "size ratio (src)\n");
-            assert(0);
-            break;
-        }
+      switch( pI->get_type() ) {
+      case B16_TYPE: nbits_to_move = 16; break;
+      case B32_TYPE: nbits_to_move = 32; break;
+      case B64_TYPE: nbits_to_move = 64; break;
+      default: printf("Execution error: mov pack/unpack with unsupported type qualifier\n"); assert(0); break;
       }
-    } else {
+
+      if( src1.is_vector() ) {
+         unsigned nelem = src1.get_vect_nelem();
+         ptx_reg_t v[4];
+         thread->get_vector_operand_values(src1, v, nelem );
+
+         unsigned bits_per_src_elem = nbits_to_move / nelem;
+         for( unsigned i=0; i < nelem; i++ ) {
+            switch(bits_per_src_elem) {
+            case 8:   tmp_bits.u64 |= ((unsigned long long)(v[i].u8)  << (8*i));  break;
+            case 16:  tmp_bits.u64 |= ((unsigned long long)(v[i].u16) << (16*i)); break;
+            case 32:  tmp_bits.u64 |= ((unsigned long long)(v[i].u32) << (32*i)); break;
+            default: printf("Execution error: mov pack/unpack with unsupported source/dst size ratio (src)\n"); assert(0); break;
+            }
+         }
+      } else {
+         data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+
+         switch( pI->get_type() ) {
+         case B16_TYPE: tmp_bits.u16 = data.u16; break;
+         case B32_TYPE: tmp_bits.u32 = data.u32; break;
+         case B64_TYPE: tmp_bits.u64 = data.u64; break;
+         default: assert(0); break;
+         }
+      }
+
+      if( dst.is_vector() ) {
+         unsigned nelem = dst.get_vect_nelem();
+         ptx_reg_t v[4];
+         unsigned bits_per_dst_elem = nbits_to_move / nelem;
+         for( unsigned i=0; i < nelem; i++ ) {
+            switch(bits_per_dst_elem) {
+            case 8:  v[i].u8  = (tmp_bits.u64 >> (8*i)) & ((unsigned long long) 0xFF); break;
+            case 16: v[i].u16 = (tmp_bits.u64 >> (16*i)) & ((unsigned long long) 0xFFFF); break;
+            case 32: v[i].u32 = (tmp_bits.u64 >> (32*i)) & ((unsigned long long) 0xFFFFFFFF); break;
+            default:
+               printf("Execution error: mov pack/unpack with unsupported source/dst size ratio (dst)\n");
+               assert(0);
+               break;
+            }
+         }
+         thread->set_vector_operand_values(dst,v[0],v[1],v[2],v[3]);
+      } else {
+         thread->set_operand_value(dst,tmp_bits, i_type, thread, pI);
+      }
+   } else if (i_type == PRED_TYPE and src1.is_literal() == true) {
+      // in ptx, literal input translate to predicate as 0 = false and 1 = true 
+      // we have adopted the opposite to simplify implementation of zero flags in ptxplus 
       data = thread->get_operand_value(src1, dst, i_type, thread, 1);
 
-      switch (pI->get_type()) {
-        case B16_TYPE:
-          tmp_bits.u16 = data.u16;
-          break;
-        case B32_TYPE:
-          tmp_bits.u32 = data.u32;
-          break;
-        case B64_TYPE:
-          tmp_bits.u64 = data.u64;
-          break;
-        default:
-          assert(0);
-          break;
-      }
-    }
+      ptx_reg_t finaldata; 
+      finaldata.pred = (data.u32 == 0)? 1 : 0;  // setting zero-flag in predicate 
+      thread->set_operand_value(dst, finaldata, i_type, thread, pI);
+   } else {
 
-    if (dst.is_vector()) {
-      unsigned nelem = dst.get_vect_nelem();
-      ptx_reg_t v[4];
-      unsigned bits_per_dst_elem = nbits_to_move / nelem;
-      for (unsigned i = 0; i < nelem; i++) {
-        switch (bits_per_dst_elem) {
-          case 8:
-            v[i].u8 = (tmp_bits.u64 >> (8 * i)) & ((unsigned long long)0xFF);
-            break;
-          case 16:
-            v[i].u16 =
-                (tmp_bits.u64 >> (16 * i)) & ((unsigned long long)0xFFFF);
-            break;
-          case 32:
-            v[i].u32 =
-                (tmp_bits.u64 >> (32 * i)) & ((unsigned long long)0xFFFFFFFF);
-            break;
-          default:
-            printf(
-                "Execution error: mov pack/unpack with unsupported source/dst "
-                "size ratio (dst)\n");
-            assert(0);
-            break;
-        }
-      }
-      thread->set_vector_operand_values(dst, v[0], v[1], v[2], v[3]);
-    } else {
-      thread->set_operand_value(dst, tmp_bits, i_type, thread, pI);
-    }
-  } else if (i_type == PRED_TYPE and src1.is_literal() == true) {
-    // in ptx, literal input translate to predicate as 0 = false and 1 = true
-    // we have adopted the opposite to simplify implementation of zero flags in
-    // ptxplus
-    data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+      data = thread->get_operand_value(src1, dst, i_type, thread, 1);
 
-    ptx_reg_t finaldata;
-    finaldata.pred = (data.u32 == 0) ? 1 : 0;  // setting zero-flag in predicate
-    thread->set_operand_value(dst, finaldata, i_type, thread, pI);
-  } else {
-    data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+     thread->set_operand_value(dst, data, i_type, thread, pI);
 
-    thread->set_operand_value(dst, data, i_type, thread, pI);
-  }
+   }
 }
 
-void mul24_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t src1_data, src2_data, data;
+void mul24_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+   ptx_reg_t src1_data, src2_data, data;
 
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  const operand_info &src2 = pI->src2();
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
+   const operand_info &src2 = pI->src2();
 
-  unsigned i_type = pI->get_type();
-  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+   unsigned i_type = pI->get_type();
+   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-  // src1_data = srcOperandModifiers(src1_data, src1, dst, i_type, thread);
-  // src2_data = srcOperandModifiers(src2_data, src2, dst, i_type, thread);
 
-  src1_data.mask_and(0, 0x00FFFFFF);
-  src2_data.mask_and(0, 0x00FFFFFF);
+   //src1_data = srcOperandModifiers(src1_data, src1, dst, i_type, thread);
+   //src2_data = srcOperandModifiers(src2_data, src2, dst, i_type, thread);
 
-  switch (i_type) {
-    case S32_TYPE:
-      if (src1_data.get_bit(23)) src1_data.mask_or(0xFFFFFFFF, 0xFF000000);
-      if (src2_data.get_bit(23)) src2_data.mask_or(0xFFFFFFFF, 0xFF000000);
+   src1_data.mask_and(0,0x00FFFFFF);
+   src2_data.mask_and(0,0x00FFFFFF);
+
+   switch ( i_type ) {
+   case S32_TYPE: 
+      if( src1_data.get_bit(23) ) 
+         src1_data.mask_or(0xFFFFFFFF,0xFF000000);
+      if( src2_data.get_bit(23) ) 
+         src2_data.mask_or(0xFFFFFFFF,0xFF000000);
       data.s64 = src1_data.s64 * src2_data.s64;
       break;
-    case U32_TYPE:
+   case U32_TYPE:
       data.u64 = src1_data.u64 * src2_data.u64;
       break;
-    default:
-      printf(
-          "GPGPU-Sim PTX: Execution error - type mismatch with instruction\n");
+   default:
+      printf("GPGPU-Sim PTX: Execution error - type mismatch with instruction\n");
       assert(0);
       break;
-  }
+   }
 
-  if (pI->is_hi()) {
-    data.u64 = data.u64 >> 16;
-    data.mask_and(0, 0xFFFFFFFF);
-  } else if (pI->is_lo()) {
-    data.mask_and(0, 0xFFFFFFFF);
-  }
+   if ( pI->is_hi() ) {
+      data.u64 = data.u64 >> 16;
+      data.mask_and(0,0xFFFFFFFF);
+   } else if (pI->is_lo()) {
+      data.mask_and(0,0xFFFFFFFF);
+   }
 
-  thread->set_operand_value(dst, data, i_type, thread, pI);
+   thread->set_operand_value(dst, data, i_type, thread, pI);
 }
 
-void mul_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t data;
+void mul_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+   ptx_reg_t data;
 
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  const operand_info &src2 = pI->src2();
-  ptx_reg_t d, t;
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
+   const operand_info &src2 = pI->src2();
+   ptx_reg_t d, t;
 
-  unsigned i_type = pI->get_type();
-  ptx_reg_t a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-  ptx_reg_t b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+   unsigned i_type = pI->get_type();
+   ptx_reg_t a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   ptx_reg_t b = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-  unsigned rounding_mode = pI->rounding_mode();
+   unsigned rounding_mode = pI->rounding_mode();
 
-  switch (i_type) {
-    case S16_TYPE:
+   switch ( i_type ) {
+   case S16_TYPE: 
       t.s32 = ((int)a.s16) * ((int)b.s16);
-      if (pI->is_wide())
-        d.s32 = t.s32;
-      else if (pI->is_hi())
-        d.s16 = (t.s32 >> 16);
-      else if (pI->is_lo())
-        d.s16 = t.s16;
-      else
-        assert(0);
+      if ( pI->is_wide() ) d.s32 = t.s32;
+      else if ( pI->is_hi() ) d.s16 = (t.s32>>16);
+      else if ( pI->is_lo() ) d.s16 = t.s16;
+      else assert(0);
       break;
-    case S32_TYPE:
+   case S32_TYPE: 
       t.s64 = ((long long)a.s32) * ((long long)b.s32);
-      if (pI->is_wide())
-        d.s64 = t.s64;
-      else if (pI->is_hi())
-        d.s32 = (t.s64 >> 32);
-      else if (pI->is_lo())
-        d.s32 = t.s32;
-      else
-        assert(0);
+      if ( pI->is_wide() ) d.s64 = t.s64;
+      else if ( pI->is_hi() ) d.s32 = (t.s64>>32);
+      else if ( pI->is_lo() ) d.s32 = t.s32;
+      else assert(0);
       break;
-    case S64_TYPE:
+   case S64_TYPE: 
       t.s64 = a.s64 * b.s64;
-      assert(!pI->is_wide());
-      assert(!pI->is_hi());
-      if (pI->is_lo())
-        d.s64 = t.s64;
-      else
-        assert(0);
+      assert( !pI->is_wide() );
+      assert( !pI->is_hi() );
+      if ( pI->is_lo() ) d.s64 = t.s64;
+      else assert(0);
       break;
-    case U16_TYPE:
+   case U16_TYPE: 
       t.u32 = ((unsigned)a.u16) * ((unsigned)b.u16);
-      if (pI->is_wide())
-        d.u32 = t.u32;
-      else if (pI->is_lo())
-        d.u16 = t.u16;
-      else if (pI->is_hi())
-        d.u16 = (t.u32 >> 16);
-      else
-        assert(0);
+      if ( pI->is_wide() ) d.u32 = t.u32;
+      else if ( pI->is_lo() ) d.u16 = t.u16;
+      else if ( pI->is_hi() ) d.u16 = (t.u32>>16);
+      else assert(0);
       break;
-    case U32_TYPE:
+   case U32_TYPE: 
       t.u64 = ((unsigned long long)a.u32) * ((unsigned long long)b.u32);
-      if (pI->is_wide())
-        d.u64 = t.u64;
-      else if (pI->is_lo())
-        d.u32 = t.u32;
-      else if (pI->is_hi())
-        d.u32 = (t.u64 >> 32);
-      else
-        assert(0);
+      if ( pI->is_wide() ) d.u64 = t.u64;
+      else if ( pI->is_lo() ) d.u32 = t.u32;
+      else if ( pI->is_hi() ) d.u32 = (t.u64>>32);
+      else assert(0);
       break;
-    case U64_TYPE:
+   case U64_TYPE: 
       t.u64 = a.u64 * b.u64;
-      assert(!pI->is_wide());
-      assert(!pI->is_hi());
-      if (pI->is_lo())
-        d.u64 = t.u64;
-      else
-        assert(0);
+      assert( !pI->is_wide() );
+      assert( !pI->is_hi() );
+      if ( pI->is_lo() ) d.u64 = t.u64;
+      else assert(0);
       break;
-    case F16_TYPE: {
-      // assert(0);
-      // break;
-      int orig_rm = fegetround();
-      switch (rounding_mode) {
-        case RN_OPTION:
-          break;
-        case RZ_OPTION:
-          fesetround(FE_TOWARDZERO);
-          break;
-        default:
-          assert(0);
-          break;
-      }
+   case F16_TYPE:{ 
+      //assert(0); 
+      //break;
+         int orig_rm = fegetround();
+         switch ( rounding_mode ) {
+         case RN_OPTION: break;
+         case RZ_OPTION: fesetround( FE_TOWARDZERO ); break;
+         default: assert(0); break;
+         }
 
-      d.f16 = a.f16 * b.f16;
+         d.f16 = a.f16 * b.f16;
 
-      if (pI->saturation_mode()) {
-        if (d.f16 < 0)
-          d.f16 = 0;
-        else if (d.f16 > 1.0f)
-          d.f16 = 1.0f;
+         if ( pI->saturation_mode() ) {
+            if ( d.f16 < 0 ) d.f16 = 0;
+            else if ( d.f16 > 1.0f ) d.f16 = 1.0f;
+         }
+         fesetround( orig_rm );
+         break;
+      }  
+   case F32_TYPE: {
+         int orig_rm = fegetround();
+         switch ( rounding_mode ) {
+         case RN_OPTION: break;
+         case RZ_OPTION: fesetround( FE_TOWARDZERO ); break;
+         default: assert(0); break;
+         }
+
+         d.f32 = a.f32 * b.f32;
+
+         if ( pI->saturation_mode() ) {
+            if ( d.f32 < 0 ) d.f32 = 0;
+            else if ( d.f32 > 1.0f ) d.f32 = 1.0f;
+         }
+         fesetround( orig_rm );
+         break;
+      }  
+   case F64_TYPE: case FF64_TYPE:{
+         int orig_rm = fegetround();
+         switch ( rounding_mode ) {
+         case RN_OPTION: break;
+         case RZ_OPTION: fesetround( FE_TOWARDZERO ); break;
+         default: assert(0); break;
+         }
+         d.f64 = a.f64 * b.f64;
+         if ( pI->saturation_mode() ) {
+            if ( d.f64 < 0 ) d.f64 = 0;
+            else if ( d.f64 > 1.0f ) d.f64 = 1.0;
+         }
+         fesetround( orig_rm );
+         break;
       }
-      fesetround(orig_rm);
+   default: 
+      assert(0); 
       break;
-    }
-    case F32_TYPE: {
-      int orig_rm = fegetround();
-      switch (rounding_mode) {
-        case RN_OPTION:
-          break;
-        case RZ_OPTION:
-          fesetround(FE_TOWARDZERO);
-          break;
-        default:
-          assert(0);
-          break;
-      }
+   }
 
-      d.f32 = a.f32 * b.f32;
-
-      if (pI->saturation_mode()) {
-        if (d.f32 < 0)
-          d.f32 = 0;
-        else if (d.f32 > 1.0f)
-          d.f32 = 1.0f;
-      }
-      fesetround(orig_rm);
-      break;
-    }
-    case F64_TYPE:
-    case FF64_TYPE: {
-      int orig_rm = fegetround();
-      switch (rounding_mode) {
-        case RN_OPTION:
-          break;
-        case RZ_OPTION:
-          fesetround(FE_TOWARDZERO);
-          break;
-        default:
-          assert(0);
-          break;
-      }
-      d.f64 = a.f64 * b.f64;
-      if (pI->saturation_mode()) {
-        if (d.f64 < 0)
-          d.f64 = 0;
-        else if (d.f64 > 1.0f)
-          d.f64 = 1.0;
-      }
-      fesetround(orig_rm);
-      break;
-    }
-    default:
-      assert(0);
-      break;
-  }
-
-  thread->set_operand_value(dst, d, i_type, thread, pI);
+   thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-void neg_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t src1_data, src2_data, data;
+void neg_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   ptx_reg_t src1_data, src2_data, data;
 
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
 
-  unsigned to_type = pI->get_type();
-  src1_data = thread->get_operand_value(src1, dst, to_type, thread, 1);
+   unsigned to_type = pI->get_type();
+   src1_data = thread->get_operand_value(src1, dst, to_type, thread, 1);
 
-  switch (to_type) {
-    case S8_TYPE:
-    case S16_TYPE:
-    case S32_TYPE:
-    case S64_TYPE:
-      data.s64 = 0 - src1_data.s64;
-      break;  // seems buggy, but not (just ignore higher bits)
-    case U8_TYPE:
-    case U16_TYPE:
-    case U32_TYPE:
-    case U64_TYPE:
-      assert(0);
-      break;
-    case F16_TYPE:
-      data.f16 = 0.0f - src1_data.f16;
-      break;  // assert(0); break;
-    case F32_TYPE:
-      data.f32 = 0.0f - src1_data.f32;
-      break;
-    case F64_TYPE:
-    case FF64_TYPE:
-      data.f64 = 0.0f - src1_data.f64;
-      break;
-    default:
-      assert(0);
-      break;
-  }
 
-  thread->set_operand_value(dst, data, to_type, thread, pI);
+   switch ( to_type ) {
+   case S8_TYPE:
+   case S16_TYPE:
+   case S32_TYPE:
+   case S64_TYPE: 
+      data.s64 = 0 - src1_data.s64; break; // seems buggy, but not (just ignore higher bits)
+   case U8_TYPE:
+   case U16_TYPE:
+   case U32_TYPE:
+   case U64_TYPE: 
+      assert(0); break;
+   case F16_TYPE: data.f16 =0.0f  - src1_data.f16; break;//assert(0); break;
+   case F32_TYPE: data.f32 = 0.0f - src1_data.f32; break;
+   case F64_TYPE: case FF64_TYPE: data.f64 = 0.0f - src1_data.f64; break;
+   default: assert(0); break;
+   }
+
+   thread->set_operand_value(dst,data, to_type, thread, pI);
 }
 
-// nandn bitwise negates second operand then bitwise nands with the first
-// operand
-void nandn_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t src1_data, src2_data, data;
+//nandn bitwise negates second operand then bitwise nands with the first operand
+void nandn_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+   ptx_reg_t src1_data, src2_data, data;
 
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  const operand_info &src2 = pI->src2();
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
+   const operand_info &src2 = pI->src2();
 
-  unsigned i_type = pI->get_type();
-  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+   unsigned i_type = pI->get_type();
+   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-  // the way ptxplus handles predicates: 1 = false and 0 = true
-  if (i_type == PRED_TYPE)
-    data.pred = (~src1_data.pred & src2_data.pred);
-  else
-    data.u64 = ~(src1_data.u64 & ~src2_data.u64);
 
-  thread->set_operand_value(dst, data, i_type, thread, pI);
+   //the way ptxplus handles predicates: 1 = false and 0 = true
+   if(i_type == PRED_TYPE)
+      data.pred = (~src1_data.pred & src2_data.pred);
+   else
+      data.u64 = ~(src1_data.u64 & ~src2_data.u64);
+
+   thread->set_operand_value(dst,data, i_type, thread, pI);
+
 }
 
-// norn bitwise negates first operand then bitwise ands with the second operand
-void norn_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t src1_data, src2_data, data;
+//norn bitwise negates first operand then bitwise ands with the second operand
+void norn_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+   ptx_reg_t src1_data, src2_data, data;
 
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  const operand_info &src2 = pI->src2();
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
+   const operand_info &src2 = pI->src2();
 
-  unsigned i_type = pI->get_type();
-  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+   unsigned i_type = pI->get_type();
+   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-  // the way ptxplus handles predicates: 1 = false and 0 = true
-  if (i_type == PRED_TYPE)
-    data.pred = ~(src1_data.pred & ~(src2_data.pred));
-  else
-    data.u64 = ~(src1_data.u64) & src2_data.u64;
 
-  thread->set_operand_value(dst, data, i_type, thread, pI);
+   //the way ptxplus handles predicates: 1 = false and 0 = true
+   if(i_type == PRED_TYPE)
+      data.pred = ~(src1_data.pred & ~(src2_data.pred));
+   else
+      data.u64 = ~(src1_data.u64) & src2_data.u64;
+
+   thread->set_operand_value(dst,data, i_type, thread, pI);
+
 }
 
-void not_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t a, b, d;
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
+void not_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+   ptx_reg_t a, b, d;
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
 
-  unsigned i_type = pI->get_type();
-  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   unsigned i_type = pI->get_type();
+   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
 
-  switch (i_type) {
-    case PRED_TYPE:
-      d.pred = (~(a.pred) & 0x000F);
-      break;
-    case B16_TYPE:
-      d.u16 = ~a.u16;
-      break;
-    case B32_TYPE:
-      d.u32 = ~a.u32;
-      break;
-    case B64_TYPE:
-      d.u64 = ~a.u64;
-      break;
-    default:
+
+   switch ( i_type ) {
+   case PRED_TYPE: d.pred = (~(a.pred) & 0x000F); break;
+   case B16_TYPE:  d.u16  = ~a.u16; break;
+   case B32_TYPE:  d.u32  = ~a.u32; break;
+   case B64_TYPE:  d.u64  = ~a.u64; break;
+   default:
       printf("Execution error: type mismatch with instruction\n");
-      assert(0);
+      assert(0); 
       break;
-  }
+   }
 
-  thread->set_operand_value(dst, d, i_type, thread, pI);
+   thread->set_operand_value(dst,d, i_type, thread, pI);
 }
 
-void or_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t src1_data, src2_data, data;
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  const operand_info &src2 = pI->src2();
+void or_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   ptx_reg_t src1_data, src2_data, data;
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
+   const operand_info &src2 = pI->src2();
 
-  unsigned i_type = pI->get_type();
-  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+   unsigned i_type = pI->get_type();
+   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-  // the way ptxplus handles predicates: 1 = false and 0 = true
-  if (i_type == PRED_TYPE)
-    data.pred = ~(~(src1_data.pred) | ~(src2_data.pred));
-  else
-    data.u64 = src1_data.u64 | src2_data.u64;
+   //the way ptxplus handles predicates: 1 = false and 0 = true
+   if(i_type == PRED_TYPE)
+      data.pred = ~(~(src1_data.pred) | ~(src2_data.pred));
+   else
+      data.u64 = src1_data.u64 | src2_data.u64;
 
-  thread->set_operand_value(dst, data, i_type, thread, pI);
+   thread->set_operand_value(dst,data, i_type, thread, pI);
 }
 
-void orn_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t src1_data, src2_data, data;
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  const operand_info &src2 = pI->src2();
+void orn_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   ptx_reg_t src1_data, src2_data, data;
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
+   const operand_info &src2 = pI->src2();
 
-  unsigned i_type = pI->get_type();
-  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+   unsigned i_type = pI->get_type();
+   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-  // the way ptxplus handles predicates: 1 = false and 0 = true
-  if (i_type == PRED_TYPE)
-    data.pred = ~(~(src1_data.pred) | (src2_data.pred));
-  else
-    data.u64 = src1_data.u64 | ~src2_data.u64;
+   //the way ptxplus handles predicates: 1 = false and 0 = true
+   if(i_type == PRED_TYPE)
+      data.pred = ~(~(src1_data.pred) | (src2_data.pred));
+   else
+      data.u64 = src1_data.u64 | ~src2_data.u64;
 
-  thread->set_operand_value(dst, data, i_type, thread, pI);
+   thread->set_operand_value(dst,data, i_type, thread, pI);
 }
 
-void pmevent_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  inst_not_implemented(pI);
-}
-void popc_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t src_data, data;
-  const operand_info &dst = pI->dst();
-  const operand_info &src = pI->src1();
+void pmevent_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
+void popc_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   ptx_reg_t src_data, data;
+   const operand_info &dst  = pI->dst();
+   const operand_info &src = pI->src1();
 
-  unsigned i_type = pI->get_type();
-  src_data = thread->get_operand_value(src, dst, i_type, thread, 1);
+   unsigned i_type = pI->get_type();
+   src_data = thread->get_operand_value(src, dst, i_type, thread, 1);
 
-  switch (i_type) {
-    case B32_TYPE: {
-      std::bitset<32> mask(src_data.u32);
+   switch ( i_type ) {
+   case B32_TYPE: {
+      std::bitset<32> mask(src_data.u32); 
+      data.u32 = mask.count(); 
+      } break;
+   case B64_TYPE: {
+      std::bitset<64> mask(src_data.u64); 
       data.u32 = mask.count();
-    } break;
-    case B64_TYPE: {
-      std::bitset<64> mask(src_data.u64);
-      data.u32 = mask.count();
-    } break;
-    default:
+      } break;
+   default:
       printf("Execution error: type mismatch with instruction\n");
-      assert(0);
+      assert(0); 
       break;
-  }
+   }
 
-  thread->set_operand_value(dst, data, i_type, thread, pI);
+   thread->set_operand_value(dst,data, i_type, thread, pI);
 }
-void prefetch_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  inst_not_implemented(pI);
-}
-void prefetchu_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  inst_not_implemented(pI);
-}
+void prefetch_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
+void prefetchu_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
 
-int prmt_mode_present(int mode) {
-  int returnval = 0;
-  switch (mode) {
-    case PRMT_F4E_MODE:
-    case PRMT_B4E_MODE:
-    case PRMT_RC8_MODE:
-    case PRMT_RC16_MODE:
-    case PRMT_ECL_MODE:
-    case PRMT_ECR_MODE:
-      returnval = 1;
-      break;
-    default:
-      break;
-  }
-  return returnval;
+int prmt_mode_present(int mode)
+{
+	int returnval=0;
+	switch(mode){
+		case PRMT_F4E_MODE:
+		case PRMT_B4E_MODE:
+		case PRMT_RC8_MODE:
+		case PRMT_RC16_MODE:
+		case PRMT_ECL_MODE:
+		case PRMT_ECR_MODE:	
+			returnval=1;
+			break;
+		default:	
+			break;
+	}
+	return returnval;
 }
-int read_byte(int mode, int control, int d_sel_index, signed long long value) {
-  int returnval = 0;
-  int prmt_f4e_mode[4][4] = {
-      {0, 1, 2, 3}, {1, 2, 3, 4}, {2, 3, 4, 5}, {3, 4, 5, 6}};
-  int prmt_b4e_mode[4][4] = {
-      {0, 7, 6, 5}, {1, 0, 7, 6}, {2, 1, 0, 7}, {3, 2, 1, 0}};
-  int prmt_rc8_mode[4][4] = {
-      {0, 0, 0, 0}, {1, 1, 1, 1}, {2, 2, 2, 2}, {3, 3, 3, 3}};
-  int prmt_ecl_mode[4][4] = {
-      {0, 1, 2, 3}, {1, 1, 2, 3}, {2, 2, 2, 3}, {3, 3, 3, 3}};
-  int prmt_ecr_mode[4][4] = {
-      {0, 0, 0, 0}, {0, 1, 1, 1}, {0, 1, 2, 2}, {0, 1, 2, 3}};
-  int prmt_rc16_mode[4][4] = {
-      {0, 1, 0, 1}, {2, 3, 2, 3}, {0, 1, 0, 1}, {2, 3, 2, 3}};
+int read_byte(int mode, int control, int d_sel_index, signed long long value){
 
-  if (!prmt_mode_present(mode)) {
-    if (control & 0x8) {
-      returnval = 0xff;
-    } else {
-      returnval = (value >> (8 * control)) & 0xff;
-    }
-  } else {
-    switch (mode) {
-      case PRMT_F4E_MODE:
-        returnval = prmt_f4e_mode[control][d_sel_index];
-        break;
-      case PRMT_B4E_MODE:
-        returnval = prmt_b4e_mode[control][d_sel_index];
-        break;
-      case PRMT_RC8_MODE:
-        returnval = prmt_rc8_mode[control][d_sel_index];
-        break;
-      case PRMT_ECL_MODE:
-        returnval = prmt_ecl_mode[control][d_sel_index];
-        break;
-      case PRMT_ECR_MODE:
-        returnval = prmt_ecr_mode[control][d_sel_index];
-        break;
-      case PRMT_RC16_MODE:
-        returnval = prmt_rc16_mode[control][d_sel_index];
-        break;
-      // Change the default from printing "ERROR" to just asserting
-      default:
-        assert(false);
-    }
-  }
-  return (returnval << 8 * d_sel_index);
+	int returnval = 0;
+	int prmt_f4e_mode[4][4]={{0,1,2,3},{1,2,3,4},{2,3,4,5},{3,4,5,6}};
+	int prmt_b4e_mode[4][4]={{0,7,6,5},{1,0,7,6},{2,1,0,7},{3,2,1,0}};
+	int prmt_rc8_mode[4][4]={{0,0,0,0},{1,1,1,1},{2,2,2,2},{3,3,3,3}};
+	int prmt_ecl_mode[4][4]={{0,1,2,3},{1,1,2,3},{2,2,2,3},{3,3,3,3}};
+	int prmt_ecr_mode[4][4]={{0,0,0,0},{0,1,1,1},{0,1,2,2},{0,1,2,3}};
+	int prmt_rc16_mode[4][4]={{0,1,0,1},{2,3,2,3},{0,1,0,1},{2,3,2,3}};
+
+	if(!prmt_mode_present(mode)){
+		if(control&0x8){
+			returnval=0xff;
+		}
+		else{
+			returnval= (value>>(8*control)) & 0xff;
+		}
+	}
+	else{
+		switch(mode){
+			case PRMT_F4E_MODE:	returnval=prmt_f4e_mode[control][d_sel_index];break;
+			case PRMT_B4E_MODE:	returnval=prmt_b4e_mode[control][d_sel_index];break;
+			case PRMT_RC8_MODE:	returnval=prmt_rc8_mode[control][d_sel_index];break;
+			case PRMT_ECL_MODE:	returnval=prmt_ecl_mode[control][d_sel_index];break;
+			case PRMT_ECR_MODE:	returnval=prmt_ecr_mode[control][d_sel_index];break;
+			case PRMT_RC16_MODE: returnval=prmt_rc16_mode[control][d_sel_index];break;
+            // Change the default from printing "ERROR" to just asserting
+			default: assert(false);
+		}
+	}	
+	return (returnval << 8 * d_sel_index);
 }
 
-void prmt_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t src1_data, src2_data, src3_data, tmpdata, data;
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  const operand_info &src2 = pI->src2();
-  const operand_info &src3 = pI->src3();
+void prmt_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { 
+   
+   ptx_reg_t src1_data, src2_data, src3_data,tmpdata,data;
+   const operand_info &dst  = pI->dst();  
+   const operand_info &src1 = pI->src1();
+   const operand_info &src2 = pI->src2();
+   const operand_info &src3 = pI->src3();
 
-  unsigned mode = pI->prmt_op();
-  unsigned i_type = pI->get_type();
+   unsigned mode   = pI->prmt_op();
+   unsigned i_type = pI->get_type();
 
-  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
-  src3_data = thread->get_operand_value(src3, dst, i_type, thread, 1);
+   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+   src3_data = thread->get_operand_value(src3, dst, i_type, thread, 1);
 
-  tmpdata.s64 = src1_data.s32 | (src2_data.s64 << 32);
-  int ctl[4];
+   tmpdata.s64=src1_data.s32|(src2_data.s64<<32);
+   int ctl[4];
 
-  if (!prmt_mode_present(mode)) {
-    ctl[0] = (src3_data.s32 >> 0) & 0xf;
-    ctl[1] = (src3_data.s32 >> 4) & 0xf;
-    ctl[2] = (src3_data.s32 >> 8) & 0xf;
-    ctl[3] = (src3_data.s32 >> 12) & 0xf;
-  } else {
-    ctl[0] = ctl[1] = ctl[2] = ctl[3] = (src3_data.s32 >> 0) & 0x3;
-  }
+   if(!prmt_mode_present(mode)){
+	ctl[0]=(src3_data.s32>>0)&0xf;
+	ctl[1]=(src3_data.s32>>4)&0xf;
+	ctl[2]=(src3_data.s32>>8)&0xf;
+	ctl[3]=(src3_data.s32>>12)&0xf;
+   }
+   else{
+	ctl[0]=ctl[1]=ctl[2]=ctl[3]=(src3_data.s32>>0)&0x3;	
+   }
+   
+   data.s32=0;
+   data.s32=data.s32|read_byte(mode,ctl[0],0,tmpdata.s64);   //First byte-0
+   data.s32=data.s32|read_byte(mode,ctl[1],1,tmpdata.s64);   //Second byte-1
+   data.s32=data.s32|read_byte(mode,ctl[2],2,tmpdata.s64);   //Third byte-2
+   data.s32=data.s32|read_byte(mode,ctl[3],3,tmpdata.s64);   //Fourth byte-3
+	
+   thread->set_operand_value(dst,data, i_type, thread, pI);
 
-  data.s32 = 0;
-  data.s32 = data.s32 | read_byte(mode, ctl[0], 0, tmpdata.s64);  // First
-                                                                  // byte-0
-  data.s32 =
-      data.s32 | read_byte(mode, ctl[1], 1, tmpdata.s64);  // Second byte-1
-  data.s32 = data.s32 | read_byte(mode, ctl[2], 2, tmpdata.s64);  // Third
-                                                                  // byte-2
-  data.s32 =
-      data.s32 | read_byte(mode, ctl[3], 3, tmpdata.s64);  // Fourth byte-3
 
-  thread->set_operand_value(dst, data, i_type, thread, pI);
 }
 
-void rcp_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t src1_data, src2_data, data;
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
+void rcp_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   ptx_reg_t src1_data, src2_data, data;
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
 
-  unsigned i_type = pI->get_type();
-  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   unsigned i_type = pI->get_type();
+   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
 
-  switch (i_type) {
-    case F32_TYPE:
+
+   switch ( i_type ) {
+   case F32_TYPE: 
       data.f32 = 1.0f / src1_data.f32;
       break;
-    case F64_TYPE:
-    case FF64_TYPE:
+   case F64_TYPE:
+   case FF64_TYPE:
       data.f64 = 1.0f / src1_data.f64;
       break;
-    default:
+   default:
       printf("Execution error: type mismatch with instruction\n");
-      assert(0);
+      assert(0); 
       break;
-  }
+   }
 
-  thread->set_operand_value(dst, data, i_type, thread, pI);
+   thread->set_operand_value(dst,data, i_type, thread, pI);
 }
 
-void red_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  inst_not_implemented(pI);
-}
+void red_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
 
-void rem_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t src1_data, src2_data, data;
+void rem_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   ptx_reg_t src1_data, src2_data, data;
 
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  const operand_info &src2 = pI->src2();
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
+   const operand_info &src2 = pI->src2();
 
-  unsigned i_type = pI->get_type();
-  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+   unsigned i_type = pI->get_type();
+   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-  switch (i_type) {
-    case S32_TYPE:
+   switch ( i_type ) {
+   case S32_TYPE:
       data.s32 = src1_data.s32 % src2_data.s32;
       break;
-    case S64_TYPE:
+   case S64_TYPE:
       data.s64 = src1_data.s64 % src2_data.s64;
       break;
-    case U32_TYPE:
+   case U32_TYPE:
       data.u32 = src1_data.u32 % src2_data.u32;
       break;
-    case U64_TYPE:
+   case U64_TYPE:
       data.u64 = src1_data.u64 % src2_data.u64;
       break;
-    default:
-      assert(0);
-      break;
-  }
+   default: assert(0); break;
+   }
 
-  thread->set_operand_value(dst, data, i_type, thread, pI);
+   thread->set_operand_value(dst,data, i_type, thread, pI);
 }
 
-void ret_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  bool empty = thread->callstack_pop();
-  if (empty) {
-    thread->set_done();
-    thread->exitCore();
-    thread->registerExit();
-  }
+void ret_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   bool empty = thread->callstack_pop();
+   if( empty ) {
+   thread->set_done();
+   thread->exitCore();
+   thread->registerExit();
+   }
 }
 
-// Ptxplus version of ret instruction.
-void retp_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  bool empty = thread->callstack_pop_plus();
-  if (empty) {
-    thread->set_done();
-    thread->exitCore();
-    thread->registerExit();
-  }
+//Ptxplus version of ret instruction.
+void retp_impl( const ptx_instruction *pI, ptx_thread_info *thread )
+{
+   bool empty = thread->callstack_pop_plus();
+   if( empty ) {
+   thread->set_done();
+   thread->exitCore();
+   thread->registerExit();
+   }
 }
 
-void rsqrt_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t a, d;
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
+void rsqrt_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   ptx_reg_t a, d;
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
 
-  unsigned i_type = pI->get_type();
-  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   unsigned i_type = pI->get_type();
+   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
 
-  switch (i_type) {
-    case F32_TYPE:
-      if (a.f32 < 0) {
-        d.u64 = 0;
-        d.u64 = 0x7fc00000;  // NaN
-      } else if (a.f32 == 0) {
-        d.u64 = 0;
-        d.u32 = 0x7f800000;  // Inf
+
+   switch ( i_type ) {
+   case F32_TYPE:
+      if ( a.f32 < 0 ) {
+         d.u64 = 0;
+         d.u64 = 0x7fc00000; // NaN
+      } else if ( a.f32 == 0 ) {
+         d.u64 = 0;
+         d.u32 = 0x7f800000; // Inf
       } else
-        d.f32 = cuda_math::__internal_accurate_fdividef(1.0f, sqrtf(a.f32));
+         d.f32 = cuda_math::__internal_accurate_fdividef(1.0f, sqrtf(a.f32));
       break;
-    case F64_TYPE:
-    case FF64_TYPE:
-      if (a.f32 < 0) {
-        d.u64 = 0;
-        d.u32 = 0x7fc00000;  // NaN
-        float x = d.f32;
-        d.f64 = (double)x;
-      } else if (a.f32 == 0) {
-        d.u64 = 0;
-        d.u32 = 0x7f800000;  // Inf
-        float x = d.f32;
-        d.f64 = (double)x;
+   case F64_TYPE: 
+   case FF64_TYPE:
+      if ( a.f32 < 0 ) {
+         d.u64 = 0;
+	      d.u32 = 0x7fc00000; // NaN
+         float x = d.f32; 
+         d.f64 = (double)x;
+      } else if ( a.f32 == 0 ) {
+         d.u64 = 0;
+	      d.u32 = 0x7f800000; // Inf
+         float x = d.f32; 
+         d.f64 = (double)x;
       } else
-        d.f64 = 1.0 / sqrt(a.f64);
+         d.f64 = 1.0 / sqrt(a.f64); 
       break;
-    default:
+   default:
       printf("Execution error: type mismatch with instruction\n");
       assert(0);
       break;
-  }
+   }
 
-  thread->set_operand_value(dst, d, i_type, thread, pI);
+   thread->set_operand_value(dst,d, i_type, thread, pI);
 }
 
-#define SAD(d, a, b, c) d = c + ((a < b) ? (b - a) : (a - b))
+#define SAD(d,a,b,c) d = c + ((a<b) ? (b-a) : (a-b))
 
-void sad_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t a, b, c, d;
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  const operand_info &src2 = pI->src2();
-  const operand_info &src3 = pI->src3();
+void sad_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   ptx_reg_t a, b, c, d;
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
+   const operand_info &src2 = pI->src2();
+   const operand_info &src3 = pI->src3();
 
-  unsigned i_type = pI->get_type();
-  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-  b = thread->get_operand_value(src2, dst, i_type, thread, 1);
-  c = thread->get_operand_value(src3, dst, i_type, thread, 1);
+   unsigned i_type = pI->get_type();
+   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+   c = thread->get_operand_value(src3, dst, i_type, thread, 1);
 
-  switch (i_type) {
-    case U16_TYPE:
-      SAD(d.u16, a.u16, b.u16, c.u16);
-      break;
-    case U32_TYPE:
-      SAD(d.u32, a.u32, b.u32, c.u32);
-      break;
-    case U64_TYPE:
-      SAD(d.u64, a.u64, b.u64, c.u64);
-      break;
-    case S16_TYPE:
-      SAD(d.s16, a.s16, b.s16, c.s16);
-      break;
-    case S32_TYPE:
-      SAD(d.s32, a.s32, b.s32, c.s32);
-      break;
-    case S64_TYPE:
-      SAD(d.s64, a.s64, b.s64, c.s64);
-      break;
-    case F32_TYPE:
-      SAD(d.f32, a.f32, b.f32, c.f32);
-      break;
-    case F64_TYPE:
-    case FF64_TYPE:
-      SAD(d.f64, a.f64, b.f64, c.f64);
-      break;
-    default:
+
+   switch ( i_type ) {
+   case U16_TYPE: SAD(d.u16,a.u16,b.u16,c.u16); break;
+   case U32_TYPE: SAD(d.u32,a.u32,b.u32,c.u32); break;
+   case U64_TYPE: SAD(d.u64,a.u64,b.u64,c.u64); break;
+   case S16_TYPE: SAD(d.s16,a.s16,b.s16,c.s16); break;
+   case S32_TYPE: SAD(d.s32,a.s32,b.s32,c.s32); break;
+   case S64_TYPE: SAD(d.s64,a.s64,b.s64,c.s64); break;
+   case F32_TYPE: SAD(d.f32,a.f32,b.f32,c.f32); break;
+   case F64_TYPE: case FF64_TYPE: SAD(d.f64,a.f64,b.f64,c.f64); break;
+   default:
       printf("Execution error: type mismatch with instruction\n");
-      assert(0);
+      assert(0); 
       break;
-  }
+   }
 
-  thread->set_operand_value(dst, d, i_type, thread, pI);
+   thread->set_operand_value(dst,d, i_type, thread, pI);
 }
 
-void selp_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  const operand_info &src2 = pI->src2();
-  const operand_info &src3 = pI->src3();
+void selp_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
+   const operand_info &src2 = pI->src2();
+   const operand_info &src3 = pI->src3();
 
-  ptx_reg_t a, b, c, d;
+   ptx_reg_t a, b, c, d;
 
-  unsigned i_type = pI->get_type();
-  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-  b = thread->get_operand_value(src2, dst, i_type, thread, 1);
-  c = thread->get_operand_value(src3, dst, i_type, thread, 1);
+   unsigned i_type = pI->get_type();
+   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+   c = thread->get_operand_value(src3, dst, i_type, thread, 1);
 
-  // predicate value was changed so the lowest bit being set means the zero flag
-  // is set.
-  // As a result, the value of c.pred must be inverted to get proper behavior
-  d = (!(c.pred & 0x0001)) ? a : b;
+   //predicate value was changed so the lowest bit being set means the zero flag is set.
+   //As a result, the value of c.pred must be inverted to get proper behavior
+   d = (!(c.pred & 0x0001))?a:b;
 
-  thread->set_operand_value(dst, d, PRED_TYPE, thread, pI);
+   thread->set_operand_value(dst,d, PRED_TYPE, thread, pI);
 }
 
-bool isFloat(int type) {
-  switch (type) {
-    case F16_TYPE:
-    case F32_TYPE:
-    case F64_TYPE:
-    case FF64_TYPE:
+bool isFloat(int type) 
+{
+   switch ( type ) {
+   case F16_TYPE:
+   case F32_TYPE:
+   case F64_TYPE:
+   case FF64_TYPE:
       return true;
-    default:
+   default:
       return false;
-  }
+   }
 }
 
-bool CmpOp(int type, ptx_reg_t a, ptx_reg_t b, unsigned cmpop) {
-  bool t = false;
+bool CmpOp( int type, ptx_reg_t a, ptx_reg_t b, unsigned cmpop )
+{
+   bool t = false;
 
-  switch (type) {
-    case B16_TYPE:
+   switch ( type ) {
+   case B16_TYPE: 
       switch (cmpop) {
-        case EQ_OPTION:
-          t = (a.u16 == b.u16);
-          break;
-        case NE_OPTION:
-          t = (a.u16 != b.u16);
-          break;
-        default:
-          assert(0);
-      }
-
-    case B32_TYPE:
-      switch (cmpop) {
-        case EQ_OPTION:
-          t = (a.u32 == b.u32);
-          break;
-        case NE_OPTION:
-          t = (a.u32 != b.u32);
-          break;
-        default:
-          assert(0);
-      }
-    case B64_TYPE:
-      switch (cmpop) {
-        case EQ_OPTION:
-          t = (a.u64 == b.u64);
-          break;
-        case NE_OPTION:
-          t = (a.u64 != b.u64);
-          break;
-        default:
-          assert(0);
-      }
-      break;
-    case S8_TYPE:
-    case S16_TYPE:
-      switch (cmpop) {
-        case EQ_OPTION:
-          t = (a.s16 == b.s16);
-          break;
-        case NE_OPTION:
-          t = (a.s16 != b.s16);
-          break;
-        case LT_OPTION:
-          t = (a.s16 < b.s16);
-          break;
-        case LE_OPTION:
-          t = (a.s16 <= b.s16);
-          break;
-        case GT_OPTION:
-          t = (a.s16 > b.s16);
-          break;
-        case GE_OPTION:
-          t = (a.s16 >= b.s16);
-          break;
-        default:
-          assert(0);
-      }
-      break;
-    case S32_TYPE:
-      switch (cmpop) {
-        case EQ_OPTION:
-          t = (a.s32 == b.s32);
-          break;
-        case NE_OPTION:
-          t = (a.s32 != b.s32);
-          break;
-        case LT_OPTION:
-          t = (a.s32 < b.s32);
-          break;
-        case LE_OPTION:
-          t = (a.s32 <= b.s32);
-          break;
-        case GT_OPTION:
-          t = (a.s32 > b.s32);
-          break;
-        case GE_OPTION:
-          t = (a.s32 >= b.s32);
-          break;
-        default:
-          assert(0);
-      }
-      break;
-    case S64_TYPE:
-      switch (cmpop) {
-        case EQ_OPTION:
-          t = (a.s64 == b.s64);
-          break;
-        case NE_OPTION:
-          t = (a.s64 != b.s64);
-          break;
-        case LT_OPTION:
-          t = (a.s64 < b.s64);
-          break;
-        case LE_OPTION:
-          t = (a.s64 <= b.s64);
-          break;
-        case GT_OPTION:
-          t = (a.s64 > b.s64);
-          break;
-        case GE_OPTION:
-          t = (a.s64 >= b.s64);
-          break;
-        default:
-          assert(0);
-      }
-      break;
-    case U8_TYPE:
-    case U16_TYPE:
-      switch (cmpop) {
-        case EQ_OPTION:
-          t = (a.u16 == b.u16);
-          break;
-        case NE_OPTION:
-          t = (a.u16 != b.u16);
-          break;
-        case LT_OPTION:
-          t = (a.u16 < b.u16);
-          break;
-        case LE_OPTION:
-          t = (a.u16 <= b.u16);
-          break;
-        case GT_OPTION:
-          t = (a.u16 > b.u16);
-          break;
-        case GE_OPTION:
-          t = (a.u16 >= b.u16);
-          break;
-        case LO_OPTION:
-          t = (a.u16 < b.u16);
-          break;
-        case LS_OPTION:
-          t = (a.u16 <= b.u16);
-          break;
-        case HI_OPTION:
-          t = (a.u16 > b.u16);
-          break;
-        case HS_OPTION:
-          t = (a.u16 >= b.u16);
-          break;
-        default:
-          assert(0);
-      }
-      break;
-    case U32_TYPE:
-      switch (cmpop) {
-        case EQ_OPTION:
-          t = (a.u32 == b.u32);
-          break;
-        case NE_OPTION:
-          t = (a.u32 != b.u32);
-          break;
-        case LT_OPTION:
-          t = (a.u32 < b.u32);
-          break;
-        case LE_OPTION:
-          t = (a.u32 <= b.u32);
-          break;
-        case GT_OPTION:
-          t = (a.u32 > b.u32);
-          break;
-        case GE_OPTION:
-          t = (a.u32 >= b.u32);
-          break;
-        case LO_OPTION:
-          t = (a.u32 < b.u32);
-          break;
-        case LS_OPTION:
-          t = (a.u32 <= b.u32);
-          break;
-        case HI_OPTION:
-          t = (a.u32 > b.u32);
-          break;
-        case HS_OPTION:
-          t = (a.u32 >= b.u32);
-          break;
-        default:
-          assert(0);
-      }
-      break;
-    case U64_TYPE:
-      switch (cmpop) {
-        case EQ_OPTION:
-          t = (a.u64 == b.u64);
-          break;
-        case NE_OPTION:
-          t = (a.u64 != b.u64);
-          break;
-        case LT_OPTION:
-          t = (a.u64 < b.u64);
-          break;
-        case LE_OPTION:
-          t = (a.u64 <= b.u64);
-          break;
-        case GT_OPTION:
-          t = (a.u64 > b.u64);
-          break;
-        case GE_OPTION:
-          t = (a.u64 >= b.u64);
-          break;
-        case LO_OPTION:
-          t = (a.u64 < b.u64);
-          break;
-        case LS_OPTION:
-          t = (a.u64 <= b.u64);
-          break;
-        case HI_OPTION:
-          t = (a.u64 > b.u64);
-          break;
-        case HS_OPTION:
-          t = (a.u64 >= b.u64);
-          break;
-        default:
-          assert(0);
-      }
-      break;
-    case F16_TYPE:
-      assert(0);
-      break;
-    case F32_TYPE:
-      switch (cmpop) {
-        case EQ_OPTION:
-          t = (a.f32 == b.f32) && !isNaN(a.f32) && !isNaN(b.f32);
-          break;
-        case NE_OPTION:
-          t = (a.f32 != b.f32) && !isNaN(a.f32) && !isNaN(b.f32);
-          break;
-        case LT_OPTION:
-          t = (a.f32 < b.f32) && !isNaN(a.f32) && !isNaN(b.f32);
-          break;
-        case LE_OPTION:
-          t = (a.f32 <= b.f32) && !isNaN(a.f32) && !isNaN(b.f32);
-          break;
-        case GT_OPTION:
-          t = (a.f32 > b.f32) && !isNaN(a.f32) && !isNaN(b.f32);
-          break;
-        case GE_OPTION:
-          t = (a.f32 >= b.f32) && !isNaN(a.f32) && !isNaN(b.f32);
-          break;
-        case EQU_OPTION:
-          t = (a.f32 == b.f32) || isNaN(a.f32) || isNaN(b.f32);
-          break;
-        case NEU_OPTION:
-          t = (a.f32 != b.f32) || isNaN(a.f32) || isNaN(b.f32);
-          break;
-        case LTU_OPTION:
-          t = (a.f32 < b.f32) || isNaN(a.f32) || isNaN(b.f32);
-          break;
-        case LEU_OPTION:
-          t = (a.f32 <= b.f32) || isNaN(a.f32) || isNaN(b.f32);
-          break;
-        case GTU_OPTION:
-          t = (a.f32 > b.f32) || isNaN(a.f32) || isNaN(b.f32);
-          break;
-        case GEU_OPTION:
-          t = (a.f32 >= b.f32) || isNaN(a.f32) || isNaN(b.f32);
-          break;
-        case NUM_OPTION:
-          t = !isNaN(a.f32) && !isNaN(b.f32);
-          break;
-        case NAN_OPTION:
-          t = isNaN(a.f32) || isNaN(b.f32);
-          break;
-        default:
-          assert(0);
-      }
-      break;
-    case F64_TYPE:
-    case FF64_TYPE:
-      switch (cmpop) {
-        case EQ_OPTION:
-          t = (a.f64 == b.f64) && !isNaN(a.f64) && !isNaN(b.f64);
-          break;
-        case NE_OPTION:
-          t = (a.f64 != b.f64) && !isNaN(a.f64) && !isNaN(b.f64);
-          break;
-        case LT_OPTION:
-          t = (a.f64 < b.f64) && !isNaN(a.f64) && !isNaN(b.f64);
-          break;
-        case LE_OPTION:
-          t = (a.f64 <= b.f64) && !isNaN(a.f64) && !isNaN(b.f64);
-          break;
-        case GT_OPTION:
-          t = (a.f64 > b.f64) && !isNaN(a.f64) && !isNaN(b.f64);
-          break;
-        case GE_OPTION:
-          t = (a.f64 >= b.f64) && !isNaN(a.f64) && !isNaN(b.f64);
-          break;
-        case EQU_OPTION:
-          t = (a.f64 == b.f64) || isNaN(a.f64) || isNaN(b.f64);
-          break;
-        case NEU_OPTION:
-          t = (a.f64 != b.f64) || isNaN(a.f64) || isNaN(b.f64);
-          break;
-        case LTU_OPTION:
-          t = (a.f64 < b.f64) || isNaN(a.f64) || isNaN(b.f64);
-          break;
-        case LEU_OPTION:
-          t = (a.f64 <= b.f64) || isNaN(a.f64) || isNaN(b.f64);
-          break;
-        case GTU_OPTION:
-          t = (a.f64 > b.f64) || isNaN(a.f64) || isNaN(b.f64);
-          break;
-        case GEU_OPTION:
-          t = (a.f64 >= b.f64) || isNaN(a.f64) || isNaN(b.f64);
-          break;
-        case NUM_OPTION:
-          t = !isNaN(a.f64) && !isNaN(b.f64);
-          break;
-        case NAN_OPTION:
-          t = isNaN(a.f64) || isNaN(b.f64);
-          break;
-        default:
-          assert(0);
-      }
-      break;
-    default:
-      assert(0);
-      break;
-  }
-
-  return t;
-}
-
-void setp_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t a, b;
-
-  int t = 0;
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  const operand_info &src2 = pI->src2();
-
-  assert(pI->get_num_operands() <
-         4);  // or need to deal with "c" operand / boolOp
-
-  unsigned type = pI->get_type();
-  unsigned cmpop = pI->get_cmpop();
-  a = thread->get_operand_value(src1, dst, type, thread, 1);
-  b = thread->get_operand_value(src2, dst, type, thread, 1);
-
-  t = CmpOp(type, a, b, cmpop);
-
-  ptx_reg_t data;
-
-  // the way ptxplus handles the zero flag, 1 = false and 0 = true
-  data.pred =
-      (t ==
-       0);  // inverting predicate since ptxplus uses "1" for a set zero flag
-
-  thread->set_operand_value(dst, data, PRED_TYPE, thread, pI);
-}
-
-void set_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t a, b;
-
-  int t = 0;
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  const operand_info &src2 = pI->src2();
-
-  assert(pI->get_num_operands() <
-         4);  // or need to deal with "c" operand / boolOp
-
-  unsigned src_type = pI->get_type2();
-  unsigned cmpop = pI->get_cmpop();
-
-  a = thread->get_operand_value(src1, dst, src_type, thread, 1);
-  b = thread->get_operand_value(src2, dst, src_type, thread, 1);
-
-  // Take abs of first operand if needed
-  if (pI->is_abs()) {
-    switch (src_type) {
-      case S16_TYPE:
-        a.s16 = my_abs(a.s16);
-        break;
-      case S32_TYPE:
-        a.s32 = my_abs(a.s32);
-        break;
-      case S64_TYPE:
-        a.s64 = my_abs(a.s64);
-        break;
-      case U16_TYPE:
-        a.u16 = a.u16;
-        break;
-      case U32_TYPE:
-        a.u32 = my_abs(a.u32);
-        break;
-      case U64_TYPE:
-        a.u64 = my_abs(a.u64);
-        break;
-      case F32_TYPE:
-        a.f32 = my_abs(a.f32);
-        break;
-      case F64_TYPE:
-      case FF64_TYPE:
-        a.f64 = my_abs(a.f64);
-        break;
+      case EQ_OPTION: t = (a.u16 == b.u16); break;
+      case NE_OPTION: t = (a.u16 != b.u16); break;
       default:
-        printf("Execution error: type mismatch with instruction\n");
-        assert(0);
-        break;
-    }
-  }
+         assert(0);
+      }
 
-  t = CmpOp(src_type, a, b, cmpop);
+   case B32_TYPE: 
+      switch (cmpop) {
+      case EQ_OPTION: t = (a.u32 == b.u32); break;
+      case NE_OPTION: t = (a.u32 != b.u32); break;
+      default:
+         assert(0);
+      }
+   case B64_TYPE:
+      switch (cmpop) {
+      case EQ_OPTION: t = (a.u64 == b.u64); break;
+      case NE_OPTION: t = (a.u64 != b.u64); break;
+      default:
+         assert(0);
+      }
+      break;
+   case S8_TYPE: 
+   case S16_TYPE:
+      switch (cmpop) {
+      case EQ_OPTION: t = (a.s16 == b.s16); break;
+      case NE_OPTION: t = (a.s16 != b.s16); break;
+      case LT_OPTION: t = (a.s16 < b.s16); break;
+      case LE_OPTION: t = (a.s16 <= b.s16); break;
+      case GT_OPTION: t = (a.s16 > b.s16); break;
+      case GE_OPTION: t = (a.s16 >= b.s16); break;
+      default:
+         assert(0);
+      }
+      break;
+   case S32_TYPE: 
+      switch (cmpop) {
+      case EQ_OPTION: t = (a.s32 == b.s32); break;
+      case NE_OPTION: t = (a.s32 != b.s32); break;
+      case LT_OPTION: t = (a.s32 < b.s32); break;
+      case LE_OPTION: t = (a.s32 <= b.s32); break;
+      case GT_OPTION: t = (a.s32 > b.s32); break;
+      case GE_OPTION: t = (a.s32 >= b.s32); break;
+      default:
+         assert(0);
+      }
+      break;
+   case S64_TYPE:
+      switch (cmpop) {
+      case EQ_OPTION: t = (a.s64 == b.s64); break;
+      case NE_OPTION: t = (a.s64 != b.s64); break;
+      case LT_OPTION: t = (a.s64 < b.s64); break;
+      case LE_OPTION: t = (a.s64 <= b.s64); break;
+      case GT_OPTION: t = (a.s64 > b.s64); break;
+      case GE_OPTION: t = (a.s64 >= b.s64); break;
+      default:
+         assert(0);
+      }
+      break;
+   case U8_TYPE: 
+   case U16_TYPE: 
+      switch (cmpop) {
+      case EQ_OPTION: t = (a.u16 == b.u16); break;
+      case NE_OPTION: t = (a.u16 != b.u16); break;
+      case LT_OPTION: t = (a.u16 < b.u16); break;
+      case LE_OPTION: t = (a.u16 <= b.u16); break;
+      case GT_OPTION: t = (a.u16 > b.u16); break;
+      case GE_OPTION: t = (a.u16 >= b.u16); break;
+      case LO_OPTION: t = (a.u16 < b.u16); break;
+      case LS_OPTION: t = (a.u16 <= b.u16); break;
+      case HI_OPTION: t = (a.u16 > b.u16); break;
+      case HS_OPTION: t = (a.u16 >= b.u16); break;
+      default:
+         assert(0);
+      }
+      break;
+   case U32_TYPE: 
+      switch (cmpop) {
+      case EQ_OPTION: t = (a.u32 == b.u32); break;
+      case NE_OPTION: t = (a.u32 != b.u32); break;
+      case LT_OPTION: t = (a.u32 < b.u32); break;
+      case LE_OPTION: t = (a.u32 <= b.u32); break;
+      case GT_OPTION: t = (a.u32 > b.u32); break;
+      case GE_OPTION: t = (a.u32 >= b.u32); break;
+      case LO_OPTION: t = (a.u32 < b.u32); break;
+      case LS_OPTION: t = (a.u32 <= b.u32); break;
+      case HI_OPTION: t = (a.u32 > b.u32); break;
+      case HS_OPTION: t = (a.u32 >= b.u32); break;
+      default:
+         assert(0);
+      }
+      break;
+   case U64_TYPE:
+      switch (cmpop) {
+      case EQ_OPTION: t = (a.u64 == b.u64); break;
+      case NE_OPTION: t = (a.u64 != b.u64); break;
+      case LT_OPTION: t = (a.u64 < b.u64); break;
+      case LE_OPTION: t = (a.u64 <= b.u64); break;
+      case GT_OPTION: t = (a.u64 > b.u64); break;
+      case GE_OPTION: t = (a.u64 >= b.u64); break;
+      case LO_OPTION: t = (a.u64 < b.u64); break;
+      case LS_OPTION: t = (a.u64 <= b.u64); break;
+      case HI_OPTION: t = (a.u64 > b.u64); break;
+      case HS_OPTION: t = (a.u64 >= b.u64); break;
+      default:
+         assert(0);
+      }
+      break;
+   case F16_TYPE: assert(0); break;
+   case F32_TYPE: 
+      switch (cmpop) {
+      case EQ_OPTION: t = (a.f32 == b.f32) && !isNaN(a.f32) && !isNaN(b.f32); break;
+      case NE_OPTION: t = (a.f32 != b.f32) && !isNaN(a.f32) && !isNaN(b.f32); break;
+      case LT_OPTION: t = (a.f32 < b.f32 ) && !isNaN(a.f32) && !isNaN(b.f32); break;
+      case LE_OPTION: t = (a.f32 <= b.f32) && !isNaN(a.f32) && !isNaN(b.f32); break;
+      case GT_OPTION: t = (a.f32 > b.f32 ) && !isNaN(a.f32) && !isNaN(b.f32); break;
+      case GE_OPTION: t = (a.f32 >= b.f32) && !isNaN(a.f32) && !isNaN(b.f32); break;
+      case EQU_OPTION: t = (a.f32 == b.f32) || isNaN(a.f32) || isNaN(b.f32); break;
+      case NEU_OPTION: t = (a.f32 != b.f32) || isNaN(a.f32) || isNaN(b.f32); break;
+      case LTU_OPTION: t = (a.f32 < b.f32 ) || isNaN(a.f32) || isNaN(b.f32); break;
+      case LEU_OPTION: t = (a.f32 <= b.f32) || isNaN(a.f32) || isNaN(b.f32); break;
+      case GTU_OPTION: t = (a.f32 > b.f32 ) || isNaN(a.f32) || isNaN(b.f32); break;
+      case GEU_OPTION: t = (a.f32 >= b.f32) || isNaN(a.f32) || isNaN(b.f32); break;
+      case NUM_OPTION: t = !isNaN(a.f32) && !isNaN(b.f32); break;
+      case NAN_OPTION: t = isNaN(a.f32) || isNaN(b.f32); break;
+      default:
+         assert(0);
+      }
+      break;
+   case F64_TYPE: 
+   case FF64_TYPE:
+      switch (cmpop) {
+      case EQ_OPTION: t = (a.f64 == b.f64) && !isNaN(a.f64) && !isNaN(b.f64); break;
+      case NE_OPTION: t = (a.f64 != b.f64) && !isNaN(a.f64) && !isNaN(b.f64); break;
+      case LT_OPTION: t = (a.f64 < b.f64 ) && !isNaN(a.f64) && !isNaN(b.f64); break;
+      case LE_OPTION: t = (a.f64 <= b.f64) && !isNaN(a.f64) && !isNaN(b.f64); break;
+      case GT_OPTION: t = (a.f64 > b.f64 ) && !isNaN(a.f64) && !isNaN(b.f64); break;
+      case GE_OPTION: t = (a.f64 >= b.f64) && !isNaN(a.f64) && !isNaN(b.f64); break;
+      case EQU_OPTION: t = (a.f64 == b.f64) || isNaN(a.f64) || isNaN(b.f64); break;
+      case NEU_OPTION: t = (a.f64 != b.f64) || isNaN(a.f64) || isNaN(b.f64); break;
+      case LTU_OPTION: t = (a.f64 < b.f64 ) || isNaN(a.f64) || isNaN(b.f64); break;
+      case LEU_OPTION: t = (a.f64 <= b.f64) || isNaN(a.f64) || isNaN(b.f64); break;
+      case GTU_OPTION: t = (a.f64 > b.f64 ) || isNaN(a.f64) || isNaN(b.f64); break;
+      case GEU_OPTION: t = (a.f64 >= b.f64) || isNaN(a.f64) || isNaN(b.f64); break;
+      case NUM_OPTION: t = !isNaN(a.f64) && !isNaN(b.f64); break;
+      case NAN_OPTION: t = isNaN(a.f64) || isNaN(b.f64); break;
+      default:
+         assert(0);
+      }
+      break;
+   default: assert(0); break;
+   }
 
-  ptx_reg_t data;
-  if (isFloat(pI->get_type())) {
-    data.f32 = (t != 0) ? 1.0f : 0.0f;
-  } else {
-    data.u32 = (t != 0) ? 0xFFFFFFFF : 0;
-  }
-
-  thread->set_operand_value(dst, data, pI->get_type(), thread, pI);
+   return t;
 }
 
-void shfl_impl(const ptx_instruction *pI, core_t *core, warp_inst_t inst) {
-  unsigned i_type = pI->get_type();
-  int tid;
+void setp_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+   ptx_reg_t a, b;
 
-  if (core->get_gpu()->is_functional_sim())
-    tid = inst.warp_id_func() * core->get_warp_size();
-  else
-    tid = inst.warp_id() * core->get_warp_size();
+   int t=0;
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
+   const operand_info &src2 = pI->src2();
 
-  ptx_thread_info *thread = core->get_thread_info()[tid];
-  ptx_warp_info *warp_info = thread->m_warp_info;
-  int lane = warp_info->get_done_threads();
-  thread = core->get_thread_info()[tid + lane];
+   assert( pI->get_num_operands() < 4 ); // or need to deal with "c" operand / boolOp
 
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  const operand_info &src2 = pI->src2();
-  const operand_info &src3 = pI->src3();
-  int bval = (thread->get_operand_value(src2, dst, i_type, thread, 1)).u32;
-  int cval = (thread->get_operand_value(src3, dst, i_type, thread, 1)).u32;
-  int mask = cval >> 8;
-  bval &= 0x1F;
-  cval &= 0x1F;
+   unsigned type = pI->get_type();
+   unsigned cmpop = pI->get_cmpop();
+   a = thread->get_operand_value(src1, dst, type, thread, 1);
+   b = thread->get_operand_value(src2, dst, type, thread, 1);
 
-  int maxLane = (lane & mask) | (cval & ~mask);
-  int minLane = lane & mask;
+   t = CmpOp(type,a,b,cmpop);
 
-  int src_idx;
-  unsigned p;
-  switch (pI->shfl_op()) {
-    case UP_OPTION:
-      src_idx = lane - bval;
-      p = (src_idx >= maxLane);
-      break;
-    case DOWN_OPTION:
-      src_idx = lane + bval;
-      p = (src_idx <= maxLane);
-      break;
-    case BFLY_OPTION:
-      src_idx = lane ^ bval;
-      p = (src_idx <= maxLane);
-      break;
-    case IDX_OPTION:
-      src_idx = minLane | (bval & ~mask);
-      p = (src_idx <= maxLane);
-      break;
-    default:
-      printf("GPGPU-Sim PTX: ERROR: Invalid shfl option\n");
-      assert(0);
-      break;
-  }
-  // copy from own lane
-  if (!p) src_idx = lane;
+   ptx_reg_t data;
 
-  // copy input from lane src_idx
-  ptx_reg_t data;
-  if (inst.active(src_idx)) {
-    ptx_thread_info *source = core->get_thread_info()[tid + src_idx];
-    data = source->get_operand_value(src1, dst, i_type, source, 1);
-  } else {
-    printf(
-        "GPGPU-Sim PTX: WARNING: shfl input value unpredictable for inactive "
-        "threads in a warp\n");
-    data.u32 = 0;
-  }
-  thread->set_operand_value(dst, data, i_type, thread, pI);
+   //the way ptxplus handles the zero flag, 1 = false and 0 = true
+   data.pred = (t==0); //inverting predicate since ptxplus uses "1" for a set zero flag
 
-  /*
-  TODO: deal with predicates appropriately using the following pseudocode:
-  if (!isGuardPredicateTrue(src_idx)) {
-          printf("GPGPU-Sim PTX: WARNING: shfl input value unpredictable for
-  predicated-off threads in a warp\n");
-  }
-  if (dest predicate selected) data.pred = p;
-  */
-
-  // keep track of the number of threads that have executed in the warp
-  warp_info->inc_done_threads();
-  if (warp_info->get_done_threads() == inst.active_count()) {
-    warp_info->reset_done_threads();
-  }
+   thread->set_operand_value(dst,data, PRED_TYPE, thread, pI);
 }
 
-void shl_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t a, b, d;
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  const operand_info &src2 = pI->src2();
+void set_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   ptx_reg_t a, b;
 
-  unsigned i_type = pI->get_type();
-  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-  b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+   int t=0;
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
+   const operand_info &src2 = pI->src2();
 
-  switch (i_type) {
-    case B16_TYPE:
-    case U16_TYPE:
-      if (b.u16 >= 16)
-        d.u16 = 0;
+   assert( pI->get_num_operands() < 4 ); // or need to deal with "c" operand / boolOp
+
+   unsigned src_type = pI->get_type2();
+   unsigned cmpop = pI->get_cmpop();
+
+   a = thread->get_operand_value(src1, dst, src_type, thread, 1);
+   b = thread->get_operand_value(src2, dst, src_type, thread, 1);
+
+   // Take abs of first operand if needed
+   if(pI->is_abs()) {
+      switch ( src_type ) {
+      case S16_TYPE: a.s16 = my_abs(a.s16); break;
+      case S32_TYPE: a.s32 = my_abs(a.s32); break;
+      case S64_TYPE: a.s64 = my_abs(a.s64); break;
+      case U16_TYPE: a.u16 = a.u16; break;
+      case U32_TYPE: a.u32 = my_abs(a.u32); break;
+      case U64_TYPE: a.u64 = my_abs(a.u64); break;
+      case F32_TYPE: a.f32 = my_abs(a.f32); break;
+      case F64_TYPE: case FF64_TYPE: a.f64 = my_abs(a.f64); break;
+      default:
+         printf("Execution error: type mismatch with instruction\n");
+         assert(0);
+         break;
+      }
+   }
+
+   t = CmpOp(src_type,a,b,cmpop);
+
+   ptx_reg_t data;
+   if ( isFloat(pI->get_type()) ) {
+      data.f32 = (t!=0)?1.0f:0.0f;
+   } else {
+      data.u32 = (t!=0)?0xFFFFFFFF:0;
+   }
+
+   thread->set_operand_value(dst, data, pI->get_type(), thread, pI);
+
+}
+
+void shfl_impl( const ptx_instruction *pI, core_t *core, warp_inst_t inst )
+{
+	unsigned i_type = pI->get_type();
+  	int tid;
+
+  	if(core->get_gpu()->is_functional_sim())
+    		tid = inst.warp_id_func() * core->get_warp_size();
+  	else
+	 	tid = inst.warp_id() * core->get_warp_size();
+	
+	ptx_thread_info *thread = core->get_thread_info()[tid];
+	ptx_warp_info *warp_info = thread->m_warp_info;
+	int lane = warp_info->get_done_threads();
+	thread = core->get_thread_info()[tid + lane];
+
+	const operand_info &dst = pI->dst();
+	const operand_info &src1 = pI->src1();
+	const operand_info &src2 = pI->src2();
+	const operand_info &src3 = pI->src3();
+	int bval = (thread->get_operand_value(src2, dst, i_type, thread, 1)).u32;
+	int cval = (thread->get_operand_value(src3, dst, i_type, thread, 1)).u32;
+	int mask = cval >> 8;
+	bval &= 0x1F;
+	cval &= 0x1F;
+
+	int maxLane = (lane & mask) | (cval & ~mask);
+	int minLane = lane & mask;
+
+	int src_idx;
+	unsigned p;
+	switch(pI->shfl_op()) {
+	case UP_OPTION:
+		src_idx = lane - bval;
+		p = (src_idx >= maxLane);
+		break;
+	case DOWN_OPTION:
+		src_idx = lane + bval;
+		p = (src_idx <= maxLane);
+		break;
+	case BFLY_OPTION:
+		src_idx = lane ^ bval;
+		p = (src_idx <= maxLane);
+		break;
+	case IDX_OPTION:
+		src_idx = minLane | (bval & ~mask);
+		p = (src_idx <= maxLane);
+		break;
+	default:
+		printf("GPGPU-Sim PTX: ERROR: Invalid shfl option\n");
+		assert(0);
+		break;
+	}
+	// copy from own lane
+	if (!p) src_idx = lane;
+
+	// copy input from lane src_idx
+	ptx_reg_t data;
+	if (inst.active(src_idx)) {
+		ptx_thread_info *source = core->get_thread_info()[tid + src_idx];
+		data = source->get_operand_value(src1, dst, i_type, source, 1);
+	} else {
+		printf("GPGPU-Sim PTX: WARNING: shfl input value unpredictable for inactive threads in a warp\n");
+		data.u32 = 0;
+	}
+	thread->set_operand_value(dst, data, i_type, thread, pI);
+
+	/*
+	TODO: deal with predicates appropriately using the following pseudocode:
+	if (!isGuardPredicateTrue(src_idx)) {
+		printf("GPGPU-Sim PTX: WARNING: shfl input value unpredictable for predicated-off threads in a warp\n");
+	}
+	if (dest predicate selected) data.pred = p;
+	*/
+
+	// keep track of the number of threads that have executed in the warp
+	warp_info->inc_done_threads();
+	if (warp_info->get_done_threads() == inst.active_count()) {
+		warp_info->reset_done_threads();
+	}
+}
+
+void shl_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+   ptx_reg_t a, b, d;
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
+   const operand_info &src2 = pI->src2();
+
+   unsigned i_type = pI->get_type();
+   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+
+   switch ( i_type ) {
+   case B16_TYPE:
+   case U16_TYPE:
+      if ( b.u16 >= 16 )
+         d.u16 = 0;
       else
-        d.u16 = (unsigned short)((a.u16 << b.u16) & 0xFFFF);
+         d.u16 = (unsigned short) ((a.u16 << b.u16) & 0xFFFF); 
       break;
-    case B32_TYPE:
-    case U32_TYPE:
-      if (b.u32 >= 32)
-        d.u32 = 0;
+   case B32_TYPE: 
+   case U32_TYPE: 
+      if ( b.u32 >= 32 )
+         d.u32 = 0;
       else
-        d.u32 = (unsigned)((a.u32 << b.u32) & 0xFFFFFFFF);
+         d.u32 = (unsigned) ((a.u32 << b.u32) & 0xFFFFFFFF); 
       break;
-    case B64_TYPE:
-    case U64_TYPE:
-      if (b.u32 >= 64)
-        d.u64 = 0;
+   case B64_TYPE: 
+   case U64_TYPE: 
+      if ( b.u32 >= 64 )
+         d.u64 = 0;
       else
-        d.u64 = (a.u64 << b.u64);
+         d.u64 = (a.u64 << b.u64); 
       break;
-    default:
+   default:
       printf("Execution error: type mismatch with instruction\n");
-      assert(0);
+      assert(0); 
       break;
-  }
+   }
 
-  thread->set_operand_value(dst, d, i_type, thread, pI);
+   thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-void shr_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t a, b, d;
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  const operand_info &src2 = pI->src2();
+void shr_impl( const ptx_instruction *pI, ptx_thread_info *thread )
+{
+   ptx_reg_t a, b, d;
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
+   const operand_info &src2 = pI->src2();
 
-  unsigned i_type = pI->get_type();
-  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-  b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+   unsigned i_type = pI->get_type();
+   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   b = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-  switch (i_type) {
-    case U16_TYPE:
-    case B16_TYPE:
-      if (b.u16 < 16)
-        d.u16 = (unsigned short)((a.u16 >> b.u16) & 0xFFFF);
+
+   switch ( i_type ) {
+   case U16_TYPE:
+   case B16_TYPE: 
+      if ( b.u16 < 16 )
+         d.u16 = (unsigned short) ((a.u16 >> b.u16) & 0xFFFF);
       else
-        d.u16 = 0;
+         d.u16 = 0;
       break;
-    case U32_TYPE:
-    case B32_TYPE:
-      if (b.u32 < 32)
-        d.u32 = (unsigned)((a.u32 >> b.u32) & 0xFFFFFFFF);
+   case U32_TYPE:
+   case B32_TYPE: 
+      if ( b.u32 < 32 )
+         d.u32 = (unsigned) ((a.u32 >> b.u32) & 0xFFFFFFFF);
       else
-        d.u32 = 0;
+         d.u32 = 0;
       break;
-    case U64_TYPE:
-    case B64_TYPE:
-      if (b.u32 < 64)
-        d.u64 = (a.u64 >> b.u64);
+   case U64_TYPE:
+   case B64_TYPE: 
+      if ( b.u32 < 64 )
+         d.u64 = (a.u64 >> b.u64);
       else
-        d.u64 = 0;
+         d.u64 = 0;
       break;
-    case S16_TYPE:
-      if (b.u16 < 16)
-        d.s64 = (a.s16 >> b.s16);
+   case S16_TYPE: 
+      if ( b.u16 < 16 )
+         d.s64 = (a.s16 >> b.s16);
       else {
-        if (a.s16 < 0) {
-          d.s64 = -1;
-        } else {
-          d.s64 = 0;
-        }
-      }
-      break;
-    case S32_TYPE:
-      if (b.u32 < 32)
-        d.s64 = (a.s32 >> b.s32);
-      else {
-        if (a.s32 < 0) {
-          d.s64 = -1;
-        } else {
-          d.s64 = 0;
-        }
-      }
-      break;
-    case S64_TYPE:
-      if (b.u64 < 64)
-        d.s64 = (a.s64 >> b.u64);
-      else {
-        if (a.s64 < 0) {
-          if (b.s32 < 0) {
-            d.u64 = -1;
-            d.s32 = 0;
-          } else {
+         if ( a.s16 < 0 ) {
             d.s64 = -1;
-          }
-        } else {
-          d.s64 = 0;
-        }
+         } else {
+            d.s64 = 0;
+         }
       }
       break;
-    default:
-      printf("Execution error: type mismatch with instruction\n");
-      assert(0);
+   case S32_TYPE: 
+      if ( b.u32 < 32 )
+         d.s64 = (a.s32 >> b.s32);
+      else {
+         if ( a.s32 < 0 ) {
+            d.s64 = -1;
+         } else {
+            d.s64 = 0;
+         }
+      }
       break;
-  }
+   case S64_TYPE: 
+      if ( b.u64 < 64 )
+         d.s64 = (a.s64 >> b.u64);
+      else {
+         if ( a.s64 < 0 ) {
+            if ( b.s32 < 0 ) {
+               d.u64 = -1;
+               d.s32 = 0;
+            } else {
+               d.s64 = -1;
+            }
+         } else {
+            d.s64 = 0;
+         }
+      }
+      break;
+   default:
+      printf("Execution error: type mismatch with instruction\n");
+      assert(0); 
+      break;
+   }
 
-  thread->set_operand_value(dst, d, i_type, thread, pI);
+   thread->set_operand_value(dst,d, i_type, thread, pI);
 }
 
-void sin_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t a, d;
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
+void sin_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+   ptx_reg_t a, d;
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
 
-  unsigned i_type = pI->get_type();
-  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   unsigned i_type = pI->get_type();
+   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
 
-  switch (i_type) {
-    case F32_TYPE:
+
+   switch ( i_type ) {
+   case F32_TYPE: 
       d.f32 = sin(a.f32);
       break;
-    default:
+   default:
+      printf("Execution error: type mismatch with instruction\n");
+      assert(0); 
+      break;
+   }
+
+   thread->set_operand_value(dst,d, i_type, thread, pI);
+}
+
+void slct_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
+   const operand_info &src2 = pI->src2();
+   const operand_info &src3 = pI->src3();
+
+   ptx_reg_t a, b, c, d;
+
+   unsigned i_type = pI->get_type();
+   unsigned c_type = pI->get_type2();
+   bool t = false;
+   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+   c = thread->get_operand_value(src3, dst, c_type, thread, 1);
+
+   switch ( c_type ) {
+   case S32_TYPE: t = c.s32 >= 0; break;
+   case F32_TYPE: t = c.f32 >= 0; break;
+   default: assert(0);
+   }
+
+   switch ( i_type ) {
+   case B16_TYPE:
+   case S16_TYPE:
+   case U16_TYPE: d.u16 = t?a.u16:b.u16; break;
+   case F32_TYPE:
+   case B32_TYPE:
+   case S32_TYPE:
+   case U32_TYPE: d.u32 = t?a.u32:b.u32; break;
+   case F64_TYPE:
+   case FF64_TYPE:
+   case B64_TYPE:
+   case S64_TYPE:
+   case U64_TYPE: d.u64 = t?a.u64:b.u64; break;
+   default: assert(0);
+   }
+
+   thread->set_operand_value(dst,d, i_type, thread, pI);
+}
+
+void sqrt_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   ptx_reg_t a, d;
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
+
+   unsigned i_type = pI->get_type();
+   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+
+
+   switch ( i_type ) {
+   case F32_TYPE: 
+      if ( a.f32 < 0 )
+         d.f32 = nanf("");
+      else
+         d.f32 = sqrt(a.f32); break;
+   case F64_TYPE: 
+   case FF64_TYPE:
+      if ( a.f64 < 0 )
+         d.f64 = nan("");
+      else
+         d.f64 = sqrt(a.f64); break;
+   default:
       printf("Execution error: type mismatch with instruction\n");
       assert(0);
       break;
-  }
+   }
 
-  thread->set_operand_value(dst, d, i_type, thread, pI);
+   thread->set_operand_value(dst,d, i_type, thread, pI);
 }
 
-void slct_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  const operand_info &src2 = pI->src2();
-  const operand_info &src3 = pI->src3();
+void sst_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+	ptx_instruction * cpI = const_cast<ptx_instruction *>(pI); // constant
+	const operand_info &dst = cpI->dst();
+	const operand_info &src1 = pI->src1();
+	const operand_info &src2 = pI->src2();
+	const operand_info &src3 = pI->src3();
+	unsigned type = pI->get_type();
+	ptx_reg_t dst_data = thread->get_operand_value(dst, dst, type, thread, 1);
+	ptx_reg_t src1_data = thread->get_operand_value(src1, src1, type, thread, 1);
+	ptx_reg_t src2_data = thread->get_operand_value(src2, src1, type, thread, 1);
+	ptx_reg_t src3_data = thread->get_operand_value(src3, src1, type, thread, 1);
+	memory_space_t space = pI->get_space();
+	memory_space *mem = NULL;
+	addr_t addr = src2_data.u32 * 4; // this assumes sstarr memory starts at address 0
+	ptx_cta_info *cta_info = thread->m_cta_info;
 
-  ptx_reg_t a, b, c, d;
+	decode_space(space,thread,src1,mem,addr);
 
-  unsigned i_type = pI->get_type();
-  unsigned c_type = pI->get_type2();
-  bool t = false;
-  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-  b = thread->get_operand_value(src2, dst, i_type, thread, 1);
-  c = thread->get_operand_value(src3, dst, c_type, thread, 1);
+	size_t size;
+	int t;
+	type_info_key::type_decode(type,size,t);
 
-  switch (c_type) {
-    case S32_TYPE:
-      t = c.s32 >= 0;
-      break;
-    case F32_TYPE:
-      t = c.f32 >= 0;
-      break;
-    default:
-      assert(0);
-  }
+	// store data in sstarr memory
+	mem->write(addr,size/8,&src3_data.s64,thread,pI);
 
-  switch (i_type) {
-    case B16_TYPE:
-    case S16_TYPE:
-    case U16_TYPE:
-      d.u16 = t ? a.u16 : b.u16;
-      break;
-    case F32_TYPE:
-    case B32_TYPE:
-    case S32_TYPE:
-    case U32_TYPE:
-      d.u32 = t ? a.u32 : b.u32;
-      break;
-    case F64_TYPE:
-    case FF64_TYPE:
-    case B64_TYPE:
-    case S64_TYPE:
-    case U64_TYPE:
-      d.u64 = t ? a.u64 : b.u64;
-      break;
-    default:
-      assert(0);
-  }
+	// sync threads
+	cpI->set_bar_id(16); // use 16 for sst because bar uses an int from 0-15
 
-  thread->set_operand_value(dst, d, i_type, thread, pI);
+	thread->m_last_effective_address = addr;
+	thread->m_last_memory_space = space;
+	thread->m_last_dram_callback.function = bar_callback;
+	thread->m_last_dram_callback.instruction = cpI;
+
+	// the last thread that executes loads all of the data back from sstarr memory
+	int NUM_THREADS = cta_info->num_threads();
+	cta_info->inc_bar_threads();
+	if (NUM_THREADS == cta_info->get_bar_threads()) {
+		unsigned offset = 0;
+		addr = 0;
+		ptx_reg_t data;
+		float sstarr_fdata[NUM_THREADS];
+		signed long long sstarr_ldata[NUM_THREADS];
+		// loop through all of the threads
+		for (int tid = 0; tid < NUM_THREADS; tid++) {
+			data.u64=0;
+			mem->read(addr+(tid*4),size/8,&data.s64);
+			sstarr_fdata[tid] = data.f32;
+			sstarr_ldata[tid] = data.s64;
+		}
+
+		// squeeze the zeros out of the array and store data back into original array
+		mem = NULL;
+		addr = src1_data.u32;
+		space.set_type(global_space);
+		decode_space(space,thread,src1,mem,addr);
+		// store nonzero entries and indices
+		for (int tid = 0; tid < NUM_THREADS; tid++) {
+			if (sstarr_fdata[tid] != 0) {
+				float ftid = (float)tid;
+				mem->write(addr+(offset*4),size/8,&sstarr_ldata[tid],thread,pI);
+				mem->write(addr+((NUM_THREADS+offset)*4),size/8,&ftid,thread,pI);
+				offset++;
+			}
+		}
+		// store the number of nonzero elements in the array
+		data = thread->get_operand_value(src1, dst, type, thread, 1);
+		data.s64 += 4*(offset-1);
+		thread->set_operand_value(dst, data, type, thread, pI);
+
+		// fill the rest of the array with zeros (dst should always have a 0 in it)
+		while (offset < NUM_THREADS) {
+			mem->write(addr+(offset*4),size/8,&dst_data.s64,thread,pI);
+			offset++;
+		}
+
+		cta_info->reset_bar_threads();
+		thread->m_last_effective_address = addr+(NUM_THREADS-1)*4;
+		thread->m_last_memory_space = space;
+	}
 }
 
-void sqrt_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t a, d;
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-
-  unsigned i_type = pI->get_type();
-  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-
-  switch (i_type) {
-    case F32_TYPE:
-      if (a.f32 < 0)
-        d.f32 = nanf("");
-      else
-        d.f32 = sqrt(a.f32);
-      break;
-    case F64_TYPE:
-    case FF64_TYPE:
-      if (a.f64 < 0)
-        d.f64 = nan("");
-      else
-        d.f64 = sqrt(a.f64);
-      break;
-    default:
-      printf("Execution error: type mismatch with instruction\n");
-      assert(0);
-      break;
-  }
-
-  thread->set_operand_value(dst, d, i_type, thread, pI);
+void ssy_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+   //printf("Execution Warning: unimplemented ssy instruction is treated as a nop\n");
+   // TODO: add implementation
 }
 
-void sst_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_instruction *cpI = const_cast<ptx_instruction *>(pI);  // constant
-  const operand_info &dst = cpI->dst();
-  const operand_info &src1 = pI->src1();
-  const operand_info &src2 = pI->src2();
-  const operand_info &src3 = pI->src3();
-  unsigned type = pI->get_type();
-  ptx_reg_t dst_data = thread->get_operand_value(dst, dst, type, thread, 1);
-  ptx_reg_t src1_data = thread->get_operand_value(src1, src1, type, thread, 1);
-  ptx_reg_t src2_data = thread->get_operand_value(src2, src1, type, thread, 1);
-  ptx_reg_t src3_data = thread->get_operand_value(src3, src1, type, thread, 1);
-  memory_space_t space = pI->get_space();
-  memory_space *mem = NULL;
-  addr_t addr =
-      src2_data.u32 * 4;  // this assumes sstarr memory starts at address 0
-  ptx_cta_info *cta_info = thread->m_cta_info;
+void st_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+   const operand_info &dst = pI->dst();
+   const operand_info &src1 = pI->src1(); //may be scalar or vector of regs
+   unsigned type = pI->get_type();
+   ptx_reg_t addr_reg = thread->get_operand_value(dst, dst, type, thread, 1);
+   ptx_reg_t data;
+   memory_space_t space = pI->get_space();
+   unsigned vector_spec = pI->get_vector();
 
-  decode_space(space, thread, src1, mem, addr);
+   memory_space *mem = NULL;
+   addr_t addr = addr_reg.u32;
 
-  size_t size;
-  int t;
-  type_info_key::type_decode(type, size, t);
+   decode_space(space,thread,dst,mem,addr);
 
-  // store data in sstarr memory
-  mem->write(addr, size / 8, &src3_data.s64, thread, pI);
+   size_t size;
+   int t;
+   type_info_key::type_decode(type,size,t);
 
-  // sync threads
-  cpI->set_bar_id(16);  // use 16 for sst because bar uses an int from 0-15
-
-  thread->m_last_effective_address = addr;
-  thread->m_last_memory_space = space;
-  thread->m_last_dram_callback.function = bar_callback;
-  thread->m_last_dram_callback.instruction = cpI;
-
-  // the last thread that executes loads all of the data back from sstarr memory
-  int NUM_THREADS = cta_info->num_threads();
-  cta_info->inc_bar_threads();
-  if (NUM_THREADS == cta_info->get_bar_threads()) {
-    unsigned offset = 0;
-    addr = 0;
-    ptx_reg_t data;
-    float sstarr_fdata[NUM_THREADS];
-    signed long long sstarr_ldata[NUM_THREADS];
-    // loop through all of the threads
-    for (int tid = 0; tid < NUM_THREADS; tid++) {
-      data.u64 = 0;
-      mem->read(addr + (tid * 4), size / 8, &data.s64);
-      sstarr_fdata[tid] = data.f32;
-      sstarr_ldata[tid] = data.s64;
-    }
-
-    // squeeze the zeros out of the array and store data back into original
-    // array
-    mem = NULL;
-    addr = src1_data.u32;
-    space.set_type(global_space);
-    decode_space(space, thread, src1, mem, addr);
-    // store nonzero entries and indices
-    for (int tid = 0; tid < NUM_THREADS; tid++) {
-      if (sstarr_fdata[tid] != 0) {
-        float ftid = (float)tid;
-        mem->write(addr + (offset * 4), size / 8, &sstarr_ldata[tid], thread,
-                   pI);
-        mem->write(addr + ((NUM_THREADS + offset) * 4), size / 8, &ftid, thread,
-                   pI);
-        offset++;
+   if (!vector_spec) {
+      data = thread->get_operand_value(src1, dst, type, thread, 1);
+      mem->write(addr,size/8,&data.s64,thread,pI);
+    } else {
+      if (vector_spec == V2_TYPE) {
+         ptx_reg_t* ptx_regs = new ptx_reg_t[2]; 
+         thread->get_vector_operand_values(src1, ptx_regs, 2); 
+         mem->write(addr,size/8,&ptx_regs[0].s64,thread,pI);
+         mem->write(addr+size/8,size/8,&ptx_regs[1].s64,thread,pI);
+         delete [] ptx_regs;
       }
-    }
-    // store the number of nonzero elements in the array
-    data = thread->get_operand_value(src1, dst, type, thread, 1);
-    data.s64 += 4 * (offset - 1);
-    thread->set_operand_value(dst, data, type, thread, pI);
-
-    // fill the rest of the array with zeros (dst should always have a 0 in it)
-    while (offset < NUM_THREADS) {
-      mem->write(addr + (offset * 4), size / 8, &dst_data.s64, thread, pI);
-      offset++;
-    }
-
-    cta_info->reset_bar_threads();
-    thread->m_last_effective_address = addr + (NUM_THREADS - 1) * 4;
-    thread->m_last_memory_space = space;
-  }
+      if (vector_spec == V3_TYPE) {
+         ptx_reg_t* ptx_regs = new ptx_reg_t[3]; 
+         thread->get_vector_operand_values(src1, ptx_regs, 3); 
+         mem->write(addr,size/8,&ptx_regs[0].s64,thread,pI);
+         mem->write(addr+size/8,size/8,&ptx_regs[1].s64,thread,pI);
+         mem->write(addr+2*size/8,size/8,&ptx_regs[2].s64,thread,pI);
+         delete [] ptx_regs;
+      }
+      if (vector_spec == V4_TYPE) {
+         ptx_reg_t* ptx_regs = new ptx_reg_t[4]; 
+         thread->get_vector_operand_values(src1, ptx_regs, 4); 
+         mem->write(addr,size/8,&ptx_regs[0].s64,thread,pI);
+         mem->write(addr+size/8,size/8,&ptx_regs[1].s64,thread,pI);
+         mem->write(addr+2*size/8,size/8,&ptx_regs[2].s64,thread,pI);
+         mem->write(addr+3*size/8,size/8,&ptx_regs[3].s64,thread,pI);
+         delete [] ptx_regs;
+      }
+   }
+   thread->m_last_effective_address = addr;
+   thread->m_last_memory_space = space; 
 }
 
-void ssy_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  // printf("Execution Warning: unimplemented ssy instruction is treated as a
-  // nop\n");
-  // TODO: add implementation
-}
+void sub_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+   ptx_reg_t data;
+   int overflow = 0;
+   int carry = 0;
 
-void st_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();  // may be scalar or vector of regs
-  unsigned type = pI->get_type();
-  ptx_reg_t addr_reg = thread->get_operand_value(dst, dst, type, thread, 1);
-  ptx_reg_t data;
-  memory_space_t space = pI->get_space();
-  unsigned vector_spec = pI->get_vector();
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
+   const operand_info &src2 = pI->src2();
 
-  memory_space *mem = NULL;
-  addr_t addr = addr_reg.u32;
+   unsigned i_type = pI->get_type();
+   ptx_reg_t src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   ptx_reg_t src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-  decode_space(space, thread, dst, mem, addr);
-
-  size_t size;
-  int t;
-  type_info_key::type_decode(type, size, t);
-
-  if (!vector_spec) {
-    data = thread->get_operand_value(src1, dst, type, thread, 1);
-    mem->write(addr, size / 8, &data.s64, thread, pI);
-  } else {
-    if (vector_spec == V2_TYPE) {
-      ptx_reg_t *ptx_regs = new ptx_reg_t[2];
-      thread->get_vector_operand_values(src1, ptx_regs, 2);
-      mem->write(addr, size / 8, &ptx_regs[0].s64, thread, pI);
-      mem->write(addr + size / 8, size / 8, &ptx_regs[1].s64, thread, pI);
-      delete[] ptx_regs;
-    }
-    if (vector_spec == V3_TYPE) {
-      ptx_reg_t *ptx_regs = new ptx_reg_t[3];
-      thread->get_vector_operand_values(src1, ptx_regs, 3);
-      mem->write(addr, size / 8, &ptx_regs[0].s64, thread, pI);
-      mem->write(addr + size / 8, size / 8, &ptx_regs[1].s64, thread, pI);
-      mem->write(addr + 2 * size / 8, size / 8, &ptx_regs[2].s64, thread, pI);
-      delete[] ptx_regs;
-    }
-    if (vector_spec == V4_TYPE) {
-      ptx_reg_t *ptx_regs = new ptx_reg_t[4];
-      thread->get_vector_operand_values(src1, ptx_regs, 4);
-      mem->write(addr, size / 8, &ptx_regs[0].s64, thread, pI);
-      mem->write(addr + size / 8, size / 8, &ptx_regs[1].s64, thread, pI);
-      mem->write(addr + 2 * size / 8, size / 8, &ptx_regs[2].s64, thread, pI);
-      mem->write(addr + 3 * size / 8, size / 8, &ptx_regs[3].s64, thread, pI);
-      delete[] ptx_regs;
-    }
-  }
-  thread->m_last_effective_address = addr;
-  thread->m_last_memory_space = space;
-}
-
-void sub_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t data;
-  int overflow = 0;
-  int carry = 0;
-
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  const operand_info &src2 = pI->src2();
-
-  unsigned i_type = pI->get_type();
-  ptx_reg_t src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-  ptx_reg_t src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
-
-  // performs addition. Sets carry and overflow if needed.
-  // the constant is added in during subtraction so the carry bit is set
-  // properly.
-  switch (i_type) {
-    case S8_TYPE:
+   //performs addition. Sets carry and overflow if needed.
+   //the constant is added in during subtraction so the carry bit is set properly.
+   switch ( i_type ) {
+   case S8_TYPE:
       data.s64 = (src1_data.s64 & 0xFF) - (src2_data.s64 & 0xFF) + 0x100;
-      if (((src1_data.s64 & 0x80) - (src2_data.s64 & 0x80)) != 0) {
-        overflow = ((src1_data.s64 & 0x80) - (data.s64 & 0x80)) == 0 ? 0 : 1;
-      }
-      carry = (data.s32 & 0x100) >> 8;
+      if(((src1_data.s64 & 0x80)-(src2_data.s64 & 0x80)) != 0) {overflow=((src1_data.s64 & 0x80)-(data.s64 & 0x80))==0?0:1; }
+      carry = (data.s32 & 0x100)>>8;
       break;
-    case S16_TYPE:
+   case S16_TYPE:
       data.s64 = (src1_data.s64 & 0xFFFF) - (src2_data.s64 & 0xFFFF) + 0x10000;
-      if (((src1_data.s64 & 0x8000) - (src2_data.s64 & 0x8000)) != 0) {
-        overflow =
-            ((src1_data.s64 & 0x8000) - (data.s64 & 0x8000)) == 0 ? 0 : 1;
-      }
-      carry = (data.s32 & 0x10000) >> 16;
+      if(((src1_data.s64 & 0x8000)-(src2_data.s64 & 0x8000)) != 0) {overflow=((src1_data.s64 & 0x8000)-(data.s64 & 0x8000))==0?0:1; }
+      carry = (data.s32 & 0x10000)>>16;
       break;
-    case S32_TYPE:
-      data.s64 = (src1_data.s64 & 0xFFFFFFFF) - (src2_data.s64 & 0xFFFFFFFF) +
-                 0x100000000;
-      if (((src1_data.s64 & 0x80000000) - (src2_data.s64 & 0x80000000)) != 0) {
-        overflow = ((src1_data.s64 & 0x80000000) - (data.s64 & 0x80000000)) == 0
-                       ? 0
-                       : 1;
-      }
-      carry = ((data.u64) >> 32) & 0x0001;
+   case S32_TYPE:
+      data.s64 = (src1_data.s64 & 0xFFFFFFFF) - (src2_data.s64 & 0xFFFFFFFF) + 0x100000000;
+      if(((src1_data.s64 & 0x80000000)-(src2_data.s64 & 0x80000000)) != 0) {overflow=((src1_data.s64 & 0x80000000)-(data.s64 & 0x80000000))==0?0:1; }
+      carry = ((data.u64)>>32) & 0x0001;
       break;
-    case S64_TYPE:
-      data.s64 = src1_data.s64 - src2_data.s64;
-      break;
-    case B8_TYPE:
-    case U8_TYPE:
+   case S64_TYPE: 
+      data.s64 = src1_data.s64 - src2_data.s64; break;
+   case B8_TYPE:
+   case U8_TYPE:
       data.u64 = (src1_data.u64 & 0xFF) - (src2_data.u64 & 0xFF) + 0x100;
-      carry = (data.u64 & 0x100) >> 8;
+      carry = (data.u64 & 0x100)>>8;
       break;
-    case B16_TYPE:
-    case U16_TYPE:
+   case B16_TYPE:
+   case U16_TYPE:
       data.u64 = (src1_data.u64 & 0xFFFF) - (src2_data.u64 & 0xFFFF) + 0x10000;
-      carry = (data.u64 & 0x10000) >> 16;
+      carry = (data.u64 & 0x10000)>>16;
       break;
-    case B32_TYPE:
-    case U32_TYPE:
-      data.u64 = (src1_data.u64 & 0xFFFFFFFF) - (src2_data.u64 & 0xFFFFFFFF) +
-                 0x100000000;
-      carry = (data.u64 & 0x100000000) >> 32;
+   case B32_TYPE:
+   case U32_TYPE:
+      data.u64 = (src1_data.u64 & 0xFFFFFFFF) - (src2_data.u64 & 0xFFFFFFFF) + 0x100000000;
+      carry = (data.u64 & 0x100000000)>>32;
       break;
-    case B64_TYPE:
-    case U64_TYPE:
-      data.u64 = src1_data.u64 - src2_data.u64;
-      break;
-    case F16_TYPE:
-      data.f16 = src1_data.f16 - src2_data.f16;
-      break;  // assert(0); break;
-    case F32_TYPE:
-      data.f32 = src1_data.f32 - src2_data.f32;
-      break;
-    case F64_TYPE:
-    case FF64_TYPE:
-      data.f64 = src1_data.f64 - src2_data.f64;
-      break;
-    default:
-      assert(0);
-      break;
-  }
+   case B64_TYPE:
+   case U64_TYPE: 
+      data.u64 = src1_data.u64 - src2_data.u64; break;
+   case F16_TYPE: data.f16 = src1_data.f16 - src2_data.f16; break;//assert(0); break;
+   case F32_TYPE: data.f32 = src1_data.f32 - src2_data.f32; break;
+   case F64_TYPE: case FF64_TYPE: data.f64 = src1_data.f64 - src2_data.f64; break;
+   default: assert(0); break;
+   }
 
-  thread->set_operand_value(dst, data, i_type, thread, pI, overflow, carry);
+   thread->set_operand_value(dst,data, i_type, thread, pI, overflow, carry);
 }
 
-void nop_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  // Do nothing
+void nop_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+   // Do nothing
 }
 
-void subc_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  inst_not_implemented(pI);
-}
-void suld_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  inst_not_implemented(pI);
-}
-void sured_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  inst_not_implemented(pI);
-}
-void sust_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  inst_not_implemented(pI);
-}
-void suq_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  inst_not_implemented(pI);
-}
+void subc_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
+void suld_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
+void sured_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
+void sust_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
+void suq_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
+
 
 union intfloat {
-  int a;
-  float b;
+   int a;
+   float b;
 };
 
-float reduce_precision(float x, unsigned bits) {
-  intfloat tmp;
-  tmp.b = x;
-  int v = tmp.a;
-  int man = v & ((1 << 23) - 1);
-  int mask = ((1 << bits) - 1) << (23 - bits);
-  int nv = (v & ((-1) - ((1 << 23) - 1))) | (mask & man);
-  tmp.a = nv;
-  float result = tmp.b;
-  return result;
+float reduce_precision( float x, unsigned bits )
+{
+   intfloat tmp;
+   tmp.b = x;
+   int v = tmp.a;
+   int man = v & ((1<<23)-1);
+   int mask =  ((1<<bits)-1) << (23-bits);
+   int nv = (v & ((-1)-((1<<23)-1))) | (mask&man);
+   tmp.a = nv;
+   float result = tmp.b;
+   return result;
 }
 
-unsigned wrap(unsigned x, unsigned y, unsigned mx, unsigned my,
-              size_t elem_size) {
-  unsigned nx = (mx + x) % mx;
-  unsigned ny = (my + y) % my;
-  return nx + mx * ny;
+unsigned wrap( unsigned x, unsigned y, unsigned mx, unsigned my, size_t elem_size )
+{
+   unsigned nx = (mx+x)%mx;
+   unsigned ny = (my+y)%my;
+   return nx + mx*ny;
 }
 
-unsigned clamp(unsigned x, unsigned y, unsigned mx, unsigned my,
-               size_t elem_size) {
-  unsigned nx = x;
-  while (nx >= mx) nx -= elem_size;
-  unsigned ny = (y >= my) ? my - 1 : y;
-  return nx + mx * ny;
+unsigned clamp( unsigned x, unsigned y, unsigned mx, unsigned my, size_t elem_size )
+{
+   unsigned nx = x;
+   while (nx >= mx) nx -= elem_size;
+   unsigned ny = (y >= my)? my - 1 : y;
+   return nx + mx*ny;
 }
 
-typedef unsigned (*texAddr_t)(unsigned x, unsigned y, unsigned mx, unsigned my,
-                              size_t elem_size);
-float tex_linf_sampling(memory_space *mem, unsigned tex_array_base, int x,
-                        int y, unsigned int width, unsigned int height,
-                        size_t elem_size, float alpha, float beta,
-                        texAddr_t b_lim) {
-  float Tij;
-  float Ti1j;
-  float Tij1;
-  float Ti1j1;
+typedef unsigned (*texAddr_t) (unsigned x, unsigned y, unsigned mx, unsigned my, size_t elem_size);
+float tex_linf_sampling(memory_space* mem, unsigned tex_array_base, 
+                        int x, int y, unsigned int width, unsigned int height, size_t elem_size,
+                        float alpha, float beta, texAddr_t b_lim)
+{
+   float Tij;
+   float Ti1j;
+   float Tij1;
+   float Ti1j1;
 
-  mem->read(tex_array_base + b_lim(x, y, width, height, elem_size), 4, &Tij);
-  mem->read(tex_array_base + b_lim(x + elem_size, y, width, height, elem_size),
-            4, &Ti1j);
-  mem->read(tex_array_base + b_lim(x, y + 1, width, height, elem_size), 4,
-            &Tij1);
-  mem->read(
-      tex_array_base + b_lim(x + elem_size, y + 1, width, height, elem_size), 4,
-      &Ti1j1);
+   mem->read(tex_array_base + b_lim(x,y,width,height,elem_size), 4, &Tij);
+   mem->read(tex_array_base + b_lim(x+elem_size,y,width,height,elem_size), 4, &Ti1j);
+   mem->read(tex_array_base + b_lim(x,y+1,width,height,elem_size), 4, &Tij1);
+   mem->read(tex_array_base + b_lim(x+elem_size,y+1,width,height,elem_size), 4, &Ti1j1);
 
-  float sample = (1 - alpha) * (1 - beta) * Tij + alpha * (1 - beta) * Ti1j +
-                 (1 - alpha) * beta * Tij1 + alpha * beta * Ti1j1;
-
-  return sample;
+   float sample = (1-alpha)*(1-beta)*Tij + 
+                   alpha*(1-beta)*Ti1j +
+                   (1-alpha)*beta*Tij1 +
+                   alpha*beta*Ti1j1;
+   
+   return sample;
 }
 
-float textureNormalizeElementSigned(int element, int bits) {
-  if (bits) {
-    int maxN = (1 << bits) - 1;
-    // removing upper bits
-    element &= maxN;
-    // normalizing the number to [-1.0,1.0]
-    maxN >>= 1;
-    float output = (float)element / maxN;
-    if (output < -1.0f) output = -1.0f;
-    return output;
-  } else {
-    return 0.0f;
-  }
+float textureNormalizeElementSigned(int element, int bits)
+{
+   if (bits) {
+      int maxN = (1 << bits) - 1; 
+      // removing upper bits 
+      element &= maxN;
+      // normalizing the number to [-1.0,1.0]
+      maxN >>= 1;
+      float output = (float) element / maxN;  
+      if (output < -1.0f) output = -1.0f; 
+      return output; 
+   } else {
+      return 0.0f; 
+   }
 }
 
-float textureNormalizeElementUnsigned(unsigned int element, int bits) {
-  if (bits) {
-    unsigned int maxN = (1 << bits) - 1;
-    // removing upper bits and normalizing the number to [0.0,1.0]
-    return (float)(element & maxN) / maxN;
-  } else {
-    return 0.0f;
-  }
+float textureNormalizeElementUnsigned(unsigned int element, int bits)
+{
+   if (bits) {
+      unsigned int maxN = (1 << bits) - 1; 
+      // removing upper bits and normalizing the number to [0.0,1.0]
+      return (float)(element & maxN) / maxN;  
+   } else {
+      return 0.0f; 
+   }
 }
 
-void textureNormalizeOutput(const struct cudaChannelFormatDesc &desc,
-                            ptx_reg_t &datax, ptx_reg_t &datay,
-                            ptx_reg_t &dataz, ptx_reg_t &dataw) {
-  if (desc.f == cudaChannelFormatKindSigned) {
-    datax.f32 = textureNormalizeElementSigned(datax.s32, desc.x);
-    datay.f32 = textureNormalizeElementSigned(datay.s32, desc.y);
-    dataz.f32 = textureNormalizeElementSigned(dataz.s32, desc.z);
-    dataw.f32 = textureNormalizeElementSigned(dataw.s32, desc.w);
-  } else if (desc.f == cudaChannelFormatKindUnsigned) {
-    datax.f32 = textureNormalizeElementUnsigned(datax.u32, desc.x);
-    datay.f32 = textureNormalizeElementUnsigned(datay.u32, desc.y);
-    dataz.f32 = textureNormalizeElementUnsigned(dataz.u32, desc.z);
-    dataw.f32 = textureNormalizeElementUnsigned(dataw.u32, desc.w);
-  } else {
-    assert(0 &&
-           "Undefined texture read mode: cudaReadModeNormalizedFloat expect "
-           "integer elements");
-  }
+void textureNormalizeOutput( const struct cudaChannelFormatDesc& desc, ptx_reg_t& datax, ptx_reg_t& datay, ptx_reg_t& dataz, ptx_reg_t& dataw ) 
+{
+   if (desc.f == cudaChannelFormatKindSigned) {
+      datax.f32 = textureNormalizeElementSigned( datax.s32, desc.x ); 
+      datay.f32 = textureNormalizeElementSigned( datay.s32, desc.y ); 
+      dataz.f32 = textureNormalizeElementSigned( dataz.s32, desc.z ); 
+      dataw.f32 = textureNormalizeElementSigned( dataw.s32, desc.w ); 
+   } else if (desc.f == cudaChannelFormatKindUnsigned) {
+      datax.f32 = textureNormalizeElementUnsigned( datax.u32, desc.x ); 
+      datay.f32 = textureNormalizeElementUnsigned( datay.u32, desc.y ); 
+      dataz.f32 = textureNormalizeElementUnsigned( dataz.u32, desc.z ); 
+      dataw.f32 = textureNormalizeElementUnsigned( dataw.u32, desc.w ); 
+   } else {
+      assert(0 && "Undefined texture read mode: cudaReadModeNormalizedFloat expect integer elements"); 
+   }
 }
 
-void tex_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  unsigned dimension = pI->dimension();
-  const operand_info &dst =
-      pI->dst();  // the registers to which fetched texel will be placed
-  const operand_info &src1 = pI->src1();  // the name of the texture
-  const operand_info &src2 = pI->src2();  // the vector registers containing
-                                          // coordinates of the texel to be
-                                          // fetched
+void tex_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+   unsigned dimension = pI->dimension();
+   const operand_info &dst = pI->dst(); //the registers to which fetched texel will be placed
+   const operand_info &src1 = pI->src1(); //the name of the texture
+   const operand_info &src2 = pI->src2(); //the vector registers containing coordinates of the texel to be fetched
 
-  std::string texname = src1.name();
-  unsigned to_type = pI->get_type();
-  unsigned c_type = pI->get_type2();
-  fflush(stdout);
-  ptx_reg_t data1, data2, data3, data4;
-  if (!thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs)
-    thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs = new ptx_reg_t[4];
-  unsigned nelem = src2.get_vect_nelem();
-  thread->get_vector_operand_values(
-      src2, thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs,
-      nelem);  // ptx_reg should be 4 entry vector type...coordinates into
-               // texture
-  /*
-    For programs with many streams, textures can be bound and unbound
-    asynchronously.  This means we need to use the kernel's "snapshot" of
-    the state of the texture mappings when it was launched (so that we
-    don't try to access the incorrect texture mapping if it's been updated,
-    or that we don't access a mapping that has been unbound).
-  */
-  gpgpu_t *gpu = thread->get_gpu();
-  kernel_info_t &k = thread->get_kernel();
-  const struct textureReference *texref = gpu->get_texref(texname);
-  const struct cudaArray *cuArray = k.get_texarray(texname);
-  const struct textureInfo *texInfo = k.get_texinfo(texname);
-  const struct textureReferenceAttr *texAttr = gpu->get_texattr(texname);
+   std::string texname = src1.name();
+   unsigned to_type = pI->get_type();
+   unsigned c_type = pI->get_type2();
+   fflush(stdout);
+   ptx_reg_t data1, data2, data3, data4;
+   if (!thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs)
+       thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs = new ptx_reg_t[4];
+   unsigned nelem = src2.get_vect_nelem();
+   thread->get_vector_operand_values(src2, thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs, nelem); //ptx_reg should be 4 entry vector type...coordinates into texture
+   /*
+     For programs with many streams, textures can be bound and unbound
+     asynchronously.  This means we need to use the kernel's "snapshot" of
+     the state of the texture mappings when it was launched (so that we
+     don't try to access the incorrect texture mapping if it's been updated,
+     or that we don't access a mapping that has been unbound).
+   */
+   gpgpu_t *gpu = thread->get_gpu();
+   kernel_info_t &k = thread->get_kernel();
+   const struct textureReference* texref = gpu->get_texref(texname);
+   const struct cudaArray* cuArray = k.get_texarray(texname); 
+   const struct textureInfo* texInfo = k.get_texinfo(texname);
+   const struct textureReferenceAttr* texAttr = gpu->get_texattr(texname);
 
-  // assume always 2D f32 input
-  // access array with src2 coordinates
-  memory_space *mem = thread->get_global_memory();
-  float x_f32, y_f32;
-  size_t size;
-  int t;
-  unsigned tex_array_base;
-  unsigned int width = 0, height = 0;
-  int x = 0;
-  int y = 0;
-  unsigned tex_array_index;
-  float alpha = 0, beta = 0;
+   //assume always 2D f32 input
+   //access array with src2 coordinates
+   memory_space *mem = thread->get_global_memory();
+   float x_f32,  y_f32;
+   size_t size;
+   int t;
+   unsigned tex_array_base;
+   unsigned int width = 0, height = 0;
+   int x = 0;
+   int y = 0;
+   unsigned tex_array_index;
+   float alpha=0, beta=0;
 
-  type_info_key::type_decode(to_type, size, t);
-  tex_array_base = cuArray->devPtr32;
+   type_info_key::type_decode(to_type,size,t);
+   tex_array_base = cuArray->devPtr32;
 
-  switch (dimension) {
-    case GEOM_MODIFIER_1D:
+   switch (dimension) {
+   case GEOM_MODIFIER_1D:
       width = cuArray->width;
       height = cuArray->height;
       if (texref->normalized) {
-        assert(c_type == F32_TYPE);
-        x_f32 = thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[0].f32;
-        if (texref->addressMode[0] == cudaAddressModeClamp) {
-          x_f32 = (x_f32 > 1.0) ? 1.0 : x_f32;
-          x_f32 = (x_f32 < 0.0) ? 0.0 : x_f32;
-        } else if (texref->addressMode[0] == cudaAddressModeWrap) {
-          x_f32 = x_f32 - floor(x_f32);
-        }
+         assert(c_type == F32_TYPE); 
+         x_f32 = thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[0].f32;
+         if (texref->addressMode[0] == cudaAddressModeClamp) {
+            x_f32 = (x_f32 > 1.0)? 1.0 : x_f32;
+            x_f32 = (x_f32 < 0.0)? 0.0 : x_f32;
+         } else if (texref->addressMode[0] == cudaAddressModeWrap) {
+            x_f32 = x_f32 - floor(x_f32);
+         }
 
-        if (texref->filterMode == cudaFilterModeLinear) {
-          float xb = x_f32 * width - 0.5;
-          alpha = xb - floor(xb);
-          alpha = reduce_precision(alpha, 9);
-          beta = 0.0;
+         if( texref->filterMode == cudaFilterModeLinear ) {
+            float xb = x_f32 * width - 0.5;
+            alpha = xb - floor(xb);
+            alpha = reduce_precision(alpha,9);
+            beta = 0.0;
 
-          x = (int)floor(xb);
-          y = 0;
-        } else {
-          x = (int)floor(x_f32 * width);
-          y = 0;
-        }
+            x = (int)floor(xb);
+            y = 0;
+         } else {
+            x = (int) floor(x_f32 * width);
+            y = 0;
+         }
       } else {
-        switch (c_type) {
-          case S32_TYPE:
+         switch ( c_type ) {
+         case S32_TYPE: 
             x = thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[0].s32;
-            assert(texref->filterMode == cudaFilterModePoint);
-            break;
-          case F32_TYPE:
+            assert(texref->filterMode == cudaFilterModePoint); 
+            break; 
+         case F32_TYPE: 
             x_f32 = thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[0].f32;
-            alpha = x_f32 -
-                    floor(x_f32);  // offset into subtexel (for linear sampling)
-            x = (int)x_f32;
-            break;
-          default:
-            assert(0 && "Unsupported texture coordinate type.");
-        }
-        // handle texture fetch that exceeded boundaries
-        if (texref->addressMode[0] == cudaAddressModeClamp) {
-          x = (x > width - 1) ? (width - 1) : x;
-          x = (x < 0) ? 0 : x;
-        } else if (texref->addressMode[0] == cudaAddressModeWrap) {
-          x = x % width;
-        }
+            alpha = x_f32 - floor(x_f32); // offset into subtexel (for linear sampling)
+            x = (int) x_f32; 
+            break; 
+         default: assert(0 && "Unsupported texture coordinate type."); 
+         }
+         // handle texture fetch that exceeded boundaries
+         if (texref->addressMode[0] == cudaAddressModeClamp) {
+            x = (x > width - 1)? (width - 1) : x;
+            x = (x < 0)? 0 : x;
+         } else if (texref->addressMode[0] == cudaAddressModeWrap) {
+            x = x % width;
+         }
       }
-      width *= (cuArray->desc.w + cuArray->desc.x + cuArray->desc.y +
-                cuArray->desc.z) /
-               8;
-      x *= (cuArray->desc.w + cuArray->desc.x + cuArray->desc.y +
-            cuArray->desc.z) /
-           8;
+      width *= (cuArray->desc.w+cuArray->desc.x+cuArray->desc.y+cuArray->desc.z)/8;
+      x *= (cuArray->desc.w+cuArray->desc.x+cuArray->desc.y+cuArray->desc.z)/8;
       tex_array_index = tex_array_base + x;
 
       break;
-    case GEOM_MODIFIER_2D:
+   case GEOM_MODIFIER_2D:
       width = cuArray->width;
       height = cuArray->height;
       if (texref->normalized) {
-        x_f32 = reduce_precision(
-            thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[0].f32, 16);
-        y_f32 = reduce_precision(
-            thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[1].f32, 15);
+         x_f32 = reduce_precision(thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[0].f32,16);
+         y_f32 = reduce_precision(thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[1].f32,15);
 
-        if (texref->addressMode[0]) {  // clamp
-          if (x_f32 < 0) x_f32 = 0;
-          if (x_f32 >= 1) x_f32 = 1 - 1 / x_f32;
-        } else {  // wrap
-          x_f32 = x_f32 - floor(x_f32);
-        }
-        if (texref->addressMode[1]) {  // clamp
-          if (y_f32 < 0) y_f32 = 0;
-          if (y_f32 >= 1) y_f32 = 1 - 1 / y_f32;
-        } else {  // wrap
-          y_f32 = y_f32 - floor(y_f32);
-        }
+         if (texref->addressMode[0]) {//clamp
+            if (x_f32<0) x_f32 = 0;
+            if (x_f32>=1) x_f32 = 1 - 1/x_f32;
+         } else {//wrap
+            x_f32 = x_f32 - floor(x_f32);
+         }
+         if (texref->addressMode[1]) {//clamp
+            if (y_f32<0) y_f32 = 0;
+            if (y_f32>=1) y_f32 = 1 - 1/y_f32;
+         } else {//wrap
+            y_f32 = y_f32 - floor(y_f32);
+         }
 
-        if (texref->filterMode == cudaFilterModeLinear) {
-          float xb = x_f32 * width - 0.5;
-          float yb = y_f32 * height - 0.5;
-          alpha = xb - floor(xb);
-          beta = yb - floor(yb);
-          alpha = reduce_precision(alpha, 9);
-          beta = reduce_precision(beta, 9);
+         if( texref->filterMode == cudaFilterModeLinear ) {
+            float xb = x_f32 * width - 0.5;
+            float yb = y_f32 * height - 0.5;
+            alpha = xb - floor(xb);
+            beta = yb - floor(yb);
+            alpha = reduce_precision(alpha,9);
+            beta = reduce_precision(beta,9);
 
-          x = (int)floor(xb);
-          y = (int)floor(yb);
-        } else {
-          x = (int)floor(x_f32 * width);
-          y = (int)floor(y_f32 * height);
-        }
+            x = (int)floor(xb);
+            y = (int)floor(yb);
+         } else {
+            x = (int) floor(x_f32 * width);
+            y = (int) floor(y_f32 * height);
+         }
       } else {
-        x_f32 = thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[0].f32;
-        y_f32 = thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[1].f32;
+         x_f32 = thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[0].f32;
+         y_f32 = thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[1].f32;
 
-        alpha = x_f32 - floor(x_f32);
-        beta = y_f32 - floor(y_f32);
+         alpha = x_f32 - floor(x_f32);
+         beta = y_f32 - floor(y_f32);
 
-        x = (int)x_f32;
-        y = (int)y_f32;
-        if (texref->addressMode[0]) {  // clamp
-          if (x < 0) x = 0;
-          if (x >= (int)width) x = width - 1;
-        } else {  // wrap
-          x = x % width;
-          if (x < 0) x *= -1;
-        }
-        if (texref->addressMode[1]) {  // clamp
-          if (y < 0) y = 0;
-          if (y >= (int)height) y = height - 1;
-        } else {  // wrap
-          y = y % height;
-          if (y < 0) y *= -1;
-        }
+         x = (int) x_f32;
+         y = (int) y_f32;
+         if (texref->addressMode[0]) {//clamp
+            if (x<0) x = 0;
+            if (x>= (int)width) x = width-1;
+         } else {//wrap
+            x = x % width;
+            if (x < 0) x*= -1;
+         }
+         if (texref->addressMode[1]) {//clamp
+            if (y<0) y = 0;
+            if (y>= (int)height) y = height -1;
+         } else {//wrap
+            y = y % height;
+            if (y < 0) y *= -1;
+         }
       }
 
-      width *= (cuArray->desc.w + cuArray->desc.x + cuArray->desc.y +
-                cuArray->desc.z) /
-               8;
-      x *= (cuArray->desc.w + cuArray->desc.x + cuArray->desc.y +
-            cuArray->desc.z) /
-           8;
-      tex_array_index = tex_array_base + (x + width * y);
+      width *= (cuArray->desc.w+cuArray->desc.x+cuArray->desc.y+cuArray->desc.z)/8;
+      x *= (cuArray->desc.w+cuArray->desc.x+cuArray->desc.y+cuArray->desc.z)/8;
+      tex_array_index = tex_array_base + (x + width*y);
       break;
-    default:
-      assert(0);
-      break;
-  }
-  switch (to_type) {
-    case U8_TYPE:
-    case U16_TYPE:
-    case U32_TYPE:
-    case B8_TYPE:
-    case B16_TYPE:
-    case B32_TYPE:
-    case S8_TYPE:
-    case S16_TYPE:
-    case S32_TYPE: {
-      unsigned long long elementOffset = 0;  // offset into the next element
-      mem->read(tex_array_index, cuArray->desc.x / 8, &data1.u32);
-      elementOffset += cuArray->desc.x / 8;
+   default:
+      assert(0); break;
+   }
+   switch ( to_type ) {
+   case U8_TYPE:
+   case U16_TYPE:
+   case U32_TYPE: 
+   case B8_TYPE:
+   case B16_TYPE:
+   case B32_TYPE: 
+   case S8_TYPE:
+   case S16_TYPE:
+   case S32_TYPE: {
+      unsigned long long elementOffset = 0; // offset into the next element 
+      mem->read( tex_array_index, cuArray->desc.x/8, &data1.u32);
+      elementOffset += cuArray->desc.x/8;  
       if (cuArray->desc.y) {
-        mem->read(tex_array_index + elementOffset, cuArray->desc.y / 8,
-                  &data2.u32);
-        elementOffset += cuArray->desc.y / 8;
-        if (cuArray->desc.z) {
-          mem->read(tex_array_index + elementOffset, cuArray->desc.z / 8,
-                    &data3.u32);
-          elementOffset += cuArray->desc.z / 8;
-          if (cuArray->desc.w)
-            mem->read(tex_array_index + elementOffset, cuArray->desc.w / 8,
-                      &data4.u32);
-        }
+         mem->read( tex_array_index + elementOffset, cuArray->desc.y/8, &data2.u32);
+         elementOffset += cuArray->desc.y/8; 
+         if (cuArray->desc.z) {
+            mem->read( tex_array_index + elementOffset, cuArray->desc.z/8, &data3.u32);
+            elementOffset += cuArray->desc.z/8; 
+            if (cuArray->desc.w) 
+               mem->read( tex_array_index + elementOffset, cuArray->desc.w/8, &data4.u32);
+         }
       }
       break;
-    }
-    case B64_TYPE:
-    case U64_TYPE:
-    case S64_TYPE:
-      mem->read(tex_array_index, 8, &data1.u64);
+   }
+   case B64_TYPE:
+   case U64_TYPE:
+   case S64_TYPE:
+      mem->read( tex_array_index, 8, &data1.u64);
       if (cuArray->desc.y) {
-        mem->read(tex_array_index + 8, 8, &data2.u64);
-        if (cuArray->desc.z) {
-          mem->read(tex_array_index + 16, 8, &data3.u64);
-          if (cuArray->desc.w) mem->read(tex_array_index + 24, 8, &data4.u64);
-        }
+         mem->read( tex_array_index+8, 8, &data2.u64);
+         if (cuArray->desc.z) {
+            mem->read( tex_array_index+16, 8, &data3.u64);
+            if (cuArray->desc.w) 
+               mem->read( tex_array_index+24, 8, &data4.u64);
+         }
       }
       break;
-    case F16_TYPE:
-      assert(0);
-      break;
-    case F32_TYPE: {
-      if (texref->filterMode == cudaFilterModeLinear) {
-        texAddr_t b_lim = wrap;
-        if (texref->addressMode[0] == cudaAddressModeClamp) {
-          b_lim = clamp;
-        }
-        size_t elem_size = (cuArray->desc.x + cuArray->desc.y +
-                            cuArray->desc.z + cuArray->desc.w) /
-                           8;
-        size_t elem_ofst = 0;
+   case F16_TYPE: assert(0); break;
+   case F32_TYPE:  {
+      if( texref->filterMode == cudaFilterModeLinear ) {
+         texAddr_t b_lim = wrap;
+         if ( texref->addressMode[0] == cudaAddressModeClamp ) {
+            b_lim = clamp;
+         }
+         size_t elem_size = (cuArray->desc.x + cuArray->desc.y + cuArray->desc.z + cuArray->desc.w) / 8;
+         size_t elem_ofst = 0;
 
-        data1.f32 =
-            tex_linf_sampling(mem, tex_array_base, x + elem_ofst, y, width,
-                              height, elem_size, alpha, beta, b_lim);
-        elem_ofst += cuArray->desc.x / 8;
-        if (cuArray->desc.y) {
-          data2.f32 =
-              tex_linf_sampling(mem, tex_array_base, x + elem_ofst, y, width,
-                                height, elem_size, alpha, beta, b_lim);
-          elem_ofst += cuArray->desc.y / 8;
-          if (cuArray->desc.z) {
-            data3.f32 =
-                tex_linf_sampling(mem, tex_array_base, x + elem_ofst, y, width,
-                                  height, elem_size, alpha, beta, b_lim);
-            elem_ofst += cuArray->desc.z / 8;
-            if (cuArray->desc.w)
-              data4.f32 = tex_linf_sampling(mem, tex_array_base, x + elem_ofst,
-                                            y, width, height, elem_size, alpha,
-                                            beta, b_lim);
-          }
-        }
+         data1.f32 = tex_linf_sampling(mem, tex_array_base, x + elem_ofst, y, width, height, elem_size, alpha, beta, b_lim);
+         elem_ofst += cuArray->desc.x / 8; 
+         if (cuArray->desc.y) {
+            data2.f32 = tex_linf_sampling(mem, tex_array_base, x + elem_ofst, y, width, height, elem_size, alpha, beta, b_lim);
+            elem_ofst += cuArray->desc.y / 8; 
+            if (cuArray->desc.z) {
+               data3.f32 = tex_linf_sampling(mem, tex_array_base, x + elem_ofst, y, width, height, elem_size, alpha, beta, b_lim);
+               elem_ofst += cuArray->desc.z / 8; 
+               if (cuArray->desc.w) 
+                  data4.f32 = tex_linf_sampling(mem, tex_array_base, x + elem_ofst, y, width, height, elem_size, alpha, beta, b_lim);
+            }
+         }
       } else {
-        mem->read(tex_array_index, cuArray->desc.x / 8, &data1.f32);
-        if (cuArray->desc.y) {
-          mem->read(tex_array_index + 4, cuArray->desc.y / 8, &data2.f32);
-          if (cuArray->desc.z) {
-            mem->read(tex_array_index + 8, cuArray->desc.z / 8, &data3.f32);
-            if (cuArray->desc.w)
-              mem->read(tex_array_index + 12, cuArray->desc.w / 8, &data4.f32);
-          }
-        }
+         mem->read( tex_array_index, cuArray->desc.x/8, &data1.f32);
+         if (cuArray->desc.y) {
+            mem->read( tex_array_index+4, cuArray->desc.y/8, &data2.f32);
+            if (cuArray->desc.z) {
+               mem->read( tex_array_index+8, cuArray->desc.z/8, &data3.f32);
+               if (cuArray->desc.w) 
+                  mem->read( tex_array_index+12, cuArray->desc.w/8, &data4.f32);
+            }
+         }
       }
-    } break;
-    case F64_TYPE:
-    case FF64_TYPE:
-      mem->read(tex_array_index, 8, &data1.f64);
+   } break;
+   case F64_TYPE: 
+   case FF64_TYPE:
+      mem->read( tex_array_index, 8, &data1.f64);
       if (cuArray->desc.y) {
-        mem->read(tex_array_index + 8, 8, &data2.f64);
-        if (cuArray->desc.z) {
-          mem->read(tex_array_index + 16, 8, &data3.f64);
-          if (cuArray->desc.w) mem->read(tex_array_index + 24, 8, &data4.f64);
-        }
+         mem->read( tex_array_index+8, 8, &data2.f64);
+         if (cuArray->desc.z) {
+            mem->read( tex_array_index+16, 8, &data3.f64);
+            if (cuArray->desc.w) 
+               mem->read( tex_array_index+24, 8, &data4.f64);
+         }
       }
       break;
-    default:
-      assert(0);
-      break;
-  }
-  int x_block_coord, y_block_coord, memreqindex, blockoffset;
+   default: assert(0); break;
+   }
+   int x_block_coord, y_block_coord, memreqindex, blockoffset;
 
-  switch (dimension) {
-    case GEOM_MODIFIER_1D:
+   switch (dimension) {
+   case GEOM_MODIFIER_1D:
       thread->m_last_effective_address = tex_array_index;
       break;
-    case GEOM_MODIFIER_2D:
+   case GEOM_MODIFIER_2D: 
       x_block_coord = x >> (texInfo->Tx_numbits + texInfo->texel_size_numbits);
       y_block_coord = y >> texInfo->Ty_numbits;
 
-      memreqindex =
-          ((y_block_coord * cuArray->width / texInfo->Tx) + x_block_coord) << 6;
+      memreqindex = ((y_block_coord*cuArray->width/texInfo->Tx)+x_block_coord)<<6;
 
-      blockoffset = (x % (texInfo->Tx * texInfo->texel_size) +
-                     (y % (texInfo->Ty)
-                      << (texInfo->Tx_numbits + texInfo->texel_size_numbits)));
+      blockoffset = (x%(texInfo->Tx*texInfo->texel_size) + (y%(texInfo->Ty)<<(texInfo->Tx_numbits + texInfo->texel_size_numbits)));
       memreqindex += blockoffset;
-      thread->m_last_effective_address =
-          tex_array_base + memreqindex;  // tex_array_index;
+      thread->m_last_effective_address = tex_array_base + memreqindex;//tex_array_index;
       break;
-    default:
+   default:
       assert(0);
-  }
-  thread->m_last_memory_space = tex_space;
+   }
+   thread->m_last_memory_space = tex_space; 
 
-  // normalize output into floating point numbers according to the texture read
-  // mode
-  if (texAttr->m_readmode == cudaReadModeNormalizedFloat) {
-    textureNormalizeOutput(cuArray->desc, data1, data2, data3, data4);
-  } else {
-    assert(texAttr->m_readmode == cudaReadModeElementType);
-  }
+   // normalize output into floating point numbers according to the texture read mode
+   if (texAttr->m_readmode == cudaReadModeNormalizedFloat) {
+      textureNormalizeOutput(cuArray->desc, data1, data2, data3, data4); 
+   } else {
+      assert(texAttr->m_readmode == cudaReadModeElementType); 
+   }
 
-  thread->set_vector_operand_values(dst, data1, data2, data3, data4);
-}
-
-void txq_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  inst_not_implemented(pI);
-}
-void trap_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  inst_not_implemented(pI);
-}
-void vabsdiff_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  inst_not_implemented(pI);
-}
-void vadd_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  inst_not_implemented(pI);
-}
-void vmad_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  inst_not_implemented(pI);
-}
-void vmax_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  inst_not_implemented(pI);
-}
-void vmin_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  inst_not_implemented(pI);
-}
-void vset_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  inst_not_implemented(pI);
-}
-void vshl_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  inst_not_implemented(pI);
-}
-void vshr_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  inst_not_implemented(pI);
-}
-void vsub_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  inst_not_implemented(pI);
+   thread->set_vector_operand_values(dst,data1,data2,data3,data4);
 }
 
-void vote_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  static bool first_in_warp = true;
-  static bool and_all;
-  static bool or_all;
-  static unsigned int ballot_result;
-  static std::list<ptx_thread_info *> threads_in_warp;
-  static unsigned last_tid;
+void txq_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
+void trap_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
+void vabsdiff_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
+void vadd_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
+void vmad_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
+void vmax_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
+void vmin_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
+void vset_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
+void vshl_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
+void vshr_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
+void vsub_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
 
-  if (first_in_warp) {
-    first_in_warp = false;
-    threads_in_warp.clear();
-    and_all = true;
-    or_all = false;
-    ballot_result = 0;
-    int offset = 31;
-    while ((offset >= 0) && !pI->active(offset)) offset--;
-    assert(offset >= 0);
-    last_tid =
-        (thread->get_hw_tid() - (thread->get_hw_tid() % pI->warp_size())) +
-        offset;
-  }
+void vote_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{
+   static bool first_in_warp = true;
+   static bool and_all;
+   static bool or_all;
+   static unsigned int ballot_result;
+   static std::list<ptx_thread_info*> threads_in_warp;
+   static unsigned last_tid;
 
-  ptx_reg_t src1_data;
-  const operand_info &src1 = pI->src1();
-  src1_data = thread->get_operand_value(src1, pI->dst(), PRED_TYPE, thread, 1);
+   if( first_in_warp ) {
+      first_in_warp = false;
+      threads_in_warp.clear();
+      and_all = true;
+      or_all = false;
+      ballot_result = 0;
+      int offset=31;
+      while( (offset>=0) && !pI->active(offset) ) 
+         offset--;
+      assert( offset >= 0 );
+      last_tid = (thread->get_hw_tid() - (thread->get_hw_tid()%pI->warp_size())) + offset;
+   }
 
-  // predicate value was changed so the lowest bit being set means the zero flag
-  // is set.
-  // As a result, the value of src1_data.pred must be inverted to get proper
-  // behavior
-  bool pred_value = !(src1_data.pred & 0x0001);
-  bool invert = src1.is_neg_pred();
+   ptx_reg_t src1_data;
+   const operand_info &src1 = pI->src1();
+   src1_data = thread->get_operand_value(src1, pI->dst(), PRED_TYPE, thread, 1);
 
-  threads_in_warp.push_back(thread);
-  and_all &= (invert ^ pred_value);
-  or_all |= (invert ^ pred_value);
+   //predicate value was changed so the lowest bit being set means the zero flag is set.
+   //As a result, the value of src1_data.pred must be inverted to get proper behavior
+   bool pred_value = !(src1_data.pred & 0x0001);
+   bool invert = src1.is_neg_pred();
 
-  // vote.ballot
-  if (invert ^ pred_value) {
-    int lane_id = thread->get_hw_tid() % pI->warp_size();
-    ballot_result |= (1 << lane_id);
-  }
+   threads_in_warp.push_back(thread);
+   and_all &= (invert ^ pred_value);
+   or_all |= (invert ^ pred_value);
 
-  if (thread->get_hw_tid() == last_tid) {
-    if (pI->vote_mode() == ptx_instruction::vote_ballot) {
-      ptx_reg_t data = ballot_result;
-      for (std::list<ptx_thread_info *>::iterator t = threads_in_warp.begin();
-           t != threads_in_warp.end(); ++t) {
-        const operand_info &dst = pI->dst();
-        (*t)->set_operand_value(dst, data, pI->get_type(), (*t), pI);
+   // vote.ballot
+   if (invert ^ pred_value) {
+      int lane_id = thread->get_hw_tid() % pI->warp_size(); 
+      ballot_result |= (1 << lane_id); 
+   }
+
+   if( thread->get_hw_tid() == last_tid ) {
+      if (pI->vote_mode() == ptx_instruction::vote_ballot) {
+         ptx_reg_t data = ballot_result; 
+         for( std::list<ptx_thread_info*>::iterator t=threads_in_warp.begin(); t!=threads_in_warp.end(); ++t ) {
+            const operand_info &dst = pI->dst();
+            (*t)->set_operand_value(dst,data, pI->get_type(), (*t), pI);
+         }
+      } else {
+         bool pred_value = false; 
+
+         switch( pI->vote_mode() ) {
+         case ptx_instruction::vote_any: pred_value = or_all; break;
+         case ptx_instruction::vote_all: pred_value = and_all; break;
+         case ptx_instruction::vote_uni: pred_value = (or_all ^ and_all); break;
+         default:
+            abort();
+         }
+         ptx_reg_t data;
+         data.pred = pred_value?0:1; //the way ptxplus handles the zero flag, 1 = false and 0 = true
+
+         for( std::list<ptx_thread_info*>::iterator t=threads_in_warp.begin(); t!=threads_in_warp.end(); ++t ) {
+            const operand_info &dst = pI->dst();
+            (*t)->set_operand_value(dst,data, PRED_TYPE, (*t), pI);
+         }
       }
-    } else {
-      bool pred_value = false;
-
-      switch (pI->vote_mode()) {
-        case ptx_instruction::vote_any:
-          pred_value = or_all;
-          break;
-        case ptx_instruction::vote_all:
-          pred_value = and_all;
-          break;
-        case ptx_instruction::vote_uni:
-          pred_value = (or_all ^ and_all);
-          break;
-        default:
-          abort();
-      }
-      ptx_reg_t data;
-      data.pred = pred_value ? 0 : 1;  // the way ptxplus handles the zero flag,
-                                       // 1 = false and 0 = true
-
-      for (std::list<ptx_thread_info *>::iterator t = threads_in_warp.begin();
-           t != threads_in_warp.end(); ++t) {
-        const operand_info &dst = pI->dst();
-        (*t)->set_operand_value(dst, data, PRED_TYPE, (*t), pI);
-      }
-    }
-    first_in_warp = true;
-  }
+      first_in_warp = true;
+   }
 }
 
-void xor_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
-  ptx_reg_t src1_data, src2_data, data;
+void xor_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
+{ 
+   ptx_reg_t src1_data, src2_data, data;
 
-  const operand_info &dst = pI->dst();
-  const operand_info &src1 = pI->src1();
-  const operand_info &src2 = pI->src2();
+   const operand_info &dst  = pI->dst();
+   const operand_info &src1 = pI->src1();
+   const operand_info &src2 = pI->src2();
 
-  unsigned i_type = pI->get_type();
-  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+   unsigned i_type = pI->get_type();
+   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-  // the way ptxplus handles predicates: 1 = false and 0 = true
-  if (i_type == PRED_TYPE)
-    data.pred = ~(~(src1_data.pred) ^ ~(src2_data.pred));
-  else
-    data.u64 = src1_data.u64 ^ src2_data.u64;
+   //the way ptxplus handles predicates: 1 = false and 0 = true
+   if(i_type == PRED_TYPE)
+      data.pred = ~(~(src1_data.pred) ^ ~(src2_data.pred));
+   else
+      data.u64 = src1_data.u64 ^ src2_data.u64;
 
-  thread->set_operand_value(dst, data, i_type, thread, pI);
+   thread->set_operand_value(dst,data, i_type, thread, pI);
 }
 
-void inst_not_implemented(const ptx_instruction *pI) {
-  printf(
-      "GPGPU-Sim PTX: ERROR (%s:%u) instruction \"%s\" not (yet) implemented\n",
-      pI->source_file(), pI->source_line(), pI->get_opcode_cstr());
-  abort();
+void inst_not_implemented( const ptx_instruction * pI ) 
+{
+   printf("GPGPU-Sim PTX: ERROR (%s:%u) instruction \"%s\" not (yet) implemented\n",
+          pI->source_file(), 
+          pI->source_line(), 
+          pI->get_opcode_cstr() );
+   abort();
 }
 
-ptx_reg_t srcOperandModifiers(ptx_reg_t opData, operand_info opInfo,
-                              operand_info dstInfo, unsigned type,
-                              ptx_thread_info *thread) {
-  ptx_reg_t result;
-  memory_space *mem = NULL;
-  size_t size;
-  int t;
-  result.u64 = 0;
+ptx_reg_t srcOperandModifiers(ptx_reg_t opData, operand_info opInfo, operand_info dstInfo, unsigned type, ptx_thread_info *thread)
+{
+   ptx_reg_t result;
+   memory_space *mem = NULL;
+   size_t size;
+   int t;
+   result.u64=0;
 
-  // complete other cases for reading from memory, such as reading from other
-  // const memory
-  if (opInfo.get_addr_space() == global_space) {
-    mem = thread->get_global_memory();
-    type_info_key::type_decode(type, size, t);
-    mem->read(opData.u32, size / 8, &result.u64);
-    if (type == S16_TYPE || type == S32_TYPE)
-      sign_extend(result, size, dstInfo);
-  } else if (opInfo.get_addr_space() == shared_space) {
-    mem = thread->m_shared_mem;
-    type_info_key::type_decode(type, size, t);
-    mem->read(opData.u32, size / 8, &result.u64);
+   //complete other cases for reading from memory, such as reading from other const memory
+   if(opInfo.get_addr_space() == global_space)
+   {
+       mem = thread->get_global_memory();
+       type_info_key::type_decode(type,size,t);
+       mem->read(opData.u32,size/8,&result.u64);
+       if( type == S16_TYPE || type == S32_TYPE ) 
+         sign_extend(result,size,dstInfo);
+   }
+   else if(opInfo.get_addr_space() == shared_space)
+   {
+       mem = thread->m_shared_mem;
+       type_info_key::type_decode(type,size,t);
+       mem->read(opData.u32,size/8,&result.u64);
 
-    if (type == S16_TYPE || type == S32_TYPE)
-      sign_extend(result, size, dstInfo);
+       if( type == S16_TYPE || type == S32_TYPE ) 
+         sign_extend(result,size,dstInfo);
 
-  } else if (opInfo.get_addr_space() == const_space) {
-    mem = thread->get_global_memory();
-    type_info_key::type_decode(type, size, t);
+   }
+   else if(opInfo.get_addr_space() == const_space)
+   {
+       mem = thread->get_global_memory();
+       type_info_key::type_decode(type,size,t);
 
-    mem->read((opData.u32 + opInfo.get_const_mem_offset()), size / 8,
-              &result.u64);
+       mem->read((opData.u32 + opInfo.get_const_mem_offset()),size/8,&result.u64);
 
-    if (type == S16_TYPE || type == S32_TYPE)
-      sign_extend(result, size, dstInfo);
-  } else {
-    result = opData;
-  }
+       if( type == S16_TYPE || type == S32_TYPE ) 
+         sign_extend(result,size,dstInfo);
+   }
+   else
+   {
+       result = opData;
+   }
 
-  if (opInfo.get_operand_lohi() == 1) {
-    result.u64 = result.u64 & 0xFFFF;
-  } else if (opInfo.get_operand_lohi() == 2) {
-    result.u64 = (result.u64 >> 16) & 0xFFFF;
-  }
+   if(opInfo.get_operand_lohi() == 1)
+   {
+        result.u64 = result.u64 & 0xFFFF;
+   }
+   else if(opInfo.get_operand_lohi() == 2)
+   {
+        result.u64 = (result.u64>>16) & 0xFFFF;
+   }
 
-  if (opInfo.get_operand_neg() == true) {
-    result.f32 = -result.f32;
-  }
+   if(opInfo.get_operand_neg() == true) {
+      result.f32 = -result.f32;
+   }
 
-  return result;
+   return result;
 }
+

--- a/src/cuda-sim/instructions.cc
+++ b/src/cuda-sim/instructions.cc
@@ -8,51 +8,51 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#include "instructions.h"
 #include "half.h"
 #include "half.hpp"
-#include "instructions.h"
-#include "ptx_ir.h"
 #include "opcodes.h"
+#include "ptx_ir.h"
 #include "ptx_sim.h"
-typedef void * yyscan_t;
+typedef void *yyscan_t;
 class ptx_recognizer;
-#include "ptx.tab.h"
-#include <stdlib.h>
-#include <math.h>
-#include <cmath>
+#include <assert.h>
 #include <fenv.h>
-#include "cuda-math.h"
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <cmath>
+#include <map>
+#include <sstream>
+#include <string>
 #include "../abstract_hardware_model.h"
-#include "ptx_loader.h"
-#include "cuda_device_printf.h"
 #include "../gpgpu-sim/gpu-sim.h"
 #include "../gpgpu-sim/shader.h"
-#include <assert.h>
-#include <string.h>
-#include <sstream>
-#include <stdio.h>
-#include <string>
-#include <map>
-#include <stdlib.h>
+#include "cuda-math.h"
+#include "cuda_device_printf.h"
+#include "ptx.tab.h"
+#include "ptx_loader.h"
 
-//Jin: include device runtime for CDP
+// Jin: include device runtime for CDP
 #include "cuda_device_runtime.h"
 
 #include <stdarg.h>
@@ -60,5629 +60,6420 @@ class ptx_recognizer;
 
 using half_float::half;
 
-
-
 const char *g_opcode_string[NUM_OPCODES] = {
-#define OP_DEF(OP,FUNC,STR,DST,CLASSIFICATION) STR,
-#define OP_W_DEF(OP,FUNC,STR,DST,CLASSIFICATION) STR,
+#define OP_DEF(OP, FUNC, STR, DST, CLASSIFICATION) STR,
+#define OP_W_DEF(OP, FUNC, STR, DST, CLASSIFICATION) STR,
 #include "opcodes.def"
 #undef OP_DEF
 #undef OP_W_DEF
 };
-//Using profiled information::check the TensorCoreMatrixArrangement.xls for details
-unsigned thread_group_offset(int thread,unsigned  wmma_type,unsigned wmma_layout,unsigned type,int stride){
+// Using profiled information::check the TensorCoreMatrixArrangement.xls for
+// details
+unsigned thread_group_offset(int thread, unsigned wmma_type,
+                             unsigned wmma_layout, unsigned type, int stride) {
+  unsigned offset;
+  unsigned load_a_row[8] = {0, 128, 0, 128, 64, 192, 64, 192};
+  unsigned load_a_col[8] = {0, 8, 0, 8, 4, 12, 4, 12};
+  unsigned load_b_row[8] = {0, 8, 0, 8, 4, 12, 4, 12};
+  unsigned load_b_col[8] = {0, 128, 0, 128, 64, 192, 64, 192};
+  unsigned load_c_float_row[8] = {0, 128, 8, 136, 64, 192, 72, 200};
+  unsigned load_c_float_col[8] = {0, 8, 128, 136, 4, 12, 132, 140};
+  unsigned load_c_half_row[8] = {0, 128, 8, 136, 64, 192, 72, 200};
+  unsigned load_c_half_col[8] = {0, 8, 128, 136, 4, 12, 132, 140};
+  unsigned thread_group = thread / 4;
+  unsigned in_tg_index = thread % 4;
 
-	unsigned offset;
-	unsigned load_a_row[8]={0,128,0,128,64,192,64,192};
-	unsigned load_a_col[8]={0,8,0,8,4,12,4,12};
-	unsigned load_b_row[8]={0,8,0,8,4,12,4,12};
-	unsigned load_b_col[8]={0,128,0,128,64,192,64,192};
-	unsigned load_c_float_row[8]={0,128,8,136,64,192,72,200};	
-	unsigned load_c_float_col[8]={0,8,128,136,4,12,132,140};	
-	unsigned load_c_half_row[8]={0,128,8,136,64,192,72,200};	
-	unsigned load_c_half_col[8]={0,8,128,136,4,12,132,140};	
-	unsigned thread_group =	thread/4;
-	unsigned in_tg_index  =	thread%4;
+  switch (wmma_type) {
+    case LOAD_A:
+      if (wmma_layout == ROW)
+        offset = load_a_row[thread_group] + 16 * in_tg_index;
+      else
+        offset = load_a_col[thread_group] + 16 * in_tg_index;
+      break;
 
-	switch(wmma_type){
-		case LOAD_A:
-				if(wmma_layout==ROW)
-					offset=load_a_row[thread_group]+16*in_tg_index;
-				else
-					offset=load_a_col[thread_group]+16*in_tg_index;
-			break;
+    case LOAD_B:
+      if (wmma_layout == ROW)
+        offset = load_b_row[thread_group] + 16 * in_tg_index;
+      else
+        offset = load_b_col[thread_group] + 16 * in_tg_index;
+      break;
 
+    case LOAD_C:
+    case STORE_D:
+      if (type == F16_TYPE) {
+        if (wmma_layout == ROW)
+          offset = load_c_half_row[thread_group] + 16 * in_tg_index;
+        else
+          offset = load_c_half_col[thread_group] + in_tg_index;
+      } else {
+        if (wmma_layout == ROW)
+          offset = load_c_float_row[thread_group];
+        else
+          offset = load_c_float_col[thread_group];
 
-		case LOAD_B:
-				if(wmma_layout==ROW)
-					offset=load_b_row[thread_group]+16*in_tg_index;
-				else	
-					offset=load_b_col[thread_group]+16*in_tg_index;
-			break;	
+        switch (in_tg_index) {
+          case 0:
+            break;
+          case 1:
+            if (wmma_layout == ROW)
+              offset += 16;
+            else
+              offset += 1;
+            break;
+          case 2:
+            if (wmma_layout == ROW)
+              offset += 2;
+            else
+              offset += 32;
+            break;
+          case 3:
+            if (wmma_layout == ROW)
+              offset += 18;
+            else
+              offset += 33;
+            break;
+          default:
+            abort();
+        }
+      }
+      break;
 
-		case LOAD_C:
-		case STORE_D:
-			if(type==F16_TYPE){
-				if(wmma_layout==ROW)
-					offset=load_c_half_row[thread_group]+16*in_tg_index;
-				else
-					offset=load_c_half_col[thread_group]+in_tg_index;
-			}
-			else{
-				if(wmma_layout==ROW)
-					offset=load_c_float_row[thread_group];
-				else
-					offset=load_c_float_col[thread_group];
-
-				switch(in_tg_index){
-					case 0:
-						break;
-					case 1:
-						if(wmma_layout==ROW)
-							offset+=16;
-						else
-							offset+=1;
-						break;
-					case 2:
-						if(wmma_layout==ROW)
-							offset+=2;
-						else
-							offset+=32;
-						break;
-					case 3:
-						if(wmma_layout==ROW)
-							offset+=18;
-						else
-							offset+=33;
-						break;
-					default:
-						abort();
-				}
-			}
-			break;	
-
-         	default:
-         	   abort();
-		
-	}
-	offset = (offset/16)*stride+offset%16;
-	return offset;
+    default:
+      abort();
+  }
+  offset = (offset / 16) * stride + offset % 16;
+  return offset;
 }
 
-int acc_float_offset(int index,int wmma_layout,int stride){
+int acc_float_offset(int index, int wmma_layout, int stride) {
+  int c_row_offset[] = {0, 1, 32, 33, 4, 5, 36, 37};
+  int c_col_offset[] = {0, 16, 2, 18, 64, 80, 66, 82};
+  int offset;
 
-	int c_row_offset[]={0,1,32,33,4,5,36,37};
-	int c_col_offset[]={0,16,2,18,64,80,66,82};
-	int offset;
-	
-	
-	if(wmma_layout==ROW)
-		offset=c_row_offset[index];
-	else if(wmma_layout==COL)
-		offset=c_col_offset[index];
-	else{
-		printf("wrong layout");
-		abort();
-	}
-	offset = (offset/16)*stride+offset%16;
-	return offset;
+  if (wmma_layout == ROW)
+    offset = c_row_offset[index];
+  else if (wmma_layout == COL)
+    offset = c_col_offset[index];
+  else {
+    printf("wrong layout");
+    abort();
+  }
+  offset = (offset / 16) * stride + offset % 16;
+  return offset;
 }
 
-void inst_not_implemented( const ptx_instruction * pI ) ;
-ptx_reg_t srcOperandModifiers(ptx_reg_t opData, operand_info opInfo, operand_info dstInfo, unsigned type, ptx_thread_info *thread);
+void inst_not_implemented(const ptx_instruction *pI);
+ptx_reg_t srcOperandModifiers(ptx_reg_t opData, operand_info opInfo,
+                              operand_info dstInfo, unsigned type,
+                              ptx_thread_info *thread);
 
-void sign_extend( ptx_reg_t &data, unsigned src_size, const operand_info &dst );
+void sign_extend(ptx_reg_t &data, unsigned src_size, const operand_info &dst);
 
-void ptx_thread_info::set_reg( const symbol *reg, const ptx_reg_t &value ) 
-{
-   assert( reg != NULL );
-   if( reg->name() == "_" ) return;
-   assert( !m_regs.empty() );
-   assert( reg->uid() > 0 );
-   m_regs.back()[ reg ] = value;
-   if (m_enable_debug_trace ) 
-      m_debug_trace_regs_modified.back()[ reg ] = value;
-   m_last_set_operand_value = value;
+void ptx_thread_info::set_reg(const symbol *reg, const ptx_reg_t &value) {
+  assert(reg != NULL);
+  if (reg->name() == "_") return;
+  assert(!m_regs.empty());
+  assert(reg->uid() > 0);
+  m_regs.back()[reg] = value;
+  if (m_enable_debug_trace) m_debug_trace_regs_modified.back()[reg] = value;
+  m_last_set_operand_value = value;
 }
 
-void ptx_thread_info::print_reg_thread(char * fname)
-{
-
-  FILE *fp= fopen(fname,"w");
-  assert(fp!=NULL);
+void ptx_thread_info::print_reg_thread(char *fname) {
+  FILE *fp = fopen(fname, "w");
+  assert(fp != NULL);
 
   int size = m_regs.size();
-  
-  if(size>0)
-  {  
-  reg_map_t reg = m_regs.back();
-  
-      reg_map_t::const_iterator it;
-      for (it = reg.begin(); it != reg.end(); ++it) 
-        {
-          const std::string &name = it->first->name();
-          const std::string &dec= it->first->decl_location();
-          unsigned size = it->first->get_size_in_bytes();
-          fprintf(fp,"%s %llu %s %d\n", name.c_str(), it->second, dec.c_str(), size);
-          
-        }
-   //m_regs.pop_back();     
+
+  if (size > 0) {
+    reg_map_t reg = m_regs.back();
+
+    reg_map_t::const_iterator it;
+    for (it = reg.begin(); it != reg.end(); ++it) {
+      const std::string &name = it->first->name();
+      const std::string &dec = it->first->decl_location();
+      unsigned size = it->first->get_size_in_bytes();
+      fprintf(fp, "%s %llu %s %d\n", name.c_str(), it->second, dec.c_str(),
+              size);
+    }
+    // m_regs.pop_back();
   }
   fclose(fp);
+}
 
+void ptx_thread_info::resume_reg_thread(char *fname, symbol_table *symtab) {
+  FILE *fp2 = fopen(fname, "r");
+  assert(fp2 != NULL);
+  // m_regs.push_back( reg_map_t() );
+  char line[200];
+  while (fgets(line, sizeof line, fp2) != NULL) {
+    symbol *reg;
+    char *pch;
+    pch = strtok(line, " ");
+    char *name = pch;
+    reg = symtab->lookup(name);
+    ptx_reg_t data;
+    pch = strtok(NULL, " ");
+    data = atoi(pch);
+    pch = strtok(NULL, " ");
+    pch = strtok(NULL, " ");
+    m_regs.back()[reg] = data;
+  }
+  fclose(fp2);
+}
+
+ptx_reg_t ptx_thread_info::get_reg(const symbol *reg) {
+  static bool unfound_register_warned = false;
+  assert(reg != NULL);
+  assert(!m_regs.empty());
+  reg_map_t::iterator regs_iter = m_regs.back().find(reg);
+  if (regs_iter == m_regs.back().end()) {
+    assert(reg->type()->get_key().is_reg());
+    const std::string &name = reg->name();
+    unsigned call_uid = m_callstack.back().m_call_uid;
+    ptx_reg_t uninit_reg;
+    uninit_reg.u32 = 0x0;
+    set_reg(reg, uninit_reg);  // give it a value since we are going to warn the
+                               // user anyway
+    std::string file_loc = get_location();
+    if (!unfound_register_warned) {
+      printf(
+          "GPGPU-Sim PTX: WARNING (%s) ** reading undefined register \'%s\' "
+          "(cuid:%u). Setting to 0X00000000. This is okay if you are "
+          "simulating the native ISA"
+          "\n",
+          file_loc.c_str(), name.c_str(), call_uid);
+      unfound_register_warned = true;
+    }
+    regs_iter = m_regs.back().find(reg);
+  }
+  if (m_enable_debug_trace)
+    m_debug_trace_regs_read.back()[reg] = regs_iter->second;
+  return regs_iter->second;
+}
+
+ptx_reg_t ptx_thread_info::get_operand_value(const operand_info &op,
+                                             operand_info dstInfo,
+                                             unsigned opType,
+                                             ptx_thread_info *thread,
+                                             int derefFlag) {
+  ptx_reg_t result, tmp;
+
+  if (op.get_double_operand_type() == 0) {
+    if (((opType != BB128_TYPE) && (opType != BB64_TYPE) &&
+         (opType != FF64_TYPE)) ||
+        (op.get_addr_space() != undefined_space)) {
+      if (op.is_reg()) {
+        result = get_reg(op.get_symbol());
+      } else if (op.is_builtin()) {
+        result.u32 = get_builtin(op.get_int(), op.get_addr_offset());
+      } else if (op.is_immediate_address()) {
+        result.u64 = op.get_addr_offset();
+      } else if (op.is_memory_operand()) {
+        // a few options here...
+        const symbol *sym = op.get_symbol();
+        const type_info *type = sym->type();
+        const type_info_key &info = type->get_key();
+
+        if (info.is_reg()) {
+          const symbol *name = op.get_symbol();
+          result.u64 = get_reg(name).u64 + op.get_addr_offset();
+        } else if (info.is_param_kernel()) {
+          result.u64 = sym->get_address() + op.get_addr_offset();
+        } else if (info.is_param_local()) {
+          result.u64 = sym->get_address() + op.get_addr_offset();
+        } else if (info.is_global()) {
+          assert(op.get_addr_offset() == 0);
+          result.u64 = sym->get_address();
+        } else if (info.is_local()) {
+          result.u64 = sym->get_address() + op.get_addr_offset();
+        } else if (info.is_const()) {
+          result.u64 = sym->get_address() + op.get_addr_offset();
+        } else if (op.is_shared()) {
+          result.u64 = op.get_symbol()->get_address() + op.get_addr_offset();
+        } else if (op.is_sstarr()) {
+          result.u64 = op.get_symbol()->get_address() + op.get_addr_offset();
+        } else {
+          const char *name = op.name().c_str();
+          printf(
+              "GPGPU-Sim PTX: ERROR ** get_operand_value : unknown memory "
+              "operand type for %s\n",
+              name);
+          abort();
+        }
+
+      } else if (op.is_literal()) {
+        result = op.get_literal_value();
+      } else if (op.is_label()) {
+        result.u64 = op.get_symbol()->get_address();
+      } else if (op.is_shared()) {
+        result.u64 = op.get_symbol()->get_address();
+      } else if (op.is_sstarr()) {
+        result.u64 = op.get_symbol()->get_address();
+      } else if (op.is_const()) {
+        result.u64 = op.get_symbol()->get_address();
+      } else if (op.is_global()) {
+        result.u64 = op.get_symbol()->get_address();
+      } else if (op.is_local()) {
+        result.u64 = op.get_symbol()->get_address();
+      } else if (op.is_function_address()) {
+        result.u64 = (size_t)op.get_symbol()->get_pc();
+      } else if (op.is_param_kernel()) {
+        result.u64 = op.get_symbol()->get_address();
+      } else {
+        const char *name = op.name().c_str();
+        const symbol *sym2 = op.get_symbol();
+        const type_info *type2 = sym2->type();
+        const type_info_key &info2 = type2->get_key();
+        if (info2.is_param_kernel()) {
+          result.u64 = sym2->get_address() + op.get_addr_offset();
+        } else {
+          printf(
+              "GPGPU-Sim PTX: ERROR ** get_operand_value : unknown operand "
+              "type for %s\n",
+              name);
+          assert(0);
+        }
+      }
+
+      if (op.get_operand_lohi() == 1)
+        result.u64 = result.u64 & 0xFFFF;
+      else if (op.get_operand_lohi() == 2)
+        result.u64 = (result.u64 >> 16) & 0xFFFF;
+    } else if (opType == BB128_TYPE) {
+      // b128
+      result.u128.lowest = get_reg(op.vec_symbol(0)).u32;
+      result.u128.low = get_reg(op.vec_symbol(1)).u32;
+      result.u128.high = get_reg(op.vec_symbol(2)).u32;
+      result.u128.highest = get_reg(op.vec_symbol(3)).u32;
+    } else {
+      // bb64 or ff64
+      result.bits.ls = get_reg(op.vec_symbol(0)).u32;
+      result.bits.ms = get_reg(op.vec_symbol(1)).u32;
+    }
+  } else if (op.get_double_operand_type() == 1) {
+    ptx_reg_t firstHalf, secondHalf;
+    firstHalf.u64 = get_reg(op.vec_symbol(0)).u64;
+    secondHalf.u64 = get_reg(op.vec_symbol(1)).u64;
+    if (op.get_operand_lohi() == 1)
+      secondHalf.u64 = secondHalf.u64 & 0xFFFF;
+    else if (op.get_operand_lohi() == 2)
+      secondHalf.u64 = (secondHalf.u64 >> 16) & 0xFFFF;
+    result.u64 = firstHalf.u64 + secondHalf.u64;
+  } else if (op.get_double_operand_type() == 2) {
+    // s[reg1 += reg2]
+    // reg1 is incremented after value is returned: the value returned is
+    // s[reg1]
+    ptx_reg_t firstHalf, secondHalf;
+    firstHalf.u64 = get_reg(op.vec_symbol(0)).u64;
+    secondHalf.u64 = get_reg(op.vec_symbol(1)).u64;
+    if (op.get_operand_lohi() == 1)
+      secondHalf.u64 = secondHalf.u64 & 0xFFFF;
+    else if (op.get_operand_lohi() == 2)
+      secondHalf.u64 = (secondHalf.u64 >> 16) & 0xFFFF;
+    result.u64 = firstHalf.u64;
+    firstHalf.u64 = firstHalf.u64 + secondHalf.u64;
+    set_reg(op.vec_symbol(0), firstHalf);
+  } else if (op.get_double_operand_type() == 3) {
+    // s[reg += immediate]
+    // reg is incremented after value is returned: the value returned is s[reg]
+    ptx_reg_t firstHalf;
+    firstHalf.u64 = get_reg(op.get_symbol()).u64;
+    result.u64 = firstHalf.u64;
+    firstHalf.u64 = firstHalf.u64 + op.get_addr_offset();
+    set_reg(op.get_symbol(), firstHalf);
   }
 
-void ptx_thread_info::resume_reg_thread(char * fname, symbol_table * symtab)
-{
+  ptx_reg_t finalResult;
+  memory_space *mem = NULL;
+  size_t size = 0;
+  int t = 0;
+  finalResult.u64 = 0;
 
+  // complete other cases for reading from memory, such as reading from other
+  // const memory
+  if ((op.get_addr_space() == global_space) && (derefFlag)) {
+    // global memory - g[4], g[$r0]
+    mem = thread->get_global_memory();
+    type_info_key::type_decode(opType, size, t);
+    mem->read(result.u32, size / 8, &finalResult.u128);
+    thread->m_last_effective_address = result.u32;
+    thread->m_last_memory_space = global_space;
 
-      FILE * fp2 = fopen(fname, "r");
-      assert(fp2!=NULL);
-      //m_regs.push_back( reg_map_t() );
-      char line [ 200 ];
-      while ( fgets ( line, sizeof line, fp2 ) != NULL )
-      {
-          symbol *reg;
-          char * pch;
-          pch = strtok (line," ");
-          char * name =pch;
-          reg= symtab->lookup(name);
-          ptx_reg_t data;
-          pch = strtok (NULL," "); 
-          data = atoi(pch);
-          pch = strtok (NULL," ");
-          pch = strtok (NULL," ");
-          m_regs.back()[reg] = data;
-      }
-      fclose ( fp2 );
-}
-    
+    if (opType == S16_TYPE || opType == S32_TYPE)
+      sign_extend(finalResult, size, dstInfo);
+  } else if ((op.get_addr_space() == shared_space) && (derefFlag)) {
+    // shared memory - s[4], s[$r0]
+    mem = thread->m_shared_mem;
+    type_info_key::type_decode(opType, size, t);
+    mem->read(result.u32, size / 8, &finalResult.u128);
+    thread->m_last_effective_address = result.u32;
+    thread->m_last_memory_space = shared_space;
 
-ptx_reg_t ptx_thread_info::get_reg( const symbol *reg )
-{
-   static bool unfound_register_warned = false;
-   assert( reg != NULL );
-   assert( !m_regs.empty() );
-   reg_map_t::iterator regs_iter = m_regs.back().find(reg);
-   if (regs_iter == m_regs.back().end()) {
-      assert( reg->type()->get_key().is_reg() );
-      const std::string &name = reg->name();
-      unsigned call_uid = m_callstack.back().m_call_uid;
-      ptx_reg_t uninit_reg;
-      uninit_reg.u32 = 0x0;
-      set_reg(reg, uninit_reg); // give it a value since we are going to warn the user anyway
-      std::string file_loc = get_location();
-      if( !unfound_register_warned ) {
-          printf("GPGPU-Sim PTX: WARNING (%s) ** reading undefined register \'%s\' (cuid:%u). Setting to 0X00000000. This is okay if you are simulating the native ISA"
-        		  "\n",
-                 file_loc.c_str(), name.c_str(), call_uid );
-          unfound_register_warned = true;
-      }
-      regs_iter = m_regs.back().find(reg);
-   }
-   if (m_enable_debug_trace ) 
-      m_debug_trace_regs_read.back()[ reg ] = regs_iter->second;
-   return regs_iter->second;
-}
+    if (opType == S16_TYPE || opType == S32_TYPE)
+      sign_extend(finalResult, size, dstInfo);
+  } else if ((op.get_addr_space() == const_space) && (derefFlag)) {
+    // const memory - ce0c1[4], ce0c1[$r0]
+    mem = thread->get_global_memory();
+    type_info_key::type_decode(opType, size, t);
+    mem->read((result.u32 + op.get_const_mem_offset()), size / 8,
+              &finalResult.u128);
+    thread->m_last_effective_address = result.u32;
+    thread->m_last_memory_space = const_space;
+    if (opType == S16_TYPE || opType == S32_TYPE)
+      sign_extend(finalResult, size, dstInfo);
+  } else if ((op.get_addr_space() == local_space) && (derefFlag)) {
+    // local memory - l0[4], l0[$r0]
+    mem = thread->m_local_mem;
+    type_info_key::type_decode(opType, size, t);
+    mem->read(result.u32, size / 8, &finalResult.u128);
+    thread->m_last_effective_address = result.u32;
+    thread->m_last_memory_space = local_space;
+    if (opType == S16_TYPE || opType == S32_TYPE)
+      sign_extend(finalResult, size, dstInfo);
+  } else {
+    finalResult = result;
+  }
 
-ptx_reg_t ptx_thread_info::get_operand_value( const operand_info &op, operand_info dstInfo, unsigned opType, ptx_thread_info *thread, int derefFlag )
-{
-   ptx_reg_t result, tmp;
-
-
-   if(op.get_double_operand_type() == 0) {
-      if(((opType != BB128_TYPE) && (opType != BB64_TYPE) && (opType != FF64_TYPE)) || (op.get_addr_space() != undefined_space)) {
-         if ( op.is_reg() ) {
-            result = get_reg( op.get_symbol() );
-         } else if ( op.is_builtin()) {
-            result.u32 = get_builtin( op.get_int(), op.get_addr_offset() );
-         } else  if(op.is_immediate_address()){
-    		 result.u64 = op.get_addr_offset();
-    	 } else if ( op.is_memory_operand() ) {
-            // a few options here...
-            const symbol *sym = op.get_symbol();
-            const type_info *type = sym->type();
-            const type_info_key &info = type->get_key();
-
-            if ( info.is_reg() ) {
-               const symbol *name = op.get_symbol();
-               result.u64 = get_reg(name).u64 + op.get_addr_offset(); 
-            } else if ( info.is_param_kernel() ) {
-               result.u64 = sym->get_address() + op.get_addr_offset();
-            } else if ( info.is_param_local() ) {
-               result.u64 = sym->get_address() + op.get_addr_offset();
-            } else if ( info.is_global() ) {
-               assert( op.get_addr_offset() == 0 );
-               result.u64 = sym->get_address();
-            } else if ( info.is_local() ) {
-               result.u64 = sym->get_address() + op.get_addr_offset();
-            } else if ( info.is_const() ) {
-               result.u64 = sym->get_address() + op.get_addr_offset();
-            } else if ( op.is_shared() ) {
-               result.u64 = op.get_symbol()->get_address() + op.get_addr_offset();
-            } else if ( op.is_sstarr() ) {
-               result.u64 = op.get_symbol()->get_address() + op.get_addr_offset();
-            } else {
-                 const char *name = op.name().c_str();
-	    	printf("GPGPU-Sim PTX: ERROR ** get_operand_value : unknown memory operand type for %s\n", name );
-            	abort();
-            }
-
-         } else if ( op.is_literal() ) {
-            result = op.get_literal_value();
-         } else if ( op.is_label() ) {
-            result.u64 = op.get_symbol()->get_address();
-         } else if ( op.is_shared() ) {
-            result.u64 = op.get_symbol()->get_address();
-         } else if ( op.is_sstarr() ) {
-            result.u64 = op.get_symbol()->get_address();
-         } else if ( op.is_const() ) {
-            result.u64 = op.get_symbol()->get_address();
-         } else if ( op.is_global() ) {
-            result.u64 = op.get_symbol()->get_address();
-         } else if ( op.is_local() ) {
-            result.u64 = op.get_symbol()->get_address();
-         } else if ( op.is_function_address() ) {
-            result.u64 = (size_t)op.get_symbol()->get_pc();
-	 } else if ( op.is_param_kernel()) {
-            result.u64 = op.get_symbol()->get_address();
-         }else {
-            const char *name = op.name().c_str();
-            const symbol *sym2 = op.get_symbol();
-            const type_info *type2 = sym2->type();
-            const type_info_key &info2 = type2->get_key();
-            if ( info2.is_param_kernel() ) {
-               result.u64 = sym2->get_address()+ op.get_addr_offset();
-            }
-	    else{ 
-             printf("GPGPU-Sim PTX: ERROR ** get_operand_value : unknown operand type for %s\n", name );
-             assert(0);
-	    }
-         }
-
-         if(op.get_operand_lohi() == 1) 
-              result.u64 = result.u64 & 0xFFFF;
-         else if(op.get_operand_lohi() == 2) 
-              result.u64 = (result.u64>>16) & 0xFFFF;
-      } else if (opType == BB128_TYPE) {
-          // b128
-          result.u128.lowest = get_reg( op.vec_symbol(0) ).u32;
-          result.u128.low = get_reg( op.vec_symbol(1) ).u32;
-          result.u128.high = get_reg( op.vec_symbol(2) ).u32;
-          result.u128.highest = get_reg( op.vec_symbol(3) ).u32;
-      } else {
-          // bb64 or ff64
-          result.bits.ls = get_reg( op.vec_symbol(0) ).u32;
-          result.bits.ms = get_reg( op.vec_symbol(1) ).u32;
-      }
-   } else if (op.get_double_operand_type() == 1) {
-      ptx_reg_t firstHalf, secondHalf;
-      firstHalf.u64 = get_reg( op.vec_symbol(0) ).u64;
-      secondHalf.u64 = get_reg( op.vec_symbol(1) ).u64;
-      if(op.get_operand_lohi() == 1)
-           secondHalf.u64 = secondHalf.u64 & 0xFFFF;
-      else if(op.get_operand_lohi() == 2)
-           secondHalf.u64 = (secondHalf.u64>>16) & 0xFFFF;
-      result.u64 = firstHalf.u64 + secondHalf.u64;
-   } else if (op.get_double_operand_type() == 2) {
-      // s[reg1 += reg2]
-      // reg1 is incremented after value is returned: the value returned is s[reg1]
-      ptx_reg_t firstHalf, secondHalf;
-      firstHalf.u64 = get_reg(op.vec_symbol(0)).u64;
-      secondHalf.u64 = get_reg(op.vec_symbol(1)).u64;
-      if(op.get_operand_lohi() == 1)
-           secondHalf.u64 = secondHalf.u64 & 0xFFFF;
-      else if(op.get_operand_lohi() == 2)
-           secondHalf.u64 = (secondHalf.u64>>16) & 0xFFFF;
-      result.u64 = firstHalf.u64;
-      firstHalf.u64 = firstHalf.u64 + secondHalf.u64;
-      set_reg(op.vec_symbol(0),firstHalf);
-   } else if (op.get_double_operand_type() == 3) {
-      // s[reg += immediate]
-      // reg is incremented after value is returned: the value returned is s[reg]
-      ptx_reg_t firstHalf;
-      firstHalf.u64 = get_reg(op.get_symbol()).u64;
-      result.u64 = firstHalf.u64;
-      firstHalf.u64 = firstHalf.u64 + op.get_addr_offset();
-      set_reg(op.get_symbol(),firstHalf);
-   }
-
-   ptx_reg_t finalResult;
-   memory_space *mem = NULL;
-   size_t size=0;
-   int t=0;
-   finalResult.u64=0;
-
-   //complete other cases for reading from memory, such as reading from other const memory
-   if((op.get_addr_space() == global_space)&&(derefFlag)) {
-       // global memory - g[4], g[$r0]
-       mem = thread->get_global_memory();
-       type_info_key::type_decode(opType,size,t);
-       mem->read(result.u32,size/8,&finalResult.u128);
-       thread->m_last_effective_address = result.u32;
-       thread->m_last_memory_space = global_space;
-
-       if( opType == S16_TYPE || opType == S32_TYPE )
-         sign_extend(finalResult,size,dstInfo);
-   } else if((op.get_addr_space() == shared_space)&&(derefFlag)) {
-      // shared memory - s[4], s[$r0]
-       mem = thread->m_shared_mem;
-       type_info_key::type_decode(opType,size,t);
-       mem->read(result.u32,size/8,&finalResult.u128);
-       thread->m_last_effective_address = result.u32;
-       thread->m_last_memory_space = shared_space;
-
-       if( opType == S16_TYPE || opType == S32_TYPE ) 
-         sign_extend(finalResult,size,dstInfo);
-   } else if((op.get_addr_space() == const_space)&&(derefFlag)) {
-      // const memory - ce0c1[4], ce0c1[$r0]
-       mem = thread->get_global_memory();
-       type_info_key::type_decode(opType,size,t);
-       mem->read((result.u32 + op.get_const_mem_offset()),size/8,&finalResult.u128);
-       thread->m_last_effective_address = result.u32;
-       thread->m_last_memory_space = const_space;
-       if( opType == S16_TYPE || opType == S32_TYPE )
-         sign_extend(finalResult,size,dstInfo);
-   } else if((op.get_addr_space() == local_space)&&(derefFlag)) {
-      // local memory - l0[4], l0[$r0]
-       mem = thread->m_local_mem;
-       type_info_key::type_decode(opType,size,t);
-       mem->read(result.u32,size/8,&finalResult.u128);
-       thread->m_last_effective_address = result.u32;
-       thread->m_last_memory_space = local_space;
-       if( opType == S16_TYPE || opType == S32_TYPE ) 
-         sign_extend(finalResult,size,dstInfo);
-   } else {
-       finalResult = result;
-   }
-
-   if((op.get_operand_neg() == true)&&(derefFlag)) {
-      switch( opType ) {
+  if ((op.get_operand_neg() == true) && (derefFlag)) {
+    switch (opType) {
       // Default to f32 for now, need to add support for others
       case S8_TYPE:
       case U8_TYPE:
       case B8_TYPE:
-         finalResult.s8 = -finalResult.s8;
-         break;
+        finalResult.s8 = -finalResult.s8;
+        break;
       case S16_TYPE:
       case U16_TYPE:
       case B16_TYPE:
-         finalResult.s16 = -finalResult.s16;
-         break;
+        finalResult.s16 = -finalResult.s16;
+        break;
       case S32_TYPE:
       case U32_TYPE:
       case B32_TYPE:
-         finalResult.s32 = -finalResult.s32;
-         break;
+        finalResult.s32 = -finalResult.s32;
+        break;
       case S64_TYPE:
       case U64_TYPE:
       case B64_TYPE:
-         finalResult.s64 = -finalResult.s64;
-         break;
+        finalResult.s64 = -finalResult.s64;
+        break;
       case F16_TYPE:
-         finalResult.f16 = -finalResult.f16;
-         break;
+        finalResult.f16 = -finalResult.f16;
+        break;
       case F32_TYPE:
-         finalResult.f32 = -finalResult.f32;
-         break;
+        finalResult.f32 = -finalResult.f32;
+        break;
       case F64_TYPE:
       case FF64_TYPE:
-         finalResult.f64 = -finalResult.f64;
-         break;
+        finalResult.f64 = -finalResult.f64;
+        break;
       default:
-         assert(0);
-      }
-
-   }
-
-   return finalResult;
-
-}
-
-unsigned get_operand_nbits( const operand_info &op )
-{
-   if ( op.is_reg() ) {
-      const symbol *sym = op.get_symbol();
-      const type_info *typ = sym->type();
-      type_info_key t = typ->get_key();
-      switch( t.scalar_type() ) {
-      case PRED_TYPE: 
-         return 1;
-      case B8_TYPE: case S8_TYPE: case U8_TYPE:
-         return 8;
-      case S16_TYPE: case U16_TYPE: case F16_TYPE: case B16_TYPE:
-         return 16;
-      case S32_TYPE: case U32_TYPE: case F32_TYPE: case B32_TYPE:
-         return 32;
-      case S64_TYPE: case U64_TYPE: case F64_TYPE: case B64_TYPE:
-         return 64;
-      default:
-         printf("ERROR: unknown register type\n");
-         fflush(stdout);
-         abort();
-      }
-   } else {
-      printf("ERROR: Need to implement get_operand_nbits() for currently unsupported operand_info type\n");
-      fflush(stdout);
-      abort();
-   }
-
-   return 0;
-}
-
-void ptx_thread_info::get_vector_operand_values( const operand_info &op, ptx_reg_t* ptx_regs, unsigned num_elements )
-{
-   assert( op.is_vector() );
-   assert( num_elements <= 8 );
-
-   for (int idx = num_elements - 1; idx >= 0; --idx) {
-      const symbol *sym = NULL;
-      sym = op.vec_symbol(idx);
-      if( strcmp(sym->name().c_str(),"_") != 0) {
-         reg_map_t::iterator reg_iter = m_regs.back().find(sym);
-         assert( reg_iter != m_regs.back().end() );
-         ptx_regs[idx] = reg_iter->second;
-      }
-   }
-}
-
-void sign_extend( ptx_reg_t &data, unsigned src_size, const operand_info &dst )
-{
-   if( !dst.is_reg() )
-      return;
-   unsigned dst_size = get_operand_nbits( dst );
-   if( src_size >= dst_size ) 
-      return;
-   // src_size < dst_size
-   unsigned long long mask = 1;
-   mask <<= (src_size-1);
-   if( (mask & data.u64) == 0 ) {
-      // no need to sign extend
-      return;
-   }
-   // need to sign extend
-   mask = 1;
-   mask <<= dst_size-src_size;
-   mask -= 1;
-   mask <<= src_size;
-   data.u64 |= mask;
-}
-
-void ptx_thread_info::set_operand_value( const operand_info &dst, const ptx_reg_t &data, unsigned type, ptx_thread_info *thread, const ptx_instruction *pI, int overflow, int carry )
-{
-    thread->set_operand_value( dst, data, type, thread, pI );
-
-    if (dst.get_double_operand_type() == -2)
-    {
-        ptx_reg_t predValue;
-        
-        const symbol *sym = dst.vec_symbol(0);
-        predValue.u64 = (m_regs.back()[ sym ].u64) & ~(0x0C);
-        predValue.u64 |= ((overflow & 0x01)<<3);
-        predValue.u64 |= ((carry & 0x01)<<2);
-
-        set_reg(sym,predValue);
-    }
-    else if (dst.get_double_operand_type() == 0)
-    {
-        //intentionally do nothing
-    }
-    else
-    {
-        printf("Unexpected double destination\n");
         assert(0);
     }
+  }
 
+  return finalResult;
 }
 
-void ptx_thread_info::set_operand_value( const operand_info &dst, const ptx_reg_t &data, unsigned type, ptx_thread_info *thread, const ptx_instruction *pI )
-{
-   ptx_reg_t dstData;
-   memory_space *mem = NULL;
-   size_t size;
-   int t;
+unsigned get_operand_nbits(const operand_info &op) {
+  if (op.is_reg()) {
+    const symbol *sym = op.get_symbol();
+    const type_info *typ = sym->type();
+    type_info_key t = typ->get_key();
+    switch (t.scalar_type()) {
+      case PRED_TYPE:
+        return 1;
+      case B8_TYPE:
+      case S8_TYPE:
+      case U8_TYPE:
+        return 8;
+      case S16_TYPE:
+      case U16_TYPE:
+      case F16_TYPE:
+      case B16_TYPE:
+        return 16;
+      case S32_TYPE:
+      case U32_TYPE:
+      case F32_TYPE:
+      case B32_TYPE:
+        return 32;
+      case S64_TYPE:
+      case U64_TYPE:
+      case F64_TYPE:
+      case B64_TYPE:
+        return 64;
+      default:
+        printf("ERROR: unknown register type\n");
+        fflush(stdout);
+        abort();
+    }
+  } else {
+    printf(
+        "ERROR: Need to implement get_operand_nbits() for currently "
+        "unsupported operand_info type\n");
+    fflush(stdout);
+    abort();
+  }
 
-   type_info_key::type_decode(type,size,t);
-
-   /*complete this section for other cases*/
-   if(dst.get_addr_space() == undefined_space)
-   {
-      ptx_reg_t setValue;
-      setValue.u64 = data.u64;
-
-      // Double destination in set instruction ($p0|$p1) - second is negation of first
-      if (dst.get_double_operand_type() == -1)
-      {
-          ptx_reg_t setValue2;
-          const symbol *name1 = dst.vec_symbol(0);
-          const symbol *name2 = dst.vec_symbol(1);
-
-          if ( (type==F16_TYPE)||(type==F32_TYPE)||(type==F64_TYPE)||(type==FF64_TYPE) ) {
-             setValue2.f32 = (setValue.u64==0)?1.0f:0.0f;
-          } else {
-             setValue2.u32 = (setValue.u64==0)?0xFFFFFFFF:0;
-          }
-
-          set_reg(name1,setValue);
-          set_reg(name2,setValue2);
-      }
-
-      // Double destination in cvt,shr,mul,etc. instruction ($p0|$r4) - second register operand receives data, first predicate operand
-      // is set as $p0=($r4!=0)
-      // Also for Double destination in set instruction ($p0/$r1)
-      else if ((dst.get_double_operand_type() == -2)||(dst.get_double_operand_type() == -3))
-      {
-          ptx_reg_t predValue;
-          const symbol *predName = dst.vec_symbol(0);
-          const symbol *regName = dst.vec_symbol(1);
-          predValue.u64 = 0;
-
-          switch ( type ) {
-          case S8_TYPE:
-              if((setValue.s8 & 0x7F) == 0)
-                  predValue.u64 |= 1;
-              break;
-          case S16_TYPE:
-              if((setValue.s16 & 0x7FFF) == 0)
-                  predValue.u64 |= 1;
-              break;
-          case S32_TYPE:
-              if((setValue.s32 & 0x7FFFFFFF) == 0)
-                  predValue.u64 |= 1;
-              break;
-          case S64_TYPE:
-              if((setValue.s64 & 0x7FFFFFFFFFFFFFFF) == 0)
-                  predValue.u64 |= 1;
-              break;
-          case U8_TYPE:
-          case B8_TYPE:
-              if(setValue.u8 == 0)
-                  predValue.u64 |= 1;
-              break;
-          case U16_TYPE:
-          case B16_TYPE:
-              if(setValue.u16 == 0)
-                  predValue.u64 |= 1;
-              break;
-          case U32_TYPE:
-          case B32_TYPE:
-              if(setValue.u32 == 0)
-                  predValue.u64 |= 1;
-              break;
-          case U64_TYPE:
-          case B64_TYPE:
-              if(setValue.u64 == 0)
-                  predValue.u64 |= 1;
-              break;
-          case F16_TYPE:
-              if(setValue.f16 == 0)
-                  predValue.u64 |= 1;
-              break;
-          case F32_TYPE:
-              if(setValue.f32 == 0)
-                  predValue.u64 |= 1;
-              break;
-          case F64_TYPE:
-          case FF64_TYPE:
-              if(setValue.f64 == 0)
-                  predValue.u64 |= 1;
-              break;
-          default: assert(0); break;
-          }
-
-
-          if ( (type==S8_TYPE)||(type==S16_TYPE)||(type==S32_TYPE)||(type==S64_TYPE)||
-               (type==U8_TYPE)||(type==U16_TYPE)||(type==U32_TYPE)||(type==U64_TYPE)||
-               (type==B8_TYPE)||(type==B16_TYPE)||(type==B32_TYPE)||(type==B64_TYPE)) {
-              if((setValue.u32 & (1<<(size-1))) != 0)
-                  predValue.u64 |= 1<<1;
-          }
-          if ( type==F32_TYPE ) {
-              if(setValue.f32 < 0)
-                  predValue.u64 |= 1<<1;
-          }
-
-          if(dst.get_operand_lohi() == 1)
-          {
-              setValue.u64 = ((m_regs.back()[ regName ].u64) & (~(0xFFFF))) + (data.u64 & 0xFFFF);
-          }
-          else if(dst.get_operand_lohi() == 2)
-          {
-              setValue.u64 = ((m_regs.back()[ regName ].u64) & (~(0xFFFF0000))) + ((data.u64<<16) & 0xFFFF0000);
-          }
-
-          set_reg(predName,predValue);
-          set_reg(regName,setValue);
-      }
-      else if (type == BB128_TYPE)
-      {
-          //b128 stuff here.
-          ptx_reg_t setValue2, setValue3, setValue4;
-          setValue.u64 = 0;
-          setValue2.u64 = 0;
-          setValue3.u64 = 0;
-          setValue4.u64 = 0;
-          setValue.u32 = data.u128.lowest;
-          setValue2.u32 = data.u128.low;
-          setValue3.u32 = data.u128.high;
-          setValue4.u32 = data.u128.highest;
-
-          const symbol *name1, *name2, *name3, *name4 = NULL;
-
-          name1 = dst.vec_symbol(0);
-          name2 = dst.vec_symbol(1);
-          name3 = dst.vec_symbol(2);
-          name4 = dst.vec_symbol(3);
-
-          set_reg(name1,setValue);
-          set_reg(name2,setValue2);
-          set_reg(name3,setValue3);
-          set_reg(name4,setValue4);
-      }
-      else if (type == BB64_TYPE || type == FF64_TYPE)
-      {
-          //ptxplus version of storing 64 bit values to registers stores to two adjacent registers
-          ptx_reg_t setValue2;
-          setValue.u32 = 0;
-          setValue2.u32 = 0;
-
-          setValue.u32 = data.bits.ls;
-          setValue2.u32 = data.bits.ms;
-
-          const symbol *name1, *name2 = NULL;
-
-          name1 = dst.vec_symbol(0);
-          name2 = dst.vec_symbol(1);
-
-          set_reg(name1,setValue);
-          set_reg(name2,setValue2);
-      }
-      else
-      {
-          if(dst.get_operand_lohi() == 1)
-          {
-              setValue.u64 = ((m_regs.back()[ dst.get_symbol() ].u64) & (~(0xFFFF))) + (data.u64 & 0xFFFF);
-          }
-          else if(dst.get_operand_lohi() == 2)
-          {
-              setValue.u64 = ((m_regs.back()[ dst.get_symbol() ].u64) & (~(0xFFFF0000))) + ((data.u64<<16) & 0xFFFF0000);
-          }
-          set_reg(dst.get_symbol(),setValue);
-      }
-   }
-
-   // global memory - g[4], g[$r0]
-   else if(dst.get_addr_space() == global_space)
-   {
-       dstData = thread->get_operand_value(dst, dst, type, thread, 0);
-       mem = thread->get_global_memory();
-       type_info_key::type_decode(type,size,t);
-
-       mem->write(dstData.u32,size/8,&data.u128,thread,pI);
-       thread->m_last_effective_address = dstData.u32;
-       thread->m_last_memory_space = global_space;
-   }
-
-   // shared memory - s[4], s[$r0]
-   else if(dst.get_addr_space() == shared_space)
-   {
-       dstData = thread->get_operand_value(dst, dst, type, thread, 0);
-       mem = thread->m_shared_mem;
-       type_info_key::type_decode(type,size,t);
-
-       mem->write(dstData.u32,size/8,&data.u128,thread,pI);
-       thread->m_last_effective_address = dstData.u32;
-       thread->m_last_memory_space = shared_space;
-   }
-
-   // local memory - l0[4], l0[$r0]
-   else if(dst.get_addr_space() == local_space)
-   {
-       dstData = thread->get_operand_value(dst, dst, type, thread, 0);
-       mem = thread->m_local_mem;
-       type_info_key::type_decode(type,size,t);
-
-       mem->write(dstData.u32,size/8,&data.u128,thread,pI);
-       thread->m_last_effective_address = dstData.u32;
-       thread->m_last_memory_space = local_space;
-   }
-
-   else
-   {
-       printf("Destination stores to unknown location.");
-       assert(0);
-   }
-
-
+  return 0;
 }
 
-void ptx_thread_info::set_vector_operand_values( const operand_info &dst, 
-                                                 const ptx_reg_t &data1, 
-                                                 const ptx_reg_t &data2, 
-                                                 const ptx_reg_t &data3, 
-                                                 const ptx_reg_t &data4 )
-{
-   unsigned num_elements = dst.get_vect_nelem(); 
-   if (num_elements > 0) {
-       set_reg(dst.vec_symbol(0), data1);
-       if (num_elements > 1) {
-           set_reg(dst.vec_symbol(1), data2);
-           if (num_elements > 2) {
-              set_reg(dst.vec_symbol(2), data3);
-              if (num_elements > 3) {
-                 set_reg(dst.vec_symbol(3), data4);
-              }
-           }
-       }
-   }
+void ptx_thread_info::get_vector_operand_values(const operand_info &op,
+                                                ptx_reg_t *ptx_regs,
+                                                unsigned num_elements) {
+  assert(op.is_vector());
+  assert(num_elements <= 8);
 
-   m_last_set_operand_value = data1;
-}
-void ptx_thread_info::set_wmma_vector_operand_values( const operand_info &dst, 
-                                                 const ptx_reg_t &data1, 
-                                                 const ptx_reg_t &data2, 
-                                                 const ptx_reg_t &data3, 
-                                                 const ptx_reg_t &data4, 
-                                                 const ptx_reg_t &data5, 
-                                                 const ptx_reg_t &data6, 
-                                                 const ptx_reg_t &data7, 
-                                                 const ptx_reg_t &data8 )
-{
-   unsigned num_elements = dst.get_vect_nelem(); 
-   if (num_elements == 8) {
-       set_reg(dst.vec_symbol(0), data1);
-       set_reg(dst.vec_symbol(1), data2);
-       set_reg(dst.vec_symbol(2), data3);
-       set_reg(dst.vec_symbol(3), data4);
-       set_reg(dst.vec_symbol(4), data5);
-       set_reg(dst.vec_symbol(5), data6);
-       set_reg(dst.vec_symbol(6), data7);
-       set_reg(dst.vec_symbol(7), data8);
-   }
-   else{
-	printf("error:set_wmma_vector_operands");
-   }
-
-   m_last_set_operand_value = data8;
+  for (int idx = num_elements - 1; idx >= 0; --idx) {
+    const symbol *sym = NULL;
+    sym = op.vec_symbol(idx);
+    if (strcmp(sym->name().c_str(), "_") != 0) {
+      reg_map_t::iterator reg_iter = m_regs.back().find(sym);
+      assert(reg_iter != m_regs.back().end());
+      ptx_regs[idx] = reg_iter->second;
+    }
+  }
 }
 
-#define my_abs(a) (((a)<0)?(-a):(a))
+void sign_extend(ptx_reg_t &data, unsigned src_size, const operand_info &dst) {
+  if (!dst.is_reg()) return;
+  unsigned dst_size = get_operand_nbits(dst);
+  if (src_size >= dst_size) return;
+  // src_size < dst_size
+  unsigned long long mask = 1;
+  mask <<= (src_size - 1);
+  if ((mask & data.u64) == 0) {
+    // no need to sign extend
+    return;
+  }
+  // need to sign extend
+  mask = 1;
+  mask <<= dst_size - src_size;
+  mask -= 1;
+  mask <<= src_size;
+  data.u64 |= mask;
+}
 
-#define MY_MAX_I(a,b) (a > b) ? a : b
-#define MY_MAX_F(a,b) isNaN(a) ? b : isNaN(b) ? a : (a > b) ? a : b
+void ptx_thread_info::set_operand_value(const operand_info &dst,
+                                        const ptx_reg_t &data, unsigned type,
+                                        ptx_thread_info *thread,
+                                        const ptx_instruction *pI, int overflow,
+                                        int carry) {
+  thread->set_operand_value(dst, data, type, thread, pI);
 
-#define MY_MIN_I(a,b) (a < b) ? a : b
-#define MY_MIN_F(a,b) isNaN(a) ? b : isNaN(b) ? a : (a < b) ? a : b
+  if (dst.get_double_operand_type() == -2) {
+    ptx_reg_t predValue;
 
-#define MY_INC_I(a,b) (a >= b) ? 0 : a+1
-#define MY_DEC_I(a,b) ((a == 0) || (a > b)) ? b : a-1
+    const symbol *sym = dst.vec_symbol(0);
+    predValue.u64 = (m_regs.back()[sym].u64) & ~(0x0C);
+    predValue.u64 |= ((overflow & 0x01) << 3);
+    predValue.u64 |= ((carry & 0x01) << 2);
 
-#define MY_CAS_I(a,b,c) (a == b) ? c : a
+    set_reg(sym, predValue);
+  } else if (dst.get_double_operand_type() == 0) {
+    // intentionally do nothing
+  } else {
+    printf("Unexpected double destination\n");
+    assert(0);
+  }
+}
 
-#define MY_EXCH(a,b) b
+void ptx_thread_info::set_operand_value(const operand_info &dst,
+                                        const ptx_reg_t &data, unsigned type,
+                                        ptx_thread_info *thread,
+                                        const ptx_instruction *pI) {
+  ptx_reg_t dstData;
+  memory_space *mem = NULL;
+  size_t size;
+  int t;
 
-void abs_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t a, d;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
+  type_info_key::type_decode(type, size, t);
 
-   unsigned i_type = pI->get_type();
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  /*complete this section for other cases*/
+  if (dst.get_addr_space() == undefined_space) {
+    ptx_reg_t setValue;
+    setValue.u64 = data.u64;
 
+    // Double destination in set instruction ($p0|$p1) - second is negation of
+    // first
+    if (dst.get_double_operand_type() == -1) {
+      ptx_reg_t setValue2;
+      const symbol *name1 = dst.vec_symbol(0);
+      const symbol *name2 = dst.vec_symbol(1);
 
-   switch ( i_type ) {
-   case S16_TYPE: d.s16 = my_abs(a.s16); break;
-   case S32_TYPE: d.s32 = my_abs(a.s32); break;
-   case S64_TYPE: d.s64 = my_abs(a.s64); break;
-   case U16_TYPE: d.s16 = my_abs(a.u16); break;
-   case U32_TYPE: d.s32 = my_abs(a.u32); break;
-   case U64_TYPE: d.s64 = my_abs(a.u64); break;
-   case F32_TYPE: d.f32 = my_abs(a.f32); break;
-   case F64_TYPE: case FF64_TYPE: d.f64 = my_abs(a.f64); break;
-   default:
+      if ((type == F16_TYPE) || (type == F32_TYPE) || (type == F64_TYPE) ||
+          (type == FF64_TYPE)) {
+        setValue2.f32 = (setValue.u64 == 0) ? 1.0f : 0.0f;
+      } else {
+        setValue2.u32 = (setValue.u64 == 0) ? 0xFFFFFFFF : 0;
+      }
+
+      set_reg(name1, setValue);
+      set_reg(name2, setValue2);
+    }
+
+    // Double destination in cvt,shr,mul,etc. instruction ($p0|$r4) - second
+    // register operand receives data, first predicate operand is set as
+    // $p0=($r4!=0) Also for Double destination in set instruction ($p0/$r1)
+    else if ((dst.get_double_operand_type() == -2) ||
+             (dst.get_double_operand_type() == -3)) {
+      ptx_reg_t predValue;
+      const symbol *predName = dst.vec_symbol(0);
+      const symbol *regName = dst.vec_symbol(1);
+      predValue.u64 = 0;
+
+      switch (type) {
+        case S8_TYPE:
+          if ((setValue.s8 & 0x7F) == 0) predValue.u64 |= 1;
+          break;
+        case S16_TYPE:
+          if ((setValue.s16 & 0x7FFF) == 0) predValue.u64 |= 1;
+          break;
+        case S32_TYPE:
+          if ((setValue.s32 & 0x7FFFFFFF) == 0) predValue.u64 |= 1;
+          break;
+        case S64_TYPE:
+          if ((setValue.s64 & 0x7FFFFFFFFFFFFFFF) == 0) predValue.u64 |= 1;
+          break;
+        case U8_TYPE:
+        case B8_TYPE:
+          if (setValue.u8 == 0) predValue.u64 |= 1;
+          break;
+        case U16_TYPE:
+        case B16_TYPE:
+          if (setValue.u16 == 0) predValue.u64 |= 1;
+          break;
+        case U32_TYPE:
+        case B32_TYPE:
+          if (setValue.u32 == 0) predValue.u64 |= 1;
+          break;
+        case U64_TYPE:
+        case B64_TYPE:
+          if (setValue.u64 == 0) predValue.u64 |= 1;
+          break;
+        case F16_TYPE:
+          if (setValue.f16 == 0) predValue.u64 |= 1;
+          break;
+        case F32_TYPE:
+          if (setValue.f32 == 0) predValue.u64 |= 1;
+          break;
+        case F64_TYPE:
+        case FF64_TYPE:
+          if (setValue.f64 == 0) predValue.u64 |= 1;
+          break;
+        default:
+          assert(0);
+          break;
+      }
+
+      if ((type == S8_TYPE) || (type == S16_TYPE) || (type == S32_TYPE) ||
+          (type == S64_TYPE) || (type == U8_TYPE) || (type == U16_TYPE) ||
+          (type == U32_TYPE) || (type == U64_TYPE) || (type == B8_TYPE) ||
+          (type == B16_TYPE) || (type == B32_TYPE) || (type == B64_TYPE)) {
+        if ((setValue.u32 & (1 << (size - 1))) != 0) predValue.u64 |= 1 << 1;
+      }
+      if (type == F32_TYPE) {
+        if (setValue.f32 < 0) predValue.u64 |= 1 << 1;
+      }
+
+      if (dst.get_operand_lohi() == 1) {
+        setValue.u64 =
+            ((m_regs.back()[regName].u64) & (~(0xFFFF))) + (data.u64 & 0xFFFF);
+      } else if (dst.get_operand_lohi() == 2) {
+        setValue.u64 = ((m_regs.back()[regName].u64) & (~(0xFFFF0000))) +
+                       ((data.u64 << 16) & 0xFFFF0000);
+      }
+
+      set_reg(predName, predValue);
+      set_reg(regName, setValue);
+    } else if (type == BB128_TYPE) {
+      // b128 stuff here.
+      ptx_reg_t setValue2, setValue3, setValue4;
+      setValue.u64 = 0;
+      setValue2.u64 = 0;
+      setValue3.u64 = 0;
+      setValue4.u64 = 0;
+      setValue.u32 = data.u128.lowest;
+      setValue2.u32 = data.u128.low;
+      setValue3.u32 = data.u128.high;
+      setValue4.u32 = data.u128.highest;
+
+      const symbol *name1, *name2, *name3, *name4 = NULL;
+
+      name1 = dst.vec_symbol(0);
+      name2 = dst.vec_symbol(1);
+      name3 = dst.vec_symbol(2);
+      name4 = dst.vec_symbol(3);
+
+      set_reg(name1, setValue);
+      set_reg(name2, setValue2);
+      set_reg(name3, setValue3);
+      set_reg(name4, setValue4);
+    } else if (type == BB64_TYPE || type == FF64_TYPE) {
+      // ptxplus version of storing 64 bit values to registers stores to two
+      // adjacent registers
+      ptx_reg_t setValue2;
+      setValue.u32 = 0;
+      setValue2.u32 = 0;
+
+      setValue.u32 = data.bits.ls;
+      setValue2.u32 = data.bits.ms;
+
+      const symbol *name1, *name2 = NULL;
+
+      name1 = dst.vec_symbol(0);
+      name2 = dst.vec_symbol(1);
+
+      set_reg(name1, setValue);
+      set_reg(name2, setValue2);
+    } else {
+      if (dst.get_operand_lohi() == 1) {
+        setValue.u64 = ((m_regs.back()[dst.get_symbol()].u64) & (~(0xFFFF))) +
+                       (data.u64 & 0xFFFF);
+      } else if (dst.get_operand_lohi() == 2) {
+        setValue.u64 =
+            ((m_regs.back()[dst.get_symbol()].u64) & (~(0xFFFF0000))) +
+            ((data.u64 << 16) & 0xFFFF0000);
+      }
+      set_reg(dst.get_symbol(), setValue);
+    }
+  }
+
+  // global memory - g[4], g[$r0]
+  else if (dst.get_addr_space() == global_space) {
+    dstData = thread->get_operand_value(dst, dst, type, thread, 0);
+    mem = thread->get_global_memory();
+    type_info_key::type_decode(type, size, t);
+
+    mem->write(dstData.u32, size / 8, &data.u128, thread, pI);
+    thread->m_last_effective_address = dstData.u32;
+    thread->m_last_memory_space = global_space;
+  }
+
+  // shared memory - s[4], s[$r0]
+  else if (dst.get_addr_space() == shared_space) {
+    dstData = thread->get_operand_value(dst, dst, type, thread, 0);
+    mem = thread->m_shared_mem;
+    type_info_key::type_decode(type, size, t);
+
+    mem->write(dstData.u32, size / 8, &data.u128, thread, pI);
+    thread->m_last_effective_address = dstData.u32;
+    thread->m_last_memory_space = shared_space;
+  }
+
+  // local memory - l0[4], l0[$r0]
+  else if (dst.get_addr_space() == local_space) {
+    dstData = thread->get_operand_value(dst, dst, type, thread, 0);
+    mem = thread->m_local_mem;
+    type_info_key::type_decode(type, size, t);
+
+    mem->write(dstData.u32, size / 8, &data.u128, thread, pI);
+    thread->m_last_effective_address = dstData.u32;
+    thread->m_last_memory_space = local_space;
+  }
+
+  else {
+    printf("Destination stores to unknown location.");
+    assert(0);
+  }
+}
+
+void ptx_thread_info::set_vector_operand_values(const operand_info &dst,
+                                                const ptx_reg_t &data1,
+                                                const ptx_reg_t &data2,
+                                                const ptx_reg_t &data3,
+                                                const ptx_reg_t &data4) {
+  unsigned num_elements = dst.get_vect_nelem();
+  if (num_elements > 0) {
+    set_reg(dst.vec_symbol(0), data1);
+    if (num_elements > 1) {
+      set_reg(dst.vec_symbol(1), data2);
+      if (num_elements > 2) {
+        set_reg(dst.vec_symbol(2), data3);
+        if (num_elements > 3) {
+          set_reg(dst.vec_symbol(3), data4);
+        }
+      }
+    }
+  }
+
+  m_last_set_operand_value = data1;
+}
+void ptx_thread_info::set_wmma_vector_operand_values(
+    const operand_info &dst, const ptx_reg_t &data1, const ptx_reg_t &data2,
+    const ptx_reg_t &data3, const ptx_reg_t &data4, const ptx_reg_t &data5,
+    const ptx_reg_t &data6, const ptx_reg_t &data7, const ptx_reg_t &data8) {
+  unsigned num_elements = dst.get_vect_nelem();
+  if (num_elements == 8) {
+    set_reg(dst.vec_symbol(0), data1);
+    set_reg(dst.vec_symbol(1), data2);
+    set_reg(dst.vec_symbol(2), data3);
+    set_reg(dst.vec_symbol(3), data4);
+    set_reg(dst.vec_symbol(4), data5);
+    set_reg(dst.vec_symbol(5), data6);
+    set_reg(dst.vec_symbol(6), data7);
+    set_reg(dst.vec_symbol(7), data8);
+  } else {
+    printf("error:set_wmma_vector_operands");
+  }
+
+  m_last_set_operand_value = data8;
+}
+
+#define my_abs(a) (((a) < 0) ? (-a) : (a))
+
+#define MY_MAX_I(a, b) (a > b) ? a : b
+#define MY_MAX_F(a, b) isNaN(a) ? b : isNaN(b) ? a : (a > b) ? a : b
+
+#define MY_MIN_I(a, b) (a < b) ? a : b
+#define MY_MIN_F(a, b) isNaN(a) ? b : isNaN(b) ? a : (a < b) ? a : b
+
+#define MY_INC_I(a, b) (a >= b) ? 0 : a + 1
+#define MY_DEC_I(a, b) ((a == 0) || (a > b)) ? b : a - 1
+
+#define MY_CAS_I(a, b, c) (a == b) ? c : a
+
+#define MY_EXCH(a, b) b
+
+void abs_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, d;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+
+  unsigned i_type = pI->get_type();
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+
+  switch (i_type) {
+    case S16_TYPE:
+      d.s16 = my_abs(a.s16);
+      break;
+    case S32_TYPE:
+      d.s32 = my_abs(a.s32);
+      break;
+    case S64_TYPE:
+      d.s64 = my_abs(a.s64);
+      break;
+    case U16_TYPE:
+      d.s16 = my_abs(a.u16);
+      break;
+    case U32_TYPE:
+      d.s32 = my_abs(a.u32);
+      break;
+    case U64_TYPE:
+      d.s64 = my_abs(a.u64);
+      break;
+    case F32_TYPE:
+      d.f32 = my_abs(a.f32);
+      break;
+    case F64_TYPE:
+    case FF64_TYPE:
+      d.f64 = my_abs(a.f64);
+      break;
+    default:
       printf("Execution error: type mismatch with instruction\n");
       assert(0);
       break;
-   }
+  }
 
-   thread->set_operand_value(dst,d, i_type, thread, pI);
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-void addp_impl( const ptx_instruction *pI, ptx_thread_info *thread )
-{
-   //PTXPlus add instruction with carry (carry is kept in a predicate) register
-   ptx_reg_t src1_data, src2_data, src3_data, data;
-   int overflow = 0;
-   int carry = 0;
+void addp_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  // PTXPlus add instruction with carry (carry is kept in a predicate) register
+  ptx_reg_t src1_data, src2_data, src3_data, data;
+  int overflow = 0;
+  int carry = 0;
 
-   const operand_info &dst  = pI->dst();  //get operand info of sources and destination
-   const operand_info &src1 = pI->src1(); //use them to determine that they are of type 'register'
-   const operand_info &src2 = pI->src2();
-   const operand_info &src3 = pI->src3();
+  const operand_info &dst =
+      pI->dst();  // get operand info of sources and destination
+  const operand_info &src1 =
+      pI->src1();  // use them to determine that they are of type 'register'
+  const operand_info &src2 = pI->src2();
+  const operand_info &src3 = pI->src3();
 
-   unsigned i_type = pI->get_type();
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
-   src3_data = thread->get_operand_value(src3, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  src3_data = thread->get_operand_value(src3, dst, i_type, thread, 1);
 
-   unsigned rounding_mode = pI->rounding_mode();
-   int orig_rm = fegetround();
-   switch ( rounding_mode ) {
-   case RN_OPTION: break;
-   case RZ_OPTION: fesetround( FE_TOWARDZERO ); break;
-   default: assert(0); break;
-   }
-
-   //performs addition. Sets carry and overflow if needed.
-   //src3_data.pred&0x4 is the carry flag
-   switch ( i_type ) {
-   case S8_TYPE:
-      data.s64 = (src1_data.s64 & 0x0000000FF) + (src2_data.s64 & 0x0000000FF) + (src3_data.pred & 0x4);
-      if(((src1_data.s64 & 0x80)-(src2_data.s64 & 0x80)) == 0) {overflow=((src1_data.s64 & 0x80)-(data.s64 & 0x80))==0?0:1; }
-      carry = (data.u64 & 0x000000100)>>8;
+  unsigned rounding_mode = pI->rounding_mode();
+  int orig_rm = fegetround();
+  switch (rounding_mode) {
+    case RN_OPTION:
       break;
-   case S16_TYPE:
-      data.s64 = (src1_data.s64 & 0x00000FFFF) + (src2_data.s64 & 0x00000FFFF) + (src3_data.pred & 0x4);
-      if(((src1_data.s64 & 0x8000)-(src2_data.s64 & 0x8000)) == 0) {overflow=((src1_data.s64 & 0x8000)-(data.s64 & 0x8000))==0?0:1; }
-      carry = (data.u64 & 0x000010000)>>16;
+    case RZ_OPTION:
+      fesetround(FE_TOWARDZERO);
       break;
-   case S32_TYPE:
-      data.s64 = (src1_data.s64 & 0x0FFFFFFFF) + (src2_data.s64 & 0x0FFFFFFFF) + (src3_data.pred & 0x4);
-      if(((src1_data.s64 & 0x80000000)-(src2_data.s64 & 0x80000000)) == 0) {overflow=((src1_data.s64 & 0x80000000)-(data.s64 & 0x80000000))==0?0:1; }
-      carry = (data.u64 & 0x100000000)>>32;
+    default:
+      assert(0);
       break;
-   case S64_TYPE:
+  }
+
+  // performs addition. Sets carry and overflow if needed.
+  // src3_data.pred&0x4 is the carry flag
+  switch (i_type) {
+    case S8_TYPE:
+      data.s64 = (src1_data.s64 & 0x0000000FF) + (src2_data.s64 & 0x0000000FF) +
+                 (src3_data.pred & 0x4);
+      if (((src1_data.s64 & 0x80) - (src2_data.s64 & 0x80)) == 0) {
+        overflow = ((src1_data.s64 & 0x80) - (data.s64 & 0x80)) == 0 ? 0 : 1;
+      }
+      carry = (data.u64 & 0x000000100) >> 8;
+      break;
+    case S16_TYPE:
+      data.s64 = (src1_data.s64 & 0x00000FFFF) + (src2_data.s64 & 0x00000FFFF) +
+                 (src3_data.pred & 0x4);
+      if (((src1_data.s64 & 0x8000) - (src2_data.s64 & 0x8000)) == 0) {
+        overflow =
+            ((src1_data.s64 & 0x8000) - (data.s64 & 0x8000)) == 0 ? 0 : 1;
+      }
+      carry = (data.u64 & 0x000010000) >> 16;
+      break;
+    case S32_TYPE:
+      data.s64 = (src1_data.s64 & 0x0FFFFFFFF) + (src2_data.s64 & 0x0FFFFFFFF) +
+                 (src3_data.pred & 0x4);
+      if (((src1_data.s64 & 0x80000000) - (src2_data.s64 & 0x80000000)) == 0) {
+        overflow = ((src1_data.s64 & 0x80000000) - (data.s64 & 0x80000000)) == 0
+                       ? 0
+                       : 1;
+      }
+      carry = (data.u64 & 0x100000000) >> 32;
+      break;
+    case S64_TYPE:
       data.s64 = src1_data.s64 + src2_data.s64 + (src3_data.pred & 0x4);
       break;
-   case U8_TYPE:
-      data.u64 = (src1_data.u64 & 0xFF) + (src2_data.u64 & 0xFF) + (src3_data.pred & 0x4);
-      carry = (data.u64 & 0x100)>>8;
+    case U8_TYPE:
+      data.u64 = (src1_data.u64 & 0xFF) + (src2_data.u64 & 0xFF) +
+                 (src3_data.pred & 0x4);
+      carry = (data.u64 & 0x100) >> 8;
       break;
-   case U16_TYPE:
-      data.u64 = (src1_data.u64 & 0xFFFF) + (src2_data.u64 & 0xFFFF) + (src3_data.pred & 0x4);
-      carry = (data.u64 & 0x10000)>>16;
+    case U16_TYPE:
+      data.u64 = (src1_data.u64 & 0xFFFF) + (src2_data.u64 & 0xFFFF) +
+                 (src3_data.pred & 0x4);
+      carry = (data.u64 & 0x10000) >> 16;
       break;
-   case U32_TYPE:
-      data.u64 = (src1_data.u64 & 0xFFFFFFFF) + (src2_data.u64 & 0xFFFFFFFF) + (src3_data.pred & 0x4);
-      carry = (data.u64 & 0x100000000)>>32;
+    case U32_TYPE:
+      data.u64 = (src1_data.u64 & 0xFFFFFFFF) + (src2_data.u64 & 0xFFFFFFFF) +
+                 (src3_data.pred & 0x4);
+      carry = (data.u64 & 0x100000000) >> 32;
       break;
-   case U64_TYPE:
+    case U64_TYPE:
       data.s64 = src1_data.s64 + src2_data.s64 + (src3_data.pred & 0x4);
       break;
-   case F16_TYPE: data.f16=src1_data.f16+src2_data.f16; break;//assert(0); break;
-   case F32_TYPE: data.f32 = src1_data.f32 + src2_data.f32; break;
-   case F64_TYPE: case FF64_TYPE: data.f64 = src1_data.f64 + src2_data.f64; break;
-   default: assert(0); break;
-   }
-   fesetround( orig_rm );
+    case F16_TYPE:
+      data.f16 = src1_data.f16 + src2_data.f16;
+      break;  // assert(0); break;
+    case F32_TYPE:
+      data.f32 = src1_data.f32 + src2_data.f32;
+      break;
+    case F64_TYPE:
+    case FF64_TYPE:
+      data.f64 = src1_data.f64 + src2_data.f64;
+      break;
+    default:
+      assert(0);
+      break;
+  }
+  fesetround(orig_rm);
 
-   thread->set_operand_value(dst, data, i_type, thread, pI, overflow, carry  );
+  thread->set_operand_value(dst, data, i_type, thread, pI, overflow, carry);
 }
 
-void add_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t src1_data, src2_data, data;
-   int overflow = 0;
-   int carry = 0;
+void add_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, src2_data, data;
+  int overflow = 0;
+  int carry = 0;
 
-   const operand_info &dst  = pI->dst();  //get operand info of sources and destination 
-   const operand_info &src1 = pI->src1(); //use them to determine that they are of type 'register'
-   const operand_info &src2 = pI->src2();
+  const operand_info &dst =
+      pI->dst();  // get operand info of sources and destination
+  const operand_info &src1 =
+      pI->src1();  // use them to determine that they are of type 'register'
+  const operand_info &src2 = pI->src2();
 
-   unsigned i_type = pI->get_type();
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-   unsigned rounding_mode = pI->rounding_mode();
-   int orig_rm = fegetround();
-   switch ( rounding_mode ) {
-   case RN_OPTION: break;
-   case RZ_OPTION: fesetround( FE_TOWARDZERO ); break;
-   default: assert(0); break;
-   }
+  unsigned rounding_mode = pI->rounding_mode();
+  int orig_rm = fegetround();
+  switch (rounding_mode) {
+    case RN_OPTION:
+      break;
+    case RZ_OPTION:
+      fesetround(FE_TOWARDZERO);
+      break;
+    default:
+      assert(0);
+      break;
+  }
 
-   //performs addition. Sets carry and overflow if needed.
-   switch ( i_type ) {
-   case S8_TYPE:
+  // performs addition. Sets carry and overflow if needed.
+  switch (i_type) {
+    case S8_TYPE:
       data.s64 = (src1_data.s64 & 0x0000000FF) + (src2_data.s64 & 0x0000000FF);
-      if(((src1_data.s64 & 0x80)-(src2_data.s64 & 0x80)) == 0) {overflow=((src1_data.s64 & 0x80)-(data.s64 & 0x80))==0?0:1; }
-      carry = (data.u64 & 0x000000100)>>8;
+      if (((src1_data.s64 & 0x80) - (src2_data.s64 & 0x80)) == 0) {
+        overflow = ((src1_data.s64 & 0x80) - (data.s64 & 0x80)) == 0 ? 0 : 1;
+      }
+      carry = (data.u64 & 0x000000100) >> 8;
       break;
-   case S16_TYPE:
+    case S16_TYPE:
       data.s64 = (src1_data.s64 & 0x00000FFFF) + (src2_data.s64 & 0x00000FFFF);
-      if(((src1_data.s64 & 0x8000)-(src2_data.s64 & 0x8000)) == 0) {overflow=((src1_data.s64 & 0x8000)-(data.s64 & 0x8000))==0?0:1; }
-      carry = (data.u64 & 0x000010000)>>16;
+      if (((src1_data.s64 & 0x8000) - (src2_data.s64 & 0x8000)) == 0) {
+        overflow =
+            ((src1_data.s64 & 0x8000) - (data.s64 & 0x8000)) == 0 ? 0 : 1;
+      }
+      carry = (data.u64 & 0x000010000) >> 16;
       break;
-   case S32_TYPE:
+    case S32_TYPE:
       data.s64 = (src1_data.s64 & 0x0FFFFFFFF) + (src2_data.s64 & 0x0FFFFFFFF);
-      if(((src1_data.s64 & 0x80000000)-(src2_data.s64 & 0x80000000)) == 0) {overflow=((src1_data.s64 & 0x80000000)-(data.s64 & 0x80000000))==0?0:1; }
-      carry = (data.u64 & 0x100000000)>>32;
+      if (((src1_data.s64 & 0x80000000) - (src2_data.s64 & 0x80000000)) == 0) {
+        overflow = ((src1_data.s64 & 0x80000000) - (data.s64 & 0x80000000)) == 0
+                       ? 0
+                       : 1;
+      }
+      carry = (data.u64 & 0x100000000) >> 32;
       break;
-   case S64_TYPE:
+    case S64_TYPE:
       data.s64 = src1_data.s64 + src2_data.s64;
       break;
-   case U8_TYPE:
+    case U8_TYPE:
       data.u64 = (src1_data.u64 & 0xFF) + (src2_data.u64 & 0xFF);
-      carry = (data.u64 & 0x100)>>8;
+      carry = (data.u64 & 0x100) >> 8;
       break;
-   case U16_TYPE:
+    case U16_TYPE:
       data.u64 = (src1_data.u64 & 0xFFFF) + (src2_data.u64 & 0xFFFF);
-      carry = (data.u64 & 0x10000)>>16;
+      carry = (data.u64 & 0x10000) >> 16;
       break;
-   case U32_TYPE:
+    case U32_TYPE:
       data.u64 = (src1_data.u64 & 0xFFFFFFFF) + (src2_data.u64 & 0xFFFFFFFF);
-      carry = (data.u64 & 0x100000000)>>32;
+      carry = (data.u64 & 0x100000000) >> 32;
       break;
-   case U64_TYPE:
+    case U64_TYPE:
       data.u64 = src1_data.u64 + src2_data.u64;
       break;
-   case F16_TYPE: data.f16=src1_data.f16+src2_data.f16; break;//assert(0); break;
-   case F32_TYPE: data.f32 = src1_data.f32 + src2_data.f32; break;
-   case F64_TYPE: case FF64_TYPE: data.f64 = src1_data.f64 + src2_data.f64; break;
-   default: assert(0); break;
-   }
-   fesetround( orig_rm );
-
-   thread->set_operand_value(dst, data, i_type, thread, pI, overflow, carry  );
-}
-
-void addc_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-
-void and_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t src1_data, src2_data, data;
-
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
-
-   unsigned i_type = pI->get_type();
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
-
-
-   //the way ptxplus handles predicates: 1 = false and 0 = true
-   if(i_type == PRED_TYPE)
-      data.pred = ~(~(src1_data.pred) & ~(src2_data.pred));
-   else
-      data.u64 = src1_data.u64 & src2_data.u64;
-
-   thread->set_operand_value(dst,data, i_type, thread, pI);
-}
-
-void andn_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t src1_data, src2_data, data;
-
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
-
-   unsigned i_type = pI->get_type();
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
-
-   switch ( i_type ) {
-   case B16_TYPE:  src2_data.u16  = ~src2_data.u16; break;
-   case B32_TYPE:  src2_data.u32  = ~src2_data.u32; break;
-   case B64_TYPE:  src2_data.u64  = ~src2_data.u64; break;
-   default:
-      printf("Execution error: type mismatch with instruction\n");
-      assert(0); 
+    case F16_TYPE:
+      data.f16 = src1_data.f16 + src2_data.f16;
+      break;  // assert(0); break;
+    case F32_TYPE:
+      data.f32 = src1_data.f32 + src2_data.f32;
       break;
-   }
-
-   data.u64 = src1_data.u64 & src2_data.u64;
-
-   thread->set_operand_value(dst,data, i_type, thread, pI);
-}
-
-void bar_callback( const inst_t* inst, ptx_thread_info* thread)
-{
-	unsigned ctaid = thread->get_cta_uid();
-	unsigned barid = inst->bar_id;
-	unsigned value = thread->get_reduction_value(ctaid,barid);
-	const ptx_instruction *pI = dynamic_cast<const ptx_instruction*>(inst);
-	const operand_info &dst  = pI->dst();
-	ptx_reg_t data;
-	data.u32 = value;
-	thread->set_operand_value(dst,value, U32_TYPE, thread, pI);
-}
-
-void atom_callback( const inst_t* inst, ptx_thread_info* thread)
-{
-   const ptx_instruction *pI = dynamic_cast<const ptx_instruction*>(inst);
-
-   // "Decode" the output type
-   unsigned to_type = pI->get_type();
-   size_t size;
-   int t;
-   type_info_key::type_decode(to_type, size, t);
-
-   // Set up operand variables
-   ptx_reg_t data;        // d
-   ptx_reg_t src1_data;   // a
-   ptx_reg_t src2_data;   // b
-   ptx_reg_t op_result;   // temp variable to hold operation result
-
-   bool data_ready = false;
-
-   // Get operand info of sources and destination
-   const operand_info &dst  = pI->dst();     // d
-   const operand_info &src1 = pI->src1();    // a
-   const operand_info &src2 = pI->src2();    // b
-
-   // Get operand values
-   src1_data = thread->get_operand_value(src1, src1, to_type, thread, 1);        // a
-   if (dst.get_symbol()->type()){
-      src2_data = thread->get_operand_value(src2, dst, to_type, thread, 1);      // b
-   } else {
-	   //This is the case whent he first argument (dest) is '_'
-      src2_data = thread->get_operand_value(src2, src1, to_type, thread, 1);     // b
-   }
-
-   // Check state space
-   addr_t effective_address = src1_data.u64;  
-   memory_space_t space = pI->get_space();
-   if (space == undefined_space) {
-      // generic space - determine space via address
-      if( whichspace(effective_address) == global_space ) {
-         effective_address = generic_to_global(effective_address);
-         space = global_space;
-      } else if( whichspace(effective_address) == shared_space ) {
-         unsigned smid = thread->get_hw_sid();
-         effective_address = generic_to_shared(smid,effective_address);
-         space = shared_space;
-      } else {
-         abort();
-      }
-   } 
-   assert( space == global_space || space == shared_space );
-
-   memory_space *mem = NULL;
-   if(space == global_space)
-       mem = thread->get_global_memory();
-   else if(space == shared_space)
-       mem = thread->m_shared_mem;
-   else
-       abort();
-
-   // Copy value pointed to in operand 'a' into register 'd'
-   // (i.e. copy src1_data to dst)
-   mem->read(effective_address,size/8,&data.s64);
-   if (dst.get_symbol()->type()){
-	   thread->set_operand_value(dst, data, to_type, thread, pI);                         // Write value into register 'd'
-   }
-
-   // Get the atomic operation to be performed
-   unsigned m_atomic_spec = pI->get_atomic();
-
-   switch ( m_atomic_spec ) {
-   // AND
-   case ATOMIC_AND:
-      {
-
-         switch ( to_type ) {
-         case B32_TYPE:
-         case U32_TYPE:
-            op_result.u32 = data.u32 & src2_data.u32;
-            data_ready = true;
-            break;
-         case S32_TYPE:
-            op_result.s32 = data.s32 & src2_data.s32;
-            data_ready = true;
-            break;
-         default:
-            printf("Execution error: type mismatch (%x) with instruction\natom.AND only accepts b32\n", to_type);
-            assert(0);
-            break;
-         }
-
-         break;
-      }
-      // OR
-   case ATOMIC_OR:
-      {
-
-         switch ( to_type ) {
-         case B32_TYPE:
-         case U32_TYPE:
-            op_result.u32 = data.u32 | src2_data.u32;
-            data_ready = true;
-            break;
-         case S32_TYPE:
-            op_result.s32 = data.s32 | src2_data.s32;
-            data_ready = true;
-            break;
-         default:
-            printf("Execution error: type mismatch (%x) with instruction\natom.OR only accepts b32\n", to_type);
-            assert(0);
-            break;
-         }
-
-         break;
-      }
-      // XOR
-   case ATOMIC_XOR:
-      {
-
-         switch ( to_type ) {
-         case B32_TYPE:
-         case U32_TYPE:
-            op_result.u32 = data.u32 ^ src2_data.u32;
-            data_ready = true;
-            break;
-         case S32_TYPE:
-            op_result.s32 = data.s32 ^ src2_data.s32;
-            data_ready = true;
-            break;
-         default:
-            printf("Execution error: type mismatch (%x) with instruction\natom.XOR only accepts b32\n", to_type);
-            assert(0);
-            break;
-         }
-
-         break;
-      }
-      // CAS
-   case ATOMIC_CAS:
-      {
-
-         ptx_reg_t src3_data;
-         const operand_info &src3 = pI->src3();
-         src3_data = thread->get_operand_value(src3, dst, to_type, thread, 1);
-
-         switch ( to_type ) {
-         case B32_TYPE:
-         case U32_TYPE:
-            op_result.u32 = MY_CAS_I(data.u32, src2_data.u32, src3_data.u32);
-            data_ready = true;
-            break;
-         case B64_TYPE:
-         case U64_TYPE:
-            op_result.u64 = MY_CAS_I(data.u64, src2_data.u64, src3_data.u64);
-            data_ready = true;
-            break;
-         case S32_TYPE:
-            op_result.s32 = MY_CAS_I(data.s32, src2_data.s32, src3_data.s32);
-            data_ready = true;
-            break;
-         default:
-            printf("Execution error: type mismatch (%x) with instruction\natom.CAS only accepts b32 and b64\n", to_type);
-            assert(0);
-            break;
-         }
-
-         break;
-      }
-      // EXCH
-   case ATOMIC_EXCH:
-      {
-         switch ( to_type ) {
-         case B32_TYPE:
-         case U32_TYPE:
-            op_result.u32 = MY_EXCH(data.u32, src2_data.u32);
-            data_ready = true;
-            break;
-         case B64_TYPE:
-         case U64_TYPE:
-            op_result.u64 = MY_EXCH(data.u64, src2_data.u64);
-            data_ready = true;
-            break;
-         case S32_TYPE:
-            op_result.s32 = MY_EXCH(data.s32, src2_data.s32);
-            data_ready = true;
-            break;
-         default:
-            printf("Execution error: type mismatch (%x) with instruction\natom.EXCH only accepts b32\n", to_type);
-            assert(0);
-            break;
-         }
-
-         break;
-      }
-      // ADD
-   case ATOMIC_ADD:
-      {
-
-         switch ( to_type ) {
-         case U32_TYPE:
-            op_result.u32 = data.u32 + src2_data.u32;
-            data_ready = true;
-            break;
-         case S32_TYPE:
-            op_result.s32 = data.s32 + src2_data.s32;
-            data_ready = true;
-            break;
-         case U64_TYPE: 
-            op_result.u64 = data.u64 + src2_data.u64; 
-            data_ready = true; 
-            break; 
-         case F32_TYPE: 
-            op_result.f32 = data.f32 + src2_data.f32; 
-            data_ready = true; 
-            break; 
-         default:
-            printf("Execution error: type mismatch with instruction\natom.ADD only accepts u32, s32, u64, and f32\n");
-            assert(0);
-            break;
-         }
-
-         break;
-      }
-      // INC
-   case ATOMIC_INC:
-      {
-         switch ( to_type ) {
-         case U32_TYPE: 
-            op_result.u32 = MY_INC_I(data.u32, src2_data.u32);
-            data_ready = true;
-            break;
-         default:
-            printf("Execution error: type mismatch with instruction\natom.INC only accepts u32 and s32\n");
-            assert(0);
-            break;
-         }
-
-         break;
-      }
-      // DEC
-   case ATOMIC_DEC:
-      {
-         switch ( to_type ) {
-         case U32_TYPE: 
-            op_result.u32 = MY_DEC_I(data.u32, src2_data.u32);
-            data_ready = true;
-            break;
-         default:
-            printf("Execution error: type mismatch with instruction\natom.DEC only accepts u32 and s32\n");
-            assert(0);
-            break;
-         }
-
-         break;
-      }
-      // MIN
-   case ATOMIC_MIN:
-      {
-         switch ( to_type ) {
-         case U32_TYPE: 
-            op_result.u32 = MY_MIN_I(data.u32, src2_data.u32);
-            data_ready = true;
-            break;
-         case S32_TYPE:
-            op_result.s32 = MY_MIN_I(data.s32, src2_data.s32);
-            data_ready = true;
-            break;
-         default:
-            printf("Execution error: type mismatch with instruction\natom.MIN only accepts u32 and s32\n");
-            assert(0);
-            break;
-         }
-
-         break;
-      }
-      // MAX
-   case ATOMIC_MAX:
-      {
-         switch ( to_type ) {
-         case U32_TYPE:
-            op_result.u32 = MY_MAX_I(data.u32, src2_data.u32);
-            data_ready = true;
-            break;
-         case S32_TYPE:
-            op_result.s32 = MY_MAX_I(data.s32, src2_data.s32);
-            data_ready = true;
-            break;
-         default:
-            printf("Execution error: type mismatch with instruction\natom.MAX only accepts u32 and s32\n");
-            assert(0);
-            break;
-         }
-
-         break;
-      }
-      // DEFAULT
-   default:
-      {
-         assert(0);
-         break;
-      }
-   }
-
-   // Write operation result into  memory
-   // (i.e. copy src1_data to dst)
-   if ( data_ready ) {
-      mem->write(effective_address,size/8,&op_result.s64,thread,pI);
-   } else {
-      printf("Execution error: data_ready not set\n");
+    case F64_TYPE:
+    case FF64_TYPE:
+      data.f64 = src1_data.f64 + src2_data.f64;
+      break;
+    default:
       assert(0);
-   }
+      break;
+  }
+  fesetround(orig_rm);
+
+  thread->set_operand_value(dst, data, i_type, thread, pI, overflow, carry);
 }
 
-// atom_impl will now result in a callback being called in mem_ctrl_pop (gpu-sim.c)
-void atom_impl( const ptx_instruction *pI, ptx_thread_info *thread )
-{   
-   // SYNTAX
-   // atom.space.operation.type d, a, b[, c]; (now read in callback)
+void addc_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
 
-   // obtain memory space of the operation 
-   memory_space_t space = pI->get_space(); 
+void and_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, src2_data, data;
 
-   // get the memory address
-   const operand_info &src1 = pI->src1();
-   // const operand_info &dst  = pI->dst();  // not needed for effective address calculation 
-   unsigned i_type = pI->get_type();
-   ptx_reg_t src1_data;
-   src1_data = thread->get_operand_value(src1, src1, i_type, thread, 1);
-   addr_t effective_address = src1_data.u64; 
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   addr_t effective_address_final; 
+  unsigned i_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-   // handle generic memory space by converting it to global 
-   if ( space == undefined_space ) {
-      if( whichspace(effective_address) == global_space ) {
-         effective_address_final = generic_to_global(effective_address);
-         space = global_space;
-      } else if( whichspace(effective_address) == shared_space ) {
-         unsigned smid = thread->get_hw_sid();
-         effective_address_final = generic_to_shared(smid,effective_address);
-         space = shared_space;
-      } else {
-         abort();
+  // the way ptxplus handles predicates: 1 = false and 0 = true
+  if (i_type == PRED_TYPE)
+    data.pred = ~(~(src1_data.pred) & ~(src2_data.pred));
+  else
+    data.u64 = src1_data.u64 & src2_data.u64;
+
+  thread->set_operand_value(dst, data, i_type, thread, pI);
+}
+
+void andn_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, src2_data, data;
+
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
+
+  unsigned i_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+
+  switch (i_type) {
+    case B16_TYPE:
+      src2_data.u16 = ~src2_data.u16;
+      break;
+    case B32_TYPE:
+      src2_data.u32 = ~src2_data.u32;
+      break;
+    case B64_TYPE:
+      src2_data.u64 = ~src2_data.u64;
+      break;
+    default:
+      printf("Execution error: type mismatch with instruction\n");
+      assert(0);
+      break;
+  }
+
+  data.u64 = src1_data.u64 & src2_data.u64;
+
+  thread->set_operand_value(dst, data, i_type, thread, pI);
+}
+
+void bar_callback(const inst_t *inst, ptx_thread_info *thread) {
+  unsigned ctaid = thread->get_cta_uid();
+  unsigned barid = inst->bar_id;
+  unsigned value = thread->get_reduction_value(ctaid, barid);
+  const ptx_instruction *pI = dynamic_cast<const ptx_instruction *>(inst);
+  const operand_info &dst = pI->dst();
+  ptx_reg_t data;
+  data.u32 = value;
+  thread->set_operand_value(dst, value, U32_TYPE, thread, pI);
+}
+
+void atom_callback(const inst_t *inst, ptx_thread_info *thread) {
+  const ptx_instruction *pI = dynamic_cast<const ptx_instruction *>(inst);
+
+  // "Decode" the output type
+  unsigned to_type = pI->get_type();
+  size_t size;
+  int t;
+  type_info_key::type_decode(to_type, size, t);
+
+  // Set up operand variables
+  ptx_reg_t data;       // d
+  ptx_reg_t src1_data;  // a
+  ptx_reg_t src2_data;  // b
+  ptx_reg_t op_result;  // temp variable to hold operation result
+
+  bool data_ready = false;
+
+  // Get operand info of sources and destination
+  const operand_info &dst = pI->dst();    // d
+  const operand_info &src1 = pI->src1();  // a
+  const operand_info &src2 = pI->src2();  // b
+
+  // Get operand values
+  src1_data = thread->get_operand_value(src1, src1, to_type, thread, 1);  // a
+  if (dst.get_symbol()->type()) {
+    src2_data = thread->get_operand_value(src2, dst, to_type, thread, 1);  // b
+  } else {
+    // This is the case whent he first argument (dest) is '_'
+    src2_data = thread->get_operand_value(src2, src1, to_type, thread, 1);  // b
+  }
+
+  // Check state space
+  addr_t effective_address = src1_data.u64;
+  memory_space_t space = pI->get_space();
+  if (space == undefined_space) {
+    // generic space - determine space via address
+    if (whichspace(effective_address) == global_space) {
+      effective_address = generic_to_global(effective_address);
+      space = global_space;
+    } else if (whichspace(effective_address) == shared_space) {
+      unsigned smid = thread->get_hw_sid();
+      effective_address = generic_to_shared(smid, effective_address);
+      space = shared_space;
+    } else {
+      abort();
+    }
+  }
+  assert(space == global_space || space == shared_space);
+
+  memory_space *mem = NULL;
+  if (space == global_space)
+    mem = thread->get_global_memory();
+  else if (space == shared_space)
+    mem = thread->m_shared_mem;
+  else
+    abort();
+
+  // Copy value pointed to in operand 'a' into register 'd'
+  // (i.e. copy src1_data to dst)
+  mem->read(effective_address, size / 8, &data.s64);
+  if (dst.get_symbol()->type()) {
+    thread->set_operand_value(dst, data, to_type, thread,
+                              pI);  // Write value into register 'd'
+  }
+
+  // Get the atomic operation to be performed
+  unsigned m_atomic_spec = pI->get_atomic();
+
+  switch (m_atomic_spec) {
+    // AND
+    case ATOMIC_AND: {
+      switch (to_type) {
+        case B32_TYPE:
+        case U32_TYPE:
+          op_result.u32 = data.u32 & src2_data.u32;
+          data_ready = true;
+          break;
+        case S32_TYPE:
+          op_result.s32 = data.s32 & src2_data.s32;
+          data_ready = true;
+          break;
+        default:
+          printf(
+              "Execution error: type mismatch (%x) with instruction\natom.AND "
+              "only accepts b32\n",
+              to_type);
+          assert(0);
+          break;
       }
-   } else {
-      assert( space == global_space || space == shared_space );
-      effective_address_final = effective_address; 
-   }
 
-   // Check state space
-   assert( space == global_space || space == shared_space );
+      break;
+    }
+      // OR
+    case ATOMIC_OR: {
+      switch (to_type) {
+        case B32_TYPE:
+        case U32_TYPE:
+          op_result.u32 = data.u32 | src2_data.u32;
+          data_ready = true;
+          break;
+        case S32_TYPE:
+          op_result.s32 = data.s32 | src2_data.s32;
+          data_ready = true;
+          break;
+        default:
+          printf(
+              "Execution error: type mismatch (%x) with instruction\natom.OR "
+              "only accepts b32\n",
+              to_type);
+          assert(0);
+          break;
+      }
 
-   thread->m_last_effective_address = effective_address_final;
-   thread->m_last_memory_space = space;
-   thread->m_last_dram_callback.function = atom_callback;
-   thread->m_last_dram_callback.instruction = pI; 
+      break;
+    }
+      // XOR
+    case ATOMIC_XOR: {
+      switch (to_type) {
+        case B32_TYPE:
+        case U32_TYPE:
+          op_result.u32 = data.u32 ^ src2_data.u32;
+          data_ready = true;
+          break;
+        case S32_TYPE:
+          op_result.s32 = data.s32 ^ src2_data.s32;
+          data_ready = true;
+          break;
+        default:
+          printf(
+              "Execution error: type mismatch (%x) with instruction\natom.XOR "
+              "only accepts b32\n",
+              to_type);
+          assert(0);
+          break;
+      }
+
+      break;
+    }
+      // CAS
+    case ATOMIC_CAS: {
+      ptx_reg_t src3_data;
+      const operand_info &src3 = pI->src3();
+      src3_data = thread->get_operand_value(src3, dst, to_type, thread, 1);
+
+      switch (to_type) {
+        case B32_TYPE:
+        case U32_TYPE:
+          op_result.u32 = MY_CAS_I(data.u32, src2_data.u32, src3_data.u32);
+          data_ready = true;
+          break;
+        case B64_TYPE:
+        case U64_TYPE:
+          op_result.u64 = MY_CAS_I(data.u64, src2_data.u64, src3_data.u64);
+          data_ready = true;
+          break;
+        case S32_TYPE:
+          op_result.s32 = MY_CAS_I(data.s32, src2_data.s32, src3_data.s32);
+          data_ready = true;
+          break;
+        default:
+          printf(
+              "Execution error: type mismatch (%x) with instruction\natom.CAS "
+              "only accepts b32 and b64\n",
+              to_type);
+          assert(0);
+          break;
+      }
+
+      break;
+    }
+      // EXCH
+    case ATOMIC_EXCH: {
+      switch (to_type) {
+        case B32_TYPE:
+        case U32_TYPE:
+          op_result.u32 = MY_EXCH(data.u32, src2_data.u32);
+          data_ready = true;
+          break;
+        case B64_TYPE:
+        case U64_TYPE:
+          op_result.u64 = MY_EXCH(data.u64, src2_data.u64);
+          data_ready = true;
+          break;
+        case S32_TYPE:
+          op_result.s32 = MY_EXCH(data.s32, src2_data.s32);
+          data_ready = true;
+          break;
+        default:
+          printf(
+              "Execution error: type mismatch (%x) with instruction\natom.EXCH "
+              "only accepts b32\n",
+              to_type);
+          assert(0);
+          break;
+      }
+
+      break;
+    }
+      // ADD
+    case ATOMIC_ADD: {
+      switch (to_type) {
+        case U32_TYPE:
+          op_result.u32 = data.u32 + src2_data.u32;
+          data_ready = true;
+          break;
+        case S32_TYPE:
+          op_result.s32 = data.s32 + src2_data.s32;
+          data_ready = true;
+          break;
+        case U64_TYPE:
+          op_result.u64 = data.u64 + src2_data.u64;
+          data_ready = true;
+          break;
+        case F32_TYPE:
+          op_result.f32 = data.f32 + src2_data.f32;
+          data_ready = true;
+          break;
+        default:
+          printf(
+              "Execution error: type mismatch with instruction\natom.ADD only "
+              "accepts u32, s32, u64, and f32\n");
+          assert(0);
+          break;
+      }
+
+      break;
+    }
+      // INC
+    case ATOMIC_INC: {
+      switch (to_type) {
+        case U32_TYPE:
+          op_result.u32 = MY_INC_I(data.u32, src2_data.u32);
+          data_ready = true;
+          break;
+        default:
+          printf(
+              "Execution error: type mismatch with instruction\natom.INC only "
+              "accepts u32 and s32\n");
+          assert(0);
+          break;
+      }
+
+      break;
+    }
+      // DEC
+    case ATOMIC_DEC: {
+      switch (to_type) {
+        case U32_TYPE:
+          op_result.u32 = MY_DEC_I(data.u32, src2_data.u32);
+          data_ready = true;
+          break;
+        default:
+          printf(
+              "Execution error: type mismatch with instruction\natom.DEC only "
+              "accepts u32 and s32\n");
+          assert(0);
+          break;
+      }
+
+      break;
+    }
+      // MIN
+    case ATOMIC_MIN: {
+      switch (to_type) {
+        case U32_TYPE:
+          op_result.u32 = MY_MIN_I(data.u32, src2_data.u32);
+          data_ready = true;
+          break;
+        case S32_TYPE:
+          op_result.s32 = MY_MIN_I(data.s32, src2_data.s32);
+          data_ready = true;
+          break;
+        default:
+          printf(
+              "Execution error: type mismatch with instruction\natom.MIN only "
+              "accepts u32 and s32\n");
+          assert(0);
+          break;
+      }
+
+      break;
+    }
+      // MAX
+    case ATOMIC_MAX: {
+      switch (to_type) {
+        case U32_TYPE:
+          op_result.u32 = MY_MAX_I(data.u32, src2_data.u32);
+          data_ready = true;
+          break;
+        case S32_TYPE:
+          op_result.s32 = MY_MAX_I(data.s32, src2_data.s32);
+          data_ready = true;
+          break;
+        default:
+          printf(
+              "Execution error: type mismatch with instruction\natom.MAX only "
+              "accepts u32 and s32\n");
+          assert(0);
+          break;
+      }
+
+      break;
+    }
+      // DEFAULT
+    default: {
+      assert(0);
+      break;
+    }
+  }
+
+  // Write operation result into  memory
+  // (i.e. copy src1_data to dst)
+  if (data_ready) {
+    mem->write(effective_address, size / 8, &op_result.s64, thread, pI);
+  } else {
+    printf("Execution error: data_ready not set\n");
+    assert(0);
+  }
 }
 
-void bar_impl( const ptx_instruction *pIin, ptx_thread_info *thread )
-{ 
-   ptx_instruction * pI = const_cast<ptx_instruction *>(pIin);
-   unsigned bar_op = pI->barrier_op();
-   unsigned red_op = pI->get_atomic();
-   unsigned ctaid = thread->get_cta_uid();
+// atom_impl will now result in a callback being called in mem_ctrl_pop
+// (gpu-sim.c)
+void atom_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  // SYNTAX
+  // atom.space.operation.type d, a, b[, c]; (now read in callback)
 
-   switch(bar_op){
-   	   case SYNC_OPTION:
-   	   {
-   		   if(pI->get_num_operands()>1){
-   			   const operand_info &op0 = pI->dst();
-   			   const operand_info &op1 = pI->src1();
-   			   ptx_reg_t op0_data;
-   			   ptx_reg_t op1_data;
-   			   op0_data = thread->get_operand_value(op0, op0, U32_TYPE, thread, 1);
-   			   op1_data = thread->get_operand_value(op1, op1, U32_TYPE, thread, 1);
-   			   pI->set_bar_id(op0_data.u32);
-   			   pI->set_bar_count(op1_data.u32);
-   		   }else{
-   			   const operand_info &op0 = pI->dst();
-   			   ptx_reg_t op0_data;
-   			   op0_data = thread->get_operand_value(op0, op0, U32_TYPE, thread, 1);
-   			   pI->set_bar_id(op0_data.u32);
-   		   }
-   		   break;
-   	   }
-   	   case ARRIVE_OPTION:
-   	   {
-			   const operand_info &op0 = pI->dst();
-			   const operand_info &op1 = pI->src1();
-			   ptx_reg_t op0_data;
-			   ptx_reg_t op1_data;
-			   op0_data = thread->get_operand_value(op0, op0, U32_TYPE, thread, 1);
-			   op1_data = thread->get_operand_value(op1, op1, U32_TYPE, thread, 1);
-   			   pI->set_bar_id(op0_data.u32);
-   			   pI->set_bar_count(op1_data.u32);
-   		   break;
-   	   }
-   	   case RED_OPTION:
-   	   {
-   		   if(pI->get_num_operands()>3){
-   			   const operand_info &op1 = pI->src1();
-   			   const operand_info &op2 = pI->src2();
-   			   const operand_info &op3 = pI->src3();
-   			   ptx_reg_t op1_data;
-   			   ptx_reg_t op2_data;
-   			   ptx_reg_t op3_data;
-   			   op1_data = thread->get_operand_value(op1, op1, U32_TYPE, thread, 1);
-   			   op2_data = thread->get_operand_value(op2, op2, U32_TYPE, thread, 1);
-   			   op3_data = thread->get_operand_value(op3, op3, PRED_TYPE, thread, 1);
-   			   op3_data.u32=!(op3_data.pred & 0x0001);
-   			   pI->set_bar_id(op1_data.u32);
-   			   pI->set_bar_count(op2_data.u32);
-   			   switch(red_op){
-   			   	   case ATOMIC_POPC:
-   			   		   thread->popc_reduction(ctaid,op1_data.u32,op3_data.u32);
-   			   		   break;
-   			   	   case ATOMIC_AND:
-   			   		   thread->and_reduction(ctaid,op1_data.u32,op3_data.u32);
-   			   		   break;
-   			   	   case ATOMIC_OR:
-   			   		   thread->or_reduction(ctaid,op1_data.u32,op3_data.u32);
-   			   		   break;
-   			   	   default:
-   			   		   abort();
-   			   		   break;
-   			   }
-   		   }else{
-   			   const operand_info &op1 = pI->src1();
-   			   const operand_info &op2 = pI->src2();
-   			   ptx_reg_t op1_data;
-   			   ptx_reg_t op2_data;
-   			   op1_data = thread->get_operand_value(op1, op1, U32_TYPE, thread, 1);
-   			   op2_data = thread->get_operand_value(op2, op2, PRED_TYPE, thread, 1);
-               op2_data.u32=!(op2_data.pred & 0x0001);
-   			   pI->set_bar_id(op1_data.u32);
-			   pI->set_bar_count(thread->get_ntid().x * thread->get_ntid().y * thread->get_ntid().z);
-   			   switch(red_op){
-   			   	   case ATOMIC_POPC:
-   			   		   thread->popc_reduction(ctaid,op1_data.u32,op2_data.u32);
-   			   		   break;
-   			   	   case ATOMIC_AND:
-   			   		   thread->and_reduction(ctaid,op1_data.u32,op2_data.u32);
-   			   		   break;
-   			   	   case ATOMIC_OR:
-   			   		   thread->or_reduction(ctaid,op1_data.u32,op2_data.u32);
-   			   		   break;
-   			   	   default:
-   			   		   abort();
-   			   		   break;
-   			   }
-   		   }
-   		   break;
-   	   }
-   	   default:
-   		   abort();
-   		   break;
-   }
+  // obtain memory space of the operation
+  memory_space_t space = pI->get_space();
 
-   thread->m_last_dram_callback.function = bar_callback;
-   thread->m_last_dram_callback.instruction = pIin;
+  // get the memory address
+  const operand_info &src1 = pI->src1();
+  // const operand_info &dst  = pI->dst();  // not needed for effective address
+  // calculation
+  unsigned i_type = pI->get_type();
+  ptx_reg_t src1_data;
+  src1_data = thread->get_operand_value(src1, src1, i_type, thread, 1);
+  addr_t effective_address = src1_data.u64;
+
+  addr_t effective_address_final;
+
+  // handle generic memory space by converting it to global
+  if (space == undefined_space) {
+    if (whichspace(effective_address) == global_space) {
+      effective_address_final = generic_to_global(effective_address);
+      space = global_space;
+    } else if (whichspace(effective_address) == shared_space) {
+      unsigned smid = thread->get_hw_sid();
+      effective_address_final = generic_to_shared(smid, effective_address);
+      space = shared_space;
+    } else {
+      abort();
+    }
+  } else {
+    assert(space == global_space || space == shared_space);
+    effective_address_final = effective_address;
+  }
+
+  // Check state space
+  assert(space == global_space || space == shared_space);
+
+  thread->m_last_effective_address = effective_address_final;
+  thread->m_last_memory_space = space;
+  thread->m_last_dram_callback.function = atom_callback;
+  thread->m_last_dram_callback.instruction = pI;
 }
 
-void bfe_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-	unsigned i_type = pI->get_type();
-	unsigned msb = (i_type == U32_TYPE || i_type == S32_TYPE) ? 31 : 63;
-    const operand_info &dst  = pI->dst();
-    const operand_info &src1 = pI->src1();
-    const operand_info &src2 = pI->src2();
-    const operand_info &src3 = pI->src3();
-    ptx_reg_t src = thread->get_operand_value(src1, dst, i_type, thread, 1);
-    ptx_reg_t b = thread->get_operand_value(src2, dst, i_type, thread, 1);
-    ptx_reg_t c = thread->get_operand_value(src3, dst, i_type, thread, 1);
-    ptx_reg_t data;
-	unsigned pos = b.u32 & 0xFF;
-	unsigned len = c.u32 & 0xFF;
-	switch (i_type)
-	{
-		case U32_TYPE:
-		{
-			unsigned mask;
-			data.u32 = src.u32 >> pos;
-			mask = 0xFFFFFFFF >> (32 - len);
-			data.u32 &= mask;
-			break;
-		}
-		case U64_TYPE:
-		{
-			unsigned long mask;
-			data.u64 = src.u64 >> pos;	
-			mask = 0xFFFFFFFFFFFFFFFF >> (64 - len);
-			data.u64 &= mask;
-			break;
-		}
-		case S32_TYPE:
-		{
-			unsigned mask;
-			unsigned min = MY_MIN_I(pos + len - 1, msb);
-			unsigned sbit = len == 0 ? 0 : (src.s32 >> min) & 0x1;
-			data.s32 = src.s32 >> pos;
-			if (sbit > 0)
-			{
-				mask = 0xFFFFFFFF << len;
-				data.s32 |= mask;
-			}
-			else
-			{
-				mask = 0xFFFFFFFF >> (32 - len);
-				data.s32 &= mask;
-			}
-			break;
-		}
-		case S64_TYPE:
-		{
-			unsigned long mask;
-			unsigned min = MY_MIN_I(pos + len - 1, msb);
-			unsigned sbit = len == 0 ? 0 : (src.s64 >> min) & 0x1;
-			data.s64 = src.s64 >> pos;
-			if (sbit > 0)
-			{
-				mask = 0xFFFFFFFFFFFFFFFF << len;
-				data.s64 |= mask;
-			}
-			else
-			{
-				mask = 0xFFFFFFFFFFFFFFFF >> (64 - len);
-				data.s64 &= mask;
-			}
-			break;
-		}
-		default:
-		printf("Operand type not supported for BFE instruction.\n");
-		abort();
-		return;
-	}
-    thread->set_operand_value(dst, data, i_type, thread, pI);
+void bar_impl(const ptx_instruction *pIin, ptx_thread_info *thread) {
+  ptx_instruction *pI = const_cast<ptx_instruction *>(pIin);
+  unsigned bar_op = pI->barrier_op();
+  unsigned red_op = pI->get_atomic();
+  unsigned ctaid = thread->get_cta_uid();
+
+  switch (bar_op) {
+    case SYNC_OPTION: {
+      if (pI->get_num_operands() > 1) {
+        const operand_info &op0 = pI->dst();
+        const operand_info &op1 = pI->src1();
+        ptx_reg_t op0_data;
+        ptx_reg_t op1_data;
+        op0_data = thread->get_operand_value(op0, op0, U32_TYPE, thread, 1);
+        op1_data = thread->get_operand_value(op1, op1, U32_TYPE, thread, 1);
+        pI->set_bar_id(op0_data.u32);
+        pI->set_bar_count(op1_data.u32);
+      } else {
+        const operand_info &op0 = pI->dst();
+        ptx_reg_t op0_data;
+        op0_data = thread->get_operand_value(op0, op0, U32_TYPE, thread, 1);
+        pI->set_bar_id(op0_data.u32);
+      }
+      break;
+    }
+    case ARRIVE_OPTION: {
+      const operand_info &op0 = pI->dst();
+      const operand_info &op1 = pI->src1();
+      ptx_reg_t op0_data;
+      ptx_reg_t op1_data;
+      op0_data = thread->get_operand_value(op0, op0, U32_TYPE, thread, 1);
+      op1_data = thread->get_operand_value(op1, op1, U32_TYPE, thread, 1);
+      pI->set_bar_id(op0_data.u32);
+      pI->set_bar_count(op1_data.u32);
+      break;
+    }
+    case RED_OPTION: {
+      if (pI->get_num_operands() > 3) {
+        const operand_info &op1 = pI->src1();
+        const operand_info &op2 = pI->src2();
+        const operand_info &op3 = pI->src3();
+        ptx_reg_t op1_data;
+        ptx_reg_t op2_data;
+        ptx_reg_t op3_data;
+        op1_data = thread->get_operand_value(op1, op1, U32_TYPE, thread, 1);
+        op2_data = thread->get_operand_value(op2, op2, U32_TYPE, thread, 1);
+        op3_data = thread->get_operand_value(op3, op3, PRED_TYPE, thread, 1);
+        op3_data.u32 = !(op3_data.pred & 0x0001);
+        pI->set_bar_id(op1_data.u32);
+        pI->set_bar_count(op2_data.u32);
+        switch (red_op) {
+          case ATOMIC_POPC:
+            thread->popc_reduction(ctaid, op1_data.u32, op3_data.u32);
+            break;
+          case ATOMIC_AND:
+            thread->and_reduction(ctaid, op1_data.u32, op3_data.u32);
+            break;
+          case ATOMIC_OR:
+            thread->or_reduction(ctaid, op1_data.u32, op3_data.u32);
+            break;
+          default:
+            abort();
+            break;
+        }
+      } else {
+        const operand_info &op1 = pI->src1();
+        const operand_info &op2 = pI->src2();
+        ptx_reg_t op1_data;
+        ptx_reg_t op2_data;
+        op1_data = thread->get_operand_value(op1, op1, U32_TYPE, thread, 1);
+        op2_data = thread->get_operand_value(op2, op2, PRED_TYPE, thread, 1);
+        op2_data.u32 = !(op2_data.pred & 0x0001);
+        pI->set_bar_id(op1_data.u32);
+        pI->set_bar_count(thread->get_ntid().x * thread->get_ntid().y *
+                          thread->get_ntid().z);
+        switch (red_op) {
+          case ATOMIC_POPC:
+            thread->popc_reduction(ctaid, op1_data.u32, op2_data.u32);
+            break;
+          case ATOMIC_AND:
+            thread->and_reduction(ctaid, op1_data.u32, op2_data.u32);
+            break;
+          case ATOMIC_OR:
+            thread->or_reduction(ctaid, op1_data.u32, op2_data.u32);
+            break;
+          default:
+            abort();
+            break;
+        }
+      }
+      break;
+    }
+    default:
+      abort();
+      break;
+  }
+
+  thread->m_last_dram_callback.function = bar_callback;
+  thread->m_last_dram_callback.instruction = pIin;
 }
 
-void bfi_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { 
-   int i,max;
-   ptx_reg_t src1_data, src2_data;
-   ptx_reg_t src3_data, src4_data, data;
+void bfe_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  unsigned i_type = pI->get_type();
+  unsigned msb = (i_type == U32_TYPE || i_type == S32_TYPE) ? 31 : 63;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
+  const operand_info &src3 = pI->src3();
+  ptx_reg_t src = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  ptx_reg_t b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  ptx_reg_t c = thread->get_operand_value(src3, dst, i_type, thread, 1);
+  ptx_reg_t data;
+  unsigned pos = b.u32 & 0xFF;
+  unsigned len = c.u32 & 0xFF;
+  switch (i_type) {
+    case U32_TYPE: {
+      unsigned mask;
+      data.u32 = src.u32 >> pos;
+      mask = 0xFFFFFFFF >> (32 - len);
+      data.u32 &= mask;
+      break;
+    }
+    case U64_TYPE: {
+      unsigned long mask;
+      data.u64 = src.u64 >> pos;
+      mask = 0xFFFFFFFFFFFFFFFF >> (64 - len);
+      data.u64 &= mask;
+      break;
+    }
+    case S32_TYPE: {
+      unsigned mask;
+      unsigned min = MY_MIN_I(pos + len - 1, msb);
+      unsigned sbit = len == 0 ? 0 : (src.s32 >> min) & 0x1;
+      data.s32 = src.s32 >> pos;
+      if (sbit > 0) {
+        mask = 0xFFFFFFFF << len;
+        data.s32 |= mask;
+      } else {
+        mask = 0xFFFFFFFF >> (32 - len);
+        data.s32 &= mask;
+      }
+      break;
+    }
+    case S64_TYPE: {
+      unsigned long mask;
+      unsigned min = MY_MIN_I(pos + len - 1, msb);
+      unsigned sbit = len == 0 ? 0 : (src.s64 >> min) & 0x1;
+      data.s64 = src.s64 >> pos;
+      if (sbit > 0) {
+        mask = 0xFFFFFFFFFFFFFFFF << len;
+        data.s64 |= mask;
+      } else {
+        mask = 0xFFFFFFFFFFFFFFFF >> (64 - len);
+        data.s64 &= mask;
+      }
+      break;
+    }
+    default:
+      printf("Operand type not supported for BFE instruction.\n");
+      abort();
+      return;
+  }
+  thread->set_operand_value(dst, data, i_type, thread, pI);
+}
 
-   const operand_info &dst  = pI->dst();  //get operand info of sources and destination 
-   const operand_info &src1 = pI->src1(); //use them to determine that they are of type 'register'
-   const operand_info &src2 = pI->src2();
-   const operand_info &src3 = pI->src3();
-   const operand_info &src4 = pI->src4();
+void bfi_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  int i, max;
+  ptx_reg_t src1_data, src2_data;
+  ptx_reg_t src3_data, src4_data, data;
 
-   unsigned i_type = pI->get_type();
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
-   src3_data = thread->get_operand_value(src3, dst, i_type, thread, 1);
-   src4_data = thread->get_operand_value(src4, dst, i_type, thread, 1);
+  const operand_info &dst =
+      pI->dst();  // get operand info of sources and destination
+  const operand_info &src1 =
+      pI->src1();  // use them to determine that they are of type 'register'
+  const operand_info &src2 = pI->src2();
+  const operand_info &src3 = pI->src3();
+  const operand_info &src4 = pI->src4();
 
-   switch ( i_type ) {
-   case B32_TYPE:
+  unsigned i_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  src3_data = thread->get_operand_value(src3, dst, i_type, thread, 1);
+  src4_data = thread->get_operand_value(src4, dst, i_type, thread, 1);
+
+  switch (i_type) {
+    case B32_TYPE:
       max = 32;
       break;
-   case B64_TYPE:
+    case B64_TYPE:
       max = 64;
       break;
-   default:
+    default:
       printf("Execution error: type mismatch with instruction\n");
       assert(0);
       break;
-   }
-   data=src2_data;
-   unsigned pos = src3_data.u32 & 0xFF;
-   unsigned len = src4_data.u32 & 0xFF;
-   for(i=0;i<len && pos+i<max;i++){
-	data.u32=(~((0x00000001)<<(pos+i)))&data.u32;
-	data.u32=data.u32|((src1_data.u32&((0x00000001)<<(i)))<<(pos));
-   }
-   thread->set_operand_value(dst, data, i_type, thread, pI);
+  }
+  data = src2_data;
+  unsigned pos = src3_data.u32 & 0xFF;
+  unsigned len = src4_data.u32 & 0xFF;
+  for (i = 0; i < len && pos + i < max; i++) {
+    data.u32 = (~((0x00000001) << (pos + i))) & data.u32;
+    data.u32 = data.u32 | ((src1_data.u32 & ((0x00000001) << (i))) << (pos));
+  }
+  thread->set_operand_value(dst, data, i_type, thread, pI);
 }
-void bfind_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-
-void bra_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   const operand_info &target  = pI->dst();
-   ptx_reg_t target_pc = thread->get_operand_value(target, target, U32_TYPE, thread, 1);
-
-   thread->m_branch_taken = true;
-   thread->set_npc(target_pc);
+void bfind_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
 }
 
-void brx_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   const operand_info &target  = pI->dst();
-   ptx_reg_t target_pc = thread->get_operand_value(target, target, U32_TYPE, thread, 1);
+void bra_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  const operand_info &target = pI->dst();
+  ptx_reg_t target_pc =
+      thread->get_operand_value(target, target, U32_TYPE, thread, 1);
 
-   thread->m_branch_taken = true;
-   thread->set_npc(target_pc);
+  thread->m_branch_taken = true;
+  thread->set_npc(target_pc);
 }
 
-void break_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   const operand_info &target  = thread->pop_breakaddr();
-   ptx_reg_t target_pc = thread->get_operand_value(target, target, U32_TYPE, thread, 1);
+void brx_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  const operand_info &target = pI->dst();
+  ptx_reg_t target_pc =
+      thread->get_operand_value(target, target, U32_TYPE, thread, 1);
 
-   thread->m_branch_taken = true;
-   thread->set_npc(target_pc);
+  thread->m_branch_taken = true;
+  thread->set_npc(target_pc);
 }
 
-void breakaddr_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   const operand_info &target  = pI->dst();
-   thread->push_breakaddr(target);
-   assert(pI->has_pred() == false); // pdom analysis cannot handle if this instruction is predicated 
+void break_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  const operand_info &target = thread->pop_breakaddr();
+  ptx_reg_t target_pc =
+      thread->get_operand_value(target, target, U32_TYPE, thread, 1);
+
+  thread->m_branch_taken = true;
+  thread->set_npc(target_pc);
 }
 
-void brev_impl( const ptx_instruction *pI, ptx_thread_info *thread )
-{
-    ptx_reg_t src1_data, data;
-    const operand_info &dst  = pI->dst();
-    const operand_info &src1 = pI->src1();
-	unsigned i_type = pI->get_type();
-    src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-
-    unsigned msb;
-    switch(i_type){
-        case B32_TYPE:
-            msb = 31;
-            for (unsigned i=0; i<=msb; i++) {
-                if((src1_data.u32 & (1 << i)))
-                    data.u32 |= 1 << (msb - i);
-            }
-            break;
-        case B64_TYPE:
-            msb = 63;
-            for (unsigned i=0; i<=msb; i++) {
-                if((src1_data.u64 & (1 << i)))
-                    data.u64 |= 1 << (msb - i);
-            }
-            break;
-        default: assert(0);
-    }
-    thread->set_operand_value(dst,data, i_type, thread, pI);
+void breakaddr_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  const operand_info &target = pI->dst();
+  thread->push_breakaddr(target);
+  assert(
+      pI->has_pred() ==
+      false);  // pdom analysis cannot handle if this instruction is predicated
 }
-void brkpt_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
+
+void brev_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, data;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  unsigned i_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+
+  unsigned msb;
+  switch (i_type) {
+    case B32_TYPE:
+      msb = 31;
+      for (unsigned i = 0; i <= msb; i++) {
+        if ((src1_data.u32 & (1 << i))) data.u32 |= 1 << (msb - i);
+      }
+      break;
+    case B64_TYPE:
+      msb = 63;
+      for (unsigned i = 0; i <= msb; i++) {
+        if ((src1_data.u64 & (1 << i))) data.u64 |= 1 << (msb - i);
+      }
+      break;
+    default:
+      assert(0);
+  }
+  thread->set_operand_value(dst, data, i_type, thread, pI);
+}
+void brkpt_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
 
 unsigned trunc(unsigned num, unsigned precision) {
-	int mask = 1, latest_one = -1;
-	unsigned data = num;
-	for (unsigned j = 0; j < sizeof(unsigned)*8; j++) {
-		int bit = data & mask;
-		if (bit == 1) latest_one = j;
-		data >>= 1;
-	}
-	if (latest_one >= precision) {
-		// round_up is 1 if the most significant truncated digit is a 1, otherwise it is 0
-		//int round_up = (num & (1 << (latest_one-precision))) >> (latest_one-precision);
-		//unsigned shifted_output = num >> (latest_one-precision+1);
-		// if shifted_output is a number like 1111, don't round up
-		//if (shifted_output == (pow(2,precision)-1)) round_up = 0;
-		//num = shifted_output + round_up;
-		num >>= (latest_one-precision+1);
-	}
-	return num;
+  int mask = 1, latest_one = -1;
+  unsigned data = num;
+  for (unsigned j = 0; j < sizeof(unsigned) * 8; j++) {
+    int bit = data & mask;
+    if (bit == 1) latest_one = j;
+    data >>= 1;
+  }
+  if (latest_one >= precision) {
+    // round_up is 1 if the most significant truncated digit is a 1, otherwise
+    // it is 0
+    // int round_up = (num & (1 << (latest_one-precision))) >>
+    // (latest_one-precision); unsigned shifted_output = num >>
+    // (latest_one-precision+1);
+    // if shifted_output is a number like 1111, don't round up
+    // if (shifted_output == (pow(2,precision)-1)) round_up = 0;
+    // num = shifted_output + round_up;
+    num >>= (latest_one - precision + 1);
+  }
+  return num;
 }
-void mapping(int thread,int wmma_type,int wmma_layout,int type,int index,int stride,int &row,int &col,int &assg_offset){
-	int offset;
-	int c_row_offset[]={0,8,0,8,4,12,4,12};
-	int c_col_offset[]={0,0,8,8,0,0,8,8};
-	int c_tg_inside_row_offset[]={0,1,0,1};	
-	int c_tg_inside_col_offset[]={0,0,2,2};	
-	int c_inside_row_offset[]={0,0,2,2,0,0,2,2};
-	int c_inside_col_offset[]={0,1,0,1,4,5,4,5};
+void mapping(int thread, int wmma_type, int wmma_layout, int type, int index,
+             int stride, int &row, int &col, int &assg_offset) {
+  int offset;
+  int c_row_offset[] = {0, 8, 0, 8, 4, 12, 4, 12};
+  int c_col_offset[] = {0, 0, 8, 8, 0, 0, 8, 8};
+  int c_tg_inside_row_offset[] = {0, 1, 0, 1};
+  int c_tg_inside_col_offset[] = {0, 0, 2, 2};
+  int c_inside_row_offset[] = {0, 0, 2, 2, 0, 0, 2, 2};
+  int c_inside_col_offset[] = {0, 1, 0, 1, 4, 5, 4, 5};
 
-	offset=thread_group_offset(thread,wmma_type,wmma_layout,type,stride);
+  offset = thread_group_offset(thread, wmma_type, wmma_layout, type, stride);
 
-	if(wmma_type==LOAD_A){
-		if(wmma_layout==ROW){
-			offset+=index+8*((thread%16)/8);
-		}
-		else{
-			offset+=64*(index/4)+index%4+128*((thread%16)/8);	
-		}
-		offset=(offset/16)*stride+offset%16;
-		assg_offset=index+8*((thread%16)/8);
-	}
-	else if(wmma_type==LOAD_B){
-		if(wmma_layout==ROW){
-			offset+=64*(index/4)+index%4+128*((thread%16)/8);	
-		}
-		else{
-			offset+=index+8*((thread%16)/8);
-		}
-		offset=(offset/16)*stride+offset%16;
-		assg_offset=index+8*((thread%16)/8);
-	}
-	else if( wmma_type==LOAD_C){
-		if(type==F16_TYPE){
-			row=c_row_offset[thread/4]+thread%4;	
-			col=c_col_offset[thread/4]+index;
-		}
-		else{
-			row=c_row_offset[thread/4]+c_tg_inside_row_offset[thread%4]+c_inside_row_offset[index];
-			col=c_col_offset[thread/4]+c_tg_inside_col_offset[thread%4]+c_inside_col_offset[index];
-		}
-		assg_offset=index;
-	}
+  if (wmma_type == LOAD_A) {
+    if (wmma_layout == ROW) {
+      offset += index + 8 * ((thread % 16) / 8);
+    } else {
+      offset += 64 * (index / 4) + index % 4 + 128 * ((thread % 16) / 8);
+    }
+    offset = (offset / 16) * stride + offset % 16;
+    assg_offset = index + 8 * ((thread % 16) / 8);
+  } else if (wmma_type == LOAD_B) {
+    if (wmma_layout == ROW) {
+      offset += 64 * (index / 4) + index % 4 + 128 * ((thread % 16) / 8);
+    } else {
+      offset += index + 8 * ((thread % 16) / 8);
+    }
+    offset = (offset / 16) * stride + offset % 16;
+    assg_offset = index + 8 * ((thread % 16) / 8);
+  } else if (wmma_type == LOAD_C) {
+    if (type == F16_TYPE) {
+      row = c_row_offset[thread / 4] + thread % 4;
+      col = c_col_offset[thread / 4] + index;
+    } else {
+      row = c_row_offset[thread / 4] + c_tg_inside_row_offset[thread % 4] +
+            c_inside_row_offset[index];
+      col = c_col_offset[thread / 4] + c_tg_inside_col_offset[thread % 4] +
+            c_inside_col_offset[index];
+    }
+    assg_offset = index;
+  }
 
-	if(wmma_type==LOAD_A||wmma_type==LOAD_B){	
-		if(wmma_layout==ROW){
-			row=offset/16;
-			col=offset%16;
-		}
-		else{
-			col=offset/16;
-			row=offset%16;
-		}
-	}
-}
-
-void mma_impl( const ptx_instruction *pI, core_t *core, warp_inst_t inst )
-{
-	int i,j,k,thrd;
-	int row,col,offset;
-   	ptx_reg_t matrix_a[16][16];
-   	ptx_reg_t matrix_b[16][16];
-   	ptx_reg_t matrix_c[16][16];
-   	ptx_reg_t matrix_d[16][16];
-   	ptx_reg_t src_data;
-	ptx_thread_info *thread;
-
-	unsigned a_layout = pI->get_wmma_layout(0);
-	unsigned b_layout = pI->get_wmma_layout(1);
-	unsigned type = pI->get_type();
-	unsigned type2 = pI->get_type2();
-	int tid ;
-	const operand_info &dst = pI->operand_lookup(0);
-	
-        if(core->get_gpu()->is_functional_sim())
-         	tid= inst.warp_id_func()*core->get_warp_size();
-        else
-         	tid= inst.warp_id()*core->get_warp_size();
-	float temp;
-	half temp2; 	
-	
-	for (thrd=0; thrd < core->get_warp_size(); thrd++){
-		thread = core->get_thread_info()[tid+thrd];
-		if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-			printf("THREAD=%d\n:",thrd);
-		for(int operand_num=1;operand_num<=3;operand_num++){
-			const operand_info &src_a=  pI->operand_lookup(operand_num);
-         		unsigned nelem = src_a.get_vect_nelem();
-         		ptx_reg_t v[8];
-         		thread->get_vector_operand_values( src_a, v, nelem );
-			if(core->get_gpu()->gpgpu_ctx->debug_tensorcore){
-				printf("Thread%d_Iteration=%d\n:", thrd, operand_num);
-				for(k = 0; k < nelem; k++){
-					printf("%llx ",v[k].u64);
-				}
-				printf("\n");
-			}
-			ptx_reg_t nw_v[16];
-			int hex_val;
-
-			if(!((operand_num==3)&&(type2==F32_TYPE))){
-					for(k=0;k<2*nelem;k++){
-					if(k%2==1)
-						hex_val=(v[k/2].s64&0xffff);
-					else
-						hex_val=((v[k/2].s64&0xffff0000)>>16);
-					nw_v[k].f16 =*((half *)&hex_val); 
-				}
-			}
-			if(!((operand_num==3)&&(type2==F32_TYPE))){
-				for(k=0;k<2*nelem;k++){
-					temp=nw_v[k].f16;
-					if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-						printf("%.2f ",temp);
-				}
-				if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-					printf("\n");
-			}
-			else{
-				if(core->get_gpu()->gpgpu_ctx->debug_tensorcore){
-					for(k=0;k<8;k++){
-						printf("%.2f ",v[k].f32);
-					}
-					printf("\n");
-				}
-			}
-			switch(operand_num) {
-			      case 1 ://operand 1
-				for(k=0;k<8;k++){
-					mapping(thrd,LOAD_A,a_layout,F16_TYPE,k,16,row,col,offset);
-					if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-						printf("A:thread=%d,row=%d,col=%d,offset=%d\n",thrd,row,col,offset);
-				 	matrix_a[row][col]=nw_v[offset];
-			        }
-			      break;
-			      case 2 ://operand 2
-				for(k=0;k<8;k++){
-					mapping(thrd,LOAD_B,b_layout,F16_TYPE,k,16,row,col,offset);
-					if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-						printf("B:thread=%d,row=%d,col=%d,offset=%d\n",thrd,row,col,offset);
-				 	matrix_b[row][col]=nw_v[offset];
-				}	
-			      break;
-			      case 3 ://operand 3
-				for(k=0;k<8;k++){
-					mapping(thrd,LOAD_C,ROW,type2,k,16,row,col,offset);
-					if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-						printf("C:thread=%d,row=%d,col=%d,offset=%d\n",thrd,row,col,offset);
-					if(type2!=F16_TYPE){
-					 	matrix_c[row][col]=v[offset];
-					}
-					else {
-				 		matrix_c[row][col]=nw_v[offset];
-					}
-				}
-			        break;
-			      default :
-			         printf("Invalid Operand Index\n" );
-			}
-		}
-		if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-			printf("\n");
-	}
-	if(core->get_gpu()->gpgpu_ctx->debug_tensorcore){
-		printf("MATRIX_A\n");
-		for (i=0;i<16;i++){
-			for(j=0;j<16;j++){
-				temp=matrix_a[i][j].f16;
-				printf("%.2f ",temp);
-			}
-			printf("\n");
-		}
-		printf("MATRIX_B\n");
-		for (i=0;i<16;i++){
-			for(j=0;j<16;j++){
-				temp=matrix_b[i][j].f16;
-				printf("%.2f ",temp);
-			}
-			printf("\n");
-		}	
-		printf("MATRIX_C\n");
-		for (i=0;i<16;i++){
-			for(j=0;j<16;j++){
-				if(type2==F16_TYPE){
-					temp=matrix_c[i][j].f16;
-					printf("%.2f ",temp);
-				}
-				else
-					printf("%.2f ",matrix_c[i][j].f32);
-			}
-			printf("\n");
-		}	
-	}
-	for (i=0;i<16;i++){
-		for(j=0;j<16;j++){
-				matrix_d[i][j].f16=0;
-		}
-	}
-	
-	for (i=0;i<16;i++){
-		for(j=0;j<16;j++){
-			for(k=0;k<16;k++){
-				matrix_d[i][j].f16=matrix_d[i][j].f16+matrix_a[i][k].f16*matrix_b[k][j].f16;
-			}
-			if((type==F16_TYPE)&&(type2==F16_TYPE))
-				matrix_d[i][j].f16+=matrix_c[i][j].f16;
-			else if((type==F32_TYPE)&&(type2==F16_TYPE)){
-				temp2=matrix_d[i][j].f16+matrix_c[i][j].f16;
-				temp=temp2;
-				matrix_d[i][j].f32=temp;
-			}
-			else if((type==F16_TYPE)&&(type2==F32_TYPE)){
-				temp=matrix_d[i][j].f16;
-				temp+=matrix_c[i][j].f32;
-				matrix_d[i][j].f16=half(temp);
-			}
-			else{
-				temp=matrix_d[i][j].f16;
-				temp+=matrix_c[i][j].f32;
-				matrix_d[i][j].f32=temp;
-			}
-		}
-	}
-	if(core->get_gpu()->gpgpu_ctx->debug_tensorcore){
-		printf("MATRIX_D\n");
-		for (i=0;i<16;i++){
-			for(j=0;j<16;j++){
-				if(type==F16_TYPE){
-					temp=matrix_d[i][j].f16;
-					printf("%.2f ",temp);
-				}
-				else
-					printf("%.2f ",matrix_d[i][j].f32);
-			}
-			printf("\n");
-		}	
-	}
-	for (thrd=0; thrd < core->get_warp_size(); thrd++){
-		int row_t[8];
-		int col_t[8];	
-		for(k=0;k<8;k++){
-			mapping(thrd,LOAD_C,ROW,type,k,16,row_t[k],col_t[k],offset);
-			if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-				printf("mma:store:row:%d,col%d\n",row_t[k],col_t[k]);
-		}
-		thread = core->get_thread_info()[tid+thrd];
-		
-	
-		if(type==F32_TYPE){
-			thread->set_wmma_vector_operand_values(dst,matrix_d[row_t[0]][col_t[0]],matrix_d[row_t[1]][col_t[1]],matrix_d[row_t[2]][col_t[2]],matrix_d[row_t[3]][col_t[3]],matrix_d[row_t[4]][col_t[4]],matrix_d[row_t[5]][col_t[5]],matrix_d[row_t[6]][col_t[6]],matrix_d[row_t[7]][col_t[7]]);
-		
-			if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-			{
-				printf("thread%d:",thrd);
-				for(k=0;k<8;k++){
-					printf("%.2f ",matrix_d[row_t[k]][col_t[k]].f32);
-				}
-				printf("\n");
-			}
-		}
-		else if(type==F16_TYPE){
-			if(core->get_gpu()->gpgpu_ctx->debug_tensorcore){	
-				printf("thread%d:",thrd);
-				for(k=0;k<8;k++){
-					temp=matrix_d[row_t[k]][col_t[k]].f16;
-					printf("%.2f ",temp);
-				}
-				printf("\n");
-
-				printf("thread%d:",thrd);
-				for(k=0;k<8;k++){
-					printf("%x ", (unsigned int)matrix_d[row_t[k]][col_t[k]].f16);
-				}
-				printf("\n");
-			}
-			ptx_reg_t nw_data1, nw_data2, nw_data3, nw_data4;
-			nw_data1.s64=((matrix_d[row_t[0]][col_t[0]].s64   & 0xffff))|((matrix_d[row_t[1]][col_t[1]].s64&0xffff)<<16);
-			nw_data2.s64=((matrix_d[row_t[2]][col_t[2]].s64   & 0xffff))|((matrix_d[row_t[3]][col_t[3]].s64&0xffff)<<16);
-			nw_data3.s64=((matrix_d[row_t[4]][col_t[4]].s64   & 0xffff))|((matrix_d[row_t[5]][col_t[5]].s64&0xffff)<<16);
-			nw_data4.s64=((matrix_d[row_t[6]][col_t[6]].s64   & 0xffff))|((matrix_d[row_t[7]][col_t[7]].s64&0xffff)<<16);
-   			thread->set_vector_operand_values(dst,nw_data1,nw_data2,nw_data3,nw_data4);
-			if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-		 		printf("thread%d=%llx,%llx,%llx,%llx", thrd, nw_data1.s64, nw_data2.s64, nw_data3.s64, nw_data4.s64);
-		
-		}
-		else{
-			printf("wmma:mma:wrong type\n");
-			abort();
-		}
-	}
+  if (wmma_type == LOAD_A || wmma_type == LOAD_B) {
+    if (wmma_layout == ROW) {
+      row = offset / 16;
+      col = offset % 16;
+    } else {
+      col = offset / 16;
+      row = offset % 16;
+    }
+  }
 }
 
-void call_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   static unsigned call_uid_next = 1;
-    
-   const operand_info &target  = pI->func_addr();
-   assert( target.is_function_address() );
-   const symbol *func_addr = target.get_symbol();
-   function_info *target_func = func_addr->get_pc();
-   if (target_func->is_pdom_set()) {
-      printf("GPGPU-Sim PTX: PDOM analysis already done for %s \n", target_func->get_name().c_str() );
-   } else {
-      printf("GPGPU-Sim PTX: finding reconvergence points for \'%s\'...\n", target_func->get_name().c_str() );
-      /*
-       * Some of the instructions like printf() gives the gpgpusim the wrong impression that it is a function call.
-       * As printf() doesnt have a body like functions do, doing pdom analysis for printf() causes a crash.
-       */
-      if (target_func->get_function_size() >0)
-          target_func->do_pdom();
-      target_func->set_pdom();
-   }
+void mma_impl(const ptx_instruction *pI, core_t *core, warp_inst_t inst) {
+  int i, j, k, thrd;
+  int row, col, offset;
+  ptx_reg_t matrix_a[16][16];
+  ptx_reg_t matrix_b[16][16];
+  ptx_reg_t matrix_c[16][16];
+  ptx_reg_t matrix_d[16][16];
+  ptx_reg_t src_data;
+  ptx_thread_info *thread;
 
-   // check that number of args and return match function requirements
-   if( pI->has_return() ^ target_func->has_return() ) {
-      printf("GPGPU-Sim PTX: Execution error - mismatch in number of return values between\n"
-             "               call instruction and function declaration\n");
-      abort(); 
-   }
-   unsigned n_return = target_func->has_return();
-   unsigned n_args = target_func->num_args();
-   unsigned n_operands = pI->get_num_operands();
+  unsigned a_layout = pI->get_wmma_layout(0);
+  unsigned b_layout = pI->get_wmma_layout(1);
+  unsigned type = pI->get_type();
+  unsigned type2 = pI->get_type2();
+  int tid;
+  const operand_info &dst = pI->operand_lookup(0);
 
-   if( n_operands != (n_return+1+n_args) ) {
-      printf("GPGPU-Sim PTX: Execution error - mismatch in number of arguements between\n"
-             "               call instruction and function declaration\n");
-      abort(); 
-   }
+  if (core->get_gpu()->is_functional_sim())
+    tid = inst.warp_id_func() * core->get_warp_size();
+  else
+    tid = inst.warp_id() * core->get_warp_size();
+  float temp;
+  half temp2;
 
-   // handle intrinsic functions
-   std::string fname = target_func->get_name();
-   if( fname == "vprintf" ) {
-      gpgpusim_cuda_vprintf(pI, thread, target_func);
-      return;
-   }
+  for (thrd = 0; thrd < core->get_warp_size(); thrd++) {
+    thread = core->get_thread_info()[tid + thrd];
+    if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+      printf("THREAD=%d\n:", thrd);
+    for (int operand_num = 1; operand_num <= 3; operand_num++) {
+      const operand_info &src_a = pI->operand_lookup(operand_num);
+      unsigned nelem = src_a.get_vect_nelem();
+      ptx_reg_t v[8];
+      thread->get_vector_operand_values(src_a, v, nelem);
+      if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) {
+        printf("Thread%d_Iteration=%d\n:", thrd, operand_num);
+        for (k = 0; k < nelem; k++) {
+          printf("%llx ", v[k].u64);
+        }
+        printf("\n");
+      }
+      ptx_reg_t nw_v[16];
+      int hex_val;
 
+      if (!((operand_num == 3) && (type2 == F32_TYPE))) {
+        for (k = 0; k < 2 * nelem; k++) {
+          if (k % 2 == 1)
+            hex_val = (v[k / 2].s64 & 0xffff);
+          else
+            hex_val = ((v[k / 2].s64 & 0xffff0000) >> 16);
+          nw_v[k].f16 = *((half *)&hex_val);
+        }
+      }
+      if (!((operand_num == 3) && (type2 == F32_TYPE))) {
+        for (k = 0; k < 2 * nelem; k++) {
+          temp = nw_v[k].f16;
+          if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+            printf("%.2f ", temp);
+        }
+        if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) printf("\n");
+      } else {
+        if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) {
+          for (k = 0; k < 8; k++) {
+            printf("%.2f ", v[k].f32);
+          }
+          printf("\n");
+        }
+      }
+      switch (operand_num) {
+        case 1:  // operand 1
+          for (k = 0; k < 8; k++) {
+            mapping(thrd, LOAD_A, a_layout, F16_TYPE, k, 16, row, col, offset);
+            if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+              printf("A:thread=%d,row=%d,col=%d,offset=%d\n", thrd, row, col,
+                     offset);
+            matrix_a[row][col] = nw_v[offset];
+          }
+          break;
+        case 2:  // operand 2
+          for (k = 0; k < 8; k++) {
+            mapping(thrd, LOAD_B, b_layout, F16_TYPE, k, 16, row, col, offset);
+            if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+              printf("B:thread=%d,row=%d,col=%d,offset=%d\n", thrd, row, col,
+                     offset);
+            matrix_b[row][col] = nw_v[offset];
+          }
+          break;
+        case 3:  // operand 3
+          for (k = 0; k < 8; k++) {
+            mapping(thrd, LOAD_C, ROW, type2, k, 16, row, col, offset);
+            if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+              printf("C:thread=%d,row=%d,col=%d,offset=%d\n", thrd, row, col,
+                     offset);
+            if (type2 != F16_TYPE) {
+              matrix_c[row][col] = v[offset];
+            } else {
+              matrix_c[row][col] = nw_v[offset];
+            }
+          }
+          break;
+        default:
+          printf("Invalid Operand Index\n");
+      }
+    }
+    if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) printf("\n");
+  }
+  if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) {
+    printf("MATRIX_A\n");
+    for (i = 0; i < 16; i++) {
+      for (j = 0; j < 16; j++) {
+        temp = matrix_a[i][j].f16;
+        printf("%.2f ", temp);
+      }
+      printf("\n");
+    }
+    printf("MATRIX_B\n");
+    for (i = 0; i < 16; i++) {
+      for (j = 0; j < 16; j++) {
+        temp = matrix_b[i][j].f16;
+        printf("%.2f ", temp);
+      }
+      printf("\n");
+    }
+    printf("MATRIX_C\n");
+    for (i = 0; i < 16; i++) {
+      for (j = 0; j < 16; j++) {
+        if (type2 == F16_TYPE) {
+          temp = matrix_c[i][j].f16;
+          printf("%.2f ", temp);
+        } else
+          printf("%.2f ", matrix_c[i][j].f32);
+      }
+      printf("\n");
+    }
+  }
+  for (i = 0; i < 16; i++) {
+    for (j = 0; j < 16; j++) {
+      matrix_d[i][j].f16 = 0;
+    }
+  }
+
+  for (i = 0; i < 16; i++) {
+    for (j = 0; j < 16; j++) {
+      for (k = 0; k < 16; k++) {
+        matrix_d[i][j].f16 =
+            matrix_d[i][j].f16 + matrix_a[i][k].f16 * matrix_b[k][j].f16;
+      }
+      if ((type == F16_TYPE) && (type2 == F16_TYPE))
+        matrix_d[i][j].f16 += matrix_c[i][j].f16;
+      else if ((type == F32_TYPE) && (type2 == F16_TYPE)) {
+        temp2 = matrix_d[i][j].f16 + matrix_c[i][j].f16;
+        temp = temp2;
+        matrix_d[i][j].f32 = temp;
+      } else if ((type == F16_TYPE) && (type2 == F32_TYPE)) {
+        temp = matrix_d[i][j].f16;
+        temp += matrix_c[i][j].f32;
+        matrix_d[i][j].f16 = half(temp);
+      } else {
+        temp = matrix_d[i][j].f16;
+        temp += matrix_c[i][j].f32;
+        matrix_d[i][j].f32 = temp;
+      }
+    }
+  }
+  if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) {
+    printf("MATRIX_D\n");
+    for (i = 0; i < 16; i++) {
+      for (j = 0; j < 16; j++) {
+        if (type == F16_TYPE) {
+          temp = matrix_d[i][j].f16;
+          printf("%.2f ", temp);
+        } else
+          printf("%.2f ", matrix_d[i][j].f32);
+      }
+      printf("\n");
+    }
+  }
+  for (thrd = 0; thrd < core->get_warp_size(); thrd++) {
+    int row_t[8];
+    int col_t[8];
+    for (k = 0; k < 8; k++) {
+      mapping(thrd, LOAD_C, ROW, type, k, 16, row_t[k], col_t[k], offset);
+      if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+        printf("mma:store:row:%d,col%d\n", row_t[k], col_t[k]);
+    }
+    thread = core->get_thread_info()[tid + thrd];
+
+    if (type == F32_TYPE) {
+      thread->set_wmma_vector_operand_values(
+          dst, matrix_d[row_t[0]][col_t[0]], matrix_d[row_t[1]][col_t[1]],
+          matrix_d[row_t[2]][col_t[2]], matrix_d[row_t[3]][col_t[3]],
+          matrix_d[row_t[4]][col_t[4]], matrix_d[row_t[5]][col_t[5]],
+          matrix_d[row_t[6]][col_t[6]], matrix_d[row_t[7]][col_t[7]]);
+
+      if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) {
+        printf("thread%d:", thrd);
+        for (k = 0; k < 8; k++) {
+          printf("%.2f ", matrix_d[row_t[k]][col_t[k]].f32);
+        }
+        printf("\n");
+      }
+    } else if (type == F16_TYPE) {
+      if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) {
+        printf("thread%d:", thrd);
+        for (k = 0; k < 8; k++) {
+          temp = matrix_d[row_t[k]][col_t[k]].f16;
+          printf("%.2f ", temp);
+        }
+        printf("\n");
+
+        printf("thread%d:", thrd);
+        for (k = 0; k < 8; k++) {
+          printf("%x ", (unsigned int)matrix_d[row_t[k]][col_t[k]].f16);
+        }
+        printf("\n");
+      }
+      ptx_reg_t nw_data1, nw_data2, nw_data3, nw_data4;
+      nw_data1.s64 = ((matrix_d[row_t[0]][col_t[0]].s64 & 0xffff)) |
+                     ((matrix_d[row_t[1]][col_t[1]].s64 & 0xffff) << 16);
+      nw_data2.s64 = ((matrix_d[row_t[2]][col_t[2]].s64 & 0xffff)) |
+                     ((matrix_d[row_t[3]][col_t[3]].s64 & 0xffff) << 16);
+      nw_data3.s64 = ((matrix_d[row_t[4]][col_t[4]].s64 & 0xffff)) |
+                     ((matrix_d[row_t[5]][col_t[5]].s64 & 0xffff) << 16);
+      nw_data4.s64 = ((matrix_d[row_t[6]][col_t[6]].s64 & 0xffff)) |
+                     ((matrix_d[row_t[7]][col_t[7]].s64 & 0xffff) << 16);
+      thread->set_vector_operand_values(dst, nw_data1, nw_data2, nw_data3,
+                                        nw_data4);
+      if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+        printf("thread%d=%llx,%llx,%llx,%llx", thrd, nw_data1.s64, nw_data2.s64,
+               nw_data3.s64, nw_data4.s64);
+
+    } else {
+      printf("wmma:mma:wrong type\n");
+      abort();
+    }
+  }
+}
+
+void call_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  static unsigned call_uid_next = 1;
+
+  const operand_info &target = pI->func_addr();
+  assert(target.is_function_address());
+  const symbol *func_addr = target.get_symbol();
+  function_info *target_func = func_addr->get_pc();
+  if (target_func->is_pdom_set()) {
+    printf("GPGPU-Sim PTX: PDOM analysis already done for %s \n",
+           target_func->get_name().c_str());
+  } else {
+    printf("GPGPU-Sim PTX: finding reconvergence points for \'%s\'...\n",
+           target_func->get_name().c_str());
+    /*
+     * Some of the instructions like printf() gives the gpgpusim the wrong
+     * impression that it is a function call. As printf() doesnt have a body
+     * like functions do, doing pdom analysis for printf() causes a crash.
+     */
+    if (target_func->get_function_size() > 0) target_func->do_pdom();
+    target_func->set_pdom();
+  }
+
+  // check that number of args and return match function requirements
+  if (pI->has_return() ^ target_func->has_return()) {
+    printf(
+        "GPGPU-Sim PTX: Execution error - mismatch in number of return values "
+        "between\n"
+        "               call instruction and function declaration\n");
+    abort();
+  }
+  unsigned n_return = target_func->has_return();
+  unsigned n_args = target_func->num_args();
+  unsigned n_operands = pI->get_num_operands();
+
+  if (n_operands != (n_return + 1 + n_args)) {
+    printf(
+        "GPGPU-Sim PTX: Execution error - mismatch in number of arguements "
+        "between\n"
+        "               call instruction and function declaration\n");
+    abort();
+  }
+
+  // handle intrinsic functions
+  std::string fname = target_func->get_name();
+  if (fname == "vprintf") {
+    gpgpusim_cuda_vprintf(pI, thread, target_func);
+    return;
+  }
 #if (CUDART_VERSION >= 5000)
-   //Jin: handle device runtime apis for CDP
-   else if(fname == "cudaGetParameterBufferV2") {
-      target_func->gpgpu_ctx->device_runtime->gpgpusim_cuda_getParameterBufferV2(pI, thread, target_func);
-	  return;
-   }
-   else if(fname == "cudaLaunchDeviceV2") {
-      target_func->gpgpu_ctx->device_runtime->gpgpusim_cuda_launchDeviceV2(pI, thread, target_func);
-	  return;
-   }
-   else if(fname == "cudaStreamCreateWithFlags") {
-      target_func->gpgpu_ctx->device_runtime->gpgpusim_cuda_streamCreateWithFlags(pI, thread, target_func);
-	  return;
-   }
+  // Jin: handle device runtime apis for CDP
+  else if (fname == "cudaGetParameterBufferV2") {
+    target_func->gpgpu_ctx->device_runtime->gpgpusim_cuda_getParameterBufferV2(
+        pI, thread, target_func);
+    return;
+  } else if (fname == "cudaLaunchDeviceV2") {
+    target_func->gpgpu_ctx->device_runtime->gpgpusim_cuda_launchDeviceV2(
+        pI, thread, target_func);
+    return;
+  } else if (fname == "cudaStreamCreateWithFlags") {
+    target_func->gpgpu_ctx->device_runtime->gpgpusim_cuda_streamCreateWithFlags(
+        pI, thread, target_func);
+    return;
+  }
 #endif
 
-   // read source arguements into register specified in declaration of function
-   arg_buffer_list_t arg_values;
-   copy_args_into_buffer_list(pI, thread, target_func, arg_values);
+  // read source arguements into register specified in declaration of function
+  arg_buffer_list_t arg_values;
+  copy_args_into_buffer_list(pI, thread, target_func, arg_values);
 
-   // record local for return value (we only support a single return value)
-   const symbol *return_var_src = NULL;
-   const symbol *return_var_dst = NULL;
-   if( target_func->has_return() ) {
-      return_var_dst = pI->dst().get_symbol();
-      return_var_src = target_func->get_return_var();
-   }
+  // record local for return value (we only support a single return value)
+  const symbol *return_var_src = NULL;
+  const symbol *return_var_dst = NULL;
+  if (target_func->has_return()) {
+    return_var_dst = pI->dst().get_symbol();
+    return_var_src = target_func->get_return_var();
+  }
 
-   gpgpu_sim *gpu = thread->get_gpu();
-   unsigned callee_pc=0, callee_rpc=0;
-   if( gpu->simd_model() == POST_DOMINATOR ) {
-      thread->get_core()->get_pdom_stack_top_info(thread->get_hw_wid(),&callee_pc,&callee_rpc);
-      assert( callee_pc == thread->get_pc() );
-   }
+  gpgpu_sim *gpu = thread->get_gpu();
+  unsigned callee_pc = 0, callee_rpc = 0;
+  if (gpu->simd_model() == POST_DOMINATOR) {
+    thread->get_core()->get_pdom_stack_top_info(thread->get_hw_wid(),
+                                                &callee_pc, &callee_rpc);
+    assert(callee_pc == thread->get_pc());
+  }
 
-   thread->callstack_push(callee_pc + pI->inst_size(), callee_rpc, return_var_src, return_var_dst, call_uid_next++);
+  thread->callstack_push(callee_pc + pI->inst_size(), callee_rpc,
+                         return_var_src, return_var_dst, call_uid_next++);
 
-   copy_buffer_list_into_frame(thread, arg_values);
+  copy_buffer_list_into_frame(thread, arg_values);
 
-   thread->set_npc(target_func);
+  thread->set_npc(target_func);
 }
 
-//Ptxplus version of call instruction. Jumps to a label not a different Kernel.
-void callp_impl( const ptx_instruction *pI, ptx_thread_info *thread )
-{
-   
-   static unsigned call_uid_next = 1;
+// Ptxplus version of call instruction. Jumps to a label not a different Kernel.
+void callp_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  static unsigned call_uid_next = 1;
 
-   const operand_info &target  = pI->dst();
-   ptx_reg_t target_pc = thread->get_operand_value(target, target, U32_TYPE, thread, 1);
+  const operand_info &target = pI->dst();
+  ptx_reg_t target_pc =
+      thread->get_operand_value(target, target, U32_TYPE, thread, 1);
 
-   const symbol *return_var_src = NULL;
-   const symbol *return_var_dst = NULL;
+  const symbol *return_var_src = NULL;
+  const symbol *return_var_dst = NULL;
 
-   gpgpu_sim *gpu = thread->get_gpu();
-   unsigned callee_pc=0, callee_rpc=0;
-   if( gpu->simd_model() == POST_DOMINATOR ) {
-      thread->get_core()->get_pdom_stack_top_info(thread->get_hw_wid(),&callee_pc,&callee_rpc);
-      assert( callee_pc == thread->get_pc() );
-   } 
+  gpgpu_sim *gpu = thread->get_gpu();
+  unsigned callee_pc = 0, callee_rpc = 0;
+  if (gpu->simd_model() == POST_DOMINATOR) {
+    thread->get_core()->get_pdom_stack_top_info(thread->get_hw_wid(),
+                                                &callee_pc, &callee_rpc);
+    assert(callee_pc == thread->get_pc());
+  }
 
-   thread->callstack_push_plus(callee_pc + pI->inst_size(), callee_rpc, return_var_src, return_var_dst, call_uid_next++);
-   thread->set_npc(target_pc);
+  thread->callstack_push_plus(callee_pc + pI->inst_size(), callee_rpc,
+                              return_var_src, return_var_dst, call_uid_next++);
+  thread->set_npc(target_pc);
 }
 
-void clz_impl( const ptx_instruction *pI, ptx_thread_info *thread )
-{
-   ptx_reg_t a, d;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
+void clz_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, d;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
 
-   unsigned i_type = pI->get_type();
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
 
-   int max;
-   unsigned long long mask;
-   d.u64 = 0;
+  int max;
+  unsigned long long mask;
+  d.u64 = 0;
 
-   switch ( i_type ) {
-   case B32_TYPE:
+  switch (i_type) {
+    case B32_TYPE:
       max = 32;
       mask = 0x80000000;
       break;
-   case B64_TYPE:
+    case B64_TYPE:
       max = 64;
       mask = 0x8000000000000000;
       break;
-   default:
+    default:
       printf("Execution error: type mismatch with instruction\n");
       assert(0);
       break;
-   }
+  }
 
-   while ((d.u32 < max) && ((a.u64&mask) == 0) ) {
-      d.u32++;
-      a.u64 = a.u64 << 1;
-   }
+  while ((d.u32 < max) && ((a.u64 & mask) == 0)) {
+    d.u32++;
+    a.u64 = a.u64 << 1;
+  }
 
-   thread->set_operand_value(dst,d, B32_TYPE, thread, pI);
+  thread->set_operand_value(dst, d, B32_TYPE, thread, pI);
 }
 
-void cnot_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t a, b, d;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
+void cnot_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, b, d;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
 
-   unsigned i_type = pI->get_type();
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
 
-   switch ( i_type ) {
-   case PRED_TYPE: d.pred = ((a.pred & 0x0001) == 0)?1:0; break;
-   case B16_TYPE:  d.u16  = (a.u16  == 0)?1:0; break;
-   case B32_TYPE:  d.u32  = (a.u32  == 0)?1:0; break;
-   case B64_TYPE:  d.u64  = (a.u64  == 0)?1:0; break;
-   default:
+  switch (i_type) {
+    case PRED_TYPE:
+      d.pred = ((a.pred & 0x0001) == 0) ? 1 : 0;
+      break;
+    case B16_TYPE:
+      d.u16 = (a.u16 == 0) ? 1 : 0;
+      break;
+    case B32_TYPE:
+      d.u32 = (a.u32 == 0) ? 1 : 0;
+      break;
+    case B64_TYPE:
+      d.u64 = (a.u64 == 0) ? 1 : 0;
+      break;
+    default:
       printf("Execution error: type mismatch with instruction\n");
       assert(0);
       break;
-   }
+  }
 
-   thread->set_operand_value(dst,d, i_type, thread, pI);
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-void cos_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   ptx_reg_t a, d;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
+void cos_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, d;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
 
-   unsigned i_type = pI->get_type();
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
 
-
-   switch ( i_type ) {
-   case F32_TYPE: 
+  switch (i_type) {
+    case F32_TYPE:
       d.f32 = cos(a.f32);
       break;
-   default:
+    default:
       printf("Execution error: type mismatch with instruction\n");
-      assert(0); 
+      assert(0);
       break;
-   }
+  }
 
-   thread->set_operand_value(dst,d, i_type, thread, pI);
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-ptx_reg_t chop( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
-{
-   switch ( to_width ) {
-   case 8:  x.mask_and(0,0xFF);  break;
-   case 16: x.mask_and(0,0xFFFF);      break;
-   case 32: x.mask_and(0,0xFFFFFFFF);  break;
-   case 64: break;
-   default: assert(0);
-   }
-   return x;
+ptx_reg_t chop(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
+               int rounding_mode, int saturation_mode) {
+  switch (to_width) {
+    case 8:
+      x.mask_and(0, 0xFF);
+      break;
+    case 16:
+      x.mask_and(0, 0xFFFF);
+      break;
+    case 32:
+      x.mask_and(0, 0xFFFFFFFF);
+      break;
+    case 64:
+      break;
+    default:
+      assert(0);
+  }
+  return x;
 }
 
-ptx_reg_t sext( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
-{
-   x=chop(x,0,from_width,0,rounding_mode,saturation_mode);
-   switch ( from_width ) {
-   case 8: if ( x.get_bit(7) ) x.mask_or(0xFFFFFFFF,0xFFFFFF00);break;
-   case 16:if ( x.get_bit(15) ) x.mask_or(0xFFFFFFFF,0xFFFF0000);break;
-   case 32: if ( x.get_bit(31) ) x.mask_or(0xFFFFFFFF,0x00000000);break;
-   case 64: break;
-   default: assert(0);
-   }
-   return x;
+ptx_reg_t sext(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
+               int rounding_mode, int saturation_mode) {
+  x = chop(x, 0, from_width, 0, rounding_mode, saturation_mode);
+  switch (from_width) {
+    case 8:
+      if (x.get_bit(7)) x.mask_or(0xFFFFFFFF, 0xFFFFFF00);
+      break;
+    case 16:
+      if (x.get_bit(15)) x.mask_or(0xFFFFFFFF, 0xFFFF0000);
+      break;
+    case 32:
+      if (x.get_bit(31)) x.mask_or(0xFFFFFFFF, 0x00000000);
+      break;
+    case 64:
+      break;
+    default:
+      assert(0);
+  }
+  return x;
 }
 
-// sign extend depending on the destination register size - hack to get SobelFilter working in CUDA 4.2
-ptx_reg_t sexd( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
-{
-   x=chop(x,0,from_width,0,rounding_mode,saturation_mode);
-   switch ( to_width ) {
-   case 8: if ( x.get_bit(7) ) x.mask_or(0xFFFFFFFF,0xFFFFFF00);break;
-   case 16:if ( x.get_bit(15) ) x.mask_or(0xFFFFFFFF,0xFFFF0000);break;
-   case 32: if ( x.get_bit(31) ) x.mask_or(0xFFFFFFFF,0x00000000);break;
-   case 64: break;
-   default: assert(0);
-   }
-   return x;
+// sign extend depending on the destination register size - hack to get
+// SobelFilter working in CUDA 4.2
+ptx_reg_t sexd(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
+               int rounding_mode, int saturation_mode) {
+  x = chop(x, 0, from_width, 0, rounding_mode, saturation_mode);
+  switch (to_width) {
+    case 8:
+      if (x.get_bit(7)) x.mask_or(0xFFFFFFFF, 0xFFFFFF00);
+      break;
+    case 16:
+      if (x.get_bit(15)) x.mask_or(0xFFFFFFFF, 0xFFFF0000);
+      break;
+    case 32:
+      if (x.get_bit(31)) x.mask_or(0xFFFFFFFF, 0x00000000);
+      break;
+    case 64:
+      break;
+    default:
+      assert(0);
+  }
+  return x;
 }
 
-ptx_reg_t zext( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
-{
-   return chop(x,0,from_width,0,rounding_mode,saturation_mode);
+ptx_reg_t zext(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
+               int rounding_mode, int saturation_mode) {
+  return chop(x, 0, from_width, 0, rounding_mode, saturation_mode);
 }
 
-int saturatei(int a, int max, int min) 
-{
-   if (a > max) a = max;
-   else if (a < min) a = min;
-   return a;
+int saturatei(int a, int max, int min) {
+  if (a > max)
+    a = max;
+  else if (a < min)
+    a = min;
+  return a;
 }
 
-unsigned int saturatei(unsigned int a, unsigned int max) 
-{
-   if (a > max) a = max;
-   return a;
+unsigned int saturatei(unsigned int a, unsigned int max) {
+  if (a > max) a = max;
+  return a;
 }
 
-ptx_reg_t f2x( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
-{
-   half mytemp;
-   half_float::half tmp_h;
-   //assert( from_width == 32); 
+ptx_reg_t f2x(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
+              int rounding_mode, int saturation_mode) {
+  half mytemp;
+  half_float::half tmp_h;
+  // assert( from_width == 32);
 
-   enum cudaRoundMode mode = cudaRoundZero;
-   switch (rounding_mode) {
-   case RZI_OPTION: mode = cudaRoundZero;    break;
-   case RNI_OPTION: mode = cudaRoundNearest; break;
-   case RMI_OPTION: mode = cudaRoundMinInf;  break;
-   case RPI_OPTION: mode = cudaRoundPosInf;  break;
-   default: break; 
-   }
+  enum cudaRoundMode mode = cudaRoundZero;
+  switch (rounding_mode) {
+    case RZI_OPTION:
+      mode = cudaRoundZero;
+      break;
+    case RNI_OPTION:
+      mode = cudaRoundNearest;
+      break;
+    case RMI_OPTION:
+      mode = cudaRoundMinInf;
+      break;
+    case RPI_OPTION:
+      mode = cudaRoundPosInf;
+      break;
+    default:
+      break;
+  }
 
-   ptx_reg_t y;
-   if ( to_sign == 1 ) { // convert to 64-bit number first?
-      int tmp = cuda_math::float2int(x.f32, mode);
-      if ((x.u32 & 0x7f800000) == 0)
-         tmp = 0; // round denorm. FP to 0
-      if (saturation_mode && to_width < 32) {
-         tmp = saturatei(tmp, (1<<to_width) - 1, -(1<<to_width));
-      }
-      switch ( to_width ) {
-      case 8:  y.s8  = (char)tmp; break;
-      case 16: y.s16 = (short)tmp; break;
-      case 32: y.s32 = (int)tmp; break;
-      case 64: y.s64 = (long long)tmp; break;
-      default: assert(0); break;
-      }
-   } else if ( to_sign == 0 ) {
-      unsigned int tmp = cuda_math::float2uint(x.f32, mode);
-      if ((x.u32 & 0x7f800000) == 0)
-         tmp = 0; // round denorm. FP to 0
-      if (saturation_mode && to_width < 32) {
-         tmp = saturatei(tmp, (1<<to_width) - 1);
-      }
-      switch ( to_width ) {
-      case 8:  y.u8  = (unsigned char)tmp; break;
-      case 16: y.u16 = (unsigned short)tmp; break;
-      case 32: y.u32 = (unsigned int)tmp; break;
-      case 64: y.u64 = (unsigned long long)tmp; break;
-      default: assert(0); break;
-      }
-   } else {
-      switch ( to_width ) {
-      case 16: 
-	 y.f16 =half_float::half_cast<half,std::numeric_limits<float>::round_style>(x.f32);//mytemp;
- 	 break;
-      case 32: 
-	 y.f32=float(x.f16);
-	 break; // handled by f2f
-      case 64: 
-         y.f64 = x.f32; 
-         break;
-      default: assert(0); break;
-      }
-   }
-   return y;
-}
-
-double saturated2i (double a, double max, double min) {
-   if (a > max) a = max;
-   else if (a < min) a = min;
-   return a;
-}
-
-ptx_reg_t d2x( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
-{
-   assert( from_width == 64); 
-
-   double tmp;
-   switch (rounding_mode) {
-   case RZI_OPTION: tmp = trunc(x.f64);     break;
-   case RNI_OPTION: tmp = nearbyint(x.f64); break;
-   case RMI_OPTION: tmp = floor(x.f64);     break;
-   case RPI_OPTION: tmp = ceil(x.f64);      break;
-   default: tmp = x.f64; break; 
-   }
-
-   ptx_reg_t y;
-   if ( to_sign == 1 ) {
-      tmp = saturated2i(tmp, ((1<<(to_width - 1)) - 1), (1<<(to_width - 1)) );
-      switch ( to_width ) {
-      case 8:  y.s8  = (char)tmp; break;
-      case 16: y.s16 = (short)tmp; break;
-      case 32: y.s32 = (int)tmp; break;
-      case 64: y.s64 = (long long)tmp; break;
-      default: assert(0); break;
-      }
-   } else if ( to_sign == 0 ) {
-      tmp = saturated2i(tmp, ((1<<(to_width - 1)) - 1), 0);
-      switch ( to_width ) {
-      case 8:  y.u8  = (unsigned char)tmp; break;
-      case 16: y.u16 = (unsigned short)tmp; break;
-      case 32: y.u32 = (unsigned int)tmp; break;
-      case 64: y.u64 = (unsigned long long)tmp; break;
-      default: assert(0); break;
-      }
-   } else {
-      switch ( to_width ) {
-      case 16: assert(0); break;
+  ptx_reg_t y;
+  if (to_sign == 1) {  // convert to 64-bit number first?
+    int tmp = cuda_math::float2int(x.f32, mode);
+    if ((x.u32 & 0x7f800000) == 0) tmp = 0;  // round denorm. FP to 0
+    if (saturation_mode && to_width < 32) {
+      tmp = saturatei(tmp, (1 << to_width) - 1, -(1 << to_width));
+    }
+    switch (to_width) {
+      case 8:
+        y.s8 = (char)tmp;
+        break;
+      case 16:
+        y.s16 = (short)tmp;
+        break;
       case 32:
-         y.f32 = x.f64;  
-         break;
-      case 64: 
-         y.f64 = x.f64; // should be handled by d2d
-         break;
-      default: assert(0); break;
-      }
-   }
-   return y;
+        y.s32 = (int)tmp;
+        break;
+      case 64:
+        y.s64 = (long long)tmp;
+        break;
+      default:
+        assert(0);
+        break;
+    }
+  } else if (to_sign == 0) {
+    unsigned int tmp = cuda_math::float2uint(x.f32, mode);
+    if ((x.u32 & 0x7f800000) == 0) tmp = 0;  // round denorm. FP to 0
+    if (saturation_mode && to_width < 32) {
+      tmp = saturatei(tmp, (1 << to_width) - 1);
+    }
+    switch (to_width) {
+      case 8:
+        y.u8 = (unsigned char)tmp;
+        break;
+      case 16:
+        y.u16 = (unsigned short)tmp;
+        break;
+      case 32:
+        y.u32 = (unsigned int)tmp;
+        break;
+      case 64:
+        y.u64 = (unsigned long long)tmp;
+        break;
+      default:
+        assert(0);
+        break;
+    }
+  } else {
+    switch (to_width) {
+      case 16:
+        y.f16 = half_float::half_cast<half,
+                                      std::numeric_limits<float>::round_style>(
+            x.f32);  // mytemp;
+        break;
+      case 32:
+        y.f32 = float(x.f16);
+        break;  // handled by f2f
+      case 64:
+        y.f64 = x.f32;
+        break;
+      default:
+        assert(0);
+        break;
+    }
+  }
+  return y;
 }
 
-ptx_reg_t s2f( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
-{
-   ptx_reg_t y;
-
-   if (from_width < 64) { // 32-bit conversion
-      y = sext(x,from_width,32,0,rounding_mode,saturation_mode);
-
-      switch ( to_width ) {
-      case 16: assert(0); break;
-      case 32: 
-         switch (rounding_mode) {
-         case RZ_OPTION: y.f32 = cuda_math::__int2float_rz(y.s32); break;
-         case RN_OPTION: y.f32 = cuda_math::__int2float_rn(y.s32); break;
-         case RM_OPTION: y.f32 = cuda_math::__int2float_rd(y.s32); break;
-         case RP_OPTION: y.f32 = cuda_math::__int2float_ru(y.s32); break;
-         default: break; 
-         }
-         break;
-      case 64: y.f64 = y.s32; break; // no rounding needed
-      default: assert(0); break;
-      }
-   } else {
-      switch ( to_width ) {
-      case 16: assert(0); break;
-      case 32: 
-         switch (rounding_mode) {
-         case RZ_OPTION: y.f32 = cuda_math::__ll2float_rz(y.s64); break; 
-         case RN_OPTION: y.f32 = cuda_math::__ll2float_rn(y.s64); break;
-         case RM_OPTION: y.f32 = cuda_math::__ll2float_rd(y.s64); break; 
-         case RP_OPTION: y.f32 = cuda_math::__ll2float_ru(y.s64); break;
-         default: break; 
-         }
-         break;
-      case 64: y.f64 = y.s64; break; // no internal implementation found
-      default: assert(0); break;
-      }
-   }
-
-   // saturating an integer to 1 or 0?
-   return y;
+double saturated2i(double a, double max, double min) {
+  if (a > max)
+    a = max;
+  else if (a < min)
+    a = min;
+  return a;
 }
 
-ptx_reg_t u2f( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
-{
-   ptx_reg_t y;
+ptx_reg_t d2x(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
+              int rounding_mode, int saturation_mode) {
+  assert(from_width == 64);
 
-   if (from_width < 64) { // 32-bit conversion
-      y = zext(x,from_width,32,0,rounding_mode,saturation_mode);
+  double tmp;
+  switch (rounding_mode) {
+    case RZI_OPTION:
+      tmp = trunc(x.f64);
+      break;
+    case RNI_OPTION:
+      tmp = nearbyint(x.f64);
+      break;
+    case RMI_OPTION:
+      tmp = floor(x.f64);
+      break;
+    case RPI_OPTION:
+      tmp = ceil(x.f64);
+      break;
+    default:
+      tmp = x.f64;
+      break;
+  }
 
-      switch ( to_width ) {
-      case 16: assert(0); break;
-      case 32: 
-         switch (rounding_mode) {
-         case RZ_OPTION: y.f32 = cuda_math::__uint2float_rz(y.u32); break;
-         case RN_OPTION: y.f32 = cuda_math::__uint2float_rn(y.u32); break;
-         case RM_OPTION: y.f32 = cuda_math::__uint2float_rd(y.u32); break;
-         case RP_OPTION: y.f32 = cuda_math::__uint2float_ru(y.u32); break;
-         default: break; 
-         }
-         break;
-      case 64: y.f64 = y.u32; break; // no rounding needed
-      default: assert(0); break;
-      }
-   } else {
-      switch ( to_width ) {
-      case 16: assert(0); break;
-      case 32: 
-         switch (rounding_mode) {
-         case RZ_OPTION: y.f32 = cuda_math::__ull2float_rn(y.u64); break; 
-         case RN_OPTION: y.f32 = cuda_math::__ull2float_rn(y.u64); break;
-         case RM_OPTION: y.f32 = cuda_math::__ull2float_rn(y.u64); break; 
-         case RP_OPTION: y.f32 = cuda_math::__ull2float_rn(y.u64); break; 
-         default: break; 
-         }
-         break;
-      case 64: y.f64 = y.u64; break; // no internal implementation found
-      default: assert(0); break;
-      }
-   }
-
-   // saturating an integer to 1 or 0?
-   return y;
+  ptx_reg_t y;
+  if (to_sign == 1) {
+    tmp = saturated2i(tmp, ((1 << (to_width - 1)) - 1), (1 << (to_width - 1)));
+    switch (to_width) {
+      case 8:
+        y.s8 = (char)tmp;
+        break;
+      case 16:
+        y.s16 = (short)tmp;
+        break;
+      case 32:
+        y.s32 = (int)tmp;
+        break;
+      case 64:
+        y.s64 = (long long)tmp;
+        break;
+      default:
+        assert(0);
+        break;
+    }
+  } else if (to_sign == 0) {
+    tmp = saturated2i(tmp, ((1 << (to_width - 1)) - 1), 0);
+    switch (to_width) {
+      case 8:
+        y.u8 = (unsigned char)tmp;
+        break;
+      case 16:
+        y.u16 = (unsigned short)tmp;
+        break;
+      case 32:
+        y.u32 = (unsigned int)tmp;
+        break;
+      case 64:
+        y.u64 = (unsigned long long)tmp;
+        break;
+      default:
+        assert(0);
+        break;
+    }
+  } else {
+    switch (to_width) {
+      case 16:
+        assert(0);
+        break;
+      case 32:
+        y.f32 = x.f64;
+        break;
+      case 64:
+        y.f64 = x.f64;  // should be handled by d2d
+        break;
+      default:
+        assert(0);
+        break;
+    }
+  }
+  return y;
 }
 
-ptx_reg_t f2f( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
-{
-   ptx_reg_t y;
-   if (from_width == 16){
-       half_float::detail::uint16 val = x.u16;
-       y.f32 = half_float::detail::half2float<float>(val);
-   }else{
-       switch ( rounding_mode ) {
-       case RZI_OPTION: 
-          y.f32 = truncf(x.f32); 
-          break;          
-       case RNI_OPTION: 
-    #if CUDART_VERSION >= 3000
-          y.f32 = nearbyintf(x.f32); 
-    #else
-          y.f32 = cuda_math::__internal_nearbyintf(x.f32); 
-    #endif
-          break;          
-       case RMI_OPTION: 
-          if ((x.u32 & 0x7f800000) == 0) {
-             y.u32 = x.u32 & 0x80000000; // round denorm. FP to 0, keeping sign
-          } else {
-             y.f32 = floorf(x.f32); 
-          }
-          break;          
-       case RPI_OPTION: 
-          if ((x.u32 & 0x7f800000) == 0) {
-             y.u32 = x.u32 & 0x80000000; // round denorm. FP to 0, keeping sign
-          } else {
-             y.f32 = ceilf(x.f32); 
-          }
-          break;          
-       default: 
-          if ((x.u32 & 0x7f800000) == 0) {
-             y.u32 = x.u32 & 0x80000000; // round denorm. FP to 0, keeping sign
-          } else {
-             y.f32 = x.f32;
-          }
-          break; 
-       }
-    #if CUDART_VERSION >= 3000
-       if (isnanf(y.f32)) 
-    #else
-       if (cuda_math::__cuda___isnanf(y.f32)) 
-    #endif
-       {
-          y.u32 = 0x7fffffff;
-       } else if (saturation_mode) {
-          y.f32 = cuda_math::__saturatef(y.f32);
-       }
-   }
+ptx_reg_t s2f(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
+              int rounding_mode, int saturation_mode) {
+  ptx_reg_t y;
 
-   return y;
+  if (from_width < 64) {  // 32-bit conversion
+    y = sext(x, from_width, 32, 0, rounding_mode, saturation_mode);
+
+    switch (to_width) {
+      case 16:
+        assert(0);
+        break;
+      case 32:
+        switch (rounding_mode) {
+          case RZ_OPTION:
+            y.f32 = cuda_math::__int2float_rz(y.s32);
+            break;
+          case RN_OPTION:
+            y.f32 = cuda_math::__int2float_rn(y.s32);
+            break;
+          case RM_OPTION:
+            y.f32 = cuda_math::__int2float_rd(y.s32);
+            break;
+          case RP_OPTION:
+            y.f32 = cuda_math::__int2float_ru(y.s32);
+            break;
+          default:
+            break;
+        }
+        break;
+      case 64:
+        y.f64 = y.s32;
+        break;  // no rounding needed
+      default:
+        assert(0);
+        break;
+    }
+  } else {
+    switch (to_width) {
+      case 16:
+        assert(0);
+        break;
+      case 32:
+        switch (rounding_mode) {
+          case RZ_OPTION:
+            y.f32 = cuda_math::__ll2float_rz(y.s64);
+            break;
+          case RN_OPTION:
+            y.f32 = cuda_math::__ll2float_rn(y.s64);
+            break;
+          case RM_OPTION:
+            y.f32 = cuda_math::__ll2float_rd(y.s64);
+            break;
+          case RP_OPTION:
+            y.f32 = cuda_math::__ll2float_ru(y.s64);
+            break;
+          default:
+            break;
+        }
+        break;
+      case 64:
+        y.f64 = y.s64;
+        break;  // no internal implementation found
+      default:
+        assert(0);
+        break;
+    }
+  }
+
+  // saturating an integer to 1 or 0?
+  return y;
 }
 
-ptx_reg_t d2d( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
-{
-   ptx_reg_t y;
-   switch ( rounding_mode ) {
-   case RZI_OPTION: 
-      y.f64 = trunc(x.f64); 
-      break;          
-   case RNI_OPTION: 
+ptx_reg_t u2f(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
+              int rounding_mode, int saturation_mode) {
+  ptx_reg_t y;
+
+  if (from_width < 64) {  // 32-bit conversion
+    y = zext(x, from_width, 32, 0, rounding_mode, saturation_mode);
+
+    switch (to_width) {
+      case 16:
+        assert(0);
+        break;
+      case 32:
+        switch (rounding_mode) {
+          case RZ_OPTION:
+            y.f32 = cuda_math::__uint2float_rz(y.u32);
+            break;
+          case RN_OPTION:
+            y.f32 = cuda_math::__uint2float_rn(y.u32);
+            break;
+          case RM_OPTION:
+            y.f32 = cuda_math::__uint2float_rd(y.u32);
+            break;
+          case RP_OPTION:
+            y.f32 = cuda_math::__uint2float_ru(y.u32);
+            break;
+          default:
+            break;
+        }
+        break;
+      case 64:
+        y.f64 = y.u32;
+        break;  // no rounding needed
+      default:
+        assert(0);
+        break;
+    }
+  } else {
+    switch (to_width) {
+      case 16:
+        assert(0);
+        break;
+      case 32:
+        switch (rounding_mode) {
+          case RZ_OPTION:
+            y.f32 = cuda_math::__ull2float_rn(y.u64);
+            break;
+          case RN_OPTION:
+            y.f32 = cuda_math::__ull2float_rn(y.u64);
+            break;
+          case RM_OPTION:
+            y.f32 = cuda_math::__ull2float_rn(y.u64);
+            break;
+          case RP_OPTION:
+            y.f32 = cuda_math::__ull2float_rn(y.u64);
+            break;
+          default:
+            break;
+        }
+        break;
+      case 64:
+        y.f64 = y.u64;
+        break;  // no internal implementation found
+      default:
+        assert(0);
+        break;
+    }
+  }
+
+  // saturating an integer to 1 or 0?
+  return y;
+}
+
+ptx_reg_t f2f(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
+              int rounding_mode, int saturation_mode) {
+  ptx_reg_t y;
+  if (from_width == 16) {
+    half_float::detail::uint16 val = x.u16;
+    y.f32 = half_float::detail::half2float<float>(val);
+  } else {
+    switch (rounding_mode) {
+      case RZI_OPTION:
+        y.f32 = truncf(x.f32);
+        break;
+      case RNI_OPTION:
 #if CUDART_VERSION >= 3000
-      y.f64 = nearbyint(x.f64); 
+        y.f32 = nearbyintf(x.f32);
 #else
-      y.f64 = cuda_math::__internal_nearbyintf(x.f64); 
+        y.f32 = cuda_math::__internal_nearbyintf(x.f32);
 #endif
-      break;          
-   case RMI_OPTION: 
-      y.f64 = floor(x.f64); 
-      break;          
-   case RPI_OPTION: 
-      y.f64 = ceil(x.f64); 
-      break;          
-   default: 
+        break;
+      case RMI_OPTION:
+        if ((x.u32 & 0x7f800000) == 0) {
+          y.u32 = x.u32 & 0x80000000;  // round denorm. FP to 0, keeping sign
+        } else {
+          y.f32 = floorf(x.f32);
+        }
+        break;
+      case RPI_OPTION:
+        if ((x.u32 & 0x7f800000) == 0) {
+          y.u32 = x.u32 & 0x80000000;  // round denorm. FP to 0, keeping sign
+        } else {
+          y.f32 = ceilf(x.f32);
+        }
+        break;
+      default:
+        if ((x.u32 & 0x7f800000) == 0) {
+          y.u32 = x.u32 & 0x80000000;  // round denorm. FP to 0, keeping sign
+        } else {
+          y.f32 = x.f32;
+        }
+        break;
+    }
+#if CUDART_VERSION >= 3000
+    if (isnanf(y.f32))
+#else
+    if (cuda_math::__cuda___isnanf(y.f32))
+#endif
+    {
+      y.u32 = 0x7fffffff;
+    } else if (saturation_mode) {
+      y.f32 = cuda_math::__saturatef(y.f32);
+    }
+  }
+
+  return y;
+}
+
+ptx_reg_t d2d(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
+              int rounding_mode, int saturation_mode) {
+  ptx_reg_t y;
+  switch (rounding_mode) {
+    case RZI_OPTION:
+      y.f64 = trunc(x.f64);
+      break;
+    case RNI_OPTION:
+#if CUDART_VERSION >= 3000
+      y.f64 = nearbyint(x.f64);
+#else
+      y.f64 = cuda_math::__internal_nearbyintf(x.f64);
+#endif
+      break;
+    case RMI_OPTION:
+      y.f64 = floor(x.f64);
+      break;
+    case RPI_OPTION:
+      y.f64 = ceil(x.f64);
+      break;
+    default:
       y.f64 = x.f64;
-      break; 
-   }
-   if (std::isnan(y.f64)) {
-      y.u64 = 0xfff8000000000000ull;
-   } else if (saturation_mode) {
-      y.f64 = cuda_math::__saturatef(y.f64); 
-   }
-   return y;
+      break;
+  }
+  if (std::isnan(y.f64)) {
+    y.u64 = 0xfff8000000000000ull;
+  } else if (saturation_mode) {
+    y.f64 = cuda_math::__saturatef(y.f64);
+  }
+  return y;
 }
 
-ptx_reg_t (*g_cvt_fn[11][11])( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, 
-                               int rounding_mode, int saturation_mode ) = {
-   { NULL, sext, sext, sext, NULL, sext, sext, sext, s2f, s2f, s2f}, 
-   { chop, NULL, sext, sext, chop, NULL, sext, sext, s2f, s2f, s2f}, 
-   { chop, sexd, NULL, sext, chop, chop, NULL, sext, s2f, s2f, s2f}, 
-   { chop, chop, chop, NULL, chop, chop, chop, NULL, s2f, s2f, s2f}, 
-   { NULL, zext, zext, zext, NULL, zext, zext, zext, u2f, u2f, u2f}, 
-   { chop, NULL, zext, zext, chop, NULL, zext, zext, u2f, u2f, u2f}, 
-   { chop, chop, NULL, zext, chop, chop, NULL, zext, u2f, u2f, u2f}, 
-   { chop, chop, chop, NULL, chop, chop, chop, NULL, u2f, u2f, u2f}, 
-   { f2x , f2x , f2x , f2x , f2x , f2x , f2x , f2x , NULL,f2f, f2x}, 
-   { f2x , f2x , f2x , f2x , f2x , f2x , f2x , f2x , f2x, f2f, f2x},
-   { d2x , d2x , d2x , d2x , d2x , d2x , d2x , d2x , d2x, d2x, d2d} 
-};
+ptx_reg_t (*g_cvt_fn[11][11])(ptx_reg_t x, unsigned from_width,
+                              unsigned to_width, int to_sign, int rounding_mode,
+                              int saturation_mode) = {
+    {NULL, sext, sext, sext, NULL, sext, sext, sext, s2f, s2f, s2f},
+    {chop, NULL, sext, sext, chop, NULL, sext, sext, s2f, s2f, s2f},
+    {chop, sexd, NULL, sext, chop, chop, NULL, sext, s2f, s2f, s2f},
+    {chop, chop, chop, NULL, chop, chop, chop, NULL, s2f, s2f, s2f},
+    {NULL, zext, zext, zext, NULL, zext, zext, zext, u2f, u2f, u2f},
+    {chop, NULL, zext, zext, chop, NULL, zext, zext, u2f, u2f, u2f},
+    {chop, chop, NULL, zext, chop, chop, NULL, zext, u2f, u2f, u2f},
+    {chop, chop, chop, NULL, chop, chop, chop, NULL, u2f, u2f, u2f},
+    {f2x, f2x, f2x, f2x, f2x, f2x, f2x, f2x, NULL, f2f, f2x},
+    {f2x, f2x, f2x, f2x, f2x, f2x, f2x, f2x, f2x, f2f, f2x},
+    {d2x, d2x, d2x, d2x, d2x, d2x, d2x, d2x, d2x, d2x, d2d}};
 
-void ptx_round(ptx_reg_t& data, int rounding_mode, int type)
-{
-   if (rounding_mode == RN_OPTION) {
-      return;
-   }
-   switch ( rounding_mode ) {
-   case RZI_OPTION: 
-      switch ( type ) {
-      case S8_TYPE:
-      case S16_TYPE:
-      case S32_TYPE:
-      case S64_TYPE:
-      case U8_TYPE:
-      case U16_TYPE:
-      case U32_TYPE:
-      case U64_TYPE:
-         printf("Trying to round an integer??\n"); assert(0); break;
-      case F16_TYPE: data.f16=truncf(data.f16);break;//assert(0); break;
-      case F32_TYPE:
-         data.f32 = truncf(data.f32); 
-         break;          
-      case F64_TYPE:
-      case FF64_TYPE:
-         if (data.f64 < 0) data.f64 = ceil(data.f64); //negative
-         else data.f64 = floor(data.f64); //positive
-         break; 
-      default: assert(0); break;
+void ptx_round(ptx_reg_t &data, int rounding_mode, int type) {
+  if (rounding_mode == RN_OPTION) {
+    return;
+  }
+  switch (rounding_mode) {
+    case RZI_OPTION:
+      switch (type) {
+        case S8_TYPE:
+        case S16_TYPE:
+        case S32_TYPE:
+        case S64_TYPE:
+        case U8_TYPE:
+        case U16_TYPE:
+        case U32_TYPE:
+        case U64_TYPE:
+          printf("Trying to round an integer??\n");
+          assert(0);
+          break;
+        case F16_TYPE:
+          data.f16 = truncf(data.f16);
+          break;  // assert(0); break;
+        case F32_TYPE:
+          data.f32 = truncf(data.f32);
+          break;
+        case F64_TYPE:
+        case FF64_TYPE:
+          if (data.f64 < 0)
+            data.f64 = ceil(data.f64);  // negative
+          else
+            data.f64 = floor(data.f64);  // positive
+          break;
+        default:
+          assert(0);
+          break;
       }
       break;
-   case RNI_OPTION: 
-      switch ( type ) {
-      case S8_TYPE:
-      case S16_TYPE:
-      case S32_TYPE:
-      case S64_TYPE:
-      case U8_TYPE:
-      case U16_TYPE:
-      case U32_TYPE:
-      case U64_TYPE:
-         printf("Trying to round an integer??\n"); assert(0); break;
-      case F16_TYPE:// assert(0); break;
+    case RNI_OPTION:
+      switch (type) {
+        case S8_TYPE:
+        case S16_TYPE:
+        case S32_TYPE:
+        case S64_TYPE:
+        case U8_TYPE:
+        case U16_TYPE:
+        case U32_TYPE:
+        case U64_TYPE:
+          printf("Trying to round an integer??\n");
+          assert(0);
+          break;
+        case F16_TYPE:  // assert(0); break;
 #if CUDART_VERSION >= 3000
-         data.f16 = nearbyintf(data.f16); 
+          data.f16 = nearbyintf(data.f16);
 #else
-         data.f16 = cuda_math::__cuda_nearbyintf(data.f16); 
+          data.f16 = cuda_math::__cuda_nearbyintf(data.f16);
 #endif
-         break;          
-      case F32_TYPE: 
+          break;
+        case F32_TYPE:
 #if CUDART_VERSION >= 3000
-         data.f32 = nearbyintf(data.f32); 
+          data.f32 = nearbyintf(data.f32);
 #else
-         data.f32 = cuda_math::__cuda_nearbyintf(data.f32); 
+          data.f32 = cuda_math::__cuda_nearbyintf(data.f32);
 #endif
-         break;          
-      case F64_TYPE: case FF64_TYPE: data.f64 = round(data.f64); break; 
-      default: assert(0); break;
+          break;
+        case F64_TYPE:
+        case FF64_TYPE:
+          data.f64 = round(data.f64);
+          break;
+        default:
+          assert(0);
+          break;
       }
       break;
-   case RMI_OPTION: 
-      switch ( type ) {
-      case S8_TYPE:
-      case S16_TYPE:
-      case S32_TYPE:
-      case S64_TYPE:
-      case U8_TYPE:
-      case U16_TYPE:
-      case U32_TYPE:
-      case U64_TYPE:
-         printf("Trying to round an integer??\n"); assert(0); break;
-      case F16_TYPE: data.f16=floorf(data.f16);break;//assert(0); break;
-      case F32_TYPE: 
-         data.f32 = floorf(data.f32); 
-         break;          
-      case F64_TYPE: case FF64_TYPE: data.f64 = floor(data.f64); break; 
-      default: assert(0); break;
+    case RMI_OPTION:
+      switch (type) {
+        case S8_TYPE:
+        case S16_TYPE:
+        case S32_TYPE:
+        case S64_TYPE:
+        case U8_TYPE:
+        case U16_TYPE:
+        case U32_TYPE:
+        case U64_TYPE:
+          printf("Trying to round an integer??\n");
+          assert(0);
+          break;
+        case F16_TYPE:
+          data.f16 = floorf(data.f16);
+          break;  // assert(0); break;
+        case F32_TYPE:
+          data.f32 = floorf(data.f32);
+          break;
+        case F64_TYPE:
+        case FF64_TYPE:
+          data.f64 = floor(data.f64);
+          break;
+        default:
+          assert(0);
+          break;
       }
       break;
-   case RPI_OPTION: 
-      switch ( type ) {
-      case S8_TYPE:
-      case S16_TYPE:
-      case S32_TYPE:
-      case S64_TYPE:
-      case U8_TYPE:
-      case U16_TYPE:
-      case U32_TYPE:
-      case U64_TYPE:
-         printf("Trying to round an integer??\n"); assert(0); break;
-      case F16_TYPE: data.f16 = ceilf(data.f16); break;  //assert(0); break;
-      case F32_TYPE: data.f32 = ceilf(data.f32); break;          
-      case F64_TYPE: case FF64_TYPE: data.f64 = ceil(data.f64); break; 
-      default: assert(0); break;
+    case RPI_OPTION:
+      switch (type) {
+        case S8_TYPE:
+        case S16_TYPE:
+        case S32_TYPE:
+        case S64_TYPE:
+        case U8_TYPE:
+        case U16_TYPE:
+        case U32_TYPE:
+        case U64_TYPE:
+          printf("Trying to round an integer??\n");
+          assert(0);
+          break;
+        case F16_TYPE:
+          data.f16 = ceilf(data.f16);
+          break;  // assert(0); break;
+        case F32_TYPE:
+          data.f32 = ceilf(data.f32);
+          break;
+        case F64_TYPE:
+        case FF64_TYPE:
+          data.f64 = ceil(data.f64);
+          break;
+        default:
+          assert(0);
+          break;
       }
       break;
-   default:  break; 
-   }
+    default:
+      break;
+  }
 
-   if (type == F32_TYPE) {
+  if (type == F32_TYPE) {
 #if CUDART_VERSION >= 3000
-      if (isnanf(data.f32)) 
+    if (isnanf(data.f32))
 #else
-      if (cuda_math::__cuda___isnanf(data.f32)) 
+    if (cuda_math::__cuda___isnanf(data.f32))
 #endif
-      {
-         data.u32 = 0x7fffffff;
-      }
-   }
-   if ((type == F64_TYPE)||(type == FF64_TYPE)) {
-      if (std::isnan(data.f64)) {
-         data.u64 = 0xfff8000000000000ull;
-      }
-   }
+    {
+      data.u32 = 0x7fffffff;
+    }
+  }
+  if ((type == F64_TYPE) || (type == FF64_TYPE)) {
+    if (std::isnan(data.f64)) {
+      data.u64 = 0xfff8000000000000ull;
+    }
+  }
 }
 
-void ptx_saturate(ptx_reg_t& data, int saturation_mode, int type)
-{
-   if (!saturation_mode) {
-      return;
-   }
-   switch ( type ) {
-   case S8_TYPE:
-   case S16_TYPE:
-   case S32_TYPE:
-   case S64_TYPE:
-   case U8_TYPE:
-   case U16_TYPE:
-   case U32_TYPE:
-   case U64_TYPE:
-      printf("Trying to clamp an integer to 1??\n"); assert(0); break;
-   case F16_TYPE: //assert(0); break;
-      if (data.f16 > 1.0f) data.f16 = 1.0f; //negative
-      if (data.f16 < 0.0f) data.f16 = 0.0f; //positive
-      break;          
-   case F32_TYPE:
-      if (data.f32 > 1.0f) data.f32 = 1.0f; //negative
-      if (data.f32 < 0.0f) data.f32 = 0.0f; //positive
-      break;          
-   case F64_TYPE:
-   case FF64_TYPE:
-      if (data.f64 > 1.0f) data.f64 = 1.0f; //negative
-      if (data.f64 < 0.0f) data.f64 = 0.0f; //positive
-      break; 
-   default: assert(0); break;
-   }
-
+void ptx_saturate(ptx_reg_t &data, int saturation_mode, int type) {
+  if (!saturation_mode) {
+    return;
+  }
+  switch (type) {
+    case S8_TYPE:
+    case S16_TYPE:
+    case S32_TYPE:
+    case S64_TYPE:
+    case U8_TYPE:
+    case U16_TYPE:
+    case U32_TYPE:
+    case U64_TYPE:
+      printf("Trying to clamp an integer to 1??\n");
+      assert(0);
+      break;
+    case F16_TYPE:                           // assert(0); break;
+      if (data.f16 > 1.0f) data.f16 = 1.0f;  // negative
+      if (data.f16 < 0.0f) data.f16 = 0.0f;  // positive
+      break;
+    case F32_TYPE:
+      if (data.f32 > 1.0f) data.f32 = 1.0f;  // negative
+      if (data.f32 < 0.0f) data.f32 = 0.0f;  // positive
+      break;
+    case F64_TYPE:
+    case FF64_TYPE:
+      if (data.f64 > 1.0f) data.f64 = 1.0f;  // negative
+      if (data.f64 < 0.0f) data.f64 = 0.0f;  // positive
+      break;
+    default:
+      assert(0);
+      break;
+  }
 }
 
-void cvt_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   unsigned to_type = pI->get_type();
-   unsigned from_type = pI->get_type2();
-   unsigned rounding_mode = pI->rounding_mode();
-   unsigned saturation_mode = pI->saturation_mode();
+void cvt_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  unsigned to_type = pI->get_type();
+  unsigned from_type = pI->get_type2();
+  unsigned rounding_mode = pI->rounding_mode();
+  unsigned saturation_mode = pI->saturation_mode();
 
-//   if ( to_type == F16_TYPE || from_type == F16_TYPE )
-//      abort();
+  //   if ( to_type == F16_TYPE || from_type == F16_TYPE )
+  //      abort();
 
-   int to_sign, from_sign;
-   size_t from_width, to_width;
-   unsigned src_fmt = type_info_key::type_decode(from_type, from_width, from_sign);
-   unsigned dst_fmt = type_info_key::type_decode(to_type, to_width, to_sign);
+  int to_sign, from_sign;
+  size_t from_width, to_width;
+  unsigned src_fmt =
+      type_info_key::type_decode(from_type, from_width, from_sign);
+  unsigned dst_fmt = type_info_key::type_decode(to_type, to_width, to_sign);
 
-   ptx_reg_t data = thread->get_operand_value(src1, dst, from_type, thread, 1);
+  ptx_reg_t data = thread->get_operand_value(src1, dst, from_type, thread, 1);
 
-   if(pI->is_neg()){
-
-   switch( from_type ) {
+  if (pI->is_neg()) {
+    switch (from_type) {
       // Default to f32 for now, need to add support for others
       case S8_TYPE:
       case U8_TYPE:
       case B8_TYPE:
-         data.s8 = -data.s8;
-         break;
+        data.s8 = -data.s8;
+        break;
       case S16_TYPE:
       case U16_TYPE:
       case B16_TYPE:
-         data.s16 = -data.s16;
-         break;
+        data.s16 = -data.s16;
+        break;
       case S32_TYPE:
       case U32_TYPE:
       case B32_TYPE:
-         data.s32 = -data.s32;
-         break;
+        data.s32 = -data.s32;
+        break;
       case S64_TYPE:
       case U64_TYPE:
       case B64_TYPE:
-         data.s64 = -data.s64;
-         break;
+        data.s64 = -data.s64;
+        break;
       case F16_TYPE:
-         data.f16 = -data.f16;
-         break;
+        data.f16 = -data.f16;
+        break;
       case F32_TYPE:
-         data.f32 = -data.f32;
-         break;
+        data.f32 = -data.f32;
+        break;
       case F64_TYPE:
       case FF64_TYPE:
-         data.f64 = -data.f64;
-         break;
+        data.f64 = -data.f64;
+        break;
       default:
-         assert(0);
-      }
+        assert(0);
+    }
+  }
 
-   }
+  if (g_cvt_fn[src_fmt][dst_fmt] != NULL) {
+    ptx_reg_t result = g_cvt_fn[src_fmt][dst_fmt](
+        data, from_width, to_width, to_sign, rounding_mode, saturation_mode);
+    data = result;
+  }
 
-
-   if ( g_cvt_fn[src_fmt][dst_fmt] != NULL ) {
-      ptx_reg_t result = g_cvt_fn[src_fmt][dst_fmt](data,from_width,to_width,to_sign, rounding_mode, saturation_mode);
-      data = result;
-   }
-
-   thread->set_operand_value(dst, data, to_type, thread, pI );
+  thread->set_operand_value(dst, data, to_type, thread, pI);
 }
 
-void cvta_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t data;
+void cvta_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t data;
 
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   memory_space_t space = pI->get_space();
-   bool to_non_generic = pI->is_to();
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  memory_space_t space = pI->get_space();
+  bool to_non_generic = pI->is_to();
 
-   unsigned i_type = pI->get_type();
-   ptx_reg_t from_addr = thread->get_operand_value(src1,dst,i_type,thread,1);
-   addr_t from_addr_hw = (addr_t)from_addr.u64;
-   addr_t to_addr_hw = 0;
-   unsigned smid = thread->get_hw_sid();
-   unsigned hwtid = thread->get_hw_tid();
+  unsigned i_type = pI->get_type();
+  ptx_reg_t from_addr = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  addr_t from_addr_hw = (addr_t)from_addr.u64;
+  addr_t to_addr_hw = 0;
+  unsigned smid = thread->get_hw_sid();
+  unsigned hwtid = thread->get_hw_tid();
 
-   if( to_non_generic ) {
-      switch( space.get_type() ) {
-      case shared_space: to_addr_hw = generic_to_shared( smid, from_addr_hw ); break;
-      case local_space:  to_addr_hw = generic_to_local( smid, hwtid, from_addr_hw ); break;
-      case global_space: to_addr_hw = generic_to_global(from_addr_hw ); break;
-      default: abort();
-      }
-   } else {
-      switch( space.get_type() ) {
-      case shared_space: to_addr_hw = shared_to_generic( smid, from_addr_hw ); break;
-      case local_space:  to_addr_hw =  local_to_generic( smid, hwtid, from_addr_hw )
-                                      + thread->get_local_mem_stack_pointer(); break; // add stack ptr here so that it can be passed as a pointer at function call 
-      case global_space: to_addr_hw = global_to_generic( from_addr_hw ); break;
-      default: abort();
-      }
-   }
-   
-   ptx_reg_t to_addr;
-   to_addr.u64 = to_addr_hw;
-   thread->set_reg(dst.get_symbol(),to_addr);
+  if (to_non_generic) {
+    switch (space.get_type()) {
+      case shared_space:
+        to_addr_hw = generic_to_shared(smid, from_addr_hw);
+        break;
+      case local_space:
+        to_addr_hw = generic_to_local(smid, hwtid, from_addr_hw);
+        break;
+      case global_space:
+        to_addr_hw = generic_to_global(from_addr_hw);
+        break;
+      default:
+        abort();
+    }
+  } else {
+    switch (space.get_type()) {
+      case shared_space:
+        to_addr_hw = shared_to_generic(smid, from_addr_hw);
+        break;
+      case local_space:
+        to_addr_hw = local_to_generic(smid, hwtid, from_addr_hw) +
+                     thread->get_local_mem_stack_pointer();
+        break;  // add stack ptr here so that it can be passed as a pointer at
+                // function call
+      case global_space:
+        to_addr_hw = global_to_generic(from_addr_hw);
+        break;
+      default:
+        abort();
+    }
+  }
+
+  ptx_reg_t to_addr;
+  to_addr.u64 = to_addr_hw;
+  thread->set_reg(dst.get_symbol(), to_addr);
 }
 
-void div_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t data;
+void div_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t data;
 
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   unsigned i_type = pI->get_type();
+  unsigned i_type = pI->get_type();
 
-   ptx_reg_t src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   ptx_reg_t src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  ptx_reg_t src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  ptx_reg_t src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-
-   switch ( i_type ) {
-   case S8_TYPE:
-      data.s8  = src1_data.s8  / src2_data.s8 ; break;
-   case S16_TYPE:
-      data.s16 = src1_data.s16 / src2_data.s16; break;
-   case S32_TYPE:
-      data.s32 = src1_data.s32 / src2_data.s32; break;
-   case S64_TYPE: 
-      data.s64 = src1_data.s64 / src2_data.s64; break;
-   case U8_TYPE:
-      data.u8  = src1_data.u8  / src2_data.u8 ; break;
-   case U16_TYPE:
-      data.u16 = src1_data.u16 / src2_data.u16; break;
-   case U32_TYPE:
-      data.u32 = src1_data.u32 / src2_data.u32; break;
-   case U64_TYPE: 
-      data.u64 = src1_data.u64 / src2_data.u64; break;
-   case B8_TYPE:
-      data.u8  = src1_data.u8  / src2_data.u8 ; break;
-   case B16_TYPE:
-      data.u16 = src1_data.u16 / src2_data.u16; break;
-   case B32_TYPE:
-      data.u32 = src1_data.u32 / src2_data.u32; break;
-   case B64_TYPE:
-      data.u64 = src1_data.u64 / src2_data.u64; break;
-   case F16_TYPE: data.f16 = src1_data.f16 / src2_data.f16; break;//assert(0); break;
-   case F32_TYPE: data.f32 = src1_data.f32 / src2_data.f32; break;
-   case F64_TYPE: case FF64_TYPE: data.f64 = src1_data.f64 / src2_data.f64; break;
-   default: assert(0); break;
-   }
-   thread->set_operand_value(dst,data, i_type, thread,pI);
+  switch (i_type) {
+    case S8_TYPE:
+      data.s8 = src1_data.s8 / src2_data.s8;
+      break;
+    case S16_TYPE:
+      data.s16 = src1_data.s16 / src2_data.s16;
+      break;
+    case S32_TYPE:
+      data.s32 = src1_data.s32 / src2_data.s32;
+      break;
+    case S64_TYPE:
+      data.s64 = src1_data.s64 / src2_data.s64;
+      break;
+    case U8_TYPE:
+      data.u8 = src1_data.u8 / src2_data.u8;
+      break;
+    case U16_TYPE:
+      data.u16 = src1_data.u16 / src2_data.u16;
+      break;
+    case U32_TYPE:
+      data.u32 = src1_data.u32 / src2_data.u32;
+      break;
+    case U64_TYPE:
+      data.u64 = src1_data.u64 / src2_data.u64;
+      break;
+    case B8_TYPE:
+      data.u8 = src1_data.u8 / src2_data.u8;
+      break;
+    case B16_TYPE:
+      data.u16 = src1_data.u16 / src2_data.u16;
+      break;
+    case B32_TYPE:
+      data.u32 = src1_data.u32 / src2_data.u32;
+      break;
+    case B64_TYPE:
+      data.u64 = src1_data.u64 / src2_data.u64;
+      break;
+    case F16_TYPE:
+      data.f16 = src1_data.f16 / src2_data.f16;
+      break;  // assert(0); break;
+    case F32_TYPE:
+      data.f32 = src1_data.f32 / src2_data.f32;
+      break;
+    case F64_TYPE:
+    case FF64_TYPE:
+      data.f64 = src1_data.f64 / src2_data.f64;
+      break;
+    default:
+      assert(0);
+      break;
+  }
+  thread->set_operand_value(dst, data, i_type, thread, pI);
 }
 
-void dp4a_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   printf("DP4A instruction not implemented yet");
-   assert(0);
-
+void dp4a_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  printf("DP4A instruction not implemented yet");
+  assert(0);
 }
 
-void ex2_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t src1_data, src2_data, data;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
+void ex2_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, src2_data, data;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
 
-   unsigned i_type = pI->get_type();
+  unsigned i_type = pI->get_type();
 
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
 
-
-   switch ( i_type ) {
-   case F32_TYPE: 
+  switch (i_type) {
+    case F32_TYPE:
       data.f32 = cuda_math::__powf(2.0, src1_data.f32);
       break;
-   default:
+    default:
       printf("Execution error: type mismatch with instruction\n");
-      assert(0); 
+      assert(0);
       break;
-   }
-   
-   thread->set_operand_value(dst,data, i_type, thread,pI);
+  }
+
+  thread->set_operand_value(dst, data, i_type, thread, pI);
 }
 
-void exit_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   thread->set_done();
-   thread->exitCore();
-   thread->registerExit();
+void exit_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  thread->set_done();
+  thread->exitCore();
+  thread->registerExit();
 }
 
-void mad_def( const ptx_instruction *pI, ptx_thread_info *thread, bool use_carry = false );
+void mad_def(const ptx_instruction *pI, ptx_thread_info *thread,
+             bool use_carry = false);
 
-void fma_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   mad_def(pI,thread);
+void fma_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  mad_def(pI, thread);
 }
 
-void isspacep_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t a;
-   bool t=false;
+void isspacep_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a;
+  bool t = false;
 
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   memory_space_t space = pI->get_space();
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  memory_space_t space = pI->get_space();
 
-   a = thread->get_reg(src1.get_symbol());
-   addr_t addr = (addr_t)a.u64;
-   unsigned smid = thread->get_hw_sid();
-   unsigned hwtid = thread->get_hw_tid();
+  a = thread->get_reg(src1.get_symbol());
+  addr_t addr = (addr_t)a.u64;
+  unsigned smid = thread->get_hw_sid();
+  unsigned hwtid = thread->get_hw_tid();
 
-   switch( space.get_type() ) {
-   case shared_space: t = isspace_shared( smid, addr );
-   case local_space:  t = isspace_local( smid, hwtid, addr );
-   case global_space: t = isspace_global( addr );
-   default: abort();
-   }
-
-   ptx_reg_t p;
-   p.pred = t?1:0;
-
-   thread->set_reg(dst.get_symbol(),p);
-}
-
-void decode_space( memory_space_t &space, ptx_thread_info *thread, const operand_info &op, memory_space *&mem, addr_t &addr)
-{
-   unsigned smid = thread->get_hw_sid();
-   unsigned hwtid = thread->get_hw_tid();
-
-   if( space == param_space_unclassified ) {
-      // need to op to determine whether it refers to a kernel param or local param
-      const symbol *s = op.get_symbol();
-      const type_info *t = s->type();
-      type_info_key ti = t->get_key();
-      if( ti.is_param_kernel() )
-         space = param_space_kernel;
-      else if( ti.is_param_local() ) {
-         space = param_space_local;
-      }
-      //mov r1, param-label
-      else if (ti.is_reg() ){
-         space = param_space_kernel;
-      }
-      else {
-         printf("GPGPU-Sim PTX: ERROR ** cannot resolve .param space for '%s'\n", s->name().c_str() );
-         abort(); 
-      }
-   }
-   switch ( space.get_type() ) {
-   case global_space: mem = thread->get_global_memory(); break;
-   case param_space_local:
-   case local_space:
-      mem = thread->m_local_mem; 
-      addr += thread->get_local_mem_stack_pointer();
-      break; 
-   case tex_space:    mem = thread->get_tex_memory(); break; 
-   case surf_space:   mem = thread->get_surf_memory(); break; 
-   case param_space_kernel:  mem = thread->get_param_memory(); break;
-   case shared_space:  mem = thread->m_shared_mem; break; 
-   case sstarr_space:	mem = thread->m_sstarr_mem; break;
-   case const_space:  mem = thread->get_global_memory(); break;
-   case generic_space:
-      if( thread->get_ptx_version().ver() >= 2.0 ) {
-         // convert generic address to memory space address
-         space = whichspace(addr);
-         switch ( space.get_type() ) {
-         case global_space: mem = thread->get_global_memory(); addr = generic_to_global(addr); break;
-         case local_space:  mem = thread->m_local_mem; addr = generic_to_local(smid,hwtid,addr); break; 
-         case shared_space: mem = thread->m_shared_mem; addr = generic_to_shared(smid,addr); break; 
-         default: abort();
-         }
-      } else {
-         abort();
-      }
-      break;
-   case param_space_unclassified:
-   case undefined_space:
-   default:
+  switch (space.get_type()) {
+    case shared_space:
+      t = isspace_shared(smid, addr);
+    case local_space:
+      t = isspace_local(smid, hwtid, addr);
+    case global_space:
+      t = isspace_global(addr);
+    default:
       abort();
-   }
+  }
+
+  ptx_reg_t p;
+  p.pred = t ? 1 : 0;
+
+  thread->set_reg(dst.get_symbol(), p);
 }
 
-void ld_exec( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   const operand_info &dst = pI->dst();
-   const operand_info &src1 = pI->src1();
+void decode_space(memory_space_t &space, ptx_thread_info *thread,
+                  const operand_info &op, memory_space *&mem, addr_t &addr) {
+  unsigned smid = thread->get_hw_sid();
+  unsigned hwtid = thread->get_hw_tid();
 
-   unsigned type = pI->get_type();
-
-   ptx_reg_t src1_data = thread->get_operand_value(src1, dst, type, thread, 1);
-   ptx_reg_t data;
-   memory_space_t space = pI->get_space();
-   unsigned vector_spec = pI->get_vector();
-
-   memory_space *mem = NULL;
-   addr_t addr = src1_data.u32;
-
-   decode_space(space,thread,src1,mem,addr);
-
-   size_t size;
-   int t;
-   data.u64=0;
-   type_info_key::type_decode(type,size,t);
-   if (!vector_spec) {
-      mem->read(addr,size/8,&data.s64);
-      if( type == S16_TYPE || type == S32_TYPE ) 
-         sign_extend(data,size,dst);
-      thread->set_operand_value(dst,data, type, thread, pI);
-   } else {
-      ptx_reg_t data1, data2, data3, data4;
-      mem->read(addr,size/8,&data1.s64);
-      mem->read(addr+size/8,size/8,&data2.s64);
-      if (vector_spec != V2_TYPE) { //either V3 or V4
-         mem->read(addr+2*size/8,size/8,&data3.s64);
-         if (vector_spec != V3_TYPE) { //v4
-            mem->read(addr+3*size/8,size/8,&data4.s64);
-            thread->set_vector_operand_values(dst,data1,data2,data3,data4);
-         } else //v3
-            thread->set_vector_operand_values(dst,data1,data2,data3,data3);
-      } else //v2
-         thread->set_vector_operand_values(dst,data1,data2,data2,data2);
-   }
-   thread->m_last_effective_address = addr;
-   thread->m_last_memory_space = space; 
+  if (space == param_space_unclassified) {
+    // need to op to determine whether it refers to a kernel param or local
+    // param
+    const symbol *s = op.get_symbol();
+    const type_info *t = s->type();
+    type_info_key ti = t->get_key();
+    if (ti.is_param_kernel())
+      space = param_space_kernel;
+    else if (ti.is_param_local()) {
+      space = param_space_local;
+    }
+    // mov r1, param-label
+    else if (ti.is_reg()) {
+      space = param_space_kernel;
+    } else {
+      printf("GPGPU-Sim PTX: ERROR ** cannot resolve .param space for '%s'\n",
+             s->name().c_str());
+      abort();
+    }
+  }
+  switch (space.get_type()) {
+    case global_space:
+      mem = thread->get_global_memory();
+      break;
+    case param_space_local:
+    case local_space:
+      mem = thread->m_local_mem;
+      addr += thread->get_local_mem_stack_pointer();
+      break;
+    case tex_space:
+      mem = thread->get_tex_memory();
+      break;
+    case surf_space:
+      mem = thread->get_surf_memory();
+      break;
+    case param_space_kernel:
+      mem = thread->get_param_memory();
+      break;
+    case shared_space:
+      mem = thread->m_shared_mem;
+      break;
+    case sstarr_space:
+      mem = thread->m_sstarr_mem;
+      break;
+    case const_space:
+      mem = thread->get_global_memory();
+      break;
+    case generic_space:
+      if (thread->get_ptx_version().ver() >= 2.0) {
+        // convert generic address to memory space address
+        space = whichspace(addr);
+        switch (space.get_type()) {
+          case global_space:
+            mem = thread->get_global_memory();
+            addr = generic_to_global(addr);
+            break;
+          case local_space:
+            mem = thread->m_local_mem;
+            addr = generic_to_local(smid, hwtid, addr);
+            break;
+          case shared_space:
+            mem = thread->m_shared_mem;
+            addr = generic_to_shared(smid, addr);
+            break;
+          default:
+            abort();
+        }
+      } else {
+        abort();
+      }
+      break;
+    case param_space_unclassified:
+    case undefined_space:
+    default:
+      abort();
+  }
 }
 
-void ld_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   ld_exec(pI,thread);
+void ld_exec(const ptx_instruction *pI, ptx_thread_info *thread) {
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+
+  unsigned type = pI->get_type();
+
+  ptx_reg_t src1_data = thread->get_operand_value(src1, dst, type, thread, 1);
+  ptx_reg_t data;
+  memory_space_t space = pI->get_space();
+  unsigned vector_spec = pI->get_vector();
+
+  memory_space *mem = NULL;
+  addr_t addr = src1_data.u32;
+
+  decode_space(space, thread, src1, mem, addr);
+
+  size_t size;
+  int t;
+  data.u64 = 0;
+  type_info_key::type_decode(type, size, t);
+  if (!vector_spec) {
+    mem->read(addr, size / 8, &data.s64);
+    if (type == S16_TYPE || type == S32_TYPE) sign_extend(data, size, dst);
+    thread->set_operand_value(dst, data, type, thread, pI);
+  } else {
+    ptx_reg_t data1, data2, data3, data4;
+    mem->read(addr, size / 8, &data1.s64);
+    mem->read(addr + size / 8, size / 8, &data2.s64);
+    if (vector_spec != V2_TYPE) {  // either V3 or V4
+      mem->read(addr + 2 * size / 8, size / 8, &data3.s64);
+      if (vector_spec != V3_TYPE) {  // v4
+        mem->read(addr + 3 * size / 8, size / 8, &data4.s64);
+        thread->set_vector_operand_values(dst, data1, data2, data3, data4);
+      } else  // v3
+        thread->set_vector_operand_values(dst, data1, data2, data3, data3);
+    } else  // v2
+      thread->set_vector_operand_values(dst, data1, data2, data2, data2);
+  }
+  thread->m_last_effective_address = addr;
+  thread->m_last_memory_space = space;
 }
-void ldu_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ld_exec(pI,thread);
+
+void ld_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ld_exec(pI, thread);
+}
+void ldu_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ld_exec(pI, thread);
 }
 
-void mma_st_impl( const ptx_instruction *pI, core_t *core, warp_inst_t &inst )
-{
-   size_t size;
-   unsigned smid;
-   int t;
-   int thrd, k;
-   ptx_thread_info *thread;
-   
-   const operand_info &src  = pI->operand_lookup(1);
-   const operand_info &src1 = pI->operand_lookup(0);
-   const operand_info &src2 = pI->operand_lookup(2);
-   int tid ;
-   unsigned type = pI->get_type();
-   unsigned wmma_type = pI->get_wmma_type();
-   unsigned wmma_layout = pI->get_wmma_layout(0);
-   int stride; 
+void mma_st_impl(const ptx_instruction *pI, core_t *core, warp_inst_t &inst) {
+  size_t size;
+  unsigned smid;
+  int t;
+  int thrd, k;
+  ptx_thread_info *thread;
 
-   if(core->get_gpu()->is_functional_sim())
-    	tid= inst.warp_id_func()*core->get_warp_size();
-   else
-    	tid= inst.warp_id()*core->get_warp_size();
+  const operand_info &src = pI->operand_lookup(1);
+  const operand_info &src1 = pI->operand_lookup(0);
+  const operand_info &src2 = pI->operand_lookup(2);
+  int tid;
+  unsigned type = pI->get_type();
+  unsigned wmma_type = pI->get_wmma_type();
+  unsigned wmma_layout = pI->get_wmma_layout(0);
+  int stride;
 
-   _memory_op_t insn_memory_op = pI->has_memory_read() ? memory_load : memory_store;
-   for (thrd=0; thrd < core->get_warp_size(); thrd++) {
-	thread = core->get_thread_info()[tid+thrd];
+  if (core->get_gpu()->is_functional_sim())
+    tid = inst.warp_id_func() * core->get_warp_size();
+  else
+    tid = inst.warp_id() * core->get_warp_size();
+
+  _memory_op_t insn_memory_op =
+      pI->has_memory_read() ? memory_load : memory_store;
+  for (thrd = 0; thrd < core->get_warp_size(); thrd++) {
+    thread = core->get_thread_info()[tid + thrd];
     ptx_reg_t addr_reg = thread->get_operand_value(src1, src, type, thread, 1);
-   	ptx_reg_t src2_data = thread->get_operand_value(src2, src, type, thread, 1);
-	const operand_info &src_a=  pI->operand_lookup(1);
-        unsigned nelem = src_a.get_vect_nelem();
-        ptx_reg_t* v= new ptx_reg_t[8]; 
-       	thread->get_vector_operand_values( src_a, v, nelem );
-  	stride = src2_data.u32;
- 
-   	memory_space_t space = pI->get_space();
+    ptx_reg_t src2_data = thread->get_operand_value(src2, src, type, thread, 1);
+    const operand_info &src_a = pI->operand_lookup(1);
+    unsigned nelem = src_a.get_vect_nelem();
+    ptx_reg_t *v = new ptx_reg_t[8];
+    thread->get_vector_operand_values(src_a, v, nelem);
+    stride = src2_data.u32;
 
-   	memory_space *mem = NULL;
-   	addr_t addr = addr_reg.u32;
-	
-	new_addr_type mem_txn_addr[MAX_ACCESSES_PER_INSN_PER_THREAD];
-	int num_mem_txn=0;
-        
-        smid = thread->get_hw_sid();
-   	if( whichspace(addr) == shared_space ) {
-          addr= generic_to_shared(smid,addr);
-          space = shared_space;
-	}
-   	decode_space(space,thread,src1,mem,addr);
+    memory_space_t space = pI->get_space();
 
-   	type_info_key::type_decode(type, size, t);
-   	if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-		printf("mma_st: thrd=%d, addr=%x, fp(size=%zu), stride=%d\n", thrd, addr_reg.u32, size, src2_data.u32);
-	addr_t new_addr = addr+thread_group_offset(thrd,wmma_type,wmma_layout,type,stride)*size/8;  
-	addr_t push_addr;
+    memory_space *mem = NULL;
+    addr_t addr = addr_reg.u32;
 
-	ptx_reg_t nw_v[8];
-	for(k=0;k<8;k++){
-		if(k%2==0)
-			nw_v[k].s64=(v[k/2].s64&0xffff);
-		else
-			nw_v[k].s64=((v[k/2].s64&0xffff0000)>>16);
-	}
+    new_addr_type mem_txn_addr[MAX_ACCESSES_PER_INSN_PER_THREAD];
+    int num_mem_txn = 0;
 
-	for(k=0;k<8;k++){
-		if(type==F32_TYPE){
-       			//mem->write(new_addr+4*acc_float_offset(k,wmma_layout,stride),size/8,&v[k].s64,thread,pI);
-       			push_addr=new_addr+4*acc_float_offset(k,wmma_layout,stride);
-       			mem->write(push_addr,size/8,&v[k].s64,thread,pI);
-			mem_txn_addr[num_mem_txn++]=push_addr;
-	
-			if(core->get_gpu()->gpgpu_ctx->debug_tensorcore){
-				printf("wmma:store:thread%d=%llx,%llx,%llx,%llx,%llx,%llx,%llx,%llx\n",thrd,v[0].s64,v[1].s64,v[2].s64,v[3].s64,v[4].s64,v[5].s64,v[6].s64,v[7].s64);   
-				float temp;
-				int l;
-				printf("thread=%d:",thrd);
-				for(l=0;l<8;l++){
-					temp=v[l].f32;
-					printf("%.2f",temp);	
-				}
-				printf("\n");
-			}
-		}
-		else if(type==F16_TYPE){
-			if(wmma_layout==ROW){
-       				//mem->write(new_addr+k*2,size/8,&nw_v[k].s64,thread,pI);
-       				push_addr=new_addr+k*2;
-       				mem->write(push_addr,size/8,&nw_v[k].s64,thread,pI);
-				if(k%2==0)
-					mem_txn_addr[num_mem_txn++]=push_addr;
-			}
-			else if(wmma_layout==COL){
-       				//mem->write(new_addr+k*2*stride,size/8,&nw_v[k].s64,thread,pI);
-       				push_addr=new_addr+k*2*stride;
-       				mem->write(push_addr,size/8,&nw_v[k].s64,thread,pI);
-				mem_txn_addr[num_mem_txn++]=push_addr;
-			}
-	
-			if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-				printf("wmma:store:thread%d=%llx,%llx,%llx,%llx,%llx,%llx,%llx,%llx\n",thrd,nw_v[0].s64,nw_v[1].s64,nw_v[2].s64,nw_v[3].s64,nw_v[4].s64,nw_v[5].s64,nw_v[6].s64,nw_v[7].s64);   
-		}
-	}
-   	
-	delete [] v;
-   	inst.space = space;
-   	inst.set_addr(thrd, (new_addr_type *)mem_txn_addr , num_mem_txn);
+    smid = thread->get_hw_sid();
+    if (whichspace(addr) == shared_space) {
+      addr = generic_to_shared(smid, addr);
+      space = shared_space;
+    }
+    decode_space(space, thread, src1, mem, addr);
 
-	if((type==F16_TYPE)&&(wmma_layout==COL))//check the profiling xls for details
-   		inst.data_size = 2; // 2 byte transaction 
-   	else
-		inst.data_size = 4; // 4 byte transaction 
+    type_info_key::type_decode(type, size, t);
+    if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+      printf("mma_st: thrd=%d, addr=%x, fp(size=%zu), stride=%d\n", thrd,
+             addr_reg.u32, size, src2_data.u32);
+    addr_t new_addr =
+        addr + thread_group_offset(thrd, wmma_type, wmma_layout, type, stride) *
+                   size / 8;
+    addr_t push_addr;
 
-   	assert( inst.memory_op == insn_memory_op );
-   	//thread->m_last_effective_address = addr;
-   	//thread->m_last_memory_space = space;
-   } 
+    ptx_reg_t nw_v[8];
+    for (k = 0; k < 8; k++) {
+      if (k % 2 == 0)
+        nw_v[k].s64 = (v[k / 2].s64 & 0xffff);
+      else
+        nw_v[k].s64 = ((v[k / 2].s64 & 0xffff0000) >> 16);
+    }
+
+    for (k = 0; k < 8; k++) {
+      if (type == F32_TYPE) {
+        // mem->write(new_addr+4*acc_float_offset(k,wmma_layout,stride),size/8,&v[k].s64,thread,pI);
+        push_addr = new_addr + 4 * acc_float_offset(k, wmma_layout, stride);
+        mem->write(push_addr, size / 8, &v[k].s64, thread, pI);
+        mem_txn_addr[num_mem_txn++] = push_addr;
+
+        if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) {
+          printf(
+              "wmma:store:thread%d=%llx,%llx,%llx,%llx,%llx,%llx,%llx,%llx\n",
+              thrd, v[0].s64, v[1].s64, v[2].s64, v[3].s64, v[4].s64, v[5].s64,
+              v[6].s64, v[7].s64);
+          float temp;
+          int l;
+          printf("thread=%d:", thrd);
+          for (l = 0; l < 8; l++) {
+            temp = v[l].f32;
+            printf("%.2f", temp);
+          }
+          printf("\n");
+        }
+      } else if (type == F16_TYPE) {
+        if (wmma_layout == ROW) {
+          // mem->write(new_addr+k*2,size/8,&nw_v[k].s64,thread,pI);
+          push_addr = new_addr + k * 2;
+          mem->write(push_addr, size / 8, &nw_v[k].s64, thread, pI);
+          if (k % 2 == 0) mem_txn_addr[num_mem_txn++] = push_addr;
+        } else if (wmma_layout == COL) {
+          // mem->write(new_addr+k*2*stride,size/8,&nw_v[k].s64,thread,pI);
+          push_addr = new_addr + k * 2 * stride;
+          mem->write(push_addr, size / 8, &nw_v[k].s64, thread, pI);
+          mem_txn_addr[num_mem_txn++] = push_addr;
+        }
+
+        if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+          printf(
+              "wmma:store:thread%d=%llx,%llx,%llx,%llx,%llx,%llx,%llx,%llx\n",
+              thrd, nw_v[0].s64, nw_v[1].s64, nw_v[2].s64, nw_v[3].s64,
+              nw_v[4].s64, nw_v[5].s64, nw_v[6].s64, nw_v[7].s64);
+      }
+    }
+
+    delete[] v;
+    inst.space = space;
+    inst.set_addr(thrd, (new_addr_type *)mem_txn_addr, num_mem_txn);
+
+    if ((type == F16_TYPE) &&
+        (wmma_layout == COL))  // check the profiling xls for details
+      inst.data_size = 2;      // 2 byte transaction
+    else
+      inst.data_size = 4;  // 4 byte transaction
+
+    assert(inst.memory_op == insn_memory_op);
+    // thread->m_last_effective_address = addr;
+    // thread->m_last_memory_space = space;
+  }
 }
 
-void mma_ld_impl( const ptx_instruction *pI, core_t *core, warp_inst_t &inst )
-{
-   size_t size;
-   int t,i;
-   unsigned smid;
-   const operand_info &dst = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+void mma_ld_impl(const ptx_instruction *pI, core_t *core, warp_inst_t &inst) {
+  size_t size;
+  int t, i;
+  unsigned smid;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   unsigned type = pI->get_type();
-   unsigned wmma_type = pI->get_wmma_type();
-   unsigned wmma_layout = pI->get_wmma_layout(0);
-   int tid;
-   int thrd,stride;
-   ptx_thread_info *thread;
- 
+  unsigned type = pI->get_type();
+  unsigned wmma_type = pI->get_wmma_type();
+  unsigned wmma_layout = pI->get_wmma_layout(0);
+  int tid;
+  int thrd, stride;
+  ptx_thread_info *thread;
 
-   if(core->get_gpu()->is_functional_sim())
-    	tid= inst.warp_id_func()*core->get_warp_size();
-   else
-    	tid= inst.warp_id()*core->get_warp_size();
+  if (core->get_gpu()->is_functional_sim())
+    tid = inst.warp_id_func() * core->get_warp_size();
+  else
+    tid = inst.warp_id() * core->get_warp_size();
 
-   _memory_op_t insn_memory_op = pI->has_memory_read() ? memory_load : memory_store;
-   
-   for (thrd=0; thrd < core->get_warp_size(); thrd++){
-   	thread = core->get_thread_info()[tid+thrd];
-   	ptx_reg_t src1_data = thread->get_operand_value(src1, dst, U32_TYPE, thread, 1);
-   	ptx_reg_t src2_data = thread->get_operand_value(src2, dst, U32_TYPE, thread, 1);
-	stride=src2_data.u32;
-   	memory_space_t space = pI->get_space();
+  _memory_op_t insn_memory_op =
+      pI->has_memory_read() ? memory_load : memory_store;
 
-   	memory_space *mem = NULL;
-   	addr_t addr = src1_data.u32;
-        smid = thread->get_hw_sid();
-        if( whichspace(addr) == shared_space ) {
-          addr= generic_to_shared(smid,addr);
-          space = shared_space;
-	}
+  for (thrd = 0; thrd < core->get_warp_size(); thrd++) {
+    thread = core->get_thread_info()[tid + thrd];
+    ptx_reg_t src1_data =
+        thread->get_operand_value(src1, dst, U32_TYPE, thread, 1);
+    ptx_reg_t src2_data =
+        thread->get_operand_value(src2, dst, U32_TYPE, thread, 1);
+    stride = src2_data.u32;
+    memory_space_t space = pI->get_space();
 
-	decode_space(space,thread,src1,mem,addr);
-   	type_info_key::type_decode(type, size, t);
-	
-	ptx_reg_t data[16];
-   	if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)	
-		printf("mma_ld: thrd=%d,addr=%x, fpsize=%zu, stride=%d\n", thrd, src1_data.u32, size, src2_data.u32);
-	
-	addr_t new_addr = addr+thread_group_offset(thrd,wmma_type,wmma_layout,type,stride)*size/8;  
-	addr_t fetch_addr;
-	new_addr_type mem_txn_addr[MAX_ACCESSES_PER_INSN_PER_THREAD];
-	int num_mem_txn=0;
+    memory_space *mem = NULL;
+    addr_t addr = src1_data.u32;
+    smid = thread->get_hw_sid();
+    if (whichspace(addr) == shared_space) {
+      addr = generic_to_shared(smid, addr);
+      space = shared_space;
+    }
 
-	if(wmma_type==LOAD_A){
-		for(i=0;i<16;i++){
-			if(wmma_layout==ROW){
-				//mem->read(new_addr+2*i,size/8,&data[i].s64);
-				fetch_addr=new_addr+2*i;
-				mem->read(fetch_addr,size/8,&data[i].s64);
-			}
-			else if(wmma_layout==COL){
-				//mem->read(new_addr+2*(i%4)+2*stride*4*(i/4),size/8,&data[i].s64);
-				fetch_addr=new_addr+2*(i%4)+2*stride*4*(i/4);
-				mem->read(fetch_addr,size/8,&data[i].s64);
-			}
-			else{
-				printf("mma_ld:wrong_layout_type\n");
-				abort();
-			
-			}
-			if(i%2==0)
-				mem_txn_addr[num_mem_txn++]=fetch_addr;	
-		}
-	}
-	else if(wmma_type==LOAD_B){
-		for(i=0;i<16;i++){
-			if(wmma_layout==COL){
-				//mem->read(new_addr+2*i,size/8,&data[i].s64);
-				fetch_addr=new_addr+2*i;
-				mem->read(fetch_addr,size/8,&data[i].s64);
-			}
-			else if(wmma_layout==ROW){
-				//mem->read(new_addr+2*(i%4)+2*stride*4*(i/4),size/8,&data[i].s64);
-				fetch_addr=new_addr+2*(i%4)+2*stride*4*(i/4);
-				mem->read(fetch_addr,size/8,&data[i].s64);
-			}
-			else{
-				printf("mma_ld:wrong_layout_type\n");
-				abort();
-			}
-			if(i%2==0)
-				mem_txn_addr[num_mem_txn++]=fetch_addr;	
-		}
-	}
-	else if(wmma_type==LOAD_C){
-		for(i=0;i<8;i++){
-			if(type==F16_TYPE){
-				if(wmma_layout==ROW){
-					//mem->read(new_addr+2*i,size/8,&data[i].s64);
-					fetch_addr=new_addr+2*i;
-					mem->read(fetch_addr,size/8,&data[i].s64);
-					if(i%2==0)
-						mem_txn_addr[num_mem_txn++]=fetch_addr;	
-				}
-				else if(wmma_layout==COL){
-					//mem->read(new_addr+2*stride*i,size/8,&data[i].s64);
-					fetch_addr=new_addr+2*stride*i;
-					mem->read(fetch_addr,size/8,&data[i].s64);
-					mem_txn_addr[num_mem_txn++]=fetch_addr;	
-				}
-				else{
-					printf("mma_ld:wrong_type\n");
-					abort();
-				}
-			}
-			else if(type==F32_TYPE){
-				//mem->read(new_addr+4*acc_float_offset(i,wmma_layout,stride),size/8,&data[i].s64);
-				fetch_addr=new_addr+4*acc_float_offset(i,wmma_layout,stride);
-				mem->read(fetch_addr,size/8,&data[i].s64);
-				mem_txn_addr[num_mem_txn++]=fetch_addr;	
-			}
-			else{
-				printf("wrong type");
-				abort();
-			}
-		}
-	}
-	else{
-		printf("wrong wmma type\n");;
-		abort();
-	}
-	//generate timing memory request
-   	inst.space = space;
-   	inst.set_addr(thrd, (new_addr_type *)mem_txn_addr , num_mem_txn);
+    decode_space(space, thread, src1, mem, addr);
+    type_info_key::type_decode(type, size, t);
 
-	if((wmma_type==LOAD_C)&&(type==F16_TYPE)&&(wmma_layout==COL))//memory address is scattered, check the profiling xls for more detail.
-   		inst.data_size = 2; // 2 byte transaction 
-	else	
-   		inst.data_size = 4; // 4 byte transaction 
-   	assert( inst.memory_op == insn_memory_op );
+    ptx_reg_t data[16];
+    if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+      printf("mma_ld: thrd=%d,addr=%x, fpsize=%zu, stride=%d\n", thrd,
+             src1_data.u32, size, src2_data.u32);
 
-	if(core->get_gpu()->gpgpu_ctx->debug_tensorcore){
-		if(type==F16_TYPE){
-			printf("\nmma_ld:thread%d= ",thrd);
-			for(i=0;i<16;i++){
-				printf("%llx ",data[i].u64);
-			}
-			printf("\n");
-			
-			printf("\nmma_ld:thread%d= ",thrd);
-			float temp;
-			for(i=0;i<16;i++){
-			temp=data[i].f16;
-				printf("%.2f ",temp);
-			}
-			printf("\n");
-		}
-		else{
-			printf("\nmma_ld:thread%d= ",thrd);
-			for(i=0;i<8;i++){
-				printf("%.2f ",data[i].f32);
-			}
-			printf("\n");
-			printf("\nmma_ld:thread%d= ",thrd);
-			for(i=0;i<8;i++){
-				printf("%llx ",data[i].u64);
-			}
-			printf("\n");
-		}
-	}
+    addr_t new_addr =
+        addr + thread_group_offset(thrd, wmma_type, wmma_layout, type, stride) *
+                   size / 8;
+    addr_t fetch_addr;
+    new_addr_type mem_txn_addr[MAX_ACCESSES_PER_INSN_PER_THREAD];
+    int num_mem_txn = 0;
 
-	if((wmma_type==LOAD_C)&&(type==F32_TYPE)){
-   		thread->set_wmma_vector_operand_values(dst,data[0],data[1],data[2],data[3],data[4],data[5],data[6],data[7]);
-	}
-	else{
-		ptx_reg_t nw_data[8];
-		int num_reg;
-		
-		if(wmma_type==LOAD_C)
-			num_reg=4;
-		else
-			num_reg=8;
+    if (wmma_type == LOAD_A) {
+      for (i = 0; i < 16; i++) {
+        if (wmma_layout == ROW) {
+          // mem->read(new_addr+2*i,size/8,&data[i].s64);
+          fetch_addr = new_addr + 2 * i;
+          mem->read(fetch_addr, size / 8, &data[i].s64);
+        } else if (wmma_layout == COL) {
+          // mem->read(new_addr+2*(i%4)+2*stride*4*(i/4),size/8,&data[i].s64);
+          fetch_addr = new_addr + 2 * (i % 4) + 2 * stride * 4 * (i / 4);
+          mem->read(fetch_addr, size / 8, &data[i].s64);
+        } else {
+          printf("mma_ld:wrong_layout_type\n");
+          abort();
+        }
+        if (i % 2 == 0) mem_txn_addr[num_mem_txn++] = fetch_addr;
+      }
+    } else if (wmma_type == LOAD_B) {
+      for (i = 0; i < 16; i++) {
+        if (wmma_layout == COL) {
+          // mem->read(new_addr+2*i,size/8,&data[i].s64);
+          fetch_addr = new_addr + 2 * i;
+          mem->read(fetch_addr, size / 8, &data[i].s64);
+        } else if (wmma_layout == ROW) {
+          // mem->read(new_addr+2*(i%4)+2*stride*4*(i/4),size/8,&data[i].s64);
+          fetch_addr = new_addr + 2 * (i % 4) + 2 * stride * 4 * (i / 4);
+          mem->read(fetch_addr, size / 8, &data[i].s64);
+        } else {
+          printf("mma_ld:wrong_layout_type\n");
+          abort();
+        }
+        if (i % 2 == 0) mem_txn_addr[num_mem_txn++] = fetch_addr;
+      }
+    } else if (wmma_type == LOAD_C) {
+      for (i = 0; i < 8; i++) {
+        if (type == F16_TYPE) {
+          if (wmma_layout == ROW) {
+            // mem->read(new_addr+2*i,size/8,&data[i].s64);
+            fetch_addr = new_addr + 2 * i;
+            mem->read(fetch_addr, size / 8, &data[i].s64);
+            if (i % 2 == 0) mem_txn_addr[num_mem_txn++] = fetch_addr;
+          } else if (wmma_layout == COL) {
+            // mem->read(new_addr+2*stride*i,size/8,&data[i].s64);
+            fetch_addr = new_addr + 2 * stride * i;
+            mem->read(fetch_addr, size / 8, &data[i].s64);
+            mem_txn_addr[num_mem_txn++] = fetch_addr;
+          } else {
+            printf("mma_ld:wrong_type\n");
+            abort();
+          }
+        } else if (type == F32_TYPE) {
+          // mem->read(new_addr+4*acc_float_offset(i,wmma_layout,stride),size/8,&data[i].s64);
+          fetch_addr = new_addr + 4 * acc_float_offset(i, wmma_layout, stride);
+          mem->read(fetch_addr, size / 8, &data[i].s64);
+          mem_txn_addr[num_mem_txn++] = fetch_addr;
+        } else {
+          printf("wrong type");
+          abort();
+        }
+      }
+    } else {
+      printf("wrong wmma type\n");
+      ;
+      abort();
+    }
+    // generate timing memory request
+    inst.space = space;
+    inst.set_addr(thrd, (new_addr_type *)mem_txn_addr, num_mem_txn);
 
-		for(i=0;i<num_reg;i++){
-			nw_data[i].s64= ((data[2*i].s64 & 0xffff)<<16)| ((data[2*i+1].s64 & 0xffff));
-		}
+    if ((wmma_type == LOAD_C) && (type == F16_TYPE) &&
+        (wmma_layout == COL))  // memory address is scattered, check the
+                               // profiling xls for more detail.
+      inst.data_size = 2;  // 2 byte transaction
+    else
+      inst.data_size = 4;  // 4 byte transaction
+    assert(inst.memory_op == insn_memory_op);
 
-		if(wmma_type==LOAD_C)
-   			thread->set_vector_operand_values(dst,nw_data[0],nw_data[1],nw_data[2],nw_data[3]);
-		else
-   			thread->set_wmma_vector_operand_values(dst,nw_data[0],nw_data[1],nw_data[2],nw_data[3],nw_data[4],nw_data[5],nw_data[6],nw_data[7]);
-		if(core->get_gpu()->gpgpu_ctx->debug_tensorcore){	
-			printf("mma_ld:data[0].s64=%llx,data[1].s64=%llx,new_data[0].s64=%llx\n",data[0].u64,data[1].u64,nw_data[0].u64);	
-			printf("mma_ld:data[2].s64=%llx,data[3].s64=%llx,new_data[1].s64=%llx\n",data[2].u64,data[3].u64,nw_data[1].u64);	
-			printf("mma_ld:data[4].s64=%llx,data[5].s64=%llx,new_data[2].s64=%llx\n",data[4].u64,data[5].u64,nw_data[2].u64);	
-			printf("mma_ld:data[6].s64=%llx,data[7].s64=%llx,new_data[3].s64=%llx\n",data[6].u64,data[7].u64,nw_data[3].u64);	
-			if(wmma_type!=LOAD_C){
-			printf("mma_ld:data[8].s64=%llx,data[9].s64=%llx,new_data[4].s64=%llx\n",data[8].u64,data[9].u64,nw_data[4].s64);	
-			printf("mma_ld:data[10].s64=%llx,data[11].s64=%llx,new_data[5].s64=%llx\n",data[10].u64,data[11].u64,nw_data[5].u64);	
-			printf("mma_ld:data[12].s64=%llx,data[13].s64=%llx,new_data[6].s64=%llx\n",data[12].u64,data[13].u64,nw_data[6].u64);	
-			printf("mma_ld:data[14].s64=%llx,data[15].s64=%llx,new_data[7].s64=%llx\n",data[14].u64,data[15].u64,nw_data[3].u64);	
-			}
-		}
-	}
+    if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) {
+      if (type == F16_TYPE) {
+        printf("\nmma_ld:thread%d= ", thrd);
+        for (i = 0; i < 16; i++) {
+          printf("%llx ", data[i].u64);
+        }
+        printf("\n");
 
-   	//thread->m_last_effective_address = addr;
-   	//thread->m_last_memory_space = space;
-   } 
+        printf("\nmma_ld:thread%d= ", thrd);
+        float temp;
+        for (i = 0; i < 16; i++) {
+          temp = data[i].f16;
+          printf("%.2f ", temp);
+        }
+        printf("\n");
+      } else {
+        printf("\nmma_ld:thread%d= ", thrd);
+        for (i = 0; i < 8; i++) {
+          printf("%.2f ", data[i].f32);
+        }
+        printf("\n");
+        printf("\nmma_ld:thread%d= ", thrd);
+        for (i = 0; i < 8; i++) {
+          printf("%llx ", data[i].u64);
+        }
+        printf("\n");
+      }
+    }
+
+    if ((wmma_type == LOAD_C) && (type == F32_TYPE)) {
+      thread->set_wmma_vector_operand_values(dst, data[0], data[1], data[2],
+                                             data[3], data[4], data[5], data[6],
+                                             data[7]);
+    } else {
+      ptx_reg_t nw_data[8];
+      int num_reg;
+
+      if (wmma_type == LOAD_C)
+        num_reg = 4;
+      else
+        num_reg = 8;
+
+      for (i = 0; i < num_reg; i++) {
+        nw_data[i].s64 = ((data[2 * i].s64 & 0xffff) << 16) |
+                         ((data[2 * i + 1].s64 & 0xffff));
+      }
+
+      if (wmma_type == LOAD_C)
+        thread->set_vector_operand_values(dst, nw_data[0], nw_data[1],
+                                          nw_data[2], nw_data[3]);
+      else
+        thread->set_wmma_vector_operand_values(
+            dst, nw_data[0], nw_data[1], nw_data[2], nw_data[3], nw_data[4],
+            nw_data[5], nw_data[6], nw_data[7]);
+      if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) {
+        printf(
+            "mma_ld:data[0].s64=%llx,data[1].s64=%llx,new_data[0].s64=%llx\n",
+            data[0].u64, data[1].u64, nw_data[0].u64);
+        printf(
+            "mma_ld:data[2].s64=%llx,data[3].s64=%llx,new_data[1].s64=%llx\n",
+            data[2].u64, data[3].u64, nw_data[1].u64);
+        printf(
+            "mma_ld:data[4].s64=%llx,data[5].s64=%llx,new_data[2].s64=%llx\n",
+            data[4].u64, data[5].u64, nw_data[2].u64);
+        printf(
+            "mma_ld:data[6].s64=%llx,data[7].s64=%llx,new_data[3].s64=%llx\n",
+            data[6].u64, data[7].u64, nw_data[3].u64);
+        if (wmma_type != LOAD_C) {
+          printf(
+              "mma_ld:data[8].s64=%llx,data[9].s64=%llx,new_data[4].s64=%llx\n",
+              data[8].u64, data[9].u64, nw_data[4].s64);
+          printf(
+              "mma_ld:data[10].s64=%llx,data[11].s64=%llx,new_data[5].s64=%"
+              "llx\n",
+              data[10].u64, data[11].u64, nw_data[5].u64);
+          printf(
+              "mma_ld:data[12].s64=%llx,data[13].s64=%llx,new_data[6].s64=%"
+              "llx\n",
+              data[12].u64, data[13].u64, nw_data[6].u64);
+          printf(
+              "mma_ld:data[14].s64=%llx,data[15].s64=%llx,new_data[7].s64=%"
+              "llx\n",
+              data[14].u64, data[15].u64, nw_data[3].u64);
+        }
+      }
+    }
+
+    // thread->m_last_effective_address = addr;
+    // thread->m_last_memory_space = space;
+  }
 }
 
-void lg2_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t a, d;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
+void lg2_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, d;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
 
-   unsigned i_type = pI->get_type();
+  unsigned i_type = pI->get_type();
 
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
 
-
-   switch ( i_type ) {
-   case F32_TYPE: 
-      d.f32 = log(a.f32)/log(2);
+  switch (i_type) {
+    case F32_TYPE:
+      d.f32 = log(a.f32) / log(2);
       break;
-   default:
+    default:
       printf("Execution error: type mismatch with instruction\n");
       assert(0);
       break;
-   }
+  }
 
-   thread->set_operand_value(dst,d, i_type, thread, pI);
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-void mad24_impl( const ptx_instruction *pI, ptx_thread_info *thread )
-{
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
-   const operand_info &src3 = pI->src3();
-   ptx_reg_t d, t;
+void mad24_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
+  const operand_info &src3 = pI->src3();
+  ptx_reg_t d, t;
 
-   unsigned i_type = pI->get_type();
-   ptx_reg_t a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   ptx_reg_t b = thread->get_operand_value(src2, dst, i_type, thread, 1);
-   ptx_reg_t c = thread->get_operand_value(src3, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  ptx_reg_t a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  ptx_reg_t b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  ptx_reg_t c = thread->get_operand_value(src3, dst, i_type, thread, 1);
 
-   unsigned sat_mode = pI->saturation_mode();
+  unsigned sat_mode = pI->saturation_mode();
 
-   assert( !pI->is_wide() );
+  assert(!pI->is_wide());
 
-   switch ( i_type ) {
-   case S32_TYPE: 
+  switch (i_type) {
+    case S32_TYPE:
       t.s64 = a.s32 * b.s32;
-      if ( pI->is_hi() ) {
-         d.s64 = (t.s64>>16) + c.s32;
-         if ( sat_mode ) {
-            if ( d.s64 > (int)0x7FFFFFFF )
-               d.s64 = (int)0x7FFFFFFF;
-            else if ( d.s64 < (int)0x80000000 )
-               d.s64 = (int)0x80000000;
-         }
-      } else if ( pI->is_lo() ) d.s64 = t.s32 + c.s32;
-      else assert(0);
+      if (pI->is_hi()) {
+        d.s64 = (t.s64 >> 16) + c.s32;
+        if (sat_mode) {
+          if (d.s64 > (int)0x7FFFFFFF)
+            d.s64 = (int)0x7FFFFFFF;
+          else if (d.s64 < (int)0x80000000)
+            d.s64 = (int)0x80000000;
+        }
+      } else if (pI->is_lo())
+        d.s64 = t.s32 + c.s32;
+      else
+        assert(0);
       break;
-   case U32_TYPE: 
+    case U32_TYPE:
       t.u64 = a.u32 * b.u32;
-      if ( pI->is_hi() ) d.u64 = (t.u64>>16) + c.u32;
-      else if ( pI->is_lo() ) d.u64 = t.u32 + c.u32;
-      else assert(0);
+      if (pI->is_hi())
+        d.u64 = (t.u64 >> 16) + c.u32;
+      else if (pI->is_lo())
+        d.u64 = t.u32 + c.u32;
+      else
+        assert(0);
       break;
-   default: 
+    default:
       assert(0);
       break;
-   }
+  }
 
-   thread->set_operand_value(dst, d, i_type, thread, pI);
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-void mad_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   mad_def(pI, thread, false);
+void mad_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  mad_def(pI, thread, false);
 }
 
-void madp_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   mad_def(pI, thread, true);
+void madp_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  mad_def(pI, thread, true);
 }
 
-void madc_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   mad_def(pI, thread, true);
+void madc_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  mad_def(pI, thread, true);
 }
 
-void mad_def( const ptx_instruction *pI, ptx_thread_info *thread, bool use_carry ) 
-{ 
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
-   const operand_info &src3 = pI->src3();
-   ptx_reg_t d, t;
+void mad_def(const ptx_instruction *pI, ptx_thread_info *thread,
+             bool use_carry) {
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
+  const operand_info &src3 = pI->src3();
+  ptx_reg_t d, t;
 
-   int carry=0;
-   int overflow=0;
+  int carry = 0;
+  int overflow = 0;
 
-   unsigned i_type = pI->get_type();
-   ptx_reg_t a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   ptx_reg_t b = thread->get_operand_value(src2, dst, i_type, thread, 1);
-   ptx_reg_t c = thread->get_operand_value(src3, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  ptx_reg_t a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  ptx_reg_t b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  ptx_reg_t c = thread->get_operand_value(src3, dst, i_type, thread, 1);
 
-   // take the carry bit, it should be the 4th operand 
-   ptx_reg_t carry_bit; 
-   carry_bit.u64 = 0;
-   if (use_carry) {
-      const operand_info &carry = pI->operand_lookup(4);
-      carry_bit = thread->get_operand_value(carry, dst, PRED_TYPE, thread, 0);
-      carry_bit.pred &= 0x4;
-      carry_bit.pred >>=2;
-   }
+  // take the carry bit, it should be the 4th operand
+  ptx_reg_t carry_bit;
+  carry_bit.u64 = 0;
+  if (use_carry) {
+    const operand_info &carry = pI->operand_lookup(4);
+    carry_bit = thread->get_operand_value(carry, dst, PRED_TYPE, thread, 0);
+    carry_bit.pred &= 0x4;
+    carry_bit.pred >>= 2;
+  }
 
-   unsigned rounding_mode = pI->rounding_mode();
+  unsigned rounding_mode = pI->rounding_mode();
 
-   switch ( i_type ) {
-   case S16_TYPE: 
+  switch (i_type) {
+    case S16_TYPE:
       t.s32 = a.s16 * b.s16;
-      if ( pI->is_wide() ) d.s32 = t.s32 + c.s32 + carry_bit.pred;
-      else if ( pI->is_hi() ) d.s16 = (t.s32>>16) + c.s16 + carry_bit.pred;
-      else if ( pI->is_lo() ) d.s16 = t.s16 + c.s16 + carry_bit.pred;
-      else assert(0);
-      carry = ((long long int)(t.s32 + c.s32 + carry_bit.pred)&0x100000000)>>32;
+      if (pI->is_wide())
+        d.s32 = t.s32 + c.s32 + carry_bit.pred;
+      else if (pI->is_hi())
+        d.s16 = (t.s32 >> 16) + c.s16 + carry_bit.pred;
+      else if (pI->is_lo())
+        d.s16 = t.s16 + c.s16 + carry_bit.pred;
+      else
+        assert(0);
+      carry =
+          ((long long int)(t.s32 + c.s32 + carry_bit.pred) & 0x100000000) >> 32;
       break;
-   case S32_TYPE: 
+    case S32_TYPE:
       t.s64 = a.s32 * b.s32;
-      if ( pI->is_wide() ) d.s64 = t.s64 + c.s64 + carry_bit.pred;
-      else if ( pI->is_hi() ) d.s32 = (t.s64>>32) + c.s32 + carry_bit.pred;
-      else if ( pI->is_lo() ) d.s32 = t.s32 + c.s32 + carry_bit.pred;
-      else assert(0);
+      if (pI->is_wide())
+        d.s64 = t.s64 + c.s64 + carry_bit.pred;
+      else if (pI->is_hi())
+        d.s32 = (t.s64 >> 32) + c.s32 + carry_bit.pred;
+      else if (pI->is_lo())
+        d.s32 = t.s32 + c.s32 + carry_bit.pred;
+      else
+        assert(0);
       break;
-   case S64_TYPE: 
+    case S64_TYPE:
       t.s64 = a.s64 * b.s64;
-      assert( !pI->is_wide() );
-      assert( !pI->is_hi() );
-      assert( use_carry == false); 
-      if ( pI->is_lo() ) d.s64 = t.s64 + c.s64 + carry_bit.pred;
-      else assert(0);
+      assert(!pI->is_wide());
+      assert(!pI->is_hi());
+      assert(use_carry == false);
+      if (pI->is_lo())
+        d.s64 = t.s64 + c.s64 + carry_bit.pred;
+      else
+        assert(0);
       break;
-   case U16_TYPE: 
+    case U16_TYPE:
       t.u32 = a.u16 * b.u16;
-      if ( pI->is_wide() ) d.u32 = t.u32 + c.u32 + carry_bit.pred;
-      else if ( pI->is_hi() ) d.u16 = (t.u32 + c.u16 + carry_bit.pred)>>16;
-      else if ( pI->is_lo() ) d.u16 = t.u16 + c.u16 + carry_bit.pred;
-      else assert(0);
-      carry = ((long long int)((long long int)t.u32 + c.u32 + carry_bit.pred)&0x100000000)>>32;
+      if (pI->is_wide())
+        d.u32 = t.u32 + c.u32 + carry_bit.pred;
+      else if (pI->is_hi())
+        d.u16 = (t.u32 + c.u16 + carry_bit.pred) >> 16;
+      else if (pI->is_lo())
+        d.u16 = t.u16 + c.u16 + carry_bit.pred;
+      else
+        assert(0);
+      carry = ((long long int)((long long int)t.u32 + c.u32 + carry_bit.pred) &
+               0x100000000) >>
+              32;
       break;
-   case U32_TYPE: 
+    case U32_TYPE:
       t.u64 = a.u32 * b.u32;
-      if ( pI->is_wide() ) d.u64 = t.u64 + c.u64 + carry_bit.pred;
-      else if ( pI->is_hi() ) d.u32 = (t.u64 + c.u32 + carry_bit.pred)>>32;
-      else if ( pI->is_lo() ) d.u32 = t.u32 + c.u32 + carry_bit.pred;
-      else assert(0);
+      if (pI->is_wide())
+        d.u64 = t.u64 + c.u64 + carry_bit.pred;
+      else if (pI->is_hi())
+        d.u32 = (t.u64 + c.u32 + carry_bit.pred) >> 32;
+      else if (pI->is_lo())
+        d.u32 = t.u32 + c.u32 + carry_bit.pred;
+      else
+        assert(0);
       break;
-   case U64_TYPE: 
+    case U64_TYPE:
       t.u64 = a.u64 * b.u64;
-      assert( !pI->is_wide() );
-      assert( !pI->is_hi() );
-      assert( use_carry == false); 
-      if ( pI->is_lo() ) d.u64 = t.u64 + c.u64 + carry_bit.pred;
-      else assert(0);
+      assert(!pI->is_wide());
+      assert(!pI->is_hi());
+      assert(use_carry == false);
+      if (pI->is_lo())
+        d.u64 = t.u64 + c.u64 + carry_bit.pred;
+      else
+        assert(0);
       break;
-   case F16_TYPE:{ 
-     // assert(0); 
-     // break;
-         assert( use_carry == false); 
-         int orig_rm = fegetround();
-         switch ( rounding_mode ) {
-         case RN_OPTION: break;
-         case RZ_OPTION: fesetround( FE_TOWARDZERO ); break;
-         default: assert(0); break;
-         }
-         d.f16 = a.f16 * b.f16 + c.f16;
-         if ( pI->saturation_mode() ) {
-            if ( d.f16 < 0 ) d.f16 = 0;
-            else if ( d.f16 > 1.0f ) d.f16 = 1.0f;
-         }
-         fesetround( orig_rm );
-         break;
-      }  
-   case F32_TYPE: {
-         assert( use_carry == false); 
-         int orig_rm = fegetround();
-         switch ( rounding_mode ) {
-         case RN_OPTION: break;
-         case RZ_OPTION: fesetround( FE_TOWARDZERO ); break;
-         default: assert(0); break;
-         }
-         d.f32 = a.f32 * b.f32 + c.f32;
-         if ( pI->saturation_mode() ) {
-            if ( d.f32 < 0 ) d.f32 = 0;
-            else if ( d.f32 > 1.0f ) d.f32 = 1.0f;
-         }
-         fesetround( orig_rm );
-         break;
-      }  
-   case F64_TYPE: case FF64_TYPE: {
-         assert( use_carry == false); 
-         int orig_rm = fegetround();
-         switch ( rounding_mode ) {
-         case RN_OPTION: break;
-         case RZ_OPTION: fesetround( FE_TOWARDZERO ); break;
-         default: assert(0); break;
-         }
-         d.f64 = a.f64 * b.f64 + c.f64;
-         if ( pI->saturation_mode() ) {
-            if ( d.f64 < 0 ) d.f64 = 0;
-            else if ( d.f64 > 1.0f ) d.f64 = 1.0;
-         }
-         fesetround( orig_rm );
-         break;
+    case F16_TYPE: {
+      // assert(0);
+      // break;
+      assert(use_carry == false);
+      int orig_rm = fegetround();
+      switch (rounding_mode) {
+        case RN_OPTION:
+          break;
+        case RZ_OPTION:
+          fesetround(FE_TOWARDZERO);
+          break;
+        default:
+          assert(0);
+          break;
       }
-   default: 
+      d.f16 = a.f16 * b.f16 + c.f16;
+      if (pI->saturation_mode()) {
+        if (d.f16 < 0)
+          d.f16 = 0;
+        else if (d.f16 > 1.0f)
+          d.f16 = 1.0f;
+      }
+      fesetround(orig_rm);
+      break;
+    }
+    case F32_TYPE: {
+      assert(use_carry == false);
+      int orig_rm = fegetround();
+      switch (rounding_mode) {
+        case RN_OPTION:
+          break;
+        case RZ_OPTION:
+          fesetround(FE_TOWARDZERO);
+          break;
+        default:
+          assert(0);
+          break;
+      }
+      d.f32 = a.f32 * b.f32 + c.f32;
+      if (pI->saturation_mode()) {
+        if (d.f32 < 0)
+          d.f32 = 0;
+        else if (d.f32 > 1.0f)
+          d.f32 = 1.0f;
+      }
+      fesetround(orig_rm);
+      break;
+    }
+    case F64_TYPE:
+    case FF64_TYPE: {
+      assert(use_carry == false);
+      int orig_rm = fegetround();
+      switch (rounding_mode) {
+        case RN_OPTION:
+          break;
+        case RZ_OPTION:
+          fesetround(FE_TOWARDZERO);
+          break;
+        default:
+          assert(0);
+          break;
+      }
+      d.f64 = a.f64 * b.f64 + c.f64;
+      if (pI->saturation_mode()) {
+        if (d.f64 < 0)
+          d.f64 = 0;
+        else if (d.f64 > 1.0f)
+          d.f64 = 1.0;
+      }
+      fesetround(orig_rm);
+      break;
+    }
+    default:
       assert(0);
       break;
-   }
-   thread->set_operand_value(dst, d, i_type, thread, pI, overflow, carry);
+  }
+  thread->set_operand_value(dst, d, i_type, thread, pI, overflow, carry);
 }
 
-bool isNaN(float x)
-{
-   return std::isnan(x);
-}
+bool isNaN(float x) { return std::isnan(x); }
 
-bool isNaN(double x)
-{
-   return std::isnan(x);
-}
+bool isNaN(double x) { return std::isnan(x); }
 
-void max_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t a, b, d;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+void max_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, b, d;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   unsigned i_type = pI->get_type();
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  b = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-
-   switch ( i_type ) {
-   case U16_TYPE: d.u16 = MY_MAX_I(a.u16,b.u16); break;
-   case U32_TYPE: d.u32 = MY_MAX_I(a.u32,b.u32); break;
-   case U64_TYPE: d.u64 = MY_MAX_I(a.u64,b.u64); break;
-   case S16_TYPE: d.s16 = MY_MAX_I(a.s16,b.s16); break;
-   case S32_TYPE: d.s32 = MY_MAX_I(a.s32,b.s32); break;
-   case S64_TYPE: d.s64 = MY_MAX_I(a.s64,b.s64); break;
-   case F32_TYPE: d.f32 = MY_MAX_F(a.f32,b.f32); break;
-   case F64_TYPE: case FF64_TYPE: d.f64 = MY_MAX_F(a.f64,b.f64); break;
-   default:
-      printf("Execution error: type mismatch with instruction\n");
-      assert(0); 
+  switch (i_type) {
+    case U16_TYPE:
+      d.u16 = MY_MAX_I(a.u16, b.u16);
       break;
-   }
-
-   thread->set_operand_value(dst,d, i_type, thread, pI);
-}
-
-void membar_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   // handled by timing simulator 
-}
-
-void min_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t a, b, d;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
-
-   unsigned i_type = pI->get_type();
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   b = thread->get_operand_value(src2, dst, i_type, thread, 1);
-
-
-   switch ( i_type ) {
-   case U16_TYPE: d.u16 = MY_MIN_I(a.u16,b.u16); break;
-   case U32_TYPE: d.u32 = MY_MIN_I(a.u32,b.u32); break;
-   case U64_TYPE: d.u64 = MY_MIN_I(a.u64,b.u64); break;
-   case S16_TYPE: d.s16 = MY_MIN_I(a.s16,b.s16); break;
-   case S32_TYPE: d.s32 = MY_MIN_I(a.s32,b.s32); break;
-   case S64_TYPE: d.s64 = MY_MIN_I(a.s64,b.s64); break;
-   case F32_TYPE: d.f32 = MY_MIN_F(a.f32,b.f32); break;
-   case F64_TYPE: case FF64_TYPE: d.f64 = MY_MIN_F(a.f64,b.f64); break;
-   default:
+    case U32_TYPE:
+      d.u32 = MY_MAX_I(a.u32, b.u32);
+      break;
+    case U64_TYPE:
+      d.u64 = MY_MAX_I(a.u64, b.u64);
+      break;
+    case S16_TYPE:
+      d.s16 = MY_MAX_I(a.s16, b.s16);
+      break;
+    case S32_TYPE:
+      d.s32 = MY_MAX_I(a.s32, b.s32);
+      break;
+    case S64_TYPE:
+      d.s64 = MY_MAX_I(a.s64, b.s64);
+      break;
+    case F32_TYPE:
+      d.f32 = MY_MAX_F(a.f32, b.f32);
+      break;
+    case F64_TYPE:
+    case FF64_TYPE:
+      d.f64 = MY_MAX_F(a.f64, b.f64);
+      break;
+    default:
       printf("Execution error: type mismatch with instruction\n");
       assert(0);
       break;
-   }
+  }
 
-   thread->set_operand_value(dst,d, i_type, thread, pI);
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-void mov_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   ptx_reg_t data;
-
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   unsigned i_type = pI->get_type();
-   assert( src1.is_param_local() == 0 );
-
-   if( (src1.is_vector() || dst.is_vector()) && (i_type != BB64_TYPE) && (i_type != BB128_TYPE) && (i_type != FF64_TYPE) ) {
-      // pack or unpack operation
-      unsigned nbits_to_move;
-      ptx_reg_t tmp_bits;
-
-      switch( pI->get_type() ) {
-      case B16_TYPE: nbits_to_move = 16; break;
-      case B32_TYPE: nbits_to_move = 32; break;
-      case B64_TYPE: nbits_to_move = 64; break;
-      default: printf("Execution error: mov pack/unpack with unsupported type qualifier\n"); assert(0); break;
-      }
-
-      if( src1.is_vector() ) {
-         unsigned nelem = src1.get_vect_nelem();
-         ptx_reg_t v[4];
-         thread->get_vector_operand_values(src1, v, nelem );
-
-         unsigned bits_per_src_elem = nbits_to_move / nelem;
-         for( unsigned i=0; i < nelem; i++ ) {
-            switch(bits_per_src_elem) {
-            case 8:   tmp_bits.u64 |= ((unsigned long long)(v[i].u8)  << (8*i));  break;
-            case 16:  tmp_bits.u64 |= ((unsigned long long)(v[i].u16) << (16*i)); break;
-            case 32:  tmp_bits.u64 |= ((unsigned long long)(v[i].u32) << (32*i)); break;
-            default: printf("Execution error: mov pack/unpack with unsupported source/dst size ratio (src)\n"); assert(0); break;
-            }
-         }
-      } else {
-         data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-
-         switch( pI->get_type() ) {
-         case B16_TYPE: tmp_bits.u16 = data.u16; break;
-         case B32_TYPE: tmp_bits.u32 = data.u32; break;
-         case B64_TYPE: tmp_bits.u64 = data.u64; break;
-         default: assert(0); break;
-         }
-      }
-
-      if( dst.is_vector() ) {
-         unsigned nelem = dst.get_vect_nelem();
-         ptx_reg_t v[4];
-         unsigned bits_per_dst_elem = nbits_to_move / nelem;
-         for( unsigned i=0; i < nelem; i++ ) {
-            switch(bits_per_dst_elem) {
-            case 8:  v[i].u8  = (tmp_bits.u64 >> (8*i)) & ((unsigned long long) 0xFF); break;
-            case 16: v[i].u16 = (tmp_bits.u64 >> (16*i)) & ((unsigned long long) 0xFFFF); break;
-            case 32: v[i].u32 = (tmp_bits.u64 >> (32*i)) & ((unsigned long long) 0xFFFFFFFF); break;
-            default:
-               printf("Execution error: mov pack/unpack with unsupported source/dst size ratio (dst)\n");
-               assert(0);
-               break;
-            }
-         }
-         thread->set_vector_operand_values(dst,v[0],v[1],v[2],v[3]);
-      } else {
-         thread->set_operand_value(dst,tmp_bits, i_type, thread, pI);
-      }
-   } else if (i_type == PRED_TYPE and src1.is_literal() == true) {
-      // in ptx, literal input translate to predicate as 0 = false and 1 = true 
-      // we have adopted the opposite to simplify implementation of zero flags in ptxplus 
-      data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-
-      ptx_reg_t finaldata; 
-      finaldata.pred = (data.u32 == 0)? 1 : 0;  // setting zero-flag in predicate 
-      thread->set_operand_value(dst, finaldata, i_type, thread, pI);
-   } else {
-
-      data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-
-     thread->set_operand_value(dst, data, i_type, thread, pI);
-
-   }
+void membar_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  // handled by timing simulator
 }
 
-void mul24_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   ptx_reg_t src1_data, src2_data, data;
+void min_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, b, d;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+  unsigned i_type = pI->get_type();
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  b = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-   unsigned i_type = pI->get_type();
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  switch (i_type) {
+    case U16_TYPE:
+      d.u16 = MY_MIN_I(a.u16, b.u16);
+      break;
+    case U32_TYPE:
+      d.u32 = MY_MIN_I(a.u32, b.u32);
+      break;
+    case U64_TYPE:
+      d.u64 = MY_MIN_I(a.u64, b.u64);
+      break;
+    case S16_TYPE:
+      d.s16 = MY_MIN_I(a.s16, b.s16);
+      break;
+    case S32_TYPE:
+      d.s32 = MY_MIN_I(a.s32, b.s32);
+      break;
+    case S64_TYPE:
+      d.s64 = MY_MIN_I(a.s64, b.s64);
+      break;
+    case F32_TYPE:
+      d.f32 = MY_MIN_F(a.f32, b.f32);
+      break;
+    case F64_TYPE:
+    case FF64_TYPE:
+      d.f64 = MY_MIN_F(a.f64, b.f64);
+      break;
+    default:
+      printf("Execution error: type mismatch with instruction\n");
+      assert(0);
+      break;
+  }
 
+  thread->set_operand_value(dst, d, i_type, thread, pI);
+}
 
-   //src1_data = srcOperandModifiers(src1_data, src1, dst, i_type, thread);
-   //src2_data = srcOperandModifiers(src2_data, src2, dst, i_type, thread);
+void mov_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t data;
 
-   src1_data.mask_and(0,0x00FFFFFF);
-   src2_data.mask_and(0,0x00FFFFFF);
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  unsigned i_type = pI->get_type();
+  assert(src1.is_param_local() == 0);
 
-   switch ( i_type ) {
-   case S32_TYPE: 
-      if( src1_data.get_bit(23) ) 
-         src1_data.mask_or(0xFFFFFFFF,0xFF000000);
-      if( src2_data.get_bit(23) ) 
-         src2_data.mask_or(0xFFFFFFFF,0xFF000000);
+  if ((src1.is_vector() || dst.is_vector()) && (i_type != BB64_TYPE) &&
+      (i_type != BB128_TYPE) && (i_type != FF64_TYPE)) {
+    // pack or unpack operation
+    unsigned nbits_to_move;
+    ptx_reg_t tmp_bits;
+
+    switch (pI->get_type()) {
+      case B16_TYPE:
+        nbits_to_move = 16;
+        break;
+      case B32_TYPE:
+        nbits_to_move = 32;
+        break;
+      case B64_TYPE:
+        nbits_to_move = 64;
+        break;
+      default:
+        printf(
+            "Execution error: mov pack/unpack with unsupported type "
+            "qualifier\n");
+        assert(0);
+        break;
+    }
+
+    if (src1.is_vector()) {
+      unsigned nelem = src1.get_vect_nelem();
+      ptx_reg_t v[4];
+      thread->get_vector_operand_values(src1, v, nelem);
+
+      unsigned bits_per_src_elem = nbits_to_move / nelem;
+      for (unsigned i = 0; i < nelem; i++) {
+        switch (bits_per_src_elem) {
+          case 8:
+            tmp_bits.u64 |= ((unsigned long long)(v[i].u8) << (8 * i));
+            break;
+          case 16:
+            tmp_bits.u64 |= ((unsigned long long)(v[i].u16) << (16 * i));
+            break;
+          case 32:
+            tmp_bits.u64 |= ((unsigned long long)(v[i].u32) << (32 * i));
+            break;
+          default:
+            printf(
+                "Execution error: mov pack/unpack with unsupported source/dst "
+                "size ratio (src)\n");
+            assert(0);
+            break;
+        }
+      }
+    } else {
+      data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+
+      switch (pI->get_type()) {
+        case B16_TYPE:
+          tmp_bits.u16 = data.u16;
+          break;
+        case B32_TYPE:
+          tmp_bits.u32 = data.u32;
+          break;
+        case B64_TYPE:
+          tmp_bits.u64 = data.u64;
+          break;
+        default:
+          assert(0);
+          break;
+      }
+    }
+
+    if (dst.is_vector()) {
+      unsigned nelem = dst.get_vect_nelem();
+      ptx_reg_t v[4];
+      unsigned bits_per_dst_elem = nbits_to_move / nelem;
+      for (unsigned i = 0; i < nelem; i++) {
+        switch (bits_per_dst_elem) {
+          case 8:
+            v[i].u8 = (tmp_bits.u64 >> (8 * i)) & ((unsigned long long)0xFF);
+            break;
+          case 16:
+            v[i].u16 =
+                (tmp_bits.u64 >> (16 * i)) & ((unsigned long long)0xFFFF);
+            break;
+          case 32:
+            v[i].u32 =
+                (tmp_bits.u64 >> (32 * i)) & ((unsigned long long)0xFFFFFFFF);
+            break;
+          default:
+            printf(
+                "Execution error: mov pack/unpack with unsupported source/dst "
+                "size ratio (dst)\n");
+            assert(0);
+            break;
+        }
+      }
+      thread->set_vector_operand_values(dst, v[0], v[1], v[2], v[3]);
+    } else {
+      thread->set_operand_value(dst, tmp_bits, i_type, thread, pI);
+    }
+  } else if (i_type == PRED_TYPE and src1.is_literal() == true) {
+    // in ptx, literal input translate to predicate as 0 = false and 1 = true
+    // we have adopted the opposite to simplify implementation of zero flags in
+    // ptxplus
+    data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+
+    ptx_reg_t finaldata;
+    finaldata.pred = (data.u32 == 0) ? 1 : 0;  // setting zero-flag in predicate
+    thread->set_operand_value(dst, finaldata, i_type, thread, pI);
+  } else {
+    data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+
+    thread->set_operand_value(dst, data, i_type, thread, pI);
+  }
+}
+
+void mul24_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, src2_data, data;
+
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
+
+  unsigned i_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+
+  // src1_data = srcOperandModifiers(src1_data, src1, dst, i_type, thread);
+  // src2_data = srcOperandModifiers(src2_data, src2, dst, i_type, thread);
+
+  src1_data.mask_and(0, 0x00FFFFFF);
+  src2_data.mask_and(0, 0x00FFFFFF);
+
+  switch (i_type) {
+    case S32_TYPE:
+      if (src1_data.get_bit(23)) src1_data.mask_or(0xFFFFFFFF, 0xFF000000);
+      if (src2_data.get_bit(23)) src2_data.mask_or(0xFFFFFFFF, 0xFF000000);
       data.s64 = src1_data.s64 * src2_data.s64;
       break;
-   case U32_TYPE:
+    case U32_TYPE:
       data.u64 = src1_data.u64 * src2_data.u64;
       break;
-   default:
-      printf("GPGPU-Sim PTX: Execution error - type mismatch with instruction\n");
+    default:
+      printf(
+          "GPGPU-Sim PTX: Execution error - type mismatch with instruction\n");
       assert(0);
       break;
-   }
+  }
 
-   if ( pI->is_hi() ) {
-      data.u64 = data.u64 >> 16;
-      data.mask_and(0,0xFFFFFFFF);
-   } else if (pI->is_lo()) {
-      data.mask_and(0,0xFFFFFFFF);
-   }
+  if (pI->is_hi()) {
+    data.u64 = data.u64 >> 16;
+    data.mask_and(0, 0xFFFFFFFF);
+  } else if (pI->is_lo()) {
+    data.mask_and(0, 0xFFFFFFFF);
+  }
 
-   thread->set_operand_value(dst, data, i_type, thread, pI);
+  thread->set_operand_value(dst, data, i_type, thread, pI);
 }
 
-void mul_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   ptx_reg_t data;
+void mul_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t data;
 
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
-   ptx_reg_t d, t;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
+  ptx_reg_t d, t;
 
-   unsigned i_type = pI->get_type();
-   ptx_reg_t a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   ptx_reg_t b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  ptx_reg_t a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  ptx_reg_t b = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-   unsigned rounding_mode = pI->rounding_mode();
+  unsigned rounding_mode = pI->rounding_mode();
 
-   switch ( i_type ) {
-   case S16_TYPE: 
+  switch (i_type) {
+    case S16_TYPE:
       t.s32 = ((int)a.s16) * ((int)b.s16);
-      if ( pI->is_wide() ) d.s32 = t.s32;
-      else if ( pI->is_hi() ) d.s16 = (t.s32>>16);
-      else if ( pI->is_lo() ) d.s16 = t.s16;
-      else assert(0);
+      if (pI->is_wide())
+        d.s32 = t.s32;
+      else if (pI->is_hi())
+        d.s16 = (t.s32 >> 16);
+      else if (pI->is_lo())
+        d.s16 = t.s16;
+      else
+        assert(0);
       break;
-   case S32_TYPE: 
+    case S32_TYPE:
       t.s64 = ((long long)a.s32) * ((long long)b.s32);
-      if ( pI->is_wide() ) d.s64 = t.s64;
-      else if ( pI->is_hi() ) d.s32 = (t.s64>>32);
-      else if ( pI->is_lo() ) d.s32 = t.s32;
-      else assert(0);
+      if (pI->is_wide())
+        d.s64 = t.s64;
+      else if (pI->is_hi())
+        d.s32 = (t.s64 >> 32);
+      else if (pI->is_lo())
+        d.s32 = t.s32;
+      else
+        assert(0);
       break;
-   case S64_TYPE: 
+    case S64_TYPE:
       t.s64 = a.s64 * b.s64;
-      assert( !pI->is_wide() );
-      assert( !pI->is_hi() );
-      if ( pI->is_lo() ) d.s64 = t.s64;
-      else assert(0);
+      assert(!pI->is_wide());
+      assert(!pI->is_hi());
+      if (pI->is_lo())
+        d.s64 = t.s64;
+      else
+        assert(0);
       break;
-   case U16_TYPE: 
+    case U16_TYPE:
       t.u32 = ((unsigned)a.u16) * ((unsigned)b.u16);
-      if ( pI->is_wide() ) d.u32 = t.u32;
-      else if ( pI->is_lo() ) d.u16 = t.u16;
-      else if ( pI->is_hi() ) d.u16 = (t.u32>>16);
-      else assert(0);
+      if (pI->is_wide())
+        d.u32 = t.u32;
+      else if (pI->is_lo())
+        d.u16 = t.u16;
+      else if (pI->is_hi())
+        d.u16 = (t.u32 >> 16);
+      else
+        assert(0);
       break;
-   case U32_TYPE: 
+    case U32_TYPE:
       t.u64 = ((unsigned long long)a.u32) * ((unsigned long long)b.u32);
-      if ( pI->is_wide() ) d.u64 = t.u64;
-      else if ( pI->is_lo() ) d.u32 = t.u32;
-      else if ( pI->is_hi() ) d.u32 = (t.u64>>32);
-      else assert(0);
+      if (pI->is_wide())
+        d.u64 = t.u64;
+      else if (pI->is_lo())
+        d.u32 = t.u32;
+      else if (pI->is_hi())
+        d.u32 = (t.u64 >> 32);
+      else
+        assert(0);
       break;
-   case U64_TYPE: 
+    case U64_TYPE:
       t.u64 = a.u64 * b.u64;
-      assert( !pI->is_wide() );
-      assert( !pI->is_hi() );
-      if ( pI->is_lo() ) d.u64 = t.u64;
-      else assert(0);
+      assert(!pI->is_wide());
+      assert(!pI->is_hi());
+      if (pI->is_lo())
+        d.u64 = t.u64;
+      else
+        assert(0);
       break;
-   case F16_TYPE:{ 
-      //assert(0); 
-      //break;
-         int orig_rm = fegetround();
-         switch ( rounding_mode ) {
-         case RN_OPTION: break;
-         case RZ_OPTION: fesetround( FE_TOWARDZERO ); break;
-         default: assert(0); break;
-         }
-
-         d.f16 = a.f16 * b.f16;
-
-         if ( pI->saturation_mode() ) {
-            if ( d.f16 < 0 ) d.f16 = 0;
-            else if ( d.f16 > 1.0f ) d.f16 = 1.0f;
-         }
-         fesetround( orig_rm );
-         break;
-      }  
-   case F32_TYPE: {
-         int orig_rm = fegetround();
-         switch ( rounding_mode ) {
-         case RN_OPTION: break;
-         case RZ_OPTION: fesetround( FE_TOWARDZERO ); break;
-         default: assert(0); break;
-         }
-
-         d.f32 = a.f32 * b.f32;
-
-         if ( pI->saturation_mode() ) {
-            if ( d.f32 < 0 ) d.f32 = 0;
-            else if ( d.f32 > 1.0f ) d.f32 = 1.0f;
-         }
-         fesetround( orig_rm );
-         break;
-      }  
-   case F64_TYPE: case FF64_TYPE:{
-         int orig_rm = fegetround();
-         switch ( rounding_mode ) {
-         case RN_OPTION: break;
-         case RZ_OPTION: fesetround( FE_TOWARDZERO ); break;
-         default: assert(0); break;
-         }
-         d.f64 = a.f64 * b.f64;
-         if ( pI->saturation_mode() ) {
-            if ( d.f64 < 0 ) d.f64 = 0;
-            else if ( d.f64 > 1.0f ) d.f64 = 1.0;
-         }
-         fesetround( orig_rm );
-         break;
+    case F16_TYPE: {
+      // assert(0);
+      // break;
+      int orig_rm = fegetround();
+      switch (rounding_mode) {
+        case RN_OPTION:
+          break;
+        case RZ_OPTION:
+          fesetround(FE_TOWARDZERO);
+          break;
+        default:
+          assert(0);
+          break;
       }
-   default: 
-      assert(0); 
+
+      d.f16 = a.f16 * b.f16;
+
+      if (pI->saturation_mode()) {
+        if (d.f16 < 0)
+          d.f16 = 0;
+        else if (d.f16 > 1.0f)
+          d.f16 = 1.0f;
+      }
+      fesetround(orig_rm);
       break;
-   }
+    }
+    case F32_TYPE: {
+      int orig_rm = fegetround();
+      switch (rounding_mode) {
+        case RN_OPTION:
+          break;
+        case RZ_OPTION:
+          fesetround(FE_TOWARDZERO);
+          break;
+        default:
+          assert(0);
+          break;
+      }
 
-   thread->set_operand_value(dst, d, i_type, thread, pI);
+      d.f32 = a.f32 * b.f32;
+
+      if (pI->saturation_mode()) {
+        if (d.f32 < 0)
+          d.f32 = 0;
+        else if (d.f32 > 1.0f)
+          d.f32 = 1.0f;
+      }
+      fesetround(orig_rm);
+      break;
+    }
+    case F64_TYPE:
+    case FF64_TYPE: {
+      int orig_rm = fegetround();
+      switch (rounding_mode) {
+        case RN_OPTION:
+          break;
+        case RZ_OPTION:
+          fesetround(FE_TOWARDZERO);
+          break;
+        default:
+          assert(0);
+          break;
+      }
+      d.f64 = a.f64 * b.f64;
+      if (pI->saturation_mode()) {
+        if (d.f64 < 0)
+          d.f64 = 0;
+        else if (d.f64 > 1.0f)
+          d.f64 = 1.0;
+      }
+      fesetround(orig_rm);
+      break;
+    }
+    default:
+      assert(0);
+      break;
+  }
+
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-void neg_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t src1_data, src2_data, data;
+void neg_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, src2_data, data;
 
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
 
-   unsigned to_type = pI->get_type();
-   src1_data = thread->get_operand_value(src1, dst, to_type, thread, 1);
+  unsigned to_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, to_type, thread, 1);
 
+  switch (to_type) {
+    case S8_TYPE:
+    case S16_TYPE:
+    case S32_TYPE:
+    case S64_TYPE:
+      data.s64 = 0 - src1_data.s64;
+      break;  // seems buggy, but not (just ignore higher bits)
+    case U8_TYPE:
+    case U16_TYPE:
+    case U32_TYPE:
+    case U64_TYPE:
+      assert(0);
+      break;
+    case F16_TYPE:
+      data.f16 = 0.0f - src1_data.f16;
+      break;  // assert(0); break;
+    case F32_TYPE:
+      data.f32 = 0.0f - src1_data.f32;
+      break;
+    case F64_TYPE:
+    case FF64_TYPE:
+      data.f64 = 0.0f - src1_data.f64;
+      break;
+    default:
+      assert(0);
+      break;
+  }
 
-   switch ( to_type ) {
-   case S8_TYPE:
-   case S16_TYPE:
-   case S32_TYPE:
-   case S64_TYPE: 
-      data.s64 = 0 - src1_data.s64; break; // seems buggy, but not (just ignore higher bits)
-   case U8_TYPE:
-   case U16_TYPE:
-   case U32_TYPE:
-   case U64_TYPE: 
-      assert(0); break;
-   case F16_TYPE: data.f16 =0.0f  - src1_data.f16; break;//assert(0); break;
-   case F32_TYPE: data.f32 = 0.0f - src1_data.f32; break;
-   case F64_TYPE: case FF64_TYPE: data.f64 = 0.0f - src1_data.f64; break;
-   default: assert(0); break;
-   }
-
-   thread->set_operand_value(dst,data, to_type, thread, pI);
+  thread->set_operand_value(dst, data, to_type, thread, pI);
 }
 
-//nandn bitwise negates second operand then bitwise nands with the first operand
-void nandn_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   ptx_reg_t src1_data, src2_data, data;
+// nandn bitwise negates second operand then bitwise nands with the first
+// operand
+void nandn_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, src2_data, data;
 
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   unsigned i_type = pI->get_type();
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
+  // the way ptxplus handles predicates: 1 = false and 0 = true
+  if (i_type == PRED_TYPE)
+    data.pred = (~src1_data.pred & src2_data.pred);
+  else
+    data.u64 = ~(src1_data.u64 & ~src2_data.u64);
 
-   //the way ptxplus handles predicates: 1 = false and 0 = true
-   if(i_type == PRED_TYPE)
-      data.pred = (~src1_data.pred & src2_data.pred);
-   else
-      data.u64 = ~(src1_data.u64 & ~src2_data.u64);
-
-   thread->set_operand_value(dst,data, i_type, thread, pI);
-
+  thread->set_operand_value(dst, data, i_type, thread, pI);
 }
 
-//norn bitwise negates first operand then bitwise ands with the second operand
-void norn_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   ptx_reg_t src1_data, src2_data, data;
+// norn bitwise negates first operand then bitwise ands with the second operand
+void norn_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, src2_data, data;
 
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   unsigned i_type = pI->get_type();
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
+  // the way ptxplus handles predicates: 1 = false and 0 = true
+  if (i_type == PRED_TYPE)
+    data.pred = ~(src1_data.pred & ~(src2_data.pred));
+  else
+    data.u64 = ~(src1_data.u64) & src2_data.u64;
 
-   //the way ptxplus handles predicates: 1 = false and 0 = true
-   if(i_type == PRED_TYPE)
-      data.pred = ~(src1_data.pred & ~(src2_data.pred));
-   else
-      data.u64 = ~(src1_data.u64) & src2_data.u64;
-
-   thread->set_operand_value(dst,data, i_type, thread, pI);
-
+  thread->set_operand_value(dst, data, i_type, thread, pI);
 }
 
-void not_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   ptx_reg_t a, b, d;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
+void not_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, b, d;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
 
-   unsigned i_type = pI->get_type();
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
 
-
-   switch ( i_type ) {
-   case PRED_TYPE: d.pred = (~(a.pred) & 0x000F); break;
-   case B16_TYPE:  d.u16  = ~a.u16; break;
-   case B32_TYPE:  d.u32  = ~a.u32; break;
-   case B64_TYPE:  d.u64  = ~a.u64; break;
-   default:
+  switch (i_type) {
+    case PRED_TYPE:
+      d.pred = (~(a.pred) & 0x000F);
+      break;
+    case B16_TYPE:
+      d.u16 = ~a.u16;
+      break;
+    case B32_TYPE:
+      d.u32 = ~a.u32;
+      break;
+    case B64_TYPE:
+      d.u64 = ~a.u64;
+      break;
+    default:
       printf("Execution error: type mismatch with instruction\n");
-      assert(0); 
+      assert(0);
       break;
-   }
+  }
 
-   thread->set_operand_value(dst,d, i_type, thread, pI);
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-void or_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t src1_data, src2_data, data;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+void or_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, src2_data, data;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   unsigned i_type = pI->get_type();
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-   //the way ptxplus handles predicates: 1 = false and 0 = true
-   if(i_type == PRED_TYPE)
-      data.pred = ~(~(src1_data.pred) | ~(src2_data.pred));
-   else
-      data.u64 = src1_data.u64 | src2_data.u64;
+  // the way ptxplus handles predicates: 1 = false and 0 = true
+  if (i_type == PRED_TYPE)
+    data.pred = ~(~(src1_data.pred) | ~(src2_data.pred));
+  else
+    data.u64 = src1_data.u64 | src2_data.u64;
 
-   thread->set_operand_value(dst,data, i_type, thread, pI);
+  thread->set_operand_value(dst, data, i_type, thread, pI);
 }
 
-void orn_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t src1_data, src2_data, data;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+void orn_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, src2_data, data;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   unsigned i_type = pI->get_type();
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-   //the way ptxplus handles predicates: 1 = false and 0 = true
-   if(i_type == PRED_TYPE)
-      data.pred = ~(~(src1_data.pred) | (src2_data.pred));
-   else
-      data.u64 = src1_data.u64 | ~src2_data.u64;
+  // the way ptxplus handles predicates: 1 = false and 0 = true
+  if (i_type == PRED_TYPE)
+    data.pred = ~(~(src1_data.pred) | (src2_data.pred));
+  else
+    data.u64 = src1_data.u64 | ~src2_data.u64;
 
-   thread->set_operand_value(dst,data, i_type, thread, pI);
+  thread->set_operand_value(dst, data, i_type, thread, pI);
 }
 
-void pmevent_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void popc_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t src_data, data;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src = pI->src1();
+void pmevent_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void popc_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src_data, data;
+  const operand_info &dst = pI->dst();
+  const operand_info &src = pI->src1();
 
-   unsigned i_type = pI->get_type();
-   src_data = thread->get_operand_value(src, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  src_data = thread->get_operand_value(src, dst, i_type, thread, 1);
 
-   switch ( i_type ) {
-   case B32_TYPE: {
-      std::bitset<32> mask(src_data.u32); 
-      data.u32 = mask.count(); 
-      } break;
-   case B64_TYPE: {
-      std::bitset<64> mask(src_data.u64); 
+  switch (i_type) {
+    case B32_TYPE: {
+      std::bitset<32> mask(src_data.u32);
       data.u32 = mask.count();
-      } break;
-   default:
+    } break;
+    case B64_TYPE: {
+      std::bitset<64> mask(src_data.u64);
+      data.u32 = mask.count();
+    } break;
+    default:
       printf("Execution error: type mismatch with instruction\n");
-      assert(0); 
+      assert(0);
       break;
-   }
+  }
 
-   thread->set_operand_value(dst,data, i_type, thread, pI);
+  thread->set_operand_value(dst, data, i_type, thread, pI);
 }
-void prefetch_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void prefetchu_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-
-int prmt_mode_present(int mode)
-{
-	int returnval=0;
-	switch(mode){
-		case PRMT_F4E_MODE:
-		case PRMT_B4E_MODE:
-		case PRMT_RC8_MODE:
-		case PRMT_RC16_MODE:
-		case PRMT_ECL_MODE:
-		case PRMT_ECR_MODE:	
-			returnval=1;
-			break;
-		default:	
-			break;
-	}
-	return returnval;
+void prefetch_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
 }
-int read_byte(int mode, int control, int d_sel_index, signed long long value){
-
-	int returnval = 0;
-	int prmt_f4e_mode[4][4]={{0,1,2,3},{1,2,3,4},{2,3,4,5},{3,4,5,6}};
-	int prmt_b4e_mode[4][4]={{0,7,6,5},{1,0,7,6},{2,1,0,7},{3,2,1,0}};
-	int prmt_rc8_mode[4][4]={{0,0,0,0},{1,1,1,1},{2,2,2,2},{3,3,3,3}};
-	int prmt_ecl_mode[4][4]={{0,1,2,3},{1,1,2,3},{2,2,2,3},{3,3,3,3}};
-	int prmt_ecr_mode[4][4]={{0,0,0,0},{0,1,1,1},{0,1,2,2},{0,1,2,3}};
-	int prmt_rc16_mode[4][4]={{0,1,0,1},{2,3,2,3},{0,1,0,1},{2,3,2,3}};
-
-	if(!prmt_mode_present(mode)){
-		if(control&0x8){
-			returnval=0xff;
-		}
-		else{
-			returnval= (value>>(8*control)) & 0xff;
-		}
-	}
-	else{
-		switch(mode){
-			case PRMT_F4E_MODE:	returnval=prmt_f4e_mode[control][d_sel_index];break;
-			case PRMT_B4E_MODE:	returnval=prmt_b4e_mode[control][d_sel_index];break;
-			case PRMT_RC8_MODE:	returnval=prmt_rc8_mode[control][d_sel_index];break;
-			case PRMT_ECL_MODE:	returnval=prmt_ecl_mode[control][d_sel_index];break;
-			case PRMT_ECR_MODE:	returnval=prmt_ecr_mode[control][d_sel_index];break;
-			case PRMT_RC16_MODE: returnval=prmt_rc16_mode[control][d_sel_index];break;
-            // Change the default from printing "ERROR" to just asserting
-			default: assert(false);
-		}
-	}	
-	return (returnval << 8 * d_sel_index);
+void prefetchu_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
 }
 
-void prmt_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { 
-   
-   ptx_reg_t src1_data, src2_data, src3_data,tmpdata,data;
-   const operand_info &dst  = pI->dst();  
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
-   const operand_info &src3 = pI->src3();
+int prmt_mode_present(int mode) {
+  int returnval = 0;
+  switch (mode) {
+    case PRMT_F4E_MODE:
+    case PRMT_B4E_MODE:
+    case PRMT_RC8_MODE:
+    case PRMT_RC16_MODE:
+    case PRMT_ECL_MODE:
+    case PRMT_ECR_MODE:
+      returnval = 1;
+      break;
+    default:
+      break;
+  }
+  return returnval;
+}
+int read_byte(int mode, int control, int d_sel_index, signed long long value) {
+  int returnval = 0;
+  int prmt_f4e_mode[4][4] = {
+      {0, 1, 2, 3}, {1, 2, 3, 4}, {2, 3, 4, 5}, {3, 4, 5, 6}};
+  int prmt_b4e_mode[4][4] = {
+      {0, 7, 6, 5}, {1, 0, 7, 6}, {2, 1, 0, 7}, {3, 2, 1, 0}};
+  int prmt_rc8_mode[4][4] = {
+      {0, 0, 0, 0}, {1, 1, 1, 1}, {2, 2, 2, 2}, {3, 3, 3, 3}};
+  int prmt_ecl_mode[4][4] = {
+      {0, 1, 2, 3}, {1, 1, 2, 3}, {2, 2, 2, 3}, {3, 3, 3, 3}};
+  int prmt_ecr_mode[4][4] = {
+      {0, 0, 0, 0}, {0, 1, 1, 1}, {0, 1, 2, 2}, {0, 1, 2, 3}};
+  int prmt_rc16_mode[4][4] = {
+      {0, 1, 0, 1}, {2, 3, 2, 3}, {0, 1, 0, 1}, {2, 3, 2, 3}};
 
-   unsigned mode   = pI->prmt_op();
-   unsigned i_type = pI->get_type();
-
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
-   src3_data = thread->get_operand_value(src3, dst, i_type, thread, 1);
-
-   tmpdata.s64=src1_data.s32|(src2_data.s64<<32);
-   int ctl[4];
-
-   if(!prmt_mode_present(mode)){
-	ctl[0]=(src3_data.s32>>0)&0xf;
-	ctl[1]=(src3_data.s32>>4)&0xf;
-	ctl[2]=(src3_data.s32>>8)&0xf;
-	ctl[3]=(src3_data.s32>>12)&0xf;
-   }
-   else{
-	ctl[0]=ctl[1]=ctl[2]=ctl[3]=(src3_data.s32>>0)&0x3;	
-   }
-   
-   data.s32=0;
-   data.s32=data.s32|read_byte(mode,ctl[0],0,tmpdata.s64);   //First byte-0
-   data.s32=data.s32|read_byte(mode,ctl[1],1,tmpdata.s64);   //Second byte-1
-   data.s32=data.s32|read_byte(mode,ctl[2],2,tmpdata.s64);   //Third byte-2
-   data.s32=data.s32|read_byte(mode,ctl[3],3,tmpdata.s64);   //Fourth byte-3
-	
-   thread->set_operand_value(dst,data, i_type, thread, pI);
-
-
+  if (!prmt_mode_present(mode)) {
+    if (control & 0x8) {
+      returnval = 0xff;
+    } else {
+      returnval = (value >> (8 * control)) & 0xff;
+    }
+  } else {
+    switch (mode) {
+      case PRMT_F4E_MODE:
+        returnval = prmt_f4e_mode[control][d_sel_index];
+        break;
+      case PRMT_B4E_MODE:
+        returnval = prmt_b4e_mode[control][d_sel_index];
+        break;
+      case PRMT_RC8_MODE:
+        returnval = prmt_rc8_mode[control][d_sel_index];
+        break;
+      case PRMT_ECL_MODE:
+        returnval = prmt_ecl_mode[control][d_sel_index];
+        break;
+      case PRMT_ECR_MODE:
+        returnval = prmt_ecr_mode[control][d_sel_index];
+        break;
+      case PRMT_RC16_MODE:
+        returnval = prmt_rc16_mode[control][d_sel_index];
+        break;
+        // Change the default from printing "ERROR" to just asserting
+      default:
+        assert(false);
+    }
+  }
+  return (returnval << 8 * d_sel_index);
 }
 
-void rcp_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t src1_data, src2_data, data;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
+void prmt_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, src2_data, src3_data, tmpdata, data;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
+  const operand_info &src3 = pI->src3();
 
-   unsigned i_type = pI->get_type();
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  unsigned mode = pI->prmt_op();
+  unsigned i_type = pI->get_type();
 
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  src3_data = thread->get_operand_value(src3, dst, i_type, thread, 1);
 
-   switch ( i_type ) {
-   case F32_TYPE: 
+  tmpdata.s64 = src1_data.s32 | (src2_data.s64 << 32);
+  int ctl[4];
+
+  if (!prmt_mode_present(mode)) {
+    ctl[0] = (src3_data.s32 >> 0) & 0xf;
+    ctl[1] = (src3_data.s32 >> 4) & 0xf;
+    ctl[2] = (src3_data.s32 >> 8) & 0xf;
+    ctl[3] = (src3_data.s32 >> 12) & 0xf;
+  } else {
+    ctl[0] = ctl[1] = ctl[2] = ctl[3] = (src3_data.s32 >> 0) & 0x3;
+  }
+
+  data.s32 = 0;
+  data.s32 = data.s32 | read_byte(mode, ctl[0], 0, tmpdata.s64);  // First
+                                                                  // byte-0
+  data.s32 =
+      data.s32 | read_byte(mode, ctl[1], 1, tmpdata.s64);  // Second byte-1
+  data.s32 = data.s32 | read_byte(mode, ctl[2], 2, tmpdata.s64);  // Third
+                                                                  // byte-2
+  data.s32 =
+      data.s32 | read_byte(mode, ctl[3], 3, tmpdata.s64);  // Fourth byte-3
+
+  thread->set_operand_value(dst, data, i_type, thread, pI);
+}
+
+void rcp_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, src2_data, data;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+
+  unsigned i_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+
+  switch (i_type) {
+    case F32_TYPE:
       data.f32 = 1.0f / src1_data.f32;
       break;
-   case F64_TYPE:
-   case FF64_TYPE:
+    case F64_TYPE:
+    case FF64_TYPE:
       data.f64 = 1.0f / src1_data.f64;
       break;
-   default:
+    default:
       printf("Execution error: type mismatch with instruction\n");
-      assert(0); 
+      assert(0);
       break;
-   }
+  }
 
-   thread->set_operand_value(dst,data, i_type, thread, pI);
+  thread->set_operand_value(dst, data, i_type, thread, pI);
 }
 
-void red_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
+void red_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
 
-void rem_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t src1_data, src2_data, data;
+void rem_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, src2_data, data;
 
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   unsigned i_type = pI->get_type();
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-   switch ( i_type ) {
-   case S32_TYPE:
+  switch (i_type) {
+    case S32_TYPE:
       data.s32 = src1_data.s32 % src2_data.s32;
       break;
-   case S64_TYPE:
+    case S64_TYPE:
       data.s64 = src1_data.s64 % src2_data.s64;
       break;
-   case U32_TYPE:
+    case U32_TYPE:
       data.u32 = src1_data.u32 % src2_data.u32;
       break;
-   case U64_TYPE:
+    case U64_TYPE:
       data.u64 = src1_data.u64 % src2_data.u64;
       break;
-   default: assert(0); break;
-   }
-
-   thread->set_operand_value(dst,data, i_type, thread, pI);
-}
-
-void ret_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   bool empty = thread->callstack_pop();
-   if( empty ) {
-   thread->set_done();
-   thread->exitCore();
-   thread->registerExit();
-   }
-}
-
-//Ptxplus version of ret instruction.
-void retp_impl( const ptx_instruction *pI, ptx_thread_info *thread )
-{
-   bool empty = thread->callstack_pop_plus();
-   if( empty ) {
-   thread->set_done();
-   thread->exitCore();
-   thread->registerExit();
-   }
-}
-
-void rsqrt_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t a, d;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-
-   unsigned i_type = pI->get_type();
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-
-
-   switch ( i_type ) {
-   case F32_TYPE:
-      if ( a.f32 < 0 ) {
-         d.u64 = 0;
-         d.u64 = 0x7fc00000; // NaN
-      } else if ( a.f32 == 0 ) {
-         d.u64 = 0;
-         d.u32 = 0x7f800000; // Inf
-      } else
-         d.f32 = cuda_math::__internal_accurate_fdividef(1.0f, sqrtf(a.f32));
+    default:
+      assert(0);
       break;
-   case F64_TYPE: 
-   case FF64_TYPE:
-      if ( a.f32 < 0 ) {
-         d.u64 = 0;
-	      d.u32 = 0x7fc00000; // NaN
-         float x = d.f32; 
-         d.f64 = (double)x;
-      } else if ( a.f32 == 0 ) {
-         d.u64 = 0;
-	      d.u32 = 0x7f800000; // Inf
-         float x = d.f32; 
-         d.f64 = (double)x;
+  }
+
+  thread->set_operand_value(dst, data, i_type, thread, pI);
+}
+
+void ret_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  bool empty = thread->callstack_pop();
+  if (empty) {
+    thread->set_done();
+    thread->exitCore();
+    thread->registerExit();
+  }
+}
+
+// Ptxplus version of ret instruction.
+void retp_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  bool empty = thread->callstack_pop_plus();
+  if (empty) {
+    thread->set_done();
+    thread->exitCore();
+    thread->registerExit();
+  }
+}
+
+void rsqrt_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, d;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+
+  unsigned i_type = pI->get_type();
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+
+  switch (i_type) {
+    case F32_TYPE:
+      if (a.f32 < 0) {
+        d.u64 = 0;
+        d.u64 = 0x7fc00000;  // NaN
+      } else if (a.f32 == 0) {
+        d.u64 = 0;
+        d.u32 = 0x7f800000;  // Inf
       } else
-         d.f64 = 1.0 / sqrt(a.f64); 
+        d.f32 = cuda_math::__internal_accurate_fdividef(1.0f, sqrtf(a.f32));
       break;
-   default:
+    case F64_TYPE:
+    case FF64_TYPE:
+      if (a.f32 < 0) {
+        d.u64 = 0;
+        d.u32 = 0x7fc00000;  // NaN
+        float x = d.f32;
+        d.f64 = (double)x;
+      } else if (a.f32 == 0) {
+        d.u64 = 0;
+        d.u32 = 0x7f800000;  // Inf
+        float x = d.f32;
+        d.f64 = (double)x;
+      } else
+        d.f64 = 1.0 / sqrt(a.f64);
+      break;
+    default:
       printf("Execution error: type mismatch with instruction\n");
       assert(0);
       break;
-   }
+  }
 
-   thread->set_operand_value(dst,d, i_type, thread, pI);
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-#define SAD(d,a,b,c) d = c + ((a<b) ? (b-a) : (a-b))
+#define SAD(d, a, b, c) d = c + ((a < b) ? (b - a) : (a - b))
 
-void sad_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t a, b, c, d;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
-   const operand_info &src3 = pI->src3();
+void sad_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, b, c, d;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
+  const operand_info &src3 = pI->src3();
 
-   unsigned i_type = pI->get_type();
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   b = thread->get_operand_value(src2, dst, i_type, thread, 1);
-   c = thread->get_operand_value(src3, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  c = thread->get_operand_value(src3, dst, i_type, thread, 1);
 
-
-   switch ( i_type ) {
-   case U16_TYPE: SAD(d.u16,a.u16,b.u16,c.u16); break;
-   case U32_TYPE: SAD(d.u32,a.u32,b.u32,c.u32); break;
-   case U64_TYPE: SAD(d.u64,a.u64,b.u64,c.u64); break;
-   case S16_TYPE: SAD(d.s16,a.s16,b.s16,c.s16); break;
-   case S32_TYPE: SAD(d.s32,a.s32,b.s32,c.s32); break;
-   case S64_TYPE: SAD(d.s64,a.s64,b.s64,c.s64); break;
-   case F32_TYPE: SAD(d.f32,a.f32,b.f32,c.f32); break;
-   case F64_TYPE: case FF64_TYPE: SAD(d.f64,a.f64,b.f64,c.f64); break;
-   default:
-      printf("Execution error: type mismatch with instruction\n");
-      assert(0); 
+  switch (i_type) {
+    case U16_TYPE:
+      SAD(d.u16, a.u16, b.u16, c.u16);
       break;
-   }
+    case U32_TYPE:
+      SAD(d.u32, a.u32, b.u32, c.u32);
+      break;
+    case U64_TYPE:
+      SAD(d.u64, a.u64, b.u64, c.u64);
+      break;
+    case S16_TYPE:
+      SAD(d.s16, a.s16, b.s16, c.s16);
+      break;
+    case S32_TYPE:
+      SAD(d.s32, a.s32, b.s32, c.s32);
+      break;
+    case S64_TYPE:
+      SAD(d.s64, a.s64, b.s64, c.s64);
+      break;
+    case F32_TYPE:
+      SAD(d.f32, a.f32, b.f32, c.f32);
+      break;
+    case F64_TYPE:
+    case FF64_TYPE:
+      SAD(d.f64, a.f64, b.f64, c.f64);
+      break;
+    default:
+      printf("Execution error: type mismatch with instruction\n");
+      assert(0);
+      break;
+  }
 
-   thread->set_operand_value(dst,d, i_type, thread, pI);
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-void selp_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
-   const operand_info &src3 = pI->src3();
+void selp_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
+  const operand_info &src3 = pI->src3();
 
-   ptx_reg_t a, b, c, d;
+  ptx_reg_t a, b, c, d;
 
-   unsigned i_type = pI->get_type();
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   b = thread->get_operand_value(src2, dst, i_type, thread, 1);
-   c = thread->get_operand_value(src3, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  c = thread->get_operand_value(src3, dst, i_type, thread, 1);
 
-   //predicate value was changed so the lowest bit being set means the zero flag is set.
-   //As a result, the value of c.pred must be inverted to get proper behavior
-   d = (!(c.pred & 0x0001))?a:b;
+  // predicate value was changed so the lowest bit being set means the zero flag
+  // is set. As a result, the value of c.pred must be inverted to get proper
+  // behavior
+  d = (!(c.pred & 0x0001)) ? a : b;
 
-   thread->set_operand_value(dst,d, PRED_TYPE, thread, pI);
+  thread->set_operand_value(dst, d, PRED_TYPE, thread, pI);
 }
 
-bool isFloat(int type) 
-{
-   switch ( type ) {
-   case F16_TYPE:
-   case F32_TYPE:
-   case F64_TYPE:
-   case FF64_TYPE:
+bool isFloat(int type) {
+  switch (type) {
+    case F16_TYPE:
+    case F32_TYPE:
+    case F64_TYPE:
+    case FF64_TYPE:
       return true;
-   default:
+    default:
       return false;
-   }
+  }
 }
 
-bool CmpOp( int type, ptx_reg_t a, ptx_reg_t b, unsigned cmpop )
-{
-   bool t = false;
+bool CmpOp(int type, ptx_reg_t a, ptx_reg_t b, unsigned cmpop) {
+  bool t = false;
 
-   switch ( type ) {
-   case B16_TYPE: 
+  switch (type) {
+    case B16_TYPE:
       switch (cmpop) {
-      case EQ_OPTION: t = (a.u16 == b.u16); break;
-      case NE_OPTION: t = (a.u16 != b.u16); break;
-      default:
-         assert(0);
+        case EQ_OPTION:
+          t = (a.u16 == b.u16);
+          break;
+        case NE_OPTION:
+          t = (a.u16 != b.u16);
+          break;
+        default:
+          assert(0);
       }
 
-   case B32_TYPE: 
+    case B32_TYPE:
       switch (cmpop) {
-      case EQ_OPTION: t = (a.u32 == b.u32); break;
-      case NE_OPTION: t = (a.u32 != b.u32); break;
-      default:
-         assert(0);
+        case EQ_OPTION:
+          t = (a.u32 == b.u32);
+          break;
+        case NE_OPTION:
+          t = (a.u32 != b.u32);
+          break;
+        default:
+          assert(0);
       }
-   case B64_TYPE:
+    case B64_TYPE:
       switch (cmpop) {
-      case EQ_OPTION: t = (a.u64 == b.u64); break;
-      case NE_OPTION: t = (a.u64 != b.u64); break;
-      default:
-         assert(0);
-      }
-      break;
-   case S8_TYPE: 
-   case S16_TYPE:
-      switch (cmpop) {
-      case EQ_OPTION: t = (a.s16 == b.s16); break;
-      case NE_OPTION: t = (a.s16 != b.s16); break;
-      case LT_OPTION: t = (a.s16 < b.s16); break;
-      case LE_OPTION: t = (a.s16 <= b.s16); break;
-      case GT_OPTION: t = (a.s16 > b.s16); break;
-      case GE_OPTION: t = (a.s16 >= b.s16); break;
-      default:
-         assert(0);
+        case EQ_OPTION:
+          t = (a.u64 == b.u64);
+          break;
+        case NE_OPTION:
+          t = (a.u64 != b.u64);
+          break;
+        default:
+          assert(0);
       }
       break;
-   case S32_TYPE: 
+    case S8_TYPE:
+    case S16_TYPE:
       switch (cmpop) {
-      case EQ_OPTION: t = (a.s32 == b.s32); break;
-      case NE_OPTION: t = (a.s32 != b.s32); break;
-      case LT_OPTION: t = (a.s32 < b.s32); break;
-      case LE_OPTION: t = (a.s32 <= b.s32); break;
-      case GT_OPTION: t = (a.s32 > b.s32); break;
-      case GE_OPTION: t = (a.s32 >= b.s32); break;
-      default:
-         assert(0);
+        case EQ_OPTION:
+          t = (a.s16 == b.s16);
+          break;
+        case NE_OPTION:
+          t = (a.s16 != b.s16);
+          break;
+        case LT_OPTION:
+          t = (a.s16 < b.s16);
+          break;
+        case LE_OPTION:
+          t = (a.s16 <= b.s16);
+          break;
+        case GT_OPTION:
+          t = (a.s16 > b.s16);
+          break;
+        case GE_OPTION:
+          t = (a.s16 >= b.s16);
+          break;
+        default:
+          assert(0);
       }
       break;
-   case S64_TYPE:
+    case S32_TYPE:
       switch (cmpop) {
-      case EQ_OPTION: t = (a.s64 == b.s64); break;
-      case NE_OPTION: t = (a.s64 != b.s64); break;
-      case LT_OPTION: t = (a.s64 < b.s64); break;
-      case LE_OPTION: t = (a.s64 <= b.s64); break;
-      case GT_OPTION: t = (a.s64 > b.s64); break;
-      case GE_OPTION: t = (a.s64 >= b.s64); break;
-      default:
-         assert(0);
+        case EQ_OPTION:
+          t = (a.s32 == b.s32);
+          break;
+        case NE_OPTION:
+          t = (a.s32 != b.s32);
+          break;
+        case LT_OPTION:
+          t = (a.s32 < b.s32);
+          break;
+        case LE_OPTION:
+          t = (a.s32 <= b.s32);
+          break;
+        case GT_OPTION:
+          t = (a.s32 > b.s32);
+          break;
+        case GE_OPTION:
+          t = (a.s32 >= b.s32);
+          break;
+        default:
+          assert(0);
       }
       break;
-   case U8_TYPE: 
-   case U16_TYPE: 
+    case S64_TYPE:
       switch (cmpop) {
-      case EQ_OPTION: t = (a.u16 == b.u16); break;
-      case NE_OPTION: t = (a.u16 != b.u16); break;
-      case LT_OPTION: t = (a.u16 < b.u16); break;
-      case LE_OPTION: t = (a.u16 <= b.u16); break;
-      case GT_OPTION: t = (a.u16 > b.u16); break;
-      case GE_OPTION: t = (a.u16 >= b.u16); break;
-      case LO_OPTION: t = (a.u16 < b.u16); break;
-      case LS_OPTION: t = (a.u16 <= b.u16); break;
-      case HI_OPTION: t = (a.u16 > b.u16); break;
-      case HS_OPTION: t = (a.u16 >= b.u16); break;
-      default:
-         assert(0);
+        case EQ_OPTION:
+          t = (a.s64 == b.s64);
+          break;
+        case NE_OPTION:
+          t = (a.s64 != b.s64);
+          break;
+        case LT_OPTION:
+          t = (a.s64 < b.s64);
+          break;
+        case LE_OPTION:
+          t = (a.s64 <= b.s64);
+          break;
+        case GT_OPTION:
+          t = (a.s64 > b.s64);
+          break;
+        case GE_OPTION:
+          t = (a.s64 >= b.s64);
+          break;
+        default:
+          assert(0);
       }
       break;
-   case U32_TYPE: 
+    case U8_TYPE:
+    case U16_TYPE:
       switch (cmpop) {
-      case EQ_OPTION: t = (a.u32 == b.u32); break;
-      case NE_OPTION: t = (a.u32 != b.u32); break;
-      case LT_OPTION: t = (a.u32 < b.u32); break;
-      case LE_OPTION: t = (a.u32 <= b.u32); break;
-      case GT_OPTION: t = (a.u32 > b.u32); break;
-      case GE_OPTION: t = (a.u32 >= b.u32); break;
-      case LO_OPTION: t = (a.u32 < b.u32); break;
-      case LS_OPTION: t = (a.u32 <= b.u32); break;
-      case HI_OPTION: t = (a.u32 > b.u32); break;
-      case HS_OPTION: t = (a.u32 >= b.u32); break;
-      default:
-         assert(0);
+        case EQ_OPTION:
+          t = (a.u16 == b.u16);
+          break;
+        case NE_OPTION:
+          t = (a.u16 != b.u16);
+          break;
+        case LT_OPTION:
+          t = (a.u16 < b.u16);
+          break;
+        case LE_OPTION:
+          t = (a.u16 <= b.u16);
+          break;
+        case GT_OPTION:
+          t = (a.u16 > b.u16);
+          break;
+        case GE_OPTION:
+          t = (a.u16 >= b.u16);
+          break;
+        case LO_OPTION:
+          t = (a.u16 < b.u16);
+          break;
+        case LS_OPTION:
+          t = (a.u16 <= b.u16);
+          break;
+        case HI_OPTION:
+          t = (a.u16 > b.u16);
+          break;
+        case HS_OPTION:
+          t = (a.u16 >= b.u16);
+          break;
+        default:
+          assert(0);
       }
       break;
-   case U64_TYPE:
+    case U32_TYPE:
       switch (cmpop) {
-      case EQ_OPTION: t = (a.u64 == b.u64); break;
-      case NE_OPTION: t = (a.u64 != b.u64); break;
-      case LT_OPTION: t = (a.u64 < b.u64); break;
-      case LE_OPTION: t = (a.u64 <= b.u64); break;
-      case GT_OPTION: t = (a.u64 > b.u64); break;
-      case GE_OPTION: t = (a.u64 >= b.u64); break;
-      case LO_OPTION: t = (a.u64 < b.u64); break;
-      case LS_OPTION: t = (a.u64 <= b.u64); break;
-      case HI_OPTION: t = (a.u64 > b.u64); break;
-      case HS_OPTION: t = (a.u64 >= b.u64); break;
-      default:
-         assert(0);
+        case EQ_OPTION:
+          t = (a.u32 == b.u32);
+          break;
+        case NE_OPTION:
+          t = (a.u32 != b.u32);
+          break;
+        case LT_OPTION:
+          t = (a.u32 < b.u32);
+          break;
+        case LE_OPTION:
+          t = (a.u32 <= b.u32);
+          break;
+        case GT_OPTION:
+          t = (a.u32 > b.u32);
+          break;
+        case GE_OPTION:
+          t = (a.u32 >= b.u32);
+          break;
+        case LO_OPTION:
+          t = (a.u32 < b.u32);
+          break;
+        case LS_OPTION:
+          t = (a.u32 <= b.u32);
+          break;
+        case HI_OPTION:
+          t = (a.u32 > b.u32);
+          break;
+        case HS_OPTION:
+          t = (a.u32 >= b.u32);
+          break;
+        default:
+          assert(0);
       }
       break;
-   case F16_TYPE: assert(0); break;
-   case F32_TYPE: 
+    case U64_TYPE:
       switch (cmpop) {
-      case EQ_OPTION: t = (a.f32 == b.f32) && !isNaN(a.f32) && !isNaN(b.f32); break;
-      case NE_OPTION: t = (a.f32 != b.f32) && !isNaN(a.f32) && !isNaN(b.f32); break;
-      case LT_OPTION: t = (a.f32 < b.f32 ) && !isNaN(a.f32) && !isNaN(b.f32); break;
-      case LE_OPTION: t = (a.f32 <= b.f32) && !isNaN(a.f32) && !isNaN(b.f32); break;
-      case GT_OPTION: t = (a.f32 > b.f32 ) && !isNaN(a.f32) && !isNaN(b.f32); break;
-      case GE_OPTION: t = (a.f32 >= b.f32) && !isNaN(a.f32) && !isNaN(b.f32); break;
-      case EQU_OPTION: t = (a.f32 == b.f32) || isNaN(a.f32) || isNaN(b.f32); break;
-      case NEU_OPTION: t = (a.f32 != b.f32) || isNaN(a.f32) || isNaN(b.f32); break;
-      case LTU_OPTION: t = (a.f32 < b.f32 ) || isNaN(a.f32) || isNaN(b.f32); break;
-      case LEU_OPTION: t = (a.f32 <= b.f32) || isNaN(a.f32) || isNaN(b.f32); break;
-      case GTU_OPTION: t = (a.f32 > b.f32 ) || isNaN(a.f32) || isNaN(b.f32); break;
-      case GEU_OPTION: t = (a.f32 >= b.f32) || isNaN(a.f32) || isNaN(b.f32); break;
-      case NUM_OPTION: t = !isNaN(a.f32) && !isNaN(b.f32); break;
-      case NAN_OPTION: t = isNaN(a.f32) || isNaN(b.f32); break;
-      default:
-         assert(0);
+        case EQ_OPTION:
+          t = (a.u64 == b.u64);
+          break;
+        case NE_OPTION:
+          t = (a.u64 != b.u64);
+          break;
+        case LT_OPTION:
+          t = (a.u64 < b.u64);
+          break;
+        case LE_OPTION:
+          t = (a.u64 <= b.u64);
+          break;
+        case GT_OPTION:
+          t = (a.u64 > b.u64);
+          break;
+        case GE_OPTION:
+          t = (a.u64 >= b.u64);
+          break;
+        case LO_OPTION:
+          t = (a.u64 < b.u64);
+          break;
+        case LS_OPTION:
+          t = (a.u64 <= b.u64);
+          break;
+        case HI_OPTION:
+          t = (a.u64 > b.u64);
+          break;
+        case HS_OPTION:
+          t = (a.u64 >= b.u64);
+          break;
+        default:
+          assert(0);
       }
       break;
-   case F64_TYPE: 
-   case FF64_TYPE:
+    case F16_TYPE:
+      assert(0);
+      break;
+    case F32_TYPE:
       switch (cmpop) {
-      case EQ_OPTION: t = (a.f64 == b.f64) && !isNaN(a.f64) && !isNaN(b.f64); break;
-      case NE_OPTION: t = (a.f64 != b.f64) && !isNaN(a.f64) && !isNaN(b.f64); break;
-      case LT_OPTION: t = (a.f64 < b.f64 ) && !isNaN(a.f64) && !isNaN(b.f64); break;
-      case LE_OPTION: t = (a.f64 <= b.f64) && !isNaN(a.f64) && !isNaN(b.f64); break;
-      case GT_OPTION: t = (a.f64 > b.f64 ) && !isNaN(a.f64) && !isNaN(b.f64); break;
-      case GE_OPTION: t = (a.f64 >= b.f64) && !isNaN(a.f64) && !isNaN(b.f64); break;
-      case EQU_OPTION: t = (a.f64 == b.f64) || isNaN(a.f64) || isNaN(b.f64); break;
-      case NEU_OPTION: t = (a.f64 != b.f64) || isNaN(a.f64) || isNaN(b.f64); break;
-      case LTU_OPTION: t = (a.f64 < b.f64 ) || isNaN(a.f64) || isNaN(b.f64); break;
-      case LEU_OPTION: t = (a.f64 <= b.f64) || isNaN(a.f64) || isNaN(b.f64); break;
-      case GTU_OPTION: t = (a.f64 > b.f64 ) || isNaN(a.f64) || isNaN(b.f64); break;
-      case GEU_OPTION: t = (a.f64 >= b.f64) || isNaN(a.f64) || isNaN(b.f64); break;
-      case NUM_OPTION: t = !isNaN(a.f64) && !isNaN(b.f64); break;
-      case NAN_OPTION: t = isNaN(a.f64) || isNaN(b.f64); break;
-      default:
-         assert(0);
+        case EQ_OPTION:
+          t = (a.f32 == b.f32) && !isNaN(a.f32) && !isNaN(b.f32);
+          break;
+        case NE_OPTION:
+          t = (a.f32 != b.f32) && !isNaN(a.f32) && !isNaN(b.f32);
+          break;
+        case LT_OPTION:
+          t = (a.f32 < b.f32) && !isNaN(a.f32) && !isNaN(b.f32);
+          break;
+        case LE_OPTION:
+          t = (a.f32 <= b.f32) && !isNaN(a.f32) && !isNaN(b.f32);
+          break;
+        case GT_OPTION:
+          t = (a.f32 > b.f32) && !isNaN(a.f32) && !isNaN(b.f32);
+          break;
+        case GE_OPTION:
+          t = (a.f32 >= b.f32) && !isNaN(a.f32) && !isNaN(b.f32);
+          break;
+        case EQU_OPTION:
+          t = (a.f32 == b.f32) || isNaN(a.f32) || isNaN(b.f32);
+          break;
+        case NEU_OPTION:
+          t = (a.f32 != b.f32) || isNaN(a.f32) || isNaN(b.f32);
+          break;
+        case LTU_OPTION:
+          t = (a.f32 < b.f32) || isNaN(a.f32) || isNaN(b.f32);
+          break;
+        case LEU_OPTION:
+          t = (a.f32 <= b.f32) || isNaN(a.f32) || isNaN(b.f32);
+          break;
+        case GTU_OPTION:
+          t = (a.f32 > b.f32) || isNaN(a.f32) || isNaN(b.f32);
+          break;
+        case GEU_OPTION:
+          t = (a.f32 >= b.f32) || isNaN(a.f32) || isNaN(b.f32);
+          break;
+        case NUM_OPTION:
+          t = !isNaN(a.f32) && !isNaN(b.f32);
+          break;
+        case NAN_OPTION:
+          t = isNaN(a.f32) || isNaN(b.f32);
+          break;
+        default:
+          assert(0);
       }
       break;
-   default: assert(0); break;
-   }
+    case F64_TYPE:
+    case FF64_TYPE:
+      switch (cmpop) {
+        case EQ_OPTION:
+          t = (a.f64 == b.f64) && !isNaN(a.f64) && !isNaN(b.f64);
+          break;
+        case NE_OPTION:
+          t = (a.f64 != b.f64) && !isNaN(a.f64) && !isNaN(b.f64);
+          break;
+        case LT_OPTION:
+          t = (a.f64 < b.f64) && !isNaN(a.f64) && !isNaN(b.f64);
+          break;
+        case LE_OPTION:
+          t = (a.f64 <= b.f64) && !isNaN(a.f64) && !isNaN(b.f64);
+          break;
+        case GT_OPTION:
+          t = (a.f64 > b.f64) && !isNaN(a.f64) && !isNaN(b.f64);
+          break;
+        case GE_OPTION:
+          t = (a.f64 >= b.f64) && !isNaN(a.f64) && !isNaN(b.f64);
+          break;
+        case EQU_OPTION:
+          t = (a.f64 == b.f64) || isNaN(a.f64) || isNaN(b.f64);
+          break;
+        case NEU_OPTION:
+          t = (a.f64 != b.f64) || isNaN(a.f64) || isNaN(b.f64);
+          break;
+        case LTU_OPTION:
+          t = (a.f64 < b.f64) || isNaN(a.f64) || isNaN(b.f64);
+          break;
+        case LEU_OPTION:
+          t = (a.f64 <= b.f64) || isNaN(a.f64) || isNaN(b.f64);
+          break;
+        case GTU_OPTION:
+          t = (a.f64 > b.f64) || isNaN(a.f64) || isNaN(b.f64);
+          break;
+        case GEU_OPTION:
+          t = (a.f64 >= b.f64) || isNaN(a.f64) || isNaN(b.f64);
+          break;
+        case NUM_OPTION:
+          t = !isNaN(a.f64) && !isNaN(b.f64);
+          break;
+        case NAN_OPTION:
+          t = isNaN(a.f64) || isNaN(b.f64);
+          break;
+        default:
+          assert(0);
+      }
+      break;
+    default:
+      assert(0);
+      break;
+  }
 
-   return t;
+  return t;
 }
 
-void setp_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   ptx_reg_t a, b;
+void setp_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, b;
 
-   int t=0;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+  int t = 0;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   assert( pI->get_num_operands() < 4 ); // or need to deal with "c" operand / boolOp
+  assert(pI->get_num_operands() <
+         4);  // or need to deal with "c" operand / boolOp
 
-   unsigned type = pI->get_type();
-   unsigned cmpop = pI->get_cmpop();
-   a = thread->get_operand_value(src1, dst, type, thread, 1);
-   b = thread->get_operand_value(src2, dst, type, thread, 1);
+  unsigned type = pI->get_type();
+  unsigned cmpop = pI->get_cmpop();
+  a = thread->get_operand_value(src1, dst, type, thread, 1);
+  b = thread->get_operand_value(src2, dst, type, thread, 1);
 
-   t = CmpOp(type,a,b,cmpop);
+  t = CmpOp(type, a, b, cmpop);
 
-   ptx_reg_t data;
+  ptx_reg_t data;
 
-   //the way ptxplus handles the zero flag, 1 = false and 0 = true
-   data.pred = (t==0); //inverting predicate since ptxplus uses "1" for a set zero flag
+  // the way ptxplus handles the zero flag, 1 = false and 0 = true
+  data.pred =
+      (t ==
+       0);  // inverting predicate since ptxplus uses "1" for a set zero flag
 
-   thread->set_operand_value(dst,data, PRED_TYPE, thread, pI);
+  thread->set_operand_value(dst, data, PRED_TYPE, thread, pI);
 }
 
-void set_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t a, b;
+void set_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, b;
 
-   int t=0;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+  int t = 0;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   assert( pI->get_num_operands() < 4 ); // or need to deal with "c" operand / boolOp
+  assert(pI->get_num_operands() <
+         4);  // or need to deal with "c" operand / boolOp
 
-   unsigned src_type = pI->get_type2();
-   unsigned cmpop = pI->get_cmpop();
+  unsigned src_type = pI->get_type2();
+  unsigned cmpop = pI->get_cmpop();
 
-   a = thread->get_operand_value(src1, dst, src_type, thread, 1);
-   b = thread->get_operand_value(src2, dst, src_type, thread, 1);
+  a = thread->get_operand_value(src1, dst, src_type, thread, 1);
+  b = thread->get_operand_value(src2, dst, src_type, thread, 1);
 
-   // Take abs of first operand if needed
-   if(pI->is_abs()) {
-      switch ( src_type ) {
-      case S16_TYPE: a.s16 = my_abs(a.s16); break;
-      case S32_TYPE: a.s32 = my_abs(a.s32); break;
-      case S64_TYPE: a.s64 = my_abs(a.s64); break;
-      case U16_TYPE: a.u16 = a.u16; break;
-      case U32_TYPE: a.u32 = my_abs(a.u32); break;
-      case U64_TYPE: a.u64 = my_abs(a.u64); break;
-      case F32_TYPE: a.f32 = my_abs(a.f32); break;
-      case F64_TYPE: case FF64_TYPE: a.f64 = my_abs(a.f64); break;
+  // Take abs of first operand if needed
+  if (pI->is_abs()) {
+    switch (src_type) {
+      case S16_TYPE:
+        a.s16 = my_abs(a.s16);
+        break;
+      case S32_TYPE:
+        a.s32 = my_abs(a.s32);
+        break;
+      case S64_TYPE:
+        a.s64 = my_abs(a.s64);
+        break;
+      case U16_TYPE:
+        a.u16 = a.u16;
+        break;
+      case U32_TYPE:
+        a.u32 = my_abs(a.u32);
+        break;
+      case U64_TYPE:
+        a.u64 = my_abs(a.u64);
+        break;
+      case F32_TYPE:
+        a.f32 = my_abs(a.f32);
+        break;
+      case F64_TYPE:
+      case FF64_TYPE:
+        a.f64 = my_abs(a.f64);
+        break;
       default:
-         printf("Execution error: type mismatch with instruction\n");
-         assert(0);
-         break;
-      }
-   }
+        printf("Execution error: type mismatch with instruction\n");
+        assert(0);
+        break;
+    }
+  }
 
-   t = CmpOp(src_type,a,b,cmpop);
+  t = CmpOp(src_type, a, b, cmpop);
 
-   ptx_reg_t data;
-   if ( isFloat(pI->get_type()) ) {
-      data.f32 = (t!=0)?1.0f:0.0f;
-   } else {
-      data.u32 = (t!=0)?0xFFFFFFFF:0;
-   }
+  ptx_reg_t data;
+  if (isFloat(pI->get_type())) {
+    data.f32 = (t != 0) ? 1.0f : 0.0f;
+  } else {
+    data.u32 = (t != 0) ? 0xFFFFFFFF : 0;
+  }
 
-   thread->set_operand_value(dst, data, pI->get_type(), thread, pI);
-
+  thread->set_operand_value(dst, data, pI->get_type(), thread, pI);
 }
 
-void shfl_impl( const ptx_instruction *pI, core_t *core, warp_inst_t inst )
-{
-	unsigned i_type = pI->get_type();
-  	int tid;
+void shfl_impl(const ptx_instruction *pI, core_t *core, warp_inst_t inst) {
+  unsigned i_type = pI->get_type();
+  int tid;
 
-  	if(core->get_gpu()->is_functional_sim())
-    		tid = inst.warp_id_func() * core->get_warp_size();
-  	else
-	 	tid = inst.warp_id() * core->get_warp_size();
-	
-	ptx_thread_info *thread = core->get_thread_info()[tid];
-	ptx_warp_info *warp_info = thread->m_warp_info;
-	int lane = warp_info->get_done_threads();
-	thread = core->get_thread_info()[tid + lane];
+  if (core->get_gpu()->is_functional_sim())
+    tid = inst.warp_id_func() * core->get_warp_size();
+  else
+    tid = inst.warp_id() * core->get_warp_size();
 
-	const operand_info &dst = pI->dst();
-	const operand_info &src1 = pI->src1();
-	const operand_info &src2 = pI->src2();
-	const operand_info &src3 = pI->src3();
-	int bval = (thread->get_operand_value(src2, dst, i_type, thread, 1)).u32;
-	int cval = (thread->get_operand_value(src3, dst, i_type, thread, 1)).u32;
-	int mask = cval >> 8;
-	bval &= 0x1F;
-	cval &= 0x1F;
+  ptx_thread_info *thread = core->get_thread_info()[tid];
+  ptx_warp_info *warp_info = thread->m_warp_info;
+  int lane = warp_info->get_done_threads();
+  thread = core->get_thread_info()[tid + lane];
 
-	int maxLane = (lane & mask) | (cval & ~mask);
-	int minLane = lane & mask;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
+  const operand_info &src3 = pI->src3();
+  int bval = (thread->get_operand_value(src2, dst, i_type, thread, 1)).u32;
+  int cval = (thread->get_operand_value(src3, dst, i_type, thread, 1)).u32;
+  int mask = cval >> 8;
+  bval &= 0x1F;
+  cval &= 0x1F;
 
-	int src_idx;
-	unsigned p;
-	switch(pI->shfl_op()) {
-	case UP_OPTION:
-		src_idx = lane - bval;
-		p = (src_idx >= maxLane);
-		break;
-	case DOWN_OPTION:
-		src_idx = lane + bval;
-		p = (src_idx <= maxLane);
-		break;
-	case BFLY_OPTION:
-		src_idx = lane ^ bval;
-		p = (src_idx <= maxLane);
-		break;
-	case IDX_OPTION:
-		src_idx = minLane | (bval & ~mask);
-		p = (src_idx <= maxLane);
-		break;
-	default:
-		printf("GPGPU-Sim PTX: ERROR: Invalid shfl option\n");
-		assert(0);
-		break;
-	}
-	// copy from own lane
-	if (!p) src_idx = lane;
+  int maxLane = (lane & mask) | (cval & ~mask);
+  int minLane = lane & mask;
 
-	// copy input from lane src_idx
-	ptx_reg_t data;
-	if (inst.active(src_idx)) {
-		ptx_thread_info *source = core->get_thread_info()[tid + src_idx];
-		data = source->get_operand_value(src1, dst, i_type, source, 1);
-	} else {
-		printf("GPGPU-Sim PTX: WARNING: shfl input value unpredictable for inactive threads in a warp\n");
-		data.u32 = 0;
-	}
-	thread->set_operand_value(dst, data, i_type, thread, pI);
+  int src_idx;
+  unsigned p;
+  switch (pI->shfl_op()) {
+    case UP_OPTION:
+      src_idx = lane - bval;
+      p = (src_idx >= maxLane);
+      break;
+    case DOWN_OPTION:
+      src_idx = lane + bval;
+      p = (src_idx <= maxLane);
+      break;
+    case BFLY_OPTION:
+      src_idx = lane ^ bval;
+      p = (src_idx <= maxLane);
+      break;
+    case IDX_OPTION:
+      src_idx = minLane | (bval & ~mask);
+      p = (src_idx <= maxLane);
+      break;
+    default:
+      printf("GPGPU-Sim PTX: ERROR: Invalid shfl option\n");
+      assert(0);
+      break;
+  }
+  // copy from own lane
+  if (!p) src_idx = lane;
 
-	/*
-	TODO: deal with predicates appropriately using the following pseudocode:
-	if (!isGuardPredicateTrue(src_idx)) {
-		printf("GPGPU-Sim PTX: WARNING: shfl input value unpredictable for predicated-off threads in a warp\n");
-	}
-	if (dest predicate selected) data.pred = p;
-	*/
+  // copy input from lane src_idx
+  ptx_reg_t data;
+  if (inst.active(src_idx)) {
+    ptx_thread_info *source = core->get_thread_info()[tid + src_idx];
+    data = source->get_operand_value(src1, dst, i_type, source, 1);
+  } else {
+    printf(
+        "GPGPU-Sim PTX: WARNING: shfl input value unpredictable for inactive "
+        "threads in a warp\n");
+    data.u32 = 0;
+  }
+  thread->set_operand_value(dst, data, i_type, thread, pI);
 
-	// keep track of the number of threads that have executed in the warp
-	warp_info->inc_done_threads();
-	if (warp_info->get_done_threads() == inst.active_count()) {
-		warp_info->reset_done_threads();
-	}
+  /*
+  TODO: deal with predicates appropriately using the following pseudocode:
+  if (!isGuardPredicateTrue(src_idx)) {
+          printf("GPGPU-Sim PTX: WARNING: shfl input value unpredictable for
+  predicated-off threads in a warp\n");
+  }
+  if (dest predicate selected) data.pred = p;
+  */
+
+  // keep track of the number of threads that have executed in the warp
+  warp_info->inc_done_threads();
+  if (warp_info->get_done_threads() == inst.active_count()) {
+    warp_info->reset_done_threads();
+  }
 }
 
-void shl_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   ptx_reg_t a, b, d;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+void shl_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, b, d;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   unsigned i_type = pI->get_type();
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  b = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-   switch ( i_type ) {
-   case B16_TYPE:
-   case U16_TYPE:
-      if ( b.u16 >= 16 )
-         d.u16 = 0;
+  switch (i_type) {
+    case B16_TYPE:
+    case U16_TYPE:
+      if (b.u16 >= 16)
+        d.u16 = 0;
       else
-         d.u16 = (unsigned short) ((a.u16 << b.u16) & 0xFFFF); 
+        d.u16 = (unsigned short)((a.u16 << b.u16) & 0xFFFF);
       break;
-   case B32_TYPE: 
-   case U32_TYPE: 
-      if ( b.u32 >= 32 )
-         d.u32 = 0;
+    case B32_TYPE:
+    case U32_TYPE:
+      if (b.u32 >= 32)
+        d.u32 = 0;
       else
-         d.u32 = (unsigned) ((a.u32 << b.u32) & 0xFFFFFFFF); 
+        d.u32 = (unsigned)((a.u32 << b.u32) & 0xFFFFFFFF);
       break;
-   case B64_TYPE: 
-   case U64_TYPE: 
-      if ( b.u32 >= 64 )
-         d.u64 = 0;
+    case B64_TYPE:
+    case U64_TYPE:
+      if (b.u32 >= 64)
+        d.u64 = 0;
       else
-         d.u64 = (a.u64 << b.u64); 
+        d.u64 = (a.u64 << b.u64);
       break;
-   default:
+    default:
       printf("Execution error: type mismatch with instruction\n");
-      assert(0); 
+      assert(0);
       break;
-   }
+  }
 
-   thread->set_operand_value(dst, d, i_type, thread, pI);
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-void shr_impl( const ptx_instruction *pI, ptx_thread_info *thread )
-{
-   ptx_reg_t a, b, d;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+void shr_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, b, d;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   unsigned i_type = pI->get_type();
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  b = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-
-   switch ( i_type ) {
-   case U16_TYPE:
-   case B16_TYPE: 
-      if ( b.u16 < 16 )
-         d.u16 = (unsigned short) ((a.u16 >> b.u16) & 0xFFFF);
+  switch (i_type) {
+    case U16_TYPE:
+    case B16_TYPE:
+      if (b.u16 < 16)
+        d.u16 = (unsigned short)((a.u16 >> b.u16) & 0xFFFF);
       else
-         d.u16 = 0;
+        d.u16 = 0;
       break;
-   case U32_TYPE:
-   case B32_TYPE: 
-      if ( b.u32 < 32 )
-         d.u32 = (unsigned) ((a.u32 >> b.u32) & 0xFFFFFFFF);
+    case U32_TYPE:
+    case B32_TYPE:
+      if (b.u32 < 32)
+        d.u32 = (unsigned)((a.u32 >> b.u32) & 0xFFFFFFFF);
       else
-         d.u32 = 0;
+        d.u32 = 0;
       break;
-   case U64_TYPE:
-   case B64_TYPE: 
-      if ( b.u32 < 64 )
-         d.u64 = (a.u64 >> b.u64);
+    case U64_TYPE:
+    case B64_TYPE:
+      if (b.u32 < 64)
+        d.u64 = (a.u64 >> b.u64);
       else
-         d.u64 = 0;
+        d.u64 = 0;
       break;
-   case S16_TYPE: 
-      if ( b.u16 < 16 )
-         d.s64 = (a.s16 >> b.s16);
+    case S16_TYPE:
+      if (b.u16 < 16)
+        d.s64 = (a.s16 >> b.s16);
       else {
-         if ( a.s16 < 0 ) {
+        if (a.s16 < 0) {
+          d.s64 = -1;
+        } else {
+          d.s64 = 0;
+        }
+      }
+      break;
+    case S32_TYPE:
+      if (b.u32 < 32)
+        d.s64 = (a.s32 >> b.s32);
+      else {
+        if (a.s32 < 0) {
+          d.s64 = -1;
+        } else {
+          d.s64 = 0;
+        }
+      }
+      break;
+    case S64_TYPE:
+      if (b.u64 < 64)
+        d.s64 = (a.s64 >> b.u64);
+      else {
+        if (a.s64 < 0) {
+          if (b.s32 < 0) {
+            d.u64 = -1;
+            d.s32 = 0;
+          } else {
             d.s64 = -1;
-         } else {
-            d.s64 = 0;
-         }
+          }
+        } else {
+          d.s64 = 0;
+        }
       }
       break;
-   case S32_TYPE: 
-      if ( b.u32 < 32 )
-         d.s64 = (a.s32 >> b.s32);
-      else {
-         if ( a.s32 < 0 ) {
-            d.s64 = -1;
-         } else {
-            d.s64 = 0;
-         }
-      }
-      break;
-   case S64_TYPE: 
-      if ( b.u64 < 64 )
-         d.s64 = (a.s64 >> b.u64);
-      else {
-         if ( a.s64 < 0 ) {
-            if ( b.s32 < 0 ) {
-               d.u64 = -1;
-               d.s32 = 0;
-            } else {
-               d.s64 = -1;
-            }
-         } else {
-            d.s64 = 0;
-         }
-      }
-      break;
-   default:
+    default:
       printf("Execution error: type mismatch with instruction\n");
-      assert(0); 
+      assert(0);
       break;
-   }
+  }
 
-   thread->set_operand_value(dst,d, i_type, thread, pI);
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-void sin_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   ptx_reg_t a, d;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
+void sin_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, d;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
 
-   unsigned i_type = pI->get_type();
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
 
-
-   switch ( i_type ) {
-   case F32_TYPE: 
+  switch (i_type) {
+    case F32_TYPE:
       d.f32 = sin(a.f32);
       break;
-   default:
-      printf("Execution error: type mismatch with instruction\n");
-      assert(0); 
-      break;
-   }
-
-   thread->set_operand_value(dst,d, i_type, thread, pI);
-}
-
-void slct_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
-   const operand_info &src3 = pI->src3();
-
-   ptx_reg_t a, b, c, d;
-
-   unsigned i_type = pI->get_type();
-   unsigned c_type = pI->get_type2();
-   bool t = false;
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   b = thread->get_operand_value(src2, dst, i_type, thread, 1);
-   c = thread->get_operand_value(src3, dst, c_type, thread, 1);
-
-   switch ( c_type ) {
-   case S32_TYPE: t = c.s32 >= 0; break;
-   case F32_TYPE: t = c.f32 >= 0; break;
-   default: assert(0);
-   }
-
-   switch ( i_type ) {
-   case B16_TYPE:
-   case S16_TYPE:
-   case U16_TYPE: d.u16 = t?a.u16:b.u16; break;
-   case F32_TYPE:
-   case B32_TYPE:
-   case S32_TYPE:
-   case U32_TYPE: d.u32 = t?a.u32:b.u32; break;
-   case F64_TYPE:
-   case FF64_TYPE:
-   case B64_TYPE:
-   case S64_TYPE:
-   case U64_TYPE: d.u64 = t?a.u64:b.u64; break;
-   default: assert(0);
-   }
-
-   thread->set_operand_value(dst,d, i_type, thread, pI);
-}
-
-void sqrt_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t a, d;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-
-   unsigned i_type = pI->get_type();
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-
-
-   switch ( i_type ) {
-   case F32_TYPE: 
-      if ( a.f32 < 0 )
-         d.f32 = nanf("");
-      else
-         d.f32 = sqrt(a.f32); break;
-   case F64_TYPE: 
-   case FF64_TYPE:
-      if ( a.f64 < 0 )
-         d.f64 = nan("");
-      else
-         d.f64 = sqrt(a.f64); break;
-   default:
+    default:
       printf("Execution error: type mismatch with instruction\n");
       assert(0);
       break;
-   }
+  }
 
-   thread->set_operand_value(dst,d, i_type, thread, pI);
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-void sst_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-	ptx_instruction * cpI = const_cast<ptx_instruction *>(pI); // constant
-	const operand_info &dst = cpI->dst();
-	const operand_info &src1 = pI->src1();
-	const operand_info &src2 = pI->src2();
-	const operand_info &src3 = pI->src3();
-	unsigned type = pI->get_type();
-	ptx_reg_t dst_data = thread->get_operand_value(dst, dst, type, thread, 1);
-	ptx_reg_t src1_data = thread->get_operand_value(src1, src1, type, thread, 1);
-	ptx_reg_t src2_data = thread->get_operand_value(src2, src1, type, thread, 1);
-	ptx_reg_t src3_data = thread->get_operand_value(src3, src1, type, thread, 1);
-	memory_space_t space = pI->get_space();
-	memory_space *mem = NULL;
-	addr_t addr = src2_data.u32 * 4; // this assumes sstarr memory starts at address 0
-	ptx_cta_info *cta_info = thread->m_cta_info;
+void slct_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
+  const operand_info &src3 = pI->src3();
 
-	decode_space(space,thread,src1,mem,addr);
+  ptx_reg_t a, b, c, d;
 
-	size_t size;
-	int t;
-	type_info_key::type_decode(type,size,t);
+  unsigned i_type = pI->get_type();
+  unsigned c_type = pI->get_type2();
+  bool t = false;
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  c = thread->get_operand_value(src3, dst, c_type, thread, 1);
 
-	// store data in sstarr memory
-	mem->write(addr,size/8,&src3_data.s64,thread,pI);
+  switch (c_type) {
+    case S32_TYPE:
+      t = c.s32 >= 0;
+      break;
+    case F32_TYPE:
+      t = c.f32 >= 0;
+      break;
+    default:
+      assert(0);
+  }
 
-	// sync threads
-	cpI->set_bar_id(16); // use 16 for sst because bar uses an int from 0-15
+  switch (i_type) {
+    case B16_TYPE:
+    case S16_TYPE:
+    case U16_TYPE:
+      d.u16 = t ? a.u16 : b.u16;
+      break;
+    case F32_TYPE:
+    case B32_TYPE:
+    case S32_TYPE:
+    case U32_TYPE:
+      d.u32 = t ? a.u32 : b.u32;
+      break;
+    case F64_TYPE:
+    case FF64_TYPE:
+    case B64_TYPE:
+    case S64_TYPE:
+    case U64_TYPE:
+      d.u64 = t ? a.u64 : b.u64;
+      break;
+    default:
+      assert(0);
+  }
 
-	thread->m_last_effective_address = addr;
-	thread->m_last_memory_space = space;
-	thread->m_last_dram_callback.function = bar_callback;
-	thread->m_last_dram_callback.instruction = cpI;
-
-	// the last thread that executes loads all of the data back from sstarr memory
-	int NUM_THREADS = cta_info->num_threads();
-	cta_info->inc_bar_threads();
-	if (NUM_THREADS == cta_info->get_bar_threads()) {
-		unsigned offset = 0;
-		addr = 0;
-		ptx_reg_t data;
-		float sstarr_fdata[NUM_THREADS];
-		signed long long sstarr_ldata[NUM_THREADS];
-		// loop through all of the threads
-		for (int tid = 0; tid < NUM_THREADS; tid++) {
-			data.u64=0;
-			mem->read(addr+(tid*4),size/8,&data.s64);
-			sstarr_fdata[tid] = data.f32;
-			sstarr_ldata[tid] = data.s64;
-		}
-
-		// squeeze the zeros out of the array and store data back into original array
-		mem = NULL;
-		addr = src1_data.u32;
-		space.set_type(global_space);
-		decode_space(space,thread,src1,mem,addr);
-		// store nonzero entries and indices
-		for (int tid = 0; tid < NUM_THREADS; tid++) {
-			if (sstarr_fdata[tid] != 0) {
-				float ftid = (float)tid;
-				mem->write(addr+(offset*4),size/8,&sstarr_ldata[tid],thread,pI);
-				mem->write(addr+((NUM_THREADS+offset)*4),size/8,&ftid,thread,pI);
-				offset++;
-			}
-		}
-		// store the number of nonzero elements in the array
-		data = thread->get_operand_value(src1, dst, type, thread, 1);
-		data.s64 += 4*(offset-1);
-		thread->set_operand_value(dst, data, type, thread, pI);
-
-		// fill the rest of the array with zeros (dst should always have a 0 in it)
-		while (offset < NUM_THREADS) {
-			mem->write(addr+(offset*4),size/8,&dst_data.s64,thread,pI);
-			offset++;
-		}
-
-		cta_info->reset_bar_threads();
-		thread->m_last_effective_address = addr+(NUM_THREADS-1)*4;
-		thread->m_last_memory_space = space;
-	}
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-void ssy_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   //printf("Execution Warning: unimplemented ssy instruction is treated as a nop\n");
-   // TODO: add implementation
+void sqrt_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, d;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+
+  unsigned i_type = pI->get_type();
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+
+  switch (i_type) {
+    case F32_TYPE:
+      if (a.f32 < 0)
+        d.f32 = nanf("");
+      else
+        d.f32 = sqrt(a.f32);
+      break;
+    case F64_TYPE:
+    case FF64_TYPE:
+      if (a.f64 < 0)
+        d.f64 = nan("");
+      else
+        d.f64 = sqrt(a.f64);
+      break;
+    default:
+      printf("Execution error: type mismatch with instruction\n");
+      assert(0);
+      break;
+  }
+
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-void st_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   const operand_info &dst = pI->dst();
-   const operand_info &src1 = pI->src1(); //may be scalar or vector of regs
-   unsigned type = pI->get_type();
-   ptx_reg_t addr_reg = thread->get_operand_value(dst, dst, type, thread, 1);
-   ptx_reg_t data;
-   memory_space_t space = pI->get_space();
-   unsigned vector_spec = pI->get_vector();
+void sst_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_instruction *cpI = const_cast<ptx_instruction *>(pI);  // constant
+  const operand_info &dst = cpI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
+  const operand_info &src3 = pI->src3();
+  unsigned type = pI->get_type();
+  ptx_reg_t dst_data = thread->get_operand_value(dst, dst, type, thread, 1);
+  ptx_reg_t src1_data = thread->get_operand_value(src1, src1, type, thread, 1);
+  ptx_reg_t src2_data = thread->get_operand_value(src2, src1, type, thread, 1);
+  ptx_reg_t src3_data = thread->get_operand_value(src3, src1, type, thread, 1);
+  memory_space_t space = pI->get_space();
+  memory_space *mem = NULL;
+  addr_t addr =
+      src2_data.u32 * 4;  // this assumes sstarr memory starts at address 0
+  ptx_cta_info *cta_info = thread->m_cta_info;
 
-   memory_space *mem = NULL;
-   addr_t addr = addr_reg.u32;
+  decode_space(space, thread, src1, mem, addr);
 
-   decode_space(space,thread,dst,mem,addr);
+  size_t size;
+  int t;
+  type_info_key::type_decode(type, size, t);
 
-   size_t size;
-   int t;
-   type_info_key::type_decode(type,size,t);
+  // store data in sstarr memory
+  mem->write(addr, size / 8, &src3_data.s64, thread, pI);
 
-   if (!vector_spec) {
-      data = thread->get_operand_value(src1, dst, type, thread, 1);
-      mem->write(addr,size/8,&data.s64,thread,pI);
-    } else {
-      if (vector_spec == V2_TYPE) {
-         ptx_reg_t* ptx_regs = new ptx_reg_t[2]; 
-         thread->get_vector_operand_values(src1, ptx_regs, 2); 
-         mem->write(addr,size/8,&ptx_regs[0].s64,thread,pI);
-         mem->write(addr+size/8,size/8,&ptx_regs[1].s64,thread,pI);
-         delete [] ptx_regs;
+  // sync threads
+  cpI->set_bar_id(16);  // use 16 for sst because bar uses an int from 0-15
+
+  thread->m_last_effective_address = addr;
+  thread->m_last_memory_space = space;
+  thread->m_last_dram_callback.function = bar_callback;
+  thread->m_last_dram_callback.instruction = cpI;
+
+  // the last thread that executes loads all of the data back from sstarr memory
+  int NUM_THREADS = cta_info->num_threads();
+  cta_info->inc_bar_threads();
+  if (NUM_THREADS == cta_info->get_bar_threads()) {
+    unsigned offset = 0;
+    addr = 0;
+    ptx_reg_t data;
+    float sstarr_fdata[NUM_THREADS];
+    signed long long sstarr_ldata[NUM_THREADS];
+    // loop through all of the threads
+    for (int tid = 0; tid < NUM_THREADS; tid++) {
+      data.u64 = 0;
+      mem->read(addr + (tid * 4), size / 8, &data.s64);
+      sstarr_fdata[tid] = data.f32;
+      sstarr_ldata[tid] = data.s64;
+    }
+
+    // squeeze the zeros out of the array and store data back into original
+    // array
+    mem = NULL;
+    addr = src1_data.u32;
+    space.set_type(global_space);
+    decode_space(space, thread, src1, mem, addr);
+    // store nonzero entries and indices
+    for (int tid = 0; tid < NUM_THREADS; tid++) {
+      if (sstarr_fdata[tid] != 0) {
+        float ftid = (float)tid;
+        mem->write(addr + (offset * 4), size / 8, &sstarr_ldata[tid], thread,
+                   pI);
+        mem->write(addr + ((NUM_THREADS + offset) * 4), size / 8, &ftid, thread,
+                   pI);
+        offset++;
       }
-      if (vector_spec == V3_TYPE) {
-         ptx_reg_t* ptx_regs = new ptx_reg_t[3]; 
-         thread->get_vector_operand_values(src1, ptx_regs, 3); 
-         mem->write(addr,size/8,&ptx_regs[0].s64,thread,pI);
-         mem->write(addr+size/8,size/8,&ptx_regs[1].s64,thread,pI);
-         mem->write(addr+2*size/8,size/8,&ptx_regs[2].s64,thread,pI);
-         delete [] ptx_regs;
-      }
-      if (vector_spec == V4_TYPE) {
-         ptx_reg_t* ptx_regs = new ptx_reg_t[4]; 
-         thread->get_vector_operand_values(src1, ptx_regs, 4); 
-         mem->write(addr,size/8,&ptx_regs[0].s64,thread,pI);
-         mem->write(addr+size/8,size/8,&ptx_regs[1].s64,thread,pI);
-         mem->write(addr+2*size/8,size/8,&ptx_regs[2].s64,thread,pI);
-         mem->write(addr+3*size/8,size/8,&ptx_regs[3].s64,thread,pI);
-         delete [] ptx_regs;
-      }
-   }
-   thread->m_last_effective_address = addr;
-   thread->m_last_memory_space = space; 
+    }
+    // store the number of nonzero elements in the array
+    data = thread->get_operand_value(src1, dst, type, thread, 1);
+    data.s64 += 4 * (offset - 1);
+    thread->set_operand_value(dst, data, type, thread, pI);
+
+    // fill the rest of the array with zeros (dst should always have a 0 in it)
+    while (offset < NUM_THREADS) {
+      mem->write(addr + (offset * 4), size / 8, &dst_data.s64, thread, pI);
+      offset++;
+    }
+
+    cta_info->reset_bar_threads();
+    thread->m_last_effective_address = addr + (NUM_THREADS - 1) * 4;
+    thread->m_last_memory_space = space;
+  }
 }
 
-void sub_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   ptx_reg_t data;
-   int overflow = 0;
-   int carry = 0;
+void ssy_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  // printf("Execution Warning: unimplemented ssy instruction is treated as a
+  // nop\n");
+  // TODO: add implementation
+}
 
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+void st_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();  // may be scalar or vector of regs
+  unsigned type = pI->get_type();
+  ptx_reg_t addr_reg = thread->get_operand_value(dst, dst, type, thread, 1);
+  ptx_reg_t data;
+  memory_space_t space = pI->get_space();
+  unsigned vector_spec = pI->get_vector();
 
-   unsigned i_type = pI->get_type();
-   ptx_reg_t src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   ptx_reg_t src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  memory_space *mem = NULL;
+  addr_t addr = addr_reg.u32;
 
-   //performs addition. Sets carry and overflow if needed.
-   //the constant is added in during subtraction so the carry bit is set properly.
-   switch ( i_type ) {
-   case S8_TYPE:
+  decode_space(space, thread, dst, mem, addr);
+
+  size_t size;
+  int t;
+  type_info_key::type_decode(type, size, t);
+
+  if (!vector_spec) {
+    data = thread->get_operand_value(src1, dst, type, thread, 1);
+    mem->write(addr, size / 8, &data.s64, thread, pI);
+  } else {
+    if (vector_spec == V2_TYPE) {
+      ptx_reg_t *ptx_regs = new ptx_reg_t[2];
+      thread->get_vector_operand_values(src1, ptx_regs, 2);
+      mem->write(addr, size / 8, &ptx_regs[0].s64, thread, pI);
+      mem->write(addr + size / 8, size / 8, &ptx_regs[1].s64, thread, pI);
+      delete[] ptx_regs;
+    }
+    if (vector_spec == V3_TYPE) {
+      ptx_reg_t *ptx_regs = new ptx_reg_t[3];
+      thread->get_vector_operand_values(src1, ptx_regs, 3);
+      mem->write(addr, size / 8, &ptx_regs[0].s64, thread, pI);
+      mem->write(addr + size / 8, size / 8, &ptx_regs[1].s64, thread, pI);
+      mem->write(addr + 2 * size / 8, size / 8, &ptx_regs[2].s64, thread, pI);
+      delete[] ptx_regs;
+    }
+    if (vector_spec == V4_TYPE) {
+      ptx_reg_t *ptx_regs = new ptx_reg_t[4];
+      thread->get_vector_operand_values(src1, ptx_regs, 4);
+      mem->write(addr, size / 8, &ptx_regs[0].s64, thread, pI);
+      mem->write(addr + size / 8, size / 8, &ptx_regs[1].s64, thread, pI);
+      mem->write(addr + 2 * size / 8, size / 8, &ptx_regs[2].s64, thread, pI);
+      mem->write(addr + 3 * size / 8, size / 8, &ptx_regs[3].s64, thread, pI);
+      delete[] ptx_regs;
+    }
+  }
+  thread->m_last_effective_address = addr;
+  thread->m_last_memory_space = space;
+}
+
+void sub_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t data;
+  int overflow = 0;
+  int carry = 0;
+
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
+
+  unsigned i_type = pI->get_type();
+  ptx_reg_t src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  ptx_reg_t src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+
+  // performs addition. Sets carry and overflow if needed.
+  // the constant is added in during subtraction so the carry bit is set
+  // properly.
+  switch (i_type) {
+    case S8_TYPE:
       data.s64 = (src1_data.s64 & 0xFF) - (src2_data.s64 & 0xFF) + 0x100;
-      if(((src1_data.s64 & 0x80)-(src2_data.s64 & 0x80)) != 0) {overflow=((src1_data.s64 & 0x80)-(data.s64 & 0x80))==0?0:1; }
-      carry = (data.s32 & 0x100)>>8;
+      if (((src1_data.s64 & 0x80) - (src2_data.s64 & 0x80)) != 0) {
+        overflow = ((src1_data.s64 & 0x80) - (data.s64 & 0x80)) == 0 ? 0 : 1;
+      }
+      carry = (data.s32 & 0x100) >> 8;
       break;
-   case S16_TYPE:
+    case S16_TYPE:
       data.s64 = (src1_data.s64 & 0xFFFF) - (src2_data.s64 & 0xFFFF) + 0x10000;
-      if(((src1_data.s64 & 0x8000)-(src2_data.s64 & 0x8000)) != 0) {overflow=((src1_data.s64 & 0x8000)-(data.s64 & 0x8000))==0?0:1; }
-      carry = (data.s32 & 0x10000)>>16;
+      if (((src1_data.s64 & 0x8000) - (src2_data.s64 & 0x8000)) != 0) {
+        overflow =
+            ((src1_data.s64 & 0x8000) - (data.s64 & 0x8000)) == 0 ? 0 : 1;
+      }
+      carry = (data.s32 & 0x10000) >> 16;
       break;
-   case S32_TYPE:
-      data.s64 = (src1_data.s64 & 0xFFFFFFFF) - (src2_data.s64 & 0xFFFFFFFF) + 0x100000000;
-      if(((src1_data.s64 & 0x80000000)-(src2_data.s64 & 0x80000000)) != 0) {overflow=((src1_data.s64 & 0x80000000)-(data.s64 & 0x80000000))==0?0:1; }
-      carry = ((data.u64)>>32) & 0x0001;
+    case S32_TYPE:
+      data.s64 = (src1_data.s64 & 0xFFFFFFFF) - (src2_data.s64 & 0xFFFFFFFF) +
+                 0x100000000;
+      if (((src1_data.s64 & 0x80000000) - (src2_data.s64 & 0x80000000)) != 0) {
+        overflow = ((src1_data.s64 & 0x80000000) - (data.s64 & 0x80000000)) == 0
+                       ? 0
+                       : 1;
+      }
+      carry = ((data.u64) >> 32) & 0x0001;
       break;
-   case S64_TYPE: 
-      data.s64 = src1_data.s64 - src2_data.s64; break;
-   case B8_TYPE:
-   case U8_TYPE:
+    case S64_TYPE:
+      data.s64 = src1_data.s64 - src2_data.s64;
+      break;
+    case B8_TYPE:
+    case U8_TYPE:
       data.u64 = (src1_data.u64 & 0xFF) - (src2_data.u64 & 0xFF) + 0x100;
-      carry = (data.u64 & 0x100)>>8;
+      carry = (data.u64 & 0x100) >> 8;
       break;
-   case B16_TYPE:
-   case U16_TYPE:
+    case B16_TYPE:
+    case U16_TYPE:
       data.u64 = (src1_data.u64 & 0xFFFF) - (src2_data.u64 & 0xFFFF) + 0x10000;
-      carry = (data.u64 & 0x10000)>>16;
+      carry = (data.u64 & 0x10000) >> 16;
       break;
-   case B32_TYPE:
-   case U32_TYPE:
-      data.u64 = (src1_data.u64 & 0xFFFFFFFF) - (src2_data.u64 & 0xFFFFFFFF) + 0x100000000;
-      carry = (data.u64 & 0x100000000)>>32;
+    case B32_TYPE:
+    case U32_TYPE:
+      data.u64 = (src1_data.u64 & 0xFFFFFFFF) - (src2_data.u64 & 0xFFFFFFFF) +
+                 0x100000000;
+      carry = (data.u64 & 0x100000000) >> 32;
       break;
-   case B64_TYPE:
-   case U64_TYPE: 
-      data.u64 = src1_data.u64 - src2_data.u64; break;
-   case F16_TYPE: data.f16 = src1_data.f16 - src2_data.f16; break;//assert(0); break;
-   case F32_TYPE: data.f32 = src1_data.f32 - src2_data.f32; break;
-   case F64_TYPE: case FF64_TYPE: data.f64 = src1_data.f64 - src2_data.f64; break;
-   default: assert(0); break;
-   }
+    case B64_TYPE:
+    case U64_TYPE:
+      data.u64 = src1_data.u64 - src2_data.u64;
+      break;
+    case F16_TYPE:
+      data.f16 = src1_data.f16 - src2_data.f16;
+      break;  // assert(0); break;
+    case F32_TYPE:
+      data.f32 = src1_data.f32 - src2_data.f32;
+      break;
+    case F64_TYPE:
+    case FF64_TYPE:
+      data.f64 = src1_data.f64 - src2_data.f64;
+      break;
+    default:
+      assert(0);
+      break;
+  }
 
-   thread->set_operand_value(dst,data, i_type, thread, pI, overflow, carry);
+  thread->set_operand_value(dst, data, i_type, thread, pI, overflow, carry);
 }
 
-void nop_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   // Do nothing
+void nop_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  // Do nothing
 }
 
-void subc_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void suld_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void sured_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void sust_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void suq_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-
+void subc_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void suld_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void sured_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void sust_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void suq_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
 
 union intfloat {
-   int a;
-   float b;
+  int a;
+  float b;
 };
 
-float reduce_precision( float x, unsigned bits )
-{
-   intfloat tmp;
-   tmp.b = x;
-   int v = tmp.a;
-   int man = v & ((1<<23)-1);
-   int mask =  ((1<<bits)-1) << (23-bits);
-   int nv = (v & ((-1)-((1<<23)-1))) | (mask&man);
-   tmp.a = nv;
-   float result = tmp.b;
-   return result;
+float reduce_precision(float x, unsigned bits) {
+  intfloat tmp;
+  tmp.b = x;
+  int v = tmp.a;
+  int man = v & ((1 << 23) - 1);
+  int mask = ((1 << bits) - 1) << (23 - bits);
+  int nv = (v & ((-1) - ((1 << 23) - 1))) | (mask & man);
+  tmp.a = nv;
+  float result = tmp.b;
+  return result;
 }
 
-unsigned wrap( unsigned x, unsigned y, unsigned mx, unsigned my, size_t elem_size )
-{
-   unsigned nx = (mx+x)%mx;
-   unsigned ny = (my+y)%my;
-   return nx + mx*ny;
+unsigned wrap(unsigned x, unsigned y, unsigned mx, unsigned my,
+              size_t elem_size) {
+  unsigned nx = (mx + x) % mx;
+  unsigned ny = (my + y) % my;
+  return nx + mx * ny;
 }
 
-unsigned clamp( unsigned x, unsigned y, unsigned mx, unsigned my, size_t elem_size )
-{
-   unsigned nx = x;
-   while (nx >= mx) nx -= elem_size;
-   unsigned ny = (y >= my)? my - 1 : y;
-   return nx + mx*ny;
+unsigned clamp(unsigned x, unsigned y, unsigned mx, unsigned my,
+               size_t elem_size) {
+  unsigned nx = x;
+  while (nx >= mx) nx -= elem_size;
+  unsigned ny = (y >= my) ? my - 1 : y;
+  return nx + mx * ny;
 }
 
-typedef unsigned (*texAddr_t) (unsigned x, unsigned y, unsigned mx, unsigned my, size_t elem_size);
-float tex_linf_sampling(memory_space* mem, unsigned tex_array_base, 
-                        int x, int y, unsigned int width, unsigned int height, size_t elem_size,
-                        float alpha, float beta, texAddr_t b_lim)
-{
-   float Tij;
-   float Ti1j;
-   float Tij1;
-   float Ti1j1;
+typedef unsigned (*texAddr_t)(unsigned x, unsigned y, unsigned mx, unsigned my,
+                              size_t elem_size);
+float tex_linf_sampling(memory_space *mem, unsigned tex_array_base, int x,
+                        int y, unsigned int width, unsigned int height,
+                        size_t elem_size, float alpha, float beta,
+                        texAddr_t b_lim) {
+  float Tij;
+  float Ti1j;
+  float Tij1;
+  float Ti1j1;
 
-   mem->read(tex_array_base + b_lim(x,y,width,height,elem_size), 4, &Tij);
-   mem->read(tex_array_base + b_lim(x+elem_size,y,width,height,elem_size), 4, &Ti1j);
-   mem->read(tex_array_base + b_lim(x,y+1,width,height,elem_size), 4, &Tij1);
-   mem->read(tex_array_base + b_lim(x+elem_size,y+1,width,height,elem_size), 4, &Ti1j1);
+  mem->read(tex_array_base + b_lim(x, y, width, height, elem_size), 4, &Tij);
+  mem->read(tex_array_base + b_lim(x + elem_size, y, width, height, elem_size),
+            4, &Ti1j);
+  mem->read(tex_array_base + b_lim(x, y + 1, width, height, elem_size), 4,
+            &Tij1);
+  mem->read(
+      tex_array_base + b_lim(x + elem_size, y + 1, width, height, elem_size), 4,
+      &Ti1j1);
 
-   float sample = (1-alpha)*(1-beta)*Tij + 
-                   alpha*(1-beta)*Ti1j +
-                   (1-alpha)*beta*Tij1 +
-                   alpha*beta*Ti1j1;
-   
-   return sample;
+  float sample = (1 - alpha) * (1 - beta) * Tij + alpha * (1 - beta) * Ti1j +
+                 (1 - alpha) * beta * Tij1 + alpha * beta * Ti1j1;
+
+  return sample;
 }
 
-float textureNormalizeElementSigned(int element, int bits)
-{
-   if (bits) {
-      int maxN = (1 << bits) - 1; 
-      // removing upper bits 
-      element &= maxN;
-      // normalizing the number to [-1.0,1.0]
-      maxN >>= 1;
-      float output = (float) element / maxN;  
-      if (output < -1.0f) output = -1.0f; 
-      return output; 
-   } else {
-      return 0.0f; 
-   }
+float textureNormalizeElementSigned(int element, int bits) {
+  if (bits) {
+    int maxN = (1 << bits) - 1;
+    // removing upper bits
+    element &= maxN;
+    // normalizing the number to [-1.0,1.0]
+    maxN >>= 1;
+    float output = (float)element / maxN;
+    if (output < -1.0f) output = -1.0f;
+    return output;
+  } else {
+    return 0.0f;
+  }
 }
 
-float textureNormalizeElementUnsigned(unsigned int element, int bits)
-{
-   if (bits) {
-      unsigned int maxN = (1 << bits) - 1; 
-      // removing upper bits and normalizing the number to [0.0,1.0]
-      return (float)(element & maxN) / maxN;  
-   } else {
-      return 0.0f; 
-   }
+float textureNormalizeElementUnsigned(unsigned int element, int bits) {
+  if (bits) {
+    unsigned int maxN = (1 << bits) - 1;
+    // removing upper bits and normalizing the number to [0.0,1.0]
+    return (float)(element & maxN) / maxN;
+  } else {
+    return 0.0f;
+  }
 }
 
-void textureNormalizeOutput( const struct cudaChannelFormatDesc& desc, ptx_reg_t& datax, ptx_reg_t& datay, ptx_reg_t& dataz, ptx_reg_t& dataw ) 
-{
-   if (desc.f == cudaChannelFormatKindSigned) {
-      datax.f32 = textureNormalizeElementSigned( datax.s32, desc.x ); 
-      datay.f32 = textureNormalizeElementSigned( datay.s32, desc.y ); 
-      dataz.f32 = textureNormalizeElementSigned( dataz.s32, desc.z ); 
-      dataw.f32 = textureNormalizeElementSigned( dataw.s32, desc.w ); 
-   } else if (desc.f == cudaChannelFormatKindUnsigned) {
-      datax.f32 = textureNormalizeElementUnsigned( datax.u32, desc.x ); 
-      datay.f32 = textureNormalizeElementUnsigned( datay.u32, desc.y ); 
-      dataz.f32 = textureNormalizeElementUnsigned( dataz.u32, desc.z ); 
-      dataw.f32 = textureNormalizeElementUnsigned( dataw.u32, desc.w ); 
-   } else {
-      assert(0 && "Undefined texture read mode: cudaReadModeNormalizedFloat expect integer elements"); 
-   }
+void textureNormalizeOutput(const struct cudaChannelFormatDesc &desc,
+                            ptx_reg_t &datax, ptx_reg_t &datay,
+                            ptx_reg_t &dataz, ptx_reg_t &dataw) {
+  if (desc.f == cudaChannelFormatKindSigned) {
+    datax.f32 = textureNormalizeElementSigned(datax.s32, desc.x);
+    datay.f32 = textureNormalizeElementSigned(datay.s32, desc.y);
+    dataz.f32 = textureNormalizeElementSigned(dataz.s32, desc.z);
+    dataw.f32 = textureNormalizeElementSigned(dataw.s32, desc.w);
+  } else if (desc.f == cudaChannelFormatKindUnsigned) {
+    datax.f32 = textureNormalizeElementUnsigned(datax.u32, desc.x);
+    datay.f32 = textureNormalizeElementUnsigned(datay.u32, desc.y);
+    dataz.f32 = textureNormalizeElementUnsigned(dataz.u32, desc.z);
+    dataw.f32 = textureNormalizeElementUnsigned(dataw.u32, desc.w);
+  } else {
+    assert(0 &&
+           "Undefined texture read mode: cudaReadModeNormalizedFloat expect "
+           "integer elements");
+  }
 }
 
-void tex_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   unsigned dimension = pI->dimension();
-   const operand_info &dst = pI->dst(); //the registers to which fetched texel will be placed
-   const operand_info &src1 = pI->src1(); //the name of the texture
-   const operand_info &src2 = pI->src2(); //the vector registers containing coordinates of the texel to be fetched
+void tex_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  unsigned dimension = pI->dimension();
+  const operand_info &dst =
+      pI->dst();  // the registers to which fetched texel will be placed
+  const operand_info &src1 = pI->src1();  // the name of the texture
+  const operand_info &src2 =
+      pI->src2();  // the vector registers containing coordinates of the texel
+                   // to be fetched
 
-   std::string texname = src1.name();
-   unsigned to_type = pI->get_type();
-   unsigned c_type = pI->get_type2();
-   fflush(stdout);
-   ptx_reg_t data1, data2, data3, data4;
-   if (!thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs)
-       thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs = new ptx_reg_t[4];
-   unsigned nelem = src2.get_vect_nelem();
-   thread->get_vector_operand_values(src2, thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs, nelem); //ptx_reg should be 4 entry vector type...coordinates into texture
-   /*
-     For programs with many streams, textures can be bound and unbound
-     asynchronously.  This means we need to use the kernel's "snapshot" of
-     the state of the texture mappings when it was launched (so that we
-     don't try to access the incorrect texture mapping if it's been updated,
-     or that we don't access a mapping that has been unbound).
-   */
-   gpgpu_t *gpu = thread->get_gpu();
-   kernel_info_t &k = thread->get_kernel();
-   const struct textureReference* texref = gpu->get_texref(texname);
-   const struct cudaArray* cuArray = k.get_texarray(texname); 
-   const struct textureInfo* texInfo = k.get_texinfo(texname);
-   const struct textureReferenceAttr* texAttr = gpu->get_texattr(texname);
+  std::string texname = src1.name();
+  unsigned to_type = pI->get_type();
+  unsigned c_type = pI->get_type2();
+  fflush(stdout);
+  ptx_reg_t data1, data2, data3, data4;
+  if (!thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs)
+    thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs = new ptx_reg_t[4];
+  unsigned nelem = src2.get_vect_nelem();
+  thread->get_vector_operand_values(
+      src2, thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs,
+      nelem);  // ptx_reg should be 4 entry vector type...coordinates into
+               // texture
+  /*
+    For programs with many streams, textures can be bound and unbound
+    asynchronously.  This means we need to use the kernel's "snapshot" of
+    the state of the texture mappings when it was launched (so that we
+    don't try to access the incorrect texture mapping if it's been updated,
+    or that we don't access a mapping that has been unbound).
+  */
+  gpgpu_t *gpu = thread->get_gpu();
+  kernel_info_t &k = thread->get_kernel();
+  const struct textureReference *texref = gpu->get_texref(texname);
+  const struct cudaArray *cuArray = k.get_texarray(texname);
+  const struct textureInfo *texInfo = k.get_texinfo(texname);
+  const struct textureReferenceAttr *texAttr = gpu->get_texattr(texname);
 
-   //assume always 2D f32 input
-   //access array with src2 coordinates
-   memory_space *mem = thread->get_global_memory();
-   float x_f32,  y_f32;
-   size_t size;
-   int t;
-   unsigned tex_array_base;
-   unsigned int width = 0, height = 0;
-   int x = 0;
-   int y = 0;
-   unsigned tex_array_index;
-   float alpha=0, beta=0;
+  // assume always 2D f32 input
+  // access array with src2 coordinates
+  memory_space *mem = thread->get_global_memory();
+  float x_f32, y_f32;
+  size_t size;
+  int t;
+  unsigned tex_array_base;
+  unsigned int width = 0, height = 0;
+  int x = 0;
+  int y = 0;
+  unsigned tex_array_index;
+  float alpha = 0, beta = 0;
 
-   type_info_key::type_decode(to_type,size,t);
-   tex_array_base = cuArray->devPtr32;
+  type_info_key::type_decode(to_type, size, t);
+  tex_array_base = cuArray->devPtr32;
 
-   switch (dimension) {
-   case GEOM_MODIFIER_1D:
+  switch (dimension) {
+    case GEOM_MODIFIER_1D:
       width = cuArray->width;
       height = cuArray->height;
       if (texref->normalized) {
-         assert(c_type == F32_TYPE); 
-         x_f32 = thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[0].f32;
-         if (texref->addressMode[0] == cudaAddressModeClamp) {
-            x_f32 = (x_f32 > 1.0)? 1.0 : x_f32;
-            x_f32 = (x_f32 < 0.0)? 0.0 : x_f32;
-         } else if (texref->addressMode[0] == cudaAddressModeWrap) {
-            x_f32 = x_f32 - floor(x_f32);
-         }
+        assert(c_type == F32_TYPE);
+        x_f32 = thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[0].f32;
+        if (texref->addressMode[0] == cudaAddressModeClamp) {
+          x_f32 = (x_f32 > 1.0) ? 1.0 : x_f32;
+          x_f32 = (x_f32 < 0.0) ? 0.0 : x_f32;
+        } else if (texref->addressMode[0] == cudaAddressModeWrap) {
+          x_f32 = x_f32 - floor(x_f32);
+        }
 
-         if( texref->filterMode == cudaFilterModeLinear ) {
-            float xb = x_f32 * width - 0.5;
-            alpha = xb - floor(xb);
-            alpha = reduce_precision(alpha,9);
-            beta = 0.0;
+        if (texref->filterMode == cudaFilterModeLinear) {
+          float xb = x_f32 * width - 0.5;
+          alpha = xb - floor(xb);
+          alpha = reduce_precision(alpha, 9);
+          beta = 0.0;
 
-            x = (int)floor(xb);
-            y = 0;
-         } else {
-            x = (int) floor(x_f32 * width);
-            y = 0;
-         }
+          x = (int)floor(xb);
+          y = 0;
+        } else {
+          x = (int)floor(x_f32 * width);
+          y = 0;
+        }
       } else {
-         switch ( c_type ) {
-         case S32_TYPE: 
+        switch (c_type) {
+          case S32_TYPE:
             x = thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[0].s32;
-            assert(texref->filterMode == cudaFilterModePoint); 
-            break; 
-         case F32_TYPE: 
+            assert(texref->filterMode == cudaFilterModePoint);
+            break;
+          case F32_TYPE:
             x_f32 = thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[0].f32;
-            alpha = x_f32 - floor(x_f32); // offset into subtexel (for linear sampling)
-            x = (int) x_f32; 
-            break; 
-         default: assert(0 && "Unsupported texture coordinate type."); 
-         }
-         // handle texture fetch that exceeded boundaries
-         if (texref->addressMode[0] == cudaAddressModeClamp) {
-            x = (x > width - 1)? (width - 1) : x;
-            x = (x < 0)? 0 : x;
-         } else if (texref->addressMode[0] == cudaAddressModeWrap) {
-            x = x % width;
-         }
+            alpha = x_f32 -
+                    floor(x_f32);  // offset into subtexel (for linear sampling)
+            x = (int)x_f32;
+            break;
+          default:
+            assert(0 && "Unsupported texture coordinate type.");
+        }
+        // handle texture fetch that exceeded boundaries
+        if (texref->addressMode[0] == cudaAddressModeClamp) {
+          x = (x > width - 1) ? (width - 1) : x;
+          x = (x < 0) ? 0 : x;
+        } else if (texref->addressMode[0] == cudaAddressModeWrap) {
+          x = x % width;
+        }
       }
-      width *= (cuArray->desc.w+cuArray->desc.x+cuArray->desc.y+cuArray->desc.z)/8;
-      x *= (cuArray->desc.w+cuArray->desc.x+cuArray->desc.y+cuArray->desc.z)/8;
+      width *= (cuArray->desc.w + cuArray->desc.x + cuArray->desc.y +
+                cuArray->desc.z) /
+               8;
+      x *= (cuArray->desc.w + cuArray->desc.x + cuArray->desc.y +
+            cuArray->desc.z) /
+           8;
       tex_array_index = tex_array_base + x;
 
       break;
-   case GEOM_MODIFIER_2D:
+    case GEOM_MODIFIER_2D:
       width = cuArray->width;
       height = cuArray->height;
       if (texref->normalized) {
-         x_f32 = reduce_precision(thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[0].f32,16);
-         y_f32 = reduce_precision(thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[1].f32,15);
+        x_f32 = reduce_precision(
+            thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[0].f32, 16);
+        y_f32 = reduce_precision(
+            thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[1].f32, 15);
 
-         if (texref->addressMode[0]) {//clamp
-            if (x_f32<0) x_f32 = 0;
-            if (x_f32>=1) x_f32 = 1 - 1/x_f32;
-         } else {//wrap
-            x_f32 = x_f32 - floor(x_f32);
-         }
-         if (texref->addressMode[1]) {//clamp
-            if (y_f32<0) y_f32 = 0;
-            if (y_f32>=1) y_f32 = 1 - 1/y_f32;
-         } else {//wrap
-            y_f32 = y_f32 - floor(y_f32);
-         }
+        if (texref->addressMode[0]) {  // clamp
+          if (x_f32 < 0) x_f32 = 0;
+          if (x_f32 >= 1) x_f32 = 1 - 1 / x_f32;
+        } else {  // wrap
+          x_f32 = x_f32 - floor(x_f32);
+        }
+        if (texref->addressMode[1]) {  // clamp
+          if (y_f32 < 0) y_f32 = 0;
+          if (y_f32 >= 1) y_f32 = 1 - 1 / y_f32;
+        } else {  // wrap
+          y_f32 = y_f32 - floor(y_f32);
+        }
 
-         if( texref->filterMode == cudaFilterModeLinear ) {
-            float xb = x_f32 * width - 0.5;
-            float yb = y_f32 * height - 0.5;
-            alpha = xb - floor(xb);
-            beta = yb - floor(yb);
-            alpha = reduce_precision(alpha,9);
-            beta = reduce_precision(beta,9);
+        if (texref->filterMode == cudaFilterModeLinear) {
+          float xb = x_f32 * width - 0.5;
+          float yb = y_f32 * height - 0.5;
+          alpha = xb - floor(xb);
+          beta = yb - floor(yb);
+          alpha = reduce_precision(alpha, 9);
+          beta = reduce_precision(beta, 9);
 
-            x = (int)floor(xb);
-            y = (int)floor(yb);
-         } else {
-            x = (int) floor(x_f32 * width);
-            y = (int) floor(y_f32 * height);
-         }
+          x = (int)floor(xb);
+          y = (int)floor(yb);
+        } else {
+          x = (int)floor(x_f32 * width);
+          y = (int)floor(y_f32 * height);
+        }
       } else {
-         x_f32 = thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[0].f32;
-         y_f32 = thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[1].f32;
+        x_f32 = thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[0].f32;
+        y_f32 = thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[1].f32;
 
-         alpha = x_f32 - floor(x_f32);
-         beta = y_f32 - floor(y_f32);
+        alpha = x_f32 - floor(x_f32);
+        beta = y_f32 - floor(y_f32);
 
-         x = (int) x_f32;
-         y = (int) y_f32;
-         if (texref->addressMode[0]) {//clamp
-            if (x<0) x = 0;
-            if (x>= (int)width) x = width-1;
-         } else {//wrap
-            x = x % width;
-            if (x < 0) x*= -1;
-         }
-         if (texref->addressMode[1]) {//clamp
-            if (y<0) y = 0;
-            if (y>= (int)height) y = height -1;
-         } else {//wrap
-            y = y % height;
-            if (y < 0) y *= -1;
-         }
+        x = (int)x_f32;
+        y = (int)y_f32;
+        if (texref->addressMode[0]) {  // clamp
+          if (x < 0) x = 0;
+          if (x >= (int)width) x = width - 1;
+        } else {  // wrap
+          x = x % width;
+          if (x < 0) x *= -1;
+        }
+        if (texref->addressMode[1]) {  // clamp
+          if (y < 0) y = 0;
+          if (y >= (int)height) y = height - 1;
+        } else {  // wrap
+          y = y % height;
+          if (y < 0) y *= -1;
+        }
       }
 
-      width *= (cuArray->desc.w+cuArray->desc.x+cuArray->desc.y+cuArray->desc.z)/8;
-      x *= (cuArray->desc.w+cuArray->desc.x+cuArray->desc.y+cuArray->desc.z)/8;
-      tex_array_index = tex_array_base + (x + width*y);
+      width *= (cuArray->desc.w + cuArray->desc.x + cuArray->desc.y +
+                cuArray->desc.z) /
+               8;
+      x *= (cuArray->desc.w + cuArray->desc.x + cuArray->desc.y +
+            cuArray->desc.z) /
+           8;
+      tex_array_index = tex_array_base + (x + width * y);
       break;
-   default:
-      assert(0); break;
-   }
-   switch ( to_type ) {
-   case U8_TYPE:
-   case U16_TYPE:
-   case U32_TYPE: 
-   case B8_TYPE:
-   case B16_TYPE:
-   case B32_TYPE: 
-   case S8_TYPE:
-   case S16_TYPE:
-   case S32_TYPE: {
-      unsigned long long elementOffset = 0; // offset into the next element 
-      mem->read( tex_array_index, cuArray->desc.x/8, &data1.u32);
-      elementOffset += cuArray->desc.x/8;  
+    default:
+      assert(0);
+      break;
+  }
+  switch (to_type) {
+    case U8_TYPE:
+    case U16_TYPE:
+    case U32_TYPE:
+    case B8_TYPE:
+    case B16_TYPE:
+    case B32_TYPE:
+    case S8_TYPE:
+    case S16_TYPE:
+    case S32_TYPE: {
+      unsigned long long elementOffset = 0;  // offset into the next element
+      mem->read(tex_array_index, cuArray->desc.x / 8, &data1.u32);
+      elementOffset += cuArray->desc.x / 8;
       if (cuArray->desc.y) {
-         mem->read( tex_array_index + elementOffset, cuArray->desc.y/8, &data2.u32);
-         elementOffset += cuArray->desc.y/8; 
-         if (cuArray->desc.z) {
-            mem->read( tex_array_index + elementOffset, cuArray->desc.z/8, &data3.u32);
-            elementOffset += cuArray->desc.z/8; 
-            if (cuArray->desc.w) 
-               mem->read( tex_array_index + elementOffset, cuArray->desc.w/8, &data4.u32);
-         }
+        mem->read(tex_array_index + elementOffset, cuArray->desc.y / 8,
+                  &data2.u32);
+        elementOffset += cuArray->desc.y / 8;
+        if (cuArray->desc.z) {
+          mem->read(tex_array_index + elementOffset, cuArray->desc.z / 8,
+                    &data3.u32);
+          elementOffset += cuArray->desc.z / 8;
+          if (cuArray->desc.w)
+            mem->read(tex_array_index + elementOffset, cuArray->desc.w / 8,
+                      &data4.u32);
+        }
       }
       break;
-   }
-   case B64_TYPE:
-   case U64_TYPE:
-   case S64_TYPE:
-      mem->read( tex_array_index, 8, &data1.u64);
+    }
+    case B64_TYPE:
+    case U64_TYPE:
+    case S64_TYPE:
+      mem->read(tex_array_index, 8, &data1.u64);
       if (cuArray->desc.y) {
-         mem->read( tex_array_index+8, 8, &data2.u64);
-         if (cuArray->desc.z) {
-            mem->read( tex_array_index+16, 8, &data3.u64);
-            if (cuArray->desc.w) 
-               mem->read( tex_array_index+24, 8, &data4.u64);
-         }
+        mem->read(tex_array_index + 8, 8, &data2.u64);
+        if (cuArray->desc.z) {
+          mem->read(tex_array_index + 16, 8, &data3.u64);
+          if (cuArray->desc.w) mem->read(tex_array_index + 24, 8, &data4.u64);
+        }
       }
       break;
-   case F16_TYPE: assert(0); break;
-   case F32_TYPE:  {
-      if( texref->filterMode == cudaFilterModeLinear ) {
-         texAddr_t b_lim = wrap;
-         if ( texref->addressMode[0] == cudaAddressModeClamp ) {
-            b_lim = clamp;
-         }
-         size_t elem_size = (cuArray->desc.x + cuArray->desc.y + cuArray->desc.z + cuArray->desc.w) / 8;
-         size_t elem_ofst = 0;
+    case F16_TYPE:
+      assert(0);
+      break;
+    case F32_TYPE: {
+      if (texref->filterMode == cudaFilterModeLinear) {
+        texAddr_t b_lim = wrap;
+        if (texref->addressMode[0] == cudaAddressModeClamp) {
+          b_lim = clamp;
+        }
+        size_t elem_size = (cuArray->desc.x + cuArray->desc.y +
+                            cuArray->desc.z + cuArray->desc.w) /
+                           8;
+        size_t elem_ofst = 0;
 
-         data1.f32 = tex_linf_sampling(mem, tex_array_base, x + elem_ofst, y, width, height, elem_size, alpha, beta, b_lim);
-         elem_ofst += cuArray->desc.x / 8; 
-         if (cuArray->desc.y) {
-            data2.f32 = tex_linf_sampling(mem, tex_array_base, x + elem_ofst, y, width, height, elem_size, alpha, beta, b_lim);
-            elem_ofst += cuArray->desc.y / 8; 
-            if (cuArray->desc.z) {
-               data3.f32 = tex_linf_sampling(mem, tex_array_base, x + elem_ofst, y, width, height, elem_size, alpha, beta, b_lim);
-               elem_ofst += cuArray->desc.z / 8; 
-               if (cuArray->desc.w) 
-                  data4.f32 = tex_linf_sampling(mem, tex_array_base, x + elem_ofst, y, width, height, elem_size, alpha, beta, b_lim);
-            }
-         }
+        data1.f32 =
+            tex_linf_sampling(mem, tex_array_base, x + elem_ofst, y, width,
+                              height, elem_size, alpha, beta, b_lim);
+        elem_ofst += cuArray->desc.x / 8;
+        if (cuArray->desc.y) {
+          data2.f32 =
+              tex_linf_sampling(mem, tex_array_base, x + elem_ofst, y, width,
+                                height, elem_size, alpha, beta, b_lim);
+          elem_ofst += cuArray->desc.y / 8;
+          if (cuArray->desc.z) {
+            data3.f32 =
+                tex_linf_sampling(mem, tex_array_base, x + elem_ofst, y, width,
+                                  height, elem_size, alpha, beta, b_lim);
+            elem_ofst += cuArray->desc.z / 8;
+            if (cuArray->desc.w)
+              data4.f32 = tex_linf_sampling(mem, tex_array_base, x + elem_ofst,
+                                            y, width, height, elem_size, alpha,
+                                            beta, b_lim);
+          }
+        }
       } else {
-         mem->read( tex_array_index, cuArray->desc.x/8, &data1.f32);
-         if (cuArray->desc.y) {
-            mem->read( tex_array_index+4, cuArray->desc.y/8, &data2.f32);
-            if (cuArray->desc.z) {
-               mem->read( tex_array_index+8, cuArray->desc.z/8, &data3.f32);
-               if (cuArray->desc.w) 
-                  mem->read( tex_array_index+12, cuArray->desc.w/8, &data4.f32);
-            }
-         }
+        mem->read(tex_array_index, cuArray->desc.x / 8, &data1.f32);
+        if (cuArray->desc.y) {
+          mem->read(tex_array_index + 4, cuArray->desc.y / 8, &data2.f32);
+          if (cuArray->desc.z) {
+            mem->read(tex_array_index + 8, cuArray->desc.z / 8, &data3.f32);
+            if (cuArray->desc.w)
+              mem->read(tex_array_index + 12, cuArray->desc.w / 8, &data4.f32);
+          }
+        }
       }
-   } break;
-   case F64_TYPE: 
-   case FF64_TYPE:
-      mem->read( tex_array_index, 8, &data1.f64);
+    } break;
+    case F64_TYPE:
+    case FF64_TYPE:
+      mem->read(tex_array_index, 8, &data1.f64);
       if (cuArray->desc.y) {
-         mem->read( tex_array_index+8, 8, &data2.f64);
-         if (cuArray->desc.z) {
-            mem->read( tex_array_index+16, 8, &data3.f64);
-            if (cuArray->desc.w) 
-               mem->read( tex_array_index+24, 8, &data4.f64);
-         }
+        mem->read(tex_array_index + 8, 8, &data2.f64);
+        if (cuArray->desc.z) {
+          mem->read(tex_array_index + 16, 8, &data3.f64);
+          if (cuArray->desc.w) mem->read(tex_array_index + 24, 8, &data4.f64);
+        }
       }
       break;
-   default: assert(0); break;
-   }
-   int x_block_coord, y_block_coord, memreqindex, blockoffset;
+    default:
+      assert(0);
+      break;
+  }
+  int x_block_coord, y_block_coord, memreqindex, blockoffset;
 
-   switch (dimension) {
-   case GEOM_MODIFIER_1D:
+  switch (dimension) {
+    case GEOM_MODIFIER_1D:
       thread->m_last_effective_address = tex_array_index;
       break;
-   case GEOM_MODIFIER_2D: 
+    case GEOM_MODIFIER_2D:
       x_block_coord = x >> (texInfo->Tx_numbits + texInfo->texel_size_numbits);
       y_block_coord = y >> texInfo->Ty_numbits;
 
-      memreqindex = ((y_block_coord*cuArray->width/texInfo->Tx)+x_block_coord)<<6;
+      memreqindex =
+          ((y_block_coord * cuArray->width / texInfo->Tx) + x_block_coord) << 6;
 
-      blockoffset = (x%(texInfo->Tx*texInfo->texel_size) + (y%(texInfo->Ty)<<(texInfo->Tx_numbits + texInfo->texel_size_numbits)));
+      blockoffset = (x % (texInfo->Tx * texInfo->texel_size) +
+                     (y % (texInfo->Ty)
+                      << (texInfo->Tx_numbits + texInfo->texel_size_numbits)));
       memreqindex += blockoffset;
-      thread->m_last_effective_address = tex_array_base + memreqindex;//tex_array_index;
+      thread->m_last_effective_address =
+          tex_array_base + memreqindex;  // tex_array_index;
       break;
-   default:
+    default:
       assert(0);
-   }
-   thread->m_last_memory_space = tex_space; 
+  }
+  thread->m_last_memory_space = tex_space;
 
-   // normalize output into floating point numbers according to the texture read mode
-   if (texAttr->m_readmode == cudaReadModeNormalizedFloat) {
-      textureNormalizeOutput(cuArray->desc, data1, data2, data3, data4); 
-   } else {
-      assert(texAttr->m_readmode == cudaReadModeElementType); 
-   }
+  // normalize output into floating point numbers according to the texture read
+  // mode
+  if (texAttr->m_readmode == cudaReadModeNormalizedFloat) {
+    textureNormalizeOutput(cuArray->desc, data1, data2, data3, data4);
+  } else {
+    assert(texAttr->m_readmode == cudaReadModeElementType);
+  }
 
-   thread->set_vector_operand_values(dst,data1,data2,data3,data4);
+  thread->set_vector_operand_values(dst, data1, data2, data3, data4);
 }
 
-void txq_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void trap_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void vabsdiff_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void vadd_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void vmad_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void vmax_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void vmin_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void vset_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void vshl_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void vshr_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void vsub_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
+void txq_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void trap_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void vabsdiff_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void vadd_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void vmad_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void vmax_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void vmin_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void vset_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void vshl_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void vshr_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void vsub_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
 
-void vote_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   static bool first_in_warp = true;
-   static bool and_all;
-   static bool or_all;
-   static unsigned int ballot_result;
-   static std::list<ptx_thread_info*> threads_in_warp;
-   static unsigned last_tid;
+void vote_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  static bool first_in_warp = true;
+  static bool and_all;
+  static bool or_all;
+  static unsigned int ballot_result;
+  static std::list<ptx_thread_info *> threads_in_warp;
+  static unsigned last_tid;
 
-   if( first_in_warp ) {
-      first_in_warp = false;
-      threads_in_warp.clear();
-      and_all = true;
-      or_all = false;
-      ballot_result = 0;
-      int offset=31;
-      while( (offset>=0) && !pI->active(offset) ) 
-         offset--;
-      assert( offset >= 0 );
-      last_tid = (thread->get_hw_tid() - (thread->get_hw_tid()%pI->warp_size())) + offset;
-   }
+  if (first_in_warp) {
+    first_in_warp = false;
+    threads_in_warp.clear();
+    and_all = true;
+    or_all = false;
+    ballot_result = 0;
+    int offset = 31;
+    while ((offset >= 0) && !pI->active(offset)) offset--;
+    assert(offset >= 0);
+    last_tid =
+        (thread->get_hw_tid() - (thread->get_hw_tid() % pI->warp_size())) +
+        offset;
+  }
 
-   ptx_reg_t src1_data;
-   const operand_info &src1 = pI->src1();
-   src1_data = thread->get_operand_value(src1, pI->dst(), PRED_TYPE, thread, 1);
+  ptx_reg_t src1_data;
+  const operand_info &src1 = pI->src1();
+  src1_data = thread->get_operand_value(src1, pI->dst(), PRED_TYPE, thread, 1);
 
-   //predicate value was changed so the lowest bit being set means the zero flag is set.
-   //As a result, the value of src1_data.pred must be inverted to get proper behavior
-   bool pred_value = !(src1_data.pred & 0x0001);
-   bool invert = src1.is_neg_pred();
+  // predicate value was changed so the lowest bit being set means the zero flag
+  // is set. As a result, the value of src1_data.pred must be inverted to get
+  // proper behavior
+  bool pred_value = !(src1_data.pred & 0x0001);
+  bool invert = src1.is_neg_pred();
 
-   threads_in_warp.push_back(thread);
-   and_all &= (invert ^ pred_value);
-   or_all |= (invert ^ pred_value);
+  threads_in_warp.push_back(thread);
+  and_all &= (invert ^ pred_value);
+  or_all |= (invert ^ pred_value);
 
-   // vote.ballot
-   if (invert ^ pred_value) {
-      int lane_id = thread->get_hw_tid() % pI->warp_size(); 
-      ballot_result |= (1 << lane_id); 
-   }
+  // vote.ballot
+  if (invert ^ pred_value) {
+    int lane_id = thread->get_hw_tid() % pI->warp_size();
+    ballot_result |= (1 << lane_id);
+  }
 
-   if( thread->get_hw_tid() == last_tid ) {
-      if (pI->vote_mode() == ptx_instruction::vote_ballot) {
-         ptx_reg_t data = ballot_result; 
-         for( std::list<ptx_thread_info*>::iterator t=threads_in_warp.begin(); t!=threads_in_warp.end(); ++t ) {
-            const operand_info &dst = pI->dst();
-            (*t)->set_operand_value(dst,data, pI->get_type(), (*t), pI);
-         }
-      } else {
-         bool pred_value = false; 
-
-         switch( pI->vote_mode() ) {
-         case ptx_instruction::vote_any: pred_value = or_all; break;
-         case ptx_instruction::vote_all: pred_value = and_all; break;
-         case ptx_instruction::vote_uni: pred_value = (or_all ^ and_all); break;
-         default:
-            abort();
-         }
-         ptx_reg_t data;
-         data.pred = pred_value?0:1; //the way ptxplus handles the zero flag, 1 = false and 0 = true
-
-         for( std::list<ptx_thread_info*>::iterator t=threads_in_warp.begin(); t!=threads_in_warp.end(); ++t ) {
-            const operand_info &dst = pI->dst();
-            (*t)->set_operand_value(dst,data, PRED_TYPE, (*t), pI);
-         }
+  if (thread->get_hw_tid() == last_tid) {
+    if (pI->vote_mode() == ptx_instruction::vote_ballot) {
+      ptx_reg_t data = ballot_result;
+      for (std::list<ptx_thread_info *>::iterator t = threads_in_warp.begin();
+           t != threads_in_warp.end(); ++t) {
+        const operand_info &dst = pI->dst();
+        (*t)->set_operand_value(dst, data, pI->get_type(), (*t), pI);
       }
-      first_in_warp = true;
-   }
+    } else {
+      bool pred_value = false;
+
+      switch (pI->vote_mode()) {
+        case ptx_instruction::vote_any:
+          pred_value = or_all;
+          break;
+        case ptx_instruction::vote_all:
+          pred_value = and_all;
+          break;
+        case ptx_instruction::vote_uni:
+          pred_value = (or_all ^ and_all);
+          break;
+        default:
+          abort();
+      }
+      ptx_reg_t data;
+      data.pred = pred_value ? 0 : 1;  // the way ptxplus handles the zero flag,
+                                       // 1 = false and 0 = true
+
+      for (std::list<ptx_thread_info *>::iterator t = threads_in_warp.begin();
+           t != threads_in_warp.end(); ++t) {
+        const operand_info &dst = pI->dst();
+        (*t)->set_operand_value(dst, data, PRED_TYPE, (*t), pI);
+      }
+    }
+    first_in_warp = true;
+  }
 }
 
-void xor_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t src1_data, src2_data, data;
+void xor_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, src2_data, data;
 
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   unsigned i_type = pI->get_type();
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-   //the way ptxplus handles predicates: 1 = false and 0 = true
-   if(i_type == PRED_TYPE)
-      data.pred = ~(~(src1_data.pred) ^ ~(src2_data.pred));
-   else
-      data.u64 = src1_data.u64 ^ src2_data.u64;
+  // the way ptxplus handles predicates: 1 = false and 0 = true
+  if (i_type == PRED_TYPE)
+    data.pred = ~(~(src1_data.pred) ^ ~(src2_data.pred));
+  else
+    data.u64 = src1_data.u64 ^ src2_data.u64;
 
-   thread->set_operand_value(dst,data, i_type, thread, pI);
+  thread->set_operand_value(dst, data, i_type, thread, pI);
 }
 
-void inst_not_implemented( const ptx_instruction * pI ) 
-{
-   printf("GPGPU-Sim PTX: ERROR (%s:%u) instruction \"%s\" not (yet) implemented\n",
-          pI->source_file(), 
-          pI->source_line(), 
-          pI->get_opcode_cstr() );
-   abort();
+void inst_not_implemented(const ptx_instruction *pI) {
+  printf(
+      "GPGPU-Sim PTX: ERROR (%s:%u) instruction \"%s\" not (yet) implemented\n",
+      pI->source_file(), pI->source_line(), pI->get_opcode_cstr());
+  abort();
 }
 
-ptx_reg_t srcOperandModifiers(ptx_reg_t opData, operand_info opInfo, operand_info dstInfo, unsigned type, ptx_thread_info *thread)
-{
-   ptx_reg_t result;
-   memory_space *mem = NULL;
-   size_t size;
-   int t;
-   result.u64=0;
+ptx_reg_t srcOperandModifiers(ptx_reg_t opData, operand_info opInfo,
+                              operand_info dstInfo, unsigned type,
+                              ptx_thread_info *thread) {
+  ptx_reg_t result;
+  memory_space *mem = NULL;
+  size_t size;
+  int t;
+  result.u64 = 0;
 
-   //complete other cases for reading from memory, such as reading from other const memory
-   if(opInfo.get_addr_space() == global_space)
-   {
-       mem = thread->get_global_memory();
-       type_info_key::type_decode(type,size,t);
-       mem->read(opData.u32,size/8,&result.u64);
-       if( type == S16_TYPE || type == S32_TYPE ) 
-         sign_extend(result,size,dstInfo);
-   }
-   else if(opInfo.get_addr_space() == shared_space)
-   {
-       mem = thread->m_shared_mem;
-       type_info_key::type_decode(type,size,t);
-       mem->read(opData.u32,size/8,&result.u64);
+  // complete other cases for reading from memory, such as reading from other
+  // const memory
+  if (opInfo.get_addr_space() == global_space) {
+    mem = thread->get_global_memory();
+    type_info_key::type_decode(type, size, t);
+    mem->read(opData.u32, size / 8, &result.u64);
+    if (type == S16_TYPE || type == S32_TYPE)
+      sign_extend(result, size, dstInfo);
+  } else if (opInfo.get_addr_space() == shared_space) {
+    mem = thread->m_shared_mem;
+    type_info_key::type_decode(type, size, t);
+    mem->read(opData.u32, size / 8, &result.u64);
 
-       if( type == S16_TYPE || type == S32_TYPE ) 
-         sign_extend(result,size,dstInfo);
+    if (type == S16_TYPE || type == S32_TYPE)
+      sign_extend(result, size, dstInfo);
 
-   }
-   else if(opInfo.get_addr_space() == const_space)
-   {
-       mem = thread->get_global_memory();
-       type_info_key::type_decode(type,size,t);
+  } else if (opInfo.get_addr_space() == const_space) {
+    mem = thread->get_global_memory();
+    type_info_key::type_decode(type, size, t);
 
-       mem->read((opData.u32 + opInfo.get_const_mem_offset()),size/8,&result.u64);
+    mem->read((opData.u32 + opInfo.get_const_mem_offset()), size / 8,
+              &result.u64);
 
-       if( type == S16_TYPE || type == S32_TYPE ) 
-         sign_extend(result,size,dstInfo);
-   }
-   else
-   {
-       result = opData;
-   }
+    if (type == S16_TYPE || type == S32_TYPE)
+      sign_extend(result, size, dstInfo);
+  } else {
+    result = opData;
+  }
 
-   if(opInfo.get_operand_lohi() == 1)
-   {
-        result.u64 = result.u64 & 0xFFFF;
-   }
-   else if(opInfo.get_operand_lohi() == 2)
-   {
-        result.u64 = (result.u64>>16) & 0xFFFF;
-   }
+  if (opInfo.get_operand_lohi() == 1) {
+    result.u64 = result.u64 & 0xFFFF;
+  } else if (opInfo.get_operand_lohi() == 2) {
+    result.u64 = (result.u64 >> 16) & 0xFFFF;
+  }
 
-   if(opInfo.get_operand_neg() == true) {
-      result.f32 = -result.f32;
-   }
+  if (opInfo.get_operand_neg() == true) {
+    result.f32 = -result.f32;
+  }
 
-   return result;
+  return result;
 }
-

--- a/src/cuda-sim/instructions.cc
+++ b/src/cuda-sim/instructions.cc
@@ -3619,7 +3619,7 @@ void mma_ld_impl(const ptx_instruction *pI, core_t *core, warp_inst_t &inst) {
     if ((wmma_type == LOAD_C) && (type == F16_TYPE) &&
         (wmma_layout == COL))  // memory address is scattered, check the
                                // profiling xls for more detail.
-      inst.data_size = 2;  // 2 byte transaction
+      inst.data_size = 2;      // 2 byte transaction
     else
       inst.data_size = 4;  // 4 byte transaction
     assert(inst.memory_op == insn_memory_op);

--- a/src/cuda-sim/instructions.cc
+++ b/src/cuda-sim/instructions.cc
@@ -3625,7 +3625,7 @@ void mma_ld_impl(const ptx_instruction *pI, core_t *core, warp_inst_t &inst) {
     if ((wmma_type == LOAD_C) && (type == F16_TYPE) &&
         (wmma_layout == COL))  // memory address is scattered, check the
                                // profiling xls for more detail.
-      inst.data_size = 2;  // 2 byte transaction
+      inst.data_size = 2;      // 2 byte transaction
     else
       inst.data_size = 4;  // 4 byte transaction
     assert(inst.memory_op == insn_memory_op);
@@ -5994,13 +5994,13 @@ void tex_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
       src2, thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs,
       nelem);  // ptx_reg should be 4 entry vector type...coordinates into
                // texture
-  /*
-    For programs with many streams, textures can be bound and unbound
-    asynchronously.  This means we need to use the kernel's "snapshot" of
-    the state of the texture mappings when it was launched (so that we
-    don't try to access the incorrect texture mapping if it's been updated,
-    or that we don't access a mapping that has been unbound).
-  */
+               /*
+                 For programs with many streams, textures can be bound and unbound
+                 asynchronously.  This means we need to use the kernel's "snapshot" of
+                 the state of the texture mappings when it was launched (so that we
+                 don't try to access the incorrect texture mapping if it's been updated,
+                 or that we don't access a mapping that has been unbound).
+               */
   gpgpu_t *gpu = thread->get_gpu();
   kernel_info_t &k = thread->get_kernel();
   const struct textureReference *texref = gpu->get_texref(texname);

--- a/src/cuda-sim/instructions.cc
+++ b/src/cuda-sim/instructions.cc
@@ -8,14 +8,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -25,34 +27,34 @@
 // CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "instructions.h"
 #include "half.h"
 #include "half.hpp"
-#include "instructions.h"
-#include "ptx_ir.h"
 #include "opcodes.h"
+#include "ptx_ir.h"
 #include "ptx_sim.h"
-typedef void * yyscan_t;
+typedef void *yyscan_t;
 class ptx_recognizer;
-#include "ptx.tab.h"
-#include <stdlib.h>
-#include <math.h>
-#include <cmath>
+#include <assert.h>
 #include <fenv.h>
-#include "cuda-math.h"
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdlib.h>
+#include <string.h>
+#include <cmath>
+#include <map>
+#include <sstream>
+#include <string>
 #include "../abstract_hardware_model.h"
-#include "ptx_loader.h"
-#include "cuda_device_printf.h"
 #include "../gpgpu-sim/gpu-sim.h"
 #include "../gpgpu-sim/shader.h"
-#include <assert.h>
-#include <string.h>
-#include <sstream>
-#include <stdio.h>
-#include <string>
-#include <map>
-#include <stdlib.h>
+#include "cuda-math.h"
+#include "cuda_device_printf.h"
+#include "ptx.tab.h"
+#include "ptx_loader.h"
 
-//Jin: include device runtime for CDP
+// Jin: include device runtime for CDP
 #include "cuda_device_runtime.h"
 
 #include <stdarg.h>
@@ -60,5629 +62,6425 @@ class ptx_recognizer;
 
 using half_float::half;
 
-
-
 const char *g_opcode_string[NUM_OPCODES] = {
-#define OP_DEF(OP,FUNC,STR,DST,CLASSIFICATION) STR,
-#define OP_W_DEF(OP,FUNC,STR,DST,CLASSIFICATION) STR,
+#define OP_DEF(OP, FUNC, STR, DST, CLASSIFICATION) STR,
+#define OP_W_DEF(OP, FUNC, STR, DST, CLASSIFICATION) STR,
 #include "opcodes.def"
 #undef OP_DEF
 #undef OP_W_DEF
 };
-//Using profiled information::check the TensorCoreMatrixArrangement.xls for details
-unsigned thread_group_offset(int thread,unsigned  wmma_type,unsigned wmma_layout,unsigned type,int stride){
+// Using profiled information::check the TensorCoreMatrixArrangement.xls for
+// details
+unsigned thread_group_offset(int thread, unsigned wmma_type,
+                             unsigned wmma_layout, unsigned type, int stride) {
+  unsigned offset;
+  unsigned load_a_row[8] = {0, 128, 0, 128, 64, 192, 64, 192};
+  unsigned load_a_col[8] = {0, 8, 0, 8, 4, 12, 4, 12};
+  unsigned load_b_row[8] = {0, 8, 0, 8, 4, 12, 4, 12};
+  unsigned load_b_col[8] = {0, 128, 0, 128, 64, 192, 64, 192};
+  unsigned load_c_float_row[8] = {0, 128, 8, 136, 64, 192, 72, 200};
+  unsigned load_c_float_col[8] = {0, 8, 128, 136, 4, 12, 132, 140};
+  unsigned load_c_half_row[8] = {0, 128, 8, 136, 64, 192, 72, 200};
+  unsigned load_c_half_col[8] = {0, 8, 128, 136, 4, 12, 132, 140};
+  unsigned thread_group = thread / 4;
+  unsigned in_tg_index = thread % 4;
 
-	unsigned offset;
-	unsigned load_a_row[8]={0,128,0,128,64,192,64,192};
-	unsigned load_a_col[8]={0,8,0,8,4,12,4,12};
-	unsigned load_b_row[8]={0,8,0,8,4,12,4,12};
-	unsigned load_b_col[8]={0,128,0,128,64,192,64,192};
-	unsigned load_c_float_row[8]={0,128,8,136,64,192,72,200};	
-	unsigned load_c_float_col[8]={0,8,128,136,4,12,132,140};	
-	unsigned load_c_half_row[8]={0,128,8,136,64,192,72,200};	
-	unsigned load_c_half_col[8]={0,8,128,136,4,12,132,140};	
-	unsigned thread_group =	thread/4;
-	unsigned in_tg_index  =	thread%4;
+  switch (wmma_type) {
+    case LOAD_A:
+      if (wmma_layout == ROW)
+        offset = load_a_row[thread_group] + 16 * in_tg_index;
+      else
+        offset = load_a_col[thread_group] + 16 * in_tg_index;
+      break;
 
-	switch(wmma_type){
-		case LOAD_A:
-				if(wmma_layout==ROW)
-					offset=load_a_row[thread_group]+16*in_tg_index;
-				else
-					offset=load_a_col[thread_group]+16*in_tg_index;
-			break;
+    case LOAD_B:
+      if (wmma_layout == ROW)
+        offset = load_b_row[thread_group] + 16 * in_tg_index;
+      else
+        offset = load_b_col[thread_group] + 16 * in_tg_index;
+      break;
 
+    case LOAD_C:
+    case STORE_D:
+      if (type == F16_TYPE) {
+        if (wmma_layout == ROW)
+          offset = load_c_half_row[thread_group] + 16 * in_tg_index;
+        else
+          offset = load_c_half_col[thread_group] + in_tg_index;
+      } else {
+        if (wmma_layout == ROW)
+          offset = load_c_float_row[thread_group];
+        else
+          offset = load_c_float_col[thread_group];
 
-		case LOAD_B:
-				if(wmma_layout==ROW)
-					offset=load_b_row[thread_group]+16*in_tg_index;
-				else	
-					offset=load_b_col[thread_group]+16*in_tg_index;
-			break;	
+        switch (in_tg_index) {
+          case 0:
+            break;
+          case 1:
+            if (wmma_layout == ROW)
+              offset += 16;
+            else
+              offset += 1;
+            break;
+          case 2:
+            if (wmma_layout == ROW)
+              offset += 2;
+            else
+              offset += 32;
+            break;
+          case 3:
+            if (wmma_layout == ROW)
+              offset += 18;
+            else
+              offset += 33;
+            break;
+          default:
+            abort();
+        }
+      }
+      break;
 
-		case LOAD_C:
-		case STORE_D:
-			if(type==F16_TYPE){
-				if(wmma_layout==ROW)
-					offset=load_c_half_row[thread_group]+16*in_tg_index;
-				else
-					offset=load_c_half_col[thread_group]+in_tg_index;
-			}
-			else{
-				if(wmma_layout==ROW)
-					offset=load_c_float_row[thread_group];
-				else
-					offset=load_c_float_col[thread_group];
-
-				switch(in_tg_index){
-					case 0:
-						break;
-					case 1:
-						if(wmma_layout==ROW)
-							offset+=16;
-						else
-							offset+=1;
-						break;
-					case 2:
-						if(wmma_layout==ROW)
-							offset+=2;
-						else
-							offset+=32;
-						break;
-					case 3:
-						if(wmma_layout==ROW)
-							offset+=18;
-						else
-							offset+=33;
-						break;
-					default:
-						abort();
-				}
-			}
-			break;	
-
-         	default:
-         	   abort();
-		
-	}
-	offset = (offset/16)*stride+offset%16;
-	return offset;
+    default:
+      abort();
+  }
+  offset = (offset / 16) * stride + offset % 16;
+  return offset;
 }
 
-int acc_float_offset(int index,int wmma_layout,int stride){
+int acc_float_offset(int index, int wmma_layout, int stride) {
+  int c_row_offset[] = {0, 1, 32, 33, 4, 5, 36, 37};
+  int c_col_offset[] = {0, 16, 2, 18, 64, 80, 66, 82};
+  int offset;
 
-	int c_row_offset[]={0,1,32,33,4,5,36,37};
-	int c_col_offset[]={0,16,2,18,64,80,66,82};
-	int offset;
-	
-	
-	if(wmma_layout==ROW)
-		offset=c_row_offset[index];
-	else if(wmma_layout==COL)
-		offset=c_col_offset[index];
-	else{
-		printf("wrong layout");
-		abort();
-	}
-	offset = (offset/16)*stride+offset%16;
-	return offset;
+  if (wmma_layout == ROW)
+    offset = c_row_offset[index];
+  else if (wmma_layout == COL)
+    offset = c_col_offset[index];
+  else {
+    printf("wrong layout");
+    abort();
+  }
+  offset = (offset / 16) * stride + offset % 16;
+  return offset;
 }
 
-void inst_not_implemented( const ptx_instruction * pI ) ;
-ptx_reg_t srcOperandModifiers(ptx_reg_t opData, operand_info opInfo, operand_info dstInfo, unsigned type, ptx_thread_info *thread);
+void inst_not_implemented(const ptx_instruction *pI);
+ptx_reg_t srcOperandModifiers(ptx_reg_t opData, operand_info opInfo,
+                              operand_info dstInfo, unsigned type,
+                              ptx_thread_info *thread);
 
-void sign_extend( ptx_reg_t &data, unsigned src_size, const operand_info &dst );
+void sign_extend(ptx_reg_t &data, unsigned src_size, const operand_info &dst);
 
-void ptx_thread_info::set_reg( const symbol *reg, const ptx_reg_t &value ) 
-{
-   assert( reg != NULL );
-   if( reg->name() == "_" ) return;
-   assert( !m_regs.empty() );
-   assert( reg->uid() > 0 );
-   m_regs.back()[ reg ] = value;
-   if (m_enable_debug_trace ) 
-      m_debug_trace_regs_modified.back()[ reg ] = value;
-   m_last_set_operand_value = value;
+void ptx_thread_info::set_reg(const symbol *reg, const ptx_reg_t &value) {
+  assert(reg != NULL);
+  if (reg->name() == "_") return;
+  assert(!m_regs.empty());
+  assert(reg->uid() > 0);
+  m_regs.back()[reg] = value;
+  if (m_enable_debug_trace) m_debug_trace_regs_modified.back()[reg] = value;
+  m_last_set_operand_value = value;
 }
 
-void ptx_thread_info::print_reg_thread(char * fname)
-{
-
-  FILE *fp= fopen(fname,"w");
-  assert(fp!=NULL);
+void ptx_thread_info::print_reg_thread(char *fname) {
+  FILE *fp = fopen(fname, "w");
+  assert(fp != NULL);
 
   int size = m_regs.size();
-  
-  if(size>0)
-  {  
-  reg_map_t reg = m_regs.back();
-  
-      reg_map_t::const_iterator it;
-      for (it = reg.begin(); it != reg.end(); ++it) 
-        {
-          const std::string &name = it->first->name();
-          const std::string &dec= it->first->decl_location();
-          unsigned size = it->first->get_size_in_bytes();
-          fprintf(fp,"%s %llu %s %d\n", name.c_str(), it->second, dec.c_str(), size);
-          
-        }
-   //m_regs.pop_back();     
+
+  if (size > 0) {
+    reg_map_t reg = m_regs.back();
+
+    reg_map_t::const_iterator it;
+    for (it = reg.begin(); it != reg.end(); ++it) {
+      const std::string &name = it->first->name();
+      const std::string &dec = it->first->decl_location();
+      unsigned size = it->first->get_size_in_bytes();
+      fprintf(fp, "%s %llu %s %d\n", name.c_str(), it->second, dec.c_str(),
+              size);
+    }
+    // m_regs.pop_back();
   }
   fclose(fp);
+}
 
+void ptx_thread_info::resume_reg_thread(char *fname, symbol_table *symtab) {
+  FILE *fp2 = fopen(fname, "r");
+  assert(fp2 != NULL);
+  // m_regs.push_back( reg_map_t() );
+  char line[200];
+  while (fgets(line, sizeof line, fp2) != NULL) {
+    symbol *reg;
+    char *pch;
+    pch = strtok(line, " ");
+    char *name = pch;
+    reg = symtab->lookup(name);
+    ptx_reg_t data;
+    pch = strtok(NULL, " ");
+    data = atoi(pch);
+    pch = strtok(NULL, " ");
+    pch = strtok(NULL, " ");
+    m_regs.back()[reg] = data;
+  }
+  fclose(fp2);
+}
+
+ptx_reg_t ptx_thread_info::get_reg(const symbol *reg) {
+  static bool unfound_register_warned = false;
+  assert(reg != NULL);
+  assert(!m_regs.empty());
+  reg_map_t::iterator regs_iter = m_regs.back().find(reg);
+  if (regs_iter == m_regs.back().end()) {
+    assert(reg->type()->get_key().is_reg());
+    const std::string &name = reg->name();
+    unsigned call_uid = m_callstack.back().m_call_uid;
+    ptx_reg_t uninit_reg;
+    uninit_reg.u32 = 0x0;
+    set_reg(reg, uninit_reg);  // give it a value since we are going to warn the
+                               // user anyway
+    std::string file_loc = get_location();
+    if (!unfound_register_warned) {
+      printf(
+          "GPGPU-Sim PTX: WARNING (%s) ** reading undefined register \'%s\' "
+          "(cuid:%u). Setting to 0X00000000. This is okay if you are "
+          "simulating the native ISA"
+          "\n",
+          file_loc.c_str(), name.c_str(), call_uid);
+      unfound_register_warned = true;
+    }
+    regs_iter = m_regs.back().find(reg);
+  }
+  if (m_enable_debug_trace)
+    m_debug_trace_regs_read.back()[reg] = regs_iter->second;
+  return regs_iter->second;
+}
+
+ptx_reg_t ptx_thread_info::get_operand_value(const operand_info &op,
+                                             operand_info dstInfo,
+                                             unsigned opType,
+                                             ptx_thread_info *thread,
+                                             int derefFlag) {
+  ptx_reg_t result, tmp;
+
+  if (op.get_double_operand_type() == 0) {
+    if (((opType != BB128_TYPE) && (opType != BB64_TYPE) &&
+         (opType != FF64_TYPE)) ||
+        (op.get_addr_space() != undefined_space)) {
+      if (op.is_reg()) {
+        result = get_reg(op.get_symbol());
+      } else if (op.is_builtin()) {
+        result.u32 = get_builtin(op.get_int(), op.get_addr_offset());
+      } else if (op.is_immediate_address()) {
+        result.u64 = op.get_addr_offset();
+      } else if (op.is_memory_operand()) {
+        // a few options here...
+        const symbol *sym = op.get_symbol();
+        const type_info *type = sym->type();
+        const type_info_key &info = type->get_key();
+
+        if (info.is_reg()) {
+          const symbol *name = op.get_symbol();
+          result.u64 = get_reg(name).u64 + op.get_addr_offset();
+        } else if (info.is_param_kernel()) {
+          result.u64 = sym->get_address() + op.get_addr_offset();
+        } else if (info.is_param_local()) {
+          result.u64 = sym->get_address() + op.get_addr_offset();
+        } else if (info.is_global()) {
+          assert(op.get_addr_offset() == 0);
+          result.u64 = sym->get_address();
+        } else if (info.is_local()) {
+          result.u64 = sym->get_address() + op.get_addr_offset();
+        } else if (info.is_const()) {
+          result.u64 = sym->get_address() + op.get_addr_offset();
+        } else if (op.is_shared()) {
+          result.u64 = op.get_symbol()->get_address() + op.get_addr_offset();
+        } else if (op.is_sstarr()) {
+          result.u64 = op.get_symbol()->get_address() + op.get_addr_offset();
+        } else {
+          const char *name = op.name().c_str();
+          printf(
+              "GPGPU-Sim PTX: ERROR ** get_operand_value : unknown memory "
+              "operand type for %s\n",
+              name);
+          abort();
+        }
+
+      } else if (op.is_literal()) {
+        result = op.get_literal_value();
+      } else if (op.is_label()) {
+        result.u64 = op.get_symbol()->get_address();
+      } else if (op.is_shared()) {
+        result.u64 = op.get_symbol()->get_address();
+      } else if (op.is_sstarr()) {
+        result.u64 = op.get_symbol()->get_address();
+      } else if (op.is_const()) {
+        result.u64 = op.get_symbol()->get_address();
+      } else if (op.is_global()) {
+        result.u64 = op.get_symbol()->get_address();
+      } else if (op.is_local()) {
+        result.u64 = op.get_symbol()->get_address();
+      } else if (op.is_function_address()) {
+        result.u64 = (size_t)op.get_symbol()->get_pc();
+      } else if (op.is_param_kernel()) {
+        result.u64 = op.get_symbol()->get_address();
+      } else {
+        const char *name = op.name().c_str();
+        const symbol *sym2 = op.get_symbol();
+        const type_info *type2 = sym2->type();
+        const type_info_key &info2 = type2->get_key();
+        if (info2.is_param_kernel()) {
+          result.u64 = sym2->get_address() + op.get_addr_offset();
+        } else {
+          printf(
+              "GPGPU-Sim PTX: ERROR ** get_operand_value : unknown operand "
+              "type for %s\n",
+              name);
+          assert(0);
+        }
+      }
+
+      if (op.get_operand_lohi() == 1)
+        result.u64 = result.u64 & 0xFFFF;
+      else if (op.get_operand_lohi() == 2)
+        result.u64 = (result.u64 >> 16) & 0xFFFF;
+    } else if (opType == BB128_TYPE) {
+      // b128
+      result.u128.lowest = get_reg(op.vec_symbol(0)).u32;
+      result.u128.low = get_reg(op.vec_symbol(1)).u32;
+      result.u128.high = get_reg(op.vec_symbol(2)).u32;
+      result.u128.highest = get_reg(op.vec_symbol(3)).u32;
+    } else {
+      // bb64 or ff64
+      result.bits.ls = get_reg(op.vec_symbol(0)).u32;
+      result.bits.ms = get_reg(op.vec_symbol(1)).u32;
+    }
+  } else if (op.get_double_operand_type() == 1) {
+    ptx_reg_t firstHalf, secondHalf;
+    firstHalf.u64 = get_reg(op.vec_symbol(0)).u64;
+    secondHalf.u64 = get_reg(op.vec_symbol(1)).u64;
+    if (op.get_operand_lohi() == 1)
+      secondHalf.u64 = secondHalf.u64 & 0xFFFF;
+    else if (op.get_operand_lohi() == 2)
+      secondHalf.u64 = (secondHalf.u64 >> 16) & 0xFFFF;
+    result.u64 = firstHalf.u64 + secondHalf.u64;
+  } else if (op.get_double_operand_type() == 2) {
+    // s[reg1 += reg2]
+    // reg1 is incremented after value is returned: the value returned is
+    // s[reg1]
+    ptx_reg_t firstHalf, secondHalf;
+    firstHalf.u64 = get_reg(op.vec_symbol(0)).u64;
+    secondHalf.u64 = get_reg(op.vec_symbol(1)).u64;
+    if (op.get_operand_lohi() == 1)
+      secondHalf.u64 = secondHalf.u64 & 0xFFFF;
+    else if (op.get_operand_lohi() == 2)
+      secondHalf.u64 = (secondHalf.u64 >> 16) & 0xFFFF;
+    result.u64 = firstHalf.u64;
+    firstHalf.u64 = firstHalf.u64 + secondHalf.u64;
+    set_reg(op.vec_symbol(0), firstHalf);
+  } else if (op.get_double_operand_type() == 3) {
+    // s[reg += immediate]
+    // reg is incremented after value is returned: the value returned is s[reg]
+    ptx_reg_t firstHalf;
+    firstHalf.u64 = get_reg(op.get_symbol()).u64;
+    result.u64 = firstHalf.u64;
+    firstHalf.u64 = firstHalf.u64 + op.get_addr_offset();
+    set_reg(op.get_symbol(), firstHalf);
   }
 
-void ptx_thread_info::resume_reg_thread(char * fname, symbol_table * symtab)
-{
+  ptx_reg_t finalResult;
+  memory_space *mem = NULL;
+  size_t size = 0;
+  int t = 0;
+  finalResult.u64 = 0;
 
+  // complete other cases for reading from memory, such as reading from other
+  // const memory
+  if ((op.get_addr_space() == global_space) && (derefFlag)) {
+    // global memory - g[4], g[$r0]
+    mem = thread->get_global_memory();
+    type_info_key::type_decode(opType, size, t);
+    mem->read(result.u32, size / 8, &finalResult.u128);
+    thread->m_last_effective_address = result.u32;
+    thread->m_last_memory_space = global_space;
 
-      FILE * fp2 = fopen(fname, "r");
-      assert(fp2!=NULL);
-      //m_regs.push_back( reg_map_t() );
-      char line [ 200 ];
-      while ( fgets ( line, sizeof line, fp2 ) != NULL )
-      {
-          symbol *reg;
-          char * pch;
-          pch = strtok (line," ");
-          char * name =pch;
-          reg= symtab->lookup(name);
-          ptx_reg_t data;
-          pch = strtok (NULL," "); 
-          data = atoi(pch);
-          pch = strtok (NULL," ");
-          pch = strtok (NULL," ");
-          m_regs.back()[reg] = data;
-      }
-      fclose ( fp2 );
-}
-    
+    if (opType == S16_TYPE || opType == S32_TYPE)
+      sign_extend(finalResult, size, dstInfo);
+  } else if ((op.get_addr_space() == shared_space) && (derefFlag)) {
+    // shared memory - s[4], s[$r0]
+    mem = thread->m_shared_mem;
+    type_info_key::type_decode(opType, size, t);
+    mem->read(result.u32, size / 8, &finalResult.u128);
+    thread->m_last_effective_address = result.u32;
+    thread->m_last_memory_space = shared_space;
 
-ptx_reg_t ptx_thread_info::get_reg( const symbol *reg )
-{
-   static bool unfound_register_warned = false;
-   assert( reg != NULL );
-   assert( !m_regs.empty() );
-   reg_map_t::iterator regs_iter = m_regs.back().find(reg);
-   if (regs_iter == m_regs.back().end()) {
-      assert( reg->type()->get_key().is_reg() );
-      const std::string &name = reg->name();
-      unsigned call_uid = m_callstack.back().m_call_uid;
-      ptx_reg_t uninit_reg;
-      uninit_reg.u32 = 0x0;
-      set_reg(reg, uninit_reg); // give it a value since we are going to warn the user anyway
-      std::string file_loc = get_location();
-      if( !unfound_register_warned ) {
-          printf("GPGPU-Sim PTX: WARNING (%s) ** reading undefined register \'%s\' (cuid:%u). Setting to 0X00000000. This is okay if you are simulating the native ISA"
-        		  "\n",
-                 file_loc.c_str(), name.c_str(), call_uid );
-          unfound_register_warned = true;
-      }
-      regs_iter = m_regs.back().find(reg);
-   }
-   if (m_enable_debug_trace ) 
-      m_debug_trace_regs_read.back()[ reg ] = regs_iter->second;
-   return regs_iter->second;
-}
+    if (opType == S16_TYPE || opType == S32_TYPE)
+      sign_extend(finalResult, size, dstInfo);
+  } else if ((op.get_addr_space() == const_space) && (derefFlag)) {
+    // const memory - ce0c1[4], ce0c1[$r0]
+    mem = thread->get_global_memory();
+    type_info_key::type_decode(opType, size, t);
+    mem->read((result.u32 + op.get_const_mem_offset()), size / 8,
+              &finalResult.u128);
+    thread->m_last_effective_address = result.u32;
+    thread->m_last_memory_space = const_space;
+    if (opType == S16_TYPE || opType == S32_TYPE)
+      sign_extend(finalResult, size, dstInfo);
+  } else if ((op.get_addr_space() == local_space) && (derefFlag)) {
+    // local memory - l0[4], l0[$r0]
+    mem = thread->m_local_mem;
+    type_info_key::type_decode(opType, size, t);
+    mem->read(result.u32, size / 8, &finalResult.u128);
+    thread->m_last_effective_address = result.u32;
+    thread->m_last_memory_space = local_space;
+    if (opType == S16_TYPE || opType == S32_TYPE)
+      sign_extend(finalResult, size, dstInfo);
+  } else {
+    finalResult = result;
+  }
 
-ptx_reg_t ptx_thread_info::get_operand_value( const operand_info &op, operand_info dstInfo, unsigned opType, ptx_thread_info *thread, int derefFlag )
-{
-   ptx_reg_t result, tmp;
-
-
-   if(op.get_double_operand_type() == 0) {
-      if(((opType != BB128_TYPE) && (opType != BB64_TYPE) && (opType != FF64_TYPE)) || (op.get_addr_space() != undefined_space)) {
-         if ( op.is_reg() ) {
-            result = get_reg( op.get_symbol() );
-         } else if ( op.is_builtin()) {
-            result.u32 = get_builtin( op.get_int(), op.get_addr_offset() );
-         } else  if(op.is_immediate_address()){
-    		 result.u64 = op.get_addr_offset();
-    	 } else if ( op.is_memory_operand() ) {
-            // a few options here...
-            const symbol *sym = op.get_symbol();
-            const type_info *type = sym->type();
-            const type_info_key &info = type->get_key();
-
-            if ( info.is_reg() ) {
-               const symbol *name = op.get_symbol();
-               result.u64 = get_reg(name).u64 + op.get_addr_offset(); 
-            } else if ( info.is_param_kernel() ) {
-               result.u64 = sym->get_address() + op.get_addr_offset();
-            } else if ( info.is_param_local() ) {
-               result.u64 = sym->get_address() + op.get_addr_offset();
-            } else if ( info.is_global() ) {
-               assert( op.get_addr_offset() == 0 );
-               result.u64 = sym->get_address();
-            } else if ( info.is_local() ) {
-               result.u64 = sym->get_address() + op.get_addr_offset();
-            } else if ( info.is_const() ) {
-               result.u64 = sym->get_address() + op.get_addr_offset();
-            } else if ( op.is_shared() ) {
-               result.u64 = op.get_symbol()->get_address() + op.get_addr_offset();
-            } else if ( op.is_sstarr() ) {
-               result.u64 = op.get_symbol()->get_address() + op.get_addr_offset();
-            } else {
-                 const char *name = op.name().c_str();
-	    	printf("GPGPU-Sim PTX: ERROR ** get_operand_value : unknown memory operand type for %s\n", name );
-            	abort();
-            }
-
-         } else if ( op.is_literal() ) {
-            result = op.get_literal_value();
-         } else if ( op.is_label() ) {
-            result.u64 = op.get_symbol()->get_address();
-         } else if ( op.is_shared() ) {
-            result.u64 = op.get_symbol()->get_address();
-         } else if ( op.is_sstarr() ) {
-            result.u64 = op.get_symbol()->get_address();
-         } else if ( op.is_const() ) {
-            result.u64 = op.get_symbol()->get_address();
-         } else if ( op.is_global() ) {
-            result.u64 = op.get_symbol()->get_address();
-         } else if ( op.is_local() ) {
-            result.u64 = op.get_symbol()->get_address();
-         } else if ( op.is_function_address() ) {
-            result.u64 = (size_t)op.get_symbol()->get_pc();
-	 } else if ( op.is_param_kernel()) {
-            result.u64 = op.get_symbol()->get_address();
-         }else {
-            const char *name = op.name().c_str();
-            const symbol *sym2 = op.get_symbol();
-            const type_info *type2 = sym2->type();
-            const type_info_key &info2 = type2->get_key();
-            if ( info2.is_param_kernel() ) {
-               result.u64 = sym2->get_address()+ op.get_addr_offset();
-            }
-	    else{ 
-             printf("GPGPU-Sim PTX: ERROR ** get_operand_value : unknown operand type for %s\n", name );
-             assert(0);
-	    }
-         }
-
-         if(op.get_operand_lohi() == 1) 
-              result.u64 = result.u64 & 0xFFFF;
-         else if(op.get_operand_lohi() == 2) 
-              result.u64 = (result.u64>>16) & 0xFFFF;
-      } else if (opType == BB128_TYPE) {
-          // b128
-          result.u128.lowest = get_reg( op.vec_symbol(0) ).u32;
-          result.u128.low = get_reg( op.vec_symbol(1) ).u32;
-          result.u128.high = get_reg( op.vec_symbol(2) ).u32;
-          result.u128.highest = get_reg( op.vec_symbol(3) ).u32;
-      } else {
-          // bb64 or ff64
-          result.bits.ls = get_reg( op.vec_symbol(0) ).u32;
-          result.bits.ms = get_reg( op.vec_symbol(1) ).u32;
-      }
-   } else if (op.get_double_operand_type() == 1) {
-      ptx_reg_t firstHalf, secondHalf;
-      firstHalf.u64 = get_reg( op.vec_symbol(0) ).u64;
-      secondHalf.u64 = get_reg( op.vec_symbol(1) ).u64;
-      if(op.get_operand_lohi() == 1)
-           secondHalf.u64 = secondHalf.u64 & 0xFFFF;
-      else if(op.get_operand_lohi() == 2)
-           secondHalf.u64 = (secondHalf.u64>>16) & 0xFFFF;
-      result.u64 = firstHalf.u64 + secondHalf.u64;
-   } else if (op.get_double_operand_type() == 2) {
-      // s[reg1 += reg2]
-      // reg1 is incremented after value is returned: the value returned is s[reg1]
-      ptx_reg_t firstHalf, secondHalf;
-      firstHalf.u64 = get_reg(op.vec_symbol(0)).u64;
-      secondHalf.u64 = get_reg(op.vec_symbol(1)).u64;
-      if(op.get_operand_lohi() == 1)
-           secondHalf.u64 = secondHalf.u64 & 0xFFFF;
-      else if(op.get_operand_lohi() == 2)
-           secondHalf.u64 = (secondHalf.u64>>16) & 0xFFFF;
-      result.u64 = firstHalf.u64;
-      firstHalf.u64 = firstHalf.u64 + secondHalf.u64;
-      set_reg(op.vec_symbol(0),firstHalf);
-   } else if (op.get_double_operand_type() == 3) {
-      // s[reg += immediate]
-      // reg is incremented after value is returned: the value returned is s[reg]
-      ptx_reg_t firstHalf;
-      firstHalf.u64 = get_reg(op.get_symbol()).u64;
-      result.u64 = firstHalf.u64;
-      firstHalf.u64 = firstHalf.u64 + op.get_addr_offset();
-      set_reg(op.get_symbol(),firstHalf);
-   }
-
-   ptx_reg_t finalResult;
-   memory_space *mem = NULL;
-   size_t size=0;
-   int t=0;
-   finalResult.u64=0;
-
-   //complete other cases for reading from memory, such as reading from other const memory
-   if((op.get_addr_space() == global_space)&&(derefFlag)) {
-       // global memory - g[4], g[$r0]
-       mem = thread->get_global_memory();
-       type_info_key::type_decode(opType,size,t);
-       mem->read(result.u32,size/8,&finalResult.u128);
-       thread->m_last_effective_address = result.u32;
-       thread->m_last_memory_space = global_space;
-
-       if( opType == S16_TYPE || opType == S32_TYPE )
-         sign_extend(finalResult,size,dstInfo);
-   } else if((op.get_addr_space() == shared_space)&&(derefFlag)) {
-      // shared memory - s[4], s[$r0]
-       mem = thread->m_shared_mem;
-       type_info_key::type_decode(opType,size,t);
-       mem->read(result.u32,size/8,&finalResult.u128);
-       thread->m_last_effective_address = result.u32;
-       thread->m_last_memory_space = shared_space;
-
-       if( opType == S16_TYPE || opType == S32_TYPE ) 
-         sign_extend(finalResult,size,dstInfo);
-   } else if((op.get_addr_space() == const_space)&&(derefFlag)) {
-      // const memory - ce0c1[4], ce0c1[$r0]
-       mem = thread->get_global_memory();
-       type_info_key::type_decode(opType,size,t);
-       mem->read((result.u32 + op.get_const_mem_offset()),size/8,&finalResult.u128);
-       thread->m_last_effective_address = result.u32;
-       thread->m_last_memory_space = const_space;
-       if( opType == S16_TYPE || opType == S32_TYPE )
-         sign_extend(finalResult,size,dstInfo);
-   } else if((op.get_addr_space() == local_space)&&(derefFlag)) {
-      // local memory - l0[4], l0[$r0]
-       mem = thread->m_local_mem;
-       type_info_key::type_decode(opType,size,t);
-       mem->read(result.u32,size/8,&finalResult.u128);
-       thread->m_last_effective_address = result.u32;
-       thread->m_last_memory_space = local_space;
-       if( opType == S16_TYPE || opType == S32_TYPE ) 
-         sign_extend(finalResult,size,dstInfo);
-   } else {
-       finalResult = result;
-   }
-
-   if((op.get_operand_neg() == true)&&(derefFlag)) {
-      switch( opType ) {
+  if ((op.get_operand_neg() == true) && (derefFlag)) {
+    switch (opType) {
       // Default to f32 for now, need to add support for others
       case S8_TYPE:
       case U8_TYPE:
       case B8_TYPE:
-         finalResult.s8 = -finalResult.s8;
-         break;
+        finalResult.s8 = -finalResult.s8;
+        break;
       case S16_TYPE:
       case U16_TYPE:
       case B16_TYPE:
-         finalResult.s16 = -finalResult.s16;
-         break;
+        finalResult.s16 = -finalResult.s16;
+        break;
       case S32_TYPE:
       case U32_TYPE:
       case B32_TYPE:
-         finalResult.s32 = -finalResult.s32;
-         break;
+        finalResult.s32 = -finalResult.s32;
+        break;
       case S64_TYPE:
       case U64_TYPE:
       case B64_TYPE:
-         finalResult.s64 = -finalResult.s64;
-         break;
+        finalResult.s64 = -finalResult.s64;
+        break;
       case F16_TYPE:
-         finalResult.f16 = -finalResult.f16;
-         break;
+        finalResult.f16 = -finalResult.f16;
+        break;
       case F32_TYPE:
-         finalResult.f32 = -finalResult.f32;
-         break;
+        finalResult.f32 = -finalResult.f32;
+        break;
       case F64_TYPE:
       case FF64_TYPE:
-         finalResult.f64 = -finalResult.f64;
-         break;
+        finalResult.f64 = -finalResult.f64;
+        break;
       default:
-         assert(0);
-      }
-
-   }
-
-   return finalResult;
-
-}
-
-unsigned get_operand_nbits( const operand_info &op )
-{
-   if ( op.is_reg() ) {
-      const symbol *sym = op.get_symbol();
-      const type_info *typ = sym->type();
-      type_info_key t = typ->get_key();
-      switch( t.scalar_type() ) {
-      case PRED_TYPE: 
-         return 1;
-      case B8_TYPE: case S8_TYPE: case U8_TYPE:
-         return 8;
-      case S16_TYPE: case U16_TYPE: case F16_TYPE: case B16_TYPE:
-         return 16;
-      case S32_TYPE: case U32_TYPE: case F32_TYPE: case B32_TYPE:
-         return 32;
-      case S64_TYPE: case U64_TYPE: case F64_TYPE: case B64_TYPE:
-         return 64;
-      default:
-         printf("ERROR: unknown register type\n");
-         fflush(stdout);
-         abort();
-      }
-   } else {
-      printf("ERROR: Need to implement get_operand_nbits() for currently unsupported operand_info type\n");
-      fflush(stdout);
-      abort();
-   }
-
-   return 0;
-}
-
-void ptx_thread_info::get_vector_operand_values( const operand_info &op, ptx_reg_t* ptx_regs, unsigned num_elements )
-{
-   assert( op.is_vector() );
-   assert( num_elements <= 8 );
-
-   for (int idx = num_elements - 1; idx >= 0; --idx) {
-      const symbol *sym = NULL;
-      sym = op.vec_symbol(idx);
-      if( strcmp(sym->name().c_str(),"_") != 0) {
-         reg_map_t::iterator reg_iter = m_regs.back().find(sym);
-         assert( reg_iter != m_regs.back().end() );
-         ptx_regs[idx] = reg_iter->second;
-      }
-   }
-}
-
-void sign_extend( ptx_reg_t &data, unsigned src_size, const operand_info &dst )
-{
-   if( !dst.is_reg() )
-      return;
-   unsigned dst_size = get_operand_nbits( dst );
-   if( src_size >= dst_size ) 
-      return;
-   // src_size < dst_size
-   unsigned long long mask = 1;
-   mask <<= (src_size-1);
-   if( (mask & data.u64) == 0 ) {
-      // no need to sign extend
-      return;
-   }
-   // need to sign extend
-   mask = 1;
-   mask <<= dst_size-src_size;
-   mask -= 1;
-   mask <<= src_size;
-   data.u64 |= mask;
-}
-
-void ptx_thread_info::set_operand_value( const operand_info &dst, const ptx_reg_t &data, unsigned type, ptx_thread_info *thread, const ptx_instruction *pI, int overflow, int carry )
-{
-    thread->set_operand_value( dst, data, type, thread, pI );
-
-    if (dst.get_double_operand_type() == -2)
-    {
-        ptx_reg_t predValue;
-        
-        const symbol *sym = dst.vec_symbol(0);
-        predValue.u64 = (m_regs.back()[ sym ].u64) & ~(0x0C);
-        predValue.u64 |= ((overflow & 0x01)<<3);
-        predValue.u64 |= ((carry & 0x01)<<2);
-
-        set_reg(sym,predValue);
-    }
-    else if (dst.get_double_operand_type() == 0)
-    {
-        //intentionally do nothing
-    }
-    else
-    {
-        printf("Unexpected double destination\n");
         assert(0);
     }
+  }
 
+  return finalResult;
 }
 
-void ptx_thread_info::set_operand_value( const operand_info &dst, const ptx_reg_t &data, unsigned type, ptx_thread_info *thread, const ptx_instruction *pI )
-{
-   ptx_reg_t dstData;
-   memory_space *mem = NULL;
-   size_t size;
-   int t;
+unsigned get_operand_nbits(const operand_info &op) {
+  if (op.is_reg()) {
+    const symbol *sym = op.get_symbol();
+    const type_info *typ = sym->type();
+    type_info_key t = typ->get_key();
+    switch (t.scalar_type()) {
+      case PRED_TYPE:
+        return 1;
+      case B8_TYPE:
+      case S8_TYPE:
+      case U8_TYPE:
+        return 8;
+      case S16_TYPE:
+      case U16_TYPE:
+      case F16_TYPE:
+      case B16_TYPE:
+        return 16;
+      case S32_TYPE:
+      case U32_TYPE:
+      case F32_TYPE:
+      case B32_TYPE:
+        return 32;
+      case S64_TYPE:
+      case U64_TYPE:
+      case F64_TYPE:
+      case B64_TYPE:
+        return 64;
+      default:
+        printf("ERROR: unknown register type\n");
+        fflush(stdout);
+        abort();
+    }
+  } else {
+    printf(
+        "ERROR: Need to implement get_operand_nbits() for currently "
+        "unsupported operand_info type\n");
+    fflush(stdout);
+    abort();
+  }
 
-   type_info_key::type_decode(type,size,t);
-
-   /*complete this section for other cases*/
-   if(dst.get_addr_space() == undefined_space)
-   {
-      ptx_reg_t setValue;
-      setValue.u64 = data.u64;
-
-      // Double destination in set instruction ($p0|$p1) - second is negation of first
-      if (dst.get_double_operand_type() == -1)
-      {
-          ptx_reg_t setValue2;
-          const symbol *name1 = dst.vec_symbol(0);
-          const symbol *name2 = dst.vec_symbol(1);
-
-          if ( (type==F16_TYPE)||(type==F32_TYPE)||(type==F64_TYPE)||(type==FF64_TYPE) ) {
-             setValue2.f32 = (setValue.u64==0)?1.0f:0.0f;
-          } else {
-             setValue2.u32 = (setValue.u64==0)?0xFFFFFFFF:0;
-          }
-
-          set_reg(name1,setValue);
-          set_reg(name2,setValue2);
-      }
-
-      // Double destination in cvt,shr,mul,etc. instruction ($p0|$r4) - second register operand receives data, first predicate operand
-      // is set as $p0=($r4!=0)
-      // Also for Double destination in set instruction ($p0/$r1)
-      else if ((dst.get_double_operand_type() == -2)||(dst.get_double_operand_type() == -3))
-      {
-          ptx_reg_t predValue;
-          const symbol *predName = dst.vec_symbol(0);
-          const symbol *regName = dst.vec_symbol(1);
-          predValue.u64 = 0;
-
-          switch ( type ) {
-          case S8_TYPE:
-              if((setValue.s8 & 0x7F) == 0)
-                  predValue.u64 |= 1;
-              break;
-          case S16_TYPE:
-              if((setValue.s16 & 0x7FFF) == 0)
-                  predValue.u64 |= 1;
-              break;
-          case S32_TYPE:
-              if((setValue.s32 & 0x7FFFFFFF) == 0)
-                  predValue.u64 |= 1;
-              break;
-          case S64_TYPE:
-              if((setValue.s64 & 0x7FFFFFFFFFFFFFFF) == 0)
-                  predValue.u64 |= 1;
-              break;
-          case U8_TYPE:
-          case B8_TYPE:
-              if(setValue.u8 == 0)
-                  predValue.u64 |= 1;
-              break;
-          case U16_TYPE:
-          case B16_TYPE:
-              if(setValue.u16 == 0)
-                  predValue.u64 |= 1;
-              break;
-          case U32_TYPE:
-          case B32_TYPE:
-              if(setValue.u32 == 0)
-                  predValue.u64 |= 1;
-              break;
-          case U64_TYPE:
-          case B64_TYPE:
-              if(setValue.u64 == 0)
-                  predValue.u64 |= 1;
-              break;
-          case F16_TYPE:
-              if(setValue.f16 == 0)
-                  predValue.u64 |= 1;
-              break;
-          case F32_TYPE:
-              if(setValue.f32 == 0)
-                  predValue.u64 |= 1;
-              break;
-          case F64_TYPE:
-          case FF64_TYPE:
-              if(setValue.f64 == 0)
-                  predValue.u64 |= 1;
-              break;
-          default: assert(0); break;
-          }
-
-
-          if ( (type==S8_TYPE)||(type==S16_TYPE)||(type==S32_TYPE)||(type==S64_TYPE)||
-               (type==U8_TYPE)||(type==U16_TYPE)||(type==U32_TYPE)||(type==U64_TYPE)||
-               (type==B8_TYPE)||(type==B16_TYPE)||(type==B32_TYPE)||(type==B64_TYPE)) {
-              if((setValue.u32 & (1<<(size-1))) != 0)
-                  predValue.u64 |= 1<<1;
-          }
-          if ( type==F32_TYPE ) {
-              if(setValue.f32 < 0)
-                  predValue.u64 |= 1<<1;
-          }
-
-          if(dst.get_operand_lohi() == 1)
-          {
-              setValue.u64 = ((m_regs.back()[ regName ].u64) & (~(0xFFFF))) + (data.u64 & 0xFFFF);
-          }
-          else if(dst.get_operand_lohi() == 2)
-          {
-              setValue.u64 = ((m_regs.back()[ regName ].u64) & (~(0xFFFF0000))) + ((data.u64<<16) & 0xFFFF0000);
-          }
-
-          set_reg(predName,predValue);
-          set_reg(regName,setValue);
-      }
-      else if (type == BB128_TYPE)
-      {
-          //b128 stuff here.
-          ptx_reg_t setValue2, setValue3, setValue4;
-          setValue.u64 = 0;
-          setValue2.u64 = 0;
-          setValue3.u64 = 0;
-          setValue4.u64 = 0;
-          setValue.u32 = data.u128.lowest;
-          setValue2.u32 = data.u128.low;
-          setValue3.u32 = data.u128.high;
-          setValue4.u32 = data.u128.highest;
-
-          const symbol *name1, *name2, *name3, *name4 = NULL;
-
-          name1 = dst.vec_symbol(0);
-          name2 = dst.vec_symbol(1);
-          name3 = dst.vec_symbol(2);
-          name4 = dst.vec_symbol(3);
-
-          set_reg(name1,setValue);
-          set_reg(name2,setValue2);
-          set_reg(name3,setValue3);
-          set_reg(name4,setValue4);
-      }
-      else if (type == BB64_TYPE || type == FF64_TYPE)
-      {
-          //ptxplus version of storing 64 bit values to registers stores to two adjacent registers
-          ptx_reg_t setValue2;
-          setValue.u32 = 0;
-          setValue2.u32 = 0;
-
-          setValue.u32 = data.bits.ls;
-          setValue2.u32 = data.bits.ms;
-
-          const symbol *name1, *name2 = NULL;
-
-          name1 = dst.vec_symbol(0);
-          name2 = dst.vec_symbol(1);
-
-          set_reg(name1,setValue);
-          set_reg(name2,setValue2);
-      }
-      else
-      {
-          if(dst.get_operand_lohi() == 1)
-          {
-              setValue.u64 = ((m_regs.back()[ dst.get_symbol() ].u64) & (~(0xFFFF))) + (data.u64 & 0xFFFF);
-          }
-          else if(dst.get_operand_lohi() == 2)
-          {
-              setValue.u64 = ((m_regs.back()[ dst.get_symbol() ].u64) & (~(0xFFFF0000))) + ((data.u64<<16) & 0xFFFF0000);
-          }
-          set_reg(dst.get_symbol(),setValue);
-      }
-   }
-
-   // global memory - g[4], g[$r0]
-   else if(dst.get_addr_space() == global_space)
-   {
-       dstData = thread->get_operand_value(dst, dst, type, thread, 0);
-       mem = thread->get_global_memory();
-       type_info_key::type_decode(type,size,t);
-
-       mem->write(dstData.u32,size/8,&data.u128,thread,pI);
-       thread->m_last_effective_address = dstData.u32;
-       thread->m_last_memory_space = global_space;
-   }
-
-   // shared memory - s[4], s[$r0]
-   else if(dst.get_addr_space() == shared_space)
-   {
-       dstData = thread->get_operand_value(dst, dst, type, thread, 0);
-       mem = thread->m_shared_mem;
-       type_info_key::type_decode(type,size,t);
-
-       mem->write(dstData.u32,size/8,&data.u128,thread,pI);
-       thread->m_last_effective_address = dstData.u32;
-       thread->m_last_memory_space = shared_space;
-   }
-
-   // local memory - l0[4], l0[$r0]
-   else if(dst.get_addr_space() == local_space)
-   {
-       dstData = thread->get_operand_value(dst, dst, type, thread, 0);
-       mem = thread->m_local_mem;
-       type_info_key::type_decode(type,size,t);
-
-       mem->write(dstData.u32,size/8,&data.u128,thread,pI);
-       thread->m_last_effective_address = dstData.u32;
-       thread->m_last_memory_space = local_space;
-   }
-
-   else
-   {
-       printf("Destination stores to unknown location.");
-       assert(0);
-   }
-
-
+  return 0;
 }
 
-void ptx_thread_info::set_vector_operand_values( const operand_info &dst, 
-                                                 const ptx_reg_t &data1, 
-                                                 const ptx_reg_t &data2, 
-                                                 const ptx_reg_t &data3, 
-                                                 const ptx_reg_t &data4 )
-{
-   unsigned num_elements = dst.get_vect_nelem(); 
-   if (num_elements > 0) {
-       set_reg(dst.vec_symbol(0), data1);
-       if (num_elements > 1) {
-           set_reg(dst.vec_symbol(1), data2);
-           if (num_elements > 2) {
-              set_reg(dst.vec_symbol(2), data3);
-              if (num_elements > 3) {
-                 set_reg(dst.vec_symbol(3), data4);
-              }
-           }
-       }
-   }
+void ptx_thread_info::get_vector_operand_values(const operand_info &op,
+                                                ptx_reg_t *ptx_regs,
+                                                unsigned num_elements) {
+  assert(op.is_vector());
+  assert(num_elements <= 8);
 
-   m_last_set_operand_value = data1;
-}
-void ptx_thread_info::set_wmma_vector_operand_values( const operand_info &dst, 
-                                                 const ptx_reg_t &data1, 
-                                                 const ptx_reg_t &data2, 
-                                                 const ptx_reg_t &data3, 
-                                                 const ptx_reg_t &data4, 
-                                                 const ptx_reg_t &data5, 
-                                                 const ptx_reg_t &data6, 
-                                                 const ptx_reg_t &data7, 
-                                                 const ptx_reg_t &data8 )
-{
-   unsigned num_elements = dst.get_vect_nelem(); 
-   if (num_elements == 8) {
-       set_reg(dst.vec_symbol(0), data1);
-       set_reg(dst.vec_symbol(1), data2);
-       set_reg(dst.vec_symbol(2), data3);
-       set_reg(dst.vec_symbol(3), data4);
-       set_reg(dst.vec_symbol(4), data5);
-       set_reg(dst.vec_symbol(5), data6);
-       set_reg(dst.vec_symbol(6), data7);
-       set_reg(dst.vec_symbol(7), data8);
-   }
-   else{
-	printf("error:set_wmma_vector_operands");
-   }
-
-   m_last_set_operand_value = data8;
+  for (int idx = num_elements - 1; idx >= 0; --idx) {
+    const symbol *sym = NULL;
+    sym = op.vec_symbol(idx);
+    if (strcmp(sym->name().c_str(), "_") != 0) {
+      reg_map_t::iterator reg_iter = m_regs.back().find(sym);
+      assert(reg_iter != m_regs.back().end());
+      ptx_regs[idx] = reg_iter->second;
+    }
+  }
 }
 
-#define my_abs(a) (((a)<0)?(-a):(a))
+void sign_extend(ptx_reg_t &data, unsigned src_size, const operand_info &dst) {
+  if (!dst.is_reg()) return;
+  unsigned dst_size = get_operand_nbits(dst);
+  if (src_size >= dst_size) return;
+  // src_size < dst_size
+  unsigned long long mask = 1;
+  mask <<= (src_size - 1);
+  if ((mask & data.u64) == 0) {
+    // no need to sign extend
+    return;
+  }
+  // need to sign extend
+  mask = 1;
+  mask <<= dst_size - src_size;
+  mask -= 1;
+  mask <<= src_size;
+  data.u64 |= mask;
+}
 
-#define MY_MAX_I(a,b) (a > b) ? a : b
-#define MY_MAX_F(a,b) isNaN(a) ? b : isNaN(b) ? a : (a > b) ? a : b
+void ptx_thread_info::set_operand_value(const operand_info &dst,
+                                        const ptx_reg_t &data, unsigned type,
+                                        ptx_thread_info *thread,
+                                        const ptx_instruction *pI, int overflow,
+                                        int carry) {
+  thread->set_operand_value(dst, data, type, thread, pI);
 
-#define MY_MIN_I(a,b) (a < b) ? a : b
-#define MY_MIN_F(a,b) isNaN(a) ? b : isNaN(b) ? a : (a < b) ? a : b
+  if (dst.get_double_operand_type() == -2) {
+    ptx_reg_t predValue;
 
-#define MY_INC_I(a,b) (a >= b) ? 0 : a+1
-#define MY_DEC_I(a,b) ((a == 0) || (a > b)) ? b : a-1
+    const symbol *sym = dst.vec_symbol(0);
+    predValue.u64 = (m_regs.back()[sym].u64) & ~(0x0C);
+    predValue.u64 |= ((overflow & 0x01) << 3);
+    predValue.u64 |= ((carry & 0x01) << 2);
 
-#define MY_CAS_I(a,b,c) (a == b) ? c : a
+    set_reg(sym, predValue);
+  } else if (dst.get_double_operand_type() == 0) {
+    // intentionally do nothing
+  } else {
+    printf("Unexpected double destination\n");
+    assert(0);
+  }
+}
 
-#define MY_EXCH(a,b) b
+void ptx_thread_info::set_operand_value(const operand_info &dst,
+                                        const ptx_reg_t &data, unsigned type,
+                                        ptx_thread_info *thread,
+                                        const ptx_instruction *pI) {
+  ptx_reg_t dstData;
+  memory_space *mem = NULL;
+  size_t size;
+  int t;
 
-void abs_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t a, d;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
+  type_info_key::type_decode(type, size, t);
 
-   unsigned i_type = pI->get_type();
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  /*complete this section for other cases*/
+  if (dst.get_addr_space() == undefined_space) {
+    ptx_reg_t setValue;
+    setValue.u64 = data.u64;
 
+    // Double destination in set instruction ($p0|$p1) - second is negation of
+    // first
+    if (dst.get_double_operand_type() == -1) {
+      ptx_reg_t setValue2;
+      const symbol *name1 = dst.vec_symbol(0);
+      const symbol *name2 = dst.vec_symbol(1);
 
-   switch ( i_type ) {
-   case S16_TYPE: d.s16 = my_abs(a.s16); break;
-   case S32_TYPE: d.s32 = my_abs(a.s32); break;
-   case S64_TYPE: d.s64 = my_abs(a.s64); break;
-   case U16_TYPE: d.s16 = my_abs(a.u16); break;
-   case U32_TYPE: d.s32 = my_abs(a.u32); break;
-   case U64_TYPE: d.s64 = my_abs(a.u64); break;
-   case F32_TYPE: d.f32 = my_abs(a.f32); break;
-   case F64_TYPE: case FF64_TYPE: d.f64 = my_abs(a.f64); break;
-   default:
+      if ((type == F16_TYPE) || (type == F32_TYPE) || (type == F64_TYPE) ||
+          (type == FF64_TYPE)) {
+        setValue2.f32 = (setValue.u64 == 0) ? 1.0f : 0.0f;
+      } else {
+        setValue2.u32 = (setValue.u64 == 0) ? 0xFFFFFFFF : 0;
+      }
+
+      set_reg(name1, setValue);
+      set_reg(name2, setValue2);
+    }
+
+    // Double destination in cvt,shr,mul,etc. instruction ($p0|$r4) - second
+    // register operand receives data, first predicate operand
+    // is set as $p0=($r4!=0)
+    // Also for Double destination in set instruction ($p0/$r1)
+    else if ((dst.get_double_operand_type() == -2) ||
+             (dst.get_double_operand_type() == -3)) {
+      ptx_reg_t predValue;
+      const symbol *predName = dst.vec_symbol(0);
+      const symbol *regName = dst.vec_symbol(1);
+      predValue.u64 = 0;
+
+      switch (type) {
+        case S8_TYPE:
+          if ((setValue.s8 & 0x7F) == 0) predValue.u64 |= 1;
+          break;
+        case S16_TYPE:
+          if ((setValue.s16 & 0x7FFF) == 0) predValue.u64 |= 1;
+          break;
+        case S32_TYPE:
+          if ((setValue.s32 & 0x7FFFFFFF) == 0) predValue.u64 |= 1;
+          break;
+        case S64_TYPE:
+          if ((setValue.s64 & 0x7FFFFFFFFFFFFFFF) == 0) predValue.u64 |= 1;
+          break;
+        case U8_TYPE:
+        case B8_TYPE:
+          if (setValue.u8 == 0) predValue.u64 |= 1;
+          break;
+        case U16_TYPE:
+        case B16_TYPE:
+          if (setValue.u16 == 0) predValue.u64 |= 1;
+          break;
+        case U32_TYPE:
+        case B32_TYPE:
+          if (setValue.u32 == 0) predValue.u64 |= 1;
+          break;
+        case U64_TYPE:
+        case B64_TYPE:
+          if (setValue.u64 == 0) predValue.u64 |= 1;
+          break;
+        case F16_TYPE:
+          if (setValue.f16 == 0) predValue.u64 |= 1;
+          break;
+        case F32_TYPE:
+          if (setValue.f32 == 0) predValue.u64 |= 1;
+          break;
+        case F64_TYPE:
+        case FF64_TYPE:
+          if (setValue.f64 == 0) predValue.u64 |= 1;
+          break;
+        default:
+          assert(0);
+          break;
+      }
+
+      if ((type == S8_TYPE) || (type == S16_TYPE) || (type == S32_TYPE) ||
+          (type == S64_TYPE) || (type == U8_TYPE) || (type == U16_TYPE) ||
+          (type == U32_TYPE) || (type == U64_TYPE) || (type == B8_TYPE) ||
+          (type == B16_TYPE) || (type == B32_TYPE) || (type == B64_TYPE)) {
+        if ((setValue.u32 & (1 << (size - 1))) != 0) predValue.u64 |= 1 << 1;
+      }
+      if (type == F32_TYPE) {
+        if (setValue.f32 < 0) predValue.u64 |= 1 << 1;
+      }
+
+      if (dst.get_operand_lohi() == 1) {
+        setValue.u64 =
+            ((m_regs.back()[regName].u64) & (~(0xFFFF))) + (data.u64 & 0xFFFF);
+      } else if (dst.get_operand_lohi() == 2) {
+        setValue.u64 = ((m_regs.back()[regName].u64) & (~(0xFFFF0000))) +
+                       ((data.u64 << 16) & 0xFFFF0000);
+      }
+
+      set_reg(predName, predValue);
+      set_reg(regName, setValue);
+    } else if (type == BB128_TYPE) {
+      // b128 stuff here.
+      ptx_reg_t setValue2, setValue3, setValue4;
+      setValue.u64 = 0;
+      setValue2.u64 = 0;
+      setValue3.u64 = 0;
+      setValue4.u64 = 0;
+      setValue.u32 = data.u128.lowest;
+      setValue2.u32 = data.u128.low;
+      setValue3.u32 = data.u128.high;
+      setValue4.u32 = data.u128.highest;
+
+      const symbol *name1, *name2, *name3, *name4 = NULL;
+
+      name1 = dst.vec_symbol(0);
+      name2 = dst.vec_symbol(1);
+      name3 = dst.vec_symbol(2);
+      name4 = dst.vec_symbol(3);
+
+      set_reg(name1, setValue);
+      set_reg(name2, setValue2);
+      set_reg(name3, setValue3);
+      set_reg(name4, setValue4);
+    } else if (type == BB64_TYPE || type == FF64_TYPE) {
+      // ptxplus version of storing 64 bit values to registers stores to two
+      // adjacent registers
+      ptx_reg_t setValue2;
+      setValue.u32 = 0;
+      setValue2.u32 = 0;
+
+      setValue.u32 = data.bits.ls;
+      setValue2.u32 = data.bits.ms;
+
+      const symbol *name1, *name2 = NULL;
+
+      name1 = dst.vec_symbol(0);
+      name2 = dst.vec_symbol(1);
+
+      set_reg(name1, setValue);
+      set_reg(name2, setValue2);
+    } else {
+      if (dst.get_operand_lohi() == 1) {
+        setValue.u64 = ((m_regs.back()[dst.get_symbol()].u64) & (~(0xFFFF))) +
+                       (data.u64 & 0xFFFF);
+      } else if (dst.get_operand_lohi() == 2) {
+        setValue.u64 =
+            ((m_regs.back()[dst.get_symbol()].u64) & (~(0xFFFF0000))) +
+            ((data.u64 << 16) & 0xFFFF0000);
+      }
+      set_reg(dst.get_symbol(), setValue);
+    }
+  }
+
+  // global memory - g[4], g[$r0]
+  else if (dst.get_addr_space() == global_space) {
+    dstData = thread->get_operand_value(dst, dst, type, thread, 0);
+    mem = thread->get_global_memory();
+    type_info_key::type_decode(type, size, t);
+
+    mem->write(dstData.u32, size / 8, &data.u128, thread, pI);
+    thread->m_last_effective_address = dstData.u32;
+    thread->m_last_memory_space = global_space;
+  }
+
+  // shared memory - s[4], s[$r0]
+  else if (dst.get_addr_space() == shared_space) {
+    dstData = thread->get_operand_value(dst, dst, type, thread, 0);
+    mem = thread->m_shared_mem;
+    type_info_key::type_decode(type, size, t);
+
+    mem->write(dstData.u32, size / 8, &data.u128, thread, pI);
+    thread->m_last_effective_address = dstData.u32;
+    thread->m_last_memory_space = shared_space;
+  }
+
+  // local memory - l0[4], l0[$r0]
+  else if (dst.get_addr_space() == local_space) {
+    dstData = thread->get_operand_value(dst, dst, type, thread, 0);
+    mem = thread->m_local_mem;
+    type_info_key::type_decode(type, size, t);
+
+    mem->write(dstData.u32, size / 8, &data.u128, thread, pI);
+    thread->m_last_effective_address = dstData.u32;
+    thread->m_last_memory_space = local_space;
+  }
+
+  else {
+    printf("Destination stores to unknown location.");
+    assert(0);
+  }
+}
+
+void ptx_thread_info::set_vector_operand_values(const operand_info &dst,
+                                                const ptx_reg_t &data1,
+                                                const ptx_reg_t &data2,
+                                                const ptx_reg_t &data3,
+                                                const ptx_reg_t &data4) {
+  unsigned num_elements = dst.get_vect_nelem();
+  if (num_elements > 0) {
+    set_reg(dst.vec_symbol(0), data1);
+    if (num_elements > 1) {
+      set_reg(dst.vec_symbol(1), data2);
+      if (num_elements > 2) {
+        set_reg(dst.vec_symbol(2), data3);
+        if (num_elements > 3) {
+          set_reg(dst.vec_symbol(3), data4);
+        }
+      }
+    }
+  }
+
+  m_last_set_operand_value = data1;
+}
+void ptx_thread_info::set_wmma_vector_operand_values(
+    const operand_info &dst, const ptx_reg_t &data1, const ptx_reg_t &data2,
+    const ptx_reg_t &data3, const ptx_reg_t &data4, const ptx_reg_t &data5,
+    const ptx_reg_t &data6, const ptx_reg_t &data7, const ptx_reg_t &data8) {
+  unsigned num_elements = dst.get_vect_nelem();
+  if (num_elements == 8) {
+    set_reg(dst.vec_symbol(0), data1);
+    set_reg(dst.vec_symbol(1), data2);
+    set_reg(dst.vec_symbol(2), data3);
+    set_reg(dst.vec_symbol(3), data4);
+    set_reg(dst.vec_symbol(4), data5);
+    set_reg(dst.vec_symbol(5), data6);
+    set_reg(dst.vec_symbol(6), data7);
+    set_reg(dst.vec_symbol(7), data8);
+  } else {
+    printf("error:set_wmma_vector_operands");
+  }
+
+  m_last_set_operand_value = data8;
+}
+
+#define my_abs(a) (((a) < 0) ? (-a) : (a))
+
+#define MY_MAX_I(a, b) (a > b) ? a : b
+#define MY_MAX_F(a, b) isNaN(a) ? b : isNaN(b) ? a : (a > b) ? a : b
+
+#define MY_MIN_I(a, b) (a < b) ? a : b
+#define MY_MIN_F(a, b) isNaN(a) ? b : isNaN(b) ? a : (a < b) ? a : b
+
+#define MY_INC_I(a, b) (a >= b) ? 0 : a + 1
+#define MY_DEC_I(a, b) ((a == 0) || (a > b)) ? b : a - 1
+
+#define MY_CAS_I(a, b, c) (a == b) ? c : a
+
+#define MY_EXCH(a, b) b
+
+void abs_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, d;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+
+  unsigned i_type = pI->get_type();
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+
+  switch (i_type) {
+    case S16_TYPE:
+      d.s16 = my_abs(a.s16);
+      break;
+    case S32_TYPE:
+      d.s32 = my_abs(a.s32);
+      break;
+    case S64_TYPE:
+      d.s64 = my_abs(a.s64);
+      break;
+    case U16_TYPE:
+      d.s16 = my_abs(a.u16);
+      break;
+    case U32_TYPE:
+      d.s32 = my_abs(a.u32);
+      break;
+    case U64_TYPE:
+      d.s64 = my_abs(a.u64);
+      break;
+    case F32_TYPE:
+      d.f32 = my_abs(a.f32);
+      break;
+    case F64_TYPE:
+    case FF64_TYPE:
+      d.f64 = my_abs(a.f64);
+      break;
+    default:
       printf("Execution error: type mismatch with instruction\n");
       assert(0);
       break;
-   }
+  }
 
-   thread->set_operand_value(dst,d, i_type, thread, pI);
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-void addp_impl( const ptx_instruction *pI, ptx_thread_info *thread )
-{
-   //PTXPlus add instruction with carry (carry is kept in a predicate) register
-   ptx_reg_t src1_data, src2_data, src3_data, data;
-   int overflow = 0;
-   int carry = 0;
+void addp_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  // PTXPlus add instruction with carry (carry is kept in a predicate) register
+  ptx_reg_t src1_data, src2_data, src3_data, data;
+  int overflow = 0;
+  int carry = 0;
 
-   const operand_info &dst  = pI->dst();  //get operand info of sources and destination
-   const operand_info &src1 = pI->src1(); //use them to determine that they are of type 'register'
-   const operand_info &src2 = pI->src2();
-   const operand_info &src3 = pI->src3();
+  const operand_info &dst =
+      pI->dst();  // get operand info of sources and destination
+  const operand_info &src1 =
+      pI->src1();  // use them to determine that they are of type 'register'
+  const operand_info &src2 = pI->src2();
+  const operand_info &src3 = pI->src3();
 
-   unsigned i_type = pI->get_type();
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
-   src3_data = thread->get_operand_value(src3, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  src3_data = thread->get_operand_value(src3, dst, i_type, thread, 1);
 
-   unsigned rounding_mode = pI->rounding_mode();
-   int orig_rm = fegetround();
-   switch ( rounding_mode ) {
-   case RN_OPTION: break;
-   case RZ_OPTION: fesetround( FE_TOWARDZERO ); break;
-   default: assert(0); break;
-   }
-
-   //performs addition. Sets carry and overflow if needed.
-   //src3_data.pred&0x4 is the carry flag
-   switch ( i_type ) {
-   case S8_TYPE:
-      data.s64 = (src1_data.s64 & 0x0000000FF) + (src2_data.s64 & 0x0000000FF) + (src3_data.pred & 0x4);
-      if(((src1_data.s64 & 0x80)-(src2_data.s64 & 0x80)) == 0) {overflow=((src1_data.s64 & 0x80)-(data.s64 & 0x80))==0?0:1; }
-      carry = (data.u64 & 0x000000100)>>8;
+  unsigned rounding_mode = pI->rounding_mode();
+  int orig_rm = fegetround();
+  switch (rounding_mode) {
+    case RN_OPTION:
       break;
-   case S16_TYPE:
-      data.s64 = (src1_data.s64 & 0x00000FFFF) + (src2_data.s64 & 0x00000FFFF) + (src3_data.pred & 0x4);
-      if(((src1_data.s64 & 0x8000)-(src2_data.s64 & 0x8000)) == 0) {overflow=((src1_data.s64 & 0x8000)-(data.s64 & 0x8000))==0?0:1; }
-      carry = (data.u64 & 0x000010000)>>16;
+    case RZ_OPTION:
+      fesetround(FE_TOWARDZERO);
       break;
-   case S32_TYPE:
-      data.s64 = (src1_data.s64 & 0x0FFFFFFFF) + (src2_data.s64 & 0x0FFFFFFFF) + (src3_data.pred & 0x4);
-      if(((src1_data.s64 & 0x80000000)-(src2_data.s64 & 0x80000000)) == 0) {overflow=((src1_data.s64 & 0x80000000)-(data.s64 & 0x80000000))==0?0:1; }
-      carry = (data.u64 & 0x100000000)>>32;
+    default:
+      assert(0);
       break;
-   case S64_TYPE:
+  }
+
+  // performs addition. Sets carry and overflow if needed.
+  // src3_data.pred&0x4 is the carry flag
+  switch (i_type) {
+    case S8_TYPE:
+      data.s64 = (src1_data.s64 & 0x0000000FF) + (src2_data.s64 & 0x0000000FF) +
+                 (src3_data.pred & 0x4);
+      if (((src1_data.s64 & 0x80) - (src2_data.s64 & 0x80)) == 0) {
+        overflow = ((src1_data.s64 & 0x80) - (data.s64 & 0x80)) == 0 ? 0 : 1;
+      }
+      carry = (data.u64 & 0x000000100) >> 8;
+      break;
+    case S16_TYPE:
+      data.s64 = (src1_data.s64 & 0x00000FFFF) + (src2_data.s64 & 0x00000FFFF) +
+                 (src3_data.pred & 0x4);
+      if (((src1_data.s64 & 0x8000) - (src2_data.s64 & 0x8000)) == 0) {
+        overflow =
+            ((src1_data.s64 & 0x8000) - (data.s64 & 0x8000)) == 0 ? 0 : 1;
+      }
+      carry = (data.u64 & 0x000010000) >> 16;
+      break;
+    case S32_TYPE:
+      data.s64 = (src1_data.s64 & 0x0FFFFFFFF) + (src2_data.s64 & 0x0FFFFFFFF) +
+                 (src3_data.pred & 0x4);
+      if (((src1_data.s64 & 0x80000000) - (src2_data.s64 & 0x80000000)) == 0) {
+        overflow = ((src1_data.s64 & 0x80000000) - (data.s64 & 0x80000000)) == 0
+                       ? 0
+                       : 1;
+      }
+      carry = (data.u64 & 0x100000000) >> 32;
+      break;
+    case S64_TYPE:
       data.s64 = src1_data.s64 + src2_data.s64 + (src3_data.pred & 0x4);
       break;
-   case U8_TYPE:
-      data.u64 = (src1_data.u64 & 0xFF) + (src2_data.u64 & 0xFF) + (src3_data.pred & 0x4);
-      carry = (data.u64 & 0x100)>>8;
+    case U8_TYPE:
+      data.u64 = (src1_data.u64 & 0xFF) + (src2_data.u64 & 0xFF) +
+                 (src3_data.pred & 0x4);
+      carry = (data.u64 & 0x100) >> 8;
       break;
-   case U16_TYPE:
-      data.u64 = (src1_data.u64 & 0xFFFF) + (src2_data.u64 & 0xFFFF) + (src3_data.pred & 0x4);
-      carry = (data.u64 & 0x10000)>>16;
+    case U16_TYPE:
+      data.u64 = (src1_data.u64 & 0xFFFF) + (src2_data.u64 & 0xFFFF) +
+                 (src3_data.pred & 0x4);
+      carry = (data.u64 & 0x10000) >> 16;
       break;
-   case U32_TYPE:
-      data.u64 = (src1_data.u64 & 0xFFFFFFFF) + (src2_data.u64 & 0xFFFFFFFF) + (src3_data.pred & 0x4);
-      carry = (data.u64 & 0x100000000)>>32;
+    case U32_TYPE:
+      data.u64 = (src1_data.u64 & 0xFFFFFFFF) + (src2_data.u64 & 0xFFFFFFFF) +
+                 (src3_data.pred & 0x4);
+      carry = (data.u64 & 0x100000000) >> 32;
       break;
-   case U64_TYPE:
+    case U64_TYPE:
       data.s64 = src1_data.s64 + src2_data.s64 + (src3_data.pred & 0x4);
       break;
-   case F16_TYPE: data.f16=src1_data.f16+src2_data.f16; break;//assert(0); break;
-   case F32_TYPE: data.f32 = src1_data.f32 + src2_data.f32; break;
-   case F64_TYPE: case FF64_TYPE: data.f64 = src1_data.f64 + src2_data.f64; break;
-   default: assert(0); break;
-   }
-   fesetround( orig_rm );
+    case F16_TYPE:
+      data.f16 = src1_data.f16 + src2_data.f16;
+      break;  // assert(0); break;
+    case F32_TYPE:
+      data.f32 = src1_data.f32 + src2_data.f32;
+      break;
+    case F64_TYPE:
+    case FF64_TYPE:
+      data.f64 = src1_data.f64 + src2_data.f64;
+      break;
+    default:
+      assert(0);
+      break;
+  }
+  fesetround(orig_rm);
 
-   thread->set_operand_value(dst, data, i_type, thread, pI, overflow, carry  );
+  thread->set_operand_value(dst, data, i_type, thread, pI, overflow, carry);
 }
 
-void add_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t src1_data, src2_data, data;
-   int overflow = 0;
-   int carry = 0;
+void add_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, src2_data, data;
+  int overflow = 0;
+  int carry = 0;
 
-   const operand_info &dst  = pI->dst();  //get operand info of sources and destination 
-   const operand_info &src1 = pI->src1(); //use them to determine that they are of type 'register'
-   const operand_info &src2 = pI->src2();
+  const operand_info &dst =
+      pI->dst();  // get operand info of sources and destination
+  const operand_info &src1 =
+      pI->src1();  // use them to determine that they are of type 'register'
+  const operand_info &src2 = pI->src2();
 
-   unsigned i_type = pI->get_type();
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-   unsigned rounding_mode = pI->rounding_mode();
-   int orig_rm = fegetround();
-   switch ( rounding_mode ) {
-   case RN_OPTION: break;
-   case RZ_OPTION: fesetround( FE_TOWARDZERO ); break;
-   default: assert(0); break;
-   }
+  unsigned rounding_mode = pI->rounding_mode();
+  int orig_rm = fegetround();
+  switch (rounding_mode) {
+    case RN_OPTION:
+      break;
+    case RZ_OPTION:
+      fesetround(FE_TOWARDZERO);
+      break;
+    default:
+      assert(0);
+      break;
+  }
 
-   //performs addition. Sets carry and overflow if needed.
-   switch ( i_type ) {
-   case S8_TYPE:
+  // performs addition. Sets carry and overflow if needed.
+  switch (i_type) {
+    case S8_TYPE:
       data.s64 = (src1_data.s64 & 0x0000000FF) + (src2_data.s64 & 0x0000000FF);
-      if(((src1_data.s64 & 0x80)-(src2_data.s64 & 0x80)) == 0) {overflow=((src1_data.s64 & 0x80)-(data.s64 & 0x80))==0?0:1; }
-      carry = (data.u64 & 0x000000100)>>8;
+      if (((src1_data.s64 & 0x80) - (src2_data.s64 & 0x80)) == 0) {
+        overflow = ((src1_data.s64 & 0x80) - (data.s64 & 0x80)) == 0 ? 0 : 1;
+      }
+      carry = (data.u64 & 0x000000100) >> 8;
       break;
-   case S16_TYPE:
+    case S16_TYPE:
       data.s64 = (src1_data.s64 & 0x00000FFFF) + (src2_data.s64 & 0x00000FFFF);
-      if(((src1_data.s64 & 0x8000)-(src2_data.s64 & 0x8000)) == 0) {overflow=((src1_data.s64 & 0x8000)-(data.s64 & 0x8000))==0?0:1; }
-      carry = (data.u64 & 0x000010000)>>16;
+      if (((src1_data.s64 & 0x8000) - (src2_data.s64 & 0x8000)) == 0) {
+        overflow =
+            ((src1_data.s64 & 0x8000) - (data.s64 & 0x8000)) == 0 ? 0 : 1;
+      }
+      carry = (data.u64 & 0x000010000) >> 16;
       break;
-   case S32_TYPE:
+    case S32_TYPE:
       data.s64 = (src1_data.s64 & 0x0FFFFFFFF) + (src2_data.s64 & 0x0FFFFFFFF);
-      if(((src1_data.s64 & 0x80000000)-(src2_data.s64 & 0x80000000)) == 0) {overflow=((src1_data.s64 & 0x80000000)-(data.s64 & 0x80000000))==0?0:1; }
-      carry = (data.u64 & 0x100000000)>>32;
+      if (((src1_data.s64 & 0x80000000) - (src2_data.s64 & 0x80000000)) == 0) {
+        overflow = ((src1_data.s64 & 0x80000000) - (data.s64 & 0x80000000)) == 0
+                       ? 0
+                       : 1;
+      }
+      carry = (data.u64 & 0x100000000) >> 32;
       break;
-   case S64_TYPE:
+    case S64_TYPE:
       data.s64 = src1_data.s64 + src2_data.s64;
       break;
-   case U8_TYPE:
+    case U8_TYPE:
       data.u64 = (src1_data.u64 & 0xFF) + (src2_data.u64 & 0xFF);
-      carry = (data.u64 & 0x100)>>8;
+      carry = (data.u64 & 0x100) >> 8;
       break;
-   case U16_TYPE:
+    case U16_TYPE:
       data.u64 = (src1_data.u64 & 0xFFFF) + (src2_data.u64 & 0xFFFF);
-      carry = (data.u64 & 0x10000)>>16;
+      carry = (data.u64 & 0x10000) >> 16;
       break;
-   case U32_TYPE:
+    case U32_TYPE:
       data.u64 = (src1_data.u64 & 0xFFFFFFFF) + (src2_data.u64 & 0xFFFFFFFF);
-      carry = (data.u64 & 0x100000000)>>32;
+      carry = (data.u64 & 0x100000000) >> 32;
       break;
-   case U64_TYPE:
+    case U64_TYPE:
       data.u64 = src1_data.u64 + src2_data.u64;
       break;
-   case F16_TYPE: data.f16=src1_data.f16+src2_data.f16; break;//assert(0); break;
-   case F32_TYPE: data.f32 = src1_data.f32 + src2_data.f32; break;
-   case F64_TYPE: case FF64_TYPE: data.f64 = src1_data.f64 + src2_data.f64; break;
-   default: assert(0); break;
-   }
-   fesetround( orig_rm );
-
-   thread->set_operand_value(dst, data, i_type, thread, pI, overflow, carry  );
-}
-
-void addc_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-
-void and_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t src1_data, src2_data, data;
-
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
-
-   unsigned i_type = pI->get_type();
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
-
-
-   //the way ptxplus handles predicates: 1 = false and 0 = true
-   if(i_type == PRED_TYPE)
-      data.pred = ~(~(src1_data.pred) & ~(src2_data.pred));
-   else
-      data.u64 = src1_data.u64 & src2_data.u64;
-
-   thread->set_operand_value(dst,data, i_type, thread, pI);
-}
-
-void andn_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t src1_data, src2_data, data;
-
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
-
-   unsigned i_type = pI->get_type();
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
-
-   switch ( i_type ) {
-   case B16_TYPE:  src2_data.u16  = ~src2_data.u16; break;
-   case B32_TYPE:  src2_data.u32  = ~src2_data.u32; break;
-   case B64_TYPE:  src2_data.u64  = ~src2_data.u64; break;
-   default:
-      printf("Execution error: type mismatch with instruction\n");
-      assert(0); 
+    case F16_TYPE:
+      data.f16 = src1_data.f16 + src2_data.f16;
+      break;  // assert(0); break;
+    case F32_TYPE:
+      data.f32 = src1_data.f32 + src2_data.f32;
       break;
-   }
-
-   data.u64 = src1_data.u64 & src2_data.u64;
-
-   thread->set_operand_value(dst,data, i_type, thread, pI);
-}
-
-void bar_callback( const inst_t* inst, ptx_thread_info* thread)
-{
-	unsigned ctaid = thread->get_cta_uid();
-	unsigned barid = inst->bar_id;
-	unsigned value = thread->get_reduction_value(ctaid,barid);
-	const ptx_instruction *pI = dynamic_cast<const ptx_instruction*>(inst);
-	const operand_info &dst  = pI->dst();
-	ptx_reg_t data;
-	data.u32 = value;
-	thread->set_operand_value(dst,value, U32_TYPE, thread, pI);
-}
-
-void atom_callback( const inst_t* inst, ptx_thread_info* thread)
-{
-   const ptx_instruction *pI = dynamic_cast<const ptx_instruction*>(inst);
-
-   // "Decode" the output type
-   unsigned to_type = pI->get_type();
-   size_t size;
-   int t;
-   type_info_key::type_decode(to_type, size, t);
-
-   // Set up operand variables
-   ptx_reg_t data;        // d
-   ptx_reg_t src1_data;   // a
-   ptx_reg_t src2_data;   // b
-   ptx_reg_t op_result;   // temp variable to hold operation result
-
-   bool data_ready = false;
-
-   // Get operand info of sources and destination
-   const operand_info &dst  = pI->dst();     // d
-   const operand_info &src1 = pI->src1();    // a
-   const operand_info &src2 = pI->src2();    // b
-
-   // Get operand values
-   src1_data = thread->get_operand_value(src1, src1, to_type, thread, 1);        // a
-   if (dst.get_symbol()->type()){
-      src2_data = thread->get_operand_value(src2, dst, to_type, thread, 1);      // b
-   } else {
-	   //This is the case whent he first argument (dest) is '_'
-      src2_data = thread->get_operand_value(src2, src1, to_type, thread, 1);     // b
-   }
-
-   // Check state space
-   addr_t effective_address = src1_data.u64;  
-   memory_space_t space = pI->get_space();
-   if (space == undefined_space) {
-      // generic space - determine space via address
-      if( whichspace(effective_address) == global_space ) {
-         effective_address = generic_to_global(effective_address);
-         space = global_space;
-      } else if( whichspace(effective_address) == shared_space ) {
-         unsigned smid = thread->get_hw_sid();
-         effective_address = generic_to_shared(smid,effective_address);
-         space = shared_space;
-      } else {
-         abort();
-      }
-   } 
-   assert( space == global_space || space == shared_space );
-
-   memory_space *mem = NULL;
-   if(space == global_space)
-       mem = thread->get_global_memory();
-   else if(space == shared_space)
-       mem = thread->m_shared_mem;
-   else
-       abort();
-
-   // Copy value pointed to in operand 'a' into register 'd'
-   // (i.e. copy src1_data to dst)
-   mem->read(effective_address,size/8,&data.s64);
-   if (dst.get_symbol()->type()){
-	   thread->set_operand_value(dst, data, to_type, thread, pI);                         // Write value into register 'd'
-   }
-
-   // Get the atomic operation to be performed
-   unsigned m_atomic_spec = pI->get_atomic();
-
-   switch ( m_atomic_spec ) {
-   // AND
-   case ATOMIC_AND:
-      {
-
-         switch ( to_type ) {
-         case B32_TYPE:
-         case U32_TYPE:
-            op_result.u32 = data.u32 & src2_data.u32;
-            data_ready = true;
-            break;
-         case S32_TYPE:
-            op_result.s32 = data.s32 & src2_data.s32;
-            data_ready = true;
-            break;
-         default:
-            printf("Execution error: type mismatch (%x) with instruction\natom.AND only accepts b32\n", to_type);
-            assert(0);
-            break;
-         }
-
-         break;
-      }
-      // OR
-   case ATOMIC_OR:
-      {
-
-         switch ( to_type ) {
-         case B32_TYPE:
-         case U32_TYPE:
-            op_result.u32 = data.u32 | src2_data.u32;
-            data_ready = true;
-            break;
-         case S32_TYPE:
-            op_result.s32 = data.s32 | src2_data.s32;
-            data_ready = true;
-            break;
-         default:
-            printf("Execution error: type mismatch (%x) with instruction\natom.OR only accepts b32\n", to_type);
-            assert(0);
-            break;
-         }
-
-         break;
-      }
-      // XOR
-   case ATOMIC_XOR:
-      {
-
-         switch ( to_type ) {
-         case B32_TYPE:
-         case U32_TYPE:
-            op_result.u32 = data.u32 ^ src2_data.u32;
-            data_ready = true;
-            break;
-         case S32_TYPE:
-            op_result.s32 = data.s32 ^ src2_data.s32;
-            data_ready = true;
-            break;
-         default:
-            printf("Execution error: type mismatch (%x) with instruction\natom.XOR only accepts b32\n", to_type);
-            assert(0);
-            break;
-         }
-
-         break;
-      }
-      // CAS
-   case ATOMIC_CAS:
-      {
-
-         ptx_reg_t src3_data;
-         const operand_info &src3 = pI->src3();
-         src3_data = thread->get_operand_value(src3, dst, to_type, thread, 1);
-
-         switch ( to_type ) {
-         case B32_TYPE:
-         case U32_TYPE:
-            op_result.u32 = MY_CAS_I(data.u32, src2_data.u32, src3_data.u32);
-            data_ready = true;
-            break;
-         case B64_TYPE:
-         case U64_TYPE:
-            op_result.u64 = MY_CAS_I(data.u64, src2_data.u64, src3_data.u64);
-            data_ready = true;
-            break;
-         case S32_TYPE:
-            op_result.s32 = MY_CAS_I(data.s32, src2_data.s32, src3_data.s32);
-            data_ready = true;
-            break;
-         default:
-            printf("Execution error: type mismatch (%x) with instruction\natom.CAS only accepts b32 and b64\n", to_type);
-            assert(0);
-            break;
-         }
-
-         break;
-      }
-      // EXCH
-   case ATOMIC_EXCH:
-      {
-         switch ( to_type ) {
-         case B32_TYPE:
-         case U32_TYPE:
-            op_result.u32 = MY_EXCH(data.u32, src2_data.u32);
-            data_ready = true;
-            break;
-         case B64_TYPE:
-         case U64_TYPE:
-            op_result.u64 = MY_EXCH(data.u64, src2_data.u64);
-            data_ready = true;
-            break;
-         case S32_TYPE:
-            op_result.s32 = MY_EXCH(data.s32, src2_data.s32);
-            data_ready = true;
-            break;
-         default:
-            printf("Execution error: type mismatch (%x) with instruction\natom.EXCH only accepts b32\n", to_type);
-            assert(0);
-            break;
-         }
-
-         break;
-      }
-      // ADD
-   case ATOMIC_ADD:
-      {
-
-         switch ( to_type ) {
-         case U32_TYPE:
-            op_result.u32 = data.u32 + src2_data.u32;
-            data_ready = true;
-            break;
-         case S32_TYPE:
-            op_result.s32 = data.s32 + src2_data.s32;
-            data_ready = true;
-            break;
-         case U64_TYPE: 
-            op_result.u64 = data.u64 + src2_data.u64; 
-            data_ready = true; 
-            break; 
-         case F32_TYPE: 
-            op_result.f32 = data.f32 + src2_data.f32; 
-            data_ready = true; 
-            break; 
-         default:
-            printf("Execution error: type mismatch with instruction\natom.ADD only accepts u32, s32, u64, and f32\n");
-            assert(0);
-            break;
-         }
-
-         break;
-      }
-      // INC
-   case ATOMIC_INC:
-      {
-         switch ( to_type ) {
-         case U32_TYPE: 
-            op_result.u32 = MY_INC_I(data.u32, src2_data.u32);
-            data_ready = true;
-            break;
-         default:
-            printf("Execution error: type mismatch with instruction\natom.INC only accepts u32 and s32\n");
-            assert(0);
-            break;
-         }
-
-         break;
-      }
-      // DEC
-   case ATOMIC_DEC:
-      {
-         switch ( to_type ) {
-         case U32_TYPE: 
-            op_result.u32 = MY_DEC_I(data.u32, src2_data.u32);
-            data_ready = true;
-            break;
-         default:
-            printf("Execution error: type mismatch with instruction\natom.DEC only accepts u32 and s32\n");
-            assert(0);
-            break;
-         }
-
-         break;
-      }
-      // MIN
-   case ATOMIC_MIN:
-      {
-         switch ( to_type ) {
-         case U32_TYPE: 
-            op_result.u32 = MY_MIN_I(data.u32, src2_data.u32);
-            data_ready = true;
-            break;
-         case S32_TYPE:
-            op_result.s32 = MY_MIN_I(data.s32, src2_data.s32);
-            data_ready = true;
-            break;
-         default:
-            printf("Execution error: type mismatch with instruction\natom.MIN only accepts u32 and s32\n");
-            assert(0);
-            break;
-         }
-
-         break;
-      }
-      // MAX
-   case ATOMIC_MAX:
-      {
-         switch ( to_type ) {
-         case U32_TYPE:
-            op_result.u32 = MY_MAX_I(data.u32, src2_data.u32);
-            data_ready = true;
-            break;
-         case S32_TYPE:
-            op_result.s32 = MY_MAX_I(data.s32, src2_data.s32);
-            data_ready = true;
-            break;
-         default:
-            printf("Execution error: type mismatch with instruction\natom.MAX only accepts u32 and s32\n");
-            assert(0);
-            break;
-         }
-
-         break;
-      }
-      // DEFAULT
-   default:
-      {
-         assert(0);
-         break;
-      }
-   }
-
-   // Write operation result into  memory
-   // (i.e. copy src1_data to dst)
-   if ( data_ready ) {
-      mem->write(effective_address,size/8,&op_result.s64,thread,pI);
-   } else {
-      printf("Execution error: data_ready not set\n");
+    case F64_TYPE:
+    case FF64_TYPE:
+      data.f64 = src1_data.f64 + src2_data.f64;
+      break;
+    default:
       assert(0);
-   }
+      break;
+  }
+  fesetround(orig_rm);
+
+  thread->set_operand_value(dst, data, i_type, thread, pI, overflow, carry);
 }
 
-// atom_impl will now result in a callback being called in mem_ctrl_pop (gpu-sim.c)
-void atom_impl( const ptx_instruction *pI, ptx_thread_info *thread )
-{   
-   // SYNTAX
-   // atom.space.operation.type d, a, b[, c]; (now read in callback)
+void addc_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
 
-   // obtain memory space of the operation 
-   memory_space_t space = pI->get_space(); 
+void and_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, src2_data, data;
 
-   // get the memory address
-   const operand_info &src1 = pI->src1();
-   // const operand_info &dst  = pI->dst();  // not needed for effective address calculation 
-   unsigned i_type = pI->get_type();
-   ptx_reg_t src1_data;
-   src1_data = thread->get_operand_value(src1, src1, i_type, thread, 1);
-   addr_t effective_address = src1_data.u64; 
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   addr_t effective_address_final; 
+  unsigned i_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-   // handle generic memory space by converting it to global 
-   if ( space == undefined_space ) {
-      if( whichspace(effective_address) == global_space ) {
-         effective_address_final = generic_to_global(effective_address);
-         space = global_space;
-      } else if( whichspace(effective_address) == shared_space ) {
-         unsigned smid = thread->get_hw_sid();
-         effective_address_final = generic_to_shared(smid,effective_address);
-         space = shared_space;
-      } else {
-         abort();
+  // the way ptxplus handles predicates: 1 = false and 0 = true
+  if (i_type == PRED_TYPE)
+    data.pred = ~(~(src1_data.pred) & ~(src2_data.pred));
+  else
+    data.u64 = src1_data.u64 & src2_data.u64;
+
+  thread->set_operand_value(dst, data, i_type, thread, pI);
+}
+
+void andn_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, src2_data, data;
+
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
+
+  unsigned i_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+
+  switch (i_type) {
+    case B16_TYPE:
+      src2_data.u16 = ~src2_data.u16;
+      break;
+    case B32_TYPE:
+      src2_data.u32 = ~src2_data.u32;
+      break;
+    case B64_TYPE:
+      src2_data.u64 = ~src2_data.u64;
+      break;
+    default:
+      printf("Execution error: type mismatch with instruction\n");
+      assert(0);
+      break;
+  }
+
+  data.u64 = src1_data.u64 & src2_data.u64;
+
+  thread->set_operand_value(dst, data, i_type, thread, pI);
+}
+
+void bar_callback(const inst_t *inst, ptx_thread_info *thread) {
+  unsigned ctaid = thread->get_cta_uid();
+  unsigned barid = inst->bar_id;
+  unsigned value = thread->get_reduction_value(ctaid, barid);
+  const ptx_instruction *pI = dynamic_cast<const ptx_instruction *>(inst);
+  const operand_info &dst = pI->dst();
+  ptx_reg_t data;
+  data.u32 = value;
+  thread->set_operand_value(dst, value, U32_TYPE, thread, pI);
+}
+
+void atom_callback(const inst_t *inst, ptx_thread_info *thread) {
+  const ptx_instruction *pI = dynamic_cast<const ptx_instruction *>(inst);
+
+  // "Decode" the output type
+  unsigned to_type = pI->get_type();
+  size_t size;
+  int t;
+  type_info_key::type_decode(to_type, size, t);
+
+  // Set up operand variables
+  ptx_reg_t data;       // d
+  ptx_reg_t src1_data;  // a
+  ptx_reg_t src2_data;  // b
+  ptx_reg_t op_result;  // temp variable to hold operation result
+
+  bool data_ready = false;
+
+  // Get operand info of sources and destination
+  const operand_info &dst = pI->dst();    // d
+  const operand_info &src1 = pI->src1();  // a
+  const operand_info &src2 = pI->src2();  // b
+
+  // Get operand values
+  src1_data = thread->get_operand_value(src1, src1, to_type, thread, 1);  // a
+  if (dst.get_symbol()->type()) {
+    src2_data = thread->get_operand_value(src2, dst, to_type, thread, 1);  // b
+  } else {
+    // This is the case whent he first argument (dest) is '_'
+    src2_data = thread->get_operand_value(src2, src1, to_type, thread, 1);  // b
+  }
+
+  // Check state space
+  addr_t effective_address = src1_data.u64;
+  memory_space_t space = pI->get_space();
+  if (space == undefined_space) {
+    // generic space - determine space via address
+    if (whichspace(effective_address) == global_space) {
+      effective_address = generic_to_global(effective_address);
+      space = global_space;
+    } else if (whichspace(effective_address) == shared_space) {
+      unsigned smid = thread->get_hw_sid();
+      effective_address = generic_to_shared(smid, effective_address);
+      space = shared_space;
+    } else {
+      abort();
+    }
+  }
+  assert(space == global_space || space == shared_space);
+
+  memory_space *mem = NULL;
+  if (space == global_space)
+    mem = thread->get_global_memory();
+  else if (space == shared_space)
+    mem = thread->m_shared_mem;
+  else
+    abort();
+
+  // Copy value pointed to in operand 'a' into register 'd'
+  // (i.e. copy src1_data to dst)
+  mem->read(effective_address, size / 8, &data.s64);
+  if (dst.get_symbol()->type()) {
+    thread->set_operand_value(dst, data, to_type, thread,
+                              pI);  // Write value into register 'd'
+  }
+
+  // Get the atomic operation to be performed
+  unsigned m_atomic_spec = pI->get_atomic();
+
+  switch (m_atomic_spec) {
+    // AND
+    case ATOMIC_AND: {
+      switch (to_type) {
+        case B32_TYPE:
+        case U32_TYPE:
+          op_result.u32 = data.u32 & src2_data.u32;
+          data_ready = true;
+          break;
+        case S32_TYPE:
+          op_result.s32 = data.s32 & src2_data.s32;
+          data_ready = true;
+          break;
+        default:
+          printf(
+              "Execution error: type mismatch (%x) with instruction\natom.AND "
+              "only accepts b32\n",
+              to_type);
+          assert(0);
+          break;
       }
-   } else {
-      assert( space == global_space || space == shared_space );
-      effective_address_final = effective_address; 
-   }
 
-   // Check state space
-   assert( space == global_space || space == shared_space );
+      break;
+    }
+    // OR
+    case ATOMIC_OR: {
+      switch (to_type) {
+        case B32_TYPE:
+        case U32_TYPE:
+          op_result.u32 = data.u32 | src2_data.u32;
+          data_ready = true;
+          break;
+        case S32_TYPE:
+          op_result.s32 = data.s32 | src2_data.s32;
+          data_ready = true;
+          break;
+        default:
+          printf(
+              "Execution error: type mismatch (%x) with instruction\natom.OR "
+              "only accepts b32\n",
+              to_type);
+          assert(0);
+          break;
+      }
 
-   thread->m_last_effective_address = effective_address_final;
-   thread->m_last_memory_space = space;
-   thread->m_last_dram_callback.function = atom_callback;
-   thread->m_last_dram_callback.instruction = pI; 
+      break;
+    }
+    // XOR
+    case ATOMIC_XOR: {
+      switch (to_type) {
+        case B32_TYPE:
+        case U32_TYPE:
+          op_result.u32 = data.u32 ^ src2_data.u32;
+          data_ready = true;
+          break;
+        case S32_TYPE:
+          op_result.s32 = data.s32 ^ src2_data.s32;
+          data_ready = true;
+          break;
+        default:
+          printf(
+              "Execution error: type mismatch (%x) with instruction\natom.XOR "
+              "only accepts b32\n",
+              to_type);
+          assert(0);
+          break;
+      }
+
+      break;
+    }
+    // CAS
+    case ATOMIC_CAS: {
+      ptx_reg_t src3_data;
+      const operand_info &src3 = pI->src3();
+      src3_data = thread->get_operand_value(src3, dst, to_type, thread, 1);
+
+      switch (to_type) {
+        case B32_TYPE:
+        case U32_TYPE:
+          op_result.u32 = MY_CAS_I(data.u32, src2_data.u32, src3_data.u32);
+          data_ready = true;
+          break;
+        case B64_TYPE:
+        case U64_TYPE:
+          op_result.u64 = MY_CAS_I(data.u64, src2_data.u64, src3_data.u64);
+          data_ready = true;
+          break;
+        case S32_TYPE:
+          op_result.s32 = MY_CAS_I(data.s32, src2_data.s32, src3_data.s32);
+          data_ready = true;
+          break;
+        default:
+          printf(
+              "Execution error: type mismatch (%x) with instruction\natom.CAS "
+              "only accepts b32 and b64\n",
+              to_type);
+          assert(0);
+          break;
+      }
+
+      break;
+    }
+    // EXCH
+    case ATOMIC_EXCH: {
+      switch (to_type) {
+        case B32_TYPE:
+        case U32_TYPE:
+          op_result.u32 = MY_EXCH(data.u32, src2_data.u32);
+          data_ready = true;
+          break;
+        case B64_TYPE:
+        case U64_TYPE:
+          op_result.u64 = MY_EXCH(data.u64, src2_data.u64);
+          data_ready = true;
+          break;
+        case S32_TYPE:
+          op_result.s32 = MY_EXCH(data.s32, src2_data.s32);
+          data_ready = true;
+          break;
+        default:
+          printf(
+              "Execution error: type mismatch (%x) with instruction\natom.EXCH "
+              "only accepts b32\n",
+              to_type);
+          assert(0);
+          break;
+      }
+
+      break;
+    }
+    // ADD
+    case ATOMIC_ADD: {
+      switch (to_type) {
+        case U32_TYPE:
+          op_result.u32 = data.u32 + src2_data.u32;
+          data_ready = true;
+          break;
+        case S32_TYPE:
+          op_result.s32 = data.s32 + src2_data.s32;
+          data_ready = true;
+          break;
+        case U64_TYPE:
+          op_result.u64 = data.u64 + src2_data.u64;
+          data_ready = true;
+          break;
+        case F32_TYPE:
+          op_result.f32 = data.f32 + src2_data.f32;
+          data_ready = true;
+          break;
+        default:
+          printf(
+              "Execution error: type mismatch with instruction\natom.ADD only "
+              "accepts u32, s32, u64, and f32\n");
+          assert(0);
+          break;
+      }
+
+      break;
+    }
+    // INC
+    case ATOMIC_INC: {
+      switch (to_type) {
+        case U32_TYPE:
+          op_result.u32 = MY_INC_I(data.u32, src2_data.u32);
+          data_ready = true;
+          break;
+        default:
+          printf(
+              "Execution error: type mismatch with instruction\natom.INC only "
+              "accepts u32 and s32\n");
+          assert(0);
+          break;
+      }
+
+      break;
+    }
+    // DEC
+    case ATOMIC_DEC: {
+      switch (to_type) {
+        case U32_TYPE:
+          op_result.u32 = MY_DEC_I(data.u32, src2_data.u32);
+          data_ready = true;
+          break;
+        default:
+          printf(
+              "Execution error: type mismatch with instruction\natom.DEC only "
+              "accepts u32 and s32\n");
+          assert(0);
+          break;
+      }
+
+      break;
+    }
+    // MIN
+    case ATOMIC_MIN: {
+      switch (to_type) {
+        case U32_TYPE:
+          op_result.u32 = MY_MIN_I(data.u32, src2_data.u32);
+          data_ready = true;
+          break;
+        case S32_TYPE:
+          op_result.s32 = MY_MIN_I(data.s32, src2_data.s32);
+          data_ready = true;
+          break;
+        default:
+          printf(
+              "Execution error: type mismatch with instruction\natom.MIN only "
+              "accepts u32 and s32\n");
+          assert(0);
+          break;
+      }
+
+      break;
+    }
+    // MAX
+    case ATOMIC_MAX: {
+      switch (to_type) {
+        case U32_TYPE:
+          op_result.u32 = MY_MAX_I(data.u32, src2_data.u32);
+          data_ready = true;
+          break;
+        case S32_TYPE:
+          op_result.s32 = MY_MAX_I(data.s32, src2_data.s32);
+          data_ready = true;
+          break;
+        default:
+          printf(
+              "Execution error: type mismatch with instruction\natom.MAX only "
+              "accepts u32 and s32\n");
+          assert(0);
+          break;
+      }
+
+      break;
+    }
+    // DEFAULT
+    default: {
+      assert(0);
+      break;
+    }
+  }
+
+  // Write operation result into  memory
+  // (i.e. copy src1_data to dst)
+  if (data_ready) {
+    mem->write(effective_address, size / 8, &op_result.s64, thread, pI);
+  } else {
+    printf("Execution error: data_ready not set\n");
+    assert(0);
+  }
 }
 
-void bar_impl( const ptx_instruction *pIin, ptx_thread_info *thread )
-{ 
-   ptx_instruction * pI = const_cast<ptx_instruction *>(pIin);
-   unsigned bar_op = pI->barrier_op();
-   unsigned red_op = pI->get_atomic();
-   unsigned ctaid = thread->get_cta_uid();
+// atom_impl will now result in a callback being called in mem_ctrl_pop
+// (gpu-sim.c)
+void atom_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  // SYNTAX
+  // atom.space.operation.type d, a, b[, c]; (now read in callback)
 
-   switch(bar_op){
-   	   case SYNC_OPTION:
-   	   {
-   		   if(pI->get_num_operands()>1){
-   			   const operand_info &op0 = pI->dst();
-   			   const operand_info &op1 = pI->src1();
-   			   ptx_reg_t op0_data;
-   			   ptx_reg_t op1_data;
-   			   op0_data = thread->get_operand_value(op0, op0, U32_TYPE, thread, 1);
-   			   op1_data = thread->get_operand_value(op1, op1, U32_TYPE, thread, 1);
-   			   pI->set_bar_id(op0_data.u32);
-   			   pI->set_bar_count(op1_data.u32);
-   		   }else{
-   			   const operand_info &op0 = pI->dst();
-   			   ptx_reg_t op0_data;
-   			   op0_data = thread->get_operand_value(op0, op0, U32_TYPE, thread, 1);
-   			   pI->set_bar_id(op0_data.u32);
-   		   }
-   		   break;
-   	   }
-   	   case ARRIVE_OPTION:
-   	   {
-			   const operand_info &op0 = pI->dst();
-			   const operand_info &op1 = pI->src1();
-			   ptx_reg_t op0_data;
-			   ptx_reg_t op1_data;
-			   op0_data = thread->get_operand_value(op0, op0, U32_TYPE, thread, 1);
-			   op1_data = thread->get_operand_value(op1, op1, U32_TYPE, thread, 1);
-   			   pI->set_bar_id(op0_data.u32);
-   			   pI->set_bar_count(op1_data.u32);
-   		   break;
-   	   }
-   	   case RED_OPTION:
-   	   {
-   		   if(pI->get_num_operands()>3){
-   			   const operand_info &op1 = pI->src1();
-   			   const operand_info &op2 = pI->src2();
-   			   const operand_info &op3 = pI->src3();
-   			   ptx_reg_t op1_data;
-   			   ptx_reg_t op2_data;
-   			   ptx_reg_t op3_data;
-   			   op1_data = thread->get_operand_value(op1, op1, U32_TYPE, thread, 1);
-   			   op2_data = thread->get_operand_value(op2, op2, U32_TYPE, thread, 1);
-   			   op3_data = thread->get_operand_value(op3, op3, PRED_TYPE, thread, 1);
-   			   op3_data.u32=!(op3_data.pred & 0x0001);
-   			   pI->set_bar_id(op1_data.u32);
-   			   pI->set_bar_count(op2_data.u32);
-   			   switch(red_op){
-   			   	   case ATOMIC_POPC:
-   			   		   thread->popc_reduction(ctaid,op1_data.u32,op3_data.u32);
-   			   		   break;
-   			   	   case ATOMIC_AND:
-   			   		   thread->and_reduction(ctaid,op1_data.u32,op3_data.u32);
-   			   		   break;
-   			   	   case ATOMIC_OR:
-   			   		   thread->or_reduction(ctaid,op1_data.u32,op3_data.u32);
-   			   		   break;
-   			   	   default:
-   			   		   abort();
-   			   		   break;
-   			   }
-   		   }else{
-   			   const operand_info &op1 = pI->src1();
-   			   const operand_info &op2 = pI->src2();
-   			   ptx_reg_t op1_data;
-   			   ptx_reg_t op2_data;
-   			   op1_data = thread->get_operand_value(op1, op1, U32_TYPE, thread, 1);
-   			   op2_data = thread->get_operand_value(op2, op2, PRED_TYPE, thread, 1);
-               op2_data.u32=!(op2_data.pred & 0x0001);
-   			   pI->set_bar_id(op1_data.u32);
-			   pI->set_bar_count(thread->get_ntid().x * thread->get_ntid().y * thread->get_ntid().z);
-   			   switch(red_op){
-   			   	   case ATOMIC_POPC:
-   			   		   thread->popc_reduction(ctaid,op1_data.u32,op2_data.u32);
-   			   		   break;
-   			   	   case ATOMIC_AND:
-   			   		   thread->and_reduction(ctaid,op1_data.u32,op2_data.u32);
-   			   		   break;
-   			   	   case ATOMIC_OR:
-   			   		   thread->or_reduction(ctaid,op1_data.u32,op2_data.u32);
-   			   		   break;
-   			   	   default:
-   			   		   abort();
-   			   		   break;
-   			   }
-   		   }
-   		   break;
-   	   }
-   	   default:
-   		   abort();
-   		   break;
-   }
+  // obtain memory space of the operation
+  memory_space_t space = pI->get_space();
 
-   thread->m_last_dram_callback.function = bar_callback;
-   thread->m_last_dram_callback.instruction = pIin;
+  // get the memory address
+  const operand_info &src1 = pI->src1();
+  // const operand_info &dst  = pI->dst();  // not needed for effective address
+  // calculation
+  unsigned i_type = pI->get_type();
+  ptx_reg_t src1_data;
+  src1_data = thread->get_operand_value(src1, src1, i_type, thread, 1);
+  addr_t effective_address = src1_data.u64;
+
+  addr_t effective_address_final;
+
+  // handle generic memory space by converting it to global
+  if (space == undefined_space) {
+    if (whichspace(effective_address) == global_space) {
+      effective_address_final = generic_to_global(effective_address);
+      space = global_space;
+    } else if (whichspace(effective_address) == shared_space) {
+      unsigned smid = thread->get_hw_sid();
+      effective_address_final = generic_to_shared(smid, effective_address);
+      space = shared_space;
+    } else {
+      abort();
+    }
+  } else {
+    assert(space == global_space || space == shared_space);
+    effective_address_final = effective_address;
+  }
+
+  // Check state space
+  assert(space == global_space || space == shared_space);
+
+  thread->m_last_effective_address = effective_address_final;
+  thread->m_last_memory_space = space;
+  thread->m_last_dram_callback.function = atom_callback;
+  thread->m_last_dram_callback.instruction = pI;
 }
 
-void bfe_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-	unsigned i_type = pI->get_type();
-	unsigned msb = (i_type == U32_TYPE || i_type == S32_TYPE) ? 31 : 63;
-    const operand_info &dst  = pI->dst();
-    const operand_info &src1 = pI->src1();
-    const operand_info &src2 = pI->src2();
-    const operand_info &src3 = pI->src3();
-    ptx_reg_t src = thread->get_operand_value(src1, dst, i_type, thread, 1);
-    ptx_reg_t b = thread->get_operand_value(src2, dst, i_type, thread, 1);
-    ptx_reg_t c = thread->get_operand_value(src3, dst, i_type, thread, 1);
-    ptx_reg_t data;
-	unsigned pos = b.u32 & 0xFF;
-	unsigned len = c.u32 & 0xFF;
-	switch (i_type)
-	{
-		case U32_TYPE:
-		{
-			unsigned mask;
-			data.u32 = src.u32 >> pos;
-			mask = 0xFFFFFFFF >> (32 - len);
-			data.u32 &= mask;
-			break;
-		}
-		case U64_TYPE:
-		{
-			unsigned long mask;
-			data.u64 = src.u64 >> pos;	
-			mask = 0xFFFFFFFFFFFFFFFF >> (64 - len);
-			data.u64 &= mask;
-			break;
-		}
-		case S32_TYPE:
-		{
-			unsigned mask;
-			unsigned min = MY_MIN_I(pos + len - 1, msb);
-			unsigned sbit = len == 0 ? 0 : (src.s32 >> min) & 0x1;
-			data.s32 = src.s32 >> pos;
-			if (sbit > 0)
-			{
-				mask = 0xFFFFFFFF << len;
-				data.s32 |= mask;
-			}
-			else
-			{
-				mask = 0xFFFFFFFF >> (32 - len);
-				data.s32 &= mask;
-			}
-			break;
-		}
-		case S64_TYPE:
-		{
-			unsigned long mask;
-			unsigned min = MY_MIN_I(pos + len - 1, msb);
-			unsigned sbit = len == 0 ? 0 : (src.s64 >> min) & 0x1;
-			data.s64 = src.s64 >> pos;
-			if (sbit > 0)
-			{
-				mask = 0xFFFFFFFFFFFFFFFF << len;
-				data.s64 |= mask;
-			}
-			else
-			{
-				mask = 0xFFFFFFFFFFFFFFFF >> (64 - len);
-				data.s64 &= mask;
-			}
-			break;
-		}
-		default:
-		printf("Operand type not supported for BFE instruction.\n");
-		abort();
-		return;
-	}
-    thread->set_operand_value(dst, data, i_type, thread, pI);
+void bar_impl(const ptx_instruction *pIin, ptx_thread_info *thread) {
+  ptx_instruction *pI = const_cast<ptx_instruction *>(pIin);
+  unsigned bar_op = pI->barrier_op();
+  unsigned red_op = pI->get_atomic();
+  unsigned ctaid = thread->get_cta_uid();
+
+  switch (bar_op) {
+    case SYNC_OPTION: {
+      if (pI->get_num_operands() > 1) {
+        const operand_info &op0 = pI->dst();
+        const operand_info &op1 = pI->src1();
+        ptx_reg_t op0_data;
+        ptx_reg_t op1_data;
+        op0_data = thread->get_operand_value(op0, op0, U32_TYPE, thread, 1);
+        op1_data = thread->get_operand_value(op1, op1, U32_TYPE, thread, 1);
+        pI->set_bar_id(op0_data.u32);
+        pI->set_bar_count(op1_data.u32);
+      } else {
+        const operand_info &op0 = pI->dst();
+        ptx_reg_t op0_data;
+        op0_data = thread->get_operand_value(op0, op0, U32_TYPE, thread, 1);
+        pI->set_bar_id(op0_data.u32);
+      }
+      break;
+    }
+    case ARRIVE_OPTION: {
+      const operand_info &op0 = pI->dst();
+      const operand_info &op1 = pI->src1();
+      ptx_reg_t op0_data;
+      ptx_reg_t op1_data;
+      op0_data = thread->get_operand_value(op0, op0, U32_TYPE, thread, 1);
+      op1_data = thread->get_operand_value(op1, op1, U32_TYPE, thread, 1);
+      pI->set_bar_id(op0_data.u32);
+      pI->set_bar_count(op1_data.u32);
+      break;
+    }
+    case RED_OPTION: {
+      if (pI->get_num_operands() > 3) {
+        const operand_info &op1 = pI->src1();
+        const operand_info &op2 = pI->src2();
+        const operand_info &op3 = pI->src3();
+        ptx_reg_t op1_data;
+        ptx_reg_t op2_data;
+        ptx_reg_t op3_data;
+        op1_data = thread->get_operand_value(op1, op1, U32_TYPE, thread, 1);
+        op2_data = thread->get_operand_value(op2, op2, U32_TYPE, thread, 1);
+        op3_data = thread->get_operand_value(op3, op3, PRED_TYPE, thread, 1);
+        op3_data.u32 = !(op3_data.pred & 0x0001);
+        pI->set_bar_id(op1_data.u32);
+        pI->set_bar_count(op2_data.u32);
+        switch (red_op) {
+          case ATOMIC_POPC:
+            thread->popc_reduction(ctaid, op1_data.u32, op3_data.u32);
+            break;
+          case ATOMIC_AND:
+            thread->and_reduction(ctaid, op1_data.u32, op3_data.u32);
+            break;
+          case ATOMIC_OR:
+            thread->or_reduction(ctaid, op1_data.u32, op3_data.u32);
+            break;
+          default:
+            abort();
+            break;
+        }
+      } else {
+        const operand_info &op1 = pI->src1();
+        const operand_info &op2 = pI->src2();
+        ptx_reg_t op1_data;
+        ptx_reg_t op2_data;
+        op1_data = thread->get_operand_value(op1, op1, U32_TYPE, thread, 1);
+        op2_data = thread->get_operand_value(op2, op2, PRED_TYPE, thread, 1);
+        op2_data.u32 = !(op2_data.pred & 0x0001);
+        pI->set_bar_id(op1_data.u32);
+        pI->set_bar_count(thread->get_ntid().x * thread->get_ntid().y *
+                          thread->get_ntid().z);
+        switch (red_op) {
+          case ATOMIC_POPC:
+            thread->popc_reduction(ctaid, op1_data.u32, op2_data.u32);
+            break;
+          case ATOMIC_AND:
+            thread->and_reduction(ctaid, op1_data.u32, op2_data.u32);
+            break;
+          case ATOMIC_OR:
+            thread->or_reduction(ctaid, op1_data.u32, op2_data.u32);
+            break;
+          default:
+            abort();
+            break;
+        }
+      }
+      break;
+    }
+    default:
+      abort();
+      break;
+  }
+
+  thread->m_last_dram_callback.function = bar_callback;
+  thread->m_last_dram_callback.instruction = pIin;
 }
 
-void bfi_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { 
-   int i,max;
-   ptx_reg_t src1_data, src2_data;
-   ptx_reg_t src3_data, src4_data, data;
+void bfe_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  unsigned i_type = pI->get_type();
+  unsigned msb = (i_type == U32_TYPE || i_type == S32_TYPE) ? 31 : 63;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
+  const operand_info &src3 = pI->src3();
+  ptx_reg_t src = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  ptx_reg_t b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  ptx_reg_t c = thread->get_operand_value(src3, dst, i_type, thread, 1);
+  ptx_reg_t data;
+  unsigned pos = b.u32 & 0xFF;
+  unsigned len = c.u32 & 0xFF;
+  switch (i_type) {
+    case U32_TYPE: {
+      unsigned mask;
+      data.u32 = src.u32 >> pos;
+      mask = 0xFFFFFFFF >> (32 - len);
+      data.u32 &= mask;
+      break;
+    }
+    case U64_TYPE: {
+      unsigned long mask;
+      data.u64 = src.u64 >> pos;
+      mask = 0xFFFFFFFFFFFFFFFF >> (64 - len);
+      data.u64 &= mask;
+      break;
+    }
+    case S32_TYPE: {
+      unsigned mask;
+      unsigned min = MY_MIN_I(pos + len - 1, msb);
+      unsigned sbit = len == 0 ? 0 : (src.s32 >> min) & 0x1;
+      data.s32 = src.s32 >> pos;
+      if (sbit > 0) {
+        mask = 0xFFFFFFFF << len;
+        data.s32 |= mask;
+      } else {
+        mask = 0xFFFFFFFF >> (32 - len);
+        data.s32 &= mask;
+      }
+      break;
+    }
+    case S64_TYPE: {
+      unsigned long mask;
+      unsigned min = MY_MIN_I(pos + len - 1, msb);
+      unsigned sbit = len == 0 ? 0 : (src.s64 >> min) & 0x1;
+      data.s64 = src.s64 >> pos;
+      if (sbit > 0) {
+        mask = 0xFFFFFFFFFFFFFFFF << len;
+        data.s64 |= mask;
+      } else {
+        mask = 0xFFFFFFFFFFFFFFFF >> (64 - len);
+        data.s64 &= mask;
+      }
+      break;
+    }
+    default:
+      printf("Operand type not supported for BFE instruction.\n");
+      abort();
+      return;
+  }
+  thread->set_operand_value(dst, data, i_type, thread, pI);
+}
 
-   const operand_info &dst  = pI->dst();  //get operand info of sources and destination 
-   const operand_info &src1 = pI->src1(); //use them to determine that they are of type 'register'
-   const operand_info &src2 = pI->src2();
-   const operand_info &src3 = pI->src3();
-   const operand_info &src4 = pI->src4();
+void bfi_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  int i, max;
+  ptx_reg_t src1_data, src2_data;
+  ptx_reg_t src3_data, src4_data, data;
 
-   unsigned i_type = pI->get_type();
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
-   src3_data = thread->get_operand_value(src3, dst, i_type, thread, 1);
-   src4_data = thread->get_operand_value(src4, dst, i_type, thread, 1);
+  const operand_info &dst =
+      pI->dst();  // get operand info of sources and destination
+  const operand_info &src1 =
+      pI->src1();  // use them to determine that they are of type 'register'
+  const operand_info &src2 = pI->src2();
+  const operand_info &src3 = pI->src3();
+  const operand_info &src4 = pI->src4();
 
-   switch ( i_type ) {
-   case B32_TYPE:
+  unsigned i_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  src3_data = thread->get_operand_value(src3, dst, i_type, thread, 1);
+  src4_data = thread->get_operand_value(src4, dst, i_type, thread, 1);
+
+  switch (i_type) {
+    case B32_TYPE:
       max = 32;
       break;
-   case B64_TYPE:
+    case B64_TYPE:
       max = 64;
       break;
-   default:
+    default:
       printf("Execution error: type mismatch with instruction\n");
       assert(0);
       break;
-   }
-   data=src2_data;
-   unsigned pos = src3_data.u32 & 0xFF;
-   unsigned len = src4_data.u32 & 0xFF;
-   for(i=0;i<len && pos+i<max;i++){
-	data.u32=(~((0x00000001)<<(pos+i)))&data.u32;
-	data.u32=data.u32|((src1_data.u32&((0x00000001)<<(i)))<<(pos));
-   }
-   thread->set_operand_value(dst, data, i_type, thread, pI);
+  }
+  data = src2_data;
+  unsigned pos = src3_data.u32 & 0xFF;
+  unsigned len = src4_data.u32 & 0xFF;
+  for (i = 0; i < len && pos + i < max; i++) {
+    data.u32 = (~((0x00000001) << (pos + i))) & data.u32;
+    data.u32 = data.u32 | ((src1_data.u32 & ((0x00000001) << (i))) << (pos));
+  }
+  thread->set_operand_value(dst, data, i_type, thread, pI);
 }
-void bfind_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-
-void bra_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   const operand_info &target  = pI->dst();
-   ptx_reg_t target_pc = thread->get_operand_value(target, target, U32_TYPE, thread, 1);
-
-   thread->m_branch_taken = true;
-   thread->set_npc(target_pc);
+void bfind_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
 }
 
-void brx_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   const operand_info &target  = pI->dst();
-   ptx_reg_t target_pc = thread->get_operand_value(target, target, U32_TYPE, thread, 1);
+void bra_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  const operand_info &target = pI->dst();
+  ptx_reg_t target_pc =
+      thread->get_operand_value(target, target, U32_TYPE, thread, 1);
 
-   thread->m_branch_taken = true;
-   thread->set_npc(target_pc);
+  thread->m_branch_taken = true;
+  thread->set_npc(target_pc);
 }
 
-void break_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   const operand_info &target  = thread->pop_breakaddr();
-   ptx_reg_t target_pc = thread->get_operand_value(target, target, U32_TYPE, thread, 1);
+void brx_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  const operand_info &target = pI->dst();
+  ptx_reg_t target_pc =
+      thread->get_operand_value(target, target, U32_TYPE, thread, 1);
 
-   thread->m_branch_taken = true;
-   thread->set_npc(target_pc);
+  thread->m_branch_taken = true;
+  thread->set_npc(target_pc);
 }
 
-void breakaddr_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   const operand_info &target  = pI->dst();
-   thread->push_breakaddr(target);
-   assert(pI->has_pred() == false); // pdom analysis cannot handle if this instruction is predicated 
+void break_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  const operand_info &target = thread->pop_breakaddr();
+  ptx_reg_t target_pc =
+      thread->get_operand_value(target, target, U32_TYPE, thread, 1);
+
+  thread->m_branch_taken = true;
+  thread->set_npc(target_pc);
 }
 
-void brev_impl( const ptx_instruction *pI, ptx_thread_info *thread )
-{
-    ptx_reg_t src1_data, data;
-    const operand_info &dst  = pI->dst();
-    const operand_info &src1 = pI->src1();
-	unsigned i_type = pI->get_type();
-    src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-
-    unsigned msb;
-    switch(i_type){
-        case B32_TYPE:
-            msb = 31;
-            for (unsigned i=0; i<=msb; i++) {
-                if((src1_data.u32 & (1 << i)))
-                    data.u32 |= 1 << (msb - i);
-            }
-            break;
-        case B64_TYPE:
-            msb = 63;
-            for (unsigned i=0; i<=msb; i++) {
-                if((src1_data.u64 & (1 << i)))
-                    data.u64 |= 1 << (msb - i);
-            }
-            break;
-        default: assert(0);
-    }
-    thread->set_operand_value(dst,data, i_type, thread, pI);
+void breakaddr_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  const operand_info &target = pI->dst();
+  thread->push_breakaddr(target);
+  assert(
+      pI->has_pred() ==
+      false);  // pdom analysis cannot handle if this instruction is predicated
 }
-void brkpt_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
+
+void brev_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, data;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  unsigned i_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+
+  unsigned msb;
+  switch (i_type) {
+    case B32_TYPE:
+      msb = 31;
+      for (unsigned i = 0; i <= msb; i++) {
+        if ((src1_data.u32 & (1 << i))) data.u32 |= 1 << (msb - i);
+      }
+      break;
+    case B64_TYPE:
+      msb = 63;
+      for (unsigned i = 0; i <= msb; i++) {
+        if ((src1_data.u64 & (1 << i))) data.u64 |= 1 << (msb - i);
+      }
+      break;
+    default:
+      assert(0);
+  }
+  thread->set_operand_value(dst, data, i_type, thread, pI);
+}
+void brkpt_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
 
 unsigned trunc(unsigned num, unsigned precision) {
-	int mask = 1, latest_one = -1;
-	unsigned data = num;
-	for (unsigned j = 0; j < sizeof(unsigned)*8; j++) {
-		int bit = data & mask;
-		if (bit == 1) latest_one = j;
-		data >>= 1;
-	}
-	if (latest_one >= precision) {
-		// round_up is 1 if the most significant truncated digit is a 1, otherwise it is 0
-		//int round_up = (num & (1 << (latest_one-precision))) >> (latest_one-precision);
-		//unsigned shifted_output = num >> (latest_one-precision+1);
-		// if shifted_output is a number like 1111, don't round up
-		//if (shifted_output == (pow(2,precision)-1)) round_up = 0;
-		//num = shifted_output + round_up;
-		num >>= (latest_one-precision+1);
-	}
-	return num;
+  int mask = 1, latest_one = -1;
+  unsigned data = num;
+  for (unsigned j = 0; j < sizeof(unsigned) * 8; j++) {
+    int bit = data & mask;
+    if (bit == 1) latest_one = j;
+    data >>= 1;
+  }
+  if (latest_one >= precision) {
+    // round_up is 1 if the most significant truncated digit is a 1, otherwise
+    // it is 0
+    // int round_up = (num & (1 << (latest_one-precision))) >>
+    // (latest_one-precision);
+    // unsigned shifted_output = num >> (latest_one-precision+1);
+    // if shifted_output is a number like 1111, don't round up
+    // if (shifted_output == (pow(2,precision)-1)) round_up = 0;
+    // num = shifted_output + round_up;
+    num >>= (latest_one - precision + 1);
+  }
+  return num;
 }
-void mapping(int thread,int wmma_type,int wmma_layout,int type,int index,int stride,int &row,int &col,int &assg_offset){
-	int offset;
-	int c_row_offset[]={0,8,0,8,4,12,4,12};
-	int c_col_offset[]={0,0,8,8,0,0,8,8};
-	int c_tg_inside_row_offset[]={0,1,0,1};	
-	int c_tg_inside_col_offset[]={0,0,2,2};	
-	int c_inside_row_offset[]={0,0,2,2,0,0,2,2};
-	int c_inside_col_offset[]={0,1,0,1,4,5,4,5};
+void mapping(int thread, int wmma_type, int wmma_layout, int type, int index,
+             int stride, int &row, int &col, int &assg_offset) {
+  int offset;
+  int c_row_offset[] = {0, 8, 0, 8, 4, 12, 4, 12};
+  int c_col_offset[] = {0, 0, 8, 8, 0, 0, 8, 8};
+  int c_tg_inside_row_offset[] = {0, 1, 0, 1};
+  int c_tg_inside_col_offset[] = {0, 0, 2, 2};
+  int c_inside_row_offset[] = {0, 0, 2, 2, 0, 0, 2, 2};
+  int c_inside_col_offset[] = {0, 1, 0, 1, 4, 5, 4, 5};
 
-	offset=thread_group_offset(thread,wmma_type,wmma_layout,type,stride);
+  offset = thread_group_offset(thread, wmma_type, wmma_layout, type, stride);
 
-	if(wmma_type==LOAD_A){
-		if(wmma_layout==ROW){
-			offset+=index+8*((thread%16)/8);
-		}
-		else{
-			offset+=64*(index/4)+index%4+128*((thread%16)/8);	
-		}
-		offset=(offset/16)*stride+offset%16;
-		assg_offset=index+8*((thread%16)/8);
-	}
-	else if(wmma_type==LOAD_B){
-		if(wmma_layout==ROW){
-			offset+=64*(index/4)+index%4+128*((thread%16)/8);	
-		}
-		else{
-			offset+=index+8*((thread%16)/8);
-		}
-		offset=(offset/16)*stride+offset%16;
-		assg_offset=index+8*((thread%16)/8);
-	}
-	else if( wmma_type==LOAD_C){
-		if(type==F16_TYPE){
-			row=c_row_offset[thread/4]+thread%4;	
-			col=c_col_offset[thread/4]+index;
-		}
-		else{
-			row=c_row_offset[thread/4]+c_tg_inside_row_offset[thread%4]+c_inside_row_offset[index];
-			col=c_col_offset[thread/4]+c_tg_inside_col_offset[thread%4]+c_inside_col_offset[index];
-		}
-		assg_offset=index;
-	}
+  if (wmma_type == LOAD_A) {
+    if (wmma_layout == ROW) {
+      offset += index + 8 * ((thread % 16) / 8);
+    } else {
+      offset += 64 * (index / 4) + index % 4 + 128 * ((thread % 16) / 8);
+    }
+    offset = (offset / 16) * stride + offset % 16;
+    assg_offset = index + 8 * ((thread % 16) / 8);
+  } else if (wmma_type == LOAD_B) {
+    if (wmma_layout == ROW) {
+      offset += 64 * (index / 4) + index % 4 + 128 * ((thread % 16) / 8);
+    } else {
+      offset += index + 8 * ((thread % 16) / 8);
+    }
+    offset = (offset / 16) * stride + offset % 16;
+    assg_offset = index + 8 * ((thread % 16) / 8);
+  } else if (wmma_type == LOAD_C) {
+    if (type == F16_TYPE) {
+      row = c_row_offset[thread / 4] + thread % 4;
+      col = c_col_offset[thread / 4] + index;
+    } else {
+      row = c_row_offset[thread / 4] + c_tg_inside_row_offset[thread % 4] +
+            c_inside_row_offset[index];
+      col = c_col_offset[thread / 4] + c_tg_inside_col_offset[thread % 4] +
+            c_inside_col_offset[index];
+    }
+    assg_offset = index;
+  }
 
-	if(wmma_type==LOAD_A||wmma_type==LOAD_B){	
-		if(wmma_layout==ROW){
-			row=offset/16;
-			col=offset%16;
-		}
-		else{
-			col=offset/16;
-			row=offset%16;
-		}
-	}
-}
-
-void mma_impl( const ptx_instruction *pI, core_t *core, warp_inst_t inst )
-{
-	int i,j,k,thrd;
-	int row,col,offset;
-   	ptx_reg_t matrix_a[16][16];
-   	ptx_reg_t matrix_b[16][16];
-   	ptx_reg_t matrix_c[16][16];
-   	ptx_reg_t matrix_d[16][16];
-   	ptx_reg_t src_data;
-	ptx_thread_info *thread;
-
-	unsigned a_layout = pI->get_wmma_layout(0);
-	unsigned b_layout = pI->get_wmma_layout(1);
-	unsigned type = pI->get_type();
-	unsigned type2 = pI->get_type2();
-	int tid ;
-	const operand_info &dst = pI->operand_lookup(0);
-	
-        if(core->get_gpu()->is_functional_sim())
-         	tid= inst.warp_id_func()*core->get_warp_size();
-        else
-         	tid= inst.warp_id()*core->get_warp_size();
-	float temp;
-	half temp2; 	
-	
-	for (thrd=0; thrd < core->get_warp_size(); thrd++){
-		thread = core->get_thread_info()[tid+thrd];
-		if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-			printf("THREAD=%d\n:",thrd);
-		for(int operand_num=1;operand_num<=3;operand_num++){
-			const operand_info &src_a=  pI->operand_lookup(operand_num);
-         		unsigned nelem = src_a.get_vect_nelem();
-         		ptx_reg_t v[8];
-         		thread->get_vector_operand_values( src_a, v, nelem );
-			if(core->get_gpu()->gpgpu_ctx->debug_tensorcore){
-				printf("Thread%d_Iteration=%d\n:", thrd, operand_num);
-				for(k = 0; k < nelem; k++){
-					printf("%llx ",v[k].u64);
-				}
-				printf("\n");
-			}
-			ptx_reg_t nw_v[16];
-			int hex_val;
-
-			if(!((operand_num==3)&&(type2==F32_TYPE))){
-					for(k=0;k<2*nelem;k++){
-					if(k%2==1)
-						hex_val=(v[k/2].s64&0xffff);
-					else
-						hex_val=((v[k/2].s64&0xffff0000)>>16);
-					nw_v[k].f16 =*((half *)&hex_val); 
-				}
-			}
-			if(!((operand_num==3)&&(type2==F32_TYPE))){
-				for(k=0;k<2*nelem;k++){
-					temp=nw_v[k].f16;
-					if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-						printf("%.2f ",temp);
-				}
-				if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-					printf("\n");
-			}
-			else{
-				if(core->get_gpu()->gpgpu_ctx->debug_tensorcore){
-					for(k=0;k<8;k++){
-						printf("%.2f ",v[k].f32);
-					}
-					printf("\n");
-				}
-			}
-			switch(operand_num) {
-			      case 1 ://operand 1
-				for(k=0;k<8;k++){
-					mapping(thrd,LOAD_A,a_layout,F16_TYPE,k,16,row,col,offset);
-					if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-						printf("A:thread=%d,row=%d,col=%d,offset=%d\n",thrd,row,col,offset);
-				 	matrix_a[row][col]=nw_v[offset];
-			        }
-			      break;
-			      case 2 ://operand 2
-				for(k=0;k<8;k++){
-					mapping(thrd,LOAD_B,b_layout,F16_TYPE,k,16,row,col,offset);
-					if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-						printf("B:thread=%d,row=%d,col=%d,offset=%d\n",thrd,row,col,offset);
-				 	matrix_b[row][col]=nw_v[offset];
-				}	
-			      break;
-			      case 3 ://operand 3
-				for(k=0;k<8;k++){
-					mapping(thrd,LOAD_C,ROW,type2,k,16,row,col,offset);
-					if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-						printf("C:thread=%d,row=%d,col=%d,offset=%d\n",thrd,row,col,offset);
-					if(type2!=F16_TYPE){
-					 	matrix_c[row][col]=v[offset];
-					}
-					else {
-				 		matrix_c[row][col]=nw_v[offset];
-					}
-				}
-			        break;
-			      default :
-			         printf("Invalid Operand Index\n" );
-			}
-		}
-		if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-			printf("\n");
-	}
-	if(core->get_gpu()->gpgpu_ctx->debug_tensorcore){
-		printf("MATRIX_A\n");
-		for (i=0;i<16;i++){
-			for(j=0;j<16;j++){
-				temp=matrix_a[i][j].f16;
-				printf("%.2f ",temp);
-			}
-			printf("\n");
-		}
-		printf("MATRIX_B\n");
-		for (i=0;i<16;i++){
-			for(j=0;j<16;j++){
-				temp=matrix_b[i][j].f16;
-				printf("%.2f ",temp);
-			}
-			printf("\n");
-		}	
-		printf("MATRIX_C\n");
-		for (i=0;i<16;i++){
-			for(j=0;j<16;j++){
-				if(type2==F16_TYPE){
-					temp=matrix_c[i][j].f16;
-					printf("%.2f ",temp);
-				}
-				else
-					printf("%.2f ",matrix_c[i][j].f32);
-			}
-			printf("\n");
-		}	
-	}
-	for (i=0;i<16;i++){
-		for(j=0;j<16;j++){
-				matrix_d[i][j].f16=0;
-		}
-	}
-	
-	for (i=0;i<16;i++){
-		for(j=0;j<16;j++){
-			for(k=0;k<16;k++){
-				matrix_d[i][j].f16=matrix_d[i][j].f16+matrix_a[i][k].f16*matrix_b[k][j].f16;
-			}
-			if((type==F16_TYPE)&&(type2==F16_TYPE))
-				matrix_d[i][j].f16+=matrix_c[i][j].f16;
-			else if((type==F32_TYPE)&&(type2==F16_TYPE)){
-				temp2=matrix_d[i][j].f16+matrix_c[i][j].f16;
-				temp=temp2;
-				matrix_d[i][j].f32=temp;
-			}
-			else if((type==F16_TYPE)&&(type2==F32_TYPE)){
-				temp=matrix_d[i][j].f16;
-				temp+=matrix_c[i][j].f32;
-				matrix_d[i][j].f16=half(temp);
-			}
-			else{
-				temp=matrix_d[i][j].f16;
-				temp+=matrix_c[i][j].f32;
-				matrix_d[i][j].f32=temp;
-			}
-		}
-	}
-	if(core->get_gpu()->gpgpu_ctx->debug_tensorcore){
-		printf("MATRIX_D\n");
-		for (i=0;i<16;i++){
-			for(j=0;j<16;j++){
-				if(type==F16_TYPE){
-					temp=matrix_d[i][j].f16;
-					printf("%.2f ",temp);
-				}
-				else
-					printf("%.2f ",matrix_d[i][j].f32);
-			}
-			printf("\n");
-		}	
-	}
-	for (thrd=0; thrd < core->get_warp_size(); thrd++){
-		int row_t[8];
-		int col_t[8];	
-		for(k=0;k<8;k++){
-			mapping(thrd,LOAD_C,ROW,type,k,16,row_t[k],col_t[k],offset);
-			if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-				printf("mma:store:row:%d,col%d\n",row_t[k],col_t[k]);
-		}
-		thread = core->get_thread_info()[tid+thrd];
-		
-	
-		if(type==F32_TYPE){
-			thread->set_wmma_vector_operand_values(dst,matrix_d[row_t[0]][col_t[0]],matrix_d[row_t[1]][col_t[1]],matrix_d[row_t[2]][col_t[2]],matrix_d[row_t[3]][col_t[3]],matrix_d[row_t[4]][col_t[4]],matrix_d[row_t[5]][col_t[5]],matrix_d[row_t[6]][col_t[6]],matrix_d[row_t[7]][col_t[7]]);
-		
-			if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-			{
-				printf("thread%d:",thrd);
-				for(k=0;k<8;k++){
-					printf("%.2f ",matrix_d[row_t[k]][col_t[k]].f32);
-				}
-				printf("\n");
-			}
-		}
-		else if(type==F16_TYPE){
-			if(core->get_gpu()->gpgpu_ctx->debug_tensorcore){	
-				printf("thread%d:",thrd);
-				for(k=0;k<8;k++){
-					temp=matrix_d[row_t[k]][col_t[k]].f16;
-					printf("%.2f ",temp);
-				}
-				printf("\n");
-
-				printf("thread%d:",thrd);
-				for(k=0;k<8;k++){
-					printf("%x ", (unsigned int)matrix_d[row_t[k]][col_t[k]].f16);
-				}
-				printf("\n");
-			}
-			ptx_reg_t nw_data1, nw_data2, nw_data3, nw_data4;
-			nw_data1.s64=((matrix_d[row_t[0]][col_t[0]].s64   & 0xffff))|((matrix_d[row_t[1]][col_t[1]].s64&0xffff)<<16);
-			nw_data2.s64=((matrix_d[row_t[2]][col_t[2]].s64   & 0xffff))|((matrix_d[row_t[3]][col_t[3]].s64&0xffff)<<16);
-			nw_data3.s64=((matrix_d[row_t[4]][col_t[4]].s64   & 0xffff))|((matrix_d[row_t[5]][col_t[5]].s64&0xffff)<<16);
-			nw_data4.s64=((matrix_d[row_t[6]][col_t[6]].s64   & 0xffff))|((matrix_d[row_t[7]][col_t[7]].s64&0xffff)<<16);
-   			thread->set_vector_operand_values(dst,nw_data1,nw_data2,nw_data3,nw_data4);
-			if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-		 		printf("thread%d=%llx,%llx,%llx,%llx", thrd, nw_data1.s64, nw_data2.s64, nw_data3.s64, nw_data4.s64);
-		
-		}
-		else{
-			printf("wmma:mma:wrong type\n");
-			abort();
-		}
-	}
+  if (wmma_type == LOAD_A || wmma_type == LOAD_B) {
+    if (wmma_layout == ROW) {
+      row = offset / 16;
+      col = offset % 16;
+    } else {
+      col = offset / 16;
+      row = offset % 16;
+    }
+  }
 }
 
-void call_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   static unsigned call_uid_next = 1;
-    
-   const operand_info &target  = pI->func_addr();
-   assert( target.is_function_address() );
-   const symbol *func_addr = target.get_symbol();
-   function_info *target_func = func_addr->get_pc();
-   if (target_func->is_pdom_set()) {
-      printf("GPGPU-Sim PTX: PDOM analysis already done for %s \n", target_func->get_name().c_str() );
-   } else {
-      printf("GPGPU-Sim PTX: finding reconvergence points for \'%s\'...\n", target_func->get_name().c_str() );
-      /*
-       * Some of the instructions like printf() gives the gpgpusim the wrong impression that it is a function call.
-       * As printf() doesnt have a body like functions do, doing pdom analysis for printf() causes a crash.
-       */
-      if (target_func->get_function_size() >0)
-          target_func->do_pdom();
-      target_func->set_pdom();
-   }
+void mma_impl(const ptx_instruction *pI, core_t *core, warp_inst_t inst) {
+  int i, j, k, thrd;
+  int row, col, offset;
+  ptx_reg_t matrix_a[16][16];
+  ptx_reg_t matrix_b[16][16];
+  ptx_reg_t matrix_c[16][16];
+  ptx_reg_t matrix_d[16][16];
+  ptx_reg_t src_data;
+  ptx_thread_info *thread;
 
-   // check that number of args and return match function requirements
-   if( pI->has_return() ^ target_func->has_return() ) {
-      printf("GPGPU-Sim PTX: Execution error - mismatch in number of return values between\n"
-             "               call instruction and function declaration\n");
-      abort(); 
-   }
-   unsigned n_return = target_func->has_return();
-   unsigned n_args = target_func->num_args();
-   unsigned n_operands = pI->get_num_operands();
+  unsigned a_layout = pI->get_wmma_layout(0);
+  unsigned b_layout = pI->get_wmma_layout(1);
+  unsigned type = pI->get_type();
+  unsigned type2 = pI->get_type2();
+  int tid;
+  const operand_info &dst = pI->operand_lookup(0);
 
-   if( n_operands != (n_return+1+n_args) ) {
-      printf("GPGPU-Sim PTX: Execution error - mismatch in number of arguements between\n"
-             "               call instruction and function declaration\n");
-      abort(); 
-   }
+  if (core->get_gpu()->is_functional_sim())
+    tid = inst.warp_id_func() * core->get_warp_size();
+  else
+    tid = inst.warp_id() * core->get_warp_size();
+  float temp;
+  half temp2;
 
-   // handle intrinsic functions
-   std::string fname = target_func->get_name();
-   if( fname == "vprintf" ) {
-      gpgpusim_cuda_vprintf(pI, thread, target_func);
-      return;
-   }
+  for (thrd = 0; thrd < core->get_warp_size(); thrd++) {
+    thread = core->get_thread_info()[tid + thrd];
+    if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+      printf("THREAD=%d\n:", thrd);
+    for (int operand_num = 1; operand_num <= 3; operand_num++) {
+      const operand_info &src_a = pI->operand_lookup(operand_num);
+      unsigned nelem = src_a.get_vect_nelem();
+      ptx_reg_t v[8];
+      thread->get_vector_operand_values(src_a, v, nelem);
+      if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) {
+        printf("Thread%d_Iteration=%d\n:", thrd, operand_num);
+        for (k = 0; k < nelem; k++) {
+          printf("%llx ", v[k].u64);
+        }
+        printf("\n");
+      }
+      ptx_reg_t nw_v[16];
+      int hex_val;
 
+      if (!((operand_num == 3) && (type2 == F32_TYPE))) {
+        for (k = 0; k < 2 * nelem; k++) {
+          if (k % 2 == 1)
+            hex_val = (v[k / 2].s64 & 0xffff);
+          else
+            hex_val = ((v[k / 2].s64 & 0xffff0000) >> 16);
+          nw_v[k].f16 = *((half *)&hex_val);
+        }
+      }
+      if (!((operand_num == 3) && (type2 == F32_TYPE))) {
+        for (k = 0; k < 2 * nelem; k++) {
+          temp = nw_v[k].f16;
+          if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+            printf("%.2f ", temp);
+        }
+        if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) printf("\n");
+      } else {
+        if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) {
+          for (k = 0; k < 8; k++) {
+            printf("%.2f ", v[k].f32);
+          }
+          printf("\n");
+        }
+      }
+      switch (operand_num) {
+        case 1:  // operand 1
+          for (k = 0; k < 8; k++) {
+            mapping(thrd, LOAD_A, a_layout, F16_TYPE, k, 16, row, col, offset);
+            if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+              printf("A:thread=%d,row=%d,col=%d,offset=%d\n", thrd, row, col,
+                     offset);
+            matrix_a[row][col] = nw_v[offset];
+          }
+          break;
+        case 2:  // operand 2
+          for (k = 0; k < 8; k++) {
+            mapping(thrd, LOAD_B, b_layout, F16_TYPE, k, 16, row, col, offset);
+            if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+              printf("B:thread=%d,row=%d,col=%d,offset=%d\n", thrd, row, col,
+                     offset);
+            matrix_b[row][col] = nw_v[offset];
+          }
+          break;
+        case 3:  // operand 3
+          for (k = 0; k < 8; k++) {
+            mapping(thrd, LOAD_C, ROW, type2, k, 16, row, col, offset);
+            if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+              printf("C:thread=%d,row=%d,col=%d,offset=%d\n", thrd, row, col,
+                     offset);
+            if (type2 != F16_TYPE) {
+              matrix_c[row][col] = v[offset];
+            } else {
+              matrix_c[row][col] = nw_v[offset];
+            }
+          }
+          break;
+        default:
+          printf("Invalid Operand Index\n");
+      }
+    }
+    if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) printf("\n");
+  }
+  if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) {
+    printf("MATRIX_A\n");
+    for (i = 0; i < 16; i++) {
+      for (j = 0; j < 16; j++) {
+        temp = matrix_a[i][j].f16;
+        printf("%.2f ", temp);
+      }
+      printf("\n");
+    }
+    printf("MATRIX_B\n");
+    for (i = 0; i < 16; i++) {
+      for (j = 0; j < 16; j++) {
+        temp = matrix_b[i][j].f16;
+        printf("%.2f ", temp);
+      }
+      printf("\n");
+    }
+    printf("MATRIX_C\n");
+    for (i = 0; i < 16; i++) {
+      for (j = 0; j < 16; j++) {
+        if (type2 == F16_TYPE) {
+          temp = matrix_c[i][j].f16;
+          printf("%.2f ", temp);
+        } else
+          printf("%.2f ", matrix_c[i][j].f32);
+      }
+      printf("\n");
+    }
+  }
+  for (i = 0; i < 16; i++) {
+    for (j = 0; j < 16; j++) {
+      matrix_d[i][j].f16 = 0;
+    }
+  }
+
+  for (i = 0; i < 16; i++) {
+    for (j = 0; j < 16; j++) {
+      for (k = 0; k < 16; k++) {
+        matrix_d[i][j].f16 =
+            matrix_d[i][j].f16 + matrix_a[i][k].f16 * matrix_b[k][j].f16;
+      }
+      if ((type == F16_TYPE) && (type2 == F16_TYPE))
+        matrix_d[i][j].f16 += matrix_c[i][j].f16;
+      else if ((type == F32_TYPE) && (type2 == F16_TYPE)) {
+        temp2 = matrix_d[i][j].f16 + matrix_c[i][j].f16;
+        temp = temp2;
+        matrix_d[i][j].f32 = temp;
+      } else if ((type == F16_TYPE) && (type2 == F32_TYPE)) {
+        temp = matrix_d[i][j].f16;
+        temp += matrix_c[i][j].f32;
+        matrix_d[i][j].f16 = half(temp);
+      } else {
+        temp = matrix_d[i][j].f16;
+        temp += matrix_c[i][j].f32;
+        matrix_d[i][j].f32 = temp;
+      }
+    }
+  }
+  if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) {
+    printf("MATRIX_D\n");
+    for (i = 0; i < 16; i++) {
+      for (j = 0; j < 16; j++) {
+        if (type == F16_TYPE) {
+          temp = matrix_d[i][j].f16;
+          printf("%.2f ", temp);
+        } else
+          printf("%.2f ", matrix_d[i][j].f32);
+      }
+      printf("\n");
+    }
+  }
+  for (thrd = 0; thrd < core->get_warp_size(); thrd++) {
+    int row_t[8];
+    int col_t[8];
+    for (k = 0; k < 8; k++) {
+      mapping(thrd, LOAD_C, ROW, type, k, 16, row_t[k], col_t[k], offset);
+      if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+        printf("mma:store:row:%d,col%d\n", row_t[k], col_t[k]);
+    }
+    thread = core->get_thread_info()[tid + thrd];
+
+    if (type == F32_TYPE) {
+      thread->set_wmma_vector_operand_values(
+          dst, matrix_d[row_t[0]][col_t[0]], matrix_d[row_t[1]][col_t[1]],
+          matrix_d[row_t[2]][col_t[2]], matrix_d[row_t[3]][col_t[3]],
+          matrix_d[row_t[4]][col_t[4]], matrix_d[row_t[5]][col_t[5]],
+          matrix_d[row_t[6]][col_t[6]], matrix_d[row_t[7]][col_t[7]]);
+
+      if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) {
+        printf("thread%d:", thrd);
+        for (k = 0; k < 8; k++) {
+          printf("%.2f ", matrix_d[row_t[k]][col_t[k]].f32);
+        }
+        printf("\n");
+      }
+    } else if (type == F16_TYPE) {
+      if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) {
+        printf("thread%d:", thrd);
+        for (k = 0; k < 8; k++) {
+          temp = matrix_d[row_t[k]][col_t[k]].f16;
+          printf("%.2f ", temp);
+        }
+        printf("\n");
+
+        printf("thread%d:", thrd);
+        for (k = 0; k < 8; k++) {
+          printf("%x ", (unsigned int)matrix_d[row_t[k]][col_t[k]].f16);
+        }
+        printf("\n");
+      }
+      ptx_reg_t nw_data1, nw_data2, nw_data3, nw_data4;
+      nw_data1.s64 = ((matrix_d[row_t[0]][col_t[0]].s64 & 0xffff)) |
+                     ((matrix_d[row_t[1]][col_t[1]].s64 & 0xffff) << 16);
+      nw_data2.s64 = ((matrix_d[row_t[2]][col_t[2]].s64 & 0xffff)) |
+                     ((matrix_d[row_t[3]][col_t[3]].s64 & 0xffff) << 16);
+      nw_data3.s64 = ((matrix_d[row_t[4]][col_t[4]].s64 & 0xffff)) |
+                     ((matrix_d[row_t[5]][col_t[5]].s64 & 0xffff) << 16);
+      nw_data4.s64 = ((matrix_d[row_t[6]][col_t[6]].s64 & 0xffff)) |
+                     ((matrix_d[row_t[7]][col_t[7]].s64 & 0xffff) << 16);
+      thread->set_vector_operand_values(dst, nw_data1, nw_data2, nw_data3,
+                                        nw_data4);
+      if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+        printf("thread%d=%llx,%llx,%llx,%llx", thrd, nw_data1.s64, nw_data2.s64,
+               nw_data3.s64, nw_data4.s64);
+
+    } else {
+      printf("wmma:mma:wrong type\n");
+      abort();
+    }
+  }
+}
+
+void call_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  static unsigned call_uid_next = 1;
+
+  const operand_info &target = pI->func_addr();
+  assert(target.is_function_address());
+  const symbol *func_addr = target.get_symbol();
+  function_info *target_func = func_addr->get_pc();
+  if (target_func->is_pdom_set()) {
+    printf("GPGPU-Sim PTX: PDOM analysis already done for %s \n",
+           target_func->get_name().c_str());
+  } else {
+    printf("GPGPU-Sim PTX: finding reconvergence points for \'%s\'...\n",
+           target_func->get_name().c_str());
+    /*
+     * Some of the instructions like printf() gives the gpgpusim the wrong
+     * impression that it is a function call.
+     * As printf() doesnt have a body like functions do, doing pdom analysis for
+     * printf() causes a crash.
+     */
+    if (target_func->get_function_size() > 0) target_func->do_pdom();
+    target_func->set_pdom();
+  }
+
+  // check that number of args and return match function requirements
+  if (pI->has_return() ^ target_func->has_return()) {
+    printf(
+        "GPGPU-Sim PTX: Execution error - mismatch in number of return values "
+        "between\n"
+        "               call instruction and function declaration\n");
+    abort();
+  }
+  unsigned n_return = target_func->has_return();
+  unsigned n_args = target_func->num_args();
+  unsigned n_operands = pI->get_num_operands();
+
+  if (n_operands != (n_return + 1 + n_args)) {
+    printf(
+        "GPGPU-Sim PTX: Execution error - mismatch in number of arguements "
+        "between\n"
+        "               call instruction and function declaration\n");
+    abort();
+  }
+
+  // handle intrinsic functions
+  std::string fname = target_func->get_name();
+  if (fname == "vprintf") {
+    gpgpusim_cuda_vprintf(pI, thread, target_func);
+    return;
+  }
 #if (CUDART_VERSION >= 5000)
-   //Jin: handle device runtime apis for CDP
-   else if(fname == "cudaGetParameterBufferV2") {
-      target_func->gpgpu_ctx->device_runtime->gpgpusim_cuda_getParameterBufferV2(pI, thread, target_func);
-	  return;
-   }
-   else if(fname == "cudaLaunchDeviceV2") {
-      target_func->gpgpu_ctx->device_runtime->gpgpusim_cuda_launchDeviceV2(pI, thread, target_func);
-	  return;
-   }
-   else if(fname == "cudaStreamCreateWithFlags") {
-      target_func->gpgpu_ctx->device_runtime->gpgpusim_cuda_streamCreateWithFlags(pI, thread, target_func);
-	  return;
-   }
+  // Jin: handle device runtime apis for CDP
+  else if (fname == "cudaGetParameterBufferV2") {
+    target_func->gpgpu_ctx->device_runtime->gpgpusim_cuda_getParameterBufferV2(
+        pI, thread, target_func);
+    return;
+  } else if (fname == "cudaLaunchDeviceV2") {
+    target_func->gpgpu_ctx->device_runtime->gpgpusim_cuda_launchDeviceV2(
+        pI, thread, target_func);
+    return;
+  } else if (fname == "cudaStreamCreateWithFlags") {
+    target_func->gpgpu_ctx->device_runtime->gpgpusim_cuda_streamCreateWithFlags(
+        pI, thread, target_func);
+    return;
+  }
 #endif
 
-   // read source arguements into register specified in declaration of function
-   arg_buffer_list_t arg_values;
-   copy_args_into_buffer_list(pI, thread, target_func, arg_values);
+  // read source arguements into register specified in declaration of function
+  arg_buffer_list_t arg_values;
+  copy_args_into_buffer_list(pI, thread, target_func, arg_values);
 
-   // record local for return value (we only support a single return value)
-   const symbol *return_var_src = NULL;
-   const symbol *return_var_dst = NULL;
-   if( target_func->has_return() ) {
-      return_var_dst = pI->dst().get_symbol();
-      return_var_src = target_func->get_return_var();
-   }
+  // record local for return value (we only support a single return value)
+  const symbol *return_var_src = NULL;
+  const symbol *return_var_dst = NULL;
+  if (target_func->has_return()) {
+    return_var_dst = pI->dst().get_symbol();
+    return_var_src = target_func->get_return_var();
+  }
 
-   gpgpu_sim *gpu = thread->get_gpu();
-   unsigned callee_pc=0, callee_rpc=0;
-   if( gpu->simd_model() == POST_DOMINATOR ) {
-      thread->get_core()->get_pdom_stack_top_info(thread->get_hw_wid(),&callee_pc,&callee_rpc);
-      assert( callee_pc == thread->get_pc() );
-   }
+  gpgpu_sim *gpu = thread->get_gpu();
+  unsigned callee_pc = 0, callee_rpc = 0;
+  if (gpu->simd_model() == POST_DOMINATOR) {
+    thread->get_core()->get_pdom_stack_top_info(thread->get_hw_wid(),
+                                                &callee_pc, &callee_rpc);
+    assert(callee_pc == thread->get_pc());
+  }
 
-   thread->callstack_push(callee_pc + pI->inst_size(), callee_rpc, return_var_src, return_var_dst, call_uid_next++);
+  thread->callstack_push(callee_pc + pI->inst_size(), callee_rpc,
+                         return_var_src, return_var_dst, call_uid_next++);
 
-   copy_buffer_list_into_frame(thread, arg_values);
+  copy_buffer_list_into_frame(thread, arg_values);
 
-   thread->set_npc(target_func);
+  thread->set_npc(target_func);
 }
 
-//Ptxplus version of call instruction. Jumps to a label not a different Kernel.
-void callp_impl( const ptx_instruction *pI, ptx_thread_info *thread )
-{
-   
-   static unsigned call_uid_next = 1;
+// Ptxplus version of call instruction. Jumps to a label not a different Kernel.
+void callp_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  static unsigned call_uid_next = 1;
 
-   const operand_info &target  = pI->dst();
-   ptx_reg_t target_pc = thread->get_operand_value(target, target, U32_TYPE, thread, 1);
+  const operand_info &target = pI->dst();
+  ptx_reg_t target_pc =
+      thread->get_operand_value(target, target, U32_TYPE, thread, 1);
 
-   const symbol *return_var_src = NULL;
-   const symbol *return_var_dst = NULL;
+  const symbol *return_var_src = NULL;
+  const symbol *return_var_dst = NULL;
 
-   gpgpu_sim *gpu = thread->get_gpu();
-   unsigned callee_pc=0, callee_rpc=0;
-   if( gpu->simd_model() == POST_DOMINATOR ) {
-      thread->get_core()->get_pdom_stack_top_info(thread->get_hw_wid(),&callee_pc,&callee_rpc);
-      assert( callee_pc == thread->get_pc() );
-   } 
+  gpgpu_sim *gpu = thread->get_gpu();
+  unsigned callee_pc = 0, callee_rpc = 0;
+  if (gpu->simd_model() == POST_DOMINATOR) {
+    thread->get_core()->get_pdom_stack_top_info(thread->get_hw_wid(),
+                                                &callee_pc, &callee_rpc);
+    assert(callee_pc == thread->get_pc());
+  }
 
-   thread->callstack_push_plus(callee_pc + pI->inst_size(), callee_rpc, return_var_src, return_var_dst, call_uid_next++);
-   thread->set_npc(target_pc);
+  thread->callstack_push_plus(callee_pc + pI->inst_size(), callee_rpc,
+                              return_var_src, return_var_dst, call_uid_next++);
+  thread->set_npc(target_pc);
 }
 
-void clz_impl( const ptx_instruction *pI, ptx_thread_info *thread )
-{
-   ptx_reg_t a, d;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
+void clz_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, d;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
 
-   unsigned i_type = pI->get_type();
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
 
-   int max;
-   unsigned long long mask;
-   d.u64 = 0;
+  int max;
+  unsigned long long mask;
+  d.u64 = 0;
 
-   switch ( i_type ) {
-   case B32_TYPE:
+  switch (i_type) {
+    case B32_TYPE:
       max = 32;
       mask = 0x80000000;
       break;
-   case B64_TYPE:
+    case B64_TYPE:
       max = 64;
       mask = 0x8000000000000000;
       break;
-   default:
+    default:
       printf("Execution error: type mismatch with instruction\n");
       assert(0);
       break;
-   }
+  }
 
-   while ((d.u32 < max) && ((a.u64&mask) == 0) ) {
-      d.u32++;
-      a.u64 = a.u64 << 1;
-   }
+  while ((d.u32 < max) && ((a.u64 & mask) == 0)) {
+    d.u32++;
+    a.u64 = a.u64 << 1;
+  }
 
-   thread->set_operand_value(dst,d, B32_TYPE, thread, pI);
+  thread->set_operand_value(dst, d, B32_TYPE, thread, pI);
 }
 
-void cnot_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t a, b, d;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
+void cnot_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, b, d;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
 
-   unsigned i_type = pI->get_type();
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
 
-   switch ( i_type ) {
-   case PRED_TYPE: d.pred = ((a.pred & 0x0001) == 0)?1:0; break;
-   case B16_TYPE:  d.u16  = (a.u16  == 0)?1:0; break;
-   case B32_TYPE:  d.u32  = (a.u32  == 0)?1:0; break;
-   case B64_TYPE:  d.u64  = (a.u64  == 0)?1:0; break;
-   default:
+  switch (i_type) {
+    case PRED_TYPE:
+      d.pred = ((a.pred & 0x0001) == 0) ? 1 : 0;
+      break;
+    case B16_TYPE:
+      d.u16 = (a.u16 == 0) ? 1 : 0;
+      break;
+    case B32_TYPE:
+      d.u32 = (a.u32 == 0) ? 1 : 0;
+      break;
+    case B64_TYPE:
+      d.u64 = (a.u64 == 0) ? 1 : 0;
+      break;
+    default:
       printf("Execution error: type mismatch with instruction\n");
       assert(0);
       break;
-   }
+  }
 
-   thread->set_operand_value(dst,d, i_type, thread, pI);
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-void cos_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   ptx_reg_t a, d;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
+void cos_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, d;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
 
-   unsigned i_type = pI->get_type();
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
 
-
-   switch ( i_type ) {
-   case F32_TYPE: 
+  switch (i_type) {
+    case F32_TYPE:
       d.f32 = cos(a.f32);
       break;
-   default:
+    default:
       printf("Execution error: type mismatch with instruction\n");
-      assert(0); 
+      assert(0);
       break;
-   }
+  }
 
-   thread->set_operand_value(dst,d, i_type, thread, pI);
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-ptx_reg_t chop( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
-{
-   switch ( to_width ) {
-   case 8:  x.mask_and(0,0xFF);  break;
-   case 16: x.mask_and(0,0xFFFF);      break;
-   case 32: x.mask_and(0,0xFFFFFFFF);  break;
-   case 64: break;
-   default: assert(0);
-   }
-   return x;
+ptx_reg_t chop(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
+               int rounding_mode, int saturation_mode) {
+  switch (to_width) {
+    case 8:
+      x.mask_and(0, 0xFF);
+      break;
+    case 16:
+      x.mask_and(0, 0xFFFF);
+      break;
+    case 32:
+      x.mask_and(0, 0xFFFFFFFF);
+      break;
+    case 64:
+      break;
+    default:
+      assert(0);
+  }
+  return x;
 }
 
-ptx_reg_t sext( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
-{
-   x=chop(x,0,from_width,0,rounding_mode,saturation_mode);
-   switch ( from_width ) {
-   case 8: if ( x.get_bit(7) ) x.mask_or(0xFFFFFFFF,0xFFFFFF00);break;
-   case 16:if ( x.get_bit(15) ) x.mask_or(0xFFFFFFFF,0xFFFF0000);break;
-   case 32: if ( x.get_bit(31) ) x.mask_or(0xFFFFFFFF,0x00000000);break;
-   case 64: break;
-   default: assert(0);
-   }
-   return x;
+ptx_reg_t sext(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
+               int rounding_mode, int saturation_mode) {
+  x = chop(x, 0, from_width, 0, rounding_mode, saturation_mode);
+  switch (from_width) {
+    case 8:
+      if (x.get_bit(7)) x.mask_or(0xFFFFFFFF, 0xFFFFFF00);
+      break;
+    case 16:
+      if (x.get_bit(15)) x.mask_or(0xFFFFFFFF, 0xFFFF0000);
+      break;
+    case 32:
+      if (x.get_bit(31)) x.mask_or(0xFFFFFFFF, 0x00000000);
+      break;
+    case 64:
+      break;
+    default:
+      assert(0);
+  }
+  return x;
 }
 
-// sign extend depending on the destination register size - hack to get SobelFilter working in CUDA 4.2
-ptx_reg_t sexd( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
-{
-   x=chop(x,0,from_width,0,rounding_mode,saturation_mode);
-   switch ( to_width ) {
-   case 8: if ( x.get_bit(7) ) x.mask_or(0xFFFFFFFF,0xFFFFFF00);break;
-   case 16:if ( x.get_bit(15) ) x.mask_or(0xFFFFFFFF,0xFFFF0000);break;
-   case 32: if ( x.get_bit(31) ) x.mask_or(0xFFFFFFFF,0x00000000);break;
-   case 64: break;
-   default: assert(0);
-   }
-   return x;
+// sign extend depending on the destination register size - hack to get
+// SobelFilter working in CUDA 4.2
+ptx_reg_t sexd(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
+               int rounding_mode, int saturation_mode) {
+  x = chop(x, 0, from_width, 0, rounding_mode, saturation_mode);
+  switch (to_width) {
+    case 8:
+      if (x.get_bit(7)) x.mask_or(0xFFFFFFFF, 0xFFFFFF00);
+      break;
+    case 16:
+      if (x.get_bit(15)) x.mask_or(0xFFFFFFFF, 0xFFFF0000);
+      break;
+    case 32:
+      if (x.get_bit(31)) x.mask_or(0xFFFFFFFF, 0x00000000);
+      break;
+    case 64:
+      break;
+    default:
+      assert(0);
+  }
+  return x;
 }
 
-ptx_reg_t zext( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
-{
-   return chop(x,0,from_width,0,rounding_mode,saturation_mode);
+ptx_reg_t zext(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
+               int rounding_mode, int saturation_mode) {
+  return chop(x, 0, from_width, 0, rounding_mode, saturation_mode);
 }
 
-int saturatei(int a, int max, int min) 
-{
-   if (a > max) a = max;
-   else if (a < min) a = min;
-   return a;
+int saturatei(int a, int max, int min) {
+  if (a > max)
+    a = max;
+  else if (a < min)
+    a = min;
+  return a;
 }
 
-unsigned int saturatei(unsigned int a, unsigned int max) 
-{
-   if (a > max) a = max;
-   return a;
+unsigned int saturatei(unsigned int a, unsigned int max) {
+  if (a > max) a = max;
+  return a;
 }
 
-ptx_reg_t f2x( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
-{
-   half mytemp;
-   half_float::half tmp_h;
-   //assert( from_width == 32); 
+ptx_reg_t f2x(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
+              int rounding_mode, int saturation_mode) {
+  half mytemp;
+  half_float::half tmp_h;
+  // assert( from_width == 32);
 
-   enum cudaRoundMode mode = cudaRoundZero;
-   switch (rounding_mode) {
-   case RZI_OPTION: mode = cudaRoundZero;    break;
-   case RNI_OPTION: mode = cudaRoundNearest; break;
-   case RMI_OPTION: mode = cudaRoundMinInf;  break;
-   case RPI_OPTION: mode = cudaRoundPosInf;  break;
-   default: break; 
-   }
+  enum cudaRoundMode mode = cudaRoundZero;
+  switch (rounding_mode) {
+    case RZI_OPTION:
+      mode = cudaRoundZero;
+      break;
+    case RNI_OPTION:
+      mode = cudaRoundNearest;
+      break;
+    case RMI_OPTION:
+      mode = cudaRoundMinInf;
+      break;
+    case RPI_OPTION:
+      mode = cudaRoundPosInf;
+      break;
+    default:
+      break;
+  }
 
-   ptx_reg_t y;
-   if ( to_sign == 1 ) { // convert to 64-bit number first?
-      int tmp = cuda_math::float2int(x.f32, mode);
-      if ((x.u32 & 0x7f800000) == 0)
-         tmp = 0; // round denorm. FP to 0
-      if (saturation_mode && to_width < 32) {
-         tmp = saturatei(tmp, (1<<to_width) - 1, -(1<<to_width));
-      }
-      switch ( to_width ) {
-      case 8:  y.s8  = (char)tmp; break;
-      case 16: y.s16 = (short)tmp; break;
-      case 32: y.s32 = (int)tmp; break;
-      case 64: y.s64 = (long long)tmp; break;
-      default: assert(0); break;
-      }
-   } else if ( to_sign == 0 ) {
-      unsigned int tmp = cuda_math::float2uint(x.f32, mode);
-      if ((x.u32 & 0x7f800000) == 0)
-         tmp = 0; // round denorm. FP to 0
-      if (saturation_mode && to_width < 32) {
-         tmp = saturatei(tmp, (1<<to_width) - 1);
-      }
-      switch ( to_width ) {
-      case 8:  y.u8  = (unsigned char)tmp; break;
-      case 16: y.u16 = (unsigned short)tmp; break;
-      case 32: y.u32 = (unsigned int)tmp; break;
-      case 64: y.u64 = (unsigned long long)tmp; break;
-      default: assert(0); break;
-      }
-   } else {
-      switch ( to_width ) {
-      case 16: 
-	 y.f16 =half_float::half_cast<half,std::numeric_limits<float>::round_style>(x.f32);//mytemp;
- 	 break;
-      case 32: 
-	 y.f32=float(x.f16);
-	 break; // handled by f2f
-      case 64: 
-         y.f64 = x.f32; 
-         break;
-      default: assert(0); break;
-      }
-   }
-   return y;
-}
-
-double saturated2i (double a, double max, double min) {
-   if (a > max) a = max;
-   else if (a < min) a = min;
-   return a;
-}
-
-ptx_reg_t d2x( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
-{
-   assert( from_width == 64); 
-
-   double tmp;
-   switch (rounding_mode) {
-   case RZI_OPTION: tmp = trunc(x.f64);     break;
-   case RNI_OPTION: tmp = nearbyint(x.f64); break;
-   case RMI_OPTION: tmp = floor(x.f64);     break;
-   case RPI_OPTION: tmp = ceil(x.f64);      break;
-   default: tmp = x.f64; break; 
-   }
-
-   ptx_reg_t y;
-   if ( to_sign == 1 ) {
-      tmp = saturated2i(tmp, ((1<<(to_width - 1)) - 1), (1<<(to_width - 1)) );
-      switch ( to_width ) {
-      case 8:  y.s8  = (char)tmp; break;
-      case 16: y.s16 = (short)tmp; break;
-      case 32: y.s32 = (int)tmp; break;
-      case 64: y.s64 = (long long)tmp; break;
-      default: assert(0); break;
-      }
-   } else if ( to_sign == 0 ) {
-      tmp = saturated2i(tmp, ((1<<(to_width - 1)) - 1), 0);
-      switch ( to_width ) {
-      case 8:  y.u8  = (unsigned char)tmp; break;
-      case 16: y.u16 = (unsigned short)tmp; break;
-      case 32: y.u32 = (unsigned int)tmp; break;
-      case 64: y.u64 = (unsigned long long)tmp; break;
-      default: assert(0); break;
-      }
-   } else {
-      switch ( to_width ) {
-      case 16: assert(0); break;
+  ptx_reg_t y;
+  if (to_sign == 1) {  // convert to 64-bit number first?
+    int tmp = cuda_math::float2int(x.f32, mode);
+    if ((x.u32 & 0x7f800000) == 0) tmp = 0;  // round denorm. FP to 0
+    if (saturation_mode && to_width < 32) {
+      tmp = saturatei(tmp, (1 << to_width) - 1, -(1 << to_width));
+    }
+    switch (to_width) {
+      case 8:
+        y.s8 = (char)tmp;
+        break;
+      case 16:
+        y.s16 = (short)tmp;
+        break;
       case 32:
-         y.f32 = x.f64;  
-         break;
-      case 64: 
-         y.f64 = x.f64; // should be handled by d2d
-         break;
-      default: assert(0); break;
-      }
-   }
-   return y;
+        y.s32 = (int)tmp;
+        break;
+      case 64:
+        y.s64 = (long long)tmp;
+        break;
+      default:
+        assert(0);
+        break;
+    }
+  } else if (to_sign == 0) {
+    unsigned int tmp = cuda_math::float2uint(x.f32, mode);
+    if ((x.u32 & 0x7f800000) == 0) tmp = 0;  // round denorm. FP to 0
+    if (saturation_mode && to_width < 32) {
+      tmp = saturatei(tmp, (1 << to_width) - 1);
+    }
+    switch (to_width) {
+      case 8:
+        y.u8 = (unsigned char)tmp;
+        break;
+      case 16:
+        y.u16 = (unsigned short)tmp;
+        break;
+      case 32:
+        y.u32 = (unsigned int)tmp;
+        break;
+      case 64:
+        y.u64 = (unsigned long long)tmp;
+        break;
+      default:
+        assert(0);
+        break;
+    }
+  } else {
+    switch (to_width) {
+      case 16:
+        y.f16 = half_float::half_cast<half,
+                                      std::numeric_limits<float>::round_style>(
+            x.f32);  // mytemp;
+        break;
+      case 32:
+        y.f32 = float(x.f16);
+        break;  // handled by f2f
+      case 64:
+        y.f64 = x.f32;
+        break;
+      default:
+        assert(0);
+        break;
+    }
+  }
+  return y;
 }
 
-ptx_reg_t s2f( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
-{
-   ptx_reg_t y;
-
-   if (from_width < 64) { // 32-bit conversion
-      y = sext(x,from_width,32,0,rounding_mode,saturation_mode);
-
-      switch ( to_width ) {
-      case 16: assert(0); break;
-      case 32: 
-         switch (rounding_mode) {
-         case RZ_OPTION: y.f32 = cuda_math::__int2float_rz(y.s32); break;
-         case RN_OPTION: y.f32 = cuda_math::__int2float_rn(y.s32); break;
-         case RM_OPTION: y.f32 = cuda_math::__int2float_rd(y.s32); break;
-         case RP_OPTION: y.f32 = cuda_math::__int2float_ru(y.s32); break;
-         default: break; 
-         }
-         break;
-      case 64: y.f64 = y.s32; break; // no rounding needed
-      default: assert(0); break;
-      }
-   } else {
-      switch ( to_width ) {
-      case 16: assert(0); break;
-      case 32: 
-         switch (rounding_mode) {
-         case RZ_OPTION: y.f32 = cuda_math::__ll2float_rz(y.s64); break; 
-         case RN_OPTION: y.f32 = cuda_math::__ll2float_rn(y.s64); break;
-         case RM_OPTION: y.f32 = cuda_math::__ll2float_rd(y.s64); break; 
-         case RP_OPTION: y.f32 = cuda_math::__ll2float_ru(y.s64); break;
-         default: break; 
-         }
-         break;
-      case 64: y.f64 = y.s64; break; // no internal implementation found
-      default: assert(0); break;
-      }
-   }
-
-   // saturating an integer to 1 or 0?
-   return y;
+double saturated2i(double a, double max, double min) {
+  if (a > max)
+    a = max;
+  else if (a < min)
+    a = min;
+  return a;
 }
 
-ptx_reg_t u2f( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
-{
-   ptx_reg_t y;
+ptx_reg_t d2x(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
+              int rounding_mode, int saturation_mode) {
+  assert(from_width == 64);
 
-   if (from_width < 64) { // 32-bit conversion
-      y = zext(x,from_width,32,0,rounding_mode,saturation_mode);
+  double tmp;
+  switch (rounding_mode) {
+    case RZI_OPTION:
+      tmp = trunc(x.f64);
+      break;
+    case RNI_OPTION:
+      tmp = nearbyint(x.f64);
+      break;
+    case RMI_OPTION:
+      tmp = floor(x.f64);
+      break;
+    case RPI_OPTION:
+      tmp = ceil(x.f64);
+      break;
+    default:
+      tmp = x.f64;
+      break;
+  }
 
-      switch ( to_width ) {
-      case 16: assert(0); break;
-      case 32: 
-         switch (rounding_mode) {
-         case RZ_OPTION: y.f32 = cuda_math::__uint2float_rz(y.u32); break;
-         case RN_OPTION: y.f32 = cuda_math::__uint2float_rn(y.u32); break;
-         case RM_OPTION: y.f32 = cuda_math::__uint2float_rd(y.u32); break;
-         case RP_OPTION: y.f32 = cuda_math::__uint2float_ru(y.u32); break;
-         default: break; 
-         }
-         break;
-      case 64: y.f64 = y.u32; break; // no rounding needed
-      default: assert(0); break;
-      }
-   } else {
-      switch ( to_width ) {
-      case 16: assert(0); break;
-      case 32: 
-         switch (rounding_mode) {
-         case RZ_OPTION: y.f32 = cuda_math::__ull2float_rn(y.u64); break; 
-         case RN_OPTION: y.f32 = cuda_math::__ull2float_rn(y.u64); break;
-         case RM_OPTION: y.f32 = cuda_math::__ull2float_rn(y.u64); break; 
-         case RP_OPTION: y.f32 = cuda_math::__ull2float_rn(y.u64); break; 
-         default: break; 
-         }
-         break;
-      case 64: y.f64 = y.u64; break; // no internal implementation found
-      default: assert(0); break;
-      }
-   }
-
-   // saturating an integer to 1 or 0?
-   return y;
+  ptx_reg_t y;
+  if (to_sign == 1) {
+    tmp = saturated2i(tmp, ((1 << (to_width - 1)) - 1), (1 << (to_width - 1)));
+    switch (to_width) {
+      case 8:
+        y.s8 = (char)tmp;
+        break;
+      case 16:
+        y.s16 = (short)tmp;
+        break;
+      case 32:
+        y.s32 = (int)tmp;
+        break;
+      case 64:
+        y.s64 = (long long)tmp;
+        break;
+      default:
+        assert(0);
+        break;
+    }
+  } else if (to_sign == 0) {
+    tmp = saturated2i(tmp, ((1 << (to_width - 1)) - 1), 0);
+    switch (to_width) {
+      case 8:
+        y.u8 = (unsigned char)tmp;
+        break;
+      case 16:
+        y.u16 = (unsigned short)tmp;
+        break;
+      case 32:
+        y.u32 = (unsigned int)tmp;
+        break;
+      case 64:
+        y.u64 = (unsigned long long)tmp;
+        break;
+      default:
+        assert(0);
+        break;
+    }
+  } else {
+    switch (to_width) {
+      case 16:
+        assert(0);
+        break;
+      case 32:
+        y.f32 = x.f64;
+        break;
+      case 64:
+        y.f64 = x.f64;  // should be handled by d2d
+        break;
+      default:
+        assert(0);
+        break;
+    }
+  }
+  return y;
 }
 
-ptx_reg_t f2f( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
-{
-   ptx_reg_t y;
-   if (from_width == 16){
-       half_float::detail::uint16 val = x.u16;
-       y.f32 = half_float::detail::half2float<float>(val);
-   }else{
-       switch ( rounding_mode ) {
-       case RZI_OPTION: 
-          y.f32 = truncf(x.f32); 
-          break;          
-       case RNI_OPTION: 
-    #if CUDART_VERSION >= 3000
-          y.f32 = nearbyintf(x.f32); 
-    #else
-          y.f32 = cuda_math::__internal_nearbyintf(x.f32); 
-    #endif
-          break;          
-       case RMI_OPTION: 
-          if ((x.u32 & 0x7f800000) == 0) {
-             y.u32 = x.u32 & 0x80000000; // round denorm. FP to 0, keeping sign
-          } else {
-             y.f32 = floorf(x.f32); 
-          }
-          break;          
-       case RPI_OPTION: 
-          if ((x.u32 & 0x7f800000) == 0) {
-             y.u32 = x.u32 & 0x80000000; // round denorm. FP to 0, keeping sign
-          } else {
-             y.f32 = ceilf(x.f32); 
-          }
-          break;          
-       default: 
-          if ((x.u32 & 0x7f800000) == 0) {
-             y.u32 = x.u32 & 0x80000000; // round denorm. FP to 0, keeping sign
-          } else {
-             y.f32 = x.f32;
-          }
-          break; 
-       }
-    #if CUDART_VERSION >= 3000
-       if (isnanf(y.f32)) 
-    #else
-       if (cuda_math::__cuda___isnanf(y.f32)) 
-    #endif
-       {
-          y.u32 = 0x7fffffff;
-       } else if (saturation_mode) {
-          y.f32 = cuda_math::__saturatef(y.f32);
-       }
-   }
+ptx_reg_t s2f(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
+              int rounding_mode, int saturation_mode) {
+  ptx_reg_t y;
 
-   return y;
+  if (from_width < 64) {  // 32-bit conversion
+    y = sext(x, from_width, 32, 0, rounding_mode, saturation_mode);
+
+    switch (to_width) {
+      case 16:
+        assert(0);
+        break;
+      case 32:
+        switch (rounding_mode) {
+          case RZ_OPTION:
+            y.f32 = cuda_math::__int2float_rz(y.s32);
+            break;
+          case RN_OPTION:
+            y.f32 = cuda_math::__int2float_rn(y.s32);
+            break;
+          case RM_OPTION:
+            y.f32 = cuda_math::__int2float_rd(y.s32);
+            break;
+          case RP_OPTION:
+            y.f32 = cuda_math::__int2float_ru(y.s32);
+            break;
+          default:
+            break;
+        }
+        break;
+      case 64:
+        y.f64 = y.s32;
+        break;  // no rounding needed
+      default:
+        assert(0);
+        break;
+    }
+  } else {
+    switch (to_width) {
+      case 16:
+        assert(0);
+        break;
+      case 32:
+        switch (rounding_mode) {
+          case RZ_OPTION:
+            y.f32 = cuda_math::__ll2float_rz(y.s64);
+            break;
+          case RN_OPTION:
+            y.f32 = cuda_math::__ll2float_rn(y.s64);
+            break;
+          case RM_OPTION:
+            y.f32 = cuda_math::__ll2float_rd(y.s64);
+            break;
+          case RP_OPTION:
+            y.f32 = cuda_math::__ll2float_ru(y.s64);
+            break;
+          default:
+            break;
+        }
+        break;
+      case 64:
+        y.f64 = y.s64;
+        break;  // no internal implementation found
+      default:
+        assert(0);
+        break;
+    }
+  }
+
+  // saturating an integer to 1 or 0?
+  return y;
 }
 
-ptx_reg_t d2d( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, int rounding_mode, int saturation_mode )
-{
-   ptx_reg_t y;
-   switch ( rounding_mode ) {
-   case RZI_OPTION: 
-      y.f64 = trunc(x.f64); 
-      break;          
-   case RNI_OPTION: 
+ptx_reg_t u2f(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
+              int rounding_mode, int saturation_mode) {
+  ptx_reg_t y;
+
+  if (from_width < 64) {  // 32-bit conversion
+    y = zext(x, from_width, 32, 0, rounding_mode, saturation_mode);
+
+    switch (to_width) {
+      case 16:
+        assert(0);
+        break;
+      case 32:
+        switch (rounding_mode) {
+          case RZ_OPTION:
+            y.f32 = cuda_math::__uint2float_rz(y.u32);
+            break;
+          case RN_OPTION:
+            y.f32 = cuda_math::__uint2float_rn(y.u32);
+            break;
+          case RM_OPTION:
+            y.f32 = cuda_math::__uint2float_rd(y.u32);
+            break;
+          case RP_OPTION:
+            y.f32 = cuda_math::__uint2float_ru(y.u32);
+            break;
+          default:
+            break;
+        }
+        break;
+      case 64:
+        y.f64 = y.u32;
+        break;  // no rounding needed
+      default:
+        assert(0);
+        break;
+    }
+  } else {
+    switch (to_width) {
+      case 16:
+        assert(0);
+        break;
+      case 32:
+        switch (rounding_mode) {
+          case RZ_OPTION:
+            y.f32 = cuda_math::__ull2float_rn(y.u64);
+            break;
+          case RN_OPTION:
+            y.f32 = cuda_math::__ull2float_rn(y.u64);
+            break;
+          case RM_OPTION:
+            y.f32 = cuda_math::__ull2float_rn(y.u64);
+            break;
+          case RP_OPTION:
+            y.f32 = cuda_math::__ull2float_rn(y.u64);
+            break;
+          default:
+            break;
+        }
+        break;
+      case 64:
+        y.f64 = y.u64;
+        break;  // no internal implementation found
+      default:
+        assert(0);
+        break;
+    }
+  }
+
+  // saturating an integer to 1 or 0?
+  return y;
+}
+
+ptx_reg_t f2f(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
+              int rounding_mode, int saturation_mode) {
+  ptx_reg_t y;
+  if (from_width == 16) {
+    half_float::detail::uint16 val = x.u16;
+    y.f32 = half_float::detail::half2float<float>(val);
+  } else {
+    switch (rounding_mode) {
+      case RZI_OPTION:
+        y.f32 = truncf(x.f32);
+        break;
+      case RNI_OPTION:
 #if CUDART_VERSION >= 3000
-      y.f64 = nearbyint(x.f64); 
+        y.f32 = nearbyintf(x.f32);
 #else
-      y.f64 = cuda_math::__internal_nearbyintf(x.f64); 
+        y.f32 = cuda_math::__internal_nearbyintf(x.f32);
 #endif
-      break;          
-   case RMI_OPTION: 
-      y.f64 = floor(x.f64); 
-      break;          
-   case RPI_OPTION: 
-      y.f64 = ceil(x.f64); 
-      break;          
-   default: 
+        break;
+      case RMI_OPTION:
+        if ((x.u32 & 0x7f800000) == 0) {
+          y.u32 = x.u32 & 0x80000000;  // round denorm. FP to 0, keeping sign
+        } else {
+          y.f32 = floorf(x.f32);
+        }
+        break;
+      case RPI_OPTION:
+        if ((x.u32 & 0x7f800000) == 0) {
+          y.u32 = x.u32 & 0x80000000;  // round denorm. FP to 0, keeping sign
+        } else {
+          y.f32 = ceilf(x.f32);
+        }
+        break;
+      default:
+        if ((x.u32 & 0x7f800000) == 0) {
+          y.u32 = x.u32 & 0x80000000;  // round denorm. FP to 0, keeping sign
+        } else {
+          y.f32 = x.f32;
+        }
+        break;
+    }
+#if CUDART_VERSION >= 3000
+    if (isnanf(y.f32))
+#else
+    if (cuda_math::__cuda___isnanf(y.f32))
+#endif
+    {
+      y.u32 = 0x7fffffff;
+    } else if (saturation_mode) {
+      y.f32 = cuda_math::__saturatef(y.f32);
+    }
+  }
+
+  return y;
+}
+
+ptx_reg_t d2d(ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign,
+              int rounding_mode, int saturation_mode) {
+  ptx_reg_t y;
+  switch (rounding_mode) {
+    case RZI_OPTION:
+      y.f64 = trunc(x.f64);
+      break;
+    case RNI_OPTION:
+#if CUDART_VERSION >= 3000
+      y.f64 = nearbyint(x.f64);
+#else
+      y.f64 = cuda_math::__internal_nearbyintf(x.f64);
+#endif
+      break;
+    case RMI_OPTION:
+      y.f64 = floor(x.f64);
+      break;
+    case RPI_OPTION:
+      y.f64 = ceil(x.f64);
+      break;
+    default:
       y.f64 = x.f64;
-      break; 
-   }
-   if (std::isnan(y.f64)) {
-      y.u64 = 0xfff8000000000000ull;
-   } else if (saturation_mode) {
-      y.f64 = cuda_math::__saturatef(y.f64); 
-   }
-   return y;
+      break;
+  }
+  if (std::isnan(y.f64)) {
+    y.u64 = 0xfff8000000000000ull;
+  } else if (saturation_mode) {
+    y.f64 = cuda_math::__saturatef(y.f64);
+  }
+  return y;
 }
 
-ptx_reg_t (*g_cvt_fn[11][11])( ptx_reg_t x, unsigned from_width, unsigned to_width, int to_sign, 
-                               int rounding_mode, int saturation_mode ) = {
-   { NULL, sext, sext, sext, NULL, sext, sext, sext, s2f, s2f, s2f}, 
-   { chop, NULL, sext, sext, chop, NULL, sext, sext, s2f, s2f, s2f}, 
-   { chop, sexd, NULL, sext, chop, chop, NULL, sext, s2f, s2f, s2f}, 
-   { chop, chop, chop, NULL, chop, chop, chop, NULL, s2f, s2f, s2f}, 
-   { NULL, zext, zext, zext, NULL, zext, zext, zext, u2f, u2f, u2f}, 
-   { chop, NULL, zext, zext, chop, NULL, zext, zext, u2f, u2f, u2f}, 
-   { chop, chop, NULL, zext, chop, chop, NULL, zext, u2f, u2f, u2f}, 
-   { chop, chop, chop, NULL, chop, chop, chop, NULL, u2f, u2f, u2f}, 
-   { f2x , f2x , f2x , f2x , f2x , f2x , f2x , f2x , NULL,f2f, f2x}, 
-   { f2x , f2x , f2x , f2x , f2x , f2x , f2x , f2x , f2x, f2f, f2x},
-   { d2x , d2x , d2x , d2x , d2x , d2x , d2x , d2x , d2x, d2x, d2d} 
-};
+ptx_reg_t (*g_cvt_fn[11][11])(ptx_reg_t x, unsigned from_width,
+                              unsigned to_width, int to_sign, int rounding_mode,
+                              int saturation_mode) = {
+    {NULL, sext, sext, sext, NULL, sext, sext, sext, s2f, s2f, s2f},
+    {chop, NULL, sext, sext, chop, NULL, sext, sext, s2f, s2f, s2f},
+    {chop, sexd, NULL, sext, chop, chop, NULL, sext, s2f, s2f, s2f},
+    {chop, chop, chop, NULL, chop, chop, chop, NULL, s2f, s2f, s2f},
+    {NULL, zext, zext, zext, NULL, zext, zext, zext, u2f, u2f, u2f},
+    {chop, NULL, zext, zext, chop, NULL, zext, zext, u2f, u2f, u2f},
+    {chop, chop, NULL, zext, chop, chop, NULL, zext, u2f, u2f, u2f},
+    {chop, chop, chop, NULL, chop, chop, chop, NULL, u2f, u2f, u2f},
+    {f2x, f2x, f2x, f2x, f2x, f2x, f2x, f2x, NULL, f2f, f2x},
+    {f2x, f2x, f2x, f2x, f2x, f2x, f2x, f2x, f2x, f2f, f2x},
+    {d2x, d2x, d2x, d2x, d2x, d2x, d2x, d2x, d2x, d2x, d2d}};
 
-void ptx_round(ptx_reg_t& data, int rounding_mode, int type)
-{
-   if (rounding_mode == RN_OPTION) {
-      return;
-   }
-   switch ( rounding_mode ) {
-   case RZI_OPTION: 
-      switch ( type ) {
-      case S8_TYPE:
-      case S16_TYPE:
-      case S32_TYPE:
-      case S64_TYPE:
-      case U8_TYPE:
-      case U16_TYPE:
-      case U32_TYPE:
-      case U64_TYPE:
-         printf("Trying to round an integer??\n"); assert(0); break;
-      case F16_TYPE: data.f16=truncf(data.f16);break;//assert(0); break;
-      case F32_TYPE:
-         data.f32 = truncf(data.f32); 
-         break;          
-      case F64_TYPE:
-      case FF64_TYPE:
-         if (data.f64 < 0) data.f64 = ceil(data.f64); //negative
-         else data.f64 = floor(data.f64); //positive
-         break; 
-      default: assert(0); break;
+void ptx_round(ptx_reg_t &data, int rounding_mode, int type) {
+  if (rounding_mode == RN_OPTION) {
+    return;
+  }
+  switch (rounding_mode) {
+    case RZI_OPTION:
+      switch (type) {
+        case S8_TYPE:
+        case S16_TYPE:
+        case S32_TYPE:
+        case S64_TYPE:
+        case U8_TYPE:
+        case U16_TYPE:
+        case U32_TYPE:
+        case U64_TYPE:
+          printf("Trying to round an integer??\n");
+          assert(0);
+          break;
+        case F16_TYPE:
+          data.f16 = truncf(data.f16);
+          break;  // assert(0); break;
+        case F32_TYPE:
+          data.f32 = truncf(data.f32);
+          break;
+        case F64_TYPE:
+        case FF64_TYPE:
+          if (data.f64 < 0)
+            data.f64 = ceil(data.f64);  // negative
+          else
+            data.f64 = floor(data.f64);  // positive
+          break;
+        default:
+          assert(0);
+          break;
       }
       break;
-   case RNI_OPTION: 
-      switch ( type ) {
-      case S8_TYPE:
-      case S16_TYPE:
-      case S32_TYPE:
-      case S64_TYPE:
-      case U8_TYPE:
-      case U16_TYPE:
-      case U32_TYPE:
-      case U64_TYPE:
-         printf("Trying to round an integer??\n"); assert(0); break;
-      case F16_TYPE:// assert(0); break;
+    case RNI_OPTION:
+      switch (type) {
+        case S8_TYPE:
+        case S16_TYPE:
+        case S32_TYPE:
+        case S64_TYPE:
+        case U8_TYPE:
+        case U16_TYPE:
+        case U32_TYPE:
+        case U64_TYPE:
+          printf("Trying to round an integer??\n");
+          assert(0);
+          break;
+        case F16_TYPE:  // assert(0); break;
 #if CUDART_VERSION >= 3000
-         data.f16 = nearbyintf(data.f16); 
+          data.f16 = nearbyintf(data.f16);
 #else
-         data.f16 = cuda_math::__cuda_nearbyintf(data.f16); 
+          data.f16 = cuda_math::__cuda_nearbyintf(data.f16);
 #endif
-         break;          
-      case F32_TYPE: 
+          break;
+        case F32_TYPE:
 #if CUDART_VERSION >= 3000
-         data.f32 = nearbyintf(data.f32); 
+          data.f32 = nearbyintf(data.f32);
 #else
-         data.f32 = cuda_math::__cuda_nearbyintf(data.f32); 
+          data.f32 = cuda_math::__cuda_nearbyintf(data.f32);
 #endif
-         break;          
-      case F64_TYPE: case FF64_TYPE: data.f64 = round(data.f64); break; 
-      default: assert(0); break;
+          break;
+        case F64_TYPE:
+        case FF64_TYPE:
+          data.f64 = round(data.f64);
+          break;
+        default:
+          assert(0);
+          break;
       }
       break;
-   case RMI_OPTION: 
-      switch ( type ) {
-      case S8_TYPE:
-      case S16_TYPE:
-      case S32_TYPE:
-      case S64_TYPE:
-      case U8_TYPE:
-      case U16_TYPE:
-      case U32_TYPE:
-      case U64_TYPE:
-         printf("Trying to round an integer??\n"); assert(0); break;
-      case F16_TYPE: data.f16=floorf(data.f16);break;//assert(0); break;
-      case F32_TYPE: 
-         data.f32 = floorf(data.f32); 
-         break;          
-      case F64_TYPE: case FF64_TYPE: data.f64 = floor(data.f64); break; 
-      default: assert(0); break;
+    case RMI_OPTION:
+      switch (type) {
+        case S8_TYPE:
+        case S16_TYPE:
+        case S32_TYPE:
+        case S64_TYPE:
+        case U8_TYPE:
+        case U16_TYPE:
+        case U32_TYPE:
+        case U64_TYPE:
+          printf("Trying to round an integer??\n");
+          assert(0);
+          break;
+        case F16_TYPE:
+          data.f16 = floorf(data.f16);
+          break;  // assert(0); break;
+        case F32_TYPE:
+          data.f32 = floorf(data.f32);
+          break;
+        case F64_TYPE:
+        case FF64_TYPE:
+          data.f64 = floor(data.f64);
+          break;
+        default:
+          assert(0);
+          break;
       }
       break;
-   case RPI_OPTION: 
-      switch ( type ) {
-      case S8_TYPE:
-      case S16_TYPE:
-      case S32_TYPE:
-      case S64_TYPE:
-      case U8_TYPE:
-      case U16_TYPE:
-      case U32_TYPE:
-      case U64_TYPE:
-         printf("Trying to round an integer??\n"); assert(0); break;
-      case F16_TYPE: data.f16 = ceilf(data.f16); break;  //assert(0); break;
-      case F32_TYPE: data.f32 = ceilf(data.f32); break;          
-      case F64_TYPE: case FF64_TYPE: data.f64 = ceil(data.f64); break; 
-      default: assert(0); break;
+    case RPI_OPTION:
+      switch (type) {
+        case S8_TYPE:
+        case S16_TYPE:
+        case S32_TYPE:
+        case S64_TYPE:
+        case U8_TYPE:
+        case U16_TYPE:
+        case U32_TYPE:
+        case U64_TYPE:
+          printf("Trying to round an integer??\n");
+          assert(0);
+          break;
+        case F16_TYPE:
+          data.f16 = ceilf(data.f16);
+          break;  // assert(0); break;
+        case F32_TYPE:
+          data.f32 = ceilf(data.f32);
+          break;
+        case F64_TYPE:
+        case FF64_TYPE:
+          data.f64 = ceil(data.f64);
+          break;
+        default:
+          assert(0);
+          break;
       }
       break;
-   default:  break; 
-   }
+    default:
+      break;
+  }
 
-   if (type == F32_TYPE) {
+  if (type == F32_TYPE) {
 #if CUDART_VERSION >= 3000
-      if (isnanf(data.f32)) 
+    if (isnanf(data.f32))
 #else
-      if (cuda_math::__cuda___isnanf(data.f32)) 
+    if (cuda_math::__cuda___isnanf(data.f32))
 #endif
-      {
-         data.u32 = 0x7fffffff;
-      }
-   }
-   if ((type == F64_TYPE)||(type == FF64_TYPE)) {
-      if (std::isnan(data.f64)) {
-         data.u64 = 0xfff8000000000000ull;
-      }
-   }
+    {
+      data.u32 = 0x7fffffff;
+    }
+  }
+  if ((type == F64_TYPE) || (type == FF64_TYPE)) {
+    if (std::isnan(data.f64)) {
+      data.u64 = 0xfff8000000000000ull;
+    }
+  }
 }
 
-void ptx_saturate(ptx_reg_t& data, int saturation_mode, int type)
-{
-   if (!saturation_mode) {
-      return;
-   }
-   switch ( type ) {
-   case S8_TYPE:
-   case S16_TYPE:
-   case S32_TYPE:
-   case S64_TYPE:
-   case U8_TYPE:
-   case U16_TYPE:
-   case U32_TYPE:
-   case U64_TYPE:
-      printf("Trying to clamp an integer to 1??\n"); assert(0); break;
-   case F16_TYPE: //assert(0); break;
-      if (data.f16 > 1.0f) data.f16 = 1.0f; //negative
-      if (data.f16 < 0.0f) data.f16 = 0.0f; //positive
-      break;          
-   case F32_TYPE:
-      if (data.f32 > 1.0f) data.f32 = 1.0f; //negative
-      if (data.f32 < 0.0f) data.f32 = 0.0f; //positive
-      break;          
-   case F64_TYPE:
-   case FF64_TYPE:
-      if (data.f64 > 1.0f) data.f64 = 1.0f; //negative
-      if (data.f64 < 0.0f) data.f64 = 0.0f; //positive
-      break; 
-   default: assert(0); break;
-   }
-
+void ptx_saturate(ptx_reg_t &data, int saturation_mode, int type) {
+  if (!saturation_mode) {
+    return;
+  }
+  switch (type) {
+    case S8_TYPE:
+    case S16_TYPE:
+    case S32_TYPE:
+    case S64_TYPE:
+    case U8_TYPE:
+    case U16_TYPE:
+    case U32_TYPE:
+    case U64_TYPE:
+      printf("Trying to clamp an integer to 1??\n");
+      assert(0);
+      break;
+    case F16_TYPE:                           // assert(0); break;
+      if (data.f16 > 1.0f) data.f16 = 1.0f;  // negative
+      if (data.f16 < 0.0f) data.f16 = 0.0f;  // positive
+      break;
+    case F32_TYPE:
+      if (data.f32 > 1.0f) data.f32 = 1.0f;  // negative
+      if (data.f32 < 0.0f) data.f32 = 0.0f;  // positive
+      break;
+    case F64_TYPE:
+    case FF64_TYPE:
+      if (data.f64 > 1.0f) data.f64 = 1.0f;  // negative
+      if (data.f64 < 0.0f) data.f64 = 0.0f;  // positive
+      break;
+    default:
+      assert(0);
+      break;
+  }
 }
 
-void cvt_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   unsigned to_type = pI->get_type();
-   unsigned from_type = pI->get_type2();
-   unsigned rounding_mode = pI->rounding_mode();
-   unsigned saturation_mode = pI->saturation_mode();
+void cvt_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  unsigned to_type = pI->get_type();
+  unsigned from_type = pI->get_type2();
+  unsigned rounding_mode = pI->rounding_mode();
+  unsigned saturation_mode = pI->saturation_mode();
 
-//   if ( to_type == F16_TYPE || from_type == F16_TYPE )
-//      abort();
+  //   if ( to_type == F16_TYPE || from_type == F16_TYPE )
+  //      abort();
 
-   int to_sign, from_sign;
-   size_t from_width, to_width;
-   unsigned src_fmt = type_info_key::type_decode(from_type, from_width, from_sign);
-   unsigned dst_fmt = type_info_key::type_decode(to_type, to_width, to_sign);
+  int to_sign, from_sign;
+  size_t from_width, to_width;
+  unsigned src_fmt =
+      type_info_key::type_decode(from_type, from_width, from_sign);
+  unsigned dst_fmt = type_info_key::type_decode(to_type, to_width, to_sign);
 
-   ptx_reg_t data = thread->get_operand_value(src1, dst, from_type, thread, 1);
+  ptx_reg_t data = thread->get_operand_value(src1, dst, from_type, thread, 1);
 
-   if(pI->is_neg()){
-
-   switch( from_type ) {
+  if (pI->is_neg()) {
+    switch (from_type) {
       // Default to f32 for now, need to add support for others
       case S8_TYPE:
       case U8_TYPE:
       case B8_TYPE:
-         data.s8 = -data.s8;
-         break;
+        data.s8 = -data.s8;
+        break;
       case S16_TYPE:
       case U16_TYPE:
       case B16_TYPE:
-         data.s16 = -data.s16;
-         break;
+        data.s16 = -data.s16;
+        break;
       case S32_TYPE:
       case U32_TYPE:
       case B32_TYPE:
-         data.s32 = -data.s32;
-         break;
+        data.s32 = -data.s32;
+        break;
       case S64_TYPE:
       case U64_TYPE:
       case B64_TYPE:
-         data.s64 = -data.s64;
-         break;
+        data.s64 = -data.s64;
+        break;
       case F16_TYPE:
-         data.f16 = -data.f16;
-         break;
+        data.f16 = -data.f16;
+        break;
       case F32_TYPE:
-         data.f32 = -data.f32;
-         break;
+        data.f32 = -data.f32;
+        break;
       case F64_TYPE:
       case FF64_TYPE:
-         data.f64 = -data.f64;
-         break;
+        data.f64 = -data.f64;
+        break;
       default:
-         assert(0);
-      }
+        assert(0);
+    }
+  }
 
-   }
+  if (g_cvt_fn[src_fmt][dst_fmt] != NULL) {
+    ptx_reg_t result = g_cvt_fn[src_fmt][dst_fmt](
+        data, from_width, to_width, to_sign, rounding_mode, saturation_mode);
+    data = result;
+  }
 
-
-   if ( g_cvt_fn[src_fmt][dst_fmt] != NULL ) {
-      ptx_reg_t result = g_cvt_fn[src_fmt][dst_fmt](data,from_width,to_width,to_sign, rounding_mode, saturation_mode);
-      data = result;
-   }
-
-   thread->set_operand_value(dst, data, to_type, thread, pI );
+  thread->set_operand_value(dst, data, to_type, thread, pI);
 }
 
-void cvta_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t data;
+void cvta_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t data;
 
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   memory_space_t space = pI->get_space();
-   bool to_non_generic = pI->is_to();
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  memory_space_t space = pI->get_space();
+  bool to_non_generic = pI->is_to();
 
-   unsigned i_type = pI->get_type();
-   ptx_reg_t from_addr = thread->get_operand_value(src1,dst,i_type,thread,1);
-   addr_t from_addr_hw = (addr_t)from_addr.u64;
-   addr_t to_addr_hw = 0;
-   unsigned smid = thread->get_hw_sid();
-   unsigned hwtid = thread->get_hw_tid();
+  unsigned i_type = pI->get_type();
+  ptx_reg_t from_addr = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  addr_t from_addr_hw = (addr_t)from_addr.u64;
+  addr_t to_addr_hw = 0;
+  unsigned smid = thread->get_hw_sid();
+  unsigned hwtid = thread->get_hw_tid();
 
-   if( to_non_generic ) {
-      switch( space.get_type() ) {
-      case shared_space: to_addr_hw = generic_to_shared( smid, from_addr_hw ); break;
-      case local_space:  to_addr_hw = generic_to_local( smid, hwtid, from_addr_hw ); break;
-      case global_space: to_addr_hw = generic_to_global(from_addr_hw ); break;
-      default: abort();
-      }
-   } else {
-      switch( space.get_type() ) {
-      case shared_space: to_addr_hw = shared_to_generic( smid, from_addr_hw ); break;
-      case local_space:  to_addr_hw =  local_to_generic( smid, hwtid, from_addr_hw )
-                                      + thread->get_local_mem_stack_pointer(); break; // add stack ptr here so that it can be passed as a pointer at function call 
-      case global_space: to_addr_hw = global_to_generic( from_addr_hw ); break;
-      default: abort();
-      }
-   }
-   
-   ptx_reg_t to_addr;
-   to_addr.u64 = to_addr_hw;
-   thread->set_reg(dst.get_symbol(),to_addr);
+  if (to_non_generic) {
+    switch (space.get_type()) {
+      case shared_space:
+        to_addr_hw = generic_to_shared(smid, from_addr_hw);
+        break;
+      case local_space:
+        to_addr_hw = generic_to_local(smid, hwtid, from_addr_hw);
+        break;
+      case global_space:
+        to_addr_hw = generic_to_global(from_addr_hw);
+        break;
+      default:
+        abort();
+    }
+  } else {
+    switch (space.get_type()) {
+      case shared_space:
+        to_addr_hw = shared_to_generic(smid, from_addr_hw);
+        break;
+      case local_space:
+        to_addr_hw = local_to_generic(smid, hwtid, from_addr_hw) +
+                     thread->get_local_mem_stack_pointer();
+        break;  // add stack ptr here so that it can be passed as a pointer at
+                // function call
+      case global_space:
+        to_addr_hw = global_to_generic(from_addr_hw);
+        break;
+      default:
+        abort();
+    }
+  }
+
+  ptx_reg_t to_addr;
+  to_addr.u64 = to_addr_hw;
+  thread->set_reg(dst.get_symbol(), to_addr);
 }
 
-void div_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t data;
+void div_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t data;
 
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   unsigned i_type = pI->get_type();
+  unsigned i_type = pI->get_type();
 
-   ptx_reg_t src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   ptx_reg_t src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  ptx_reg_t src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  ptx_reg_t src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-
-   switch ( i_type ) {
-   case S8_TYPE:
-      data.s8  = src1_data.s8  / src2_data.s8 ; break;
-   case S16_TYPE:
-      data.s16 = src1_data.s16 / src2_data.s16; break;
-   case S32_TYPE:
-      data.s32 = src1_data.s32 / src2_data.s32; break;
-   case S64_TYPE: 
-      data.s64 = src1_data.s64 / src2_data.s64; break;
-   case U8_TYPE:
-      data.u8  = src1_data.u8  / src2_data.u8 ; break;
-   case U16_TYPE:
-      data.u16 = src1_data.u16 / src2_data.u16; break;
-   case U32_TYPE:
-      data.u32 = src1_data.u32 / src2_data.u32; break;
-   case U64_TYPE: 
-      data.u64 = src1_data.u64 / src2_data.u64; break;
-   case B8_TYPE:
-      data.u8  = src1_data.u8  / src2_data.u8 ; break;
-   case B16_TYPE:
-      data.u16 = src1_data.u16 / src2_data.u16; break;
-   case B32_TYPE:
-      data.u32 = src1_data.u32 / src2_data.u32; break;
-   case B64_TYPE:
-      data.u64 = src1_data.u64 / src2_data.u64; break;
-   case F16_TYPE: data.f16 = src1_data.f16 / src2_data.f16; break;//assert(0); break;
-   case F32_TYPE: data.f32 = src1_data.f32 / src2_data.f32; break;
-   case F64_TYPE: case FF64_TYPE: data.f64 = src1_data.f64 / src2_data.f64; break;
-   default: assert(0); break;
-   }
-   thread->set_operand_value(dst,data, i_type, thread,pI);
+  switch (i_type) {
+    case S8_TYPE:
+      data.s8 = src1_data.s8 / src2_data.s8;
+      break;
+    case S16_TYPE:
+      data.s16 = src1_data.s16 / src2_data.s16;
+      break;
+    case S32_TYPE:
+      data.s32 = src1_data.s32 / src2_data.s32;
+      break;
+    case S64_TYPE:
+      data.s64 = src1_data.s64 / src2_data.s64;
+      break;
+    case U8_TYPE:
+      data.u8 = src1_data.u8 / src2_data.u8;
+      break;
+    case U16_TYPE:
+      data.u16 = src1_data.u16 / src2_data.u16;
+      break;
+    case U32_TYPE:
+      data.u32 = src1_data.u32 / src2_data.u32;
+      break;
+    case U64_TYPE:
+      data.u64 = src1_data.u64 / src2_data.u64;
+      break;
+    case B8_TYPE:
+      data.u8 = src1_data.u8 / src2_data.u8;
+      break;
+    case B16_TYPE:
+      data.u16 = src1_data.u16 / src2_data.u16;
+      break;
+    case B32_TYPE:
+      data.u32 = src1_data.u32 / src2_data.u32;
+      break;
+    case B64_TYPE:
+      data.u64 = src1_data.u64 / src2_data.u64;
+      break;
+    case F16_TYPE:
+      data.f16 = src1_data.f16 / src2_data.f16;
+      break;  // assert(0); break;
+    case F32_TYPE:
+      data.f32 = src1_data.f32 / src2_data.f32;
+      break;
+    case F64_TYPE:
+    case FF64_TYPE:
+      data.f64 = src1_data.f64 / src2_data.f64;
+      break;
+    default:
+      assert(0);
+      break;
+  }
+  thread->set_operand_value(dst, data, i_type, thread, pI);
 }
 
-void dp4a_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   printf("DP4A instruction not implemented yet");
-   assert(0);
-
+void dp4a_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  printf("DP4A instruction not implemented yet");
+  assert(0);
 }
 
-void ex2_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t src1_data, src2_data, data;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
+void ex2_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, src2_data, data;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
 
-   unsigned i_type = pI->get_type();
+  unsigned i_type = pI->get_type();
 
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
 
-
-   switch ( i_type ) {
-   case F32_TYPE: 
+  switch (i_type) {
+    case F32_TYPE:
       data.f32 = cuda_math::__powf(2.0, src1_data.f32);
       break;
-   default:
+    default:
       printf("Execution error: type mismatch with instruction\n");
-      assert(0); 
+      assert(0);
       break;
-   }
-   
-   thread->set_operand_value(dst,data, i_type, thread,pI);
+  }
+
+  thread->set_operand_value(dst, data, i_type, thread, pI);
 }
 
-void exit_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   thread->set_done();
-   thread->exitCore();
-   thread->registerExit();
+void exit_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  thread->set_done();
+  thread->exitCore();
+  thread->registerExit();
 }
 
-void mad_def( const ptx_instruction *pI, ptx_thread_info *thread, bool use_carry = false );
+void mad_def(const ptx_instruction *pI, ptx_thread_info *thread,
+             bool use_carry = false);
 
-void fma_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   mad_def(pI,thread);
+void fma_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  mad_def(pI, thread);
 }
 
-void isspacep_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t a;
-   bool t=false;
+void isspacep_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a;
+  bool t = false;
 
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   memory_space_t space = pI->get_space();
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  memory_space_t space = pI->get_space();
 
-   a = thread->get_reg(src1.get_symbol());
-   addr_t addr = (addr_t)a.u64;
-   unsigned smid = thread->get_hw_sid();
-   unsigned hwtid = thread->get_hw_tid();
+  a = thread->get_reg(src1.get_symbol());
+  addr_t addr = (addr_t)a.u64;
+  unsigned smid = thread->get_hw_sid();
+  unsigned hwtid = thread->get_hw_tid();
 
-   switch( space.get_type() ) {
-   case shared_space: t = isspace_shared( smid, addr );
-   case local_space:  t = isspace_local( smid, hwtid, addr );
-   case global_space: t = isspace_global( addr );
-   default: abort();
-   }
-
-   ptx_reg_t p;
-   p.pred = t?1:0;
-
-   thread->set_reg(dst.get_symbol(),p);
-}
-
-void decode_space( memory_space_t &space, ptx_thread_info *thread, const operand_info &op, memory_space *&mem, addr_t &addr)
-{
-   unsigned smid = thread->get_hw_sid();
-   unsigned hwtid = thread->get_hw_tid();
-
-   if( space == param_space_unclassified ) {
-      // need to op to determine whether it refers to a kernel param or local param
-      const symbol *s = op.get_symbol();
-      const type_info *t = s->type();
-      type_info_key ti = t->get_key();
-      if( ti.is_param_kernel() )
-         space = param_space_kernel;
-      else if( ti.is_param_local() ) {
-         space = param_space_local;
-      }
-      //mov r1, param-label
-      else if (ti.is_reg() ){
-         space = param_space_kernel;
-      }
-      else {
-         printf("GPGPU-Sim PTX: ERROR ** cannot resolve .param space for '%s'\n", s->name().c_str() );
-         abort(); 
-      }
-   }
-   switch ( space.get_type() ) {
-   case global_space: mem = thread->get_global_memory(); break;
-   case param_space_local:
-   case local_space:
-      mem = thread->m_local_mem; 
-      addr += thread->get_local_mem_stack_pointer();
-      break; 
-   case tex_space:    mem = thread->get_tex_memory(); break; 
-   case surf_space:   mem = thread->get_surf_memory(); break; 
-   case param_space_kernel:  mem = thread->get_param_memory(); break;
-   case shared_space:  mem = thread->m_shared_mem; break; 
-   case sstarr_space:	mem = thread->m_sstarr_mem; break;
-   case const_space:  mem = thread->get_global_memory(); break;
-   case generic_space:
-      if( thread->get_ptx_version().ver() >= 2.0 ) {
-         // convert generic address to memory space address
-         space = whichspace(addr);
-         switch ( space.get_type() ) {
-         case global_space: mem = thread->get_global_memory(); addr = generic_to_global(addr); break;
-         case local_space:  mem = thread->m_local_mem; addr = generic_to_local(smid,hwtid,addr); break; 
-         case shared_space: mem = thread->m_shared_mem; addr = generic_to_shared(smid,addr); break; 
-         default: abort();
-         }
-      } else {
-         abort();
-      }
-      break;
-   case param_space_unclassified:
-   case undefined_space:
-   default:
+  switch (space.get_type()) {
+    case shared_space:
+      t = isspace_shared(smid, addr);
+    case local_space:
+      t = isspace_local(smid, hwtid, addr);
+    case global_space:
+      t = isspace_global(addr);
+    default:
       abort();
-   }
+  }
+
+  ptx_reg_t p;
+  p.pred = t ? 1 : 0;
+
+  thread->set_reg(dst.get_symbol(), p);
 }
 
-void ld_exec( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   const operand_info &dst = pI->dst();
-   const operand_info &src1 = pI->src1();
+void decode_space(memory_space_t &space, ptx_thread_info *thread,
+                  const operand_info &op, memory_space *&mem, addr_t &addr) {
+  unsigned smid = thread->get_hw_sid();
+  unsigned hwtid = thread->get_hw_tid();
 
-   unsigned type = pI->get_type();
-
-   ptx_reg_t src1_data = thread->get_operand_value(src1, dst, type, thread, 1);
-   ptx_reg_t data;
-   memory_space_t space = pI->get_space();
-   unsigned vector_spec = pI->get_vector();
-
-   memory_space *mem = NULL;
-   addr_t addr = src1_data.u32;
-
-   decode_space(space,thread,src1,mem,addr);
-
-   size_t size;
-   int t;
-   data.u64=0;
-   type_info_key::type_decode(type,size,t);
-   if (!vector_spec) {
-      mem->read(addr,size/8,&data.s64);
-      if( type == S16_TYPE || type == S32_TYPE ) 
-         sign_extend(data,size,dst);
-      thread->set_operand_value(dst,data, type, thread, pI);
-   } else {
-      ptx_reg_t data1, data2, data3, data4;
-      mem->read(addr,size/8,&data1.s64);
-      mem->read(addr+size/8,size/8,&data2.s64);
-      if (vector_spec != V2_TYPE) { //either V3 or V4
-         mem->read(addr+2*size/8,size/8,&data3.s64);
-         if (vector_spec != V3_TYPE) { //v4
-            mem->read(addr+3*size/8,size/8,&data4.s64);
-            thread->set_vector_operand_values(dst,data1,data2,data3,data4);
-         } else //v3
-            thread->set_vector_operand_values(dst,data1,data2,data3,data3);
-      } else //v2
-         thread->set_vector_operand_values(dst,data1,data2,data2,data2);
-   }
-   thread->m_last_effective_address = addr;
-   thread->m_last_memory_space = space; 
+  if (space == param_space_unclassified) {
+    // need to op to determine whether it refers to a kernel param or local
+    // param
+    const symbol *s = op.get_symbol();
+    const type_info *t = s->type();
+    type_info_key ti = t->get_key();
+    if (ti.is_param_kernel())
+      space = param_space_kernel;
+    else if (ti.is_param_local()) {
+      space = param_space_local;
+    }
+    // mov r1, param-label
+    else if (ti.is_reg()) {
+      space = param_space_kernel;
+    } else {
+      printf("GPGPU-Sim PTX: ERROR ** cannot resolve .param space for '%s'\n",
+             s->name().c_str());
+      abort();
+    }
+  }
+  switch (space.get_type()) {
+    case global_space:
+      mem = thread->get_global_memory();
+      break;
+    case param_space_local:
+    case local_space:
+      mem = thread->m_local_mem;
+      addr += thread->get_local_mem_stack_pointer();
+      break;
+    case tex_space:
+      mem = thread->get_tex_memory();
+      break;
+    case surf_space:
+      mem = thread->get_surf_memory();
+      break;
+    case param_space_kernel:
+      mem = thread->get_param_memory();
+      break;
+    case shared_space:
+      mem = thread->m_shared_mem;
+      break;
+    case sstarr_space:
+      mem = thread->m_sstarr_mem;
+      break;
+    case const_space:
+      mem = thread->get_global_memory();
+      break;
+    case generic_space:
+      if (thread->get_ptx_version().ver() >= 2.0) {
+        // convert generic address to memory space address
+        space = whichspace(addr);
+        switch (space.get_type()) {
+          case global_space:
+            mem = thread->get_global_memory();
+            addr = generic_to_global(addr);
+            break;
+          case local_space:
+            mem = thread->m_local_mem;
+            addr = generic_to_local(smid, hwtid, addr);
+            break;
+          case shared_space:
+            mem = thread->m_shared_mem;
+            addr = generic_to_shared(smid, addr);
+            break;
+          default:
+            abort();
+        }
+      } else {
+        abort();
+      }
+      break;
+    case param_space_unclassified:
+    case undefined_space:
+    default:
+      abort();
+  }
 }
 
-void ld_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   ld_exec(pI,thread);
+void ld_exec(const ptx_instruction *pI, ptx_thread_info *thread) {
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+
+  unsigned type = pI->get_type();
+
+  ptx_reg_t src1_data = thread->get_operand_value(src1, dst, type, thread, 1);
+  ptx_reg_t data;
+  memory_space_t space = pI->get_space();
+  unsigned vector_spec = pI->get_vector();
+
+  memory_space *mem = NULL;
+  addr_t addr = src1_data.u32;
+
+  decode_space(space, thread, src1, mem, addr);
+
+  size_t size;
+  int t;
+  data.u64 = 0;
+  type_info_key::type_decode(type, size, t);
+  if (!vector_spec) {
+    mem->read(addr, size / 8, &data.s64);
+    if (type == S16_TYPE || type == S32_TYPE) sign_extend(data, size, dst);
+    thread->set_operand_value(dst, data, type, thread, pI);
+  } else {
+    ptx_reg_t data1, data2, data3, data4;
+    mem->read(addr, size / 8, &data1.s64);
+    mem->read(addr + size / 8, size / 8, &data2.s64);
+    if (vector_spec != V2_TYPE) {  // either V3 or V4
+      mem->read(addr + 2 * size / 8, size / 8, &data3.s64);
+      if (vector_spec != V3_TYPE) {  // v4
+        mem->read(addr + 3 * size / 8, size / 8, &data4.s64);
+        thread->set_vector_operand_values(dst, data1, data2, data3, data4);
+      } else  // v3
+        thread->set_vector_operand_values(dst, data1, data2, data3, data3);
+    } else  // v2
+      thread->set_vector_operand_values(dst, data1, data2, data2, data2);
+  }
+  thread->m_last_effective_address = addr;
+  thread->m_last_memory_space = space;
 }
-void ldu_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ld_exec(pI,thread);
+
+void ld_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ld_exec(pI, thread);
+}
+void ldu_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ld_exec(pI, thread);
 }
 
-void mma_st_impl( const ptx_instruction *pI, core_t *core, warp_inst_t &inst )
-{
-   size_t size;
-   unsigned smid;
-   int t;
-   int thrd, k;
-   ptx_thread_info *thread;
-   
-   const operand_info &src  = pI->operand_lookup(1);
-   const operand_info &src1 = pI->operand_lookup(0);
-   const operand_info &src2 = pI->operand_lookup(2);
-   int tid ;
-   unsigned type = pI->get_type();
-   unsigned wmma_type = pI->get_wmma_type();
-   unsigned wmma_layout = pI->get_wmma_layout(0);
-   int stride; 
+void mma_st_impl(const ptx_instruction *pI, core_t *core, warp_inst_t &inst) {
+  size_t size;
+  unsigned smid;
+  int t;
+  int thrd, k;
+  ptx_thread_info *thread;
 
-   if(core->get_gpu()->is_functional_sim())
-    	tid= inst.warp_id_func()*core->get_warp_size();
-   else
-    	tid= inst.warp_id()*core->get_warp_size();
+  const operand_info &src = pI->operand_lookup(1);
+  const operand_info &src1 = pI->operand_lookup(0);
+  const operand_info &src2 = pI->operand_lookup(2);
+  int tid;
+  unsigned type = pI->get_type();
+  unsigned wmma_type = pI->get_wmma_type();
+  unsigned wmma_layout = pI->get_wmma_layout(0);
+  int stride;
 
-   _memory_op_t insn_memory_op = pI->has_memory_read() ? memory_load : memory_store;
-   for (thrd=0; thrd < core->get_warp_size(); thrd++) {
-	thread = core->get_thread_info()[tid+thrd];
+  if (core->get_gpu()->is_functional_sim())
+    tid = inst.warp_id_func() * core->get_warp_size();
+  else
+    tid = inst.warp_id() * core->get_warp_size();
+
+  _memory_op_t insn_memory_op =
+      pI->has_memory_read() ? memory_load : memory_store;
+  for (thrd = 0; thrd < core->get_warp_size(); thrd++) {
+    thread = core->get_thread_info()[tid + thrd];
     ptx_reg_t addr_reg = thread->get_operand_value(src1, src, type, thread, 1);
-   	ptx_reg_t src2_data = thread->get_operand_value(src2, src, type, thread, 1);
-	const operand_info &src_a=  pI->operand_lookup(1);
-        unsigned nelem = src_a.get_vect_nelem();
-        ptx_reg_t* v= new ptx_reg_t[8]; 
-       	thread->get_vector_operand_values( src_a, v, nelem );
-  	stride = src2_data.u32;
- 
-   	memory_space_t space = pI->get_space();
+    ptx_reg_t src2_data = thread->get_operand_value(src2, src, type, thread, 1);
+    const operand_info &src_a = pI->operand_lookup(1);
+    unsigned nelem = src_a.get_vect_nelem();
+    ptx_reg_t *v = new ptx_reg_t[8];
+    thread->get_vector_operand_values(src_a, v, nelem);
+    stride = src2_data.u32;
 
-   	memory_space *mem = NULL;
-   	addr_t addr = addr_reg.u32;
-	
-	new_addr_type mem_txn_addr[MAX_ACCESSES_PER_INSN_PER_THREAD];
-	int num_mem_txn=0;
-        
-        smid = thread->get_hw_sid();
-   	if( whichspace(addr) == shared_space ) {
-          addr= generic_to_shared(smid,addr);
-          space = shared_space;
-	}
-   	decode_space(space,thread,src1,mem,addr);
+    memory_space_t space = pI->get_space();
 
-   	type_info_key::type_decode(type, size, t);
-   	if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-		printf("mma_st: thrd=%d, addr=%x, fp(size=%zu), stride=%d\n", thrd, addr_reg.u32, size, src2_data.u32);
-	addr_t new_addr = addr+thread_group_offset(thrd,wmma_type,wmma_layout,type,stride)*size/8;  
-	addr_t push_addr;
+    memory_space *mem = NULL;
+    addr_t addr = addr_reg.u32;
 
-	ptx_reg_t nw_v[8];
-	for(k=0;k<8;k++){
-		if(k%2==0)
-			nw_v[k].s64=(v[k/2].s64&0xffff);
-		else
-			nw_v[k].s64=((v[k/2].s64&0xffff0000)>>16);
-	}
+    new_addr_type mem_txn_addr[MAX_ACCESSES_PER_INSN_PER_THREAD];
+    int num_mem_txn = 0;
 
-	for(k=0;k<8;k++){
-		if(type==F32_TYPE){
-       			//mem->write(new_addr+4*acc_float_offset(k,wmma_layout,stride),size/8,&v[k].s64,thread,pI);
-       			push_addr=new_addr+4*acc_float_offset(k,wmma_layout,stride);
-       			mem->write(push_addr,size/8,&v[k].s64,thread,pI);
-			mem_txn_addr[num_mem_txn++]=push_addr;
-	
-			if(core->get_gpu()->gpgpu_ctx->debug_tensorcore){
-				printf("wmma:store:thread%d=%llx,%llx,%llx,%llx,%llx,%llx,%llx,%llx\n",thrd,v[0].s64,v[1].s64,v[2].s64,v[3].s64,v[4].s64,v[5].s64,v[6].s64,v[7].s64);   
-				float temp;
-				int l;
-				printf("thread=%d:",thrd);
-				for(l=0;l<8;l++){
-					temp=v[l].f32;
-					printf("%.2f",temp);	
-				}
-				printf("\n");
-			}
-		}
-		else if(type==F16_TYPE){
-			if(wmma_layout==ROW){
-       				//mem->write(new_addr+k*2,size/8,&nw_v[k].s64,thread,pI);
-       				push_addr=new_addr+k*2;
-       				mem->write(push_addr,size/8,&nw_v[k].s64,thread,pI);
-				if(k%2==0)
-					mem_txn_addr[num_mem_txn++]=push_addr;
-			}
-			else if(wmma_layout==COL){
-       				//mem->write(new_addr+k*2*stride,size/8,&nw_v[k].s64,thread,pI);
-       				push_addr=new_addr+k*2*stride;
-       				mem->write(push_addr,size/8,&nw_v[k].s64,thread,pI);
-				mem_txn_addr[num_mem_txn++]=push_addr;
-			}
-	
-			if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)
-				printf("wmma:store:thread%d=%llx,%llx,%llx,%llx,%llx,%llx,%llx,%llx\n",thrd,nw_v[0].s64,nw_v[1].s64,nw_v[2].s64,nw_v[3].s64,nw_v[4].s64,nw_v[5].s64,nw_v[6].s64,nw_v[7].s64);   
-		}
-	}
-   	
-	delete [] v;
-   	inst.space = space;
-   	inst.set_addr(thrd, (new_addr_type *)mem_txn_addr , num_mem_txn);
+    smid = thread->get_hw_sid();
+    if (whichspace(addr) == shared_space) {
+      addr = generic_to_shared(smid, addr);
+      space = shared_space;
+    }
+    decode_space(space, thread, src1, mem, addr);
 
-	if((type==F16_TYPE)&&(wmma_layout==COL))//check the profiling xls for details
-   		inst.data_size = 2; // 2 byte transaction 
-   	else
-		inst.data_size = 4; // 4 byte transaction 
+    type_info_key::type_decode(type, size, t);
+    if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+      printf("mma_st: thrd=%d, addr=%x, fp(size=%zu), stride=%d\n", thrd,
+             addr_reg.u32, size, src2_data.u32);
+    addr_t new_addr =
+        addr +
+        thread_group_offset(thrd, wmma_type, wmma_layout, type, stride) * size /
+            8;
+    addr_t push_addr;
 
-   	assert( inst.memory_op == insn_memory_op );
-   	//thread->m_last_effective_address = addr;
-   	//thread->m_last_memory_space = space;
-   } 
+    ptx_reg_t nw_v[8];
+    for (k = 0; k < 8; k++) {
+      if (k % 2 == 0)
+        nw_v[k].s64 = (v[k / 2].s64 & 0xffff);
+      else
+        nw_v[k].s64 = ((v[k / 2].s64 & 0xffff0000) >> 16);
+    }
+
+    for (k = 0; k < 8; k++) {
+      if (type == F32_TYPE) {
+        // mem->write(new_addr+4*acc_float_offset(k,wmma_layout,stride),size/8,&v[k].s64,thread,pI);
+        push_addr = new_addr + 4 * acc_float_offset(k, wmma_layout, stride);
+        mem->write(push_addr, size / 8, &v[k].s64, thread, pI);
+        mem_txn_addr[num_mem_txn++] = push_addr;
+
+        if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) {
+          printf(
+              "wmma:store:thread%d=%llx,%llx,%llx,%llx,%llx,%llx,%llx,%llx\n",
+              thrd, v[0].s64, v[1].s64, v[2].s64, v[3].s64, v[4].s64, v[5].s64,
+              v[6].s64, v[7].s64);
+          float temp;
+          int l;
+          printf("thread=%d:", thrd);
+          for (l = 0; l < 8; l++) {
+            temp = v[l].f32;
+            printf("%.2f", temp);
+          }
+          printf("\n");
+        }
+      } else if (type == F16_TYPE) {
+        if (wmma_layout == ROW) {
+          // mem->write(new_addr+k*2,size/8,&nw_v[k].s64,thread,pI);
+          push_addr = new_addr + k * 2;
+          mem->write(push_addr, size / 8, &nw_v[k].s64, thread, pI);
+          if (k % 2 == 0) mem_txn_addr[num_mem_txn++] = push_addr;
+        } else if (wmma_layout == COL) {
+          // mem->write(new_addr+k*2*stride,size/8,&nw_v[k].s64,thread,pI);
+          push_addr = new_addr + k * 2 * stride;
+          mem->write(push_addr, size / 8, &nw_v[k].s64, thread, pI);
+          mem_txn_addr[num_mem_txn++] = push_addr;
+        }
+
+        if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+          printf(
+              "wmma:store:thread%d=%llx,%llx,%llx,%llx,%llx,%llx,%llx,%llx\n",
+              thrd, nw_v[0].s64, nw_v[1].s64, nw_v[2].s64, nw_v[3].s64,
+              nw_v[4].s64, nw_v[5].s64, nw_v[6].s64, nw_v[7].s64);
+      }
+    }
+
+    delete[] v;
+    inst.space = space;
+    inst.set_addr(thrd, (new_addr_type *)mem_txn_addr, num_mem_txn);
+
+    if ((type == F16_TYPE) &&
+        (wmma_layout == COL))  // check the profiling xls for details
+      inst.data_size = 2;      // 2 byte transaction
+    else
+      inst.data_size = 4;  // 4 byte transaction
+
+    assert(inst.memory_op == insn_memory_op);
+    // thread->m_last_effective_address = addr;
+    // thread->m_last_memory_space = space;
+  }
 }
 
-void mma_ld_impl( const ptx_instruction *pI, core_t *core, warp_inst_t &inst )
-{
-   size_t size;
-   int t,i;
-   unsigned smid;
-   const operand_info &dst = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+void mma_ld_impl(const ptx_instruction *pI, core_t *core, warp_inst_t &inst) {
+  size_t size;
+  int t, i;
+  unsigned smid;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   unsigned type = pI->get_type();
-   unsigned wmma_type = pI->get_wmma_type();
-   unsigned wmma_layout = pI->get_wmma_layout(0);
-   int tid;
-   int thrd,stride;
-   ptx_thread_info *thread;
- 
+  unsigned type = pI->get_type();
+  unsigned wmma_type = pI->get_wmma_type();
+  unsigned wmma_layout = pI->get_wmma_layout(0);
+  int tid;
+  int thrd, stride;
+  ptx_thread_info *thread;
 
-   if(core->get_gpu()->is_functional_sim())
-    	tid= inst.warp_id_func()*core->get_warp_size();
-   else
-    	tid= inst.warp_id()*core->get_warp_size();
+  if (core->get_gpu()->is_functional_sim())
+    tid = inst.warp_id_func() * core->get_warp_size();
+  else
+    tid = inst.warp_id() * core->get_warp_size();
 
-   _memory_op_t insn_memory_op = pI->has_memory_read() ? memory_load : memory_store;
-   
-   for (thrd=0; thrd < core->get_warp_size(); thrd++){
-   	thread = core->get_thread_info()[tid+thrd];
-   	ptx_reg_t src1_data = thread->get_operand_value(src1, dst, U32_TYPE, thread, 1);
-   	ptx_reg_t src2_data = thread->get_operand_value(src2, dst, U32_TYPE, thread, 1);
-	stride=src2_data.u32;
-   	memory_space_t space = pI->get_space();
+  _memory_op_t insn_memory_op =
+      pI->has_memory_read() ? memory_load : memory_store;
 
-   	memory_space *mem = NULL;
-   	addr_t addr = src1_data.u32;
-        smid = thread->get_hw_sid();
-        if( whichspace(addr) == shared_space ) {
-          addr= generic_to_shared(smid,addr);
-          space = shared_space;
-	}
+  for (thrd = 0; thrd < core->get_warp_size(); thrd++) {
+    thread = core->get_thread_info()[tid + thrd];
+    ptx_reg_t src1_data =
+        thread->get_operand_value(src1, dst, U32_TYPE, thread, 1);
+    ptx_reg_t src2_data =
+        thread->get_operand_value(src2, dst, U32_TYPE, thread, 1);
+    stride = src2_data.u32;
+    memory_space_t space = pI->get_space();
 
-	decode_space(space,thread,src1,mem,addr);
-   	type_info_key::type_decode(type, size, t);
-	
-	ptx_reg_t data[16];
-   	if(core->get_gpu()->gpgpu_ctx->debug_tensorcore)	
-		printf("mma_ld: thrd=%d,addr=%x, fpsize=%zu, stride=%d\n", thrd, src1_data.u32, size, src2_data.u32);
-	
-	addr_t new_addr = addr+thread_group_offset(thrd,wmma_type,wmma_layout,type,stride)*size/8;  
-	addr_t fetch_addr;
-	new_addr_type mem_txn_addr[MAX_ACCESSES_PER_INSN_PER_THREAD];
-	int num_mem_txn=0;
+    memory_space *mem = NULL;
+    addr_t addr = src1_data.u32;
+    smid = thread->get_hw_sid();
+    if (whichspace(addr) == shared_space) {
+      addr = generic_to_shared(smid, addr);
+      space = shared_space;
+    }
 
-	if(wmma_type==LOAD_A){
-		for(i=0;i<16;i++){
-			if(wmma_layout==ROW){
-				//mem->read(new_addr+2*i,size/8,&data[i].s64);
-				fetch_addr=new_addr+2*i;
-				mem->read(fetch_addr,size/8,&data[i].s64);
-			}
-			else if(wmma_layout==COL){
-				//mem->read(new_addr+2*(i%4)+2*stride*4*(i/4),size/8,&data[i].s64);
-				fetch_addr=new_addr+2*(i%4)+2*stride*4*(i/4);
-				mem->read(fetch_addr,size/8,&data[i].s64);
-			}
-			else{
-				printf("mma_ld:wrong_layout_type\n");
-				abort();
-			
-			}
-			if(i%2==0)
-				mem_txn_addr[num_mem_txn++]=fetch_addr;	
-		}
-	}
-	else if(wmma_type==LOAD_B){
-		for(i=0;i<16;i++){
-			if(wmma_layout==COL){
-				//mem->read(new_addr+2*i,size/8,&data[i].s64);
-				fetch_addr=new_addr+2*i;
-				mem->read(fetch_addr,size/8,&data[i].s64);
-			}
-			else if(wmma_layout==ROW){
-				//mem->read(new_addr+2*(i%4)+2*stride*4*(i/4),size/8,&data[i].s64);
-				fetch_addr=new_addr+2*(i%4)+2*stride*4*(i/4);
-				mem->read(fetch_addr,size/8,&data[i].s64);
-			}
-			else{
-				printf("mma_ld:wrong_layout_type\n");
-				abort();
-			}
-			if(i%2==0)
-				mem_txn_addr[num_mem_txn++]=fetch_addr;	
-		}
-	}
-	else if(wmma_type==LOAD_C){
-		for(i=0;i<8;i++){
-			if(type==F16_TYPE){
-				if(wmma_layout==ROW){
-					//mem->read(new_addr+2*i,size/8,&data[i].s64);
-					fetch_addr=new_addr+2*i;
-					mem->read(fetch_addr,size/8,&data[i].s64);
-					if(i%2==0)
-						mem_txn_addr[num_mem_txn++]=fetch_addr;	
-				}
-				else if(wmma_layout==COL){
-					//mem->read(new_addr+2*stride*i,size/8,&data[i].s64);
-					fetch_addr=new_addr+2*stride*i;
-					mem->read(fetch_addr,size/8,&data[i].s64);
-					mem_txn_addr[num_mem_txn++]=fetch_addr;	
-				}
-				else{
-					printf("mma_ld:wrong_type\n");
-					abort();
-				}
-			}
-			else if(type==F32_TYPE){
-				//mem->read(new_addr+4*acc_float_offset(i,wmma_layout,stride),size/8,&data[i].s64);
-				fetch_addr=new_addr+4*acc_float_offset(i,wmma_layout,stride);
-				mem->read(fetch_addr,size/8,&data[i].s64);
-				mem_txn_addr[num_mem_txn++]=fetch_addr;	
-			}
-			else{
-				printf("wrong type");
-				abort();
-			}
-		}
-	}
-	else{
-		printf("wrong wmma type\n");;
-		abort();
-	}
-	//generate timing memory request
-   	inst.space = space;
-   	inst.set_addr(thrd, (new_addr_type *)mem_txn_addr , num_mem_txn);
+    decode_space(space, thread, src1, mem, addr);
+    type_info_key::type_decode(type, size, t);
 
-	if((wmma_type==LOAD_C)&&(type==F16_TYPE)&&(wmma_layout==COL))//memory address is scattered, check the profiling xls for more detail.
-   		inst.data_size = 2; // 2 byte transaction 
-	else	
-   		inst.data_size = 4; // 4 byte transaction 
-   	assert( inst.memory_op == insn_memory_op );
+    ptx_reg_t data[16];
+    if (core->get_gpu()->gpgpu_ctx->debug_tensorcore)
+      printf("mma_ld: thrd=%d,addr=%x, fpsize=%zu, stride=%d\n", thrd,
+             src1_data.u32, size, src2_data.u32);
 
-	if(core->get_gpu()->gpgpu_ctx->debug_tensorcore){
-		if(type==F16_TYPE){
-			printf("\nmma_ld:thread%d= ",thrd);
-			for(i=0;i<16;i++){
-				printf("%llx ",data[i].u64);
-			}
-			printf("\n");
-			
-			printf("\nmma_ld:thread%d= ",thrd);
-			float temp;
-			for(i=0;i<16;i++){
-			temp=data[i].f16;
-				printf("%.2f ",temp);
-			}
-			printf("\n");
-		}
-		else{
-			printf("\nmma_ld:thread%d= ",thrd);
-			for(i=0;i<8;i++){
-				printf("%.2f ",data[i].f32);
-			}
-			printf("\n");
-			printf("\nmma_ld:thread%d= ",thrd);
-			for(i=0;i<8;i++){
-				printf("%llx ",data[i].u64);
-			}
-			printf("\n");
-		}
-	}
+    addr_t new_addr =
+        addr +
+        thread_group_offset(thrd, wmma_type, wmma_layout, type, stride) * size /
+            8;
+    addr_t fetch_addr;
+    new_addr_type mem_txn_addr[MAX_ACCESSES_PER_INSN_PER_THREAD];
+    int num_mem_txn = 0;
 
-	if((wmma_type==LOAD_C)&&(type==F32_TYPE)){
-   		thread->set_wmma_vector_operand_values(dst,data[0],data[1],data[2],data[3],data[4],data[5],data[6],data[7]);
-	}
-	else{
-		ptx_reg_t nw_data[8];
-		int num_reg;
-		
-		if(wmma_type==LOAD_C)
-			num_reg=4;
-		else
-			num_reg=8;
+    if (wmma_type == LOAD_A) {
+      for (i = 0; i < 16; i++) {
+        if (wmma_layout == ROW) {
+          // mem->read(new_addr+2*i,size/8,&data[i].s64);
+          fetch_addr = new_addr + 2 * i;
+          mem->read(fetch_addr, size / 8, &data[i].s64);
+        } else if (wmma_layout == COL) {
+          // mem->read(new_addr+2*(i%4)+2*stride*4*(i/4),size/8,&data[i].s64);
+          fetch_addr = new_addr + 2 * (i % 4) + 2 * stride * 4 * (i / 4);
+          mem->read(fetch_addr, size / 8, &data[i].s64);
+        } else {
+          printf("mma_ld:wrong_layout_type\n");
+          abort();
+        }
+        if (i % 2 == 0) mem_txn_addr[num_mem_txn++] = fetch_addr;
+      }
+    } else if (wmma_type == LOAD_B) {
+      for (i = 0; i < 16; i++) {
+        if (wmma_layout == COL) {
+          // mem->read(new_addr+2*i,size/8,&data[i].s64);
+          fetch_addr = new_addr + 2 * i;
+          mem->read(fetch_addr, size / 8, &data[i].s64);
+        } else if (wmma_layout == ROW) {
+          // mem->read(new_addr+2*(i%4)+2*stride*4*(i/4),size/8,&data[i].s64);
+          fetch_addr = new_addr + 2 * (i % 4) + 2 * stride * 4 * (i / 4);
+          mem->read(fetch_addr, size / 8, &data[i].s64);
+        } else {
+          printf("mma_ld:wrong_layout_type\n");
+          abort();
+        }
+        if (i % 2 == 0) mem_txn_addr[num_mem_txn++] = fetch_addr;
+      }
+    } else if (wmma_type == LOAD_C) {
+      for (i = 0; i < 8; i++) {
+        if (type == F16_TYPE) {
+          if (wmma_layout == ROW) {
+            // mem->read(new_addr+2*i,size/8,&data[i].s64);
+            fetch_addr = new_addr + 2 * i;
+            mem->read(fetch_addr, size / 8, &data[i].s64);
+            if (i % 2 == 0) mem_txn_addr[num_mem_txn++] = fetch_addr;
+          } else if (wmma_layout == COL) {
+            // mem->read(new_addr+2*stride*i,size/8,&data[i].s64);
+            fetch_addr = new_addr + 2 * stride * i;
+            mem->read(fetch_addr, size / 8, &data[i].s64);
+            mem_txn_addr[num_mem_txn++] = fetch_addr;
+          } else {
+            printf("mma_ld:wrong_type\n");
+            abort();
+          }
+        } else if (type == F32_TYPE) {
+          // mem->read(new_addr+4*acc_float_offset(i,wmma_layout,stride),size/8,&data[i].s64);
+          fetch_addr = new_addr + 4 * acc_float_offset(i, wmma_layout, stride);
+          mem->read(fetch_addr, size / 8, &data[i].s64);
+          mem_txn_addr[num_mem_txn++] = fetch_addr;
+        } else {
+          printf("wrong type");
+          abort();
+        }
+      }
+    } else {
+      printf("wrong wmma type\n");
+      ;
+      abort();
+    }
+    // generate timing memory request
+    inst.space = space;
+    inst.set_addr(thrd, (new_addr_type *)mem_txn_addr, num_mem_txn);
 
-		for(i=0;i<num_reg;i++){
-			nw_data[i].s64= ((data[2*i].s64 & 0xffff)<<16)| ((data[2*i+1].s64 & 0xffff));
-		}
+    if ((wmma_type == LOAD_C) && (type == F16_TYPE) &&
+        (wmma_layout == COL))  // memory address is scattered, check the
+                               // profiling xls for more detail.
+      inst.data_size = 2;  // 2 byte transaction
+    else
+      inst.data_size = 4;  // 4 byte transaction
+    assert(inst.memory_op == insn_memory_op);
 
-		if(wmma_type==LOAD_C)
-   			thread->set_vector_operand_values(dst,nw_data[0],nw_data[1],nw_data[2],nw_data[3]);
-		else
-   			thread->set_wmma_vector_operand_values(dst,nw_data[0],nw_data[1],nw_data[2],nw_data[3],nw_data[4],nw_data[5],nw_data[6],nw_data[7]);
-		if(core->get_gpu()->gpgpu_ctx->debug_tensorcore){	
-			printf("mma_ld:data[0].s64=%llx,data[1].s64=%llx,new_data[0].s64=%llx\n",data[0].u64,data[1].u64,nw_data[0].u64);	
-			printf("mma_ld:data[2].s64=%llx,data[3].s64=%llx,new_data[1].s64=%llx\n",data[2].u64,data[3].u64,nw_data[1].u64);	
-			printf("mma_ld:data[4].s64=%llx,data[5].s64=%llx,new_data[2].s64=%llx\n",data[4].u64,data[5].u64,nw_data[2].u64);	
-			printf("mma_ld:data[6].s64=%llx,data[7].s64=%llx,new_data[3].s64=%llx\n",data[6].u64,data[7].u64,nw_data[3].u64);	
-			if(wmma_type!=LOAD_C){
-			printf("mma_ld:data[8].s64=%llx,data[9].s64=%llx,new_data[4].s64=%llx\n",data[8].u64,data[9].u64,nw_data[4].s64);	
-			printf("mma_ld:data[10].s64=%llx,data[11].s64=%llx,new_data[5].s64=%llx\n",data[10].u64,data[11].u64,nw_data[5].u64);	
-			printf("mma_ld:data[12].s64=%llx,data[13].s64=%llx,new_data[6].s64=%llx\n",data[12].u64,data[13].u64,nw_data[6].u64);	
-			printf("mma_ld:data[14].s64=%llx,data[15].s64=%llx,new_data[7].s64=%llx\n",data[14].u64,data[15].u64,nw_data[3].u64);	
-			}
-		}
-	}
+    if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) {
+      if (type == F16_TYPE) {
+        printf("\nmma_ld:thread%d= ", thrd);
+        for (i = 0; i < 16; i++) {
+          printf("%llx ", data[i].u64);
+        }
+        printf("\n");
 
-   	//thread->m_last_effective_address = addr;
-   	//thread->m_last_memory_space = space;
-   } 
+        printf("\nmma_ld:thread%d= ", thrd);
+        float temp;
+        for (i = 0; i < 16; i++) {
+          temp = data[i].f16;
+          printf("%.2f ", temp);
+        }
+        printf("\n");
+      } else {
+        printf("\nmma_ld:thread%d= ", thrd);
+        for (i = 0; i < 8; i++) {
+          printf("%.2f ", data[i].f32);
+        }
+        printf("\n");
+        printf("\nmma_ld:thread%d= ", thrd);
+        for (i = 0; i < 8; i++) {
+          printf("%llx ", data[i].u64);
+        }
+        printf("\n");
+      }
+    }
+
+    if ((wmma_type == LOAD_C) && (type == F32_TYPE)) {
+      thread->set_wmma_vector_operand_values(dst, data[0], data[1], data[2],
+                                             data[3], data[4], data[5], data[6],
+                                             data[7]);
+    } else {
+      ptx_reg_t nw_data[8];
+      int num_reg;
+
+      if (wmma_type == LOAD_C)
+        num_reg = 4;
+      else
+        num_reg = 8;
+
+      for (i = 0; i < num_reg; i++) {
+        nw_data[i].s64 = ((data[2 * i].s64 & 0xffff) << 16) |
+                         ((data[2 * i + 1].s64 & 0xffff));
+      }
+
+      if (wmma_type == LOAD_C)
+        thread->set_vector_operand_values(dst, nw_data[0], nw_data[1],
+                                          nw_data[2], nw_data[3]);
+      else
+        thread->set_wmma_vector_operand_values(
+            dst, nw_data[0], nw_data[1], nw_data[2], nw_data[3], nw_data[4],
+            nw_data[5], nw_data[6], nw_data[7]);
+      if (core->get_gpu()->gpgpu_ctx->debug_tensorcore) {
+        printf(
+            "mma_ld:data[0].s64=%llx,data[1].s64=%llx,new_data[0].s64=%llx\n",
+            data[0].u64, data[1].u64, nw_data[0].u64);
+        printf(
+            "mma_ld:data[2].s64=%llx,data[3].s64=%llx,new_data[1].s64=%llx\n",
+            data[2].u64, data[3].u64, nw_data[1].u64);
+        printf(
+            "mma_ld:data[4].s64=%llx,data[5].s64=%llx,new_data[2].s64=%llx\n",
+            data[4].u64, data[5].u64, nw_data[2].u64);
+        printf(
+            "mma_ld:data[6].s64=%llx,data[7].s64=%llx,new_data[3].s64=%llx\n",
+            data[6].u64, data[7].u64, nw_data[3].u64);
+        if (wmma_type != LOAD_C) {
+          printf(
+              "mma_ld:data[8].s64=%llx,data[9].s64=%llx,new_data[4].s64=%llx\n",
+              data[8].u64, data[9].u64, nw_data[4].s64);
+          printf(
+              "mma_ld:data[10].s64=%llx,data[11].s64=%llx,new_data[5].s64=%"
+              "llx\n",
+              data[10].u64, data[11].u64, nw_data[5].u64);
+          printf(
+              "mma_ld:data[12].s64=%llx,data[13].s64=%llx,new_data[6].s64=%"
+              "llx\n",
+              data[12].u64, data[13].u64, nw_data[6].u64);
+          printf(
+              "mma_ld:data[14].s64=%llx,data[15].s64=%llx,new_data[7].s64=%"
+              "llx\n",
+              data[14].u64, data[15].u64, nw_data[3].u64);
+        }
+      }
+    }
+
+    // thread->m_last_effective_address = addr;
+    // thread->m_last_memory_space = space;
+  }
 }
 
-void lg2_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t a, d;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
+void lg2_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, d;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
 
-   unsigned i_type = pI->get_type();
+  unsigned i_type = pI->get_type();
 
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
 
-
-   switch ( i_type ) {
-   case F32_TYPE: 
-      d.f32 = log(a.f32)/log(2);
+  switch (i_type) {
+    case F32_TYPE:
+      d.f32 = log(a.f32) / log(2);
       break;
-   default:
+    default:
       printf("Execution error: type mismatch with instruction\n");
       assert(0);
       break;
-   }
+  }
 
-   thread->set_operand_value(dst,d, i_type, thread, pI);
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-void mad24_impl( const ptx_instruction *pI, ptx_thread_info *thread )
-{
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
-   const operand_info &src3 = pI->src3();
-   ptx_reg_t d, t;
+void mad24_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
+  const operand_info &src3 = pI->src3();
+  ptx_reg_t d, t;
 
-   unsigned i_type = pI->get_type();
-   ptx_reg_t a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   ptx_reg_t b = thread->get_operand_value(src2, dst, i_type, thread, 1);
-   ptx_reg_t c = thread->get_operand_value(src3, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  ptx_reg_t a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  ptx_reg_t b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  ptx_reg_t c = thread->get_operand_value(src3, dst, i_type, thread, 1);
 
-   unsigned sat_mode = pI->saturation_mode();
+  unsigned sat_mode = pI->saturation_mode();
 
-   assert( !pI->is_wide() );
+  assert(!pI->is_wide());
 
-   switch ( i_type ) {
-   case S32_TYPE: 
+  switch (i_type) {
+    case S32_TYPE:
       t.s64 = a.s32 * b.s32;
-      if ( pI->is_hi() ) {
-         d.s64 = (t.s64>>16) + c.s32;
-         if ( sat_mode ) {
-            if ( d.s64 > (int)0x7FFFFFFF )
-               d.s64 = (int)0x7FFFFFFF;
-            else if ( d.s64 < (int)0x80000000 )
-               d.s64 = (int)0x80000000;
-         }
-      } else if ( pI->is_lo() ) d.s64 = t.s32 + c.s32;
-      else assert(0);
+      if (pI->is_hi()) {
+        d.s64 = (t.s64 >> 16) + c.s32;
+        if (sat_mode) {
+          if (d.s64 > (int)0x7FFFFFFF)
+            d.s64 = (int)0x7FFFFFFF;
+          else if (d.s64 < (int)0x80000000)
+            d.s64 = (int)0x80000000;
+        }
+      } else if (pI->is_lo())
+        d.s64 = t.s32 + c.s32;
+      else
+        assert(0);
       break;
-   case U32_TYPE: 
+    case U32_TYPE:
       t.u64 = a.u32 * b.u32;
-      if ( pI->is_hi() ) d.u64 = (t.u64>>16) + c.u32;
-      else if ( pI->is_lo() ) d.u64 = t.u32 + c.u32;
-      else assert(0);
+      if (pI->is_hi())
+        d.u64 = (t.u64 >> 16) + c.u32;
+      else if (pI->is_lo())
+        d.u64 = t.u32 + c.u32;
+      else
+        assert(0);
       break;
-   default: 
+    default:
       assert(0);
       break;
-   }
+  }
 
-   thread->set_operand_value(dst, d, i_type, thread, pI);
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-void mad_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   mad_def(pI, thread, false);
+void mad_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  mad_def(pI, thread, false);
 }
 
-void madp_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   mad_def(pI, thread, true);
+void madp_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  mad_def(pI, thread, true);
 }
 
-void madc_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   mad_def(pI, thread, true);
+void madc_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  mad_def(pI, thread, true);
 }
 
-void mad_def( const ptx_instruction *pI, ptx_thread_info *thread, bool use_carry ) 
-{ 
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
-   const operand_info &src3 = pI->src3();
-   ptx_reg_t d, t;
+void mad_def(const ptx_instruction *pI, ptx_thread_info *thread,
+             bool use_carry) {
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
+  const operand_info &src3 = pI->src3();
+  ptx_reg_t d, t;
 
-   int carry=0;
-   int overflow=0;
+  int carry = 0;
+  int overflow = 0;
 
-   unsigned i_type = pI->get_type();
-   ptx_reg_t a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   ptx_reg_t b = thread->get_operand_value(src2, dst, i_type, thread, 1);
-   ptx_reg_t c = thread->get_operand_value(src3, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  ptx_reg_t a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  ptx_reg_t b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  ptx_reg_t c = thread->get_operand_value(src3, dst, i_type, thread, 1);
 
-   // take the carry bit, it should be the 4th operand 
-   ptx_reg_t carry_bit; 
-   carry_bit.u64 = 0;
-   if (use_carry) {
-      const operand_info &carry = pI->operand_lookup(4);
-      carry_bit = thread->get_operand_value(carry, dst, PRED_TYPE, thread, 0);
-      carry_bit.pred &= 0x4;
-      carry_bit.pred >>=2;
-   }
+  // take the carry bit, it should be the 4th operand
+  ptx_reg_t carry_bit;
+  carry_bit.u64 = 0;
+  if (use_carry) {
+    const operand_info &carry = pI->operand_lookup(4);
+    carry_bit = thread->get_operand_value(carry, dst, PRED_TYPE, thread, 0);
+    carry_bit.pred &= 0x4;
+    carry_bit.pred >>= 2;
+  }
 
-   unsigned rounding_mode = pI->rounding_mode();
+  unsigned rounding_mode = pI->rounding_mode();
 
-   switch ( i_type ) {
-   case S16_TYPE: 
+  switch (i_type) {
+    case S16_TYPE:
       t.s32 = a.s16 * b.s16;
-      if ( pI->is_wide() ) d.s32 = t.s32 + c.s32 + carry_bit.pred;
-      else if ( pI->is_hi() ) d.s16 = (t.s32>>16) + c.s16 + carry_bit.pred;
-      else if ( pI->is_lo() ) d.s16 = t.s16 + c.s16 + carry_bit.pred;
-      else assert(0);
-      carry = ((long long int)(t.s32 + c.s32 + carry_bit.pred)&0x100000000)>>32;
+      if (pI->is_wide())
+        d.s32 = t.s32 + c.s32 + carry_bit.pred;
+      else if (pI->is_hi())
+        d.s16 = (t.s32 >> 16) + c.s16 + carry_bit.pred;
+      else if (pI->is_lo())
+        d.s16 = t.s16 + c.s16 + carry_bit.pred;
+      else
+        assert(0);
+      carry =
+          ((long long int)(t.s32 + c.s32 + carry_bit.pred) & 0x100000000) >> 32;
       break;
-   case S32_TYPE: 
+    case S32_TYPE:
       t.s64 = a.s32 * b.s32;
-      if ( pI->is_wide() ) d.s64 = t.s64 + c.s64 + carry_bit.pred;
-      else if ( pI->is_hi() ) d.s32 = (t.s64>>32) + c.s32 + carry_bit.pred;
-      else if ( pI->is_lo() ) d.s32 = t.s32 + c.s32 + carry_bit.pred;
-      else assert(0);
+      if (pI->is_wide())
+        d.s64 = t.s64 + c.s64 + carry_bit.pred;
+      else if (pI->is_hi())
+        d.s32 = (t.s64 >> 32) + c.s32 + carry_bit.pred;
+      else if (pI->is_lo())
+        d.s32 = t.s32 + c.s32 + carry_bit.pred;
+      else
+        assert(0);
       break;
-   case S64_TYPE: 
+    case S64_TYPE:
       t.s64 = a.s64 * b.s64;
-      assert( !pI->is_wide() );
-      assert( !pI->is_hi() );
-      assert( use_carry == false); 
-      if ( pI->is_lo() ) d.s64 = t.s64 + c.s64 + carry_bit.pred;
-      else assert(0);
+      assert(!pI->is_wide());
+      assert(!pI->is_hi());
+      assert(use_carry == false);
+      if (pI->is_lo())
+        d.s64 = t.s64 + c.s64 + carry_bit.pred;
+      else
+        assert(0);
       break;
-   case U16_TYPE: 
+    case U16_TYPE:
       t.u32 = a.u16 * b.u16;
-      if ( pI->is_wide() ) d.u32 = t.u32 + c.u32 + carry_bit.pred;
-      else if ( pI->is_hi() ) d.u16 = (t.u32 + c.u16 + carry_bit.pred)>>16;
-      else if ( pI->is_lo() ) d.u16 = t.u16 + c.u16 + carry_bit.pred;
-      else assert(0);
-      carry = ((long long int)((long long int)t.u32 + c.u32 + carry_bit.pred)&0x100000000)>>32;
+      if (pI->is_wide())
+        d.u32 = t.u32 + c.u32 + carry_bit.pred;
+      else if (pI->is_hi())
+        d.u16 = (t.u32 + c.u16 + carry_bit.pred) >> 16;
+      else if (pI->is_lo())
+        d.u16 = t.u16 + c.u16 + carry_bit.pred;
+      else
+        assert(0);
+      carry = ((long long int)((long long int)t.u32 + c.u32 + carry_bit.pred) &
+               0x100000000) >>
+              32;
       break;
-   case U32_TYPE: 
+    case U32_TYPE:
       t.u64 = a.u32 * b.u32;
-      if ( pI->is_wide() ) d.u64 = t.u64 + c.u64 + carry_bit.pred;
-      else if ( pI->is_hi() ) d.u32 = (t.u64 + c.u32 + carry_bit.pred)>>32;
-      else if ( pI->is_lo() ) d.u32 = t.u32 + c.u32 + carry_bit.pred;
-      else assert(0);
+      if (pI->is_wide())
+        d.u64 = t.u64 + c.u64 + carry_bit.pred;
+      else if (pI->is_hi())
+        d.u32 = (t.u64 + c.u32 + carry_bit.pred) >> 32;
+      else if (pI->is_lo())
+        d.u32 = t.u32 + c.u32 + carry_bit.pred;
+      else
+        assert(0);
       break;
-   case U64_TYPE: 
+    case U64_TYPE:
       t.u64 = a.u64 * b.u64;
-      assert( !pI->is_wide() );
-      assert( !pI->is_hi() );
-      assert( use_carry == false); 
-      if ( pI->is_lo() ) d.u64 = t.u64 + c.u64 + carry_bit.pred;
-      else assert(0);
+      assert(!pI->is_wide());
+      assert(!pI->is_hi());
+      assert(use_carry == false);
+      if (pI->is_lo())
+        d.u64 = t.u64 + c.u64 + carry_bit.pred;
+      else
+        assert(0);
       break;
-   case F16_TYPE:{ 
-     // assert(0); 
-     // break;
-         assert( use_carry == false); 
-         int orig_rm = fegetround();
-         switch ( rounding_mode ) {
-         case RN_OPTION: break;
-         case RZ_OPTION: fesetround( FE_TOWARDZERO ); break;
-         default: assert(0); break;
-         }
-         d.f16 = a.f16 * b.f16 + c.f16;
-         if ( pI->saturation_mode() ) {
-            if ( d.f16 < 0 ) d.f16 = 0;
-            else if ( d.f16 > 1.0f ) d.f16 = 1.0f;
-         }
-         fesetround( orig_rm );
-         break;
-      }  
-   case F32_TYPE: {
-         assert( use_carry == false); 
-         int orig_rm = fegetround();
-         switch ( rounding_mode ) {
-         case RN_OPTION: break;
-         case RZ_OPTION: fesetround( FE_TOWARDZERO ); break;
-         default: assert(0); break;
-         }
-         d.f32 = a.f32 * b.f32 + c.f32;
-         if ( pI->saturation_mode() ) {
-            if ( d.f32 < 0 ) d.f32 = 0;
-            else if ( d.f32 > 1.0f ) d.f32 = 1.0f;
-         }
-         fesetround( orig_rm );
-         break;
-      }  
-   case F64_TYPE: case FF64_TYPE: {
-         assert( use_carry == false); 
-         int orig_rm = fegetround();
-         switch ( rounding_mode ) {
-         case RN_OPTION: break;
-         case RZ_OPTION: fesetround( FE_TOWARDZERO ); break;
-         default: assert(0); break;
-         }
-         d.f64 = a.f64 * b.f64 + c.f64;
-         if ( pI->saturation_mode() ) {
-            if ( d.f64 < 0 ) d.f64 = 0;
-            else if ( d.f64 > 1.0f ) d.f64 = 1.0;
-         }
-         fesetround( orig_rm );
-         break;
+    case F16_TYPE: {
+      // assert(0);
+      // break;
+      assert(use_carry == false);
+      int orig_rm = fegetround();
+      switch (rounding_mode) {
+        case RN_OPTION:
+          break;
+        case RZ_OPTION:
+          fesetround(FE_TOWARDZERO);
+          break;
+        default:
+          assert(0);
+          break;
       }
-   default: 
+      d.f16 = a.f16 * b.f16 + c.f16;
+      if (pI->saturation_mode()) {
+        if (d.f16 < 0)
+          d.f16 = 0;
+        else if (d.f16 > 1.0f)
+          d.f16 = 1.0f;
+      }
+      fesetround(orig_rm);
+      break;
+    }
+    case F32_TYPE: {
+      assert(use_carry == false);
+      int orig_rm = fegetround();
+      switch (rounding_mode) {
+        case RN_OPTION:
+          break;
+        case RZ_OPTION:
+          fesetround(FE_TOWARDZERO);
+          break;
+        default:
+          assert(0);
+          break;
+      }
+      d.f32 = a.f32 * b.f32 + c.f32;
+      if (pI->saturation_mode()) {
+        if (d.f32 < 0)
+          d.f32 = 0;
+        else if (d.f32 > 1.0f)
+          d.f32 = 1.0f;
+      }
+      fesetround(orig_rm);
+      break;
+    }
+    case F64_TYPE:
+    case FF64_TYPE: {
+      assert(use_carry == false);
+      int orig_rm = fegetround();
+      switch (rounding_mode) {
+        case RN_OPTION:
+          break;
+        case RZ_OPTION:
+          fesetround(FE_TOWARDZERO);
+          break;
+        default:
+          assert(0);
+          break;
+      }
+      d.f64 = a.f64 * b.f64 + c.f64;
+      if (pI->saturation_mode()) {
+        if (d.f64 < 0)
+          d.f64 = 0;
+        else if (d.f64 > 1.0f)
+          d.f64 = 1.0;
+      }
+      fesetround(orig_rm);
+      break;
+    }
+    default:
       assert(0);
       break;
-   }
-   thread->set_operand_value(dst, d, i_type, thread, pI, overflow, carry);
+  }
+  thread->set_operand_value(dst, d, i_type, thread, pI, overflow, carry);
 }
 
-bool isNaN(float x)
-{
-   return std::isnan(x);
-}
+bool isNaN(float x) { return std::isnan(x); }
 
-bool isNaN(double x)
-{
-   return std::isnan(x);
-}
+bool isNaN(double x) { return std::isnan(x); }
 
-void max_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t a, b, d;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+void max_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, b, d;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   unsigned i_type = pI->get_type();
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  b = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-
-   switch ( i_type ) {
-   case U16_TYPE: d.u16 = MY_MAX_I(a.u16,b.u16); break;
-   case U32_TYPE: d.u32 = MY_MAX_I(a.u32,b.u32); break;
-   case U64_TYPE: d.u64 = MY_MAX_I(a.u64,b.u64); break;
-   case S16_TYPE: d.s16 = MY_MAX_I(a.s16,b.s16); break;
-   case S32_TYPE: d.s32 = MY_MAX_I(a.s32,b.s32); break;
-   case S64_TYPE: d.s64 = MY_MAX_I(a.s64,b.s64); break;
-   case F32_TYPE: d.f32 = MY_MAX_F(a.f32,b.f32); break;
-   case F64_TYPE: case FF64_TYPE: d.f64 = MY_MAX_F(a.f64,b.f64); break;
-   default:
-      printf("Execution error: type mismatch with instruction\n");
-      assert(0); 
+  switch (i_type) {
+    case U16_TYPE:
+      d.u16 = MY_MAX_I(a.u16, b.u16);
       break;
-   }
-
-   thread->set_operand_value(dst,d, i_type, thread, pI);
-}
-
-void membar_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   // handled by timing simulator 
-}
-
-void min_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t a, b, d;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
-
-   unsigned i_type = pI->get_type();
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   b = thread->get_operand_value(src2, dst, i_type, thread, 1);
-
-
-   switch ( i_type ) {
-   case U16_TYPE: d.u16 = MY_MIN_I(a.u16,b.u16); break;
-   case U32_TYPE: d.u32 = MY_MIN_I(a.u32,b.u32); break;
-   case U64_TYPE: d.u64 = MY_MIN_I(a.u64,b.u64); break;
-   case S16_TYPE: d.s16 = MY_MIN_I(a.s16,b.s16); break;
-   case S32_TYPE: d.s32 = MY_MIN_I(a.s32,b.s32); break;
-   case S64_TYPE: d.s64 = MY_MIN_I(a.s64,b.s64); break;
-   case F32_TYPE: d.f32 = MY_MIN_F(a.f32,b.f32); break;
-   case F64_TYPE: case FF64_TYPE: d.f64 = MY_MIN_F(a.f64,b.f64); break;
-   default:
+    case U32_TYPE:
+      d.u32 = MY_MAX_I(a.u32, b.u32);
+      break;
+    case U64_TYPE:
+      d.u64 = MY_MAX_I(a.u64, b.u64);
+      break;
+    case S16_TYPE:
+      d.s16 = MY_MAX_I(a.s16, b.s16);
+      break;
+    case S32_TYPE:
+      d.s32 = MY_MAX_I(a.s32, b.s32);
+      break;
+    case S64_TYPE:
+      d.s64 = MY_MAX_I(a.s64, b.s64);
+      break;
+    case F32_TYPE:
+      d.f32 = MY_MAX_F(a.f32, b.f32);
+      break;
+    case F64_TYPE:
+    case FF64_TYPE:
+      d.f64 = MY_MAX_F(a.f64, b.f64);
+      break;
+    default:
       printf("Execution error: type mismatch with instruction\n");
       assert(0);
       break;
-   }
+  }
 
-   thread->set_operand_value(dst,d, i_type, thread, pI);
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-void mov_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   ptx_reg_t data;
-
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   unsigned i_type = pI->get_type();
-   assert( src1.is_param_local() == 0 );
-
-   if( (src1.is_vector() || dst.is_vector()) && (i_type != BB64_TYPE) && (i_type != BB128_TYPE) && (i_type != FF64_TYPE) ) {
-      // pack or unpack operation
-      unsigned nbits_to_move;
-      ptx_reg_t tmp_bits;
-
-      switch( pI->get_type() ) {
-      case B16_TYPE: nbits_to_move = 16; break;
-      case B32_TYPE: nbits_to_move = 32; break;
-      case B64_TYPE: nbits_to_move = 64; break;
-      default: printf("Execution error: mov pack/unpack with unsupported type qualifier\n"); assert(0); break;
-      }
-
-      if( src1.is_vector() ) {
-         unsigned nelem = src1.get_vect_nelem();
-         ptx_reg_t v[4];
-         thread->get_vector_operand_values(src1, v, nelem );
-
-         unsigned bits_per_src_elem = nbits_to_move / nelem;
-         for( unsigned i=0; i < nelem; i++ ) {
-            switch(bits_per_src_elem) {
-            case 8:   tmp_bits.u64 |= ((unsigned long long)(v[i].u8)  << (8*i));  break;
-            case 16:  tmp_bits.u64 |= ((unsigned long long)(v[i].u16) << (16*i)); break;
-            case 32:  tmp_bits.u64 |= ((unsigned long long)(v[i].u32) << (32*i)); break;
-            default: printf("Execution error: mov pack/unpack with unsupported source/dst size ratio (src)\n"); assert(0); break;
-            }
-         }
-      } else {
-         data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-
-         switch( pI->get_type() ) {
-         case B16_TYPE: tmp_bits.u16 = data.u16; break;
-         case B32_TYPE: tmp_bits.u32 = data.u32; break;
-         case B64_TYPE: tmp_bits.u64 = data.u64; break;
-         default: assert(0); break;
-         }
-      }
-
-      if( dst.is_vector() ) {
-         unsigned nelem = dst.get_vect_nelem();
-         ptx_reg_t v[4];
-         unsigned bits_per_dst_elem = nbits_to_move / nelem;
-         for( unsigned i=0; i < nelem; i++ ) {
-            switch(bits_per_dst_elem) {
-            case 8:  v[i].u8  = (tmp_bits.u64 >> (8*i)) & ((unsigned long long) 0xFF); break;
-            case 16: v[i].u16 = (tmp_bits.u64 >> (16*i)) & ((unsigned long long) 0xFFFF); break;
-            case 32: v[i].u32 = (tmp_bits.u64 >> (32*i)) & ((unsigned long long) 0xFFFFFFFF); break;
-            default:
-               printf("Execution error: mov pack/unpack with unsupported source/dst size ratio (dst)\n");
-               assert(0);
-               break;
-            }
-         }
-         thread->set_vector_operand_values(dst,v[0],v[1],v[2],v[3]);
-      } else {
-         thread->set_operand_value(dst,tmp_bits, i_type, thread, pI);
-      }
-   } else if (i_type == PRED_TYPE and src1.is_literal() == true) {
-      // in ptx, literal input translate to predicate as 0 = false and 1 = true 
-      // we have adopted the opposite to simplify implementation of zero flags in ptxplus 
-      data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-
-      ptx_reg_t finaldata; 
-      finaldata.pred = (data.u32 == 0)? 1 : 0;  // setting zero-flag in predicate 
-      thread->set_operand_value(dst, finaldata, i_type, thread, pI);
-   } else {
-
-      data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-
-     thread->set_operand_value(dst, data, i_type, thread, pI);
-
-   }
+void membar_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  // handled by timing simulator
 }
 
-void mul24_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   ptx_reg_t src1_data, src2_data, data;
+void min_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, b, d;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+  unsigned i_type = pI->get_type();
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  b = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-   unsigned i_type = pI->get_type();
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  switch (i_type) {
+    case U16_TYPE:
+      d.u16 = MY_MIN_I(a.u16, b.u16);
+      break;
+    case U32_TYPE:
+      d.u32 = MY_MIN_I(a.u32, b.u32);
+      break;
+    case U64_TYPE:
+      d.u64 = MY_MIN_I(a.u64, b.u64);
+      break;
+    case S16_TYPE:
+      d.s16 = MY_MIN_I(a.s16, b.s16);
+      break;
+    case S32_TYPE:
+      d.s32 = MY_MIN_I(a.s32, b.s32);
+      break;
+    case S64_TYPE:
+      d.s64 = MY_MIN_I(a.s64, b.s64);
+      break;
+    case F32_TYPE:
+      d.f32 = MY_MIN_F(a.f32, b.f32);
+      break;
+    case F64_TYPE:
+    case FF64_TYPE:
+      d.f64 = MY_MIN_F(a.f64, b.f64);
+      break;
+    default:
+      printf("Execution error: type mismatch with instruction\n");
+      assert(0);
+      break;
+  }
 
+  thread->set_operand_value(dst, d, i_type, thread, pI);
+}
 
-   //src1_data = srcOperandModifiers(src1_data, src1, dst, i_type, thread);
-   //src2_data = srcOperandModifiers(src2_data, src2, dst, i_type, thread);
+void mov_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t data;
 
-   src1_data.mask_and(0,0x00FFFFFF);
-   src2_data.mask_and(0,0x00FFFFFF);
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  unsigned i_type = pI->get_type();
+  assert(src1.is_param_local() == 0);
 
-   switch ( i_type ) {
-   case S32_TYPE: 
-      if( src1_data.get_bit(23) ) 
-         src1_data.mask_or(0xFFFFFFFF,0xFF000000);
-      if( src2_data.get_bit(23) ) 
-         src2_data.mask_or(0xFFFFFFFF,0xFF000000);
+  if ((src1.is_vector() || dst.is_vector()) && (i_type != BB64_TYPE) &&
+      (i_type != BB128_TYPE) && (i_type != FF64_TYPE)) {
+    // pack or unpack operation
+    unsigned nbits_to_move;
+    ptx_reg_t tmp_bits;
+
+    switch (pI->get_type()) {
+      case B16_TYPE:
+        nbits_to_move = 16;
+        break;
+      case B32_TYPE:
+        nbits_to_move = 32;
+        break;
+      case B64_TYPE:
+        nbits_to_move = 64;
+        break;
+      default:
+        printf(
+            "Execution error: mov pack/unpack with unsupported type "
+            "qualifier\n");
+        assert(0);
+        break;
+    }
+
+    if (src1.is_vector()) {
+      unsigned nelem = src1.get_vect_nelem();
+      ptx_reg_t v[4];
+      thread->get_vector_operand_values(src1, v, nelem);
+
+      unsigned bits_per_src_elem = nbits_to_move / nelem;
+      for (unsigned i = 0; i < nelem; i++) {
+        switch (bits_per_src_elem) {
+          case 8:
+            tmp_bits.u64 |= ((unsigned long long)(v[i].u8) << (8 * i));
+            break;
+          case 16:
+            tmp_bits.u64 |= ((unsigned long long)(v[i].u16) << (16 * i));
+            break;
+          case 32:
+            tmp_bits.u64 |= ((unsigned long long)(v[i].u32) << (32 * i));
+            break;
+          default:
+            printf(
+                "Execution error: mov pack/unpack with unsupported source/dst "
+                "size ratio (src)\n");
+            assert(0);
+            break;
+        }
+      }
+    } else {
+      data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+
+      switch (pI->get_type()) {
+        case B16_TYPE:
+          tmp_bits.u16 = data.u16;
+          break;
+        case B32_TYPE:
+          tmp_bits.u32 = data.u32;
+          break;
+        case B64_TYPE:
+          tmp_bits.u64 = data.u64;
+          break;
+        default:
+          assert(0);
+          break;
+      }
+    }
+
+    if (dst.is_vector()) {
+      unsigned nelem = dst.get_vect_nelem();
+      ptx_reg_t v[4];
+      unsigned bits_per_dst_elem = nbits_to_move / nelem;
+      for (unsigned i = 0; i < nelem; i++) {
+        switch (bits_per_dst_elem) {
+          case 8:
+            v[i].u8 = (tmp_bits.u64 >> (8 * i)) & ((unsigned long long)0xFF);
+            break;
+          case 16:
+            v[i].u16 =
+                (tmp_bits.u64 >> (16 * i)) & ((unsigned long long)0xFFFF);
+            break;
+          case 32:
+            v[i].u32 =
+                (tmp_bits.u64 >> (32 * i)) & ((unsigned long long)0xFFFFFFFF);
+            break;
+          default:
+            printf(
+                "Execution error: mov pack/unpack with unsupported source/dst "
+                "size ratio (dst)\n");
+            assert(0);
+            break;
+        }
+      }
+      thread->set_vector_operand_values(dst, v[0], v[1], v[2], v[3]);
+    } else {
+      thread->set_operand_value(dst, tmp_bits, i_type, thread, pI);
+    }
+  } else if (i_type == PRED_TYPE and src1.is_literal() == true) {
+    // in ptx, literal input translate to predicate as 0 = false and 1 = true
+    // we have adopted the opposite to simplify implementation of zero flags in
+    // ptxplus
+    data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+
+    ptx_reg_t finaldata;
+    finaldata.pred = (data.u32 == 0) ? 1 : 0;  // setting zero-flag in predicate
+    thread->set_operand_value(dst, finaldata, i_type, thread, pI);
+  } else {
+    data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+
+    thread->set_operand_value(dst, data, i_type, thread, pI);
+  }
+}
+
+void mul24_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, src2_data, data;
+
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
+
+  unsigned i_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+
+  // src1_data = srcOperandModifiers(src1_data, src1, dst, i_type, thread);
+  // src2_data = srcOperandModifiers(src2_data, src2, dst, i_type, thread);
+
+  src1_data.mask_and(0, 0x00FFFFFF);
+  src2_data.mask_and(0, 0x00FFFFFF);
+
+  switch (i_type) {
+    case S32_TYPE:
+      if (src1_data.get_bit(23)) src1_data.mask_or(0xFFFFFFFF, 0xFF000000);
+      if (src2_data.get_bit(23)) src2_data.mask_or(0xFFFFFFFF, 0xFF000000);
       data.s64 = src1_data.s64 * src2_data.s64;
       break;
-   case U32_TYPE:
+    case U32_TYPE:
       data.u64 = src1_data.u64 * src2_data.u64;
       break;
-   default:
-      printf("GPGPU-Sim PTX: Execution error - type mismatch with instruction\n");
+    default:
+      printf(
+          "GPGPU-Sim PTX: Execution error - type mismatch with instruction\n");
       assert(0);
       break;
-   }
+  }
 
-   if ( pI->is_hi() ) {
-      data.u64 = data.u64 >> 16;
-      data.mask_and(0,0xFFFFFFFF);
-   } else if (pI->is_lo()) {
-      data.mask_and(0,0xFFFFFFFF);
-   }
+  if (pI->is_hi()) {
+    data.u64 = data.u64 >> 16;
+    data.mask_and(0, 0xFFFFFFFF);
+  } else if (pI->is_lo()) {
+    data.mask_and(0, 0xFFFFFFFF);
+  }
 
-   thread->set_operand_value(dst, data, i_type, thread, pI);
+  thread->set_operand_value(dst, data, i_type, thread, pI);
 }
 
-void mul_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   ptx_reg_t data;
+void mul_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t data;
 
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
-   ptx_reg_t d, t;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
+  ptx_reg_t d, t;
 
-   unsigned i_type = pI->get_type();
-   ptx_reg_t a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   ptx_reg_t b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  ptx_reg_t a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  ptx_reg_t b = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-   unsigned rounding_mode = pI->rounding_mode();
+  unsigned rounding_mode = pI->rounding_mode();
 
-   switch ( i_type ) {
-   case S16_TYPE: 
+  switch (i_type) {
+    case S16_TYPE:
       t.s32 = ((int)a.s16) * ((int)b.s16);
-      if ( pI->is_wide() ) d.s32 = t.s32;
-      else if ( pI->is_hi() ) d.s16 = (t.s32>>16);
-      else if ( pI->is_lo() ) d.s16 = t.s16;
-      else assert(0);
+      if (pI->is_wide())
+        d.s32 = t.s32;
+      else if (pI->is_hi())
+        d.s16 = (t.s32 >> 16);
+      else if (pI->is_lo())
+        d.s16 = t.s16;
+      else
+        assert(0);
       break;
-   case S32_TYPE: 
+    case S32_TYPE:
       t.s64 = ((long long)a.s32) * ((long long)b.s32);
-      if ( pI->is_wide() ) d.s64 = t.s64;
-      else if ( pI->is_hi() ) d.s32 = (t.s64>>32);
-      else if ( pI->is_lo() ) d.s32 = t.s32;
-      else assert(0);
+      if (pI->is_wide())
+        d.s64 = t.s64;
+      else if (pI->is_hi())
+        d.s32 = (t.s64 >> 32);
+      else if (pI->is_lo())
+        d.s32 = t.s32;
+      else
+        assert(0);
       break;
-   case S64_TYPE: 
+    case S64_TYPE:
       t.s64 = a.s64 * b.s64;
-      assert( !pI->is_wide() );
-      assert( !pI->is_hi() );
-      if ( pI->is_lo() ) d.s64 = t.s64;
-      else assert(0);
+      assert(!pI->is_wide());
+      assert(!pI->is_hi());
+      if (pI->is_lo())
+        d.s64 = t.s64;
+      else
+        assert(0);
       break;
-   case U16_TYPE: 
+    case U16_TYPE:
       t.u32 = ((unsigned)a.u16) * ((unsigned)b.u16);
-      if ( pI->is_wide() ) d.u32 = t.u32;
-      else if ( pI->is_lo() ) d.u16 = t.u16;
-      else if ( pI->is_hi() ) d.u16 = (t.u32>>16);
-      else assert(0);
+      if (pI->is_wide())
+        d.u32 = t.u32;
+      else if (pI->is_lo())
+        d.u16 = t.u16;
+      else if (pI->is_hi())
+        d.u16 = (t.u32 >> 16);
+      else
+        assert(0);
       break;
-   case U32_TYPE: 
+    case U32_TYPE:
       t.u64 = ((unsigned long long)a.u32) * ((unsigned long long)b.u32);
-      if ( pI->is_wide() ) d.u64 = t.u64;
-      else if ( pI->is_lo() ) d.u32 = t.u32;
-      else if ( pI->is_hi() ) d.u32 = (t.u64>>32);
-      else assert(0);
+      if (pI->is_wide())
+        d.u64 = t.u64;
+      else if (pI->is_lo())
+        d.u32 = t.u32;
+      else if (pI->is_hi())
+        d.u32 = (t.u64 >> 32);
+      else
+        assert(0);
       break;
-   case U64_TYPE: 
+    case U64_TYPE:
       t.u64 = a.u64 * b.u64;
-      assert( !pI->is_wide() );
-      assert( !pI->is_hi() );
-      if ( pI->is_lo() ) d.u64 = t.u64;
-      else assert(0);
+      assert(!pI->is_wide());
+      assert(!pI->is_hi());
+      if (pI->is_lo())
+        d.u64 = t.u64;
+      else
+        assert(0);
       break;
-   case F16_TYPE:{ 
-      //assert(0); 
-      //break;
-         int orig_rm = fegetround();
-         switch ( rounding_mode ) {
-         case RN_OPTION: break;
-         case RZ_OPTION: fesetround( FE_TOWARDZERO ); break;
-         default: assert(0); break;
-         }
-
-         d.f16 = a.f16 * b.f16;
-
-         if ( pI->saturation_mode() ) {
-            if ( d.f16 < 0 ) d.f16 = 0;
-            else if ( d.f16 > 1.0f ) d.f16 = 1.0f;
-         }
-         fesetround( orig_rm );
-         break;
-      }  
-   case F32_TYPE: {
-         int orig_rm = fegetround();
-         switch ( rounding_mode ) {
-         case RN_OPTION: break;
-         case RZ_OPTION: fesetround( FE_TOWARDZERO ); break;
-         default: assert(0); break;
-         }
-
-         d.f32 = a.f32 * b.f32;
-
-         if ( pI->saturation_mode() ) {
-            if ( d.f32 < 0 ) d.f32 = 0;
-            else if ( d.f32 > 1.0f ) d.f32 = 1.0f;
-         }
-         fesetround( orig_rm );
-         break;
-      }  
-   case F64_TYPE: case FF64_TYPE:{
-         int orig_rm = fegetround();
-         switch ( rounding_mode ) {
-         case RN_OPTION: break;
-         case RZ_OPTION: fesetround( FE_TOWARDZERO ); break;
-         default: assert(0); break;
-         }
-         d.f64 = a.f64 * b.f64;
-         if ( pI->saturation_mode() ) {
-            if ( d.f64 < 0 ) d.f64 = 0;
-            else if ( d.f64 > 1.0f ) d.f64 = 1.0;
-         }
-         fesetround( orig_rm );
-         break;
+    case F16_TYPE: {
+      // assert(0);
+      // break;
+      int orig_rm = fegetround();
+      switch (rounding_mode) {
+        case RN_OPTION:
+          break;
+        case RZ_OPTION:
+          fesetround(FE_TOWARDZERO);
+          break;
+        default:
+          assert(0);
+          break;
       }
-   default: 
-      assert(0); 
+
+      d.f16 = a.f16 * b.f16;
+
+      if (pI->saturation_mode()) {
+        if (d.f16 < 0)
+          d.f16 = 0;
+        else if (d.f16 > 1.0f)
+          d.f16 = 1.0f;
+      }
+      fesetround(orig_rm);
       break;
-   }
+    }
+    case F32_TYPE: {
+      int orig_rm = fegetround();
+      switch (rounding_mode) {
+        case RN_OPTION:
+          break;
+        case RZ_OPTION:
+          fesetround(FE_TOWARDZERO);
+          break;
+        default:
+          assert(0);
+          break;
+      }
 
-   thread->set_operand_value(dst, d, i_type, thread, pI);
+      d.f32 = a.f32 * b.f32;
+
+      if (pI->saturation_mode()) {
+        if (d.f32 < 0)
+          d.f32 = 0;
+        else if (d.f32 > 1.0f)
+          d.f32 = 1.0f;
+      }
+      fesetround(orig_rm);
+      break;
+    }
+    case F64_TYPE:
+    case FF64_TYPE: {
+      int orig_rm = fegetround();
+      switch (rounding_mode) {
+        case RN_OPTION:
+          break;
+        case RZ_OPTION:
+          fesetround(FE_TOWARDZERO);
+          break;
+        default:
+          assert(0);
+          break;
+      }
+      d.f64 = a.f64 * b.f64;
+      if (pI->saturation_mode()) {
+        if (d.f64 < 0)
+          d.f64 = 0;
+        else if (d.f64 > 1.0f)
+          d.f64 = 1.0;
+      }
+      fesetround(orig_rm);
+      break;
+    }
+    default:
+      assert(0);
+      break;
+  }
+
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-void neg_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t src1_data, src2_data, data;
+void neg_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, src2_data, data;
 
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
 
-   unsigned to_type = pI->get_type();
-   src1_data = thread->get_operand_value(src1, dst, to_type, thread, 1);
+  unsigned to_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, to_type, thread, 1);
 
+  switch (to_type) {
+    case S8_TYPE:
+    case S16_TYPE:
+    case S32_TYPE:
+    case S64_TYPE:
+      data.s64 = 0 - src1_data.s64;
+      break;  // seems buggy, but not (just ignore higher bits)
+    case U8_TYPE:
+    case U16_TYPE:
+    case U32_TYPE:
+    case U64_TYPE:
+      assert(0);
+      break;
+    case F16_TYPE:
+      data.f16 = 0.0f - src1_data.f16;
+      break;  // assert(0); break;
+    case F32_TYPE:
+      data.f32 = 0.0f - src1_data.f32;
+      break;
+    case F64_TYPE:
+    case FF64_TYPE:
+      data.f64 = 0.0f - src1_data.f64;
+      break;
+    default:
+      assert(0);
+      break;
+  }
 
-   switch ( to_type ) {
-   case S8_TYPE:
-   case S16_TYPE:
-   case S32_TYPE:
-   case S64_TYPE: 
-      data.s64 = 0 - src1_data.s64; break; // seems buggy, but not (just ignore higher bits)
-   case U8_TYPE:
-   case U16_TYPE:
-   case U32_TYPE:
-   case U64_TYPE: 
-      assert(0); break;
-   case F16_TYPE: data.f16 =0.0f  - src1_data.f16; break;//assert(0); break;
-   case F32_TYPE: data.f32 = 0.0f - src1_data.f32; break;
-   case F64_TYPE: case FF64_TYPE: data.f64 = 0.0f - src1_data.f64; break;
-   default: assert(0); break;
-   }
-
-   thread->set_operand_value(dst,data, to_type, thread, pI);
+  thread->set_operand_value(dst, data, to_type, thread, pI);
 }
 
-//nandn bitwise negates second operand then bitwise nands with the first operand
-void nandn_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   ptx_reg_t src1_data, src2_data, data;
+// nandn bitwise negates second operand then bitwise nands with the first
+// operand
+void nandn_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, src2_data, data;
 
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   unsigned i_type = pI->get_type();
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
+  // the way ptxplus handles predicates: 1 = false and 0 = true
+  if (i_type == PRED_TYPE)
+    data.pred = (~src1_data.pred & src2_data.pred);
+  else
+    data.u64 = ~(src1_data.u64 & ~src2_data.u64);
 
-   //the way ptxplus handles predicates: 1 = false and 0 = true
-   if(i_type == PRED_TYPE)
-      data.pred = (~src1_data.pred & src2_data.pred);
-   else
-      data.u64 = ~(src1_data.u64 & ~src2_data.u64);
-
-   thread->set_operand_value(dst,data, i_type, thread, pI);
-
+  thread->set_operand_value(dst, data, i_type, thread, pI);
 }
 
-//norn bitwise negates first operand then bitwise ands with the second operand
-void norn_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   ptx_reg_t src1_data, src2_data, data;
+// norn bitwise negates first operand then bitwise ands with the second operand
+void norn_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, src2_data, data;
 
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   unsigned i_type = pI->get_type();
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
+  // the way ptxplus handles predicates: 1 = false and 0 = true
+  if (i_type == PRED_TYPE)
+    data.pred = ~(src1_data.pred & ~(src2_data.pred));
+  else
+    data.u64 = ~(src1_data.u64) & src2_data.u64;
 
-   //the way ptxplus handles predicates: 1 = false and 0 = true
-   if(i_type == PRED_TYPE)
-      data.pred = ~(src1_data.pred & ~(src2_data.pred));
-   else
-      data.u64 = ~(src1_data.u64) & src2_data.u64;
-
-   thread->set_operand_value(dst,data, i_type, thread, pI);
-
+  thread->set_operand_value(dst, data, i_type, thread, pI);
 }
 
-void not_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   ptx_reg_t a, b, d;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
+void not_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, b, d;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
 
-   unsigned i_type = pI->get_type();
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
 
-
-   switch ( i_type ) {
-   case PRED_TYPE: d.pred = (~(a.pred) & 0x000F); break;
-   case B16_TYPE:  d.u16  = ~a.u16; break;
-   case B32_TYPE:  d.u32  = ~a.u32; break;
-   case B64_TYPE:  d.u64  = ~a.u64; break;
-   default:
+  switch (i_type) {
+    case PRED_TYPE:
+      d.pred = (~(a.pred) & 0x000F);
+      break;
+    case B16_TYPE:
+      d.u16 = ~a.u16;
+      break;
+    case B32_TYPE:
+      d.u32 = ~a.u32;
+      break;
+    case B64_TYPE:
+      d.u64 = ~a.u64;
+      break;
+    default:
       printf("Execution error: type mismatch with instruction\n");
-      assert(0); 
+      assert(0);
       break;
-   }
+  }
 
-   thread->set_operand_value(dst,d, i_type, thread, pI);
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-void or_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t src1_data, src2_data, data;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+void or_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, src2_data, data;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   unsigned i_type = pI->get_type();
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-   //the way ptxplus handles predicates: 1 = false and 0 = true
-   if(i_type == PRED_TYPE)
-      data.pred = ~(~(src1_data.pred) | ~(src2_data.pred));
-   else
-      data.u64 = src1_data.u64 | src2_data.u64;
+  // the way ptxplus handles predicates: 1 = false and 0 = true
+  if (i_type == PRED_TYPE)
+    data.pred = ~(~(src1_data.pred) | ~(src2_data.pred));
+  else
+    data.u64 = src1_data.u64 | src2_data.u64;
 
-   thread->set_operand_value(dst,data, i_type, thread, pI);
+  thread->set_operand_value(dst, data, i_type, thread, pI);
 }
 
-void orn_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t src1_data, src2_data, data;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+void orn_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, src2_data, data;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   unsigned i_type = pI->get_type();
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-   //the way ptxplus handles predicates: 1 = false and 0 = true
-   if(i_type == PRED_TYPE)
-      data.pred = ~(~(src1_data.pred) | (src2_data.pred));
-   else
-      data.u64 = src1_data.u64 | ~src2_data.u64;
+  // the way ptxplus handles predicates: 1 = false and 0 = true
+  if (i_type == PRED_TYPE)
+    data.pred = ~(~(src1_data.pred) | (src2_data.pred));
+  else
+    data.u64 = src1_data.u64 | ~src2_data.u64;
 
-   thread->set_operand_value(dst,data, i_type, thread, pI);
+  thread->set_operand_value(dst, data, i_type, thread, pI);
 }
 
-void pmevent_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void popc_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t src_data, data;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src = pI->src1();
+void pmevent_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void popc_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src_data, data;
+  const operand_info &dst = pI->dst();
+  const operand_info &src = pI->src1();
 
-   unsigned i_type = pI->get_type();
-   src_data = thread->get_operand_value(src, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  src_data = thread->get_operand_value(src, dst, i_type, thread, 1);
 
-   switch ( i_type ) {
-   case B32_TYPE: {
-      std::bitset<32> mask(src_data.u32); 
-      data.u32 = mask.count(); 
-      } break;
-   case B64_TYPE: {
-      std::bitset<64> mask(src_data.u64); 
+  switch (i_type) {
+    case B32_TYPE: {
+      std::bitset<32> mask(src_data.u32);
       data.u32 = mask.count();
-      } break;
-   default:
+    } break;
+    case B64_TYPE: {
+      std::bitset<64> mask(src_data.u64);
+      data.u32 = mask.count();
+    } break;
+    default:
       printf("Execution error: type mismatch with instruction\n");
-      assert(0); 
+      assert(0);
       break;
-   }
+  }
 
-   thread->set_operand_value(dst,data, i_type, thread, pI);
+  thread->set_operand_value(dst, data, i_type, thread, pI);
 }
-void prefetch_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void prefetchu_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-
-int prmt_mode_present(int mode)
-{
-	int returnval=0;
-	switch(mode){
-		case PRMT_F4E_MODE:
-		case PRMT_B4E_MODE:
-		case PRMT_RC8_MODE:
-		case PRMT_RC16_MODE:
-		case PRMT_ECL_MODE:
-		case PRMT_ECR_MODE:	
-			returnval=1;
-			break;
-		default:	
-			break;
-	}
-	return returnval;
+void prefetch_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
 }
-int read_byte(int mode, int control, int d_sel_index, signed long long value){
-
-	int returnval = 0;
-	int prmt_f4e_mode[4][4]={{0,1,2,3},{1,2,3,4},{2,3,4,5},{3,4,5,6}};
-	int prmt_b4e_mode[4][4]={{0,7,6,5},{1,0,7,6},{2,1,0,7},{3,2,1,0}};
-	int prmt_rc8_mode[4][4]={{0,0,0,0},{1,1,1,1},{2,2,2,2},{3,3,3,3}};
-	int prmt_ecl_mode[4][4]={{0,1,2,3},{1,1,2,3},{2,2,2,3},{3,3,3,3}};
-	int prmt_ecr_mode[4][4]={{0,0,0,0},{0,1,1,1},{0,1,2,2},{0,1,2,3}};
-	int prmt_rc16_mode[4][4]={{0,1,0,1},{2,3,2,3},{0,1,0,1},{2,3,2,3}};
-
-	if(!prmt_mode_present(mode)){
-		if(control&0x8){
-			returnval=0xff;
-		}
-		else{
-			returnval= (value>>(8*control)) & 0xff;
-		}
-	}
-	else{
-		switch(mode){
-			case PRMT_F4E_MODE:	returnval=prmt_f4e_mode[control][d_sel_index];break;
-			case PRMT_B4E_MODE:	returnval=prmt_b4e_mode[control][d_sel_index];break;
-			case PRMT_RC8_MODE:	returnval=prmt_rc8_mode[control][d_sel_index];break;
-			case PRMT_ECL_MODE:	returnval=prmt_ecl_mode[control][d_sel_index];break;
-			case PRMT_ECR_MODE:	returnval=prmt_ecr_mode[control][d_sel_index];break;
-			case PRMT_RC16_MODE: returnval=prmt_rc16_mode[control][d_sel_index];break;
-            // Change the default from printing "ERROR" to just asserting
-			default: assert(false);
-		}
-	}	
-	return (returnval << 8 * d_sel_index);
+void prefetchu_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
 }
 
-void prmt_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { 
-   
-   ptx_reg_t src1_data, src2_data, src3_data,tmpdata,data;
-   const operand_info &dst  = pI->dst();  
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
-   const operand_info &src3 = pI->src3();
+int prmt_mode_present(int mode) {
+  int returnval = 0;
+  switch (mode) {
+    case PRMT_F4E_MODE:
+    case PRMT_B4E_MODE:
+    case PRMT_RC8_MODE:
+    case PRMT_RC16_MODE:
+    case PRMT_ECL_MODE:
+    case PRMT_ECR_MODE:
+      returnval = 1;
+      break;
+    default:
+      break;
+  }
+  return returnval;
+}
+int read_byte(int mode, int control, int d_sel_index, signed long long value) {
+  int returnval = 0;
+  int prmt_f4e_mode[4][4] = {
+      {0, 1, 2, 3}, {1, 2, 3, 4}, {2, 3, 4, 5}, {3, 4, 5, 6}};
+  int prmt_b4e_mode[4][4] = {
+      {0, 7, 6, 5}, {1, 0, 7, 6}, {2, 1, 0, 7}, {3, 2, 1, 0}};
+  int prmt_rc8_mode[4][4] = {
+      {0, 0, 0, 0}, {1, 1, 1, 1}, {2, 2, 2, 2}, {3, 3, 3, 3}};
+  int prmt_ecl_mode[4][4] = {
+      {0, 1, 2, 3}, {1, 1, 2, 3}, {2, 2, 2, 3}, {3, 3, 3, 3}};
+  int prmt_ecr_mode[4][4] = {
+      {0, 0, 0, 0}, {0, 1, 1, 1}, {0, 1, 2, 2}, {0, 1, 2, 3}};
+  int prmt_rc16_mode[4][4] = {
+      {0, 1, 0, 1}, {2, 3, 2, 3}, {0, 1, 0, 1}, {2, 3, 2, 3}};
 
-   unsigned mode   = pI->prmt_op();
-   unsigned i_type = pI->get_type();
-
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
-   src3_data = thread->get_operand_value(src3, dst, i_type, thread, 1);
-
-   tmpdata.s64=src1_data.s32|(src2_data.s64<<32);
-   int ctl[4];
-
-   if(!prmt_mode_present(mode)){
-	ctl[0]=(src3_data.s32>>0)&0xf;
-	ctl[1]=(src3_data.s32>>4)&0xf;
-	ctl[2]=(src3_data.s32>>8)&0xf;
-	ctl[3]=(src3_data.s32>>12)&0xf;
-   }
-   else{
-	ctl[0]=ctl[1]=ctl[2]=ctl[3]=(src3_data.s32>>0)&0x3;	
-   }
-   
-   data.s32=0;
-   data.s32=data.s32|read_byte(mode,ctl[0],0,tmpdata.s64);   //First byte-0
-   data.s32=data.s32|read_byte(mode,ctl[1],1,tmpdata.s64);   //Second byte-1
-   data.s32=data.s32|read_byte(mode,ctl[2],2,tmpdata.s64);   //Third byte-2
-   data.s32=data.s32|read_byte(mode,ctl[3],3,tmpdata.s64);   //Fourth byte-3
-	
-   thread->set_operand_value(dst,data, i_type, thread, pI);
-
-
+  if (!prmt_mode_present(mode)) {
+    if (control & 0x8) {
+      returnval = 0xff;
+    } else {
+      returnval = (value >> (8 * control)) & 0xff;
+    }
+  } else {
+    switch (mode) {
+      case PRMT_F4E_MODE:
+        returnval = prmt_f4e_mode[control][d_sel_index];
+        break;
+      case PRMT_B4E_MODE:
+        returnval = prmt_b4e_mode[control][d_sel_index];
+        break;
+      case PRMT_RC8_MODE:
+        returnval = prmt_rc8_mode[control][d_sel_index];
+        break;
+      case PRMT_ECL_MODE:
+        returnval = prmt_ecl_mode[control][d_sel_index];
+        break;
+      case PRMT_ECR_MODE:
+        returnval = prmt_ecr_mode[control][d_sel_index];
+        break;
+      case PRMT_RC16_MODE:
+        returnval = prmt_rc16_mode[control][d_sel_index];
+        break;
+      // Change the default from printing "ERROR" to just asserting
+      default:
+        assert(false);
+    }
+  }
+  return (returnval << 8 * d_sel_index);
 }
 
-void rcp_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t src1_data, src2_data, data;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
+void prmt_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, src2_data, src3_data, tmpdata, data;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
+  const operand_info &src3 = pI->src3();
 
-   unsigned i_type = pI->get_type();
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  unsigned mode = pI->prmt_op();
+  unsigned i_type = pI->get_type();
 
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  src3_data = thread->get_operand_value(src3, dst, i_type, thread, 1);
 
-   switch ( i_type ) {
-   case F32_TYPE: 
+  tmpdata.s64 = src1_data.s32 | (src2_data.s64 << 32);
+  int ctl[4];
+
+  if (!prmt_mode_present(mode)) {
+    ctl[0] = (src3_data.s32 >> 0) & 0xf;
+    ctl[1] = (src3_data.s32 >> 4) & 0xf;
+    ctl[2] = (src3_data.s32 >> 8) & 0xf;
+    ctl[3] = (src3_data.s32 >> 12) & 0xf;
+  } else {
+    ctl[0] = ctl[1] = ctl[2] = ctl[3] = (src3_data.s32 >> 0) & 0x3;
+  }
+
+  data.s32 = 0;
+  data.s32 = data.s32 | read_byte(mode, ctl[0], 0, tmpdata.s64);  // First
+                                                                  // byte-0
+  data.s32 =
+      data.s32 | read_byte(mode, ctl[1], 1, tmpdata.s64);  // Second byte-1
+  data.s32 = data.s32 | read_byte(mode, ctl[2], 2, tmpdata.s64);  // Third
+                                                                  // byte-2
+  data.s32 =
+      data.s32 | read_byte(mode, ctl[3], 3, tmpdata.s64);  // Fourth byte-3
+
+  thread->set_operand_value(dst, data, i_type, thread, pI);
+}
+
+void rcp_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, src2_data, data;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+
+  unsigned i_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+
+  switch (i_type) {
+    case F32_TYPE:
       data.f32 = 1.0f / src1_data.f32;
       break;
-   case F64_TYPE:
-   case FF64_TYPE:
+    case F64_TYPE:
+    case FF64_TYPE:
       data.f64 = 1.0f / src1_data.f64;
       break;
-   default:
+    default:
       printf("Execution error: type mismatch with instruction\n");
-      assert(0); 
+      assert(0);
       break;
-   }
+  }
 
-   thread->set_operand_value(dst,data, i_type, thread, pI);
+  thread->set_operand_value(dst, data, i_type, thread, pI);
 }
 
-void red_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
+void red_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
 
-void rem_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t src1_data, src2_data, data;
+void rem_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, src2_data, data;
 
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   unsigned i_type = pI->get_type();
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-   switch ( i_type ) {
-   case S32_TYPE:
+  switch (i_type) {
+    case S32_TYPE:
       data.s32 = src1_data.s32 % src2_data.s32;
       break;
-   case S64_TYPE:
+    case S64_TYPE:
       data.s64 = src1_data.s64 % src2_data.s64;
       break;
-   case U32_TYPE:
+    case U32_TYPE:
       data.u32 = src1_data.u32 % src2_data.u32;
       break;
-   case U64_TYPE:
+    case U64_TYPE:
       data.u64 = src1_data.u64 % src2_data.u64;
       break;
-   default: assert(0); break;
-   }
-
-   thread->set_operand_value(dst,data, i_type, thread, pI);
-}
-
-void ret_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   bool empty = thread->callstack_pop();
-   if( empty ) {
-   thread->set_done();
-   thread->exitCore();
-   thread->registerExit();
-   }
-}
-
-//Ptxplus version of ret instruction.
-void retp_impl( const ptx_instruction *pI, ptx_thread_info *thread )
-{
-   bool empty = thread->callstack_pop_plus();
-   if( empty ) {
-   thread->set_done();
-   thread->exitCore();
-   thread->registerExit();
-   }
-}
-
-void rsqrt_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t a, d;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-
-   unsigned i_type = pI->get_type();
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-
-
-   switch ( i_type ) {
-   case F32_TYPE:
-      if ( a.f32 < 0 ) {
-         d.u64 = 0;
-         d.u64 = 0x7fc00000; // NaN
-      } else if ( a.f32 == 0 ) {
-         d.u64 = 0;
-         d.u32 = 0x7f800000; // Inf
-      } else
-         d.f32 = cuda_math::__internal_accurate_fdividef(1.0f, sqrtf(a.f32));
+    default:
+      assert(0);
       break;
-   case F64_TYPE: 
-   case FF64_TYPE:
-      if ( a.f32 < 0 ) {
-         d.u64 = 0;
-	      d.u32 = 0x7fc00000; // NaN
-         float x = d.f32; 
-         d.f64 = (double)x;
-      } else if ( a.f32 == 0 ) {
-         d.u64 = 0;
-	      d.u32 = 0x7f800000; // Inf
-         float x = d.f32; 
-         d.f64 = (double)x;
+  }
+
+  thread->set_operand_value(dst, data, i_type, thread, pI);
+}
+
+void ret_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  bool empty = thread->callstack_pop();
+  if (empty) {
+    thread->set_done();
+    thread->exitCore();
+    thread->registerExit();
+  }
+}
+
+// Ptxplus version of ret instruction.
+void retp_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  bool empty = thread->callstack_pop_plus();
+  if (empty) {
+    thread->set_done();
+    thread->exitCore();
+    thread->registerExit();
+  }
+}
+
+void rsqrt_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, d;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+
+  unsigned i_type = pI->get_type();
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+
+  switch (i_type) {
+    case F32_TYPE:
+      if (a.f32 < 0) {
+        d.u64 = 0;
+        d.u64 = 0x7fc00000;  // NaN
+      } else if (a.f32 == 0) {
+        d.u64 = 0;
+        d.u32 = 0x7f800000;  // Inf
       } else
-         d.f64 = 1.0 / sqrt(a.f64); 
+        d.f32 = cuda_math::__internal_accurate_fdividef(1.0f, sqrtf(a.f32));
       break;
-   default:
+    case F64_TYPE:
+    case FF64_TYPE:
+      if (a.f32 < 0) {
+        d.u64 = 0;
+        d.u32 = 0x7fc00000;  // NaN
+        float x = d.f32;
+        d.f64 = (double)x;
+      } else if (a.f32 == 0) {
+        d.u64 = 0;
+        d.u32 = 0x7f800000;  // Inf
+        float x = d.f32;
+        d.f64 = (double)x;
+      } else
+        d.f64 = 1.0 / sqrt(a.f64);
+      break;
+    default:
       printf("Execution error: type mismatch with instruction\n");
       assert(0);
       break;
-   }
+  }
 
-   thread->set_operand_value(dst,d, i_type, thread, pI);
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-#define SAD(d,a,b,c) d = c + ((a<b) ? (b-a) : (a-b))
+#define SAD(d, a, b, c) d = c + ((a < b) ? (b - a) : (a - b))
 
-void sad_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t a, b, c, d;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
-   const operand_info &src3 = pI->src3();
+void sad_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, b, c, d;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
+  const operand_info &src3 = pI->src3();
 
-   unsigned i_type = pI->get_type();
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   b = thread->get_operand_value(src2, dst, i_type, thread, 1);
-   c = thread->get_operand_value(src3, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  c = thread->get_operand_value(src3, dst, i_type, thread, 1);
 
-
-   switch ( i_type ) {
-   case U16_TYPE: SAD(d.u16,a.u16,b.u16,c.u16); break;
-   case U32_TYPE: SAD(d.u32,a.u32,b.u32,c.u32); break;
-   case U64_TYPE: SAD(d.u64,a.u64,b.u64,c.u64); break;
-   case S16_TYPE: SAD(d.s16,a.s16,b.s16,c.s16); break;
-   case S32_TYPE: SAD(d.s32,a.s32,b.s32,c.s32); break;
-   case S64_TYPE: SAD(d.s64,a.s64,b.s64,c.s64); break;
-   case F32_TYPE: SAD(d.f32,a.f32,b.f32,c.f32); break;
-   case F64_TYPE: case FF64_TYPE: SAD(d.f64,a.f64,b.f64,c.f64); break;
-   default:
-      printf("Execution error: type mismatch with instruction\n");
-      assert(0); 
+  switch (i_type) {
+    case U16_TYPE:
+      SAD(d.u16, a.u16, b.u16, c.u16);
       break;
-   }
+    case U32_TYPE:
+      SAD(d.u32, a.u32, b.u32, c.u32);
+      break;
+    case U64_TYPE:
+      SAD(d.u64, a.u64, b.u64, c.u64);
+      break;
+    case S16_TYPE:
+      SAD(d.s16, a.s16, b.s16, c.s16);
+      break;
+    case S32_TYPE:
+      SAD(d.s32, a.s32, b.s32, c.s32);
+      break;
+    case S64_TYPE:
+      SAD(d.s64, a.s64, b.s64, c.s64);
+      break;
+    case F32_TYPE:
+      SAD(d.f32, a.f32, b.f32, c.f32);
+      break;
+    case F64_TYPE:
+    case FF64_TYPE:
+      SAD(d.f64, a.f64, b.f64, c.f64);
+      break;
+    default:
+      printf("Execution error: type mismatch with instruction\n");
+      assert(0);
+      break;
+  }
 
-   thread->set_operand_value(dst,d, i_type, thread, pI);
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-void selp_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
-   const operand_info &src3 = pI->src3();
+void selp_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
+  const operand_info &src3 = pI->src3();
 
-   ptx_reg_t a, b, c, d;
+  ptx_reg_t a, b, c, d;
 
-   unsigned i_type = pI->get_type();
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   b = thread->get_operand_value(src2, dst, i_type, thread, 1);
-   c = thread->get_operand_value(src3, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  c = thread->get_operand_value(src3, dst, i_type, thread, 1);
 
-   //predicate value was changed so the lowest bit being set means the zero flag is set.
-   //As a result, the value of c.pred must be inverted to get proper behavior
-   d = (!(c.pred & 0x0001))?a:b;
+  // predicate value was changed so the lowest bit being set means the zero flag
+  // is set.
+  // As a result, the value of c.pred must be inverted to get proper behavior
+  d = (!(c.pred & 0x0001)) ? a : b;
 
-   thread->set_operand_value(dst,d, PRED_TYPE, thread, pI);
+  thread->set_operand_value(dst, d, PRED_TYPE, thread, pI);
 }
 
-bool isFloat(int type) 
-{
-   switch ( type ) {
-   case F16_TYPE:
-   case F32_TYPE:
-   case F64_TYPE:
-   case FF64_TYPE:
+bool isFloat(int type) {
+  switch (type) {
+    case F16_TYPE:
+    case F32_TYPE:
+    case F64_TYPE:
+    case FF64_TYPE:
       return true;
-   default:
+    default:
       return false;
-   }
+  }
 }
 
-bool CmpOp( int type, ptx_reg_t a, ptx_reg_t b, unsigned cmpop )
-{
-   bool t = false;
+bool CmpOp(int type, ptx_reg_t a, ptx_reg_t b, unsigned cmpop) {
+  bool t = false;
 
-   switch ( type ) {
-   case B16_TYPE: 
+  switch (type) {
+    case B16_TYPE:
       switch (cmpop) {
-      case EQ_OPTION: t = (a.u16 == b.u16); break;
-      case NE_OPTION: t = (a.u16 != b.u16); break;
-      default:
-         assert(0);
+        case EQ_OPTION:
+          t = (a.u16 == b.u16);
+          break;
+        case NE_OPTION:
+          t = (a.u16 != b.u16);
+          break;
+        default:
+          assert(0);
       }
 
-   case B32_TYPE: 
+    case B32_TYPE:
       switch (cmpop) {
-      case EQ_OPTION: t = (a.u32 == b.u32); break;
-      case NE_OPTION: t = (a.u32 != b.u32); break;
-      default:
-         assert(0);
+        case EQ_OPTION:
+          t = (a.u32 == b.u32);
+          break;
+        case NE_OPTION:
+          t = (a.u32 != b.u32);
+          break;
+        default:
+          assert(0);
       }
-   case B64_TYPE:
+    case B64_TYPE:
       switch (cmpop) {
-      case EQ_OPTION: t = (a.u64 == b.u64); break;
-      case NE_OPTION: t = (a.u64 != b.u64); break;
-      default:
-         assert(0);
-      }
-      break;
-   case S8_TYPE: 
-   case S16_TYPE:
-      switch (cmpop) {
-      case EQ_OPTION: t = (a.s16 == b.s16); break;
-      case NE_OPTION: t = (a.s16 != b.s16); break;
-      case LT_OPTION: t = (a.s16 < b.s16); break;
-      case LE_OPTION: t = (a.s16 <= b.s16); break;
-      case GT_OPTION: t = (a.s16 > b.s16); break;
-      case GE_OPTION: t = (a.s16 >= b.s16); break;
-      default:
-         assert(0);
+        case EQ_OPTION:
+          t = (a.u64 == b.u64);
+          break;
+        case NE_OPTION:
+          t = (a.u64 != b.u64);
+          break;
+        default:
+          assert(0);
       }
       break;
-   case S32_TYPE: 
+    case S8_TYPE:
+    case S16_TYPE:
       switch (cmpop) {
-      case EQ_OPTION: t = (a.s32 == b.s32); break;
-      case NE_OPTION: t = (a.s32 != b.s32); break;
-      case LT_OPTION: t = (a.s32 < b.s32); break;
-      case LE_OPTION: t = (a.s32 <= b.s32); break;
-      case GT_OPTION: t = (a.s32 > b.s32); break;
-      case GE_OPTION: t = (a.s32 >= b.s32); break;
-      default:
-         assert(0);
+        case EQ_OPTION:
+          t = (a.s16 == b.s16);
+          break;
+        case NE_OPTION:
+          t = (a.s16 != b.s16);
+          break;
+        case LT_OPTION:
+          t = (a.s16 < b.s16);
+          break;
+        case LE_OPTION:
+          t = (a.s16 <= b.s16);
+          break;
+        case GT_OPTION:
+          t = (a.s16 > b.s16);
+          break;
+        case GE_OPTION:
+          t = (a.s16 >= b.s16);
+          break;
+        default:
+          assert(0);
       }
       break;
-   case S64_TYPE:
+    case S32_TYPE:
       switch (cmpop) {
-      case EQ_OPTION: t = (a.s64 == b.s64); break;
-      case NE_OPTION: t = (a.s64 != b.s64); break;
-      case LT_OPTION: t = (a.s64 < b.s64); break;
-      case LE_OPTION: t = (a.s64 <= b.s64); break;
-      case GT_OPTION: t = (a.s64 > b.s64); break;
-      case GE_OPTION: t = (a.s64 >= b.s64); break;
-      default:
-         assert(0);
+        case EQ_OPTION:
+          t = (a.s32 == b.s32);
+          break;
+        case NE_OPTION:
+          t = (a.s32 != b.s32);
+          break;
+        case LT_OPTION:
+          t = (a.s32 < b.s32);
+          break;
+        case LE_OPTION:
+          t = (a.s32 <= b.s32);
+          break;
+        case GT_OPTION:
+          t = (a.s32 > b.s32);
+          break;
+        case GE_OPTION:
+          t = (a.s32 >= b.s32);
+          break;
+        default:
+          assert(0);
       }
       break;
-   case U8_TYPE: 
-   case U16_TYPE: 
+    case S64_TYPE:
       switch (cmpop) {
-      case EQ_OPTION: t = (a.u16 == b.u16); break;
-      case NE_OPTION: t = (a.u16 != b.u16); break;
-      case LT_OPTION: t = (a.u16 < b.u16); break;
-      case LE_OPTION: t = (a.u16 <= b.u16); break;
-      case GT_OPTION: t = (a.u16 > b.u16); break;
-      case GE_OPTION: t = (a.u16 >= b.u16); break;
-      case LO_OPTION: t = (a.u16 < b.u16); break;
-      case LS_OPTION: t = (a.u16 <= b.u16); break;
-      case HI_OPTION: t = (a.u16 > b.u16); break;
-      case HS_OPTION: t = (a.u16 >= b.u16); break;
-      default:
-         assert(0);
+        case EQ_OPTION:
+          t = (a.s64 == b.s64);
+          break;
+        case NE_OPTION:
+          t = (a.s64 != b.s64);
+          break;
+        case LT_OPTION:
+          t = (a.s64 < b.s64);
+          break;
+        case LE_OPTION:
+          t = (a.s64 <= b.s64);
+          break;
+        case GT_OPTION:
+          t = (a.s64 > b.s64);
+          break;
+        case GE_OPTION:
+          t = (a.s64 >= b.s64);
+          break;
+        default:
+          assert(0);
       }
       break;
-   case U32_TYPE: 
+    case U8_TYPE:
+    case U16_TYPE:
       switch (cmpop) {
-      case EQ_OPTION: t = (a.u32 == b.u32); break;
-      case NE_OPTION: t = (a.u32 != b.u32); break;
-      case LT_OPTION: t = (a.u32 < b.u32); break;
-      case LE_OPTION: t = (a.u32 <= b.u32); break;
-      case GT_OPTION: t = (a.u32 > b.u32); break;
-      case GE_OPTION: t = (a.u32 >= b.u32); break;
-      case LO_OPTION: t = (a.u32 < b.u32); break;
-      case LS_OPTION: t = (a.u32 <= b.u32); break;
-      case HI_OPTION: t = (a.u32 > b.u32); break;
-      case HS_OPTION: t = (a.u32 >= b.u32); break;
-      default:
-         assert(0);
+        case EQ_OPTION:
+          t = (a.u16 == b.u16);
+          break;
+        case NE_OPTION:
+          t = (a.u16 != b.u16);
+          break;
+        case LT_OPTION:
+          t = (a.u16 < b.u16);
+          break;
+        case LE_OPTION:
+          t = (a.u16 <= b.u16);
+          break;
+        case GT_OPTION:
+          t = (a.u16 > b.u16);
+          break;
+        case GE_OPTION:
+          t = (a.u16 >= b.u16);
+          break;
+        case LO_OPTION:
+          t = (a.u16 < b.u16);
+          break;
+        case LS_OPTION:
+          t = (a.u16 <= b.u16);
+          break;
+        case HI_OPTION:
+          t = (a.u16 > b.u16);
+          break;
+        case HS_OPTION:
+          t = (a.u16 >= b.u16);
+          break;
+        default:
+          assert(0);
       }
       break;
-   case U64_TYPE:
+    case U32_TYPE:
       switch (cmpop) {
-      case EQ_OPTION: t = (a.u64 == b.u64); break;
-      case NE_OPTION: t = (a.u64 != b.u64); break;
-      case LT_OPTION: t = (a.u64 < b.u64); break;
-      case LE_OPTION: t = (a.u64 <= b.u64); break;
-      case GT_OPTION: t = (a.u64 > b.u64); break;
-      case GE_OPTION: t = (a.u64 >= b.u64); break;
-      case LO_OPTION: t = (a.u64 < b.u64); break;
-      case LS_OPTION: t = (a.u64 <= b.u64); break;
-      case HI_OPTION: t = (a.u64 > b.u64); break;
-      case HS_OPTION: t = (a.u64 >= b.u64); break;
-      default:
-         assert(0);
+        case EQ_OPTION:
+          t = (a.u32 == b.u32);
+          break;
+        case NE_OPTION:
+          t = (a.u32 != b.u32);
+          break;
+        case LT_OPTION:
+          t = (a.u32 < b.u32);
+          break;
+        case LE_OPTION:
+          t = (a.u32 <= b.u32);
+          break;
+        case GT_OPTION:
+          t = (a.u32 > b.u32);
+          break;
+        case GE_OPTION:
+          t = (a.u32 >= b.u32);
+          break;
+        case LO_OPTION:
+          t = (a.u32 < b.u32);
+          break;
+        case LS_OPTION:
+          t = (a.u32 <= b.u32);
+          break;
+        case HI_OPTION:
+          t = (a.u32 > b.u32);
+          break;
+        case HS_OPTION:
+          t = (a.u32 >= b.u32);
+          break;
+        default:
+          assert(0);
       }
       break;
-   case F16_TYPE: assert(0); break;
-   case F32_TYPE: 
+    case U64_TYPE:
       switch (cmpop) {
-      case EQ_OPTION: t = (a.f32 == b.f32) && !isNaN(a.f32) && !isNaN(b.f32); break;
-      case NE_OPTION: t = (a.f32 != b.f32) && !isNaN(a.f32) && !isNaN(b.f32); break;
-      case LT_OPTION: t = (a.f32 < b.f32 ) && !isNaN(a.f32) && !isNaN(b.f32); break;
-      case LE_OPTION: t = (a.f32 <= b.f32) && !isNaN(a.f32) && !isNaN(b.f32); break;
-      case GT_OPTION: t = (a.f32 > b.f32 ) && !isNaN(a.f32) && !isNaN(b.f32); break;
-      case GE_OPTION: t = (a.f32 >= b.f32) && !isNaN(a.f32) && !isNaN(b.f32); break;
-      case EQU_OPTION: t = (a.f32 == b.f32) || isNaN(a.f32) || isNaN(b.f32); break;
-      case NEU_OPTION: t = (a.f32 != b.f32) || isNaN(a.f32) || isNaN(b.f32); break;
-      case LTU_OPTION: t = (a.f32 < b.f32 ) || isNaN(a.f32) || isNaN(b.f32); break;
-      case LEU_OPTION: t = (a.f32 <= b.f32) || isNaN(a.f32) || isNaN(b.f32); break;
-      case GTU_OPTION: t = (a.f32 > b.f32 ) || isNaN(a.f32) || isNaN(b.f32); break;
-      case GEU_OPTION: t = (a.f32 >= b.f32) || isNaN(a.f32) || isNaN(b.f32); break;
-      case NUM_OPTION: t = !isNaN(a.f32) && !isNaN(b.f32); break;
-      case NAN_OPTION: t = isNaN(a.f32) || isNaN(b.f32); break;
-      default:
-         assert(0);
+        case EQ_OPTION:
+          t = (a.u64 == b.u64);
+          break;
+        case NE_OPTION:
+          t = (a.u64 != b.u64);
+          break;
+        case LT_OPTION:
+          t = (a.u64 < b.u64);
+          break;
+        case LE_OPTION:
+          t = (a.u64 <= b.u64);
+          break;
+        case GT_OPTION:
+          t = (a.u64 > b.u64);
+          break;
+        case GE_OPTION:
+          t = (a.u64 >= b.u64);
+          break;
+        case LO_OPTION:
+          t = (a.u64 < b.u64);
+          break;
+        case LS_OPTION:
+          t = (a.u64 <= b.u64);
+          break;
+        case HI_OPTION:
+          t = (a.u64 > b.u64);
+          break;
+        case HS_OPTION:
+          t = (a.u64 >= b.u64);
+          break;
+        default:
+          assert(0);
       }
       break;
-   case F64_TYPE: 
-   case FF64_TYPE:
+    case F16_TYPE:
+      assert(0);
+      break;
+    case F32_TYPE:
       switch (cmpop) {
-      case EQ_OPTION: t = (a.f64 == b.f64) && !isNaN(a.f64) && !isNaN(b.f64); break;
-      case NE_OPTION: t = (a.f64 != b.f64) && !isNaN(a.f64) && !isNaN(b.f64); break;
-      case LT_OPTION: t = (a.f64 < b.f64 ) && !isNaN(a.f64) && !isNaN(b.f64); break;
-      case LE_OPTION: t = (a.f64 <= b.f64) && !isNaN(a.f64) && !isNaN(b.f64); break;
-      case GT_OPTION: t = (a.f64 > b.f64 ) && !isNaN(a.f64) && !isNaN(b.f64); break;
-      case GE_OPTION: t = (a.f64 >= b.f64) && !isNaN(a.f64) && !isNaN(b.f64); break;
-      case EQU_OPTION: t = (a.f64 == b.f64) || isNaN(a.f64) || isNaN(b.f64); break;
-      case NEU_OPTION: t = (a.f64 != b.f64) || isNaN(a.f64) || isNaN(b.f64); break;
-      case LTU_OPTION: t = (a.f64 < b.f64 ) || isNaN(a.f64) || isNaN(b.f64); break;
-      case LEU_OPTION: t = (a.f64 <= b.f64) || isNaN(a.f64) || isNaN(b.f64); break;
-      case GTU_OPTION: t = (a.f64 > b.f64 ) || isNaN(a.f64) || isNaN(b.f64); break;
-      case GEU_OPTION: t = (a.f64 >= b.f64) || isNaN(a.f64) || isNaN(b.f64); break;
-      case NUM_OPTION: t = !isNaN(a.f64) && !isNaN(b.f64); break;
-      case NAN_OPTION: t = isNaN(a.f64) || isNaN(b.f64); break;
-      default:
-         assert(0);
+        case EQ_OPTION:
+          t = (a.f32 == b.f32) && !isNaN(a.f32) && !isNaN(b.f32);
+          break;
+        case NE_OPTION:
+          t = (a.f32 != b.f32) && !isNaN(a.f32) && !isNaN(b.f32);
+          break;
+        case LT_OPTION:
+          t = (a.f32 < b.f32) && !isNaN(a.f32) && !isNaN(b.f32);
+          break;
+        case LE_OPTION:
+          t = (a.f32 <= b.f32) && !isNaN(a.f32) && !isNaN(b.f32);
+          break;
+        case GT_OPTION:
+          t = (a.f32 > b.f32) && !isNaN(a.f32) && !isNaN(b.f32);
+          break;
+        case GE_OPTION:
+          t = (a.f32 >= b.f32) && !isNaN(a.f32) && !isNaN(b.f32);
+          break;
+        case EQU_OPTION:
+          t = (a.f32 == b.f32) || isNaN(a.f32) || isNaN(b.f32);
+          break;
+        case NEU_OPTION:
+          t = (a.f32 != b.f32) || isNaN(a.f32) || isNaN(b.f32);
+          break;
+        case LTU_OPTION:
+          t = (a.f32 < b.f32) || isNaN(a.f32) || isNaN(b.f32);
+          break;
+        case LEU_OPTION:
+          t = (a.f32 <= b.f32) || isNaN(a.f32) || isNaN(b.f32);
+          break;
+        case GTU_OPTION:
+          t = (a.f32 > b.f32) || isNaN(a.f32) || isNaN(b.f32);
+          break;
+        case GEU_OPTION:
+          t = (a.f32 >= b.f32) || isNaN(a.f32) || isNaN(b.f32);
+          break;
+        case NUM_OPTION:
+          t = !isNaN(a.f32) && !isNaN(b.f32);
+          break;
+        case NAN_OPTION:
+          t = isNaN(a.f32) || isNaN(b.f32);
+          break;
+        default:
+          assert(0);
       }
       break;
-   default: assert(0); break;
-   }
+    case F64_TYPE:
+    case FF64_TYPE:
+      switch (cmpop) {
+        case EQ_OPTION:
+          t = (a.f64 == b.f64) && !isNaN(a.f64) && !isNaN(b.f64);
+          break;
+        case NE_OPTION:
+          t = (a.f64 != b.f64) && !isNaN(a.f64) && !isNaN(b.f64);
+          break;
+        case LT_OPTION:
+          t = (a.f64 < b.f64) && !isNaN(a.f64) && !isNaN(b.f64);
+          break;
+        case LE_OPTION:
+          t = (a.f64 <= b.f64) && !isNaN(a.f64) && !isNaN(b.f64);
+          break;
+        case GT_OPTION:
+          t = (a.f64 > b.f64) && !isNaN(a.f64) && !isNaN(b.f64);
+          break;
+        case GE_OPTION:
+          t = (a.f64 >= b.f64) && !isNaN(a.f64) && !isNaN(b.f64);
+          break;
+        case EQU_OPTION:
+          t = (a.f64 == b.f64) || isNaN(a.f64) || isNaN(b.f64);
+          break;
+        case NEU_OPTION:
+          t = (a.f64 != b.f64) || isNaN(a.f64) || isNaN(b.f64);
+          break;
+        case LTU_OPTION:
+          t = (a.f64 < b.f64) || isNaN(a.f64) || isNaN(b.f64);
+          break;
+        case LEU_OPTION:
+          t = (a.f64 <= b.f64) || isNaN(a.f64) || isNaN(b.f64);
+          break;
+        case GTU_OPTION:
+          t = (a.f64 > b.f64) || isNaN(a.f64) || isNaN(b.f64);
+          break;
+        case GEU_OPTION:
+          t = (a.f64 >= b.f64) || isNaN(a.f64) || isNaN(b.f64);
+          break;
+        case NUM_OPTION:
+          t = !isNaN(a.f64) && !isNaN(b.f64);
+          break;
+        case NAN_OPTION:
+          t = isNaN(a.f64) || isNaN(b.f64);
+          break;
+        default:
+          assert(0);
+      }
+      break;
+    default:
+      assert(0);
+      break;
+  }
 
-   return t;
+  return t;
 }
 
-void setp_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   ptx_reg_t a, b;
+void setp_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, b;
 
-   int t=0;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+  int t = 0;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   assert( pI->get_num_operands() < 4 ); // or need to deal with "c" operand / boolOp
+  assert(pI->get_num_operands() <
+         4);  // or need to deal with "c" operand / boolOp
 
-   unsigned type = pI->get_type();
-   unsigned cmpop = pI->get_cmpop();
-   a = thread->get_operand_value(src1, dst, type, thread, 1);
-   b = thread->get_operand_value(src2, dst, type, thread, 1);
+  unsigned type = pI->get_type();
+  unsigned cmpop = pI->get_cmpop();
+  a = thread->get_operand_value(src1, dst, type, thread, 1);
+  b = thread->get_operand_value(src2, dst, type, thread, 1);
 
-   t = CmpOp(type,a,b,cmpop);
+  t = CmpOp(type, a, b, cmpop);
 
-   ptx_reg_t data;
+  ptx_reg_t data;
 
-   //the way ptxplus handles the zero flag, 1 = false and 0 = true
-   data.pred = (t==0); //inverting predicate since ptxplus uses "1" for a set zero flag
+  // the way ptxplus handles the zero flag, 1 = false and 0 = true
+  data.pred =
+      (t ==
+       0);  // inverting predicate since ptxplus uses "1" for a set zero flag
 
-   thread->set_operand_value(dst,data, PRED_TYPE, thread, pI);
+  thread->set_operand_value(dst, data, PRED_TYPE, thread, pI);
 }
 
-void set_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t a, b;
+void set_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, b;
 
-   int t=0;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+  int t = 0;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   assert( pI->get_num_operands() < 4 ); // or need to deal with "c" operand / boolOp
+  assert(pI->get_num_operands() <
+         4);  // or need to deal with "c" operand / boolOp
 
-   unsigned src_type = pI->get_type2();
-   unsigned cmpop = pI->get_cmpop();
+  unsigned src_type = pI->get_type2();
+  unsigned cmpop = pI->get_cmpop();
 
-   a = thread->get_operand_value(src1, dst, src_type, thread, 1);
-   b = thread->get_operand_value(src2, dst, src_type, thread, 1);
+  a = thread->get_operand_value(src1, dst, src_type, thread, 1);
+  b = thread->get_operand_value(src2, dst, src_type, thread, 1);
 
-   // Take abs of first operand if needed
-   if(pI->is_abs()) {
-      switch ( src_type ) {
-      case S16_TYPE: a.s16 = my_abs(a.s16); break;
-      case S32_TYPE: a.s32 = my_abs(a.s32); break;
-      case S64_TYPE: a.s64 = my_abs(a.s64); break;
-      case U16_TYPE: a.u16 = a.u16; break;
-      case U32_TYPE: a.u32 = my_abs(a.u32); break;
-      case U64_TYPE: a.u64 = my_abs(a.u64); break;
-      case F32_TYPE: a.f32 = my_abs(a.f32); break;
-      case F64_TYPE: case FF64_TYPE: a.f64 = my_abs(a.f64); break;
+  // Take abs of first operand if needed
+  if (pI->is_abs()) {
+    switch (src_type) {
+      case S16_TYPE:
+        a.s16 = my_abs(a.s16);
+        break;
+      case S32_TYPE:
+        a.s32 = my_abs(a.s32);
+        break;
+      case S64_TYPE:
+        a.s64 = my_abs(a.s64);
+        break;
+      case U16_TYPE:
+        a.u16 = a.u16;
+        break;
+      case U32_TYPE:
+        a.u32 = my_abs(a.u32);
+        break;
+      case U64_TYPE:
+        a.u64 = my_abs(a.u64);
+        break;
+      case F32_TYPE:
+        a.f32 = my_abs(a.f32);
+        break;
+      case F64_TYPE:
+      case FF64_TYPE:
+        a.f64 = my_abs(a.f64);
+        break;
       default:
-         printf("Execution error: type mismatch with instruction\n");
-         assert(0);
-         break;
-      }
-   }
+        printf("Execution error: type mismatch with instruction\n");
+        assert(0);
+        break;
+    }
+  }
 
-   t = CmpOp(src_type,a,b,cmpop);
+  t = CmpOp(src_type, a, b, cmpop);
 
-   ptx_reg_t data;
-   if ( isFloat(pI->get_type()) ) {
-      data.f32 = (t!=0)?1.0f:0.0f;
-   } else {
-      data.u32 = (t!=0)?0xFFFFFFFF:0;
-   }
+  ptx_reg_t data;
+  if (isFloat(pI->get_type())) {
+    data.f32 = (t != 0) ? 1.0f : 0.0f;
+  } else {
+    data.u32 = (t != 0) ? 0xFFFFFFFF : 0;
+  }
 
-   thread->set_operand_value(dst, data, pI->get_type(), thread, pI);
-
+  thread->set_operand_value(dst, data, pI->get_type(), thread, pI);
 }
 
-void shfl_impl( const ptx_instruction *pI, core_t *core, warp_inst_t inst )
-{
-	unsigned i_type = pI->get_type();
-  	int tid;
+void shfl_impl(const ptx_instruction *pI, core_t *core, warp_inst_t inst) {
+  unsigned i_type = pI->get_type();
+  int tid;
 
-  	if(core->get_gpu()->is_functional_sim())
-    		tid = inst.warp_id_func() * core->get_warp_size();
-  	else
-	 	tid = inst.warp_id() * core->get_warp_size();
-	
-	ptx_thread_info *thread = core->get_thread_info()[tid];
-	ptx_warp_info *warp_info = thread->m_warp_info;
-	int lane = warp_info->get_done_threads();
-	thread = core->get_thread_info()[tid + lane];
+  if (core->get_gpu()->is_functional_sim())
+    tid = inst.warp_id_func() * core->get_warp_size();
+  else
+    tid = inst.warp_id() * core->get_warp_size();
 
-	const operand_info &dst = pI->dst();
-	const operand_info &src1 = pI->src1();
-	const operand_info &src2 = pI->src2();
-	const operand_info &src3 = pI->src3();
-	int bval = (thread->get_operand_value(src2, dst, i_type, thread, 1)).u32;
-	int cval = (thread->get_operand_value(src3, dst, i_type, thread, 1)).u32;
-	int mask = cval >> 8;
-	bval &= 0x1F;
-	cval &= 0x1F;
+  ptx_thread_info *thread = core->get_thread_info()[tid];
+  ptx_warp_info *warp_info = thread->m_warp_info;
+  int lane = warp_info->get_done_threads();
+  thread = core->get_thread_info()[tid + lane];
 
-	int maxLane = (lane & mask) | (cval & ~mask);
-	int minLane = lane & mask;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
+  const operand_info &src3 = pI->src3();
+  int bval = (thread->get_operand_value(src2, dst, i_type, thread, 1)).u32;
+  int cval = (thread->get_operand_value(src3, dst, i_type, thread, 1)).u32;
+  int mask = cval >> 8;
+  bval &= 0x1F;
+  cval &= 0x1F;
 
-	int src_idx;
-	unsigned p;
-	switch(pI->shfl_op()) {
-	case UP_OPTION:
-		src_idx = lane - bval;
-		p = (src_idx >= maxLane);
-		break;
-	case DOWN_OPTION:
-		src_idx = lane + bval;
-		p = (src_idx <= maxLane);
-		break;
-	case BFLY_OPTION:
-		src_idx = lane ^ bval;
-		p = (src_idx <= maxLane);
-		break;
-	case IDX_OPTION:
-		src_idx = minLane | (bval & ~mask);
-		p = (src_idx <= maxLane);
-		break;
-	default:
-		printf("GPGPU-Sim PTX: ERROR: Invalid shfl option\n");
-		assert(0);
-		break;
-	}
-	// copy from own lane
-	if (!p) src_idx = lane;
+  int maxLane = (lane & mask) | (cval & ~mask);
+  int minLane = lane & mask;
 
-	// copy input from lane src_idx
-	ptx_reg_t data;
-	if (inst.active(src_idx)) {
-		ptx_thread_info *source = core->get_thread_info()[tid + src_idx];
-		data = source->get_operand_value(src1, dst, i_type, source, 1);
-	} else {
-		printf("GPGPU-Sim PTX: WARNING: shfl input value unpredictable for inactive threads in a warp\n");
-		data.u32 = 0;
-	}
-	thread->set_operand_value(dst, data, i_type, thread, pI);
+  int src_idx;
+  unsigned p;
+  switch (pI->shfl_op()) {
+    case UP_OPTION:
+      src_idx = lane - bval;
+      p = (src_idx >= maxLane);
+      break;
+    case DOWN_OPTION:
+      src_idx = lane + bval;
+      p = (src_idx <= maxLane);
+      break;
+    case BFLY_OPTION:
+      src_idx = lane ^ bval;
+      p = (src_idx <= maxLane);
+      break;
+    case IDX_OPTION:
+      src_idx = minLane | (bval & ~mask);
+      p = (src_idx <= maxLane);
+      break;
+    default:
+      printf("GPGPU-Sim PTX: ERROR: Invalid shfl option\n");
+      assert(0);
+      break;
+  }
+  // copy from own lane
+  if (!p) src_idx = lane;
 
-	/*
-	TODO: deal with predicates appropriately using the following pseudocode:
-	if (!isGuardPredicateTrue(src_idx)) {
-		printf("GPGPU-Sim PTX: WARNING: shfl input value unpredictable for predicated-off threads in a warp\n");
-	}
-	if (dest predicate selected) data.pred = p;
-	*/
+  // copy input from lane src_idx
+  ptx_reg_t data;
+  if (inst.active(src_idx)) {
+    ptx_thread_info *source = core->get_thread_info()[tid + src_idx];
+    data = source->get_operand_value(src1, dst, i_type, source, 1);
+  } else {
+    printf(
+        "GPGPU-Sim PTX: WARNING: shfl input value unpredictable for inactive "
+        "threads in a warp\n");
+    data.u32 = 0;
+  }
+  thread->set_operand_value(dst, data, i_type, thread, pI);
 
-	// keep track of the number of threads that have executed in the warp
-	warp_info->inc_done_threads();
-	if (warp_info->get_done_threads() == inst.active_count()) {
-		warp_info->reset_done_threads();
-	}
+  /*
+  TODO: deal with predicates appropriately using the following pseudocode:
+  if (!isGuardPredicateTrue(src_idx)) {
+          printf("GPGPU-Sim PTX: WARNING: shfl input value unpredictable for
+  predicated-off threads in a warp\n");
+  }
+  if (dest predicate selected) data.pred = p;
+  */
+
+  // keep track of the number of threads that have executed in the warp
+  warp_info->inc_done_threads();
+  if (warp_info->get_done_threads() == inst.active_count()) {
+    warp_info->reset_done_threads();
+  }
 }
 
-void shl_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   ptx_reg_t a, b, d;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+void shl_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, b, d;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   unsigned i_type = pI->get_type();
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  b = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-   switch ( i_type ) {
-   case B16_TYPE:
-   case U16_TYPE:
-      if ( b.u16 >= 16 )
-         d.u16 = 0;
+  switch (i_type) {
+    case B16_TYPE:
+    case U16_TYPE:
+      if (b.u16 >= 16)
+        d.u16 = 0;
       else
-         d.u16 = (unsigned short) ((a.u16 << b.u16) & 0xFFFF); 
+        d.u16 = (unsigned short)((a.u16 << b.u16) & 0xFFFF);
       break;
-   case B32_TYPE: 
-   case U32_TYPE: 
-      if ( b.u32 >= 32 )
-         d.u32 = 0;
+    case B32_TYPE:
+    case U32_TYPE:
+      if (b.u32 >= 32)
+        d.u32 = 0;
       else
-         d.u32 = (unsigned) ((a.u32 << b.u32) & 0xFFFFFFFF); 
+        d.u32 = (unsigned)((a.u32 << b.u32) & 0xFFFFFFFF);
       break;
-   case B64_TYPE: 
-   case U64_TYPE: 
-      if ( b.u32 >= 64 )
-         d.u64 = 0;
+    case B64_TYPE:
+    case U64_TYPE:
+      if (b.u32 >= 64)
+        d.u64 = 0;
       else
-         d.u64 = (a.u64 << b.u64); 
+        d.u64 = (a.u64 << b.u64);
       break;
-   default:
+    default:
       printf("Execution error: type mismatch with instruction\n");
-      assert(0); 
+      assert(0);
       break;
-   }
+  }
 
-   thread->set_operand_value(dst, d, i_type, thread, pI);
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-void shr_impl( const ptx_instruction *pI, ptx_thread_info *thread )
-{
-   ptx_reg_t a, b, d;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+void shr_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, b, d;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   unsigned i_type = pI->get_type();
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  b = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-
-   switch ( i_type ) {
-   case U16_TYPE:
-   case B16_TYPE: 
-      if ( b.u16 < 16 )
-         d.u16 = (unsigned short) ((a.u16 >> b.u16) & 0xFFFF);
+  switch (i_type) {
+    case U16_TYPE:
+    case B16_TYPE:
+      if (b.u16 < 16)
+        d.u16 = (unsigned short)((a.u16 >> b.u16) & 0xFFFF);
       else
-         d.u16 = 0;
+        d.u16 = 0;
       break;
-   case U32_TYPE:
-   case B32_TYPE: 
-      if ( b.u32 < 32 )
-         d.u32 = (unsigned) ((a.u32 >> b.u32) & 0xFFFFFFFF);
+    case U32_TYPE:
+    case B32_TYPE:
+      if (b.u32 < 32)
+        d.u32 = (unsigned)((a.u32 >> b.u32) & 0xFFFFFFFF);
       else
-         d.u32 = 0;
+        d.u32 = 0;
       break;
-   case U64_TYPE:
-   case B64_TYPE: 
-      if ( b.u32 < 64 )
-         d.u64 = (a.u64 >> b.u64);
+    case U64_TYPE:
+    case B64_TYPE:
+      if (b.u32 < 64)
+        d.u64 = (a.u64 >> b.u64);
       else
-         d.u64 = 0;
+        d.u64 = 0;
       break;
-   case S16_TYPE: 
-      if ( b.u16 < 16 )
-         d.s64 = (a.s16 >> b.s16);
+    case S16_TYPE:
+      if (b.u16 < 16)
+        d.s64 = (a.s16 >> b.s16);
       else {
-         if ( a.s16 < 0 ) {
+        if (a.s16 < 0) {
+          d.s64 = -1;
+        } else {
+          d.s64 = 0;
+        }
+      }
+      break;
+    case S32_TYPE:
+      if (b.u32 < 32)
+        d.s64 = (a.s32 >> b.s32);
+      else {
+        if (a.s32 < 0) {
+          d.s64 = -1;
+        } else {
+          d.s64 = 0;
+        }
+      }
+      break;
+    case S64_TYPE:
+      if (b.u64 < 64)
+        d.s64 = (a.s64 >> b.u64);
+      else {
+        if (a.s64 < 0) {
+          if (b.s32 < 0) {
+            d.u64 = -1;
+            d.s32 = 0;
+          } else {
             d.s64 = -1;
-         } else {
-            d.s64 = 0;
-         }
+          }
+        } else {
+          d.s64 = 0;
+        }
       }
       break;
-   case S32_TYPE: 
-      if ( b.u32 < 32 )
-         d.s64 = (a.s32 >> b.s32);
-      else {
-         if ( a.s32 < 0 ) {
-            d.s64 = -1;
-         } else {
-            d.s64 = 0;
-         }
-      }
-      break;
-   case S64_TYPE: 
-      if ( b.u64 < 64 )
-         d.s64 = (a.s64 >> b.u64);
-      else {
-         if ( a.s64 < 0 ) {
-            if ( b.s32 < 0 ) {
-               d.u64 = -1;
-               d.s32 = 0;
-            } else {
-               d.s64 = -1;
-            }
-         } else {
-            d.s64 = 0;
-         }
-      }
-      break;
-   default:
+    default:
       printf("Execution error: type mismatch with instruction\n");
-      assert(0); 
+      assert(0);
       break;
-   }
+  }
 
-   thread->set_operand_value(dst,d, i_type, thread, pI);
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-void sin_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   ptx_reg_t a, d;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
+void sin_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, d;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
 
-   unsigned i_type = pI->get_type();
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
 
-
-   switch ( i_type ) {
-   case F32_TYPE: 
+  switch (i_type) {
+    case F32_TYPE:
       d.f32 = sin(a.f32);
       break;
-   default:
-      printf("Execution error: type mismatch with instruction\n");
-      assert(0); 
-      break;
-   }
-
-   thread->set_operand_value(dst,d, i_type, thread, pI);
-}
-
-void slct_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
-   const operand_info &src3 = pI->src3();
-
-   ptx_reg_t a, b, c, d;
-
-   unsigned i_type = pI->get_type();
-   unsigned c_type = pI->get_type2();
-   bool t = false;
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   b = thread->get_operand_value(src2, dst, i_type, thread, 1);
-   c = thread->get_operand_value(src3, dst, c_type, thread, 1);
-
-   switch ( c_type ) {
-   case S32_TYPE: t = c.s32 >= 0; break;
-   case F32_TYPE: t = c.f32 >= 0; break;
-   default: assert(0);
-   }
-
-   switch ( i_type ) {
-   case B16_TYPE:
-   case S16_TYPE:
-   case U16_TYPE: d.u16 = t?a.u16:b.u16; break;
-   case F32_TYPE:
-   case B32_TYPE:
-   case S32_TYPE:
-   case U32_TYPE: d.u32 = t?a.u32:b.u32; break;
-   case F64_TYPE:
-   case FF64_TYPE:
-   case B64_TYPE:
-   case S64_TYPE:
-   case U64_TYPE: d.u64 = t?a.u64:b.u64; break;
-   default: assert(0);
-   }
-
-   thread->set_operand_value(dst,d, i_type, thread, pI);
-}
-
-void sqrt_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t a, d;
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-
-   unsigned i_type = pI->get_type();
-   a = thread->get_operand_value(src1, dst, i_type, thread, 1);
-
-
-   switch ( i_type ) {
-   case F32_TYPE: 
-      if ( a.f32 < 0 )
-         d.f32 = nanf("");
-      else
-         d.f32 = sqrt(a.f32); break;
-   case F64_TYPE: 
-   case FF64_TYPE:
-      if ( a.f64 < 0 )
-         d.f64 = nan("");
-      else
-         d.f64 = sqrt(a.f64); break;
-   default:
+    default:
       printf("Execution error: type mismatch with instruction\n");
       assert(0);
       break;
-   }
+  }
 
-   thread->set_operand_value(dst,d, i_type, thread, pI);
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-void sst_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-	ptx_instruction * cpI = const_cast<ptx_instruction *>(pI); // constant
-	const operand_info &dst = cpI->dst();
-	const operand_info &src1 = pI->src1();
-	const operand_info &src2 = pI->src2();
-	const operand_info &src3 = pI->src3();
-	unsigned type = pI->get_type();
-	ptx_reg_t dst_data = thread->get_operand_value(dst, dst, type, thread, 1);
-	ptx_reg_t src1_data = thread->get_operand_value(src1, src1, type, thread, 1);
-	ptx_reg_t src2_data = thread->get_operand_value(src2, src1, type, thread, 1);
-	ptx_reg_t src3_data = thread->get_operand_value(src3, src1, type, thread, 1);
-	memory_space_t space = pI->get_space();
-	memory_space *mem = NULL;
-	addr_t addr = src2_data.u32 * 4; // this assumes sstarr memory starts at address 0
-	ptx_cta_info *cta_info = thread->m_cta_info;
+void slct_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
+  const operand_info &src3 = pI->src3();
 
-	decode_space(space,thread,src1,mem,addr);
+  ptx_reg_t a, b, c, d;
 
-	size_t size;
-	int t;
-	type_info_key::type_decode(type,size,t);
+  unsigned i_type = pI->get_type();
+  unsigned c_type = pI->get_type2();
+  bool t = false;
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  b = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  c = thread->get_operand_value(src3, dst, c_type, thread, 1);
 
-	// store data in sstarr memory
-	mem->write(addr,size/8,&src3_data.s64,thread,pI);
+  switch (c_type) {
+    case S32_TYPE:
+      t = c.s32 >= 0;
+      break;
+    case F32_TYPE:
+      t = c.f32 >= 0;
+      break;
+    default:
+      assert(0);
+  }
 
-	// sync threads
-	cpI->set_bar_id(16); // use 16 for sst because bar uses an int from 0-15
+  switch (i_type) {
+    case B16_TYPE:
+    case S16_TYPE:
+    case U16_TYPE:
+      d.u16 = t ? a.u16 : b.u16;
+      break;
+    case F32_TYPE:
+    case B32_TYPE:
+    case S32_TYPE:
+    case U32_TYPE:
+      d.u32 = t ? a.u32 : b.u32;
+      break;
+    case F64_TYPE:
+    case FF64_TYPE:
+    case B64_TYPE:
+    case S64_TYPE:
+    case U64_TYPE:
+      d.u64 = t ? a.u64 : b.u64;
+      break;
+    default:
+      assert(0);
+  }
 
-	thread->m_last_effective_address = addr;
-	thread->m_last_memory_space = space;
-	thread->m_last_dram_callback.function = bar_callback;
-	thread->m_last_dram_callback.instruction = cpI;
-
-	// the last thread that executes loads all of the data back from sstarr memory
-	int NUM_THREADS = cta_info->num_threads();
-	cta_info->inc_bar_threads();
-	if (NUM_THREADS == cta_info->get_bar_threads()) {
-		unsigned offset = 0;
-		addr = 0;
-		ptx_reg_t data;
-		float sstarr_fdata[NUM_THREADS];
-		signed long long sstarr_ldata[NUM_THREADS];
-		// loop through all of the threads
-		for (int tid = 0; tid < NUM_THREADS; tid++) {
-			data.u64=0;
-			mem->read(addr+(tid*4),size/8,&data.s64);
-			sstarr_fdata[tid] = data.f32;
-			sstarr_ldata[tid] = data.s64;
-		}
-
-		// squeeze the zeros out of the array and store data back into original array
-		mem = NULL;
-		addr = src1_data.u32;
-		space.set_type(global_space);
-		decode_space(space,thread,src1,mem,addr);
-		// store nonzero entries and indices
-		for (int tid = 0; tid < NUM_THREADS; tid++) {
-			if (sstarr_fdata[tid] != 0) {
-				float ftid = (float)tid;
-				mem->write(addr+(offset*4),size/8,&sstarr_ldata[tid],thread,pI);
-				mem->write(addr+((NUM_THREADS+offset)*4),size/8,&ftid,thread,pI);
-				offset++;
-			}
-		}
-		// store the number of nonzero elements in the array
-		data = thread->get_operand_value(src1, dst, type, thread, 1);
-		data.s64 += 4*(offset-1);
-		thread->set_operand_value(dst, data, type, thread, pI);
-
-		// fill the rest of the array with zeros (dst should always have a 0 in it)
-		while (offset < NUM_THREADS) {
-			mem->write(addr+(offset*4),size/8,&dst_data.s64,thread,pI);
-			offset++;
-		}
-
-		cta_info->reset_bar_threads();
-		thread->m_last_effective_address = addr+(NUM_THREADS-1)*4;
-		thread->m_last_memory_space = space;
-	}
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-void ssy_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   //printf("Execution Warning: unimplemented ssy instruction is treated as a nop\n");
-   // TODO: add implementation
+void sqrt_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t a, d;
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+
+  unsigned i_type = pI->get_type();
+  a = thread->get_operand_value(src1, dst, i_type, thread, 1);
+
+  switch (i_type) {
+    case F32_TYPE:
+      if (a.f32 < 0)
+        d.f32 = nanf("");
+      else
+        d.f32 = sqrt(a.f32);
+      break;
+    case F64_TYPE:
+    case FF64_TYPE:
+      if (a.f64 < 0)
+        d.f64 = nan("");
+      else
+        d.f64 = sqrt(a.f64);
+      break;
+    default:
+      printf("Execution error: type mismatch with instruction\n");
+      assert(0);
+      break;
+  }
+
+  thread->set_operand_value(dst, d, i_type, thread, pI);
 }
 
-void st_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   const operand_info &dst = pI->dst();
-   const operand_info &src1 = pI->src1(); //may be scalar or vector of regs
-   unsigned type = pI->get_type();
-   ptx_reg_t addr_reg = thread->get_operand_value(dst, dst, type, thread, 1);
-   ptx_reg_t data;
-   memory_space_t space = pI->get_space();
-   unsigned vector_spec = pI->get_vector();
+void sst_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_instruction *cpI = const_cast<ptx_instruction *>(pI);  // constant
+  const operand_info &dst = cpI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
+  const operand_info &src3 = pI->src3();
+  unsigned type = pI->get_type();
+  ptx_reg_t dst_data = thread->get_operand_value(dst, dst, type, thread, 1);
+  ptx_reg_t src1_data = thread->get_operand_value(src1, src1, type, thread, 1);
+  ptx_reg_t src2_data = thread->get_operand_value(src2, src1, type, thread, 1);
+  ptx_reg_t src3_data = thread->get_operand_value(src3, src1, type, thread, 1);
+  memory_space_t space = pI->get_space();
+  memory_space *mem = NULL;
+  addr_t addr =
+      src2_data.u32 * 4;  // this assumes sstarr memory starts at address 0
+  ptx_cta_info *cta_info = thread->m_cta_info;
 
-   memory_space *mem = NULL;
-   addr_t addr = addr_reg.u32;
+  decode_space(space, thread, src1, mem, addr);
 
-   decode_space(space,thread,dst,mem,addr);
+  size_t size;
+  int t;
+  type_info_key::type_decode(type, size, t);
 
-   size_t size;
-   int t;
-   type_info_key::type_decode(type,size,t);
+  // store data in sstarr memory
+  mem->write(addr, size / 8, &src3_data.s64, thread, pI);
 
-   if (!vector_spec) {
-      data = thread->get_operand_value(src1, dst, type, thread, 1);
-      mem->write(addr,size/8,&data.s64,thread,pI);
-    } else {
-      if (vector_spec == V2_TYPE) {
-         ptx_reg_t* ptx_regs = new ptx_reg_t[2]; 
-         thread->get_vector_operand_values(src1, ptx_regs, 2); 
-         mem->write(addr,size/8,&ptx_regs[0].s64,thread,pI);
-         mem->write(addr+size/8,size/8,&ptx_regs[1].s64,thread,pI);
-         delete [] ptx_regs;
+  // sync threads
+  cpI->set_bar_id(16);  // use 16 for sst because bar uses an int from 0-15
+
+  thread->m_last_effective_address = addr;
+  thread->m_last_memory_space = space;
+  thread->m_last_dram_callback.function = bar_callback;
+  thread->m_last_dram_callback.instruction = cpI;
+
+  // the last thread that executes loads all of the data back from sstarr memory
+  int NUM_THREADS = cta_info->num_threads();
+  cta_info->inc_bar_threads();
+  if (NUM_THREADS == cta_info->get_bar_threads()) {
+    unsigned offset = 0;
+    addr = 0;
+    ptx_reg_t data;
+    float sstarr_fdata[NUM_THREADS];
+    signed long long sstarr_ldata[NUM_THREADS];
+    // loop through all of the threads
+    for (int tid = 0; tid < NUM_THREADS; tid++) {
+      data.u64 = 0;
+      mem->read(addr + (tid * 4), size / 8, &data.s64);
+      sstarr_fdata[tid] = data.f32;
+      sstarr_ldata[tid] = data.s64;
+    }
+
+    // squeeze the zeros out of the array and store data back into original
+    // array
+    mem = NULL;
+    addr = src1_data.u32;
+    space.set_type(global_space);
+    decode_space(space, thread, src1, mem, addr);
+    // store nonzero entries and indices
+    for (int tid = 0; tid < NUM_THREADS; tid++) {
+      if (sstarr_fdata[tid] != 0) {
+        float ftid = (float)tid;
+        mem->write(addr + (offset * 4), size / 8, &sstarr_ldata[tid], thread,
+                   pI);
+        mem->write(addr + ((NUM_THREADS + offset) * 4), size / 8, &ftid, thread,
+                   pI);
+        offset++;
       }
-      if (vector_spec == V3_TYPE) {
-         ptx_reg_t* ptx_regs = new ptx_reg_t[3]; 
-         thread->get_vector_operand_values(src1, ptx_regs, 3); 
-         mem->write(addr,size/8,&ptx_regs[0].s64,thread,pI);
-         mem->write(addr+size/8,size/8,&ptx_regs[1].s64,thread,pI);
-         mem->write(addr+2*size/8,size/8,&ptx_regs[2].s64,thread,pI);
-         delete [] ptx_regs;
-      }
-      if (vector_spec == V4_TYPE) {
-         ptx_reg_t* ptx_regs = new ptx_reg_t[4]; 
-         thread->get_vector_operand_values(src1, ptx_regs, 4); 
-         mem->write(addr,size/8,&ptx_regs[0].s64,thread,pI);
-         mem->write(addr+size/8,size/8,&ptx_regs[1].s64,thread,pI);
-         mem->write(addr+2*size/8,size/8,&ptx_regs[2].s64,thread,pI);
-         mem->write(addr+3*size/8,size/8,&ptx_regs[3].s64,thread,pI);
-         delete [] ptx_regs;
-      }
-   }
-   thread->m_last_effective_address = addr;
-   thread->m_last_memory_space = space; 
+    }
+    // store the number of nonzero elements in the array
+    data = thread->get_operand_value(src1, dst, type, thread, 1);
+    data.s64 += 4 * (offset - 1);
+    thread->set_operand_value(dst, data, type, thread, pI);
+
+    // fill the rest of the array with zeros (dst should always have a 0 in it)
+    while (offset < NUM_THREADS) {
+      mem->write(addr + (offset * 4), size / 8, &dst_data.s64, thread, pI);
+      offset++;
+    }
+
+    cta_info->reset_bar_threads();
+    thread->m_last_effective_address = addr + (NUM_THREADS - 1) * 4;
+    thread->m_last_memory_space = space;
+  }
 }
 
-void sub_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   ptx_reg_t data;
-   int overflow = 0;
-   int carry = 0;
+void ssy_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  // printf("Execution Warning: unimplemented ssy instruction is treated as a
+  // nop\n");
+  // TODO: add implementation
+}
 
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+void st_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();  // may be scalar or vector of regs
+  unsigned type = pI->get_type();
+  ptx_reg_t addr_reg = thread->get_operand_value(dst, dst, type, thread, 1);
+  ptx_reg_t data;
+  memory_space_t space = pI->get_space();
+  unsigned vector_spec = pI->get_vector();
 
-   unsigned i_type = pI->get_type();
-   ptx_reg_t src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   ptx_reg_t src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  memory_space *mem = NULL;
+  addr_t addr = addr_reg.u32;
 
-   //performs addition. Sets carry and overflow if needed.
-   //the constant is added in during subtraction so the carry bit is set properly.
-   switch ( i_type ) {
-   case S8_TYPE:
+  decode_space(space, thread, dst, mem, addr);
+
+  size_t size;
+  int t;
+  type_info_key::type_decode(type, size, t);
+
+  if (!vector_spec) {
+    data = thread->get_operand_value(src1, dst, type, thread, 1);
+    mem->write(addr, size / 8, &data.s64, thread, pI);
+  } else {
+    if (vector_spec == V2_TYPE) {
+      ptx_reg_t *ptx_regs = new ptx_reg_t[2];
+      thread->get_vector_operand_values(src1, ptx_regs, 2);
+      mem->write(addr, size / 8, &ptx_regs[0].s64, thread, pI);
+      mem->write(addr + size / 8, size / 8, &ptx_regs[1].s64, thread, pI);
+      delete[] ptx_regs;
+    }
+    if (vector_spec == V3_TYPE) {
+      ptx_reg_t *ptx_regs = new ptx_reg_t[3];
+      thread->get_vector_operand_values(src1, ptx_regs, 3);
+      mem->write(addr, size / 8, &ptx_regs[0].s64, thread, pI);
+      mem->write(addr + size / 8, size / 8, &ptx_regs[1].s64, thread, pI);
+      mem->write(addr + 2 * size / 8, size / 8, &ptx_regs[2].s64, thread, pI);
+      delete[] ptx_regs;
+    }
+    if (vector_spec == V4_TYPE) {
+      ptx_reg_t *ptx_regs = new ptx_reg_t[4];
+      thread->get_vector_operand_values(src1, ptx_regs, 4);
+      mem->write(addr, size / 8, &ptx_regs[0].s64, thread, pI);
+      mem->write(addr + size / 8, size / 8, &ptx_regs[1].s64, thread, pI);
+      mem->write(addr + 2 * size / 8, size / 8, &ptx_regs[2].s64, thread, pI);
+      mem->write(addr + 3 * size / 8, size / 8, &ptx_regs[3].s64, thread, pI);
+      delete[] ptx_regs;
+    }
+  }
+  thread->m_last_effective_address = addr;
+  thread->m_last_memory_space = space;
+}
+
+void sub_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t data;
+  int overflow = 0;
+  int carry = 0;
+
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
+
+  unsigned i_type = pI->get_type();
+  ptx_reg_t src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  ptx_reg_t src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+
+  // performs addition. Sets carry and overflow if needed.
+  // the constant is added in during subtraction so the carry bit is set
+  // properly.
+  switch (i_type) {
+    case S8_TYPE:
       data.s64 = (src1_data.s64 & 0xFF) - (src2_data.s64 & 0xFF) + 0x100;
-      if(((src1_data.s64 & 0x80)-(src2_data.s64 & 0x80)) != 0) {overflow=((src1_data.s64 & 0x80)-(data.s64 & 0x80))==0?0:1; }
-      carry = (data.s32 & 0x100)>>8;
+      if (((src1_data.s64 & 0x80) - (src2_data.s64 & 0x80)) != 0) {
+        overflow = ((src1_data.s64 & 0x80) - (data.s64 & 0x80)) == 0 ? 0 : 1;
+      }
+      carry = (data.s32 & 0x100) >> 8;
       break;
-   case S16_TYPE:
+    case S16_TYPE:
       data.s64 = (src1_data.s64 & 0xFFFF) - (src2_data.s64 & 0xFFFF) + 0x10000;
-      if(((src1_data.s64 & 0x8000)-(src2_data.s64 & 0x8000)) != 0) {overflow=((src1_data.s64 & 0x8000)-(data.s64 & 0x8000))==0?0:1; }
-      carry = (data.s32 & 0x10000)>>16;
+      if (((src1_data.s64 & 0x8000) - (src2_data.s64 & 0x8000)) != 0) {
+        overflow =
+            ((src1_data.s64 & 0x8000) - (data.s64 & 0x8000)) == 0 ? 0 : 1;
+      }
+      carry = (data.s32 & 0x10000) >> 16;
       break;
-   case S32_TYPE:
-      data.s64 = (src1_data.s64 & 0xFFFFFFFF) - (src2_data.s64 & 0xFFFFFFFF) + 0x100000000;
-      if(((src1_data.s64 & 0x80000000)-(src2_data.s64 & 0x80000000)) != 0) {overflow=((src1_data.s64 & 0x80000000)-(data.s64 & 0x80000000))==0?0:1; }
-      carry = ((data.u64)>>32) & 0x0001;
+    case S32_TYPE:
+      data.s64 = (src1_data.s64 & 0xFFFFFFFF) - (src2_data.s64 & 0xFFFFFFFF) +
+                 0x100000000;
+      if (((src1_data.s64 & 0x80000000) - (src2_data.s64 & 0x80000000)) != 0) {
+        overflow = ((src1_data.s64 & 0x80000000) - (data.s64 & 0x80000000)) == 0
+                       ? 0
+                       : 1;
+      }
+      carry = ((data.u64) >> 32) & 0x0001;
       break;
-   case S64_TYPE: 
-      data.s64 = src1_data.s64 - src2_data.s64; break;
-   case B8_TYPE:
-   case U8_TYPE:
+    case S64_TYPE:
+      data.s64 = src1_data.s64 - src2_data.s64;
+      break;
+    case B8_TYPE:
+    case U8_TYPE:
       data.u64 = (src1_data.u64 & 0xFF) - (src2_data.u64 & 0xFF) + 0x100;
-      carry = (data.u64 & 0x100)>>8;
+      carry = (data.u64 & 0x100) >> 8;
       break;
-   case B16_TYPE:
-   case U16_TYPE:
+    case B16_TYPE:
+    case U16_TYPE:
       data.u64 = (src1_data.u64 & 0xFFFF) - (src2_data.u64 & 0xFFFF) + 0x10000;
-      carry = (data.u64 & 0x10000)>>16;
+      carry = (data.u64 & 0x10000) >> 16;
       break;
-   case B32_TYPE:
-   case U32_TYPE:
-      data.u64 = (src1_data.u64 & 0xFFFFFFFF) - (src2_data.u64 & 0xFFFFFFFF) + 0x100000000;
-      carry = (data.u64 & 0x100000000)>>32;
+    case B32_TYPE:
+    case U32_TYPE:
+      data.u64 = (src1_data.u64 & 0xFFFFFFFF) - (src2_data.u64 & 0xFFFFFFFF) +
+                 0x100000000;
+      carry = (data.u64 & 0x100000000) >> 32;
       break;
-   case B64_TYPE:
-   case U64_TYPE: 
-      data.u64 = src1_data.u64 - src2_data.u64; break;
-   case F16_TYPE: data.f16 = src1_data.f16 - src2_data.f16; break;//assert(0); break;
-   case F32_TYPE: data.f32 = src1_data.f32 - src2_data.f32; break;
-   case F64_TYPE: case FF64_TYPE: data.f64 = src1_data.f64 - src2_data.f64; break;
-   default: assert(0); break;
-   }
+    case B64_TYPE:
+    case U64_TYPE:
+      data.u64 = src1_data.u64 - src2_data.u64;
+      break;
+    case F16_TYPE:
+      data.f16 = src1_data.f16 - src2_data.f16;
+      break;  // assert(0); break;
+    case F32_TYPE:
+      data.f32 = src1_data.f32 - src2_data.f32;
+      break;
+    case F64_TYPE:
+    case FF64_TYPE:
+      data.f64 = src1_data.f64 - src2_data.f64;
+      break;
+    default:
+      assert(0);
+      break;
+  }
 
-   thread->set_operand_value(dst,data, i_type, thread, pI, overflow, carry);
+  thread->set_operand_value(dst, data, i_type, thread, pI, overflow, carry);
 }
 
-void nop_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   // Do nothing
+void nop_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  // Do nothing
 }
 
-void subc_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void suld_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void sured_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void sust_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void suq_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-
+void subc_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void suld_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void sured_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void sust_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void suq_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
 
 union intfloat {
-   int a;
-   float b;
+  int a;
+  float b;
 };
 
-float reduce_precision( float x, unsigned bits )
-{
-   intfloat tmp;
-   tmp.b = x;
-   int v = tmp.a;
-   int man = v & ((1<<23)-1);
-   int mask =  ((1<<bits)-1) << (23-bits);
-   int nv = (v & ((-1)-((1<<23)-1))) | (mask&man);
-   tmp.a = nv;
-   float result = tmp.b;
-   return result;
+float reduce_precision(float x, unsigned bits) {
+  intfloat tmp;
+  tmp.b = x;
+  int v = tmp.a;
+  int man = v & ((1 << 23) - 1);
+  int mask = ((1 << bits) - 1) << (23 - bits);
+  int nv = (v & ((-1) - ((1 << 23) - 1))) | (mask & man);
+  tmp.a = nv;
+  float result = tmp.b;
+  return result;
 }
 
-unsigned wrap( unsigned x, unsigned y, unsigned mx, unsigned my, size_t elem_size )
-{
-   unsigned nx = (mx+x)%mx;
-   unsigned ny = (my+y)%my;
-   return nx + mx*ny;
+unsigned wrap(unsigned x, unsigned y, unsigned mx, unsigned my,
+              size_t elem_size) {
+  unsigned nx = (mx + x) % mx;
+  unsigned ny = (my + y) % my;
+  return nx + mx * ny;
 }
 
-unsigned clamp( unsigned x, unsigned y, unsigned mx, unsigned my, size_t elem_size )
-{
-   unsigned nx = x;
-   while (nx >= mx) nx -= elem_size;
-   unsigned ny = (y >= my)? my - 1 : y;
-   return nx + mx*ny;
+unsigned clamp(unsigned x, unsigned y, unsigned mx, unsigned my,
+               size_t elem_size) {
+  unsigned nx = x;
+  while (nx >= mx) nx -= elem_size;
+  unsigned ny = (y >= my) ? my - 1 : y;
+  return nx + mx * ny;
 }
 
-typedef unsigned (*texAddr_t) (unsigned x, unsigned y, unsigned mx, unsigned my, size_t elem_size);
-float tex_linf_sampling(memory_space* mem, unsigned tex_array_base, 
-                        int x, int y, unsigned int width, unsigned int height, size_t elem_size,
-                        float alpha, float beta, texAddr_t b_lim)
-{
-   float Tij;
-   float Ti1j;
-   float Tij1;
-   float Ti1j1;
+typedef unsigned (*texAddr_t)(unsigned x, unsigned y, unsigned mx, unsigned my,
+                              size_t elem_size);
+float tex_linf_sampling(memory_space *mem, unsigned tex_array_base, int x,
+                        int y, unsigned int width, unsigned int height,
+                        size_t elem_size, float alpha, float beta,
+                        texAddr_t b_lim) {
+  float Tij;
+  float Ti1j;
+  float Tij1;
+  float Ti1j1;
 
-   mem->read(tex_array_base + b_lim(x,y,width,height,elem_size), 4, &Tij);
-   mem->read(tex_array_base + b_lim(x+elem_size,y,width,height,elem_size), 4, &Ti1j);
-   mem->read(tex_array_base + b_lim(x,y+1,width,height,elem_size), 4, &Tij1);
-   mem->read(tex_array_base + b_lim(x+elem_size,y+1,width,height,elem_size), 4, &Ti1j1);
+  mem->read(tex_array_base + b_lim(x, y, width, height, elem_size), 4, &Tij);
+  mem->read(tex_array_base + b_lim(x + elem_size, y, width, height, elem_size),
+            4, &Ti1j);
+  mem->read(tex_array_base + b_lim(x, y + 1, width, height, elem_size), 4,
+            &Tij1);
+  mem->read(
+      tex_array_base + b_lim(x + elem_size, y + 1, width, height, elem_size), 4,
+      &Ti1j1);
 
-   float sample = (1-alpha)*(1-beta)*Tij + 
-                   alpha*(1-beta)*Ti1j +
-                   (1-alpha)*beta*Tij1 +
-                   alpha*beta*Ti1j1;
-   
-   return sample;
+  float sample = (1 - alpha) * (1 - beta) * Tij + alpha * (1 - beta) * Ti1j +
+                 (1 - alpha) * beta * Tij1 + alpha * beta * Ti1j1;
+
+  return sample;
 }
 
-float textureNormalizeElementSigned(int element, int bits)
-{
-   if (bits) {
-      int maxN = (1 << bits) - 1; 
-      // removing upper bits 
-      element &= maxN;
-      // normalizing the number to [-1.0,1.0]
-      maxN >>= 1;
-      float output = (float) element / maxN;  
-      if (output < -1.0f) output = -1.0f; 
-      return output; 
-   } else {
-      return 0.0f; 
-   }
+float textureNormalizeElementSigned(int element, int bits) {
+  if (bits) {
+    int maxN = (1 << bits) - 1;
+    // removing upper bits
+    element &= maxN;
+    // normalizing the number to [-1.0,1.0]
+    maxN >>= 1;
+    float output = (float)element / maxN;
+    if (output < -1.0f) output = -1.0f;
+    return output;
+  } else {
+    return 0.0f;
+  }
 }
 
-float textureNormalizeElementUnsigned(unsigned int element, int bits)
-{
-   if (bits) {
-      unsigned int maxN = (1 << bits) - 1; 
-      // removing upper bits and normalizing the number to [0.0,1.0]
-      return (float)(element & maxN) / maxN;  
-   } else {
-      return 0.0f; 
-   }
+float textureNormalizeElementUnsigned(unsigned int element, int bits) {
+  if (bits) {
+    unsigned int maxN = (1 << bits) - 1;
+    // removing upper bits and normalizing the number to [0.0,1.0]
+    return (float)(element & maxN) / maxN;
+  } else {
+    return 0.0f;
+  }
 }
 
-void textureNormalizeOutput( const struct cudaChannelFormatDesc& desc, ptx_reg_t& datax, ptx_reg_t& datay, ptx_reg_t& dataz, ptx_reg_t& dataw ) 
-{
-   if (desc.f == cudaChannelFormatKindSigned) {
-      datax.f32 = textureNormalizeElementSigned( datax.s32, desc.x ); 
-      datay.f32 = textureNormalizeElementSigned( datay.s32, desc.y ); 
-      dataz.f32 = textureNormalizeElementSigned( dataz.s32, desc.z ); 
-      dataw.f32 = textureNormalizeElementSigned( dataw.s32, desc.w ); 
-   } else if (desc.f == cudaChannelFormatKindUnsigned) {
-      datax.f32 = textureNormalizeElementUnsigned( datax.u32, desc.x ); 
-      datay.f32 = textureNormalizeElementUnsigned( datay.u32, desc.y ); 
-      dataz.f32 = textureNormalizeElementUnsigned( dataz.u32, desc.z ); 
-      dataw.f32 = textureNormalizeElementUnsigned( dataw.u32, desc.w ); 
-   } else {
-      assert(0 && "Undefined texture read mode: cudaReadModeNormalizedFloat expect integer elements"); 
-   }
+void textureNormalizeOutput(const struct cudaChannelFormatDesc &desc,
+                            ptx_reg_t &datax, ptx_reg_t &datay,
+                            ptx_reg_t &dataz, ptx_reg_t &dataw) {
+  if (desc.f == cudaChannelFormatKindSigned) {
+    datax.f32 = textureNormalizeElementSigned(datax.s32, desc.x);
+    datay.f32 = textureNormalizeElementSigned(datay.s32, desc.y);
+    dataz.f32 = textureNormalizeElementSigned(dataz.s32, desc.z);
+    dataw.f32 = textureNormalizeElementSigned(dataw.s32, desc.w);
+  } else if (desc.f == cudaChannelFormatKindUnsigned) {
+    datax.f32 = textureNormalizeElementUnsigned(datax.u32, desc.x);
+    datay.f32 = textureNormalizeElementUnsigned(datay.u32, desc.y);
+    dataz.f32 = textureNormalizeElementUnsigned(dataz.u32, desc.z);
+    dataw.f32 = textureNormalizeElementUnsigned(dataw.u32, desc.w);
+  } else {
+    assert(0 &&
+           "Undefined texture read mode: cudaReadModeNormalizedFloat expect "
+           "integer elements");
+  }
 }
 
-void tex_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   unsigned dimension = pI->dimension();
-   const operand_info &dst = pI->dst(); //the registers to which fetched texel will be placed
-   const operand_info &src1 = pI->src1(); //the name of the texture
-   const operand_info &src2 = pI->src2(); //the vector registers containing coordinates of the texel to be fetched
+void tex_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  unsigned dimension = pI->dimension();
+  const operand_info &dst =
+      pI->dst();  // the registers to which fetched texel will be placed
+  const operand_info &src1 = pI->src1();  // the name of the texture
+  const operand_info &src2 = pI->src2();  // the vector registers containing
+                                          // coordinates of the texel to be
+                                          // fetched
 
-   std::string texname = src1.name();
-   unsigned to_type = pI->get_type();
-   unsigned c_type = pI->get_type2();
-   fflush(stdout);
-   ptx_reg_t data1, data2, data3, data4;
-   if (!thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs)
-       thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs = new ptx_reg_t[4];
-   unsigned nelem = src2.get_vect_nelem();
-   thread->get_vector_operand_values(src2, thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs, nelem); //ptx_reg should be 4 entry vector type...coordinates into texture
-   /*
-     For programs with many streams, textures can be bound and unbound
-     asynchronously.  This means we need to use the kernel's "snapshot" of
-     the state of the texture mappings when it was launched (so that we
-     don't try to access the incorrect texture mapping if it's been updated,
-     or that we don't access a mapping that has been unbound).
-   */
-   gpgpu_t *gpu = thread->get_gpu();
-   kernel_info_t &k = thread->get_kernel();
-   const struct textureReference* texref = gpu->get_texref(texname);
-   const struct cudaArray* cuArray = k.get_texarray(texname); 
-   const struct textureInfo* texInfo = k.get_texinfo(texname);
-   const struct textureReferenceAttr* texAttr = gpu->get_texattr(texname);
+  std::string texname = src1.name();
+  unsigned to_type = pI->get_type();
+  unsigned c_type = pI->get_type2();
+  fflush(stdout);
+  ptx_reg_t data1, data2, data3, data4;
+  if (!thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs)
+    thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs = new ptx_reg_t[4];
+  unsigned nelem = src2.get_vect_nelem();
+  thread->get_vector_operand_values(
+      src2, thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs,
+      nelem);  // ptx_reg should be 4 entry vector type...coordinates into
+               // texture
+  /*
+    For programs with many streams, textures can be bound and unbound
+    asynchronously.  This means we need to use the kernel's "snapshot" of
+    the state of the texture mappings when it was launched (so that we
+    don't try to access the incorrect texture mapping if it's been updated,
+    or that we don't access a mapping that has been unbound).
+  */
+  gpgpu_t *gpu = thread->get_gpu();
+  kernel_info_t &k = thread->get_kernel();
+  const struct textureReference *texref = gpu->get_texref(texname);
+  const struct cudaArray *cuArray = k.get_texarray(texname);
+  const struct textureInfo *texInfo = k.get_texinfo(texname);
+  const struct textureReferenceAttr *texAttr = gpu->get_texattr(texname);
 
-   //assume always 2D f32 input
-   //access array with src2 coordinates
-   memory_space *mem = thread->get_global_memory();
-   float x_f32,  y_f32;
-   size_t size;
-   int t;
-   unsigned tex_array_base;
-   unsigned int width = 0, height = 0;
-   int x = 0;
-   int y = 0;
-   unsigned tex_array_index;
-   float alpha=0, beta=0;
+  // assume always 2D f32 input
+  // access array with src2 coordinates
+  memory_space *mem = thread->get_global_memory();
+  float x_f32, y_f32;
+  size_t size;
+  int t;
+  unsigned tex_array_base;
+  unsigned int width = 0, height = 0;
+  int x = 0;
+  int y = 0;
+  unsigned tex_array_index;
+  float alpha = 0, beta = 0;
 
-   type_info_key::type_decode(to_type,size,t);
-   tex_array_base = cuArray->devPtr32;
+  type_info_key::type_decode(to_type, size, t);
+  tex_array_base = cuArray->devPtr32;
 
-   switch (dimension) {
-   case GEOM_MODIFIER_1D:
+  switch (dimension) {
+    case GEOM_MODIFIER_1D:
       width = cuArray->width;
       height = cuArray->height;
       if (texref->normalized) {
-         assert(c_type == F32_TYPE); 
-         x_f32 = thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[0].f32;
-         if (texref->addressMode[0] == cudaAddressModeClamp) {
-            x_f32 = (x_f32 > 1.0)? 1.0 : x_f32;
-            x_f32 = (x_f32 < 0.0)? 0.0 : x_f32;
-         } else if (texref->addressMode[0] == cudaAddressModeWrap) {
-            x_f32 = x_f32 - floor(x_f32);
-         }
+        assert(c_type == F32_TYPE);
+        x_f32 = thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[0].f32;
+        if (texref->addressMode[0] == cudaAddressModeClamp) {
+          x_f32 = (x_f32 > 1.0) ? 1.0 : x_f32;
+          x_f32 = (x_f32 < 0.0) ? 0.0 : x_f32;
+        } else if (texref->addressMode[0] == cudaAddressModeWrap) {
+          x_f32 = x_f32 - floor(x_f32);
+        }
 
-         if( texref->filterMode == cudaFilterModeLinear ) {
-            float xb = x_f32 * width - 0.5;
-            alpha = xb - floor(xb);
-            alpha = reduce_precision(alpha,9);
-            beta = 0.0;
+        if (texref->filterMode == cudaFilterModeLinear) {
+          float xb = x_f32 * width - 0.5;
+          alpha = xb - floor(xb);
+          alpha = reduce_precision(alpha, 9);
+          beta = 0.0;
 
-            x = (int)floor(xb);
-            y = 0;
-         } else {
-            x = (int) floor(x_f32 * width);
-            y = 0;
-         }
+          x = (int)floor(xb);
+          y = 0;
+        } else {
+          x = (int)floor(x_f32 * width);
+          y = 0;
+        }
       } else {
-         switch ( c_type ) {
-         case S32_TYPE: 
+        switch (c_type) {
+          case S32_TYPE:
             x = thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[0].s32;
-            assert(texref->filterMode == cudaFilterModePoint); 
-            break; 
-         case F32_TYPE: 
+            assert(texref->filterMode == cudaFilterModePoint);
+            break;
+          case F32_TYPE:
             x_f32 = thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[0].f32;
-            alpha = x_f32 - floor(x_f32); // offset into subtexel (for linear sampling)
-            x = (int) x_f32; 
-            break; 
-         default: assert(0 && "Unsupported texture coordinate type."); 
-         }
-         // handle texture fetch that exceeded boundaries
-         if (texref->addressMode[0] == cudaAddressModeClamp) {
-            x = (x > width - 1)? (width - 1) : x;
-            x = (x < 0)? 0 : x;
-         } else if (texref->addressMode[0] == cudaAddressModeWrap) {
-            x = x % width;
-         }
+            alpha = x_f32 -
+                    floor(x_f32);  // offset into subtexel (for linear sampling)
+            x = (int)x_f32;
+            break;
+          default:
+            assert(0 && "Unsupported texture coordinate type.");
+        }
+        // handle texture fetch that exceeded boundaries
+        if (texref->addressMode[0] == cudaAddressModeClamp) {
+          x = (x > width - 1) ? (width - 1) : x;
+          x = (x < 0) ? 0 : x;
+        } else if (texref->addressMode[0] == cudaAddressModeWrap) {
+          x = x % width;
+        }
       }
-      width *= (cuArray->desc.w+cuArray->desc.x+cuArray->desc.y+cuArray->desc.z)/8;
-      x *= (cuArray->desc.w+cuArray->desc.x+cuArray->desc.y+cuArray->desc.z)/8;
+      width *= (cuArray->desc.w + cuArray->desc.x + cuArray->desc.y +
+                cuArray->desc.z) /
+               8;
+      x *= (cuArray->desc.w + cuArray->desc.x + cuArray->desc.y +
+            cuArray->desc.z) /
+           8;
       tex_array_index = tex_array_base + x;
 
       break;
-   case GEOM_MODIFIER_2D:
+    case GEOM_MODIFIER_2D:
       width = cuArray->width;
       height = cuArray->height;
       if (texref->normalized) {
-         x_f32 = reduce_precision(thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[0].f32,16);
-         y_f32 = reduce_precision(thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[1].f32,15);
+        x_f32 = reduce_precision(
+            thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[0].f32, 16);
+        y_f32 = reduce_precision(
+            thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[1].f32, 15);
 
-         if (texref->addressMode[0]) {//clamp
-            if (x_f32<0) x_f32 = 0;
-            if (x_f32>=1) x_f32 = 1 - 1/x_f32;
-         } else {//wrap
-            x_f32 = x_f32 - floor(x_f32);
-         }
-         if (texref->addressMode[1]) {//clamp
-            if (y_f32<0) y_f32 = 0;
-            if (y_f32>=1) y_f32 = 1 - 1/y_f32;
-         } else {//wrap
-            y_f32 = y_f32 - floor(y_f32);
-         }
+        if (texref->addressMode[0]) {  // clamp
+          if (x_f32 < 0) x_f32 = 0;
+          if (x_f32 >= 1) x_f32 = 1 - 1 / x_f32;
+        } else {  // wrap
+          x_f32 = x_f32 - floor(x_f32);
+        }
+        if (texref->addressMode[1]) {  // clamp
+          if (y_f32 < 0) y_f32 = 0;
+          if (y_f32 >= 1) y_f32 = 1 - 1 / y_f32;
+        } else {  // wrap
+          y_f32 = y_f32 - floor(y_f32);
+        }
 
-         if( texref->filterMode == cudaFilterModeLinear ) {
-            float xb = x_f32 * width - 0.5;
-            float yb = y_f32 * height - 0.5;
-            alpha = xb - floor(xb);
-            beta = yb - floor(yb);
-            alpha = reduce_precision(alpha,9);
-            beta = reduce_precision(beta,9);
+        if (texref->filterMode == cudaFilterModeLinear) {
+          float xb = x_f32 * width - 0.5;
+          float yb = y_f32 * height - 0.5;
+          alpha = xb - floor(xb);
+          beta = yb - floor(yb);
+          alpha = reduce_precision(alpha, 9);
+          beta = reduce_precision(beta, 9);
 
-            x = (int)floor(xb);
-            y = (int)floor(yb);
-         } else {
-            x = (int) floor(x_f32 * width);
-            y = (int) floor(y_f32 * height);
-         }
+          x = (int)floor(xb);
+          y = (int)floor(yb);
+        } else {
+          x = (int)floor(x_f32 * width);
+          y = (int)floor(y_f32 * height);
+        }
       } else {
-         x_f32 = thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[0].f32;
-         y_f32 = thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[1].f32;
+        x_f32 = thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[0].f32;
+        y_f32 = thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs[1].f32;
 
-         alpha = x_f32 - floor(x_f32);
-         beta = y_f32 - floor(y_f32);
+        alpha = x_f32 - floor(x_f32);
+        beta = y_f32 - floor(y_f32);
 
-         x = (int) x_f32;
-         y = (int) y_f32;
-         if (texref->addressMode[0]) {//clamp
-            if (x<0) x = 0;
-            if (x>= (int)width) x = width-1;
-         } else {//wrap
-            x = x % width;
-            if (x < 0) x*= -1;
-         }
-         if (texref->addressMode[1]) {//clamp
-            if (y<0) y = 0;
-            if (y>= (int)height) y = height -1;
-         } else {//wrap
-            y = y % height;
-            if (y < 0) y *= -1;
-         }
+        x = (int)x_f32;
+        y = (int)y_f32;
+        if (texref->addressMode[0]) {  // clamp
+          if (x < 0) x = 0;
+          if (x >= (int)width) x = width - 1;
+        } else {  // wrap
+          x = x % width;
+          if (x < 0) x *= -1;
+        }
+        if (texref->addressMode[1]) {  // clamp
+          if (y < 0) y = 0;
+          if (y >= (int)height) y = height - 1;
+        } else {  // wrap
+          y = y % height;
+          if (y < 0) y *= -1;
+        }
       }
 
-      width *= (cuArray->desc.w+cuArray->desc.x+cuArray->desc.y+cuArray->desc.z)/8;
-      x *= (cuArray->desc.w+cuArray->desc.x+cuArray->desc.y+cuArray->desc.z)/8;
-      tex_array_index = tex_array_base + (x + width*y);
+      width *= (cuArray->desc.w + cuArray->desc.x + cuArray->desc.y +
+                cuArray->desc.z) /
+               8;
+      x *= (cuArray->desc.w + cuArray->desc.x + cuArray->desc.y +
+            cuArray->desc.z) /
+           8;
+      tex_array_index = tex_array_base + (x + width * y);
       break;
-   default:
-      assert(0); break;
-   }
-   switch ( to_type ) {
-   case U8_TYPE:
-   case U16_TYPE:
-   case U32_TYPE: 
-   case B8_TYPE:
-   case B16_TYPE:
-   case B32_TYPE: 
-   case S8_TYPE:
-   case S16_TYPE:
-   case S32_TYPE: {
-      unsigned long long elementOffset = 0; // offset into the next element 
-      mem->read( tex_array_index, cuArray->desc.x/8, &data1.u32);
-      elementOffset += cuArray->desc.x/8;  
+    default:
+      assert(0);
+      break;
+  }
+  switch (to_type) {
+    case U8_TYPE:
+    case U16_TYPE:
+    case U32_TYPE:
+    case B8_TYPE:
+    case B16_TYPE:
+    case B32_TYPE:
+    case S8_TYPE:
+    case S16_TYPE:
+    case S32_TYPE: {
+      unsigned long long elementOffset = 0;  // offset into the next element
+      mem->read(tex_array_index, cuArray->desc.x / 8, &data1.u32);
+      elementOffset += cuArray->desc.x / 8;
       if (cuArray->desc.y) {
-         mem->read( tex_array_index + elementOffset, cuArray->desc.y/8, &data2.u32);
-         elementOffset += cuArray->desc.y/8; 
-         if (cuArray->desc.z) {
-            mem->read( tex_array_index + elementOffset, cuArray->desc.z/8, &data3.u32);
-            elementOffset += cuArray->desc.z/8; 
-            if (cuArray->desc.w) 
-               mem->read( tex_array_index + elementOffset, cuArray->desc.w/8, &data4.u32);
-         }
+        mem->read(tex_array_index + elementOffset, cuArray->desc.y / 8,
+                  &data2.u32);
+        elementOffset += cuArray->desc.y / 8;
+        if (cuArray->desc.z) {
+          mem->read(tex_array_index + elementOffset, cuArray->desc.z / 8,
+                    &data3.u32);
+          elementOffset += cuArray->desc.z / 8;
+          if (cuArray->desc.w)
+            mem->read(tex_array_index + elementOffset, cuArray->desc.w / 8,
+                      &data4.u32);
+        }
       }
       break;
-   }
-   case B64_TYPE:
-   case U64_TYPE:
-   case S64_TYPE:
-      mem->read( tex_array_index, 8, &data1.u64);
+    }
+    case B64_TYPE:
+    case U64_TYPE:
+    case S64_TYPE:
+      mem->read(tex_array_index, 8, &data1.u64);
       if (cuArray->desc.y) {
-         mem->read( tex_array_index+8, 8, &data2.u64);
-         if (cuArray->desc.z) {
-            mem->read( tex_array_index+16, 8, &data3.u64);
-            if (cuArray->desc.w) 
-               mem->read( tex_array_index+24, 8, &data4.u64);
-         }
+        mem->read(tex_array_index + 8, 8, &data2.u64);
+        if (cuArray->desc.z) {
+          mem->read(tex_array_index + 16, 8, &data3.u64);
+          if (cuArray->desc.w) mem->read(tex_array_index + 24, 8, &data4.u64);
+        }
       }
       break;
-   case F16_TYPE: assert(0); break;
-   case F32_TYPE:  {
-      if( texref->filterMode == cudaFilterModeLinear ) {
-         texAddr_t b_lim = wrap;
-         if ( texref->addressMode[0] == cudaAddressModeClamp ) {
-            b_lim = clamp;
-         }
-         size_t elem_size = (cuArray->desc.x + cuArray->desc.y + cuArray->desc.z + cuArray->desc.w) / 8;
-         size_t elem_ofst = 0;
+    case F16_TYPE:
+      assert(0);
+      break;
+    case F32_TYPE: {
+      if (texref->filterMode == cudaFilterModeLinear) {
+        texAddr_t b_lim = wrap;
+        if (texref->addressMode[0] == cudaAddressModeClamp) {
+          b_lim = clamp;
+        }
+        size_t elem_size = (cuArray->desc.x + cuArray->desc.y +
+                            cuArray->desc.z + cuArray->desc.w) /
+                           8;
+        size_t elem_ofst = 0;
 
-         data1.f32 = tex_linf_sampling(mem, tex_array_base, x + elem_ofst, y, width, height, elem_size, alpha, beta, b_lim);
-         elem_ofst += cuArray->desc.x / 8; 
-         if (cuArray->desc.y) {
-            data2.f32 = tex_linf_sampling(mem, tex_array_base, x + elem_ofst, y, width, height, elem_size, alpha, beta, b_lim);
-            elem_ofst += cuArray->desc.y / 8; 
-            if (cuArray->desc.z) {
-               data3.f32 = tex_linf_sampling(mem, tex_array_base, x + elem_ofst, y, width, height, elem_size, alpha, beta, b_lim);
-               elem_ofst += cuArray->desc.z / 8; 
-               if (cuArray->desc.w) 
-                  data4.f32 = tex_linf_sampling(mem, tex_array_base, x + elem_ofst, y, width, height, elem_size, alpha, beta, b_lim);
-            }
-         }
+        data1.f32 =
+            tex_linf_sampling(mem, tex_array_base, x + elem_ofst, y, width,
+                              height, elem_size, alpha, beta, b_lim);
+        elem_ofst += cuArray->desc.x / 8;
+        if (cuArray->desc.y) {
+          data2.f32 =
+              tex_linf_sampling(mem, tex_array_base, x + elem_ofst, y, width,
+                                height, elem_size, alpha, beta, b_lim);
+          elem_ofst += cuArray->desc.y / 8;
+          if (cuArray->desc.z) {
+            data3.f32 =
+                tex_linf_sampling(mem, tex_array_base, x + elem_ofst, y, width,
+                                  height, elem_size, alpha, beta, b_lim);
+            elem_ofst += cuArray->desc.z / 8;
+            if (cuArray->desc.w)
+              data4.f32 = tex_linf_sampling(mem, tex_array_base, x + elem_ofst,
+                                            y, width, height, elem_size, alpha,
+                                            beta, b_lim);
+          }
+        }
       } else {
-         mem->read( tex_array_index, cuArray->desc.x/8, &data1.f32);
-         if (cuArray->desc.y) {
-            mem->read( tex_array_index+4, cuArray->desc.y/8, &data2.f32);
-            if (cuArray->desc.z) {
-               mem->read( tex_array_index+8, cuArray->desc.z/8, &data3.f32);
-               if (cuArray->desc.w) 
-                  mem->read( tex_array_index+12, cuArray->desc.w/8, &data4.f32);
-            }
-         }
+        mem->read(tex_array_index, cuArray->desc.x / 8, &data1.f32);
+        if (cuArray->desc.y) {
+          mem->read(tex_array_index + 4, cuArray->desc.y / 8, &data2.f32);
+          if (cuArray->desc.z) {
+            mem->read(tex_array_index + 8, cuArray->desc.z / 8, &data3.f32);
+            if (cuArray->desc.w)
+              mem->read(tex_array_index + 12, cuArray->desc.w / 8, &data4.f32);
+          }
+        }
       }
-   } break;
-   case F64_TYPE: 
-   case FF64_TYPE:
-      mem->read( tex_array_index, 8, &data1.f64);
+    } break;
+    case F64_TYPE:
+    case FF64_TYPE:
+      mem->read(tex_array_index, 8, &data1.f64);
       if (cuArray->desc.y) {
-         mem->read( tex_array_index+8, 8, &data2.f64);
-         if (cuArray->desc.z) {
-            mem->read( tex_array_index+16, 8, &data3.f64);
-            if (cuArray->desc.w) 
-               mem->read( tex_array_index+24, 8, &data4.f64);
-         }
+        mem->read(tex_array_index + 8, 8, &data2.f64);
+        if (cuArray->desc.z) {
+          mem->read(tex_array_index + 16, 8, &data3.f64);
+          if (cuArray->desc.w) mem->read(tex_array_index + 24, 8, &data4.f64);
+        }
       }
       break;
-   default: assert(0); break;
-   }
-   int x_block_coord, y_block_coord, memreqindex, blockoffset;
+    default:
+      assert(0);
+      break;
+  }
+  int x_block_coord, y_block_coord, memreqindex, blockoffset;
 
-   switch (dimension) {
-   case GEOM_MODIFIER_1D:
+  switch (dimension) {
+    case GEOM_MODIFIER_1D:
       thread->m_last_effective_address = tex_array_index;
       break;
-   case GEOM_MODIFIER_2D: 
+    case GEOM_MODIFIER_2D:
       x_block_coord = x >> (texInfo->Tx_numbits + texInfo->texel_size_numbits);
       y_block_coord = y >> texInfo->Ty_numbits;
 
-      memreqindex = ((y_block_coord*cuArray->width/texInfo->Tx)+x_block_coord)<<6;
+      memreqindex =
+          ((y_block_coord * cuArray->width / texInfo->Tx) + x_block_coord) << 6;
 
-      blockoffset = (x%(texInfo->Tx*texInfo->texel_size) + (y%(texInfo->Ty)<<(texInfo->Tx_numbits + texInfo->texel_size_numbits)));
+      blockoffset = (x % (texInfo->Tx * texInfo->texel_size) +
+                     (y % (texInfo->Ty)
+                      << (texInfo->Tx_numbits + texInfo->texel_size_numbits)));
       memreqindex += blockoffset;
-      thread->m_last_effective_address = tex_array_base + memreqindex;//tex_array_index;
+      thread->m_last_effective_address =
+          tex_array_base + memreqindex;  // tex_array_index;
       break;
-   default:
+    default:
       assert(0);
-   }
-   thread->m_last_memory_space = tex_space; 
+  }
+  thread->m_last_memory_space = tex_space;
 
-   // normalize output into floating point numbers according to the texture read mode
-   if (texAttr->m_readmode == cudaReadModeNormalizedFloat) {
-      textureNormalizeOutput(cuArray->desc, data1, data2, data3, data4); 
-   } else {
-      assert(texAttr->m_readmode == cudaReadModeElementType); 
-   }
+  // normalize output into floating point numbers according to the texture read
+  // mode
+  if (texAttr->m_readmode == cudaReadModeNormalizedFloat) {
+    textureNormalizeOutput(cuArray->desc, data1, data2, data3, data4);
+  } else {
+    assert(texAttr->m_readmode == cudaReadModeElementType);
+  }
 
-   thread->set_vector_operand_values(dst,data1,data2,data3,data4);
+  thread->set_vector_operand_values(dst, data1, data2, data3, data4);
 }
 
-void txq_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void trap_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void vabsdiff_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void vadd_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void vmad_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void vmax_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void vmin_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void vset_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void vshl_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void vshr_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
-void vsub_impl( const ptx_instruction *pI, ptx_thread_info *thread ) { inst_not_implemented(pI); }
+void txq_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void trap_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void vabsdiff_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void vadd_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void vmad_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void vmax_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void vmin_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void vset_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void vshl_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void vshr_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
+void vsub_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  inst_not_implemented(pI);
+}
 
-void vote_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{
-   static bool first_in_warp = true;
-   static bool and_all;
-   static bool or_all;
-   static unsigned int ballot_result;
-   static std::list<ptx_thread_info*> threads_in_warp;
-   static unsigned last_tid;
+void vote_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  static bool first_in_warp = true;
+  static bool and_all;
+  static bool or_all;
+  static unsigned int ballot_result;
+  static std::list<ptx_thread_info *> threads_in_warp;
+  static unsigned last_tid;
 
-   if( first_in_warp ) {
-      first_in_warp = false;
-      threads_in_warp.clear();
-      and_all = true;
-      or_all = false;
-      ballot_result = 0;
-      int offset=31;
-      while( (offset>=0) && !pI->active(offset) ) 
-         offset--;
-      assert( offset >= 0 );
-      last_tid = (thread->get_hw_tid() - (thread->get_hw_tid()%pI->warp_size())) + offset;
-   }
+  if (first_in_warp) {
+    first_in_warp = false;
+    threads_in_warp.clear();
+    and_all = true;
+    or_all = false;
+    ballot_result = 0;
+    int offset = 31;
+    while ((offset >= 0) && !pI->active(offset)) offset--;
+    assert(offset >= 0);
+    last_tid =
+        (thread->get_hw_tid() - (thread->get_hw_tid() % pI->warp_size())) +
+        offset;
+  }
 
-   ptx_reg_t src1_data;
-   const operand_info &src1 = pI->src1();
-   src1_data = thread->get_operand_value(src1, pI->dst(), PRED_TYPE, thread, 1);
+  ptx_reg_t src1_data;
+  const operand_info &src1 = pI->src1();
+  src1_data = thread->get_operand_value(src1, pI->dst(), PRED_TYPE, thread, 1);
 
-   //predicate value was changed so the lowest bit being set means the zero flag is set.
-   //As a result, the value of src1_data.pred must be inverted to get proper behavior
-   bool pred_value = !(src1_data.pred & 0x0001);
-   bool invert = src1.is_neg_pred();
+  // predicate value was changed so the lowest bit being set means the zero flag
+  // is set.
+  // As a result, the value of src1_data.pred must be inverted to get proper
+  // behavior
+  bool pred_value = !(src1_data.pred & 0x0001);
+  bool invert = src1.is_neg_pred();
 
-   threads_in_warp.push_back(thread);
-   and_all &= (invert ^ pred_value);
-   or_all |= (invert ^ pred_value);
+  threads_in_warp.push_back(thread);
+  and_all &= (invert ^ pred_value);
+  or_all |= (invert ^ pred_value);
 
-   // vote.ballot
-   if (invert ^ pred_value) {
-      int lane_id = thread->get_hw_tid() % pI->warp_size(); 
-      ballot_result |= (1 << lane_id); 
-   }
+  // vote.ballot
+  if (invert ^ pred_value) {
+    int lane_id = thread->get_hw_tid() % pI->warp_size();
+    ballot_result |= (1 << lane_id);
+  }
 
-   if( thread->get_hw_tid() == last_tid ) {
-      if (pI->vote_mode() == ptx_instruction::vote_ballot) {
-         ptx_reg_t data = ballot_result; 
-         for( std::list<ptx_thread_info*>::iterator t=threads_in_warp.begin(); t!=threads_in_warp.end(); ++t ) {
-            const operand_info &dst = pI->dst();
-            (*t)->set_operand_value(dst,data, pI->get_type(), (*t), pI);
-         }
-      } else {
-         bool pred_value = false; 
-
-         switch( pI->vote_mode() ) {
-         case ptx_instruction::vote_any: pred_value = or_all; break;
-         case ptx_instruction::vote_all: pred_value = and_all; break;
-         case ptx_instruction::vote_uni: pred_value = (or_all ^ and_all); break;
-         default:
-            abort();
-         }
-         ptx_reg_t data;
-         data.pred = pred_value?0:1; //the way ptxplus handles the zero flag, 1 = false and 0 = true
-
-         for( std::list<ptx_thread_info*>::iterator t=threads_in_warp.begin(); t!=threads_in_warp.end(); ++t ) {
-            const operand_info &dst = pI->dst();
-            (*t)->set_operand_value(dst,data, PRED_TYPE, (*t), pI);
-         }
+  if (thread->get_hw_tid() == last_tid) {
+    if (pI->vote_mode() == ptx_instruction::vote_ballot) {
+      ptx_reg_t data = ballot_result;
+      for (std::list<ptx_thread_info *>::iterator t = threads_in_warp.begin();
+           t != threads_in_warp.end(); ++t) {
+        const operand_info &dst = pI->dst();
+        (*t)->set_operand_value(dst, data, pI->get_type(), (*t), pI);
       }
-      first_in_warp = true;
-   }
+    } else {
+      bool pred_value = false;
+
+      switch (pI->vote_mode()) {
+        case ptx_instruction::vote_any:
+          pred_value = or_all;
+          break;
+        case ptx_instruction::vote_all:
+          pred_value = and_all;
+          break;
+        case ptx_instruction::vote_uni:
+          pred_value = (or_all ^ and_all);
+          break;
+        default:
+          abort();
+      }
+      ptx_reg_t data;
+      data.pred = pred_value ? 0 : 1;  // the way ptxplus handles the zero flag,
+                                       // 1 = false and 0 = true
+
+      for (std::list<ptx_thread_info *>::iterator t = threads_in_warp.begin();
+           t != threads_in_warp.end(); ++t) {
+        const operand_info &dst = pI->dst();
+        (*t)->set_operand_value(dst, data, PRED_TYPE, (*t), pI);
+      }
+    }
+    first_in_warp = true;
+  }
 }
 
-void xor_impl( const ptx_instruction *pI, ptx_thread_info *thread ) 
-{ 
-   ptx_reg_t src1_data, src2_data, data;
+void xor_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+  ptx_reg_t src1_data, src2_data, data;
 
-   const operand_info &dst  = pI->dst();
-   const operand_info &src1 = pI->src1();
-   const operand_info &src2 = pI->src2();
+  const operand_info &dst = pI->dst();
+  const operand_info &src1 = pI->src1();
+  const operand_info &src2 = pI->src2();
 
-   unsigned i_type = pI->get_type();
-   src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
-   src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
+  unsigned i_type = pI->get_type();
+  src1_data = thread->get_operand_value(src1, dst, i_type, thread, 1);
+  src2_data = thread->get_operand_value(src2, dst, i_type, thread, 1);
 
-   //the way ptxplus handles predicates: 1 = false and 0 = true
-   if(i_type == PRED_TYPE)
-      data.pred = ~(~(src1_data.pred) ^ ~(src2_data.pred));
-   else
-      data.u64 = src1_data.u64 ^ src2_data.u64;
+  // the way ptxplus handles predicates: 1 = false and 0 = true
+  if (i_type == PRED_TYPE)
+    data.pred = ~(~(src1_data.pred) ^ ~(src2_data.pred));
+  else
+    data.u64 = src1_data.u64 ^ src2_data.u64;
 
-   thread->set_operand_value(dst,data, i_type, thread, pI);
+  thread->set_operand_value(dst, data, i_type, thread, pI);
 }
 
-void inst_not_implemented( const ptx_instruction * pI ) 
-{
-   printf("GPGPU-Sim PTX: ERROR (%s:%u) instruction \"%s\" not (yet) implemented\n",
-          pI->source_file(), 
-          pI->source_line(), 
-          pI->get_opcode_cstr() );
-   abort();
+void inst_not_implemented(const ptx_instruction *pI) {
+  printf(
+      "GPGPU-Sim PTX: ERROR (%s:%u) instruction \"%s\" not (yet) implemented\n",
+      pI->source_file(), pI->source_line(), pI->get_opcode_cstr());
+  abort();
 }
 
-ptx_reg_t srcOperandModifiers(ptx_reg_t opData, operand_info opInfo, operand_info dstInfo, unsigned type, ptx_thread_info *thread)
-{
-   ptx_reg_t result;
-   memory_space *mem = NULL;
-   size_t size;
-   int t;
-   result.u64=0;
+ptx_reg_t srcOperandModifiers(ptx_reg_t opData, operand_info opInfo,
+                              operand_info dstInfo, unsigned type,
+                              ptx_thread_info *thread) {
+  ptx_reg_t result;
+  memory_space *mem = NULL;
+  size_t size;
+  int t;
+  result.u64 = 0;
 
-   //complete other cases for reading from memory, such as reading from other const memory
-   if(opInfo.get_addr_space() == global_space)
-   {
-       mem = thread->get_global_memory();
-       type_info_key::type_decode(type,size,t);
-       mem->read(opData.u32,size/8,&result.u64);
-       if( type == S16_TYPE || type == S32_TYPE ) 
-         sign_extend(result,size,dstInfo);
-   }
-   else if(opInfo.get_addr_space() == shared_space)
-   {
-       mem = thread->m_shared_mem;
-       type_info_key::type_decode(type,size,t);
-       mem->read(opData.u32,size/8,&result.u64);
+  // complete other cases for reading from memory, such as reading from other
+  // const memory
+  if (opInfo.get_addr_space() == global_space) {
+    mem = thread->get_global_memory();
+    type_info_key::type_decode(type, size, t);
+    mem->read(opData.u32, size / 8, &result.u64);
+    if (type == S16_TYPE || type == S32_TYPE)
+      sign_extend(result, size, dstInfo);
+  } else if (opInfo.get_addr_space() == shared_space) {
+    mem = thread->m_shared_mem;
+    type_info_key::type_decode(type, size, t);
+    mem->read(opData.u32, size / 8, &result.u64);
 
-       if( type == S16_TYPE || type == S32_TYPE ) 
-         sign_extend(result,size,dstInfo);
+    if (type == S16_TYPE || type == S32_TYPE)
+      sign_extend(result, size, dstInfo);
 
-   }
-   else if(opInfo.get_addr_space() == const_space)
-   {
-       mem = thread->get_global_memory();
-       type_info_key::type_decode(type,size,t);
+  } else if (opInfo.get_addr_space() == const_space) {
+    mem = thread->get_global_memory();
+    type_info_key::type_decode(type, size, t);
 
-       mem->read((opData.u32 + opInfo.get_const_mem_offset()),size/8,&result.u64);
+    mem->read((opData.u32 + opInfo.get_const_mem_offset()), size / 8,
+              &result.u64);
 
-       if( type == S16_TYPE || type == S32_TYPE ) 
-         sign_extend(result,size,dstInfo);
-   }
-   else
-   {
-       result = opData;
-   }
+    if (type == S16_TYPE || type == S32_TYPE)
+      sign_extend(result, size, dstInfo);
+  } else {
+    result = opData;
+  }
 
-   if(opInfo.get_operand_lohi() == 1)
-   {
-        result.u64 = result.u64 & 0xFFFF;
-   }
-   else if(opInfo.get_operand_lohi() == 2)
-   {
-        result.u64 = (result.u64>>16) & 0xFFFF;
-   }
+  if (opInfo.get_operand_lohi() == 1) {
+    result.u64 = result.u64 & 0xFFFF;
+  } else if (opInfo.get_operand_lohi() == 2) {
+    result.u64 = (result.u64 >> 16) & 0xFFFF;
+  }
 
-   if(opInfo.get_operand_neg() == true) {
-      result.f32 = -result.f32;
-   }
+  if (opInfo.get_operand_neg() == true) {
+    result.f32 = -result.f32;
+  }
 
-   return result;
+  return result;
 }
-

--- a/src/cuda-sim/instructions.cc
+++ b/src/cuda-sim/instructions.cc
@@ -3625,7 +3625,7 @@ void mma_ld_impl(const ptx_instruction *pI, core_t *core, warp_inst_t &inst) {
     if ((wmma_type == LOAD_C) && (type == F16_TYPE) &&
         (wmma_layout == COL))  // memory address is scattered, check the
                                // profiling xls for more detail.
-      inst.data_size = 2;      // 2 byte transaction
+      inst.data_size = 2;  // 2 byte transaction
     else
       inst.data_size = 4;  // 4 byte transaction
     assert(inst.memory_op == insn_memory_op);
@@ -5994,13 +5994,13 @@ void tex_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
       src2, thread->get_gpu()->gpgpu_ctx->func_sim->ptx_tex_regs,
       nelem);  // ptx_reg should be 4 entry vector type...coordinates into
                // texture
-               /*
-                 For programs with many streams, textures can be bound and unbound
-                 asynchronously.  This means we need to use the kernel's "snapshot" of
-                 the state of the texture mappings when it was launched (so that we
-                 don't try to access the incorrect texture mapping if it's been updated,
-                 or that we don't access a mapping that has been unbound).
-               */
+  /*
+    For programs with many streams, textures can be bound and unbound
+    asynchronously.  This means we need to use the kernel's "snapshot" of
+    the state of the texture mappings when it was launched (so that we
+    don't try to access the incorrect texture mapping if it's been updated,
+    or that we don't access a mapping that has been unbound).
+  */
   gpgpu_t *gpu = thread->get_gpu();
   kernel_info_t &k = thread->get_kernel();
   const struct textureReference *texref = gpu->get_texref(texname);

--- a/src/cuda-sim/memory.cc
+++ b/src/cuda-sim/memory.cc
@@ -7,210 +7,227 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #include "memory.h"
 #include <stdlib.h>
-#include "../debug.h"
 #include "../../libcuda/gpgpu_context.h"
+#include "../debug.h"
 
-template<unsigned BSIZE> memory_space_impl<BSIZE>::memory_space_impl( std::string name, unsigned hash_size )
-{
-   m_name = name;
-   MEM_MAP_RESIZE(hash_size);
+template <unsigned BSIZE>
+memory_space_impl<BSIZE>::memory_space_impl(std::string name,
+                                            unsigned hash_size) {
+  m_name = name;
+  MEM_MAP_RESIZE(hash_size);
 
-   m_log2_block_size = -1;
-   for( unsigned n=0, mask=1; mask != 0; mask <<= 1, n++ ) {
-      if( BSIZE & mask ) {
-         assert( m_log2_block_size == (unsigned)-1 );
-         m_log2_block_size = n; 
+  m_log2_block_size = -1;
+  for (unsigned n = 0, mask = 1; mask != 0; mask <<= 1, n++) {
+    if (BSIZE & mask) {
+      assert(m_log2_block_size == (unsigned)-1);
+      m_log2_block_size = n;
+    }
+  }
+  assert(m_log2_block_size != (unsigned)-1);
+}
+
+template <unsigned BSIZE>
+void memory_space_impl<BSIZE>::write_only(mem_addr_t offset, mem_addr_t index,
+                                          size_t length, const void *data) {
+  m_data[index].write(offset, length, (const unsigned char *)data);
+}
+
+template <unsigned BSIZE>
+void memory_space_impl<BSIZE>::write(mem_addr_t addr, size_t length,
+                                     const void *data,
+                                     class ptx_thread_info *thd,
+                                     const ptx_instruction *pI) {
+  mem_addr_t index = addr >> m_log2_block_size;
+
+  if ((addr + length) <= (index + 1) * BSIZE) {
+    // fast route for intra-block access
+    unsigned offset = addr & (BSIZE - 1);
+    unsigned nbytes = length;
+    m_data[index].write(offset, nbytes, (const unsigned char *)data);
+  } else {
+    // slow route for inter-block access
+    unsigned nbytes_remain = length;
+    unsigned src_offset = 0;
+    mem_addr_t current_addr = addr;
+
+    while (nbytes_remain > 0) {
+      unsigned offset = current_addr & (BSIZE - 1);
+      mem_addr_t page = current_addr >> m_log2_block_size;
+      mem_addr_t access_limit = offset + nbytes_remain;
+      if (access_limit > BSIZE) {
+        access_limit = BSIZE;
       }
-   }
-   assert( m_log2_block_size != (unsigned)-1 );
+
+      size_t tx_bytes = access_limit - offset;
+      m_data[page].write(offset, tx_bytes,
+                         &((const unsigned char *)data)[src_offset]);
+
+      // advance pointers
+      src_offset += tx_bytes;
+      current_addr += tx_bytes;
+      nbytes_remain -= tx_bytes;
+    }
+    assert(nbytes_remain == 0);
+  }
+  if (!m_watchpoints.empty()) {
+    std::map<unsigned, mem_addr_t>::iterator i;
+    for (i = m_watchpoints.begin(); i != m_watchpoints.end(); i++) {
+      mem_addr_t wa = i->second;
+      if (((addr <= wa) && ((addr + length) > wa)) ||
+          ((addr > wa) && (addr < (wa + 4))))
+        thd->get_gpu()->gpgpu_ctx->the_gpgpusim->g_the_gpu->hit_watchpoint(
+            i->first, thd, pI);
+    }
+  }
 }
 
-template<unsigned BSIZE> void memory_space_impl<BSIZE>::write_only( mem_addr_t offset, mem_addr_t index, size_t length, const void *data)
-{
-   m_data[index].write(offset,length,(const unsigned char*)data);
+template <unsigned BSIZE>
+void memory_space_impl<BSIZE>::read_single_block(mem_addr_t blk_idx,
+                                                 mem_addr_t addr, size_t length,
+                                                 void *data) const {
+  if ((addr + length) > (blk_idx + 1) * BSIZE) {
+    printf(
+        "GPGPU-Sim PTX: ERROR * access to memory \'%s\' is unaligned : "
+        "addr=0x%x, length=%zu\n",
+        m_name.c_str(), addr, length);
+    printf(
+        "GPGPU-Sim PTX: (addr+length)=0x%lx > 0x%x=(index+1)*BSIZE, "
+        "index=0x%x, BSIZE=0x%x\n",
+        (addr + length), (blk_idx + 1) * BSIZE, blk_idx, BSIZE);
+    throw 1;
+  }
+  typename map_t::const_iterator i = m_data.find(blk_idx);
+  if (i == m_data.end()) {
+    for (size_t n = 0; n < length; n++)
+      ((unsigned char *)data)[n] = (unsigned char)0;
+    // printf("GPGPU-Sim PTX:  WARNING reading %zu bytes from unititialized
+    // memory at address 0x%x in space %s\n", length, addr, m_name.c_str() );
+  } else {
+    unsigned offset = addr & (BSIZE - 1);
+    unsigned nbytes = length;
+    i->second.read(offset, nbytes, (unsigned char *)data);
+  }
 }
 
-template<unsigned BSIZE> void memory_space_impl<BSIZE>::write( mem_addr_t addr, size_t length, const void *data, class ptx_thread_info *thd, const ptx_instruction *pI)
-{
+template <unsigned BSIZE>
+void memory_space_impl<BSIZE>::read(mem_addr_t addr, size_t length,
+                                    void *data) const {
+  mem_addr_t index = addr >> m_log2_block_size;
+  if ((addr + length) <= (index + 1) * BSIZE) {
+    // fast route for intra-block access
+    read_single_block(index, addr, length, data);
+  } else {
+    // slow route for inter-block access
+    unsigned nbytes_remain = length;
+    unsigned dst_offset = 0;
+    mem_addr_t current_addr = addr;
 
-   mem_addr_t index = addr >> m_log2_block_size;
-
-   if ( (addr+length) <= (index+1)*BSIZE ) {
-      // fast route for intra-block access 
-      unsigned offset = addr & (BSIZE-1);
-      unsigned nbytes = length;
-      m_data[index].write(offset,nbytes,(const unsigned char*)data);
-   } else {
-      // slow route for inter-block access
-      unsigned nbytes_remain = length;
-      unsigned src_offset = 0; 
-      mem_addr_t current_addr = addr; 
-
-      while (nbytes_remain > 0) {
-         unsigned offset = current_addr & (BSIZE-1);
-         mem_addr_t page = current_addr >> m_log2_block_size; 
-         mem_addr_t access_limit = offset + nbytes_remain; 
-         if (access_limit > BSIZE) {
-            access_limit = BSIZE;
-         } 
-         
-         size_t tx_bytes = access_limit - offset; 
-         m_data[page].write(offset, tx_bytes, &((const unsigned char*)data)[src_offset]);
-
-         // advance pointers 
-         src_offset += tx_bytes; 
-         current_addr += tx_bytes; 
-         nbytes_remain -= tx_bytes; 
+    while (nbytes_remain > 0) {
+      unsigned offset = current_addr & (BSIZE - 1);
+      mem_addr_t page = current_addr >> m_log2_block_size;
+      mem_addr_t access_limit = offset + nbytes_remain;
+      if (access_limit > BSIZE) {
+        access_limit = BSIZE;
       }
-      assert(nbytes_remain == 0); 
-   }
-   if( !m_watchpoints.empty() ) {
-      std::map<unsigned,mem_addr_t>::iterator i;
-      for( i=m_watchpoints.begin(); i!=m_watchpoints.end(); i++ ) {
-         mem_addr_t wa = i->second;
-         if( ((addr<=wa) && ((addr+length)>wa)) || ((addr>wa) && (addr < (wa+4))) ) 
-            thd->get_gpu()->gpgpu_ctx->the_gpgpusim->g_the_gpu->hit_watchpoint(i->first,thd,pI);
-      }
-   }
+
+      size_t tx_bytes = access_limit - offset;
+      read_single_block(page, current_addr, tx_bytes,
+                        &((unsigned char *)data)[dst_offset]);
+
+      // advance pointers
+      dst_offset += tx_bytes;
+      current_addr += tx_bytes;
+      nbytes_remain -= tx_bytes;
+    }
+    assert(nbytes_remain == 0);
+  }
 }
 
-template<unsigned BSIZE> void memory_space_impl<BSIZE>::read_single_block( mem_addr_t blk_idx, mem_addr_t addr, size_t length, void *data) const
-{
-   if ((addr + length) > (blk_idx + 1) * BSIZE) {
-      printf("GPGPU-Sim PTX: ERROR * access to memory \'%s\' is unaligned : addr=0x%x, length=%zu\n",
-             m_name.c_str(), addr, length);
-      printf("GPGPU-Sim PTX: (addr+length)=0x%lx > 0x%x=(index+1)*BSIZE, index=0x%x, BSIZE=0x%x\n",
-             (addr+length),(blk_idx+1)*BSIZE, blk_idx, BSIZE);
-      throw 1;
-   }
-   typename map_t::const_iterator i = m_data.find(blk_idx);
-   if( i == m_data.end() ) {
-      for( size_t n=0; n < length; n++ ) 
-         ((unsigned char*)data)[n] = (unsigned char) 0;
-      //printf("GPGPU-Sim PTX:  WARNING reading %zu bytes from unititialized memory at address 0x%x in space %s\n", length, addr, m_name.c_str() );
-   } else {
-      unsigned offset = addr & (BSIZE-1);
-      unsigned nbytes = length;
-      i->second.read(offset,nbytes,(unsigned char*)data);
-   }
+template <unsigned BSIZE>
+void memory_space_impl<BSIZE>::print(const char *format, FILE *fout) const {
+  typename map_t::const_iterator i_page;
+
+  for (i_page = m_data.begin(); i_page != m_data.end(); ++i_page) {
+    fprintf(fout, "%s %08x:", m_name.c_str(), i_page->first);
+    i_page->second.print(format, fout);
+  }
 }
 
-template<unsigned BSIZE> void memory_space_impl<BSIZE>::read( mem_addr_t addr, size_t length, void *data ) const
-{
-   mem_addr_t index = addr >> m_log2_block_size;
-   if ((addr+length) <= (index+1)*BSIZE ) {
-      // fast route for intra-block access 
-      read_single_block(index, addr, length, data); 
-   } else {
-      // slow route for inter-block access 
-      unsigned nbytes_remain = length;
-      unsigned dst_offset = 0; 
-      mem_addr_t current_addr = addr; 
-
-      while (nbytes_remain > 0) {
-         unsigned offset = current_addr & (BSIZE-1);
-         mem_addr_t page = current_addr >> m_log2_block_size; 
-         mem_addr_t access_limit = offset + nbytes_remain; 
-         if (access_limit > BSIZE) {
-            access_limit = BSIZE;
-         } 
-         
-         size_t tx_bytes = access_limit - offset; 
-         read_single_block(page, current_addr, tx_bytes, &((unsigned char*)data)[dst_offset]); 
-
-         // advance pointers 
-         dst_offset += tx_bytes; 
-         current_addr += tx_bytes; 
-         nbytes_remain -= tx_bytes; 
-      }
-      assert(nbytes_remain == 0); 
-   }
-}
-
-template<unsigned BSIZE> void memory_space_impl<BSIZE>::print( const char *format, FILE *fout ) const
-{
-   typename map_t::const_iterator i_page;
-
-   for ( i_page = m_data.begin(); i_page != m_data.end(); ++i_page) {
-      fprintf(fout, "%s %08x:", m_name.c_str(), i_page->first);
-      i_page->second.print(format, fout);
-   }
-}
-
-template<unsigned BSIZE> void memory_space_impl<BSIZE>::set_watch( addr_t addr, unsigned watchpoint ) 
-{
-   m_watchpoints[watchpoint]=addr;
+template <unsigned BSIZE>
+void memory_space_impl<BSIZE>::set_watch(addr_t addr, unsigned watchpoint) {
+  m_watchpoints[watchpoint] = addr;
 }
 
 template class memory_space_impl<32>;
 template class memory_space_impl<64>;
 template class memory_space_impl<8192>;
-template class memory_space_impl<16*1024>;
+template class memory_space_impl<16 * 1024>;
 
-void g_print_memory_space(memory_space *mem, const char *format = "%08x", FILE *fout = stdout) 
-{
-    mem->print(format,fout);
+void g_print_memory_space(memory_space *mem, const char *format = "%08x",
+                          FILE *fout = stdout) {
+  mem->print(format, fout);
 }
 
 #ifdef UNIT_TEST
 
-int main(int argc, char *argv[] )
-{
-   int errors_found=0;
-   memory_space *mem = new memory_space_impl<32>("test",4);
-   // write address to [address]
-   for( mem_addr_t addr=0; addr < 16*1024; addr+=4) 
-      mem->write(addr,4,&addr,NULL,NULL);
+int main(int argc, char *argv[]) {
+  int errors_found = 0;
+  memory_space *mem = new memory_space_impl<32>("test", 4);
+  // write address to [address]
+  for (mem_addr_t addr = 0; addr < 16 * 1024; addr += 4)
+    mem->write(addr, 4, &addr, NULL, NULL);
 
-   for( mem_addr_t addr=0; addr < 16*1024; addr+=4) {
-      unsigned tmp=0;
-      mem->read(addr,4,&tmp);
-      if( tmp != addr ) {
-         errors_found=1;
-         printf("ERROR ** mem[0x%x] = 0x%x, expected 0x%x\n", addr, tmp, addr );
-      }
-   }
+  for (mem_addr_t addr = 0; addr < 16 * 1024; addr += 4) {
+    unsigned tmp = 0;
+    mem->read(addr, 4, &tmp);
+    if (tmp != addr) {
+      errors_found = 1;
+      printf("ERROR ** mem[0x%x] = 0x%x, expected 0x%x\n", addr, tmp, addr);
+    }
+  }
 
-   for( mem_addr_t addr=0; addr < 16*1024; addr+=1) {
-      unsigned char val = (addr + 128) % 256;
-      mem->write(addr,1,&val,NULL,NULL);
-   }
+  for (mem_addr_t addr = 0; addr < 16 * 1024; addr += 1) {
+    unsigned char val = (addr + 128) % 256;
+    mem->write(addr, 1, &val, NULL, NULL);
+  }
 
-   for( mem_addr_t addr=0; addr < 16*1024; addr+=1) {
-      unsigned tmp=0;
-      mem->read(addr,1,&tmp);
-      unsigned char val = (addr + 128) % 256;
-      if( tmp != val ) {
-         errors_found=1;
-         printf("ERROR ** mem[0x%x] = 0x%x, expected 0x%x\n", addr, tmp, (unsigned)val );
-      }
-   }
+  for (mem_addr_t addr = 0; addr < 16 * 1024; addr += 1) {
+    unsigned tmp = 0;
+    mem->read(addr, 1, &tmp);
+    unsigned char val = (addr + 128) % 256;
+    if (tmp != val) {
+      errors_found = 1;
+      printf("ERROR ** mem[0x%x] = 0x%x, expected 0x%x\n", addr, tmp,
+             (unsigned)val);
+    }
+  }
 
-   if( errors_found ) {
-      printf("SUMMARY:  ERRORS FOUND\n");
-   } else {
-      printf("SUMMARY: UNIT TEST PASSED\n");
-   }
+  if (errors_found) {
+    printf("SUMMARY:  ERRORS FOUND\n");
+  } else {
+    printf("SUMMARY: UNIT TEST PASSED\n");
+  }
 }
 
 #endif

--- a/src/cuda-sim/memory.cc
+++ b/src/cuda-sim/memory.cc
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -29,206 +27,190 @@
 
 #include "memory.h"
 #include <stdlib.h>
-#include "../../libcuda/gpgpu_context.h"
 #include "../debug.h"
+#include "../../libcuda/gpgpu_context.h"
 
-template <unsigned BSIZE>
-memory_space_impl<BSIZE>::memory_space_impl(std::string name,
-                                            unsigned hash_size) {
-  m_name = name;
-  MEM_MAP_RESIZE(hash_size);
+template<unsigned BSIZE> memory_space_impl<BSIZE>::memory_space_impl( std::string name, unsigned hash_size )
+{
+   m_name = name;
+   MEM_MAP_RESIZE(hash_size);
 
-  m_log2_block_size = -1;
-  for (unsigned n = 0, mask = 1; mask != 0; mask <<= 1, n++) {
-    if (BSIZE & mask) {
-      assert(m_log2_block_size == (unsigned)-1);
-      m_log2_block_size = n;
-    }
-  }
-  assert(m_log2_block_size != (unsigned)-1);
-}
-
-template <unsigned BSIZE>
-void memory_space_impl<BSIZE>::write_only(mem_addr_t offset, mem_addr_t index,
-                                          size_t length, const void *data) {
-  m_data[index].write(offset, length, (const unsigned char *)data);
-}
-
-template <unsigned BSIZE>
-void memory_space_impl<BSIZE>::write(mem_addr_t addr, size_t length,
-                                     const void *data,
-                                     class ptx_thread_info *thd,
-                                     const ptx_instruction *pI) {
-  mem_addr_t index = addr >> m_log2_block_size;
-
-  if ((addr + length) <= (index + 1) * BSIZE) {
-    // fast route for intra-block access
-    unsigned offset = addr & (BSIZE - 1);
-    unsigned nbytes = length;
-    m_data[index].write(offset, nbytes, (const unsigned char *)data);
-  } else {
-    // slow route for inter-block access
-    unsigned nbytes_remain = length;
-    unsigned src_offset = 0;
-    mem_addr_t current_addr = addr;
-
-    while (nbytes_remain > 0) {
-      unsigned offset = current_addr & (BSIZE - 1);
-      mem_addr_t page = current_addr >> m_log2_block_size;
-      mem_addr_t access_limit = offset + nbytes_remain;
-      if (access_limit > BSIZE) {
-        access_limit = BSIZE;
+   m_log2_block_size = -1;
+   for( unsigned n=0, mask=1; mask != 0; mask <<= 1, n++ ) {
+      if( BSIZE & mask ) {
+         assert( m_log2_block_size == (unsigned)-1 );
+         m_log2_block_size = n; 
       }
-
-      size_t tx_bytes = access_limit - offset;
-      m_data[page].write(offset, tx_bytes,
-                         &((const unsigned char *)data)[src_offset]);
-
-      // advance pointers
-      src_offset += tx_bytes;
-      current_addr += tx_bytes;
-      nbytes_remain -= tx_bytes;
-    }
-    assert(nbytes_remain == 0);
-  }
-  if (!m_watchpoints.empty()) {
-    std::map<unsigned, mem_addr_t>::iterator i;
-    for (i = m_watchpoints.begin(); i != m_watchpoints.end(); i++) {
-      mem_addr_t wa = i->second;
-      if (((addr <= wa) && ((addr + length) > wa)) ||
-          ((addr > wa) && (addr < (wa + 4))))
-        thd->get_gpu()->gpgpu_ctx->the_gpgpusim->g_the_gpu->hit_watchpoint(
-            i->first, thd, pI);
-    }
-  }
+   }
+   assert( m_log2_block_size != (unsigned)-1 );
 }
 
-template <unsigned BSIZE>
-void memory_space_impl<BSIZE>::read_single_block(mem_addr_t blk_idx,
-                                                 mem_addr_t addr, size_t length,
-                                                 void *data) const {
-  if ((addr + length) > (blk_idx + 1) * BSIZE) {
-    printf(
-        "GPGPU-Sim PTX: ERROR * access to memory \'%s\' is unaligned : "
-        "addr=0x%x, length=%zu\n",
-        m_name.c_str(), addr, length);
-    printf(
-        "GPGPU-Sim PTX: (addr+length)=0x%lx > 0x%x=(index+1)*BSIZE, "
-        "index=0x%x, BSIZE=0x%x\n",
-        (addr + length), (blk_idx + 1) * BSIZE, blk_idx, BSIZE);
-    throw 1;
-  }
-  typename map_t::const_iterator i = m_data.find(blk_idx);
-  if (i == m_data.end()) {
-    for (size_t n = 0; n < length; n++)
-      ((unsigned char *)data)[n] = (unsigned char)0;
-    // printf("GPGPU-Sim PTX:  WARNING reading %zu bytes from unititialized
-    // memory at address 0x%x in space %s\n", length, addr, m_name.c_str() );
-  } else {
-    unsigned offset = addr & (BSIZE - 1);
-    unsigned nbytes = length;
-    i->second.read(offset, nbytes, (unsigned char *)data);
-  }
+template<unsigned BSIZE> void memory_space_impl<BSIZE>::write_only( mem_addr_t offset, mem_addr_t index, size_t length, const void *data)
+{
+   m_data[index].write(offset,length,(const unsigned char*)data);
 }
 
-template <unsigned BSIZE>
-void memory_space_impl<BSIZE>::read(mem_addr_t addr, size_t length,
-                                    void *data) const {
-  mem_addr_t index = addr >> m_log2_block_size;
-  if ((addr + length) <= (index + 1) * BSIZE) {
-    // fast route for intra-block access
-    read_single_block(index, addr, length, data);
-  } else {
-    // slow route for inter-block access
-    unsigned nbytes_remain = length;
-    unsigned dst_offset = 0;
-    mem_addr_t current_addr = addr;
+template<unsigned BSIZE> void memory_space_impl<BSIZE>::write( mem_addr_t addr, size_t length, const void *data, class ptx_thread_info *thd, const ptx_instruction *pI)
+{
 
-    while (nbytes_remain > 0) {
-      unsigned offset = current_addr & (BSIZE - 1);
-      mem_addr_t page = current_addr >> m_log2_block_size;
-      mem_addr_t access_limit = offset + nbytes_remain;
-      if (access_limit > BSIZE) {
-        access_limit = BSIZE;
+   mem_addr_t index = addr >> m_log2_block_size;
+
+   if ( (addr+length) <= (index+1)*BSIZE ) {
+      // fast route for intra-block access 
+      unsigned offset = addr & (BSIZE-1);
+      unsigned nbytes = length;
+      m_data[index].write(offset,nbytes,(const unsigned char*)data);
+   } else {
+      // slow route for inter-block access
+      unsigned nbytes_remain = length;
+      unsigned src_offset = 0; 
+      mem_addr_t current_addr = addr; 
+
+      while (nbytes_remain > 0) {
+         unsigned offset = current_addr & (BSIZE-1);
+         mem_addr_t page = current_addr >> m_log2_block_size; 
+         mem_addr_t access_limit = offset + nbytes_remain; 
+         if (access_limit > BSIZE) {
+            access_limit = BSIZE;
+         } 
+         
+         size_t tx_bytes = access_limit - offset; 
+         m_data[page].write(offset, tx_bytes, &((const unsigned char*)data)[src_offset]);
+
+         // advance pointers 
+         src_offset += tx_bytes; 
+         current_addr += tx_bytes; 
+         nbytes_remain -= tx_bytes; 
       }
-
-      size_t tx_bytes = access_limit - offset;
-      read_single_block(page, current_addr, tx_bytes,
-                        &((unsigned char *)data)[dst_offset]);
-
-      // advance pointers
-      dst_offset += tx_bytes;
-      current_addr += tx_bytes;
-      nbytes_remain -= tx_bytes;
-    }
-    assert(nbytes_remain == 0);
-  }
+      assert(nbytes_remain == 0); 
+   }
+   if( !m_watchpoints.empty() ) {
+      std::map<unsigned,mem_addr_t>::iterator i;
+      for( i=m_watchpoints.begin(); i!=m_watchpoints.end(); i++ ) {
+         mem_addr_t wa = i->second;
+         if( ((addr<=wa) && ((addr+length)>wa)) || ((addr>wa) && (addr < (wa+4))) ) 
+            thd->get_gpu()->gpgpu_ctx->the_gpgpusim->g_the_gpu->hit_watchpoint(i->first,thd,pI);
+      }
+   }
 }
 
-template <unsigned BSIZE>
-void memory_space_impl<BSIZE>::print(const char *format, FILE *fout) const {
-  typename map_t::const_iterator i_page;
-
-  for (i_page = m_data.begin(); i_page != m_data.end(); ++i_page) {
-    fprintf(fout, "%s %08x:", m_name.c_str(), i_page->first);
-    i_page->second.print(format, fout);
-  }
+template<unsigned BSIZE> void memory_space_impl<BSIZE>::read_single_block( mem_addr_t blk_idx, mem_addr_t addr, size_t length, void *data) const
+{
+   if ((addr + length) > (blk_idx + 1) * BSIZE) {
+      printf("GPGPU-Sim PTX: ERROR * access to memory \'%s\' is unaligned : addr=0x%x, length=%zu\n",
+             m_name.c_str(), addr, length);
+      printf("GPGPU-Sim PTX: (addr+length)=0x%lx > 0x%x=(index+1)*BSIZE, index=0x%x, BSIZE=0x%x\n",
+             (addr+length),(blk_idx+1)*BSIZE, blk_idx, BSIZE);
+      throw 1;
+   }
+   typename map_t::const_iterator i = m_data.find(blk_idx);
+   if( i == m_data.end() ) {
+      for( size_t n=0; n < length; n++ ) 
+         ((unsigned char*)data)[n] = (unsigned char) 0;
+      //printf("GPGPU-Sim PTX:  WARNING reading %zu bytes from unititialized memory at address 0x%x in space %s\n", length, addr, m_name.c_str() );
+   } else {
+      unsigned offset = addr & (BSIZE-1);
+      unsigned nbytes = length;
+      i->second.read(offset,nbytes,(unsigned char*)data);
+   }
 }
 
-template <unsigned BSIZE>
-void memory_space_impl<BSIZE>::set_watch(addr_t addr, unsigned watchpoint) {
-  m_watchpoints[watchpoint] = addr;
+template<unsigned BSIZE> void memory_space_impl<BSIZE>::read( mem_addr_t addr, size_t length, void *data ) const
+{
+   mem_addr_t index = addr >> m_log2_block_size;
+   if ((addr+length) <= (index+1)*BSIZE ) {
+      // fast route for intra-block access 
+      read_single_block(index, addr, length, data); 
+   } else {
+      // slow route for inter-block access 
+      unsigned nbytes_remain = length;
+      unsigned dst_offset = 0; 
+      mem_addr_t current_addr = addr; 
+
+      while (nbytes_remain > 0) {
+         unsigned offset = current_addr & (BSIZE-1);
+         mem_addr_t page = current_addr >> m_log2_block_size; 
+         mem_addr_t access_limit = offset + nbytes_remain; 
+         if (access_limit > BSIZE) {
+            access_limit = BSIZE;
+         } 
+         
+         size_t tx_bytes = access_limit - offset; 
+         read_single_block(page, current_addr, tx_bytes, &((unsigned char*)data)[dst_offset]); 
+
+         // advance pointers 
+         dst_offset += tx_bytes; 
+         current_addr += tx_bytes; 
+         nbytes_remain -= tx_bytes; 
+      }
+      assert(nbytes_remain == 0); 
+   }
+}
+
+template<unsigned BSIZE> void memory_space_impl<BSIZE>::print( const char *format, FILE *fout ) const
+{
+   typename map_t::const_iterator i_page;
+
+   for ( i_page = m_data.begin(); i_page != m_data.end(); ++i_page) {
+      fprintf(fout, "%s %08x:", m_name.c_str(), i_page->first);
+      i_page->second.print(format, fout);
+   }
+}
+
+template<unsigned BSIZE> void memory_space_impl<BSIZE>::set_watch( addr_t addr, unsigned watchpoint ) 
+{
+   m_watchpoints[watchpoint]=addr;
 }
 
 template class memory_space_impl<32>;
 template class memory_space_impl<64>;
 template class memory_space_impl<8192>;
-template class memory_space_impl<16 * 1024>;
+template class memory_space_impl<16*1024>;
 
-void g_print_memory_space(memory_space *mem, const char *format = "%08x",
-                          FILE *fout = stdout) {
-  mem->print(format, fout);
+void g_print_memory_space(memory_space *mem, const char *format = "%08x", FILE *fout = stdout) 
+{
+    mem->print(format,fout);
 }
 
 #ifdef UNIT_TEST
 
-int main(int argc, char *argv[]) {
-  int errors_found = 0;
-  memory_space *mem = new memory_space_impl<32>("test", 4);
-  // write address to [address]
-  for (mem_addr_t addr = 0; addr < 16 * 1024; addr += 4)
-    mem->write(addr, 4, &addr, NULL, NULL);
+int main(int argc, char *argv[] )
+{
+   int errors_found=0;
+   memory_space *mem = new memory_space_impl<32>("test",4);
+   // write address to [address]
+   for( mem_addr_t addr=0; addr < 16*1024; addr+=4) 
+      mem->write(addr,4,&addr,NULL,NULL);
 
-  for (mem_addr_t addr = 0; addr < 16 * 1024; addr += 4) {
-    unsigned tmp = 0;
-    mem->read(addr, 4, &tmp);
-    if (tmp != addr) {
-      errors_found = 1;
-      printf("ERROR ** mem[0x%x] = 0x%x, expected 0x%x\n", addr, tmp, addr);
-    }
-  }
+   for( mem_addr_t addr=0; addr < 16*1024; addr+=4) {
+      unsigned tmp=0;
+      mem->read(addr,4,&tmp);
+      if( tmp != addr ) {
+         errors_found=1;
+         printf("ERROR ** mem[0x%x] = 0x%x, expected 0x%x\n", addr, tmp, addr );
+      }
+   }
 
-  for (mem_addr_t addr = 0; addr < 16 * 1024; addr += 1) {
-    unsigned char val = (addr + 128) % 256;
-    mem->write(addr, 1, &val, NULL, NULL);
-  }
+   for( mem_addr_t addr=0; addr < 16*1024; addr+=1) {
+      unsigned char val = (addr + 128) % 256;
+      mem->write(addr,1,&val,NULL,NULL);
+   }
 
-  for (mem_addr_t addr = 0; addr < 16 * 1024; addr += 1) {
-    unsigned tmp = 0;
-    mem->read(addr, 1, &tmp);
-    unsigned char val = (addr + 128) % 256;
-    if (tmp != val) {
-      errors_found = 1;
-      printf("ERROR ** mem[0x%x] = 0x%x, expected 0x%x\n", addr, tmp,
-             (unsigned)val);
-    }
-  }
+   for( mem_addr_t addr=0; addr < 16*1024; addr+=1) {
+      unsigned tmp=0;
+      mem->read(addr,1,&tmp);
+      unsigned char val = (addr + 128) % 256;
+      if( tmp != val ) {
+         errors_found=1;
+         printf("ERROR ** mem[0x%x] = 0x%x, expected 0x%x\n", addr, tmp, (unsigned)val );
+      }
+   }
 
-  if (errors_found) {
-    printf("SUMMARY:  ERRORS FOUND\n");
-  } else {
-    printf("SUMMARY: UNIT TEST PASSED\n");
-  }
+   if( errors_found ) {
+      printf("SUMMARY:  ERRORS FOUND\n");
+   } else {
+      printf("SUMMARY: UNIT TEST PASSED\n");
+   }
 }
 
 #endif

--- a/src/cuda-sim/memory.cc
+++ b/src/cuda-sim/memory.cc
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -27,190 +29,206 @@
 
 #include "memory.h"
 #include <stdlib.h>
-#include "../debug.h"
 #include "../../libcuda/gpgpu_context.h"
+#include "../debug.h"
 
-template<unsigned BSIZE> memory_space_impl<BSIZE>::memory_space_impl( std::string name, unsigned hash_size )
-{
-   m_name = name;
-   MEM_MAP_RESIZE(hash_size);
+template <unsigned BSIZE>
+memory_space_impl<BSIZE>::memory_space_impl(std::string name,
+                                            unsigned hash_size) {
+  m_name = name;
+  MEM_MAP_RESIZE(hash_size);
 
-   m_log2_block_size = -1;
-   for( unsigned n=0, mask=1; mask != 0; mask <<= 1, n++ ) {
-      if( BSIZE & mask ) {
-         assert( m_log2_block_size == (unsigned)-1 );
-         m_log2_block_size = n; 
+  m_log2_block_size = -1;
+  for (unsigned n = 0, mask = 1; mask != 0; mask <<= 1, n++) {
+    if (BSIZE & mask) {
+      assert(m_log2_block_size == (unsigned)-1);
+      m_log2_block_size = n;
+    }
+  }
+  assert(m_log2_block_size != (unsigned)-1);
+}
+
+template <unsigned BSIZE>
+void memory_space_impl<BSIZE>::write_only(mem_addr_t offset, mem_addr_t index,
+                                          size_t length, const void *data) {
+  m_data[index].write(offset, length, (const unsigned char *)data);
+}
+
+template <unsigned BSIZE>
+void memory_space_impl<BSIZE>::write(mem_addr_t addr, size_t length,
+                                     const void *data,
+                                     class ptx_thread_info *thd,
+                                     const ptx_instruction *pI) {
+  mem_addr_t index = addr >> m_log2_block_size;
+
+  if ((addr + length) <= (index + 1) * BSIZE) {
+    // fast route for intra-block access
+    unsigned offset = addr & (BSIZE - 1);
+    unsigned nbytes = length;
+    m_data[index].write(offset, nbytes, (const unsigned char *)data);
+  } else {
+    // slow route for inter-block access
+    unsigned nbytes_remain = length;
+    unsigned src_offset = 0;
+    mem_addr_t current_addr = addr;
+
+    while (nbytes_remain > 0) {
+      unsigned offset = current_addr & (BSIZE - 1);
+      mem_addr_t page = current_addr >> m_log2_block_size;
+      mem_addr_t access_limit = offset + nbytes_remain;
+      if (access_limit > BSIZE) {
+        access_limit = BSIZE;
       }
-   }
-   assert( m_log2_block_size != (unsigned)-1 );
+
+      size_t tx_bytes = access_limit - offset;
+      m_data[page].write(offset, tx_bytes,
+                         &((const unsigned char *)data)[src_offset]);
+
+      // advance pointers
+      src_offset += tx_bytes;
+      current_addr += tx_bytes;
+      nbytes_remain -= tx_bytes;
+    }
+    assert(nbytes_remain == 0);
+  }
+  if (!m_watchpoints.empty()) {
+    std::map<unsigned, mem_addr_t>::iterator i;
+    for (i = m_watchpoints.begin(); i != m_watchpoints.end(); i++) {
+      mem_addr_t wa = i->second;
+      if (((addr <= wa) && ((addr + length) > wa)) ||
+          ((addr > wa) && (addr < (wa + 4))))
+        thd->get_gpu()->gpgpu_ctx->the_gpgpusim->g_the_gpu->hit_watchpoint(
+            i->first, thd, pI);
+    }
+  }
 }
 
-template<unsigned BSIZE> void memory_space_impl<BSIZE>::write_only( mem_addr_t offset, mem_addr_t index, size_t length, const void *data)
-{
-   m_data[index].write(offset,length,(const unsigned char*)data);
+template <unsigned BSIZE>
+void memory_space_impl<BSIZE>::read_single_block(mem_addr_t blk_idx,
+                                                 mem_addr_t addr, size_t length,
+                                                 void *data) const {
+  if ((addr + length) > (blk_idx + 1) * BSIZE) {
+    printf(
+        "GPGPU-Sim PTX: ERROR * access to memory \'%s\' is unaligned : "
+        "addr=0x%x, length=%zu\n",
+        m_name.c_str(), addr, length);
+    printf(
+        "GPGPU-Sim PTX: (addr+length)=0x%lx > 0x%x=(index+1)*BSIZE, "
+        "index=0x%x, BSIZE=0x%x\n",
+        (addr + length), (blk_idx + 1) * BSIZE, blk_idx, BSIZE);
+    throw 1;
+  }
+  typename map_t::const_iterator i = m_data.find(blk_idx);
+  if (i == m_data.end()) {
+    for (size_t n = 0; n < length; n++)
+      ((unsigned char *)data)[n] = (unsigned char)0;
+    // printf("GPGPU-Sim PTX:  WARNING reading %zu bytes from unititialized
+    // memory at address 0x%x in space %s\n", length, addr, m_name.c_str() );
+  } else {
+    unsigned offset = addr & (BSIZE - 1);
+    unsigned nbytes = length;
+    i->second.read(offset, nbytes, (unsigned char *)data);
+  }
 }
 
-template<unsigned BSIZE> void memory_space_impl<BSIZE>::write( mem_addr_t addr, size_t length, const void *data, class ptx_thread_info *thd, const ptx_instruction *pI)
-{
+template <unsigned BSIZE>
+void memory_space_impl<BSIZE>::read(mem_addr_t addr, size_t length,
+                                    void *data) const {
+  mem_addr_t index = addr >> m_log2_block_size;
+  if ((addr + length) <= (index + 1) * BSIZE) {
+    // fast route for intra-block access
+    read_single_block(index, addr, length, data);
+  } else {
+    // slow route for inter-block access
+    unsigned nbytes_remain = length;
+    unsigned dst_offset = 0;
+    mem_addr_t current_addr = addr;
 
-   mem_addr_t index = addr >> m_log2_block_size;
-
-   if ( (addr+length) <= (index+1)*BSIZE ) {
-      // fast route for intra-block access 
-      unsigned offset = addr & (BSIZE-1);
-      unsigned nbytes = length;
-      m_data[index].write(offset,nbytes,(const unsigned char*)data);
-   } else {
-      // slow route for inter-block access
-      unsigned nbytes_remain = length;
-      unsigned src_offset = 0; 
-      mem_addr_t current_addr = addr; 
-
-      while (nbytes_remain > 0) {
-         unsigned offset = current_addr & (BSIZE-1);
-         mem_addr_t page = current_addr >> m_log2_block_size; 
-         mem_addr_t access_limit = offset + nbytes_remain; 
-         if (access_limit > BSIZE) {
-            access_limit = BSIZE;
-         } 
-         
-         size_t tx_bytes = access_limit - offset; 
-         m_data[page].write(offset, tx_bytes, &((const unsigned char*)data)[src_offset]);
-
-         // advance pointers 
-         src_offset += tx_bytes; 
-         current_addr += tx_bytes; 
-         nbytes_remain -= tx_bytes; 
+    while (nbytes_remain > 0) {
+      unsigned offset = current_addr & (BSIZE - 1);
+      mem_addr_t page = current_addr >> m_log2_block_size;
+      mem_addr_t access_limit = offset + nbytes_remain;
+      if (access_limit > BSIZE) {
+        access_limit = BSIZE;
       }
-      assert(nbytes_remain == 0); 
-   }
-   if( !m_watchpoints.empty() ) {
-      std::map<unsigned,mem_addr_t>::iterator i;
-      for( i=m_watchpoints.begin(); i!=m_watchpoints.end(); i++ ) {
-         mem_addr_t wa = i->second;
-         if( ((addr<=wa) && ((addr+length)>wa)) || ((addr>wa) && (addr < (wa+4))) ) 
-            thd->get_gpu()->gpgpu_ctx->the_gpgpusim->g_the_gpu->hit_watchpoint(i->first,thd,pI);
-      }
-   }
+
+      size_t tx_bytes = access_limit - offset;
+      read_single_block(page, current_addr, tx_bytes,
+                        &((unsigned char *)data)[dst_offset]);
+
+      // advance pointers
+      dst_offset += tx_bytes;
+      current_addr += tx_bytes;
+      nbytes_remain -= tx_bytes;
+    }
+    assert(nbytes_remain == 0);
+  }
 }
 
-template<unsigned BSIZE> void memory_space_impl<BSIZE>::read_single_block( mem_addr_t blk_idx, mem_addr_t addr, size_t length, void *data) const
-{
-   if ((addr + length) > (blk_idx + 1) * BSIZE) {
-      printf("GPGPU-Sim PTX: ERROR * access to memory \'%s\' is unaligned : addr=0x%x, length=%zu\n",
-             m_name.c_str(), addr, length);
-      printf("GPGPU-Sim PTX: (addr+length)=0x%lx > 0x%x=(index+1)*BSIZE, index=0x%x, BSIZE=0x%x\n",
-             (addr+length),(blk_idx+1)*BSIZE, blk_idx, BSIZE);
-      throw 1;
-   }
-   typename map_t::const_iterator i = m_data.find(blk_idx);
-   if( i == m_data.end() ) {
-      for( size_t n=0; n < length; n++ ) 
-         ((unsigned char*)data)[n] = (unsigned char) 0;
-      //printf("GPGPU-Sim PTX:  WARNING reading %zu bytes from unititialized memory at address 0x%x in space %s\n", length, addr, m_name.c_str() );
-   } else {
-      unsigned offset = addr & (BSIZE-1);
-      unsigned nbytes = length;
-      i->second.read(offset,nbytes,(unsigned char*)data);
-   }
+template <unsigned BSIZE>
+void memory_space_impl<BSIZE>::print(const char *format, FILE *fout) const {
+  typename map_t::const_iterator i_page;
+
+  for (i_page = m_data.begin(); i_page != m_data.end(); ++i_page) {
+    fprintf(fout, "%s %08x:", m_name.c_str(), i_page->first);
+    i_page->second.print(format, fout);
+  }
 }
 
-template<unsigned BSIZE> void memory_space_impl<BSIZE>::read( mem_addr_t addr, size_t length, void *data ) const
-{
-   mem_addr_t index = addr >> m_log2_block_size;
-   if ((addr+length) <= (index+1)*BSIZE ) {
-      // fast route for intra-block access 
-      read_single_block(index, addr, length, data); 
-   } else {
-      // slow route for inter-block access 
-      unsigned nbytes_remain = length;
-      unsigned dst_offset = 0; 
-      mem_addr_t current_addr = addr; 
-
-      while (nbytes_remain > 0) {
-         unsigned offset = current_addr & (BSIZE-1);
-         mem_addr_t page = current_addr >> m_log2_block_size; 
-         mem_addr_t access_limit = offset + nbytes_remain; 
-         if (access_limit > BSIZE) {
-            access_limit = BSIZE;
-         } 
-         
-         size_t tx_bytes = access_limit - offset; 
-         read_single_block(page, current_addr, tx_bytes, &((unsigned char*)data)[dst_offset]); 
-
-         // advance pointers 
-         dst_offset += tx_bytes; 
-         current_addr += tx_bytes; 
-         nbytes_remain -= tx_bytes; 
-      }
-      assert(nbytes_remain == 0); 
-   }
-}
-
-template<unsigned BSIZE> void memory_space_impl<BSIZE>::print( const char *format, FILE *fout ) const
-{
-   typename map_t::const_iterator i_page;
-
-   for ( i_page = m_data.begin(); i_page != m_data.end(); ++i_page) {
-      fprintf(fout, "%s %08x:", m_name.c_str(), i_page->first);
-      i_page->second.print(format, fout);
-   }
-}
-
-template<unsigned BSIZE> void memory_space_impl<BSIZE>::set_watch( addr_t addr, unsigned watchpoint ) 
-{
-   m_watchpoints[watchpoint]=addr;
+template <unsigned BSIZE>
+void memory_space_impl<BSIZE>::set_watch(addr_t addr, unsigned watchpoint) {
+  m_watchpoints[watchpoint] = addr;
 }
 
 template class memory_space_impl<32>;
 template class memory_space_impl<64>;
 template class memory_space_impl<8192>;
-template class memory_space_impl<16*1024>;
+template class memory_space_impl<16 * 1024>;
 
-void g_print_memory_space(memory_space *mem, const char *format = "%08x", FILE *fout = stdout) 
-{
-    mem->print(format,fout);
+void g_print_memory_space(memory_space *mem, const char *format = "%08x",
+                          FILE *fout = stdout) {
+  mem->print(format, fout);
 }
 
 #ifdef UNIT_TEST
 
-int main(int argc, char *argv[] )
-{
-   int errors_found=0;
-   memory_space *mem = new memory_space_impl<32>("test",4);
-   // write address to [address]
-   for( mem_addr_t addr=0; addr < 16*1024; addr+=4) 
-      mem->write(addr,4,&addr,NULL,NULL);
+int main(int argc, char *argv[]) {
+  int errors_found = 0;
+  memory_space *mem = new memory_space_impl<32>("test", 4);
+  // write address to [address]
+  for (mem_addr_t addr = 0; addr < 16 * 1024; addr += 4)
+    mem->write(addr, 4, &addr, NULL, NULL);
 
-   for( mem_addr_t addr=0; addr < 16*1024; addr+=4) {
-      unsigned tmp=0;
-      mem->read(addr,4,&tmp);
-      if( tmp != addr ) {
-         errors_found=1;
-         printf("ERROR ** mem[0x%x] = 0x%x, expected 0x%x\n", addr, tmp, addr );
-      }
-   }
+  for (mem_addr_t addr = 0; addr < 16 * 1024; addr += 4) {
+    unsigned tmp = 0;
+    mem->read(addr, 4, &tmp);
+    if (tmp != addr) {
+      errors_found = 1;
+      printf("ERROR ** mem[0x%x] = 0x%x, expected 0x%x\n", addr, tmp, addr);
+    }
+  }
 
-   for( mem_addr_t addr=0; addr < 16*1024; addr+=1) {
-      unsigned char val = (addr + 128) % 256;
-      mem->write(addr,1,&val,NULL,NULL);
-   }
+  for (mem_addr_t addr = 0; addr < 16 * 1024; addr += 1) {
+    unsigned char val = (addr + 128) % 256;
+    mem->write(addr, 1, &val, NULL, NULL);
+  }
 
-   for( mem_addr_t addr=0; addr < 16*1024; addr+=1) {
-      unsigned tmp=0;
-      mem->read(addr,1,&tmp);
-      unsigned char val = (addr + 128) % 256;
-      if( tmp != val ) {
-         errors_found=1;
-         printf("ERROR ** mem[0x%x] = 0x%x, expected 0x%x\n", addr, tmp, (unsigned)val );
-      }
-   }
+  for (mem_addr_t addr = 0; addr < 16 * 1024; addr += 1) {
+    unsigned tmp = 0;
+    mem->read(addr, 1, &tmp);
+    unsigned char val = (addr + 128) % 256;
+    if (tmp != val) {
+      errors_found = 1;
+      printf("ERROR ** mem[0x%x] = 0x%x, expected 0x%x\n", addr, tmp,
+             (unsigned)val);
+    }
+  }
 
-   if( errors_found ) {
-      printf("SUMMARY:  ERRORS FOUND\n");
-   } else {
-      printf("SUMMARY: UNIT TEST PASSED\n");
-   }
+  if (errors_found) {
+    printf("SUMMARY:  ERRORS FOUND\n");
+  } else {
+    printf("SUMMARY: UNIT TEST PASSED\n");
+  }
 }
 
 #endif

--- a/src/cuda-sim/memory.h
+++ b/src/cuda-sim/memory.h
@@ -7,23 +7,24 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef memory_h_INCLUDED
 #define memory_h_INCLUDED
@@ -33,101 +34,97 @@
 #include "../tr1_hash_map.h"
 #define mem_map tr1_hash_map
 #if tr1_hash_map_ismap == 1
-   #define MEM_MAP_RESIZE(hash_size) 
+#define MEM_MAP_RESIZE(hash_size)
 #else
-   #define MEM_MAP_RESIZE(hash_size) (m_data.rehash(hash_size))
+#define MEM_MAP_RESIZE(hash_size) (m_data.rehash(hash_size))
 #endif
 
 #include <assert.h>
-#include <string.h>
 #include <stdio.h>
-#include <string>
-#include <map>
 #include <stdlib.h>
+#include <string.h>
+#include <map>
+#include <string>
 
 typedef address_type mem_addr_t;
 
-#define MEM_BLOCK_SIZE (4*1024)
+#define MEM_BLOCK_SIZE (4 * 1024)
 
-template<unsigned BSIZE> class mem_storage {
-public:
-   mem_storage( const mem_storage &another )
-   {
-      m_data = (unsigned char*)calloc(1,BSIZE);
-      memcpy(m_data,another.m_data,BSIZE);
-   }
-   mem_storage()
-   {
-      m_data = (unsigned char*)calloc(1,BSIZE);
-   }
-   ~mem_storage()
-   {
-      free(m_data);
-   }
+template <unsigned BSIZE>
+class mem_storage {
+ public:
+  mem_storage(const mem_storage &another) {
+    m_data = (unsigned char *)calloc(1, BSIZE);
+    memcpy(m_data, another.m_data, BSIZE);
+  }
+  mem_storage() { m_data = (unsigned char *)calloc(1, BSIZE); }
+  ~mem_storage() { free(m_data); }
 
-   void write( unsigned offset, size_t length, const unsigned char *data )
-   {
-      assert( offset + length <= BSIZE );
-      memcpy(m_data+offset,data,length);
-   }
+  void write(unsigned offset, size_t length, const unsigned char *data) {
+    assert(offset + length <= BSIZE);
+    memcpy(m_data + offset, data, length);
+  }
 
-   void read( unsigned offset, size_t length, unsigned char *data ) const
-   {
-      assert( offset + length <= BSIZE );
-      memcpy(data,m_data+offset,length);
-   }
+  void read(unsigned offset, size_t length, unsigned char *data) const {
+    assert(offset + length <= BSIZE);
+    memcpy(data, m_data + offset, length);
+  }
 
-   void print( const char *format, FILE *fout ) const
-   {
-      unsigned int *i_data = (unsigned int*)m_data;
-      for (int d = 0; d < (BSIZE / sizeof(unsigned int)); d++) {
-         if (d % 1 == 0) {
-            fprintf(fout, "\n");
-         }
-         fprintf(fout, format, i_data[d]);
-         fprintf(fout, " ");
+  void print(const char *format, FILE *fout) const {
+    unsigned int *i_data = (unsigned int *)m_data;
+    for (int d = 0; d < (BSIZE / sizeof(unsigned int)); d++) {
+      if (d % 1 == 0) {
+        fprintf(fout, "\n");
       }
-      fprintf(fout, "\n");
-      fflush(fout);
-   }
+      fprintf(fout, format, i_data[d]);
+      fprintf(fout, " ");
+    }
+    fprintf(fout, "\n");
+    fflush(fout);
+  }
 
-private:
-   unsigned m_nbytes;
-   unsigned char *m_data;
+ private:
+  unsigned m_nbytes;
+  unsigned char *m_data;
 };
 
 class ptx_thread_info;
 class ptx_instruction;
 
-class memory_space
-{
-public:
-   virtual ~memory_space() {}
-   virtual void write( mem_addr_t addr, size_t length, const void *data, ptx_thread_info *thd, const ptx_instruction *pI ) = 0;
-   virtual void write_only( mem_addr_t index, mem_addr_t offset,  size_t length, const void *data ) = 0;
-   virtual void read( mem_addr_t addr, size_t length, void *data ) const = 0;
-   virtual void print( const char *format, FILE *fout ) const = 0;
-   virtual void set_watch( addr_t addr, unsigned watchpoint ) = 0;
+class memory_space {
+ public:
+  virtual ~memory_space() {}
+  virtual void write(mem_addr_t addr, size_t length, const void *data,
+                     ptx_thread_info *thd, const ptx_instruction *pI) = 0;
+  virtual void write_only(mem_addr_t index, mem_addr_t offset, size_t length,
+                          const void *data) = 0;
+  virtual void read(mem_addr_t addr, size_t length, void *data) const = 0;
+  virtual void print(const char *format, FILE *fout) const = 0;
+  virtual void set_watch(addr_t addr, unsigned watchpoint) = 0;
 };
 
-template<unsigned BSIZE> class memory_space_impl : public memory_space {
-public:
-   memory_space_impl( std::string name, unsigned hash_size );
+template <unsigned BSIZE>
+class memory_space_impl : public memory_space {
+ public:
+  memory_space_impl(std::string name, unsigned hash_size);
 
-   virtual void write( mem_addr_t addr, size_t length, const void *data, ptx_thread_info *thd, const ptx_instruction *pI );
-   virtual void write_only( mem_addr_t index, mem_addr_t offset, size_t length, const void *data);
-   virtual void read( mem_addr_t addr, size_t length, void *data ) const;
-   virtual void print( const char *format, FILE *fout ) const;
-   
-   virtual void set_watch( addr_t addr, unsigned watchpoint ); 
+  virtual void write(mem_addr_t addr, size_t length, const void *data,
+                     ptx_thread_info *thd, const ptx_instruction *pI);
+  virtual void write_only(mem_addr_t index, mem_addr_t offset, size_t length,
+                          const void *data);
+  virtual void read(mem_addr_t addr, size_t length, void *data) const;
+  virtual void print(const char *format, FILE *fout) const;
 
-private:
-   void read_single_block( mem_addr_t blk_idx, mem_addr_t addr, size_t length, void *data) const; 
-   std::string m_name;
-   unsigned m_log2_block_size;
-   typedef mem_map<mem_addr_t,mem_storage<BSIZE> > map_t;
-   map_t m_data;
-   std::map<unsigned,mem_addr_t> m_watchpoints;
+  virtual void set_watch(addr_t addr, unsigned watchpoint);
+
+ private:
+  void read_single_block(mem_addr_t blk_idx, mem_addr_t addr, size_t length,
+                         void *data) const;
+  std::string m_name;
+  unsigned m_log2_block_size;
+  typedef mem_map<mem_addr_t, mem_storage<BSIZE> > map_t;
+  map_t m_data;
+  std::map<unsigned, mem_addr_t> m_watchpoints;
 };
 
 #endif

--- a/src/cuda-sim/memory.h
+++ b/src/cuda-sim/memory.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -35,97 +33,101 @@
 #include "../tr1_hash_map.h"
 #define mem_map tr1_hash_map
 #if tr1_hash_map_ismap == 1
-#define MEM_MAP_RESIZE(hash_size)
+   #define MEM_MAP_RESIZE(hash_size) 
 #else
-#define MEM_MAP_RESIZE(hash_size) (m_data.rehash(hash_size))
+   #define MEM_MAP_RESIZE(hash_size) (m_data.rehash(hash_size))
 #endif
 
 #include <assert.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
-#include <map>
+#include <stdio.h>
 #include <string>
+#include <map>
+#include <stdlib.h>
 
 typedef address_type mem_addr_t;
 
-#define MEM_BLOCK_SIZE (4 * 1024)
+#define MEM_BLOCK_SIZE (4*1024)
 
-template <unsigned BSIZE>
-class mem_storage {
- public:
-  mem_storage(const mem_storage &another) {
-    m_data = (unsigned char *)calloc(1, BSIZE);
-    memcpy(m_data, another.m_data, BSIZE);
-  }
-  mem_storage() { m_data = (unsigned char *)calloc(1, BSIZE); }
-  ~mem_storage() { free(m_data); }
+template<unsigned BSIZE> class mem_storage {
+public:
+   mem_storage( const mem_storage &another )
+   {
+      m_data = (unsigned char*)calloc(1,BSIZE);
+      memcpy(m_data,another.m_data,BSIZE);
+   }
+   mem_storage()
+   {
+      m_data = (unsigned char*)calloc(1,BSIZE);
+   }
+   ~mem_storage()
+   {
+      free(m_data);
+   }
 
-  void write(unsigned offset, size_t length, const unsigned char *data) {
-    assert(offset + length <= BSIZE);
-    memcpy(m_data + offset, data, length);
-  }
+   void write( unsigned offset, size_t length, const unsigned char *data )
+   {
+      assert( offset + length <= BSIZE );
+      memcpy(m_data+offset,data,length);
+   }
 
-  void read(unsigned offset, size_t length, unsigned char *data) const {
-    assert(offset + length <= BSIZE);
-    memcpy(data, m_data + offset, length);
-  }
+   void read( unsigned offset, size_t length, unsigned char *data ) const
+   {
+      assert( offset + length <= BSIZE );
+      memcpy(data,m_data+offset,length);
+   }
 
-  void print(const char *format, FILE *fout) const {
-    unsigned int *i_data = (unsigned int *)m_data;
-    for (int d = 0; d < (BSIZE / sizeof(unsigned int)); d++) {
-      if (d % 1 == 0) {
-        fprintf(fout, "\n");
+   void print( const char *format, FILE *fout ) const
+   {
+      unsigned int *i_data = (unsigned int*)m_data;
+      for (int d = 0; d < (BSIZE / sizeof(unsigned int)); d++) {
+         if (d % 1 == 0) {
+            fprintf(fout, "\n");
+         }
+         fprintf(fout, format, i_data[d]);
+         fprintf(fout, " ");
       }
-      fprintf(fout, format, i_data[d]);
-      fprintf(fout, " ");
-    }
-    fprintf(fout, "\n");
-    fflush(fout);
-  }
+      fprintf(fout, "\n");
+      fflush(fout);
+   }
 
- private:
-  unsigned m_nbytes;
-  unsigned char *m_data;
+private:
+   unsigned m_nbytes;
+   unsigned char *m_data;
 };
 
 class ptx_thread_info;
 class ptx_instruction;
 
-class memory_space {
- public:
-  virtual ~memory_space() {}
-  virtual void write(mem_addr_t addr, size_t length, const void *data,
-                     ptx_thread_info *thd, const ptx_instruction *pI) = 0;
-  virtual void write_only(mem_addr_t index, mem_addr_t offset, size_t length,
-                          const void *data) = 0;
-  virtual void read(mem_addr_t addr, size_t length, void *data) const = 0;
-  virtual void print(const char *format, FILE *fout) const = 0;
-  virtual void set_watch(addr_t addr, unsigned watchpoint) = 0;
+class memory_space
+{
+public:
+   virtual ~memory_space() {}
+   virtual void write( mem_addr_t addr, size_t length, const void *data, ptx_thread_info *thd, const ptx_instruction *pI ) = 0;
+   virtual void write_only( mem_addr_t index, mem_addr_t offset,  size_t length, const void *data ) = 0;
+   virtual void read( mem_addr_t addr, size_t length, void *data ) const = 0;
+   virtual void print( const char *format, FILE *fout ) const = 0;
+   virtual void set_watch( addr_t addr, unsigned watchpoint ) = 0;
 };
 
-template <unsigned BSIZE>
-class memory_space_impl : public memory_space {
- public:
-  memory_space_impl(std::string name, unsigned hash_size);
+template<unsigned BSIZE> class memory_space_impl : public memory_space {
+public:
+   memory_space_impl( std::string name, unsigned hash_size );
 
-  virtual void write(mem_addr_t addr, size_t length, const void *data,
-                     ptx_thread_info *thd, const ptx_instruction *pI);
-  virtual void write_only(mem_addr_t index, mem_addr_t offset, size_t length,
-                          const void *data);
-  virtual void read(mem_addr_t addr, size_t length, void *data) const;
-  virtual void print(const char *format, FILE *fout) const;
+   virtual void write( mem_addr_t addr, size_t length, const void *data, ptx_thread_info *thd, const ptx_instruction *pI );
+   virtual void write_only( mem_addr_t index, mem_addr_t offset, size_t length, const void *data);
+   virtual void read( mem_addr_t addr, size_t length, void *data ) const;
+   virtual void print( const char *format, FILE *fout ) const;
+   
+   virtual void set_watch( addr_t addr, unsigned watchpoint ); 
 
-  virtual void set_watch(addr_t addr, unsigned watchpoint);
-
- private:
-  void read_single_block(mem_addr_t blk_idx, mem_addr_t addr, size_t length,
-                         void *data) const;
-  std::string m_name;
-  unsigned m_log2_block_size;
-  typedef mem_map<mem_addr_t, mem_storage<BSIZE> > map_t;
-  map_t m_data;
-  std::map<unsigned, mem_addr_t> m_watchpoints;
+private:
+   void read_single_block( mem_addr_t blk_idx, mem_addr_t addr, size_t length, void *data) const; 
+   std::string m_name;
+   unsigned m_log2_block_size;
+   typedef mem_map<mem_addr_t,mem_storage<BSIZE> > map_t;
+   map_t m_data;
+   std::map<unsigned,mem_addr_t> m_watchpoints;
 };
 
 #endif

--- a/src/cuda-sim/memory.h
+++ b/src/cuda-sim/memory.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -33,101 +35,97 @@
 #include "../tr1_hash_map.h"
 #define mem_map tr1_hash_map
 #if tr1_hash_map_ismap == 1
-   #define MEM_MAP_RESIZE(hash_size) 
+#define MEM_MAP_RESIZE(hash_size)
 #else
-   #define MEM_MAP_RESIZE(hash_size) (m_data.rehash(hash_size))
+#define MEM_MAP_RESIZE(hash_size) (m_data.rehash(hash_size))
 #endif
 
 #include <assert.h>
-#include <string.h>
 #include <stdio.h>
-#include <string>
-#include <map>
 #include <stdlib.h>
+#include <string.h>
+#include <map>
+#include <string>
 
 typedef address_type mem_addr_t;
 
-#define MEM_BLOCK_SIZE (4*1024)
+#define MEM_BLOCK_SIZE (4 * 1024)
 
-template<unsigned BSIZE> class mem_storage {
-public:
-   mem_storage( const mem_storage &another )
-   {
-      m_data = (unsigned char*)calloc(1,BSIZE);
-      memcpy(m_data,another.m_data,BSIZE);
-   }
-   mem_storage()
-   {
-      m_data = (unsigned char*)calloc(1,BSIZE);
-   }
-   ~mem_storage()
-   {
-      free(m_data);
-   }
+template <unsigned BSIZE>
+class mem_storage {
+ public:
+  mem_storage(const mem_storage &another) {
+    m_data = (unsigned char *)calloc(1, BSIZE);
+    memcpy(m_data, another.m_data, BSIZE);
+  }
+  mem_storage() { m_data = (unsigned char *)calloc(1, BSIZE); }
+  ~mem_storage() { free(m_data); }
 
-   void write( unsigned offset, size_t length, const unsigned char *data )
-   {
-      assert( offset + length <= BSIZE );
-      memcpy(m_data+offset,data,length);
-   }
+  void write(unsigned offset, size_t length, const unsigned char *data) {
+    assert(offset + length <= BSIZE);
+    memcpy(m_data + offset, data, length);
+  }
 
-   void read( unsigned offset, size_t length, unsigned char *data ) const
-   {
-      assert( offset + length <= BSIZE );
-      memcpy(data,m_data+offset,length);
-   }
+  void read(unsigned offset, size_t length, unsigned char *data) const {
+    assert(offset + length <= BSIZE);
+    memcpy(data, m_data + offset, length);
+  }
 
-   void print( const char *format, FILE *fout ) const
-   {
-      unsigned int *i_data = (unsigned int*)m_data;
-      for (int d = 0; d < (BSIZE / sizeof(unsigned int)); d++) {
-         if (d % 1 == 0) {
-            fprintf(fout, "\n");
-         }
-         fprintf(fout, format, i_data[d]);
-         fprintf(fout, " ");
+  void print(const char *format, FILE *fout) const {
+    unsigned int *i_data = (unsigned int *)m_data;
+    for (int d = 0; d < (BSIZE / sizeof(unsigned int)); d++) {
+      if (d % 1 == 0) {
+        fprintf(fout, "\n");
       }
-      fprintf(fout, "\n");
-      fflush(fout);
-   }
+      fprintf(fout, format, i_data[d]);
+      fprintf(fout, " ");
+    }
+    fprintf(fout, "\n");
+    fflush(fout);
+  }
 
-private:
-   unsigned m_nbytes;
-   unsigned char *m_data;
+ private:
+  unsigned m_nbytes;
+  unsigned char *m_data;
 };
 
 class ptx_thread_info;
 class ptx_instruction;
 
-class memory_space
-{
-public:
-   virtual ~memory_space() {}
-   virtual void write( mem_addr_t addr, size_t length, const void *data, ptx_thread_info *thd, const ptx_instruction *pI ) = 0;
-   virtual void write_only( mem_addr_t index, mem_addr_t offset,  size_t length, const void *data ) = 0;
-   virtual void read( mem_addr_t addr, size_t length, void *data ) const = 0;
-   virtual void print( const char *format, FILE *fout ) const = 0;
-   virtual void set_watch( addr_t addr, unsigned watchpoint ) = 0;
+class memory_space {
+ public:
+  virtual ~memory_space() {}
+  virtual void write(mem_addr_t addr, size_t length, const void *data,
+                     ptx_thread_info *thd, const ptx_instruction *pI) = 0;
+  virtual void write_only(mem_addr_t index, mem_addr_t offset, size_t length,
+                          const void *data) = 0;
+  virtual void read(mem_addr_t addr, size_t length, void *data) const = 0;
+  virtual void print(const char *format, FILE *fout) const = 0;
+  virtual void set_watch(addr_t addr, unsigned watchpoint) = 0;
 };
 
-template<unsigned BSIZE> class memory_space_impl : public memory_space {
-public:
-   memory_space_impl( std::string name, unsigned hash_size );
+template <unsigned BSIZE>
+class memory_space_impl : public memory_space {
+ public:
+  memory_space_impl(std::string name, unsigned hash_size);
 
-   virtual void write( mem_addr_t addr, size_t length, const void *data, ptx_thread_info *thd, const ptx_instruction *pI );
-   virtual void write_only( mem_addr_t index, mem_addr_t offset, size_t length, const void *data);
-   virtual void read( mem_addr_t addr, size_t length, void *data ) const;
-   virtual void print( const char *format, FILE *fout ) const;
-   
-   virtual void set_watch( addr_t addr, unsigned watchpoint ); 
+  virtual void write(mem_addr_t addr, size_t length, const void *data,
+                     ptx_thread_info *thd, const ptx_instruction *pI);
+  virtual void write_only(mem_addr_t index, mem_addr_t offset, size_t length,
+                          const void *data);
+  virtual void read(mem_addr_t addr, size_t length, void *data) const;
+  virtual void print(const char *format, FILE *fout) const;
 
-private:
-   void read_single_block( mem_addr_t blk_idx, mem_addr_t addr, size_t length, void *data) const; 
-   std::string m_name;
-   unsigned m_log2_block_size;
-   typedef mem_map<mem_addr_t,mem_storage<BSIZE> > map_t;
-   map_t m_data;
-   std::map<unsigned,mem_addr_t> m_watchpoints;
+  virtual void set_watch(addr_t addr, unsigned watchpoint);
+
+ private:
+  void read_single_block(mem_addr_t blk_idx, mem_addr_t addr, size_t length,
+                         void *data) const;
+  std::string m_name;
+  unsigned m_log2_block_size;
+  typedef mem_map<mem_addr_t, mem_storage<BSIZE> > map_t;
+  map_t m_data;
+  std::map<unsigned, mem_addr_t> m_watchpoints;
 };
 
 #endif

--- a/src/cuda-sim/opcodes.h
+++ b/src/cuda-sim/opcodes.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -29,49 +31,48 @@
 #define opcodes_h_included
 
 enum opcode_t {
-#define OP_DEF(OP,FUNC,STR,DST,CLASSIFICATION) OP,
-#define OP_W_DEF(OP,FUNC,STR,DST,CLASSIFICATION) OP,
+#define OP_DEF(OP, FUNC, STR, DST, CLASSIFICATION) OP,
+#define OP_W_DEF(OP, FUNC, STR, DST, CLASSIFICATION) OP,
 #include "opcodes.def"
-	NUM_OPCODES
+  NUM_OPCODES
 #undef OP_DEF
 #undef OP_W_DEF
 };
 
 enum special_regs {
-   CLOCK_REG,
-   HALFCLOCK_ID,
-   CLOCK64_REG,
-   CTAID_REG,
-   ENVREG_REG,
-   GRIDID_REG,
-   LANEID_REG,
-   LANEMASK_EQ_REG,
-   LANEMASK_LE_REG,
-   LANEMASK_LT_REG,
-   LANEMASK_GE_REG,
-   LANEMASK_GT_REG,
-   NCTAID_REG,
-   NTID_REG,
-   NSMID_REG,
-   NWARPID_REG,
-   PM_REG,
-   SMID_REG,
-   TID_REG,
-   WARPID_REG,
-   WARPSZ_REG
+  CLOCK_REG,
+  HALFCLOCK_ID,
+  CLOCK64_REG,
+  CTAID_REG,
+  ENVREG_REG,
+  GRIDID_REG,
+  LANEID_REG,
+  LANEMASK_EQ_REG,
+  LANEMASK_LE_REG,
+  LANEMASK_LT_REG,
+  LANEMASK_GE_REG,
+  LANEMASK_GT_REG,
+  NCTAID_REG,
+  NTID_REG,
+  NSMID_REG,
+  NWARPID_REG,
+  PM_REG,
+  SMID_REG,
+  TID_REG,
+  WARPID_REG,
+  WARPSZ_REG
 };
-enum wmma_type{
-	LOAD_A,
-	LOAD_B,
-	LOAD_C,
-	STORE_D,
-	MMA,
-	ROW,
-	COL,
-	M16N16K16,
-	M32N8K16,
-	M8N32K16
-
+enum wmma_type {
+  LOAD_A,
+  LOAD_B,
+  LOAD_C,
+  STORE_D,
+  MMA,
+  ROW,
+  COL,
+  M16N16K16,
+  M32N8K16,
+  M8N32K16
 
 };
 #endif

--- a/src/cuda-sim/opcodes.h
+++ b/src/cuda-sim/opcodes.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -31,48 +29,49 @@
 #define opcodes_h_included
 
 enum opcode_t {
-#define OP_DEF(OP, FUNC, STR, DST, CLASSIFICATION) OP,
-#define OP_W_DEF(OP, FUNC, STR, DST, CLASSIFICATION) OP,
+#define OP_DEF(OP,FUNC,STR,DST,CLASSIFICATION) OP,
+#define OP_W_DEF(OP,FUNC,STR,DST,CLASSIFICATION) OP,
 #include "opcodes.def"
-  NUM_OPCODES
+	NUM_OPCODES
 #undef OP_DEF
 #undef OP_W_DEF
 };
 
 enum special_regs {
-  CLOCK_REG,
-  HALFCLOCK_ID,
-  CLOCK64_REG,
-  CTAID_REG,
-  ENVREG_REG,
-  GRIDID_REG,
-  LANEID_REG,
-  LANEMASK_EQ_REG,
-  LANEMASK_LE_REG,
-  LANEMASK_LT_REG,
-  LANEMASK_GE_REG,
-  LANEMASK_GT_REG,
-  NCTAID_REG,
-  NTID_REG,
-  NSMID_REG,
-  NWARPID_REG,
-  PM_REG,
-  SMID_REG,
-  TID_REG,
-  WARPID_REG,
-  WARPSZ_REG
+   CLOCK_REG,
+   HALFCLOCK_ID,
+   CLOCK64_REG,
+   CTAID_REG,
+   ENVREG_REG,
+   GRIDID_REG,
+   LANEID_REG,
+   LANEMASK_EQ_REG,
+   LANEMASK_LE_REG,
+   LANEMASK_LT_REG,
+   LANEMASK_GE_REG,
+   LANEMASK_GT_REG,
+   NCTAID_REG,
+   NTID_REG,
+   NSMID_REG,
+   NWARPID_REG,
+   PM_REG,
+   SMID_REG,
+   TID_REG,
+   WARPID_REG,
+   WARPSZ_REG
 };
-enum wmma_type {
-  LOAD_A,
-  LOAD_B,
-  LOAD_C,
-  STORE_D,
-  MMA,
-  ROW,
-  COL,
-  M16N16K16,
-  M32N8K16,
-  M8N32K16
+enum wmma_type{
+	LOAD_A,
+	LOAD_B,
+	LOAD_C,
+	STORE_D,
+	MMA,
+	ROW,
+	COL,
+	M16N16K16,
+	M32N8K16,
+	M8N32K16
+
 
 };
 #endif

--- a/src/cuda-sim/opcodes.h
+++ b/src/cuda-sim/opcodes.h
@@ -7,71 +7,71 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef opcodes_h_included
 #define opcodes_h_included
 
 enum opcode_t {
-#define OP_DEF(OP,FUNC,STR,DST,CLASSIFICATION) OP,
-#define OP_W_DEF(OP,FUNC,STR,DST,CLASSIFICATION) OP,
+#define OP_DEF(OP, FUNC, STR, DST, CLASSIFICATION) OP,
+#define OP_W_DEF(OP, FUNC, STR, DST, CLASSIFICATION) OP,
 #include "opcodes.def"
-	NUM_OPCODES
+  NUM_OPCODES
 #undef OP_DEF
 #undef OP_W_DEF
 };
 
 enum special_regs {
-   CLOCK_REG,
-   HALFCLOCK_ID,
-   CLOCK64_REG,
-   CTAID_REG,
-   ENVREG_REG,
-   GRIDID_REG,
-   LANEID_REG,
-   LANEMASK_EQ_REG,
-   LANEMASK_LE_REG,
-   LANEMASK_LT_REG,
-   LANEMASK_GE_REG,
-   LANEMASK_GT_REG,
-   NCTAID_REG,
-   NTID_REG,
-   NSMID_REG,
-   NWARPID_REG,
-   PM_REG,
-   SMID_REG,
-   TID_REG,
-   WARPID_REG,
-   WARPSZ_REG
+  CLOCK_REG,
+  HALFCLOCK_ID,
+  CLOCK64_REG,
+  CTAID_REG,
+  ENVREG_REG,
+  GRIDID_REG,
+  LANEID_REG,
+  LANEMASK_EQ_REG,
+  LANEMASK_LE_REG,
+  LANEMASK_LT_REG,
+  LANEMASK_GE_REG,
+  LANEMASK_GT_REG,
+  NCTAID_REG,
+  NTID_REG,
+  NSMID_REG,
+  NWARPID_REG,
+  PM_REG,
+  SMID_REG,
+  TID_REG,
+  WARPID_REG,
+  WARPSZ_REG
 };
-enum wmma_type{
-	LOAD_A,
-	LOAD_B,
-	LOAD_C,
-	STORE_D,
-	MMA,
-	ROW,
-	COL,
-	M16N16K16,
-	M32N8K16,
-	M8N32K16
-
+enum wmma_type {
+  LOAD_A,
+  LOAD_B,
+  LOAD_C,
+  STORE_D,
+  MMA,
+  ROW,
+  COL,
+  M16N16K16,
+  M32N8K16,
+  M8N32K16
 
 };
 #endif

--- a/src/cuda-sim/ptx-stats.cc
+++ b/src/cuda-sim/ptx-stats.cc
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -25,248 +27,266 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "ptx_ir.h"
-#include "ptx_sim.h"
 #include "ptx-stats.h"
-#include "../option_parser.h"
 #include <stdio.h>
 #include <map>
-#include "../tr1_hash_map.h"
 #include "../../libcuda/gpgpu_context.h"
+#include "../option_parser.h"
+#include "../tr1_hash_map.h"
+#include "ptx_ir.h"
+#include "ptx_sim.h"
 
-void ptx_stats::ptx_file_line_stats_options(option_parser_t opp)
-{
-    option_parser_register(opp, "-enable_ptx_file_line_stats", OPT_BOOL, 
-                           &enable_ptx_file_line_stats, 
-                           "Turn on PTX source line statistic profiling. (1 = On)", "1");
-    option_parser_register(opp, "-ptx_line_stats_filename", OPT_CSTR, 
-                           &ptx_line_stats_filename, 
-                           "Output file for PTX source line statistics.", "gpgpu_inst_stats.txt");
+void ptx_stats::ptx_file_line_stats_options(option_parser_t opp) {
+  option_parser_register(
+      opp, "-enable_ptx_file_line_stats", OPT_BOOL, &enable_ptx_file_line_stats,
+      "Turn on PTX source line statistic profiling. (1 = On)", "1");
+  option_parser_register(
+      opp, "-ptx_line_stats_filename", OPT_CSTR, &ptx_line_stats_filename,
+      "Output file for PTX source line statistics.", "gpgpu_inst_stats.txt");
 }
 
 // implementations
 
 // defining a PTX source line = filename + line number
-class ptx_file_line 
-{
-public:
-    ptx_file_line(const char* s, int l) {
-        if( s == NULL ) 
-            st = "NULL_NAME";
-        else 
-            st = s;
-        line = l;
-    }
+class ptx_file_line {
+ public:
+  ptx_file_line(const char *s, int l) {
+    if (s == NULL)
+      st = "NULL_NAME";
+    else
+      st = s;
+    line = l;
+  }
 
-    bool operator<(const ptx_file_line &other) const {
-        if( st == other.st ) {
-            if( line < other.line ) 
-                return true;
-            else
-                return false; 
-        } else {
-            return st < other.st;
-        }
+  bool operator<(const ptx_file_line &other) const {
+    if (st == other.st) {
+      if (line < other.line)
+        return true;
+      else
+        return false;
+    } else {
+      return st < other.st;
     }
+  }
 
-    bool operator==(const ptx_file_line &other) const {
-        return (line==other.line) && (st==other.st);
-    }
+  bool operator==(const ptx_file_line &other) const {
+    return (line == other.line) && (st == other.st);
+  }
 
-    std::string st;
-    unsigned line;
+  std::string st;
+  unsigned line;
 };
 
 // holds all statistics collected for a singe PTX source line
-class ptx_file_line_stats
-{
-public:
-    ptx_file_line_stats() 
-        : exec_count(0), latency(0), dram_traffic(0), 
-          smem_n_way_bank_conflict_total(0), smem_warp_count(0),
-          gmem_n_access_total(0), gmem_warp_count(0), exposed_latency(0),
-          warp_divergence(0)
-    { }
-    
-    unsigned long exec_count;
-    unsigned long long latency;
-    unsigned long long dram_traffic;
-    unsigned long long smem_n_way_bank_conflict_total;  // total number of banks accessed by this instruction
-    unsigned long smem_warp_count;                      // number of warps accessing shared memory
-    unsigned long long gmem_n_access_total; // number of uncoalesced access in total from this instruction
-    unsigned long gmem_warp_count;          // number of warps causing these uncoalesced access
-    unsigned long long exposed_latency; // latency exposed as pipeline bubbles (attributed to this instruction)
-    unsigned long long warp_divergence; // number of warp divergence occured at this instruction
+class ptx_file_line_stats {
+ public:
+  ptx_file_line_stats()
+      : exec_count(0),
+        latency(0),
+        dram_traffic(0),
+        smem_n_way_bank_conflict_total(0),
+        smem_warp_count(0),
+        gmem_n_access_total(0),
+        gmem_warp_count(0),
+        exposed_latency(0),
+        warp_divergence(0) {}
+
+  unsigned long exec_count;
+  unsigned long long latency;
+  unsigned long long dram_traffic;
+  unsigned long long smem_n_way_bank_conflict_total;  // total number of banks
+                                                      // accessed by this
+                                                      // instruction
+  unsigned long smem_warp_count;  // number of warps accessing shared memory
+  unsigned long long gmem_n_access_total;  // number of uncoalesced access in
+                                           // total from this instruction
+  unsigned long
+      gmem_warp_count;  // number of warps causing these uncoalesced access
+  unsigned long long exposed_latency;  // latency exposed as pipeline bubbles
+                                       // (attributed to this instruction)
+  unsigned long long
+      warp_divergence;  // number of warp divergence occured at this instruction
 };
 
 #if (tr1_hash_map_ismap == 1)
-typedef tr1_hash_map<ptx_file_line, ptx_file_line_stats> ptx_file_line_stats_map_t;
+typedef tr1_hash_map<ptx_file_line, ptx_file_line_stats>
+    ptx_file_line_stats_map_t;
 #else
-struct hash_ptx_file_line
-{
-    std::size_t operator()(const ptx_file_line & pfline) const {
-        std::hash<unsigned> hash_line;
-        return hash_line(pfline.line);
-    }
+struct hash_ptx_file_line {
+  std::size_t operator()(const ptx_file_line &pfline) const {
+    std::hash<unsigned> hash_line;
+    return hash_line(pfline.line);
+  }
 };
-typedef tr1_hash_map<ptx_file_line, ptx_file_line_stats, hash_ptx_file_line> ptx_file_line_stats_map_t;
+typedef tr1_hash_map<ptx_file_line, ptx_file_line_stats, hash_ptx_file_line>
+    ptx_file_line_stats_map_t;
 #endif
 
 static ptx_file_line_stats_map_t ptx_file_line_stats_tracker;
 
 // output statistics to a file
-void ptx_stats::ptx_file_line_stats_write_file()
-{
-    // check if stat collection is turned on
-    if (enable_ptx_file_line_stats == 0) return;
+void ptx_stats::ptx_file_line_stats_write_file() {
+  // check if stat collection is turned on
+  if (enable_ptx_file_line_stats == 0) return;
 
-    ptx_file_line_stats_map_t::iterator it;
-    FILE * pfile;
+  ptx_file_line_stats_map_t::iterator it;
+  FILE *pfile;
 
-    pfile = fopen(ptx_line_stats_filename, "w");
-    fprintf(pfile,"kernel line : count latency dram_traffic smem_bk_conflicts smem_warp gmem_access_generated gmem_warp exposed_latency warp_divergence\n");
-    for( it=ptx_file_line_stats_tracker.begin(); it != ptx_file_line_stats_tracker.end(); it++ ) {
-        fprintf(pfile, "%s %i : ", it->first.st.c_str(), it->first.line);
-        fprintf(pfile, "%lu ", it->second.exec_count);
-        fprintf(pfile, "%llu ", it->second.latency);
-        fprintf(pfile, "%llu ", it->second.dram_traffic);
-        fprintf(pfile, "%llu ", it->second.smem_n_way_bank_conflict_total);
-        fprintf(pfile, "%lu ", it->second.smem_warp_count);
-        fprintf(pfile, "%llu ", it->second.gmem_n_access_total);
-        fprintf(pfile, "%lu ", it->second.gmem_warp_count);
-        fprintf(pfile, "%llu ", it->second.exposed_latency);
-        fprintf(pfile, "%llu ", it->second.warp_divergence);
-        fprintf(pfile, "\n");
-    }
-    fflush(pfile);
-    fclose(pfile);
+  pfile = fopen(ptx_line_stats_filename, "w");
+  fprintf(pfile,
+          "kernel line : count latency dram_traffic smem_bk_conflicts "
+          "smem_warp gmem_access_generated gmem_warp exposed_latency "
+          "warp_divergence\n");
+  for (it = ptx_file_line_stats_tracker.begin();
+       it != ptx_file_line_stats_tracker.end(); it++) {
+    fprintf(pfile, "%s %i : ", it->first.st.c_str(), it->first.line);
+    fprintf(pfile, "%lu ", it->second.exec_count);
+    fprintf(pfile, "%llu ", it->second.latency);
+    fprintf(pfile, "%llu ", it->second.dram_traffic);
+    fprintf(pfile, "%llu ", it->second.smem_n_way_bank_conflict_total);
+    fprintf(pfile, "%lu ", it->second.smem_warp_count);
+    fprintf(pfile, "%llu ", it->second.gmem_n_access_total);
+    fprintf(pfile, "%lu ", it->second.gmem_warp_count);
+    fprintf(pfile, "%llu ", it->second.exposed_latency);
+    fprintf(pfile, "%llu ", it->second.warp_divergence);
+    fprintf(pfile, "\n");
+  }
+  fflush(pfile);
+  fclose(pfile);
 }
 
 // attribute one more execution count to this ptx instruction
 // counting the number of threads (not warps) executing this instruction
-void ptx_file_line_stats_add_exec_count(const ptx_instruction *pInsn)
-{
-    ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(), pInsn->source_line())].exec_count += 1;
+void ptx_file_line_stats_add_exec_count(const ptx_instruction *pInsn) {
+  ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(),
+                                            pInsn->source_line())]
+      .exec_count += 1;
 }
 
 // attribute pipeline latency to this ptx instruction (specified by the pc)
-// pipeline latency is the number of cycles a warp with this instruction spent in the pipeline
-void ptx_stats::ptx_file_line_stats_add_latency(unsigned pc, unsigned latency)
-{
-    const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
-    
-    ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(), pInsn->source_line())].latency += latency;
+// pipeline latency is the number of cycles a warp with this instruction spent
+// in the pipeline
+void ptx_stats::ptx_file_line_stats_add_latency(unsigned pc, unsigned latency) {
+  const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
+
+  ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(),
+                                            pInsn->source_line())]
+      .latency += latency;
 }
 
 // attribute dram traffic to this ptx instruction (specified by the pc)
-// dram traffic is counted in number of requests 
-void ptx_stats::ptx_file_line_stats_add_dram_traffic(unsigned pc, unsigned dram_traffic)
-{
-    const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
-    
-    ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(), pInsn->source_line())].dram_traffic += dram_traffic;
+// dram traffic is counted in number of requests
+void ptx_stats::ptx_file_line_stats_add_dram_traffic(unsigned pc,
+                                                     unsigned dram_traffic) {
+  const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
+
+  ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(),
+                                            pInsn->source_line())]
+      .dram_traffic += dram_traffic;
 }
 
 // attribute the number of shared memory access cycles to a ptx instruction
-// counts both the number of warps doing shared memory access and the number of cycles involved
-void ptx_stats::ptx_file_line_stats_add_smem_bank_conflict(unsigned pc, unsigned n_way_bkconflict)
-{
-    const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
-    
-    ptx_file_line_stats& line_stats = ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(), pInsn->source_line())];
-    line_stats.smem_n_way_bank_conflict_total += n_way_bkconflict;
-    line_stats.smem_warp_count += 1;
+// counts both the number of warps doing shared memory access and the number of
+// cycles involved
+void ptx_stats::ptx_file_line_stats_add_smem_bank_conflict(
+    unsigned pc, unsigned n_way_bkconflict) {
+  const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
+
+  ptx_file_line_stats &line_stats = ptx_file_line_stats_tracker[ptx_file_line(
+      pInsn->source_file(), pInsn->source_line())];
+  line_stats.smem_n_way_bank_conflict_total += n_way_bkconflict;
+  line_stats.smem_warp_count += 1;
 }
 
-// attribute a non-coalesced mem access to a ptx instruction 
-// counts both the number of warps causing this and the number of memory requests generated
-void ptx_stats::ptx_file_line_stats_add_uncoalesced_gmem(unsigned pc, unsigned n_access)
-{
-    const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
-    
-    ptx_file_line_stats& line_stats = ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(), pInsn->source_line())];
-    line_stats.gmem_n_access_total += n_access;
-    line_stats.gmem_warp_count += 1;
+// attribute a non-coalesced mem access to a ptx instruction
+// counts both the number of warps causing this and the number of memory
+// requests generated
+void ptx_stats::ptx_file_line_stats_add_uncoalesced_gmem(unsigned pc,
+                                                         unsigned n_access) {
+  const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
+
+  ptx_file_line_stats &line_stats = ptx_file_line_stats_tracker[ptx_file_line(
+      pInsn->source_file(), pInsn->source_line())];
+  line_stats.gmem_n_access_total += n_access;
+  line_stats.gmem_warp_count += 1;
 }
 
-// a class that tracks the inflight memory instructions of a shader core 
-// and attributes exposed latency to those instructions when signaled to do so 
-class ptx_inflight_memory_insn_tracker
-{
-public:
-    typedef std::map<const ptx_instruction *, int> insn_count_map;
+// a class that tracks the inflight memory instructions of a shader core
+// and attributes exposed latency to those instructions when signaled to do so
+class ptx_inflight_memory_insn_tracker {
+ public:
+  typedef std::map<const ptx_instruction *, int> insn_count_map;
 
-    void add_count(const ptx_instruction * pInsn, int count = 1)
-    {
-        ptx_inflight_memory_insns[pInsn] += count;
+  void add_count(const ptx_instruction *pInsn, int count = 1) {
+    ptx_inflight_memory_insns[pInsn] += count;
+  }
+
+  void sub_count(const ptx_instruction *pInsn, int count = 1) {
+    insn_count_map::iterator i_insncount;
+    i_insncount = ptx_inflight_memory_insns.find(pInsn);
+
+    assert(i_insncount != ptx_inflight_memory_insns.end());
+
+    i_insncount->second -= count;
+
+    if (i_insncount->second <= 0) {
+      ptx_inflight_memory_insns.erase(i_insncount);
     }
+  }
 
-    void sub_count(const ptx_instruction * pInsn, int count = 1)
-    {
-        insn_count_map::iterator i_insncount; 
-        i_insncount = ptx_inflight_memory_insns.find(pInsn);
+  void attribute_exposed_latency(int count = 1) {
+    insn_count_map &exlat_insnmap = ptx_inflight_memory_insns;
+    insn_count_map::const_iterator i_exlatinsn;
 
-        assert(i_insncount != ptx_inflight_memory_insns.end());
-
-        i_insncount->second -= count;
-
-        if (i_insncount->second <= 0) {
-            ptx_inflight_memory_insns.erase(i_insncount);
-        }
+    i_exlatinsn = exlat_insnmap.begin();
+    for (; i_exlatinsn != exlat_insnmap.end(); ++i_exlatinsn) {
+      const ptx_instruction *pInsn = i_exlatinsn->first;
+      ptx_file_line_stats &line_stats =
+          ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(),
+                                                    pInsn->source_line())];
+      line_stats.exposed_latency += count;
     }
+  }
 
-    void attribute_exposed_latency(int count = 1)
-    {
-        insn_count_map &exlat_insnmap = ptx_inflight_memory_insns;
-        insn_count_map::const_iterator i_exlatinsn;
-
-        i_exlatinsn = exlat_insnmap.begin();
-        for (; i_exlatinsn != exlat_insnmap.end(); ++i_exlatinsn) {
-            const ptx_instruction *pInsn = i_exlatinsn->first;
-            ptx_file_line_stats& line_stats = ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(), pInsn->source_line())];
-            line_stats.exposed_latency += count;
-        }
-    }
-
-    insn_count_map ptx_inflight_memory_insns;
+  insn_count_map ptx_inflight_memory_insns;
 };
 
 static ptx_inflight_memory_insn_tracker *inflight_mem_tracker = NULL;
 
-void ptx_file_line_stats_create_exposed_latency_tracker(int n_shader_cores)
-{
-    inflight_mem_tracker = new ptx_inflight_memory_insn_tracker[n_shader_cores];
+void ptx_file_line_stats_create_exposed_latency_tracker(int n_shader_cores) {
+  inflight_mem_tracker = new ptx_inflight_memory_insn_tracker[n_shader_cores];
 }
 
 // add an inflight memory instruction
-void ptx_stats::ptx_file_line_stats_add_inflight_memory_insn(int sc_id, unsigned pc)
-{
-    const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
+void ptx_stats::ptx_file_line_stats_add_inflight_memory_insn(int sc_id,
+                                                             unsigned pc) {
+  const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
 
-    inflight_mem_tracker[sc_id].add_count(pInsn);
+  inflight_mem_tracker[sc_id].add_count(pInsn);
 }
 
 // remove an inflight memory instruction
-void ptx_stats::ptx_file_line_stats_sub_inflight_memory_insn(int sc_id, unsigned pc)
-{
-    const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
+void ptx_stats::ptx_file_line_stats_sub_inflight_memory_insn(int sc_id,
+                                                             unsigned pc) {
+  const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
 
-    inflight_mem_tracker[sc_id].sub_count(pInsn);
+  inflight_mem_tracker[sc_id].sub_count(pInsn);
 }
 
-// attribute an empty cycle in the pipeline (exposed latency) to the ptx memory instructions in flight
-void ptx_file_line_stats_commit_exposed_latency(int sc_id, int exposed_latency)
-{
-    assert(exposed_latency > 0);
-    inflight_mem_tracker[sc_id].attribute_exposed_latency(exposed_latency);
+// attribute an empty cycle in the pipeline (exposed latency) to the ptx memory
+// instructions in flight
+void ptx_file_line_stats_commit_exposed_latency(int sc_id,
+                                                int exposed_latency) {
+  assert(exposed_latency > 0);
+  inflight_mem_tracker[sc_id].attribute_exposed_latency(exposed_latency);
 }
 
 // attribute the number of warp divergence to a ptx instruction
-void ptx_stats::ptx_file_line_stats_add_warp_divergence(unsigned pc, unsigned n_way_divergence)
-{
-    const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
-    
-    ptx_file_line_stats& line_stats = ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(), pInsn->source_line())];
-    line_stats.warp_divergence += n_way_divergence;
-}
+void ptx_stats::ptx_file_line_stats_add_warp_divergence(
+    unsigned pc, unsigned n_way_divergence) {
+  const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
 
+  ptx_file_line_stats &line_stats = ptx_file_line_stats_tracker[ptx_file_line(
+      pInsn->source_file(), pInsn->source_line())];
+  line_stats.warp_divergence += n_way_divergence;
+}

--- a/src/cuda-sim/ptx-stats.cc
+++ b/src/cuda-sim/ptx-stats.cc
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -27,266 +25,248 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "ptx-stats.h"
-#include <stdio.h>
-#include <map>
-#include "../../libcuda/gpgpu_context.h"
-#include "../option_parser.h"
-#include "../tr1_hash_map.h"
 #include "ptx_ir.h"
 #include "ptx_sim.h"
+#include "ptx-stats.h"
+#include "../option_parser.h"
+#include <stdio.h>
+#include <map>
+#include "../tr1_hash_map.h"
+#include "../../libcuda/gpgpu_context.h"
 
-void ptx_stats::ptx_file_line_stats_options(option_parser_t opp) {
-  option_parser_register(
-      opp, "-enable_ptx_file_line_stats", OPT_BOOL, &enable_ptx_file_line_stats,
-      "Turn on PTX source line statistic profiling. (1 = On)", "1");
-  option_parser_register(
-      opp, "-ptx_line_stats_filename", OPT_CSTR, &ptx_line_stats_filename,
-      "Output file for PTX source line statistics.", "gpgpu_inst_stats.txt");
+void ptx_stats::ptx_file_line_stats_options(option_parser_t opp)
+{
+    option_parser_register(opp, "-enable_ptx_file_line_stats", OPT_BOOL, 
+                           &enable_ptx_file_line_stats, 
+                           "Turn on PTX source line statistic profiling. (1 = On)", "1");
+    option_parser_register(opp, "-ptx_line_stats_filename", OPT_CSTR, 
+                           &ptx_line_stats_filename, 
+                           "Output file for PTX source line statistics.", "gpgpu_inst_stats.txt");
 }
 
 // implementations
 
 // defining a PTX source line = filename + line number
-class ptx_file_line {
- public:
-  ptx_file_line(const char *s, int l) {
-    if (s == NULL)
-      st = "NULL_NAME";
-    else
-      st = s;
-    line = l;
-  }
-
-  bool operator<(const ptx_file_line &other) const {
-    if (st == other.st) {
-      if (line < other.line)
-        return true;
-      else
-        return false;
-    } else {
-      return st < other.st;
+class ptx_file_line 
+{
+public:
+    ptx_file_line(const char* s, int l) {
+        if( s == NULL ) 
+            st = "NULL_NAME";
+        else 
+            st = s;
+        line = l;
     }
-  }
 
-  bool operator==(const ptx_file_line &other) const {
-    return (line == other.line) && (st == other.st);
-  }
+    bool operator<(const ptx_file_line &other) const {
+        if( st == other.st ) {
+            if( line < other.line ) 
+                return true;
+            else
+                return false; 
+        } else {
+            return st < other.st;
+        }
+    }
 
-  std::string st;
-  unsigned line;
+    bool operator==(const ptx_file_line &other) const {
+        return (line==other.line) && (st==other.st);
+    }
+
+    std::string st;
+    unsigned line;
 };
 
 // holds all statistics collected for a singe PTX source line
-class ptx_file_line_stats {
- public:
-  ptx_file_line_stats()
-      : exec_count(0),
-        latency(0),
-        dram_traffic(0),
-        smem_n_way_bank_conflict_total(0),
-        smem_warp_count(0),
-        gmem_n_access_total(0),
-        gmem_warp_count(0),
-        exposed_latency(0),
-        warp_divergence(0) {}
-
-  unsigned long exec_count;
-  unsigned long long latency;
-  unsigned long long dram_traffic;
-  unsigned long long smem_n_way_bank_conflict_total;  // total number of banks
-                                                      // accessed by this
-                                                      // instruction
-  unsigned long smem_warp_count;  // number of warps accessing shared memory
-  unsigned long long gmem_n_access_total;  // number of uncoalesced access in
-                                           // total from this instruction
-  unsigned long
-      gmem_warp_count;  // number of warps causing these uncoalesced access
-  unsigned long long exposed_latency;  // latency exposed as pipeline bubbles
-                                       // (attributed to this instruction)
-  unsigned long long
-      warp_divergence;  // number of warp divergence occured at this instruction
+class ptx_file_line_stats
+{
+public:
+    ptx_file_line_stats() 
+        : exec_count(0), latency(0), dram_traffic(0), 
+          smem_n_way_bank_conflict_total(0), smem_warp_count(0),
+          gmem_n_access_total(0), gmem_warp_count(0), exposed_latency(0),
+          warp_divergence(0)
+    { }
+    
+    unsigned long exec_count;
+    unsigned long long latency;
+    unsigned long long dram_traffic;
+    unsigned long long smem_n_way_bank_conflict_total;  // total number of banks accessed by this instruction
+    unsigned long smem_warp_count;                      // number of warps accessing shared memory
+    unsigned long long gmem_n_access_total; // number of uncoalesced access in total from this instruction
+    unsigned long gmem_warp_count;          // number of warps causing these uncoalesced access
+    unsigned long long exposed_latency; // latency exposed as pipeline bubbles (attributed to this instruction)
+    unsigned long long warp_divergence; // number of warp divergence occured at this instruction
 };
 
 #if (tr1_hash_map_ismap == 1)
-typedef tr1_hash_map<ptx_file_line, ptx_file_line_stats>
-    ptx_file_line_stats_map_t;
+typedef tr1_hash_map<ptx_file_line, ptx_file_line_stats> ptx_file_line_stats_map_t;
 #else
-struct hash_ptx_file_line {
-  std::size_t operator()(const ptx_file_line &pfline) const {
-    std::hash<unsigned> hash_line;
-    return hash_line(pfline.line);
-  }
+struct hash_ptx_file_line
+{
+    std::size_t operator()(const ptx_file_line & pfline) const {
+        std::hash<unsigned> hash_line;
+        return hash_line(pfline.line);
+    }
 };
-typedef tr1_hash_map<ptx_file_line, ptx_file_line_stats, hash_ptx_file_line>
-    ptx_file_line_stats_map_t;
+typedef tr1_hash_map<ptx_file_line, ptx_file_line_stats, hash_ptx_file_line> ptx_file_line_stats_map_t;
 #endif
 
 static ptx_file_line_stats_map_t ptx_file_line_stats_tracker;
 
 // output statistics to a file
-void ptx_stats::ptx_file_line_stats_write_file() {
-  // check if stat collection is turned on
-  if (enable_ptx_file_line_stats == 0) return;
+void ptx_stats::ptx_file_line_stats_write_file()
+{
+    // check if stat collection is turned on
+    if (enable_ptx_file_line_stats == 0) return;
 
-  ptx_file_line_stats_map_t::iterator it;
-  FILE *pfile;
+    ptx_file_line_stats_map_t::iterator it;
+    FILE * pfile;
 
-  pfile = fopen(ptx_line_stats_filename, "w");
-  fprintf(pfile,
-          "kernel line : count latency dram_traffic smem_bk_conflicts "
-          "smem_warp gmem_access_generated gmem_warp exposed_latency "
-          "warp_divergence\n");
-  for (it = ptx_file_line_stats_tracker.begin();
-       it != ptx_file_line_stats_tracker.end(); it++) {
-    fprintf(pfile, "%s %i : ", it->first.st.c_str(), it->first.line);
-    fprintf(pfile, "%lu ", it->second.exec_count);
-    fprintf(pfile, "%llu ", it->second.latency);
-    fprintf(pfile, "%llu ", it->second.dram_traffic);
-    fprintf(pfile, "%llu ", it->second.smem_n_way_bank_conflict_total);
-    fprintf(pfile, "%lu ", it->second.smem_warp_count);
-    fprintf(pfile, "%llu ", it->second.gmem_n_access_total);
-    fprintf(pfile, "%lu ", it->second.gmem_warp_count);
-    fprintf(pfile, "%llu ", it->second.exposed_latency);
-    fprintf(pfile, "%llu ", it->second.warp_divergence);
-    fprintf(pfile, "\n");
-  }
-  fflush(pfile);
-  fclose(pfile);
+    pfile = fopen(ptx_line_stats_filename, "w");
+    fprintf(pfile,"kernel line : count latency dram_traffic smem_bk_conflicts smem_warp gmem_access_generated gmem_warp exposed_latency warp_divergence\n");
+    for( it=ptx_file_line_stats_tracker.begin(); it != ptx_file_line_stats_tracker.end(); it++ ) {
+        fprintf(pfile, "%s %i : ", it->first.st.c_str(), it->first.line);
+        fprintf(pfile, "%lu ", it->second.exec_count);
+        fprintf(pfile, "%llu ", it->second.latency);
+        fprintf(pfile, "%llu ", it->second.dram_traffic);
+        fprintf(pfile, "%llu ", it->second.smem_n_way_bank_conflict_total);
+        fprintf(pfile, "%lu ", it->second.smem_warp_count);
+        fprintf(pfile, "%llu ", it->second.gmem_n_access_total);
+        fprintf(pfile, "%lu ", it->second.gmem_warp_count);
+        fprintf(pfile, "%llu ", it->second.exposed_latency);
+        fprintf(pfile, "%llu ", it->second.warp_divergence);
+        fprintf(pfile, "\n");
+    }
+    fflush(pfile);
+    fclose(pfile);
 }
 
 // attribute one more execution count to this ptx instruction
 // counting the number of threads (not warps) executing this instruction
-void ptx_file_line_stats_add_exec_count(const ptx_instruction *pInsn) {
-  ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(),
-                                            pInsn->source_line())]
-      .exec_count += 1;
+void ptx_file_line_stats_add_exec_count(const ptx_instruction *pInsn)
+{
+    ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(), pInsn->source_line())].exec_count += 1;
 }
 
 // attribute pipeline latency to this ptx instruction (specified by the pc)
-// pipeline latency is the number of cycles a warp with this instruction spent
-// in the pipeline
-void ptx_stats::ptx_file_line_stats_add_latency(unsigned pc, unsigned latency) {
-  const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
-
-  ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(),
-                                            pInsn->source_line())]
-      .latency += latency;
+// pipeline latency is the number of cycles a warp with this instruction spent in the pipeline
+void ptx_stats::ptx_file_line_stats_add_latency(unsigned pc, unsigned latency)
+{
+    const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
+    
+    ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(), pInsn->source_line())].latency += latency;
 }
 
 // attribute dram traffic to this ptx instruction (specified by the pc)
-// dram traffic is counted in number of requests
-void ptx_stats::ptx_file_line_stats_add_dram_traffic(unsigned pc,
-                                                     unsigned dram_traffic) {
-  const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
-
-  ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(),
-                                            pInsn->source_line())]
-      .dram_traffic += dram_traffic;
+// dram traffic is counted in number of requests 
+void ptx_stats::ptx_file_line_stats_add_dram_traffic(unsigned pc, unsigned dram_traffic)
+{
+    const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
+    
+    ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(), pInsn->source_line())].dram_traffic += dram_traffic;
 }
 
 // attribute the number of shared memory access cycles to a ptx instruction
-// counts both the number of warps doing shared memory access and the number of
-// cycles involved
-void ptx_stats::ptx_file_line_stats_add_smem_bank_conflict(
-    unsigned pc, unsigned n_way_bkconflict) {
-  const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
-
-  ptx_file_line_stats &line_stats = ptx_file_line_stats_tracker[ptx_file_line(
-      pInsn->source_file(), pInsn->source_line())];
-  line_stats.smem_n_way_bank_conflict_total += n_way_bkconflict;
-  line_stats.smem_warp_count += 1;
+// counts both the number of warps doing shared memory access and the number of cycles involved
+void ptx_stats::ptx_file_line_stats_add_smem_bank_conflict(unsigned pc, unsigned n_way_bkconflict)
+{
+    const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
+    
+    ptx_file_line_stats& line_stats = ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(), pInsn->source_line())];
+    line_stats.smem_n_way_bank_conflict_total += n_way_bkconflict;
+    line_stats.smem_warp_count += 1;
 }
 
-// attribute a non-coalesced mem access to a ptx instruction
-// counts both the number of warps causing this and the number of memory
-// requests generated
-void ptx_stats::ptx_file_line_stats_add_uncoalesced_gmem(unsigned pc,
-                                                         unsigned n_access) {
-  const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
-
-  ptx_file_line_stats &line_stats = ptx_file_line_stats_tracker[ptx_file_line(
-      pInsn->source_file(), pInsn->source_line())];
-  line_stats.gmem_n_access_total += n_access;
-  line_stats.gmem_warp_count += 1;
+// attribute a non-coalesced mem access to a ptx instruction 
+// counts both the number of warps causing this and the number of memory requests generated
+void ptx_stats::ptx_file_line_stats_add_uncoalesced_gmem(unsigned pc, unsigned n_access)
+{
+    const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
+    
+    ptx_file_line_stats& line_stats = ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(), pInsn->source_line())];
+    line_stats.gmem_n_access_total += n_access;
+    line_stats.gmem_warp_count += 1;
 }
 
-// a class that tracks the inflight memory instructions of a shader core
-// and attributes exposed latency to those instructions when signaled to do so
-class ptx_inflight_memory_insn_tracker {
- public:
-  typedef std::map<const ptx_instruction *, int> insn_count_map;
+// a class that tracks the inflight memory instructions of a shader core 
+// and attributes exposed latency to those instructions when signaled to do so 
+class ptx_inflight_memory_insn_tracker
+{
+public:
+    typedef std::map<const ptx_instruction *, int> insn_count_map;
 
-  void add_count(const ptx_instruction *pInsn, int count = 1) {
-    ptx_inflight_memory_insns[pInsn] += count;
-  }
-
-  void sub_count(const ptx_instruction *pInsn, int count = 1) {
-    insn_count_map::iterator i_insncount;
-    i_insncount = ptx_inflight_memory_insns.find(pInsn);
-
-    assert(i_insncount != ptx_inflight_memory_insns.end());
-
-    i_insncount->second -= count;
-
-    if (i_insncount->second <= 0) {
-      ptx_inflight_memory_insns.erase(i_insncount);
+    void add_count(const ptx_instruction * pInsn, int count = 1)
+    {
+        ptx_inflight_memory_insns[pInsn] += count;
     }
-  }
 
-  void attribute_exposed_latency(int count = 1) {
-    insn_count_map &exlat_insnmap = ptx_inflight_memory_insns;
-    insn_count_map::const_iterator i_exlatinsn;
+    void sub_count(const ptx_instruction * pInsn, int count = 1)
+    {
+        insn_count_map::iterator i_insncount; 
+        i_insncount = ptx_inflight_memory_insns.find(pInsn);
 
-    i_exlatinsn = exlat_insnmap.begin();
-    for (; i_exlatinsn != exlat_insnmap.end(); ++i_exlatinsn) {
-      const ptx_instruction *pInsn = i_exlatinsn->first;
-      ptx_file_line_stats &line_stats =
-          ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(),
-                                                    pInsn->source_line())];
-      line_stats.exposed_latency += count;
+        assert(i_insncount != ptx_inflight_memory_insns.end());
+
+        i_insncount->second -= count;
+
+        if (i_insncount->second <= 0) {
+            ptx_inflight_memory_insns.erase(i_insncount);
+        }
     }
-  }
 
-  insn_count_map ptx_inflight_memory_insns;
+    void attribute_exposed_latency(int count = 1)
+    {
+        insn_count_map &exlat_insnmap = ptx_inflight_memory_insns;
+        insn_count_map::const_iterator i_exlatinsn;
+
+        i_exlatinsn = exlat_insnmap.begin();
+        for (; i_exlatinsn != exlat_insnmap.end(); ++i_exlatinsn) {
+            const ptx_instruction *pInsn = i_exlatinsn->first;
+            ptx_file_line_stats& line_stats = ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(), pInsn->source_line())];
+            line_stats.exposed_latency += count;
+        }
+    }
+
+    insn_count_map ptx_inflight_memory_insns;
 };
 
 static ptx_inflight_memory_insn_tracker *inflight_mem_tracker = NULL;
 
-void ptx_file_line_stats_create_exposed_latency_tracker(int n_shader_cores) {
-  inflight_mem_tracker = new ptx_inflight_memory_insn_tracker[n_shader_cores];
+void ptx_file_line_stats_create_exposed_latency_tracker(int n_shader_cores)
+{
+    inflight_mem_tracker = new ptx_inflight_memory_insn_tracker[n_shader_cores];
 }
 
 // add an inflight memory instruction
-void ptx_stats::ptx_file_line_stats_add_inflight_memory_insn(int sc_id,
-                                                             unsigned pc) {
-  const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
+void ptx_stats::ptx_file_line_stats_add_inflight_memory_insn(int sc_id, unsigned pc)
+{
+    const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
 
-  inflight_mem_tracker[sc_id].add_count(pInsn);
+    inflight_mem_tracker[sc_id].add_count(pInsn);
 }
 
 // remove an inflight memory instruction
-void ptx_stats::ptx_file_line_stats_sub_inflight_memory_insn(int sc_id,
-                                                             unsigned pc) {
-  const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
+void ptx_stats::ptx_file_line_stats_sub_inflight_memory_insn(int sc_id, unsigned pc)
+{
+    const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
 
-  inflight_mem_tracker[sc_id].sub_count(pInsn);
+    inflight_mem_tracker[sc_id].sub_count(pInsn);
 }
 
-// attribute an empty cycle in the pipeline (exposed latency) to the ptx memory
-// instructions in flight
-void ptx_file_line_stats_commit_exposed_latency(int sc_id,
-                                                int exposed_latency) {
-  assert(exposed_latency > 0);
-  inflight_mem_tracker[sc_id].attribute_exposed_latency(exposed_latency);
+// attribute an empty cycle in the pipeline (exposed latency) to the ptx memory instructions in flight
+void ptx_file_line_stats_commit_exposed_latency(int sc_id, int exposed_latency)
+{
+    assert(exposed_latency > 0);
+    inflight_mem_tracker[sc_id].attribute_exposed_latency(exposed_latency);
 }
 
 // attribute the number of warp divergence to a ptx instruction
-void ptx_stats::ptx_file_line_stats_add_warp_divergence(
-    unsigned pc, unsigned n_way_divergence) {
-  const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
-
-  ptx_file_line_stats &line_stats = ptx_file_line_stats_tracker[ptx_file_line(
-      pInsn->source_file(), pInsn->source_line())];
-  line_stats.warp_divergence += n_way_divergence;
+void ptx_stats::ptx_file_line_stats_add_warp_divergence(unsigned pc, unsigned n_way_divergence)
+{
+    const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
+    
+    ptx_file_line_stats& line_stats = ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(), pInsn->source_line())];
+    line_stats.warp_divergence += n_way_divergence;
 }
+

--- a/src/cuda-sim/ptx-stats.cc
+++ b/src/cuda-sim/ptx-stats.cc
@@ -7,266 +7,285 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
-#include "ptx_ir.h"
-#include "ptx_sim.h"
 #include "ptx-stats.h"
-#include "../option_parser.h"
 #include <stdio.h>
 #include <map>
-#include "../tr1_hash_map.h"
 #include "../../libcuda/gpgpu_context.h"
+#include "../option_parser.h"
+#include "../tr1_hash_map.h"
+#include "ptx_ir.h"
+#include "ptx_sim.h"
 
-void ptx_stats::ptx_file_line_stats_options(option_parser_t opp)
-{
-    option_parser_register(opp, "-enable_ptx_file_line_stats", OPT_BOOL, 
-                           &enable_ptx_file_line_stats, 
-                           "Turn on PTX source line statistic profiling. (1 = On)", "1");
-    option_parser_register(opp, "-ptx_line_stats_filename", OPT_CSTR, 
-                           &ptx_line_stats_filename, 
-                           "Output file for PTX source line statistics.", "gpgpu_inst_stats.txt");
+void ptx_stats::ptx_file_line_stats_options(option_parser_t opp) {
+  option_parser_register(
+      opp, "-enable_ptx_file_line_stats", OPT_BOOL, &enable_ptx_file_line_stats,
+      "Turn on PTX source line statistic profiling. (1 = On)", "1");
+  option_parser_register(
+      opp, "-ptx_line_stats_filename", OPT_CSTR, &ptx_line_stats_filename,
+      "Output file for PTX source line statistics.", "gpgpu_inst_stats.txt");
 }
 
 // implementations
 
 // defining a PTX source line = filename + line number
-class ptx_file_line 
-{
-public:
-    ptx_file_line(const char* s, int l) {
-        if( s == NULL ) 
-            st = "NULL_NAME";
-        else 
-            st = s;
-        line = l;
-    }
+class ptx_file_line {
+ public:
+  ptx_file_line(const char *s, int l) {
+    if (s == NULL)
+      st = "NULL_NAME";
+    else
+      st = s;
+    line = l;
+  }
 
-    bool operator<(const ptx_file_line &other) const {
-        if( st == other.st ) {
-            if( line < other.line ) 
-                return true;
-            else
-                return false; 
-        } else {
-            return st < other.st;
-        }
+  bool operator<(const ptx_file_line &other) const {
+    if (st == other.st) {
+      if (line < other.line)
+        return true;
+      else
+        return false;
+    } else {
+      return st < other.st;
     }
+  }
 
-    bool operator==(const ptx_file_line &other) const {
-        return (line==other.line) && (st==other.st);
-    }
+  bool operator==(const ptx_file_line &other) const {
+    return (line == other.line) && (st == other.st);
+  }
 
-    std::string st;
-    unsigned line;
+  std::string st;
+  unsigned line;
 };
 
 // holds all statistics collected for a singe PTX source line
-class ptx_file_line_stats
-{
-public:
-    ptx_file_line_stats() 
-        : exec_count(0), latency(0), dram_traffic(0), 
-          smem_n_way_bank_conflict_total(0), smem_warp_count(0),
-          gmem_n_access_total(0), gmem_warp_count(0), exposed_latency(0),
-          warp_divergence(0)
-    { }
-    
-    unsigned long exec_count;
-    unsigned long long latency;
-    unsigned long long dram_traffic;
-    unsigned long long smem_n_way_bank_conflict_total;  // total number of banks accessed by this instruction
-    unsigned long smem_warp_count;                      // number of warps accessing shared memory
-    unsigned long long gmem_n_access_total; // number of uncoalesced access in total from this instruction
-    unsigned long gmem_warp_count;          // number of warps causing these uncoalesced access
-    unsigned long long exposed_latency; // latency exposed as pipeline bubbles (attributed to this instruction)
-    unsigned long long warp_divergence; // number of warp divergence occured at this instruction
+class ptx_file_line_stats {
+ public:
+  ptx_file_line_stats()
+      : exec_count(0),
+        latency(0),
+        dram_traffic(0),
+        smem_n_way_bank_conflict_total(0),
+        smem_warp_count(0),
+        gmem_n_access_total(0),
+        gmem_warp_count(0),
+        exposed_latency(0),
+        warp_divergence(0) {}
+
+  unsigned long exec_count;
+  unsigned long long latency;
+  unsigned long long dram_traffic;
+  unsigned long long
+      smem_n_way_bank_conflict_total;  // total number of banks accessed by this
+                                       // instruction
+  unsigned long smem_warp_count;  // number of warps accessing shared memory
+  unsigned long long gmem_n_access_total;  // number of uncoalesced access in
+                                           // total from this instruction
+  unsigned long
+      gmem_warp_count;  // number of warps causing these uncoalesced access
+  unsigned long long exposed_latency;  // latency exposed as pipeline bubbles
+                                       // (attributed to this instruction)
+  unsigned long long
+      warp_divergence;  // number of warp divergence occured at this instruction
 };
 
 #if (tr1_hash_map_ismap == 1)
-typedef tr1_hash_map<ptx_file_line, ptx_file_line_stats> ptx_file_line_stats_map_t;
+typedef tr1_hash_map<ptx_file_line, ptx_file_line_stats>
+    ptx_file_line_stats_map_t;
 #else
-struct hash_ptx_file_line
-{
-    std::size_t operator()(const ptx_file_line & pfline) const {
-        std::hash<unsigned> hash_line;
-        return hash_line(pfline.line);
-    }
+struct hash_ptx_file_line {
+  std::size_t operator()(const ptx_file_line &pfline) const {
+    std::hash<unsigned> hash_line;
+    return hash_line(pfline.line);
+  }
 };
-typedef tr1_hash_map<ptx_file_line, ptx_file_line_stats, hash_ptx_file_line> ptx_file_line_stats_map_t;
+typedef tr1_hash_map<ptx_file_line, ptx_file_line_stats, hash_ptx_file_line>
+    ptx_file_line_stats_map_t;
 #endif
 
 static ptx_file_line_stats_map_t ptx_file_line_stats_tracker;
 
 // output statistics to a file
-void ptx_stats::ptx_file_line_stats_write_file()
-{
-    // check if stat collection is turned on
-    if (enable_ptx_file_line_stats == 0) return;
+void ptx_stats::ptx_file_line_stats_write_file() {
+  // check if stat collection is turned on
+  if (enable_ptx_file_line_stats == 0) return;
 
-    ptx_file_line_stats_map_t::iterator it;
-    FILE * pfile;
+  ptx_file_line_stats_map_t::iterator it;
+  FILE *pfile;
 
-    pfile = fopen(ptx_line_stats_filename, "w");
-    fprintf(pfile,"kernel line : count latency dram_traffic smem_bk_conflicts smem_warp gmem_access_generated gmem_warp exposed_latency warp_divergence\n");
-    for( it=ptx_file_line_stats_tracker.begin(); it != ptx_file_line_stats_tracker.end(); it++ ) {
-        fprintf(pfile, "%s %i : ", it->first.st.c_str(), it->first.line);
-        fprintf(pfile, "%lu ", it->second.exec_count);
-        fprintf(pfile, "%llu ", it->second.latency);
-        fprintf(pfile, "%llu ", it->second.dram_traffic);
-        fprintf(pfile, "%llu ", it->second.smem_n_way_bank_conflict_total);
-        fprintf(pfile, "%lu ", it->second.smem_warp_count);
-        fprintf(pfile, "%llu ", it->second.gmem_n_access_total);
-        fprintf(pfile, "%lu ", it->second.gmem_warp_count);
-        fprintf(pfile, "%llu ", it->second.exposed_latency);
-        fprintf(pfile, "%llu ", it->second.warp_divergence);
-        fprintf(pfile, "\n");
-    }
-    fflush(pfile);
-    fclose(pfile);
+  pfile = fopen(ptx_line_stats_filename, "w");
+  fprintf(
+      pfile,
+      "kernel line : count latency dram_traffic smem_bk_conflicts smem_warp "
+      "gmem_access_generated gmem_warp exposed_latency warp_divergence\n");
+  for (it = ptx_file_line_stats_tracker.begin();
+       it != ptx_file_line_stats_tracker.end(); it++) {
+    fprintf(pfile, "%s %i : ", it->first.st.c_str(), it->first.line);
+    fprintf(pfile, "%lu ", it->second.exec_count);
+    fprintf(pfile, "%llu ", it->second.latency);
+    fprintf(pfile, "%llu ", it->second.dram_traffic);
+    fprintf(pfile, "%llu ", it->second.smem_n_way_bank_conflict_total);
+    fprintf(pfile, "%lu ", it->second.smem_warp_count);
+    fprintf(pfile, "%llu ", it->second.gmem_n_access_total);
+    fprintf(pfile, "%lu ", it->second.gmem_warp_count);
+    fprintf(pfile, "%llu ", it->second.exposed_latency);
+    fprintf(pfile, "%llu ", it->second.warp_divergence);
+    fprintf(pfile, "\n");
+  }
+  fflush(pfile);
+  fclose(pfile);
 }
 
 // attribute one more execution count to this ptx instruction
 // counting the number of threads (not warps) executing this instruction
-void ptx_file_line_stats_add_exec_count(const ptx_instruction *pInsn)
-{
-    ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(), pInsn->source_line())].exec_count += 1;
+void ptx_file_line_stats_add_exec_count(const ptx_instruction *pInsn) {
+  ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(),
+                                            pInsn->source_line())]
+      .exec_count += 1;
 }
 
 // attribute pipeline latency to this ptx instruction (specified by the pc)
-// pipeline latency is the number of cycles a warp with this instruction spent in the pipeline
-void ptx_stats::ptx_file_line_stats_add_latency(unsigned pc, unsigned latency)
-{
-    const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
-    
-    ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(), pInsn->source_line())].latency += latency;
+// pipeline latency is the number of cycles a warp with this instruction spent
+// in the pipeline
+void ptx_stats::ptx_file_line_stats_add_latency(unsigned pc, unsigned latency) {
+  const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
+
+  ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(),
+                                            pInsn->source_line())]
+      .latency += latency;
 }
 
 // attribute dram traffic to this ptx instruction (specified by the pc)
-// dram traffic is counted in number of requests 
-void ptx_stats::ptx_file_line_stats_add_dram_traffic(unsigned pc, unsigned dram_traffic)
-{
-    const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
-    
-    ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(), pInsn->source_line())].dram_traffic += dram_traffic;
+// dram traffic is counted in number of requests
+void ptx_stats::ptx_file_line_stats_add_dram_traffic(unsigned pc,
+                                                     unsigned dram_traffic) {
+  const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
+
+  ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(),
+                                            pInsn->source_line())]
+      .dram_traffic += dram_traffic;
 }
 
 // attribute the number of shared memory access cycles to a ptx instruction
-// counts both the number of warps doing shared memory access and the number of cycles involved
-void ptx_stats::ptx_file_line_stats_add_smem_bank_conflict(unsigned pc, unsigned n_way_bkconflict)
-{
-    const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
-    
-    ptx_file_line_stats& line_stats = ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(), pInsn->source_line())];
-    line_stats.smem_n_way_bank_conflict_total += n_way_bkconflict;
-    line_stats.smem_warp_count += 1;
+// counts both the number of warps doing shared memory access and the number of
+// cycles involved
+void ptx_stats::ptx_file_line_stats_add_smem_bank_conflict(
+    unsigned pc, unsigned n_way_bkconflict) {
+  const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
+
+  ptx_file_line_stats &line_stats = ptx_file_line_stats_tracker[ptx_file_line(
+      pInsn->source_file(), pInsn->source_line())];
+  line_stats.smem_n_way_bank_conflict_total += n_way_bkconflict;
+  line_stats.smem_warp_count += 1;
 }
 
-// attribute a non-coalesced mem access to a ptx instruction 
-// counts both the number of warps causing this and the number of memory requests generated
-void ptx_stats::ptx_file_line_stats_add_uncoalesced_gmem(unsigned pc, unsigned n_access)
-{
-    const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
-    
-    ptx_file_line_stats& line_stats = ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(), pInsn->source_line())];
-    line_stats.gmem_n_access_total += n_access;
-    line_stats.gmem_warp_count += 1;
+// attribute a non-coalesced mem access to a ptx instruction
+// counts both the number of warps causing this and the number of memory
+// requests generated
+void ptx_stats::ptx_file_line_stats_add_uncoalesced_gmem(unsigned pc,
+                                                         unsigned n_access) {
+  const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
+
+  ptx_file_line_stats &line_stats = ptx_file_line_stats_tracker[ptx_file_line(
+      pInsn->source_file(), pInsn->source_line())];
+  line_stats.gmem_n_access_total += n_access;
+  line_stats.gmem_warp_count += 1;
 }
 
-// a class that tracks the inflight memory instructions of a shader core 
-// and attributes exposed latency to those instructions when signaled to do so 
-class ptx_inflight_memory_insn_tracker
-{
-public:
-    typedef std::map<const ptx_instruction *, int> insn_count_map;
+// a class that tracks the inflight memory instructions of a shader core
+// and attributes exposed latency to those instructions when signaled to do so
+class ptx_inflight_memory_insn_tracker {
+ public:
+  typedef std::map<const ptx_instruction *, int> insn_count_map;
 
-    void add_count(const ptx_instruction * pInsn, int count = 1)
-    {
-        ptx_inflight_memory_insns[pInsn] += count;
+  void add_count(const ptx_instruction *pInsn, int count = 1) {
+    ptx_inflight_memory_insns[pInsn] += count;
+  }
+
+  void sub_count(const ptx_instruction *pInsn, int count = 1) {
+    insn_count_map::iterator i_insncount;
+    i_insncount = ptx_inflight_memory_insns.find(pInsn);
+
+    assert(i_insncount != ptx_inflight_memory_insns.end());
+
+    i_insncount->second -= count;
+
+    if (i_insncount->second <= 0) {
+      ptx_inflight_memory_insns.erase(i_insncount);
     }
+  }
 
-    void sub_count(const ptx_instruction * pInsn, int count = 1)
-    {
-        insn_count_map::iterator i_insncount; 
-        i_insncount = ptx_inflight_memory_insns.find(pInsn);
+  void attribute_exposed_latency(int count = 1) {
+    insn_count_map &exlat_insnmap = ptx_inflight_memory_insns;
+    insn_count_map::const_iterator i_exlatinsn;
 
-        assert(i_insncount != ptx_inflight_memory_insns.end());
-
-        i_insncount->second -= count;
-
-        if (i_insncount->second <= 0) {
-            ptx_inflight_memory_insns.erase(i_insncount);
-        }
+    i_exlatinsn = exlat_insnmap.begin();
+    for (; i_exlatinsn != exlat_insnmap.end(); ++i_exlatinsn) {
+      const ptx_instruction *pInsn = i_exlatinsn->first;
+      ptx_file_line_stats &line_stats =
+          ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(),
+                                                    pInsn->source_line())];
+      line_stats.exposed_latency += count;
     }
+  }
 
-    void attribute_exposed_latency(int count = 1)
-    {
-        insn_count_map &exlat_insnmap = ptx_inflight_memory_insns;
-        insn_count_map::const_iterator i_exlatinsn;
-
-        i_exlatinsn = exlat_insnmap.begin();
-        for (; i_exlatinsn != exlat_insnmap.end(); ++i_exlatinsn) {
-            const ptx_instruction *pInsn = i_exlatinsn->first;
-            ptx_file_line_stats& line_stats = ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(), pInsn->source_line())];
-            line_stats.exposed_latency += count;
-        }
-    }
-
-    insn_count_map ptx_inflight_memory_insns;
+  insn_count_map ptx_inflight_memory_insns;
 };
 
 static ptx_inflight_memory_insn_tracker *inflight_mem_tracker = NULL;
 
-void ptx_file_line_stats_create_exposed_latency_tracker(int n_shader_cores)
-{
-    inflight_mem_tracker = new ptx_inflight_memory_insn_tracker[n_shader_cores];
+void ptx_file_line_stats_create_exposed_latency_tracker(int n_shader_cores) {
+  inflight_mem_tracker = new ptx_inflight_memory_insn_tracker[n_shader_cores];
 }
 
 // add an inflight memory instruction
-void ptx_stats::ptx_file_line_stats_add_inflight_memory_insn(int sc_id, unsigned pc)
-{
-    const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
+void ptx_stats::ptx_file_line_stats_add_inflight_memory_insn(int sc_id,
+                                                             unsigned pc) {
+  const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
 
-    inflight_mem_tracker[sc_id].add_count(pInsn);
+  inflight_mem_tracker[sc_id].add_count(pInsn);
 }
 
 // remove an inflight memory instruction
-void ptx_stats::ptx_file_line_stats_sub_inflight_memory_insn(int sc_id, unsigned pc)
-{
-    const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
+void ptx_stats::ptx_file_line_stats_sub_inflight_memory_insn(int sc_id,
+                                                             unsigned pc) {
+  const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
 
-    inflight_mem_tracker[sc_id].sub_count(pInsn);
+  inflight_mem_tracker[sc_id].sub_count(pInsn);
 }
 
-// attribute an empty cycle in the pipeline (exposed latency) to the ptx memory instructions in flight
-void ptx_file_line_stats_commit_exposed_latency(int sc_id, int exposed_latency)
-{
-    assert(exposed_latency > 0);
-    inflight_mem_tracker[sc_id].attribute_exposed_latency(exposed_latency);
+// attribute an empty cycle in the pipeline (exposed latency) to the ptx memory
+// instructions in flight
+void ptx_file_line_stats_commit_exposed_latency(int sc_id,
+                                                int exposed_latency) {
+  assert(exposed_latency > 0);
+  inflight_mem_tracker[sc_id].attribute_exposed_latency(exposed_latency);
 }
 
 // attribute the number of warp divergence to a ptx instruction
-void ptx_stats::ptx_file_line_stats_add_warp_divergence(unsigned pc, unsigned n_way_divergence)
-{
-    const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
-    
-    ptx_file_line_stats& line_stats = ptx_file_line_stats_tracker[ptx_file_line(pInsn->source_file(), pInsn->source_line())];
-    line_stats.warp_divergence += n_way_divergence;
-}
+void ptx_stats::ptx_file_line_stats_add_warp_divergence(
+    unsigned pc, unsigned n_way_divergence) {
+  const ptx_instruction *pInsn = gpgpu_ctx->pc_to_instruction(pc);
 
+  ptx_file_line_stats &line_stats = ptx_file_line_stats_tracker[ptx_file_line(
+      pInsn->source_file(), pInsn->source_line())];
+  line_stats.warp_divergence += n_way_divergence;
+}

--- a/src/cuda-sim/ptx-stats.h
+++ b/src/cuda-sim/ptx-stats.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -27,14 +25,15 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#pragma once
+#pragma once 
 
 #include "../option_parser.h"
+
 
 #ifdef __cplusplus
 // stat collection interface to cuda-sim
 class ptx_instruction;
-void ptx_file_line_stats_add_exec_count(const ptx_instruction* pInsn);
+void ptx_file_line_stats_add_exec_count(const ptx_instruction *pInsn);
 #endif
 
 // stat collection interface to gpgpu-sim
@@ -42,29 +41,28 @@ void ptx_file_line_stats_add_exec_count(const ptx_instruction* pInsn);
 void ptx_file_line_stats_create_exposed_latency_tracker(int n_shader_cores);
 void ptx_file_line_stats_commit_exposed_latency(int sc_id, int exposed_latency);
 
+
 class gpgpu_context;
 class ptx_stats {
- public:
-  ptx_stats(gpgpu_context* ctx) {
-    ptx_line_stats_filename = NULL;
-    gpgpu_ctx = ctx;
-  }
-  char* ptx_line_stats_filename;
-  bool enable_ptx_file_line_stats;
-  gpgpu_context* gpgpu_ctx;
-  // set options
-  void ptx_file_line_stats_options(option_parser_t opp);
+    public:
+	ptx_stats(gpgpu_context* ctx) {
+	    ptx_line_stats_filename = NULL;
+	    gpgpu_ctx = ctx;
+	}
+	char * ptx_line_stats_filename;
+	bool enable_ptx_file_line_stats;
+	gpgpu_context* gpgpu_ctx;
+	// set options
+	void ptx_file_line_stats_options(option_parser_t opp);
 
-  // output stats to a file
-  void ptx_file_line_stats_write_file();
-  // stat collection interface to gpgpu-sim
-  void ptx_file_line_stats_add_latency(unsigned pc, unsigned latency);
-  void ptx_file_line_stats_add_dram_traffic(unsigned pc, unsigned dram_traffic);
-  void ptx_file_line_stats_add_smem_bank_conflict(unsigned pc,
-                                                  unsigned n_way_bkconflict);
-  void ptx_file_line_stats_add_uncoalesced_gmem(unsigned pc, unsigned n_access);
-  void ptx_file_line_stats_add_inflight_memory_insn(int sc_id, unsigned pc);
-  void ptx_file_line_stats_sub_inflight_memory_insn(int sc_id, unsigned pc);
-  void ptx_file_line_stats_add_warp_divergence(unsigned pc,
-                                               unsigned n_way_divergence);
+	// output stats to a file
+	void ptx_file_line_stats_write_file();
+	// stat collection interface to gpgpu-sim
+	void ptx_file_line_stats_add_latency(unsigned pc, unsigned latency);
+	void ptx_file_line_stats_add_dram_traffic(unsigned pc, unsigned dram_traffic);
+	void ptx_file_line_stats_add_smem_bank_conflict(unsigned pc, unsigned n_way_bkconflict);
+	void ptx_file_line_stats_add_uncoalesced_gmem(unsigned pc, unsigned n_access);
+	void ptx_file_line_stats_add_inflight_memory_insn(int sc_id, unsigned pc);
+	void ptx_file_line_stats_sub_inflight_memory_insn(int sc_id, unsigned pc);
+	void ptx_file_line_stats_add_warp_divergence(unsigned pc, unsigned n_way_divergence);
 };

--- a/src/cuda-sim/ptx-stats.h
+++ b/src/cuda-sim/ptx-stats.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -25,15 +27,14 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#pragma once 
+#pragma once
 
 #include "../option_parser.h"
-
 
 #ifdef __cplusplus
 // stat collection interface to cuda-sim
 class ptx_instruction;
-void ptx_file_line_stats_add_exec_count(const ptx_instruction *pInsn);
+void ptx_file_line_stats_add_exec_count(const ptx_instruction* pInsn);
 #endif
 
 // stat collection interface to gpgpu-sim
@@ -41,28 +42,29 @@ void ptx_file_line_stats_add_exec_count(const ptx_instruction *pInsn);
 void ptx_file_line_stats_create_exposed_latency_tracker(int n_shader_cores);
 void ptx_file_line_stats_commit_exposed_latency(int sc_id, int exposed_latency);
 
-
 class gpgpu_context;
 class ptx_stats {
-    public:
-	ptx_stats(gpgpu_context* ctx) {
-	    ptx_line_stats_filename = NULL;
-	    gpgpu_ctx = ctx;
-	}
-	char * ptx_line_stats_filename;
-	bool enable_ptx_file_line_stats;
-	gpgpu_context* gpgpu_ctx;
-	// set options
-	void ptx_file_line_stats_options(option_parser_t opp);
+ public:
+  ptx_stats(gpgpu_context* ctx) {
+    ptx_line_stats_filename = NULL;
+    gpgpu_ctx = ctx;
+  }
+  char* ptx_line_stats_filename;
+  bool enable_ptx_file_line_stats;
+  gpgpu_context* gpgpu_ctx;
+  // set options
+  void ptx_file_line_stats_options(option_parser_t opp);
 
-	// output stats to a file
-	void ptx_file_line_stats_write_file();
-	// stat collection interface to gpgpu-sim
-	void ptx_file_line_stats_add_latency(unsigned pc, unsigned latency);
-	void ptx_file_line_stats_add_dram_traffic(unsigned pc, unsigned dram_traffic);
-	void ptx_file_line_stats_add_smem_bank_conflict(unsigned pc, unsigned n_way_bkconflict);
-	void ptx_file_line_stats_add_uncoalesced_gmem(unsigned pc, unsigned n_access);
-	void ptx_file_line_stats_add_inflight_memory_insn(int sc_id, unsigned pc);
-	void ptx_file_line_stats_sub_inflight_memory_insn(int sc_id, unsigned pc);
-	void ptx_file_line_stats_add_warp_divergence(unsigned pc, unsigned n_way_divergence);
+  // output stats to a file
+  void ptx_file_line_stats_write_file();
+  // stat collection interface to gpgpu-sim
+  void ptx_file_line_stats_add_latency(unsigned pc, unsigned latency);
+  void ptx_file_line_stats_add_dram_traffic(unsigned pc, unsigned dram_traffic);
+  void ptx_file_line_stats_add_smem_bank_conflict(unsigned pc,
+                                                  unsigned n_way_bkconflict);
+  void ptx_file_line_stats_add_uncoalesced_gmem(unsigned pc, unsigned n_access);
+  void ptx_file_line_stats_add_inflight_memory_insn(int sc_id, unsigned pc);
+  void ptx_file_line_stats_sub_inflight_memory_insn(int sc_id, unsigned pc);
+  void ptx_file_line_stats_add_warp_divergence(unsigned pc,
+                                               unsigned n_way_divergence);
 };

--- a/src/cuda-sim/ptx-stats.h
+++ b/src/cuda-sim/ptx-stats.h
@@ -7,33 +7,33 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
-#pragma once 
+#pragma once
 
 #include "../option_parser.h"
-
 
 #ifdef __cplusplus
 // stat collection interface to cuda-sim
 class ptx_instruction;
-void ptx_file_line_stats_add_exec_count(const ptx_instruction *pInsn);
+void ptx_file_line_stats_add_exec_count(const ptx_instruction* pInsn);
 #endif
 
 // stat collection interface to gpgpu-sim
@@ -41,28 +41,29 @@ void ptx_file_line_stats_add_exec_count(const ptx_instruction *pInsn);
 void ptx_file_line_stats_create_exposed_latency_tracker(int n_shader_cores);
 void ptx_file_line_stats_commit_exposed_latency(int sc_id, int exposed_latency);
 
-
 class gpgpu_context;
 class ptx_stats {
-    public:
-	ptx_stats(gpgpu_context* ctx) {
-	    ptx_line_stats_filename = NULL;
-	    gpgpu_ctx = ctx;
-	}
-	char * ptx_line_stats_filename;
-	bool enable_ptx_file_line_stats;
-	gpgpu_context* gpgpu_ctx;
-	// set options
-	void ptx_file_line_stats_options(option_parser_t opp);
+ public:
+  ptx_stats(gpgpu_context* ctx) {
+    ptx_line_stats_filename = NULL;
+    gpgpu_ctx = ctx;
+  }
+  char* ptx_line_stats_filename;
+  bool enable_ptx_file_line_stats;
+  gpgpu_context* gpgpu_ctx;
+  // set options
+  void ptx_file_line_stats_options(option_parser_t opp);
 
-	// output stats to a file
-	void ptx_file_line_stats_write_file();
-	// stat collection interface to gpgpu-sim
-	void ptx_file_line_stats_add_latency(unsigned pc, unsigned latency);
-	void ptx_file_line_stats_add_dram_traffic(unsigned pc, unsigned dram_traffic);
-	void ptx_file_line_stats_add_smem_bank_conflict(unsigned pc, unsigned n_way_bkconflict);
-	void ptx_file_line_stats_add_uncoalesced_gmem(unsigned pc, unsigned n_access);
-	void ptx_file_line_stats_add_inflight_memory_insn(int sc_id, unsigned pc);
-	void ptx_file_line_stats_sub_inflight_memory_insn(int sc_id, unsigned pc);
-	void ptx_file_line_stats_add_warp_divergence(unsigned pc, unsigned n_way_divergence);
+  // output stats to a file
+  void ptx_file_line_stats_write_file();
+  // stat collection interface to gpgpu-sim
+  void ptx_file_line_stats_add_latency(unsigned pc, unsigned latency);
+  void ptx_file_line_stats_add_dram_traffic(unsigned pc, unsigned dram_traffic);
+  void ptx_file_line_stats_add_smem_bank_conflict(unsigned pc,
+                                                  unsigned n_way_bkconflict);
+  void ptx_file_line_stats_add_uncoalesced_gmem(unsigned pc, unsigned n_access);
+  void ptx_file_line_stats_add_inflight_memory_insn(int sc_id, unsigned pc);
+  void ptx_file_line_stats_sub_inflight_memory_insn(int sc_id, unsigned pc);
+  void ptx_file_line_stats_add_warp_divergence(unsigned pc,
+                                               unsigned n_way_divergence);
 };

--- a/src/cuda-sim/ptx_ir.cc
+++ b/src/cuda-sim/ptx_ir.cc
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2011, Tor M. Aamodt, Ali Bakhoda, Wilson W.L. Fung,
-// George L. Yuan
+// George L. Yuan 
 // The University of British Columbia
 // All rights reserved.
 //
@@ -8,16 +8,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -28,1244 +26,1152 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "ptx_ir.h"
 #include "ptx_parser.h"
-typedef void *yyscan_t;
-#include <assert.h>
+#include "ptx_ir.h"
+typedef void * yyscan_t;
+#include "ptx.tab.h"
+#include "opcodes.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include <algorithm>
 #include <list>
+#include <assert.h>
+#include <algorithm>
 #include "assert.h"
-#include "opcodes.h"
-#include "ptx.tab.h"
 
-#include "../../libcuda/gpgpu_context.h"
 #include "cuda-sim.h"
+#include "../../libcuda/gpgpu_context.h"
 
 #define STR_SIZE 1024
 
-const ptx_instruction *gpgpu_context::pc_to_instruction(unsigned pc) {
-  if (pc < s_g_pc_to_insn.size())
-    return s_g_pc_to_insn[pc];
-  else
-    return NULL;
-}
-
-unsigned symbol::get_uid() {
-  unsigned result = (gpgpu_ctx->symbol_sm_next_uid)++;
-  return result;
-}
-
-void symbol::add_initializer(const std::list<operand_info> &init) {
-  m_initializer = init;
-}
-
-void symbol::print_info(FILE *fp) const {
-  fprintf(fp, "uid:%u, decl:%s, type:%p, ", m_uid, m_decl_location.c_str(),
-          m_type);
-  if (m_address_valid) fprintf(fp, "<address valid>, ");
-  if (m_is_label) fprintf(fp, " is_label ");
-  if (m_is_shared) fprintf(fp, " is_shared ");
-  if (m_is_const) fprintf(fp, " is_const ");
-  if (m_is_global) fprintf(fp, " is_global ");
-  if (m_is_local) fprintf(fp, " is_local ");
-  if (m_is_tex) fprintf(fp, " is_tex ");
-  if (m_is_func_addr) fprintf(fp, " is_func_addr ");
-  if (m_function) fprintf(fp, " %p ", m_function);
-}
-
-symbol_table::symbol_table() { assert(0); }
-
-symbol_table::symbol_table(const char *scope_name, unsigned entry_point,
-                           symbol_table *parent, gpgpu_context *ctx) {
-  gpgpu_ctx = ctx;
-  m_scope_name = std::string(scope_name);
-  m_reg_allocator = 0;
-  m_shared_next = 0;
-  m_const_next = 0;
-  m_global_next = 0x100;
-  m_local_next = 0;
-  m_tex_next = 0;
-
-  // Jin: handle instruction group for cdp
-  m_inst_group_id = 0;
-
-  m_parent = parent;
-  if (m_parent) {
-    m_shared_next = m_parent->m_shared_next;
-    m_global_next = m_parent->m_global_next;
-  }
-}
-
-void symbol_table::set_name(const char *name) {
-  m_scope_name = std::string(name);
-}
-
-const ptx_version &symbol_table::get_ptx_version() const {
-  if (m_parent == NULL)
-    return m_ptx_version;
-  else
-    return m_parent->get_ptx_version();
-}
-
-unsigned symbol_table::get_sm_target() const {
-  if (m_parent == NULL)
-    return m_ptx_version.target();
-  else
-    return m_parent->get_sm_target();
-}
-
-void symbol_table::set_ptx_version(float ver, unsigned ext) {
-  m_ptx_version = ptx_version(ver, ext);
-}
-
-void symbol_table::set_sm_target(const char *target, const char *ext,
-                                 const char *ext2) {
-  m_ptx_version.set_target(target, ext, ext2);
-}
-
-symbol *symbol_table::lookup(const char *identifier) {
-  std::string key(identifier);
-  std::map<std::string, symbol *>::iterator i = m_symbols.find(key);
-  if (i != m_symbols.end()) {
-    return i->second;
-  }
-  if (m_parent) {
-    return m_parent->lookup(identifier);
-  }
-  return NULL;
-}
-
-symbol *symbol_table::add_variable(const char *identifier,
-                                   const type_info *type, unsigned size,
-                                   const char *filename, unsigned line) {
-  char buf[1024];
-  std::string key(identifier);
-  assert(m_symbols.find(key) == m_symbols.end());
-  snprintf(buf, 1024, "%s:%u", filename, line);
-  symbol *s = new symbol(identifier, type, buf, size, gpgpu_ctx);
-  m_symbols[key] = s;
-
-  if (type != NULL && type->get_key().is_global()) {
-    m_globals.push_back(s);
-  }
-  if (type != NULL && type->get_key().is_const()) {
-    m_consts.push_back(s);
-  }
-
-  return s;
-}
-
-void symbol_table::add_function(function_info *func, const char *filename,
-                                unsigned linenumber) {
-  std::map<std::string, symbol *>::iterator i =
-      m_symbols.find(func->get_name());
-  if (i != m_symbols.end()) return;
-  char buf[1024];
-  snprintf(buf, 1024, "%s:%u", filename, linenumber);
-  type_info *type = add_type(func);
-  symbol *s = new symbol(func->get_name().c_str(), type, buf, 0, gpgpu_ctx);
-  s->set_function(func);
-  m_symbols[func->get_name()] = s;
-}
-
-// Jin: handle instruction group for cdp
-symbol_table *symbol_table::start_inst_group() {
-  char inst_group_name[4096];
-  snprintf(inst_group_name, 4096, "%s_inst_group_%u", m_scope_name.c_str(),
-           m_inst_group_id);
-
-  // previous added
-  assert(m_inst_group_symtab.find(std::string(inst_group_name)) ==
-         m_inst_group_symtab.end());
-  symbol_table *sym_table =
-      new symbol_table(inst_group_name, 3 /*inst group*/, this, gpgpu_ctx);
-
-  sym_table->m_global_next = m_global_next;
-  sym_table->m_shared_next = m_shared_next;
-  sym_table->m_local_next = m_local_next;
-  sym_table->m_reg_allocator = m_reg_allocator;
-  sym_table->m_tex_next = m_tex_next;
-  sym_table->m_const_next = m_const_next;
-
-  m_inst_group_symtab[std::string(inst_group_name)] = sym_table;
-
-  return sym_table;
-}
-
-symbol_table *symbol_table::end_inst_group() {
-  symbol_table *sym_table = m_parent;
-
-  sym_table->m_global_next = m_global_next;
-  sym_table->m_shared_next = m_shared_next;
-  sym_table->m_local_next = m_local_next;
-  sym_table->m_reg_allocator = m_reg_allocator;
-  sym_table->m_tex_next = m_tex_next;
-  sym_table->m_const_next = m_const_next;
-  sym_table->m_inst_group_id++;
-
-  return sym_table;
-}
-
-void register_ptx_function(const char *name,
-                           function_info *impl);  // either libcuda or libopencl
-
-bool symbol_table::add_function_decl(const char *name, int entry_point,
-                                     function_info **func_info,
-                                     symbol_table **sym_table) {
-  std::string key = std::string(name);
-  bool prior_decl = false;
-  if (m_function_info_lookup.find(key) != m_function_info_lookup.end()) {
-    *func_info = m_function_info_lookup[key];
-    prior_decl = true;
-  } else {
-    *func_info = new function_info(entry_point, gpgpu_ctx);
-    (*func_info)->set_name(name);
-    (*func_info)->set_maxnt_id(0);
-    m_function_info_lookup[key] = *func_info;
-  }
-
-  if (m_function_symtab_lookup.find(key) != m_function_symtab_lookup.end()) {
-    assert(prior_decl);
-    *sym_table = m_function_symtab_lookup[key];
-  } else {
-    assert(!prior_decl);
-    *sym_table = new symbol_table("", entry_point, this, gpgpu_ctx);
-
-    // Initial setup code to support a register represented as "_".
-    // This register is used when an instruction operand is
-    // not read or written.  However, the parser must recognize it
-    // as a legitimate register but we do not want to pass
-    // it to the micro-architectural register to the performance simulator.
-    // For this purpose we add a symbol to the symbol table but
-    // mark it as a non_arch_reg so it does not effect the performance sim.
-    type_info_key null_key(reg_space, 0, 0, 0, 0, 0);
-    null_key.set_is_non_arch_reg();
-    // First param is null - which is bad.
-    // However, the first parameter is actually unread in the constructor...
-    // TODO - remove the symbol_table* from type_info
-    type_info *null_type_info = new type_info(NULL, null_key);
-    symbol *null_reg =
-        (*sym_table)->add_variable("_", null_type_info, 0, "", 0);
-    null_reg->set_regno(0, 0);
-
-    (*sym_table)->set_name(name);
-    (*func_info)->set_symtab(*sym_table);
-    m_function_symtab_lookup[key] = *sym_table;
-    assert((*func_info)->get_symtab() == *sym_table);
-    register_ptx_function(name, *func_info);
-  }
-  return prior_decl;
-}
-
-function_info *symbol_table::lookup_function(std::string name) {
-  std::string key = std::string(name);
-  std::map<std::string, function_info *>::iterator it =
-      m_function_info_lookup.find(key);
-  assert(it != m_function_info_lookup.end());
-  return it->second;
-}
-
-type_info *symbol_table::add_type(memory_space_t space_spec,
-                                  int scalar_type_spec, int vector_spec,
-                                  int alignment_spec, int extern_spec) {
-  if (space_spec == param_space_unclassified) space_spec = param_space_local;
-  type_info_key t(space_spec, scalar_type_spec, vector_spec, alignment_spec,
-                  extern_spec, 0);
-  type_info *pt;
-  pt = new type_info(this, t);
-  return pt;
-}
-
-type_info *symbol_table::add_type(function_info *func) {
-  type_info_key t;
-  type_info *pt;
-  t.set_is_func();
-  pt = new type_info(this, t);
-  return pt;
-}
-
-type_info *symbol_table::get_array_type(type_info *base_type,
-                                        unsigned array_dim) {
-  type_info_key t = base_type->get_key();
-  t.set_array_dim(array_dim);
-  type_info *pt = new type_info(this, t);
-  // Where else is m_types being used? As of now, I dont find any use of it and
-  // causing seg fault. So disabling m_types.
-  // TODO: find where m_types can be used in future and solve the seg fault.
-  // pt = m_types[t] = new type_info(this,t);
-  return pt;
-}
-
-void symbol_table::set_label_address(const symbol *label, unsigned addr) {
-  std::map<std::string, symbol *>::iterator i = m_symbols.find(label->name());
-  assert(i != m_symbols.end());
-  symbol *s = i->second;
-  s->set_label_address(addr);
-}
-
-void symbol_table::dump() {
-  printf("\n\n");
-  printf("Symbol table for \"%s\":\n", m_scope_name.c_str());
-  std::map<std::string, symbol *>::iterator i;
-  for (i = m_symbols.begin(); i != m_symbols.end(); i++) {
-    printf("%30s : ", i->first.c_str());
-    if (i->second)
-      i->second->print_info(stdout);
+const ptx_instruction* gpgpu_context::pc_to_instruction(unsigned pc) 
+{
+    if( pc < s_g_pc_to_insn.size() )
+	return s_g_pc_to_insn[pc];
     else
-      printf(" <no symbol object> ");
-    printf("\n");
-  }
-  printf("\n");
+	return NULL;
 }
 
-unsigned operand_info::get_uid() {
-  unsigned result = (gpgpu_ctx->operand_info_sm_next_uid)++;
-  return result;
+unsigned symbol::get_uid()
+{
+   unsigned result = (gpgpu_ctx->symbol_sm_next_uid)++;
+   return result;
 }
 
-std::list<ptx_instruction *>::iterator
-function_info::find_next_real_instruction(
-    std::list<ptx_instruction *>::iterator i) {
-  while ((i != m_instructions.end()) && (*i)->is_label()) i++;
-  return i;
+void symbol::add_initializer( const std::list<operand_info> &init )
+{
+   m_initializer = init;
 }
 
-void function_info::create_basic_blocks() {
-  std::list<ptx_instruction *> leaders;
-  std::list<ptx_instruction *>::iterator i, l;
-
-  // first instruction is a leader
-  i = m_instructions.begin();
-  leaders.push_back(*i);
-  i++;
-  while (i != m_instructions.end()) {
-    ptx_instruction *pI = *i;
-    if (pI->is_label()) {
-      leaders.push_back(pI);
-      i = find_next_real_instruction(++i);
-    } else {
-      switch (pI->get_opcode()) {
-        case BRA_OP:
-        case RET_OP:
-        case EXIT_OP:
-        case RETP_OP:
-        case BREAK_OP:
-          i++;
-          if (i != m_instructions.end()) leaders.push_back(*i);
-          i = find_next_real_instruction(i);
-          break;
-        case CALL_OP:
-        case CALLP_OP:
-          if (pI->has_pred()) {
-            printf("GPGPU-Sim PTX: Warning found predicated call\n");
-            i++;
-            if (i != m_instructions.end()) leaders.push_back(*i);
-            i = find_next_real_instruction(i);
-          } else
-            i++;
-          break;
-        default:
-          i++;
-      }
-    }
-  }
-
-  if (leaders.empty()) {
-    printf("GPGPU-Sim PTX: Function \'%s\' has no basic blocks\n",
-           m_name.c_str());
-    return;
-  }
-
-  unsigned bb_id = 0;
-  l = leaders.begin();
-  i = m_instructions.begin();
-  m_basic_blocks.push_back(
-      new basic_block_t(bb_id++, *find_next_real_instruction(i), NULL, 1, 0));
-  ptx_instruction *last_real_inst = *(l++);
-
-  for (; i != m_instructions.end(); i++) {
-    ptx_instruction *pI = *i;
-    if (l != leaders.end() && *i == *l) {
-      // found start of next basic block
-      m_basic_blocks.back()->ptx_end = last_real_inst;
-      if (find_next_real_instruction(i) !=
-          m_instructions.end()) {  // if not bogus trailing label
-        m_basic_blocks.push_back(new basic_block_t(
-            bb_id++, *find_next_real_instruction(i), NULL, 0, 0));
-        last_real_inst = *find_next_real_instruction(i);
-      }
-      // start search for next leader
-      l++;
-    }
-    pI->assign_bb(m_basic_blocks.back());
-    if (!pI->is_label()) last_real_inst = pI;
-  }
-  m_basic_blocks.back()->ptx_end = last_real_inst;
-  m_basic_blocks.push_back(
-      /*exit basic block*/ new basic_block_t(bb_id, NULL, NULL, 0, 1));
+void symbol::print_info(FILE *fp) const
+{
+   fprintf(fp,"uid:%u, decl:%s, type:%p, ", m_uid, m_decl_location.c_str(), m_type );
+   if( m_address_valid ) 
+      fprintf(fp,"<address valid>, ");
+   if( m_is_label )
+      fprintf(fp," is_label ");
+   if( m_is_shared )
+      fprintf(fp," is_shared ");
+   if( m_is_const )
+      fprintf(fp," is_const ");
+   if( m_is_global )
+      fprintf(fp," is_global ");
+   if( m_is_local )
+      fprintf(fp," is_local ");
+   if( m_is_tex )
+      fprintf(fp," is_tex ");
+   if( m_is_func_addr )
+      fprintf(fp," is_func_addr ");
+   if( m_function ) 
+      fprintf(fp," %p ", m_function );
 }
 
-void function_info::print_basic_blocks() {
-  printf("Printing basic blocks for function \'%s\':\n", m_name.c_str());
-  std::list<ptx_instruction *>::iterator ptx_itr;
-  unsigned last_bb = 0;
-  for (ptx_itr = m_instructions.begin(); ptx_itr != m_instructions.end();
-       ptx_itr++) {
-    if ((*ptx_itr)->get_bb()) {
-      if ((*ptx_itr)->get_bb()->bb_id != last_bb) {
-        printf("\n");
-        last_bb = (*ptx_itr)->get_bb()->bb_id;
-      }
-      printf("bb_%02u\t: ", (*ptx_itr)->get_bb()->bb_id);
-      (*ptx_itr)->print_insn();
+symbol_table::symbol_table() 
+{ 
+   assert(0); 
+}
+
+symbol_table::symbol_table( const char *scope_name, unsigned entry_point, symbol_table *parent, gpgpu_context* ctx )
+{
+   gpgpu_ctx = ctx;
+   m_scope_name = std::string(scope_name);
+   m_reg_allocator=0;
+   m_shared_next = 0;
+   m_const_next  = 0;
+   m_global_next = 0x100;
+   m_local_next  = 0;
+   m_tex_next = 0;
+
+   //Jin: handle instruction group for cdp
+   m_inst_group_id = 0;
+
+   m_parent = parent;
+   if ( m_parent ) {
+      m_shared_next = m_parent->m_shared_next;
+      m_global_next = m_parent->m_global_next;
+   }
+}
+
+void symbol_table::set_name( const char *name )
+{
+   m_scope_name = std::string(name);
+}
+
+const ptx_version &symbol_table::get_ptx_version() const 
+{ 
+   if( m_parent == NULL ) return m_ptx_version;
+   else return m_parent->get_ptx_version(); 
+}
+
+unsigned symbol_table::get_sm_target() const 
+{ 
+   if( m_parent == NULL ) 
+      return m_ptx_version.target();
+   else return m_parent->get_sm_target(); 
+}
+
+void symbol_table::set_ptx_version( float ver, unsigned ext ) 
+{ 
+   m_ptx_version = ptx_version(ver,ext); 
+}
+
+void symbol_table::set_sm_target( const char *target, const char *ext, const char *ext2 )
+{
+   m_ptx_version.set_target(target,ext,ext2);
+}
+
+symbol *symbol_table::lookup( const char *identifier ) 
+{
+   std::string key(identifier);
+   std::map<std::string, symbol *>::iterator i = m_symbols.find(key);
+   if (  i != m_symbols.end() ) {
+      return i->second;
+   }
+   if ( m_parent ) {
+      return m_parent->lookup(identifier);
+   }
+   return NULL;
+}
+
+symbol *symbol_table::add_variable( const char *identifier, const type_info *type, unsigned size, const char *filename, unsigned line )
+{
+   char buf[1024];
+   std::string key(identifier);
+   assert( m_symbols.find(key) == m_symbols.end() );
+   snprintf(buf,1024,"%s:%u",filename,line);
+   symbol *s = new symbol(identifier,type,buf,size,gpgpu_ctx);
+   m_symbols[ key ] = s;
+
+   if ( type != NULL && type->get_key().is_global()  ) {
+      m_globals.push_back(s);
+   }
+   if ( type != NULL && type->get_key().is_const()  ) {
+      m_consts.push_back(s);
+   }
+
+   return s;
+}
+
+void symbol_table::add_function( function_info *func, const char *filename, unsigned linenumber )
+{
+   std::map<std::string, symbol *>::iterator i = m_symbols.find( func->get_name() );
+   if( i != m_symbols.end() )
+      return;
+   char buf[1024];
+   snprintf(buf,1024,"%s:%u",filename,linenumber);
+   type_info *type = add_type( func );
+   symbol *s = new symbol(func->get_name().c_str(),type,buf,0,gpgpu_ctx);
+   s->set_function(func);
+   m_symbols[ func->get_name() ] = s;
+}
+
+//Jin: handle instruction group for cdp
+symbol_table* symbol_table::start_inst_group() {
+   char inst_group_name[4096];
+   snprintf(inst_group_name, 4096, "%s_inst_group_%u", m_scope_name.c_str(), m_inst_group_id);
+
+   //previous added
+   assert(m_inst_group_symtab.find(std::string(inst_group_name)) == m_inst_group_symtab.end());
+   symbol_table *sym_table = new symbol_table(inst_group_name, 3/*inst group*/, this, gpgpu_ctx );
+ 
+   sym_table->m_global_next = m_global_next;
+   sym_table->m_shared_next = m_shared_next;
+   sym_table->m_local_next = m_local_next;
+   sym_table->m_reg_allocator = m_reg_allocator;
+   sym_table->m_tex_next = m_tex_next;
+   sym_table->m_const_next = m_const_next;
+
+   m_inst_group_symtab[std::string(inst_group_name)] = sym_table;
+
+   return sym_table;
+}
+
+symbol_table * symbol_table::end_inst_group() {
+   symbol_table * sym_table = m_parent;
+   
+   sym_table->m_global_next = m_global_next;
+   sym_table->m_shared_next = m_shared_next;
+   sym_table->m_local_next = m_local_next;
+   sym_table->m_reg_allocator = m_reg_allocator;
+   sym_table->m_tex_next = m_tex_next;
+   sym_table->m_const_next = m_const_next;
+   sym_table->m_inst_group_id++;
+
+   return sym_table;
+}
+
+void register_ptx_function( const char *name, function_info *impl ); // either libcuda or libopencl
+
+bool symbol_table::add_function_decl( const char *name, int entry_point, function_info **func_info, symbol_table **sym_table )
+{
+   std::string key = std::string(name);
+   bool prior_decl = false;
+   if( m_function_info_lookup.find(key) != m_function_info_lookup.end() ) {
+      *func_info = m_function_info_lookup[key];
+      prior_decl = true;
+   } else {
+      *func_info = new function_info(entry_point, gpgpu_ctx);
+      (*func_info)->set_name(name);
+      (*func_info)->set_maxnt_id(0);
+      m_function_info_lookup[key] = *func_info;
+   }
+
+   if( m_function_symtab_lookup.find(key) != m_function_symtab_lookup.end() ) {
+      assert( prior_decl );
+      *sym_table = m_function_symtab_lookup[key];
+   } else {
+      assert( !prior_decl );
+      *sym_table = new symbol_table( "", entry_point, this, gpgpu_ctx );
+      
+      // Initial setup code to support a register represented as "_".
+      // This register is used when an instruction operand is
+      // not read or written.  However, the parser must recognize it
+      // as a legitimate register but we do not want to pass
+      // it to the micro-architectural register to the performance simulator.
+      // For this purpose we add a symbol to the symbol table but
+      // mark it as a non_arch_reg so it does not effect the performance sim.
+      type_info_key null_key( reg_space, 0, 0, 0, 0, 0 );
+      null_key.set_is_non_arch_reg();
+      // First param is null - which is bad.
+      // However, the first parameter is actually unread in the constructor...
+      // TODO - remove the symbol_table* from type_info
+      type_info* null_type_info = new type_info( NULL, null_key );
+      symbol *null_reg = (*sym_table)->add_variable( "_", null_type_info, 0, "", 0 ); 
+      null_reg->set_regno(0, 0);
+      
+      (*sym_table)->set_name(name);
+      (*func_info)->set_symtab(*sym_table);
+      m_function_symtab_lookup[key] = *sym_table;
+      assert( (*func_info)->get_symtab() == *sym_table );
+      register_ptx_function(name,*func_info);
+   }
+   return prior_decl;
+}
+
+function_info *symbol_table::lookup_function( std::string name )
+{
+   std::string key = std::string(name);
+   std::map<std::string,function_info*>::iterator it = m_function_info_lookup.find(key);
+   assert ( it != m_function_info_lookup.end() );
+   return it->second;
+}
+
+type_info *symbol_table::add_type( memory_space_t space_spec, int scalar_type_spec, int vector_spec, int alignment_spec, int extern_spec )
+{
+   if( space_spec == param_space_unclassified ) 
+      space_spec = param_space_local;
+   type_info_key t(space_spec,scalar_type_spec,vector_spec,alignment_spec,extern_spec,0);
+   type_info *pt;
+   pt = new type_info(this,t);
+   return pt;
+}
+
+type_info *symbol_table::add_type( function_info *func )
+{
+   type_info_key t;
+   type_info *pt;
+   t.set_is_func();
+   pt = new type_info(this,t);
+   return pt;
+}
+
+type_info *symbol_table::get_array_type( type_info *base_type, unsigned array_dim ) 
+{
+   type_info_key t = base_type->get_key();
+   t.set_array_dim(array_dim);
+   type_info *pt = new type_info(this,t);
+   //Where else is m_types being used? As of now, I dont find any use of it and causing seg fault. So disabling m_types.
+   //TODO: find where m_types can be used in future and solve the seg fault.
+   //pt = m_types[t] = new type_info(this,t);
+   return pt;
+}
+
+void symbol_table::set_label_address( const symbol *label, unsigned addr )
+{
+   std::map<std::string, symbol *>::iterator i=m_symbols.find(label->name());
+   assert( i != m_symbols.end() );
+   symbol *s = i->second;
+   s->set_label_address(addr);
+}
+
+void symbol_table::dump()
+{
+   printf("\n\n");
+   printf("Symbol table for \"%s\":\n", m_scope_name.c_str() );
+   std::map<std::string, symbol *>::iterator i;
+   for( i=m_symbols.begin(); i!=m_symbols.end(); i++ ) {
+      printf("%30s : ", i->first.c_str() );
+      if( i->second ) 
+         i->second->print_info(stdout);
+      else
+         printf(" <no symbol object> ");
       printf("\n");
-    }
-  }
-  printf("\nSummary of basic blocks for \'%s\':\n", m_name.c_str());
-  std::vector<basic_block_t *>::iterator bb_itr;
-  for (bb_itr = m_basic_blocks.begin(); bb_itr != m_basic_blocks.end();
-       bb_itr++) {
-    printf("bb_%02u\t:", (*bb_itr)->bb_id);
-    if ((*bb_itr)->ptx_begin)
-      printf(" first: %s\t", ((*bb_itr)->ptx_begin)->get_opcode_cstr());
-    else
-      printf(" first: NULL\t");
-    if ((*bb_itr)->ptx_end) {
-      printf(" last: %s\t", ((*bb_itr)->ptx_end)->get_opcode_cstr());
-    } else
-      printf(" last: NULL\t");
-    printf("\n");
-  }
-  printf("\n");
+   }
+   printf("\n");
 }
 
-void function_info::print_basic_block_links() {
-  printf("Printing basic blocks links for function \'%s\':\n", m_name.c_str());
-  std::vector<basic_block_t *>::iterator bb_itr;
-  for (bb_itr = m_basic_blocks.begin(); bb_itr != m_basic_blocks.end();
-       bb_itr++) {
-    printf("ID: %d\t:", (*bb_itr)->bb_id);
-    if (!(*bb_itr)->predecessor_ids.empty()) {
-      printf("Predecessors:");
-      std::set<int>::iterator p;
-      for (p = (*bb_itr)->predecessor_ids.begin();
-           p != (*bb_itr)->predecessor_ids.end(); p++) {
-        printf(" %d", *p);
-      }
-      printf("\t");
-    }
-    if (!(*bb_itr)->successor_ids.empty()) {
-      printf("Successors:");
-      std::set<int>::iterator s;
-      for (s = (*bb_itr)->successor_ids.begin();
-           s != (*bb_itr)->successor_ids.end(); s++) {
-        printf(" %d", *s);
-      }
-    }
-    printf("\n");
-  }
-}
-operand_info *function_info::find_break_target(
-    ptx_instruction *p_break_insn)  // find the target of a break instruction
+unsigned operand_info::get_uid()
 {
-  const basic_block_t *break_bb = p_break_insn->get_bb();
-  // go through the dominator tree
-  for (const basic_block_t *p_bb = break_bb; p_bb->immediatedominator_id != -1;
-       p_bb = m_basic_blocks[p_bb->immediatedominator_id]) {
-    // reverse search through instructions in basic block for breakaddr
-    // instruction
-    unsigned insn_addr = p_bb->ptx_end->get_m_instr_mem_index();
-    while (insn_addr >= p_bb->ptx_begin->get_m_instr_mem_index()) {
-      ptx_instruction *pI = m_instr_mem[insn_addr];
-      insn_addr -= 1;
-      if (pI == NULL)
-        continue;  // temporary solution for variable size instructions
-      if (pI->get_opcode() == BREAKADDR_OP) {
-        return &(pI->dst());
-      }
-    }
-  }
-
-  assert(0);
-
-  // lazy fallback: just traverse backwards?
-  for (int insn_addr = p_break_insn->get_m_instr_mem_index(); insn_addr >= 0;
-       insn_addr--) {
-    ptx_instruction *pI = m_instr_mem[insn_addr];
-    if (pI->get_opcode() == BREAKADDR_OP) {
-      return &(pI->dst());
-    }
-  }
-
-  return NULL;
+   unsigned result = (gpgpu_ctx->operand_info_sm_next_uid)++;
+   return result;
 }
-void function_info::connect_basic_blocks()  // iterate across m_basic_blocks of
-                                            // function, connecting basic blocks
-                                            // together
+
+std::list<ptx_instruction*>::iterator function_info::find_next_real_instruction( std::list<ptx_instruction*>::iterator i)
 {
-  std::vector<basic_block_t *>::iterator bb_itr;
-  std::vector<basic_block_t *>::iterator bb_target_itr;
-  basic_block_t *exit_bb = m_basic_blocks.back();
-
-  // start from first basic block, which we know is the entry point
-  bb_itr = m_basic_blocks.begin();
-  for (bb_itr = m_basic_blocks.begin(); bb_itr != m_basic_blocks.end();
-       bb_itr++) {
-    ptx_instruction *pI = (*bb_itr)->ptx_end;
-    if ((*bb_itr)->is_exit)  // reached last basic block, no successors to link
-      continue;
-    if (pI->get_opcode() == RETP_OP || pI->get_opcode() == RET_OP ||
-        pI->get_opcode() == EXIT_OP) {
-      (*bb_itr)->successor_ids.insert(exit_bb->bb_id);
-      exit_bb->predecessor_ids.insert((*bb_itr)->bb_id);
-      if (pI->has_pred()) {
-        printf("GPGPU-Sim PTX: Warning detected predicated return/exit.\n");
-        // if predicated, add link to next block
-        unsigned next_addr = pI->get_m_instr_mem_index() + pI->inst_size();
-        if (next_addr < m_instr_mem_size && m_instr_mem[next_addr]) {
-          basic_block_t *next_bb = m_instr_mem[next_addr]->get_bb();
-          (*bb_itr)->successor_ids.insert(next_bb->bb_id);
-          next_bb->predecessor_ids.insert((*bb_itr)->bb_id);
-        }
-      }
-      continue;
-    } else if (pI->get_opcode() == BRA_OP) {
-      // find successor and link that basic_block to this one
-      operand_info &target = pI->dst();  // get operand, e.g. target name
-      unsigned addr = labels[target.name()];
-      ptx_instruction *target_pI = m_instr_mem[addr];
-      basic_block_t *target_bb = target_pI->get_bb();
-      (*bb_itr)->successor_ids.insert(target_bb->bb_id);
-      target_bb->predecessor_ids.insert((*bb_itr)->bb_id);
-    }
-
-    if (!(pI->get_opcode() == BRA_OP && (!pI->has_pred()))) {
-      // if basic block does not end in an unpredicated branch,
-      // then next basic block is also successor
-      // (this is better than testing for .uni)
-      unsigned next_addr = pI->get_m_instr_mem_index() + pI->inst_size();
-      basic_block_t *next_bb = m_instr_mem[next_addr]->get_bb();
-      (*bb_itr)->successor_ids.insert(next_bb->bb_id);
-      next_bb->predecessor_ids.insert((*bb_itr)->bb_id);
-    } else
-      assert(pI->get_opcode() == BRA_OP);
-  }
+   while( (i != m_instructions.end()) && (*i)->is_label() ) 
+      i++;
+   return i;
 }
-bool function_info::connect_break_targets()  // connecting break instructions
-                                             // with proper targets
+
+void function_info::create_basic_blocks()
 {
-  std::vector<basic_block_t *>::iterator bb_itr;
-  std::vector<basic_block_t *>::iterator bb_target_itr;
-  bool modified = false;
+   std::list<ptx_instruction*> leaders;
+   std::list<ptx_instruction*>::iterator i, l;
 
-  // start from first basic block, which we know is the entry point
-  bb_itr = m_basic_blocks.begin();
-  for (bb_itr = m_basic_blocks.begin(); bb_itr != m_basic_blocks.end();
-       bb_itr++) {
-    basic_block_t *p_bb = *bb_itr;
-    ptx_instruction *pI = p_bb->ptx_end;
-    if (p_bb->is_exit)  // reached last basic block, no successors to link
-      continue;
-    if (pI->get_opcode() == BREAK_OP) {
-      // backup existing successor_ids for stability check
-      std::set<int> orig_successor_ids = p_bb->successor_ids;
-
-      // erase the previous linkage with old successors
-      for (std::set<int>::iterator succ_ids = p_bb->successor_ids.begin();
-           succ_ids != p_bb->successor_ids.end(); ++succ_ids) {
-        basic_block_t *successor_bb = m_basic_blocks[*succ_ids];
-        successor_bb->predecessor_ids.erase(p_bb->bb_id);
-      }
-      p_bb->successor_ids.clear();
-
-      // find successor and link that basic_block to this one
-      // successor of a break is set by an preceeding breakaddr instruction
-      operand_info *target = find_break_target(pI);
-      unsigned addr = labels[target->name()];
-      ptx_instruction *target_pI = m_instr_mem[addr];
-      basic_block_t *target_bb = target_pI->get_bb();
-      p_bb->successor_ids.insert(target_bb->bb_id);
-      target_bb->predecessor_ids.insert(p_bb->bb_id);
-
-      if (pI->has_pred()) {
-        // predicated break - add link to next basic block
-        unsigned next_addr = pI->get_m_instr_mem_index() + pI->inst_size();
-        basic_block_t *next_bb = m_instr_mem[next_addr]->get_bb();
-        p_bb->successor_ids.insert(next_bb->bb_id);
-        next_bb->predecessor_ids.insert(p_bb->bb_id);
-      }
-
-      modified = modified || (orig_successor_ids != p_bb->successor_ids);
-    }
-  }
-
-  return modified;
-}
-void function_info::do_pdom() {
-  create_basic_blocks();
-  connect_basic_blocks();
-  bool modified = false;
-  do {
-    find_dominators();
-    find_idominators();
-    modified = connect_break_targets();
-  } while (modified == true);
-
-  if (g_debug_execution >= 50) {
-    print_basic_blocks();
-    print_basic_block_links();
-    print_basic_block_dot();
-  }
-  if (g_debug_execution >= 2) {
-    print_dominators();
-  }
-  find_postdominators();
-  find_ipostdominators();
-  if (g_debug_execution >= 50) {
-    print_postdominators();
-    print_ipostdominators();
-  }
-  printf("GPGPU-Sim PTX: pre-decoding instructions for \'%s\'...\n",
-         m_name.c_str());
-  for (unsigned ii = 0; ii < m_n;
-       ii += m_instr_mem[ii]->inst_size()) {  // handle branch instructions
-    ptx_instruction *pI = m_instr_mem[ii];
-    pI->pre_decode();
-  }
-  printf("GPGPU-Sim PTX: ... done pre-decoding instructions for \'%s\'.\n",
-         m_name.c_str());
-  fflush(stdout);
-  m_assembled = true;
-}
-void intersect(std::set<int> &A, const std::set<int> &B) {
-  // return intersection of A and B in A
-  for (std::set<int>::iterator a = A.begin(); a != A.end();) {
-    std::set<int>::iterator a_next = a;
-    a_next++;
-    if (B.find(*a) == B.end()) {
-      A.erase(*a);
-      a = a_next;
-    } else
-      a++;
-  }
-}
-
-bool is_equal(const std::set<int> &A, const std::set<int> &B) {
-  if (A.size() != B.size()) return false;
-  for (std::set<int>::iterator b = B.begin(); b != B.end(); b++)
-    if (A.find(*b) == A.end()) return false;
-  return true;
-}
-
-void print_set(const std::set<int> &A) {
-  std::set<int>::iterator a;
-  for (a = A.begin(); a != A.end(); a++) {
-    printf("%d ", (*a));
-  }
-  printf("\n");
-}
-
-void function_info::find_dominators() {
-  // find dominators using algorithm of Muchnick's Adv. Compiler Design &
-  // Implemmntation Fig 7.14
-  printf("GPGPU-Sim PTX: Finding dominators for \'%s\'...\n", m_name.c_str());
-  fflush(stdout);
-  assert(m_basic_blocks.size() >= 2);  // must have a distinquished entry block
-  std::vector<basic_block_t *>::iterator bb_itr = m_basic_blocks.begin();
-  (*bb_itr)->dominator_ids.insert(
-      (*bb_itr)->bb_id);  // the only dominator of the entry block is the entry
-  // copy all basic blocks to all dominator lists EXCEPT for the entry block
-  for (++bb_itr; bb_itr != m_basic_blocks.end(); bb_itr++) {
-    for (unsigned i = 0; i < m_basic_blocks.size(); i++)
-      (*bb_itr)->dominator_ids.insert(i);
-  }
-  bool change = true;
-  while (change) {
-    change = false;
-    for (int h = 1 /*skip entry*/; h < m_basic_blocks.size(); ++h) {
-      assert(m_basic_blocks[h]->bb_id == (unsigned)h);
-      std::set<int> T;
-      for (unsigned i = 0; i < m_basic_blocks.size(); i++) T.insert(i);
-      for (std::set<int>::iterator s =
-               m_basic_blocks[h]->predecessor_ids.begin();
-           s != m_basic_blocks[h]->predecessor_ids.end(); s++)
-        intersect(T, m_basic_blocks[*s]->dominator_ids);
-      T.insert(h);
-      if (!is_equal(T, m_basic_blocks[h]->dominator_ids)) {
-        change = true;
-        m_basic_blocks[h]->dominator_ids = T;
-      }
-    }
-  }
-  // clean the basic block of dominators of it has no predecessors -- except for
-  // entry block
-  bb_itr = m_basic_blocks.begin();
-  for (++bb_itr; bb_itr != m_basic_blocks.end(); bb_itr++) {
-    if ((*bb_itr)->predecessor_ids.empty()) (*bb_itr)->dominator_ids.clear();
-  }
-}
-
-void function_info::find_postdominators() {
-  // find postdominators using algorithm of Muchnick's Adv. Compiler Design &
-  // Implemmntation Fig 7.14
-  printf("GPGPU-Sim PTX: Finding postdominators for \'%s\'...\n",
-         m_name.c_str());
-  fflush(stdout);
-  assert(m_basic_blocks.size() >= 2);  // must have a distinquished exit block
-  std::vector<basic_block_t *>::reverse_iterator bb_itr =
-      m_basic_blocks.rbegin();
-  (*bb_itr)->postdominator_ids.insert(
-      (*bb_itr)
-          ->bb_id);  // the only postdominator of the exit block is the exit
-  for (++bb_itr; bb_itr != m_basic_blocks.rend();
-       bb_itr++) {  // copy all basic blocks to all postdominator lists EXCEPT
-                    // for the exit block
-    for (unsigned i = 0; i < m_basic_blocks.size(); i++)
-      (*bb_itr)->postdominator_ids.insert(i);
-  }
-  bool change = true;
-  while (change) {
-    change = false;
-    for (int h = m_basic_blocks.size() - 2 /*skip exit*/; h >= 0; --h) {
-      assert(m_basic_blocks[h]->bb_id == (unsigned)h);
-      std::set<int> T;
-      for (unsigned i = 0; i < m_basic_blocks.size(); i++) T.insert(i);
-      for (std::set<int>::iterator s = m_basic_blocks[h]->successor_ids.begin();
-           s != m_basic_blocks[h]->successor_ids.end(); s++)
-        intersect(T, m_basic_blocks[*s]->postdominator_ids);
-      T.insert(h);
-      if (!is_equal(T, m_basic_blocks[h]->postdominator_ids)) {
-        change = true;
-        m_basic_blocks[h]->postdominator_ids = T;
-      }
-    }
-  }
-}
-
-void function_info::find_ipostdominators() {
-  // find immediate postdominator blocks, using algorithm of
-  // Muchnick's Adv. Compiler Design & Implemmntation Fig 7.15
-  printf("GPGPU-Sim PTX: Finding immediate postdominators for \'%s\'...\n",
-         m_name.c_str());
-  fflush(stdout);
-  assert(m_basic_blocks.size() >= 2);  // must have a distinquished exit block
-  for (unsigned i = 0; i < m_basic_blocks.size();
-       i++) {  // initialize Tmp(n) to all pdoms of n except for n
-    m_basic_blocks[i]->Tmp_ids = m_basic_blocks[i]->postdominator_ids;
-    assert(m_basic_blocks[i]->bb_id == i);
-    m_basic_blocks[i]->Tmp_ids.erase(i);
-  }
-  for (int n = m_basic_blocks.size() - 2; n >= 0; --n) {
-    // point iterator to basic block before the exit
-    for (std::set<int>::iterator s = m_basic_blocks[n]->Tmp_ids.begin();
-         s != m_basic_blocks[n]->Tmp_ids.end(); s++) {
-      int bb_s = *s;
-      for (std::set<int>::iterator t = m_basic_blocks[n]->Tmp_ids.begin();
-           t != m_basic_blocks[n]->Tmp_ids.end();) {
-        std::set<int>::iterator t_next = t;
-        t_next++;  // might erase thing pointed to be t, invalidating iterator t
-        if (*s == *t) {
-          t = t_next;
-          continue;
-        }
-        int bb_t = *t;
-        if (m_basic_blocks[bb_s]->postdominator_ids.find(bb_t) !=
-            m_basic_blocks[bb_s]->postdominator_ids.end())
-          m_basic_blocks[n]->Tmp_ids.erase(bb_t);
-        t = t_next;
-      }
-    }
-  }
-  unsigned num_ipdoms = 0;
-  for (int n = m_basic_blocks.size() - 1; n >= 0; --n) {
-    assert(m_basic_blocks[n]->Tmp_ids.size() <= 1);
-    // if the above assert fails we have an error in either postdominator
-    // computation, the flow graph does not have a unique exit, or some other
-    // error
-    if (!m_basic_blocks[n]->Tmp_ids.empty()) {
-      m_basic_blocks[n]->immediatepostdominator_id =
-          *m_basic_blocks[n]->Tmp_ids.begin();
-      num_ipdoms++;
-    }
-  }
-  assert(num_ipdoms == m_basic_blocks.size() - 1);
-  // the exit node does not have an immediate post dominator, but everyone else
-  // should
-}
-
-void function_info::find_idominators() {
-  // find immediate dominator blocks, using algorithm of
-  // Muchnick's Adv. Compiler Design & Implemmntation Fig 7.15
-  printf("GPGPU-Sim PTX: Finding immediate dominators for \'%s\'...\n",
-         m_name.c_str());
-  fflush(stdout);
-  assert(m_basic_blocks.size() >= 2);  // must have a distinquished entry block
-  for (unsigned i = 0; i < m_basic_blocks.size();
-       i++) {  // initialize Tmp(n) to all doms of n except for n
-    m_basic_blocks[i]->Tmp_ids = m_basic_blocks[i]->dominator_ids;
-    assert(m_basic_blocks[i]->bb_id == i);
-    m_basic_blocks[i]->Tmp_ids.erase(i);
-  }
-  for (int n = 0; n < m_basic_blocks.size(); ++n) {
-    // point iterator to basic block before the exit
-    for (std::set<int>::iterator s = m_basic_blocks[n]->Tmp_ids.begin();
-         s != m_basic_blocks[n]->Tmp_ids.end(); s++) {
-      int bb_s = *s;
-      for (std::set<int>::iterator t = m_basic_blocks[n]->Tmp_ids.begin();
-           t != m_basic_blocks[n]->Tmp_ids.end();) {
-        std::set<int>::iterator t_next = t;
-        t_next++;  // might erase thing pointed to be t, invalidating iterator t
-        if (*s == *t) {
-          t = t_next;
-          continue;
-        }
-        int bb_t = *t;
-        if (m_basic_blocks[bb_s]->dominator_ids.find(bb_t) !=
-            m_basic_blocks[bb_s]->dominator_ids.end())
-          m_basic_blocks[n]->Tmp_ids.erase(bb_t);
-        t = t_next;
-      }
-    }
-  }
-  unsigned num_idoms = 0;
-  unsigned num_nopred = 0;
-  for (int n = 0; n < m_basic_blocks.size(); ++n) {
-    // assert( m_basic_blocks[n]->Tmp_ids.size() <= 1 );
-    // if the above assert fails we have an error in either dominator
-    // computation, the flow graph does not have a unique entry, or some other
-    // error
-    if (!m_basic_blocks[n]->Tmp_ids.empty()) {
-      m_basic_blocks[n]->immediatedominator_id =
-          *m_basic_blocks[n]->Tmp_ids.begin();
-      num_idoms++;
-    } else if (m_basic_blocks[n]->predecessor_ids.empty()) {
-      num_nopred += 1;
-    }
-  }
-  assert(num_idoms == m_basic_blocks.size() - num_nopred);
-  // the entry node does not have an immediate dominator, but everyone else
-  // should
-}
-
-void function_info::print_dominators() {
-  printf("Printing dominators for function \'%s\':\n", m_name.c_str());
-  std::vector<int>::iterator bb_itr;
-  for (unsigned i = 0; i < m_basic_blocks.size(); i++) {
-    printf("ID: %d\t:", i);
-    for (std::set<int>::iterator j = m_basic_blocks[i]->dominator_ids.begin();
-         j != m_basic_blocks[i]->dominator_ids.end(); j++)
-      printf(" %d", *j);
-    printf("\n");
-  }
-}
-
-void function_info::print_postdominators() {
-  printf("Printing postdominators for function \'%s\':\n", m_name.c_str());
-  std::vector<int>::iterator bb_itr;
-  for (unsigned i = 0; i < m_basic_blocks.size(); i++) {
-    printf("ID: %d\t:", i);
-    for (std::set<int>::iterator j =
-             m_basic_blocks[i]->postdominator_ids.begin();
-         j != m_basic_blocks[i]->postdominator_ids.end(); j++)
-      printf(" %d", *j);
-    printf("\n");
-  }
-}
-
-void function_info::print_ipostdominators() {
-  printf("Printing immediate postdominators for function \'%s\':\n",
-         m_name.c_str());
-  std::vector<int>::iterator bb_itr;
-  for (unsigned i = 0; i < m_basic_blocks.size(); i++) {
-    printf("ID: %d\t:", i);
-    printf("%d\n", m_basic_blocks[i]->immediatepostdominator_id);
-  }
-}
-
-void function_info::print_idominators() {
-  printf("Printing immediate dominators for function \'%s\':\n",
-         m_name.c_str());
-  std::vector<int>::iterator bb_itr;
-  for (unsigned i = 0; i < m_basic_blocks.size(); i++) {
-    printf("ID: %d\t:", i);
-    printf("%d\n", m_basic_blocks[i]->immediatedominator_id);
-  }
-}
-
-unsigned function_info::get_num_reconvergence_pairs() {
-  if (!num_reconvergence_pairs) {
-    if (m_basic_blocks.size() == 0) return 0;
-    for (unsigned i = 0; i < (m_basic_blocks.size() - 1);
-         i++) {  // last basic block containing exit obviously won't have a pair
-      if (m_basic_blocks[i]->ptx_end->get_opcode() == BRA_OP) {
-        num_reconvergence_pairs++;
-      }
-    }
-  }
-  return num_reconvergence_pairs;
-}
-
-void function_info::get_reconvergence_pairs(gpgpu_recon_t *recon_points) {
-  unsigned idx = 0;  // array index
-  if (m_basic_blocks.size() == 0) return;
-  for (unsigned i = 0; i < (m_basic_blocks.size() - 1);
-       i++) {  // last basic block containing exit obviously won't have a pair
-#ifdef DEBUG_GET_RECONVERG_PAIRS
-    printf("i=%d\n", i);
-    fflush(stdout);
-#endif
-    if (m_basic_blocks[i]->ptx_end->get_opcode() == BRA_OP) {
-#ifdef DEBUG_GET_RECONVERG_PAIRS
-      printf("\tbranch!\n");
-      printf("\tbb_id=%d; ipdom=%d\n", m_basic_blocks[i]->bb_id,
-             m_basic_blocks[i]->immediatepostdominator_id);
-      printf("\tm_instr_mem index=%d\n",
-             m_basic_blocks[i]->ptx_end->get_m_instr_mem_index());
-      fflush(stdout);
-#endif
-      recon_points[idx].source_pc = m_basic_blocks[i]->ptx_end->get_PC();
-      recon_points[idx].source_inst = m_basic_blocks[i]->ptx_end;
-#ifdef DEBUG_GET_RECONVERG_PAIRS
-      printf("\trecon_points[idx].source_pc=%d\n", recon_points[idx].source_pc);
-#endif
-      if (m_basic_blocks[m_basic_blocks[i]->immediatepostdominator_id]
-              ->ptx_begin) {
-        recon_points[idx].target_pc =
-            m_basic_blocks[m_basic_blocks[i]->immediatepostdominator_id]
-                ->ptx_begin->get_PC();
-        recon_points[idx].target_inst =
-            m_basic_blocks[m_basic_blocks[i]->immediatepostdominator_id]
-                ->ptx_begin;
+   // first instruction is a leader
+   i=m_instructions.begin();
+   leaders.push_back(*i);
+   i++;
+   while( i!=m_instructions.end() ) {
+      ptx_instruction *pI = *i;
+      if( pI->is_label() ) {
+         leaders.push_back(pI);
+         i = find_next_real_instruction(++i);
       } else {
-        // reconverge after function return
-        recon_points[idx].target_pc = -2;
-        recon_points[idx].target_inst = NULL;
+         switch( pI->get_opcode() ) {
+         case BRA_OP: case RET_OP: case EXIT_OP: case RETP_OP: case BREAK_OP: 
+            i++;
+            if( i != m_instructions.end() ) 
+               leaders.push_back(*i);
+            i = find_next_real_instruction(i);
+            break;
+         case CALL_OP: case CALLP_OP:
+            if( pI->has_pred() ) {
+               printf("GPGPU-Sim PTX: Warning found predicated call\n");
+               i++;
+               if( i != m_instructions.end() ) 
+                  leaders.push_back(*i);
+               i = find_next_real_instruction(i);
+            } else i++;
+            break;
+         default:
+            i++;
+         }
+      } 
+   }
+
+   if( leaders.empty() ) {
+      printf("GPGPU-Sim PTX: Function \'%s\' has no basic blocks\n", m_name.c_str());
+      return;
+   }
+
+   unsigned bb_id = 0;
+   l=leaders.begin();
+   i=m_instructions.begin();
+   m_basic_blocks.push_back( new basic_block_t(bb_id++,*find_next_real_instruction(i),NULL,1,0) );
+   ptx_instruction *last_real_inst=*(l++);
+
+   for( ; i!=m_instructions.end(); i++ ) {
+      ptx_instruction *pI = *i;
+      if( l != leaders.end() && *i == *l ) {
+         // found start of next basic block
+         m_basic_blocks.back()->ptx_end = last_real_inst;
+         if( find_next_real_instruction(i) != m_instructions.end() ) { // if not bogus trailing label
+            m_basic_blocks.push_back( new basic_block_t(bb_id++,*find_next_real_instruction(i),NULL,0,0) );
+            last_real_inst = *find_next_real_instruction(i);
+         }
+         // start search for next leader
+         l++;
       }
+      pI->assign_bb( m_basic_blocks.back() );
+      if( !pI->is_label() ) last_real_inst = pI;
+   }
+   m_basic_blocks.back()->ptx_end = last_real_inst;
+   m_basic_blocks.push_back( /*exit basic block*/ new basic_block_t(bb_id,NULL,NULL,0,1) );
+}
+
+void function_info::print_basic_blocks()
+{
+   printf("Printing basic blocks for function \'%s\':\n", m_name.c_str() );
+   std::list<ptx_instruction*>::iterator ptx_itr;
+   unsigned last_bb=0;
+   for (ptx_itr = m_instructions.begin();ptx_itr != m_instructions.end(); ptx_itr++) {
+      if( (*ptx_itr)->get_bb() ) {
+         if( (*ptx_itr)->get_bb()->bb_id != last_bb ) {
+            printf("\n");
+            last_bb = (*ptx_itr)->get_bb()->bb_id;
+         }
+         printf("bb_%02u\t: ", (*ptx_itr)->get_bb()->bb_id);
+         (*ptx_itr)->print_insn();
+         printf("\n");
+      }
+   }
+   printf("\nSummary of basic blocks for \'%s\':\n", m_name.c_str() );
+   std::vector<basic_block_t*>::iterator bb_itr;
+   for (bb_itr = m_basic_blocks.begin();bb_itr != m_basic_blocks.end(); bb_itr++) {
+      printf("bb_%02u\t:", (*bb_itr)->bb_id);
+      if ((*bb_itr)->ptx_begin)
+         printf(" first: %s\t", ((*bb_itr)->ptx_begin)->get_opcode_cstr());
+      else printf(" first: NULL\t");
+      if ((*bb_itr)->ptx_end) {
+         printf(" last: %s\t", ((*bb_itr)->ptx_end)->get_opcode_cstr());
+      } else printf(" last: NULL\t");
+      printf("\n");
+   }
+   printf("\n");
+}
+
+void function_info::print_basic_block_links()
+{
+   printf("Printing basic blocks links for function \'%s\':\n", m_name.c_str() );
+   std::vector<basic_block_t*>::iterator bb_itr;
+   for (bb_itr = m_basic_blocks.begin();bb_itr != m_basic_blocks.end(); bb_itr++) {
+      printf("ID: %d\t:", (*bb_itr)->bb_id);
+      if ( !(*bb_itr)->predecessor_ids.empty() ) {
+         printf("Predecessors:");
+         std::set<int>::iterator p;
+         for (p= (*bb_itr)->predecessor_ids.begin();p != (*bb_itr)->predecessor_ids.end();p++) {
+            printf(" %d", *p);
+         }
+         printf("\t");
+      }
+      if ( !(*bb_itr)->successor_ids.empty() ) {
+         printf("Successors:");
+         std::set<int>::iterator s;
+         for (s= (*bb_itr)->successor_ids.begin();s != (*bb_itr)->successor_ids.end();s++) {
+            printf(" %d", *s);
+         }
+      }
+      printf("\n");
+   }
+}
+operand_info* function_info::find_break_target( ptx_instruction * p_break_insn ) //find the target of a break instruction 
+{
+   const basic_block_t *break_bb = p_break_insn->get_bb(); 
+   // go through the dominator tree 
+   for(const basic_block_t *p_bb = break_bb; 
+       p_bb->immediatedominator_id != -1; 
+       p_bb = m_basic_blocks[p_bb->immediatedominator_id]) 
+   {
+      // reverse search through instructions in basic block for breakaddr instruction 
+      unsigned insn_addr = p_bb->ptx_end->get_m_instr_mem_index(); 
+      while (insn_addr >= p_bb->ptx_begin->get_m_instr_mem_index()) { 
+         ptx_instruction *pI = m_instr_mem[insn_addr]; 
+         insn_addr -= 1; 
+         if (pI == NULL) continue; // temporary solution for variable size instructions 
+         if (pI->get_opcode() == BREAKADDR_OP) {
+            return &(pI->dst()); 
+         }
+      }
+   }
+
+   assert(0); 
+
+   // lazy fallback: just traverse backwards? 
+   for (int insn_addr = p_break_insn->get_m_instr_mem_index(); 
+        insn_addr >= 0; insn_addr--) 
+   { 
+      ptx_instruction *pI = m_instr_mem[insn_addr]; 
+      if (pI->get_opcode() == BREAKADDR_OP) {
+         return &(pI->dst()); 
+      }
+   }
+
+   return NULL; 
+}
+void function_info::connect_basic_blocks( ) //iterate across m_basic_blocks of function, connecting basic blocks together
+{
+   std::vector<basic_block_t*>::iterator bb_itr;
+   std::vector<basic_block_t*>::iterator bb_target_itr;
+   basic_block_t* exit_bb = m_basic_blocks.back();
+
+   //start from first basic block, which we know is the entry point
+   bb_itr = m_basic_blocks.begin(); 
+   for (bb_itr = m_basic_blocks.begin();bb_itr != m_basic_blocks.end(); bb_itr++) {
+      ptx_instruction *pI = (*bb_itr)->ptx_end;
+      if ((*bb_itr)->is_exit) //reached last basic block, no successors to link 
+         continue;
+      if (pI->get_opcode() == RETP_OP || pI->get_opcode() == RET_OP || pI->get_opcode() == EXIT_OP ) {
+         (*bb_itr)->successor_ids.insert(exit_bb->bb_id);
+         exit_bb->predecessor_ids.insert((*bb_itr)->bb_id);
+         if( pI->has_pred() ) {
+            printf("GPGPU-Sim PTX: Warning detected predicated return/exit.\n");
+            // if predicated, add link to next block
+            unsigned next_addr = pI->get_m_instr_mem_index() + pI->inst_size();
+            if( next_addr < m_instr_mem_size && m_instr_mem[next_addr] ) {
+               basic_block_t *next_bb = m_instr_mem[next_addr]->get_bb();
+               (*bb_itr)->successor_ids.insert(next_bb->bb_id);
+               next_bb->predecessor_ids.insert((*bb_itr)->bb_id);
+            }
+         }
+         continue;
+      } else if (pI->get_opcode() == BRA_OP) {
+         //find successor and link that basic_block to this one
+         operand_info &target = pI->dst(); //get operand, e.g. target name
+         unsigned addr = labels[ target.name() ];
+         ptx_instruction *target_pI = m_instr_mem[addr];
+         basic_block_t *target_bb = target_pI->get_bb();
+         (*bb_itr)->successor_ids.insert(target_bb->bb_id);
+         target_bb->predecessor_ids.insert((*bb_itr)->bb_id);
+      } 
+
+      if ( !(pI->get_opcode()==BRA_OP && (!pI->has_pred())) ) { 
+         // if basic block does not end in an unpredicated branch, 
+         // then next basic block is also successor
+         // (this is better than testing for .uni)
+         unsigned next_addr = pI->get_m_instr_mem_index() + pI->inst_size();
+         basic_block_t *next_bb = m_instr_mem[next_addr]->get_bb();
+         (*bb_itr)->successor_ids.insert(next_bb->bb_id);
+         next_bb->predecessor_ids.insert((*bb_itr)->bb_id);
+      } else
+         assert(pI->get_opcode() == BRA_OP);
+   }
+}
+bool function_info::connect_break_targets() //connecting break instructions with proper targets
+{
+   std::vector<basic_block_t*>::iterator bb_itr;
+   std::vector<basic_block_t*>::iterator bb_target_itr;
+   bool modified = false; 
+
+   //start from first basic block, which we know is the entry point
+   bb_itr = m_basic_blocks.begin(); 
+   for (bb_itr = m_basic_blocks.begin();bb_itr != m_basic_blocks.end(); bb_itr++) {
+      basic_block_t *p_bb = *bb_itr; 
+      ptx_instruction *pI = p_bb->ptx_end;
+      if (p_bb->is_exit) //reached last basic block, no successors to link 
+         continue;
+      if (pI->get_opcode() == BREAK_OP) {
+         // backup existing successor_ids for stability check
+         std::set<int> orig_successor_ids = p_bb->successor_ids; 
+
+         // erase the previous linkage with old successors 
+         for(std::set<int>::iterator succ_ids = p_bb->successor_ids.begin(); succ_ids != p_bb->successor_ids.end(); ++succ_ids) {
+            basic_block_t *successor_bb = m_basic_blocks[*succ_ids];
+            successor_bb->predecessor_ids.erase(p_bb->bb_id); 
+         }
+         p_bb->successor_ids.clear(); 
+
+         //find successor and link that basic_block to this one
+         //successor of a break is set by an preceeding breakaddr instruction 
+         operand_info *target = find_break_target(pI); 
+         unsigned addr = labels[ target->name() ];
+         ptx_instruction *target_pI = m_instr_mem[addr];
+         basic_block_t *target_bb = target_pI->get_bb();
+         p_bb->successor_ids.insert(target_bb->bb_id);
+         target_bb->predecessor_ids.insert(p_bb->bb_id);
+
+         if (pI->has_pred()) {
+            // predicated break - add link to next basic block
+            unsigned next_addr = pI->get_m_instr_mem_index() + pI->inst_size();
+            basic_block_t *next_bb = m_instr_mem[next_addr]->get_bb();
+            p_bb->successor_ids.insert(next_bb->bb_id);
+            next_bb->predecessor_ids.insert(p_bb->bb_id);
+         }
+
+         modified = modified || (orig_successor_ids != p_bb->successor_ids); 
+      }
+   }
+
+   return modified; 
+}
+void function_info::do_pdom() 
+{
+   create_basic_blocks();
+   connect_basic_blocks();
+   bool modified = false; 
+   do {
+      find_dominators();
+      find_idominators();
+      modified = connect_break_targets(); 
+   } while (modified == true);
+
+   if ( g_debug_execution>=50 ) {
+      print_basic_blocks();
+      print_basic_block_links();
+      print_basic_block_dot();
+   }
+   if ( g_debug_execution>=2 ) {
+      print_dominators();
+   }
+   find_postdominators();
+   find_ipostdominators();
+   if ( g_debug_execution>=50 ) {
+      print_postdominators();
+      print_ipostdominators();
+   }
+   printf("GPGPU-Sim PTX: pre-decoding instructions for \'%s\'...\n", m_name.c_str() );
+   for ( unsigned ii=0; ii < m_n; ii += m_instr_mem[ii]->inst_size() ) { // handle branch instructions
+      ptx_instruction *pI = m_instr_mem[ii];
+      pI->pre_decode();
+   }
+   printf("GPGPU-Sim PTX: ... done pre-decoding instructions for \'%s\'.\n", m_name.c_str() );
+   fflush(stdout);
+   m_assembled = true;
+}
+void intersect( std::set<int> &A, const std::set<int> &B )
+{
+   // return intersection of A and B in A
+   for( std::set<int>::iterator a=A.begin(); a!=A.end(); ) {    
+      std::set<int>::iterator a_next = a;
+      a_next++;
+      if( B.find(*a) == B.end() ) {
+         A.erase(*a);
+         a = a_next;
+      } else 
+         a++;
+   }
+}
+
+bool is_equal( const std::set<int> &A, const std::set<int> &B )
+{
+   if( A.size() != B.size() ) 
+      return false;
+   for( std::set<int>::iterator b=B.begin(); b!=B.end(); b++ ) 
+      if( A.find(*b) == A.end() ) 
+         return false;
+   return true;
+}
+
+void print_set(const std::set<int> &A)
+{
+   std::set<int>::iterator a;
+   for (a= A.begin(); a != A.end(); a++) {
+      printf("%d ", (*a));
+   }
+   printf("\n");
+}
+
+void function_info::find_dominators( )
+{  
+   // find dominators using algorithm of Muchnick's Adv. Compiler Design & Implemmntation Fig 7.14 
+   printf("GPGPU-Sim PTX: Finding dominators for \'%s\'...\n", m_name.c_str() );
+   fflush(stdout);
+   assert( m_basic_blocks.size() >= 2 ); // must have a distinquished entry block
+   std::vector<basic_block_t*>::iterator bb_itr = m_basic_blocks.begin();
+   (*bb_itr)->dominator_ids.insert((*bb_itr)->bb_id);  // the only dominator of the entry block is the entry
+   //copy all basic blocks to all dominator lists EXCEPT for the entry block
+   for (++bb_itr;bb_itr != m_basic_blocks.end(); bb_itr++) { 
+      for (unsigned i = 0; i < m_basic_blocks.size(); i++) 
+         (*bb_itr)->dominator_ids.insert(i);
+   }
+   bool change = true;
+   while (change) {
+      change = false;
+      for ( int h = 1/*skip entry*/; h < m_basic_blocks.size(); ++h ) {
+         assert( m_basic_blocks[h]->bb_id == (unsigned)h );
+         std::set<int> T;
+         for (unsigned i=0;i< m_basic_blocks.size();i++) 
+            T.insert(i);
+         for ( std::set<int>::iterator s = m_basic_blocks[h]->predecessor_ids.begin();s != m_basic_blocks[h]->predecessor_ids.end();s++) 
+            intersect(T, m_basic_blocks[*s]->dominator_ids);
+         T.insert(h);
+         if (!is_equal(T, m_basic_blocks[h]->dominator_ids)) {
+            change = true;
+            m_basic_blocks[h]->dominator_ids = T;
+         }
+      }
+   }
+   //clean the basic block of dominators of it has no predecessors -- except for entry block
+   bb_itr = m_basic_blocks.begin();
+   for (++bb_itr;bb_itr != m_basic_blocks.end(); bb_itr++) {
+	  if ((*bb_itr)->predecessor_ids.empty())
+         (*bb_itr)->dominator_ids.clear();
+   }
+}
+
+void function_info::find_postdominators( )
+{  
+   // find postdominators using algorithm of Muchnick's Adv. Compiler Design & Implemmntation Fig 7.14 
+   printf("GPGPU-Sim PTX: Finding postdominators for \'%s\'...\n", m_name.c_str() );
+   fflush(stdout);
+   assert( m_basic_blocks.size() >= 2 ); // must have a distinquished exit block
+   std::vector<basic_block_t*>::reverse_iterator bb_itr = m_basic_blocks.rbegin();
+   (*bb_itr)->postdominator_ids.insert((*bb_itr)->bb_id);  // the only postdominator of the exit block is the exit
+   for (++bb_itr;bb_itr != m_basic_blocks.rend();bb_itr++) { //copy all basic blocks to all postdominator lists EXCEPT for the exit block
+      for (unsigned i=0; i<m_basic_blocks.size(); i++) 
+         (*bb_itr)->postdominator_ids.insert(i);
+   }
+   bool change = true;
+   while (change) {
+      change = false;
+      for ( int h = m_basic_blocks.size()-2/*skip exit*/; h >= 0 ; --h ) {
+         assert( m_basic_blocks[h]->bb_id == (unsigned)h );
+         std::set<int> T;
+         for (unsigned i=0;i< m_basic_blocks.size();i++) 
+            T.insert(i);
+         for ( std::set<int>::iterator s = m_basic_blocks[h]->successor_ids.begin();s != m_basic_blocks[h]->successor_ids.end();s++) 
+            intersect(T, m_basic_blocks[*s]->postdominator_ids);
+         T.insert(h);
+         if (!is_equal(T,m_basic_blocks[h]->postdominator_ids)) {
+            change = true;
+            m_basic_blocks[h]->postdominator_ids = T;
+         }
+      }
+   }
+}
+
+void function_info::find_ipostdominators( )
+{  
+   // find immediate postdominator blocks, using algorithm of
+   // Muchnick's Adv. Compiler Design & Implemmntation Fig 7.15 
+   printf("GPGPU-Sim PTX: Finding immediate postdominators for \'%s\'...\n", m_name.c_str() );
+   fflush(stdout);
+   assert( m_basic_blocks.size() >= 2 ); // must have a distinquished exit block
+   for (unsigned i=0; i<m_basic_blocks.size(); i++) { //initialize Tmp(n) to all pdoms of n except for n
+      m_basic_blocks[i]->Tmp_ids = m_basic_blocks[i]->postdominator_ids;
+      assert( m_basic_blocks[i]->bb_id == i );
+      m_basic_blocks[i]->Tmp_ids.erase(i);
+   }
+   for ( int n = m_basic_blocks.size()-2; n >=0;--n) {
+      // point iterator to basic block before the exit
+      for( std::set<int>::iterator s=m_basic_blocks[n]->Tmp_ids.begin(); s != m_basic_blocks[n]->Tmp_ids.end(); s++ ) {
+         int bb_s = *s;
+         for( std::set<int>::iterator t=m_basic_blocks[n]->Tmp_ids.begin(); t != m_basic_blocks[n]->Tmp_ids.end(); ) {
+            std::set<int>::iterator t_next = t; t_next++; // might erase thing pointed to be t, invalidating iterator t
+            if( *s == *t ) {
+               t = t_next;
+               continue;
+            }
+            int bb_t = *t;
+            if( m_basic_blocks[bb_s]->postdominator_ids.find(bb_t) != m_basic_blocks[bb_s]->postdominator_ids.end() ) 
+                m_basic_blocks[n]->Tmp_ids.erase(bb_t);
+            t = t_next;
+         }
+      }
+   }
+   unsigned num_ipdoms=0;
+   for ( int n = m_basic_blocks.size()-1; n >=0;--n) {
+      assert( m_basic_blocks[n]->Tmp_ids.size() <= 1 ); 
+         // if the above assert fails we have an error in either postdominator 
+         // computation, the flow graph does not have a unique exit, or some other error
+      if( !m_basic_blocks[n]->Tmp_ids.empty() ) {
+         m_basic_blocks[n]->immediatepostdominator_id = *m_basic_blocks[n]->Tmp_ids.begin();
+         num_ipdoms++;
+      }
+   }
+   assert( num_ipdoms == m_basic_blocks.size()-1 ); 
+      // the exit node does not have an immediate post dominator, but everyone else should
+}
+
+void function_info::find_idominators( )
+{  
+   // find immediate dominator blocks, using algorithm of
+   // Muchnick's Adv. Compiler Design & Implemmntation Fig 7.15 
+   printf("GPGPU-Sim PTX: Finding immediate dominators for \'%s\'...\n", m_name.c_str() );
+   fflush(stdout);
+   assert( m_basic_blocks.size() >= 2 ); // must have a distinquished entry block
+   for (unsigned i=0; i<m_basic_blocks.size(); i++) { //initialize Tmp(n) to all doms of n except for n
+      m_basic_blocks[i]->Tmp_ids = m_basic_blocks[i]->dominator_ids;
+      assert( m_basic_blocks[i]->bb_id == i );
+      m_basic_blocks[i]->Tmp_ids.erase(i);
+   }
+   for ( int n = 0; n < m_basic_blocks.size(); ++n) {
+      // point iterator to basic block before the exit
+      for( std::set<int>::iterator s=m_basic_blocks[n]->Tmp_ids.begin(); s != m_basic_blocks[n]->Tmp_ids.end(); s++ ) {
+         int bb_s = *s;
+         for( std::set<int>::iterator t=m_basic_blocks[n]->Tmp_ids.begin(); t != m_basic_blocks[n]->Tmp_ids.end(); ) {
+            std::set<int>::iterator t_next = t; t_next++; // might erase thing pointed to be t, invalidating iterator t
+            if( *s == *t ) {
+               t = t_next;
+               continue;
+            }
+            int bb_t = *t;
+            if( m_basic_blocks[bb_s]->dominator_ids.find(bb_t) != m_basic_blocks[bb_s]->dominator_ids.end() ) 
+                m_basic_blocks[n]->Tmp_ids.erase(bb_t);
+            t = t_next;
+         }
+      }
+   }
+   unsigned num_idoms=0;
+   unsigned num_nopred = 0;
+   for ( int n = 0; n < m_basic_blocks.size(); ++n) {
+      //assert( m_basic_blocks[n]->Tmp_ids.size() <= 1 );
+         // if the above assert fails we have an error in either dominator
+         // computation, the flow graph does not have a unique entry, or some other error
+      if( !m_basic_blocks[n]->Tmp_ids.empty() ) {
+         m_basic_blocks[n]->immediatedominator_id = *m_basic_blocks[n]->Tmp_ids.begin();
+         num_idoms++;
+      } else if (m_basic_blocks[n]->predecessor_ids.empty()) {
+    	  num_nopred += 1;
+      }
+   }
+   assert( num_idoms == m_basic_blocks.size()-num_nopred );
+      // the entry node does not have an immediate dominator, but everyone else should
+}
+
+void function_info::print_dominators()
+{
+   printf("Printing dominators for function \'%s\':\n", m_name.c_str() );
+   std::vector<int>::iterator bb_itr;
+   for (unsigned i = 0; i < m_basic_blocks.size(); i++) {
+      printf("ID: %d\t:", i);
+      for( std::set<int>::iterator j=m_basic_blocks[i]->dominator_ids.begin(); j!=m_basic_blocks[i]->dominator_ids.end(); j++) 
+         printf(" %d", *j );
+      printf("\n");
+   }
+}
+
+void function_info::print_postdominators()
+{
+   printf("Printing postdominators for function \'%s\':\n", m_name.c_str() );
+   std::vector<int>::iterator bb_itr;
+   for (unsigned i = 0; i < m_basic_blocks.size(); i++) {
+      printf("ID: %d\t:", i);
+      for( std::set<int>::iterator j=m_basic_blocks[i]->postdominator_ids.begin(); j!=m_basic_blocks[i]->postdominator_ids.end(); j++) 
+         printf(" %d", *j );
+      printf("\n");
+   }
+}
+
+void function_info::print_ipostdominators()
+{
+   printf("Printing immediate postdominators for function \'%s\':\n", m_name.c_str() );
+   std::vector<int>::iterator bb_itr;
+   for (unsigned i = 0; i < m_basic_blocks.size(); i++) {
+      printf("ID: %d\t:", i);
+      printf("%d\n", m_basic_blocks[i]->immediatepostdominator_id);
+   }
+}
+
+void function_info::print_idominators()
+{
+   printf("Printing immediate dominators for function \'%s\':\n", m_name.c_str() );
+   std::vector<int>::iterator bb_itr;
+   for (unsigned i = 0; i < m_basic_blocks.size(); i++) {
+      printf("ID: %d\t:", i);
+      printf("%d\n", m_basic_blocks[i]->immediatedominator_id);
+   }
+}
+
+unsigned function_info::get_num_reconvergence_pairs()
+{
+   if (!num_reconvergence_pairs) {
+      if( m_basic_blocks.size() == 0 ) 
+         return 0;
+      for (unsigned i=0; i< (m_basic_blocks.size()-1); i++) { //last basic block containing exit obviously won't have a pair
+         if (m_basic_blocks[i]->ptx_end->get_opcode() == BRA_OP) {
+            num_reconvergence_pairs++;
+         }
+      }
+   }
+   return num_reconvergence_pairs;
+}
+
+void function_info::get_reconvergence_pairs(gpgpu_recon_t* recon_points)
+{
+   unsigned idx=0; //array index
+   if( m_basic_blocks.size() == 0 ) 
+       return;
+   for (unsigned i=0; i< (m_basic_blocks.size()-1); i++) { //last basic block containing exit obviously won't have a pair
 #ifdef DEBUG_GET_RECONVERG_PAIRS
-      m_basic_blocks[m_basic_blocks[i]->immediatepostdominator_id]
-          ->ptx_begin->print_insn();
-      printf("\trecon_points[idx].target_pc=%d\n", recon_points[idx].target_pc);
-      fflush(stdout);
+      printf("i=%d\n", i); fflush(stdout);
 #endif
-      idx++;
-    }
-  }
+      if (m_basic_blocks[i]->ptx_end->get_opcode() == BRA_OP) {
+#ifdef DEBUG_GET_RECONVERG_PAIRS
+         printf("\tbranch!\n");
+         printf("\tbb_id=%d; ipdom=%d\n", m_basic_blocks[i]->bb_id, m_basic_blocks[i]->immediatepostdominator_id);
+         printf("\tm_instr_mem index=%d\n", m_basic_blocks[i]->ptx_end->get_m_instr_mem_index());
+         fflush(stdout);
+#endif
+         recon_points[idx].source_pc = m_basic_blocks[i]->ptx_end->get_PC();
+         recon_points[idx].source_inst = m_basic_blocks[i]->ptx_end;
+#ifdef DEBUG_GET_RECONVERG_PAIRS
+         printf("\trecon_points[idx].source_pc=%d\n", recon_points[idx].source_pc);
+#endif
+         if( m_basic_blocks[m_basic_blocks[i]->immediatepostdominator_id]->ptx_begin ) {
+            recon_points[idx].target_pc = m_basic_blocks[m_basic_blocks[i]->immediatepostdominator_id]->ptx_begin->get_PC();
+            recon_points[idx].target_inst = m_basic_blocks[m_basic_blocks[i]->immediatepostdominator_id]->ptx_begin;
+         } else {
+            // reconverge after function return
+            recon_points[idx].target_pc = -2;
+            recon_points[idx].target_inst = NULL;
+         }
+#ifdef DEBUG_GET_RECONVERG_PAIRS
+         m_basic_blocks[m_basic_blocks[i]->immediatepostdominator_id]->ptx_begin->print_insn();
+         printf("\trecon_points[idx].target_pc=%d\n", recon_points[idx].target_pc); fflush(stdout);
+#endif
+         idx++;
+      }
+   }
 }
 
 // interface with graphviz (print the graph in DOT language) for plotting
-void function_info::print_basic_block_dot() {
-  printf("Basic Block in DOT\n");
-  printf("digraph %s {\n", m_name.c_str());
-  std::vector<basic_block_t *>::iterator bb_itr;
-  for (bb_itr = m_basic_blocks.begin(); bb_itr != m_basic_blocks.end();
-       bb_itr++) {
-    printf("\t");
-    std::set<int>::iterator s;
-    for (s = (*bb_itr)->successor_ids.begin();
-         s != (*bb_itr)->successor_ids.end(); s++) {
-      unsigned succ_bb = *s;
-      printf("%d -> %d; ", (*bb_itr)->bb_id, succ_bb);
-    }
-    printf("\n");
-  }
-  printf("}\n");
+void function_info::print_basic_block_dot()
+{
+   printf("Basic Block in DOT\n");
+   printf("digraph %s {\n", m_name.c_str());
+   std::vector<basic_block_t*>::iterator bb_itr;
+   for (bb_itr = m_basic_blocks.begin();bb_itr != m_basic_blocks.end(); bb_itr++) {
+      printf("\t");
+      std::set<int>::iterator s;
+      for (s = (*bb_itr)->successor_ids.begin();s != (*bb_itr)->successor_ids.end();s++) {
+         unsigned succ_bb = *s;
+         printf("%d -> %d; ", (*bb_itr)->bb_id, succ_bb );
+      }
+      printf("\n");
+   }
+   printf("}\n");
 }
 
-unsigned ptx_kernel_shmem_size(void *kernel_impl) {
-  function_info *f = (function_info *)kernel_impl;
-  const struct gpgpu_ptx_sim_info *kernel_info = f->get_kernel_info();
-  return kernel_info->smem;
+unsigned ptx_kernel_shmem_size( void *kernel_impl )
+{
+   function_info *f = (function_info*)kernel_impl;
+   const struct gpgpu_ptx_sim_info *kernel_info = f->get_kernel_info();
+   return kernel_info->smem;
 }
 
-unsigned ptx_kernel_nregs(void *kernel_impl) {
-  function_info *f = (function_info *)kernel_impl;
-  const struct gpgpu_ptx_sim_info *kernel_info = f->get_kernel_info();
-  return kernel_info->regs;
+unsigned ptx_kernel_nregs( void *kernel_impl )
+{
+   function_info *f = (function_info*)kernel_impl;
+   const struct gpgpu_ptx_sim_info *kernel_info = f->get_kernel_info();
+   return kernel_info->regs;
 }
 
-unsigned type_info_key::type_decode(size_t &size, int &basic_type) const {
-  int type = scalar_type();
-  return type_decode(type, size, basic_type);
+unsigned type_info_key::type_decode( size_t &size, int &basic_type ) const
+{
+   int type = scalar_type();
+   return type_decode(type,size,basic_type);
 }
 
-unsigned type_info_key::type_decode(int type, size_t &size, int &basic_type) {
-  switch (type) {
-    case S8_TYPE:
-      size = 8;
-      basic_type = 1;
-      return 0;
-    case S16_TYPE:
-      size = 16;
-      basic_type = 1;
-      return 1;
-    case S32_TYPE:
-      size = 32;
-      basic_type = 1;
-      return 2;
-    case S64_TYPE:
-      size = 64;
-      basic_type = 1;
-      return 3;
-    case U8_TYPE:
-      size = 8;
-      basic_type = 0;
-      return 4;
-    case U16_TYPE:
-      size = 16;
-      basic_type = 0;
-      return 5;
-    case U32_TYPE:
-      size = 32;
-      basic_type = 0;
-      return 6;
-    case U64_TYPE:
-      size = 64;
-      basic_type = 0;
-      return 7;
-    case F16_TYPE:
-      size = 16;
-      basic_type = -1;
-      return 8;
-    case F32_TYPE:
-      size = 32;
-      basic_type = -1;
-      return 9;
-    case F64_TYPE:
-      size = 64;
-      basic_type = -1;
-      return 10;
-    case FF64_TYPE:
-      size = 64;
-      basic_type = -1;
-      return 10;
-    case PRED_TYPE:
-      size = 1;
-      basic_type = 2;
-      return 11;
-    case B8_TYPE:
-      size = 8;
-      basic_type = 0;
-      return 12;
-    case B16_TYPE:
-      size = 16;
-      basic_type = 0;
-      return 13;
-    case B32_TYPE:
-      size = 32;
-      basic_type = 0;
-      return 14;
-    case B64_TYPE:
-      size = 64;
-      basic_type = 0;
-      return 15;
-    case BB64_TYPE:
-      size = 64;
-      basic_type = 0;
-      return 15;
-    case BB128_TYPE:
-      size = 128;
-      basic_type = 0;
-      return 16;
-    case TEXREF_TYPE:
-    case SAMPLERREF_TYPE:
-    case SURFREF_TYPE:
-      size = 32;
-      basic_type = 3;
-      return 16;
-    default:
-      printf("ERROR ** type_decode() does not know about \"%s\"\n",
-             decode_token(type));
-      assert(0);
+unsigned type_info_key::type_decode( int type, size_t &size, int &basic_type )
+{
+   switch ( type ) {
+   case S8_TYPE:  size=8;  basic_type=1; return 0;
+   case S16_TYPE: size=16; basic_type=1; return 1;
+   case S32_TYPE: size=32; basic_type=1; return 2;
+   case S64_TYPE: size=64; basic_type=1; return 3;
+   case U8_TYPE:  size=8;  basic_type=0; return 4;
+   case U16_TYPE: size=16; basic_type=0; return 5;
+   case U32_TYPE: size=32; basic_type=0; return 6;
+   case U64_TYPE: size=64; basic_type=0; return 7;
+   case F16_TYPE: size=16; basic_type=-1; return 8;
+   case F32_TYPE: size=32; basic_type=-1; return 9;
+   case F64_TYPE: size=64; basic_type=-1; return 10;
+   case FF64_TYPE: size=64; basic_type=-1; return 10;
+   case PRED_TYPE: size=1; basic_type=2; return 11;
+   case B8_TYPE:  size=8;  basic_type=0; return 12;
+   case B16_TYPE: size=16; basic_type=0; return 13;
+   case B32_TYPE: size=32; basic_type=0; return 14;
+   case B64_TYPE: size=64; basic_type=0; return 15;
+   case BB64_TYPE: size=64; basic_type=0; return 15;
+   case BB128_TYPE: size=128; basic_type=0; return 16;
+   case TEXREF_TYPE: case SAMPLERREF_TYPE: case SURFREF_TYPE:
+      size=32; basic_type=3; return 16;
+   default: 
+      printf("ERROR ** type_decode() does not know about \"%s\"\n", decode_token(type) ); 
+      assert(0); 
       return 0xDEADBEEF;
-  }
+   }
 }
 
-arg_buffer_t copy_arg_to_buffer(ptx_thread_info *thread,
-                                operand_info actual_param_op,
-                                const symbol *formal_param) {
-  if (actual_param_op.is_reg()) {
-    ptx_reg_t value = thread->get_reg(actual_param_op.get_symbol());
-    return arg_buffer_t(formal_param, actual_param_op, value);
-  } else if (actual_param_op.is_param_local()) {
-    unsigned size = formal_param->get_size_in_bytes();
-    addr_t frame_offset = actual_param_op.get_symbol()->get_address();
-    addr_t from_addr = thread->get_local_mem_stack_pointer() + frame_offset;
-    char buffer[1024];
-    assert(size < 1024);
-    thread->m_local_mem->read(from_addr, size, buffer);
-    return arg_buffer_t(formal_param, actual_param_op, buffer, size);
-  } else {
-    printf(
-        "GPGPU-Sim PTX: ERROR ** need to add support for this operand type in "
-        "call/return\n");
-    abort();
-  }
+arg_buffer_t copy_arg_to_buffer(ptx_thread_info * thread, operand_info actual_param_op, const symbol * formal_param)
+{
+   if( actual_param_op.is_reg() )  {
+      ptx_reg_t value = thread->get_reg(actual_param_op.get_symbol());
+      return arg_buffer_t(formal_param,actual_param_op,value);
+   } else if ( actual_param_op.is_param_local() ) {
+      unsigned size=formal_param->get_size_in_bytes();
+      addr_t frame_offset = actual_param_op.get_symbol()->get_address();
+      addr_t from_addr = thread->get_local_mem_stack_pointer() + frame_offset;
+      char buffer[1024];
+      assert(size<1024); 
+      thread->m_local_mem->read(from_addr,size,buffer);
+      return arg_buffer_t(formal_param,actual_param_op,buffer,size);
+   } else {
+      printf("GPGPU-Sim PTX: ERROR ** need to add support for this operand type in call/return\n");
+      abort();
+   }
 }
 
-void copy_args_into_buffer_list(const ptx_instruction *pI,
-                                ptx_thread_info *thread,
-                                const function_info *target_func,
-                                arg_buffer_list_t &arg_values) {
-  unsigned n_return = target_func->has_return();
-  unsigned n_args = target_func->num_args();
-  for (unsigned arg = 0; arg < n_args; arg++) {
-    const operand_info &actual_param_op =
-        pI->operand_lookup(n_return + 1 + arg);
-    const symbol *formal_param = target_func->get_arg(arg);
-    arg_values.push_back(
-        copy_arg_to_buffer(thread, actual_param_op, formal_param));
-  }
+void copy_args_into_buffer_list( const ptx_instruction * pI, 
+                                 ptx_thread_info * thread, 
+                                 const function_info * target_func, 
+                                 arg_buffer_list_t &arg_values ) 
+{
+   unsigned n_return = target_func->has_return();
+   unsigned n_args = target_func->num_args();
+   for( unsigned arg=0; arg < n_args; arg ++ ) {
+      const operand_info &actual_param_op = pI->operand_lookup(n_return+1+arg);
+      const symbol *formal_param = target_func->get_arg(arg);
+      arg_values.push_back( copy_arg_to_buffer(thread, actual_param_op, formal_param) );
+   }
 }
 
-void copy_buffer_to_frame(ptx_thread_info *thread, const arg_buffer_t &a) {
-  if (a.is_reg()) {
-    ptx_reg_t value = a.get_reg();
-    operand_info dst_reg =
-        operand_info(a.get_dst(), thread->get_gpu()->gpgpu_ctx);
-    thread->set_reg(dst_reg.get_symbol(), value);
-  } else {
-    const void *buffer = a.get_param_buffer();
-    size_t size = a.get_param_buffer_size();
-    const symbol *dst = a.get_dst();
-    addr_t frame_offset = dst->get_address();
-    addr_t to_addr = thread->get_local_mem_stack_pointer() + frame_offset;
-    thread->m_local_mem->write(to_addr, size, buffer, NULL, NULL);
-  }
+void copy_buffer_to_frame(ptx_thread_info * thread, const arg_buffer_t &a) 
+{
+   if( a.is_reg() ) {
+      ptx_reg_t value = a.get_reg();
+      operand_info dst_reg = operand_info(a.get_dst(), thread->get_gpu()->gpgpu_ctx); 
+      thread->set_reg(dst_reg.get_symbol(),value);
+   } else {  
+      const void *buffer = a.get_param_buffer();
+      size_t size = a.get_param_buffer_size();
+      const symbol *dst = a.get_dst();
+      addr_t frame_offset = dst->get_address();
+      addr_t to_addr = thread->get_local_mem_stack_pointer() + frame_offset;
+      thread->m_local_mem->write(to_addr,size,buffer,NULL,NULL);
+   }
 }
 
-void copy_buffer_list_into_frame(ptx_thread_info *thread,
-                                 arg_buffer_list_t &arg_values) {
-  arg_buffer_list_t::iterator a;
-  for (a = arg_values.begin(); a != arg_values.end(); a++) {
-    copy_buffer_to_frame(thread, *a);
-  }
+void copy_buffer_list_into_frame(ptx_thread_info * thread, arg_buffer_list_t &arg_values) 
+{
+   arg_buffer_list_t::iterator a;
+   for( a=arg_values.begin(); a != arg_values.end(); a++ ) {
+      copy_buffer_to_frame(thread, *a);
+   }
 }
 
-static std::list<operand_info> check_operands(
-    int opcode, const std::list<int> &scalar_type,
-    const std::list<operand_info> &operands, gpgpu_context *ctx) {
-  static int g_warn_literal_operands_two_type_inst;
-  if ((opcode == CVT_OP) || (opcode == SET_OP) || (opcode == SLCT_OP) ||
-      (opcode == TEX_OP) || (opcode == MMA_OP) || (opcode == DP4A_OP)) {
-    // just make sure these do not have have const operands...
-    if (!g_warn_literal_operands_two_type_inst) {
-      std::list<operand_info>::const_iterator o;
-      for (o = operands.begin(); o != operands.end(); o++) {
-        const operand_info &op = *o;
-        if (op.is_literal()) {
-          printf(
-              "GPGPU-Sim PTX: PTX uses two scalar type intruction with literal "
-              "operand.\n");
-          g_warn_literal_operands_two_type_inst = 1;
+
+
+static std::list<operand_info> check_operands( int opcode,
+                                        const std::list<int> &scalar_type,
+                                        const std::list<operand_info> &operands,
+					gpgpu_context* ctx)
+{
+   static int g_warn_literal_operands_two_type_inst;
+    if( (opcode == CVT_OP) || (opcode == SET_OP) || (opcode == SLCT_OP) || (opcode == TEX_OP) || (opcode==MMA_OP) || (opcode == DP4A_OP)) {
+        // just make sure these do not have have const operands... 
+        if( !g_warn_literal_operands_two_type_inst ) {
+            std::list<operand_info>::const_iterator o;
+            for( o = operands.begin(); o != operands.end(); o++ ) {
+                const operand_info &op = *o;
+                if( op.is_literal() ) {
+                    printf("GPGPU-Sim PTX: PTX uses two scalar type intruction with literal operand.\n");
+                    g_warn_literal_operands_two_type_inst = 1;
+                }
+            }
         }
-      }
+    } else {
+        assert( scalar_type.size() < 2 );
+        if( scalar_type.size() == 1 ) {
+            std::list<operand_info> result;
+            int inst_type = scalar_type.front();
+            std::list<operand_info>::const_iterator o;
+            for( o = operands.begin(); o != operands.end(); o++ ) {
+                const operand_info &op = *o;
+                if( op.is_literal() ) {
+                    if( (op.get_type() == double_op_t) && (inst_type == F32_TYPE) ) {
+                        ptx_reg_t v = op.get_literal_value();
+                        float u = (float)v.f64;
+                        operand_info n(u, ctx);
+                        result.push_back(n);
+                    } else {
+                        result.push_back(op);
+                    }
+                } else {
+                        result.push_back(op);
+                }
+            }
+            return result;
+        } 
     }
-  } else {
-    assert(scalar_type.size() < 2);
-    if (scalar_type.size() == 1) {
-      std::list<operand_info> result;
-      int inst_type = scalar_type.front();
-      std::list<operand_info>::const_iterator o;
-      for (o = operands.begin(); o != operands.end(); o++) {
-        const operand_info &op = *o;
-        if (op.is_literal()) {
-          if ((op.get_type() == double_op_t) && (inst_type == F32_TYPE)) {
-            ptx_reg_t v = op.get_literal_value();
-            float u = (float)v.f64;
-            operand_info n(u, ctx);
-            result.push_back(n);
-          } else {
-            result.push_back(op);
-          }
-        } else {
-          result.push_back(op);
-        }
-      }
-      return result;
-    }
-  }
-  return operands;
+    return operands;
 }
 
-ptx_instruction::ptx_instruction(
-    int opcode, const symbol *pred, int neg_pred, int pred_mod, symbol *label,
-    const std::list<operand_info> &operands, const operand_info &return_var,
-    const std::list<int> &options, const std::list<int> &wmma_options,
-    const std::list<int> &scalar_type, memory_space_t space_spec,
-    const char *file, unsigned line, const char *source,
-    const core_config *config, gpgpu_context *ctx)
-    : warp_inst_t(config), m_return_var(ctx) {
-  gpgpu_ctx = ctx;
-  m_uid = ++(ctx->g_num_ptx_inst_uid);
-  m_PC = 0;
-  m_opcode = opcode;
-  m_pred = pred;
-  m_neg_pred = neg_pred;
-  m_pred_mod = pred_mod;
-  m_label = label;
-  const std::list<operand_info> checked_operands =
-      check_operands(opcode, scalar_type, operands, ctx);
-  m_operands.insert(m_operands.begin(), checked_operands.begin(),
-                    checked_operands.end());
-  m_return_var = return_var;
-  m_options = options;
-  m_wmma_options = wmma_options;
-  m_wide = false;
-  m_hi = false;
-  m_lo = false;
-  m_uni = false;
-  m_exit = false;
-  m_abs = false;
-  m_neg = false;
-  m_to_option = false;
-  m_cache_option = 0;
-  m_rounding_mode = RN_OPTION;
-  m_compare_op = -1;
-  m_saturation_mode = 0;
-  m_geom_spec = 0;
-  m_vector_spec = 0;
-  m_atomic_spec = 0;
-  m_membar_level = 0;
-  m_inst_size = 8;  // bytes
-  int rr = 0;
-  std::list<int>::const_iterator i;
-  unsigned n = 1;
-  for (i = wmma_options.begin(); i != wmma_options.end(); i++, n++) {
-    int last_ptx_inst_option = *i;
-    switch (last_ptx_inst_option) {
-      case SYNC_OPTION:
-      case LOAD_A:
-      case LOAD_B:
-      case LOAD_C:
-      case STORE_D:
-      case MMA:
-        m_wmma_type = last_ptx_inst_option;
-        break;
-      case ROW:
-      case COL:
-        m_wmma_layout[rr++] = last_ptx_inst_option;
-        break;
-      case M16N16K16:
-      case M32N8K16:
-      case M8N32K16:
-        break;
-      default:
-        assert(0);
-        break;
-    }
-  }
-  rr = 0;
-  n = 1;
-  for (i = options.begin(); i != options.end(); i++, n++) {
-    int last_ptx_inst_option = *i;
-    switch (last_ptx_inst_option) {
+
+ptx_instruction::ptx_instruction( int opcode, 
+                                  const symbol *pred, 
+                                  int neg_pred, 
+                                  int pred_mod,
+                                  symbol *label,
+                                  const std::list<operand_info> &operands, 
+                                  const operand_info &return_var,
+                                  const std::list<int> &options, 
+                                  const std::list<int> &wmma_options, 
+                                  const std::list<int> &scalar_type,
+                                  memory_space_t space_spec,
+                                  const char *file, 
+                                  unsigned line,
+                                  const char *source,
+                                  const core_config *config,
+				  gpgpu_context* ctx ) : warp_inst_t(config), m_return_var(ctx)
+{
+   gpgpu_ctx = ctx;
+   m_uid = ++(ctx->g_num_ptx_inst_uid);
+   m_PC = 0;
+   m_opcode = opcode;
+   m_pred = pred;
+   m_neg_pred = neg_pred;
+   m_pred_mod = pred_mod;
+   m_label = label;
+   const std::list<operand_info> checked_operands = check_operands(opcode,scalar_type,operands, ctx);
+   m_operands.insert(m_operands.begin(), checked_operands.begin(), checked_operands.end() );
+   m_return_var = return_var;
+   m_options = options;
+   m_wmma_options = wmma_options;
+   m_wide = false;
+   m_hi = false;
+   m_lo = false;
+   m_uni = false;
+   m_exit = false;
+   m_abs = false;
+   m_neg = false;
+   m_to_option = false;
+   m_cache_option = 0;
+   m_rounding_mode = RN_OPTION;
+   m_compare_op = -1;
+   m_saturation_mode = 0;
+   m_geom_spec = 0;
+   m_vector_spec = 0;
+   m_atomic_spec = 0;
+   m_membar_level = 0;
+   m_inst_size = 8; // bytes
+   int rr=0;
+   std::list<int>::const_iterator i;
+   unsigned n=1;
+   for ( i=wmma_options.begin(); i!= wmma_options.end(); i++, n++ ) {
+      int last_ptx_inst_option = *i;
+      switch ( last_ptx_inst_option ) {
+      		case SYNC_OPTION:
+      		case LOAD_A:
+      		case LOAD_B:
+      		case LOAD_C:
+      		case STORE_D:
+      		case MMA:
+      		  m_wmma_type=last_ptx_inst_option;
+      		  break;
+      		case ROW:
+      		case COL:
+      		  m_wmma_layout[rr++]=last_ptx_inst_option;
+      		  break;
+      		case M16N16K16:
+      		case M32N8K16:
+      		case M8N32K16:
+			break;
+      		default:
+      		   assert(0);
+      		   break;
+	}
+   }
+   rr=0;
+   n=1;
+   for ( i=options.begin(); i!= options.end(); i++, n++ ) {
+      int last_ptx_inst_option = *i;
+      switch ( last_ptx_inst_option ) {
       case SYNC_OPTION:
       case ARRIVE_OPTION:
       case RED_OPTION:
-        m_barrier_op = last_ptx_inst_option;
-        break;
+          m_barrier_op = last_ptx_inst_option;
+          break;
       case EQU_OPTION:
       case NEU_OPTION:
       case LTU_OPTION:
@@ -1280,16 +1186,16 @@ ptx_instruction::ptx_instruction(
       case GE_OPTION:
       case LS_OPTION:
       case HS_OPTION:
-        m_compare_op = last_ptx_inst_option;
-        break;
+         m_compare_op = last_ptx_inst_option;
+         break;
       case NUM_OPTION:
       case NAN_OPTION:
-        m_compare_op = last_ptx_inst_option;
+    	  m_compare_op = last_ptx_inst_option;
         // assert(0); // finish this
-        break;
+         break;
       case SAT_OPTION:
-        m_saturation_mode = 1;
-        break;
+         m_saturation_mode = 1;
+         break;
       case RNI_OPTION:
       case RZI_OPTION:
       case RMI_OPTION:
@@ -1298,39 +1204,38 @@ ptx_instruction::ptx_instruction(
       case RZ_OPTION:
       case RM_OPTION:
       case RP_OPTION:
-        m_rounding_mode = last_ptx_inst_option;
-        break;
+         m_rounding_mode = last_ptx_inst_option;
+         break;
       case HI_OPTION:
-        m_compare_op = last_ptx_inst_option;
-        m_hi = true;
-        assert(!m_lo);
-        assert(!m_wide);
-        break;
+         m_compare_op = last_ptx_inst_option;
+         m_hi = true;
+         assert( !m_lo ); 
+         assert( !m_wide );
+         break;
       case LO_OPTION:
-        m_compare_op = last_ptx_inst_option;
-        m_lo = true;
-        assert(!m_hi);
-        assert(!m_wide);
-        break;
+         m_compare_op = last_ptx_inst_option;
+         m_lo = true;
+         assert( !m_hi );
+         assert( !m_wide );
+         break;
       case WIDE_OPTION:
-        m_wide = true;
-        assert(!m_lo);
-        assert(!m_hi);
-        break;
+         m_wide = true;
+         assert( !m_lo ); 
+         assert( !m_hi ); 
+         break;
       case UNI_OPTION:
-        m_uni = true;  // don't care... < now we DO care when constructing
-                       // flowgraph>
-        break;
+         m_uni = true; // don't care... < now we DO care when constructing flowgraph>
+         break;
       case GEOM_MODIFIER_1D:
       case GEOM_MODIFIER_2D:
       case GEOM_MODIFIER_3D:
-        m_geom_spec = last_ptx_inst_option;
-        break;
+         m_geom_spec = last_ptx_inst_option;
+         break;
       case V2_TYPE:
       case V3_TYPE:
       case V4_TYPE:
-        m_vector_spec = last_ptx_inst_option;
-        break;
+         m_vector_spec = last_ptx_inst_option;
+         break;
       case ATOMIC_AND:
       case ATOMIC_OR:
       case ATOMIC_XOR:
@@ -1341,225 +1246,223 @@ ptx_instruction::ptx_instruction(
       case ATOMIC_DEC:
       case ATOMIC_MIN:
       case ATOMIC_MAX:
-        m_atomic_spec = last_ptx_inst_option;
-        break;
+         m_atomic_spec = last_ptx_inst_option;
+         break;
       case APPROX_OPTION:
-        break;
+         break;
       case FULL_OPTION:
-        break;
+         break;
       case ANY_OPTION:
-        m_vote_mode = vote_any;
-        break;
+         m_vote_mode = vote_any;
+         break;
       case ALL_OPTION:
-        m_vote_mode = vote_all;
-        break;
+         m_vote_mode = vote_all;
+         break;
       case BALLOT_OPTION:
-        m_vote_mode = vote_ballot;
-        break;
+         m_vote_mode = vote_ballot;
+         break;
       case GLOBAL_OPTION:
-        m_membar_level = GLOBAL_OPTION;
-        break;
+         m_membar_level = GLOBAL_OPTION;
+         break;
       case CTA_OPTION:
-        m_membar_level = CTA_OPTION;
-        break;
+         m_membar_level = CTA_OPTION;
+         break;
       case SYS_OPTION:
-        m_membar_level = SYS_OPTION;
-        break;
+         m_membar_level = SYS_OPTION;
+         break;
       case FTZ_OPTION:
-        break;
+         break;
       case EXIT_OPTION:
-        m_exit = true;
-        break;
+         m_exit = true;
+         break;
       case ABS_OPTION:
-        m_abs = true;
-        break;
+         m_abs = true;
+         break;
       case NEG_OPTION:
-        m_neg = true;
-        break;
+         m_neg = true;
+         break;
       case TO_OPTION:
-        m_to_option = true;
-        break;
-      case CA_OPTION:
-      case CG_OPTION:
-      case CS_OPTION:
-      case LU_OPTION:
-      case CV_OPTION:
-        m_cache_option = last_ptx_inst_option;
-        break;
+         m_to_option = true;
+         break;
+      case CA_OPTION: case CG_OPTION: case CS_OPTION: case LU_OPTION: case CV_OPTION:
+         m_cache_option = last_ptx_inst_option;
+         break;
       case HALF_OPTION:
-        m_inst_size = 4;  // bytes
-        break;
+         m_inst_size = 4; // bytes
+         break;
       case EXTP_OPTION:
-        break;
+             break;
       case NC_OPTION:
-        m_cache_option = last_ptx_inst_option;
-        break;
+             m_cache_option = last_ptx_inst_option;
+             break;
       case UP_OPTION:
       case DOWN_OPTION:
       case BFLY_OPTION:
       case IDX_OPTION:
-        m_shfl_op = last_ptx_inst_option;
-        break;
+		  m_shfl_op = last_ptx_inst_option;
+		  break;
       case PRMT_F4E_MODE:
       case PRMT_B4E_MODE:
       case PRMT_RC8_MODE:
       case PRMT_ECL_MODE:
       case PRMT_ECR_MODE:
       case PRMT_RC16_MODE:
-        m_prmt_op = last_ptx_inst_option;
-        break;
+		  m_prmt_op = last_ptx_inst_option;
+		  break;
       default:
-        assert(0);
-        break;
-    }
-  }
-  m_scalar_type = scalar_type;
-  m_space_spec = space_spec;
-  if ((opcode == ST_OP || opcode == LD_OP || opcode == LDU_OP) &&
-      (space_spec == undefined_space)) {
-    m_space_spec = generic_space;
-  }
-  for (std::vector<operand_info>::const_iterator i = m_operands.begin();
-       i != m_operands.end(); ++i) {
-    const operand_info &op = *i;
-    if (op.get_addr_space() != undefined_space)
-      m_space_spec = op.get_addr_space();  // TODO: can have more than one
-                                           // memory space for ptxplus (g8x)
-                                           // inst
-  }
-  if (opcode == TEX_OP) m_space_spec = tex_space;
+         assert(0);
+         break;
+      }
+   }
+   m_scalar_type = scalar_type;
+   m_space_spec = space_spec;
+   if( ( opcode == ST_OP || opcode == LD_OP || opcode == LDU_OP ) && (space_spec == undefined_space) ) {
+      m_space_spec = generic_space;
+   } 
+   for( std::vector<operand_info>::const_iterator i=m_operands.begin(); i!=m_operands.end(); ++i) {
+       const operand_info &op = *i;
+       if( op.get_addr_space() != undefined_space ) 
+           m_space_spec = op.get_addr_space(); // TODO: can have more than one memory space for ptxplus (g8x) inst
+   }
+   if( opcode == TEX_OP ) 
+       m_space_spec = tex_space;
+   
+   m_source_file = file?file:"<unknown>";
+   m_source_line = line;
+   m_source = source;
+   // Trim tabs
+   m_source.erase( std::remove( m_source.begin(), m_source.end(), '\t' ), m_source.end() );
 
-  m_source_file = file ? file : "<unknown>";
-  m_source_line = line;
-  m_source = source;
-  // Trim tabs
-  m_source.erase(std::remove(m_source.begin(), m_source.end(), '\t'),
-                 m_source.end());
+   if (opcode == CALL_OP) {
+       const operand_info &target  = func_addr();
+       assert( target.is_function_address() );
+       const symbol *func_addr = target.get_symbol();
+       const function_info *target_func = func_addr->get_pc();
+       std::string fname = target_func->get_name();
 
-  if (opcode == CALL_OP) {
-    const operand_info &target = func_addr();
-    assert(target.is_function_address());
-    const symbol *func_addr = target.get_symbol();
-    const function_info *target_func = func_addr->get_pc();
-    std::string fname = target_func->get_name();
+       if (fname =="vprintf"){
+           m_is_printf = true;
+       }
+       if(fname == "cudaStreamCreateWithFlags")
+           m_is_cdp = 1;
+       if(fname == "cudaGetParameterBufferV2")
+           m_is_cdp = 2;
+       if(fname == "cudaLaunchDeviceV2")
+           m_is_cdp = 4;
 
-    if (fname == "vprintf") {
-      m_is_printf = true;
-    }
-    if (fname == "cudaStreamCreateWithFlags") m_is_cdp = 1;
-    if (fname == "cudaGetParameterBufferV2") m_is_cdp = 2;
-    if (fname == "cudaLaunchDeviceV2") m_is_cdp = 4;
-  }
+   }
 }
 
-void ptx_instruction::print_insn() const {
-  print_insn(stdout);
-  fflush(stdout);
+void ptx_instruction::print_insn() const
+{
+   print_insn(stdout);
+   fflush(stdout);
 }
 
-void ptx_instruction::print_insn(FILE *fp) const {
-  fprintf(fp, "%s", to_string().c_str());
+void ptx_instruction::print_insn( FILE *fp ) const
+{
+    fprintf( fp, "%s", to_string().c_str() );
 }
 
-std::string ptx_instruction::to_string() const {
-  char buf[STR_SIZE];
-  unsigned used_bytes = 0;
-  if (!is_label()) {
-    used_bytes +=
-        snprintf(buf + used_bytes, STR_SIZE - used_bytes, " PC=0x%03x ", m_PC);
-  } else {
-    used_bytes +=
-        snprintf(buf + used_bytes, STR_SIZE - used_bytes, "                ");
-  }
-  used_bytes +=
-      snprintf(buf + used_bytes, STR_SIZE - used_bytes, "(%s:%d) %s",
-               m_source_file.c_str(), m_source_line, m_source.c_str());
-  return std::string(buf);
+std::string ptx_instruction::to_string() const
+{
+   char buf[ STR_SIZE ];
+   unsigned used_bytes = 0;
+   if( !is_label() ) {
+      used_bytes += snprintf( buf + used_bytes, STR_SIZE - used_bytes, " PC=0x%03x ", m_PC );
+   } else {
+      used_bytes += snprintf( buf + used_bytes, STR_SIZE - used_bytes, "                " );
+   }
+   used_bytes += snprintf( buf + used_bytes, STR_SIZE - used_bytes,
+                           "(%s:%d) %s",
+                           m_source_file.c_str(), m_source_line,
+                           m_source.c_str() );
+   return std::string( buf );
 }
-operand_info ptx_instruction::get_pred() const {
-  return operand_info(m_pred, gpgpu_ctx);
-}
-
-function_info::function_info(int entry_point, gpgpu_context *ctx) {
-  gpgpu_ctx = ctx;
-  m_uid = (gpgpu_ctx->function_info_sm_next_uid)++;
-  m_entry_point = (entry_point == 1) ? true : false;
-  m_extern = (entry_point == 2) ? true : false;
-  num_reconvergence_pairs = 0;
-  m_symtab = NULL;
-  m_assembled = false;
-  m_return_var_sym = NULL;
-  m_kernel_info.cmem = 0;
-  m_kernel_info.lmem = 0;
-  m_kernel_info.regs = 0;
-  m_kernel_info.smem = 0;
-  m_local_mem_framesize = 0;
-  m_args_aligned_size = -1;
-  pdom_done = false;  // initialize it to false
+operand_info ptx_instruction::get_pred() const
+{
+    return operand_info( m_pred, gpgpu_ctx);
 }
 
-unsigned function_info::print_insn(unsigned pc, FILE *fp) const {
-  unsigned inst_size = 1;  // return offset to next instruction or 1 if unknown
-  unsigned index = pc - m_start_PC;
-  char command[1024];
-  char buffer[1024];
-  memset(command, 0, 1024);
-  memset(buffer, 0, 1024);
-  snprintf(command, 1024, "c++filt -p %s", m_name.c_str());
-  FILE *p = popen(command, "r");
-  buffer[0] = 0;
-  assert(fgets(buffer, 1023, p) != NULL);
-  // Remove trailing "\n" in buffer
-  char *c;
-  if ((c = strchr(buffer, '\n')) != NULL) *c = '\0';
-  fprintf(fp, "%s", buffer);
-  if (index >= m_instr_mem_size) {
-    fprintf(fp, "<past last instruction (max pc=%u)>",
-            m_start_PC + m_instr_mem_size - 1);
-  } else {
-    if (m_instr_mem[index] != NULL) {
-      m_instr_mem[index]->print_insn(fp);
-      inst_size = m_instr_mem[index]->isize;
-    } else
-      fprintf(fp, "<no instruction at pc = %u>", pc);
-  }
-  pclose(p);
-  return inst_size;
+
+function_info::function_info(int entry_point, gpgpu_context* ctx )
+{
+   gpgpu_ctx = ctx;
+   m_uid = (gpgpu_ctx->function_info_sm_next_uid)++;
+   m_entry_point = (entry_point==1)?true:false;
+   m_extern = (entry_point==2)?true:false;
+   num_reconvergence_pairs = 0;
+   m_symtab = NULL;
+   m_assembled = false;
+   m_return_var_sym = NULL; 
+   m_kernel_info.cmem = 0;
+   m_kernel_info.lmem = 0;
+   m_kernel_info.regs = 0;
+   m_kernel_info.smem = 0;
+   m_local_mem_framesize = 0;
+   m_args_aligned_size = -1;
+   pdom_done = false; //initialize it to false
 }
 
-std::string function_info::get_insn_str(unsigned pc) const {
-  unsigned index = pc - m_start_PC;
-  if (index >= m_instr_mem_size) {
-    char buff[STR_SIZE];
-    buff[STR_SIZE - 1] = '\0';
-    snprintf(buff, STR_SIZE, "<past last instruction (max pc=%u)>",
-             m_start_PC + m_instr_mem_size - 1);
-    return std::string(buff);
-  } else {
-    if (m_instr_mem[index] != NULL) {
-      return m_instr_mem[index]->to_string();
-    } else {
+unsigned function_info::print_insn( unsigned pc, FILE * fp ) const
+{
+   unsigned inst_size=1; // return offset to next instruction or 1 if unknown
+   unsigned index = pc - m_start_PC;
+   char command[1024];
+   char buffer[1024];
+   memset(command, 0, 1024);
+   memset(buffer, 0, 1024);
+   snprintf(command,1024,"c++filt -p %s",m_name.c_str());
+   FILE *p = popen(command,"r");
+   buffer[0]=0;
+   assert(fgets(buffer, 1023, p) != NULL);
+   // Remove trailing "\n" in buffer
+   char *c;
+   if ((c=strchr(buffer, '\n')) != NULL) *c = '\0';
+   fprintf(fp,"%s",buffer);
+   if ( index >= m_instr_mem_size ) {
+      fprintf(fp, "<past last instruction (max pc=%u)>", m_start_PC + m_instr_mem_size - 1 );
+   } else {
+      if ( m_instr_mem[index] != NULL ) {
+         m_instr_mem[index]->print_insn(fp);
+         inst_size = m_instr_mem[index]->isize;
+      } else
+         fprintf(fp, "<no instruction at pc = %u>", pc );
+   }
+   pclose(p);
+   return inst_size;
+}
+
+std::string function_info::get_insn_str( unsigned pc ) const
+{
+   unsigned index = pc - m_start_PC;
+   if ( index >= m_instr_mem_size ) {
       char buff[STR_SIZE];
-      buff[STR_SIZE - 1] = '\0';
-      snprintf(buff, STR_SIZE, "<no instruction at pc = %u>", pc);
+      buff[STR_SIZE-1] = '\0';
+      snprintf(buff, STR_SIZE, "<past last instruction (max pc=%u)>", m_start_PC + m_instr_mem_size - 1 );
       return std::string(buff);
-    }
-  }
+   } else {
+      if ( m_instr_mem[index] != NULL ) {
+         return m_instr_mem[index]->to_string();
+      } else {
+         char buff[STR_SIZE];
+         buff[STR_SIZE-1] = '\0';
+         snprintf(buff, STR_SIZE, "<no instruction at pc = %u>", pc );
+         return std::string(buff);
+      }
+   }
 }
 
-void gpgpu_ptx_assemble(std::string kname, void *kinfo) {
-  function_info *func_info = (function_info *)kinfo;
-  if ((function_info *)kinfo == NULL) {
-    printf("GPGPU-Sim PTX: Warning - missing function definition \'%s\'\n",
-           kname.c_str());
-    return;
-  }
-  if (func_info->is_extern()) {
-    printf(
-        "GPGPU-Sim PTX: skipping assembly for extern declared function "
-        "\'%s\'\n",
-        func_info->get_name().c_str());
-    return;
-  }
-  func_info->ptx_assemble();
+void gpgpu_ptx_assemble( std::string kname, void *kinfo )
+{
+    function_info *func_info = (function_info *)kinfo;
+    if((function_info *)kinfo == NULL) {
+       printf("GPGPU-Sim PTX: Warning - missing function definition \'%s\'\n", kname.c_str());
+       return;
+    }
+    if( func_info->is_extern() ) {
+       printf("GPGPU-Sim PTX: skipping assembly for extern declared function \'%s\'\n", func_info->get_name().c_str() );
+       return;
+    }
+    func_info->ptx_assemble();
 }

--- a/src/cuda-sim/ptx_ir.cc
+++ b/src/cuda-sim/ptx_ir.cc
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2011, Tor M. Aamodt, Ali Bakhoda, Wilson W.L. Fung,
-// George L. Yuan 
+// George L. Yuan
 // The University of British Columbia
 // All rights reserved.
 //
@@ -8,1170 +8,1263 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
-#include "ptx_parser.h"
 #include "ptx_ir.h"
-typedef void * yyscan_t;
-#include "ptx.tab.h"
-#include "opcodes.h"
+#include "ptx_parser.h"
+typedef void *yyscan_t;
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <list>
-#include <assert.h>
 #include <algorithm>
+#include <list>
 #include "assert.h"
+#include "opcodes.h"
+#include "ptx.tab.h"
 
-#include "cuda-sim.h"
 #include "../../libcuda/gpgpu_context.h"
+#include "cuda-sim.h"
 
 #define STR_SIZE 1024
 
-const ptx_instruction* gpgpu_context::pc_to_instruction(unsigned pc) 
-{
-    if( pc < s_g_pc_to_insn.size() )
-	return s_g_pc_to_insn[pc];
+const ptx_instruction *gpgpu_context::pc_to_instruction(unsigned pc) {
+  if (pc < s_g_pc_to_insn.size())
+    return s_g_pc_to_insn[pc];
+  else
+    return NULL;
+}
+
+unsigned symbol::get_uid() {
+  unsigned result = (gpgpu_ctx->symbol_sm_next_uid)++;
+  return result;
+}
+
+void symbol::add_initializer(const std::list<operand_info> &init) {
+  m_initializer = init;
+}
+
+void symbol::print_info(FILE *fp) const {
+  fprintf(fp, "uid:%u, decl:%s, type:%p, ", m_uid, m_decl_location.c_str(),
+          m_type);
+  if (m_address_valid) fprintf(fp, "<address valid>, ");
+  if (m_is_label) fprintf(fp, " is_label ");
+  if (m_is_shared) fprintf(fp, " is_shared ");
+  if (m_is_const) fprintf(fp, " is_const ");
+  if (m_is_global) fprintf(fp, " is_global ");
+  if (m_is_local) fprintf(fp, " is_local ");
+  if (m_is_tex) fprintf(fp, " is_tex ");
+  if (m_is_func_addr) fprintf(fp, " is_func_addr ");
+  if (m_function) fprintf(fp, " %p ", m_function);
+}
+
+symbol_table::symbol_table() { assert(0); }
+
+symbol_table::symbol_table(const char *scope_name, unsigned entry_point,
+                           symbol_table *parent, gpgpu_context *ctx) {
+  gpgpu_ctx = ctx;
+  m_scope_name = std::string(scope_name);
+  m_reg_allocator = 0;
+  m_shared_next = 0;
+  m_const_next = 0;
+  m_global_next = 0x100;
+  m_local_next = 0;
+  m_tex_next = 0;
+
+  // Jin: handle instruction group for cdp
+  m_inst_group_id = 0;
+
+  m_parent = parent;
+  if (m_parent) {
+    m_shared_next = m_parent->m_shared_next;
+    m_global_next = m_parent->m_global_next;
+  }
+}
+
+void symbol_table::set_name(const char *name) {
+  m_scope_name = std::string(name);
+}
+
+const ptx_version &symbol_table::get_ptx_version() const {
+  if (m_parent == NULL)
+    return m_ptx_version;
+  else
+    return m_parent->get_ptx_version();
+}
+
+unsigned symbol_table::get_sm_target() const {
+  if (m_parent == NULL)
+    return m_ptx_version.target();
+  else
+    return m_parent->get_sm_target();
+}
+
+void symbol_table::set_ptx_version(float ver, unsigned ext) {
+  m_ptx_version = ptx_version(ver, ext);
+}
+
+void symbol_table::set_sm_target(const char *target, const char *ext,
+                                 const char *ext2) {
+  m_ptx_version.set_target(target, ext, ext2);
+}
+
+symbol *symbol_table::lookup(const char *identifier) {
+  std::string key(identifier);
+  std::map<std::string, symbol *>::iterator i = m_symbols.find(key);
+  if (i != m_symbols.end()) {
+    return i->second;
+  }
+  if (m_parent) {
+    return m_parent->lookup(identifier);
+  }
+  return NULL;
+}
+
+symbol *symbol_table::add_variable(const char *identifier,
+                                   const type_info *type, unsigned size,
+                                   const char *filename, unsigned line) {
+  char buf[1024];
+  std::string key(identifier);
+  assert(m_symbols.find(key) == m_symbols.end());
+  snprintf(buf, 1024, "%s:%u", filename, line);
+  symbol *s = new symbol(identifier, type, buf, size, gpgpu_ctx);
+  m_symbols[key] = s;
+
+  if (type != NULL && type->get_key().is_global()) {
+    m_globals.push_back(s);
+  }
+  if (type != NULL && type->get_key().is_const()) {
+    m_consts.push_back(s);
+  }
+
+  return s;
+}
+
+void symbol_table::add_function(function_info *func, const char *filename,
+                                unsigned linenumber) {
+  std::map<std::string, symbol *>::iterator i =
+      m_symbols.find(func->get_name());
+  if (i != m_symbols.end()) return;
+  char buf[1024];
+  snprintf(buf, 1024, "%s:%u", filename, linenumber);
+  type_info *type = add_type(func);
+  symbol *s = new symbol(func->get_name().c_str(), type, buf, 0, gpgpu_ctx);
+  s->set_function(func);
+  m_symbols[func->get_name()] = s;
+}
+
+// Jin: handle instruction group for cdp
+symbol_table *symbol_table::start_inst_group() {
+  char inst_group_name[4096];
+  snprintf(inst_group_name, 4096, "%s_inst_group_%u", m_scope_name.c_str(),
+           m_inst_group_id);
+
+  // previous added
+  assert(m_inst_group_symtab.find(std::string(inst_group_name)) ==
+         m_inst_group_symtab.end());
+  symbol_table *sym_table =
+      new symbol_table(inst_group_name, 3 /*inst group*/, this, gpgpu_ctx);
+
+  sym_table->m_global_next = m_global_next;
+  sym_table->m_shared_next = m_shared_next;
+  sym_table->m_local_next = m_local_next;
+  sym_table->m_reg_allocator = m_reg_allocator;
+  sym_table->m_tex_next = m_tex_next;
+  sym_table->m_const_next = m_const_next;
+
+  m_inst_group_symtab[std::string(inst_group_name)] = sym_table;
+
+  return sym_table;
+}
+
+symbol_table *symbol_table::end_inst_group() {
+  symbol_table *sym_table = m_parent;
+
+  sym_table->m_global_next = m_global_next;
+  sym_table->m_shared_next = m_shared_next;
+  sym_table->m_local_next = m_local_next;
+  sym_table->m_reg_allocator = m_reg_allocator;
+  sym_table->m_tex_next = m_tex_next;
+  sym_table->m_const_next = m_const_next;
+  sym_table->m_inst_group_id++;
+
+  return sym_table;
+}
+
+void register_ptx_function(const char *name,
+                           function_info *impl);  // either libcuda or libopencl
+
+bool symbol_table::add_function_decl(const char *name, int entry_point,
+                                     function_info **func_info,
+                                     symbol_table **sym_table) {
+  std::string key = std::string(name);
+  bool prior_decl = false;
+  if (m_function_info_lookup.find(key) != m_function_info_lookup.end()) {
+    *func_info = m_function_info_lookup[key];
+    prior_decl = true;
+  } else {
+    *func_info = new function_info(entry_point, gpgpu_ctx);
+    (*func_info)->set_name(name);
+    (*func_info)->set_maxnt_id(0);
+    m_function_info_lookup[key] = *func_info;
+  }
+
+  if (m_function_symtab_lookup.find(key) != m_function_symtab_lookup.end()) {
+    assert(prior_decl);
+    *sym_table = m_function_symtab_lookup[key];
+  } else {
+    assert(!prior_decl);
+    *sym_table = new symbol_table("", entry_point, this, gpgpu_ctx);
+
+    // Initial setup code to support a register represented as "_".
+    // This register is used when an instruction operand is
+    // not read or written.  However, the parser must recognize it
+    // as a legitimate register but we do not want to pass
+    // it to the micro-architectural register to the performance simulator.
+    // For this purpose we add a symbol to the symbol table but
+    // mark it as a non_arch_reg so it does not effect the performance sim.
+    type_info_key null_key(reg_space, 0, 0, 0, 0, 0);
+    null_key.set_is_non_arch_reg();
+    // First param is null - which is bad.
+    // However, the first parameter is actually unread in the constructor...
+    // TODO - remove the symbol_table* from type_info
+    type_info *null_type_info = new type_info(NULL, null_key);
+    symbol *null_reg =
+        (*sym_table)->add_variable("_", null_type_info, 0, "", 0);
+    null_reg->set_regno(0, 0);
+
+    (*sym_table)->set_name(name);
+    (*func_info)->set_symtab(*sym_table);
+    m_function_symtab_lookup[key] = *sym_table;
+    assert((*func_info)->get_symtab() == *sym_table);
+    register_ptx_function(name, *func_info);
+  }
+  return prior_decl;
+}
+
+function_info *symbol_table::lookup_function(std::string name) {
+  std::string key = std::string(name);
+  std::map<std::string, function_info *>::iterator it =
+      m_function_info_lookup.find(key);
+  assert(it != m_function_info_lookup.end());
+  return it->second;
+}
+
+type_info *symbol_table::add_type(memory_space_t space_spec,
+                                  int scalar_type_spec, int vector_spec,
+                                  int alignment_spec, int extern_spec) {
+  if (space_spec == param_space_unclassified) space_spec = param_space_local;
+  type_info_key t(space_spec, scalar_type_spec, vector_spec, alignment_spec,
+                  extern_spec, 0);
+  type_info *pt;
+  pt = new type_info(this, t);
+  return pt;
+}
+
+type_info *symbol_table::add_type(function_info *func) {
+  type_info_key t;
+  type_info *pt;
+  t.set_is_func();
+  pt = new type_info(this, t);
+  return pt;
+}
+
+type_info *symbol_table::get_array_type(type_info *base_type,
+                                        unsigned array_dim) {
+  type_info_key t = base_type->get_key();
+  t.set_array_dim(array_dim);
+  type_info *pt = new type_info(this, t);
+  // Where else is m_types being used? As of now, I dont find any use of it and
+  // causing seg fault. So disabling m_types.
+  // TODO: find where m_types can be used in future and solve the seg fault.
+  // pt = m_types[t] = new type_info(this,t);
+  return pt;
+}
+
+void symbol_table::set_label_address(const symbol *label, unsigned addr) {
+  std::map<std::string, symbol *>::iterator i = m_symbols.find(label->name());
+  assert(i != m_symbols.end());
+  symbol *s = i->second;
+  s->set_label_address(addr);
+}
+
+void symbol_table::dump() {
+  printf("\n\n");
+  printf("Symbol table for \"%s\":\n", m_scope_name.c_str());
+  std::map<std::string, symbol *>::iterator i;
+  for (i = m_symbols.begin(); i != m_symbols.end(); i++) {
+    printf("%30s : ", i->first.c_str());
+    if (i->second)
+      i->second->print_info(stdout);
     else
-	return NULL;
+      printf(" <no symbol object> ");
+    printf("\n");
+  }
+  printf("\n");
 }
 
-unsigned symbol::get_uid()
-{
-   unsigned result = (gpgpu_ctx->symbol_sm_next_uid)++;
-   return result;
+unsigned operand_info::get_uid() {
+  unsigned result = (gpgpu_ctx->operand_info_sm_next_uid)++;
+  return result;
 }
 
-void symbol::add_initializer( const std::list<operand_info> &init )
-{
-   m_initializer = init;
+std::list<ptx_instruction *>::iterator
+function_info::find_next_real_instruction(
+    std::list<ptx_instruction *>::iterator i) {
+  while ((i != m_instructions.end()) && (*i)->is_label()) i++;
+  return i;
 }
 
-void symbol::print_info(FILE *fp) const
-{
-   fprintf(fp,"uid:%u, decl:%s, type:%p, ", m_uid, m_decl_location.c_str(), m_type );
-   if( m_address_valid ) 
-      fprintf(fp,"<address valid>, ");
-   if( m_is_label )
-      fprintf(fp," is_label ");
-   if( m_is_shared )
-      fprintf(fp," is_shared ");
-   if( m_is_const )
-      fprintf(fp," is_const ");
-   if( m_is_global )
-      fprintf(fp," is_global ");
-   if( m_is_local )
-      fprintf(fp," is_local ");
-   if( m_is_tex )
-      fprintf(fp," is_tex ");
-   if( m_is_func_addr )
-      fprintf(fp," is_func_addr ");
-   if( m_function ) 
-      fprintf(fp," %p ", m_function );
-}
+void function_info::create_basic_blocks() {
+  std::list<ptx_instruction *> leaders;
+  std::list<ptx_instruction *>::iterator i, l;
 
-symbol_table::symbol_table() 
-{ 
-   assert(0); 
-}
-
-symbol_table::symbol_table( const char *scope_name, unsigned entry_point, symbol_table *parent, gpgpu_context* ctx )
-{
-   gpgpu_ctx = ctx;
-   m_scope_name = std::string(scope_name);
-   m_reg_allocator=0;
-   m_shared_next = 0;
-   m_const_next  = 0;
-   m_global_next = 0x100;
-   m_local_next  = 0;
-   m_tex_next = 0;
-
-   //Jin: handle instruction group for cdp
-   m_inst_group_id = 0;
-
-   m_parent = parent;
-   if ( m_parent ) {
-      m_shared_next = m_parent->m_shared_next;
-      m_global_next = m_parent->m_global_next;
-   }
-}
-
-void symbol_table::set_name( const char *name )
-{
-   m_scope_name = std::string(name);
-}
-
-const ptx_version &symbol_table::get_ptx_version() const 
-{ 
-   if( m_parent == NULL ) return m_ptx_version;
-   else return m_parent->get_ptx_version(); 
-}
-
-unsigned symbol_table::get_sm_target() const 
-{ 
-   if( m_parent == NULL ) 
-      return m_ptx_version.target();
-   else return m_parent->get_sm_target(); 
-}
-
-void symbol_table::set_ptx_version( float ver, unsigned ext ) 
-{ 
-   m_ptx_version = ptx_version(ver,ext); 
-}
-
-void symbol_table::set_sm_target( const char *target, const char *ext, const char *ext2 )
-{
-   m_ptx_version.set_target(target,ext,ext2);
-}
-
-symbol *symbol_table::lookup( const char *identifier ) 
-{
-   std::string key(identifier);
-   std::map<std::string, symbol *>::iterator i = m_symbols.find(key);
-   if (  i != m_symbols.end() ) {
-      return i->second;
-   }
-   if ( m_parent ) {
-      return m_parent->lookup(identifier);
-   }
-   return NULL;
-}
-
-symbol *symbol_table::add_variable( const char *identifier, const type_info *type, unsigned size, const char *filename, unsigned line )
-{
-   char buf[1024];
-   std::string key(identifier);
-   assert( m_symbols.find(key) == m_symbols.end() );
-   snprintf(buf,1024,"%s:%u",filename,line);
-   symbol *s = new symbol(identifier,type,buf,size,gpgpu_ctx);
-   m_symbols[ key ] = s;
-
-   if ( type != NULL && type->get_key().is_global()  ) {
-      m_globals.push_back(s);
-   }
-   if ( type != NULL && type->get_key().is_const()  ) {
-      m_consts.push_back(s);
-   }
-
-   return s;
-}
-
-void symbol_table::add_function( function_info *func, const char *filename, unsigned linenumber )
-{
-   std::map<std::string, symbol *>::iterator i = m_symbols.find( func->get_name() );
-   if( i != m_symbols.end() )
-      return;
-   char buf[1024];
-   snprintf(buf,1024,"%s:%u",filename,linenumber);
-   type_info *type = add_type( func );
-   symbol *s = new symbol(func->get_name().c_str(),type,buf,0,gpgpu_ctx);
-   s->set_function(func);
-   m_symbols[ func->get_name() ] = s;
-}
-
-//Jin: handle instruction group for cdp
-symbol_table* symbol_table::start_inst_group() {
-   char inst_group_name[4096];
-   snprintf(inst_group_name, 4096, "%s_inst_group_%u", m_scope_name.c_str(), m_inst_group_id);
-
-   //previous added
-   assert(m_inst_group_symtab.find(std::string(inst_group_name)) == m_inst_group_symtab.end());
-   symbol_table *sym_table = new symbol_table(inst_group_name, 3/*inst group*/, this, gpgpu_ctx );
- 
-   sym_table->m_global_next = m_global_next;
-   sym_table->m_shared_next = m_shared_next;
-   sym_table->m_local_next = m_local_next;
-   sym_table->m_reg_allocator = m_reg_allocator;
-   sym_table->m_tex_next = m_tex_next;
-   sym_table->m_const_next = m_const_next;
-
-   m_inst_group_symtab[std::string(inst_group_name)] = sym_table;
-
-   return sym_table;
-}
-
-symbol_table * symbol_table::end_inst_group() {
-   symbol_table * sym_table = m_parent;
-   
-   sym_table->m_global_next = m_global_next;
-   sym_table->m_shared_next = m_shared_next;
-   sym_table->m_local_next = m_local_next;
-   sym_table->m_reg_allocator = m_reg_allocator;
-   sym_table->m_tex_next = m_tex_next;
-   sym_table->m_const_next = m_const_next;
-   sym_table->m_inst_group_id++;
-
-   return sym_table;
-}
-
-void register_ptx_function( const char *name, function_info *impl ); // either libcuda or libopencl
-
-bool symbol_table::add_function_decl( const char *name, int entry_point, function_info **func_info, symbol_table **sym_table )
-{
-   std::string key = std::string(name);
-   bool prior_decl = false;
-   if( m_function_info_lookup.find(key) != m_function_info_lookup.end() ) {
-      *func_info = m_function_info_lookup[key];
-      prior_decl = true;
-   } else {
-      *func_info = new function_info(entry_point, gpgpu_ctx);
-      (*func_info)->set_name(name);
-      (*func_info)->set_maxnt_id(0);
-      m_function_info_lookup[key] = *func_info;
-   }
-
-   if( m_function_symtab_lookup.find(key) != m_function_symtab_lookup.end() ) {
-      assert( prior_decl );
-      *sym_table = m_function_symtab_lookup[key];
-   } else {
-      assert( !prior_decl );
-      *sym_table = new symbol_table( "", entry_point, this, gpgpu_ctx );
-      
-      // Initial setup code to support a register represented as "_".
-      // This register is used when an instruction operand is
-      // not read or written.  However, the parser must recognize it
-      // as a legitimate register but we do not want to pass
-      // it to the micro-architectural register to the performance simulator.
-      // For this purpose we add a symbol to the symbol table but
-      // mark it as a non_arch_reg so it does not effect the performance sim.
-      type_info_key null_key( reg_space, 0, 0, 0, 0, 0 );
-      null_key.set_is_non_arch_reg();
-      // First param is null - which is bad.
-      // However, the first parameter is actually unread in the constructor...
-      // TODO - remove the symbol_table* from type_info
-      type_info* null_type_info = new type_info( NULL, null_key );
-      symbol *null_reg = (*sym_table)->add_variable( "_", null_type_info, 0, "", 0 ); 
-      null_reg->set_regno(0, 0);
-      
-      (*sym_table)->set_name(name);
-      (*func_info)->set_symtab(*sym_table);
-      m_function_symtab_lookup[key] = *sym_table;
-      assert( (*func_info)->get_symtab() == *sym_table );
-      register_ptx_function(name,*func_info);
-   }
-   return prior_decl;
-}
-
-function_info *symbol_table::lookup_function( std::string name )
-{
-   std::string key = std::string(name);
-   std::map<std::string,function_info*>::iterator it = m_function_info_lookup.find(key);
-   assert ( it != m_function_info_lookup.end() );
-   return it->second;
-}
-
-type_info *symbol_table::add_type( memory_space_t space_spec, int scalar_type_spec, int vector_spec, int alignment_spec, int extern_spec )
-{
-   if( space_spec == param_space_unclassified ) 
-      space_spec = param_space_local;
-   type_info_key t(space_spec,scalar_type_spec,vector_spec,alignment_spec,extern_spec,0);
-   type_info *pt;
-   pt = new type_info(this,t);
-   return pt;
-}
-
-type_info *symbol_table::add_type( function_info *func )
-{
-   type_info_key t;
-   type_info *pt;
-   t.set_is_func();
-   pt = new type_info(this,t);
-   return pt;
-}
-
-type_info *symbol_table::get_array_type( type_info *base_type, unsigned array_dim ) 
-{
-   type_info_key t = base_type->get_key();
-   t.set_array_dim(array_dim);
-   type_info *pt = new type_info(this,t);
-   //Where else is m_types being used? As of now, I dont find any use of it and causing seg fault. So disabling m_types.
-   //TODO: find where m_types can be used in future and solve the seg fault.
-   //pt = m_types[t] = new type_info(this,t);
-   return pt;
-}
-
-void symbol_table::set_label_address( const symbol *label, unsigned addr )
-{
-   std::map<std::string, symbol *>::iterator i=m_symbols.find(label->name());
-   assert( i != m_symbols.end() );
-   symbol *s = i->second;
-   s->set_label_address(addr);
-}
-
-void symbol_table::dump()
-{
-   printf("\n\n");
-   printf("Symbol table for \"%s\":\n", m_scope_name.c_str() );
-   std::map<std::string, symbol *>::iterator i;
-   for( i=m_symbols.begin(); i!=m_symbols.end(); i++ ) {
-      printf("%30s : ", i->first.c_str() );
-      if( i->second ) 
-         i->second->print_info(stdout);
-      else
-         printf(" <no symbol object> ");
-      printf("\n");
-   }
-   printf("\n");
-}
-
-unsigned operand_info::get_uid()
-{
-   unsigned result = (gpgpu_ctx->operand_info_sm_next_uid)++;
-   return result;
-}
-
-std::list<ptx_instruction*>::iterator function_info::find_next_real_instruction( std::list<ptx_instruction*>::iterator i)
-{
-   while( (i != m_instructions.end()) && (*i)->is_label() ) 
-      i++;
-   return i;
-}
-
-void function_info::create_basic_blocks()
-{
-   std::list<ptx_instruction*> leaders;
-   std::list<ptx_instruction*>::iterator i, l;
-
-   // first instruction is a leader
-   i=m_instructions.begin();
-   leaders.push_back(*i);
-   i++;
-   while( i!=m_instructions.end() ) {
-      ptx_instruction *pI = *i;
-      if( pI->is_label() ) {
-         leaders.push_back(pI);
-         i = find_next_real_instruction(++i);
-      } else {
-         switch( pI->get_opcode() ) {
-         case BRA_OP: case RET_OP: case EXIT_OP: case RETP_OP: case BREAK_OP: 
+  // first instruction is a leader
+  i = m_instructions.begin();
+  leaders.push_back(*i);
+  i++;
+  while (i != m_instructions.end()) {
+    ptx_instruction *pI = *i;
+    if (pI->is_label()) {
+      leaders.push_back(pI);
+      i = find_next_real_instruction(++i);
+    } else {
+      switch (pI->get_opcode()) {
+        case BRA_OP:
+        case RET_OP:
+        case EXIT_OP:
+        case RETP_OP:
+        case BREAK_OP:
+          i++;
+          if (i != m_instructions.end()) leaders.push_back(*i);
+          i = find_next_real_instruction(i);
+          break;
+        case CALL_OP:
+        case CALLP_OP:
+          if (pI->has_pred()) {
+            printf("GPGPU-Sim PTX: Warning found predicated call\n");
             i++;
-            if( i != m_instructions.end() ) 
-               leaders.push_back(*i);
+            if (i != m_instructions.end()) leaders.push_back(*i);
             i = find_next_real_instruction(i);
-            break;
-         case CALL_OP: case CALLP_OP:
-            if( pI->has_pred() ) {
-               printf("GPGPU-Sim PTX: Warning found predicated call\n");
-               i++;
-               if( i != m_instructions.end() ) 
-                  leaders.push_back(*i);
-               i = find_next_real_instruction(i);
-            } else i++;
-            break;
-         default:
+          } else
             i++;
-         }
-      } 
-   }
-
-   if( leaders.empty() ) {
-      printf("GPGPU-Sim PTX: Function \'%s\' has no basic blocks\n", m_name.c_str());
-      return;
-   }
-
-   unsigned bb_id = 0;
-   l=leaders.begin();
-   i=m_instructions.begin();
-   m_basic_blocks.push_back( new basic_block_t(bb_id++,*find_next_real_instruction(i),NULL,1,0) );
-   ptx_instruction *last_real_inst=*(l++);
-
-   for( ; i!=m_instructions.end(); i++ ) {
-      ptx_instruction *pI = *i;
-      if( l != leaders.end() && *i == *l ) {
-         // found start of next basic block
-         m_basic_blocks.back()->ptx_end = last_real_inst;
-         if( find_next_real_instruction(i) != m_instructions.end() ) { // if not bogus trailing label
-            m_basic_blocks.push_back( new basic_block_t(bb_id++,*find_next_real_instruction(i),NULL,0,0) );
-            last_real_inst = *find_next_real_instruction(i);
-         }
-         // start search for next leader
-         l++;
+          break;
+        default:
+          i++;
       }
-      pI->assign_bb( m_basic_blocks.back() );
-      if( !pI->is_label() ) last_real_inst = pI;
-   }
-   m_basic_blocks.back()->ptx_end = last_real_inst;
-   m_basic_blocks.push_back( /*exit basic block*/ new basic_block_t(bb_id,NULL,NULL,0,1) );
+    }
+  }
+
+  if (leaders.empty()) {
+    printf("GPGPU-Sim PTX: Function \'%s\' has no basic blocks\n",
+           m_name.c_str());
+    return;
+  }
+
+  unsigned bb_id = 0;
+  l = leaders.begin();
+  i = m_instructions.begin();
+  m_basic_blocks.push_back(
+      new basic_block_t(bb_id++, *find_next_real_instruction(i), NULL, 1, 0));
+  ptx_instruction *last_real_inst = *(l++);
+
+  for (; i != m_instructions.end(); i++) {
+    ptx_instruction *pI = *i;
+    if (l != leaders.end() && *i == *l) {
+      // found start of next basic block
+      m_basic_blocks.back()->ptx_end = last_real_inst;
+      if (find_next_real_instruction(i) !=
+          m_instructions.end()) {  // if not bogus trailing label
+        m_basic_blocks.push_back(new basic_block_t(
+            bb_id++, *find_next_real_instruction(i), NULL, 0, 0));
+        last_real_inst = *find_next_real_instruction(i);
+      }
+      // start search for next leader
+      l++;
+    }
+    pI->assign_bb(m_basic_blocks.back());
+    if (!pI->is_label()) last_real_inst = pI;
+  }
+  m_basic_blocks.back()->ptx_end = last_real_inst;
+  m_basic_blocks.push_back(
+      /*exit basic block*/ new basic_block_t(bb_id, NULL, NULL, 0, 1));
 }
 
-void function_info::print_basic_blocks()
-{
-   printf("Printing basic blocks for function \'%s\':\n", m_name.c_str() );
-   std::list<ptx_instruction*>::iterator ptx_itr;
-   unsigned last_bb=0;
-   for (ptx_itr = m_instructions.begin();ptx_itr != m_instructions.end(); ptx_itr++) {
-      if( (*ptx_itr)->get_bb() ) {
-         if( (*ptx_itr)->get_bb()->bb_id != last_bb ) {
-            printf("\n");
-            last_bb = (*ptx_itr)->get_bb()->bb_id;
-         }
-         printf("bb_%02u\t: ", (*ptx_itr)->get_bb()->bb_id);
-         (*ptx_itr)->print_insn();
-         printf("\n");
+void function_info::print_basic_blocks() {
+  printf("Printing basic blocks for function \'%s\':\n", m_name.c_str());
+  std::list<ptx_instruction *>::iterator ptx_itr;
+  unsigned last_bb = 0;
+  for (ptx_itr = m_instructions.begin(); ptx_itr != m_instructions.end();
+       ptx_itr++) {
+    if ((*ptx_itr)->get_bb()) {
+      if ((*ptx_itr)->get_bb()->bb_id != last_bb) {
+        printf("\n");
+        last_bb = (*ptx_itr)->get_bb()->bb_id;
       }
-   }
-   printf("\nSummary of basic blocks for \'%s\':\n", m_name.c_str() );
-   std::vector<basic_block_t*>::iterator bb_itr;
-   for (bb_itr = m_basic_blocks.begin();bb_itr != m_basic_blocks.end(); bb_itr++) {
-      printf("bb_%02u\t:", (*bb_itr)->bb_id);
-      if ((*bb_itr)->ptx_begin)
-         printf(" first: %s\t", ((*bb_itr)->ptx_begin)->get_opcode_cstr());
-      else printf(" first: NULL\t");
-      if ((*bb_itr)->ptx_end) {
-         printf(" last: %s\t", ((*bb_itr)->ptx_end)->get_opcode_cstr());
-      } else printf(" last: NULL\t");
+      printf("bb_%02u\t: ", (*ptx_itr)->get_bb()->bb_id);
+      (*ptx_itr)->print_insn();
       printf("\n");
-   }
-   printf("\n");
+    }
+  }
+  printf("\nSummary of basic blocks for \'%s\':\n", m_name.c_str());
+  std::vector<basic_block_t *>::iterator bb_itr;
+  for (bb_itr = m_basic_blocks.begin(); bb_itr != m_basic_blocks.end();
+       bb_itr++) {
+    printf("bb_%02u\t:", (*bb_itr)->bb_id);
+    if ((*bb_itr)->ptx_begin)
+      printf(" first: %s\t", ((*bb_itr)->ptx_begin)->get_opcode_cstr());
+    else
+      printf(" first: NULL\t");
+    if ((*bb_itr)->ptx_end) {
+      printf(" last: %s\t", ((*bb_itr)->ptx_end)->get_opcode_cstr());
+    } else
+      printf(" last: NULL\t");
+    printf("\n");
+  }
+  printf("\n");
 }
 
-void function_info::print_basic_block_links()
-{
-   printf("Printing basic blocks links for function \'%s\':\n", m_name.c_str() );
-   std::vector<basic_block_t*>::iterator bb_itr;
-   for (bb_itr = m_basic_blocks.begin();bb_itr != m_basic_blocks.end(); bb_itr++) {
-      printf("ID: %d\t:", (*bb_itr)->bb_id);
-      if ( !(*bb_itr)->predecessor_ids.empty() ) {
-         printf("Predecessors:");
-         std::set<int>::iterator p;
-         for (p= (*bb_itr)->predecessor_ids.begin();p != (*bb_itr)->predecessor_ids.end();p++) {
-            printf(" %d", *p);
-         }
-         printf("\t");
+void function_info::print_basic_block_links() {
+  printf("Printing basic blocks links for function \'%s\':\n", m_name.c_str());
+  std::vector<basic_block_t *>::iterator bb_itr;
+  for (bb_itr = m_basic_blocks.begin(); bb_itr != m_basic_blocks.end();
+       bb_itr++) {
+    printf("ID: %d\t:", (*bb_itr)->bb_id);
+    if (!(*bb_itr)->predecessor_ids.empty()) {
+      printf("Predecessors:");
+      std::set<int>::iterator p;
+      for (p = (*bb_itr)->predecessor_ids.begin();
+           p != (*bb_itr)->predecessor_ids.end(); p++) {
+        printf(" %d", *p);
       }
-      if ( !(*bb_itr)->successor_ids.empty() ) {
-         printf("Successors:");
-         std::set<int>::iterator s;
-         for (s= (*bb_itr)->successor_ids.begin();s != (*bb_itr)->successor_ids.end();s++) {
-            printf(" %d", *s);
-         }
+      printf("\t");
+    }
+    if (!(*bb_itr)->successor_ids.empty()) {
+      printf("Successors:");
+      std::set<int>::iterator s;
+      for (s = (*bb_itr)->successor_ids.begin();
+           s != (*bb_itr)->successor_ids.end(); s++) {
+        printf(" %d", *s);
       }
-      printf("\n");
-   }
+    }
+    printf("\n");
+  }
 }
-operand_info* function_info::find_break_target( ptx_instruction * p_break_insn ) //find the target of a break instruction 
+operand_info *function_info::find_break_target(
+    ptx_instruction *p_break_insn)  // find the target of a break instruction
 {
-   const basic_block_t *break_bb = p_break_insn->get_bb(); 
-   // go through the dominator tree 
-   for(const basic_block_t *p_bb = break_bb; 
-       p_bb->immediatedominator_id != -1; 
-       p_bb = m_basic_blocks[p_bb->immediatedominator_id]) 
-   {
-      // reverse search through instructions in basic block for breakaddr instruction 
-      unsigned insn_addr = p_bb->ptx_end->get_m_instr_mem_index(); 
-      while (insn_addr >= p_bb->ptx_begin->get_m_instr_mem_index()) { 
-         ptx_instruction *pI = m_instr_mem[insn_addr]; 
-         insn_addr -= 1; 
-         if (pI == NULL) continue; // temporary solution for variable size instructions 
-         if (pI->get_opcode() == BREAKADDR_OP) {
-            return &(pI->dst()); 
-         }
-      }
-   }
-
-   assert(0); 
-
-   // lazy fallback: just traverse backwards? 
-   for (int insn_addr = p_break_insn->get_m_instr_mem_index(); 
-        insn_addr >= 0; insn_addr--) 
-   { 
-      ptx_instruction *pI = m_instr_mem[insn_addr]; 
+  const basic_block_t *break_bb = p_break_insn->get_bb();
+  // go through the dominator tree
+  for (const basic_block_t *p_bb = break_bb; p_bb->immediatedominator_id != -1;
+       p_bb = m_basic_blocks[p_bb->immediatedominator_id]) {
+    // reverse search through instructions in basic block for breakaddr
+    // instruction
+    unsigned insn_addr = p_bb->ptx_end->get_m_instr_mem_index();
+    while (insn_addr >= p_bb->ptx_begin->get_m_instr_mem_index()) {
+      ptx_instruction *pI = m_instr_mem[insn_addr];
+      insn_addr -= 1;
+      if (pI == NULL)
+        continue;  // temporary solution for variable size instructions
       if (pI->get_opcode() == BREAKADDR_OP) {
-         return &(pI->dst()); 
+        return &(pI->dst());
       }
-   }
+    }
+  }
 
-   return NULL; 
+  assert(0);
+
+  // lazy fallback: just traverse backwards?
+  for (int insn_addr = p_break_insn->get_m_instr_mem_index(); insn_addr >= 0;
+       insn_addr--) {
+    ptx_instruction *pI = m_instr_mem[insn_addr];
+    if (pI->get_opcode() == BREAKADDR_OP) {
+      return &(pI->dst());
+    }
+  }
+
+  return NULL;
 }
-void function_info::connect_basic_blocks( ) //iterate across m_basic_blocks of function, connecting basic blocks together
+void function_info::connect_basic_blocks()  // iterate across m_basic_blocks of
+                                            // function, connecting basic blocks
+                                            // together
 {
-   std::vector<basic_block_t*>::iterator bb_itr;
-   std::vector<basic_block_t*>::iterator bb_target_itr;
-   basic_block_t* exit_bb = m_basic_blocks.back();
+  std::vector<basic_block_t *>::iterator bb_itr;
+  std::vector<basic_block_t *>::iterator bb_target_itr;
+  basic_block_t *exit_bb = m_basic_blocks.back();
 
-   //start from first basic block, which we know is the entry point
-   bb_itr = m_basic_blocks.begin(); 
-   for (bb_itr = m_basic_blocks.begin();bb_itr != m_basic_blocks.end(); bb_itr++) {
-      ptx_instruction *pI = (*bb_itr)->ptx_end;
-      if ((*bb_itr)->is_exit) //reached last basic block, no successors to link 
-         continue;
-      if (pI->get_opcode() == RETP_OP || pI->get_opcode() == RET_OP || pI->get_opcode() == EXIT_OP ) {
-         (*bb_itr)->successor_ids.insert(exit_bb->bb_id);
-         exit_bb->predecessor_ids.insert((*bb_itr)->bb_id);
-         if( pI->has_pred() ) {
-            printf("GPGPU-Sim PTX: Warning detected predicated return/exit.\n");
-            // if predicated, add link to next block
-            unsigned next_addr = pI->get_m_instr_mem_index() + pI->inst_size();
-            if( next_addr < m_instr_mem_size && m_instr_mem[next_addr] ) {
-               basic_block_t *next_bb = m_instr_mem[next_addr]->get_bb();
-               (*bb_itr)->successor_ids.insert(next_bb->bb_id);
-               next_bb->predecessor_ids.insert((*bb_itr)->bb_id);
-            }
-         }
-         continue;
-      } else if (pI->get_opcode() == BRA_OP) {
-         //find successor and link that basic_block to this one
-         operand_info &target = pI->dst(); //get operand, e.g. target name
-         unsigned addr = labels[ target.name() ];
-         ptx_instruction *target_pI = m_instr_mem[addr];
-         basic_block_t *target_bb = target_pI->get_bb();
-         (*bb_itr)->successor_ids.insert(target_bb->bb_id);
-         target_bb->predecessor_ids.insert((*bb_itr)->bb_id);
-      } 
-
-      if ( !(pI->get_opcode()==BRA_OP && (!pI->has_pred())) ) { 
-         // if basic block does not end in an unpredicated branch, 
-         // then next basic block is also successor
-         // (this is better than testing for .uni)
-         unsigned next_addr = pI->get_m_instr_mem_index() + pI->inst_size();
-         basic_block_t *next_bb = m_instr_mem[next_addr]->get_bb();
-         (*bb_itr)->successor_ids.insert(next_bb->bb_id);
-         next_bb->predecessor_ids.insert((*bb_itr)->bb_id);
-      } else
-         assert(pI->get_opcode() == BRA_OP);
-   }
-}
-bool function_info::connect_break_targets() //connecting break instructions with proper targets
-{
-   std::vector<basic_block_t*>::iterator bb_itr;
-   std::vector<basic_block_t*>::iterator bb_target_itr;
-   bool modified = false; 
-
-   //start from first basic block, which we know is the entry point
-   bb_itr = m_basic_blocks.begin(); 
-   for (bb_itr = m_basic_blocks.begin();bb_itr != m_basic_blocks.end(); bb_itr++) {
-      basic_block_t *p_bb = *bb_itr; 
-      ptx_instruction *pI = p_bb->ptx_end;
-      if (p_bb->is_exit) //reached last basic block, no successors to link 
-         continue;
-      if (pI->get_opcode() == BREAK_OP) {
-         // backup existing successor_ids for stability check
-         std::set<int> orig_successor_ids = p_bb->successor_ids; 
-
-         // erase the previous linkage with old successors 
-         for(std::set<int>::iterator succ_ids = p_bb->successor_ids.begin(); succ_ids != p_bb->successor_ids.end(); ++succ_ids) {
-            basic_block_t *successor_bb = m_basic_blocks[*succ_ids];
-            successor_bb->predecessor_ids.erase(p_bb->bb_id); 
-         }
-         p_bb->successor_ids.clear(); 
-
-         //find successor and link that basic_block to this one
-         //successor of a break is set by an preceeding breakaddr instruction 
-         operand_info *target = find_break_target(pI); 
-         unsigned addr = labels[ target->name() ];
-         ptx_instruction *target_pI = m_instr_mem[addr];
-         basic_block_t *target_bb = target_pI->get_bb();
-         p_bb->successor_ids.insert(target_bb->bb_id);
-         target_bb->predecessor_ids.insert(p_bb->bb_id);
-
-         if (pI->has_pred()) {
-            // predicated break - add link to next basic block
-            unsigned next_addr = pI->get_m_instr_mem_index() + pI->inst_size();
-            basic_block_t *next_bb = m_instr_mem[next_addr]->get_bb();
-            p_bb->successor_ids.insert(next_bb->bb_id);
-            next_bb->predecessor_ids.insert(p_bb->bb_id);
-         }
-
-         modified = modified || (orig_successor_ids != p_bb->successor_ids); 
+  // start from first basic block, which we know is the entry point
+  bb_itr = m_basic_blocks.begin();
+  for (bb_itr = m_basic_blocks.begin(); bb_itr != m_basic_blocks.end();
+       bb_itr++) {
+    ptx_instruction *pI = (*bb_itr)->ptx_end;
+    if ((*bb_itr)->is_exit)  // reached last basic block, no successors to link
+      continue;
+    if (pI->get_opcode() == RETP_OP || pI->get_opcode() == RET_OP ||
+        pI->get_opcode() == EXIT_OP) {
+      (*bb_itr)->successor_ids.insert(exit_bb->bb_id);
+      exit_bb->predecessor_ids.insert((*bb_itr)->bb_id);
+      if (pI->has_pred()) {
+        printf("GPGPU-Sim PTX: Warning detected predicated return/exit.\n");
+        // if predicated, add link to next block
+        unsigned next_addr = pI->get_m_instr_mem_index() + pI->inst_size();
+        if (next_addr < m_instr_mem_size && m_instr_mem[next_addr]) {
+          basic_block_t *next_bb = m_instr_mem[next_addr]->get_bb();
+          (*bb_itr)->successor_ids.insert(next_bb->bb_id);
+          next_bb->predecessor_ids.insert((*bb_itr)->bb_id);
+        }
       }
-   }
+      continue;
+    } else if (pI->get_opcode() == BRA_OP) {
+      // find successor and link that basic_block to this one
+      operand_info &target = pI->dst();  // get operand, e.g. target name
+      unsigned addr = labels[target.name()];
+      ptx_instruction *target_pI = m_instr_mem[addr];
+      basic_block_t *target_bb = target_pI->get_bb();
+      (*bb_itr)->successor_ids.insert(target_bb->bb_id);
+      target_bb->predecessor_ids.insert((*bb_itr)->bb_id);
+    }
 
-   return modified; 
+    if (!(pI->get_opcode() == BRA_OP && (!pI->has_pred()))) {
+      // if basic block does not end in an unpredicated branch,
+      // then next basic block is also successor
+      // (this is better than testing for .uni)
+      unsigned next_addr = pI->get_m_instr_mem_index() + pI->inst_size();
+      basic_block_t *next_bb = m_instr_mem[next_addr]->get_bb();
+      (*bb_itr)->successor_ids.insert(next_bb->bb_id);
+      next_bb->predecessor_ids.insert((*bb_itr)->bb_id);
+    } else
+      assert(pI->get_opcode() == BRA_OP);
+  }
 }
-void function_info::do_pdom() 
+bool function_info::connect_break_targets()  // connecting break instructions
+                                             // with proper targets
 {
-   create_basic_blocks();
-   connect_basic_blocks();
-   bool modified = false; 
-   do {
-      find_dominators();
-      find_idominators();
-      modified = connect_break_targets(); 
-   } while (modified == true);
+  std::vector<basic_block_t *>::iterator bb_itr;
+  std::vector<basic_block_t *>::iterator bb_target_itr;
+  bool modified = false;
 
-   if ( g_debug_execution>=50 ) {
-      print_basic_blocks();
-      print_basic_block_links();
-      print_basic_block_dot();
-   }
-   if ( g_debug_execution>=2 ) {
-      print_dominators();
-   }
-   find_postdominators();
-   find_ipostdominators();
-   if ( g_debug_execution>=50 ) {
-      print_postdominators();
-      print_ipostdominators();
-   }
-   printf("GPGPU-Sim PTX: pre-decoding instructions for \'%s\'...\n", m_name.c_str() );
-   for ( unsigned ii=0; ii < m_n; ii += m_instr_mem[ii]->inst_size() ) { // handle branch instructions
-      ptx_instruction *pI = m_instr_mem[ii];
-      pI->pre_decode();
-   }
-   printf("GPGPU-Sim PTX: ... done pre-decoding instructions for \'%s\'.\n", m_name.c_str() );
-   fflush(stdout);
-   m_assembled = true;
-}
-void intersect( std::set<int> &A, const std::set<int> &B )
-{
-   // return intersection of A and B in A
-   for( std::set<int>::iterator a=A.begin(); a!=A.end(); ) {    
-      std::set<int>::iterator a_next = a;
-      a_next++;
-      if( B.find(*a) == B.end() ) {
-         A.erase(*a);
-         a = a_next;
-      } else 
-         a++;
-   }
-}
+  // start from first basic block, which we know is the entry point
+  bb_itr = m_basic_blocks.begin();
+  for (bb_itr = m_basic_blocks.begin(); bb_itr != m_basic_blocks.end();
+       bb_itr++) {
+    basic_block_t *p_bb = *bb_itr;
+    ptx_instruction *pI = p_bb->ptx_end;
+    if (p_bb->is_exit)  // reached last basic block, no successors to link
+      continue;
+    if (pI->get_opcode() == BREAK_OP) {
+      // backup existing successor_ids for stability check
+      std::set<int> orig_successor_ids = p_bb->successor_ids;
 
-bool is_equal( const std::set<int> &A, const std::set<int> &B )
-{
-   if( A.size() != B.size() ) 
-      return false;
-   for( std::set<int>::iterator b=B.begin(); b!=B.end(); b++ ) 
-      if( A.find(*b) == A.end() ) 
-         return false;
-   return true;
-}
-
-void print_set(const std::set<int> &A)
-{
-   std::set<int>::iterator a;
-   for (a= A.begin(); a != A.end(); a++) {
-      printf("%d ", (*a));
-   }
-   printf("\n");
-}
-
-void function_info::find_dominators( )
-{  
-   // find dominators using algorithm of Muchnick's Adv. Compiler Design & Implemmntation Fig 7.14 
-   printf("GPGPU-Sim PTX: Finding dominators for \'%s\'...\n", m_name.c_str() );
-   fflush(stdout);
-   assert( m_basic_blocks.size() >= 2 ); // must have a distinquished entry block
-   std::vector<basic_block_t*>::iterator bb_itr = m_basic_blocks.begin();
-   (*bb_itr)->dominator_ids.insert((*bb_itr)->bb_id);  // the only dominator of the entry block is the entry
-   //copy all basic blocks to all dominator lists EXCEPT for the entry block
-   for (++bb_itr;bb_itr != m_basic_blocks.end(); bb_itr++) { 
-      for (unsigned i = 0; i < m_basic_blocks.size(); i++) 
-         (*bb_itr)->dominator_ids.insert(i);
-   }
-   bool change = true;
-   while (change) {
-      change = false;
-      for ( int h = 1/*skip entry*/; h < m_basic_blocks.size(); ++h ) {
-         assert( m_basic_blocks[h]->bb_id == (unsigned)h );
-         std::set<int> T;
-         for (unsigned i=0;i< m_basic_blocks.size();i++) 
-            T.insert(i);
-         for ( std::set<int>::iterator s = m_basic_blocks[h]->predecessor_ids.begin();s != m_basic_blocks[h]->predecessor_ids.end();s++) 
-            intersect(T, m_basic_blocks[*s]->dominator_ids);
-         T.insert(h);
-         if (!is_equal(T, m_basic_blocks[h]->dominator_ids)) {
-            change = true;
-            m_basic_blocks[h]->dominator_ids = T;
-         }
+      // erase the previous linkage with old successors
+      for (std::set<int>::iterator succ_ids = p_bb->successor_ids.begin();
+           succ_ids != p_bb->successor_ids.end(); ++succ_ids) {
+        basic_block_t *successor_bb = m_basic_blocks[*succ_ids];
+        successor_bb->predecessor_ids.erase(p_bb->bb_id);
       }
-   }
-   //clean the basic block of dominators of it has no predecessors -- except for entry block
-   bb_itr = m_basic_blocks.begin();
-   for (++bb_itr;bb_itr != m_basic_blocks.end(); bb_itr++) {
-	  if ((*bb_itr)->predecessor_ids.empty())
-         (*bb_itr)->dominator_ids.clear();
-   }
-}
+      p_bb->successor_ids.clear();
 
-void function_info::find_postdominators( )
-{  
-   // find postdominators using algorithm of Muchnick's Adv. Compiler Design & Implemmntation Fig 7.14 
-   printf("GPGPU-Sim PTX: Finding postdominators for \'%s\'...\n", m_name.c_str() );
-   fflush(stdout);
-   assert( m_basic_blocks.size() >= 2 ); // must have a distinquished exit block
-   std::vector<basic_block_t*>::reverse_iterator bb_itr = m_basic_blocks.rbegin();
-   (*bb_itr)->postdominator_ids.insert((*bb_itr)->bb_id);  // the only postdominator of the exit block is the exit
-   for (++bb_itr;bb_itr != m_basic_blocks.rend();bb_itr++) { //copy all basic blocks to all postdominator lists EXCEPT for the exit block
-      for (unsigned i=0; i<m_basic_blocks.size(); i++) 
-         (*bb_itr)->postdominator_ids.insert(i);
-   }
-   bool change = true;
-   while (change) {
-      change = false;
-      for ( int h = m_basic_blocks.size()-2/*skip exit*/; h >= 0 ; --h ) {
-         assert( m_basic_blocks[h]->bb_id == (unsigned)h );
-         std::set<int> T;
-         for (unsigned i=0;i< m_basic_blocks.size();i++) 
-            T.insert(i);
-         for ( std::set<int>::iterator s = m_basic_blocks[h]->successor_ids.begin();s != m_basic_blocks[h]->successor_ids.end();s++) 
-            intersect(T, m_basic_blocks[*s]->postdominator_ids);
-         T.insert(h);
-         if (!is_equal(T,m_basic_blocks[h]->postdominator_ids)) {
-            change = true;
-            m_basic_blocks[h]->postdominator_ids = T;
-         }
+      // find successor and link that basic_block to this one
+      // successor of a break is set by an preceeding breakaddr instruction
+      operand_info *target = find_break_target(pI);
+      unsigned addr = labels[target->name()];
+      ptx_instruction *target_pI = m_instr_mem[addr];
+      basic_block_t *target_bb = target_pI->get_bb();
+      p_bb->successor_ids.insert(target_bb->bb_id);
+      target_bb->predecessor_ids.insert(p_bb->bb_id);
+
+      if (pI->has_pred()) {
+        // predicated break - add link to next basic block
+        unsigned next_addr = pI->get_m_instr_mem_index() + pI->inst_size();
+        basic_block_t *next_bb = m_instr_mem[next_addr]->get_bb();
+        p_bb->successor_ids.insert(next_bb->bb_id);
+        next_bb->predecessor_ids.insert(p_bb->bb_id);
       }
-   }
+
+      modified = modified || (orig_successor_ids != p_bb->successor_ids);
+    }
+  }
+
+  return modified;
+}
+void function_info::do_pdom() {
+  create_basic_blocks();
+  connect_basic_blocks();
+  bool modified = false;
+  do {
+    find_dominators();
+    find_idominators();
+    modified = connect_break_targets();
+  } while (modified == true);
+
+  if (g_debug_execution >= 50) {
+    print_basic_blocks();
+    print_basic_block_links();
+    print_basic_block_dot();
+  }
+  if (g_debug_execution >= 2) {
+    print_dominators();
+  }
+  find_postdominators();
+  find_ipostdominators();
+  if (g_debug_execution >= 50) {
+    print_postdominators();
+    print_ipostdominators();
+  }
+  printf("GPGPU-Sim PTX: pre-decoding instructions for \'%s\'...\n",
+         m_name.c_str());
+  for (unsigned ii = 0; ii < m_n;
+       ii += m_instr_mem[ii]->inst_size()) {  // handle branch instructions
+    ptx_instruction *pI = m_instr_mem[ii];
+    pI->pre_decode();
+  }
+  printf("GPGPU-Sim PTX: ... done pre-decoding instructions for \'%s\'.\n",
+         m_name.c_str());
+  fflush(stdout);
+  m_assembled = true;
+}
+void intersect(std::set<int> &A, const std::set<int> &B) {
+  // return intersection of A and B in A
+  for (std::set<int>::iterator a = A.begin(); a != A.end();) {
+    std::set<int>::iterator a_next = a;
+    a_next++;
+    if (B.find(*a) == B.end()) {
+      A.erase(*a);
+      a = a_next;
+    } else
+      a++;
+  }
 }
 
-void function_info::find_ipostdominators( )
-{  
-   // find immediate postdominator blocks, using algorithm of
-   // Muchnick's Adv. Compiler Design & Implemmntation Fig 7.15 
-   printf("GPGPU-Sim PTX: Finding immediate postdominators for \'%s\'...\n", m_name.c_str() );
-   fflush(stdout);
-   assert( m_basic_blocks.size() >= 2 ); // must have a distinquished exit block
-   for (unsigned i=0; i<m_basic_blocks.size(); i++) { //initialize Tmp(n) to all pdoms of n except for n
-      m_basic_blocks[i]->Tmp_ids = m_basic_blocks[i]->postdominator_ids;
-      assert( m_basic_blocks[i]->bb_id == i );
-      m_basic_blocks[i]->Tmp_ids.erase(i);
-   }
-   for ( int n = m_basic_blocks.size()-2; n >=0;--n) {
-      // point iterator to basic block before the exit
-      for( std::set<int>::iterator s=m_basic_blocks[n]->Tmp_ids.begin(); s != m_basic_blocks[n]->Tmp_ids.end(); s++ ) {
-         int bb_s = *s;
-         for( std::set<int>::iterator t=m_basic_blocks[n]->Tmp_ids.begin(); t != m_basic_blocks[n]->Tmp_ids.end(); ) {
-            std::set<int>::iterator t_next = t; t_next++; // might erase thing pointed to be t, invalidating iterator t
-            if( *s == *t ) {
-               t = t_next;
-               continue;
-            }
-            int bb_t = *t;
-            if( m_basic_blocks[bb_s]->postdominator_ids.find(bb_t) != m_basic_blocks[bb_s]->postdominator_ids.end() ) 
-                m_basic_blocks[n]->Tmp_ids.erase(bb_t);
-            t = t_next;
-         }
+bool is_equal(const std::set<int> &A, const std::set<int> &B) {
+  if (A.size() != B.size()) return false;
+  for (std::set<int>::iterator b = B.begin(); b != B.end(); b++)
+    if (A.find(*b) == A.end()) return false;
+  return true;
+}
+
+void print_set(const std::set<int> &A) {
+  std::set<int>::iterator a;
+  for (a = A.begin(); a != A.end(); a++) {
+    printf("%d ", (*a));
+  }
+  printf("\n");
+}
+
+void function_info::find_dominators() {
+  // find dominators using algorithm of Muchnick's Adv. Compiler Design &
+  // Implemmntation Fig 7.14
+  printf("GPGPU-Sim PTX: Finding dominators for \'%s\'...\n", m_name.c_str());
+  fflush(stdout);
+  assert(m_basic_blocks.size() >= 2);  // must have a distinquished entry block
+  std::vector<basic_block_t *>::iterator bb_itr = m_basic_blocks.begin();
+  (*bb_itr)->dominator_ids.insert(
+      (*bb_itr)->bb_id);  // the only dominator of the entry block is the entry
+  // copy all basic blocks to all dominator lists EXCEPT for the entry block
+  for (++bb_itr; bb_itr != m_basic_blocks.end(); bb_itr++) {
+    for (unsigned i = 0; i < m_basic_blocks.size(); i++)
+      (*bb_itr)->dominator_ids.insert(i);
+  }
+  bool change = true;
+  while (change) {
+    change = false;
+    for (int h = 1 /*skip entry*/; h < m_basic_blocks.size(); ++h) {
+      assert(m_basic_blocks[h]->bb_id == (unsigned)h);
+      std::set<int> T;
+      for (unsigned i = 0; i < m_basic_blocks.size(); i++) T.insert(i);
+      for (std::set<int>::iterator s =
+               m_basic_blocks[h]->predecessor_ids.begin();
+           s != m_basic_blocks[h]->predecessor_ids.end(); s++)
+        intersect(T, m_basic_blocks[*s]->dominator_ids);
+      T.insert(h);
+      if (!is_equal(T, m_basic_blocks[h]->dominator_ids)) {
+        change = true;
+        m_basic_blocks[h]->dominator_ids = T;
       }
-   }
-   unsigned num_ipdoms=0;
-   for ( int n = m_basic_blocks.size()-1; n >=0;--n) {
-      assert( m_basic_blocks[n]->Tmp_ids.size() <= 1 ); 
-         // if the above assert fails we have an error in either postdominator 
-         // computation, the flow graph does not have a unique exit, or some other error
-      if( !m_basic_blocks[n]->Tmp_ids.empty() ) {
-         m_basic_blocks[n]->immediatepostdominator_id = *m_basic_blocks[n]->Tmp_ids.begin();
-         num_ipdoms++;
+    }
+  }
+  // clean the basic block of dominators of it has no predecessors -- except for
+  // entry block
+  bb_itr = m_basic_blocks.begin();
+  for (++bb_itr; bb_itr != m_basic_blocks.end(); bb_itr++) {
+    if ((*bb_itr)->predecessor_ids.empty()) (*bb_itr)->dominator_ids.clear();
+  }
+}
+
+void function_info::find_postdominators() {
+  // find postdominators using algorithm of Muchnick's Adv. Compiler Design &
+  // Implemmntation Fig 7.14
+  printf("GPGPU-Sim PTX: Finding postdominators for \'%s\'...\n",
+         m_name.c_str());
+  fflush(stdout);
+  assert(m_basic_blocks.size() >= 2);  // must have a distinquished exit block
+  std::vector<basic_block_t *>::reverse_iterator bb_itr =
+      m_basic_blocks.rbegin();
+  (*bb_itr)->postdominator_ids.insert(
+      (*bb_itr)
+          ->bb_id);  // the only postdominator of the exit block is the exit
+  for (++bb_itr; bb_itr != m_basic_blocks.rend();
+       bb_itr++) {  // copy all basic blocks to all postdominator lists EXCEPT
+                    // for the exit block
+    for (unsigned i = 0; i < m_basic_blocks.size(); i++)
+      (*bb_itr)->postdominator_ids.insert(i);
+  }
+  bool change = true;
+  while (change) {
+    change = false;
+    for (int h = m_basic_blocks.size() - 2 /*skip exit*/; h >= 0; --h) {
+      assert(m_basic_blocks[h]->bb_id == (unsigned)h);
+      std::set<int> T;
+      for (unsigned i = 0; i < m_basic_blocks.size(); i++) T.insert(i);
+      for (std::set<int>::iterator s = m_basic_blocks[h]->successor_ids.begin();
+           s != m_basic_blocks[h]->successor_ids.end(); s++)
+        intersect(T, m_basic_blocks[*s]->postdominator_ids);
+      T.insert(h);
+      if (!is_equal(T, m_basic_blocks[h]->postdominator_ids)) {
+        change = true;
+        m_basic_blocks[h]->postdominator_ids = T;
       }
-   }
-   assert( num_ipdoms == m_basic_blocks.size()-1 ); 
-      // the exit node does not have an immediate post dominator, but everyone else should
+    }
+  }
 }
 
-void function_info::find_idominators( )
-{  
-   // find immediate dominator blocks, using algorithm of
-   // Muchnick's Adv. Compiler Design & Implemmntation Fig 7.15 
-   printf("GPGPU-Sim PTX: Finding immediate dominators for \'%s\'...\n", m_name.c_str() );
-   fflush(stdout);
-   assert( m_basic_blocks.size() >= 2 ); // must have a distinquished entry block
-   for (unsigned i=0; i<m_basic_blocks.size(); i++) { //initialize Tmp(n) to all doms of n except for n
-      m_basic_blocks[i]->Tmp_ids = m_basic_blocks[i]->dominator_ids;
-      assert( m_basic_blocks[i]->bb_id == i );
-      m_basic_blocks[i]->Tmp_ids.erase(i);
-   }
-   for ( int n = 0; n < m_basic_blocks.size(); ++n) {
-      // point iterator to basic block before the exit
-      for( std::set<int>::iterator s=m_basic_blocks[n]->Tmp_ids.begin(); s != m_basic_blocks[n]->Tmp_ids.end(); s++ ) {
-         int bb_s = *s;
-         for( std::set<int>::iterator t=m_basic_blocks[n]->Tmp_ids.begin(); t != m_basic_blocks[n]->Tmp_ids.end(); ) {
-            std::set<int>::iterator t_next = t; t_next++; // might erase thing pointed to be t, invalidating iterator t
-            if( *s == *t ) {
-               t = t_next;
-               continue;
-            }
-            int bb_t = *t;
-            if( m_basic_blocks[bb_s]->dominator_ids.find(bb_t) != m_basic_blocks[bb_s]->dominator_ids.end() ) 
-                m_basic_blocks[n]->Tmp_ids.erase(bb_t);
-            t = t_next;
-         }
+void function_info::find_ipostdominators() {
+  // find immediate postdominator blocks, using algorithm of
+  // Muchnick's Adv. Compiler Design & Implemmntation Fig 7.15
+  printf("GPGPU-Sim PTX: Finding immediate postdominators for \'%s\'...\n",
+         m_name.c_str());
+  fflush(stdout);
+  assert(m_basic_blocks.size() >= 2);  // must have a distinquished exit block
+  for (unsigned i = 0; i < m_basic_blocks.size();
+       i++) {  // initialize Tmp(n) to all pdoms of n except for n
+    m_basic_blocks[i]->Tmp_ids = m_basic_blocks[i]->postdominator_ids;
+    assert(m_basic_blocks[i]->bb_id == i);
+    m_basic_blocks[i]->Tmp_ids.erase(i);
+  }
+  for (int n = m_basic_blocks.size() - 2; n >= 0; --n) {
+    // point iterator to basic block before the exit
+    for (std::set<int>::iterator s = m_basic_blocks[n]->Tmp_ids.begin();
+         s != m_basic_blocks[n]->Tmp_ids.end(); s++) {
+      int bb_s = *s;
+      for (std::set<int>::iterator t = m_basic_blocks[n]->Tmp_ids.begin();
+           t != m_basic_blocks[n]->Tmp_ids.end();) {
+        std::set<int>::iterator t_next = t;
+        t_next++;  // might erase thing pointed to be t, invalidating iterator t
+        if (*s == *t) {
+          t = t_next;
+          continue;
+        }
+        int bb_t = *t;
+        if (m_basic_blocks[bb_s]->postdominator_ids.find(bb_t) !=
+            m_basic_blocks[bb_s]->postdominator_ids.end())
+          m_basic_blocks[n]->Tmp_ids.erase(bb_t);
+        t = t_next;
       }
-   }
-   unsigned num_idoms=0;
-   unsigned num_nopred = 0;
-   for ( int n = 0; n < m_basic_blocks.size(); ++n) {
-      //assert( m_basic_blocks[n]->Tmp_ids.size() <= 1 );
-         // if the above assert fails we have an error in either dominator
-         // computation, the flow graph does not have a unique entry, or some other error
-      if( !m_basic_blocks[n]->Tmp_ids.empty() ) {
-         m_basic_blocks[n]->immediatedominator_id = *m_basic_blocks[n]->Tmp_ids.begin();
-         num_idoms++;
-      } else if (m_basic_blocks[n]->predecessor_ids.empty()) {
-    	  num_nopred += 1;
+    }
+  }
+  unsigned num_ipdoms = 0;
+  for (int n = m_basic_blocks.size() - 1; n >= 0; --n) {
+    assert(m_basic_blocks[n]->Tmp_ids.size() <= 1);
+    // if the above assert fails we have an error in either postdominator
+    // computation, the flow graph does not have a unique exit, or some other
+    // error
+    if (!m_basic_blocks[n]->Tmp_ids.empty()) {
+      m_basic_blocks[n]->immediatepostdominator_id =
+          *m_basic_blocks[n]->Tmp_ids.begin();
+      num_ipdoms++;
+    }
+  }
+  assert(num_ipdoms == m_basic_blocks.size() - 1);
+  // the exit node does not have an immediate post dominator, but everyone else
+  // should
+}
+
+void function_info::find_idominators() {
+  // find immediate dominator blocks, using algorithm of
+  // Muchnick's Adv. Compiler Design & Implemmntation Fig 7.15
+  printf("GPGPU-Sim PTX: Finding immediate dominators for \'%s\'...\n",
+         m_name.c_str());
+  fflush(stdout);
+  assert(m_basic_blocks.size() >= 2);  // must have a distinquished entry block
+  for (unsigned i = 0; i < m_basic_blocks.size();
+       i++) {  // initialize Tmp(n) to all doms of n except for n
+    m_basic_blocks[i]->Tmp_ids = m_basic_blocks[i]->dominator_ids;
+    assert(m_basic_blocks[i]->bb_id == i);
+    m_basic_blocks[i]->Tmp_ids.erase(i);
+  }
+  for (int n = 0; n < m_basic_blocks.size(); ++n) {
+    // point iterator to basic block before the exit
+    for (std::set<int>::iterator s = m_basic_blocks[n]->Tmp_ids.begin();
+         s != m_basic_blocks[n]->Tmp_ids.end(); s++) {
+      int bb_s = *s;
+      for (std::set<int>::iterator t = m_basic_blocks[n]->Tmp_ids.begin();
+           t != m_basic_blocks[n]->Tmp_ids.end();) {
+        std::set<int>::iterator t_next = t;
+        t_next++;  // might erase thing pointed to be t, invalidating iterator t
+        if (*s == *t) {
+          t = t_next;
+          continue;
+        }
+        int bb_t = *t;
+        if (m_basic_blocks[bb_s]->dominator_ids.find(bb_t) !=
+            m_basic_blocks[bb_s]->dominator_ids.end())
+          m_basic_blocks[n]->Tmp_ids.erase(bb_t);
+        t = t_next;
       }
-   }
-   assert( num_idoms == m_basic_blocks.size()-num_nopred );
-      // the entry node does not have an immediate dominator, but everyone else should
+    }
+  }
+  unsigned num_idoms = 0;
+  unsigned num_nopred = 0;
+  for (int n = 0; n < m_basic_blocks.size(); ++n) {
+    // assert( m_basic_blocks[n]->Tmp_ids.size() <= 1 );
+    // if the above assert fails we have an error in either dominator
+    // computation, the flow graph does not have a unique entry, or some other
+    // error
+    if (!m_basic_blocks[n]->Tmp_ids.empty()) {
+      m_basic_blocks[n]->immediatedominator_id =
+          *m_basic_blocks[n]->Tmp_ids.begin();
+      num_idoms++;
+    } else if (m_basic_blocks[n]->predecessor_ids.empty()) {
+      num_nopred += 1;
+    }
+  }
+  assert(num_idoms == m_basic_blocks.size() - num_nopred);
+  // the entry node does not have an immediate dominator, but everyone else
+  // should
 }
 
-void function_info::print_dominators()
-{
-   printf("Printing dominators for function \'%s\':\n", m_name.c_str() );
-   std::vector<int>::iterator bb_itr;
-   for (unsigned i = 0; i < m_basic_blocks.size(); i++) {
-      printf("ID: %d\t:", i);
-      for( std::set<int>::iterator j=m_basic_blocks[i]->dominator_ids.begin(); j!=m_basic_blocks[i]->dominator_ids.end(); j++) 
-         printf(" %d", *j );
-      printf("\n");
-   }
+void function_info::print_dominators() {
+  printf("Printing dominators for function \'%s\':\n", m_name.c_str());
+  std::vector<int>::iterator bb_itr;
+  for (unsigned i = 0; i < m_basic_blocks.size(); i++) {
+    printf("ID: %d\t:", i);
+    for (std::set<int>::iterator j = m_basic_blocks[i]->dominator_ids.begin();
+         j != m_basic_blocks[i]->dominator_ids.end(); j++)
+      printf(" %d", *j);
+    printf("\n");
+  }
 }
 
-void function_info::print_postdominators()
-{
-   printf("Printing postdominators for function \'%s\':\n", m_name.c_str() );
-   std::vector<int>::iterator bb_itr;
-   for (unsigned i = 0; i < m_basic_blocks.size(); i++) {
-      printf("ID: %d\t:", i);
-      for( std::set<int>::iterator j=m_basic_blocks[i]->postdominator_ids.begin(); j!=m_basic_blocks[i]->postdominator_ids.end(); j++) 
-         printf(" %d", *j );
-      printf("\n");
-   }
+void function_info::print_postdominators() {
+  printf("Printing postdominators for function \'%s\':\n", m_name.c_str());
+  std::vector<int>::iterator bb_itr;
+  for (unsigned i = 0; i < m_basic_blocks.size(); i++) {
+    printf("ID: %d\t:", i);
+    for (std::set<int>::iterator j =
+             m_basic_blocks[i]->postdominator_ids.begin();
+         j != m_basic_blocks[i]->postdominator_ids.end(); j++)
+      printf(" %d", *j);
+    printf("\n");
+  }
 }
 
-void function_info::print_ipostdominators()
-{
-   printf("Printing immediate postdominators for function \'%s\':\n", m_name.c_str() );
-   std::vector<int>::iterator bb_itr;
-   for (unsigned i = 0; i < m_basic_blocks.size(); i++) {
-      printf("ID: %d\t:", i);
-      printf("%d\n", m_basic_blocks[i]->immediatepostdominator_id);
-   }
+void function_info::print_ipostdominators() {
+  printf("Printing immediate postdominators for function \'%s\':\n",
+         m_name.c_str());
+  std::vector<int>::iterator bb_itr;
+  for (unsigned i = 0; i < m_basic_blocks.size(); i++) {
+    printf("ID: %d\t:", i);
+    printf("%d\n", m_basic_blocks[i]->immediatepostdominator_id);
+  }
 }
 
-void function_info::print_idominators()
-{
-   printf("Printing immediate dominators for function \'%s\':\n", m_name.c_str() );
-   std::vector<int>::iterator bb_itr;
-   for (unsigned i = 0; i < m_basic_blocks.size(); i++) {
-      printf("ID: %d\t:", i);
-      printf("%d\n", m_basic_blocks[i]->immediatedominator_id);
-   }
+void function_info::print_idominators() {
+  printf("Printing immediate dominators for function \'%s\':\n",
+         m_name.c_str());
+  std::vector<int>::iterator bb_itr;
+  for (unsigned i = 0; i < m_basic_blocks.size(); i++) {
+    printf("ID: %d\t:", i);
+    printf("%d\n", m_basic_blocks[i]->immediatedominator_id);
+  }
 }
 
-unsigned function_info::get_num_reconvergence_pairs()
-{
-   if (!num_reconvergence_pairs) {
-      if( m_basic_blocks.size() == 0 ) 
-         return 0;
-      for (unsigned i=0; i< (m_basic_blocks.size()-1); i++) { //last basic block containing exit obviously won't have a pair
-         if (m_basic_blocks[i]->ptx_end->get_opcode() == BRA_OP) {
-            num_reconvergence_pairs++;
-         }
-      }
-   }
-   return num_reconvergence_pairs;
-}
-
-void function_info::get_reconvergence_pairs(gpgpu_recon_t* recon_points)
-{
-   unsigned idx=0; //array index
-   if( m_basic_blocks.size() == 0 ) 
-       return;
-   for (unsigned i=0; i< (m_basic_blocks.size()-1); i++) { //last basic block containing exit obviously won't have a pair
-#ifdef DEBUG_GET_RECONVERG_PAIRS
-      printf("i=%d\n", i); fflush(stdout);
-#endif
+unsigned function_info::get_num_reconvergence_pairs() {
+  if (!num_reconvergence_pairs) {
+    if (m_basic_blocks.size() == 0) return 0;
+    for (unsigned i = 0; i < (m_basic_blocks.size() - 1);
+         i++) {  // last basic block containing exit obviously won't have a pair
       if (m_basic_blocks[i]->ptx_end->get_opcode() == BRA_OP) {
-#ifdef DEBUG_GET_RECONVERG_PAIRS
-         printf("\tbranch!\n");
-         printf("\tbb_id=%d; ipdom=%d\n", m_basic_blocks[i]->bb_id, m_basic_blocks[i]->immediatepostdominator_id);
-         printf("\tm_instr_mem index=%d\n", m_basic_blocks[i]->ptx_end->get_m_instr_mem_index());
-         fflush(stdout);
-#endif
-         recon_points[idx].source_pc = m_basic_blocks[i]->ptx_end->get_PC();
-         recon_points[idx].source_inst = m_basic_blocks[i]->ptx_end;
-#ifdef DEBUG_GET_RECONVERG_PAIRS
-         printf("\trecon_points[idx].source_pc=%d\n", recon_points[idx].source_pc);
-#endif
-         if( m_basic_blocks[m_basic_blocks[i]->immediatepostdominator_id]->ptx_begin ) {
-            recon_points[idx].target_pc = m_basic_blocks[m_basic_blocks[i]->immediatepostdominator_id]->ptx_begin->get_PC();
-            recon_points[idx].target_inst = m_basic_blocks[m_basic_blocks[i]->immediatepostdominator_id]->ptx_begin;
-         } else {
-            // reconverge after function return
-            recon_points[idx].target_pc = -2;
-            recon_points[idx].target_inst = NULL;
-         }
-#ifdef DEBUG_GET_RECONVERG_PAIRS
-         m_basic_blocks[m_basic_blocks[i]->immediatepostdominator_id]->ptx_begin->print_insn();
-         printf("\trecon_points[idx].target_pc=%d\n", recon_points[idx].target_pc); fflush(stdout);
-#endif
-         idx++;
+        num_reconvergence_pairs++;
       }
-   }
+    }
+  }
+  return num_reconvergence_pairs;
+}
+
+void function_info::get_reconvergence_pairs(gpgpu_recon_t *recon_points) {
+  unsigned idx = 0;  // array index
+  if (m_basic_blocks.size() == 0) return;
+  for (unsigned i = 0; i < (m_basic_blocks.size() - 1);
+       i++) {  // last basic block containing exit obviously won't have a pair
+#ifdef DEBUG_GET_RECONVERG_PAIRS
+    printf("i=%d\n", i);
+    fflush(stdout);
+#endif
+    if (m_basic_blocks[i]->ptx_end->get_opcode() == BRA_OP) {
+#ifdef DEBUG_GET_RECONVERG_PAIRS
+      printf("\tbranch!\n");
+      printf("\tbb_id=%d; ipdom=%d\n", m_basic_blocks[i]->bb_id,
+             m_basic_blocks[i]->immediatepostdominator_id);
+      printf("\tm_instr_mem index=%d\n",
+             m_basic_blocks[i]->ptx_end->get_m_instr_mem_index());
+      fflush(stdout);
+#endif
+      recon_points[idx].source_pc = m_basic_blocks[i]->ptx_end->get_PC();
+      recon_points[idx].source_inst = m_basic_blocks[i]->ptx_end;
+#ifdef DEBUG_GET_RECONVERG_PAIRS
+      printf("\trecon_points[idx].source_pc=%d\n", recon_points[idx].source_pc);
+#endif
+      if (m_basic_blocks[m_basic_blocks[i]->immediatepostdominator_id]
+              ->ptx_begin) {
+        recon_points[idx].target_pc =
+            m_basic_blocks[m_basic_blocks[i]->immediatepostdominator_id]
+                ->ptx_begin->get_PC();
+        recon_points[idx].target_inst =
+            m_basic_blocks[m_basic_blocks[i]->immediatepostdominator_id]
+                ->ptx_begin;
+      } else {
+        // reconverge after function return
+        recon_points[idx].target_pc = -2;
+        recon_points[idx].target_inst = NULL;
+      }
+#ifdef DEBUG_GET_RECONVERG_PAIRS
+      m_basic_blocks[m_basic_blocks[i]->immediatepostdominator_id]
+          ->ptx_begin->print_insn();
+      printf("\trecon_points[idx].target_pc=%d\n", recon_points[idx].target_pc);
+      fflush(stdout);
+#endif
+      idx++;
+    }
+  }
 }
 
 // interface with graphviz (print the graph in DOT language) for plotting
-void function_info::print_basic_block_dot()
-{
-   printf("Basic Block in DOT\n");
-   printf("digraph %s {\n", m_name.c_str());
-   std::vector<basic_block_t*>::iterator bb_itr;
-   for (bb_itr = m_basic_blocks.begin();bb_itr != m_basic_blocks.end(); bb_itr++) {
-      printf("\t");
-      std::set<int>::iterator s;
-      for (s = (*bb_itr)->successor_ids.begin();s != (*bb_itr)->successor_ids.end();s++) {
-         unsigned succ_bb = *s;
-         printf("%d -> %d; ", (*bb_itr)->bb_id, succ_bb );
-      }
-      printf("\n");
-   }
-   printf("}\n");
-}
-
-unsigned ptx_kernel_shmem_size( void *kernel_impl )
-{
-   function_info *f = (function_info*)kernel_impl;
-   const struct gpgpu_ptx_sim_info *kernel_info = f->get_kernel_info();
-   return kernel_info->smem;
-}
-
-unsigned ptx_kernel_nregs( void *kernel_impl )
-{
-   function_info *f = (function_info*)kernel_impl;
-   const struct gpgpu_ptx_sim_info *kernel_info = f->get_kernel_info();
-   return kernel_info->regs;
-}
-
-unsigned type_info_key::type_decode( size_t &size, int &basic_type ) const
-{
-   int type = scalar_type();
-   return type_decode(type,size,basic_type);
-}
-
-unsigned type_info_key::type_decode( int type, size_t &size, int &basic_type )
-{
-   switch ( type ) {
-   case S8_TYPE:  size=8;  basic_type=1; return 0;
-   case S16_TYPE: size=16; basic_type=1; return 1;
-   case S32_TYPE: size=32; basic_type=1; return 2;
-   case S64_TYPE: size=64; basic_type=1; return 3;
-   case U8_TYPE:  size=8;  basic_type=0; return 4;
-   case U16_TYPE: size=16; basic_type=0; return 5;
-   case U32_TYPE: size=32; basic_type=0; return 6;
-   case U64_TYPE: size=64; basic_type=0; return 7;
-   case F16_TYPE: size=16; basic_type=-1; return 8;
-   case F32_TYPE: size=32; basic_type=-1; return 9;
-   case F64_TYPE: size=64; basic_type=-1; return 10;
-   case FF64_TYPE: size=64; basic_type=-1; return 10;
-   case PRED_TYPE: size=1; basic_type=2; return 11;
-   case B8_TYPE:  size=8;  basic_type=0; return 12;
-   case B16_TYPE: size=16; basic_type=0; return 13;
-   case B32_TYPE: size=32; basic_type=0; return 14;
-   case B64_TYPE: size=64; basic_type=0; return 15;
-   case BB64_TYPE: size=64; basic_type=0; return 15;
-   case BB128_TYPE: size=128; basic_type=0; return 16;
-   case TEXREF_TYPE: case SAMPLERREF_TYPE: case SURFREF_TYPE:
-      size=32; basic_type=3; return 16;
-   default: 
-      printf("ERROR ** type_decode() does not know about \"%s\"\n", decode_token(type) ); 
-      assert(0); 
-      return 0xDEADBEEF;
-   }
-}
-
-arg_buffer_t copy_arg_to_buffer(ptx_thread_info * thread, operand_info actual_param_op, const symbol * formal_param)
-{
-   if( actual_param_op.is_reg() )  {
-      ptx_reg_t value = thread->get_reg(actual_param_op.get_symbol());
-      return arg_buffer_t(formal_param,actual_param_op,value);
-   } else if ( actual_param_op.is_param_local() ) {
-      unsigned size=formal_param->get_size_in_bytes();
-      addr_t frame_offset = actual_param_op.get_symbol()->get_address();
-      addr_t from_addr = thread->get_local_mem_stack_pointer() + frame_offset;
-      char buffer[1024];
-      assert(size<1024); 
-      thread->m_local_mem->read(from_addr,size,buffer);
-      return arg_buffer_t(formal_param,actual_param_op,buffer,size);
-   } else {
-      printf("GPGPU-Sim PTX: ERROR ** need to add support for this operand type in call/return\n");
-      abort();
-   }
-}
-
-void copy_args_into_buffer_list( const ptx_instruction * pI, 
-                                 ptx_thread_info * thread, 
-                                 const function_info * target_func, 
-                                 arg_buffer_list_t &arg_values ) 
-{
-   unsigned n_return = target_func->has_return();
-   unsigned n_args = target_func->num_args();
-   for( unsigned arg=0; arg < n_args; arg ++ ) {
-      const operand_info &actual_param_op = pI->operand_lookup(n_return+1+arg);
-      const symbol *formal_param = target_func->get_arg(arg);
-      arg_values.push_back( copy_arg_to_buffer(thread, actual_param_op, formal_param) );
-   }
-}
-
-void copy_buffer_to_frame(ptx_thread_info * thread, const arg_buffer_t &a) 
-{
-   if( a.is_reg() ) {
-      ptx_reg_t value = a.get_reg();
-      operand_info dst_reg = operand_info(a.get_dst(), thread->get_gpu()->gpgpu_ctx); 
-      thread->set_reg(dst_reg.get_symbol(),value);
-   } else {  
-      const void *buffer = a.get_param_buffer();
-      size_t size = a.get_param_buffer_size();
-      const symbol *dst = a.get_dst();
-      addr_t frame_offset = dst->get_address();
-      addr_t to_addr = thread->get_local_mem_stack_pointer() + frame_offset;
-      thread->m_local_mem->write(to_addr,size,buffer,NULL,NULL);
-   }
-}
-
-void copy_buffer_list_into_frame(ptx_thread_info * thread, arg_buffer_list_t &arg_values) 
-{
-   arg_buffer_list_t::iterator a;
-   for( a=arg_values.begin(); a != arg_values.end(); a++ ) {
-      copy_buffer_to_frame(thread, *a);
-   }
-}
-
-
-
-static std::list<operand_info> check_operands( int opcode,
-                                        const std::list<int> &scalar_type,
-                                        const std::list<operand_info> &operands,
-					gpgpu_context* ctx)
-{
-   static int g_warn_literal_operands_two_type_inst;
-    if( (opcode == CVT_OP) || (opcode == SET_OP) || (opcode == SLCT_OP) || (opcode == TEX_OP) || (opcode==MMA_OP) || (opcode == DP4A_OP)) {
-        // just make sure these do not have have const operands... 
-        if( !g_warn_literal_operands_two_type_inst ) {
-            std::list<operand_info>::const_iterator o;
-            for( o = operands.begin(); o != operands.end(); o++ ) {
-                const operand_info &op = *o;
-                if( op.is_literal() ) {
-                    printf("GPGPU-Sim PTX: PTX uses two scalar type intruction with literal operand.\n");
-                    g_warn_literal_operands_two_type_inst = 1;
-                }
-            }
-        }
-    } else {
-        assert( scalar_type.size() < 2 );
-        if( scalar_type.size() == 1 ) {
-            std::list<operand_info> result;
-            int inst_type = scalar_type.front();
-            std::list<operand_info>::const_iterator o;
-            for( o = operands.begin(); o != operands.end(); o++ ) {
-                const operand_info &op = *o;
-                if( op.is_literal() ) {
-                    if( (op.get_type() == double_op_t) && (inst_type == F32_TYPE) ) {
-                        ptx_reg_t v = op.get_literal_value();
-                        float u = (float)v.f64;
-                        operand_info n(u, ctx);
-                        result.push_back(n);
-                    } else {
-                        result.push_back(op);
-                    }
-                } else {
-                        result.push_back(op);
-                }
-            }
-            return result;
-        } 
+void function_info::print_basic_block_dot() {
+  printf("Basic Block in DOT\n");
+  printf("digraph %s {\n", m_name.c_str());
+  std::vector<basic_block_t *>::iterator bb_itr;
+  for (bb_itr = m_basic_blocks.begin(); bb_itr != m_basic_blocks.end();
+       bb_itr++) {
+    printf("\t");
+    std::set<int>::iterator s;
+    for (s = (*bb_itr)->successor_ids.begin();
+         s != (*bb_itr)->successor_ids.end(); s++) {
+      unsigned succ_bb = *s;
+      printf("%d -> %d; ", (*bb_itr)->bb_id, succ_bb);
     }
-    return operands;
+    printf("\n");
+  }
+  printf("}\n");
 }
 
+unsigned ptx_kernel_shmem_size(void *kernel_impl) {
+  function_info *f = (function_info *)kernel_impl;
+  const struct gpgpu_ptx_sim_info *kernel_info = f->get_kernel_info();
+  return kernel_info->smem;
+}
 
-ptx_instruction::ptx_instruction( int opcode, 
-                                  const symbol *pred, 
-                                  int neg_pred, 
-                                  int pred_mod,
-                                  symbol *label,
-                                  const std::list<operand_info> &operands, 
-                                  const operand_info &return_var,
-                                  const std::list<int> &options, 
-                                  const std::list<int> &wmma_options, 
-                                  const std::list<int> &scalar_type,
-                                  memory_space_t space_spec,
-                                  const char *file, 
-                                  unsigned line,
-                                  const char *source,
-                                  const core_config *config,
-				  gpgpu_context* ctx ) : warp_inst_t(config), m_return_var(ctx)
-{
-   gpgpu_ctx = ctx;
-   m_uid = ++(ctx->g_num_ptx_inst_uid);
-   m_PC = 0;
-   m_opcode = opcode;
-   m_pred = pred;
-   m_neg_pred = neg_pred;
-   m_pred_mod = pred_mod;
-   m_label = label;
-   const std::list<operand_info> checked_operands = check_operands(opcode,scalar_type,operands, ctx);
-   m_operands.insert(m_operands.begin(), checked_operands.begin(), checked_operands.end() );
-   m_return_var = return_var;
-   m_options = options;
-   m_wmma_options = wmma_options;
-   m_wide = false;
-   m_hi = false;
-   m_lo = false;
-   m_uni = false;
-   m_exit = false;
-   m_abs = false;
-   m_neg = false;
-   m_to_option = false;
-   m_cache_option = 0;
-   m_rounding_mode = RN_OPTION;
-   m_compare_op = -1;
-   m_saturation_mode = 0;
-   m_geom_spec = 0;
-   m_vector_spec = 0;
-   m_atomic_spec = 0;
-   m_membar_level = 0;
-   m_inst_size = 8; // bytes
-   int rr=0;
-   std::list<int>::const_iterator i;
-   unsigned n=1;
-   for ( i=wmma_options.begin(); i!= wmma_options.end(); i++, n++ ) {
-      int last_ptx_inst_option = *i;
-      switch ( last_ptx_inst_option ) {
-      		case SYNC_OPTION:
-      		case LOAD_A:
-      		case LOAD_B:
-      		case LOAD_C:
-      		case STORE_D:
-      		case MMA:
-      		  m_wmma_type=last_ptx_inst_option;
-      		  break;
-      		case ROW:
-      		case COL:
-      		  m_wmma_layout[rr++]=last_ptx_inst_option;
-      		  break;
-      		case M16N16K16:
-      		case M32N8K16:
-      		case M8N32K16:
-			break;
-      		default:
-      		   assert(0);
-      		   break;
-	}
-   }
-   rr=0;
-   n=1;
-   for ( i=options.begin(); i!= options.end(); i++, n++ ) {
-      int last_ptx_inst_option = *i;
-      switch ( last_ptx_inst_option ) {
+unsigned ptx_kernel_nregs(void *kernel_impl) {
+  function_info *f = (function_info *)kernel_impl;
+  const struct gpgpu_ptx_sim_info *kernel_info = f->get_kernel_info();
+  return kernel_info->regs;
+}
+
+unsigned type_info_key::type_decode(size_t &size, int &basic_type) const {
+  int type = scalar_type();
+  return type_decode(type, size, basic_type);
+}
+
+unsigned type_info_key::type_decode(int type, size_t &size, int &basic_type) {
+  switch (type) {
+    case S8_TYPE:
+      size = 8;
+      basic_type = 1;
+      return 0;
+    case S16_TYPE:
+      size = 16;
+      basic_type = 1;
+      return 1;
+    case S32_TYPE:
+      size = 32;
+      basic_type = 1;
+      return 2;
+    case S64_TYPE:
+      size = 64;
+      basic_type = 1;
+      return 3;
+    case U8_TYPE:
+      size = 8;
+      basic_type = 0;
+      return 4;
+    case U16_TYPE:
+      size = 16;
+      basic_type = 0;
+      return 5;
+    case U32_TYPE:
+      size = 32;
+      basic_type = 0;
+      return 6;
+    case U64_TYPE:
+      size = 64;
+      basic_type = 0;
+      return 7;
+    case F16_TYPE:
+      size = 16;
+      basic_type = -1;
+      return 8;
+    case F32_TYPE:
+      size = 32;
+      basic_type = -1;
+      return 9;
+    case F64_TYPE:
+      size = 64;
+      basic_type = -1;
+      return 10;
+    case FF64_TYPE:
+      size = 64;
+      basic_type = -1;
+      return 10;
+    case PRED_TYPE:
+      size = 1;
+      basic_type = 2;
+      return 11;
+    case B8_TYPE:
+      size = 8;
+      basic_type = 0;
+      return 12;
+    case B16_TYPE:
+      size = 16;
+      basic_type = 0;
+      return 13;
+    case B32_TYPE:
+      size = 32;
+      basic_type = 0;
+      return 14;
+    case B64_TYPE:
+      size = 64;
+      basic_type = 0;
+      return 15;
+    case BB64_TYPE:
+      size = 64;
+      basic_type = 0;
+      return 15;
+    case BB128_TYPE:
+      size = 128;
+      basic_type = 0;
+      return 16;
+    case TEXREF_TYPE:
+    case SAMPLERREF_TYPE:
+    case SURFREF_TYPE:
+      size = 32;
+      basic_type = 3;
+      return 16;
+    default:
+      printf("ERROR ** type_decode() does not know about \"%s\"\n",
+             decode_token(type));
+      assert(0);
+      return 0xDEADBEEF;
+  }
+}
+
+arg_buffer_t copy_arg_to_buffer(ptx_thread_info *thread,
+                                operand_info actual_param_op,
+                                const symbol *formal_param) {
+  if (actual_param_op.is_reg()) {
+    ptx_reg_t value = thread->get_reg(actual_param_op.get_symbol());
+    return arg_buffer_t(formal_param, actual_param_op, value);
+  } else if (actual_param_op.is_param_local()) {
+    unsigned size = formal_param->get_size_in_bytes();
+    addr_t frame_offset = actual_param_op.get_symbol()->get_address();
+    addr_t from_addr = thread->get_local_mem_stack_pointer() + frame_offset;
+    char buffer[1024];
+    assert(size < 1024);
+    thread->m_local_mem->read(from_addr, size, buffer);
+    return arg_buffer_t(formal_param, actual_param_op, buffer, size);
+  } else {
+    printf(
+        "GPGPU-Sim PTX: ERROR ** need to add support for this operand type in "
+        "call/return\n");
+    abort();
+  }
+}
+
+void copy_args_into_buffer_list(const ptx_instruction *pI,
+                                ptx_thread_info *thread,
+                                const function_info *target_func,
+                                arg_buffer_list_t &arg_values) {
+  unsigned n_return = target_func->has_return();
+  unsigned n_args = target_func->num_args();
+  for (unsigned arg = 0; arg < n_args; arg++) {
+    const operand_info &actual_param_op =
+        pI->operand_lookup(n_return + 1 + arg);
+    const symbol *formal_param = target_func->get_arg(arg);
+    arg_values.push_back(
+        copy_arg_to_buffer(thread, actual_param_op, formal_param));
+  }
+}
+
+void copy_buffer_to_frame(ptx_thread_info *thread, const arg_buffer_t &a) {
+  if (a.is_reg()) {
+    ptx_reg_t value = a.get_reg();
+    operand_info dst_reg =
+        operand_info(a.get_dst(), thread->get_gpu()->gpgpu_ctx);
+    thread->set_reg(dst_reg.get_symbol(), value);
+  } else {
+    const void *buffer = a.get_param_buffer();
+    size_t size = a.get_param_buffer_size();
+    const symbol *dst = a.get_dst();
+    addr_t frame_offset = dst->get_address();
+    addr_t to_addr = thread->get_local_mem_stack_pointer() + frame_offset;
+    thread->m_local_mem->write(to_addr, size, buffer, NULL, NULL);
+  }
+}
+
+void copy_buffer_list_into_frame(ptx_thread_info *thread,
+                                 arg_buffer_list_t &arg_values) {
+  arg_buffer_list_t::iterator a;
+  for (a = arg_values.begin(); a != arg_values.end(); a++) {
+    copy_buffer_to_frame(thread, *a);
+  }
+}
+
+static std::list<operand_info> check_operands(
+    int opcode, const std::list<int> &scalar_type,
+    const std::list<operand_info> &operands, gpgpu_context *ctx) {
+  static int g_warn_literal_operands_two_type_inst;
+  if ((opcode == CVT_OP) || (opcode == SET_OP) || (opcode == SLCT_OP) ||
+      (opcode == TEX_OP) || (opcode == MMA_OP) || (opcode == DP4A_OP)) {
+    // just make sure these do not have have const operands...
+    if (!g_warn_literal_operands_two_type_inst) {
+      std::list<operand_info>::const_iterator o;
+      for (o = operands.begin(); o != operands.end(); o++) {
+        const operand_info &op = *o;
+        if (op.is_literal()) {
+          printf(
+              "GPGPU-Sim PTX: PTX uses two scalar type intruction with literal "
+              "operand.\n");
+          g_warn_literal_operands_two_type_inst = 1;
+        }
+      }
+    }
+  } else {
+    assert(scalar_type.size() < 2);
+    if (scalar_type.size() == 1) {
+      std::list<operand_info> result;
+      int inst_type = scalar_type.front();
+      std::list<operand_info>::const_iterator o;
+      for (o = operands.begin(); o != operands.end(); o++) {
+        const operand_info &op = *o;
+        if (op.is_literal()) {
+          if ((op.get_type() == double_op_t) && (inst_type == F32_TYPE)) {
+            ptx_reg_t v = op.get_literal_value();
+            float u = (float)v.f64;
+            operand_info n(u, ctx);
+            result.push_back(n);
+          } else {
+            result.push_back(op);
+          }
+        } else {
+          result.push_back(op);
+        }
+      }
+      return result;
+    }
+  }
+  return operands;
+}
+
+ptx_instruction::ptx_instruction(
+    int opcode, const symbol *pred, int neg_pred, int pred_mod, symbol *label,
+    const std::list<operand_info> &operands, const operand_info &return_var,
+    const std::list<int> &options, const std::list<int> &wmma_options,
+    const std::list<int> &scalar_type, memory_space_t space_spec,
+    const char *file, unsigned line, const char *source,
+    const core_config *config, gpgpu_context *ctx)
+    : warp_inst_t(config), m_return_var(ctx) {
+  gpgpu_ctx = ctx;
+  m_uid = ++(ctx->g_num_ptx_inst_uid);
+  m_PC = 0;
+  m_opcode = opcode;
+  m_pred = pred;
+  m_neg_pred = neg_pred;
+  m_pred_mod = pred_mod;
+  m_label = label;
+  const std::list<operand_info> checked_operands =
+      check_operands(opcode, scalar_type, operands, ctx);
+  m_operands.insert(m_operands.begin(), checked_operands.begin(),
+                    checked_operands.end());
+  m_return_var = return_var;
+  m_options = options;
+  m_wmma_options = wmma_options;
+  m_wide = false;
+  m_hi = false;
+  m_lo = false;
+  m_uni = false;
+  m_exit = false;
+  m_abs = false;
+  m_neg = false;
+  m_to_option = false;
+  m_cache_option = 0;
+  m_rounding_mode = RN_OPTION;
+  m_compare_op = -1;
+  m_saturation_mode = 0;
+  m_geom_spec = 0;
+  m_vector_spec = 0;
+  m_atomic_spec = 0;
+  m_membar_level = 0;
+  m_inst_size = 8;  // bytes
+  int rr = 0;
+  std::list<int>::const_iterator i;
+  unsigned n = 1;
+  for (i = wmma_options.begin(); i != wmma_options.end(); i++, n++) {
+    int last_ptx_inst_option = *i;
+    switch (last_ptx_inst_option) {
+      case SYNC_OPTION:
+      case LOAD_A:
+      case LOAD_B:
+      case LOAD_C:
+      case STORE_D:
+      case MMA:
+        m_wmma_type = last_ptx_inst_option;
+        break;
+      case ROW:
+      case COL:
+        m_wmma_layout[rr++] = last_ptx_inst_option;
+        break;
+      case M16N16K16:
+      case M32N8K16:
+      case M8N32K16:
+        break;
+      default:
+        assert(0);
+        break;
+    }
+  }
+  rr = 0;
+  n = 1;
+  for (i = options.begin(); i != options.end(); i++, n++) {
+    int last_ptx_inst_option = *i;
+    switch (last_ptx_inst_option) {
       case SYNC_OPTION:
       case ARRIVE_OPTION:
       case RED_OPTION:
-          m_barrier_op = last_ptx_inst_option;
-          break;
+        m_barrier_op = last_ptx_inst_option;
+        break;
       case EQU_OPTION:
       case NEU_OPTION:
       case LTU_OPTION:
@@ -1186,16 +1279,16 @@ ptx_instruction::ptx_instruction( int opcode,
       case GE_OPTION:
       case LS_OPTION:
       case HS_OPTION:
-         m_compare_op = last_ptx_inst_option;
-         break;
+        m_compare_op = last_ptx_inst_option;
+        break;
       case NUM_OPTION:
       case NAN_OPTION:
-    	  m_compare_op = last_ptx_inst_option;
+        m_compare_op = last_ptx_inst_option;
         // assert(0); // finish this
-         break;
+        break;
       case SAT_OPTION:
-         m_saturation_mode = 1;
-         break;
+        m_saturation_mode = 1;
+        break;
       case RNI_OPTION:
       case RZI_OPTION:
       case RMI_OPTION:
@@ -1204,38 +1297,39 @@ ptx_instruction::ptx_instruction( int opcode,
       case RZ_OPTION:
       case RM_OPTION:
       case RP_OPTION:
-         m_rounding_mode = last_ptx_inst_option;
-         break;
+        m_rounding_mode = last_ptx_inst_option;
+        break;
       case HI_OPTION:
-         m_compare_op = last_ptx_inst_option;
-         m_hi = true;
-         assert( !m_lo ); 
-         assert( !m_wide );
-         break;
+        m_compare_op = last_ptx_inst_option;
+        m_hi = true;
+        assert(!m_lo);
+        assert(!m_wide);
+        break;
       case LO_OPTION:
-         m_compare_op = last_ptx_inst_option;
-         m_lo = true;
-         assert( !m_hi );
-         assert( !m_wide );
-         break;
+        m_compare_op = last_ptx_inst_option;
+        m_lo = true;
+        assert(!m_hi);
+        assert(!m_wide);
+        break;
       case WIDE_OPTION:
-         m_wide = true;
-         assert( !m_lo ); 
-         assert( !m_hi ); 
-         break;
+        m_wide = true;
+        assert(!m_lo);
+        assert(!m_hi);
+        break;
       case UNI_OPTION:
-         m_uni = true; // don't care... < now we DO care when constructing flowgraph>
-         break;
+        m_uni = true;  // don't care... < now we DO care when constructing
+                       // flowgraph>
+        break;
       case GEOM_MODIFIER_1D:
       case GEOM_MODIFIER_2D:
       case GEOM_MODIFIER_3D:
-         m_geom_spec = last_ptx_inst_option;
-         break;
+        m_geom_spec = last_ptx_inst_option;
+        break;
       case V2_TYPE:
       case V3_TYPE:
       case V4_TYPE:
-         m_vector_spec = last_ptx_inst_option;
-         break;
+        m_vector_spec = last_ptx_inst_option;
+        break;
       case ATOMIC_AND:
       case ATOMIC_OR:
       case ATOMIC_XOR:
@@ -1246,223 +1340,225 @@ ptx_instruction::ptx_instruction( int opcode,
       case ATOMIC_DEC:
       case ATOMIC_MIN:
       case ATOMIC_MAX:
-         m_atomic_spec = last_ptx_inst_option;
-         break;
+        m_atomic_spec = last_ptx_inst_option;
+        break;
       case APPROX_OPTION:
-         break;
+        break;
       case FULL_OPTION:
-         break;
+        break;
       case ANY_OPTION:
-         m_vote_mode = vote_any;
-         break;
+        m_vote_mode = vote_any;
+        break;
       case ALL_OPTION:
-         m_vote_mode = vote_all;
-         break;
+        m_vote_mode = vote_all;
+        break;
       case BALLOT_OPTION:
-         m_vote_mode = vote_ballot;
-         break;
+        m_vote_mode = vote_ballot;
+        break;
       case GLOBAL_OPTION:
-         m_membar_level = GLOBAL_OPTION;
-         break;
+        m_membar_level = GLOBAL_OPTION;
+        break;
       case CTA_OPTION:
-         m_membar_level = CTA_OPTION;
-         break;
+        m_membar_level = CTA_OPTION;
+        break;
       case SYS_OPTION:
-         m_membar_level = SYS_OPTION;
-         break;
+        m_membar_level = SYS_OPTION;
+        break;
       case FTZ_OPTION:
-         break;
+        break;
       case EXIT_OPTION:
-         m_exit = true;
-         break;
+        m_exit = true;
+        break;
       case ABS_OPTION:
-         m_abs = true;
-         break;
+        m_abs = true;
+        break;
       case NEG_OPTION:
-         m_neg = true;
-         break;
+        m_neg = true;
+        break;
       case TO_OPTION:
-         m_to_option = true;
-         break;
-      case CA_OPTION: case CG_OPTION: case CS_OPTION: case LU_OPTION: case CV_OPTION:
-         m_cache_option = last_ptx_inst_option;
-         break;
+        m_to_option = true;
+        break;
+      case CA_OPTION:
+      case CG_OPTION:
+      case CS_OPTION:
+      case LU_OPTION:
+      case CV_OPTION:
+        m_cache_option = last_ptx_inst_option;
+        break;
       case HALF_OPTION:
-         m_inst_size = 4; // bytes
-         break;
+        m_inst_size = 4;  // bytes
+        break;
       case EXTP_OPTION:
-             break;
+        break;
       case NC_OPTION:
-             m_cache_option = last_ptx_inst_option;
-             break;
+        m_cache_option = last_ptx_inst_option;
+        break;
       case UP_OPTION:
       case DOWN_OPTION:
       case BFLY_OPTION:
       case IDX_OPTION:
-		  m_shfl_op = last_ptx_inst_option;
-		  break;
+        m_shfl_op = last_ptx_inst_option;
+        break;
       case PRMT_F4E_MODE:
       case PRMT_B4E_MODE:
       case PRMT_RC8_MODE:
       case PRMT_ECL_MODE:
       case PRMT_ECR_MODE:
       case PRMT_RC16_MODE:
-		  m_prmt_op = last_ptx_inst_option;
-		  break;
+        m_prmt_op = last_ptx_inst_option;
+        break;
       default:
-         assert(0);
-         break;
-      }
-   }
-   m_scalar_type = scalar_type;
-   m_space_spec = space_spec;
-   if( ( opcode == ST_OP || opcode == LD_OP || opcode == LDU_OP ) && (space_spec == undefined_space) ) {
-      m_space_spec = generic_space;
-   } 
-   for( std::vector<operand_info>::const_iterator i=m_operands.begin(); i!=m_operands.end(); ++i) {
-       const operand_info &op = *i;
-       if( op.get_addr_space() != undefined_space ) 
-           m_space_spec = op.get_addr_space(); // TODO: can have more than one memory space for ptxplus (g8x) inst
-   }
-   if( opcode == TEX_OP ) 
-       m_space_spec = tex_space;
-   
-   m_source_file = file?file:"<unknown>";
-   m_source_line = line;
-   m_source = source;
-   // Trim tabs
-   m_source.erase( std::remove( m_source.begin(), m_source.end(), '\t' ), m_source.end() );
+        assert(0);
+        break;
+    }
+  }
+  m_scalar_type = scalar_type;
+  m_space_spec = space_spec;
+  if ((opcode == ST_OP || opcode == LD_OP || opcode == LDU_OP) &&
+      (space_spec == undefined_space)) {
+    m_space_spec = generic_space;
+  }
+  for (std::vector<operand_info>::const_iterator i = m_operands.begin();
+       i != m_operands.end(); ++i) {
+    const operand_info &op = *i;
+    if (op.get_addr_space() != undefined_space)
+      m_space_spec =
+          op.get_addr_space();  // TODO: can have more than one memory space for
+                                // ptxplus (g8x) inst
+  }
+  if (opcode == TEX_OP) m_space_spec = tex_space;
 
-   if (opcode == CALL_OP) {
-       const operand_info &target  = func_addr();
-       assert( target.is_function_address() );
-       const symbol *func_addr = target.get_symbol();
-       const function_info *target_func = func_addr->get_pc();
-       std::string fname = target_func->get_name();
+  m_source_file = file ? file : "<unknown>";
+  m_source_line = line;
+  m_source = source;
+  // Trim tabs
+  m_source.erase(std::remove(m_source.begin(), m_source.end(), '\t'),
+                 m_source.end());
 
-       if (fname =="vprintf"){
-           m_is_printf = true;
-       }
-       if(fname == "cudaStreamCreateWithFlags")
-           m_is_cdp = 1;
-       if(fname == "cudaGetParameterBufferV2")
-           m_is_cdp = 2;
-       if(fname == "cudaLaunchDeviceV2")
-           m_is_cdp = 4;
+  if (opcode == CALL_OP) {
+    const operand_info &target = func_addr();
+    assert(target.is_function_address());
+    const symbol *func_addr = target.get_symbol();
+    const function_info *target_func = func_addr->get_pc();
+    std::string fname = target_func->get_name();
 
-   }
+    if (fname == "vprintf") {
+      m_is_printf = true;
+    }
+    if (fname == "cudaStreamCreateWithFlags") m_is_cdp = 1;
+    if (fname == "cudaGetParameterBufferV2") m_is_cdp = 2;
+    if (fname == "cudaLaunchDeviceV2") m_is_cdp = 4;
+  }
 }
 
-void ptx_instruction::print_insn() const
-{
-   print_insn(stdout);
-   fflush(stdout);
+void ptx_instruction::print_insn() const {
+  print_insn(stdout);
+  fflush(stdout);
 }
 
-void ptx_instruction::print_insn( FILE *fp ) const
-{
-    fprintf( fp, "%s", to_string().c_str() );
+void ptx_instruction::print_insn(FILE *fp) const {
+  fprintf(fp, "%s", to_string().c_str());
 }
 
-std::string ptx_instruction::to_string() const
-{
-   char buf[ STR_SIZE ];
-   unsigned used_bytes = 0;
-   if( !is_label() ) {
-      used_bytes += snprintf( buf + used_bytes, STR_SIZE - used_bytes, " PC=0x%03x ", m_PC );
-   } else {
-      used_bytes += snprintf( buf + used_bytes, STR_SIZE - used_bytes, "                " );
-   }
-   used_bytes += snprintf( buf + used_bytes, STR_SIZE - used_bytes,
-                           "(%s:%d) %s",
-                           m_source_file.c_str(), m_source_line,
-                           m_source.c_str() );
-   return std::string( buf );
+std::string ptx_instruction::to_string() const {
+  char buf[STR_SIZE];
+  unsigned used_bytes = 0;
+  if (!is_label()) {
+    used_bytes +=
+        snprintf(buf + used_bytes, STR_SIZE - used_bytes, " PC=0x%03x ", m_PC);
+  } else {
+    used_bytes +=
+        snprintf(buf + used_bytes, STR_SIZE - used_bytes, "                ");
+  }
+  used_bytes +=
+      snprintf(buf + used_bytes, STR_SIZE - used_bytes, "(%s:%d) %s",
+               m_source_file.c_str(), m_source_line, m_source.c_str());
+  return std::string(buf);
 }
-operand_info ptx_instruction::get_pred() const
-{
-    return operand_info( m_pred, gpgpu_ctx);
-}
-
-
-function_info::function_info(int entry_point, gpgpu_context* ctx )
-{
-   gpgpu_ctx = ctx;
-   m_uid = (gpgpu_ctx->function_info_sm_next_uid)++;
-   m_entry_point = (entry_point==1)?true:false;
-   m_extern = (entry_point==2)?true:false;
-   num_reconvergence_pairs = 0;
-   m_symtab = NULL;
-   m_assembled = false;
-   m_return_var_sym = NULL; 
-   m_kernel_info.cmem = 0;
-   m_kernel_info.lmem = 0;
-   m_kernel_info.regs = 0;
-   m_kernel_info.smem = 0;
-   m_local_mem_framesize = 0;
-   m_args_aligned_size = -1;
-   pdom_done = false; //initialize it to false
+operand_info ptx_instruction::get_pred() const {
+  return operand_info(m_pred, gpgpu_ctx);
 }
 
-unsigned function_info::print_insn( unsigned pc, FILE * fp ) const
-{
-   unsigned inst_size=1; // return offset to next instruction or 1 if unknown
-   unsigned index = pc - m_start_PC;
-   char command[1024];
-   char buffer[1024];
-   memset(command, 0, 1024);
-   memset(buffer, 0, 1024);
-   snprintf(command,1024,"c++filt -p %s",m_name.c_str());
-   FILE *p = popen(command,"r");
-   buffer[0]=0;
-   assert(fgets(buffer, 1023, p) != NULL);
-   // Remove trailing "\n" in buffer
-   char *c;
-   if ((c=strchr(buffer, '\n')) != NULL) *c = '\0';
-   fprintf(fp,"%s",buffer);
-   if ( index >= m_instr_mem_size ) {
-      fprintf(fp, "<past last instruction (max pc=%u)>", m_start_PC + m_instr_mem_size - 1 );
-   } else {
-      if ( m_instr_mem[index] != NULL ) {
-         m_instr_mem[index]->print_insn(fp);
-         inst_size = m_instr_mem[index]->isize;
-      } else
-         fprintf(fp, "<no instruction at pc = %u>", pc );
-   }
-   pclose(p);
-   return inst_size;
+function_info::function_info(int entry_point, gpgpu_context *ctx) {
+  gpgpu_ctx = ctx;
+  m_uid = (gpgpu_ctx->function_info_sm_next_uid)++;
+  m_entry_point = (entry_point == 1) ? true : false;
+  m_extern = (entry_point == 2) ? true : false;
+  num_reconvergence_pairs = 0;
+  m_symtab = NULL;
+  m_assembled = false;
+  m_return_var_sym = NULL;
+  m_kernel_info.cmem = 0;
+  m_kernel_info.lmem = 0;
+  m_kernel_info.regs = 0;
+  m_kernel_info.smem = 0;
+  m_local_mem_framesize = 0;
+  m_args_aligned_size = -1;
+  pdom_done = false;  // initialize it to false
 }
 
-std::string function_info::get_insn_str( unsigned pc ) const
-{
-   unsigned index = pc - m_start_PC;
-   if ( index >= m_instr_mem_size ) {
+unsigned function_info::print_insn(unsigned pc, FILE *fp) const {
+  unsigned inst_size = 1;  // return offset to next instruction or 1 if unknown
+  unsigned index = pc - m_start_PC;
+  char command[1024];
+  char buffer[1024];
+  memset(command, 0, 1024);
+  memset(buffer, 0, 1024);
+  snprintf(command, 1024, "c++filt -p %s", m_name.c_str());
+  FILE *p = popen(command, "r");
+  buffer[0] = 0;
+  assert(fgets(buffer, 1023, p) != NULL);
+  // Remove trailing "\n" in buffer
+  char *c;
+  if ((c = strchr(buffer, '\n')) != NULL) *c = '\0';
+  fprintf(fp, "%s", buffer);
+  if (index >= m_instr_mem_size) {
+    fprintf(fp, "<past last instruction (max pc=%u)>",
+            m_start_PC + m_instr_mem_size - 1);
+  } else {
+    if (m_instr_mem[index] != NULL) {
+      m_instr_mem[index]->print_insn(fp);
+      inst_size = m_instr_mem[index]->isize;
+    } else
+      fprintf(fp, "<no instruction at pc = %u>", pc);
+  }
+  pclose(p);
+  return inst_size;
+}
+
+std::string function_info::get_insn_str(unsigned pc) const {
+  unsigned index = pc - m_start_PC;
+  if (index >= m_instr_mem_size) {
+    char buff[STR_SIZE];
+    buff[STR_SIZE - 1] = '\0';
+    snprintf(buff, STR_SIZE, "<past last instruction (max pc=%u)>",
+             m_start_PC + m_instr_mem_size - 1);
+    return std::string(buff);
+  } else {
+    if (m_instr_mem[index] != NULL) {
+      return m_instr_mem[index]->to_string();
+    } else {
       char buff[STR_SIZE];
-      buff[STR_SIZE-1] = '\0';
-      snprintf(buff, STR_SIZE, "<past last instruction (max pc=%u)>", m_start_PC + m_instr_mem_size - 1 );
+      buff[STR_SIZE - 1] = '\0';
+      snprintf(buff, STR_SIZE, "<no instruction at pc = %u>", pc);
       return std::string(buff);
-   } else {
-      if ( m_instr_mem[index] != NULL ) {
-         return m_instr_mem[index]->to_string();
-      } else {
-         char buff[STR_SIZE];
-         buff[STR_SIZE-1] = '\0';
-         snprintf(buff, STR_SIZE, "<no instruction at pc = %u>", pc );
-         return std::string(buff);
-      }
-   }
+    }
+  }
 }
 
-void gpgpu_ptx_assemble( std::string kname, void *kinfo )
-{
-    function_info *func_info = (function_info *)kinfo;
-    if((function_info *)kinfo == NULL) {
-       printf("GPGPU-Sim PTX: Warning - missing function definition \'%s\'\n", kname.c_str());
-       return;
-    }
-    if( func_info->is_extern() ) {
-       printf("GPGPU-Sim PTX: skipping assembly for extern declared function \'%s\'\n", func_info->get_name().c_str() );
-       return;
-    }
-    func_info->ptx_assemble();
+void gpgpu_ptx_assemble(std::string kname, void *kinfo) {
+  function_info *func_info = (function_info *)kinfo;
+  if ((function_info *)kinfo == NULL) {
+    printf("GPGPU-Sim PTX: Warning - missing function definition \'%s\'\n",
+           kname.c_str());
+    return;
+  }
+  if (func_info->is_extern()) {
+    printf(
+        "GPGPU-Sim PTX: skipping assembly for extern declared function "
+        "\'%s\'\n",
+        func_info->get_name().c_str());
+    return;
+  }
+  func_info->ptx_assemble();
 }

--- a/src/cuda-sim/ptx_ir.cc
+++ b/src/cuda-sim/ptx_ir.cc
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2011, Tor M. Aamodt, Ali Bakhoda, Wilson W.L. Fung,
-// George L. Yuan 
+// George L. Yuan
 // The University of British Columbia
 // All rights reserved.
 //
@@ -8,14 +8,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -26,1152 +28,1244 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "ptx_parser.h"
 #include "ptx_ir.h"
-typedef void * yyscan_t;
-#include "ptx.tab.h"
-#include "opcodes.h"
+#include "ptx_parser.h"
+typedef void *yyscan_t;
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <list>
-#include <assert.h>
 #include <algorithm>
+#include <list>
 #include "assert.h"
+#include "opcodes.h"
+#include "ptx.tab.h"
 
-#include "cuda-sim.h"
 #include "../../libcuda/gpgpu_context.h"
+#include "cuda-sim.h"
 
 #define STR_SIZE 1024
 
-const ptx_instruction* gpgpu_context::pc_to_instruction(unsigned pc) 
-{
-    if( pc < s_g_pc_to_insn.size() )
-	return s_g_pc_to_insn[pc];
+const ptx_instruction *gpgpu_context::pc_to_instruction(unsigned pc) {
+  if (pc < s_g_pc_to_insn.size())
+    return s_g_pc_to_insn[pc];
+  else
+    return NULL;
+}
+
+unsigned symbol::get_uid() {
+  unsigned result = (gpgpu_ctx->symbol_sm_next_uid)++;
+  return result;
+}
+
+void symbol::add_initializer(const std::list<operand_info> &init) {
+  m_initializer = init;
+}
+
+void symbol::print_info(FILE *fp) const {
+  fprintf(fp, "uid:%u, decl:%s, type:%p, ", m_uid, m_decl_location.c_str(),
+          m_type);
+  if (m_address_valid) fprintf(fp, "<address valid>, ");
+  if (m_is_label) fprintf(fp, " is_label ");
+  if (m_is_shared) fprintf(fp, " is_shared ");
+  if (m_is_const) fprintf(fp, " is_const ");
+  if (m_is_global) fprintf(fp, " is_global ");
+  if (m_is_local) fprintf(fp, " is_local ");
+  if (m_is_tex) fprintf(fp, " is_tex ");
+  if (m_is_func_addr) fprintf(fp, " is_func_addr ");
+  if (m_function) fprintf(fp, " %p ", m_function);
+}
+
+symbol_table::symbol_table() { assert(0); }
+
+symbol_table::symbol_table(const char *scope_name, unsigned entry_point,
+                           symbol_table *parent, gpgpu_context *ctx) {
+  gpgpu_ctx = ctx;
+  m_scope_name = std::string(scope_name);
+  m_reg_allocator = 0;
+  m_shared_next = 0;
+  m_const_next = 0;
+  m_global_next = 0x100;
+  m_local_next = 0;
+  m_tex_next = 0;
+
+  // Jin: handle instruction group for cdp
+  m_inst_group_id = 0;
+
+  m_parent = parent;
+  if (m_parent) {
+    m_shared_next = m_parent->m_shared_next;
+    m_global_next = m_parent->m_global_next;
+  }
+}
+
+void symbol_table::set_name(const char *name) {
+  m_scope_name = std::string(name);
+}
+
+const ptx_version &symbol_table::get_ptx_version() const {
+  if (m_parent == NULL)
+    return m_ptx_version;
+  else
+    return m_parent->get_ptx_version();
+}
+
+unsigned symbol_table::get_sm_target() const {
+  if (m_parent == NULL)
+    return m_ptx_version.target();
+  else
+    return m_parent->get_sm_target();
+}
+
+void symbol_table::set_ptx_version(float ver, unsigned ext) {
+  m_ptx_version = ptx_version(ver, ext);
+}
+
+void symbol_table::set_sm_target(const char *target, const char *ext,
+                                 const char *ext2) {
+  m_ptx_version.set_target(target, ext, ext2);
+}
+
+symbol *symbol_table::lookup(const char *identifier) {
+  std::string key(identifier);
+  std::map<std::string, symbol *>::iterator i = m_symbols.find(key);
+  if (i != m_symbols.end()) {
+    return i->second;
+  }
+  if (m_parent) {
+    return m_parent->lookup(identifier);
+  }
+  return NULL;
+}
+
+symbol *symbol_table::add_variable(const char *identifier,
+                                   const type_info *type, unsigned size,
+                                   const char *filename, unsigned line) {
+  char buf[1024];
+  std::string key(identifier);
+  assert(m_symbols.find(key) == m_symbols.end());
+  snprintf(buf, 1024, "%s:%u", filename, line);
+  symbol *s = new symbol(identifier, type, buf, size, gpgpu_ctx);
+  m_symbols[key] = s;
+
+  if (type != NULL && type->get_key().is_global()) {
+    m_globals.push_back(s);
+  }
+  if (type != NULL && type->get_key().is_const()) {
+    m_consts.push_back(s);
+  }
+
+  return s;
+}
+
+void symbol_table::add_function(function_info *func, const char *filename,
+                                unsigned linenumber) {
+  std::map<std::string, symbol *>::iterator i =
+      m_symbols.find(func->get_name());
+  if (i != m_symbols.end()) return;
+  char buf[1024];
+  snprintf(buf, 1024, "%s:%u", filename, linenumber);
+  type_info *type = add_type(func);
+  symbol *s = new symbol(func->get_name().c_str(), type, buf, 0, gpgpu_ctx);
+  s->set_function(func);
+  m_symbols[func->get_name()] = s;
+}
+
+// Jin: handle instruction group for cdp
+symbol_table *symbol_table::start_inst_group() {
+  char inst_group_name[4096];
+  snprintf(inst_group_name, 4096, "%s_inst_group_%u", m_scope_name.c_str(),
+           m_inst_group_id);
+
+  // previous added
+  assert(m_inst_group_symtab.find(std::string(inst_group_name)) ==
+         m_inst_group_symtab.end());
+  symbol_table *sym_table =
+      new symbol_table(inst_group_name, 3 /*inst group*/, this, gpgpu_ctx);
+
+  sym_table->m_global_next = m_global_next;
+  sym_table->m_shared_next = m_shared_next;
+  sym_table->m_local_next = m_local_next;
+  sym_table->m_reg_allocator = m_reg_allocator;
+  sym_table->m_tex_next = m_tex_next;
+  sym_table->m_const_next = m_const_next;
+
+  m_inst_group_symtab[std::string(inst_group_name)] = sym_table;
+
+  return sym_table;
+}
+
+symbol_table *symbol_table::end_inst_group() {
+  symbol_table *sym_table = m_parent;
+
+  sym_table->m_global_next = m_global_next;
+  sym_table->m_shared_next = m_shared_next;
+  sym_table->m_local_next = m_local_next;
+  sym_table->m_reg_allocator = m_reg_allocator;
+  sym_table->m_tex_next = m_tex_next;
+  sym_table->m_const_next = m_const_next;
+  sym_table->m_inst_group_id++;
+
+  return sym_table;
+}
+
+void register_ptx_function(const char *name,
+                           function_info *impl);  // either libcuda or libopencl
+
+bool symbol_table::add_function_decl(const char *name, int entry_point,
+                                     function_info **func_info,
+                                     symbol_table **sym_table) {
+  std::string key = std::string(name);
+  bool prior_decl = false;
+  if (m_function_info_lookup.find(key) != m_function_info_lookup.end()) {
+    *func_info = m_function_info_lookup[key];
+    prior_decl = true;
+  } else {
+    *func_info = new function_info(entry_point, gpgpu_ctx);
+    (*func_info)->set_name(name);
+    (*func_info)->set_maxnt_id(0);
+    m_function_info_lookup[key] = *func_info;
+  }
+
+  if (m_function_symtab_lookup.find(key) != m_function_symtab_lookup.end()) {
+    assert(prior_decl);
+    *sym_table = m_function_symtab_lookup[key];
+  } else {
+    assert(!prior_decl);
+    *sym_table = new symbol_table("", entry_point, this, gpgpu_ctx);
+
+    // Initial setup code to support a register represented as "_".
+    // This register is used when an instruction operand is
+    // not read or written.  However, the parser must recognize it
+    // as a legitimate register but we do not want to pass
+    // it to the micro-architectural register to the performance simulator.
+    // For this purpose we add a symbol to the symbol table but
+    // mark it as a non_arch_reg so it does not effect the performance sim.
+    type_info_key null_key(reg_space, 0, 0, 0, 0, 0);
+    null_key.set_is_non_arch_reg();
+    // First param is null - which is bad.
+    // However, the first parameter is actually unread in the constructor...
+    // TODO - remove the symbol_table* from type_info
+    type_info *null_type_info = new type_info(NULL, null_key);
+    symbol *null_reg =
+        (*sym_table)->add_variable("_", null_type_info, 0, "", 0);
+    null_reg->set_regno(0, 0);
+
+    (*sym_table)->set_name(name);
+    (*func_info)->set_symtab(*sym_table);
+    m_function_symtab_lookup[key] = *sym_table;
+    assert((*func_info)->get_symtab() == *sym_table);
+    register_ptx_function(name, *func_info);
+  }
+  return prior_decl;
+}
+
+function_info *symbol_table::lookup_function(std::string name) {
+  std::string key = std::string(name);
+  std::map<std::string, function_info *>::iterator it =
+      m_function_info_lookup.find(key);
+  assert(it != m_function_info_lookup.end());
+  return it->second;
+}
+
+type_info *symbol_table::add_type(memory_space_t space_spec,
+                                  int scalar_type_spec, int vector_spec,
+                                  int alignment_spec, int extern_spec) {
+  if (space_spec == param_space_unclassified) space_spec = param_space_local;
+  type_info_key t(space_spec, scalar_type_spec, vector_spec, alignment_spec,
+                  extern_spec, 0);
+  type_info *pt;
+  pt = new type_info(this, t);
+  return pt;
+}
+
+type_info *symbol_table::add_type(function_info *func) {
+  type_info_key t;
+  type_info *pt;
+  t.set_is_func();
+  pt = new type_info(this, t);
+  return pt;
+}
+
+type_info *symbol_table::get_array_type(type_info *base_type,
+                                        unsigned array_dim) {
+  type_info_key t = base_type->get_key();
+  t.set_array_dim(array_dim);
+  type_info *pt = new type_info(this, t);
+  // Where else is m_types being used? As of now, I dont find any use of it and
+  // causing seg fault. So disabling m_types.
+  // TODO: find where m_types can be used in future and solve the seg fault.
+  // pt = m_types[t] = new type_info(this,t);
+  return pt;
+}
+
+void symbol_table::set_label_address(const symbol *label, unsigned addr) {
+  std::map<std::string, symbol *>::iterator i = m_symbols.find(label->name());
+  assert(i != m_symbols.end());
+  symbol *s = i->second;
+  s->set_label_address(addr);
+}
+
+void symbol_table::dump() {
+  printf("\n\n");
+  printf("Symbol table for \"%s\":\n", m_scope_name.c_str());
+  std::map<std::string, symbol *>::iterator i;
+  for (i = m_symbols.begin(); i != m_symbols.end(); i++) {
+    printf("%30s : ", i->first.c_str());
+    if (i->second)
+      i->second->print_info(stdout);
     else
-	return NULL;
+      printf(" <no symbol object> ");
+    printf("\n");
+  }
+  printf("\n");
 }
 
-unsigned symbol::get_uid()
-{
-   unsigned result = (gpgpu_ctx->symbol_sm_next_uid)++;
-   return result;
+unsigned operand_info::get_uid() {
+  unsigned result = (gpgpu_ctx->operand_info_sm_next_uid)++;
+  return result;
 }
 
-void symbol::add_initializer( const std::list<operand_info> &init )
-{
-   m_initializer = init;
+std::list<ptx_instruction *>::iterator
+function_info::find_next_real_instruction(
+    std::list<ptx_instruction *>::iterator i) {
+  while ((i != m_instructions.end()) && (*i)->is_label()) i++;
+  return i;
 }
 
-void symbol::print_info(FILE *fp) const
-{
-   fprintf(fp,"uid:%u, decl:%s, type:%p, ", m_uid, m_decl_location.c_str(), m_type );
-   if( m_address_valid ) 
-      fprintf(fp,"<address valid>, ");
-   if( m_is_label )
-      fprintf(fp," is_label ");
-   if( m_is_shared )
-      fprintf(fp," is_shared ");
-   if( m_is_const )
-      fprintf(fp," is_const ");
-   if( m_is_global )
-      fprintf(fp," is_global ");
-   if( m_is_local )
-      fprintf(fp," is_local ");
-   if( m_is_tex )
-      fprintf(fp," is_tex ");
-   if( m_is_func_addr )
-      fprintf(fp," is_func_addr ");
-   if( m_function ) 
-      fprintf(fp," %p ", m_function );
-}
+void function_info::create_basic_blocks() {
+  std::list<ptx_instruction *> leaders;
+  std::list<ptx_instruction *>::iterator i, l;
 
-symbol_table::symbol_table() 
-{ 
-   assert(0); 
-}
-
-symbol_table::symbol_table( const char *scope_name, unsigned entry_point, symbol_table *parent, gpgpu_context* ctx )
-{
-   gpgpu_ctx = ctx;
-   m_scope_name = std::string(scope_name);
-   m_reg_allocator=0;
-   m_shared_next = 0;
-   m_const_next  = 0;
-   m_global_next = 0x100;
-   m_local_next  = 0;
-   m_tex_next = 0;
-
-   //Jin: handle instruction group for cdp
-   m_inst_group_id = 0;
-
-   m_parent = parent;
-   if ( m_parent ) {
-      m_shared_next = m_parent->m_shared_next;
-      m_global_next = m_parent->m_global_next;
-   }
-}
-
-void symbol_table::set_name( const char *name )
-{
-   m_scope_name = std::string(name);
-}
-
-const ptx_version &symbol_table::get_ptx_version() const 
-{ 
-   if( m_parent == NULL ) return m_ptx_version;
-   else return m_parent->get_ptx_version(); 
-}
-
-unsigned symbol_table::get_sm_target() const 
-{ 
-   if( m_parent == NULL ) 
-      return m_ptx_version.target();
-   else return m_parent->get_sm_target(); 
-}
-
-void symbol_table::set_ptx_version( float ver, unsigned ext ) 
-{ 
-   m_ptx_version = ptx_version(ver,ext); 
-}
-
-void symbol_table::set_sm_target( const char *target, const char *ext, const char *ext2 )
-{
-   m_ptx_version.set_target(target,ext,ext2);
-}
-
-symbol *symbol_table::lookup( const char *identifier ) 
-{
-   std::string key(identifier);
-   std::map<std::string, symbol *>::iterator i = m_symbols.find(key);
-   if (  i != m_symbols.end() ) {
-      return i->second;
-   }
-   if ( m_parent ) {
-      return m_parent->lookup(identifier);
-   }
-   return NULL;
-}
-
-symbol *symbol_table::add_variable( const char *identifier, const type_info *type, unsigned size, const char *filename, unsigned line )
-{
-   char buf[1024];
-   std::string key(identifier);
-   assert( m_symbols.find(key) == m_symbols.end() );
-   snprintf(buf,1024,"%s:%u",filename,line);
-   symbol *s = new symbol(identifier,type,buf,size,gpgpu_ctx);
-   m_symbols[ key ] = s;
-
-   if ( type != NULL && type->get_key().is_global()  ) {
-      m_globals.push_back(s);
-   }
-   if ( type != NULL && type->get_key().is_const()  ) {
-      m_consts.push_back(s);
-   }
-
-   return s;
-}
-
-void symbol_table::add_function( function_info *func, const char *filename, unsigned linenumber )
-{
-   std::map<std::string, symbol *>::iterator i = m_symbols.find( func->get_name() );
-   if( i != m_symbols.end() )
-      return;
-   char buf[1024];
-   snprintf(buf,1024,"%s:%u",filename,linenumber);
-   type_info *type = add_type( func );
-   symbol *s = new symbol(func->get_name().c_str(),type,buf,0,gpgpu_ctx);
-   s->set_function(func);
-   m_symbols[ func->get_name() ] = s;
-}
-
-//Jin: handle instruction group for cdp
-symbol_table* symbol_table::start_inst_group() {
-   char inst_group_name[4096];
-   snprintf(inst_group_name, 4096, "%s_inst_group_%u", m_scope_name.c_str(), m_inst_group_id);
-
-   //previous added
-   assert(m_inst_group_symtab.find(std::string(inst_group_name)) == m_inst_group_symtab.end());
-   symbol_table *sym_table = new symbol_table(inst_group_name, 3/*inst group*/, this, gpgpu_ctx );
- 
-   sym_table->m_global_next = m_global_next;
-   sym_table->m_shared_next = m_shared_next;
-   sym_table->m_local_next = m_local_next;
-   sym_table->m_reg_allocator = m_reg_allocator;
-   sym_table->m_tex_next = m_tex_next;
-   sym_table->m_const_next = m_const_next;
-
-   m_inst_group_symtab[std::string(inst_group_name)] = sym_table;
-
-   return sym_table;
-}
-
-symbol_table * symbol_table::end_inst_group() {
-   symbol_table * sym_table = m_parent;
-   
-   sym_table->m_global_next = m_global_next;
-   sym_table->m_shared_next = m_shared_next;
-   sym_table->m_local_next = m_local_next;
-   sym_table->m_reg_allocator = m_reg_allocator;
-   sym_table->m_tex_next = m_tex_next;
-   sym_table->m_const_next = m_const_next;
-   sym_table->m_inst_group_id++;
-
-   return sym_table;
-}
-
-void register_ptx_function( const char *name, function_info *impl ); // either libcuda or libopencl
-
-bool symbol_table::add_function_decl( const char *name, int entry_point, function_info **func_info, symbol_table **sym_table )
-{
-   std::string key = std::string(name);
-   bool prior_decl = false;
-   if( m_function_info_lookup.find(key) != m_function_info_lookup.end() ) {
-      *func_info = m_function_info_lookup[key];
-      prior_decl = true;
-   } else {
-      *func_info = new function_info(entry_point, gpgpu_ctx);
-      (*func_info)->set_name(name);
-      (*func_info)->set_maxnt_id(0);
-      m_function_info_lookup[key] = *func_info;
-   }
-
-   if( m_function_symtab_lookup.find(key) != m_function_symtab_lookup.end() ) {
-      assert( prior_decl );
-      *sym_table = m_function_symtab_lookup[key];
-   } else {
-      assert( !prior_decl );
-      *sym_table = new symbol_table( "", entry_point, this, gpgpu_ctx );
-      
-      // Initial setup code to support a register represented as "_".
-      // This register is used when an instruction operand is
-      // not read or written.  However, the parser must recognize it
-      // as a legitimate register but we do not want to pass
-      // it to the micro-architectural register to the performance simulator.
-      // For this purpose we add a symbol to the symbol table but
-      // mark it as a non_arch_reg so it does not effect the performance sim.
-      type_info_key null_key( reg_space, 0, 0, 0, 0, 0 );
-      null_key.set_is_non_arch_reg();
-      // First param is null - which is bad.
-      // However, the first parameter is actually unread in the constructor...
-      // TODO - remove the symbol_table* from type_info
-      type_info* null_type_info = new type_info( NULL, null_key );
-      symbol *null_reg = (*sym_table)->add_variable( "_", null_type_info, 0, "", 0 ); 
-      null_reg->set_regno(0, 0);
-      
-      (*sym_table)->set_name(name);
-      (*func_info)->set_symtab(*sym_table);
-      m_function_symtab_lookup[key] = *sym_table;
-      assert( (*func_info)->get_symtab() == *sym_table );
-      register_ptx_function(name,*func_info);
-   }
-   return prior_decl;
-}
-
-function_info *symbol_table::lookup_function( std::string name )
-{
-   std::string key = std::string(name);
-   std::map<std::string,function_info*>::iterator it = m_function_info_lookup.find(key);
-   assert ( it != m_function_info_lookup.end() );
-   return it->second;
-}
-
-type_info *symbol_table::add_type( memory_space_t space_spec, int scalar_type_spec, int vector_spec, int alignment_spec, int extern_spec )
-{
-   if( space_spec == param_space_unclassified ) 
-      space_spec = param_space_local;
-   type_info_key t(space_spec,scalar_type_spec,vector_spec,alignment_spec,extern_spec,0);
-   type_info *pt;
-   pt = new type_info(this,t);
-   return pt;
-}
-
-type_info *symbol_table::add_type( function_info *func )
-{
-   type_info_key t;
-   type_info *pt;
-   t.set_is_func();
-   pt = new type_info(this,t);
-   return pt;
-}
-
-type_info *symbol_table::get_array_type( type_info *base_type, unsigned array_dim ) 
-{
-   type_info_key t = base_type->get_key();
-   t.set_array_dim(array_dim);
-   type_info *pt = new type_info(this,t);
-   //Where else is m_types being used? As of now, I dont find any use of it and causing seg fault. So disabling m_types.
-   //TODO: find where m_types can be used in future and solve the seg fault.
-   //pt = m_types[t] = new type_info(this,t);
-   return pt;
-}
-
-void symbol_table::set_label_address( const symbol *label, unsigned addr )
-{
-   std::map<std::string, symbol *>::iterator i=m_symbols.find(label->name());
-   assert( i != m_symbols.end() );
-   symbol *s = i->second;
-   s->set_label_address(addr);
-}
-
-void symbol_table::dump()
-{
-   printf("\n\n");
-   printf("Symbol table for \"%s\":\n", m_scope_name.c_str() );
-   std::map<std::string, symbol *>::iterator i;
-   for( i=m_symbols.begin(); i!=m_symbols.end(); i++ ) {
-      printf("%30s : ", i->first.c_str() );
-      if( i->second ) 
-         i->second->print_info(stdout);
-      else
-         printf(" <no symbol object> ");
-      printf("\n");
-   }
-   printf("\n");
-}
-
-unsigned operand_info::get_uid()
-{
-   unsigned result = (gpgpu_ctx->operand_info_sm_next_uid)++;
-   return result;
-}
-
-std::list<ptx_instruction*>::iterator function_info::find_next_real_instruction( std::list<ptx_instruction*>::iterator i)
-{
-   while( (i != m_instructions.end()) && (*i)->is_label() ) 
-      i++;
-   return i;
-}
-
-void function_info::create_basic_blocks()
-{
-   std::list<ptx_instruction*> leaders;
-   std::list<ptx_instruction*>::iterator i, l;
-
-   // first instruction is a leader
-   i=m_instructions.begin();
-   leaders.push_back(*i);
-   i++;
-   while( i!=m_instructions.end() ) {
-      ptx_instruction *pI = *i;
-      if( pI->is_label() ) {
-         leaders.push_back(pI);
-         i = find_next_real_instruction(++i);
-      } else {
-         switch( pI->get_opcode() ) {
-         case BRA_OP: case RET_OP: case EXIT_OP: case RETP_OP: case BREAK_OP: 
+  // first instruction is a leader
+  i = m_instructions.begin();
+  leaders.push_back(*i);
+  i++;
+  while (i != m_instructions.end()) {
+    ptx_instruction *pI = *i;
+    if (pI->is_label()) {
+      leaders.push_back(pI);
+      i = find_next_real_instruction(++i);
+    } else {
+      switch (pI->get_opcode()) {
+        case BRA_OP:
+        case RET_OP:
+        case EXIT_OP:
+        case RETP_OP:
+        case BREAK_OP:
+          i++;
+          if (i != m_instructions.end()) leaders.push_back(*i);
+          i = find_next_real_instruction(i);
+          break;
+        case CALL_OP:
+        case CALLP_OP:
+          if (pI->has_pred()) {
+            printf("GPGPU-Sim PTX: Warning found predicated call\n");
             i++;
-            if( i != m_instructions.end() ) 
-               leaders.push_back(*i);
+            if (i != m_instructions.end()) leaders.push_back(*i);
             i = find_next_real_instruction(i);
-            break;
-         case CALL_OP: case CALLP_OP:
-            if( pI->has_pred() ) {
-               printf("GPGPU-Sim PTX: Warning found predicated call\n");
-               i++;
-               if( i != m_instructions.end() ) 
-                  leaders.push_back(*i);
-               i = find_next_real_instruction(i);
-            } else i++;
-            break;
-         default:
+          } else
             i++;
-         }
-      } 
-   }
-
-   if( leaders.empty() ) {
-      printf("GPGPU-Sim PTX: Function \'%s\' has no basic blocks\n", m_name.c_str());
-      return;
-   }
-
-   unsigned bb_id = 0;
-   l=leaders.begin();
-   i=m_instructions.begin();
-   m_basic_blocks.push_back( new basic_block_t(bb_id++,*find_next_real_instruction(i),NULL,1,0) );
-   ptx_instruction *last_real_inst=*(l++);
-
-   for( ; i!=m_instructions.end(); i++ ) {
-      ptx_instruction *pI = *i;
-      if( l != leaders.end() && *i == *l ) {
-         // found start of next basic block
-         m_basic_blocks.back()->ptx_end = last_real_inst;
-         if( find_next_real_instruction(i) != m_instructions.end() ) { // if not bogus trailing label
-            m_basic_blocks.push_back( new basic_block_t(bb_id++,*find_next_real_instruction(i),NULL,0,0) );
-            last_real_inst = *find_next_real_instruction(i);
-         }
-         // start search for next leader
-         l++;
+          break;
+        default:
+          i++;
       }
-      pI->assign_bb( m_basic_blocks.back() );
-      if( !pI->is_label() ) last_real_inst = pI;
-   }
-   m_basic_blocks.back()->ptx_end = last_real_inst;
-   m_basic_blocks.push_back( /*exit basic block*/ new basic_block_t(bb_id,NULL,NULL,0,1) );
+    }
+  }
+
+  if (leaders.empty()) {
+    printf("GPGPU-Sim PTX: Function \'%s\' has no basic blocks\n",
+           m_name.c_str());
+    return;
+  }
+
+  unsigned bb_id = 0;
+  l = leaders.begin();
+  i = m_instructions.begin();
+  m_basic_blocks.push_back(
+      new basic_block_t(bb_id++, *find_next_real_instruction(i), NULL, 1, 0));
+  ptx_instruction *last_real_inst = *(l++);
+
+  for (; i != m_instructions.end(); i++) {
+    ptx_instruction *pI = *i;
+    if (l != leaders.end() && *i == *l) {
+      // found start of next basic block
+      m_basic_blocks.back()->ptx_end = last_real_inst;
+      if (find_next_real_instruction(i) !=
+          m_instructions.end()) {  // if not bogus trailing label
+        m_basic_blocks.push_back(new basic_block_t(
+            bb_id++, *find_next_real_instruction(i), NULL, 0, 0));
+        last_real_inst = *find_next_real_instruction(i);
+      }
+      // start search for next leader
+      l++;
+    }
+    pI->assign_bb(m_basic_blocks.back());
+    if (!pI->is_label()) last_real_inst = pI;
+  }
+  m_basic_blocks.back()->ptx_end = last_real_inst;
+  m_basic_blocks.push_back(
+      /*exit basic block*/ new basic_block_t(bb_id, NULL, NULL, 0, 1));
 }
 
-void function_info::print_basic_blocks()
-{
-   printf("Printing basic blocks for function \'%s\':\n", m_name.c_str() );
-   std::list<ptx_instruction*>::iterator ptx_itr;
-   unsigned last_bb=0;
-   for (ptx_itr = m_instructions.begin();ptx_itr != m_instructions.end(); ptx_itr++) {
-      if( (*ptx_itr)->get_bb() ) {
-         if( (*ptx_itr)->get_bb()->bb_id != last_bb ) {
-            printf("\n");
-            last_bb = (*ptx_itr)->get_bb()->bb_id;
-         }
-         printf("bb_%02u\t: ", (*ptx_itr)->get_bb()->bb_id);
-         (*ptx_itr)->print_insn();
-         printf("\n");
+void function_info::print_basic_blocks() {
+  printf("Printing basic blocks for function \'%s\':\n", m_name.c_str());
+  std::list<ptx_instruction *>::iterator ptx_itr;
+  unsigned last_bb = 0;
+  for (ptx_itr = m_instructions.begin(); ptx_itr != m_instructions.end();
+       ptx_itr++) {
+    if ((*ptx_itr)->get_bb()) {
+      if ((*ptx_itr)->get_bb()->bb_id != last_bb) {
+        printf("\n");
+        last_bb = (*ptx_itr)->get_bb()->bb_id;
       }
-   }
-   printf("\nSummary of basic blocks for \'%s\':\n", m_name.c_str() );
-   std::vector<basic_block_t*>::iterator bb_itr;
-   for (bb_itr = m_basic_blocks.begin();bb_itr != m_basic_blocks.end(); bb_itr++) {
-      printf("bb_%02u\t:", (*bb_itr)->bb_id);
-      if ((*bb_itr)->ptx_begin)
-         printf(" first: %s\t", ((*bb_itr)->ptx_begin)->get_opcode_cstr());
-      else printf(" first: NULL\t");
-      if ((*bb_itr)->ptx_end) {
-         printf(" last: %s\t", ((*bb_itr)->ptx_end)->get_opcode_cstr());
-      } else printf(" last: NULL\t");
+      printf("bb_%02u\t: ", (*ptx_itr)->get_bb()->bb_id);
+      (*ptx_itr)->print_insn();
       printf("\n");
-   }
-   printf("\n");
+    }
+  }
+  printf("\nSummary of basic blocks for \'%s\':\n", m_name.c_str());
+  std::vector<basic_block_t *>::iterator bb_itr;
+  for (bb_itr = m_basic_blocks.begin(); bb_itr != m_basic_blocks.end();
+       bb_itr++) {
+    printf("bb_%02u\t:", (*bb_itr)->bb_id);
+    if ((*bb_itr)->ptx_begin)
+      printf(" first: %s\t", ((*bb_itr)->ptx_begin)->get_opcode_cstr());
+    else
+      printf(" first: NULL\t");
+    if ((*bb_itr)->ptx_end) {
+      printf(" last: %s\t", ((*bb_itr)->ptx_end)->get_opcode_cstr());
+    } else
+      printf(" last: NULL\t");
+    printf("\n");
+  }
+  printf("\n");
 }
 
-void function_info::print_basic_block_links()
-{
-   printf("Printing basic blocks links for function \'%s\':\n", m_name.c_str() );
-   std::vector<basic_block_t*>::iterator bb_itr;
-   for (bb_itr = m_basic_blocks.begin();bb_itr != m_basic_blocks.end(); bb_itr++) {
-      printf("ID: %d\t:", (*bb_itr)->bb_id);
-      if ( !(*bb_itr)->predecessor_ids.empty() ) {
-         printf("Predecessors:");
-         std::set<int>::iterator p;
-         for (p= (*bb_itr)->predecessor_ids.begin();p != (*bb_itr)->predecessor_ids.end();p++) {
-            printf(" %d", *p);
-         }
-         printf("\t");
+void function_info::print_basic_block_links() {
+  printf("Printing basic blocks links for function \'%s\':\n", m_name.c_str());
+  std::vector<basic_block_t *>::iterator bb_itr;
+  for (bb_itr = m_basic_blocks.begin(); bb_itr != m_basic_blocks.end();
+       bb_itr++) {
+    printf("ID: %d\t:", (*bb_itr)->bb_id);
+    if (!(*bb_itr)->predecessor_ids.empty()) {
+      printf("Predecessors:");
+      std::set<int>::iterator p;
+      for (p = (*bb_itr)->predecessor_ids.begin();
+           p != (*bb_itr)->predecessor_ids.end(); p++) {
+        printf(" %d", *p);
       }
-      if ( !(*bb_itr)->successor_ids.empty() ) {
-         printf("Successors:");
-         std::set<int>::iterator s;
-         for (s= (*bb_itr)->successor_ids.begin();s != (*bb_itr)->successor_ids.end();s++) {
-            printf(" %d", *s);
-         }
+      printf("\t");
+    }
+    if (!(*bb_itr)->successor_ids.empty()) {
+      printf("Successors:");
+      std::set<int>::iterator s;
+      for (s = (*bb_itr)->successor_ids.begin();
+           s != (*bb_itr)->successor_ids.end(); s++) {
+        printf(" %d", *s);
       }
-      printf("\n");
-   }
+    }
+    printf("\n");
+  }
 }
-operand_info* function_info::find_break_target( ptx_instruction * p_break_insn ) //find the target of a break instruction 
+operand_info *function_info::find_break_target(
+    ptx_instruction *p_break_insn)  // find the target of a break instruction
 {
-   const basic_block_t *break_bb = p_break_insn->get_bb(); 
-   // go through the dominator tree 
-   for(const basic_block_t *p_bb = break_bb; 
-       p_bb->immediatedominator_id != -1; 
-       p_bb = m_basic_blocks[p_bb->immediatedominator_id]) 
-   {
-      // reverse search through instructions in basic block for breakaddr instruction 
-      unsigned insn_addr = p_bb->ptx_end->get_m_instr_mem_index(); 
-      while (insn_addr >= p_bb->ptx_begin->get_m_instr_mem_index()) { 
-         ptx_instruction *pI = m_instr_mem[insn_addr]; 
-         insn_addr -= 1; 
-         if (pI == NULL) continue; // temporary solution for variable size instructions 
-         if (pI->get_opcode() == BREAKADDR_OP) {
-            return &(pI->dst()); 
-         }
-      }
-   }
-
-   assert(0); 
-
-   // lazy fallback: just traverse backwards? 
-   for (int insn_addr = p_break_insn->get_m_instr_mem_index(); 
-        insn_addr >= 0; insn_addr--) 
-   { 
-      ptx_instruction *pI = m_instr_mem[insn_addr]; 
+  const basic_block_t *break_bb = p_break_insn->get_bb();
+  // go through the dominator tree
+  for (const basic_block_t *p_bb = break_bb; p_bb->immediatedominator_id != -1;
+       p_bb = m_basic_blocks[p_bb->immediatedominator_id]) {
+    // reverse search through instructions in basic block for breakaddr
+    // instruction
+    unsigned insn_addr = p_bb->ptx_end->get_m_instr_mem_index();
+    while (insn_addr >= p_bb->ptx_begin->get_m_instr_mem_index()) {
+      ptx_instruction *pI = m_instr_mem[insn_addr];
+      insn_addr -= 1;
+      if (pI == NULL)
+        continue;  // temporary solution for variable size instructions
       if (pI->get_opcode() == BREAKADDR_OP) {
-         return &(pI->dst()); 
+        return &(pI->dst());
       }
-   }
+    }
+  }
 
-   return NULL; 
+  assert(0);
+
+  // lazy fallback: just traverse backwards?
+  for (int insn_addr = p_break_insn->get_m_instr_mem_index(); insn_addr >= 0;
+       insn_addr--) {
+    ptx_instruction *pI = m_instr_mem[insn_addr];
+    if (pI->get_opcode() == BREAKADDR_OP) {
+      return &(pI->dst());
+    }
+  }
+
+  return NULL;
 }
-void function_info::connect_basic_blocks( ) //iterate across m_basic_blocks of function, connecting basic blocks together
+void function_info::connect_basic_blocks()  // iterate across m_basic_blocks of
+                                            // function, connecting basic blocks
+                                            // together
 {
-   std::vector<basic_block_t*>::iterator bb_itr;
-   std::vector<basic_block_t*>::iterator bb_target_itr;
-   basic_block_t* exit_bb = m_basic_blocks.back();
+  std::vector<basic_block_t *>::iterator bb_itr;
+  std::vector<basic_block_t *>::iterator bb_target_itr;
+  basic_block_t *exit_bb = m_basic_blocks.back();
 
-   //start from first basic block, which we know is the entry point
-   bb_itr = m_basic_blocks.begin(); 
-   for (bb_itr = m_basic_blocks.begin();bb_itr != m_basic_blocks.end(); bb_itr++) {
-      ptx_instruction *pI = (*bb_itr)->ptx_end;
-      if ((*bb_itr)->is_exit) //reached last basic block, no successors to link 
-         continue;
-      if (pI->get_opcode() == RETP_OP || pI->get_opcode() == RET_OP || pI->get_opcode() == EXIT_OP ) {
-         (*bb_itr)->successor_ids.insert(exit_bb->bb_id);
-         exit_bb->predecessor_ids.insert((*bb_itr)->bb_id);
-         if( pI->has_pred() ) {
-            printf("GPGPU-Sim PTX: Warning detected predicated return/exit.\n");
-            // if predicated, add link to next block
-            unsigned next_addr = pI->get_m_instr_mem_index() + pI->inst_size();
-            if( next_addr < m_instr_mem_size && m_instr_mem[next_addr] ) {
-               basic_block_t *next_bb = m_instr_mem[next_addr]->get_bb();
-               (*bb_itr)->successor_ids.insert(next_bb->bb_id);
-               next_bb->predecessor_ids.insert((*bb_itr)->bb_id);
-            }
-         }
-         continue;
-      } else if (pI->get_opcode() == BRA_OP) {
-         //find successor and link that basic_block to this one
-         operand_info &target = pI->dst(); //get operand, e.g. target name
-         unsigned addr = labels[ target.name() ];
-         ptx_instruction *target_pI = m_instr_mem[addr];
-         basic_block_t *target_bb = target_pI->get_bb();
-         (*bb_itr)->successor_ids.insert(target_bb->bb_id);
-         target_bb->predecessor_ids.insert((*bb_itr)->bb_id);
-      } 
-
-      if ( !(pI->get_opcode()==BRA_OP && (!pI->has_pred())) ) { 
-         // if basic block does not end in an unpredicated branch, 
-         // then next basic block is also successor
-         // (this is better than testing for .uni)
-         unsigned next_addr = pI->get_m_instr_mem_index() + pI->inst_size();
-         basic_block_t *next_bb = m_instr_mem[next_addr]->get_bb();
-         (*bb_itr)->successor_ids.insert(next_bb->bb_id);
-         next_bb->predecessor_ids.insert((*bb_itr)->bb_id);
-      } else
-         assert(pI->get_opcode() == BRA_OP);
-   }
-}
-bool function_info::connect_break_targets() //connecting break instructions with proper targets
-{
-   std::vector<basic_block_t*>::iterator bb_itr;
-   std::vector<basic_block_t*>::iterator bb_target_itr;
-   bool modified = false; 
-
-   //start from first basic block, which we know is the entry point
-   bb_itr = m_basic_blocks.begin(); 
-   for (bb_itr = m_basic_blocks.begin();bb_itr != m_basic_blocks.end(); bb_itr++) {
-      basic_block_t *p_bb = *bb_itr; 
-      ptx_instruction *pI = p_bb->ptx_end;
-      if (p_bb->is_exit) //reached last basic block, no successors to link 
-         continue;
-      if (pI->get_opcode() == BREAK_OP) {
-         // backup existing successor_ids for stability check
-         std::set<int> orig_successor_ids = p_bb->successor_ids; 
-
-         // erase the previous linkage with old successors 
-         for(std::set<int>::iterator succ_ids = p_bb->successor_ids.begin(); succ_ids != p_bb->successor_ids.end(); ++succ_ids) {
-            basic_block_t *successor_bb = m_basic_blocks[*succ_ids];
-            successor_bb->predecessor_ids.erase(p_bb->bb_id); 
-         }
-         p_bb->successor_ids.clear(); 
-
-         //find successor and link that basic_block to this one
-         //successor of a break is set by an preceeding breakaddr instruction 
-         operand_info *target = find_break_target(pI); 
-         unsigned addr = labels[ target->name() ];
-         ptx_instruction *target_pI = m_instr_mem[addr];
-         basic_block_t *target_bb = target_pI->get_bb();
-         p_bb->successor_ids.insert(target_bb->bb_id);
-         target_bb->predecessor_ids.insert(p_bb->bb_id);
-
-         if (pI->has_pred()) {
-            // predicated break - add link to next basic block
-            unsigned next_addr = pI->get_m_instr_mem_index() + pI->inst_size();
-            basic_block_t *next_bb = m_instr_mem[next_addr]->get_bb();
-            p_bb->successor_ids.insert(next_bb->bb_id);
-            next_bb->predecessor_ids.insert(p_bb->bb_id);
-         }
-
-         modified = modified || (orig_successor_ids != p_bb->successor_ids); 
+  // start from first basic block, which we know is the entry point
+  bb_itr = m_basic_blocks.begin();
+  for (bb_itr = m_basic_blocks.begin(); bb_itr != m_basic_blocks.end();
+       bb_itr++) {
+    ptx_instruction *pI = (*bb_itr)->ptx_end;
+    if ((*bb_itr)->is_exit)  // reached last basic block, no successors to link
+      continue;
+    if (pI->get_opcode() == RETP_OP || pI->get_opcode() == RET_OP ||
+        pI->get_opcode() == EXIT_OP) {
+      (*bb_itr)->successor_ids.insert(exit_bb->bb_id);
+      exit_bb->predecessor_ids.insert((*bb_itr)->bb_id);
+      if (pI->has_pred()) {
+        printf("GPGPU-Sim PTX: Warning detected predicated return/exit.\n");
+        // if predicated, add link to next block
+        unsigned next_addr = pI->get_m_instr_mem_index() + pI->inst_size();
+        if (next_addr < m_instr_mem_size && m_instr_mem[next_addr]) {
+          basic_block_t *next_bb = m_instr_mem[next_addr]->get_bb();
+          (*bb_itr)->successor_ids.insert(next_bb->bb_id);
+          next_bb->predecessor_ids.insert((*bb_itr)->bb_id);
+        }
       }
-   }
+      continue;
+    } else if (pI->get_opcode() == BRA_OP) {
+      // find successor and link that basic_block to this one
+      operand_info &target = pI->dst();  // get operand, e.g. target name
+      unsigned addr = labels[target.name()];
+      ptx_instruction *target_pI = m_instr_mem[addr];
+      basic_block_t *target_bb = target_pI->get_bb();
+      (*bb_itr)->successor_ids.insert(target_bb->bb_id);
+      target_bb->predecessor_ids.insert((*bb_itr)->bb_id);
+    }
 
-   return modified; 
+    if (!(pI->get_opcode() == BRA_OP && (!pI->has_pred()))) {
+      // if basic block does not end in an unpredicated branch,
+      // then next basic block is also successor
+      // (this is better than testing for .uni)
+      unsigned next_addr = pI->get_m_instr_mem_index() + pI->inst_size();
+      basic_block_t *next_bb = m_instr_mem[next_addr]->get_bb();
+      (*bb_itr)->successor_ids.insert(next_bb->bb_id);
+      next_bb->predecessor_ids.insert((*bb_itr)->bb_id);
+    } else
+      assert(pI->get_opcode() == BRA_OP);
+  }
 }
-void function_info::do_pdom() 
+bool function_info::connect_break_targets()  // connecting break instructions
+                                             // with proper targets
 {
-   create_basic_blocks();
-   connect_basic_blocks();
-   bool modified = false; 
-   do {
-      find_dominators();
-      find_idominators();
-      modified = connect_break_targets(); 
-   } while (modified == true);
+  std::vector<basic_block_t *>::iterator bb_itr;
+  std::vector<basic_block_t *>::iterator bb_target_itr;
+  bool modified = false;
 
-   if ( g_debug_execution>=50 ) {
-      print_basic_blocks();
-      print_basic_block_links();
-      print_basic_block_dot();
-   }
-   if ( g_debug_execution>=2 ) {
-      print_dominators();
-   }
-   find_postdominators();
-   find_ipostdominators();
-   if ( g_debug_execution>=50 ) {
-      print_postdominators();
-      print_ipostdominators();
-   }
-   printf("GPGPU-Sim PTX: pre-decoding instructions for \'%s\'...\n", m_name.c_str() );
-   for ( unsigned ii=0; ii < m_n; ii += m_instr_mem[ii]->inst_size() ) { // handle branch instructions
-      ptx_instruction *pI = m_instr_mem[ii];
-      pI->pre_decode();
-   }
-   printf("GPGPU-Sim PTX: ... done pre-decoding instructions for \'%s\'.\n", m_name.c_str() );
-   fflush(stdout);
-   m_assembled = true;
-}
-void intersect( std::set<int> &A, const std::set<int> &B )
-{
-   // return intersection of A and B in A
-   for( std::set<int>::iterator a=A.begin(); a!=A.end(); ) {    
-      std::set<int>::iterator a_next = a;
-      a_next++;
-      if( B.find(*a) == B.end() ) {
-         A.erase(*a);
-         a = a_next;
-      } else 
-         a++;
-   }
-}
+  // start from first basic block, which we know is the entry point
+  bb_itr = m_basic_blocks.begin();
+  for (bb_itr = m_basic_blocks.begin(); bb_itr != m_basic_blocks.end();
+       bb_itr++) {
+    basic_block_t *p_bb = *bb_itr;
+    ptx_instruction *pI = p_bb->ptx_end;
+    if (p_bb->is_exit)  // reached last basic block, no successors to link
+      continue;
+    if (pI->get_opcode() == BREAK_OP) {
+      // backup existing successor_ids for stability check
+      std::set<int> orig_successor_ids = p_bb->successor_ids;
 
-bool is_equal( const std::set<int> &A, const std::set<int> &B )
-{
-   if( A.size() != B.size() ) 
-      return false;
-   for( std::set<int>::iterator b=B.begin(); b!=B.end(); b++ ) 
-      if( A.find(*b) == A.end() ) 
-         return false;
-   return true;
-}
-
-void print_set(const std::set<int> &A)
-{
-   std::set<int>::iterator a;
-   for (a= A.begin(); a != A.end(); a++) {
-      printf("%d ", (*a));
-   }
-   printf("\n");
-}
-
-void function_info::find_dominators( )
-{  
-   // find dominators using algorithm of Muchnick's Adv. Compiler Design & Implemmntation Fig 7.14 
-   printf("GPGPU-Sim PTX: Finding dominators for \'%s\'...\n", m_name.c_str() );
-   fflush(stdout);
-   assert( m_basic_blocks.size() >= 2 ); // must have a distinquished entry block
-   std::vector<basic_block_t*>::iterator bb_itr = m_basic_blocks.begin();
-   (*bb_itr)->dominator_ids.insert((*bb_itr)->bb_id);  // the only dominator of the entry block is the entry
-   //copy all basic blocks to all dominator lists EXCEPT for the entry block
-   for (++bb_itr;bb_itr != m_basic_blocks.end(); bb_itr++) { 
-      for (unsigned i = 0; i < m_basic_blocks.size(); i++) 
-         (*bb_itr)->dominator_ids.insert(i);
-   }
-   bool change = true;
-   while (change) {
-      change = false;
-      for ( int h = 1/*skip entry*/; h < m_basic_blocks.size(); ++h ) {
-         assert( m_basic_blocks[h]->bb_id == (unsigned)h );
-         std::set<int> T;
-         for (unsigned i=0;i< m_basic_blocks.size();i++) 
-            T.insert(i);
-         for ( std::set<int>::iterator s = m_basic_blocks[h]->predecessor_ids.begin();s != m_basic_blocks[h]->predecessor_ids.end();s++) 
-            intersect(T, m_basic_blocks[*s]->dominator_ids);
-         T.insert(h);
-         if (!is_equal(T, m_basic_blocks[h]->dominator_ids)) {
-            change = true;
-            m_basic_blocks[h]->dominator_ids = T;
-         }
+      // erase the previous linkage with old successors
+      for (std::set<int>::iterator succ_ids = p_bb->successor_ids.begin();
+           succ_ids != p_bb->successor_ids.end(); ++succ_ids) {
+        basic_block_t *successor_bb = m_basic_blocks[*succ_ids];
+        successor_bb->predecessor_ids.erase(p_bb->bb_id);
       }
-   }
-   //clean the basic block of dominators of it has no predecessors -- except for entry block
-   bb_itr = m_basic_blocks.begin();
-   for (++bb_itr;bb_itr != m_basic_blocks.end(); bb_itr++) {
-	  if ((*bb_itr)->predecessor_ids.empty())
-         (*bb_itr)->dominator_ids.clear();
-   }
-}
+      p_bb->successor_ids.clear();
 
-void function_info::find_postdominators( )
-{  
-   // find postdominators using algorithm of Muchnick's Adv. Compiler Design & Implemmntation Fig 7.14 
-   printf("GPGPU-Sim PTX: Finding postdominators for \'%s\'...\n", m_name.c_str() );
-   fflush(stdout);
-   assert( m_basic_blocks.size() >= 2 ); // must have a distinquished exit block
-   std::vector<basic_block_t*>::reverse_iterator bb_itr = m_basic_blocks.rbegin();
-   (*bb_itr)->postdominator_ids.insert((*bb_itr)->bb_id);  // the only postdominator of the exit block is the exit
-   for (++bb_itr;bb_itr != m_basic_blocks.rend();bb_itr++) { //copy all basic blocks to all postdominator lists EXCEPT for the exit block
-      for (unsigned i=0; i<m_basic_blocks.size(); i++) 
-         (*bb_itr)->postdominator_ids.insert(i);
-   }
-   bool change = true;
-   while (change) {
-      change = false;
-      for ( int h = m_basic_blocks.size()-2/*skip exit*/; h >= 0 ; --h ) {
-         assert( m_basic_blocks[h]->bb_id == (unsigned)h );
-         std::set<int> T;
-         for (unsigned i=0;i< m_basic_blocks.size();i++) 
-            T.insert(i);
-         for ( std::set<int>::iterator s = m_basic_blocks[h]->successor_ids.begin();s != m_basic_blocks[h]->successor_ids.end();s++) 
-            intersect(T, m_basic_blocks[*s]->postdominator_ids);
-         T.insert(h);
-         if (!is_equal(T,m_basic_blocks[h]->postdominator_ids)) {
-            change = true;
-            m_basic_blocks[h]->postdominator_ids = T;
-         }
+      // find successor and link that basic_block to this one
+      // successor of a break is set by an preceeding breakaddr instruction
+      operand_info *target = find_break_target(pI);
+      unsigned addr = labels[target->name()];
+      ptx_instruction *target_pI = m_instr_mem[addr];
+      basic_block_t *target_bb = target_pI->get_bb();
+      p_bb->successor_ids.insert(target_bb->bb_id);
+      target_bb->predecessor_ids.insert(p_bb->bb_id);
+
+      if (pI->has_pred()) {
+        // predicated break - add link to next basic block
+        unsigned next_addr = pI->get_m_instr_mem_index() + pI->inst_size();
+        basic_block_t *next_bb = m_instr_mem[next_addr]->get_bb();
+        p_bb->successor_ids.insert(next_bb->bb_id);
+        next_bb->predecessor_ids.insert(p_bb->bb_id);
       }
-   }
+
+      modified = modified || (orig_successor_ids != p_bb->successor_ids);
+    }
+  }
+
+  return modified;
+}
+void function_info::do_pdom() {
+  create_basic_blocks();
+  connect_basic_blocks();
+  bool modified = false;
+  do {
+    find_dominators();
+    find_idominators();
+    modified = connect_break_targets();
+  } while (modified == true);
+
+  if (g_debug_execution >= 50) {
+    print_basic_blocks();
+    print_basic_block_links();
+    print_basic_block_dot();
+  }
+  if (g_debug_execution >= 2) {
+    print_dominators();
+  }
+  find_postdominators();
+  find_ipostdominators();
+  if (g_debug_execution >= 50) {
+    print_postdominators();
+    print_ipostdominators();
+  }
+  printf("GPGPU-Sim PTX: pre-decoding instructions for \'%s\'...\n",
+         m_name.c_str());
+  for (unsigned ii = 0; ii < m_n;
+       ii += m_instr_mem[ii]->inst_size()) {  // handle branch instructions
+    ptx_instruction *pI = m_instr_mem[ii];
+    pI->pre_decode();
+  }
+  printf("GPGPU-Sim PTX: ... done pre-decoding instructions for \'%s\'.\n",
+         m_name.c_str());
+  fflush(stdout);
+  m_assembled = true;
+}
+void intersect(std::set<int> &A, const std::set<int> &B) {
+  // return intersection of A and B in A
+  for (std::set<int>::iterator a = A.begin(); a != A.end();) {
+    std::set<int>::iterator a_next = a;
+    a_next++;
+    if (B.find(*a) == B.end()) {
+      A.erase(*a);
+      a = a_next;
+    } else
+      a++;
+  }
 }
 
-void function_info::find_ipostdominators( )
-{  
-   // find immediate postdominator blocks, using algorithm of
-   // Muchnick's Adv. Compiler Design & Implemmntation Fig 7.15 
-   printf("GPGPU-Sim PTX: Finding immediate postdominators for \'%s\'...\n", m_name.c_str() );
-   fflush(stdout);
-   assert( m_basic_blocks.size() >= 2 ); // must have a distinquished exit block
-   for (unsigned i=0; i<m_basic_blocks.size(); i++) { //initialize Tmp(n) to all pdoms of n except for n
-      m_basic_blocks[i]->Tmp_ids = m_basic_blocks[i]->postdominator_ids;
-      assert( m_basic_blocks[i]->bb_id == i );
-      m_basic_blocks[i]->Tmp_ids.erase(i);
-   }
-   for ( int n = m_basic_blocks.size()-2; n >=0;--n) {
-      // point iterator to basic block before the exit
-      for( std::set<int>::iterator s=m_basic_blocks[n]->Tmp_ids.begin(); s != m_basic_blocks[n]->Tmp_ids.end(); s++ ) {
-         int bb_s = *s;
-         for( std::set<int>::iterator t=m_basic_blocks[n]->Tmp_ids.begin(); t != m_basic_blocks[n]->Tmp_ids.end(); ) {
-            std::set<int>::iterator t_next = t; t_next++; // might erase thing pointed to be t, invalidating iterator t
-            if( *s == *t ) {
-               t = t_next;
-               continue;
-            }
-            int bb_t = *t;
-            if( m_basic_blocks[bb_s]->postdominator_ids.find(bb_t) != m_basic_blocks[bb_s]->postdominator_ids.end() ) 
-                m_basic_blocks[n]->Tmp_ids.erase(bb_t);
-            t = t_next;
-         }
+bool is_equal(const std::set<int> &A, const std::set<int> &B) {
+  if (A.size() != B.size()) return false;
+  for (std::set<int>::iterator b = B.begin(); b != B.end(); b++)
+    if (A.find(*b) == A.end()) return false;
+  return true;
+}
+
+void print_set(const std::set<int> &A) {
+  std::set<int>::iterator a;
+  for (a = A.begin(); a != A.end(); a++) {
+    printf("%d ", (*a));
+  }
+  printf("\n");
+}
+
+void function_info::find_dominators() {
+  // find dominators using algorithm of Muchnick's Adv. Compiler Design &
+  // Implemmntation Fig 7.14
+  printf("GPGPU-Sim PTX: Finding dominators for \'%s\'...\n", m_name.c_str());
+  fflush(stdout);
+  assert(m_basic_blocks.size() >= 2);  // must have a distinquished entry block
+  std::vector<basic_block_t *>::iterator bb_itr = m_basic_blocks.begin();
+  (*bb_itr)->dominator_ids.insert(
+      (*bb_itr)->bb_id);  // the only dominator of the entry block is the entry
+  // copy all basic blocks to all dominator lists EXCEPT for the entry block
+  for (++bb_itr; bb_itr != m_basic_blocks.end(); bb_itr++) {
+    for (unsigned i = 0; i < m_basic_blocks.size(); i++)
+      (*bb_itr)->dominator_ids.insert(i);
+  }
+  bool change = true;
+  while (change) {
+    change = false;
+    for (int h = 1 /*skip entry*/; h < m_basic_blocks.size(); ++h) {
+      assert(m_basic_blocks[h]->bb_id == (unsigned)h);
+      std::set<int> T;
+      for (unsigned i = 0; i < m_basic_blocks.size(); i++) T.insert(i);
+      for (std::set<int>::iterator s =
+               m_basic_blocks[h]->predecessor_ids.begin();
+           s != m_basic_blocks[h]->predecessor_ids.end(); s++)
+        intersect(T, m_basic_blocks[*s]->dominator_ids);
+      T.insert(h);
+      if (!is_equal(T, m_basic_blocks[h]->dominator_ids)) {
+        change = true;
+        m_basic_blocks[h]->dominator_ids = T;
       }
-   }
-   unsigned num_ipdoms=0;
-   for ( int n = m_basic_blocks.size()-1; n >=0;--n) {
-      assert( m_basic_blocks[n]->Tmp_ids.size() <= 1 ); 
-         // if the above assert fails we have an error in either postdominator 
-         // computation, the flow graph does not have a unique exit, or some other error
-      if( !m_basic_blocks[n]->Tmp_ids.empty() ) {
-         m_basic_blocks[n]->immediatepostdominator_id = *m_basic_blocks[n]->Tmp_ids.begin();
-         num_ipdoms++;
+    }
+  }
+  // clean the basic block of dominators of it has no predecessors -- except for
+  // entry block
+  bb_itr = m_basic_blocks.begin();
+  for (++bb_itr; bb_itr != m_basic_blocks.end(); bb_itr++) {
+    if ((*bb_itr)->predecessor_ids.empty()) (*bb_itr)->dominator_ids.clear();
+  }
+}
+
+void function_info::find_postdominators() {
+  // find postdominators using algorithm of Muchnick's Adv. Compiler Design &
+  // Implemmntation Fig 7.14
+  printf("GPGPU-Sim PTX: Finding postdominators for \'%s\'...\n",
+         m_name.c_str());
+  fflush(stdout);
+  assert(m_basic_blocks.size() >= 2);  // must have a distinquished exit block
+  std::vector<basic_block_t *>::reverse_iterator bb_itr =
+      m_basic_blocks.rbegin();
+  (*bb_itr)->postdominator_ids.insert(
+      (*bb_itr)
+          ->bb_id);  // the only postdominator of the exit block is the exit
+  for (++bb_itr; bb_itr != m_basic_blocks.rend();
+       bb_itr++) {  // copy all basic blocks to all postdominator lists EXCEPT
+                    // for the exit block
+    for (unsigned i = 0; i < m_basic_blocks.size(); i++)
+      (*bb_itr)->postdominator_ids.insert(i);
+  }
+  bool change = true;
+  while (change) {
+    change = false;
+    for (int h = m_basic_blocks.size() - 2 /*skip exit*/; h >= 0; --h) {
+      assert(m_basic_blocks[h]->bb_id == (unsigned)h);
+      std::set<int> T;
+      for (unsigned i = 0; i < m_basic_blocks.size(); i++) T.insert(i);
+      for (std::set<int>::iterator s = m_basic_blocks[h]->successor_ids.begin();
+           s != m_basic_blocks[h]->successor_ids.end(); s++)
+        intersect(T, m_basic_blocks[*s]->postdominator_ids);
+      T.insert(h);
+      if (!is_equal(T, m_basic_blocks[h]->postdominator_ids)) {
+        change = true;
+        m_basic_blocks[h]->postdominator_ids = T;
       }
-   }
-   assert( num_ipdoms == m_basic_blocks.size()-1 ); 
-      // the exit node does not have an immediate post dominator, but everyone else should
+    }
+  }
 }
 
-void function_info::find_idominators( )
-{  
-   // find immediate dominator blocks, using algorithm of
-   // Muchnick's Adv. Compiler Design & Implemmntation Fig 7.15 
-   printf("GPGPU-Sim PTX: Finding immediate dominators for \'%s\'...\n", m_name.c_str() );
-   fflush(stdout);
-   assert( m_basic_blocks.size() >= 2 ); // must have a distinquished entry block
-   for (unsigned i=0; i<m_basic_blocks.size(); i++) { //initialize Tmp(n) to all doms of n except for n
-      m_basic_blocks[i]->Tmp_ids = m_basic_blocks[i]->dominator_ids;
-      assert( m_basic_blocks[i]->bb_id == i );
-      m_basic_blocks[i]->Tmp_ids.erase(i);
-   }
-   for ( int n = 0; n < m_basic_blocks.size(); ++n) {
-      // point iterator to basic block before the exit
-      for( std::set<int>::iterator s=m_basic_blocks[n]->Tmp_ids.begin(); s != m_basic_blocks[n]->Tmp_ids.end(); s++ ) {
-         int bb_s = *s;
-         for( std::set<int>::iterator t=m_basic_blocks[n]->Tmp_ids.begin(); t != m_basic_blocks[n]->Tmp_ids.end(); ) {
-            std::set<int>::iterator t_next = t; t_next++; // might erase thing pointed to be t, invalidating iterator t
-            if( *s == *t ) {
-               t = t_next;
-               continue;
-            }
-            int bb_t = *t;
-            if( m_basic_blocks[bb_s]->dominator_ids.find(bb_t) != m_basic_blocks[bb_s]->dominator_ids.end() ) 
-                m_basic_blocks[n]->Tmp_ids.erase(bb_t);
-            t = t_next;
-         }
+void function_info::find_ipostdominators() {
+  // find immediate postdominator blocks, using algorithm of
+  // Muchnick's Adv. Compiler Design & Implemmntation Fig 7.15
+  printf("GPGPU-Sim PTX: Finding immediate postdominators for \'%s\'...\n",
+         m_name.c_str());
+  fflush(stdout);
+  assert(m_basic_blocks.size() >= 2);  // must have a distinquished exit block
+  for (unsigned i = 0; i < m_basic_blocks.size();
+       i++) {  // initialize Tmp(n) to all pdoms of n except for n
+    m_basic_blocks[i]->Tmp_ids = m_basic_blocks[i]->postdominator_ids;
+    assert(m_basic_blocks[i]->bb_id == i);
+    m_basic_blocks[i]->Tmp_ids.erase(i);
+  }
+  for (int n = m_basic_blocks.size() - 2; n >= 0; --n) {
+    // point iterator to basic block before the exit
+    for (std::set<int>::iterator s = m_basic_blocks[n]->Tmp_ids.begin();
+         s != m_basic_blocks[n]->Tmp_ids.end(); s++) {
+      int bb_s = *s;
+      for (std::set<int>::iterator t = m_basic_blocks[n]->Tmp_ids.begin();
+           t != m_basic_blocks[n]->Tmp_ids.end();) {
+        std::set<int>::iterator t_next = t;
+        t_next++;  // might erase thing pointed to be t, invalidating iterator t
+        if (*s == *t) {
+          t = t_next;
+          continue;
+        }
+        int bb_t = *t;
+        if (m_basic_blocks[bb_s]->postdominator_ids.find(bb_t) !=
+            m_basic_blocks[bb_s]->postdominator_ids.end())
+          m_basic_blocks[n]->Tmp_ids.erase(bb_t);
+        t = t_next;
       }
-   }
-   unsigned num_idoms=0;
-   unsigned num_nopred = 0;
-   for ( int n = 0; n < m_basic_blocks.size(); ++n) {
-      //assert( m_basic_blocks[n]->Tmp_ids.size() <= 1 );
-         // if the above assert fails we have an error in either dominator
-         // computation, the flow graph does not have a unique entry, or some other error
-      if( !m_basic_blocks[n]->Tmp_ids.empty() ) {
-         m_basic_blocks[n]->immediatedominator_id = *m_basic_blocks[n]->Tmp_ids.begin();
-         num_idoms++;
-      } else if (m_basic_blocks[n]->predecessor_ids.empty()) {
-    	  num_nopred += 1;
+    }
+  }
+  unsigned num_ipdoms = 0;
+  for (int n = m_basic_blocks.size() - 1; n >= 0; --n) {
+    assert(m_basic_blocks[n]->Tmp_ids.size() <= 1);
+    // if the above assert fails we have an error in either postdominator
+    // computation, the flow graph does not have a unique exit, or some other
+    // error
+    if (!m_basic_blocks[n]->Tmp_ids.empty()) {
+      m_basic_blocks[n]->immediatepostdominator_id =
+          *m_basic_blocks[n]->Tmp_ids.begin();
+      num_ipdoms++;
+    }
+  }
+  assert(num_ipdoms == m_basic_blocks.size() - 1);
+  // the exit node does not have an immediate post dominator, but everyone else
+  // should
+}
+
+void function_info::find_idominators() {
+  // find immediate dominator blocks, using algorithm of
+  // Muchnick's Adv. Compiler Design & Implemmntation Fig 7.15
+  printf("GPGPU-Sim PTX: Finding immediate dominators for \'%s\'...\n",
+         m_name.c_str());
+  fflush(stdout);
+  assert(m_basic_blocks.size() >= 2);  // must have a distinquished entry block
+  for (unsigned i = 0; i < m_basic_blocks.size();
+       i++) {  // initialize Tmp(n) to all doms of n except for n
+    m_basic_blocks[i]->Tmp_ids = m_basic_blocks[i]->dominator_ids;
+    assert(m_basic_blocks[i]->bb_id == i);
+    m_basic_blocks[i]->Tmp_ids.erase(i);
+  }
+  for (int n = 0; n < m_basic_blocks.size(); ++n) {
+    // point iterator to basic block before the exit
+    for (std::set<int>::iterator s = m_basic_blocks[n]->Tmp_ids.begin();
+         s != m_basic_blocks[n]->Tmp_ids.end(); s++) {
+      int bb_s = *s;
+      for (std::set<int>::iterator t = m_basic_blocks[n]->Tmp_ids.begin();
+           t != m_basic_blocks[n]->Tmp_ids.end();) {
+        std::set<int>::iterator t_next = t;
+        t_next++;  // might erase thing pointed to be t, invalidating iterator t
+        if (*s == *t) {
+          t = t_next;
+          continue;
+        }
+        int bb_t = *t;
+        if (m_basic_blocks[bb_s]->dominator_ids.find(bb_t) !=
+            m_basic_blocks[bb_s]->dominator_ids.end())
+          m_basic_blocks[n]->Tmp_ids.erase(bb_t);
+        t = t_next;
       }
-   }
-   assert( num_idoms == m_basic_blocks.size()-num_nopred );
-      // the entry node does not have an immediate dominator, but everyone else should
+    }
+  }
+  unsigned num_idoms = 0;
+  unsigned num_nopred = 0;
+  for (int n = 0; n < m_basic_blocks.size(); ++n) {
+    // assert( m_basic_blocks[n]->Tmp_ids.size() <= 1 );
+    // if the above assert fails we have an error in either dominator
+    // computation, the flow graph does not have a unique entry, or some other
+    // error
+    if (!m_basic_blocks[n]->Tmp_ids.empty()) {
+      m_basic_blocks[n]->immediatedominator_id =
+          *m_basic_blocks[n]->Tmp_ids.begin();
+      num_idoms++;
+    } else if (m_basic_blocks[n]->predecessor_ids.empty()) {
+      num_nopred += 1;
+    }
+  }
+  assert(num_idoms == m_basic_blocks.size() - num_nopred);
+  // the entry node does not have an immediate dominator, but everyone else
+  // should
 }
 
-void function_info::print_dominators()
-{
-   printf("Printing dominators for function \'%s\':\n", m_name.c_str() );
-   std::vector<int>::iterator bb_itr;
-   for (unsigned i = 0; i < m_basic_blocks.size(); i++) {
-      printf("ID: %d\t:", i);
-      for( std::set<int>::iterator j=m_basic_blocks[i]->dominator_ids.begin(); j!=m_basic_blocks[i]->dominator_ids.end(); j++) 
-         printf(" %d", *j );
-      printf("\n");
-   }
+void function_info::print_dominators() {
+  printf("Printing dominators for function \'%s\':\n", m_name.c_str());
+  std::vector<int>::iterator bb_itr;
+  for (unsigned i = 0; i < m_basic_blocks.size(); i++) {
+    printf("ID: %d\t:", i);
+    for (std::set<int>::iterator j = m_basic_blocks[i]->dominator_ids.begin();
+         j != m_basic_blocks[i]->dominator_ids.end(); j++)
+      printf(" %d", *j);
+    printf("\n");
+  }
 }
 
-void function_info::print_postdominators()
-{
-   printf("Printing postdominators for function \'%s\':\n", m_name.c_str() );
-   std::vector<int>::iterator bb_itr;
-   for (unsigned i = 0; i < m_basic_blocks.size(); i++) {
-      printf("ID: %d\t:", i);
-      for( std::set<int>::iterator j=m_basic_blocks[i]->postdominator_ids.begin(); j!=m_basic_blocks[i]->postdominator_ids.end(); j++) 
-         printf(" %d", *j );
-      printf("\n");
-   }
+void function_info::print_postdominators() {
+  printf("Printing postdominators for function \'%s\':\n", m_name.c_str());
+  std::vector<int>::iterator bb_itr;
+  for (unsigned i = 0; i < m_basic_blocks.size(); i++) {
+    printf("ID: %d\t:", i);
+    for (std::set<int>::iterator j =
+             m_basic_blocks[i]->postdominator_ids.begin();
+         j != m_basic_blocks[i]->postdominator_ids.end(); j++)
+      printf(" %d", *j);
+    printf("\n");
+  }
 }
 
-void function_info::print_ipostdominators()
-{
-   printf("Printing immediate postdominators for function \'%s\':\n", m_name.c_str() );
-   std::vector<int>::iterator bb_itr;
-   for (unsigned i = 0; i < m_basic_blocks.size(); i++) {
-      printf("ID: %d\t:", i);
-      printf("%d\n", m_basic_blocks[i]->immediatepostdominator_id);
-   }
+void function_info::print_ipostdominators() {
+  printf("Printing immediate postdominators for function \'%s\':\n",
+         m_name.c_str());
+  std::vector<int>::iterator bb_itr;
+  for (unsigned i = 0; i < m_basic_blocks.size(); i++) {
+    printf("ID: %d\t:", i);
+    printf("%d\n", m_basic_blocks[i]->immediatepostdominator_id);
+  }
 }
 
-void function_info::print_idominators()
-{
-   printf("Printing immediate dominators for function \'%s\':\n", m_name.c_str() );
-   std::vector<int>::iterator bb_itr;
-   for (unsigned i = 0; i < m_basic_blocks.size(); i++) {
-      printf("ID: %d\t:", i);
-      printf("%d\n", m_basic_blocks[i]->immediatedominator_id);
-   }
+void function_info::print_idominators() {
+  printf("Printing immediate dominators for function \'%s\':\n",
+         m_name.c_str());
+  std::vector<int>::iterator bb_itr;
+  for (unsigned i = 0; i < m_basic_blocks.size(); i++) {
+    printf("ID: %d\t:", i);
+    printf("%d\n", m_basic_blocks[i]->immediatedominator_id);
+  }
 }
 
-unsigned function_info::get_num_reconvergence_pairs()
-{
-   if (!num_reconvergence_pairs) {
-      if( m_basic_blocks.size() == 0 ) 
-         return 0;
-      for (unsigned i=0; i< (m_basic_blocks.size()-1); i++) { //last basic block containing exit obviously won't have a pair
-         if (m_basic_blocks[i]->ptx_end->get_opcode() == BRA_OP) {
-            num_reconvergence_pairs++;
-         }
-      }
-   }
-   return num_reconvergence_pairs;
-}
-
-void function_info::get_reconvergence_pairs(gpgpu_recon_t* recon_points)
-{
-   unsigned idx=0; //array index
-   if( m_basic_blocks.size() == 0 ) 
-       return;
-   for (unsigned i=0; i< (m_basic_blocks.size()-1); i++) { //last basic block containing exit obviously won't have a pair
-#ifdef DEBUG_GET_RECONVERG_PAIRS
-      printf("i=%d\n", i); fflush(stdout);
-#endif
+unsigned function_info::get_num_reconvergence_pairs() {
+  if (!num_reconvergence_pairs) {
+    if (m_basic_blocks.size() == 0) return 0;
+    for (unsigned i = 0; i < (m_basic_blocks.size() - 1);
+         i++) {  // last basic block containing exit obviously won't have a pair
       if (m_basic_blocks[i]->ptx_end->get_opcode() == BRA_OP) {
-#ifdef DEBUG_GET_RECONVERG_PAIRS
-         printf("\tbranch!\n");
-         printf("\tbb_id=%d; ipdom=%d\n", m_basic_blocks[i]->bb_id, m_basic_blocks[i]->immediatepostdominator_id);
-         printf("\tm_instr_mem index=%d\n", m_basic_blocks[i]->ptx_end->get_m_instr_mem_index());
-         fflush(stdout);
-#endif
-         recon_points[idx].source_pc = m_basic_blocks[i]->ptx_end->get_PC();
-         recon_points[idx].source_inst = m_basic_blocks[i]->ptx_end;
-#ifdef DEBUG_GET_RECONVERG_PAIRS
-         printf("\trecon_points[idx].source_pc=%d\n", recon_points[idx].source_pc);
-#endif
-         if( m_basic_blocks[m_basic_blocks[i]->immediatepostdominator_id]->ptx_begin ) {
-            recon_points[idx].target_pc = m_basic_blocks[m_basic_blocks[i]->immediatepostdominator_id]->ptx_begin->get_PC();
-            recon_points[idx].target_inst = m_basic_blocks[m_basic_blocks[i]->immediatepostdominator_id]->ptx_begin;
-         } else {
-            // reconverge after function return
-            recon_points[idx].target_pc = -2;
-            recon_points[idx].target_inst = NULL;
-         }
-#ifdef DEBUG_GET_RECONVERG_PAIRS
-         m_basic_blocks[m_basic_blocks[i]->immediatepostdominator_id]->ptx_begin->print_insn();
-         printf("\trecon_points[idx].target_pc=%d\n", recon_points[idx].target_pc); fflush(stdout);
-#endif
-         idx++;
+        num_reconvergence_pairs++;
       }
-   }
+    }
+  }
+  return num_reconvergence_pairs;
+}
+
+void function_info::get_reconvergence_pairs(gpgpu_recon_t *recon_points) {
+  unsigned idx = 0;  // array index
+  if (m_basic_blocks.size() == 0) return;
+  for (unsigned i = 0; i < (m_basic_blocks.size() - 1);
+       i++) {  // last basic block containing exit obviously won't have a pair
+#ifdef DEBUG_GET_RECONVERG_PAIRS
+    printf("i=%d\n", i);
+    fflush(stdout);
+#endif
+    if (m_basic_blocks[i]->ptx_end->get_opcode() == BRA_OP) {
+#ifdef DEBUG_GET_RECONVERG_PAIRS
+      printf("\tbranch!\n");
+      printf("\tbb_id=%d; ipdom=%d\n", m_basic_blocks[i]->bb_id,
+             m_basic_blocks[i]->immediatepostdominator_id);
+      printf("\tm_instr_mem index=%d\n",
+             m_basic_blocks[i]->ptx_end->get_m_instr_mem_index());
+      fflush(stdout);
+#endif
+      recon_points[idx].source_pc = m_basic_blocks[i]->ptx_end->get_PC();
+      recon_points[idx].source_inst = m_basic_blocks[i]->ptx_end;
+#ifdef DEBUG_GET_RECONVERG_PAIRS
+      printf("\trecon_points[idx].source_pc=%d\n", recon_points[idx].source_pc);
+#endif
+      if (m_basic_blocks[m_basic_blocks[i]->immediatepostdominator_id]
+              ->ptx_begin) {
+        recon_points[idx].target_pc =
+            m_basic_blocks[m_basic_blocks[i]->immediatepostdominator_id]
+                ->ptx_begin->get_PC();
+        recon_points[idx].target_inst =
+            m_basic_blocks[m_basic_blocks[i]->immediatepostdominator_id]
+                ->ptx_begin;
+      } else {
+        // reconverge after function return
+        recon_points[idx].target_pc = -2;
+        recon_points[idx].target_inst = NULL;
+      }
+#ifdef DEBUG_GET_RECONVERG_PAIRS
+      m_basic_blocks[m_basic_blocks[i]->immediatepostdominator_id]
+          ->ptx_begin->print_insn();
+      printf("\trecon_points[idx].target_pc=%d\n", recon_points[idx].target_pc);
+      fflush(stdout);
+#endif
+      idx++;
+    }
+  }
 }
 
 // interface with graphviz (print the graph in DOT language) for plotting
-void function_info::print_basic_block_dot()
-{
-   printf("Basic Block in DOT\n");
-   printf("digraph %s {\n", m_name.c_str());
-   std::vector<basic_block_t*>::iterator bb_itr;
-   for (bb_itr = m_basic_blocks.begin();bb_itr != m_basic_blocks.end(); bb_itr++) {
-      printf("\t");
-      std::set<int>::iterator s;
-      for (s = (*bb_itr)->successor_ids.begin();s != (*bb_itr)->successor_ids.end();s++) {
-         unsigned succ_bb = *s;
-         printf("%d -> %d; ", (*bb_itr)->bb_id, succ_bb );
-      }
-      printf("\n");
-   }
-   printf("}\n");
-}
-
-unsigned ptx_kernel_shmem_size( void *kernel_impl )
-{
-   function_info *f = (function_info*)kernel_impl;
-   const struct gpgpu_ptx_sim_info *kernel_info = f->get_kernel_info();
-   return kernel_info->smem;
-}
-
-unsigned ptx_kernel_nregs( void *kernel_impl )
-{
-   function_info *f = (function_info*)kernel_impl;
-   const struct gpgpu_ptx_sim_info *kernel_info = f->get_kernel_info();
-   return kernel_info->regs;
-}
-
-unsigned type_info_key::type_decode( size_t &size, int &basic_type ) const
-{
-   int type = scalar_type();
-   return type_decode(type,size,basic_type);
-}
-
-unsigned type_info_key::type_decode( int type, size_t &size, int &basic_type )
-{
-   switch ( type ) {
-   case S8_TYPE:  size=8;  basic_type=1; return 0;
-   case S16_TYPE: size=16; basic_type=1; return 1;
-   case S32_TYPE: size=32; basic_type=1; return 2;
-   case S64_TYPE: size=64; basic_type=1; return 3;
-   case U8_TYPE:  size=8;  basic_type=0; return 4;
-   case U16_TYPE: size=16; basic_type=0; return 5;
-   case U32_TYPE: size=32; basic_type=0; return 6;
-   case U64_TYPE: size=64; basic_type=0; return 7;
-   case F16_TYPE: size=16; basic_type=-1; return 8;
-   case F32_TYPE: size=32; basic_type=-1; return 9;
-   case F64_TYPE: size=64; basic_type=-1; return 10;
-   case FF64_TYPE: size=64; basic_type=-1; return 10;
-   case PRED_TYPE: size=1; basic_type=2; return 11;
-   case B8_TYPE:  size=8;  basic_type=0; return 12;
-   case B16_TYPE: size=16; basic_type=0; return 13;
-   case B32_TYPE: size=32; basic_type=0; return 14;
-   case B64_TYPE: size=64; basic_type=0; return 15;
-   case BB64_TYPE: size=64; basic_type=0; return 15;
-   case BB128_TYPE: size=128; basic_type=0; return 16;
-   case TEXREF_TYPE: case SAMPLERREF_TYPE: case SURFREF_TYPE:
-      size=32; basic_type=3; return 16;
-   default: 
-      printf("ERROR ** type_decode() does not know about \"%s\"\n", decode_token(type) ); 
-      assert(0); 
-      return 0xDEADBEEF;
-   }
-}
-
-arg_buffer_t copy_arg_to_buffer(ptx_thread_info * thread, operand_info actual_param_op, const symbol * formal_param)
-{
-   if( actual_param_op.is_reg() )  {
-      ptx_reg_t value = thread->get_reg(actual_param_op.get_symbol());
-      return arg_buffer_t(formal_param,actual_param_op,value);
-   } else if ( actual_param_op.is_param_local() ) {
-      unsigned size=formal_param->get_size_in_bytes();
-      addr_t frame_offset = actual_param_op.get_symbol()->get_address();
-      addr_t from_addr = thread->get_local_mem_stack_pointer() + frame_offset;
-      char buffer[1024];
-      assert(size<1024); 
-      thread->m_local_mem->read(from_addr,size,buffer);
-      return arg_buffer_t(formal_param,actual_param_op,buffer,size);
-   } else {
-      printf("GPGPU-Sim PTX: ERROR ** need to add support for this operand type in call/return\n");
-      abort();
-   }
-}
-
-void copy_args_into_buffer_list( const ptx_instruction * pI, 
-                                 ptx_thread_info * thread, 
-                                 const function_info * target_func, 
-                                 arg_buffer_list_t &arg_values ) 
-{
-   unsigned n_return = target_func->has_return();
-   unsigned n_args = target_func->num_args();
-   for( unsigned arg=0; arg < n_args; arg ++ ) {
-      const operand_info &actual_param_op = pI->operand_lookup(n_return+1+arg);
-      const symbol *formal_param = target_func->get_arg(arg);
-      arg_values.push_back( copy_arg_to_buffer(thread, actual_param_op, formal_param) );
-   }
-}
-
-void copy_buffer_to_frame(ptx_thread_info * thread, const arg_buffer_t &a) 
-{
-   if( a.is_reg() ) {
-      ptx_reg_t value = a.get_reg();
-      operand_info dst_reg = operand_info(a.get_dst(), thread->get_gpu()->gpgpu_ctx); 
-      thread->set_reg(dst_reg.get_symbol(),value);
-   } else {  
-      const void *buffer = a.get_param_buffer();
-      size_t size = a.get_param_buffer_size();
-      const symbol *dst = a.get_dst();
-      addr_t frame_offset = dst->get_address();
-      addr_t to_addr = thread->get_local_mem_stack_pointer() + frame_offset;
-      thread->m_local_mem->write(to_addr,size,buffer,NULL,NULL);
-   }
-}
-
-void copy_buffer_list_into_frame(ptx_thread_info * thread, arg_buffer_list_t &arg_values) 
-{
-   arg_buffer_list_t::iterator a;
-   for( a=arg_values.begin(); a != arg_values.end(); a++ ) {
-      copy_buffer_to_frame(thread, *a);
-   }
-}
-
-
-
-static std::list<operand_info> check_operands( int opcode,
-                                        const std::list<int> &scalar_type,
-                                        const std::list<operand_info> &operands,
-					gpgpu_context* ctx)
-{
-   static int g_warn_literal_operands_two_type_inst;
-    if( (opcode == CVT_OP) || (opcode == SET_OP) || (opcode == SLCT_OP) || (opcode == TEX_OP) || (opcode==MMA_OP) || (opcode == DP4A_OP)) {
-        // just make sure these do not have have const operands... 
-        if( !g_warn_literal_operands_two_type_inst ) {
-            std::list<operand_info>::const_iterator o;
-            for( o = operands.begin(); o != operands.end(); o++ ) {
-                const operand_info &op = *o;
-                if( op.is_literal() ) {
-                    printf("GPGPU-Sim PTX: PTX uses two scalar type intruction with literal operand.\n");
-                    g_warn_literal_operands_two_type_inst = 1;
-                }
-            }
-        }
-    } else {
-        assert( scalar_type.size() < 2 );
-        if( scalar_type.size() == 1 ) {
-            std::list<operand_info> result;
-            int inst_type = scalar_type.front();
-            std::list<operand_info>::const_iterator o;
-            for( o = operands.begin(); o != operands.end(); o++ ) {
-                const operand_info &op = *o;
-                if( op.is_literal() ) {
-                    if( (op.get_type() == double_op_t) && (inst_type == F32_TYPE) ) {
-                        ptx_reg_t v = op.get_literal_value();
-                        float u = (float)v.f64;
-                        operand_info n(u, ctx);
-                        result.push_back(n);
-                    } else {
-                        result.push_back(op);
-                    }
-                } else {
-                        result.push_back(op);
-                }
-            }
-            return result;
-        } 
+void function_info::print_basic_block_dot() {
+  printf("Basic Block in DOT\n");
+  printf("digraph %s {\n", m_name.c_str());
+  std::vector<basic_block_t *>::iterator bb_itr;
+  for (bb_itr = m_basic_blocks.begin(); bb_itr != m_basic_blocks.end();
+       bb_itr++) {
+    printf("\t");
+    std::set<int>::iterator s;
+    for (s = (*bb_itr)->successor_ids.begin();
+         s != (*bb_itr)->successor_ids.end(); s++) {
+      unsigned succ_bb = *s;
+      printf("%d -> %d; ", (*bb_itr)->bb_id, succ_bb);
     }
-    return operands;
+    printf("\n");
+  }
+  printf("}\n");
 }
 
+unsigned ptx_kernel_shmem_size(void *kernel_impl) {
+  function_info *f = (function_info *)kernel_impl;
+  const struct gpgpu_ptx_sim_info *kernel_info = f->get_kernel_info();
+  return kernel_info->smem;
+}
 
-ptx_instruction::ptx_instruction( int opcode, 
-                                  const symbol *pred, 
-                                  int neg_pred, 
-                                  int pred_mod,
-                                  symbol *label,
-                                  const std::list<operand_info> &operands, 
-                                  const operand_info &return_var,
-                                  const std::list<int> &options, 
-                                  const std::list<int> &wmma_options, 
-                                  const std::list<int> &scalar_type,
-                                  memory_space_t space_spec,
-                                  const char *file, 
-                                  unsigned line,
-                                  const char *source,
-                                  const core_config *config,
-				  gpgpu_context* ctx ) : warp_inst_t(config), m_return_var(ctx)
-{
-   gpgpu_ctx = ctx;
-   m_uid = ++(ctx->g_num_ptx_inst_uid);
-   m_PC = 0;
-   m_opcode = opcode;
-   m_pred = pred;
-   m_neg_pred = neg_pred;
-   m_pred_mod = pred_mod;
-   m_label = label;
-   const std::list<operand_info> checked_operands = check_operands(opcode,scalar_type,operands, ctx);
-   m_operands.insert(m_operands.begin(), checked_operands.begin(), checked_operands.end() );
-   m_return_var = return_var;
-   m_options = options;
-   m_wmma_options = wmma_options;
-   m_wide = false;
-   m_hi = false;
-   m_lo = false;
-   m_uni = false;
-   m_exit = false;
-   m_abs = false;
-   m_neg = false;
-   m_to_option = false;
-   m_cache_option = 0;
-   m_rounding_mode = RN_OPTION;
-   m_compare_op = -1;
-   m_saturation_mode = 0;
-   m_geom_spec = 0;
-   m_vector_spec = 0;
-   m_atomic_spec = 0;
-   m_membar_level = 0;
-   m_inst_size = 8; // bytes
-   int rr=0;
-   std::list<int>::const_iterator i;
-   unsigned n=1;
-   for ( i=wmma_options.begin(); i!= wmma_options.end(); i++, n++ ) {
-      int last_ptx_inst_option = *i;
-      switch ( last_ptx_inst_option ) {
-      		case SYNC_OPTION:
-      		case LOAD_A:
-      		case LOAD_B:
-      		case LOAD_C:
-      		case STORE_D:
-      		case MMA:
-      		  m_wmma_type=last_ptx_inst_option;
-      		  break;
-      		case ROW:
-      		case COL:
-      		  m_wmma_layout[rr++]=last_ptx_inst_option;
-      		  break;
-      		case M16N16K16:
-      		case M32N8K16:
-      		case M8N32K16:
-			break;
-      		default:
-      		   assert(0);
-      		   break;
-	}
-   }
-   rr=0;
-   n=1;
-   for ( i=options.begin(); i!= options.end(); i++, n++ ) {
-      int last_ptx_inst_option = *i;
-      switch ( last_ptx_inst_option ) {
+unsigned ptx_kernel_nregs(void *kernel_impl) {
+  function_info *f = (function_info *)kernel_impl;
+  const struct gpgpu_ptx_sim_info *kernel_info = f->get_kernel_info();
+  return kernel_info->regs;
+}
+
+unsigned type_info_key::type_decode(size_t &size, int &basic_type) const {
+  int type = scalar_type();
+  return type_decode(type, size, basic_type);
+}
+
+unsigned type_info_key::type_decode(int type, size_t &size, int &basic_type) {
+  switch (type) {
+    case S8_TYPE:
+      size = 8;
+      basic_type = 1;
+      return 0;
+    case S16_TYPE:
+      size = 16;
+      basic_type = 1;
+      return 1;
+    case S32_TYPE:
+      size = 32;
+      basic_type = 1;
+      return 2;
+    case S64_TYPE:
+      size = 64;
+      basic_type = 1;
+      return 3;
+    case U8_TYPE:
+      size = 8;
+      basic_type = 0;
+      return 4;
+    case U16_TYPE:
+      size = 16;
+      basic_type = 0;
+      return 5;
+    case U32_TYPE:
+      size = 32;
+      basic_type = 0;
+      return 6;
+    case U64_TYPE:
+      size = 64;
+      basic_type = 0;
+      return 7;
+    case F16_TYPE:
+      size = 16;
+      basic_type = -1;
+      return 8;
+    case F32_TYPE:
+      size = 32;
+      basic_type = -1;
+      return 9;
+    case F64_TYPE:
+      size = 64;
+      basic_type = -1;
+      return 10;
+    case FF64_TYPE:
+      size = 64;
+      basic_type = -1;
+      return 10;
+    case PRED_TYPE:
+      size = 1;
+      basic_type = 2;
+      return 11;
+    case B8_TYPE:
+      size = 8;
+      basic_type = 0;
+      return 12;
+    case B16_TYPE:
+      size = 16;
+      basic_type = 0;
+      return 13;
+    case B32_TYPE:
+      size = 32;
+      basic_type = 0;
+      return 14;
+    case B64_TYPE:
+      size = 64;
+      basic_type = 0;
+      return 15;
+    case BB64_TYPE:
+      size = 64;
+      basic_type = 0;
+      return 15;
+    case BB128_TYPE:
+      size = 128;
+      basic_type = 0;
+      return 16;
+    case TEXREF_TYPE:
+    case SAMPLERREF_TYPE:
+    case SURFREF_TYPE:
+      size = 32;
+      basic_type = 3;
+      return 16;
+    default:
+      printf("ERROR ** type_decode() does not know about \"%s\"\n",
+             decode_token(type));
+      assert(0);
+      return 0xDEADBEEF;
+  }
+}
+
+arg_buffer_t copy_arg_to_buffer(ptx_thread_info *thread,
+                                operand_info actual_param_op,
+                                const symbol *formal_param) {
+  if (actual_param_op.is_reg()) {
+    ptx_reg_t value = thread->get_reg(actual_param_op.get_symbol());
+    return arg_buffer_t(formal_param, actual_param_op, value);
+  } else if (actual_param_op.is_param_local()) {
+    unsigned size = formal_param->get_size_in_bytes();
+    addr_t frame_offset = actual_param_op.get_symbol()->get_address();
+    addr_t from_addr = thread->get_local_mem_stack_pointer() + frame_offset;
+    char buffer[1024];
+    assert(size < 1024);
+    thread->m_local_mem->read(from_addr, size, buffer);
+    return arg_buffer_t(formal_param, actual_param_op, buffer, size);
+  } else {
+    printf(
+        "GPGPU-Sim PTX: ERROR ** need to add support for this operand type in "
+        "call/return\n");
+    abort();
+  }
+}
+
+void copy_args_into_buffer_list(const ptx_instruction *pI,
+                                ptx_thread_info *thread,
+                                const function_info *target_func,
+                                arg_buffer_list_t &arg_values) {
+  unsigned n_return = target_func->has_return();
+  unsigned n_args = target_func->num_args();
+  for (unsigned arg = 0; arg < n_args; arg++) {
+    const operand_info &actual_param_op =
+        pI->operand_lookup(n_return + 1 + arg);
+    const symbol *formal_param = target_func->get_arg(arg);
+    arg_values.push_back(
+        copy_arg_to_buffer(thread, actual_param_op, formal_param));
+  }
+}
+
+void copy_buffer_to_frame(ptx_thread_info *thread, const arg_buffer_t &a) {
+  if (a.is_reg()) {
+    ptx_reg_t value = a.get_reg();
+    operand_info dst_reg =
+        operand_info(a.get_dst(), thread->get_gpu()->gpgpu_ctx);
+    thread->set_reg(dst_reg.get_symbol(), value);
+  } else {
+    const void *buffer = a.get_param_buffer();
+    size_t size = a.get_param_buffer_size();
+    const symbol *dst = a.get_dst();
+    addr_t frame_offset = dst->get_address();
+    addr_t to_addr = thread->get_local_mem_stack_pointer() + frame_offset;
+    thread->m_local_mem->write(to_addr, size, buffer, NULL, NULL);
+  }
+}
+
+void copy_buffer_list_into_frame(ptx_thread_info *thread,
+                                 arg_buffer_list_t &arg_values) {
+  arg_buffer_list_t::iterator a;
+  for (a = arg_values.begin(); a != arg_values.end(); a++) {
+    copy_buffer_to_frame(thread, *a);
+  }
+}
+
+static std::list<operand_info> check_operands(
+    int opcode, const std::list<int> &scalar_type,
+    const std::list<operand_info> &operands, gpgpu_context *ctx) {
+  static int g_warn_literal_operands_two_type_inst;
+  if ((opcode == CVT_OP) || (opcode == SET_OP) || (opcode == SLCT_OP) ||
+      (opcode == TEX_OP) || (opcode == MMA_OP) || (opcode == DP4A_OP)) {
+    // just make sure these do not have have const operands...
+    if (!g_warn_literal_operands_two_type_inst) {
+      std::list<operand_info>::const_iterator o;
+      for (o = operands.begin(); o != operands.end(); o++) {
+        const operand_info &op = *o;
+        if (op.is_literal()) {
+          printf(
+              "GPGPU-Sim PTX: PTX uses two scalar type intruction with literal "
+              "operand.\n");
+          g_warn_literal_operands_two_type_inst = 1;
+        }
+      }
+    }
+  } else {
+    assert(scalar_type.size() < 2);
+    if (scalar_type.size() == 1) {
+      std::list<operand_info> result;
+      int inst_type = scalar_type.front();
+      std::list<operand_info>::const_iterator o;
+      for (o = operands.begin(); o != operands.end(); o++) {
+        const operand_info &op = *o;
+        if (op.is_literal()) {
+          if ((op.get_type() == double_op_t) && (inst_type == F32_TYPE)) {
+            ptx_reg_t v = op.get_literal_value();
+            float u = (float)v.f64;
+            operand_info n(u, ctx);
+            result.push_back(n);
+          } else {
+            result.push_back(op);
+          }
+        } else {
+          result.push_back(op);
+        }
+      }
+      return result;
+    }
+  }
+  return operands;
+}
+
+ptx_instruction::ptx_instruction(
+    int opcode, const symbol *pred, int neg_pred, int pred_mod, symbol *label,
+    const std::list<operand_info> &operands, const operand_info &return_var,
+    const std::list<int> &options, const std::list<int> &wmma_options,
+    const std::list<int> &scalar_type, memory_space_t space_spec,
+    const char *file, unsigned line, const char *source,
+    const core_config *config, gpgpu_context *ctx)
+    : warp_inst_t(config), m_return_var(ctx) {
+  gpgpu_ctx = ctx;
+  m_uid = ++(ctx->g_num_ptx_inst_uid);
+  m_PC = 0;
+  m_opcode = opcode;
+  m_pred = pred;
+  m_neg_pred = neg_pred;
+  m_pred_mod = pred_mod;
+  m_label = label;
+  const std::list<operand_info> checked_operands =
+      check_operands(opcode, scalar_type, operands, ctx);
+  m_operands.insert(m_operands.begin(), checked_operands.begin(),
+                    checked_operands.end());
+  m_return_var = return_var;
+  m_options = options;
+  m_wmma_options = wmma_options;
+  m_wide = false;
+  m_hi = false;
+  m_lo = false;
+  m_uni = false;
+  m_exit = false;
+  m_abs = false;
+  m_neg = false;
+  m_to_option = false;
+  m_cache_option = 0;
+  m_rounding_mode = RN_OPTION;
+  m_compare_op = -1;
+  m_saturation_mode = 0;
+  m_geom_spec = 0;
+  m_vector_spec = 0;
+  m_atomic_spec = 0;
+  m_membar_level = 0;
+  m_inst_size = 8;  // bytes
+  int rr = 0;
+  std::list<int>::const_iterator i;
+  unsigned n = 1;
+  for (i = wmma_options.begin(); i != wmma_options.end(); i++, n++) {
+    int last_ptx_inst_option = *i;
+    switch (last_ptx_inst_option) {
+      case SYNC_OPTION:
+      case LOAD_A:
+      case LOAD_B:
+      case LOAD_C:
+      case STORE_D:
+      case MMA:
+        m_wmma_type = last_ptx_inst_option;
+        break;
+      case ROW:
+      case COL:
+        m_wmma_layout[rr++] = last_ptx_inst_option;
+        break;
+      case M16N16K16:
+      case M32N8K16:
+      case M8N32K16:
+        break;
+      default:
+        assert(0);
+        break;
+    }
+  }
+  rr = 0;
+  n = 1;
+  for (i = options.begin(); i != options.end(); i++, n++) {
+    int last_ptx_inst_option = *i;
+    switch (last_ptx_inst_option) {
       case SYNC_OPTION:
       case ARRIVE_OPTION:
       case RED_OPTION:
-          m_barrier_op = last_ptx_inst_option;
-          break;
+        m_barrier_op = last_ptx_inst_option;
+        break;
       case EQU_OPTION:
       case NEU_OPTION:
       case LTU_OPTION:
@@ -1186,16 +1280,16 @@ ptx_instruction::ptx_instruction( int opcode,
       case GE_OPTION:
       case LS_OPTION:
       case HS_OPTION:
-         m_compare_op = last_ptx_inst_option;
-         break;
+        m_compare_op = last_ptx_inst_option;
+        break;
       case NUM_OPTION:
       case NAN_OPTION:
-    	  m_compare_op = last_ptx_inst_option;
+        m_compare_op = last_ptx_inst_option;
         // assert(0); // finish this
-         break;
+        break;
       case SAT_OPTION:
-         m_saturation_mode = 1;
-         break;
+        m_saturation_mode = 1;
+        break;
       case RNI_OPTION:
       case RZI_OPTION:
       case RMI_OPTION:
@@ -1204,38 +1298,39 @@ ptx_instruction::ptx_instruction( int opcode,
       case RZ_OPTION:
       case RM_OPTION:
       case RP_OPTION:
-         m_rounding_mode = last_ptx_inst_option;
-         break;
+        m_rounding_mode = last_ptx_inst_option;
+        break;
       case HI_OPTION:
-         m_compare_op = last_ptx_inst_option;
-         m_hi = true;
-         assert( !m_lo ); 
-         assert( !m_wide );
-         break;
+        m_compare_op = last_ptx_inst_option;
+        m_hi = true;
+        assert(!m_lo);
+        assert(!m_wide);
+        break;
       case LO_OPTION:
-         m_compare_op = last_ptx_inst_option;
-         m_lo = true;
-         assert( !m_hi );
-         assert( !m_wide );
-         break;
+        m_compare_op = last_ptx_inst_option;
+        m_lo = true;
+        assert(!m_hi);
+        assert(!m_wide);
+        break;
       case WIDE_OPTION:
-         m_wide = true;
-         assert( !m_lo ); 
-         assert( !m_hi ); 
-         break;
+        m_wide = true;
+        assert(!m_lo);
+        assert(!m_hi);
+        break;
       case UNI_OPTION:
-         m_uni = true; // don't care... < now we DO care when constructing flowgraph>
-         break;
+        m_uni = true;  // don't care... < now we DO care when constructing
+                       // flowgraph>
+        break;
       case GEOM_MODIFIER_1D:
       case GEOM_MODIFIER_2D:
       case GEOM_MODIFIER_3D:
-         m_geom_spec = last_ptx_inst_option;
-         break;
+        m_geom_spec = last_ptx_inst_option;
+        break;
       case V2_TYPE:
       case V3_TYPE:
       case V4_TYPE:
-         m_vector_spec = last_ptx_inst_option;
-         break;
+        m_vector_spec = last_ptx_inst_option;
+        break;
       case ATOMIC_AND:
       case ATOMIC_OR:
       case ATOMIC_XOR:
@@ -1246,223 +1341,225 @@ ptx_instruction::ptx_instruction( int opcode,
       case ATOMIC_DEC:
       case ATOMIC_MIN:
       case ATOMIC_MAX:
-         m_atomic_spec = last_ptx_inst_option;
-         break;
+        m_atomic_spec = last_ptx_inst_option;
+        break;
       case APPROX_OPTION:
-         break;
+        break;
       case FULL_OPTION:
-         break;
+        break;
       case ANY_OPTION:
-         m_vote_mode = vote_any;
-         break;
+        m_vote_mode = vote_any;
+        break;
       case ALL_OPTION:
-         m_vote_mode = vote_all;
-         break;
+        m_vote_mode = vote_all;
+        break;
       case BALLOT_OPTION:
-         m_vote_mode = vote_ballot;
-         break;
+        m_vote_mode = vote_ballot;
+        break;
       case GLOBAL_OPTION:
-         m_membar_level = GLOBAL_OPTION;
-         break;
+        m_membar_level = GLOBAL_OPTION;
+        break;
       case CTA_OPTION:
-         m_membar_level = CTA_OPTION;
-         break;
+        m_membar_level = CTA_OPTION;
+        break;
       case SYS_OPTION:
-         m_membar_level = SYS_OPTION;
-         break;
+        m_membar_level = SYS_OPTION;
+        break;
       case FTZ_OPTION:
-         break;
+        break;
       case EXIT_OPTION:
-         m_exit = true;
-         break;
+        m_exit = true;
+        break;
       case ABS_OPTION:
-         m_abs = true;
-         break;
+        m_abs = true;
+        break;
       case NEG_OPTION:
-         m_neg = true;
-         break;
+        m_neg = true;
+        break;
       case TO_OPTION:
-         m_to_option = true;
-         break;
-      case CA_OPTION: case CG_OPTION: case CS_OPTION: case LU_OPTION: case CV_OPTION:
-         m_cache_option = last_ptx_inst_option;
-         break;
+        m_to_option = true;
+        break;
+      case CA_OPTION:
+      case CG_OPTION:
+      case CS_OPTION:
+      case LU_OPTION:
+      case CV_OPTION:
+        m_cache_option = last_ptx_inst_option;
+        break;
       case HALF_OPTION:
-         m_inst_size = 4; // bytes
-         break;
+        m_inst_size = 4;  // bytes
+        break;
       case EXTP_OPTION:
-             break;
+        break;
       case NC_OPTION:
-             m_cache_option = last_ptx_inst_option;
-             break;
+        m_cache_option = last_ptx_inst_option;
+        break;
       case UP_OPTION:
       case DOWN_OPTION:
       case BFLY_OPTION:
       case IDX_OPTION:
-		  m_shfl_op = last_ptx_inst_option;
-		  break;
+        m_shfl_op = last_ptx_inst_option;
+        break;
       case PRMT_F4E_MODE:
       case PRMT_B4E_MODE:
       case PRMT_RC8_MODE:
       case PRMT_ECL_MODE:
       case PRMT_ECR_MODE:
       case PRMT_RC16_MODE:
-		  m_prmt_op = last_ptx_inst_option;
-		  break;
+        m_prmt_op = last_ptx_inst_option;
+        break;
       default:
-         assert(0);
-         break;
-      }
-   }
-   m_scalar_type = scalar_type;
-   m_space_spec = space_spec;
-   if( ( opcode == ST_OP || opcode == LD_OP || opcode == LDU_OP ) && (space_spec == undefined_space) ) {
-      m_space_spec = generic_space;
-   } 
-   for( std::vector<operand_info>::const_iterator i=m_operands.begin(); i!=m_operands.end(); ++i) {
-       const operand_info &op = *i;
-       if( op.get_addr_space() != undefined_space ) 
-           m_space_spec = op.get_addr_space(); // TODO: can have more than one memory space for ptxplus (g8x) inst
-   }
-   if( opcode == TEX_OP ) 
-       m_space_spec = tex_space;
-   
-   m_source_file = file?file:"<unknown>";
-   m_source_line = line;
-   m_source = source;
-   // Trim tabs
-   m_source.erase( std::remove( m_source.begin(), m_source.end(), '\t' ), m_source.end() );
+        assert(0);
+        break;
+    }
+  }
+  m_scalar_type = scalar_type;
+  m_space_spec = space_spec;
+  if ((opcode == ST_OP || opcode == LD_OP || opcode == LDU_OP) &&
+      (space_spec == undefined_space)) {
+    m_space_spec = generic_space;
+  }
+  for (std::vector<operand_info>::const_iterator i = m_operands.begin();
+       i != m_operands.end(); ++i) {
+    const operand_info &op = *i;
+    if (op.get_addr_space() != undefined_space)
+      m_space_spec = op.get_addr_space();  // TODO: can have more than one
+                                           // memory space for ptxplus (g8x)
+                                           // inst
+  }
+  if (opcode == TEX_OP) m_space_spec = tex_space;
 
-   if (opcode == CALL_OP) {
-       const operand_info &target  = func_addr();
-       assert( target.is_function_address() );
-       const symbol *func_addr = target.get_symbol();
-       const function_info *target_func = func_addr->get_pc();
-       std::string fname = target_func->get_name();
+  m_source_file = file ? file : "<unknown>";
+  m_source_line = line;
+  m_source = source;
+  // Trim tabs
+  m_source.erase(std::remove(m_source.begin(), m_source.end(), '\t'),
+                 m_source.end());
 
-       if (fname =="vprintf"){
-           m_is_printf = true;
-       }
-       if(fname == "cudaStreamCreateWithFlags")
-           m_is_cdp = 1;
-       if(fname == "cudaGetParameterBufferV2")
-           m_is_cdp = 2;
-       if(fname == "cudaLaunchDeviceV2")
-           m_is_cdp = 4;
+  if (opcode == CALL_OP) {
+    const operand_info &target = func_addr();
+    assert(target.is_function_address());
+    const symbol *func_addr = target.get_symbol();
+    const function_info *target_func = func_addr->get_pc();
+    std::string fname = target_func->get_name();
 
-   }
+    if (fname == "vprintf") {
+      m_is_printf = true;
+    }
+    if (fname == "cudaStreamCreateWithFlags") m_is_cdp = 1;
+    if (fname == "cudaGetParameterBufferV2") m_is_cdp = 2;
+    if (fname == "cudaLaunchDeviceV2") m_is_cdp = 4;
+  }
 }
 
-void ptx_instruction::print_insn() const
-{
-   print_insn(stdout);
-   fflush(stdout);
+void ptx_instruction::print_insn() const {
+  print_insn(stdout);
+  fflush(stdout);
 }
 
-void ptx_instruction::print_insn( FILE *fp ) const
-{
-    fprintf( fp, "%s", to_string().c_str() );
+void ptx_instruction::print_insn(FILE *fp) const {
+  fprintf(fp, "%s", to_string().c_str());
 }
 
-std::string ptx_instruction::to_string() const
-{
-   char buf[ STR_SIZE ];
-   unsigned used_bytes = 0;
-   if( !is_label() ) {
-      used_bytes += snprintf( buf + used_bytes, STR_SIZE - used_bytes, " PC=0x%03x ", m_PC );
-   } else {
-      used_bytes += snprintf( buf + used_bytes, STR_SIZE - used_bytes, "                " );
-   }
-   used_bytes += snprintf( buf + used_bytes, STR_SIZE - used_bytes,
-                           "(%s:%d) %s",
-                           m_source_file.c_str(), m_source_line,
-                           m_source.c_str() );
-   return std::string( buf );
+std::string ptx_instruction::to_string() const {
+  char buf[STR_SIZE];
+  unsigned used_bytes = 0;
+  if (!is_label()) {
+    used_bytes +=
+        snprintf(buf + used_bytes, STR_SIZE - used_bytes, " PC=0x%03x ", m_PC);
+  } else {
+    used_bytes +=
+        snprintf(buf + used_bytes, STR_SIZE - used_bytes, "                ");
+  }
+  used_bytes +=
+      snprintf(buf + used_bytes, STR_SIZE - used_bytes, "(%s:%d) %s",
+               m_source_file.c_str(), m_source_line, m_source.c_str());
+  return std::string(buf);
 }
-operand_info ptx_instruction::get_pred() const
-{
-    return operand_info( m_pred, gpgpu_ctx);
-}
-
-
-function_info::function_info(int entry_point, gpgpu_context* ctx )
-{
-   gpgpu_ctx = ctx;
-   m_uid = (gpgpu_ctx->function_info_sm_next_uid)++;
-   m_entry_point = (entry_point==1)?true:false;
-   m_extern = (entry_point==2)?true:false;
-   num_reconvergence_pairs = 0;
-   m_symtab = NULL;
-   m_assembled = false;
-   m_return_var_sym = NULL; 
-   m_kernel_info.cmem = 0;
-   m_kernel_info.lmem = 0;
-   m_kernel_info.regs = 0;
-   m_kernel_info.smem = 0;
-   m_local_mem_framesize = 0;
-   m_args_aligned_size = -1;
-   pdom_done = false; //initialize it to false
+operand_info ptx_instruction::get_pred() const {
+  return operand_info(m_pred, gpgpu_ctx);
 }
 
-unsigned function_info::print_insn( unsigned pc, FILE * fp ) const
-{
-   unsigned inst_size=1; // return offset to next instruction or 1 if unknown
-   unsigned index = pc - m_start_PC;
-   char command[1024];
-   char buffer[1024];
-   memset(command, 0, 1024);
-   memset(buffer, 0, 1024);
-   snprintf(command,1024,"c++filt -p %s",m_name.c_str());
-   FILE *p = popen(command,"r");
-   buffer[0]=0;
-   assert(fgets(buffer, 1023, p) != NULL);
-   // Remove trailing "\n" in buffer
-   char *c;
-   if ((c=strchr(buffer, '\n')) != NULL) *c = '\0';
-   fprintf(fp,"%s",buffer);
-   if ( index >= m_instr_mem_size ) {
-      fprintf(fp, "<past last instruction (max pc=%u)>", m_start_PC + m_instr_mem_size - 1 );
-   } else {
-      if ( m_instr_mem[index] != NULL ) {
-         m_instr_mem[index]->print_insn(fp);
-         inst_size = m_instr_mem[index]->isize;
-      } else
-         fprintf(fp, "<no instruction at pc = %u>", pc );
-   }
-   pclose(p);
-   return inst_size;
+function_info::function_info(int entry_point, gpgpu_context *ctx) {
+  gpgpu_ctx = ctx;
+  m_uid = (gpgpu_ctx->function_info_sm_next_uid)++;
+  m_entry_point = (entry_point == 1) ? true : false;
+  m_extern = (entry_point == 2) ? true : false;
+  num_reconvergence_pairs = 0;
+  m_symtab = NULL;
+  m_assembled = false;
+  m_return_var_sym = NULL;
+  m_kernel_info.cmem = 0;
+  m_kernel_info.lmem = 0;
+  m_kernel_info.regs = 0;
+  m_kernel_info.smem = 0;
+  m_local_mem_framesize = 0;
+  m_args_aligned_size = -1;
+  pdom_done = false;  // initialize it to false
 }
 
-std::string function_info::get_insn_str( unsigned pc ) const
-{
-   unsigned index = pc - m_start_PC;
-   if ( index >= m_instr_mem_size ) {
+unsigned function_info::print_insn(unsigned pc, FILE *fp) const {
+  unsigned inst_size = 1;  // return offset to next instruction or 1 if unknown
+  unsigned index = pc - m_start_PC;
+  char command[1024];
+  char buffer[1024];
+  memset(command, 0, 1024);
+  memset(buffer, 0, 1024);
+  snprintf(command, 1024, "c++filt -p %s", m_name.c_str());
+  FILE *p = popen(command, "r");
+  buffer[0] = 0;
+  assert(fgets(buffer, 1023, p) != NULL);
+  // Remove trailing "\n" in buffer
+  char *c;
+  if ((c = strchr(buffer, '\n')) != NULL) *c = '\0';
+  fprintf(fp, "%s", buffer);
+  if (index >= m_instr_mem_size) {
+    fprintf(fp, "<past last instruction (max pc=%u)>",
+            m_start_PC + m_instr_mem_size - 1);
+  } else {
+    if (m_instr_mem[index] != NULL) {
+      m_instr_mem[index]->print_insn(fp);
+      inst_size = m_instr_mem[index]->isize;
+    } else
+      fprintf(fp, "<no instruction at pc = %u>", pc);
+  }
+  pclose(p);
+  return inst_size;
+}
+
+std::string function_info::get_insn_str(unsigned pc) const {
+  unsigned index = pc - m_start_PC;
+  if (index >= m_instr_mem_size) {
+    char buff[STR_SIZE];
+    buff[STR_SIZE - 1] = '\0';
+    snprintf(buff, STR_SIZE, "<past last instruction (max pc=%u)>",
+             m_start_PC + m_instr_mem_size - 1);
+    return std::string(buff);
+  } else {
+    if (m_instr_mem[index] != NULL) {
+      return m_instr_mem[index]->to_string();
+    } else {
       char buff[STR_SIZE];
-      buff[STR_SIZE-1] = '\0';
-      snprintf(buff, STR_SIZE, "<past last instruction (max pc=%u)>", m_start_PC + m_instr_mem_size - 1 );
+      buff[STR_SIZE - 1] = '\0';
+      snprintf(buff, STR_SIZE, "<no instruction at pc = %u>", pc);
       return std::string(buff);
-   } else {
-      if ( m_instr_mem[index] != NULL ) {
-         return m_instr_mem[index]->to_string();
-      } else {
-         char buff[STR_SIZE];
-         buff[STR_SIZE-1] = '\0';
-         snprintf(buff, STR_SIZE, "<no instruction at pc = %u>", pc );
-         return std::string(buff);
-      }
-   }
+    }
+  }
 }
 
-void gpgpu_ptx_assemble( std::string kname, void *kinfo )
-{
-    function_info *func_info = (function_info *)kinfo;
-    if((function_info *)kinfo == NULL) {
-       printf("GPGPU-Sim PTX: Warning - missing function definition \'%s\'\n", kname.c_str());
-       return;
-    }
-    if( func_info->is_extern() ) {
-       printf("GPGPU-Sim PTX: skipping assembly for extern declared function \'%s\'\n", func_info->get_name().c_str() );
-       return;
-    }
-    func_info->ptx_assemble();
+void gpgpu_ptx_assemble(std::string kname, void *kinfo) {
+  function_info *func_info = (function_info *)kinfo;
+  if ((function_info *)kinfo == NULL) {
+    printf("GPGPU-Sim PTX: Warning - missing function definition \'%s\'\n",
+           kname.c_str());
+    return;
+  }
+  if (func_info->is_extern()) {
+    printf(
+        "GPGPU-Sim PTX: skipping assembly for extern declared function "
+        "\'%s\'\n",
+        func_info->get_name().c_str());
+    return;
+  }
+  func_info->ptx_assemble();
 }

--- a/src/cuda-sim/ptx_ir.h
+++ b/src/cuda-sim/ptx_ir.h
@@ -7,36 +7,37 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef ptx_ir_INCLUDED
 #define ptx_ir_INCLUDED
 
 #include "../abstract_hardware_model.h"
 
+#include <assert.h>
 #include <cstdlib>
 #include <cstring>
-#include <string>
 #include <list>
 #include <map>
+#include <string>
 #include <vector>
-#include <assert.h>
 
 //#include "ptx.tab.h"
 #include "ptx_sim.h"
@@ -46,1537 +47,1517 @@
 class gpgpu_context;
 
 class type_info_key {
-public:
-   type_info_key()
-   {
-      m_is_non_arch_reg = false;
-      m_init = false;
-   }
-   type_info_key( memory_space_t space_spec, int scalar_type_spec, int vector_spec, int alignment_spec, int extern_spec, int array_dim )
-   {
-      m_is_non_arch_reg = false;
-      m_init = true;
-      m_space_spec = space_spec; 
-      m_scalar_type_spec = scalar_type_spec;
-      m_vector_spec = vector_spec;
-      m_alignment_spec = alignment_spec;
-      m_extern_spec = extern_spec;
-      m_array_dim = array_dim;
-      m_is_function = 0;
-   } 
-   void set_is_func()
-   { 
-      assert(!m_init);
-      m_init = true;
-      m_space_spec = undefined_space; 
-      m_scalar_type_spec = 0;
-      m_vector_spec = 0;
-      m_alignment_spec = 0;
-      m_extern_spec = 0;
-      m_array_dim = 0; 
-      m_is_function = 1;
-   }
+ public:
+  type_info_key() {
+    m_is_non_arch_reg = false;
+    m_init = false;
+  }
+  type_info_key(memory_space_t space_spec, int scalar_type_spec,
+                int vector_spec, int alignment_spec, int extern_spec,
+                int array_dim) {
+    m_is_non_arch_reg = false;
+    m_init = true;
+    m_space_spec = space_spec;
+    m_scalar_type_spec = scalar_type_spec;
+    m_vector_spec = vector_spec;
+    m_alignment_spec = alignment_spec;
+    m_extern_spec = extern_spec;
+    m_array_dim = array_dim;
+    m_is_function = 0;
+  }
+  void set_is_func() {
+    assert(!m_init);
+    m_init = true;
+    m_space_spec = undefined_space;
+    m_scalar_type_spec = 0;
+    m_vector_spec = 0;
+    m_alignment_spec = 0;
+    m_extern_spec = 0;
+    m_array_dim = 0;
+    m_is_function = 1;
+  }
 
-   void set_array_dim( int array_dim ) { m_array_dim = array_dim; }
-   int get_array_dim() const { assert(m_init); return m_array_dim; }
-   void set_is_non_arch_reg() { m_is_non_arch_reg = true;  }
+  void set_array_dim(int array_dim) { m_array_dim = array_dim; }
+  int get_array_dim() const {
+    assert(m_init);
+    return m_array_dim;
+  }
+  void set_is_non_arch_reg() { m_is_non_arch_reg = true; }
 
-   bool is_non_arch_reg() const { return m_is_non_arch_reg; }
-   bool is_reg() const { return m_space_spec == reg_space;} 
-   bool is_param_kernel() const { return m_space_spec == param_space_kernel;}
-   bool is_param_local() const { return m_space_spec == param_space_local; }
-   bool is_param_unclassified() const { return m_space_spec == param_space_unclassified; }
-   bool is_global() const { return m_space_spec == global_space;}
-   bool is_local() const { return m_space_spec == local_space;}
-   bool is_shared() const { return m_space_spec == shared_space;}
-   bool is_const() const { return m_space_spec.get_type() == const_space;}
-   bool is_tex() const { return m_space_spec == tex_space;}
-   bool is_func_addr() const { return m_is_function?true:false; }
-   int  scalar_type() const { return m_scalar_type_spec;}
-   int  get_alignment_spec() const { return m_alignment_spec;}
-   unsigned type_decode( size_t &size, int &t ) const;
-   static unsigned type_decode( int type, size_t &size, int &t );
-   memory_space_t get_memory_space() const { return m_space_spec; }
-private:
-   bool m_init;
-   memory_space_t m_space_spec; 
-   int m_scalar_type_spec;
-   int m_vector_spec;
-   int m_alignment_spec;
-   int m_extern_spec;
-   int m_array_dim;
-   int m_is_function;
-   bool m_is_non_arch_reg;
+  bool is_non_arch_reg() const { return m_is_non_arch_reg; }
+  bool is_reg() const { return m_space_spec == reg_space; }
+  bool is_param_kernel() const { return m_space_spec == param_space_kernel; }
+  bool is_param_local() const { return m_space_spec == param_space_local; }
+  bool is_param_unclassified() const {
+    return m_space_spec == param_space_unclassified;
+  }
+  bool is_global() const { return m_space_spec == global_space; }
+  bool is_local() const { return m_space_spec == local_space; }
+  bool is_shared() const { return m_space_spec == shared_space; }
+  bool is_const() const { return m_space_spec.get_type() == const_space; }
+  bool is_tex() const { return m_space_spec == tex_space; }
+  bool is_func_addr() const { return m_is_function ? true : false; }
+  int scalar_type() const { return m_scalar_type_spec; }
+  int get_alignment_spec() const { return m_alignment_spec; }
+  unsigned type_decode(size_t &size, int &t) const;
+  static unsigned type_decode(int type, size_t &size, int &t);
+  memory_space_t get_memory_space() const { return m_space_spec; }
 
-   friend struct type_info_key_compare;
+ private:
+  bool m_init;
+  memory_space_t m_space_spec;
+  int m_scalar_type_spec;
+  int m_vector_spec;
+  int m_alignment_spec;
+  int m_extern_spec;
+  int m_array_dim;
+  int m_is_function;
+  bool m_is_non_arch_reg;
+
+  friend struct type_info_key_compare;
 };
 
 class symbol_table;
 
 struct type_info_key_compare {
-   bool operator()( const type_info_key &a, const type_info_key &b ) const
-   {
-      assert( a.m_init && b.m_init );
-      if ( a.m_space_spec < b.m_space_spec ) return true;
-      if ( a.m_scalar_type_spec < b.m_scalar_type_spec ) return true;
-      if ( a.m_vector_spec < b.m_vector_spec ) return true;
-      if ( a.m_alignment_spec < b.m_alignment_spec ) return true;
-      if ( a.m_extern_spec < b.m_extern_spec ) return true;
-      if ( a.m_array_dim < b.m_array_dim ) return true;
-      if ( a.m_is_function < b.m_is_function ) return true;
+  bool operator()(const type_info_key &a, const type_info_key &b) const {
+    assert(a.m_init && b.m_init);
+    if (a.m_space_spec < b.m_space_spec) return true;
+    if (a.m_scalar_type_spec < b.m_scalar_type_spec) return true;
+    if (a.m_vector_spec < b.m_vector_spec) return true;
+    if (a.m_alignment_spec < b.m_alignment_spec) return true;
+    if (a.m_extern_spec < b.m_extern_spec) return true;
+    if (a.m_array_dim < b.m_array_dim) return true;
+    if (a.m_is_function < b.m_is_function) return true;
 
-      return false;
-   }
+    return false;
+  }
 };
 
 class type_info {
-public:
-   type_info( symbol_table *scope, type_info_key t )
-   {
-      m_type_info = t;
-   }
-   const type_info_key &get_key() const { return m_type_info;}
+ public:
+  type_info(symbol_table *scope, type_info_key t) { m_type_info = t; }
+  const type_info_key &get_key() const { return m_type_info; }
 
-private:
-   symbol_table *m_scope;
-   type_info_key m_type_info;
+ private:
+  symbol_table *m_scope;
+  type_info_key m_type_info;
 };
 
 enum operand_type {
-   reg_t, vector_t, builtin_t, address_t, memory_t, float_op_t, double_op_t, int_t, 
-   unsigned_t, symbolic_t, label_t, v_reg_t, v_float_op_t, v_double_op_t,
-   v_int_t, v_unsigned_t, undef_t
+  reg_t,
+  vector_t,
+  builtin_t,
+  address_t,
+  memory_t,
+  float_op_t,
+  double_op_t,
+  int_t,
+  unsigned_t,
+  symbolic_t,
+  label_t,
+  v_reg_t,
+  v_float_op_t,
+  v_double_op_t,
+  v_int_t,
+  v_unsigned_t,
+  undef_t
 };
 
 class operand_info;
 
 class symbol {
-public:
-   symbol( const char *name, const type_info *type, const char *location, unsigned size, gpgpu_context* ctx ) 
-   {
-      gpgpu_ctx = ctx;
-      m_uid = get_uid();
-      m_name = name;
-      m_decl_location = location;
-      m_type = type;
-      m_size = size;
-      m_address_valid = false;
-      m_is_label = false;
-      m_is_shared = false;
-      m_is_const = false;
-      m_is_global = false;
-      m_is_local = false;
-      m_is_param_local = false;
-      m_is_param_kernel = false;
-      m_is_tex = false;
-      m_is_func_addr = false;
-      m_reg_num_valid = false;
-      m_function = NULL;
-      m_reg_num=(unsigned)-1;
-      m_arch_reg_num=(unsigned)-1;
-      m_address=(unsigned)-1;
-      m_initializer.clear();
-      if ( type ) m_is_shared = type->get_key().is_shared();
-      if ( type ) m_is_const = type->get_key().is_const();
-      if ( type ) m_is_global = type->get_key().is_global();
-      if ( type ) m_is_local = type->get_key().is_local();
-      if ( type ) m_is_param_local = type->get_key().is_param_local();
-      if ( type ) m_is_param_kernel = type->get_key().is_param_kernel();
-      if ( type ) m_is_tex = type->get_key().is_tex();
-      if ( type ) m_is_func_addr = type->get_key().is_func_addr();
-   }
-   unsigned get_size_in_bytes() const
-   {
-      return m_size;
-   }
-   const std::string &name() const { return m_name;}
-   const std::string &decl_location() const { return m_decl_location;} 
-   const type_info *type() const { return m_type;}
-   addr_t get_address() const 
-   { 
-      assert( m_is_label || !m_type->get_key().is_reg() ); // todo : other assertions
-      assert( m_address_valid );
-      return m_address;
-   }
-   function_info *get_pc() const
-   {
-      return m_function;
-   }
-   void set_regno( unsigned regno, unsigned arch_regno )
-   {
-      m_reg_num_valid = true;
-      m_reg_num = regno;
-      m_arch_reg_num = arch_regno;
-   }
+ public:
+  symbol(const char *name, const type_info *type, const char *location,
+         unsigned size, gpgpu_context *ctx) {
+    gpgpu_ctx = ctx;
+    m_uid = get_uid();
+    m_name = name;
+    m_decl_location = location;
+    m_type = type;
+    m_size = size;
+    m_address_valid = false;
+    m_is_label = false;
+    m_is_shared = false;
+    m_is_const = false;
+    m_is_global = false;
+    m_is_local = false;
+    m_is_param_local = false;
+    m_is_param_kernel = false;
+    m_is_tex = false;
+    m_is_func_addr = false;
+    m_reg_num_valid = false;
+    m_function = NULL;
+    m_reg_num = (unsigned)-1;
+    m_arch_reg_num = (unsigned)-1;
+    m_address = (unsigned)-1;
+    m_initializer.clear();
+    if (type) m_is_shared = type->get_key().is_shared();
+    if (type) m_is_const = type->get_key().is_const();
+    if (type) m_is_global = type->get_key().is_global();
+    if (type) m_is_local = type->get_key().is_local();
+    if (type) m_is_param_local = type->get_key().is_param_local();
+    if (type) m_is_param_kernel = type->get_key().is_param_kernel();
+    if (type) m_is_tex = type->get_key().is_tex();
+    if (type) m_is_func_addr = type->get_key().is_func_addr();
+  }
+  unsigned get_size_in_bytes() const { return m_size; }
+  const std::string &name() const { return m_name; }
+  const std::string &decl_location() const { return m_decl_location; }
+  const type_info *type() const { return m_type; }
+  addr_t get_address() const {
+    assert(m_is_label ||
+           !m_type->get_key().is_reg());  // todo : other assertions
+    assert(m_address_valid);
+    return m_address;
+  }
+  function_info *get_pc() const { return m_function; }
+  void set_regno(unsigned regno, unsigned arch_regno) {
+    m_reg_num_valid = true;
+    m_reg_num = regno;
+    m_arch_reg_num = arch_regno;
+  }
 
-   void set_address( addr_t addr )
-   {
-      m_address_valid = true;
-      m_address = addr;
-   }
-   void set_label_address( addr_t addr)
-   {
-      m_address_valid = true;
-      m_address = addr;
-      m_is_label = true;
-   }
-   void set_function( function_info *func )
-   {
-      m_function = func;
-      m_is_func_addr = true; 
-   }
+  void set_address(addr_t addr) {
+    m_address_valid = true;
+    m_address = addr;
+  }
+  void set_label_address(addr_t addr) {
+    m_address_valid = true;
+    m_address = addr;
+    m_is_label = true;
+  }
+  void set_function(function_info *func) {
+    m_function = func;
+    m_is_func_addr = true;
+  }
 
-   bool is_label() const { return m_is_label;}
-   bool is_shared() const { return m_is_shared;}
-   bool is_sstarr() const { return m_is_sstarr;}
-   bool is_const() const { return m_is_const;}
-   bool is_global() const { return m_is_global;}
-   bool is_local() const { return m_is_local;}
-   bool is_param_local() const { return m_is_param_local; }
-   bool is_param_kernel() const { return m_is_param_kernel; }
-   bool is_tex() const { return m_is_tex;}
-   bool is_func_addr() const { return m_is_func_addr; }
-   bool is_reg() const
-   {
-       if ( m_type == NULL ) {
-           return false;
-       }
-      return m_type->get_key().is_reg(); 
-   }
-   bool is_non_arch_reg() const
-   {
-       if ( m_type == NULL ) {
-           return false;
-       }
-      return m_type->get_key().is_non_arch_reg(); 
-   }
+  bool is_label() const { return m_is_label; }
+  bool is_shared() const { return m_is_shared; }
+  bool is_sstarr() const { return m_is_sstarr; }
+  bool is_const() const { return m_is_const; }
+  bool is_global() const { return m_is_global; }
+  bool is_local() const { return m_is_local; }
+  bool is_param_local() const { return m_is_param_local; }
+  bool is_param_kernel() const { return m_is_param_kernel; }
+  bool is_tex() const { return m_is_tex; }
+  bool is_func_addr() const { return m_is_func_addr; }
+  bool is_reg() const {
+    if (m_type == NULL) {
+      return false;
+    }
+    return m_type->get_key().is_reg();
+  }
+  bool is_non_arch_reg() const {
+    if (m_type == NULL) {
+      return false;
+    }
+    return m_type->get_key().is_non_arch_reg();
+  }
 
-   void add_initializer( const std::list<operand_info> &init );
-   bool has_initializer() const 
-   {
-      return m_initializer.size() > 0; 
-   }
-   std::list<operand_info> get_initializer() const
-   {
-      return m_initializer;
-   }
-   unsigned reg_num() const
-   {
-      assert( m_reg_num_valid );
-      return m_reg_num; 
-   }
-   unsigned arch_reg_num() const
-   {
-      assert( m_reg_num_valid );
-      return m_arch_reg_num; 
-   }
-   void print_info(FILE *fp) const;
-   unsigned uid() const { return m_uid; }
+  void add_initializer(const std::list<operand_info> &init);
+  bool has_initializer() const { return m_initializer.size() > 0; }
+  std::list<operand_info> get_initializer() const { return m_initializer; }
+  unsigned reg_num() const {
+    assert(m_reg_num_valid);
+    return m_reg_num;
+  }
+  unsigned arch_reg_num() const {
+    assert(m_reg_num_valid);
+    return m_arch_reg_num;
+  }
+  void print_info(FILE *fp) const;
+  unsigned uid() const { return m_uid; }
 
-private:
-   gpgpu_context* gpgpu_ctx;
-   unsigned get_uid();
-   unsigned m_uid;
-   const type_info *m_type;
-   unsigned m_size; // in bytes
-   std::string m_name;
-   std::string m_decl_location;
+ private:
+  gpgpu_context *gpgpu_ctx;
+  unsigned get_uid();
+  unsigned m_uid;
+  const type_info *m_type;
+  unsigned m_size;  // in bytes
+  std::string m_name;
+  std::string m_decl_location;
 
-   unsigned m_address;
-   function_info *m_function; // used for function symbols
+  unsigned m_address;
+  function_info *m_function;  // used for function symbols
 
-   bool m_address_valid;
-   bool m_is_label;
-   bool m_is_shared;
-   bool m_is_sstarr;
-   bool m_is_const;
-   bool m_is_global;
-   bool m_is_local;
-   bool m_is_param_local;
-   bool m_is_param_kernel;
-   bool m_is_tex;
-   bool m_is_func_addr;
-   unsigned m_reg_num; 
-   unsigned m_arch_reg_num; 
-   bool m_reg_num_valid; 
+  bool m_address_valid;
+  bool m_is_label;
+  bool m_is_shared;
+  bool m_is_sstarr;
+  bool m_is_const;
+  bool m_is_global;
+  bool m_is_local;
+  bool m_is_param_local;
+  bool m_is_param_kernel;
+  bool m_is_tex;
+  bool m_is_func_addr;
+  unsigned m_reg_num;
+  unsigned m_arch_reg_num;
+  bool m_reg_num_valid;
 
-   std::list<operand_info> m_initializer;
+  std::list<operand_info> m_initializer;
 };
 
 class symbol_table {
-public:
-   symbol_table();
-   symbol_table( const char *scope_name, unsigned entry_point, symbol_table *parent, gpgpu_context* ctx);
-   void set_name( const char *name );
-   const ptx_version &get_ptx_version() const;
-   unsigned get_sm_target() const;
-   void set_ptx_version( float ver, unsigned ext );
-   void set_sm_target( const char *target, const char *ext, const char *ext2 );
-   symbol* lookup( const char *identifier );
-   std::string get_scope_name() const { return m_scope_name; }
-   symbol *add_variable( const char *identifier, const type_info *type, unsigned size, const char *filename, unsigned line );
-   void add_function( function_info *func, const char *filename, unsigned linenumber );
-   bool add_function_decl( const char *name, int entry_point, function_info **func_info, symbol_table **symbol_table );
-   function_info *lookup_function(std::string name);
-   type_info *add_type( memory_space_t space_spec, int scalar_type_spec, int vector_spec, int alignment_spec, int extern_spec );
-   type_info *add_type( function_info *func );
-   type_info *get_array_type( type_info *base_type, unsigned array_dim ); 
-   void set_label_address( const symbol *label, unsigned addr );
-   unsigned next_reg_num() { return ++m_reg_allocator;}
-   addr_t get_shared_next() { return m_shared_next;}
-   addr_t get_sstarr_next() { return m_sstarr_next;}
-   addr_t get_global_next() { return m_global_next;}
-   addr_t get_local_next() { return m_local_next;}
-   addr_t get_tex_next() { return m_tex_next;}
-   void  alloc_shared( unsigned num_bytes ) { m_shared_next += num_bytes;}
-   void  alloc_sstarr( unsigned num_bytes ) { m_sstarr_next += num_bytes;}
-   void  alloc_global( unsigned num_bytes ) { m_global_next += num_bytes;}
-   void  alloc_local( unsigned num_bytes ) { m_local_next += num_bytes;}
-   void  alloc_tex( unsigned num_bytes ) { m_tex_next += num_bytes;}
+ public:
+  symbol_table();
+  symbol_table(const char *scope_name, unsigned entry_point,
+               symbol_table *parent, gpgpu_context *ctx);
+  void set_name(const char *name);
+  const ptx_version &get_ptx_version() const;
+  unsigned get_sm_target() const;
+  void set_ptx_version(float ver, unsigned ext);
+  void set_sm_target(const char *target, const char *ext, const char *ext2);
+  symbol *lookup(const char *identifier);
+  std::string get_scope_name() const { return m_scope_name; }
+  symbol *add_variable(const char *identifier, const type_info *type,
+                       unsigned size, const char *filename, unsigned line);
+  void add_function(function_info *func, const char *filename,
+                    unsigned linenumber);
+  bool add_function_decl(const char *name, int entry_point,
+                         function_info **func_info,
+                         symbol_table **symbol_table);
+  function_info *lookup_function(std::string name);
+  type_info *add_type(memory_space_t space_spec, int scalar_type_spec,
+                      int vector_spec, int alignment_spec, int extern_spec);
+  type_info *add_type(function_info *func);
+  type_info *get_array_type(type_info *base_type, unsigned array_dim);
+  void set_label_address(const symbol *label, unsigned addr);
+  unsigned next_reg_num() { return ++m_reg_allocator; }
+  addr_t get_shared_next() { return m_shared_next; }
+  addr_t get_sstarr_next() { return m_sstarr_next; }
+  addr_t get_global_next() { return m_global_next; }
+  addr_t get_local_next() { return m_local_next; }
+  addr_t get_tex_next() { return m_tex_next; }
+  void alloc_shared(unsigned num_bytes) { m_shared_next += num_bytes; }
+  void alloc_sstarr(unsigned num_bytes) { m_sstarr_next += num_bytes; }
+  void alloc_global(unsigned num_bytes) { m_global_next += num_bytes; }
+  void alloc_local(unsigned num_bytes) { m_local_next += num_bytes; }
+  void alloc_tex(unsigned num_bytes) { m_tex_next += num_bytes; }
 
-   typedef std::list<symbol*>::iterator iterator;
+  typedef std::list<symbol *>::iterator iterator;
 
-   iterator global_iterator_begin() { return m_globals.begin();}
-   iterator global_iterator_end() { return m_globals.end();}
+  iterator global_iterator_begin() { return m_globals.begin(); }
+  iterator global_iterator_end() { return m_globals.end(); }
 
-   iterator const_iterator_begin() { return m_consts.begin();}
-   iterator const_iterator_end() { return m_consts.end();}
+  iterator const_iterator_begin() { return m_consts.begin(); }
+  iterator const_iterator_end() { return m_consts.end(); }
 
-   void dump();
-   
-   //Jin: handle instruction group for cdp
-   symbol_table* start_inst_group();
-   symbol_table* end_inst_group();
+  void dump();
 
-   // backward pointer
-   class gpgpu_context* gpgpu_ctx;
+  // Jin: handle instruction group for cdp
+  symbol_table *start_inst_group();
+  symbol_table *end_inst_group();
 
-private:
-   unsigned m_reg_allocator;
-   unsigned m_shared_next;
-   unsigned m_sstarr_next;
-   unsigned m_const_next;
-   unsigned m_global_next;
-   unsigned m_local_next;
-   unsigned m_tex_next;
+  // backward pointer
+  class gpgpu_context *gpgpu_ctx;
 
-   symbol_table *m_parent;
-   ptx_version m_ptx_version;
-   std::string m_scope_name;
-   std::map<std::string, symbol *> m_symbols; //map from name of register to pointers to the registers
-   std::map<type_info_key,type_info*,type_info_key_compare>  m_types;
-   std::list<symbol*> m_globals;
-   std::list<symbol*> m_consts;
-   std::map<std::string,function_info*> m_function_info_lookup;
-   std::map<std::string,symbol_table*> m_function_symtab_lookup;
-   
-   //Jin: handle instruction group for cdp
-   unsigned m_inst_group_id;
-   std::map<std::string,symbol_table*> m_inst_group_symtab;
+ private:
+  unsigned m_reg_allocator;
+  unsigned m_shared_next;
+  unsigned m_sstarr_next;
+  unsigned m_const_next;
+  unsigned m_global_next;
+  unsigned m_local_next;
+  unsigned m_tex_next;
+
+  symbol_table *m_parent;
+  ptx_version m_ptx_version;
+  std::string m_scope_name;
+  std::map<std::string, symbol *>
+      m_symbols;  // map from name of register to pointers to the registers
+  std::map<type_info_key, type_info *, type_info_key_compare> m_types;
+  std::list<symbol *> m_globals;
+  std::list<symbol *> m_consts;
+  std::map<std::string, function_info *> m_function_info_lookup;
+  std::map<std::string, symbol_table *> m_function_symtab_lookup;
+
+  // Jin: handle instruction group for cdp
+  unsigned m_inst_group_id;
+  std::map<std::string, symbol_table *> m_inst_group_symtab;
 };
 
 class operand_info {
-public:
-   operand_info(gpgpu_context* ctx)
-   {
-      init(ctx);
-      m_is_non_arch_reg = false;
-      m_addr_space = undefined_space;
-      m_operand_lohi = 0;
-      m_double_operand_type = 0;
-      m_operand_neg = false;
-      m_const_mem_offset = 0;
-      m_uid = get_uid();
-      m_valid = false;
-      m_immediate_address=false;
-      m_addr_offset = 0;
-      m_value.m_symbolic=NULL;
-   }
-   operand_info( const symbol *addr, gpgpu_context* ctx )
-   {
-      init(ctx);
-      m_is_non_arch_reg = false;
-      m_addr_space = undefined_space;
-      m_operand_lohi = 0;
-      m_double_operand_type = 0;
-      m_operand_neg = false;
-      m_const_mem_offset = 0;
-      m_uid = get_uid();
-      m_valid = true;
-      if ( addr->is_label() ) {
-         m_type = label_t;
-      } else if ( addr->is_shared() ) {
-         m_type = symbolic_t;
-      } else if ( addr->is_const() ) {
-         m_type = symbolic_t;
-      } else if ( addr->is_global() ) {
-         m_type = symbolic_t;
-      } else if ( addr->is_local() ) {
-         m_type = symbolic_t;
-      } else if ( addr->is_param_local() ) {
-         m_type = symbolic_t;
-      } else if ( addr->is_param_kernel() ) {
-         m_type = symbolic_t;
-      } else if ( addr->is_tex() ) {
-         m_type = symbolic_t;
-      } else if ( addr->is_func_addr() ) {
-         m_type = symbolic_t;
-      } else if ( !addr->is_reg() ) {
-         m_type = symbolic_t;
-      } else {
-         m_type = reg_t;
-      }
-      
-      m_is_non_arch_reg = addr->is_non_arch_reg();
-      m_value.m_symbolic = addr;
-      m_addr_offset = 0;
-      m_vector = false;
-      m_neg_pred = false;
-      m_is_return_var = false;
-      m_immediate_address=false;
-   }
-   operand_info( const symbol *addr1, const symbol *addr2, gpgpu_context* ctx )
-   {
-      init(ctx);
-      m_is_non_arch_reg = false;
-      m_addr_space = undefined_space;
-      m_operand_lohi = 0;
-      m_double_operand_type = 0;
-      m_operand_neg = false;
-      m_const_mem_offset = 0;
-      m_uid = get_uid();
-      m_valid = true;
-      m_type = memory_t;
-      m_value.m_vector_symbolic = new const symbol*[8];
-      m_value.m_vector_symbolic[0] = addr1;
-      m_value.m_vector_symbolic[1] = addr2;
-      m_value.m_vector_symbolic[2] = NULL;
-      m_value.m_vector_symbolic[3] = NULL;
-      m_value.m_vector_symbolic[4] = NULL;
-      m_value.m_vector_symbolic[5] = NULL;
-      m_value.m_vector_symbolic[6] = NULL;
-      m_value.m_vector_symbolic[7] = NULL;
-      m_addr_offset = 0;
-      m_vector = false;
-      m_neg_pred = false;
-      m_is_return_var = false;
-      m_immediate_address=false;
-   }
-   operand_info( int builtin_id, int dim_mod, gpgpu_context* ctx )
-   {
-      init(ctx);
-      m_is_non_arch_reg = false;
-      m_addr_space = undefined_space;
-      m_operand_lohi = 0;
-      m_double_operand_type = 0;
-      m_operand_neg = false;
-      m_const_mem_offset = 0;
-      m_uid = get_uid();
-      m_valid = true;
-      m_vector = false;
-      m_type = builtin_t;
-      m_value.m_int = builtin_id;
-      m_addr_offset = dim_mod;
-      m_neg_pred = false;
-      m_is_return_var = false;
-      m_immediate_address=false;
-   }
-   operand_info( const symbol *addr, int offset, gpgpu_context* ctx )
-   {
-      init(ctx);
-      m_is_non_arch_reg = false;
-      m_addr_space = undefined_space;
-      m_operand_lohi = 0;
-      m_double_operand_type = 0;
-      m_operand_neg = false;
-      m_const_mem_offset = 0;
-      m_uid = get_uid();
-      m_valid = true;
-      m_vector = false;
-      m_type = address_t;
-      m_value.m_symbolic = addr;
-      m_addr_offset = offset;
-      m_neg_pred = false;
-      m_is_return_var = false;
-      m_immediate_address=false;
-   }
-   operand_info( unsigned x, gpgpu_context* ctx )
-   {
-      init(ctx);
-      m_is_non_arch_reg = false;
-      m_addr_space = undefined_space;
-      m_operand_lohi = 0;
-      m_double_operand_type = 0;
-      m_operand_neg = false;
-      m_const_mem_offset = 0;
-      m_uid = get_uid();
-      m_valid = true;
-      m_vector = false;
-      m_type = unsigned_t;
-      m_value.m_unsigned = x;
-      m_addr_offset = x;
-      m_neg_pred = false;
-      m_is_return_var = false;
-      m_immediate_address=true;
-   }
-   operand_info( int x, gpgpu_context* ctx )
-   {
-      init(ctx);
-      m_is_non_arch_reg = false;
-      m_addr_space = undefined_space;
-      m_operand_lohi = 0;
-      m_double_operand_type = 0;
-      m_operand_neg = false;
-      m_const_mem_offset = 0;
-      m_uid = get_uid();
-      m_valid = true;
-      m_vector = false;
-      m_type = int_t;
-      m_value.m_int = x;
-      m_addr_offset = 0;
-      m_neg_pred = false;
-      m_is_return_var = false;
-      m_immediate_address=false;
-   }
-   operand_info( float x, gpgpu_context* ctx )
-   {
-      init(ctx);
-      m_is_non_arch_reg = false;
-      m_addr_space = undefined_space;
-      m_operand_lohi = 0;
-      m_double_operand_type = 0;
-      m_operand_neg = false;
-      m_const_mem_offset = 0;
-      m_uid = get_uid();
-      m_valid = true;
-      m_vector = false;
-      m_type = float_op_t;
-      m_value.m_float = x;
-      m_addr_offset = 0;
-      m_neg_pred = false;
-      m_is_return_var = false;
-      m_immediate_address=false;
-   }
-   operand_info( double x, gpgpu_context* ctx )
-   {
-      init(ctx);
-      m_is_non_arch_reg = false;
-      m_addr_space = undefined_space;
-      m_operand_lohi = 0;
-      m_double_operand_type = 0;
-      m_operand_neg = false;
-      m_const_mem_offset = 0;
-      m_uid = get_uid();
-      m_valid = true;
-      m_vector = false;
-      m_type = double_op_t;
-      m_value.m_double = x;
-      m_addr_offset = 0;
-      m_neg_pred = false;
-      m_is_return_var = false;
-      m_immediate_address=false;
-   }
-   operand_info( const symbol *s1, const symbol *s2, const symbol *s3, const symbol *s4, gpgpu_context* ctx )
-   {
-      init(ctx);
-      m_is_non_arch_reg = false;
-      m_addr_space = undefined_space;
-      m_operand_lohi = 0;
-      m_double_operand_type = 0;
-      m_operand_neg = false;
-      m_const_mem_offset = 0;
-      m_uid = get_uid();
-      m_valid = true;
-      m_vector = true;
-      m_type = vector_t;
-      m_value.m_vector_symbolic = new const symbol*[8];
-      m_value.m_vector_symbolic[0] = s1;
-      m_value.m_vector_symbolic[1] = s2;
-      m_value.m_vector_symbolic[2] = s3;
-      m_value.m_vector_symbolic[3] = s4;
-      m_value.m_vector_symbolic[4] = NULL;
-      m_value.m_vector_symbolic[5] = NULL;
-      m_value.m_vector_symbolic[6] = NULL;
-      m_value.m_vector_symbolic[7] = NULL;
-      m_addr_offset = 0;
-      m_neg_pred = false;
-      m_is_return_var = false;
-      m_immediate_address=false;
-   }
-   operand_info( const symbol *s1, const symbol *s2, const symbol *s3, const symbol *s4 ,const symbol *s5,const symbol *s6,const symbol *s7, const symbol *s8, gpgpu_context* ctx)
-   {
-      init(ctx);
-      m_is_non_arch_reg = false;
-      m_addr_space = undefined_space;
-      m_operand_lohi = 0;
-      m_double_operand_type = 0;
-      m_operand_neg = false;
-      m_const_mem_offset = 0;
-      m_uid = get_uid();
-      m_valid = true;
-      m_vector = true;
-      m_type = vector_t;
-      m_value.m_vector_symbolic = new const symbol*[8];
-      m_value.m_vector_symbolic[0] = s1;
-      m_value.m_vector_symbolic[1] = s2;
-      m_value.m_vector_symbolic[2] = s3;
-      m_value.m_vector_symbolic[3] = s4;
-      m_value.m_vector_symbolic[4] = s5;
-      m_value.m_vector_symbolic[5] = s6;
-      m_value.m_vector_symbolic[6] = s7;
-      m_value.m_vector_symbolic[7] = s8;
-      m_addr_offset = 0;
-      m_neg_pred = false;
-      m_is_return_var = false;
-      m_immediate_address=false;
-   }
+ public:
+  operand_info(gpgpu_context *ctx) {
+    init(ctx);
+    m_is_non_arch_reg = false;
+    m_addr_space = undefined_space;
+    m_operand_lohi = 0;
+    m_double_operand_type = 0;
+    m_operand_neg = false;
+    m_const_mem_offset = 0;
+    m_uid = get_uid();
+    m_valid = false;
+    m_immediate_address = false;
+    m_addr_offset = 0;
+    m_value.m_symbolic = NULL;
+  }
+  operand_info(const symbol *addr, gpgpu_context *ctx) {
+    init(ctx);
+    m_is_non_arch_reg = false;
+    m_addr_space = undefined_space;
+    m_operand_lohi = 0;
+    m_double_operand_type = 0;
+    m_operand_neg = false;
+    m_const_mem_offset = 0;
+    m_uid = get_uid();
+    m_valid = true;
+    if (addr->is_label()) {
+      m_type = label_t;
+    } else if (addr->is_shared()) {
+      m_type = symbolic_t;
+    } else if (addr->is_const()) {
+      m_type = symbolic_t;
+    } else if (addr->is_global()) {
+      m_type = symbolic_t;
+    } else if (addr->is_local()) {
+      m_type = symbolic_t;
+    } else if (addr->is_param_local()) {
+      m_type = symbolic_t;
+    } else if (addr->is_param_kernel()) {
+      m_type = symbolic_t;
+    } else if (addr->is_tex()) {
+      m_type = symbolic_t;
+    } else if (addr->is_func_addr()) {
+      m_type = symbolic_t;
+    } else if (!addr->is_reg()) {
+      m_type = symbolic_t;
+    } else {
+      m_type = reg_t;
+    }
 
-   void init(gpgpu_context* ctx)
-   {
-       gpgpu_ctx = ctx;
-       m_uid=(unsigned)-1;
-       m_valid=false;
-       m_vector=false;
-       m_type=undef_t;
-       m_immediate_address=false;
-       m_addr_space=undefined_space;
-       m_operand_lohi=0;
-       m_double_operand_type=0;
-       m_operand_neg=false;
-       m_const_mem_offset=(unsigned)-1;
-       m_value.m_int=0;
-       m_value.m_unsigned=(unsigned)-1;
-       m_value.m_float=0;
-       m_value.m_double=0;
-       for(unsigned i=0; i<4; i++){
-           m_value.m_vint[i]=0;
-           m_value.m_vunsigned[i]=0;
-           m_value.m_vfloat[i]=0;
-           m_value.m_vdouble[i]=0;
-       }
-       m_value.m_symbolic=NULL;
-       m_value.m_vector_symbolic=NULL;
-       m_addr_offset=0;
-       m_neg_pred=0;
-       m_is_return_var=0;
-       m_is_non_arch_reg=0;
+    m_is_non_arch_reg = addr->is_non_arch_reg();
+    m_value.m_symbolic = addr;
+    m_addr_offset = 0;
+    m_vector = false;
+    m_neg_pred = false;
+    m_is_return_var = false;
+    m_immediate_address = false;
+  }
+  operand_info(const symbol *addr1, const symbol *addr2, gpgpu_context *ctx) {
+    init(ctx);
+    m_is_non_arch_reg = false;
+    m_addr_space = undefined_space;
+    m_operand_lohi = 0;
+    m_double_operand_type = 0;
+    m_operand_neg = false;
+    m_const_mem_offset = 0;
+    m_uid = get_uid();
+    m_valid = true;
+    m_type = memory_t;
+    m_value.m_vector_symbolic = new const symbol *[8];
+    m_value.m_vector_symbolic[0] = addr1;
+    m_value.m_vector_symbolic[1] = addr2;
+    m_value.m_vector_symbolic[2] = NULL;
+    m_value.m_vector_symbolic[3] = NULL;
+    m_value.m_vector_symbolic[4] = NULL;
+    m_value.m_vector_symbolic[5] = NULL;
+    m_value.m_vector_symbolic[6] = NULL;
+    m_value.m_vector_symbolic[7] = NULL;
+    m_addr_offset = 0;
+    m_vector = false;
+    m_neg_pred = false;
+    m_is_return_var = false;
+    m_immediate_address = false;
+  }
+  operand_info(int builtin_id, int dim_mod, gpgpu_context *ctx) {
+    init(ctx);
+    m_is_non_arch_reg = false;
+    m_addr_space = undefined_space;
+    m_operand_lohi = 0;
+    m_double_operand_type = 0;
+    m_operand_neg = false;
+    m_const_mem_offset = 0;
+    m_uid = get_uid();
+    m_valid = true;
+    m_vector = false;
+    m_type = builtin_t;
+    m_value.m_int = builtin_id;
+    m_addr_offset = dim_mod;
+    m_neg_pred = false;
+    m_is_return_var = false;
+    m_immediate_address = false;
+  }
+  operand_info(const symbol *addr, int offset, gpgpu_context *ctx) {
+    init(ctx);
+    m_is_non_arch_reg = false;
+    m_addr_space = undefined_space;
+    m_operand_lohi = 0;
+    m_double_operand_type = 0;
+    m_operand_neg = false;
+    m_const_mem_offset = 0;
+    m_uid = get_uid();
+    m_valid = true;
+    m_vector = false;
+    m_type = address_t;
+    m_value.m_symbolic = addr;
+    m_addr_offset = offset;
+    m_neg_pred = false;
+    m_is_return_var = false;
+    m_immediate_address = false;
+  }
+  operand_info(unsigned x, gpgpu_context *ctx) {
+    init(ctx);
+    m_is_non_arch_reg = false;
+    m_addr_space = undefined_space;
+    m_operand_lohi = 0;
+    m_double_operand_type = 0;
+    m_operand_neg = false;
+    m_const_mem_offset = 0;
+    m_uid = get_uid();
+    m_valid = true;
+    m_vector = false;
+    m_type = unsigned_t;
+    m_value.m_unsigned = x;
+    m_addr_offset = x;
+    m_neg_pred = false;
+    m_is_return_var = false;
+    m_immediate_address = true;
+  }
+  operand_info(int x, gpgpu_context *ctx) {
+    init(ctx);
+    m_is_non_arch_reg = false;
+    m_addr_space = undefined_space;
+    m_operand_lohi = 0;
+    m_double_operand_type = 0;
+    m_operand_neg = false;
+    m_const_mem_offset = 0;
+    m_uid = get_uid();
+    m_valid = true;
+    m_vector = false;
+    m_type = int_t;
+    m_value.m_int = x;
+    m_addr_offset = 0;
+    m_neg_pred = false;
+    m_is_return_var = false;
+    m_immediate_address = false;
+  }
+  operand_info(float x, gpgpu_context *ctx) {
+    init(ctx);
+    m_is_non_arch_reg = false;
+    m_addr_space = undefined_space;
+    m_operand_lohi = 0;
+    m_double_operand_type = 0;
+    m_operand_neg = false;
+    m_const_mem_offset = 0;
+    m_uid = get_uid();
+    m_valid = true;
+    m_vector = false;
+    m_type = float_op_t;
+    m_value.m_float = x;
+    m_addr_offset = 0;
+    m_neg_pred = false;
+    m_is_return_var = false;
+    m_immediate_address = false;
+  }
+  operand_info(double x, gpgpu_context *ctx) {
+    init(ctx);
+    m_is_non_arch_reg = false;
+    m_addr_space = undefined_space;
+    m_operand_lohi = 0;
+    m_double_operand_type = 0;
+    m_operand_neg = false;
+    m_const_mem_offset = 0;
+    m_uid = get_uid();
+    m_valid = true;
+    m_vector = false;
+    m_type = double_op_t;
+    m_value.m_double = x;
+    m_addr_offset = 0;
+    m_neg_pred = false;
+    m_is_return_var = false;
+    m_immediate_address = false;
+  }
+  operand_info(const symbol *s1, const symbol *s2, const symbol *s3,
+               const symbol *s4, gpgpu_context *ctx) {
+    init(ctx);
+    m_is_non_arch_reg = false;
+    m_addr_space = undefined_space;
+    m_operand_lohi = 0;
+    m_double_operand_type = 0;
+    m_operand_neg = false;
+    m_const_mem_offset = 0;
+    m_uid = get_uid();
+    m_valid = true;
+    m_vector = true;
+    m_type = vector_t;
+    m_value.m_vector_symbolic = new const symbol *[8];
+    m_value.m_vector_symbolic[0] = s1;
+    m_value.m_vector_symbolic[1] = s2;
+    m_value.m_vector_symbolic[2] = s3;
+    m_value.m_vector_symbolic[3] = s4;
+    m_value.m_vector_symbolic[4] = NULL;
+    m_value.m_vector_symbolic[5] = NULL;
+    m_value.m_vector_symbolic[6] = NULL;
+    m_value.m_vector_symbolic[7] = NULL;
+    m_addr_offset = 0;
+    m_neg_pred = false;
+    m_is_return_var = false;
+    m_immediate_address = false;
+  }
+  operand_info(const symbol *s1, const symbol *s2, const symbol *s3,
+               const symbol *s4, const symbol *s5, const symbol *s6,
+               const symbol *s7, const symbol *s8, gpgpu_context *ctx) {
+    init(ctx);
+    m_is_non_arch_reg = false;
+    m_addr_space = undefined_space;
+    m_operand_lohi = 0;
+    m_double_operand_type = 0;
+    m_operand_neg = false;
+    m_const_mem_offset = 0;
+    m_uid = get_uid();
+    m_valid = true;
+    m_vector = true;
+    m_type = vector_t;
+    m_value.m_vector_symbolic = new const symbol *[8];
+    m_value.m_vector_symbolic[0] = s1;
+    m_value.m_vector_symbolic[1] = s2;
+    m_value.m_vector_symbolic[2] = s3;
+    m_value.m_vector_symbolic[3] = s4;
+    m_value.m_vector_symbolic[4] = s5;
+    m_value.m_vector_symbolic[5] = s6;
+    m_value.m_vector_symbolic[6] = s7;
+    m_value.m_vector_symbolic[7] = s8;
+    m_addr_offset = 0;
+    m_neg_pred = false;
+    m_is_return_var = false;
+    m_immediate_address = false;
+  }
 
-   }
-   void make_memory_operand() { m_type = memory_t;}
-   void set_return() { m_is_return_var = true; }
-   void set_immediate_addr() {m_immediate_address=true;}
-   const std::string &name() const
-   {
-      assert( m_type == symbolic_t || m_type == reg_t || m_type == address_t || m_type == memory_t || m_type == label_t);
-      return m_value.m_symbolic->name();
-   }
+  void init(gpgpu_context *ctx) {
+    gpgpu_ctx = ctx;
+    m_uid = (unsigned)-1;
+    m_valid = false;
+    m_vector = false;
+    m_type = undef_t;
+    m_immediate_address = false;
+    m_addr_space = undefined_space;
+    m_operand_lohi = 0;
+    m_double_operand_type = 0;
+    m_operand_neg = false;
+    m_const_mem_offset = (unsigned)-1;
+    m_value.m_int = 0;
+    m_value.m_unsigned = (unsigned)-1;
+    m_value.m_float = 0;
+    m_value.m_double = 0;
+    for (unsigned i = 0; i < 4; i++) {
+      m_value.m_vint[i] = 0;
+      m_value.m_vunsigned[i] = 0;
+      m_value.m_vfloat[i] = 0;
+      m_value.m_vdouble[i] = 0;
+    }
+    m_value.m_symbolic = NULL;
+    m_value.m_vector_symbolic = NULL;
+    m_addr_offset = 0;
+    m_neg_pred = 0;
+    m_is_return_var = 0;
+    m_is_non_arch_reg = 0;
+  }
+  void make_memory_operand() { m_type = memory_t; }
+  void set_return() { m_is_return_var = true; }
+  void set_immediate_addr() { m_immediate_address = true; }
+  const std::string &name() const {
+    assert(m_type == symbolic_t || m_type == reg_t || m_type == address_t ||
+           m_type == memory_t || m_type == label_t);
+    return m_value.m_symbolic->name();
+  }
 
-   unsigned get_vect_nelem() const
-   {
-      assert( is_vector() );
-      if( !m_value.m_vector_symbolic[0] ) return 0;
-      if( !m_value.m_vector_symbolic[1] ) return 1;
-      if( !m_value.m_vector_symbolic[2] ) return 2;
-      if( !m_value.m_vector_symbolic[3] ) return 3;
-      if( !m_value.m_vector_symbolic[4] ) return 4;
-      if( !m_value.m_vector_symbolic[5] ) return 5;
-      if( !m_value.m_vector_symbolic[6] ) return 6;
-      if( !m_value.m_vector_symbolic[7] ) return 7;
-      return 8;
-   }
+  unsigned get_vect_nelem() const {
+    assert(is_vector());
+    if (!m_value.m_vector_symbolic[0]) return 0;
+    if (!m_value.m_vector_symbolic[1]) return 1;
+    if (!m_value.m_vector_symbolic[2]) return 2;
+    if (!m_value.m_vector_symbolic[3]) return 3;
+    if (!m_value.m_vector_symbolic[4]) return 4;
+    if (!m_value.m_vector_symbolic[5]) return 5;
+    if (!m_value.m_vector_symbolic[6]) return 6;
+    if (!m_value.m_vector_symbolic[7]) return 7;
+    return 8;
+  }
 
-   const symbol* vec_symbol(int idx) const 
-   {
-      assert(idx < 8);
-      const symbol *result = m_value.m_vector_symbolic[idx];
-      assert( result != NULL );
-      return result;
-   }
+  const symbol *vec_symbol(int idx) const {
+    assert(idx < 8);
+    const symbol *result = m_value.m_vector_symbolic[idx];
+    assert(result != NULL);
+    return result;
+  }
 
-   const std::string &vec_name1() const
-   {
-      assert( m_type == vector_t);
-      return m_value.m_vector_symbolic[0]->name();
-   }
+  const std::string &vec_name1() const {
+    assert(m_type == vector_t);
+    return m_value.m_vector_symbolic[0]->name();
+  }
 
-   const std::string &vec_name2() const
-   {
-      assert( m_type == vector_t);
-      return m_value.m_vector_symbolic[1]->name();
-   }
+  const std::string &vec_name2() const {
+    assert(m_type == vector_t);
+    return m_value.m_vector_symbolic[1]->name();
+  }
 
-   const std::string &vec_name3() const
-   {
-      assert( m_type == vector_t);
-      return m_value.m_vector_symbolic[2]->name();
-   }
+  const std::string &vec_name3() const {
+    assert(m_type == vector_t);
+    return m_value.m_vector_symbolic[2]->name();
+  }
 
-   const std::string &vec_name4() const
-   {
-      assert( m_type == vector_t);
-      return m_value.m_vector_symbolic[3]->name();
-   }
+  const std::string &vec_name4() const {
+    assert(m_type == vector_t);
+    return m_value.m_vector_symbolic[3]->name();
+  }
 
-   bool is_reg() const
-   {
-      if ( m_type == reg_t ) {
-         return true;
-      }
-      if ( m_type != symbolic_t ) {
-         return false;
-      }
-      return m_value.m_symbolic->type()->get_key().is_reg();
-   }
-   bool is_param_local() const
-   {
-      if ( m_type != symbolic_t ) 
-         return false;
-      return m_value.m_symbolic->type()->get_key().is_param_local();
-   }
-
-   bool is_param_kernel() const
-   {
-      if ( m_type != symbolic_t ) 
-         return false;
-      return m_value.m_symbolic->type()->get_key().is_param_kernel();
-   }
-
-   bool is_vector() const
-   {
-      if ( m_vector) return true;
+  bool is_reg() const {
+    if (m_type == reg_t) {
+      return true;
+    }
+    if (m_type != symbolic_t) {
       return false;
-   }
-   int reg_num() const { return m_value.m_symbolic->reg_num();}
-   int reg1_num() const { return m_value.m_vector_symbolic[0]->reg_num();}
-   int reg2_num() const { return m_value.m_vector_symbolic[1]->reg_num();}
-   int reg3_num() const { return m_value.m_vector_symbolic[2]?m_value.m_vector_symbolic[2]->reg_num():0; }
-   int reg4_num() const { return m_value.m_vector_symbolic[3]?m_value.m_vector_symbolic[3]->reg_num():0; }
-   int reg5_num() const { return m_value.m_vector_symbolic[4]?m_value.m_vector_symbolic[4]->reg_num():0; }
-   int reg6_num() const { return m_value.m_vector_symbolic[5]?m_value.m_vector_symbolic[5]->reg_num():0; }
-   int reg7_num() const { return m_value.m_vector_symbolic[6]?m_value.m_vector_symbolic[6]->reg_num():0; }
-   int reg8_num() const { return m_value.m_vector_symbolic[7]?m_value.m_vector_symbolic[7]->reg_num():0; }
-   int arch_reg_num() const { return m_value.m_symbolic->arch_reg_num(); }
-   int arch_reg_num(unsigned n) const { return (m_value.m_vector_symbolic[n])? m_value.m_vector_symbolic[n]->arch_reg_num() : -1; }
-   bool is_label() const { return m_type == label_t;}
-   bool is_builtin() const { return m_type == builtin_t;}
+    }
+    return m_value.m_symbolic->type()->get_key().is_reg();
+  }
+  bool is_param_local() const {
+    if (m_type != symbolic_t) return false;
+    return m_value.m_symbolic->type()->get_key().is_param_local();
+  }
 
-   // Memory operand used in ld / st instructions (ex. [__var1])
-   bool is_memory_operand() const { return m_type == memory_t;}
+  bool is_param_kernel() const {
+    if (m_type != symbolic_t) return false;
+    return m_value.m_symbolic->type()->get_key().is_param_kernel();
+  }
 
-   // Memory operand with immediate access (ex. s[0x0004] or g[$r1+=0x0004])
-   // This is used by the PTXPlus extension. The operand is assigned an address space during parsing.
-   bool is_memory_operand2() const { 
-      return (m_addr_space!=undefined_space); 
-   }
+  bool is_vector() const {
+    if (m_vector) return true;
+    return false;
+  }
+  int reg_num() const { return m_value.m_symbolic->reg_num(); }
+  int reg1_num() const { return m_value.m_vector_symbolic[0]->reg_num(); }
+  int reg2_num() const { return m_value.m_vector_symbolic[1]->reg_num(); }
+  int reg3_num() const {
+    return m_value.m_vector_symbolic[2]
+               ? m_value.m_vector_symbolic[2]->reg_num()
+               : 0;
+  }
+  int reg4_num() const {
+    return m_value.m_vector_symbolic[3]
+               ? m_value.m_vector_symbolic[3]->reg_num()
+               : 0;
+  }
+  int reg5_num() const {
+    return m_value.m_vector_symbolic[4]
+               ? m_value.m_vector_symbolic[4]->reg_num()
+               : 0;
+  }
+  int reg6_num() const {
+    return m_value.m_vector_symbolic[5]
+               ? m_value.m_vector_symbolic[5]->reg_num()
+               : 0;
+  }
+  int reg7_num() const {
+    return m_value.m_vector_symbolic[6]
+               ? m_value.m_vector_symbolic[6]->reg_num()
+               : 0;
+  }
+  int reg8_num() const {
+    return m_value.m_vector_symbolic[7]
+               ? m_value.m_vector_symbolic[7]->reg_num()
+               : 0;
+  }
+  int arch_reg_num() const { return m_value.m_symbolic->arch_reg_num(); }
+  int arch_reg_num(unsigned n) const {
+    return (m_value.m_vector_symbolic[n])
+               ? m_value.m_vector_symbolic[n]->arch_reg_num()
+               : -1;
+  }
+  bool is_label() const { return m_type == label_t; }
+  bool is_builtin() const { return m_type == builtin_t; }
 
-   bool is_immediate_address() const {
-       return   m_immediate_address;
-   }
+  // Memory operand used in ld / st instructions (ex. [__var1])
+  bool is_memory_operand() const { return m_type == memory_t; }
 
-   bool is_literal() const { return m_type == int_t ||
-      m_type == float_op_t ||
-      m_type == double_op_t ||
-      m_type == unsigned_t;} 
-   bool is_shared() const {
-      if ( !(m_type == symbolic_t || m_type == address_t || m_type == memory_t) ) {
-         return false;
-      }
-      return  m_value.m_symbolic->is_shared();
-   }
-   bool is_sstarr() const { return m_value.m_symbolic->is_sstarr();}
-   bool is_const() const { return m_value.m_symbolic->is_const();}
-   bool is_global() const { return m_value.m_symbolic->is_global();}
-   bool is_local() const { return m_value.m_symbolic->is_local();}
-   bool is_tex() const { return m_value.m_symbolic->is_tex();}
-   bool is_return_var() const { return m_is_return_var; }
+  // Memory operand with immediate access (ex. s[0x0004] or g[$r1+=0x0004])
+  // This is used by the PTXPlus extension. The operand is assigned an address
+  // space during parsing.
+  bool is_memory_operand2() const { return (m_addr_space != undefined_space); }
 
-   bool is_function_address() const
-   {
-      if( m_type != symbolic_t ) {
-         return false;
-      }
-      return m_value.m_symbolic->is_func_addr();
-   }
+  bool is_immediate_address() const { return m_immediate_address; }
 
-   ptx_reg_t get_literal_value() const
-   {
-      ptx_reg_t result;
-      switch ( m_type ) {
-      case int_t:         result.s64 = m_value.m_int; break;
-      case float_op_t:    result.f32 = m_value.m_float; break;
-      case double_op_t:   result.f64 = m_value.m_double; break; 
-      case unsigned_t:    result.u32 = m_value.m_unsigned; break;
+  bool is_literal() const {
+    return m_type == int_t || m_type == float_op_t || m_type == double_op_t ||
+           m_type == unsigned_t;
+  }
+  bool is_shared() const {
+    if (!(m_type == symbolic_t || m_type == address_t || m_type == memory_t)) {
+      return false;
+    }
+    return m_value.m_symbolic->is_shared();
+  }
+  bool is_sstarr() const { return m_value.m_symbolic->is_sstarr(); }
+  bool is_const() const { return m_value.m_symbolic->is_const(); }
+  bool is_global() const { return m_value.m_symbolic->is_global(); }
+  bool is_local() const { return m_value.m_symbolic->is_local(); }
+  bool is_tex() const { return m_value.m_symbolic->is_tex(); }
+  bool is_return_var() const { return m_is_return_var; }
+
+  bool is_function_address() const {
+    if (m_type != symbolic_t) {
+      return false;
+    }
+    return m_value.m_symbolic->is_func_addr();
+  }
+
+  ptx_reg_t get_literal_value() const {
+    ptx_reg_t result;
+    switch (m_type) {
+      case int_t:
+        result.s64 = m_value.m_int;
+        break;
+      case float_op_t:
+        result.f32 = m_value.m_float;
+        break;
+      case double_op_t:
+        result.f64 = m_value.m_double;
+        break;
+      case unsigned_t:
+        result.u32 = m_value.m_unsigned;
+        break;
       default:
-         assert(0);
-         break;
-      } 
-      return result;
-   }
-   int get_int() const { return m_value.m_int;}
-   int get_addr_offset() const { return m_addr_offset;}
-   const symbol *get_symbol() const { return m_value.m_symbolic;}
-   void set_type( enum operand_type type ) 
-   {
-      m_type = type;
-   }
-   enum operand_type get_type() const {
-      return m_type;
-   }
-   void set_neg_pred()
-   {
-      assert( m_valid );
-      m_neg_pred = true;
-   }
-   bool is_neg_pred() const { return m_neg_pred; }
-   bool is_valid() const { return m_valid; }
+        assert(0);
+        break;
+    }
+    return result;
+  }
+  int get_int() const { return m_value.m_int; }
+  int get_addr_offset() const { return m_addr_offset; }
+  const symbol *get_symbol() const { return m_value.m_symbolic; }
+  void set_type(enum operand_type type) { m_type = type; }
+  enum operand_type get_type() const { return m_type; }
+  void set_neg_pred() {
+    assert(m_valid);
+    m_neg_pred = true;
+  }
+  bool is_neg_pred() const { return m_neg_pred; }
+  bool is_valid() const { return m_valid; }
 
-   void set_addr_space(enum _memory_space_t set_value) { m_addr_space = set_value; }
-   enum _memory_space_t get_addr_space() const { return m_addr_space; }
-   void set_operand_lohi(int set_value) { m_operand_lohi = set_value; }
-   int get_operand_lohi() const { return m_operand_lohi; }
-   void set_double_operand_type(int set_value) {  m_double_operand_type = set_value; }
-   int get_double_operand_type() const { return  m_double_operand_type; }
-   void set_operand_neg() { m_operand_neg = true; }
-   bool get_operand_neg() const { return m_operand_neg; }
-   void set_const_mem_offset(addr_t set_value) { m_const_mem_offset = set_value; }
-   addr_t get_const_mem_offset() const { return m_const_mem_offset; }
-   bool is_non_arch_reg() const { return m_is_non_arch_reg; }
+  void set_addr_space(enum _memory_space_t set_value) {
+    m_addr_space = set_value;
+  }
+  enum _memory_space_t get_addr_space() const { return m_addr_space; }
+  void set_operand_lohi(int set_value) { m_operand_lohi = set_value; }
+  int get_operand_lohi() const { return m_operand_lohi; }
+  void set_double_operand_type(int set_value) {
+    m_double_operand_type = set_value;
+  }
+  int get_double_operand_type() const { return m_double_operand_type; }
+  void set_operand_neg() { m_operand_neg = true; }
+  bool get_operand_neg() const { return m_operand_neg; }
+  void set_const_mem_offset(addr_t set_value) {
+    m_const_mem_offset = set_value;
+  }
+  addr_t get_const_mem_offset() const { return m_const_mem_offset; }
+  bool is_non_arch_reg() const { return m_is_non_arch_reg; }
 
-private:
-   gpgpu_context* gpgpu_ctx;
-   unsigned m_uid;
-   bool m_valid;
-   bool m_vector;
-   enum operand_type m_type;
-   bool m_immediate_address;
-   enum _memory_space_t m_addr_space;
-   int m_operand_lohi;
-   int m_double_operand_type;
-   bool m_operand_neg;
-   addr_t m_const_mem_offset;
-   union {
-      int             m_int;
-      unsigned int    m_unsigned;
-      float           m_float;
-      double          m_double;
-      int             m_vint[4];
-      unsigned int    m_vunsigned[4];
-      float           m_vfloat[4];
-      double          m_vdouble[4];
-      const symbol*  m_symbolic;
-      const symbol**  m_vector_symbolic;
-   } m_value;
+ private:
+  gpgpu_context *gpgpu_ctx;
+  unsigned m_uid;
+  bool m_valid;
+  bool m_vector;
+  enum operand_type m_type;
+  bool m_immediate_address;
+  enum _memory_space_t m_addr_space;
+  int m_operand_lohi;
+  int m_double_operand_type;
+  bool m_operand_neg;
+  addr_t m_const_mem_offset;
+  union {
+    int m_int;
+    unsigned int m_unsigned;
+    float m_float;
+    double m_double;
+    int m_vint[4];
+    unsigned int m_vunsigned[4];
+    float m_vfloat[4];
+    double m_vdouble[4];
+    const symbol *m_symbolic;
+    const symbol **m_vector_symbolic;
+  } m_value;
 
-   int m_addr_offset;
+  int m_addr_offset;
 
-   bool m_neg_pred;
-   bool m_is_return_var;
-   bool m_is_non_arch_reg;
+  bool m_neg_pred;
+  bool m_is_return_var;
+  bool m_is_non_arch_reg;
 
-   unsigned get_uid();
+  unsigned get_uid();
 };
 
 extern const char *g_opcode_string[];
 struct basic_block_t {
-   basic_block_t( unsigned ID, ptx_instruction *begin, ptx_instruction *end, bool entry, bool ex)
-   {
-      bb_id = ID;
-      ptx_begin = begin;
-      ptx_end = end;
-      is_entry=entry;
-      is_exit=ex;
-      immediatepostdominator_id = -1;
-      immediatedominator_id = -1;
-   }
+  basic_block_t(unsigned ID, ptx_instruction *begin, ptx_instruction *end,
+                bool entry, bool ex) {
+    bb_id = ID;
+    ptx_begin = begin;
+    ptx_end = end;
+    is_entry = entry;
+    is_exit = ex;
+    immediatepostdominator_id = -1;
+    immediatedominator_id = -1;
+  }
 
-   ptx_instruction* ptx_begin;
-   ptx_instruction* ptx_end;
-   std::set<int> predecessor_ids; //indices of other basic blocks in m_basic_blocks array
-   std::set<int> successor_ids;
-   std::set<int> postdominator_ids;
-   std::set<int> dominator_ids;
-   std::set<int> Tmp_ids;
-   int immediatepostdominator_id;
-   int immediatedominator_id;
-   bool is_entry;
-   bool is_exit;
-   unsigned bb_id;
+  ptx_instruction *ptx_begin;
+  ptx_instruction *ptx_end;
+  std::set<int>
+      predecessor_ids;  // indices of other basic blocks in m_basic_blocks array
+  std::set<int> successor_ids;
+  std::set<int> postdominator_ids;
+  std::set<int> dominator_ids;
+  std::set<int> Tmp_ids;
+  int immediatepostdominator_id;
+  int immediatedominator_id;
+  bool is_entry;
+  bool is_exit;
+  unsigned bb_id;
 
-   // if this basic block dom B
-   bool dom(const basic_block_t *B) {
-      return (B->dominator_ids.find(this->bb_id) != B->dominator_ids.end());
-   }
+  // if this basic block dom B
+  bool dom(const basic_block_t *B) {
+    return (B->dominator_ids.find(this->bb_id) != B->dominator_ids.end());
+  }
 
-   // if this basic block pdom B
-   bool pdom(const basic_block_t *B) {
-      return (B->postdominator_ids.find(this->bb_id) != B->postdominator_ids.end());
-   }
+  // if this basic block pdom B
+  bool pdom(const basic_block_t *B) {
+    return (B->postdominator_ids.find(this->bb_id) !=
+            B->postdominator_ids.end());
+  }
 };
 
 struct gpgpu_recon_t {
-   address_type source_pc;
-   address_type target_pc;
-   class ptx_instruction* source_inst;
-   class ptx_instruction* target_inst;
+  address_type source_pc;
+  address_type target_pc;
+  class ptx_instruction *source_inst;
+  class ptx_instruction *target_inst;
 };
 
 class ptx_instruction : public warp_inst_t {
-public:
-    ptx_instruction( int opcode, 
-                    const symbol *pred, 
-                    int neg_pred, 
-                    int pred_mod,
-                    symbol *label,
-                    const std::list<operand_info> &operands, 
-                    const operand_info &return_var,
-                    const std::list<int> &options, 
-                    const std::list<int> &wmma_options, 
-                    const std::list<int> &scalar_type,
-                    memory_space_t space_spec,
-                    const char *file, 
-                    unsigned line,
-                    const char *source,
-                    const core_config *config,
-		    gpgpu_context* ctx);
+ public:
+  ptx_instruction(int opcode, const symbol *pred, int neg_pred, int pred_mod,
+                  symbol *label, const std::list<operand_info> &operands,
+                  const operand_info &return_var, const std::list<int> &options,
+                  const std::list<int> &wmma_options,
+                  const std::list<int> &scalar_type, memory_space_t space_spec,
+                  const char *file, unsigned line, const char *source,
+                  const core_config *config, gpgpu_context *ctx);
 
-   void print_insn() const;
-   virtual void print_insn( FILE *fp ) const;
-   std::string to_string() const;
-   unsigned inst_size() const { return m_inst_size; }
-   unsigned uid() const { return m_uid;}
-   int get_opcode() const { return m_opcode;}
-   const char *get_opcode_cstr() const 
-   {
-      if ( m_opcode != -1 ) {
-         return g_opcode_string[m_opcode]; 
-      } else {
-         return "label";
-      }
-   }
-   const char *source_file() const { return m_source_file.c_str();} 
-   unsigned source_line() const { return m_source_line;}
-   unsigned get_num_operands() const { return m_operands.size();}
-   bool has_pred() const { return m_pred != NULL;}
-   operand_info get_pred() const;
-   bool get_pred_neg() const { return m_neg_pred;}
-   int get_pred_mod() const { return m_pred_mod;}
-   const char *get_source() const { return m_source.c_str();}
+  void print_insn() const;
+  virtual void print_insn(FILE *fp) const;
+  std::string to_string() const;
+  unsigned inst_size() const { return m_inst_size; }
+  unsigned uid() const { return m_uid; }
+  int get_opcode() const { return m_opcode; }
+  const char *get_opcode_cstr() const {
+    if (m_opcode != -1) {
+      return g_opcode_string[m_opcode];
+    } else {
+      return "label";
+    }
+  }
+  const char *source_file() const { return m_source_file.c_str(); }
+  unsigned source_line() const { return m_source_line; }
+  unsigned get_num_operands() const { return m_operands.size(); }
+  bool has_pred() const { return m_pred != NULL; }
+  operand_info get_pred() const;
+  bool get_pred_neg() const { return m_neg_pred; }
+  int get_pred_mod() const { return m_pred_mod; }
+  const char *get_source() const { return m_source.c_str(); }
 
-   typedef std::vector<operand_info>::const_iterator const_iterator;
+  typedef std::vector<operand_info>::const_iterator const_iterator;
 
-   const_iterator op_iter_begin() const 
-   { 
-      return m_operands.begin();
-   }
+  const_iterator op_iter_begin() const { return m_operands.begin(); }
 
-   const_iterator op_iter_end() const 
-   { 
-      return m_operands.end();
-   }
+  const_iterator op_iter_end() const { return m_operands.end(); }
 
-   const operand_info &dst() const 
-   { 
-      assert( !m_operands.empty() );
+  const operand_info &dst() const {
+    assert(!m_operands.empty());
+    return m_operands[0];
+  }
+
+  const operand_info &func_addr() const {
+    assert(!m_operands.empty());
+    if (!m_operands[0].is_return_var()) {
       return m_operands[0];
-   }
-
-   const operand_info &func_addr() const
-   {
-      assert( !m_operands.empty() );
-      if( !m_operands[0].is_return_var() ) {
-         return m_operands[0];
-      } else {
-         assert( m_operands.size() >= 2 );
-         return m_operands[1];
-      }
-   }
-
-   operand_info &dst() 
-   { 
-      assert( !m_operands.empty() );
-      return m_operands[0];
-   }
-
-   const operand_info &src1() const 
-   { 
-      assert( m_operands.size() > 1 );
+    } else {
+      assert(m_operands.size() >= 2);
       return m_operands[1];
-   }
+    }
+  }
 
-   const operand_info &src2() const 
-   { 
-      assert( m_operands.size() > 2 );
-      return m_operands[2];
-   }
+  operand_info &dst() {
+    assert(!m_operands.empty());
+    return m_operands[0];
+  }
 
-   const operand_info &src3() const 
-   { 
-      assert( m_operands.size() > 3 );
-      return m_operands[3];
-   }
-   const operand_info &src4() const 
-   { 
-      assert( m_operands.size() > 4 );
-      return m_operands[4];
-   }
-   const operand_info &src5() const 
-   { 
-      assert( m_operands.size() > 5 );
-      return m_operands[5];
-   }
-   const operand_info &src6() const 
-   { 
-      assert( m_operands.size() > 6 );
-      return m_operands[6];
-   }
-   const operand_info &src7() const 
-   { 
-      assert( m_operands.size() > 7 );
-      return m_operands[7];
-   }
-   const operand_info &src8() const 
-   { 
-      assert( m_operands.size() > 8 );
-      return m_operands[8];
-   }
+  const operand_info &src1() const {
+    assert(m_operands.size() > 1);
+    return m_operands[1];
+  }
 
-   const operand_info &operand_lookup( unsigned n ) const
-   {
-      assert( n < m_operands.size() );
-      return m_operands[n];
-   }
-   bool has_return() const
-   {
-      return m_return_var.is_valid();
-   }
+  const operand_info &src2() const {
+    assert(m_operands.size() > 2);
+    return m_operands[2];
+  }
 
-   memory_space_t get_space() const { return m_space_spec;}
-   unsigned get_vector() const { return m_vector_spec;}
-   unsigned get_atomic() const { return m_atomic_spec;}
+  const operand_info &src3() const {
+    assert(m_operands.size() > 3);
+    return m_operands[3];
+  }
+  const operand_info &src4() const {
+    assert(m_operands.size() > 4);
+    return m_operands[4];
+  }
+  const operand_info &src5() const {
+    assert(m_operands.size() > 5);
+    return m_operands[5];
+  }
+  const operand_info &src6() const {
+    assert(m_operands.size() > 6);
+    return m_operands[6];
+  }
+  const operand_info &src7() const {
+    assert(m_operands.size() > 7);
+    return m_operands[7];
+  }
+  const operand_info &src8() const {
+    assert(m_operands.size() > 8);
+    return m_operands[8];
+  }
 
-   int get_wmma_type() const {
-      return m_wmma_type;
-   }
-   int get_wmma_layout(int index) const {
-      return m_wmma_layout[index];//0->Matrix D,1->Matrix C
-   }
-   int get_type() const 
-   {
-      assert( !m_scalar_type.empty() );
-      return m_scalar_type.front();
-   }
+  const operand_info &operand_lookup(unsigned n) const {
+    assert(n < m_operands.size());
+    return m_operands[n];
+  }
+  bool has_return() const { return m_return_var.is_valid(); }
 
-   int get_type2() const 
-   {
-      assert( m_scalar_type.size()==2 );
-      return m_scalar_type.back();
-   }
+  memory_space_t get_space() const { return m_space_spec; }
+  unsigned get_vector() const { return m_vector_spec; }
+  unsigned get_atomic() const { return m_atomic_spec; }
 
-   void assign_bb(basic_block_t* basic_block) //assign instruction to a basic block
-   {
-      m_basic_block = basic_block;
-   }
-   basic_block_t* get_bb() { return m_basic_block;}
-   void set_m_instr_mem_index(unsigned index) {
-      m_instr_mem_index = index; 
-   }
-   void set_PC( addr_t PC )
-   {
-       m_PC = PC;
-   }
-   addr_t get_PC() const
-   {
-       return m_PC;
-   }
+  int get_wmma_type() const { return m_wmma_type; }
+  int get_wmma_layout(int index) const {
+    return m_wmma_layout[index];  // 0->Matrix D,1->Matrix C
+  }
+  int get_type() const {
+    assert(!m_scalar_type.empty());
+    return m_scalar_type.front();
+  }
 
-   unsigned get_m_instr_mem_index() { return m_instr_mem_index;}
-   unsigned get_cmpop() const { return m_compare_op;}
-   const symbol *get_label() const { return m_label;}
-   bool is_label() const { if(m_label){ assert(m_opcode==-1);return true;} return false;}
-   bool is_hi() const { return m_hi;}
-   bool is_lo() const { return m_lo;}
-   bool is_wide() const { return m_wide;}
-   bool is_uni() const { return m_uni;}
-   bool is_exit() const { return m_exit;}
-   bool is_abs() const { return m_abs;}
-   bool is_neg() const { return m_neg;}
-   bool is_to() const { return m_to_option; }
-   unsigned cache_option() const { return m_cache_option; }
-   unsigned rounding_mode() const { return m_rounding_mode;}
-   unsigned saturation_mode() const { return m_saturation_mode;}
-   unsigned dimension() const { return m_geom_spec;}
-   unsigned barrier_op() const {return m_barrier_op;}
-   unsigned shfl_op() const {return m_shfl_op;}
-   unsigned prmt_op() const {return m_prmt_op;}
-   enum vote_mode_t { vote_any, vote_all, vote_uni, vote_ballot };
-   enum vote_mode_t vote_mode() const { return m_vote_mode; }
+  int get_type2() const {
+    assert(m_scalar_type.size() == 2);
+    return m_scalar_type.back();
+  }
 
-   int membar_level() const { return m_membar_level; }
+  void assign_bb(
+      basic_block_t *basic_block)  // assign instruction to a basic block
+  {
+    m_basic_block = basic_block;
+  }
+  basic_block_t *get_bb() { return m_basic_block; }
+  void set_m_instr_mem_index(unsigned index) { m_instr_mem_index = index; }
+  void set_PC(addr_t PC) { m_PC = PC; }
+  addr_t get_PC() const { return m_PC; }
 
-   bool has_memory_read() const {
-      if( m_opcode == LD_OP || m_opcode == LDU_OP || m_opcode == TEX_OP|| m_opcode==MMA_LD_OP ) 
-         return true;
-      // Check PTXPlus operand type below
-      // Source operands are memory operands
-      ptx_instruction::const_iterator op=op_iter_begin();
-      for ( int n=0; op != op_iter_end(); op++, n++ ) { //process operands
-         if( n > 0 && op->is_memory_operand2()) // source operands only
-            return true;
-      }
-      return false;
-   }
-   bool has_memory_write() const {
-      if( m_opcode == ST_OP || m_opcode==MMA_ST_OP ) return true;
-      // Check PTXPlus operand type below
-      // Destination operand is a memory operand
-      ptx_instruction::const_iterator op=op_iter_begin();
-      for ( int n=0; (op!=op_iter_end() && n<1); op++, n++ ) { //process operands
-         if( n==0 && op->is_memory_operand2()) // source operands only
-            return true;
-      }
-      return false;
-   }
+  unsigned get_m_instr_mem_index() { return m_instr_mem_index; }
+  unsigned get_cmpop() const { return m_compare_op; }
+  const symbol *get_label() const { return m_label; }
+  bool is_label() const {
+    if (m_label) {
+      assert(m_opcode == -1);
+      return true;
+    }
+    return false;
+  }
+  bool is_hi() const { return m_hi; }
+  bool is_lo() const { return m_lo; }
+  bool is_wide() const { return m_wide; }
+  bool is_uni() const { return m_uni; }
+  bool is_exit() const { return m_exit; }
+  bool is_abs() const { return m_abs; }
+  bool is_neg() const { return m_neg; }
+  bool is_to() const { return m_to_option; }
+  unsigned cache_option() const { return m_cache_option; }
+  unsigned rounding_mode() const { return m_rounding_mode; }
+  unsigned saturation_mode() const { return m_saturation_mode; }
+  unsigned dimension() const { return m_geom_spec; }
+  unsigned barrier_op() const { return m_barrier_op; }
+  unsigned shfl_op() const { return m_shfl_op; }
+  unsigned prmt_op() const { return m_prmt_op; }
+  enum vote_mode_t { vote_any, vote_all, vote_uni, vote_ballot };
+  enum vote_mode_t vote_mode() const { return m_vote_mode; }
 
+  int membar_level() const { return m_membar_level; }
 
-private:
-   void set_opcode_and_latency();
-   void set_bar_type();
-   void set_fp_or_int_archop();
-   void set_mul_div_or_other_archop();
+  bool has_memory_read() const {
+    if (m_opcode == LD_OP || m_opcode == LDU_OP || m_opcode == TEX_OP ||
+        m_opcode == MMA_LD_OP)
+      return true;
+    // Check PTXPlus operand type below
+    // Source operands are memory operands
+    ptx_instruction::const_iterator op = op_iter_begin();
+    for (int n = 0; op != op_iter_end(); op++, n++) {  // process operands
+      if (n > 0 && op->is_memory_operand2())           // source operands only
+        return true;
+    }
+    return false;
+  }
+  bool has_memory_write() const {
+    if (m_opcode == ST_OP || m_opcode == MMA_ST_OP) return true;
+    // Check PTXPlus operand type below
+    // Destination operand is a memory operand
+    ptx_instruction::const_iterator op = op_iter_begin();
+    for (int n = 0; (op != op_iter_end() && n < 1);
+         op++, n++) {                          // process operands
+      if (n == 0 && op->is_memory_operand2())  // source operands only
+        return true;
+    }
+    return false;
+  }
 
-   basic_block_t        *m_basic_block;
-   unsigned          m_uid;
-   addr_t            m_PC;
-   std::string             m_source_file;
-   unsigned                m_source_line;
-   std::string          m_source;
+ private:
+  void set_opcode_and_latency();
+  void set_bar_type();
+  void set_fp_or_int_archop();
+  void set_mul_div_or_other_archop();
 
-   const symbol           *m_pred;
-   bool                    m_neg_pred;
-   int                    m_pred_mod;
-   int                     m_opcode;
-   const symbol           *m_label;
-   std::vector<operand_info> m_operands;
-   operand_info m_return_var;
+  basic_block_t *m_basic_block;
+  unsigned m_uid;
+  addr_t m_PC;
+  std::string m_source_file;
+  unsigned m_source_line;
+  std::string m_source;
 
-   std::list<int>          m_options;
-   std::list<int>          m_wmma_options;
-   bool                m_wide;
-   bool                m_hi;
-   bool                m_lo;
-   bool                m_exit;
-   bool                m_abs;
-   bool                m_neg;
-   bool                m_uni; //if branch instruction, this evaluates to true for uniform branches (ie jumps)
-   bool                m_to_option;
-   unsigned            m_cache_option;
-   int      m_wmma_type;
-   int      m_wmma_layout[2];
-   int      m_wmma_configuration;
-   unsigned            m_rounding_mode;
-   unsigned            m_compare_op;
-   unsigned            m_saturation_mode;
-   unsigned 		   m_barrier_op;
-   unsigned			   m_shfl_op;
-   unsigned			   m_prmt_op;
+  const symbol *m_pred;
+  bool m_neg_pred;
+  int m_pred_mod;
+  int m_opcode;
+  const symbol *m_label;
+  std::vector<operand_info> m_operands;
+  operand_info m_return_var;
 
-   std::list<int>          m_scalar_type;
-   memory_space_t m_space_spec;
-   int m_geom_spec;
-   int m_vector_spec;
-   int m_atomic_spec;
-   enum vote_mode_t m_vote_mode;
-   int m_membar_level;
-   int m_instr_mem_index; //index into m_instr_mem array
-   unsigned m_inst_size; // bytes
+  std::list<int> m_options;
+  std::list<int> m_wmma_options;
+  bool m_wide;
+  bool m_hi;
+  bool m_lo;
+  bool m_exit;
+  bool m_abs;
+  bool m_neg;
+  bool m_uni;  // if branch instruction, this evaluates to true for uniform
+               // branches (ie jumps)
+  bool m_to_option;
+  unsigned m_cache_option;
+  int m_wmma_type;
+  int m_wmma_layout[2];
+  int m_wmma_configuration;
+  unsigned m_rounding_mode;
+  unsigned m_compare_op;
+  unsigned m_saturation_mode;
+  unsigned m_barrier_op;
+  unsigned m_shfl_op;
+  unsigned m_prmt_op;
 
-   virtual void pre_decode();
-   friend class function_info;
-   // backward pointer
-   class gpgpu_context* gpgpu_ctx;
+  std::list<int> m_scalar_type;
+  memory_space_t m_space_spec;
+  int m_geom_spec;
+  int m_vector_spec;
+  int m_atomic_spec;
+  enum vote_mode_t m_vote_mode;
+  int m_membar_level;
+  int m_instr_mem_index;  // index into m_instr_mem array
+  unsigned m_inst_size;   // bytes
+
+  virtual void pre_decode();
+  friend class function_info;
+  // backward pointer
+  class gpgpu_context *gpgpu_ctx;
 };
 
 class param_info {
-public:
-   param_info() { m_valid = false; m_value_set=false; m_size = 0; m_is_ptr = false; }
-   param_info( std::string name, int type, size_t size, bool is_ptr, memory_space_t ptr_space ) 
-   {
-      m_valid = true;
-      m_value_set = false;
-      m_name = name;
-      m_type = type;
-      m_size = size;
-      m_is_ptr = is_ptr; 
-      m_ptr_space = ptr_space; 
-   }
-   void add_data( param_t v ) { 
-      assert( (!m_value_set) || (m_value.size == v.size) ); // if this fails concurrent kernel launches might execute incorrectly
-      m_value_set = true;
-      m_value = v;
-   }
-   void add_offset( unsigned offset ) { m_offset = offset; }
-   unsigned get_offset() { assert(m_valid); return m_offset; }
-   std::string get_name() const { assert(m_valid); return m_name; }
-   int get_type() const { assert(m_valid);  return m_type; }
-   param_t get_value() const { assert(m_value_set); return m_value; }
-   size_t get_size() const { assert(m_valid); return m_size; }
-   bool is_ptr_shared() const { assert(m_valid); return (m_is_ptr and m_ptr_space == shared_space); }
-private:
-   bool m_valid;
-   std::string m_name;
-   int m_type;
-   size_t m_size;
-   bool m_value_set;
-   param_t m_value;
-   unsigned m_offset;
-   bool m_is_ptr; 
-   memory_space_t m_ptr_space; 
+ public:
+  param_info() {
+    m_valid = false;
+    m_value_set = false;
+    m_size = 0;
+    m_is_ptr = false;
+  }
+  param_info(std::string name, int type, size_t size, bool is_ptr,
+             memory_space_t ptr_space) {
+    m_valid = true;
+    m_value_set = false;
+    m_name = name;
+    m_type = type;
+    m_size = size;
+    m_is_ptr = is_ptr;
+    m_ptr_space = ptr_space;
+  }
+  void add_data(param_t v) {
+    assert((!m_value_set) ||
+           (m_value.size == v.size));  // if this fails concurrent kernel
+                                       // launches might execute incorrectly
+    m_value_set = true;
+    m_value = v;
+  }
+  void add_offset(unsigned offset) { m_offset = offset; }
+  unsigned get_offset() {
+    assert(m_valid);
+    return m_offset;
+  }
+  std::string get_name() const {
+    assert(m_valid);
+    return m_name;
+  }
+  int get_type() const {
+    assert(m_valid);
+    return m_type;
+  }
+  param_t get_value() const {
+    assert(m_value_set);
+    return m_value;
+  }
+  size_t get_size() const {
+    assert(m_valid);
+    return m_size;
+  }
+  bool is_ptr_shared() const {
+    assert(m_valid);
+    return (m_is_ptr and m_ptr_space == shared_space);
+  }
+
+ private:
+  bool m_valid;
+  std::string m_name;
+  int m_type;
+  size_t m_size;
+  bool m_value_set;
+  param_t m_value;
+  unsigned m_offset;
+  bool m_is_ptr;
+  memory_space_t m_ptr_space;
 };
 
 class function_info {
-public:
-   function_info(int entry_point, gpgpu_context* ctx );
-   const ptx_version &get_ptx_version() const { return m_symtab->get_ptx_version(); }
-   unsigned get_sm_target() const { return m_symtab->get_sm_target(); }
-   bool is_extern() const { return m_extern; }
-   void set_name(const char *name)
-   {
-      m_name = name;
-   }
-   void set_symtab(symbol_table *symtab )
-   {
-      m_symtab = symtab;
-   }
-   std::string get_name() const
-   {
-      return m_name;
-   }
-   unsigned print_insn( unsigned pc, FILE * fp ) const;
-    std::string get_insn_str( unsigned pc ) const;
-   void add_inst( const std::list<ptx_instruction*> &instructions )
-   {
-      m_instructions = instructions;
-   }
-   std::list<ptx_instruction*>::iterator find_next_real_instruction( std::list<ptx_instruction*>::iterator i );
-   void create_basic_blocks( );
+ public:
+  function_info(int entry_point, gpgpu_context *ctx);
+  const ptx_version &get_ptx_version() const {
+    return m_symtab->get_ptx_version();
+  }
+  unsigned get_sm_target() const { return m_symtab->get_sm_target(); }
+  bool is_extern() const { return m_extern; }
+  void set_name(const char *name) { m_name = name; }
+  void set_symtab(symbol_table *symtab) { m_symtab = symtab; }
+  std::string get_name() const { return m_name; }
+  unsigned print_insn(unsigned pc, FILE *fp) const;
+  std::string get_insn_str(unsigned pc) const;
+  void add_inst(const std::list<ptx_instruction *> &instructions) {
+    m_instructions = instructions;
+  }
+  std::list<ptx_instruction *>::iterator find_next_real_instruction(
+      std::list<ptx_instruction *>::iterator i);
+  void create_basic_blocks();
 
-   void print_basic_blocks();
+  void print_basic_blocks();
 
-   void print_basic_block_links();
-   void print_basic_block_dot();
+  void print_basic_block_links();
+  void print_basic_block_dot();
 
-   operand_info* find_break_target( ptx_instruction * p_break_insn ); //find the target of a break instruction 
-   void connect_basic_blocks( ); //iterate across m_basic_blocks of function, connecting basic blocks together
-   bool connect_break_targets(); //connecting break instructions with proper targets
+  operand_info *find_break_target(
+      ptx_instruction *p_break_insn);  // find the target of a break instruction
+  void connect_basic_blocks();  // iterate across m_basic_blocks of function,
+                                // connecting basic blocks together
+  bool
+  connect_break_targets();  // connecting break instructions with proper targets
 
-   //iterate across m_basic_blocks of function, 
-   //finding dominator blocks, using algorithm of
-   //Muchnick's Adv. Compiler Design & Implemmntation Fig 7.14 
-   void find_dominators( );
-   void print_dominators();
-   void find_idominators();
-   void print_idominators();
+  // iterate across m_basic_blocks of function,
+  // finding dominator blocks, using algorithm of
+  // Muchnick's Adv. Compiler Design & Implemmntation Fig 7.14
+  void find_dominators();
+  void print_dominators();
+  void find_idominators();
+  void print_idominators();
 
-   //iterate across m_basic_blocks of function, 
-   //finding postdominator blocks, using algorithm of
-   //Muchnick's Adv. Compiler Design & Implemmntation Fig 7.14 
-   void find_postdominators( );
-   void print_postdominators();
+  // iterate across m_basic_blocks of function,
+  // finding postdominator blocks, using algorithm of
+  // Muchnick's Adv. Compiler Design & Implemmntation Fig 7.14
+  void find_postdominators();
+  void print_postdominators();
 
-   //iterate across m_basic_blocks of function, 
-   //finding immediate postdominator blocks, using algorithm of
-   //Muchnick's Adv. Compiler Design & Implemmntation Fig 7.15 
-   void find_ipostdominators( );
-   void print_ipostdominators();
-   void do_pdom(); //function to call pdom analysis
+  // iterate across m_basic_blocks of function,
+  // finding immediate postdominator blocks, using algorithm of
+  // Muchnick's Adv. Compiler Design & Implemmntation Fig 7.15
+  void find_ipostdominators();
+  void print_ipostdominators();
+  void do_pdom();  // function to call pdom analysis
 
-   unsigned get_num_reconvergence_pairs();
+  unsigned get_num_reconvergence_pairs();
 
-   void get_reconvergence_pairs(gpgpu_recon_t* recon_points);
+  void get_reconvergence_pairs(gpgpu_recon_t *recon_points);
 
-   unsigned get_function_size() { return m_instructions.size();}
+  unsigned get_function_size() { return m_instructions.size(); }
 
-   void ptx_assemble();
- 
-   unsigned ptx_get_inst_op( ptx_thread_info *thread );
-   void add_param( const char *name, struct param_t value )
-   {
-      m_kernel_params[ name ] = value;
-   }
-   void add_param_name_type_size( unsigned index, std::string name, int type, size_t size, bool ptr, memory_space_t space );
-   void add_param_data( unsigned argn, struct gpgpu_ptx_sim_arg *args );
-   void add_return_var( const symbol *rv )
-   {
-      m_return_var_sym = rv;
-   }
-   void add_arg( const symbol *arg )
-   {
-      assert( arg != NULL );
-      m_args.push_back(arg);
-   }
-   void remove_args()
-   {
-      m_args.clear();
-   }
-   unsigned num_args() const
-   {
-      return m_args.size();
-   }
-   unsigned get_args_aligned_size();
+  void ptx_assemble();
 
-   const symbol* get_arg( unsigned n ) const
-   {
-      assert( n < m_args.size() );
-      return m_args[n];
-   }
-   bool has_return() const
-   {
-      return m_return_var_sym != NULL;
-   }
-   const symbol *get_return_var() const
-   {
-      return m_return_var_sym;
-   }
-   const ptx_instruction *get_instruction( unsigned PC ) const
-   {
-      unsigned index = PC - m_start_PC;
-      if( index < m_instr_mem_size ) 
-         return m_instr_mem[index];
-      return NULL;
-   }
-   addr_t get_start_PC() const
-   {
-       return m_start_PC;
-   }
+  unsigned ptx_get_inst_op(ptx_thread_info *thread);
+  void add_param(const char *name, struct param_t value) {
+    m_kernel_params[name] = value;
+  }
+  void add_param_name_type_size(unsigned index, std::string name, int type,
+                                size_t size, bool ptr, memory_space_t space);
+  void add_param_data(unsigned argn, struct gpgpu_ptx_sim_arg *args);
+  void add_return_var(const symbol *rv) { m_return_var_sym = rv; }
+  void add_arg(const symbol *arg) {
+    assert(arg != NULL);
+    m_args.push_back(arg);
+  }
+  void remove_args() { m_args.clear(); }
+  unsigned num_args() const { return m_args.size(); }
+  unsigned get_args_aligned_size();
 
-   void finalize( memory_space *param_mem );
-   void param_to_shared( memory_space *shared_mem, symbol_table *symtab ); 
-   void list_param( FILE *fout ) const;
-   void ptx_jit_config(std::map<unsigned long long, size_t> mallocPtr_Size, memory_space *param_mem, gpgpu_t* gpu, dim3 gridDim, dim3 blockDim) ;
+  const symbol *get_arg(unsigned n) const {
+    assert(n < m_args.size());
+    return m_args[n];
+  }
+  bool has_return() const { return m_return_var_sym != NULL; }
+  const symbol *get_return_var() const { return m_return_var_sym; }
+  const ptx_instruction *get_instruction(unsigned PC) const {
+    unsigned index = PC - m_start_PC;
+    if (index < m_instr_mem_size) return m_instr_mem[index];
+    return NULL;
+  }
+  addr_t get_start_PC() const { return m_start_PC; }
 
-   const struct gpgpu_ptx_sim_info* get_kernel_info () const
-   {
-      assert (m_kernel_info.maxthreads == maxnt_id);
-      return &m_kernel_info;
-   }
+  void finalize(memory_space *param_mem);
+  void param_to_shared(memory_space *shared_mem, symbol_table *symtab);
+  void list_param(FILE *fout) const;
+  void ptx_jit_config(std::map<unsigned long long, size_t> mallocPtr_Size,
+                      memory_space *param_mem, gpgpu_t *gpu, dim3 gridDim,
+                      dim3 blockDim);
 
-   const void set_kernel_info (const struct gpgpu_ptx_sim_info &info) {
-      m_kernel_info = info;
-      m_kernel_info.ptx_version = 10*get_ptx_version().ver();
-      m_kernel_info.sm_target = get_ptx_version().target();
-      // THIS DEPENDS ON ptxas being called after the PTX is parsed.
-      m_kernel_info.maxthreads = maxnt_id;
-   }
-   symbol_table *get_symtab()
-   {
-      return m_symtab;
-   }
+  const struct gpgpu_ptx_sim_info *get_kernel_info() const {
+    assert(m_kernel_info.maxthreads == maxnt_id);
+    return &m_kernel_info;
+  }
 
-   unsigned local_mem_framesize() const 
-   { 
-      return m_local_mem_framesize; 
-   }
-   void set_framesize( unsigned sz )
-   {
-      m_local_mem_framesize = sz;
-   }
-   bool is_entry_point() const { return m_entry_point; }
-   bool is_pdom_set() const { return pdom_done; } //return pdom flag
-   void set_pdom() { pdom_done = true; } //set pdom flag
+  const void set_kernel_info(const struct gpgpu_ptx_sim_info &info) {
+    m_kernel_info = info;
+    m_kernel_info.ptx_version = 10 * get_ptx_version().ver();
+    m_kernel_info.sm_target = get_ptx_version().target();
+    // THIS DEPENDS ON ptxas being called after the PTX is parsed.
+    m_kernel_info.maxthreads = maxnt_id;
+  }
+  symbol_table *get_symtab() { return m_symtab; }
 
-   void add_config_param( size_t size, unsigned alignment ){
-      unsigned offset = 0;
-      if (m_param_configs.size()>0){
-          unsigned offset_nom = m_param_configs.back().first + m_param_configs.back().second;
-          //ensure offset matches alignment requirements
-          offset = offset_nom%alignment ? (offset_nom/alignment + 1) * alignment : offset_nom;
-      }
-      m_param_configs.push_back(std::pair<size_t,unsigned>(size, offset));
-   }
+  unsigned local_mem_framesize() const { return m_local_mem_framesize; }
+  void set_framesize(unsigned sz) { m_local_mem_framesize = sz; }
+  bool is_entry_point() const { return m_entry_point; }
+  bool is_pdom_set() const { return pdom_done; }  // return pdom flag
+  void set_pdom() { pdom_done = true; }           // set pdom flag
 
-   std::pair<size_t, unsigned> get_param_config(unsigned param_num) const { return m_param_configs[param_num]; }
+  void add_config_param(size_t size, unsigned alignment) {
+    unsigned offset = 0;
+    if (m_param_configs.size() > 0) {
+      unsigned offset_nom =
+          m_param_configs.back().first + m_param_configs.back().second;
+      // ensure offset matches alignment requirements
+      offset = offset_nom % alignment ? (offset_nom / alignment + 1) * alignment
+                                      : offset_nom;
+    }
+    m_param_configs.push_back(std::pair<size_t, unsigned>(size, offset));
+  }
 
-   void set_maxnt_id(unsigned maxthreads) { maxnt_id = maxthreads;}
-   unsigned get_maxnt_id() { return maxnt_id;}
-   // backward pointer
-   class gpgpu_context* gpgpu_ctx;
+  std::pair<size_t, unsigned> get_param_config(unsigned param_num) const {
+    return m_param_configs[param_num];
+  }
 
-private:
-   unsigned maxnt_id;
-   unsigned m_uid;
-   unsigned m_local_mem_framesize;
-   bool m_entry_point;
-   bool m_extern;
-   bool m_assembled;
-   bool pdom_done; //flag to check whether pdom is completed or not
-   std::string m_name;
-   ptx_instruction **m_instr_mem;
-   unsigned m_start_PC;
-   unsigned m_instr_mem_size;
-   std::map<std::string,param_t> m_kernel_params;
-   std::map<unsigned,param_info> m_ptx_kernel_param_info;
-   std::vector< std::pair<size_t, unsigned> > m_param_configs;
-   const symbol *m_return_var_sym;
-   std::vector<const symbol*> m_args;
-   std::list<ptx_instruction*> m_instructions;
-   std::vector<basic_block_t*> m_basic_blocks;
-   std::list<std::pair<unsigned, unsigned> > m_back_edges;
-   std::map<std::string,unsigned> labels;
-   unsigned num_reconvergence_pairs;
+  void set_maxnt_id(unsigned maxthreads) { maxnt_id = maxthreads; }
+  unsigned get_maxnt_id() { return maxnt_id; }
+  // backward pointer
+  class gpgpu_context *gpgpu_ctx;
 
-   //Registers/shmem/etc. used (from ptxas -v), loaded from ___.ptxinfo along with ___.ptx
-   struct gpgpu_ptx_sim_info m_kernel_info;
+ private:
+  unsigned maxnt_id;
+  unsigned m_uid;
+  unsigned m_local_mem_framesize;
+  bool m_entry_point;
+  bool m_extern;
+  bool m_assembled;
+  bool pdom_done;  // flag to check whether pdom is completed or not
+  std::string m_name;
+  ptx_instruction **m_instr_mem;
+  unsigned m_start_PC;
+  unsigned m_instr_mem_size;
+  std::map<std::string, param_t> m_kernel_params;
+  std::map<unsigned, param_info> m_ptx_kernel_param_info;
+  std::vector<std::pair<size_t, unsigned> > m_param_configs;
+  const symbol *m_return_var_sym;
+  std::vector<const symbol *> m_args;
+  std::list<ptx_instruction *> m_instructions;
+  std::vector<basic_block_t *> m_basic_blocks;
+  std::list<std::pair<unsigned, unsigned> > m_back_edges;
+  std::map<std::string, unsigned> labels;
+  unsigned num_reconvergence_pairs;
 
-   symbol_table *m_symtab;
+  // Registers/shmem/etc. used (from ptxas -v), loaded from ___.ptxinfo along
+  // with ___.ptx
+  struct gpgpu_ptx_sim_info m_kernel_info;
 
-   //parameter size for device kernels
-   int m_args_aligned_size;
-   
-   addr_t m_n;  // offset in m_instr_mem (used in do_pdom)
+  symbol_table *m_symtab;
+
+  // parameter size for device kernels
+  int m_args_aligned_size;
+
+  addr_t m_n;  // offset in m_instr_mem (used in do_pdom)
 };
 
 class arg_buffer_t {
-public:
-   arg_buffer_t(gpgpu_context* ctx) : m_src_op(ctx)
-   {
-      m_is_reg=false;
-      m_is_param=false;
-      m_param_value=NULL;
-      m_reg_value=ptx_reg_t();
-   }
-   arg_buffer_t( const arg_buffer_t &another, gpgpu_context* ctx ) : m_src_op(ctx)
-   {
-      make_copy(another);
-   }
-   void make_copy( const arg_buffer_t &another )
-   {
-      m_dst = another.m_dst;
-      m_src_op = another.m_src_op;
-      m_is_reg = another.m_is_reg;
-      m_is_param = another.m_is_param;
-      m_reg_value = another.m_reg_value;
-      m_param_bytes = another.m_param_bytes;
-      if( m_is_param ) {
-         m_param_value = malloc(m_param_bytes);
-         memcpy(m_param_value,another.m_param_value,m_param_bytes);
+ public:
+  arg_buffer_t(gpgpu_context *ctx) : m_src_op(ctx) {
+    m_is_reg = false;
+    m_is_param = false;
+    m_param_value = NULL;
+    m_reg_value = ptx_reg_t();
+  }
+  arg_buffer_t(const arg_buffer_t &another, gpgpu_context *ctx)
+      : m_src_op(ctx) {
+    make_copy(another);
+  }
+  void make_copy(const arg_buffer_t &another) {
+    m_dst = another.m_dst;
+    m_src_op = another.m_src_op;
+    m_is_reg = another.m_is_reg;
+    m_is_param = another.m_is_param;
+    m_reg_value = another.m_reg_value;
+    m_param_bytes = another.m_param_bytes;
+    if (m_is_param) {
+      m_param_value = malloc(m_param_bytes);
+      memcpy(m_param_value, another.m_param_value, m_param_bytes);
+    }
+  }
+  void operator=(const arg_buffer_t &another) { make_copy(another); }
+  ~arg_buffer_t() {
+    if (m_is_param) free(m_param_value);
+  }
+  arg_buffer_t(const symbol *dst_sym, const operand_info &src_op,
+               ptx_reg_t source_value)
+      : m_src_op(src_op) {
+    m_dst = dst_sym;
+    m_reg_value = ptx_reg_t();
+    if (dst_sym->is_reg()) {
+      m_is_reg = true;
+      m_is_param = false;
+      assert(src_op.is_reg());
+      m_reg_value = source_value;
+    } else {
+      m_is_param = true;
+      m_is_reg = false;
+      m_param_value = calloc(sizeof(ptx_reg_t), 1);
+      // new (m_param_value) ptx_reg_t(source_value);
+      memcpy(m_param_value, &source_value, sizeof(ptx_reg_t));
+      m_param_bytes = sizeof(ptx_reg_t);
+    }
+  }
+  arg_buffer_t(const symbol *dst_sym, const operand_info &src_op,
+               void *source_param_value_array, unsigned array_size)
+      : m_src_op(src_op) {
+    m_dst = dst_sym;
+    if (dst_sym->is_reg()) {
+      m_is_reg = true;
+      m_is_param = false;
+      assert(src_op.is_param_local());
+      assert(dst_sym->get_size_in_bytes() == array_size);
+      switch (array_size) {
+        case 1:
+          m_reg_value.u8 = *(unsigned char *)source_param_value_array;
+          break;
+        case 2:
+          m_reg_value.u16 = *(unsigned short *)source_param_value_array;
+          break;
+        case 4:
+          m_reg_value.u32 = *(unsigned int *)source_param_value_array;
+          break;
+        case 8:
+          m_reg_value.u64 = *(unsigned long long *)source_param_value_array;
+          break;
+        default:
+          printf(
+              "GPGPU-Sim PTX: ERROR ** source param size does not match known "
+              "register sizes\n");
+          break;
       }
-   }
-   void operator=( const arg_buffer_t &another )
-   {
-      make_copy(another);
-   }
-   ~arg_buffer_t()
-   {
-      if( m_is_param ) 
-         free(m_param_value);
-   }
-   arg_buffer_t( const symbol *dst_sym, const operand_info &src_op, ptx_reg_t source_value ) : m_src_op(src_op)
-   {
-      m_dst = dst_sym;
-      m_reg_value=ptx_reg_t();
-      if( dst_sym->is_reg() ) {
-         m_is_reg = true;
-         m_is_param = false;
-         assert( src_op.is_reg() );
-         m_reg_value = source_value;
-      } else {
-         m_is_param = true;
-         m_is_reg = false;
-         m_param_value = calloc(sizeof(ptx_reg_t),1);
-         //new (m_param_value) ptx_reg_t(source_value);
-         memcpy(m_param_value,&source_value,sizeof(ptx_reg_t));
-         m_param_bytes = sizeof(ptx_reg_t);
-      }
-   }
-   arg_buffer_t( const symbol *dst_sym, const operand_info &src_op, void *source_param_value_array, unsigned array_size ) : m_src_op(src_op)
-   {
-      m_dst = dst_sym;
-      if( dst_sym->is_reg() ) {
-         m_is_reg = true;
-         m_is_param = false;
-         assert( src_op.is_param_local() );
-         assert( dst_sym->get_size_in_bytes() == array_size );
-         switch( array_size ) {
-         case 1: m_reg_value.u8 = *(unsigned char*)source_param_value_array; break;
-         case 2: m_reg_value.u16 = *(unsigned short*)source_param_value_array; break;
-         case 4: m_reg_value.u32 = *(unsigned int*)source_param_value_array; break;
-         case 8: m_reg_value.u64 = *(unsigned long long*)source_param_value_array; break;
-         default:
-            printf("GPGPU-Sim PTX: ERROR ** source param size does not match known register sizes\n");
-            break;
-         }
-      } else {
-         // param
-         m_is_param = true;
-         m_is_reg = false;
-         m_param_value = calloc(array_size,1);
-         m_param_bytes = array_size;
-         memcpy(m_param_value,source_param_value_array,array_size);
-      }
-   }
+    } else {
+      // param
+      m_is_param = true;
+      m_is_reg = false;
+      m_param_value = calloc(array_size, 1);
+      m_param_bytes = array_size;
+      memcpy(m_param_value, source_param_value_array, array_size);
+    }
+  }
 
-   bool is_reg() const { return m_is_reg; }
-   ptx_reg_t get_reg() const 
-   { 
-      assert(m_is_reg); 
-      return m_reg_value; 
-   }
+  bool is_reg() const { return m_is_reg; }
+  ptx_reg_t get_reg() const {
+    assert(m_is_reg);
+    return m_reg_value;
+  }
 
-   const void *get_param_buffer() const
-   {
-      assert(m_is_param);
-      return m_param_value;
-   }
-   size_t get_param_buffer_size() const
-   {
-      assert(m_is_param);
-      return m_param_bytes;
-   }
+  const void *get_param_buffer() const {
+    assert(m_is_param);
+    return m_param_value;
+  }
+  size_t get_param_buffer_size() const {
+    assert(m_is_param);
+    return m_param_bytes;
+  }
 
-   const symbol *get_dst() const { return m_dst; }
+  const symbol *get_dst() const { return m_dst; }
 
-private:
-   // destination of copy
-   const symbol *m_dst;
+ private:
+  // destination of copy
+  const symbol *m_dst;
 
-   // source operand
-   operand_info m_src_op;
+  // source operand
+  operand_info m_src_op;
 
-   // source information
-   bool m_is_reg;
-   bool m_is_param;
+  // source information
+  bool m_is_reg;
+  bool m_is_param;
 
-   // source is register
-   ptx_reg_t m_reg_value;
+  // source is register
+  ptx_reg_t m_reg_value;
 
-   // source is param
-   void     *m_param_value;
-   unsigned  m_param_bytes;
+  // source is param
+  void *m_param_value;
+  unsigned m_param_bytes;
 };
 
-typedef std::list< arg_buffer_t > arg_buffer_list_t;
-arg_buffer_t copy_arg_to_buffer(ptx_thread_info * thread, operand_info actual_param_op, const symbol * formal_param);
-void copy_args_into_buffer_list( const ptx_instruction * pI, 
-                                 ptx_thread_info * thread, 
-                                 const function_info * target_func, 
-                                 arg_buffer_list_t &arg_values ); 
-void copy_buffer_list_into_frame(ptx_thread_info * thread, arg_buffer_list_t &arg_values);
-void copy_buffer_to_frame(ptx_thread_info * thread, const arg_buffer_t &a);
-
+typedef std::list<arg_buffer_t> arg_buffer_list_t;
+arg_buffer_t copy_arg_to_buffer(ptx_thread_info *thread,
+                                operand_info actual_param_op,
+                                const symbol *formal_param);
+void copy_args_into_buffer_list(const ptx_instruction *pI,
+                                ptx_thread_info *thread,
+                                const function_info *target_func,
+                                arg_buffer_list_t &arg_values);
+void copy_buffer_list_into_frame(ptx_thread_info *thread,
+                                 arg_buffer_list_t &arg_values);
+void copy_buffer_to_frame(ptx_thread_info *thread, const arg_buffer_t &a);
 
 struct textureInfo {
-   unsigned int texel_size; //size in bytes, e.g. (channelDesc.x+y+z+w)/8
-   unsigned int Tx,Ty; //tiling factor dimensions of layout of texels per 64B cache block
-   unsigned int Tx_numbits,Ty_numbits; //log2(T)
-   unsigned int texel_size_numbits; //log2(texel_size)
+  unsigned int texel_size;  // size in bytes, e.g. (channelDesc.x+y+z+w)/8
+  unsigned int Tx,
+      Ty;  // tiling factor dimensions of layout of texels per 64B cache block
+  unsigned int Tx_numbits, Ty_numbits;  // log2(T)
+  unsigned int texel_size_numbits;      // log2(texel_size)
 };
 
-extern std::map<std::string,symbol_table*> g_sym_name_to_symbol_table;
+extern std::map<std::string, symbol_table *> g_sym_name_to_symbol_table;
 
-
-void gpgpu_ptx_assemble( std::string kname, void *kinfo );
+void gpgpu_ptx_assemble(std::string kname, void *kinfo);
 #include "../option_parser.h"
-unsigned ptx_kernel_shmem_size( void *kernel_impl );
-unsigned ptx_kernel_nregs( void *kernel_impl );
+unsigned ptx_kernel_shmem_size(void *kernel_impl);
+unsigned ptx_kernel_nregs(void *kernel_impl);
 
 #endif

--- a/src/cuda-sim/ptx_ir.h
+++ b/src/cuda-sim/ptx_ir.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -32,13 +30,13 @@
 
 #include "../abstract_hardware_model.h"
 
-#include <assert.h>
 #include <cstdlib>
 #include <cstring>
+#include <string>
 #include <list>
 #include <map>
-#include <string>
 #include <vector>
+#include <assert.h>
 
 //#include "ptx.tab.h"
 #include "ptx_sim.h"
@@ -48,1518 +46,1537 @@
 class gpgpu_context;
 
 class type_info_key {
- public:
-  type_info_key() {
-    m_is_non_arch_reg = false;
-    m_init = false;
-  }
-  type_info_key(memory_space_t space_spec, int scalar_type_spec,
-                int vector_spec, int alignment_spec, int extern_spec,
-                int array_dim) {
-    m_is_non_arch_reg = false;
-    m_init = true;
-    m_space_spec = space_spec;
-    m_scalar_type_spec = scalar_type_spec;
-    m_vector_spec = vector_spec;
-    m_alignment_spec = alignment_spec;
-    m_extern_spec = extern_spec;
-    m_array_dim = array_dim;
-    m_is_function = 0;
-  }
-  void set_is_func() {
-    assert(!m_init);
-    m_init = true;
-    m_space_spec = undefined_space;
-    m_scalar_type_spec = 0;
-    m_vector_spec = 0;
-    m_alignment_spec = 0;
-    m_extern_spec = 0;
-    m_array_dim = 0;
-    m_is_function = 1;
-  }
+public:
+   type_info_key()
+   {
+      m_is_non_arch_reg = false;
+      m_init = false;
+   }
+   type_info_key( memory_space_t space_spec, int scalar_type_spec, int vector_spec, int alignment_spec, int extern_spec, int array_dim )
+   {
+      m_is_non_arch_reg = false;
+      m_init = true;
+      m_space_spec = space_spec; 
+      m_scalar_type_spec = scalar_type_spec;
+      m_vector_spec = vector_spec;
+      m_alignment_spec = alignment_spec;
+      m_extern_spec = extern_spec;
+      m_array_dim = array_dim;
+      m_is_function = 0;
+   } 
+   void set_is_func()
+   { 
+      assert(!m_init);
+      m_init = true;
+      m_space_spec = undefined_space; 
+      m_scalar_type_spec = 0;
+      m_vector_spec = 0;
+      m_alignment_spec = 0;
+      m_extern_spec = 0;
+      m_array_dim = 0; 
+      m_is_function = 1;
+   }
 
-  void set_array_dim(int array_dim) { m_array_dim = array_dim; }
-  int get_array_dim() const {
-    assert(m_init);
-    return m_array_dim;
-  }
-  void set_is_non_arch_reg() { m_is_non_arch_reg = true; }
+   void set_array_dim( int array_dim ) { m_array_dim = array_dim; }
+   int get_array_dim() const { assert(m_init); return m_array_dim; }
+   void set_is_non_arch_reg() { m_is_non_arch_reg = true;  }
 
-  bool is_non_arch_reg() const { return m_is_non_arch_reg; }
-  bool is_reg() const { return m_space_spec == reg_space; }
-  bool is_param_kernel() const { return m_space_spec == param_space_kernel; }
-  bool is_param_local() const { return m_space_spec == param_space_local; }
-  bool is_param_unclassified() const {
-    return m_space_spec == param_space_unclassified;
-  }
-  bool is_global() const { return m_space_spec == global_space; }
-  bool is_local() const { return m_space_spec == local_space; }
-  bool is_shared() const { return m_space_spec == shared_space; }
-  bool is_const() const { return m_space_spec.get_type() == const_space; }
-  bool is_tex() const { return m_space_spec == tex_space; }
-  bool is_func_addr() const { return m_is_function ? true : false; }
-  int scalar_type() const { return m_scalar_type_spec; }
-  int get_alignment_spec() const { return m_alignment_spec; }
-  unsigned type_decode(size_t &size, int &t) const;
-  static unsigned type_decode(int type, size_t &size, int &t);
-  memory_space_t get_memory_space() const { return m_space_spec; }
+   bool is_non_arch_reg() const { return m_is_non_arch_reg; }
+   bool is_reg() const { return m_space_spec == reg_space;} 
+   bool is_param_kernel() const { return m_space_spec == param_space_kernel;}
+   bool is_param_local() const { return m_space_spec == param_space_local; }
+   bool is_param_unclassified() const { return m_space_spec == param_space_unclassified; }
+   bool is_global() const { return m_space_spec == global_space;}
+   bool is_local() const { return m_space_spec == local_space;}
+   bool is_shared() const { return m_space_spec == shared_space;}
+   bool is_const() const { return m_space_spec.get_type() == const_space;}
+   bool is_tex() const { return m_space_spec == tex_space;}
+   bool is_func_addr() const { return m_is_function?true:false; }
+   int  scalar_type() const { return m_scalar_type_spec;}
+   int  get_alignment_spec() const { return m_alignment_spec;}
+   unsigned type_decode( size_t &size, int &t ) const;
+   static unsigned type_decode( int type, size_t &size, int &t );
+   memory_space_t get_memory_space() const { return m_space_spec; }
+private:
+   bool m_init;
+   memory_space_t m_space_spec; 
+   int m_scalar_type_spec;
+   int m_vector_spec;
+   int m_alignment_spec;
+   int m_extern_spec;
+   int m_array_dim;
+   int m_is_function;
+   bool m_is_non_arch_reg;
 
- private:
-  bool m_init;
-  memory_space_t m_space_spec;
-  int m_scalar_type_spec;
-  int m_vector_spec;
-  int m_alignment_spec;
-  int m_extern_spec;
-  int m_array_dim;
-  int m_is_function;
-  bool m_is_non_arch_reg;
-
-  friend struct type_info_key_compare;
+   friend struct type_info_key_compare;
 };
 
 class symbol_table;
 
 struct type_info_key_compare {
-  bool operator()(const type_info_key &a, const type_info_key &b) const {
-    assert(a.m_init && b.m_init);
-    if (a.m_space_spec < b.m_space_spec) return true;
-    if (a.m_scalar_type_spec < b.m_scalar_type_spec) return true;
-    if (a.m_vector_spec < b.m_vector_spec) return true;
-    if (a.m_alignment_spec < b.m_alignment_spec) return true;
-    if (a.m_extern_spec < b.m_extern_spec) return true;
-    if (a.m_array_dim < b.m_array_dim) return true;
-    if (a.m_is_function < b.m_is_function) return true;
+   bool operator()( const type_info_key &a, const type_info_key &b ) const
+   {
+      assert( a.m_init && b.m_init );
+      if ( a.m_space_spec < b.m_space_spec ) return true;
+      if ( a.m_scalar_type_spec < b.m_scalar_type_spec ) return true;
+      if ( a.m_vector_spec < b.m_vector_spec ) return true;
+      if ( a.m_alignment_spec < b.m_alignment_spec ) return true;
+      if ( a.m_extern_spec < b.m_extern_spec ) return true;
+      if ( a.m_array_dim < b.m_array_dim ) return true;
+      if ( a.m_is_function < b.m_is_function ) return true;
 
-    return false;
-  }
+      return false;
+   }
 };
 
 class type_info {
- public:
-  type_info(symbol_table *scope, type_info_key t) { m_type_info = t; }
-  const type_info_key &get_key() const { return m_type_info; }
+public:
+   type_info( symbol_table *scope, type_info_key t )
+   {
+      m_type_info = t;
+   }
+   const type_info_key &get_key() const { return m_type_info;}
 
- private:
-  symbol_table *m_scope;
-  type_info_key m_type_info;
+private:
+   symbol_table *m_scope;
+   type_info_key m_type_info;
 };
 
 enum operand_type {
-  reg_t,
-  vector_t,
-  builtin_t,
-  address_t,
-  memory_t,
-  float_op_t,
-  double_op_t,
-  int_t,
-  unsigned_t,
-  symbolic_t,
-  label_t,
-  v_reg_t,
-  v_float_op_t,
-  v_double_op_t,
-  v_int_t,
-  v_unsigned_t,
-  undef_t
+   reg_t, vector_t, builtin_t, address_t, memory_t, float_op_t, double_op_t, int_t, 
+   unsigned_t, symbolic_t, label_t, v_reg_t, v_float_op_t, v_double_op_t,
+   v_int_t, v_unsigned_t, undef_t
 };
 
 class operand_info;
 
 class symbol {
- public:
-  symbol(const char *name, const type_info *type, const char *location,
-         unsigned size, gpgpu_context *ctx) {
-    gpgpu_ctx = ctx;
-    m_uid = get_uid();
-    m_name = name;
-    m_decl_location = location;
-    m_type = type;
-    m_size = size;
-    m_address_valid = false;
-    m_is_label = false;
-    m_is_shared = false;
-    m_is_const = false;
-    m_is_global = false;
-    m_is_local = false;
-    m_is_param_local = false;
-    m_is_param_kernel = false;
-    m_is_tex = false;
-    m_is_func_addr = false;
-    m_reg_num_valid = false;
-    m_function = NULL;
-    m_reg_num = (unsigned)-1;
-    m_arch_reg_num = (unsigned)-1;
-    m_address = (unsigned)-1;
-    m_initializer.clear();
-    if (type) m_is_shared = type->get_key().is_shared();
-    if (type) m_is_const = type->get_key().is_const();
-    if (type) m_is_global = type->get_key().is_global();
-    if (type) m_is_local = type->get_key().is_local();
-    if (type) m_is_param_local = type->get_key().is_param_local();
-    if (type) m_is_param_kernel = type->get_key().is_param_kernel();
-    if (type) m_is_tex = type->get_key().is_tex();
-    if (type) m_is_func_addr = type->get_key().is_func_addr();
-  }
-  unsigned get_size_in_bytes() const { return m_size; }
-  const std::string &name() const { return m_name; }
-  const std::string &decl_location() const { return m_decl_location; }
-  const type_info *type() const { return m_type; }
-  addr_t get_address() const {
-    assert(m_is_label ||
-           !m_type->get_key().is_reg());  // todo : other assertions
-    assert(m_address_valid);
-    return m_address;
-  }
-  function_info *get_pc() const { return m_function; }
-  void set_regno(unsigned regno, unsigned arch_regno) {
-    m_reg_num_valid = true;
-    m_reg_num = regno;
-    m_arch_reg_num = arch_regno;
-  }
+public:
+   symbol( const char *name, const type_info *type, const char *location, unsigned size, gpgpu_context* ctx ) 
+   {
+      gpgpu_ctx = ctx;
+      m_uid = get_uid();
+      m_name = name;
+      m_decl_location = location;
+      m_type = type;
+      m_size = size;
+      m_address_valid = false;
+      m_is_label = false;
+      m_is_shared = false;
+      m_is_const = false;
+      m_is_global = false;
+      m_is_local = false;
+      m_is_param_local = false;
+      m_is_param_kernel = false;
+      m_is_tex = false;
+      m_is_func_addr = false;
+      m_reg_num_valid = false;
+      m_function = NULL;
+      m_reg_num=(unsigned)-1;
+      m_arch_reg_num=(unsigned)-1;
+      m_address=(unsigned)-1;
+      m_initializer.clear();
+      if ( type ) m_is_shared = type->get_key().is_shared();
+      if ( type ) m_is_const = type->get_key().is_const();
+      if ( type ) m_is_global = type->get_key().is_global();
+      if ( type ) m_is_local = type->get_key().is_local();
+      if ( type ) m_is_param_local = type->get_key().is_param_local();
+      if ( type ) m_is_param_kernel = type->get_key().is_param_kernel();
+      if ( type ) m_is_tex = type->get_key().is_tex();
+      if ( type ) m_is_func_addr = type->get_key().is_func_addr();
+   }
+   unsigned get_size_in_bytes() const
+   {
+      return m_size;
+   }
+   const std::string &name() const { return m_name;}
+   const std::string &decl_location() const { return m_decl_location;} 
+   const type_info *type() const { return m_type;}
+   addr_t get_address() const 
+   { 
+      assert( m_is_label || !m_type->get_key().is_reg() ); // todo : other assertions
+      assert( m_address_valid );
+      return m_address;
+   }
+   function_info *get_pc() const
+   {
+      return m_function;
+   }
+   void set_regno( unsigned regno, unsigned arch_regno )
+   {
+      m_reg_num_valid = true;
+      m_reg_num = regno;
+      m_arch_reg_num = arch_regno;
+   }
 
-  void set_address(addr_t addr) {
-    m_address_valid = true;
-    m_address = addr;
-  }
-  void set_label_address(addr_t addr) {
-    m_address_valid = true;
-    m_address = addr;
-    m_is_label = true;
-  }
-  void set_function(function_info *func) {
-    m_function = func;
-    m_is_func_addr = true;
-  }
+   void set_address( addr_t addr )
+   {
+      m_address_valid = true;
+      m_address = addr;
+   }
+   void set_label_address( addr_t addr)
+   {
+      m_address_valid = true;
+      m_address = addr;
+      m_is_label = true;
+   }
+   void set_function( function_info *func )
+   {
+      m_function = func;
+      m_is_func_addr = true; 
+   }
 
-  bool is_label() const { return m_is_label; }
-  bool is_shared() const { return m_is_shared; }
-  bool is_sstarr() const { return m_is_sstarr; }
-  bool is_const() const { return m_is_const; }
-  bool is_global() const { return m_is_global; }
-  bool is_local() const { return m_is_local; }
-  bool is_param_local() const { return m_is_param_local; }
-  bool is_param_kernel() const { return m_is_param_kernel; }
-  bool is_tex() const { return m_is_tex; }
-  bool is_func_addr() const { return m_is_func_addr; }
-  bool is_reg() const {
-    if (m_type == NULL) {
-      return false;
-    }
-    return m_type->get_key().is_reg();
-  }
-  bool is_non_arch_reg() const {
-    if (m_type == NULL) {
-      return false;
-    }
-    return m_type->get_key().is_non_arch_reg();
-  }
+   bool is_label() const { return m_is_label;}
+   bool is_shared() const { return m_is_shared;}
+   bool is_sstarr() const { return m_is_sstarr;}
+   bool is_const() const { return m_is_const;}
+   bool is_global() const { return m_is_global;}
+   bool is_local() const { return m_is_local;}
+   bool is_param_local() const { return m_is_param_local; }
+   bool is_param_kernel() const { return m_is_param_kernel; }
+   bool is_tex() const { return m_is_tex;}
+   bool is_func_addr() const { return m_is_func_addr; }
+   bool is_reg() const
+   {
+       if ( m_type == NULL ) {
+           return false;
+       }
+      return m_type->get_key().is_reg(); 
+   }
+   bool is_non_arch_reg() const
+   {
+       if ( m_type == NULL ) {
+           return false;
+       }
+      return m_type->get_key().is_non_arch_reg(); 
+   }
 
-  void add_initializer(const std::list<operand_info> &init);
-  bool has_initializer() const { return m_initializer.size() > 0; }
-  std::list<operand_info> get_initializer() const { return m_initializer; }
-  unsigned reg_num() const {
-    assert(m_reg_num_valid);
-    return m_reg_num;
-  }
-  unsigned arch_reg_num() const {
-    assert(m_reg_num_valid);
-    return m_arch_reg_num;
-  }
-  void print_info(FILE *fp) const;
-  unsigned uid() const { return m_uid; }
+   void add_initializer( const std::list<operand_info> &init );
+   bool has_initializer() const 
+   {
+      return m_initializer.size() > 0; 
+   }
+   std::list<operand_info> get_initializer() const
+   {
+      return m_initializer;
+   }
+   unsigned reg_num() const
+   {
+      assert( m_reg_num_valid );
+      return m_reg_num; 
+   }
+   unsigned arch_reg_num() const
+   {
+      assert( m_reg_num_valid );
+      return m_arch_reg_num; 
+   }
+   void print_info(FILE *fp) const;
+   unsigned uid() const { return m_uid; }
 
- private:
-  gpgpu_context *gpgpu_ctx;
-  unsigned get_uid();
-  unsigned m_uid;
-  const type_info *m_type;
-  unsigned m_size;  // in bytes
-  std::string m_name;
-  std::string m_decl_location;
+private:
+   gpgpu_context* gpgpu_ctx;
+   unsigned get_uid();
+   unsigned m_uid;
+   const type_info *m_type;
+   unsigned m_size; // in bytes
+   std::string m_name;
+   std::string m_decl_location;
 
-  unsigned m_address;
-  function_info *m_function;  // used for function symbols
+   unsigned m_address;
+   function_info *m_function; // used for function symbols
 
-  bool m_address_valid;
-  bool m_is_label;
-  bool m_is_shared;
-  bool m_is_sstarr;
-  bool m_is_const;
-  bool m_is_global;
-  bool m_is_local;
-  bool m_is_param_local;
-  bool m_is_param_kernel;
-  bool m_is_tex;
-  bool m_is_func_addr;
-  unsigned m_reg_num;
-  unsigned m_arch_reg_num;
-  bool m_reg_num_valid;
+   bool m_address_valid;
+   bool m_is_label;
+   bool m_is_shared;
+   bool m_is_sstarr;
+   bool m_is_const;
+   bool m_is_global;
+   bool m_is_local;
+   bool m_is_param_local;
+   bool m_is_param_kernel;
+   bool m_is_tex;
+   bool m_is_func_addr;
+   unsigned m_reg_num; 
+   unsigned m_arch_reg_num; 
+   bool m_reg_num_valid; 
 
-  std::list<operand_info> m_initializer;
+   std::list<operand_info> m_initializer;
 };
 
 class symbol_table {
- public:
-  symbol_table();
-  symbol_table(const char *scope_name, unsigned entry_point,
-               symbol_table *parent, gpgpu_context *ctx);
-  void set_name(const char *name);
-  const ptx_version &get_ptx_version() const;
-  unsigned get_sm_target() const;
-  void set_ptx_version(float ver, unsigned ext);
-  void set_sm_target(const char *target, const char *ext, const char *ext2);
-  symbol *lookup(const char *identifier);
-  std::string get_scope_name() const { return m_scope_name; }
-  symbol *add_variable(const char *identifier, const type_info *type,
-                       unsigned size, const char *filename, unsigned line);
-  void add_function(function_info *func, const char *filename,
-                    unsigned linenumber);
-  bool add_function_decl(const char *name, int entry_point,
-                         function_info **func_info,
-                         symbol_table **symbol_table);
-  function_info *lookup_function(std::string name);
-  type_info *add_type(memory_space_t space_spec, int scalar_type_spec,
-                      int vector_spec, int alignment_spec, int extern_spec);
-  type_info *add_type(function_info *func);
-  type_info *get_array_type(type_info *base_type, unsigned array_dim);
-  void set_label_address(const symbol *label, unsigned addr);
-  unsigned next_reg_num() { return ++m_reg_allocator; }
-  addr_t get_shared_next() { return m_shared_next; }
-  addr_t get_sstarr_next() { return m_sstarr_next; }
-  addr_t get_global_next() { return m_global_next; }
-  addr_t get_local_next() { return m_local_next; }
-  addr_t get_tex_next() { return m_tex_next; }
-  void alloc_shared(unsigned num_bytes) { m_shared_next += num_bytes; }
-  void alloc_sstarr(unsigned num_bytes) { m_sstarr_next += num_bytes; }
-  void alloc_global(unsigned num_bytes) { m_global_next += num_bytes; }
-  void alloc_local(unsigned num_bytes) { m_local_next += num_bytes; }
-  void alloc_tex(unsigned num_bytes) { m_tex_next += num_bytes; }
+public:
+   symbol_table();
+   symbol_table( const char *scope_name, unsigned entry_point, symbol_table *parent, gpgpu_context* ctx);
+   void set_name( const char *name );
+   const ptx_version &get_ptx_version() const;
+   unsigned get_sm_target() const;
+   void set_ptx_version( float ver, unsigned ext );
+   void set_sm_target( const char *target, const char *ext, const char *ext2 );
+   symbol* lookup( const char *identifier );
+   std::string get_scope_name() const { return m_scope_name; }
+   symbol *add_variable( const char *identifier, const type_info *type, unsigned size, const char *filename, unsigned line );
+   void add_function( function_info *func, const char *filename, unsigned linenumber );
+   bool add_function_decl( const char *name, int entry_point, function_info **func_info, symbol_table **symbol_table );
+   function_info *lookup_function(std::string name);
+   type_info *add_type( memory_space_t space_spec, int scalar_type_spec, int vector_spec, int alignment_spec, int extern_spec );
+   type_info *add_type( function_info *func );
+   type_info *get_array_type( type_info *base_type, unsigned array_dim ); 
+   void set_label_address( const symbol *label, unsigned addr );
+   unsigned next_reg_num() { return ++m_reg_allocator;}
+   addr_t get_shared_next() { return m_shared_next;}
+   addr_t get_sstarr_next() { return m_sstarr_next;}
+   addr_t get_global_next() { return m_global_next;}
+   addr_t get_local_next() { return m_local_next;}
+   addr_t get_tex_next() { return m_tex_next;}
+   void  alloc_shared( unsigned num_bytes ) { m_shared_next += num_bytes;}
+   void  alloc_sstarr( unsigned num_bytes ) { m_sstarr_next += num_bytes;}
+   void  alloc_global( unsigned num_bytes ) { m_global_next += num_bytes;}
+   void  alloc_local( unsigned num_bytes ) { m_local_next += num_bytes;}
+   void  alloc_tex( unsigned num_bytes ) { m_tex_next += num_bytes;}
 
-  typedef std::list<symbol *>::iterator iterator;
+   typedef std::list<symbol*>::iterator iterator;
 
-  iterator global_iterator_begin() { return m_globals.begin(); }
-  iterator global_iterator_end() { return m_globals.end(); }
+   iterator global_iterator_begin() { return m_globals.begin();}
+   iterator global_iterator_end() { return m_globals.end();}
 
-  iterator const_iterator_begin() { return m_consts.begin(); }
-  iterator const_iterator_end() { return m_consts.end(); }
+   iterator const_iterator_begin() { return m_consts.begin();}
+   iterator const_iterator_end() { return m_consts.end();}
 
-  void dump();
+   void dump();
+   
+   //Jin: handle instruction group for cdp
+   symbol_table* start_inst_group();
+   symbol_table* end_inst_group();
 
-  // Jin: handle instruction group for cdp
-  symbol_table *start_inst_group();
-  symbol_table *end_inst_group();
+   // backward pointer
+   class gpgpu_context* gpgpu_ctx;
 
-  // backward pointer
-  class gpgpu_context *gpgpu_ctx;
+private:
+   unsigned m_reg_allocator;
+   unsigned m_shared_next;
+   unsigned m_sstarr_next;
+   unsigned m_const_next;
+   unsigned m_global_next;
+   unsigned m_local_next;
+   unsigned m_tex_next;
 
- private:
-  unsigned m_reg_allocator;
-  unsigned m_shared_next;
-  unsigned m_sstarr_next;
-  unsigned m_const_next;
-  unsigned m_global_next;
-  unsigned m_local_next;
-  unsigned m_tex_next;
-
-  symbol_table *m_parent;
-  ptx_version m_ptx_version;
-  std::string m_scope_name;
-  std::map<std::string, symbol *>
-      m_symbols;  // map from name of register to pointers to the registers
-  std::map<type_info_key, type_info *, type_info_key_compare> m_types;
-  std::list<symbol *> m_globals;
-  std::list<symbol *> m_consts;
-  std::map<std::string, function_info *> m_function_info_lookup;
-  std::map<std::string, symbol_table *> m_function_symtab_lookup;
-
-  // Jin: handle instruction group for cdp
-  unsigned m_inst_group_id;
-  std::map<std::string, symbol_table *> m_inst_group_symtab;
+   symbol_table *m_parent;
+   ptx_version m_ptx_version;
+   std::string m_scope_name;
+   std::map<std::string, symbol *> m_symbols; //map from name of register to pointers to the registers
+   std::map<type_info_key,type_info*,type_info_key_compare>  m_types;
+   std::list<symbol*> m_globals;
+   std::list<symbol*> m_consts;
+   std::map<std::string,function_info*> m_function_info_lookup;
+   std::map<std::string,symbol_table*> m_function_symtab_lookup;
+   
+   //Jin: handle instruction group for cdp
+   unsigned m_inst_group_id;
+   std::map<std::string,symbol_table*> m_inst_group_symtab;
 };
 
 class operand_info {
- public:
-  operand_info(gpgpu_context *ctx) {
-    init(ctx);
-    m_is_non_arch_reg = false;
-    m_addr_space = undefined_space;
-    m_operand_lohi = 0;
-    m_double_operand_type = 0;
-    m_operand_neg = false;
-    m_const_mem_offset = 0;
-    m_uid = get_uid();
-    m_valid = false;
-    m_immediate_address = false;
-    m_addr_offset = 0;
-    m_value.m_symbolic = NULL;
-  }
-  operand_info(const symbol *addr, gpgpu_context *ctx) {
-    init(ctx);
-    m_is_non_arch_reg = false;
-    m_addr_space = undefined_space;
-    m_operand_lohi = 0;
-    m_double_operand_type = 0;
-    m_operand_neg = false;
-    m_const_mem_offset = 0;
-    m_uid = get_uid();
-    m_valid = true;
-    if (addr->is_label()) {
-      m_type = label_t;
-    } else if (addr->is_shared()) {
-      m_type = symbolic_t;
-    } else if (addr->is_const()) {
-      m_type = symbolic_t;
-    } else if (addr->is_global()) {
-      m_type = symbolic_t;
-    } else if (addr->is_local()) {
-      m_type = symbolic_t;
-    } else if (addr->is_param_local()) {
-      m_type = symbolic_t;
-    } else if (addr->is_param_kernel()) {
-      m_type = symbolic_t;
-    } else if (addr->is_tex()) {
-      m_type = symbolic_t;
-    } else if (addr->is_func_addr()) {
-      m_type = symbolic_t;
-    } else if (!addr->is_reg()) {
-      m_type = symbolic_t;
-    } else {
-      m_type = reg_t;
-    }
+public:
+   operand_info(gpgpu_context* ctx)
+   {
+      init(ctx);
+      m_is_non_arch_reg = false;
+      m_addr_space = undefined_space;
+      m_operand_lohi = 0;
+      m_double_operand_type = 0;
+      m_operand_neg = false;
+      m_const_mem_offset = 0;
+      m_uid = get_uid();
+      m_valid = false;
+      m_immediate_address=false;
+      m_addr_offset = 0;
+      m_value.m_symbolic=NULL;
+   }
+   operand_info( const symbol *addr, gpgpu_context* ctx )
+   {
+      init(ctx);
+      m_is_non_arch_reg = false;
+      m_addr_space = undefined_space;
+      m_operand_lohi = 0;
+      m_double_operand_type = 0;
+      m_operand_neg = false;
+      m_const_mem_offset = 0;
+      m_uid = get_uid();
+      m_valid = true;
+      if ( addr->is_label() ) {
+         m_type = label_t;
+      } else if ( addr->is_shared() ) {
+         m_type = symbolic_t;
+      } else if ( addr->is_const() ) {
+         m_type = symbolic_t;
+      } else if ( addr->is_global() ) {
+         m_type = symbolic_t;
+      } else if ( addr->is_local() ) {
+         m_type = symbolic_t;
+      } else if ( addr->is_param_local() ) {
+         m_type = symbolic_t;
+      } else if ( addr->is_param_kernel() ) {
+         m_type = symbolic_t;
+      } else if ( addr->is_tex() ) {
+         m_type = symbolic_t;
+      } else if ( addr->is_func_addr() ) {
+         m_type = symbolic_t;
+      } else if ( !addr->is_reg() ) {
+         m_type = symbolic_t;
+      } else {
+         m_type = reg_t;
+      }
+      
+      m_is_non_arch_reg = addr->is_non_arch_reg();
+      m_value.m_symbolic = addr;
+      m_addr_offset = 0;
+      m_vector = false;
+      m_neg_pred = false;
+      m_is_return_var = false;
+      m_immediate_address=false;
+   }
+   operand_info( const symbol *addr1, const symbol *addr2, gpgpu_context* ctx )
+   {
+      init(ctx);
+      m_is_non_arch_reg = false;
+      m_addr_space = undefined_space;
+      m_operand_lohi = 0;
+      m_double_operand_type = 0;
+      m_operand_neg = false;
+      m_const_mem_offset = 0;
+      m_uid = get_uid();
+      m_valid = true;
+      m_type = memory_t;
+      m_value.m_vector_symbolic = new const symbol*[8];
+      m_value.m_vector_symbolic[0] = addr1;
+      m_value.m_vector_symbolic[1] = addr2;
+      m_value.m_vector_symbolic[2] = NULL;
+      m_value.m_vector_symbolic[3] = NULL;
+      m_value.m_vector_symbolic[4] = NULL;
+      m_value.m_vector_symbolic[5] = NULL;
+      m_value.m_vector_symbolic[6] = NULL;
+      m_value.m_vector_symbolic[7] = NULL;
+      m_addr_offset = 0;
+      m_vector = false;
+      m_neg_pred = false;
+      m_is_return_var = false;
+      m_immediate_address=false;
+   }
+   operand_info( int builtin_id, int dim_mod, gpgpu_context* ctx )
+   {
+      init(ctx);
+      m_is_non_arch_reg = false;
+      m_addr_space = undefined_space;
+      m_operand_lohi = 0;
+      m_double_operand_type = 0;
+      m_operand_neg = false;
+      m_const_mem_offset = 0;
+      m_uid = get_uid();
+      m_valid = true;
+      m_vector = false;
+      m_type = builtin_t;
+      m_value.m_int = builtin_id;
+      m_addr_offset = dim_mod;
+      m_neg_pred = false;
+      m_is_return_var = false;
+      m_immediate_address=false;
+   }
+   operand_info( const symbol *addr, int offset, gpgpu_context* ctx )
+   {
+      init(ctx);
+      m_is_non_arch_reg = false;
+      m_addr_space = undefined_space;
+      m_operand_lohi = 0;
+      m_double_operand_type = 0;
+      m_operand_neg = false;
+      m_const_mem_offset = 0;
+      m_uid = get_uid();
+      m_valid = true;
+      m_vector = false;
+      m_type = address_t;
+      m_value.m_symbolic = addr;
+      m_addr_offset = offset;
+      m_neg_pred = false;
+      m_is_return_var = false;
+      m_immediate_address=false;
+   }
+   operand_info( unsigned x, gpgpu_context* ctx )
+   {
+      init(ctx);
+      m_is_non_arch_reg = false;
+      m_addr_space = undefined_space;
+      m_operand_lohi = 0;
+      m_double_operand_type = 0;
+      m_operand_neg = false;
+      m_const_mem_offset = 0;
+      m_uid = get_uid();
+      m_valid = true;
+      m_vector = false;
+      m_type = unsigned_t;
+      m_value.m_unsigned = x;
+      m_addr_offset = x;
+      m_neg_pred = false;
+      m_is_return_var = false;
+      m_immediate_address=true;
+   }
+   operand_info( int x, gpgpu_context* ctx )
+   {
+      init(ctx);
+      m_is_non_arch_reg = false;
+      m_addr_space = undefined_space;
+      m_operand_lohi = 0;
+      m_double_operand_type = 0;
+      m_operand_neg = false;
+      m_const_mem_offset = 0;
+      m_uid = get_uid();
+      m_valid = true;
+      m_vector = false;
+      m_type = int_t;
+      m_value.m_int = x;
+      m_addr_offset = 0;
+      m_neg_pred = false;
+      m_is_return_var = false;
+      m_immediate_address=false;
+   }
+   operand_info( float x, gpgpu_context* ctx )
+   {
+      init(ctx);
+      m_is_non_arch_reg = false;
+      m_addr_space = undefined_space;
+      m_operand_lohi = 0;
+      m_double_operand_type = 0;
+      m_operand_neg = false;
+      m_const_mem_offset = 0;
+      m_uid = get_uid();
+      m_valid = true;
+      m_vector = false;
+      m_type = float_op_t;
+      m_value.m_float = x;
+      m_addr_offset = 0;
+      m_neg_pred = false;
+      m_is_return_var = false;
+      m_immediate_address=false;
+   }
+   operand_info( double x, gpgpu_context* ctx )
+   {
+      init(ctx);
+      m_is_non_arch_reg = false;
+      m_addr_space = undefined_space;
+      m_operand_lohi = 0;
+      m_double_operand_type = 0;
+      m_operand_neg = false;
+      m_const_mem_offset = 0;
+      m_uid = get_uid();
+      m_valid = true;
+      m_vector = false;
+      m_type = double_op_t;
+      m_value.m_double = x;
+      m_addr_offset = 0;
+      m_neg_pred = false;
+      m_is_return_var = false;
+      m_immediate_address=false;
+   }
+   operand_info( const symbol *s1, const symbol *s2, const symbol *s3, const symbol *s4, gpgpu_context* ctx )
+   {
+      init(ctx);
+      m_is_non_arch_reg = false;
+      m_addr_space = undefined_space;
+      m_operand_lohi = 0;
+      m_double_operand_type = 0;
+      m_operand_neg = false;
+      m_const_mem_offset = 0;
+      m_uid = get_uid();
+      m_valid = true;
+      m_vector = true;
+      m_type = vector_t;
+      m_value.m_vector_symbolic = new const symbol*[8];
+      m_value.m_vector_symbolic[0] = s1;
+      m_value.m_vector_symbolic[1] = s2;
+      m_value.m_vector_symbolic[2] = s3;
+      m_value.m_vector_symbolic[3] = s4;
+      m_value.m_vector_symbolic[4] = NULL;
+      m_value.m_vector_symbolic[5] = NULL;
+      m_value.m_vector_symbolic[6] = NULL;
+      m_value.m_vector_symbolic[7] = NULL;
+      m_addr_offset = 0;
+      m_neg_pred = false;
+      m_is_return_var = false;
+      m_immediate_address=false;
+   }
+   operand_info( const symbol *s1, const symbol *s2, const symbol *s3, const symbol *s4 ,const symbol *s5,const symbol *s6,const symbol *s7, const symbol *s8, gpgpu_context* ctx)
+   {
+      init(ctx);
+      m_is_non_arch_reg = false;
+      m_addr_space = undefined_space;
+      m_operand_lohi = 0;
+      m_double_operand_type = 0;
+      m_operand_neg = false;
+      m_const_mem_offset = 0;
+      m_uid = get_uid();
+      m_valid = true;
+      m_vector = true;
+      m_type = vector_t;
+      m_value.m_vector_symbolic = new const symbol*[8];
+      m_value.m_vector_symbolic[0] = s1;
+      m_value.m_vector_symbolic[1] = s2;
+      m_value.m_vector_symbolic[2] = s3;
+      m_value.m_vector_symbolic[3] = s4;
+      m_value.m_vector_symbolic[4] = s5;
+      m_value.m_vector_symbolic[5] = s6;
+      m_value.m_vector_symbolic[6] = s7;
+      m_value.m_vector_symbolic[7] = s8;
+      m_addr_offset = 0;
+      m_neg_pred = false;
+      m_is_return_var = false;
+      m_immediate_address=false;
+   }
 
-    m_is_non_arch_reg = addr->is_non_arch_reg();
-    m_value.m_symbolic = addr;
-    m_addr_offset = 0;
-    m_vector = false;
-    m_neg_pred = false;
-    m_is_return_var = false;
-    m_immediate_address = false;
-  }
-  operand_info(const symbol *addr1, const symbol *addr2, gpgpu_context *ctx) {
-    init(ctx);
-    m_is_non_arch_reg = false;
-    m_addr_space = undefined_space;
-    m_operand_lohi = 0;
-    m_double_operand_type = 0;
-    m_operand_neg = false;
-    m_const_mem_offset = 0;
-    m_uid = get_uid();
-    m_valid = true;
-    m_type = memory_t;
-    m_value.m_vector_symbolic = new const symbol *[8];
-    m_value.m_vector_symbolic[0] = addr1;
-    m_value.m_vector_symbolic[1] = addr2;
-    m_value.m_vector_symbolic[2] = NULL;
-    m_value.m_vector_symbolic[3] = NULL;
-    m_value.m_vector_symbolic[4] = NULL;
-    m_value.m_vector_symbolic[5] = NULL;
-    m_value.m_vector_symbolic[6] = NULL;
-    m_value.m_vector_symbolic[7] = NULL;
-    m_addr_offset = 0;
-    m_vector = false;
-    m_neg_pred = false;
-    m_is_return_var = false;
-    m_immediate_address = false;
-  }
-  operand_info(int builtin_id, int dim_mod, gpgpu_context *ctx) {
-    init(ctx);
-    m_is_non_arch_reg = false;
-    m_addr_space = undefined_space;
-    m_operand_lohi = 0;
-    m_double_operand_type = 0;
-    m_operand_neg = false;
-    m_const_mem_offset = 0;
-    m_uid = get_uid();
-    m_valid = true;
-    m_vector = false;
-    m_type = builtin_t;
-    m_value.m_int = builtin_id;
-    m_addr_offset = dim_mod;
-    m_neg_pred = false;
-    m_is_return_var = false;
-    m_immediate_address = false;
-  }
-  operand_info(const symbol *addr, int offset, gpgpu_context *ctx) {
-    init(ctx);
-    m_is_non_arch_reg = false;
-    m_addr_space = undefined_space;
-    m_operand_lohi = 0;
-    m_double_operand_type = 0;
-    m_operand_neg = false;
-    m_const_mem_offset = 0;
-    m_uid = get_uid();
-    m_valid = true;
-    m_vector = false;
-    m_type = address_t;
-    m_value.m_symbolic = addr;
-    m_addr_offset = offset;
-    m_neg_pred = false;
-    m_is_return_var = false;
-    m_immediate_address = false;
-  }
-  operand_info(unsigned x, gpgpu_context *ctx) {
-    init(ctx);
-    m_is_non_arch_reg = false;
-    m_addr_space = undefined_space;
-    m_operand_lohi = 0;
-    m_double_operand_type = 0;
-    m_operand_neg = false;
-    m_const_mem_offset = 0;
-    m_uid = get_uid();
-    m_valid = true;
-    m_vector = false;
-    m_type = unsigned_t;
-    m_value.m_unsigned = x;
-    m_addr_offset = x;
-    m_neg_pred = false;
-    m_is_return_var = false;
-    m_immediate_address = true;
-  }
-  operand_info(int x, gpgpu_context *ctx) {
-    init(ctx);
-    m_is_non_arch_reg = false;
-    m_addr_space = undefined_space;
-    m_operand_lohi = 0;
-    m_double_operand_type = 0;
-    m_operand_neg = false;
-    m_const_mem_offset = 0;
-    m_uid = get_uid();
-    m_valid = true;
-    m_vector = false;
-    m_type = int_t;
-    m_value.m_int = x;
-    m_addr_offset = 0;
-    m_neg_pred = false;
-    m_is_return_var = false;
-    m_immediate_address = false;
-  }
-  operand_info(float x, gpgpu_context *ctx) {
-    init(ctx);
-    m_is_non_arch_reg = false;
-    m_addr_space = undefined_space;
-    m_operand_lohi = 0;
-    m_double_operand_type = 0;
-    m_operand_neg = false;
-    m_const_mem_offset = 0;
-    m_uid = get_uid();
-    m_valid = true;
-    m_vector = false;
-    m_type = float_op_t;
-    m_value.m_float = x;
-    m_addr_offset = 0;
-    m_neg_pred = false;
-    m_is_return_var = false;
-    m_immediate_address = false;
-  }
-  operand_info(double x, gpgpu_context *ctx) {
-    init(ctx);
-    m_is_non_arch_reg = false;
-    m_addr_space = undefined_space;
-    m_operand_lohi = 0;
-    m_double_operand_type = 0;
-    m_operand_neg = false;
-    m_const_mem_offset = 0;
-    m_uid = get_uid();
-    m_valid = true;
-    m_vector = false;
-    m_type = double_op_t;
-    m_value.m_double = x;
-    m_addr_offset = 0;
-    m_neg_pred = false;
-    m_is_return_var = false;
-    m_immediate_address = false;
-  }
-  operand_info(const symbol *s1, const symbol *s2, const symbol *s3,
-               const symbol *s4, gpgpu_context *ctx) {
-    init(ctx);
-    m_is_non_arch_reg = false;
-    m_addr_space = undefined_space;
-    m_operand_lohi = 0;
-    m_double_operand_type = 0;
-    m_operand_neg = false;
-    m_const_mem_offset = 0;
-    m_uid = get_uid();
-    m_valid = true;
-    m_vector = true;
-    m_type = vector_t;
-    m_value.m_vector_symbolic = new const symbol *[8];
-    m_value.m_vector_symbolic[0] = s1;
-    m_value.m_vector_symbolic[1] = s2;
-    m_value.m_vector_symbolic[2] = s3;
-    m_value.m_vector_symbolic[3] = s4;
-    m_value.m_vector_symbolic[4] = NULL;
-    m_value.m_vector_symbolic[5] = NULL;
-    m_value.m_vector_symbolic[6] = NULL;
-    m_value.m_vector_symbolic[7] = NULL;
-    m_addr_offset = 0;
-    m_neg_pred = false;
-    m_is_return_var = false;
-    m_immediate_address = false;
-  }
-  operand_info(const symbol *s1, const symbol *s2, const symbol *s3,
-               const symbol *s4, const symbol *s5, const symbol *s6,
-               const symbol *s7, const symbol *s8, gpgpu_context *ctx) {
-    init(ctx);
-    m_is_non_arch_reg = false;
-    m_addr_space = undefined_space;
-    m_operand_lohi = 0;
-    m_double_operand_type = 0;
-    m_operand_neg = false;
-    m_const_mem_offset = 0;
-    m_uid = get_uid();
-    m_valid = true;
-    m_vector = true;
-    m_type = vector_t;
-    m_value.m_vector_symbolic = new const symbol *[8];
-    m_value.m_vector_symbolic[0] = s1;
-    m_value.m_vector_symbolic[1] = s2;
-    m_value.m_vector_symbolic[2] = s3;
-    m_value.m_vector_symbolic[3] = s4;
-    m_value.m_vector_symbolic[4] = s5;
-    m_value.m_vector_symbolic[5] = s6;
-    m_value.m_vector_symbolic[6] = s7;
-    m_value.m_vector_symbolic[7] = s8;
-    m_addr_offset = 0;
-    m_neg_pred = false;
-    m_is_return_var = false;
-    m_immediate_address = false;
-  }
+   void init(gpgpu_context* ctx)
+   {
+       gpgpu_ctx = ctx;
+       m_uid=(unsigned)-1;
+       m_valid=false;
+       m_vector=false;
+       m_type=undef_t;
+       m_immediate_address=false;
+       m_addr_space=undefined_space;
+       m_operand_lohi=0;
+       m_double_operand_type=0;
+       m_operand_neg=false;
+       m_const_mem_offset=(unsigned)-1;
+       m_value.m_int=0;
+       m_value.m_unsigned=(unsigned)-1;
+       m_value.m_float=0;
+       m_value.m_double=0;
+       for(unsigned i=0; i<4; i++){
+           m_value.m_vint[i]=0;
+           m_value.m_vunsigned[i]=0;
+           m_value.m_vfloat[i]=0;
+           m_value.m_vdouble[i]=0;
+       }
+       m_value.m_symbolic=NULL;
+       m_value.m_vector_symbolic=NULL;
+       m_addr_offset=0;
+       m_neg_pred=0;
+       m_is_return_var=0;
+       m_is_non_arch_reg=0;
 
-  void init(gpgpu_context *ctx) {
-    gpgpu_ctx = ctx;
-    m_uid = (unsigned)-1;
-    m_valid = false;
-    m_vector = false;
-    m_type = undef_t;
-    m_immediate_address = false;
-    m_addr_space = undefined_space;
-    m_operand_lohi = 0;
-    m_double_operand_type = 0;
-    m_operand_neg = false;
-    m_const_mem_offset = (unsigned)-1;
-    m_value.m_int = 0;
-    m_value.m_unsigned = (unsigned)-1;
-    m_value.m_float = 0;
-    m_value.m_double = 0;
-    for (unsigned i = 0; i < 4; i++) {
-      m_value.m_vint[i] = 0;
-      m_value.m_vunsigned[i] = 0;
-      m_value.m_vfloat[i] = 0;
-      m_value.m_vdouble[i] = 0;
-    }
-    m_value.m_symbolic = NULL;
-    m_value.m_vector_symbolic = NULL;
-    m_addr_offset = 0;
-    m_neg_pred = 0;
-    m_is_return_var = 0;
-    m_is_non_arch_reg = 0;
-  }
-  void make_memory_operand() { m_type = memory_t; }
-  void set_return() { m_is_return_var = true; }
-  void set_immediate_addr() { m_immediate_address = true; }
-  const std::string &name() const {
-    assert(m_type == symbolic_t || m_type == reg_t || m_type == address_t ||
-           m_type == memory_t || m_type == label_t);
-    return m_value.m_symbolic->name();
-  }
+   }
+   void make_memory_operand() { m_type = memory_t;}
+   void set_return() { m_is_return_var = true; }
+   void set_immediate_addr() {m_immediate_address=true;}
+   const std::string &name() const
+   {
+      assert( m_type == symbolic_t || m_type == reg_t || m_type == address_t || m_type == memory_t || m_type == label_t);
+      return m_value.m_symbolic->name();
+   }
 
-  unsigned get_vect_nelem() const {
-    assert(is_vector());
-    if (!m_value.m_vector_symbolic[0]) return 0;
-    if (!m_value.m_vector_symbolic[1]) return 1;
-    if (!m_value.m_vector_symbolic[2]) return 2;
-    if (!m_value.m_vector_symbolic[3]) return 3;
-    if (!m_value.m_vector_symbolic[4]) return 4;
-    if (!m_value.m_vector_symbolic[5]) return 5;
-    if (!m_value.m_vector_symbolic[6]) return 6;
-    if (!m_value.m_vector_symbolic[7]) return 7;
-    return 8;
-  }
+   unsigned get_vect_nelem() const
+   {
+      assert( is_vector() );
+      if( !m_value.m_vector_symbolic[0] ) return 0;
+      if( !m_value.m_vector_symbolic[1] ) return 1;
+      if( !m_value.m_vector_symbolic[2] ) return 2;
+      if( !m_value.m_vector_symbolic[3] ) return 3;
+      if( !m_value.m_vector_symbolic[4] ) return 4;
+      if( !m_value.m_vector_symbolic[5] ) return 5;
+      if( !m_value.m_vector_symbolic[6] ) return 6;
+      if( !m_value.m_vector_symbolic[7] ) return 7;
+      return 8;
+   }
 
-  const symbol *vec_symbol(int idx) const {
-    assert(idx < 8);
-    const symbol *result = m_value.m_vector_symbolic[idx];
-    assert(result != NULL);
-    return result;
-  }
+   const symbol* vec_symbol(int idx) const 
+   {
+      assert(idx < 8);
+      const symbol *result = m_value.m_vector_symbolic[idx];
+      assert( result != NULL );
+      return result;
+   }
 
-  const std::string &vec_name1() const {
-    assert(m_type == vector_t);
-    return m_value.m_vector_symbolic[0]->name();
-  }
+   const std::string &vec_name1() const
+   {
+      assert( m_type == vector_t);
+      return m_value.m_vector_symbolic[0]->name();
+   }
 
-  const std::string &vec_name2() const {
-    assert(m_type == vector_t);
-    return m_value.m_vector_symbolic[1]->name();
-  }
+   const std::string &vec_name2() const
+   {
+      assert( m_type == vector_t);
+      return m_value.m_vector_symbolic[1]->name();
+   }
 
-  const std::string &vec_name3() const {
-    assert(m_type == vector_t);
-    return m_value.m_vector_symbolic[2]->name();
-  }
+   const std::string &vec_name3() const
+   {
+      assert( m_type == vector_t);
+      return m_value.m_vector_symbolic[2]->name();
+   }
 
-  const std::string &vec_name4() const {
-    assert(m_type == vector_t);
-    return m_value.m_vector_symbolic[3]->name();
-  }
+   const std::string &vec_name4() const
+   {
+      assert( m_type == vector_t);
+      return m_value.m_vector_symbolic[3]->name();
+   }
 
-  bool is_reg() const {
-    if (m_type == reg_t) {
-      return true;
-    }
-    if (m_type != symbolic_t) {
+   bool is_reg() const
+   {
+      if ( m_type == reg_t ) {
+         return true;
+      }
+      if ( m_type != symbolic_t ) {
+         return false;
+      }
+      return m_value.m_symbolic->type()->get_key().is_reg();
+   }
+   bool is_param_local() const
+   {
+      if ( m_type != symbolic_t ) 
+         return false;
+      return m_value.m_symbolic->type()->get_key().is_param_local();
+   }
+
+   bool is_param_kernel() const
+   {
+      if ( m_type != symbolic_t ) 
+         return false;
+      return m_value.m_symbolic->type()->get_key().is_param_kernel();
+   }
+
+   bool is_vector() const
+   {
+      if ( m_vector) return true;
       return false;
-    }
-    return m_value.m_symbolic->type()->get_key().is_reg();
-  }
-  bool is_param_local() const {
-    if (m_type != symbolic_t) return false;
-    return m_value.m_symbolic->type()->get_key().is_param_local();
-  }
+   }
+   int reg_num() const { return m_value.m_symbolic->reg_num();}
+   int reg1_num() const { return m_value.m_vector_symbolic[0]->reg_num();}
+   int reg2_num() const { return m_value.m_vector_symbolic[1]->reg_num();}
+   int reg3_num() const { return m_value.m_vector_symbolic[2]?m_value.m_vector_symbolic[2]->reg_num():0; }
+   int reg4_num() const { return m_value.m_vector_symbolic[3]?m_value.m_vector_symbolic[3]->reg_num():0; }
+   int reg5_num() const { return m_value.m_vector_symbolic[4]?m_value.m_vector_symbolic[4]->reg_num():0; }
+   int reg6_num() const { return m_value.m_vector_symbolic[5]?m_value.m_vector_symbolic[5]->reg_num():0; }
+   int reg7_num() const { return m_value.m_vector_symbolic[6]?m_value.m_vector_symbolic[6]->reg_num():0; }
+   int reg8_num() const { return m_value.m_vector_symbolic[7]?m_value.m_vector_symbolic[7]->reg_num():0; }
+   int arch_reg_num() const { return m_value.m_symbolic->arch_reg_num(); }
+   int arch_reg_num(unsigned n) const { return (m_value.m_vector_symbolic[n])? m_value.m_vector_symbolic[n]->arch_reg_num() : -1; }
+   bool is_label() const { return m_type == label_t;}
+   bool is_builtin() const { return m_type == builtin_t;}
 
-  bool is_param_kernel() const {
-    if (m_type != symbolic_t) return false;
-    return m_value.m_symbolic->type()->get_key().is_param_kernel();
-  }
+   // Memory operand used in ld / st instructions (ex. [__var1])
+   bool is_memory_operand() const { return m_type == memory_t;}
 
-  bool is_vector() const {
-    if (m_vector) return true;
-    return false;
-  }
-  int reg_num() const { return m_value.m_symbolic->reg_num(); }
-  int reg1_num() const { return m_value.m_vector_symbolic[0]->reg_num(); }
-  int reg2_num() const { return m_value.m_vector_symbolic[1]->reg_num(); }
-  int reg3_num() const {
-    return m_value.m_vector_symbolic[2]
-               ? m_value.m_vector_symbolic[2]->reg_num()
-               : 0;
-  }
-  int reg4_num() const {
-    return m_value.m_vector_symbolic[3]
-               ? m_value.m_vector_symbolic[3]->reg_num()
-               : 0;
-  }
-  int reg5_num() const {
-    return m_value.m_vector_symbolic[4]
-               ? m_value.m_vector_symbolic[4]->reg_num()
-               : 0;
-  }
-  int reg6_num() const {
-    return m_value.m_vector_symbolic[5]
-               ? m_value.m_vector_symbolic[5]->reg_num()
-               : 0;
-  }
-  int reg7_num() const {
-    return m_value.m_vector_symbolic[6]
-               ? m_value.m_vector_symbolic[6]->reg_num()
-               : 0;
-  }
-  int reg8_num() const {
-    return m_value.m_vector_symbolic[7]
-               ? m_value.m_vector_symbolic[7]->reg_num()
-               : 0;
-  }
-  int arch_reg_num() const { return m_value.m_symbolic->arch_reg_num(); }
-  int arch_reg_num(unsigned n) const {
-    return (m_value.m_vector_symbolic[n])
-               ? m_value.m_vector_symbolic[n]->arch_reg_num()
-               : -1;
-  }
-  bool is_label() const { return m_type == label_t; }
-  bool is_builtin() const { return m_type == builtin_t; }
+   // Memory operand with immediate access (ex. s[0x0004] or g[$r1+=0x0004])
+   // This is used by the PTXPlus extension. The operand is assigned an address space during parsing.
+   bool is_memory_operand2() const { 
+      return (m_addr_space!=undefined_space); 
+   }
 
-  // Memory operand used in ld / st instructions (ex. [__var1])
-  bool is_memory_operand() const { return m_type == memory_t; }
+   bool is_immediate_address() const {
+       return   m_immediate_address;
+   }
 
-  // Memory operand with immediate access (ex. s[0x0004] or g[$r1+=0x0004])
-  // This is used by the PTXPlus extension. The operand is assigned an address
-  // space during parsing.
-  bool is_memory_operand2() const { return (m_addr_space != undefined_space); }
+   bool is_literal() const { return m_type == int_t ||
+      m_type == float_op_t ||
+      m_type == double_op_t ||
+      m_type == unsigned_t;} 
+   bool is_shared() const {
+      if ( !(m_type == symbolic_t || m_type == address_t || m_type == memory_t) ) {
+         return false;
+      }
+      return  m_value.m_symbolic->is_shared();
+   }
+   bool is_sstarr() const { return m_value.m_symbolic->is_sstarr();}
+   bool is_const() const { return m_value.m_symbolic->is_const();}
+   bool is_global() const { return m_value.m_symbolic->is_global();}
+   bool is_local() const { return m_value.m_symbolic->is_local();}
+   bool is_tex() const { return m_value.m_symbolic->is_tex();}
+   bool is_return_var() const { return m_is_return_var; }
 
-  bool is_immediate_address() const { return m_immediate_address; }
+   bool is_function_address() const
+   {
+      if( m_type != symbolic_t ) {
+         return false;
+      }
+      return m_value.m_symbolic->is_func_addr();
+   }
 
-  bool is_literal() const {
-    return m_type == int_t || m_type == float_op_t || m_type == double_op_t ||
-           m_type == unsigned_t;
-  }
-  bool is_shared() const {
-    if (!(m_type == symbolic_t || m_type == address_t || m_type == memory_t)) {
-      return false;
-    }
-    return m_value.m_symbolic->is_shared();
-  }
-  bool is_sstarr() const { return m_value.m_symbolic->is_sstarr(); }
-  bool is_const() const { return m_value.m_symbolic->is_const(); }
-  bool is_global() const { return m_value.m_symbolic->is_global(); }
-  bool is_local() const { return m_value.m_symbolic->is_local(); }
-  bool is_tex() const { return m_value.m_symbolic->is_tex(); }
-  bool is_return_var() const { return m_is_return_var; }
-
-  bool is_function_address() const {
-    if (m_type != symbolic_t) {
-      return false;
-    }
-    return m_value.m_symbolic->is_func_addr();
-  }
-
-  ptx_reg_t get_literal_value() const {
-    ptx_reg_t result;
-    switch (m_type) {
-      case int_t:
-        result.s64 = m_value.m_int;
-        break;
-      case float_op_t:
-        result.f32 = m_value.m_float;
-        break;
-      case double_op_t:
-        result.f64 = m_value.m_double;
-        break;
-      case unsigned_t:
-        result.u32 = m_value.m_unsigned;
-        break;
+   ptx_reg_t get_literal_value() const
+   {
+      ptx_reg_t result;
+      switch ( m_type ) {
+      case int_t:         result.s64 = m_value.m_int; break;
+      case float_op_t:    result.f32 = m_value.m_float; break;
+      case double_op_t:   result.f64 = m_value.m_double; break; 
+      case unsigned_t:    result.u32 = m_value.m_unsigned; break;
       default:
-        assert(0);
-        break;
-    }
-    return result;
-  }
-  int get_int() const { return m_value.m_int; }
-  int get_addr_offset() const { return m_addr_offset; }
-  const symbol *get_symbol() const { return m_value.m_symbolic; }
-  void set_type(enum operand_type type) { m_type = type; }
-  enum operand_type get_type() const { return m_type; }
-  void set_neg_pred() {
-    assert(m_valid);
-    m_neg_pred = true;
-  }
-  bool is_neg_pred() const { return m_neg_pred; }
-  bool is_valid() const { return m_valid; }
+         assert(0);
+         break;
+      } 
+      return result;
+   }
+   int get_int() const { return m_value.m_int;}
+   int get_addr_offset() const { return m_addr_offset;}
+   const symbol *get_symbol() const { return m_value.m_symbolic;}
+   void set_type( enum operand_type type ) 
+   {
+      m_type = type;
+   }
+   enum operand_type get_type() const {
+      return m_type;
+   }
+   void set_neg_pred()
+   {
+      assert( m_valid );
+      m_neg_pred = true;
+   }
+   bool is_neg_pred() const { return m_neg_pred; }
+   bool is_valid() const { return m_valid; }
 
-  void set_addr_space(enum _memory_space_t set_value) {
-    m_addr_space = set_value;
-  }
-  enum _memory_space_t get_addr_space() const { return m_addr_space; }
-  void set_operand_lohi(int set_value) { m_operand_lohi = set_value; }
-  int get_operand_lohi() const { return m_operand_lohi; }
-  void set_double_operand_type(int set_value) {
-    m_double_operand_type = set_value;
-  }
-  int get_double_operand_type() const { return m_double_operand_type; }
-  void set_operand_neg() { m_operand_neg = true; }
-  bool get_operand_neg() const { return m_operand_neg; }
-  void set_const_mem_offset(addr_t set_value) {
-    m_const_mem_offset = set_value;
-  }
-  addr_t get_const_mem_offset() const { return m_const_mem_offset; }
-  bool is_non_arch_reg() const { return m_is_non_arch_reg; }
+   void set_addr_space(enum _memory_space_t set_value) { m_addr_space = set_value; }
+   enum _memory_space_t get_addr_space() const { return m_addr_space; }
+   void set_operand_lohi(int set_value) { m_operand_lohi = set_value; }
+   int get_operand_lohi() const { return m_operand_lohi; }
+   void set_double_operand_type(int set_value) {  m_double_operand_type = set_value; }
+   int get_double_operand_type() const { return  m_double_operand_type; }
+   void set_operand_neg() { m_operand_neg = true; }
+   bool get_operand_neg() const { return m_operand_neg; }
+   void set_const_mem_offset(addr_t set_value) { m_const_mem_offset = set_value; }
+   addr_t get_const_mem_offset() const { return m_const_mem_offset; }
+   bool is_non_arch_reg() const { return m_is_non_arch_reg; }
 
- private:
-  gpgpu_context *gpgpu_ctx;
-  unsigned m_uid;
-  bool m_valid;
-  bool m_vector;
-  enum operand_type m_type;
-  bool m_immediate_address;
-  enum _memory_space_t m_addr_space;
-  int m_operand_lohi;
-  int m_double_operand_type;
-  bool m_operand_neg;
-  addr_t m_const_mem_offset;
-  union {
-    int m_int;
-    unsigned int m_unsigned;
-    float m_float;
-    double m_double;
-    int m_vint[4];
-    unsigned int m_vunsigned[4];
-    float m_vfloat[4];
-    double m_vdouble[4];
-    const symbol *m_symbolic;
-    const symbol **m_vector_symbolic;
-  } m_value;
+private:
+   gpgpu_context* gpgpu_ctx;
+   unsigned m_uid;
+   bool m_valid;
+   bool m_vector;
+   enum operand_type m_type;
+   bool m_immediate_address;
+   enum _memory_space_t m_addr_space;
+   int m_operand_lohi;
+   int m_double_operand_type;
+   bool m_operand_neg;
+   addr_t m_const_mem_offset;
+   union {
+      int             m_int;
+      unsigned int    m_unsigned;
+      float           m_float;
+      double          m_double;
+      int             m_vint[4];
+      unsigned int    m_vunsigned[4];
+      float           m_vfloat[4];
+      double          m_vdouble[4];
+      const symbol*  m_symbolic;
+      const symbol**  m_vector_symbolic;
+   } m_value;
 
-  int m_addr_offset;
+   int m_addr_offset;
 
-  bool m_neg_pred;
-  bool m_is_return_var;
-  bool m_is_non_arch_reg;
+   bool m_neg_pred;
+   bool m_is_return_var;
+   bool m_is_non_arch_reg;
 
-  unsigned get_uid();
+   unsigned get_uid();
 };
 
 extern const char *g_opcode_string[];
 struct basic_block_t {
-  basic_block_t(unsigned ID, ptx_instruction *begin, ptx_instruction *end,
-                bool entry, bool ex) {
-    bb_id = ID;
-    ptx_begin = begin;
-    ptx_end = end;
-    is_entry = entry;
-    is_exit = ex;
-    immediatepostdominator_id = -1;
-    immediatedominator_id = -1;
-  }
+   basic_block_t( unsigned ID, ptx_instruction *begin, ptx_instruction *end, bool entry, bool ex)
+   {
+      bb_id = ID;
+      ptx_begin = begin;
+      ptx_end = end;
+      is_entry=entry;
+      is_exit=ex;
+      immediatepostdominator_id = -1;
+      immediatedominator_id = -1;
+   }
 
-  ptx_instruction *ptx_begin;
-  ptx_instruction *ptx_end;
-  std::set<int>
-      predecessor_ids;  // indices of other basic blocks in m_basic_blocks array
-  std::set<int> successor_ids;
-  std::set<int> postdominator_ids;
-  std::set<int> dominator_ids;
-  std::set<int> Tmp_ids;
-  int immediatepostdominator_id;
-  int immediatedominator_id;
-  bool is_entry;
-  bool is_exit;
-  unsigned bb_id;
+   ptx_instruction* ptx_begin;
+   ptx_instruction* ptx_end;
+   std::set<int> predecessor_ids; //indices of other basic blocks in m_basic_blocks array
+   std::set<int> successor_ids;
+   std::set<int> postdominator_ids;
+   std::set<int> dominator_ids;
+   std::set<int> Tmp_ids;
+   int immediatepostdominator_id;
+   int immediatedominator_id;
+   bool is_entry;
+   bool is_exit;
+   unsigned bb_id;
 
-  // if this basic block dom B
-  bool dom(const basic_block_t *B) {
-    return (B->dominator_ids.find(this->bb_id) != B->dominator_ids.end());
-  }
+   // if this basic block dom B
+   bool dom(const basic_block_t *B) {
+      return (B->dominator_ids.find(this->bb_id) != B->dominator_ids.end());
+   }
 
-  // if this basic block pdom B
-  bool pdom(const basic_block_t *B) {
-    return (B->postdominator_ids.find(this->bb_id) !=
-            B->postdominator_ids.end());
-  }
+   // if this basic block pdom B
+   bool pdom(const basic_block_t *B) {
+      return (B->postdominator_ids.find(this->bb_id) != B->postdominator_ids.end());
+   }
 };
 
 struct gpgpu_recon_t {
-  address_type source_pc;
-  address_type target_pc;
-  class ptx_instruction *source_inst;
-  class ptx_instruction *target_inst;
+   address_type source_pc;
+   address_type target_pc;
+   class ptx_instruction* source_inst;
+   class ptx_instruction* target_inst;
 };
 
 class ptx_instruction : public warp_inst_t {
- public:
-  ptx_instruction(int opcode, const symbol *pred, int neg_pred, int pred_mod,
-                  symbol *label, const std::list<operand_info> &operands,
-                  const operand_info &return_var, const std::list<int> &options,
-                  const std::list<int> &wmma_options,
-                  const std::list<int> &scalar_type, memory_space_t space_spec,
-                  const char *file, unsigned line, const char *source,
-                  const core_config *config, gpgpu_context *ctx);
+public:
+    ptx_instruction( int opcode, 
+                    const symbol *pred, 
+                    int neg_pred, 
+                    int pred_mod,
+                    symbol *label,
+                    const std::list<operand_info> &operands, 
+                    const operand_info &return_var,
+                    const std::list<int> &options, 
+                    const std::list<int> &wmma_options, 
+                    const std::list<int> &scalar_type,
+                    memory_space_t space_spec,
+                    const char *file, 
+                    unsigned line,
+                    const char *source,
+                    const core_config *config,
+		    gpgpu_context* ctx);
 
-  void print_insn() const;
-  virtual void print_insn(FILE *fp) const;
-  std::string to_string() const;
-  unsigned inst_size() const { return m_inst_size; }
-  unsigned uid() const { return m_uid; }
-  int get_opcode() const { return m_opcode; }
-  const char *get_opcode_cstr() const {
-    if (m_opcode != -1) {
-      return g_opcode_string[m_opcode];
-    } else {
-      return "label";
-    }
-  }
-  const char *source_file() const { return m_source_file.c_str(); }
-  unsigned source_line() const { return m_source_line; }
-  unsigned get_num_operands() const { return m_operands.size(); }
-  bool has_pred() const { return m_pred != NULL; }
-  operand_info get_pred() const;
-  bool get_pred_neg() const { return m_neg_pred; }
-  int get_pred_mod() const { return m_pred_mod; }
-  const char *get_source() const { return m_source.c_str(); }
+   void print_insn() const;
+   virtual void print_insn( FILE *fp ) const;
+   std::string to_string() const;
+   unsigned inst_size() const { return m_inst_size; }
+   unsigned uid() const { return m_uid;}
+   int get_opcode() const { return m_opcode;}
+   const char *get_opcode_cstr() const 
+   {
+      if ( m_opcode != -1 ) {
+         return g_opcode_string[m_opcode]; 
+      } else {
+         return "label";
+      }
+   }
+   const char *source_file() const { return m_source_file.c_str();} 
+   unsigned source_line() const { return m_source_line;}
+   unsigned get_num_operands() const { return m_operands.size();}
+   bool has_pred() const { return m_pred != NULL;}
+   operand_info get_pred() const;
+   bool get_pred_neg() const { return m_neg_pred;}
+   int get_pred_mod() const { return m_pred_mod;}
+   const char *get_source() const { return m_source.c_str();}
 
-  typedef std::vector<operand_info>::const_iterator const_iterator;
+   typedef std::vector<operand_info>::const_iterator const_iterator;
 
-  const_iterator op_iter_begin() const { return m_operands.begin(); }
+   const_iterator op_iter_begin() const 
+   { 
+      return m_operands.begin();
+   }
 
-  const_iterator op_iter_end() const { return m_operands.end(); }
+   const_iterator op_iter_end() const 
+   { 
+      return m_operands.end();
+   }
 
-  const operand_info &dst() const {
-    assert(!m_operands.empty());
-    return m_operands[0];
-  }
-
-  const operand_info &func_addr() const {
-    assert(!m_operands.empty());
-    if (!m_operands[0].is_return_var()) {
+   const operand_info &dst() const 
+   { 
+      assert( !m_operands.empty() );
       return m_operands[0];
-    } else {
-      assert(m_operands.size() >= 2);
+   }
+
+   const operand_info &func_addr() const
+   {
+      assert( !m_operands.empty() );
+      if( !m_operands[0].is_return_var() ) {
+         return m_operands[0];
+      } else {
+         assert( m_operands.size() >= 2 );
+         return m_operands[1];
+      }
+   }
+
+   operand_info &dst() 
+   { 
+      assert( !m_operands.empty() );
+      return m_operands[0];
+   }
+
+   const operand_info &src1() const 
+   { 
+      assert( m_operands.size() > 1 );
       return m_operands[1];
-    }
-  }
+   }
 
-  operand_info &dst() {
-    assert(!m_operands.empty());
-    return m_operands[0];
-  }
+   const operand_info &src2() const 
+   { 
+      assert( m_operands.size() > 2 );
+      return m_operands[2];
+   }
 
-  const operand_info &src1() const {
-    assert(m_operands.size() > 1);
-    return m_operands[1];
-  }
+   const operand_info &src3() const 
+   { 
+      assert( m_operands.size() > 3 );
+      return m_operands[3];
+   }
+   const operand_info &src4() const 
+   { 
+      assert( m_operands.size() > 4 );
+      return m_operands[4];
+   }
+   const operand_info &src5() const 
+   { 
+      assert( m_operands.size() > 5 );
+      return m_operands[5];
+   }
+   const operand_info &src6() const 
+   { 
+      assert( m_operands.size() > 6 );
+      return m_operands[6];
+   }
+   const operand_info &src7() const 
+   { 
+      assert( m_operands.size() > 7 );
+      return m_operands[7];
+   }
+   const operand_info &src8() const 
+   { 
+      assert( m_operands.size() > 8 );
+      return m_operands[8];
+   }
 
-  const operand_info &src2() const {
-    assert(m_operands.size() > 2);
-    return m_operands[2];
-  }
+   const operand_info &operand_lookup( unsigned n ) const
+   {
+      assert( n < m_operands.size() );
+      return m_operands[n];
+   }
+   bool has_return() const
+   {
+      return m_return_var.is_valid();
+   }
 
-  const operand_info &src3() const {
-    assert(m_operands.size() > 3);
-    return m_operands[3];
-  }
-  const operand_info &src4() const {
-    assert(m_operands.size() > 4);
-    return m_operands[4];
-  }
-  const operand_info &src5() const {
-    assert(m_operands.size() > 5);
-    return m_operands[5];
-  }
-  const operand_info &src6() const {
-    assert(m_operands.size() > 6);
-    return m_operands[6];
-  }
-  const operand_info &src7() const {
-    assert(m_operands.size() > 7);
-    return m_operands[7];
-  }
-  const operand_info &src8() const {
-    assert(m_operands.size() > 8);
-    return m_operands[8];
-  }
+   memory_space_t get_space() const { return m_space_spec;}
+   unsigned get_vector() const { return m_vector_spec;}
+   unsigned get_atomic() const { return m_atomic_spec;}
 
-  const operand_info &operand_lookup(unsigned n) const {
-    assert(n < m_operands.size());
-    return m_operands[n];
-  }
-  bool has_return() const { return m_return_var.is_valid(); }
+   int get_wmma_type() const {
+      return m_wmma_type;
+   }
+   int get_wmma_layout(int index) const {
+      return m_wmma_layout[index];//0->Matrix D,1->Matrix C
+   }
+   int get_type() const 
+   {
+      assert( !m_scalar_type.empty() );
+      return m_scalar_type.front();
+   }
 
-  memory_space_t get_space() const { return m_space_spec; }
-  unsigned get_vector() const { return m_vector_spec; }
-  unsigned get_atomic() const { return m_atomic_spec; }
+   int get_type2() const 
+   {
+      assert( m_scalar_type.size()==2 );
+      return m_scalar_type.back();
+   }
 
-  int get_wmma_type() const { return m_wmma_type; }
-  int get_wmma_layout(int index) const {
-    return m_wmma_layout[index];  // 0->Matrix D,1->Matrix C
-  }
-  int get_type() const {
-    assert(!m_scalar_type.empty());
-    return m_scalar_type.front();
-  }
+   void assign_bb(basic_block_t* basic_block) //assign instruction to a basic block
+   {
+      m_basic_block = basic_block;
+   }
+   basic_block_t* get_bb() { return m_basic_block;}
+   void set_m_instr_mem_index(unsigned index) {
+      m_instr_mem_index = index; 
+   }
+   void set_PC( addr_t PC )
+   {
+       m_PC = PC;
+   }
+   addr_t get_PC() const
+   {
+       return m_PC;
+   }
 
-  int get_type2() const {
-    assert(m_scalar_type.size() == 2);
-    return m_scalar_type.back();
-  }
+   unsigned get_m_instr_mem_index() { return m_instr_mem_index;}
+   unsigned get_cmpop() const { return m_compare_op;}
+   const symbol *get_label() const { return m_label;}
+   bool is_label() const { if(m_label){ assert(m_opcode==-1);return true;} return false;}
+   bool is_hi() const { return m_hi;}
+   bool is_lo() const { return m_lo;}
+   bool is_wide() const { return m_wide;}
+   bool is_uni() const { return m_uni;}
+   bool is_exit() const { return m_exit;}
+   bool is_abs() const { return m_abs;}
+   bool is_neg() const { return m_neg;}
+   bool is_to() const { return m_to_option; }
+   unsigned cache_option() const { return m_cache_option; }
+   unsigned rounding_mode() const { return m_rounding_mode;}
+   unsigned saturation_mode() const { return m_saturation_mode;}
+   unsigned dimension() const { return m_geom_spec;}
+   unsigned barrier_op() const {return m_barrier_op;}
+   unsigned shfl_op() const {return m_shfl_op;}
+   unsigned prmt_op() const {return m_prmt_op;}
+   enum vote_mode_t { vote_any, vote_all, vote_uni, vote_ballot };
+   enum vote_mode_t vote_mode() const { return m_vote_mode; }
 
-  void assign_bb(
-      basic_block_t *basic_block)  // assign instruction to a basic block
-  {
-    m_basic_block = basic_block;
-  }
-  basic_block_t *get_bb() { return m_basic_block; }
-  void set_m_instr_mem_index(unsigned index) { m_instr_mem_index = index; }
-  void set_PC(addr_t PC) { m_PC = PC; }
-  addr_t get_PC() const { return m_PC; }
+   int membar_level() const { return m_membar_level; }
 
-  unsigned get_m_instr_mem_index() { return m_instr_mem_index; }
-  unsigned get_cmpop() const { return m_compare_op; }
-  const symbol *get_label() const { return m_label; }
-  bool is_label() const {
-    if (m_label) {
-      assert(m_opcode == -1);
-      return true;
-    }
-    return false;
-  }
-  bool is_hi() const { return m_hi; }
-  bool is_lo() const { return m_lo; }
-  bool is_wide() const { return m_wide; }
-  bool is_uni() const { return m_uni; }
-  bool is_exit() const { return m_exit; }
-  bool is_abs() const { return m_abs; }
-  bool is_neg() const { return m_neg; }
-  bool is_to() const { return m_to_option; }
-  unsigned cache_option() const { return m_cache_option; }
-  unsigned rounding_mode() const { return m_rounding_mode; }
-  unsigned saturation_mode() const { return m_saturation_mode; }
-  unsigned dimension() const { return m_geom_spec; }
-  unsigned barrier_op() const { return m_barrier_op; }
-  unsigned shfl_op() const { return m_shfl_op; }
-  unsigned prmt_op() const { return m_prmt_op; }
-  enum vote_mode_t { vote_any, vote_all, vote_uni, vote_ballot };
-  enum vote_mode_t vote_mode() const { return m_vote_mode; }
+   bool has_memory_read() const {
+      if( m_opcode == LD_OP || m_opcode == LDU_OP || m_opcode == TEX_OP|| m_opcode==MMA_LD_OP ) 
+         return true;
+      // Check PTXPlus operand type below
+      // Source operands are memory operands
+      ptx_instruction::const_iterator op=op_iter_begin();
+      for ( int n=0; op != op_iter_end(); op++, n++ ) { //process operands
+         if( n > 0 && op->is_memory_operand2()) // source operands only
+            return true;
+      }
+      return false;
+   }
+   bool has_memory_write() const {
+      if( m_opcode == ST_OP || m_opcode==MMA_ST_OP ) return true;
+      // Check PTXPlus operand type below
+      // Destination operand is a memory operand
+      ptx_instruction::const_iterator op=op_iter_begin();
+      for ( int n=0; (op!=op_iter_end() && n<1); op++, n++ ) { //process operands
+         if( n==0 && op->is_memory_operand2()) // source operands only
+            return true;
+      }
+      return false;
+   }
 
-  int membar_level() const { return m_membar_level; }
 
-  bool has_memory_read() const {
-    if (m_opcode == LD_OP || m_opcode == LDU_OP || m_opcode == TEX_OP ||
-        m_opcode == MMA_LD_OP)
-      return true;
-    // Check PTXPlus operand type below
-    // Source operands are memory operands
-    ptx_instruction::const_iterator op = op_iter_begin();
-    for (int n = 0; op != op_iter_end(); op++, n++) {  // process operands
-      if (n > 0 && op->is_memory_operand2())           // source operands only
-        return true;
-    }
-    return false;
-  }
-  bool has_memory_write() const {
-    if (m_opcode == ST_OP || m_opcode == MMA_ST_OP) return true;
-    // Check PTXPlus operand type below
-    // Destination operand is a memory operand
-    ptx_instruction::const_iterator op = op_iter_begin();
-    for (int n = 0; (op != op_iter_end() && n < 1);
-         op++, n++) {                          // process operands
-      if (n == 0 && op->is_memory_operand2())  // source operands only
-        return true;
-    }
-    return false;
-  }
+private:
+   void set_opcode_and_latency();
+   void set_bar_type();
+   void set_fp_or_int_archop();
+   void set_mul_div_or_other_archop();
 
- private:
-  void set_opcode_and_latency();
-  void set_bar_type();
-  void set_fp_or_int_archop();
-  void set_mul_div_or_other_archop();
+   basic_block_t        *m_basic_block;
+   unsigned          m_uid;
+   addr_t            m_PC;
+   std::string             m_source_file;
+   unsigned                m_source_line;
+   std::string          m_source;
 
-  basic_block_t *m_basic_block;
-  unsigned m_uid;
-  addr_t m_PC;
-  std::string m_source_file;
-  unsigned m_source_line;
-  std::string m_source;
+   const symbol           *m_pred;
+   bool                    m_neg_pred;
+   int                    m_pred_mod;
+   int                     m_opcode;
+   const symbol           *m_label;
+   std::vector<operand_info> m_operands;
+   operand_info m_return_var;
 
-  const symbol *m_pred;
-  bool m_neg_pred;
-  int m_pred_mod;
-  int m_opcode;
-  const symbol *m_label;
-  std::vector<operand_info> m_operands;
-  operand_info m_return_var;
+   std::list<int>          m_options;
+   std::list<int>          m_wmma_options;
+   bool                m_wide;
+   bool                m_hi;
+   bool                m_lo;
+   bool                m_exit;
+   bool                m_abs;
+   bool                m_neg;
+   bool                m_uni; //if branch instruction, this evaluates to true for uniform branches (ie jumps)
+   bool                m_to_option;
+   unsigned            m_cache_option;
+   int      m_wmma_type;
+   int      m_wmma_layout[2];
+   int      m_wmma_configuration;
+   unsigned            m_rounding_mode;
+   unsigned            m_compare_op;
+   unsigned            m_saturation_mode;
+   unsigned 		   m_barrier_op;
+   unsigned			   m_shfl_op;
+   unsigned			   m_prmt_op;
 
-  std::list<int> m_options;
-  std::list<int> m_wmma_options;
-  bool m_wide;
-  bool m_hi;
-  bool m_lo;
-  bool m_exit;
-  bool m_abs;
-  bool m_neg;
-  bool m_uni;  // if branch instruction, this evaluates to true for uniform
-               // branches (ie jumps)
-  bool m_to_option;
-  unsigned m_cache_option;
-  int m_wmma_type;
-  int m_wmma_layout[2];
-  int m_wmma_configuration;
-  unsigned m_rounding_mode;
-  unsigned m_compare_op;
-  unsigned m_saturation_mode;
-  unsigned m_barrier_op;
-  unsigned m_shfl_op;
-  unsigned m_prmt_op;
+   std::list<int>          m_scalar_type;
+   memory_space_t m_space_spec;
+   int m_geom_spec;
+   int m_vector_spec;
+   int m_atomic_spec;
+   enum vote_mode_t m_vote_mode;
+   int m_membar_level;
+   int m_instr_mem_index; //index into m_instr_mem array
+   unsigned m_inst_size; // bytes
 
-  std::list<int> m_scalar_type;
-  memory_space_t m_space_spec;
-  int m_geom_spec;
-  int m_vector_spec;
-  int m_atomic_spec;
-  enum vote_mode_t m_vote_mode;
-  int m_membar_level;
-  int m_instr_mem_index;  // index into m_instr_mem array
-  unsigned m_inst_size;   // bytes
-
-  virtual void pre_decode();
-  friend class function_info;
-  // backward pointer
-  class gpgpu_context *gpgpu_ctx;
+   virtual void pre_decode();
+   friend class function_info;
+   // backward pointer
+   class gpgpu_context* gpgpu_ctx;
 };
 
 class param_info {
- public:
-  param_info() {
-    m_valid = false;
-    m_value_set = false;
-    m_size = 0;
-    m_is_ptr = false;
-  }
-  param_info(std::string name, int type, size_t size, bool is_ptr,
-             memory_space_t ptr_space) {
-    m_valid = true;
-    m_value_set = false;
-    m_name = name;
-    m_type = type;
-    m_size = size;
-    m_is_ptr = is_ptr;
-    m_ptr_space = ptr_space;
-  }
-  void add_data(param_t v) {
-    assert((!m_value_set) || (m_value.size == v.size));  // if this fails
-                                                         // concurrent kernel
-                                                         // launches might
-                                                         // execute incorrectly
-    m_value_set = true;
-    m_value = v;
-  }
-  void add_offset(unsigned offset) { m_offset = offset; }
-  unsigned get_offset() {
-    assert(m_valid);
-    return m_offset;
-  }
-  std::string get_name() const {
-    assert(m_valid);
-    return m_name;
-  }
-  int get_type() const {
-    assert(m_valid);
-    return m_type;
-  }
-  param_t get_value() const {
-    assert(m_value_set);
-    return m_value;
-  }
-  size_t get_size() const {
-    assert(m_valid);
-    return m_size;
-  }
-  bool is_ptr_shared() const {
-    assert(m_valid);
-    return (m_is_ptr and m_ptr_space == shared_space);
-  }
-
- private:
-  bool m_valid;
-  std::string m_name;
-  int m_type;
-  size_t m_size;
-  bool m_value_set;
-  param_t m_value;
-  unsigned m_offset;
-  bool m_is_ptr;
-  memory_space_t m_ptr_space;
+public:
+   param_info() { m_valid = false; m_value_set=false; m_size = 0; m_is_ptr = false; }
+   param_info( std::string name, int type, size_t size, bool is_ptr, memory_space_t ptr_space ) 
+   {
+      m_valid = true;
+      m_value_set = false;
+      m_name = name;
+      m_type = type;
+      m_size = size;
+      m_is_ptr = is_ptr; 
+      m_ptr_space = ptr_space; 
+   }
+   void add_data( param_t v ) { 
+      assert( (!m_value_set) || (m_value.size == v.size) ); // if this fails concurrent kernel launches might execute incorrectly
+      m_value_set = true;
+      m_value = v;
+   }
+   void add_offset( unsigned offset ) { m_offset = offset; }
+   unsigned get_offset() { assert(m_valid); return m_offset; }
+   std::string get_name() const { assert(m_valid); return m_name; }
+   int get_type() const { assert(m_valid);  return m_type; }
+   param_t get_value() const { assert(m_value_set); return m_value; }
+   size_t get_size() const { assert(m_valid); return m_size; }
+   bool is_ptr_shared() const { assert(m_valid); return (m_is_ptr and m_ptr_space == shared_space); }
+private:
+   bool m_valid;
+   std::string m_name;
+   int m_type;
+   size_t m_size;
+   bool m_value_set;
+   param_t m_value;
+   unsigned m_offset;
+   bool m_is_ptr; 
+   memory_space_t m_ptr_space; 
 };
 
 class function_info {
- public:
-  function_info(int entry_point, gpgpu_context *ctx);
-  const ptx_version &get_ptx_version() const {
-    return m_symtab->get_ptx_version();
-  }
-  unsigned get_sm_target() const { return m_symtab->get_sm_target(); }
-  bool is_extern() const { return m_extern; }
-  void set_name(const char *name) { m_name = name; }
-  void set_symtab(symbol_table *symtab) { m_symtab = symtab; }
-  std::string get_name() const { return m_name; }
-  unsigned print_insn(unsigned pc, FILE *fp) const;
-  std::string get_insn_str(unsigned pc) const;
-  void add_inst(const std::list<ptx_instruction *> &instructions) {
-    m_instructions = instructions;
-  }
-  std::list<ptx_instruction *>::iterator find_next_real_instruction(
-      std::list<ptx_instruction *>::iterator i);
-  void create_basic_blocks();
+public:
+   function_info(int entry_point, gpgpu_context* ctx );
+   const ptx_version &get_ptx_version() const { return m_symtab->get_ptx_version(); }
+   unsigned get_sm_target() const { return m_symtab->get_sm_target(); }
+   bool is_extern() const { return m_extern; }
+   void set_name(const char *name)
+   {
+      m_name = name;
+   }
+   void set_symtab(symbol_table *symtab )
+   {
+      m_symtab = symtab;
+   }
+   std::string get_name() const
+   {
+      return m_name;
+   }
+   unsigned print_insn( unsigned pc, FILE * fp ) const;
+    std::string get_insn_str( unsigned pc ) const;
+   void add_inst( const std::list<ptx_instruction*> &instructions )
+   {
+      m_instructions = instructions;
+   }
+   std::list<ptx_instruction*>::iterator find_next_real_instruction( std::list<ptx_instruction*>::iterator i );
+   void create_basic_blocks( );
 
-  void print_basic_blocks();
+   void print_basic_blocks();
 
-  void print_basic_block_links();
-  void print_basic_block_dot();
+   void print_basic_block_links();
+   void print_basic_block_dot();
 
-  operand_info *find_break_target(
-      ptx_instruction *p_break_insn);  // find the target of a break instruction
-  void connect_basic_blocks();  // iterate across m_basic_blocks of function,
-                                // connecting basic blocks together
-  bool
-  connect_break_targets();  // connecting break instructions with proper targets
+   operand_info* find_break_target( ptx_instruction * p_break_insn ); //find the target of a break instruction 
+   void connect_basic_blocks( ); //iterate across m_basic_blocks of function, connecting basic blocks together
+   bool connect_break_targets(); //connecting break instructions with proper targets
 
-  // iterate across m_basic_blocks of function,
-  // finding dominator blocks, using algorithm of
-  // Muchnick's Adv. Compiler Design & Implemmntation Fig 7.14
-  void find_dominators();
-  void print_dominators();
-  void find_idominators();
-  void print_idominators();
+   //iterate across m_basic_blocks of function, 
+   //finding dominator blocks, using algorithm of
+   //Muchnick's Adv. Compiler Design & Implemmntation Fig 7.14 
+   void find_dominators( );
+   void print_dominators();
+   void find_idominators();
+   void print_idominators();
 
-  // iterate across m_basic_blocks of function,
-  // finding postdominator blocks, using algorithm of
-  // Muchnick's Adv. Compiler Design & Implemmntation Fig 7.14
-  void find_postdominators();
-  void print_postdominators();
+   //iterate across m_basic_blocks of function, 
+   //finding postdominator blocks, using algorithm of
+   //Muchnick's Adv. Compiler Design & Implemmntation Fig 7.14 
+   void find_postdominators( );
+   void print_postdominators();
 
-  // iterate across m_basic_blocks of function,
-  // finding immediate postdominator blocks, using algorithm of
-  // Muchnick's Adv. Compiler Design & Implemmntation Fig 7.15
-  void find_ipostdominators();
-  void print_ipostdominators();
-  void do_pdom();  // function to call pdom analysis
+   //iterate across m_basic_blocks of function, 
+   //finding immediate postdominator blocks, using algorithm of
+   //Muchnick's Adv. Compiler Design & Implemmntation Fig 7.15 
+   void find_ipostdominators( );
+   void print_ipostdominators();
+   void do_pdom(); //function to call pdom analysis
 
-  unsigned get_num_reconvergence_pairs();
+   unsigned get_num_reconvergence_pairs();
 
-  void get_reconvergence_pairs(gpgpu_recon_t *recon_points);
+   void get_reconvergence_pairs(gpgpu_recon_t* recon_points);
 
-  unsigned get_function_size() { return m_instructions.size(); }
+   unsigned get_function_size() { return m_instructions.size();}
 
-  void ptx_assemble();
+   void ptx_assemble();
+ 
+   unsigned ptx_get_inst_op( ptx_thread_info *thread );
+   void add_param( const char *name, struct param_t value )
+   {
+      m_kernel_params[ name ] = value;
+   }
+   void add_param_name_type_size( unsigned index, std::string name, int type, size_t size, bool ptr, memory_space_t space );
+   void add_param_data( unsigned argn, struct gpgpu_ptx_sim_arg *args );
+   void add_return_var( const symbol *rv )
+   {
+      m_return_var_sym = rv;
+   }
+   void add_arg( const symbol *arg )
+   {
+      assert( arg != NULL );
+      m_args.push_back(arg);
+   }
+   void remove_args()
+   {
+      m_args.clear();
+   }
+   unsigned num_args() const
+   {
+      return m_args.size();
+   }
+   unsigned get_args_aligned_size();
 
-  unsigned ptx_get_inst_op(ptx_thread_info *thread);
-  void add_param(const char *name, struct param_t value) {
-    m_kernel_params[name] = value;
-  }
-  void add_param_name_type_size(unsigned index, std::string name, int type,
-                                size_t size, bool ptr, memory_space_t space);
-  void add_param_data(unsigned argn, struct gpgpu_ptx_sim_arg *args);
-  void add_return_var(const symbol *rv) { m_return_var_sym = rv; }
-  void add_arg(const symbol *arg) {
-    assert(arg != NULL);
-    m_args.push_back(arg);
-  }
-  void remove_args() { m_args.clear(); }
-  unsigned num_args() const { return m_args.size(); }
-  unsigned get_args_aligned_size();
+   const symbol* get_arg( unsigned n ) const
+   {
+      assert( n < m_args.size() );
+      return m_args[n];
+   }
+   bool has_return() const
+   {
+      return m_return_var_sym != NULL;
+   }
+   const symbol *get_return_var() const
+   {
+      return m_return_var_sym;
+   }
+   const ptx_instruction *get_instruction( unsigned PC ) const
+   {
+      unsigned index = PC - m_start_PC;
+      if( index < m_instr_mem_size ) 
+         return m_instr_mem[index];
+      return NULL;
+   }
+   addr_t get_start_PC() const
+   {
+       return m_start_PC;
+   }
 
-  const symbol *get_arg(unsigned n) const {
-    assert(n < m_args.size());
-    return m_args[n];
-  }
-  bool has_return() const { return m_return_var_sym != NULL; }
-  const symbol *get_return_var() const { return m_return_var_sym; }
-  const ptx_instruction *get_instruction(unsigned PC) const {
-    unsigned index = PC - m_start_PC;
-    if (index < m_instr_mem_size) return m_instr_mem[index];
-    return NULL;
-  }
-  addr_t get_start_PC() const { return m_start_PC; }
+   void finalize( memory_space *param_mem );
+   void param_to_shared( memory_space *shared_mem, symbol_table *symtab ); 
+   void list_param( FILE *fout ) const;
+   void ptx_jit_config(std::map<unsigned long long, size_t> mallocPtr_Size, memory_space *param_mem, gpgpu_t* gpu, dim3 gridDim, dim3 blockDim) ;
 
-  void finalize(memory_space *param_mem);
-  void param_to_shared(memory_space *shared_mem, symbol_table *symtab);
-  void list_param(FILE *fout) const;
-  void ptx_jit_config(std::map<unsigned long long, size_t> mallocPtr_Size,
-                      memory_space *param_mem, gpgpu_t *gpu, dim3 gridDim,
-                      dim3 blockDim);
+   const struct gpgpu_ptx_sim_info* get_kernel_info () const
+   {
+      assert (m_kernel_info.maxthreads == maxnt_id);
+      return &m_kernel_info;
+   }
 
-  const struct gpgpu_ptx_sim_info *get_kernel_info() const {
-    assert(m_kernel_info.maxthreads == maxnt_id);
-    return &m_kernel_info;
-  }
+   const void set_kernel_info (const struct gpgpu_ptx_sim_info &info) {
+      m_kernel_info = info;
+      m_kernel_info.ptx_version = 10*get_ptx_version().ver();
+      m_kernel_info.sm_target = get_ptx_version().target();
+      // THIS DEPENDS ON ptxas being called after the PTX is parsed.
+      m_kernel_info.maxthreads = maxnt_id;
+   }
+   symbol_table *get_symtab()
+   {
+      return m_symtab;
+   }
 
-  const void set_kernel_info(const struct gpgpu_ptx_sim_info &info) {
-    m_kernel_info = info;
-    m_kernel_info.ptx_version = 10 * get_ptx_version().ver();
-    m_kernel_info.sm_target = get_ptx_version().target();
-    // THIS DEPENDS ON ptxas being called after the PTX is parsed.
-    m_kernel_info.maxthreads = maxnt_id;
-  }
-  symbol_table *get_symtab() { return m_symtab; }
+   unsigned local_mem_framesize() const 
+   { 
+      return m_local_mem_framesize; 
+   }
+   void set_framesize( unsigned sz )
+   {
+      m_local_mem_framesize = sz;
+   }
+   bool is_entry_point() const { return m_entry_point; }
+   bool is_pdom_set() const { return pdom_done; } //return pdom flag
+   void set_pdom() { pdom_done = true; } //set pdom flag
 
-  unsigned local_mem_framesize() const { return m_local_mem_framesize; }
-  void set_framesize(unsigned sz) { m_local_mem_framesize = sz; }
-  bool is_entry_point() const { return m_entry_point; }
-  bool is_pdom_set() const { return pdom_done; }  // return pdom flag
-  void set_pdom() { pdom_done = true; }           // set pdom flag
+   void add_config_param( size_t size, unsigned alignment ){
+      unsigned offset = 0;
+      if (m_param_configs.size()>0){
+          unsigned offset_nom = m_param_configs.back().first + m_param_configs.back().second;
+          //ensure offset matches alignment requirements
+          offset = offset_nom%alignment ? (offset_nom/alignment + 1) * alignment : offset_nom;
+      }
+      m_param_configs.push_back(std::pair<size_t,unsigned>(size, offset));
+   }
 
-  void add_config_param(size_t size, unsigned alignment) {
-    unsigned offset = 0;
-    if (m_param_configs.size() > 0) {
-      unsigned offset_nom =
-          m_param_configs.back().first + m_param_configs.back().second;
-      // ensure offset matches alignment requirements
-      offset = offset_nom % alignment ? (offset_nom / alignment + 1) * alignment
-                                      : offset_nom;
-    }
-    m_param_configs.push_back(std::pair<size_t, unsigned>(size, offset));
-  }
+   std::pair<size_t, unsigned> get_param_config(unsigned param_num) const { return m_param_configs[param_num]; }
 
-  std::pair<size_t, unsigned> get_param_config(unsigned param_num) const {
-    return m_param_configs[param_num];
-  }
+   void set_maxnt_id(unsigned maxthreads) { maxnt_id = maxthreads;}
+   unsigned get_maxnt_id() { return maxnt_id;}
+   // backward pointer
+   class gpgpu_context* gpgpu_ctx;
 
-  void set_maxnt_id(unsigned maxthreads) { maxnt_id = maxthreads; }
-  unsigned get_maxnt_id() { return maxnt_id; }
-  // backward pointer
-  class gpgpu_context *gpgpu_ctx;
+private:
+   unsigned maxnt_id;
+   unsigned m_uid;
+   unsigned m_local_mem_framesize;
+   bool m_entry_point;
+   bool m_extern;
+   bool m_assembled;
+   bool pdom_done; //flag to check whether pdom is completed or not
+   std::string m_name;
+   ptx_instruction **m_instr_mem;
+   unsigned m_start_PC;
+   unsigned m_instr_mem_size;
+   std::map<std::string,param_t> m_kernel_params;
+   std::map<unsigned,param_info> m_ptx_kernel_param_info;
+   std::vector< std::pair<size_t, unsigned> > m_param_configs;
+   const symbol *m_return_var_sym;
+   std::vector<const symbol*> m_args;
+   std::list<ptx_instruction*> m_instructions;
+   std::vector<basic_block_t*> m_basic_blocks;
+   std::list<std::pair<unsigned, unsigned> > m_back_edges;
+   std::map<std::string,unsigned> labels;
+   unsigned num_reconvergence_pairs;
 
- private:
-  unsigned maxnt_id;
-  unsigned m_uid;
-  unsigned m_local_mem_framesize;
-  bool m_entry_point;
-  bool m_extern;
-  bool m_assembled;
-  bool pdom_done;  // flag to check whether pdom is completed or not
-  std::string m_name;
-  ptx_instruction **m_instr_mem;
-  unsigned m_start_PC;
-  unsigned m_instr_mem_size;
-  std::map<std::string, param_t> m_kernel_params;
-  std::map<unsigned, param_info> m_ptx_kernel_param_info;
-  std::vector<std::pair<size_t, unsigned> > m_param_configs;
-  const symbol *m_return_var_sym;
-  std::vector<const symbol *> m_args;
-  std::list<ptx_instruction *> m_instructions;
-  std::vector<basic_block_t *> m_basic_blocks;
-  std::list<std::pair<unsigned, unsigned> > m_back_edges;
-  std::map<std::string, unsigned> labels;
-  unsigned num_reconvergence_pairs;
+   //Registers/shmem/etc. used (from ptxas -v), loaded from ___.ptxinfo along with ___.ptx
+   struct gpgpu_ptx_sim_info m_kernel_info;
 
-  // Registers/shmem/etc. used (from ptxas -v), loaded from ___.ptxinfo along
-  // with ___.ptx
-  struct gpgpu_ptx_sim_info m_kernel_info;
+   symbol_table *m_symtab;
 
-  symbol_table *m_symtab;
-
-  // parameter size for device kernels
-  int m_args_aligned_size;
-
-  addr_t m_n;  // offset in m_instr_mem (used in do_pdom)
+   //parameter size for device kernels
+   int m_args_aligned_size;
+   
+   addr_t m_n;  // offset in m_instr_mem (used in do_pdom)
 };
 
 class arg_buffer_t {
- public:
-  arg_buffer_t(gpgpu_context *ctx) : m_src_op(ctx) {
-    m_is_reg = false;
-    m_is_param = false;
-    m_param_value = NULL;
-    m_reg_value = ptx_reg_t();
-  }
-  arg_buffer_t(const arg_buffer_t &another, gpgpu_context *ctx)
-      : m_src_op(ctx) {
-    make_copy(another);
-  }
-  void make_copy(const arg_buffer_t &another) {
-    m_dst = another.m_dst;
-    m_src_op = another.m_src_op;
-    m_is_reg = another.m_is_reg;
-    m_is_param = another.m_is_param;
-    m_reg_value = another.m_reg_value;
-    m_param_bytes = another.m_param_bytes;
-    if (m_is_param) {
-      m_param_value = malloc(m_param_bytes);
-      memcpy(m_param_value, another.m_param_value, m_param_bytes);
-    }
-  }
-  void operator=(const arg_buffer_t &another) { make_copy(another); }
-  ~arg_buffer_t() {
-    if (m_is_param) free(m_param_value);
-  }
-  arg_buffer_t(const symbol *dst_sym, const operand_info &src_op,
-               ptx_reg_t source_value)
-      : m_src_op(src_op) {
-    m_dst = dst_sym;
-    m_reg_value = ptx_reg_t();
-    if (dst_sym->is_reg()) {
-      m_is_reg = true;
-      m_is_param = false;
-      assert(src_op.is_reg());
-      m_reg_value = source_value;
-    } else {
-      m_is_param = true;
-      m_is_reg = false;
-      m_param_value = calloc(sizeof(ptx_reg_t), 1);
-      // new (m_param_value) ptx_reg_t(source_value);
-      memcpy(m_param_value, &source_value, sizeof(ptx_reg_t));
-      m_param_bytes = sizeof(ptx_reg_t);
-    }
-  }
-  arg_buffer_t(const symbol *dst_sym, const operand_info &src_op,
-               void *source_param_value_array, unsigned array_size)
-      : m_src_op(src_op) {
-    m_dst = dst_sym;
-    if (dst_sym->is_reg()) {
-      m_is_reg = true;
-      m_is_param = false;
-      assert(src_op.is_param_local());
-      assert(dst_sym->get_size_in_bytes() == array_size);
-      switch (array_size) {
-        case 1:
-          m_reg_value.u8 = *(unsigned char *)source_param_value_array;
-          break;
-        case 2:
-          m_reg_value.u16 = *(unsigned short *)source_param_value_array;
-          break;
-        case 4:
-          m_reg_value.u32 = *(unsigned int *)source_param_value_array;
-          break;
-        case 8:
-          m_reg_value.u64 = *(unsigned long long *)source_param_value_array;
-          break;
-        default:
-          printf(
-              "GPGPU-Sim PTX: ERROR ** source param size does not match known "
-              "register sizes\n");
-          break;
+public:
+   arg_buffer_t(gpgpu_context* ctx) : m_src_op(ctx)
+   {
+      m_is_reg=false;
+      m_is_param=false;
+      m_param_value=NULL;
+      m_reg_value=ptx_reg_t();
+   }
+   arg_buffer_t( const arg_buffer_t &another, gpgpu_context* ctx ) : m_src_op(ctx)
+   {
+      make_copy(another);
+   }
+   void make_copy( const arg_buffer_t &another )
+   {
+      m_dst = another.m_dst;
+      m_src_op = another.m_src_op;
+      m_is_reg = another.m_is_reg;
+      m_is_param = another.m_is_param;
+      m_reg_value = another.m_reg_value;
+      m_param_bytes = another.m_param_bytes;
+      if( m_is_param ) {
+         m_param_value = malloc(m_param_bytes);
+         memcpy(m_param_value,another.m_param_value,m_param_bytes);
       }
-    } else {
-      // param
-      m_is_param = true;
-      m_is_reg = false;
-      m_param_value = calloc(array_size, 1);
-      m_param_bytes = array_size;
-      memcpy(m_param_value, source_param_value_array, array_size);
-    }
-  }
+   }
+   void operator=( const arg_buffer_t &another )
+   {
+      make_copy(another);
+   }
+   ~arg_buffer_t()
+   {
+      if( m_is_param ) 
+         free(m_param_value);
+   }
+   arg_buffer_t( const symbol *dst_sym, const operand_info &src_op, ptx_reg_t source_value ) : m_src_op(src_op)
+   {
+      m_dst = dst_sym;
+      m_reg_value=ptx_reg_t();
+      if( dst_sym->is_reg() ) {
+         m_is_reg = true;
+         m_is_param = false;
+         assert( src_op.is_reg() );
+         m_reg_value = source_value;
+      } else {
+         m_is_param = true;
+         m_is_reg = false;
+         m_param_value = calloc(sizeof(ptx_reg_t),1);
+         //new (m_param_value) ptx_reg_t(source_value);
+         memcpy(m_param_value,&source_value,sizeof(ptx_reg_t));
+         m_param_bytes = sizeof(ptx_reg_t);
+      }
+   }
+   arg_buffer_t( const symbol *dst_sym, const operand_info &src_op, void *source_param_value_array, unsigned array_size ) : m_src_op(src_op)
+   {
+      m_dst = dst_sym;
+      if( dst_sym->is_reg() ) {
+         m_is_reg = true;
+         m_is_param = false;
+         assert( src_op.is_param_local() );
+         assert( dst_sym->get_size_in_bytes() == array_size );
+         switch( array_size ) {
+         case 1: m_reg_value.u8 = *(unsigned char*)source_param_value_array; break;
+         case 2: m_reg_value.u16 = *(unsigned short*)source_param_value_array; break;
+         case 4: m_reg_value.u32 = *(unsigned int*)source_param_value_array; break;
+         case 8: m_reg_value.u64 = *(unsigned long long*)source_param_value_array; break;
+         default:
+            printf("GPGPU-Sim PTX: ERROR ** source param size does not match known register sizes\n");
+            break;
+         }
+      } else {
+         // param
+         m_is_param = true;
+         m_is_reg = false;
+         m_param_value = calloc(array_size,1);
+         m_param_bytes = array_size;
+         memcpy(m_param_value,source_param_value_array,array_size);
+      }
+   }
 
-  bool is_reg() const { return m_is_reg; }
-  ptx_reg_t get_reg() const {
-    assert(m_is_reg);
-    return m_reg_value;
-  }
+   bool is_reg() const { return m_is_reg; }
+   ptx_reg_t get_reg() const 
+   { 
+      assert(m_is_reg); 
+      return m_reg_value; 
+   }
 
-  const void *get_param_buffer() const {
-    assert(m_is_param);
-    return m_param_value;
-  }
-  size_t get_param_buffer_size() const {
-    assert(m_is_param);
-    return m_param_bytes;
-  }
+   const void *get_param_buffer() const
+   {
+      assert(m_is_param);
+      return m_param_value;
+   }
+   size_t get_param_buffer_size() const
+   {
+      assert(m_is_param);
+      return m_param_bytes;
+   }
 
-  const symbol *get_dst() const { return m_dst; }
+   const symbol *get_dst() const { return m_dst; }
 
- private:
-  // destination of copy
-  const symbol *m_dst;
+private:
+   // destination of copy
+   const symbol *m_dst;
 
-  // source operand
-  operand_info m_src_op;
+   // source operand
+   operand_info m_src_op;
 
-  // source information
-  bool m_is_reg;
-  bool m_is_param;
+   // source information
+   bool m_is_reg;
+   bool m_is_param;
 
-  // source is register
-  ptx_reg_t m_reg_value;
+   // source is register
+   ptx_reg_t m_reg_value;
 
-  // source is param
-  void *m_param_value;
-  unsigned m_param_bytes;
+   // source is param
+   void     *m_param_value;
+   unsigned  m_param_bytes;
 };
 
-typedef std::list<arg_buffer_t> arg_buffer_list_t;
-arg_buffer_t copy_arg_to_buffer(ptx_thread_info *thread,
-                                operand_info actual_param_op,
-                                const symbol *formal_param);
-void copy_args_into_buffer_list(const ptx_instruction *pI,
-                                ptx_thread_info *thread,
-                                const function_info *target_func,
-                                arg_buffer_list_t &arg_values);
-void copy_buffer_list_into_frame(ptx_thread_info *thread,
-                                 arg_buffer_list_t &arg_values);
-void copy_buffer_to_frame(ptx_thread_info *thread, const arg_buffer_t &a);
+typedef std::list< arg_buffer_t > arg_buffer_list_t;
+arg_buffer_t copy_arg_to_buffer(ptx_thread_info * thread, operand_info actual_param_op, const symbol * formal_param);
+void copy_args_into_buffer_list( const ptx_instruction * pI, 
+                                 ptx_thread_info * thread, 
+                                 const function_info * target_func, 
+                                 arg_buffer_list_t &arg_values ); 
+void copy_buffer_list_into_frame(ptx_thread_info * thread, arg_buffer_list_t &arg_values);
+void copy_buffer_to_frame(ptx_thread_info * thread, const arg_buffer_t &a);
+
 
 struct textureInfo {
-  unsigned int texel_size;  // size in bytes, e.g. (channelDesc.x+y+z+w)/8
-  unsigned int Tx,
-      Ty;  // tiling factor dimensions of layout of texels per 64B cache block
-  unsigned int Tx_numbits, Ty_numbits;  // log2(T)
-  unsigned int texel_size_numbits;      // log2(texel_size)
+   unsigned int texel_size; //size in bytes, e.g. (channelDesc.x+y+z+w)/8
+   unsigned int Tx,Ty; //tiling factor dimensions of layout of texels per 64B cache block
+   unsigned int Tx_numbits,Ty_numbits; //log2(T)
+   unsigned int texel_size_numbits; //log2(texel_size)
 };
 
-extern std::map<std::string, symbol_table *> g_sym_name_to_symbol_table;
+extern std::map<std::string,symbol_table*> g_sym_name_to_symbol_table;
 
-void gpgpu_ptx_assemble(std::string kname, void *kinfo);
+
+void gpgpu_ptx_assemble( std::string kname, void *kinfo );
 #include "../option_parser.h"
-unsigned ptx_kernel_shmem_size(void *kernel_impl);
-unsigned ptx_kernel_nregs(void *kernel_impl);
+unsigned ptx_kernel_shmem_size( void *kernel_impl );
+unsigned ptx_kernel_nregs( void *kernel_impl );
 
 #endif

--- a/src/cuda-sim/ptx_ir.h
+++ b/src/cuda-sim/ptx_ir.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -30,13 +32,13 @@
 
 #include "../abstract_hardware_model.h"
 
+#include <assert.h>
 #include <cstdlib>
 #include <cstring>
-#include <string>
 #include <list>
 #include <map>
+#include <string>
 #include <vector>
-#include <assert.h>
 
 //#include "ptx.tab.h"
 #include "ptx_sim.h"
@@ -46,1537 +48,1518 @@
 class gpgpu_context;
 
 class type_info_key {
-public:
-   type_info_key()
-   {
-      m_is_non_arch_reg = false;
-      m_init = false;
-   }
-   type_info_key( memory_space_t space_spec, int scalar_type_spec, int vector_spec, int alignment_spec, int extern_spec, int array_dim )
-   {
-      m_is_non_arch_reg = false;
-      m_init = true;
-      m_space_spec = space_spec; 
-      m_scalar_type_spec = scalar_type_spec;
-      m_vector_spec = vector_spec;
-      m_alignment_spec = alignment_spec;
-      m_extern_spec = extern_spec;
-      m_array_dim = array_dim;
-      m_is_function = 0;
-   } 
-   void set_is_func()
-   { 
-      assert(!m_init);
-      m_init = true;
-      m_space_spec = undefined_space; 
-      m_scalar_type_spec = 0;
-      m_vector_spec = 0;
-      m_alignment_spec = 0;
-      m_extern_spec = 0;
-      m_array_dim = 0; 
-      m_is_function = 1;
-   }
+ public:
+  type_info_key() {
+    m_is_non_arch_reg = false;
+    m_init = false;
+  }
+  type_info_key(memory_space_t space_spec, int scalar_type_spec,
+                int vector_spec, int alignment_spec, int extern_spec,
+                int array_dim) {
+    m_is_non_arch_reg = false;
+    m_init = true;
+    m_space_spec = space_spec;
+    m_scalar_type_spec = scalar_type_spec;
+    m_vector_spec = vector_spec;
+    m_alignment_spec = alignment_spec;
+    m_extern_spec = extern_spec;
+    m_array_dim = array_dim;
+    m_is_function = 0;
+  }
+  void set_is_func() {
+    assert(!m_init);
+    m_init = true;
+    m_space_spec = undefined_space;
+    m_scalar_type_spec = 0;
+    m_vector_spec = 0;
+    m_alignment_spec = 0;
+    m_extern_spec = 0;
+    m_array_dim = 0;
+    m_is_function = 1;
+  }
 
-   void set_array_dim( int array_dim ) { m_array_dim = array_dim; }
-   int get_array_dim() const { assert(m_init); return m_array_dim; }
-   void set_is_non_arch_reg() { m_is_non_arch_reg = true;  }
+  void set_array_dim(int array_dim) { m_array_dim = array_dim; }
+  int get_array_dim() const {
+    assert(m_init);
+    return m_array_dim;
+  }
+  void set_is_non_arch_reg() { m_is_non_arch_reg = true; }
 
-   bool is_non_arch_reg() const { return m_is_non_arch_reg; }
-   bool is_reg() const { return m_space_spec == reg_space;} 
-   bool is_param_kernel() const { return m_space_spec == param_space_kernel;}
-   bool is_param_local() const { return m_space_spec == param_space_local; }
-   bool is_param_unclassified() const { return m_space_spec == param_space_unclassified; }
-   bool is_global() const { return m_space_spec == global_space;}
-   bool is_local() const { return m_space_spec == local_space;}
-   bool is_shared() const { return m_space_spec == shared_space;}
-   bool is_const() const { return m_space_spec.get_type() == const_space;}
-   bool is_tex() const { return m_space_spec == tex_space;}
-   bool is_func_addr() const { return m_is_function?true:false; }
-   int  scalar_type() const { return m_scalar_type_spec;}
-   int  get_alignment_spec() const { return m_alignment_spec;}
-   unsigned type_decode( size_t &size, int &t ) const;
-   static unsigned type_decode( int type, size_t &size, int &t );
-   memory_space_t get_memory_space() const { return m_space_spec; }
-private:
-   bool m_init;
-   memory_space_t m_space_spec; 
-   int m_scalar_type_spec;
-   int m_vector_spec;
-   int m_alignment_spec;
-   int m_extern_spec;
-   int m_array_dim;
-   int m_is_function;
-   bool m_is_non_arch_reg;
+  bool is_non_arch_reg() const { return m_is_non_arch_reg; }
+  bool is_reg() const { return m_space_spec == reg_space; }
+  bool is_param_kernel() const { return m_space_spec == param_space_kernel; }
+  bool is_param_local() const { return m_space_spec == param_space_local; }
+  bool is_param_unclassified() const {
+    return m_space_spec == param_space_unclassified;
+  }
+  bool is_global() const { return m_space_spec == global_space; }
+  bool is_local() const { return m_space_spec == local_space; }
+  bool is_shared() const { return m_space_spec == shared_space; }
+  bool is_const() const { return m_space_spec.get_type() == const_space; }
+  bool is_tex() const { return m_space_spec == tex_space; }
+  bool is_func_addr() const { return m_is_function ? true : false; }
+  int scalar_type() const { return m_scalar_type_spec; }
+  int get_alignment_spec() const { return m_alignment_spec; }
+  unsigned type_decode(size_t &size, int &t) const;
+  static unsigned type_decode(int type, size_t &size, int &t);
+  memory_space_t get_memory_space() const { return m_space_spec; }
 
-   friend struct type_info_key_compare;
+ private:
+  bool m_init;
+  memory_space_t m_space_spec;
+  int m_scalar_type_spec;
+  int m_vector_spec;
+  int m_alignment_spec;
+  int m_extern_spec;
+  int m_array_dim;
+  int m_is_function;
+  bool m_is_non_arch_reg;
+
+  friend struct type_info_key_compare;
 };
 
 class symbol_table;
 
 struct type_info_key_compare {
-   bool operator()( const type_info_key &a, const type_info_key &b ) const
-   {
-      assert( a.m_init && b.m_init );
-      if ( a.m_space_spec < b.m_space_spec ) return true;
-      if ( a.m_scalar_type_spec < b.m_scalar_type_spec ) return true;
-      if ( a.m_vector_spec < b.m_vector_spec ) return true;
-      if ( a.m_alignment_spec < b.m_alignment_spec ) return true;
-      if ( a.m_extern_spec < b.m_extern_spec ) return true;
-      if ( a.m_array_dim < b.m_array_dim ) return true;
-      if ( a.m_is_function < b.m_is_function ) return true;
+  bool operator()(const type_info_key &a, const type_info_key &b) const {
+    assert(a.m_init && b.m_init);
+    if (a.m_space_spec < b.m_space_spec) return true;
+    if (a.m_scalar_type_spec < b.m_scalar_type_spec) return true;
+    if (a.m_vector_spec < b.m_vector_spec) return true;
+    if (a.m_alignment_spec < b.m_alignment_spec) return true;
+    if (a.m_extern_spec < b.m_extern_spec) return true;
+    if (a.m_array_dim < b.m_array_dim) return true;
+    if (a.m_is_function < b.m_is_function) return true;
 
-      return false;
-   }
+    return false;
+  }
 };
 
 class type_info {
-public:
-   type_info( symbol_table *scope, type_info_key t )
-   {
-      m_type_info = t;
-   }
-   const type_info_key &get_key() const { return m_type_info;}
+ public:
+  type_info(symbol_table *scope, type_info_key t) { m_type_info = t; }
+  const type_info_key &get_key() const { return m_type_info; }
 
-private:
-   symbol_table *m_scope;
-   type_info_key m_type_info;
+ private:
+  symbol_table *m_scope;
+  type_info_key m_type_info;
 };
 
 enum operand_type {
-   reg_t, vector_t, builtin_t, address_t, memory_t, float_op_t, double_op_t, int_t, 
-   unsigned_t, symbolic_t, label_t, v_reg_t, v_float_op_t, v_double_op_t,
-   v_int_t, v_unsigned_t, undef_t
+  reg_t,
+  vector_t,
+  builtin_t,
+  address_t,
+  memory_t,
+  float_op_t,
+  double_op_t,
+  int_t,
+  unsigned_t,
+  symbolic_t,
+  label_t,
+  v_reg_t,
+  v_float_op_t,
+  v_double_op_t,
+  v_int_t,
+  v_unsigned_t,
+  undef_t
 };
 
 class operand_info;
 
 class symbol {
-public:
-   symbol( const char *name, const type_info *type, const char *location, unsigned size, gpgpu_context* ctx ) 
-   {
-      gpgpu_ctx = ctx;
-      m_uid = get_uid();
-      m_name = name;
-      m_decl_location = location;
-      m_type = type;
-      m_size = size;
-      m_address_valid = false;
-      m_is_label = false;
-      m_is_shared = false;
-      m_is_const = false;
-      m_is_global = false;
-      m_is_local = false;
-      m_is_param_local = false;
-      m_is_param_kernel = false;
-      m_is_tex = false;
-      m_is_func_addr = false;
-      m_reg_num_valid = false;
-      m_function = NULL;
-      m_reg_num=(unsigned)-1;
-      m_arch_reg_num=(unsigned)-1;
-      m_address=(unsigned)-1;
-      m_initializer.clear();
-      if ( type ) m_is_shared = type->get_key().is_shared();
-      if ( type ) m_is_const = type->get_key().is_const();
-      if ( type ) m_is_global = type->get_key().is_global();
-      if ( type ) m_is_local = type->get_key().is_local();
-      if ( type ) m_is_param_local = type->get_key().is_param_local();
-      if ( type ) m_is_param_kernel = type->get_key().is_param_kernel();
-      if ( type ) m_is_tex = type->get_key().is_tex();
-      if ( type ) m_is_func_addr = type->get_key().is_func_addr();
-   }
-   unsigned get_size_in_bytes() const
-   {
-      return m_size;
-   }
-   const std::string &name() const { return m_name;}
-   const std::string &decl_location() const { return m_decl_location;} 
-   const type_info *type() const { return m_type;}
-   addr_t get_address() const 
-   { 
-      assert( m_is_label || !m_type->get_key().is_reg() ); // todo : other assertions
-      assert( m_address_valid );
-      return m_address;
-   }
-   function_info *get_pc() const
-   {
-      return m_function;
-   }
-   void set_regno( unsigned regno, unsigned arch_regno )
-   {
-      m_reg_num_valid = true;
-      m_reg_num = regno;
-      m_arch_reg_num = arch_regno;
-   }
+ public:
+  symbol(const char *name, const type_info *type, const char *location,
+         unsigned size, gpgpu_context *ctx) {
+    gpgpu_ctx = ctx;
+    m_uid = get_uid();
+    m_name = name;
+    m_decl_location = location;
+    m_type = type;
+    m_size = size;
+    m_address_valid = false;
+    m_is_label = false;
+    m_is_shared = false;
+    m_is_const = false;
+    m_is_global = false;
+    m_is_local = false;
+    m_is_param_local = false;
+    m_is_param_kernel = false;
+    m_is_tex = false;
+    m_is_func_addr = false;
+    m_reg_num_valid = false;
+    m_function = NULL;
+    m_reg_num = (unsigned)-1;
+    m_arch_reg_num = (unsigned)-1;
+    m_address = (unsigned)-1;
+    m_initializer.clear();
+    if (type) m_is_shared = type->get_key().is_shared();
+    if (type) m_is_const = type->get_key().is_const();
+    if (type) m_is_global = type->get_key().is_global();
+    if (type) m_is_local = type->get_key().is_local();
+    if (type) m_is_param_local = type->get_key().is_param_local();
+    if (type) m_is_param_kernel = type->get_key().is_param_kernel();
+    if (type) m_is_tex = type->get_key().is_tex();
+    if (type) m_is_func_addr = type->get_key().is_func_addr();
+  }
+  unsigned get_size_in_bytes() const { return m_size; }
+  const std::string &name() const { return m_name; }
+  const std::string &decl_location() const { return m_decl_location; }
+  const type_info *type() const { return m_type; }
+  addr_t get_address() const {
+    assert(m_is_label ||
+           !m_type->get_key().is_reg());  // todo : other assertions
+    assert(m_address_valid);
+    return m_address;
+  }
+  function_info *get_pc() const { return m_function; }
+  void set_regno(unsigned regno, unsigned arch_regno) {
+    m_reg_num_valid = true;
+    m_reg_num = regno;
+    m_arch_reg_num = arch_regno;
+  }
 
-   void set_address( addr_t addr )
-   {
-      m_address_valid = true;
-      m_address = addr;
-   }
-   void set_label_address( addr_t addr)
-   {
-      m_address_valid = true;
-      m_address = addr;
-      m_is_label = true;
-   }
-   void set_function( function_info *func )
-   {
-      m_function = func;
-      m_is_func_addr = true; 
-   }
+  void set_address(addr_t addr) {
+    m_address_valid = true;
+    m_address = addr;
+  }
+  void set_label_address(addr_t addr) {
+    m_address_valid = true;
+    m_address = addr;
+    m_is_label = true;
+  }
+  void set_function(function_info *func) {
+    m_function = func;
+    m_is_func_addr = true;
+  }
 
-   bool is_label() const { return m_is_label;}
-   bool is_shared() const { return m_is_shared;}
-   bool is_sstarr() const { return m_is_sstarr;}
-   bool is_const() const { return m_is_const;}
-   bool is_global() const { return m_is_global;}
-   bool is_local() const { return m_is_local;}
-   bool is_param_local() const { return m_is_param_local; }
-   bool is_param_kernel() const { return m_is_param_kernel; }
-   bool is_tex() const { return m_is_tex;}
-   bool is_func_addr() const { return m_is_func_addr; }
-   bool is_reg() const
-   {
-       if ( m_type == NULL ) {
-           return false;
-       }
-      return m_type->get_key().is_reg(); 
-   }
-   bool is_non_arch_reg() const
-   {
-       if ( m_type == NULL ) {
-           return false;
-       }
-      return m_type->get_key().is_non_arch_reg(); 
-   }
+  bool is_label() const { return m_is_label; }
+  bool is_shared() const { return m_is_shared; }
+  bool is_sstarr() const { return m_is_sstarr; }
+  bool is_const() const { return m_is_const; }
+  bool is_global() const { return m_is_global; }
+  bool is_local() const { return m_is_local; }
+  bool is_param_local() const { return m_is_param_local; }
+  bool is_param_kernel() const { return m_is_param_kernel; }
+  bool is_tex() const { return m_is_tex; }
+  bool is_func_addr() const { return m_is_func_addr; }
+  bool is_reg() const {
+    if (m_type == NULL) {
+      return false;
+    }
+    return m_type->get_key().is_reg();
+  }
+  bool is_non_arch_reg() const {
+    if (m_type == NULL) {
+      return false;
+    }
+    return m_type->get_key().is_non_arch_reg();
+  }
 
-   void add_initializer( const std::list<operand_info> &init );
-   bool has_initializer() const 
-   {
-      return m_initializer.size() > 0; 
-   }
-   std::list<operand_info> get_initializer() const
-   {
-      return m_initializer;
-   }
-   unsigned reg_num() const
-   {
-      assert( m_reg_num_valid );
-      return m_reg_num; 
-   }
-   unsigned arch_reg_num() const
-   {
-      assert( m_reg_num_valid );
-      return m_arch_reg_num; 
-   }
-   void print_info(FILE *fp) const;
-   unsigned uid() const { return m_uid; }
+  void add_initializer(const std::list<operand_info> &init);
+  bool has_initializer() const { return m_initializer.size() > 0; }
+  std::list<operand_info> get_initializer() const { return m_initializer; }
+  unsigned reg_num() const {
+    assert(m_reg_num_valid);
+    return m_reg_num;
+  }
+  unsigned arch_reg_num() const {
+    assert(m_reg_num_valid);
+    return m_arch_reg_num;
+  }
+  void print_info(FILE *fp) const;
+  unsigned uid() const { return m_uid; }
 
-private:
-   gpgpu_context* gpgpu_ctx;
-   unsigned get_uid();
-   unsigned m_uid;
-   const type_info *m_type;
-   unsigned m_size; // in bytes
-   std::string m_name;
-   std::string m_decl_location;
+ private:
+  gpgpu_context *gpgpu_ctx;
+  unsigned get_uid();
+  unsigned m_uid;
+  const type_info *m_type;
+  unsigned m_size;  // in bytes
+  std::string m_name;
+  std::string m_decl_location;
 
-   unsigned m_address;
-   function_info *m_function; // used for function symbols
+  unsigned m_address;
+  function_info *m_function;  // used for function symbols
 
-   bool m_address_valid;
-   bool m_is_label;
-   bool m_is_shared;
-   bool m_is_sstarr;
-   bool m_is_const;
-   bool m_is_global;
-   bool m_is_local;
-   bool m_is_param_local;
-   bool m_is_param_kernel;
-   bool m_is_tex;
-   bool m_is_func_addr;
-   unsigned m_reg_num; 
-   unsigned m_arch_reg_num; 
-   bool m_reg_num_valid; 
+  bool m_address_valid;
+  bool m_is_label;
+  bool m_is_shared;
+  bool m_is_sstarr;
+  bool m_is_const;
+  bool m_is_global;
+  bool m_is_local;
+  bool m_is_param_local;
+  bool m_is_param_kernel;
+  bool m_is_tex;
+  bool m_is_func_addr;
+  unsigned m_reg_num;
+  unsigned m_arch_reg_num;
+  bool m_reg_num_valid;
 
-   std::list<operand_info> m_initializer;
+  std::list<operand_info> m_initializer;
 };
 
 class symbol_table {
-public:
-   symbol_table();
-   symbol_table( const char *scope_name, unsigned entry_point, symbol_table *parent, gpgpu_context* ctx);
-   void set_name( const char *name );
-   const ptx_version &get_ptx_version() const;
-   unsigned get_sm_target() const;
-   void set_ptx_version( float ver, unsigned ext );
-   void set_sm_target( const char *target, const char *ext, const char *ext2 );
-   symbol* lookup( const char *identifier );
-   std::string get_scope_name() const { return m_scope_name; }
-   symbol *add_variable( const char *identifier, const type_info *type, unsigned size, const char *filename, unsigned line );
-   void add_function( function_info *func, const char *filename, unsigned linenumber );
-   bool add_function_decl( const char *name, int entry_point, function_info **func_info, symbol_table **symbol_table );
-   function_info *lookup_function(std::string name);
-   type_info *add_type( memory_space_t space_spec, int scalar_type_spec, int vector_spec, int alignment_spec, int extern_spec );
-   type_info *add_type( function_info *func );
-   type_info *get_array_type( type_info *base_type, unsigned array_dim ); 
-   void set_label_address( const symbol *label, unsigned addr );
-   unsigned next_reg_num() { return ++m_reg_allocator;}
-   addr_t get_shared_next() { return m_shared_next;}
-   addr_t get_sstarr_next() { return m_sstarr_next;}
-   addr_t get_global_next() { return m_global_next;}
-   addr_t get_local_next() { return m_local_next;}
-   addr_t get_tex_next() { return m_tex_next;}
-   void  alloc_shared( unsigned num_bytes ) { m_shared_next += num_bytes;}
-   void  alloc_sstarr( unsigned num_bytes ) { m_sstarr_next += num_bytes;}
-   void  alloc_global( unsigned num_bytes ) { m_global_next += num_bytes;}
-   void  alloc_local( unsigned num_bytes ) { m_local_next += num_bytes;}
-   void  alloc_tex( unsigned num_bytes ) { m_tex_next += num_bytes;}
+ public:
+  symbol_table();
+  symbol_table(const char *scope_name, unsigned entry_point,
+               symbol_table *parent, gpgpu_context *ctx);
+  void set_name(const char *name);
+  const ptx_version &get_ptx_version() const;
+  unsigned get_sm_target() const;
+  void set_ptx_version(float ver, unsigned ext);
+  void set_sm_target(const char *target, const char *ext, const char *ext2);
+  symbol *lookup(const char *identifier);
+  std::string get_scope_name() const { return m_scope_name; }
+  symbol *add_variable(const char *identifier, const type_info *type,
+                       unsigned size, const char *filename, unsigned line);
+  void add_function(function_info *func, const char *filename,
+                    unsigned linenumber);
+  bool add_function_decl(const char *name, int entry_point,
+                         function_info **func_info,
+                         symbol_table **symbol_table);
+  function_info *lookup_function(std::string name);
+  type_info *add_type(memory_space_t space_spec, int scalar_type_spec,
+                      int vector_spec, int alignment_spec, int extern_spec);
+  type_info *add_type(function_info *func);
+  type_info *get_array_type(type_info *base_type, unsigned array_dim);
+  void set_label_address(const symbol *label, unsigned addr);
+  unsigned next_reg_num() { return ++m_reg_allocator; }
+  addr_t get_shared_next() { return m_shared_next; }
+  addr_t get_sstarr_next() { return m_sstarr_next; }
+  addr_t get_global_next() { return m_global_next; }
+  addr_t get_local_next() { return m_local_next; }
+  addr_t get_tex_next() { return m_tex_next; }
+  void alloc_shared(unsigned num_bytes) { m_shared_next += num_bytes; }
+  void alloc_sstarr(unsigned num_bytes) { m_sstarr_next += num_bytes; }
+  void alloc_global(unsigned num_bytes) { m_global_next += num_bytes; }
+  void alloc_local(unsigned num_bytes) { m_local_next += num_bytes; }
+  void alloc_tex(unsigned num_bytes) { m_tex_next += num_bytes; }
 
-   typedef std::list<symbol*>::iterator iterator;
+  typedef std::list<symbol *>::iterator iterator;
 
-   iterator global_iterator_begin() { return m_globals.begin();}
-   iterator global_iterator_end() { return m_globals.end();}
+  iterator global_iterator_begin() { return m_globals.begin(); }
+  iterator global_iterator_end() { return m_globals.end(); }
 
-   iterator const_iterator_begin() { return m_consts.begin();}
-   iterator const_iterator_end() { return m_consts.end();}
+  iterator const_iterator_begin() { return m_consts.begin(); }
+  iterator const_iterator_end() { return m_consts.end(); }
 
-   void dump();
-   
-   //Jin: handle instruction group for cdp
-   symbol_table* start_inst_group();
-   symbol_table* end_inst_group();
+  void dump();
 
-   // backward pointer
-   class gpgpu_context* gpgpu_ctx;
+  // Jin: handle instruction group for cdp
+  symbol_table *start_inst_group();
+  symbol_table *end_inst_group();
 
-private:
-   unsigned m_reg_allocator;
-   unsigned m_shared_next;
-   unsigned m_sstarr_next;
-   unsigned m_const_next;
-   unsigned m_global_next;
-   unsigned m_local_next;
-   unsigned m_tex_next;
+  // backward pointer
+  class gpgpu_context *gpgpu_ctx;
 
-   symbol_table *m_parent;
-   ptx_version m_ptx_version;
-   std::string m_scope_name;
-   std::map<std::string, symbol *> m_symbols; //map from name of register to pointers to the registers
-   std::map<type_info_key,type_info*,type_info_key_compare>  m_types;
-   std::list<symbol*> m_globals;
-   std::list<symbol*> m_consts;
-   std::map<std::string,function_info*> m_function_info_lookup;
-   std::map<std::string,symbol_table*> m_function_symtab_lookup;
-   
-   //Jin: handle instruction group for cdp
-   unsigned m_inst_group_id;
-   std::map<std::string,symbol_table*> m_inst_group_symtab;
+ private:
+  unsigned m_reg_allocator;
+  unsigned m_shared_next;
+  unsigned m_sstarr_next;
+  unsigned m_const_next;
+  unsigned m_global_next;
+  unsigned m_local_next;
+  unsigned m_tex_next;
+
+  symbol_table *m_parent;
+  ptx_version m_ptx_version;
+  std::string m_scope_name;
+  std::map<std::string, symbol *>
+      m_symbols;  // map from name of register to pointers to the registers
+  std::map<type_info_key, type_info *, type_info_key_compare> m_types;
+  std::list<symbol *> m_globals;
+  std::list<symbol *> m_consts;
+  std::map<std::string, function_info *> m_function_info_lookup;
+  std::map<std::string, symbol_table *> m_function_symtab_lookup;
+
+  // Jin: handle instruction group for cdp
+  unsigned m_inst_group_id;
+  std::map<std::string, symbol_table *> m_inst_group_symtab;
 };
 
 class operand_info {
-public:
-   operand_info(gpgpu_context* ctx)
-   {
-      init(ctx);
-      m_is_non_arch_reg = false;
-      m_addr_space = undefined_space;
-      m_operand_lohi = 0;
-      m_double_operand_type = 0;
-      m_operand_neg = false;
-      m_const_mem_offset = 0;
-      m_uid = get_uid();
-      m_valid = false;
-      m_immediate_address=false;
-      m_addr_offset = 0;
-      m_value.m_symbolic=NULL;
-   }
-   operand_info( const symbol *addr, gpgpu_context* ctx )
-   {
-      init(ctx);
-      m_is_non_arch_reg = false;
-      m_addr_space = undefined_space;
-      m_operand_lohi = 0;
-      m_double_operand_type = 0;
-      m_operand_neg = false;
-      m_const_mem_offset = 0;
-      m_uid = get_uid();
-      m_valid = true;
-      if ( addr->is_label() ) {
-         m_type = label_t;
-      } else if ( addr->is_shared() ) {
-         m_type = symbolic_t;
-      } else if ( addr->is_const() ) {
-         m_type = symbolic_t;
-      } else if ( addr->is_global() ) {
-         m_type = symbolic_t;
-      } else if ( addr->is_local() ) {
-         m_type = symbolic_t;
-      } else if ( addr->is_param_local() ) {
-         m_type = symbolic_t;
-      } else if ( addr->is_param_kernel() ) {
-         m_type = symbolic_t;
-      } else if ( addr->is_tex() ) {
-         m_type = symbolic_t;
-      } else if ( addr->is_func_addr() ) {
-         m_type = symbolic_t;
-      } else if ( !addr->is_reg() ) {
-         m_type = symbolic_t;
-      } else {
-         m_type = reg_t;
-      }
-      
-      m_is_non_arch_reg = addr->is_non_arch_reg();
-      m_value.m_symbolic = addr;
-      m_addr_offset = 0;
-      m_vector = false;
-      m_neg_pred = false;
-      m_is_return_var = false;
-      m_immediate_address=false;
-   }
-   operand_info( const symbol *addr1, const symbol *addr2, gpgpu_context* ctx )
-   {
-      init(ctx);
-      m_is_non_arch_reg = false;
-      m_addr_space = undefined_space;
-      m_operand_lohi = 0;
-      m_double_operand_type = 0;
-      m_operand_neg = false;
-      m_const_mem_offset = 0;
-      m_uid = get_uid();
-      m_valid = true;
-      m_type = memory_t;
-      m_value.m_vector_symbolic = new const symbol*[8];
-      m_value.m_vector_symbolic[0] = addr1;
-      m_value.m_vector_symbolic[1] = addr2;
-      m_value.m_vector_symbolic[2] = NULL;
-      m_value.m_vector_symbolic[3] = NULL;
-      m_value.m_vector_symbolic[4] = NULL;
-      m_value.m_vector_symbolic[5] = NULL;
-      m_value.m_vector_symbolic[6] = NULL;
-      m_value.m_vector_symbolic[7] = NULL;
-      m_addr_offset = 0;
-      m_vector = false;
-      m_neg_pred = false;
-      m_is_return_var = false;
-      m_immediate_address=false;
-   }
-   operand_info( int builtin_id, int dim_mod, gpgpu_context* ctx )
-   {
-      init(ctx);
-      m_is_non_arch_reg = false;
-      m_addr_space = undefined_space;
-      m_operand_lohi = 0;
-      m_double_operand_type = 0;
-      m_operand_neg = false;
-      m_const_mem_offset = 0;
-      m_uid = get_uid();
-      m_valid = true;
-      m_vector = false;
-      m_type = builtin_t;
-      m_value.m_int = builtin_id;
-      m_addr_offset = dim_mod;
-      m_neg_pred = false;
-      m_is_return_var = false;
-      m_immediate_address=false;
-   }
-   operand_info( const symbol *addr, int offset, gpgpu_context* ctx )
-   {
-      init(ctx);
-      m_is_non_arch_reg = false;
-      m_addr_space = undefined_space;
-      m_operand_lohi = 0;
-      m_double_operand_type = 0;
-      m_operand_neg = false;
-      m_const_mem_offset = 0;
-      m_uid = get_uid();
-      m_valid = true;
-      m_vector = false;
-      m_type = address_t;
-      m_value.m_symbolic = addr;
-      m_addr_offset = offset;
-      m_neg_pred = false;
-      m_is_return_var = false;
-      m_immediate_address=false;
-   }
-   operand_info( unsigned x, gpgpu_context* ctx )
-   {
-      init(ctx);
-      m_is_non_arch_reg = false;
-      m_addr_space = undefined_space;
-      m_operand_lohi = 0;
-      m_double_operand_type = 0;
-      m_operand_neg = false;
-      m_const_mem_offset = 0;
-      m_uid = get_uid();
-      m_valid = true;
-      m_vector = false;
-      m_type = unsigned_t;
-      m_value.m_unsigned = x;
-      m_addr_offset = x;
-      m_neg_pred = false;
-      m_is_return_var = false;
-      m_immediate_address=true;
-   }
-   operand_info( int x, gpgpu_context* ctx )
-   {
-      init(ctx);
-      m_is_non_arch_reg = false;
-      m_addr_space = undefined_space;
-      m_operand_lohi = 0;
-      m_double_operand_type = 0;
-      m_operand_neg = false;
-      m_const_mem_offset = 0;
-      m_uid = get_uid();
-      m_valid = true;
-      m_vector = false;
-      m_type = int_t;
-      m_value.m_int = x;
-      m_addr_offset = 0;
-      m_neg_pred = false;
-      m_is_return_var = false;
-      m_immediate_address=false;
-   }
-   operand_info( float x, gpgpu_context* ctx )
-   {
-      init(ctx);
-      m_is_non_arch_reg = false;
-      m_addr_space = undefined_space;
-      m_operand_lohi = 0;
-      m_double_operand_type = 0;
-      m_operand_neg = false;
-      m_const_mem_offset = 0;
-      m_uid = get_uid();
-      m_valid = true;
-      m_vector = false;
-      m_type = float_op_t;
-      m_value.m_float = x;
-      m_addr_offset = 0;
-      m_neg_pred = false;
-      m_is_return_var = false;
-      m_immediate_address=false;
-   }
-   operand_info( double x, gpgpu_context* ctx )
-   {
-      init(ctx);
-      m_is_non_arch_reg = false;
-      m_addr_space = undefined_space;
-      m_operand_lohi = 0;
-      m_double_operand_type = 0;
-      m_operand_neg = false;
-      m_const_mem_offset = 0;
-      m_uid = get_uid();
-      m_valid = true;
-      m_vector = false;
-      m_type = double_op_t;
-      m_value.m_double = x;
-      m_addr_offset = 0;
-      m_neg_pred = false;
-      m_is_return_var = false;
-      m_immediate_address=false;
-   }
-   operand_info( const symbol *s1, const symbol *s2, const symbol *s3, const symbol *s4, gpgpu_context* ctx )
-   {
-      init(ctx);
-      m_is_non_arch_reg = false;
-      m_addr_space = undefined_space;
-      m_operand_lohi = 0;
-      m_double_operand_type = 0;
-      m_operand_neg = false;
-      m_const_mem_offset = 0;
-      m_uid = get_uid();
-      m_valid = true;
-      m_vector = true;
-      m_type = vector_t;
-      m_value.m_vector_symbolic = new const symbol*[8];
-      m_value.m_vector_symbolic[0] = s1;
-      m_value.m_vector_symbolic[1] = s2;
-      m_value.m_vector_symbolic[2] = s3;
-      m_value.m_vector_symbolic[3] = s4;
-      m_value.m_vector_symbolic[4] = NULL;
-      m_value.m_vector_symbolic[5] = NULL;
-      m_value.m_vector_symbolic[6] = NULL;
-      m_value.m_vector_symbolic[7] = NULL;
-      m_addr_offset = 0;
-      m_neg_pred = false;
-      m_is_return_var = false;
-      m_immediate_address=false;
-   }
-   operand_info( const symbol *s1, const symbol *s2, const symbol *s3, const symbol *s4 ,const symbol *s5,const symbol *s6,const symbol *s7, const symbol *s8, gpgpu_context* ctx)
-   {
-      init(ctx);
-      m_is_non_arch_reg = false;
-      m_addr_space = undefined_space;
-      m_operand_lohi = 0;
-      m_double_operand_type = 0;
-      m_operand_neg = false;
-      m_const_mem_offset = 0;
-      m_uid = get_uid();
-      m_valid = true;
-      m_vector = true;
-      m_type = vector_t;
-      m_value.m_vector_symbolic = new const symbol*[8];
-      m_value.m_vector_symbolic[0] = s1;
-      m_value.m_vector_symbolic[1] = s2;
-      m_value.m_vector_symbolic[2] = s3;
-      m_value.m_vector_symbolic[3] = s4;
-      m_value.m_vector_symbolic[4] = s5;
-      m_value.m_vector_symbolic[5] = s6;
-      m_value.m_vector_symbolic[6] = s7;
-      m_value.m_vector_symbolic[7] = s8;
-      m_addr_offset = 0;
-      m_neg_pred = false;
-      m_is_return_var = false;
-      m_immediate_address=false;
-   }
+ public:
+  operand_info(gpgpu_context *ctx) {
+    init(ctx);
+    m_is_non_arch_reg = false;
+    m_addr_space = undefined_space;
+    m_operand_lohi = 0;
+    m_double_operand_type = 0;
+    m_operand_neg = false;
+    m_const_mem_offset = 0;
+    m_uid = get_uid();
+    m_valid = false;
+    m_immediate_address = false;
+    m_addr_offset = 0;
+    m_value.m_symbolic = NULL;
+  }
+  operand_info(const symbol *addr, gpgpu_context *ctx) {
+    init(ctx);
+    m_is_non_arch_reg = false;
+    m_addr_space = undefined_space;
+    m_operand_lohi = 0;
+    m_double_operand_type = 0;
+    m_operand_neg = false;
+    m_const_mem_offset = 0;
+    m_uid = get_uid();
+    m_valid = true;
+    if (addr->is_label()) {
+      m_type = label_t;
+    } else if (addr->is_shared()) {
+      m_type = symbolic_t;
+    } else if (addr->is_const()) {
+      m_type = symbolic_t;
+    } else if (addr->is_global()) {
+      m_type = symbolic_t;
+    } else if (addr->is_local()) {
+      m_type = symbolic_t;
+    } else if (addr->is_param_local()) {
+      m_type = symbolic_t;
+    } else if (addr->is_param_kernel()) {
+      m_type = symbolic_t;
+    } else if (addr->is_tex()) {
+      m_type = symbolic_t;
+    } else if (addr->is_func_addr()) {
+      m_type = symbolic_t;
+    } else if (!addr->is_reg()) {
+      m_type = symbolic_t;
+    } else {
+      m_type = reg_t;
+    }
 
-   void init(gpgpu_context* ctx)
-   {
-       gpgpu_ctx = ctx;
-       m_uid=(unsigned)-1;
-       m_valid=false;
-       m_vector=false;
-       m_type=undef_t;
-       m_immediate_address=false;
-       m_addr_space=undefined_space;
-       m_operand_lohi=0;
-       m_double_operand_type=0;
-       m_operand_neg=false;
-       m_const_mem_offset=(unsigned)-1;
-       m_value.m_int=0;
-       m_value.m_unsigned=(unsigned)-1;
-       m_value.m_float=0;
-       m_value.m_double=0;
-       for(unsigned i=0; i<4; i++){
-           m_value.m_vint[i]=0;
-           m_value.m_vunsigned[i]=0;
-           m_value.m_vfloat[i]=0;
-           m_value.m_vdouble[i]=0;
-       }
-       m_value.m_symbolic=NULL;
-       m_value.m_vector_symbolic=NULL;
-       m_addr_offset=0;
-       m_neg_pred=0;
-       m_is_return_var=0;
-       m_is_non_arch_reg=0;
+    m_is_non_arch_reg = addr->is_non_arch_reg();
+    m_value.m_symbolic = addr;
+    m_addr_offset = 0;
+    m_vector = false;
+    m_neg_pred = false;
+    m_is_return_var = false;
+    m_immediate_address = false;
+  }
+  operand_info(const symbol *addr1, const symbol *addr2, gpgpu_context *ctx) {
+    init(ctx);
+    m_is_non_arch_reg = false;
+    m_addr_space = undefined_space;
+    m_operand_lohi = 0;
+    m_double_operand_type = 0;
+    m_operand_neg = false;
+    m_const_mem_offset = 0;
+    m_uid = get_uid();
+    m_valid = true;
+    m_type = memory_t;
+    m_value.m_vector_symbolic = new const symbol *[8];
+    m_value.m_vector_symbolic[0] = addr1;
+    m_value.m_vector_symbolic[1] = addr2;
+    m_value.m_vector_symbolic[2] = NULL;
+    m_value.m_vector_symbolic[3] = NULL;
+    m_value.m_vector_symbolic[4] = NULL;
+    m_value.m_vector_symbolic[5] = NULL;
+    m_value.m_vector_symbolic[6] = NULL;
+    m_value.m_vector_symbolic[7] = NULL;
+    m_addr_offset = 0;
+    m_vector = false;
+    m_neg_pred = false;
+    m_is_return_var = false;
+    m_immediate_address = false;
+  }
+  operand_info(int builtin_id, int dim_mod, gpgpu_context *ctx) {
+    init(ctx);
+    m_is_non_arch_reg = false;
+    m_addr_space = undefined_space;
+    m_operand_lohi = 0;
+    m_double_operand_type = 0;
+    m_operand_neg = false;
+    m_const_mem_offset = 0;
+    m_uid = get_uid();
+    m_valid = true;
+    m_vector = false;
+    m_type = builtin_t;
+    m_value.m_int = builtin_id;
+    m_addr_offset = dim_mod;
+    m_neg_pred = false;
+    m_is_return_var = false;
+    m_immediate_address = false;
+  }
+  operand_info(const symbol *addr, int offset, gpgpu_context *ctx) {
+    init(ctx);
+    m_is_non_arch_reg = false;
+    m_addr_space = undefined_space;
+    m_operand_lohi = 0;
+    m_double_operand_type = 0;
+    m_operand_neg = false;
+    m_const_mem_offset = 0;
+    m_uid = get_uid();
+    m_valid = true;
+    m_vector = false;
+    m_type = address_t;
+    m_value.m_symbolic = addr;
+    m_addr_offset = offset;
+    m_neg_pred = false;
+    m_is_return_var = false;
+    m_immediate_address = false;
+  }
+  operand_info(unsigned x, gpgpu_context *ctx) {
+    init(ctx);
+    m_is_non_arch_reg = false;
+    m_addr_space = undefined_space;
+    m_operand_lohi = 0;
+    m_double_operand_type = 0;
+    m_operand_neg = false;
+    m_const_mem_offset = 0;
+    m_uid = get_uid();
+    m_valid = true;
+    m_vector = false;
+    m_type = unsigned_t;
+    m_value.m_unsigned = x;
+    m_addr_offset = x;
+    m_neg_pred = false;
+    m_is_return_var = false;
+    m_immediate_address = true;
+  }
+  operand_info(int x, gpgpu_context *ctx) {
+    init(ctx);
+    m_is_non_arch_reg = false;
+    m_addr_space = undefined_space;
+    m_operand_lohi = 0;
+    m_double_operand_type = 0;
+    m_operand_neg = false;
+    m_const_mem_offset = 0;
+    m_uid = get_uid();
+    m_valid = true;
+    m_vector = false;
+    m_type = int_t;
+    m_value.m_int = x;
+    m_addr_offset = 0;
+    m_neg_pred = false;
+    m_is_return_var = false;
+    m_immediate_address = false;
+  }
+  operand_info(float x, gpgpu_context *ctx) {
+    init(ctx);
+    m_is_non_arch_reg = false;
+    m_addr_space = undefined_space;
+    m_operand_lohi = 0;
+    m_double_operand_type = 0;
+    m_operand_neg = false;
+    m_const_mem_offset = 0;
+    m_uid = get_uid();
+    m_valid = true;
+    m_vector = false;
+    m_type = float_op_t;
+    m_value.m_float = x;
+    m_addr_offset = 0;
+    m_neg_pred = false;
+    m_is_return_var = false;
+    m_immediate_address = false;
+  }
+  operand_info(double x, gpgpu_context *ctx) {
+    init(ctx);
+    m_is_non_arch_reg = false;
+    m_addr_space = undefined_space;
+    m_operand_lohi = 0;
+    m_double_operand_type = 0;
+    m_operand_neg = false;
+    m_const_mem_offset = 0;
+    m_uid = get_uid();
+    m_valid = true;
+    m_vector = false;
+    m_type = double_op_t;
+    m_value.m_double = x;
+    m_addr_offset = 0;
+    m_neg_pred = false;
+    m_is_return_var = false;
+    m_immediate_address = false;
+  }
+  operand_info(const symbol *s1, const symbol *s2, const symbol *s3,
+               const symbol *s4, gpgpu_context *ctx) {
+    init(ctx);
+    m_is_non_arch_reg = false;
+    m_addr_space = undefined_space;
+    m_operand_lohi = 0;
+    m_double_operand_type = 0;
+    m_operand_neg = false;
+    m_const_mem_offset = 0;
+    m_uid = get_uid();
+    m_valid = true;
+    m_vector = true;
+    m_type = vector_t;
+    m_value.m_vector_symbolic = new const symbol *[8];
+    m_value.m_vector_symbolic[0] = s1;
+    m_value.m_vector_symbolic[1] = s2;
+    m_value.m_vector_symbolic[2] = s3;
+    m_value.m_vector_symbolic[3] = s4;
+    m_value.m_vector_symbolic[4] = NULL;
+    m_value.m_vector_symbolic[5] = NULL;
+    m_value.m_vector_symbolic[6] = NULL;
+    m_value.m_vector_symbolic[7] = NULL;
+    m_addr_offset = 0;
+    m_neg_pred = false;
+    m_is_return_var = false;
+    m_immediate_address = false;
+  }
+  operand_info(const symbol *s1, const symbol *s2, const symbol *s3,
+               const symbol *s4, const symbol *s5, const symbol *s6,
+               const symbol *s7, const symbol *s8, gpgpu_context *ctx) {
+    init(ctx);
+    m_is_non_arch_reg = false;
+    m_addr_space = undefined_space;
+    m_operand_lohi = 0;
+    m_double_operand_type = 0;
+    m_operand_neg = false;
+    m_const_mem_offset = 0;
+    m_uid = get_uid();
+    m_valid = true;
+    m_vector = true;
+    m_type = vector_t;
+    m_value.m_vector_symbolic = new const symbol *[8];
+    m_value.m_vector_symbolic[0] = s1;
+    m_value.m_vector_symbolic[1] = s2;
+    m_value.m_vector_symbolic[2] = s3;
+    m_value.m_vector_symbolic[3] = s4;
+    m_value.m_vector_symbolic[4] = s5;
+    m_value.m_vector_symbolic[5] = s6;
+    m_value.m_vector_symbolic[6] = s7;
+    m_value.m_vector_symbolic[7] = s8;
+    m_addr_offset = 0;
+    m_neg_pred = false;
+    m_is_return_var = false;
+    m_immediate_address = false;
+  }
 
-   }
-   void make_memory_operand() { m_type = memory_t;}
-   void set_return() { m_is_return_var = true; }
-   void set_immediate_addr() {m_immediate_address=true;}
-   const std::string &name() const
-   {
-      assert( m_type == symbolic_t || m_type == reg_t || m_type == address_t || m_type == memory_t || m_type == label_t);
-      return m_value.m_symbolic->name();
-   }
+  void init(gpgpu_context *ctx) {
+    gpgpu_ctx = ctx;
+    m_uid = (unsigned)-1;
+    m_valid = false;
+    m_vector = false;
+    m_type = undef_t;
+    m_immediate_address = false;
+    m_addr_space = undefined_space;
+    m_operand_lohi = 0;
+    m_double_operand_type = 0;
+    m_operand_neg = false;
+    m_const_mem_offset = (unsigned)-1;
+    m_value.m_int = 0;
+    m_value.m_unsigned = (unsigned)-1;
+    m_value.m_float = 0;
+    m_value.m_double = 0;
+    for (unsigned i = 0; i < 4; i++) {
+      m_value.m_vint[i] = 0;
+      m_value.m_vunsigned[i] = 0;
+      m_value.m_vfloat[i] = 0;
+      m_value.m_vdouble[i] = 0;
+    }
+    m_value.m_symbolic = NULL;
+    m_value.m_vector_symbolic = NULL;
+    m_addr_offset = 0;
+    m_neg_pred = 0;
+    m_is_return_var = 0;
+    m_is_non_arch_reg = 0;
+  }
+  void make_memory_operand() { m_type = memory_t; }
+  void set_return() { m_is_return_var = true; }
+  void set_immediate_addr() { m_immediate_address = true; }
+  const std::string &name() const {
+    assert(m_type == symbolic_t || m_type == reg_t || m_type == address_t ||
+           m_type == memory_t || m_type == label_t);
+    return m_value.m_symbolic->name();
+  }
 
-   unsigned get_vect_nelem() const
-   {
-      assert( is_vector() );
-      if( !m_value.m_vector_symbolic[0] ) return 0;
-      if( !m_value.m_vector_symbolic[1] ) return 1;
-      if( !m_value.m_vector_symbolic[2] ) return 2;
-      if( !m_value.m_vector_symbolic[3] ) return 3;
-      if( !m_value.m_vector_symbolic[4] ) return 4;
-      if( !m_value.m_vector_symbolic[5] ) return 5;
-      if( !m_value.m_vector_symbolic[6] ) return 6;
-      if( !m_value.m_vector_symbolic[7] ) return 7;
-      return 8;
-   }
+  unsigned get_vect_nelem() const {
+    assert(is_vector());
+    if (!m_value.m_vector_symbolic[0]) return 0;
+    if (!m_value.m_vector_symbolic[1]) return 1;
+    if (!m_value.m_vector_symbolic[2]) return 2;
+    if (!m_value.m_vector_symbolic[3]) return 3;
+    if (!m_value.m_vector_symbolic[4]) return 4;
+    if (!m_value.m_vector_symbolic[5]) return 5;
+    if (!m_value.m_vector_symbolic[6]) return 6;
+    if (!m_value.m_vector_symbolic[7]) return 7;
+    return 8;
+  }
 
-   const symbol* vec_symbol(int idx) const 
-   {
-      assert(idx < 8);
-      const symbol *result = m_value.m_vector_symbolic[idx];
-      assert( result != NULL );
-      return result;
-   }
+  const symbol *vec_symbol(int idx) const {
+    assert(idx < 8);
+    const symbol *result = m_value.m_vector_symbolic[idx];
+    assert(result != NULL);
+    return result;
+  }
 
-   const std::string &vec_name1() const
-   {
-      assert( m_type == vector_t);
-      return m_value.m_vector_symbolic[0]->name();
-   }
+  const std::string &vec_name1() const {
+    assert(m_type == vector_t);
+    return m_value.m_vector_symbolic[0]->name();
+  }
 
-   const std::string &vec_name2() const
-   {
-      assert( m_type == vector_t);
-      return m_value.m_vector_symbolic[1]->name();
-   }
+  const std::string &vec_name2() const {
+    assert(m_type == vector_t);
+    return m_value.m_vector_symbolic[1]->name();
+  }
 
-   const std::string &vec_name3() const
-   {
-      assert( m_type == vector_t);
-      return m_value.m_vector_symbolic[2]->name();
-   }
+  const std::string &vec_name3() const {
+    assert(m_type == vector_t);
+    return m_value.m_vector_symbolic[2]->name();
+  }
 
-   const std::string &vec_name4() const
-   {
-      assert( m_type == vector_t);
-      return m_value.m_vector_symbolic[3]->name();
-   }
+  const std::string &vec_name4() const {
+    assert(m_type == vector_t);
+    return m_value.m_vector_symbolic[3]->name();
+  }
 
-   bool is_reg() const
-   {
-      if ( m_type == reg_t ) {
-         return true;
-      }
-      if ( m_type != symbolic_t ) {
-         return false;
-      }
-      return m_value.m_symbolic->type()->get_key().is_reg();
-   }
-   bool is_param_local() const
-   {
-      if ( m_type != symbolic_t ) 
-         return false;
-      return m_value.m_symbolic->type()->get_key().is_param_local();
-   }
-
-   bool is_param_kernel() const
-   {
-      if ( m_type != symbolic_t ) 
-         return false;
-      return m_value.m_symbolic->type()->get_key().is_param_kernel();
-   }
-
-   bool is_vector() const
-   {
-      if ( m_vector) return true;
+  bool is_reg() const {
+    if (m_type == reg_t) {
+      return true;
+    }
+    if (m_type != symbolic_t) {
       return false;
-   }
-   int reg_num() const { return m_value.m_symbolic->reg_num();}
-   int reg1_num() const { return m_value.m_vector_symbolic[0]->reg_num();}
-   int reg2_num() const { return m_value.m_vector_symbolic[1]->reg_num();}
-   int reg3_num() const { return m_value.m_vector_symbolic[2]?m_value.m_vector_symbolic[2]->reg_num():0; }
-   int reg4_num() const { return m_value.m_vector_symbolic[3]?m_value.m_vector_symbolic[3]->reg_num():0; }
-   int reg5_num() const { return m_value.m_vector_symbolic[4]?m_value.m_vector_symbolic[4]->reg_num():0; }
-   int reg6_num() const { return m_value.m_vector_symbolic[5]?m_value.m_vector_symbolic[5]->reg_num():0; }
-   int reg7_num() const { return m_value.m_vector_symbolic[6]?m_value.m_vector_symbolic[6]->reg_num():0; }
-   int reg8_num() const { return m_value.m_vector_symbolic[7]?m_value.m_vector_symbolic[7]->reg_num():0; }
-   int arch_reg_num() const { return m_value.m_symbolic->arch_reg_num(); }
-   int arch_reg_num(unsigned n) const { return (m_value.m_vector_symbolic[n])? m_value.m_vector_symbolic[n]->arch_reg_num() : -1; }
-   bool is_label() const { return m_type == label_t;}
-   bool is_builtin() const { return m_type == builtin_t;}
+    }
+    return m_value.m_symbolic->type()->get_key().is_reg();
+  }
+  bool is_param_local() const {
+    if (m_type != symbolic_t) return false;
+    return m_value.m_symbolic->type()->get_key().is_param_local();
+  }
 
-   // Memory operand used in ld / st instructions (ex. [__var1])
-   bool is_memory_operand() const { return m_type == memory_t;}
+  bool is_param_kernel() const {
+    if (m_type != symbolic_t) return false;
+    return m_value.m_symbolic->type()->get_key().is_param_kernel();
+  }
 
-   // Memory operand with immediate access (ex. s[0x0004] or g[$r1+=0x0004])
-   // This is used by the PTXPlus extension. The operand is assigned an address space during parsing.
-   bool is_memory_operand2() const { 
-      return (m_addr_space!=undefined_space); 
-   }
+  bool is_vector() const {
+    if (m_vector) return true;
+    return false;
+  }
+  int reg_num() const { return m_value.m_symbolic->reg_num(); }
+  int reg1_num() const { return m_value.m_vector_symbolic[0]->reg_num(); }
+  int reg2_num() const { return m_value.m_vector_symbolic[1]->reg_num(); }
+  int reg3_num() const {
+    return m_value.m_vector_symbolic[2]
+               ? m_value.m_vector_symbolic[2]->reg_num()
+               : 0;
+  }
+  int reg4_num() const {
+    return m_value.m_vector_symbolic[3]
+               ? m_value.m_vector_symbolic[3]->reg_num()
+               : 0;
+  }
+  int reg5_num() const {
+    return m_value.m_vector_symbolic[4]
+               ? m_value.m_vector_symbolic[4]->reg_num()
+               : 0;
+  }
+  int reg6_num() const {
+    return m_value.m_vector_symbolic[5]
+               ? m_value.m_vector_symbolic[5]->reg_num()
+               : 0;
+  }
+  int reg7_num() const {
+    return m_value.m_vector_symbolic[6]
+               ? m_value.m_vector_symbolic[6]->reg_num()
+               : 0;
+  }
+  int reg8_num() const {
+    return m_value.m_vector_symbolic[7]
+               ? m_value.m_vector_symbolic[7]->reg_num()
+               : 0;
+  }
+  int arch_reg_num() const { return m_value.m_symbolic->arch_reg_num(); }
+  int arch_reg_num(unsigned n) const {
+    return (m_value.m_vector_symbolic[n])
+               ? m_value.m_vector_symbolic[n]->arch_reg_num()
+               : -1;
+  }
+  bool is_label() const { return m_type == label_t; }
+  bool is_builtin() const { return m_type == builtin_t; }
 
-   bool is_immediate_address() const {
-       return   m_immediate_address;
-   }
+  // Memory operand used in ld / st instructions (ex. [__var1])
+  bool is_memory_operand() const { return m_type == memory_t; }
 
-   bool is_literal() const { return m_type == int_t ||
-      m_type == float_op_t ||
-      m_type == double_op_t ||
-      m_type == unsigned_t;} 
-   bool is_shared() const {
-      if ( !(m_type == symbolic_t || m_type == address_t || m_type == memory_t) ) {
-         return false;
-      }
-      return  m_value.m_symbolic->is_shared();
-   }
-   bool is_sstarr() const { return m_value.m_symbolic->is_sstarr();}
-   bool is_const() const { return m_value.m_symbolic->is_const();}
-   bool is_global() const { return m_value.m_symbolic->is_global();}
-   bool is_local() const { return m_value.m_symbolic->is_local();}
-   bool is_tex() const { return m_value.m_symbolic->is_tex();}
-   bool is_return_var() const { return m_is_return_var; }
+  // Memory operand with immediate access (ex. s[0x0004] or g[$r1+=0x0004])
+  // This is used by the PTXPlus extension. The operand is assigned an address
+  // space during parsing.
+  bool is_memory_operand2() const { return (m_addr_space != undefined_space); }
 
-   bool is_function_address() const
-   {
-      if( m_type != symbolic_t ) {
-         return false;
-      }
-      return m_value.m_symbolic->is_func_addr();
-   }
+  bool is_immediate_address() const { return m_immediate_address; }
 
-   ptx_reg_t get_literal_value() const
-   {
-      ptx_reg_t result;
-      switch ( m_type ) {
-      case int_t:         result.s64 = m_value.m_int; break;
-      case float_op_t:    result.f32 = m_value.m_float; break;
-      case double_op_t:   result.f64 = m_value.m_double; break; 
-      case unsigned_t:    result.u32 = m_value.m_unsigned; break;
+  bool is_literal() const {
+    return m_type == int_t || m_type == float_op_t || m_type == double_op_t ||
+           m_type == unsigned_t;
+  }
+  bool is_shared() const {
+    if (!(m_type == symbolic_t || m_type == address_t || m_type == memory_t)) {
+      return false;
+    }
+    return m_value.m_symbolic->is_shared();
+  }
+  bool is_sstarr() const { return m_value.m_symbolic->is_sstarr(); }
+  bool is_const() const { return m_value.m_symbolic->is_const(); }
+  bool is_global() const { return m_value.m_symbolic->is_global(); }
+  bool is_local() const { return m_value.m_symbolic->is_local(); }
+  bool is_tex() const { return m_value.m_symbolic->is_tex(); }
+  bool is_return_var() const { return m_is_return_var; }
+
+  bool is_function_address() const {
+    if (m_type != symbolic_t) {
+      return false;
+    }
+    return m_value.m_symbolic->is_func_addr();
+  }
+
+  ptx_reg_t get_literal_value() const {
+    ptx_reg_t result;
+    switch (m_type) {
+      case int_t:
+        result.s64 = m_value.m_int;
+        break;
+      case float_op_t:
+        result.f32 = m_value.m_float;
+        break;
+      case double_op_t:
+        result.f64 = m_value.m_double;
+        break;
+      case unsigned_t:
+        result.u32 = m_value.m_unsigned;
+        break;
       default:
-         assert(0);
-         break;
-      } 
-      return result;
-   }
-   int get_int() const { return m_value.m_int;}
-   int get_addr_offset() const { return m_addr_offset;}
-   const symbol *get_symbol() const { return m_value.m_symbolic;}
-   void set_type( enum operand_type type ) 
-   {
-      m_type = type;
-   }
-   enum operand_type get_type() const {
-      return m_type;
-   }
-   void set_neg_pred()
-   {
-      assert( m_valid );
-      m_neg_pred = true;
-   }
-   bool is_neg_pred() const { return m_neg_pred; }
-   bool is_valid() const { return m_valid; }
+        assert(0);
+        break;
+    }
+    return result;
+  }
+  int get_int() const { return m_value.m_int; }
+  int get_addr_offset() const { return m_addr_offset; }
+  const symbol *get_symbol() const { return m_value.m_symbolic; }
+  void set_type(enum operand_type type) { m_type = type; }
+  enum operand_type get_type() const { return m_type; }
+  void set_neg_pred() {
+    assert(m_valid);
+    m_neg_pred = true;
+  }
+  bool is_neg_pred() const { return m_neg_pred; }
+  bool is_valid() const { return m_valid; }
 
-   void set_addr_space(enum _memory_space_t set_value) { m_addr_space = set_value; }
-   enum _memory_space_t get_addr_space() const { return m_addr_space; }
-   void set_operand_lohi(int set_value) { m_operand_lohi = set_value; }
-   int get_operand_lohi() const { return m_operand_lohi; }
-   void set_double_operand_type(int set_value) {  m_double_operand_type = set_value; }
-   int get_double_operand_type() const { return  m_double_operand_type; }
-   void set_operand_neg() { m_operand_neg = true; }
-   bool get_operand_neg() const { return m_operand_neg; }
-   void set_const_mem_offset(addr_t set_value) { m_const_mem_offset = set_value; }
-   addr_t get_const_mem_offset() const { return m_const_mem_offset; }
-   bool is_non_arch_reg() const { return m_is_non_arch_reg; }
+  void set_addr_space(enum _memory_space_t set_value) {
+    m_addr_space = set_value;
+  }
+  enum _memory_space_t get_addr_space() const { return m_addr_space; }
+  void set_operand_lohi(int set_value) { m_operand_lohi = set_value; }
+  int get_operand_lohi() const { return m_operand_lohi; }
+  void set_double_operand_type(int set_value) {
+    m_double_operand_type = set_value;
+  }
+  int get_double_operand_type() const { return m_double_operand_type; }
+  void set_operand_neg() { m_operand_neg = true; }
+  bool get_operand_neg() const { return m_operand_neg; }
+  void set_const_mem_offset(addr_t set_value) {
+    m_const_mem_offset = set_value;
+  }
+  addr_t get_const_mem_offset() const { return m_const_mem_offset; }
+  bool is_non_arch_reg() const { return m_is_non_arch_reg; }
 
-private:
-   gpgpu_context* gpgpu_ctx;
-   unsigned m_uid;
-   bool m_valid;
-   bool m_vector;
-   enum operand_type m_type;
-   bool m_immediate_address;
-   enum _memory_space_t m_addr_space;
-   int m_operand_lohi;
-   int m_double_operand_type;
-   bool m_operand_neg;
-   addr_t m_const_mem_offset;
-   union {
-      int             m_int;
-      unsigned int    m_unsigned;
-      float           m_float;
-      double          m_double;
-      int             m_vint[4];
-      unsigned int    m_vunsigned[4];
-      float           m_vfloat[4];
-      double          m_vdouble[4];
-      const symbol*  m_symbolic;
-      const symbol**  m_vector_symbolic;
-   } m_value;
+ private:
+  gpgpu_context *gpgpu_ctx;
+  unsigned m_uid;
+  bool m_valid;
+  bool m_vector;
+  enum operand_type m_type;
+  bool m_immediate_address;
+  enum _memory_space_t m_addr_space;
+  int m_operand_lohi;
+  int m_double_operand_type;
+  bool m_operand_neg;
+  addr_t m_const_mem_offset;
+  union {
+    int m_int;
+    unsigned int m_unsigned;
+    float m_float;
+    double m_double;
+    int m_vint[4];
+    unsigned int m_vunsigned[4];
+    float m_vfloat[4];
+    double m_vdouble[4];
+    const symbol *m_symbolic;
+    const symbol **m_vector_symbolic;
+  } m_value;
 
-   int m_addr_offset;
+  int m_addr_offset;
 
-   bool m_neg_pred;
-   bool m_is_return_var;
-   bool m_is_non_arch_reg;
+  bool m_neg_pred;
+  bool m_is_return_var;
+  bool m_is_non_arch_reg;
 
-   unsigned get_uid();
+  unsigned get_uid();
 };
 
 extern const char *g_opcode_string[];
 struct basic_block_t {
-   basic_block_t( unsigned ID, ptx_instruction *begin, ptx_instruction *end, bool entry, bool ex)
-   {
-      bb_id = ID;
-      ptx_begin = begin;
-      ptx_end = end;
-      is_entry=entry;
-      is_exit=ex;
-      immediatepostdominator_id = -1;
-      immediatedominator_id = -1;
-   }
+  basic_block_t(unsigned ID, ptx_instruction *begin, ptx_instruction *end,
+                bool entry, bool ex) {
+    bb_id = ID;
+    ptx_begin = begin;
+    ptx_end = end;
+    is_entry = entry;
+    is_exit = ex;
+    immediatepostdominator_id = -1;
+    immediatedominator_id = -1;
+  }
 
-   ptx_instruction* ptx_begin;
-   ptx_instruction* ptx_end;
-   std::set<int> predecessor_ids; //indices of other basic blocks in m_basic_blocks array
-   std::set<int> successor_ids;
-   std::set<int> postdominator_ids;
-   std::set<int> dominator_ids;
-   std::set<int> Tmp_ids;
-   int immediatepostdominator_id;
-   int immediatedominator_id;
-   bool is_entry;
-   bool is_exit;
-   unsigned bb_id;
+  ptx_instruction *ptx_begin;
+  ptx_instruction *ptx_end;
+  std::set<int>
+      predecessor_ids;  // indices of other basic blocks in m_basic_blocks array
+  std::set<int> successor_ids;
+  std::set<int> postdominator_ids;
+  std::set<int> dominator_ids;
+  std::set<int> Tmp_ids;
+  int immediatepostdominator_id;
+  int immediatedominator_id;
+  bool is_entry;
+  bool is_exit;
+  unsigned bb_id;
 
-   // if this basic block dom B
-   bool dom(const basic_block_t *B) {
-      return (B->dominator_ids.find(this->bb_id) != B->dominator_ids.end());
-   }
+  // if this basic block dom B
+  bool dom(const basic_block_t *B) {
+    return (B->dominator_ids.find(this->bb_id) != B->dominator_ids.end());
+  }
 
-   // if this basic block pdom B
-   bool pdom(const basic_block_t *B) {
-      return (B->postdominator_ids.find(this->bb_id) != B->postdominator_ids.end());
-   }
+  // if this basic block pdom B
+  bool pdom(const basic_block_t *B) {
+    return (B->postdominator_ids.find(this->bb_id) !=
+            B->postdominator_ids.end());
+  }
 };
 
 struct gpgpu_recon_t {
-   address_type source_pc;
-   address_type target_pc;
-   class ptx_instruction* source_inst;
-   class ptx_instruction* target_inst;
+  address_type source_pc;
+  address_type target_pc;
+  class ptx_instruction *source_inst;
+  class ptx_instruction *target_inst;
 };
 
 class ptx_instruction : public warp_inst_t {
-public:
-    ptx_instruction( int opcode, 
-                    const symbol *pred, 
-                    int neg_pred, 
-                    int pred_mod,
-                    symbol *label,
-                    const std::list<operand_info> &operands, 
-                    const operand_info &return_var,
-                    const std::list<int> &options, 
-                    const std::list<int> &wmma_options, 
-                    const std::list<int> &scalar_type,
-                    memory_space_t space_spec,
-                    const char *file, 
-                    unsigned line,
-                    const char *source,
-                    const core_config *config,
-		    gpgpu_context* ctx);
+ public:
+  ptx_instruction(int opcode, const symbol *pred, int neg_pred, int pred_mod,
+                  symbol *label, const std::list<operand_info> &operands,
+                  const operand_info &return_var, const std::list<int> &options,
+                  const std::list<int> &wmma_options,
+                  const std::list<int> &scalar_type, memory_space_t space_spec,
+                  const char *file, unsigned line, const char *source,
+                  const core_config *config, gpgpu_context *ctx);
 
-   void print_insn() const;
-   virtual void print_insn( FILE *fp ) const;
-   std::string to_string() const;
-   unsigned inst_size() const { return m_inst_size; }
-   unsigned uid() const { return m_uid;}
-   int get_opcode() const { return m_opcode;}
-   const char *get_opcode_cstr() const 
-   {
-      if ( m_opcode != -1 ) {
-         return g_opcode_string[m_opcode]; 
-      } else {
-         return "label";
-      }
-   }
-   const char *source_file() const { return m_source_file.c_str();} 
-   unsigned source_line() const { return m_source_line;}
-   unsigned get_num_operands() const { return m_operands.size();}
-   bool has_pred() const { return m_pred != NULL;}
-   operand_info get_pred() const;
-   bool get_pred_neg() const { return m_neg_pred;}
-   int get_pred_mod() const { return m_pred_mod;}
-   const char *get_source() const { return m_source.c_str();}
+  void print_insn() const;
+  virtual void print_insn(FILE *fp) const;
+  std::string to_string() const;
+  unsigned inst_size() const { return m_inst_size; }
+  unsigned uid() const { return m_uid; }
+  int get_opcode() const { return m_opcode; }
+  const char *get_opcode_cstr() const {
+    if (m_opcode != -1) {
+      return g_opcode_string[m_opcode];
+    } else {
+      return "label";
+    }
+  }
+  const char *source_file() const { return m_source_file.c_str(); }
+  unsigned source_line() const { return m_source_line; }
+  unsigned get_num_operands() const { return m_operands.size(); }
+  bool has_pred() const { return m_pred != NULL; }
+  operand_info get_pred() const;
+  bool get_pred_neg() const { return m_neg_pred; }
+  int get_pred_mod() const { return m_pred_mod; }
+  const char *get_source() const { return m_source.c_str(); }
 
-   typedef std::vector<operand_info>::const_iterator const_iterator;
+  typedef std::vector<operand_info>::const_iterator const_iterator;
 
-   const_iterator op_iter_begin() const 
-   { 
-      return m_operands.begin();
-   }
+  const_iterator op_iter_begin() const { return m_operands.begin(); }
 
-   const_iterator op_iter_end() const 
-   { 
-      return m_operands.end();
-   }
+  const_iterator op_iter_end() const { return m_operands.end(); }
 
-   const operand_info &dst() const 
-   { 
-      assert( !m_operands.empty() );
+  const operand_info &dst() const {
+    assert(!m_operands.empty());
+    return m_operands[0];
+  }
+
+  const operand_info &func_addr() const {
+    assert(!m_operands.empty());
+    if (!m_operands[0].is_return_var()) {
       return m_operands[0];
-   }
-
-   const operand_info &func_addr() const
-   {
-      assert( !m_operands.empty() );
-      if( !m_operands[0].is_return_var() ) {
-         return m_operands[0];
-      } else {
-         assert( m_operands.size() >= 2 );
-         return m_operands[1];
-      }
-   }
-
-   operand_info &dst() 
-   { 
-      assert( !m_operands.empty() );
-      return m_operands[0];
-   }
-
-   const operand_info &src1() const 
-   { 
-      assert( m_operands.size() > 1 );
+    } else {
+      assert(m_operands.size() >= 2);
       return m_operands[1];
-   }
+    }
+  }
 
-   const operand_info &src2() const 
-   { 
-      assert( m_operands.size() > 2 );
-      return m_operands[2];
-   }
+  operand_info &dst() {
+    assert(!m_operands.empty());
+    return m_operands[0];
+  }
 
-   const operand_info &src3() const 
-   { 
-      assert( m_operands.size() > 3 );
-      return m_operands[3];
-   }
-   const operand_info &src4() const 
-   { 
-      assert( m_operands.size() > 4 );
-      return m_operands[4];
-   }
-   const operand_info &src5() const 
-   { 
-      assert( m_operands.size() > 5 );
-      return m_operands[5];
-   }
-   const operand_info &src6() const 
-   { 
-      assert( m_operands.size() > 6 );
-      return m_operands[6];
-   }
-   const operand_info &src7() const 
-   { 
-      assert( m_operands.size() > 7 );
-      return m_operands[7];
-   }
-   const operand_info &src8() const 
-   { 
-      assert( m_operands.size() > 8 );
-      return m_operands[8];
-   }
+  const operand_info &src1() const {
+    assert(m_operands.size() > 1);
+    return m_operands[1];
+  }
 
-   const operand_info &operand_lookup( unsigned n ) const
-   {
-      assert( n < m_operands.size() );
-      return m_operands[n];
-   }
-   bool has_return() const
-   {
-      return m_return_var.is_valid();
-   }
+  const operand_info &src2() const {
+    assert(m_operands.size() > 2);
+    return m_operands[2];
+  }
 
-   memory_space_t get_space() const { return m_space_spec;}
-   unsigned get_vector() const { return m_vector_spec;}
-   unsigned get_atomic() const { return m_atomic_spec;}
+  const operand_info &src3() const {
+    assert(m_operands.size() > 3);
+    return m_operands[3];
+  }
+  const operand_info &src4() const {
+    assert(m_operands.size() > 4);
+    return m_operands[4];
+  }
+  const operand_info &src5() const {
+    assert(m_operands.size() > 5);
+    return m_operands[5];
+  }
+  const operand_info &src6() const {
+    assert(m_operands.size() > 6);
+    return m_operands[6];
+  }
+  const operand_info &src7() const {
+    assert(m_operands.size() > 7);
+    return m_operands[7];
+  }
+  const operand_info &src8() const {
+    assert(m_operands.size() > 8);
+    return m_operands[8];
+  }
 
-   int get_wmma_type() const {
-      return m_wmma_type;
-   }
-   int get_wmma_layout(int index) const {
-      return m_wmma_layout[index];//0->Matrix D,1->Matrix C
-   }
-   int get_type() const 
-   {
-      assert( !m_scalar_type.empty() );
-      return m_scalar_type.front();
-   }
+  const operand_info &operand_lookup(unsigned n) const {
+    assert(n < m_operands.size());
+    return m_operands[n];
+  }
+  bool has_return() const { return m_return_var.is_valid(); }
 
-   int get_type2() const 
-   {
-      assert( m_scalar_type.size()==2 );
-      return m_scalar_type.back();
-   }
+  memory_space_t get_space() const { return m_space_spec; }
+  unsigned get_vector() const { return m_vector_spec; }
+  unsigned get_atomic() const { return m_atomic_spec; }
 
-   void assign_bb(basic_block_t* basic_block) //assign instruction to a basic block
-   {
-      m_basic_block = basic_block;
-   }
-   basic_block_t* get_bb() { return m_basic_block;}
-   void set_m_instr_mem_index(unsigned index) {
-      m_instr_mem_index = index; 
-   }
-   void set_PC( addr_t PC )
-   {
-       m_PC = PC;
-   }
-   addr_t get_PC() const
-   {
-       return m_PC;
-   }
+  int get_wmma_type() const { return m_wmma_type; }
+  int get_wmma_layout(int index) const {
+    return m_wmma_layout[index];  // 0->Matrix D,1->Matrix C
+  }
+  int get_type() const {
+    assert(!m_scalar_type.empty());
+    return m_scalar_type.front();
+  }
 
-   unsigned get_m_instr_mem_index() { return m_instr_mem_index;}
-   unsigned get_cmpop() const { return m_compare_op;}
-   const symbol *get_label() const { return m_label;}
-   bool is_label() const { if(m_label){ assert(m_opcode==-1);return true;} return false;}
-   bool is_hi() const { return m_hi;}
-   bool is_lo() const { return m_lo;}
-   bool is_wide() const { return m_wide;}
-   bool is_uni() const { return m_uni;}
-   bool is_exit() const { return m_exit;}
-   bool is_abs() const { return m_abs;}
-   bool is_neg() const { return m_neg;}
-   bool is_to() const { return m_to_option; }
-   unsigned cache_option() const { return m_cache_option; }
-   unsigned rounding_mode() const { return m_rounding_mode;}
-   unsigned saturation_mode() const { return m_saturation_mode;}
-   unsigned dimension() const { return m_geom_spec;}
-   unsigned barrier_op() const {return m_barrier_op;}
-   unsigned shfl_op() const {return m_shfl_op;}
-   unsigned prmt_op() const {return m_prmt_op;}
-   enum vote_mode_t { vote_any, vote_all, vote_uni, vote_ballot };
-   enum vote_mode_t vote_mode() const { return m_vote_mode; }
+  int get_type2() const {
+    assert(m_scalar_type.size() == 2);
+    return m_scalar_type.back();
+  }
 
-   int membar_level() const { return m_membar_level; }
+  void assign_bb(
+      basic_block_t *basic_block)  // assign instruction to a basic block
+  {
+    m_basic_block = basic_block;
+  }
+  basic_block_t *get_bb() { return m_basic_block; }
+  void set_m_instr_mem_index(unsigned index) { m_instr_mem_index = index; }
+  void set_PC(addr_t PC) { m_PC = PC; }
+  addr_t get_PC() const { return m_PC; }
 
-   bool has_memory_read() const {
-      if( m_opcode == LD_OP || m_opcode == LDU_OP || m_opcode == TEX_OP|| m_opcode==MMA_LD_OP ) 
-         return true;
-      // Check PTXPlus operand type below
-      // Source operands are memory operands
-      ptx_instruction::const_iterator op=op_iter_begin();
-      for ( int n=0; op != op_iter_end(); op++, n++ ) { //process operands
-         if( n > 0 && op->is_memory_operand2()) // source operands only
-            return true;
-      }
-      return false;
-   }
-   bool has_memory_write() const {
-      if( m_opcode == ST_OP || m_opcode==MMA_ST_OP ) return true;
-      // Check PTXPlus operand type below
-      // Destination operand is a memory operand
-      ptx_instruction::const_iterator op=op_iter_begin();
-      for ( int n=0; (op!=op_iter_end() && n<1); op++, n++ ) { //process operands
-         if( n==0 && op->is_memory_operand2()) // source operands only
-            return true;
-      }
-      return false;
-   }
+  unsigned get_m_instr_mem_index() { return m_instr_mem_index; }
+  unsigned get_cmpop() const { return m_compare_op; }
+  const symbol *get_label() const { return m_label; }
+  bool is_label() const {
+    if (m_label) {
+      assert(m_opcode == -1);
+      return true;
+    }
+    return false;
+  }
+  bool is_hi() const { return m_hi; }
+  bool is_lo() const { return m_lo; }
+  bool is_wide() const { return m_wide; }
+  bool is_uni() const { return m_uni; }
+  bool is_exit() const { return m_exit; }
+  bool is_abs() const { return m_abs; }
+  bool is_neg() const { return m_neg; }
+  bool is_to() const { return m_to_option; }
+  unsigned cache_option() const { return m_cache_option; }
+  unsigned rounding_mode() const { return m_rounding_mode; }
+  unsigned saturation_mode() const { return m_saturation_mode; }
+  unsigned dimension() const { return m_geom_spec; }
+  unsigned barrier_op() const { return m_barrier_op; }
+  unsigned shfl_op() const { return m_shfl_op; }
+  unsigned prmt_op() const { return m_prmt_op; }
+  enum vote_mode_t { vote_any, vote_all, vote_uni, vote_ballot };
+  enum vote_mode_t vote_mode() const { return m_vote_mode; }
 
+  int membar_level() const { return m_membar_level; }
 
-private:
-   void set_opcode_and_latency();
-   void set_bar_type();
-   void set_fp_or_int_archop();
-   void set_mul_div_or_other_archop();
+  bool has_memory_read() const {
+    if (m_opcode == LD_OP || m_opcode == LDU_OP || m_opcode == TEX_OP ||
+        m_opcode == MMA_LD_OP)
+      return true;
+    // Check PTXPlus operand type below
+    // Source operands are memory operands
+    ptx_instruction::const_iterator op = op_iter_begin();
+    for (int n = 0; op != op_iter_end(); op++, n++) {  // process operands
+      if (n > 0 && op->is_memory_operand2())           // source operands only
+        return true;
+    }
+    return false;
+  }
+  bool has_memory_write() const {
+    if (m_opcode == ST_OP || m_opcode == MMA_ST_OP) return true;
+    // Check PTXPlus operand type below
+    // Destination operand is a memory operand
+    ptx_instruction::const_iterator op = op_iter_begin();
+    for (int n = 0; (op != op_iter_end() && n < 1);
+         op++, n++) {                          // process operands
+      if (n == 0 && op->is_memory_operand2())  // source operands only
+        return true;
+    }
+    return false;
+  }
 
-   basic_block_t        *m_basic_block;
-   unsigned          m_uid;
-   addr_t            m_PC;
-   std::string             m_source_file;
-   unsigned                m_source_line;
-   std::string          m_source;
+ private:
+  void set_opcode_and_latency();
+  void set_bar_type();
+  void set_fp_or_int_archop();
+  void set_mul_div_or_other_archop();
 
-   const symbol           *m_pred;
-   bool                    m_neg_pred;
-   int                    m_pred_mod;
-   int                     m_opcode;
-   const symbol           *m_label;
-   std::vector<operand_info> m_operands;
-   operand_info m_return_var;
+  basic_block_t *m_basic_block;
+  unsigned m_uid;
+  addr_t m_PC;
+  std::string m_source_file;
+  unsigned m_source_line;
+  std::string m_source;
 
-   std::list<int>          m_options;
-   std::list<int>          m_wmma_options;
-   bool                m_wide;
-   bool                m_hi;
-   bool                m_lo;
-   bool                m_exit;
-   bool                m_abs;
-   bool                m_neg;
-   bool                m_uni; //if branch instruction, this evaluates to true for uniform branches (ie jumps)
-   bool                m_to_option;
-   unsigned            m_cache_option;
-   int      m_wmma_type;
-   int      m_wmma_layout[2];
-   int      m_wmma_configuration;
-   unsigned            m_rounding_mode;
-   unsigned            m_compare_op;
-   unsigned            m_saturation_mode;
-   unsigned 		   m_barrier_op;
-   unsigned			   m_shfl_op;
-   unsigned			   m_prmt_op;
+  const symbol *m_pred;
+  bool m_neg_pred;
+  int m_pred_mod;
+  int m_opcode;
+  const symbol *m_label;
+  std::vector<operand_info> m_operands;
+  operand_info m_return_var;
 
-   std::list<int>          m_scalar_type;
-   memory_space_t m_space_spec;
-   int m_geom_spec;
-   int m_vector_spec;
-   int m_atomic_spec;
-   enum vote_mode_t m_vote_mode;
-   int m_membar_level;
-   int m_instr_mem_index; //index into m_instr_mem array
-   unsigned m_inst_size; // bytes
+  std::list<int> m_options;
+  std::list<int> m_wmma_options;
+  bool m_wide;
+  bool m_hi;
+  bool m_lo;
+  bool m_exit;
+  bool m_abs;
+  bool m_neg;
+  bool m_uni;  // if branch instruction, this evaluates to true for uniform
+               // branches (ie jumps)
+  bool m_to_option;
+  unsigned m_cache_option;
+  int m_wmma_type;
+  int m_wmma_layout[2];
+  int m_wmma_configuration;
+  unsigned m_rounding_mode;
+  unsigned m_compare_op;
+  unsigned m_saturation_mode;
+  unsigned m_barrier_op;
+  unsigned m_shfl_op;
+  unsigned m_prmt_op;
 
-   virtual void pre_decode();
-   friend class function_info;
-   // backward pointer
-   class gpgpu_context* gpgpu_ctx;
+  std::list<int> m_scalar_type;
+  memory_space_t m_space_spec;
+  int m_geom_spec;
+  int m_vector_spec;
+  int m_atomic_spec;
+  enum vote_mode_t m_vote_mode;
+  int m_membar_level;
+  int m_instr_mem_index;  // index into m_instr_mem array
+  unsigned m_inst_size;   // bytes
+
+  virtual void pre_decode();
+  friend class function_info;
+  // backward pointer
+  class gpgpu_context *gpgpu_ctx;
 };
 
 class param_info {
-public:
-   param_info() { m_valid = false; m_value_set=false; m_size = 0; m_is_ptr = false; }
-   param_info( std::string name, int type, size_t size, bool is_ptr, memory_space_t ptr_space ) 
-   {
-      m_valid = true;
-      m_value_set = false;
-      m_name = name;
-      m_type = type;
-      m_size = size;
-      m_is_ptr = is_ptr; 
-      m_ptr_space = ptr_space; 
-   }
-   void add_data( param_t v ) { 
-      assert( (!m_value_set) || (m_value.size == v.size) ); // if this fails concurrent kernel launches might execute incorrectly
-      m_value_set = true;
-      m_value = v;
-   }
-   void add_offset( unsigned offset ) { m_offset = offset; }
-   unsigned get_offset() { assert(m_valid); return m_offset; }
-   std::string get_name() const { assert(m_valid); return m_name; }
-   int get_type() const { assert(m_valid);  return m_type; }
-   param_t get_value() const { assert(m_value_set); return m_value; }
-   size_t get_size() const { assert(m_valid); return m_size; }
-   bool is_ptr_shared() const { assert(m_valid); return (m_is_ptr and m_ptr_space == shared_space); }
-private:
-   bool m_valid;
-   std::string m_name;
-   int m_type;
-   size_t m_size;
-   bool m_value_set;
-   param_t m_value;
-   unsigned m_offset;
-   bool m_is_ptr; 
-   memory_space_t m_ptr_space; 
+ public:
+  param_info() {
+    m_valid = false;
+    m_value_set = false;
+    m_size = 0;
+    m_is_ptr = false;
+  }
+  param_info(std::string name, int type, size_t size, bool is_ptr,
+             memory_space_t ptr_space) {
+    m_valid = true;
+    m_value_set = false;
+    m_name = name;
+    m_type = type;
+    m_size = size;
+    m_is_ptr = is_ptr;
+    m_ptr_space = ptr_space;
+  }
+  void add_data(param_t v) {
+    assert((!m_value_set) || (m_value.size == v.size));  // if this fails
+                                                         // concurrent kernel
+                                                         // launches might
+                                                         // execute incorrectly
+    m_value_set = true;
+    m_value = v;
+  }
+  void add_offset(unsigned offset) { m_offset = offset; }
+  unsigned get_offset() {
+    assert(m_valid);
+    return m_offset;
+  }
+  std::string get_name() const {
+    assert(m_valid);
+    return m_name;
+  }
+  int get_type() const {
+    assert(m_valid);
+    return m_type;
+  }
+  param_t get_value() const {
+    assert(m_value_set);
+    return m_value;
+  }
+  size_t get_size() const {
+    assert(m_valid);
+    return m_size;
+  }
+  bool is_ptr_shared() const {
+    assert(m_valid);
+    return (m_is_ptr and m_ptr_space == shared_space);
+  }
+
+ private:
+  bool m_valid;
+  std::string m_name;
+  int m_type;
+  size_t m_size;
+  bool m_value_set;
+  param_t m_value;
+  unsigned m_offset;
+  bool m_is_ptr;
+  memory_space_t m_ptr_space;
 };
 
 class function_info {
-public:
-   function_info(int entry_point, gpgpu_context* ctx );
-   const ptx_version &get_ptx_version() const { return m_symtab->get_ptx_version(); }
-   unsigned get_sm_target() const { return m_symtab->get_sm_target(); }
-   bool is_extern() const { return m_extern; }
-   void set_name(const char *name)
-   {
-      m_name = name;
-   }
-   void set_symtab(symbol_table *symtab )
-   {
-      m_symtab = symtab;
-   }
-   std::string get_name() const
-   {
-      return m_name;
-   }
-   unsigned print_insn( unsigned pc, FILE * fp ) const;
-    std::string get_insn_str( unsigned pc ) const;
-   void add_inst( const std::list<ptx_instruction*> &instructions )
-   {
-      m_instructions = instructions;
-   }
-   std::list<ptx_instruction*>::iterator find_next_real_instruction( std::list<ptx_instruction*>::iterator i );
-   void create_basic_blocks( );
+ public:
+  function_info(int entry_point, gpgpu_context *ctx);
+  const ptx_version &get_ptx_version() const {
+    return m_symtab->get_ptx_version();
+  }
+  unsigned get_sm_target() const { return m_symtab->get_sm_target(); }
+  bool is_extern() const { return m_extern; }
+  void set_name(const char *name) { m_name = name; }
+  void set_symtab(symbol_table *symtab) { m_symtab = symtab; }
+  std::string get_name() const { return m_name; }
+  unsigned print_insn(unsigned pc, FILE *fp) const;
+  std::string get_insn_str(unsigned pc) const;
+  void add_inst(const std::list<ptx_instruction *> &instructions) {
+    m_instructions = instructions;
+  }
+  std::list<ptx_instruction *>::iterator find_next_real_instruction(
+      std::list<ptx_instruction *>::iterator i);
+  void create_basic_blocks();
 
-   void print_basic_blocks();
+  void print_basic_blocks();
 
-   void print_basic_block_links();
-   void print_basic_block_dot();
+  void print_basic_block_links();
+  void print_basic_block_dot();
 
-   operand_info* find_break_target( ptx_instruction * p_break_insn ); //find the target of a break instruction 
-   void connect_basic_blocks( ); //iterate across m_basic_blocks of function, connecting basic blocks together
-   bool connect_break_targets(); //connecting break instructions with proper targets
+  operand_info *find_break_target(
+      ptx_instruction *p_break_insn);  // find the target of a break instruction
+  void connect_basic_blocks();  // iterate across m_basic_blocks of function,
+                                // connecting basic blocks together
+  bool
+  connect_break_targets();  // connecting break instructions with proper targets
 
-   //iterate across m_basic_blocks of function, 
-   //finding dominator blocks, using algorithm of
-   //Muchnick's Adv. Compiler Design & Implemmntation Fig 7.14 
-   void find_dominators( );
-   void print_dominators();
-   void find_idominators();
-   void print_idominators();
+  // iterate across m_basic_blocks of function,
+  // finding dominator blocks, using algorithm of
+  // Muchnick's Adv. Compiler Design & Implemmntation Fig 7.14
+  void find_dominators();
+  void print_dominators();
+  void find_idominators();
+  void print_idominators();
 
-   //iterate across m_basic_blocks of function, 
-   //finding postdominator blocks, using algorithm of
-   //Muchnick's Adv. Compiler Design & Implemmntation Fig 7.14 
-   void find_postdominators( );
-   void print_postdominators();
+  // iterate across m_basic_blocks of function,
+  // finding postdominator blocks, using algorithm of
+  // Muchnick's Adv. Compiler Design & Implemmntation Fig 7.14
+  void find_postdominators();
+  void print_postdominators();
 
-   //iterate across m_basic_blocks of function, 
-   //finding immediate postdominator blocks, using algorithm of
-   //Muchnick's Adv. Compiler Design & Implemmntation Fig 7.15 
-   void find_ipostdominators( );
-   void print_ipostdominators();
-   void do_pdom(); //function to call pdom analysis
+  // iterate across m_basic_blocks of function,
+  // finding immediate postdominator blocks, using algorithm of
+  // Muchnick's Adv. Compiler Design & Implemmntation Fig 7.15
+  void find_ipostdominators();
+  void print_ipostdominators();
+  void do_pdom();  // function to call pdom analysis
 
-   unsigned get_num_reconvergence_pairs();
+  unsigned get_num_reconvergence_pairs();
 
-   void get_reconvergence_pairs(gpgpu_recon_t* recon_points);
+  void get_reconvergence_pairs(gpgpu_recon_t *recon_points);
 
-   unsigned get_function_size() { return m_instructions.size();}
+  unsigned get_function_size() { return m_instructions.size(); }
 
-   void ptx_assemble();
- 
-   unsigned ptx_get_inst_op( ptx_thread_info *thread );
-   void add_param( const char *name, struct param_t value )
-   {
-      m_kernel_params[ name ] = value;
-   }
-   void add_param_name_type_size( unsigned index, std::string name, int type, size_t size, bool ptr, memory_space_t space );
-   void add_param_data( unsigned argn, struct gpgpu_ptx_sim_arg *args );
-   void add_return_var( const symbol *rv )
-   {
-      m_return_var_sym = rv;
-   }
-   void add_arg( const symbol *arg )
-   {
-      assert( arg != NULL );
-      m_args.push_back(arg);
-   }
-   void remove_args()
-   {
-      m_args.clear();
-   }
-   unsigned num_args() const
-   {
-      return m_args.size();
-   }
-   unsigned get_args_aligned_size();
+  void ptx_assemble();
 
-   const symbol* get_arg( unsigned n ) const
-   {
-      assert( n < m_args.size() );
-      return m_args[n];
-   }
-   bool has_return() const
-   {
-      return m_return_var_sym != NULL;
-   }
-   const symbol *get_return_var() const
-   {
-      return m_return_var_sym;
-   }
-   const ptx_instruction *get_instruction( unsigned PC ) const
-   {
-      unsigned index = PC - m_start_PC;
-      if( index < m_instr_mem_size ) 
-         return m_instr_mem[index];
-      return NULL;
-   }
-   addr_t get_start_PC() const
-   {
-       return m_start_PC;
-   }
+  unsigned ptx_get_inst_op(ptx_thread_info *thread);
+  void add_param(const char *name, struct param_t value) {
+    m_kernel_params[name] = value;
+  }
+  void add_param_name_type_size(unsigned index, std::string name, int type,
+                                size_t size, bool ptr, memory_space_t space);
+  void add_param_data(unsigned argn, struct gpgpu_ptx_sim_arg *args);
+  void add_return_var(const symbol *rv) { m_return_var_sym = rv; }
+  void add_arg(const symbol *arg) {
+    assert(arg != NULL);
+    m_args.push_back(arg);
+  }
+  void remove_args() { m_args.clear(); }
+  unsigned num_args() const { return m_args.size(); }
+  unsigned get_args_aligned_size();
 
-   void finalize( memory_space *param_mem );
-   void param_to_shared( memory_space *shared_mem, symbol_table *symtab ); 
-   void list_param( FILE *fout ) const;
-   void ptx_jit_config(std::map<unsigned long long, size_t> mallocPtr_Size, memory_space *param_mem, gpgpu_t* gpu, dim3 gridDim, dim3 blockDim) ;
+  const symbol *get_arg(unsigned n) const {
+    assert(n < m_args.size());
+    return m_args[n];
+  }
+  bool has_return() const { return m_return_var_sym != NULL; }
+  const symbol *get_return_var() const { return m_return_var_sym; }
+  const ptx_instruction *get_instruction(unsigned PC) const {
+    unsigned index = PC - m_start_PC;
+    if (index < m_instr_mem_size) return m_instr_mem[index];
+    return NULL;
+  }
+  addr_t get_start_PC() const { return m_start_PC; }
 
-   const struct gpgpu_ptx_sim_info* get_kernel_info () const
-   {
-      assert (m_kernel_info.maxthreads == maxnt_id);
-      return &m_kernel_info;
-   }
+  void finalize(memory_space *param_mem);
+  void param_to_shared(memory_space *shared_mem, symbol_table *symtab);
+  void list_param(FILE *fout) const;
+  void ptx_jit_config(std::map<unsigned long long, size_t> mallocPtr_Size,
+                      memory_space *param_mem, gpgpu_t *gpu, dim3 gridDim,
+                      dim3 blockDim);
 
-   const void set_kernel_info (const struct gpgpu_ptx_sim_info &info) {
-      m_kernel_info = info;
-      m_kernel_info.ptx_version = 10*get_ptx_version().ver();
-      m_kernel_info.sm_target = get_ptx_version().target();
-      // THIS DEPENDS ON ptxas being called after the PTX is parsed.
-      m_kernel_info.maxthreads = maxnt_id;
-   }
-   symbol_table *get_symtab()
-   {
-      return m_symtab;
-   }
+  const struct gpgpu_ptx_sim_info *get_kernel_info() const {
+    assert(m_kernel_info.maxthreads == maxnt_id);
+    return &m_kernel_info;
+  }
 
-   unsigned local_mem_framesize() const 
-   { 
-      return m_local_mem_framesize; 
-   }
-   void set_framesize( unsigned sz )
-   {
-      m_local_mem_framesize = sz;
-   }
-   bool is_entry_point() const { return m_entry_point; }
-   bool is_pdom_set() const { return pdom_done; } //return pdom flag
-   void set_pdom() { pdom_done = true; } //set pdom flag
+  const void set_kernel_info(const struct gpgpu_ptx_sim_info &info) {
+    m_kernel_info = info;
+    m_kernel_info.ptx_version = 10 * get_ptx_version().ver();
+    m_kernel_info.sm_target = get_ptx_version().target();
+    // THIS DEPENDS ON ptxas being called after the PTX is parsed.
+    m_kernel_info.maxthreads = maxnt_id;
+  }
+  symbol_table *get_symtab() { return m_symtab; }
 
-   void add_config_param( size_t size, unsigned alignment ){
-      unsigned offset = 0;
-      if (m_param_configs.size()>0){
-          unsigned offset_nom = m_param_configs.back().first + m_param_configs.back().second;
-          //ensure offset matches alignment requirements
-          offset = offset_nom%alignment ? (offset_nom/alignment + 1) * alignment : offset_nom;
-      }
-      m_param_configs.push_back(std::pair<size_t,unsigned>(size, offset));
-   }
+  unsigned local_mem_framesize() const { return m_local_mem_framesize; }
+  void set_framesize(unsigned sz) { m_local_mem_framesize = sz; }
+  bool is_entry_point() const { return m_entry_point; }
+  bool is_pdom_set() const { return pdom_done; }  // return pdom flag
+  void set_pdom() { pdom_done = true; }           // set pdom flag
 
-   std::pair<size_t, unsigned> get_param_config(unsigned param_num) const { return m_param_configs[param_num]; }
+  void add_config_param(size_t size, unsigned alignment) {
+    unsigned offset = 0;
+    if (m_param_configs.size() > 0) {
+      unsigned offset_nom =
+          m_param_configs.back().first + m_param_configs.back().second;
+      // ensure offset matches alignment requirements
+      offset = offset_nom % alignment ? (offset_nom / alignment + 1) * alignment
+                                      : offset_nom;
+    }
+    m_param_configs.push_back(std::pair<size_t, unsigned>(size, offset));
+  }
 
-   void set_maxnt_id(unsigned maxthreads) { maxnt_id = maxthreads;}
-   unsigned get_maxnt_id() { return maxnt_id;}
-   // backward pointer
-   class gpgpu_context* gpgpu_ctx;
+  std::pair<size_t, unsigned> get_param_config(unsigned param_num) const {
+    return m_param_configs[param_num];
+  }
 
-private:
-   unsigned maxnt_id;
-   unsigned m_uid;
-   unsigned m_local_mem_framesize;
-   bool m_entry_point;
-   bool m_extern;
-   bool m_assembled;
-   bool pdom_done; //flag to check whether pdom is completed or not
-   std::string m_name;
-   ptx_instruction **m_instr_mem;
-   unsigned m_start_PC;
-   unsigned m_instr_mem_size;
-   std::map<std::string,param_t> m_kernel_params;
-   std::map<unsigned,param_info> m_ptx_kernel_param_info;
-   std::vector< std::pair<size_t, unsigned> > m_param_configs;
-   const symbol *m_return_var_sym;
-   std::vector<const symbol*> m_args;
-   std::list<ptx_instruction*> m_instructions;
-   std::vector<basic_block_t*> m_basic_blocks;
-   std::list<std::pair<unsigned, unsigned> > m_back_edges;
-   std::map<std::string,unsigned> labels;
-   unsigned num_reconvergence_pairs;
+  void set_maxnt_id(unsigned maxthreads) { maxnt_id = maxthreads; }
+  unsigned get_maxnt_id() { return maxnt_id; }
+  // backward pointer
+  class gpgpu_context *gpgpu_ctx;
 
-   //Registers/shmem/etc. used (from ptxas -v), loaded from ___.ptxinfo along with ___.ptx
-   struct gpgpu_ptx_sim_info m_kernel_info;
+ private:
+  unsigned maxnt_id;
+  unsigned m_uid;
+  unsigned m_local_mem_framesize;
+  bool m_entry_point;
+  bool m_extern;
+  bool m_assembled;
+  bool pdom_done;  // flag to check whether pdom is completed or not
+  std::string m_name;
+  ptx_instruction **m_instr_mem;
+  unsigned m_start_PC;
+  unsigned m_instr_mem_size;
+  std::map<std::string, param_t> m_kernel_params;
+  std::map<unsigned, param_info> m_ptx_kernel_param_info;
+  std::vector<std::pair<size_t, unsigned> > m_param_configs;
+  const symbol *m_return_var_sym;
+  std::vector<const symbol *> m_args;
+  std::list<ptx_instruction *> m_instructions;
+  std::vector<basic_block_t *> m_basic_blocks;
+  std::list<std::pair<unsigned, unsigned> > m_back_edges;
+  std::map<std::string, unsigned> labels;
+  unsigned num_reconvergence_pairs;
 
-   symbol_table *m_symtab;
+  // Registers/shmem/etc. used (from ptxas -v), loaded from ___.ptxinfo along
+  // with ___.ptx
+  struct gpgpu_ptx_sim_info m_kernel_info;
 
-   //parameter size for device kernels
-   int m_args_aligned_size;
-   
-   addr_t m_n;  // offset in m_instr_mem (used in do_pdom)
+  symbol_table *m_symtab;
+
+  // parameter size for device kernels
+  int m_args_aligned_size;
+
+  addr_t m_n;  // offset in m_instr_mem (used in do_pdom)
 };
 
 class arg_buffer_t {
-public:
-   arg_buffer_t(gpgpu_context* ctx) : m_src_op(ctx)
-   {
-      m_is_reg=false;
-      m_is_param=false;
-      m_param_value=NULL;
-      m_reg_value=ptx_reg_t();
-   }
-   arg_buffer_t( const arg_buffer_t &another, gpgpu_context* ctx ) : m_src_op(ctx)
-   {
-      make_copy(another);
-   }
-   void make_copy( const arg_buffer_t &another )
-   {
-      m_dst = another.m_dst;
-      m_src_op = another.m_src_op;
-      m_is_reg = another.m_is_reg;
-      m_is_param = another.m_is_param;
-      m_reg_value = another.m_reg_value;
-      m_param_bytes = another.m_param_bytes;
-      if( m_is_param ) {
-         m_param_value = malloc(m_param_bytes);
-         memcpy(m_param_value,another.m_param_value,m_param_bytes);
+ public:
+  arg_buffer_t(gpgpu_context *ctx) : m_src_op(ctx) {
+    m_is_reg = false;
+    m_is_param = false;
+    m_param_value = NULL;
+    m_reg_value = ptx_reg_t();
+  }
+  arg_buffer_t(const arg_buffer_t &another, gpgpu_context *ctx)
+      : m_src_op(ctx) {
+    make_copy(another);
+  }
+  void make_copy(const arg_buffer_t &another) {
+    m_dst = another.m_dst;
+    m_src_op = another.m_src_op;
+    m_is_reg = another.m_is_reg;
+    m_is_param = another.m_is_param;
+    m_reg_value = another.m_reg_value;
+    m_param_bytes = another.m_param_bytes;
+    if (m_is_param) {
+      m_param_value = malloc(m_param_bytes);
+      memcpy(m_param_value, another.m_param_value, m_param_bytes);
+    }
+  }
+  void operator=(const arg_buffer_t &another) { make_copy(another); }
+  ~arg_buffer_t() {
+    if (m_is_param) free(m_param_value);
+  }
+  arg_buffer_t(const symbol *dst_sym, const operand_info &src_op,
+               ptx_reg_t source_value)
+      : m_src_op(src_op) {
+    m_dst = dst_sym;
+    m_reg_value = ptx_reg_t();
+    if (dst_sym->is_reg()) {
+      m_is_reg = true;
+      m_is_param = false;
+      assert(src_op.is_reg());
+      m_reg_value = source_value;
+    } else {
+      m_is_param = true;
+      m_is_reg = false;
+      m_param_value = calloc(sizeof(ptx_reg_t), 1);
+      // new (m_param_value) ptx_reg_t(source_value);
+      memcpy(m_param_value, &source_value, sizeof(ptx_reg_t));
+      m_param_bytes = sizeof(ptx_reg_t);
+    }
+  }
+  arg_buffer_t(const symbol *dst_sym, const operand_info &src_op,
+               void *source_param_value_array, unsigned array_size)
+      : m_src_op(src_op) {
+    m_dst = dst_sym;
+    if (dst_sym->is_reg()) {
+      m_is_reg = true;
+      m_is_param = false;
+      assert(src_op.is_param_local());
+      assert(dst_sym->get_size_in_bytes() == array_size);
+      switch (array_size) {
+        case 1:
+          m_reg_value.u8 = *(unsigned char *)source_param_value_array;
+          break;
+        case 2:
+          m_reg_value.u16 = *(unsigned short *)source_param_value_array;
+          break;
+        case 4:
+          m_reg_value.u32 = *(unsigned int *)source_param_value_array;
+          break;
+        case 8:
+          m_reg_value.u64 = *(unsigned long long *)source_param_value_array;
+          break;
+        default:
+          printf(
+              "GPGPU-Sim PTX: ERROR ** source param size does not match known "
+              "register sizes\n");
+          break;
       }
-   }
-   void operator=( const arg_buffer_t &another )
-   {
-      make_copy(another);
-   }
-   ~arg_buffer_t()
-   {
-      if( m_is_param ) 
-         free(m_param_value);
-   }
-   arg_buffer_t( const symbol *dst_sym, const operand_info &src_op, ptx_reg_t source_value ) : m_src_op(src_op)
-   {
-      m_dst = dst_sym;
-      m_reg_value=ptx_reg_t();
-      if( dst_sym->is_reg() ) {
-         m_is_reg = true;
-         m_is_param = false;
-         assert( src_op.is_reg() );
-         m_reg_value = source_value;
-      } else {
-         m_is_param = true;
-         m_is_reg = false;
-         m_param_value = calloc(sizeof(ptx_reg_t),1);
-         //new (m_param_value) ptx_reg_t(source_value);
-         memcpy(m_param_value,&source_value,sizeof(ptx_reg_t));
-         m_param_bytes = sizeof(ptx_reg_t);
-      }
-   }
-   arg_buffer_t( const symbol *dst_sym, const operand_info &src_op, void *source_param_value_array, unsigned array_size ) : m_src_op(src_op)
-   {
-      m_dst = dst_sym;
-      if( dst_sym->is_reg() ) {
-         m_is_reg = true;
-         m_is_param = false;
-         assert( src_op.is_param_local() );
-         assert( dst_sym->get_size_in_bytes() == array_size );
-         switch( array_size ) {
-         case 1: m_reg_value.u8 = *(unsigned char*)source_param_value_array; break;
-         case 2: m_reg_value.u16 = *(unsigned short*)source_param_value_array; break;
-         case 4: m_reg_value.u32 = *(unsigned int*)source_param_value_array; break;
-         case 8: m_reg_value.u64 = *(unsigned long long*)source_param_value_array; break;
-         default:
-            printf("GPGPU-Sim PTX: ERROR ** source param size does not match known register sizes\n");
-            break;
-         }
-      } else {
-         // param
-         m_is_param = true;
-         m_is_reg = false;
-         m_param_value = calloc(array_size,1);
-         m_param_bytes = array_size;
-         memcpy(m_param_value,source_param_value_array,array_size);
-      }
-   }
+    } else {
+      // param
+      m_is_param = true;
+      m_is_reg = false;
+      m_param_value = calloc(array_size, 1);
+      m_param_bytes = array_size;
+      memcpy(m_param_value, source_param_value_array, array_size);
+    }
+  }
 
-   bool is_reg() const { return m_is_reg; }
-   ptx_reg_t get_reg() const 
-   { 
-      assert(m_is_reg); 
-      return m_reg_value; 
-   }
+  bool is_reg() const { return m_is_reg; }
+  ptx_reg_t get_reg() const {
+    assert(m_is_reg);
+    return m_reg_value;
+  }
 
-   const void *get_param_buffer() const
-   {
-      assert(m_is_param);
-      return m_param_value;
-   }
-   size_t get_param_buffer_size() const
-   {
-      assert(m_is_param);
-      return m_param_bytes;
-   }
+  const void *get_param_buffer() const {
+    assert(m_is_param);
+    return m_param_value;
+  }
+  size_t get_param_buffer_size() const {
+    assert(m_is_param);
+    return m_param_bytes;
+  }
 
-   const symbol *get_dst() const { return m_dst; }
+  const symbol *get_dst() const { return m_dst; }
 
-private:
-   // destination of copy
-   const symbol *m_dst;
+ private:
+  // destination of copy
+  const symbol *m_dst;
 
-   // source operand
-   operand_info m_src_op;
+  // source operand
+  operand_info m_src_op;
 
-   // source information
-   bool m_is_reg;
-   bool m_is_param;
+  // source information
+  bool m_is_reg;
+  bool m_is_param;
 
-   // source is register
-   ptx_reg_t m_reg_value;
+  // source is register
+  ptx_reg_t m_reg_value;
 
-   // source is param
-   void     *m_param_value;
-   unsigned  m_param_bytes;
+  // source is param
+  void *m_param_value;
+  unsigned m_param_bytes;
 };
 
-typedef std::list< arg_buffer_t > arg_buffer_list_t;
-arg_buffer_t copy_arg_to_buffer(ptx_thread_info * thread, operand_info actual_param_op, const symbol * formal_param);
-void copy_args_into_buffer_list( const ptx_instruction * pI, 
-                                 ptx_thread_info * thread, 
-                                 const function_info * target_func, 
-                                 arg_buffer_list_t &arg_values ); 
-void copy_buffer_list_into_frame(ptx_thread_info * thread, arg_buffer_list_t &arg_values);
-void copy_buffer_to_frame(ptx_thread_info * thread, const arg_buffer_t &a);
-
+typedef std::list<arg_buffer_t> arg_buffer_list_t;
+arg_buffer_t copy_arg_to_buffer(ptx_thread_info *thread,
+                                operand_info actual_param_op,
+                                const symbol *formal_param);
+void copy_args_into_buffer_list(const ptx_instruction *pI,
+                                ptx_thread_info *thread,
+                                const function_info *target_func,
+                                arg_buffer_list_t &arg_values);
+void copy_buffer_list_into_frame(ptx_thread_info *thread,
+                                 arg_buffer_list_t &arg_values);
+void copy_buffer_to_frame(ptx_thread_info *thread, const arg_buffer_t &a);
 
 struct textureInfo {
-   unsigned int texel_size; //size in bytes, e.g. (channelDesc.x+y+z+w)/8
-   unsigned int Tx,Ty; //tiling factor dimensions of layout of texels per 64B cache block
-   unsigned int Tx_numbits,Ty_numbits; //log2(T)
-   unsigned int texel_size_numbits; //log2(texel_size)
+  unsigned int texel_size;  // size in bytes, e.g. (channelDesc.x+y+z+w)/8
+  unsigned int Tx,
+      Ty;  // tiling factor dimensions of layout of texels per 64B cache block
+  unsigned int Tx_numbits, Ty_numbits;  // log2(T)
+  unsigned int texel_size_numbits;      // log2(texel_size)
 };
 
-extern std::map<std::string,symbol_table*> g_sym_name_to_symbol_table;
+extern std::map<std::string, symbol_table *> g_sym_name_to_symbol_table;
 
-
-void gpgpu_ptx_assemble( std::string kname, void *kinfo );
+void gpgpu_ptx_assemble(std::string kname, void *kinfo);
 #include "../option_parser.h"
-unsigned ptx_kernel_shmem_size( void *kernel_impl );
-unsigned ptx_kernel_nregs( void *kernel_impl );
+unsigned ptx_kernel_shmem_size(void *kernel_impl);
+unsigned ptx_kernel_nregs(void *kernel_impl);
 
 #endif

--- a/src/cuda-sim/ptx_loader.cc
+++ b/src/cuda-sim/ptx_loader.cc
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -26,503 +28,556 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "ptx_loader.h"
-#include "ptx_ir.h"
-#include "cuda-sim.h"
-#include "ptx_parser.h"
-#include <unistd.h>
 #include <dirent.h>
+#include <unistd.h>
 #include <fstream>
 #include <sstream>
 #include "../../libcuda/gpgpu_context.h"
+#include "cuda-sim.h"
+#include "ptx_ir.h"
+#include "ptx_parser.h"
 
 /// extern prototypes
 
-extern int ptx_error( yyscan_t yyscanner, const char *s );
-extern int ptx_lex_init(yyscan_t* scanner);
-extern void ptx_set_in(FILE * _in_str ,yyscan_t yyscanner );
-extern int ptx_parse(yyscan_t scanner, ptx_recognizer* recognizer);
+extern int ptx_error(yyscan_t yyscanner, const char *s);
+extern int ptx_lex_init(yyscan_t *scanner);
+extern void ptx_set_in(FILE *_in_str, yyscan_t yyscanner);
+extern int ptx_parse(yyscan_t scanner, ptx_recognizer *recognizer);
 extern int ptx_lex_destroy(yyscan_t scanner);
-extern int ptx__scan_string(const char*, yyscan_t scanner);
+extern int ptx__scan_string(const char *, yyscan_t scanner);
 
-extern std::map<unsigned,const char*> get_duplicate();
+extern std::map<unsigned, const char *> get_duplicate();
 
-typedef void * yyscan_t;
-extern int ptxinfo_lex_init(yyscan_t* scanner);
-extern void ptxinfo_set_in  (FILE * _in_str ,yyscan_t yyscanner );
-extern int ptxinfo_parse(yyscan_t scanner, ptxinfo_data* ptxinfo);
+typedef void *yyscan_t;
+extern int ptxinfo_lex_init(yyscan_t *scanner);
+extern void ptxinfo_set_in(FILE *_in_str, yyscan_t yyscanner);
+extern int ptxinfo_parse(yyscan_t scanner, ptxinfo_data *ptxinfo);
 extern int ptxinfo_lex_destroy(yyscan_t scanner);
 
 static bool g_save_embedded_ptx;
 static int g_occupancy_sm_number;
 
-bool ptxinfo_data::keep_intermediate_files() {return g_keep_intermediate_files;}
-
-void gpgpu_context::ptx_reg_options(option_parser_t opp)
-{
-   option_parser_register(opp, "-save_embedded_ptx", OPT_BOOL, &g_save_embedded_ptx, 
-                "saves ptx files embedded in binary as <n>.ptx",
-                "0");
-   option_parser_register(opp, "-keep", OPT_BOOL, &(ptxinfo->g_keep_intermediate_files),
-                "keep intermediate files created by GPGPU-Sim when interfacing with external programs",
-                "0");
-   option_parser_register(opp, "-gpgpu_ptx_save_converted_ptxplus", OPT_BOOL,
-                &(ptxinfo->m_ptx_save_converted_ptxplus),
-                "Saved converted ptxplus to a file",
-                "0");
-   option_parser_register(opp, "-gpgpu_occupancy_sm_number", OPT_INT32, &g_occupancy_sm_number,
-                "The SM number to pass to ptxas when getting register usage for computing GPU occupancy. "
-                "This parameter is required in the config.",
-                "0");
+bool ptxinfo_data::keep_intermediate_files() {
+  return g_keep_intermediate_files;
 }
 
-void gpgpu_context::print_ptx_file( const char *p, unsigned source_num, const char *filename )
-{
-   printf("\nGPGPU-Sim PTX: file _%u.ptx contents:\n\n", source_num );
-   char *s = strdup(p);
-   char *t = s;
-   unsigned n=1;
-   while ( *t != '\0'  ) {
-      char *u = t;
-      while ( (*u != '\n') && (*u != '\0') ) u++;
-      unsigned last = (*u == '\0');
-      *u = '\0';
-      const ptx_instruction *pI = ptx_parser->ptx_instruction_lookup(filename,n);
-      char pc[64];
-      if( pI && pI->get_PC() )
-         snprintf(pc,64,"%4u", pI->get_PC() );
-      else 
-         snprintf(pc,64,"    ");
-      printf("    _%u.ptx  %4u (pc=%s):  %s\n", source_num, n, pc, t );
-      if ( last ) break;
-      t = u+1;
-      n++;
-   }
-   free(s);
-   fflush(stdout);
+void gpgpu_context::ptx_reg_options(option_parser_t opp) {
+  option_parser_register(opp, "-save_embedded_ptx", OPT_BOOL,
+                         &g_save_embedded_ptx,
+                         "saves ptx files embedded in binary as <n>.ptx", "0");
+  option_parser_register(opp, "-keep", OPT_BOOL,
+                         &(ptxinfo->g_keep_intermediate_files),
+                         "keep intermediate files created by GPGPU-Sim when "
+                         "interfacing with external programs",
+                         "0");
+  option_parser_register(opp, "-gpgpu_ptx_save_converted_ptxplus", OPT_BOOL,
+                         &(ptxinfo->m_ptx_save_converted_ptxplus),
+                         "Saved converted ptxplus to a file", "0");
+  option_parser_register(opp, "-gpgpu_occupancy_sm_number", OPT_INT32,
+                         &g_occupancy_sm_number,
+                         "The SM number to pass to ptxas when getting register "
+                         "usage for computing GPU occupancy. "
+                         "This parameter is required in the config.",
+                         "0");
 }
 
-char* ptxinfo_data::gpgpu_ptx_sim_convert_ptx_and_sass_to_ptxplus(const std::string ptxfilename, const std::string elffilename, const std::string sassfilename)
-{
-
-	printf("GPGPU-Sim PTX: converting EMBEDDED .ptx file to ptxplus \n");
-
-    char fname_ptxplus[1024];
-    snprintf(fname_ptxplus,1024,"_ptxplus_XXXXXX");
-    int fd4=mkstemp(fname_ptxplus);
-    close(fd4);
-
-	// Run cuobjdump_to_ptxplus
-	char commandline[1024];
-	int result;
-	snprintf(commandline, 1024, "$GPGPUSIM_ROOT/build/$GPGPUSIM_CONFIG/cuobjdump_to_ptxplus/cuobjdump_to_ptxplus %s %s %s %s",
-			ptxfilename.c_str(),
-			sassfilename.c_str(),
-			elffilename.c_str(),
-			fname_ptxplus);
-	fflush(stdout);
-	printf("GPGPU-Sim PTX: calling cuobjdump_to_ptxplus\ncommandline: %s\n", commandline);
-	result = system(commandline);
-	if(result){fprintf(stderr, "GPGPU-Sim PTX: ERROR ** could not execute %s\n", commandline); exit(1);}
-
-
-	// Get ptxplus from file
-	std::ifstream fileStream(fname_ptxplus, std::ios::in);
-	std::string text, line;
-	while(getline(fileStream,line)) {
-		text += (line + "\n");
-	}
-	fileStream.close();
-
-	char* ptxplus_str = new char [strlen(text.c_str())+1];
-	strcpy(ptxplus_str, text.c_str());
-
-	if (!m_ptx_save_converted_ptxplus){
-		char rm_commandline[1024];
-
-		snprintf(rm_commandline,1024,"rm -f %s", fname_ptxplus);
-
-		printf("GPGPU-Sim PTX: removing temporary files using \"%s\"\n", rm_commandline);
-		int rm_result = system(rm_commandline);
-		if( rm_result != 0 ) {
-			fprintf(stderr, "GPGPU-Sim PTX: ERROR ** while removing temporary files %d\n", rm_result);
-			exit(1);
-		}
-	}
-	printf("GPGPU-Sim PTX: DONE converting EMBEDDED .ptx file to ptxplus \n");
-
-	return ptxplus_str;
+void gpgpu_context::print_ptx_file(const char *p, unsigned source_num,
+                                   const char *filename) {
+  printf("\nGPGPU-Sim PTX: file _%u.ptx contents:\n\n", source_num);
+  char *s = strdup(p);
+  char *t = s;
+  unsigned n = 1;
+  while (*t != '\0') {
+    char *u = t;
+    while ((*u != '\n') && (*u != '\0')) u++;
+    unsigned last = (*u == '\0');
+    *u = '\0';
+    const ptx_instruction *pI = ptx_parser->ptx_instruction_lookup(filename, n);
+    char pc[64];
+    if (pI && pI->get_PC())
+      snprintf(pc, 64, "%4u", pI->get_PC());
+    else
+      snprintf(pc, 64, "    ");
+    printf("    _%u.ptx  %4u (pc=%s):  %s\n", source_num, n, pc, t);
+    if (last) break;
+    t = u + 1;
+    n++;
+  }
+  free(s);
+  fflush(stdout);
 }
 
+char *ptxinfo_data::gpgpu_ptx_sim_convert_ptx_and_sass_to_ptxplus(
+    const std::string ptxfilename, const std::string elffilename,
+    const std::string sassfilename) {
+  printf("GPGPU-Sim PTX: converting EMBEDDED .ptx file to ptxplus \n");
 
-symbol_table *gpgpu_context::gpgpu_ptx_sim_load_ptx_from_string( const char *p, unsigned source_num )
-{
-    char buf[1024];
-    snprintf(buf,1024,"_%u.ptx", source_num );
-    if( g_save_embedded_ptx ) {
-       FILE *fp = fopen(buf,"w");
-       fprintf(fp,"%s",p);
-       fclose(fp);
+  char fname_ptxplus[1024];
+  snprintf(fname_ptxplus, 1024, "_ptxplus_XXXXXX");
+  int fd4 = mkstemp(fname_ptxplus);
+  close(fd4);
+
+  // Run cuobjdump_to_ptxplus
+  char commandline[1024];
+  int result;
+  snprintf(commandline, 1024,
+           "$GPGPUSIM_ROOT/build/$GPGPUSIM_CONFIG/cuobjdump_to_ptxplus/"
+           "cuobjdump_to_ptxplus %s %s %s %s",
+           ptxfilename.c_str(), sassfilename.c_str(), elffilename.c_str(),
+           fname_ptxplus);
+  fflush(stdout);
+  printf("GPGPU-Sim PTX: calling cuobjdump_to_ptxplus\ncommandline: %s\n",
+         commandline);
+  result = system(commandline);
+  if (result) {
+    fprintf(stderr, "GPGPU-Sim PTX: ERROR ** could not execute %s\n",
+            commandline);
+    exit(1);
+  }
+
+  // Get ptxplus from file
+  std::ifstream fileStream(fname_ptxplus, std::ios::in);
+  std::string text, line;
+  while (getline(fileStream, line)) {
+    text += (line + "\n");
+  }
+  fileStream.close();
+
+  char *ptxplus_str = new char[strlen(text.c_str()) + 1];
+  strcpy(ptxplus_str, text.c_str());
+
+  if (!m_ptx_save_converted_ptxplus) {
+    char rm_commandline[1024];
+
+    snprintf(rm_commandline, 1024, "rm -f %s", fname_ptxplus);
+
+    printf("GPGPU-Sim PTX: removing temporary files using \"%s\"\n",
+           rm_commandline);
+    int rm_result = system(rm_commandline);
+    if (rm_result != 0) {
+      fprintf(stderr,
+              "GPGPU-Sim PTX: ERROR ** while removing temporary files %d\n",
+              rm_result);
+      exit(1);
     }
-    symbol_table *symtab=init_parser(buf);
-    ptx_lex_init(&(ptx_parser->scanner));
-    ptx__scan_string(p, ptx_parser->scanner);
-    int errors = ptx_parse (ptx_parser->scanner, ptx_parser);
-    if ( errors ) {
-        char fname[1024];
-        snprintf(fname,1024,"_ptx_errors_XXXXXX");
-        int fd=mkstemp(fname); 
-        close(fd);
-        printf("GPGPU-Sim PTX: parser error detected, exiting... but first extracting .ptx to \"%s\"\n", fname);
-        FILE *ptxfile = fopen(fname,"w");
-        fprintf(ptxfile,"%s", p );
-        fclose(ptxfile);
-        abort();
-        exit(40);
-    }
-    ptx_lex_destroy(ptx_parser->scanner);
+  }
+  printf("GPGPU-Sim PTX: DONE converting EMBEDDED .ptx file to ptxplus \n");
 
-    if ( g_debug_execution >= 100 ) 
-       print_ptx_file(p,source_num,buf);
-
-    printf("GPGPU-Sim PTX: finished parsing EMBEDDED .ptx file %s\n",buf);
-    return symtab;
+  return ptxplus_str;
 }
 
-symbol_table *gpgpu_context::gpgpu_ptx_sim_load_ptx_from_filename( const char *filename )
-{
-    symbol_table *symtab=init_parser(filename);
-    printf("GPGPU-Sim PTX: finished parsing EMBEDDED .ptx file %s\n",filename);
-    return symtab;
+symbol_table *gpgpu_context::gpgpu_ptx_sim_load_ptx_from_string(
+    const char *p, unsigned source_num) {
+  char buf[1024];
+  snprintf(buf, 1024, "_%u.ptx", source_num);
+  if (g_save_embedded_ptx) {
+    FILE *fp = fopen(buf, "w");
+    fprintf(fp, "%s", p);
+    fclose(fp);
+  }
+  symbol_table *symtab = init_parser(buf);
+  ptx_lex_init(&(ptx_parser->scanner));
+  ptx__scan_string(p, ptx_parser->scanner);
+  int errors = ptx_parse(ptx_parser->scanner, ptx_parser);
+  if (errors) {
+    char fname[1024];
+    snprintf(fname, 1024, "_ptx_errors_XXXXXX");
+    int fd = mkstemp(fname);
+    close(fd);
+    printf(
+        "GPGPU-Sim PTX: parser error detected, exiting... but first extracting "
+        ".ptx to \"%s\"\n",
+        fname);
+    FILE *ptxfile = fopen(fname, "w");
+    fprintf(ptxfile, "%s", p);
+    fclose(ptxfile);
+    abort();
+    exit(40);
+  }
+  ptx_lex_destroy(ptx_parser->scanner);
+
+  if (g_debug_execution >= 100) print_ptx_file(p, source_num, buf);
+
+  printf("GPGPU-Sim PTX: finished parsing EMBEDDED .ptx file %s\n", buf);
+  return symtab;
+}
+
+symbol_table *gpgpu_context::gpgpu_ptx_sim_load_ptx_from_filename(
+    const char *filename) {
+  symbol_table *symtab = init_parser(filename);
+  printf("GPGPU-Sim PTX: finished parsing EMBEDDED .ptx file %s\n", filename);
+  return symtab;
 }
 
 void fix_duplicate_errors(char fname2[1024]) {
-	char tempfile[1024] = "_temp_ptx";
-	char commandline[1024];
+  char tempfile[1024] = "_temp_ptx";
+  char commandline[1024];
 
-	// change the name of the ptx file to _temp_ptx
-	snprintf(commandline,1024,"mv %s %s",fname2,tempfile);
-	printf("Running: %s\n", commandline);
-	int result = system(commandline);
-	if (result != 0) {
-		fprintf(stderr, "GPGPU-Sim PTX: ERROR ** while changing filename from %s to %s", fname2, tempfile);
-		exit(1);
-	}
+  // change the name of the ptx file to _temp_ptx
+  snprintf(commandline, 1024, "mv %s %s", fname2, tempfile);
+  printf("Running: %s\n", commandline);
+  int result = system(commandline);
+  if (result != 0) {
+    fprintf(stderr,
+            "GPGPU-Sim PTX: ERROR ** while changing filename from %s to %s",
+            fname2, tempfile);
+    exit(1);
+  }
 
-	// store all of the ptx into a char array
-	FILE *ptxsource = fopen(tempfile,"r");
-	fseek(ptxsource, 0, SEEK_END);
-	long filesize = ftell(ptxsource);
-	rewind(ptxsource);
-	char *ptxdata = (char*)malloc((filesize+1)*sizeof(char));
-    // Fail if we do not read the file
-	assert(fread(ptxdata, filesize, 1, ptxsource) == 1);
-	fclose(ptxsource);
+  // store all of the ptx into a char array
+  FILE *ptxsource = fopen(tempfile, "r");
+  fseek(ptxsource, 0, SEEK_END);
+  long filesize = ftell(ptxsource);
+  rewind(ptxsource);
+  char *ptxdata = (char *)malloc((filesize + 1) * sizeof(char));
+  // Fail if we do not read the file
+  assert(fread(ptxdata, filesize, 1, ptxsource) == 1);
+  fclose(ptxsource);
 
-	FILE *ptxdest = fopen(fname2,"w");
-	std::map<unsigned,const char*> duplicate = get_duplicate();
-	unsigned offset;
-	unsigned oldlinenum = 1;
-	unsigned linenum;
-	char *startptr = ptxdata;
-	char *funcptr;
-	char *tempptr = ptxdata - 1;
-	char *lineptr = ptxdata - 1;
+  FILE *ptxdest = fopen(fname2, "w");
+  std::map<unsigned, const char *> duplicate = get_duplicate();
+  unsigned offset;
+  unsigned oldlinenum = 1;
+  unsigned linenum;
+  char *startptr = ptxdata;
+  char *funcptr;
+  char *tempptr = ptxdata - 1;
+  char *lineptr = ptxdata - 1;
 
-	// recreate the ptx file without duplications
-	for (	std::map<unsigned,const char*>::iterator iter = duplicate.begin();
-			iter != duplicate.end();
-			iter++){
-		// find the line of the next error
-		linenum = iter->first;
-		for (int i = oldlinenum; i < linenum; i++) {
-			lineptr = strchr(lineptr + 1, '\n');
-		}
-		
-		// find the end of the current section to be copied over
-		// then find the start of the next section that will be copied
-		if (strcmp("function", iter->second) == 0) {
-			// get location of most recent .func
-			while (tempptr < lineptr && tempptr != NULL) {
-				funcptr = tempptr;
-				tempptr = strstr(funcptr + 1, ".func");
-			}
+  // recreate the ptx file without duplications
+  for (std::map<unsigned, const char *>::iterator iter = duplicate.begin();
+       iter != duplicate.end(); iter++) {
+    // find the line of the next error
+    linenum = iter->first;
+    for (int i = oldlinenum; i < linenum; i++) {
+      lineptr = strchr(lineptr + 1, '\n');
+    }
 
-			// get the start of the previous line
-			offset = 0;
-			while (*(funcptr - offset) != '\n') offset++;
+    // find the end of the current section to be copied over
+    // then find the start of the next section that will be copied
+    if (strcmp("function", iter->second) == 0) {
+      // get location of most recent .func
+      while (tempptr < lineptr && tempptr != NULL) {
+        funcptr = tempptr;
+        tempptr = strstr(funcptr + 1, ".func");
+      }
 
-			fwrite(startptr, sizeof(char), funcptr - offset + 1 - startptr, ptxdest);
+      // get the start of the previous line
+      offset = 0;
+      while (*(funcptr - offset) != '\n') offset++;
 
-			//find next location of startptr
-			if (*(lineptr + 3) == ';') {
-				// for function definitions
-				startptr = lineptr + 5;
-			} else if (*(lineptr + 3) == '{') {
-				// for functions enclosed with curly brackets
-				offset = 5;
-				unsigned bracket = 1;
-				while (bracket != 0) {
-					if (*(lineptr + offset) == '{') bracket++;
-					else if (*(lineptr + offset) == '}') bracket--;
-					offset++;
-				}
-				startptr = lineptr + offset + 1;
-			} else {
-				printf("GPGPU-Sim PTX: ERROR ** Unrecognized function format\n");
-				abort();
-			}
-		} else if (strcmp("variable", iter->second) == 0) {
-			fwrite(startptr, sizeof(char), (int)(lineptr + 1 - startptr), ptxdest);
-			
-			//find next location of startptr
-			offset = 1;
-			while (*(lineptr + offset) != '\n') offset++;
-			startptr = lineptr + offset + 1;
-		} else {
-			printf("GPGPU-Sim PTX: ERROR ** Unsupported duplicate type: %s\n", iter->second);
-		}
+      fwrite(startptr, sizeof(char), funcptr - offset + 1 - startptr, ptxdest);
 
-		oldlinenum = linenum;
-	}
-	// copy over the rest of the file
-	fwrite(startptr, sizeof(char), ptxdata + filesize - startptr, ptxdest);
-
-	// cleanup
-	free(ptxdata);
-	fclose(ptxdest);
-	snprintf(commandline,1024,"rm -f %s",tempfile);
-	printf("Running: %s\n", commandline);
-	result = system(commandline);
-	if (result != 0) {
-		fprintf(stderr, "GPGPU-Sim PTX: ERROR ** while deleting %s", tempfile);
-		exit(1);
-	}
-}
-
-
-//we need the application name here too.
-char* get_app_binary_name(){
-   char exe_path[1025];
-   char *self_exe_path;
-#ifdef __APPLE__
-   //AMRUTH:  get apple device and check the result.
-   printf("WARNING: not tested for Apple-mac devices \n");
-   abort();
-#else
-   std::stringstream exec_link;
-   exec_link << "/proc/self/exe";
-   ssize_t path_length = readlink(exec_link.str().c_str(), exe_path, 1024);
-   assert(path_length != -1);
-   exe_path[path_length] = '\0';
-
-   char *token = strtok(exe_path, "/");
-   while(token !=NULL){
-        self_exe_path = token;
-        token = strtok(NULL,"/");
-   }
-#endif
-   self_exe_path = strtok(self_exe_path, ".");
-   printf("self exe links to: %s\n", self_exe_path);
-   return self_exe_path;
-}
-
-void gpgpu_context::gpgpu_ptx_info_load_from_filename( const char *filename, unsigned sm_version)
-{
-    std::string ptxas_filename(std::string(filename) + "as");
-    char buff[1024], extra_flags[1024];
-	extra_flags[0]=0;
-	if(!device_runtime->g_cdp_enabled)
-	       	snprintf(extra_flags,1024,"--gpu-name=sm_%u",sm_version);
-	else
-	       	snprintf(extra_flags,1024,"--compile-only --gpu-name=sm_%u",sm_version);
-   	snprintf(buff,1024,"$CUDA_INSTALL_PATH/bin/ptxas %s -v %s --output-file  /dev/null 2> %s",
-         extra_flags, filename, ptxas_filename.c_str());
-	int result = system(buff);
-	if( result != 0 ) {
-		printf("GPGPU-Sim PTX: ERROR ** while loading PTX (b) %d\n", result);
-		printf("               Ensure ptxas is in your path.\n");
-		exit(1);
-	}
-
-    FILE *ptxinfo_in;
-    ptxinfo->g_ptxinfo_filename = strdup(ptxas_filename.c_str());
-    ptxinfo_in = fopen(ptxinfo->g_ptxinfo_filename,"r");
-    ptxinfo_lex_init(&(ptxinfo->scanner));
-    ptxinfo_set_in(ptxinfo_in, ptxinfo->scanner);
-    ptxinfo_parse(ptxinfo->scanner, ptxinfo);
-    ptxinfo_lex_destroy(ptxinfo->scanner);
-    fclose(ptxinfo_in);
-}
-
-void gpgpu_context::gpgpu_ptxinfo_load_from_string( const char *p_for_info, unsigned source_num, unsigned sm_version, int no_of_ptx )
-{
-    //do ptxas for individual files instead of one big embedded ptx. This prevents the duplicate defs and declarations.
-    char ptx_file[1000];
-    char *name=get_app_binary_name();
-    char commandline[4096], fname[1024], fname2[1024], final_tempfile_ptxinfo[1024], tempfile_ptxinfo[1024];
-    for (int index=1; index <= no_of_ptx; index++){
-        snprintf(ptx_file, 1000, "%s.%d.sm_%u.ptx", name, index, sm_version);
-        snprintf(fname,1024,"_ptx_XXXXXX");
-        int fd=mkstemp(fname); 
-        close(fd);
-
-        printf("GPGPU-Sim PTX: extracting embedded .ptx to temporary file \"%s\"\n", fname);
-        snprintf(commandline,4096,"cat %s > %s",ptx_file, fname);
-        if (system(commandline) !=0) {
-            printf("ERROR: %s command failed\n", commandline);
-            exit(0);
+      // find next location of startptr
+      if (*(lineptr + 3) == ';') {
+        // for function definitions
+        startptr = lineptr + 5;
+      } else if (*(lineptr + 3) == '{') {
+        // for functions enclosed with curly brackets
+        offset = 5;
+        unsigned bracket = 1;
+        while (bracket != 0) {
+          if (*(lineptr + offset) == '{')
+            bracket++;
+          else if (*(lineptr + offset) == '}')
+            bracket--;
+          offset++;
         }
-	
-        snprintf(fname2,1024,"_ptx2_XXXXXX");
-        fd=mkstemp(fname2); 
-        close(fd);
-        char commandline2[4096];
-        snprintf(commandline2,4096,"cat %s | sed 's/.version 1.5/.version 1.4/' | sed 's/, texmode_independent//' | sed 's/\\(\\.extern \\.const\\[1\\] .b8 \\w\\+\\)\\[\\]/\\1\\[1\\]/' | sed 's/const\\[.\\]/const\\[0\\]/g' > %s", fname, fname2);
-        printf("Running: %s\n", commandline2);
-        int result = system(commandline2);
-        if( result != 0 ) {
-       	    printf("GPGPU-Sim PTX: ERROR ** while loading PTX (a) %d\n", result);
-       	    printf("               Ensure you have write access to simulation directory\n");
-       	    printf("               and have \'cat\' and \'sed\' in your path.\n");
-       	    exit(1);
-    	}
+        startptr = lineptr + offset + 1;
+      } else {
+        printf("GPGPU-Sim PTX: ERROR ** Unrecognized function format\n");
+        abort();
+      }
+    } else if (strcmp("variable", iter->second) == 0) {
+      fwrite(startptr, sizeof(char), (int)(lineptr + 1 - startptr), ptxdest);
 
-        snprintf(tempfile_ptxinfo,1024,"%sinfo",fname);
-        char extra_flags[1024];
-        extra_flags[0]=0;
+      // find next location of startptr
+      offset = 1;
+      while (*(lineptr + offset) != '\n') offset++;
+      startptr = lineptr + offset + 1;
+    } else {
+      printf("GPGPU-Sim PTX: ERROR ** Unsupported duplicate type: %s\n",
+             iter->second);
+    }
+
+    oldlinenum = linenum;
+  }
+  // copy over the rest of the file
+  fwrite(startptr, sizeof(char), ptxdata + filesize - startptr, ptxdest);
+
+  // cleanup
+  free(ptxdata);
+  fclose(ptxdest);
+  snprintf(commandline, 1024, "rm -f %s", tempfile);
+  printf("Running: %s\n", commandline);
+  result = system(commandline);
+  if (result != 0) {
+    fprintf(stderr, "GPGPU-Sim PTX: ERROR ** while deleting %s", tempfile);
+    exit(1);
+  }
+}
+
+// we need the application name here too.
+char *get_app_binary_name() {
+  char exe_path[1025];
+  char *self_exe_path;
+#ifdef __APPLE__
+  // AMRUTH:  get apple device and check the result.
+  printf("WARNING: not tested for Apple-mac devices \n");
+  abort();
+#else
+  std::stringstream exec_link;
+  exec_link << "/proc/self/exe";
+  ssize_t path_length = readlink(exec_link.str().c_str(), exe_path, 1024);
+  assert(path_length != -1);
+  exe_path[path_length] = '\0';
+
+  char *token = strtok(exe_path, "/");
+  while (token != NULL) {
+    self_exe_path = token;
+    token = strtok(NULL, "/");
+  }
+#endif
+  self_exe_path = strtok(self_exe_path, ".");
+  printf("self exe links to: %s\n", self_exe_path);
+  return self_exe_path;
+}
+
+void gpgpu_context::gpgpu_ptx_info_load_from_filename(const char *filename,
+                                                      unsigned sm_version) {
+  std::string ptxas_filename(std::string(filename) + "as");
+  char buff[1024], extra_flags[1024];
+  extra_flags[0] = 0;
+  if (!device_runtime->g_cdp_enabled)
+    snprintf(extra_flags, 1024, "--gpu-name=sm_%u", sm_version);
+  else
+    snprintf(extra_flags, 1024, "--compile-only --gpu-name=sm_%u", sm_version);
+  snprintf(
+      buff, 1024,
+      "$CUDA_INSTALL_PATH/bin/ptxas %s -v %s --output-file  /dev/null 2> %s",
+      extra_flags, filename, ptxas_filename.c_str());
+  int result = system(buff);
+  if (result != 0) {
+    printf("GPGPU-Sim PTX: ERROR ** while loading PTX (b) %d\n", result);
+    printf("               Ensure ptxas is in your path.\n");
+    exit(1);
+  }
+
+  FILE *ptxinfo_in;
+  ptxinfo->g_ptxinfo_filename = strdup(ptxas_filename.c_str());
+  ptxinfo_in = fopen(ptxinfo->g_ptxinfo_filename, "r");
+  ptxinfo_lex_init(&(ptxinfo->scanner));
+  ptxinfo_set_in(ptxinfo_in, ptxinfo->scanner);
+  ptxinfo_parse(ptxinfo->scanner, ptxinfo);
+  ptxinfo_lex_destroy(ptxinfo->scanner);
+  fclose(ptxinfo_in);
+}
+
+void gpgpu_context::gpgpu_ptxinfo_load_from_string(const char *p_for_info,
+                                                   unsigned source_num,
+                                                   unsigned sm_version,
+                                                   int no_of_ptx) {
+  // do ptxas for individual files instead of one big embedded ptx. This
+  // prevents the duplicate defs and declarations.
+  char ptx_file[1000];
+  char *name = get_app_binary_name();
+  char commandline[4096], fname[1024], fname2[1024],
+      final_tempfile_ptxinfo[1024], tempfile_ptxinfo[1024];
+  for (int index = 1; index <= no_of_ptx; index++) {
+    snprintf(ptx_file, 1000, "%s.%d.sm_%u.ptx", name, index, sm_version);
+    snprintf(fname, 1024, "_ptx_XXXXXX");
+    int fd = mkstemp(fname);
+    close(fd);
+
+    printf("GPGPU-Sim PTX: extracting embedded .ptx to temporary file \"%s\"\n",
+           fname);
+    snprintf(commandline, 4096, "cat %s > %s", ptx_file, fname);
+    if (system(commandline) != 0) {
+      printf("ERROR: %s command failed\n", commandline);
+      exit(0);
+    }
+
+    snprintf(fname2, 1024, "_ptx2_XXXXXX");
+    fd = mkstemp(fname2);
+    close(fd);
+    char commandline2[4096];
+    snprintf(commandline2, 4096,
+             "cat %s | sed 's/.version 1.5/.version 1.4/' | sed 's/, "
+             "texmode_independent//' | sed 's/\\(\\.extern \\.const\\[1\\] .b8 "
+             "\\w\\+\\)\\[\\]/\\1\\[1\\]/' | sed "
+             "'s/const\\[.\\]/const\\[0\\]/g' > %s",
+             fname, fname2);
+    printf("Running: %s\n", commandline2);
+    int result = system(commandline2);
+    if (result != 0) {
+      printf("GPGPU-Sim PTX: ERROR ** while loading PTX (a) %d\n", result);
+      printf(
+          "               Ensure you have write access to simulation "
+          "directory\n");
+      printf("               and have \'cat\' and \'sed\' in your path.\n");
+      exit(1);
+    }
+
+    snprintf(tempfile_ptxinfo, 1024, "%sinfo", fname);
+    char extra_flags[1024];
+    extra_flags[0] = 0;
 
 #if CUDART_VERSION >= 3000
-    if ( g_occupancy_sm_number == 0 ) {
-        fprintf( stderr, "gpgpusim.config must specify the sm version for the GPU that you use to compute occupancy \"-gpgpu_occupancy_sm_number XX\".\n"
-                         "The register file size is specifically tied to the sm version used to querry ptxas for register usage.\n"
-                         "A register size/SM mismatch may result in occupancy differences." );
-        exit(1);
+    if (g_occupancy_sm_number == 0) {
+      fprintf(
+          stderr,
+          "gpgpusim.config must specify the sm version for the GPU that you "
+          "use to compute occupancy \"-gpgpu_occupancy_sm_number XX\".\n"
+          "The register file size is specifically tied to the sm version used "
+          "to querry ptxas for register usage.\n"
+          "A register size/SM mismatch may result in occupancy differences.");
+      exit(1);
     }
-    if(!device_runtime->g_cdp_enabled)
-        snprintf(extra_flags,1024,"--gpu-name=sm_%u", g_occupancy_sm_number);
+    if (!device_runtime->g_cdp_enabled)
+      snprintf(extra_flags, 1024, "--gpu-name=sm_%u", g_occupancy_sm_number);
     else
-        snprintf(extra_flags,1024,"--compile-only --gpu-name=sm_%u",g_occupancy_sm_number);
+      snprintf(extra_flags, 1024, "--compile-only --gpu-name=sm_%u",
+               g_occupancy_sm_number);
 #endif
 
-    snprintf(commandline,1024,"$PTXAS_CUDA_INSTALL_PATH/bin/ptxas %s -v %s --output-file  /dev/null 2> %s",
+    snprintf(commandline, 1024,
+             "$PTXAS_CUDA_INSTALL_PATH/bin/ptxas %s -v %s --output-file  "
+             "/dev/null 2> %s",
              extra_flags, fname2, tempfile_ptxinfo);
     printf("GPGPU-Sim PTX: generating ptxinfo using \"%s\"\n", commandline);
     result = system(commandline);
-    if( result != 0 ) {
-    	// 65280 = duplicate errors
-    	if (result == 65280) {
-		FILE *ptxinfo_in;
-    		ptxinfo_in = fopen(tempfile_ptxinfo,"r");
-		ptxinfo->g_ptxinfo_filename = tempfile_ptxinfo;
-		ptxinfo_lex_init(&(ptxinfo->scanner));
-		ptxinfo_set_in(ptxinfo_in, ptxinfo->scanner);
-		ptxinfo_parse(ptxinfo->scanner, ptxinfo);
-		ptxinfo_lex_destroy(ptxinfo->scanner);
-		fclose(ptxinfo_in);
+    if (result != 0) {
+      // 65280 = duplicate errors
+      if (result == 65280) {
+        FILE *ptxinfo_in;
+        ptxinfo_in = fopen(tempfile_ptxinfo, "r");
+        ptxinfo->g_ptxinfo_filename = tempfile_ptxinfo;
+        ptxinfo_lex_init(&(ptxinfo->scanner));
+        ptxinfo_set_in(ptxinfo_in, ptxinfo->scanner);
+        ptxinfo_parse(ptxinfo->scanner, ptxinfo);
+        ptxinfo_lex_destroy(ptxinfo->scanner);
+        fclose(ptxinfo_in);
 
-    		fix_duplicate_errors(fname2);
-    		snprintf(commandline,1024,"$CUDA_INSTALL_PATH/bin/ptxas %s -v %s --output-file  /dev/null 2> %s",
-    			 extra_flags, fname2, tempfile_ptxinfo);
-    		printf("GPGPU-Sim PTX: regenerating ptxinfo using \"%s\"\n", commandline);
-    		result = system(commandline);
-	    }
-	    if (result != 0) {
-		printf("GPGPU-Sim PTX: ERROR ** while loading PTX (b) %d\n", result);
-		printf("               Ensure ptxas is in your path.\n");
-		exit(1);
-	    }
-    	}
+        fix_duplicate_errors(fname2);
+        snprintf(commandline, 1024,
+                 "$CUDA_INSTALL_PATH/bin/ptxas %s -v %s --output-file  "
+                 "/dev/null 2> %s",
+                 extra_flags, fname2, tempfile_ptxinfo);
+        printf("GPGPU-Sim PTX: regenerating ptxinfo using \"%s\"\n",
+               commandline);
+        result = system(commandline);
+      }
+      if (result != 0) {
+        printf("GPGPU-Sim PTX: ERROR ** while loading PTX (b) %d\n", result);
+        printf("               Ensure ptxas is in your path.\n");
+        exit(1);
+      }
     }
+  }
 
-    //TODO: duplicate code! move it into a function so that it can be reused!
-    if(no_of_ptx==0) {
-        //For CDP, we dump everything. So no_of_ptx will be 0.
-	snprintf(fname,1024,"_ptx_XXXXXX");
-	int fd=mkstemp(fname);
-	close(fd);
+  // TODO: duplicate code! move it into a function so that it can be reused!
+  if (no_of_ptx == 0) {
+    // For CDP, we dump everything. So no_of_ptx will be 0.
+    snprintf(fname, 1024, "_ptx_XXXXXX");
+    int fd = mkstemp(fname);
+    close(fd);
 
-	printf("GPGPU-Sim PTX: extracting embedded .ptx to temporary file \"%s\"\n", fname);
-	FILE *ptxfile = fopen(fname,"w");
-	fprintf(ptxfile,"%s", p_for_info);
-	fclose(ptxfile);
+    printf("GPGPU-Sim PTX: extracting embedded .ptx to temporary file \"%s\"\n",
+           fname);
+    FILE *ptxfile = fopen(fname, "w");
+    fprintf(ptxfile, "%s", p_for_info);
+    fclose(ptxfile);
 
-	snprintf(fname2,1024,"_ptx2_XXXXXX");
-	fd=mkstemp(fname2);
-	close(fd);
-	char commandline2[4096];
-	snprintf(commandline2,4096,"cat %s | sed 's/.version 1.5/.version 1.4/' | sed 's/, texmode_independent//' | sed 's/\\(\\.extern \\.const\\[1\\] .b8 \\w\\+\\)\\[\\]/\\1\\[1\\]/' | sed 's/const\\[.\\]/const\\[0\\]/g' > %s", fname, fname2);
-	printf("Running: %s\n", commandline2);
-	int result = system(commandline2);
-	if( result != 0 ) {
-		printf("GPGPU-Sim PTX: ERROR ** while loading PTX (a) %d\n", result);
-		printf("               Ensure you have write access to simulation directory\n");
-		printf("               and have \'cat\' and \'sed\' in your path.\n");
-		exit(1);
-	}
-	//char tempfile_ptxinfo[1024];
-	snprintf(tempfile_ptxinfo,1024,"%sinfo",fname);
-	char extra_flags[1024];
-	extra_flags[0]=0;
-
-	#if CUDART_VERSION >= 3000
-	if (sm_version == 0) sm_version = 20;
-	if(!device_runtime->g_cdp_enabled)
-	       	snprintf(extra_flags,1024,"--gpu-name=sm_%u",sm_version);
-	else
-	       	snprintf(extra_flags,1024,"--compile-only --gpu-name=sm_%u",sm_version);
-	#endif
-
-	snprintf(commandline,1024,"$CUDA_INSTALL_PATH/bin/ptxas %s -v %s --output-file  /dev/null 2> %s",
-			            extra_flags, fname2, tempfile_ptxinfo);
-	printf("GPGPU-Sim PTX: generating ptxinfo using \"%s\"\n", commandline);
-	fflush(stdout);
-	result = system(commandline);
-	if( result != 0 ) {
-		printf("GPGPU-Sim PTX: ERROR ** while loading PTX (b) %d\n", result);
-		printf("               Ensure ptxas is in your path.\n");
-		exit(1);
-	}
+    snprintf(fname2, 1024, "_ptx2_XXXXXX");
+    fd = mkstemp(fname2);
+    close(fd);
+    char commandline2[4096];
+    snprintf(commandline2, 4096,
+             "cat %s | sed 's/.version 1.5/.version 1.4/' | sed 's/, "
+             "texmode_independent//' | sed 's/\\(\\.extern \\.const\\[1\\] .b8 "
+             "\\w\\+\\)\\[\\]/\\1\\[1\\]/' | sed "
+             "'s/const\\[.\\]/const\\[0\\]/g' > %s",
+             fname, fname2);
+    printf("Running: %s\n", commandline2);
+    int result = system(commandline2);
+    if (result != 0) {
+      printf("GPGPU-Sim PTX: ERROR ** while loading PTX (a) %d\n", result);
+      printf(
+          "               Ensure you have write access to simulation "
+          "directory\n");
+      printf("               and have \'cat\' and \'sed\' in your path.\n");
+      exit(1);
     }
+    // char tempfile_ptxinfo[1024];
+    snprintf(tempfile_ptxinfo, 1024, "%sinfo", fname);
+    char extra_flags[1024];
+    extra_flags[0] = 0;
 
-    //Now that we got resource usage per kernel in a ptx file, we dump all into one file and pass it to rest of the code as usual.
-    if(no_of_ptx>0){
-        char commandline3[4096];
-        snprintf(final_tempfile_ptxinfo,1024,"f_tempfile_ptx");
-        snprintf(commandline3,4096, "cat *info > %s", final_tempfile_ptxinfo);
-        if (system(commandline3)!=0) {
-	    printf("ERROR: Either we dont have info files or cat is not working \n");
-            printf("ERROR: %s command failed\n",commandline3);
-	    exit(1);
-        }
-    }	
-
-    if(no_of_ptx>0)
-        ptxinfo->g_ptxinfo_filename = final_tempfile_ptxinfo;
+#if CUDART_VERSION >= 3000
+    if (sm_version == 0) sm_version = 20;
+    if (!device_runtime->g_cdp_enabled)
+      snprintf(extra_flags, 1024, "--gpu-name=sm_%u", sm_version);
     else
-	ptxinfo->g_ptxinfo_filename = tempfile_ptxinfo;
-    FILE *ptxinfo_in;
-    ptxinfo_in = fopen(ptxinfo->g_ptxinfo_filename,"r");
+      snprintf(extra_flags, 1024, "--compile-only --gpu-name=sm_%u",
+               sm_version);
+#endif
 
-    ptxinfo_lex_init(&(ptxinfo->scanner));
-    ptxinfo_set_in(ptxinfo_in, ptxinfo->scanner);
-    ptxinfo_parse(ptxinfo->scanner, ptxinfo);
-    ptxinfo_lex_destroy(ptxinfo->scanner);
-    fclose(ptxinfo_in);
+    snprintf(
+        commandline, 1024,
+        "$CUDA_INSTALL_PATH/bin/ptxas %s -v %s --output-file  /dev/null 2> %s",
+        extra_flags, fname2, tempfile_ptxinfo);
+    printf("GPGPU-Sim PTX: generating ptxinfo using \"%s\"\n", commandline);
+    fflush(stdout);
+    result = system(commandline);
+    if (result != 0) {
+      printf("GPGPU-Sim PTX: ERROR ** while loading PTX (b) %d\n", result);
+      printf("               Ensure ptxas is in your path.\n");
+      exit(1);
+    }
+  }
 
-    snprintf(commandline,1024,"rm -f *info");
-    if( system(commandline) != 0 ) {
-	    printf("GPGPU-Sim PTX: ERROR ** while removing temporary info files\n");
-	    exit(1);
+  // Now that we got resource usage per kernel in a ptx file, we dump all into
+  // one file and pass it to rest of the code as usual.
+  if (no_of_ptx > 0) {
+    char commandline3[4096];
+    snprintf(final_tempfile_ptxinfo, 1024, "f_tempfile_ptx");
+    snprintf(commandline3, 4096, "cat *info > %s", final_tempfile_ptxinfo);
+    if (system(commandline3) != 0) {
+      printf("ERROR: Either we dont have info files or cat is not working \n");
+      printf("ERROR: %s command failed\n", commandline3);
+      exit(1);
     }
-    if( ! g_save_embedded_ptx ) {
-	if(no_of_ptx>0)
-            snprintf(commandline,1024,"rm -f %s %s %s", fname, fname2, final_tempfile_ptxinfo);
-	else
-            snprintf(commandline,1024,"rm -f %s %s %s", fname, fname2, tempfile_ptxinfo);
-        printf("GPGPU-Sim PTX: removing ptxinfo using \"%s\"\n", commandline);
-        if( system(commandline) != 0 ) {
-    	    printf("GPGPU-Sim PTX: ERROR ** while removing temporary files\n");
-    	    exit(1);
-        }
+  }
+
+  if (no_of_ptx > 0)
+    ptxinfo->g_ptxinfo_filename = final_tempfile_ptxinfo;
+  else
+    ptxinfo->g_ptxinfo_filename = tempfile_ptxinfo;
+  FILE *ptxinfo_in;
+  ptxinfo_in = fopen(ptxinfo->g_ptxinfo_filename, "r");
+
+  ptxinfo_lex_init(&(ptxinfo->scanner));
+  ptxinfo_set_in(ptxinfo_in, ptxinfo->scanner);
+  ptxinfo_parse(ptxinfo->scanner, ptxinfo);
+  ptxinfo_lex_destroy(ptxinfo->scanner);
+  fclose(ptxinfo_in);
+
+  snprintf(commandline, 1024, "rm -f *info");
+  if (system(commandline) != 0) {
+    printf("GPGPU-Sim PTX: ERROR ** while removing temporary info files\n");
+    exit(1);
+  }
+  if (!g_save_embedded_ptx) {
+    if (no_of_ptx > 0)
+      snprintf(commandline, 1024, "rm -f %s %s %s", fname, fname2,
+               final_tempfile_ptxinfo);
+    else
+      snprintf(commandline, 1024, "rm -f %s %s %s", fname, fname2,
+               tempfile_ptxinfo);
+    printf("GPGPU-Sim PTX: removing ptxinfo using \"%s\"\n", commandline);
+    if (system(commandline) != 0) {
+      printf("GPGPU-Sim PTX: ERROR ** while removing temporary files\n");
+      exit(1);
     }
+  }
 }

--- a/src/cuda-sim/ptx_loader.cc
+++ b/src/cuda-sim/ptx_loader.cc
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -28,556 +26,503 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "ptx_loader.h"
-#include <dirent.h>
+#include "ptx_ir.h"
+#include "cuda-sim.h"
+#include "ptx_parser.h"
 #include <unistd.h>
+#include <dirent.h>
 #include <fstream>
 #include <sstream>
 #include "../../libcuda/gpgpu_context.h"
-#include "cuda-sim.h"
-#include "ptx_ir.h"
-#include "ptx_parser.h"
 
 /// extern prototypes
 
-extern int ptx_error(yyscan_t yyscanner, const char *s);
-extern int ptx_lex_init(yyscan_t *scanner);
-extern void ptx_set_in(FILE *_in_str, yyscan_t yyscanner);
-extern int ptx_parse(yyscan_t scanner, ptx_recognizer *recognizer);
+extern int ptx_error( yyscan_t yyscanner, const char *s );
+extern int ptx_lex_init(yyscan_t* scanner);
+extern void ptx_set_in(FILE * _in_str ,yyscan_t yyscanner );
+extern int ptx_parse(yyscan_t scanner, ptx_recognizer* recognizer);
 extern int ptx_lex_destroy(yyscan_t scanner);
-extern int ptx__scan_string(const char *, yyscan_t scanner);
+extern int ptx__scan_string(const char*, yyscan_t scanner);
 
-extern std::map<unsigned, const char *> get_duplicate();
+extern std::map<unsigned,const char*> get_duplicate();
 
-typedef void *yyscan_t;
-extern int ptxinfo_lex_init(yyscan_t *scanner);
-extern void ptxinfo_set_in(FILE *_in_str, yyscan_t yyscanner);
-extern int ptxinfo_parse(yyscan_t scanner, ptxinfo_data *ptxinfo);
+typedef void * yyscan_t;
+extern int ptxinfo_lex_init(yyscan_t* scanner);
+extern void ptxinfo_set_in  (FILE * _in_str ,yyscan_t yyscanner );
+extern int ptxinfo_parse(yyscan_t scanner, ptxinfo_data* ptxinfo);
 extern int ptxinfo_lex_destroy(yyscan_t scanner);
 
 static bool g_save_embedded_ptx;
 static int g_occupancy_sm_number;
 
-bool ptxinfo_data::keep_intermediate_files() {
-  return g_keep_intermediate_files;
+bool ptxinfo_data::keep_intermediate_files() {return g_keep_intermediate_files;}
+
+void gpgpu_context::ptx_reg_options(option_parser_t opp)
+{
+   option_parser_register(opp, "-save_embedded_ptx", OPT_BOOL, &g_save_embedded_ptx, 
+                "saves ptx files embedded in binary as <n>.ptx",
+                "0");
+   option_parser_register(opp, "-keep", OPT_BOOL, &(ptxinfo->g_keep_intermediate_files),
+                "keep intermediate files created by GPGPU-Sim when interfacing with external programs",
+                "0");
+   option_parser_register(opp, "-gpgpu_ptx_save_converted_ptxplus", OPT_BOOL,
+                &(ptxinfo->m_ptx_save_converted_ptxplus),
+                "Saved converted ptxplus to a file",
+                "0");
+   option_parser_register(opp, "-gpgpu_occupancy_sm_number", OPT_INT32, &g_occupancy_sm_number,
+                "The SM number to pass to ptxas when getting register usage for computing GPU occupancy. "
+                "This parameter is required in the config.",
+                "0");
 }
 
-void gpgpu_context::ptx_reg_options(option_parser_t opp) {
-  option_parser_register(opp, "-save_embedded_ptx", OPT_BOOL,
-                         &g_save_embedded_ptx,
-                         "saves ptx files embedded in binary as <n>.ptx", "0");
-  option_parser_register(opp, "-keep", OPT_BOOL,
-                         &(ptxinfo->g_keep_intermediate_files),
-                         "keep intermediate files created by GPGPU-Sim when "
-                         "interfacing with external programs",
-                         "0");
-  option_parser_register(opp, "-gpgpu_ptx_save_converted_ptxplus", OPT_BOOL,
-                         &(ptxinfo->m_ptx_save_converted_ptxplus),
-                         "Saved converted ptxplus to a file", "0");
-  option_parser_register(opp, "-gpgpu_occupancy_sm_number", OPT_INT32,
-                         &g_occupancy_sm_number,
-                         "The SM number to pass to ptxas when getting register "
-                         "usage for computing GPU occupancy. "
-                         "This parameter is required in the config.",
-                         "0");
+void gpgpu_context::print_ptx_file( const char *p, unsigned source_num, const char *filename )
+{
+   printf("\nGPGPU-Sim PTX: file _%u.ptx contents:\n\n", source_num );
+   char *s = strdup(p);
+   char *t = s;
+   unsigned n=1;
+   while ( *t != '\0'  ) {
+      char *u = t;
+      while ( (*u != '\n') && (*u != '\0') ) u++;
+      unsigned last = (*u == '\0');
+      *u = '\0';
+      const ptx_instruction *pI = ptx_parser->ptx_instruction_lookup(filename,n);
+      char pc[64];
+      if( pI && pI->get_PC() )
+         snprintf(pc,64,"%4u", pI->get_PC() );
+      else 
+         snprintf(pc,64,"    ");
+      printf("    _%u.ptx  %4u (pc=%s):  %s\n", source_num, n, pc, t );
+      if ( last ) break;
+      t = u+1;
+      n++;
+   }
+   free(s);
+   fflush(stdout);
 }
 
-void gpgpu_context::print_ptx_file(const char *p, unsigned source_num,
-                                   const char *filename) {
-  printf("\nGPGPU-Sim PTX: file _%u.ptx contents:\n\n", source_num);
-  char *s = strdup(p);
-  char *t = s;
-  unsigned n = 1;
-  while (*t != '\0') {
-    char *u = t;
-    while ((*u != '\n') && (*u != '\0')) u++;
-    unsigned last = (*u == '\0');
-    *u = '\0';
-    const ptx_instruction *pI = ptx_parser->ptx_instruction_lookup(filename, n);
-    char pc[64];
-    if (pI && pI->get_PC())
-      snprintf(pc, 64, "%4u", pI->get_PC());
-    else
-      snprintf(pc, 64, "    ");
-    printf("    _%u.ptx  %4u (pc=%s):  %s\n", source_num, n, pc, t);
-    if (last) break;
-    t = u + 1;
-    n++;
-  }
-  free(s);
-  fflush(stdout);
+char* ptxinfo_data::gpgpu_ptx_sim_convert_ptx_and_sass_to_ptxplus(const std::string ptxfilename, const std::string elffilename, const std::string sassfilename)
+{
+
+	printf("GPGPU-Sim PTX: converting EMBEDDED .ptx file to ptxplus \n");
+
+    char fname_ptxplus[1024];
+    snprintf(fname_ptxplus,1024,"_ptxplus_XXXXXX");
+    int fd4=mkstemp(fname_ptxplus);
+    close(fd4);
+
+	// Run cuobjdump_to_ptxplus
+	char commandline[1024];
+	int result;
+	snprintf(commandline, 1024, "$GPGPUSIM_ROOT/build/$GPGPUSIM_CONFIG/cuobjdump_to_ptxplus/cuobjdump_to_ptxplus %s %s %s %s",
+			ptxfilename.c_str(),
+			sassfilename.c_str(),
+			elffilename.c_str(),
+			fname_ptxplus);
+	fflush(stdout);
+	printf("GPGPU-Sim PTX: calling cuobjdump_to_ptxplus\ncommandline: %s\n", commandline);
+	result = system(commandline);
+	if(result){fprintf(stderr, "GPGPU-Sim PTX: ERROR ** could not execute %s\n", commandline); exit(1);}
+
+
+	// Get ptxplus from file
+	std::ifstream fileStream(fname_ptxplus, std::ios::in);
+	std::string text, line;
+	while(getline(fileStream,line)) {
+		text += (line + "\n");
+	}
+	fileStream.close();
+
+	char* ptxplus_str = new char [strlen(text.c_str())+1];
+	strcpy(ptxplus_str, text.c_str());
+
+	if (!m_ptx_save_converted_ptxplus){
+		char rm_commandline[1024];
+
+		snprintf(rm_commandline,1024,"rm -f %s", fname_ptxplus);
+
+		printf("GPGPU-Sim PTX: removing temporary files using \"%s\"\n", rm_commandline);
+		int rm_result = system(rm_commandline);
+		if( rm_result != 0 ) {
+			fprintf(stderr, "GPGPU-Sim PTX: ERROR ** while removing temporary files %d\n", rm_result);
+			exit(1);
+		}
+	}
+	printf("GPGPU-Sim PTX: DONE converting EMBEDDED .ptx file to ptxplus \n");
+
+	return ptxplus_str;
 }
 
-char *ptxinfo_data::gpgpu_ptx_sim_convert_ptx_and_sass_to_ptxplus(
-    const std::string ptxfilename, const std::string elffilename,
-    const std::string sassfilename) {
-  printf("GPGPU-Sim PTX: converting EMBEDDED .ptx file to ptxplus \n");
 
-  char fname_ptxplus[1024];
-  snprintf(fname_ptxplus, 1024, "_ptxplus_XXXXXX");
-  int fd4 = mkstemp(fname_ptxplus);
-  close(fd4);
-
-  // Run cuobjdump_to_ptxplus
-  char commandline[1024];
-  int result;
-  snprintf(commandline, 1024,
-           "$GPGPUSIM_ROOT/build/$GPGPUSIM_CONFIG/cuobjdump_to_ptxplus/"
-           "cuobjdump_to_ptxplus %s %s %s %s",
-           ptxfilename.c_str(), sassfilename.c_str(), elffilename.c_str(),
-           fname_ptxplus);
-  fflush(stdout);
-  printf("GPGPU-Sim PTX: calling cuobjdump_to_ptxplus\ncommandline: %s\n",
-         commandline);
-  result = system(commandline);
-  if (result) {
-    fprintf(stderr, "GPGPU-Sim PTX: ERROR ** could not execute %s\n",
-            commandline);
-    exit(1);
-  }
-
-  // Get ptxplus from file
-  std::ifstream fileStream(fname_ptxplus, std::ios::in);
-  std::string text, line;
-  while (getline(fileStream, line)) {
-    text += (line + "\n");
-  }
-  fileStream.close();
-
-  char *ptxplus_str = new char[strlen(text.c_str()) + 1];
-  strcpy(ptxplus_str, text.c_str());
-
-  if (!m_ptx_save_converted_ptxplus) {
-    char rm_commandline[1024];
-
-    snprintf(rm_commandline, 1024, "rm -f %s", fname_ptxplus);
-
-    printf("GPGPU-Sim PTX: removing temporary files using \"%s\"\n",
-           rm_commandline);
-    int rm_result = system(rm_commandline);
-    if (rm_result != 0) {
-      fprintf(stderr,
-              "GPGPU-Sim PTX: ERROR ** while removing temporary files %d\n",
-              rm_result);
-      exit(1);
+symbol_table *gpgpu_context::gpgpu_ptx_sim_load_ptx_from_string( const char *p, unsigned source_num )
+{
+    char buf[1024];
+    snprintf(buf,1024,"_%u.ptx", source_num );
+    if( g_save_embedded_ptx ) {
+       FILE *fp = fopen(buf,"w");
+       fprintf(fp,"%s",p);
+       fclose(fp);
     }
-  }
-  printf("GPGPU-Sim PTX: DONE converting EMBEDDED .ptx file to ptxplus \n");
+    symbol_table *symtab=init_parser(buf);
+    ptx_lex_init(&(ptx_parser->scanner));
+    ptx__scan_string(p, ptx_parser->scanner);
+    int errors = ptx_parse (ptx_parser->scanner, ptx_parser);
+    if ( errors ) {
+        char fname[1024];
+        snprintf(fname,1024,"_ptx_errors_XXXXXX");
+        int fd=mkstemp(fname); 
+        close(fd);
+        printf("GPGPU-Sim PTX: parser error detected, exiting... but first extracting .ptx to \"%s\"\n", fname);
+        FILE *ptxfile = fopen(fname,"w");
+        fprintf(ptxfile,"%s", p );
+        fclose(ptxfile);
+        abort();
+        exit(40);
+    }
+    ptx_lex_destroy(ptx_parser->scanner);
 
-  return ptxplus_str;
+    if ( g_debug_execution >= 100 ) 
+       print_ptx_file(p,source_num,buf);
+
+    printf("GPGPU-Sim PTX: finished parsing EMBEDDED .ptx file %s\n",buf);
+    return symtab;
 }
 
-symbol_table *gpgpu_context::gpgpu_ptx_sim_load_ptx_from_string(
-    const char *p, unsigned source_num) {
-  char buf[1024];
-  snprintf(buf, 1024, "_%u.ptx", source_num);
-  if (g_save_embedded_ptx) {
-    FILE *fp = fopen(buf, "w");
-    fprintf(fp, "%s", p);
-    fclose(fp);
-  }
-  symbol_table *symtab = init_parser(buf);
-  ptx_lex_init(&(ptx_parser->scanner));
-  ptx__scan_string(p, ptx_parser->scanner);
-  int errors = ptx_parse(ptx_parser->scanner, ptx_parser);
-  if (errors) {
-    char fname[1024];
-    snprintf(fname, 1024, "_ptx_errors_XXXXXX");
-    int fd = mkstemp(fname);
-    close(fd);
-    printf(
-        "GPGPU-Sim PTX: parser error detected, exiting... but first extracting "
-        ".ptx to \"%s\"\n",
-        fname);
-    FILE *ptxfile = fopen(fname, "w");
-    fprintf(ptxfile, "%s", p);
-    fclose(ptxfile);
-    abort();
-    exit(40);
-  }
-  ptx_lex_destroy(ptx_parser->scanner);
-
-  if (g_debug_execution >= 100) print_ptx_file(p, source_num, buf);
-
-  printf("GPGPU-Sim PTX: finished parsing EMBEDDED .ptx file %s\n", buf);
-  return symtab;
-}
-
-symbol_table *gpgpu_context::gpgpu_ptx_sim_load_ptx_from_filename(
-    const char *filename) {
-  symbol_table *symtab = init_parser(filename);
-  printf("GPGPU-Sim PTX: finished parsing EMBEDDED .ptx file %s\n", filename);
-  return symtab;
+symbol_table *gpgpu_context::gpgpu_ptx_sim_load_ptx_from_filename( const char *filename )
+{
+    symbol_table *symtab=init_parser(filename);
+    printf("GPGPU-Sim PTX: finished parsing EMBEDDED .ptx file %s\n",filename);
+    return symtab;
 }
 
 void fix_duplicate_errors(char fname2[1024]) {
-  char tempfile[1024] = "_temp_ptx";
-  char commandline[1024];
+	char tempfile[1024] = "_temp_ptx";
+	char commandline[1024];
 
-  // change the name of the ptx file to _temp_ptx
-  snprintf(commandline, 1024, "mv %s %s", fname2, tempfile);
-  printf("Running: %s\n", commandline);
-  int result = system(commandline);
-  if (result != 0) {
-    fprintf(stderr,
-            "GPGPU-Sim PTX: ERROR ** while changing filename from %s to %s",
-            fname2, tempfile);
-    exit(1);
-  }
+	// change the name of the ptx file to _temp_ptx
+	snprintf(commandline,1024,"mv %s %s",fname2,tempfile);
+	printf("Running: %s\n", commandline);
+	int result = system(commandline);
+	if (result != 0) {
+		fprintf(stderr, "GPGPU-Sim PTX: ERROR ** while changing filename from %s to %s", fname2, tempfile);
+		exit(1);
+	}
 
-  // store all of the ptx into a char array
-  FILE *ptxsource = fopen(tempfile, "r");
-  fseek(ptxsource, 0, SEEK_END);
-  long filesize = ftell(ptxsource);
-  rewind(ptxsource);
-  char *ptxdata = (char *)malloc((filesize + 1) * sizeof(char));
-  // Fail if we do not read the file
-  assert(fread(ptxdata, filesize, 1, ptxsource) == 1);
-  fclose(ptxsource);
+	// store all of the ptx into a char array
+	FILE *ptxsource = fopen(tempfile,"r");
+	fseek(ptxsource, 0, SEEK_END);
+	long filesize = ftell(ptxsource);
+	rewind(ptxsource);
+	char *ptxdata = (char*)malloc((filesize+1)*sizeof(char));
+    // Fail if we do not read the file
+	assert(fread(ptxdata, filesize, 1, ptxsource) == 1);
+	fclose(ptxsource);
 
-  FILE *ptxdest = fopen(fname2, "w");
-  std::map<unsigned, const char *> duplicate = get_duplicate();
-  unsigned offset;
-  unsigned oldlinenum = 1;
-  unsigned linenum;
-  char *startptr = ptxdata;
-  char *funcptr;
-  char *tempptr = ptxdata - 1;
-  char *lineptr = ptxdata - 1;
+	FILE *ptxdest = fopen(fname2,"w");
+	std::map<unsigned,const char*> duplicate = get_duplicate();
+	unsigned offset;
+	unsigned oldlinenum = 1;
+	unsigned linenum;
+	char *startptr = ptxdata;
+	char *funcptr;
+	char *tempptr = ptxdata - 1;
+	char *lineptr = ptxdata - 1;
 
-  // recreate the ptx file without duplications
-  for (std::map<unsigned, const char *>::iterator iter = duplicate.begin();
-       iter != duplicate.end(); iter++) {
-    // find the line of the next error
-    linenum = iter->first;
-    for (int i = oldlinenum; i < linenum; i++) {
-      lineptr = strchr(lineptr + 1, '\n');
-    }
+	// recreate the ptx file without duplications
+	for (	std::map<unsigned,const char*>::iterator iter = duplicate.begin();
+			iter != duplicate.end();
+			iter++){
+		// find the line of the next error
+		linenum = iter->first;
+		for (int i = oldlinenum; i < linenum; i++) {
+			lineptr = strchr(lineptr + 1, '\n');
+		}
+		
+		// find the end of the current section to be copied over
+		// then find the start of the next section that will be copied
+		if (strcmp("function", iter->second) == 0) {
+			// get location of most recent .func
+			while (tempptr < lineptr && tempptr != NULL) {
+				funcptr = tempptr;
+				tempptr = strstr(funcptr + 1, ".func");
+			}
 
-    // find the end of the current section to be copied over
-    // then find the start of the next section that will be copied
-    if (strcmp("function", iter->second) == 0) {
-      // get location of most recent .func
-      while (tempptr < lineptr && tempptr != NULL) {
-        funcptr = tempptr;
-        tempptr = strstr(funcptr + 1, ".func");
-      }
+			// get the start of the previous line
+			offset = 0;
+			while (*(funcptr - offset) != '\n') offset++;
 
-      // get the start of the previous line
-      offset = 0;
-      while (*(funcptr - offset) != '\n') offset++;
+			fwrite(startptr, sizeof(char), funcptr - offset + 1 - startptr, ptxdest);
 
-      fwrite(startptr, sizeof(char), funcptr - offset + 1 - startptr, ptxdest);
+			//find next location of startptr
+			if (*(lineptr + 3) == ';') {
+				// for function definitions
+				startptr = lineptr + 5;
+			} else if (*(lineptr + 3) == '{') {
+				// for functions enclosed with curly brackets
+				offset = 5;
+				unsigned bracket = 1;
+				while (bracket != 0) {
+					if (*(lineptr + offset) == '{') bracket++;
+					else if (*(lineptr + offset) == '}') bracket--;
+					offset++;
+				}
+				startptr = lineptr + offset + 1;
+			} else {
+				printf("GPGPU-Sim PTX: ERROR ** Unrecognized function format\n");
+				abort();
+			}
+		} else if (strcmp("variable", iter->second) == 0) {
+			fwrite(startptr, sizeof(char), (int)(lineptr + 1 - startptr), ptxdest);
+			
+			//find next location of startptr
+			offset = 1;
+			while (*(lineptr + offset) != '\n') offset++;
+			startptr = lineptr + offset + 1;
+		} else {
+			printf("GPGPU-Sim PTX: ERROR ** Unsupported duplicate type: %s\n", iter->second);
+		}
 
-      // find next location of startptr
-      if (*(lineptr + 3) == ';') {
-        // for function definitions
-        startptr = lineptr + 5;
-      } else if (*(lineptr + 3) == '{') {
-        // for functions enclosed with curly brackets
-        offset = 5;
-        unsigned bracket = 1;
-        while (bracket != 0) {
-          if (*(lineptr + offset) == '{')
-            bracket++;
-          else if (*(lineptr + offset) == '}')
-            bracket--;
-          offset++;
-        }
-        startptr = lineptr + offset + 1;
-      } else {
-        printf("GPGPU-Sim PTX: ERROR ** Unrecognized function format\n");
-        abort();
-      }
-    } else if (strcmp("variable", iter->second) == 0) {
-      fwrite(startptr, sizeof(char), (int)(lineptr + 1 - startptr), ptxdest);
+		oldlinenum = linenum;
+	}
+	// copy over the rest of the file
+	fwrite(startptr, sizeof(char), ptxdata + filesize - startptr, ptxdest);
 
-      // find next location of startptr
-      offset = 1;
-      while (*(lineptr + offset) != '\n') offset++;
-      startptr = lineptr + offset + 1;
-    } else {
-      printf("GPGPU-Sim PTX: ERROR ** Unsupported duplicate type: %s\n",
-             iter->second);
-    }
-
-    oldlinenum = linenum;
-  }
-  // copy over the rest of the file
-  fwrite(startptr, sizeof(char), ptxdata + filesize - startptr, ptxdest);
-
-  // cleanup
-  free(ptxdata);
-  fclose(ptxdest);
-  snprintf(commandline, 1024, "rm -f %s", tempfile);
-  printf("Running: %s\n", commandline);
-  result = system(commandline);
-  if (result != 0) {
-    fprintf(stderr, "GPGPU-Sim PTX: ERROR ** while deleting %s", tempfile);
-    exit(1);
-  }
+	// cleanup
+	free(ptxdata);
+	fclose(ptxdest);
+	snprintf(commandline,1024,"rm -f %s",tempfile);
+	printf("Running: %s\n", commandline);
+	result = system(commandline);
+	if (result != 0) {
+		fprintf(stderr, "GPGPU-Sim PTX: ERROR ** while deleting %s", tempfile);
+		exit(1);
+	}
 }
 
-// we need the application name here too.
-char *get_app_binary_name() {
-  char exe_path[1025];
-  char *self_exe_path;
+
+//we need the application name here too.
+char* get_app_binary_name(){
+   char exe_path[1025];
+   char *self_exe_path;
 #ifdef __APPLE__
-  // AMRUTH:  get apple device and check the result.
-  printf("WARNING: not tested for Apple-mac devices \n");
-  abort();
+   //AMRUTH:  get apple device and check the result.
+   printf("WARNING: not tested for Apple-mac devices \n");
+   abort();
 #else
-  std::stringstream exec_link;
-  exec_link << "/proc/self/exe";
-  ssize_t path_length = readlink(exec_link.str().c_str(), exe_path, 1024);
-  assert(path_length != -1);
-  exe_path[path_length] = '\0';
+   std::stringstream exec_link;
+   exec_link << "/proc/self/exe";
+   ssize_t path_length = readlink(exec_link.str().c_str(), exe_path, 1024);
+   assert(path_length != -1);
+   exe_path[path_length] = '\0';
 
-  char *token = strtok(exe_path, "/");
-  while (token != NULL) {
-    self_exe_path = token;
-    token = strtok(NULL, "/");
-  }
+   char *token = strtok(exe_path, "/");
+   while(token !=NULL){
+        self_exe_path = token;
+        token = strtok(NULL,"/");
+   }
 #endif
-  self_exe_path = strtok(self_exe_path, ".");
-  printf("self exe links to: %s\n", self_exe_path);
-  return self_exe_path;
+   self_exe_path = strtok(self_exe_path, ".");
+   printf("self exe links to: %s\n", self_exe_path);
+   return self_exe_path;
 }
 
-void gpgpu_context::gpgpu_ptx_info_load_from_filename(const char *filename,
-                                                      unsigned sm_version) {
-  std::string ptxas_filename(std::string(filename) + "as");
-  char buff[1024], extra_flags[1024];
-  extra_flags[0] = 0;
-  if (!device_runtime->g_cdp_enabled)
-    snprintf(extra_flags, 1024, "--gpu-name=sm_%u", sm_version);
-  else
-    snprintf(extra_flags, 1024, "--compile-only --gpu-name=sm_%u", sm_version);
-  snprintf(
-      buff, 1024,
-      "$CUDA_INSTALL_PATH/bin/ptxas %s -v %s --output-file  /dev/null 2> %s",
-      extra_flags, filename, ptxas_filename.c_str());
-  int result = system(buff);
-  if (result != 0) {
-    printf("GPGPU-Sim PTX: ERROR ** while loading PTX (b) %d\n", result);
-    printf("               Ensure ptxas is in your path.\n");
-    exit(1);
-  }
+void gpgpu_context::gpgpu_ptx_info_load_from_filename( const char *filename, unsigned sm_version)
+{
+    std::string ptxas_filename(std::string(filename) + "as");
+    char buff[1024], extra_flags[1024];
+	extra_flags[0]=0;
+	if(!device_runtime->g_cdp_enabled)
+	       	snprintf(extra_flags,1024,"--gpu-name=sm_%u",sm_version);
+	else
+	       	snprintf(extra_flags,1024,"--compile-only --gpu-name=sm_%u",sm_version);
+   	snprintf(buff,1024,"$CUDA_INSTALL_PATH/bin/ptxas %s -v %s --output-file  /dev/null 2> %s",
+         extra_flags, filename, ptxas_filename.c_str());
+	int result = system(buff);
+	if( result != 0 ) {
+		printf("GPGPU-Sim PTX: ERROR ** while loading PTX (b) %d\n", result);
+		printf("               Ensure ptxas is in your path.\n");
+		exit(1);
+	}
 
-  FILE *ptxinfo_in;
-  ptxinfo->g_ptxinfo_filename = strdup(ptxas_filename.c_str());
-  ptxinfo_in = fopen(ptxinfo->g_ptxinfo_filename, "r");
-  ptxinfo_lex_init(&(ptxinfo->scanner));
-  ptxinfo_set_in(ptxinfo_in, ptxinfo->scanner);
-  ptxinfo_parse(ptxinfo->scanner, ptxinfo);
-  ptxinfo_lex_destroy(ptxinfo->scanner);
-  fclose(ptxinfo_in);
+    FILE *ptxinfo_in;
+    ptxinfo->g_ptxinfo_filename = strdup(ptxas_filename.c_str());
+    ptxinfo_in = fopen(ptxinfo->g_ptxinfo_filename,"r");
+    ptxinfo_lex_init(&(ptxinfo->scanner));
+    ptxinfo_set_in(ptxinfo_in, ptxinfo->scanner);
+    ptxinfo_parse(ptxinfo->scanner, ptxinfo);
+    ptxinfo_lex_destroy(ptxinfo->scanner);
+    fclose(ptxinfo_in);
 }
 
-void gpgpu_context::gpgpu_ptxinfo_load_from_string(const char *p_for_info,
-                                                   unsigned source_num,
-                                                   unsigned sm_version,
-                                                   int no_of_ptx) {
-  // do ptxas for individual files instead of one big embedded ptx. This
-  // prevents the duplicate defs and declarations.
-  char ptx_file[1000];
-  char *name = get_app_binary_name();
-  char commandline[4096], fname[1024], fname2[1024],
-      final_tempfile_ptxinfo[1024], tempfile_ptxinfo[1024];
-  for (int index = 1; index <= no_of_ptx; index++) {
-    snprintf(ptx_file, 1000, "%s.%d.sm_%u.ptx", name, index, sm_version);
-    snprintf(fname, 1024, "_ptx_XXXXXX");
-    int fd = mkstemp(fname);
-    close(fd);
+void gpgpu_context::gpgpu_ptxinfo_load_from_string( const char *p_for_info, unsigned source_num, unsigned sm_version, int no_of_ptx )
+{
+    //do ptxas for individual files instead of one big embedded ptx. This prevents the duplicate defs and declarations.
+    char ptx_file[1000];
+    char *name=get_app_binary_name();
+    char commandline[4096], fname[1024], fname2[1024], final_tempfile_ptxinfo[1024], tempfile_ptxinfo[1024];
+    for (int index=1; index <= no_of_ptx; index++){
+        snprintf(ptx_file, 1000, "%s.%d.sm_%u.ptx", name, index, sm_version);
+        snprintf(fname,1024,"_ptx_XXXXXX");
+        int fd=mkstemp(fname); 
+        close(fd);
 
-    printf("GPGPU-Sim PTX: extracting embedded .ptx to temporary file \"%s\"\n",
-           fname);
-    snprintf(commandline, 4096, "cat %s > %s", ptx_file, fname);
-    if (system(commandline) != 0) {
-      printf("ERROR: %s command failed\n", commandline);
-      exit(0);
-    }
+        printf("GPGPU-Sim PTX: extracting embedded .ptx to temporary file \"%s\"\n", fname);
+        snprintf(commandline,4096,"cat %s > %s",ptx_file, fname);
+        if (system(commandline) !=0) {
+            printf("ERROR: %s command failed\n", commandline);
+            exit(0);
+        }
+	
+        snprintf(fname2,1024,"_ptx2_XXXXXX");
+        fd=mkstemp(fname2); 
+        close(fd);
+        char commandline2[4096];
+        snprintf(commandline2,4096,"cat %s | sed 's/.version 1.5/.version 1.4/' | sed 's/, texmode_independent//' | sed 's/\\(\\.extern \\.const\\[1\\] .b8 \\w\\+\\)\\[\\]/\\1\\[1\\]/' | sed 's/const\\[.\\]/const\\[0\\]/g' > %s", fname, fname2);
+        printf("Running: %s\n", commandline2);
+        int result = system(commandline2);
+        if( result != 0 ) {
+       	    printf("GPGPU-Sim PTX: ERROR ** while loading PTX (a) %d\n", result);
+       	    printf("               Ensure you have write access to simulation directory\n");
+       	    printf("               and have \'cat\' and \'sed\' in your path.\n");
+       	    exit(1);
+    	}
 
-    snprintf(fname2, 1024, "_ptx2_XXXXXX");
-    fd = mkstemp(fname2);
-    close(fd);
-    char commandline2[4096];
-    snprintf(commandline2, 4096,
-             "cat %s | sed 's/.version 1.5/.version 1.4/' | sed 's/, "
-             "texmode_independent//' | sed 's/\\(\\.extern \\.const\\[1\\] .b8 "
-             "\\w\\+\\)\\[\\]/\\1\\[1\\]/' | sed "
-             "'s/const\\[.\\]/const\\[0\\]/g' > %s",
-             fname, fname2);
-    printf("Running: %s\n", commandline2);
-    int result = system(commandline2);
-    if (result != 0) {
-      printf("GPGPU-Sim PTX: ERROR ** while loading PTX (a) %d\n", result);
-      printf(
-          "               Ensure you have write access to simulation "
-          "directory\n");
-      printf("               and have \'cat\' and \'sed\' in your path.\n");
-      exit(1);
-    }
-
-    snprintf(tempfile_ptxinfo, 1024, "%sinfo", fname);
-    char extra_flags[1024];
-    extra_flags[0] = 0;
+        snprintf(tempfile_ptxinfo,1024,"%sinfo",fname);
+        char extra_flags[1024];
+        extra_flags[0]=0;
 
 #if CUDART_VERSION >= 3000
-    if (g_occupancy_sm_number == 0) {
-      fprintf(
-          stderr,
-          "gpgpusim.config must specify the sm version for the GPU that you "
-          "use to compute occupancy \"-gpgpu_occupancy_sm_number XX\".\n"
-          "The register file size is specifically tied to the sm version used "
-          "to querry ptxas for register usage.\n"
-          "A register size/SM mismatch may result in occupancy differences.");
-      exit(1);
+    if ( g_occupancy_sm_number == 0 ) {
+        fprintf( stderr, "gpgpusim.config must specify the sm version for the GPU that you use to compute occupancy \"-gpgpu_occupancy_sm_number XX\".\n"
+                         "The register file size is specifically tied to the sm version used to querry ptxas for register usage.\n"
+                         "A register size/SM mismatch may result in occupancy differences." );
+        exit(1);
     }
-    if (!device_runtime->g_cdp_enabled)
-      snprintf(extra_flags, 1024, "--gpu-name=sm_%u", g_occupancy_sm_number);
+    if(!device_runtime->g_cdp_enabled)
+        snprintf(extra_flags,1024,"--gpu-name=sm_%u", g_occupancy_sm_number);
     else
-      snprintf(extra_flags, 1024, "--compile-only --gpu-name=sm_%u",
-               g_occupancy_sm_number);
+        snprintf(extra_flags,1024,"--compile-only --gpu-name=sm_%u",g_occupancy_sm_number);
 #endif
 
-    snprintf(commandline, 1024,
-             "$PTXAS_CUDA_INSTALL_PATH/bin/ptxas %s -v %s --output-file  "
-             "/dev/null 2> %s",
+    snprintf(commandline,1024,"$PTXAS_CUDA_INSTALL_PATH/bin/ptxas %s -v %s --output-file  /dev/null 2> %s",
              extra_flags, fname2, tempfile_ptxinfo);
     printf("GPGPU-Sim PTX: generating ptxinfo using \"%s\"\n", commandline);
     result = system(commandline);
-    if (result != 0) {
-      // 65280 = duplicate errors
-      if (result == 65280) {
-        FILE *ptxinfo_in;
-        ptxinfo_in = fopen(tempfile_ptxinfo, "r");
-        ptxinfo->g_ptxinfo_filename = tempfile_ptxinfo;
-        ptxinfo_lex_init(&(ptxinfo->scanner));
-        ptxinfo_set_in(ptxinfo_in, ptxinfo->scanner);
-        ptxinfo_parse(ptxinfo->scanner, ptxinfo);
-        ptxinfo_lex_destroy(ptxinfo->scanner);
-        fclose(ptxinfo_in);
+    if( result != 0 ) {
+    	// 65280 = duplicate errors
+    	if (result == 65280) {
+		FILE *ptxinfo_in;
+    		ptxinfo_in = fopen(tempfile_ptxinfo,"r");
+		ptxinfo->g_ptxinfo_filename = tempfile_ptxinfo;
+		ptxinfo_lex_init(&(ptxinfo->scanner));
+		ptxinfo_set_in(ptxinfo_in, ptxinfo->scanner);
+		ptxinfo_parse(ptxinfo->scanner, ptxinfo);
+		ptxinfo_lex_destroy(ptxinfo->scanner);
+		fclose(ptxinfo_in);
 
-        fix_duplicate_errors(fname2);
-        snprintf(commandline, 1024,
-                 "$CUDA_INSTALL_PATH/bin/ptxas %s -v %s --output-file  "
-                 "/dev/null 2> %s",
-                 extra_flags, fname2, tempfile_ptxinfo);
-        printf("GPGPU-Sim PTX: regenerating ptxinfo using \"%s\"\n",
-               commandline);
-        result = system(commandline);
-      }
-      if (result != 0) {
-        printf("GPGPU-Sim PTX: ERROR ** while loading PTX (b) %d\n", result);
-        printf("               Ensure ptxas is in your path.\n");
-        exit(1);
-      }
+    		fix_duplicate_errors(fname2);
+    		snprintf(commandline,1024,"$CUDA_INSTALL_PATH/bin/ptxas %s -v %s --output-file  /dev/null 2> %s",
+    			 extra_flags, fname2, tempfile_ptxinfo);
+    		printf("GPGPU-Sim PTX: regenerating ptxinfo using \"%s\"\n", commandline);
+    		result = system(commandline);
+	    }
+	    if (result != 0) {
+		printf("GPGPU-Sim PTX: ERROR ** while loading PTX (b) %d\n", result);
+		printf("               Ensure ptxas is in your path.\n");
+		exit(1);
+	    }
+    	}
     }
-  }
 
-  // TODO: duplicate code! move it into a function so that it can be reused!
-  if (no_of_ptx == 0) {
-    // For CDP, we dump everything. So no_of_ptx will be 0.
-    snprintf(fname, 1024, "_ptx_XXXXXX");
-    int fd = mkstemp(fname);
-    close(fd);
+    //TODO: duplicate code! move it into a function so that it can be reused!
+    if(no_of_ptx==0) {
+        //For CDP, we dump everything. So no_of_ptx will be 0.
+	snprintf(fname,1024,"_ptx_XXXXXX");
+	int fd=mkstemp(fname);
+	close(fd);
 
-    printf("GPGPU-Sim PTX: extracting embedded .ptx to temporary file \"%s\"\n",
-           fname);
-    FILE *ptxfile = fopen(fname, "w");
-    fprintf(ptxfile, "%s", p_for_info);
-    fclose(ptxfile);
+	printf("GPGPU-Sim PTX: extracting embedded .ptx to temporary file \"%s\"\n", fname);
+	FILE *ptxfile = fopen(fname,"w");
+	fprintf(ptxfile,"%s", p_for_info);
+	fclose(ptxfile);
 
-    snprintf(fname2, 1024, "_ptx2_XXXXXX");
-    fd = mkstemp(fname2);
-    close(fd);
-    char commandline2[4096];
-    snprintf(commandline2, 4096,
-             "cat %s | sed 's/.version 1.5/.version 1.4/' | sed 's/, "
-             "texmode_independent//' | sed 's/\\(\\.extern \\.const\\[1\\] .b8 "
-             "\\w\\+\\)\\[\\]/\\1\\[1\\]/' | sed "
-             "'s/const\\[.\\]/const\\[0\\]/g' > %s",
-             fname, fname2);
-    printf("Running: %s\n", commandline2);
-    int result = system(commandline2);
-    if (result != 0) {
-      printf("GPGPU-Sim PTX: ERROR ** while loading PTX (a) %d\n", result);
-      printf(
-          "               Ensure you have write access to simulation "
-          "directory\n");
-      printf("               and have \'cat\' and \'sed\' in your path.\n");
-      exit(1);
+	snprintf(fname2,1024,"_ptx2_XXXXXX");
+	fd=mkstemp(fname2);
+	close(fd);
+	char commandline2[4096];
+	snprintf(commandline2,4096,"cat %s | sed 's/.version 1.5/.version 1.4/' | sed 's/, texmode_independent//' | sed 's/\\(\\.extern \\.const\\[1\\] .b8 \\w\\+\\)\\[\\]/\\1\\[1\\]/' | sed 's/const\\[.\\]/const\\[0\\]/g' > %s", fname, fname2);
+	printf("Running: %s\n", commandline2);
+	int result = system(commandline2);
+	if( result != 0 ) {
+		printf("GPGPU-Sim PTX: ERROR ** while loading PTX (a) %d\n", result);
+		printf("               Ensure you have write access to simulation directory\n");
+		printf("               and have \'cat\' and \'sed\' in your path.\n");
+		exit(1);
+	}
+	//char tempfile_ptxinfo[1024];
+	snprintf(tempfile_ptxinfo,1024,"%sinfo",fname);
+	char extra_flags[1024];
+	extra_flags[0]=0;
+
+	#if CUDART_VERSION >= 3000
+	if (sm_version == 0) sm_version = 20;
+	if(!device_runtime->g_cdp_enabled)
+	       	snprintf(extra_flags,1024,"--gpu-name=sm_%u",sm_version);
+	else
+	       	snprintf(extra_flags,1024,"--compile-only --gpu-name=sm_%u",sm_version);
+	#endif
+
+	snprintf(commandline,1024,"$CUDA_INSTALL_PATH/bin/ptxas %s -v %s --output-file  /dev/null 2> %s",
+			            extra_flags, fname2, tempfile_ptxinfo);
+	printf("GPGPU-Sim PTX: generating ptxinfo using \"%s\"\n", commandline);
+	fflush(stdout);
+	result = system(commandline);
+	if( result != 0 ) {
+		printf("GPGPU-Sim PTX: ERROR ** while loading PTX (b) %d\n", result);
+		printf("               Ensure ptxas is in your path.\n");
+		exit(1);
+	}
     }
-    // char tempfile_ptxinfo[1024];
-    snprintf(tempfile_ptxinfo, 1024, "%sinfo", fname);
-    char extra_flags[1024];
-    extra_flags[0] = 0;
 
-#if CUDART_VERSION >= 3000
-    if (sm_version == 0) sm_version = 20;
-    if (!device_runtime->g_cdp_enabled)
-      snprintf(extra_flags, 1024, "--gpu-name=sm_%u", sm_version);
+    //Now that we got resource usage per kernel in a ptx file, we dump all into one file and pass it to rest of the code as usual.
+    if(no_of_ptx>0){
+        char commandline3[4096];
+        snprintf(final_tempfile_ptxinfo,1024,"f_tempfile_ptx");
+        snprintf(commandline3,4096, "cat *info > %s", final_tempfile_ptxinfo);
+        if (system(commandline3)!=0) {
+	    printf("ERROR: Either we dont have info files or cat is not working \n");
+            printf("ERROR: %s command failed\n",commandline3);
+	    exit(1);
+        }
+    }	
+
+    if(no_of_ptx>0)
+        ptxinfo->g_ptxinfo_filename = final_tempfile_ptxinfo;
     else
-      snprintf(extra_flags, 1024, "--compile-only --gpu-name=sm_%u",
-               sm_version);
-#endif
+	ptxinfo->g_ptxinfo_filename = tempfile_ptxinfo;
+    FILE *ptxinfo_in;
+    ptxinfo_in = fopen(ptxinfo->g_ptxinfo_filename,"r");
 
-    snprintf(
-        commandline, 1024,
-        "$CUDA_INSTALL_PATH/bin/ptxas %s -v %s --output-file  /dev/null 2> %s",
-        extra_flags, fname2, tempfile_ptxinfo);
-    printf("GPGPU-Sim PTX: generating ptxinfo using \"%s\"\n", commandline);
-    fflush(stdout);
-    result = system(commandline);
-    if (result != 0) {
-      printf("GPGPU-Sim PTX: ERROR ** while loading PTX (b) %d\n", result);
-      printf("               Ensure ptxas is in your path.\n");
-      exit(1);
+    ptxinfo_lex_init(&(ptxinfo->scanner));
+    ptxinfo_set_in(ptxinfo_in, ptxinfo->scanner);
+    ptxinfo_parse(ptxinfo->scanner, ptxinfo);
+    ptxinfo_lex_destroy(ptxinfo->scanner);
+    fclose(ptxinfo_in);
+
+    snprintf(commandline,1024,"rm -f *info");
+    if( system(commandline) != 0 ) {
+	    printf("GPGPU-Sim PTX: ERROR ** while removing temporary info files\n");
+	    exit(1);
     }
-  }
-
-  // Now that we got resource usage per kernel in a ptx file, we dump all into
-  // one file and pass it to rest of the code as usual.
-  if (no_of_ptx > 0) {
-    char commandline3[4096];
-    snprintf(final_tempfile_ptxinfo, 1024, "f_tempfile_ptx");
-    snprintf(commandline3, 4096, "cat *info > %s", final_tempfile_ptxinfo);
-    if (system(commandline3) != 0) {
-      printf("ERROR: Either we dont have info files or cat is not working \n");
-      printf("ERROR: %s command failed\n", commandline3);
-      exit(1);
+    if( ! g_save_embedded_ptx ) {
+	if(no_of_ptx>0)
+            snprintf(commandline,1024,"rm -f %s %s %s", fname, fname2, final_tempfile_ptxinfo);
+	else
+            snprintf(commandline,1024,"rm -f %s %s %s", fname, fname2, tempfile_ptxinfo);
+        printf("GPGPU-Sim PTX: removing ptxinfo using \"%s\"\n", commandline);
+        if( system(commandline) != 0 ) {
+    	    printf("GPGPU-Sim PTX: ERROR ** while removing temporary files\n");
+    	    exit(1);
+        }
     }
-  }
-
-  if (no_of_ptx > 0)
-    ptxinfo->g_ptxinfo_filename = final_tempfile_ptxinfo;
-  else
-    ptxinfo->g_ptxinfo_filename = tempfile_ptxinfo;
-  FILE *ptxinfo_in;
-  ptxinfo_in = fopen(ptxinfo->g_ptxinfo_filename, "r");
-
-  ptxinfo_lex_init(&(ptxinfo->scanner));
-  ptxinfo_set_in(ptxinfo_in, ptxinfo->scanner);
-  ptxinfo_parse(ptxinfo->scanner, ptxinfo);
-  ptxinfo_lex_destroy(ptxinfo->scanner);
-  fclose(ptxinfo_in);
-
-  snprintf(commandline, 1024, "rm -f *info");
-  if (system(commandline) != 0) {
-    printf("GPGPU-Sim PTX: ERROR ** while removing temporary info files\n");
-    exit(1);
-  }
-  if (!g_save_embedded_ptx) {
-    if (no_of_ptx > 0)
-      snprintf(commandline, 1024, "rm -f %s %s %s", fname, fname2,
-               final_tempfile_ptxinfo);
-    else
-      snprintf(commandline, 1024, "rm -f %s %s %s", fname, fname2,
-               tempfile_ptxinfo);
-    printf("GPGPU-Sim PTX: removing ptxinfo using \"%s\"\n", commandline);
-    if (system(commandline) != 0) {
-      printf("GPGPU-Sim PTX: ERROR ** while removing temporary files\n");
-      exit(1);
-    }
-  }
 }

--- a/src/cuda-sim/ptx_loader.cc
+++ b/src/cuda-sim/ptx_loader.cc
@@ -7,522 +7,576 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #include "ptx_loader.h"
-#include "ptx_ir.h"
-#include "cuda-sim.h"
-#include "ptx_parser.h"
-#include <unistd.h>
 #include <dirent.h>
+#include <unistd.h>
 #include <fstream>
 #include <sstream>
 #include "../../libcuda/gpgpu_context.h"
+#include "cuda-sim.h"
+#include "ptx_ir.h"
+#include "ptx_parser.h"
 
 /// extern prototypes
 
-extern int ptx_error( yyscan_t yyscanner, const char *s );
-extern int ptx_lex_init(yyscan_t* scanner);
-extern void ptx_set_in(FILE * _in_str ,yyscan_t yyscanner );
-extern int ptx_parse(yyscan_t scanner, ptx_recognizer* recognizer);
+extern int ptx_error(yyscan_t yyscanner, const char *s);
+extern int ptx_lex_init(yyscan_t *scanner);
+extern void ptx_set_in(FILE *_in_str, yyscan_t yyscanner);
+extern int ptx_parse(yyscan_t scanner, ptx_recognizer *recognizer);
 extern int ptx_lex_destroy(yyscan_t scanner);
-extern int ptx__scan_string(const char*, yyscan_t scanner);
+extern int ptx__scan_string(const char *, yyscan_t scanner);
 
-extern std::map<unsigned,const char*> get_duplicate();
+extern std::map<unsigned, const char *> get_duplicate();
 
-typedef void * yyscan_t;
-extern int ptxinfo_lex_init(yyscan_t* scanner);
-extern void ptxinfo_set_in  (FILE * _in_str ,yyscan_t yyscanner );
-extern int ptxinfo_parse(yyscan_t scanner, ptxinfo_data* ptxinfo);
+typedef void *yyscan_t;
+extern int ptxinfo_lex_init(yyscan_t *scanner);
+extern void ptxinfo_set_in(FILE *_in_str, yyscan_t yyscanner);
+extern int ptxinfo_parse(yyscan_t scanner, ptxinfo_data *ptxinfo);
 extern int ptxinfo_lex_destroy(yyscan_t scanner);
 
 static bool g_save_embedded_ptx;
 static int g_occupancy_sm_number;
 
-bool ptxinfo_data::keep_intermediate_files() {return g_keep_intermediate_files;}
-
-void gpgpu_context::ptx_reg_options(option_parser_t opp)
-{
-   option_parser_register(opp, "-save_embedded_ptx", OPT_BOOL, &g_save_embedded_ptx, 
-                "saves ptx files embedded in binary as <n>.ptx",
-                "0");
-   option_parser_register(opp, "-keep", OPT_BOOL, &(ptxinfo->g_keep_intermediate_files),
-                "keep intermediate files created by GPGPU-Sim when interfacing with external programs",
-                "0");
-   option_parser_register(opp, "-gpgpu_ptx_save_converted_ptxplus", OPT_BOOL,
-                &(ptxinfo->m_ptx_save_converted_ptxplus),
-                "Saved converted ptxplus to a file",
-                "0");
-   option_parser_register(opp, "-gpgpu_occupancy_sm_number", OPT_INT32, &g_occupancy_sm_number,
-                "The SM number to pass to ptxas when getting register usage for computing GPU occupancy. "
-                "This parameter is required in the config.",
-                "0");
+bool ptxinfo_data::keep_intermediate_files() {
+  return g_keep_intermediate_files;
 }
 
-void gpgpu_context::print_ptx_file( const char *p, unsigned source_num, const char *filename )
-{
-   printf("\nGPGPU-Sim PTX: file _%u.ptx contents:\n\n", source_num );
-   char *s = strdup(p);
-   char *t = s;
-   unsigned n=1;
-   while ( *t != '\0'  ) {
-      char *u = t;
-      while ( (*u != '\n') && (*u != '\0') ) u++;
-      unsigned last = (*u == '\0');
-      *u = '\0';
-      const ptx_instruction *pI = ptx_parser->ptx_instruction_lookup(filename,n);
-      char pc[64];
-      if( pI && pI->get_PC() )
-         snprintf(pc,64,"%4u", pI->get_PC() );
-      else 
-         snprintf(pc,64,"    ");
-      printf("    _%u.ptx  %4u (pc=%s):  %s\n", source_num, n, pc, t );
-      if ( last ) break;
-      t = u+1;
-      n++;
-   }
-   free(s);
-   fflush(stdout);
+void gpgpu_context::ptx_reg_options(option_parser_t opp) {
+  option_parser_register(opp, "-save_embedded_ptx", OPT_BOOL,
+                         &g_save_embedded_ptx,
+                         "saves ptx files embedded in binary as <n>.ptx", "0");
+  option_parser_register(opp, "-keep", OPT_BOOL,
+                         &(ptxinfo->g_keep_intermediate_files),
+                         "keep intermediate files created by GPGPU-Sim when "
+                         "interfacing with external programs",
+                         "0");
+  option_parser_register(opp, "-gpgpu_ptx_save_converted_ptxplus", OPT_BOOL,
+                         &(ptxinfo->m_ptx_save_converted_ptxplus),
+                         "Saved converted ptxplus to a file", "0");
+  option_parser_register(opp, "-gpgpu_occupancy_sm_number", OPT_INT32,
+                         &g_occupancy_sm_number,
+                         "The SM number to pass to ptxas when getting register "
+                         "usage for computing GPU occupancy. "
+                         "This parameter is required in the config.",
+                         "0");
 }
 
-char* ptxinfo_data::gpgpu_ptx_sim_convert_ptx_and_sass_to_ptxplus(const std::string ptxfilename, const std::string elffilename, const std::string sassfilename)
-{
-
-	printf("GPGPU-Sim PTX: converting EMBEDDED .ptx file to ptxplus \n");
-
-    char fname_ptxplus[1024];
-    snprintf(fname_ptxplus,1024,"_ptxplus_XXXXXX");
-    int fd4=mkstemp(fname_ptxplus);
-    close(fd4);
-
-	// Run cuobjdump_to_ptxplus
-	char commandline[1024];
-	int result;
-	snprintf(commandline, 1024, "$GPGPUSIM_ROOT/build/$GPGPUSIM_CONFIG/cuobjdump_to_ptxplus/cuobjdump_to_ptxplus %s %s %s %s",
-			ptxfilename.c_str(),
-			sassfilename.c_str(),
-			elffilename.c_str(),
-			fname_ptxplus);
-	fflush(stdout);
-	printf("GPGPU-Sim PTX: calling cuobjdump_to_ptxplus\ncommandline: %s\n", commandline);
-	result = system(commandline);
-	if(result){fprintf(stderr, "GPGPU-Sim PTX: ERROR ** could not execute %s\n", commandline); exit(1);}
-
-
-	// Get ptxplus from file
-	std::ifstream fileStream(fname_ptxplus, std::ios::in);
-	std::string text, line;
-	while(getline(fileStream,line)) {
-		text += (line + "\n");
-	}
-	fileStream.close();
-
-	char* ptxplus_str = new char [strlen(text.c_str())+1];
-	strcpy(ptxplus_str, text.c_str());
-
-	if (!m_ptx_save_converted_ptxplus){
-		char rm_commandline[1024];
-
-		snprintf(rm_commandline,1024,"rm -f %s", fname_ptxplus);
-
-		printf("GPGPU-Sim PTX: removing temporary files using \"%s\"\n", rm_commandline);
-		int rm_result = system(rm_commandline);
-		if( rm_result != 0 ) {
-			fprintf(stderr, "GPGPU-Sim PTX: ERROR ** while removing temporary files %d\n", rm_result);
-			exit(1);
-		}
-	}
-	printf("GPGPU-Sim PTX: DONE converting EMBEDDED .ptx file to ptxplus \n");
-
-	return ptxplus_str;
+void gpgpu_context::print_ptx_file(const char *p, unsigned source_num,
+                                   const char *filename) {
+  printf("\nGPGPU-Sim PTX: file _%u.ptx contents:\n\n", source_num);
+  char *s = strdup(p);
+  char *t = s;
+  unsigned n = 1;
+  while (*t != '\0') {
+    char *u = t;
+    while ((*u != '\n') && (*u != '\0')) u++;
+    unsigned last = (*u == '\0');
+    *u = '\0';
+    const ptx_instruction *pI = ptx_parser->ptx_instruction_lookup(filename, n);
+    char pc[64];
+    if (pI && pI->get_PC())
+      snprintf(pc, 64, "%4u", pI->get_PC());
+    else
+      snprintf(pc, 64, "    ");
+    printf("    _%u.ptx  %4u (pc=%s):  %s\n", source_num, n, pc, t);
+    if (last) break;
+    t = u + 1;
+    n++;
+  }
+  free(s);
+  fflush(stdout);
 }
 
+char *ptxinfo_data::gpgpu_ptx_sim_convert_ptx_and_sass_to_ptxplus(
+    const std::string ptxfilename, const std::string elffilename,
+    const std::string sassfilename) {
+  printf("GPGPU-Sim PTX: converting EMBEDDED .ptx file to ptxplus \n");
 
-symbol_table *gpgpu_context::gpgpu_ptx_sim_load_ptx_from_string( const char *p, unsigned source_num )
-{
-    char buf[1024];
-    snprintf(buf,1024,"_%u.ptx", source_num );
-    if( g_save_embedded_ptx ) {
-       FILE *fp = fopen(buf,"w");
-       fprintf(fp,"%s",p);
-       fclose(fp);
+  char fname_ptxplus[1024];
+  snprintf(fname_ptxplus, 1024, "_ptxplus_XXXXXX");
+  int fd4 = mkstemp(fname_ptxplus);
+  close(fd4);
+
+  // Run cuobjdump_to_ptxplus
+  char commandline[1024];
+  int result;
+  snprintf(commandline, 1024,
+           "$GPGPUSIM_ROOT/build/$GPGPUSIM_CONFIG/cuobjdump_to_ptxplus/"
+           "cuobjdump_to_ptxplus %s %s %s %s",
+           ptxfilename.c_str(), sassfilename.c_str(), elffilename.c_str(),
+           fname_ptxplus);
+  fflush(stdout);
+  printf("GPGPU-Sim PTX: calling cuobjdump_to_ptxplus\ncommandline: %s\n",
+         commandline);
+  result = system(commandline);
+  if (result) {
+    fprintf(stderr, "GPGPU-Sim PTX: ERROR ** could not execute %s\n",
+            commandline);
+    exit(1);
+  }
+
+  // Get ptxplus from file
+  std::ifstream fileStream(fname_ptxplus, std::ios::in);
+  std::string text, line;
+  while (getline(fileStream, line)) {
+    text += (line + "\n");
+  }
+  fileStream.close();
+
+  char *ptxplus_str = new char[strlen(text.c_str()) + 1];
+  strcpy(ptxplus_str, text.c_str());
+
+  if (!m_ptx_save_converted_ptxplus) {
+    char rm_commandline[1024];
+
+    snprintf(rm_commandline, 1024, "rm -f %s", fname_ptxplus);
+
+    printf("GPGPU-Sim PTX: removing temporary files using \"%s\"\n",
+           rm_commandline);
+    int rm_result = system(rm_commandline);
+    if (rm_result != 0) {
+      fprintf(stderr,
+              "GPGPU-Sim PTX: ERROR ** while removing temporary files %d\n",
+              rm_result);
+      exit(1);
     }
-    symbol_table *symtab=init_parser(buf);
-    ptx_lex_init(&(ptx_parser->scanner));
-    ptx__scan_string(p, ptx_parser->scanner);
-    int errors = ptx_parse (ptx_parser->scanner, ptx_parser);
-    if ( errors ) {
-        char fname[1024];
-        snprintf(fname,1024,"_ptx_errors_XXXXXX");
-        int fd=mkstemp(fname); 
-        close(fd);
-        printf("GPGPU-Sim PTX: parser error detected, exiting... but first extracting .ptx to \"%s\"\n", fname);
-        FILE *ptxfile = fopen(fname,"w");
-        fprintf(ptxfile,"%s", p );
-        fclose(ptxfile);
-        abort();
-        exit(40);
-    }
-    ptx_lex_destroy(ptx_parser->scanner);
+  }
+  printf("GPGPU-Sim PTX: DONE converting EMBEDDED .ptx file to ptxplus \n");
 
-    if ( g_debug_execution >= 100 ) 
-       print_ptx_file(p,source_num,buf);
-
-    printf("GPGPU-Sim PTX: finished parsing EMBEDDED .ptx file %s\n",buf);
-    return symtab;
+  return ptxplus_str;
 }
 
-symbol_table *gpgpu_context::gpgpu_ptx_sim_load_ptx_from_filename( const char *filename )
-{
-    symbol_table *symtab=init_parser(filename);
-    printf("GPGPU-Sim PTX: finished parsing EMBEDDED .ptx file %s\n",filename);
-    return symtab;
+symbol_table *gpgpu_context::gpgpu_ptx_sim_load_ptx_from_string(
+    const char *p, unsigned source_num) {
+  char buf[1024];
+  snprintf(buf, 1024, "_%u.ptx", source_num);
+  if (g_save_embedded_ptx) {
+    FILE *fp = fopen(buf, "w");
+    fprintf(fp, "%s", p);
+    fclose(fp);
+  }
+  symbol_table *symtab = init_parser(buf);
+  ptx_lex_init(&(ptx_parser->scanner));
+  ptx__scan_string(p, ptx_parser->scanner);
+  int errors = ptx_parse(ptx_parser->scanner, ptx_parser);
+  if (errors) {
+    char fname[1024];
+    snprintf(fname, 1024, "_ptx_errors_XXXXXX");
+    int fd = mkstemp(fname);
+    close(fd);
+    printf(
+        "GPGPU-Sim PTX: parser error detected, exiting... but first extracting "
+        ".ptx to \"%s\"\n",
+        fname);
+    FILE *ptxfile = fopen(fname, "w");
+    fprintf(ptxfile, "%s", p);
+    fclose(ptxfile);
+    abort();
+    exit(40);
+  }
+  ptx_lex_destroy(ptx_parser->scanner);
+
+  if (g_debug_execution >= 100) print_ptx_file(p, source_num, buf);
+
+  printf("GPGPU-Sim PTX: finished parsing EMBEDDED .ptx file %s\n", buf);
+  return symtab;
+}
+
+symbol_table *gpgpu_context::gpgpu_ptx_sim_load_ptx_from_filename(
+    const char *filename) {
+  symbol_table *symtab = init_parser(filename);
+  printf("GPGPU-Sim PTX: finished parsing EMBEDDED .ptx file %s\n", filename);
+  return symtab;
 }
 
 void fix_duplicate_errors(char fname2[1024]) {
-	char tempfile[1024] = "_temp_ptx";
-	char commandline[1024];
+  char tempfile[1024] = "_temp_ptx";
+  char commandline[1024];
 
-	// change the name of the ptx file to _temp_ptx
-	snprintf(commandline,1024,"mv %s %s",fname2,tempfile);
-	printf("Running: %s\n", commandline);
-	int result = system(commandline);
-	if (result != 0) {
-		fprintf(stderr, "GPGPU-Sim PTX: ERROR ** while changing filename from %s to %s", fname2, tempfile);
-		exit(1);
-	}
+  // change the name of the ptx file to _temp_ptx
+  snprintf(commandline, 1024, "mv %s %s", fname2, tempfile);
+  printf("Running: %s\n", commandline);
+  int result = system(commandline);
+  if (result != 0) {
+    fprintf(stderr,
+            "GPGPU-Sim PTX: ERROR ** while changing filename from %s to %s",
+            fname2, tempfile);
+    exit(1);
+  }
 
-	// store all of the ptx into a char array
-	FILE *ptxsource = fopen(tempfile,"r");
-	fseek(ptxsource, 0, SEEK_END);
-	long filesize = ftell(ptxsource);
-	rewind(ptxsource);
-	char *ptxdata = (char*)malloc((filesize+1)*sizeof(char));
-    // Fail if we do not read the file
-	assert(fread(ptxdata, filesize, 1, ptxsource) == 1);
-	fclose(ptxsource);
+  // store all of the ptx into a char array
+  FILE *ptxsource = fopen(tempfile, "r");
+  fseek(ptxsource, 0, SEEK_END);
+  long filesize = ftell(ptxsource);
+  rewind(ptxsource);
+  char *ptxdata = (char *)malloc((filesize + 1) * sizeof(char));
+  // Fail if we do not read the file
+  assert(fread(ptxdata, filesize, 1, ptxsource) == 1);
+  fclose(ptxsource);
 
-	FILE *ptxdest = fopen(fname2,"w");
-	std::map<unsigned,const char*> duplicate = get_duplicate();
-	unsigned offset;
-	unsigned oldlinenum = 1;
-	unsigned linenum;
-	char *startptr = ptxdata;
-	char *funcptr;
-	char *tempptr = ptxdata - 1;
-	char *lineptr = ptxdata - 1;
+  FILE *ptxdest = fopen(fname2, "w");
+  std::map<unsigned, const char *> duplicate = get_duplicate();
+  unsigned offset;
+  unsigned oldlinenum = 1;
+  unsigned linenum;
+  char *startptr = ptxdata;
+  char *funcptr;
+  char *tempptr = ptxdata - 1;
+  char *lineptr = ptxdata - 1;
 
-	// recreate the ptx file without duplications
-	for (	std::map<unsigned,const char*>::iterator iter = duplicate.begin();
-			iter != duplicate.end();
-			iter++){
-		// find the line of the next error
-		linenum = iter->first;
-		for (int i = oldlinenum; i < linenum; i++) {
-			lineptr = strchr(lineptr + 1, '\n');
-		}
-		
-		// find the end of the current section to be copied over
-		// then find the start of the next section that will be copied
-		if (strcmp("function", iter->second) == 0) {
-			// get location of most recent .func
-			while (tempptr < lineptr && tempptr != NULL) {
-				funcptr = tempptr;
-				tempptr = strstr(funcptr + 1, ".func");
-			}
+  // recreate the ptx file without duplications
+  for (std::map<unsigned, const char *>::iterator iter = duplicate.begin();
+       iter != duplicate.end(); iter++) {
+    // find the line of the next error
+    linenum = iter->first;
+    for (int i = oldlinenum; i < linenum; i++) {
+      lineptr = strchr(lineptr + 1, '\n');
+    }
 
-			// get the start of the previous line
-			offset = 0;
-			while (*(funcptr - offset) != '\n') offset++;
+    // find the end of the current section to be copied over
+    // then find the start of the next section that will be copied
+    if (strcmp("function", iter->second) == 0) {
+      // get location of most recent .func
+      while (tempptr < lineptr && tempptr != NULL) {
+        funcptr = tempptr;
+        tempptr = strstr(funcptr + 1, ".func");
+      }
 
-			fwrite(startptr, sizeof(char), funcptr - offset + 1 - startptr, ptxdest);
+      // get the start of the previous line
+      offset = 0;
+      while (*(funcptr - offset) != '\n') offset++;
 
-			//find next location of startptr
-			if (*(lineptr + 3) == ';') {
-				// for function definitions
-				startptr = lineptr + 5;
-			} else if (*(lineptr + 3) == '{') {
-				// for functions enclosed with curly brackets
-				offset = 5;
-				unsigned bracket = 1;
-				while (bracket != 0) {
-					if (*(lineptr + offset) == '{') bracket++;
-					else if (*(lineptr + offset) == '}') bracket--;
-					offset++;
-				}
-				startptr = lineptr + offset + 1;
-			} else {
-				printf("GPGPU-Sim PTX: ERROR ** Unrecognized function format\n");
-				abort();
-			}
-		} else if (strcmp("variable", iter->second) == 0) {
-			fwrite(startptr, sizeof(char), (int)(lineptr + 1 - startptr), ptxdest);
-			
-			//find next location of startptr
-			offset = 1;
-			while (*(lineptr + offset) != '\n') offset++;
-			startptr = lineptr + offset + 1;
-		} else {
-			printf("GPGPU-Sim PTX: ERROR ** Unsupported duplicate type: %s\n", iter->second);
-		}
+      fwrite(startptr, sizeof(char), funcptr - offset + 1 - startptr, ptxdest);
 
-		oldlinenum = linenum;
-	}
-	// copy over the rest of the file
-	fwrite(startptr, sizeof(char), ptxdata + filesize - startptr, ptxdest);
-
-	// cleanup
-	free(ptxdata);
-	fclose(ptxdest);
-	snprintf(commandline,1024,"rm -f %s",tempfile);
-	printf("Running: %s\n", commandline);
-	result = system(commandline);
-	if (result != 0) {
-		fprintf(stderr, "GPGPU-Sim PTX: ERROR ** while deleting %s", tempfile);
-		exit(1);
-	}
-}
-
-
-//we need the application name here too.
-char* get_app_binary_name(){
-   char exe_path[1025];
-   char *self_exe_path;
-#ifdef __APPLE__
-   //AMRUTH:  get apple device and check the result.
-   printf("WARNING: not tested for Apple-mac devices \n");
-   abort();
-#else
-   std::stringstream exec_link;
-   exec_link << "/proc/self/exe";
-   ssize_t path_length = readlink(exec_link.str().c_str(), exe_path, 1024);
-   assert(path_length != -1);
-   exe_path[path_length] = '\0';
-
-   char *token = strtok(exe_path, "/");
-   while(token !=NULL){
-        self_exe_path = token;
-        token = strtok(NULL,"/");
-   }
-#endif
-   self_exe_path = strtok(self_exe_path, ".");
-   printf("self exe links to: %s\n", self_exe_path);
-   return self_exe_path;
-}
-
-void gpgpu_context::gpgpu_ptx_info_load_from_filename( const char *filename, unsigned sm_version)
-{
-    std::string ptxas_filename(std::string(filename) + "as");
-    char buff[1024], extra_flags[1024];
-	extra_flags[0]=0;
-	if(!device_runtime->g_cdp_enabled)
-	       	snprintf(extra_flags,1024,"--gpu-name=sm_%u",sm_version);
-	else
-	       	snprintf(extra_flags,1024,"--compile-only --gpu-name=sm_%u",sm_version);
-   	snprintf(buff,1024,"$CUDA_INSTALL_PATH/bin/ptxas %s -v %s --output-file  /dev/null 2> %s",
-         extra_flags, filename, ptxas_filename.c_str());
-	int result = system(buff);
-	if( result != 0 ) {
-		printf("GPGPU-Sim PTX: ERROR ** while loading PTX (b) %d\n", result);
-		printf("               Ensure ptxas is in your path.\n");
-		exit(1);
-	}
-
-    FILE *ptxinfo_in;
-    ptxinfo->g_ptxinfo_filename = strdup(ptxas_filename.c_str());
-    ptxinfo_in = fopen(ptxinfo->g_ptxinfo_filename,"r");
-    ptxinfo_lex_init(&(ptxinfo->scanner));
-    ptxinfo_set_in(ptxinfo_in, ptxinfo->scanner);
-    ptxinfo_parse(ptxinfo->scanner, ptxinfo);
-    ptxinfo_lex_destroy(ptxinfo->scanner);
-    fclose(ptxinfo_in);
-}
-
-void gpgpu_context::gpgpu_ptxinfo_load_from_string( const char *p_for_info, unsigned source_num, unsigned sm_version, int no_of_ptx )
-{
-    //do ptxas for individual files instead of one big embedded ptx. This prevents the duplicate defs and declarations.
-    char ptx_file[1000];
-    char *name=get_app_binary_name();
-    char commandline[4096], fname[1024], fname2[1024], final_tempfile_ptxinfo[1024], tempfile_ptxinfo[1024];
-    for (int index=1; index <= no_of_ptx; index++){
-        snprintf(ptx_file, 1000, "%s.%d.sm_%u.ptx", name, index, sm_version);
-        snprintf(fname,1024,"_ptx_XXXXXX");
-        int fd=mkstemp(fname); 
-        close(fd);
-
-        printf("GPGPU-Sim PTX: extracting embedded .ptx to temporary file \"%s\"\n", fname);
-        snprintf(commandline,4096,"cat %s > %s",ptx_file, fname);
-        if (system(commandline) !=0) {
-            printf("ERROR: %s command failed\n", commandline);
-            exit(0);
+      // find next location of startptr
+      if (*(lineptr + 3) == ';') {
+        // for function definitions
+        startptr = lineptr + 5;
+      } else if (*(lineptr + 3) == '{') {
+        // for functions enclosed with curly brackets
+        offset = 5;
+        unsigned bracket = 1;
+        while (bracket != 0) {
+          if (*(lineptr + offset) == '{')
+            bracket++;
+          else if (*(lineptr + offset) == '}')
+            bracket--;
+          offset++;
         }
-	
-        snprintf(fname2,1024,"_ptx2_XXXXXX");
-        fd=mkstemp(fname2); 
-        close(fd);
-        char commandline2[4096];
-        snprintf(commandline2,4096,"cat %s | sed 's/.version 1.5/.version 1.4/' | sed 's/, texmode_independent//' | sed 's/\\(\\.extern \\.const\\[1\\] .b8 \\w\\+\\)\\[\\]/\\1\\[1\\]/' | sed 's/const\\[.\\]/const\\[0\\]/g' > %s", fname, fname2);
-        printf("Running: %s\n", commandline2);
-        int result = system(commandline2);
-        if( result != 0 ) {
-       	    printf("GPGPU-Sim PTX: ERROR ** while loading PTX (a) %d\n", result);
-       	    printf("               Ensure you have write access to simulation directory\n");
-       	    printf("               and have \'cat\' and \'sed\' in your path.\n");
-       	    exit(1);
-    	}
+        startptr = lineptr + offset + 1;
+      } else {
+        printf("GPGPU-Sim PTX: ERROR ** Unrecognized function format\n");
+        abort();
+      }
+    } else if (strcmp("variable", iter->second) == 0) {
+      fwrite(startptr, sizeof(char), (int)(lineptr + 1 - startptr), ptxdest);
 
-        snprintf(tempfile_ptxinfo,1024,"%sinfo",fname);
-        char extra_flags[1024];
-        extra_flags[0]=0;
+      // find next location of startptr
+      offset = 1;
+      while (*(lineptr + offset) != '\n') offset++;
+      startptr = lineptr + offset + 1;
+    } else {
+      printf("GPGPU-Sim PTX: ERROR ** Unsupported duplicate type: %s\n",
+             iter->second);
+    }
+
+    oldlinenum = linenum;
+  }
+  // copy over the rest of the file
+  fwrite(startptr, sizeof(char), ptxdata + filesize - startptr, ptxdest);
+
+  // cleanup
+  free(ptxdata);
+  fclose(ptxdest);
+  snprintf(commandline, 1024, "rm -f %s", tempfile);
+  printf("Running: %s\n", commandline);
+  result = system(commandline);
+  if (result != 0) {
+    fprintf(stderr, "GPGPU-Sim PTX: ERROR ** while deleting %s", tempfile);
+    exit(1);
+  }
+}
+
+// we need the application name here too.
+char *get_app_binary_name() {
+  char exe_path[1025];
+  char *self_exe_path;
+#ifdef __APPLE__
+  // AMRUTH:  get apple device and check the result.
+  printf("WARNING: not tested for Apple-mac devices \n");
+  abort();
+#else
+  std::stringstream exec_link;
+  exec_link << "/proc/self/exe";
+  ssize_t path_length = readlink(exec_link.str().c_str(), exe_path, 1024);
+  assert(path_length != -1);
+  exe_path[path_length] = '\0';
+
+  char *token = strtok(exe_path, "/");
+  while (token != NULL) {
+    self_exe_path = token;
+    token = strtok(NULL, "/");
+  }
+#endif
+  self_exe_path = strtok(self_exe_path, ".");
+  printf("self exe links to: %s\n", self_exe_path);
+  return self_exe_path;
+}
+
+void gpgpu_context::gpgpu_ptx_info_load_from_filename(const char *filename,
+                                                      unsigned sm_version) {
+  std::string ptxas_filename(std::string(filename) + "as");
+  char buff[1024], extra_flags[1024];
+  extra_flags[0] = 0;
+  if (!device_runtime->g_cdp_enabled)
+    snprintf(extra_flags, 1024, "--gpu-name=sm_%u", sm_version);
+  else
+    snprintf(extra_flags, 1024, "--compile-only --gpu-name=sm_%u", sm_version);
+  snprintf(
+      buff, 1024,
+      "$CUDA_INSTALL_PATH/bin/ptxas %s -v %s --output-file  /dev/null 2> %s",
+      extra_flags, filename, ptxas_filename.c_str());
+  int result = system(buff);
+  if (result != 0) {
+    printf("GPGPU-Sim PTX: ERROR ** while loading PTX (b) %d\n", result);
+    printf("               Ensure ptxas is in your path.\n");
+    exit(1);
+  }
+
+  FILE *ptxinfo_in;
+  ptxinfo->g_ptxinfo_filename = strdup(ptxas_filename.c_str());
+  ptxinfo_in = fopen(ptxinfo->g_ptxinfo_filename, "r");
+  ptxinfo_lex_init(&(ptxinfo->scanner));
+  ptxinfo_set_in(ptxinfo_in, ptxinfo->scanner);
+  ptxinfo_parse(ptxinfo->scanner, ptxinfo);
+  ptxinfo_lex_destroy(ptxinfo->scanner);
+  fclose(ptxinfo_in);
+}
+
+void gpgpu_context::gpgpu_ptxinfo_load_from_string(const char *p_for_info,
+                                                   unsigned source_num,
+                                                   unsigned sm_version,
+                                                   int no_of_ptx) {
+  // do ptxas for individual files instead of one big embedded ptx. This
+  // prevents the duplicate defs and declarations.
+  char ptx_file[1000];
+  char *name = get_app_binary_name();
+  char commandline[4096], fname[1024], fname2[1024],
+      final_tempfile_ptxinfo[1024], tempfile_ptxinfo[1024];
+  for (int index = 1; index <= no_of_ptx; index++) {
+    snprintf(ptx_file, 1000, "%s.%d.sm_%u.ptx", name, index, sm_version);
+    snprintf(fname, 1024, "_ptx_XXXXXX");
+    int fd = mkstemp(fname);
+    close(fd);
+
+    printf("GPGPU-Sim PTX: extracting embedded .ptx to temporary file \"%s\"\n",
+           fname);
+    snprintf(commandline, 4096, "cat %s > %s", ptx_file, fname);
+    if (system(commandline) != 0) {
+      printf("ERROR: %s command failed\n", commandline);
+      exit(0);
+    }
+
+    snprintf(fname2, 1024, "_ptx2_XXXXXX");
+    fd = mkstemp(fname2);
+    close(fd);
+    char commandline2[4096];
+    snprintf(commandline2, 4096,
+             "cat %s | sed 's/.version 1.5/.version 1.4/' | sed 's/, "
+             "texmode_independent//' | sed 's/\\(\\.extern \\.const\\[1\\] .b8 "
+             "\\w\\+\\)\\[\\]/\\1\\[1\\]/' | sed "
+             "'s/const\\[.\\]/const\\[0\\]/g' > %s",
+             fname, fname2);
+    printf("Running: %s\n", commandline2);
+    int result = system(commandline2);
+    if (result != 0) {
+      printf("GPGPU-Sim PTX: ERROR ** while loading PTX (a) %d\n", result);
+      printf(
+          "               Ensure you have write access to simulation "
+          "directory\n");
+      printf("               and have \'cat\' and \'sed\' in your path.\n");
+      exit(1);
+    }
+
+    snprintf(tempfile_ptxinfo, 1024, "%sinfo", fname);
+    char extra_flags[1024];
+    extra_flags[0] = 0;
 
 #if CUDART_VERSION >= 3000
-    if ( g_occupancy_sm_number == 0 ) {
-        fprintf( stderr, "gpgpusim.config must specify the sm version for the GPU that you use to compute occupancy \"-gpgpu_occupancy_sm_number XX\".\n"
-                         "The register file size is specifically tied to the sm version used to querry ptxas for register usage.\n"
-                         "A register size/SM mismatch may result in occupancy differences." );
-        exit(1);
+    if (g_occupancy_sm_number == 0) {
+      fprintf(
+          stderr,
+          "gpgpusim.config must specify the sm version for the GPU that you "
+          "use to compute occupancy \"-gpgpu_occupancy_sm_number XX\".\n"
+          "The register file size is specifically tied to the sm version used "
+          "to querry ptxas for register usage.\n"
+          "A register size/SM mismatch may result in occupancy differences.");
+      exit(1);
     }
-    if(!device_runtime->g_cdp_enabled)
-        snprintf(extra_flags,1024,"--gpu-name=sm_%u", g_occupancy_sm_number);
+    if (!device_runtime->g_cdp_enabled)
+      snprintf(extra_flags, 1024, "--gpu-name=sm_%u", g_occupancy_sm_number);
     else
-        snprintf(extra_flags,1024,"--compile-only --gpu-name=sm_%u",g_occupancy_sm_number);
+      snprintf(extra_flags, 1024, "--compile-only --gpu-name=sm_%u",
+               g_occupancy_sm_number);
 #endif
 
-    snprintf(commandline,1024,"$PTXAS_CUDA_INSTALL_PATH/bin/ptxas %s -v %s --output-file  /dev/null 2> %s",
+    snprintf(commandline, 1024,
+             "$PTXAS_CUDA_INSTALL_PATH/bin/ptxas %s -v %s --output-file  "
+             "/dev/null 2> %s",
              extra_flags, fname2, tempfile_ptxinfo);
     printf("GPGPU-Sim PTX: generating ptxinfo using \"%s\"\n", commandline);
     result = system(commandline);
-    if( result != 0 ) {
-    	// 65280 = duplicate errors
-    	if (result == 65280) {
-		FILE *ptxinfo_in;
-    		ptxinfo_in = fopen(tempfile_ptxinfo,"r");
-		ptxinfo->g_ptxinfo_filename = tempfile_ptxinfo;
-		ptxinfo_lex_init(&(ptxinfo->scanner));
-		ptxinfo_set_in(ptxinfo_in, ptxinfo->scanner);
-		ptxinfo_parse(ptxinfo->scanner, ptxinfo);
-		ptxinfo_lex_destroy(ptxinfo->scanner);
-		fclose(ptxinfo_in);
+    if (result != 0) {
+      // 65280 = duplicate errors
+      if (result == 65280) {
+        FILE *ptxinfo_in;
+        ptxinfo_in = fopen(tempfile_ptxinfo, "r");
+        ptxinfo->g_ptxinfo_filename = tempfile_ptxinfo;
+        ptxinfo_lex_init(&(ptxinfo->scanner));
+        ptxinfo_set_in(ptxinfo_in, ptxinfo->scanner);
+        ptxinfo_parse(ptxinfo->scanner, ptxinfo);
+        ptxinfo_lex_destroy(ptxinfo->scanner);
+        fclose(ptxinfo_in);
 
-    		fix_duplicate_errors(fname2);
-    		snprintf(commandline,1024,"$CUDA_INSTALL_PATH/bin/ptxas %s -v %s --output-file  /dev/null 2> %s",
-    			 extra_flags, fname2, tempfile_ptxinfo);
-    		printf("GPGPU-Sim PTX: regenerating ptxinfo using \"%s\"\n", commandline);
-    		result = system(commandline);
-	    }
-	    if (result != 0) {
-		printf("GPGPU-Sim PTX: ERROR ** while loading PTX (b) %d\n", result);
-		printf("               Ensure ptxas is in your path.\n");
-		exit(1);
-	    }
-    	}
+        fix_duplicate_errors(fname2);
+        snprintf(commandline, 1024,
+                 "$CUDA_INSTALL_PATH/bin/ptxas %s -v %s --output-file  "
+                 "/dev/null 2> %s",
+                 extra_flags, fname2, tempfile_ptxinfo);
+        printf("GPGPU-Sim PTX: regenerating ptxinfo using \"%s\"\n",
+               commandline);
+        result = system(commandline);
+      }
+      if (result != 0) {
+        printf("GPGPU-Sim PTX: ERROR ** while loading PTX (b) %d\n", result);
+        printf("               Ensure ptxas is in your path.\n");
+        exit(1);
+      }
     }
+  }
 
-    //TODO: duplicate code! move it into a function so that it can be reused!
-    if(no_of_ptx==0) {
-        //For CDP, we dump everything. So no_of_ptx will be 0.
-	snprintf(fname,1024,"_ptx_XXXXXX");
-	int fd=mkstemp(fname);
-	close(fd);
+  // TODO: duplicate code! move it into a function so that it can be reused!
+  if (no_of_ptx == 0) {
+    // For CDP, we dump everything. So no_of_ptx will be 0.
+    snprintf(fname, 1024, "_ptx_XXXXXX");
+    int fd = mkstemp(fname);
+    close(fd);
 
-	printf("GPGPU-Sim PTX: extracting embedded .ptx to temporary file \"%s\"\n", fname);
-	FILE *ptxfile = fopen(fname,"w");
-	fprintf(ptxfile,"%s", p_for_info);
-	fclose(ptxfile);
+    printf("GPGPU-Sim PTX: extracting embedded .ptx to temporary file \"%s\"\n",
+           fname);
+    FILE *ptxfile = fopen(fname, "w");
+    fprintf(ptxfile, "%s", p_for_info);
+    fclose(ptxfile);
 
-	snprintf(fname2,1024,"_ptx2_XXXXXX");
-	fd=mkstemp(fname2);
-	close(fd);
-	char commandline2[4096];
-	snprintf(commandline2,4096,"cat %s | sed 's/.version 1.5/.version 1.4/' | sed 's/, texmode_independent//' | sed 's/\\(\\.extern \\.const\\[1\\] .b8 \\w\\+\\)\\[\\]/\\1\\[1\\]/' | sed 's/const\\[.\\]/const\\[0\\]/g' > %s", fname, fname2);
-	printf("Running: %s\n", commandline2);
-	int result = system(commandline2);
-	if( result != 0 ) {
-		printf("GPGPU-Sim PTX: ERROR ** while loading PTX (a) %d\n", result);
-		printf("               Ensure you have write access to simulation directory\n");
-		printf("               and have \'cat\' and \'sed\' in your path.\n");
-		exit(1);
-	}
-	//char tempfile_ptxinfo[1024];
-	snprintf(tempfile_ptxinfo,1024,"%sinfo",fname);
-	char extra_flags[1024];
-	extra_flags[0]=0;
-
-	#if CUDART_VERSION >= 3000
-	if (sm_version == 0) sm_version = 20;
-	if(!device_runtime->g_cdp_enabled)
-	       	snprintf(extra_flags,1024,"--gpu-name=sm_%u",sm_version);
-	else
-	       	snprintf(extra_flags,1024,"--compile-only --gpu-name=sm_%u",sm_version);
-	#endif
-
-	snprintf(commandline,1024,"$CUDA_INSTALL_PATH/bin/ptxas %s -v %s --output-file  /dev/null 2> %s",
-			            extra_flags, fname2, tempfile_ptxinfo);
-	printf("GPGPU-Sim PTX: generating ptxinfo using \"%s\"\n", commandline);
-	fflush(stdout);
-	result = system(commandline);
-	if( result != 0 ) {
-		printf("GPGPU-Sim PTX: ERROR ** while loading PTX (b) %d\n", result);
-		printf("               Ensure ptxas is in your path.\n");
-		exit(1);
-	}
+    snprintf(fname2, 1024, "_ptx2_XXXXXX");
+    fd = mkstemp(fname2);
+    close(fd);
+    char commandline2[4096];
+    snprintf(commandline2, 4096,
+             "cat %s | sed 's/.version 1.5/.version 1.4/' | sed 's/, "
+             "texmode_independent//' | sed 's/\\(\\.extern \\.const\\[1\\] .b8 "
+             "\\w\\+\\)\\[\\]/\\1\\[1\\]/' | sed "
+             "'s/const\\[.\\]/const\\[0\\]/g' > %s",
+             fname, fname2);
+    printf("Running: %s\n", commandline2);
+    int result = system(commandline2);
+    if (result != 0) {
+      printf("GPGPU-Sim PTX: ERROR ** while loading PTX (a) %d\n", result);
+      printf(
+          "               Ensure you have write access to simulation "
+          "directory\n");
+      printf("               and have \'cat\' and \'sed\' in your path.\n");
+      exit(1);
     }
+    // char tempfile_ptxinfo[1024];
+    snprintf(tempfile_ptxinfo, 1024, "%sinfo", fname);
+    char extra_flags[1024];
+    extra_flags[0] = 0;
 
-    //Now that we got resource usage per kernel in a ptx file, we dump all into one file and pass it to rest of the code as usual.
-    if(no_of_ptx>0){
-        char commandline3[4096];
-        snprintf(final_tempfile_ptxinfo,1024,"f_tempfile_ptx");
-        snprintf(commandline3,4096, "cat *info > %s", final_tempfile_ptxinfo);
-        if (system(commandline3)!=0) {
-	    printf("ERROR: Either we dont have info files or cat is not working \n");
-            printf("ERROR: %s command failed\n",commandline3);
-	    exit(1);
-        }
-    }	
-
-    if(no_of_ptx>0)
-        ptxinfo->g_ptxinfo_filename = final_tempfile_ptxinfo;
+#if CUDART_VERSION >= 3000
+    if (sm_version == 0) sm_version = 20;
+    if (!device_runtime->g_cdp_enabled)
+      snprintf(extra_flags, 1024, "--gpu-name=sm_%u", sm_version);
     else
-	ptxinfo->g_ptxinfo_filename = tempfile_ptxinfo;
-    FILE *ptxinfo_in;
-    ptxinfo_in = fopen(ptxinfo->g_ptxinfo_filename,"r");
+      snprintf(extra_flags, 1024, "--compile-only --gpu-name=sm_%u",
+               sm_version);
+#endif
 
-    ptxinfo_lex_init(&(ptxinfo->scanner));
-    ptxinfo_set_in(ptxinfo_in, ptxinfo->scanner);
-    ptxinfo_parse(ptxinfo->scanner, ptxinfo);
-    ptxinfo_lex_destroy(ptxinfo->scanner);
-    fclose(ptxinfo_in);
+    snprintf(
+        commandline, 1024,
+        "$CUDA_INSTALL_PATH/bin/ptxas %s -v %s --output-file  /dev/null 2> %s",
+        extra_flags, fname2, tempfile_ptxinfo);
+    printf("GPGPU-Sim PTX: generating ptxinfo using \"%s\"\n", commandline);
+    fflush(stdout);
+    result = system(commandline);
+    if (result != 0) {
+      printf("GPGPU-Sim PTX: ERROR ** while loading PTX (b) %d\n", result);
+      printf("               Ensure ptxas is in your path.\n");
+      exit(1);
+    }
+  }
 
-    snprintf(commandline,1024,"rm -f *info");
-    if( system(commandline) != 0 ) {
-	    printf("GPGPU-Sim PTX: ERROR ** while removing temporary info files\n");
-	    exit(1);
+  // Now that we got resource usage per kernel in a ptx file, we dump all into
+  // one file and pass it to rest of the code as usual.
+  if (no_of_ptx > 0) {
+    char commandline3[4096];
+    snprintf(final_tempfile_ptxinfo, 1024, "f_tempfile_ptx");
+    snprintf(commandline3, 4096, "cat *info > %s", final_tempfile_ptxinfo);
+    if (system(commandline3) != 0) {
+      printf("ERROR: Either we dont have info files or cat is not working \n");
+      printf("ERROR: %s command failed\n", commandline3);
+      exit(1);
     }
-    if( ! g_save_embedded_ptx ) {
-	if(no_of_ptx>0)
-            snprintf(commandline,1024,"rm -f %s %s %s", fname, fname2, final_tempfile_ptxinfo);
-	else
-            snprintf(commandline,1024,"rm -f %s %s %s", fname, fname2, tempfile_ptxinfo);
-        printf("GPGPU-Sim PTX: removing ptxinfo using \"%s\"\n", commandline);
-        if( system(commandline) != 0 ) {
-    	    printf("GPGPU-Sim PTX: ERROR ** while removing temporary files\n");
-    	    exit(1);
-        }
+  }
+
+  if (no_of_ptx > 0)
+    ptxinfo->g_ptxinfo_filename = final_tempfile_ptxinfo;
+  else
+    ptxinfo->g_ptxinfo_filename = tempfile_ptxinfo;
+  FILE *ptxinfo_in;
+  ptxinfo_in = fopen(ptxinfo->g_ptxinfo_filename, "r");
+
+  ptxinfo_lex_init(&(ptxinfo->scanner));
+  ptxinfo_set_in(ptxinfo_in, ptxinfo->scanner);
+  ptxinfo_parse(ptxinfo->scanner, ptxinfo);
+  ptxinfo_lex_destroy(ptxinfo->scanner);
+  fclose(ptxinfo_in);
+
+  snprintf(commandline, 1024, "rm -f *info");
+  if (system(commandline) != 0) {
+    printf("GPGPU-Sim PTX: ERROR ** while removing temporary info files\n");
+    exit(1);
+  }
+  if (!g_save_embedded_ptx) {
+    if (no_of_ptx > 0)
+      snprintf(commandline, 1024, "rm -f %s %s %s", fname, fname2,
+               final_tempfile_ptxinfo);
+    else
+      snprintf(commandline, 1024, "rm -f %s %s %s", fname, fname2,
+               tempfile_ptxinfo);
+    printf("GPGPU-Sim PTX: removing ptxinfo using \"%s\"\n", commandline);
+    if (system(commandline) != 0) {
+      printf("GPGPU-Sim PTX: ERROR ** while removing temporary files\n");
+      exit(1);
     }
+  }
 }

--- a/src/cuda-sim/ptx_loader.h
+++ b/src/cuda-sim/ptx_loader.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -33,22 +31,22 @@
 
 #define PTXINFO_LINEBUF_SIZE 1024
 class gpgpu_context;
-typedef void* yyscan_t;
-class ptxinfo_data {
- public:
-  ptxinfo_data(gpgpu_context* ctx) { gpgpu_ctx = ctx; }
-  yyscan_t scanner;
-  char linebuf[PTXINFO_LINEBUF_SIZE];
-  unsigned col;
-  const char* g_ptxinfo_filename;
-  class gpgpu_context* gpgpu_ctx;
-  bool g_keep_intermediate_files;
-  bool m_ptx_save_converted_ptxplus;
-  void ptxinfo_addinfo();
-  bool keep_intermediate_files();
-  char* gpgpu_ptx_sim_convert_ptx_and_sass_to_ptxplus(
-      const std::string ptx_str, const std::string sass_str,
-      const std::string elf_str);
+typedef void * yyscan_t;
+class ptxinfo_data{
+    public:
+	ptxinfo_data(gpgpu_context* ctx) {
+	    gpgpu_ctx = ctx;
+	}
+	yyscan_t scanner;
+	char linebuf[PTXINFO_LINEBUF_SIZE];
+	unsigned col;
+	const char *g_ptxinfo_filename;
+	class gpgpu_context* gpgpu_ctx;
+	bool g_keep_intermediate_files;
+	bool m_ptx_save_converted_ptxplus;
+	void ptxinfo_addinfo();
+	bool keep_intermediate_files();
+	char* gpgpu_ptx_sim_convert_ptx_and_sass_to_ptxplus(const std::string ptx_str, const std::string sass_str, const std::string elf_str);
 };
 
 #endif

--- a/src/cuda-sim/ptx_loader.h
+++ b/src/cuda-sim/ptx_loader.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -31,22 +33,22 @@
 
 #define PTXINFO_LINEBUF_SIZE 1024
 class gpgpu_context;
-typedef void * yyscan_t;
-class ptxinfo_data{
-    public:
-	ptxinfo_data(gpgpu_context* ctx) {
-	    gpgpu_ctx = ctx;
-	}
-	yyscan_t scanner;
-	char linebuf[PTXINFO_LINEBUF_SIZE];
-	unsigned col;
-	const char *g_ptxinfo_filename;
-	class gpgpu_context* gpgpu_ctx;
-	bool g_keep_intermediate_files;
-	bool m_ptx_save_converted_ptxplus;
-	void ptxinfo_addinfo();
-	bool keep_intermediate_files();
-	char* gpgpu_ptx_sim_convert_ptx_and_sass_to_ptxplus(const std::string ptx_str, const std::string sass_str, const std::string elf_str);
+typedef void* yyscan_t;
+class ptxinfo_data {
+ public:
+  ptxinfo_data(gpgpu_context* ctx) { gpgpu_ctx = ctx; }
+  yyscan_t scanner;
+  char linebuf[PTXINFO_LINEBUF_SIZE];
+  unsigned col;
+  const char* g_ptxinfo_filename;
+  class gpgpu_context* gpgpu_ctx;
+  bool g_keep_intermediate_files;
+  bool m_ptx_save_converted_ptxplus;
+  void ptxinfo_addinfo();
+  bool keep_intermediate_files();
+  char* gpgpu_ptx_sim_convert_ptx_and_sass_to_ptxplus(
+      const std::string ptx_str, const std::string sass_str,
+      const std::string elf_str);
 };
 
 #endif

--- a/src/cuda-sim/ptx_loader.h
+++ b/src/cuda-sim/ptx_loader.h
@@ -7,23 +7,24 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef PTX_LOADER_H_INCLUDED
 #define PTX_LOADER_H_INCLUDED
@@ -31,22 +32,22 @@
 
 #define PTXINFO_LINEBUF_SIZE 1024
 class gpgpu_context;
-typedef void * yyscan_t;
-class ptxinfo_data{
-    public:
-	ptxinfo_data(gpgpu_context* ctx) {
-	    gpgpu_ctx = ctx;
-	}
-	yyscan_t scanner;
-	char linebuf[PTXINFO_LINEBUF_SIZE];
-	unsigned col;
-	const char *g_ptxinfo_filename;
-	class gpgpu_context* gpgpu_ctx;
-	bool g_keep_intermediate_files;
-	bool m_ptx_save_converted_ptxplus;
-	void ptxinfo_addinfo();
-	bool keep_intermediate_files();
-	char* gpgpu_ptx_sim_convert_ptx_and_sass_to_ptxplus(const std::string ptx_str, const std::string sass_str, const std::string elf_str);
+typedef void* yyscan_t;
+class ptxinfo_data {
+ public:
+  ptxinfo_data(gpgpu_context* ctx) { gpgpu_ctx = ctx; }
+  yyscan_t scanner;
+  char linebuf[PTXINFO_LINEBUF_SIZE];
+  unsigned col;
+  const char* g_ptxinfo_filename;
+  class gpgpu_context* gpgpu_ctx;
+  bool g_keep_intermediate_files;
+  bool m_ptx_save_converted_ptxplus;
+  void ptxinfo_addinfo();
+  bool keep_intermediate_files();
+  char* gpgpu_ptx_sim_convert_ptx_and_sass_to_ptxplus(
+      const std::string ptx_str, const std::string sass_str,
+      const std::string elf_str);
 };
 
 #endif

--- a/src/cuda-sim/ptx_parser.cc
+++ b/src/cuda-sim/ptx_parser.cc
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -28,971 +26,998 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "ptx_parser.h"
-#include "../../libcuda/gpgpu_context.h"
 #include "ptx_ir.h"
+#include "../../libcuda/gpgpu_context.h"
 
-typedef void *yyscan_t;
-#include <stdarg.h>
+typedef void * yyscan_t;
 #include "ptx.tab.h"
+#include <stdarg.h>
 
-extern int ptx_get_lineno(yyscan_t yyscanner);
-extern YYSTYPE *ptx_get_lval(yyscan_t yyscanner);
-extern int ptx_error(yyscan_t yyscanner, const char *s);
-extern int ptx_lex_init(yyscan_t *scanner);
-extern void ptx_set_in(FILE *_in_str, yyscan_t yyscanner);
-extern FILE *ptx_get_in(yyscan_t yyscanner);
-extern int ptx_parse(yyscan_t scanner, ptx_recognizer *recognizer);
+extern int ptx_get_lineno (yyscan_t yyscanner );
+extern YYSTYPE* ptx_get_lval (yyscan_t yyscanner );
+extern int ptx_error( yyscan_t yyscanner, const char *s );
+extern int ptx_lex_init(yyscan_t* scanner);
+extern void ptx_set_in(FILE * _in_str ,yyscan_t yyscanner );
+extern FILE *ptx_get_in (yyscan_t yyscanner );
+extern int ptx_parse(yyscan_t scanner, ptx_recognizer* recognizer);
 extern int ptx_lex_destroy(yyscan_t scanner);
 
-void ptx_recognizer::set_ptx_warp_size(const struct core_config *warp_size) {
-  g_shader_core_config = warp_size;
+void ptx_recognizer::set_ptx_warp_size(const struct core_config * warp_size)
+{
+   g_shader_core_config=warp_size;
 }
 
-#define PTX_PARSE_DPRINTF(...)                                            \
-  if (g_debug_ir_generation) {                                            \
-    printf(" %s:%u => ", gpgpu_ctx->g_filename, ptx_get_lineno(scanner)); \
-    printf("   (%s:%u) ", __FILE__, __LINE__);                            \
-    printf(__VA_ARGS__);                                                  \
-    printf("\n");                                                         \
-    fflush(stdout);                                                       \
-  }
 
-static std::map<unsigned, std::string> g_ptx_token_decode;
+#define PTX_PARSE_DPRINTF(...) \
+   if( g_debug_ir_generation ) { \
+      printf(" %s:%u => ",gpgpu_ctx->g_filename,ptx_get_lineno(scanner)); \
+      printf("   (%s:%u) ", __FILE__, __LINE__); \
+      printf(__VA_ARGS__); \
+      printf("\n"); \
+      fflush(stdout); \
+   }
 
-const char *decode_token(int type) { return g_ptx_token_decode[type].c_str(); }
+static std::map<unsigned,std::string> g_ptx_token_decode;
 
-void ptx_recognizer::read_parser_environment_variables() {
-  gpgpu_ctx->g_filename = getenv("PTX_SIM_KERNELFILE");
-  char *dbg_level = getenv("PTX_SIM_DEBUG");
-  if (dbg_level && strlen(dbg_level)) {
-    int debug_execution = 0;
-    sscanf(dbg_level, "%d", &debug_execution);
-    if (debug_execution >= 30) g_debug_ir_generation = true;
-  }
+const char *decode_token( int type )
+{
+   return g_ptx_token_decode[type].c_str();
 }
 
-void ptx_recognizer::init_directive_state() {
-  PTX_PARSE_DPRINTF("init_directive_state");
-  g_space_spec = undefined_space;
-  g_ptr_spec = undefined_space;
-  g_scalar_type_spec = -1;
-  g_vector_spec = -1;
-  g_opcode = -1;
-  g_alignment_spec = -1;
-  g_size = -1;
-  g_extern_spec = 0;
-  g_scalar_type.clear();
-  g_operands.clear();
-  g_last_symbol = NULL;
+void ptx_recognizer::read_parser_environment_variables() 
+{
+   gpgpu_ctx->g_filename = getenv("PTX_SIM_KERNELFILE");
+   char *dbg_level = getenv("PTX_SIM_DEBUG");
+   if ( dbg_level && strlen(dbg_level) ) {
+      int debug_execution=0;
+      sscanf(dbg_level,"%d", &debug_execution);
+      if ( debug_execution >= 30 ) 
+         g_debug_ir_generation=true;
+   }
 }
 
-void ptx_recognizer::init_instruction_state() {
-  PTX_PARSE_DPRINTF("init_instruction_state");
-  g_pred = NULL;
-  g_neg_pred = 0;
-  g_pred_mod = -1;
-  g_label = NULL;
-  g_opcode = -1;
-  g_options.clear();
-  g_wmma_options.clear();
-  g_return_var = operand_info(gpgpu_ctx);
-  init_directive_state();
+void ptx_recognizer::init_directive_state()
+{
+   PTX_PARSE_DPRINTF("init_directive_state");
+   g_space_spec=undefined_space;
+   g_ptr_spec=undefined_space;
+   g_scalar_type_spec=-1;
+   g_vector_spec=-1;
+   g_opcode=-1;
+   g_alignment_spec = -1;
+   g_size = -1;
+   g_extern_spec = 0;
+   g_scalar_type.clear();
+   g_operands.clear();
+   g_last_symbol = NULL;
 }
 
-symbol_table *gpgpu_context::init_parser(const char *ptx_filename) {
-  g_filename = strdup(ptx_filename);
-  if (g_global_allfiles_symbol_table == NULL) {
-    g_global_allfiles_symbol_table =
-        new symbol_table("global_allfiles", 0, NULL, this);
-    ptx_parser->g_global_symbol_table = ptx_parser->g_current_symbol_table =
-        g_global_allfiles_symbol_table;
-  }
-/*else {
-    g_global_symbol_table = g_current_symbol_table = new
-symbol_table("global",0,g_global_allfiles_symbol_table);
-}*/
+void ptx_recognizer::init_instruction_state()
+{
+   PTX_PARSE_DPRINTF("init_instruction_state");
+   g_pred = NULL;
+   g_neg_pred = 0;
+   g_pred_mod = -1;
+   g_label = NULL;
+   g_opcode = -1;
+   g_options.clear();
+   g_wmma_options.clear();
+   g_return_var = operand_info(gpgpu_ctx);
+   init_directive_state();
+}
 
-#define DEF(X, Y) g_ptx_token_decode[X] = Y;
+symbol_table * gpgpu_context::init_parser( const char *ptx_filename )
+{
+   g_filename = strdup(ptx_filename);
+   if  (g_global_allfiles_symbol_table == NULL) {
+       g_global_allfiles_symbol_table = new symbol_table("global_allfiles", 0, NULL, this);
+       ptx_parser->g_global_symbol_table = ptx_parser->g_current_symbol_table = g_global_allfiles_symbol_table;
+   }
+   /*else {
+       g_global_symbol_table = g_current_symbol_table = new symbol_table("global",0,g_global_allfiles_symbol_table);
+   }*/
+
+#define DEF(X,Y) g_ptx_token_decode[X] = Y;
 #include "ptx_parser_decode.def"
 #undef DEF
-  g_ptx_token_decode[undefined_space] = "undefined_space";
-  g_ptx_token_decode[undefined_space] = "undefined_space=0";
-  g_ptx_token_decode[reg_space] = "reg_space";
-  g_ptx_token_decode[local_space] = "local_space";
-  g_ptx_token_decode[shared_space] = "shared_space";
-  g_ptx_token_decode[param_space_unclassified] = "param_space_unclassified";
-  g_ptx_token_decode[param_space_kernel] = "param_space_kernel";
-  g_ptx_token_decode[param_space_local] = "param_space_local";
-  g_ptx_token_decode[const_space] = "const_space";
-  g_ptx_token_decode[tex_space] = "tex_space";
-  g_ptx_token_decode[surf_space] = "surf_space";
-  g_ptx_token_decode[global_space] = "global_space";
-  g_ptx_token_decode[generic_space] = "generic_space";
-  g_ptx_token_decode[instruction_space] = "instruction_space";
+   g_ptx_token_decode[undefined_space] = "undefined_space";
+   g_ptx_token_decode[undefined_space] = "undefined_space=0";
+   g_ptx_token_decode[reg_space] = "reg_space";
+   g_ptx_token_decode[local_space] = "local_space";
+   g_ptx_token_decode[shared_space] = "shared_space";
+   g_ptx_token_decode[param_space_unclassified] = "param_space_unclassified";
+   g_ptx_token_decode[param_space_kernel] = "param_space_kernel";
+   g_ptx_token_decode[param_space_local] = "param_space_local";
+   g_ptx_token_decode[const_space] = "const_space";
+   g_ptx_token_decode[tex_space] = "tex_space";
+   g_ptx_token_decode[surf_space] = "surf_space";
+   g_ptx_token_decode[global_space] = "global_space";
+   g_ptx_token_decode[generic_space] = "generic_space";
+   g_ptx_token_decode[instruction_space] = "instruction_space";
 
-  ptx_lex_init(&(ptx_parser->scanner));
-  ptx_parser->init_directive_state();
-  ptx_parser->init_instruction_state();
+   ptx_lex_init(&(ptx_parser->scanner));
+   ptx_parser->init_directive_state();
+   ptx_parser->init_instruction_state();
 
-  FILE *ptx_in;
-  ptx_in = fopen(ptx_filename, "r");
-  ptx_set_in(ptx_in, ptx_parser->scanner);
-  ptx_parse(ptx_parser->scanner, ptx_parser);
-  ptx_in = ptx_get_in(ptx_parser->scanner);
-  ptx_lex_destroy(ptx_parser->scanner);
-  fclose(ptx_in);
-  return ptx_parser->g_global_symbol_table;
+   FILE *ptx_in;
+   ptx_in = fopen(ptx_filename, "r");
+   ptx_set_in(ptx_in, ptx_parser->scanner);
+   ptx_parse(ptx_parser->scanner, ptx_parser);
+   ptx_in = ptx_get_in(ptx_parser->scanner);
+   ptx_lex_destroy(ptx_parser->scanner);
+   fclose(ptx_in);
+   return ptx_parser->g_global_symbol_table;
 }
 
-void ptx_recognizer::start_function(int entry_point) {
-  PTX_PARSE_DPRINTF("start_function");
-  init_directive_state();
-  init_instruction_state();
-  g_entry_point = entry_point;
-  g_func_info = NULL;
-  g_entry_func_param_index = 0;
+
+void ptx_recognizer::start_function( int entry_point )
+{
+   PTX_PARSE_DPRINTF("start_function");
+   init_directive_state();
+   init_instruction_state();
+   g_entry_point = entry_point;
+   g_func_info = NULL;
+   g_entry_func_param_index=0;
 }
 
-void ptx_recognizer::add_function_name(const char *name) {
-  PTX_PARSE_DPRINTF(
-      "add_function_name %s %s", name,
-      ((g_entry_point == 1) ? "(entrypoint)"
-                            : ((g_entry_point == 2) ? "(extern)" : "")));
-  bool prior_decl = g_global_symbol_table->add_function_decl(
-      name, g_entry_point, &g_func_info, &g_current_symbol_table);
-  if (g_add_identifier_cached__identifier) {
-    add_identifier(g_add_identifier_cached__identifier,
-                   g_add_identifier_cached__array_dim,
-                   g_add_identifier_cached__array_ident);
-    free(g_add_identifier_cached__identifier);
-    g_add_identifier_cached__identifier = NULL;
-    g_func_info->add_return_var(g_last_symbol);
-    init_directive_state();
-  }
-  if (prior_decl) {
-    g_func_info->remove_args();
-  }
-  g_global_symbol_table->add_function(g_func_info, gpgpu_ctx->g_filename,
-                                      ptx_get_lineno(scanner));
+void ptx_recognizer::add_function_name( const char *name )
+{
+   PTX_PARSE_DPRINTF("add_function_name %s %s", name,  ((g_entry_point==1)?"(entrypoint)":((g_entry_point==2)?"(extern)":"")));
+   bool prior_decl = g_global_symbol_table->add_function_decl( name, g_entry_point, &g_func_info, &g_current_symbol_table );
+   if( g_add_identifier_cached__identifier ) {
+      add_identifier( g_add_identifier_cached__identifier,
+                      g_add_identifier_cached__array_dim,
+                      g_add_identifier_cached__array_ident );
+      free( g_add_identifier_cached__identifier );
+      g_add_identifier_cached__identifier = NULL;
+      g_func_info->add_return_var( g_last_symbol );
+      init_directive_state();
+   }
+   if( prior_decl ) {
+      g_func_info->remove_args();
+   }
+   g_global_symbol_table->add_function( g_func_info, gpgpu_ctx->g_filename, ptx_get_lineno(scanner) );
 }
 
-// Jin: handle instruction group for cdp
+//Jin: handle instruction group for cdp
 void ptx_recognizer::start_inst_group() {
-  PTX_PARSE_DPRINTF("start_instruction_group");
-  g_current_symbol_table = g_current_symbol_table->start_inst_group();
+   PTX_PARSE_DPRINTF("start_instruction_group");
+   g_current_symbol_table = g_current_symbol_table->start_inst_group();
 }
 
 void ptx_recognizer::end_inst_group() {
-  PTX_PARSE_DPRINTF("end_instruction_group");
-  g_current_symbol_table = g_current_symbol_table->end_inst_group();
+   PTX_PARSE_DPRINTF("end_instruction_group");
+   g_current_symbol_table = g_current_symbol_table->end_inst_group();
 }
 
-void ptx_recognizer::add_directive() {
-  PTX_PARSE_DPRINTF("add_directive");
-  init_directive_state();
+void ptx_recognizer::add_directive()
+{
+   PTX_PARSE_DPRINTF("add_directive");
+   init_directive_state();
 }
 
-#define mymax(a, b) ((a) > (b) ? (a) : (b))
+#define mymax(a,b) ((a)>(b)?(a):(b))
 
-void ptx_recognizer::end_function() {
-  PTX_PARSE_DPRINTF("end_function");
+void ptx_recognizer::end_function()
+{
+   PTX_PARSE_DPRINTF("end_function");
 
-  init_directive_state();
-  init_instruction_state();
-  g_max_regs_per_thread = mymax(g_max_regs_per_thread,
-                                (g_current_symbol_table->next_reg_num() - 1));
-  g_func_info->add_inst(g_instructions);
-  g_instructions.clear();
-  gpgpu_ptx_assemble(g_func_info->get_name(), g_func_info);
-  g_current_symbol_table = g_global_symbol_table;
+   init_directive_state();
+   init_instruction_state();
+   g_max_regs_per_thread = mymax( g_max_regs_per_thread, (g_current_symbol_table->next_reg_num()-1)); 
+   g_func_info->add_inst( g_instructions );
+   g_instructions.clear();
+   gpgpu_ptx_assemble( g_func_info->get_name(), g_func_info );
+   g_current_symbol_table = g_global_symbol_table;
 
-  PTX_PARSE_DPRINTF("function %s, PC = %d\n", g_func_info->get_name().c_str(),
-                    g_func_info->get_start_PC());
+   PTX_PARSE_DPRINTF("function %s, PC = %d\n", g_func_info->get_name().c_str(), g_func_info->get_start_PC());
 }
 
-#define parse_error(msg, ...) \
-  parse_error_impl(__FILE__, __LINE__, msg, ##__VA_ARGS__)
-#define parse_assert(cond, msg, ...) \
-  parse_assert_impl((cond), __FILE__, __LINE__, msg, ##__VA_ARGS__)
+#define parse_error(msg, ...) parse_error_impl(__FILE__,__LINE__, msg, ##__VA_ARGS__)
+#define parse_assert(cond,msg, ...) parse_assert_impl((cond),__FILE__,__LINE__, msg, ##__VA_ARGS__)
 
-void ptx_recognizer::parse_error_impl(const char *file, unsigned line,
-                                      const char *msg, ...) {
-  va_list ap;
-  char buf[1024];
-  va_start(ap, msg);
-  vsnprintf(buf, 1024, msg, ap);
-  va_end(ap);
+void ptx_recognizer::parse_error_impl( const char *file, unsigned line, const char *msg, ... )
+{
+   va_list ap;
+   char buf[1024];
+   va_start(ap,msg);
+   vsnprintf(buf,1024,msg,ap);
+   va_end(ap);
 
-  g_error_detected = 1;
-  printf("%s:%u: Parse error: %s (%s:%u)\n\n", gpgpu_ctx->g_filename,
-         ptx_get_lineno(scanner), buf, file, line);
-  ptx_error(scanner, NULL);
-  abort();
-  exit(1);
+   g_error_detected = 1;
+   printf("%s:%u: Parse error: %s (%s:%u)\n\n", gpgpu_ctx->g_filename, ptx_get_lineno(scanner), buf, file, line);
+   ptx_error(scanner, NULL);
+   abort();
+   exit(1);
 }
 
-void ptx_recognizer::parse_assert_impl(int test_value, const char *file,
-                                       unsigned line, const char *msg, ...) {
-  va_list ap;
-  char buf[1024];
-  va_start(ap, msg);
-  vsnprintf(buf, 1024, msg, ap);
-  va_end(ap);
+void ptx_recognizer::parse_assert_impl( int test_value, const char *file, unsigned line, const char *msg, ... )
+{
+   va_list ap;
+   char buf[1024];
+   va_start(ap,msg);
+   vsnprintf(buf,1024,msg,ap);
+   va_end(ap);
 
-  if (test_value == 0) parse_error_impl(file, line, msg);
+   if ( test_value == 0 )
+      parse_error_impl(file,line, msg);
 }
 
-void ptx_recognizer::set_return() {
-  parse_assert((g_opcode == CALL_OP || g_opcode == CALLP_OP),
-               "only call can have return value");
-  g_operands.front().set_return();
-  g_return_var = g_operands.front();
+
+
+void ptx_recognizer::set_return()
+{
+   parse_assert( (g_opcode == CALL_OP || g_opcode == CALLP_OP), "only call can have return value");
+   g_operands.front().set_return();
+   g_return_var = g_operands.front();
 }
 
-const ptx_instruction *ptx_recognizer::ptx_instruction_lookup(
-    const char *filename, unsigned linenumber) {
-  std::map<std::string, std::map<unsigned, const ptx_instruction *> >::iterator
-      f = g_inst_lookup.find(filename);
-  if (f == g_inst_lookup.end()) return NULL;
-  std::map<unsigned, const ptx_instruction *>::iterator l =
-      f->second.find(linenumber);
-  if (l == f->second.end()) return NULL;
-  return l->second;
+
+const ptx_instruction *ptx_recognizer::ptx_instruction_lookup( const char *filename, unsigned linenumber )
+{
+   std::map<std::string,std::map<unsigned,const ptx_instruction*> >::iterator f=g_inst_lookup.find(filename);
+   if( f == g_inst_lookup.end() ) 
+      return NULL;
+   std::map<unsigned,const ptx_instruction*>::iterator l=f->second.find(linenumber);
+   if( l == f->second.end() ) 
+      return NULL;
+   return l->second; 
 }
 
-void ptx_recognizer::add_instruction() {
-  PTX_PARSE_DPRINTF("add_instruction: %s",
-                    ((g_opcode > 0) ? g_opcode_string[g_opcode] : "<label>"));
-  assert(g_shader_core_config != 0);
-  ptx_instruction *i = new ptx_instruction(
-      g_opcode, g_pred, g_neg_pred, g_pred_mod, g_label, g_operands,
-      g_return_var, g_options, g_wmma_options, g_scalar_type, g_space_spec,
-      gpgpu_ctx->g_filename, ptx_get_lineno(scanner), linebuf,
-      g_shader_core_config, gpgpu_ctx);
-  g_instructions.push_back(i);
-  g_inst_lookup[gpgpu_ctx->g_filename][ptx_get_lineno(scanner)] = i;
-  init_instruction_state();
+void ptx_recognizer::add_instruction()
+{
+   PTX_PARSE_DPRINTF("add_instruction: %s", ((g_opcode>0)?g_opcode_string[g_opcode]:"<label>") );
+   assert( g_shader_core_config != 0 );
+   ptx_instruction *i = new ptx_instruction( g_opcode, 
+                                             g_pred, 
+                                             g_neg_pred,
+                                             g_pred_mod, 
+                                             g_label, 
+                                             g_operands,
+                                             g_return_var,
+                                             g_options, 
+                                             g_wmma_options, 
+                                             g_scalar_type,
+                                             g_space_spec,
+                                             gpgpu_ctx->g_filename,
+                                             ptx_get_lineno(scanner),
+                                             linebuf,
+                                             g_shader_core_config,
+					     gpgpu_ctx );
+   g_instructions.push_back(i);
+   g_inst_lookup[gpgpu_ctx->g_filename][ptx_get_lineno(scanner)] = i;
+   init_instruction_state();
 }
 
-void ptx_recognizer::add_variables() {
-  PTX_PARSE_DPRINTF("add_variables");
-  if (!g_operands.empty()) {
-    assert(g_last_symbol != NULL);
-    g_last_symbol->add_initializer(g_operands);
-  }
-  init_directive_state();
+void ptx_recognizer::add_variables()
+{
+   PTX_PARSE_DPRINTF("add_variables");
+   if ( !g_operands.empty() ) {
+      assert( g_last_symbol != NULL ); 
+      g_last_symbol->add_initializer(g_operands);
+   }
+   init_directive_state();
 }
 
-void ptx_recognizer::set_variable_type() {
-  PTX_PARSE_DPRINTF("set_variable_type space_spec=%s scalar_type_spec=%s",
-                    g_ptx_token_decode[g_space_spec.get_type()].c_str(),
-                    g_ptx_token_decode[g_scalar_type_spec].c_str());
-  parse_assert(g_space_spec != undefined_space,
-               "variable has no space specification");
-  parse_assert(
-      g_scalar_type_spec != -1,
-      "variable has no type information");  // need to extend for structs?
-  g_var_type = g_current_symbol_table->add_type(
-      g_space_spec, g_scalar_type_spec, g_vector_spec, g_alignment_spec,
-      g_extern_spec);
+void ptx_recognizer::set_variable_type()
+{
+   PTX_PARSE_DPRINTF("set_variable_type space_spec=%s scalar_type_spec=%s", 
+           g_ptx_token_decode[g_space_spec.get_type()].c_str(), 
+           g_ptx_token_decode[g_scalar_type_spec].c_str() );
+   parse_assert( g_space_spec != undefined_space, "variable has no space specification" );
+   parse_assert( g_scalar_type_spec != -1, "variable has no type information" ); // need to extend for structs?
+   g_var_type = g_current_symbol_table->add_type( g_space_spec, 
+                                                  g_scalar_type_spec, 
+                                                  g_vector_spec, 
+                                                  g_alignment_spec, 
+                                                  g_extern_spec );
 }
 
-bool ptx_recognizer::check_for_duplicates(const char *identifier) {
-  const symbol *s = g_current_symbol_table->lookup(identifier);
-  return (s != NULL);
+bool ptx_recognizer::check_for_duplicates( const char *identifier )
+{
+   const symbol *s = g_current_symbol_table->lookup(identifier);
+   return ( s != NULL );
 }
 
-// Returns padding that needs to be inserted ahead of address to make it aligned
-// to min(size, maxalign)
+// Returns padding that needs to be inserted ahead of address to make it aligned to min(size, maxalign)
 /*
  * @param address the address in bytes
  * @param size the size of the memory to be allocated in bytes
- * @param maximum alignment in bytes. i.e. if size is too big then align to this
- * instead
+ * @param maximum alignment in bytes. i.e. if size is too big then align to this instead
  */
-int pad_address(new_addr_type address, unsigned size, unsigned maxalign) {
-  assert(size >= 0);
-  assert(maxalign > 0);
-  int alignto = maxalign;
-  if (size < maxalign && (size & (size - 1)) == 0) {  // size is a power of 2
-    alignto = size;
-  }
-  return alignto ? ((alignto - (address % alignto)) % alignto) : 0;
+int pad_address (new_addr_type address, unsigned size, unsigned maxalign) {
+    assert(size >= 0);
+    assert(maxalign > 0);
+    int alignto = maxalign;
+    if (size < maxalign &&
+            (size & (size-1)) == 0) { //size is a power of 2
+        alignto = size;
+    }
+    return alignto ? ((alignto - (address % alignto)) % alignto) : 0;
 }
 
-void ptx_recognizer::add_identifier(const char *identifier, int array_dim,
-                                    unsigned array_ident) {
-  if (array_ident == ARRAY_IDENTIFIER) {
-    g_size *= array_dim;
-  }
-  if (g_func_decl && (g_func_info == NULL)) {
-    // return variable decl...
-    assert(g_add_identifier_cached__identifier == NULL);
-    g_add_identifier_cached__identifier = strdup(identifier);
-    g_add_identifier_cached__array_dim = array_dim;
-    g_add_identifier_cached__array_ident = array_ident;
-    return;
-  }
-  PTX_PARSE_DPRINTF("add_identifier \"%s\" (%u)", identifier, g_ident_add_uid);
-  g_ident_add_uid++;
-  type_info *type = g_var_type;
-  type_info_key ti = type->get_key();
-  int basic_type;
-  int regnum;
-  size_t num_bits;
-  unsigned addr_pad;
-  new_addr_type addr;
-  ti.type_decode(num_bits, basic_type);
+void ptx_recognizer::add_identifier( const char *identifier, int array_dim, unsigned array_ident )
+{
+   if(array_ident==ARRAY_IDENTIFIER){
+       g_size *= array_dim;
+   }
+   if( g_func_decl && (g_func_info == NULL) ) {
+      // return variable decl...
+      assert( g_add_identifier_cached__identifier == NULL );
+      g_add_identifier_cached__identifier = strdup(identifier);
+      g_add_identifier_cached__array_dim = array_dim;
+      g_add_identifier_cached__array_ident = array_ident;
+      return;
+   }
+   PTX_PARSE_DPRINTF("add_identifier \"%s\" (%u)", identifier, g_ident_add_uid);
+   g_ident_add_uid++;
+   type_info *type = g_var_type;
+   type_info_key ti = type->get_key();
+   int basic_type;
+   int regnum;
+   size_t num_bits;
+   unsigned addr_pad;
+   new_addr_type addr;
+   ti.type_decode(num_bits,basic_type);
 
-  bool duplicates = check_for_duplicates(identifier);
-  if (duplicates) {
-    symbol *s = g_current_symbol_table->lookup(identifier);
-    g_last_symbol = s;
-    if (g_func_decl) return;
-    std::string msg = std::string(identifier) + " was declared previous at " +
-                      s->decl_location() + " skipping new declaration";
-    printf("GPGPU-Sim PTX: Warning %s\n", msg.c_str());
-    return;
-  }
+   bool duplicates = check_for_duplicates( identifier );
+   if( duplicates ) {
+      symbol *s = g_current_symbol_table->lookup(identifier);
+      g_last_symbol = s;
+      if( g_func_decl ) 
+         return;
+      std::string msg = std::string(identifier) + " was declared previous at " + s->decl_location() + " skipping new declaration"; 
+      printf("GPGPU-Sim PTX: Warning %s\n", msg.c_str());
+      return;
+   }
 
-  assert(g_var_type != NULL);
-  switch (array_ident) {
-    case ARRAY_IDENTIFIER:
-      type = g_current_symbol_table->get_array_type(type, array_dim);
+   assert( g_var_type != NULL );
+   switch ( array_ident ) {
+   case ARRAY_IDENTIFIER:
+      type = g_current_symbol_table->get_array_type(type,array_dim);
       num_bits = array_dim * num_bits;
       break;
-    case ARRAY_IDENTIFIER_NO_DIM:
-      type = g_current_symbol_table->get_array_type(type, (unsigned)-1);
+   case ARRAY_IDENTIFIER_NO_DIM:
+      type = g_current_symbol_table->get_array_type(type,(unsigned)-1);
       num_bits = 0;
       break;
-    default:
+   default:
       break;
-  }
-  g_last_symbol = g_current_symbol_table->add_variable(
-      identifier, type, num_bits / 8, gpgpu_ctx->g_filename,
-      ptx_get_lineno(scanner));
-  switch (ti.get_memory_space().get_type()) {
-    case reg_space: {
+   }
+   g_last_symbol = g_current_symbol_table->add_variable(identifier,type,num_bits/8,gpgpu_ctx->g_filename,ptx_get_lineno(scanner));
+   switch ( ti.get_memory_space().get_type() ) {
+   case reg_space: {
       regnum = g_current_symbol_table->next_reg_num();
       int arch_regnum = -1;
       for (int d = 0; d < strlen(identifier); d++) {
-        if (isdigit(identifier[d])) {
-          sscanf(identifier + d, "%d", &arch_regnum);
-          break;
-        }
+         if (isdigit(identifier[d])) {
+            sscanf(identifier + d, "%d", &arch_regnum);
+            break;
+         }
       }
       if (strcmp(identifier, "%sp") == 0) {
-        arch_regnum = 0;
+         arch_regnum = 0;
       }
       g_last_symbol->set_regno(regnum, arch_regnum);
-    } break;
-    case shared_space:
-      printf("GPGPU-Sim PTX: allocating shared region for \"%s\" ", identifier);
+      } break;
+   case shared_space:
+      printf("GPGPU-Sim PTX: allocating shared region for \"%s\" ",
+             identifier);
       fflush(stdout);
-      assert((num_bits % 8) == 0);
+      assert( (num_bits%8) == 0  );
       addr = g_current_symbol_table->get_shared_next();
-      addr_pad = pad_address(addr, num_bits / 8, 128);
-      printf("from 0x%llx to 0x%llx (shared memory space)\n", addr + addr_pad,
-             addr + addr_pad + num_bits / 8);
-      fflush(stdout);
-      g_last_symbol->set_address(addr + addr_pad);
-      g_current_symbol_table->alloc_shared(num_bits / 8 + addr_pad);
+      addr_pad = pad_address(addr, num_bits/8, 128);
+      printf("from 0x%llx to 0x%llx (shared memory space)\n",
+              addr+addr_pad,
+              addr+addr_pad + num_bits/8);
+         fflush(stdout);
+      g_last_symbol->set_address( addr+addr_pad );
+      g_current_symbol_table->alloc_shared( num_bits/8 + addr_pad );
       break;
-    case sstarr_space:
-      printf("GPGPU-Sim PTX: allocating sstarr region for \"%s\" ", identifier);
-      fflush(stdout);
-      assert((num_bits % 8) == 0);
-      addr = g_current_symbol_table->get_sstarr_next();
-      addr_pad = pad_address(addr, num_bits / 8, 128);
-      printf("from 0x%llx to 0x%llx (sstarr memory space)\n", addr + addr_pad,
-             addr + addr_pad + num_bits / 8);
-      fflush(stdout);
-      g_last_symbol->set_address(addr + addr_pad);
-      g_current_symbol_table->alloc_sstarr(num_bits / 8 + addr_pad);
-      break;
-    case const_space:
-      if (array_ident == ARRAY_IDENTIFIER_NO_DIM) {
-        printf(
-            "GPGPU-Sim PTX: deferring allocation of constant region for \"%s\" "
-            "(need size information)\n",
-            identifier);
+   case sstarr_space:
+         printf("GPGPU-Sim PTX: allocating sstarr region for \"%s\" ",
+                identifier);
+         fflush(stdout);
+         assert( (num_bits%8) == 0  );
+         addr = g_current_symbol_table->get_sstarr_next();
+         addr_pad = pad_address(addr, num_bits/8, 128);
+         printf("from 0x%llx to 0x%llx (sstarr memory space)\n",
+                 addr+addr_pad,
+                 addr+addr_pad + num_bits/8);
+            fflush(stdout);
+         g_last_symbol->set_address( addr+addr_pad );
+         g_current_symbol_table->alloc_sstarr( num_bits/8 + addr_pad );
+         break;
+   case const_space:
+      if( array_ident == ARRAY_IDENTIFIER_NO_DIM ) {
+         printf("GPGPU-Sim PTX: deferring allocation of constant region for \"%s\" (need size information)\n", identifier );
       } else {
-        printf("GPGPU-Sim PTX: allocating constant region for \"%s\" ",
-               identifier);
-        fflush(stdout);
-        assert((num_bits % 8) == 0);
-        addr = g_current_symbol_table->get_global_next();
-        addr_pad = pad_address(addr, num_bits / 8, 128);
-        printf("from 0x%llx to 0x%llx (global memory space) %u\n",
-               addr + addr_pad, addr + addr_pad + num_bits / 8,
-               g_const_alloc++);
-        fflush(stdout);
-        g_last_symbol->set_address(addr + addr_pad);
-        g_current_symbol_table->alloc_global(num_bits / 8 + addr_pad);
+         printf("GPGPU-Sim PTX: allocating constant region for \"%s\" ",
+                identifier);
+         fflush(stdout);
+         assert( (num_bits%8) == 0  ); 
+         addr = g_current_symbol_table->get_global_next();
+         addr_pad = pad_address(addr, num_bits/8, 128);
+         printf("from 0x%llx to 0x%llx (global memory space) %u\n",
+              addr+addr_pad,
+              addr+addr_pad + num_bits/8,
+              g_const_alloc++);
+         fflush(stdout);
+         g_last_symbol->set_address( addr + addr_pad );
+         g_current_symbol_table->alloc_global( num_bits/8 + addr_pad ); 
       }
-      if (g_current_symbol_table == g_global_symbol_table) {
-        gpgpu_ctx->func_sim->g_constants.insert(identifier);
+      if( g_current_symbol_table == g_global_symbol_table ) { 
+         gpgpu_ctx->func_sim->g_constants.insert( identifier );
       }
-      assert(g_current_symbol_table != NULL);
-      g_sym_name_to_symbol_table[identifier] = g_current_symbol_table;
+      assert( g_current_symbol_table != NULL );
+      g_sym_name_to_symbol_table[ identifier ] = g_current_symbol_table;
       break;
-    case global_space:
-      printf("GPGPU-Sim PTX: allocating global region for \"%s\" ", identifier);
+   case global_space:
+      printf("GPGPU-Sim PTX: allocating global region for \"%s\" ",
+             identifier);
       fflush(stdout);
-      assert((num_bits % 8) == 0);
+      assert( (num_bits%8) == 0  );
       addr = g_current_symbol_table->get_global_next();
-      addr_pad = pad_address(addr, num_bits / 8, 128);
-      printf("from 0x%llx to 0x%llx (global memory space)\n", addr + addr_pad,
-             addr + addr_pad + num_bits / 8);
+      addr_pad = pad_address(addr, num_bits/8, 128);
+      printf("from 0x%llx to 0x%llx (global memory space)\n",
+              addr+addr_pad,
+              addr+addr_pad + num_bits/8);
       fflush(stdout);
-      g_last_symbol->set_address(addr + addr_pad);
-      g_current_symbol_table->alloc_global(num_bits / 8 + addr_pad);
-      gpgpu_ctx->func_sim->g_globals.insert(identifier);
-      assert(g_current_symbol_table != NULL);
-      g_sym_name_to_symbol_table[identifier] = g_current_symbol_table;
+      g_last_symbol->set_address( addr+addr_pad );
+      g_current_symbol_table->alloc_global( num_bits/8 + addr_pad );
+      gpgpu_ctx->func_sim->g_globals.insert( identifier );
+      assert( g_current_symbol_table != NULL );
+      g_sym_name_to_symbol_table[ identifier ] = g_current_symbol_table;
       break;
-    case local_space:
-      if (g_func_info == NULL) {
-        printf("GPGPU-Sim PTX: allocating local region for \"%s\" ",
+   case local_space:
+      if( g_func_info == NULL ) {
+          printf("GPGPU-Sim PTX: allocating local region for \"%s\" ", identifier);
+         fflush(stdout);
+         assert( (num_bits%8) == 0  );
+         addr = g_current_symbol_table->get_local_next();
+         addr_pad = pad_address(addr, num_bits/8, 128);
+         printf("from 0x%llx to 0x%llx (local memory space)\n",
+                 addr+addr_pad,
+                 addr+addr_pad + num_bits/8);
+         fflush(stdout);
+         g_last_symbol->set_address( addr+addr_pad);
+         g_current_symbol_table->alloc_local( num_bits/8 + addr_pad);
+      } else {
+        printf("GPGPU-Sim PTX: allocating stack frame region for .local \"%s\" ",
                identifier);
         fflush(stdout);
-        assert((num_bits % 8) == 0);
+        assert( (num_bits%8) == 0 );
         addr = g_current_symbol_table->get_local_next();
-        addr_pad = pad_address(addr, num_bits / 8, 128);
-        printf("from 0x%llx to 0x%llx (local memory space)\n", addr + addr_pad,
-               addr + addr_pad + num_bits / 8);
+        addr_pad = pad_address(addr, num_bits/8, 128);
+        printf("from 0x%llx to 0x%llx\n",
+                addr+addr_pad,
+                addr+addr_pad + num_bits/8);
         fflush(stdout);
-        g_last_symbol->set_address(addr + addr_pad);
-        g_current_symbol_table->alloc_local(num_bits / 8 + addr_pad);
-      } else {
-        printf(
-            "GPGPU-Sim PTX: allocating stack frame region for .local \"%s\" ",
-            identifier);
-        fflush(stdout);
-        assert((num_bits % 8) == 0);
-        addr = g_current_symbol_table->get_local_next();
-        addr_pad = pad_address(addr, num_bits / 8, 128);
-        printf("from 0x%llx to 0x%llx\n", addr + addr_pad,
-               addr + addr_pad + num_bits / 8);
-        fflush(stdout);
-        g_last_symbol->set_address(addr + addr_pad);
-        g_current_symbol_table->alloc_local(num_bits / 8 + addr_pad);
-        g_func_info->set_framesize(g_current_symbol_table->get_local_next());
+        g_last_symbol->set_address( addr+addr_pad );
+        g_current_symbol_table->alloc_local( num_bits/8 + addr_pad);
+        g_func_info->set_framesize( g_current_symbol_table->get_local_next() );
       }
       break;
-    case tex_space:
+   case tex_space:
       printf("GPGPU-Sim PTX: encountered texture directive %s.\n", identifier);
       break;
-    case param_space_local:
-      printf(
-          "GPGPU-Sim PTX: allocating stack frame region for .param \"%s\" from "
-          "0x%x to 0x%lx\n",
-          identifier, g_current_symbol_table->get_local_next(),
-          g_current_symbol_table->get_local_next() + num_bits / 8);
+   case param_space_local:
+      printf("GPGPU-Sim PTX: allocating stack frame region for .param \"%s\" from 0x%x to 0x%lx\n",
+             identifier,
+             g_current_symbol_table->get_local_next(),
+             g_current_symbol_table->get_local_next() + num_bits/8 );
       fflush(stdout);
-      assert((num_bits % 8) == 0);
-      g_last_symbol->set_address(g_current_symbol_table->get_local_next());
-      g_current_symbol_table->alloc_local(num_bits / 8);
-      g_func_info->set_framesize(g_current_symbol_table->get_local_next());
+      assert( (num_bits%8) == 0  );
+      g_last_symbol->set_address( g_current_symbol_table->get_local_next() );
+      g_current_symbol_table->alloc_local( num_bits/8 );
+      g_func_info->set_framesize( g_current_symbol_table->get_local_next() );
       break;
-    case param_space_kernel:
+   case param_space_kernel:
       break;
-    default:
+   default:
       abort();
       break;
-  }
+   }
 
-  assert(!ti.is_param_unclassified());
-  if (ti.is_param_kernel()) {
-    bool is_ptr = (g_ptr_spec != undefined_space);
-    g_func_info->add_param_name_type_size(g_entry_func_param_index, identifier,
-                                          ti.scalar_type(), num_bits, is_ptr,
-                                          g_ptr_spec);
-    g_entry_func_param_index++;
-  }
+   assert( !ti.is_param_unclassified() );
+   if ( ti.is_param_kernel() ) {
+      bool is_ptr = (g_ptr_spec != undefined_space); 
+      g_func_info->add_param_name_type_size(g_entry_func_param_index,identifier, ti.scalar_type(), num_bits, is_ptr, g_ptr_spec);
+      g_entry_func_param_index++;
+   }
 }
 
-void ptx_recognizer::add_constptr(const char *identifier1,
-                                  const char *identifier2, int offset) {
-  symbol *s1 = g_current_symbol_table->lookup(identifier1);
-  const symbol *s2 = g_current_symbol_table->lookup(identifier2);
-  parse_assert(s1 != NULL, "'from' constant identifier does not exist.");
-  parse_assert(s1 != NULL, "'to' constant identifier does not exist.");
+void ptx_recognizer::add_constptr(const char* identifier1, const char* identifier2, int offset)
+{
+   symbol *s1 = g_current_symbol_table->lookup(identifier1);
+   const symbol *s2 = g_current_symbol_table->lookup(identifier2);
+   parse_assert( s1 != NULL, "'from' constant identifier does not exist.");
+   parse_assert( s1 != NULL, "'to' constant identifier does not exist.");
 
-  unsigned addr = s2->get_address();
+   unsigned addr = s2->get_address();
 
-  printf("GPGPU-Sim PTX: moving \"%s\" from 0x%x to 0x%x (%s+%x)\n",
-         identifier1, s1->get_address(), addr + offset, identifier2, offset);
+   printf("GPGPU-Sim PTX: moving \"%s\" from 0x%x to 0x%x (%s+%x)\n",
+      identifier1, s1->get_address(), addr+offset, identifier2, offset);
 
-  s1->set_address(addr + offset);
+   s1->set_address( addr + offset );
 }
 
-void ptx_recognizer::add_function_arg() {
-  assert(g_size > 0);
-  if (g_func_info) {
-    PTX_PARSE_DPRINTF("add_function_arg \"%s\"", g_last_symbol->name().c_str());
-    g_func_info->add_arg(g_last_symbol);
-    unsigned alignment = (g_alignment_spec == -1) ? g_size : g_alignment_spec;
-    assert(alignment == 1 || alignment == 2 || alignment == 4 ||
-           alignment == 8 || alignment == 16);  // known valid alignment values
-    g_func_info->add_config_param(g_size, alignment);
-  }
+void ptx_recognizer::add_function_arg()
+{
+   assert(g_size>0);
+   if( g_func_info ) {
+      PTX_PARSE_DPRINTF("add_function_arg \"%s\"", g_last_symbol->name().c_str() );
+      g_func_info->add_arg(g_last_symbol);
+      unsigned alignment = (g_alignment_spec==-1) ? g_size : g_alignment_spec;
+      assert(alignment==1||alignment==2||alignment==4||alignment==8||alignment==16);//known valid alignment values
+      g_func_info->add_config_param( g_size,  alignment);
+   }
+
 }
 
-void ptx_recognizer::add_extern_spec() {
-  PTX_PARSE_DPRINTF("add_extern_spec");
-  g_extern_spec = 1;
+void ptx_recognizer::add_extern_spec()
+{
+   PTX_PARSE_DPRINTF("add_extern_spec");
+   g_extern_spec = 1;
 }
 
-void ptx_recognizer::add_alignment_spec(int spec) {
-  PTX_PARSE_DPRINTF("add_alignment_spec");
-  parse_assert(
-      g_alignment_spec == -1,
-      "multiple .align specifiers per variable declaration not allowed.");
-  g_alignment_spec = spec;
+void ptx_recognizer::add_alignment_spec( int spec )
+{
+   PTX_PARSE_DPRINTF("add_alignment_spec");
+   parse_assert( g_alignment_spec == -1, "multiple .align specifiers per variable declaration not allowed." );
+   g_alignment_spec = spec;
 }
 
-void ptx_recognizer::add_ptr_spec(enum _memory_space_t spec) {
-  PTX_PARSE_DPRINTF("add_ptr_spec \"%s\"", g_ptx_token_decode[spec].c_str());
-  parse_assert(g_ptr_spec == undefined_space,
-               "multiple ptr space specifiers not allowed.");
-  parse_assert(
-      spec == global_space or spec == local_space or spec == shared_space,
-      "invalid space for ptr directive.");
-  g_ptr_spec = spec;
+void ptx_recognizer::add_ptr_spec( enum _memory_space_t spec )
+{
+   PTX_PARSE_DPRINTF("add_ptr_spec \"%s\"", g_ptx_token_decode[spec].c_str() );
+   parse_assert( g_ptr_spec == undefined_space, "multiple ptr space specifiers not allowed." );
+   parse_assert( spec == global_space or spec == local_space or spec == shared_space, "invalid space for ptr directive." );
+   g_ptr_spec = spec; 
 }
 
-void ptx_recognizer::add_space_spec(enum _memory_space_t spec, int value) {
-  PTX_PARSE_DPRINTF("add_space_spec \"%s\"", g_ptx_token_decode[spec].c_str());
-  parse_assert(g_space_spec == undefined_space,
-               "multiple space specifiers not allowed.");
-  if (spec == param_space_unclassified) {
-    if (g_func_decl) {
-      if (g_entry_point == 1)
-        g_space_spec = param_space_kernel;
-      else
-        g_space_spec = param_space_local;
-    } else
-      g_space_spec = param_space_unclassified;
-  } else {
-    g_space_spec = spec;
-    if (g_space_spec == const_space) g_space_spec.set_bank((unsigned)value);
-  }
+void ptx_recognizer::add_space_spec( enum _memory_space_t spec, int value )
+{
+   PTX_PARSE_DPRINTF("add_space_spec \"%s\"", g_ptx_token_decode[spec].c_str() );
+   parse_assert( g_space_spec == undefined_space, "multiple space specifiers not allowed." );
+   if( spec == param_space_unclassified ) {
+      if( g_func_decl ) {
+         if( g_entry_point == 1) 
+            g_space_spec = param_space_kernel;
+         else 
+            g_space_spec = param_space_local;
+      } else
+         g_space_spec = param_space_unclassified;
+   } else {
+      g_space_spec = spec;
+      if( g_space_spec == const_space )
+         g_space_spec.set_bank((unsigned)value);
+   }
 }
 
-void ptx_recognizer::add_vector_spec(int spec) {
-  PTX_PARSE_DPRINTF("add_vector_spec");
-  parse_assert(g_vector_spec == -1, "multiple vector specifiers not allowed.");
-  g_vector_spec = spec;
+void ptx_recognizer::add_vector_spec(int spec )
+{
+   PTX_PARSE_DPRINTF("add_vector_spec");
+   parse_assert( g_vector_spec == -1, "multiple vector specifiers not allowed." );
+   g_vector_spec = spec;
 }
 
-void ptx_recognizer::add_scalar_type_spec(int type_spec) {
-  // save size of parameter
-  switch (type_spec) {
-    case B8_TYPE:
-    case S8_TYPE:
-    case U8_TYPE:
-      g_size = 1;
-      break;
-    case B16_TYPE:
-    case S16_TYPE:
-    case U16_TYPE:
-    case F16_TYPE:
-      g_size = 2;
-      break;
-    case B32_TYPE:
-    case S32_TYPE:
-    case U32_TYPE:
-    case F32_TYPE:
-      g_size = 4;
-      break;
-    case B64_TYPE:
-    case BB64_TYPE:
-    case S64_TYPE:
-    case U64_TYPE:
-    case F64_TYPE:
-    case FF64_TYPE:
-      g_size = 8;
-      break;
-    case BB128_TYPE:
-      g_size = 16;
-      break;
-  }
-  PTX_PARSE_DPRINTF("add_scalar_type_spec \"%s\"",
-                    g_ptx_token_decode[type_spec].c_str());
-  g_scalar_type.push_back(type_spec);
-  if (g_scalar_type.size() > 1) {
-    parse_assert((g_opcode == -1) || (g_opcode == CVT_OP) ||
-                     (g_opcode == SET_OP) || (g_opcode == SLCT_OP) ||
-                     (g_opcode == TEX_OP) || (g_opcode == MMA_OP) ||
-                     (g_opcode == DP4A_OP),
-                 "only cvt, set, slct, tex and dp4a can have more than one "
-                 "type specifier.");
-  }
-  g_scalar_type_spec = type_spec;
+void ptx_recognizer::add_scalar_type_spec( int type_spec )
+{
+   //save size of parameter
+   switch ( type_spec ) {
+      case B8_TYPE:
+      case S8_TYPE:
+      case U8_TYPE: 
+         g_size = 1; break;
+      case B16_TYPE:
+      case S16_TYPE:
+      case U16_TYPE:
+      case F16_TYPE: 
+         g_size = 2; break;
+      case B32_TYPE:
+      case S32_TYPE:
+      case U32_TYPE:
+      case F32_TYPE: 
+         g_size = 4; break;
+      case B64_TYPE:
+      case BB64_TYPE:
+      case S64_TYPE:
+      case U64_TYPE:
+      case F64_TYPE: 
+      case FF64_TYPE:
+         g_size = 8; break;
+      case BB128_TYPE: 
+         g_size = 16; break;
+   }
+   PTX_PARSE_DPRINTF("add_scalar_type_spec \"%s\"", g_ptx_token_decode[type_spec].c_str());
+   g_scalar_type.push_back( type_spec );
+   if ( g_scalar_type.size() > 1 ) {
+      parse_assert( (g_opcode == -1) || (g_opcode == CVT_OP) || (g_opcode == SET_OP) || (g_opcode == SLCT_OP)
+                    || (g_opcode == TEX_OP)|| (g_opcode==MMA_OP)|| (g_opcode == DP4A_OP),
+                    "only cvt, set, slct, tex and dp4a can have more than one type specifier.");
+   }
+   g_scalar_type_spec = type_spec;
 }
 
-void ptx_recognizer::add_label(const char *identifier) {
-  PTX_PARSE_DPRINTF("add_label");
-  symbol *s = g_current_symbol_table->lookup(identifier);
-  if (s != NULL) {
-    g_label = s;
-  } else {
-    g_label = g_current_symbol_table->add_variable(
-        identifier, NULL, 0, gpgpu_ctx->g_filename, ptx_get_lineno(scanner));
-  }
+void ptx_recognizer::add_label( const char *identifier )
+{
+   PTX_PARSE_DPRINTF("add_label");
+   symbol *s = g_current_symbol_table->lookup(identifier);
+   if ( s != NULL ) {
+      g_label = s;
+   } else {
+      g_label = g_current_symbol_table->add_variable(identifier,NULL,0,gpgpu_ctx->g_filename,ptx_get_lineno(scanner));
+   }
 }
 
-void ptx_recognizer::add_opcode(int opcode) { g_opcode = opcode; }
-
-void ptx_recognizer::add_pred(const char *identifier, int neg,
-                              int predModifier) {
-  PTX_PARSE_DPRINTF("add_pred");
-  const symbol *s = g_current_symbol_table->lookup(identifier);
-  if (s == NULL) {
-    std::string msg =
-        std::string("predicate \"") + identifier + "\" has no declaration.";
-    parse_error(msg.c_str());
-  }
-  g_pred = s;
-  g_neg_pred = neg;
-  g_pred_mod = predModifier;
+void ptx_recognizer::add_opcode( int opcode )
+{
+   g_opcode = opcode;
 }
 
-void ptx_recognizer::add_option(int option) {
-  PTX_PARSE_DPRINTF("add_option");
-  g_options.push_back(option);
-}
-void ptx_recognizer::add_wmma_option(int option) {
-  PTX_PARSE_DPRINTF("add_option");
-  g_wmma_options.push_back(option);
-}
-void ptx_recognizer::add_double_operand(const char *d1, const char *d2) {
-  // operands that access two variables.
-  // eg. s[$ofs1+$r0], g[$ofs1+=$r0]
-  // TODO: Not sure if I'm going to use this for storing to two destinations or
-  // not.
-
-  PTX_PARSE_DPRINTF("add_double_operand");
-  const symbol *s1 = g_current_symbol_table->lookup(d1);
-  const symbol *s2 = g_current_symbol_table->lookup(d2);
-  parse_assert(s1 != NULL && s2 != NULL, "component(s) missing declarations.");
-  g_operands.push_back(operand_info(s1, s2, gpgpu_ctx));
+void ptx_recognizer::add_pred( const char *identifier, int neg, int predModifier )
+{
+   PTX_PARSE_DPRINTF("add_pred");
+   const symbol *s = g_current_symbol_table->lookup(identifier);
+   if ( s == NULL ) {
+      std::string msg = std::string("predicate \"") + identifier + "\" has no declaration.";
+      parse_error( msg.c_str() );
+   }
+   g_pred = s;
+   g_neg_pred = neg;
+   g_pred_mod = predModifier;
 }
 
-void ptx_recognizer::add_1vector_operand(const char *d1) {
-  // handles the single element vector operand ({%v1}) found in tex.1d
-  // instructions
-  PTX_PARSE_DPRINTF("add_1vector_operand");
-  const symbol *s1 = g_current_symbol_table->lookup(d1);
-  parse_assert(s1 != NULL, "component(s) missing declarations.");
-  g_operands.push_back(operand_info(s1, NULL, NULL, NULL, gpgpu_ctx));
+void ptx_recognizer::add_option( int option )
+{
+   PTX_PARSE_DPRINTF("add_option");
+   g_options.push_back( option );
+}
+void ptx_recognizer::add_wmma_option( int option )
+{
+   PTX_PARSE_DPRINTF("add_option");
+   g_wmma_options.push_back( option );
+}
+void ptx_recognizer::add_double_operand( const char *d1, const char *d2 )
+{
+   //operands that access two variables.
+   //eg. s[$ofs1+$r0], g[$ofs1+=$r0]
+   //TODO: Not sure if I'm going to use this for storing to two destinations or not.
+
+   PTX_PARSE_DPRINTF("add_double_operand");
+   const symbol *s1 = g_current_symbol_table->lookup(d1);
+   const symbol *s2 = g_current_symbol_table->lookup(d2);
+   parse_assert( s1 != NULL && s2 != NULL, "component(s) missing declarations.");
+   g_operands.push_back( operand_info(s1,s2,gpgpu_ctx) );
 }
 
-void ptx_recognizer::add_2vector_operand(const char *d1, const char *d2) {
-  PTX_PARSE_DPRINTF("add_2vector_operand");
-  const symbol *s1 = g_current_symbol_table->lookup(d1);
-  const symbol *s2 = g_current_symbol_table->lookup(d2);
-  parse_assert(s1 != NULL && s2 != NULL,
-               "v2 component(s) missing declarations.");
-  g_operands.push_back(operand_info(s1, s2, NULL, NULL, gpgpu_ctx));
+void ptx_recognizer::add_1vector_operand( const char *d1 )
+{
+   // handles the single element vector operand ({%v1}) found in tex.1d instructions
+   PTX_PARSE_DPRINTF("add_1vector_operand");
+   const symbol *s1 = g_current_symbol_table->lookup(d1);
+   parse_assert( s1 != NULL, "component(s) missing declarations.");
+   g_operands.push_back( operand_info(s1,NULL,NULL,NULL,gpgpu_ctx) );
 }
 
-void ptx_recognizer::add_3vector_operand(const char *d1, const char *d2,
-                                         const char *d3) {
-  PTX_PARSE_DPRINTF("add_3vector_operand");
-  const symbol *s1 = g_current_symbol_table->lookup(d1);
-  const symbol *s2 = g_current_symbol_table->lookup(d2);
-  const symbol *s3 = g_current_symbol_table->lookup(d3);
-  parse_assert(s1 != NULL && s2 != NULL && s3 != NULL,
-               "v3 component(s) missing declarations.");
-  g_operands.push_back(operand_info(s1, s2, s3, NULL, gpgpu_ctx));
+void ptx_recognizer::add_2vector_operand( const char *d1, const char *d2 )
+{
+   PTX_PARSE_DPRINTF("add_2vector_operand");
+   const symbol *s1 = g_current_symbol_table->lookup(d1);
+   const symbol *s2 = g_current_symbol_table->lookup(d2);
+   parse_assert( s1 != NULL && s2 != NULL, "v2 component(s) missing declarations.");
+   g_operands.push_back( operand_info(s1,s2,NULL,NULL,gpgpu_ctx) );
 }
 
-void ptx_recognizer::add_4vector_operand(const char *d1, const char *d2,
-                                         const char *d3, const char *d4) {
-  PTX_PARSE_DPRINTF("add_4vector_operand");
-  const symbol *s1 = g_current_symbol_table->lookup(d1);
-  const symbol *s2 = g_current_symbol_table->lookup(d2);
-  const symbol *s3 = g_current_symbol_table->lookup(d3);
-  const symbol *s4 = g_current_symbol_table->lookup(d4);
-  parse_assert(s1 != NULL && s2 != NULL && s3 != NULL && s4 != NULL,
-               "v4 component(s) missing declarations.");
-  const symbol *null_op = g_current_symbol_table->lookup("_");
-  if (s2 == null_op) s2 = NULL;
-  if (s3 == null_op) s3 = NULL;
-  if (s4 == null_op) s4 = NULL;
-  g_operands.push_back(operand_info(s1, s2, s3, s4, gpgpu_ctx));
-}
-void ptx_recognizer::add_8vector_operand(const char *d1, const char *d2,
-                                         const char *d3, const char *d4,
-                                         const char *d5, const char *d6,
-                                         const char *d7, const char *d8) {
-  PTX_PARSE_DPRINTF("add_8vector_operand");
-  const symbol *s1 = g_current_symbol_table->lookup(d1);
-  const symbol *s2 = g_current_symbol_table->lookup(d2);
-  const symbol *s3 = g_current_symbol_table->lookup(d3);
-  const symbol *s4 = g_current_symbol_table->lookup(d4);
-  const symbol *s5 = g_current_symbol_table->lookup(d5);
-  const symbol *s6 = g_current_symbol_table->lookup(d6);
-  const symbol *s7 = g_current_symbol_table->lookup(d7);
-  const symbol *s8 = g_current_symbol_table->lookup(d8);
-  parse_assert(s1 != NULL && s2 != NULL && s3 != NULL && s4 != NULL &&
-                   s5 != NULL && s6 != NULL && s7 != NULL && s8 != NULL,
-               "v4 component(s) missing declarations.");
-  const symbol *null_op = g_current_symbol_table->lookup("_");
-  if (s2 == null_op) s2 = NULL;
-  if (s3 == null_op) s3 = NULL;
-  if (s4 == null_op) s4 = NULL;
-  if (s5 == null_op) s5 = NULL;
-  if (s6 == null_op) s6 = NULL;
-  if (s7 == null_op) s7 = NULL;
-  if (s8 == null_op) s8 = NULL;
-  g_operands.push_back(operand_info(s1, s2, s3, s4, s5, s6, s7, s8, gpgpu_ctx));
+void ptx_recognizer::add_3vector_operand( const char *d1, const char *d2, const char *d3 )
+{
+   PTX_PARSE_DPRINTF("add_3vector_operand");
+   const symbol *s1 = g_current_symbol_table->lookup(d1);
+   const symbol *s2 = g_current_symbol_table->lookup(d2);
+   const symbol *s3 = g_current_symbol_table->lookup(d3);
+   parse_assert( s1 != NULL && s2 != NULL && s3 != NULL, "v3 component(s) missing declarations.");
+   g_operands.push_back( operand_info(s1,s2,s3,NULL,gpgpu_ctx) );
 }
 
-void ptx_recognizer::add_builtin_operand(int builtin, int dim_modifier) {
-  PTX_PARSE_DPRINTF("add_builtin_operand");
-  g_operands.push_back(operand_info(builtin, dim_modifier, gpgpu_ctx));
+void ptx_recognizer::add_4vector_operand( const char *d1, const char *d2, const char *d3, const char *d4 )
+{
+   PTX_PARSE_DPRINTF("add_4vector_operand");
+   const symbol *s1 = g_current_symbol_table->lookup(d1);
+   const symbol *s2 = g_current_symbol_table->lookup(d2);
+   const symbol *s3 = g_current_symbol_table->lookup(d3);
+   const symbol *s4 = g_current_symbol_table->lookup(d4);
+   parse_assert( s1 != NULL && s2 != NULL && s3 != NULL && s4 != NULL, "v4 component(s) missing declarations.");
+   const symbol *null_op = g_current_symbol_table->lookup("_");
+   if ( s2 == null_op ) s2 = NULL;
+   if ( s3 == null_op ) s3 = NULL;
+   if ( s4 == null_op ) s4 = NULL;
+   g_operands.push_back( operand_info(s1,s2,s3,s4,gpgpu_ctx) );
+}
+void ptx_recognizer::add_8vector_operand( const char *d1, const char *d2, const char *d3, const char *d4,const char *d5,const char *d6,const char *d7,const char *d8 )
+{
+   PTX_PARSE_DPRINTF("add_8vector_operand");
+   const symbol *s1 = g_current_symbol_table->lookup(d1);
+   const symbol *s2 = g_current_symbol_table->lookup(d2);
+   const symbol *s3 = g_current_symbol_table->lookup(d3);
+   const symbol *s4 = g_current_symbol_table->lookup(d4);
+   const symbol *s5 = g_current_symbol_table->lookup(d5);
+   const symbol *s6 = g_current_symbol_table->lookup(d6);
+   const symbol *s7 = g_current_symbol_table->lookup(d7);
+   const symbol *s8 = g_current_symbol_table->lookup(d8);
+   parse_assert( s1 != NULL && s2 != NULL && s3 != NULL && s4 != NULL && s5 !=NULL && s6 !=NULL && s7 !=NULL && s8 !=NULL, "v4 component(s) missing declarations.");
+   const symbol *null_op = g_current_symbol_table->lookup("_");
+   if ( s2 == null_op ) s2 = NULL;
+   if ( s3 == null_op ) s3 = NULL;
+   if ( s4 == null_op ) s4 = NULL;
+   if ( s5 == null_op ) s5 = NULL;
+   if ( s6 == null_op ) s6 = NULL;
+   if ( s7 == null_op ) s7 = NULL;
+   if ( s8 == null_op ) s8 = NULL;
+   g_operands.push_back( operand_info(s1,s2,s3,s4,s5,s6,s7,s8,gpgpu_ctx) );
 }
 
-void ptx_recognizer::add_memory_operand() {
-  PTX_PARSE_DPRINTF("add_memory_operand");
-  assert(!g_operands.empty());
-  g_operands.back().make_memory_operand();
+void ptx_recognizer::add_builtin_operand( int builtin, int dim_modifier )
+{
+   PTX_PARSE_DPRINTF("add_builtin_operand");
+   g_operands.push_back( operand_info(builtin,dim_modifier,gpgpu_ctx) );
+}
+
+void ptx_recognizer::add_memory_operand()
+{
+   PTX_PARSE_DPRINTF("add_memory_operand");
+   assert( !g_operands.empty() );
+   g_operands.back().make_memory_operand();
 }
 
 /*TODO: add other memory locations*/
-void ptx_recognizer::change_memory_addr_space(const char *identifier) {
-  /*0 = N/A, not reading from memory
-   *1 = global memory
-   *2 = shared memory
-   *3 = const memory segment
-   *4 = local memory segment
-   */
+void ptx_recognizer::change_memory_addr_space(const char *identifier)
+{
+   /*0 = N/A, not reading from memory
+    *1 = global memory
+    *2 = shared memory
+    *3 = const memory segment
+    *4 = local memory segment
+    */
 
-  bool recognizedType = false;
+   bool recognizedType = false;
 
-  PTX_PARSE_DPRINTF("change_memory_addr_space");
-  assert(!g_operands.empty());
-  if (!strcmp(identifier, "g")) {
-    g_operands.back().set_addr_space(global_space);
-    recognizedType = true;
-  }
-  if (!strcmp(identifier, "s")) {
-    g_operands.back().set_addr_space(shared_space);
-    recognizedType = true;
-  }
-  // For constants, check if the first character is 'c'
-  char c[2];
-  strncpy(c, identifier, 1);
-  c[1] = '\0';
-  if (!strcmp(c, "c")) {
-    g_operands.back().set_addr_space(const_space);
-    parse_assert(g_current_symbol_table->lookup(identifier) != NULL,
-                 "Constant was not defined.");
-    g_operands.back().set_const_mem_offset(
-        g_current_symbol_table->lookup(identifier)->get_address());
-    recognizedType = true;
-  }
-  // For local memory, check if the first character is 'l'
-  char l[2];
-  strncpy(l, identifier, 1);
-  l[1] = '\0';
-  if (!strcmp(l, "l")) {
-    g_operands.back().set_addr_space(local_space);
-    // parse_assert(g_current_symbol_table->lookup(identifier) != NULL, "Local
-    // memory segment was not defined.");
-    // g_operands.back().set_const_mem_offset(g_current_symbol_table->lookup(identifier)->get_address());
-    recognizedType = true;
-  }
+   PTX_PARSE_DPRINTF("change_memory_addr_space");
+   assert( !g_operands.empty() );
+   if(!strcmp(identifier, "g"))
+   {
+       g_operands.back().set_addr_space(global_space);
+       recognizedType = true;
+   }
+   if(!strcmp(identifier, "s"))
+   {
+       g_operands.back().set_addr_space(shared_space);
+       recognizedType = true;
+   }
+   // For constants, check if the first character is 'c'
+   char c[2];
+   strncpy(c, identifier, 1); c[1] = '\0';
+   if(!strcmp(c, "c"))
+   {
+       g_operands.back().set_addr_space(const_space);
+       parse_assert(g_current_symbol_table->lookup(identifier) != NULL, "Constant was not defined.");
+       g_operands.back().set_const_mem_offset(g_current_symbol_table->lookup(identifier)->get_address());
+       recognizedType = true;
+   }
+   // For local memory, check if the first character is 'l'
+   char l[2];
+   strncpy(l, identifier, 1); l[1] = '\0';
+   if(!strcmp(l, "l"))
+   {
+       g_operands.back().set_addr_space(local_space);
+       //parse_assert(g_current_symbol_table->lookup(identifier) != NULL, "Local memory segment was not defined.");
+       //g_operands.back().set_const_mem_offset(g_current_symbol_table->lookup(identifier)->get_address());
+       recognizedType = true;
+   }
 
-  parse_assert(recognizedType, "Error: unrecognized memory type.");
+   parse_assert(recognizedType, "Error: unrecognized memory type.");
 }
 
-void ptx_recognizer::change_operand_lohi(int lohi) {
-  /*0 = N/A, read entire operand
-   *1 = lo, reading from lowest bits
-   *2 = hi, reading from highest bits
-   */
+void ptx_recognizer::change_operand_lohi( int lohi )
+{
+   /*0 = N/A, read entire operand
+    *1 = lo, reading from lowest bits
+    *2 = hi, reading from highest bits
+    */
 
-  PTX_PARSE_DPRINTF("change_operand_lohi");
-  assert(!g_operands.empty());
+   PTX_PARSE_DPRINTF("change_operand_lohi");
+   assert( !g_operands.empty() );
 
-  g_operands.back().set_operand_lohi(lohi);
+   g_operands.back().set_operand_lohi(lohi);
+
 }
 
-void ptx_recognizer::set_immediate_operand_type() {
-  PTX_PARSE_DPRINTF("set_immediate_operand_type");
-  assert(!g_operands.empty());
-  g_operands.back().set_immediate_addr();
+void ptx_recognizer::set_immediate_operand_type ()
+{
+     PTX_PARSE_DPRINTF("set_immediate_operand_type");
+     assert( !g_operands.empty() );
+     g_operands.back().set_immediate_addr();
 }
 
-void ptx_recognizer::change_double_operand_type(int operand_type) {
-  /*
-   *-3 = reg / reg (set instruction, but both get same value)
-   *-2 = reg | reg (cvt instruction)
-   *-1 = reg | reg (set instruction)
-   *0 = N/A, default
-   *1 = reg + reg
-   *2 = reg += reg
-   *3 = reg += immediate
-   */
+void ptx_recognizer::change_double_operand_type( int operand_type )
+{
+   /*
+    *-3 = reg / reg (set instruction, but both get same value)
+    *-2 = reg | reg (cvt instruction)
+    *-1 = reg | reg (set instruction)
+    *0 = N/A, default
+    *1 = reg + reg
+    *2 = reg += reg
+    *3 = reg += immediate
+    */
 
-  PTX_PARSE_DPRINTF("change_double_operand_type");
-  assert(!g_operands.empty());
+   PTX_PARSE_DPRINTF("change_double_operand_type");
+   assert( !g_operands.empty() );
 
-  // For double destination operands, ensure valid instruction
-  if (operand_type == -1 || operand_type == -2) {
-    if ((g_opcode == SET_OP) || (g_opcode == SETP_OP))
-      g_operands.back().set_double_operand_type(-1);
-    else
-      g_operands.back().set_double_operand_type(-2);
-  } else if (operand_type == -3) {
-    if (g_opcode == SET_OP || g_opcode == MAD_OP)
+   // For double destination operands, ensure valid instruction
+   if( operand_type == -1 || operand_type == -2 ) {
+      if((g_opcode == SET_OP)||(g_opcode == SETP_OP))
+         g_operands.back().set_double_operand_type(-1);
+      else
+         g_operands.back().set_double_operand_type(-2);
+   } else if( operand_type == -3 ) {
+      if(g_opcode == SET_OP || g_opcode == MAD_OP)
+         g_operands.back().set_double_operand_type(operand_type);
+      else
+         parse_assert(0, "Error: Unsupported use of double destination operand.");
+   } else {
       g_operands.back().set_double_operand_type(operand_type);
-    else
-      parse_assert(0, "Error: Unsupported use of double destination operand.");
-  } else {
-    g_operands.back().set_double_operand_type(operand_type);
-  }
+   }
+
 }
 
-void ptx_recognizer::change_operand_neg() {
-  PTX_PARSE_DPRINTF("change_operand_neg");
-  assert(!g_operands.empty());
+void ptx_recognizer::change_operand_neg( )
+{
+   PTX_PARSE_DPRINTF("change_operand_neg");
+   assert( !g_operands.empty() );
 
-  g_operands.back().set_operand_neg();
+   g_operands.back().set_operand_neg();
+
 }
 
-void ptx_recognizer::add_literal_int(int value) {
-  PTX_PARSE_DPRINTF("add_literal_int");
-  g_operands.push_back(operand_info(value, gpgpu_ctx));
+void ptx_recognizer::add_literal_int( int value )
+{
+   PTX_PARSE_DPRINTF("add_literal_int");
+   g_operands.push_back( operand_info(value,gpgpu_ctx) );
 }
 
-void ptx_recognizer::add_literal_float(float value) {
-  PTX_PARSE_DPRINTF("add_literal_float");
-  g_operands.push_back(operand_info(value, gpgpu_ctx));
+void ptx_recognizer::add_literal_float( float value )
+{
+   PTX_PARSE_DPRINTF("add_literal_float");
+   g_operands.push_back( operand_info(value,gpgpu_ctx) );
 }
 
-void ptx_recognizer::add_literal_double(double value) {
-  PTX_PARSE_DPRINTF("add_literal_double");
-  g_operands.push_back(operand_info(value, gpgpu_ctx));
+void ptx_recognizer::add_literal_double( double value )
+{
+   PTX_PARSE_DPRINTF("add_literal_double");
+   g_operands.push_back( operand_info(value,gpgpu_ctx) );
 }
 
-void ptx_recognizer::add_scalar_operand(const char *identifier) {
-  PTX_PARSE_DPRINTF("add_scalar_operand");
-  const symbol *s = g_current_symbol_table->lookup(identifier);
-  if (s == NULL) {
-    if (g_opcode == BRA_OP || g_opcode == CALLP_OP) {
-      // forward branch target...
-      s = g_current_symbol_table->add_variable(
-          identifier, NULL, 0, gpgpu_ctx->g_filename, ptx_get_lineno(scanner));
-    } else {
-      std::string msg =
-          std::string("operand \"") + identifier + "\" has no declaration.";
-      parse_error(msg.c_str());
-    }
-  }
-  g_operands.push_back(operand_info(s, gpgpu_ctx));
+void ptx_recognizer::add_scalar_operand( const char *identifier )
+{
+   PTX_PARSE_DPRINTF("add_scalar_operand");
+   const symbol *s = g_current_symbol_table->lookup(identifier);
+   if ( s == NULL ) {
+      if ( g_opcode == BRA_OP || g_opcode == CALLP_OP) {
+         // forward branch target...
+         s = g_current_symbol_table->add_variable(identifier,NULL,0,gpgpu_ctx->g_filename,ptx_get_lineno(scanner));
+      } else {
+         std::string msg = std::string("operand \"") + identifier + "\" has no declaration.";
+         parse_error( msg.c_str() );
+      }
+   }
+   g_operands.push_back( operand_info(s,gpgpu_ctx) );
 }
 
-void ptx_recognizer::add_neg_pred_operand(const char *identifier) {
-  PTX_PARSE_DPRINTF("add_neg_pred_operand");
-  const symbol *s = g_current_symbol_table->lookup(identifier);
-  if (s == NULL) {
-    s = g_current_symbol_table->add_variable(
-        identifier, NULL, 1, gpgpu_ctx->g_filename, ptx_get_lineno(scanner));
-  }
-  operand_info op(s, gpgpu_ctx);
-  op.set_neg_pred();
-  g_operands.push_back(op);
+void ptx_recognizer::add_neg_pred_operand( const char *identifier )
+{
+   PTX_PARSE_DPRINTF("add_neg_pred_operand");
+   const symbol *s = g_current_symbol_table->lookup(identifier);
+   if ( s == NULL ) {
+       s = g_current_symbol_table->add_variable(identifier,NULL,1,gpgpu_ctx->g_filename,ptx_get_lineno(scanner));
+   }
+   operand_info op(s, gpgpu_ctx);
+   op.set_neg_pred();
+   g_operands.push_back( op );
 }
 
-void ptx_recognizer::add_address_operand(const char *identifier, int offset) {
-  PTX_PARSE_DPRINTF("add_address_operand");
-  const symbol *s = g_current_symbol_table->lookup(identifier);
-  if (s == NULL) {
-    std::string msg =
-        std::string("operand \"") + identifier + "\" has no declaration.";
-    parse_error(msg.c_str());
-  }
-  g_operands.push_back(operand_info(s, offset, gpgpu_ctx));
+void ptx_recognizer::add_address_operand( const char *identifier, int offset )
+{
+   PTX_PARSE_DPRINTF("add_address_operand");
+   const symbol *s = g_current_symbol_table->lookup(identifier);
+   if ( s == NULL ) {
+      std::string msg = std::string("operand \"") + identifier + "\" has no declaration.";
+      parse_error( msg.c_str() );
+   }
+   g_operands.push_back( operand_info(s,offset,gpgpu_ctx) );
 }
 
-void ptx_recognizer::add_address_operand2(int offset) {
-  PTX_PARSE_DPRINTF("add_address_operand");
-  g_operands.push_back(operand_info((unsigned)offset, gpgpu_ctx));
+void ptx_recognizer::add_address_operand2( int offset )
+{
+   PTX_PARSE_DPRINTF("add_address_operand");
+   g_operands.push_back( operand_info((unsigned)offset,gpgpu_ctx) );
 }
 
-void ptx_recognizer::add_array_initializer() {
-  g_last_symbol->add_initializer(g_operands);
+void ptx_recognizer::add_array_initializer()
+{
+   g_last_symbol->add_initializer(g_operands);
 }
 
-void ptx_recognizer::add_version_info(float ver, unsigned ext) {
-  g_global_symbol_table->set_ptx_version(ver, ext);
+void ptx_recognizer::add_version_info( float ver, unsigned ext )
+{
+   g_global_symbol_table->set_ptx_version(ver,ext);
 }
 
-void ptx_recognizer::add_file(unsigned num, const char *filename) {
-  if (gpgpu_ctx->g_filename == NULL) {
-    char *b = strdup(filename);
-    char *l = b;
-    char *n = b;
-    while (*n != '\0') {
-      if (*n == '/') l = n + 1;
-      n++;
-    }
+void ptx_recognizer::add_file( unsigned num, const char *filename )
+{
+   if( gpgpu_ctx->g_filename == NULL ) {
+      char *b = strdup(filename);
+      char *l=b;
+      char *n=b;
+      while( *n != '\0' ) {
+          if( *n == '/' ) 
+              l = n+1;
+          n++;
+      }
 
-    char *p = strtok(l, ".");
-    char buf[1024];
-    snprintf(buf, 1024, "%s.ptx", p);
+      char *p = strtok(l,".");
+      char buf[1024];
+      snprintf(buf,1024,"%s.ptx",p);
 
-    char *q = strtok(NULL, ".");
-    if (q && !strcmp(q, "cu")) {
-      gpgpu_ctx->g_filename = strdup(buf);
-    }
+      char *q = strtok(NULL,".");
+      if( q && !strcmp(q,"cu") ) {
+          gpgpu_ctx->g_filename = strdup(buf);
+      }
 
-    free(b);
-  }
+      free( b );
+   }
 
-  g_current_symbol_table = g_global_symbol_table;
+   g_current_symbol_table = g_global_symbol_table;
 }
 
-void *ptx_recognizer::reset_symtab() {
-  void *result = g_current_symbol_table;
-  g_current_symbol_table = g_global_symbol_table;
-  return result;
+void * ptx_recognizer::reset_symtab()
+{
+   void *result = g_current_symbol_table;
+   g_current_symbol_table = g_global_symbol_table;
+   return result;
 }
 
-void ptx_recognizer::set_symtab(void *symtab) {
-  g_current_symbol_table = (symbol_table *)symtab;
+void ptx_recognizer::set_symtab(void*symtab)
+{
+   g_current_symbol_table = (symbol_table*)symtab;
 }
 
-void ptx_recognizer::add_pragma(const char *str) {
-  printf("GPGPU-Sim PTX: Warning -- ignoring pragma '%s'\n", str);
+void ptx_recognizer::add_pragma( const char *str )
+{
+   printf("GPGPU-Sim PTX: Warning -- ignoring pragma '%s'\n", str );
 }
 
-void ptx_recognizer::version_header(double a) {}  // intentional dummy function
+void ptx_recognizer::version_header(double a) {}  //intentional dummy function
 
-void ptx_recognizer::target_header(char *a) {
-  g_global_symbol_table->set_sm_target(a, NULL, NULL);
+void ptx_recognizer::target_header(char* a)
+{
+   g_global_symbol_table->set_sm_target(a,NULL,NULL);
 }
 
-void ptx_recognizer::target_header2(char *a, char *b) {
-  g_global_symbol_table->set_sm_target(a, b, NULL);
+void ptx_recognizer::target_header2(char* a, char* b)
+{
+   g_global_symbol_table->set_sm_target(a,b,NULL);
 }
 
-void ptx_recognizer::target_header3(char *a, char *b, char *c) {
-  g_global_symbol_table->set_sm_target(a, b, c);
+void ptx_recognizer::target_header3(char* a, char* b, char* c)
+{
+   g_global_symbol_table->set_sm_target(a,b,c);
 }
 
 void ptx_recognizer::maxnt_id(int x, int y, int z) {
   g_func_info->set_maxnt_id(x * y * z);
 }
 
-void ptx_recognizer::func_header(const char *a) {}  // intentional dummy
-                                                    // function
-void ptx_recognizer::func_header_info(const char *a) {
-}  // intentional dummy function
-void ptx_recognizer::func_header_info_int(const char *a, int b) {
-}  // intentional dummy function
+void ptx_recognizer::func_header(const char* a) {} //intentional dummy function
+void ptx_recognizer::func_header_info(const char* a) {} //intentional dummy function
+void ptx_recognizer::func_header_info_int(const char* a, int b) {} //intentional dummy function

--- a/src/cuda-sim/ptx_parser.cc
+++ b/src/cuda-sim/ptx_parser.cc
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -26,998 +28,971 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "ptx_parser.h"
-#include "ptx_ir.h"
 #include "../../libcuda/gpgpu_context.h"
+#include "ptx_ir.h"
 
-typedef void * yyscan_t;
-#include "ptx.tab.h"
+typedef void *yyscan_t;
 #include <stdarg.h>
+#include "ptx.tab.h"
 
-extern int ptx_get_lineno (yyscan_t yyscanner );
-extern YYSTYPE* ptx_get_lval (yyscan_t yyscanner );
-extern int ptx_error( yyscan_t yyscanner, const char *s );
-extern int ptx_lex_init(yyscan_t* scanner);
-extern void ptx_set_in(FILE * _in_str ,yyscan_t yyscanner );
-extern FILE *ptx_get_in (yyscan_t yyscanner );
-extern int ptx_parse(yyscan_t scanner, ptx_recognizer* recognizer);
+extern int ptx_get_lineno(yyscan_t yyscanner);
+extern YYSTYPE *ptx_get_lval(yyscan_t yyscanner);
+extern int ptx_error(yyscan_t yyscanner, const char *s);
+extern int ptx_lex_init(yyscan_t *scanner);
+extern void ptx_set_in(FILE *_in_str, yyscan_t yyscanner);
+extern FILE *ptx_get_in(yyscan_t yyscanner);
+extern int ptx_parse(yyscan_t scanner, ptx_recognizer *recognizer);
 extern int ptx_lex_destroy(yyscan_t scanner);
 
-void ptx_recognizer::set_ptx_warp_size(const struct core_config * warp_size)
-{
-   g_shader_core_config=warp_size;
+void ptx_recognizer::set_ptx_warp_size(const struct core_config *warp_size) {
+  g_shader_core_config = warp_size;
 }
 
+#define PTX_PARSE_DPRINTF(...)                                            \
+  if (g_debug_ir_generation) {                                            \
+    printf(" %s:%u => ", gpgpu_ctx->g_filename, ptx_get_lineno(scanner)); \
+    printf("   (%s:%u) ", __FILE__, __LINE__);                            \
+    printf(__VA_ARGS__);                                                  \
+    printf("\n");                                                         \
+    fflush(stdout);                                                       \
+  }
 
-#define PTX_PARSE_DPRINTF(...) \
-   if( g_debug_ir_generation ) { \
-      printf(" %s:%u => ",gpgpu_ctx->g_filename,ptx_get_lineno(scanner)); \
-      printf("   (%s:%u) ", __FILE__, __LINE__); \
-      printf(__VA_ARGS__); \
-      printf("\n"); \
-      fflush(stdout); \
-   }
+static std::map<unsigned, std::string> g_ptx_token_decode;
 
-static std::map<unsigned,std::string> g_ptx_token_decode;
+const char *decode_token(int type) { return g_ptx_token_decode[type].c_str(); }
 
-const char *decode_token( int type )
-{
-   return g_ptx_token_decode[type].c_str();
+void ptx_recognizer::read_parser_environment_variables() {
+  gpgpu_ctx->g_filename = getenv("PTX_SIM_KERNELFILE");
+  char *dbg_level = getenv("PTX_SIM_DEBUG");
+  if (dbg_level && strlen(dbg_level)) {
+    int debug_execution = 0;
+    sscanf(dbg_level, "%d", &debug_execution);
+    if (debug_execution >= 30) g_debug_ir_generation = true;
+  }
 }
 
-void ptx_recognizer::read_parser_environment_variables() 
-{
-   gpgpu_ctx->g_filename = getenv("PTX_SIM_KERNELFILE");
-   char *dbg_level = getenv("PTX_SIM_DEBUG");
-   if ( dbg_level && strlen(dbg_level) ) {
-      int debug_execution=0;
-      sscanf(dbg_level,"%d", &debug_execution);
-      if ( debug_execution >= 30 ) 
-         g_debug_ir_generation=true;
-   }
+void ptx_recognizer::init_directive_state() {
+  PTX_PARSE_DPRINTF("init_directive_state");
+  g_space_spec = undefined_space;
+  g_ptr_spec = undefined_space;
+  g_scalar_type_spec = -1;
+  g_vector_spec = -1;
+  g_opcode = -1;
+  g_alignment_spec = -1;
+  g_size = -1;
+  g_extern_spec = 0;
+  g_scalar_type.clear();
+  g_operands.clear();
+  g_last_symbol = NULL;
 }
 
-void ptx_recognizer::init_directive_state()
-{
-   PTX_PARSE_DPRINTF("init_directive_state");
-   g_space_spec=undefined_space;
-   g_ptr_spec=undefined_space;
-   g_scalar_type_spec=-1;
-   g_vector_spec=-1;
-   g_opcode=-1;
-   g_alignment_spec = -1;
-   g_size = -1;
-   g_extern_spec = 0;
-   g_scalar_type.clear();
-   g_operands.clear();
-   g_last_symbol = NULL;
+void ptx_recognizer::init_instruction_state() {
+  PTX_PARSE_DPRINTF("init_instruction_state");
+  g_pred = NULL;
+  g_neg_pred = 0;
+  g_pred_mod = -1;
+  g_label = NULL;
+  g_opcode = -1;
+  g_options.clear();
+  g_wmma_options.clear();
+  g_return_var = operand_info(gpgpu_ctx);
+  init_directive_state();
 }
 
-void ptx_recognizer::init_instruction_state()
-{
-   PTX_PARSE_DPRINTF("init_instruction_state");
-   g_pred = NULL;
-   g_neg_pred = 0;
-   g_pred_mod = -1;
-   g_label = NULL;
-   g_opcode = -1;
-   g_options.clear();
-   g_wmma_options.clear();
-   g_return_var = operand_info(gpgpu_ctx);
-   init_directive_state();
-}
+symbol_table *gpgpu_context::init_parser(const char *ptx_filename) {
+  g_filename = strdup(ptx_filename);
+  if (g_global_allfiles_symbol_table == NULL) {
+    g_global_allfiles_symbol_table =
+        new symbol_table("global_allfiles", 0, NULL, this);
+    ptx_parser->g_global_symbol_table = ptx_parser->g_current_symbol_table =
+        g_global_allfiles_symbol_table;
+  }
+/*else {
+    g_global_symbol_table = g_current_symbol_table = new
+symbol_table("global",0,g_global_allfiles_symbol_table);
+}*/
 
-symbol_table * gpgpu_context::init_parser( const char *ptx_filename )
-{
-   g_filename = strdup(ptx_filename);
-   if  (g_global_allfiles_symbol_table == NULL) {
-       g_global_allfiles_symbol_table = new symbol_table("global_allfiles", 0, NULL, this);
-       ptx_parser->g_global_symbol_table = ptx_parser->g_current_symbol_table = g_global_allfiles_symbol_table;
-   }
-   /*else {
-       g_global_symbol_table = g_current_symbol_table = new symbol_table("global",0,g_global_allfiles_symbol_table);
-   }*/
-
-#define DEF(X,Y) g_ptx_token_decode[X] = Y;
+#define DEF(X, Y) g_ptx_token_decode[X] = Y;
 #include "ptx_parser_decode.def"
 #undef DEF
-   g_ptx_token_decode[undefined_space] = "undefined_space";
-   g_ptx_token_decode[undefined_space] = "undefined_space=0";
-   g_ptx_token_decode[reg_space] = "reg_space";
-   g_ptx_token_decode[local_space] = "local_space";
-   g_ptx_token_decode[shared_space] = "shared_space";
-   g_ptx_token_decode[param_space_unclassified] = "param_space_unclassified";
-   g_ptx_token_decode[param_space_kernel] = "param_space_kernel";
-   g_ptx_token_decode[param_space_local] = "param_space_local";
-   g_ptx_token_decode[const_space] = "const_space";
-   g_ptx_token_decode[tex_space] = "tex_space";
-   g_ptx_token_decode[surf_space] = "surf_space";
-   g_ptx_token_decode[global_space] = "global_space";
-   g_ptx_token_decode[generic_space] = "generic_space";
-   g_ptx_token_decode[instruction_space] = "instruction_space";
+  g_ptx_token_decode[undefined_space] = "undefined_space";
+  g_ptx_token_decode[undefined_space] = "undefined_space=0";
+  g_ptx_token_decode[reg_space] = "reg_space";
+  g_ptx_token_decode[local_space] = "local_space";
+  g_ptx_token_decode[shared_space] = "shared_space";
+  g_ptx_token_decode[param_space_unclassified] = "param_space_unclassified";
+  g_ptx_token_decode[param_space_kernel] = "param_space_kernel";
+  g_ptx_token_decode[param_space_local] = "param_space_local";
+  g_ptx_token_decode[const_space] = "const_space";
+  g_ptx_token_decode[tex_space] = "tex_space";
+  g_ptx_token_decode[surf_space] = "surf_space";
+  g_ptx_token_decode[global_space] = "global_space";
+  g_ptx_token_decode[generic_space] = "generic_space";
+  g_ptx_token_decode[instruction_space] = "instruction_space";
 
-   ptx_lex_init(&(ptx_parser->scanner));
-   ptx_parser->init_directive_state();
-   ptx_parser->init_instruction_state();
+  ptx_lex_init(&(ptx_parser->scanner));
+  ptx_parser->init_directive_state();
+  ptx_parser->init_instruction_state();
 
-   FILE *ptx_in;
-   ptx_in = fopen(ptx_filename, "r");
-   ptx_set_in(ptx_in, ptx_parser->scanner);
-   ptx_parse(ptx_parser->scanner, ptx_parser);
-   ptx_in = ptx_get_in(ptx_parser->scanner);
-   ptx_lex_destroy(ptx_parser->scanner);
-   fclose(ptx_in);
-   return ptx_parser->g_global_symbol_table;
+  FILE *ptx_in;
+  ptx_in = fopen(ptx_filename, "r");
+  ptx_set_in(ptx_in, ptx_parser->scanner);
+  ptx_parse(ptx_parser->scanner, ptx_parser);
+  ptx_in = ptx_get_in(ptx_parser->scanner);
+  ptx_lex_destroy(ptx_parser->scanner);
+  fclose(ptx_in);
+  return ptx_parser->g_global_symbol_table;
 }
 
-
-void ptx_recognizer::start_function( int entry_point )
-{
-   PTX_PARSE_DPRINTF("start_function");
-   init_directive_state();
-   init_instruction_state();
-   g_entry_point = entry_point;
-   g_func_info = NULL;
-   g_entry_func_param_index=0;
+void ptx_recognizer::start_function(int entry_point) {
+  PTX_PARSE_DPRINTF("start_function");
+  init_directive_state();
+  init_instruction_state();
+  g_entry_point = entry_point;
+  g_func_info = NULL;
+  g_entry_func_param_index = 0;
 }
 
-void ptx_recognizer::add_function_name( const char *name )
-{
-   PTX_PARSE_DPRINTF("add_function_name %s %s", name,  ((g_entry_point==1)?"(entrypoint)":((g_entry_point==2)?"(extern)":"")));
-   bool prior_decl = g_global_symbol_table->add_function_decl( name, g_entry_point, &g_func_info, &g_current_symbol_table );
-   if( g_add_identifier_cached__identifier ) {
-      add_identifier( g_add_identifier_cached__identifier,
-                      g_add_identifier_cached__array_dim,
-                      g_add_identifier_cached__array_ident );
-      free( g_add_identifier_cached__identifier );
-      g_add_identifier_cached__identifier = NULL;
-      g_func_info->add_return_var( g_last_symbol );
-      init_directive_state();
-   }
-   if( prior_decl ) {
-      g_func_info->remove_args();
-   }
-   g_global_symbol_table->add_function( g_func_info, gpgpu_ctx->g_filename, ptx_get_lineno(scanner) );
+void ptx_recognizer::add_function_name(const char *name) {
+  PTX_PARSE_DPRINTF(
+      "add_function_name %s %s", name,
+      ((g_entry_point == 1) ? "(entrypoint)"
+                            : ((g_entry_point == 2) ? "(extern)" : "")));
+  bool prior_decl = g_global_symbol_table->add_function_decl(
+      name, g_entry_point, &g_func_info, &g_current_symbol_table);
+  if (g_add_identifier_cached__identifier) {
+    add_identifier(g_add_identifier_cached__identifier,
+                   g_add_identifier_cached__array_dim,
+                   g_add_identifier_cached__array_ident);
+    free(g_add_identifier_cached__identifier);
+    g_add_identifier_cached__identifier = NULL;
+    g_func_info->add_return_var(g_last_symbol);
+    init_directive_state();
+  }
+  if (prior_decl) {
+    g_func_info->remove_args();
+  }
+  g_global_symbol_table->add_function(g_func_info, gpgpu_ctx->g_filename,
+                                      ptx_get_lineno(scanner));
 }
 
-//Jin: handle instruction group for cdp
+// Jin: handle instruction group for cdp
 void ptx_recognizer::start_inst_group() {
-   PTX_PARSE_DPRINTF("start_instruction_group");
-   g_current_symbol_table = g_current_symbol_table->start_inst_group();
+  PTX_PARSE_DPRINTF("start_instruction_group");
+  g_current_symbol_table = g_current_symbol_table->start_inst_group();
 }
 
 void ptx_recognizer::end_inst_group() {
-   PTX_PARSE_DPRINTF("end_instruction_group");
-   g_current_symbol_table = g_current_symbol_table->end_inst_group();
+  PTX_PARSE_DPRINTF("end_instruction_group");
+  g_current_symbol_table = g_current_symbol_table->end_inst_group();
 }
 
-void ptx_recognizer::add_directive()
-{
-   PTX_PARSE_DPRINTF("add_directive");
-   init_directive_state();
+void ptx_recognizer::add_directive() {
+  PTX_PARSE_DPRINTF("add_directive");
+  init_directive_state();
 }
 
-#define mymax(a,b) ((a)>(b)?(a):(b))
+#define mymax(a, b) ((a) > (b) ? (a) : (b))
 
-void ptx_recognizer::end_function()
-{
-   PTX_PARSE_DPRINTF("end_function");
+void ptx_recognizer::end_function() {
+  PTX_PARSE_DPRINTF("end_function");
 
-   init_directive_state();
-   init_instruction_state();
-   g_max_regs_per_thread = mymax( g_max_regs_per_thread, (g_current_symbol_table->next_reg_num()-1)); 
-   g_func_info->add_inst( g_instructions );
-   g_instructions.clear();
-   gpgpu_ptx_assemble( g_func_info->get_name(), g_func_info );
-   g_current_symbol_table = g_global_symbol_table;
+  init_directive_state();
+  init_instruction_state();
+  g_max_regs_per_thread = mymax(g_max_regs_per_thread,
+                                (g_current_symbol_table->next_reg_num() - 1));
+  g_func_info->add_inst(g_instructions);
+  g_instructions.clear();
+  gpgpu_ptx_assemble(g_func_info->get_name(), g_func_info);
+  g_current_symbol_table = g_global_symbol_table;
 
-   PTX_PARSE_DPRINTF("function %s, PC = %d\n", g_func_info->get_name().c_str(), g_func_info->get_start_PC());
+  PTX_PARSE_DPRINTF("function %s, PC = %d\n", g_func_info->get_name().c_str(),
+                    g_func_info->get_start_PC());
 }
 
-#define parse_error(msg, ...) parse_error_impl(__FILE__,__LINE__, msg, ##__VA_ARGS__)
-#define parse_assert(cond,msg, ...) parse_assert_impl((cond),__FILE__,__LINE__, msg, ##__VA_ARGS__)
+#define parse_error(msg, ...) \
+  parse_error_impl(__FILE__, __LINE__, msg, ##__VA_ARGS__)
+#define parse_assert(cond, msg, ...) \
+  parse_assert_impl((cond), __FILE__, __LINE__, msg, ##__VA_ARGS__)
 
-void ptx_recognizer::parse_error_impl( const char *file, unsigned line, const char *msg, ... )
-{
-   va_list ap;
-   char buf[1024];
-   va_start(ap,msg);
-   vsnprintf(buf,1024,msg,ap);
-   va_end(ap);
+void ptx_recognizer::parse_error_impl(const char *file, unsigned line,
+                                      const char *msg, ...) {
+  va_list ap;
+  char buf[1024];
+  va_start(ap, msg);
+  vsnprintf(buf, 1024, msg, ap);
+  va_end(ap);
 
-   g_error_detected = 1;
-   printf("%s:%u: Parse error: %s (%s:%u)\n\n", gpgpu_ctx->g_filename, ptx_get_lineno(scanner), buf, file, line);
-   ptx_error(scanner, NULL);
-   abort();
-   exit(1);
+  g_error_detected = 1;
+  printf("%s:%u: Parse error: %s (%s:%u)\n\n", gpgpu_ctx->g_filename,
+         ptx_get_lineno(scanner), buf, file, line);
+  ptx_error(scanner, NULL);
+  abort();
+  exit(1);
 }
 
-void ptx_recognizer::parse_assert_impl( int test_value, const char *file, unsigned line, const char *msg, ... )
-{
-   va_list ap;
-   char buf[1024];
-   va_start(ap,msg);
-   vsnprintf(buf,1024,msg,ap);
-   va_end(ap);
+void ptx_recognizer::parse_assert_impl(int test_value, const char *file,
+                                       unsigned line, const char *msg, ...) {
+  va_list ap;
+  char buf[1024];
+  va_start(ap, msg);
+  vsnprintf(buf, 1024, msg, ap);
+  va_end(ap);
 
-   if ( test_value == 0 )
-      parse_error_impl(file,line, msg);
+  if (test_value == 0) parse_error_impl(file, line, msg);
 }
 
-
-
-void ptx_recognizer::set_return()
-{
-   parse_assert( (g_opcode == CALL_OP || g_opcode == CALLP_OP), "only call can have return value");
-   g_operands.front().set_return();
-   g_return_var = g_operands.front();
+void ptx_recognizer::set_return() {
+  parse_assert((g_opcode == CALL_OP || g_opcode == CALLP_OP),
+               "only call can have return value");
+  g_operands.front().set_return();
+  g_return_var = g_operands.front();
 }
 
-
-const ptx_instruction *ptx_recognizer::ptx_instruction_lookup( const char *filename, unsigned linenumber )
-{
-   std::map<std::string,std::map<unsigned,const ptx_instruction*> >::iterator f=g_inst_lookup.find(filename);
-   if( f == g_inst_lookup.end() ) 
-      return NULL;
-   std::map<unsigned,const ptx_instruction*>::iterator l=f->second.find(linenumber);
-   if( l == f->second.end() ) 
-      return NULL;
-   return l->second; 
+const ptx_instruction *ptx_recognizer::ptx_instruction_lookup(
+    const char *filename, unsigned linenumber) {
+  std::map<std::string, std::map<unsigned, const ptx_instruction *> >::iterator
+      f = g_inst_lookup.find(filename);
+  if (f == g_inst_lookup.end()) return NULL;
+  std::map<unsigned, const ptx_instruction *>::iterator l =
+      f->second.find(linenumber);
+  if (l == f->second.end()) return NULL;
+  return l->second;
 }
 
-void ptx_recognizer::add_instruction()
-{
-   PTX_PARSE_DPRINTF("add_instruction: %s", ((g_opcode>0)?g_opcode_string[g_opcode]:"<label>") );
-   assert( g_shader_core_config != 0 );
-   ptx_instruction *i = new ptx_instruction( g_opcode, 
-                                             g_pred, 
-                                             g_neg_pred,
-                                             g_pred_mod, 
-                                             g_label, 
-                                             g_operands,
-                                             g_return_var,
-                                             g_options, 
-                                             g_wmma_options, 
-                                             g_scalar_type,
-                                             g_space_spec,
-                                             gpgpu_ctx->g_filename,
-                                             ptx_get_lineno(scanner),
-                                             linebuf,
-                                             g_shader_core_config,
-					     gpgpu_ctx );
-   g_instructions.push_back(i);
-   g_inst_lookup[gpgpu_ctx->g_filename][ptx_get_lineno(scanner)] = i;
-   init_instruction_state();
+void ptx_recognizer::add_instruction() {
+  PTX_PARSE_DPRINTF("add_instruction: %s",
+                    ((g_opcode > 0) ? g_opcode_string[g_opcode] : "<label>"));
+  assert(g_shader_core_config != 0);
+  ptx_instruction *i = new ptx_instruction(
+      g_opcode, g_pred, g_neg_pred, g_pred_mod, g_label, g_operands,
+      g_return_var, g_options, g_wmma_options, g_scalar_type, g_space_spec,
+      gpgpu_ctx->g_filename, ptx_get_lineno(scanner), linebuf,
+      g_shader_core_config, gpgpu_ctx);
+  g_instructions.push_back(i);
+  g_inst_lookup[gpgpu_ctx->g_filename][ptx_get_lineno(scanner)] = i;
+  init_instruction_state();
 }
 
-void ptx_recognizer::add_variables()
-{
-   PTX_PARSE_DPRINTF("add_variables");
-   if ( !g_operands.empty() ) {
-      assert( g_last_symbol != NULL ); 
-      g_last_symbol->add_initializer(g_operands);
-   }
-   init_directive_state();
+void ptx_recognizer::add_variables() {
+  PTX_PARSE_DPRINTF("add_variables");
+  if (!g_operands.empty()) {
+    assert(g_last_symbol != NULL);
+    g_last_symbol->add_initializer(g_operands);
+  }
+  init_directive_state();
 }
 
-void ptx_recognizer::set_variable_type()
-{
-   PTX_PARSE_DPRINTF("set_variable_type space_spec=%s scalar_type_spec=%s", 
-           g_ptx_token_decode[g_space_spec.get_type()].c_str(), 
-           g_ptx_token_decode[g_scalar_type_spec].c_str() );
-   parse_assert( g_space_spec != undefined_space, "variable has no space specification" );
-   parse_assert( g_scalar_type_spec != -1, "variable has no type information" ); // need to extend for structs?
-   g_var_type = g_current_symbol_table->add_type( g_space_spec, 
-                                                  g_scalar_type_spec, 
-                                                  g_vector_spec, 
-                                                  g_alignment_spec, 
-                                                  g_extern_spec );
+void ptx_recognizer::set_variable_type() {
+  PTX_PARSE_DPRINTF("set_variable_type space_spec=%s scalar_type_spec=%s",
+                    g_ptx_token_decode[g_space_spec.get_type()].c_str(),
+                    g_ptx_token_decode[g_scalar_type_spec].c_str());
+  parse_assert(g_space_spec != undefined_space,
+               "variable has no space specification");
+  parse_assert(
+      g_scalar_type_spec != -1,
+      "variable has no type information");  // need to extend for structs?
+  g_var_type = g_current_symbol_table->add_type(
+      g_space_spec, g_scalar_type_spec, g_vector_spec, g_alignment_spec,
+      g_extern_spec);
 }
 
-bool ptx_recognizer::check_for_duplicates( const char *identifier )
-{
-   const symbol *s = g_current_symbol_table->lookup(identifier);
-   return ( s != NULL );
+bool ptx_recognizer::check_for_duplicates(const char *identifier) {
+  const symbol *s = g_current_symbol_table->lookup(identifier);
+  return (s != NULL);
 }
 
-// Returns padding that needs to be inserted ahead of address to make it aligned to min(size, maxalign)
+// Returns padding that needs to be inserted ahead of address to make it aligned
+// to min(size, maxalign)
 /*
  * @param address the address in bytes
  * @param size the size of the memory to be allocated in bytes
- * @param maximum alignment in bytes. i.e. if size is too big then align to this instead
+ * @param maximum alignment in bytes. i.e. if size is too big then align to this
+ * instead
  */
-int pad_address (new_addr_type address, unsigned size, unsigned maxalign) {
-    assert(size >= 0);
-    assert(maxalign > 0);
-    int alignto = maxalign;
-    if (size < maxalign &&
-            (size & (size-1)) == 0) { //size is a power of 2
-        alignto = size;
-    }
-    return alignto ? ((alignto - (address % alignto)) % alignto) : 0;
+int pad_address(new_addr_type address, unsigned size, unsigned maxalign) {
+  assert(size >= 0);
+  assert(maxalign > 0);
+  int alignto = maxalign;
+  if (size < maxalign && (size & (size - 1)) == 0) {  // size is a power of 2
+    alignto = size;
+  }
+  return alignto ? ((alignto - (address % alignto)) % alignto) : 0;
 }
 
-void ptx_recognizer::add_identifier( const char *identifier, int array_dim, unsigned array_ident )
-{
-   if(array_ident==ARRAY_IDENTIFIER){
-       g_size *= array_dim;
-   }
-   if( g_func_decl && (g_func_info == NULL) ) {
-      // return variable decl...
-      assert( g_add_identifier_cached__identifier == NULL );
-      g_add_identifier_cached__identifier = strdup(identifier);
-      g_add_identifier_cached__array_dim = array_dim;
-      g_add_identifier_cached__array_ident = array_ident;
-      return;
-   }
-   PTX_PARSE_DPRINTF("add_identifier \"%s\" (%u)", identifier, g_ident_add_uid);
-   g_ident_add_uid++;
-   type_info *type = g_var_type;
-   type_info_key ti = type->get_key();
-   int basic_type;
-   int regnum;
-   size_t num_bits;
-   unsigned addr_pad;
-   new_addr_type addr;
-   ti.type_decode(num_bits,basic_type);
+void ptx_recognizer::add_identifier(const char *identifier, int array_dim,
+                                    unsigned array_ident) {
+  if (array_ident == ARRAY_IDENTIFIER) {
+    g_size *= array_dim;
+  }
+  if (g_func_decl && (g_func_info == NULL)) {
+    // return variable decl...
+    assert(g_add_identifier_cached__identifier == NULL);
+    g_add_identifier_cached__identifier = strdup(identifier);
+    g_add_identifier_cached__array_dim = array_dim;
+    g_add_identifier_cached__array_ident = array_ident;
+    return;
+  }
+  PTX_PARSE_DPRINTF("add_identifier \"%s\" (%u)", identifier, g_ident_add_uid);
+  g_ident_add_uid++;
+  type_info *type = g_var_type;
+  type_info_key ti = type->get_key();
+  int basic_type;
+  int regnum;
+  size_t num_bits;
+  unsigned addr_pad;
+  new_addr_type addr;
+  ti.type_decode(num_bits, basic_type);
 
-   bool duplicates = check_for_duplicates( identifier );
-   if( duplicates ) {
-      symbol *s = g_current_symbol_table->lookup(identifier);
-      g_last_symbol = s;
-      if( g_func_decl ) 
-         return;
-      std::string msg = std::string(identifier) + " was declared previous at " + s->decl_location() + " skipping new declaration"; 
-      printf("GPGPU-Sim PTX: Warning %s\n", msg.c_str());
-      return;
-   }
+  bool duplicates = check_for_duplicates(identifier);
+  if (duplicates) {
+    symbol *s = g_current_symbol_table->lookup(identifier);
+    g_last_symbol = s;
+    if (g_func_decl) return;
+    std::string msg = std::string(identifier) + " was declared previous at " +
+                      s->decl_location() + " skipping new declaration";
+    printf("GPGPU-Sim PTX: Warning %s\n", msg.c_str());
+    return;
+  }
 
-   assert( g_var_type != NULL );
-   switch ( array_ident ) {
-   case ARRAY_IDENTIFIER:
-      type = g_current_symbol_table->get_array_type(type,array_dim);
+  assert(g_var_type != NULL);
+  switch (array_ident) {
+    case ARRAY_IDENTIFIER:
+      type = g_current_symbol_table->get_array_type(type, array_dim);
       num_bits = array_dim * num_bits;
       break;
-   case ARRAY_IDENTIFIER_NO_DIM:
-      type = g_current_symbol_table->get_array_type(type,(unsigned)-1);
+    case ARRAY_IDENTIFIER_NO_DIM:
+      type = g_current_symbol_table->get_array_type(type, (unsigned)-1);
       num_bits = 0;
       break;
-   default:
+    default:
       break;
-   }
-   g_last_symbol = g_current_symbol_table->add_variable(identifier,type,num_bits/8,gpgpu_ctx->g_filename,ptx_get_lineno(scanner));
-   switch ( ti.get_memory_space().get_type() ) {
-   case reg_space: {
+  }
+  g_last_symbol = g_current_symbol_table->add_variable(
+      identifier, type, num_bits / 8, gpgpu_ctx->g_filename,
+      ptx_get_lineno(scanner));
+  switch (ti.get_memory_space().get_type()) {
+    case reg_space: {
       regnum = g_current_symbol_table->next_reg_num();
       int arch_regnum = -1;
       for (int d = 0; d < strlen(identifier); d++) {
-         if (isdigit(identifier[d])) {
-            sscanf(identifier + d, "%d", &arch_regnum);
-            break;
-         }
+        if (isdigit(identifier[d])) {
+          sscanf(identifier + d, "%d", &arch_regnum);
+          break;
+        }
       }
       if (strcmp(identifier, "%sp") == 0) {
-         arch_regnum = 0;
+        arch_regnum = 0;
       }
       g_last_symbol->set_regno(regnum, arch_regnum);
-      } break;
-   case shared_space:
-      printf("GPGPU-Sim PTX: allocating shared region for \"%s\" ",
-             identifier);
+    } break;
+    case shared_space:
+      printf("GPGPU-Sim PTX: allocating shared region for \"%s\" ", identifier);
       fflush(stdout);
-      assert( (num_bits%8) == 0  );
+      assert((num_bits % 8) == 0);
       addr = g_current_symbol_table->get_shared_next();
-      addr_pad = pad_address(addr, num_bits/8, 128);
-      printf("from 0x%llx to 0x%llx (shared memory space)\n",
-              addr+addr_pad,
-              addr+addr_pad + num_bits/8);
-         fflush(stdout);
-      g_last_symbol->set_address( addr+addr_pad );
-      g_current_symbol_table->alloc_shared( num_bits/8 + addr_pad );
-      break;
-   case sstarr_space:
-         printf("GPGPU-Sim PTX: allocating sstarr region for \"%s\" ",
-                identifier);
-         fflush(stdout);
-         assert( (num_bits%8) == 0  );
-         addr = g_current_symbol_table->get_sstarr_next();
-         addr_pad = pad_address(addr, num_bits/8, 128);
-         printf("from 0x%llx to 0x%llx (sstarr memory space)\n",
-                 addr+addr_pad,
-                 addr+addr_pad + num_bits/8);
-            fflush(stdout);
-         g_last_symbol->set_address( addr+addr_pad );
-         g_current_symbol_table->alloc_sstarr( num_bits/8 + addr_pad );
-         break;
-   case const_space:
-      if( array_ident == ARRAY_IDENTIFIER_NO_DIM ) {
-         printf("GPGPU-Sim PTX: deferring allocation of constant region for \"%s\" (need size information)\n", identifier );
-      } else {
-         printf("GPGPU-Sim PTX: allocating constant region for \"%s\" ",
-                identifier);
-         fflush(stdout);
-         assert( (num_bits%8) == 0  ); 
-         addr = g_current_symbol_table->get_global_next();
-         addr_pad = pad_address(addr, num_bits/8, 128);
-         printf("from 0x%llx to 0x%llx (global memory space) %u\n",
-              addr+addr_pad,
-              addr+addr_pad + num_bits/8,
-              g_const_alloc++);
-         fflush(stdout);
-         g_last_symbol->set_address( addr + addr_pad );
-         g_current_symbol_table->alloc_global( num_bits/8 + addr_pad ); 
-      }
-      if( g_current_symbol_table == g_global_symbol_table ) { 
-         gpgpu_ctx->func_sim->g_constants.insert( identifier );
-      }
-      assert( g_current_symbol_table != NULL );
-      g_sym_name_to_symbol_table[ identifier ] = g_current_symbol_table;
-      break;
-   case global_space:
-      printf("GPGPU-Sim PTX: allocating global region for \"%s\" ",
-             identifier);
+      addr_pad = pad_address(addr, num_bits / 8, 128);
+      printf("from 0x%llx to 0x%llx (shared memory space)\n", addr + addr_pad,
+             addr + addr_pad + num_bits / 8);
       fflush(stdout);
-      assert( (num_bits%8) == 0  );
-      addr = g_current_symbol_table->get_global_next();
-      addr_pad = pad_address(addr, num_bits/8, 128);
-      printf("from 0x%llx to 0x%llx (global memory space)\n",
-              addr+addr_pad,
-              addr+addr_pad + num_bits/8);
-      fflush(stdout);
-      g_last_symbol->set_address( addr+addr_pad );
-      g_current_symbol_table->alloc_global( num_bits/8 + addr_pad );
-      gpgpu_ctx->func_sim->g_globals.insert( identifier );
-      assert( g_current_symbol_table != NULL );
-      g_sym_name_to_symbol_table[ identifier ] = g_current_symbol_table;
+      g_last_symbol->set_address(addr + addr_pad);
+      g_current_symbol_table->alloc_shared(num_bits / 8 + addr_pad);
       break;
-   case local_space:
-      if( g_func_info == NULL ) {
-          printf("GPGPU-Sim PTX: allocating local region for \"%s\" ", identifier);
-         fflush(stdout);
-         assert( (num_bits%8) == 0  );
-         addr = g_current_symbol_table->get_local_next();
-         addr_pad = pad_address(addr, num_bits/8, 128);
-         printf("from 0x%llx to 0x%llx (local memory space)\n",
-                 addr+addr_pad,
-                 addr+addr_pad + num_bits/8);
-         fflush(stdout);
-         g_last_symbol->set_address( addr+addr_pad);
-         g_current_symbol_table->alloc_local( num_bits/8 + addr_pad);
+    case sstarr_space:
+      printf("GPGPU-Sim PTX: allocating sstarr region for \"%s\" ", identifier);
+      fflush(stdout);
+      assert((num_bits % 8) == 0);
+      addr = g_current_symbol_table->get_sstarr_next();
+      addr_pad = pad_address(addr, num_bits / 8, 128);
+      printf("from 0x%llx to 0x%llx (sstarr memory space)\n", addr + addr_pad,
+             addr + addr_pad + num_bits / 8);
+      fflush(stdout);
+      g_last_symbol->set_address(addr + addr_pad);
+      g_current_symbol_table->alloc_sstarr(num_bits / 8 + addr_pad);
+      break;
+    case const_space:
+      if (array_ident == ARRAY_IDENTIFIER_NO_DIM) {
+        printf(
+            "GPGPU-Sim PTX: deferring allocation of constant region for \"%s\" "
+            "(need size information)\n",
+            identifier);
       } else {
-        printf("GPGPU-Sim PTX: allocating stack frame region for .local \"%s\" ",
+        printf("GPGPU-Sim PTX: allocating constant region for \"%s\" ",
                identifier);
         fflush(stdout);
-        assert( (num_bits%8) == 0 );
-        addr = g_current_symbol_table->get_local_next();
-        addr_pad = pad_address(addr, num_bits/8, 128);
-        printf("from 0x%llx to 0x%llx\n",
-                addr+addr_pad,
-                addr+addr_pad + num_bits/8);
+        assert((num_bits % 8) == 0);
+        addr = g_current_symbol_table->get_global_next();
+        addr_pad = pad_address(addr, num_bits / 8, 128);
+        printf("from 0x%llx to 0x%llx (global memory space) %u\n",
+               addr + addr_pad, addr + addr_pad + num_bits / 8,
+               g_const_alloc++);
         fflush(stdout);
-        g_last_symbol->set_address( addr+addr_pad );
-        g_current_symbol_table->alloc_local( num_bits/8 + addr_pad);
-        g_func_info->set_framesize( g_current_symbol_table->get_local_next() );
+        g_last_symbol->set_address(addr + addr_pad);
+        g_current_symbol_table->alloc_global(num_bits / 8 + addr_pad);
+      }
+      if (g_current_symbol_table == g_global_symbol_table) {
+        gpgpu_ctx->func_sim->g_constants.insert(identifier);
+      }
+      assert(g_current_symbol_table != NULL);
+      g_sym_name_to_symbol_table[identifier] = g_current_symbol_table;
+      break;
+    case global_space:
+      printf("GPGPU-Sim PTX: allocating global region for \"%s\" ", identifier);
+      fflush(stdout);
+      assert((num_bits % 8) == 0);
+      addr = g_current_symbol_table->get_global_next();
+      addr_pad = pad_address(addr, num_bits / 8, 128);
+      printf("from 0x%llx to 0x%llx (global memory space)\n", addr + addr_pad,
+             addr + addr_pad + num_bits / 8);
+      fflush(stdout);
+      g_last_symbol->set_address(addr + addr_pad);
+      g_current_symbol_table->alloc_global(num_bits / 8 + addr_pad);
+      gpgpu_ctx->func_sim->g_globals.insert(identifier);
+      assert(g_current_symbol_table != NULL);
+      g_sym_name_to_symbol_table[identifier] = g_current_symbol_table;
+      break;
+    case local_space:
+      if (g_func_info == NULL) {
+        printf("GPGPU-Sim PTX: allocating local region for \"%s\" ",
+               identifier);
+        fflush(stdout);
+        assert((num_bits % 8) == 0);
+        addr = g_current_symbol_table->get_local_next();
+        addr_pad = pad_address(addr, num_bits / 8, 128);
+        printf("from 0x%llx to 0x%llx (local memory space)\n", addr + addr_pad,
+               addr + addr_pad + num_bits / 8);
+        fflush(stdout);
+        g_last_symbol->set_address(addr + addr_pad);
+        g_current_symbol_table->alloc_local(num_bits / 8 + addr_pad);
+      } else {
+        printf(
+            "GPGPU-Sim PTX: allocating stack frame region for .local \"%s\" ",
+            identifier);
+        fflush(stdout);
+        assert((num_bits % 8) == 0);
+        addr = g_current_symbol_table->get_local_next();
+        addr_pad = pad_address(addr, num_bits / 8, 128);
+        printf("from 0x%llx to 0x%llx\n", addr + addr_pad,
+               addr + addr_pad + num_bits / 8);
+        fflush(stdout);
+        g_last_symbol->set_address(addr + addr_pad);
+        g_current_symbol_table->alloc_local(num_bits / 8 + addr_pad);
+        g_func_info->set_framesize(g_current_symbol_table->get_local_next());
       }
       break;
-   case tex_space:
+    case tex_space:
       printf("GPGPU-Sim PTX: encountered texture directive %s.\n", identifier);
       break;
-   case param_space_local:
-      printf("GPGPU-Sim PTX: allocating stack frame region for .param \"%s\" from 0x%x to 0x%lx\n",
-             identifier,
-             g_current_symbol_table->get_local_next(),
-             g_current_symbol_table->get_local_next() + num_bits/8 );
+    case param_space_local:
+      printf(
+          "GPGPU-Sim PTX: allocating stack frame region for .param \"%s\" from "
+          "0x%x to 0x%lx\n",
+          identifier, g_current_symbol_table->get_local_next(),
+          g_current_symbol_table->get_local_next() + num_bits / 8);
       fflush(stdout);
-      assert( (num_bits%8) == 0  );
-      g_last_symbol->set_address( g_current_symbol_table->get_local_next() );
-      g_current_symbol_table->alloc_local( num_bits/8 );
-      g_func_info->set_framesize( g_current_symbol_table->get_local_next() );
+      assert((num_bits % 8) == 0);
+      g_last_symbol->set_address(g_current_symbol_table->get_local_next());
+      g_current_symbol_table->alloc_local(num_bits / 8);
+      g_func_info->set_framesize(g_current_symbol_table->get_local_next());
       break;
-   case param_space_kernel:
+    case param_space_kernel:
       break;
-   default:
+    default:
       abort();
       break;
-   }
+  }
 
-   assert( !ti.is_param_unclassified() );
-   if ( ti.is_param_kernel() ) {
-      bool is_ptr = (g_ptr_spec != undefined_space); 
-      g_func_info->add_param_name_type_size(g_entry_func_param_index,identifier, ti.scalar_type(), num_bits, is_ptr, g_ptr_spec);
-      g_entry_func_param_index++;
-   }
+  assert(!ti.is_param_unclassified());
+  if (ti.is_param_kernel()) {
+    bool is_ptr = (g_ptr_spec != undefined_space);
+    g_func_info->add_param_name_type_size(g_entry_func_param_index, identifier,
+                                          ti.scalar_type(), num_bits, is_ptr,
+                                          g_ptr_spec);
+    g_entry_func_param_index++;
+  }
 }
 
-void ptx_recognizer::add_constptr(const char* identifier1, const char* identifier2, int offset)
-{
-   symbol *s1 = g_current_symbol_table->lookup(identifier1);
-   const symbol *s2 = g_current_symbol_table->lookup(identifier2);
-   parse_assert( s1 != NULL, "'from' constant identifier does not exist.");
-   parse_assert( s1 != NULL, "'to' constant identifier does not exist.");
+void ptx_recognizer::add_constptr(const char *identifier1,
+                                  const char *identifier2, int offset) {
+  symbol *s1 = g_current_symbol_table->lookup(identifier1);
+  const symbol *s2 = g_current_symbol_table->lookup(identifier2);
+  parse_assert(s1 != NULL, "'from' constant identifier does not exist.");
+  parse_assert(s1 != NULL, "'to' constant identifier does not exist.");
 
-   unsigned addr = s2->get_address();
+  unsigned addr = s2->get_address();
 
-   printf("GPGPU-Sim PTX: moving \"%s\" from 0x%x to 0x%x (%s+%x)\n",
-      identifier1, s1->get_address(), addr+offset, identifier2, offset);
+  printf("GPGPU-Sim PTX: moving \"%s\" from 0x%x to 0x%x (%s+%x)\n",
+         identifier1, s1->get_address(), addr + offset, identifier2, offset);
 
-   s1->set_address( addr + offset );
+  s1->set_address(addr + offset);
 }
 
-void ptx_recognizer::add_function_arg()
-{
-   assert(g_size>0);
-   if( g_func_info ) {
-      PTX_PARSE_DPRINTF("add_function_arg \"%s\"", g_last_symbol->name().c_str() );
-      g_func_info->add_arg(g_last_symbol);
-      unsigned alignment = (g_alignment_spec==-1) ? g_size : g_alignment_spec;
-      assert(alignment==1||alignment==2||alignment==4||alignment==8||alignment==16);//known valid alignment values
-      g_func_info->add_config_param( g_size,  alignment);
-   }
-
+void ptx_recognizer::add_function_arg() {
+  assert(g_size > 0);
+  if (g_func_info) {
+    PTX_PARSE_DPRINTF("add_function_arg \"%s\"", g_last_symbol->name().c_str());
+    g_func_info->add_arg(g_last_symbol);
+    unsigned alignment = (g_alignment_spec == -1) ? g_size : g_alignment_spec;
+    assert(alignment == 1 || alignment == 2 || alignment == 4 ||
+           alignment == 8 || alignment == 16);  // known valid alignment values
+    g_func_info->add_config_param(g_size, alignment);
+  }
 }
 
-void ptx_recognizer::add_extern_spec()
-{
-   PTX_PARSE_DPRINTF("add_extern_spec");
-   g_extern_spec = 1;
+void ptx_recognizer::add_extern_spec() {
+  PTX_PARSE_DPRINTF("add_extern_spec");
+  g_extern_spec = 1;
 }
 
-void ptx_recognizer::add_alignment_spec( int spec )
-{
-   PTX_PARSE_DPRINTF("add_alignment_spec");
-   parse_assert( g_alignment_spec == -1, "multiple .align specifiers per variable declaration not allowed." );
-   g_alignment_spec = spec;
+void ptx_recognizer::add_alignment_spec(int spec) {
+  PTX_PARSE_DPRINTF("add_alignment_spec");
+  parse_assert(
+      g_alignment_spec == -1,
+      "multiple .align specifiers per variable declaration not allowed.");
+  g_alignment_spec = spec;
 }
 
-void ptx_recognizer::add_ptr_spec( enum _memory_space_t spec )
-{
-   PTX_PARSE_DPRINTF("add_ptr_spec \"%s\"", g_ptx_token_decode[spec].c_str() );
-   parse_assert( g_ptr_spec == undefined_space, "multiple ptr space specifiers not allowed." );
-   parse_assert( spec == global_space or spec == local_space or spec == shared_space, "invalid space for ptr directive." );
-   g_ptr_spec = spec; 
+void ptx_recognizer::add_ptr_spec(enum _memory_space_t spec) {
+  PTX_PARSE_DPRINTF("add_ptr_spec \"%s\"", g_ptx_token_decode[spec].c_str());
+  parse_assert(g_ptr_spec == undefined_space,
+               "multiple ptr space specifiers not allowed.");
+  parse_assert(
+      spec == global_space or spec == local_space or spec == shared_space,
+      "invalid space for ptr directive.");
+  g_ptr_spec = spec;
 }
 
-void ptx_recognizer::add_space_spec( enum _memory_space_t spec, int value )
-{
-   PTX_PARSE_DPRINTF("add_space_spec \"%s\"", g_ptx_token_decode[spec].c_str() );
-   parse_assert( g_space_spec == undefined_space, "multiple space specifiers not allowed." );
-   if( spec == param_space_unclassified ) {
-      if( g_func_decl ) {
-         if( g_entry_point == 1) 
-            g_space_spec = param_space_kernel;
-         else 
-            g_space_spec = param_space_local;
-      } else
-         g_space_spec = param_space_unclassified;
-   } else {
-      g_space_spec = spec;
-      if( g_space_spec == const_space )
-         g_space_spec.set_bank((unsigned)value);
-   }
+void ptx_recognizer::add_space_spec(enum _memory_space_t spec, int value) {
+  PTX_PARSE_DPRINTF("add_space_spec \"%s\"", g_ptx_token_decode[spec].c_str());
+  parse_assert(g_space_spec == undefined_space,
+               "multiple space specifiers not allowed.");
+  if (spec == param_space_unclassified) {
+    if (g_func_decl) {
+      if (g_entry_point == 1)
+        g_space_spec = param_space_kernel;
+      else
+        g_space_spec = param_space_local;
+    } else
+      g_space_spec = param_space_unclassified;
+  } else {
+    g_space_spec = spec;
+    if (g_space_spec == const_space) g_space_spec.set_bank((unsigned)value);
+  }
 }
 
-void ptx_recognizer::add_vector_spec(int spec )
-{
-   PTX_PARSE_DPRINTF("add_vector_spec");
-   parse_assert( g_vector_spec == -1, "multiple vector specifiers not allowed." );
-   g_vector_spec = spec;
+void ptx_recognizer::add_vector_spec(int spec) {
+  PTX_PARSE_DPRINTF("add_vector_spec");
+  parse_assert(g_vector_spec == -1, "multiple vector specifiers not allowed.");
+  g_vector_spec = spec;
 }
 
-void ptx_recognizer::add_scalar_type_spec( int type_spec )
-{
-   //save size of parameter
-   switch ( type_spec ) {
-      case B8_TYPE:
-      case S8_TYPE:
-      case U8_TYPE: 
-         g_size = 1; break;
-      case B16_TYPE:
-      case S16_TYPE:
-      case U16_TYPE:
-      case F16_TYPE: 
-         g_size = 2; break;
-      case B32_TYPE:
-      case S32_TYPE:
-      case U32_TYPE:
-      case F32_TYPE: 
-         g_size = 4; break;
-      case B64_TYPE:
-      case BB64_TYPE:
-      case S64_TYPE:
-      case U64_TYPE:
-      case F64_TYPE: 
-      case FF64_TYPE:
-         g_size = 8; break;
-      case BB128_TYPE: 
-         g_size = 16; break;
-   }
-   PTX_PARSE_DPRINTF("add_scalar_type_spec \"%s\"", g_ptx_token_decode[type_spec].c_str());
-   g_scalar_type.push_back( type_spec );
-   if ( g_scalar_type.size() > 1 ) {
-      parse_assert( (g_opcode == -1) || (g_opcode == CVT_OP) || (g_opcode == SET_OP) || (g_opcode == SLCT_OP)
-                    || (g_opcode == TEX_OP)|| (g_opcode==MMA_OP)|| (g_opcode == DP4A_OP),
-                    "only cvt, set, slct, tex and dp4a can have more than one type specifier.");
-   }
-   g_scalar_type_spec = type_spec;
+void ptx_recognizer::add_scalar_type_spec(int type_spec) {
+  // save size of parameter
+  switch (type_spec) {
+    case B8_TYPE:
+    case S8_TYPE:
+    case U8_TYPE:
+      g_size = 1;
+      break;
+    case B16_TYPE:
+    case S16_TYPE:
+    case U16_TYPE:
+    case F16_TYPE:
+      g_size = 2;
+      break;
+    case B32_TYPE:
+    case S32_TYPE:
+    case U32_TYPE:
+    case F32_TYPE:
+      g_size = 4;
+      break;
+    case B64_TYPE:
+    case BB64_TYPE:
+    case S64_TYPE:
+    case U64_TYPE:
+    case F64_TYPE:
+    case FF64_TYPE:
+      g_size = 8;
+      break;
+    case BB128_TYPE:
+      g_size = 16;
+      break;
+  }
+  PTX_PARSE_DPRINTF("add_scalar_type_spec \"%s\"",
+                    g_ptx_token_decode[type_spec].c_str());
+  g_scalar_type.push_back(type_spec);
+  if (g_scalar_type.size() > 1) {
+    parse_assert((g_opcode == -1) || (g_opcode == CVT_OP) ||
+                     (g_opcode == SET_OP) || (g_opcode == SLCT_OP) ||
+                     (g_opcode == TEX_OP) || (g_opcode == MMA_OP) ||
+                     (g_opcode == DP4A_OP),
+                 "only cvt, set, slct, tex and dp4a can have more than one "
+                 "type specifier.");
+  }
+  g_scalar_type_spec = type_spec;
 }
 
-void ptx_recognizer::add_label( const char *identifier )
-{
-   PTX_PARSE_DPRINTF("add_label");
-   symbol *s = g_current_symbol_table->lookup(identifier);
-   if ( s != NULL ) {
-      g_label = s;
-   } else {
-      g_label = g_current_symbol_table->add_variable(identifier,NULL,0,gpgpu_ctx->g_filename,ptx_get_lineno(scanner));
-   }
+void ptx_recognizer::add_label(const char *identifier) {
+  PTX_PARSE_DPRINTF("add_label");
+  symbol *s = g_current_symbol_table->lookup(identifier);
+  if (s != NULL) {
+    g_label = s;
+  } else {
+    g_label = g_current_symbol_table->add_variable(
+        identifier, NULL, 0, gpgpu_ctx->g_filename, ptx_get_lineno(scanner));
+  }
 }
 
-void ptx_recognizer::add_opcode( int opcode )
-{
-   g_opcode = opcode;
+void ptx_recognizer::add_opcode(int opcode) { g_opcode = opcode; }
+
+void ptx_recognizer::add_pred(const char *identifier, int neg,
+                              int predModifier) {
+  PTX_PARSE_DPRINTF("add_pred");
+  const symbol *s = g_current_symbol_table->lookup(identifier);
+  if (s == NULL) {
+    std::string msg =
+        std::string("predicate \"") + identifier + "\" has no declaration.";
+    parse_error(msg.c_str());
+  }
+  g_pred = s;
+  g_neg_pred = neg;
+  g_pred_mod = predModifier;
 }
 
-void ptx_recognizer::add_pred( const char *identifier, int neg, int predModifier )
-{
-   PTX_PARSE_DPRINTF("add_pred");
-   const symbol *s = g_current_symbol_table->lookup(identifier);
-   if ( s == NULL ) {
-      std::string msg = std::string("predicate \"") + identifier + "\" has no declaration.";
-      parse_error( msg.c_str() );
-   }
-   g_pred = s;
-   g_neg_pred = neg;
-   g_pred_mod = predModifier;
+void ptx_recognizer::add_option(int option) {
+  PTX_PARSE_DPRINTF("add_option");
+  g_options.push_back(option);
+}
+void ptx_recognizer::add_wmma_option(int option) {
+  PTX_PARSE_DPRINTF("add_option");
+  g_wmma_options.push_back(option);
+}
+void ptx_recognizer::add_double_operand(const char *d1, const char *d2) {
+  // operands that access two variables.
+  // eg. s[$ofs1+$r0], g[$ofs1+=$r0]
+  // TODO: Not sure if I'm going to use this for storing to two destinations or
+  // not.
+
+  PTX_PARSE_DPRINTF("add_double_operand");
+  const symbol *s1 = g_current_symbol_table->lookup(d1);
+  const symbol *s2 = g_current_symbol_table->lookup(d2);
+  parse_assert(s1 != NULL && s2 != NULL, "component(s) missing declarations.");
+  g_operands.push_back(operand_info(s1, s2, gpgpu_ctx));
 }
 
-void ptx_recognizer::add_option( int option )
-{
-   PTX_PARSE_DPRINTF("add_option");
-   g_options.push_back( option );
-}
-void ptx_recognizer::add_wmma_option( int option )
-{
-   PTX_PARSE_DPRINTF("add_option");
-   g_wmma_options.push_back( option );
-}
-void ptx_recognizer::add_double_operand( const char *d1, const char *d2 )
-{
-   //operands that access two variables.
-   //eg. s[$ofs1+$r0], g[$ofs1+=$r0]
-   //TODO: Not sure if I'm going to use this for storing to two destinations or not.
-
-   PTX_PARSE_DPRINTF("add_double_operand");
-   const symbol *s1 = g_current_symbol_table->lookup(d1);
-   const symbol *s2 = g_current_symbol_table->lookup(d2);
-   parse_assert( s1 != NULL && s2 != NULL, "component(s) missing declarations.");
-   g_operands.push_back( operand_info(s1,s2,gpgpu_ctx) );
+void ptx_recognizer::add_1vector_operand(const char *d1) {
+  // handles the single element vector operand ({%v1}) found in tex.1d
+  // instructions
+  PTX_PARSE_DPRINTF("add_1vector_operand");
+  const symbol *s1 = g_current_symbol_table->lookup(d1);
+  parse_assert(s1 != NULL, "component(s) missing declarations.");
+  g_operands.push_back(operand_info(s1, NULL, NULL, NULL, gpgpu_ctx));
 }
 
-void ptx_recognizer::add_1vector_operand( const char *d1 )
-{
-   // handles the single element vector operand ({%v1}) found in tex.1d instructions
-   PTX_PARSE_DPRINTF("add_1vector_operand");
-   const symbol *s1 = g_current_symbol_table->lookup(d1);
-   parse_assert( s1 != NULL, "component(s) missing declarations.");
-   g_operands.push_back( operand_info(s1,NULL,NULL,NULL,gpgpu_ctx) );
+void ptx_recognizer::add_2vector_operand(const char *d1, const char *d2) {
+  PTX_PARSE_DPRINTF("add_2vector_operand");
+  const symbol *s1 = g_current_symbol_table->lookup(d1);
+  const symbol *s2 = g_current_symbol_table->lookup(d2);
+  parse_assert(s1 != NULL && s2 != NULL,
+               "v2 component(s) missing declarations.");
+  g_operands.push_back(operand_info(s1, s2, NULL, NULL, gpgpu_ctx));
 }
 
-void ptx_recognizer::add_2vector_operand( const char *d1, const char *d2 )
-{
-   PTX_PARSE_DPRINTF("add_2vector_operand");
-   const symbol *s1 = g_current_symbol_table->lookup(d1);
-   const symbol *s2 = g_current_symbol_table->lookup(d2);
-   parse_assert( s1 != NULL && s2 != NULL, "v2 component(s) missing declarations.");
-   g_operands.push_back( operand_info(s1,s2,NULL,NULL,gpgpu_ctx) );
+void ptx_recognizer::add_3vector_operand(const char *d1, const char *d2,
+                                         const char *d3) {
+  PTX_PARSE_DPRINTF("add_3vector_operand");
+  const symbol *s1 = g_current_symbol_table->lookup(d1);
+  const symbol *s2 = g_current_symbol_table->lookup(d2);
+  const symbol *s3 = g_current_symbol_table->lookup(d3);
+  parse_assert(s1 != NULL && s2 != NULL && s3 != NULL,
+               "v3 component(s) missing declarations.");
+  g_operands.push_back(operand_info(s1, s2, s3, NULL, gpgpu_ctx));
 }
 
-void ptx_recognizer::add_3vector_operand( const char *d1, const char *d2, const char *d3 )
-{
-   PTX_PARSE_DPRINTF("add_3vector_operand");
-   const symbol *s1 = g_current_symbol_table->lookup(d1);
-   const symbol *s2 = g_current_symbol_table->lookup(d2);
-   const symbol *s3 = g_current_symbol_table->lookup(d3);
-   parse_assert( s1 != NULL && s2 != NULL && s3 != NULL, "v3 component(s) missing declarations.");
-   g_operands.push_back( operand_info(s1,s2,s3,NULL,gpgpu_ctx) );
+void ptx_recognizer::add_4vector_operand(const char *d1, const char *d2,
+                                         const char *d3, const char *d4) {
+  PTX_PARSE_DPRINTF("add_4vector_operand");
+  const symbol *s1 = g_current_symbol_table->lookup(d1);
+  const symbol *s2 = g_current_symbol_table->lookup(d2);
+  const symbol *s3 = g_current_symbol_table->lookup(d3);
+  const symbol *s4 = g_current_symbol_table->lookup(d4);
+  parse_assert(s1 != NULL && s2 != NULL && s3 != NULL && s4 != NULL,
+               "v4 component(s) missing declarations.");
+  const symbol *null_op = g_current_symbol_table->lookup("_");
+  if (s2 == null_op) s2 = NULL;
+  if (s3 == null_op) s3 = NULL;
+  if (s4 == null_op) s4 = NULL;
+  g_operands.push_back(operand_info(s1, s2, s3, s4, gpgpu_ctx));
+}
+void ptx_recognizer::add_8vector_operand(const char *d1, const char *d2,
+                                         const char *d3, const char *d4,
+                                         const char *d5, const char *d6,
+                                         const char *d7, const char *d8) {
+  PTX_PARSE_DPRINTF("add_8vector_operand");
+  const symbol *s1 = g_current_symbol_table->lookup(d1);
+  const symbol *s2 = g_current_symbol_table->lookup(d2);
+  const symbol *s3 = g_current_symbol_table->lookup(d3);
+  const symbol *s4 = g_current_symbol_table->lookup(d4);
+  const symbol *s5 = g_current_symbol_table->lookup(d5);
+  const symbol *s6 = g_current_symbol_table->lookup(d6);
+  const symbol *s7 = g_current_symbol_table->lookup(d7);
+  const symbol *s8 = g_current_symbol_table->lookup(d8);
+  parse_assert(s1 != NULL && s2 != NULL && s3 != NULL && s4 != NULL &&
+                   s5 != NULL && s6 != NULL && s7 != NULL && s8 != NULL,
+               "v4 component(s) missing declarations.");
+  const symbol *null_op = g_current_symbol_table->lookup("_");
+  if (s2 == null_op) s2 = NULL;
+  if (s3 == null_op) s3 = NULL;
+  if (s4 == null_op) s4 = NULL;
+  if (s5 == null_op) s5 = NULL;
+  if (s6 == null_op) s6 = NULL;
+  if (s7 == null_op) s7 = NULL;
+  if (s8 == null_op) s8 = NULL;
+  g_operands.push_back(operand_info(s1, s2, s3, s4, s5, s6, s7, s8, gpgpu_ctx));
 }
 
-void ptx_recognizer::add_4vector_operand( const char *d1, const char *d2, const char *d3, const char *d4 )
-{
-   PTX_PARSE_DPRINTF("add_4vector_operand");
-   const symbol *s1 = g_current_symbol_table->lookup(d1);
-   const symbol *s2 = g_current_symbol_table->lookup(d2);
-   const symbol *s3 = g_current_symbol_table->lookup(d3);
-   const symbol *s4 = g_current_symbol_table->lookup(d4);
-   parse_assert( s1 != NULL && s2 != NULL && s3 != NULL && s4 != NULL, "v4 component(s) missing declarations.");
-   const symbol *null_op = g_current_symbol_table->lookup("_");
-   if ( s2 == null_op ) s2 = NULL;
-   if ( s3 == null_op ) s3 = NULL;
-   if ( s4 == null_op ) s4 = NULL;
-   g_operands.push_back( operand_info(s1,s2,s3,s4,gpgpu_ctx) );
-}
-void ptx_recognizer::add_8vector_operand( const char *d1, const char *d2, const char *d3, const char *d4,const char *d5,const char *d6,const char *d7,const char *d8 )
-{
-   PTX_PARSE_DPRINTF("add_8vector_operand");
-   const symbol *s1 = g_current_symbol_table->lookup(d1);
-   const symbol *s2 = g_current_symbol_table->lookup(d2);
-   const symbol *s3 = g_current_symbol_table->lookup(d3);
-   const symbol *s4 = g_current_symbol_table->lookup(d4);
-   const symbol *s5 = g_current_symbol_table->lookup(d5);
-   const symbol *s6 = g_current_symbol_table->lookup(d6);
-   const symbol *s7 = g_current_symbol_table->lookup(d7);
-   const symbol *s8 = g_current_symbol_table->lookup(d8);
-   parse_assert( s1 != NULL && s2 != NULL && s3 != NULL && s4 != NULL && s5 !=NULL && s6 !=NULL && s7 !=NULL && s8 !=NULL, "v4 component(s) missing declarations.");
-   const symbol *null_op = g_current_symbol_table->lookup("_");
-   if ( s2 == null_op ) s2 = NULL;
-   if ( s3 == null_op ) s3 = NULL;
-   if ( s4 == null_op ) s4 = NULL;
-   if ( s5 == null_op ) s5 = NULL;
-   if ( s6 == null_op ) s6 = NULL;
-   if ( s7 == null_op ) s7 = NULL;
-   if ( s8 == null_op ) s8 = NULL;
-   g_operands.push_back( operand_info(s1,s2,s3,s4,s5,s6,s7,s8,gpgpu_ctx) );
+void ptx_recognizer::add_builtin_operand(int builtin, int dim_modifier) {
+  PTX_PARSE_DPRINTF("add_builtin_operand");
+  g_operands.push_back(operand_info(builtin, dim_modifier, gpgpu_ctx));
 }
 
-void ptx_recognizer::add_builtin_operand( int builtin, int dim_modifier )
-{
-   PTX_PARSE_DPRINTF("add_builtin_operand");
-   g_operands.push_back( operand_info(builtin,dim_modifier,gpgpu_ctx) );
-}
-
-void ptx_recognizer::add_memory_operand()
-{
-   PTX_PARSE_DPRINTF("add_memory_operand");
-   assert( !g_operands.empty() );
-   g_operands.back().make_memory_operand();
+void ptx_recognizer::add_memory_operand() {
+  PTX_PARSE_DPRINTF("add_memory_operand");
+  assert(!g_operands.empty());
+  g_operands.back().make_memory_operand();
 }
 
 /*TODO: add other memory locations*/
-void ptx_recognizer::change_memory_addr_space(const char *identifier)
-{
-   /*0 = N/A, not reading from memory
-    *1 = global memory
-    *2 = shared memory
-    *3 = const memory segment
-    *4 = local memory segment
-    */
+void ptx_recognizer::change_memory_addr_space(const char *identifier) {
+  /*0 = N/A, not reading from memory
+   *1 = global memory
+   *2 = shared memory
+   *3 = const memory segment
+   *4 = local memory segment
+   */
 
-   bool recognizedType = false;
+  bool recognizedType = false;
 
-   PTX_PARSE_DPRINTF("change_memory_addr_space");
-   assert( !g_operands.empty() );
-   if(!strcmp(identifier, "g"))
-   {
-       g_operands.back().set_addr_space(global_space);
-       recognizedType = true;
-   }
-   if(!strcmp(identifier, "s"))
-   {
-       g_operands.back().set_addr_space(shared_space);
-       recognizedType = true;
-   }
-   // For constants, check if the first character is 'c'
-   char c[2];
-   strncpy(c, identifier, 1); c[1] = '\0';
-   if(!strcmp(c, "c"))
-   {
-       g_operands.back().set_addr_space(const_space);
-       parse_assert(g_current_symbol_table->lookup(identifier) != NULL, "Constant was not defined.");
-       g_operands.back().set_const_mem_offset(g_current_symbol_table->lookup(identifier)->get_address());
-       recognizedType = true;
-   }
-   // For local memory, check if the first character is 'l'
-   char l[2];
-   strncpy(l, identifier, 1); l[1] = '\0';
-   if(!strcmp(l, "l"))
-   {
-       g_operands.back().set_addr_space(local_space);
-       //parse_assert(g_current_symbol_table->lookup(identifier) != NULL, "Local memory segment was not defined.");
-       //g_operands.back().set_const_mem_offset(g_current_symbol_table->lookup(identifier)->get_address());
-       recognizedType = true;
-   }
+  PTX_PARSE_DPRINTF("change_memory_addr_space");
+  assert(!g_operands.empty());
+  if (!strcmp(identifier, "g")) {
+    g_operands.back().set_addr_space(global_space);
+    recognizedType = true;
+  }
+  if (!strcmp(identifier, "s")) {
+    g_operands.back().set_addr_space(shared_space);
+    recognizedType = true;
+  }
+  // For constants, check if the first character is 'c'
+  char c[2];
+  strncpy(c, identifier, 1);
+  c[1] = '\0';
+  if (!strcmp(c, "c")) {
+    g_operands.back().set_addr_space(const_space);
+    parse_assert(g_current_symbol_table->lookup(identifier) != NULL,
+                 "Constant was not defined.");
+    g_operands.back().set_const_mem_offset(
+        g_current_symbol_table->lookup(identifier)->get_address());
+    recognizedType = true;
+  }
+  // For local memory, check if the first character is 'l'
+  char l[2];
+  strncpy(l, identifier, 1);
+  l[1] = '\0';
+  if (!strcmp(l, "l")) {
+    g_operands.back().set_addr_space(local_space);
+    // parse_assert(g_current_symbol_table->lookup(identifier) != NULL, "Local
+    // memory segment was not defined.");
+    // g_operands.back().set_const_mem_offset(g_current_symbol_table->lookup(identifier)->get_address());
+    recognizedType = true;
+  }
 
-   parse_assert(recognizedType, "Error: unrecognized memory type.");
+  parse_assert(recognizedType, "Error: unrecognized memory type.");
 }
 
-void ptx_recognizer::change_operand_lohi( int lohi )
-{
-   /*0 = N/A, read entire operand
-    *1 = lo, reading from lowest bits
-    *2 = hi, reading from highest bits
-    */
+void ptx_recognizer::change_operand_lohi(int lohi) {
+  /*0 = N/A, read entire operand
+   *1 = lo, reading from lowest bits
+   *2 = hi, reading from highest bits
+   */
 
-   PTX_PARSE_DPRINTF("change_operand_lohi");
-   assert( !g_operands.empty() );
+  PTX_PARSE_DPRINTF("change_operand_lohi");
+  assert(!g_operands.empty());
 
-   g_operands.back().set_operand_lohi(lohi);
-
+  g_operands.back().set_operand_lohi(lohi);
 }
 
-void ptx_recognizer::set_immediate_operand_type ()
-{
-     PTX_PARSE_DPRINTF("set_immediate_operand_type");
-     assert( !g_operands.empty() );
-     g_operands.back().set_immediate_addr();
+void ptx_recognizer::set_immediate_operand_type() {
+  PTX_PARSE_DPRINTF("set_immediate_operand_type");
+  assert(!g_operands.empty());
+  g_operands.back().set_immediate_addr();
 }
 
-void ptx_recognizer::change_double_operand_type( int operand_type )
-{
-   /*
-    *-3 = reg / reg (set instruction, but both get same value)
-    *-2 = reg | reg (cvt instruction)
-    *-1 = reg | reg (set instruction)
-    *0 = N/A, default
-    *1 = reg + reg
-    *2 = reg += reg
-    *3 = reg += immediate
-    */
+void ptx_recognizer::change_double_operand_type(int operand_type) {
+  /*
+   *-3 = reg / reg (set instruction, but both get same value)
+   *-2 = reg | reg (cvt instruction)
+   *-1 = reg | reg (set instruction)
+   *0 = N/A, default
+   *1 = reg + reg
+   *2 = reg += reg
+   *3 = reg += immediate
+   */
 
-   PTX_PARSE_DPRINTF("change_double_operand_type");
-   assert( !g_operands.empty() );
+  PTX_PARSE_DPRINTF("change_double_operand_type");
+  assert(!g_operands.empty());
 
-   // For double destination operands, ensure valid instruction
-   if( operand_type == -1 || operand_type == -2 ) {
-      if((g_opcode == SET_OP)||(g_opcode == SETP_OP))
-         g_operands.back().set_double_operand_type(-1);
-      else
-         g_operands.back().set_double_operand_type(-2);
-   } else if( operand_type == -3 ) {
-      if(g_opcode == SET_OP || g_opcode == MAD_OP)
-         g_operands.back().set_double_operand_type(operand_type);
-      else
-         parse_assert(0, "Error: Unsupported use of double destination operand.");
-   } else {
+  // For double destination operands, ensure valid instruction
+  if (operand_type == -1 || operand_type == -2) {
+    if ((g_opcode == SET_OP) || (g_opcode == SETP_OP))
+      g_operands.back().set_double_operand_type(-1);
+    else
+      g_operands.back().set_double_operand_type(-2);
+  } else if (operand_type == -3) {
+    if (g_opcode == SET_OP || g_opcode == MAD_OP)
       g_operands.back().set_double_operand_type(operand_type);
-   }
-
+    else
+      parse_assert(0, "Error: Unsupported use of double destination operand.");
+  } else {
+    g_operands.back().set_double_operand_type(operand_type);
+  }
 }
 
-void ptx_recognizer::change_operand_neg( )
-{
-   PTX_PARSE_DPRINTF("change_operand_neg");
-   assert( !g_operands.empty() );
+void ptx_recognizer::change_operand_neg() {
+  PTX_PARSE_DPRINTF("change_operand_neg");
+  assert(!g_operands.empty());
 
-   g_operands.back().set_operand_neg();
-
+  g_operands.back().set_operand_neg();
 }
 
-void ptx_recognizer::add_literal_int( int value )
-{
-   PTX_PARSE_DPRINTF("add_literal_int");
-   g_operands.push_back( operand_info(value,gpgpu_ctx) );
+void ptx_recognizer::add_literal_int(int value) {
+  PTX_PARSE_DPRINTF("add_literal_int");
+  g_operands.push_back(operand_info(value, gpgpu_ctx));
 }
 
-void ptx_recognizer::add_literal_float( float value )
-{
-   PTX_PARSE_DPRINTF("add_literal_float");
-   g_operands.push_back( operand_info(value,gpgpu_ctx) );
+void ptx_recognizer::add_literal_float(float value) {
+  PTX_PARSE_DPRINTF("add_literal_float");
+  g_operands.push_back(operand_info(value, gpgpu_ctx));
 }
 
-void ptx_recognizer::add_literal_double( double value )
-{
-   PTX_PARSE_DPRINTF("add_literal_double");
-   g_operands.push_back( operand_info(value,gpgpu_ctx) );
+void ptx_recognizer::add_literal_double(double value) {
+  PTX_PARSE_DPRINTF("add_literal_double");
+  g_operands.push_back(operand_info(value, gpgpu_ctx));
 }
 
-void ptx_recognizer::add_scalar_operand( const char *identifier )
-{
-   PTX_PARSE_DPRINTF("add_scalar_operand");
-   const symbol *s = g_current_symbol_table->lookup(identifier);
-   if ( s == NULL ) {
-      if ( g_opcode == BRA_OP || g_opcode == CALLP_OP) {
-         // forward branch target...
-         s = g_current_symbol_table->add_variable(identifier,NULL,0,gpgpu_ctx->g_filename,ptx_get_lineno(scanner));
-      } else {
-         std::string msg = std::string("operand \"") + identifier + "\" has no declaration.";
-         parse_error( msg.c_str() );
-      }
-   }
-   g_operands.push_back( operand_info(s,gpgpu_ctx) );
+void ptx_recognizer::add_scalar_operand(const char *identifier) {
+  PTX_PARSE_DPRINTF("add_scalar_operand");
+  const symbol *s = g_current_symbol_table->lookup(identifier);
+  if (s == NULL) {
+    if (g_opcode == BRA_OP || g_opcode == CALLP_OP) {
+      // forward branch target...
+      s = g_current_symbol_table->add_variable(
+          identifier, NULL, 0, gpgpu_ctx->g_filename, ptx_get_lineno(scanner));
+    } else {
+      std::string msg =
+          std::string("operand \"") + identifier + "\" has no declaration.";
+      parse_error(msg.c_str());
+    }
+  }
+  g_operands.push_back(operand_info(s, gpgpu_ctx));
 }
 
-void ptx_recognizer::add_neg_pred_operand( const char *identifier )
-{
-   PTX_PARSE_DPRINTF("add_neg_pred_operand");
-   const symbol *s = g_current_symbol_table->lookup(identifier);
-   if ( s == NULL ) {
-       s = g_current_symbol_table->add_variable(identifier,NULL,1,gpgpu_ctx->g_filename,ptx_get_lineno(scanner));
-   }
-   operand_info op(s, gpgpu_ctx);
-   op.set_neg_pred();
-   g_operands.push_back( op );
+void ptx_recognizer::add_neg_pred_operand(const char *identifier) {
+  PTX_PARSE_DPRINTF("add_neg_pred_operand");
+  const symbol *s = g_current_symbol_table->lookup(identifier);
+  if (s == NULL) {
+    s = g_current_symbol_table->add_variable(
+        identifier, NULL, 1, gpgpu_ctx->g_filename, ptx_get_lineno(scanner));
+  }
+  operand_info op(s, gpgpu_ctx);
+  op.set_neg_pred();
+  g_operands.push_back(op);
 }
 
-void ptx_recognizer::add_address_operand( const char *identifier, int offset )
-{
-   PTX_PARSE_DPRINTF("add_address_operand");
-   const symbol *s = g_current_symbol_table->lookup(identifier);
-   if ( s == NULL ) {
-      std::string msg = std::string("operand \"") + identifier + "\" has no declaration.";
-      parse_error( msg.c_str() );
-   }
-   g_operands.push_back( operand_info(s,offset,gpgpu_ctx) );
+void ptx_recognizer::add_address_operand(const char *identifier, int offset) {
+  PTX_PARSE_DPRINTF("add_address_operand");
+  const symbol *s = g_current_symbol_table->lookup(identifier);
+  if (s == NULL) {
+    std::string msg =
+        std::string("operand \"") + identifier + "\" has no declaration.";
+    parse_error(msg.c_str());
+  }
+  g_operands.push_back(operand_info(s, offset, gpgpu_ctx));
 }
 
-void ptx_recognizer::add_address_operand2( int offset )
-{
-   PTX_PARSE_DPRINTF("add_address_operand");
-   g_operands.push_back( operand_info((unsigned)offset,gpgpu_ctx) );
+void ptx_recognizer::add_address_operand2(int offset) {
+  PTX_PARSE_DPRINTF("add_address_operand");
+  g_operands.push_back(operand_info((unsigned)offset, gpgpu_ctx));
 }
 
-void ptx_recognizer::add_array_initializer()
-{
-   g_last_symbol->add_initializer(g_operands);
+void ptx_recognizer::add_array_initializer() {
+  g_last_symbol->add_initializer(g_operands);
 }
 
-void ptx_recognizer::add_version_info( float ver, unsigned ext )
-{
-   g_global_symbol_table->set_ptx_version(ver,ext);
+void ptx_recognizer::add_version_info(float ver, unsigned ext) {
+  g_global_symbol_table->set_ptx_version(ver, ext);
 }
 
-void ptx_recognizer::add_file( unsigned num, const char *filename )
-{
-   if( gpgpu_ctx->g_filename == NULL ) {
-      char *b = strdup(filename);
-      char *l=b;
-      char *n=b;
-      while( *n != '\0' ) {
-          if( *n == '/' ) 
-              l = n+1;
-          n++;
-      }
+void ptx_recognizer::add_file(unsigned num, const char *filename) {
+  if (gpgpu_ctx->g_filename == NULL) {
+    char *b = strdup(filename);
+    char *l = b;
+    char *n = b;
+    while (*n != '\0') {
+      if (*n == '/') l = n + 1;
+      n++;
+    }
 
-      char *p = strtok(l,".");
-      char buf[1024];
-      snprintf(buf,1024,"%s.ptx",p);
+    char *p = strtok(l, ".");
+    char buf[1024];
+    snprintf(buf, 1024, "%s.ptx", p);
 
-      char *q = strtok(NULL,".");
-      if( q && !strcmp(q,"cu") ) {
-          gpgpu_ctx->g_filename = strdup(buf);
-      }
+    char *q = strtok(NULL, ".");
+    if (q && !strcmp(q, "cu")) {
+      gpgpu_ctx->g_filename = strdup(buf);
+    }
 
-      free( b );
-   }
+    free(b);
+  }
 
-   g_current_symbol_table = g_global_symbol_table;
+  g_current_symbol_table = g_global_symbol_table;
 }
 
-void * ptx_recognizer::reset_symtab()
-{
-   void *result = g_current_symbol_table;
-   g_current_symbol_table = g_global_symbol_table;
-   return result;
+void *ptx_recognizer::reset_symtab() {
+  void *result = g_current_symbol_table;
+  g_current_symbol_table = g_global_symbol_table;
+  return result;
 }
 
-void ptx_recognizer::set_symtab(void*symtab)
-{
-   g_current_symbol_table = (symbol_table*)symtab;
+void ptx_recognizer::set_symtab(void *symtab) {
+  g_current_symbol_table = (symbol_table *)symtab;
 }
 
-void ptx_recognizer::add_pragma( const char *str )
-{
-   printf("GPGPU-Sim PTX: Warning -- ignoring pragma '%s'\n", str );
+void ptx_recognizer::add_pragma(const char *str) {
+  printf("GPGPU-Sim PTX: Warning -- ignoring pragma '%s'\n", str);
 }
 
-void ptx_recognizer::version_header(double a) {}  //intentional dummy function
+void ptx_recognizer::version_header(double a) {}  // intentional dummy function
 
-void ptx_recognizer::target_header(char* a)
-{
-   g_global_symbol_table->set_sm_target(a,NULL,NULL);
+void ptx_recognizer::target_header(char *a) {
+  g_global_symbol_table->set_sm_target(a, NULL, NULL);
 }
 
-void ptx_recognizer::target_header2(char* a, char* b)
-{
-   g_global_symbol_table->set_sm_target(a,b,NULL);
+void ptx_recognizer::target_header2(char *a, char *b) {
+  g_global_symbol_table->set_sm_target(a, b, NULL);
 }
 
-void ptx_recognizer::target_header3(char* a, char* b, char* c)
-{
-   g_global_symbol_table->set_sm_target(a,b,c);
+void ptx_recognizer::target_header3(char *a, char *b, char *c) {
+  g_global_symbol_table->set_sm_target(a, b, c);
 }
 
 void ptx_recognizer::maxnt_id(int x, int y, int z) {
   g_func_info->set_maxnt_id(x * y * z);
 }
 
-void ptx_recognizer::func_header(const char* a) {} //intentional dummy function
-void ptx_recognizer::func_header_info(const char* a) {} //intentional dummy function
-void ptx_recognizer::func_header_info_int(const char* a, int b) {} //intentional dummy function
+void ptx_recognizer::func_header(const char *a) {}  // intentional dummy
+                                                    // function
+void ptx_recognizer::func_header_info(const char *a) {
+}  // intentional dummy function
+void ptx_recognizer::func_header_info_int(const char *a, int b) {
+}  // intentional dummy function

--- a/src/cuda-sim/ptx_parser.cc
+++ b/src/cuda-sim/ptx_parser.cc
@@ -7,1017 +7,991 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #include "ptx_parser.h"
-#include "ptx_ir.h"
 #include "../../libcuda/gpgpu_context.h"
+#include "ptx_ir.h"
 
-typedef void * yyscan_t;
-#include "ptx.tab.h"
+typedef void *yyscan_t;
 #include <stdarg.h>
+#include "ptx.tab.h"
 
-extern int ptx_get_lineno (yyscan_t yyscanner );
-extern YYSTYPE* ptx_get_lval (yyscan_t yyscanner );
-extern int ptx_error( yyscan_t yyscanner, const char *s );
-extern int ptx_lex_init(yyscan_t* scanner);
-extern void ptx_set_in(FILE * _in_str ,yyscan_t yyscanner );
-extern FILE *ptx_get_in (yyscan_t yyscanner );
-extern int ptx_parse(yyscan_t scanner, ptx_recognizer* recognizer);
+extern int ptx_get_lineno(yyscan_t yyscanner);
+extern YYSTYPE *ptx_get_lval(yyscan_t yyscanner);
+extern int ptx_error(yyscan_t yyscanner, const char *s);
+extern int ptx_lex_init(yyscan_t *scanner);
+extern void ptx_set_in(FILE *_in_str, yyscan_t yyscanner);
+extern FILE *ptx_get_in(yyscan_t yyscanner);
+extern int ptx_parse(yyscan_t scanner, ptx_recognizer *recognizer);
 extern int ptx_lex_destroy(yyscan_t scanner);
 
-void ptx_recognizer::set_ptx_warp_size(const struct core_config * warp_size)
-{
-   g_shader_core_config=warp_size;
+void ptx_recognizer::set_ptx_warp_size(const struct core_config *warp_size) {
+  g_shader_core_config = warp_size;
 }
 
+#define PTX_PARSE_DPRINTF(...)                                            \
+  if (g_debug_ir_generation) {                                            \
+    printf(" %s:%u => ", gpgpu_ctx->g_filename, ptx_get_lineno(scanner)); \
+    printf("   (%s:%u) ", __FILE__, __LINE__);                            \
+    printf(__VA_ARGS__);                                                  \
+    printf("\n");                                                         \
+    fflush(stdout);                                                       \
+  }
 
-#define PTX_PARSE_DPRINTF(...) \
-   if( g_debug_ir_generation ) { \
-      printf(" %s:%u => ",gpgpu_ctx->g_filename,ptx_get_lineno(scanner)); \
-      printf("   (%s:%u) ", __FILE__, __LINE__); \
-      printf(__VA_ARGS__); \
-      printf("\n"); \
-      fflush(stdout); \
-   }
+static std::map<unsigned, std::string> g_ptx_token_decode;
 
-static std::map<unsigned,std::string> g_ptx_token_decode;
+const char *decode_token(int type) { return g_ptx_token_decode[type].c_str(); }
 
-const char *decode_token( int type )
-{
-   return g_ptx_token_decode[type].c_str();
+void ptx_recognizer::read_parser_environment_variables() {
+  gpgpu_ctx->g_filename = getenv("PTX_SIM_KERNELFILE");
+  char *dbg_level = getenv("PTX_SIM_DEBUG");
+  if (dbg_level && strlen(dbg_level)) {
+    int debug_execution = 0;
+    sscanf(dbg_level, "%d", &debug_execution);
+    if (debug_execution >= 30) g_debug_ir_generation = true;
+  }
 }
 
-void ptx_recognizer::read_parser_environment_variables() 
-{
-   gpgpu_ctx->g_filename = getenv("PTX_SIM_KERNELFILE");
-   char *dbg_level = getenv("PTX_SIM_DEBUG");
-   if ( dbg_level && strlen(dbg_level) ) {
-      int debug_execution=0;
-      sscanf(dbg_level,"%d", &debug_execution);
-      if ( debug_execution >= 30 ) 
-         g_debug_ir_generation=true;
-   }
+void ptx_recognizer::init_directive_state() {
+  PTX_PARSE_DPRINTF("init_directive_state");
+  g_space_spec = undefined_space;
+  g_ptr_spec = undefined_space;
+  g_scalar_type_spec = -1;
+  g_vector_spec = -1;
+  g_opcode = -1;
+  g_alignment_spec = -1;
+  g_size = -1;
+  g_extern_spec = 0;
+  g_scalar_type.clear();
+  g_operands.clear();
+  g_last_symbol = NULL;
 }
 
-void ptx_recognizer::init_directive_state()
-{
-   PTX_PARSE_DPRINTF("init_directive_state");
-   g_space_spec=undefined_space;
-   g_ptr_spec=undefined_space;
-   g_scalar_type_spec=-1;
-   g_vector_spec=-1;
-   g_opcode=-1;
-   g_alignment_spec = -1;
-   g_size = -1;
-   g_extern_spec = 0;
-   g_scalar_type.clear();
-   g_operands.clear();
-   g_last_symbol = NULL;
+void ptx_recognizer::init_instruction_state() {
+  PTX_PARSE_DPRINTF("init_instruction_state");
+  g_pred = NULL;
+  g_neg_pred = 0;
+  g_pred_mod = -1;
+  g_label = NULL;
+  g_opcode = -1;
+  g_options.clear();
+  g_wmma_options.clear();
+  g_return_var = operand_info(gpgpu_ctx);
+  init_directive_state();
 }
 
-void ptx_recognizer::init_instruction_state()
-{
-   PTX_PARSE_DPRINTF("init_instruction_state");
-   g_pred = NULL;
-   g_neg_pred = 0;
-   g_pred_mod = -1;
-   g_label = NULL;
-   g_opcode = -1;
-   g_options.clear();
-   g_wmma_options.clear();
-   g_return_var = operand_info(gpgpu_ctx);
-   init_directive_state();
-}
+symbol_table *gpgpu_context::init_parser(const char *ptx_filename) {
+  g_filename = strdup(ptx_filename);
+  if (g_global_allfiles_symbol_table == NULL) {
+    g_global_allfiles_symbol_table =
+        new symbol_table("global_allfiles", 0, NULL, this);
+    ptx_parser->g_global_symbol_table = ptx_parser->g_current_symbol_table =
+        g_global_allfiles_symbol_table;
+  }
+  /*else {
+      g_global_symbol_table = g_current_symbol_table = new
+  symbol_table("global",0,g_global_allfiles_symbol_table);
+  }*/
 
-symbol_table * gpgpu_context::init_parser( const char *ptx_filename )
-{
-   g_filename = strdup(ptx_filename);
-   if  (g_global_allfiles_symbol_table == NULL) {
-       g_global_allfiles_symbol_table = new symbol_table("global_allfiles", 0, NULL, this);
-       ptx_parser->g_global_symbol_table = ptx_parser->g_current_symbol_table = g_global_allfiles_symbol_table;
-   }
-   /*else {
-       g_global_symbol_table = g_current_symbol_table = new symbol_table("global",0,g_global_allfiles_symbol_table);
-   }*/
-
-#define DEF(X,Y) g_ptx_token_decode[X] = Y;
+#define DEF(X, Y) g_ptx_token_decode[X] = Y;
 #include "ptx_parser_decode.def"
 #undef DEF
-   g_ptx_token_decode[undefined_space] = "undefined_space";
-   g_ptx_token_decode[undefined_space] = "undefined_space=0";
-   g_ptx_token_decode[reg_space] = "reg_space";
-   g_ptx_token_decode[local_space] = "local_space";
-   g_ptx_token_decode[shared_space] = "shared_space";
-   g_ptx_token_decode[param_space_unclassified] = "param_space_unclassified";
-   g_ptx_token_decode[param_space_kernel] = "param_space_kernel";
-   g_ptx_token_decode[param_space_local] = "param_space_local";
-   g_ptx_token_decode[const_space] = "const_space";
-   g_ptx_token_decode[tex_space] = "tex_space";
-   g_ptx_token_decode[surf_space] = "surf_space";
-   g_ptx_token_decode[global_space] = "global_space";
-   g_ptx_token_decode[generic_space] = "generic_space";
-   g_ptx_token_decode[instruction_space] = "instruction_space";
+  g_ptx_token_decode[undefined_space] = "undefined_space";
+  g_ptx_token_decode[undefined_space] = "undefined_space=0";
+  g_ptx_token_decode[reg_space] = "reg_space";
+  g_ptx_token_decode[local_space] = "local_space";
+  g_ptx_token_decode[shared_space] = "shared_space";
+  g_ptx_token_decode[param_space_unclassified] = "param_space_unclassified";
+  g_ptx_token_decode[param_space_kernel] = "param_space_kernel";
+  g_ptx_token_decode[param_space_local] = "param_space_local";
+  g_ptx_token_decode[const_space] = "const_space";
+  g_ptx_token_decode[tex_space] = "tex_space";
+  g_ptx_token_decode[surf_space] = "surf_space";
+  g_ptx_token_decode[global_space] = "global_space";
+  g_ptx_token_decode[generic_space] = "generic_space";
+  g_ptx_token_decode[instruction_space] = "instruction_space";
 
-   ptx_lex_init(&(ptx_parser->scanner));
-   ptx_parser->init_directive_state();
-   ptx_parser->init_instruction_state();
+  ptx_lex_init(&(ptx_parser->scanner));
+  ptx_parser->init_directive_state();
+  ptx_parser->init_instruction_state();
 
-   FILE *ptx_in;
-   ptx_in = fopen(ptx_filename, "r");
-   ptx_set_in(ptx_in, ptx_parser->scanner);
-   ptx_parse(ptx_parser->scanner, ptx_parser);
-   ptx_in = ptx_get_in(ptx_parser->scanner);
-   ptx_lex_destroy(ptx_parser->scanner);
-   fclose(ptx_in);
-   return ptx_parser->g_global_symbol_table;
+  FILE *ptx_in;
+  ptx_in = fopen(ptx_filename, "r");
+  ptx_set_in(ptx_in, ptx_parser->scanner);
+  ptx_parse(ptx_parser->scanner, ptx_parser);
+  ptx_in = ptx_get_in(ptx_parser->scanner);
+  ptx_lex_destroy(ptx_parser->scanner);
+  fclose(ptx_in);
+  return ptx_parser->g_global_symbol_table;
 }
 
-
-void ptx_recognizer::start_function( int entry_point )
-{
-   PTX_PARSE_DPRINTF("start_function");
-   init_directive_state();
-   init_instruction_state();
-   g_entry_point = entry_point;
-   g_func_info = NULL;
-   g_entry_func_param_index=0;
+void ptx_recognizer::start_function(int entry_point) {
+  PTX_PARSE_DPRINTF("start_function");
+  init_directive_state();
+  init_instruction_state();
+  g_entry_point = entry_point;
+  g_func_info = NULL;
+  g_entry_func_param_index = 0;
 }
 
-void ptx_recognizer::add_function_name( const char *name )
-{
-   PTX_PARSE_DPRINTF("add_function_name %s %s", name,  ((g_entry_point==1)?"(entrypoint)":((g_entry_point==2)?"(extern)":"")));
-   bool prior_decl = g_global_symbol_table->add_function_decl( name, g_entry_point, &g_func_info, &g_current_symbol_table );
-   if( g_add_identifier_cached__identifier ) {
-      add_identifier( g_add_identifier_cached__identifier,
-                      g_add_identifier_cached__array_dim,
-                      g_add_identifier_cached__array_ident );
-      free( g_add_identifier_cached__identifier );
-      g_add_identifier_cached__identifier = NULL;
-      g_func_info->add_return_var( g_last_symbol );
-      init_directive_state();
-   }
-   if( prior_decl ) {
-      g_func_info->remove_args();
-   }
-   g_global_symbol_table->add_function( g_func_info, gpgpu_ctx->g_filename, ptx_get_lineno(scanner) );
+void ptx_recognizer::add_function_name(const char *name) {
+  PTX_PARSE_DPRINTF(
+      "add_function_name %s %s", name,
+      ((g_entry_point == 1) ? "(entrypoint)"
+                            : ((g_entry_point == 2) ? "(extern)" : "")));
+  bool prior_decl = g_global_symbol_table->add_function_decl(
+      name, g_entry_point, &g_func_info, &g_current_symbol_table);
+  if (g_add_identifier_cached__identifier) {
+    add_identifier(g_add_identifier_cached__identifier,
+                   g_add_identifier_cached__array_dim,
+                   g_add_identifier_cached__array_ident);
+    free(g_add_identifier_cached__identifier);
+    g_add_identifier_cached__identifier = NULL;
+    g_func_info->add_return_var(g_last_symbol);
+    init_directive_state();
+  }
+  if (prior_decl) {
+    g_func_info->remove_args();
+  }
+  g_global_symbol_table->add_function(g_func_info, gpgpu_ctx->g_filename,
+                                      ptx_get_lineno(scanner));
 }
 
-//Jin: handle instruction group for cdp
+// Jin: handle instruction group for cdp
 void ptx_recognizer::start_inst_group() {
-   PTX_PARSE_DPRINTF("start_instruction_group");
-   g_current_symbol_table = g_current_symbol_table->start_inst_group();
+  PTX_PARSE_DPRINTF("start_instruction_group");
+  g_current_symbol_table = g_current_symbol_table->start_inst_group();
 }
 
 void ptx_recognizer::end_inst_group() {
-   PTX_PARSE_DPRINTF("end_instruction_group");
-   g_current_symbol_table = g_current_symbol_table->end_inst_group();
+  PTX_PARSE_DPRINTF("end_instruction_group");
+  g_current_symbol_table = g_current_symbol_table->end_inst_group();
 }
 
-void ptx_recognizer::add_directive()
-{
-   PTX_PARSE_DPRINTF("add_directive");
-   init_directive_state();
+void ptx_recognizer::add_directive() {
+  PTX_PARSE_DPRINTF("add_directive");
+  init_directive_state();
 }
 
-#define mymax(a,b) ((a)>(b)?(a):(b))
+#define mymax(a, b) ((a) > (b) ? (a) : (b))
 
-void ptx_recognizer::end_function()
-{
-   PTX_PARSE_DPRINTF("end_function");
+void ptx_recognizer::end_function() {
+  PTX_PARSE_DPRINTF("end_function");
 
-   init_directive_state();
-   init_instruction_state();
-   g_max_regs_per_thread = mymax( g_max_regs_per_thread, (g_current_symbol_table->next_reg_num()-1)); 
-   g_func_info->add_inst( g_instructions );
-   g_instructions.clear();
-   gpgpu_ptx_assemble( g_func_info->get_name(), g_func_info );
-   g_current_symbol_table = g_global_symbol_table;
+  init_directive_state();
+  init_instruction_state();
+  g_max_regs_per_thread = mymax(g_max_regs_per_thread,
+                                (g_current_symbol_table->next_reg_num() - 1));
+  g_func_info->add_inst(g_instructions);
+  g_instructions.clear();
+  gpgpu_ptx_assemble(g_func_info->get_name(), g_func_info);
+  g_current_symbol_table = g_global_symbol_table;
 
-   PTX_PARSE_DPRINTF("function %s, PC = %d\n", g_func_info->get_name().c_str(), g_func_info->get_start_PC());
+  PTX_PARSE_DPRINTF("function %s, PC = %d\n", g_func_info->get_name().c_str(),
+                    g_func_info->get_start_PC());
 }
 
-#define parse_error(msg, ...) parse_error_impl(__FILE__,__LINE__, msg, ##__VA_ARGS__)
-#define parse_assert(cond,msg, ...) parse_assert_impl((cond),__FILE__,__LINE__, msg, ##__VA_ARGS__)
+#define parse_error(msg, ...) \
+  parse_error_impl(__FILE__, __LINE__, msg, ##__VA_ARGS__)
+#define parse_assert(cond, msg, ...) \
+  parse_assert_impl((cond), __FILE__, __LINE__, msg, ##__VA_ARGS__)
 
-void ptx_recognizer::parse_error_impl( const char *file, unsigned line, const char *msg, ... )
-{
-   va_list ap;
-   char buf[1024];
-   va_start(ap,msg);
-   vsnprintf(buf,1024,msg,ap);
-   va_end(ap);
+void ptx_recognizer::parse_error_impl(const char *file, unsigned line,
+                                      const char *msg, ...) {
+  va_list ap;
+  char buf[1024];
+  va_start(ap, msg);
+  vsnprintf(buf, 1024, msg, ap);
+  va_end(ap);
 
-   g_error_detected = 1;
-   printf("%s:%u: Parse error: %s (%s:%u)\n\n", gpgpu_ctx->g_filename, ptx_get_lineno(scanner), buf, file, line);
-   ptx_error(scanner, NULL);
-   abort();
-   exit(1);
+  g_error_detected = 1;
+  printf("%s:%u: Parse error: %s (%s:%u)\n\n", gpgpu_ctx->g_filename,
+         ptx_get_lineno(scanner), buf, file, line);
+  ptx_error(scanner, NULL);
+  abort();
+  exit(1);
 }
 
-void ptx_recognizer::parse_assert_impl( int test_value, const char *file, unsigned line, const char *msg, ... )
-{
-   va_list ap;
-   char buf[1024];
-   va_start(ap,msg);
-   vsnprintf(buf,1024,msg,ap);
-   va_end(ap);
+void ptx_recognizer::parse_assert_impl(int test_value, const char *file,
+                                       unsigned line, const char *msg, ...) {
+  va_list ap;
+  char buf[1024];
+  va_start(ap, msg);
+  vsnprintf(buf, 1024, msg, ap);
+  va_end(ap);
 
-   if ( test_value == 0 )
-      parse_error_impl(file,line, msg);
+  if (test_value == 0) parse_error_impl(file, line, msg);
 }
 
-
-
-void ptx_recognizer::set_return()
-{
-   parse_assert( (g_opcode == CALL_OP || g_opcode == CALLP_OP), "only call can have return value");
-   g_operands.front().set_return();
-   g_return_var = g_operands.front();
+void ptx_recognizer::set_return() {
+  parse_assert((g_opcode == CALL_OP || g_opcode == CALLP_OP),
+               "only call can have return value");
+  g_operands.front().set_return();
+  g_return_var = g_operands.front();
 }
 
-
-const ptx_instruction *ptx_recognizer::ptx_instruction_lookup( const char *filename, unsigned linenumber )
-{
-   std::map<std::string,std::map<unsigned,const ptx_instruction*> >::iterator f=g_inst_lookup.find(filename);
-   if( f == g_inst_lookup.end() ) 
-      return NULL;
-   std::map<unsigned,const ptx_instruction*>::iterator l=f->second.find(linenumber);
-   if( l == f->second.end() ) 
-      return NULL;
-   return l->second; 
+const ptx_instruction *ptx_recognizer::ptx_instruction_lookup(
+    const char *filename, unsigned linenumber) {
+  std::map<std::string, std::map<unsigned, const ptx_instruction *> >::iterator
+      f = g_inst_lookup.find(filename);
+  if (f == g_inst_lookup.end()) return NULL;
+  std::map<unsigned, const ptx_instruction *>::iterator l =
+      f->second.find(linenumber);
+  if (l == f->second.end()) return NULL;
+  return l->second;
 }
 
-void ptx_recognizer::add_instruction()
-{
-   PTX_PARSE_DPRINTF("add_instruction: %s", ((g_opcode>0)?g_opcode_string[g_opcode]:"<label>") );
-   assert( g_shader_core_config != 0 );
-   ptx_instruction *i = new ptx_instruction( g_opcode, 
-                                             g_pred, 
-                                             g_neg_pred,
-                                             g_pred_mod, 
-                                             g_label, 
-                                             g_operands,
-                                             g_return_var,
-                                             g_options, 
-                                             g_wmma_options, 
-                                             g_scalar_type,
-                                             g_space_spec,
-                                             gpgpu_ctx->g_filename,
-                                             ptx_get_lineno(scanner),
-                                             linebuf,
-                                             g_shader_core_config,
-					     gpgpu_ctx );
-   g_instructions.push_back(i);
-   g_inst_lookup[gpgpu_ctx->g_filename][ptx_get_lineno(scanner)] = i;
-   init_instruction_state();
+void ptx_recognizer::add_instruction() {
+  PTX_PARSE_DPRINTF("add_instruction: %s",
+                    ((g_opcode > 0) ? g_opcode_string[g_opcode] : "<label>"));
+  assert(g_shader_core_config != 0);
+  ptx_instruction *i = new ptx_instruction(
+      g_opcode, g_pred, g_neg_pred, g_pred_mod, g_label, g_operands,
+      g_return_var, g_options, g_wmma_options, g_scalar_type, g_space_spec,
+      gpgpu_ctx->g_filename, ptx_get_lineno(scanner), linebuf,
+      g_shader_core_config, gpgpu_ctx);
+  g_instructions.push_back(i);
+  g_inst_lookup[gpgpu_ctx->g_filename][ptx_get_lineno(scanner)] = i;
+  init_instruction_state();
 }
 
-void ptx_recognizer::add_variables()
-{
-   PTX_PARSE_DPRINTF("add_variables");
-   if ( !g_operands.empty() ) {
-      assert( g_last_symbol != NULL ); 
-      g_last_symbol->add_initializer(g_operands);
-   }
-   init_directive_state();
+void ptx_recognizer::add_variables() {
+  PTX_PARSE_DPRINTF("add_variables");
+  if (!g_operands.empty()) {
+    assert(g_last_symbol != NULL);
+    g_last_symbol->add_initializer(g_operands);
+  }
+  init_directive_state();
 }
 
-void ptx_recognizer::set_variable_type()
-{
-   PTX_PARSE_DPRINTF("set_variable_type space_spec=%s scalar_type_spec=%s", 
-           g_ptx_token_decode[g_space_spec.get_type()].c_str(), 
-           g_ptx_token_decode[g_scalar_type_spec].c_str() );
-   parse_assert( g_space_spec != undefined_space, "variable has no space specification" );
-   parse_assert( g_scalar_type_spec != -1, "variable has no type information" ); // need to extend for structs?
-   g_var_type = g_current_symbol_table->add_type( g_space_spec, 
-                                                  g_scalar_type_spec, 
-                                                  g_vector_spec, 
-                                                  g_alignment_spec, 
-                                                  g_extern_spec );
+void ptx_recognizer::set_variable_type() {
+  PTX_PARSE_DPRINTF("set_variable_type space_spec=%s scalar_type_spec=%s",
+                    g_ptx_token_decode[g_space_spec.get_type()].c_str(),
+                    g_ptx_token_decode[g_scalar_type_spec].c_str());
+  parse_assert(g_space_spec != undefined_space,
+               "variable has no space specification");
+  parse_assert(
+      g_scalar_type_spec != -1,
+      "variable has no type information");  // need to extend for structs?
+  g_var_type = g_current_symbol_table->add_type(
+      g_space_spec, g_scalar_type_spec, g_vector_spec, g_alignment_spec,
+      g_extern_spec);
 }
 
-bool ptx_recognizer::check_for_duplicates( const char *identifier )
-{
-   const symbol *s = g_current_symbol_table->lookup(identifier);
-   return ( s != NULL );
+bool ptx_recognizer::check_for_duplicates(const char *identifier) {
+  const symbol *s = g_current_symbol_table->lookup(identifier);
+  return (s != NULL);
 }
 
-// Returns padding that needs to be inserted ahead of address to make it aligned to min(size, maxalign)
+// Returns padding that needs to be inserted ahead of address to make it aligned
+// to min(size, maxalign)
 /*
  * @param address the address in bytes
  * @param size the size of the memory to be allocated in bytes
- * @param maximum alignment in bytes. i.e. if size is too big then align to this instead
+ * @param maximum alignment in bytes. i.e. if size is too big then align to this
+ * instead
  */
-int pad_address (new_addr_type address, unsigned size, unsigned maxalign) {
-    assert(size >= 0);
-    assert(maxalign > 0);
-    int alignto = maxalign;
-    if (size < maxalign &&
-            (size & (size-1)) == 0) { //size is a power of 2
-        alignto = size;
-    }
-    return alignto ? ((alignto - (address % alignto)) % alignto) : 0;
+int pad_address(new_addr_type address, unsigned size, unsigned maxalign) {
+  assert(size >= 0);
+  assert(maxalign > 0);
+  int alignto = maxalign;
+  if (size < maxalign && (size & (size - 1)) == 0) {  // size is a power of 2
+    alignto = size;
+  }
+  return alignto ? ((alignto - (address % alignto)) % alignto) : 0;
 }
 
-void ptx_recognizer::add_identifier( const char *identifier, int array_dim, unsigned array_ident )
-{
-   if(array_ident==ARRAY_IDENTIFIER){
-       g_size *= array_dim;
-   }
-   if( g_func_decl && (g_func_info == NULL) ) {
-      // return variable decl...
-      assert( g_add_identifier_cached__identifier == NULL );
-      g_add_identifier_cached__identifier = strdup(identifier);
-      g_add_identifier_cached__array_dim = array_dim;
-      g_add_identifier_cached__array_ident = array_ident;
-      return;
-   }
-   PTX_PARSE_DPRINTF("add_identifier \"%s\" (%u)", identifier, g_ident_add_uid);
-   g_ident_add_uid++;
-   type_info *type = g_var_type;
-   type_info_key ti = type->get_key();
-   int basic_type;
-   int regnum;
-   size_t num_bits;
-   unsigned addr_pad;
-   new_addr_type addr;
-   ti.type_decode(num_bits,basic_type);
+void ptx_recognizer::add_identifier(const char *identifier, int array_dim,
+                                    unsigned array_ident) {
+  if (array_ident == ARRAY_IDENTIFIER) {
+    g_size *= array_dim;
+  }
+  if (g_func_decl && (g_func_info == NULL)) {
+    // return variable decl...
+    assert(g_add_identifier_cached__identifier == NULL);
+    g_add_identifier_cached__identifier = strdup(identifier);
+    g_add_identifier_cached__array_dim = array_dim;
+    g_add_identifier_cached__array_ident = array_ident;
+    return;
+  }
+  PTX_PARSE_DPRINTF("add_identifier \"%s\" (%u)", identifier, g_ident_add_uid);
+  g_ident_add_uid++;
+  type_info *type = g_var_type;
+  type_info_key ti = type->get_key();
+  int basic_type;
+  int regnum;
+  size_t num_bits;
+  unsigned addr_pad;
+  new_addr_type addr;
+  ti.type_decode(num_bits, basic_type);
 
-   bool duplicates = check_for_duplicates( identifier );
-   if( duplicates ) {
-      symbol *s = g_current_symbol_table->lookup(identifier);
-      g_last_symbol = s;
-      if( g_func_decl ) 
-         return;
-      std::string msg = std::string(identifier) + " was declared previous at " + s->decl_location() + " skipping new declaration"; 
-      printf("GPGPU-Sim PTX: Warning %s\n", msg.c_str());
-      return;
-   }
+  bool duplicates = check_for_duplicates(identifier);
+  if (duplicates) {
+    symbol *s = g_current_symbol_table->lookup(identifier);
+    g_last_symbol = s;
+    if (g_func_decl) return;
+    std::string msg = std::string(identifier) + " was declared previous at " +
+                      s->decl_location() + " skipping new declaration";
+    printf("GPGPU-Sim PTX: Warning %s\n", msg.c_str());
+    return;
+  }
 
-   assert( g_var_type != NULL );
-   switch ( array_ident ) {
-   case ARRAY_IDENTIFIER:
-      type = g_current_symbol_table->get_array_type(type,array_dim);
+  assert(g_var_type != NULL);
+  switch (array_ident) {
+    case ARRAY_IDENTIFIER:
+      type = g_current_symbol_table->get_array_type(type, array_dim);
       num_bits = array_dim * num_bits;
       break;
-   case ARRAY_IDENTIFIER_NO_DIM:
-      type = g_current_symbol_table->get_array_type(type,(unsigned)-1);
+    case ARRAY_IDENTIFIER_NO_DIM:
+      type = g_current_symbol_table->get_array_type(type, (unsigned)-1);
       num_bits = 0;
       break;
-   default:
+    default:
       break;
-   }
-   g_last_symbol = g_current_symbol_table->add_variable(identifier,type,num_bits/8,gpgpu_ctx->g_filename,ptx_get_lineno(scanner));
-   switch ( ti.get_memory_space().get_type() ) {
-   case reg_space: {
+  }
+  g_last_symbol = g_current_symbol_table->add_variable(
+      identifier, type, num_bits / 8, gpgpu_ctx->g_filename,
+      ptx_get_lineno(scanner));
+  switch (ti.get_memory_space().get_type()) {
+    case reg_space: {
       regnum = g_current_symbol_table->next_reg_num();
       int arch_regnum = -1;
       for (int d = 0; d < strlen(identifier); d++) {
-         if (isdigit(identifier[d])) {
-            sscanf(identifier + d, "%d", &arch_regnum);
-            break;
-         }
+        if (isdigit(identifier[d])) {
+          sscanf(identifier + d, "%d", &arch_regnum);
+          break;
+        }
       }
       if (strcmp(identifier, "%sp") == 0) {
-         arch_regnum = 0;
+        arch_regnum = 0;
       }
       g_last_symbol->set_regno(regnum, arch_regnum);
-      } break;
-   case shared_space:
-      printf("GPGPU-Sim PTX: allocating shared region for \"%s\" ",
-             identifier);
+    } break;
+    case shared_space:
+      printf("GPGPU-Sim PTX: allocating shared region for \"%s\" ", identifier);
       fflush(stdout);
-      assert( (num_bits%8) == 0  );
+      assert((num_bits % 8) == 0);
       addr = g_current_symbol_table->get_shared_next();
-      addr_pad = pad_address(addr, num_bits/8, 128);
-      printf("from 0x%llx to 0x%llx (shared memory space)\n",
-              addr+addr_pad,
-              addr+addr_pad + num_bits/8);
-         fflush(stdout);
-      g_last_symbol->set_address( addr+addr_pad );
-      g_current_symbol_table->alloc_shared( num_bits/8 + addr_pad );
-      break;
-   case sstarr_space:
-         printf("GPGPU-Sim PTX: allocating sstarr region for \"%s\" ",
-                identifier);
-         fflush(stdout);
-         assert( (num_bits%8) == 0  );
-         addr = g_current_symbol_table->get_sstarr_next();
-         addr_pad = pad_address(addr, num_bits/8, 128);
-         printf("from 0x%llx to 0x%llx (sstarr memory space)\n",
-                 addr+addr_pad,
-                 addr+addr_pad + num_bits/8);
-            fflush(stdout);
-         g_last_symbol->set_address( addr+addr_pad );
-         g_current_symbol_table->alloc_sstarr( num_bits/8 + addr_pad );
-         break;
-   case const_space:
-      if( array_ident == ARRAY_IDENTIFIER_NO_DIM ) {
-         printf("GPGPU-Sim PTX: deferring allocation of constant region for \"%s\" (need size information)\n", identifier );
-      } else {
-         printf("GPGPU-Sim PTX: allocating constant region for \"%s\" ",
-                identifier);
-         fflush(stdout);
-         assert( (num_bits%8) == 0  ); 
-         addr = g_current_symbol_table->get_global_next();
-         addr_pad = pad_address(addr, num_bits/8, 128);
-         printf("from 0x%llx to 0x%llx (global memory space) %u\n",
-              addr+addr_pad,
-              addr+addr_pad + num_bits/8,
-              g_const_alloc++);
-         fflush(stdout);
-         g_last_symbol->set_address( addr + addr_pad );
-         g_current_symbol_table->alloc_global( num_bits/8 + addr_pad ); 
-      }
-      if( g_current_symbol_table == g_global_symbol_table ) { 
-         gpgpu_ctx->func_sim->g_constants.insert( identifier );
-      }
-      assert( g_current_symbol_table != NULL );
-      g_sym_name_to_symbol_table[ identifier ] = g_current_symbol_table;
-      break;
-   case global_space:
-      printf("GPGPU-Sim PTX: allocating global region for \"%s\" ",
-             identifier);
+      addr_pad = pad_address(addr, num_bits / 8, 128);
+      printf("from 0x%llx to 0x%llx (shared memory space)\n", addr + addr_pad,
+             addr + addr_pad + num_bits / 8);
       fflush(stdout);
-      assert( (num_bits%8) == 0  );
-      addr = g_current_symbol_table->get_global_next();
-      addr_pad = pad_address(addr, num_bits/8, 128);
-      printf("from 0x%llx to 0x%llx (global memory space)\n",
-              addr+addr_pad,
-              addr+addr_pad + num_bits/8);
-      fflush(stdout);
-      g_last_symbol->set_address( addr+addr_pad );
-      g_current_symbol_table->alloc_global( num_bits/8 + addr_pad );
-      gpgpu_ctx->func_sim->g_globals.insert( identifier );
-      assert( g_current_symbol_table != NULL );
-      g_sym_name_to_symbol_table[ identifier ] = g_current_symbol_table;
+      g_last_symbol->set_address(addr + addr_pad);
+      g_current_symbol_table->alloc_shared(num_bits / 8 + addr_pad);
       break;
-   case local_space:
-      if( g_func_info == NULL ) {
-          printf("GPGPU-Sim PTX: allocating local region for \"%s\" ", identifier);
-         fflush(stdout);
-         assert( (num_bits%8) == 0  );
-         addr = g_current_symbol_table->get_local_next();
-         addr_pad = pad_address(addr, num_bits/8, 128);
-         printf("from 0x%llx to 0x%llx (local memory space)\n",
-                 addr+addr_pad,
-                 addr+addr_pad + num_bits/8);
-         fflush(stdout);
-         g_last_symbol->set_address( addr+addr_pad);
-         g_current_symbol_table->alloc_local( num_bits/8 + addr_pad);
+    case sstarr_space:
+      printf("GPGPU-Sim PTX: allocating sstarr region for \"%s\" ", identifier);
+      fflush(stdout);
+      assert((num_bits % 8) == 0);
+      addr = g_current_symbol_table->get_sstarr_next();
+      addr_pad = pad_address(addr, num_bits / 8, 128);
+      printf("from 0x%llx to 0x%llx (sstarr memory space)\n", addr + addr_pad,
+             addr + addr_pad + num_bits / 8);
+      fflush(stdout);
+      g_last_symbol->set_address(addr + addr_pad);
+      g_current_symbol_table->alloc_sstarr(num_bits / 8 + addr_pad);
+      break;
+    case const_space:
+      if (array_ident == ARRAY_IDENTIFIER_NO_DIM) {
+        printf(
+            "GPGPU-Sim PTX: deferring allocation of constant region for \"%s\" "
+            "(need size information)\n",
+            identifier);
       } else {
-        printf("GPGPU-Sim PTX: allocating stack frame region for .local \"%s\" ",
+        printf("GPGPU-Sim PTX: allocating constant region for \"%s\" ",
                identifier);
         fflush(stdout);
-        assert( (num_bits%8) == 0 );
-        addr = g_current_symbol_table->get_local_next();
-        addr_pad = pad_address(addr, num_bits/8, 128);
-        printf("from 0x%llx to 0x%llx\n",
-                addr+addr_pad,
-                addr+addr_pad + num_bits/8);
+        assert((num_bits % 8) == 0);
+        addr = g_current_symbol_table->get_global_next();
+        addr_pad = pad_address(addr, num_bits / 8, 128);
+        printf("from 0x%llx to 0x%llx (global memory space) %u\n",
+               addr + addr_pad, addr + addr_pad + num_bits / 8,
+               g_const_alloc++);
         fflush(stdout);
-        g_last_symbol->set_address( addr+addr_pad );
-        g_current_symbol_table->alloc_local( num_bits/8 + addr_pad);
-        g_func_info->set_framesize( g_current_symbol_table->get_local_next() );
+        g_last_symbol->set_address(addr + addr_pad);
+        g_current_symbol_table->alloc_global(num_bits / 8 + addr_pad);
+      }
+      if (g_current_symbol_table == g_global_symbol_table) {
+        gpgpu_ctx->func_sim->g_constants.insert(identifier);
+      }
+      assert(g_current_symbol_table != NULL);
+      g_sym_name_to_symbol_table[identifier] = g_current_symbol_table;
+      break;
+    case global_space:
+      printf("GPGPU-Sim PTX: allocating global region for \"%s\" ", identifier);
+      fflush(stdout);
+      assert((num_bits % 8) == 0);
+      addr = g_current_symbol_table->get_global_next();
+      addr_pad = pad_address(addr, num_bits / 8, 128);
+      printf("from 0x%llx to 0x%llx (global memory space)\n", addr + addr_pad,
+             addr + addr_pad + num_bits / 8);
+      fflush(stdout);
+      g_last_symbol->set_address(addr + addr_pad);
+      g_current_symbol_table->alloc_global(num_bits / 8 + addr_pad);
+      gpgpu_ctx->func_sim->g_globals.insert(identifier);
+      assert(g_current_symbol_table != NULL);
+      g_sym_name_to_symbol_table[identifier] = g_current_symbol_table;
+      break;
+    case local_space:
+      if (g_func_info == NULL) {
+        printf("GPGPU-Sim PTX: allocating local region for \"%s\" ",
+               identifier);
+        fflush(stdout);
+        assert((num_bits % 8) == 0);
+        addr = g_current_symbol_table->get_local_next();
+        addr_pad = pad_address(addr, num_bits / 8, 128);
+        printf("from 0x%llx to 0x%llx (local memory space)\n", addr + addr_pad,
+               addr + addr_pad + num_bits / 8);
+        fflush(stdout);
+        g_last_symbol->set_address(addr + addr_pad);
+        g_current_symbol_table->alloc_local(num_bits / 8 + addr_pad);
+      } else {
+        printf(
+            "GPGPU-Sim PTX: allocating stack frame region for .local \"%s\" ",
+            identifier);
+        fflush(stdout);
+        assert((num_bits % 8) == 0);
+        addr = g_current_symbol_table->get_local_next();
+        addr_pad = pad_address(addr, num_bits / 8, 128);
+        printf("from 0x%llx to 0x%llx\n", addr + addr_pad,
+               addr + addr_pad + num_bits / 8);
+        fflush(stdout);
+        g_last_symbol->set_address(addr + addr_pad);
+        g_current_symbol_table->alloc_local(num_bits / 8 + addr_pad);
+        g_func_info->set_framesize(g_current_symbol_table->get_local_next());
       }
       break;
-   case tex_space:
+    case tex_space:
       printf("GPGPU-Sim PTX: encountered texture directive %s.\n", identifier);
       break;
-   case param_space_local:
-      printf("GPGPU-Sim PTX: allocating stack frame region for .param \"%s\" from 0x%x to 0x%lx\n",
-             identifier,
-             g_current_symbol_table->get_local_next(),
-             g_current_symbol_table->get_local_next() + num_bits/8 );
+    case param_space_local:
+      printf(
+          "GPGPU-Sim PTX: allocating stack frame region for .param \"%s\" from "
+          "0x%x to 0x%lx\n",
+          identifier, g_current_symbol_table->get_local_next(),
+          g_current_symbol_table->get_local_next() + num_bits / 8);
       fflush(stdout);
-      assert( (num_bits%8) == 0  );
-      g_last_symbol->set_address( g_current_symbol_table->get_local_next() );
-      g_current_symbol_table->alloc_local( num_bits/8 );
-      g_func_info->set_framesize( g_current_symbol_table->get_local_next() );
+      assert((num_bits % 8) == 0);
+      g_last_symbol->set_address(g_current_symbol_table->get_local_next());
+      g_current_symbol_table->alloc_local(num_bits / 8);
+      g_func_info->set_framesize(g_current_symbol_table->get_local_next());
       break;
-   case param_space_kernel:
+    case param_space_kernel:
       break;
-   default:
+    default:
       abort();
       break;
-   }
+  }
 
-   assert( !ti.is_param_unclassified() );
-   if ( ti.is_param_kernel() ) {
-      bool is_ptr = (g_ptr_spec != undefined_space); 
-      g_func_info->add_param_name_type_size(g_entry_func_param_index,identifier, ti.scalar_type(), num_bits, is_ptr, g_ptr_spec);
-      g_entry_func_param_index++;
-   }
+  assert(!ti.is_param_unclassified());
+  if (ti.is_param_kernel()) {
+    bool is_ptr = (g_ptr_spec != undefined_space);
+    g_func_info->add_param_name_type_size(g_entry_func_param_index, identifier,
+                                          ti.scalar_type(), num_bits, is_ptr,
+                                          g_ptr_spec);
+    g_entry_func_param_index++;
+  }
 }
 
-void ptx_recognizer::add_constptr(const char* identifier1, const char* identifier2, int offset)
-{
-   symbol *s1 = g_current_symbol_table->lookup(identifier1);
-   const symbol *s2 = g_current_symbol_table->lookup(identifier2);
-   parse_assert( s1 != NULL, "'from' constant identifier does not exist.");
-   parse_assert( s1 != NULL, "'to' constant identifier does not exist.");
+void ptx_recognizer::add_constptr(const char *identifier1,
+                                  const char *identifier2, int offset) {
+  symbol *s1 = g_current_symbol_table->lookup(identifier1);
+  const symbol *s2 = g_current_symbol_table->lookup(identifier2);
+  parse_assert(s1 != NULL, "'from' constant identifier does not exist.");
+  parse_assert(s1 != NULL, "'to' constant identifier does not exist.");
 
-   unsigned addr = s2->get_address();
+  unsigned addr = s2->get_address();
 
-   printf("GPGPU-Sim PTX: moving \"%s\" from 0x%x to 0x%x (%s+%x)\n",
-      identifier1, s1->get_address(), addr+offset, identifier2, offset);
+  printf("GPGPU-Sim PTX: moving \"%s\" from 0x%x to 0x%x (%s+%x)\n",
+         identifier1, s1->get_address(), addr + offset, identifier2, offset);
 
-   s1->set_address( addr + offset );
+  s1->set_address(addr + offset);
 }
 
-void ptx_recognizer::add_function_arg()
-{
-   assert(g_size>0);
-   if( g_func_info ) {
-      PTX_PARSE_DPRINTF("add_function_arg \"%s\"", g_last_symbol->name().c_str() );
-      g_func_info->add_arg(g_last_symbol);
-      unsigned alignment = (g_alignment_spec==-1) ? g_size : g_alignment_spec;
-      assert(alignment==1||alignment==2||alignment==4||alignment==8||alignment==16);//known valid alignment values
-      g_func_info->add_config_param( g_size,  alignment);
-   }
-
+void ptx_recognizer::add_function_arg() {
+  assert(g_size > 0);
+  if (g_func_info) {
+    PTX_PARSE_DPRINTF("add_function_arg \"%s\"", g_last_symbol->name().c_str());
+    g_func_info->add_arg(g_last_symbol);
+    unsigned alignment = (g_alignment_spec == -1) ? g_size : g_alignment_spec;
+    assert(alignment == 1 || alignment == 2 || alignment == 4 ||
+           alignment == 8 || alignment == 16);  // known valid alignment values
+    g_func_info->add_config_param(g_size, alignment);
+  }
 }
 
-void ptx_recognizer::add_extern_spec()
-{
-   PTX_PARSE_DPRINTF("add_extern_spec");
-   g_extern_spec = 1;
+void ptx_recognizer::add_extern_spec() {
+  PTX_PARSE_DPRINTF("add_extern_spec");
+  g_extern_spec = 1;
 }
 
-void ptx_recognizer::add_alignment_spec( int spec )
-{
-   PTX_PARSE_DPRINTF("add_alignment_spec");
-   parse_assert( g_alignment_spec == -1, "multiple .align specifiers per variable declaration not allowed." );
-   g_alignment_spec = spec;
+void ptx_recognizer::add_alignment_spec(int spec) {
+  PTX_PARSE_DPRINTF("add_alignment_spec");
+  parse_assert(
+      g_alignment_spec == -1,
+      "multiple .align specifiers per variable declaration not allowed.");
+  g_alignment_spec = spec;
 }
 
-void ptx_recognizer::add_ptr_spec( enum _memory_space_t spec )
-{
-   PTX_PARSE_DPRINTF("add_ptr_spec \"%s\"", g_ptx_token_decode[spec].c_str() );
-   parse_assert( g_ptr_spec == undefined_space, "multiple ptr space specifiers not allowed." );
-   parse_assert( spec == global_space or spec == local_space or spec == shared_space, "invalid space for ptr directive." );
-   g_ptr_spec = spec; 
+void ptx_recognizer::add_ptr_spec(enum _memory_space_t spec) {
+  PTX_PARSE_DPRINTF("add_ptr_spec \"%s\"", g_ptx_token_decode[spec].c_str());
+  parse_assert(g_ptr_spec == undefined_space,
+               "multiple ptr space specifiers not allowed.");
+  parse_assert(
+      spec == global_space or spec == local_space or spec == shared_space,
+      "invalid space for ptr directive.");
+  g_ptr_spec = spec;
 }
 
-void ptx_recognizer::add_space_spec( enum _memory_space_t spec, int value )
-{
-   PTX_PARSE_DPRINTF("add_space_spec \"%s\"", g_ptx_token_decode[spec].c_str() );
-   parse_assert( g_space_spec == undefined_space, "multiple space specifiers not allowed." );
-   if( spec == param_space_unclassified ) {
-      if( g_func_decl ) {
-         if( g_entry_point == 1) 
-            g_space_spec = param_space_kernel;
-         else 
-            g_space_spec = param_space_local;
-      } else
-         g_space_spec = param_space_unclassified;
-   } else {
-      g_space_spec = spec;
-      if( g_space_spec == const_space )
-         g_space_spec.set_bank((unsigned)value);
-   }
+void ptx_recognizer::add_space_spec(enum _memory_space_t spec, int value) {
+  PTX_PARSE_DPRINTF("add_space_spec \"%s\"", g_ptx_token_decode[spec].c_str());
+  parse_assert(g_space_spec == undefined_space,
+               "multiple space specifiers not allowed.");
+  if (spec == param_space_unclassified) {
+    if (g_func_decl) {
+      if (g_entry_point == 1)
+        g_space_spec = param_space_kernel;
+      else
+        g_space_spec = param_space_local;
+    } else
+      g_space_spec = param_space_unclassified;
+  } else {
+    g_space_spec = spec;
+    if (g_space_spec == const_space) g_space_spec.set_bank((unsigned)value);
+  }
 }
 
-void ptx_recognizer::add_vector_spec(int spec )
-{
-   PTX_PARSE_DPRINTF("add_vector_spec");
-   parse_assert( g_vector_spec == -1, "multiple vector specifiers not allowed." );
-   g_vector_spec = spec;
+void ptx_recognizer::add_vector_spec(int spec) {
+  PTX_PARSE_DPRINTF("add_vector_spec");
+  parse_assert(g_vector_spec == -1, "multiple vector specifiers not allowed.");
+  g_vector_spec = spec;
 }
 
-void ptx_recognizer::add_scalar_type_spec( int type_spec )
-{
-   //save size of parameter
-   switch ( type_spec ) {
-      case B8_TYPE:
-      case S8_TYPE:
-      case U8_TYPE: 
-         g_size = 1; break;
-      case B16_TYPE:
-      case S16_TYPE:
-      case U16_TYPE:
-      case F16_TYPE: 
-         g_size = 2; break;
-      case B32_TYPE:
-      case S32_TYPE:
-      case U32_TYPE:
-      case F32_TYPE: 
-         g_size = 4; break;
-      case B64_TYPE:
-      case BB64_TYPE:
-      case S64_TYPE:
-      case U64_TYPE:
-      case F64_TYPE: 
-      case FF64_TYPE:
-         g_size = 8; break;
-      case BB128_TYPE: 
-         g_size = 16; break;
-   }
-   PTX_PARSE_DPRINTF("add_scalar_type_spec \"%s\"", g_ptx_token_decode[type_spec].c_str());
-   g_scalar_type.push_back( type_spec );
-   if ( g_scalar_type.size() > 1 ) {
-      parse_assert( (g_opcode == -1) || (g_opcode == CVT_OP) || (g_opcode == SET_OP) || (g_opcode == SLCT_OP)
-                    || (g_opcode == TEX_OP)|| (g_opcode==MMA_OP)|| (g_opcode == DP4A_OP),
-                    "only cvt, set, slct, tex and dp4a can have more than one type specifier.");
-   }
-   g_scalar_type_spec = type_spec;
+void ptx_recognizer::add_scalar_type_spec(int type_spec) {
+  // save size of parameter
+  switch (type_spec) {
+    case B8_TYPE:
+    case S8_TYPE:
+    case U8_TYPE:
+      g_size = 1;
+      break;
+    case B16_TYPE:
+    case S16_TYPE:
+    case U16_TYPE:
+    case F16_TYPE:
+      g_size = 2;
+      break;
+    case B32_TYPE:
+    case S32_TYPE:
+    case U32_TYPE:
+    case F32_TYPE:
+      g_size = 4;
+      break;
+    case B64_TYPE:
+    case BB64_TYPE:
+    case S64_TYPE:
+    case U64_TYPE:
+    case F64_TYPE:
+    case FF64_TYPE:
+      g_size = 8;
+      break;
+    case BB128_TYPE:
+      g_size = 16;
+      break;
+  }
+  PTX_PARSE_DPRINTF("add_scalar_type_spec \"%s\"",
+                    g_ptx_token_decode[type_spec].c_str());
+  g_scalar_type.push_back(type_spec);
+  if (g_scalar_type.size() > 1) {
+    parse_assert((g_opcode == -1) || (g_opcode == CVT_OP) ||
+                     (g_opcode == SET_OP) || (g_opcode == SLCT_OP) ||
+                     (g_opcode == TEX_OP) || (g_opcode == MMA_OP) ||
+                     (g_opcode == DP4A_OP),
+                 "only cvt, set, slct, tex and dp4a can have more than one "
+                 "type specifier.");
+  }
+  g_scalar_type_spec = type_spec;
 }
 
-void ptx_recognizer::add_label( const char *identifier )
-{
-   PTX_PARSE_DPRINTF("add_label");
-   symbol *s = g_current_symbol_table->lookup(identifier);
-   if ( s != NULL ) {
-      g_label = s;
-   } else {
-      g_label = g_current_symbol_table->add_variable(identifier,NULL,0,gpgpu_ctx->g_filename,ptx_get_lineno(scanner));
-   }
+void ptx_recognizer::add_label(const char *identifier) {
+  PTX_PARSE_DPRINTF("add_label");
+  symbol *s = g_current_symbol_table->lookup(identifier);
+  if (s != NULL) {
+    g_label = s;
+  } else {
+    g_label = g_current_symbol_table->add_variable(
+        identifier, NULL, 0, gpgpu_ctx->g_filename, ptx_get_lineno(scanner));
+  }
 }
 
-void ptx_recognizer::add_opcode( int opcode )
-{
-   g_opcode = opcode;
+void ptx_recognizer::add_opcode(int opcode) { g_opcode = opcode; }
+
+void ptx_recognizer::add_pred(const char *identifier, int neg,
+                              int predModifier) {
+  PTX_PARSE_DPRINTF("add_pred");
+  const symbol *s = g_current_symbol_table->lookup(identifier);
+  if (s == NULL) {
+    std::string msg =
+        std::string("predicate \"") + identifier + "\" has no declaration.";
+    parse_error(msg.c_str());
+  }
+  g_pred = s;
+  g_neg_pred = neg;
+  g_pred_mod = predModifier;
 }
 
-void ptx_recognizer::add_pred( const char *identifier, int neg, int predModifier )
-{
-   PTX_PARSE_DPRINTF("add_pred");
-   const symbol *s = g_current_symbol_table->lookup(identifier);
-   if ( s == NULL ) {
-      std::string msg = std::string("predicate \"") + identifier + "\" has no declaration.";
-      parse_error( msg.c_str() );
-   }
-   g_pred = s;
-   g_neg_pred = neg;
-   g_pred_mod = predModifier;
+void ptx_recognizer::add_option(int option) {
+  PTX_PARSE_DPRINTF("add_option");
+  g_options.push_back(option);
+}
+void ptx_recognizer::add_wmma_option(int option) {
+  PTX_PARSE_DPRINTF("add_option");
+  g_wmma_options.push_back(option);
+}
+void ptx_recognizer::add_double_operand(const char *d1, const char *d2) {
+  // operands that access two variables.
+  // eg. s[$ofs1+$r0], g[$ofs1+=$r0]
+  // TODO: Not sure if I'm going to use this for storing to two destinations or
+  // not.
+
+  PTX_PARSE_DPRINTF("add_double_operand");
+  const symbol *s1 = g_current_symbol_table->lookup(d1);
+  const symbol *s2 = g_current_symbol_table->lookup(d2);
+  parse_assert(s1 != NULL && s2 != NULL, "component(s) missing declarations.");
+  g_operands.push_back(operand_info(s1, s2, gpgpu_ctx));
 }
 
-void ptx_recognizer::add_option( int option )
-{
-   PTX_PARSE_DPRINTF("add_option");
-   g_options.push_back( option );
-}
-void ptx_recognizer::add_wmma_option( int option )
-{
-   PTX_PARSE_DPRINTF("add_option");
-   g_wmma_options.push_back( option );
-}
-void ptx_recognizer::add_double_operand( const char *d1, const char *d2 )
-{
-   //operands that access two variables.
-   //eg. s[$ofs1+$r0], g[$ofs1+=$r0]
-   //TODO: Not sure if I'm going to use this for storing to two destinations or not.
-
-   PTX_PARSE_DPRINTF("add_double_operand");
-   const symbol *s1 = g_current_symbol_table->lookup(d1);
-   const symbol *s2 = g_current_symbol_table->lookup(d2);
-   parse_assert( s1 != NULL && s2 != NULL, "component(s) missing declarations.");
-   g_operands.push_back( operand_info(s1,s2,gpgpu_ctx) );
+void ptx_recognizer::add_1vector_operand(const char *d1) {
+  // handles the single element vector operand ({%v1}) found in tex.1d
+  // instructions
+  PTX_PARSE_DPRINTF("add_1vector_operand");
+  const symbol *s1 = g_current_symbol_table->lookup(d1);
+  parse_assert(s1 != NULL, "component(s) missing declarations.");
+  g_operands.push_back(operand_info(s1, NULL, NULL, NULL, gpgpu_ctx));
 }
 
-void ptx_recognizer::add_1vector_operand( const char *d1 )
-{
-   // handles the single element vector operand ({%v1}) found in tex.1d instructions
-   PTX_PARSE_DPRINTF("add_1vector_operand");
-   const symbol *s1 = g_current_symbol_table->lookup(d1);
-   parse_assert( s1 != NULL, "component(s) missing declarations.");
-   g_operands.push_back( operand_info(s1,NULL,NULL,NULL,gpgpu_ctx) );
+void ptx_recognizer::add_2vector_operand(const char *d1, const char *d2) {
+  PTX_PARSE_DPRINTF("add_2vector_operand");
+  const symbol *s1 = g_current_symbol_table->lookup(d1);
+  const symbol *s2 = g_current_symbol_table->lookup(d2);
+  parse_assert(s1 != NULL && s2 != NULL,
+               "v2 component(s) missing declarations.");
+  g_operands.push_back(operand_info(s1, s2, NULL, NULL, gpgpu_ctx));
 }
 
-void ptx_recognizer::add_2vector_operand( const char *d1, const char *d2 )
-{
-   PTX_PARSE_DPRINTF("add_2vector_operand");
-   const symbol *s1 = g_current_symbol_table->lookup(d1);
-   const symbol *s2 = g_current_symbol_table->lookup(d2);
-   parse_assert( s1 != NULL && s2 != NULL, "v2 component(s) missing declarations.");
-   g_operands.push_back( operand_info(s1,s2,NULL,NULL,gpgpu_ctx) );
+void ptx_recognizer::add_3vector_operand(const char *d1, const char *d2,
+                                         const char *d3) {
+  PTX_PARSE_DPRINTF("add_3vector_operand");
+  const symbol *s1 = g_current_symbol_table->lookup(d1);
+  const symbol *s2 = g_current_symbol_table->lookup(d2);
+  const symbol *s3 = g_current_symbol_table->lookup(d3);
+  parse_assert(s1 != NULL && s2 != NULL && s3 != NULL,
+               "v3 component(s) missing declarations.");
+  g_operands.push_back(operand_info(s1, s2, s3, NULL, gpgpu_ctx));
 }
 
-void ptx_recognizer::add_3vector_operand( const char *d1, const char *d2, const char *d3 )
-{
-   PTX_PARSE_DPRINTF("add_3vector_operand");
-   const symbol *s1 = g_current_symbol_table->lookup(d1);
-   const symbol *s2 = g_current_symbol_table->lookup(d2);
-   const symbol *s3 = g_current_symbol_table->lookup(d3);
-   parse_assert( s1 != NULL && s2 != NULL && s3 != NULL, "v3 component(s) missing declarations.");
-   g_operands.push_back( operand_info(s1,s2,s3,NULL,gpgpu_ctx) );
+void ptx_recognizer::add_4vector_operand(const char *d1, const char *d2,
+                                         const char *d3, const char *d4) {
+  PTX_PARSE_DPRINTF("add_4vector_operand");
+  const symbol *s1 = g_current_symbol_table->lookup(d1);
+  const symbol *s2 = g_current_symbol_table->lookup(d2);
+  const symbol *s3 = g_current_symbol_table->lookup(d3);
+  const symbol *s4 = g_current_symbol_table->lookup(d4);
+  parse_assert(s1 != NULL && s2 != NULL && s3 != NULL && s4 != NULL,
+               "v4 component(s) missing declarations.");
+  const symbol *null_op = g_current_symbol_table->lookup("_");
+  if (s2 == null_op) s2 = NULL;
+  if (s3 == null_op) s3 = NULL;
+  if (s4 == null_op) s4 = NULL;
+  g_operands.push_back(operand_info(s1, s2, s3, s4, gpgpu_ctx));
+}
+void ptx_recognizer::add_8vector_operand(const char *d1, const char *d2,
+                                         const char *d3, const char *d4,
+                                         const char *d5, const char *d6,
+                                         const char *d7, const char *d8) {
+  PTX_PARSE_DPRINTF("add_8vector_operand");
+  const symbol *s1 = g_current_symbol_table->lookup(d1);
+  const symbol *s2 = g_current_symbol_table->lookup(d2);
+  const symbol *s3 = g_current_symbol_table->lookup(d3);
+  const symbol *s4 = g_current_symbol_table->lookup(d4);
+  const symbol *s5 = g_current_symbol_table->lookup(d5);
+  const symbol *s6 = g_current_symbol_table->lookup(d6);
+  const symbol *s7 = g_current_symbol_table->lookup(d7);
+  const symbol *s8 = g_current_symbol_table->lookup(d8);
+  parse_assert(s1 != NULL && s2 != NULL && s3 != NULL && s4 != NULL &&
+                   s5 != NULL && s6 != NULL && s7 != NULL && s8 != NULL,
+               "v4 component(s) missing declarations.");
+  const symbol *null_op = g_current_symbol_table->lookup("_");
+  if (s2 == null_op) s2 = NULL;
+  if (s3 == null_op) s3 = NULL;
+  if (s4 == null_op) s4 = NULL;
+  if (s5 == null_op) s5 = NULL;
+  if (s6 == null_op) s6 = NULL;
+  if (s7 == null_op) s7 = NULL;
+  if (s8 == null_op) s8 = NULL;
+  g_operands.push_back(operand_info(s1, s2, s3, s4, s5, s6, s7, s8, gpgpu_ctx));
 }
 
-void ptx_recognizer::add_4vector_operand( const char *d1, const char *d2, const char *d3, const char *d4 )
-{
-   PTX_PARSE_DPRINTF("add_4vector_operand");
-   const symbol *s1 = g_current_symbol_table->lookup(d1);
-   const symbol *s2 = g_current_symbol_table->lookup(d2);
-   const symbol *s3 = g_current_symbol_table->lookup(d3);
-   const symbol *s4 = g_current_symbol_table->lookup(d4);
-   parse_assert( s1 != NULL && s2 != NULL && s3 != NULL && s4 != NULL, "v4 component(s) missing declarations.");
-   const symbol *null_op = g_current_symbol_table->lookup("_");
-   if ( s2 == null_op ) s2 = NULL;
-   if ( s3 == null_op ) s3 = NULL;
-   if ( s4 == null_op ) s4 = NULL;
-   g_operands.push_back( operand_info(s1,s2,s3,s4,gpgpu_ctx) );
-}
-void ptx_recognizer::add_8vector_operand( const char *d1, const char *d2, const char *d3, const char *d4,const char *d5,const char *d6,const char *d7,const char *d8 )
-{
-   PTX_PARSE_DPRINTF("add_8vector_operand");
-   const symbol *s1 = g_current_symbol_table->lookup(d1);
-   const symbol *s2 = g_current_symbol_table->lookup(d2);
-   const symbol *s3 = g_current_symbol_table->lookup(d3);
-   const symbol *s4 = g_current_symbol_table->lookup(d4);
-   const symbol *s5 = g_current_symbol_table->lookup(d5);
-   const symbol *s6 = g_current_symbol_table->lookup(d6);
-   const symbol *s7 = g_current_symbol_table->lookup(d7);
-   const symbol *s8 = g_current_symbol_table->lookup(d8);
-   parse_assert( s1 != NULL && s2 != NULL && s3 != NULL && s4 != NULL && s5 !=NULL && s6 !=NULL && s7 !=NULL && s8 !=NULL, "v4 component(s) missing declarations.");
-   const symbol *null_op = g_current_symbol_table->lookup("_");
-   if ( s2 == null_op ) s2 = NULL;
-   if ( s3 == null_op ) s3 = NULL;
-   if ( s4 == null_op ) s4 = NULL;
-   if ( s5 == null_op ) s5 = NULL;
-   if ( s6 == null_op ) s6 = NULL;
-   if ( s7 == null_op ) s7 = NULL;
-   if ( s8 == null_op ) s8 = NULL;
-   g_operands.push_back( operand_info(s1,s2,s3,s4,s5,s6,s7,s8,gpgpu_ctx) );
+void ptx_recognizer::add_builtin_operand(int builtin, int dim_modifier) {
+  PTX_PARSE_DPRINTF("add_builtin_operand");
+  g_operands.push_back(operand_info(builtin, dim_modifier, gpgpu_ctx));
 }
 
-void ptx_recognizer::add_builtin_operand( int builtin, int dim_modifier )
-{
-   PTX_PARSE_DPRINTF("add_builtin_operand");
-   g_operands.push_back( operand_info(builtin,dim_modifier,gpgpu_ctx) );
-}
-
-void ptx_recognizer::add_memory_operand()
-{
-   PTX_PARSE_DPRINTF("add_memory_operand");
-   assert( !g_operands.empty() );
-   g_operands.back().make_memory_operand();
+void ptx_recognizer::add_memory_operand() {
+  PTX_PARSE_DPRINTF("add_memory_operand");
+  assert(!g_operands.empty());
+  g_operands.back().make_memory_operand();
 }
 
 /*TODO: add other memory locations*/
-void ptx_recognizer::change_memory_addr_space(const char *identifier)
-{
-   /*0 = N/A, not reading from memory
-    *1 = global memory
-    *2 = shared memory
-    *3 = const memory segment
-    *4 = local memory segment
-    */
+void ptx_recognizer::change_memory_addr_space(const char *identifier) {
+  /*0 = N/A, not reading from memory
+   *1 = global memory
+   *2 = shared memory
+   *3 = const memory segment
+   *4 = local memory segment
+   */
 
-   bool recognizedType = false;
+  bool recognizedType = false;
 
-   PTX_PARSE_DPRINTF("change_memory_addr_space");
-   assert( !g_operands.empty() );
-   if(!strcmp(identifier, "g"))
-   {
-       g_operands.back().set_addr_space(global_space);
-       recognizedType = true;
-   }
-   if(!strcmp(identifier, "s"))
-   {
-       g_operands.back().set_addr_space(shared_space);
-       recognizedType = true;
-   }
-   // For constants, check if the first character is 'c'
-   char c[2];
-   strncpy(c, identifier, 1); c[1] = '\0';
-   if(!strcmp(c, "c"))
-   {
-       g_operands.back().set_addr_space(const_space);
-       parse_assert(g_current_symbol_table->lookup(identifier) != NULL, "Constant was not defined.");
-       g_operands.back().set_const_mem_offset(g_current_symbol_table->lookup(identifier)->get_address());
-       recognizedType = true;
-   }
-   // For local memory, check if the first character is 'l'
-   char l[2];
-   strncpy(l, identifier, 1); l[1] = '\0';
-   if(!strcmp(l, "l"))
-   {
-       g_operands.back().set_addr_space(local_space);
-       //parse_assert(g_current_symbol_table->lookup(identifier) != NULL, "Local memory segment was not defined.");
-       //g_operands.back().set_const_mem_offset(g_current_symbol_table->lookup(identifier)->get_address());
-       recognizedType = true;
-   }
+  PTX_PARSE_DPRINTF("change_memory_addr_space");
+  assert(!g_operands.empty());
+  if (!strcmp(identifier, "g")) {
+    g_operands.back().set_addr_space(global_space);
+    recognizedType = true;
+  }
+  if (!strcmp(identifier, "s")) {
+    g_operands.back().set_addr_space(shared_space);
+    recognizedType = true;
+  }
+  // For constants, check if the first character is 'c'
+  char c[2];
+  strncpy(c, identifier, 1);
+  c[1] = '\0';
+  if (!strcmp(c, "c")) {
+    g_operands.back().set_addr_space(const_space);
+    parse_assert(g_current_symbol_table->lookup(identifier) != NULL,
+                 "Constant was not defined.");
+    g_operands.back().set_const_mem_offset(
+        g_current_symbol_table->lookup(identifier)->get_address());
+    recognizedType = true;
+  }
+  // For local memory, check if the first character is 'l'
+  char l[2];
+  strncpy(l, identifier, 1);
+  l[1] = '\0';
+  if (!strcmp(l, "l")) {
+    g_operands.back().set_addr_space(local_space);
+    // parse_assert(g_current_symbol_table->lookup(identifier) != NULL, "Local
+    // memory segment was not defined.");
+    // g_operands.back().set_const_mem_offset(g_current_symbol_table->lookup(identifier)->get_address());
+    recognizedType = true;
+  }
 
-   parse_assert(recognizedType, "Error: unrecognized memory type.");
+  parse_assert(recognizedType, "Error: unrecognized memory type.");
 }
 
-void ptx_recognizer::change_operand_lohi( int lohi )
-{
-   /*0 = N/A, read entire operand
-    *1 = lo, reading from lowest bits
-    *2 = hi, reading from highest bits
-    */
+void ptx_recognizer::change_operand_lohi(int lohi) {
+  /*0 = N/A, read entire operand
+   *1 = lo, reading from lowest bits
+   *2 = hi, reading from highest bits
+   */
 
-   PTX_PARSE_DPRINTF("change_operand_lohi");
-   assert( !g_operands.empty() );
+  PTX_PARSE_DPRINTF("change_operand_lohi");
+  assert(!g_operands.empty());
 
-   g_operands.back().set_operand_lohi(lohi);
-
+  g_operands.back().set_operand_lohi(lohi);
 }
 
-void ptx_recognizer::set_immediate_operand_type ()
-{
-     PTX_PARSE_DPRINTF("set_immediate_operand_type");
-     assert( !g_operands.empty() );
-     g_operands.back().set_immediate_addr();
+void ptx_recognizer::set_immediate_operand_type() {
+  PTX_PARSE_DPRINTF("set_immediate_operand_type");
+  assert(!g_operands.empty());
+  g_operands.back().set_immediate_addr();
 }
 
-void ptx_recognizer::change_double_operand_type( int operand_type )
-{
-   /*
-    *-3 = reg / reg (set instruction, but both get same value)
-    *-2 = reg | reg (cvt instruction)
-    *-1 = reg | reg (set instruction)
-    *0 = N/A, default
-    *1 = reg + reg
-    *2 = reg += reg
-    *3 = reg += immediate
-    */
+void ptx_recognizer::change_double_operand_type(int operand_type) {
+  /*
+   *-3 = reg / reg (set instruction, but both get same value)
+   *-2 = reg | reg (cvt instruction)
+   *-1 = reg | reg (set instruction)
+   *0 = N/A, default
+   *1 = reg + reg
+   *2 = reg += reg
+   *3 = reg += immediate
+   */
 
-   PTX_PARSE_DPRINTF("change_double_operand_type");
-   assert( !g_operands.empty() );
+  PTX_PARSE_DPRINTF("change_double_operand_type");
+  assert(!g_operands.empty());
 
-   // For double destination operands, ensure valid instruction
-   if( operand_type == -1 || operand_type == -2 ) {
-      if((g_opcode == SET_OP)||(g_opcode == SETP_OP))
-         g_operands.back().set_double_operand_type(-1);
-      else
-         g_operands.back().set_double_operand_type(-2);
-   } else if( operand_type == -3 ) {
-      if(g_opcode == SET_OP || g_opcode == MAD_OP)
-         g_operands.back().set_double_operand_type(operand_type);
-      else
-         parse_assert(0, "Error: Unsupported use of double destination operand.");
-   } else {
+  // For double destination operands, ensure valid instruction
+  if (operand_type == -1 || operand_type == -2) {
+    if ((g_opcode == SET_OP) || (g_opcode == SETP_OP))
+      g_operands.back().set_double_operand_type(-1);
+    else
+      g_operands.back().set_double_operand_type(-2);
+  } else if (operand_type == -3) {
+    if (g_opcode == SET_OP || g_opcode == MAD_OP)
       g_operands.back().set_double_operand_type(operand_type);
-   }
-
+    else
+      parse_assert(0, "Error: Unsupported use of double destination operand.");
+  } else {
+    g_operands.back().set_double_operand_type(operand_type);
+  }
 }
 
-void ptx_recognizer::change_operand_neg( )
-{
-   PTX_PARSE_DPRINTF("change_operand_neg");
-   assert( !g_operands.empty() );
+void ptx_recognizer::change_operand_neg() {
+  PTX_PARSE_DPRINTF("change_operand_neg");
+  assert(!g_operands.empty());
 
-   g_operands.back().set_operand_neg();
-
+  g_operands.back().set_operand_neg();
 }
 
-void ptx_recognizer::add_literal_int( int value )
-{
-   PTX_PARSE_DPRINTF("add_literal_int");
-   g_operands.push_back( operand_info(value,gpgpu_ctx) );
+void ptx_recognizer::add_literal_int(int value) {
+  PTX_PARSE_DPRINTF("add_literal_int");
+  g_operands.push_back(operand_info(value, gpgpu_ctx));
 }
 
-void ptx_recognizer::add_literal_float( float value )
-{
-   PTX_PARSE_DPRINTF("add_literal_float");
-   g_operands.push_back( operand_info(value,gpgpu_ctx) );
+void ptx_recognizer::add_literal_float(float value) {
+  PTX_PARSE_DPRINTF("add_literal_float");
+  g_operands.push_back(operand_info(value, gpgpu_ctx));
 }
 
-void ptx_recognizer::add_literal_double( double value )
-{
-   PTX_PARSE_DPRINTF("add_literal_double");
-   g_operands.push_back( operand_info(value,gpgpu_ctx) );
+void ptx_recognizer::add_literal_double(double value) {
+  PTX_PARSE_DPRINTF("add_literal_double");
+  g_operands.push_back(operand_info(value, gpgpu_ctx));
 }
 
-void ptx_recognizer::add_scalar_operand( const char *identifier )
-{
-   PTX_PARSE_DPRINTF("add_scalar_operand");
-   const symbol *s = g_current_symbol_table->lookup(identifier);
-   if ( s == NULL ) {
-      if ( g_opcode == BRA_OP || g_opcode == CALLP_OP) {
-         // forward branch target...
-         s = g_current_symbol_table->add_variable(identifier,NULL,0,gpgpu_ctx->g_filename,ptx_get_lineno(scanner));
-      } else {
-         std::string msg = std::string("operand \"") + identifier + "\" has no declaration.";
-         parse_error( msg.c_str() );
-      }
-   }
-   g_operands.push_back( operand_info(s,gpgpu_ctx) );
+void ptx_recognizer::add_scalar_operand(const char *identifier) {
+  PTX_PARSE_DPRINTF("add_scalar_operand");
+  const symbol *s = g_current_symbol_table->lookup(identifier);
+  if (s == NULL) {
+    if (g_opcode == BRA_OP || g_opcode == CALLP_OP) {
+      // forward branch target...
+      s = g_current_symbol_table->add_variable(
+          identifier, NULL, 0, gpgpu_ctx->g_filename, ptx_get_lineno(scanner));
+    } else {
+      std::string msg =
+          std::string("operand \"") + identifier + "\" has no declaration.";
+      parse_error(msg.c_str());
+    }
+  }
+  g_operands.push_back(operand_info(s, gpgpu_ctx));
 }
 
-void ptx_recognizer::add_neg_pred_operand( const char *identifier )
-{
-   PTX_PARSE_DPRINTF("add_neg_pred_operand");
-   const symbol *s = g_current_symbol_table->lookup(identifier);
-   if ( s == NULL ) {
-       s = g_current_symbol_table->add_variable(identifier,NULL,1,gpgpu_ctx->g_filename,ptx_get_lineno(scanner));
-   }
-   operand_info op(s, gpgpu_ctx);
-   op.set_neg_pred();
-   g_operands.push_back( op );
+void ptx_recognizer::add_neg_pred_operand(const char *identifier) {
+  PTX_PARSE_DPRINTF("add_neg_pred_operand");
+  const symbol *s = g_current_symbol_table->lookup(identifier);
+  if (s == NULL) {
+    s = g_current_symbol_table->add_variable(
+        identifier, NULL, 1, gpgpu_ctx->g_filename, ptx_get_lineno(scanner));
+  }
+  operand_info op(s, gpgpu_ctx);
+  op.set_neg_pred();
+  g_operands.push_back(op);
 }
 
-void ptx_recognizer::add_address_operand( const char *identifier, int offset )
-{
-   PTX_PARSE_DPRINTF("add_address_operand");
-   const symbol *s = g_current_symbol_table->lookup(identifier);
-   if ( s == NULL ) {
-      std::string msg = std::string("operand \"") + identifier + "\" has no declaration.";
-      parse_error( msg.c_str() );
-   }
-   g_operands.push_back( operand_info(s,offset,gpgpu_ctx) );
+void ptx_recognizer::add_address_operand(const char *identifier, int offset) {
+  PTX_PARSE_DPRINTF("add_address_operand");
+  const symbol *s = g_current_symbol_table->lookup(identifier);
+  if (s == NULL) {
+    std::string msg =
+        std::string("operand \"") + identifier + "\" has no declaration.";
+    parse_error(msg.c_str());
+  }
+  g_operands.push_back(operand_info(s, offset, gpgpu_ctx));
 }
 
-void ptx_recognizer::add_address_operand2( int offset )
-{
-   PTX_PARSE_DPRINTF("add_address_operand");
-   g_operands.push_back( operand_info((unsigned)offset,gpgpu_ctx) );
+void ptx_recognizer::add_address_operand2(int offset) {
+  PTX_PARSE_DPRINTF("add_address_operand");
+  g_operands.push_back(operand_info((unsigned)offset, gpgpu_ctx));
 }
 
-void ptx_recognizer::add_array_initializer()
-{
-   g_last_symbol->add_initializer(g_operands);
+void ptx_recognizer::add_array_initializer() {
+  g_last_symbol->add_initializer(g_operands);
 }
 
-void ptx_recognizer::add_version_info( float ver, unsigned ext )
-{
-   g_global_symbol_table->set_ptx_version(ver,ext);
+void ptx_recognizer::add_version_info(float ver, unsigned ext) {
+  g_global_symbol_table->set_ptx_version(ver, ext);
 }
 
-void ptx_recognizer::add_file( unsigned num, const char *filename )
-{
-   if( gpgpu_ctx->g_filename == NULL ) {
-      char *b = strdup(filename);
-      char *l=b;
-      char *n=b;
-      while( *n != '\0' ) {
-          if( *n == '/' ) 
-              l = n+1;
-          n++;
-      }
+void ptx_recognizer::add_file(unsigned num, const char *filename) {
+  if (gpgpu_ctx->g_filename == NULL) {
+    char *b = strdup(filename);
+    char *l = b;
+    char *n = b;
+    while (*n != '\0') {
+      if (*n == '/') l = n + 1;
+      n++;
+    }
 
-      char *p = strtok(l,".");
-      char buf[1024];
-      snprintf(buf,1024,"%s.ptx",p);
+    char *p = strtok(l, ".");
+    char buf[1024];
+    snprintf(buf, 1024, "%s.ptx", p);
 
-      char *q = strtok(NULL,".");
-      if( q && !strcmp(q,"cu") ) {
-          gpgpu_ctx->g_filename = strdup(buf);
-      }
+    char *q = strtok(NULL, ".");
+    if (q && !strcmp(q, "cu")) {
+      gpgpu_ctx->g_filename = strdup(buf);
+    }
 
-      free( b );
-   }
+    free(b);
+  }
 
-   g_current_symbol_table = g_global_symbol_table;
+  g_current_symbol_table = g_global_symbol_table;
 }
 
-void * ptx_recognizer::reset_symtab()
-{
-   void *result = g_current_symbol_table;
-   g_current_symbol_table = g_global_symbol_table;
-   return result;
+void *ptx_recognizer::reset_symtab() {
+  void *result = g_current_symbol_table;
+  g_current_symbol_table = g_global_symbol_table;
+  return result;
 }
 
-void ptx_recognizer::set_symtab(void*symtab)
-{
-   g_current_symbol_table = (symbol_table*)symtab;
+void ptx_recognizer::set_symtab(void *symtab) {
+  g_current_symbol_table = (symbol_table *)symtab;
 }
 
-void ptx_recognizer::add_pragma( const char *str )
-{
-   printf("GPGPU-Sim PTX: Warning -- ignoring pragma '%s'\n", str );
+void ptx_recognizer::add_pragma(const char *str) {
+  printf("GPGPU-Sim PTX: Warning -- ignoring pragma '%s'\n", str);
 }
 
-void ptx_recognizer::version_header(double a) {}  //intentional dummy function
+void ptx_recognizer::version_header(double a) {}  // intentional dummy function
 
-void ptx_recognizer::target_header(char* a)
-{
-   g_global_symbol_table->set_sm_target(a,NULL,NULL);
+void ptx_recognizer::target_header(char *a) {
+  g_global_symbol_table->set_sm_target(a, NULL, NULL);
 }
 
-void ptx_recognizer::target_header2(char* a, char* b)
-{
-   g_global_symbol_table->set_sm_target(a,b,NULL);
+void ptx_recognizer::target_header2(char *a, char *b) {
+  g_global_symbol_table->set_sm_target(a, b, NULL);
 }
 
-void ptx_recognizer::target_header3(char* a, char* b, char* c)
-{
-   g_global_symbol_table->set_sm_target(a,b,c);
+void ptx_recognizer::target_header3(char *a, char *b, char *c) {
+  g_global_symbol_table->set_sm_target(a, b, c);
 }
 
 void ptx_recognizer::maxnt_id(int x, int y, int z) {
   g_func_info->set_maxnt_id(x * y * z);
 }
 
-void ptx_recognizer::func_header(const char* a) {} //intentional dummy function
-void ptx_recognizer::func_header_info(const char* a) {} //intentional dummy function
-void ptx_recognizer::func_header_info_int(const char* a, int b) {} //intentional dummy function
+void ptx_recognizer::func_header(const char *a) {}  // intentional dummy
+                                                    // function
+void ptx_recognizer::func_header_info(const char *a) {
+}  // intentional dummy function
+void ptx_recognizer::func_header_info_int(const char *a, int b) {
+}  // intentional dummy function

--- a/src/cuda-sim/ptx_parser.h
+++ b/src/cuda-sim/ptx_parser.h
@@ -7,23 +7,24 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef ptx_parser_INCLUDED
 #define ptx_parser_INCLUDED
@@ -32,155 +33,161 @@
 #include "ptx_ir.h"
 
 class gpgpu_context;
-typedef void * yyscan_t;
+typedef void *yyscan_t;
 class ptx_recognizer {
-    public:
-	ptx_recognizer( gpgpu_context* ctx ) : g_return_var(ctx) {
-	    scanner = NULL;
-	    g_size = -1;
-	    g_add_identifier_cached__identifier = NULL;
-	    g_alignment_spec = -1;
-	    g_var_type = NULL;
-	    g_opcode = -1;
-	    g_space_spec = undefined_space;
-	    g_ptr_spec = undefined_space;
-	    g_scalar_type_spec = -1;
-	    g_vector_spec = -1;
-	    g_extern_spec = 0;
-	    g_func_decl = 0;
-	    g_ident_add_uid = 0;
-	    g_const_alloc = 1;
-	    g_max_regs_per_thread = 0;
-	    g_global_symbol_table = NULL;
-	    g_current_symbol_table = NULL;
-	    g_last_symbol = NULL;
-	    g_error_detected = 0;
-	    g_entry_func_param_index=0;
-	    g_func_info = NULL;
-	    g_debug_ir_generation=false;
-	    gpgpu_ctx = ctx;
-	}
-	// global list
-	yyscan_t scanner;
-#define PTX_LINEBUF_SIZE (4*1024)
-	char linebuf[PTX_LINEBUF_SIZE];
-	unsigned col;
-	int g_size;
-	char *g_add_identifier_cached__identifier;
-	int g_add_identifier_cached__array_dim;
-	int g_add_identifier_cached__array_ident;
-	int g_alignment_spec;
-	// variable declaration stuff:
-	type_info *g_var_type;
-	// instruction definition stuff:
-	const symbol *g_pred;
-	int g_neg_pred;
-	int g_pred_mod;
-	symbol *g_label;
-	int g_opcode;
-	std::list<operand_info> g_operands;
-	std::list<int> g_options;
-	std::list<int> g_wmma_options;
-	std::list<int> g_scalar_type;
-	// type specifier stuff:
-	memory_space_t g_space_spec;
-	memory_space_t g_ptr_spec;
-	int g_scalar_type_spec;
-	int g_vector_spec;
-	int g_extern_spec;
-	int g_func_decl;
-	int g_ident_add_uid;
-	unsigned g_const_alloc;
-	unsigned g_max_regs_per_thread;
-	symbol_table *g_global_symbol_table;
-	symbol_table *g_current_symbol_table;
-	symbol *g_last_symbol;
-	std::list<ptx_instruction*> g_instructions;
-	int g_error_detected;
-	unsigned g_entry_func_param_index;
-	function_info *g_func_info;
-	operand_info g_return_var;
-	bool g_debug_ir_generation;
-	int g_entry_point;
-	const struct core_config *g_shader_core_config;
-	std::map<std::string,std::map<unsigned,const ptx_instruction*> > g_inst_lookup;
-	// the program intermediate representation...
-	std::map<std::string,symbol_table*> g_sym_name_to_symbol_table;
-	// backward pointer
-	class gpgpu_context* gpgpu_ctx;
+ public:
+  ptx_recognizer(gpgpu_context *ctx) : g_return_var(ctx) {
+    scanner = NULL;
+    g_size = -1;
+    g_add_identifier_cached__identifier = NULL;
+    g_alignment_spec = -1;
+    g_var_type = NULL;
+    g_opcode = -1;
+    g_space_spec = undefined_space;
+    g_ptr_spec = undefined_space;
+    g_scalar_type_spec = -1;
+    g_vector_spec = -1;
+    g_extern_spec = 0;
+    g_func_decl = 0;
+    g_ident_add_uid = 0;
+    g_const_alloc = 1;
+    g_max_regs_per_thread = 0;
+    g_global_symbol_table = NULL;
+    g_current_symbol_table = NULL;
+    g_last_symbol = NULL;
+    g_error_detected = 0;
+    g_entry_func_param_index = 0;
+    g_func_info = NULL;
+    g_debug_ir_generation = false;
+    gpgpu_ctx = ctx;
+  }
+  // global list
+  yyscan_t scanner;
+#define PTX_LINEBUF_SIZE (4 * 1024)
+  char linebuf[PTX_LINEBUF_SIZE];
+  unsigned col;
+  int g_size;
+  char *g_add_identifier_cached__identifier;
+  int g_add_identifier_cached__array_dim;
+  int g_add_identifier_cached__array_ident;
+  int g_alignment_spec;
+  // variable declaration stuff:
+  type_info *g_var_type;
+  // instruction definition stuff:
+  const symbol *g_pred;
+  int g_neg_pred;
+  int g_pred_mod;
+  symbol *g_label;
+  int g_opcode;
+  std::list<operand_info> g_operands;
+  std::list<int> g_options;
+  std::list<int> g_wmma_options;
+  std::list<int> g_scalar_type;
+  // type specifier stuff:
+  memory_space_t g_space_spec;
+  memory_space_t g_ptr_spec;
+  int g_scalar_type_spec;
+  int g_vector_spec;
+  int g_extern_spec;
+  int g_func_decl;
+  int g_ident_add_uid;
+  unsigned g_const_alloc;
+  unsigned g_max_regs_per_thread;
+  symbol_table *g_global_symbol_table;
+  symbol_table *g_current_symbol_table;
+  symbol *g_last_symbol;
+  std::list<ptx_instruction *> g_instructions;
+  int g_error_detected;
+  unsigned g_entry_func_param_index;
+  function_info *g_func_info;
+  operand_info g_return_var;
+  bool g_debug_ir_generation;
+  int g_entry_point;
+  const struct core_config *g_shader_core_config;
+  std::map<std::string, std::map<unsigned, const ptx_instruction *> >
+      g_inst_lookup;
+  // the program intermediate representation...
+  std::map<std::string, symbol_table *> g_sym_name_to_symbol_table;
+  // backward pointer
+  class gpgpu_context *gpgpu_ctx;
 
-	// member function list
-	void init_directive_state();
-	void init_instruction_state();
-	void start_function( int entry_point );
-	void add_function_name( const char *fname );
-	void add_directive();
-	void end_function();
-	void add_identifier( const char *s, int array_dim, unsigned array_ident );
-	void add_function_arg();
-	void add_scalar_type_spec( int type_spec );
-	void add_scalar_operand( const char *identifier );
-	void add_neg_pred_operand( const char *identifier );
-	void add_variables();
-	void set_variable_type();
-	void add_opcode( int opcode );
-	void add_pred( const char *identifier, int negate, int predModifier );
-	void add_1vector_operand( const char *d1 );
-	void add_2vector_operand( const char *d1, const char *d2 );
-	void add_3vector_operand( const char *d1, const char *d2, const char *d3 );
-	void add_4vector_operand( const char *d1, const char *d2, const char *d3, const char *d4 );
-	void add_8vector_operand( const char *d1, const char *d2, const char *d3, const char *d4 ,const char *d5,const char *d6,const char *d7,const char *d8);
-	void add_option(int option );
-	void add_wmma_option(int option );
-	void add_builtin_operand( int builtin, int dim_modifier );
-	void add_memory_operand( );
-	void add_literal_int( int value );
-	void add_literal_float( float value );
-	void add_literal_double( double value );
-	void add_address_operand( const char *identifier, int offset );
-	void add_address_operand2( int offset );
-	void add_label( const char *idenfiier );
-	void add_vector_spec(int spec );
-	void add_space_spec( enum _memory_space_t spec, int value );
-	void add_ptr_spec( enum _memory_space_t spec );
-	void add_extern_spec();
-	void add_instruction();
-	void set_return();
-	void add_alignment_spec( int spec );
-	void add_array_initializer();
-	void add_file( unsigned num, const char *filename );
-	void add_version_info( float ver, unsigned ext);
-	void *reset_symtab();
-	void set_symtab(void*);
-	void add_pragma( const char *str );
-	void func_header(const char* a);
-	void func_header_info(const char* a);
-	void func_header_info_int(const char* a, int b);
-	void add_constptr(const char* identifier1, const char* identifier2, int offset);
-	void target_header(char* a);
-	void target_header2(char* a, char* b);
-	void target_header3(char* a, char* b, char* c);
-	void add_double_operand( const char *d1, const char *d2 );
-	void change_memory_addr_space( const char *identifier );
-	void change_operand_lohi( int lohi );
-	void change_double_operand_type( int addr_type );
-	void change_operand_neg( );
-	void set_immediate_operand_type( );
-	void version_header(double a);
-	void maxnt_id(int x, int y, int z);
-	void parse_error_impl( const char *file, unsigned line, const char *msg, ... );
-	void parse_assert_impl( int test_value, const char *file, unsigned line, const char *msg, ... );
-	//Jin: handle instructino group for cdp
-	void start_inst_group();
-	void end_inst_group();
-	bool check_for_duplicates( const char *identifier );
-	void read_parser_environment_variables(); 
-	void set_ptx_warp_size(const struct core_config * warp_size);
-	const class ptx_instruction *ptx_instruction_lookup( const char *filename, unsigned linenumber );
-
+  // member function list
+  void init_directive_state();
+  void init_instruction_state();
+  void start_function(int entry_point);
+  void add_function_name(const char *fname);
+  void add_directive();
+  void end_function();
+  void add_identifier(const char *s, int array_dim, unsigned array_ident);
+  void add_function_arg();
+  void add_scalar_type_spec(int type_spec);
+  void add_scalar_operand(const char *identifier);
+  void add_neg_pred_operand(const char *identifier);
+  void add_variables();
+  void set_variable_type();
+  void add_opcode(int opcode);
+  void add_pred(const char *identifier, int negate, int predModifier);
+  void add_1vector_operand(const char *d1);
+  void add_2vector_operand(const char *d1, const char *d2);
+  void add_3vector_operand(const char *d1, const char *d2, const char *d3);
+  void add_4vector_operand(const char *d1, const char *d2, const char *d3,
+                           const char *d4);
+  void add_8vector_operand(const char *d1, const char *d2, const char *d3,
+                           const char *d4, const char *d5, const char *d6,
+                           const char *d7, const char *d8);
+  void add_option(int option);
+  void add_wmma_option(int option);
+  void add_builtin_operand(int builtin, int dim_modifier);
+  void add_memory_operand();
+  void add_literal_int(int value);
+  void add_literal_float(float value);
+  void add_literal_double(double value);
+  void add_address_operand(const char *identifier, int offset);
+  void add_address_operand2(int offset);
+  void add_label(const char *idenfiier);
+  void add_vector_spec(int spec);
+  void add_space_spec(enum _memory_space_t spec, int value);
+  void add_ptr_spec(enum _memory_space_t spec);
+  void add_extern_spec();
+  void add_instruction();
+  void set_return();
+  void add_alignment_spec(int spec);
+  void add_array_initializer();
+  void add_file(unsigned num, const char *filename);
+  void add_version_info(float ver, unsigned ext);
+  void *reset_symtab();
+  void set_symtab(void *);
+  void add_pragma(const char *str);
+  void func_header(const char *a);
+  void func_header_info(const char *a);
+  void func_header_info_int(const char *a, int b);
+  void add_constptr(const char *identifier1, const char *identifier2,
+                    int offset);
+  void target_header(char *a);
+  void target_header2(char *a, char *b);
+  void target_header3(char *a, char *b, char *c);
+  void add_double_operand(const char *d1, const char *d2);
+  void change_memory_addr_space(const char *identifier);
+  void change_operand_lohi(int lohi);
+  void change_double_operand_type(int addr_type);
+  void change_operand_neg();
+  void set_immediate_operand_type();
+  void version_header(double a);
+  void maxnt_id(int x, int y, int z);
+  void parse_error_impl(const char *file, unsigned line, const char *msg, ...);
+  void parse_assert_impl(int test_value, const char *file, unsigned line,
+                         const char *msg, ...);
+  // Jin: handle instructino group for cdp
+  void start_inst_group();
+  void end_inst_group();
+  bool check_for_duplicates(const char *identifier);
+  void read_parser_environment_variables();
+  void set_ptx_warp_size(const struct core_config *warp_size);
+  const class ptx_instruction *ptx_instruction_lookup(const char *filename,
+                                                      unsigned linenumber);
 };
 
-const char *decode_token( int type );
+const char *decode_token(int type);
 void read_parser_environment_variables();
 
 #define NON_ARRAY_IDENTIFIER 1

--- a/src/cuda-sim/ptx_parser.h
+++ b/src/cuda-sim/ptx_parser.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -32,155 +34,161 @@
 #include "ptx_ir.h"
 
 class gpgpu_context;
-typedef void * yyscan_t;
+typedef void *yyscan_t;
 class ptx_recognizer {
-    public:
-	ptx_recognizer( gpgpu_context* ctx ) : g_return_var(ctx) {
-	    scanner = NULL;
-	    g_size = -1;
-	    g_add_identifier_cached__identifier = NULL;
-	    g_alignment_spec = -1;
-	    g_var_type = NULL;
-	    g_opcode = -1;
-	    g_space_spec = undefined_space;
-	    g_ptr_spec = undefined_space;
-	    g_scalar_type_spec = -1;
-	    g_vector_spec = -1;
-	    g_extern_spec = 0;
-	    g_func_decl = 0;
-	    g_ident_add_uid = 0;
-	    g_const_alloc = 1;
-	    g_max_regs_per_thread = 0;
-	    g_global_symbol_table = NULL;
-	    g_current_symbol_table = NULL;
-	    g_last_symbol = NULL;
-	    g_error_detected = 0;
-	    g_entry_func_param_index=0;
-	    g_func_info = NULL;
-	    g_debug_ir_generation=false;
-	    gpgpu_ctx = ctx;
-	}
-	// global list
-	yyscan_t scanner;
-#define PTX_LINEBUF_SIZE (4*1024)
-	char linebuf[PTX_LINEBUF_SIZE];
-	unsigned col;
-	int g_size;
-	char *g_add_identifier_cached__identifier;
-	int g_add_identifier_cached__array_dim;
-	int g_add_identifier_cached__array_ident;
-	int g_alignment_spec;
-	// variable declaration stuff:
-	type_info *g_var_type;
-	// instruction definition stuff:
-	const symbol *g_pred;
-	int g_neg_pred;
-	int g_pred_mod;
-	symbol *g_label;
-	int g_opcode;
-	std::list<operand_info> g_operands;
-	std::list<int> g_options;
-	std::list<int> g_wmma_options;
-	std::list<int> g_scalar_type;
-	// type specifier stuff:
-	memory_space_t g_space_spec;
-	memory_space_t g_ptr_spec;
-	int g_scalar_type_spec;
-	int g_vector_spec;
-	int g_extern_spec;
-	int g_func_decl;
-	int g_ident_add_uid;
-	unsigned g_const_alloc;
-	unsigned g_max_regs_per_thread;
-	symbol_table *g_global_symbol_table;
-	symbol_table *g_current_symbol_table;
-	symbol *g_last_symbol;
-	std::list<ptx_instruction*> g_instructions;
-	int g_error_detected;
-	unsigned g_entry_func_param_index;
-	function_info *g_func_info;
-	operand_info g_return_var;
-	bool g_debug_ir_generation;
-	int g_entry_point;
-	const struct core_config *g_shader_core_config;
-	std::map<std::string,std::map<unsigned,const ptx_instruction*> > g_inst_lookup;
-	// the program intermediate representation...
-	std::map<std::string,symbol_table*> g_sym_name_to_symbol_table;
-	// backward pointer
-	class gpgpu_context* gpgpu_ctx;
+ public:
+  ptx_recognizer(gpgpu_context *ctx) : g_return_var(ctx) {
+    scanner = NULL;
+    g_size = -1;
+    g_add_identifier_cached__identifier = NULL;
+    g_alignment_spec = -1;
+    g_var_type = NULL;
+    g_opcode = -1;
+    g_space_spec = undefined_space;
+    g_ptr_spec = undefined_space;
+    g_scalar_type_spec = -1;
+    g_vector_spec = -1;
+    g_extern_spec = 0;
+    g_func_decl = 0;
+    g_ident_add_uid = 0;
+    g_const_alloc = 1;
+    g_max_regs_per_thread = 0;
+    g_global_symbol_table = NULL;
+    g_current_symbol_table = NULL;
+    g_last_symbol = NULL;
+    g_error_detected = 0;
+    g_entry_func_param_index = 0;
+    g_func_info = NULL;
+    g_debug_ir_generation = false;
+    gpgpu_ctx = ctx;
+  }
+  // global list
+  yyscan_t scanner;
+#define PTX_LINEBUF_SIZE (4 * 1024)
+  char linebuf[PTX_LINEBUF_SIZE];
+  unsigned col;
+  int g_size;
+  char *g_add_identifier_cached__identifier;
+  int g_add_identifier_cached__array_dim;
+  int g_add_identifier_cached__array_ident;
+  int g_alignment_spec;
+  // variable declaration stuff:
+  type_info *g_var_type;
+  // instruction definition stuff:
+  const symbol *g_pred;
+  int g_neg_pred;
+  int g_pred_mod;
+  symbol *g_label;
+  int g_opcode;
+  std::list<operand_info> g_operands;
+  std::list<int> g_options;
+  std::list<int> g_wmma_options;
+  std::list<int> g_scalar_type;
+  // type specifier stuff:
+  memory_space_t g_space_spec;
+  memory_space_t g_ptr_spec;
+  int g_scalar_type_spec;
+  int g_vector_spec;
+  int g_extern_spec;
+  int g_func_decl;
+  int g_ident_add_uid;
+  unsigned g_const_alloc;
+  unsigned g_max_regs_per_thread;
+  symbol_table *g_global_symbol_table;
+  symbol_table *g_current_symbol_table;
+  symbol *g_last_symbol;
+  std::list<ptx_instruction *> g_instructions;
+  int g_error_detected;
+  unsigned g_entry_func_param_index;
+  function_info *g_func_info;
+  operand_info g_return_var;
+  bool g_debug_ir_generation;
+  int g_entry_point;
+  const struct core_config *g_shader_core_config;
+  std::map<std::string, std::map<unsigned, const ptx_instruction *> >
+      g_inst_lookup;
+  // the program intermediate representation...
+  std::map<std::string, symbol_table *> g_sym_name_to_symbol_table;
+  // backward pointer
+  class gpgpu_context *gpgpu_ctx;
 
-	// member function list
-	void init_directive_state();
-	void init_instruction_state();
-	void start_function( int entry_point );
-	void add_function_name( const char *fname );
-	void add_directive();
-	void end_function();
-	void add_identifier( const char *s, int array_dim, unsigned array_ident );
-	void add_function_arg();
-	void add_scalar_type_spec( int type_spec );
-	void add_scalar_operand( const char *identifier );
-	void add_neg_pred_operand( const char *identifier );
-	void add_variables();
-	void set_variable_type();
-	void add_opcode( int opcode );
-	void add_pred( const char *identifier, int negate, int predModifier );
-	void add_1vector_operand( const char *d1 );
-	void add_2vector_operand( const char *d1, const char *d2 );
-	void add_3vector_operand( const char *d1, const char *d2, const char *d3 );
-	void add_4vector_operand( const char *d1, const char *d2, const char *d3, const char *d4 );
-	void add_8vector_operand( const char *d1, const char *d2, const char *d3, const char *d4 ,const char *d5,const char *d6,const char *d7,const char *d8);
-	void add_option(int option );
-	void add_wmma_option(int option );
-	void add_builtin_operand( int builtin, int dim_modifier );
-	void add_memory_operand( );
-	void add_literal_int( int value );
-	void add_literal_float( float value );
-	void add_literal_double( double value );
-	void add_address_operand( const char *identifier, int offset );
-	void add_address_operand2( int offset );
-	void add_label( const char *idenfiier );
-	void add_vector_spec(int spec );
-	void add_space_spec( enum _memory_space_t spec, int value );
-	void add_ptr_spec( enum _memory_space_t spec );
-	void add_extern_spec();
-	void add_instruction();
-	void set_return();
-	void add_alignment_spec( int spec );
-	void add_array_initializer();
-	void add_file( unsigned num, const char *filename );
-	void add_version_info( float ver, unsigned ext);
-	void *reset_symtab();
-	void set_symtab(void*);
-	void add_pragma( const char *str );
-	void func_header(const char* a);
-	void func_header_info(const char* a);
-	void func_header_info_int(const char* a, int b);
-	void add_constptr(const char* identifier1, const char* identifier2, int offset);
-	void target_header(char* a);
-	void target_header2(char* a, char* b);
-	void target_header3(char* a, char* b, char* c);
-	void add_double_operand( const char *d1, const char *d2 );
-	void change_memory_addr_space( const char *identifier );
-	void change_operand_lohi( int lohi );
-	void change_double_operand_type( int addr_type );
-	void change_operand_neg( );
-	void set_immediate_operand_type( );
-	void version_header(double a);
-	void maxnt_id(int x, int y, int z);
-	void parse_error_impl( const char *file, unsigned line, const char *msg, ... );
-	void parse_assert_impl( int test_value, const char *file, unsigned line, const char *msg, ... );
-	//Jin: handle instructino group for cdp
-	void start_inst_group();
-	void end_inst_group();
-	bool check_for_duplicates( const char *identifier );
-	void read_parser_environment_variables(); 
-	void set_ptx_warp_size(const struct core_config * warp_size);
-	const class ptx_instruction *ptx_instruction_lookup( const char *filename, unsigned linenumber );
-
+  // member function list
+  void init_directive_state();
+  void init_instruction_state();
+  void start_function(int entry_point);
+  void add_function_name(const char *fname);
+  void add_directive();
+  void end_function();
+  void add_identifier(const char *s, int array_dim, unsigned array_ident);
+  void add_function_arg();
+  void add_scalar_type_spec(int type_spec);
+  void add_scalar_operand(const char *identifier);
+  void add_neg_pred_operand(const char *identifier);
+  void add_variables();
+  void set_variable_type();
+  void add_opcode(int opcode);
+  void add_pred(const char *identifier, int negate, int predModifier);
+  void add_1vector_operand(const char *d1);
+  void add_2vector_operand(const char *d1, const char *d2);
+  void add_3vector_operand(const char *d1, const char *d2, const char *d3);
+  void add_4vector_operand(const char *d1, const char *d2, const char *d3,
+                           const char *d4);
+  void add_8vector_operand(const char *d1, const char *d2, const char *d3,
+                           const char *d4, const char *d5, const char *d6,
+                           const char *d7, const char *d8);
+  void add_option(int option);
+  void add_wmma_option(int option);
+  void add_builtin_operand(int builtin, int dim_modifier);
+  void add_memory_operand();
+  void add_literal_int(int value);
+  void add_literal_float(float value);
+  void add_literal_double(double value);
+  void add_address_operand(const char *identifier, int offset);
+  void add_address_operand2(int offset);
+  void add_label(const char *idenfiier);
+  void add_vector_spec(int spec);
+  void add_space_spec(enum _memory_space_t spec, int value);
+  void add_ptr_spec(enum _memory_space_t spec);
+  void add_extern_spec();
+  void add_instruction();
+  void set_return();
+  void add_alignment_spec(int spec);
+  void add_array_initializer();
+  void add_file(unsigned num, const char *filename);
+  void add_version_info(float ver, unsigned ext);
+  void *reset_symtab();
+  void set_symtab(void *);
+  void add_pragma(const char *str);
+  void func_header(const char *a);
+  void func_header_info(const char *a);
+  void func_header_info_int(const char *a, int b);
+  void add_constptr(const char *identifier1, const char *identifier2,
+                    int offset);
+  void target_header(char *a);
+  void target_header2(char *a, char *b);
+  void target_header3(char *a, char *b, char *c);
+  void add_double_operand(const char *d1, const char *d2);
+  void change_memory_addr_space(const char *identifier);
+  void change_operand_lohi(int lohi);
+  void change_double_operand_type(int addr_type);
+  void change_operand_neg();
+  void set_immediate_operand_type();
+  void version_header(double a);
+  void maxnt_id(int x, int y, int z);
+  void parse_error_impl(const char *file, unsigned line, const char *msg, ...);
+  void parse_assert_impl(int test_value, const char *file, unsigned line,
+                         const char *msg, ...);
+  // Jin: handle instructino group for cdp
+  void start_inst_group();
+  void end_inst_group();
+  bool check_for_duplicates(const char *identifier);
+  void read_parser_environment_variables();
+  void set_ptx_warp_size(const struct core_config *warp_size);
+  const class ptx_instruction *ptx_instruction_lookup(const char *filename,
+                                                      unsigned linenumber);
 };
 
-const char *decode_token( int type );
+const char *decode_token(int type);
 void read_parser_environment_variables();
 
 #define NON_ARRAY_IDENTIFIER 1

--- a/src/cuda-sim/ptx_parser.h
+++ b/src/cuda-sim/ptx_parser.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -34,161 +32,155 @@
 #include "ptx_ir.h"
 
 class gpgpu_context;
-typedef void *yyscan_t;
+typedef void * yyscan_t;
 class ptx_recognizer {
- public:
-  ptx_recognizer(gpgpu_context *ctx) : g_return_var(ctx) {
-    scanner = NULL;
-    g_size = -1;
-    g_add_identifier_cached__identifier = NULL;
-    g_alignment_spec = -1;
-    g_var_type = NULL;
-    g_opcode = -1;
-    g_space_spec = undefined_space;
-    g_ptr_spec = undefined_space;
-    g_scalar_type_spec = -1;
-    g_vector_spec = -1;
-    g_extern_spec = 0;
-    g_func_decl = 0;
-    g_ident_add_uid = 0;
-    g_const_alloc = 1;
-    g_max_regs_per_thread = 0;
-    g_global_symbol_table = NULL;
-    g_current_symbol_table = NULL;
-    g_last_symbol = NULL;
-    g_error_detected = 0;
-    g_entry_func_param_index = 0;
-    g_func_info = NULL;
-    g_debug_ir_generation = false;
-    gpgpu_ctx = ctx;
-  }
-  // global list
-  yyscan_t scanner;
-#define PTX_LINEBUF_SIZE (4 * 1024)
-  char linebuf[PTX_LINEBUF_SIZE];
-  unsigned col;
-  int g_size;
-  char *g_add_identifier_cached__identifier;
-  int g_add_identifier_cached__array_dim;
-  int g_add_identifier_cached__array_ident;
-  int g_alignment_spec;
-  // variable declaration stuff:
-  type_info *g_var_type;
-  // instruction definition stuff:
-  const symbol *g_pred;
-  int g_neg_pred;
-  int g_pred_mod;
-  symbol *g_label;
-  int g_opcode;
-  std::list<operand_info> g_operands;
-  std::list<int> g_options;
-  std::list<int> g_wmma_options;
-  std::list<int> g_scalar_type;
-  // type specifier stuff:
-  memory_space_t g_space_spec;
-  memory_space_t g_ptr_spec;
-  int g_scalar_type_spec;
-  int g_vector_spec;
-  int g_extern_spec;
-  int g_func_decl;
-  int g_ident_add_uid;
-  unsigned g_const_alloc;
-  unsigned g_max_regs_per_thread;
-  symbol_table *g_global_symbol_table;
-  symbol_table *g_current_symbol_table;
-  symbol *g_last_symbol;
-  std::list<ptx_instruction *> g_instructions;
-  int g_error_detected;
-  unsigned g_entry_func_param_index;
-  function_info *g_func_info;
-  operand_info g_return_var;
-  bool g_debug_ir_generation;
-  int g_entry_point;
-  const struct core_config *g_shader_core_config;
-  std::map<std::string, std::map<unsigned, const ptx_instruction *> >
-      g_inst_lookup;
-  // the program intermediate representation...
-  std::map<std::string, symbol_table *> g_sym_name_to_symbol_table;
-  // backward pointer
-  class gpgpu_context *gpgpu_ctx;
+    public:
+	ptx_recognizer( gpgpu_context* ctx ) : g_return_var(ctx) {
+	    scanner = NULL;
+	    g_size = -1;
+	    g_add_identifier_cached__identifier = NULL;
+	    g_alignment_spec = -1;
+	    g_var_type = NULL;
+	    g_opcode = -1;
+	    g_space_spec = undefined_space;
+	    g_ptr_spec = undefined_space;
+	    g_scalar_type_spec = -1;
+	    g_vector_spec = -1;
+	    g_extern_spec = 0;
+	    g_func_decl = 0;
+	    g_ident_add_uid = 0;
+	    g_const_alloc = 1;
+	    g_max_regs_per_thread = 0;
+	    g_global_symbol_table = NULL;
+	    g_current_symbol_table = NULL;
+	    g_last_symbol = NULL;
+	    g_error_detected = 0;
+	    g_entry_func_param_index=0;
+	    g_func_info = NULL;
+	    g_debug_ir_generation=false;
+	    gpgpu_ctx = ctx;
+	}
+	// global list
+	yyscan_t scanner;
+#define PTX_LINEBUF_SIZE (4*1024)
+	char linebuf[PTX_LINEBUF_SIZE];
+	unsigned col;
+	int g_size;
+	char *g_add_identifier_cached__identifier;
+	int g_add_identifier_cached__array_dim;
+	int g_add_identifier_cached__array_ident;
+	int g_alignment_spec;
+	// variable declaration stuff:
+	type_info *g_var_type;
+	// instruction definition stuff:
+	const symbol *g_pred;
+	int g_neg_pred;
+	int g_pred_mod;
+	symbol *g_label;
+	int g_opcode;
+	std::list<operand_info> g_operands;
+	std::list<int> g_options;
+	std::list<int> g_wmma_options;
+	std::list<int> g_scalar_type;
+	// type specifier stuff:
+	memory_space_t g_space_spec;
+	memory_space_t g_ptr_spec;
+	int g_scalar_type_spec;
+	int g_vector_spec;
+	int g_extern_spec;
+	int g_func_decl;
+	int g_ident_add_uid;
+	unsigned g_const_alloc;
+	unsigned g_max_regs_per_thread;
+	symbol_table *g_global_symbol_table;
+	symbol_table *g_current_symbol_table;
+	symbol *g_last_symbol;
+	std::list<ptx_instruction*> g_instructions;
+	int g_error_detected;
+	unsigned g_entry_func_param_index;
+	function_info *g_func_info;
+	operand_info g_return_var;
+	bool g_debug_ir_generation;
+	int g_entry_point;
+	const struct core_config *g_shader_core_config;
+	std::map<std::string,std::map<unsigned,const ptx_instruction*> > g_inst_lookup;
+	// the program intermediate representation...
+	std::map<std::string,symbol_table*> g_sym_name_to_symbol_table;
+	// backward pointer
+	class gpgpu_context* gpgpu_ctx;
 
-  // member function list
-  void init_directive_state();
-  void init_instruction_state();
-  void start_function(int entry_point);
-  void add_function_name(const char *fname);
-  void add_directive();
-  void end_function();
-  void add_identifier(const char *s, int array_dim, unsigned array_ident);
-  void add_function_arg();
-  void add_scalar_type_spec(int type_spec);
-  void add_scalar_operand(const char *identifier);
-  void add_neg_pred_operand(const char *identifier);
-  void add_variables();
-  void set_variable_type();
-  void add_opcode(int opcode);
-  void add_pred(const char *identifier, int negate, int predModifier);
-  void add_1vector_operand(const char *d1);
-  void add_2vector_operand(const char *d1, const char *d2);
-  void add_3vector_operand(const char *d1, const char *d2, const char *d3);
-  void add_4vector_operand(const char *d1, const char *d2, const char *d3,
-                           const char *d4);
-  void add_8vector_operand(const char *d1, const char *d2, const char *d3,
-                           const char *d4, const char *d5, const char *d6,
-                           const char *d7, const char *d8);
-  void add_option(int option);
-  void add_wmma_option(int option);
-  void add_builtin_operand(int builtin, int dim_modifier);
-  void add_memory_operand();
-  void add_literal_int(int value);
-  void add_literal_float(float value);
-  void add_literal_double(double value);
-  void add_address_operand(const char *identifier, int offset);
-  void add_address_operand2(int offset);
-  void add_label(const char *idenfiier);
-  void add_vector_spec(int spec);
-  void add_space_spec(enum _memory_space_t spec, int value);
-  void add_ptr_spec(enum _memory_space_t spec);
-  void add_extern_spec();
-  void add_instruction();
-  void set_return();
-  void add_alignment_spec(int spec);
-  void add_array_initializer();
-  void add_file(unsigned num, const char *filename);
-  void add_version_info(float ver, unsigned ext);
-  void *reset_symtab();
-  void set_symtab(void *);
-  void add_pragma(const char *str);
-  void func_header(const char *a);
-  void func_header_info(const char *a);
-  void func_header_info_int(const char *a, int b);
-  void add_constptr(const char *identifier1, const char *identifier2,
-                    int offset);
-  void target_header(char *a);
-  void target_header2(char *a, char *b);
-  void target_header3(char *a, char *b, char *c);
-  void add_double_operand(const char *d1, const char *d2);
-  void change_memory_addr_space(const char *identifier);
-  void change_operand_lohi(int lohi);
-  void change_double_operand_type(int addr_type);
-  void change_operand_neg();
-  void set_immediate_operand_type();
-  void version_header(double a);
-  void maxnt_id(int x, int y, int z);
-  void parse_error_impl(const char *file, unsigned line, const char *msg, ...);
-  void parse_assert_impl(int test_value, const char *file, unsigned line,
-                         const char *msg, ...);
-  // Jin: handle instructino group for cdp
-  void start_inst_group();
-  void end_inst_group();
-  bool check_for_duplicates(const char *identifier);
-  void read_parser_environment_variables();
-  void set_ptx_warp_size(const struct core_config *warp_size);
-  const class ptx_instruction *ptx_instruction_lookup(const char *filename,
-                                                      unsigned linenumber);
+	// member function list
+	void init_directive_state();
+	void init_instruction_state();
+	void start_function( int entry_point );
+	void add_function_name( const char *fname );
+	void add_directive();
+	void end_function();
+	void add_identifier( const char *s, int array_dim, unsigned array_ident );
+	void add_function_arg();
+	void add_scalar_type_spec( int type_spec );
+	void add_scalar_operand( const char *identifier );
+	void add_neg_pred_operand( const char *identifier );
+	void add_variables();
+	void set_variable_type();
+	void add_opcode( int opcode );
+	void add_pred( const char *identifier, int negate, int predModifier );
+	void add_1vector_operand( const char *d1 );
+	void add_2vector_operand( const char *d1, const char *d2 );
+	void add_3vector_operand( const char *d1, const char *d2, const char *d3 );
+	void add_4vector_operand( const char *d1, const char *d2, const char *d3, const char *d4 );
+	void add_8vector_operand( const char *d1, const char *d2, const char *d3, const char *d4 ,const char *d5,const char *d6,const char *d7,const char *d8);
+	void add_option(int option );
+	void add_wmma_option(int option );
+	void add_builtin_operand( int builtin, int dim_modifier );
+	void add_memory_operand( );
+	void add_literal_int( int value );
+	void add_literal_float( float value );
+	void add_literal_double( double value );
+	void add_address_operand( const char *identifier, int offset );
+	void add_address_operand2( int offset );
+	void add_label( const char *idenfiier );
+	void add_vector_spec(int spec );
+	void add_space_spec( enum _memory_space_t spec, int value );
+	void add_ptr_spec( enum _memory_space_t spec );
+	void add_extern_spec();
+	void add_instruction();
+	void set_return();
+	void add_alignment_spec( int spec );
+	void add_array_initializer();
+	void add_file( unsigned num, const char *filename );
+	void add_version_info( float ver, unsigned ext);
+	void *reset_symtab();
+	void set_symtab(void*);
+	void add_pragma( const char *str );
+	void func_header(const char* a);
+	void func_header_info(const char* a);
+	void func_header_info_int(const char* a, int b);
+	void add_constptr(const char* identifier1, const char* identifier2, int offset);
+	void target_header(char* a);
+	void target_header2(char* a, char* b);
+	void target_header3(char* a, char* b, char* c);
+	void add_double_operand( const char *d1, const char *d2 );
+	void change_memory_addr_space( const char *identifier );
+	void change_operand_lohi( int lohi );
+	void change_double_operand_type( int addr_type );
+	void change_operand_neg( );
+	void set_immediate_operand_type( );
+	void version_header(double a);
+	void maxnt_id(int x, int y, int z);
+	void parse_error_impl( const char *file, unsigned line, const char *msg, ... );
+	void parse_assert_impl( int test_value, const char *file, unsigned line, const char *msg, ... );
+	//Jin: handle instructino group for cdp
+	void start_inst_group();
+	void end_inst_group();
+	bool check_for_duplicates( const char *identifier );
+	void read_parser_environment_variables(); 
+	void set_ptx_warp_size(const struct core_config * warp_size);
+	const class ptx_instruction *ptx_instruction_lookup( const char *filename, unsigned linenumber );
+
 };
 
-const char *decode_token(int type);
+const char *decode_token( int type );
 void read_parser_environment_variables();
 
 #define NON_ARRAY_IDENTIFIER 1

--- a/src/cuda-sim/ptx_sim.cc
+++ b/src/cuda-sim/ptx_sim.cc
@@ -7,595 +7,611 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #include "ptx_sim.h"
 #include <string>
 #include "ptx_ir.h"
 class ptx_recognizer;
-typedef void * yyscan_t;
-#include "ptx.tab.h"
+typedef void *yyscan_t;
+#include "../../libcuda/gpgpu_context.h"
 #include "../gpgpu-sim/gpu-sim.h"
 #include "../gpgpu-sim/shader.h"
-#include "../../libcuda/gpgpu_context.h"
+#include "ptx.tab.h"
 
-void feature_not_implemented( const char *f );
+void feature_not_implemented(const char *f);
 
+ptx_cta_info::ptx_cta_info(unsigned sm_idx, gpgpu_context *ctx) {
+  assert(ctx->func_sim->g_ptx_cta_info_sm_idx_used.find(sm_idx) ==
+         ctx->func_sim->g_ptx_cta_info_sm_idx_used.end());
+  ctx->func_sim->g_ptx_cta_info_sm_idx_used.insert(sm_idx);
 
-ptx_cta_info::ptx_cta_info( unsigned sm_idx, gpgpu_context* ctx )
-{
-   assert( ctx->func_sim->g_ptx_cta_info_sm_idx_used.find(sm_idx) == ctx->func_sim->g_ptx_cta_info_sm_idx_used.end() );
-   ctx->func_sim->g_ptx_cta_info_sm_idx_used.insert(sm_idx);
-
-   m_sm_idx = sm_idx;
-   m_uid = (ctx->g_ptx_cta_info_uid)++;
-   m_bar_threads = 0;
-   gpgpu_ctx = ctx;
+  m_sm_idx = sm_idx;
+  m_uid = (ctx->g_ptx_cta_info_uid)++;
+  m_bar_threads = 0;
+  gpgpu_ctx = ctx;
 }
 
-void ptx_cta_info::add_thread( ptx_thread_info *thd )
-{
-   m_threads_in_cta.insert(thd);
+void ptx_cta_info::add_thread(ptx_thread_info *thd) {
+  m_threads_in_cta.insert(thd);
 }
 
-unsigned ptx_cta_info::num_threads() const
-{
-   return m_threads_in_cta.size();
-}
+unsigned ptx_cta_info::num_threads() const { return m_threads_in_cta.size(); }
 
-void ptx_cta_info::check_cta_thread_status_and_reset()
-{
-   bool fail = false;
-   if ( m_threads_that_have_exited.size() != m_threads_in_cta.size() ) {
-      printf("\n\n");
-      printf("Execution error: Some threads still running in CTA during CTA reallocation! (1)\n");
-      printf("   CTA uid = %Lu (sm_idx = %u) : %lu running out of %zu total\n", 
-             m_uid, 
-             m_sm_idx,
-             (m_threads_in_cta.size() - m_threads_that_have_exited.size()), m_threads_in_cta.size() );
-      printf("   These are the threads that are still running:\n");
-      std::set<ptx_thread_info*>::iterator t_iter;
-      for ( t_iter=m_threads_in_cta.begin(); t_iter != m_threads_in_cta.end(); ++t_iter ) {
-         ptx_thread_info *t = *t_iter;
-         if ( m_threads_that_have_exited.find(t) == m_threads_that_have_exited.end() ) {
-            if ( m_dangling_pointers.find(t) != m_dangling_pointers.end() ) {
-               printf("       <thread deleted>\n");
-            } else {
-               printf("       [done=%c] : ", (t->is_done()?'Y':'N') );
-               t->print_insn( t->get_pc(), stdout );
-               printf("\n");
-            }
-         }
-      }
-      printf("\n\n");
-      fail = true;
-   }
-   if ( fail ) {
-      abort();
-   }
-
-   bool fail2 = false;
-   std::set<ptx_thread_info*>::iterator t_iter;
-   for ( t_iter=m_threads_in_cta.begin(); t_iter != m_threads_in_cta.end(); ++t_iter ) {
+void ptx_cta_info::check_cta_thread_status_and_reset() {
+  bool fail = false;
+  if (m_threads_that_have_exited.size() != m_threads_in_cta.size()) {
+    printf("\n\n");
+    printf(
+        "Execution error: Some threads still running in CTA during CTA "
+        "reallocation! (1)\n");
+    printf("   CTA uid = %Lu (sm_idx = %u) : %lu running out of %zu total\n",
+           m_uid, m_sm_idx,
+           (m_threads_in_cta.size() - m_threads_that_have_exited.size()),
+           m_threads_in_cta.size());
+    printf("   These are the threads that are still running:\n");
+    std::set<ptx_thread_info *>::iterator t_iter;
+    for (t_iter = m_threads_in_cta.begin(); t_iter != m_threads_in_cta.end();
+         ++t_iter) {
       ptx_thread_info *t = *t_iter;
-      if ( m_dangling_pointers.find(t) == m_dangling_pointers.end() ) {
-         if ( !t->is_done() ) {
-            if ( !fail2 ) {
-               printf("Execution error: Some threads still running in CTA during CTA reallocation! (2)\n");
-               printf("   CTA uid = %Lu (sm_idx = %u) :\n", m_uid, m_sm_idx );
-               fail2 = true;
-            }
-            printf("       ");
-            t->print_insn( t->get_pc(), stdout );
-            printf("\n");
-         }
+      if (m_threads_that_have_exited.find(t) ==
+          m_threads_that_have_exited.end()) {
+        if (m_dangling_pointers.find(t) != m_dangling_pointers.end()) {
+          printf("       <thread deleted>\n");
+        } else {
+          printf("       [done=%c] : ", (t->is_done() ? 'Y' : 'N'));
+          t->print_insn(t->get_pc(), stdout);
+          printf("\n");
+        }
       }
-   }
-   if ( fail2 ) {
-      abort();
-   }
-   m_threads_in_cta.clear();
-   m_threads_that_have_exited.clear();
-   m_dangling_pointers.clear();
+    }
+    printf("\n\n");
+    fail = true;
+  }
+  if (fail) {
+    abort();
+  }
+
+  bool fail2 = false;
+  std::set<ptx_thread_info *>::iterator t_iter;
+  for (t_iter = m_threads_in_cta.begin(); t_iter != m_threads_in_cta.end();
+       ++t_iter) {
+    ptx_thread_info *t = *t_iter;
+    if (m_dangling_pointers.find(t) == m_dangling_pointers.end()) {
+      if (!t->is_done()) {
+        if (!fail2) {
+          printf(
+              "Execution error: Some threads still running in CTA during CTA "
+              "reallocation! (2)\n");
+          printf("   CTA uid = %Lu (sm_idx = %u) :\n", m_uid, m_sm_idx);
+          fail2 = true;
+        }
+        printf("       ");
+        t->print_insn(t->get_pc(), stdout);
+        printf("\n");
+      }
+    }
+  }
+  if (fail2) {
+    abort();
+  }
+  m_threads_in_cta.clear();
+  m_threads_that_have_exited.clear();
+  m_dangling_pointers.clear();
 }
 
-void ptx_cta_info::register_thread_exit( ptx_thread_info *thd )
-{
-   assert( m_threads_that_have_exited.find(thd) == m_threads_that_have_exited.end() );
-   m_threads_that_have_exited.insert(thd);
+void ptx_cta_info::register_thread_exit(ptx_thread_info *thd) {
+  assert(m_threads_that_have_exited.find(thd) ==
+         m_threads_that_have_exited.end());
+  m_threads_that_have_exited.insert(thd);
 }
 
-void ptx_cta_info::register_deleted_thread( ptx_thread_info *thd )
-{
-   m_dangling_pointers.insert(thd);
+void ptx_cta_info::register_deleted_thread(ptx_thread_info *thd) {
+  m_dangling_pointers.insert(thd);
 }
 
-unsigned ptx_cta_info::get_sm_idx() const
-{
-   return m_sm_idx;
+unsigned ptx_cta_info::get_sm_idx() const { return m_sm_idx; }
+
+unsigned ptx_cta_info::get_bar_threads() const { return m_bar_threads; }
+
+void ptx_cta_info::inc_bar_threads() { m_bar_threads++; }
+
+void ptx_cta_info::reset_bar_threads() { m_bar_threads = 0; }
+
+ptx_warp_info::ptx_warp_info() { reset_done_threads(); }
+
+unsigned ptx_warp_info::get_done_threads() const { return m_done_threads; }
+
+void ptx_warp_info::inc_done_threads() { m_done_threads++; }
+
+void ptx_warp_info::reset_done_threads() { m_done_threads = 0; }
+
+ptx_thread_info::~ptx_thread_info() {
+  m_gpu->gpgpu_ctx->func_sim->g_ptx_thread_info_delete_count++;
 }
 
-unsigned ptx_cta_info::get_bar_threads() const
-{
-   return m_bar_threads;
+ptx_thread_info::ptx_thread_info(kernel_info_t &kernel) : m_kernel(kernel) {
+  m_uid = kernel.entry()->gpgpu_ctx->func_sim->g_ptx_thread_info_uid_next++;
+  m_core = NULL;
+  m_barrier_num = -1;
+  m_at_barrier = false;
+  m_valid = false;
+  m_gridid = 0;
+  m_thread_done = false;
+  m_cycle_done = 0;
+  m_PC = 0;
+  m_icount = 0;
+  m_last_effective_address = 0;
+  m_last_memory_space = undefined_space;
+  m_branch_taken = 0;
+  m_shared_mem = NULL;
+  m_sstarr_mem = NULL;
+  m_warp_info = NULL;
+  m_cta_info = NULL;
+  m_local_mem = NULL;
+  m_symbol_table = NULL;
+  m_func_info = NULL;
+  m_hw_tid = -1;
+  m_hw_wid = -1;
+  m_hw_sid = -1;
+  m_last_dram_callback.function = NULL;
+  m_last_dram_callback.instruction = NULL;
+  m_regs.push_back(reg_map_t());
+  m_debug_trace_regs_modified.push_back(reg_map_t());
+  m_debug_trace_regs_read.push_back(reg_map_t());
+  m_callstack.push_back(stack_entry());
+  m_RPC = -1;
+  m_RPC_updated = false;
+  m_last_was_call = false;
+  m_enable_debug_trace = false;
+  m_local_mem_stack_pointer = 0;
+  m_gpu = NULL;
+  m_last_set_operand_value = ptx_reg_t();
 }
 
-void ptx_cta_info::inc_bar_threads()
-{
-	m_bar_threads++;
+const ptx_version &ptx_thread_info::get_ptx_version() const {
+  return m_func_info->get_ptx_version();
 }
 
-void ptx_cta_info::reset_bar_threads()
-{
-	m_bar_threads = 0;
+void ptx_thread_info::set_done() {
+  assert(!m_at_barrier);
+  m_thread_done = true;
+  m_cycle_done = m_gpu->gpu_sim_cycle;
 }
 
-ptx_warp_info::ptx_warp_info()
-{
-	reset_done_threads();
-}
-
-unsigned ptx_warp_info::get_done_threads() const
-{
-	return m_done_threads;
-}
-
-void ptx_warp_info::inc_done_threads()
-{
-	m_done_threads++;
-}
-
-void ptx_warp_info::reset_done_threads()
-{
-	m_done_threads = 0;
-}
-
-
-ptx_thread_info::~ptx_thread_info()
-{
-   m_gpu->gpgpu_ctx->func_sim->g_ptx_thread_info_delete_count++;
-}
-
-ptx_thread_info::ptx_thread_info( kernel_info_t &kernel )
-    : m_kernel(kernel)
-{
-   m_uid = kernel.entry()->gpgpu_ctx->func_sim->g_ptx_thread_info_uid_next++;
-   m_core = NULL;
-   m_barrier_num = -1;
-   m_at_barrier = false;
-   m_valid = false;
-   m_gridid = 0;
-   m_thread_done = false;
-   m_cycle_done = 0;
-   m_PC=0;
-   m_icount = 0;
-   m_last_effective_address = 0;
-   m_last_memory_space = undefined_space; 
-   m_branch_taken = 0;
-   m_shared_mem = NULL;
-   m_sstarr_mem = NULL;
-   m_warp_info = NULL;
-   m_cta_info = NULL;
-   m_local_mem = NULL;
-   m_symbol_table = NULL;
-   m_func_info = NULL;
-   m_hw_tid = -1;
-   m_hw_wid = -1;
-   m_hw_sid = -1;
-   m_last_dram_callback.function = NULL;
-   m_last_dram_callback.instruction = NULL;
-   m_regs.push_back( reg_map_t() );
-   m_debug_trace_regs_modified.push_back( reg_map_t() );
-   m_debug_trace_regs_read.push_back( reg_map_t() );
-   m_callstack.push_back( stack_entry() );
-   m_RPC = -1;
-   m_RPC_updated = false;
-   m_last_was_call = false;
-   m_enable_debug_trace = false;
-   m_local_mem_stack_pointer = 0;
-   m_gpu = NULL;
-   m_last_set_operand_value=ptx_reg_t();
-}
-
-const ptx_version &ptx_thread_info::get_ptx_version() const 
-{ 
-   return m_func_info->get_ptx_version(); 
-}
-
-void ptx_thread_info::set_done() 
-{
-   assert( !m_at_barrier );
-   m_thread_done = true;
-   m_cycle_done = m_gpu->gpu_sim_cycle;
-}
-
-unsigned ptx_thread_info::get_builtin( int builtin_id, unsigned dim_mod ) 
-{
-   assert( m_valid );
-   switch ((builtin_id&0xFFFF)) {
-   case CLOCK_REG:
+unsigned ptx_thread_info::get_builtin(int builtin_id, unsigned dim_mod) {
+  assert(m_valid);
+  switch ((builtin_id & 0xFFFF)) {
+    case CLOCK_REG:
       return (unsigned)(m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-   case CLOCK64_REG:
-      abort(); // change return value to unsigned long long?
-	  // GPGPUSim clock is 4 times slower - multiply by 4
-	   return (m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle)*4;
-   case HALFCLOCK_ID:
+    case CLOCK64_REG:
+      abort();  // change return value to unsigned long long?
+                // GPGPUSim clock is 4 times slower - multiply by 4
+      return (m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle) * 4;
+    case HALFCLOCK_ID:
       // GPGPUSim clock is 4 times slower - multiply by 4
-	  // Hardware clock counter is incremented at half the shader clock frequency - divide by 2 (Henry '10)
-      return (m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle)*2;
-   case CTAID_REG:
-      assert( dim_mod < 3 );
-      if( dim_mod == 0 ) return m_ctaid.x;
-      if( dim_mod == 1 ) return m_ctaid.y;
-      if( dim_mod == 2 ) return m_ctaid.z;
+      // Hardware clock counter is incremented at half the shader clock
+      // frequency - divide by 2 (Henry '10)
+      return (m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle) * 2;
+    case CTAID_REG:
+      assert(dim_mod < 3);
+      if (dim_mod == 0) return m_ctaid.x;
+      if (dim_mod == 1) return m_ctaid.y;
+      if (dim_mod == 2) return m_ctaid.z;
       abort();
       break;
-   case ENVREG_REG:{
-	int index = builtin_id >> 16;
-	dim3 gdim = this->get_core()->get_kernel_info()->get_grid_dim();
-		switch(index){
-		case 0:
-		case 1:
-		case 2:
-		case 3:
-		case 4:
-		case 5:
-			return 0;
-			break;
-		case 6:
-			return gdim.x;
-		case 7:
-			return gdim.y;
-		case 8:
-			return gdim.z;
-		case 9:
-			if(gdim.z == 1 && gdim.y == 1)
-				return 1;
-			else if(gdim.z == 1)
-				return 2;
-			else
-				return 3;
-			break;
-		default:
-			break;
-		}
-   }
-   case GRIDID_REG:
+    case ENVREG_REG: {
+      int index = builtin_id >> 16;
+      dim3 gdim = this->get_core()->get_kernel_info()->get_grid_dim();
+      switch (index) {
+        case 0:
+        case 1:
+        case 2:
+        case 3:
+        case 4:
+        case 5:
+          return 0;
+          break;
+        case 6:
+          return gdim.x;
+        case 7:
+          return gdim.y;
+        case 8:
+          return gdim.z;
+        case 9:
+          if (gdim.z == 1 && gdim.y == 1)
+            return 1;
+          else if (gdim.z == 1)
+            return 2;
+          else
+            return 3;
+          break;
+        default:
+          break;
+      }
+    }
+    case GRIDID_REG:
       return m_gridid;
-   case LANEID_REG: return get_hw_tid() % m_core->get_warp_size();
-   case LANEMASK_EQ_REG: feature_not_implemented( "%lanemask_eq" ); return 0;
-   case LANEMASK_LE_REG: feature_not_implemented( "%lanemask_le" ); return 0;
-   case LANEMASK_LT_REG: feature_not_implemented( "%lanemask_lt" ); return 0;
-   case LANEMASK_GE_REG: feature_not_implemented( "%lanemask_ge" ); return 0;
-   case LANEMASK_GT_REG: feature_not_implemented( "%lanemask_gt" ); return 0;
-   case NCTAID_REG:
-      assert( dim_mod < 3 );
-      if( dim_mod == 0 ) return m_nctaid.x;
-      if( dim_mod == 1 ) return m_nctaid.y;
-      if( dim_mod == 2 ) return m_nctaid.z;
+    case LANEID_REG:
+      return get_hw_tid() % m_core->get_warp_size();
+    case LANEMASK_EQ_REG:
+      feature_not_implemented("%lanemask_eq");
+      return 0;
+    case LANEMASK_LE_REG:
+      feature_not_implemented("%lanemask_le");
+      return 0;
+    case LANEMASK_LT_REG:
+      feature_not_implemented("%lanemask_lt");
+      return 0;
+    case LANEMASK_GE_REG:
+      feature_not_implemented("%lanemask_ge");
+      return 0;
+    case LANEMASK_GT_REG:
+      feature_not_implemented("%lanemask_gt");
+      return 0;
+    case NCTAID_REG:
+      assert(dim_mod < 3);
+      if (dim_mod == 0) return m_nctaid.x;
+      if (dim_mod == 1) return m_nctaid.y;
+      if (dim_mod == 2) return m_nctaid.z;
       abort();
       break;
-   case NTID_REG:
-      assert( dim_mod < 3 );
-      if( dim_mod == 0 ) return m_ntid.x;
-      if( dim_mod == 1 ) return m_ntid.y;
-      if( dim_mod == 2 ) return m_ntid.z;
+    case NTID_REG:
+      assert(dim_mod < 3);
+      if (dim_mod == 0) return m_ntid.x;
+      if (dim_mod == 1) return m_ntid.y;
+      if (dim_mod == 2) return m_ntid.z;
       abort();
       break;
-   case NWARPID_REG: feature_not_implemented( "%nwarpid" ); return 0;
-   case PM_REG: feature_not_implemented( "%pm" ); return 0;
-   case SMID_REG: feature_not_implemented( "%smid" ); return 0;
-   case TID_REG:
-      assert( dim_mod < 3 );
-      if( dim_mod == 0 ) return m_tid.x;
-      if( dim_mod == 1 ) return m_tid.y;
-      if( dim_mod == 2 ) return m_tid.z;
+    case NWARPID_REG:
+      feature_not_implemented("%nwarpid");
+      return 0;
+    case PM_REG:
+      feature_not_implemented("%pm");
+      return 0;
+    case SMID_REG:
+      feature_not_implemented("%smid");
+      return 0;
+    case TID_REG:
+      assert(dim_mod < 3);
+      if (dim_mod == 0) return m_tid.x;
+      if (dim_mod == 1) return m_tid.y;
+      if (dim_mod == 2) return m_tid.z;
       abort();
       break;
-   case WARPSZ_REG: return m_core->get_warp_size() ;
-   default:
+    case WARPSZ_REG:
+      return m_core->get_warp_size();
+    default:
       assert(0);
-   }
-   return 0;
+  }
+  return 0;
 }
 
-void ptx_thread_info::set_info( function_info *func ) 
-{
+void ptx_thread_info::set_info(function_info *func) {
   m_symbol_table = func->get_symtab();
   m_func_info = func;
   m_PC = func->get_start_PC();
 }
 
-void ptx_thread_info::cpy_tid_to_reg( dim3 tid )
-{
-   //copies %tid.x, %tid.y and %tid.z into $r0
-   ptx_reg_t data;
-   data.s64=0;
+void ptx_thread_info::cpy_tid_to_reg(dim3 tid) {
+  // copies %tid.x, %tid.y and %tid.z into $r0
+  ptx_reg_t data;
+  data.s64 = 0;
 
-   data.u32=(tid.x + (tid.y<<16) + (tid.z<<26));
+  data.u32 = (tid.x + (tid.y << 16) + (tid.z << 26));
 
-   const symbol *r0 = m_symbol_table->lookup("$r0");
-   if (r0){
-	   //No need to set pid if kernel doesn't use it
-	   set_reg(r0,data);
-   }
+  const symbol *r0 = m_symbol_table->lookup("$r0");
+  if (r0) {
+    // No need to set pid if kernel doesn't use it
+    set_reg(r0, data);
+  }
 }
 
-void ptx_thread_info::print_insn( unsigned pc, FILE * fp ) const
-{
-   m_func_info->print_insn(pc,fp);
+void ptx_thread_info::print_insn(unsigned pc, FILE *fp) const {
+  m_func_info->print_insn(pc, fp);
 }
 
-static void print_reg( FILE *fp, std::string name, ptx_reg_t value, symbol_table *symtab )
-{
-   const symbol *sym = symtab->lookup(name.c_str());
-   fprintf(fp,"  %8s   ", name.c_str() );
-   if( sym == NULL ) {
-      fprintf(fp,"<unknown type> 0x%llx\n", (unsigned long long ) value.u64 );
-      return;
-   }
-   const type_info *t = sym->type();
-   if( t == NULL ) {
-      fprintf(fp,"<unknown type> 0x%llx\n", (unsigned long long ) value.u64 );
-      return;
-   }
-   type_info_key ti = t->get_key();
+static void print_reg(FILE *fp, std::string name, ptx_reg_t value,
+                      symbol_table *symtab) {
+  const symbol *sym = symtab->lookup(name.c_str());
+  fprintf(fp, "  %8s   ", name.c_str());
+  if (sym == NULL) {
+    fprintf(fp, "<unknown type> 0x%llx\n", (unsigned long long)value.u64);
+    return;
+  }
+  const type_info *t = sym->type();
+  if (t == NULL) {
+    fprintf(fp, "<unknown type> 0x%llx\n", (unsigned long long)value.u64);
+    return;
+  }
+  type_info_key ti = t->get_key();
 
-   switch ( ti.scalar_type() ) {
-   case S8_TYPE:  fprintf(fp,".s8  %d\n", value.s8 );  break;
-   case S16_TYPE: fprintf(fp,".s16 %d\n", value.s16 ); break;
-   case S32_TYPE: fprintf(fp,".s32 %d\n", value.s32 ); break;
-   case S64_TYPE: fprintf(fp,".s64 %Ld\n", value.s64 ); break;
-   case U8_TYPE:  fprintf(fp,".u8  %u [0x%02x]\n", value.u8, (unsigned) value.u8 );  break;
-   case U16_TYPE: fprintf(fp,".u16 %u [0x%04x]\n", value.u16, (unsigned) value.u16 ); break;
-   case U32_TYPE: fprintf(fp,".u32 %u [0x%08x]\n", value.u32, (unsigned) value.u32 ); break;
-   case U64_TYPE: fprintf(fp,".u64 %llu [0x%llx]\n", value.u64, value.u64 ); break;
-   case F16_TYPE: fprintf(fp,".f16 %f [0x%04x]\n",  value.f16, (unsigned) value.u16 ); break;
-   case F32_TYPE: fprintf(fp,".f32 %.15lf [0x%08x]\n",  value.f32, value.u32 ); break;
-   case F64_TYPE: fprintf(fp,".f64 %.15le [0x%016llx]\n", value.f64, value.u64 ); break;
-   case B8_TYPE:  fprintf(fp,".b8  0x%02x\n",   (unsigned) value.u8 );  break;
-   case B16_TYPE: fprintf(fp,".b16 0x%04x\n",   (unsigned) value.u16 ); break;
-   case B32_TYPE: fprintf(fp,".b32 0x%08x\n", (unsigned) value.u32 ); break;
-   case B64_TYPE: fprintf(fp,".b64 0x%llx\n",    (unsigned long long ) value.u64 ); break;
-   case PRED_TYPE: fprintf(fp,".pred %u\n",     (unsigned) value.pred ); break;
-   default: 
-      fprintf( fp, "non-scalar type\n" );
+  switch (ti.scalar_type()) {
+    case S8_TYPE:
+      fprintf(fp, ".s8  %d\n", value.s8);
       break;
-   }
-   fflush(fp);
+    case S16_TYPE:
+      fprintf(fp, ".s16 %d\n", value.s16);
+      break;
+    case S32_TYPE:
+      fprintf(fp, ".s32 %d\n", value.s32);
+      break;
+    case S64_TYPE:
+      fprintf(fp, ".s64 %Ld\n", value.s64);
+      break;
+    case U8_TYPE:
+      fprintf(fp, ".u8  %u [0x%02x]\n", value.u8, (unsigned)value.u8);
+      break;
+    case U16_TYPE:
+      fprintf(fp, ".u16 %u [0x%04x]\n", value.u16, (unsigned)value.u16);
+      break;
+    case U32_TYPE:
+      fprintf(fp, ".u32 %u [0x%08x]\n", value.u32, (unsigned)value.u32);
+      break;
+    case U64_TYPE:
+      fprintf(fp, ".u64 %llu [0x%llx]\n", value.u64, value.u64);
+      break;
+    case F16_TYPE:
+      fprintf(fp, ".f16 %f [0x%04x]\n", value.f16, (unsigned)value.u16);
+      break;
+    case F32_TYPE:
+      fprintf(fp, ".f32 %.15lf [0x%08x]\n", value.f32, value.u32);
+      break;
+    case F64_TYPE:
+      fprintf(fp, ".f64 %.15le [0x%016llx]\n", value.f64, value.u64);
+      break;
+    case B8_TYPE:
+      fprintf(fp, ".b8  0x%02x\n", (unsigned)value.u8);
+      break;
+    case B16_TYPE:
+      fprintf(fp, ".b16 0x%04x\n", (unsigned)value.u16);
+      break;
+    case B32_TYPE:
+      fprintf(fp, ".b32 0x%08x\n", (unsigned)value.u32);
+      break;
+    case B64_TYPE:
+      fprintf(fp, ".b64 0x%llx\n", (unsigned long long)value.u64);
+      break;
+    case PRED_TYPE:
+      fprintf(fp, ".pred %u\n", (unsigned)value.pred);
+      break;
+    default:
+      fprintf(fp, "non-scalar type\n");
+      break;
+  }
+  fflush(fp);
 }
 
-static void print_reg( std::string name, ptx_reg_t value, symbol_table *symtab )
-{
-   print_reg(stdout,name,value,symtab);
+static void print_reg(std::string name, ptx_reg_t value, symbol_table *symtab) {
+  print_reg(stdout, name, value, symtab);
 }
 
-void ptx_thread_info::callstack_push( unsigned pc, unsigned rpc, const symbol *return_var_src, const symbol *return_var_dst, unsigned call_uid )
-{
-   m_RPC = -1;
-   m_RPC_updated = true;
-   m_last_was_call = true;
-   assert( m_func_info != NULL );
-   m_callstack.push_back( stack_entry(m_symbol_table,m_func_info,pc,rpc,return_var_src,return_var_dst,call_uid) );
-   m_regs.push_back( reg_map_t() );
-   m_debug_trace_regs_modified.push_back( reg_map_t() );
-   m_debug_trace_regs_read.push_back( reg_map_t() );
-   m_local_mem_stack_pointer += m_func_info->local_mem_framesize(); 
+void ptx_thread_info::callstack_push(unsigned pc, unsigned rpc,
+                                     const symbol *return_var_src,
+                                     const symbol *return_var_dst,
+                                     unsigned call_uid) {
+  m_RPC = -1;
+  m_RPC_updated = true;
+  m_last_was_call = true;
+  assert(m_func_info != NULL);
+  m_callstack.push_back(stack_entry(m_symbol_table, m_func_info, pc, rpc,
+                                    return_var_src, return_var_dst, call_uid));
+  m_regs.push_back(reg_map_t());
+  m_debug_trace_regs_modified.push_back(reg_map_t());
+  m_debug_trace_regs_read.push_back(reg_map_t());
+  m_local_mem_stack_pointer += m_func_info->local_mem_framesize();
 }
 
-//ptxplus version of callstack_push.
-void ptx_thread_info::callstack_push_plus( unsigned pc, unsigned rpc, const symbol *return_var_src, const symbol *return_var_dst, unsigned call_uid )
-{
-   m_RPC = -1;
-   m_RPC_updated = true;
-   m_last_was_call = true;
-   assert( m_func_info != NULL );
-   m_callstack.push_back( stack_entry(m_symbol_table,m_func_info,pc,rpc,return_var_src,return_var_dst,call_uid) );
-   //m_regs.push_back( reg_map_t() );
-   //m_debug_trace_regs_modified.push_back( reg_map_t() );
-   //m_debug_trace_regs_read.push_back( reg_map_t() );
-   m_local_mem_stack_pointer += m_func_info->local_mem_framesize();
+// ptxplus version of callstack_push.
+void ptx_thread_info::callstack_push_plus(unsigned pc, unsigned rpc,
+                                          const symbol *return_var_src,
+                                          const symbol *return_var_dst,
+                                          unsigned call_uid) {
+  m_RPC = -1;
+  m_RPC_updated = true;
+  m_last_was_call = true;
+  assert(m_func_info != NULL);
+  m_callstack.push_back(stack_entry(m_symbol_table, m_func_info, pc, rpc,
+                                    return_var_src, return_var_dst, call_uid));
+  // m_regs.push_back( reg_map_t() );
+  // m_debug_trace_regs_modified.push_back( reg_map_t() );
+  // m_debug_trace_regs_read.push_back( reg_map_t() );
+  m_local_mem_stack_pointer += m_func_info->local_mem_framesize();
 }
 
+bool ptx_thread_info::callstack_pop() {
+  const symbol *rv_src = m_callstack.back().m_return_var_src;
+  const symbol *rv_dst = m_callstack.back().m_return_var_dst;
+  assert(!((rv_src != NULL) ^
+           (rv_dst != NULL)));  // ensure caller and callee agree on whether
+                                // there is a return value
 
-bool ptx_thread_info::callstack_pop()
-{
-   const symbol *rv_src = m_callstack.back().m_return_var_src;
-   const symbol *rv_dst = m_callstack.back().m_return_var_dst;
-   assert( !((rv_src != NULL) ^ (rv_dst != NULL)) ); // ensure caller and callee agree on whether there is a return value
+  // read return value from callee frame
+  arg_buffer_t buffer(m_gpu->gpgpu_ctx);
+  if (rv_src != NULL)
+    buffer = copy_arg_to_buffer(this, operand_info(rv_src, m_gpu->gpgpu_ctx),
+                                rv_dst);
 
-   // read return value from callee frame
-   arg_buffer_t buffer(m_gpu->gpgpu_ctx);
-   if( rv_src != NULL ) 
-      buffer = copy_arg_to_buffer(this, operand_info(rv_src, m_gpu->gpgpu_ctx), rv_dst );
+  m_symbol_table = m_callstack.back().m_symbol_table;
+  m_NPC = m_callstack.back().m_PC;
+  m_RPC_updated = true;
+  m_last_was_call = false;
+  m_RPC = m_callstack.back().m_RPC;
+  m_func_info = m_callstack.back().m_func_info;
+  if (m_func_info) {
+    assert(m_local_mem_stack_pointer >= m_func_info->local_mem_framesize());
+    m_local_mem_stack_pointer -= m_func_info->local_mem_framesize();
+  }
+  m_callstack.pop_back();
+  m_regs.pop_back();
+  m_debug_trace_regs_modified.pop_back();
+  m_debug_trace_regs_read.pop_back();
 
-   m_symbol_table = m_callstack.back().m_symbol_table;
-   m_NPC = m_callstack.back().m_PC;
-   m_RPC_updated = true;
-   m_last_was_call = false;
-   m_RPC = m_callstack.back().m_RPC;
-   m_func_info = m_callstack.back().m_func_info;
-   if( m_func_info ) {
-      assert( m_local_mem_stack_pointer >= m_func_info->local_mem_framesize() );
-      m_local_mem_stack_pointer -= m_func_info->local_mem_framesize(); 
-   }
-   m_callstack.pop_back();
-   m_regs.pop_back();
-   m_debug_trace_regs_modified.pop_back();
-   m_debug_trace_regs_read.pop_back();
+  // write return value into caller frame
+  if (rv_dst != NULL) copy_buffer_to_frame(this, buffer);
 
-   // write return value into caller frame
-   if( rv_dst != NULL ) 
-      copy_buffer_to_frame(this, buffer);
-
-   return m_callstack.empty();
+  return m_callstack.empty();
 }
 
-//ptxplus version of callstack_pop
-bool ptx_thread_info::callstack_pop_plus()
-{
-   const symbol *rv_src = m_callstack.back().m_return_var_src;
-   const symbol *rv_dst = m_callstack.back().m_return_var_dst;
-   assert( !((rv_src != NULL) ^ (rv_dst != NULL)) ); // ensure caller and callee agree on whether there is a return value
+// ptxplus version of callstack_pop
+bool ptx_thread_info::callstack_pop_plus() {
+  const symbol *rv_src = m_callstack.back().m_return_var_src;
+  const symbol *rv_dst = m_callstack.back().m_return_var_dst;
+  assert(!((rv_src != NULL) ^
+           (rv_dst != NULL)));  // ensure caller and callee agree on whether
+                                // there is a return value
 
-   // read return value from callee frame
-   arg_buffer_t buffer(m_gpu->gpgpu_ctx);
-   if( rv_src != NULL )
-      buffer = copy_arg_to_buffer(this, operand_info(rv_src, m_gpu->gpgpu_ctx), rv_dst );
+  // read return value from callee frame
+  arg_buffer_t buffer(m_gpu->gpgpu_ctx);
+  if (rv_src != NULL)
+    buffer = copy_arg_to_buffer(this, operand_info(rv_src, m_gpu->gpgpu_ctx),
+                                rv_dst);
 
-   m_symbol_table = m_callstack.back().m_symbol_table;
-   m_NPC = m_callstack.back().m_PC;
-   m_RPC_updated = true;
-   m_last_was_call = false;
-   m_RPC = m_callstack.back().m_RPC;
-   m_func_info = m_callstack.back().m_func_info;
-   if( m_func_info ) {
-      assert( m_local_mem_stack_pointer >= m_func_info->local_mem_framesize() );
-      m_local_mem_stack_pointer -= m_func_info->local_mem_framesize();
-   }
-   m_callstack.pop_back();
-   //m_regs.pop_back();
-   //m_debug_trace_regs_modified.pop_back();
-   //m_debug_trace_regs_read.pop_back();
+  m_symbol_table = m_callstack.back().m_symbol_table;
+  m_NPC = m_callstack.back().m_PC;
+  m_RPC_updated = true;
+  m_last_was_call = false;
+  m_RPC = m_callstack.back().m_RPC;
+  m_func_info = m_callstack.back().m_func_info;
+  if (m_func_info) {
+    assert(m_local_mem_stack_pointer >= m_func_info->local_mem_framesize());
+    m_local_mem_stack_pointer -= m_func_info->local_mem_framesize();
+  }
+  m_callstack.pop_back();
+  // m_regs.pop_back();
+  // m_debug_trace_regs_modified.pop_back();
+  // m_debug_trace_regs_read.pop_back();
 
-   // write return value into caller frame
-   if( rv_dst != NULL )
-      copy_buffer_to_frame(this, buffer);
+  // write return value into caller frame
+  if (rv_dst != NULL) copy_buffer_to_frame(this, buffer);
 
-   return m_callstack.empty();
+  return m_callstack.empty();
 }
 
-void ptx_thread_info::dump_callstack() const
-{
-   std::list<stack_entry>::const_iterator c=m_callstack.begin();
-   std::list<reg_map_t>::const_iterator r=m_regs.begin();
+void ptx_thread_info::dump_callstack() const {
+  std::list<stack_entry>::const_iterator c = m_callstack.begin();
+  std::list<reg_map_t>::const_iterator r = m_regs.begin();
 
-   printf("\n\n");
-   printf("Call stack for thread uid = %u (sc=%u, hwtid=%u)\n", m_uid, m_hw_sid, m_hw_tid );
-   while( c != m_callstack.end() && r != m_regs.end() ) {
-      const stack_entry &c_e = *c;
-      const reg_map_t &regs = *r;
-      if( !c_e.m_valid ) {
-         printf("  <entry>                              #regs = %zu\n", regs.size() );
-      } else {
-         printf("  %20s  PC=%3u RV= (callee=\'%s\',caller=\'%s\') #regs = %zu\n", 
-                c_e.m_func_info->get_name().c_str(), c_e.m_PC, 
-                c_e.m_return_var_src->name().c_str(), 
-                c_e.m_return_var_dst->name().c_str(), 
-                regs.size() );
-      }
-      c++;
-      r++;
-   }
-   if( c != m_callstack.end() || r != m_regs.end() ) {
-      printf("  *** mismatch in m_regs and m_callstack sizes ***\n" );
-   }
-   printf("\n\n");
+  printf("\n\n");
+  printf("Call stack for thread uid = %u (sc=%u, hwtid=%u)\n", m_uid, m_hw_sid,
+         m_hw_tid);
+  while (c != m_callstack.end() && r != m_regs.end()) {
+    const stack_entry &c_e = *c;
+    const reg_map_t &regs = *r;
+    if (!c_e.m_valid) {
+      printf("  <entry>                              #regs = %zu\n",
+             regs.size());
+    } else {
+      printf("  %20s  PC=%3u RV= (callee=\'%s\',caller=\'%s\') #regs = %zu\n",
+             c_e.m_func_info->get_name().c_str(), c_e.m_PC,
+             c_e.m_return_var_src->name().c_str(),
+             c_e.m_return_var_dst->name().c_str(), regs.size());
+    }
+    c++;
+    r++;
+  }
+  if (c != m_callstack.end() || r != m_regs.end()) {
+    printf("  *** mismatch in m_regs and m_callstack sizes ***\n");
+  }
+  printf("\n\n");
 }
 
-std::string ptx_thread_info::get_location() const
-{
-   const ptx_instruction *pI = m_func_info->get_instruction(m_PC);
-   char buf[1024];
-   snprintf(buf,1024,"%s:%u", pI->source_file(), pI->source_line() );
-   return std::string(buf);
+std::string ptx_thread_info::get_location() const {
+  const ptx_instruction *pI = m_func_info->get_instruction(m_PC);
+  char buf[1024];
+  snprintf(buf, 1024, "%s:%u", pI->source_file(), pI->source_line());
+  return std::string(buf);
 }
 
-const ptx_instruction *ptx_thread_info::get_inst() const
-{
-   return m_func_info->get_instruction(m_PC);
+const ptx_instruction *ptx_thread_info::get_inst() const {
+  return m_func_info->get_instruction(m_PC);
 }
 
-const ptx_instruction *ptx_thread_info::get_inst( addr_t pc ) const
-{
-   return m_func_info->get_instruction(pc);
+const ptx_instruction *ptx_thread_info::get_inst(addr_t pc) const {
+  return m_func_info->get_instruction(pc);
 }
 
-void ptx_thread_info::dump_regs( FILE *fp )
-{
-   if(m_regs.empty()) return;
-   if(m_regs.back().empty()) return;
-   fprintf(fp,"Register File Contents:\n");
-   fflush(fp);
-   reg_map_t::const_iterator r;
-   for ( r=m_regs.back().begin(); r != m_regs.back().end(); ++r ) {
+void ptx_thread_info::dump_regs(FILE *fp) {
+  if (m_regs.empty()) return;
+  if (m_regs.back().empty()) return;
+  fprintf(fp, "Register File Contents:\n");
+  fflush(fp);
+  reg_map_t::const_iterator r;
+  for (r = m_regs.back().begin(); r != m_regs.back().end(); ++r) {
+    const symbol *sym = r->first;
+    ptx_reg_t value = r->second;
+    std::string name = sym->name();
+    print_reg(fp, name, value, m_symbol_table);
+  }
+}
+
+void ptx_thread_info::dump_modifiedregs(FILE *fp) {
+  if (!(m_debug_trace_regs_modified.empty() ||
+        m_debug_trace_regs_modified.back().empty())) {
+    fprintf(fp, "Output Registers:\n");
+    fflush(fp);
+    reg_map_t::iterator r;
+    for (r = m_debug_trace_regs_modified.back().begin();
+         r != m_debug_trace_regs_modified.back().end(); ++r) {
       const symbol *sym = r->first;
-      ptx_reg_t value = r->second;
       std::string name = sym->name();
-      print_reg(fp,name,value,m_symbol_table);
-   }
+      ptx_reg_t value = r->second;
+      print_reg(fp, name, value, m_symbol_table);
+    }
+  }
+  if (!(m_debug_trace_regs_read.empty() ||
+        m_debug_trace_regs_read.back().empty())) {
+    fprintf(fp, "Input Registers:\n");
+    fflush(fp);
+    reg_map_t::iterator r;
+    for (r = m_debug_trace_regs_read.back().begin();
+         r != m_debug_trace_regs_read.back().end(); ++r) {
+      const symbol *sym = r->first;
+      std::string name = sym->name();
+      ptx_reg_t value = r->second;
+      print_reg(fp, name, value, m_symbol_table);
+    }
+  }
 }
 
-void ptx_thread_info::dump_modifiedregs(FILE *fp)
-{
-   if( !(m_debug_trace_regs_modified.empty() || 
-         m_debug_trace_regs_modified.back().empty()) ) { 
-      fprintf(fp,"Output Registers:\n");
-      fflush(fp);
-      reg_map_t::iterator r;
-      for ( r=m_debug_trace_regs_modified.back().begin(); r != m_debug_trace_regs_modified.back().end(); ++r ) {
-         const symbol *sym = r->first;
-         std::string name = sym->name();
-         ptx_reg_t value = r->second;
-         print_reg(fp,name,value,m_symbol_table);
-      }
-   }
-   if( !(m_debug_trace_regs_read.empty() ||
-         m_debug_trace_regs_read.back().empty()) ) { 
-      fprintf(fp,"Input Registers:\n");
-      fflush(fp);
-      reg_map_t::iterator r;
-      for ( r=m_debug_trace_regs_read.back().begin(); r != m_debug_trace_regs_read.back().end(); ++r ) {
-         const symbol *sym = r->first;
-         std::string name = sym->name();
-         ptx_reg_t value = r->second;
-         print_reg(fp,name,value,m_symbol_table);
-      }
-   }
+void ptx_thread_info::push_breakaddr(const operand_info &breakaddr) {
+  m_breakaddrs.push(breakaddr);
 }
 
-void ptx_thread_info::push_breakaddr(const operand_info &breakaddr) 
-{
-   m_breakaddrs.push(breakaddr);
+const operand_info &ptx_thread_info::pop_breakaddr() {
+  if (m_breakaddrs.empty()) {
+    printf("empty breakaddrs stack");
+    assert(0);
+  }
+  operand_info &breakaddr = m_breakaddrs.top();
+  m_breakaddrs.pop();
+  return breakaddr;
 }
 
-const operand_info& ptx_thread_info::pop_breakaddr() 
-{
-   if(m_breakaddrs.empty()) {
-      printf("empty breakaddrs stack");
-      assert(0);
-   }
-   operand_info& breakaddr = m_breakaddrs.top();
-   m_breakaddrs.pop();
-   return breakaddr;
+void ptx_thread_info::set_npc(const function_info *f) {
+  m_NPC = f->get_start_PC();
+  m_func_info = const_cast<function_info *>(f);
+  m_symbol_table = m_func_info->get_symtab();
 }
 
-void ptx_thread_info::set_npc( const function_info *f )
-{
-   m_NPC = f->get_start_PC();
-   m_func_info = const_cast<function_info*>( f );
-   m_symbol_table = m_func_info->get_symtab();
-}
-
-
-void feature_not_implemented( const char *f ) 
-{
-   printf("GPGPU-Sim: feature '%s' not supported\n", f );
-   abort();
+void feature_not_implemented(const char *f) {
+  printf("GPGPU-Sim: feature '%s' not supported\n", f);
+  abort();
 }

--- a/src/cuda-sim/ptx_sim.cc
+++ b/src/cuda-sim/ptx_sim.cc
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -31,588 +29,573 @@
 #include <string>
 #include "ptx_ir.h"
 class ptx_recognizer;
-typedef void *yyscan_t;
-#include "../../libcuda/gpgpu_context.h"
+typedef void * yyscan_t;
+#include "ptx.tab.h"
 #include "../gpgpu-sim/gpu-sim.h"
 #include "../gpgpu-sim/shader.h"
-#include "ptx.tab.h"
+#include "../../libcuda/gpgpu_context.h"
 
-void feature_not_implemented(const char *f);
+void feature_not_implemented( const char *f );
 
-ptx_cta_info::ptx_cta_info(unsigned sm_idx, gpgpu_context *ctx) {
-  assert(ctx->func_sim->g_ptx_cta_info_sm_idx_used.find(sm_idx) ==
-         ctx->func_sim->g_ptx_cta_info_sm_idx_used.end());
-  ctx->func_sim->g_ptx_cta_info_sm_idx_used.insert(sm_idx);
 
-  m_sm_idx = sm_idx;
-  m_uid = (ctx->g_ptx_cta_info_uid)++;
-  m_bar_threads = 0;
-  gpgpu_ctx = ctx;
+ptx_cta_info::ptx_cta_info( unsigned sm_idx, gpgpu_context* ctx )
+{
+   assert( ctx->func_sim->g_ptx_cta_info_sm_idx_used.find(sm_idx) == ctx->func_sim->g_ptx_cta_info_sm_idx_used.end() );
+   ctx->func_sim->g_ptx_cta_info_sm_idx_used.insert(sm_idx);
+
+   m_sm_idx = sm_idx;
+   m_uid = (ctx->g_ptx_cta_info_uid)++;
+   m_bar_threads = 0;
+   gpgpu_ctx = ctx;
 }
 
-void ptx_cta_info::add_thread(ptx_thread_info *thd) {
-  m_threads_in_cta.insert(thd);
+void ptx_cta_info::add_thread( ptx_thread_info *thd )
+{
+   m_threads_in_cta.insert(thd);
 }
 
-unsigned ptx_cta_info::num_threads() const { return m_threads_in_cta.size(); }
+unsigned ptx_cta_info::num_threads() const
+{
+   return m_threads_in_cta.size();
+}
 
-void ptx_cta_info::check_cta_thread_status_and_reset() {
-  bool fail = false;
-  if (m_threads_that_have_exited.size() != m_threads_in_cta.size()) {
-    printf("\n\n");
-    printf(
-        "Execution error: Some threads still running in CTA during CTA "
-        "reallocation! (1)\n");
-    printf("   CTA uid = %Lu (sm_idx = %u) : %lu running out of %zu total\n",
-           m_uid, m_sm_idx,
-           (m_threads_in_cta.size() - m_threads_that_have_exited.size()),
-           m_threads_in_cta.size());
-    printf("   These are the threads that are still running:\n");
-    std::set<ptx_thread_info *>::iterator t_iter;
-    for (t_iter = m_threads_in_cta.begin(); t_iter != m_threads_in_cta.end();
-         ++t_iter) {
+void ptx_cta_info::check_cta_thread_status_and_reset()
+{
+   bool fail = false;
+   if ( m_threads_that_have_exited.size() != m_threads_in_cta.size() ) {
+      printf("\n\n");
+      printf("Execution error: Some threads still running in CTA during CTA reallocation! (1)\n");
+      printf("   CTA uid = %Lu (sm_idx = %u) : %lu running out of %zu total\n", 
+             m_uid, 
+             m_sm_idx,
+             (m_threads_in_cta.size() - m_threads_that_have_exited.size()), m_threads_in_cta.size() );
+      printf("   These are the threads that are still running:\n");
+      std::set<ptx_thread_info*>::iterator t_iter;
+      for ( t_iter=m_threads_in_cta.begin(); t_iter != m_threads_in_cta.end(); ++t_iter ) {
+         ptx_thread_info *t = *t_iter;
+         if ( m_threads_that_have_exited.find(t) == m_threads_that_have_exited.end() ) {
+            if ( m_dangling_pointers.find(t) != m_dangling_pointers.end() ) {
+               printf("       <thread deleted>\n");
+            } else {
+               printf("       [done=%c] : ", (t->is_done()?'Y':'N') );
+               t->print_insn( t->get_pc(), stdout );
+               printf("\n");
+            }
+         }
+      }
+      printf("\n\n");
+      fail = true;
+   }
+   if ( fail ) {
+      abort();
+   }
+
+   bool fail2 = false;
+   std::set<ptx_thread_info*>::iterator t_iter;
+   for ( t_iter=m_threads_in_cta.begin(); t_iter != m_threads_in_cta.end(); ++t_iter ) {
       ptx_thread_info *t = *t_iter;
-      if (m_threads_that_have_exited.find(t) ==
-          m_threads_that_have_exited.end()) {
-        if (m_dangling_pointers.find(t) != m_dangling_pointers.end()) {
-          printf("       <thread deleted>\n");
-        } else {
-          printf("       [done=%c] : ", (t->is_done() ? 'Y' : 'N'));
-          t->print_insn(t->get_pc(), stdout);
-          printf("\n");
-        }
+      if ( m_dangling_pointers.find(t) == m_dangling_pointers.end() ) {
+         if ( !t->is_done() ) {
+            if ( !fail2 ) {
+               printf("Execution error: Some threads still running in CTA during CTA reallocation! (2)\n");
+               printf("   CTA uid = %Lu (sm_idx = %u) :\n", m_uid, m_sm_idx );
+               fail2 = true;
+            }
+            printf("       ");
+            t->print_insn( t->get_pc(), stdout );
+            printf("\n");
+         }
       }
-    }
-    printf("\n\n");
-    fail = true;
-  }
-  if (fail) {
-    abort();
-  }
-
-  bool fail2 = false;
-  std::set<ptx_thread_info *>::iterator t_iter;
-  for (t_iter = m_threads_in_cta.begin(); t_iter != m_threads_in_cta.end();
-       ++t_iter) {
-    ptx_thread_info *t = *t_iter;
-    if (m_dangling_pointers.find(t) == m_dangling_pointers.end()) {
-      if (!t->is_done()) {
-        if (!fail2) {
-          printf(
-              "Execution error: Some threads still running in CTA during CTA "
-              "reallocation! (2)\n");
-          printf("   CTA uid = %Lu (sm_idx = %u) :\n", m_uid, m_sm_idx);
-          fail2 = true;
-        }
-        printf("       ");
-        t->print_insn(t->get_pc(), stdout);
-        printf("\n");
-      }
-    }
-  }
-  if (fail2) {
-    abort();
-  }
-  m_threads_in_cta.clear();
-  m_threads_that_have_exited.clear();
-  m_dangling_pointers.clear();
+   }
+   if ( fail2 ) {
+      abort();
+   }
+   m_threads_in_cta.clear();
+   m_threads_that_have_exited.clear();
+   m_dangling_pointers.clear();
 }
 
-void ptx_cta_info::register_thread_exit(ptx_thread_info *thd) {
-  assert(m_threads_that_have_exited.find(thd) ==
-         m_threads_that_have_exited.end());
-  m_threads_that_have_exited.insert(thd);
+void ptx_cta_info::register_thread_exit( ptx_thread_info *thd )
+{
+   assert( m_threads_that_have_exited.find(thd) == m_threads_that_have_exited.end() );
+   m_threads_that_have_exited.insert(thd);
 }
 
-void ptx_cta_info::register_deleted_thread(ptx_thread_info *thd) {
-  m_dangling_pointers.insert(thd);
+void ptx_cta_info::register_deleted_thread( ptx_thread_info *thd )
+{
+   m_dangling_pointers.insert(thd);
 }
 
-unsigned ptx_cta_info::get_sm_idx() const { return m_sm_idx; }
-
-unsigned ptx_cta_info::get_bar_threads() const { return m_bar_threads; }
-
-void ptx_cta_info::inc_bar_threads() { m_bar_threads++; }
-
-void ptx_cta_info::reset_bar_threads() { m_bar_threads = 0; }
-
-ptx_warp_info::ptx_warp_info() { reset_done_threads(); }
-
-unsigned ptx_warp_info::get_done_threads() const { return m_done_threads; }
-
-void ptx_warp_info::inc_done_threads() { m_done_threads++; }
-
-void ptx_warp_info::reset_done_threads() { m_done_threads = 0; }
-
-ptx_thread_info::~ptx_thread_info() {
-  m_gpu->gpgpu_ctx->func_sim->g_ptx_thread_info_delete_count++;
+unsigned ptx_cta_info::get_sm_idx() const
+{
+   return m_sm_idx;
 }
 
-ptx_thread_info::ptx_thread_info(kernel_info_t &kernel) : m_kernel(kernel) {
-  m_uid = kernel.entry()->gpgpu_ctx->func_sim->g_ptx_thread_info_uid_next++;
-  m_core = NULL;
-  m_barrier_num = -1;
-  m_at_barrier = false;
-  m_valid = false;
-  m_gridid = 0;
-  m_thread_done = false;
-  m_cycle_done = 0;
-  m_PC = 0;
-  m_icount = 0;
-  m_last_effective_address = 0;
-  m_last_memory_space = undefined_space;
-  m_branch_taken = 0;
-  m_shared_mem = NULL;
-  m_sstarr_mem = NULL;
-  m_warp_info = NULL;
-  m_cta_info = NULL;
-  m_local_mem = NULL;
-  m_symbol_table = NULL;
-  m_func_info = NULL;
-  m_hw_tid = -1;
-  m_hw_wid = -1;
-  m_hw_sid = -1;
-  m_last_dram_callback.function = NULL;
-  m_last_dram_callback.instruction = NULL;
-  m_regs.push_back(reg_map_t());
-  m_debug_trace_regs_modified.push_back(reg_map_t());
-  m_debug_trace_regs_read.push_back(reg_map_t());
-  m_callstack.push_back(stack_entry());
-  m_RPC = -1;
-  m_RPC_updated = false;
-  m_last_was_call = false;
-  m_enable_debug_trace = false;
-  m_local_mem_stack_pointer = 0;
-  m_gpu = NULL;
-  m_last_set_operand_value = ptx_reg_t();
+unsigned ptx_cta_info::get_bar_threads() const
+{
+   return m_bar_threads;
 }
 
-const ptx_version &ptx_thread_info::get_ptx_version() const {
-  return m_func_info->get_ptx_version();
+void ptx_cta_info::inc_bar_threads()
+{
+	m_bar_threads++;
 }
 
-void ptx_thread_info::set_done() {
-  assert(!m_at_barrier);
-  m_thread_done = true;
-  m_cycle_done = m_gpu->gpu_sim_cycle;
+void ptx_cta_info::reset_bar_threads()
+{
+	m_bar_threads = 0;
 }
 
-unsigned ptx_thread_info::get_builtin(int builtin_id, unsigned dim_mod) {
-  assert(m_valid);
-  switch ((builtin_id & 0xFFFF)) {
-    case CLOCK_REG:
+ptx_warp_info::ptx_warp_info()
+{
+	reset_done_threads();
+}
+
+unsigned ptx_warp_info::get_done_threads() const
+{
+	return m_done_threads;
+}
+
+void ptx_warp_info::inc_done_threads()
+{
+	m_done_threads++;
+}
+
+void ptx_warp_info::reset_done_threads()
+{
+	m_done_threads = 0;
+}
+
+
+ptx_thread_info::~ptx_thread_info()
+{
+   m_gpu->gpgpu_ctx->func_sim->g_ptx_thread_info_delete_count++;
+}
+
+ptx_thread_info::ptx_thread_info( kernel_info_t &kernel )
+    : m_kernel(kernel)
+{
+   m_uid = kernel.entry()->gpgpu_ctx->func_sim->g_ptx_thread_info_uid_next++;
+   m_core = NULL;
+   m_barrier_num = -1;
+   m_at_barrier = false;
+   m_valid = false;
+   m_gridid = 0;
+   m_thread_done = false;
+   m_cycle_done = 0;
+   m_PC=0;
+   m_icount = 0;
+   m_last_effective_address = 0;
+   m_last_memory_space = undefined_space; 
+   m_branch_taken = 0;
+   m_shared_mem = NULL;
+   m_sstarr_mem = NULL;
+   m_warp_info = NULL;
+   m_cta_info = NULL;
+   m_local_mem = NULL;
+   m_symbol_table = NULL;
+   m_func_info = NULL;
+   m_hw_tid = -1;
+   m_hw_wid = -1;
+   m_hw_sid = -1;
+   m_last_dram_callback.function = NULL;
+   m_last_dram_callback.instruction = NULL;
+   m_regs.push_back( reg_map_t() );
+   m_debug_trace_regs_modified.push_back( reg_map_t() );
+   m_debug_trace_regs_read.push_back( reg_map_t() );
+   m_callstack.push_back( stack_entry() );
+   m_RPC = -1;
+   m_RPC_updated = false;
+   m_last_was_call = false;
+   m_enable_debug_trace = false;
+   m_local_mem_stack_pointer = 0;
+   m_gpu = NULL;
+   m_last_set_operand_value=ptx_reg_t();
+}
+
+const ptx_version &ptx_thread_info::get_ptx_version() const 
+{ 
+   return m_func_info->get_ptx_version(); 
+}
+
+void ptx_thread_info::set_done() 
+{
+   assert( !m_at_barrier );
+   m_thread_done = true;
+   m_cycle_done = m_gpu->gpu_sim_cycle;
+}
+
+unsigned ptx_thread_info::get_builtin( int builtin_id, unsigned dim_mod ) 
+{
+   assert( m_valid );
+   switch ((builtin_id&0xFFFF)) {
+   case CLOCK_REG:
       return (unsigned)(m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-    case CLOCK64_REG:
-      abort();  // change return value to unsigned long long?
-                // GPGPUSim clock is 4 times slower - multiply by 4
-      return (m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle) * 4;
-    case HALFCLOCK_ID:
+   case CLOCK64_REG:
+      abort(); // change return value to unsigned long long?
+	  // GPGPUSim clock is 4 times slower - multiply by 4
+	   return (m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle)*4;
+   case HALFCLOCK_ID:
       // GPGPUSim clock is 4 times slower - multiply by 4
-      // Hardware clock counter is incremented at half the shader clock
-      // frequency - divide by 2 (Henry '10)
-      return (m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle) * 2;
-    case CTAID_REG:
-      assert(dim_mod < 3);
-      if (dim_mod == 0) return m_ctaid.x;
-      if (dim_mod == 1) return m_ctaid.y;
-      if (dim_mod == 2) return m_ctaid.z;
+	  // Hardware clock counter is incremented at half the shader clock frequency - divide by 2 (Henry '10)
+      return (m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle)*2;
+   case CTAID_REG:
+      assert( dim_mod < 3 );
+      if( dim_mod == 0 ) return m_ctaid.x;
+      if( dim_mod == 1 ) return m_ctaid.y;
+      if( dim_mod == 2 ) return m_ctaid.z;
       abort();
       break;
-    case ENVREG_REG: {
-      int index = builtin_id >> 16;
-      dim3 gdim = this->get_core()->get_kernel_info()->get_grid_dim();
-      switch (index) {
-        case 0:
-        case 1:
-        case 2:
-        case 3:
-        case 4:
-        case 5:
-          return 0;
-          break;
-        case 6:
-          return gdim.x;
-        case 7:
-          return gdim.y;
-        case 8:
-          return gdim.z;
-        case 9:
-          if (gdim.z == 1 && gdim.y == 1)
-            return 1;
-          else if (gdim.z == 1)
-            return 2;
-          else
-            return 3;
-          break;
-        default:
-          break;
-      }
-    }
-    case GRIDID_REG:
+   case ENVREG_REG:{
+	int index = builtin_id >> 16;
+	dim3 gdim = this->get_core()->get_kernel_info()->get_grid_dim();
+		switch(index){
+		case 0:
+		case 1:
+		case 2:
+		case 3:
+		case 4:
+		case 5:
+			return 0;
+			break;
+		case 6:
+			return gdim.x;
+		case 7:
+			return gdim.y;
+		case 8:
+			return gdim.z;
+		case 9:
+			if(gdim.z == 1 && gdim.y == 1)
+				return 1;
+			else if(gdim.z == 1)
+				return 2;
+			else
+				return 3;
+			break;
+		default:
+			break;
+		}
+   }
+   case GRIDID_REG:
       return m_gridid;
-    case LANEID_REG:
-      return get_hw_tid() % m_core->get_warp_size();
-    case LANEMASK_EQ_REG:
-      feature_not_implemented("%lanemask_eq");
-      return 0;
-    case LANEMASK_LE_REG:
-      feature_not_implemented("%lanemask_le");
-      return 0;
-    case LANEMASK_LT_REG:
-      feature_not_implemented("%lanemask_lt");
-      return 0;
-    case LANEMASK_GE_REG:
-      feature_not_implemented("%lanemask_ge");
-      return 0;
-    case LANEMASK_GT_REG:
-      feature_not_implemented("%lanemask_gt");
-      return 0;
-    case NCTAID_REG:
-      assert(dim_mod < 3);
-      if (dim_mod == 0) return m_nctaid.x;
-      if (dim_mod == 1) return m_nctaid.y;
-      if (dim_mod == 2) return m_nctaid.z;
+   case LANEID_REG: return get_hw_tid() % m_core->get_warp_size();
+   case LANEMASK_EQ_REG: feature_not_implemented( "%lanemask_eq" ); return 0;
+   case LANEMASK_LE_REG: feature_not_implemented( "%lanemask_le" ); return 0;
+   case LANEMASK_LT_REG: feature_not_implemented( "%lanemask_lt" ); return 0;
+   case LANEMASK_GE_REG: feature_not_implemented( "%lanemask_ge" ); return 0;
+   case LANEMASK_GT_REG: feature_not_implemented( "%lanemask_gt" ); return 0;
+   case NCTAID_REG:
+      assert( dim_mod < 3 );
+      if( dim_mod == 0 ) return m_nctaid.x;
+      if( dim_mod == 1 ) return m_nctaid.y;
+      if( dim_mod == 2 ) return m_nctaid.z;
       abort();
       break;
-    case NTID_REG:
-      assert(dim_mod < 3);
-      if (dim_mod == 0) return m_ntid.x;
-      if (dim_mod == 1) return m_ntid.y;
-      if (dim_mod == 2) return m_ntid.z;
+   case NTID_REG:
+      assert( dim_mod < 3 );
+      if( dim_mod == 0 ) return m_ntid.x;
+      if( dim_mod == 1 ) return m_ntid.y;
+      if( dim_mod == 2 ) return m_ntid.z;
       abort();
       break;
-    case NWARPID_REG:
-      feature_not_implemented("%nwarpid");
-      return 0;
-    case PM_REG:
-      feature_not_implemented("%pm");
-      return 0;
-    case SMID_REG:
-      feature_not_implemented("%smid");
-      return 0;
-    case TID_REG:
-      assert(dim_mod < 3);
-      if (dim_mod == 0) return m_tid.x;
-      if (dim_mod == 1) return m_tid.y;
-      if (dim_mod == 2) return m_tid.z;
+   case NWARPID_REG: feature_not_implemented( "%nwarpid" ); return 0;
+   case PM_REG: feature_not_implemented( "%pm" ); return 0;
+   case SMID_REG: feature_not_implemented( "%smid" ); return 0;
+   case TID_REG:
+      assert( dim_mod < 3 );
+      if( dim_mod == 0 ) return m_tid.x;
+      if( dim_mod == 1 ) return m_tid.y;
+      if( dim_mod == 2 ) return m_tid.z;
       abort();
       break;
-    case WARPSZ_REG:
-      return m_core->get_warp_size();
-    default:
+   case WARPSZ_REG: return m_core->get_warp_size() ;
+   default:
       assert(0);
-  }
-  return 0;
+   }
+   return 0;
 }
 
-void ptx_thread_info::set_info(function_info *func) {
+void ptx_thread_info::set_info( function_info *func ) 
+{
   m_symbol_table = func->get_symtab();
   m_func_info = func;
   m_PC = func->get_start_PC();
 }
 
-void ptx_thread_info::cpy_tid_to_reg(dim3 tid) {
-  // copies %tid.x, %tid.y and %tid.z into $r0
-  ptx_reg_t data;
-  data.s64 = 0;
+void ptx_thread_info::cpy_tid_to_reg( dim3 tid )
+{
+   //copies %tid.x, %tid.y and %tid.z into $r0
+   ptx_reg_t data;
+   data.s64=0;
 
-  data.u32 = (tid.x + (tid.y << 16) + (tid.z << 26));
+   data.u32=(tid.x + (tid.y<<16) + (tid.z<<26));
 
-  const symbol *r0 = m_symbol_table->lookup("$r0");
-  if (r0) {
-    // No need to set pid if kernel doesn't use it
-    set_reg(r0, data);
-  }
+   const symbol *r0 = m_symbol_table->lookup("$r0");
+   if (r0){
+	   //No need to set pid if kernel doesn't use it
+	   set_reg(r0,data);
+   }
 }
 
-void ptx_thread_info::print_insn(unsigned pc, FILE *fp) const {
-  m_func_info->print_insn(pc, fp);
+void ptx_thread_info::print_insn( unsigned pc, FILE * fp ) const
+{
+   m_func_info->print_insn(pc,fp);
 }
 
-static void print_reg(FILE *fp, std::string name, ptx_reg_t value,
-                      symbol_table *symtab) {
-  const symbol *sym = symtab->lookup(name.c_str());
-  fprintf(fp, "  %8s   ", name.c_str());
-  if (sym == NULL) {
-    fprintf(fp, "<unknown type> 0x%llx\n", (unsigned long long)value.u64);
-    return;
-  }
-  const type_info *t = sym->type();
-  if (t == NULL) {
-    fprintf(fp, "<unknown type> 0x%llx\n", (unsigned long long)value.u64);
-    return;
-  }
-  type_info_key ti = t->get_key();
+static void print_reg( FILE *fp, std::string name, ptx_reg_t value, symbol_table *symtab )
+{
+   const symbol *sym = symtab->lookup(name.c_str());
+   fprintf(fp,"  %8s   ", name.c_str() );
+   if( sym == NULL ) {
+      fprintf(fp,"<unknown type> 0x%llx\n", (unsigned long long ) value.u64 );
+      return;
+   }
+   const type_info *t = sym->type();
+   if( t == NULL ) {
+      fprintf(fp,"<unknown type> 0x%llx\n", (unsigned long long ) value.u64 );
+      return;
+   }
+   type_info_key ti = t->get_key();
 
-  switch (ti.scalar_type()) {
-    case S8_TYPE:
-      fprintf(fp, ".s8  %d\n", value.s8);
+   switch ( ti.scalar_type() ) {
+   case S8_TYPE:  fprintf(fp,".s8  %d\n", value.s8 );  break;
+   case S16_TYPE: fprintf(fp,".s16 %d\n", value.s16 ); break;
+   case S32_TYPE: fprintf(fp,".s32 %d\n", value.s32 ); break;
+   case S64_TYPE: fprintf(fp,".s64 %Ld\n", value.s64 ); break;
+   case U8_TYPE:  fprintf(fp,".u8  %u [0x%02x]\n", value.u8, (unsigned) value.u8 );  break;
+   case U16_TYPE: fprintf(fp,".u16 %u [0x%04x]\n", value.u16, (unsigned) value.u16 ); break;
+   case U32_TYPE: fprintf(fp,".u32 %u [0x%08x]\n", value.u32, (unsigned) value.u32 ); break;
+   case U64_TYPE: fprintf(fp,".u64 %llu [0x%llx]\n", value.u64, value.u64 ); break;
+   case F16_TYPE: fprintf(fp,".f16 %f [0x%04x]\n",  value.f16, (unsigned) value.u16 ); break;
+   case F32_TYPE: fprintf(fp,".f32 %.15lf [0x%08x]\n",  value.f32, value.u32 ); break;
+   case F64_TYPE: fprintf(fp,".f64 %.15le [0x%016llx]\n", value.f64, value.u64 ); break;
+   case B8_TYPE:  fprintf(fp,".b8  0x%02x\n",   (unsigned) value.u8 );  break;
+   case B16_TYPE: fprintf(fp,".b16 0x%04x\n",   (unsigned) value.u16 ); break;
+   case B32_TYPE: fprintf(fp,".b32 0x%08x\n", (unsigned) value.u32 ); break;
+   case B64_TYPE: fprintf(fp,".b64 0x%llx\n",    (unsigned long long ) value.u64 ); break;
+   case PRED_TYPE: fprintf(fp,".pred %u\n",     (unsigned) value.pred ); break;
+   default: 
+      fprintf( fp, "non-scalar type\n" );
       break;
-    case S16_TYPE:
-      fprintf(fp, ".s16 %d\n", value.s16);
-      break;
-    case S32_TYPE:
-      fprintf(fp, ".s32 %d\n", value.s32);
-      break;
-    case S64_TYPE:
-      fprintf(fp, ".s64 %Ld\n", value.s64);
-      break;
-    case U8_TYPE:
-      fprintf(fp, ".u8  %u [0x%02x]\n", value.u8, (unsigned)value.u8);
-      break;
-    case U16_TYPE:
-      fprintf(fp, ".u16 %u [0x%04x]\n", value.u16, (unsigned)value.u16);
-      break;
-    case U32_TYPE:
-      fprintf(fp, ".u32 %u [0x%08x]\n", value.u32, (unsigned)value.u32);
-      break;
-    case U64_TYPE:
-      fprintf(fp, ".u64 %llu [0x%llx]\n", value.u64, value.u64);
-      break;
-    case F16_TYPE:
-      fprintf(fp, ".f16 %f [0x%04x]\n", value.f16, (unsigned)value.u16);
-      break;
-    case F32_TYPE:
-      fprintf(fp, ".f32 %.15lf [0x%08x]\n", value.f32, value.u32);
-      break;
-    case F64_TYPE:
-      fprintf(fp, ".f64 %.15le [0x%016llx]\n", value.f64, value.u64);
-      break;
-    case B8_TYPE:
-      fprintf(fp, ".b8  0x%02x\n", (unsigned)value.u8);
-      break;
-    case B16_TYPE:
-      fprintf(fp, ".b16 0x%04x\n", (unsigned)value.u16);
-      break;
-    case B32_TYPE:
-      fprintf(fp, ".b32 0x%08x\n", (unsigned)value.u32);
-      break;
-    case B64_TYPE:
-      fprintf(fp, ".b64 0x%llx\n", (unsigned long long)value.u64);
-      break;
-    case PRED_TYPE:
-      fprintf(fp, ".pred %u\n", (unsigned)value.pred);
-      break;
-    default:
-      fprintf(fp, "non-scalar type\n");
-      break;
-  }
-  fflush(fp);
+   }
+   fflush(fp);
 }
 
-static void print_reg(std::string name, ptx_reg_t value, symbol_table *symtab) {
-  print_reg(stdout, name, value, symtab);
+static void print_reg( std::string name, ptx_reg_t value, symbol_table *symtab )
+{
+   print_reg(stdout,name,value,symtab);
 }
 
-void ptx_thread_info::callstack_push(unsigned pc, unsigned rpc,
-                                     const symbol *return_var_src,
-                                     const symbol *return_var_dst,
-                                     unsigned call_uid) {
-  m_RPC = -1;
-  m_RPC_updated = true;
-  m_last_was_call = true;
-  assert(m_func_info != NULL);
-  m_callstack.push_back(stack_entry(m_symbol_table, m_func_info, pc, rpc,
-                                    return_var_src, return_var_dst, call_uid));
-  m_regs.push_back(reg_map_t());
-  m_debug_trace_regs_modified.push_back(reg_map_t());
-  m_debug_trace_regs_read.push_back(reg_map_t());
-  m_local_mem_stack_pointer += m_func_info->local_mem_framesize();
+void ptx_thread_info::callstack_push( unsigned pc, unsigned rpc, const symbol *return_var_src, const symbol *return_var_dst, unsigned call_uid )
+{
+   m_RPC = -1;
+   m_RPC_updated = true;
+   m_last_was_call = true;
+   assert( m_func_info != NULL );
+   m_callstack.push_back( stack_entry(m_symbol_table,m_func_info,pc,rpc,return_var_src,return_var_dst,call_uid) );
+   m_regs.push_back( reg_map_t() );
+   m_debug_trace_regs_modified.push_back( reg_map_t() );
+   m_debug_trace_regs_read.push_back( reg_map_t() );
+   m_local_mem_stack_pointer += m_func_info->local_mem_framesize(); 
 }
 
-// ptxplus version of callstack_push.
-void ptx_thread_info::callstack_push_plus(unsigned pc, unsigned rpc,
-                                          const symbol *return_var_src,
-                                          const symbol *return_var_dst,
-                                          unsigned call_uid) {
-  m_RPC = -1;
-  m_RPC_updated = true;
-  m_last_was_call = true;
-  assert(m_func_info != NULL);
-  m_callstack.push_back(stack_entry(m_symbol_table, m_func_info, pc, rpc,
-                                    return_var_src, return_var_dst, call_uid));
-  // m_regs.push_back( reg_map_t() );
-  // m_debug_trace_regs_modified.push_back( reg_map_t() );
-  // m_debug_trace_regs_read.push_back( reg_map_t() );
-  m_local_mem_stack_pointer += m_func_info->local_mem_framesize();
+//ptxplus version of callstack_push.
+void ptx_thread_info::callstack_push_plus( unsigned pc, unsigned rpc, const symbol *return_var_src, const symbol *return_var_dst, unsigned call_uid )
+{
+   m_RPC = -1;
+   m_RPC_updated = true;
+   m_last_was_call = true;
+   assert( m_func_info != NULL );
+   m_callstack.push_back( stack_entry(m_symbol_table,m_func_info,pc,rpc,return_var_src,return_var_dst,call_uid) );
+   //m_regs.push_back( reg_map_t() );
+   //m_debug_trace_regs_modified.push_back( reg_map_t() );
+   //m_debug_trace_regs_read.push_back( reg_map_t() );
+   m_local_mem_stack_pointer += m_func_info->local_mem_framesize();
 }
 
-bool ptx_thread_info::callstack_pop() {
-  const symbol *rv_src = m_callstack.back().m_return_var_src;
-  const symbol *rv_dst = m_callstack.back().m_return_var_dst;
-  assert(!((rv_src != NULL) ^ (rv_dst != NULL)));  // ensure caller and callee
-                                                   // agree on whether there is
-                                                   // a return value
 
-  // read return value from callee frame
-  arg_buffer_t buffer(m_gpu->gpgpu_ctx);
-  if (rv_src != NULL)
-    buffer = copy_arg_to_buffer(this, operand_info(rv_src, m_gpu->gpgpu_ctx),
-                                rv_dst);
+bool ptx_thread_info::callstack_pop()
+{
+   const symbol *rv_src = m_callstack.back().m_return_var_src;
+   const symbol *rv_dst = m_callstack.back().m_return_var_dst;
+   assert( !((rv_src != NULL) ^ (rv_dst != NULL)) ); // ensure caller and callee agree on whether there is a return value
 
-  m_symbol_table = m_callstack.back().m_symbol_table;
-  m_NPC = m_callstack.back().m_PC;
-  m_RPC_updated = true;
-  m_last_was_call = false;
-  m_RPC = m_callstack.back().m_RPC;
-  m_func_info = m_callstack.back().m_func_info;
-  if (m_func_info) {
-    assert(m_local_mem_stack_pointer >= m_func_info->local_mem_framesize());
-    m_local_mem_stack_pointer -= m_func_info->local_mem_framesize();
-  }
-  m_callstack.pop_back();
-  m_regs.pop_back();
-  m_debug_trace_regs_modified.pop_back();
-  m_debug_trace_regs_read.pop_back();
+   // read return value from callee frame
+   arg_buffer_t buffer(m_gpu->gpgpu_ctx);
+   if( rv_src != NULL ) 
+      buffer = copy_arg_to_buffer(this, operand_info(rv_src, m_gpu->gpgpu_ctx), rv_dst );
 
-  // write return value into caller frame
-  if (rv_dst != NULL) copy_buffer_to_frame(this, buffer);
+   m_symbol_table = m_callstack.back().m_symbol_table;
+   m_NPC = m_callstack.back().m_PC;
+   m_RPC_updated = true;
+   m_last_was_call = false;
+   m_RPC = m_callstack.back().m_RPC;
+   m_func_info = m_callstack.back().m_func_info;
+   if( m_func_info ) {
+      assert( m_local_mem_stack_pointer >= m_func_info->local_mem_framesize() );
+      m_local_mem_stack_pointer -= m_func_info->local_mem_framesize(); 
+   }
+   m_callstack.pop_back();
+   m_regs.pop_back();
+   m_debug_trace_regs_modified.pop_back();
+   m_debug_trace_regs_read.pop_back();
 
-  return m_callstack.empty();
+   // write return value into caller frame
+   if( rv_dst != NULL ) 
+      copy_buffer_to_frame(this, buffer);
+
+   return m_callstack.empty();
 }
 
-// ptxplus version of callstack_pop
-bool ptx_thread_info::callstack_pop_plus() {
-  const symbol *rv_src = m_callstack.back().m_return_var_src;
-  const symbol *rv_dst = m_callstack.back().m_return_var_dst;
-  assert(!((rv_src != NULL) ^ (rv_dst != NULL)));  // ensure caller and callee
-                                                   // agree on whether there is
-                                                   // a return value
+//ptxplus version of callstack_pop
+bool ptx_thread_info::callstack_pop_plus()
+{
+   const symbol *rv_src = m_callstack.back().m_return_var_src;
+   const symbol *rv_dst = m_callstack.back().m_return_var_dst;
+   assert( !((rv_src != NULL) ^ (rv_dst != NULL)) ); // ensure caller and callee agree on whether there is a return value
 
-  // read return value from callee frame
-  arg_buffer_t buffer(m_gpu->gpgpu_ctx);
-  if (rv_src != NULL)
-    buffer = copy_arg_to_buffer(this, operand_info(rv_src, m_gpu->gpgpu_ctx),
-                                rv_dst);
+   // read return value from callee frame
+   arg_buffer_t buffer(m_gpu->gpgpu_ctx);
+   if( rv_src != NULL )
+      buffer = copy_arg_to_buffer(this, operand_info(rv_src, m_gpu->gpgpu_ctx), rv_dst );
 
-  m_symbol_table = m_callstack.back().m_symbol_table;
-  m_NPC = m_callstack.back().m_PC;
-  m_RPC_updated = true;
-  m_last_was_call = false;
-  m_RPC = m_callstack.back().m_RPC;
-  m_func_info = m_callstack.back().m_func_info;
-  if (m_func_info) {
-    assert(m_local_mem_stack_pointer >= m_func_info->local_mem_framesize());
-    m_local_mem_stack_pointer -= m_func_info->local_mem_framesize();
-  }
-  m_callstack.pop_back();
-  // m_regs.pop_back();
-  // m_debug_trace_regs_modified.pop_back();
-  // m_debug_trace_regs_read.pop_back();
+   m_symbol_table = m_callstack.back().m_symbol_table;
+   m_NPC = m_callstack.back().m_PC;
+   m_RPC_updated = true;
+   m_last_was_call = false;
+   m_RPC = m_callstack.back().m_RPC;
+   m_func_info = m_callstack.back().m_func_info;
+   if( m_func_info ) {
+      assert( m_local_mem_stack_pointer >= m_func_info->local_mem_framesize() );
+      m_local_mem_stack_pointer -= m_func_info->local_mem_framesize();
+   }
+   m_callstack.pop_back();
+   //m_regs.pop_back();
+   //m_debug_trace_regs_modified.pop_back();
+   //m_debug_trace_regs_read.pop_back();
 
-  // write return value into caller frame
-  if (rv_dst != NULL) copy_buffer_to_frame(this, buffer);
+   // write return value into caller frame
+   if( rv_dst != NULL )
+      copy_buffer_to_frame(this, buffer);
 
-  return m_callstack.empty();
+   return m_callstack.empty();
 }
 
-void ptx_thread_info::dump_callstack() const {
-  std::list<stack_entry>::const_iterator c = m_callstack.begin();
-  std::list<reg_map_t>::const_iterator r = m_regs.begin();
+void ptx_thread_info::dump_callstack() const
+{
+   std::list<stack_entry>::const_iterator c=m_callstack.begin();
+   std::list<reg_map_t>::const_iterator r=m_regs.begin();
 
-  printf("\n\n");
-  printf("Call stack for thread uid = %u (sc=%u, hwtid=%u)\n", m_uid, m_hw_sid,
-         m_hw_tid);
-  while (c != m_callstack.end() && r != m_regs.end()) {
-    const stack_entry &c_e = *c;
-    const reg_map_t &regs = *r;
-    if (!c_e.m_valid) {
-      printf("  <entry>                              #regs = %zu\n",
-             regs.size());
-    } else {
-      printf("  %20s  PC=%3u RV= (callee=\'%s\',caller=\'%s\') #regs = %zu\n",
-             c_e.m_func_info->get_name().c_str(), c_e.m_PC,
-             c_e.m_return_var_src->name().c_str(),
-             c_e.m_return_var_dst->name().c_str(), regs.size());
-    }
-    c++;
-    r++;
-  }
-  if (c != m_callstack.end() || r != m_regs.end()) {
-    printf("  *** mismatch in m_regs and m_callstack sizes ***\n");
-  }
-  printf("\n\n");
+   printf("\n\n");
+   printf("Call stack for thread uid = %u (sc=%u, hwtid=%u)\n", m_uid, m_hw_sid, m_hw_tid );
+   while( c != m_callstack.end() && r != m_regs.end() ) {
+      const stack_entry &c_e = *c;
+      const reg_map_t &regs = *r;
+      if( !c_e.m_valid ) {
+         printf("  <entry>                              #regs = %zu\n", regs.size() );
+      } else {
+         printf("  %20s  PC=%3u RV= (callee=\'%s\',caller=\'%s\') #regs = %zu\n", 
+                c_e.m_func_info->get_name().c_str(), c_e.m_PC, 
+                c_e.m_return_var_src->name().c_str(), 
+                c_e.m_return_var_dst->name().c_str(), 
+                regs.size() );
+      }
+      c++;
+      r++;
+   }
+   if( c != m_callstack.end() || r != m_regs.end() ) {
+      printf("  *** mismatch in m_regs and m_callstack sizes ***\n" );
+   }
+   printf("\n\n");
 }
 
-std::string ptx_thread_info::get_location() const {
-  const ptx_instruction *pI = m_func_info->get_instruction(m_PC);
-  char buf[1024];
-  snprintf(buf, 1024, "%s:%u", pI->source_file(), pI->source_line());
-  return std::string(buf);
+std::string ptx_thread_info::get_location() const
+{
+   const ptx_instruction *pI = m_func_info->get_instruction(m_PC);
+   char buf[1024];
+   snprintf(buf,1024,"%s:%u", pI->source_file(), pI->source_line() );
+   return std::string(buf);
 }
 
-const ptx_instruction *ptx_thread_info::get_inst() const {
-  return m_func_info->get_instruction(m_PC);
+const ptx_instruction *ptx_thread_info::get_inst() const
+{
+   return m_func_info->get_instruction(m_PC);
 }
 
-const ptx_instruction *ptx_thread_info::get_inst(addr_t pc) const {
-  return m_func_info->get_instruction(pc);
+const ptx_instruction *ptx_thread_info::get_inst( addr_t pc ) const
+{
+   return m_func_info->get_instruction(pc);
 }
 
-void ptx_thread_info::dump_regs(FILE *fp) {
-  if (m_regs.empty()) return;
-  if (m_regs.back().empty()) return;
-  fprintf(fp, "Register File Contents:\n");
-  fflush(fp);
-  reg_map_t::const_iterator r;
-  for (r = m_regs.back().begin(); r != m_regs.back().end(); ++r) {
-    const symbol *sym = r->first;
-    ptx_reg_t value = r->second;
-    std::string name = sym->name();
-    print_reg(fp, name, value, m_symbol_table);
-  }
-}
-
-void ptx_thread_info::dump_modifiedregs(FILE *fp) {
-  if (!(m_debug_trace_regs_modified.empty() ||
-        m_debug_trace_regs_modified.back().empty())) {
-    fprintf(fp, "Output Registers:\n");
-    fflush(fp);
-    reg_map_t::iterator r;
-    for (r = m_debug_trace_regs_modified.back().begin();
-         r != m_debug_trace_regs_modified.back().end(); ++r) {
+void ptx_thread_info::dump_regs( FILE *fp )
+{
+   if(m_regs.empty()) return;
+   if(m_regs.back().empty()) return;
+   fprintf(fp,"Register File Contents:\n");
+   fflush(fp);
+   reg_map_t::const_iterator r;
+   for ( r=m_regs.back().begin(); r != m_regs.back().end(); ++r ) {
       const symbol *sym = r->first;
-      std::string name = sym->name();
       ptx_reg_t value = r->second;
-      print_reg(fp, name, value, m_symbol_table);
-    }
-  }
-  if (!(m_debug_trace_regs_read.empty() ||
-        m_debug_trace_regs_read.back().empty())) {
-    fprintf(fp, "Input Registers:\n");
-    fflush(fp);
-    reg_map_t::iterator r;
-    for (r = m_debug_trace_regs_read.back().begin();
-         r != m_debug_trace_regs_read.back().end(); ++r) {
-      const symbol *sym = r->first;
       std::string name = sym->name();
-      ptx_reg_t value = r->second;
-      print_reg(fp, name, value, m_symbol_table);
-    }
-  }
+      print_reg(fp,name,value,m_symbol_table);
+   }
 }
 
-void ptx_thread_info::push_breakaddr(const operand_info &breakaddr) {
-  m_breakaddrs.push(breakaddr);
+void ptx_thread_info::dump_modifiedregs(FILE *fp)
+{
+   if( !(m_debug_trace_regs_modified.empty() || 
+         m_debug_trace_regs_modified.back().empty()) ) { 
+      fprintf(fp,"Output Registers:\n");
+      fflush(fp);
+      reg_map_t::iterator r;
+      for ( r=m_debug_trace_regs_modified.back().begin(); r != m_debug_trace_regs_modified.back().end(); ++r ) {
+         const symbol *sym = r->first;
+         std::string name = sym->name();
+         ptx_reg_t value = r->second;
+         print_reg(fp,name,value,m_symbol_table);
+      }
+   }
+   if( !(m_debug_trace_regs_read.empty() ||
+         m_debug_trace_regs_read.back().empty()) ) { 
+      fprintf(fp,"Input Registers:\n");
+      fflush(fp);
+      reg_map_t::iterator r;
+      for ( r=m_debug_trace_regs_read.back().begin(); r != m_debug_trace_regs_read.back().end(); ++r ) {
+         const symbol *sym = r->first;
+         std::string name = sym->name();
+         ptx_reg_t value = r->second;
+         print_reg(fp,name,value,m_symbol_table);
+      }
+   }
 }
 
-const operand_info &ptx_thread_info::pop_breakaddr() {
-  if (m_breakaddrs.empty()) {
-    printf("empty breakaddrs stack");
-    assert(0);
-  }
-  operand_info &breakaddr = m_breakaddrs.top();
-  m_breakaddrs.pop();
-  return breakaddr;
+void ptx_thread_info::push_breakaddr(const operand_info &breakaddr) 
+{
+   m_breakaddrs.push(breakaddr);
 }
 
-void ptx_thread_info::set_npc(const function_info *f) {
-  m_NPC = f->get_start_PC();
-  m_func_info = const_cast<function_info *>(f);
-  m_symbol_table = m_func_info->get_symtab();
+const operand_info& ptx_thread_info::pop_breakaddr() 
+{
+   if(m_breakaddrs.empty()) {
+      printf("empty breakaddrs stack");
+      assert(0);
+   }
+   operand_info& breakaddr = m_breakaddrs.top();
+   m_breakaddrs.pop();
+   return breakaddr;
 }
 
-void feature_not_implemented(const char *f) {
-  printf("GPGPU-Sim: feature '%s' not supported\n", f);
-  abort();
+void ptx_thread_info::set_npc( const function_info *f )
+{
+   m_NPC = f->get_start_PC();
+   m_func_info = const_cast<function_info*>( f );
+   m_symbol_table = m_func_info->get_symtab();
+}
+
+
+void feature_not_implemented( const char *f ) 
+{
+   printf("GPGPU-Sim: feature '%s' not supported\n", f );
+   abort();
 }

--- a/src/cuda-sim/ptx_sim.cc
+++ b/src/cuda-sim/ptx_sim.cc
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -29,573 +31,588 @@
 #include <string>
 #include "ptx_ir.h"
 class ptx_recognizer;
-typedef void * yyscan_t;
-#include "ptx.tab.h"
+typedef void *yyscan_t;
+#include "../../libcuda/gpgpu_context.h"
 #include "../gpgpu-sim/gpu-sim.h"
 #include "../gpgpu-sim/shader.h"
-#include "../../libcuda/gpgpu_context.h"
+#include "ptx.tab.h"
 
-void feature_not_implemented( const char *f );
+void feature_not_implemented(const char *f);
 
+ptx_cta_info::ptx_cta_info(unsigned sm_idx, gpgpu_context *ctx) {
+  assert(ctx->func_sim->g_ptx_cta_info_sm_idx_used.find(sm_idx) ==
+         ctx->func_sim->g_ptx_cta_info_sm_idx_used.end());
+  ctx->func_sim->g_ptx_cta_info_sm_idx_used.insert(sm_idx);
 
-ptx_cta_info::ptx_cta_info( unsigned sm_idx, gpgpu_context* ctx )
-{
-   assert( ctx->func_sim->g_ptx_cta_info_sm_idx_used.find(sm_idx) == ctx->func_sim->g_ptx_cta_info_sm_idx_used.end() );
-   ctx->func_sim->g_ptx_cta_info_sm_idx_used.insert(sm_idx);
-
-   m_sm_idx = sm_idx;
-   m_uid = (ctx->g_ptx_cta_info_uid)++;
-   m_bar_threads = 0;
-   gpgpu_ctx = ctx;
+  m_sm_idx = sm_idx;
+  m_uid = (ctx->g_ptx_cta_info_uid)++;
+  m_bar_threads = 0;
+  gpgpu_ctx = ctx;
 }
 
-void ptx_cta_info::add_thread( ptx_thread_info *thd )
-{
-   m_threads_in_cta.insert(thd);
+void ptx_cta_info::add_thread(ptx_thread_info *thd) {
+  m_threads_in_cta.insert(thd);
 }
 
-unsigned ptx_cta_info::num_threads() const
-{
-   return m_threads_in_cta.size();
-}
+unsigned ptx_cta_info::num_threads() const { return m_threads_in_cta.size(); }
 
-void ptx_cta_info::check_cta_thread_status_and_reset()
-{
-   bool fail = false;
-   if ( m_threads_that_have_exited.size() != m_threads_in_cta.size() ) {
-      printf("\n\n");
-      printf("Execution error: Some threads still running in CTA during CTA reallocation! (1)\n");
-      printf("   CTA uid = %Lu (sm_idx = %u) : %lu running out of %zu total\n", 
-             m_uid, 
-             m_sm_idx,
-             (m_threads_in_cta.size() - m_threads_that_have_exited.size()), m_threads_in_cta.size() );
-      printf("   These are the threads that are still running:\n");
-      std::set<ptx_thread_info*>::iterator t_iter;
-      for ( t_iter=m_threads_in_cta.begin(); t_iter != m_threads_in_cta.end(); ++t_iter ) {
-         ptx_thread_info *t = *t_iter;
-         if ( m_threads_that_have_exited.find(t) == m_threads_that_have_exited.end() ) {
-            if ( m_dangling_pointers.find(t) != m_dangling_pointers.end() ) {
-               printf("       <thread deleted>\n");
-            } else {
-               printf("       [done=%c] : ", (t->is_done()?'Y':'N') );
-               t->print_insn( t->get_pc(), stdout );
-               printf("\n");
-            }
-         }
-      }
-      printf("\n\n");
-      fail = true;
-   }
-   if ( fail ) {
-      abort();
-   }
-
-   bool fail2 = false;
-   std::set<ptx_thread_info*>::iterator t_iter;
-   for ( t_iter=m_threads_in_cta.begin(); t_iter != m_threads_in_cta.end(); ++t_iter ) {
+void ptx_cta_info::check_cta_thread_status_and_reset() {
+  bool fail = false;
+  if (m_threads_that_have_exited.size() != m_threads_in_cta.size()) {
+    printf("\n\n");
+    printf(
+        "Execution error: Some threads still running in CTA during CTA "
+        "reallocation! (1)\n");
+    printf("   CTA uid = %Lu (sm_idx = %u) : %lu running out of %zu total\n",
+           m_uid, m_sm_idx,
+           (m_threads_in_cta.size() - m_threads_that_have_exited.size()),
+           m_threads_in_cta.size());
+    printf("   These are the threads that are still running:\n");
+    std::set<ptx_thread_info *>::iterator t_iter;
+    for (t_iter = m_threads_in_cta.begin(); t_iter != m_threads_in_cta.end();
+         ++t_iter) {
       ptx_thread_info *t = *t_iter;
-      if ( m_dangling_pointers.find(t) == m_dangling_pointers.end() ) {
-         if ( !t->is_done() ) {
-            if ( !fail2 ) {
-               printf("Execution error: Some threads still running in CTA during CTA reallocation! (2)\n");
-               printf("   CTA uid = %Lu (sm_idx = %u) :\n", m_uid, m_sm_idx );
-               fail2 = true;
-            }
-            printf("       ");
-            t->print_insn( t->get_pc(), stdout );
-            printf("\n");
-         }
+      if (m_threads_that_have_exited.find(t) ==
+          m_threads_that_have_exited.end()) {
+        if (m_dangling_pointers.find(t) != m_dangling_pointers.end()) {
+          printf("       <thread deleted>\n");
+        } else {
+          printf("       [done=%c] : ", (t->is_done() ? 'Y' : 'N'));
+          t->print_insn(t->get_pc(), stdout);
+          printf("\n");
+        }
       }
-   }
-   if ( fail2 ) {
-      abort();
-   }
-   m_threads_in_cta.clear();
-   m_threads_that_have_exited.clear();
-   m_dangling_pointers.clear();
+    }
+    printf("\n\n");
+    fail = true;
+  }
+  if (fail) {
+    abort();
+  }
+
+  bool fail2 = false;
+  std::set<ptx_thread_info *>::iterator t_iter;
+  for (t_iter = m_threads_in_cta.begin(); t_iter != m_threads_in_cta.end();
+       ++t_iter) {
+    ptx_thread_info *t = *t_iter;
+    if (m_dangling_pointers.find(t) == m_dangling_pointers.end()) {
+      if (!t->is_done()) {
+        if (!fail2) {
+          printf(
+              "Execution error: Some threads still running in CTA during CTA "
+              "reallocation! (2)\n");
+          printf("   CTA uid = %Lu (sm_idx = %u) :\n", m_uid, m_sm_idx);
+          fail2 = true;
+        }
+        printf("       ");
+        t->print_insn(t->get_pc(), stdout);
+        printf("\n");
+      }
+    }
+  }
+  if (fail2) {
+    abort();
+  }
+  m_threads_in_cta.clear();
+  m_threads_that_have_exited.clear();
+  m_dangling_pointers.clear();
 }
 
-void ptx_cta_info::register_thread_exit( ptx_thread_info *thd )
-{
-   assert( m_threads_that_have_exited.find(thd) == m_threads_that_have_exited.end() );
-   m_threads_that_have_exited.insert(thd);
+void ptx_cta_info::register_thread_exit(ptx_thread_info *thd) {
+  assert(m_threads_that_have_exited.find(thd) ==
+         m_threads_that_have_exited.end());
+  m_threads_that_have_exited.insert(thd);
 }
 
-void ptx_cta_info::register_deleted_thread( ptx_thread_info *thd )
-{
-   m_dangling_pointers.insert(thd);
+void ptx_cta_info::register_deleted_thread(ptx_thread_info *thd) {
+  m_dangling_pointers.insert(thd);
 }
 
-unsigned ptx_cta_info::get_sm_idx() const
-{
-   return m_sm_idx;
+unsigned ptx_cta_info::get_sm_idx() const { return m_sm_idx; }
+
+unsigned ptx_cta_info::get_bar_threads() const { return m_bar_threads; }
+
+void ptx_cta_info::inc_bar_threads() { m_bar_threads++; }
+
+void ptx_cta_info::reset_bar_threads() { m_bar_threads = 0; }
+
+ptx_warp_info::ptx_warp_info() { reset_done_threads(); }
+
+unsigned ptx_warp_info::get_done_threads() const { return m_done_threads; }
+
+void ptx_warp_info::inc_done_threads() { m_done_threads++; }
+
+void ptx_warp_info::reset_done_threads() { m_done_threads = 0; }
+
+ptx_thread_info::~ptx_thread_info() {
+  m_gpu->gpgpu_ctx->func_sim->g_ptx_thread_info_delete_count++;
 }
 
-unsigned ptx_cta_info::get_bar_threads() const
-{
-   return m_bar_threads;
+ptx_thread_info::ptx_thread_info(kernel_info_t &kernel) : m_kernel(kernel) {
+  m_uid = kernel.entry()->gpgpu_ctx->func_sim->g_ptx_thread_info_uid_next++;
+  m_core = NULL;
+  m_barrier_num = -1;
+  m_at_barrier = false;
+  m_valid = false;
+  m_gridid = 0;
+  m_thread_done = false;
+  m_cycle_done = 0;
+  m_PC = 0;
+  m_icount = 0;
+  m_last_effective_address = 0;
+  m_last_memory_space = undefined_space;
+  m_branch_taken = 0;
+  m_shared_mem = NULL;
+  m_sstarr_mem = NULL;
+  m_warp_info = NULL;
+  m_cta_info = NULL;
+  m_local_mem = NULL;
+  m_symbol_table = NULL;
+  m_func_info = NULL;
+  m_hw_tid = -1;
+  m_hw_wid = -1;
+  m_hw_sid = -1;
+  m_last_dram_callback.function = NULL;
+  m_last_dram_callback.instruction = NULL;
+  m_regs.push_back(reg_map_t());
+  m_debug_trace_regs_modified.push_back(reg_map_t());
+  m_debug_trace_regs_read.push_back(reg_map_t());
+  m_callstack.push_back(stack_entry());
+  m_RPC = -1;
+  m_RPC_updated = false;
+  m_last_was_call = false;
+  m_enable_debug_trace = false;
+  m_local_mem_stack_pointer = 0;
+  m_gpu = NULL;
+  m_last_set_operand_value = ptx_reg_t();
 }
 
-void ptx_cta_info::inc_bar_threads()
-{
-	m_bar_threads++;
+const ptx_version &ptx_thread_info::get_ptx_version() const {
+  return m_func_info->get_ptx_version();
 }
 
-void ptx_cta_info::reset_bar_threads()
-{
-	m_bar_threads = 0;
+void ptx_thread_info::set_done() {
+  assert(!m_at_barrier);
+  m_thread_done = true;
+  m_cycle_done = m_gpu->gpu_sim_cycle;
 }
 
-ptx_warp_info::ptx_warp_info()
-{
-	reset_done_threads();
-}
-
-unsigned ptx_warp_info::get_done_threads() const
-{
-	return m_done_threads;
-}
-
-void ptx_warp_info::inc_done_threads()
-{
-	m_done_threads++;
-}
-
-void ptx_warp_info::reset_done_threads()
-{
-	m_done_threads = 0;
-}
-
-
-ptx_thread_info::~ptx_thread_info()
-{
-   m_gpu->gpgpu_ctx->func_sim->g_ptx_thread_info_delete_count++;
-}
-
-ptx_thread_info::ptx_thread_info( kernel_info_t &kernel )
-    : m_kernel(kernel)
-{
-   m_uid = kernel.entry()->gpgpu_ctx->func_sim->g_ptx_thread_info_uid_next++;
-   m_core = NULL;
-   m_barrier_num = -1;
-   m_at_barrier = false;
-   m_valid = false;
-   m_gridid = 0;
-   m_thread_done = false;
-   m_cycle_done = 0;
-   m_PC=0;
-   m_icount = 0;
-   m_last_effective_address = 0;
-   m_last_memory_space = undefined_space; 
-   m_branch_taken = 0;
-   m_shared_mem = NULL;
-   m_sstarr_mem = NULL;
-   m_warp_info = NULL;
-   m_cta_info = NULL;
-   m_local_mem = NULL;
-   m_symbol_table = NULL;
-   m_func_info = NULL;
-   m_hw_tid = -1;
-   m_hw_wid = -1;
-   m_hw_sid = -1;
-   m_last_dram_callback.function = NULL;
-   m_last_dram_callback.instruction = NULL;
-   m_regs.push_back( reg_map_t() );
-   m_debug_trace_regs_modified.push_back( reg_map_t() );
-   m_debug_trace_regs_read.push_back( reg_map_t() );
-   m_callstack.push_back( stack_entry() );
-   m_RPC = -1;
-   m_RPC_updated = false;
-   m_last_was_call = false;
-   m_enable_debug_trace = false;
-   m_local_mem_stack_pointer = 0;
-   m_gpu = NULL;
-   m_last_set_operand_value=ptx_reg_t();
-}
-
-const ptx_version &ptx_thread_info::get_ptx_version() const 
-{ 
-   return m_func_info->get_ptx_version(); 
-}
-
-void ptx_thread_info::set_done() 
-{
-   assert( !m_at_barrier );
-   m_thread_done = true;
-   m_cycle_done = m_gpu->gpu_sim_cycle;
-}
-
-unsigned ptx_thread_info::get_builtin( int builtin_id, unsigned dim_mod ) 
-{
-   assert( m_valid );
-   switch ((builtin_id&0xFFFF)) {
-   case CLOCK_REG:
+unsigned ptx_thread_info::get_builtin(int builtin_id, unsigned dim_mod) {
+  assert(m_valid);
+  switch ((builtin_id & 0xFFFF)) {
+    case CLOCK_REG:
       return (unsigned)(m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-   case CLOCK64_REG:
-      abort(); // change return value to unsigned long long?
-	  // GPGPUSim clock is 4 times slower - multiply by 4
-	   return (m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle)*4;
-   case HALFCLOCK_ID:
+    case CLOCK64_REG:
+      abort();  // change return value to unsigned long long?
+                // GPGPUSim clock is 4 times slower - multiply by 4
+      return (m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle) * 4;
+    case HALFCLOCK_ID:
       // GPGPUSim clock is 4 times slower - multiply by 4
-	  // Hardware clock counter is incremented at half the shader clock frequency - divide by 2 (Henry '10)
-      return (m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle)*2;
-   case CTAID_REG:
-      assert( dim_mod < 3 );
-      if( dim_mod == 0 ) return m_ctaid.x;
-      if( dim_mod == 1 ) return m_ctaid.y;
-      if( dim_mod == 2 ) return m_ctaid.z;
+      // Hardware clock counter is incremented at half the shader clock
+      // frequency - divide by 2 (Henry '10)
+      return (m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle) * 2;
+    case CTAID_REG:
+      assert(dim_mod < 3);
+      if (dim_mod == 0) return m_ctaid.x;
+      if (dim_mod == 1) return m_ctaid.y;
+      if (dim_mod == 2) return m_ctaid.z;
       abort();
       break;
-   case ENVREG_REG:{
-	int index = builtin_id >> 16;
-	dim3 gdim = this->get_core()->get_kernel_info()->get_grid_dim();
-		switch(index){
-		case 0:
-		case 1:
-		case 2:
-		case 3:
-		case 4:
-		case 5:
-			return 0;
-			break;
-		case 6:
-			return gdim.x;
-		case 7:
-			return gdim.y;
-		case 8:
-			return gdim.z;
-		case 9:
-			if(gdim.z == 1 && gdim.y == 1)
-				return 1;
-			else if(gdim.z == 1)
-				return 2;
-			else
-				return 3;
-			break;
-		default:
-			break;
-		}
-   }
-   case GRIDID_REG:
+    case ENVREG_REG: {
+      int index = builtin_id >> 16;
+      dim3 gdim = this->get_core()->get_kernel_info()->get_grid_dim();
+      switch (index) {
+        case 0:
+        case 1:
+        case 2:
+        case 3:
+        case 4:
+        case 5:
+          return 0;
+          break;
+        case 6:
+          return gdim.x;
+        case 7:
+          return gdim.y;
+        case 8:
+          return gdim.z;
+        case 9:
+          if (gdim.z == 1 && gdim.y == 1)
+            return 1;
+          else if (gdim.z == 1)
+            return 2;
+          else
+            return 3;
+          break;
+        default:
+          break;
+      }
+    }
+    case GRIDID_REG:
       return m_gridid;
-   case LANEID_REG: return get_hw_tid() % m_core->get_warp_size();
-   case LANEMASK_EQ_REG: feature_not_implemented( "%lanemask_eq" ); return 0;
-   case LANEMASK_LE_REG: feature_not_implemented( "%lanemask_le" ); return 0;
-   case LANEMASK_LT_REG: feature_not_implemented( "%lanemask_lt" ); return 0;
-   case LANEMASK_GE_REG: feature_not_implemented( "%lanemask_ge" ); return 0;
-   case LANEMASK_GT_REG: feature_not_implemented( "%lanemask_gt" ); return 0;
-   case NCTAID_REG:
-      assert( dim_mod < 3 );
-      if( dim_mod == 0 ) return m_nctaid.x;
-      if( dim_mod == 1 ) return m_nctaid.y;
-      if( dim_mod == 2 ) return m_nctaid.z;
+    case LANEID_REG:
+      return get_hw_tid() % m_core->get_warp_size();
+    case LANEMASK_EQ_REG:
+      feature_not_implemented("%lanemask_eq");
+      return 0;
+    case LANEMASK_LE_REG:
+      feature_not_implemented("%lanemask_le");
+      return 0;
+    case LANEMASK_LT_REG:
+      feature_not_implemented("%lanemask_lt");
+      return 0;
+    case LANEMASK_GE_REG:
+      feature_not_implemented("%lanemask_ge");
+      return 0;
+    case LANEMASK_GT_REG:
+      feature_not_implemented("%lanemask_gt");
+      return 0;
+    case NCTAID_REG:
+      assert(dim_mod < 3);
+      if (dim_mod == 0) return m_nctaid.x;
+      if (dim_mod == 1) return m_nctaid.y;
+      if (dim_mod == 2) return m_nctaid.z;
       abort();
       break;
-   case NTID_REG:
-      assert( dim_mod < 3 );
-      if( dim_mod == 0 ) return m_ntid.x;
-      if( dim_mod == 1 ) return m_ntid.y;
-      if( dim_mod == 2 ) return m_ntid.z;
+    case NTID_REG:
+      assert(dim_mod < 3);
+      if (dim_mod == 0) return m_ntid.x;
+      if (dim_mod == 1) return m_ntid.y;
+      if (dim_mod == 2) return m_ntid.z;
       abort();
       break;
-   case NWARPID_REG: feature_not_implemented( "%nwarpid" ); return 0;
-   case PM_REG: feature_not_implemented( "%pm" ); return 0;
-   case SMID_REG: feature_not_implemented( "%smid" ); return 0;
-   case TID_REG:
-      assert( dim_mod < 3 );
-      if( dim_mod == 0 ) return m_tid.x;
-      if( dim_mod == 1 ) return m_tid.y;
-      if( dim_mod == 2 ) return m_tid.z;
+    case NWARPID_REG:
+      feature_not_implemented("%nwarpid");
+      return 0;
+    case PM_REG:
+      feature_not_implemented("%pm");
+      return 0;
+    case SMID_REG:
+      feature_not_implemented("%smid");
+      return 0;
+    case TID_REG:
+      assert(dim_mod < 3);
+      if (dim_mod == 0) return m_tid.x;
+      if (dim_mod == 1) return m_tid.y;
+      if (dim_mod == 2) return m_tid.z;
       abort();
       break;
-   case WARPSZ_REG: return m_core->get_warp_size() ;
-   default:
+    case WARPSZ_REG:
+      return m_core->get_warp_size();
+    default:
       assert(0);
-   }
-   return 0;
+  }
+  return 0;
 }
 
-void ptx_thread_info::set_info( function_info *func ) 
-{
+void ptx_thread_info::set_info(function_info *func) {
   m_symbol_table = func->get_symtab();
   m_func_info = func;
   m_PC = func->get_start_PC();
 }
 
-void ptx_thread_info::cpy_tid_to_reg( dim3 tid )
-{
-   //copies %tid.x, %tid.y and %tid.z into $r0
-   ptx_reg_t data;
-   data.s64=0;
+void ptx_thread_info::cpy_tid_to_reg(dim3 tid) {
+  // copies %tid.x, %tid.y and %tid.z into $r0
+  ptx_reg_t data;
+  data.s64 = 0;
 
-   data.u32=(tid.x + (tid.y<<16) + (tid.z<<26));
+  data.u32 = (tid.x + (tid.y << 16) + (tid.z << 26));
 
-   const symbol *r0 = m_symbol_table->lookup("$r0");
-   if (r0){
-	   //No need to set pid if kernel doesn't use it
-	   set_reg(r0,data);
-   }
+  const symbol *r0 = m_symbol_table->lookup("$r0");
+  if (r0) {
+    // No need to set pid if kernel doesn't use it
+    set_reg(r0, data);
+  }
 }
 
-void ptx_thread_info::print_insn( unsigned pc, FILE * fp ) const
-{
-   m_func_info->print_insn(pc,fp);
+void ptx_thread_info::print_insn(unsigned pc, FILE *fp) const {
+  m_func_info->print_insn(pc, fp);
 }
 
-static void print_reg( FILE *fp, std::string name, ptx_reg_t value, symbol_table *symtab )
-{
-   const symbol *sym = symtab->lookup(name.c_str());
-   fprintf(fp,"  %8s   ", name.c_str() );
-   if( sym == NULL ) {
-      fprintf(fp,"<unknown type> 0x%llx\n", (unsigned long long ) value.u64 );
-      return;
-   }
-   const type_info *t = sym->type();
-   if( t == NULL ) {
-      fprintf(fp,"<unknown type> 0x%llx\n", (unsigned long long ) value.u64 );
-      return;
-   }
-   type_info_key ti = t->get_key();
+static void print_reg(FILE *fp, std::string name, ptx_reg_t value,
+                      symbol_table *symtab) {
+  const symbol *sym = symtab->lookup(name.c_str());
+  fprintf(fp, "  %8s   ", name.c_str());
+  if (sym == NULL) {
+    fprintf(fp, "<unknown type> 0x%llx\n", (unsigned long long)value.u64);
+    return;
+  }
+  const type_info *t = sym->type();
+  if (t == NULL) {
+    fprintf(fp, "<unknown type> 0x%llx\n", (unsigned long long)value.u64);
+    return;
+  }
+  type_info_key ti = t->get_key();
 
-   switch ( ti.scalar_type() ) {
-   case S8_TYPE:  fprintf(fp,".s8  %d\n", value.s8 );  break;
-   case S16_TYPE: fprintf(fp,".s16 %d\n", value.s16 ); break;
-   case S32_TYPE: fprintf(fp,".s32 %d\n", value.s32 ); break;
-   case S64_TYPE: fprintf(fp,".s64 %Ld\n", value.s64 ); break;
-   case U8_TYPE:  fprintf(fp,".u8  %u [0x%02x]\n", value.u8, (unsigned) value.u8 );  break;
-   case U16_TYPE: fprintf(fp,".u16 %u [0x%04x]\n", value.u16, (unsigned) value.u16 ); break;
-   case U32_TYPE: fprintf(fp,".u32 %u [0x%08x]\n", value.u32, (unsigned) value.u32 ); break;
-   case U64_TYPE: fprintf(fp,".u64 %llu [0x%llx]\n", value.u64, value.u64 ); break;
-   case F16_TYPE: fprintf(fp,".f16 %f [0x%04x]\n",  value.f16, (unsigned) value.u16 ); break;
-   case F32_TYPE: fprintf(fp,".f32 %.15lf [0x%08x]\n",  value.f32, value.u32 ); break;
-   case F64_TYPE: fprintf(fp,".f64 %.15le [0x%016llx]\n", value.f64, value.u64 ); break;
-   case B8_TYPE:  fprintf(fp,".b8  0x%02x\n",   (unsigned) value.u8 );  break;
-   case B16_TYPE: fprintf(fp,".b16 0x%04x\n",   (unsigned) value.u16 ); break;
-   case B32_TYPE: fprintf(fp,".b32 0x%08x\n", (unsigned) value.u32 ); break;
-   case B64_TYPE: fprintf(fp,".b64 0x%llx\n",    (unsigned long long ) value.u64 ); break;
-   case PRED_TYPE: fprintf(fp,".pred %u\n",     (unsigned) value.pred ); break;
-   default: 
-      fprintf( fp, "non-scalar type\n" );
+  switch (ti.scalar_type()) {
+    case S8_TYPE:
+      fprintf(fp, ".s8  %d\n", value.s8);
       break;
-   }
-   fflush(fp);
+    case S16_TYPE:
+      fprintf(fp, ".s16 %d\n", value.s16);
+      break;
+    case S32_TYPE:
+      fprintf(fp, ".s32 %d\n", value.s32);
+      break;
+    case S64_TYPE:
+      fprintf(fp, ".s64 %Ld\n", value.s64);
+      break;
+    case U8_TYPE:
+      fprintf(fp, ".u8  %u [0x%02x]\n", value.u8, (unsigned)value.u8);
+      break;
+    case U16_TYPE:
+      fprintf(fp, ".u16 %u [0x%04x]\n", value.u16, (unsigned)value.u16);
+      break;
+    case U32_TYPE:
+      fprintf(fp, ".u32 %u [0x%08x]\n", value.u32, (unsigned)value.u32);
+      break;
+    case U64_TYPE:
+      fprintf(fp, ".u64 %llu [0x%llx]\n", value.u64, value.u64);
+      break;
+    case F16_TYPE:
+      fprintf(fp, ".f16 %f [0x%04x]\n", value.f16, (unsigned)value.u16);
+      break;
+    case F32_TYPE:
+      fprintf(fp, ".f32 %.15lf [0x%08x]\n", value.f32, value.u32);
+      break;
+    case F64_TYPE:
+      fprintf(fp, ".f64 %.15le [0x%016llx]\n", value.f64, value.u64);
+      break;
+    case B8_TYPE:
+      fprintf(fp, ".b8  0x%02x\n", (unsigned)value.u8);
+      break;
+    case B16_TYPE:
+      fprintf(fp, ".b16 0x%04x\n", (unsigned)value.u16);
+      break;
+    case B32_TYPE:
+      fprintf(fp, ".b32 0x%08x\n", (unsigned)value.u32);
+      break;
+    case B64_TYPE:
+      fprintf(fp, ".b64 0x%llx\n", (unsigned long long)value.u64);
+      break;
+    case PRED_TYPE:
+      fprintf(fp, ".pred %u\n", (unsigned)value.pred);
+      break;
+    default:
+      fprintf(fp, "non-scalar type\n");
+      break;
+  }
+  fflush(fp);
 }
 
-static void print_reg( std::string name, ptx_reg_t value, symbol_table *symtab )
-{
-   print_reg(stdout,name,value,symtab);
+static void print_reg(std::string name, ptx_reg_t value, symbol_table *symtab) {
+  print_reg(stdout, name, value, symtab);
 }
 
-void ptx_thread_info::callstack_push( unsigned pc, unsigned rpc, const symbol *return_var_src, const symbol *return_var_dst, unsigned call_uid )
-{
-   m_RPC = -1;
-   m_RPC_updated = true;
-   m_last_was_call = true;
-   assert( m_func_info != NULL );
-   m_callstack.push_back( stack_entry(m_symbol_table,m_func_info,pc,rpc,return_var_src,return_var_dst,call_uid) );
-   m_regs.push_back( reg_map_t() );
-   m_debug_trace_regs_modified.push_back( reg_map_t() );
-   m_debug_trace_regs_read.push_back( reg_map_t() );
-   m_local_mem_stack_pointer += m_func_info->local_mem_framesize(); 
+void ptx_thread_info::callstack_push(unsigned pc, unsigned rpc,
+                                     const symbol *return_var_src,
+                                     const symbol *return_var_dst,
+                                     unsigned call_uid) {
+  m_RPC = -1;
+  m_RPC_updated = true;
+  m_last_was_call = true;
+  assert(m_func_info != NULL);
+  m_callstack.push_back(stack_entry(m_symbol_table, m_func_info, pc, rpc,
+                                    return_var_src, return_var_dst, call_uid));
+  m_regs.push_back(reg_map_t());
+  m_debug_trace_regs_modified.push_back(reg_map_t());
+  m_debug_trace_regs_read.push_back(reg_map_t());
+  m_local_mem_stack_pointer += m_func_info->local_mem_framesize();
 }
 
-//ptxplus version of callstack_push.
-void ptx_thread_info::callstack_push_plus( unsigned pc, unsigned rpc, const symbol *return_var_src, const symbol *return_var_dst, unsigned call_uid )
-{
-   m_RPC = -1;
-   m_RPC_updated = true;
-   m_last_was_call = true;
-   assert( m_func_info != NULL );
-   m_callstack.push_back( stack_entry(m_symbol_table,m_func_info,pc,rpc,return_var_src,return_var_dst,call_uid) );
-   //m_regs.push_back( reg_map_t() );
-   //m_debug_trace_regs_modified.push_back( reg_map_t() );
-   //m_debug_trace_regs_read.push_back( reg_map_t() );
-   m_local_mem_stack_pointer += m_func_info->local_mem_framesize();
+// ptxplus version of callstack_push.
+void ptx_thread_info::callstack_push_plus(unsigned pc, unsigned rpc,
+                                          const symbol *return_var_src,
+                                          const symbol *return_var_dst,
+                                          unsigned call_uid) {
+  m_RPC = -1;
+  m_RPC_updated = true;
+  m_last_was_call = true;
+  assert(m_func_info != NULL);
+  m_callstack.push_back(stack_entry(m_symbol_table, m_func_info, pc, rpc,
+                                    return_var_src, return_var_dst, call_uid));
+  // m_regs.push_back( reg_map_t() );
+  // m_debug_trace_regs_modified.push_back( reg_map_t() );
+  // m_debug_trace_regs_read.push_back( reg_map_t() );
+  m_local_mem_stack_pointer += m_func_info->local_mem_framesize();
 }
 
+bool ptx_thread_info::callstack_pop() {
+  const symbol *rv_src = m_callstack.back().m_return_var_src;
+  const symbol *rv_dst = m_callstack.back().m_return_var_dst;
+  assert(!((rv_src != NULL) ^ (rv_dst != NULL)));  // ensure caller and callee
+                                                   // agree on whether there is
+                                                   // a return value
 
-bool ptx_thread_info::callstack_pop()
-{
-   const symbol *rv_src = m_callstack.back().m_return_var_src;
-   const symbol *rv_dst = m_callstack.back().m_return_var_dst;
-   assert( !((rv_src != NULL) ^ (rv_dst != NULL)) ); // ensure caller and callee agree on whether there is a return value
+  // read return value from callee frame
+  arg_buffer_t buffer(m_gpu->gpgpu_ctx);
+  if (rv_src != NULL)
+    buffer = copy_arg_to_buffer(this, operand_info(rv_src, m_gpu->gpgpu_ctx),
+                                rv_dst);
 
-   // read return value from callee frame
-   arg_buffer_t buffer(m_gpu->gpgpu_ctx);
-   if( rv_src != NULL ) 
-      buffer = copy_arg_to_buffer(this, operand_info(rv_src, m_gpu->gpgpu_ctx), rv_dst );
+  m_symbol_table = m_callstack.back().m_symbol_table;
+  m_NPC = m_callstack.back().m_PC;
+  m_RPC_updated = true;
+  m_last_was_call = false;
+  m_RPC = m_callstack.back().m_RPC;
+  m_func_info = m_callstack.back().m_func_info;
+  if (m_func_info) {
+    assert(m_local_mem_stack_pointer >= m_func_info->local_mem_framesize());
+    m_local_mem_stack_pointer -= m_func_info->local_mem_framesize();
+  }
+  m_callstack.pop_back();
+  m_regs.pop_back();
+  m_debug_trace_regs_modified.pop_back();
+  m_debug_trace_regs_read.pop_back();
 
-   m_symbol_table = m_callstack.back().m_symbol_table;
-   m_NPC = m_callstack.back().m_PC;
-   m_RPC_updated = true;
-   m_last_was_call = false;
-   m_RPC = m_callstack.back().m_RPC;
-   m_func_info = m_callstack.back().m_func_info;
-   if( m_func_info ) {
-      assert( m_local_mem_stack_pointer >= m_func_info->local_mem_framesize() );
-      m_local_mem_stack_pointer -= m_func_info->local_mem_framesize(); 
-   }
-   m_callstack.pop_back();
-   m_regs.pop_back();
-   m_debug_trace_regs_modified.pop_back();
-   m_debug_trace_regs_read.pop_back();
+  // write return value into caller frame
+  if (rv_dst != NULL) copy_buffer_to_frame(this, buffer);
 
-   // write return value into caller frame
-   if( rv_dst != NULL ) 
-      copy_buffer_to_frame(this, buffer);
-
-   return m_callstack.empty();
+  return m_callstack.empty();
 }
 
-//ptxplus version of callstack_pop
-bool ptx_thread_info::callstack_pop_plus()
-{
-   const symbol *rv_src = m_callstack.back().m_return_var_src;
-   const symbol *rv_dst = m_callstack.back().m_return_var_dst;
-   assert( !((rv_src != NULL) ^ (rv_dst != NULL)) ); // ensure caller and callee agree on whether there is a return value
+// ptxplus version of callstack_pop
+bool ptx_thread_info::callstack_pop_plus() {
+  const symbol *rv_src = m_callstack.back().m_return_var_src;
+  const symbol *rv_dst = m_callstack.back().m_return_var_dst;
+  assert(!((rv_src != NULL) ^ (rv_dst != NULL)));  // ensure caller and callee
+                                                   // agree on whether there is
+                                                   // a return value
 
-   // read return value from callee frame
-   arg_buffer_t buffer(m_gpu->gpgpu_ctx);
-   if( rv_src != NULL )
-      buffer = copy_arg_to_buffer(this, operand_info(rv_src, m_gpu->gpgpu_ctx), rv_dst );
+  // read return value from callee frame
+  arg_buffer_t buffer(m_gpu->gpgpu_ctx);
+  if (rv_src != NULL)
+    buffer = copy_arg_to_buffer(this, operand_info(rv_src, m_gpu->gpgpu_ctx),
+                                rv_dst);
 
-   m_symbol_table = m_callstack.back().m_symbol_table;
-   m_NPC = m_callstack.back().m_PC;
-   m_RPC_updated = true;
-   m_last_was_call = false;
-   m_RPC = m_callstack.back().m_RPC;
-   m_func_info = m_callstack.back().m_func_info;
-   if( m_func_info ) {
-      assert( m_local_mem_stack_pointer >= m_func_info->local_mem_framesize() );
-      m_local_mem_stack_pointer -= m_func_info->local_mem_framesize();
-   }
-   m_callstack.pop_back();
-   //m_regs.pop_back();
-   //m_debug_trace_regs_modified.pop_back();
-   //m_debug_trace_regs_read.pop_back();
+  m_symbol_table = m_callstack.back().m_symbol_table;
+  m_NPC = m_callstack.back().m_PC;
+  m_RPC_updated = true;
+  m_last_was_call = false;
+  m_RPC = m_callstack.back().m_RPC;
+  m_func_info = m_callstack.back().m_func_info;
+  if (m_func_info) {
+    assert(m_local_mem_stack_pointer >= m_func_info->local_mem_framesize());
+    m_local_mem_stack_pointer -= m_func_info->local_mem_framesize();
+  }
+  m_callstack.pop_back();
+  // m_regs.pop_back();
+  // m_debug_trace_regs_modified.pop_back();
+  // m_debug_trace_regs_read.pop_back();
 
-   // write return value into caller frame
-   if( rv_dst != NULL )
-      copy_buffer_to_frame(this, buffer);
+  // write return value into caller frame
+  if (rv_dst != NULL) copy_buffer_to_frame(this, buffer);
 
-   return m_callstack.empty();
+  return m_callstack.empty();
 }
 
-void ptx_thread_info::dump_callstack() const
-{
-   std::list<stack_entry>::const_iterator c=m_callstack.begin();
-   std::list<reg_map_t>::const_iterator r=m_regs.begin();
+void ptx_thread_info::dump_callstack() const {
+  std::list<stack_entry>::const_iterator c = m_callstack.begin();
+  std::list<reg_map_t>::const_iterator r = m_regs.begin();
 
-   printf("\n\n");
-   printf("Call stack for thread uid = %u (sc=%u, hwtid=%u)\n", m_uid, m_hw_sid, m_hw_tid );
-   while( c != m_callstack.end() && r != m_regs.end() ) {
-      const stack_entry &c_e = *c;
-      const reg_map_t &regs = *r;
-      if( !c_e.m_valid ) {
-         printf("  <entry>                              #regs = %zu\n", regs.size() );
-      } else {
-         printf("  %20s  PC=%3u RV= (callee=\'%s\',caller=\'%s\') #regs = %zu\n", 
-                c_e.m_func_info->get_name().c_str(), c_e.m_PC, 
-                c_e.m_return_var_src->name().c_str(), 
-                c_e.m_return_var_dst->name().c_str(), 
-                regs.size() );
-      }
-      c++;
-      r++;
-   }
-   if( c != m_callstack.end() || r != m_regs.end() ) {
-      printf("  *** mismatch in m_regs and m_callstack sizes ***\n" );
-   }
-   printf("\n\n");
+  printf("\n\n");
+  printf("Call stack for thread uid = %u (sc=%u, hwtid=%u)\n", m_uid, m_hw_sid,
+         m_hw_tid);
+  while (c != m_callstack.end() && r != m_regs.end()) {
+    const stack_entry &c_e = *c;
+    const reg_map_t &regs = *r;
+    if (!c_e.m_valid) {
+      printf("  <entry>                              #regs = %zu\n",
+             regs.size());
+    } else {
+      printf("  %20s  PC=%3u RV= (callee=\'%s\',caller=\'%s\') #regs = %zu\n",
+             c_e.m_func_info->get_name().c_str(), c_e.m_PC,
+             c_e.m_return_var_src->name().c_str(),
+             c_e.m_return_var_dst->name().c_str(), regs.size());
+    }
+    c++;
+    r++;
+  }
+  if (c != m_callstack.end() || r != m_regs.end()) {
+    printf("  *** mismatch in m_regs and m_callstack sizes ***\n");
+  }
+  printf("\n\n");
 }
 
-std::string ptx_thread_info::get_location() const
-{
-   const ptx_instruction *pI = m_func_info->get_instruction(m_PC);
-   char buf[1024];
-   snprintf(buf,1024,"%s:%u", pI->source_file(), pI->source_line() );
-   return std::string(buf);
+std::string ptx_thread_info::get_location() const {
+  const ptx_instruction *pI = m_func_info->get_instruction(m_PC);
+  char buf[1024];
+  snprintf(buf, 1024, "%s:%u", pI->source_file(), pI->source_line());
+  return std::string(buf);
 }
 
-const ptx_instruction *ptx_thread_info::get_inst() const
-{
-   return m_func_info->get_instruction(m_PC);
+const ptx_instruction *ptx_thread_info::get_inst() const {
+  return m_func_info->get_instruction(m_PC);
 }
 
-const ptx_instruction *ptx_thread_info::get_inst( addr_t pc ) const
-{
-   return m_func_info->get_instruction(pc);
+const ptx_instruction *ptx_thread_info::get_inst(addr_t pc) const {
+  return m_func_info->get_instruction(pc);
 }
 
-void ptx_thread_info::dump_regs( FILE *fp )
-{
-   if(m_regs.empty()) return;
-   if(m_regs.back().empty()) return;
-   fprintf(fp,"Register File Contents:\n");
-   fflush(fp);
-   reg_map_t::const_iterator r;
-   for ( r=m_regs.back().begin(); r != m_regs.back().end(); ++r ) {
+void ptx_thread_info::dump_regs(FILE *fp) {
+  if (m_regs.empty()) return;
+  if (m_regs.back().empty()) return;
+  fprintf(fp, "Register File Contents:\n");
+  fflush(fp);
+  reg_map_t::const_iterator r;
+  for (r = m_regs.back().begin(); r != m_regs.back().end(); ++r) {
+    const symbol *sym = r->first;
+    ptx_reg_t value = r->second;
+    std::string name = sym->name();
+    print_reg(fp, name, value, m_symbol_table);
+  }
+}
+
+void ptx_thread_info::dump_modifiedregs(FILE *fp) {
+  if (!(m_debug_trace_regs_modified.empty() ||
+        m_debug_trace_regs_modified.back().empty())) {
+    fprintf(fp, "Output Registers:\n");
+    fflush(fp);
+    reg_map_t::iterator r;
+    for (r = m_debug_trace_regs_modified.back().begin();
+         r != m_debug_trace_regs_modified.back().end(); ++r) {
       const symbol *sym = r->first;
-      ptx_reg_t value = r->second;
       std::string name = sym->name();
-      print_reg(fp,name,value,m_symbol_table);
-   }
+      ptx_reg_t value = r->second;
+      print_reg(fp, name, value, m_symbol_table);
+    }
+  }
+  if (!(m_debug_trace_regs_read.empty() ||
+        m_debug_trace_regs_read.back().empty())) {
+    fprintf(fp, "Input Registers:\n");
+    fflush(fp);
+    reg_map_t::iterator r;
+    for (r = m_debug_trace_regs_read.back().begin();
+         r != m_debug_trace_regs_read.back().end(); ++r) {
+      const symbol *sym = r->first;
+      std::string name = sym->name();
+      ptx_reg_t value = r->second;
+      print_reg(fp, name, value, m_symbol_table);
+    }
+  }
 }
 
-void ptx_thread_info::dump_modifiedregs(FILE *fp)
-{
-   if( !(m_debug_trace_regs_modified.empty() || 
-         m_debug_trace_regs_modified.back().empty()) ) { 
-      fprintf(fp,"Output Registers:\n");
-      fflush(fp);
-      reg_map_t::iterator r;
-      for ( r=m_debug_trace_regs_modified.back().begin(); r != m_debug_trace_regs_modified.back().end(); ++r ) {
-         const symbol *sym = r->first;
-         std::string name = sym->name();
-         ptx_reg_t value = r->second;
-         print_reg(fp,name,value,m_symbol_table);
-      }
-   }
-   if( !(m_debug_trace_regs_read.empty() ||
-         m_debug_trace_regs_read.back().empty()) ) { 
-      fprintf(fp,"Input Registers:\n");
-      fflush(fp);
-      reg_map_t::iterator r;
-      for ( r=m_debug_trace_regs_read.back().begin(); r != m_debug_trace_regs_read.back().end(); ++r ) {
-         const symbol *sym = r->first;
-         std::string name = sym->name();
-         ptx_reg_t value = r->second;
-         print_reg(fp,name,value,m_symbol_table);
-      }
-   }
+void ptx_thread_info::push_breakaddr(const operand_info &breakaddr) {
+  m_breakaddrs.push(breakaddr);
 }
 
-void ptx_thread_info::push_breakaddr(const operand_info &breakaddr) 
-{
-   m_breakaddrs.push(breakaddr);
+const operand_info &ptx_thread_info::pop_breakaddr() {
+  if (m_breakaddrs.empty()) {
+    printf("empty breakaddrs stack");
+    assert(0);
+  }
+  operand_info &breakaddr = m_breakaddrs.top();
+  m_breakaddrs.pop();
+  return breakaddr;
 }
 
-const operand_info& ptx_thread_info::pop_breakaddr() 
-{
-   if(m_breakaddrs.empty()) {
-      printf("empty breakaddrs stack");
-      assert(0);
-   }
-   operand_info& breakaddr = m_breakaddrs.top();
-   m_breakaddrs.pop();
-   return breakaddr;
+void ptx_thread_info::set_npc(const function_info *f) {
+  m_NPC = f->get_start_PC();
+  m_func_info = const_cast<function_info *>(f);
+  m_symbol_table = m_func_info->get_symtab();
 }
 
-void ptx_thread_info::set_npc( const function_info *f )
-{
-   m_NPC = f->get_start_PC();
-   m_func_info = const_cast<function_info*>( f );
-   m_symbol_table = m_func_info->get_symtab();
-}
-
-
-void feature_not_implemented( const char *f ) 
-{
-   printf("GPGPU-Sim: feature '%s' not supported\n", f );
-   abort();
+void feature_not_implemented(const char *f) {
+  printf("GPGPU-Sim: feature '%s' not supported\n", f);
+  abort();
 }

--- a/src/cuda-sim/ptx_sim.h
+++ b/src/cuda-sim/ptx_sim.h
@@ -6,53 +6,51 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef ptx_sim_h_INCLUDED
 #define ptx_sim_h_INCLUDED
 
 #include <stdlib.h>
-#include "half.h"
 #include "../abstract_hardware_model.h"
-#include "../tr1_hash_map.h" 
+#include "../tr1_hash_map.h"
+#include "half.h"
 
 #include <assert.h>
 #include "opcodes.h"
 
-#include <string>
+#include <list>
 #include <map>
 #include <set>
-#include <list>
+#include <string>
 
 #include "memory.h"
 
-#define GCC_VERSION (__GNUC__ * 10000 \
-                     + __GNUC_MINOR__ * 100 \
-                     + __GNUC_PATCHLEVEL__)
-
-
+#define GCC_VERSION \
+  (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 
 struct param_t {
-   const void *pdata;
-   int type;
-   size_t size;
-   size_t offset;
+  const void *pdata;
+  int type;
+  size_t size;
+  size_t offset;
 };
 
 #include <stack>
@@ -62,98 +60,93 @@ struct param_t {
 using half_float::half;
 
 union ptx_reg_t {
-   ptx_reg_t() {
-      bits.ms = 0;
-      bits.ls = 0;
-      u128.low=0;
-      u128.lowest=0;
-      u128.highest=0;
-      u128.high=0;
-      s8=0;
-      s16=0;
-      s32=0;
-      s64=0;
-      u8=0;
-      u16=0;
-      u64=0;
-      f16=0;
-      f32=0;
-      f64=0;
-      pred=0;
-   }
-   ptx_reg_t(unsigned x) 
-   {
-      bits.ms = 0;
-      bits.ls = 0;
-      u128.low=0;
-      u128.lowest=0;
-      u128.highest=0;
-      u128.high=0;
-      s8=0;
-      s16=0;
-      s32=0;
-      s64=0;
-      u8=0;
-      u16=0;
-      u64=0;
-      f16=0;
-      f32=0;
-      f64=0;
-      pred=0;
-      u32 = x;
-   }
-   operator unsigned int() { return u32;}
-   operator unsigned short() { return u16;}
-   operator unsigned char() { return u8;}
-   operator unsigned long long() { return u64;}
+  ptx_reg_t() {
+    bits.ms = 0;
+    bits.ls = 0;
+    u128.low = 0;
+    u128.lowest = 0;
+    u128.highest = 0;
+    u128.high = 0;
+    s8 = 0;
+    s16 = 0;
+    s32 = 0;
+    s64 = 0;
+    u8 = 0;
+    u16 = 0;
+    u64 = 0;
+    f16 = 0;
+    f32 = 0;
+    f64 = 0;
+    pred = 0;
+  }
+  ptx_reg_t(unsigned x) {
+    bits.ms = 0;
+    bits.ls = 0;
+    u128.low = 0;
+    u128.lowest = 0;
+    u128.highest = 0;
+    u128.high = 0;
+    s8 = 0;
+    s16 = 0;
+    s32 = 0;
+    s64 = 0;
+    u8 = 0;
+    u16 = 0;
+    u64 = 0;
+    f16 = 0;
+    f32 = 0;
+    f64 = 0;
+    pred = 0;
+    u32 = x;
+  }
+  operator unsigned int() { return u32; }
+  operator unsigned short() { return u16; }
+  operator unsigned char() { return u8; }
+  operator unsigned long long() { return u64; }
 
-   void mask_and( unsigned ms, unsigned ls )
-   {
-      bits.ms &= ms;
-      bits.ls &= ls;
-   }
+  void mask_and(unsigned ms, unsigned ls) {
+    bits.ms &= ms;
+    bits.ls &= ls;
+  }
 
-   void mask_or( unsigned ms, unsigned ls )
-   {
-      bits.ms |= ms;
-      bits.ls |= ls;
-   }
-   int get_bit( unsigned bit )
-   {
-      if ( bit < 32 )
-         return(bits.ls >> bit) & 1;
-      else
-         return(bits.ms >> (bit-32)) & 1;
-   }
+  void mask_or(unsigned ms, unsigned ls) {
+    bits.ms |= ms;
+    bits.ls |= ls;
+  }
+  int get_bit(unsigned bit) {
+    if (bit < 32)
+      return (bits.ls >> bit) & 1;
+    else
+      return (bits.ms >> (bit - 32)) & 1;
+  }
 
-   signed char       s8;
-   signed short      s16;
-   signed int        s32;
-   signed long long  s64;
-   unsigned char     u8;
-   unsigned short    u16;
-   unsigned int      u32;
-   unsigned long long   u64;
-   //gcc 4.7.0
-   #if GCC_VERSION >= 40700
-   half 		f16; 
-   #else
-   float 		f16; 
-   #endif
-   float          f32;
-   double            f64;
-   struct {
-      unsigned ls;
-      unsigned ms;
-   } bits;
-   struct {
-       unsigned int lowest;
-       unsigned int low;
-       unsigned int high;
-       unsigned int highest;
-   } u128;
-   unsigned       pred : 4;
-
+  signed char s8;
+  signed short s16;
+  signed int s32;
+  signed long long s64;
+  unsigned char u8;
+  unsigned short u16;
+  unsigned int u32;
+  unsigned long long u64;
+// gcc 4.7.0
+#if GCC_VERSION >= 40700
+  half f16;
+#else
+  float f16;
+#endif
+  float f32;
+  double f64;
+  struct {
+    unsigned ls;
+    unsigned ms;
+  } bits;
+  struct {
+    unsigned int lowest;
+    unsigned int low;
+    unsigned int high;
+    unsigned int highest;
+  } u128;
+  unsigned pred : 4;
 };
 
 class ptx_instruction;
@@ -163,373 +156,375 @@ class function_info;
 class ptx_thread_info;
 
 class ptx_cta_info {
-public:
-   ptx_cta_info( unsigned sm_idx, gpgpu_context* ctx );
-   void add_thread( ptx_thread_info *thd );
-   unsigned num_threads() const;
-   void check_cta_thread_status_and_reset();
-   void register_thread_exit( ptx_thread_info *thd );
-   void register_deleted_thread( ptx_thread_info *thd );
-   unsigned get_sm_idx() const;
-   unsigned get_bar_threads() const;
-   void inc_bar_threads();
-   void reset_bar_threads();
+ public:
+  ptx_cta_info(unsigned sm_idx, gpgpu_context *ctx);
+  void add_thread(ptx_thread_info *thd);
+  unsigned num_threads() const;
+  void check_cta_thread_status_and_reset();
+  void register_thread_exit(ptx_thread_info *thd);
+  void register_deleted_thread(ptx_thread_info *thd);
+  unsigned get_sm_idx() const;
+  unsigned get_bar_threads() const;
+  void inc_bar_threads();
+  void reset_bar_threads();
 
-private:
-   // backward pointer
-   class gpgpu_context* gpgpu_ctx;
-   unsigned           m_bar_threads;
-   unsigned long long         m_uid;
-   unsigned                m_sm_idx;
-   std::set<ptx_thread_info*>    m_threads_in_cta;
-   std::set<ptx_thread_info*>  m_threads_that_have_exited;
-   std::set<ptx_thread_info*>  m_dangling_pointers;
+ private:
+  // backward pointer
+  class gpgpu_context *gpgpu_ctx;
+  unsigned m_bar_threads;
+  unsigned long long m_uid;
+  unsigned m_sm_idx;
+  std::set<ptx_thread_info *> m_threads_in_cta;
+  std::set<ptx_thread_info *> m_threads_that_have_exited;
+  std::set<ptx_thread_info *> m_dangling_pointers;
 };
 
 class ptx_warp_info {
-public:
-	ptx_warp_info(); // add get_core or something, or threads?
-	unsigned get_done_threads() const;
-	void inc_done_threads();
-	void reset_done_threads();
+ public:
+  ptx_warp_info();  // add get_core or something, or threads?
+  unsigned get_done_threads() const;
+  void inc_done_threads();
+  void reset_done_threads();
 
-private:
-	unsigned m_done_threads;
+ private:
+  unsigned m_done_threads;
 };
 
 class symbol;
 
 struct stack_entry {
-   stack_entry() {
-      m_symbol_table=NULL;
-      m_func_info=NULL;
-      m_PC=0;
-      m_RPC=-1;
-      m_return_var_src = NULL;
-      m_return_var_dst = NULL;
-      m_call_uid = 0;
-      m_valid = false;
-   }
-   stack_entry( symbol_table *s, function_info *f, unsigned pc, unsigned rpc, const symbol *return_var_src, const symbol *return_var_dst, unsigned call_uid )
-   {
-      m_symbol_table=s;
-      m_func_info=f;
-      m_PC=pc;
-      m_RPC=rpc;
-      m_return_var_src = return_var_src;
-      m_return_var_dst = return_var_dst;
-      m_call_uid = call_uid;
-      m_valid = true;
-   }
+  stack_entry() {
+    m_symbol_table = NULL;
+    m_func_info = NULL;
+    m_PC = 0;
+    m_RPC = -1;
+    m_return_var_src = NULL;
+    m_return_var_dst = NULL;
+    m_call_uid = 0;
+    m_valid = false;
+  }
+  stack_entry(symbol_table *s, function_info *f, unsigned pc, unsigned rpc,
+              const symbol *return_var_src, const symbol *return_var_dst,
+              unsigned call_uid) {
+    m_symbol_table = s;
+    m_func_info = f;
+    m_PC = pc;
+    m_RPC = rpc;
+    m_return_var_src = return_var_src;
+    m_return_var_dst = return_var_dst;
+    m_call_uid = call_uid;
+    m_valid = true;
+  }
 
-   bool m_valid;
-   symbol_table  *m_symbol_table;
-   function_info *m_func_info;
-   unsigned       m_PC;
-   unsigned       m_RPC;
-   const symbol  *m_return_var_src;
-   const symbol  *m_return_var_dst;
-   unsigned       m_call_uid;
+  bool m_valid;
+  symbol_table *m_symbol_table;
+  function_info *m_func_info;
+  unsigned m_PC;
+  unsigned m_RPC;
+  const symbol *m_return_var_src;
+  const symbol *m_return_var_dst;
+  unsigned m_call_uid;
 };
 
 class ptx_version {
-public:
-      ptx_version()
-      {
-         m_valid = false;
-         m_ptx_version = 0;
-         m_ptx_extensions = 0;
-         m_sm_version_valid=false;
-         m_texmode_unified=true;
-         m_map_f64_to_f32 = true; 
-      }
-      ptx_version(float ver, unsigned extensions)
-      {
-         m_valid = true;
-         m_ptx_version = ver;
-         m_ptx_extensions = extensions;
-         m_sm_version_valid=false;
-         m_texmode_unified=true;
-      }
-      void set_target( const char *sm_ver, const char *ext, const char *ext2 ) 
-      { 
-         assert( m_valid );
-         m_sm_version_str = sm_ver;
-         check_target_extension(ext); 
-         check_target_extension(ext2); 
-         sscanf(sm_ver,"%u",&m_sm_version);
-         m_sm_version_valid=true; 
-      }
-      float    ver() const { assert(m_valid); return m_ptx_version; }
-      unsigned target() const { assert(m_valid&&m_sm_version_valid); return m_sm_version; }
-      unsigned extensions() const { assert(m_valid); return m_ptx_extensions; }
-private:
-      void check_target_extension( const char *ext ) 
-      {
-         if( ext ) {
-            if( !strcmp(ext,"texmode_independent") ) 
-               m_texmode_unified=false;
-            else if( !strcmp(ext,"texmode_unified") ) 
-               m_texmode_unified=true;
-            else if( !strcmp(ext,"map_f64_to_f32") ) 
-               m_map_f64_to_f32 = true; 
-            else abort();
-         }
-      }
+ public:
+  ptx_version() {
+    m_valid = false;
+    m_ptx_version = 0;
+    m_ptx_extensions = 0;
+    m_sm_version_valid = false;
+    m_texmode_unified = true;
+    m_map_f64_to_f32 = true;
+  }
+  ptx_version(float ver, unsigned extensions) {
+    m_valid = true;
+    m_ptx_version = ver;
+    m_ptx_extensions = extensions;
+    m_sm_version_valid = false;
+    m_texmode_unified = true;
+  }
+  void set_target(const char *sm_ver, const char *ext, const char *ext2) {
+    assert(m_valid);
+    m_sm_version_str = sm_ver;
+    check_target_extension(ext);
+    check_target_extension(ext2);
+    sscanf(sm_ver, "%u", &m_sm_version);
+    m_sm_version_valid = true;
+  }
+  float ver() const {
+    assert(m_valid);
+    return m_ptx_version;
+  }
+  unsigned target() const {
+    assert(m_valid && m_sm_version_valid);
+    return m_sm_version;
+  }
+  unsigned extensions() const {
+    assert(m_valid);
+    return m_ptx_extensions;
+  }
 
-      bool     m_valid;
-      float    m_ptx_version;
-      unsigned m_sm_version_valid;
-      std::string m_sm_version_str;
-      bool     m_texmode_unified;
-      bool     m_map_f64_to_f32; 
-      unsigned m_sm_version;
-      unsigned m_ptx_extensions;
+ private:
+  void check_target_extension(const char *ext) {
+    if (ext) {
+      if (!strcmp(ext, "texmode_independent"))
+        m_texmode_unified = false;
+      else if (!strcmp(ext, "texmode_unified"))
+        m_texmode_unified = true;
+      else if (!strcmp(ext, "map_f64_to_f32"))
+        m_map_f64_to_f32 = true;
+      else
+        abort();
+    }
+  }
+
+  bool m_valid;
+  float m_ptx_version;
+  unsigned m_sm_version_valid;
+  std::string m_sm_version_str;
+  bool m_texmode_unified;
+  bool m_map_f64_to_f32;
+  unsigned m_sm_version;
+  unsigned m_ptx_extensions;
 };
 
 class ptx_thread_info {
-public:
-   ~ptx_thread_info();
-   ptx_thread_info( kernel_info_t &kernel );
+ public:
+  ~ptx_thread_info();
+  ptx_thread_info(kernel_info_t &kernel);
 
-   void init(gpgpu_t *gpu, core_t *core, unsigned sid, unsigned cta_id, unsigned wid, unsigned tid, bool fsim) 
-   { 
-      m_gpu = gpu;
-      m_core = core; 
-      m_hw_sid=sid;
-      m_hw_ctaid=cta_id;
-      m_hw_wid=wid;
-      m_hw_tid=tid;
-      m_functionalSimulationMode = fsim;
-   }
+  void init(gpgpu_t *gpu, core_t *core, unsigned sid, unsigned cta_id,
+            unsigned wid, unsigned tid, bool fsim) {
+    m_gpu = gpu;
+    m_core = core;
+    m_hw_sid = sid;
+    m_hw_ctaid = cta_id;
+    m_hw_wid = wid;
+    m_hw_tid = tid;
+    m_functionalSimulationMode = fsim;
+  }
 
-   void ptx_fetch_inst( inst_t &inst ) const;
-   void ptx_exec_inst( warp_inst_t &inst, unsigned lane_id );
+  void ptx_fetch_inst(inst_t &inst) const;
+  void ptx_exec_inst(warp_inst_t &inst, unsigned lane_id);
 
-   const ptx_version &get_ptx_version() const;
-   void set_reg( const symbol *reg, const ptx_reg_t &value );
-   void print_reg_thread (char * fname);
-   void resume_reg_thread(char * fname,  symbol_table * symtab);
-   ptx_reg_t get_reg( const symbol *reg );
-   ptx_reg_t get_operand_value( const operand_info &op, operand_info dstInfo, unsigned opType, ptx_thread_info *thread, int derefFlag );
-   void set_operand_value( const operand_info &dst, const ptx_reg_t &data, unsigned type, ptx_thread_info *thread, const ptx_instruction *pI );
-   void set_operand_value( const operand_info &dst, const ptx_reg_t &data, unsigned type, ptx_thread_info *thread, const ptx_instruction *pI, int overflow, int carry );
-   void get_vector_operand_values( const operand_info &op, ptx_reg_t* ptx_regs, unsigned num_elements );
-   void set_vector_operand_values( const operand_info &dst, 
-                                   const ptx_reg_t &data1, 
-                                   const ptx_reg_t &data2, 
-                                   const ptx_reg_t &data3, 
-                                   const ptx_reg_t &data4 );
-   void set_wmma_vector_operand_values( const operand_info &dst, 
-                                        const ptx_reg_t &data1, 
-                                        const ptx_reg_t &data2, 
-                                        const ptx_reg_t &data3, 
-                                        const ptx_reg_t &data4, 
-                                        const ptx_reg_t &data5, 
-                                        const ptx_reg_t &data6, 
-                                        const ptx_reg_t &data7, 
-                                        const ptx_reg_t &data8 );
+  const ptx_version &get_ptx_version() const;
+  void set_reg(const symbol *reg, const ptx_reg_t &value);
+  void print_reg_thread(char *fname);
+  void resume_reg_thread(char *fname, symbol_table *symtab);
+  ptx_reg_t get_reg(const symbol *reg);
+  ptx_reg_t get_operand_value(const operand_info &op, operand_info dstInfo,
+                              unsigned opType, ptx_thread_info *thread,
+                              int derefFlag);
+  void set_operand_value(const operand_info &dst, const ptx_reg_t &data,
+                         unsigned type, ptx_thread_info *thread,
+                         const ptx_instruction *pI);
+  void set_operand_value(const operand_info &dst, const ptx_reg_t &data,
+                         unsigned type, ptx_thread_info *thread,
+                         const ptx_instruction *pI, int overflow, int carry);
+  void get_vector_operand_values(const operand_info &op, ptx_reg_t *ptx_regs,
+                                 unsigned num_elements);
+  void set_vector_operand_values(const operand_info &dst,
+                                 const ptx_reg_t &data1, const ptx_reg_t &data2,
+                                 const ptx_reg_t &data3,
+                                 const ptx_reg_t &data4);
+  void set_wmma_vector_operand_values(
+      const operand_info &dst, const ptx_reg_t &data1, const ptx_reg_t &data2,
+      const ptx_reg_t &data3, const ptx_reg_t &data4, const ptx_reg_t &data5,
+      const ptx_reg_t &data6, const ptx_reg_t &data7, const ptx_reg_t &data8);
 
-   function_info *func_info()
-   {
-      return m_func_info; 
-   }
-   void print_insn( unsigned pc, FILE * fp ) const;
-   void set_info( function_info *func );
-   unsigned get_uid() const
-   {
-      return m_uid;
-   }
+  function_info *func_info() { return m_func_info; }
+  void print_insn(unsigned pc, FILE *fp) const;
+  void set_info(function_info *func);
+  unsigned get_uid() const { return m_uid; }
 
-   dim3 get_ctaid() const { return m_ctaid; }
-   dim3 get_tid() const { return m_tid; }
-   dim3 get_ntid() const { return m_ntid; }
-   class gpgpu_sim *get_gpu() { return (gpgpu_sim*)m_gpu;}
-   unsigned get_hw_tid() const { return m_hw_tid;}
-   unsigned get_hw_ctaid() const { return m_hw_ctaid;}
-   unsigned get_hw_wid() const { return m_hw_wid;}
-   unsigned get_hw_sid() const { return m_hw_sid;}
-   core_t *get_core() { return m_core; }
+  dim3 get_ctaid() const { return m_ctaid; }
+  dim3 get_tid() const { return m_tid; }
+  dim3 get_ntid() const { return m_ntid; }
+  class gpgpu_sim *get_gpu() {
+    return (gpgpu_sim *)m_gpu;
+  }
+  unsigned get_hw_tid() const { return m_hw_tid; }
+  unsigned get_hw_ctaid() const { return m_hw_ctaid; }
+  unsigned get_hw_wid() const { return m_hw_wid; }
+  unsigned get_hw_sid() const { return m_hw_sid; }
+  core_t *get_core() { return m_core; }
 
-   unsigned get_icount() const { return m_icount;}
-   void set_valid() { m_valid = true;}
-   addr_t last_eaddr() const { return m_last_effective_address;}
-   memory_space_t last_space() const { return m_last_memory_space;}
-   dram_callback_t last_callback() const { return m_last_dram_callback;}
-   unsigned long long get_cta_uid() { return m_cta_info->get_sm_idx();}
+  unsigned get_icount() const { return m_icount; }
+  void set_valid() { m_valid = true; }
+  addr_t last_eaddr() const { return m_last_effective_address; }
+  memory_space_t last_space() const { return m_last_memory_space; }
+  dram_callback_t last_callback() const { return m_last_dram_callback; }
+  unsigned long long get_cta_uid() { return m_cta_info->get_sm_idx(); }
 
-   void set_single_thread_single_block()
-   {
-      m_ntid.x = 1;
-      m_ntid.y = 1;
-      m_ntid.z = 1;
-      m_ctaid.x = 0;
-      m_ctaid.y = 0;
-      m_ctaid.z = 0;
-      m_tid.x = 0;
-      m_tid.y = 0;
-      m_tid.z = 0;
-      m_nctaid.x = 1;
-      m_nctaid.y = 1;
-      m_nctaid.z = 1;
-      m_gridid = 0;
-      m_valid = true;
-   }
-   void set_tid( dim3 tid ) { m_tid = tid; }
-   void cpy_tid_to_reg( dim3 tid );
-   void set_ctaid( dim3 ctaid ) { m_ctaid = ctaid; }
-   void set_ntid( dim3 tid ) { m_ntid = tid; }
-   void set_nctaid( dim3 cta_size ) { m_nctaid = cta_size; }
+  void set_single_thread_single_block() {
+    m_ntid.x = 1;
+    m_ntid.y = 1;
+    m_ntid.z = 1;
+    m_ctaid.x = 0;
+    m_ctaid.y = 0;
+    m_ctaid.z = 0;
+    m_tid.x = 0;
+    m_tid.y = 0;
+    m_tid.z = 0;
+    m_nctaid.x = 1;
+    m_nctaid.y = 1;
+    m_nctaid.z = 1;
+    m_gridid = 0;
+    m_valid = true;
+  }
+  void set_tid(dim3 tid) { m_tid = tid; }
+  void cpy_tid_to_reg(dim3 tid);
+  void set_ctaid(dim3 ctaid) { m_ctaid = ctaid; }
+  void set_ntid(dim3 tid) { m_ntid = tid; }
+  void set_nctaid(dim3 cta_size) { m_nctaid = cta_size; }
 
-   unsigned get_builtin( int builtin_id, unsigned dim_mod ); 
+  unsigned get_builtin(int builtin_id, unsigned dim_mod);
 
-   void set_done();
-   bool is_done() { return m_thread_done;}
-   unsigned donecycle() const { return m_cycle_done; }
+  void set_done();
+  bool is_done() { return m_thread_done; }
+  unsigned donecycle() const { return m_cycle_done; }
 
-   unsigned next_instr()
-   {
-      m_icount++;
-      m_branch_taken = false;
-      return m_PC;
-   }
-   bool branch_taken() const
-   {
-      return m_branch_taken;
-   }
-   unsigned get_pc() const
-   {
-      return m_PC;
-   }
-   void set_npc( unsigned npc )
-   {
-      m_NPC = npc;
-   }
-   void set_npc( const function_info *f );
-   void callstack_push( unsigned npc, unsigned rpc, const symbol *return_var_src, const symbol *return_var_dst, unsigned call_uid );
-   bool callstack_pop();
-   void callstack_push_plus( unsigned npc, unsigned rpc, const symbol *return_var_src, const symbol *return_var_dst, unsigned call_uid );
-   bool callstack_pop_plus();
-   void dump_callstack() const;
-   std::string get_location() const;
-   const ptx_instruction *get_inst() const;
-   const ptx_instruction *get_inst( addr_t pc ) const;
-   bool rpc_updated() const { return m_RPC_updated; }
-   bool last_was_call() const { return m_last_was_call; }
-   unsigned get_rpc() const { return m_RPC; }
-   void clearRPC()
-   {
-      m_RPC = -1;
-      m_RPC_updated = false;
-      m_last_was_call = false;
-   }
-   unsigned get_return_PC()
-   {
-       return m_callstack.back().m_PC;
-   }
-   void update_pc( )
-   {
-      m_PC = m_NPC;
-   }
-   void dump_regs(FILE * fp);
-   void dump_modifiedregs(FILE *fp);
-   void clear_modifiedregs() { m_debug_trace_regs_modified.back().clear(); m_debug_trace_regs_read.back().clear(); }
-   function_info *get_finfo() { return m_func_info;   }
-   const function_info *get_finfo() const { return m_func_info;   }
-   void push_breakaddr(const operand_info &breakaddr);
-   const operand_info& pop_breakaddr();
-   void enable_debug_trace() { m_enable_debug_trace = true; }
-   unsigned get_local_mem_stack_pointer() const { return m_local_mem_stack_pointer; }
+  unsigned next_instr() {
+    m_icount++;
+    m_branch_taken = false;
+    return m_PC;
+  }
+  bool branch_taken() const { return m_branch_taken; }
+  unsigned get_pc() const { return m_PC; }
+  void set_npc(unsigned npc) { m_NPC = npc; }
+  void set_npc(const function_info *f);
+  void callstack_push(unsigned npc, unsigned rpc, const symbol *return_var_src,
+                      const symbol *return_var_dst, unsigned call_uid);
+  bool callstack_pop();
+  void callstack_push_plus(unsigned npc, unsigned rpc,
+                           const symbol *return_var_src,
+                           const symbol *return_var_dst, unsigned call_uid);
+  bool callstack_pop_plus();
+  void dump_callstack() const;
+  std::string get_location() const;
+  const ptx_instruction *get_inst() const;
+  const ptx_instruction *get_inst(addr_t pc) const;
+  bool rpc_updated() const { return m_RPC_updated; }
+  bool last_was_call() const { return m_last_was_call; }
+  unsigned get_rpc() const { return m_RPC; }
+  void clearRPC() {
+    m_RPC = -1;
+    m_RPC_updated = false;
+    m_last_was_call = false;
+  }
+  unsigned get_return_PC() { return m_callstack.back().m_PC; }
+  void update_pc() { m_PC = m_NPC; }
+  void dump_regs(FILE *fp);
+  void dump_modifiedregs(FILE *fp);
+  void clear_modifiedregs() {
+    m_debug_trace_regs_modified.back().clear();
+    m_debug_trace_regs_read.back().clear();
+  }
+  function_info *get_finfo() { return m_func_info; }
+  const function_info *get_finfo() const { return m_func_info; }
+  void push_breakaddr(const operand_info &breakaddr);
+  const operand_info &pop_breakaddr();
+  void enable_debug_trace() { m_enable_debug_trace = true; }
+  unsigned get_local_mem_stack_pointer() const {
+    return m_local_mem_stack_pointer;
+  }
 
-   memory_space *get_global_memory() { return m_gpu->get_global_memory(); }
-   memory_space *get_tex_memory() { return m_gpu->get_tex_memory(); }
-   memory_space *get_surf_memory() { return m_gpu->get_surf_memory(); }
-   memory_space *get_param_memory() { return m_kernel.get_param_memory(); }
-   const gpgpu_functional_sim_config &get_config() const { return m_gpu->get_config(); }
-   bool isInFunctionalSimulationMode(){ return m_functionalSimulationMode;}
-   void exitCore()
-   {
-       //m_core is not used in case of functional simulation mode
-       if(!m_functionalSimulationMode)
-           m_core->warp_exit(m_hw_wid);
-   }
-   
-   void registerExit(){m_cta_info->register_thread_exit(this);}
-   unsigned get_reduction_value(unsigned ctaid, unsigned barid) {return m_core->get_reduction_value(ctaid,barid);}
-   void and_reduction(unsigned ctaid, unsigned barid, bool value) {m_core->and_reduction(ctaid,barid,value);}
-   void or_reduction(unsigned ctaid, unsigned barid, bool value) {m_core->or_reduction(ctaid,barid,value);}
-   void popc_reduction(unsigned ctaid, unsigned barid, bool value) {m_core->popc_reduction(ctaid,barid,value);}
+  memory_space *get_global_memory() { return m_gpu->get_global_memory(); }
+  memory_space *get_tex_memory() { return m_gpu->get_tex_memory(); }
+  memory_space *get_surf_memory() { return m_gpu->get_surf_memory(); }
+  memory_space *get_param_memory() { return m_kernel.get_param_memory(); }
+  const gpgpu_functional_sim_config &get_config() const {
+    return m_gpu->get_config();
+  }
+  bool isInFunctionalSimulationMode() { return m_functionalSimulationMode; }
+  void exitCore() {
+    // m_core is not used in case of functional simulation mode
+    if (!m_functionalSimulationMode) m_core->warp_exit(m_hw_wid);
+  }
 
-   //Jin: get corresponding kernel grid for CDP purpose
-   kernel_info_t & get_kernel() { return m_kernel; }
+  void registerExit() { m_cta_info->register_thread_exit(this); }
+  unsigned get_reduction_value(unsigned ctaid, unsigned barid) {
+    return m_core->get_reduction_value(ctaid, barid);
+  }
+  void and_reduction(unsigned ctaid, unsigned barid, bool value) {
+    m_core->and_reduction(ctaid, barid, value);
+  }
+  void or_reduction(unsigned ctaid, unsigned barid, bool value) {
+    m_core->or_reduction(ctaid, barid, value);
+  }
+  void popc_reduction(unsigned ctaid, unsigned barid, bool value) {
+    m_core->popc_reduction(ctaid, barid, value);
+  }
 
-public:
-   addr_t         m_last_effective_address;
-   bool        m_branch_taken;
-   memory_space_t m_last_memory_space;
-   dram_callback_t   m_last_dram_callback; 
-   memory_space   *m_shared_mem;
-   memory_space   *m_sstarr_mem;
-   memory_space   *m_local_mem;
-   ptx_warp_info  *m_warp_info;
-   ptx_cta_info   *m_cta_info;
-   ptx_reg_t m_last_set_operand_value;
+  // Jin: get corresponding kernel grid for CDP purpose
+  kernel_info_t &get_kernel() { return m_kernel; }
 
-private:
+ public:
+  addr_t m_last_effective_address;
+  bool m_branch_taken;
+  memory_space_t m_last_memory_space;
+  dram_callback_t m_last_dram_callback;
+  memory_space *m_shared_mem;
+  memory_space *m_sstarr_mem;
+  memory_space *m_local_mem;
+  ptx_warp_info *m_warp_info;
+  ptx_cta_info *m_cta_info;
+  ptx_reg_t m_last_set_operand_value;
 
-   bool m_functionalSimulationMode; 
-   unsigned m_uid;
-   kernel_info_t &m_kernel;
-   core_t *m_core;
-   gpgpu_t *m_gpu;
-   bool   m_valid;
-   dim3   m_ntid;
-   dim3   m_tid;
-   dim3   m_nctaid;
-   dim3   m_ctaid;
-   unsigned m_gridid;
-   bool m_thread_done;
-   unsigned m_hw_sid;
-   unsigned m_hw_tid;
-   unsigned m_hw_wid;
-   unsigned m_hw_ctaid;
+ private:
+  bool m_functionalSimulationMode;
+  unsigned m_uid;
+  kernel_info_t &m_kernel;
+  core_t *m_core;
+  gpgpu_t *m_gpu;
+  bool m_valid;
+  dim3 m_ntid;
+  dim3 m_tid;
+  dim3 m_nctaid;
+  dim3 m_ctaid;
+  unsigned m_gridid;
+  bool m_thread_done;
+  unsigned m_hw_sid;
+  unsigned m_hw_tid;
+  unsigned m_hw_wid;
+  unsigned m_hw_ctaid;
 
-   unsigned m_icount;
-   unsigned m_PC;
-   unsigned m_NPC;
-   unsigned m_RPC;
-   bool m_RPC_updated;
-   bool m_last_was_call;
-   unsigned m_cycle_done;
+  unsigned m_icount;
+  unsigned m_PC;
+  unsigned m_NPC;
+  unsigned m_RPC;
+  bool m_RPC_updated;
+  bool m_last_was_call;
+  unsigned m_cycle_done;
 
-   int m_barrier_num;
-   bool m_at_barrier;
+  int m_barrier_num;
+  bool m_at_barrier;
 
-   symbol_table  *m_symbol_table;
-   function_info *m_func_info;
+  symbol_table *m_symbol_table;
+  function_info *m_func_info;
 
-   std::list<stack_entry> m_callstack;
-   unsigned m_local_mem_stack_pointer;
+  std::list<stack_entry> m_callstack;
+  unsigned m_local_mem_stack_pointer;
 
-   typedef tr1_hash_map<const symbol*,ptx_reg_t> reg_map_t;
-   std::list<reg_map_t> m_regs;
-   std::list<reg_map_t> m_debug_trace_regs_modified;
-   std::list<reg_map_t> m_debug_trace_regs_read;
-   bool m_enable_debug_trace;
+  typedef tr1_hash_map<const symbol *, ptx_reg_t> reg_map_t;
+  std::list<reg_map_t> m_regs;
+  std::list<reg_map_t> m_debug_trace_regs_modified;
+  std::list<reg_map_t> m_debug_trace_regs_read;
+  bool m_enable_debug_trace;
 
-   std::stack<class operand_info, std::vector<operand_info> > m_breakaddrs;
+  std::stack<class operand_info, std::vector<operand_info> > m_breakaddrs;
 };
 
-addr_t generic_to_local( unsigned smid, unsigned hwtid, addr_t addr );
-addr_t generic_to_shared( unsigned smid, addr_t addr );
-addr_t generic_to_global( addr_t addr );
-addr_t local_to_generic( unsigned smid, unsigned hwtid, addr_t addr );
-addr_t shared_to_generic( unsigned smid, addr_t addr );
-addr_t global_to_generic( addr_t addr );
-bool isspace_local( unsigned smid, unsigned hwtid, addr_t addr );
-bool isspace_shared( unsigned smid, addr_t addr );
-bool isspace_global( addr_t addr );
-memory_space_t whichspace( addr_t addr );
+addr_t generic_to_local(unsigned smid, unsigned hwtid, addr_t addr);
+addr_t generic_to_shared(unsigned smid, addr_t addr);
+addr_t generic_to_global(addr_t addr);
+addr_t local_to_generic(unsigned smid, unsigned hwtid, addr_t addr);
+addr_t shared_to_generic(unsigned smid, addr_t addr);
+addr_t global_to_generic(addr_t addr);
+bool isspace_local(unsigned smid, unsigned hwtid, addr_t addr);
+bool isspace_shared(unsigned smid, addr_t addr);
+bool isspace_global(addr_t addr);
+memory_space_t whichspace(addr_t addr);
 
 extern unsigned g_ptx_thread_info_uid_next;
 

--- a/src/cuda-sim/ptx_sim.h
+++ b/src/cuda-sim/ptx_sim.h
@@ -6,14 +6,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -28,31 +30,28 @@
 #define ptx_sim_h_INCLUDED
 
 #include <stdlib.h>
-#include "half.h"
 #include "../abstract_hardware_model.h"
-#include "../tr1_hash_map.h" 
+#include "../tr1_hash_map.h"
+#include "half.h"
 
 #include <assert.h>
 #include "opcodes.h"
 
-#include <string>
+#include <list>
 #include <map>
 #include <set>
-#include <list>
+#include <string>
 
 #include "memory.h"
 
-#define GCC_VERSION (__GNUC__ * 10000 \
-                     + __GNUC_MINOR__ * 100 \
-                     + __GNUC_PATCHLEVEL__)
-
-
+#define GCC_VERSION \
+  (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 
 struct param_t {
-   const void *pdata;
-   int type;
-   size_t size;
-   size_t offset;
+  const void *pdata;
+  int type;
+  size_t size;
+  size_t offset;
 };
 
 #include <stack>
@@ -62,98 +61,93 @@ struct param_t {
 using half_float::half;
 
 union ptx_reg_t {
-   ptx_reg_t() {
-      bits.ms = 0;
-      bits.ls = 0;
-      u128.low=0;
-      u128.lowest=0;
-      u128.highest=0;
-      u128.high=0;
-      s8=0;
-      s16=0;
-      s32=0;
-      s64=0;
-      u8=0;
-      u16=0;
-      u64=0;
-      f16=0;
-      f32=0;
-      f64=0;
-      pred=0;
-   }
-   ptx_reg_t(unsigned x) 
-   {
-      bits.ms = 0;
-      bits.ls = 0;
-      u128.low=0;
-      u128.lowest=0;
-      u128.highest=0;
-      u128.high=0;
-      s8=0;
-      s16=0;
-      s32=0;
-      s64=0;
-      u8=0;
-      u16=0;
-      u64=0;
-      f16=0;
-      f32=0;
-      f64=0;
-      pred=0;
-      u32 = x;
-   }
-   operator unsigned int() { return u32;}
-   operator unsigned short() { return u16;}
-   operator unsigned char() { return u8;}
-   operator unsigned long long() { return u64;}
+  ptx_reg_t() {
+    bits.ms = 0;
+    bits.ls = 0;
+    u128.low = 0;
+    u128.lowest = 0;
+    u128.highest = 0;
+    u128.high = 0;
+    s8 = 0;
+    s16 = 0;
+    s32 = 0;
+    s64 = 0;
+    u8 = 0;
+    u16 = 0;
+    u64 = 0;
+    f16 = 0;
+    f32 = 0;
+    f64 = 0;
+    pred = 0;
+  }
+  ptx_reg_t(unsigned x) {
+    bits.ms = 0;
+    bits.ls = 0;
+    u128.low = 0;
+    u128.lowest = 0;
+    u128.highest = 0;
+    u128.high = 0;
+    s8 = 0;
+    s16 = 0;
+    s32 = 0;
+    s64 = 0;
+    u8 = 0;
+    u16 = 0;
+    u64 = 0;
+    f16 = 0;
+    f32 = 0;
+    f64 = 0;
+    pred = 0;
+    u32 = x;
+  }
+  operator unsigned int() { return u32; }
+  operator unsigned short() { return u16; }
+  operator unsigned char() { return u8; }
+  operator unsigned long long() { return u64; }
 
-   void mask_and( unsigned ms, unsigned ls )
-   {
-      bits.ms &= ms;
-      bits.ls &= ls;
-   }
+  void mask_and(unsigned ms, unsigned ls) {
+    bits.ms &= ms;
+    bits.ls &= ls;
+  }
 
-   void mask_or( unsigned ms, unsigned ls )
-   {
-      bits.ms |= ms;
-      bits.ls |= ls;
-   }
-   int get_bit( unsigned bit )
-   {
-      if ( bit < 32 )
-         return(bits.ls >> bit) & 1;
-      else
-         return(bits.ms >> (bit-32)) & 1;
-   }
+  void mask_or(unsigned ms, unsigned ls) {
+    bits.ms |= ms;
+    bits.ls |= ls;
+  }
+  int get_bit(unsigned bit) {
+    if (bit < 32)
+      return (bits.ls >> bit) & 1;
+    else
+      return (bits.ms >> (bit - 32)) & 1;
+  }
 
-   signed char       s8;
-   signed short      s16;
-   signed int        s32;
-   signed long long  s64;
-   unsigned char     u8;
-   unsigned short    u16;
-   unsigned int      u32;
-   unsigned long long   u64;
-   //gcc 4.7.0
-   #if GCC_VERSION >= 40700
-   half 		f16; 
-   #else
-   float 		f16; 
-   #endif
-   float          f32;
-   double            f64;
-   struct {
-      unsigned ls;
-      unsigned ms;
-   } bits;
-   struct {
-       unsigned int lowest;
-       unsigned int low;
-       unsigned int high;
-       unsigned int highest;
-   } u128;
-   unsigned       pred : 4;
-
+  signed char s8;
+  signed short s16;
+  signed int s32;
+  signed long long s64;
+  unsigned char u8;
+  unsigned short u16;
+  unsigned int u32;
+  unsigned long long u64;
+// gcc 4.7.0
+#if GCC_VERSION >= 40700
+  half f16;
+#else
+  float f16;
+#endif
+  float f32;
+  double f64;
+  struct {
+    unsigned ls;
+    unsigned ms;
+  } bits;
+  struct {
+    unsigned int lowest;
+    unsigned int low;
+    unsigned int high;
+    unsigned int highest;
+  } u128;
+  unsigned pred : 4;
 };
 
 class ptx_instruction;
@@ -163,373 +157,375 @@ class function_info;
 class ptx_thread_info;
 
 class ptx_cta_info {
-public:
-   ptx_cta_info( unsigned sm_idx, gpgpu_context* ctx );
-   void add_thread( ptx_thread_info *thd );
-   unsigned num_threads() const;
-   void check_cta_thread_status_and_reset();
-   void register_thread_exit( ptx_thread_info *thd );
-   void register_deleted_thread( ptx_thread_info *thd );
-   unsigned get_sm_idx() const;
-   unsigned get_bar_threads() const;
-   void inc_bar_threads();
-   void reset_bar_threads();
+ public:
+  ptx_cta_info(unsigned sm_idx, gpgpu_context *ctx);
+  void add_thread(ptx_thread_info *thd);
+  unsigned num_threads() const;
+  void check_cta_thread_status_and_reset();
+  void register_thread_exit(ptx_thread_info *thd);
+  void register_deleted_thread(ptx_thread_info *thd);
+  unsigned get_sm_idx() const;
+  unsigned get_bar_threads() const;
+  void inc_bar_threads();
+  void reset_bar_threads();
 
-private:
-   // backward pointer
-   class gpgpu_context* gpgpu_ctx;
-   unsigned           m_bar_threads;
-   unsigned long long         m_uid;
-   unsigned                m_sm_idx;
-   std::set<ptx_thread_info*>    m_threads_in_cta;
-   std::set<ptx_thread_info*>  m_threads_that_have_exited;
-   std::set<ptx_thread_info*>  m_dangling_pointers;
+ private:
+  // backward pointer
+  class gpgpu_context *gpgpu_ctx;
+  unsigned m_bar_threads;
+  unsigned long long m_uid;
+  unsigned m_sm_idx;
+  std::set<ptx_thread_info *> m_threads_in_cta;
+  std::set<ptx_thread_info *> m_threads_that_have_exited;
+  std::set<ptx_thread_info *> m_dangling_pointers;
 };
 
 class ptx_warp_info {
-public:
-	ptx_warp_info(); // add get_core or something, or threads?
-	unsigned get_done_threads() const;
-	void inc_done_threads();
-	void reset_done_threads();
+ public:
+  ptx_warp_info();  // add get_core or something, or threads?
+  unsigned get_done_threads() const;
+  void inc_done_threads();
+  void reset_done_threads();
 
-private:
-	unsigned m_done_threads;
+ private:
+  unsigned m_done_threads;
 };
 
 class symbol;
 
 struct stack_entry {
-   stack_entry() {
-      m_symbol_table=NULL;
-      m_func_info=NULL;
-      m_PC=0;
-      m_RPC=-1;
-      m_return_var_src = NULL;
-      m_return_var_dst = NULL;
-      m_call_uid = 0;
-      m_valid = false;
-   }
-   stack_entry( symbol_table *s, function_info *f, unsigned pc, unsigned rpc, const symbol *return_var_src, const symbol *return_var_dst, unsigned call_uid )
-   {
-      m_symbol_table=s;
-      m_func_info=f;
-      m_PC=pc;
-      m_RPC=rpc;
-      m_return_var_src = return_var_src;
-      m_return_var_dst = return_var_dst;
-      m_call_uid = call_uid;
-      m_valid = true;
-   }
+  stack_entry() {
+    m_symbol_table = NULL;
+    m_func_info = NULL;
+    m_PC = 0;
+    m_RPC = -1;
+    m_return_var_src = NULL;
+    m_return_var_dst = NULL;
+    m_call_uid = 0;
+    m_valid = false;
+  }
+  stack_entry(symbol_table *s, function_info *f, unsigned pc, unsigned rpc,
+              const symbol *return_var_src, const symbol *return_var_dst,
+              unsigned call_uid) {
+    m_symbol_table = s;
+    m_func_info = f;
+    m_PC = pc;
+    m_RPC = rpc;
+    m_return_var_src = return_var_src;
+    m_return_var_dst = return_var_dst;
+    m_call_uid = call_uid;
+    m_valid = true;
+  }
 
-   bool m_valid;
-   symbol_table  *m_symbol_table;
-   function_info *m_func_info;
-   unsigned       m_PC;
-   unsigned       m_RPC;
-   const symbol  *m_return_var_src;
-   const symbol  *m_return_var_dst;
-   unsigned       m_call_uid;
+  bool m_valid;
+  symbol_table *m_symbol_table;
+  function_info *m_func_info;
+  unsigned m_PC;
+  unsigned m_RPC;
+  const symbol *m_return_var_src;
+  const symbol *m_return_var_dst;
+  unsigned m_call_uid;
 };
 
 class ptx_version {
-public:
-      ptx_version()
-      {
-         m_valid = false;
-         m_ptx_version = 0;
-         m_ptx_extensions = 0;
-         m_sm_version_valid=false;
-         m_texmode_unified=true;
-         m_map_f64_to_f32 = true; 
-      }
-      ptx_version(float ver, unsigned extensions)
-      {
-         m_valid = true;
-         m_ptx_version = ver;
-         m_ptx_extensions = extensions;
-         m_sm_version_valid=false;
-         m_texmode_unified=true;
-      }
-      void set_target( const char *sm_ver, const char *ext, const char *ext2 ) 
-      { 
-         assert( m_valid );
-         m_sm_version_str = sm_ver;
-         check_target_extension(ext); 
-         check_target_extension(ext2); 
-         sscanf(sm_ver,"%u",&m_sm_version);
-         m_sm_version_valid=true; 
-      }
-      float    ver() const { assert(m_valid); return m_ptx_version; }
-      unsigned target() const { assert(m_valid&&m_sm_version_valid); return m_sm_version; }
-      unsigned extensions() const { assert(m_valid); return m_ptx_extensions; }
-private:
-      void check_target_extension( const char *ext ) 
-      {
-         if( ext ) {
-            if( !strcmp(ext,"texmode_independent") ) 
-               m_texmode_unified=false;
-            else if( !strcmp(ext,"texmode_unified") ) 
-               m_texmode_unified=true;
-            else if( !strcmp(ext,"map_f64_to_f32") ) 
-               m_map_f64_to_f32 = true; 
-            else abort();
-         }
-      }
+ public:
+  ptx_version() {
+    m_valid = false;
+    m_ptx_version = 0;
+    m_ptx_extensions = 0;
+    m_sm_version_valid = false;
+    m_texmode_unified = true;
+    m_map_f64_to_f32 = true;
+  }
+  ptx_version(float ver, unsigned extensions) {
+    m_valid = true;
+    m_ptx_version = ver;
+    m_ptx_extensions = extensions;
+    m_sm_version_valid = false;
+    m_texmode_unified = true;
+  }
+  void set_target(const char *sm_ver, const char *ext, const char *ext2) {
+    assert(m_valid);
+    m_sm_version_str = sm_ver;
+    check_target_extension(ext);
+    check_target_extension(ext2);
+    sscanf(sm_ver, "%u", &m_sm_version);
+    m_sm_version_valid = true;
+  }
+  float ver() const {
+    assert(m_valid);
+    return m_ptx_version;
+  }
+  unsigned target() const {
+    assert(m_valid && m_sm_version_valid);
+    return m_sm_version;
+  }
+  unsigned extensions() const {
+    assert(m_valid);
+    return m_ptx_extensions;
+  }
 
-      bool     m_valid;
-      float    m_ptx_version;
-      unsigned m_sm_version_valid;
-      std::string m_sm_version_str;
-      bool     m_texmode_unified;
-      bool     m_map_f64_to_f32; 
-      unsigned m_sm_version;
-      unsigned m_ptx_extensions;
+ private:
+  void check_target_extension(const char *ext) {
+    if (ext) {
+      if (!strcmp(ext, "texmode_independent"))
+        m_texmode_unified = false;
+      else if (!strcmp(ext, "texmode_unified"))
+        m_texmode_unified = true;
+      else if (!strcmp(ext, "map_f64_to_f32"))
+        m_map_f64_to_f32 = true;
+      else
+        abort();
+    }
+  }
+
+  bool m_valid;
+  float m_ptx_version;
+  unsigned m_sm_version_valid;
+  std::string m_sm_version_str;
+  bool m_texmode_unified;
+  bool m_map_f64_to_f32;
+  unsigned m_sm_version;
+  unsigned m_ptx_extensions;
 };
 
 class ptx_thread_info {
-public:
-   ~ptx_thread_info();
-   ptx_thread_info( kernel_info_t &kernel );
+ public:
+  ~ptx_thread_info();
+  ptx_thread_info(kernel_info_t &kernel);
 
-   void init(gpgpu_t *gpu, core_t *core, unsigned sid, unsigned cta_id, unsigned wid, unsigned tid, bool fsim) 
-   { 
-      m_gpu = gpu;
-      m_core = core; 
-      m_hw_sid=sid;
-      m_hw_ctaid=cta_id;
-      m_hw_wid=wid;
-      m_hw_tid=tid;
-      m_functionalSimulationMode = fsim;
-   }
+  void init(gpgpu_t *gpu, core_t *core, unsigned sid, unsigned cta_id,
+            unsigned wid, unsigned tid, bool fsim) {
+    m_gpu = gpu;
+    m_core = core;
+    m_hw_sid = sid;
+    m_hw_ctaid = cta_id;
+    m_hw_wid = wid;
+    m_hw_tid = tid;
+    m_functionalSimulationMode = fsim;
+  }
 
-   void ptx_fetch_inst( inst_t &inst ) const;
-   void ptx_exec_inst( warp_inst_t &inst, unsigned lane_id );
+  void ptx_fetch_inst(inst_t &inst) const;
+  void ptx_exec_inst(warp_inst_t &inst, unsigned lane_id);
 
-   const ptx_version &get_ptx_version() const;
-   void set_reg( const symbol *reg, const ptx_reg_t &value );
-   void print_reg_thread (char * fname);
-   void resume_reg_thread(char * fname,  symbol_table * symtab);
-   ptx_reg_t get_reg( const symbol *reg );
-   ptx_reg_t get_operand_value( const operand_info &op, operand_info dstInfo, unsigned opType, ptx_thread_info *thread, int derefFlag );
-   void set_operand_value( const operand_info &dst, const ptx_reg_t &data, unsigned type, ptx_thread_info *thread, const ptx_instruction *pI );
-   void set_operand_value( const operand_info &dst, const ptx_reg_t &data, unsigned type, ptx_thread_info *thread, const ptx_instruction *pI, int overflow, int carry );
-   void get_vector_operand_values( const operand_info &op, ptx_reg_t* ptx_regs, unsigned num_elements );
-   void set_vector_operand_values( const operand_info &dst, 
-                                   const ptx_reg_t &data1, 
-                                   const ptx_reg_t &data2, 
-                                   const ptx_reg_t &data3, 
-                                   const ptx_reg_t &data4 );
-   void set_wmma_vector_operand_values( const operand_info &dst, 
-                                        const ptx_reg_t &data1, 
-                                        const ptx_reg_t &data2, 
-                                        const ptx_reg_t &data3, 
-                                        const ptx_reg_t &data4, 
-                                        const ptx_reg_t &data5, 
-                                        const ptx_reg_t &data6, 
-                                        const ptx_reg_t &data7, 
-                                        const ptx_reg_t &data8 );
+  const ptx_version &get_ptx_version() const;
+  void set_reg(const symbol *reg, const ptx_reg_t &value);
+  void print_reg_thread(char *fname);
+  void resume_reg_thread(char *fname, symbol_table *symtab);
+  ptx_reg_t get_reg(const symbol *reg);
+  ptx_reg_t get_operand_value(const operand_info &op, operand_info dstInfo,
+                              unsigned opType, ptx_thread_info *thread,
+                              int derefFlag);
+  void set_operand_value(const operand_info &dst, const ptx_reg_t &data,
+                         unsigned type, ptx_thread_info *thread,
+                         const ptx_instruction *pI);
+  void set_operand_value(const operand_info &dst, const ptx_reg_t &data,
+                         unsigned type, ptx_thread_info *thread,
+                         const ptx_instruction *pI, int overflow, int carry);
+  void get_vector_operand_values(const operand_info &op, ptx_reg_t *ptx_regs,
+                                 unsigned num_elements);
+  void set_vector_operand_values(const operand_info &dst,
+                                 const ptx_reg_t &data1, const ptx_reg_t &data2,
+                                 const ptx_reg_t &data3,
+                                 const ptx_reg_t &data4);
+  void set_wmma_vector_operand_values(
+      const operand_info &dst, const ptx_reg_t &data1, const ptx_reg_t &data2,
+      const ptx_reg_t &data3, const ptx_reg_t &data4, const ptx_reg_t &data5,
+      const ptx_reg_t &data6, const ptx_reg_t &data7, const ptx_reg_t &data8);
 
-   function_info *func_info()
-   {
-      return m_func_info; 
-   }
-   void print_insn( unsigned pc, FILE * fp ) const;
-   void set_info( function_info *func );
-   unsigned get_uid() const
-   {
-      return m_uid;
-   }
+  function_info *func_info() { return m_func_info; }
+  void print_insn(unsigned pc, FILE *fp) const;
+  void set_info(function_info *func);
+  unsigned get_uid() const { return m_uid; }
 
-   dim3 get_ctaid() const { return m_ctaid; }
-   dim3 get_tid() const { return m_tid; }
-   dim3 get_ntid() const { return m_ntid; }
-   class gpgpu_sim *get_gpu() { return (gpgpu_sim*)m_gpu;}
-   unsigned get_hw_tid() const { return m_hw_tid;}
-   unsigned get_hw_ctaid() const { return m_hw_ctaid;}
-   unsigned get_hw_wid() const { return m_hw_wid;}
-   unsigned get_hw_sid() const { return m_hw_sid;}
-   core_t *get_core() { return m_core; }
+  dim3 get_ctaid() const { return m_ctaid; }
+  dim3 get_tid() const { return m_tid; }
+  dim3 get_ntid() const { return m_ntid; }
+  class gpgpu_sim *get_gpu() {
+    return (gpgpu_sim *)m_gpu;
+  }
+  unsigned get_hw_tid() const { return m_hw_tid; }
+  unsigned get_hw_ctaid() const { return m_hw_ctaid; }
+  unsigned get_hw_wid() const { return m_hw_wid; }
+  unsigned get_hw_sid() const { return m_hw_sid; }
+  core_t *get_core() { return m_core; }
 
-   unsigned get_icount() const { return m_icount;}
-   void set_valid() { m_valid = true;}
-   addr_t last_eaddr() const { return m_last_effective_address;}
-   memory_space_t last_space() const { return m_last_memory_space;}
-   dram_callback_t last_callback() const { return m_last_dram_callback;}
-   unsigned long long get_cta_uid() { return m_cta_info->get_sm_idx();}
+  unsigned get_icount() const { return m_icount; }
+  void set_valid() { m_valid = true; }
+  addr_t last_eaddr() const { return m_last_effective_address; }
+  memory_space_t last_space() const { return m_last_memory_space; }
+  dram_callback_t last_callback() const { return m_last_dram_callback; }
+  unsigned long long get_cta_uid() { return m_cta_info->get_sm_idx(); }
 
-   void set_single_thread_single_block()
-   {
-      m_ntid.x = 1;
-      m_ntid.y = 1;
-      m_ntid.z = 1;
-      m_ctaid.x = 0;
-      m_ctaid.y = 0;
-      m_ctaid.z = 0;
-      m_tid.x = 0;
-      m_tid.y = 0;
-      m_tid.z = 0;
-      m_nctaid.x = 1;
-      m_nctaid.y = 1;
-      m_nctaid.z = 1;
-      m_gridid = 0;
-      m_valid = true;
-   }
-   void set_tid( dim3 tid ) { m_tid = tid; }
-   void cpy_tid_to_reg( dim3 tid );
-   void set_ctaid( dim3 ctaid ) { m_ctaid = ctaid; }
-   void set_ntid( dim3 tid ) { m_ntid = tid; }
-   void set_nctaid( dim3 cta_size ) { m_nctaid = cta_size; }
+  void set_single_thread_single_block() {
+    m_ntid.x = 1;
+    m_ntid.y = 1;
+    m_ntid.z = 1;
+    m_ctaid.x = 0;
+    m_ctaid.y = 0;
+    m_ctaid.z = 0;
+    m_tid.x = 0;
+    m_tid.y = 0;
+    m_tid.z = 0;
+    m_nctaid.x = 1;
+    m_nctaid.y = 1;
+    m_nctaid.z = 1;
+    m_gridid = 0;
+    m_valid = true;
+  }
+  void set_tid(dim3 tid) { m_tid = tid; }
+  void cpy_tid_to_reg(dim3 tid);
+  void set_ctaid(dim3 ctaid) { m_ctaid = ctaid; }
+  void set_ntid(dim3 tid) { m_ntid = tid; }
+  void set_nctaid(dim3 cta_size) { m_nctaid = cta_size; }
 
-   unsigned get_builtin( int builtin_id, unsigned dim_mod ); 
+  unsigned get_builtin(int builtin_id, unsigned dim_mod);
 
-   void set_done();
-   bool is_done() { return m_thread_done;}
-   unsigned donecycle() const { return m_cycle_done; }
+  void set_done();
+  bool is_done() { return m_thread_done; }
+  unsigned donecycle() const { return m_cycle_done; }
 
-   unsigned next_instr()
-   {
-      m_icount++;
-      m_branch_taken = false;
-      return m_PC;
-   }
-   bool branch_taken() const
-   {
-      return m_branch_taken;
-   }
-   unsigned get_pc() const
-   {
-      return m_PC;
-   }
-   void set_npc( unsigned npc )
-   {
-      m_NPC = npc;
-   }
-   void set_npc( const function_info *f );
-   void callstack_push( unsigned npc, unsigned rpc, const symbol *return_var_src, const symbol *return_var_dst, unsigned call_uid );
-   bool callstack_pop();
-   void callstack_push_plus( unsigned npc, unsigned rpc, const symbol *return_var_src, const symbol *return_var_dst, unsigned call_uid );
-   bool callstack_pop_plus();
-   void dump_callstack() const;
-   std::string get_location() const;
-   const ptx_instruction *get_inst() const;
-   const ptx_instruction *get_inst( addr_t pc ) const;
-   bool rpc_updated() const { return m_RPC_updated; }
-   bool last_was_call() const { return m_last_was_call; }
-   unsigned get_rpc() const { return m_RPC; }
-   void clearRPC()
-   {
-      m_RPC = -1;
-      m_RPC_updated = false;
-      m_last_was_call = false;
-   }
-   unsigned get_return_PC()
-   {
-       return m_callstack.back().m_PC;
-   }
-   void update_pc( )
-   {
-      m_PC = m_NPC;
-   }
-   void dump_regs(FILE * fp);
-   void dump_modifiedregs(FILE *fp);
-   void clear_modifiedregs() { m_debug_trace_regs_modified.back().clear(); m_debug_trace_regs_read.back().clear(); }
-   function_info *get_finfo() { return m_func_info;   }
-   const function_info *get_finfo() const { return m_func_info;   }
-   void push_breakaddr(const operand_info &breakaddr);
-   const operand_info& pop_breakaddr();
-   void enable_debug_trace() { m_enable_debug_trace = true; }
-   unsigned get_local_mem_stack_pointer() const { return m_local_mem_stack_pointer; }
+  unsigned next_instr() {
+    m_icount++;
+    m_branch_taken = false;
+    return m_PC;
+  }
+  bool branch_taken() const { return m_branch_taken; }
+  unsigned get_pc() const { return m_PC; }
+  void set_npc(unsigned npc) { m_NPC = npc; }
+  void set_npc(const function_info *f);
+  void callstack_push(unsigned npc, unsigned rpc, const symbol *return_var_src,
+                      const symbol *return_var_dst, unsigned call_uid);
+  bool callstack_pop();
+  void callstack_push_plus(unsigned npc, unsigned rpc,
+                           const symbol *return_var_src,
+                           const symbol *return_var_dst, unsigned call_uid);
+  bool callstack_pop_plus();
+  void dump_callstack() const;
+  std::string get_location() const;
+  const ptx_instruction *get_inst() const;
+  const ptx_instruction *get_inst(addr_t pc) const;
+  bool rpc_updated() const { return m_RPC_updated; }
+  bool last_was_call() const { return m_last_was_call; }
+  unsigned get_rpc() const { return m_RPC; }
+  void clearRPC() {
+    m_RPC = -1;
+    m_RPC_updated = false;
+    m_last_was_call = false;
+  }
+  unsigned get_return_PC() { return m_callstack.back().m_PC; }
+  void update_pc() { m_PC = m_NPC; }
+  void dump_regs(FILE *fp);
+  void dump_modifiedregs(FILE *fp);
+  void clear_modifiedregs() {
+    m_debug_trace_regs_modified.back().clear();
+    m_debug_trace_regs_read.back().clear();
+  }
+  function_info *get_finfo() { return m_func_info; }
+  const function_info *get_finfo() const { return m_func_info; }
+  void push_breakaddr(const operand_info &breakaddr);
+  const operand_info &pop_breakaddr();
+  void enable_debug_trace() { m_enable_debug_trace = true; }
+  unsigned get_local_mem_stack_pointer() const {
+    return m_local_mem_stack_pointer;
+  }
 
-   memory_space *get_global_memory() { return m_gpu->get_global_memory(); }
-   memory_space *get_tex_memory() { return m_gpu->get_tex_memory(); }
-   memory_space *get_surf_memory() { return m_gpu->get_surf_memory(); }
-   memory_space *get_param_memory() { return m_kernel.get_param_memory(); }
-   const gpgpu_functional_sim_config &get_config() const { return m_gpu->get_config(); }
-   bool isInFunctionalSimulationMode(){ return m_functionalSimulationMode;}
-   void exitCore()
-   {
-       //m_core is not used in case of functional simulation mode
-       if(!m_functionalSimulationMode)
-           m_core->warp_exit(m_hw_wid);
-   }
-   
-   void registerExit(){m_cta_info->register_thread_exit(this);}
-   unsigned get_reduction_value(unsigned ctaid, unsigned barid) {return m_core->get_reduction_value(ctaid,barid);}
-   void and_reduction(unsigned ctaid, unsigned barid, bool value) {m_core->and_reduction(ctaid,barid,value);}
-   void or_reduction(unsigned ctaid, unsigned barid, bool value) {m_core->or_reduction(ctaid,barid,value);}
-   void popc_reduction(unsigned ctaid, unsigned barid, bool value) {m_core->popc_reduction(ctaid,barid,value);}
+  memory_space *get_global_memory() { return m_gpu->get_global_memory(); }
+  memory_space *get_tex_memory() { return m_gpu->get_tex_memory(); }
+  memory_space *get_surf_memory() { return m_gpu->get_surf_memory(); }
+  memory_space *get_param_memory() { return m_kernel.get_param_memory(); }
+  const gpgpu_functional_sim_config &get_config() const {
+    return m_gpu->get_config();
+  }
+  bool isInFunctionalSimulationMode() { return m_functionalSimulationMode; }
+  void exitCore() {
+    // m_core is not used in case of functional simulation mode
+    if (!m_functionalSimulationMode) m_core->warp_exit(m_hw_wid);
+  }
 
-   //Jin: get corresponding kernel grid for CDP purpose
-   kernel_info_t & get_kernel() { return m_kernel; }
+  void registerExit() { m_cta_info->register_thread_exit(this); }
+  unsigned get_reduction_value(unsigned ctaid, unsigned barid) {
+    return m_core->get_reduction_value(ctaid, barid);
+  }
+  void and_reduction(unsigned ctaid, unsigned barid, bool value) {
+    m_core->and_reduction(ctaid, barid, value);
+  }
+  void or_reduction(unsigned ctaid, unsigned barid, bool value) {
+    m_core->or_reduction(ctaid, barid, value);
+  }
+  void popc_reduction(unsigned ctaid, unsigned barid, bool value) {
+    m_core->popc_reduction(ctaid, barid, value);
+  }
 
-public:
-   addr_t         m_last_effective_address;
-   bool        m_branch_taken;
-   memory_space_t m_last_memory_space;
-   dram_callback_t   m_last_dram_callback; 
-   memory_space   *m_shared_mem;
-   memory_space   *m_sstarr_mem;
-   memory_space   *m_local_mem;
-   ptx_warp_info  *m_warp_info;
-   ptx_cta_info   *m_cta_info;
-   ptx_reg_t m_last_set_operand_value;
+  // Jin: get corresponding kernel grid for CDP purpose
+  kernel_info_t &get_kernel() { return m_kernel; }
 
-private:
+ public:
+  addr_t m_last_effective_address;
+  bool m_branch_taken;
+  memory_space_t m_last_memory_space;
+  dram_callback_t m_last_dram_callback;
+  memory_space *m_shared_mem;
+  memory_space *m_sstarr_mem;
+  memory_space *m_local_mem;
+  ptx_warp_info *m_warp_info;
+  ptx_cta_info *m_cta_info;
+  ptx_reg_t m_last_set_operand_value;
 
-   bool m_functionalSimulationMode; 
-   unsigned m_uid;
-   kernel_info_t &m_kernel;
-   core_t *m_core;
-   gpgpu_t *m_gpu;
-   bool   m_valid;
-   dim3   m_ntid;
-   dim3   m_tid;
-   dim3   m_nctaid;
-   dim3   m_ctaid;
-   unsigned m_gridid;
-   bool m_thread_done;
-   unsigned m_hw_sid;
-   unsigned m_hw_tid;
-   unsigned m_hw_wid;
-   unsigned m_hw_ctaid;
+ private:
+  bool m_functionalSimulationMode;
+  unsigned m_uid;
+  kernel_info_t &m_kernel;
+  core_t *m_core;
+  gpgpu_t *m_gpu;
+  bool m_valid;
+  dim3 m_ntid;
+  dim3 m_tid;
+  dim3 m_nctaid;
+  dim3 m_ctaid;
+  unsigned m_gridid;
+  bool m_thread_done;
+  unsigned m_hw_sid;
+  unsigned m_hw_tid;
+  unsigned m_hw_wid;
+  unsigned m_hw_ctaid;
 
-   unsigned m_icount;
-   unsigned m_PC;
-   unsigned m_NPC;
-   unsigned m_RPC;
-   bool m_RPC_updated;
-   bool m_last_was_call;
-   unsigned m_cycle_done;
+  unsigned m_icount;
+  unsigned m_PC;
+  unsigned m_NPC;
+  unsigned m_RPC;
+  bool m_RPC_updated;
+  bool m_last_was_call;
+  unsigned m_cycle_done;
 
-   int m_barrier_num;
-   bool m_at_barrier;
+  int m_barrier_num;
+  bool m_at_barrier;
 
-   symbol_table  *m_symbol_table;
-   function_info *m_func_info;
+  symbol_table *m_symbol_table;
+  function_info *m_func_info;
 
-   std::list<stack_entry> m_callstack;
-   unsigned m_local_mem_stack_pointer;
+  std::list<stack_entry> m_callstack;
+  unsigned m_local_mem_stack_pointer;
 
-   typedef tr1_hash_map<const symbol*,ptx_reg_t> reg_map_t;
-   std::list<reg_map_t> m_regs;
-   std::list<reg_map_t> m_debug_trace_regs_modified;
-   std::list<reg_map_t> m_debug_trace_regs_read;
-   bool m_enable_debug_trace;
+  typedef tr1_hash_map<const symbol *, ptx_reg_t> reg_map_t;
+  std::list<reg_map_t> m_regs;
+  std::list<reg_map_t> m_debug_trace_regs_modified;
+  std::list<reg_map_t> m_debug_trace_regs_read;
+  bool m_enable_debug_trace;
 
-   std::stack<class operand_info, std::vector<operand_info> > m_breakaddrs;
+  std::stack<class operand_info, std::vector<operand_info> > m_breakaddrs;
 };
 
-addr_t generic_to_local( unsigned smid, unsigned hwtid, addr_t addr );
-addr_t generic_to_shared( unsigned smid, addr_t addr );
-addr_t generic_to_global( addr_t addr );
-addr_t local_to_generic( unsigned smid, unsigned hwtid, addr_t addr );
-addr_t shared_to_generic( unsigned smid, addr_t addr );
-addr_t global_to_generic( addr_t addr );
-bool isspace_local( unsigned smid, unsigned hwtid, addr_t addr );
-bool isspace_shared( unsigned smid, addr_t addr );
-bool isspace_global( addr_t addr );
-memory_space_t whichspace( addr_t addr );
+addr_t generic_to_local(unsigned smid, unsigned hwtid, addr_t addr);
+addr_t generic_to_shared(unsigned smid, addr_t addr);
+addr_t generic_to_global(addr_t addr);
+addr_t local_to_generic(unsigned smid, unsigned hwtid, addr_t addr);
+addr_t shared_to_generic(unsigned smid, addr_t addr);
+addr_t global_to_generic(addr_t addr);
+bool isspace_local(unsigned smid, unsigned hwtid, addr_t addr);
+bool isspace_shared(unsigned smid, addr_t addr);
+bool isspace_global(addr_t addr);
+memory_space_t whichspace(addr_t addr);
 
 extern unsigned g_ptx_thread_info_uid_next;
 

--- a/src/cuda-sim/ptx_sim.h
+++ b/src/cuda-sim/ptx_sim.h
@@ -6,16 +6,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -30,28 +28,31 @@
 #define ptx_sim_h_INCLUDED
 
 #include <stdlib.h>
-#include "../abstract_hardware_model.h"
-#include "../tr1_hash_map.h"
 #include "half.h"
+#include "../abstract_hardware_model.h"
+#include "../tr1_hash_map.h" 
 
 #include <assert.h>
 #include "opcodes.h"
 
-#include <list>
+#include <string>
 #include <map>
 #include <set>
-#include <string>
+#include <list>
 
 #include "memory.h"
 
-#define GCC_VERSION \
-  (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+#define GCC_VERSION (__GNUC__ * 10000 \
+                     + __GNUC_MINOR__ * 100 \
+                     + __GNUC_PATCHLEVEL__)
+
+
 
 struct param_t {
-  const void *pdata;
-  int type;
-  size_t size;
-  size_t offset;
+   const void *pdata;
+   int type;
+   size_t size;
+   size_t offset;
 };
 
 #include <stack>
@@ -61,93 +62,98 @@ struct param_t {
 using half_float::half;
 
 union ptx_reg_t {
-  ptx_reg_t() {
-    bits.ms = 0;
-    bits.ls = 0;
-    u128.low = 0;
-    u128.lowest = 0;
-    u128.highest = 0;
-    u128.high = 0;
-    s8 = 0;
-    s16 = 0;
-    s32 = 0;
-    s64 = 0;
-    u8 = 0;
-    u16 = 0;
-    u64 = 0;
-    f16 = 0;
-    f32 = 0;
-    f64 = 0;
-    pred = 0;
-  }
-  ptx_reg_t(unsigned x) {
-    bits.ms = 0;
-    bits.ls = 0;
-    u128.low = 0;
-    u128.lowest = 0;
-    u128.highest = 0;
-    u128.high = 0;
-    s8 = 0;
-    s16 = 0;
-    s32 = 0;
-    s64 = 0;
-    u8 = 0;
-    u16 = 0;
-    u64 = 0;
-    f16 = 0;
-    f32 = 0;
-    f64 = 0;
-    pred = 0;
-    u32 = x;
-  }
-  operator unsigned int() { return u32; }
-  operator unsigned short() { return u16; }
-  operator unsigned char() { return u8; }
-  operator unsigned long long() { return u64; }
+   ptx_reg_t() {
+      bits.ms = 0;
+      bits.ls = 0;
+      u128.low=0;
+      u128.lowest=0;
+      u128.highest=0;
+      u128.high=0;
+      s8=0;
+      s16=0;
+      s32=0;
+      s64=0;
+      u8=0;
+      u16=0;
+      u64=0;
+      f16=0;
+      f32=0;
+      f64=0;
+      pred=0;
+   }
+   ptx_reg_t(unsigned x) 
+   {
+      bits.ms = 0;
+      bits.ls = 0;
+      u128.low=0;
+      u128.lowest=0;
+      u128.highest=0;
+      u128.high=0;
+      s8=0;
+      s16=0;
+      s32=0;
+      s64=0;
+      u8=0;
+      u16=0;
+      u64=0;
+      f16=0;
+      f32=0;
+      f64=0;
+      pred=0;
+      u32 = x;
+   }
+   operator unsigned int() { return u32;}
+   operator unsigned short() { return u16;}
+   operator unsigned char() { return u8;}
+   operator unsigned long long() { return u64;}
 
-  void mask_and(unsigned ms, unsigned ls) {
-    bits.ms &= ms;
-    bits.ls &= ls;
-  }
+   void mask_and( unsigned ms, unsigned ls )
+   {
+      bits.ms &= ms;
+      bits.ls &= ls;
+   }
 
-  void mask_or(unsigned ms, unsigned ls) {
-    bits.ms |= ms;
-    bits.ls |= ls;
-  }
-  int get_bit(unsigned bit) {
-    if (bit < 32)
-      return (bits.ls >> bit) & 1;
-    else
-      return (bits.ms >> (bit - 32)) & 1;
-  }
+   void mask_or( unsigned ms, unsigned ls )
+   {
+      bits.ms |= ms;
+      bits.ls |= ls;
+   }
+   int get_bit( unsigned bit )
+   {
+      if ( bit < 32 )
+         return(bits.ls >> bit) & 1;
+      else
+         return(bits.ms >> (bit-32)) & 1;
+   }
 
-  signed char s8;
-  signed short s16;
-  signed int s32;
-  signed long long s64;
-  unsigned char u8;
-  unsigned short u16;
-  unsigned int u32;
-  unsigned long long u64;
-// gcc 4.7.0
-#if GCC_VERSION >= 40700
-  half f16;
-#else
-  float f16;
-#endif
-  float f32;
-  double f64;
-  struct {
-    unsigned ls;
-    unsigned ms;
-  } bits;
-  struct {
-    unsigned int lowest;
-    unsigned int low;
-    unsigned int high;
-    unsigned int highest;
-  } u128;
-  unsigned pred : 4;
+   signed char       s8;
+   signed short      s16;
+   signed int        s32;
+   signed long long  s64;
+   unsigned char     u8;
+   unsigned short    u16;
+   unsigned int      u32;
+   unsigned long long   u64;
+   //gcc 4.7.0
+   #if GCC_VERSION >= 40700
+   half 		f16; 
+   #else
+   float 		f16; 
+   #endif
+   float          f32;
+   double            f64;
+   struct {
+      unsigned ls;
+      unsigned ms;
+   } bits;
+   struct {
+       unsigned int lowest;
+       unsigned int low;
+       unsigned int high;
+       unsigned int highest;
+   } u128;
+   unsigned       pred : 4;
+
 };
 
 class ptx_instruction;
@@ -157,375 +163,373 @@ class function_info;
 class ptx_thread_info;
 
 class ptx_cta_info {
- public:
-  ptx_cta_info(unsigned sm_idx, gpgpu_context *ctx);
-  void add_thread(ptx_thread_info *thd);
-  unsigned num_threads() const;
-  void check_cta_thread_status_and_reset();
-  void register_thread_exit(ptx_thread_info *thd);
-  void register_deleted_thread(ptx_thread_info *thd);
-  unsigned get_sm_idx() const;
-  unsigned get_bar_threads() const;
-  void inc_bar_threads();
-  void reset_bar_threads();
+public:
+   ptx_cta_info( unsigned sm_idx, gpgpu_context* ctx );
+   void add_thread( ptx_thread_info *thd );
+   unsigned num_threads() const;
+   void check_cta_thread_status_and_reset();
+   void register_thread_exit( ptx_thread_info *thd );
+   void register_deleted_thread( ptx_thread_info *thd );
+   unsigned get_sm_idx() const;
+   unsigned get_bar_threads() const;
+   void inc_bar_threads();
+   void reset_bar_threads();
 
- private:
-  // backward pointer
-  class gpgpu_context *gpgpu_ctx;
-  unsigned m_bar_threads;
-  unsigned long long m_uid;
-  unsigned m_sm_idx;
-  std::set<ptx_thread_info *> m_threads_in_cta;
-  std::set<ptx_thread_info *> m_threads_that_have_exited;
-  std::set<ptx_thread_info *> m_dangling_pointers;
+private:
+   // backward pointer
+   class gpgpu_context* gpgpu_ctx;
+   unsigned           m_bar_threads;
+   unsigned long long         m_uid;
+   unsigned                m_sm_idx;
+   std::set<ptx_thread_info*>    m_threads_in_cta;
+   std::set<ptx_thread_info*>  m_threads_that_have_exited;
+   std::set<ptx_thread_info*>  m_dangling_pointers;
 };
 
 class ptx_warp_info {
- public:
-  ptx_warp_info();  // add get_core or something, or threads?
-  unsigned get_done_threads() const;
-  void inc_done_threads();
-  void reset_done_threads();
+public:
+	ptx_warp_info(); // add get_core or something, or threads?
+	unsigned get_done_threads() const;
+	void inc_done_threads();
+	void reset_done_threads();
 
- private:
-  unsigned m_done_threads;
+private:
+	unsigned m_done_threads;
 };
 
 class symbol;
 
 struct stack_entry {
-  stack_entry() {
-    m_symbol_table = NULL;
-    m_func_info = NULL;
-    m_PC = 0;
-    m_RPC = -1;
-    m_return_var_src = NULL;
-    m_return_var_dst = NULL;
-    m_call_uid = 0;
-    m_valid = false;
-  }
-  stack_entry(symbol_table *s, function_info *f, unsigned pc, unsigned rpc,
-              const symbol *return_var_src, const symbol *return_var_dst,
-              unsigned call_uid) {
-    m_symbol_table = s;
-    m_func_info = f;
-    m_PC = pc;
-    m_RPC = rpc;
-    m_return_var_src = return_var_src;
-    m_return_var_dst = return_var_dst;
-    m_call_uid = call_uid;
-    m_valid = true;
-  }
+   stack_entry() {
+      m_symbol_table=NULL;
+      m_func_info=NULL;
+      m_PC=0;
+      m_RPC=-1;
+      m_return_var_src = NULL;
+      m_return_var_dst = NULL;
+      m_call_uid = 0;
+      m_valid = false;
+   }
+   stack_entry( symbol_table *s, function_info *f, unsigned pc, unsigned rpc, const symbol *return_var_src, const symbol *return_var_dst, unsigned call_uid )
+   {
+      m_symbol_table=s;
+      m_func_info=f;
+      m_PC=pc;
+      m_RPC=rpc;
+      m_return_var_src = return_var_src;
+      m_return_var_dst = return_var_dst;
+      m_call_uid = call_uid;
+      m_valid = true;
+   }
 
-  bool m_valid;
-  symbol_table *m_symbol_table;
-  function_info *m_func_info;
-  unsigned m_PC;
-  unsigned m_RPC;
-  const symbol *m_return_var_src;
-  const symbol *m_return_var_dst;
-  unsigned m_call_uid;
+   bool m_valid;
+   symbol_table  *m_symbol_table;
+   function_info *m_func_info;
+   unsigned       m_PC;
+   unsigned       m_RPC;
+   const symbol  *m_return_var_src;
+   const symbol  *m_return_var_dst;
+   unsigned       m_call_uid;
 };
 
 class ptx_version {
- public:
-  ptx_version() {
-    m_valid = false;
-    m_ptx_version = 0;
-    m_ptx_extensions = 0;
-    m_sm_version_valid = false;
-    m_texmode_unified = true;
-    m_map_f64_to_f32 = true;
-  }
-  ptx_version(float ver, unsigned extensions) {
-    m_valid = true;
-    m_ptx_version = ver;
-    m_ptx_extensions = extensions;
-    m_sm_version_valid = false;
-    m_texmode_unified = true;
-  }
-  void set_target(const char *sm_ver, const char *ext, const char *ext2) {
-    assert(m_valid);
-    m_sm_version_str = sm_ver;
-    check_target_extension(ext);
-    check_target_extension(ext2);
-    sscanf(sm_ver, "%u", &m_sm_version);
-    m_sm_version_valid = true;
-  }
-  float ver() const {
-    assert(m_valid);
-    return m_ptx_version;
-  }
-  unsigned target() const {
-    assert(m_valid && m_sm_version_valid);
-    return m_sm_version;
-  }
-  unsigned extensions() const {
-    assert(m_valid);
-    return m_ptx_extensions;
-  }
+public:
+      ptx_version()
+      {
+         m_valid = false;
+         m_ptx_version = 0;
+         m_ptx_extensions = 0;
+         m_sm_version_valid=false;
+         m_texmode_unified=true;
+         m_map_f64_to_f32 = true; 
+      }
+      ptx_version(float ver, unsigned extensions)
+      {
+         m_valid = true;
+         m_ptx_version = ver;
+         m_ptx_extensions = extensions;
+         m_sm_version_valid=false;
+         m_texmode_unified=true;
+      }
+      void set_target( const char *sm_ver, const char *ext, const char *ext2 ) 
+      { 
+         assert( m_valid );
+         m_sm_version_str = sm_ver;
+         check_target_extension(ext); 
+         check_target_extension(ext2); 
+         sscanf(sm_ver,"%u",&m_sm_version);
+         m_sm_version_valid=true; 
+      }
+      float    ver() const { assert(m_valid); return m_ptx_version; }
+      unsigned target() const { assert(m_valid&&m_sm_version_valid); return m_sm_version; }
+      unsigned extensions() const { assert(m_valid); return m_ptx_extensions; }
+private:
+      void check_target_extension( const char *ext ) 
+      {
+         if( ext ) {
+            if( !strcmp(ext,"texmode_independent") ) 
+               m_texmode_unified=false;
+            else if( !strcmp(ext,"texmode_unified") ) 
+               m_texmode_unified=true;
+            else if( !strcmp(ext,"map_f64_to_f32") ) 
+               m_map_f64_to_f32 = true; 
+            else abort();
+         }
+      }
 
- private:
-  void check_target_extension(const char *ext) {
-    if (ext) {
-      if (!strcmp(ext, "texmode_independent"))
-        m_texmode_unified = false;
-      else if (!strcmp(ext, "texmode_unified"))
-        m_texmode_unified = true;
-      else if (!strcmp(ext, "map_f64_to_f32"))
-        m_map_f64_to_f32 = true;
-      else
-        abort();
-    }
-  }
-
-  bool m_valid;
-  float m_ptx_version;
-  unsigned m_sm_version_valid;
-  std::string m_sm_version_str;
-  bool m_texmode_unified;
-  bool m_map_f64_to_f32;
-  unsigned m_sm_version;
-  unsigned m_ptx_extensions;
+      bool     m_valid;
+      float    m_ptx_version;
+      unsigned m_sm_version_valid;
+      std::string m_sm_version_str;
+      bool     m_texmode_unified;
+      bool     m_map_f64_to_f32; 
+      unsigned m_sm_version;
+      unsigned m_ptx_extensions;
 };
 
 class ptx_thread_info {
- public:
-  ~ptx_thread_info();
-  ptx_thread_info(kernel_info_t &kernel);
+public:
+   ~ptx_thread_info();
+   ptx_thread_info( kernel_info_t &kernel );
 
-  void init(gpgpu_t *gpu, core_t *core, unsigned sid, unsigned cta_id,
-            unsigned wid, unsigned tid, bool fsim) {
-    m_gpu = gpu;
-    m_core = core;
-    m_hw_sid = sid;
-    m_hw_ctaid = cta_id;
-    m_hw_wid = wid;
-    m_hw_tid = tid;
-    m_functionalSimulationMode = fsim;
-  }
+   void init(gpgpu_t *gpu, core_t *core, unsigned sid, unsigned cta_id, unsigned wid, unsigned tid, bool fsim) 
+   { 
+      m_gpu = gpu;
+      m_core = core; 
+      m_hw_sid=sid;
+      m_hw_ctaid=cta_id;
+      m_hw_wid=wid;
+      m_hw_tid=tid;
+      m_functionalSimulationMode = fsim;
+   }
 
-  void ptx_fetch_inst(inst_t &inst) const;
-  void ptx_exec_inst(warp_inst_t &inst, unsigned lane_id);
+   void ptx_fetch_inst( inst_t &inst ) const;
+   void ptx_exec_inst( warp_inst_t &inst, unsigned lane_id );
 
-  const ptx_version &get_ptx_version() const;
-  void set_reg(const symbol *reg, const ptx_reg_t &value);
-  void print_reg_thread(char *fname);
-  void resume_reg_thread(char *fname, symbol_table *symtab);
-  ptx_reg_t get_reg(const symbol *reg);
-  ptx_reg_t get_operand_value(const operand_info &op, operand_info dstInfo,
-                              unsigned opType, ptx_thread_info *thread,
-                              int derefFlag);
-  void set_operand_value(const operand_info &dst, const ptx_reg_t &data,
-                         unsigned type, ptx_thread_info *thread,
-                         const ptx_instruction *pI);
-  void set_operand_value(const operand_info &dst, const ptx_reg_t &data,
-                         unsigned type, ptx_thread_info *thread,
-                         const ptx_instruction *pI, int overflow, int carry);
-  void get_vector_operand_values(const operand_info &op, ptx_reg_t *ptx_regs,
-                                 unsigned num_elements);
-  void set_vector_operand_values(const operand_info &dst,
-                                 const ptx_reg_t &data1, const ptx_reg_t &data2,
-                                 const ptx_reg_t &data3,
-                                 const ptx_reg_t &data4);
-  void set_wmma_vector_operand_values(
-      const operand_info &dst, const ptx_reg_t &data1, const ptx_reg_t &data2,
-      const ptx_reg_t &data3, const ptx_reg_t &data4, const ptx_reg_t &data5,
-      const ptx_reg_t &data6, const ptx_reg_t &data7, const ptx_reg_t &data8);
+   const ptx_version &get_ptx_version() const;
+   void set_reg( const symbol *reg, const ptx_reg_t &value );
+   void print_reg_thread (char * fname);
+   void resume_reg_thread(char * fname,  symbol_table * symtab);
+   ptx_reg_t get_reg( const symbol *reg );
+   ptx_reg_t get_operand_value( const operand_info &op, operand_info dstInfo, unsigned opType, ptx_thread_info *thread, int derefFlag );
+   void set_operand_value( const operand_info &dst, const ptx_reg_t &data, unsigned type, ptx_thread_info *thread, const ptx_instruction *pI );
+   void set_operand_value( const operand_info &dst, const ptx_reg_t &data, unsigned type, ptx_thread_info *thread, const ptx_instruction *pI, int overflow, int carry );
+   void get_vector_operand_values( const operand_info &op, ptx_reg_t* ptx_regs, unsigned num_elements );
+   void set_vector_operand_values( const operand_info &dst, 
+                                   const ptx_reg_t &data1, 
+                                   const ptx_reg_t &data2, 
+                                   const ptx_reg_t &data3, 
+                                   const ptx_reg_t &data4 );
+   void set_wmma_vector_operand_values( const operand_info &dst, 
+                                        const ptx_reg_t &data1, 
+                                        const ptx_reg_t &data2, 
+                                        const ptx_reg_t &data3, 
+                                        const ptx_reg_t &data4, 
+                                        const ptx_reg_t &data5, 
+                                        const ptx_reg_t &data6, 
+                                        const ptx_reg_t &data7, 
+                                        const ptx_reg_t &data8 );
 
-  function_info *func_info() { return m_func_info; }
-  void print_insn(unsigned pc, FILE *fp) const;
-  void set_info(function_info *func);
-  unsigned get_uid() const { return m_uid; }
+   function_info *func_info()
+   {
+      return m_func_info; 
+   }
+   void print_insn( unsigned pc, FILE * fp ) const;
+   void set_info( function_info *func );
+   unsigned get_uid() const
+   {
+      return m_uid;
+   }
 
-  dim3 get_ctaid() const { return m_ctaid; }
-  dim3 get_tid() const { return m_tid; }
-  dim3 get_ntid() const { return m_ntid; }
-  class gpgpu_sim *get_gpu() {
-    return (gpgpu_sim *)m_gpu;
-  }
-  unsigned get_hw_tid() const { return m_hw_tid; }
-  unsigned get_hw_ctaid() const { return m_hw_ctaid; }
-  unsigned get_hw_wid() const { return m_hw_wid; }
-  unsigned get_hw_sid() const { return m_hw_sid; }
-  core_t *get_core() { return m_core; }
+   dim3 get_ctaid() const { return m_ctaid; }
+   dim3 get_tid() const { return m_tid; }
+   dim3 get_ntid() const { return m_ntid; }
+   class gpgpu_sim *get_gpu() { return (gpgpu_sim*)m_gpu;}
+   unsigned get_hw_tid() const { return m_hw_tid;}
+   unsigned get_hw_ctaid() const { return m_hw_ctaid;}
+   unsigned get_hw_wid() const { return m_hw_wid;}
+   unsigned get_hw_sid() const { return m_hw_sid;}
+   core_t *get_core() { return m_core; }
 
-  unsigned get_icount() const { return m_icount; }
-  void set_valid() { m_valid = true; }
-  addr_t last_eaddr() const { return m_last_effective_address; }
-  memory_space_t last_space() const { return m_last_memory_space; }
-  dram_callback_t last_callback() const { return m_last_dram_callback; }
-  unsigned long long get_cta_uid() { return m_cta_info->get_sm_idx(); }
+   unsigned get_icount() const { return m_icount;}
+   void set_valid() { m_valid = true;}
+   addr_t last_eaddr() const { return m_last_effective_address;}
+   memory_space_t last_space() const { return m_last_memory_space;}
+   dram_callback_t last_callback() const { return m_last_dram_callback;}
+   unsigned long long get_cta_uid() { return m_cta_info->get_sm_idx();}
 
-  void set_single_thread_single_block() {
-    m_ntid.x = 1;
-    m_ntid.y = 1;
-    m_ntid.z = 1;
-    m_ctaid.x = 0;
-    m_ctaid.y = 0;
-    m_ctaid.z = 0;
-    m_tid.x = 0;
-    m_tid.y = 0;
-    m_tid.z = 0;
-    m_nctaid.x = 1;
-    m_nctaid.y = 1;
-    m_nctaid.z = 1;
-    m_gridid = 0;
-    m_valid = true;
-  }
-  void set_tid(dim3 tid) { m_tid = tid; }
-  void cpy_tid_to_reg(dim3 tid);
-  void set_ctaid(dim3 ctaid) { m_ctaid = ctaid; }
-  void set_ntid(dim3 tid) { m_ntid = tid; }
-  void set_nctaid(dim3 cta_size) { m_nctaid = cta_size; }
+   void set_single_thread_single_block()
+   {
+      m_ntid.x = 1;
+      m_ntid.y = 1;
+      m_ntid.z = 1;
+      m_ctaid.x = 0;
+      m_ctaid.y = 0;
+      m_ctaid.z = 0;
+      m_tid.x = 0;
+      m_tid.y = 0;
+      m_tid.z = 0;
+      m_nctaid.x = 1;
+      m_nctaid.y = 1;
+      m_nctaid.z = 1;
+      m_gridid = 0;
+      m_valid = true;
+   }
+   void set_tid( dim3 tid ) { m_tid = tid; }
+   void cpy_tid_to_reg( dim3 tid );
+   void set_ctaid( dim3 ctaid ) { m_ctaid = ctaid; }
+   void set_ntid( dim3 tid ) { m_ntid = tid; }
+   void set_nctaid( dim3 cta_size ) { m_nctaid = cta_size; }
 
-  unsigned get_builtin(int builtin_id, unsigned dim_mod);
+   unsigned get_builtin( int builtin_id, unsigned dim_mod ); 
 
-  void set_done();
-  bool is_done() { return m_thread_done; }
-  unsigned donecycle() const { return m_cycle_done; }
+   void set_done();
+   bool is_done() { return m_thread_done;}
+   unsigned donecycle() const { return m_cycle_done; }
 
-  unsigned next_instr() {
-    m_icount++;
-    m_branch_taken = false;
-    return m_PC;
-  }
-  bool branch_taken() const { return m_branch_taken; }
-  unsigned get_pc() const { return m_PC; }
-  void set_npc(unsigned npc) { m_NPC = npc; }
-  void set_npc(const function_info *f);
-  void callstack_push(unsigned npc, unsigned rpc, const symbol *return_var_src,
-                      const symbol *return_var_dst, unsigned call_uid);
-  bool callstack_pop();
-  void callstack_push_plus(unsigned npc, unsigned rpc,
-                           const symbol *return_var_src,
-                           const symbol *return_var_dst, unsigned call_uid);
-  bool callstack_pop_plus();
-  void dump_callstack() const;
-  std::string get_location() const;
-  const ptx_instruction *get_inst() const;
-  const ptx_instruction *get_inst(addr_t pc) const;
-  bool rpc_updated() const { return m_RPC_updated; }
-  bool last_was_call() const { return m_last_was_call; }
-  unsigned get_rpc() const { return m_RPC; }
-  void clearRPC() {
-    m_RPC = -1;
-    m_RPC_updated = false;
-    m_last_was_call = false;
-  }
-  unsigned get_return_PC() { return m_callstack.back().m_PC; }
-  void update_pc() { m_PC = m_NPC; }
-  void dump_regs(FILE *fp);
-  void dump_modifiedregs(FILE *fp);
-  void clear_modifiedregs() {
-    m_debug_trace_regs_modified.back().clear();
-    m_debug_trace_regs_read.back().clear();
-  }
-  function_info *get_finfo() { return m_func_info; }
-  const function_info *get_finfo() const { return m_func_info; }
-  void push_breakaddr(const operand_info &breakaddr);
-  const operand_info &pop_breakaddr();
-  void enable_debug_trace() { m_enable_debug_trace = true; }
-  unsigned get_local_mem_stack_pointer() const {
-    return m_local_mem_stack_pointer;
-  }
+   unsigned next_instr()
+   {
+      m_icount++;
+      m_branch_taken = false;
+      return m_PC;
+   }
+   bool branch_taken() const
+   {
+      return m_branch_taken;
+   }
+   unsigned get_pc() const
+   {
+      return m_PC;
+   }
+   void set_npc( unsigned npc )
+   {
+      m_NPC = npc;
+   }
+   void set_npc( const function_info *f );
+   void callstack_push( unsigned npc, unsigned rpc, const symbol *return_var_src, const symbol *return_var_dst, unsigned call_uid );
+   bool callstack_pop();
+   void callstack_push_plus( unsigned npc, unsigned rpc, const symbol *return_var_src, const symbol *return_var_dst, unsigned call_uid );
+   bool callstack_pop_plus();
+   void dump_callstack() const;
+   std::string get_location() const;
+   const ptx_instruction *get_inst() const;
+   const ptx_instruction *get_inst( addr_t pc ) const;
+   bool rpc_updated() const { return m_RPC_updated; }
+   bool last_was_call() const { return m_last_was_call; }
+   unsigned get_rpc() const { return m_RPC; }
+   void clearRPC()
+   {
+      m_RPC = -1;
+      m_RPC_updated = false;
+      m_last_was_call = false;
+   }
+   unsigned get_return_PC()
+   {
+       return m_callstack.back().m_PC;
+   }
+   void update_pc( )
+   {
+      m_PC = m_NPC;
+   }
+   void dump_regs(FILE * fp);
+   void dump_modifiedregs(FILE *fp);
+   void clear_modifiedregs() { m_debug_trace_regs_modified.back().clear(); m_debug_trace_regs_read.back().clear(); }
+   function_info *get_finfo() { return m_func_info;   }
+   const function_info *get_finfo() const { return m_func_info;   }
+   void push_breakaddr(const operand_info &breakaddr);
+   const operand_info& pop_breakaddr();
+   void enable_debug_trace() { m_enable_debug_trace = true; }
+   unsigned get_local_mem_stack_pointer() const { return m_local_mem_stack_pointer; }
 
-  memory_space *get_global_memory() { return m_gpu->get_global_memory(); }
-  memory_space *get_tex_memory() { return m_gpu->get_tex_memory(); }
-  memory_space *get_surf_memory() { return m_gpu->get_surf_memory(); }
-  memory_space *get_param_memory() { return m_kernel.get_param_memory(); }
-  const gpgpu_functional_sim_config &get_config() const {
-    return m_gpu->get_config();
-  }
-  bool isInFunctionalSimulationMode() { return m_functionalSimulationMode; }
-  void exitCore() {
-    // m_core is not used in case of functional simulation mode
-    if (!m_functionalSimulationMode) m_core->warp_exit(m_hw_wid);
-  }
+   memory_space *get_global_memory() { return m_gpu->get_global_memory(); }
+   memory_space *get_tex_memory() { return m_gpu->get_tex_memory(); }
+   memory_space *get_surf_memory() { return m_gpu->get_surf_memory(); }
+   memory_space *get_param_memory() { return m_kernel.get_param_memory(); }
+   const gpgpu_functional_sim_config &get_config() const { return m_gpu->get_config(); }
+   bool isInFunctionalSimulationMode(){ return m_functionalSimulationMode;}
+   void exitCore()
+   {
+       //m_core is not used in case of functional simulation mode
+       if(!m_functionalSimulationMode)
+           m_core->warp_exit(m_hw_wid);
+   }
+   
+   void registerExit(){m_cta_info->register_thread_exit(this);}
+   unsigned get_reduction_value(unsigned ctaid, unsigned barid) {return m_core->get_reduction_value(ctaid,barid);}
+   void and_reduction(unsigned ctaid, unsigned barid, bool value) {m_core->and_reduction(ctaid,barid,value);}
+   void or_reduction(unsigned ctaid, unsigned barid, bool value) {m_core->or_reduction(ctaid,barid,value);}
+   void popc_reduction(unsigned ctaid, unsigned barid, bool value) {m_core->popc_reduction(ctaid,barid,value);}
 
-  void registerExit() { m_cta_info->register_thread_exit(this); }
-  unsigned get_reduction_value(unsigned ctaid, unsigned barid) {
-    return m_core->get_reduction_value(ctaid, barid);
-  }
-  void and_reduction(unsigned ctaid, unsigned barid, bool value) {
-    m_core->and_reduction(ctaid, barid, value);
-  }
-  void or_reduction(unsigned ctaid, unsigned barid, bool value) {
-    m_core->or_reduction(ctaid, barid, value);
-  }
-  void popc_reduction(unsigned ctaid, unsigned barid, bool value) {
-    m_core->popc_reduction(ctaid, barid, value);
-  }
+   //Jin: get corresponding kernel grid for CDP purpose
+   kernel_info_t & get_kernel() { return m_kernel; }
 
-  // Jin: get corresponding kernel grid for CDP purpose
-  kernel_info_t &get_kernel() { return m_kernel; }
+public:
+   addr_t         m_last_effective_address;
+   bool        m_branch_taken;
+   memory_space_t m_last_memory_space;
+   dram_callback_t   m_last_dram_callback; 
+   memory_space   *m_shared_mem;
+   memory_space   *m_sstarr_mem;
+   memory_space   *m_local_mem;
+   ptx_warp_info  *m_warp_info;
+   ptx_cta_info   *m_cta_info;
+   ptx_reg_t m_last_set_operand_value;
 
- public:
-  addr_t m_last_effective_address;
-  bool m_branch_taken;
-  memory_space_t m_last_memory_space;
-  dram_callback_t m_last_dram_callback;
-  memory_space *m_shared_mem;
-  memory_space *m_sstarr_mem;
-  memory_space *m_local_mem;
-  ptx_warp_info *m_warp_info;
-  ptx_cta_info *m_cta_info;
-  ptx_reg_t m_last_set_operand_value;
+private:
 
- private:
-  bool m_functionalSimulationMode;
-  unsigned m_uid;
-  kernel_info_t &m_kernel;
-  core_t *m_core;
-  gpgpu_t *m_gpu;
-  bool m_valid;
-  dim3 m_ntid;
-  dim3 m_tid;
-  dim3 m_nctaid;
-  dim3 m_ctaid;
-  unsigned m_gridid;
-  bool m_thread_done;
-  unsigned m_hw_sid;
-  unsigned m_hw_tid;
-  unsigned m_hw_wid;
-  unsigned m_hw_ctaid;
+   bool m_functionalSimulationMode; 
+   unsigned m_uid;
+   kernel_info_t &m_kernel;
+   core_t *m_core;
+   gpgpu_t *m_gpu;
+   bool   m_valid;
+   dim3   m_ntid;
+   dim3   m_tid;
+   dim3   m_nctaid;
+   dim3   m_ctaid;
+   unsigned m_gridid;
+   bool m_thread_done;
+   unsigned m_hw_sid;
+   unsigned m_hw_tid;
+   unsigned m_hw_wid;
+   unsigned m_hw_ctaid;
 
-  unsigned m_icount;
-  unsigned m_PC;
-  unsigned m_NPC;
-  unsigned m_RPC;
-  bool m_RPC_updated;
-  bool m_last_was_call;
-  unsigned m_cycle_done;
+   unsigned m_icount;
+   unsigned m_PC;
+   unsigned m_NPC;
+   unsigned m_RPC;
+   bool m_RPC_updated;
+   bool m_last_was_call;
+   unsigned m_cycle_done;
 
-  int m_barrier_num;
-  bool m_at_barrier;
+   int m_barrier_num;
+   bool m_at_barrier;
 
-  symbol_table *m_symbol_table;
-  function_info *m_func_info;
+   symbol_table  *m_symbol_table;
+   function_info *m_func_info;
 
-  std::list<stack_entry> m_callstack;
-  unsigned m_local_mem_stack_pointer;
+   std::list<stack_entry> m_callstack;
+   unsigned m_local_mem_stack_pointer;
 
-  typedef tr1_hash_map<const symbol *, ptx_reg_t> reg_map_t;
-  std::list<reg_map_t> m_regs;
-  std::list<reg_map_t> m_debug_trace_regs_modified;
-  std::list<reg_map_t> m_debug_trace_regs_read;
-  bool m_enable_debug_trace;
+   typedef tr1_hash_map<const symbol*,ptx_reg_t> reg_map_t;
+   std::list<reg_map_t> m_regs;
+   std::list<reg_map_t> m_debug_trace_regs_modified;
+   std::list<reg_map_t> m_debug_trace_regs_read;
+   bool m_enable_debug_trace;
 
-  std::stack<class operand_info, std::vector<operand_info> > m_breakaddrs;
+   std::stack<class operand_info, std::vector<operand_info> > m_breakaddrs;
 };
 
-addr_t generic_to_local(unsigned smid, unsigned hwtid, addr_t addr);
-addr_t generic_to_shared(unsigned smid, addr_t addr);
-addr_t generic_to_global(addr_t addr);
-addr_t local_to_generic(unsigned smid, unsigned hwtid, addr_t addr);
-addr_t shared_to_generic(unsigned smid, addr_t addr);
-addr_t global_to_generic(addr_t addr);
-bool isspace_local(unsigned smid, unsigned hwtid, addr_t addr);
-bool isspace_shared(unsigned smid, addr_t addr);
-bool isspace_global(addr_t addr);
-memory_space_t whichspace(addr_t addr);
+addr_t generic_to_local( unsigned smid, unsigned hwtid, addr_t addr );
+addr_t generic_to_shared( unsigned smid, addr_t addr );
+addr_t generic_to_global( addr_t addr );
+addr_t local_to_generic( unsigned smid, unsigned hwtid, addr_t addr );
+addr_t shared_to_generic( unsigned smid, addr_t addr );
+addr_t global_to_generic( addr_t addr );
+bool isspace_local( unsigned smid, unsigned hwtid, addr_t addr );
+bool isspace_shared( unsigned smid, addr_t addr );
+bool isspace_global( addr_t addr );
+memory_space_t whichspace( addr_t addr );
 
 extern unsigned g_ptx_thread_info_uid_next;
 

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -26,183 +28,197 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "debug.h"
-#include "gpgpu-sim/shader.h"
-#include "gpgpu-sim/gpu-sim.h"
-#include "cuda-sim/ptx_sim.h"
 #include "cuda-sim/cuda-sim.h"
 #include "cuda-sim/ptx_ir.h"
+#include "cuda-sim/ptx_sim.h"
+#include "gpgpu-sim/gpu-sim.h"
+#include "gpgpu-sim/shader.h"
 
-#include <map>
 #include <stdio.h>
 #include <string.h>
+#include <map>
 
-void gpgpu_sim::hit_watchpoint( unsigned watchpoint_num, ptx_thread_info *thd, const ptx_instruction *pI )
-{
-   g_watchpoint_hits[watchpoint_num]=watchpoint_event(thd,pI);
+void gpgpu_sim::hit_watchpoint(unsigned watchpoint_num, ptx_thread_info *thd,
+                               const ptx_instruction *pI) {
+  g_watchpoint_hits[watchpoint_num] = watchpoint_event(thd, pI);
 }
 
-/// interactive debugger 
+/// interactive debugger
 
-void gpgpu_sim::gpgpu_debug()
-{
-   bool done=true;
+void gpgpu_sim::gpgpu_debug() {
+  bool done = true;
 
-   static bool single_step=true;
-   static unsigned next_brkpt=1;
-   static std::map<unsigned,brk_pt> breakpoints;
+  static bool single_step = true;
+  static unsigned next_brkpt = 1;
+  static std::map<unsigned, brk_pt> breakpoints;
 
-   /// if single stepping, go to interactive debugger
+  /// if single stepping, go to interactive debugger
 
-   if( single_step ) 
-      done=false;
+  if (single_step) done = false;
 
-   /// check if we've reached a breakpoint
-   const ptx_thread_info *brk_thd = NULL;
-   const ptx_instruction *brk_inst = NULL;
+  /// check if we've reached a breakpoint
+  const ptx_thread_info *brk_thd = NULL;
+  const ptx_instruction *brk_inst = NULL;
 
-   for( std::map<unsigned,brk_pt>::iterator i=breakpoints.begin(); i!=breakpoints.end(); i++) {
-      unsigned num=i->first;
-      brk_pt &b=i->second;
-      if( b.is_watchpoint() ) {
-         unsigned addr = b.get_addr();
-         unsigned new_value; 
-         m_global_mem->read(addr,4,&new_value);
-         if( new_value != b.get_value() || g_watchpoint_hits.find(num) != g_watchpoint_hits.end() ) {
-            printf( "GPGPU-Sim PTX DBG: watch point %u triggered (old value=%x, new value=%x)\n",
-                     num,b.get_value(),new_value );
-            std::map<unsigned,watchpoint_event>::iterator w=g_watchpoint_hits.find(num);
-            if( w==g_watchpoint_hits.end() ) 
-               printf( "GPGPU-Sim PTX DBG: memory transfer modified value\n");
-            else {
-               watchpoint_event wa = w->second;
-               brk_thd = wa.thread();
-               brk_inst = wa.inst();
-               printf( "GPGPU-Sim PTX DBG: modified by thread uid=%u, sid=%u, hwtid=%u\n",
-                       brk_thd->get_uid(),brk_thd->get_hw_sid(), brk_thd->get_hw_tid() );
-               printf( "GPGPU-Sim PTX DBG: ");
-               brk_inst->print_insn(stdout);
-               printf( "\n" );
-               g_watchpoint_hits.erase(w);
-            }
-            b.set_value(new_value);
-            done = false; 
-         }
-      } else {
-          /*
-         for( unsigned sid=0; sid < m_n_shader; sid++ ) { 
-            unsigned hw_thread_id = -1;
-            abort();
-            ptx_thread_info *thread = m_sc[sid]->get_functional_thread(hw_thread_id);
-            if( thread_at_brkpt(thread, b) ) {
-               done = false;
-               printf("GPGPU-Sim PTX DBG: reached breakpoint %u at %s (sm=%u, hwtid=%u)\n", 
-                      num, b.location().c_str(), sid, hw_thread_id );
-               brk_thd = thread;
-               brk_inst = brk_thd->get_inst();
-               printf( "GPGPU-Sim PTX DBG: reached by thread uid=%u, sid=%u, hwtid=%u\n",
-                       brk_thd->get_uid(),brk_thd->get_hw_sid(), brk_thd->get_hw_tid() );
-               printf( "GPGPU-Sim PTX DBG: ");
-               brk_inst->print_insn(stdout);
-               printf( "\n" );
-            }
-         }
-         */
+  for (std::map<unsigned, brk_pt>::iterator i = breakpoints.begin();
+       i != breakpoints.end(); i++) {
+    unsigned num = i->first;
+    brk_pt &b = i->second;
+    if (b.is_watchpoint()) {
+      unsigned addr = b.get_addr();
+      unsigned new_value;
+      m_global_mem->read(addr, 4, &new_value);
+      if (new_value != b.get_value() ||
+          g_watchpoint_hits.find(num) != g_watchpoint_hits.end()) {
+        printf(
+            "GPGPU-Sim PTX DBG: watch point %u triggered (old value=%x, new "
+            "value=%x)\n",
+            num, b.get_value(), new_value);
+        std::map<unsigned, watchpoint_event>::iterator w =
+            g_watchpoint_hits.find(num);
+        if (w == g_watchpoint_hits.end())
+          printf("GPGPU-Sim PTX DBG: memory transfer modified value\n");
+        else {
+          watchpoint_event wa = w->second;
+          brk_thd = wa.thread();
+          brk_inst = wa.inst();
+          printf(
+              "GPGPU-Sim PTX DBG: modified by thread uid=%u, sid=%u, "
+              "hwtid=%u\n",
+              brk_thd->get_uid(), brk_thd->get_hw_sid(), brk_thd->get_hw_tid());
+          printf("GPGPU-Sim PTX DBG: ");
+          brk_inst->print_insn(stdout);
+          printf("\n");
+          g_watchpoint_hits.erase(w);
+        }
+        b.set_value(new_value);
+        done = false;
       }
-   }
+    } else {
+      /*
+     for( unsigned sid=0; sid < m_n_shader; sid++ ) {
+        unsigned hw_thread_id = -1;
+        abort();
+        ptx_thread_info *thread =
+     m_sc[sid]->get_functional_thread(hw_thread_id);
+        if( thread_at_brkpt(thread, b) ) {
+           done = false;
+           printf("GPGPU-Sim PTX DBG: reached breakpoint %u at %s (sm=%u,
+     hwtid=%u)\n",
+                  num, b.location().c_str(), sid, hw_thread_id );
+           brk_thd = thread;
+           brk_inst = brk_thd->get_inst();
+           printf( "GPGPU-Sim PTX DBG: reached by thread uid=%u, sid=%u,
+     hwtid=%u\n",
+                   brk_thd->get_uid(),brk_thd->get_hw_sid(),
+     brk_thd->get_hw_tid() );
+           printf( "GPGPU-Sim PTX DBG: ");
+           brk_inst->print_insn(stdout);
+           printf( "\n" );
+        }
+     }
+     */
+    }
+  }
 
-   if( done ) 
-      assert( g_watchpoint_hits.empty() );
+  if (done) assert(g_watchpoint_hits.empty());
 
-   /// enter interactive debugger loop
+  /// enter interactive debugger loop
 
-   while (!done) {
-      printf("(ptx debugger) ");
+  while (!done) {
+    printf("(ptx debugger) ");
+    fflush(stdout);
+
+    char line[1024];
+    fgets(line, 1024, stdin);
+
+    char *tok = strtok(line, " \t\n");
+    if (!strcmp(tok, "dp")) {
+      int shader_num = 0;
+      tok = strtok(NULL, " \t\n");
+      sscanf(tok, "%d", &shader_num);
+      dump_pipeline((0x40 | 0x4 | 0x1), shader_num, 0);
+      printf("\n");
       fflush(stdout);
-      
-      char line[1024];
-      fgets(line,1024,stdin);
-
-      char *tok = strtok(line," \t\n");
-      if( !strcmp(tok,"dp") ) {
-         int shader_num = 0;
-         tok = strtok(NULL," \t\n");
-         sscanf(tok,"%d",&shader_num);
-         dump_pipeline((0x40|0x4|0x1),shader_num,0);
-         printf("\n");
-         fflush(stdout);
-      } else if( !strcmp(tok,"q") || !strcmp(tok,"quit") ) {
-         printf("\nreally quit GPGPU-Sim (y/n)?\n");
-         fgets(line,1024,stdin);
-         tok = strtok(line," \t\n");
-         if( !strcmp(tok,"y") ) {
-            exit(0);
-         } else {
-            printf("not quiting.\n");
-         }
-      } else if( !strcmp(tok,"b") ) {
-         tok = strtok(NULL," \t\n");
-         char brkpt[1024];
-         sscanf(tok,"%s",brkpt);
-         tok = strtok(NULL," \t\n");
-         unsigned uid;
-         sscanf(tok,"%u",&uid);
-         breakpoints[next_brkpt++] = brk_pt(brkpt,uid);
-      } else if( !strcmp(tok,"d") ) {
-         tok = strtok(NULL," \t\n");
-         unsigned uid;
-         sscanf(tok,"%u",&uid);
-         breakpoints.erase(uid);
-      } else if( !strcmp(tok,"s") ) {
-         done = true;
-      } else if( !strcmp(tok,"c") ) {
-         single_step=false;
-         done = true;
-      } else if( !strcmp(tok,"w") ) {
-         tok = strtok(NULL," \t\n");
-         unsigned addr;
-         sscanf(tok,"%x",&addr);
-         unsigned value; 
-         m_global_mem->read(addr,4,&value);
-         m_global_mem->set_watch(addr,next_brkpt); 
-         breakpoints[next_brkpt++] = brk_pt(addr,value);
-      } else if( !strcmp(tok,"l") ) {
-         if( brk_thd == NULL  ) {
-            printf("no thread selected\n");
-         } else {
-            addr_t pc = brk_thd->get_pc();
-            addr_t start_pc = (pc<5)?0:(pc-5);
-            for( addr_t p=start_pc;  p <= pc+5; p++ ) {
-               const ptx_instruction *i = brk_thd->get_inst(p);
-               if( i ) {
-                  if( p != pc )
-                     printf( "    " );
-                  else
-                     printf( "==> " );
-                      i->print_insn(stdout);
-                  printf( "\n" );
-               }
-            }
-         }
-      } else if( !strcmp(tok,"h") ) {
-         printf("commands:\n");
-         printf("  q                           - quit GPGPU-Sim\n");
-         printf("  b <file>:<line> <thead uid> - set breakpoint\n");
-         printf("  w <global address>          - set watchpoint\n");
-         printf("  del <n>                     - delete breakpoint\n");
-         printf("  s                           - single step one shader cycle (all cores)\n");
-         printf("  c                           - continue simulation without single stepping\n");
-         printf("  l                           - list PTX around current breakpoint\n");
-         printf("  dp <n>                      - display pipeline contents on SM <n>\n");
-         printf("  h                           - print this message\n");
+    } else if (!strcmp(tok, "q") || !strcmp(tok, "quit")) {
+      printf("\nreally quit GPGPU-Sim (y/n)?\n");
+      fgets(line, 1024, stdin);
+      tok = strtok(line, " \t\n");
+      if (!strcmp(tok, "y")) {
+        exit(0);
       } else {
-         printf("\ncommand not understood.\n");
+        printf("not quiting.\n");
       }
-      fflush(stdout);
-   }
+    } else if (!strcmp(tok, "b")) {
+      tok = strtok(NULL, " \t\n");
+      char brkpt[1024];
+      sscanf(tok, "%s", brkpt);
+      tok = strtok(NULL, " \t\n");
+      unsigned uid;
+      sscanf(tok, "%u", &uid);
+      breakpoints[next_brkpt++] = brk_pt(brkpt, uid);
+    } else if (!strcmp(tok, "d")) {
+      tok = strtok(NULL, " \t\n");
+      unsigned uid;
+      sscanf(tok, "%u", &uid);
+      breakpoints.erase(uid);
+    } else if (!strcmp(tok, "s")) {
+      done = true;
+    } else if (!strcmp(tok, "c")) {
+      single_step = false;
+      done = true;
+    } else if (!strcmp(tok, "w")) {
+      tok = strtok(NULL, " \t\n");
+      unsigned addr;
+      sscanf(tok, "%x", &addr);
+      unsigned value;
+      m_global_mem->read(addr, 4, &value);
+      m_global_mem->set_watch(addr, next_brkpt);
+      breakpoints[next_brkpt++] = brk_pt(addr, value);
+    } else if (!strcmp(tok, "l")) {
+      if (brk_thd == NULL) {
+        printf("no thread selected\n");
+      } else {
+        addr_t pc = brk_thd->get_pc();
+        addr_t start_pc = (pc < 5) ? 0 : (pc - 5);
+        for (addr_t p = start_pc; p <= pc + 5; p++) {
+          const ptx_instruction *i = brk_thd->get_inst(p);
+          if (i) {
+            if (p != pc)
+              printf("    ");
+            else
+              printf("==> ");
+            i->print_insn(stdout);
+            printf("\n");
+          }
+        }
+      }
+    } else if (!strcmp(tok, "h")) {
+      printf("commands:\n");
+      printf("  q                           - quit GPGPU-Sim\n");
+      printf("  b <file>:<line> <thead uid> - set breakpoint\n");
+      printf("  w <global address>          - set watchpoint\n");
+      printf("  del <n>                     - delete breakpoint\n");
+      printf(
+          "  s                           - single step one shader cycle (all "
+          "cores)\n");
+      printf(
+          "  c                           - continue simulation without single "
+          "stepping\n");
+      printf(
+          "  l                           - list PTX around current "
+          "breakpoint\n");
+      printf(
+          "  dp <n>                      - display pipeline contents on SM "
+          "<n>\n");
+      printf("  h                           - print this message\n");
+    } else {
+      printf("\ncommand not understood.\n");
+    }
+    fflush(stdout);
+  }
 }
 
-bool thread_at_brkpt( ptx_thread_info *thread, const class brk_pt &b )
-{
-   return b.is_equal(thread->get_location(),thread->get_uid());
+bool thread_at_brkpt(ptx_thread_info *thread, const class brk_pt &b) {
+  return b.is_equal(thread->get_location(), thread->get_uid());
 }
-

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -7,202 +7,212 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #include "debug.h"
-#include "gpgpu-sim/shader.h"
-#include "gpgpu-sim/gpu-sim.h"
-#include "cuda-sim/ptx_sim.h"
 #include "cuda-sim/cuda-sim.h"
 #include "cuda-sim/ptx_ir.h"
+#include "cuda-sim/ptx_sim.h"
+#include "gpgpu-sim/gpu-sim.h"
+#include "gpgpu-sim/shader.h"
 
-#include <map>
 #include <stdio.h>
 #include <string.h>
+#include <map>
 
-void gpgpu_sim::hit_watchpoint( unsigned watchpoint_num, ptx_thread_info *thd, const ptx_instruction *pI )
-{
-   g_watchpoint_hits[watchpoint_num]=watchpoint_event(thd,pI);
+void gpgpu_sim::hit_watchpoint(unsigned watchpoint_num, ptx_thread_info *thd,
+                               const ptx_instruction *pI) {
+  g_watchpoint_hits[watchpoint_num] = watchpoint_event(thd, pI);
 }
 
-/// interactive debugger 
+/// interactive debugger
 
-void gpgpu_sim::gpgpu_debug()
-{
-   bool done=true;
+void gpgpu_sim::gpgpu_debug() {
+  bool done = true;
 
-   static bool single_step=true;
-   static unsigned next_brkpt=1;
-   static std::map<unsigned,brk_pt> breakpoints;
+  static bool single_step = true;
+  static unsigned next_brkpt = 1;
+  static std::map<unsigned, brk_pt> breakpoints;
 
-   /// if single stepping, go to interactive debugger
+  /// if single stepping, go to interactive debugger
 
-   if( single_step ) 
-      done=false;
+  if (single_step) done = false;
 
-   /// check if we've reached a breakpoint
-   const ptx_thread_info *brk_thd = NULL;
-   const ptx_instruction *brk_inst = NULL;
+  /// check if we've reached a breakpoint
+  const ptx_thread_info *brk_thd = NULL;
+  const ptx_instruction *brk_inst = NULL;
 
-   for( std::map<unsigned,brk_pt>::iterator i=breakpoints.begin(); i!=breakpoints.end(); i++) {
-      unsigned num=i->first;
-      brk_pt &b=i->second;
-      if( b.is_watchpoint() ) {
-         unsigned addr = b.get_addr();
-         unsigned new_value; 
-         m_global_mem->read(addr,4,&new_value);
-         if( new_value != b.get_value() || g_watchpoint_hits.find(num) != g_watchpoint_hits.end() ) {
-            printf( "GPGPU-Sim PTX DBG: watch point %u triggered (old value=%x, new value=%x)\n",
-                     num,b.get_value(),new_value );
-            std::map<unsigned,watchpoint_event>::iterator w=g_watchpoint_hits.find(num);
-            if( w==g_watchpoint_hits.end() ) 
-               printf( "GPGPU-Sim PTX DBG: memory transfer modified value\n");
-            else {
-               watchpoint_event wa = w->second;
-               brk_thd = wa.thread();
-               brk_inst = wa.inst();
-               printf( "GPGPU-Sim PTX DBG: modified by thread uid=%u, sid=%u, hwtid=%u\n",
-                       brk_thd->get_uid(),brk_thd->get_hw_sid(), brk_thd->get_hw_tid() );
-               printf( "GPGPU-Sim PTX DBG: ");
-               brk_inst->print_insn(stdout);
-               printf( "\n" );
-               g_watchpoint_hits.erase(w);
-            }
-            b.set_value(new_value);
-            done = false; 
-         }
-      } else {
-          /*
-         for( unsigned sid=0; sid < m_n_shader; sid++ ) { 
-            unsigned hw_thread_id = -1;
-            abort();
-            ptx_thread_info *thread = m_sc[sid]->get_functional_thread(hw_thread_id);
-            if( thread_at_brkpt(thread, b) ) {
-               done = false;
-               printf("GPGPU-Sim PTX DBG: reached breakpoint %u at %s (sm=%u, hwtid=%u)\n", 
-                      num, b.location().c_str(), sid, hw_thread_id );
-               brk_thd = thread;
-               brk_inst = brk_thd->get_inst();
-               printf( "GPGPU-Sim PTX DBG: reached by thread uid=%u, sid=%u, hwtid=%u\n",
-                       brk_thd->get_uid(),brk_thd->get_hw_sid(), brk_thd->get_hw_tid() );
-               printf( "GPGPU-Sim PTX DBG: ");
-               brk_inst->print_insn(stdout);
-               printf( "\n" );
-            }
-         }
-         */
+  for (std::map<unsigned, brk_pt>::iterator i = breakpoints.begin();
+       i != breakpoints.end(); i++) {
+    unsigned num = i->first;
+    brk_pt &b = i->second;
+    if (b.is_watchpoint()) {
+      unsigned addr = b.get_addr();
+      unsigned new_value;
+      m_global_mem->read(addr, 4, &new_value);
+      if (new_value != b.get_value() ||
+          g_watchpoint_hits.find(num) != g_watchpoint_hits.end()) {
+        printf(
+            "GPGPU-Sim PTX DBG: watch point %u triggered (old value=%x, new "
+            "value=%x)\n",
+            num, b.get_value(), new_value);
+        std::map<unsigned, watchpoint_event>::iterator w =
+            g_watchpoint_hits.find(num);
+        if (w == g_watchpoint_hits.end())
+          printf("GPGPU-Sim PTX DBG: memory transfer modified value\n");
+        else {
+          watchpoint_event wa = w->second;
+          brk_thd = wa.thread();
+          brk_inst = wa.inst();
+          printf(
+              "GPGPU-Sim PTX DBG: modified by thread uid=%u, sid=%u, "
+              "hwtid=%u\n",
+              brk_thd->get_uid(), brk_thd->get_hw_sid(), brk_thd->get_hw_tid());
+          printf("GPGPU-Sim PTX DBG: ");
+          brk_inst->print_insn(stdout);
+          printf("\n");
+          g_watchpoint_hits.erase(w);
+        }
+        b.set_value(new_value);
+        done = false;
       }
-   }
+    } else {
+      /*
+     for( unsigned sid=0; sid < m_n_shader; sid++ ) {
+        unsigned hw_thread_id = -1;
+        abort();
+        ptx_thread_info *thread =
+     m_sc[sid]->get_functional_thread(hw_thread_id); if( thread_at_brkpt(thread,
+     b) ) { done = false; printf("GPGPU-Sim PTX DBG: reached breakpoint %u at %s
+     (sm=%u, hwtid=%u)\n", num, b.location().c_str(), sid, hw_thread_id );
+           brk_thd = thread;
+           brk_inst = brk_thd->get_inst();
+           printf( "GPGPU-Sim PTX DBG: reached by thread uid=%u, sid=%u,
+     hwtid=%u\n", brk_thd->get_uid(),brk_thd->get_hw_sid(),
+     brk_thd->get_hw_tid() ); printf( "GPGPU-Sim PTX DBG: ");
+           brk_inst->print_insn(stdout);
+           printf( "\n" );
+        }
+     }
+     */
+    }
+  }
 
-   if( done ) 
-      assert( g_watchpoint_hits.empty() );
+  if (done) assert(g_watchpoint_hits.empty());
 
-   /// enter interactive debugger loop
+  /// enter interactive debugger loop
 
-   while (!done) {
-      printf("(ptx debugger) ");
+  while (!done) {
+    printf("(ptx debugger) ");
+    fflush(stdout);
+
+    char line[1024];
+    fgets(line, 1024, stdin);
+
+    char *tok = strtok(line, " \t\n");
+    if (!strcmp(tok, "dp")) {
+      int shader_num = 0;
+      tok = strtok(NULL, " \t\n");
+      sscanf(tok, "%d", &shader_num);
+      dump_pipeline((0x40 | 0x4 | 0x1), shader_num, 0);
+      printf("\n");
       fflush(stdout);
-      
-      char line[1024];
-      fgets(line,1024,stdin);
-
-      char *tok = strtok(line," \t\n");
-      if( !strcmp(tok,"dp") ) {
-         int shader_num = 0;
-         tok = strtok(NULL," \t\n");
-         sscanf(tok,"%d",&shader_num);
-         dump_pipeline((0x40|0x4|0x1),shader_num,0);
-         printf("\n");
-         fflush(stdout);
-      } else if( !strcmp(tok,"q") || !strcmp(tok,"quit") ) {
-         printf("\nreally quit GPGPU-Sim (y/n)?\n");
-         fgets(line,1024,stdin);
-         tok = strtok(line," \t\n");
-         if( !strcmp(tok,"y") ) {
-            exit(0);
-         } else {
-            printf("not quiting.\n");
-         }
-      } else if( !strcmp(tok,"b") ) {
-         tok = strtok(NULL," \t\n");
-         char brkpt[1024];
-         sscanf(tok,"%s",brkpt);
-         tok = strtok(NULL," \t\n");
-         unsigned uid;
-         sscanf(tok,"%u",&uid);
-         breakpoints[next_brkpt++] = brk_pt(brkpt,uid);
-      } else if( !strcmp(tok,"d") ) {
-         tok = strtok(NULL," \t\n");
-         unsigned uid;
-         sscanf(tok,"%u",&uid);
-         breakpoints.erase(uid);
-      } else if( !strcmp(tok,"s") ) {
-         done = true;
-      } else if( !strcmp(tok,"c") ) {
-         single_step=false;
-         done = true;
-      } else if( !strcmp(tok,"w") ) {
-         tok = strtok(NULL," \t\n");
-         unsigned addr;
-         sscanf(tok,"%x",&addr);
-         unsigned value; 
-         m_global_mem->read(addr,4,&value);
-         m_global_mem->set_watch(addr,next_brkpt); 
-         breakpoints[next_brkpt++] = brk_pt(addr,value);
-      } else if( !strcmp(tok,"l") ) {
-         if( brk_thd == NULL  ) {
-            printf("no thread selected\n");
-         } else {
-            addr_t pc = brk_thd->get_pc();
-            addr_t start_pc = (pc<5)?0:(pc-5);
-            for( addr_t p=start_pc;  p <= pc+5; p++ ) {
-               const ptx_instruction *i = brk_thd->get_inst(p);
-               if( i ) {
-                  if( p != pc )
-                     printf( "    " );
-                  else
-                     printf( "==> " );
-                      i->print_insn(stdout);
-                  printf( "\n" );
-               }
-            }
-         }
-      } else if( !strcmp(tok,"h") ) {
-         printf("commands:\n");
-         printf("  q                           - quit GPGPU-Sim\n");
-         printf("  b <file>:<line> <thead uid> - set breakpoint\n");
-         printf("  w <global address>          - set watchpoint\n");
-         printf("  del <n>                     - delete breakpoint\n");
-         printf("  s                           - single step one shader cycle (all cores)\n");
-         printf("  c                           - continue simulation without single stepping\n");
-         printf("  l                           - list PTX around current breakpoint\n");
-         printf("  dp <n>                      - display pipeline contents on SM <n>\n");
-         printf("  h                           - print this message\n");
+    } else if (!strcmp(tok, "q") || !strcmp(tok, "quit")) {
+      printf("\nreally quit GPGPU-Sim (y/n)?\n");
+      fgets(line, 1024, stdin);
+      tok = strtok(line, " \t\n");
+      if (!strcmp(tok, "y")) {
+        exit(0);
       } else {
-         printf("\ncommand not understood.\n");
+        printf("not quiting.\n");
       }
-      fflush(stdout);
-   }
+    } else if (!strcmp(tok, "b")) {
+      tok = strtok(NULL, " \t\n");
+      char brkpt[1024];
+      sscanf(tok, "%s", brkpt);
+      tok = strtok(NULL, " \t\n");
+      unsigned uid;
+      sscanf(tok, "%u", &uid);
+      breakpoints[next_brkpt++] = brk_pt(brkpt, uid);
+    } else if (!strcmp(tok, "d")) {
+      tok = strtok(NULL, " \t\n");
+      unsigned uid;
+      sscanf(tok, "%u", &uid);
+      breakpoints.erase(uid);
+    } else if (!strcmp(tok, "s")) {
+      done = true;
+    } else if (!strcmp(tok, "c")) {
+      single_step = false;
+      done = true;
+    } else if (!strcmp(tok, "w")) {
+      tok = strtok(NULL, " \t\n");
+      unsigned addr;
+      sscanf(tok, "%x", &addr);
+      unsigned value;
+      m_global_mem->read(addr, 4, &value);
+      m_global_mem->set_watch(addr, next_brkpt);
+      breakpoints[next_brkpt++] = brk_pt(addr, value);
+    } else if (!strcmp(tok, "l")) {
+      if (brk_thd == NULL) {
+        printf("no thread selected\n");
+      } else {
+        addr_t pc = brk_thd->get_pc();
+        addr_t start_pc = (pc < 5) ? 0 : (pc - 5);
+        for (addr_t p = start_pc; p <= pc + 5; p++) {
+          const ptx_instruction *i = brk_thd->get_inst(p);
+          if (i) {
+            if (p != pc)
+              printf("    ");
+            else
+              printf("==> ");
+            i->print_insn(stdout);
+            printf("\n");
+          }
+        }
+      }
+    } else if (!strcmp(tok, "h")) {
+      printf("commands:\n");
+      printf("  q                           - quit GPGPU-Sim\n");
+      printf("  b <file>:<line> <thead uid> - set breakpoint\n");
+      printf("  w <global address>          - set watchpoint\n");
+      printf("  del <n>                     - delete breakpoint\n");
+      printf(
+          "  s                           - single step one shader cycle (all "
+          "cores)\n");
+      printf(
+          "  c                           - continue simulation without single "
+          "stepping\n");
+      printf(
+          "  l                           - list PTX around current "
+          "breakpoint\n");
+      printf(
+          "  dp <n>                      - display pipeline contents on SM "
+          "<n>\n");
+      printf("  h                           - print this message\n");
+    } else {
+      printf("\ncommand not understood.\n");
+    }
+    fflush(stdout);
+  }
 }
 
-bool thread_at_brkpt( ptx_thread_info *thread, const class brk_pt &b )
-{
-   return b.is_equal(thread->get_location(),thread->get_uid());
+bool thread_at_brkpt(ptx_thread_info *thread, const class brk_pt &b) {
+  return b.is_equal(thread->get_location(), thread->get_uid());
 }
-

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -28,197 +26,183 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "debug.h"
+#include "gpgpu-sim/shader.h"
+#include "gpgpu-sim/gpu-sim.h"
+#include "cuda-sim/ptx_sim.h"
 #include "cuda-sim/cuda-sim.h"
 #include "cuda-sim/ptx_ir.h"
-#include "cuda-sim/ptx_sim.h"
-#include "gpgpu-sim/gpu-sim.h"
-#include "gpgpu-sim/shader.h"
 
+#include <map>
 #include <stdio.h>
 #include <string.h>
-#include <map>
 
-void gpgpu_sim::hit_watchpoint(unsigned watchpoint_num, ptx_thread_info *thd,
-                               const ptx_instruction *pI) {
-  g_watchpoint_hits[watchpoint_num] = watchpoint_event(thd, pI);
+void gpgpu_sim::hit_watchpoint( unsigned watchpoint_num, ptx_thread_info *thd, const ptx_instruction *pI )
+{
+   g_watchpoint_hits[watchpoint_num]=watchpoint_event(thd,pI);
 }
 
-/// interactive debugger
+/// interactive debugger 
 
-void gpgpu_sim::gpgpu_debug() {
-  bool done = true;
+void gpgpu_sim::gpgpu_debug()
+{
+   bool done=true;
 
-  static bool single_step = true;
-  static unsigned next_brkpt = 1;
-  static std::map<unsigned, brk_pt> breakpoints;
+   static bool single_step=true;
+   static unsigned next_brkpt=1;
+   static std::map<unsigned,brk_pt> breakpoints;
 
-  /// if single stepping, go to interactive debugger
+   /// if single stepping, go to interactive debugger
 
-  if (single_step) done = false;
+   if( single_step ) 
+      done=false;
 
-  /// check if we've reached a breakpoint
-  const ptx_thread_info *brk_thd = NULL;
-  const ptx_instruction *brk_inst = NULL;
+   /// check if we've reached a breakpoint
+   const ptx_thread_info *brk_thd = NULL;
+   const ptx_instruction *brk_inst = NULL;
 
-  for (std::map<unsigned, brk_pt>::iterator i = breakpoints.begin();
-       i != breakpoints.end(); i++) {
-    unsigned num = i->first;
-    brk_pt &b = i->second;
-    if (b.is_watchpoint()) {
-      unsigned addr = b.get_addr();
-      unsigned new_value;
-      m_global_mem->read(addr, 4, &new_value);
-      if (new_value != b.get_value() ||
-          g_watchpoint_hits.find(num) != g_watchpoint_hits.end()) {
-        printf(
-            "GPGPU-Sim PTX DBG: watch point %u triggered (old value=%x, new "
-            "value=%x)\n",
-            num, b.get_value(), new_value);
-        std::map<unsigned, watchpoint_event>::iterator w =
-            g_watchpoint_hits.find(num);
-        if (w == g_watchpoint_hits.end())
-          printf("GPGPU-Sim PTX DBG: memory transfer modified value\n");
-        else {
-          watchpoint_event wa = w->second;
-          brk_thd = wa.thread();
-          brk_inst = wa.inst();
-          printf(
-              "GPGPU-Sim PTX DBG: modified by thread uid=%u, sid=%u, "
-              "hwtid=%u\n",
-              brk_thd->get_uid(), brk_thd->get_hw_sid(), brk_thd->get_hw_tid());
-          printf("GPGPU-Sim PTX DBG: ");
-          brk_inst->print_insn(stdout);
-          printf("\n");
-          g_watchpoint_hits.erase(w);
-        }
-        b.set_value(new_value);
-        done = false;
+   for( std::map<unsigned,brk_pt>::iterator i=breakpoints.begin(); i!=breakpoints.end(); i++) {
+      unsigned num=i->first;
+      brk_pt &b=i->second;
+      if( b.is_watchpoint() ) {
+         unsigned addr = b.get_addr();
+         unsigned new_value; 
+         m_global_mem->read(addr,4,&new_value);
+         if( new_value != b.get_value() || g_watchpoint_hits.find(num) != g_watchpoint_hits.end() ) {
+            printf( "GPGPU-Sim PTX DBG: watch point %u triggered (old value=%x, new value=%x)\n",
+                     num,b.get_value(),new_value );
+            std::map<unsigned,watchpoint_event>::iterator w=g_watchpoint_hits.find(num);
+            if( w==g_watchpoint_hits.end() ) 
+               printf( "GPGPU-Sim PTX DBG: memory transfer modified value\n");
+            else {
+               watchpoint_event wa = w->second;
+               brk_thd = wa.thread();
+               brk_inst = wa.inst();
+               printf( "GPGPU-Sim PTX DBG: modified by thread uid=%u, sid=%u, hwtid=%u\n",
+                       brk_thd->get_uid(),brk_thd->get_hw_sid(), brk_thd->get_hw_tid() );
+               printf( "GPGPU-Sim PTX DBG: ");
+               brk_inst->print_insn(stdout);
+               printf( "\n" );
+               g_watchpoint_hits.erase(w);
+            }
+            b.set_value(new_value);
+            done = false; 
+         }
+      } else {
+          /*
+         for( unsigned sid=0; sid < m_n_shader; sid++ ) { 
+            unsigned hw_thread_id = -1;
+            abort();
+            ptx_thread_info *thread = m_sc[sid]->get_functional_thread(hw_thread_id);
+            if( thread_at_brkpt(thread, b) ) {
+               done = false;
+               printf("GPGPU-Sim PTX DBG: reached breakpoint %u at %s (sm=%u, hwtid=%u)\n", 
+                      num, b.location().c_str(), sid, hw_thread_id );
+               brk_thd = thread;
+               brk_inst = brk_thd->get_inst();
+               printf( "GPGPU-Sim PTX DBG: reached by thread uid=%u, sid=%u, hwtid=%u\n",
+                       brk_thd->get_uid(),brk_thd->get_hw_sid(), brk_thd->get_hw_tid() );
+               printf( "GPGPU-Sim PTX DBG: ");
+               brk_inst->print_insn(stdout);
+               printf( "\n" );
+            }
+         }
+         */
       }
-    } else {
-      /*
-     for( unsigned sid=0; sid < m_n_shader; sid++ ) {
-        unsigned hw_thread_id = -1;
-        abort();
-        ptx_thread_info *thread =
-     m_sc[sid]->get_functional_thread(hw_thread_id);
-        if( thread_at_brkpt(thread, b) ) {
-           done = false;
-           printf("GPGPU-Sim PTX DBG: reached breakpoint %u at %s (sm=%u,
-     hwtid=%u)\n",
-                  num, b.location().c_str(), sid, hw_thread_id );
-           brk_thd = thread;
-           brk_inst = brk_thd->get_inst();
-           printf( "GPGPU-Sim PTX DBG: reached by thread uid=%u, sid=%u,
-     hwtid=%u\n",
-                   brk_thd->get_uid(),brk_thd->get_hw_sid(),
-     brk_thd->get_hw_tid() );
-           printf( "GPGPU-Sim PTX DBG: ");
-           brk_inst->print_insn(stdout);
-           printf( "\n" );
-        }
-     }
-     */
-    }
-  }
+   }
 
-  if (done) assert(g_watchpoint_hits.empty());
+   if( done ) 
+      assert( g_watchpoint_hits.empty() );
 
-  /// enter interactive debugger loop
+   /// enter interactive debugger loop
 
-  while (!done) {
-    printf("(ptx debugger) ");
-    fflush(stdout);
-
-    char line[1024];
-    fgets(line, 1024, stdin);
-
-    char *tok = strtok(line, " \t\n");
-    if (!strcmp(tok, "dp")) {
-      int shader_num = 0;
-      tok = strtok(NULL, " \t\n");
-      sscanf(tok, "%d", &shader_num);
-      dump_pipeline((0x40 | 0x4 | 0x1), shader_num, 0);
-      printf("\n");
+   while (!done) {
+      printf("(ptx debugger) ");
       fflush(stdout);
-    } else if (!strcmp(tok, "q") || !strcmp(tok, "quit")) {
-      printf("\nreally quit GPGPU-Sim (y/n)?\n");
-      fgets(line, 1024, stdin);
-      tok = strtok(line, " \t\n");
-      if (!strcmp(tok, "y")) {
-        exit(0);
+      
+      char line[1024];
+      fgets(line,1024,stdin);
+
+      char *tok = strtok(line," \t\n");
+      if( !strcmp(tok,"dp") ) {
+         int shader_num = 0;
+         tok = strtok(NULL," \t\n");
+         sscanf(tok,"%d",&shader_num);
+         dump_pipeline((0x40|0x4|0x1),shader_num,0);
+         printf("\n");
+         fflush(stdout);
+      } else if( !strcmp(tok,"q") || !strcmp(tok,"quit") ) {
+         printf("\nreally quit GPGPU-Sim (y/n)?\n");
+         fgets(line,1024,stdin);
+         tok = strtok(line," \t\n");
+         if( !strcmp(tok,"y") ) {
+            exit(0);
+         } else {
+            printf("not quiting.\n");
+         }
+      } else if( !strcmp(tok,"b") ) {
+         tok = strtok(NULL," \t\n");
+         char brkpt[1024];
+         sscanf(tok,"%s",brkpt);
+         tok = strtok(NULL," \t\n");
+         unsigned uid;
+         sscanf(tok,"%u",&uid);
+         breakpoints[next_brkpt++] = brk_pt(brkpt,uid);
+      } else if( !strcmp(tok,"d") ) {
+         tok = strtok(NULL," \t\n");
+         unsigned uid;
+         sscanf(tok,"%u",&uid);
+         breakpoints.erase(uid);
+      } else if( !strcmp(tok,"s") ) {
+         done = true;
+      } else if( !strcmp(tok,"c") ) {
+         single_step=false;
+         done = true;
+      } else if( !strcmp(tok,"w") ) {
+         tok = strtok(NULL," \t\n");
+         unsigned addr;
+         sscanf(tok,"%x",&addr);
+         unsigned value; 
+         m_global_mem->read(addr,4,&value);
+         m_global_mem->set_watch(addr,next_brkpt); 
+         breakpoints[next_brkpt++] = brk_pt(addr,value);
+      } else if( !strcmp(tok,"l") ) {
+         if( brk_thd == NULL  ) {
+            printf("no thread selected\n");
+         } else {
+            addr_t pc = brk_thd->get_pc();
+            addr_t start_pc = (pc<5)?0:(pc-5);
+            for( addr_t p=start_pc;  p <= pc+5; p++ ) {
+               const ptx_instruction *i = brk_thd->get_inst(p);
+               if( i ) {
+                  if( p != pc )
+                     printf( "    " );
+                  else
+                     printf( "==> " );
+                      i->print_insn(stdout);
+                  printf( "\n" );
+               }
+            }
+         }
+      } else if( !strcmp(tok,"h") ) {
+         printf("commands:\n");
+         printf("  q                           - quit GPGPU-Sim\n");
+         printf("  b <file>:<line> <thead uid> - set breakpoint\n");
+         printf("  w <global address>          - set watchpoint\n");
+         printf("  del <n>                     - delete breakpoint\n");
+         printf("  s                           - single step one shader cycle (all cores)\n");
+         printf("  c                           - continue simulation without single stepping\n");
+         printf("  l                           - list PTX around current breakpoint\n");
+         printf("  dp <n>                      - display pipeline contents on SM <n>\n");
+         printf("  h                           - print this message\n");
       } else {
-        printf("not quiting.\n");
+         printf("\ncommand not understood.\n");
       }
-    } else if (!strcmp(tok, "b")) {
-      tok = strtok(NULL, " \t\n");
-      char brkpt[1024];
-      sscanf(tok, "%s", brkpt);
-      tok = strtok(NULL, " \t\n");
-      unsigned uid;
-      sscanf(tok, "%u", &uid);
-      breakpoints[next_brkpt++] = brk_pt(brkpt, uid);
-    } else if (!strcmp(tok, "d")) {
-      tok = strtok(NULL, " \t\n");
-      unsigned uid;
-      sscanf(tok, "%u", &uid);
-      breakpoints.erase(uid);
-    } else if (!strcmp(tok, "s")) {
-      done = true;
-    } else if (!strcmp(tok, "c")) {
-      single_step = false;
-      done = true;
-    } else if (!strcmp(tok, "w")) {
-      tok = strtok(NULL, " \t\n");
-      unsigned addr;
-      sscanf(tok, "%x", &addr);
-      unsigned value;
-      m_global_mem->read(addr, 4, &value);
-      m_global_mem->set_watch(addr, next_brkpt);
-      breakpoints[next_brkpt++] = brk_pt(addr, value);
-    } else if (!strcmp(tok, "l")) {
-      if (brk_thd == NULL) {
-        printf("no thread selected\n");
-      } else {
-        addr_t pc = brk_thd->get_pc();
-        addr_t start_pc = (pc < 5) ? 0 : (pc - 5);
-        for (addr_t p = start_pc; p <= pc + 5; p++) {
-          const ptx_instruction *i = brk_thd->get_inst(p);
-          if (i) {
-            if (p != pc)
-              printf("    ");
-            else
-              printf("==> ");
-            i->print_insn(stdout);
-            printf("\n");
-          }
-        }
-      }
-    } else if (!strcmp(tok, "h")) {
-      printf("commands:\n");
-      printf("  q                           - quit GPGPU-Sim\n");
-      printf("  b <file>:<line> <thead uid> - set breakpoint\n");
-      printf("  w <global address>          - set watchpoint\n");
-      printf("  del <n>                     - delete breakpoint\n");
-      printf(
-          "  s                           - single step one shader cycle (all "
-          "cores)\n");
-      printf(
-          "  c                           - continue simulation without single "
-          "stepping\n");
-      printf(
-          "  l                           - list PTX around current "
-          "breakpoint\n");
-      printf(
-          "  dp <n>                      - display pipeline contents on SM "
-          "<n>\n");
-      printf("  h                           - print this message\n");
-    } else {
-      printf("\ncommand not understood.\n");
-    }
-    fflush(stdout);
-  }
+      fflush(stdout);
+   }
 }
 
-bool thread_at_brkpt(ptx_thread_info *thread, const class brk_pt &b) {
-  return b.is_equal(thread->get_location(), thread->get_uid());
+bool thread_at_brkpt( ptx_thread_info *thread, const class brk_pt &b )
+{
+   return b.is_equal(thread->get_location(),thread->get_uid());
 }
+

--- a/src/debug.h
+++ b/src/debug.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -35,53 +33,58 @@
 #include <string>
 
 class brk_pt {
- public:
-  brk_pt() { m_valid = false; }
-  brk_pt(const char *fileline, unsigned uid) {
-    m_valid = true;
-    m_watch = false;
-    m_fileline = std::string(fileline);
-    m_thread_uid = uid;
-  }
-  brk_pt(unsigned addr, unsigned value) {
-    m_valid = true;
-    m_watch = true;
-    m_addr = addr;
-    m_value = value;
-  }
+public:
+   brk_pt() { m_valid=false; }
+   brk_pt( const char *fileline, unsigned uid )
+   {
+      m_valid = true;
+      m_watch = false;
+      m_fileline = std::string(fileline);
+      m_thread_uid=uid;
+   }
+   brk_pt( unsigned addr, unsigned value )
+   {
+      m_valid = true;
+      m_watch = true;
+      m_addr = addr;
+      m_value = value;
+   }
 
-  unsigned get_value() const { return m_value; }
-  addr_t get_addr() const { return m_addr; }
-  bool is_valid() const { return m_valid; }
-  bool is_watchpoint() const { return m_watch; }
-  bool is_equal(const std::string &fileline, unsigned uid) const {
-    if (m_watch) return false;
-    if ((m_thread_uid != (unsigned)-1) && (uid != m_thread_uid)) return false;
-    return m_fileline == fileline;
-  }
-  std::string location() const {
-    char buffer[1024];
-    sprintf(buffer, "%s thread uid = %u", m_fileline.c_str(), m_thread_uid);
-    return buffer;
-  }
+   unsigned get_value() const { return m_value; }
+   addr_t get_addr() const { return m_addr; }
+   bool is_valid() const { return m_valid; }
+   bool is_watchpoint() const { return m_watch; }
+   bool is_equal( const std::string &fileline, unsigned uid ) const
+   {
+      if( m_watch ) 
+         return false; 
+      if( (m_thread_uid != (unsigned)-1) && (uid != m_thread_uid) ) 
+         return false;
+      return m_fileline == fileline;
+   }
+   std::string location() const
+   {
+      char buffer[1024];
+      sprintf(buffer,"%s thread uid = %u", m_fileline.c_str(), m_thread_uid);
+      return buffer;
+   }
 
-  unsigned set_value(unsigned val) { return m_value = val; }
+   unsigned set_value( unsigned val ) { return m_value=val; }
+private:
+   bool         m_valid;
+   bool         m_watch;
 
- private:
-  bool m_valid;
-  bool m_watch;
+   // break point
+   std::string  m_fileline;
+   unsigned     m_thread_uid;
 
-  // break point
-  std::string m_fileline;
-  unsigned m_thread_uid;
-
-  // watch point
-  unsigned m_addr;
-  unsigned m_value;
+   // watch point
+   unsigned     m_addr;
+   unsigned     m_value;
 };
 
 class ptx_thread_info;
 class ptx_instruction;
-bool thread_at_brkpt(ptx_thread_info *thd_info, const class brk_pt &b);
+bool thread_at_brkpt( ptx_thread_info *thd_info, const class brk_pt &b );
 
 #endif

--- a/src/debug.h
+++ b/src/debug.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -33,58 +35,53 @@
 #include <string>
 
 class brk_pt {
-public:
-   brk_pt() { m_valid=false; }
-   brk_pt( const char *fileline, unsigned uid )
-   {
-      m_valid = true;
-      m_watch = false;
-      m_fileline = std::string(fileline);
-      m_thread_uid=uid;
-   }
-   brk_pt( unsigned addr, unsigned value )
-   {
-      m_valid = true;
-      m_watch = true;
-      m_addr = addr;
-      m_value = value;
-   }
+ public:
+  brk_pt() { m_valid = false; }
+  brk_pt(const char *fileline, unsigned uid) {
+    m_valid = true;
+    m_watch = false;
+    m_fileline = std::string(fileline);
+    m_thread_uid = uid;
+  }
+  brk_pt(unsigned addr, unsigned value) {
+    m_valid = true;
+    m_watch = true;
+    m_addr = addr;
+    m_value = value;
+  }
 
-   unsigned get_value() const { return m_value; }
-   addr_t get_addr() const { return m_addr; }
-   bool is_valid() const { return m_valid; }
-   bool is_watchpoint() const { return m_watch; }
-   bool is_equal( const std::string &fileline, unsigned uid ) const
-   {
-      if( m_watch ) 
-         return false; 
-      if( (m_thread_uid != (unsigned)-1) && (uid != m_thread_uid) ) 
-         return false;
-      return m_fileline == fileline;
-   }
-   std::string location() const
-   {
-      char buffer[1024];
-      sprintf(buffer,"%s thread uid = %u", m_fileline.c_str(), m_thread_uid);
-      return buffer;
-   }
+  unsigned get_value() const { return m_value; }
+  addr_t get_addr() const { return m_addr; }
+  bool is_valid() const { return m_valid; }
+  bool is_watchpoint() const { return m_watch; }
+  bool is_equal(const std::string &fileline, unsigned uid) const {
+    if (m_watch) return false;
+    if ((m_thread_uid != (unsigned)-1) && (uid != m_thread_uid)) return false;
+    return m_fileline == fileline;
+  }
+  std::string location() const {
+    char buffer[1024];
+    sprintf(buffer, "%s thread uid = %u", m_fileline.c_str(), m_thread_uid);
+    return buffer;
+  }
 
-   unsigned set_value( unsigned val ) { return m_value=val; }
-private:
-   bool         m_valid;
-   bool         m_watch;
+  unsigned set_value(unsigned val) { return m_value = val; }
 
-   // break point
-   std::string  m_fileline;
-   unsigned     m_thread_uid;
+ private:
+  bool m_valid;
+  bool m_watch;
 
-   // watch point
-   unsigned     m_addr;
-   unsigned     m_value;
+  // break point
+  std::string m_fileline;
+  unsigned m_thread_uid;
+
+  // watch point
+  unsigned m_addr;
+  unsigned m_value;
 };
 
 class ptx_thread_info;
 class ptx_instruction;
-bool thread_at_brkpt( ptx_thread_info *thd_info, const class brk_pt &b );
+bool thread_at_brkpt(ptx_thread_info *thd_info, const class brk_pt &b);
 
 #endif

--- a/src/debug.h
+++ b/src/debug.h
@@ -7,23 +7,24 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef PTX_DEBUG_INCLUDED
 #define PTX_DEBUG_INCLUDED
@@ -33,58 +34,53 @@
 #include <string>
 
 class brk_pt {
-public:
-   brk_pt() { m_valid=false; }
-   brk_pt( const char *fileline, unsigned uid )
-   {
-      m_valid = true;
-      m_watch = false;
-      m_fileline = std::string(fileline);
-      m_thread_uid=uid;
-   }
-   brk_pt( unsigned addr, unsigned value )
-   {
-      m_valid = true;
-      m_watch = true;
-      m_addr = addr;
-      m_value = value;
-   }
+ public:
+  brk_pt() { m_valid = false; }
+  brk_pt(const char *fileline, unsigned uid) {
+    m_valid = true;
+    m_watch = false;
+    m_fileline = std::string(fileline);
+    m_thread_uid = uid;
+  }
+  brk_pt(unsigned addr, unsigned value) {
+    m_valid = true;
+    m_watch = true;
+    m_addr = addr;
+    m_value = value;
+  }
 
-   unsigned get_value() const { return m_value; }
-   addr_t get_addr() const { return m_addr; }
-   bool is_valid() const { return m_valid; }
-   bool is_watchpoint() const { return m_watch; }
-   bool is_equal( const std::string &fileline, unsigned uid ) const
-   {
-      if( m_watch ) 
-         return false; 
-      if( (m_thread_uid != (unsigned)-1) && (uid != m_thread_uid) ) 
-         return false;
-      return m_fileline == fileline;
-   }
-   std::string location() const
-   {
-      char buffer[1024];
-      sprintf(buffer,"%s thread uid = %u", m_fileline.c_str(), m_thread_uid);
-      return buffer;
-   }
+  unsigned get_value() const { return m_value; }
+  addr_t get_addr() const { return m_addr; }
+  bool is_valid() const { return m_valid; }
+  bool is_watchpoint() const { return m_watch; }
+  bool is_equal(const std::string &fileline, unsigned uid) const {
+    if (m_watch) return false;
+    if ((m_thread_uid != (unsigned)-1) && (uid != m_thread_uid)) return false;
+    return m_fileline == fileline;
+  }
+  std::string location() const {
+    char buffer[1024];
+    sprintf(buffer, "%s thread uid = %u", m_fileline.c_str(), m_thread_uid);
+    return buffer;
+  }
 
-   unsigned set_value( unsigned val ) { return m_value=val; }
-private:
-   bool         m_valid;
-   bool         m_watch;
+  unsigned set_value(unsigned val) { return m_value = val; }
 
-   // break point
-   std::string  m_fileline;
-   unsigned     m_thread_uid;
+ private:
+  bool m_valid;
+  bool m_watch;
 
-   // watch point
-   unsigned     m_addr;
-   unsigned     m_value;
+  // break point
+  std::string m_fileline;
+  unsigned m_thread_uid;
+
+  // watch point
+  unsigned m_addr;
+  unsigned m_value;
 };
 
 class ptx_thread_info;
 class ptx_instruction;
-bool thread_at_brkpt( ptx_thread_info *thd_info, const class brk_pt &b );
+bool thread_at_brkpt(ptx_thread_info *thd_info, const class brk_pt &b);
 
 #endif

--- a/src/gpgpu-sim/addrdec.cc
+++ b/src/gpgpu-sim/addrdec.cc
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -25,532 +27,607 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
-#include <string.h>
 #include "addrdec.h"
-#include "gpu-sim.h"
+#include <string.h>
 #include "../option_parser.h"
+#include "gpu-sim.h"
 
+static long int powli(long int x, long int y);
+static unsigned int LOGB2_32(unsigned int v);
+static new_addr_type addrdec_packbits(new_addr_type mask, new_addr_type val,
+                                      unsigned char high, unsigned char low);
+static void addrdec_getmasklimit(new_addr_type mask, unsigned char *high,
+                                 unsigned char *low);
 
-
-static long int powli( long int x, long int y );
-static unsigned int LOGB2_32( unsigned int v );
-static new_addr_type addrdec_packbits( new_addr_type mask, new_addr_type val, unsigned char high, unsigned char low);
-static void addrdec_getmasklimit(new_addr_type mask, unsigned char *high, unsigned char *low); 
-
-linear_to_raw_address_translation::linear_to_raw_address_translation()
-{
-   addrdec_option = NULL;
-   ADDR_CHIP_S = 10;
-   memset(addrdec_mklow,0,N_ADDRDEC);
-   memset(addrdec_mkhigh,64,N_ADDRDEC);
-   addrdec_mask[0] = 0x0000000000001C00;
-   addrdec_mask[1] = 0x0000000000000300;
-   addrdec_mask[2] = 0x000000000FFF0000;
-   addrdec_mask[3] = 0x000000000000E0FF;
-   addrdec_mask[4] = 0x000000000000000F;
+linear_to_raw_address_translation::linear_to_raw_address_translation() {
+  addrdec_option = NULL;
+  ADDR_CHIP_S = 10;
+  memset(addrdec_mklow, 0, N_ADDRDEC);
+  memset(addrdec_mkhigh, 64, N_ADDRDEC);
+  addrdec_mask[0] = 0x0000000000001C00;
+  addrdec_mask[1] = 0x0000000000000300;
+  addrdec_mask[2] = 0x000000000FFF0000;
+  addrdec_mask[3] = 0x000000000000E0FF;
+  addrdec_mask[4] = 0x000000000000000F;
 }
 
-void linear_to_raw_address_translation::addrdec_setoption(option_parser_t opp)
-{
-   option_parser_register(opp, "-gpgpu_mem_addr_mapping", OPT_CSTR, &addrdec_option,
-      "mapping memory address to dram model {dramid@<start bit>;<memory address map>}",
-      NULL);
-   option_parser_register(opp, "-gpgpu_mem_addr_test", OPT_BOOL, &run_test,
-      "run sweep test to check address mapping for aliased address",
+void linear_to_raw_address_translation::addrdec_setoption(option_parser_t opp) {
+  option_parser_register(opp, "-gpgpu_mem_addr_mapping", OPT_CSTR,
+                         &addrdec_option,
+                         "mapping memory address to dram model {dramid@<start "
+                         "bit>;<memory address map>}",
+                         NULL);
+  option_parser_register(
+      opp, "-gpgpu_mem_addr_test", OPT_BOOL, &run_test,
+      "run sweep test to check address mapping for aliased address", "0");
+  option_parser_register(opp, "-gpgpu_mem_address_mask", OPT_INT32,
+                         &gpgpu_mem_address_mask,
+                         "0 = old addressing mask, 1 = new addressing mask, 2 "
+                         "= new add. mask + flipped bank sel and chip sel bits",
+                         "0");
+  option_parser_register(
+      opp, "-memory_partition_indexing", OPT_UINT32, &memory_partition_indexing,
+      "0 = no indexing, 1 = bitwise xoring, 2 = IPoly, 3 = custom indexing",
       "0");
-   option_parser_register(opp, "-gpgpu_mem_address_mask", OPT_INT32, &gpgpu_mem_address_mask, 
-               "0 = old addressing mask, 1 = new addressing mask, 2 = new add. mask + flipped bank sel and chip sel bits",
-               "0");
-   option_parser_register(opp, "-memory_partition_indexing", OPT_UINT32, &memory_partition_indexing,
-                  "0 = no indexing, 1 = bitwise xoring, 2 = IPoly, 3 = custom indexing",
-                  "0");
 }
 
-new_addr_type linear_to_raw_address_translation::partition_address( new_addr_type addr ) const 
-{ 
-   if (!gap) {
-      return addrdec_packbits( ~(addrdec_mask[CHIP] | sub_partition_id_mask), addr, 64, 0 ); 
-   } else {
-      // see addrdec_tlx for explanation 
-      unsigned long long int partition_addr; 
-      partition_addr = ( (addr>>ADDR_CHIP_S) / m_n_channel) << ADDR_CHIP_S; 
-      partition_addr |= addr & ((1 << ADDR_CHIP_S) - 1); 
-      // remove the part of address that constributes to the sub partition ID
-      partition_addr = addrdec_packbits( ~sub_partition_id_mask, partition_addr, 64, 0); 
-      return partition_addr; 
-   }
+new_addr_type linear_to_raw_address_translation::partition_address(
+    new_addr_type addr) const {
+  if (!gap) {
+    return addrdec_packbits(~(addrdec_mask[CHIP] | sub_partition_id_mask), addr,
+                            64, 0);
+  } else {
+    // see addrdec_tlx for explanation
+    unsigned long long int partition_addr;
+    partition_addr = ((addr >> ADDR_CHIP_S) / m_n_channel) << ADDR_CHIP_S;
+    partition_addr |= addr & ((1 << ADDR_CHIP_S) - 1);
+    // remove the part of address that constributes to the sub partition ID
+    partition_addr =
+        addrdec_packbits(~sub_partition_id_mask, partition_addr, 64, 0);
+    return partition_addr;
+  }
 }
 
-void linear_to_raw_address_translation::addrdec_tlx(new_addr_type addr, addrdec_t *tlx) const
-{  
-   unsigned long long int addr_for_chip,rest_of_addr;
-   if (!gap) {
-      tlx->chip = addrdec_packbits(addrdec_mask[CHIP], addr, addrdec_mkhigh[CHIP], addrdec_mklow[CHIP]);
-      tlx->bk   = addrdec_packbits(addrdec_mask[BK], addr, addrdec_mkhigh[BK], addrdec_mklow[BK]);
-      tlx->row  = addrdec_packbits(addrdec_mask[ROW], addr, addrdec_mkhigh[ROW], addrdec_mklow[ROW]);
-      tlx->col  = addrdec_packbits(addrdec_mask[COL], addr, addrdec_mkhigh[COL], addrdec_mklow[COL]);
-      tlx->burst= addrdec_packbits(addrdec_mask[BURST], addr, addrdec_mkhigh[BURST], addrdec_mklow[BURST]);
-   } else {
-      // Split the given address at ADDR_CHIP_S into (MSBs,LSBs)
-      // - extract chip address using modulus of MSBs
-      // - recreate the rest of the address by stitching the quotient of MSBs and the LSBs 
-      addr_for_chip = (addr>>ADDR_CHIP_S) % m_n_channel; 
-      rest_of_addr = ( (addr>>ADDR_CHIP_S) / m_n_channel) << ADDR_CHIP_S; 
-      rest_of_addr |= addr & ((1 << ADDR_CHIP_S) - 1); 
+void linear_to_raw_address_translation::addrdec_tlx(new_addr_type addr,
+                                                    addrdec_t *tlx) const {
+  unsigned long long int addr_for_chip, rest_of_addr;
+  if (!gap) {
+    tlx->chip = addrdec_packbits(addrdec_mask[CHIP], addr, addrdec_mkhigh[CHIP],
+                                 addrdec_mklow[CHIP]);
+    tlx->bk = addrdec_packbits(addrdec_mask[BK], addr, addrdec_mkhigh[BK],
+                               addrdec_mklow[BK]);
+    tlx->row = addrdec_packbits(addrdec_mask[ROW], addr, addrdec_mkhigh[ROW],
+                                addrdec_mklow[ROW]);
+    tlx->col = addrdec_packbits(addrdec_mask[COL], addr, addrdec_mkhigh[COL],
+                                addrdec_mklow[COL]);
+    tlx->burst = addrdec_packbits(addrdec_mask[BURST], addr,
+                                  addrdec_mkhigh[BURST], addrdec_mklow[BURST]);
+  } else {
+    // Split the given address at ADDR_CHIP_S into (MSBs,LSBs)
+    // - extract chip address using modulus of MSBs
+    // - recreate the rest of the address by stitching the quotient of MSBs and
+    // the LSBs
+    addr_for_chip = (addr >> ADDR_CHIP_S) % m_n_channel;
+    rest_of_addr = ((addr >> ADDR_CHIP_S) / m_n_channel) << ADDR_CHIP_S;
+    rest_of_addr |= addr & ((1 << ADDR_CHIP_S) - 1);
 
-      tlx->chip = addr_for_chip; 
-      tlx->bk   = addrdec_packbits(addrdec_mask[BK], rest_of_addr, addrdec_mkhigh[BK], addrdec_mklow[BK]);
-      tlx->row  = addrdec_packbits(addrdec_mask[ROW], rest_of_addr, addrdec_mkhigh[ROW], addrdec_mklow[ROW]);
-      tlx->col  = addrdec_packbits(addrdec_mask[COL], rest_of_addr, addrdec_mkhigh[COL], addrdec_mklow[COL]);
-      tlx->burst= addrdec_packbits(addrdec_mask[BURST], rest_of_addr, addrdec_mkhigh[BURST], addrdec_mklow[BURST]);
-   }
+    tlx->chip = addr_for_chip;
+    tlx->bk = addrdec_packbits(addrdec_mask[BK], rest_of_addr,
+                               addrdec_mkhigh[BK], addrdec_mklow[BK]);
+    tlx->row = addrdec_packbits(addrdec_mask[ROW], rest_of_addr,
+                                addrdec_mkhigh[ROW], addrdec_mklow[ROW]);
+    tlx->col = addrdec_packbits(addrdec_mask[COL], rest_of_addr,
+                                addrdec_mkhigh[COL], addrdec_mklow[COL]);
+    tlx->burst = addrdec_packbits(addrdec_mask[BURST], rest_of_addr,
+                                  addrdec_mkhigh[BURST], addrdec_mklow[BURST]);
+  }
 
-    switch(memory_partition_indexing){
-		case CONSECUTIVE:
-			//Do nothing
-			break;
-		case BITWISE_PERMUTATION:
-		{
-			assert(!gap);
-			tlx->chip = (tlx->chip) ^ (tlx->row & (m_n_channel-1));
-			assert(tlx->chip < m_n_channel);
-			break;
-		}
-		case IPOLY:
-		{
-		    /*
-			* Set Indexing function from "Pseudo-randomly interleaved memory."
-			* Rau, B. R et al.
-			* ISCA 1991
-			*
-			* equations are adopted from:
-			* "Sacat: streaming-aware conflict-avoiding thrashing-resistant gpgpu cache management scheme."
-			* Khairy et al.
-			* IEEE TPDS 2017.
-			*/
-			if(m_n_channel == 32) {
-				std::bitset<64> a(tlx->row);
-				std::bitset<5> chip(tlx->chip);
-				chip[0] = a[13]^a[12]^a[11]^a[10]^a[9]^a[6]^a[5]^a[3]^a[0]^chip[0];
-				chip[1] = a[14]^a[13]^a[12]^a[11]^a[10]^a[7]^a[6]^a[4]^a[1]^chip[1];
-				chip[2] = a[14]^a[10]^a[9]^a[8]^a[7]^a[6]^a[3]^a[2]^a[0]^chip[2];
-				chip[3] = a[11]^a[10]^a[9]^a[8]^a[7]^a[4]^a[3]^a[1]^chip[3];
-				chip[4] = a[12]^a[11]^a[10]^a[9]^a[8]^a[5]^a[4]^a[2]^chip[4];
-				tlx->chip = chip.to_ulong();
-				
-			}
-			else{ /* Else incorrect number of channels for the hashing function */
-            assert("\nGPGPU-Sim memory_partition_indexing error: The number of channels should be "
-                    "32 for the hashing IPOLY index function.\n" && 0);
-			}
-			assert(tlx->chip < m_n_channel);
-			break;
-		}
-		case PAE:
-		{
-			//Page Address Entropy
-			//random selected bits from the page and bank bits
-			//similar to
-			//Liu, Yuxi, et al. "Get Out of the Valley: Power-Efficient Address Mapping for GPUs." ISCA 2018
-			std::bitset<64> a(tlx->row);
-			std::bitset<5> chip(tlx->chip);
-			std::bitset<4> b(tlx->bk);
-			chip[0] = a[13]^a[10]^a[9]^a[5]^a[0]^b[3]^b[0]^chip[0];
-			chip[1] = a[12]^a[11]^a[6]^a[1]^b[3]^b[2]^b[1]^chip[1];
-			chip[2] = a[14]^a[9]^a[8]^a[7]^a[2]^b[1]^chip[2];
-			chip[3] = a[11]^a[10]^a[8]^a[3]^b[2]^b[3]^chip[3];
-			chip[4] = a[12]^a[9]^a[8]^a[5]^a[4]^b[1]^b[0]^chip[4];
-			tlx->chip = chip.to_ulong();
-			assert(tlx->chip < m_n_channel);
-			break;
-		}
-		case RANDOM:
-		{
-			//This is an unrealistic hashing using software hashtable
-			//we generate a random set for each memory address and save the value in a big hashtable for future reuse
-			new_addr_type chip_address = (addr>>ADDR_CHIP_S);
-			tr1_hash_map<new_addr_type,unsigned>::const_iterator got = address_random_interleaving.find (chip_address);
-			  if ( got == address_random_interleaving.end() ) {
-				  unsigned new_chip_id = rand() % (m_n_channel*m_n_sub_partition_in_channel);
-				  address_random_interleaving[chip_address] = new_chip_id;
-				  tlx->chip = new_chip_id/m_n_sub_partition_in_channel;
-				  tlx->sub_partition = new_chip_id;
-			  }
-			  else {
-				  unsigned new_chip_id = got->second;
-				  tlx->chip = new_chip_id/m_n_sub_partition_in_channel;
-				  tlx->sub_partition = new_chip_id;
-			  }
+  switch (memory_partition_indexing) {
+    case CONSECUTIVE:
+      // Do nothing
+      break;
+    case BITWISE_PERMUTATION: {
+      assert(!gap);
+      tlx->chip = (tlx->chip) ^ (tlx->row & (m_n_channel - 1));
+      assert(tlx->chip < m_n_channel);
+      break;
+    }
+    case IPOLY: {
+      /*
+          * Set Indexing function from "Pseudo-randomly interleaved memory."
+          * Rau, B. R et al.
+          * ISCA 1991
+          *
+          * equations are adopted from:
+          * "Sacat: streaming-aware conflict-avoiding thrashing-resistant gpgpu
+       * cache management scheme."
+          * Khairy et al.
+          * IEEE TPDS 2017.
+          */
+      if (m_n_channel == 32) {
+        std::bitset<64> a(tlx->row);
+        std::bitset<5> chip(tlx->chip);
+        chip[0] = a[13] ^ a[12] ^ a[11] ^ a[10] ^ a[9] ^ a[6] ^ a[5] ^ a[3] ^
+                  a[0] ^ chip[0];
+        chip[1] = a[14] ^ a[13] ^ a[12] ^ a[11] ^ a[10] ^ a[7] ^ a[6] ^ a[4] ^
+                  a[1] ^ chip[1];
+        chip[2] = a[14] ^ a[10] ^ a[9] ^ a[8] ^ a[7] ^ a[6] ^ a[3] ^ a[2] ^
+                  a[0] ^ chip[2];
+        chip[3] =
+            a[11] ^ a[10] ^ a[9] ^ a[8] ^ a[7] ^ a[4] ^ a[3] ^ a[1] ^ chip[3];
+        chip[4] =
+            a[12] ^ a[11] ^ a[10] ^ a[9] ^ a[8] ^ a[5] ^ a[4] ^ a[2] ^ chip[4];
+        tlx->chip = chip.to_ulong();
 
-			  assert(tlx->chip < m_n_channel);
-			  assert(tlx->sub_partition < m_n_channel * m_n_sub_partition_in_channel);
-			  return;
-			break;
-		}
-		case CUSTOM:
-			/* No custom set function implemented */
-			//Do you custom index here
-			break;
-		default:
-			 assert("\nUndefined set index function.\n" && 0);
-			 break;
-	}
-
-   // combine the chip address and the lower bits of DRAM bank address to form the subpartition ID
-   unsigned sub_partition_addr_mask = m_n_sub_partition_in_channel - 1;
-   tlx->sub_partition = tlx->chip * m_n_sub_partition_in_channel
-                        + (tlx->bk & sub_partition_addr_mask);
-}
-
-void linear_to_raw_address_translation::addrdec_parseoption(const char *option)
-{
-   unsigned int dramid_start = 0;
-   int dramid_parsed = sscanf(option, "dramid@%d", &dramid_start);
-   if (dramid_parsed == 1) {
-      ADDR_CHIP_S = dramid_start;
-   } else {
-      ADDR_CHIP_S = -1;
-   }
-   
-   const char *cmapping = strchr(option, ';');
-   if (cmapping == NULL) {
-      cmapping = option;
-   } else {
-      cmapping += 1;
-   }
-
-   addrdec_mask[CHIP] = 0x0;
-   addrdec_mask[BK]   = 0x0;
-   addrdec_mask[ROW]  = 0x0;
-   addrdec_mask[COL]  = 0x0;
-   addrdec_mask[BURST]= 0x0;
-   
-   int ofs = 63;
-   while ((*cmapping) != '\0') {
-      switch (*cmapping) {
-         case 'D': case 'd':  
-            assert(dramid_parsed != 1); addrdec_mask[CHIP]  |= (1ULL << ofs); ofs--; break;
-         case 'B': case 'b':   addrdec_mask[BK]    |= (1ULL << ofs); ofs--; break;
-         case 'R': case 'r':   addrdec_mask[ROW]   |= (1ULL << ofs); ofs--; break;
-         case 'C': case 'c':   addrdec_mask[COL]   |= (1ULL << ofs); ofs--; break;
-         case 'S': case 's':   addrdec_mask[BURST] |= (1ULL << ofs); addrdec_mask[COL]   |= (1ULL << ofs); ofs--; break;
-         // ignore bit
-         case '0': ofs--; break;
-         // ignore character
-         case '|':
-         case ' ':
-         case '.': break;
-         default:
-            fprintf(stderr, "ERROR: Invalid address mapping character '%c' in option '%s'\n", *cmapping, option);
+      } else { /* Else incorrect number of channels for the hashing function */
+        assert(
+            "\nGPGPU-Sim memory_partition_indexing error: The number of "
+            "channels should be "
+            "32 for the hashing IPOLY index function.\n" &&
+            0);
       }
-      cmapping += 1;
-   }
+      assert(tlx->chip < m_n_channel);
+      break;
+    }
+    case PAE: {
+      // Page Address Entropy
+      // random selected bits from the page and bank bits
+      // similar to
+      // Liu, Yuxi, et al. "Get Out of the Valley: Power-Efficient Address
+      // Mapping for GPUs." ISCA 2018
+      std::bitset<64> a(tlx->row);
+      std::bitset<5> chip(tlx->chip);
+      std::bitset<4> b(tlx->bk);
+      chip[0] = a[13] ^ a[10] ^ a[9] ^ a[5] ^ a[0] ^ b[3] ^ b[0] ^ chip[0];
+      chip[1] = a[12] ^ a[11] ^ a[6] ^ a[1] ^ b[3] ^ b[2] ^ b[1] ^ chip[1];
+      chip[2] = a[14] ^ a[9] ^ a[8] ^ a[7] ^ a[2] ^ b[1] ^ chip[2];
+      chip[3] = a[11] ^ a[10] ^ a[8] ^ a[3] ^ b[2] ^ b[3] ^ chip[3];
+      chip[4] = a[12] ^ a[9] ^ a[8] ^ a[5] ^ a[4] ^ b[1] ^ b[0] ^ chip[4];
+      tlx->chip = chip.to_ulong();
+      assert(tlx->chip < m_n_channel);
+      break;
+    }
+    case RANDOM: {
+      // This is an unrealistic hashing using software hashtable
+      // we generate a random set for each memory address and save the value in
+      // a big hashtable for future reuse
+      new_addr_type chip_address = (addr >> ADDR_CHIP_S);
+      tr1_hash_map<new_addr_type, unsigned>::const_iterator got =
+          address_random_interleaving.find(chip_address);
+      if (got == address_random_interleaving.end()) {
+        unsigned new_chip_id =
+            rand() % (m_n_channel * m_n_sub_partition_in_channel);
+        address_random_interleaving[chip_address] = new_chip_id;
+        tlx->chip = new_chip_id / m_n_sub_partition_in_channel;
+        tlx->sub_partition = new_chip_id;
+      } else {
+        unsigned new_chip_id = got->second;
+        tlx->chip = new_chip_id / m_n_sub_partition_in_channel;
+        tlx->sub_partition = new_chip_id;
+      }
 
-   if (ofs != -1) {
-      fprintf(stderr, "ERROR: Invalid address mapping length (%d) in option '%s'\n", 63 - ofs, option);
-      assert(ofs == -1);
-   }
+      assert(tlx->chip < m_n_channel);
+      assert(tlx->sub_partition < m_n_channel * m_n_sub_partition_in_channel);
+      return;
+      break;
+    }
+    case CUSTOM:
+      /* No custom set function implemented */
+      // Do you custom index here
+      break;
+    default:
+      assert("\nUndefined set index function.\n" && 0);
+      break;
+  }
+
+  // combine the chip address and the lower bits of DRAM bank address to form
+  // the subpartition ID
+  unsigned sub_partition_addr_mask = m_n_sub_partition_in_channel - 1;
+  tlx->sub_partition = tlx->chip * m_n_sub_partition_in_channel +
+                       (tlx->bk & sub_partition_addr_mask);
 }
 
-void linear_to_raw_address_translation::init(unsigned int n_channel, unsigned int n_sub_partition_in_channel) 
-{
-   unsigned i;
-   unsigned long long int mask;
-   unsigned int nchipbits = ::LOGB2_32(n_channel);
-   m_n_channel = n_channel;
-   m_n_sub_partition_in_channel = n_sub_partition_in_channel; 
+void linear_to_raw_address_translation::addrdec_parseoption(
+    const char *option) {
+  unsigned int dramid_start = 0;
+  int dramid_parsed = sscanf(option, "dramid@%d", &dramid_start);
+  if (dramid_parsed == 1) {
+    ADDR_CHIP_S = dramid_start;
+  } else {
+    ADDR_CHIP_S = -1;
+  }
 
-   gap = (n_channel - ::powli(2,nchipbits));
-   if (gap) {
-      nchipbits++;
-   }
-   switch (gpgpu_mem_address_mask) {
-   case 0: 
-      //old, added 2row bits, use #define ADDR_CHIP_S 10
+  const char *cmapping = strchr(option, ';');
+  if (cmapping == NULL) {
+    cmapping = option;
+  } else {
+    cmapping += 1;
+  }
+
+  addrdec_mask[CHIP] = 0x0;
+  addrdec_mask[BK] = 0x0;
+  addrdec_mask[ROW] = 0x0;
+  addrdec_mask[COL] = 0x0;
+  addrdec_mask[BURST] = 0x0;
+
+  int ofs = 63;
+  while ((*cmapping) != '\0') {
+    switch (*cmapping) {
+      case 'D':
+      case 'd':
+        assert(dramid_parsed != 1);
+        addrdec_mask[CHIP] |= (1ULL << ofs);
+        ofs--;
+        break;
+      case 'B':
+      case 'b':
+        addrdec_mask[BK] |= (1ULL << ofs);
+        ofs--;
+        break;
+      case 'R':
+      case 'r':
+        addrdec_mask[ROW] |= (1ULL << ofs);
+        ofs--;
+        break;
+      case 'C':
+      case 'c':
+        addrdec_mask[COL] |= (1ULL << ofs);
+        ofs--;
+        break;
+      case 'S':
+      case 's':
+        addrdec_mask[BURST] |= (1ULL << ofs);
+        addrdec_mask[COL] |= (1ULL << ofs);
+        ofs--;
+        break;
+      // ignore bit
+      case '0':
+        ofs--;
+        break;
+      // ignore character
+      case '|':
+      case ' ':
+      case '.':
+        break;
+      default:
+        fprintf(
+            stderr,
+            "ERROR: Invalid address mapping character '%c' in option '%s'\n",
+            *cmapping, option);
+    }
+    cmapping += 1;
+  }
+
+  if (ofs != -1) {
+    fprintf(stderr,
+            "ERROR: Invalid address mapping length (%d) in option '%s'\n",
+            63 - ofs, option);
+    assert(ofs == -1);
+  }
+}
+
+void linear_to_raw_address_translation::init(
+    unsigned int n_channel, unsigned int n_sub_partition_in_channel) {
+  unsigned i;
+  unsigned long long int mask;
+  unsigned int nchipbits = ::LOGB2_32(n_channel);
+  m_n_channel = n_channel;
+  m_n_sub_partition_in_channel = n_sub_partition_in_channel;
+
+  gap = (n_channel - ::powli(2, nchipbits));
+  if (gap) {
+    nchipbits++;
+  }
+  switch (gpgpu_mem_address_mask) {
+    case 0:
+      // old, added 2row bits, use #define ADDR_CHIP_S 10
       ADDR_CHIP_S = 10;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK]   = 0x0000000000000300;
-      addrdec_mask[ROW]  = 0x0000000007FFE000;
-      addrdec_mask[COL]  = 0x0000000000001CFF;
+      addrdec_mask[BK] = 0x0000000000000300;
+      addrdec_mask[ROW] = 0x0000000007FFE000;
+      addrdec_mask[COL] = 0x0000000000001CFF;
       break;
-   case 1:
+    case 1:
       ADDR_CHIP_S = 13;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK]   = 0x0000000000001800;
-      addrdec_mask[ROW]  = 0x0000000007FFE000;
-      addrdec_mask[COL]  = 0x00000000000007FF;
+      addrdec_mask[BK] = 0x0000000000001800;
+      addrdec_mask[ROW] = 0x0000000007FFE000;
+      addrdec_mask[COL] = 0x00000000000007FF;
       break;
-   case 2:
+    case 2:
       ADDR_CHIP_S = 11;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK]   = 0x0000000000001800;
-      addrdec_mask[ROW]  = 0x0000000007FFE000;
-      addrdec_mask[COL]  = 0x00000000000007FF;
+      addrdec_mask[BK] = 0x0000000000001800;
+      addrdec_mask[ROW] = 0x0000000007FFE000;
+      addrdec_mask[COL] = 0x00000000000007FF;
       break;
-   case 3:
+    case 3:
       ADDR_CHIP_S = 11;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK]   = 0x0000000000001800;
-      addrdec_mask[ROW]  = 0x000000000FFFE000;
-      addrdec_mask[COL]  = 0x00000000000007FF;
+      addrdec_mask[BK] = 0x0000000000001800;
+      addrdec_mask[ROW] = 0x000000000FFFE000;
+      addrdec_mask[COL] = 0x00000000000007FF;
       break;
 
-   case 14:
+    case 14:
       ADDR_CHIP_S = 14;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK]   = 0x0000000000001800;
-      addrdec_mask[ROW]  = 0x0000000007FFE000;
-      addrdec_mask[COL]  = 0x00000000000007FF;
+      addrdec_mask[BK] = 0x0000000000001800;
+      addrdec_mask[ROW] = 0x0000000007FFE000;
+      addrdec_mask[COL] = 0x00000000000007FF;
       break;
-   case 15:
+    case 15:
       ADDR_CHIP_S = 15;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK]   = 0x0000000000001800;
-      addrdec_mask[ROW]  = 0x0000000007FFE000;
-      addrdec_mask[COL]  = 0x00000000000007FF;
+      addrdec_mask[BK] = 0x0000000000001800;
+      addrdec_mask[ROW] = 0x0000000007FFE000;
+      addrdec_mask[COL] = 0x00000000000007FF;
       break;
-   case 16:
+    case 16:
       ADDR_CHIP_S = 16;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK]   = 0x0000000000001800;
-      addrdec_mask[ROW]  = 0x0000000007FFE000;
-      addrdec_mask[COL]  = 0x00000000000007FF;
+      addrdec_mask[BK] = 0x0000000000001800;
+      addrdec_mask[ROW] = 0x0000000007FFE000;
+      addrdec_mask[COL] = 0x00000000000007FF;
       break;
-   case 6:
+    case 6:
       ADDR_CHIP_S = 6;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK]   = 0x0000000000001800;
-      addrdec_mask[ROW]  = 0x0000000007FFE000;
-      addrdec_mask[COL]  = 0x00000000000007FF;
+      addrdec_mask[BK] = 0x0000000000001800;
+      addrdec_mask[ROW] = 0x0000000007FFE000;
+      addrdec_mask[COL] = 0x00000000000007FF;
       break;
-   case 5:
+    case 5:
       ADDR_CHIP_S = 5;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK]   = 0x0000000000001800;
-      addrdec_mask[ROW]  = 0x0000000007FFE000;
-      addrdec_mask[COL]  = 0x00000000000007FF;
-      break;                         
-   case 100:
+      addrdec_mask[BK] = 0x0000000000001800;
+      addrdec_mask[ROW] = 0x0000000007FFE000;
+      addrdec_mask[COL] = 0x00000000000007FF;
+      break;
+    case 100:
       ADDR_CHIP_S = 1;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK]   = 0x0000000000000003;
-      addrdec_mask[ROW]  = 0x0000000007FFE000;
-      addrdec_mask[COL]  = 0x0000000000001FFC;
+      addrdec_mask[BK] = 0x0000000000000003;
+      addrdec_mask[ROW] = 0x0000000007FFE000;
+      addrdec_mask[COL] = 0x0000000000001FFC;
       break;
-   case 103:
+    case 103:
       ADDR_CHIP_S = 3;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK]   = 0x0000000000000003;
-      addrdec_mask[ROW]  = 0x0000000007FFE000;
-      addrdec_mask[COL]  = 0x0000000000001FFC;
+      addrdec_mask[BK] = 0x0000000000000003;
+      addrdec_mask[ROW] = 0x0000000007FFE000;
+      addrdec_mask[COL] = 0x0000000000001FFC;
       break;
-   case 106:
+    case 106:
       ADDR_CHIP_S = 6;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK]   = 0x0000000000001800;
-      addrdec_mask[ROW]  = 0x0000000007FFE000;
-      addrdec_mask[COL]  = 0x00000000000007FF;
+      addrdec_mask[BK] = 0x0000000000001800;
+      addrdec_mask[ROW] = 0x0000000007FFE000;
+      addrdec_mask[COL] = 0x00000000000007FF;
       break;
-   case 160: 
-      //old, added 2row bits, use #define ADDR_CHIP_S 10
+    case 160:
+      // old, added 2row bits, use #define ADDR_CHIP_S 10
       ADDR_CHIP_S = 6;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK]   = 0x0000000000000300;
-      addrdec_mask[ROW]  = 0x0000000007FFE000;
-      addrdec_mask[COL]  = 0x0000000000001CFF;
+      addrdec_mask[BK] = 0x0000000000000300;
+      addrdec_mask[ROW] = 0x0000000007FFE000;
+      addrdec_mask[COL] = 0x0000000000001CFF;
 
-   default:
+    default:
       break;
-   }
+  }
 
-   if (addrdec_option != NULL) 
-      addrdec_parseoption(addrdec_option);
+  if (addrdec_option != NULL) addrdec_parseoption(addrdec_option);
 
-   if (ADDR_CHIP_S != -1) { 
-      if (!gap) {
-         // number of chip is power of two: 
-         // - insert CHIP mask starting at the bit position ADDR_CHIP_S
-         mask = ((unsigned long long int)1 << ADDR_CHIP_S) - 1;
-         addrdec_mask[BK]   = ((addrdec_mask[BK] & ~mask) << nchipbits) | (addrdec_mask[BK] & mask);
-         addrdec_mask[ROW]  = ((addrdec_mask[ROW] & ~mask) << nchipbits) | (addrdec_mask[ROW] & mask);
-         addrdec_mask[COL]  = ((addrdec_mask[COL] & ~mask) << nchipbits) | (addrdec_mask[COL] & mask);
+  if (ADDR_CHIP_S != -1) {
+    if (!gap) {
+      // number of chip is power of two:
+      // - insert CHIP mask starting at the bit position ADDR_CHIP_S
+      mask = ((unsigned long long int)1 << ADDR_CHIP_S) - 1;
+      addrdec_mask[BK] =
+          ((addrdec_mask[BK] & ~mask) << nchipbits) | (addrdec_mask[BK] & mask);
+      addrdec_mask[ROW] = ((addrdec_mask[ROW] & ~mask) << nchipbits) |
+                          (addrdec_mask[ROW] & mask);
+      addrdec_mask[COL] = ((addrdec_mask[COL] & ~mask) << nchipbits) |
+                          (addrdec_mask[COL] & mask);
 
-         for (i=ADDR_CHIP_S;i<(ADDR_CHIP_S+nchipbits);i++) {
-            mask = (unsigned long long int)1 << i;
-            addrdec_mask[CHIP] |= mask;
-         }
-      } // otherwise, no need to change the masks
-   } else {
-      // make sure n_channel is power of two when explicit dram id mask is used
-      assert((n_channel & (n_channel - 1)) == 0); 
-   }
-   // make sure m_n_sub_partition_in_channel is power of two 
-   assert((m_n_sub_partition_in_channel & (m_n_sub_partition_in_channel - 1)) == 0); 
-
-   addrdec_getmasklimit(addrdec_mask[CHIP],  &addrdec_mkhigh[CHIP],  &addrdec_mklow[CHIP] );
-   addrdec_getmasklimit(addrdec_mask[BK],    &addrdec_mkhigh[BK],    &addrdec_mklow[BK]   );
-   addrdec_getmasklimit(addrdec_mask[ROW],   &addrdec_mkhigh[ROW],   &addrdec_mklow[ROW]  );
-   addrdec_getmasklimit(addrdec_mask[COL],   &addrdec_mkhigh[COL],   &addrdec_mklow[COL]  );
-   addrdec_getmasklimit(addrdec_mask[BURST], &addrdec_mkhigh[BURST], &addrdec_mklow[BURST]);
-
-   printf("addr_dec_mask[CHIP]  = %016llx \thigh:%d low:%d\n", addrdec_mask[CHIP],  addrdec_mkhigh[CHIP],  addrdec_mklow[CHIP] );
-   printf("addr_dec_mask[BK]    = %016llx \thigh:%d low:%d\n", addrdec_mask[BK],    addrdec_mkhigh[BK],    addrdec_mklow[BK]   );
-   printf("addr_dec_mask[ROW]   = %016llx \thigh:%d low:%d\n", addrdec_mask[ROW],   addrdec_mkhigh[ROW],   addrdec_mklow[ROW]  );
-   printf("addr_dec_mask[COL]   = %016llx \thigh:%d low:%d\n", addrdec_mask[COL],   addrdec_mkhigh[COL],   addrdec_mklow[COL]  );
-   printf("addr_dec_mask[BURST] = %016llx \thigh:%d low:%d\n", addrdec_mask[BURST], addrdec_mkhigh[BURST], addrdec_mklow[BURST]);
-
-   // create the sub partition ID mask (for removing the sub partition ID from the partition address)
-   sub_partition_id_mask = 0; 
-   if (m_n_sub_partition_in_channel > 1) {
-      unsigned n_sub_partition_log2 = LOGB2_32(m_n_sub_partition_in_channel); 
-      unsigned pos=0;
-      for (unsigned i=addrdec_mklow[BK];i<addrdec_mkhigh[BK];i++) {
-         if ((addrdec_mask[BK] & ((unsigned long long int)1<<i)) != 0) {
-            sub_partition_id_mask |= ((unsigned long long int)1<<i);
-            pos++;
-            if (pos >= n_sub_partition_log2) 
-               break; 
-         }
+      for (i = ADDR_CHIP_S; i < (ADDR_CHIP_S + nchipbits); i++) {
+        mask = (unsigned long long int)1 << i;
+        addrdec_mask[CHIP] |= mask;
       }
-   }
-   printf("sub_partition_id_mask = %016llx\n", sub_partition_id_mask);
+    }  // otherwise, no need to change the masks
+  } else {
+    // make sure n_channel is power of two when explicit dram id mask is used
+    assert((n_channel & (n_channel - 1)) == 0);
+  }
+  // make sure m_n_sub_partition_in_channel is power of two
+  assert((m_n_sub_partition_in_channel & (m_n_sub_partition_in_channel - 1)) ==
+         0);
 
-   if (run_test) {
-      sweep_test(); 
-   }
+  addrdec_getmasklimit(addrdec_mask[CHIP], &addrdec_mkhigh[CHIP],
+                       &addrdec_mklow[CHIP]);
+  addrdec_getmasklimit(addrdec_mask[BK], &addrdec_mkhigh[BK],
+                       &addrdec_mklow[BK]);
+  addrdec_getmasklimit(addrdec_mask[ROW], &addrdec_mkhigh[ROW],
+                       &addrdec_mklow[ROW]);
+  addrdec_getmasklimit(addrdec_mask[COL], &addrdec_mkhigh[COL],
+                       &addrdec_mklow[COL]);
+  addrdec_getmasklimit(addrdec_mask[BURST], &addrdec_mkhigh[BURST],
+                       &addrdec_mklow[BURST]);
 
-   if(memory_partition_indexing == RANDOM)
-     srand (1);
+  printf("addr_dec_mask[CHIP]  = %016llx \thigh:%d low:%d\n",
+         addrdec_mask[CHIP], addrdec_mkhigh[CHIP], addrdec_mklow[CHIP]);
+  printf("addr_dec_mask[BK]    = %016llx \thigh:%d low:%d\n", addrdec_mask[BK],
+         addrdec_mkhigh[BK], addrdec_mklow[BK]);
+  printf("addr_dec_mask[ROW]   = %016llx \thigh:%d low:%d\n", addrdec_mask[ROW],
+         addrdec_mkhigh[ROW], addrdec_mklow[ROW]);
+  printf("addr_dec_mask[COL]   = %016llx \thigh:%d low:%d\n", addrdec_mask[COL],
+         addrdec_mkhigh[COL], addrdec_mklow[COL]);
+  printf("addr_dec_mask[BURST] = %016llx \thigh:%d low:%d\n",
+         addrdec_mask[BURST], addrdec_mkhigh[BURST], addrdec_mklow[BURST]);
 
+  // create the sub partition ID mask (for removing the sub partition ID from
+  // the partition address)
+  sub_partition_id_mask = 0;
+  if (m_n_sub_partition_in_channel > 1) {
+    unsigned n_sub_partition_log2 = LOGB2_32(m_n_sub_partition_in_channel);
+    unsigned pos = 0;
+    for (unsigned i = addrdec_mklow[BK]; i < addrdec_mkhigh[BK]; i++) {
+      if ((addrdec_mask[BK] & ((unsigned long long int)1 << i)) != 0) {
+        sub_partition_id_mask |= ((unsigned long long int)1 << i);
+        pos++;
+        if (pos >= n_sub_partition_log2) break;
+      }
+    }
+  }
+  printf("sub_partition_id_mask = %016llx\n", sub_partition_id_mask);
+
+  if (run_test) {
+    sweep_test();
+  }
+
+  if (memory_partition_indexing == RANDOM) srand(1);
 }
 
-#include "../tr1_hash_map.h" 
+#include "../tr1_hash_map.h"
 
-bool operator==(const addrdec_t &x, const addrdec_t &y) 
-{
-   return ( memcmp(&x, &y, sizeof(addrdec_t)) == 0 ); 
+bool operator==(const addrdec_t &x, const addrdec_t &y) {
+  return (memcmp(&x, &y, sizeof(addrdec_t)) == 0);
 }
 
-bool operator<(const addrdec_t &x, const addrdec_t &y) 
-{
-   if (x.chip >= y.chip) return false; 
-   else if (x.bk >= y.bk) return false;
-   else if (x.row >= y.row) return false;
-   else if (x.col >= y.col) return false;
-   else if (x.burst >= y.burst) return false;
-   else return true; 
+bool operator<(const addrdec_t &x, const addrdec_t &y) {
+  if (x.chip >= y.chip)
+    return false;
+  else if (x.bk >= y.bk)
+    return false;
+  else if (x.row >= y.row)
+    return false;
+  else if (x.col >= y.col)
+    return false;
+  else if (x.burst >= y.burst)
+    return false;
+  else
+    return true;
 }
 
-class hash_addrdec_t
-{
-public: 
-   size_t operator()(const addrdec_t &x) const {
-      return (x.chip ^ x.bk ^ x.row ^ x.col ^ x.burst); 
-   }
+class hash_addrdec_t {
+ public:
+  size_t operator()(const addrdec_t &x) const {
+    return (x.chip ^ x.bk ^ x.row ^ x.col ^ x.burst);
+  }
 };
 
-// a simple sweep test to ensure that two linear addresses are not mapped to the same raw address 
-void linear_to_raw_address_translation::sweep_test() const
-{
-   new_addr_type sweep_range = 16 * 1024 * 1024; 
+// a simple sweep test to ensure that two linear addresses are not mapped to the
+// same raw address
+void linear_to_raw_address_translation::sweep_test() const {
+  new_addr_type sweep_range = 16 * 1024 * 1024;
 
 #if tr1_hash_map_ismap == 1
-   typedef tr1_hash_map<addrdec_t, new_addr_type> history_map_t; 
+  typedef tr1_hash_map<addrdec_t, new_addr_type> history_map_t;
 #else
-   typedef tr1_hash_map<addrdec_t, new_addr_type, hash_addrdec_t> history_map_t; 
+  typedef tr1_hash_map<addrdec_t, new_addr_type, hash_addrdec_t> history_map_t;
 #endif
-   history_map_t history_map; 
+  history_map_t history_map;
 
-   for (new_addr_type raw_addr = 4; raw_addr < sweep_range; raw_addr += 4) {
-      addrdec_t tlx; 
-      addrdec_tlx(raw_addr, &tlx); 
+  for (new_addr_type raw_addr = 4; raw_addr < sweep_range; raw_addr += 4) {
+    addrdec_t tlx;
+    addrdec_tlx(raw_addr, &tlx);
 
-      history_map_t::iterator h = history_map.find(tlx); 
+    history_map_t::iterator h = history_map.find(tlx);
 
-      if (h != history_map.end()) {
-         printf("[AddrDec] ** Error: address decoding mapping aliases two addresses to same partition with same intra-partition address: %llx %llx\n", h->second, raw_addr); 
-         abort(); 
+    if (h != history_map.end()) {
+      printf(
+          "[AddrDec] ** Error: address decoding mapping aliases two addresses "
+          "to same partition with same intra-partition address: %llx %llx\n",
+          h->second, raw_addr);
+      abort();
+    } else {
+      assert((int)tlx.chip < m_n_channel);
+      // ensure that partition_address() returns the concatenated address
+      if ((ADDR_CHIP_S != -1 and raw_addr >= (1ULL << ADDR_CHIP_S)) or
+          (ADDR_CHIP_S == -1 and raw_addr >= (1ULL << addrdec_mklow[CHIP]))) {
+        assert(raw_addr != partition_address(raw_addr));
+      }
+      history_map[tlx] = raw_addr;
+    }
+
+    if ((raw_addr & 0xffff) == 0) printf("%llu scaned\n", raw_addr);
+  }
+}
+
+void addrdec_t::print(FILE *fp) const {
+  fprintf(fp, "\tchip:%x ", chip);
+  fprintf(fp, "\trow:%x ", row);
+  fprintf(fp, "\tcol:%x ", col);
+  fprintf(fp, "\tbk:%x ", bk);
+  fprintf(fp, "\tburst:%x ", burst);
+  fprintf(fp, "\tsub_partition:%x ", sub_partition);
+}
+
+static long int powli(long int x, long int y)  // compute x to the y
+{
+  long int r = 1;
+  int i;
+  for (i = 0; i < y; ++i) {
+    r *= x;
+  }
+  return r;
+}
+
+static unsigned int LOGB2_32(unsigned int v) {
+  unsigned int shift;
+  unsigned int r;
+
+  r = 0;
+
+  shift = ((v & 0xFFFF0000) != 0) << 4;
+  v >>= shift;
+  r |= shift;
+  shift = ((v & 0xFF00) != 0) << 3;
+  v >>= shift;
+  r |= shift;
+  shift = ((v & 0xF0) != 0) << 2;
+  v >>= shift;
+  r |= shift;
+  shift = ((v & 0xC) != 0) << 1;
+  v >>= shift;
+  r |= shift;
+  shift = ((v & 0x2) != 0) << 0;
+  v >>= shift;
+  r |= shift;
+
+  return r;
+}
+
+static new_addr_type addrdec_packbits(new_addr_type mask, new_addr_type val,
+                                      unsigned char high, unsigned char low) {
+  unsigned pos = 0;
+  new_addr_type result = 0;
+  for (unsigned i = low; i < high; i++) {
+    if ((mask & ((unsigned long long int)1 << i)) != 0) {
+      result |= ((val & ((unsigned long long int)1 << i)) >> i) << pos;
+      pos++;
+    }
+  }
+  return result;
+}
+
+static void addrdec_getmasklimit(new_addr_type mask, unsigned char *high,
+                                 unsigned char *low) {
+  *high = 64;
+  *low = 0;
+  int i;
+  int low_found = 0;
+
+  for (i = 0; i < 64; i++) {
+    if ((mask & ((unsigned long long int)1 << i)) != 0) {
+      if (low_found) {
+        *high = i + 1;
       } else {
-         assert((int)tlx.chip < m_n_channel); 
-         // ensure that partition_address() returns the concatenated address 
-         if ((ADDR_CHIP_S != -1 and raw_addr >= (1ULL << ADDR_CHIP_S)) or 
-             (ADDR_CHIP_S == -1 and raw_addr >= (1ULL << addrdec_mklow[CHIP]))) {
-            assert(raw_addr != partition_address(raw_addr)); 
-         }
-         history_map[tlx] = raw_addr; 
+        *high = i + 1;
+        *low = i;
+        low_found = 1;
       }
-
-      if ((raw_addr & 0xffff) == 0) printf("%llu scaned\n", raw_addr); 
-   }
-}
-
-void addrdec_t::print( FILE *fp ) const
-{
-   fprintf(fp,"\tchip:%x ", chip);
-   fprintf(fp,"\trow:%x ", row);
-   fprintf(fp,"\tcol:%x ", col);
-   fprintf(fp,"\tbk:%x ", bk);
-   fprintf(fp,"\tburst:%x ", burst);
-   fprintf(fp,"\tsub_partition:%x ", sub_partition);
-} 
-
-
-static long int powli( long int x, long int y ) // compute x to the y
-{
-   long int r = 1;
-   int i; 
-   for (i = 0; i < y; ++i ) {
-      r *= x;
-   }
-   return r;
-}
-
-static unsigned int LOGB2_32( unsigned int v ) 
-{
-   unsigned int shift;
-   unsigned int r;
-
-   r = 0;
-
-   shift = (( v & 0xFFFF0000) != 0 ) << 4; v >>= shift; r |= shift;
-   shift = (( v & 0xFF00    ) != 0 ) << 3; v >>= shift; r |= shift;
-   shift = (( v & 0xF0      ) != 0 ) << 2; v >>= shift; r |= shift;
-   shift = (( v & 0xC       ) != 0 ) << 1; v >>= shift; r |= shift;
-   shift = (( v & 0x2       ) != 0 ) << 0; v >>= shift; r |= shift;
-
-   return r;
-}
-
-static new_addr_type addrdec_packbits( new_addr_type mask, new_addr_type val, unsigned char high, unsigned char low) 
-{
-   unsigned pos=0;
-   new_addr_type result = 0;
-   for (unsigned i=low;i<high;i++) {
-      if ((mask & ((unsigned long long int)1<<i)) != 0) {
-         result |= ((val & ((unsigned long long int)1<<i)) >> i) << pos;
-         pos++;
-      }
-   }
-   return result;
-}
-
-static void addrdec_getmasklimit(new_addr_type mask, unsigned char *high, unsigned char *low) 
-{
-   *high = 64;
-   *low = 0;
-   int i;
-   int low_found = 0;
-
-   for (i=0;i<64;i++) {
-      if ((mask & ((unsigned long long int)1<<i)) != 0) {
-         if (low_found) {
-            *high = i + 1;
-         } else {
-            *high = i + 1;
-            *low = i;
-            low_found = 1;
-         }
-      }
-   }
+    }
+  }
 }

--- a/src/gpgpu-sim/addrdec.cc
+++ b/src/gpgpu-sim/addrdec.cc
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -27,607 +25,532 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "addrdec.h"
+
 #include <string.h>
-#include "../option_parser.h"
+#include "addrdec.h"
 #include "gpu-sim.h"
+#include "../option_parser.h"
 
-static long int powli(long int x, long int y);
-static unsigned int LOGB2_32(unsigned int v);
-static new_addr_type addrdec_packbits(new_addr_type mask, new_addr_type val,
-                                      unsigned char high, unsigned char low);
-static void addrdec_getmasklimit(new_addr_type mask, unsigned char *high,
-                                 unsigned char *low);
 
-linear_to_raw_address_translation::linear_to_raw_address_translation() {
-  addrdec_option = NULL;
-  ADDR_CHIP_S = 10;
-  memset(addrdec_mklow, 0, N_ADDRDEC);
-  memset(addrdec_mkhigh, 64, N_ADDRDEC);
-  addrdec_mask[0] = 0x0000000000001C00;
-  addrdec_mask[1] = 0x0000000000000300;
-  addrdec_mask[2] = 0x000000000FFF0000;
-  addrdec_mask[3] = 0x000000000000E0FF;
-  addrdec_mask[4] = 0x000000000000000F;
+
+static long int powli( long int x, long int y );
+static unsigned int LOGB2_32( unsigned int v );
+static new_addr_type addrdec_packbits( new_addr_type mask, new_addr_type val, unsigned char high, unsigned char low);
+static void addrdec_getmasklimit(new_addr_type mask, unsigned char *high, unsigned char *low); 
+
+linear_to_raw_address_translation::linear_to_raw_address_translation()
+{
+   addrdec_option = NULL;
+   ADDR_CHIP_S = 10;
+   memset(addrdec_mklow,0,N_ADDRDEC);
+   memset(addrdec_mkhigh,64,N_ADDRDEC);
+   addrdec_mask[0] = 0x0000000000001C00;
+   addrdec_mask[1] = 0x0000000000000300;
+   addrdec_mask[2] = 0x000000000FFF0000;
+   addrdec_mask[3] = 0x000000000000E0FF;
+   addrdec_mask[4] = 0x000000000000000F;
 }
 
-void linear_to_raw_address_translation::addrdec_setoption(option_parser_t opp) {
-  option_parser_register(opp, "-gpgpu_mem_addr_mapping", OPT_CSTR,
-                         &addrdec_option,
-                         "mapping memory address to dram model {dramid@<start "
-                         "bit>;<memory address map>}",
-                         NULL);
-  option_parser_register(
-      opp, "-gpgpu_mem_addr_test", OPT_BOOL, &run_test,
-      "run sweep test to check address mapping for aliased address", "0");
-  option_parser_register(opp, "-gpgpu_mem_address_mask", OPT_INT32,
-                         &gpgpu_mem_address_mask,
-                         "0 = old addressing mask, 1 = new addressing mask, 2 "
-                         "= new add. mask + flipped bank sel and chip sel bits",
-                         "0");
-  option_parser_register(
-      opp, "-memory_partition_indexing", OPT_UINT32, &memory_partition_indexing,
-      "0 = no indexing, 1 = bitwise xoring, 2 = IPoly, 3 = custom indexing",
+void linear_to_raw_address_translation::addrdec_setoption(option_parser_t opp)
+{
+   option_parser_register(opp, "-gpgpu_mem_addr_mapping", OPT_CSTR, &addrdec_option,
+      "mapping memory address to dram model {dramid@<start bit>;<memory address map>}",
+      NULL);
+   option_parser_register(opp, "-gpgpu_mem_addr_test", OPT_BOOL, &run_test,
+      "run sweep test to check address mapping for aliased address",
       "0");
+   option_parser_register(opp, "-gpgpu_mem_address_mask", OPT_INT32, &gpgpu_mem_address_mask, 
+               "0 = old addressing mask, 1 = new addressing mask, 2 = new add. mask + flipped bank sel and chip sel bits",
+               "0");
+   option_parser_register(opp, "-memory_partition_indexing", OPT_UINT32, &memory_partition_indexing,
+                  "0 = no indexing, 1 = bitwise xoring, 2 = IPoly, 3 = custom indexing",
+                  "0");
 }
 
-new_addr_type linear_to_raw_address_translation::partition_address(
-    new_addr_type addr) const {
-  if (!gap) {
-    return addrdec_packbits(~(addrdec_mask[CHIP] | sub_partition_id_mask), addr,
-                            64, 0);
-  } else {
-    // see addrdec_tlx for explanation
-    unsigned long long int partition_addr;
-    partition_addr = ((addr >> ADDR_CHIP_S) / m_n_channel) << ADDR_CHIP_S;
-    partition_addr |= addr & ((1 << ADDR_CHIP_S) - 1);
-    // remove the part of address that constributes to the sub partition ID
-    partition_addr =
-        addrdec_packbits(~sub_partition_id_mask, partition_addr, 64, 0);
-    return partition_addr;
-  }
+new_addr_type linear_to_raw_address_translation::partition_address( new_addr_type addr ) const 
+{ 
+   if (!gap) {
+      return addrdec_packbits( ~(addrdec_mask[CHIP] | sub_partition_id_mask), addr, 64, 0 ); 
+   } else {
+      // see addrdec_tlx for explanation 
+      unsigned long long int partition_addr; 
+      partition_addr = ( (addr>>ADDR_CHIP_S) / m_n_channel) << ADDR_CHIP_S; 
+      partition_addr |= addr & ((1 << ADDR_CHIP_S) - 1); 
+      // remove the part of address that constributes to the sub partition ID
+      partition_addr = addrdec_packbits( ~sub_partition_id_mask, partition_addr, 64, 0); 
+      return partition_addr; 
+   }
 }
 
-void linear_to_raw_address_translation::addrdec_tlx(new_addr_type addr,
-                                                    addrdec_t *tlx) const {
-  unsigned long long int addr_for_chip, rest_of_addr;
-  if (!gap) {
-    tlx->chip = addrdec_packbits(addrdec_mask[CHIP], addr, addrdec_mkhigh[CHIP],
-                                 addrdec_mklow[CHIP]);
-    tlx->bk = addrdec_packbits(addrdec_mask[BK], addr, addrdec_mkhigh[BK],
-                               addrdec_mklow[BK]);
-    tlx->row = addrdec_packbits(addrdec_mask[ROW], addr, addrdec_mkhigh[ROW],
-                                addrdec_mklow[ROW]);
-    tlx->col = addrdec_packbits(addrdec_mask[COL], addr, addrdec_mkhigh[COL],
-                                addrdec_mklow[COL]);
-    tlx->burst = addrdec_packbits(addrdec_mask[BURST], addr,
-                                  addrdec_mkhigh[BURST], addrdec_mklow[BURST]);
-  } else {
-    // Split the given address at ADDR_CHIP_S into (MSBs,LSBs)
-    // - extract chip address using modulus of MSBs
-    // - recreate the rest of the address by stitching the quotient of MSBs and
-    // the LSBs
-    addr_for_chip = (addr >> ADDR_CHIP_S) % m_n_channel;
-    rest_of_addr = ((addr >> ADDR_CHIP_S) / m_n_channel) << ADDR_CHIP_S;
-    rest_of_addr |= addr & ((1 << ADDR_CHIP_S) - 1);
+void linear_to_raw_address_translation::addrdec_tlx(new_addr_type addr, addrdec_t *tlx) const
+{  
+   unsigned long long int addr_for_chip,rest_of_addr;
+   if (!gap) {
+      tlx->chip = addrdec_packbits(addrdec_mask[CHIP], addr, addrdec_mkhigh[CHIP], addrdec_mklow[CHIP]);
+      tlx->bk   = addrdec_packbits(addrdec_mask[BK], addr, addrdec_mkhigh[BK], addrdec_mklow[BK]);
+      tlx->row  = addrdec_packbits(addrdec_mask[ROW], addr, addrdec_mkhigh[ROW], addrdec_mklow[ROW]);
+      tlx->col  = addrdec_packbits(addrdec_mask[COL], addr, addrdec_mkhigh[COL], addrdec_mklow[COL]);
+      tlx->burst= addrdec_packbits(addrdec_mask[BURST], addr, addrdec_mkhigh[BURST], addrdec_mklow[BURST]);
+   } else {
+      // Split the given address at ADDR_CHIP_S into (MSBs,LSBs)
+      // - extract chip address using modulus of MSBs
+      // - recreate the rest of the address by stitching the quotient of MSBs and the LSBs 
+      addr_for_chip = (addr>>ADDR_CHIP_S) % m_n_channel; 
+      rest_of_addr = ( (addr>>ADDR_CHIP_S) / m_n_channel) << ADDR_CHIP_S; 
+      rest_of_addr |= addr & ((1 << ADDR_CHIP_S) - 1); 
 
-    tlx->chip = addr_for_chip;
-    tlx->bk = addrdec_packbits(addrdec_mask[BK], rest_of_addr,
-                               addrdec_mkhigh[BK], addrdec_mklow[BK]);
-    tlx->row = addrdec_packbits(addrdec_mask[ROW], rest_of_addr,
-                                addrdec_mkhigh[ROW], addrdec_mklow[ROW]);
-    tlx->col = addrdec_packbits(addrdec_mask[COL], rest_of_addr,
-                                addrdec_mkhigh[COL], addrdec_mklow[COL]);
-    tlx->burst = addrdec_packbits(addrdec_mask[BURST], rest_of_addr,
-                                  addrdec_mkhigh[BURST], addrdec_mklow[BURST]);
-  }
+      tlx->chip = addr_for_chip; 
+      tlx->bk   = addrdec_packbits(addrdec_mask[BK], rest_of_addr, addrdec_mkhigh[BK], addrdec_mklow[BK]);
+      tlx->row  = addrdec_packbits(addrdec_mask[ROW], rest_of_addr, addrdec_mkhigh[ROW], addrdec_mklow[ROW]);
+      tlx->col  = addrdec_packbits(addrdec_mask[COL], rest_of_addr, addrdec_mkhigh[COL], addrdec_mklow[COL]);
+      tlx->burst= addrdec_packbits(addrdec_mask[BURST], rest_of_addr, addrdec_mkhigh[BURST], addrdec_mklow[BURST]);
+   }
 
-  switch (memory_partition_indexing) {
-    case CONSECUTIVE:
-      // Do nothing
-      break;
-    case BITWISE_PERMUTATION: {
-      assert(!gap);
-      tlx->chip = (tlx->chip) ^ (tlx->row & (m_n_channel - 1));
-      assert(tlx->chip < m_n_channel);
-      break;
-    }
-    case IPOLY: {
-      /*
-          * Set Indexing function from "Pseudo-randomly interleaved memory."
-          * Rau, B. R et al.
-          * ISCA 1991
-          *
-          * equations are adopted from:
-          * "Sacat: streaming-aware conflict-avoiding thrashing-resistant gpgpu
-       * cache management scheme."
-          * Khairy et al.
-          * IEEE TPDS 2017.
-          */
-      if (m_n_channel == 32) {
-        std::bitset<64> a(tlx->row);
-        std::bitset<5> chip(tlx->chip);
-        chip[0] = a[13] ^ a[12] ^ a[11] ^ a[10] ^ a[9] ^ a[6] ^ a[5] ^ a[3] ^
-                  a[0] ^ chip[0];
-        chip[1] = a[14] ^ a[13] ^ a[12] ^ a[11] ^ a[10] ^ a[7] ^ a[6] ^ a[4] ^
-                  a[1] ^ chip[1];
-        chip[2] = a[14] ^ a[10] ^ a[9] ^ a[8] ^ a[7] ^ a[6] ^ a[3] ^ a[2] ^
-                  a[0] ^ chip[2];
-        chip[3] =
-            a[11] ^ a[10] ^ a[9] ^ a[8] ^ a[7] ^ a[4] ^ a[3] ^ a[1] ^ chip[3];
-        chip[4] =
-            a[12] ^ a[11] ^ a[10] ^ a[9] ^ a[8] ^ a[5] ^ a[4] ^ a[2] ^ chip[4];
-        tlx->chip = chip.to_ulong();
+    switch(memory_partition_indexing){
+		case CONSECUTIVE:
+			//Do nothing
+			break;
+		case BITWISE_PERMUTATION:
+		{
+			assert(!gap);
+			tlx->chip = (tlx->chip) ^ (tlx->row & (m_n_channel-1));
+			assert(tlx->chip < m_n_channel);
+			break;
+		}
+		case IPOLY:
+		{
+		    /*
+			* Set Indexing function from "Pseudo-randomly interleaved memory."
+			* Rau, B. R et al.
+			* ISCA 1991
+			*
+			* equations are adopted from:
+			* "Sacat: streaming-aware conflict-avoiding thrashing-resistant gpgpu cache management scheme."
+			* Khairy et al.
+			* IEEE TPDS 2017.
+			*/
+			if(m_n_channel == 32) {
+				std::bitset<64> a(tlx->row);
+				std::bitset<5> chip(tlx->chip);
+				chip[0] = a[13]^a[12]^a[11]^a[10]^a[9]^a[6]^a[5]^a[3]^a[0]^chip[0];
+				chip[1] = a[14]^a[13]^a[12]^a[11]^a[10]^a[7]^a[6]^a[4]^a[1]^chip[1];
+				chip[2] = a[14]^a[10]^a[9]^a[8]^a[7]^a[6]^a[3]^a[2]^a[0]^chip[2];
+				chip[3] = a[11]^a[10]^a[9]^a[8]^a[7]^a[4]^a[3]^a[1]^chip[3];
+				chip[4] = a[12]^a[11]^a[10]^a[9]^a[8]^a[5]^a[4]^a[2]^chip[4];
+				tlx->chip = chip.to_ulong();
+				
+			}
+			else{ /* Else incorrect number of channels for the hashing function */
+            assert("\nGPGPU-Sim memory_partition_indexing error: The number of channels should be "
+                    "32 for the hashing IPOLY index function.\n" && 0);
+			}
+			assert(tlx->chip < m_n_channel);
+			break;
+		}
+		case PAE:
+		{
+			//Page Address Entropy
+			//random selected bits from the page and bank bits
+			//similar to
+			//Liu, Yuxi, et al. "Get Out of the Valley: Power-Efficient Address Mapping for GPUs." ISCA 2018
+			std::bitset<64> a(tlx->row);
+			std::bitset<5> chip(tlx->chip);
+			std::bitset<4> b(tlx->bk);
+			chip[0] = a[13]^a[10]^a[9]^a[5]^a[0]^b[3]^b[0]^chip[0];
+			chip[1] = a[12]^a[11]^a[6]^a[1]^b[3]^b[2]^b[1]^chip[1];
+			chip[2] = a[14]^a[9]^a[8]^a[7]^a[2]^b[1]^chip[2];
+			chip[3] = a[11]^a[10]^a[8]^a[3]^b[2]^b[3]^chip[3];
+			chip[4] = a[12]^a[9]^a[8]^a[5]^a[4]^b[1]^b[0]^chip[4];
+			tlx->chip = chip.to_ulong();
+			assert(tlx->chip < m_n_channel);
+			break;
+		}
+		case RANDOM:
+		{
+			//This is an unrealistic hashing using software hashtable
+			//we generate a random set for each memory address and save the value in a big hashtable for future reuse
+			new_addr_type chip_address = (addr>>ADDR_CHIP_S);
+			tr1_hash_map<new_addr_type,unsigned>::const_iterator got = address_random_interleaving.find (chip_address);
+			  if ( got == address_random_interleaving.end() ) {
+				  unsigned new_chip_id = rand() % (m_n_channel*m_n_sub_partition_in_channel);
+				  address_random_interleaving[chip_address] = new_chip_id;
+				  tlx->chip = new_chip_id/m_n_sub_partition_in_channel;
+				  tlx->sub_partition = new_chip_id;
+			  }
+			  else {
+				  unsigned new_chip_id = got->second;
+				  tlx->chip = new_chip_id/m_n_sub_partition_in_channel;
+				  tlx->sub_partition = new_chip_id;
+			  }
 
-      } else { /* Else incorrect number of channels for the hashing function */
-        assert(
-            "\nGPGPU-Sim memory_partition_indexing error: The number of "
-            "channels should be "
-            "32 for the hashing IPOLY index function.\n" &&
-            0);
+			  assert(tlx->chip < m_n_channel);
+			  assert(tlx->sub_partition < m_n_channel * m_n_sub_partition_in_channel);
+			  return;
+			break;
+		}
+		case CUSTOM:
+			/* No custom set function implemented */
+			//Do you custom index here
+			break;
+		default:
+			 assert("\nUndefined set index function.\n" && 0);
+			 break;
+	}
+
+   // combine the chip address and the lower bits of DRAM bank address to form the subpartition ID
+   unsigned sub_partition_addr_mask = m_n_sub_partition_in_channel - 1;
+   tlx->sub_partition = tlx->chip * m_n_sub_partition_in_channel
+                        + (tlx->bk & sub_partition_addr_mask);
+}
+
+void linear_to_raw_address_translation::addrdec_parseoption(const char *option)
+{
+   unsigned int dramid_start = 0;
+   int dramid_parsed = sscanf(option, "dramid@%d", &dramid_start);
+   if (dramid_parsed == 1) {
+      ADDR_CHIP_S = dramid_start;
+   } else {
+      ADDR_CHIP_S = -1;
+   }
+   
+   const char *cmapping = strchr(option, ';');
+   if (cmapping == NULL) {
+      cmapping = option;
+   } else {
+      cmapping += 1;
+   }
+
+   addrdec_mask[CHIP] = 0x0;
+   addrdec_mask[BK]   = 0x0;
+   addrdec_mask[ROW]  = 0x0;
+   addrdec_mask[COL]  = 0x0;
+   addrdec_mask[BURST]= 0x0;
+   
+   int ofs = 63;
+   while ((*cmapping) != '\0') {
+      switch (*cmapping) {
+         case 'D': case 'd':  
+            assert(dramid_parsed != 1); addrdec_mask[CHIP]  |= (1ULL << ofs); ofs--; break;
+         case 'B': case 'b':   addrdec_mask[BK]    |= (1ULL << ofs); ofs--; break;
+         case 'R': case 'r':   addrdec_mask[ROW]   |= (1ULL << ofs); ofs--; break;
+         case 'C': case 'c':   addrdec_mask[COL]   |= (1ULL << ofs); ofs--; break;
+         case 'S': case 's':   addrdec_mask[BURST] |= (1ULL << ofs); addrdec_mask[COL]   |= (1ULL << ofs); ofs--; break;
+         // ignore bit
+         case '0': ofs--; break;
+         // ignore character
+         case '|':
+         case ' ':
+         case '.': break;
+         default:
+            fprintf(stderr, "ERROR: Invalid address mapping character '%c' in option '%s'\n", *cmapping, option);
       }
-      assert(tlx->chip < m_n_channel);
-      break;
-    }
-    case PAE: {
-      // Page Address Entropy
-      // random selected bits from the page and bank bits
-      // similar to
-      // Liu, Yuxi, et al. "Get Out of the Valley: Power-Efficient Address
-      // Mapping for GPUs." ISCA 2018
-      std::bitset<64> a(tlx->row);
-      std::bitset<5> chip(tlx->chip);
-      std::bitset<4> b(tlx->bk);
-      chip[0] = a[13] ^ a[10] ^ a[9] ^ a[5] ^ a[0] ^ b[3] ^ b[0] ^ chip[0];
-      chip[1] = a[12] ^ a[11] ^ a[6] ^ a[1] ^ b[3] ^ b[2] ^ b[1] ^ chip[1];
-      chip[2] = a[14] ^ a[9] ^ a[8] ^ a[7] ^ a[2] ^ b[1] ^ chip[2];
-      chip[3] = a[11] ^ a[10] ^ a[8] ^ a[3] ^ b[2] ^ b[3] ^ chip[3];
-      chip[4] = a[12] ^ a[9] ^ a[8] ^ a[5] ^ a[4] ^ b[1] ^ b[0] ^ chip[4];
-      tlx->chip = chip.to_ulong();
-      assert(tlx->chip < m_n_channel);
-      break;
-    }
-    case RANDOM: {
-      // This is an unrealistic hashing using software hashtable
-      // we generate a random set for each memory address and save the value in
-      // a big hashtable for future reuse
-      new_addr_type chip_address = (addr >> ADDR_CHIP_S);
-      tr1_hash_map<new_addr_type, unsigned>::const_iterator got =
-          address_random_interleaving.find(chip_address);
-      if (got == address_random_interleaving.end()) {
-        unsigned new_chip_id =
-            rand() % (m_n_channel * m_n_sub_partition_in_channel);
-        address_random_interleaving[chip_address] = new_chip_id;
-        tlx->chip = new_chip_id / m_n_sub_partition_in_channel;
-        tlx->sub_partition = new_chip_id;
-      } else {
-        unsigned new_chip_id = got->second;
-        tlx->chip = new_chip_id / m_n_sub_partition_in_channel;
-        tlx->sub_partition = new_chip_id;
-      }
+      cmapping += 1;
+   }
 
-      assert(tlx->chip < m_n_channel);
-      assert(tlx->sub_partition < m_n_channel * m_n_sub_partition_in_channel);
-      return;
-      break;
-    }
-    case CUSTOM:
-      /* No custom set function implemented */
-      // Do you custom index here
-      break;
-    default:
-      assert("\nUndefined set index function.\n" && 0);
-      break;
-  }
-
-  // combine the chip address and the lower bits of DRAM bank address to form
-  // the subpartition ID
-  unsigned sub_partition_addr_mask = m_n_sub_partition_in_channel - 1;
-  tlx->sub_partition = tlx->chip * m_n_sub_partition_in_channel +
-                       (tlx->bk & sub_partition_addr_mask);
+   if (ofs != -1) {
+      fprintf(stderr, "ERROR: Invalid address mapping length (%d) in option '%s'\n", 63 - ofs, option);
+      assert(ofs == -1);
+   }
 }
 
-void linear_to_raw_address_translation::addrdec_parseoption(
-    const char *option) {
-  unsigned int dramid_start = 0;
-  int dramid_parsed = sscanf(option, "dramid@%d", &dramid_start);
-  if (dramid_parsed == 1) {
-    ADDR_CHIP_S = dramid_start;
-  } else {
-    ADDR_CHIP_S = -1;
-  }
+void linear_to_raw_address_translation::init(unsigned int n_channel, unsigned int n_sub_partition_in_channel) 
+{
+   unsigned i;
+   unsigned long long int mask;
+   unsigned int nchipbits = ::LOGB2_32(n_channel);
+   m_n_channel = n_channel;
+   m_n_sub_partition_in_channel = n_sub_partition_in_channel; 
 
-  const char *cmapping = strchr(option, ';');
-  if (cmapping == NULL) {
-    cmapping = option;
-  } else {
-    cmapping += 1;
-  }
-
-  addrdec_mask[CHIP] = 0x0;
-  addrdec_mask[BK] = 0x0;
-  addrdec_mask[ROW] = 0x0;
-  addrdec_mask[COL] = 0x0;
-  addrdec_mask[BURST] = 0x0;
-
-  int ofs = 63;
-  while ((*cmapping) != '\0') {
-    switch (*cmapping) {
-      case 'D':
-      case 'd':
-        assert(dramid_parsed != 1);
-        addrdec_mask[CHIP] |= (1ULL << ofs);
-        ofs--;
-        break;
-      case 'B':
-      case 'b':
-        addrdec_mask[BK] |= (1ULL << ofs);
-        ofs--;
-        break;
-      case 'R':
-      case 'r':
-        addrdec_mask[ROW] |= (1ULL << ofs);
-        ofs--;
-        break;
-      case 'C':
-      case 'c':
-        addrdec_mask[COL] |= (1ULL << ofs);
-        ofs--;
-        break;
-      case 'S':
-      case 's':
-        addrdec_mask[BURST] |= (1ULL << ofs);
-        addrdec_mask[COL] |= (1ULL << ofs);
-        ofs--;
-        break;
-      // ignore bit
-      case '0':
-        ofs--;
-        break;
-      // ignore character
-      case '|':
-      case ' ':
-      case '.':
-        break;
-      default:
-        fprintf(
-            stderr,
-            "ERROR: Invalid address mapping character '%c' in option '%s'\n",
-            *cmapping, option);
-    }
-    cmapping += 1;
-  }
-
-  if (ofs != -1) {
-    fprintf(stderr,
-            "ERROR: Invalid address mapping length (%d) in option '%s'\n",
-            63 - ofs, option);
-    assert(ofs == -1);
-  }
-}
-
-void linear_to_raw_address_translation::init(
-    unsigned int n_channel, unsigned int n_sub_partition_in_channel) {
-  unsigned i;
-  unsigned long long int mask;
-  unsigned int nchipbits = ::LOGB2_32(n_channel);
-  m_n_channel = n_channel;
-  m_n_sub_partition_in_channel = n_sub_partition_in_channel;
-
-  gap = (n_channel - ::powli(2, nchipbits));
-  if (gap) {
-    nchipbits++;
-  }
-  switch (gpgpu_mem_address_mask) {
-    case 0:
-      // old, added 2row bits, use #define ADDR_CHIP_S 10
+   gap = (n_channel - ::powli(2,nchipbits));
+   if (gap) {
+      nchipbits++;
+   }
+   switch (gpgpu_mem_address_mask) {
+   case 0: 
+      //old, added 2row bits, use #define ADDR_CHIP_S 10
       ADDR_CHIP_S = 10;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK] = 0x0000000000000300;
-      addrdec_mask[ROW] = 0x0000000007FFE000;
-      addrdec_mask[COL] = 0x0000000000001CFF;
+      addrdec_mask[BK]   = 0x0000000000000300;
+      addrdec_mask[ROW]  = 0x0000000007FFE000;
+      addrdec_mask[COL]  = 0x0000000000001CFF;
       break;
-    case 1:
+   case 1:
       ADDR_CHIP_S = 13;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK] = 0x0000000000001800;
-      addrdec_mask[ROW] = 0x0000000007FFE000;
-      addrdec_mask[COL] = 0x00000000000007FF;
+      addrdec_mask[BK]   = 0x0000000000001800;
+      addrdec_mask[ROW]  = 0x0000000007FFE000;
+      addrdec_mask[COL]  = 0x00000000000007FF;
       break;
-    case 2:
+   case 2:
       ADDR_CHIP_S = 11;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK] = 0x0000000000001800;
-      addrdec_mask[ROW] = 0x0000000007FFE000;
-      addrdec_mask[COL] = 0x00000000000007FF;
+      addrdec_mask[BK]   = 0x0000000000001800;
+      addrdec_mask[ROW]  = 0x0000000007FFE000;
+      addrdec_mask[COL]  = 0x00000000000007FF;
       break;
-    case 3:
+   case 3:
       ADDR_CHIP_S = 11;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK] = 0x0000000000001800;
-      addrdec_mask[ROW] = 0x000000000FFFE000;
-      addrdec_mask[COL] = 0x00000000000007FF;
+      addrdec_mask[BK]   = 0x0000000000001800;
+      addrdec_mask[ROW]  = 0x000000000FFFE000;
+      addrdec_mask[COL]  = 0x00000000000007FF;
       break;
 
-    case 14:
+   case 14:
       ADDR_CHIP_S = 14;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK] = 0x0000000000001800;
-      addrdec_mask[ROW] = 0x0000000007FFE000;
-      addrdec_mask[COL] = 0x00000000000007FF;
+      addrdec_mask[BK]   = 0x0000000000001800;
+      addrdec_mask[ROW]  = 0x0000000007FFE000;
+      addrdec_mask[COL]  = 0x00000000000007FF;
       break;
-    case 15:
+   case 15:
       ADDR_CHIP_S = 15;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK] = 0x0000000000001800;
-      addrdec_mask[ROW] = 0x0000000007FFE000;
-      addrdec_mask[COL] = 0x00000000000007FF;
+      addrdec_mask[BK]   = 0x0000000000001800;
+      addrdec_mask[ROW]  = 0x0000000007FFE000;
+      addrdec_mask[COL]  = 0x00000000000007FF;
       break;
-    case 16:
+   case 16:
       ADDR_CHIP_S = 16;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK] = 0x0000000000001800;
-      addrdec_mask[ROW] = 0x0000000007FFE000;
-      addrdec_mask[COL] = 0x00000000000007FF;
+      addrdec_mask[BK]   = 0x0000000000001800;
+      addrdec_mask[ROW]  = 0x0000000007FFE000;
+      addrdec_mask[COL]  = 0x00000000000007FF;
       break;
-    case 6:
+   case 6:
       ADDR_CHIP_S = 6;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK] = 0x0000000000001800;
-      addrdec_mask[ROW] = 0x0000000007FFE000;
-      addrdec_mask[COL] = 0x00000000000007FF;
+      addrdec_mask[BK]   = 0x0000000000001800;
+      addrdec_mask[ROW]  = 0x0000000007FFE000;
+      addrdec_mask[COL]  = 0x00000000000007FF;
       break;
-    case 5:
+   case 5:
       ADDR_CHIP_S = 5;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK] = 0x0000000000001800;
-      addrdec_mask[ROW] = 0x0000000007FFE000;
-      addrdec_mask[COL] = 0x00000000000007FF;
-      break;
-    case 100:
+      addrdec_mask[BK]   = 0x0000000000001800;
+      addrdec_mask[ROW]  = 0x0000000007FFE000;
+      addrdec_mask[COL]  = 0x00000000000007FF;
+      break;                         
+   case 100:
       ADDR_CHIP_S = 1;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK] = 0x0000000000000003;
-      addrdec_mask[ROW] = 0x0000000007FFE000;
-      addrdec_mask[COL] = 0x0000000000001FFC;
+      addrdec_mask[BK]   = 0x0000000000000003;
+      addrdec_mask[ROW]  = 0x0000000007FFE000;
+      addrdec_mask[COL]  = 0x0000000000001FFC;
       break;
-    case 103:
+   case 103:
       ADDR_CHIP_S = 3;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK] = 0x0000000000000003;
-      addrdec_mask[ROW] = 0x0000000007FFE000;
-      addrdec_mask[COL] = 0x0000000000001FFC;
+      addrdec_mask[BK]   = 0x0000000000000003;
+      addrdec_mask[ROW]  = 0x0000000007FFE000;
+      addrdec_mask[COL]  = 0x0000000000001FFC;
       break;
-    case 106:
+   case 106:
       ADDR_CHIP_S = 6;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK] = 0x0000000000001800;
-      addrdec_mask[ROW] = 0x0000000007FFE000;
-      addrdec_mask[COL] = 0x00000000000007FF;
+      addrdec_mask[BK]   = 0x0000000000001800;
+      addrdec_mask[ROW]  = 0x0000000007FFE000;
+      addrdec_mask[COL]  = 0x00000000000007FF;
       break;
-    case 160:
-      // old, added 2row bits, use #define ADDR_CHIP_S 10
+   case 160: 
+      //old, added 2row bits, use #define ADDR_CHIP_S 10
       ADDR_CHIP_S = 6;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK] = 0x0000000000000300;
-      addrdec_mask[ROW] = 0x0000000007FFE000;
-      addrdec_mask[COL] = 0x0000000000001CFF;
+      addrdec_mask[BK]   = 0x0000000000000300;
+      addrdec_mask[ROW]  = 0x0000000007FFE000;
+      addrdec_mask[COL]  = 0x0000000000001CFF;
 
-    default:
+   default:
       break;
-  }
+   }
 
-  if (addrdec_option != NULL) addrdec_parseoption(addrdec_option);
+   if (addrdec_option != NULL) 
+      addrdec_parseoption(addrdec_option);
 
-  if (ADDR_CHIP_S != -1) {
-    if (!gap) {
-      // number of chip is power of two:
-      // - insert CHIP mask starting at the bit position ADDR_CHIP_S
-      mask = ((unsigned long long int)1 << ADDR_CHIP_S) - 1;
-      addrdec_mask[BK] =
-          ((addrdec_mask[BK] & ~mask) << nchipbits) | (addrdec_mask[BK] & mask);
-      addrdec_mask[ROW] = ((addrdec_mask[ROW] & ~mask) << nchipbits) |
-                          (addrdec_mask[ROW] & mask);
-      addrdec_mask[COL] = ((addrdec_mask[COL] & ~mask) << nchipbits) |
-                          (addrdec_mask[COL] & mask);
+   if (ADDR_CHIP_S != -1) { 
+      if (!gap) {
+         // number of chip is power of two: 
+         // - insert CHIP mask starting at the bit position ADDR_CHIP_S
+         mask = ((unsigned long long int)1 << ADDR_CHIP_S) - 1;
+         addrdec_mask[BK]   = ((addrdec_mask[BK] & ~mask) << nchipbits) | (addrdec_mask[BK] & mask);
+         addrdec_mask[ROW]  = ((addrdec_mask[ROW] & ~mask) << nchipbits) | (addrdec_mask[ROW] & mask);
+         addrdec_mask[COL]  = ((addrdec_mask[COL] & ~mask) << nchipbits) | (addrdec_mask[COL] & mask);
 
-      for (i = ADDR_CHIP_S; i < (ADDR_CHIP_S + nchipbits); i++) {
-        mask = (unsigned long long int)1 << i;
-        addrdec_mask[CHIP] |= mask;
+         for (i=ADDR_CHIP_S;i<(ADDR_CHIP_S+nchipbits);i++) {
+            mask = (unsigned long long int)1 << i;
+            addrdec_mask[CHIP] |= mask;
+         }
+      } // otherwise, no need to change the masks
+   } else {
+      // make sure n_channel is power of two when explicit dram id mask is used
+      assert((n_channel & (n_channel - 1)) == 0); 
+   }
+   // make sure m_n_sub_partition_in_channel is power of two 
+   assert((m_n_sub_partition_in_channel & (m_n_sub_partition_in_channel - 1)) == 0); 
+
+   addrdec_getmasklimit(addrdec_mask[CHIP],  &addrdec_mkhigh[CHIP],  &addrdec_mklow[CHIP] );
+   addrdec_getmasklimit(addrdec_mask[BK],    &addrdec_mkhigh[BK],    &addrdec_mklow[BK]   );
+   addrdec_getmasklimit(addrdec_mask[ROW],   &addrdec_mkhigh[ROW],   &addrdec_mklow[ROW]  );
+   addrdec_getmasklimit(addrdec_mask[COL],   &addrdec_mkhigh[COL],   &addrdec_mklow[COL]  );
+   addrdec_getmasklimit(addrdec_mask[BURST], &addrdec_mkhigh[BURST], &addrdec_mklow[BURST]);
+
+   printf("addr_dec_mask[CHIP]  = %016llx \thigh:%d low:%d\n", addrdec_mask[CHIP],  addrdec_mkhigh[CHIP],  addrdec_mklow[CHIP] );
+   printf("addr_dec_mask[BK]    = %016llx \thigh:%d low:%d\n", addrdec_mask[BK],    addrdec_mkhigh[BK],    addrdec_mklow[BK]   );
+   printf("addr_dec_mask[ROW]   = %016llx \thigh:%d low:%d\n", addrdec_mask[ROW],   addrdec_mkhigh[ROW],   addrdec_mklow[ROW]  );
+   printf("addr_dec_mask[COL]   = %016llx \thigh:%d low:%d\n", addrdec_mask[COL],   addrdec_mkhigh[COL],   addrdec_mklow[COL]  );
+   printf("addr_dec_mask[BURST] = %016llx \thigh:%d low:%d\n", addrdec_mask[BURST], addrdec_mkhigh[BURST], addrdec_mklow[BURST]);
+
+   // create the sub partition ID mask (for removing the sub partition ID from the partition address)
+   sub_partition_id_mask = 0; 
+   if (m_n_sub_partition_in_channel > 1) {
+      unsigned n_sub_partition_log2 = LOGB2_32(m_n_sub_partition_in_channel); 
+      unsigned pos=0;
+      for (unsigned i=addrdec_mklow[BK];i<addrdec_mkhigh[BK];i++) {
+         if ((addrdec_mask[BK] & ((unsigned long long int)1<<i)) != 0) {
+            sub_partition_id_mask |= ((unsigned long long int)1<<i);
+            pos++;
+            if (pos >= n_sub_partition_log2) 
+               break; 
+         }
       }
-    }  // otherwise, no need to change the masks
-  } else {
-    // make sure n_channel is power of two when explicit dram id mask is used
-    assert((n_channel & (n_channel - 1)) == 0);
-  }
-  // make sure m_n_sub_partition_in_channel is power of two
-  assert((m_n_sub_partition_in_channel & (m_n_sub_partition_in_channel - 1)) ==
-         0);
+   }
+   printf("sub_partition_id_mask = %016llx\n", sub_partition_id_mask);
 
-  addrdec_getmasklimit(addrdec_mask[CHIP], &addrdec_mkhigh[CHIP],
-                       &addrdec_mklow[CHIP]);
-  addrdec_getmasklimit(addrdec_mask[BK], &addrdec_mkhigh[BK],
-                       &addrdec_mklow[BK]);
-  addrdec_getmasklimit(addrdec_mask[ROW], &addrdec_mkhigh[ROW],
-                       &addrdec_mklow[ROW]);
-  addrdec_getmasklimit(addrdec_mask[COL], &addrdec_mkhigh[COL],
-                       &addrdec_mklow[COL]);
-  addrdec_getmasklimit(addrdec_mask[BURST], &addrdec_mkhigh[BURST],
-                       &addrdec_mklow[BURST]);
+   if (run_test) {
+      sweep_test(); 
+   }
 
-  printf("addr_dec_mask[CHIP]  = %016llx \thigh:%d low:%d\n",
-         addrdec_mask[CHIP], addrdec_mkhigh[CHIP], addrdec_mklow[CHIP]);
-  printf("addr_dec_mask[BK]    = %016llx \thigh:%d low:%d\n", addrdec_mask[BK],
-         addrdec_mkhigh[BK], addrdec_mklow[BK]);
-  printf("addr_dec_mask[ROW]   = %016llx \thigh:%d low:%d\n", addrdec_mask[ROW],
-         addrdec_mkhigh[ROW], addrdec_mklow[ROW]);
-  printf("addr_dec_mask[COL]   = %016llx \thigh:%d low:%d\n", addrdec_mask[COL],
-         addrdec_mkhigh[COL], addrdec_mklow[COL]);
-  printf("addr_dec_mask[BURST] = %016llx \thigh:%d low:%d\n",
-         addrdec_mask[BURST], addrdec_mkhigh[BURST], addrdec_mklow[BURST]);
+   if(memory_partition_indexing == RANDOM)
+     srand (1);
 
-  // create the sub partition ID mask (for removing the sub partition ID from
-  // the partition address)
-  sub_partition_id_mask = 0;
-  if (m_n_sub_partition_in_channel > 1) {
-    unsigned n_sub_partition_log2 = LOGB2_32(m_n_sub_partition_in_channel);
-    unsigned pos = 0;
-    for (unsigned i = addrdec_mklow[BK]; i < addrdec_mkhigh[BK]; i++) {
-      if ((addrdec_mask[BK] & ((unsigned long long int)1 << i)) != 0) {
-        sub_partition_id_mask |= ((unsigned long long int)1 << i);
-        pos++;
-        if (pos >= n_sub_partition_log2) break;
-      }
-    }
-  }
-  printf("sub_partition_id_mask = %016llx\n", sub_partition_id_mask);
-
-  if (run_test) {
-    sweep_test();
-  }
-
-  if (memory_partition_indexing == RANDOM) srand(1);
 }
 
-#include "../tr1_hash_map.h"
+#include "../tr1_hash_map.h" 
 
-bool operator==(const addrdec_t &x, const addrdec_t &y) {
-  return (memcmp(&x, &y, sizeof(addrdec_t)) == 0);
+bool operator==(const addrdec_t &x, const addrdec_t &y) 
+{
+   return ( memcmp(&x, &y, sizeof(addrdec_t)) == 0 ); 
 }
 
-bool operator<(const addrdec_t &x, const addrdec_t &y) {
-  if (x.chip >= y.chip)
-    return false;
-  else if (x.bk >= y.bk)
-    return false;
-  else if (x.row >= y.row)
-    return false;
-  else if (x.col >= y.col)
-    return false;
-  else if (x.burst >= y.burst)
-    return false;
-  else
-    return true;
+bool operator<(const addrdec_t &x, const addrdec_t &y) 
+{
+   if (x.chip >= y.chip) return false; 
+   else if (x.bk >= y.bk) return false;
+   else if (x.row >= y.row) return false;
+   else if (x.col >= y.col) return false;
+   else if (x.burst >= y.burst) return false;
+   else return true; 
 }
 
-class hash_addrdec_t {
- public:
-  size_t operator()(const addrdec_t &x) const {
-    return (x.chip ^ x.bk ^ x.row ^ x.col ^ x.burst);
-  }
+class hash_addrdec_t
+{
+public: 
+   size_t operator()(const addrdec_t &x) const {
+      return (x.chip ^ x.bk ^ x.row ^ x.col ^ x.burst); 
+   }
 };
 
-// a simple sweep test to ensure that two linear addresses are not mapped to the
-// same raw address
-void linear_to_raw_address_translation::sweep_test() const {
-  new_addr_type sweep_range = 16 * 1024 * 1024;
+// a simple sweep test to ensure that two linear addresses are not mapped to the same raw address 
+void linear_to_raw_address_translation::sweep_test() const
+{
+   new_addr_type sweep_range = 16 * 1024 * 1024; 
 
 #if tr1_hash_map_ismap == 1
-  typedef tr1_hash_map<addrdec_t, new_addr_type> history_map_t;
+   typedef tr1_hash_map<addrdec_t, new_addr_type> history_map_t; 
 #else
-  typedef tr1_hash_map<addrdec_t, new_addr_type, hash_addrdec_t> history_map_t;
+   typedef tr1_hash_map<addrdec_t, new_addr_type, hash_addrdec_t> history_map_t; 
 #endif
-  history_map_t history_map;
+   history_map_t history_map; 
 
-  for (new_addr_type raw_addr = 4; raw_addr < sweep_range; raw_addr += 4) {
-    addrdec_t tlx;
-    addrdec_tlx(raw_addr, &tlx);
+   for (new_addr_type raw_addr = 4; raw_addr < sweep_range; raw_addr += 4) {
+      addrdec_t tlx; 
+      addrdec_tlx(raw_addr, &tlx); 
 
-    history_map_t::iterator h = history_map.find(tlx);
+      history_map_t::iterator h = history_map.find(tlx); 
 
-    if (h != history_map.end()) {
-      printf(
-          "[AddrDec] ** Error: address decoding mapping aliases two addresses "
-          "to same partition with same intra-partition address: %llx %llx\n",
-          h->second, raw_addr);
-      abort();
-    } else {
-      assert((int)tlx.chip < m_n_channel);
-      // ensure that partition_address() returns the concatenated address
-      if ((ADDR_CHIP_S != -1 and raw_addr >= (1ULL << ADDR_CHIP_S)) or
-          (ADDR_CHIP_S == -1 and raw_addr >= (1ULL << addrdec_mklow[CHIP]))) {
-        assert(raw_addr != partition_address(raw_addr));
-      }
-      history_map[tlx] = raw_addr;
-    }
-
-    if ((raw_addr & 0xffff) == 0) printf("%llu scaned\n", raw_addr);
-  }
-}
-
-void addrdec_t::print(FILE *fp) const {
-  fprintf(fp, "\tchip:%x ", chip);
-  fprintf(fp, "\trow:%x ", row);
-  fprintf(fp, "\tcol:%x ", col);
-  fprintf(fp, "\tbk:%x ", bk);
-  fprintf(fp, "\tburst:%x ", burst);
-  fprintf(fp, "\tsub_partition:%x ", sub_partition);
-}
-
-static long int powli(long int x, long int y)  // compute x to the y
-{
-  long int r = 1;
-  int i;
-  for (i = 0; i < y; ++i) {
-    r *= x;
-  }
-  return r;
-}
-
-static unsigned int LOGB2_32(unsigned int v) {
-  unsigned int shift;
-  unsigned int r;
-
-  r = 0;
-
-  shift = ((v & 0xFFFF0000) != 0) << 4;
-  v >>= shift;
-  r |= shift;
-  shift = ((v & 0xFF00) != 0) << 3;
-  v >>= shift;
-  r |= shift;
-  shift = ((v & 0xF0) != 0) << 2;
-  v >>= shift;
-  r |= shift;
-  shift = ((v & 0xC) != 0) << 1;
-  v >>= shift;
-  r |= shift;
-  shift = ((v & 0x2) != 0) << 0;
-  v >>= shift;
-  r |= shift;
-
-  return r;
-}
-
-static new_addr_type addrdec_packbits(new_addr_type mask, new_addr_type val,
-                                      unsigned char high, unsigned char low) {
-  unsigned pos = 0;
-  new_addr_type result = 0;
-  for (unsigned i = low; i < high; i++) {
-    if ((mask & ((unsigned long long int)1 << i)) != 0) {
-      result |= ((val & ((unsigned long long int)1 << i)) >> i) << pos;
-      pos++;
-    }
-  }
-  return result;
-}
-
-static void addrdec_getmasklimit(new_addr_type mask, unsigned char *high,
-                                 unsigned char *low) {
-  *high = 64;
-  *low = 0;
-  int i;
-  int low_found = 0;
-
-  for (i = 0; i < 64; i++) {
-    if ((mask & ((unsigned long long int)1 << i)) != 0) {
-      if (low_found) {
-        *high = i + 1;
+      if (h != history_map.end()) {
+         printf("[AddrDec] ** Error: address decoding mapping aliases two addresses to same partition with same intra-partition address: %llx %llx\n", h->second, raw_addr); 
+         abort(); 
       } else {
-        *high = i + 1;
-        *low = i;
-        low_found = 1;
+         assert((int)tlx.chip < m_n_channel); 
+         // ensure that partition_address() returns the concatenated address 
+         if ((ADDR_CHIP_S != -1 and raw_addr >= (1ULL << ADDR_CHIP_S)) or 
+             (ADDR_CHIP_S == -1 and raw_addr >= (1ULL << addrdec_mklow[CHIP]))) {
+            assert(raw_addr != partition_address(raw_addr)); 
+         }
+         history_map[tlx] = raw_addr; 
       }
-    }
-  }
+
+      if ((raw_addr & 0xffff) == 0) printf("%llu scaned\n", raw_addr); 
+   }
+}
+
+void addrdec_t::print( FILE *fp ) const
+{
+   fprintf(fp,"\tchip:%x ", chip);
+   fprintf(fp,"\trow:%x ", row);
+   fprintf(fp,"\tcol:%x ", col);
+   fprintf(fp,"\tbk:%x ", bk);
+   fprintf(fp,"\tburst:%x ", burst);
+   fprintf(fp,"\tsub_partition:%x ", sub_partition);
+} 
+
+
+static long int powli( long int x, long int y ) // compute x to the y
+{
+   long int r = 1;
+   int i; 
+   for (i = 0; i < y; ++i ) {
+      r *= x;
+   }
+   return r;
+}
+
+static unsigned int LOGB2_32( unsigned int v ) 
+{
+   unsigned int shift;
+   unsigned int r;
+
+   r = 0;
+
+   shift = (( v & 0xFFFF0000) != 0 ) << 4; v >>= shift; r |= shift;
+   shift = (( v & 0xFF00    ) != 0 ) << 3; v >>= shift; r |= shift;
+   shift = (( v & 0xF0      ) != 0 ) << 2; v >>= shift; r |= shift;
+   shift = (( v & 0xC       ) != 0 ) << 1; v >>= shift; r |= shift;
+   shift = (( v & 0x2       ) != 0 ) << 0; v >>= shift; r |= shift;
+
+   return r;
+}
+
+static new_addr_type addrdec_packbits( new_addr_type mask, new_addr_type val, unsigned char high, unsigned char low) 
+{
+   unsigned pos=0;
+   new_addr_type result = 0;
+   for (unsigned i=low;i<high;i++) {
+      if ((mask & ((unsigned long long int)1<<i)) != 0) {
+         result |= ((val & ((unsigned long long int)1<<i)) >> i) << pos;
+         pos++;
+      }
+   }
+   return result;
+}
+
+static void addrdec_getmasklimit(new_addr_type mask, unsigned char *high, unsigned char *low) 
+{
+   *high = 64;
+   *low = 0;
+   int i;
+   int low_found = 0;
+
+   for (i=0;i<64;i++) {
+      if ((mask & ((unsigned long long int)1<<i)) != 0) {
+         if (low_found) {
+            *high = i + 1;
+         } else {
+            *high = i + 1;
+            *low = i;
+            low_found = 1;
+         }
+      }
+   }
 }

--- a/src/gpgpu-sim/addrdec.cc
+++ b/src/gpgpu-sim/addrdec.cc
@@ -7,550 +7,624 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
-
-#include <string.h>
 #include "addrdec.h"
-#include "gpu-sim.h"
+#include <string.h>
 #include "../option_parser.h"
+#include "gpu-sim.h"
 
+static long int powli(long int x, long int y);
+static unsigned int LOGB2_32(unsigned int v);
+static new_addr_type addrdec_packbits(new_addr_type mask, new_addr_type val,
+                                      unsigned char high, unsigned char low);
+static void addrdec_getmasklimit(new_addr_type mask, unsigned char *high,
+                                 unsigned char *low);
 
-
-static long int powli( long int x, long int y );
-static unsigned int LOGB2_32( unsigned int v );
-static new_addr_type addrdec_packbits( new_addr_type mask, new_addr_type val, unsigned char high, unsigned char low);
-static void addrdec_getmasklimit(new_addr_type mask, unsigned char *high, unsigned char *low); 
-
-linear_to_raw_address_translation::linear_to_raw_address_translation()
-{
-   addrdec_option = NULL;
-   ADDR_CHIP_S = 10;
-   memset(addrdec_mklow,0,N_ADDRDEC);
-   memset(addrdec_mkhigh,64,N_ADDRDEC);
-   addrdec_mask[0] = 0x0000000000001C00;
-   addrdec_mask[1] = 0x0000000000000300;
-   addrdec_mask[2] = 0x000000000FFF0000;
-   addrdec_mask[3] = 0x000000000000E0FF;
-   addrdec_mask[4] = 0x000000000000000F;
+linear_to_raw_address_translation::linear_to_raw_address_translation() {
+  addrdec_option = NULL;
+  ADDR_CHIP_S = 10;
+  memset(addrdec_mklow, 0, N_ADDRDEC);
+  memset(addrdec_mkhigh, 64, N_ADDRDEC);
+  addrdec_mask[0] = 0x0000000000001C00;
+  addrdec_mask[1] = 0x0000000000000300;
+  addrdec_mask[2] = 0x000000000FFF0000;
+  addrdec_mask[3] = 0x000000000000E0FF;
+  addrdec_mask[4] = 0x000000000000000F;
 }
 
-void linear_to_raw_address_translation::addrdec_setoption(option_parser_t opp)
-{
-   option_parser_register(opp, "-gpgpu_mem_addr_mapping", OPT_CSTR, &addrdec_option,
-      "mapping memory address to dram model {dramid@<start bit>;<memory address map>}",
-      NULL);
-   option_parser_register(opp, "-gpgpu_mem_addr_test", OPT_BOOL, &run_test,
-      "run sweep test to check address mapping for aliased address",
+void linear_to_raw_address_translation::addrdec_setoption(option_parser_t opp) {
+  option_parser_register(opp, "-gpgpu_mem_addr_mapping", OPT_CSTR,
+                         &addrdec_option,
+                         "mapping memory address to dram model {dramid@<start "
+                         "bit>;<memory address map>}",
+                         NULL);
+  option_parser_register(
+      opp, "-gpgpu_mem_addr_test", OPT_BOOL, &run_test,
+      "run sweep test to check address mapping for aliased address", "0");
+  option_parser_register(opp, "-gpgpu_mem_address_mask", OPT_INT32,
+                         &gpgpu_mem_address_mask,
+                         "0 = old addressing mask, 1 = new addressing mask, 2 "
+                         "= new add. mask + flipped bank sel and chip sel bits",
+                         "0");
+  option_parser_register(
+      opp, "-memory_partition_indexing", OPT_UINT32, &memory_partition_indexing,
+      "0 = no indexing, 1 = bitwise xoring, 2 = IPoly, 3 = custom indexing",
       "0");
-   option_parser_register(opp, "-gpgpu_mem_address_mask", OPT_INT32, &gpgpu_mem_address_mask, 
-               "0 = old addressing mask, 1 = new addressing mask, 2 = new add. mask + flipped bank sel and chip sel bits",
-               "0");
-   option_parser_register(opp, "-memory_partition_indexing", OPT_UINT32, &memory_partition_indexing,
-                  "0 = no indexing, 1 = bitwise xoring, 2 = IPoly, 3 = custom indexing",
-                  "0");
 }
 
-new_addr_type linear_to_raw_address_translation::partition_address( new_addr_type addr ) const 
-{ 
-   if (!gap) {
-      return addrdec_packbits( ~(addrdec_mask[CHIP] | sub_partition_id_mask), addr, 64, 0 ); 
-   } else {
-      // see addrdec_tlx for explanation 
-      unsigned long long int partition_addr; 
-      partition_addr = ( (addr>>ADDR_CHIP_S) / m_n_channel) << ADDR_CHIP_S; 
-      partition_addr |= addr & ((1 << ADDR_CHIP_S) - 1); 
-      // remove the part of address that constributes to the sub partition ID
-      partition_addr = addrdec_packbits( ~sub_partition_id_mask, partition_addr, 64, 0); 
-      return partition_addr; 
-   }
+new_addr_type linear_to_raw_address_translation::partition_address(
+    new_addr_type addr) const {
+  if (!gap) {
+    return addrdec_packbits(~(addrdec_mask[CHIP] | sub_partition_id_mask), addr,
+                            64, 0);
+  } else {
+    // see addrdec_tlx for explanation
+    unsigned long long int partition_addr;
+    partition_addr = ((addr >> ADDR_CHIP_S) / m_n_channel) << ADDR_CHIP_S;
+    partition_addr |= addr & ((1 << ADDR_CHIP_S) - 1);
+    // remove the part of address that constributes to the sub partition ID
+    partition_addr =
+        addrdec_packbits(~sub_partition_id_mask, partition_addr, 64, 0);
+    return partition_addr;
+  }
 }
 
-void linear_to_raw_address_translation::addrdec_tlx(new_addr_type addr, addrdec_t *tlx) const
-{  
-   unsigned long long int addr_for_chip,rest_of_addr;
-   if (!gap) {
-      tlx->chip = addrdec_packbits(addrdec_mask[CHIP], addr, addrdec_mkhigh[CHIP], addrdec_mklow[CHIP]);
-      tlx->bk   = addrdec_packbits(addrdec_mask[BK], addr, addrdec_mkhigh[BK], addrdec_mklow[BK]);
-      tlx->row  = addrdec_packbits(addrdec_mask[ROW], addr, addrdec_mkhigh[ROW], addrdec_mklow[ROW]);
-      tlx->col  = addrdec_packbits(addrdec_mask[COL], addr, addrdec_mkhigh[COL], addrdec_mklow[COL]);
-      tlx->burst= addrdec_packbits(addrdec_mask[BURST], addr, addrdec_mkhigh[BURST], addrdec_mklow[BURST]);
-   } else {
-      // Split the given address at ADDR_CHIP_S into (MSBs,LSBs)
-      // - extract chip address using modulus of MSBs
-      // - recreate the rest of the address by stitching the quotient of MSBs and the LSBs 
-      addr_for_chip = (addr>>ADDR_CHIP_S) % m_n_channel; 
-      rest_of_addr = ( (addr>>ADDR_CHIP_S) / m_n_channel) << ADDR_CHIP_S; 
-      rest_of_addr |= addr & ((1 << ADDR_CHIP_S) - 1); 
+void linear_to_raw_address_translation::addrdec_tlx(new_addr_type addr,
+                                                    addrdec_t *tlx) const {
+  unsigned long long int addr_for_chip, rest_of_addr;
+  if (!gap) {
+    tlx->chip = addrdec_packbits(addrdec_mask[CHIP], addr, addrdec_mkhigh[CHIP],
+                                 addrdec_mklow[CHIP]);
+    tlx->bk = addrdec_packbits(addrdec_mask[BK], addr, addrdec_mkhigh[BK],
+                               addrdec_mklow[BK]);
+    tlx->row = addrdec_packbits(addrdec_mask[ROW], addr, addrdec_mkhigh[ROW],
+                                addrdec_mklow[ROW]);
+    tlx->col = addrdec_packbits(addrdec_mask[COL], addr, addrdec_mkhigh[COL],
+                                addrdec_mklow[COL]);
+    tlx->burst = addrdec_packbits(addrdec_mask[BURST], addr,
+                                  addrdec_mkhigh[BURST], addrdec_mklow[BURST]);
+  } else {
+    // Split the given address at ADDR_CHIP_S into (MSBs,LSBs)
+    // - extract chip address using modulus of MSBs
+    // - recreate the rest of the address by stitching the quotient of MSBs and
+    // the LSBs
+    addr_for_chip = (addr >> ADDR_CHIP_S) % m_n_channel;
+    rest_of_addr = ((addr >> ADDR_CHIP_S) / m_n_channel) << ADDR_CHIP_S;
+    rest_of_addr |= addr & ((1 << ADDR_CHIP_S) - 1);
 
-      tlx->chip = addr_for_chip; 
-      tlx->bk   = addrdec_packbits(addrdec_mask[BK], rest_of_addr, addrdec_mkhigh[BK], addrdec_mklow[BK]);
-      tlx->row  = addrdec_packbits(addrdec_mask[ROW], rest_of_addr, addrdec_mkhigh[ROW], addrdec_mklow[ROW]);
-      tlx->col  = addrdec_packbits(addrdec_mask[COL], rest_of_addr, addrdec_mkhigh[COL], addrdec_mklow[COL]);
-      tlx->burst= addrdec_packbits(addrdec_mask[BURST], rest_of_addr, addrdec_mkhigh[BURST], addrdec_mklow[BURST]);
-   }
+    tlx->chip = addr_for_chip;
+    tlx->bk = addrdec_packbits(addrdec_mask[BK], rest_of_addr,
+                               addrdec_mkhigh[BK], addrdec_mklow[BK]);
+    tlx->row = addrdec_packbits(addrdec_mask[ROW], rest_of_addr,
+                                addrdec_mkhigh[ROW], addrdec_mklow[ROW]);
+    tlx->col = addrdec_packbits(addrdec_mask[COL], rest_of_addr,
+                                addrdec_mkhigh[COL], addrdec_mklow[COL]);
+    tlx->burst = addrdec_packbits(addrdec_mask[BURST], rest_of_addr,
+                                  addrdec_mkhigh[BURST], addrdec_mklow[BURST]);
+  }
 
-    switch(memory_partition_indexing){
-		case CONSECUTIVE:
-			//Do nothing
-			break;
-		case BITWISE_PERMUTATION:
-		{
-			assert(!gap);
-			tlx->chip = (tlx->chip) ^ (tlx->row & (m_n_channel-1));
-			assert(tlx->chip < m_n_channel);
-			break;
-		}
-		case IPOLY:
-		{
-		    /*
-			* Set Indexing function from "Pseudo-randomly interleaved memory."
-			* Rau, B. R et al.
-			* ISCA 1991
-			*
-			* equations are adopted from:
-			* "Sacat: streaming-aware conflict-avoiding thrashing-resistant gpgpu cache management scheme."
-			* Khairy et al.
-			* IEEE TPDS 2017.
-			*/
-			if(m_n_channel == 32) {
-				std::bitset<64> a(tlx->row);
-				std::bitset<5> chip(tlx->chip);
-				chip[0] = a[13]^a[12]^a[11]^a[10]^a[9]^a[6]^a[5]^a[3]^a[0]^chip[0];
-				chip[1] = a[14]^a[13]^a[12]^a[11]^a[10]^a[7]^a[6]^a[4]^a[1]^chip[1];
-				chip[2] = a[14]^a[10]^a[9]^a[8]^a[7]^a[6]^a[3]^a[2]^a[0]^chip[2];
-				chip[3] = a[11]^a[10]^a[9]^a[8]^a[7]^a[4]^a[3]^a[1]^chip[3];
-				chip[4] = a[12]^a[11]^a[10]^a[9]^a[8]^a[5]^a[4]^a[2]^chip[4];
-				tlx->chip = chip.to_ulong();
-				
-			}
-			else{ /* Else incorrect number of channels for the hashing function */
-            assert("\nGPGPU-Sim memory_partition_indexing error: The number of channels should be "
-                    "32 for the hashing IPOLY index function.\n" && 0);
-			}
-			assert(tlx->chip < m_n_channel);
-			break;
-		}
-		case PAE:
-		{
-			//Page Address Entropy
-			//random selected bits from the page and bank bits
-			//similar to
-			//Liu, Yuxi, et al. "Get Out of the Valley: Power-Efficient Address Mapping for GPUs." ISCA 2018
-			std::bitset<64> a(tlx->row);
-			std::bitset<5> chip(tlx->chip);
-			std::bitset<4> b(tlx->bk);
-			chip[0] = a[13]^a[10]^a[9]^a[5]^a[0]^b[3]^b[0]^chip[0];
-			chip[1] = a[12]^a[11]^a[6]^a[1]^b[3]^b[2]^b[1]^chip[1];
-			chip[2] = a[14]^a[9]^a[8]^a[7]^a[2]^b[1]^chip[2];
-			chip[3] = a[11]^a[10]^a[8]^a[3]^b[2]^b[3]^chip[3];
-			chip[4] = a[12]^a[9]^a[8]^a[5]^a[4]^b[1]^b[0]^chip[4];
-			tlx->chip = chip.to_ulong();
-			assert(tlx->chip < m_n_channel);
-			break;
-		}
-		case RANDOM:
-		{
-			//This is an unrealistic hashing using software hashtable
-			//we generate a random set for each memory address and save the value in a big hashtable for future reuse
-			new_addr_type chip_address = (addr>>ADDR_CHIP_S);
-			tr1_hash_map<new_addr_type,unsigned>::const_iterator got = address_random_interleaving.find (chip_address);
-			  if ( got == address_random_interleaving.end() ) {
-				  unsigned new_chip_id = rand() % (m_n_channel*m_n_sub_partition_in_channel);
-				  address_random_interleaving[chip_address] = new_chip_id;
-				  tlx->chip = new_chip_id/m_n_sub_partition_in_channel;
-				  tlx->sub_partition = new_chip_id;
-			  }
-			  else {
-				  unsigned new_chip_id = got->second;
-				  tlx->chip = new_chip_id/m_n_sub_partition_in_channel;
-				  tlx->sub_partition = new_chip_id;
-			  }
+  switch (memory_partition_indexing) {
+    case CONSECUTIVE:
+      // Do nothing
+      break;
+    case BITWISE_PERMUTATION: {
+      assert(!gap);
+      tlx->chip = (tlx->chip) ^ (tlx->row & (m_n_channel - 1));
+      assert(tlx->chip < m_n_channel);
+      break;
+    }
+    case IPOLY: {
+      /*
+       * Set Indexing function from "Pseudo-randomly interleaved memory."
+       * Rau, B. R et al.
+       * ISCA 1991
+       *
+       * equations are adopted from:
+       * "Sacat: streaming-aware conflict-avoiding thrashing-resistant gpgpu
+       * cache management scheme." Khairy et al. IEEE TPDS 2017.
+       */
+      if (m_n_channel == 32) {
+        std::bitset<64> a(tlx->row);
+        std::bitset<5> chip(tlx->chip);
+        chip[0] = a[13] ^ a[12] ^ a[11] ^ a[10] ^ a[9] ^ a[6] ^ a[5] ^ a[3] ^
+                  a[0] ^ chip[0];
+        chip[1] = a[14] ^ a[13] ^ a[12] ^ a[11] ^ a[10] ^ a[7] ^ a[6] ^ a[4] ^
+                  a[1] ^ chip[1];
+        chip[2] = a[14] ^ a[10] ^ a[9] ^ a[8] ^ a[7] ^ a[6] ^ a[3] ^ a[2] ^
+                  a[0] ^ chip[2];
+        chip[3] =
+            a[11] ^ a[10] ^ a[9] ^ a[8] ^ a[7] ^ a[4] ^ a[3] ^ a[1] ^ chip[3];
+        chip[4] =
+            a[12] ^ a[11] ^ a[10] ^ a[9] ^ a[8] ^ a[5] ^ a[4] ^ a[2] ^ chip[4];
+        tlx->chip = chip.to_ulong();
 
-			  assert(tlx->chip < m_n_channel);
-			  assert(tlx->sub_partition < m_n_channel * m_n_sub_partition_in_channel);
-			  return;
-			break;
-		}
-		case CUSTOM:
-			/* No custom set function implemented */
-			//Do you custom index here
-			break;
-		default:
-			 assert("\nUndefined set index function.\n" && 0);
-			 break;
-	}
-
-   // combine the chip address and the lower bits of DRAM bank address to form the subpartition ID
-   unsigned sub_partition_addr_mask = m_n_sub_partition_in_channel - 1;
-   tlx->sub_partition = tlx->chip * m_n_sub_partition_in_channel
-                        + (tlx->bk & sub_partition_addr_mask);
-}
-
-void linear_to_raw_address_translation::addrdec_parseoption(const char *option)
-{
-   unsigned int dramid_start = 0;
-   int dramid_parsed = sscanf(option, "dramid@%d", &dramid_start);
-   if (dramid_parsed == 1) {
-      ADDR_CHIP_S = dramid_start;
-   } else {
-      ADDR_CHIP_S = -1;
-   }
-   
-   const char *cmapping = strchr(option, ';');
-   if (cmapping == NULL) {
-      cmapping = option;
-   } else {
-      cmapping += 1;
-   }
-
-   addrdec_mask[CHIP] = 0x0;
-   addrdec_mask[BK]   = 0x0;
-   addrdec_mask[ROW]  = 0x0;
-   addrdec_mask[COL]  = 0x0;
-   addrdec_mask[BURST]= 0x0;
-   
-   int ofs = 63;
-   while ((*cmapping) != '\0') {
-      switch (*cmapping) {
-         case 'D': case 'd':  
-            assert(dramid_parsed != 1); addrdec_mask[CHIP]  |= (1ULL << ofs); ofs--; break;
-         case 'B': case 'b':   addrdec_mask[BK]    |= (1ULL << ofs); ofs--; break;
-         case 'R': case 'r':   addrdec_mask[ROW]   |= (1ULL << ofs); ofs--; break;
-         case 'C': case 'c':   addrdec_mask[COL]   |= (1ULL << ofs); ofs--; break;
-         case 'S': case 's':   addrdec_mask[BURST] |= (1ULL << ofs); addrdec_mask[COL]   |= (1ULL << ofs); ofs--; break;
-         // ignore bit
-         case '0': ofs--; break;
-         // ignore character
-         case '|':
-         case ' ':
-         case '.': break;
-         default:
-            fprintf(stderr, "ERROR: Invalid address mapping character '%c' in option '%s'\n", *cmapping, option);
+      } else { /* Else incorrect number of channels for the hashing function */
+        assert(
+            "\nGPGPU-Sim memory_partition_indexing error: The number of "
+            "channels should be "
+            "32 for the hashing IPOLY index function.\n" &&
+            0);
       }
-      cmapping += 1;
-   }
+      assert(tlx->chip < m_n_channel);
+      break;
+    }
+    case PAE: {
+      // Page Address Entropy
+      // random selected bits from the page and bank bits
+      // similar to
+      // Liu, Yuxi, et al. "Get Out of the Valley: Power-Efficient Address
+      // Mapping for GPUs." ISCA 2018
+      std::bitset<64> a(tlx->row);
+      std::bitset<5> chip(tlx->chip);
+      std::bitset<4> b(tlx->bk);
+      chip[0] = a[13] ^ a[10] ^ a[9] ^ a[5] ^ a[0] ^ b[3] ^ b[0] ^ chip[0];
+      chip[1] = a[12] ^ a[11] ^ a[6] ^ a[1] ^ b[3] ^ b[2] ^ b[1] ^ chip[1];
+      chip[2] = a[14] ^ a[9] ^ a[8] ^ a[7] ^ a[2] ^ b[1] ^ chip[2];
+      chip[3] = a[11] ^ a[10] ^ a[8] ^ a[3] ^ b[2] ^ b[3] ^ chip[3];
+      chip[4] = a[12] ^ a[9] ^ a[8] ^ a[5] ^ a[4] ^ b[1] ^ b[0] ^ chip[4];
+      tlx->chip = chip.to_ulong();
+      assert(tlx->chip < m_n_channel);
+      break;
+    }
+    case RANDOM: {
+      // This is an unrealistic hashing using software hashtable
+      // we generate a random set for each memory address and save the value in
+      // a big hashtable for future reuse
+      new_addr_type chip_address = (addr >> ADDR_CHIP_S);
+      tr1_hash_map<new_addr_type, unsigned>::const_iterator got =
+          address_random_interleaving.find(chip_address);
+      if (got == address_random_interleaving.end()) {
+        unsigned new_chip_id =
+            rand() % (m_n_channel * m_n_sub_partition_in_channel);
+        address_random_interleaving[chip_address] = new_chip_id;
+        tlx->chip = new_chip_id / m_n_sub_partition_in_channel;
+        tlx->sub_partition = new_chip_id;
+      } else {
+        unsigned new_chip_id = got->second;
+        tlx->chip = new_chip_id / m_n_sub_partition_in_channel;
+        tlx->sub_partition = new_chip_id;
+      }
 
-   if (ofs != -1) {
-      fprintf(stderr, "ERROR: Invalid address mapping length (%d) in option '%s'\n", 63 - ofs, option);
-      assert(ofs == -1);
-   }
+      assert(tlx->chip < m_n_channel);
+      assert(tlx->sub_partition < m_n_channel * m_n_sub_partition_in_channel);
+      return;
+      break;
+    }
+    case CUSTOM:
+      /* No custom set function implemented */
+      // Do you custom index here
+      break;
+    default:
+      assert("\nUndefined set index function.\n" && 0);
+      break;
+  }
+
+  // combine the chip address and the lower bits of DRAM bank address to form
+  // the subpartition ID
+  unsigned sub_partition_addr_mask = m_n_sub_partition_in_channel - 1;
+  tlx->sub_partition = tlx->chip * m_n_sub_partition_in_channel +
+                       (tlx->bk & sub_partition_addr_mask);
 }
 
-void linear_to_raw_address_translation::init(unsigned int n_channel, unsigned int n_sub_partition_in_channel) 
-{
-   unsigned i;
-   unsigned long long int mask;
-   unsigned int nchipbits = ::LOGB2_32(n_channel);
-   m_n_channel = n_channel;
-   m_n_sub_partition_in_channel = n_sub_partition_in_channel; 
+void linear_to_raw_address_translation::addrdec_parseoption(
+    const char *option) {
+  unsigned int dramid_start = 0;
+  int dramid_parsed = sscanf(option, "dramid@%d", &dramid_start);
+  if (dramid_parsed == 1) {
+    ADDR_CHIP_S = dramid_start;
+  } else {
+    ADDR_CHIP_S = -1;
+  }
 
-   gap = (n_channel - ::powli(2,nchipbits));
-   if (gap) {
-      nchipbits++;
-   }
-   switch (gpgpu_mem_address_mask) {
-   case 0: 
-      //old, added 2row bits, use #define ADDR_CHIP_S 10
+  const char *cmapping = strchr(option, ';');
+  if (cmapping == NULL) {
+    cmapping = option;
+  } else {
+    cmapping += 1;
+  }
+
+  addrdec_mask[CHIP] = 0x0;
+  addrdec_mask[BK] = 0x0;
+  addrdec_mask[ROW] = 0x0;
+  addrdec_mask[COL] = 0x0;
+  addrdec_mask[BURST] = 0x0;
+
+  int ofs = 63;
+  while ((*cmapping) != '\0') {
+    switch (*cmapping) {
+      case 'D':
+      case 'd':
+        assert(dramid_parsed != 1);
+        addrdec_mask[CHIP] |= (1ULL << ofs);
+        ofs--;
+        break;
+      case 'B':
+      case 'b':
+        addrdec_mask[BK] |= (1ULL << ofs);
+        ofs--;
+        break;
+      case 'R':
+      case 'r':
+        addrdec_mask[ROW] |= (1ULL << ofs);
+        ofs--;
+        break;
+      case 'C':
+      case 'c':
+        addrdec_mask[COL] |= (1ULL << ofs);
+        ofs--;
+        break;
+      case 'S':
+      case 's':
+        addrdec_mask[BURST] |= (1ULL << ofs);
+        addrdec_mask[COL] |= (1ULL << ofs);
+        ofs--;
+        break;
+      // ignore bit
+      case '0':
+        ofs--;
+        break;
+      // ignore character
+      case '|':
+      case ' ':
+      case '.':
+        break;
+      default:
+        fprintf(
+            stderr,
+            "ERROR: Invalid address mapping character '%c' in option '%s'\n",
+            *cmapping, option);
+    }
+    cmapping += 1;
+  }
+
+  if (ofs != -1) {
+    fprintf(stderr,
+            "ERROR: Invalid address mapping length (%d) in option '%s'\n",
+            63 - ofs, option);
+    assert(ofs == -1);
+  }
+}
+
+void linear_to_raw_address_translation::init(
+    unsigned int n_channel, unsigned int n_sub_partition_in_channel) {
+  unsigned i;
+  unsigned long long int mask;
+  unsigned int nchipbits = ::LOGB2_32(n_channel);
+  m_n_channel = n_channel;
+  m_n_sub_partition_in_channel = n_sub_partition_in_channel;
+
+  gap = (n_channel - ::powli(2, nchipbits));
+  if (gap) {
+    nchipbits++;
+  }
+  switch (gpgpu_mem_address_mask) {
+    case 0:
+      // old, added 2row bits, use #define ADDR_CHIP_S 10
       ADDR_CHIP_S = 10;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK]   = 0x0000000000000300;
-      addrdec_mask[ROW]  = 0x0000000007FFE000;
-      addrdec_mask[COL]  = 0x0000000000001CFF;
+      addrdec_mask[BK] = 0x0000000000000300;
+      addrdec_mask[ROW] = 0x0000000007FFE000;
+      addrdec_mask[COL] = 0x0000000000001CFF;
       break;
-   case 1:
+    case 1:
       ADDR_CHIP_S = 13;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK]   = 0x0000000000001800;
-      addrdec_mask[ROW]  = 0x0000000007FFE000;
-      addrdec_mask[COL]  = 0x00000000000007FF;
+      addrdec_mask[BK] = 0x0000000000001800;
+      addrdec_mask[ROW] = 0x0000000007FFE000;
+      addrdec_mask[COL] = 0x00000000000007FF;
       break;
-   case 2:
+    case 2:
       ADDR_CHIP_S = 11;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK]   = 0x0000000000001800;
-      addrdec_mask[ROW]  = 0x0000000007FFE000;
-      addrdec_mask[COL]  = 0x00000000000007FF;
+      addrdec_mask[BK] = 0x0000000000001800;
+      addrdec_mask[ROW] = 0x0000000007FFE000;
+      addrdec_mask[COL] = 0x00000000000007FF;
       break;
-   case 3:
+    case 3:
       ADDR_CHIP_S = 11;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK]   = 0x0000000000001800;
-      addrdec_mask[ROW]  = 0x000000000FFFE000;
-      addrdec_mask[COL]  = 0x00000000000007FF;
+      addrdec_mask[BK] = 0x0000000000001800;
+      addrdec_mask[ROW] = 0x000000000FFFE000;
+      addrdec_mask[COL] = 0x00000000000007FF;
       break;
 
-   case 14:
+    case 14:
       ADDR_CHIP_S = 14;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK]   = 0x0000000000001800;
-      addrdec_mask[ROW]  = 0x0000000007FFE000;
-      addrdec_mask[COL]  = 0x00000000000007FF;
+      addrdec_mask[BK] = 0x0000000000001800;
+      addrdec_mask[ROW] = 0x0000000007FFE000;
+      addrdec_mask[COL] = 0x00000000000007FF;
       break;
-   case 15:
+    case 15:
       ADDR_CHIP_S = 15;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK]   = 0x0000000000001800;
-      addrdec_mask[ROW]  = 0x0000000007FFE000;
-      addrdec_mask[COL]  = 0x00000000000007FF;
+      addrdec_mask[BK] = 0x0000000000001800;
+      addrdec_mask[ROW] = 0x0000000007FFE000;
+      addrdec_mask[COL] = 0x00000000000007FF;
       break;
-   case 16:
+    case 16:
       ADDR_CHIP_S = 16;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK]   = 0x0000000000001800;
-      addrdec_mask[ROW]  = 0x0000000007FFE000;
-      addrdec_mask[COL]  = 0x00000000000007FF;
+      addrdec_mask[BK] = 0x0000000000001800;
+      addrdec_mask[ROW] = 0x0000000007FFE000;
+      addrdec_mask[COL] = 0x00000000000007FF;
       break;
-   case 6:
+    case 6:
       ADDR_CHIP_S = 6;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK]   = 0x0000000000001800;
-      addrdec_mask[ROW]  = 0x0000000007FFE000;
-      addrdec_mask[COL]  = 0x00000000000007FF;
+      addrdec_mask[BK] = 0x0000000000001800;
+      addrdec_mask[ROW] = 0x0000000007FFE000;
+      addrdec_mask[COL] = 0x00000000000007FF;
       break;
-   case 5:
+    case 5:
       ADDR_CHIP_S = 5;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK]   = 0x0000000000001800;
-      addrdec_mask[ROW]  = 0x0000000007FFE000;
-      addrdec_mask[COL]  = 0x00000000000007FF;
-      break;                         
-   case 100:
+      addrdec_mask[BK] = 0x0000000000001800;
+      addrdec_mask[ROW] = 0x0000000007FFE000;
+      addrdec_mask[COL] = 0x00000000000007FF;
+      break;
+    case 100:
       ADDR_CHIP_S = 1;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK]   = 0x0000000000000003;
-      addrdec_mask[ROW]  = 0x0000000007FFE000;
-      addrdec_mask[COL]  = 0x0000000000001FFC;
+      addrdec_mask[BK] = 0x0000000000000003;
+      addrdec_mask[ROW] = 0x0000000007FFE000;
+      addrdec_mask[COL] = 0x0000000000001FFC;
       break;
-   case 103:
+    case 103:
       ADDR_CHIP_S = 3;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK]   = 0x0000000000000003;
-      addrdec_mask[ROW]  = 0x0000000007FFE000;
-      addrdec_mask[COL]  = 0x0000000000001FFC;
+      addrdec_mask[BK] = 0x0000000000000003;
+      addrdec_mask[ROW] = 0x0000000007FFE000;
+      addrdec_mask[COL] = 0x0000000000001FFC;
       break;
-   case 106:
+    case 106:
       ADDR_CHIP_S = 6;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK]   = 0x0000000000001800;
-      addrdec_mask[ROW]  = 0x0000000007FFE000;
-      addrdec_mask[COL]  = 0x00000000000007FF;
+      addrdec_mask[BK] = 0x0000000000001800;
+      addrdec_mask[ROW] = 0x0000000007FFE000;
+      addrdec_mask[COL] = 0x00000000000007FF;
       break;
-   case 160: 
-      //old, added 2row bits, use #define ADDR_CHIP_S 10
+    case 160:
+      // old, added 2row bits, use #define ADDR_CHIP_S 10
       ADDR_CHIP_S = 6;
       addrdec_mask[CHIP] = 0x0000000000000000;
-      addrdec_mask[BK]   = 0x0000000000000300;
-      addrdec_mask[ROW]  = 0x0000000007FFE000;
-      addrdec_mask[COL]  = 0x0000000000001CFF;
+      addrdec_mask[BK] = 0x0000000000000300;
+      addrdec_mask[ROW] = 0x0000000007FFE000;
+      addrdec_mask[COL] = 0x0000000000001CFF;
 
-   default:
+    default:
       break;
-   }
+  }
 
-   if (addrdec_option != NULL) 
-      addrdec_parseoption(addrdec_option);
+  if (addrdec_option != NULL) addrdec_parseoption(addrdec_option);
 
-   if (ADDR_CHIP_S != -1) { 
-      if (!gap) {
-         // number of chip is power of two: 
-         // - insert CHIP mask starting at the bit position ADDR_CHIP_S
-         mask = ((unsigned long long int)1 << ADDR_CHIP_S) - 1;
-         addrdec_mask[BK]   = ((addrdec_mask[BK] & ~mask) << nchipbits) | (addrdec_mask[BK] & mask);
-         addrdec_mask[ROW]  = ((addrdec_mask[ROW] & ~mask) << nchipbits) | (addrdec_mask[ROW] & mask);
-         addrdec_mask[COL]  = ((addrdec_mask[COL] & ~mask) << nchipbits) | (addrdec_mask[COL] & mask);
+  if (ADDR_CHIP_S != -1) {
+    if (!gap) {
+      // number of chip is power of two:
+      // - insert CHIP mask starting at the bit position ADDR_CHIP_S
+      mask = ((unsigned long long int)1 << ADDR_CHIP_S) - 1;
+      addrdec_mask[BK] =
+          ((addrdec_mask[BK] & ~mask) << nchipbits) | (addrdec_mask[BK] & mask);
+      addrdec_mask[ROW] = ((addrdec_mask[ROW] & ~mask) << nchipbits) |
+                          (addrdec_mask[ROW] & mask);
+      addrdec_mask[COL] = ((addrdec_mask[COL] & ~mask) << nchipbits) |
+                          (addrdec_mask[COL] & mask);
 
-         for (i=ADDR_CHIP_S;i<(ADDR_CHIP_S+nchipbits);i++) {
-            mask = (unsigned long long int)1 << i;
-            addrdec_mask[CHIP] |= mask;
-         }
-      } // otherwise, no need to change the masks
-   } else {
-      // make sure n_channel is power of two when explicit dram id mask is used
-      assert((n_channel & (n_channel - 1)) == 0); 
-   }
-   // make sure m_n_sub_partition_in_channel is power of two 
-   assert((m_n_sub_partition_in_channel & (m_n_sub_partition_in_channel - 1)) == 0); 
-
-   addrdec_getmasklimit(addrdec_mask[CHIP],  &addrdec_mkhigh[CHIP],  &addrdec_mklow[CHIP] );
-   addrdec_getmasklimit(addrdec_mask[BK],    &addrdec_mkhigh[BK],    &addrdec_mklow[BK]   );
-   addrdec_getmasklimit(addrdec_mask[ROW],   &addrdec_mkhigh[ROW],   &addrdec_mklow[ROW]  );
-   addrdec_getmasklimit(addrdec_mask[COL],   &addrdec_mkhigh[COL],   &addrdec_mklow[COL]  );
-   addrdec_getmasklimit(addrdec_mask[BURST], &addrdec_mkhigh[BURST], &addrdec_mklow[BURST]);
-
-   printf("addr_dec_mask[CHIP]  = %016llx \thigh:%d low:%d\n", addrdec_mask[CHIP],  addrdec_mkhigh[CHIP],  addrdec_mklow[CHIP] );
-   printf("addr_dec_mask[BK]    = %016llx \thigh:%d low:%d\n", addrdec_mask[BK],    addrdec_mkhigh[BK],    addrdec_mklow[BK]   );
-   printf("addr_dec_mask[ROW]   = %016llx \thigh:%d low:%d\n", addrdec_mask[ROW],   addrdec_mkhigh[ROW],   addrdec_mklow[ROW]  );
-   printf("addr_dec_mask[COL]   = %016llx \thigh:%d low:%d\n", addrdec_mask[COL],   addrdec_mkhigh[COL],   addrdec_mklow[COL]  );
-   printf("addr_dec_mask[BURST] = %016llx \thigh:%d low:%d\n", addrdec_mask[BURST], addrdec_mkhigh[BURST], addrdec_mklow[BURST]);
-
-   // create the sub partition ID mask (for removing the sub partition ID from the partition address)
-   sub_partition_id_mask = 0; 
-   if (m_n_sub_partition_in_channel > 1) {
-      unsigned n_sub_partition_log2 = LOGB2_32(m_n_sub_partition_in_channel); 
-      unsigned pos=0;
-      for (unsigned i=addrdec_mklow[BK];i<addrdec_mkhigh[BK];i++) {
-         if ((addrdec_mask[BK] & ((unsigned long long int)1<<i)) != 0) {
-            sub_partition_id_mask |= ((unsigned long long int)1<<i);
-            pos++;
-            if (pos >= n_sub_partition_log2) 
-               break; 
-         }
+      for (i = ADDR_CHIP_S; i < (ADDR_CHIP_S + nchipbits); i++) {
+        mask = (unsigned long long int)1 << i;
+        addrdec_mask[CHIP] |= mask;
       }
-   }
-   printf("sub_partition_id_mask = %016llx\n", sub_partition_id_mask);
+    }  // otherwise, no need to change the masks
+  } else {
+    // make sure n_channel is power of two when explicit dram id mask is used
+    assert((n_channel & (n_channel - 1)) == 0);
+  }
+  // make sure m_n_sub_partition_in_channel is power of two
+  assert((m_n_sub_partition_in_channel & (m_n_sub_partition_in_channel - 1)) ==
+         0);
 
-   if (run_test) {
-      sweep_test(); 
-   }
+  addrdec_getmasklimit(addrdec_mask[CHIP], &addrdec_mkhigh[CHIP],
+                       &addrdec_mklow[CHIP]);
+  addrdec_getmasklimit(addrdec_mask[BK], &addrdec_mkhigh[BK],
+                       &addrdec_mklow[BK]);
+  addrdec_getmasklimit(addrdec_mask[ROW], &addrdec_mkhigh[ROW],
+                       &addrdec_mklow[ROW]);
+  addrdec_getmasklimit(addrdec_mask[COL], &addrdec_mkhigh[COL],
+                       &addrdec_mklow[COL]);
+  addrdec_getmasklimit(addrdec_mask[BURST], &addrdec_mkhigh[BURST],
+                       &addrdec_mklow[BURST]);
 
-   if(memory_partition_indexing == RANDOM)
-     srand (1);
+  printf("addr_dec_mask[CHIP]  = %016llx \thigh:%d low:%d\n",
+         addrdec_mask[CHIP], addrdec_mkhigh[CHIP], addrdec_mklow[CHIP]);
+  printf("addr_dec_mask[BK]    = %016llx \thigh:%d low:%d\n", addrdec_mask[BK],
+         addrdec_mkhigh[BK], addrdec_mklow[BK]);
+  printf("addr_dec_mask[ROW]   = %016llx \thigh:%d low:%d\n", addrdec_mask[ROW],
+         addrdec_mkhigh[ROW], addrdec_mklow[ROW]);
+  printf("addr_dec_mask[COL]   = %016llx \thigh:%d low:%d\n", addrdec_mask[COL],
+         addrdec_mkhigh[COL], addrdec_mklow[COL]);
+  printf("addr_dec_mask[BURST] = %016llx \thigh:%d low:%d\n",
+         addrdec_mask[BURST], addrdec_mkhigh[BURST], addrdec_mklow[BURST]);
 
+  // create the sub partition ID mask (for removing the sub partition ID from
+  // the partition address)
+  sub_partition_id_mask = 0;
+  if (m_n_sub_partition_in_channel > 1) {
+    unsigned n_sub_partition_log2 = LOGB2_32(m_n_sub_partition_in_channel);
+    unsigned pos = 0;
+    for (unsigned i = addrdec_mklow[BK]; i < addrdec_mkhigh[BK]; i++) {
+      if ((addrdec_mask[BK] & ((unsigned long long int)1 << i)) != 0) {
+        sub_partition_id_mask |= ((unsigned long long int)1 << i);
+        pos++;
+        if (pos >= n_sub_partition_log2) break;
+      }
+    }
+  }
+  printf("sub_partition_id_mask = %016llx\n", sub_partition_id_mask);
+
+  if (run_test) {
+    sweep_test();
+  }
+
+  if (memory_partition_indexing == RANDOM) srand(1);
 }
 
-#include "../tr1_hash_map.h" 
+#include "../tr1_hash_map.h"
 
-bool operator==(const addrdec_t &x, const addrdec_t &y) 
-{
-   return ( memcmp(&x, &y, sizeof(addrdec_t)) == 0 ); 
+bool operator==(const addrdec_t &x, const addrdec_t &y) {
+  return (memcmp(&x, &y, sizeof(addrdec_t)) == 0);
 }
 
-bool operator<(const addrdec_t &x, const addrdec_t &y) 
-{
-   if (x.chip >= y.chip) return false; 
-   else if (x.bk >= y.bk) return false;
-   else if (x.row >= y.row) return false;
-   else if (x.col >= y.col) return false;
-   else if (x.burst >= y.burst) return false;
-   else return true; 
+bool operator<(const addrdec_t &x, const addrdec_t &y) {
+  if (x.chip >= y.chip)
+    return false;
+  else if (x.bk >= y.bk)
+    return false;
+  else if (x.row >= y.row)
+    return false;
+  else if (x.col >= y.col)
+    return false;
+  else if (x.burst >= y.burst)
+    return false;
+  else
+    return true;
 }
 
-class hash_addrdec_t
-{
-public: 
-   size_t operator()(const addrdec_t &x) const {
-      return (x.chip ^ x.bk ^ x.row ^ x.col ^ x.burst); 
-   }
+class hash_addrdec_t {
+ public:
+  size_t operator()(const addrdec_t &x) const {
+    return (x.chip ^ x.bk ^ x.row ^ x.col ^ x.burst);
+  }
 };
 
-// a simple sweep test to ensure that two linear addresses are not mapped to the same raw address 
-void linear_to_raw_address_translation::sweep_test() const
-{
-   new_addr_type sweep_range = 16 * 1024 * 1024; 
+// a simple sweep test to ensure that two linear addresses are not mapped to the
+// same raw address
+void linear_to_raw_address_translation::sweep_test() const {
+  new_addr_type sweep_range = 16 * 1024 * 1024;
 
 #if tr1_hash_map_ismap == 1
-   typedef tr1_hash_map<addrdec_t, new_addr_type> history_map_t; 
+  typedef tr1_hash_map<addrdec_t, new_addr_type> history_map_t;
 #else
-   typedef tr1_hash_map<addrdec_t, new_addr_type, hash_addrdec_t> history_map_t; 
+  typedef tr1_hash_map<addrdec_t, new_addr_type, hash_addrdec_t> history_map_t;
 #endif
-   history_map_t history_map; 
+  history_map_t history_map;
 
-   for (new_addr_type raw_addr = 4; raw_addr < sweep_range; raw_addr += 4) {
-      addrdec_t tlx; 
-      addrdec_tlx(raw_addr, &tlx); 
+  for (new_addr_type raw_addr = 4; raw_addr < sweep_range; raw_addr += 4) {
+    addrdec_t tlx;
+    addrdec_tlx(raw_addr, &tlx);
 
-      history_map_t::iterator h = history_map.find(tlx); 
+    history_map_t::iterator h = history_map.find(tlx);
 
-      if (h != history_map.end()) {
-         printf("[AddrDec] ** Error: address decoding mapping aliases two addresses to same partition with same intra-partition address: %llx %llx\n", h->second, raw_addr); 
-         abort(); 
+    if (h != history_map.end()) {
+      printf(
+          "[AddrDec] ** Error: address decoding mapping aliases two addresses "
+          "to same partition with same intra-partition address: %llx %llx\n",
+          h->second, raw_addr);
+      abort();
+    } else {
+      assert((int)tlx.chip < m_n_channel);
+      // ensure that partition_address() returns the concatenated address
+      if ((ADDR_CHIP_S != -1 and raw_addr >= (1ULL << ADDR_CHIP_S)) or
+          (ADDR_CHIP_S == -1 and raw_addr >= (1ULL << addrdec_mklow[CHIP]))) {
+        assert(raw_addr != partition_address(raw_addr));
+      }
+      history_map[tlx] = raw_addr;
+    }
+
+    if ((raw_addr & 0xffff) == 0) printf("%llu scaned\n", raw_addr);
+  }
+}
+
+void addrdec_t::print(FILE *fp) const {
+  fprintf(fp, "\tchip:%x ", chip);
+  fprintf(fp, "\trow:%x ", row);
+  fprintf(fp, "\tcol:%x ", col);
+  fprintf(fp, "\tbk:%x ", bk);
+  fprintf(fp, "\tburst:%x ", burst);
+  fprintf(fp, "\tsub_partition:%x ", sub_partition);
+}
+
+static long int powli(long int x, long int y)  // compute x to the y
+{
+  long int r = 1;
+  int i;
+  for (i = 0; i < y; ++i) {
+    r *= x;
+  }
+  return r;
+}
+
+static unsigned int LOGB2_32(unsigned int v) {
+  unsigned int shift;
+  unsigned int r;
+
+  r = 0;
+
+  shift = ((v & 0xFFFF0000) != 0) << 4;
+  v >>= shift;
+  r |= shift;
+  shift = ((v & 0xFF00) != 0) << 3;
+  v >>= shift;
+  r |= shift;
+  shift = ((v & 0xF0) != 0) << 2;
+  v >>= shift;
+  r |= shift;
+  shift = ((v & 0xC) != 0) << 1;
+  v >>= shift;
+  r |= shift;
+  shift = ((v & 0x2) != 0) << 0;
+  v >>= shift;
+  r |= shift;
+
+  return r;
+}
+
+static new_addr_type addrdec_packbits(new_addr_type mask, new_addr_type val,
+                                      unsigned char high, unsigned char low) {
+  unsigned pos = 0;
+  new_addr_type result = 0;
+  for (unsigned i = low; i < high; i++) {
+    if ((mask & ((unsigned long long int)1 << i)) != 0) {
+      result |= ((val & ((unsigned long long int)1 << i)) >> i) << pos;
+      pos++;
+    }
+  }
+  return result;
+}
+
+static void addrdec_getmasklimit(new_addr_type mask, unsigned char *high,
+                                 unsigned char *low) {
+  *high = 64;
+  *low = 0;
+  int i;
+  int low_found = 0;
+
+  for (i = 0; i < 64; i++) {
+    if ((mask & ((unsigned long long int)1 << i)) != 0) {
+      if (low_found) {
+        *high = i + 1;
       } else {
-         assert((int)tlx.chip < m_n_channel); 
-         // ensure that partition_address() returns the concatenated address 
-         if ((ADDR_CHIP_S != -1 and raw_addr >= (1ULL << ADDR_CHIP_S)) or 
-             (ADDR_CHIP_S == -1 and raw_addr >= (1ULL << addrdec_mklow[CHIP]))) {
-            assert(raw_addr != partition_address(raw_addr)); 
-         }
-         history_map[tlx] = raw_addr; 
+        *high = i + 1;
+        *low = i;
+        low_found = 1;
       }
-
-      if ((raw_addr & 0xffff) == 0) printf("%llu scaned\n", raw_addr); 
-   }
-}
-
-void addrdec_t::print( FILE *fp ) const
-{
-   fprintf(fp,"\tchip:%x ", chip);
-   fprintf(fp,"\trow:%x ", row);
-   fprintf(fp,"\tcol:%x ", col);
-   fprintf(fp,"\tbk:%x ", bk);
-   fprintf(fp,"\tburst:%x ", burst);
-   fprintf(fp,"\tsub_partition:%x ", sub_partition);
-} 
-
-
-static long int powli( long int x, long int y ) // compute x to the y
-{
-   long int r = 1;
-   int i; 
-   for (i = 0; i < y; ++i ) {
-      r *= x;
-   }
-   return r;
-}
-
-static unsigned int LOGB2_32( unsigned int v ) 
-{
-   unsigned int shift;
-   unsigned int r;
-
-   r = 0;
-
-   shift = (( v & 0xFFFF0000) != 0 ) << 4; v >>= shift; r |= shift;
-   shift = (( v & 0xFF00    ) != 0 ) << 3; v >>= shift; r |= shift;
-   shift = (( v & 0xF0      ) != 0 ) << 2; v >>= shift; r |= shift;
-   shift = (( v & 0xC       ) != 0 ) << 1; v >>= shift; r |= shift;
-   shift = (( v & 0x2       ) != 0 ) << 0; v >>= shift; r |= shift;
-
-   return r;
-}
-
-static new_addr_type addrdec_packbits( new_addr_type mask, new_addr_type val, unsigned char high, unsigned char low) 
-{
-   unsigned pos=0;
-   new_addr_type result = 0;
-   for (unsigned i=low;i<high;i++) {
-      if ((mask & ((unsigned long long int)1<<i)) != 0) {
-         result |= ((val & ((unsigned long long int)1<<i)) >> i) << pos;
-         pos++;
-      }
-   }
-   return result;
-}
-
-static void addrdec_getmasklimit(new_addr_type mask, unsigned char *high, unsigned char *low) 
-{
-   *high = 64;
-   *low = 0;
-   int i;
-   int low_found = 0;
-
-   for (i=0;i<64;i++) {
-      if ((mask & ((unsigned long long int)1<<i)) != 0) {
-         if (low_found) {
-            *high = i + 1;
-         } else {
-            *high = i + 1;
-            *low = i;
-            low_found = 1;
-         }
-      }
-   }
+    }
+  }
 }

--- a/src/gpgpu-sim/addrdec.h
+++ b/src/gpgpu-sim/addrdec.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -25,9 +27,9 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <assert.h>
 #include "../option_parser.h"
 
 #ifndef ADDRDEC_H
@@ -35,66 +37,57 @@
 
 #include "../abstract_hardware_model.h"
 
-enum partition_index_function{
-	CONSECUTIVE = 0,
-	BITWISE_PERMUTATION,
-	IPOLY,
-	PAE,
-	RANDOM,
-    CUSTOM
+enum partition_index_function {
+  CONSECUTIVE = 0,
+  BITWISE_PERMUTATION,
+  IPOLY,
+  PAE,
+  RANDOM,
+  CUSTOM
 };
 
 struct addrdec_t {
-   void print( FILE *fp ) const;
-    
-   unsigned chip;
-   unsigned bk;
-   unsigned row;
-   unsigned col;
-   unsigned burst;
+  void print(FILE *fp) const;
 
-   unsigned sub_partition; 
+  unsigned chip;
+  unsigned bk;
+  unsigned row;
+  unsigned col;
+  unsigned burst;
+
+  unsigned sub_partition;
 };
 
-
 class linear_to_raw_address_translation {
-public:
-   linear_to_raw_address_translation();
-   void addrdec_setoption(option_parser_t opp);
-   void init(unsigned int n_channel, unsigned int n_sub_partition_in_channel); 
+ public:
+  linear_to_raw_address_translation();
+  void addrdec_setoption(option_parser_t opp);
+  void init(unsigned int n_channel, unsigned int n_sub_partition_in_channel);
 
-   // accessors
-   void addrdec_tlx(new_addr_type addr, addrdec_t *tlx) const;
-   new_addr_type partition_address( new_addr_type addr ) const;
+  // accessors
+  void addrdec_tlx(new_addr_type addr, addrdec_t *tlx) const;
+  new_addr_type partition_address(new_addr_type addr) const;
 
-private:
-   void addrdec_parseoption(const char *option);
-   void sweep_test() const; // sanity check to ensure no overlapping
+ private:
+  void addrdec_parseoption(const char *option);
+  void sweep_test() const;  // sanity check to ensure no overlapping
 
-   enum {
-      CHIP  = 0,
-      BK    = 1,
-      ROW   = 2,
-      COL   = 3,
-      BURST = 4,
-      N_ADDRDEC
-   };
+  enum { CHIP = 0, BK = 1, ROW = 2, COL = 3, BURST = 4, N_ADDRDEC };
 
-   const char *addrdec_option;
-   int gpgpu_mem_address_mask;
-   partition_index_function memory_partition_indexing;
-   bool run_test; 
+  const char *addrdec_option;
+  int gpgpu_mem_address_mask;
+  partition_index_function memory_partition_indexing;
+  bool run_test;
 
-   int ADDR_CHIP_S;
-   unsigned char addrdec_mklow[N_ADDRDEC];
-   unsigned char addrdec_mkhigh[N_ADDRDEC];
-   new_addr_type addrdec_mask[N_ADDRDEC];
-   new_addr_type sub_partition_id_mask; 
+  int ADDR_CHIP_S;
+  unsigned char addrdec_mklow[N_ADDRDEC];
+  unsigned char addrdec_mkhigh[N_ADDRDEC];
+  new_addr_type addrdec_mask[N_ADDRDEC];
+  new_addr_type sub_partition_id_mask;
 
-   unsigned int gap;
-   unsigned m_n_channel;
-   int m_n_sub_partition_in_channel; 
-
+  unsigned int gap;
+  unsigned m_n_channel;
+  int m_n_sub_partition_in_channel;
 };
 
 #endif

--- a/src/gpgpu-sim/addrdec.h
+++ b/src/gpgpu-sim/addrdec.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -27,9 +25,9 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <assert.h>
 #include "../option_parser.h"
 
 #ifndef ADDRDEC_H
@@ -37,57 +35,66 @@
 
 #include "../abstract_hardware_model.h"
 
-enum partition_index_function {
-  CONSECUTIVE = 0,
-  BITWISE_PERMUTATION,
-  IPOLY,
-  PAE,
-  RANDOM,
-  CUSTOM
+enum partition_index_function{
+	CONSECUTIVE = 0,
+	BITWISE_PERMUTATION,
+	IPOLY,
+	PAE,
+	RANDOM,
+    CUSTOM
 };
 
 struct addrdec_t {
-  void print(FILE *fp) const;
+   void print( FILE *fp ) const;
+    
+   unsigned chip;
+   unsigned bk;
+   unsigned row;
+   unsigned col;
+   unsigned burst;
 
-  unsigned chip;
-  unsigned bk;
-  unsigned row;
-  unsigned col;
-  unsigned burst;
-
-  unsigned sub_partition;
+   unsigned sub_partition; 
 };
 
+
 class linear_to_raw_address_translation {
- public:
-  linear_to_raw_address_translation();
-  void addrdec_setoption(option_parser_t opp);
-  void init(unsigned int n_channel, unsigned int n_sub_partition_in_channel);
+public:
+   linear_to_raw_address_translation();
+   void addrdec_setoption(option_parser_t opp);
+   void init(unsigned int n_channel, unsigned int n_sub_partition_in_channel); 
 
-  // accessors
-  void addrdec_tlx(new_addr_type addr, addrdec_t *tlx) const;
-  new_addr_type partition_address(new_addr_type addr) const;
+   // accessors
+   void addrdec_tlx(new_addr_type addr, addrdec_t *tlx) const;
+   new_addr_type partition_address( new_addr_type addr ) const;
 
- private:
-  void addrdec_parseoption(const char *option);
-  void sweep_test() const;  // sanity check to ensure no overlapping
+private:
+   void addrdec_parseoption(const char *option);
+   void sweep_test() const; // sanity check to ensure no overlapping
 
-  enum { CHIP = 0, BK = 1, ROW = 2, COL = 3, BURST = 4, N_ADDRDEC };
+   enum {
+      CHIP  = 0,
+      BK    = 1,
+      ROW   = 2,
+      COL   = 3,
+      BURST = 4,
+      N_ADDRDEC
+   };
 
-  const char *addrdec_option;
-  int gpgpu_mem_address_mask;
-  partition_index_function memory_partition_indexing;
-  bool run_test;
+   const char *addrdec_option;
+   int gpgpu_mem_address_mask;
+   partition_index_function memory_partition_indexing;
+   bool run_test; 
 
-  int ADDR_CHIP_S;
-  unsigned char addrdec_mklow[N_ADDRDEC];
-  unsigned char addrdec_mkhigh[N_ADDRDEC];
-  new_addr_type addrdec_mask[N_ADDRDEC];
-  new_addr_type sub_partition_id_mask;
+   int ADDR_CHIP_S;
+   unsigned char addrdec_mklow[N_ADDRDEC];
+   unsigned char addrdec_mkhigh[N_ADDRDEC];
+   new_addr_type addrdec_mask[N_ADDRDEC];
+   new_addr_type sub_partition_id_mask; 
 
-  unsigned int gap;
-  unsigned m_n_channel;
-  int m_n_sub_partition_in_channel;
+   unsigned int gap;
+   unsigned m_n_channel;
+   int m_n_sub_partition_in_channel; 
+
 };
 
 #endif

--- a/src/gpgpu-sim/addrdec.h
+++ b/src/gpgpu-sim/addrdec.h
@@ -7,27 +7,28 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <assert.h>
 #include "../option_parser.h"
 
 #ifndef ADDRDEC_H
@@ -35,66 +36,57 @@
 
 #include "../abstract_hardware_model.h"
 
-enum partition_index_function{
-	CONSECUTIVE = 0,
-	BITWISE_PERMUTATION,
-	IPOLY,
-	PAE,
-	RANDOM,
-    CUSTOM
+enum partition_index_function {
+  CONSECUTIVE = 0,
+  BITWISE_PERMUTATION,
+  IPOLY,
+  PAE,
+  RANDOM,
+  CUSTOM
 };
 
 struct addrdec_t {
-   void print( FILE *fp ) const;
-    
-   unsigned chip;
-   unsigned bk;
-   unsigned row;
-   unsigned col;
-   unsigned burst;
+  void print(FILE *fp) const;
 
-   unsigned sub_partition; 
+  unsigned chip;
+  unsigned bk;
+  unsigned row;
+  unsigned col;
+  unsigned burst;
+
+  unsigned sub_partition;
 };
 
-
 class linear_to_raw_address_translation {
-public:
-   linear_to_raw_address_translation();
-   void addrdec_setoption(option_parser_t opp);
-   void init(unsigned int n_channel, unsigned int n_sub_partition_in_channel); 
+ public:
+  linear_to_raw_address_translation();
+  void addrdec_setoption(option_parser_t opp);
+  void init(unsigned int n_channel, unsigned int n_sub_partition_in_channel);
 
-   // accessors
-   void addrdec_tlx(new_addr_type addr, addrdec_t *tlx) const;
-   new_addr_type partition_address( new_addr_type addr ) const;
+  // accessors
+  void addrdec_tlx(new_addr_type addr, addrdec_t *tlx) const;
+  new_addr_type partition_address(new_addr_type addr) const;
 
-private:
-   void addrdec_parseoption(const char *option);
-   void sweep_test() const; // sanity check to ensure no overlapping
+ private:
+  void addrdec_parseoption(const char *option);
+  void sweep_test() const;  // sanity check to ensure no overlapping
 
-   enum {
-      CHIP  = 0,
-      BK    = 1,
-      ROW   = 2,
-      COL   = 3,
-      BURST = 4,
-      N_ADDRDEC
-   };
+  enum { CHIP = 0, BK = 1, ROW = 2, COL = 3, BURST = 4, N_ADDRDEC };
 
-   const char *addrdec_option;
-   int gpgpu_mem_address_mask;
-   partition_index_function memory_partition_indexing;
-   bool run_test; 
+  const char *addrdec_option;
+  int gpgpu_mem_address_mask;
+  partition_index_function memory_partition_indexing;
+  bool run_test;
 
-   int ADDR_CHIP_S;
-   unsigned char addrdec_mklow[N_ADDRDEC];
-   unsigned char addrdec_mkhigh[N_ADDRDEC];
-   new_addr_type addrdec_mask[N_ADDRDEC];
-   new_addr_type sub_partition_id_mask; 
+  int ADDR_CHIP_S;
+  unsigned char addrdec_mklow[N_ADDRDEC];
+  unsigned char addrdec_mkhigh[N_ADDRDEC];
+  new_addr_type addrdec_mask[N_ADDRDEC];
+  new_addr_type sub_partition_id_mask;
 
-   unsigned int gap;
-   unsigned m_n_channel;
-   int m_n_sub_partition_in_channel; 
-
+  unsigned int gap;
+  unsigned m_n_channel;
+  int m_n_sub_partition_in_channel;
 };
 
 #endif

--- a/src/gpgpu-sim/delayqueue.h
+++ b/src/gpgpu-sim/delayqueue.h
@@ -7,26 +7,27 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
-#include <stdio.h>
 #include <assert.h>
+#include <stdio.h>
 #include <stdlib.h>
 
 #ifndef DELAYQUEUE_H
@@ -37,157 +38,150 @@
 
 template <class T>
 struct fifo_data {
-   T *m_data;
-   fifo_data *m_next;
+  T* m_data;
+  fifo_data* m_next;
 };
 
-template <class T> 
+template <class T>
 class fifo_pipeline {
-public:
-   fifo_pipeline(const char* nm, unsigned int minlen, unsigned int maxlen ) 
-   {
-      assert(maxlen);
-      m_name = nm;
-      m_min_len = minlen;
-      m_max_len = maxlen;
-      m_length = 0;
-      m_n_element = 0;
-      m_head = NULL;
-      m_tail = NULL;
-      for (unsigned i=0;i<m_min_len;i++) 
-         push(NULL);
-   }
+ public:
+  fifo_pipeline(const char* nm, unsigned int minlen, unsigned int maxlen) {
+    assert(maxlen);
+    m_name = nm;
+    m_min_len = minlen;
+    m_max_len = maxlen;
+    m_length = 0;
+    m_n_element = 0;
+    m_head = NULL;
+    m_tail = NULL;
+    for (unsigned i = 0; i < m_min_len; i++) push(NULL);
+  }
 
-   ~fifo_pipeline() 
-   {
-      while (m_head) {
-         m_tail = m_head;
-         m_head = m_head->m_next;
-         delete m_tail;
+  ~fifo_pipeline() {
+    while (m_head) {
+      m_tail = m_head;
+      m_head = m_head->m_next;
+      delete m_tail;
+    }
+  }
+
+  void push(T* data) {
+    assert(m_length < m_max_len);
+    if (m_head) {
+      if (m_tail->m_data || m_length < m_min_len) {
+        m_tail->m_next = new fifo_data<T>();
+        m_tail = m_tail->m_next;
+        m_length++;
+        m_n_element++;
       }
-   }
+    } else {
+      m_head = m_tail = new fifo_data<T>();
+      m_length++;
+      m_n_element++;
+    }
+    m_tail->m_next = NULL;
+    m_tail->m_data = data;
+  }
 
-   void push(T* data ) 
-   {
-      assert(m_length < m_max_len);
-      if (m_head) {
-         if (m_tail->m_data || m_length < m_min_len) {
-            m_tail->m_next = new fifo_data<T>();
-            m_tail = m_tail->m_next;
-            m_length++;
-            m_n_element++;
-         }
-      } else {
-         m_head = m_tail = new fifo_data<T>();
-         m_length++;
-         m_n_element++;
+  T* pop() {
+    fifo_data<T>* next;
+    T* data;
+    if (m_head) {
+      next = m_head->m_next;
+      data = m_head->m_data;
+      if (m_head == m_tail) {
+        assert(next == NULL);
+        m_tail = NULL;
       }
-      m_tail->m_next = NULL;
-      m_tail->m_data = data;
-   }
+      delete m_head;
+      m_head = next;
+      m_length--;
+      if (m_length == 0) {
+        assert(m_head == NULL);
+        m_tail = m_head;
+      }
+      m_n_element--;
+      if (m_min_len && m_length < m_min_len) {
+        push(NULL);
+        m_n_element--;  // uncount NULL elements inserted to create delays
+      }
+    } else {
+      data = NULL;
+    }
+    return data;
+  }
 
-   T* pop() 
-   {
-      fifo_data<T>* next;
-      T* data;
-      if (m_head) {
-        next = m_head->m_next;
-        data = m_head->m_data;
-        if ( m_head == m_tail ) {
-           assert( next == NULL );
-           m_tail = NULL;     
+  T* top() const {
+    if (m_head) {
+      return m_head->m_data;
+    } else {
+      return NULL;
+    }
+  }
+
+  void set_min_length(unsigned int new_min_len) {
+    if (new_min_len == m_min_len) return;
+
+    if (new_min_len > m_min_len) {
+      m_min_len = new_min_len;
+      while (m_length < m_min_len) {
+        push(NULL);
+        m_n_element--;  // uncount NULL elements inserted to create delays
+      }
+    } else {
+      // in this branch imply that the original min_len is larger then 0
+      // ie. head != 0
+      assert(m_head);
+      m_min_len = new_min_len;
+      while ((m_length > m_min_len) && (m_tail->m_data == 0)) {
+        fifo_data<T>* iter;
+        iter = m_head;
+        while (iter && (iter->m_next != m_tail)) iter = iter->m_next;
+        if (!iter) {
+          // there is only one node, and that node is empty
+          assert(m_head->m_data == 0);
+          pop();
+        } else {
+          // there are more than one node, and tail node is empty
+          assert(iter->m_next == m_tail);
+          delete m_tail;
+          m_tail = iter;
+          m_tail->m_next = 0;
+          m_length--;
         }
-        delete m_head;
-        m_head = next;
-        m_length--;
-        if (m_length == 0) {
-           assert( m_head == NULL );
-           m_tail = m_head;
-        }
-        m_n_element--; 
-         if (m_min_len && m_length < m_min_len) {
-            push(NULL);
-            m_n_element--; // uncount NULL elements inserted to create delays
-         }
-      } else {
-         data = NULL;
       }
-      return data;
-   }
+    }
+  }
 
-   T* top() const
-   {
-      if (m_head) {
-         return m_head->m_data;
-      } else {
-         return NULL;
-      }
-   }
+  bool full() const { return (m_max_len && m_length >= m_max_len); }
+  bool is_avilable_size(unsigned size) const {
+    return (m_max_len && m_length + size - 1 >= m_max_len);
+  }
+  bool empty() const { return m_head == NULL; }
+  unsigned get_n_element() const { return m_n_element; }
+  unsigned get_length() const { return m_length; }
+  unsigned get_max_len() const { return m_max_len; }
 
-   void set_min_length(unsigned int new_min_len) 
-   {
-      if (new_min_len == m_min_len) return;
-   
-      if (new_min_len > m_min_len) {
-         m_min_len = new_min_len;
-         while (m_length < m_min_len) {
-            push(NULL);
-            m_n_element--; // uncount NULL elements inserted to create delays
-         }
-      } else {
-         // in this branch imply that the original min_len is larger then 0
-         // ie. head != 0
-         assert(m_head);
-         m_min_len = new_min_len;
-         while ((m_length > m_min_len) && (m_tail->m_data == 0)) {
-            fifo_data<T> *iter;
-            iter = m_head;
-            while (iter && (iter->m_next != m_tail))
-               iter = iter->m_next;
-            if (!iter) {
-               // there is only one node, and that node is empty
-               assert(m_head->m_data == 0);
-               pop();
-            } else {
-               // there are more than one node, and tail node is empty
-               assert(iter->m_next == m_tail);
-               delete m_tail;
-               m_tail = iter;
-               m_tail->m_next = 0;
-               m_length--;
-            }
-         }
-      }
-   }
+  void print() const {
+    fifo_data<T>* ddp = m_head;
+    printf("%s(%d): ", m_name, m_length);
+    while (ddp) {
+      printf("%p ", ddp->m_data);
+      ddp = ddp->m_next;
+    }
+    printf("\n");
+  }
 
-   bool full() const { return (m_max_len && m_length >= m_max_len); }
-   bool is_avilable_size(unsigned size) const { return (m_max_len && m_length+size-1 >= m_max_len); }
-   bool empty() const { return m_head == NULL; }
-   unsigned get_n_element() const { return m_n_element; }
-   unsigned get_length() const { return m_length; }
-   unsigned get_max_len() const { return m_max_len; }
+ private:
+  const char* m_name;
 
-   void print() const
-   {
-      fifo_data<T>* ddp = m_head;
-      printf("%s(%d): ", m_name, m_length);
-      while (ddp) {
-         printf("%p ", ddp->m_data);
-         ddp = ddp->m_next;
-      }
-      printf("\n");
-   }
+  unsigned int m_min_len;
+  unsigned int m_max_len;
+  unsigned int m_length;
+  unsigned int m_n_element;
 
-private:
-   const char* m_name;
-
-   unsigned int m_min_len;
-   unsigned int m_max_len;
-   unsigned int m_length;
-   unsigned int m_n_element;
-
-   fifo_data<T> *m_head;
-   fifo_data<T> *m_tail;
+  fifo_data<T>* m_head;
+  fifo_data<T>* m_tail;
 };
 
 #endif

--- a/src/gpgpu-sim/delayqueue.h
+++ b/src/gpgpu-sim/delayqueue.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -25,8 +27,8 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <stdio.h>
 #include <assert.h>
+#include <stdio.h>
 #include <stdlib.h>
 
 #ifndef DELAYQUEUE_H
@@ -37,157 +39,150 @@
 
 template <class T>
 struct fifo_data {
-   T *m_data;
-   fifo_data *m_next;
+  T* m_data;
+  fifo_data* m_next;
 };
 
-template <class T> 
+template <class T>
 class fifo_pipeline {
-public:
-   fifo_pipeline(const char* nm, unsigned int minlen, unsigned int maxlen ) 
-   {
-      assert(maxlen);
-      m_name = nm;
-      m_min_len = minlen;
-      m_max_len = maxlen;
-      m_length = 0;
-      m_n_element = 0;
-      m_head = NULL;
-      m_tail = NULL;
-      for (unsigned i=0;i<m_min_len;i++) 
-         push(NULL);
-   }
+ public:
+  fifo_pipeline(const char* nm, unsigned int minlen, unsigned int maxlen) {
+    assert(maxlen);
+    m_name = nm;
+    m_min_len = minlen;
+    m_max_len = maxlen;
+    m_length = 0;
+    m_n_element = 0;
+    m_head = NULL;
+    m_tail = NULL;
+    for (unsigned i = 0; i < m_min_len; i++) push(NULL);
+  }
 
-   ~fifo_pipeline() 
-   {
-      while (m_head) {
-         m_tail = m_head;
-         m_head = m_head->m_next;
-         delete m_tail;
+  ~fifo_pipeline() {
+    while (m_head) {
+      m_tail = m_head;
+      m_head = m_head->m_next;
+      delete m_tail;
+    }
+  }
+
+  void push(T* data) {
+    assert(m_length < m_max_len);
+    if (m_head) {
+      if (m_tail->m_data || m_length < m_min_len) {
+        m_tail->m_next = new fifo_data<T>();
+        m_tail = m_tail->m_next;
+        m_length++;
+        m_n_element++;
       }
-   }
+    } else {
+      m_head = m_tail = new fifo_data<T>();
+      m_length++;
+      m_n_element++;
+    }
+    m_tail->m_next = NULL;
+    m_tail->m_data = data;
+  }
 
-   void push(T* data ) 
-   {
-      assert(m_length < m_max_len);
-      if (m_head) {
-         if (m_tail->m_data || m_length < m_min_len) {
-            m_tail->m_next = new fifo_data<T>();
-            m_tail = m_tail->m_next;
-            m_length++;
-            m_n_element++;
-         }
-      } else {
-         m_head = m_tail = new fifo_data<T>();
-         m_length++;
-         m_n_element++;
+  T* pop() {
+    fifo_data<T>* next;
+    T* data;
+    if (m_head) {
+      next = m_head->m_next;
+      data = m_head->m_data;
+      if (m_head == m_tail) {
+        assert(next == NULL);
+        m_tail = NULL;
       }
-      m_tail->m_next = NULL;
-      m_tail->m_data = data;
-   }
+      delete m_head;
+      m_head = next;
+      m_length--;
+      if (m_length == 0) {
+        assert(m_head == NULL);
+        m_tail = m_head;
+      }
+      m_n_element--;
+      if (m_min_len && m_length < m_min_len) {
+        push(NULL);
+        m_n_element--;  // uncount NULL elements inserted to create delays
+      }
+    } else {
+      data = NULL;
+    }
+    return data;
+  }
 
-   T* pop() 
-   {
-      fifo_data<T>* next;
-      T* data;
-      if (m_head) {
-        next = m_head->m_next;
-        data = m_head->m_data;
-        if ( m_head == m_tail ) {
-           assert( next == NULL );
-           m_tail = NULL;     
+  T* top() const {
+    if (m_head) {
+      return m_head->m_data;
+    } else {
+      return NULL;
+    }
+  }
+
+  void set_min_length(unsigned int new_min_len) {
+    if (new_min_len == m_min_len) return;
+
+    if (new_min_len > m_min_len) {
+      m_min_len = new_min_len;
+      while (m_length < m_min_len) {
+        push(NULL);
+        m_n_element--;  // uncount NULL elements inserted to create delays
+      }
+    } else {
+      // in this branch imply that the original min_len is larger then 0
+      // ie. head != 0
+      assert(m_head);
+      m_min_len = new_min_len;
+      while ((m_length > m_min_len) && (m_tail->m_data == 0)) {
+        fifo_data<T>* iter;
+        iter = m_head;
+        while (iter && (iter->m_next != m_tail)) iter = iter->m_next;
+        if (!iter) {
+          // there is only one node, and that node is empty
+          assert(m_head->m_data == 0);
+          pop();
+        } else {
+          // there are more than one node, and tail node is empty
+          assert(iter->m_next == m_tail);
+          delete m_tail;
+          m_tail = iter;
+          m_tail->m_next = 0;
+          m_length--;
         }
-        delete m_head;
-        m_head = next;
-        m_length--;
-        if (m_length == 0) {
-           assert( m_head == NULL );
-           m_tail = m_head;
-        }
-        m_n_element--; 
-         if (m_min_len && m_length < m_min_len) {
-            push(NULL);
-            m_n_element--; // uncount NULL elements inserted to create delays
-         }
-      } else {
-         data = NULL;
       }
-      return data;
-   }
+    }
+  }
 
-   T* top() const
-   {
-      if (m_head) {
-         return m_head->m_data;
-      } else {
-         return NULL;
-      }
-   }
+  bool full() const { return (m_max_len && m_length >= m_max_len); }
+  bool is_avilable_size(unsigned size) const {
+    return (m_max_len && m_length + size - 1 >= m_max_len);
+  }
+  bool empty() const { return m_head == NULL; }
+  unsigned get_n_element() const { return m_n_element; }
+  unsigned get_length() const { return m_length; }
+  unsigned get_max_len() const { return m_max_len; }
 
-   void set_min_length(unsigned int new_min_len) 
-   {
-      if (new_min_len == m_min_len) return;
-   
-      if (new_min_len > m_min_len) {
-         m_min_len = new_min_len;
-         while (m_length < m_min_len) {
-            push(NULL);
-            m_n_element--; // uncount NULL elements inserted to create delays
-         }
-      } else {
-         // in this branch imply that the original min_len is larger then 0
-         // ie. head != 0
-         assert(m_head);
-         m_min_len = new_min_len;
-         while ((m_length > m_min_len) && (m_tail->m_data == 0)) {
-            fifo_data<T> *iter;
-            iter = m_head;
-            while (iter && (iter->m_next != m_tail))
-               iter = iter->m_next;
-            if (!iter) {
-               // there is only one node, and that node is empty
-               assert(m_head->m_data == 0);
-               pop();
-            } else {
-               // there are more than one node, and tail node is empty
-               assert(iter->m_next == m_tail);
-               delete m_tail;
-               m_tail = iter;
-               m_tail->m_next = 0;
-               m_length--;
-            }
-         }
-      }
-   }
+  void print() const {
+    fifo_data<T>* ddp = m_head;
+    printf("%s(%d): ", m_name, m_length);
+    while (ddp) {
+      printf("%p ", ddp->m_data);
+      ddp = ddp->m_next;
+    }
+    printf("\n");
+  }
 
-   bool full() const { return (m_max_len && m_length >= m_max_len); }
-   bool is_avilable_size(unsigned size) const { return (m_max_len && m_length+size-1 >= m_max_len); }
-   bool empty() const { return m_head == NULL; }
-   unsigned get_n_element() const { return m_n_element; }
-   unsigned get_length() const { return m_length; }
-   unsigned get_max_len() const { return m_max_len; }
+ private:
+  const char* m_name;
 
-   void print() const
-   {
-      fifo_data<T>* ddp = m_head;
-      printf("%s(%d): ", m_name, m_length);
-      while (ddp) {
-         printf("%p ", ddp->m_data);
-         ddp = ddp->m_next;
-      }
-      printf("\n");
-   }
+  unsigned int m_min_len;
+  unsigned int m_max_len;
+  unsigned int m_length;
+  unsigned int m_n_element;
 
-private:
-   const char* m_name;
-
-   unsigned int m_min_len;
-   unsigned int m_max_len;
-   unsigned int m_length;
-   unsigned int m_n_element;
-
-   fifo_data<T> *m_head;
-   fifo_data<T> *m_tail;
+  fifo_data<T>* m_head;
+  fifo_data<T>* m_tail;
 };
 
 #endif

--- a/src/gpgpu-sim/delayqueue.h
+++ b/src/gpgpu-sim/delayqueue.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -27,8 +25,8 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <assert.h>
 #include <stdio.h>
+#include <assert.h>
 #include <stdlib.h>
 
 #ifndef DELAYQUEUE_H
@@ -39,150 +37,157 @@
 
 template <class T>
 struct fifo_data {
-  T* m_data;
-  fifo_data* m_next;
+   T *m_data;
+   fifo_data *m_next;
 };
 
-template <class T>
+template <class T> 
 class fifo_pipeline {
- public:
-  fifo_pipeline(const char* nm, unsigned int minlen, unsigned int maxlen) {
-    assert(maxlen);
-    m_name = nm;
-    m_min_len = minlen;
-    m_max_len = maxlen;
-    m_length = 0;
-    m_n_element = 0;
-    m_head = NULL;
-    m_tail = NULL;
-    for (unsigned i = 0; i < m_min_len; i++) push(NULL);
-  }
+public:
+   fifo_pipeline(const char* nm, unsigned int minlen, unsigned int maxlen ) 
+   {
+      assert(maxlen);
+      m_name = nm;
+      m_min_len = minlen;
+      m_max_len = maxlen;
+      m_length = 0;
+      m_n_element = 0;
+      m_head = NULL;
+      m_tail = NULL;
+      for (unsigned i=0;i<m_min_len;i++) 
+         push(NULL);
+   }
 
-  ~fifo_pipeline() {
-    while (m_head) {
-      m_tail = m_head;
-      m_head = m_head->m_next;
-      delete m_tail;
-    }
-  }
-
-  void push(T* data) {
-    assert(m_length < m_max_len);
-    if (m_head) {
-      if (m_tail->m_data || m_length < m_min_len) {
-        m_tail->m_next = new fifo_data<T>();
-        m_tail = m_tail->m_next;
-        m_length++;
-        m_n_element++;
+   ~fifo_pipeline() 
+   {
+      while (m_head) {
+         m_tail = m_head;
+         m_head = m_head->m_next;
+         delete m_tail;
       }
-    } else {
-      m_head = m_tail = new fifo_data<T>();
-      m_length++;
-      m_n_element++;
-    }
-    m_tail->m_next = NULL;
-    m_tail->m_data = data;
-  }
+   }
 
-  T* pop() {
-    fifo_data<T>* next;
-    T* data;
-    if (m_head) {
-      next = m_head->m_next;
-      data = m_head->m_data;
-      if (m_head == m_tail) {
-        assert(next == NULL);
-        m_tail = NULL;
+   void push(T* data ) 
+   {
+      assert(m_length < m_max_len);
+      if (m_head) {
+         if (m_tail->m_data || m_length < m_min_len) {
+            m_tail->m_next = new fifo_data<T>();
+            m_tail = m_tail->m_next;
+            m_length++;
+            m_n_element++;
+         }
+      } else {
+         m_head = m_tail = new fifo_data<T>();
+         m_length++;
+         m_n_element++;
       }
-      delete m_head;
-      m_head = next;
-      m_length--;
-      if (m_length == 0) {
-        assert(m_head == NULL);
-        m_tail = m_head;
-      }
-      m_n_element--;
-      if (m_min_len && m_length < m_min_len) {
-        push(NULL);
-        m_n_element--;  // uncount NULL elements inserted to create delays
-      }
-    } else {
-      data = NULL;
-    }
-    return data;
-  }
+      m_tail->m_next = NULL;
+      m_tail->m_data = data;
+   }
 
-  T* top() const {
-    if (m_head) {
-      return m_head->m_data;
-    } else {
-      return NULL;
-    }
-  }
-
-  void set_min_length(unsigned int new_min_len) {
-    if (new_min_len == m_min_len) return;
-
-    if (new_min_len > m_min_len) {
-      m_min_len = new_min_len;
-      while (m_length < m_min_len) {
-        push(NULL);
-        m_n_element--;  // uncount NULL elements inserted to create delays
-      }
-    } else {
-      // in this branch imply that the original min_len is larger then 0
-      // ie. head != 0
-      assert(m_head);
-      m_min_len = new_min_len;
-      while ((m_length > m_min_len) && (m_tail->m_data == 0)) {
-        fifo_data<T>* iter;
-        iter = m_head;
-        while (iter && (iter->m_next != m_tail)) iter = iter->m_next;
-        if (!iter) {
-          // there is only one node, and that node is empty
-          assert(m_head->m_data == 0);
-          pop();
-        } else {
-          // there are more than one node, and tail node is empty
-          assert(iter->m_next == m_tail);
-          delete m_tail;
-          m_tail = iter;
-          m_tail->m_next = 0;
-          m_length--;
+   T* pop() 
+   {
+      fifo_data<T>* next;
+      T* data;
+      if (m_head) {
+        next = m_head->m_next;
+        data = m_head->m_data;
+        if ( m_head == m_tail ) {
+           assert( next == NULL );
+           m_tail = NULL;     
         }
+        delete m_head;
+        m_head = next;
+        m_length--;
+        if (m_length == 0) {
+           assert( m_head == NULL );
+           m_tail = m_head;
+        }
+        m_n_element--; 
+         if (m_min_len && m_length < m_min_len) {
+            push(NULL);
+            m_n_element--; // uncount NULL elements inserted to create delays
+         }
+      } else {
+         data = NULL;
       }
-    }
-  }
+      return data;
+   }
 
-  bool full() const { return (m_max_len && m_length >= m_max_len); }
-  bool is_avilable_size(unsigned size) const {
-    return (m_max_len && m_length + size - 1 >= m_max_len);
-  }
-  bool empty() const { return m_head == NULL; }
-  unsigned get_n_element() const { return m_n_element; }
-  unsigned get_length() const { return m_length; }
-  unsigned get_max_len() const { return m_max_len; }
+   T* top() const
+   {
+      if (m_head) {
+         return m_head->m_data;
+      } else {
+         return NULL;
+      }
+   }
 
-  void print() const {
-    fifo_data<T>* ddp = m_head;
-    printf("%s(%d): ", m_name, m_length);
-    while (ddp) {
-      printf("%p ", ddp->m_data);
-      ddp = ddp->m_next;
-    }
-    printf("\n");
-  }
+   void set_min_length(unsigned int new_min_len) 
+   {
+      if (new_min_len == m_min_len) return;
+   
+      if (new_min_len > m_min_len) {
+         m_min_len = new_min_len;
+         while (m_length < m_min_len) {
+            push(NULL);
+            m_n_element--; // uncount NULL elements inserted to create delays
+         }
+      } else {
+         // in this branch imply that the original min_len is larger then 0
+         // ie. head != 0
+         assert(m_head);
+         m_min_len = new_min_len;
+         while ((m_length > m_min_len) && (m_tail->m_data == 0)) {
+            fifo_data<T> *iter;
+            iter = m_head;
+            while (iter && (iter->m_next != m_tail))
+               iter = iter->m_next;
+            if (!iter) {
+               // there is only one node, and that node is empty
+               assert(m_head->m_data == 0);
+               pop();
+            } else {
+               // there are more than one node, and tail node is empty
+               assert(iter->m_next == m_tail);
+               delete m_tail;
+               m_tail = iter;
+               m_tail->m_next = 0;
+               m_length--;
+            }
+         }
+      }
+   }
 
- private:
-  const char* m_name;
+   bool full() const { return (m_max_len && m_length >= m_max_len); }
+   bool is_avilable_size(unsigned size) const { return (m_max_len && m_length+size-1 >= m_max_len); }
+   bool empty() const { return m_head == NULL; }
+   unsigned get_n_element() const { return m_n_element; }
+   unsigned get_length() const { return m_length; }
+   unsigned get_max_len() const { return m_max_len; }
 
-  unsigned int m_min_len;
-  unsigned int m_max_len;
-  unsigned int m_length;
-  unsigned int m_n_element;
+   void print() const
+   {
+      fifo_data<T>* ddp = m_head;
+      printf("%s(%d): ", m_name, m_length);
+      while (ddp) {
+         printf("%p ", ddp->m_data);
+         ddp = ddp->m_next;
+      }
+      printf("\n");
+   }
 
-  fifo_data<T>* m_head;
-  fifo_data<T>* m_tail;
+private:
+   const char* m_name;
+
+   unsigned int m_min_len;
+   unsigned int m_max_len;
+   unsigned int m_length;
+   unsigned int m_n_element;
+
+   fifo_data<T> *m_head;
+   fifo_data<T> *m_tail;
 };
 
 #endif

--- a/src/gpgpu-sim/dram.cc
+++ b/src/gpgpu-sim/dram.cc
@@ -8,16 +8,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -28,13 +26,13 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "dram.h"
-#include "dram_sched.h"
-#include "gpu-misc.h"
 #include "gpu-sim.h"
-#include "l2cache.h"
-#include "mem_fetch.h"
+#include "gpu-misc.h"
+#include "dram.h"
 #include "mem_latency_stat.h"
+#include "dram_sched.h"
+#include "mem_fetch.h"
+#include "l2cache.h"
 
 #ifdef DRAM_VERIFY
 int PRINT_CYCLE = 0;
@@ -43,828 +41,869 @@ int PRINT_CYCLE = 0;
 template class fifo_pipeline<mem_fetch>;
 template class fifo_pipeline<dram_req_t>;
 
-dram_t::dram_t(unsigned int partition_id, const memory_config *config,
-               memory_stats_t *stats, memory_partition_unit *mp,
-               gpgpu_sim *gpu) {
-  id = partition_id;
-  m_memory_partition_unit = mp;
-  m_stats = stats;
-  m_config = config;
-  m_gpu = gpu;
+dram_t::dram_t( unsigned int partition_id, const memory_config *config, memory_stats_t *stats,
+                memory_partition_unit *mp, gpgpu_sim* gpu )
+{
+   id = partition_id;
+   m_memory_partition_unit = mp;
+   m_stats = stats;
+   m_config = config;
+   m_gpu = gpu;
 
-  // rowblp
-  access_num = 0;
-  hits_num = 0;
-  read_num = 0;
-  write_num = 0;
-  hits_read_num = 0;
-  hits_write_num = 0;
-  banks_1time = 0;
-  banks_acess_total = 0;
-  banks_acess_total_after = 0;
-  banks_time_ready = 0;
-  banks_access_ready_total = 0;
-  issued_two = 0;
-  issued_total = 0;
-  issued_total_row = 0;
-  issued_total_col = 0;
+   //rowblp
+   access_num=0;
+   hits_num=0;
+   read_num=0;
+   write_num=0;
+   hits_read_num=0;
+   hits_write_num=0;
+   banks_1time=0;
+   banks_acess_total=0;
+   banks_acess_total_after=0;
+   banks_time_ready=0;
+   banks_access_ready_total=0;
+   issued_two=0;
+   issued_total=0;
+   issued_total_row=0;
+   issued_total_col=0;
 
-  CCDc = 0;
-  RRDc = 0;
-  RTWc = 0;
-  WTRc = 0;
+   CCDc = 0;
+   RRDc = 0;
+   RTWc = 0;
+   WTRc = 0;
 
-  wasted_bw_row = 0;
-  wasted_bw_col = 0;
-  util_bw = 0;
-  idle_bw = 0;
-  RCDc_limit = 0;
-  CCDLc_limit = 0;
-  CCDLc_limit_alone = 0;
-  CCDc_limit = 0;
-  WTRc_limit = 0;
-  WTRc_limit_alone = 0;
-  RCDWRc_limit = 0;
-  RTWc_limit = 0;
-  RTWc_limit_alone = 0;
-  rwq_limit = 0;
-  write_to_read_ratio_blp_rw_average = 0;
-  bkgrp_parallsim_rw = 0;
+   wasted_bw_row=0;
+   wasted_bw_col=0;
+   util_bw=0;
+   idle_bw=0;
+   RCDc_limit=0;
+   CCDLc_limit=0;
+   CCDLc_limit_alone=0;
+   CCDc_limit=0;
+   WTRc_limit=0;
+   WTRc_limit_alone=0;
+   RCDWRc_limit=0;
+   RTWc_limit=0;
+   RTWc_limit_alone=0;
+   rwq_limit=0;
+   write_to_read_ratio_blp_rw_average=0;
+   bkgrp_parallsim_rw=0;
 
-  rw = READ;  // read mode is default
+   rw = READ; //read mode is default
 
-  bkgrp = (bankgrp_t **)calloc(sizeof(bankgrp_t *), m_config->nbkgrp);
-  bkgrp[0] = (bankgrp_t *)calloc(sizeof(bank_t), m_config->nbkgrp);
-  for (unsigned i = 1; i < m_config->nbkgrp; i++) {
-    bkgrp[i] = bkgrp[0] + i;
-  }
-  for (unsigned i = 0; i < m_config->nbkgrp; i++) {
-    bkgrp[i]->CCDLc = 0;
-    bkgrp[i]->RTPLc = 0;
-  }
+	bkgrp = (bankgrp_t**) calloc(sizeof(bankgrp_t*), m_config->nbkgrp);
+	bkgrp[0] = (bankgrp_t*) calloc(sizeof(bank_t), m_config->nbkgrp);
+	for (unsigned i=1; i<m_config->nbkgrp; i++) {
+		bkgrp[i] = bkgrp[0] + i;
+	}
+	for (unsigned i=0; i<m_config->nbkgrp; i++) {
+		bkgrp[i]->CCDLc = 0;
+		bkgrp[i]->RTPLc = 0;
+	}
 
-  bk = (bank_t **)calloc(sizeof(bank_t *), m_config->nbk);
-  bk[0] = (bank_t *)calloc(sizeof(bank_t), m_config->nbk);
-  for (unsigned i = 1; i < m_config->nbk; i++) bk[i] = bk[0] + i;
-  for (unsigned i = 0; i < m_config->nbk; i++) {
-    bk[i]->state = BANK_IDLE;
-    bk[i]->bkgrpindex = i / (m_config->nbk / m_config->nbkgrp);
-  }
-  prio = 0;
+   bk = (bank_t**) calloc(sizeof(bank_t*),m_config->nbk);
+   bk[0] = (bank_t*) calloc(sizeof(bank_t),m_config->nbk);
+   for (unsigned i=1;i<m_config->nbk;i++) 
+      bk[i] = bk[0] + i;
+   for (unsigned i=0;i<m_config->nbk;i++) {
+      bk[i]->state = BANK_IDLE;
+      bk[i]->bkgrpindex = i/(m_config->nbk/m_config->nbkgrp);
+   }
+   prio = 0;
 
-  rwq = new fifo_pipeline<dram_req_t>("rwq", m_config->CL, m_config->CL + 1);
-  mrqq = new fifo_pipeline<dram_req_t>("mrqq", 0, 2);
-  returnq = new fifo_pipeline<mem_fetch>(
-      "dramreturnq", 0, m_config->gpgpu_dram_return_queue_size == 0
-                            ? 1024
-                            : m_config->gpgpu_dram_return_queue_size);
-  m_frfcfs_scheduler = NULL;
-  if (m_config->scheduler_type == DRAM_FRFCFS)
-    m_frfcfs_scheduler = new frfcfs_scheduler(m_config, this, stats);
-  n_cmd = 0;
-  n_activity = 0;
-  n_nop = 0;
-  n_act = 0;
-  n_pre = 0;
-  n_rd = 0;
-  n_wr = 0;
-  n_wr_WB = 0;
-  n_rd_L2_A = 0;
-  n_req = 0;
-  max_mrqs_temp = 0;
-  bwutil = 0;
-  max_mrqs = 0;
-  ave_mrqs = 0;
+   rwq = new fifo_pipeline<dram_req_t>("rwq",m_config->CL,m_config->CL+1);
+   mrqq = new fifo_pipeline<dram_req_t>("mrqq",0,2);
+   returnq = new fifo_pipeline<mem_fetch>("dramreturnq",0,m_config->gpgpu_dram_return_queue_size==0?1024:m_config->gpgpu_dram_return_queue_size); 
+   m_frfcfs_scheduler = NULL;
+   if ( m_config->scheduler_type == DRAM_FRFCFS)
+      m_frfcfs_scheduler = new frfcfs_scheduler(m_config,this,stats);
+   n_cmd = 0;
+   n_activity = 0;
+   n_nop = 0; 
+   n_act = 0; 
+   n_pre = 0; 
+   n_rd = 0;
+   n_wr = 0;
+   n_wr_WB=0;
+   n_rd_L2_A=0;
+   n_req = 0;
+   max_mrqs_temp = 0;
+   bwutil = 0;
+   max_mrqs = 0;
+   ave_mrqs = 0;
 
-  for (unsigned i = 0; i < 10; i++) {
-    dram_util_bins[i] = 0;
-    dram_eff_bins[i] = 0;
-  }
-  last_n_cmd = last_n_activity = last_bwutil = 0;
+   for (unsigned i=0;i<10;i++) {
+      dram_util_bins[i]=0;
+      dram_eff_bins[i]=0;
+   }
+   last_n_cmd = last_n_activity = last_bwutil = 0;
 
-  n_cmd_partial = 0;
-  n_activity_partial = 0;
-  n_nop_partial = 0;
-  n_act_partial = 0;
-  n_pre_partial = 0;
-  n_req_partial = 0;
-  ave_mrqs_partial = 0;
-  bwutil_partial = 0;
+   n_cmd_partial = 0;
+   n_activity_partial = 0;
+   n_nop_partial = 0;  
+   n_act_partial = 0;  
+   n_pre_partial = 0;  
+   n_req_partial = 0;
+   ave_mrqs_partial = 0;
+   bwutil_partial = 0;
 
-  if (queue_limit())
-    mrqq_Dist = StatCreate("mrqq_length", 1, queue_limit());
-  else                                             // queue length is unlimited;
-    mrqq_Dist = StatCreate("mrqq_length", 1, 64);  // track up to 64 entries
+   if ( queue_limit() )
+      mrqq_Dist = StatCreate("mrqq_length",1, queue_limit());
+   else //queue length is unlimited; 
+      mrqq_Dist = StatCreate("mrqq_length",1,64); //track up to 64 entries
+
 }
 
-bool dram_t::full(bool is_write) const {
-  if (m_config->scheduler_type == DRAM_FRFCFS) {
-    if (m_config->gpgpu_frfcfs_dram_sched_queue_size == 0) return false;
-    if (m_config->seperate_write_queue_enabled) {
-      if (is_write)
-        return m_frfcfs_scheduler->num_write_pending() >=
-               m_config->gpgpu_frfcfs_dram_write_queue_size;
-      else
-        return m_frfcfs_scheduler->num_pending() >=
-               m_config->gpgpu_frfcfs_dram_sched_queue_size;
-    } else
-      return m_frfcfs_scheduler->num_pending() >=
-             m_config->gpgpu_frfcfs_dram_sched_queue_size;
-  } else
-    return mrqq->full();
-}
-
-unsigned dram_t::que_length() const {
-  unsigned nreqs = 0;
-  if (m_config->scheduler_type == DRAM_FRFCFS) {
-    nreqs = m_frfcfs_scheduler->num_pending();
-  } else {
-    nreqs = mrqq->get_length();
-  }
-  return nreqs;
-}
-
-bool dram_t::returnq_full() const { return returnq->full(); }
-
-unsigned int dram_t::queue_limit() const {
-  return m_config->gpgpu_frfcfs_dram_sched_queue_size;
-}
-
-dram_req_t::dram_req_t(class mem_fetch *mf, unsigned banks,
-                       unsigned dram_bnk_indexing_policy,
-                       class gpgpu_sim *gpu) {
-  txbytes = 0;
-  dqbytes = 0;
-  data = mf;
-  m_gpu = gpu;
-
-  const addrdec_t &tlx = mf->get_tlx_addr();
-
-  switch (dram_bnk_indexing_policy) {
-    case LINEAR_BK_INDEX: {
-      bk = tlx.bk;
-      break;
-    }
-    case BITWISE_XORING_BK_INDEX: {
-      // xoring bank bits with lower bits of the page
-      int lbank = log2(banks);
-      bk = tlx.bk ^ (tlx.row & ((1 << lbank) - 1));
-      break;
-    }
-    case CUSTOM_BK_INDEX:
-      /* No custom set function implemented */
-      // Do you custom index here
-      break;
-    default:
-      assert("\nUndefined bank index function.\n" && 0);
-      break;
-  }
-
-  row = tlx.row;
-  col = tlx.col;
-  nbytes = mf->get_data_size();
-
-  timestamp = m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle;
-  addr = mf->get_addr();
-  insertion_time = (unsigned)m_gpu->gpu_sim_cycle;
-  rw = data->get_is_write() ? WRITE : READ;
-}
-
-void dram_t::push(class mem_fetch *data) {
-  assert(id ==
-         data->get_tlx_addr()
-             .chip);  // Ensure request is in correct memory partition
-
-  dram_req_t *mrq =
-      new dram_req_t(data, m_config->nbk, m_config->dram_bnk_indexing_policy,
-                     m_memory_partition_unit->get_mgpu());
-
-  data->set_status(IN_PARTITION_MC_INTERFACE_QUEUE,
-                   m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-  mrqq->push(mrq);
-
-  // stats...
-  n_req += 1;
-  n_req_partial += 1;
-  if (m_config->scheduler_type == DRAM_FRFCFS) {
-    unsigned nreqs = m_frfcfs_scheduler->num_pending();
-    if (nreqs > max_mrqs_temp) max_mrqs_temp = nreqs;
-  } else {
-    max_mrqs_temp = (max_mrqs_temp > mrqq->get_length()) ? max_mrqs_temp
-                                                         : mrqq->get_length();
-  }
-  m_stats->memlatstat_dram_access(data);
-}
-
-void dram_t::scheduler_fifo() {
-  if (!mrqq->empty()) {
-    unsigned int bkn;
-    dram_req_t *head_mrqq = mrqq->top();
-    head_mrqq->data->set_status(
-        IN_PARTITION_MC_BANK_ARB_QUEUE,
-        m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-    bkn = head_mrqq->bk;
-    if (!bk[bkn]->mrq) bk[bkn]->mrq = mrqq->pop();
-  }
-}
-
-#define DEC2ZERO(x) x = (x) ? (x - 1) : 0;
-#define SWAP(a, b) \
-  a ^= b;          \
-  b ^= a;          \
-  a ^= b;
-
-void dram_t::cycle() {
-  if (!returnq->full()) {
-    dram_req_t *cmd = rwq->pop();
-    if (cmd) {
-#ifdef DRAM_VIEWCMD
-      printf("\tDQ: BK%d Row:%03x Col:%03x", cmd->bk, cmd->row,
-             cmd->col + cmd->dqbytes);
-#endif
-      cmd->dqbytes += m_config->dram_atom_size;
-
-      if (cmd->dqbytes >= cmd->nbytes) {
-        mem_fetch *data = cmd->data;
-        data->set_status(IN_PARTITION_MC_RETURNQ,
-                         m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-        if (data->get_access_type() != L1_WRBK_ACC &&
-            data->get_access_type() != L2_WRBK_ACC) {
-          data->set_reply();
-          returnq->push(data);
-        } else {
-          m_memory_partition_unit->set_done(data);
-          delete data;
+bool dram_t::full(bool is_write) const
+{
+    if(m_config->scheduler_type == DRAM_FRFCFS){
+        if(m_config->gpgpu_frfcfs_dram_sched_queue_size == 0 ) return false;
+        if(m_config->seperate_write_queue_enabled){
+        	if(is_write)
+        		return m_frfcfs_scheduler->num_write_pending() >= m_config->gpgpu_frfcfs_dram_write_queue_size;
+        	else
+        		return m_frfcfs_scheduler->num_pending() >= m_config->gpgpu_frfcfs_dram_sched_queue_size;
         }
-        delete cmd;
-      }
-#ifdef DRAM_VIEWCMD
-      printf("\n");
+        else
+        	return m_frfcfs_scheduler->num_pending() >= m_config->gpgpu_frfcfs_dram_sched_queue_size;
+    }
+   else return mrqq->full();
+}
+
+unsigned dram_t::que_length() const
+{
+   unsigned nreqs = 0;
+   if (m_config->scheduler_type == DRAM_FRFCFS) {
+      nreqs = m_frfcfs_scheduler->num_pending();
+   } else {
+      nreqs = mrqq->get_length();
+   }
+   return nreqs;
+}
+
+bool dram_t::returnq_full() const
+{
+   return returnq->full();
+}
+
+unsigned int dram_t::queue_limit() const 
+{ 
+   return m_config->gpgpu_frfcfs_dram_sched_queue_size; 
+}
+
+
+dram_req_t::dram_req_t( class mem_fetch *mf, unsigned banks, unsigned dram_bnk_indexing_policy, class gpgpu_sim* gpu)
+{
+   txbytes = 0;
+   dqbytes = 0;
+   data = mf;
+   m_gpu = gpu;
+
+   const addrdec_t &tlx = mf->get_tlx_addr();
+
+    switch(dram_bnk_indexing_policy){
+		case LINEAR_BK_INDEX:
+		{
+			bk = tlx.bk;
+			break;
+		}
+		case BITWISE_XORING_BK_INDEX:
+		{
+			//xoring bank bits with lower bits of the page
+			int lbank = log2(banks);
+			bk  = tlx.bk ^ (tlx.row & ((1<<lbank)-1));
+			break;
+		}
+		case CUSTOM_BK_INDEX:
+	        /* No custom set function implemented */
+			//Do you custom index here
+			break;
+		default:
+			 assert("\nUndefined bank index function.\n" && 0);
+			 break;
+	}
+
+
+   row = tlx.row; 
+   col = tlx.col; 
+   nbytes = mf->get_data_size();
+
+   timestamp = m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle;
+   addr = mf->get_addr();
+   insertion_time = (unsigned) m_gpu->gpu_sim_cycle;
+   rw = data->get_is_write()?WRITE:READ;
+}
+
+void dram_t::push( class mem_fetch *data ) 
+{
+   assert(id == data->get_tlx_addr().chip); // Ensure request is in correct memory partition
+
+   dram_req_t *mrq = new dram_req_t(data,m_config->nbk,m_config->dram_bnk_indexing_policy,m_memory_partition_unit->get_mgpu());
+
+   data->set_status(IN_PARTITION_MC_INTERFACE_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
+	   mrqq->push(mrq);
+
+   // stats...
+   n_req += 1;
+   n_req_partial += 1;
+   if ( m_config->scheduler_type == DRAM_FRFCFS) {
+      unsigned nreqs = m_frfcfs_scheduler->num_pending();
+      if ( nreqs > max_mrqs_temp)
+         max_mrqs_temp = nreqs;
+   } else {
+      max_mrqs_temp = (max_mrqs_temp > mrqq->get_length())? max_mrqs_temp : mrqq->get_length();
+   }
+   m_stats->memlatstat_dram_access(data);
+}
+
+void dram_t::scheduler_fifo()
+{
+   if (!mrqq->empty()) {
+      unsigned int bkn;
+      dram_req_t *head_mrqq = mrqq->top();
+      head_mrqq->data->set_status(IN_PARTITION_MC_BANK_ARB_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
+      bkn = head_mrqq->bk;
+      if (!bk[bkn]->mrq) 
+         bk[bkn]->mrq = mrqq->pop();
+   }
+}
+
+
+#define DEC2ZERO(x) x = (x)? (x-1) : 0;
+#define SWAP(a,b) a ^= b; b ^= a; a ^= b;
+
+void dram_t::cycle()
+{
+
+   if( !returnq->full() ) {
+       dram_req_t *cmd = rwq->pop();
+       if( cmd ) {
+#ifdef DRAM_VIEWCMD 
+           printf("\tDQ: BK%d Row:%03x Col:%03x", cmd->bk, cmd->row, cmd->col + cmd->dqbytes);
 #endif
-    }
-  }
+           cmd->dqbytes += m_config->dram_atom_size; 
 
-  /* check if the upcoming request is on an idle bank */
-  /* Should we modify this so that multiple requests are checked? */
-
-  switch (m_config->scheduler_type) {
-    case DRAM_FIFO:
-      scheduler_fifo();
-      break;
-    case DRAM_FRFCFS:
-      scheduler_frfcfs();
-      break;
-    default:
-      printf("Error: Unknown DRAM scheduler type\n");
-      assert(0);
-  }
-  if (m_config->scheduler_type == DRAM_FRFCFS) {
-    unsigned nreqs = m_frfcfs_scheduler->num_pending();
-    if (nreqs > max_mrqs) {
-      max_mrqs = nreqs;
-    }
-    ave_mrqs += nreqs;
-    ave_mrqs_partial += nreqs;
-  } else {
-    if (mrqq->get_length() > max_mrqs) {
-      max_mrqs = mrqq->get_length();
-    }
-    ave_mrqs += mrqq->get_length();
-    ave_mrqs_partial += mrqq->get_length();
-  }
-
-  unsigned k = m_config->nbk;
-  bool issued = false;
-
-  // collect row buffer locality, BLP and other statistics
-  /////////////////////////////////////////////////////////////////////////
-  unsigned int memory_pending = 0;
-  for (unsigned i = 0; i < m_config->nbk; i++) {
-    if (bk[i]->mrq) memory_pending++;
-  }
-  banks_1time += memory_pending;
-  if (memory_pending > 0) banks_acess_total++;
-
-  unsigned int memory_pending_rw = 0;
-  unsigned read_blp_rw = 0;
-  unsigned write_blp_rw = 0;
-  std::bitset<8> bnkgrp_rw_found;  // assume max we have 8 bank groups
-
-  for (unsigned j = 0; j < m_config->nbk; j++) {
-    unsigned grp = get_bankgrp_number(j);
-    if (bk[j]->mrq &&
-        (((bk[j]->curr_row == bk[j]->mrq->row) && (bk[j]->mrq->rw == READ) &&
-          (bk[j]->state == BANK_ACTIVE)))) {
-      memory_pending_rw++;
-      read_blp_rw++;
-      bnkgrp_rw_found.set(grp);
-    } else if (bk[j]->mrq &&
-               (((bk[j]->curr_row == bk[j]->mrq->row) &&
-                 (bk[j]->mrq->rw == WRITE) && (bk[j]->state == BANK_ACTIVE)))) {
-      memory_pending_rw++;
-      write_blp_rw++;
-      bnkgrp_rw_found.set(grp);
-    }
-  }
-  banks_time_rw += memory_pending_rw;
-  bkgrp_parallsim_rw += bnkgrp_rw_found.count();
-  if (memory_pending_rw > 0) {
-    write_to_read_ratio_blp_rw_average +=
-        (double)write_blp_rw / (write_blp_rw + read_blp_rw);
-    banks_access_rw_total++;
-  }
-
-  unsigned int memory_Pending_ready = 0;
-  for (unsigned j = 0; j < m_config->nbk; j++) {
-    unsigned grp = get_bankgrp_number(j);
-    if (bk[j]->mrq &&
-        ((!CCDc && !bk[j]->RCDc && !(bkgrp[grp]->CCDLc) &&
-          (bk[j]->curr_row == bk[j]->mrq->row) && (bk[j]->mrq->rw == READ) &&
-          (WTRc == 0) && (bk[j]->state == BANK_ACTIVE) && !rwq->full()) ||
-         (!CCDc && !bk[j]->RCDWRc && !(bkgrp[grp]->CCDLc) &&
-          (bk[j]->curr_row == bk[j]->mrq->row) && (bk[j]->mrq->rw == WRITE) &&
-          (RTWc == 0) && (bk[j]->state == BANK_ACTIVE) && !rwq->full()))) {
-      memory_Pending_ready++;
-    }
-  }
-  banks_time_ready += memory_Pending_ready;
-  if (memory_Pending_ready > 0) banks_access_ready_total++;
-  ///////////////////////////////////////////////////////////////////////////////////
-
-  bool issued_col_cmd = false;
-  bool issued_row_cmd = false;
-
-  if (m_config->dual_bus_interface) {
-    // dual bus interface
-    // issue one row command and one column command
-    for (unsigned i = 0; i < m_config->nbk; i++) {
-      unsigned j = (i + prio) % m_config->nbk;
-      issued_col_cmd = issue_col_command(j);
-      if (issued_col_cmd) break;
-    }
-    for (unsigned i = 0; i < m_config->nbk; i++) {
-      unsigned j = (i + prio) % m_config->nbk;
-      issued_row_cmd = issue_row_command(j);
-      if (issued_row_cmd) break;
-    }
-    for (unsigned i = 0; i < m_config->nbk; i++) {
-      unsigned j = (i + prio) % m_config->nbk;
-      if (!bk[j]->mrq) {
-        if (!CCDc && !RRDc && !RTWc && !WTRc && !bk[j]->RCDc && !bk[j]->RASc &&
-            !bk[j]->RCc && !bk[j]->RPc && !bk[j]->RCDWRc)
-          k--;
-        bk[j]->n_idle++;
-      }
-    }
-  } else {
-    // single bus interface
-    // issue only one row/column command
-    for (unsigned i = 0; i < m_config->nbk; i++) {
-      unsigned j = (i + prio) % m_config->nbk;
-      if (!issued_col_cmd) issued_col_cmd = issue_col_command(j);
-
-      if (!issued_col_cmd && !issued_row_cmd)
-        issued_row_cmd = issue_row_command(j);
-
-      if (!bk[j]->mrq) {
-        if (!CCDc && !RRDc && !RTWc && !WTRc && !bk[j]->RCDc && !bk[j]->RASc &&
-            !bk[j]->RCc && !bk[j]->RPc && !bk[j]->RCDWRc)
-          k--;
-        bk[j]->n_idle++;
-      }
-    }
-  }
-
-  issued = issued_row_cmd || issued_col_cmd;
-  if (!issued) {
-    n_nop++;
-    n_nop_partial++;
-#ifdef DRAM_VIEWCMD
-    printf("\tNOP                        ");
+           if (cmd->dqbytes >= cmd->nbytes) {
+              mem_fetch *data = cmd->data; 
+              data->set_status(IN_PARTITION_MC_RETURNQ,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
+              if( data->get_access_type() != L1_WRBK_ACC && data->get_access_type() != L2_WRBK_ACC ) {
+                 data->set_reply();
+                 returnq->push(data);
+              } else {
+                 m_memory_partition_unit->set_done(data);
+                 delete data;
+              }
+              delete cmd;
+           }
+#ifdef DRAM_VIEWCMD 
+           printf("\n");
 #endif
-  }
-  if (k) {
-    n_activity++;
-    n_activity_partial++;
-  }
-  n_cmd++;
-  n_cmd_partial++;
-  if (issued) {
-    issued_total++;
-    if (issued_col_cmd && issued_row_cmd) issued_two++;
-  }
-  if (issued_col_cmd) issued_total_col++;
-  if (issued_row_cmd) issued_total_row++;
+       }
+   }
 
-  // Collect some statistics
-  // check the limitation, see where BW is wasted?
-  /////////////////////////////////////////////////////////
-  unsigned int memory_pending_found = 0;
-  for (unsigned i = 0; i < m_config->nbk; i++) {
-    if (bk[i]->mrq) memory_pending_found++;
-  }
-  if (memory_pending_found > 0) banks_acess_total_after++;
+   /* check if the upcoming request is on an idle bank */
+   /* Should we modify this so that multiple requests are checked? */
 
-  bool memory_pending_rw_found = false;
-  for (unsigned j = 0; j < m_config->nbk; j++) {
-    if (bk[j]->mrq &&
-        (((bk[j]->curr_row == bk[j]->mrq->row) && (bk[j]->mrq->rw == READ) &&
-          (bk[j]->state == BANK_ACTIVE)) ||
-         ((bk[j]->curr_row == bk[j]->mrq->row) && (bk[j]->mrq->rw == WRITE) &&
-          (bk[j]->state == BANK_ACTIVE))))
-      memory_pending_rw_found = true;
-  }
-
-  if (issued_col_cmd || CCDc)
-    util_bw++;
-  else if (memory_pending_rw_found) {
-    wasted_bw_col++;
-    for (unsigned j = 0; j < m_config->nbk; j++) {
-      unsigned grp = get_bankgrp_number(j);
-      // read
-      if (bk[j]->mrq &&
-          (((bk[j]->curr_row == bk[j]->mrq->row) && (bk[j]->mrq->rw == READ) &&
-            (bk[j]->state == BANK_ACTIVE)))) {
-        if (bk[j]->RCDc) RCDc_limit++;
-        if (bkgrp[grp]->CCDLc) CCDLc_limit++;
-        if (WTRc) WTRc_limit++;
-        if (CCDc) CCDc_limit++;
-        if (rwq->full()) rwq_limit++;
-        if (bkgrp[grp]->CCDLc && !WTRc) CCDLc_limit_alone++;
-        if (!bkgrp[grp]->CCDLc && WTRc) WTRc_limit_alone++;
+   switch (m_config->scheduler_type) {
+   case DRAM_FIFO: scheduler_fifo(); break;
+   case DRAM_FRFCFS: scheduler_frfcfs(); break;
+	default:
+		printf("Error: Unknown DRAM scheduler type\n");
+		assert(0);
+   }
+   if ( m_config->scheduler_type == DRAM_FRFCFS) {
+      unsigned nreqs = m_frfcfs_scheduler->num_pending();
+      if ( nreqs > max_mrqs) {
+         max_mrqs = nreqs;
       }
-      // write
-      else if (bk[j]->mrq &&
-               ((bk[j]->curr_row == bk[j]->mrq->row) &&
-                (bk[j]->mrq->rw == WRITE) && (bk[j]->state == BANK_ACTIVE))) {
-        if (bk[j]->RCDWRc) RCDWRc_limit++;
-        if (bkgrp[grp]->CCDLc) CCDLc_limit++;
-        if (RTWc) RTWc_limit++;
-        if (CCDc) CCDc_limit++;
-        if (rwq->full()) rwq_limit++;
-        if (bkgrp[grp]->CCDLc && !RTWc) CCDLc_limit_alone++;
-        if (!bkgrp[grp]->CCDLc && RTWc) RTWc_limit_alone++;
+      ave_mrqs += nreqs;
+      ave_mrqs_partial += nreqs;
+   } else {
+      if (mrqq->get_length() > max_mrqs) {
+         max_mrqs = mrqq->get_length();
       }
-    }
-  } else if (memory_pending_found)
-    wasted_bw_row++;
-  else if (!memory_pending_found)
-    idle_bw++;
-  else
-    assert(1);
+      ave_mrqs += mrqq->get_length();
+      ave_mrqs_partial +=  mrqq->get_length();
+   }
 
-  /////////////////////////////////////////////////////////
+   unsigned k=m_config->nbk;
+   bool issued = false;
 
-  // decrements counters once for each time dram_issueCMD is called
-  DEC2ZERO(RRDc);
-  DEC2ZERO(CCDc);
-  DEC2ZERO(RTWc);
-  DEC2ZERO(WTRc);
-  for (unsigned j = 0; j < m_config->nbk; j++) {
-    DEC2ZERO(bk[j]->RCDc);
-    DEC2ZERO(bk[j]->RASc);
-    DEC2ZERO(bk[j]->RCc);
-    DEC2ZERO(bk[j]->RPc);
-    DEC2ZERO(bk[j]->RCDWRc);
-    DEC2ZERO(bk[j]->WTPc);
-    DEC2ZERO(bk[j]->RTPc);
-  }
-  for (unsigned j = 0; j < m_config->nbkgrp; j++) {
-    DEC2ZERO(bkgrp[j]->CCDLc);
-    DEC2ZERO(bkgrp[j]->RTPLc);
-  }
+   //collect row buffer locality, BLP and other statistics
+   /////////////////////////////////////////////////////////////////////////
+   unsigned int memory_pending=0;
+   for (unsigned i=0;i<m_config->nbk;i++) {
+	   if (bk[i]->mrq)
+		   memory_pending++;
+   }
+   banks_1time += memory_pending;
+   if(memory_pending >0)
+	   banks_acess_total++;
+
+   unsigned int memory_pending_rw=0;
+   unsigned read_blp_rw=0;
+   unsigned write_blp_rw=0;
+   std::bitset<8> bnkgrp_rw_found;  //assume max we have 8 bank groups
+
+   for (unsigned j=0;j<m_config->nbk;j++) {
+  	   unsigned grp = get_bankgrp_number(j);
+  	   if (bk[j]->mrq && (((bk[j]->curr_row == bk[j]->mrq->row) &&
+  		  (bk[j]->mrq->rw == READ)  &&
+  		  (bk[j]->state == BANK_ACTIVE))))
+  	   {
+  		    memory_pending_rw++;
+  		    read_blp_rw++;
+  		    bnkgrp_rw_found.set(grp);
+  	   }
+  	   else if
+  	        (bk[j]->mrq && (((bk[j]->curr_row == bk[j]->mrq->row)  &&
+  			 (bk[j]->mrq->rw == WRITE) &&
+  			 (bk[j]->state == BANK_ACTIVE))))
+  	   {
+  		     memory_pending_rw++;
+  		     write_blp_rw++;
+  		     bnkgrp_rw_found.set(grp);
+  	   }
+     }
+     banks_time_rw += memory_pending_rw;
+     bkgrp_parallsim_rw += bnkgrp_rw_found.count();
+     if(memory_pending_rw >0)
+     {
+    	 write_to_read_ratio_blp_rw_average += (double)write_blp_rw/(write_blp_rw+read_blp_rw);
+  	     banks_access_rw_total++;
+     }
+
+   unsigned int memory_Pending_ready=0;
+   for (unsigned j=0;j<m_config->nbk;j++) {
+	   unsigned grp = get_bankgrp_number(j);
+	   if (bk[j]->mrq && ((!CCDc && !bk[j]->RCDc &&
+		  !(bkgrp[grp]->CCDLc) &&
+		  (bk[j]->curr_row == bk[j]->mrq->row) &&
+		  (bk[j]->mrq->rw == READ) && (WTRc == 0 )  &&
+		  (bk[j]->state == BANK_ACTIVE) &&
+		  !rwq->full())
+		   ||
+		   (!CCDc && !bk[j]->RCDWRc &&
+			 !(bkgrp[grp]->CCDLc) &&
+			 (bk[j]->curr_row == bk[j]->mrq->row)  &&
+			 (bk[j]->mrq->rw == WRITE) && (RTWc == 0 )  &&
+			 (bk[j]->state == BANK_ACTIVE) &&
+			 !rwq->full())))
+	   {
+		   memory_Pending_ready++;
+	   }
+   }
+   banks_time_ready += memory_Pending_ready;
+   if(memory_Pending_ready >0)
+	   banks_access_ready_total++;
+   ///////////////////////////////////////////////////////////////////////////////////
+
+   bool issued_col_cmd = false;
+   bool issued_row_cmd = false;
+
+   if(m_config->dual_bus_interface)
+   {
+	   //dual bus interface
+	   //issue one row command and one column command
+	     for (unsigned i=0;i<m_config->nbk;i++) {
+	       unsigned j = (i + prio) % m_config->nbk;
+	  	   issued_col_cmd  = issue_col_command(j);
+	  	   if(issued_col_cmd) break;
+	     }
+	     for (unsigned i=0;i<m_config->nbk;i++) {
+	    	unsigned j = (i + prio) % m_config->nbk;
+	  	    issued_row_cmd = issue_row_command(j);
+	  	    if(issued_row_cmd) break;
+	     }
+	     for (unsigned i=0;i<m_config->nbk;i++) {
+	    	 unsigned j = (i + prio) % m_config->nbk;
+	    	 if(!bk[j]->mrq) {
+				  if (!CCDc && !RRDc && !RTWc && !WTRc && !bk[j]->RCDc && !bk[j]->RASc
+					  && !bk[j]->RCc && !bk[j]->RPc  && !bk[j]->RCDWRc) k--;
+				  bk[j]->n_idle++;
+			}
+	     }
+   }
+   else
+   {
+	   //single bus interface
+	   //issue only one row/column command
+	   for (unsigned i=0;i<m_config->nbk;i++) {
+		   unsigned j = (i + prio) % m_config->nbk;
+		   if(!issued_col_cmd)
+		       issued_col_cmd  = issue_col_command(j);
+
+		   if(!issued_col_cmd && !issued_row_cmd)
+		       issued_row_cmd = issue_row_command(j);
+
+		   if(!bk[j]->mrq) {
+		          if (!CCDc && !RRDc && !RTWc && !WTRc && !bk[j]->RCDc && !bk[j]->RASc
+		              && !bk[j]->RCc && !bk[j]->RPc  && !bk[j]->RCDWRc) k--;
+		          bk[j]->n_idle++;
+		    }
+
+	   }
+   }
+
+   issued = issued_row_cmd || issued_col_cmd;
+   if (!issued) {
+      n_nop++;
+      n_nop_partial++;
+#ifdef DRAM_VIEWCMD
+      printf("\tNOP                        ");
+#endif
+   }
+   if (k) {
+      n_activity++;
+      n_activity_partial++;
+   }
+   n_cmd++;
+   n_cmd_partial++;
+   if(issued)
+   {
+	   issued_total++;
+	   if(issued_col_cmd && issued_row_cmd)
+		   issued_two++;
+   }
+   if(issued_col_cmd)  issued_total_col++;
+   if(issued_row_cmd)  issued_total_row++;
+
+
+   //Collect some statistics
+   //check the limitation, see where BW is wasted?
+   /////////////////////////////////////////////////////////
+   unsigned int memory_pending_found=0;
+      for (unsigned i=0;i<m_config->nbk;i++) {
+   	   if (bk[i]->mrq)
+   		memory_pending_found++;
+      }
+      if(memory_pending_found>0)
+    	  banks_acess_total_after++;
+
+        bool memory_pending_rw_found=false;
+        for (unsigned j=0;j<m_config->nbk;j++) {
+     	   if (bk[j]->mrq && (((bk[j]->curr_row == bk[j]->mrq->row) &&
+     		  (bk[j]->mrq->rw == READ)  &&
+     		  (bk[j]->state == BANK_ACTIVE))
+     		   ||
+     		   (
+     			 (bk[j]->curr_row == bk[j]->mrq->row)  &&
+     			 (bk[j]->mrq->rw == WRITE) &&
+     			 (bk[j]->state == BANK_ACTIVE))))
+     		  memory_pending_rw_found=true;
+        }
+
+
+   if(issued_col_cmd  || CCDc)
+	   util_bw++;
+   else if (memory_pending_rw_found)
+   {
+	   wasted_bw_col++;
+	   for (unsigned j=0;j<m_config->nbk;j++) {
+		   unsigned grp = get_bankgrp_number(j);
+		   //read
+		   if (bk[j]->mrq && (((bk[j]->curr_row == bk[j]->mrq->row) &&
+			  (bk[j]->mrq->rw == READ)  &&
+			  (bk[j]->state == BANK_ACTIVE))))
+		   {
+			   if(bk[j]->RCDc) RCDc_limit++;
+			   if(bkgrp[grp]->CCDLc) CCDLc_limit++;
+			   if(WTRc) WTRc_limit++;
+			   if(CCDc) CCDc_limit++;
+			   if(rwq->full()) rwq_limit++;
+			   if(bkgrp[grp]->CCDLc && !WTRc) CCDLc_limit_alone++;
+			   if(!bkgrp[grp]->CCDLc && WTRc) WTRc_limit_alone++;
+		   }
+		   //write
+		   else if (bk[j]->mrq && ((bk[j]->curr_row == bk[j]->mrq->row)  &&
+				 (bk[j]->mrq->rw == WRITE) &&
+				 (bk[j]->state == BANK_ACTIVE)))
+		   {
+			   if(bk[j]->RCDWRc) RCDWRc_limit++;
+			   if(bkgrp[grp]->CCDLc) CCDLc_limit++;
+			   if(RTWc) RTWc_limit++;
+			   if(CCDc) CCDc_limit++;
+			   if(rwq->full()) rwq_limit++;
+			   if(bkgrp[grp]->CCDLc && !RTWc) CCDLc_limit_alone++;
+			   if(!bkgrp[grp]->CCDLc && RTWc) RTWc_limit_alone++;
+		   }
+	     }
+   }
+   else if (memory_pending_found)
+	   wasted_bw_row++;
+   else if (!memory_pending_found)
+  	   idle_bw++;
+   else
+	   assert(1);
+
+   /////////////////////////////////////////////////////////
+
+   // decrements counters once for each time dram_issueCMD is called
+   DEC2ZERO(RRDc);
+   DEC2ZERO(CCDc);
+   DEC2ZERO(RTWc);
+   DEC2ZERO(WTRc);
+   for (unsigned j=0;j<m_config->nbk;j++) {
+      DEC2ZERO(bk[j]->RCDc);
+      DEC2ZERO(bk[j]->RASc);
+      DEC2ZERO(bk[j]->RCc);
+      DEC2ZERO(bk[j]->RPc);
+      DEC2ZERO(bk[j]->RCDWRc);
+      DEC2ZERO(bk[j]->WTPc);
+      DEC2ZERO(bk[j]->RTPc);
+   }
+   for (unsigned j=0; j<m_config->nbkgrp; j++) {
+	   DEC2ZERO(bkgrp[j]->CCDLc);
+	   DEC2ZERO(bkgrp[j]->RTPLc);
+   }
 
 #ifdef DRAM_VISUALIZE
-  visualize();
+   visualize();
 #endif
 }
 
-bool dram_t::issue_col_command(int j) {
-  bool issued = false;
-  unsigned grp = get_bankgrp_number(j);
-  if (bk[j]->mrq) {  // if currently servicing a memory request
-    bk[j]->mrq->data->set_status(
-        IN_PARTITION_DRAM, m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-    // correct row activated for a READ
-    if (!issued && !CCDc && !bk[j]->RCDc && !(bkgrp[grp]->CCDLc) &&
-        (bk[j]->curr_row == bk[j]->mrq->row) && (bk[j]->mrq->rw == READ) &&
-        (WTRc == 0) && (bk[j]->state == BANK_ACTIVE) && !rwq->full()) {
-      if (rw == WRITE) {
-        rw = READ;
-        rwq->set_min_length(m_config->CL);
-      }
-      rwq->push(bk[j]->mrq);
-      bk[j]->mrq->txbytes += m_config->dram_atom_size;
-      CCDc = m_config->tCCD;
-      bkgrp[grp]->CCDLc = m_config->tCCDL;
-      RTWc = m_config->tRTW;
-      bk[j]->RTPc = m_config->BL / m_config->data_command_freq_ratio;
-      bkgrp[grp]->RTPLc = m_config->tRTPL;
-      issued = true;
-      if (bk[j]->mrq->data->get_access_type() == L2_WR_ALLOC_R)
-        n_rd_L2_A++;
-      else
-        n_rd++;
-
-      bwutil += m_config->BL / m_config->data_command_freq_ratio;
-      bwutil_partial += m_config->BL / m_config->data_command_freq_ratio;
-      bk[j]->n_access++;
-
-#ifdef DRAM_VERIFY
-      PRINT_CYCLE = 1;
-      printf("\tRD  Bk:%d Row:%03x Col:%03x \n", j, bk[j]->curr_row,
-             bk[j]->mrq->col + bk[j]->mrq->txbytes - m_config->dram_atom_size);
-#endif
-      // transfer done
-      if (!(bk[j]->mrq->txbytes < bk[j]->mrq->nbytes)) {
-        bk[j]->mrq = NULL;
-      }
-    } else
-        // correct row activated for a WRITE
-        if (!issued && !CCDc && !bk[j]->RCDWRc && !(bkgrp[grp]->CCDLc) &&
-            (bk[j]->curr_row == bk[j]->mrq->row) && (bk[j]->mrq->rw == WRITE) &&
-            (RTWc == 0) && (bk[j]->state == BANK_ACTIVE) && !rwq->full()) {
-      if (rw == READ) {
-        rw = WRITE;
-        rwq->set_min_length(m_config->WL);
-      }
-      rwq->push(bk[j]->mrq);
-
-      bk[j]->mrq->txbytes += m_config->dram_atom_size;
-      CCDc = m_config->tCCD;
-      bkgrp[grp]->CCDLc = m_config->tCCDL;
-      WTRc = m_config->tWTR;
-      bk[j]->WTPc = m_config->tWTP;
-      issued = true;
-
-      if (bk[j]->mrq->data->get_access_type() == L2_WRBK_ACC)
-        n_wr_WB++;
-      else
-        n_wr++;
-      bwutil += m_config->BL / m_config->data_command_freq_ratio;
-      bwutil_partial += m_config->BL / m_config->data_command_freq_ratio;
-#ifdef DRAM_VERIFY
-      PRINT_CYCLE = 1;
-      printf("\tWR  Bk:%d Row:%03x Col:%03x \n", j, bk[j]->curr_row,
-             bk[j]->mrq->col + bk[j]->mrq->txbytes - m_config->dram_atom_size);
-#endif
-      // transfer done
-      if (!(bk[j]->mrq->txbytes < bk[j]->mrq->nbytes)) {
-        bk[j]->mrq = NULL;
-      }
-    }
-  }
-
-  return issued;
-}
-
-bool dram_t::issue_row_command(int j) {
-  bool issued = false;
-  unsigned grp = get_bankgrp_number(j);
-  if (bk[j]->mrq) {  // if currently servicing a memory request
-    bk[j]->mrq->data->set_status(
-        IN_PARTITION_DRAM, m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-    //     bank is idle
-    // else
-    if (!issued && !RRDc && (bk[j]->state == BANK_IDLE) && !bk[j]->RPc &&
-        !bk[j]->RCc) {  //
-#ifdef DRAM_VERIFY
-      PRINT_CYCLE = 1;
-      printf("\tACT BK:%d NewRow:%03x From:%03x \n", j, bk[j]->mrq->row,
-             bk[j]->curr_row);
-#endif
-      // activate the row with current memory request
-      bk[j]->curr_row = bk[j]->mrq->row;
-      bk[j]->state = BANK_ACTIVE;
-      RRDc = m_config->tRRD;
-      bk[j]->RCDc = m_config->tRCD;
-      bk[j]->RCDWRc = m_config->tRCDWR;
-      bk[j]->RASc = m_config->tRAS;
-      bk[j]->RCc = m_config->tRC;
-      prio = (j + 1) % m_config->nbk;
-      issued = true;
-      n_act_partial++;
-      n_act++;
-    }
-
-    else
-        // different row activated
-        if ((!issued) && (bk[j]->curr_row != bk[j]->mrq->row) &&
+bool dram_t::issue_col_command(int j)
+{
+	bool issued = false;
+	unsigned grp = get_bankgrp_number(j);
+    if (bk[j]->mrq) { //if currently servicing a memory request
+        bk[j]->mrq->data->set_status(IN_PARTITION_DRAM,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
+       // correct row activated for a READ
+       if ( !issued && !CCDc && !bk[j]->RCDc &&
+            !(bkgrp[grp]->CCDLc) &&
+            (bk[j]->curr_row == bk[j]->mrq->row) &&
+            (bk[j]->mrq->rw == READ) && (WTRc == 0 )  &&
             (bk[j]->state == BANK_ACTIVE) &&
-            (!bk[j]->RASc && !bk[j]->WTPc && !bk[j]->RTPc &&
-             !bkgrp[grp]->RTPLc)) {
-      // make the bank idle again
-      bk[j]->state = BANK_IDLE;
-      bk[j]->RPc = m_config->tRP;
-      prio = (j + 1) % m_config->nbk;
-      issued = true;
-      n_pre++;
-      n_pre_partial++;
+            !rwq->full() ) {
+          if (rw==WRITE) {
+             rw=READ;
+             rwq->set_min_length(m_config->CL);
+          }
+          rwq->push(bk[j]->mrq);
+          bk[j]->mrq->txbytes += m_config->dram_atom_size;
+          CCDc = m_config->tCCD;
+          bkgrp[grp]->CCDLc = m_config->tCCDL;
+          RTWc = m_config->tRTW;
+          bk[j]->RTPc = m_config->BL/m_config->data_command_freq_ratio;
+          bkgrp[grp]->RTPLc = m_config->tRTPL;
+          issued = true;
+          if(bk[j]->mrq->data->get_access_type() == L2_WR_ALLOC_R)
+        	  n_rd_L2_A++;
+          else
+                n_rd++;
+
+          bwutil += m_config->BL/m_config->data_command_freq_ratio;
+          bwutil_partial += m_config->BL/m_config->data_command_freq_ratio;
+          bk[j]->n_access++;
+
 #ifdef DRAM_VERIFY
-      PRINT_CYCLE = 1;
-      printf("\tPRE BK:%d Row:%03x \n", j, bk[j]->curr_row);
+          PRINT_CYCLE=1;
+          printf("\tRD  Bk:%d Row:%03x Col:%03x \n",
+                 j, bk[j]->curr_row,
+                 bk[j]->mrq->col + bk[j]->mrq->txbytes - m_config->dram_atom_size);
 #endif
+          // transfer done
+          if ( !(bk[j]->mrq->txbytes < bk[j]->mrq->nbytes) ) {
+             bk[j]->mrq = NULL;
+          }
+       } else
+          // correct row activated for a WRITE
+          if ( !issued && !CCDc && !bk[j]->RCDWRc &&
+               !(bkgrp[grp]->CCDLc) &&
+               (bk[j]->curr_row == bk[j]->mrq->row)  &&
+               (bk[j]->mrq->rw == WRITE) && (RTWc == 0 )  &&
+               (bk[j]->state == BANK_ACTIVE) &&
+               !rwq->full() ) {
+          if (rw==READ) {
+             rw=WRITE;
+             rwq->set_min_length(m_config->WL);
+          }
+          rwq->push(bk[j]->mrq);
+
+          bk[j]->mrq->txbytes += m_config->dram_atom_size;
+          CCDc = m_config->tCCD;
+          bkgrp[grp]->CCDLc = m_config->tCCDL;
+          WTRc = m_config->tWTR;
+          bk[j]->WTPc = m_config->tWTP;
+          issued = true;
+
+          if(bk[j]->mrq->data->get_access_type() == L2_WRBK_ACC)
+          	n_wr_WB++;
+          else
+          	 n_wr++;
+          bwutil += m_config->BL/m_config->data_command_freq_ratio;
+          bwutil_partial += m_config->BL/m_config->data_command_freq_ratio;
+#ifdef DRAM_VERIFY
+          PRINT_CYCLE=1;
+          printf("\tWR  Bk:%d Row:%03x Col:%03x \n",
+                 j, bk[j]->curr_row,
+                 bk[j]->mrq->col + bk[j]->mrq->txbytes - m_config->dram_atom_size);
+#endif
+          // transfer done
+          if ( !(bk[j]->mrq->txbytes < bk[j]->mrq->nbytes) ) {
+             bk[j]->mrq = NULL;
+          }
+       }
+
     }
-  }
-  return issued;
+
+    return issued;
 }
 
-// if mrq is being serviced by dram, gets popped after CL latency fulfilled
-class mem_fetch *dram_t::return_queue_pop() {
-  return returnq->pop();
+bool dram_t::issue_row_command(int j)
+{
+	bool issued = false;
+	unsigned grp = get_bankgrp_number(j);
+    if (bk[j]->mrq) { //if currently servicing a memory request
+        bk[j]->mrq->data->set_status(IN_PARTITION_DRAM,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
+      //     bank is idle
+    //else
+  	  if ( !issued && !RRDc &&
+               (bk[j]->state == BANK_IDLE) &&
+               !bk[j]->RPc && !bk[j]->RCc) { //
+#ifdef DRAM_VERIFY
+          PRINT_CYCLE=1;
+          printf("\tACT BK:%d NewRow:%03x From:%03x \n",
+                 j,bk[j]->mrq->row,bk[j]->curr_row);
+#endif
+          // activate the row with current memory request
+          bk[j]->curr_row = bk[j]->mrq->row;
+          bk[j]->state = BANK_ACTIVE;
+          RRDc = m_config->tRRD;
+          bk[j]->RCDc = m_config->tRCD;
+          bk[j]->RCDWRc = m_config->tRCDWR;
+          bk[j]->RASc = m_config->tRAS;
+          bk[j]->RCc = m_config->tRC;
+          prio = (j + 1) % m_config->nbk;
+          issued = true;
+          n_act_partial++;
+          n_act++;
+       }
+
+       else
+          // different row activated
+          if ( (!issued) &&
+               (bk[j]->curr_row != bk[j]->mrq->row) &&
+               (bk[j]->state == BANK_ACTIVE) &&
+               (!bk[j]->RASc && !bk[j]->WTPc &&
+				  !bk[j]->RTPc &&
+				  !bkgrp[grp]->RTPLc) ) {
+          // make the bank idle again
+          bk[j]->state = BANK_IDLE;
+          bk[j]->RPc = m_config->tRP;
+          prio = (j + 1) % m_config->nbk;
+          issued = true;
+          n_pre++;
+          n_pre_partial++;
+#ifdef DRAM_VERIFY
+          PRINT_CYCLE=1;
+          printf("\tPRE BK:%d Row:%03x \n", j,bk[j]->curr_row);
+#endif
+       }
+    }
+    return issued;
 }
 
-class mem_fetch *dram_t::return_queue_top() {
-  return returnq->top();
+
+//if mrq is being serviced by dram, gets popped after CL latency fulfilled
+class mem_fetch* dram_t::return_queue_pop()
+{
+    return returnq->pop();
 }
 
-void dram_t::print(FILE *simFile) const {
-  unsigned i;
-  fprintf(simFile, "DRAM[%d]: %d bks, busW=%d BL=%d CL=%d, ", id, m_config->nbk,
-          m_config->busW, m_config->BL, m_config->CL);
-  fprintf(simFile, "tRRD=%d tCCD=%d, tRCD=%d tRAS=%d tRP=%d tRC=%d\n",
-          m_config->tRRD, m_config->tCCD, m_config->tRCD, m_config->tRAS,
-          m_config->tRP, m_config->tRC);
-  fprintf(simFile,
-          "n_cmd=%llu n_nop=%llu n_act=%llu n_pre=%llu n_ref_event=%llu "
-          "n_req=%llu n_rd=%llu n_rd_L2_A=%llu n_write=%llu n_wr_bk=%llu "
-          "bw_util=%.4g\n",
-          n_cmd, n_nop, n_act, n_pre, n_ref, n_req, n_rd, n_rd_L2_A, n_wr,
-          n_wr_WB, (float)bwutil / n_cmd);
-  fprintf(simFile, "n_activity=%llu dram_eff=%.4g\n", n_activity,
-          (float)bwutil / n_activity);
-  for (i = 0; i < m_config->nbk; i++) {
-    fprintf(simFile, "bk%d: %da %di ", i, bk[i]->n_access, bk[i]->n_idle);
-  }
-  fprintf(simFile, "\n");
-  fprintf(simFile,
-          "\n------------------------------------------------------------------"
-          "------\n");
-
-  printf("\nRow_Buffer_Locality = %.6f", (float)hits_num / access_num);
-  printf("\nRow_Buffer_Locality_read = %.6f", (float)hits_read_num / read_num);
-  printf("\nRow_Buffer_Locality_write = %.6f",
-         (float)hits_write_num / write_num);
-  printf("\nBank_Level_Parallism = %.6f",
-         (float)banks_1time / banks_acess_total);
-  printf("\nBank_Level_Parallism_Col = %.6f",
-         (float)banks_time_rw / banks_access_rw_total);
-  printf("\nBank_Level_Parallism_Ready = %.6f",
-         (float)banks_time_ready / banks_access_ready_total);
-  printf("\nwrite_to_read_ratio_blp_rw_average = %.6f",
-         write_to_read_ratio_blp_rw_average / banks_access_rw_total);
-  printf("\nGrpLevelPara = %.6f \n",
-         (float)bkgrp_parallsim_rw / banks_access_rw_total);
-
-  printf("\nBW Util details:\n");
-  printf("bwutil = %.6f \n", (float)bwutil / n_cmd);
-  printf("total_CMD = %llu \n", n_cmd);
-  printf("util_bw = %llu \n", util_bw);
-  printf("Wasted_Col = %llu \n", wasted_bw_col);
-  printf("Wasted_Row = %llu \n", wasted_bw_row);
-  printf("Idle = %llu \n", idle_bw);
-
-  printf("\nBW Util Bottlenecks: \n");
-  printf("RCDc_limit = %llu \n", RCDc_limit);
-  printf("RCDWRc_limit = %llu \n", RCDWRc_limit);
-  printf("WTRc_limit = %llu \n", WTRc_limit);
-  printf("RTWc_limit = %llu \n", RTWc_limit);
-  printf("CCDLc_limit = %llu \n", CCDLc_limit);
-  printf("rwq = %llu \n", rwq_limit);
-  printf("CCDLc_limit_alone = %llu \n", CCDLc_limit_alone);
-  printf("WTRc_limit_alone = %llu \n", WTRc_limit_alone);
-  printf("RTWc_limit_alone = %llu \n", RTWc_limit_alone);
-
-  printf("\nCommands details: \n");
-  printf("total_CMD = %llu \n", n_cmd);
-  printf("n_nop = %llu \n", n_nop);
-  printf("Read = %llu \n", n_rd);
-  printf("Write = %llu \n", n_wr);
-  printf("L2_Alloc = %llu \n", n_rd_L2_A);
-  printf("L2_WB = %llu \n", n_wr_WB);
-  printf("n_act = %llu \n", n_act);
-  printf("n_pre = %llu \n", n_pre);
-  printf("n_ref = %llu \n", n_ref);
-  printf("n_req = %llu \n", n_req);
-  printf("total_req = %llu \n", n_rd + n_wr + n_rd_L2_A + n_wr_WB);
-
-  printf("\nDual Bus Interface Util: \n");
-  printf("issued_total_row = %llu \n", issued_total_row);
-  printf("issued_total_col = %llu \n", issued_total_col);
-  printf("Row_Bus_Util =  %.6f \n", (float)issued_total_row / n_cmd);
-  printf("CoL_Bus_Util = %.6f \n", (float)issued_total_col / n_cmd);
-  printf("Either_Row_CoL_Bus_Util = %.6f \n", (float)issued_total / n_cmd);
-  printf("Issued_on_Two_Bus_Simul_Util = %.6f \n", (float)issued_two / n_cmd);
-  printf("issued_two_Eff = %.6f \n", (float)issued_two / issued_total);
-  printf("queue_avg = %.6f \n\n", (float)ave_mrqs / n_cmd);
-
-  fprintf(simFile, "\n");
-  fprintf(simFile, "dram_util_bins:");
-  for (i = 0; i < 10; i++) fprintf(simFile, " %d", dram_util_bins[i]);
-  fprintf(simFile, "\ndram_eff_bins:");
-  for (i = 0; i < 10; i++) fprintf(simFile, " %d", dram_eff_bins[i]);
-  fprintf(simFile, "\n");
-  if (m_config->scheduler_type == DRAM_FRFCFS)
-    fprintf(simFile, "mrqq: max=%d avg=%g\n", max_mrqs,
-            (float)ave_mrqs / n_cmd);
+class mem_fetch* dram_t::return_queue_top()
+{
+    return returnq->top();
 }
 
-void dram_t::visualize() const {
-  printf("RRDc=%d CCDc=%d mrqq.Length=%d rwq.Length=%d\n", RRDc, CCDc,
-         mrqq->get_length(), rwq->get_length());
-  for (unsigned i = 0; i < m_config->nbk; i++) {
-    printf("BK%d: state=%c curr_row=%03x, %2d %2d %2d %2d %p ", i, bk[i]->state,
-           bk[i]->curr_row, bk[i]->RCDc, bk[i]->RASc, bk[i]->RPc, bk[i]->RCc,
-           bk[i]->mrq);
-    if (bk[i]->mrq)
-      printf("txf: %d %d", bk[i]->mrq->nbytes, bk[i]->mrq->txbytes);
-    printf("\n");
-  }
-  if (m_frfcfs_scheduler) m_frfcfs_scheduler->print(stdout);
+
+void dram_t::print( FILE* simFile) const
+{
+   unsigned i;
+   fprintf(simFile,"DRAM[%d]: %d bks, busW=%d BL=%d CL=%d, ", 
+           id, m_config->nbk, m_config->busW, m_config->BL, m_config->CL );
+   fprintf(simFile,"tRRD=%d tCCD=%d, tRCD=%d tRAS=%d tRP=%d tRC=%d\n",
+           m_config->tRRD, m_config->tCCD, m_config->tRCD, m_config->tRAS, m_config->tRP, m_config->tRC );
+   fprintf(simFile,"n_cmd=%llu n_nop=%llu n_act=%llu n_pre=%llu n_ref_event=%llu n_req=%llu n_rd=%llu n_rd_L2_A=%llu n_write=%llu n_wr_bk=%llu bw_util=%.4g\n",
+           n_cmd, n_nop, n_act, n_pre, n_ref, n_req, n_rd, n_rd_L2_A, n_wr, n_wr_WB,
+           (float)bwutil/n_cmd);
+   fprintf(simFile,"n_activity=%llu dram_eff=%.4g\n",
+           n_activity, (float)bwutil/n_activity);
+   for (i=0;i<m_config->nbk;i++) {
+      fprintf(simFile, "bk%d: %da %di ",i,bk[i]->n_access,bk[i]->n_idle);
+   }
+   fprintf(simFile, "\n");
+   fprintf(simFile, "\n------------------------------------------------------------------------\n");
+
+   printf("\nRow_Buffer_Locality = %.6f", (float)hits_num / access_num);
+   printf("\nRow_Buffer_Locality_read = %.6f", (float)hits_read_num / read_num);
+   printf("\nRow_Buffer_Locality_write = %.6f", (float)hits_write_num / write_num);
+   printf("\nBank_Level_Parallism = %.6f", (float)banks_1time / banks_acess_total);
+   printf("\nBank_Level_Parallism_Col = %.6f", (float)banks_time_rw / banks_access_rw_total);
+   printf("\nBank_Level_Parallism_Ready = %.6f", (float)banks_time_ready /banks_access_ready_total);
+   printf("\nwrite_to_read_ratio_blp_rw_average = %.6f", write_to_read_ratio_blp_rw_average /banks_access_rw_total);
+   printf("\nGrpLevelPara = %.6f \n", (float)bkgrp_parallsim_rw /banks_access_rw_total);
+
+   printf("\nBW Util details:\n");
+   printf("bwutil = %.6f \n", (float)bwutil/n_cmd);
+   printf("total_CMD = %llu \n", n_cmd);
+   printf("util_bw = %llu \n", util_bw);
+   printf("Wasted_Col = %llu \n", wasted_bw_col);
+   printf("Wasted_Row = %llu \n", wasted_bw_row);
+   printf("Idle = %llu \n", idle_bw);
+
+   printf("\nBW Util Bottlenecks: \n");
+   printf("RCDc_limit = %llu \n", RCDc_limit);
+   printf("RCDWRc_limit = %llu \n", RCDWRc_limit);
+   printf("WTRc_limit = %llu \n", WTRc_limit);
+   printf("RTWc_limit = %llu \n", RTWc_limit);
+   printf("CCDLc_limit = %llu \n", CCDLc_limit);
+   printf("rwq = %llu \n", rwq_limit);
+   printf("CCDLc_limit_alone = %llu \n", CCDLc_limit_alone);
+   printf("WTRc_limit_alone = %llu \n", WTRc_limit_alone);
+   printf("RTWc_limit_alone = %llu \n", RTWc_limit_alone);
+
+   printf("\nCommands details: \n");
+   printf("total_CMD = %llu \n", n_cmd);
+   printf("n_nop = %llu \n", n_nop);
+   printf("Read = %llu \n", n_rd);
+   printf("Write = %llu \n",n_wr);
+   printf("L2_Alloc = %llu \n", n_rd_L2_A);
+   printf("L2_WB = %llu \n", n_wr_WB);
+   printf("n_act = %llu \n", n_act);
+   printf("n_pre = %llu \n", n_pre);
+   printf("n_ref = %llu \n", n_ref);
+   printf("n_req = %llu \n", n_req );
+   printf("total_req = %llu \n", n_rd+n_wr+n_rd_L2_A+n_wr_WB);
+
+   printf("\nDual Bus Interface Util: \n");
+   printf("issued_total_row = %llu \n", issued_total_row);
+   printf("issued_total_col = %llu \n", issued_total_col);
+   printf("Row_Bus_Util =  %.6f \n", (float)issued_total_row / n_cmd);
+   printf("CoL_Bus_Util = %.6f \n", (float)issued_total_col / n_cmd);
+   printf("Either_Row_CoL_Bus_Util = %.6f \n",  (float)issued_total / n_cmd);
+   printf("Issued_on_Two_Bus_Simul_Util = %.6f \n",  (float)issued_two /n_cmd);
+   printf("issued_two_Eff = %.6f \n",  (float)issued_two /issued_total);
+   printf("queue_avg = %.6f \n\n", (float)ave_mrqs/n_cmd );
+
+   fprintf(simFile, "\n");
+   fprintf(simFile, "dram_util_bins:");
+   for (i=0;i<10;i++) fprintf(simFile, " %d", dram_util_bins[i]);
+   fprintf(simFile, "\ndram_eff_bins:");
+   for (i=0;i<10;i++) fprintf(simFile, " %d", dram_eff_bins[i]);
+   fprintf(simFile, "\n");
+   if(m_config->scheduler_type== DRAM_FRFCFS)
+       fprintf(simFile, "mrqq: max=%d avg=%g\n", max_mrqs, (float)ave_mrqs/n_cmd);
 }
 
-void dram_t::print_stat(FILE *simFile) {
-  fprintf(simFile,
-          "DRAM (%u): n_cmd=%llu n_nop=%llu n_act=%llu n_pre=%llu n_ref=%llu "
-          "n_req=%llu n_rd=%llu n_write=%llu bw_util=%.4g ",
-          id, n_cmd, n_nop, n_act, n_pre, n_ref, n_req, n_rd, n_wr,
-          (float)bwutil / n_cmd);
-  fprintf(simFile, "mrqq: %d %.4g mrqsmax=%llu ", max_mrqs,
-          (float)ave_mrqs / n_cmd, max_mrqs_temp);
-  fprintf(simFile, "\n");
-  fprintf(simFile, "dram_util_bins:");
-  for (unsigned i = 0; i < 10; i++) fprintf(simFile, " %d", dram_util_bins[i]);
-  fprintf(simFile, "\ndram_eff_bins:");
-  for (unsigned i = 0; i < 10; i++) fprintf(simFile, " %d", dram_eff_bins[i]);
-  fprintf(simFile, "\n");
-  max_mrqs_temp = 0;
+void dram_t::visualize() const
+{
+   printf("RRDc=%d CCDc=%d mrqq.Length=%d rwq.Length=%d\n", 
+          RRDc, CCDc, mrqq->get_length(),rwq->get_length());
+   for (unsigned i=0;i<m_config->nbk;i++) {
+      printf("BK%d: state=%c curr_row=%03x, %2d %2d %2d %2d %p ", 
+             i, bk[i]->state, bk[i]->curr_row,
+             bk[i]->RCDc, bk[i]->RASc,
+             bk[i]->RPc, bk[i]->RCc,
+             bk[i]->mrq );
+      if (bk[i]->mrq)
+         printf("txf: %d %d", bk[i]->mrq->nbytes, bk[i]->mrq->txbytes);
+      printf("\n");
+   }
+   if ( m_frfcfs_scheduler ) 
+      m_frfcfs_scheduler->print(stdout);
 }
 
-void dram_t::visualizer_print(gzFile visualizer_file) {
-  // dram specific statistics
-  gzprintf(visualizer_file, "dramncmd: %u %u\n", id, n_cmd_partial);
-  gzprintf(visualizer_file, "dramnop: %u %u\n", id, n_nop_partial);
-  gzprintf(visualizer_file, "dramnact: %u %u\n", id, n_act_partial);
-  gzprintf(visualizer_file, "dramnpre: %u %u\n", id, n_pre_partial);
-  gzprintf(visualizer_file, "dramnreq: %u %u\n", id, n_req_partial);
-  gzprintf(visualizer_file, "dramavemrqs: %u %u\n", id,
-           n_cmd_partial ? (ave_mrqs_partial / n_cmd_partial) : 0);
-
-  // utilization and efficiency
-  gzprintf(visualizer_file, "dramutil: %u %u\n", id,
-           n_cmd_partial ? 100 * bwutil_partial / n_cmd_partial : 0);
-  gzprintf(visualizer_file, "drameff: %u %u\n", id,
-           n_activity_partial ? 100 * bwutil_partial / n_activity_partial : 0);
-
-  // reset for next interval
-  bwutil_partial = 0;
-  n_activity_partial = 0;
-  ave_mrqs_partial = 0;
-  n_cmd_partial = 0;
-  n_nop_partial = 0;
-  n_act_partial = 0;
-  n_pre_partial = 0;
-  n_req_partial = 0;
-
-  // dram access type classification
-  for (unsigned j = 0; j < m_config->nbk; j++) {
-    gzprintf(visualizer_file, "dramglobal_acc_r: %u %u %u\n", id, j,
-             m_stats->mem_access_type_stats[GLOBAL_ACC_R][id][j]);
-    gzprintf(visualizer_file, "dramglobal_acc_w: %u %u %u\n", id, j,
-             m_stats->mem_access_type_stats[GLOBAL_ACC_W][id][j]);
-    gzprintf(visualizer_file, "dramlocal_acc_r: %u %u %u\n", id, j,
-             m_stats->mem_access_type_stats[LOCAL_ACC_R][id][j]);
-    gzprintf(visualizer_file, "dramlocal_acc_w: %u %u %u\n", id, j,
-             m_stats->mem_access_type_stats[LOCAL_ACC_W][id][j]);
-    gzprintf(visualizer_file, "dramconst_acc_r: %u %u %u\n", id, j,
-             m_stats->mem_access_type_stats[CONST_ACC_R][id][j]);
-    gzprintf(visualizer_file, "dramtexture_acc_r: %u %u %u\n", id, j,
-             m_stats->mem_access_type_stats[TEXTURE_ACC_R][id][j]);
-  }
+void dram_t::print_stat( FILE* simFile ) 
+{
+   fprintf(simFile,"DRAM (%u): n_cmd=%llu n_nop=%llu n_act=%llu n_pre=%llu n_ref=%llu n_req=%llu n_rd=%llu n_write=%llu bw_util=%.4g ",
+           id, n_cmd, n_nop, n_act, n_pre, n_ref, n_req, n_rd, n_wr,
+           (float)bwutil/n_cmd);
+   fprintf(simFile, "mrqq: %d %.4g mrqsmax=%llu ", max_mrqs, (float)ave_mrqs/n_cmd, max_mrqs_temp);
+   fprintf(simFile, "\n");
+   fprintf(simFile, "dram_util_bins:");
+   for (unsigned i=0;i<10;i++) fprintf(simFile, " %d", dram_util_bins[i]);
+   fprintf(simFile, "\ndram_eff_bins:");
+   for (unsigned i=0;i<10;i++) fprintf(simFile, " %d", dram_eff_bins[i]);
+   fprintf(simFile, "\n");
+   max_mrqs_temp = 0;
 }
 
-void dram_t::set_dram_power_stats(unsigned &cmd, unsigned &activity,
-                                  unsigned &nop, unsigned &act, unsigned &pre,
-                                  unsigned &rd, unsigned &wr,
-                                  unsigned &req) const {
-  // Point power performance counters to low-level DRAM counters
-  cmd = n_cmd;
-  activity = n_activity;
-  nop = n_nop;
-  act = n_act;
-  pre = n_pre;
-  rd = n_rd;
-  wr = n_wr;
-  req = n_req;
+void dram_t::visualizer_print( gzFile visualizer_file )
+{
+   // dram specific statistics
+   gzprintf(visualizer_file,"dramncmd: %u %u\n",id, n_cmd_partial);  
+   gzprintf(visualizer_file,"dramnop: %u %u\n",id,n_nop_partial);
+   gzprintf(visualizer_file,"dramnact: %u %u\n",id,n_act_partial);
+   gzprintf(visualizer_file,"dramnpre: %u %u\n",id,n_pre_partial);
+   gzprintf(visualizer_file,"dramnreq: %u %u\n",id,n_req_partial);
+   gzprintf(visualizer_file,"dramavemrqs: %u %u\n",id,
+            n_cmd_partial?(ave_mrqs_partial/n_cmd_partial ):0);
+
+   // utilization and efficiency
+   gzprintf(visualizer_file,"dramutil: %u %u\n",  
+            id,n_cmd_partial?100*bwutil_partial/n_cmd_partial:0);
+   gzprintf(visualizer_file,"drameff: %u %u\n", 
+            id,n_activity_partial?100*bwutil_partial/n_activity_partial:0);
+
+   // reset for next interval
+   bwutil_partial = 0;
+   n_activity_partial = 0;
+   ave_mrqs_partial = 0; 
+   n_cmd_partial = 0;
+   n_nop_partial = 0;
+   n_act_partial = 0;
+   n_pre_partial = 0;
+   n_req_partial = 0;
+
+
+   // dram access type classification
+   for (unsigned j = 0; j < m_config->nbk; j++) {
+      gzprintf(visualizer_file,"dramglobal_acc_r: %u %u %u\n", id, j, 
+               m_stats->mem_access_type_stats[GLOBAL_ACC_R][id][j]);
+      gzprintf(visualizer_file,"dramglobal_acc_w: %u %u %u\n", id, j, 
+               m_stats->mem_access_type_stats[GLOBAL_ACC_W][id][j]);
+      gzprintf(visualizer_file,"dramlocal_acc_r: %u %u %u\n", id, j, 
+               m_stats->mem_access_type_stats[LOCAL_ACC_R][id][j]);
+      gzprintf(visualizer_file,"dramlocal_acc_w: %u %u %u\n", id, j, 
+               m_stats->mem_access_type_stats[LOCAL_ACC_W][id][j]);
+      gzprintf(visualizer_file,"dramconst_acc_r: %u %u %u\n", id, j, 
+               m_stats->mem_access_type_stats[CONST_ACC_R][id][j]);
+      gzprintf(visualizer_file,"dramtexture_acc_r: %u %u %u\n", id, j, 
+               m_stats->mem_access_type_stats[TEXTURE_ACC_R][id][j]);
+   }
 }
 
-unsigned dram_t::get_bankgrp_number(unsigned i) {
-  if (m_config->dram_bnkgrp_indexing_policy == HIGHER_BITS) {  // higher bits
-    return i >> m_config->bk_tag_length;
-  } else if (m_config->dram_bnkgrp_indexing_policy ==
-             LOWER_BITS) {  // lower bits
-    return i & ((m_config->nbkgrp - 1));
-  } else {
-    assert(1);
-  }
+
+void dram_t::set_dram_power_stats(	unsigned &cmd,
+									unsigned &activity,
+									unsigned &nop,
+									unsigned &act,
+									unsigned &pre,
+									unsigned &rd,
+									unsigned &wr,
+									unsigned &req) const{
+
+	// Point power performance counters to low-level DRAM counters
+	cmd = n_cmd;
+	activity = n_activity;
+	nop = n_nop;
+	act = n_act;
+	pre = n_pre;
+	rd = n_rd;
+	wr = n_wr;
+	req = n_req;
+}
+
+unsigned dram_t::get_bankgrp_number(unsigned i)
+{
+	if(m_config->dram_bnkgrp_indexing_policy == HIGHER_BITS) { //higher bits
+		return i >> m_config->bk_tag_length;
+	}
+	else if (m_config->dram_bnkgrp_indexing_policy == LOWER_BITS) { //lower bits
+		return i & ((m_config->nbkgrp - 1));
+	}
+	else {
+		assert(1);
+	}
 }

--- a/src/gpgpu-sim/dram.cc
+++ b/src/gpgpu-sim/dram.cc
@@ -8,31 +8,32 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
-#include "gpu-sim.h"
-#include "gpu-misc.h"
 #include "dram.h"
-#include "mem_latency_stat.h"
 #include "dram_sched.h"
-#include "mem_fetch.h"
+#include "gpu-misc.h"
+#include "gpu-sim.h"
 #include "l2cache.h"
+#include "mem_fetch.h"
+#include "mem_latency_stat.h"
 
 #ifdef DRAM_VERIFY
 int PRINT_CYCLE = 0;
@@ -41,869 +42,828 @@ int PRINT_CYCLE = 0;
 template class fifo_pipeline<mem_fetch>;
 template class fifo_pipeline<dram_req_t>;
 
-dram_t::dram_t( unsigned int partition_id, const memory_config *config, memory_stats_t *stats,
-                memory_partition_unit *mp, gpgpu_sim* gpu )
-{
-   id = partition_id;
-   m_memory_partition_unit = mp;
-   m_stats = stats;
-   m_config = config;
-   m_gpu = gpu;
+dram_t::dram_t(unsigned int partition_id, const memory_config *config,
+               memory_stats_t *stats, memory_partition_unit *mp,
+               gpgpu_sim *gpu) {
+  id = partition_id;
+  m_memory_partition_unit = mp;
+  m_stats = stats;
+  m_config = config;
+  m_gpu = gpu;
 
-   //rowblp
-   access_num=0;
-   hits_num=0;
-   read_num=0;
-   write_num=0;
-   hits_read_num=0;
-   hits_write_num=0;
-   banks_1time=0;
-   banks_acess_total=0;
-   banks_acess_total_after=0;
-   banks_time_ready=0;
-   banks_access_ready_total=0;
-   issued_two=0;
-   issued_total=0;
-   issued_total_row=0;
-   issued_total_col=0;
+  // rowblp
+  access_num = 0;
+  hits_num = 0;
+  read_num = 0;
+  write_num = 0;
+  hits_read_num = 0;
+  hits_write_num = 0;
+  banks_1time = 0;
+  banks_acess_total = 0;
+  banks_acess_total_after = 0;
+  banks_time_ready = 0;
+  banks_access_ready_total = 0;
+  issued_two = 0;
+  issued_total = 0;
+  issued_total_row = 0;
+  issued_total_col = 0;
 
-   CCDc = 0;
-   RRDc = 0;
-   RTWc = 0;
-   WTRc = 0;
+  CCDc = 0;
+  RRDc = 0;
+  RTWc = 0;
+  WTRc = 0;
 
-   wasted_bw_row=0;
-   wasted_bw_col=0;
-   util_bw=0;
-   idle_bw=0;
-   RCDc_limit=0;
-   CCDLc_limit=0;
-   CCDLc_limit_alone=0;
-   CCDc_limit=0;
-   WTRc_limit=0;
-   WTRc_limit_alone=0;
-   RCDWRc_limit=0;
-   RTWc_limit=0;
-   RTWc_limit_alone=0;
-   rwq_limit=0;
-   write_to_read_ratio_blp_rw_average=0;
-   bkgrp_parallsim_rw=0;
+  wasted_bw_row = 0;
+  wasted_bw_col = 0;
+  util_bw = 0;
+  idle_bw = 0;
+  RCDc_limit = 0;
+  CCDLc_limit = 0;
+  CCDLc_limit_alone = 0;
+  CCDc_limit = 0;
+  WTRc_limit = 0;
+  WTRc_limit_alone = 0;
+  RCDWRc_limit = 0;
+  RTWc_limit = 0;
+  RTWc_limit_alone = 0;
+  rwq_limit = 0;
+  write_to_read_ratio_blp_rw_average = 0;
+  bkgrp_parallsim_rw = 0;
 
-   rw = READ; //read mode is default
+  rw = READ;  // read mode is default
 
-	bkgrp = (bankgrp_t**) calloc(sizeof(bankgrp_t*), m_config->nbkgrp);
-	bkgrp[0] = (bankgrp_t*) calloc(sizeof(bank_t), m_config->nbkgrp);
-	for (unsigned i=1; i<m_config->nbkgrp; i++) {
-		bkgrp[i] = bkgrp[0] + i;
-	}
-	for (unsigned i=0; i<m_config->nbkgrp; i++) {
-		bkgrp[i]->CCDLc = 0;
-		bkgrp[i]->RTPLc = 0;
-	}
+  bkgrp = (bankgrp_t **)calloc(sizeof(bankgrp_t *), m_config->nbkgrp);
+  bkgrp[0] = (bankgrp_t *)calloc(sizeof(bank_t), m_config->nbkgrp);
+  for (unsigned i = 1; i < m_config->nbkgrp; i++) {
+    bkgrp[i] = bkgrp[0] + i;
+  }
+  for (unsigned i = 0; i < m_config->nbkgrp; i++) {
+    bkgrp[i]->CCDLc = 0;
+    bkgrp[i]->RTPLc = 0;
+  }
 
-   bk = (bank_t**) calloc(sizeof(bank_t*),m_config->nbk);
-   bk[0] = (bank_t*) calloc(sizeof(bank_t),m_config->nbk);
-   for (unsigned i=1;i<m_config->nbk;i++) 
-      bk[i] = bk[0] + i;
-   for (unsigned i=0;i<m_config->nbk;i++) {
-      bk[i]->state = BANK_IDLE;
-      bk[i]->bkgrpindex = i/(m_config->nbk/m_config->nbkgrp);
-   }
-   prio = 0;
+  bk = (bank_t **)calloc(sizeof(bank_t *), m_config->nbk);
+  bk[0] = (bank_t *)calloc(sizeof(bank_t), m_config->nbk);
+  for (unsigned i = 1; i < m_config->nbk; i++) bk[i] = bk[0] + i;
+  for (unsigned i = 0; i < m_config->nbk; i++) {
+    bk[i]->state = BANK_IDLE;
+    bk[i]->bkgrpindex = i / (m_config->nbk / m_config->nbkgrp);
+  }
+  prio = 0;
 
-   rwq = new fifo_pipeline<dram_req_t>("rwq",m_config->CL,m_config->CL+1);
-   mrqq = new fifo_pipeline<dram_req_t>("mrqq",0,2);
-   returnq = new fifo_pipeline<mem_fetch>("dramreturnq",0,m_config->gpgpu_dram_return_queue_size==0?1024:m_config->gpgpu_dram_return_queue_size); 
-   m_frfcfs_scheduler = NULL;
-   if ( m_config->scheduler_type == DRAM_FRFCFS)
-      m_frfcfs_scheduler = new frfcfs_scheduler(m_config,this,stats);
-   n_cmd = 0;
-   n_activity = 0;
-   n_nop = 0; 
-   n_act = 0; 
-   n_pre = 0; 
-   n_rd = 0;
-   n_wr = 0;
-   n_wr_WB=0;
-   n_rd_L2_A=0;
-   n_req = 0;
-   max_mrqs_temp = 0;
-   bwutil = 0;
-   max_mrqs = 0;
-   ave_mrqs = 0;
+  rwq = new fifo_pipeline<dram_req_t>("rwq", m_config->CL, m_config->CL + 1);
+  mrqq = new fifo_pipeline<dram_req_t>("mrqq", 0, 2);
+  returnq = new fifo_pipeline<mem_fetch>(
+      "dramreturnq", 0,
+      m_config->gpgpu_dram_return_queue_size == 0
+          ? 1024
+          : m_config->gpgpu_dram_return_queue_size);
+  m_frfcfs_scheduler = NULL;
+  if (m_config->scheduler_type == DRAM_FRFCFS)
+    m_frfcfs_scheduler = new frfcfs_scheduler(m_config, this, stats);
+  n_cmd = 0;
+  n_activity = 0;
+  n_nop = 0;
+  n_act = 0;
+  n_pre = 0;
+  n_rd = 0;
+  n_wr = 0;
+  n_wr_WB = 0;
+  n_rd_L2_A = 0;
+  n_req = 0;
+  max_mrqs_temp = 0;
+  bwutil = 0;
+  max_mrqs = 0;
+  ave_mrqs = 0;
 
-   for (unsigned i=0;i<10;i++) {
-      dram_util_bins[i]=0;
-      dram_eff_bins[i]=0;
-   }
-   last_n_cmd = last_n_activity = last_bwutil = 0;
+  for (unsigned i = 0; i < 10; i++) {
+    dram_util_bins[i] = 0;
+    dram_eff_bins[i] = 0;
+  }
+  last_n_cmd = last_n_activity = last_bwutil = 0;
 
-   n_cmd_partial = 0;
-   n_activity_partial = 0;
-   n_nop_partial = 0;  
-   n_act_partial = 0;  
-   n_pre_partial = 0;  
-   n_req_partial = 0;
-   ave_mrqs_partial = 0;
-   bwutil_partial = 0;
+  n_cmd_partial = 0;
+  n_activity_partial = 0;
+  n_nop_partial = 0;
+  n_act_partial = 0;
+  n_pre_partial = 0;
+  n_req_partial = 0;
+  ave_mrqs_partial = 0;
+  bwutil_partial = 0;
 
-   if ( queue_limit() )
-      mrqq_Dist = StatCreate("mrqq_length",1, queue_limit());
-   else //queue length is unlimited; 
-      mrqq_Dist = StatCreate("mrqq_length",1,64); //track up to 64 entries
-
+  if (queue_limit())
+    mrqq_Dist = StatCreate("mrqq_length", 1, queue_limit());
+  else                                             // queue length is unlimited;
+    mrqq_Dist = StatCreate("mrqq_length", 1, 64);  // track up to 64 entries
 }
 
-bool dram_t::full(bool is_write) const
-{
-    if(m_config->scheduler_type == DRAM_FRFCFS){
-        if(m_config->gpgpu_frfcfs_dram_sched_queue_size == 0 ) return false;
-        if(m_config->seperate_write_queue_enabled){
-        	if(is_write)
-        		return m_frfcfs_scheduler->num_write_pending() >= m_config->gpgpu_frfcfs_dram_write_queue_size;
-        	else
-        		return m_frfcfs_scheduler->num_pending() >= m_config->gpgpu_frfcfs_dram_sched_queue_size;
-        }
-        else
-        	return m_frfcfs_scheduler->num_pending() >= m_config->gpgpu_frfcfs_dram_sched_queue_size;
+bool dram_t::full(bool is_write) const {
+  if (m_config->scheduler_type == DRAM_FRFCFS) {
+    if (m_config->gpgpu_frfcfs_dram_sched_queue_size == 0) return false;
+    if (m_config->seperate_write_queue_enabled) {
+      if (is_write)
+        return m_frfcfs_scheduler->num_write_pending() >=
+               m_config->gpgpu_frfcfs_dram_write_queue_size;
+      else
+        return m_frfcfs_scheduler->num_pending() >=
+               m_config->gpgpu_frfcfs_dram_sched_queue_size;
+    } else
+      return m_frfcfs_scheduler->num_pending() >=
+             m_config->gpgpu_frfcfs_dram_sched_queue_size;
+  } else
+    return mrqq->full();
+}
+
+unsigned dram_t::que_length() const {
+  unsigned nreqs = 0;
+  if (m_config->scheduler_type == DRAM_FRFCFS) {
+    nreqs = m_frfcfs_scheduler->num_pending();
+  } else {
+    nreqs = mrqq->get_length();
+  }
+  return nreqs;
+}
+
+bool dram_t::returnq_full() const { return returnq->full(); }
+
+unsigned int dram_t::queue_limit() const {
+  return m_config->gpgpu_frfcfs_dram_sched_queue_size;
+}
+
+dram_req_t::dram_req_t(class mem_fetch *mf, unsigned banks,
+                       unsigned dram_bnk_indexing_policy,
+                       class gpgpu_sim *gpu) {
+  txbytes = 0;
+  dqbytes = 0;
+  data = mf;
+  m_gpu = gpu;
+
+  const addrdec_t &tlx = mf->get_tlx_addr();
+
+  switch (dram_bnk_indexing_policy) {
+    case LINEAR_BK_INDEX: {
+      bk = tlx.bk;
+      break;
     }
-   else return mrqq->full();
+    case BITWISE_XORING_BK_INDEX: {
+      // xoring bank bits with lower bits of the page
+      int lbank = log2(banks);
+      bk = tlx.bk ^ (tlx.row & ((1 << lbank) - 1));
+      break;
+    }
+    case CUSTOM_BK_INDEX:
+      /* No custom set function implemented */
+      // Do you custom index here
+      break;
+    default:
+      assert("\nUndefined bank index function.\n" && 0);
+      break;
+  }
+
+  row = tlx.row;
+  col = tlx.col;
+  nbytes = mf->get_data_size();
+
+  timestamp = m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle;
+  addr = mf->get_addr();
+  insertion_time = (unsigned)m_gpu->gpu_sim_cycle;
+  rw = data->get_is_write() ? WRITE : READ;
 }
 
-unsigned dram_t::que_length() const
-{
-   unsigned nreqs = 0;
-   if (m_config->scheduler_type == DRAM_FRFCFS) {
-      nreqs = m_frfcfs_scheduler->num_pending();
-   } else {
-      nreqs = mrqq->get_length();
-   }
-   return nreqs;
+void dram_t::push(class mem_fetch *data) {
+  assert(id == data->get_tlx_addr()
+                   .chip);  // Ensure request is in correct memory partition
+
+  dram_req_t *mrq =
+      new dram_req_t(data, m_config->nbk, m_config->dram_bnk_indexing_policy,
+                     m_memory_partition_unit->get_mgpu());
+
+  data->set_status(IN_PARTITION_MC_INTERFACE_QUEUE,
+                   m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+  mrqq->push(mrq);
+
+  // stats...
+  n_req += 1;
+  n_req_partial += 1;
+  if (m_config->scheduler_type == DRAM_FRFCFS) {
+    unsigned nreqs = m_frfcfs_scheduler->num_pending();
+    if (nreqs > max_mrqs_temp) max_mrqs_temp = nreqs;
+  } else {
+    max_mrqs_temp = (max_mrqs_temp > mrqq->get_length()) ? max_mrqs_temp
+                                                         : mrqq->get_length();
+  }
+  m_stats->memlatstat_dram_access(data);
 }
 
-bool dram_t::returnq_full() const
-{
-   return returnq->full();
+void dram_t::scheduler_fifo() {
+  if (!mrqq->empty()) {
+    unsigned int bkn;
+    dram_req_t *head_mrqq = mrqq->top();
+    head_mrqq->data->set_status(
+        IN_PARTITION_MC_BANK_ARB_QUEUE,
+        m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+    bkn = head_mrqq->bk;
+    if (!bk[bkn]->mrq) bk[bkn]->mrq = mrqq->pop();
+  }
 }
 
-unsigned int dram_t::queue_limit() const 
-{ 
-   return m_config->gpgpu_frfcfs_dram_sched_queue_size; 
-}
+#define DEC2ZERO(x) x = (x) ? (x - 1) : 0;
+#define SWAP(a, b) \
+  a ^= b;          \
+  b ^= a;          \
+  a ^= b;
 
-
-dram_req_t::dram_req_t( class mem_fetch *mf, unsigned banks, unsigned dram_bnk_indexing_policy, class gpgpu_sim* gpu)
-{
-   txbytes = 0;
-   dqbytes = 0;
-   data = mf;
-   m_gpu = gpu;
-
-   const addrdec_t &tlx = mf->get_tlx_addr();
-
-    switch(dram_bnk_indexing_policy){
-		case LINEAR_BK_INDEX:
-		{
-			bk = tlx.bk;
-			break;
-		}
-		case BITWISE_XORING_BK_INDEX:
-		{
-			//xoring bank bits with lower bits of the page
-			int lbank = log2(banks);
-			bk  = tlx.bk ^ (tlx.row & ((1<<lbank)-1));
-			break;
-		}
-		case CUSTOM_BK_INDEX:
-	        /* No custom set function implemented */
-			//Do you custom index here
-			break;
-		default:
-			 assert("\nUndefined bank index function.\n" && 0);
-			 break;
-	}
-
-
-   row = tlx.row; 
-   col = tlx.col; 
-   nbytes = mf->get_data_size();
-
-   timestamp = m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle;
-   addr = mf->get_addr();
-   insertion_time = (unsigned) m_gpu->gpu_sim_cycle;
-   rw = data->get_is_write()?WRITE:READ;
-}
-
-void dram_t::push( class mem_fetch *data ) 
-{
-   assert(id == data->get_tlx_addr().chip); // Ensure request is in correct memory partition
-
-   dram_req_t *mrq = new dram_req_t(data,m_config->nbk,m_config->dram_bnk_indexing_policy,m_memory_partition_unit->get_mgpu());
-
-   data->set_status(IN_PARTITION_MC_INTERFACE_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-	   mrqq->push(mrq);
-
-   // stats...
-   n_req += 1;
-   n_req_partial += 1;
-   if ( m_config->scheduler_type == DRAM_FRFCFS) {
-      unsigned nreqs = m_frfcfs_scheduler->num_pending();
-      if ( nreqs > max_mrqs_temp)
-         max_mrqs_temp = nreqs;
-   } else {
-      max_mrqs_temp = (max_mrqs_temp > mrqq->get_length())? max_mrqs_temp : mrqq->get_length();
-   }
-   m_stats->memlatstat_dram_access(data);
-}
-
-void dram_t::scheduler_fifo()
-{
-   if (!mrqq->empty()) {
-      unsigned int bkn;
-      dram_req_t *head_mrqq = mrqq->top();
-      head_mrqq->data->set_status(IN_PARTITION_MC_BANK_ARB_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-      bkn = head_mrqq->bk;
-      if (!bk[bkn]->mrq) 
-         bk[bkn]->mrq = mrqq->pop();
-   }
-}
-
-
-#define DEC2ZERO(x) x = (x)? (x-1) : 0;
-#define SWAP(a,b) a ^= b; b ^= a; a ^= b;
-
-void dram_t::cycle()
-{
-
-   if( !returnq->full() ) {
-       dram_req_t *cmd = rwq->pop();
-       if( cmd ) {
-#ifdef DRAM_VIEWCMD 
-           printf("\tDQ: BK%d Row:%03x Col:%03x", cmd->bk, cmd->row, cmd->col + cmd->dqbytes);
-#endif
-           cmd->dqbytes += m_config->dram_atom_size; 
-
-           if (cmd->dqbytes >= cmd->nbytes) {
-              mem_fetch *data = cmd->data; 
-              data->set_status(IN_PARTITION_MC_RETURNQ,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-              if( data->get_access_type() != L1_WRBK_ACC && data->get_access_type() != L2_WRBK_ACC ) {
-                 data->set_reply();
-                 returnq->push(data);
-              } else {
-                 m_memory_partition_unit->set_done(data);
-                 delete data;
-              }
-              delete cmd;
-           }
-#ifdef DRAM_VIEWCMD 
-           printf("\n");
-#endif
-       }
-   }
-
-   /* check if the upcoming request is on an idle bank */
-   /* Should we modify this so that multiple requests are checked? */
-
-   switch (m_config->scheduler_type) {
-   case DRAM_FIFO: scheduler_fifo(); break;
-   case DRAM_FRFCFS: scheduler_frfcfs(); break;
-	default:
-		printf("Error: Unknown DRAM scheduler type\n");
-		assert(0);
-   }
-   if ( m_config->scheduler_type == DRAM_FRFCFS) {
-      unsigned nreqs = m_frfcfs_scheduler->num_pending();
-      if ( nreqs > max_mrqs) {
-         max_mrqs = nreqs;
-      }
-      ave_mrqs += nreqs;
-      ave_mrqs_partial += nreqs;
-   } else {
-      if (mrqq->get_length() > max_mrqs) {
-         max_mrqs = mrqq->get_length();
-      }
-      ave_mrqs += mrqq->get_length();
-      ave_mrqs_partial +=  mrqq->get_length();
-   }
-
-   unsigned k=m_config->nbk;
-   bool issued = false;
-
-   //collect row buffer locality, BLP and other statistics
-   /////////////////////////////////////////////////////////////////////////
-   unsigned int memory_pending=0;
-   for (unsigned i=0;i<m_config->nbk;i++) {
-	   if (bk[i]->mrq)
-		   memory_pending++;
-   }
-   banks_1time += memory_pending;
-   if(memory_pending >0)
-	   banks_acess_total++;
-
-   unsigned int memory_pending_rw=0;
-   unsigned read_blp_rw=0;
-   unsigned write_blp_rw=0;
-   std::bitset<8> bnkgrp_rw_found;  //assume max we have 8 bank groups
-
-   for (unsigned j=0;j<m_config->nbk;j++) {
-  	   unsigned grp = get_bankgrp_number(j);
-  	   if (bk[j]->mrq && (((bk[j]->curr_row == bk[j]->mrq->row) &&
-  		  (bk[j]->mrq->rw == READ)  &&
-  		  (bk[j]->state == BANK_ACTIVE))))
-  	   {
-  		    memory_pending_rw++;
-  		    read_blp_rw++;
-  		    bnkgrp_rw_found.set(grp);
-  	   }
-  	   else if
-  	        (bk[j]->mrq && (((bk[j]->curr_row == bk[j]->mrq->row)  &&
-  			 (bk[j]->mrq->rw == WRITE) &&
-  			 (bk[j]->state == BANK_ACTIVE))))
-  	   {
-  		     memory_pending_rw++;
-  		     write_blp_rw++;
-  		     bnkgrp_rw_found.set(grp);
-  	   }
-     }
-     banks_time_rw += memory_pending_rw;
-     bkgrp_parallsim_rw += bnkgrp_rw_found.count();
-     if(memory_pending_rw >0)
-     {
-    	 write_to_read_ratio_blp_rw_average += (double)write_blp_rw/(write_blp_rw+read_blp_rw);
-  	     banks_access_rw_total++;
-     }
-
-   unsigned int memory_Pending_ready=0;
-   for (unsigned j=0;j<m_config->nbk;j++) {
-	   unsigned grp = get_bankgrp_number(j);
-	   if (bk[j]->mrq && ((!CCDc && !bk[j]->RCDc &&
-		  !(bkgrp[grp]->CCDLc) &&
-		  (bk[j]->curr_row == bk[j]->mrq->row) &&
-		  (bk[j]->mrq->rw == READ) && (WTRc == 0 )  &&
-		  (bk[j]->state == BANK_ACTIVE) &&
-		  !rwq->full())
-		   ||
-		   (!CCDc && !bk[j]->RCDWRc &&
-			 !(bkgrp[grp]->CCDLc) &&
-			 (bk[j]->curr_row == bk[j]->mrq->row)  &&
-			 (bk[j]->mrq->rw == WRITE) && (RTWc == 0 )  &&
-			 (bk[j]->state == BANK_ACTIVE) &&
-			 !rwq->full())))
-	   {
-		   memory_Pending_ready++;
-	   }
-   }
-   banks_time_ready += memory_Pending_ready;
-   if(memory_Pending_ready >0)
-	   banks_access_ready_total++;
-   ///////////////////////////////////////////////////////////////////////////////////
-
-   bool issued_col_cmd = false;
-   bool issued_row_cmd = false;
-
-   if(m_config->dual_bus_interface)
-   {
-	   //dual bus interface
-	   //issue one row command and one column command
-	     for (unsigned i=0;i<m_config->nbk;i++) {
-	       unsigned j = (i + prio) % m_config->nbk;
-	  	   issued_col_cmd  = issue_col_command(j);
-	  	   if(issued_col_cmd) break;
-	     }
-	     for (unsigned i=0;i<m_config->nbk;i++) {
-	    	unsigned j = (i + prio) % m_config->nbk;
-	  	    issued_row_cmd = issue_row_command(j);
-	  	    if(issued_row_cmd) break;
-	     }
-	     for (unsigned i=0;i<m_config->nbk;i++) {
-	    	 unsigned j = (i + prio) % m_config->nbk;
-	    	 if(!bk[j]->mrq) {
-				  if (!CCDc && !RRDc && !RTWc && !WTRc && !bk[j]->RCDc && !bk[j]->RASc
-					  && !bk[j]->RCc && !bk[j]->RPc  && !bk[j]->RCDWRc) k--;
-				  bk[j]->n_idle++;
-			}
-	     }
-   }
-   else
-   {
-	   //single bus interface
-	   //issue only one row/column command
-	   for (unsigned i=0;i<m_config->nbk;i++) {
-		   unsigned j = (i + prio) % m_config->nbk;
-		   if(!issued_col_cmd)
-		       issued_col_cmd  = issue_col_command(j);
-
-		   if(!issued_col_cmd && !issued_row_cmd)
-		       issued_row_cmd = issue_row_command(j);
-
-		   if(!bk[j]->mrq) {
-		          if (!CCDc && !RRDc && !RTWc && !WTRc && !bk[j]->RCDc && !bk[j]->RASc
-		              && !bk[j]->RCc && !bk[j]->RPc  && !bk[j]->RCDWRc) k--;
-		          bk[j]->n_idle++;
-		    }
-
-	   }
-   }
-
-   issued = issued_row_cmd || issued_col_cmd;
-   if (!issued) {
-      n_nop++;
-      n_nop_partial++;
+void dram_t::cycle() {
+  if (!returnq->full()) {
+    dram_req_t *cmd = rwq->pop();
+    if (cmd) {
 #ifdef DRAM_VIEWCMD
-      printf("\tNOP                        ");
+      printf("\tDQ: BK%d Row:%03x Col:%03x", cmd->bk, cmd->row,
+             cmd->col + cmd->dqbytes);
 #endif
-   }
-   if (k) {
-      n_activity++;
-      n_activity_partial++;
-   }
-   n_cmd++;
-   n_cmd_partial++;
-   if(issued)
-   {
-	   issued_total++;
-	   if(issued_col_cmd && issued_row_cmd)
-		   issued_two++;
-   }
-   if(issued_col_cmd)  issued_total_col++;
-   if(issued_row_cmd)  issued_total_row++;
+      cmd->dqbytes += m_config->dram_atom_size;
 
-
-   //Collect some statistics
-   //check the limitation, see where BW is wasted?
-   /////////////////////////////////////////////////////////
-   unsigned int memory_pending_found=0;
-      for (unsigned i=0;i<m_config->nbk;i++) {
-   	   if (bk[i]->mrq)
-   		memory_pending_found++;
-      }
-      if(memory_pending_found>0)
-    	  banks_acess_total_after++;
-
-        bool memory_pending_rw_found=false;
-        for (unsigned j=0;j<m_config->nbk;j++) {
-     	   if (bk[j]->mrq && (((bk[j]->curr_row == bk[j]->mrq->row) &&
-     		  (bk[j]->mrq->rw == READ)  &&
-     		  (bk[j]->state == BANK_ACTIVE))
-     		   ||
-     		   (
-     			 (bk[j]->curr_row == bk[j]->mrq->row)  &&
-     			 (bk[j]->mrq->rw == WRITE) &&
-     			 (bk[j]->state == BANK_ACTIVE))))
-     		  memory_pending_rw_found=true;
+      if (cmd->dqbytes >= cmd->nbytes) {
+        mem_fetch *data = cmd->data;
+        data->set_status(IN_PARTITION_MC_RETURNQ,
+                         m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+        if (data->get_access_type() != L1_WRBK_ACC &&
+            data->get_access_type() != L2_WRBK_ACC) {
+          data->set_reply();
+          returnq->push(data);
+        } else {
+          m_memory_partition_unit->set_done(data);
+          delete data;
         }
+        delete cmd;
+      }
+#ifdef DRAM_VIEWCMD
+      printf("\n");
+#endif
+    }
+  }
 
+  /* check if the upcoming request is on an idle bank */
+  /* Should we modify this so that multiple requests are checked? */
 
-   if(issued_col_cmd  || CCDc)
-	   util_bw++;
-   else if (memory_pending_rw_found)
-   {
-	   wasted_bw_col++;
-	   for (unsigned j=0;j<m_config->nbk;j++) {
-		   unsigned grp = get_bankgrp_number(j);
-		   //read
-		   if (bk[j]->mrq && (((bk[j]->curr_row == bk[j]->mrq->row) &&
-			  (bk[j]->mrq->rw == READ)  &&
-			  (bk[j]->state == BANK_ACTIVE))))
-		   {
-			   if(bk[j]->RCDc) RCDc_limit++;
-			   if(bkgrp[grp]->CCDLc) CCDLc_limit++;
-			   if(WTRc) WTRc_limit++;
-			   if(CCDc) CCDc_limit++;
-			   if(rwq->full()) rwq_limit++;
-			   if(bkgrp[grp]->CCDLc && !WTRc) CCDLc_limit_alone++;
-			   if(!bkgrp[grp]->CCDLc && WTRc) WTRc_limit_alone++;
-		   }
-		   //write
-		   else if (bk[j]->mrq && ((bk[j]->curr_row == bk[j]->mrq->row)  &&
-				 (bk[j]->mrq->rw == WRITE) &&
-				 (bk[j]->state == BANK_ACTIVE)))
-		   {
-			   if(bk[j]->RCDWRc) RCDWRc_limit++;
-			   if(bkgrp[grp]->CCDLc) CCDLc_limit++;
-			   if(RTWc) RTWc_limit++;
-			   if(CCDc) CCDc_limit++;
-			   if(rwq->full()) rwq_limit++;
-			   if(bkgrp[grp]->CCDLc && !RTWc) CCDLc_limit_alone++;
-			   if(!bkgrp[grp]->CCDLc && RTWc) RTWc_limit_alone++;
-		   }
-	     }
-   }
-   else if (memory_pending_found)
-	   wasted_bw_row++;
-   else if (!memory_pending_found)
-  	   idle_bw++;
-   else
-	   assert(1);
+  switch (m_config->scheduler_type) {
+    case DRAM_FIFO:
+      scheduler_fifo();
+      break;
+    case DRAM_FRFCFS:
+      scheduler_frfcfs();
+      break;
+    default:
+      printf("Error: Unknown DRAM scheduler type\n");
+      assert(0);
+  }
+  if (m_config->scheduler_type == DRAM_FRFCFS) {
+    unsigned nreqs = m_frfcfs_scheduler->num_pending();
+    if (nreqs > max_mrqs) {
+      max_mrqs = nreqs;
+    }
+    ave_mrqs += nreqs;
+    ave_mrqs_partial += nreqs;
+  } else {
+    if (mrqq->get_length() > max_mrqs) {
+      max_mrqs = mrqq->get_length();
+    }
+    ave_mrqs += mrqq->get_length();
+    ave_mrqs_partial += mrqq->get_length();
+  }
 
-   /////////////////////////////////////////////////////////
+  unsigned k = m_config->nbk;
+  bool issued = false;
 
-   // decrements counters once for each time dram_issueCMD is called
-   DEC2ZERO(RRDc);
-   DEC2ZERO(CCDc);
-   DEC2ZERO(RTWc);
-   DEC2ZERO(WTRc);
-   for (unsigned j=0;j<m_config->nbk;j++) {
-      DEC2ZERO(bk[j]->RCDc);
-      DEC2ZERO(bk[j]->RASc);
-      DEC2ZERO(bk[j]->RCc);
-      DEC2ZERO(bk[j]->RPc);
-      DEC2ZERO(bk[j]->RCDWRc);
-      DEC2ZERO(bk[j]->WTPc);
-      DEC2ZERO(bk[j]->RTPc);
-   }
-   for (unsigned j=0; j<m_config->nbkgrp; j++) {
-	   DEC2ZERO(bkgrp[j]->CCDLc);
-	   DEC2ZERO(bkgrp[j]->RTPLc);
-   }
+  // collect row buffer locality, BLP and other statistics
+  /////////////////////////////////////////////////////////////////////////
+  unsigned int memory_pending = 0;
+  for (unsigned i = 0; i < m_config->nbk; i++) {
+    if (bk[i]->mrq) memory_pending++;
+  }
+  banks_1time += memory_pending;
+  if (memory_pending > 0) banks_acess_total++;
+
+  unsigned int memory_pending_rw = 0;
+  unsigned read_blp_rw = 0;
+  unsigned write_blp_rw = 0;
+  std::bitset<8> bnkgrp_rw_found;  // assume max we have 8 bank groups
+
+  for (unsigned j = 0; j < m_config->nbk; j++) {
+    unsigned grp = get_bankgrp_number(j);
+    if (bk[j]->mrq &&
+        (((bk[j]->curr_row == bk[j]->mrq->row) && (bk[j]->mrq->rw == READ) &&
+          (bk[j]->state == BANK_ACTIVE)))) {
+      memory_pending_rw++;
+      read_blp_rw++;
+      bnkgrp_rw_found.set(grp);
+    } else if (bk[j]->mrq &&
+               (((bk[j]->curr_row == bk[j]->mrq->row) &&
+                 (bk[j]->mrq->rw == WRITE) && (bk[j]->state == BANK_ACTIVE)))) {
+      memory_pending_rw++;
+      write_blp_rw++;
+      bnkgrp_rw_found.set(grp);
+    }
+  }
+  banks_time_rw += memory_pending_rw;
+  bkgrp_parallsim_rw += bnkgrp_rw_found.count();
+  if (memory_pending_rw > 0) {
+    write_to_read_ratio_blp_rw_average +=
+        (double)write_blp_rw / (write_blp_rw + read_blp_rw);
+    banks_access_rw_total++;
+  }
+
+  unsigned int memory_Pending_ready = 0;
+  for (unsigned j = 0; j < m_config->nbk; j++) {
+    unsigned grp = get_bankgrp_number(j);
+    if (bk[j]->mrq &&
+        ((!CCDc && !bk[j]->RCDc && !(bkgrp[grp]->CCDLc) &&
+          (bk[j]->curr_row == bk[j]->mrq->row) && (bk[j]->mrq->rw == READ) &&
+          (WTRc == 0) && (bk[j]->state == BANK_ACTIVE) && !rwq->full()) ||
+         (!CCDc && !bk[j]->RCDWRc && !(bkgrp[grp]->CCDLc) &&
+          (bk[j]->curr_row == bk[j]->mrq->row) && (bk[j]->mrq->rw == WRITE) &&
+          (RTWc == 0) && (bk[j]->state == BANK_ACTIVE) && !rwq->full()))) {
+      memory_Pending_ready++;
+    }
+  }
+  banks_time_ready += memory_Pending_ready;
+  if (memory_Pending_ready > 0) banks_access_ready_total++;
+  ///////////////////////////////////////////////////////////////////////////////////
+
+  bool issued_col_cmd = false;
+  bool issued_row_cmd = false;
+
+  if (m_config->dual_bus_interface) {
+    // dual bus interface
+    // issue one row command and one column command
+    for (unsigned i = 0; i < m_config->nbk; i++) {
+      unsigned j = (i + prio) % m_config->nbk;
+      issued_col_cmd = issue_col_command(j);
+      if (issued_col_cmd) break;
+    }
+    for (unsigned i = 0; i < m_config->nbk; i++) {
+      unsigned j = (i + prio) % m_config->nbk;
+      issued_row_cmd = issue_row_command(j);
+      if (issued_row_cmd) break;
+    }
+    for (unsigned i = 0; i < m_config->nbk; i++) {
+      unsigned j = (i + prio) % m_config->nbk;
+      if (!bk[j]->mrq) {
+        if (!CCDc && !RRDc && !RTWc && !WTRc && !bk[j]->RCDc && !bk[j]->RASc &&
+            !bk[j]->RCc && !bk[j]->RPc && !bk[j]->RCDWRc)
+          k--;
+        bk[j]->n_idle++;
+      }
+    }
+  } else {
+    // single bus interface
+    // issue only one row/column command
+    for (unsigned i = 0; i < m_config->nbk; i++) {
+      unsigned j = (i + prio) % m_config->nbk;
+      if (!issued_col_cmd) issued_col_cmd = issue_col_command(j);
+
+      if (!issued_col_cmd && !issued_row_cmd)
+        issued_row_cmd = issue_row_command(j);
+
+      if (!bk[j]->mrq) {
+        if (!CCDc && !RRDc && !RTWc && !WTRc && !bk[j]->RCDc && !bk[j]->RASc &&
+            !bk[j]->RCc && !bk[j]->RPc && !bk[j]->RCDWRc)
+          k--;
+        bk[j]->n_idle++;
+      }
+    }
+  }
+
+  issued = issued_row_cmd || issued_col_cmd;
+  if (!issued) {
+    n_nop++;
+    n_nop_partial++;
+#ifdef DRAM_VIEWCMD
+    printf("\tNOP                        ");
+#endif
+  }
+  if (k) {
+    n_activity++;
+    n_activity_partial++;
+  }
+  n_cmd++;
+  n_cmd_partial++;
+  if (issued) {
+    issued_total++;
+    if (issued_col_cmd && issued_row_cmd) issued_two++;
+  }
+  if (issued_col_cmd) issued_total_col++;
+  if (issued_row_cmd) issued_total_row++;
+
+  // Collect some statistics
+  // check the limitation, see where BW is wasted?
+  /////////////////////////////////////////////////////////
+  unsigned int memory_pending_found = 0;
+  for (unsigned i = 0; i < m_config->nbk; i++) {
+    if (bk[i]->mrq) memory_pending_found++;
+  }
+  if (memory_pending_found > 0) banks_acess_total_after++;
+
+  bool memory_pending_rw_found = false;
+  for (unsigned j = 0; j < m_config->nbk; j++) {
+    if (bk[j]->mrq &&
+        (((bk[j]->curr_row == bk[j]->mrq->row) && (bk[j]->mrq->rw == READ) &&
+          (bk[j]->state == BANK_ACTIVE)) ||
+         ((bk[j]->curr_row == bk[j]->mrq->row) && (bk[j]->mrq->rw == WRITE) &&
+          (bk[j]->state == BANK_ACTIVE))))
+      memory_pending_rw_found = true;
+  }
+
+  if (issued_col_cmd || CCDc)
+    util_bw++;
+  else if (memory_pending_rw_found) {
+    wasted_bw_col++;
+    for (unsigned j = 0; j < m_config->nbk; j++) {
+      unsigned grp = get_bankgrp_number(j);
+      // read
+      if (bk[j]->mrq &&
+          (((bk[j]->curr_row == bk[j]->mrq->row) && (bk[j]->mrq->rw == READ) &&
+            (bk[j]->state == BANK_ACTIVE)))) {
+        if (bk[j]->RCDc) RCDc_limit++;
+        if (bkgrp[grp]->CCDLc) CCDLc_limit++;
+        if (WTRc) WTRc_limit++;
+        if (CCDc) CCDc_limit++;
+        if (rwq->full()) rwq_limit++;
+        if (bkgrp[grp]->CCDLc && !WTRc) CCDLc_limit_alone++;
+        if (!bkgrp[grp]->CCDLc && WTRc) WTRc_limit_alone++;
+      }
+      // write
+      else if (bk[j]->mrq &&
+               ((bk[j]->curr_row == bk[j]->mrq->row) &&
+                (bk[j]->mrq->rw == WRITE) && (bk[j]->state == BANK_ACTIVE))) {
+        if (bk[j]->RCDWRc) RCDWRc_limit++;
+        if (bkgrp[grp]->CCDLc) CCDLc_limit++;
+        if (RTWc) RTWc_limit++;
+        if (CCDc) CCDc_limit++;
+        if (rwq->full()) rwq_limit++;
+        if (bkgrp[grp]->CCDLc && !RTWc) CCDLc_limit_alone++;
+        if (!bkgrp[grp]->CCDLc && RTWc) RTWc_limit_alone++;
+      }
+    }
+  } else if (memory_pending_found)
+    wasted_bw_row++;
+  else if (!memory_pending_found)
+    idle_bw++;
+  else
+    assert(1);
+
+  /////////////////////////////////////////////////////////
+
+  // decrements counters once for each time dram_issueCMD is called
+  DEC2ZERO(RRDc);
+  DEC2ZERO(CCDc);
+  DEC2ZERO(RTWc);
+  DEC2ZERO(WTRc);
+  for (unsigned j = 0; j < m_config->nbk; j++) {
+    DEC2ZERO(bk[j]->RCDc);
+    DEC2ZERO(bk[j]->RASc);
+    DEC2ZERO(bk[j]->RCc);
+    DEC2ZERO(bk[j]->RPc);
+    DEC2ZERO(bk[j]->RCDWRc);
+    DEC2ZERO(bk[j]->WTPc);
+    DEC2ZERO(bk[j]->RTPc);
+  }
+  for (unsigned j = 0; j < m_config->nbkgrp; j++) {
+    DEC2ZERO(bkgrp[j]->CCDLc);
+    DEC2ZERO(bkgrp[j]->RTPLc);
+  }
 
 #ifdef DRAM_VISUALIZE
-   visualize();
+  visualize();
 #endif
 }
 
-bool dram_t::issue_col_command(int j)
-{
-	bool issued = false;
-	unsigned grp = get_bankgrp_number(j);
-    if (bk[j]->mrq) { //if currently servicing a memory request
-        bk[j]->mrq->data->set_status(IN_PARTITION_DRAM,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-       // correct row activated for a READ
-       if ( !issued && !CCDc && !bk[j]->RCDc &&
-            !(bkgrp[grp]->CCDLc) &&
-            (bk[j]->curr_row == bk[j]->mrq->row) &&
-            (bk[j]->mrq->rw == READ) && (WTRc == 0 )  &&
+bool dram_t::issue_col_command(int j) {
+  bool issued = false;
+  unsigned grp = get_bankgrp_number(j);
+  if (bk[j]->mrq) {  // if currently servicing a memory request
+    bk[j]->mrq->data->set_status(
+        IN_PARTITION_DRAM, m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+    // correct row activated for a READ
+    if (!issued && !CCDc && !bk[j]->RCDc && !(bkgrp[grp]->CCDLc) &&
+        (bk[j]->curr_row == bk[j]->mrq->row) && (bk[j]->mrq->rw == READ) &&
+        (WTRc == 0) && (bk[j]->state == BANK_ACTIVE) && !rwq->full()) {
+      if (rw == WRITE) {
+        rw = READ;
+        rwq->set_min_length(m_config->CL);
+      }
+      rwq->push(bk[j]->mrq);
+      bk[j]->mrq->txbytes += m_config->dram_atom_size;
+      CCDc = m_config->tCCD;
+      bkgrp[grp]->CCDLc = m_config->tCCDL;
+      RTWc = m_config->tRTW;
+      bk[j]->RTPc = m_config->BL / m_config->data_command_freq_ratio;
+      bkgrp[grp]->RTPLc = m_config->tRTPL;
+      issued = true;
+      if (bk[j]->mrq->data->get_access_type() == L2_WR_ALLOC_R)
+        n_rd_L2_A++;
+      else
+        n_rd++;
+
+      bwutil += m_config->BL / m_config->data_command_freq_ratio;
+      bwutil_partial += m_config->BL / m_config->data_command_freq_ratio;
+      bk[j]->n_access++;
+
+#ifdef DRAM_VERIFY
+      PRINT_CYCLE = 1;
+      printf("\tRD  Bk:%d Row:%03x Col:%03x \n", j, bk[j]->curr_row,
+             bk[j]->mrq->col + bk[j]->mrq->txbytes - m_config->dram_atom_size);
+#endif
+      // transfer done
+      if (!(bk[j]->mrq->txbytes < bk[j]->mrq->nbytes)) {
+        bk[j]->mrq = NULL;
+      }
+    } else
+        // correct row activated for a WRITE
+        if (!issued && !CCDc && !bk[j]->RCDWRc && !(bkgrp[grp]->CCDLc) &&
+            (bk[j]->curr_row == bk[j]->mrq->row) && (bk[j]->mrq->rw == WRITE) &&
+            (RTWc == 0) && (bk[j]->state == BANK_ACTIVE) && !rwq->full()) {
+      if (rw == READ) {
+        rw = WRITE;
+        rwq->set_min_length(m_config->WL);
+      }
+      rwq->push(bk[j]->mrq);
+
+      bk[j]->mrq->txbytes += m_config->dram_atom_size;
+      CCDc = m_config->tCCD;
+      bkgrp[grp]->CCDLc = m_config->tCCDL;
+      WTRc = m_config->tWTR;
+      bk[j]->WTPc = m_config->tWTP;
+      issued = true;
+
+      if (bk[j]->mrq->data->get_access_type() == L2_WRBK_ACC)
+        n_wr_WB++;
+      else
+        n_wr++;
+      bwutil += m_config->BL / m_config->data_command_freq_ratio;
+      bwutil_partial += m_config->BL / m_config->data_command_freq_ratio;
+#ifdef DRAM_VERIFY
+      PRINT_CYCLE = 1;
+      printf("\tWR  Bk:%d Row:%03x Col:%03x \n", j, bk[j]->curr_row,
+             bk[j]->mrq->col + bk[j]->mrq->txbytes - m_config->dram_atom_size);
+#endif
+      // transfer done
+      if (!(bk[j]->mrq->txbytes < bk[j]->mrq->nbytes)) {
+        bk[j]->mrq = NULL;
+      }
+    }
+  }
+
+  return issued;
+}
+
+bool dram_t::issue_row_command(int j) {
+  bool issued = false;
+  unsigned grp = get_bankgrp_number(j);
+  if (bk[j]->mrq) {  // if currently servicing a memory request
+    bk[j]->mrq->data->set_status(
+        IN_PARTITION_DRAM, m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+    //     bank is idle
+    // else
+    if (!issued && !RRDc && (bk[j]->state == BANK_IDLE) && !bk[j]->RPc &&
+        !bk[j]->RCc) {  //
+#ifdef DRAM_VERIFY
+      PRINT_CYCLE = 1;
+      printf("\tACT BK:%d NewRow:%03x From:%03x \n", j, bk[j]->mrq->row,
+             bk[j]->curr_row);
+#endif
+      // activate the row with current memory request
+      bk[j]->curr_row = bk[j]->mrq->row;
+      bk[j]->state = BANK_ACTIVE;
+      RRDc = m_config->tRRD;
+      bk[j]->RCDc = m_config->tRCD;
+      bk[j]->RCDWRc = m_config->tRCDWR;
+      bk[j]->RASc = m_config->tRAS;
+      bk[j]->RCc = m_config->tRC;
+      prio = (j + 1) % m_config->nbk;
+      issued = true;
+      n_act_partial++;
+      n_act++;
+    }
+
+    else
+        // different row activated
+        if ((!issued) && (bk[j]->curr_row != bk[j]->mrq->row) &&
             (bk[j]->state == BANK_ACTIVE) &&
-            !rwq->full() ) {
-          if (rw==WRITE) {
-             rw=READ;
-             rwq->set_min_length(m_config->CL);
-          }
-          rwq->push(bk[j]->mrq);
-          bk[j]->mrq->txbytes += m_config->dram_atom_size;
-          CCDc = m_config->tCCD;
-          bkgrp[grp]->CCDLc = m_config->tCCDL;
-          RTWc = m_config->tRTW;
-          bk[j]->RTPc = m_config->BL/m_config->data_command_freq_ratio;
-          bkgrp[grp]->RTPLc = m_config->tRTPL;
-          issued = true;
-          if(bk[j]->mrq->data->get_access_type() == L2_WR_ALLOC_R)
-        	  n_rd_L2_A++;
-          else
-                n_rd++;
-
-          bwutil += m_config->BL/m_config->data_command_freq_ratio;
-          bwutil_partial += m_config->BL/m_config->data_command_freq_ratio;
-          bk[j]->n_access++;
-
+            (!bk[j]->RASc && !bk[j]->WTPc && !bk[j]->RTPc &&
+             !bkgrp[grp]->RTPLc)) {
+      // make the bank idle again
+      bk[j]->state = BANK_IDLE;
+      bk[j]->RPc = m_config->tRP;
+      prio = (j + 1) % m_config->nbk;
+      issued = true;
+      n_pre++;
+      n_pre_partial++;
 #ifdef DRAM_VERIFY
-          PRINT_CYCLE=1;
-          printf("\tRD  Bk:%d Row:%03x Col:%03x \n",
-                 j, bk[j]->curr_row,
-                 bk[j]->mrq->col + bk[j]->mrq->txbytes - m_config->dram_atom_size);
+      PRINT_CYCLE = 1;
+      printf("\tPRE BK:%d Row:%03x \n", j, bk[j]->curr_row);
 #endif
-          // transfer done
-          if ( !(bk[j]->mrq->txbytes < bk[j]->mrq->nbytes) ) {
-             bk[j]->mrq = NULL;
-          }
-       } else
-          // correct row activated for a WRITE
-          if ( !issued && !CCDc && !bk[j]->RCDWRc &&
-               !(bkgrp[grp]->CCDLc) &&
-               (bk[j]->curr_row == bk[j]->mrq->row)  &&
-               (bk[j]->mrq->rw == WRITE) && (RTWc == 0 )  &&
-               (bk[j]->state == BANK_ACTIVE) &&
-               !rwq->full() ) {
-          if (rw==READ) {
-             rw=WRITE;
-             rwq->set_min_length(m_config->WL);
-          }
-          rwq->push(bk[j]->mrq);
-
-          bk[j]->mrq->txbytes += m_config->dram_atom_size;
-          CCDc = m_config->tCCD;
-          bkgrp[grp]->CCDLc = m_config->tCCDL;
-          WTRc = m_config->tWTR;
-          bk[j]->WTPc = m_config->tWTP;
-          issued = true;
-
-          if(bk[j]->mrq->data->get_access_type() == L2_WRBK_ACC)
-          	n_wr_WB++;
-          else
-          	 n_wr++;
-          bwutil += m_config->BL/m_config->data_command_freq_ratio;
-          bwutil_partial += m_config->BL/m_config->data_command_freq_ratio;
-#ifdef DRAM_VERIFY
-          PRINT_CYCLE=1;
-          printf("\tWR  Bk:%d Row:%03x Col:%03x \n",
-                 j, bk[j]->curr_row,
-                 bk[j]->mrq->col + bk[j]->mrq->txbytes - m_config->dram_atom_size);
-#endif
-          // transfer done
-          if ( !(bk[j]->mrq->txbytes < bk[j]->mrq->nbytes) ) {
-             bk[j]->mrq = NULL;
-          }
-       }
-
     }
-
-    return issued;
+  }
+  return issued;
 }
 
-bool dram_t::issue_row_command(int j)
-{
-	bool issued = false;
-	unsigned grp = get_bankgrp_number(j);
-    if (bk[j]->mrq) { //if currently servicing a memory request
-        bk[j]->mrq->data->set_status(IN_PARTITION_DRAM,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-      //     bank is idle
-    //else
-  	  if ( !issued && !RRDc &&
-               (bk[j]->state == BANK_IDLE) &&
-               !bk[j]->RPc && !bk[j]->RCc) { //
-#ifdef DRAM_VERIFY
-          PRINT_CYCLE=1;
-          printf("\tACT BK:%d NewRow:%03x From:%03x \n",
-                 j,bk[j]->mrq->row,bk[j]->curr_row);
-#endif
-          // activate the row with current memory request
-          bk[j]->curr_row = bk[j]->mrq->row;
-          bk[j]->state = BANK_ACTIVE;
-          RRDc = m_config->tRRD;
-          bk[j]->RCDc = m_config->tRCD;
-          bk[j]->RCDWRc = m_config->tRCDWR;
-          bk[j]->RASc = m_config->tRAS;
-          bk[j]->RCc = m_config->tRC;
-          prio = (j + 1) % m_config->nbk;
-          issued = true;
-          n_act_partial++;
-          n_act++;
-       }
-
-       else
-          // different row activated
-          if ( (!issued) &&
-               (bk[j]->curr_row != bk[j]->mrq->row) &&
-               (bk[j]->state == BANK_ACTIVE) &&
-               (!bk[j]->RASc && !bk[j]->WTPc &&
-				  !bk[j]->RTPc &&
-				  !bkgrp[grp]->RTPLc) ) {
-          // make the bank idle again
-          bk[j]->state = BANK_IDLE;
-          bk[j]->RPc = m_config->tRP;
-          prio = (j + 1) % m_config->nbk;
-          issued = true;
-          n_pre++;
-          n_pre_partial++;
-#ifdef DRAM_VERIFY
-          PRINT_CYCLE=1;
-          printf("\tPRE BK:%d Row:%03x \n", j,bk[j]->curr_row);
-#endif
-       }
-    }
-    return issued;
+// if mrq is being serviced by dram, gets popped after CL latency fulfilled
+class mem_fetch *dram_t::return_queue_pop() {
+  return returnq->pop();
 }
 
-
-//if mrq is being serviced by dram, gets popped after CL latency fulfilled
-class mem_fetch* dram_t::return_queue_pop()
-{
-    return returnq->pop();
+class mem_fetch *dram_t::return_queue_top() {
+  return returnq->top();
 }
 
-class mem_fetch* dram_t::return_queue_top()
-{
-    return returnq->top();
+void dram_t::print(FILE *simFile) const {
+  unsigned i;
+  fprintf(simFile, "DRAM[%d]: %d bks, busW=%d BL=%d CL=%d, ", id, m_config->nbk,
+          m_config->busW, m_config->BL, m_config->CL);
+  fprintf(simFile, "tRRD=%d tCCD=%d, tRCD=%d tRAS=%d tRP=%d tRC=%d\n",
+          m_config->tRRD, m_config->tCCD, m_config->tRCD, m_config->tRAS,
+          m_config->tRP, m_config->tRC);
+  fprintf(
+      simFile,
+      "n_cmd=%llu n_nop=%llu n_act=%llu n_pre=%llu n_ref_event=%llu n_req=%llu "
+      "n_rd=%llu n_rd_L2_A=%llu n_write=%llu n_wr_bk=%llu bw_util=%.4g\n",
+      n_cmd, n_nop, n_act, n_pre, n_ref, n_req, n_rd, n_rd_L2_A, n_wr, n_wr_WB,
+      (float)bwutil / n_cmd);
+  fprintf(simFile, "n_activity=%llu dram_eff=%.4g\n", n_activity,
+          (float)bwutil / n_activity);
+  for (i = 0; i < m_config->nbk; i++) {
+    fprintf(simFile, "bk%d: %da %di ", i, bk[i]->n_access, bk[i]->n_idle);
+  }
+  fprintf(simFile, "\n");
+  fprintf(simFile,
+          "\n------------------------------------------------------------------"
+          "------\n");
+
+  printf("\nRow_Buffer_Locality = %.6f", (float)hits_num / access_num);
+  printf("\nRow_Buffer_Locality_read = %.6f", (float)hits_read_num / read_num);
+  printf("\nRow_Buffer_Locality_write = %.6f",
+         (float)hits_write_num / write_num);
+  printf("\nBank_Level_Parallism = %.6f",
+         (float)banks_1time / banks_acess_total);
+  printf("\nBank_Level_Parallism_Col = %.6f",
+         (float)banks_time_rw / banks_access_rw_total);
+  printf("\nBank_Level_Parallism_Ready = %.6f",
+         (float)banks_time_ready / banks_access_ready_total);
+  printf("\nwrite_to_read_ratio_blp_rw_average = %.6f",
+         write_to_read_ratio_blp_rw_average / banks_access_rw_total);
+  printf("\nGrpLevelPara = %.6f \n",
+         (float)bkgrp_parallsim_rw / banks_access_rw_total);
+
+  printf("\nBW Util details:\n");
+  printf("bwutil = %.6f \n", (float)bwutil / n_cmd);
+  printf("total_CMD = %llu \n", n_cmd);
+  printf("util_bw = %llu \n", util_bw);
+  printf("Wasted_Col = %llu \n", wasted_bw_col);
+  printf("Wasted_Row = %llu \n", wasted_bw_row);
+  printf("Idle = %llu \n", idle_bw);
+
+  printf("\nBW Util Bottlenecks: \n");
+  printf("RCDc_limit = %llu \n", RCDc_limit);
+  printf("RCDWRc_limit = %llu \n", RCDWRc_limit);
+  printf("WTRc_limit = %llu \n", WTRc_limit);
+  printf("RTWc_limit = %llu \n", RTWc_limit);
+  printf("CCDLc_limit = %llu \n", CCDLc_limit);
+  printf("rwq = %llu \n", rwq_limit);
+  printf("CCDLc_limit_alone = %llu \n", CCDLc_limit_alone);
+  printf("WTRc_limit_alone = %llu \n", WTRc_limit_alone);
+  printf("RTWc_limit_alone = %llu \n", RTWc_limit_alone);
+
+  printf("\nCommands details: \n");
+  printf("total_CMD = %llu \n", n_cmd);
+  printf("n_nop = %llu \n", n_nop);
+  printf("Read = %llu \n", n_rd);
+  printf("Write = %llu \n", n_wr);
+  printf("L2_Alloc = %llu \n", n_rd_L2_A);
+  printf("L2_WB = %llu \n", n_wr_WB);
+  printf("n_act = %llu \n", n_act);
+  printf("n_pre = %llu \n", n_pre);
+  printf("n_ref = %llu \n", n_ref);
+  printf("n_req = %llu \n", n_req);
+  printf("total_req = %llu \n", n_rd + n_wr + n_rd_L2_A + n_wr_WB);
+
+  printf("\nDual Bus Interface Util: \n");
+  printf("issued_total_row = %llu \n", issued_total_row);
+  printf("issued_total_col = %llu \n", issued_total_col);
+  printf("Row_Bus_Util =  %.6f \n", (float)issued_total_row / n_cmd);
+  printf("CoL_Bus_Util = %.6f \n", (float)issued_total_col / n_cmd);
+  printf("Either_Row_CoL_Bus_Util = %.6f \n", (float)issued_total / n_cmd);
+  printf("Issued_on_Two_Bus_Simul_Util = %.6f \n", (float)issued_two / n_cmd);
+  printf("issued_two_Eff = %.6f \n", (float)issued_two / issued_total);
+  printf("queue_avg = %.6f \n\n", (float)ave_mrqs / n_cmd);
+
+  fprintf(simFile, "\n");
+  fprintf(simFile, "dram_util_bins:");
+  for (i = 0; i < 10; i++) fprintf(simFile, " %d", dram_util_bins[i]);
+  fprintf(simFile, "\ndram_eff_bins:");
+  for (i = 0; i < 10; i++) fprintf(simFile, " %d", dram_eff_bins[i]);
+  fprintf(simFile, "\n");
+  if (m_config->scheduler_type == DRAM_FRFCFS)
+    fprintf(simFile, "mrqq: max=%d avg=%g\n", max_mrqs,
+            (float)ave_mrqs / n_cmd);
 }
 
-
-void dram_t::print( FILE* simFile) const
-{
-   unsigned i;
-   fprintf(simFile,"DRAM[%d]: %d bks, busW=%d BL=%d CL=%d, ", 
-           id, m_config->nbk, m_config->busW, m_config->BL, m_config->CL );
-   fprintf(simFile,"tRRD=%d tCCD=%d, tRCD=%d tRAS=%d tRP=%d tRC=%d\n",
-           m_config->tRRD, m_config->tCCD, m_config->tRCD, m_config->tRAS, m_config->tRP, m_config->tRC );
-   fprintf(simFile,"n_cmd=%llu n_nop=%llu n_act=%llu n_pre=%llu n_ref_event=%llu n_req=%llu n_rd=%llu n_rd_L2_A=%llu n_write=%llu n_wr_bk=%llu bw_util=%.4g\n",
-           n_cmd, n_nop, n_act, n_pre, n_ref, n_req, n_rd, n_rd_L2_A, n_wr, n_wr_WB,
-           (float)bwutil/n_cmd);
-   fprintf(simFile,"n_activity=%llu dram_eff=%.4g\n",
-           n_activity, (float)bwutil/n_activity);
-   for (i=0;i<m_config->nbk;i++) {
-      fprintf(simFile, "bk%d: %da %di ",i,bk[i]->n_access,bk[i]->n_idle);
-   }
-   fprintf(simFile, "\n");
-   fprintf(simFile, "\n------------------------------------------------------------------------\n");
-
-   printf("\nRow_Buffer_Locality = %.6f", (float)hits_num / access_num);
-   printf("\nRow_Buffer_Locality_read = %.6f", (float)hits_read_num / read_num);
-   printf("\nRow_Buffer_Locality_write = %.6f", (float)hits_write_num / write_num);
-   printf("\nBank_Level_Parallism = %.6f", (float)banks_1time / banks_acess_total);
-   printf("\nBank_Level_Parallism_Col = %.6f", (float)banks_time_rw / banks_access_rw_total);
-   printf("\nBank_Level_Parallism_Ready = %.6f", (float)banks_time_ready /banks_access_ready_total);
-   printf("\nwrite_to_read_ratio_blp_rw_average = %.6f", write_to_read_ratio_blp_rw_average /banks_access_rw_total);
-   printf("\nGrpLevelPara = %.6f \n", (float)bkgrp_parallsim_rw /banks_access_rw_total);
-
-   printf("\nBW Util details:\n");
-   printf("bwutil = %.6f \n", (float)bwutil/n_cmd);
-   printf("total_CMD = %llu \n", n_cmd);
-   printf("util_bw = %llu \n", util_bw);
-   printf("Wasted_Col = %llu \n", wasted_bw_col);
-   printf("Wasted_Row = %llu \n", wasted_bw_row);
-   printf("Idle = %llu \n", idle_bw);
-
-   printf("\nBW Util Bottlenecks: \n");
-   printf("RCDc_limit = %llu \n", RCDc_limit);
-   printf("RCDWRc_limit = %llu \n", RCDWRc_limit);
-   printf("WTRc_limit = %llu \n", WTRc_limit);
-   printf("RTWc_limit = %llu \n", RTWc_limit);
-   printf("CCDLc_limit = %llu \n", CCDLc_limit);
-   printf("rwq = %llu \n", rwq_limit);
-   printf("CCDLc_limit_alone = %llu \n", CCDLc_limit_alone);
-   printf("WTRc_limit_alone = %llu \n", WTRc_limit_alone);
-   printf("RTWc_limit_alone = %llu \n", RTWc_limit_alone);
-
-   printf("\nCommands details: \n");
-   printf("total_CMD = %llu \n", n_cmd);
-   printf("n_nop = %llu \n", n_nop);
-   printf("Read = %llu \n", n_rd);
-   printf("Write = %llu \n",n_wr);
-   printf("L2_Alloc = %llu \n", n_rd_L2_A);
-   printf("L2_WB = %llu \n", n_wr_WB);
-   printf("n_act = %llu \n", n_act);
-   printf("n_pre = %llu \n", n_pre);
-   printf("n_ref = %llu \n", n_ref);
-   printf("n_req = %llu \n", n_req );
-   printf("total_req = %llu \n", n_rd+n_wr+n_rd_L2_A+n_wr_WB);
-
-   printf("\nDual Bus Interface Util: \n");
-   printf("issued_total_row = %llu \n", issued_total_row);
-   printf("issued_total_col = %llu \n", issued_total_col);
-   printf("Row_Bus_Util =  %.6f \n", (float)issued_total_row / n_cmd);
-   printf("CoL_Bus_Util = %.6f \n", (float)issued_total_col / n_cmd);
-   printf("Either_Row_CoL_Bus_Util = %.6f \n",  (float)issued_total / n_cmd);
-   printf("Issued_on_Two_Bus_Simul_Util = %.6f \n",  (float)issued_two /n_cmd);
-   printf("issued_two_Eff = %.6f \n",  (float)issued_two /issued_total);
-   printf("queue_avg = %.6f \n\n", (float)ave_mrqs/n_cmd );
-
-   fprintf(simFile, "\n");
-   fprintf(simFile, "dram_util_bins:");
-   for (i=0;i<10;i++) fprintf(simFile, " %d", dram_util_bins[i]);
-   fprintf(simFile, "\ndram_eff_bins:");
-   for (i=0;i<10;i++) fprintf(simFile, " %d", dram_eff_bins[i]);
-   fprintf(simFile, "\n");
-   if(m_config->scheduler_type== DRAM_FRFCFS)
-       fprintf(simFile, "mrqq: max=%d avg=%g\n", max_mrqs, (float)ave_mrqs/n_cmd);
+void dram_t::visualize() const {
+  printf("RRDc=%d CCDc=%d mrqq.Length=%d rwq.Length=%d\n", RRDc, CCDc,
+         mrqq->get_length(), rwq->get_length());
+  for (unsigned i = 0; i < m_config->nbk; i++) {
+    printf("BK%d: state=%c curr_row=%03x, %2d %2d %2d %2d %p ", i, bk[i]->state,
+           bk[i]->curr_row, bk[i]->RCDc, bk[i]->RASc, bk[i]->RPc, bk[i]->RCc,
+           bk[i]->mrq);
+    if (bk[i]->mrq)
+      printf("txf: %d %d", bk[i]->mrq->nbytes, bk[i]->mrq->txbytes);
+    printf("\n");
+  }
+  if (m_frfcfs_scheduler) m_frfcfs_scheduler->print(stdout);
 }
 
-void dram_t::visualize() const
-{
-   printf("RRDc=%d CCDc=%d mrqq.Length=%d rwq.Length=%d\n", 
-          RRDc, CCDc, mrqq->get_length(),rwq->get_length());
-   for (unsigned i=0;i<m_config->nbk;i++) {
-      printf("BK%d: state=%c curr_row=%03x, %2d %2d %2d %2d %p ", 
-             i, bk[i]->state, bk[i]->curr_row,
-             bk[i]->RCDc, bk[i]->RASc,
-             bk[i]->RPc, bk[i]->RCc,
-             bk[i]->mrq );
-      if (bk[i]->mrq)
-         printf("txf: %d %d", bk[i]->mrq->nbytes, bk[i]->mrq->txbytes);
-      printf("\n");
-   }
-   if ( m_frfcfs_scheduler ) 
-      m_frfcfs_scheduler->print(stdout);
+void dram_t::print_stat(FILE *simFile) {
+  fprintf(simFile,
+          "DRAM (%u): n_cmd=%llu n_nop=%llu n_act=%llu n_pre=%llu n_ref=%llu "
+          "n_req=%llu n_rd=%llu n_write=%llu bw_util=%.4g ",
+          id, n_cmd, n_nop, n_act, n_pre, n_ref, n_req, n_rd, n_wr,
+          (float)bwutil / n_cmd);
+  fprintf(simFile, "mrqq: %d %.4g mrqsmax=%llu ", max_mrqs,
+          (float)ave_mrqs / n_cmd, max_mrqs_temp);
+  fprintf(simFile, "\n");
+  fprintf(simFile, "dram_util_bins:");
+  for (unsigned i = 0; i < 10; i++) fprintf(simFile, " %d", dram_util_bins[i]);
+  fprintf(simFile, "\ndram_eff_bins:");
+  for (unsigned i = 0; i < 10; i++) fprintf(simFile, " %d", dram_eff_bins[i]);
+  fprintf(simFile, "\n");
+  max_mrqs_temp = 0;
 }
 
-void dram_t::print_stat( FILE* simFile ) 
-{
-   fprintf(simFile,"DRAM (%u): n_cmd=%llu n_nop=%llu n_act=%llu n_pre=%llu n_ref=%llu n_req=%llu n_rd=%llu n_write=%llu bw_util=%.4g ",
-           id, n_cmd, n_nop, n_act, n_pre, n_ref, n_req, n_rd, n_wr,
-           (float)bwutil/n_cmd);
-   fprintf(simFile, "mrqq: %d %.4g mrqsmax=%llu ", max_mrqs, (float)ave_mrqs/n_cmd, max_mrqs_temp);
-   fprintf(simFile, "\n");
-   fprintf(simFile, "dram_util_bins:");
-   for (unsigned i=0;i<10;i++) fprintf(simFile, " %d", dram_util_bins[i]);
-   fprintf(simFile, "\ndram_eff_bins:");
-   for (unsigned i=0;i<10;i++) fprintf(simFile, " %d", dram_eff_bins[i]);
-   fprintf(simFile, "\n");
-   max_mrqs_temp = 0;
+void dram_t::visualizer_print(gzFile visualizer_file) {
+  // dram specific statistics
+  gzprintf(visualizer_file, "dramncmd: %u %u\n", id, n_cmd_partial);
+  gzprintf(visualizer_file, "dramnop: %u %u\n", id, n_nop_partial);
+  gzprintf(visualizer_file, "dramnact: %u %u\n", id, n_act_partial);
+  gzprintf(visualizer_file, "dramnpre: %u %u\n", id, n_pre_partial);
+  gzprintf(visualizer_file, "dramnreq: %u %u\n", id, n_req_partial);
+  gzprintf(visualizer_file, "dramavemrqs: %u %u\n", id,
+           n_cmd_partial ? (ave_mrqs_partial / n_cmd_partial) : 0);
+
+  // utilization and efficiency
+  gzprintf(visualizer_file, "dramutil: %u %u\n", id,
+           n_cmd_partial ? 100 * bwutil_partial / n_cmd_partial : 0);
+  gzprintf(visualizer_file, "drameff: %u %u\n", id,
+           n_activity_partial ? 100 * bwutil_partial / n_activity_partial : 0);
+
+  // reset for next interval
+  bwutil_partial = 0;
+  n_activity_partial = 0;
+  ave_mrqs_partial = 0;
+  n_cmd_partial = 0;
+  n_nop_partial = 0;
+  n_act_partial = 0;
+  n_pre_partial = 0;
+  n_req_partial = 0;
+
+  // dram access type classification
+  for (unsigned j = 0; j < m_config->nbk; j++) {
+    gzprintf(visualizer_file, "dramglobal_acc_r: %u %u %u\n", id, j,
+             m_stats->mem_access_type_stats[GLOBAL_ACC_R][id][j]);
+    gzprintf(visualizer_file, "dramglobal_acc_w: %u %u %u\n", id, j,
+             m_stats->mem_access_type_stats[GLOBAL_ACC_W][id][j]);
+    gzprintf(visualizer_file, "dramlocal_acc_r: %u %u %u\n", id, j,
+             m_stats->mem_access_type_stats[LOCAL_ACC_R][id][j]);
+    gzprintf(visualizer_file, "dramlocal_acc_w: %u %u %u\n", id, j,
+             m_stats->mem_access_type_stats[LOCAL_ACC_W][id][j]);
+    gzprintf(visualizer_file, "dramconst_acc_r: %u %u %u\n", id, j,
+             m_stats->mem_access_type_stats[CONST_ACC_R][id][j]);
+    gzprintf(visualizer_file, "dramtexture_acc_r: %u %u %u\n", id, j,
+             m_stats->mem_access_type_stats[TEXTURE_ACC_R][id][j]);
+  }
 }
 
-void dram_t::visualizer_print( gzFile visualizer_file )
-{
-   // dram specific statistics
-   gzprintf(visualizer_file,"dramncmd: %u %u\n",id, n_cmd_partial);  
-   gzprintf(visualizer_file,"dramnop: %u %u\n",id,n_nop_partial);
-   gzprintf(visualizer_file,"dramnact: %u %u\n",id,n_act_partial);
-   gzprintf(visualizer_file,"dramnpre: %u %u\n",id,n_pre_partial);
-   gzprintf(visualizer_file,"dramnreq: %u %u\n",id,n_req_partial);
-   gzprintf(visualizer_file,"dramavemrqs: %u %u\n",id,
-            n_cmd_partial?(ave_mrqs_partial/n_cmd_partial ):0);
-
-   // utilization and efficiency
-   gzprintf(visualizer_file,"dramutil: %u %u\n",  
-            id,n_cmd_partial?100*bwutil_partial/n_cmd_partial:0);
-   gzprintf(visualizer_file,"drameff: %u %u\n", 
-            id,n_activity_partial?100*bwutil_partial/n_activity_partial:0);
-
-   // reset for next interval
-   bwutil_partial = 0;
-   n_activity_partial = 0;
-   ave_mrqs_partial = 0; 
-   n_cmd_partial = 0;
-   n_nop_partial = 0;
-   n_act_partial = 0;
-   n_pre_partial = 0;
-   n_req_partial = 0;
-
-
-   // dram access type classification
-   for (unsigned j = 0; j < m_config->nbk; j++) {
-      gzprintf(visualizer_file,"dramglobal_acc_r: %u %u %u\n", id, j, 
-               m_stats->mem_access_type_stats[GLOBAL_ACC_R][id][j]);
-      gzprintf(visualizer_file,"dramglobal_acc_w: %u %u %u\n", id, j, 
-               m_stats->mem_access_type_stats[GLOBAL_ACC_W][id][j]);
-      gzprintf(visualizer_file,"dramlocal_acc_r: %u %u %u\n", id, j, 
-               m_stats->mem_access_type_stats[LOCAL_ACC_R][id][j]);
-      gzprintf(visualizer_file,"dramlocal_acc_w: %u %u %u\n", id, j, 
-               m_stats->mem_access_type_stats[LOCAL_ACC_W][id][j]);
-      gzprintf(visualizer_file,"dramconst_acc_r: %u %u %u\n", id, j, 
-               m_stats->mem_access_type_stats[CONST_ACC_R][id][j]);
-      gzprintf(visualizer_file,"dramtexture_acc_r: %u %u %u\n", id, j, 
-               m_stats->mem_access_type_stats[TEXTURE_ACC_R][id][j]);
-   }
+void dram_t::set_dram_power_stats(unsigned &cmd, unsigned &activity,
+                                  unsigned &nop, unsigned &act, unsigned &pre,
+                                  unsigned &rd, unsigned &wr,
+                                  unsigned &req) const {
+  // Point power performance counters to low-level DRAM counters
+  cmd = n_cmd;
+  activity = n_activity;
+  nop = n_nop;
+  act = n_act;
+  pre = n_pre;
+  rd = n_rd;
+  wr = n_wr;
+  req = n_req;
 }
 
-
-void dram_t::set_dram_power_stats(	unsigned &cmd,
-									unsigned &activity,
-									unsigned &nop,
-									unsigned &act,
-									unsigned &pre,
-									unsigned &rd,
-									unsigned &wr,
-									unsigned &req) const{
-
-	// Point power performance counters to low-level DRAM counters
-	cmd = n_cmd;
-	activity = n_activity;
-	nop = n_nop;
-	act = n_act;
-	pre = n_pre;
-	rd = n_rd;
-	wr = n_wr;
-	req = n_req;
-}
-
-unsigned dram_t::get_bankgrp_number(unsigned i)
-{
-	if(m_config->dram_bnkgrp_indexing_policy == HIGHER_BITS) { //higher bits
-		return i >> m_config->bk_tag_length;
-	}
-	else if (m_config->dram_bnkgrp_indexing_policy == LOWER_BITS) { //lower bits
-		return i & ((m_config->nbkgrp - 1));
-	}
-	else {
-		assert(1);
-	}
+unsigned dram_t::get_bankgrp_number(unsigned i) {
+  if (m_config->dram_bnkgrp_indexing_policy == HIGHER_BITS) {  // higher bits
+    return i >> m_config->bk_tag_length;
+  } else if (m_config->dram_bnkgrp_indexing_policy ==
+             LOWER_BITS) {  // lower bits
+    return i & ((m_config->nbkgrp - 1));
+  } else {
+    assert(1);
+  }
 }

--- a/src/gpgpu-sim/dram.cc
+++ b/src/gpgpu-sim/dram.cc
@@ -8,14 +8,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -26,13 +28,13 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "gpu-sim.h"
-#include "gpu-misc.h"
 #include "dram.h"
-#include "mem_latency_stat.h"
 #include "dram_sched.h"
-#include "mem_fetch.h"
+#include "gpu-misc.h"
+#include "gpu-sim.h"
 #include "l2cache.h"
+#include "mem_fetch.h"
+#include "mem_latency_stat.h"
 
 #ifdef DRAM_VERIFY
 int PRINT_CYCLE = 0;
@@ -41,869 +43,828 @@ int PRINT_CYCLE = 0;
 template class fifo_pipeline<mem_fetch>;
 template class fifo_pipeline<dram_req_t>;
 
-dram_t::dram_t( unsigned int partition_id, const memory_config *config, memory_stats_t *stats,
-                memory_partition_unit *mp, gpgpu_sim* gpu )
-{
-   id = partition_id;
-   m_memory_partition_unit = mp;
-   m_stats = stats;
-   m_config = config;
-   m_gpu = gpu;
+dram_t::dram_t(unsigned int partition_id, const memory_config *config,
+               memory_stats_t *stats, memory_partition_unit *mp,
+               gpgpu_sim *gpu) {
+  id = partition_id;
+  m_memory_partition_unit = mp;
+  m_stats = stats;
+  m_config = config;
+  m_gpu = gpu;
 
-   //rowblp
-   access_num=0;
-   hits_num=0;
-   read_num=0;
-   write_num=0;
-   hits_read_num=0;
-   hits_write_num=0;
-   banks_1time=0;
-   banks_acess_total=0;
-   banks_acess_total_after=0;
-   banks_time_ready=0;
-   banks_access_ready_total=0;
-   issued_two=0;
-   issued_total=0;
-   issued_total_row=0;
-   issued_total_col=0;
+  // rowblp
+  access_num = 0;
+  hits_num = 0;
+  read_num = 0;
+  write_num = 0;
+  hits_read_num = 0;
+  hits_write_num = 0;
+  banks_1time = 0;
+  banks_acess_total = 0;
+  banks_acess_total_after = 0;
+  banks_time_ready = 0;
+  banks_access_ready_total = 0;
+  issued_two = 0;
+  issued_total = 0;
+  issued_total_row = 0;
+  issued_total_col = 0;
 
-   CCDc = 0;
-   RRDc = 0;
-   RTWc = 0;
-   WTRc = 0;
+  CCDc = 0;
+  RRDc = 0;
+  RTWc = 0;
+  WTRc = 0;
 
-   wasted_bw_row=0;
-   wasted_bw_col=0;
-   util_bw=0;
-   idle_bw=0;
-   RCDc_limit=0;
-   CCDLc_limit=0;
-   CCDLc_limit_alone=0;
-   CCDc_limit=0;
-   WTRc_limit=0;
-   WTRc_limit_alone=0;
-   RCDWRc_limit=0;
-   RTWc_limit=0;
-   RTWc_limit_alone=0;
-   rwq_limit=0;
-   write_to_read_ratio_blp_rw_average=0;
-   bkgrp_parallsim_rw=0;
+  wasted_bw_row = 0;
+  wasted_bw_col = 0;
+  util_bw = 0;
+  idle_bw = 0;
+  RCDc_limit = 0;
+  CCDLc_limit = 0;
+  CCDLc_limit_alone = 0;
+  CCDc_limit = 0;
+  WTRc_limit = 0;
+  WTRc_limit_alone = 0;
+  RCDWRc_limit = 0;
+  RTWc_limit = 0;
+  RTWc_limit_alone = 0;
+  rwq_limit = 0;
+  write_to_read_ratio_blp_rw_average = 0;
+  bkgrp_parallsim_rw = 0;
 
-   rw = READ; //read mode is default
+  rw = READ;  // read mode is default
 
-	bkgrp = (bankgrp_t**) calloc(sizeof(bankgrp_t*), m_config->nbkgrp);
-	bkgrp[0] = (bankgrp_t*) calloc(sizeof(bank_t), m_config->nbkgrp);
-	for (unsigned i=1; i<m_config->nbkgrp; i++) {
-		bkgrp[i] = bkgrp[0] + i;
-	}
-	for (unsigned i=0; i<m_config->nbkgrp; i++) {
-		bkgrp[i]->CCDLc = 0;
-		bkgrp[i]->RTPLc = 0;
-	}
+  bkgrp = (bankgrp_t **)calloc(sizeof(bankgrp_t *), m_config->nbkgrp);
+  bkgrp[0] = (bankgrp_t *)calloc(sizeof(bank_t), m_config->nbkgrp);
+  for (unsigned i = 1; i < m_config->nbkgrp; i++) {
+    bkgrp[i] = bkgrp[0] + i;
+  }
+  for (unsigned i = 0; i < m_config->nbkgrp; i++) {
+    bkgrp[i]->CCDLc = 0;
+    bkgrp[i]->RTPLc = 0;
+  }
 
-   bk = (bank_t**) calloc(sizeof(bank_t*),m_config->nbk);
-   bk[0] = (bank_t*) calloc(sizeof(bank_t),m_config->nbk);
-   for (unsigned i=1;i<m_config->nbk;i++) 
-      bk[i] = bk[0] + i;
-   for (unsigned i=0;i<m_config->nbk;i++) {
-      bk[i]->state = BANK_IDLE;
-      bk[i]->bkgrpindex = i/(m_config->nbk/m_config->nbkgrp);
-   }
-   prio = 0;
+  bk = (bank_t **)calloc(sizeof(bank_t *), m_config->nbk);
+  bk[0] = (bank_t *)calloc(sizeof(bank_t), m_config->nbk);
+  for (unsigned i = 1; i < m_config->nbk; i++) bk[i] = bk[0] + i;
+  for (unsigned i = 0; i < m_config->nbk; i++) {
+    bk[i]->state = BANK_IDLE;
+    bk[i]->bkgrpindex = i / (m_config->nbk / m_config->nbkgrp);
+  }
+  prio = 0;
 
-   rwq = new fifo_pipeline<dram_req_t>("rwq",m_config->CL,m_config->CL+1);
-   mrqq = new fifo_pipeline<dram_req_t>("mrqq",0,2);
-   returnq = new fifo_pipeline<mem_fetch>("dramreturnq",0,m_config->gpgpu_dram_return_queue_size==0?1024:m_config->gpgpu_dram_return_queue_size); 
-   m_frfcfs_scheduler = NULL;
-   if ( m_config->scheduler_type == DRAM_FRFCFS)
-      m_frfcfs_scheduler = new frfcfs_scheduler(m_config,this,stats);
-   n_cmd = 0;
-   n_activity = 0;
-   n_nop = 0; 
-   n_act = 0; 
-   n_pre = 0; 
-   n_rd = 0;
-   n_wr = 0;
-   n_wr_WB=0;
-   n_rd_L2_A=0;
-   n_req = 0;
-   max_mrqs_temp = 0;
-   bwutil = 0;
-   max_mrqs = 0;
-   ave_mrqs = 0;
+  rwq = new fifo_pipeline<dram_req_t>("rwq", m_config->CL, m_config->CL + 1);
+  mrqq = new fifo_pipeline<dram_req_t>("mrqq", 0, 2);
+  returnq = new fifo_pipeline<mem_fetch>(
+      "dramreturnq", 0, m_config->gpgpu_dram_return_queue_size == 0
+                            ? 1024
+                            : m_config->gpgpu_dram_return_queue_size);
+  m_frfcfs_scheduler = NULL;
+  if (m_config->scheduler_type == DRAM_FRFCFS)
+    m_frfcfs_scheduler = new frfcfs_scheduler(m_config, this, stats);
+  n_cmd = 0;
+  n_activity = 0;
+  n_nop = 0;
+  n_act = 0;
+  n_pre = 0;
+  n_rd = 0;
+  n_wr = 0;
+  n_wr_WB = 0;
+  n_rd_L2_A = 0;
+  n_req = 0;
+  max_mrqs_temp = 0;
+  bwutil = 0;
+  max_mrqs = 0;
+  ave_mrqs = 0;
 
-   for (unsigned i=0;i<10;i++) {
-      dram_util_bins[i]=0;
-      dram_eff_bins[i]=0;
-   }
-   last_n_cmd = last_n_activity = last_bwutil = 0;
+  for (unsigned i = 0; i < 10; i++) {
+    dram_util_bins[i] = 0;
+    dram_eff_bins[i] = 0;
+  }
+  last_n_cmd = last_n_activity = last_bwutil = 0;
 
-   n_cmd_partial = 0;
-   n_activity_partial = 0;
-   n_nop_partial = 0;  
-   n_act_partial = 0;  
-   n_pre_partial = 0;  
-   n_req_partial = 0;
-   ave_mrqs_partial = 0;
-   bwutil_partial = 0;
+  n_cmd_partial = 0;
+  n_activity_partial = 0;
+  n_nop_partial = 0;
+  n_act_partial = 0;
+  n_pre_partial = 0;
+  n_req_partial = 0;
+  ave_mrqs_partial = 0;
+  bwutil_partial = 0;
 
-   if ( queue_limit() )
-      mrqq_Dist = StatCreate("mrqq_length",1, queue_limit());
-   else //queue length is unlimited; 
-      mrqq_Dist = StatCreate("mrqq_length",1,64); //track up to 64 entries
-
+  if (queue_limit())
+    mrqq_Dist = StatCreate("mrqq_length", 1, queue_limit());
+  else                                             // queue length is unlimited;
+    mrqq_Dist = StatCreate("mrqq_length", 1, 64);  // track up to 64 entries
 }
 
-bool dram_t::full(bool is_write) const
-{
-    if(m_config->scheduler_type == DRAM_FRFCFS){
-        if(m_config->gpgpu_frfcfs_dram_sched_queue_size == 0 ) return false;
-        if(m_config->seperate_write_queue_enabled){
-        	if(is_write)
-        		return m_frfcfs_scheduler->num_write_pending() >= m_config->gpgpu_frfcfs_dram_write_queue_size;
-        	else
-        		return m_frfcfs_scheduler->num_pending() >= m_config->gpgpu_frfcfs_dram_sched_queue_size;
-        }
-        else
-        	return m_frfcfs_scheduler->num_pending() >= m_config->gpgpu_frfcfs_dram_sched_queue_size;
+bool dram_t::full(bool is_write) const {
+  if (m_config->scheduler_type == DRAM_FRFCFS) {
+    if (m_config->gpgpu_frfcfs_dram_sched_queue_size == 0) return false;
+    if (m_config->seperate_write_queue_enabled) {
+      if (is_write)
+        return m_frfcfs_scheduler->num_write_pending() >=
+               m_config->gpgpu_frfcfs_dram_write_queue_size;
+      else
+        return m_frfcfs_scheduler->num_pending() >=
+               m_config->gpgpu_frfcfs_dram_sched_queue_size;
+    } else
+      return m_frfcfs_scheduler->num_pending() >=
+             m_config->gpgpu_frfcfs_dram_sched_queue_size;
+  } else
+    return mrqq->full();
+}
+
+unsigned dram_t::que_length() const {
+  unsigned nreqs = 0;
+  if (m_config->scheduler_type == DRAM_FRFCFS) {
+    nreqs = m_frfcfs_scheduler->num_pending();
+  } else {
+    nreqs = mrqq->get_length();
+  }
+  return nreqs;
+}
+
+bool dram_t::returnq_full() const { return returnq->full(); }
+
+unsigned int dram_t::queue_limit() const {
+  return m_config->gpgpu_frfcfs_dram_sched_queue_size;
+}
+
+dram_req_t::dram_req_t(class mem_fetch *mf, unsigned banks,
+                       unsigned dram_bnk_indexing_policy,
+                       class gpgpu_sim *gpu) {
+  txbytes = 0;
+  dqbytes = 0;
+  data = mf;
+  m_gpu = gpu;
+
+  const addrdec_t &tlx = mf->get_tlx_addr();
+
+  switch (dram_bnk_indexing_policy) {
+    case LINEAR_BK_INDEX: {
+      bk = tlx.bk;
+      break;
     }
-   else return mrqq->full();
+    case BITWISE_XORING_BK_INDEX: {
+      // xoring bank bits with lower bits of the page
+      int lbank = log2(banks);
+      bk = tlx.bk ^ (tlx.row & ((1 << lbank) - 1));
+      break;
+    }
+    case CUSTOM_BK_INDEX:
+      /* No custom set function implemented */
+      // Do you custom index here
+      break;
+    default:
+      assert("\nUndefined bank index function.\n" && 0);
+      break;
+  }
+
+  row = tlx.row;
+  col = tlx.col;
+  nbytes = mf->get_data_size();
+
+  timestamp = m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle;
+  addr = mf->get_addr();
+  insertion_time = (unsigned)m_gpu->gpu_sim_cycle;
+  rw = data->get_is_write() ? WRITE : READ;
 }
 
-unsigned dram_t::que_length() const
-{
-   unsigned nreqs = 0;
-   if (m_config->scheduler_type == DRAM_FRFCFS) {
-      nreqs = m_frfcfs_scheduler->num_pending();
-   } else {
-      nreqs = mrqq->get_length();
-   }
-   return nreqs;
+void dram_t::push(class mem_fetch *data) {
+  assert(id ==
+         data->get_tlx_addr()
+             .chip);  // Ensure request is in correct memory partition
+
+  dram_req_t *mrq =
+      new dram_req_t(data, m_config->nbk, m_config->dram_bnk_indexing_policy,
+                     m_memory_partition_unit->get_mgpu());
+
+  data->set_status(IN_PARTITION_MC_INTERFACE_QUEUE,
+                   m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+  mrqq->push(mrq);
+
+  // stats...
+  n_req += 1;
+  n_req_partial += 1;
+  if (m_config->scheduler_type == DRAM_FRFCFS) {
+    unsigned nreqs = m_frfcfs_scheduler->num_pending();
+    if (nreqs > max_mrqs_temp) max_mrqs_temp = nreqs;
+  } else {
+    max_mrqs_temp = (max_mrqs_temp > mrqq->get_length()) ? max_mrqs_temp
+                                                         : mrqq->get_length();
+  }
+  m_stats->memlatstat_dram_access(data);
 }
 
-bool dram_t::returnq_full() const
-{
-   return returnq->full();
+void dram_t::scheduler_fifo() {
+  if (!mrqq->empty()) {
+    unsigned int bkn;
+    dram_req_t *head_mrqq = mrqq->top();
+    head_mrqq->data->set_status(
+        IN_PARTITION_MC_BANK_ARB_QUEUE,
+        m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+    bkn = head_mrqq->bk;
+    if (!bk[bkn]->mrq) bk[bkn]->mrq = mrqq->pop();
+  }
 }
 
-unsigned int dram_t::queue_limit() const 
-{ 
-   return m_config->gpgpu_frfcfs_dram_sched_queue_size; 
-}
+#define DEC2ZERO(x) x = (x) ? (x - 1) : 0;
+#define SWAP(a, b) \
+  a ^= b;          \
+  b ^= a;          \
+  a ^= b;
 
-
-dram_req_t::dram_req_t( class mem_fetch *mf, unsigned banks, unsigned dram_bnk_indexing_policy, class gpgpu_sim* gpu)
-{
-   txbytes = 0;
-   dqbytes = 0;
-   data = mf;
-   m_gpu = gpu;
-
-   const addrdec_t &tlx = mf->get_tlx_addr();
-
-    switch(dram_bnk_indexing_policy){
-		case LINEAR_BK_INDEX:
-		{
-			bk = tlx.bk;
-			break;
-		}
-		case BITWISE_XORING_BK_INDEX:
-		{
-			//xoring bank bits with lower bits of the page
-			int lbank = log2(banks);
-			bk  = tlx.bk ^ (tlx.row & ((1<<lbank)-1));
-			break;
-		}
-		case CUSTOM_BK_INDEX:
-	        /* No custom set function implemented */
-			//Do you custom index here
-			break;
-		default:
-			 assert("\nUndefined bank index function.\n" && 0);
-			 break;
-	}
-
-
-   row = tlx.row; 
-   col = tlx.col; 
-   nbytes = mf->get_data_size();
-
-   timestamp = m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle;
-   addr = mf->get_addr();
-   insertion_time = (unsigned) m_gpu->gpu_sim_cycle;
-   rw = data->get_is_write()?WRITE:READ;
-}
-
-void dram_t::push( class mem_fetch *data ) 
-{
-   assert(id == data->get_tlx_addr().chip); // Ensure request is in correct memory partition
-
-   dram_req_t *mrq = new dram_req_t(data,m_config->nbk,m_config->dram_bnk_indexing_policy,m_memory_partition_unit->get_mgpu());
-
-   data->set_status(IN_PARTITION_MC_INTERFACE_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-	   mrqq->push(mrq);
-
-   // stats...
-   n_req += 1;
-   n_req_partial += 1;
-   if ( m_config->scheduler_type == DRAM_FRFCFS) {
-      unsigned nreqs = m_frfcfs_scheduler->num_pending();
-      if ( nreqs > max_mrqs_temp)
-         max_mrqs_temp = nreqs;
-   } else {
-      max_mrqs_temp = (max_mrqs_temp > mrqq->get_length())? max_mrqs_temp : mrqq->get_length();
-   }
-   m_stats->memlatstat_dram_access(data);
-}
-
-void dram_t::scheduler_fifo()
-{
-   if (!mrqq->empty()) {
-      unsigned int bkn;
-      dram_req_t *head_mrqq = mrqq->top();
-      head_mrqq->data->set_status(IN_PARTITION_MC_BANK_ARB_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-      bkn = head_mrqq->bk;
-      if (!bk[bkn]->mrq) 
-         bk[bkn]->mrq = mrqq->pop();
-   }
-}
-
-
-#define DEC2ZERO(x) x = (x)? (x-1) : 0;
-#define SWAP(a,b) a ^= b; b ^= a; a ^= b;
-
-void dram_t::cycle()
-{
-
-   if( !returnq->full() ) {
-       dram_req_t *cmd = rwq->pop();
-       if( cmd ) {
-#ifdef DRAM_VIEWCMD 
-           printf("\tDQ: BK%d Row:%03x Col:%03x", cmd->bk, cmd->row, cmd->col + cmd->dqbytes);
-#endif
-           cmd->dqbytes += m_config->dram_atom_size; 
-
-           if (cmd->dqbytes >= cmd->nbytes) {
-              mem_fetch *data = cmd->data; 
-              data->set_status(IN_PARTITION_MC_RETURNQ,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-              if( data->get_access_type() != L1_WRBK_ACC && data->get_access_type() != L2_WRBK_ACC ) {
-                 data->set_reply();
-                 returnq->push(data);
-              } else {
-                 m_memory_partition_unit->set_done(data);
-                 delete data;
-              }
-              delete cmd;
-           }
-#ifdef DRAM_VIEWCMD 
-           printf("\n");
-#endif
-       }
-   }
-
-   /* check if the upcoming request is on an idle bank */
-   /* Should we modify this so that multiple requests are checked? */
-
-   switch (m_config->scheduler_type) {
-   case DRAM_FIFO: scheduler_fifo(); break;
-   case DRAM_FRFCFS: scheduler_frfcfs(); break;
-	default:
-		printf("Error: Unknown DRAM scheduler type\n");
-		assert(0);
-   }
-   if ( m_config->scheduler_type == DRAM_FRFCFS) {
-      unsigned nreqs = m_frfcfs_scheduler->num_pending();
-      if ( nreqs > max_mrqs) {
-         max_mrqs = nreqs;
-      }
-      ave_mrqs += nreqs;
-      ave_mrqs_partial += nreqs;
-   } else {
-      if (mrqq->get_length() > max_mrqs) {
-         max_mrqs = mrqq->get_length();
-      }
-      ave_mrqs += mrqq->get_length();
-      ave_mrqs_partial +=  mrqq->get_length();
-   }
-
-   unsigned k=m_config->nbk;
-   bool issued = false;
-
-   //collect row buffer locality, BLP and other statistics
-   /////////////////////////////////////////////////////////////////////////
-   unsigned int memory_pending=0;
-   for (unsigned i=0;i<m_config->nbk;i++) {
-	   if (bk[i]->mrq)
-		   memory_pending++;
-   }
-   banks_1time += memory_pending;
-   if(memory_pending >0)
-	   banks_acess_total++;
-
-   unsigned int memory_pending_rw=0;
-   unsigned read_blp_rw=0;
-   unsigned write_blp_rw=0;
-   std::bitset<8> bnkgrp_rw_found;  //assume max we have 8 bank groups
-
-   for (unsigned j=0;j<m_config->nbk;j++) {
-  	   unsigned grp = get_bankgrp_number(j);
-  	   if (bk[j]->mrq && (((bk[j]->curr_row == bk[j]->mrq->row) &&
-  		  (bk[j]->mrq->rw == READ)  &&
-  		  (bk[j]->state == BANK_ACTIVE))))
-  	   {
-  		    memory_pending_rw++;
-  		    read_blp_rw++;
-  		    bnkgrp_rw_found.set(grp);
-  	   }
-  	   else if
-  	        (bk[j]->mrq && (((bk[j]->curr_row == bk[j]->mrq->row)  &&
-  			 (bk[j]->mrq->rw == WRITE) &&
-  			 (bk[j]->state == BANK_ACTIVE))))
-  	   {
-  		     memory_pending_rw++;
-  		     write_blp_rw++;
-  		     bnkgrp_rw_found.set(grp);
-  	   }
-     }
-     banks_time_rw += memory_pending_rw;
-     bkgrp_parallsim_rw += bnkgrp_rw_found.count();
-     if(memory_pending_rw >0)
-     {
-    	 write_to_read_ratio_blp_rw_average += (double)write_blp_rw/(write_blp_rw+read_blp_rw);
-  	     banks_access_rw_total++;
-     }
-
-   unsigned int memory_Pending_ready=0;
-   for (unsigned j=0;j<m_config->nbk;j++) {
-	   unsigned grp = get_bankgrp_number(j);
-	   if (bk[j]->mrq && ((!CCDc && !bk[j]->RCDc &&
-		  !(bkgrp[grp]->CCDLc) &&
-		  (bk[j]->curr_row == bk[j]->mrq->row) &&
-		  (bk[j]->mrq->rw == READ) && (WTRc == 0 )  &&
-		  (bk[j]->state == BANK_ACTIVE) &&
-		  !rwq->full())
-		   ||
-		   (!CCDc && !bk[j]->RCDWRc &&
-			 !(bkgrp[grp]->CCDLc) &&
-			 (bk[j]->curr_row == bk[j]->mrq->row)  &&
-			 (bk[j]->mrq->rw == WRITE) && (RTWc == 0 )  &&
-			 (bk[j]->state == BANK_ACTIVE) &&
-			 !rwq->full())))
-	   {
-		   memory_Pending_ready++;
-	   }
-   }
-   banks_time_ready += memory_Pending_ready;
-   if(memory_Pending_ready >0)
-	   banks_access_ready_total++;
-   ///////////////////////////////////////////////////////////////////////////////////
-
-   bool issued_col_cmd = false;
-   bool issued_row_cmd = false;
-
-   if(m_config->dual_bus_interface)
-   {
-	   //dual bus interface
-	   //issue one row command and one column command
-	     for (unsigned i=0;i<m_config->nbk;i++) {
-	       unsigned j = (i + prio) % m_config->nbk;
-	  	   issued_col_cmd  = issue_col_command(j);
-	  	   if(issued_col_cmd) break;
-	     }
-	     for (unsigned i=0;i<m_config->nbk;i++) {
-	    	unsigned j = (i + prio) % m_config->nbk;
-	  	    issued_row_cmd = issue_row_command(j);
-	  	    if(issued_row_cmd) break;
-	     }
-	     for (unsigned i=0;i<m_config->nbk;i++) {
-	    	 unsigned j = (i + prio) % m_config->nbk;
-	    	 if(!bk[j]->mrq) {
-				  if (!CCDc && !RRDc && !RTWc && !WTRc && !bk[j]->RCDc && !bk[j]->RASc
-					  && !bk[j]->RCc && !bk[j]->RPc  && !bk[j]->RCDWRc) k--;
-				  bk[j]->n_idle++;
-			}
-	     }
-   }
-   else
-   {
-	   //single bus interface
-	   //issue only one row/column command
-	   for (unsigned i=0;i<m_config->nbk;i++) {
-		   unsigned j = (i + prio) % m_config->nbk;
-		   if(!issued_col_cmd)
-		       issued_col_cmd  = issue_col_command(j);
-
-		   if(!issued_col_cmd && !issued_row_cmd)
-		       issued_row_cmd = issue_row_command(j);
-
-		   if(!bk[j]->mrq) {
-		          if (!CCDc && !RRDc && !RTWc && !WTRc && !bk[j]->RCDc && !bk[j]->RASc
-		              && !bk[j]->RCc && !bk[j]->RPc  && !bk[j]->RCDWRc) k--;
-		          bk[j]->n_idle++;
-		    }
-
-	   }
-   }
-
-   issued = issued_row_cmd || issued_col_cmd;
-   if (!issued) {
-      n_nop++;
-      n_nop_partial++;
+void dram_t::cycle() {
+  if (!returnq->full()) {
+    dram_req_t *cmd = rwq->pop();
+    if (cmd) {
 #ifdef DRAM_VIEWCMD
-      printf("\tNOP                        ");
+      printf("\tDQ: BK%d Row:%03x Col:%03x", cmd->bk, cmd->row,
+             cmd->col + cmd->dqbytes);
 #endif
-   }
-   if (k) {
-      n_activity++;
-      n_activity_partial++;
-   }
-   n_cmd++;
-   n_cmd_partial++;
-   if(issued)
-   {
-	   issued_total++;
-	   if(issued_col_cmd && issued_row_cmd)
-		   issued_two++;
-   }
-   if(issued_col_cmd)  issued_total_col++;
-   if(issued_row_cmd)  issued_total_row++;
+      cmd->dqbytes += m_config->dram_atom_size;
 
-
-   //Collect some statistics
-   //check the limitation, see where BW is wasted?
-   /////////////////////////////////////////////////////////
-   unsigned int memory_pending_found=0;
-      for (unsigned i=0;i<m_config->nbk;i++) {
-   	   if (bk[i]->mrq)
-   		memory_pending_found++;
-      }
-      if(memory_pending_found>0)
-    	  banks_acess_total_after++;
-
-        bool memory_pending_rw_found=false;
-        for (unsigned j=0;j<m_config->nbk;j++) {
-     	   if (bk[j]->mrq && (((bk[j]->curr_row == bk[j]->mrq->row) &&
-     		  (bk[j]->mrq->rw == READ)  &&
-     		  (bk[j]->state == BANK_ACTIVE))
-     		   ||
-     		   (
-     			 (bk[j]->curr_row == bk[j]->mrq->row)  &&
-     			 (bk[j]->mrq->rw == WRITE) &&
-     			 (bk[j]->state == BANK_ACTIVE))))
-     		  memory_pending_rw_found=true;
+      if (cmd->dqbytes >= cmd->nbytes) {
+        mem_fetch *data = cmd->data;
+        data->set_status(IN_PARTITION_MC_RETURNQ,
+                         m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+        if (data->get_access_type() != L1_WRBK_ACC &&
+            data->get_access_type() != L2_WRBK_ACC) {
+          data->set_reply();
+          returnq->push(data);
+        } else {
+          m_memory_partition_unit->set_done(data);
+          delete data;
         }
+        delete cmd;
+      }
+#ifdef DRAM_VIEWCMD
+      printf("\n");
+#endif
+    }
+  }
 
+  /* check if the upcoming request is on an idle bank */
+  /* Should we modify this so that multiple requests are checked? */
 
-   if(issued_col_cmd  || CCDc)
-	   util_bw++;
-   else if (memory_pending_rw_found)
-   {
-	   wasted_bw_col++;
-	   for (unsigned j=0;j<m_config->nbk;j++) {
-		   unsigned grp = get_bankgrp_number(j);
-		   //read
-		   if (bk[j]->mrq && (((bk[j]->curr_row == bk[j]->mrq->row) &&
-			  (bk[j]->mrq->rw == READ)  &&
-			  (bk[j]->state == BANK_ACTIVE))))
-		   {
-			   if(bk[j]->RCDc) RCDc_limit++;
-			   if(bkgrp[grp]->CCDLc) CCDLc_limit++;
-			   if(WTRc) WTRc_limit++;
-			   if(CCDc) CCDc_limit++;
-			   if(rwq->full()) rwq_limit++;
-			   if(bkgrp[grp]->CCDLc && !WTRc) CCDLc_limit_alone++;
-			   if(!bkgrp[grp]->CCDLc && WTRc) WTRc_limit_alone++;
-		   }
-		   //write
-		   else if (bk[j]->mrq && ((bk[j]->curr_row == bk[j]->mrq->row)  &&
-				 (bk[j]->mrq->rw == WRITE) &&
-				 (bk[j]->state == BANK_ACTIVE)))
-		   {
-			   if(bk[j]->RCDWRc) RCDWRc_limit++;
-			   if(bkgrp[grp]->CCDLc) CCDLc_limit++;
-			   if(RTWc) RTWc_limit++;
-			   if(CCDc) CCDc_limit++;
-			   if(rwq->full()) rwq_limit++;
-			   if(bkgrp[grp]->CCDLc && !RTWc) CCDLc_limit_alone++;
-			   if(!bkgrp[grp]->CCDLc && RTWc) RTWc_limit_alone++;
-		   }
-	     }
-   }
-   else if (memory_pending_found)
-	   wasted_bw_row++;
-   else if (!memory_pending_found)
-  	   idle_bw++;
-   else
-	   assert(1);
+  switch (m_config->scheduler_type) {
+    case DRAM_FIFO:
+      scheduler_fifo();
+      break;
+    case DRAM_FRFCFS:
+      scheduler_frfcfs();
+      break;
+    default:
+      printf("Error: Unknown DRAM scheduler type\n");
+      assert(0);
+  }
+  if (m_config->scheduler_type == DRAM_FRFCFS) {
+    unsigned nreqs = m_frfcfs_scheduler->num_pending();
+    if (nreqs > max_mrqs) {
+      max_mrqs = nreqs;
+    }
+    ave_mrqs += nreqs;
+    ave_mrqs_partial += nreqs;
+  } else {
+    if (mrqq->get_length() > max_mrqs) {
+      max_mrqs = mrqq->get_length();
+    }
+    ave_mrqs += mrqq->get_length();
+    ave_mrqs_partial += mrqq->get_length();
+  }
 
-   /////////////////////////////////////////////////////////
+  unsigned k = m_config->nbk;
+  bool issued = false;
 
-   // decrements counters once for each time dram_issueCMD is called
-   DEC2ZERO(RRDc);
-   DEC2ZERO(CCDc);
-   DEC2ZERO(RTWc);
-   DEC2ZERO(WTRc);
-   for (unsigned j=0;j<m_config->nbk;j++) {
-      DEC2ZERO(bk[j]->RCDc);
-      DEC2ZERO(bk[j]->RASc);
-      DEC2ZERO(bk[j]->RCc);
-      DEC2ZERO(bk[j]->RPc);
-      DEC2ZERO(bk[j]->RCDWRc);
-      DEC2ZERO(bk[j]->WTPc);
-      DEC2ZERO(bk[j]->RTPc);
-   }
-   for (unsigned j=0; j<m_config->nbkgrp; j++) {
-	   DEC2ZERO(bkgrp[j]->CCDLc);
-	   DEC2ZERO(bkgrp[j]->RTPLc);
-   }
+  // collect row buffer locality, BLP and other statistics
+  /////////////////////////////////////////////////////////////////////////
+  unsigned int memory_pending = 0;
+  for (unsigned i = 0; i < m_config->nbk; i++) {
+    if (bk[i]->mrq) memory_pending++;
+  }
+  banks_1time += memory_pending;
+  if (memory_pending > 0) banks_acess_total++;
+
+  unsigned int memory_pending_rw = 0;
+  unsigned read_blp_rw = 0;
+  unsigned write_blp_rw = 0;
+  std::bitset<8> bnkgrp_rw_found;  // assume max we have 8 bank groups
+
+  for (unsigned j = 0; j < m_config->nbk; j++) {
+    unsigned grp = get_bankgrp_number(j);
+    if (bk[j]->mrq &&
+        (((bk[j]->curr_row == bk[j]->mrq->row) && (bk[j]->mrq->rw == READ) &&
+          (bk[j]->state == BANK_ACTIVE)))) {
+      memory_pending_rw++;
+      read_blp_rw++;
+      bnkgrp_rw_found.set(grp);
+    } else if (bk[j]->mrq &&
+               (((bk[j]->curr_row == bk[j]->mrq->row) &&
+                 (bk[j]->mrq->rw == WRITE) && (bk[j]->state == BANK_ACTIVE)))) {
+      memory_pending_rw++;
+      write_blp_rw++;
+      bnkgrp_rw_found.set(grp);
+    }
+  }
+  banks_time_rw += memory_pending_rw;
+  bkgrp_parallsim_rw += bnkgrp_rw_found.count();
+  if (memory_pending_rw > 0) {
+    write_to_read_ratio_blp_rw_average +=
+        (double)write_blp_rw / (write_blp_rw + read_blp_rw);
+    banks_access_rw_total++;
+  }
+
+  unsigned int memory_Pending_ready = 0;
+  for (unsigned j = 0; j < m_config->nbk; j++) {
+    unsigned grp = get_bankgrp_number(j);
+    if (bk[j]->mrq &&
+        ((!CCDc && !bk[j]->RCDc && !(bkgrp[grp]->CCDLc) &&
+          (bk[j]->curr_row == bk[j]->mrq->row) && (bk[j]->mrq->rw == READ) &&
+          (WTRc == 0) && (bk[j]->state == BANK_ACTIVE) && !rwq->full()) ||
+         (!CCDc && !bk[j]->RCDWRc && !(bkgrp[grp]->CCDLc) &&
+          (bk[j]->curr_row == bk[j]->mrq->row) && (bk[j]->mrq->rw == WRITE) &&
+          (RTWc == 0) && (bk[j]->state == BANK_ACTIVE) && !rwq->full()))) {
+      memory_Pending_ready++;
+    }
+  }
+  banks_time_ready += memory_Pending_ready;
+  if (memory_Pending_ready > 0) banks_access_ready_total++;
+  ///////////////////////////////////////////////////////////////////////////////////
+
+  bool issued_col_cmd = false;
+  bool issued_row_cmd = false;
+
+  if (m_config->dual_bus_interface) {
+    // dual bus interface
+    // issue one row command and one column command
+    for (unsigned i = 0; i < m_config->nbk; i++) {
+      unsigned j = (i + prio) % m_config->nbk;
+      issued_col_cmd = issue_col_command(j);
+      if (issued_col_cmd) break;
+    }
+    for (unsigned i = 0; i < m_config->nbk; i++) {
+      unsigned j = (i + prio) % m_config->nbk;
+      issued_row_cmd = issue_row_command(j);
+      if (issued_row_cmd) break;
+    }
+    for (unsigned i = 0; i < m_config->nbk; i++) {
+      unsigned j = (i + prio) % m_config->nbk;
+      if (!bk[j]->mrq) {
+        if (!CCDc && !RRDc && !RTWc && !WTRc && !bk[j]->RCDc && !bk[j]->RASc &&
+            !bk[j]->RCc && !bk[j]->RPc && !bk[j]->RCDWRc)
+          k--;
+        bk[j]->n_idle++;
+      }
+    }
+  } else {
+    // single bus interface
+    // issue only one row/column command
+    for (unsigned i = 0; i < m_config->nbk; i++) {
+      unsigned j = (i + prio) % m_config->nbk;
+      if (!issued_col_cmd) issued_col_cmd = issue_col_command(j);
+
+      if (!issued_col_cmd && !issued_row_cmd)
+        issued_row_cmd = issue_row_command(j);
+
+      if (!bk[j]->mrq) {
+        if (!CCDc && !RRDc && !RTWc && !WTRc && !bk[j]->RCDc && !bk[j]->RASc &&
+            !bk[j]->RCc && !bk[j]->RPc && !bk[j]->RCDWRc)
+          k--;
+        bk[j]->n_idle++;
+      }
+    }
+  }
+
+  issued = issued_row_cmd || issued_col_cmd;
+  if (!issued) {
+    n_nop++;
+    n_nop_partial++;
+#ifdef DRAM_VIEWCMD
+    printf("\tNOP                        ");
+#endif
+  }
+  if (k) {
+    n_activity++;
+    n_activity_partial++;
+  }
+  n_cmd++;
+  n_cmd_partial++;
+  if (issued) {
+    issued_total++;
+    if (issued_col_cmd && issued_row_cmd) issued_two++;
+  }
+  if (issued_col_cmd) issued_total_col++;
+  if (issued_row_cmd) issued_total_row++;
+
+  // Collect some statistics
+  // check the limitation, see where BW is wasted?
+  /////////////////////////////////////////////////////////
+  unsigned int memory_pending_found = 0;
+  for (unsigned i = 0; i < m_config->nbk; i++) {
+    if (bk[i]->mrq) memory_pending_found++;
+  }
+  if (memory_pending_found > 0) banks_acess_total_after++;
+
+  bool memory_pending_rw_found = false;
+  for (unsigned j = 0; j < m_config->nbk; j++) {
+    if (bk[j]->mrq &&
+        (((bk[j]->curr_row == bk[j]->mrq->row) && (bk[j]->mrq->rw == READ) &&
+          (bk[j]->state == BANK_ACTIVE)) ||
+         ((bk[j]->curr_row == bk[j]->mrq->row) && (bk[j]->mrq->rw == WRITE) &&
+          (bk[j]->state == BANK_ACTIVE))))
+      memory_pending_rw_found = true;
+  }
+
+  if (issued_col_cmd || CCDc)
+    util_bw++;
+  else if (memory_pending_rw_found) {
+    wasted_bw_col++;
+    for (unsigned j = 0; j < m_config->nbk; j++) {
+      unsigned grp = get_bankgrp_number(j);
+      // read
+      if (bk[j]->mrq &&
+          (((bk[j]->curr_row == bk[j]->mrq->row) && (bk[j]->mrq->rw == READ) &&
+            (bk[j]->state == BANK_ACTIVE)))) {
+        if (bk[j]->RCDc) RCDc_limit++;
+        if (bkgrp[grp]->CCDLc) CCDLc_limit++;
+        if (WTRc) WTRc_limit++;
+        if (CCDc) CCDc_limit++;
+        if (rwq->full()) rwq_limit++;
+        if (bkgrp[grp]->CCDLc && !WTRc) CCDLc_limit_alone++;
+        if (!bkgrp[grp]->CCDLc && WTRc) WTRc_limit_alone++;
+      }
+      // write
+      else if (bk[j]->mrq &&
+               ((bk[j]->curr_row == bk[j]->mrq->row) &&
+                (bk[j]->mrq->rw == WRITE) && (bk[j]->state == BANK_ACTIVE))) {
+        if (bk[j]->RCDWRc) RCDWRc_limit++;
+        if (bkgrp[grp]->CCDLc) CCDLc_limit++;
+        if (RTWc) RTWc_limit++;
+        if (CCDc) CCDc_limit++;
+        if (rwq->full()) rwq_limit++;
+        if (bkgrp[grp]->CCDLc && !RTWc) CCDLc_limit_alone++;
+        if (!bkgrp[grp]->CCDLc && RTWc) RTWc_limit_alone++;
+      }
+    }
+  } else if (memory_pending_found)
+    wasted_bw_row++;
+  else if (!memory_pending_found)
+    idle_bw++;
+  else
+    assert(1);
+
+  /////////////////////////////////////////////////////////
+
+  // decrements counters once for each time dram_issueCMD is called
+  DEC2ZERO(RRDc);
+  DEC2ZERO(CCDc);
+  DEC2ZERO(RTWc);
+  DEC2ZERO(WTRc);
+  for (unsigned j = 0; j < m_config->nbk; j++) {
+    DEC2ZERO(bk[j]->RCDc);
+    DEC2ZERO(bk[j]->RASc);
+    DEC2ZERO(bk[j]->RCc);
+    DEC2ZERO(bk[j]->RPc);
+    DEC2ZERO(bk[j]->RCDWRc);
+    DEC2ZERO(bk[j]->WTPc);
+    DEC2ZERO(bk[j]->RTPc);
+  }
+  for (unsigned j = 0; j < m_config->nbkgrp; j++) {
+    DEC2ZERO(bkgrp[j]->CCDLc);
+    DEC2ZERO(bkgrp[j]->RTPLc);
+  }
 
 #ifdef DRAM_VISUALIZE
-   visualize();
+  visualize();
 #endif
 }
 
-bool dram_t::issue_col_command(int j)
-{
-	bool issued = false;
-	unsigned grp = get_bankgrp_number(j);
-    if (bk[j]->mrq) { //if currently servicing a memory request
-        bk[j]->mrq->data->set_status(IN_PARTITION_DRAM,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-       // correct row activated for a READ
-       if ( !issued && !CCDc && !bk[j]->RCDc &&
-            !(bkgrp[grp]->CCDLc) &&
-            (bk[j]->curr_row == bk[j]->mrq->row) &&
-            (bk[j]->mrq->rw == READ) && (WTRc == 0 )  &&
+bool dram_t::issue_col_command(int j) {
+  bool issued = false;
+  unsigned grp = get_bankgrp_number(j);
+  if (bk[j]->mrq) {  // if currently servicing a memory request
+    bk[j]->mrq->data->set_status(
+        IN_PARTITION_DRAM, m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+    // correct row activated for a READ
+    if (!issued && !CCDc && !bk[j]->RCDc && !(bkgrp[grp]->CCDLc) &&
+        (bk[j]->curr_row == bk[j]->mrq->row) && (bk[j]->mrq->rw == READ) &&
+        (WTRc == 0) && (bk[j]->state == BANK_ACTIVE) && !rwq->full()) {
+      if (rw == WRITE) {
+        rw = READ;
+        rwq->set_min_length(m_config->CL);
+      }
+      rwq->push(bk[j]->mrq);
+      bk[j]->mrq->txbytes += m_config->dram_atom_size;
+      CCDc = m_config->tCCD;
+      bkgrp[grp]->CCDLc = m_config->tCCDL;
+      RTWc = m_config->tRTW;
+      bk[j]->RTPc = m_config->BL / m_config->data_command_freq_ratio;
+      bkgrp[grp]->RTPLc = m_config->tRTPL;
+      issued = true;
+      if (bk[j]->mrq->data->get_access_type() == L2_WR_ALLOC_R)
+        n_rd_L2_A++;
+      else
+        n_rd++;
+
+      bwutil += m_config->BL / m_config->data_command_freq_ratio;
+      bwutil_partial += m_config->BL / m_config->data_command_freq_ratio;
+      bk[j]->n_access++;
+
+#ifdef DRAM_VERIFY
+      PRINT_CYCLE = 1;
+      printf("\tRD  Bk:%d Row:%03x Col:%03x \n", j, bk[j]->curr_row,
+             bk[j]->mrq->col + bk[j]->mrq->txbytes - m_config->dram_atom_size);
+#endif
+      // transfer done
+      if (!(bk[j]->mrq->txbytes < bk[j]->mrq->nbytes)) {
+        bk[j]->mrq = NULL;
+      }
+    } else
+        // correct row activated for a WRITE
+        if (!issued && !CCDc && !bk[j]->RCDWRc && !(bkgrp[grp]->CCDLc) &&
+            (bk[j]->curr_row == bk[j]->mrq->row) && (bk[j]->mrq->rw == WRITE) &&
+            (RTWc == 0) && (bk[j]->state == BANK_ACTIVE) && !rwq->full()) {
+      if (rw == READ) {
+        rw = WRITE;
+        rwq->set_min_length(m_config->WL);
+      }
+      rwq->push(bk[j]->mrq);
+
+      bk[j]->mrq->txbytes += m_config->dram_atom_size;
+      CCDc = m_config->tCCD;
+      bkgrp[grp]->CCDLc = m_config->tCCDL;
+      WTRc = m_config->tWTR;
+      bk[j]->WTPc = m_config->tWTP;
+      issued = true;
+
+      if (bk[j]->mrq->data->get_access_type() == L2_WRBK_ACC)
+        n_wr_WB++;
+      else
+        n_wr++;
+      bwutil += m_config->BL / m_config->data_command_freq_ratio;
+      bwutil_partial += m_config->BL / m_config->data_command_freq_ratio;
+#ifdef DRAM_VERIFY
+      PRINT_CYCLE = 1;
+      printf("\tWR  Bk:%d Row:%03x Col:%03x \n", j, bk[j]->curr_row,
+             bk[j]->mrq->col + bk[j]->mrq->txbytes - m_config->dram_atom_size);
+#endif
+      // transfer done
+      if (!(bk[j]->mrq->txbytes < bk[j]->mrq->nbytes)) {
+        bk[j]->mrq = NULL;
+      }
+    }
+  }
+
+  return issued;
+}
+
+bool dram_t::issue_row_command(int j) {
+  bool issued = false;
+  unsigned grp = get_bankgrp_number(j);
+  if (bk[j]->mrq) {  // if currently servicing a memory request
+    bk[j]->mrq->data->set_status(
+        IN_PARTITION_DRAM, m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+    //     bank is idle
+    // else
+    if (!issued && !RRDc && (bk[j]->state == BANK_IDLE) && !bk[j]->RPc &&
+        !bk[j]->RCc) {  //
+#ifdef DRAM_VERIFY
+      PRINT_CYCLE = 1;
+      printf("\tACT BK:%d NewRow:%03x From:%03x \n", j, bk[j]->mrq->row,
+             bk[j]->curr_row);
+#endif
+      // activate the row with current memory request
+      bk[j]->curr_row = bk[j]->mrq->row;
+      bk[j]->state = BANK_ACTIVE;
+      RRDc = m_config->tRRD;
+      bk[j]->RCDc = m_config->tRCD;
+      bk[j]->RCDWRc = m_config->tRCDWR;
+      bk[j]->RASc = m_config->tRAS;
+      bk[j]->RCc = m_config->tRC;
+      prio = (j + 1) % m_config->nbk;
+      issued = true;
+      n_act_partial++;
+      n_act++;
+    }
+
+    else
+        // different row activated
+        if ((!issued) && (bk[j]->curr_row != bk[j]->mrq->row) &&
             (bk[j]->state == BANK_ACTIVE) &&
-            !rwq->full() ) {
-          if (rw==WRITE) {
-             rw=READ;
-             rwq->set_min_length(m_config->CL);
-          }
-          rwq->push(bk[j]->mrq);
-          bk[j]->mrq->txbytes += m_config->dram_atom_size;
-          CCDc = m_config->tCCD;
-          bkgrp[grp]->CCDLc = m_config->tCCDL;
-          RTWc = m_config->tRTW;
-          bk[j]->RTPc = m_config->BL/m_config->data_command_freq_ratio;
-          bkgrp[grp]->RTPLc = m_config->tRTPL;
-          issued = true;
-          if(bk[j]->mrq->data->get_access_type() == L2_WR_ALLOC_R)
-        	  n_rd_L2_A++;
-          else
-                n_rd++;
-
-          bwutil += m_config->BL/m_config->data_command_freq_ratio;
-          bwutil_partial += m_config->BL/m_config->data_command_freq_ratio;
-          bk[j]->n_access++;
-
+            (!bk[j]->RASc && !bk[j]->WTPc && !bk[j]->RTPc &&
+             !bkgrp[grp]->RTPLc)) {
+      // make the bank idle again
+      bk[j]->state = BANK_IDLE;
+      bk[j]->RPc = m_config->tRP;
+      prio = (j + 1) % m_config->nbk;
+      issued = true;
+      n_pre++;
+      n_pre_partial++;
 #ifdef DRAM_VERIFY
-          PRINT_CYCLE=1;
-          printf("\tRD  Bk:%d Row:%03x Col:%03x \n",
-                 j, bk[j]->curr_row,
-                 bk[j]->mrq->col + bk[j]->mrq->txbytes - m_config->dram_atom_size);
+      PRINT_CYCLE = 1;
+      printf("\tPRE BK:%d Row:%03x \n", j, bk[j]->curr_row);
 #endif
-          // transfer done
-          if ( !(bk[j]->mrq->txbytes < bk[j]->mrq->nbytes) ) {
-             bk[j]->mrq = NULL;
-          }
-       } else
-          // correct row activated for a WRITE
-          if ( !issued && !CCDc && !bk[j]->RCDWRc &&
-               !(bkgrp[grp]->CCDLc) &&
-               (bk[j]->curr_row == bk[j]->mrq->row)  &&
-               (bk[j]->mrq->rw == WRITE) && (RTWc == 0 )  &&
-               (bk[j]->state == BANK_ACTIVE) &&
-               !rwq->full() ) {
-          if (rw==READ) {
-             rw=WRITE;
-             rwq->set_min_length(m_config->WL);
-          }
-          rwq->push(bk[j]->mrq);
-
-          bk[j]->mrq->txbytes += m_config->dram_atom_size;
-          CCDc = m_config->tCCD;
-          bkgrp[grp]->CCDLc = m_config->tCCDL;
-          WTRc = m_config->tWTR;
-          bk[j]->WTPc = m_config->tWTP;
-          issued = true;
-
-          if(bk[j]->mrq->data->get_access_type() == L2_WRBK_ACC)
-          	n_wr_WB++;
-          else
-          	 n_wr++;
-          bwutil += m_config->BL/m_config->data_command_freq_ratio;
-          bwutil_partial += m_config->BL/m_config->data_command_freq_ratio;
-#ifdef DRAM_VERIFY
-          PRINT_CYCLE=1;
-          printf("\tWR  Bk:%d Row:%03x Col:%03x \n",
-                 j, bk[j]->curr_row,
-                 bk[j]->mrq->col + bk[j]->mrq->txbytes - m_config->dram_atom_size);
-#endif
-          // transfer done
-          if ( !(bk[j]->mrq->txbytes < bk[j]->mrq->nbytes) ) {
-             bk[j]->mrq = NULL;
-          }
-       }
-
     }
-
-    return issued;
+  }
+  return issued;
 }
 
-bool dram_t::issue_row_command(int j)
-{
-	bool issued = false;
-	unsigned grp = get_bankgrp_number(j);
-    if (bk[j]->mrq) { //if currently servicing a memory request
-        bk[j]->mrq->data->set_status(IN_PARTITION_DRAM,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-      //     bank is idle
-    //else
-  	  if ( !issued && !RRDc &&
-               (bk[j]->state == BANK_IDLE) &&
-               !bk[j]->RPc && !bk[j]->RCc) { //
-#ifdef DRAM_VERIFY
-          PRINT_CYCLE=1;
-          printf("\tACT BK:%d NewRow:%03x From:%03x \n",
-                 j,bk[j]->mrq->row,bk[j]->curr_row);
-#endif
-          // activate the row with current memory request
-          bk[j]->curr_row = bk[j]->mrq->row;
-          bk[j]->state = BANK_ACTIVE;
-          RRDc = m_config->tRRD;
-          bk[j]->RCDc = m_config->tRCD;
-          bk[j]->RCDWRc = m_config->tRCDWR;
-          bk[j]->RASc = m_config->tRAS;
-          bk[j]->RCc = m_config->tRC;
-          prio = (j + 1) % m_config->nbk;
-          issued = true;
-          n_act_partial++;
-          n_act++;
-       }
-
-       else
-          // different row activated
-          if ( (!issued) &&
-               (bk[j]->curr_row != bk[j]->mrq->row) &&
-               (bk[j]->state == BANK_ACTIVE) &&
-               (!bk[j]->RASc && !bk[j]->WTPc &&
-				  !bk[j]->RTPc &&
-				  !bkgrp[grp]->RTPLc) ) {
-          // make the bank idle again
-          bk[j]->state = BANK_IDLE;
-          bk[j]->RPc = m_config->tRP;
-          prio = (j + 1) % m_config->nbk;
-          issued = true;
-          n_pre++;
-          n_pre_partial++;
-#ifdef DRAM_VERIFY
-          PRINT_CYCLE=1;
-          printf("\tPRE BK:%d Row:%03x \n", j,bk[j]->curr_row);
-#endif
-       }
-    }
-    return issued;
+// if mrq is being serviced by dram, gets popped after CL latency fulfilled
+class mem_fetch *dram_t::return_queue_pop() {
+  return returnq->pop();
 }
 
-
-//if mrq is being serviced by dram, gets popped after CL latency fulfilled
-class mem_fetch* dram_t::return_queue_pop()
-{
-    return returnq->pop();
+class mem_fetch *dram_t::return_queue_top() {
+  return returnq->top();
 }
 
-class mem_fetch* dram_t::return_queue_top()
-{
-    return returnq->top();
+void dram_t::print(FILE *simFile) const {
+  unsigned i;
+  fprintf(simFile, "DRAM[%d]: %d bks, busW=%d BL=%d CL=%d, ", id, m_config->nbk,
+          m_config->busW, m_config->BL, m_config->CL);
+  fprintf(simFile, "tRRD=%d tCCD=%d, tRCD=%d tRAS=%d tRP=%d tRC=%d\n",
+          m_config->tRRD, m_config->tCCD, m_config->tRCD, m_config->tRAS,
+          m_config->tRP, m_config->tRC);
+  fprintf(simFile,
+          "n_cmd=%llu n_nop=%llu n_act=%llu n_pre=%llu n_ref_event=%llu "
+          "n_req=%llu n_rd=%llu n_rd_L2_A=%llu n_write=%llu n_wr_bk=%llu "
+          "bw_util=%.4g\n",
+          n_cmd, n_nop, n_act, n_pre, n_ref, n_req, n_rd, n_rd_L2_A, n_wr,
+          n_wr_WB, (float)bwutil / n_cmd);
+  fprintf(simFile, "n_activity=%llu dram_eff=%.4g\n", n_activity,
+          (float)bwutil / n_activity);
+  for (i = 0; i < m_config->nbk; i++) {
+    fprintf(simFile, "bk%d: %da %di ", i, bk[i]->n_access, bk[i]->n_idle);
+  }
+  fprintf(simFile, "\n");
+  fprintf(simFile,
+          "\n------------------------------------------------------------------"
+          "------\n");
+
+  printf("\nRow_Buffer_Locality = %.6f", (float)hits_num / access_num);
+  printf("\nRow_Buffer_Locality_read = %.6f", (float)hits_read_num / read_num);
+  printf("\nRow_Buffer_Locality_write = %.6f",
+         (float)hits_write_num / write_num);
+  printf("\nBank_Level_Parallism = %.6f",
+         (float)banks_1time / banks_acess_total);
+  printf("\nBank_Level_Parallism_Col = %.6f",
+         (float)banks_time_rw / banks_access_rw_total);
+  printf("\nBank_Level_Parallism_Ready = %.6f",
+         (float)banks_time_ready / banks_access_ready_total);
+  printf("\nwrite_to_read_ratio_blp_rw_average = %.6f",
+         write_to_read_ratio_blp_rw_average / banks_access_rw_total);
+  printf("\nGrpLevelPara = %.6f \n",
+         (float)bkgrp_parallsim_rw / banks_access_rw_total);
+
+  printf("\nBW Util details:\n");
+  printf("bwutil = %.6f \n", (float)bwutil / n_cmd);
+  printf("total_CMD = %llu \n", n_cmd);
+  printf("util_bw = %llu \n", util_bw);
+  printf("Wasted_Col = %llu \n", wasted_bw_col);
+  printf("Wasted_Row = %llu \n", wasted_bw_row);
+  printf("Idle = %llu \n", idle_bw);
+
+  printf("\nBW Util Bottlenecks: \n");
+  printf("RCDc_limit = %llu \n", RCDc_limit);
+  printf("RCDWRc_limit = %llu \n", RCDWRc_limit);
+  printf("WTRc_limit = %llu \n", WTRc_limit);
+  printf("RTWc_limit = %llu \n", RTWc_limit);
+  printf("CCDLc_limit = %llu \n", CCDLc_limit);
+  printf("rwq = %llu \n", rwq_limit);
+  printf("CCDLc_limit_alone = %llu \n", CCDLc_limit_alone);
+  printf("WTRc_limit_alone = %llu \n", WTRc_limit_alone);
+  printf("RTWc_limit_alone = %llu \n", RTWc_limit_alone);
+
+  printf("\nCommands details: \n");
+  printf("total_CMD = %llu \n", n_cmd);
+  printf("n_nop = %llu \n", n_nop);
+  printf("Read = %llu \n", n_rd);
+  printf("Write = %llu \n", n_wr);
+  printf("L2_Alloc = %llu \n", n_rd_L2_A);
+  printf("L2_WB = %llu \n", n_wr_WB);
+  printf("n_act = %llu \n", n_act);
+  printf("n_pre = %llu \n", n_pre);
+  printf("n_ref = %llu \n", n_ref);
+  printf("n_req = %llu \n", n_req);
+  printf("total_req = %llu \n", n_rd + n_wr + n_rd_L2_A + n_wr_WB);
+
+  printf("\nDual Bus Interface Util: \n");
+  printf("issued_total_row = %llu \n", issued_total_row);
+  printf("issued_total_col = %llu \n", issued_total_col);
+  printf("Row_Bus_Util =  %.6f \n", (float)issued_total_row / n_cmd);
+  printf("CoL_Bus_Util = %.6f \n", (float)issued_total_col / n_cmd);
+  printf("Either_Row_CoL_Bus_Util = %.6f \n", (float)issued_total / n_cmd);
+  printf("Issued_on_Two_Bus_Simul_Util = %.6f \n", (float)issued_two / n_cmd);
+  printf("issued_two_Eff = %.6f \n", (float)issued_two / issued_total);
+  printf("queue_avg = %.6f \n\n", (float)ave_mrqs / n_cmd);
+
+  fprintf(simFile, "\n");
+  fprintf(simFile, "dram_util_bins:");
+  for (i = 0; i < 10; i++) fprintf(simFile, " %d", dram_util_bins[i]);
+  fprintf(simFile, "\ndram_eff_bins:");
+  for (i = 0; i < 10; i++) fprintf(simFile, " %d", dram_eff_bins[i]);
+  fprintf(simFile, "\n");
+  if (m_config->scheduler_type == DRAM_FRFCFS)
+    fprintf(simFile, "mrqq: max=%d avg=%g\n", max_mrqs,
+            (float)ave_mrqs / n_cmd);
 }
 
-
-void dram_t::print( FILE* simFile) const
-{
-   unsigned i;
-   fprintf(simFile,"DRAM[%d]: %d bks, busW=%d BL=%d CL=%d, ", 
-           id, m_config->nbk, m_config->busW, m_config->BL, m_config->CL );
-   fprintf(simFile,"tRRD=%d tCCD=%d, tRCD=%d tRAS=%d tRP=%d tRC=%d\n",
-           m_config->tRRD, m_config->tCCD, m_config->tRCD, m_config->tRAS, m_config->tRP, m_config->tRC );
-   fprintf(simFile,"n_cmd=%llu n_nop=%llu n_act=%llu n_pre=%llu n_ref_event=%llu n_req=%llu n_rd=%llu n_rd_L2_A=%llu n_write=%llu n_wr_bk=%llu bw_util=%.4g\n",
-           n_cmd, n_nop, n_act, n_pre, n_ref, n_req, n_rd, n_rd_L2_A, n_wr, n_wr_WB,
-           (float)bwutil/n_cmd);
-   fprintf(simFile,"n_activity=%llu dram_eff=%.4g\n",
-           n_activity, (float)bwutil/n_activity);
-   for (i=0;i<m_config->nbk;i++) {
-      fprintf(simFile, "bk%d: %da %di ",i,bk[i]->n_access,bk[i]->n_idle);
-   }
-   fprintf(simFile, "\n");
-   fprintf(simFile, "\n------------------------------------------------------------------------\n");
-
-   printf("\nRow_Buffer_Locality = %.6f", (float)hits_num / access_num);
-   printf("\nRow_Buffer_Locality_read = %.6f", (float)hits_read_num / read_num);
-   printf("\nRow_Buffer_Locality_write = %.6f", (float)hits_write_num / write_num);
-   printf("\nBank_Level_Parallism = %.6f", (float)banks_1time / banks_acess_total);
-   printf("\nBank_Level_Parallism_Col = %.6f", (float)banks_time_rw / banks_access_rw_total);
-   printf("\nBank_Level_Parallism_Ready = %.6f", (float)banks_time_ready /banks_access_ready_total);
-   printf("\nwrite_to_read_ratio_blp_rw_average = %.6f", write_to_read_ratio_blp_rw_average /banks_access_rw_total);
-   printf("\nGrpLevelPara = %.6f \n", (float)bkgrp_parallsim_rw /banks_access_rw_total);
-
-   printf("\nBW Util details:\n");
-   printf("bwutil = %.6f \n", (float)bwutil/n_cmd);
-   printf("total_CMD = %llu \n", n_cmd);
-   printf("util_bw = %llu \n", util_bw);
-   printf("Wasted_Col = %llu \n", wasted_bw_col);
-   printf("Wasted_Row = %llu \n", wasted_bw_row);
-   printf("Idle = %llu \n", idle_bw);
-
-   printf("\nBW Util Bottlenecks: \n");
-   printf("RCDc_limit = %llu \n", RCDc_limit);
-   printf("RCDWRc_limit = %llu \n", RCDWRc_limit);
-   printf("WTRc_limit = %llu \n", WTRc_limit);
-   printf("RTWc_limit = %llu \n", RTWc_limit);
-   printf("CCDLc_limit = %llu \n", CCDLc_limit);
-   printf("rwq = %llu \n", rwq_limit);
-   printf("CCDLc_limit_alone = %llu \n", CCDLc_limit_alone);
-   printf("WTRc_limit_alone = %llu \n", WTRc_limit_alone);
-   printf("RTWc_limit_alone = %llu \n", RTWc_limit_alone);
-
-   printf("\nCommands details: \n");
-   printf("total_CMD = %llu \n", n_cmd);
-   printf("n_nop = %llu \n", n_nop);
-   printf("Read = %llu \n", n_rd);
-   printf("Write = %llu \n",n_wr);
-   printf("L2_Alloc = %llu \n", n_rd_L2_A);
-   printf("L2_WB = %llu \n", n_wr_WB);
-   printf("n_act = %llu \n", n_act);
-   printf("n_pre = %llu \n", n_pre);
-   printf("n_ref = %llu \n", n_ref);
-   printf("n_req = %llu \n", n_req );
-   printf("total_req = %llu \n", n_rd+n_wr+n_rd_L2_A+n_wr_WB);
-
-   printf("\nDual Bus Interface Util: \n");
-   printf("issued_total_row = %llu \n", issued_total_row);
-   printf("issued_total_col = %llu \n", issued_total_col);
-   printf("Row_Bus_Util =  %.6f \n", (float)issued_total_row / n_cmd);
-   printf("CoL_Bus_Util = %.6f \n", (float)issued_total_col / n_cmd);
-   printf("Either_Row_CoL_Bus_Util = %.6f \n",  (float)issued_total / n_cmd);
-   printf("Issued_on_Two_Bus_Simul_Util = %.6f \n",  (float)issued_two /n_cmd);
-   printf("issued_two_Eff = %.6f \n",  (float)issued_two /issued_total);
-   printf("queue_avg = %.6f \n\n", (float)ave_mrqs/n_cmd );
-
-   fprintf(simFile, "\n");
-   fprintf(simFile, "dram_util_bins:");
-   for (i=0;i<10;i++) fprintf(simFile, " %d", dram_util_bins[i]);
-   fprintf(simFile, "\ndram_eff_bins:");
-   for (i=0;i<10;i++) fprintf(simFile, " %d", dram_eff_bins[i]);
-   fprintf(simFile, "\n");
-   if(m_config->scheduler_type== DRAM_FRFCFS)
-       fprintf(simFile, "mrqq: max=%d avg=%g\n", max_mrqs, (float)ave_mrqs/n_cmd);
+void dram_t::visualize() const {
+  printf("RRDc=%d CCDc=%d mrqq.Length=%d rwq.Length=%d\n", RRDc, CCDc,
+         mrqq->get_length(), rwq->get_length());
+  for (unsigned i = 0; i < m_config->nbk; i++) {
+    printf("BK%d: state=%c curr_row=%03x, %2d %2d %2d %2d %p ", i, bk[i]->state,
+           bk[i]->curr_row, bk[i]->RCDc, bk[i]->RASc, bk[i]->RPc, bk[i]->RCc,
+           bk[i]->mrq);
+    if (bk[i]->mrq)
+      printf("txf: %d %d", bk[i]->mrq->nbytes, bk[i]->mrq->txbytes);
+    printf("\n");
+  }
+  if (m_frfcfs_scheduler) m_frfcfs_scheduler->print(stdout);
 }
 
-void dram_t::visualize() const
-{
-   printf("RRDc=%d CCDc=%d mrqq.Length=%d rwq.Length=%d\n", 
-          RRDc, CCDc, mrqq->get_length(),rwq->get_length());
-   for (unsigned i=0;i<m_config->nbk;i++) {
-      printf("BK%d: state=%c curr_row=%03x, %2d %2d %2d %2d %p ", 
-             i, bk[i]->state, bk[i]->curr_row,
-             bk[i]->RCDc, bk[i]->RASc,
-             bk[i]->RPc, bk[i]->RCc,
-             bk[i]->mrq );
-      if (bk[i]->mrq)
-         printf("txf: %d %d", bk[i]->mrq->nbytes, bk[i]->mrq->txbytes);
-      printf("\n");
-   }
-   if ( m_frfcfs_scheduler ) 
-      m_frfcfs_scheduler->print(stdout);
+void dram_t::print_stat(FILE *simFile) {
+  fprintf(simFile,
+          "DRAM (%u): n_cmd=%llu n_nop=%llu n_act=%llu n_pre=%llu n_ref=%llu "
+          "n_req=%llu n_rd=%llu n_write=%llu bw_util=%.4g ",
+          id, n_cmd, n_nop, n_act, n_pre, n_ref, n_req, n_rd, n_wr,
+          (float)bwutil / n_cmd);
+  fprintf(simFile, "mrqq: %d %.4g mrqsmax=%llu ", max_mrqs,
+          (float)ave_mrqs / n_cmd, max_mrqs_temp);
+  fprintf(simFile, "\n");
+  fprintf(simFile, "dram_util_bins:");
+  for (unsigned i = 0; i < 10; i++) fprintf(simFile, " %d", dram_util_bins[i]);
+  fprintf(simFile, "\ndram_eff_bins:");
+  for (unsigned i = 0; i < 10; i++) fprintf(simFile, " %d", dram_eff_bins[i]);
+  fprintf(simFile, "\n");
+  max_mrqs_temp = 0;
 }
 
-void dram_t::print_stat( FILE* simFile ) 
-{
-   fprintf(simFile,"DRAM (%u): n_cmd=%llu n_nop=%llu n_act=%llu n_pre=%llu n_ref=%llu n_req=%llu n_rd=%llu n_write=%llu bw_util=%.4g ",
-           id, n_cmd, n_nop, n_act, n_pre, n_ref, n_req, n_rd, n_wr,
-           (float)bwutil/n_cmd);
-   fprintf(simFile, "mrqq: %d %.4g mrqsmax=%llu ", max_mrqs, (float)ave_mrqs/n_cmd, max_mrqs_temp);
-   fprintf(simFile, "\n");
-   fprintf(simFile, "dram_util_bins:");
-   for (unsigned i=0;i<10;i++) fprintf(simFile, " %d", dram_util_bins[i]);
-   fprintf(simFile, "\ndram_eff_bins:");
-   for (unsigned i=0;i<10;i++) fprintf(simFile, " %d", dram_eff_bins[i]);
-   fprintf(simFile, "\n");
-   max_mrqs_temp = 0;
+void dram_t::visualizer_print(gzFile visualizer_file) {
+  // dram specific statistics
+  gzprintf(visualizer_file, "dramncmd: %u %u\n", id, n_cmd_partial);
+  gzprintf(visualizer_file, "dramnop: %u %u\n", id, n_nop_partial);
+  gzprintf(visualizer_file, "dramnact: %u %u\n", id, n_act_partial);
+  gzprintf(visualizer_file, "dramnpre: %u %u\n", id, n_pre_partial);
+  gzprintf(visualizer_file, "dramnreq: %u %u\n", id, n_req_partial);
+  gzprintf(visualizer_file, "dramavemrqs: %u %u\n", id,
+           n_cmd_partial ? (ave_mrqs_partial / n_cmd_partial) : 0);
+
+  // utilization and efficiency
+  gzprintf(visualizer_file, "dramutil: %u %u\n", id,
+           n_cmd_partial ? 100 * bwutil_partial / n_cmd_partial : 0);
+  gzprintf(visualizer_file, "drameff: %u %u\n", id,
+           n_activity_partial ? 100 * bwutil_partial / n_activity_partial : 0);
+
+  // reset for next interval
+  bwutil_partial = 0;
+  n_activity_partial = 0;
+  ave_mrqs_partial = 0;
+  n_cmd_partial = 0;
+  n_nop_partial = 0;
+  n_act_partial = 0;
+  n_pre_partial = 0;
+  n_req_partial = 0;
+
+  // dram access type classification
+  for (unsigned j = 0; j < m_config->nbk; j++) {
+    gzprintf(visualizer_file, "dramglobal_acc_r: %u %u %u\n", id, j,
+             m_stats->mem_access_type_stats[GLOBAL_ACC_R][id][j]);
+    gzprintf(visualizer_file, "dramglobal_acc_w: %u %u %u\n", id, j,
+             m_stats->mem_access_type_stats[GLOBAL_ACC_W][id][j]);
+    gzprintf(visualizer_file, "dramlocal_acc_r: %u %u %u\n", id, j,
+             m_stats->mem_access_type_stats[LOCAL_ACC_R][id][j]);
+    gzprintf(visualizer_file, "dramlocal_acc_w: %u %u %u\n", id, j,
+             m_stats->mem_access_type_stats[LOCAL_ACC_W][id][j]);
+    gzprintf(visualizer_file, "dramconst_acc_r: %u %u %u\n", id, j,
+             m_stats->mem_access_type_stats[CONST_ACC_R][id][j]);
+    gzprintf(visualizer_file, "dramtexture_acc_r: %u %u %u\n", id, j,
+             m_stats->mem_access_type_stats[TEXTURE_ACC_R][id][j]);
+  }
 }
 
-void dram_t::visualizer_print( gzFile visualizer_file )
-{
-   // dram specific statistics
-   gzprintf(visualizer_file,"dramncmd: %u %u\n",id, n_cmd_partial);  
-   gzprintf(visualizer_file,"dramnop: %u %u\n",id,n_nop_partial);
-   gzprintf(visualizer_file,"dramnact: %u %u\n",id,n_act_partial);
-   gzprintf(visualizer_file,"dramnpre: %u %u\n",id,n_pre_partial);
-   gzprintf(visualizer_file,"dramnreq: %u %u\n",id,n_req_partial);
-   gzprintf(visualizer_file,"dramavemrqs: %u %u\n",id,
-            n_cmd_partial?(ave_mrqs_partial/n_cmd_partial ):0);
-
-   // utilization and efficiency
-   gzprintf(visualizer_file,"dramutil: %u %u\n",  
-            id,n_cmd_partial?100*bwutil_partial/n_cmd_partial:0);
-   gzprintf(visualizer_file,"drameff: %u %u\n", 
-            id,n_activity_partial?100*bwutil_partial/n_activity_partial:0);
-
-   // reset for next interval
-   bwutil_partial = 0;
-   n_activity_partial = 0;
-   ave_mrqs_partial = 0; 
-   n_cmd_partial = 0;
-   n_nop_partial = 0;
-   n_act_partial = 0;
-   n_pre_partial = 0;
-   n_req_partial = 0;
-
-
-   // dram access type classification
-   for (unsigned j = 0; j < m_config->nbk; j++) {
-      gzprintf(visualizer_file,"dramglobal_acc_r: %u %u %u\n", id, j, 
-               m_stats->mem_access_type_stats[GLOBAL_ACC_R][id][j]);
-      gzprintf(visualizer_file,"dramglobal_acc_w: %u %u %u\n", id, j, 
-               m_stats->mem_access_type_stats[GLOBAL_ACC_W][id][j]);
-      gzprintf(visualizer_file,"dramlocal_acc_r: %u %u %u\n", id, j, 
-               m_stats->mem_access_type_stats[LOCAL_ACC_R][id][j]);
-      gzprintf(visualizer_file,"dramlocal_acc_w: %u %u %u\n", id, j, 
-               m_stats->mem_access_type_stats[LOCAL_ACC_W][id][j]);
-      gzprintf(visualizer_file,"dramconst_acc_r: %u %u %u\n", id, j, 
-               m_stats->mem_access_type_stats[CONST_ACC_R][id][j]);
-      gzprintf(visualizer_file,"dramtexture_acc_r: %u %u %u\n", id, j, 
-               m_stats->mem_access_type_stats[TEXTURE_ACC_R][id][j]);
-   }
+void dram_t::set_dram_power_stats(unsigned &cmd, unsigned &activity,
+                                  unsigned &nop, unsigned &act, unsigned &pre,
+                                  unsigned &rd, unsigned &wr,
+                                  unsigned &req) const {
+  // Point power performance counters to low-level DRAM counters
+  cmd = n_cmd;
+  activity = n_activity;
+  nop = n_nop;
+  act = n_act;
+  pre = n_pre;
+  rd = n_rd;
+  wr = n_wr;
+  req = n_req;
 }
 
-
-void dram_t::set_dram_power_stats(	unsigned &cmd,
-									unsigned &activity,
-									unsigned &nop,
-									unsigned &act,
-									unsigned &pre,
-									unsigned &rd,
-									unsigned &wr,
-									unsigned &req) const{
-
-	// Point power performance counters to low-level DRAM counters
-	cmd = n_cmd;
-	activity = n_activity;
-	nop = n_nop;
-	act = n_act;
-	pre = n_pre;
-	rd = n_rd;
-	wr = n_wr;
-	req = n_req;
-}
-
-unsigned dram_t::get_bankgrp_number(unsigned i)
-{
-	if(m_config->dram_bnkgrp_indexing_policy == HIGHER_BITS) { //higher bits
-		return i >> m_config->bk_tag_length;
-	}
-	else if (m_config->dram_bnkgrp_indexing_policy == LOWER_BITS) { //lower bits
-		return i & ((m_config->nbkgrp - 1));
-	}
-	else {
-		assert(1);
-	}
+unsigned dram_t::get_bankgrp_number(unsigned i) {
+  if (m_config->dram_bnkgrp_indexing_policy == HIGHER_BITS) {  // higher bits
+    return i >> m_config->bk_tag_length;
+  } else if (m_config->dram_bnkgrp_indexing_policy ==
+             LOWER_BITS) {  // lower bits
+    return i & ((m_config->nbkgrp - 1));
+  } else {
+    assert(1);
+  }
 }

--- a/src/gpgpu-sim/dram.h
+++ b/src/gpgpu-sim/dram.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2011, Tor M. Aamodt, Ivan Sham, Ali Bakhoda, 
+// Copyright (c) 2009-2011, Tor M. Aamodt, Ivan Sham, Ali Bakhoda,
 // George L. Yuan, Wilson W.L. Fung
 // The University of British Columbia
 // All rights reserved.
@@ -8,14 +8,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -29,227 +31,217 @@
 #ifndef DRAM_H
 #define DRAM_H
 
-#include "delayqueue.h"
-#include <set>
-#include <vector>
-#include <bitset>
-#include <sstream>
-#include <string>
-#include <fstream>
-#include <zlib.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include<iomanip>
+#include <zlib.h>
+#include <bitset>
+#include <fstream>
+#include <iomanip>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
+#include "delayqueue.h"
 
-#define READ 'R'  //define read and write states
+#define READ 'R'  // define read and write states
 #define WRITE 'W'
 #define BANK_IDLE 'I'
 #define BANK_ACTIVE 'A'
 
 class dram_req_t {
-public:
-   dram_req_t( class mem_fetch *data , unsigned banks, unsigned dram_bnk_indexing_policy, class gpgpu_sim* gpu);
+ public:
+  dram_req_t(class mem_fetch *data, unsigned banks,
+             unsigned dram_bnk_indexing_policy, class gpgpu_sim *gpu);
 
-   unsigned int row;
-   unsigned int col;
-   unsigned int bk;
-   unsigned int nbytes;
-   unsigned int txbytes;
-   unsigned int dqbytes;
-   unsigned int age;
-   unsigned int timestamp;
-   unsigned char rw;    //is the request a read or a write?
-   unsigned long long int addr;
-   unsigned int insertion_time;
-   class mem_fetch * data;
-   class gpgpu_sim * m_gpu;
+  unsigned int row;
+  unsigned int col;
+  unsigned int bk;
+  unsigned int nbytes;
+  unsigned int txbytes;
+  unsigned int dqbytes;
+  unsigned int age;
+  unsigned int timestamp;
+  unsigned char rw;  // is the request a read or a write?
+  unsigned long long int addr;
+  unsigned int insertion_time;
+  class mem_fetch *data;
+  class gpgpu_sim *m_gpu;
 };
 
-struct bankgrp_t
-{
-	unsigned int CCDLc;
-	unsigned int RTPLc;
+struct bankgrp_t {
+  unsigned int CCDLc;
+  unsigned int RTPLc;
 };
 
-struct bank_t
-{
-   unsigned int RCDc;
-   unsigned int RCDWRc;
-   unsigned int RASc;
-   unsigned int RPc;
-   unsigned int RCc;
-   unsigned int WTPc; // write to precharge
-   unsigned int RTPc; // read to precharge
+struct bank_t {
+  unsigned int RCDc;
+  unsigned int RCDWRc;
+  unsigned int RASc;
+  unsigned int RPc;
+  unsigned int RCc;
+  unsigned int WTPc;  // write to precharge
+  unsigned int RTPc;  // read to precharge
 
-   unsigned char rw;    //is the bank reading or writing?
-   unsigned char state; //is the bank active or idle?
-   unsigned int curr_row;
+  unsigned char rw;     // is the bank reading or writing?
+  unsigned char state;  // is the bank active or idle?
+  unsigned int curr_row;
 
-   dram_req_t *mrq;
+  dram_req_t *mrq;
 
-   unsigned int n_access;
-   unsigned int n_writes;
-   unsigned int n_idle;
+  unsigned int n_access;
+  unsigned int n_writes;
+  unsigned int n_idle;
 
-   unsigned int bkgrpindex;
+  unsigned int bkgrpindex;
 };
 
-enum bank_index_function{
-	LINEAR_BK_INDEX = 0,
-	BITWISE_XORING_BK_INDEX,
-    CUSTOM_BK_INDEX
+enum bank_index_function {
+  LINEAR_BK_INDEX = 0,
+  BITWISE_XORING_BK_INDEX,
+  CUSTOM_BK_INDEX
 };
 
-enum bank_grp_bits_position{
-	HIGHER_BITS = 0,
-	LOWER_BITS
-};
+enum bank_grp_bits_position { HIGHER_BITS = 0, LOWER_BITS };
 
 class mem_fetch;
 class memory_config;
 
-class dram_t 
-{
-public:
-   dram_t( unsigned int parition_id, const memory_config *config, class memory_stats_t *stats,
-           class memory_partition_unit *mp, class gpgpu_sim* gpu );
+class dram_t {
+ public:
+  dram_t(unsigned int parition_id, const memory_config *config,
+         class memory_stats_t *stats, class memory_partition_unit *mp,
+         class gpgpu_sim *gpu);
 
-   bool full(bool is_write) const;
-   void print( FILE* simFile ) const;
-   void visualize() const;
-   void print_stat( FILE* simFile );
-   unsigned que_length() const; 
-   bool returnq_full() const;
-   unsigned int queue_limit() const;
-   void visualizer_print( gzFile visualizer_file );
+  bool full(bool is_write) const;
+  void print(FILE *simFile) const;
+  void visualize() const;
+  void print_stat(FILE *simFile);
+  unsigned que_length() const;
+  bool returnq_full() const;
+  unsigned int queue_limit() const;
+  void visualizer_print(gzFile visualizer_file);
 
-   class mem_fetch* return_queue_pop();
-   class mem_fetch* return_queue_top();
+  class mem_fetch *return_queue_pop();
+  class mem_fetch *return_queue_top();
 
-   void push( class mem_fetch *data );
-   void cycle();
-   void dram_log (int task);
+  void push(class mem_fetch *data);
+  void cycle();
+  void dram_log(int task);
 
-   class memory_partition_unit *m_memory_partition_unit;
-   class gpgpu_sim* m_gpu;
-   unsigned int id;
+  class memory_partition_unit *m_memory_partition_unit;
+  class gpgpu_sim *m_gpu;
+  unsigned int id;
 
-   // Power Model
-   void set_dram_power_stats(unsigned &cmd,
-								unsigned &activity,
-								unsigned &nop,
-								unsigned &act,
-								unsigned &pre,
-								unsigned &rd,
-								unsigned &wr,
-								unsigned &req) const;
+  // Power Model
+  void set_dram_power_stats(unsigned &cmd, unsigned &activity, unsigned &nop,
+                            unsigned &act, unsigned &pre, unsigned &rd,
+                            unsigned &wr, unsigned &req) const;
 
+  const memory_config *m_config;
 
+ private:
+  bankgrp_t **bkgrp;
 
-   const memory_config *m_config;
+  bank_t **bk;
+  unsigned int prio;
 
-private:
-   bankgrp_t **bkgrp;
+  unsigned get_bankgrp_number(unsigned i);
 
-   bank_t **bk;
-   unsigned int prio;
+  void scheduler_fifo();
+  void scheduler_frfcfs();
 
-   unsigned get_bankgrp_number(unsigned i);
+  bool issue_col_command(int j);
+  bool issue_row_command(int j);
 
-   void scheduler_fifo();
-   void scheduler_frfcfs();
+  unsigned int RRDc;
+  unsigned int CCDc;
+  unsigned int RTWc;  // read to write penalty applies across banks
+  unsigned int WTRc;  // write to read penalty applies across banks
 
-   bool issue_col_command(int j);
-   bool issue_row_command(int j);
+  unsigned char
+      rw;  // was last request a read or write? (important for RTW, WTR)
 
-   unsigned int RRDc;
-   unsigned int CCDc;
-   unsigned int RTWc;   //read to write penalty applies across banks
-   unsigned int WTRc;   //write to read penalty applies across banks
+  unsigned int pending_writes;
 
-   unsigned char rw; //was last request a read or write? (important for RTW, WTR)
+  fifo_pipeline<dram_req_t> *rwq;
+  fifo_pipeline<dram_req_t> *mrqq;
+  // buffer to hold packets when DRAM processing is over
+  // should be filled with dram clock and popped with l2or icnt clock
+  fifo_pipeline<mem_fetch> *returnq;
 
-   unsigned int pending_writes;
+  unsigned int dram_util_bins[10];
+  unsigned int dram_eff_bins[10];
+  unsigned int last_n_cmd, last_n_activity, last_bwutil;
 
-   fifo_pipeline<dram_req_t> *rwq;
-   fifo_pipeline<dram_req_t> *mrqq;
-   //buffer to hold packets when DRAM processing is over
-   //should be filled with dram clock and popped with l2or icnt clock
-   fifo_pipeline<mem_fetch> *returnq;
+  unsigned long long n_cmd;
+  unsigned long long n_activity;
+  unsigned long long n_nop;
+  unsigned long long n_act;
+  unsigned long long n_pre;
+  unsigned long long n_ref;
+  unsigned long long n_rd;
+  unsigned long long n_rd_L2_A;
+  unsigned long long n_wr;
+  unsigned long long n_wr_WB;
+  unsigned long long n_req;
+  unsigned long long max_mrqs_temp;
 
-   unsigned int dram_util_bins[10];
-   unsigned int dram_eff_bins[10];
-   unsigned int last_n_cmd, last_n_activity, last_bwutil;
+  // some statistics to see where BW is wasted?
+  unsigned long long wasted_bw_row;
+  unsigned long long wasted_bw_col;
+  unsigned long long util_bw;
+  unsigned long long idle_bw;
+  unsigned long long RCDc_limit;
+  unsigned long long CCDLc_limit;
+  unsigned long long CCDLc_limit_alone;
+  unsigned long long CCDc_limit;
+  unsigned long long WTRc_limit;
+  unsigned long long WTRc_limit_alone;
+  unsigned long long RCDWRc_limit;
+  unsigned long long RTWc_limit;
+  unsigned long long RTWc_limit_alone;
+  unsigned long long rwq_limit;
 
-   unsigned long long n_cmd;
-   unsigned long long n_activity;
-   unsigned long long n_nop;
-   unsigned long long n_act;
-   unsigned long long n_pre;
-   unsigned long long n_ref;
-   unsigned long long n_rd;
-   unsigned long long n_rd_L2_A;
-   unsigned long long n_wr;
-   unsigned long long n_wr_WB;
-   unsigned long long n_req;
-   unsigned long long max_mrqs_temp;
+  // row locality, BLP and other statistics
+  unsigned long long access_num;
+  unsigned long long read_num;
+  unsigned long long write_num;
+  unsigned long long hits_num;
+  unsigned long long hits_read_num;
+  unsigned long long hits_write_num;
+  unsigned long long banks_1time;
+  unsigned long long banks_acess_total;
+  unsigned long long banks_acess_total_after;
+  unsigned long long banks_time_rw;
+  unsigned long long banks_access_rw_total;
+  unsigned long long banks_time_ready;
+  unsigned long long banks_access_ready_total;
+  unsigned long long issued_two;
+  unsigned long long issued_total;
+  unsigned long long issued_total_row;
+  unsigned long long issued_total_col;
+  double write_to_read_ratio_blp_rw_average;
+  unsigned long long bkgrp_parallsim_rw;
 
-   //some statistics to see where BW is wasted?
-   unsigned long long wasted_bw_row;
-   unsigned long long wasted_bw_col;
-   unsigned long long util_bw;
-   unsigned long long idle_bw;
-   unsigned long long RCDc_limit;
-   unsigned long long CCDLc_limit;
-   unsigned long long CCDLc_limit_alone;
-   unsigned long long CCDc_limit;
-   unsigned long long WTRc_limit;
-   unsigned long long WTRc_limit_alone;
-   unsigned long long RCDWRc_limit;
-   unsigned long long RTWc_limit;
-   unsigned long long RTWc_limit_alone;
-   unsigned long long rwq_limit;
+  unsigned int bwutil;
+  unsigned int max_mrqs;
+  unsigned int ave_mrqs;
 
-   //row locality, BLP and other statistics
-   unsigned long long access_num;
-   unsigned long long read_num;
-   unsigned long long write_num;
-   unsigned long long hits_num;
-   unsigned long long hits_read_num;
-   unsigned long long hits_write_num;
-   unsigned long long banks_1time;
-   unsigned long long banks_acess_total;
-   unsigned long long banks_acess_total_after;
-   unsigned long long banks_time_rw;
-   unsigned long long banks_access_rw_total;
-   unsigned long long banks_time_ready;
-   unsigned long long banks_access_ready_total;
-   unsigned long long issued_two;
-   unsigned long long issued_total;
-   unsigned long long issued_total_row;
-   unsigned long long issued_total_col;
-   double write_to_read_ratio_blp_rw_average;
-   unsigned long long bkgrp_parallsim_rw;
+  class frfcfs_scheduler *m_frfcfs_scheduler;
 
-   unsigned int bwutil;
-   unsigned int max_mrqs;
-   unsigned int ave_mrqs;
+  unsigned int n_cmd_partial;
+  unsigned int n_activity_partial;
+  unsigned int n_nop_partial;
+  unsigned int n_act_partial;
+  unsigned int n_pre_partial;
+  unsigned int n_req_partial;
+  unsigned int ave_mrqs_partial;
+  unsigned int bwutil_partial;
 
-   class frfcfs_scheduler* m_frfcfs_scheduler;
+  class memory_stats_t *m_stats;
+  class Stats *mrqq_Dist;  // memory request queue inside DRAM
 
-   unsigned int n_cmd_partial;
-   unsigned int n_activity_partial;
-   unsigned int n_nop_partial; 
-   unsigned int n_act_partial; 
-   unsigned int n_pre_partial; 
-   unsigned int n_req_partial;
-   unsigned int ave_mrqs_partial;
-   unsigned int bwutil_partial;
-
-   class memory_stats_t *m_stats;
-   class Stats* mrqq_Dist; //memory request queue inside DRAM  
-
-   friend class frfcfs_scheduler;
+  friend class frfcfs_scheduler;
 };
 
 #endif /*DRAM_H*/

--- a/src/gpgpu-sim/dram.h
+++ b/src/gpgpu-sim/dram.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2011, Tor M. Aamodt, Ivan Sham, Ali Bakhoda, 
+// Copyright (c) 2009-2011, Tor M. Aamodt, Ivan Sham, Ali Bakhoda,
 // George L. Yuan, Wilson W.L. Fung
 // The University of British Columbia
 // All rights reserved.
@@ -8,248 +8,239 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef DRAM_H
 #define DRAM_H
 
-#include "delayqueue.h"
-#include <set>
-#include <vector>
-#include <bitset>
-#include <sstream>
-#include <string>
-#include <fstream>
-#include <zlib.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include<iomanip>
+#include <zlib.h>
+#include <bitset>
+#include <fstream>
+#include <iomanip>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
+#include "delayqueue.h"
 
-#define READ 'R'  //define read and write states
+#define READ 'R'  // define read and write states
 #define WRITE 'W'
 #define BANK_IDLE 'I'
 #define BANK_ACTIVE 'A'
 
 class dram_req_t {
-public:
-   dram_req_t( class mem_fetch *data , unsigned banks, unsigned dram_bnk_indexing_policy, class gpgpu_sim* gpu);
+ public:
+  dram_req_t(class mem_fetch *data, unsigned banks,
+             unsigned dram_bnk_indexing_policy, class gpgpu_sim *gpu);
 
-   unsigned int row;
-   unsigned int col;
-   unsigned int bk;
-   unsigned int nbytes;
-   unsigned int txbytes;
-   unsigned int dqbytes;
-   unsigned int age;
-   unsigned int timestamp;
-   unsigned char rw;    //is the request a read or a write?
-   unsigned long long int addr;
-   unsigned int insertion_time;
-   class mem_fetch * data;
-   class gpgpu_sim * m_gpu;
+  unsigned int row;
+  unsigned int col;
+  unsigned int bk;
+  unsigned int nbytes;
+  unsigned int txbytes;
+  unsigned int dqbytes;
+  unsigned int age;
+  unsigned int timestamp;
+  unsigned char rw;  // is the request a read or a write?
+  unsigned long long int addr;
+  unsigned int insertion_time;
+  class mem_fetch *data;
+  class gpgpu_sim *m_gpu;
 };
 
-struct bankgrp_t
-{
-	unsigned int CCDLc;
-	unsigned int RTPLc;
+struct bankgrp_t {
+  unsigned int CCDLc;
+  unsigned int RTPLc;
 };
 
-struct bank_t
-{
-   unsigned int RCDc;
-   unsigned int RCDWRc;
-   unsigned int RASc;
-   unsigned int RPc;
-   unsigned int RCc;
-   unsigned int WTPc; // write to precharge
-   unsigned int RTPc; // read to precharge
+struct bank_t {
+  unsigned int RCDc;
+  unsigned int RCDWRc;
+  unsigned int RASc;
+  unsigned int RPc;
+  unsigned int RCc;
+  unsigned int WTPc;  // write to precharge
+  unsigned int RTPc;  // read to precharge
 
-   unsigned char rw;    //is the bank reading or writing?
-   unsigned char state; //is the bank active or idle?
-   unsigned int curr_row;
+  unsigned char rw;     // is the bank reading or writing?
+  unsigned char state;  // is the bank active or idle?
+  unsigned int curr_row;
 
-   dram_req_t *mrq;
+  dram_req_t *mrq;
 
-   unsigned int n_access;
-   unsigned int n_writes;
-   unsigned int n_idle;
+  unsigned int n_access;
+  unsigned int n_writes;
+  unsigned int n_idle;
 
-   unsigned int bkgrpindex;
+  unsigned int bkgrpindex;
 };
 
-enum bank_index_function{
-	LINEAR_BK_INDEX = 0,
-	BITWISE_XORING_BK_INDEX,
-    CUSTOM_BK_INDEX
+enum bank_index_function {
+  LINEAR_BK_INDEX = 0,
+  BITWISE_XORING_BK_INDEX,
+  CUSTOM_BK_INDEX
 };
 
-enum bank_grp_bits_position{
-	HIGHER_BITS = 0,
-	LOWER_BITS
-};
+enum bank_grp_bits_position { HIGHER_BITS = 0, LOWER_BITS };
 
 class mem_fetch;
 class memory_config;
 
-class dram_t 
-{
-public:
-   dram_t( unsigned int parition_id, const memory_config *config, class memory_stats_t *stats,
-           class memory_partition_unit *mp, class gpgpu_sim* gpu );
+class dram_t {
+ public:
+  dram_t(unsigned int parition_id, const memory_config *config,
+         class memory_stats_t *stats, class memory_partition_unit *mp,
+         class gpgpu_sim *gpu);
 
-   bool full(bool is_write) const;
-   void print( FILE* simFile ) const;
-   void visualize() const;
-   void print_stat( FILE* simFile );
-   unsigned que_length() const; 
-   bool returnq_full() const;
-   unsigned int queue_limit() const;
-   void visualizer_print( gzFile visualizer_file );
+  bool full(bool is_write) const;
+  void print(FILE *simFile) const;
+  void visualize() const;
+  void print_stat(FILE *simFile);
+  unsigned que_length() const;
+  bool returnq_full() const;
+  unsigned int queue_limit() const;
+  void visualizer_print(gzFile visualizer_file);
 
-   class mem_fetch* return_queue_pop();
-   class mem_fetch* return_queue_top();
+  class mem_fetch *return_queue_pop();
+  class mem_fetch *return_queue_top();
 
-   void push( class mem_fetch *data );
-   void cycle();
-   void dram_log (int task);
+  void push(class mem_fetch *data);
+  void cycle();
+  void dram_log(int task);
 
-   class memory_partition_unit *m_memory_partition_unit;
-   class gpgpu_sim* m_gpu;
-   unsigned int id;
+  class memory_partition_unit *m_memory_partition_unit;
+  class gpgpu_sim *m_gpu;
+  unsigned int id;
 
-   // Power Model
-   void set_dram_power_stats(unsigned &cmd,
-								unsigned &activity,
-								unsigned &nop,
-								unsigned &act,
-								unsigned &pre,
-								unsigned &rd,
-								unsigned &wr,
-								unsigned &req) const;
+  // Power Model
+  void set_dram_power_stats(unsigned &cmd, unsigned &activity, unsigned &nop,
+                            unsigned &act, unsigned &pre, unsigned &rd,
+                            unsigned &wr, unsigned &req) const;
 
+  const memory_config *m_config;
 
+ private:
+  bankgrp_t **bkgrp;
 
-   const memory_config *m_config;
+  bank_t **bk;
+  unsigned int prio;
 
-private:
-   bankgrp_t **bkgrp;
+  unsigned get_bankgrp_number(unsigned i);
 
-   bank_t **bk;
-   unsigned int prio;
+  void scheduler_fifo();
+  void scheduler_frfcfs();
 
-   unsigned get_bankgrp_number(unsigned i);
+  bool issue_col_command(int j);
+  bool issue_row_command(int j);
 
-   void scheduler_fifo();
-   void scheduler_frfcfs();
+  unsigned int RRDc;
+  unsigned int CCDc;
+  unsigned int RTWc;  // read to write penalty applies across banks
+  unsigned int WTRc;  // write to read penalty applies across banks
 
-   bool issue_col_command(int j);
-   bool issue_row_command(int j);
+  unsigned char
+      rw;  // was last request a read or write? (important for RTW, WTR)
 
-   unsigned int RRDc;
-   unsigned int CCDc;
-   unsigned int RTWc;   //read to write penalty applies across banks
-   unsigned int WTRc;   //write to read penalty applies across banks
+  unsigned int pending_writes;
 
-   unsigned char rw; //was last request a read or write? (important for RTW, WTR)
+  fifo_pipeline<dram_req_t> *rwq;
+  fifo_pipeline<dram_req_t> *mrqq;
+  // buffer to hold packets when DRAM processing is over
+  // should be filled with dram clock and popped with l2or icnt clock
+  fifo_pipeline<mem_fetch> *returnq;
 
-   unsigned int pending_writes;
+  unsigned int dram_util_bins[10];
+  unsigned int dram_eff_bins[10];
+  unsigned int last_n_cmd, last_n_activity, last_bwutil;
 
-   fifo_pipeline<dram_req_t> *rwq;
-   fifo_pipeline<dram_req_t> *mrqq;
-   //buffer to hold packets when DRAM processing is over
-   //should be filled with dram clock and popped with l2or icnt clock
-   fifo_pipeline<mem_fetch> *returnq;
+  unsigned long long n_cmd;
+  unsigned long long n_activity;
+  unsigned long long n_nop;
+  unsigned long long n_act;
+  unsigned long long n_pre;
+  unsigned long long n_ref;
+  unsigned long long n_rd;
+  unsigned long long n_rd_L2_A;
+  unsigned long long n_wr;
+  unsigned long long n_wr_WB;
+  unsigned long long n_req;
+  unsigned long long max_mrqs_temp;
 
-   unsigned int dram_util_bins[10];
-   unsigned int dram_eff_bins[10];
-   unsigned int last_n_cmd, last_n_activity, last_bwutil;
+  // some statistics to see where BW is wasted?
+  unsigned long long wasted_bw_row;
+  unsigned long long wasted_bw_col;
+  unsigned long long util_bw;
+  unsigned long long idle_bw;
+  unsigned long long RCDc_limit;
+  unsigned long long CCDLc_limit;
+  unsigned long long CCDLc_limit_alone;
+  unsigned long long CCDc_limit;
+  unsigned long long WTRc_limit;
+  unsigned long long WTRc_limit_alone;
+  unsigned long long RCDWRc_limit;
+  unsigned long long RTWc_limit;
+  unsigned long long RTWc_limit_alone;
+  unsigned long long rwq_limit;
 
-   unsigned long long n_cmd;
-   unsigned long long n_activity;
-   unsigned long long n_nop;
-   unsigned long long n_act;
-   unsigned long long n_pre;
-   unsigned long long n_ref;
-   unsigned long long n_rd;
-   unsigned long long n_rd_L2_A;
-   unsigned long long n_wr;
-   unsigned long long n_wr_WB;
-   unsigned long long n_req;
-   unsigned long long max_mrqs_temp;
+  // row locality, BLP and other statistics
+  unsigned long long access_num;
+  unsigned long long read_num;
+  unsigned long long write_num;
+  unsigned long long hits_num;
+  unsigned long long hits_read_num;
+  unsigned long long hits_write_num;
+  unsigned long long banks_1time;
+  unsigned long long banks_acess_total;
+  unsigned long long banks_acess_total_after;
+  unsigned long long banks_time_rw;
+  unsigned long long banks_access_rw_total;
+  unsigned long long banks_time_ready;
+  unsigned long long banks_access_ready_total;
+  unsigned long long issued_two;
+  unsigned long long issued_total;
+  unsigned long long issued_total_row;
+  unsigned long long issued_total_col;
+  double write_to_read_ratio_blp_rw_average;
+  unsigned long long bkgrp_parallsim_rw;
 
-   //some statistics to see where BW is wasted?
-   unsigned long long wasted_bw_row;
-   unsigned long long wasted_bw_col;
-   unsigned long long util_bw;
-   unsigned long long idle_bw;
-   unsigned long long RCDc_limit;
-   unsigned long long CCDLc_limit;
-   unsigned long long CCDLc_limit_alone;
-   unsigned long long CCDc_limit;
-   unsigned long long WTRc_limit;
-   unsigned long long WTRc_limit_alone;
-   unsigned long long RCDWRc_limit;
-   unsigned long long RTWc_limit;
-   unsigned long long RTWc_limit_alone;
-   unsigned long long rwq_limit;
+  unsigned int bwutil;
+  unsigned int max_mrqs;
+  unsigned int ave_mrqs;
 
-   //row locality, BLP and other statistics
-   unsigned long long access_num;
-   unsigned long long read_num;
-   unsigned long long write_num;
-   unsigned long long hits_num;
-   unsigned long long hits_read_num;
-   unsigned long long hits_write_num;
-   unsigned long long banks_1time;
-   unsigned long long banks_acess_total;
-   unsigned long long banks_acess_total_after;
-   unsigned long long banks_time_rw;
-   unsigned long long banks_access_rw_total;
-   unsigned long long banks_time_ready;
-   unsigned long long banks_access_ready_total;
-   unsigned long long issued_two;
-   unsigned long long issued_total;
-   unsigned long long issued_total_row;
-   unsigned long long issued_total_col;
-   double write_to_read_ratio_blp_rw_average;
-   unsigned long long bkgrp_parallsim_rw;
+  class frfcfs_scheduler *m_frfcfs_scheduler;
 
-   unsigned int bwutil;
-   unsigned int max_mrqs;
-   unsigned int ave_mrqs;
+  unsigned int n_cmd_partial;
+  unsigned int n_activity_partial;
+  unsigned int n_nop_partial;
+  unsigned int n_act_partial;
+  unsigned int n_pre_partial;
+  unsigned int n_req_partial;
+  unsigned int ave_mrqs_partial;
+  unsigned int bwutil_partial;
 
-   class frfcfs_scheduler* m_frfcfs_scheduler;
+  class memory_stats_t *m_stats;
+  class Stats *mrqq_Dist;  // memory request queue inside DRAM
 
-   unsigned int n_cmd_partial;
-   unsigned int n_activity_partial;
-   unsigned int n_nop_partial; 
-   unsigned int n_act_partial; 
-   unsigned int n_pre_partial; 
-   unsigned int n_req_partial;
-   unsigned int ave_mrqs_partial;
-   unsigned int bwutil_partial;
-
-   class memory_stats_t *m_stats;
-   class Stats* mrqq_Dist; //memory request queue inside DRAM  
-
-   friend class frfcfs_scheduler;
+  friend class frfcfs_scheduler;
 };
 
 #endif /*DRAM_H*/

--- a/src/gpgpu-sim/dram.h
+++ b/src/gpgpu-sim/dram.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2011, Tor M. Aamodt, Ivan Sham, Ali Bakhoda,
+// Copyright (c) 2009-2011, Tor M. Aamodt, Ivan Sham, Ali Bakhoda, 
 // George L. Yuan, Wilson W.L. Fung
 // The University of British Columbia
 // All rights reserved.
@@ -8,16 +8,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -31,217 +29,227 @@
 #ifndef DRAM_H
 #define DRAM_H
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <zlib.h>
-#include <bitset>
-#include <fstream>
-#include <iomanip>
+#include "delayqueue.h"
 #include <set>
+#include <vector>
+#include <bitset>
 #include <sstream>
 #include <string>
-#include <vector>
-#include "delayqueue.h"
+#include <fstream>
+#include <zlib.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include<iomanip>
 
-#define READ 'R'  // define read and write states
+#define READ 'R'  //define read and write states
 #define WRITE 'W'
 #define BANK_IDLE 'I'
 #define BANK_ACTIVE 'A'
 
 class dram_req_t {
- public:
-  dram_req_t(class mem_fetch *data, unsigned banks,
-             unsigned dram_bnk_indexing_policy, class gpgpu_sim *gpu);
+public:
+   dram_req_t( class mem_fetch *data , unsigned banks, unsigned dram_bnk_indexing_policy, class gpgpu_sim* gpu);
 
-  unsigned int row;
-  unsigned int col;
-  unsigned int bk;
-  unsigned int nbytes;
-  unsigned int txbytes;
-  unsigned int dqbytes;
-  unsigned int age;
-  unsigned int timestamp;
-  unsigned char rw;  // is the request a read or a write?
-  unsigned long long int addr;
-  unsigned int insertion_time;
-  class mem_fetch *data;
-  class gpgpu_sim *m_gpu;
+   unsigned int row;
+   unsigned int col;
+   unsigned int bk;
+   unsigned int nbytes;
+   unsigned int txbytes;
+   unsigned int dqbytes;
+   unsigned int age;
+   unsigned int timestamp;
+   unsigned char rw;    //is the request a read or a write?
+   unsigned long long int addr;
+   unsigned int insertion_time;
+   class mem_fetch * data;
+   class gpgpu_sim * m_gpu;
 };
 
-struct bankgrp_t {
-  unsigned int CCDLc;
-  unsigned int RTPLc;
+struct bankgrp_t
+{
+	unsigned int CCDLc;
+	unsigned int RTPLc;
 };
 
-struct bank_t {
-  unsigned int RCDc;
-  unsigned int RCDWRc;
-  unsigned int RASc;
-  unsigned int RPc;
-  unsigned int RCc;
-  unsigned int WTPc;  // write to precharge
-  unsigned int RTPc;  // read to precharge
+struct bank_t
+{
+   unsigned int RCDc;
+   unsigned int RCDWRc;
+   unsigned int RASc;
+   unsigned int RPc;
+   unsigned int RCc;
+   unsigned int WTPc; // write to precharge
+   unsigned int RTPc; // read to precharge
 
-  unsigned char rw;     // is the bank reading or writing?
-  unsigned char state;  // is the bank active or idle?
-  unsigned int curr_row;
+   unsigned char rw;    //is the bank reading or writing?
+   unsigned char state; //is the bank active or idle?
+   unsigned int curr_row;
 
-  dram_req_t *mrq;
+   dram_req_t *mrq;
 
-  unsigned int n_access;
-  unsigned int n_writes;
-  unsigned int n_idle;
+   unsigned int n_access;
+   unsigned int n_writes;
+   unsigned int n_idle;
 
-  unsigned int bkgrpindex;
+   unsigned int bkgrpindex;
 };
 
-enum bank_index_function {
-  LINEAR_BK_INDEX = 0,
-  BITWISE_XORING_BK_INDEX,
-  CUSTOM_BK_INDEX
+enum bank_index_function{
+	LINEAR_BK_INDEX = 0,
+	BITWISE_XORING_BK_INDEX,
+    CUSTOM_BK_INDEX
 };
 
-enum bank_grp_bits_position { HIGHER_BITS = 0, LOWER_BITS };
+enum bank_grp_bits_position{
+	HIGHER_BITS = 0,
+	LOWER_BITS
+};
 
 class mem_fetch;
 class memory_config;
 
-class dram_t {
- public:
-  dram_t(unsigned int parition_id, const memory_config *config,
-         class memory_stats_t *stats, class memory_partition_unit *mp,
-         class gpgpu_sim *gpu);
+class dram_t 
+{
+public:
+   dram_t( unsigned int parition_id, const memory_config *config, class memory_stats_t *stats,
+           class memory_partition_unit *mp, class gpgpu_sim* gpu );
 
-  bool full(bool is_write) const;
-  void print(FILE *simFile) const;
-  void visualize() const;
-  void print_stat(FILE *simFile);
-  unsigned que_length() const;
-  bool returnq_full() const;
-  unsigned int queue_limit() const;
-  void visualizer_print(gzFile visualizer_file);
+   bool full(bool is_write) const;
+   void print( FILE* simFile ) const;
+   void visualize() const;
+   void print_stat( FILE* simFile );
+   unsigned que_length() const; 
+   bool returnq_full() const;
+   unsigned int queue_limit() const;
+   void visualizer_print( gzFile visualizer_file );
 
-  class mem_fetch *return_queue_pop();
-  class mem_fetch *return_queue_top();
+   class mem_fetch* return_queue_pop();
+   class mem_fetch* return_queue_top();
 
-  void push(class mem_fetch *data);
-  void cycle();
-  void dram_log(int task);
+   void push( class mem_fetch *data );
+   void cycle();
+   void dram_log (int task);
 
-  class memory_partition_unit *m_memory_partition_unit;
-  class gpgpu_sim *m_gpu;
-  unsigned int id;
+   class memory_partition_unit *m_memory_partition_unit;
+   class gpgpu_sim* m_gpu;
+   unsigned int id;
 
-  // Power Model
-  void set_dram_power_stats(unsigned &cmd, unsigned &activity, unsigned &nop,
-                            unsigned &act, unsigned &pre, unsigned &rd,
-                            unsigned &wr, unsigned &req) const;
+   // Power Model
+   void set_dram_power_stats(unsigned &cmd,
+								unsigned &activity,
+								unsigned &nop,
+								unsigned &act,
+								unsigned &pre,
+								unsigned &rd,
+								unsigned &wr,
+								unsigned &req) const;
 
-  const memory_config *m_config;
 
- private:
-  bankgrp_t **bkgrp;
 
-  bank_t **bk;
-  unsigned int prio;
+   const memory_config *m_config;
 
-  unsigned get_bankgrp_number(unsigned i);
+private:
+   bankgrp_t **bkgrp;
 
-  void scheduler_fifo();
-  void scheduler_frfcfs();
+   bank_t **bk;
+   unsigned int prio;
 
-  bool issue_col_command(int j);
-  bool issue_row_command(int j);
+   unsigned get_bankgrp_number(unsigned i);
 
-  unsigned int RRDc;
-  unsigned int CCDc;
-  unsigned int RTWc;  // read to write penalty applies across banks
-  unsigned int WTRc;  // write to read penalty applies across banks
+   void scheduler_fifo();
+   void scheduler_frfcfs();
 
-  unsigned char
-      rw;  // was last request a read or write? (important for RTW, WTR)
+   bool issue_col_command(int j);
+   bool issue_row_command(int j);
 
-  unsigned int pending_writes;
+   unsigned int RRDc;
+   unsigned int CCDc;
+   unsigned int RTWc;   //read to write penalty applies across banks
+   unsigned int WTRc;   //write to read penalty applies across banks
 
-  fifo_pipeline<dram_req_t> *rwq;
-  fifo_pipeline<dram_req_t> *mrqq;
-  // buffer to hold packets when DRAM processing is over
-  // should be filled with dram clock and popped with l2or icnt clock
-  fifo_pipeline<mem_fetch> *returnq;
+   unsigned char rw; //was last request a read or write? (important for RTW, WTR)
 
-  unsigned int dram_util_bins[10];
-  unsigned int dram_eff_bins[10];
-  unsigned int last_n_cmd, last_n_activity, last_bwutil;
+   unsigned int pending_writes;
 
-  unsigned long long n_cmd;
-  unsigned long long n_activity;
-  unsigned long long n_nop;
-  unsigned long long n_act;
-  unsigned long long n_pre;
-  unsigned long long n_ref;
-  unsigned long long n_rd;
-  unsigned long long n_rd_L2_A;
-  unsigned long long n_wr;
-  unsigned long long n_wr_WB;
-  unsigned long long n_req;
-  unsigned long long max_mrqs_temp;
+   fifo_pipeline<dram_req_t> *rwq;
+   fifo_pipeline<dram_req_t> *mrqq;
+   //buffer to hold packets when DRAM processing is over
+   //should be filled with dram clock and popped with l2or icnt clock
+   fifo_pipeline<mem_fetch> *returnq;
 
-  // some statistics to see where BW is wasted?
-  unsigned long long wasted_bw_row;
-  unsigned long long wasted_bw_col;
-  unsigned long long util_bw;
-  unsigned long long idle_bw;
-  unsigned long long RCDc_limit;
-  unsigned long long CCDLc_limit;
-  unsigned long long CCDLc_limit_alone;
-  unsigned long long CCDc_limit;
-  unsigned long long WTRc_limit;
-  unsigned long long WTRc_limit_alone;
-  unsigned long long RCDWRc_limit;
-  unsigned long long RTWc_limit;
-  unsigned long long RTWc_limit_alone;
-  unsigned long long rwq_limit;
+   unsigned int dram_util_bins[10];
+   unsigned int dram_eff_bins[10];
+   unsigned int last_n_cmd, last_n_activity, last_bwutil;
 
-  // row locality, BLP and other statistics
-  unsigned long long access_num;
-  unsigned long long read_num;
-  unsigned long long write_num;
-  unsigned long long hits_num;
-  unsigned long long hits_read_num;
-  unsigned long long hits_write_num;
-  unsigned long long banks_1time;
-  unsigned long long banks_acess_total;
-  unsigned long long banks_acess_total_after;
-  unsigned long long banks_time_rw;
-  unsigned long long banks_access_rw_total;
-  unsigned long long banks_time_ready;
-  unsigned long long banks_access_ready_total;
-  unsigned long long issued_two;
-  unsigned long long issued_total;
-  unsigned long long issued_total_row;
-  unsigned long long issued_total_col;
-  double write_to_read_ratio_blp_rw_average;
-  unsigned long long bkgrp_parallsim_rw;
+   unsigned long long n_cmd;
+   unsigned long long n_activity;
+   unsigned long long n_nop;
+   unsigned long long n_act;
+   unsigned long long n_pre;
+   unsigned long long n_ref;
+   unsigned long long n_rd;
+   unsigned long long n_rd_L2_A;
+   unsigned long long n_wr;
+   unsigned long long n_wr_WB;
+   unsigned long long n_req;
+   unsigned long long max_mrqs_temp;
 
-  unsigned int bwutil;
-  unsigned int max_mrqs;
-  unsigned int ave_mrqs;
+   //some statistics to see where BW is wasted?
+   unsigned long long wasted_bw_row;
+   unsigned long long wasted_bw_col;
+   unsigned long long util_bw;
+   unsigned long long idle_bw;
+   unsigned long long RCDc_limit;
+   unsigned long long CCDLc_limit;
+   unsigned long long CCDLc_limit_alone;
+   unsigned long long CCDc_limit;
+   unsigned long long WTRc_limit;
+   unsigned long long WTRc_limit_alone;
+   unsigned long long RCDWRc_limit;
+   unsigned long long RTWc_limit;
+   unsigned long long RTWc_limit_alone;
+   unsigned long long rwq_limit;
 
-  class frfcfs_scheduler *m_frfcfs_scheduler;
+   //row locality, BLP and other statistics
+   unsigned long long access_num;
+   unsigned long long read_num;
+   unsigned long long write_num;
+   unsigned long long hits_num;
+   unsigned long long hits_read_num;
+   unsigned long long hits_write_num;
+   unsigned long long banks_1time;
+   unsigned long long banks_acess_total;
+   unsigned long long banks_acess_total_after;
+   unsigned long long banks_time_rw;
+   unsigned long long banks_access_rw_total;
+   unsigned long long banks_time_ready;
+   unsigned long long banks_access_ready_total;
+   unsigned long long issued_two;
+   unsigned long long issued_total;
+   unsigned long long issued_total_row;
+   unsigned long long issued_total_col;
+   double write_to_read_ratio_blp_rw_average;
+   unsigned long long bkgrp_parallsim_rw;
 
-  unsigned int n_cmd_partial;
-  unsigned int n_activity_partial;
-  unsigned int n_nop_partial;
-  unsigned int n_act_partial;
-  unsigned int n_pre_partial;
-  unsigned int n_req_partial;
-  unsigned int ave_mrqs_partial;
-  unsigned int bwutil_partial;
+   unsigned int bwutil;
+   unsigned int max_mrqs;
+   unsigned int ave_mrqs;
 
-  class memory_stats_t *m_stats;
-  class Stats *mrqq_Dist;  // memory request queue inside DRAM
+   class frfcfs_scheduler* m_frfcfs_scheduler;
 
-  friend class frfcfs_scheduler;
+   unsigned int n_cmd_partial;
+   unsigned int n_activity_partial;
+   unsigned int n_nop_partial; 
+   unsigned int n_act_partial; 
+   unsigned int n_pre_partial; 
+   unsigned int n_req_partial;
+   unsigned int ave_mrqs_partial;
+   unsigned int bwutil_partial;
+
+   class memory_stats_t *m_stats;
+   class Stats* mrqq_Dist; //memory request queue inside DRAM  
+
+   friend class frfcfs_scheduler;
 };
 
 #endif /*DRAM_H*/

--- a/src/gpgpu-sim/dram_sched.cc
+++ b/src/gpgpu-sim/dram_sched.cc
@@ -7,243 +7,252 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #include "dram_sched.h"
+#include "../abstract_hardware_model.h"
 #include "gpu-misc.h"
 #include "gpu-sim.h"
-#include "../abstract_hardware_model.h"
 #include "mem_latency_stat.h"
 
-frfcfs_scheduler::frfcfs_scheduler( const memory_config *config, dram_t *dm, memory_stats_t *stats )
-{
-   m_config = config;
-   m_stats = stats;
-   m_num_pending = 0;
-   m_num_write_pending = 0;
-   m_dram = dm;
-   m_queue = new std::list<dram_req_t*>[m_config->nbk];
-   m_bins = new std::map<unsigned,std::list<std::list<dram_req_t*>::iterator> >[ m_config->nbk ];
-   m_last_row = new std::list<std::list<dram_req_t*>::iterator>*[ m_config->nbk ];
-   curr_row_service_time = new unsigned[m_config->nbk];
-   row_service_timestamp = new unsigned[m_config->nbk];
-   for ( unsigned i=0; i < m_config->nbk; i++ ) {
-      m_queue[i].clear();
-      m_bins[i].clear();
-      m_last_row[i] = NULL;
-      curr_row_service_time[i] = 0;
-      row_service_timestamp[i] = 0;
-   }
-   if(m_config->seperate_write_queue_enabled) {
-	   m_write_queue = new std::list<dram_req_t*>[m_config->nbk];
-	   m_write_bins = new std::map<unsigned,std::list<std::list<dram_req_t*>::iterator> >[ m_config->nbk ];
-	   m_last_write_row = new std::list<std::list<dram_req_t*>::iterator>*[ m_config->nbk ];
+frfcfs_scheduler::frfcfs_scheduler(const memory_config *config, dram_t *dm,
+                                   memory_stats_t *stats) {
+  m_config = config;
+  m_stats = stats;
+  m_num_pending = 0;
+  m_num_write_pending = 0;
+  m_dram = dm;
+  m_queue = new std::list<dram_req_t *>[m_config->nbk];
+  m_bins = new std::map<
+      unsigned, std::list<std::list<dram_req_t *>::iterator> >[m_config->nbk];
+  m_last_row =
+      new std::list<std::list<dram_req_t *>::iterator> *[m_config->nbk];
+  curr_row_service_time = new unsigned[m_config->nbk];
+  row_service_timestamp = new unsigned[m_config->nbk];
+  for (unsigned i = 0; i < m_config->nbk; i++) {
+    m_queue[i].clear();
+    m_bins[i].clear();
+    m_last_row[i] = NULL;
+    curr_row_service_time[i] = 0;
+    row_service_timestamp[i] = 0;
+  }
+  if (m_config->seperate_write_queue_enabled) {
+    m_write_queue = new std::list<dram_req_t *>[m_config->nbk];
+    m_write_bins = new std::map<
+        unsigned, std::list<std::list<dram_req_t *>::iterator> >[m_config->nbk];
+    m_last_write_row =
+        new std::list<std::list<dram_req_t *>::iterator> *[m_config->nbk];
 
-	   for ( unsigned i=0; i < m_config->nbk; i++ ) {
-	         m_write_queue[i].clear();
-	         m_write_bins[i].clear();
-	         m_last_write_row[i] = NULL;
-	      }
-   }
-   m_mode = READ_MODE;
-
+    for (unsigned i = 0; i < m_config->nbk; i++) {
+      m_write_queue[i].clear();
+      m_write_bins[i].clear();
+      m_last_write_row[i] = NULL;
+    }
+  }
+  m_mode = READ_MODE;
 }
 
-void frfcfs_scheduler::add_req( dram_req_t *req )
-{
-  if(m_config->seperate_write_queue_enabled && req->data->is_write()) {
-	  assert(m_num_write_pending < m_config->gpgpu_frfcfs_dram_write_queue_size);
-	  m_num_write_pending++;
-	  m_write_queue[req->bk].push_front(req);
-	  std::list<dram_req_t*>::iterator ptr = m_write_queue[req->bk].begin();
-	  m_write_bins[req->bk][req->row].push_front( ptr ); //newest reqs to the front
+void frfcfs_scheduler::add_req(dram_req_t *req) {
+  if (m_config->seperate_write_queue_enabled && req->data->is_write()) {
+    assert(m_num_write_pending < m_config->gpgpu_frfcfs_dram_write_queue_size);
+    m_num_write_pending++;
+    m_write_queue[req->bk].push_front(req);
+    std::list<dram_req_t *>::iterator ptr = m_write_queue[req->bk].begin();
+    m_write_bins[req->bk][req->row].push_front(ptr);  // newest reqs to the
+                                                      // front
   } else {
-	   assert(m_num_pending < m_config->gpgpu_frfcfs_dram_sched_queue_size);
-	   m_num_pending++;
-	   m_queue[req->bk].push_front(req);
-	   std::list<dram_req_t*>::iterator ptr = m_queue[req->bk].begin();
-	   m_bins[req->bk][req->row].push_front( ptr ); //newest reqs to the front
+    assert(m_num_pending < m_config->gpgpu_frfcfs_dram_sched_queue_size);
+    m_num_pending++;
+    m_queue[req->bk].push_front(req);
+    std::list<dram_req_t *>::iterator ptr = m_queue[req->bk].begin();
+    m_bins[req->bk][req->row].push_front(ptr);  // newest reqs to the front
   }
 }
 
-void frfcfs_scheduler::data_collection(unsigned int bank)
-{
-   if (m_dram->m_gpu->gpu_sim_cycle > row_service_timestamp[bank]) {
-      curr_row_service_time[bank] = m_dram->m_gpu->gpu_sim_cycle - row_service_timestamp[bank];
-      if (curr_row_service_time[bank] > m_stats->max_servicetime2samerow[m_dram->id][bank])
-         m_stats->max_servicetime2samerow[m_dram->id][bank] = curr_row_service_time[bank];
-   }
-   curr_row_service_time[bank] = 0;
-   row_service_timestamp[bank] = m_dram->m_gpu->gpu_sim_cycle;
-   if (m_stats->concurrent_row_access[m_dram->id][bank] > m_stats->max_conc_access2samerow[m_dram->id][bank]) {
-      m_stats->max_conc_access2samerow[m_dram->id][bank] = m_stats->concurrent_row_access[m_dram->id][bank];
-   }
-   m_stats->concurrent_row_access[m_dram->id][bank] = 0;
-   m_stats->num_activates[m_dram->id][bank]++;
+void frfcfs_scheduler::data_collection(unsigned int bank) {
+  if (m_dram->m_gpu->gpu_sim_cycle > row_service_timestamp[bank]) {
+    curr_row_service_time[bank] =
+        m_dram->m_gpu->gpu_sim_cycle - row_service_timestamp[bank];
+    if (curr_row_service_time[bank] >
+        m_stats->max_servicetime2samerow[m_dram->id][bank])
+      m_stats->max_servicetime2samerow[m_dram->id][bank] =
+          curr_row_service_time[bank];
+  }
+  curr_row_service_time[bank] = 0;
+  row_service_timestamp[bank] = m_dram->m_gpu->gpu_sim_cycle;
+  if (m_stats->concurrent_row_access[m_dram->id][bank] >
+      m_stats->max_conc_access2samerow[m_dram->id][bank]) {
+    m_stats->max_conc_access2samerow[m_dram->id][bank] =
+        m_stats->concurrent_row_access[m_dram->id][bank];
+  }
+  m_stats->concurrent_row_access[m_dram->id][bank] = 0;
+  m_stats->num_activates[m_dram->id][bank]++;
 }
 
-dram_req_t *frfcfs_scheduler::schedule( unsigned bank, unsigned curr_row )
-{
-   //row
-   bool rowhit = true;
-   std::list<dram_req_t*> *m_current_queue = m_queue;
-   std::map<unsigned,std::list<std::list<dram_req_t*>::iterator> > *m_current_bins = m_bins ;
-   std::list<std::list<dram_req_t*>::iterator> **m_current_last_row = m_last_row;
+dram_req_t *frfcfs_scheduler::schedule(unsigned bank, unsigned curr_row) {
+  // row
+  bool rowhit = true;
+  std::list<dram_req_t *> *m_current_queue = m_queue;
+  std::map<unsigned, std::list<std::list<dram_req_t *>::iterator> >
+      *m_current_bins = m_bins;
+  std::list<std::list<dram_req_t *>::iterator> **m_current_last_row =
+      m_last_row;
 
-   if(m_config->seperate_write_queue_enabled) {
-	   if(m_mode == READ_MODE &&
-			  ((m_num_write_pending >= m_config->write_high_watermark )
-			  // || (m_queue[bank].empty() && !m_write_queue[bank].empty())
-			   )) {
-		   m_mode = WRITE_MODE;
-	   }
-	   else if(m_mode == WRITE_MODE &&
-				  (( m_num_write_pending < m_config->write_low_watermark )
-				 //  || (!m_queue[bank].empty() && m_write_queue[bank].empty())
-				   )){
-		   m_mode = READ_MODE;
-	   }
-   }
-
-   if(m_mode == WRITE_MODE) {
-	   m_current_queue = m_write_queue;
-	   m_current_bins = m_write_bins ;
-	   m_current_last_row = m_last_write_row;
-   }
-
-   if ( m_current_last_row[bank] == NULL ) {
-      if ( m_current_queue[bank].empty() )
-         return NULL;
-
-      std::map<unsigned,std::list<std::list<dram_req_t*>::iterator> >::iterator bin_ptr = m_current_bins[bank].find( curr_row );
-      if ( bin_ptr == m_current_bins[bank].end()) {
-         dram_req_t *req = m_current_queue[bank].back();
-         bin_ptr = m_current_bins[bank].find( req->row );
-         assert( bin_ptr != m_current_bins[bank].end() ); // where did the request go???
-         m_current_last_row[bank] = &(bin_ptr->second);
-         data_collection(bank);
-         rowhit = false;
-      } else {
-    	  m_current_last_row[bank] = &(bin_ptr->second);
-         rowhit = true;
-      }
-   }
-   std::list<dram_req_t*>::iterator next = m_current_last_row[bank]->back();
-   dram_req_t *req = (*next);
-
-   //rowblp stats
-    m_dram->access_num++;
-    bool is_write = req->data->is_write();
-    if(is_write)
-  	  m_dram->write_num++;
-    else
-  	  m_dram->read_num++;
-
-    if(rowhit) {
-     m_dram->hits_num++;
-     if(is_write)
-    	  m_dram->hits_write_num++;
-      else
-    	  m_dram->hits_read_num++;
+  if (m_config->seperate_write_queue_enabled) {
+    if (m_mode == READ_MODE &&
+        ((m_num_write_pending >= m_config->write_high_watermark)
+         // || (m_queue[bank].empty() && !m_write_queue[bank].empty())
+         )) {
+      m_mode = WRITE_MODE;
+    } else if (m_mode == WRITE_MODE &&
+               ((m_num_write_pending < m_config->write_low_watermark)
+                //  || (!m_queue[bank].empty() && m_write_queue[bank].empty())
+                )) {
+      m_mode = READ_MODE;
     }
+  }
 
-   m_stats->concurrent_row_access[m_dram->id][bank]++;
-   m_stats->row_access[m_dram->id][bank]++;
-   m_current_last_row[bank]->pop_back();
+  if (m_mode == WRITE_MODE) {
+    m_current_queue = m_write_queue;
+    m_current_bins = m_write_bins;
+    m_current_last_row = m_last_write_row;
+  }
 
-   m_current_queue[bank].erase(next);
-   if ( m_current_last_row[bank]->empty() ) {
-	   m_current_bins[bank].erase( req->row );
-	   m_current_last_row[bank] = NULL;
-   }
+  if (m_current_last_row[bank] == NULL) {
+    if (m_current_queue[bank].empty()) return NULL;
+
+    std::map<unsigned, std::list<std::list<dram_req_t *>::iterator> >::iterator
+        bin_ptr = m_current_bins[bank].find(curr_row);
+    if (bin_ptr == m_current_bins[bank].end()) {
+      dram_req_t *req = m_current_queue[bank].back();
+      bin_ptr = m_current_bins[bank].find(req->row);
+      assert(bin_ptr !=
+             m_current_bins[bank].end());  // where did the request go???
+      m_current_last_row[bank] = &(bin_ptr->second);
+      data_collection(bank);
+      rowhit = false;
+    } else {
+      m_current_last_row[bank] = &(bin_ptr->second);
+      rowhit = true;
+    }
+  }
+  std::list<dram_req_t *>::iterator next = m_current_last_row[bank]->back();
+  dram_req_t *req = (*next);
+
+  // rowblp stats
+  m_dram->access_num++;
+  bool is_write = req->data->is_write();
+  if (is_write)
+    m_dram->write_num++;
+  else
+    m_dram->read_num++;
+
+  if (rowhit) {
+    m_dram->hits_num++;
+    if (is_write)
+      m_dram->hits_write_num++;
+    else
+      m_dram->hits_read_num++;
+  }
+
+  m_stats->concurrent_row_access[m_dram->id][bank]++;
+  m_stats->row_access[m_dram->id][bank]++;
+  m_current_last_row[bank]->pop_back();
+
+  m_current_queue[bank].erase(next);
+  if (m_current_last_row[bank]->empty()) {
+    m_current_bins[bank].erase(req->row);
+    m_current_last_row[bank] = NULL;
+  }
 #ifdef DEBUG_FAST_IDEAL_SCHED
-   if ( req )
-      printf("%08u : DRAM(%u) scheduling memory request to bank=%u, row=%u\n", 
-             (unsigned)gpu_sim_cycle, m_dram->id, req->bk, req->row );
+  if (req)
+    printf("%08u : DRAM(%u) scheduling memory request to bank=%u, row=%u\n",
+           (unsigned)gpu_sim_cycle, m_dram->id, req->bk, req->row);
 #endif
 
-   if(m_config->seperate_write_queue_enabled && req->data->is_write()) {
-	   assert( req != NULL && m_num_write_pending != 0 );
-	   m_num_write_pending--;
-   }
-   else {
-	   assert( req != NULL && m_num_pending != 0 );
-	   m_num_pending--;
-   }
+  if (m_config->seperate_write_queue_enabled && req->data->is_write()) {
+    assert(req != NULL && m_num_write_pending != 0);
+    m_num_write_pending--;
+  } else {
+    assert(req != NULL && m_num_pending != 0);
+    m_num_pending--;
+  }
 
-   return req;
+  return req;
 }
 
-
-void frfcfs_scheduler::print( FILE *fp )
-{
-   for ( unsigned b=0; b < m_config->nbk; b++ ) {
-      printf(" %u: queue length = %u\n", b, (unsigned)m_queue[b].size() );
-   }
+void frfcfs_scheduler::print(FILE *fp) {
+  for (unsigned b = 0; b < m_config->nbk; b++) {
+    printf(" %u: queue length = %u\n", b, (unsigned)m_queue[b].size());
+  }
 }
 
-void dram_t::scheduler_frfcfs()
-{
-   unsigned mrq_latency;
-   frfcfs_scheduler *sched = m_frfcfs_scheduler;
-   while ( !mrqq->empty() ) {
-      dram_req_t *req = mrqq->pop();
+void dram_t::scheduler_frfcfs() {
+  unsigned mrq_latency;
+  frfcfs_scheduler *sched = m_frfcfs_scheduler;
+  while (!mrqq->empty()) {
+    dram_req_t *req = mrqq->pop();
 
-      // Power stats
-      //if(req->data->get_type() != READ_REPLY && req->data->get_type() != WRITE_ACK)
-      m_stats->total_n_access++;
+    // Power stats
+    // if(req->data->get_type() != READ_REPLY && req->data->get_type() !=
+    // WRITE_ACK)
+    m_stats->total_n_access++;
 
-      if(req->data->get_type() == WRITE_REQUEST){
-    	  m_stats->total_n_writes++;
-      }else if(req->data->get_type() == READ_REQUEST){
-    	  m_stats->total_n_reads++;
+    if (req->data->get_type() == WRITE_REQUEST) {
+      m_stats->total_n_writes++;
+    } else if (req->data->get_type() == READ_REQUEST) {
+      m_stats->total_n_reads++;
+    }
+
+    req->data->set_status(IN_PARTITION_MC_INPUT_QUEUE,
+                          m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+    sched->add_req(req);
+  }
+
+  dram_req_t *req;
+  unsigned i;
+  for (i = 0; i < m_config->nbk; i++) {
+    unsigned b = (i + prio) % m_config->nbk;
+    if (!bk[b]->mrq) {
+      req = sched->schedule(b, bk[b]->curr_row);
+
+      if (req) {
+        req->data->set_status(IN_PARTITION_MC_BANK_ARB_QUEUE,
+                              m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+        prio = (prio + 1) % m_config->nbk;
+        bk[b]->mrq = req;
+        if (m_config->gpgpu_memlatency_stat) {
+          mrq_latency = m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle -
+                        bk[b]->mrq->timestamp;
+          m_stats->tot_mrq_latency += mrq_latency;
+          m_stats->tot_mrq_num++;
+          bk[b]->mrq->timestamp =
+              m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle;
+          m_stats->mrq_lat_table[LOGB2(mrq_latency)]++;
+          if (mrq_latency > m_stats->max_mrq_latency) {
+            m_stats->max_mrq_latency = mrq_latency;
+          }
+        }
+
+        break;
       }
-
-      req->data->set_status(IN_PARTITION_MC_INPUT_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-      sched->add_req(req);
-   }
-
-   dram_req_t *req;
-   unsigned i;
-   for ( i=0; i < m_config->nbk; i++ ) {
-      unsigned b = (i+prio)%m_config->nbk;
-      if ( !bk[b]->mrq ) {
-
-         req = sched->schedule(b, bk[b]->curr_row);
-
-         if ( req ) {
-            req->data->set_status(IN_PARTITION_MC_BANK_ARB_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-            prio = (prio+1)%m_config->nbk;
-            bk[b]->mrq = req;
-            if (m_config->gpgpu_memlatency_stat) {
-               mrq_latency = m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle - bk[b]->mrq->timestamp;
-               m_stats->tot_mrq_latency += mrq_latency;
-               m_stats->tot_mrq_num++;
-               bk[b]->mrq->timestamp =m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle;
-               m_stats->mrq_lat_table[LOGB2(mrq_latency)]++;
-               if (mrq_latency > m_stats->max_mrq_latency) {
-                  m_stats->max_mrq_latency = mrq_latency;
-               }
-            }
-
-            break;
-         }
-      }
-   }
+    }
+  }
 }

--- a/src/gpgpu-sim/dram_sched.cc
+++ b/src/gpgpu-sim/dram_sched.cc
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -26,224 +28,232 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "dram_sched.h"
+#include "../abstract_hardware_model.h"
 #include "gpu-misc.h"
 #include "gpu-sim.h"
-#include "../abstract_hardware_model.h"
 #include "mem_latency_stat.h"
 
-frfcfs_scheduler::frfcfs_scheduler( const memory_config *config, dram_t *dm, memory_stats_t *stats )
-{
-   m_config = config;
-   m_stats = stats;
-   m_num_pending = 0;
-   m_num_write_pending = 0;
-   m_dram = dm;
-   m_queue = new std::list<dram_req_t*>[m_config->nbk];
-   m_bins = new std::map<unsigned,std::list<std::list<dram_req_t*>::iterator> >[ m_config->nbk ];
-   m_last_row = new std::list<std::list<dram_req_t*>::iterator>*[ m_config->nbk ];
-   curr_row_service_time = new unsigned[m_config->nbk];
-   row_service_timestamp = new unsigned[m_config->nbk];
-   for ( unsigned i=0; i < m_config->nbk; i++ ) {
-      m_queue[i].clear();
-      m_bins[i].clear();
-      m_last_row[i] = NULL;
-      curr_row_service_time[i] = 0;
-      row_service_timestamp[i] = 0;
-   }
-   if(m_config->seperate_write_queue_enabled) {
-	   m_write_queue = new std::list<dram_req_t*>[m_config->nbk];
-	   m_write_bins = new std::map<unsigned,std::list<std::list<dram_req_t*>::iterator> >[ m_config->nbk ];
-	   m_last_write_row = new std::list<std::list<dram_req_t*>::iterator>*[ m_config->nbk ];
+frfcfs_scheduler::frfcfs_scheduler(const memory_config *config, dram_t *dm,
+                                   memory_stats_t *stats) {
+  m_config = config;
+  m_stats = stats;
+  m_num_pending = 0;
+  m_num_write_pending = 0;
+  m_dram = dm;
+  m_queue = new std::list<dram_req_t *>[m_config->nbk];
+  m_bins = new std::map<
+      unsigned, std::list<std::list<dram_req_t *>::iterator> >[m_config->nbk];
+  m_last_row =
+      new std::list<std::list<dram_req_t *>::iterator> *[m_config->nbk];
+  curr_row_service_time = new unsigned[m_config->nbk];
+  row_service_timestamp = new unsigned[m_config->nbk];
+  for (unsigned i = 0; i < m_config->nbk; i++) {
+    m_queue[i].clear();
+    m_bins[i].clear();
+    m_last_row[i] = NULL;
+    curr_row_service_time[i] = 0;
+    row_service_timestamp[i] = 0;
+  }
+  if (m_config->seperate_write_queue_enabled) {
+    m_write_queue = new std::list<dram_req_t *>[m_config->nbk];
+    m_write_bins = new std::map<
+        unsigned, std::list<std::list<dram_req_t *>::iterator> >[m_config->nbk];
+    m_last_write_row =
+        new std::list<std::list<dram_req_t *>::iterator> *[m_config->nbk];
 
-	   for ( unsigned i=0; i < m_config->nbk; i++ ) {
-	         m_write_queue[i].clear();
-	         m_write_bins[i].clear();
-	         m_last_write_row[i] = NULL;
-	      }
-   }
-   m_mode = READ_MODE;
-
+    for (unsigned i = 0; i < m_config->nbk; i++) {
+      m_write_queue[i].clear();
+      m_write_bins[i].clear();
+      m_last_write_row[i] = NULL;
+    }
+  }
+  m_mode = READ_MODE;
 }
 
-void frfcfs_scheduler::add_req( dram_req_t *req )
-{
-  if(m_config->seperate_write_queue_enabled && req->data->is_write()) {
-	  assert(m_num_write_pending < m_config->gpgpu_frfcfs_dram_write_queue_size);
-	  m_num_write_pending++;
-	  m_write_queue[req->bk].push_front(req);
-	  std::list<dram_req_t*>::iterator ptr = m_write_queue[req->bk].begin();
-	  m_write_bins[req->bk][req->row].push_front( ptr ); //newest reqs to the front
+void frfcfs_scheduler::add_req(dram_req_t *req) {
+  if (m_config->seperate_write_queue_enabled && req->data->is_write()) {
+    assert(m_num_write_pending < m_config->gpgpu_frfcfs_dram_write_queue_size);
+    m_num_write_pending++;
+    m_write_queue[req->bk].push_front(req);
+    std::list<dram_req_t *>::iterator ptr = m_write_queue[req->bk].begin();
+    m_write_bins[req->bk][req->row].push_front(ptr);  // newest reqs to the
+                                                      // front
   } else {
-	   assert(m_num_pending < m_config->gpgpu_frfcfs_dram_sched_queue_size);
-	   m_num_pending++;
-	   m_queue[req->bk].push_front(req);
-	   std::list<dram_req_t*>::iterator ptr = m_queue[req->bk].begin();
-	   m_bins[req->bk][req->row].push_front( ptr ); //newest reqs to the front
+    assert(m_num_pending < m_config->gpgpu_frfcfs_dram_sched_queue_size);
+    m_num_pending++;
+    m_queue[req->bk].push_front(req);
+    std::list<dram_req_t *>::iterator ptr = m_queue[req->bk].begin();
+    m_bins[req->bk][req->row].push_front(ptr);  // newest reqs to the front
   }
 }
 
-void frfcfs_scheduler::data_collection(unsigned int bank)
-{
-   if (m_dram->m_gpu->gpu_sim_cycle > row_service_timestamp[bank]) {
-      curr_row_service_time[bank] = m_dram->m_gpu->gpu_sim_cycle - row_service_timestamp[bank];
-      if (curr_row_service_time[bank] > m_stats->max_servicetime2samerow[m_dram->id][bank])
-         m_stats->max_servicetime2samerow[m_dram->id][bank] = curr_row_service_time[bank];
-   }
-   curr_row_service_time[bank] = 0;
-   row_service_timestamp[bank] = m_dram->m_gpu->gpu_sim_cycle;
-   if (m_stats->concurrent_row_access[m_dram->id][bank] > m_stats->max_conc_access2samerow[m_dram->id][bank]) {
-      m_stats->max_conc_access2samerow[m_dram->id][bank] = m_stats->concurrent_row_access[m_dram->id][bank];
-   }
-   m_stats->concurrent_row_access[m_dram->id][bank] = 0;
-   m_stats->num_activates[m_dram->id][bank]++;
+void frfcfs_scheduler::data_collection(unsigned int bank) {
+  if (m_dram->m_gpu->gpu_sim_cycle > row_service_timestamp[bank]) {
+    curr_row_service_time[bank] =
+        m_dram->m_gpu->gpu_sim_cycle - row_service_timestamp[bank];
+    if (curr_row_service_time[bank] >
+        m_stats->max_servicetime2samerow[m_dram->id][bank])
+      m_stats->max_servicetime2samerow[m_dram->id][bank] =
+          curr_row_service_time[bank];
+  }
+  curr_row_service_time[bank] = 0;
+  row_service_timestamp[bank] = m_dram->m_gpu->gpu_sim_cycle;
+  if (m_stats->concurrent_row_access[m_dram->id][bank] >
+      m_stats->max_conc_access2samerow[m_dram->id][bank]) {
+    m_stats->max_conc_access2samerow[m_dram->id][bank] =
+        m_stats->concurrent_row_access[m_dram->id][bank];
+  }
+  m_stats->concurrent_row_access[m_dram->id][bank] = 0;
+  m_stats->num_activates[m_dram->id][bank]++;
 }
 
-dram_req_t *frfcfs_scheduler::schedule( unsigned bank, unsigned curr_row )
-{
-   //row
-   bool rowhit = true;
-   std::list<dram_req_t*> *m_current_queue = m_queue;
-   std::map<unsigned,std::list<std::list<dram_req_t*>::iterator> > *m_current_bins = m_bins ;
-   std::list<std::list<dram_req_t*>::iterator> **m_current_last_row = m_last_row;
+dram_req_t *frfcfs_scheduler::schedule(unsigned bank, unsigned curr_row) {
+  // row
+  bool rowhit = true;
+  std::list<dram_req_t *> *m_current_queue = m_queue;
+  std::map<unsigned, std::list<std::list<dram_req_t *>::iterator> >
+      *m_current_bins = m_bins;
+  std::list<std::list<dram_req_t *>::iterator> **m_current_last_row =
+      m_last_row;
 
-   if(m_config->seperate_write_queue_enabled) {
-	   if(m_mode == READ_MODE &&
-			  ((m_num_write_pending >= m_config->write_high_watermark )
-			  // || (m_queue[bank].empty() && !m_write_queue[bank].empty())
-			   )) {
-		   m_mode = WRITE_MODE;
-	   }
-	   else if(m_mode == WRITE_MODE &&
-				  (( m_num_write_pending < m_config->write_low_watermark )
-				 //  || (!m_queue[bank].empty() && m_write_queue[bank].empty())
-				   )){
-		   m_mode = READ_MODE;
-	   }
-   }
-
-   if(m_mode == WRITE_MODE) {
-	   m_current_queue = m_write_queue;
-	   m_current_bins = m_write_bins ;
-	   m_current_last_row = m_last_write_row;
-   }
-
-   if ( m_current_last_row[bank] == NULL ) {
-      if ( m_current_queue[bank].empty() )
-         return NULL;
-
-      std::map<unsigned,std::list<std::list<dram_req_t*>::iterator> >::iterator bin_ptr = m_current_bins[bank].find( curr_row );
-      if ( bin_ptr == m_current_bins[bank].end()) {
-         dram_req_t *req = m_current_queue[bank].back();
-         bin_ptr = m_current_bins[bank].find( req->row );
-         assert( bin_ptr != m_current_bins[bank].end() ); // where did the request go???
-         m_current_last_row[bank] = &(bin_ptr->second);
-         data_collection(bank);
-         rowhit = false;
-      } else {
-    	  m_current_last_row[bank] = &(bin_ptr->second);
-         rowhit = true;
-      }
-   }
-   std::list<dram_req_t*>::iterator next = m_current_last_row[bank]->back();
-   dram_req_t *req = (*next);
-
-   //rowblp stats
-    m_dram->access_num++;
-    bool is_write = req->data->is_write();
-    if(is_write)
-  	  m_dram->write_num++;
-    else
-  	  m_dram->read_num++;
-
-    if(rowhit) {
-     m_dram->hits_num++;
-     if(is_write)
-    	  m_dram->hits_write_num++;
-      else
-    	  m_dram->hits_read_num++;
+  if (m_config->seperate_write_queue_enabled) {
+    if (m_mode == READ_MODE &&
+        ((m_num_write_pending >= m_config->write_high_watermark)
+         // || (m_queue[bank].empty() && !m_write_queue[bank].empty())
+         )) {
+      m_mode = WRITE_MODE;
+    } else if (m_mode == WRITE_MODE &&
+               ((m_num_write_pending < m_config->write_low_watermark)
+                //  || (!m_queue[bank].empty() && m_write_queue[bank].empty())
+                )) {
+      m_mode = READ_MODE;
     }
+  }
 
-   m_stats->concurrent_row_access[m_dram->id][bank]++;
-   m_stats->row_access[m_dram->id][bank]++;
-   m_current_last_row[bank]->pop_back();
+  if (m_mode == WRITE_MODE) {
+    m_current_queue = m_write_queue;
+    m_current_bins = m_write_bins;
+    m_current_last_row = m_last_write_row;
+  }
 
-   m_current_queue[bank].erase(next);
-   if ( m_current_last_row[bank]->empty() ) {
-	   m_current_bins[bank].erase( req->row );
-	   m_current_last_row[bank] = NULL;
-   }
+  if (m_current_last_row[bank] == NULL) {
+    if (m_current_queue[bank].empty()) return NULL;
+
+    std::map<unsigned, std::list<std::list<dram_req_t *>::iterator> >::iterator
+        bin_ptr = m_current_bins[bank].find(curr_row);
+    if (bin_ptr == m_current_bins[bank].end()) {
+      dram_req_t *req = m_current_queue[bank].back();
+      bin_ptr = m_current_bins[bank].find(req->row);
+      assert(bin_ptr !=
+             m_current_bins[bank].end());  // where did the request go???
+      m_current_last_row[bank] = &(bin_ptr->second);
+      data_collection(bank);
+      rowhit = false;
+    } else {
+      m_current_last_row[bank] = &(bin_ptr->second);
+      rowhit = true;
+    }
+  }
+  std::list<dram_req_t *>::iterator next = m_current_last_row[bank]->back();
+  dram_req_t *req = (*next);
+
+  // rowblp stats
+  m_dram->access_num++;
+  bool is_write = req->data->is_write();
+  if (is_write)
+    m_dram->write_num++;
+  else
+    m_dram->read_num++;
+
+  if (rowhit) {
+    m_dram->hits_num++;
+    if (is_write)
+      m_dram->hits_write_num++;
+    else
+      m_dram->hits_read_num++;
+  }
+
+  m_stats->concurrent_row_access[m_dram->id][bank]++;
+  m_stats->row_access[m_dram->id][bank]++;
+  m_current_last_row[bank]->pop_back();
+
+  m_current_queue[bank].erase(next);
+  if (m_current_last_row[bank]->empty()) {
+    m_current_bins[bank].erase(req->row);
+    m_current_last_row[bank] = NULL;
+  }
 #ifdef DEBUG_FAST_IDEAL_SCHED
-   if ( req )
-      printf("%08u : DRAM(%u) scheduling memory request to bank=%u, row=%u\n", 
-             (unsigned)gpu_sim_cycle, m_dram->id, req->bk, req->row );
+  if (req)
+    printf("%08u : DRAM(%u) scheduling memory request to bank=%u, row=%u\n",
+           (unsigned)gpu_sim_cycle, m_dram->id, req->bk, req->row);
 #endif
 
-   if(m_config->seperate_write_queue_enabled && req->data->is_write()) {
-	   assert( req != NULL && m_num_write_pending != 0 );
-	   m_num_write_pending--;
-   }
-   else {
-	   assert( req != NULL && m_num_pending != 0 );
-	   m_num_pending--;
-   }
+  if (m_config->seperate_write_queue_enabled && req->data->is_write()) {
+    assert(req != NULL && m_num_write_pending != 0);
+    m_num_write_pending--;
+  } else {
+    assert(req != NULL && m_num_pending != 0);
+    m_num_pending--;
+  }
 
-   return req;
+  return req;
 }
 
-
-void frfcfs_scheduler::print( FILE *fp )
-{
-   for ( unsigned b=0; b < m_config->nbk; b++ ) {
-      printf(" %u: queue length = %u\n", b, (unsigned)m_queue[b].size() );
-   }
+void frfcfs_scheduler::print(FILE *fp) {
+  for (unsigned b = 0; b < m_config->nbk; b++) {
+    printf(" %u: queue length = %u\n", b, (unsigned)m_queue[b].size());
+  }
 }
 
-void dram_t::scheduler_frfcfs()
-{
-   unsigned mrq_latency;
-   frfcfs_scheduler *sched = m_frfcfs_scheduler;
-   while ( !mrqq->empty() ) {
-      dram_req_t *req = mrqq->pop();
+void dram_t::scheduler_frfcfs() {
+  unsigned mrq_latency;
+  frfcfs_scheduler *sched = m_frfcfs_scheduler;
+  while (!mrqq->empty()) {
+    dram_req_t *req = mrqq->pop();
 
-      // Power stats
-      //if(req->data->get_type() != READ_REPLY && req->data->get_type() != WRITE_ACK)
-      m_stats->total_n_access++;
+    // Power stats
+    // if(req->data->get_type() != READ_REPLY && req->data->get_type() !=
+    // WRITE_ACK)
+    m_stats->total_n_access++;
 
-      if(req->data->get_type() == WRITE_REQUEST){
-    	  m_stats->total_n_writes++;
-      }else if(req->data->get_type() == READ_REQUEST){
-    	  m_stats->total_n_reads++;
+    if (req->data->get_type() == WRITE_REQUEST) {
+      m_stats->total_n_writes++;
+    } else if (req->data->get_type() == READ_REQUEST) {
+      m_stats->total_n_reads++;
+    }
+
+    req->data->set_status(IN_PARTITION_MC_INPUT_QUEUE,
+                          m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+    sched->add_req(req);
+  }
+
+  dram_req_t *req;
+  unsigned i;
+  for (i = 0; i < m_config->nbk; i++) {
+    unsigned b = (i + prio) % m_config->nbk;
+    if (!bk[b]->mrq) {
+      req = sched->schedule(b, bk[b]->curr_row);
+
+      if (req) {
+        req->data->set_status(IN_PARTITION_MC_BANK_ARB_QUEUE,
+                              m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+        prio = (prio + 1) % m_config->nbk;
+        bk[b]->mrq = req;
+        if (m_config->gpgpu_memlatency_stat) {
+          mrq_latency = m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle -
+                        bk[b]->mrq->timestamp;
+          m_stats->tot_mrq_latency += mrq_latency;
+          m_stats->tot_mrq_num++;
+          bk[b]->mrq->timestamp =
+              m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle;
+          m_stats->mrq_lat_table[LOGB2(mrq_latency)]++;
+          if (mrq_latency > m_stats->max_mrq_latency) {
+            m_stats->max_mrq_latency = mrq_latency;
+          }
+        }
+
+        break;
       }
-
-      req->data->set_status(IN_PARTITION_MC_INPUT_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-      sched->add_req(req);
-   }
-
-   dram_req_t *req;
-   unsigned i;
-   for ( i=0; i < m_config->nbk; i++ ) {
-      unsigned b = (i+prio)%m_config->nbk;
-      if ( !bk[b]->mrq ) {
-
-         req = sched->schedule(b, bk[b]->curr_row);
-
-         if ( req ) {
-            req->data->set_status(IN_PARTITION_MC_BANK_ARB_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-            prio = (prio+1)%m_config->nbk;
-            bk[b]->mrq = req;
-            if (m_config->gpgpu_memlatency_stat) {
-               mrq_latency = m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle - bk[b]->mrq->timestamp;
-               m_stats->tot_mrq_latency += mrq_latency;
-               m_stats->tot_mrq_num++;
-               bk[b]->mrq->timestamp =m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle;
-               m_stats->mrq_lat_table[LOGB2(mrq_latency)]++;
-               if (mrq_latency > m_stats->max_mrq_latency) {
-                  m_stats->max_mrq_latency = mrq_latency;
-               }
-            }
-
-            break;
-         }
-      }
-   }
+    }
+  }
 }

--- a/src/gpgpu-sim/dram_sched.cc
+++ b/src/gpgpu-sim/dram_sched.cc
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -28,232 +26,224 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "dram_sched.h"
-#include "../abstract_hardware_model.h"
 #include "gpu-misc.h"
 #include "gpu-sim.h"
+#include "../abstract_hardware_model.h"
 #include "mem_latency_stat.h"
 
-frfcfs_scheduler::frfcfs_scheduler(const memory_config *config, dram_t *dm,
-                                   memory_stats_t *stats) {
-  m_config = config;
-  m_stats = stats;
-  m_num_pending = 0;
-  m_num_write_pending = 0;
-  m_dram = dm;
-  m_queue = new std::list<dram_req_t *>[m_config->nbk];
-  m_bins = new std::map<
-      unsigned, std::list<std::list<dram_req_t *>::iterator> >[m_config->nbk];
-  m_last_row =
-      new std::list<std::list<dram_req_t *>::iterator> *[m_config->nbk];
-  curr_row_service_time = new unsigned[m_config->nbk];
-  row_service_timestamp = new unsigned[m_config->nbk];
-  for (unsigned i = 0; i < m_config->nbk; i++) {
-    m_queue[i].clear();
-    m_bins[i].clear();
-    m_last_row[i] = NULL;
-    curr_row_service_time[i] = 0;
-    row_service_timestamp[i] = 0;
-  }
-  if (m_config->seperate_write_queue_enabled) {
-    m_write_queue = new std::list<dram_req_t *>[m_config->nbk];
-    m_write_bins = new std::map<
-        unsigned, std::list<std::list<dram_req_t *>::iterator> >[m_config->nbk];
-    m_last_write_row =
-        new std::list<std::list<dram_req_t *>::iterator> *[m_config->nbk];
+frfcfs_scheduler::frfcfs_scheduler( const memory_config *config, dram_t *dm, memory_stats_t *stats )
+{
+   m_config = config;
+   m_stats = stats;
+   m_num_pending = 0;
+   m_num_write_pending = 0;
+   m_dram = dm;
+   m_queue = new std::list<dram_req_t*>[m_config->nbk];
+   m_bins = new std::map<unsigned,std::list<std::list<dram_req_t*>::iterator> >[ m_config->nbk ];
+   m_last_row = new std::list<std::list<dram_req_t*>::iterator>*[ m_config->nbk ];
+   curr_row_service_time = new unsigned[m_config->nbk];
+   row_service_timestamp = new unsigned[m_config->nbk];
+   for ( unsigned i=0; i < m_config->nbk; i++ ) {
+      m_queue[i].clear();
+      m_bins[i].clear();
+      m_last_row[i] = NULL;
+      curr_row_service_time[i] = 0;
+      row_service_timestamp[i] = 0;
+   }
+   if(m_config->seperate_write_queue_enabled) {
+	   m_write_queue = new std::list<dram_req_t*>[m_config->nbk];
+	   m_write_bins = new std::map<unsigned,std::list<std::list<dram_req_t*>::iterator> >[ m_config->nbk ];
+	   m_last_write_row = new std::list<std::list<dram_req_t*>::iterator>*[ m_config->nbk ];
 
-    for (unsigned i = 0; i < m_config->nbk; i++) {
-      m_write_queue[i].clear();
-      m_write_bins[i].clear();
-      m_last_write_row[i] = NULL;
-    }
-  }
-  m_mode = READ_MODE;
+	   for ( unsigned i=0; i < m_config->nbk; i++ ) {
+	         m_write_queue[i].clear();
+	         m_write_bins[i].clear();
+	         m_last_write_row[i] = NULL;
+	      }
+   }
+   m_mode = READ_MODE;
+
 }
 
-void frfcfs_scheduler::add_req(dram_req_t *req) {
-  if (m_config->seperate_write_queue_enabled && req->data->is_write()) {
-    assert(m_num_write_pending < m_config->gpgpu_frfcfs_dram_write_queue_size);
-    m_num_write_pending++;
-    m_write_queue[req->bk].push_front(req);
-    std::list<dram_req_t *>::iterator ptr = m_write_queue[req->bk].begin();
-    m_write_bins[req->bk][req->row].push_front(ptr);  // newest reqs to the
-                                                      // front
+void frfcfs_scheduler::add_req( dram_req_t *req )
+{
+  if(m_config->seperate_write_queue_enabled && req->data->is_write()) {
+	  assert(m_num_write_pending < m_config->gpgpu_frfcfs_dram_write_queue_size);
+	  m_num_write_pending++;
+	  m_write_queue[req->bk].push_front(req);
+	  std::list<dram_req_t*>::iterator ptr = m_write_queue[req->bk].begin();
+	  m_write_bins[req->bk][req->row].push_front( ptr ); //newest reqs to the front
   } else {
-    assert(m_num_pending < m_config->gpgpu_frfcfs_dram_sched_queue_size);
-    m_num_pending++;
-    m_queue[req->bk].push_front(req);
-    std::list<dram_req_t *>::iterator ptr = m_queue[req->bk].begin();
-    m_bins[req->bk][req->row].push_front(ptr);  // newest reqs to the front
+	   assert(m_num_pending < m_config->gpgpu_frfcfs_dram_sched_queue_size);
+	   m_num_pending++;
+	   m_queue[req->bk].push_front(req);
+	   std::list<dram_req_t*>::iterator ptr = m_queue[req->bk].begin();
+	   m_bins[req->bk][req->row].push_front( ptr ); //newest reqs to the front
   }
 }
 
-void frfcfs_scheduler::data_collection(unsigned int bank) {
-  if (m_dram->m_gpu->gpu_sim_cycle > row_service_timestamp[bank]) {
-    curr_row_service_time[bank] =
-        m_dram->m_gpu->gpu_sim_cycle - row_service_timestamp[bank];
-    if (curr_row_service_time[bank] >
-        m_stats->max_servicetime2samerow[m_dram->id][bank])
-      m_stats->max_servicetime2samerow[m_dram->id][bank] =
-          curr_row_service_time[bank];
-  }
-  curr_row_service_time[bank] = 0;
-  row_service_timestamp[bank] = m_dram->m_gpu->gpu_sim_cycle;
-  if (m_stats->concurrent_row_access[m_dram->id][bank] >
-      m_stats->max_conc_access2samerow[m_dram->id][bank]) {
-    m_stats->max_conc_access2samerow[m_dram->id][bank] =
-        m_stats->concurrent_row_access[m_dram->id][bank];
-  }
-  m_stats->concurrent_row_access[m_dram->id][bank] = 0;
-  m_stats->num_activates[m_dram->id][bank]++;
+void frfcfs_scheduler::data_collection(unsigned int bank)
+{
+   if (m_dram->m_gpu->gpu_sim_cycle > row_service_timestamp[bank]) {
+      curr_row_service_time[bank] = m_dram->m_gpu->gpu_sim_cycle - row_service_timestamp[bank];
+      if (curr_row_service_time[bank] > m_stats->max_servicetime2samerow[m_dram->id][bank])
+         m_stats->max_servicetime2samerow[m_dram->id][bank] = curr_row_service_time[bank];
+   }
+   curr_row_service_time[bank] = 0;
+   row_service_timestamp[bank] = m_dram->m_gpu->gpu_sim_cycle;
+   if (m_stats->concurrent_row_access[m_dram->id][bank] > m_stats->max_conc_access2samerow[m_dram->id][bank]) {
+      m_stats->max_conc_access2samerow[m_dram->id][bank] = m_stats->concurrent_row_access[m_dram->id][bank];
+   }
+   m_stats->concurrent_row_access[m_dram->id][bank] = 0;
+   m_stats->num_activates[m_dram->id][bank]++;
 }
 
-dram_req_t *frfcfs_scheduler::schedule(unsigned bank, unsigned curr_row) {
-  // row
-  bool rowhit = true;
-  std::list<dram_req_t *> *m_current_queue = m_queue;
-  std::map<unsigned, std::list<std::list<dram_req_t *>::iterator> >
-      *m_current_bins = m_bins;
-  std::list<std::list<dram_req_t *>::iterator> **m_current_last_row =
-      m_last_row;
+dram_req_t *frfcfs_scheduler::schedule( unsigned bank, unsigned curr_row )
+{
+   //row
+   bool rowhit = true;
+   std::list<dram_req_t*> *m_current_queue = m_queue;
+   std::map<unsigned,std::list<std::list<dram_req_t*>::iterator> > *m_current_bins = m_bins ;
+   std::list<std::list<dram_req_t*>::iterator> **m_current_last_row = m_last_row;
 
-  if (m_config->seperate_write_queue_enabled) {
-    if (m_mode == READ_MODE &&
-        ((m_num_write_pending >= m_config->write_high_watermark)
-         // || (m_queue[bank].empty() && !m_write_queue[bank].empty())
-         )) {
-      m_mode = WRITE_MODE;
-    } else if (m_mode == WRITE_MODE &&
-               ((m_num_write_pending < m_config->write_low_watermark)
-                //  || (!m_queue[bank].empty() && m_write_queue[bank].empty())
-                )) {
-      m_mode = READ_MODE;
-    }
-  }
+   if(m_config->seperate_write_queue_enabled) {
+	   if(m_mode == READ_MODE &&
+			  ((m_num_write_pending >= m_config->write_high_watermark )
+			  // || (m_queue[bank].empty() && !m_write_queue[bank].empty())
+			   )) {
+		   m_mode = WRITE_MODE;
+	   }
+	   else if(m_mode == WRITE_MODE &&
+				  (( m_num_write_pending < m_config->write_low_watermark )
+				 //  || (!m_queue[bank].empty() && m_write_queue[bank].empty())
+				   )){
+		   m_mode = READ_MODE;
+	   }
+   }
 
-  if (m_mode == WRITE_MODE) {
-    m_current_queue = m_write_queue;
-    m_current_bins = m_write_bins;
-    m_current_last_row = m_last_write_row;
-  }
+   if(m_mode == WRITE_MODE) {
+	   m_current_queue = m_write_queue;
+	   m_current_bins = m_write_bins ;
+	   m_current_last_row = m_last_write_row;
+   }
 
-  if (m_current_last_row[bank] == NULL) {
-    if (m_current_queue[bank].empty()) return NULL;
+   if ( m_current_last_row[bank] == NULL ) {
+      if ( m_current_queue[bank].empty() )
+         return NULL;
 
-    std::map<unsigned, std::list<std::list<dram_req_t *>::iterator> >::iterator
-        bin_ptr = m_current_bins[bank].find(curr_row);
-    if (bin_ptr == m_current_bins[bank].end()) {
-      dram_req_t *req = m_current_queue[bank].back();
-      bin_ptr = m_current_bins[bank].find(req->row);
-      assert(bin_ptr !=
-             m_current_bins[bank].end());  // where did the request go???
-      m_current_last_row[bank] = &(bin_ptr->second);
-      data_collection(bank);
-      rowhit = false;
-    } else {
-      m_current_last_row[bank] = &(bin_ptr->second);
-      rowhit = true;
-    }
-  }
-  std::list<dram_req_t *>::iterator next = m_current_last_row[bank]->back();
-  dram_req_t *req = (*next);
+      std::map<unsigned,std::list<std::list<dram_req_t*>::iterator> >::iterator bin_ptr = m_current_bins[bank].find( curr_row );
+      if ( bin_ptr == m_current_bins[bank].end()) {
+         dram_req_t *req = m_current_queue[bank].back();
+         bin_ptr = m_current_bins[bank].find( req->row );
+         assert( bin_ptr != m_current_bins[bank].end() ); // where did the request go???
+         m_current_last_row[bank] = &(bin_ptr->second);
+         data_collection(bank);
+         rowhit = false;
+      } else {
+    	  m_current_last_row[bank] = &(bin_ptr->second);
+         rowhit = true;
+      }
+   }
+   std::list<dram_req_t*>::iterator next = m_current_last_row[bank]->back();
+   dram_req_t *req = (*next);
 
-  // rowblp stats
-  m_dram->access_num++;
-  bool is_write = req->data->is_write();
-  if (is_write)
-    m_dram->write_num++;
-  else
-    m_dram->read_num++;
-
-  if (rowhit) {
-    m_dram->hits_num++;
-    if (is_write)
-      m_dram->hits_write_num++;
+   //rowblp stats
+    m_dram->access_num++;
+    bool is_write = req->data->is_write();
+    if(is_write)
+  	  m_dram->write_num++;
     else
-      m_dram->hits_read_num++;
-  }
+  	  m_dram->read_num++;
 
-  m_stats->concurrent_row_access[m_dram->id][bank]++;
-  m_stats->row_access[m_dram->id][bank]++;
-  m_current_last_row[bank]->pop_back();
+    if(rowhit) {
+     m_dram->hits_num++;
+     if(is_write)
+    	  m_dram->hits_write_num++;
+      else
+    	  m_dram->hits_read_num++;
+    }
 
-  m_current_queue[bank].erase(next);
-  if (m_current_last_row[bank]->empty()) {
-    m_current_bins[bank].erase(req->row);
-    m_current_last_row[bank] = NULL;
-  }
+   m_stats->concurrent_row_access[m_dram->id][bank]++;
+   m_stats->row_access[m_dram->id][bank]++;
+   m_current_last_row[bank]->pop_back();
+
+   m_current_queue[bank].erase(next);
+   if ( m_current_last_row[bank]->empty() ) {
+	   m_current_bins[bank].erase( req->row );
+	   m_current_last_row[bank] = NULL;
+   }
 #ifdef DEBUG_FAST_IDEAL_SCHED
-  if (req)
-    printf("%08u : DRAM(%u) scheduling memory request to bank=%u, row=%u\n",
-           (unsigned)gpu_sim_cycle, m_dram->id, req->bk, req->row);
+   if ( req )
+      printf("%08u : DRAM(%u) scheduling memory request to bank=%u, row=%u\n", 
+             (unsigned)gpu_sim_cycle, m_dram->id, req->bk, req->row );
 #endif
 
-  if (m_config->seperate_write_queue_enabled && req->data->is_write()) {
-    assert(req != NULL && m_num_write_pending != 0);
-    m_num_write_pending--;
-  } else {
-    assert(req != NULL && m_num_pending != 0);
-    m_num_pending--;
-  }
+   if(m_config->seperate_write_queue_enabled && req->data->is_write()) {
+	   assert( req != NULL && m_num_write_pending != 0 );
+	   m_num_write_pending--;
+   }
+   else {
+	   assert( req != NULL && m_num_pending != 0 );
+	   m_num_pending--;
+   }
 
-  return req;
+   return req;
 }
 
-void frfcfs_scheduler::print(FILE *fp) {
-  for (unsigned b = 0; b < m_config->nbk; b++) {
-    printf(" %u: queue length = %u\n", b, (unsigned)m_queue[b].size());
-  }
+
+void frfcfs_scheduler::print( FILE *fp )
+{
+   for ( unsigned b=0; b < m_config->nbk; b++ ) {
+      printf(" %u: queue length = %u\n", b, (unsigned)m_queue[b].size() );
+   }
 }
 
-void dram_t::scheduler_frfcfs() {
-  unsigned mrq_latency;
-  frfcfs_scheduler *sched = m_frfcfs_scheduler;
-  while (!mrqq->empty()) {
-    dram_req_t *req = mrqq->pop();
+void dram_t::scheduler_frfcfs()
+{
+   unsigned mrq_latency;
+   frfcfs_scheduler *sched = m_frfcfs_scheduler;
+   while ( !mrqq->empty() ) {
+      dram_req_t *req = mrqq->pop();
 
-    // Power stats
-    // if(req->data->get_type() != READ_REPLY && req->data->get_type() !=
-    // WRITE_ACK)
-    m_stats->total_n_access++;
+      // Power stats
+      //if(req->data->get_type() != READ_REPLY && req->data->get_type() != WRITE_ACK)
+      m_stats->total_n_access++;
 
-    if (req->data->get_type() == WRITE_REQUEST) {
-      m_stats->total_n_writes++;
-    } else if (req->data->get_type() == READ_REQUEST) {
-      m_stats->total_n_reads++;
-    }
-
-    req->data->set_status(IN_PARTITION_MC_INPUT_QUEUE,
-                          m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-    sched->add_req(req);
-  }
-
-  dram_req_t *req;
-  unsigned i;
-  for (i = 0; i < m_config->nbk; i++) {
-    unsigned b = (i + prio) % m_config->nbk;
-    if (!bk[b]->mrq) {
-      req = sched->schedule(b, bk[b]->curr_row);
-
-      if (req) {
-        req->data->set_status(IN_PARTITION_MC_BANK_ARB_QUEUE,
-                              m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-        prio = (prio + 1) % m_config->nbk;
-        bk[b]->mrq = req;
-        if (m_config->gpgpu_memlatency_stat) {
-          mrq_latency = m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle -
-                        bk[b]->mrq->timestamp;
-          m_stats->tot_mrq_latency += mrq_latency;
-          m_stats->tot_mrq_num++;
-          bk[b]->mrq->timestamp =
-              m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle;
-          m_stats->mrq_lat_table[LOGB2(mrq_latency)]++;
-          if (mrq_latency > m_stats->max_mrq_latency) {
-            m_stats->max_mrq_latency = mrq_latency;
-          }
-        }
-
-        break;
+      if(req->data->get_type() == WRITE_REQUEST){
+    	  m_stats->total_n_writes++;
+      }else if(req->data->get_type() == READ_REQUEST){
+    	  m_stats->total_n_reads++;
       }
-    }
-  }
+
+      req->data->set_status(IN_PARTITION_MC_INPUT_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
+      sched->add_req(req);
+   }
+
+   dram_req_t *req;
+   unsigned i;
+   for ( i=0; i < m_config->nbk; i++ ) {
+      unsigned b = (i+prio)%m_config->nbk;
+      if ( !bk[b]->mrq ) {
+
+         req = sched->schedule(b, bk[b]->curr_row);
+
+         if ( req ) {
+            req->data->set_status(IN_PARTITION_MC_BANK_ARB_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
+            prio = (prio+1)%m_config->nbk;
+            bk[b]->mrq = req;
+            if (m_config->gpgpu_memlatency_stat) {
+               mrq_latency = m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle - bk[b]->mrq->timestamp;
+               m_stats->tot_mrq_latency += mrq_latency;
+               m_stats->tot_mrq_num++;
+               bk[b]->mrq->timestamp =m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle;
+               m_stats->mrq_lat_table[LOGB2(mrq_latency)]++;
+               if (mrq_latency > m_stats->max_mrq_latency) {
+                  m_stats->max_mrq_latency = mrq_latency;
+               }
+            }
+
+            break;
+         }
+      }
+   }
 }

--- a/src/gpgpu-sim/dram_sched.h
+++ b/src/gpgpu-sim/dram_sched.h
@@ -7,66 +7,67 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef dram_sched_h_INCLUDED
 #define dram_sched_h_INCLUDED
 
-#include "dram.h"
-#include "shader.h"
-#include "gpu-sim.h"
-#include "gpu-misc.h"
 #include <list>
 #include <map>
+#include "dram.h"
+#include "gpu-misc.h"
+#include "gpu-sim.h"
+#include "shader.h"
 
-enum memory_mode {
-   READ_MODE = 0,
-   WRITE_MODE
-};
+enum memory_mode { READ_MODE = 0, WRITE_MODE };
 
 class frfcfs_scheduler {
-public:
-   frfcfs_scheduler( const memory_config *config, dram_t *dm, memory_stats_t *stats );
-   void add_req( dram_req_t *req );
-   void data_collection(unsigned bank);
-   dram_req_t *schedule( unsigned bank, unsigned curr_row );
-   void print( FILE *fp );
-   unsigned num_pending() const { return m_num_pending;}
-   unsigned num_write_pending() const { return m_num_write_pending;}
+ public:
+  frfcfs_scheduler(const memory_config *config, dram_t *dm,
+                   memory_stats_t *stats);
+  void add_req(dram_req_t *req);
+  void data_collection(unsigned bank);
+  dram_req_t *schedule(unsigned bank, unsigned curr_row);
+  void print(FILE *fp);
+  unsigned num_pending() const { return m_num_pending; }
+  unsigned num_write_pending() const { return m_num_write_pending; }
 
-private:
-   const memory_config *m_config;
-   dram_t *m_dram;
-   unsigned m_num_pending;
-   unsigned m_num_write_pending;
-   std::list<dram_req_t*>                                    *m_queue;
-   std::map<unsigned,std::list<std::list<dram_req_t*>::iterator> >    *m_bins;
-   std::list<std::list<dram_req_t*>::iterator>                 **m_last_row;
-   unsigned *curr_row_service_time; //one set of variables for each bank.
-   unsigned *row_service_timestamp; //tracks when scheduler began servicing current row
+ private:
+  const memory_config *m_config;
+  dram_t *m_dram;
+  unsigned m_num_pending;
+  unsigned m_num_write_pending;
+  std::list<dram_req_t *> *m_queue;
+  std::map<unsigned, std::list<std::list<dram_req_t *>::iterator> > *m_bins;
+  std::list<std::list<dram_req_t *>::iterator> **m_last_row;
+  unsigned *curr_row_service_time;  // one set of variables for each bank.
+  unsigned *row_service_timestamp;  // tracks when scheduler began servicing
+                                    // current row
 
-   std::list<dram_req_t*>                                    *m_write_queue;
-   std::map<unsigned,std::list<std::list<dram_req_t*>::iterator> >    *m_write_bins;
-   std::list<std::list<dram_req_t*>::iterator>                 **m_last_write_row;
+  std::list<dram_req_t *> *m_write_queue;
+  std::map<unsigned, std::list<std::list<dram_req_t *>::iterator> >
+      *m_write_bins;
+  std::list<std::list<dram_req_t *>::iterator> **m_last_write_row;
 
-   enum memory_mode m_mode;
-   memory_stats_t *m_stats;
+  enum memory_mode m_mode;
+  memory_stats_t *m_stats;
 };
 
 #endif

--- a/src/gpgpu-sim/dram_sched.h
+++ b/src/gpgpu-sim/dram_sched.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -30,45 +28,45 @@
 #ifndef dram_sched_h_INCLUDED
 #define dram_sched_h_INCLUDED
 
+#include "dram.h"
+#include "shader.h"
+#include "gpu-sim.h"
+#include "gpu-misc.h"
 #include <list>
 #include <map>
-#include "dram.h"
-#include "gpu-misc.h"
-#include "gpu-sim.h"
-#include "shader.h"
 
-enum memory_mode { READ_MODE = 0, WRITE_MODE };
+enum memory_mode {
+   READ_MODE = 0,
+   WRITE_MODE
+};
 
 class frfcfs_scheduler {
- public:
-  frfcfs_scheduler(const memory_config *config, dram_t *dm,
-                   memory_stats_t *stats);
-  void add_req(dram_req_t *req);
-  void data_collection(unsigned bank);
-  dram_req_t *schedule(unsigned bank, unsigned curr_row);
-  void print(FILE *fp);
-  unsigned num_pending() const { return m_num_pending; }
-  unsigned num_write_pending() const { return m_num_write_pending; }
+public:
+   frfcfs_scheduler( const memory_config *config, dram_t *dm, memory_stats_t *stats );
+   void add_req( dram_req_t *req );
+   void data_collection(unsigned bank);
+   dram_req_t *schedule( unsigned bank, unsigned curr_row );
+   void print( FILE *fp );
+   unsigned num_pending() const { return m_num_pending;}
+   unsigned num_write_pending() const { return m_num_write_pending;}
 
- private:
-  const memory_config *m_config;
-  dram_t *m_dram;
-  unsigned m_num_pending;
-  unsigned m_num_write_pending;
-  std::list<dram_req_t *> *m_queue;
-  std::map<unsigned, std::list<std::list<dram_req_t *>::iterator> > *m_bins;
-  std::list<std::list<dram_req_t *>::iterator> **m_last_row;
-  unsigned *curr_row_service_time;  // one set of variables for each bank.
-  unsigned *row_service_timestamp;  // tracks when scheduler began servicing
-                                    // current row
+private:
+   const memory_config *m_config;
+   dram_t *m_dram;
+   unsigned m_num_pending;
+   unsigned m_num_write_pending;
+   std::list<dram_req_t*>                                    *m_queue;
+   std::map<unsigned,std::list<std::list<dram_req_t*>::iterator> >    *m_bins;
+   std::list<std::list<dram_req_t*>::iterator>                 **m_last_row;
+   unsigned *curr_row_service_time; //one set of variables for each bank.
+   unsigned *row_service_timestamp; //tracks when scheduler began servicing current row
 
-  std::list<dram_req_t *> *m_write_queue;
-  std::map<unsigned, std::list<std::list<dram_req_t *>::iterator> >
-      *m_write_bins;
-  std::list<std::list<dram_req_t *>::iterator> **m_last_write_row;
+   std::list<dram_req_t*>                                    *m_write_queue;
+   std::map<unsigned,std::list<std::list<dram_req_t*>::iterator> >    *m_write_bins;
+   std::list<std::list<dram_req_t*>::iterator>                 **m_last_write_row;
 
-  enum memory_mode m_mode;
-  memory_stats_t *m_stats;
+   enum memory_mode m_mode;
+   memory_stats_t *m_stats;
 };
 
 #endif

--- a/src/gpgpu-sim/dram_sched.h
+++ b/src/gpgpu-sim/dram_sched.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -28,45 +30,45 @@
 #ifndef dram_sched_h_INCLUDED
 #define dram_sched_h_INCLUDED
 
-#include "dram.h"
-#include "shader.h"
-#include "gpu-sim.h"
-#include "gpu-misc.h"
 #include <list>
 #include <map>
+#include "dram.h"
+#include "gpu-misc.h"
+#include "gpu-sim.h"
+#include "shader.h"
 
-enum memory_mode {
-   READ_MODE = 0,
-   WRITE_MODE
-};
+enum memory_mode { READ_MODE = 0, WRITE_MODE };
 
 class frfcfs_scheduler {
-public:
-   frfcfs_scheduler( const memory_config *config, dram_t *dm, memory_stats_t *stats );
-   void add_req( dram_req_t *req );
-   void data_collection(unsigned bank);
-   dram_req_t *schedule( unsigned bank, unsigned curr_row );
-   void print( FILE *fp );
-   unsigned num_pending() const { return m_num_pending;}
-   unsigned num_write_pending() const { return m_num_write_pending;}
+ public:
+  frfcfs_scheduler(const memory_config *config, dram_t *dm,
+                   memory_stats_t *stats);
+  void add_req(dram_req_t *req);
+  void data_collection(unsigned bank);
+  dram_req_t *schedule(unsigned bank, unsigned curr_row);
+  void print(FILE *fp);
+  unsigned num_pending() const { return m_num_pending; }
+  unsigned num_write_pending() const { return m_num_write_pending; }
 
-private:
-   const memory_config *m_config;
-   dram_t *m_dram;
-   unsigned m_num_pending;
-   unsigned m_num_write_pending;
-   std::list<dram_req_t*>                                    *m_queue;
-   std::map<unsigned,std::list<std::list<dram_req_t*>::iterator> >    *m_bins;
-   std::list<std::list<dram_req_t*>::iterator>                 **m_last_row;
-   unsigned *curr_row_service_time; //one set of variables for each bank.
-   unsigned *row_service_timestamp; //tracks when scheduler began servicing current row
+ private:
+  const memory_config *m_config;
+  dram_t *m_dram;
+  unsigned m_num_pending;
+  unsigned m_num_write_pending;
+  std::list<dram_req_t *> *m_queue;
+  std::map<unsigned, std::list<std::list<dram_req_t *>::iterator> > *m_bins;
+  std::list<std::list<dram_req_t *>::iterator> **m_last_row;
+  unsigned *curr_row_service_time;  // one set of variables for each bank.
+  unsigned *row_service_timestamp;  // tracks when scheduler began servicing
+                                    // current row
 
-   std::list<dram_req_t*>                                    *m_write_queue;
-   std::map<unsigned,std::list<std::list<dram_req_t*>::iterator> >    *m_write_bins;
-   std::list<std::list<dram_req_t*>::iterator>                 **m_last_write_row;
+  std::list<dram_req_t *> *m_write_queue;
+  std::map<unsigned, std::list<std::list<dram_req_t *>::iterator> >
+      *m_write_bins;
+  std::list<std::list<dram_req_t *>::iterator> **m_last_write_row;
 
-   enum memory_mode m_mode;
-   memory_stats_t *m_stats;
+  enum memory_mode m_mode;
+  memory_stats_t *m_stats;
 };
 
 #endif

--- a/src/gpgpu-sim/gpu-cache.cc
+++ b/src/gpgpu-sim/gpu-cache.cc
@@ -1329,8 +1329,8 @@ enum cache_request_status data_cache::wr_miss_wa_fetch_on_write(
 
   if (mf->get_access_byte_mask().count() == m_config.get_atom_sz()) {
     // if the request writes to the whole cache line/sector, then, write and set
-    // cache line Modified. and no need to send read request to memory or reserve
-    // mshr
+    // cache line Modified. and no need to send read request to memory or
+    // reserve mshr
 
     if (miss_queue_full(0)) {
       m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);

--- a/src/gpgpu-sim/gpu-cache.cc
+++ b/src/gpgpu-sim/gpu-cache.cc
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -26,1618 +28,1621 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "gpu-cache.h"
+#include <assert.h>
 #include "gpu-sim.h"
 #include "stat-tool.h"
-#include <assert.h>
 
-// used to allocate memory that is large enough to adapt the changes in cache size across kernels
+// used to allocate memory that is large enough to adapt the changes in cache
+// size across kernels
 
-const char * cache_request_status_str(enum cache_request_status status) 
-{
-   static const char * static_cache_request_status_str[] = {
-      "HIT",
-      "HIT_RESERVED",
-      "MISS",
-      "RESERVATION_FAIL",
-	  "SECTOR_MISS"
-   }; 
+const char *cache_request_status_str(enum cache_request_status status) {
+  static const char *static_cache_request_status_str[] = {
+      "HIT", "HIT_RESERVED", "MISS", "RESERVATION_FAIL", "SECTOR_MISS"};
 
-   assert(sizeof(static_cache_request_status_str) / sizeof(const char*) == NUM_CACHE_REQUEST_STATUS); 
-   assert(status < NUM_CACHE_REQUEST_STATUS); 
+  assert(sizeof(static_cache_request_status_str) / sizeof(const char *) ==
+         NUM_CACHE_REQUEST_STATUS);
+  assert(status < NUM_CACHE_REQUEST_STATUS);
 
-   return static_cache_request_status_str[status]; 
+  return static_cache_request_status_str[status];
 }
 
-const char * cache_fail_status_str(enum cache_reservation_fail_reason status)
-{
-   static const char * static_cache_reservation_fail_reason_str[] = {
-	  "LINE_ALLOC_FAIL",
-	  "MISS_QUEUE_FULL",
-	  "MSHR_ENRTY_FAIL",
-      "MSHR_MERGE_ENRTY_FAIL",
-      "MSHR_RW_PENDING"
-   };
+const char *cache_fail_status_str(enum cache_reservation_fail_reason status) {
+  static const char *static_cache_reservation_fail_reason_str[] = {
+      "LINE_ALLOC_FAIL", "MISS_QUEUE_FULL", "MSHR_ENRTY_FAIL",
+      "MSHR_MERGE_ENRTY_FAIL", "MSHR_RW_PENDING"};
 
-   assert(sizeof(static_cache_reservation_fail_reason_str) / sizeof(const char*) == NUM_CACHE_RESERVATION_FAIL_STATUS);
-   assert(status < NUM_CACHE_RESERVATION_FAIL_STATUS);
+  assert(sizeof(static_cache_reservation_fail_reason_str) /
+             sizeof(const char *) ==
+         NUM_CACHE_RESERVATION_FAIL_STATUS);
+  assert(status < NUM_CACHE_RESERVATION_FAIL_STATUS);
 
-   return static_cache_reservation_fail_reason_str[status];
+  return static_cache_reservation_fail_reason_str[status];
 }
 
-unsigned l1d_cache_config::set_bank(new_addr_type addr) const{
-
-	if(m_cache_type == SECTOR)
-		return (addr >> m_sector_sz_log2) & (l1_banks-1);
-	else
-		return (addr >> m_line_sz_log2) & (l1_banks-1);
+unsigned l1d_cache_config::set_bank(new_addr_type addr) const {
+  if (m_cache_type == SECTOR)
+    return (addr >> m_sector_sz_log2) & (l1_banks - 1);
+  else
+    return (addr >> m_line_sz_log2) & (l1_banks - 1);
 }
 
-unsigned l1d_cache_config::set_index(new_addr_type addr) const{
-    unsigned set_index = m_nset; // Default to linear set index function
-    unsigned lower_xor = 0;
-    unsigned upper_xor = 0;
+unsigned l1d_cache_config::set_index(new_addr_type addr) const {
+  unsigned set_index = m_nset;  // Default to linear set index function
+  unsigned lower_xor = 0;
+  unsigned upper_xor = 0;
 
-    switch(m_set_index_function){
+  switch (m_set_index_function) {
     case FERMI_HASH_SET_FUNCTION:
     case BITWISE_XORING_FUNCTION:
-        /*
-        * Set Indexing function from "A Detailed GPU Cache Model Based on Reuse Distance Theory"
-        * Cedric Nugteren et al.
-        * HPCA 2014
-        */
-        if(m_nset == 32 || m_nset == 64){
-            // Lower xor value is bits 7-11
-            lower_xor = (addr >> m_line_sz_log2) & 0x1F;
+      /*
+      * Set Indexing function from "A Detailed GPU Cache Model Based on Reuse
+      * Distance Theory"
+      * Cedric Nugteren et al.
+      * HPCA 2014
+      */
+      if (m_nset == 32 || m_nset == 64) {
+        // Lower xor value is bits 7-11
+        lower_xor = (addr >> m_line_sz_log2) & 0x1F;
 
-            // Upper xor value is bits 13, 14, 15, 17, and 19
-            upper_xor  = (addr & 0xE000)  >> 13; // Bits 13, 14, 15
-            upper_xor |= (addr & 0x20000) >> 14; // Bit 17
-            upper_xor |= (addr & 0x80000) >> 15; // Bit 19
+        // Upper xor value is bits 13, 14, 15, 17, and 19
+        upper_xor = (addr & 0xE000) >> 13;    // Bits 13, 14, 15
+        upper_xor |= (addr & 0x20000) >> 14;  // Bit 17
+        upper_xor |= (addr & 0x80000) >> 15;  // Bit 19
 
-            set_index = (lower_xor ^ upper_xor);
+        set_index = (lower_xor ^ upper_xor);
 
-            // 48KB cache prepends the set_index with bit 12
-            if(m_nset == 64)
-                set_index |= (addr & 0x1000) >> 7;
+        // 48KB cache prepends the set_index with bit 12
+        if (m_nset == 64) set_index |= (addr & 0x1000) >> 7;
 
-        }else{ /* Else incorrect number of sets for the hashing function */
-            assert("\nGPGPU-Sim cache configuration error: The number of sets should be "
-                    "32 or 64 for the hashing set index function.\n" && 0);
-        }
-        break;
+      } else { /* Else incorrect number of sets for the hashing function */
+        assert(
+            "\nGPGPU-Sim cache configuration error: The number of sets should "
+            "be "
+            "32 or 64 for the hashing set index function.\n" &&
+            0);
+      }
+      break;
 
     case HASH_IPOLY_FUNCTION:
-    	/*
-		* Set Indexing function from "Pseudo-randomly interleaved memory."
-		* Rau, B. R et al.
-		* ISCA 1991
-		*
-		* "Sacat: streaming-aware conflict-avoiding thrashing-resistant gpgpu cache management scheme."
-		* Khairy et al.
-		* IEEE TPDS 2017.
-    	*/
-    	if(m_nset == 32 || m_nset == 64){
-		std::bitset<64> a(addr);
-		std::bitset<6> index;
-		index[0] = a[25]^a[24]^a[23]^a[22]^a[21]^a[18]^a[17]^a[15]^a[12]^a[7]; //10
-		index[1] = a[26]^a[25]^a[24]^a[23]^a[22]^a[19]^a[18]^a[16]^a[13]^a[8]; //10
-		index[2] = a[26]^a[22]^a[21]^a[20]^a[19]^a[18]^a[15]^a[14]^a[12]^a[9]; //10
-		index[3] = a[23]^a[22]^a[21]^a[20]^a[19]^a[16]^a[15]^a[13]^a[10]; //9
-		index[4] = a[24]^a[23]^a[22]^a[21]^a[20]^a[17]^a[16]^a[14]^a[11]; //9
+      /*
+              * Set Indexing function from "Pseudo-randomly interleaved memory."
+              * Rau, B. R et al.
+              * ISCA 1991
+              *
+              * "Sacat: streaming-aware conflict-avoiding thrashing-resistant
+       * gpgpu cache management scheme."
+              * Khairy et al.
+              * IEEE TPDS 2017.
+      */
+      if (m_nset == 32 || m_nset == 64) {
+        std::bitset<64> a(addr);
+        std::bitset<6> index;
+        index[0] = a[25] ^ a[24] ^ a[23] ^ a[22] ^ a[21] ^ a[18] ^ a[17] ^
+                   a[15] ^ a[12] ^ a[7];  // 10
+        index[1] = a[26] ^ a[25] ^ a[24] ^ a[23] ^ a[22] ^ a[19] ^ a[18] ^
+                   a[16] ^ a[13] ^ a[8];  // 10
+        index[2] = a[26] ^ a[22] ^ a[21] ^ a[20] ^ a[19] ^ a[18] ^ a[15] ^
+                   a[14] ^ a[12] ^ a[9];  // 10
+        index[3] = a[23] ^ a[22] ^ a[21] ^ a[20] ^ a[19] ^ a[16] ^ a[15] ^
+                   a[13] ^ a[10];  // 9
+        index[4] = a[24] ^ a[23] ^ a[22] ^ a[21] ^ a[20] ^ a[17] ^ a[16] ^
+                   a[14] ^ a[11];  // 9
 
-		 if(m_nset == 64)
-			 index[5] = a[12];
+        if (m_nset == 64) index[5] = a[12];
 
-		set_index = index.to_ulong();
+        set_index = index.to_ulong();
 
-    	}else{ /* Else incorrect number of sets for the hashing function */
-    	            assert("\nGPGPU-Sim cache configuration error: The number of sets should be "
-    	                    "32 or 64 for the hashing set index function.\n" && 0);
-    	 }
-        break;
+      } else { /* Else incorrect number of sets for the hashing function */
+        assert(
+            "\nGPGPU-Sim cache configuration error: The number of sets should "
+            "be "
+            "32 or 64 for the hashing set index function.\n" &&
+            0);
+      }
+      break;
 
     case CUSTOM_SET_FUNCTION:
-        /* No custom set function implemented */
-        break;
+      /* No custom set function implemented */
+      break;
 
     case LINEAR_SET_FUNCTION:
-        set_index = (addr >> m_line_sz_log2) & (m_nset-1);
-        break;
+      set_index = (addr >> m_line_sz_log2) & (m_nset - 1);
+      break;
 
     default:
-    	 assert("\nUndefined set index function.\n" && 0);
-    	 break;
-    }
+      assert("\nUndefined set index function.\n" && 0);
+      break;
+  }
 
-    // Linear function selected or custom set index function not implemented
-    assert((set_index < m_nset) && "\nError: Set index out of bounds. This is caused by "
-            "an incorrect or unimplemented custom set index function.\n");
+  // Linear function selected or custom set index function not implemented
+  assert((set_index < m_nset) &&
+         "\nError: Set index out of bounds. This is caused by "
+         "an incorrect or unimplemented custom set index function.\n");
 
-    return set_index;
+  return set_index;
 }
 
-void l2_cache_config::init(linear_to_raw_address_translation *address_mapping){
-	cache_config::init(m_config_string,FuncCachePreferNone);
-	m_address_mapping = address_mapping;
+void l2_cache_config::init(linear_to_raw_address_translation *address_mapping) {
+  cache_config::init(m_config_string, FuncCachePreferNone);
+  m_address_mapping = address_mapping;
 }
 
-unsigned l2_cache_config::set_index(new_addr_type addr) const{
-	if(!m_address_mapping){
-		return(addr >> m_line_sz_log2) & (m_nset-1);
-	}else{
-		// Calculate set index without memory partition bits to reduce set camping
-		new_addr_type part_addr = m_address_mapping->partition_address(addr);
-		return(part_addr >> m_line_sz_log2) & (m_nset -1);
-	}
+unsigned l2_cache_config::set_index(new_addr_type addr) const {
+  if (!m_address_mapping) {
+    return (addr >> m_line_sz_log2) & (m_nset - 1);
+  } else {
+    // Calculate set index without memory partition bits to reduce set camping
+    new_addr_type part_addr = m_address_mapping->partition_address(addr);
+    return (part_addr >> m_line_sz_log2) & (m_nset - 1);
+  }
 }
 
-tag_array::~tag_array() 
-{
-	unsigned cache_lines_num = m_config.get_max_num_lines();
-	for(unsigned i=0; i<cache_lines_num; ++i)
-		delete m_lines[i];
-    delete[] m_lines;
+tag_array::~tag_array() {
+  unsigned cache_lines_num = m_config.get_max_num_lines();
+  for (unsigned i = 0; i < cache_lines_num; ++i) delete m_lines[i];
+  delete[] m_lines;
 }
 
-tag_array::tag_array( cache_config &config,
-                      int core_id,
-                      int type_id,
-                      cache_block_t** new_lines)
-    : m_config( config ),
-      m_lines( new_lines )
-{
-    init( core_id, type_id );
+tag_array::tag_array(cache_config &config, int core_id, int type_id,
+                     cache_block_t **new_lines)
+    : m_config(config), m_lines(new_lines) {
+  init(core_id, type_id);
 }
 
-void tag_array::update_cache_parameters(cache_config &config)
-{
-	m_config=config;
+void tag_array::update_cache_parameters(cache_config &config) {
+  m_config = config;
 }
 
-tag_array::tag_array( cache_config &config,
-                      int core_id,
-                      int type_id )
-    : m_config( config )
-{
-    //assert( m_config.m_write_policy == READ_ONLY ); Old assert
-	unsigned cache_lines_num = config.get_max_num_lines();
-	m_lines = new cache_block_t*[cache_lines_num];
-	if(config.m_cache_type == NORMAL)
-	{
-		for(unsigned i=0; i<cache_lines_num; ++i)
-			m_lines[i] = new line_cache_block();
-	}
-	else if(config.m_cache_type == SECTOR)
-	{
-		for(unsigned i=0; i<cache_lines_num; ++i)
-			m_lines[i] = new sector_cache_block();
-	}
-	else
-		assert(0);
+tag_array::tag_array(cache_config &config, int core_id, int type_id)
+    : m_config(config) {
+  // assert( m_config.m_write_policy == READ_ONLY ); Old assert
+  unsigned cache_lines_num = config.get_max_num_lines();
+  m_lines = new cache_block_t *[cache_lines_num];
+  if (config.m_cache_type == NORMAL) {
+    for (unsigned i = 0; i < cache_lines_num; ++i)
+      m_lines[i] = new line_cache_block();
+  } else if (config.m_cache_type == SECTOR) {
+    for (unsigned i = 0; i < cache_lines_num; ++i)
+      m_lines[i] = new sector_cache_block();
+  } else
+    assert(0);
 
-    init( core_id, type_id );
+  init(core_id, type_id);
 }
 
-void tag_array::init( int core_id, int type_id )
-{
-    m_access = 0;
-    m_miss = 0;
-    m_pending_hit = 0;
-    m_res_fail = 0;
-    m_sector_miss = 0;
-    // initialize snapshot counters for visualizer
-    m_prev_snapshot_access = 0;
-    m_prev_snapshot_miss = 0;
-    m_prev_snapshot_pending_hit = 0;
-    m_core_id = core_id; 
-    m_type_id = type_id;
-    is_used = false;
+void tag_array::init(int core_id, int type_id) {
+  m_access = 0;
+  m_miss = 0;
+  m_pending_hit = 0;
+  m_res_fail = 0;
+  m_sector_miss = 0;
+  // initialize snapshot counters for visualizer
+  m_prev_snapshot_access = 0;
+  m_prev_snapshot_miss = 0;
+  m_prev_snapshot_pending_hit = 0;
+  m_core_id = core_id;
+  m_type_id = type_id;
+  is_used = false;
 }
 
-void tag_array::add_pending_line(mem_fetch *mf){
-	assert(mf);
-	new_addr_type addr = m_config.block_addr(mf->get_addr());
-	line_table::const_iterator i = pending_lines.find(addr);
-	if ( i == pending_lines.end() ) {
-		pending_lines[addr] = mf->get_inst().get_uid();
-	}
+void tag_array::add_pending_line(mem_fetch *mf) {
+  assert(mf);
+  new_addr_type addr = m_config.block_addr(mf->get_addr());
+  line_table::const_iterator i = pending_lines.find(addr);
+  if (i == pending_lines.end()) {
+    pending_lines[addr] = mf->get_inst().get_uid();
+  }
 }
 
-void tag_array::remove_pending_line(mem_fetch *mf){
-	assert(mf);
-	new_addr_type addr = m_config.block_addr(mf->get_addr());
-	line_table::const_iterator i = pending_lines.find(addr);
-	if ( i != pending_lines.end() ) {
-		pending_lines.erase(addr);
-	}
+void tag_array::remove_pending_line(mem_fetch *mf) {
+  assert(mf);
+  new_addr_type addr = m_config.block_addr(mf->get_addr());
+  line_table::const_iterator i = pending_lines.find(addr);
+  if (i != pending_lines.end()) {
+    pending_lines.erase(addr);
+  }
 }
 
-enum cache_request_status tag_array::probe( new_addr_type addr, unsigned &idx, mem_fetch* mf, bool probe_mode) const {
-    mem_access_sector_mask_t mask = mf->get_access_sector_mask();
-    return probe(addr, idx, mask, probe_mode, mf);
+enum cache_request_status tag_array::probe(new_addr_type addr, unsigned &idx,
+                                           mem_fetch *mf,
+                                           bool probe_mode) const {
+  mem_access_sector_mask_t mask = mf->get_access_sector_mask();
+  return probe(addr, idx, mask, probe_mode, mf);
 }
 
+enum cache_request_status tag_array::probe(new_addr_type addr, unsigned &idx,
+                                           mem_access_sector_mask_t mask,
+                                           bool probe_mode,
+                                           mem_fetch *mf) const {
+  // assert( m_config.m_write_policy == READ_ONLY );
+  unsigned set_index = m_config.set_index(addr);
+  new_addr_type tag = m_config.tag(addr);
 
-enum cache_request_status tag_array::probe( new_addr_type addr, unsigned &idx, mem_access_sector_mask_t mask, bool probe_mode, mem_fetch* mf) const {
-    //assert( m_config.m_write_policy == READ_ONLY );
-    unsigned set_index = m_config.set_index(addr);
-    new_addr_type tag = m_config.tag(addr);
+  unsigned invalid_line = (unsigned)-1;
+  unsigned valid_line = (unsigned)-1;
+  unsigned long long valid_timestamp = (unsigned)-1;
 
-    unsigned invalid_line = (unsigned)-1;
-    unsigned valid_line = (unsigned)-1;
-    unsigned long long valid_timestamp = (unsigned)-1;
+  bool all_reserved = true;
 
-    bool all_reserved = true;
-
-    // check for hit or pending hit
-    for (unsigned way=0; way<m_config.m_assoc; way++) {
-        unsigned index = set_index*m_config.m_assoc+way;
-        cache_block_t *line = m_lines[index];
-        if (line->m_tag == tag) {
-            if ( line->get_status(mask) == RESERVED ) {
-                idx = index;
-                return HIT_RESERVED;
-            } else if ( line->get_status(mask) == VALID ) {
-                idx = index;
-                return HIT;
-            } else if ( line->get_status(mask) == MODIFIED) {
-            	if(line->is_readable(mask)) {
-					idx = index;
-					return HIT;
-            	}
-            	else {
-            		idx = index;
-            		return SECTOR_MISS;
-            	}
-
-            } else if ( line->is_valid_line() && line->get_status(mask) == INVALID ) {
-                idx = index;
-                return SECTOR_MISS;
-            }else {
-                assert( line->get_status(mask) == INVALID );
-            }
+  // check for hit or pending hit
+  for (unsigned way = 0; way < m_config.m_assoc; way++) {
+    unsigned index = set_index * m_config.m_assoc + way;
+    cache_block_t *line = m_lines[index];
+    if (line->m_tag == tag) {
+      if (line->get_status(mask) == RESERVED) {
+        idx = index;
+        return HIT_RESERVED;
+      } else if (line->get_status(mask) == VALID) {
+        idx = index;
+        return HIT;
+      } else if (line->get_status(mask) == MODIFIED) {
+        if (line->is_readable(mask)) {
+          idx = index;
+          return HIT;
+        } else {
+          idx = index;
+          return SECTOR_MISS;
         }
-        if (!line->is_reserved_line()) {
-            all_reserved = false;
-            if (line->is_invalid_line()) {
-                invalid_line = index;
-            } else {
-                // valid line : keep track of most appropriate replacement candidate
-                if ( m_config.m_replacement_policy == LRU ) {
-                    if ( line->get_last_access_time() < valid_timestamp ) {
-                        valid_timestamp = line->get_last_access_time();
-                        valid_line = index;
-                    }
-                } else if ( m_config.m_replacement_policy == FIFO ) {
-                    if ( line->get_alloc_time() < valid_timestamp ) {
-                        valid_timestamp = line->get_alloc_time();
-                        valid_line = index;
-                    }
-                }
-            }
+
+      } else if (line->is_valid_line() && line->get_status(mask) == INVALID) {
+        idx = index;
+        return SECTOR_MISS;
+      } else {
+        assert(line->get_status(mask) == INVALID);
+      }
+    }
+    if (!line->is_reserved_line()) {
+      all_reserved = false;
+      if (line->is_invalid_line()) {
+        invalid_line = index;
+      } else {
+        // valid line : keep track of most appropriate replacement candidate
+        if (m_config.m_replacement_policy == LRU) {
+          if (line->get_last_access_time() < valid_timestamp) {
+            valid_timestamp = line->get_last_access_time();
+            valid_line = index;
+          }
+        } else if (m_config.m_replacement_policy == FIFO) {
+          if (line->get_alloc_time() < valid_timestamp) {
+            valid_timestamp = line->get_alloc_time();
+            valid_line = index;
+          }
         }
+      }
     }
-    if ( all_reserved ) {
-        assert( m_config.m_alloc_policy == ON_MISS ); 
-        return RESERVATION_FAIL; // miss and not enough space in cache to allocate on miss
+  }
+  if (all_reserved) {
+    assert(m_config.m_alloc_policy == ON_MISS);
+    return RESERVATION_FAIL;  // miss and not enough space in cache to allocate
+                              // on miss
+  }
+
+  if (invalid_line != (unsigned)-1) {
+    idx = invalid_line;
+  } else if (valid_line != (unsigned)-1) {
+    idx = valid_line;
+  } else
+    abort();  // if an unreserved block exists, it is either invalid or
+              // replaceable
+
+  if (probe_mode && m_config.is_streaming()) {
+    line_table::const_iterator i =
+        pending_lines.find(m_config.block_addr(addr));
+    assert(mf);
+    if (!mf->is_write() && i != pending_lines.end()) {
+      if (i->second != mf->get_inst().get_uid()) return SECTOR_MISS;
     }
+  }
 
-    if ( invalid_line != (unsigned)-1 ) {
-        idx = invalid_line;
-    } else if ( valid_line != (unsigned)-1) {
-        idx = valid_line;
-    } else abort(); // if an unreserved block exists, it is either invalid or replaceable 
-
-
-    if(probe_mode && m_config.is_streaming()){
-		line_table::const_iterator i = pending_lines.find(m_config.block_addr(addr));
-		assert(mf);
-		if ( !mf->is_write() && i != pending_lines.end() ) {
-			 if(i->second != mf->get_inst().get_uid())
-				 return SECTOR_MISS;
-		}
-    }
-
-    return MISS;
+  return MISS;
 }
 
-enum cache_request_status tag_array::access( new_addr_type addr, unsigned time, unsigned &idx, mem_fetch* mf)
-{
-    bool wb=false;
-    evicted_block_info evicted;
-    enum cache_request_status result = access(addr,time,idx,wb,evicted,mf);
-    assert(!wb);
-    return result;
+enum cache_request_status tag_array::access(new_addr_type addr, unsigned time,
+                                            unsigned &idx, mem_fetch *mf) {
+  bool wb = false;
+  evicted_block_info evicted;
+  enum cache_request_status result = access(addr, time, idx, wb, evicted, mf);
+  assert(!wb);
+  return result;
 }
 
-enum cache_request_status tag_array::access( new_addr_type addr, unsigned time, unsigned &idx, bool &wb, evicted_block_info &evicted, mem_fetch* mf )
-{
-    m_access++;
-    is_used = true;
-    shader_cache_access_log(m_core_id, m_type_id, 0); // log accesses to cache
-    enum cache_request_status status = probe(addr,idx,mf);
-    switch (status) {
-    case HIT_RESERVED: 
-        m_pending_hit++;
-    case HIT: 
-        m_lines[idx]->set_last_access_time(time, mf->get_access_sector_mask());
-        break;
+enum cache_request_status tag_array::access(new_addr_type addr, unsigned time,
+                                            unsigned &idx, bool &wb,
+                                            evicted_block_info &evicted,
+                                            mem_fetch *mf) {
+  m_access++;
+  is_used = true;
+  shader_cache_access_log(m_core_id, m_type_id, 0);  // log accesses to cache
+  enum cache_request_status status = probe(addr, idx, mf);
+  switch (status) {
+    case HIT_RESERVED:
+      m_pending_hit++;
+    case HIT:
+      m_lines[idx]->set_last_access_time(time, mf->get_access_sector_mask());
+      break;
     case MISS:
-        m_miss++;
-        shader_cache_access_log(m_core_id, m_type_id, 1); // log cache misses
-        if ( m_config.m_alloc_policy == ON_MISS ) {
-            if( m_lines[idx]->is_modified_line()) {
-                wb = true;
-                evicted.set_info(m_lines[idx]->m_block_addr, m_lines[idx]->get_modified_size());
-            }
-            m_lines[idx]->allocate( m_config.tag(addr), m_config.block_addr(addr), time, mf->get_access_sector_mask());
+      m_miss++;
+      shader_cache_access_log(m_core_id, m_type_id, 1);  // log cache misses
+      if (m_config.m_alloc_policy == ON_MISS) {
+        if (m_lines[idx]->is_modified_line()) {
+          wb = true;
+          evicted.set_info(m_lines[idx]->m_block_addr,
+                           m_lines[idx]->get_modified_size());
         }
-        break;
+        m_lines[idx]->allocate(m_config.tag(addr), m_config.block_addr(addr),
+                               time, mf->get_access_sector_mask());
+      }
+      break;
     case SECTOR_MISS:
-    	assert(m_config.m_cache_type == SECTOR);
-    	m_sector_miss++;
-		shader_cache_access_log(m_core_id, m_type_id, 1); // log cache misses
-		if ( m_config.m_alloc_policy == ON_MISS ) {
-			((sector_cache_block*)m_lines[idx])->allocate_sector( time, mf->get_access_sector_mask() );
-		}
-		break;
+      assert(m_config.m_cache_type == SECTOR);
+      m_sector_miss++;
+      shader_cache_access_log(m_core_id, m_type_id, 1);  // log cache misses
+      if (m_config.m_alloc_policy == ON_MISS) {
+        ((sector_cache_block *)m_lines[idx])
+            ->allocate_sector(time, mf->get_access_sector_mask());
+      }
+      break;
     case RESERVATION_FAIL:
-        m_res_fail++;
-        shader_cache_access_log(m_core_id, m_type_id, 1); // log cache misses
-        break;
+      m_res_fail++;
+      shader_cache_access_log(m_core_id, m_type_id, 1);  // log cache misses
+      break;
     default:
-        fprintf( stderr, "tag_array::access - Error: Unknown"
-            "cache_request_status %d\n", status );
-        abort();
+      fprintf(stderr,
+              "tag_array::access - Error: Unknown"
+              "cache_request_status %d\n",
+              status);
+      abort();
+  }
+  return status;
+}
+
+void tag_array::fill(new_addr_type addr, unsigned time, mem_fetch *mf) {
+  fill(addr, time, mf->get_access_sector_mask());
+}
+
+void tag_array::fill(new_addr_type addr, unsigned time,
+                     mem_access_sector_mask_t mask) {
+  // assert( m_config.m_alloc_policy == ON_FILL );
+  unsigned idx;
+  enum cache_request_status status = probe(addr, idx, mask);
+  // assert(status==MISS||status==SECTOR_MISS); // MSHR should have prevented
+  // redundant memory request
+  if (status == MISS)
+    m_lines[idx]->allocate(m_config.tag(addr), m_config.block_addr(addr), time,
+                           mask);
+  else if (status == SECTOR_MISS) {
+    assert(m_config.m_cache_type == SECTOR);
+    ((sector_cache_block *)m_lines[idx])->allocate_sector(time, mask);
+  }
+
+  m_lines[idx]->fill(time, mask);
+}
+
+void tag_array::fill(unsigned index, unsigned time, mem_fetch *mf) {
+  assert(m_config.m_alloc_policy == ON_MISS);
+  m_lines[index]->fill(time, mf->get_access_sector_mask());
+}
+
+// TODO: we need write back the flushed data to the upper level
+void tag_array::flush() {
+  if (!is_used) return;
+
+  for (unsigned i = 0; i < m_config.get_num_lines(); i++)
+    if (m_lines[i]->is_modified_line()) {
+      for (unsigned j = 0; j < SECTOR_CHUNCK_SIZE; j++)
+        m_lines[i]->set_status(INVALID, mem_access_sector_mask_t().set(j));
     }
-    return status;
+
+  is_used = false;
 }
 
-void tag_array::fill( new_addr_type addr, unsigned time, mem_fetch* mf)
-{
-    fill(addr, time, mf->get_access_sector_mask());
+void tag_array::invalidate() {
+  if (!is_used) return;
+
+  for (unsigned i = 0; i < m_config.get_num_lines(); i++)
+    for (unsigned j = 0; j < SECTOR_CHUNCK_SIZE; j++)
+      m_lines[i]->set_status(INVALID, mem_access_sector_mask_t().set(j));
+
+  is_used = false;
 }
 
-void tag_array::fill( new_addr_type addr, unsigned time, mem_access_sector_mask_t mask )
-{
-    //assert( m_config.m_alloc_policy == ON_FILL );
-    unsigned idx;
-    enum cache_request_status status = probe(addr,idx,mask);
-    //assert(status==MISS||status==SECTOR_MISS); // MSHR should have prevented redundant memory request
-    if(status==MISS)
-    	m_lines[idx]->allocate( m_config.tag(addr), m_config.block_addr(addr), time, mask );
-    else if (status==SECTOR_MISS) {
-    	assert(m_config.m_cache_type == SECTOR);
-    	((sector_cache_block*)m_lines[idx])->allocate_sector( time, mask );
-    }
+float tag_array::windowed_miss_rate() const {
+  unsigned n_access = m_access - m_prev_snapshot_access;
+  unsigned n_miss = (m_miss + m_sector_miss) - m_prev_snapshot_miss;
+  // unsigned n_pending_hit = m_pending_hit - m_prev_snapshot_pending_hit;
 
-    m_lines[idx]->fill(time, mask);
+  float missrate = 0.0f;
+  if (n_access != 0) missrate = (float)(n_miss + m_sector_miss) / n_access;
+  return missrate;
 }
 
-void tag_array::fill( unsigned index, unsigned time, mem_fetch* mf)
-{
-    assert( m_config.m_alloc_policy == ON_MISS );
-    m_lines[index]->fill(time, mf->get_access_sector_mask());
+void tag_array::new_window() {
+  m_prev_snapshot_access = m_access;
+  m_prev_snapshot_miss = m_miss;
+  m_prev_snapshot_miss = m_miss + m_sector_miss;
+  m_prev_snapshot_pending_hit = m_pending_hit;
 }
 
-
-//TODO: we need write back the flushed data to the upper level
-void tag_array::flush() 
-{
-	if(!is_used)
-		return;
-
-    for (unsigned i=0; i < m_config.get_num_lines(); i++)
-    	if(m_lines[i]->is_modified_line()) {
-    	for(unsigned j=0; j < SECTOR_CHUNCK_SIZE; j++)
-    		m_lines[i]->set_status(INVALID, mem_access_sector_mask_t().set(j)) ;
-    	}
-
-    is_used = false;
+void tag_array::print(FILE *stream, unsigned &total_access,
+                      unsigned &total_misses) const {
+  m_config.print(stream);
+  fprintf(stream,
+          "\t\tAccess = %d, Miss = %d, Sector_Miss = %d, Total_Miss = %d "
+          "(%.3g), PendingHit = %d (%.3g)\n",
+          m_access, m_miss, m_sector_miss, (m_miss + m_sector_miss),
+          (float)(m_miss + m_sector_miss) / m_access, m_pending_hit,
+          (float)m_pending_hit / m_access);
+  total_misses += (m_miss + m_sector_miss);
+  total_access += m_access;
 }
 
-void tag_array::invalidate()
-{
-	if(!is_used)
-		return;
-
-    for (unsigned i=0; i < m_config.get_num_lines(); i++)
-    	for(unsigned j=0; j < SECTOR_CHUNCK_SIZE; j++)
-    		m_lines[i]->set_status(INVALID, mem_access_sector_mask_t().set(j)) ;
-
-    is_used = false;
+void tag_array::get_stats(unsigned &total_access, unsigned &total_misses,
+                          unsigned &total_hit_res,
+                          unsigned &total_res_fail) const {
+  // Update statistics from the tag array
+  total_access = m_access;
+  total_misses = (m_miss + m_sector_miss);
+  total_hit_res = m_pending_hit;
+  total_res_fail = m_res_fail;
 }
 
-float tag_array::windowed_miss_rate( ) const
-{
-    unsigned n_access    = m_access - m_prev_snapshot_access;
-    unsigned n_miss      = (m_miss+m_sector_miss) - m_prev_snapshot_miss;
-    // unsigned n_pending_hit = m_pending_hit - m_prev_snapshot_pending_hit;
-
-    float missrate = 0.0f;
-    if (n_access != 0)
-        missrate = (float) (n_miss+m_sector_miss) / n_access;
-    return missrate;
+bool was_write_sent(const std::list<cache_event> &events) {
+  for (std::list<cache_event>::const_iterator e = events.begin();
+       e != events.end(); e++) {
+    if ((*e).m_cache_event_type == WRITE_REQUEST_SENT) return true;
+  }
+  return false;
 }
 
-void tag_array::new_window()
-{
-    m_prev_snapshot_access = m_access;
-    m_prev_snapshot_miss = m_miss;
-    m_prev_snapshot_miss = m_miss + m_sector_miss;
-    m_prev_snapshot_pending_hit = m_pending_hit;
+bool was_writeback_sent(const std::list<cache_event> &events,
+                        cache_event &wb_event) {
+  for (std::list<cache_event>::const_iterator e = events.begin();
+       e != events.end(); e++) {
+    if ((*e).m_cache_event_type == WRITE_BACK_REQUEST_SENT) wb_event = *e;
+    return true;
+  }
+  return false;
 }
 
-void tag_array::print( FILE *stream, unsigned &total_access, unsigned &total_misses ) const
-{
-    m_config.print(stream);
-    fprintf( stream, "\t\tAccess = %d, Miss = %d, Sector_Miss = %d, Total_Miss = %d (%.3g), PendingHit = %d (%.3g)\n",
-             m_access, m_miss, m_sector_miss, (m_miss+m_sector_miss), (float) (m_miss+m_sector_miss) / m_access,
-             m_pending_hit, (float) m_pending_hit / m_access);
-    total_misses+=(m_miss+m_sector_miss);
-    total_access+=m_access;
+bool was_read_sent(const std::list<cache_event> &events) {
+  for (std::list<cache_event>::const_iterator e = events.begin();
+       e != events.end(); e++) {
+    if ((*e).m_cache_event_type == READ_REQUEST_SENT) return true;
+  }
+  return false;
 }
 
-void tag_array::get_stats(unsigned &total_access, unsigned &total_misses, unsigned &total_hit_res, unsigned &total_res_fail) const{
-    // Update statistics from the tag array
-    total_access    = m_access;
-    total_misses    = (m_miss+m_sector_miss);
-    total_hit_res   = m_pending_hit;
-    total_res_fail  = m_res_fail;
+bool was_writeallocate_sent(const std::list<cache_event> &events) {
+  for (std::list<cache_event>::const_iterator e = events.begin();
+       e != events.end(); e++) {
+    if ((*e).m_cache_event_type == WRITE_ALLOCATE_SENT) return true;
+  }
+  return false;
 }
-
-
-bool was_write_sent( const std::list<cache_event> &events )
-{
-    for( std::list<cache_event>::const_iterator e=events.begin(); e!=events.end(); e++ ) {
-        if( (*e).m_cache_event_type == WRITE_REQUEST_SENT )
-            return true;
-    }
-    return false;
-}
-
-bool was_writeback_sent( const std::list<cache_event> &events, cache_event& wb_event)
-{
-    for( std::list<cache_event>::const_iterator e=events.begin(); e!=events.end(); e++ ) {
-        if( (*e).m_cache_event_type == WRITE_BACK_REQUEST_SENT )
-        	wb_event = *e;
-            return true;
-    }
-    return false;
-}
-
-bool was_read_sent( const std::list<cache_event> &events )
-{
-    for( std::list<cache_event>::const_iterator e=events.begin(); e!=events.end(); e++ ) {
-        if( (*e).m_cache_event_type == READ_REQUEST_SENT )
-            return true;
-    }
-    return false;
-}
-
-bool was_writeallocate_sent( const std::list<cache_event> &events )
-{
-    for( std::list<cache_event>::const_iterator e=events.begin(); e!=events.end(); e++ ) {
-        if( (*e).m_cache_event_type == WRITE_ALLOCATE_SENT )
-            return true;
-    }
-    return false;
-}
-/****************************************************************** MSHR ******************************************************************/
+/****************************************************************** MSHR
+ * ******************************************************************/
 
 /// Checks if there is a pending request to the lower memory level already
-bool mshr_table::probe( new_addr_type block_addr ) const{
-    table::const_iterator a = m_data.find(block_addr);
-    return a != m_data.end();
+bool mshr_table::probe(new_addr_type block_addr) const {
+  table::const_iterator a = m_data.find(block_addr);
+  return a != m_data.end();
 }
 
 /// Checks if there is space for tracking a new memory access
-bool mshr_table::full( new_addr_type block_addr ) const{
-    table::const_iterator i=m_data.find(block_addr);
-    if ( i != m_data.end() )
-        return i->second.m_list.size() >= m_max_merged;
-    else
-        return m_data.size() >= m_num_entries;
+bool mshr_table::full(new_addr_type block_addr) const {
+  table::const_iterator i = m_data.find(block_addr);
+  if (i != m_data.end())
+    return i->second.m_list.size() >= m_max_merged;
+  else
+    return m_data.size() >= m_num_entries;
 }
 
 /// Add or merge this access
-void mshr_table::add( new_addr_type block_addr, mem_fetch *mf ){
-	m_data[block_addr].m_list.push_back(mf);
-	assert( m_data.size() <= m_num_entries );
-	assert( m_data[block_addr].m_list.size() <= m_max_merged );
-	// indicate that this MSHR entry contains an atomic operation
-	if ( mf->isatomic() ) {
-		m_data[block_addr].m_has_atomic = true;
-	}
+void mshr_table::add(new_addr_type block_addr, mem_fetch *mf) {
+  m_data[block_addr].m_list.push_back(mf);
+  assert(m_data.size() <= m_num_entries);
+  assert(m_data[block_addr].m_list.size() <= m_max_merged);
+  // indicate that this MSHR entry contains an atomic operation
+  if (mf->isatomic()) {
+    m_data[block_addr].m_has_atomic = true;
+  }
 }
 
 /// check is_read_after_write_pending
-bool mshr_table::is_read_after_write_pending( new_addr_type block_addr){
-	std::list<mem_fetch*> my_list = m_data[block_addr].m_list;
-	bool write_found = false;
-	for (std::list<mem_fetch*>::iterator it=my_list.begin(); it != my_list.end(); ++it)
-	{
-		if((*it)->is_write()) //Pending Write Request
-			write_found = true;
-		else if(write_found)   //Pending Read Request and we found previous Write
-				return true;
-	}
+bool mshr_table::is_read_after_write_pending(new_addr_type block_addr) {
+  std::list<mem_fetch *> my_list = m_data[block_addr].m_list;
+  bool write_found = false;
+  for (std::list<mem_fetch *>::iterator it = my_list.begin();
+       it != my_list.end(); ++it) {
+    if ((*it)->is_write())  // Pending Write Request
+      write_found = true;
+    else if (write_found)  // Pending Read Request and we found previous Write
+      return true;
+  }
 
-	return false;
-
+  return false;
 }
 
 /// Accept a new cache fill response: mark entry ready for processing
-void mshr_table::mark_ready( new_addr_type block_addr, bool &has_atomic ){
-    assert( !busy() );
-    table::iterator a = m_data.find(block_addr);
-    assert( a != m_data.end() );
-    m_current_response.push_back( block_addr );
-    has_atomic = a->second.m_has_atomic;
-    assert( m_current_response.size() <= m_data.size() );
+void mshr_table::mark_ready(new_addr_type block_addr, bool &has_atomic) {
+  assert(!busy());
+  table::iterator a = m_data.find(block_addr);
+  assert(a != m_data.end());
+  m_current_response.push_back(block_addr);
+  has_atomic = a->second.m_has_atomic;
+  assert(m_current_response.size() <= m_data.size());
 }
 
 /// Returns next ready access
-mem_fetch *mshr_table::next_access(){
-    assert( access_ready() );
-    new_addr_type block_addr = m_current_response.front();
-    assert( !m_data[block_addr].m_list.empty() );
-    mem_fetch *result = m_data[block_addr].m_list.front();
-    m_data[block_addr].m_list.pop_front();
-    if ( m_data[block_addr].m_list.empty() ) {
-        // release entry
-        m_data.erase(block_addr);
-        m_current_response.pop_front();
+mem_fetch *mshr_table::next_access() {
+  assert(access_ready());
+  new_addr_type block_addr = m_current_response.front();
+  assert(!m_data[block_addr].m_list.empty());
+  mem_fetch *result = m_data[block_addr].m_list.front();
+  m_data[block_addr].m_list.pop_front();
+  if (m_data[block_addr].m_list.empty()) {
+    // release entry
+    m_data.erase(block_addr);
+    m_current_response.pop_front();
+  }
+  return result;
+}
+
+void mshr_table::display(FILE *fp) const {
+  fprintf(fp, "MSHR contents\n");
+  for (table::const_iterator e = m_data.begin(); e != m_data.end(); ++e) {
+    unsigned block_addr = e->first;
+    fprintf(fp, "MSHR: tag=0x%06x, atomic=%d %zu entries : ", block_addr,
+            e->second.m_has_atomic, e->second.m_list.size());
+    if (!e->second.m_list.empty()) {
+      mem_fetch *mf = e->second.m_list.front();
+      fprintf(fp, "%p :", mf);
+      mf->print(fp);
+    } else {
+      fprintf(fp, " no memory requests???\n");
     }
-    return result;
+  }
+}
+/***************************************************************** Caches
+ * *****************************************************************/
+cache_stats::cache_stats() {
+  m_stats.resize(NUM_MEM_ACCESS_TYPE);
+  m_stats_pw.resize(NUM_MEM_ACCESS_TYPE);
+  m_fail_stats.resize(NUM_MEM_ACCESS_TYPE);
+  for (unsigned i = 0; i < NUM_MEM_ACCESS_TYPE; ++i) {
+    m_stats[i].resize(NUM_CACHE_REQUEST_STATUS, 0);
+    m_stats_pw[i].resize(NUM_CACHE_REQUEST_STATUS, 0);
+    m_fail_stats[i].resize(NUM_CACHE_RESERVATION_FAIL_STATUS, 0);
+  }
+  m_cache_port_available_cycles = 0;
+  m_cache_data_port_busy_cycles = 0;
+  m_cache_fill_port_busy_cycles = 0;
 }
 
-void mshr_table::display( FILE *fp ) const{
-    fprintf(fp,"MSHR contents\n");
-    for ( table::const_iterator e=m_data.begin(); e!=m_data.end(); ++e ) {
-        unsigned block_addr = e->first;
-        fprintf(fp,"MSHR: tag=0x%06x, atomic=%d %zu entries : ", block_addr, e->second.m_has_atomic, e->second.m_list.size());
-        if ( !e->second.m_list.empty() ) {
-            mem_fetch *mf = e->second.m_list.front();
-            fprintf(fp,"%p :",mf);
-            mf->print(fp);
-        } else {
-            fprintf(fp," no memory requests???\n");
-        }
+void cache_stats::clear() {
+  ///
+  /// Zero out all current cache statistics
+  ///
+  for (unsigned i = 0; i < NUM_MEM_ACCESS_TYPE; ++i) {
+    std::fill(m_stats[i].begin(), m_stats[i].end(), 0);
+    std::fill(m_fail_stats[i].begin(), m_fail_stats[i].end(), 0);
+  }
+  m_cache_port_available_cycles = 0;
+  m_cache_data_port_busy_cycles = 0;
+  m_cache_fill_port_busy_cycles = 0;
+}
+
+void cache_stats::clear_pw() {
+  ///
+  /// Zero out per-window cache statistics
+  ///
+  for (unsigned i = 0; i < NUM_MEM_ACCESS_TYPE; ++i) {
+    std::fill(m_stats_pw[i].begin(), m_stats_pw[i].end(), 0);
+  }
+}
+
+void cache_stats::inc_stats(int access_type, int access_outcome) {
+  ///
+  /// Increment the stat corresponding to (access_type, access_outcome) by 1.
+  ///
+  if (!check_valid(access_type, access_outcome))
+    assert(0 && "Unknown cache access type or access outcome");
+
+  m_stats[access_type][access_outcome]++;
+}
+
+void cache_stats::inc_stats_pw(int access_type, int access_outcome) {
+  ///
+  /// Increment the corresponding per-window cache stat
+  ///
+  if (!check_valid(access_type, access_outcome))
+    assert(0 && "Unknown cache access type or access outcome");
+  m_stats_pw[access_type][access_outcome]++;
+}
+
+void cache_stats::inc_fail_stats(int access_type, int fail_outcome) {
+  if (!check_fail_valid(access_type, fail_outcome))
+    assert(0 && "Unknown cache access type or access fail");
+
+  m_fail_stats[access_type][fail_outcome]++;
+}
+
+enum cache_request_status cache_stats::select_stats_status(
+    enum cache_request_status probe, enum cache_request_status access) const {
+  ///
+  /// This function selects how the cache access outcome should be counted.
+  /// HIT_RESERVED is considered as a MISS
+  /// in the cores, however, it should be counted as a HIT_RESERVED in the
+  /// caches.
+  ///
+  if (probe == HIT_RESERVED && access != RESERVATION_FAIL)
+    return probe;
+  else if (probe == SECTOR_MISS && access == MISS)
+    return probe;
+  else
+    return access;
+}
+
+unsigned long long &cache_stats::operator()(int access_type, int access_outcome,
+                                            bool fail_outcome) {
+  ///
+  /// Simple method to read/modify the stat corresponding to (access_type,
+  /// access_outcome)
+  /// Used overloaded () to avoid the need for separate read/write member
+  /// functions
+  ///
+  if (fail_outcome) {
+    if (!check_fail_valid(access_type, access_outcome))
+      assert(0 && "Unknown cache access type or fail outcome");
+
+    return m_fail_stats[access_type][access_outcome];
+  } else {
+    if (!check_valid(access_type, access_outcome))
+      assert(0 && "Unknown cache access type or access outcome");
+
+    return m_stats[access_type][access_outcome];
+  }
+}
+
+unsigned long long cache_stats::operator()(int access_type, int access_outcome,
+                                           bool fail_outcome) const {
+  ///
+  /// Const accessor into m_stats.
+  ///
+  if (fail_outcome) {
+    if (!check_fail_valid(access_type, access_outcome))
+      assert(0 && "Unknown cache access type or fail outcome");
+
+    return m_fail_stats[access_type][access_outcome];
+  } else {
+    if (!check_valid(access_type, access_outcome))
+      assert(0 && "Unknown cache access type or access outcome");
+
+    return m_stats[access_type][access_outcome];
+  }
+}
+
+cache_stats cache_stats::operator+(const cache_stats &cs) {
+  ///
+  /// Overloaded + operator to allow for simple stat accumulation
+  ///
+  cache_stats ret;
+  for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
+    for (unsigned status = 0; status < NUM_CACHE_REQUEST_STATUS; ++status) {
+      ret(type, status, false) =
+          m_stats[type][status] + cs(type, status, false);
     }
-}
-/***************************************************************** Caches *****************************************************************/
-cache_stats::cache_stats(){
-    m_stats.resize(NUM_MEM_ACCESS_TYPE);
-    m_stats_pw.resize(NUM_MEM_ACCESS_TYPE);
-    m_fail_stats.resize(NUM_MEM_ACCESS_TYPE);
-    for(unsigned i=0; i<NUM_MEM_ACCESS_TYPE; ++i){
-        m_stats[i].resize(NUM_CACHE_REQUEST_STATUS, 0);
-        m_stats_pw[i].resize(NUM_CACHE_REQUEST_STATUS, 0);
-		m_fail_stats[i].resize(NUM_CACHE_RESERVATION_FAIL_STATUS, 0);
-	}
-    m_cache_port_available_cycles = 0; 
-    m_cache_data_port_busy_cycles = 0; 
-    m_cache_fill_port_busy_cycles = 0; 
-}
-
-void cache_stats::clear(){
-    ///
-    /// Zero out all current cache statistics
-    ///
-    for(unsigned i=0; i<NUM_MEM_ACCESS_TYPE; ++i){
-        std::fill(m_stats[i].begin(), m_stats[i].end(), 0);
-		std::fill(m_fail_stats[i].begin(), m_fail_stats[i].end(), 0);
-	}
-    m_cache_port_available_cycles = 0; 
-    m_cache_data_port_busy_cycles = 0; 
-    m_cache_fill_port_busy_cycles = 0; 
-}
-
-void cache_stats::clear_pw(){
-    ///
-    /// Zero out per-window cache statistics
-    ///
-    for(unsigned i=0; i<NUM_MEM_ACCESS_TYPE; ++i){
-        std::fill(m_stats_pw[i].begin(), m_stats_pw[i].end(), 0);
-	}
-}
-
-void cache_stats::inc_stats(int access_type, int access_outcome){
-    ///
-    /// Increment the stat corresponding to (access_type, access_outcome) by 1.
-    ///
-    if(!check_valid(access_type, access_outcome))
-        assert(0 && "Unknown cache access type or access outcome");
-
-    m_stats[access_type][access_outcome]++;
-}
-
-void cache_stats::inc_stats_pw(int access_type, int access_outcome){
-    ///
-    /// Increment the corresponding per-window cache stat
-    ///
-    if(!check_valid(access_type, access_outcome))
-        assert(0 && "Unknown cache access type or access outcome");
-    m_stats_pw[access_type][access_outcome]++;
-}
-
-void cache_stats::inc_fail_stats(int access_type, int fail_outcome){
-
-	if(!check_fail_valid(access_type, fail_outcome))
-		 assert(0 && "Unknown cache access type or access fail");
-
-	m_fail_stats[access_type][fail_outcome]++;
-}
-
-
-enum cache_request_status cache_stats::select_stats_status(enum cache_request_status probe, enum cache_request_status access) const {
-	///
-	/// This function selects how the cache access outcome should be counted. HIT_RESERVED is considered as a MISS
-	/// in the cores, however, it should be counted as a HIT_RESERVED in the caches.
-	///
-	if(probe == HIT_RESERVED && access != RESERVATION_FAIL)
-		return probe;
-	else if(probe == SECTOR_MISS && access == MISS)
-		return probe;
-	else
-		return access;
-}
-
-unsigned long long &cache_stats::operator()(int access_type, int access_outcome, bool fail_outcome){
-    ///
-    /// Simple method to read/modify the stat corresponding to (access_type, access_outcome)
-    /// Used overloaded () to avoid the need for separate read/write member functions
-    ///
-	if(fail_outcome) {
-		if(!check_fail_valid(access_type, access_outcome))
-			assert(0 && "Unknown cache access type or fail outcome");
-
-		return m_fail_stats[access_type][access_outcome];
-	}
-	else {
-		if(!check_valid(access_type, access_outcome))
-			assert(0 && "Unknown cache access type or access outcome");
-
-		return m_stats[access_type][access_outcome];
-	}
-}
-
-unsigned long long cache_stats::operator()(int access_type, int access_outcome, bool fail_outcome) const{
-    ///
-    /// Const accessor into m_stats.
-    ///
-	if(fail_outcome) {
-		if(!check_fail_valid(access_type, access_outcome))
-			assert(0 && "Unknown cache access type or fail outcome");
-
-		return m_fail_stats[access_type][access_outcome];
-	}
-	else {
-		if(!check_valid(access_type, access_outcome))
-			assert(0 && "Unknown cache access type or access outcome");
-
-		return m_stats[access_type][access_outcome];
-	}
-}
-
-cache_stats cache_stats::operator+(const cache_stats &cs){
-    ///
-    /// Overloaded + operator to allow for simple stat accumulation
-    ///
-    cache_stats ret;
-    for(unsigned type=0; type<NUM_MEM_ACCESS_TYPE; ++type){
-        for(unsigned status=0; status<NUM_CACHE_REQUEST_STATUS; ++status){
-            ret(type, status, false) = m_stats[type][status] + cs(type, status, false);
-        }
-		for(unsigned status=0; status<NUM_CACHE_RESERVATION_FAIL_STATUS; ++status){
-			   ret(type, status, true) = m_fail_stats[type][status] + cs(type, status, true);
-		   }
-        }
-    ret.m_cache_port_available_cycles = m_cache_port_available_cycles + cs.m_cache_port_available_cycles; 
-    ret.m_cache_data_port_busy_cycles = m_cache_data_port_busy_cycles + cs.m_cache_data_port_busy_cycles; 
-    ret.m_cache_fill_port_busy_cycles = m_cache_fill_port_busy_cycles + cs.m_cache_fill_port_busy_cycles; 
-    return ret;
-}
-
-cache_stats &cache_stats::operator+=(const cache_stats &cs){
-    ///
-    /// Overloaded += operator to allow for simple stat accumulation
-    ///
-    for(unsigned type=0; type<NUM_MEM_ACCESS_TYPE; ++type){
-        for(unsigned status=0; status<NUM_CACHE_REQUEST_STATUS; ++status){
-            m_stats[type][status] += cs(type, status, false);
-        }
-        for(unsigned status=0; status<NUM_CACHE_REQUEST_STATUS; ++status){
-            m_stats_pw[type][status] += cs(type, status, false);
-        }
-        for(unsigned status=0; status<NUM_CACHE_RESERVATION_FAIL_STATUS; ++status){
-            m_fail_stats[type][status] += cs(type, status, true);
-	   }
+    for (unsigned status = 0; status < NUM_CACHE_RESERVATION_FAIL_STATUS;
+         ++status) {
+      ret(type, status, true) =
+          m_fail_stats[type][status] + cs(type, status, true);
     }
-    m_cache_port_available_cycles += cs.m_cache_port_available_cycles; 
-    m_cache_data_port_busy_cycles += cs.m_cache_data_port_busy_cycles; 
-    m_cache_fill_port_busy_cycles += cs.m_cache_fill_port_busy_cycles; 
-    return *this;
+  }
+  ret.m_cache_port_available_cycles =
+      m_cache_port_available_cycles + cs.m_cache_port_available_cycles;
+  ret.m_cache_data_port_busy_cycles =
+      m_cache_data_port_busy_cycles + cs.m_cache_data_port_busy_cycles;
+  ret.m_cache_fill_port_busy_cycles =
+      m_cache_fill_port_busy_cycles + cs.m_cache_fill_port_busy_cycles;
+  return ret;
 }
 
-void cache_stats::print_stats(FILE *fout, const char *cache_name) const{
-    ///
-    /// Print out each non-zero cache statistic for every memory access type and status
-    /// "cache_name" defaults to "Cache_stats" when no argument is provided, otherwise
-    /// the provided name is used.
-    /// The printed format is "<cache_name>[<request_type>][<request_status>] = <stat_value>"
-    ///
-    std::vector< unsigned > total_access;
-    total_access.resize(NUM_MEM_ACCESS_TYPE, 0);
-    std::string m_cache_name = cache_name;
-    for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
-        for (unsigned status = 0; status < NUM_CACHE_REQUEST_STATUS; ++status) {
-            fprintf(fout, "\t%s[%s][%s] = %llu\n",
-                m_cache_name.c_str(),
+cache_stats &cache_stats::operator+=(const cache_stats &cs) {
+  ///
+  /// Overloaded += operator to allow for simple stat accumulation
+  ///
+  for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
+    for (unsigned status = 0; status < NUM_CACHE_REQUEST_STATUS; ++status) {
+      m_stats[type][status] += cs(type, status, false);
+    }
+    for (unsigned status = 0; status < NUM_CACHE_REQUEST_STATUS; ++status) {
+      m_stats_pw[type][status] += cs(type, status, false);
+    }
+    for (unsigned status = 0; status < NUM_CACHE_RESERVATION_FAIL_STATUS;
+         ++status) {
+      m_fail_stats[type][status] += cs(type, status, true);
+    }
+  }
+  m_cache_port_available_cycles += cs.m_cache_port_available_cycles;
+  m_cache_data_port_busy_cycles += cs.m_cache_data_port_busy_cycles;
+  m_cache_fill_port_busy_cycles += cs.m_cache_fill_port_busy_cycles;
+  return *this;
+}
+
+void cache_stats::print_stats(FILE *fout, const char *cache_name) const {
+  ///
+  /// Print out each non-zero cache statistic for every memory access type and
+  /// status
+  /// "cache_name" defaults to "Cache_stats" when no argument is provided,
+  /// otherwise
+  /// the provided name is used.
+  /// The printed format is "<cache_name>[<request_type>][<request_status>] =
+  /// <stat_value>"
+  ///
+  std::vector<unsigned> total_access;
+  total_access.resize(NUM_MEM_ACCESS_TYPE, 0);
+  std::string m_cache_name = cache_name;
+  for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
+    for (unsigned status = 0; status < NUM_CACHE_REQUEST_STATUS; ++status) {
+      fprintf(fout, "\t%s[%s][%s] = %llu\n", m_cache_name.c_str(),
+              mem_access_type_str((enum mem_access_type)type),
+              cache_request_status_str((enum cache_request_status)status),
+              m_stats[type][status]);
+
+      if (status != RESERVATION_FAIL)
+        total_access[type] += m_stats[type][status];
+    }
+  }
+  for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
+    if (total_access[type] > 0)
+      fprintf(fout, "\t%s[%s][%s] = %u\n", m_cache_name.c_str(),
+              mem_access_type_str((enum mem_access_type)type), "TOTAL_ACCESS",
+              total_access[type]);
+  }
+}
+
+void cache_stats::print_fail_stats(FILE *fout, const char *cache_name) const {
+  std::string m_cache_name = cache_name;
+  for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
+    for (unsigned fail = 0; fail < NUM_CACHE_RESERVATION_FAIL_STATUS; ++fail) {
+      if (m_fail_stats[type][fail] > 0) {
+        fprintf(fout, "\t%s[%s][%s] = %llu\n", m_cache_name.c_str(),
                 mem_access_type_str((enum mem_access_type)type),
-                cache_request_status_str((enum cache_request_status)status),
-                m_stats[type][status]);
+                cache_fail_status_str((enum cache_reservation_fail_reason)fail),
+                m_fail_stats[type][fail]);
+      }
+    }
+  }
+}
 
-            if(status != RESERVATION_FAIL)
-            	 total_access[type]+= m_stats[type][status];
+void cache_sub_stats::print_port_stats(FILE *fout,
+                                       const char *cache_name) const {
+  float data_port_util = 0.0f;
+  if (port_available_cycles > 0) {
+    data_port_util = (float)data_port_busy_cycles / port_available_cycles;
+  }
+  fprintf(fout, "%s_data_port_util = %.3f\n", cache_name, data_port_util);
+  float fill_port_util = 0.0f;
+  if (port_available_cycles > 0) {
+    fill_port_util = (float)fill_port_busy_cycles / port_available_cycles;
+  }
+  fprintf(fout, "%s_fill_port_util = %.3f\n", cache_name, fill_port_util);
+}
+
+unsigned long long cache_stats::get_stats(
+    enum mem_access_type *access_type, unsigned num_access_type,
+    enum cache_request_status *access_status,
+    unsigned num_access_status) const {
+  ///
+  /// Returns a sum of the stats corresponding to each "access_type" and
+  /// "access_status" pair.
+  /// "access_type" is an array of "num_access_type" mem_access_types.
+  /// "access_status" is an array of "num_access_status" cache_request_statuses.
+  ///
+  unsigned long long total = 0;
+  for (unsigned type = 0; type < num_access_type; ++type) {
+    for (unsigned status = 0; status < num_access_status; ++status) {
+      if (!check_valid((int)access_type[type], (int)access_status[status]))
+        assert(0 && "Unknown cache access type or access outcome");
+      total += m_stats[access_type[type]][access_status[status]];
+    }
+  }
+  return total;
+}
+
+void cache_stats::get_sub_stats(struct cache_sub_stats &css) const {
+  ///
+  /// Overwrites "css" with the appropriate statistics from this cache.
+  ///
+  struct cache_sub_stats t_css;
+  t_css.clear();
+
+  for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
+    for (unsigned status = 0; status < NUM_CACHE_REQUEST_STATUS; ++status) {
+      if (status == HIT || status == MISS || status == SECTOR_MISS ||
+          status == HIT_RESERVED)
+        t_css.accesses += m_stats[type][status];
+
+      if (status == MISS || status == SECTOR_MISS)
+        t_css.misses += m_stats[type][status];
+
+      if (status == HIT_RESERVED) t_css.pending_hits += m_stats[type][status];
+
+      if (status == RESERVATION_FAIL) t_css.res_fails += m_stats[type][status];
+    }
+  }
+
+  t_css.port_available_cycles = m_cache_port_available_cycles;
+  t_css.data_port_busy_cycles = m_cache_data_port_busy_cycles;
+  t_css.fill_port_busy_cycles = m_cache_fill_port_busy_cycles;
+
+  css = t_css;
+}
+
+void cache_stats::get_sub_stats_pw(struct cache_sub_stats_pw &css) const {
+  ///
+  /// Overwrites "css" with the appropriate statistics from this cache.
+  ///
+  struct cache_sub_stats_pw t_css;
+  t_css.clear();
+
+  for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
+    for (unsigned status = 0; status < NUM_CACHE_REQUEST_STATUS; ++status) {
+      if (status == HIT || status == MISS || status == SECTOR_MISS ||
+          status == HIT_RESERVED)
+        t_css.accesses += m_stats_pw[type][status];
+
+      if (status == HIT) {
+        if (type == GLOBAL_ACC_R || type == CONST_ACC_R || type == INST_ACC_R) {
+          t_css.read_hits += m_stats_pw[type][status];
+        } else if (type == GLOBAL_ACC_W) {
+          t_css.write_hits += m_stats_pw[type][status];
         }
-    }
-    for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
-    	 if(total_access[type] > 0)
-    	  fprintf(fout, "\t%s[%s][%s] = %u\n",
-				m_cache_name.c_str(),
-				mem_access_type_str((enum mem_access_type)type),
-				"TOTAL_ACCESS",
-				total_access[type]);
-    }
-}
+      }
 
-void cache_stats::print_fail_stats(FILE *fout, const char *cache_name) const{
-	std::string m_cache_name = cache_name;
-	    for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
-	        for (unsigned fail = 0; fail < NUM_CACHE_RESERVATION_FAIL_STATUS; ++fail) {
-	            if(m_fail_stats[type][fail] > 0){
-	                fprintf(fout, "\t%s[%s][%s] = %llu\n",
-	                    m_cache_name.c_str(),
-	                    mem_access_type_str((enum mem_access_type)type),
-						cache_fail_status_str((enum cache_reservation_fail_reason)fail),
-						m_fail_stats[type][fail]);
-	            }
-	        }
-	    }
-}
-
-void cache_sub_stats::print_port_stats(FILE *fout, const char *cache_name) const
-{
-    float data_port_util = 0.0f; 
-    if (port_available_cycles > 0) {
-        data_port_util = (float) data_port_busy_cycles / port_available_cycles; 
-    }
-    fprintf(fout, "%s_data_port_util = %.3f\n", cache_name, data_port_util); 
-    float fill_port_util = 0.0f; 
-    if (port_available_cycles > 0) {
-        fill_port_util = (float) fill_port_busy_cycles / port_available_cycles; 
-    }
-    fprintf(fout, "%s_fill_port_util = %.3f\n", cache_name, fill_port_util); 
-}
-
-unsigned long long cache_stats::get_stats(enum mem_access_type *access_type, unsigned num_access_type, enum cache_request_status *access_status, unsigned num_access_status) const{
-    ///
-    /// Returns a sum of the stats corresponding to each "access_type" and "access_status" pair.
-    /// "access_type" is an array of "num_access_type" mem_access_types.
-    /// "access_status" is an array of "num_access_status" cache_request_statuses.
-    ///
-    unsigned long long total=0;
-    for(unsigned type =0; type < num_access_type; ++type){
-        for(unsigned status=0; status < num_access_status; ++status){
-            if(!check_valid((int)access_type[type], (int)access_status[status]))
-                assert(0 && "Unknown cache access type or access outcome");
-            total += m_stats[access_type[type]][access_status[status]];
+      if (status == MISS || status == SECTOR_MISS) {
+        if (type == GLOBAL_ACC_R || type == CONST_ACC_R || type == INST_ACC_R) {
+          t_css.read_misses += m_stats_pw[type][status];
+        } else if (type == GLOBAL_ACC_W) {
+          t_css.write_misses += m_stats_pw[type][status];
         }
-    }
-    return total;
-}
+      }
 
-void cache_stats::get_sub_stats(struct cache_sub_stats &css) const{
-    ///
-    /// Overwrites "css" with the appropriate statistics from this cache.
-    ///
-    struct cache_sub_stats t_css;
-    t_css.clear();
-
-    for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
-        for (unsigned status = 0; status < NUM_CACHE_REQUEST_STATUS; ++status) {
-            if(status == HIT || status == MISS || status == SECTOR_MISS || status == HIT_RESERVED)
-                t_css.accesses += m_stats[type][status];
-
-            if(status == MISS || status == SECTOR_MISS)
-                t_css.misses += m_stats[type][status];
-
-            if(status == HIT_RESERVED)
-                t_css.pending_hits += m_stats[type][status];
-
-            if(status == RESERVATION_FAIL)
-                t_css.res_fails += m_stats[type][status];
+      if (status == HIT_RESERVED) {
+        if (type == GLOBAL_ACC_R || type == CONST_ACC_R || type == INST_ACC_R) {
+          t_css.read_pending_hits += m_stats_pw[type][status];
+        } else if (type == GLOBAL_ACC_W) {
+          t_css.write_pending_hits += m_stats_pw[type][status];
         }
-    }
+      }
 
-    t_css.port_available_cycles = m_cache_port_available_cycles; 
-    t_css.data_port_busy_cycles = m_cache_data_port_busy_cycles; 
-    t_css.fill_port_busy_cycles = m_cache_fill_port_busy_cycles; 
-
-    css = t_css;
-}
-
-void cache_stats::get_sub_stats_pw(struct cache_sub_stats_pw &css) const{
-    ///
-    /// Overwrites "css" with the appropriate statistics from this cache.
-    ///
-    struct cache_sub_stats_pw t_css;
-    t_css.clear();
-
-    for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
-        for (unsigned status = 0; status < NUM_CACHE_REQUEST_STATUS; ++status) {
-            if(status == HIT || status == MISS || status == SECTOR_MISS || status == HIT_RESERVED)
-                t_css.accesses += m_stats_pw[type][status];
-
-            if(status == HIT){
-                if(type == GLOBAL_ACC_R || type == CONST_ACC_R || type == INST_ACC_R){
-                    t_css.read_hits += m_stats_pw[type][status];
-                } else if(type == GLOBAL_ACC_W){
-                    t_css.write_hits += m_stats_pw[type][status];
-                }
-            }
-
-            if(status == MISS || status == SECTOR_MISS){
-                if(type == GLOBAL_ACC_R || type == CONST_ACC_R || type == INST_ACC_R){
-                    t_css.read_misses += m_stats_pw[type][status];
-                } else if(type == GLOBAL_ACC_W){
-                    t_css.write_misses += m_stats_pw[type][status];
-                }
-            }
-
-            if(status == HIT_RESERVED){
-                if(type == GLOBAL_ACC_R || type == CONST_ACC_R || type == INST_ACC_R){
-                    t_css.read_pending_hits += m_stats_pw[type][status];
-                } else if(type == GLOBAL_ACC_W){
-                    t_css.write_pending_hits += m_stats_pw[type][status];
-                }
-            }
-
-            if(status == RESERVATION_FAIL){
-                if(type == GLOBAL_ACC_R || type == CONST_ACC_R || type == INST_ACC_R){
-                    t_css.read_res_fails += m_stats_pw[type][status];
-                } else if(type == GLOBAL_ACC_W){
-                    t_css.write_res_fails += m_stats_pw[type][status];
-                }
-            }
+      if (status == RESERVATION_FAIL) {
+        if (type == GLOBAL_ACC_R || type == CONST_ACC_R || type == INST_ACC_R) {
+          t_css.read_res_fails += m_stats_pw[type][status];
+        } else if (type == GLOBAL_ACC_W) {
+          t_css.write_res_fails += m_stats_pw[type][status];
         }
+      }
     }
+  }
 
-    css = t_css;
+  css = t_css;
 }
 
-bool cache_stats::check_valid(int type, int status) const{
-    ///
-    /// Verify a valid access_type/access_status
-    ///
-    if((type >= 0) && (type < NUM_MEM_ACCESS_TYPE) && (status >= 0) && (status < NUM_CACHE_REQUEST_STATUS))
-        return true;
-    else
-        return false;
+bool cache_stats::check_valid(int type, int status) const {
+  ///
+  /// Verify a valid access_type/access_status
+  ///
+  if ((type >= 0) && (type < NUM_MEM_ACCESS_TYPE) && (status >= 0) &&
+      (status < NUM_CACHE_REQUEST_STATUS))
+    return true;
+  else
+    return false;
 }
 
-bool cache_stats::check_fail_valid(int type, int fail) const{
-    ///
-    /// Verify a valid access_type/access_status
-    ///
-    if((type >= 0) && (type < NUM_MEM_ACCESS_TYPE) && (fail >= 0) && (fail < NUM_CACHE_RESERVATION_FAIL_STATUS))
-        return true;
-    else
-        return false;
+bool cache_stats::check_fail_valid(int type, int fail) const {
+  ///
+  /// Verify a valid access_type/access_status
+  ///
+  if ((type >= 0) && (type < NUM_MEM_ACCESS_TYPE) && (fail >= 0) &&
+      (fail < NUM_CACHE_RESERVATION_FAIL_STATUS))
+    return true;
+  else
+    return false;
 }
 
-void cache_stats::sample_cache_port_utility(bool data_port_busy, bool fill_port_busy) 
-{
-    m_cache_port_available_cycles += 1; 
-    if (data_port_busy) {
-        m_cache_data_port_busy_cycles += 1; 
-    } 
-    if (fill_port_busy) {
-        m_cache_fill_port_busy_cycles += 1; 
-    } 
+void cache_stats::sample_cache_port_utility(bool data_port_busy,
+                                            bool fill_port_busy) {
+  m_cache_port_available_cycles += 1;
+  if (data_port_busy) {
+    m_cache_data_port_busy_cycles += 1;
+  }
+  if (fill_port_busy) {
+    m_cache_fill_port_busy_cycles += 1;
+  }
 }
 
-baseline_cache::bandwidth_management::bandwidth_management(cache_config &config) 
-: m_config(config)
-{
-    m_data_port_occupied_cycles = 0; 
-    m_fill_port_occupied_cycles = 0; 
+baseline_cache::bandwidth_management::bandwidth_management(cache_config &config)
+    : m_config(config) {
+  m_data_port_occupied_cycles = 0;
+  m_fill_port_occupied_cycles = 0;
 }
 
-/// use the data port based on the outcome and events generated by the mem_fetch request 
-void baseline_cache::bandwidth_management::use_data_port(mem_fetch *mf, enum cache_request_status outcome, const std::list<cache_event> &events)
-{
-    unsigned data_size = mf->get_data_size(); 
-    unsigned port_width = m_config.m_data_port_width; 
-    switch (outcome) {
+/// use the data port based on the outcome and events generated by the mem_fetch
+/// request
+void baseline_cache::bandwidth_management::use_data_port(
+    mem_fetch *mf, enum cache_request_status outcome,
+    const std::list<cache_event> &events) {
+  unsigned data_size = mf->get_data_size();
+  unsigned port_width = m_config.m_data_port_width;
+  switch (outcome) {
     case HIT: {
-        unsigned data_cycles = data_size / port_width + ((data_size % port_width > 0)? 1 : 0); 
-        m_data_port_occupied_cycles += data_cycles; 
-        } break; 
+      unsigned data_cycles =
+          data_size / port_width + ((data_size % port_width > 0) ? 1 : 0);
+      m_data_port_occupied_cycles += data_cycles;
+    } break;
     case HIT_RESERVED:
     case MISS: {
-        // the data array is accessed to read out the entire line for write-back 
-    	// in case of sector cache we need to write bank only the modified sectors
-    	cache_event ev(WRITE_BACK_REQUEST_SENT);
-        if (was_writeback_sent(events, ev)) {
-            unsigned data_cycles = ev.m_evicted_block.m_modified_size / port_width;
-            m_data_port_occupied_cycles += data_cycles; 
-        }
-        } break; 
+      // the data array is accessed to read out the entire line for write-back
+      // in case of sector cache we need to write bank only the modified sectors
+      cache_event ev(WRITE_BACK_REQUEST_SENT);
+      if (was_writeback_sent(events, ev)) {
+        unsigned data_cycles = ev.m_evicted_block.m_modified_size / port_width;
+        m_data_port_occupied_cycles += data_cycles;
+      }
+    } break;
     case SECTOR_MISS:
     case RESERVATION_FAIL:
-        // Does not consume any port bandwidth 
-        break; 
-    default: 
-        assert(0); 
-        break; 
-    } 
+      // Does not consume any port bandwidth
+      break;
+    default:
+      assert(0);
+      break;
+  }
 }
 
-/// use the fill port 
-void baseline_cache::bandwidth_management::use_fill_port(mem_fetch *mf)
-{
-    // assume filling the entire line with the returned request 
-    unsigned fill_cycles = m_config.get_atom_sz() / m_config.m_data_port_width;
-    m_fill_port_occupied_cycles += fill_cycles; 
+/// use the fill port
+void baseline_cache::bandwidth_management::use_fill_port(mem_fetch *mf) {
+  // assume filling the entire line with the returned request
+  unsigned fill_cycles = m_config.get_atom_sz() / m_config.m_data_port_width;
+  m_fill_port_occupied_cycles += fill_cycles;
 }
 
-/// called every cache cycle to free up the ports 
-void baseline_cache::bandwidth_management::replenish_port_bandwidth()
-{
-    if (m_data_port_occupied_cycles > 0) {
-        m_data_port_occupied_cycles -= 1; 
-    }
-    assert(m_data_port_occupied_cycles >= 0); 
+/// called every cache cycle to free up the ports
+void baseline_cache::bandwidth_management::replenish_port_bandwidth() {
+  if (m_data_port_occupied_cycles > 0) {
+    m_data_port_occupied_cycles -= 1;
+  }
+  assert(m_data_port_occupied_cycles >= 0);
 
-    if (m_fill_port_occupied_cycles > 0) {
-        m_fill_port_occupied_cycles -= 1; 
-    }
-    assert(m_fill_port_occupied_cycles >= 0); 
+  if (m_fill_port_occupied_cycles > 0) {
+    m_fill_port_occupied_cycles -= 1;
+  }
+  assert(m_fill_port_occupied_cycles >= 0);
 }
 
-/// query for data port availability 
-bool baseline_cache::bandwidth_management::data_port_free() const
-{
-    return (m_data_port_occupied_cycles == 0); 
+/// query for data port availability
+bool baseline_cache::bandwidth_management::data_port_free() const {
+  return (m_data_port_occupied_cycles == 0);
 }
 
-/// query for fill port availability 
-bool baseline_cache::bandwidth_management::fill_port_free() const
-{
-    return (m_fill_port_occupied_cycles == 0); 
+/// query for fill port availability
+bool baseline_cache::bandwidth_management::fill_port_free() const {
+  return (m_fill_port_occupied_cycles == 0);
 }
 
 /// Sends next request to lower level of memory
-void baseline_cache::cycle(){
-    if ( !m_miss_queue.empty() ) {
-        mem_fetch *mf = m_miss_queue.front();
-        if ( !m_memport->full(mf->size(),mf->get_is_write()) ) {
-            m_miss_queue.pop_front();
-            m_memport->push(mf);
-        }
+void baseline_cache::cycle() {
+  if (!m_miss_queue.empty()) {
+    mem_fetch *mf = m_miss_queue.front();
+    if (!m_memport->full(mf->size(), mf->get_is_write())) {
+      m_miss_queue.pop_front();
+      m_memport->push(mf);
     }
-    bool data_port_busy = !m_bandwidth_management.data_port_free(); 
-    bool fill_port_busy = !m_bandwidth_management.fill_port_free(); 
-    m_stats.sample_cache_port_utility(data_port_busy, fill_port_busy); 
-    m_bandwidth_management.replenish_port_bandwidth(); 
+  }
+  bool data_port_busy = !m_bandwidth_management.data_port_free();
+  bool fill_port_busy = !m_bandwidth_management.fill_port_free();
+  m_stats.sample_cache_port_utility(data_port_busy, fill_port_busy);
+  m_bandwidth_management.replenish_port_bandwidth();
 }
 
-/// Interface for response from lower memory level (model bandwidth restictions in caller)
-void baseline_cache::fill(mem_fetch *mf, unsigned time){
-
-	if(m_config.m_mshr_type == SECTOR_ASSOC) {
-	assert(mf->get_original_mf());
-	extra_mf_fields_lookup::iterator e = m_extra_mf_fields.find(mf->get_original_mf());
-    assert( e != m_extra_mf_fields.end() );
+/// Interface for response from lower memory level (model bandwidth restictions
+/// in caller)
+void baseline_cache::fill(mem_fetch *mf, unsigned time) {
+  if (m_config.m_mshr_type == SECTOR_ASSOC) {
+    assert(mf->get_original_mf());
+    extra_mf_fields_lookup::iterator e =
+        m_extra_mf_fields.find(mf->get_original_mf());
+    assert(e != m_extra_mf_fields.end());
     e->second.pending_read--;
 
-    if(e->second.pending_read > 0) {
-    	//wait for the other requests to come back
-    	delete mf;
-    	return;
-      } else {
-    	mem_fetch *temp = mf;
-    	mf = mf->get_original_mf();
-    	delete temp;
-      }
-	}
+    if (e->second.pending_read > 0) {
+      // wait for the other requests to come back
+      delete mf;
+      return;
+    } else {
+      mem_fetch *temp = mf;
+      mf = mf->get_original_mf();
+      delete temp;
+    }
+  }
 
-    extra_mf_fields_lookup::iterator e = m_extra_mf_fields.find(mf);
-    assert( e != m_extra_mf_fields.end() );
-    assert( e->second.m_valid );
-    mf->set_data_size( e->second.m_data_size );
-    mf->set_addr( e->second.m_addr );
-    if ( m_config.m_alloc_policy == ON_MISS )
-        m_tag_array->fill(e->second.m_cache_index,time,mf);
-    else if ( m_config.m_alloc_policy == ON_FILL ) {
-        m_tag_array->fill(e->second.m_block_addr,time,mf);
-        if(m_config.is_streaming())
-        	m_tag_array->remove_pending_line(mf);
-    }
-    else abort();
-    bool has_atomic = false;
-    m_mshrs.mark_ready(e->second.m_block_addr, has_atomic);
-    if (has_atomic) {
-        assert(m_config.m_alloc_policy == ON_MISS);
-        cache_block_t* block = m_tag_array->get_block(e->second.m_cache_index);
-        block->set_status(MODIFIED, mf->get_access_sector_mask()); // mark line as dirty for atomic operation
-    }
-    m_extra_mf_fields.erase(mf);
-    m_bandwidth_management.use_fill_port(mf); 
+  extra_mf_fields_lookup::iterator e = m_extra_mf_fields.find(mf);
+  assert(e != m_extra_mf_fields.end());
+  assert(e->second.m_valid);
+  mf->set_data_size(e->second.m_data_size);
+  mf->set_addr(e->second.m_addr);
+  if (m_config.m_alloc_policy == ON_MISS)
+    m_tag_array->fill(e->second.m_cache_index, time, mf);
+  else if (m_config.m_alloc_policy == ON_FILL) {
+    m_tag_array->fill(e->second.m_block_addr, time, mf);
+    if (m_config.is_streaming()) m_tag_array->remove_pending_line(mf);
+  } else
+    abort();
+  bool has_atomic = false;
+  m_mshrs.mark_ready(e->second.m_block_addr, has_atomic);
+  if (has_atomic) {
+    assert(m_config.m_alloc_policy == ON_MISS);
+    cache_block_t *block = m_tag_array->get_block(e->second.m_cache_index);
+    block->set_status(MODIFIED, mf->get_access_sector_mask());  // mark line as
+                                                                // dirty for
+                                                                // atomic
+                                                                // operation
+  }
+  m_extra_mf_fields.erase(mf);
+  m_bandwidth_management.use_fill_port(mf);
 }
 
 /// Checks if mf is waiting to be filled by lower memory level
-bool baseline_cache::waiting_for_fill( mem_fetch *mf ){
-    extra_mf_fields_lookup::iterator e = m_extra_mf_fields.find(mf);
-    return e != m_extra_mf_fields.end();
+bool baseline_cache::waiting_for_fill(mem_fetch *mf) {
+  extra_mf_fields_lookup::iterator e = m_extra_mf_fields.find(mf);
+  return e != m_extra_mf_fields.end();
 }
 
-void baseline_cache::print(FILE *fp, unsigned &accesses, unsigned &misses) const{
-    fprintf( fp, "Cache %s:\t", m_name.c_str() );
-    m_tag_array->print(fp,accesses,misses);
+void baseline_cache::print(FILE *fp, unsigned &accesses,
+                           unsigned &misses) const {
+  fprintf(fp, "Cache %s:\t", m_name.c_str());
+  m_tag_array->print(fp, accesses, misses);
 }
 
-void baseline_cache::display_state( FILE *fp ) const{
-    fprintf(fp,"Cache %s:\n", m_name.c_str() );
-    m_mshrs.display(fp);
-    fprintf(fp,"\n");
+void baseline_cache::display_state(FILE *fp) const {
+  fprintf(fp, "Cache %s:\n", m_name.c_str());
+  m_mshrs.display(fp);
+  fprintf(fp, "\n");
 }
 
 /// Read miss handler without writeback
-void baseline_cache::send_read_request(new_addr_type addr, new_addr_type block_addr, unsigned cache_index, mem_fetch *mf,
-		unsigned time, bool &do_miss, std::list<cache_event> &events, bool read_only, bool wa){
-
-	bool wb=false;
-	evicted_block_info e;
-	send_read_request(addr, block_addr, cache_index, mf, time, do_miss, wb, e, events, read_only, wa);
+void baseline_cache::send_read_request(new_addr_type addr,
+                                       new_addr_type block_addr,
+                                       unsigned cache_index, mem_fetch *mf,
+                                       unsigned time, bool &do_miss,
+                                       std::list<cache_event> &events,
+                                       bool read_only, bool wa) {
+  bool wb = false;
+  evicted_block_info e;
+  send_read_request(addr, block_addr, cache_index, mf, time, do_miss, wb, e,
+                    events, read_only, wa);
 }
 
 /// Read miss handler. Check MSHR hit or MSHR available
-void baseline_cache::send_read_request(new_addr_type addr, new_addr_type block_addr, unsigned cache_index, mem_fetch *mf,
-		unsigned time, bool &do_miss, bool &wb, evicted_block_info &evicted, std::list<cache_event> &events, bool read_only, bool wa){
-
-	new_addr_type mshr_addr = m_config.mshr_addr(mf->get_addr());
-    bool mshr_hit = m_mshrs.probe(mshr_addr);
-    bool mshr_avail = !m_mshrs.full(mshr_addr);
-    if ( mshr_hit && mshr_avail ) {
-    	if(read_only)
-    		m_tag_array->access(block_addr,time,cache_index,mf);
-    	else
-    		m_tag_array->access(block_addr,time,cache_index,wb,evicted,mf);
-
-        m_mshrs.add(mshr_addr,mf);
-        do_miss = true;
-
-    } else if ( !mshr_hit && mshr_avail && (m_miss_queue.size() < m_config.m_miss_queue_size) ) {
-    	if(read_only)
-    		m_tag_array->access(block_addr,time,cache_index,mf);
-    	else
-    		m_tag_array->access(block_addr,time,cache_index,wb,evicted,mf);
-
-        m_mshrs.add(mshr_addr,mf);
-        if(m_config.is_streaming() && m_config.m_cache_type == SECTOR){
-			m_tag_array->add_pending_line(mf);
-		}
-        m_extra_mf_fields[mf] = extra_mf_fields(mshr_addr,mf->get_addr(),cache_index, mf->get_data_size(), m_config);
-        mf->set_data_size( m_config.get_atom_sz() );
-        mf->set_addr( mshr_addr );
-        m_miss_queue.push_back(mf);
-        mf->set_status(m_miss_queue_status,time);
-        if(!wa)
-        	events.push_back(cache_event(READ_REQUEST_SENT));
-
-        do_miss = true;
-    }
-    else if(mshr_hit && !mshr_avail)
-        m_stats.inc_fail_stats(mf->get_access_type(), MSHR_MERGE_ENRTY_FAIL);
-    else if (!mshr_hit && !mshr_avail)
-    	 m_stats.inc_fail_stats(mf->get_access_type(), MSHR_ENRTY_FAIL);
+void baseline_cache::send_read_request(new_addr_type addr,
+                                       new_addr_type block_addr,
+                                       unsigned cache_index, mem_fetch *mf,
+                                       unsigned time, bool &do_miss, bool &wb,
+                                       evicted_block_info &evicted,
+                                       std::list<cache_event> &events,
+                                       bool read_only, bool wa) {
+  new_addr_type mshr_addr = m_config.mshr_addr(mf->get_addr());
+  bool mshr_hit = m_mshrs.probe(mshr_addr);
+  bool mshr_avail = !m_mshrs.full(mshr_addr);
+  if (mshr_hit && mshr_avail) {
+    if (read_only)
+      m_tag_array->access(block_addr, time, cache_index, mf);
     else
-    	assert(0);
-}
+      m_tag_array->access(block_addr, time, cache_index, wb, evicted, mf);
 
+    m_mshrs.add(mshr_addr, mf);
+    do_miss = true;
+
+  } else if (!mshr_hit && mshr_avail &&
+             (m_miss_queue.size() < m_config.m_miss_queue_size)) {
+    if (read_only)
+      m_tag_array->access(block_addr, time, cache_index, mf);
+    else
+      m_tag_array->access(block_addr, time, cache_index, wb, evicted, mf);
+
+    m_mshrs.add(mshr_addr, mf);
+    if (m_config.is_streaming() && m_config.m_cache_type == SECTOR) {
+      m_tag_array->add_pending_line(mf);
+    }
+    m_extra_mf_fields[mf] = extra_mf_fields(
+        mshr_addr, mf->get_addr(), cache_index, mf->get_data_size(), m_config);
+    mf->set_data_size(m_config.get_atom_sz());
+    mf->set_addr(mshr_addr);
+    m_miss_queue.push_back(mf);
+    mf->set_status(m_miss_queue_status, time);
+    if (!wa) events.push_back(cache_event(READ_REQUEST_SENT));
+
+    do_miss = true;
+  } else if (mshr_hit && !mshr_avail)
+    m_stats.inc_fail_stats(mf->get_access_type(), MSHR_MERGE_ENRTY_FAIL);
+  else if (!mshr_hit && !mshr_avail)
+    m_stats.inc_fail_stats(mf->get_access_type(), MSHR_ENRTY_FAIL);
+  else
+    assert(0);
+}
 
 /// Sends write request to lower level memory (write or writeback)
-void data_cache::send_write_request(mem_fetch *mf, cache_event request, unsigned time, std::list<cache_event> &events){
-
-	events.push_back(request);
-    m_miss_queue.push_back(mf);
-    mf->set_status(m_miss_queue_status,time);
+void data_cache::send_write_request(mem_fetch *mf, cache_event request,
+                                    unsigned time,
+                                    std::list<cache_event> &events) {
+  events.push_back(request);
+  m_miss_queue.push_back(mf);
+  mf->set_status(m_miss_queue_status, time);
 }
-
 
 /****** Write-hit functions (Set by config file) ******/
 
 /// Write-back hit: Mark block as modified
-cache_request_status data_cache::wr_hit_wb(new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time, std::list<cache_event> &events, enum cache_request_status status ){
-	new_addr_type block_addr = m_config.block_addr(addr);
-	m_tag_array->access(block_addr,time,cache_index,mf); // update LRU state
-	cache_block_t* block = m_tag_array->get_block(cache_index);
-	block->set_status(MODIFIED, mf->get_access_sector_mask());
+cache_request_status data_cache::wr_hit_wb(new_addr_type addr,
+                                           unsigned cache_index, mem_fetch *mf,
+                                           unsigned time,
+                                           std::list<cache_event> &events,
+                                           enum cache_request_status status) {
+  new_addr_type block_addr = m_config.block_addr(addr);
+  m_tag_array->access(block_addr, time, cache_index, mf);  // update LRU state
+  cache_block_t *block = m_tag_array->get_block(cache_index);
+  block->set_status(MODIFIED, mf->get_access_sector_mask());
 
-	return HIT;
+  return HIT;
 }
 
 /// Write-through hit: Directly send request to lower level memory
-cache_request_status data_cache::wr_hit_wt(new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time, std::list<cache_event> &events, enum cache_request_status status ){
-	if(miss_queue_full(0)) {
-		m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
-		return RESERVATION_FAIL; // cannot handle request this cycle
-	}
+cache_request_status data_cache::wr_hit_wt(new_addr_type addr,
+                                           unsigned cache_index, mem_fetch *mf,
+                                           unsigned time,
+                                           std::list<cache_event> &events,
+                                           enum cache_request_status status) {
+  if (miss_queue_full(0)) {
+    m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
+    return RESERVATION_FAIL;  // cannot handle request this cycle
+  }
 
-	new_addr_type block_addr = m_config.block_addr(addr);
-	m_tag_array->access(block_addr,time,cache_index,mf); // update LRU state
-	cache_block_t* block = m_tag_array->get_block(cache_index);
-	block->set_status(MODIFIED, mf->get_access_sector_mask());
+  new_addr_type block_addr = m_config.block_addr(addr);
+  m_tag_array->access(block_addr, time, cache_index, mf);  // update LRU state
+  cache_block_t *block = m_tag_array->get_block(cache_index);
+  block->set_status(MODIFIED, mf->get_access_sector_mask());
 
-	// generate a write-through
-	send_write_request(mf, cache_event(WRITE_REQUEST_SENT), time, events);
+  // generate a write-through
+  send_write_request(mf, cache_event(WRITE_REQUEST_SENT), time, events);
 
-	return HIT;
+  return HIT;
 }
 
-/// Write-evict hit: Send request to lower level memory and invalidate corresponding block
-cache_request_status data_cache::wr_hit_we(new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time, std::list<cache_event> &events, enum cache_request_status status ){
-	if(miss_queue_full(0)) {
-		m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
-		return RESERVATION_FAIL; // cannot handle request this cycle
-	}
+/// Write-evict hit: Send request to lower level memory and invalidate
+/// corresponding block
+cache_request_status data_cache::wr_hit_we(new_addr_type addr,
+                                           unsigned cache_index, mem_fetch *mf,
+                                           unsigned time,
+                                           std::list<cache_event> &events,
+                                           enum cache_request_status status) {
+  if (miss_queue_full(0)) {
+    m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
+    return RESERVATION_FAIL;  // cannot handle request this cycle
+  }
 
-	// generate a write-through/evict
-	cache_block_t* block = m_tag_array->get_block(cache_index);
-	send_write_request(mf, cache_event(WRITE_REQUEST_SENT), time, events);
+  // generate a write-through/evict
+  cache_block_t *block = m_tag_array->get_block(cache_index);
+  send_write_request(mf, cache_event(WRITE_REQUEST_SENT), time, events);
 
-	// Invalidate block
-	block->set_status(INVALID, mf->get_access_sector_mask());
+  // Invalidate block
+  block->set_status(INVALID, mf->get_access_sector_mask());
 
-	return HIT;
+  return HIT;
 }
 
 /// Global write-evict, local write-back: Useful for private caches
-enum cache_request_status data_cache::wr_hit_global_we_local_wb(new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time, std::list<cache_event> &events, enum cache_request_status status ){
-	bool evict = (mf->get_access_type() == GLOBAL_ACC_W); // evict a line that hits on global memory write
-	if(evict)
-		return wr_hit_we(addr, cache_index, mf, time, events, status); // Write-evict
-	else
-		return wr_hit_wb(addr, cache_index, mf, time, events, status); // Write-back
+enum cache_request_status data_cache::wr_hit_global_we_local_wb(
+    new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+    std::list<cache_event> &events, enum cache_request_status status) {
+  bool evict = (mf->get_access_type() ==
+                GLOBAL_ACC_W);  // evict a line that hits on global memory write
+  if (evict)
+    return wr_hit_we(addr, cache_index, mf, time, events,
+                     status);  // Write-evict
+  else
+    return wr_hit_wb(addr, cache_index, mf, time, events,
+                     status);  // Write-back
 }
 
 /****** Write-miss functions (Set by config file) ******/
 
 /// Write-allocate miss: Send write request to lower level memory
 // and send a read request for the same block
-enum cache_request_status
-data_cache::wr_miss_wa_naive( new_addr_type addr,
-                        unsigned cache_index, mem_fetch *mf,
-                        unsigned time, std::list<cache_event> &events,
-                        enum cache_request_status status )
-{
-    new_addr_type block_addr = m_config.block_addr(addr);
-    new_addr_type mshr_addr = m_config.mshr_addr(mf->get_addr());
+enum cache_request_status data_cache::wr_miss_wa_naive(
+    new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+    std::list<cache_event> &events, enum cache_request_status status) {
+  new_addr_type block_addr = m_config.block_addr(addr);
+  new_addr_type mshr_addr = m_config.mshr_addr(mf->get_addr());
 
-    // Write allocate, maximum 3 requests (write miss, read request, write back request)
-    // Conservatively ensure the worst-case request can be handled this cycle
-    bool mshr_hit = m_mshrs.probe(mshr_addr);
-    bool mshr_avail = !m_mshrs.full(mshr_addr);
-    if(miss_queue_full(2) 
-        || (!(mshr_hit && mshr_avail) 
-        && !(!mshr_hit && mshr_avail && (m_miss_queue.size() < m_config.m_miss_queue_size)))) {
-    	//check what is the exactly the failure reason
-    	 if(miss_queue_full(2) )
-    		 m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
-         else if(mshr_hit && !mshr_avail)
-    	      m_stats.inc_fail_stats(mf->get_access_type(), MSHR_MERGE_ENRTY_FAIL);
-    	 else if (!mshr_hit && !mshr_avail)
-    	    m_stats.inc_fail_stats(mf->get_access_type(), MSHR_ENRTY_FAIL);
-    	 else
-    		 assert(0);
+  // Write allocate, maximum 3 requests (write miss, read request, write back
+  // request)
+  // Conservatively ensure the worst-case request can be handled this cycle
+  bool mshr_hit = m_mshrs.probe(mshr_addr);
+  bool mshr_avail = !m_mshrs.full(mshr_addr);
+  if (miss_queue_full(2) ||
+      (!(mshr_hit && mshr_avail) &&
+       !(!mshr_hit && mshr_avail &&
+         (m_miss_queue.size() < m_config.m_miss_queue_size)))) {
+    // check what is the exactly the failure reason
+    if (miss_queue_full(2))
+      m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
+    else if (mshr_hit && !mshr_avail)
+      m_stats.inc_fail_stats(mf->get_access_type(), MSHR_MERGE_ENRTY_FAIL);
+    else if (!mshr_hit && !mshr_avail)
+      m_stats.inc_fail_stats(mf->get_access_type(), MSHR_ENRTY_FAIL);
+    else
+      assert(0);
 
-        return RESERVATION_FAIL;
+    return RESERVATION_FAIL;
+  }
+
+  send_write_request(mf, cache_event(WRITE_REQUEST_SENT), time, events);
+  // Tries to send write allocate request, returns true on success and false on
+  // failure
+  // if(!send_write_allocate(mf, addr, block_addr, cache_index, time, events))
+  //    return RESERVATION_FAIL;
+
+  const mem_access_t *ma =
+      new mem_access_t(m_wr_alloc_type, mf->get_addr(), m_config.get_atom_sz(),
+                       false,  // Now performing a read
+                       mf->get_access_warp_mask(), mf->get_access_byte_mask(),
+                       mf->get_access_sector_mask(), m_gpu->gpgpu_ctx);
+
+  mem_fetch *n_mf =
+      new mem_fetch(*ma, NULL, mf->get_ctrl_size(), mf->get_wid(),
+                    mf->get_sid(), mf->get_tpc(), mf->get_mem_config(),
+                    m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle);
+
+  bool do_miss = false;
+  bool wb = false;
+  evicted_block_info evicted;
+
+  // Send read request resulting from write miss
+  send_read_request(addr, block_addr, cache_index, n_mf, time, do_miss, wb,
+                    evicted, events, false, true);
+
+  events.push_back(cache_event(WRITE_ALLOCATE_SENT));
+
+  if (do_miss) {
+    // If evicted block is modified and not a write-through
+    // (already modified lower level)
+    if (wb && (m_config.m_write_policy != WRITE_THROUGH)) {
+      assert(status ==
+             MISS);  // SECTOR_MISS and HIT_RESERVED should not send write back
+      mem_fetch *wb = m_memfetch_creator->alloc(
+          evicted.m_block_addr, m_wrbk_type, evicted.m_modified_size, true,
+          m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle);
+      send_write_request(wb, cache_event(WRITE_BACK_REQUEST_SENT, evicted),
+                         time, events);
+    }
+    return MISS;
+  }
+
+  return RESERVATION_FAIL;
+}
+
+enum cache_request_status data_cache::wr_miss_wa_fetch_on_write(
+    new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+    std::list<cache_event> &events, enum cache_request_status status) {
+  new_addr_type block_addr = m_config.block_addr(addr);
+  new_addr_type mshr_addr = m_config.mshr_addr(mf->get_addr());
+
+  if (mf->get_access_byte_mask().count() == m_config.get_atom_sz()) {
+    // if the request writes to the whole cache line/sector, then, write and set
+    // cache line Modified.
+    // and no need to send read request to memory or reserve mshr
+
+    if (miss_queue_full(0)) {
+      m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
+      return RESERVATION_FAIL;  // cannot handle request this cycle
     }
 
-    send_write_request(mf, cache_event(WRITE_REQUEST_SENT), time, events);
-    // Tries to send write allocate request, returns true on success and false on failure
-    //if(!send_write_allocate(mf, addr, block_addr, cache_index, time, events))
-    //    return RESERVATION_FAIL;
-
-    const mem_access_t *ma = new  mem_access_t( m_wr_alloc_type,
-                        mf->get_addr(),
-						m_config.get_atom_sz(),
-                        false, // Now performing a read
-                        mf->get_access_warp_mask(),
-                        mf->get_access_byte_mask(),
-		                mf->get_access_sector_mask(),
-				m_gpu->gpgpu_ctx);
-
-    mem_fetch *n_mf = new mem_fetch( *ma,
-                    NULL,
-                    mf->get_ctrl_size(),
-                    mf->get_wid(),
-                    mf->get_sid(),
-                    mf->get_tpc(),
-                    mf->get_mem_config(),
-					m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle);
-
-    bool do_miss = false;
     bool wb = false;
     evicted_block_info evicted;
 
-    // Send read request resulting from write miss
+    cache_request_status status =
+        m_tag_array->access(block_addr, time, cache_index, wb, evicted, mf);
+    assert(status != HIT);
+    cache_block_t *block = m_tag_array->get_block(cache_index);
+    block->set_status(MODIFIED, mf->get_access_sector_mask());
+    if (status == HIT_RESERVED)
+      block->set_ignore_on_fill(true, mf->get_access_sector_mask());
+
+    if (status != RESERVATION_FAIL) {
+      // If evicted block is modified and not a write-through
+      // (already modified lower level)
+      if (wb && (m_config.m_write_policy != WRITE_THROUGH)) {
+        mem_fetch *wb = m_memfetch_creator->alloc(
+            evicted.m_block_addr, m_wrbk_type, evicted.m_modified_size, true,
+            m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle);
+        send_write_request(wb, cache_event(WRITE_BACK_REQUEST_SENT, evicted),
+                           time, events);
+      }
+      return MISS;
+    }
+    return RESERVATION_FAIL;
+  } else {
+    bool mshr_hit = m_mshrs.probe(mshr_addr);
+    bool mshr_avail = !m_mshrs.full(mshr_addr);
+    if (miss_queue_full(1) ||
+        (!(mshr_hit && mshr_avail) &&
+         !(!mshr_hit && mshr_avail &&
+           (m_miss_queue.size() < m_config.m_miss_queue_size)))) {
+      // check what is the exactly the failure reason
+      if (miss_queue_full(1))
+        m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
+      else if (mshr_hit && !mshr_avail)
+        m_stats.inc_fail_stats(mf->get_access_type(), MSHR_MERGE_ENRTY_FAIL);
+      else if (!mshr_hit && !mshr_avail)
+        m_stats.inc_fail_stats(mf->get_access_type(), MSHR_ENRTY_FAIL);
+      else
+        assert(0);
+
+      return RESERVATION_FAIL;
+    }
+
+    // prevent Write - Read - Write in pending mshr
+    // allowing another write will override the value of the first write, and
+    // the pending read request will read incorrect result from the second write
+    if (m_mshrs.probe(mshr_addr) &&
+        m_mshrs.is_read_after_write_pending(mshr_addr) && mf->is_write()) {
+      // assert(0);
+      m_stats.inc_fail_stats(mf->get_access_type(), MSHR_RW_PENDING);
+      return RESERVATION_FAIL;
+    }
+
+    const mem_access_t *ma = new mem_access_t(
+        m_wr_alloc_type, mf->get_addr(), m_config.get_atom_sz(),
+        false,  // Now performing a read
+        mf->get_access_warp_mask(), mf->get_access_byte_mask(),
+        mf->get_access_sector_mask(), m_gpu->gpgpu_ctx);
+
+    mem_fetch *n_mf = new mem_fetch(
+        *ma, NULL, mf->get_ctrl_size(), mf->get_wid(), mf->get_sid(),
+        mf->get_tpc(), mf->get_mem_config(),
+        m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle, NULL, mf);
+
+    new_addr_type block_addr = m_config.block_addr(addr);
+    bool do_miss = false;
+    bool wb = false;
+    evicted_block_info evicted;
     send_read_request(addr, block_addr, cache_index, n_mf, time, do_miss, wb,
-        evicted, events, false, true);
+                      evicted, events, false, true);
+
+    cache_block_t *block = m_tag_array->get_block(cache_index);
+    block->set_modified_on_fill(true, mf->get_access_sector_mask());
 
     events.push_back(cache_event(WRITE_ALLOCATE_SENT));
 
-    if( do_miss ){
-        // If evicted block is modified and not a write-through
-        // (already modified lower level)
-        if( wb && (m_config.m_write_policy != WRITE_THROUGH) ) { 
-        	assert(status == MISS);   //SECTOR_MISS and HIT_RESERVED should not send write back
-            mem_fetch *wb = m_memfetch_creator->alloc(evicted.m_block_addr,
-                m_wrbk_type,evicted.m_modified_size,true,m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle);
-            send_write_request(wb, cache_event(WRITE_BACK_REQUEST_SENT, evicted), time, events);
-        }
-        return MISS;
+    if (do_miss) {
+      // If evicted block is modified and not a write-through
+      // (already modified lower level)
+      if (wb && (m_config.m_write_policy != WRITE_THROUGH)) {
+        mem_fetch *wb = m_memfetch_creator->alloc(
+            evicted.m_block_addr, m_wrbk_type, evicted.m_modified_size, true,
+            m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle);
+        send_write_request(wb, cache_event(WRITE_BACK_REQUEST_SENT, evicted),
+                           time, events);
+      }
+      return MISS;
     }
-
     return RESERVATION_FAIL;
+  }
 }
 
+enum cache_request_status data_cache::wr_miss_wa_lazy_fetch_on_read(
+    new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+    std::list<cache_event> &events, enum cache_request_status status) {
+  new_addr_type block_addr = m_config.block_addr(addr);
 
-enum cache_request_status
-data_cache::wr_miss_wa_fetch_on_write( new_addr_type addr,
-                        unsigned cache_index, mem_fetch *mf,
-                        unsigned time, std::list<cache_event> &events,
-                        enum cache_request_status status )
-{
-    new_addr_type block_addr = m_config.block_addr(addr);
-    new_addr_type mshr_addr = m_config.mshr_addr(mf->get_addr());
+  // if the request writes to the whole cache line/sector, then, write and set
+  // cache line Modified.
+  // and no need to send read request to memory or reserve mshr
 
-	if(mf->get_access_byte_mask().count() == m_config.get_atom_sz())
-	{
-		//if the request writes to the whole cache line/sector, then, write and set cache line Modified.
-		//and no need to send read request to memory or reserve mshr
+  if (miss_queue_full(0)) {
+    m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
+    return RESERVATION_FAIL;  // cannot handle request this cycle
+  }
 
-		if(miss_queue_full(0)) {
-			m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
-			return RESERVATION_FAIL; // cannot handle request this cycle
-		}
+  bool wb = false;
+  evicted_block_info evicted;
 
-		bool wb = false;
-		evicted_block_info evicted;
+  cache_request_status m_status =
+      m_tag_array->access(block_addr, time, cache_index, wb, evicted, mf);
+  assert(m_status != HIT);
+  cache_block_t *block = m_tag_array->get_block(cache_index);
+  block->set_status(MODIFIED, mf->get_access_sector_mask());
+  if (m_status == HIT_RESERVED) {
+    block->set_ignore_on_fill(true, mf->get_access_sector_mask());
+    block->set_modified_on_fill(true, mf->get_access_sector_mask());
+  }
 
-		cache_request_status status =  m_tag_array->access(block_addr,time,cache_index,wb,evicted,mf);
-		assert(status != HIT);
-		cache_block_t* block = m_tag_array->get_block(cache_index);
-		block->set_status(MODIFIED, mf->get_access_sector_mask());
-		if(status == HIT_RESERVED)
-			block->set_ignore_on_fill(true, mf->get_access_sector_mask());
+  if (mf->get_access_byte_mask().count() == m_config.get_atom_sz()) {
+    block->set_m_readable(true, mf->get_access_sector_mask());
+  } else {
+    block->set_m_readable(false, mf->get_access_sector_mask());
+  }
 
-		if( status != RESERVATION_FAIL ){
-			   // If evicted block is modified and not a write-through
-			   // (already modified lower level)
-			   if( wb && (m_config.m_write_policy != WRITE_THROUGH) ) {
-				   mem_fetch *wb = m_memfetch_creator->alloc(evicted.m_block_addr,
-					   m_wrbk_type,evicted.m_modified_size,true,m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle);
-				   send_write_request(wb, cache_event(WRITE_BACK_REQUEST_SENT, evicted), time, events);
-			   }
-			   return MISS;
-		   }
-		return RESERVATION_FAIL;
-	}
-	else
-	{
-		bool mshr_hit = m_mshrs.probe(mshr_addr);
-		bool mshr_avail = !m_mshrs.full(mshr_addr);
-		if(miss_queue_full(1)
-			|| (!(mshr_hit && mshr_avail)
-			&& !(!mshr_hit && mshr_avail && (m_miss_queue.size() < m_config.m_miss_queue_size)))) {
-			//check what is the exactly the failure reason
-			 if(miss_queue_full(1) )
-				 m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
-			 else if(mshr_hit && !mshr_avail)
-				  m_stats.inc_fail_stats(mf->get_access_type(), MSHR_MERGE_ENRTY_FAIL);
-			 else if (!mshr_hit && !mshr_avail)
-				m_stats.inc_fail_stats(mf->get_access_type(), MSHR_ENRTY_FAIL);
-			 else
-				 assert(0);
-
-			return RESERVATION_FAIL;
-		}
-
-
-		  //prevent Write - Read - Write in pending mshr
-		  //allowing another write will override the value of the first write, and the pending read request will read incorrect result from the second write
-		  if(m_mshrs.probe(mshr_addr) && m_mshrs.is_read_after_write_pending(mshr_addr) && mf->is_write())
-		  {
-			  //assert(0);
-			  m_stats.inc_fail_stats(mf->get_access_type(), MSHR_RW_PENDING);
-			  return RESERVATION_FAIL;
-		  }
-
-		  const mem_access_t *ma = new  mem_access_t( m_wr_alloc_type,
-									mf->get_addr(),
-									m_config.get_atom_sz(),
-									false, // Now performing a read
-									mf->get_access_warp_mask(),
-									mf->get_access_byte_mask(),
-									mf->get_access_sector_mask(),
-									m_gpu->gpgpu_ctx);
-
-		  mem_fetch *n_mf = new mem_fetch( *ma,
-								NULL,
-								mf->get_ctrl_size(),
-								mf->get_wid(),
-								mf->get_sid(),
-								mf->get_tpc(),
-								mf->get_mem_config(),
-								m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle,
-								NULL,
-								mf);
-
-
-			new_addr_type block_addr = m_config.block_addr(addr);
-			bool do_miss = false;
-			bool wb = false;
-			evicted_block_info evicted;
-			send_read_request( addr,
-							   block_addr,
-							   cache_index,
-							   n_mf, time, do_miss, wb, evicted, events, false, true);
-
-			cache_block_t* block = m_tag_array->get_block(cache_index);
-			block->set_modified_on_fill(true, mf->get_access_sector_mask());
-
-			events.push_back(cache_event(WRITE_ALLOCATE_SENT));
-
-			if( do_miss ){
-				// If evicted block is modified and not a write-through
-				// (already modified lower level)
-				if(wb && (m_config.m_write_policy != WRITE_THROUGH) ){
-					mem_fetch *wb = m_memfetch_creator->alloc(evicted.m_block_addr,
-						m_wrbk_type,evicted.m_modified_size,true,m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle);
-					send_write_request(wb, cache_event(WRITE_BACK_REQUEST_SENT, evicted), time, events);
-			}
-				return MISS;
-			}
-	   return RESERVATION_FAIL;
-	}
-}
-
-enum cache_request_status
-data_cache::wr_miss_wa_lazy_fetch_on_read( new_addr_type addr,
-                        unsigned cache_index, mem_fetch *mf,
-                        unsigned time, std::list<cache_event> &events,
-                        enum cache_request_status status )
-{
-
-	    new_addr_type block_addr = m_config.block_addr(addr);
-
-		//if the request writes to the whole cache line/sector, then, write and set cache line Modified.
-		//and no need to send read request to memory or reserve mshr
-
-		if(miss_queue_full(0)) {
-			m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
-			return RESERVATION_FAIL; // cannot handle request this cycle
-		}
-
-		bool wb = false;
-		evicted_block_info evicted;
-
-		cache_request_status m_status =  m_tag_array->access(block_addr,time,cache_index,wb,evicted,mf);
-		assert(m_status != HIT);
-		cache_block_t* block = m_tag_array->get_block(cache_index);
-		block->set_status(MODIFIED, mf->get_access_sector_mask());
-		if(m_status == HIT_RESERVED) {
-			block->set_ignore_on_fill(true, mf->get_access_sector_mask());
-			block->set_modified_on_fill(true, mf->get_access_sector_mask());
-		}
-
-		if(mf->get_access_byte_mask().count() == m_config.get_atom_sz())
-		{
-			block->set_m_readable(true, mf->get_access_sector_mask());
-		} else
-		{
-			block->set_m_readable(false, mf->get_access_sector_mask());
-		}
-
-		if( m_status != RESERVATION_FAIL ){
-			   // If evicted block is modified and not a write-through
-			   // (already modified lower level)
-			   if( wb && (m_config.m_write_policy != WRITE_THROUGH) ) {
-				   mem_fetch *wb = m_memfetch_creator->alloc(evicted.m_block_addr,
-					   m_wrbk_type,evicted.m_modified_size,true,m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle);
-				   send_write_request(wb, cache_event(WRITE_BACK_REQUEST_SENT, evicted), time, events);
-			   }
-			   return MISS;
-		   }
-		return RESERVATION_FAIL;
+  if (m_status != RESERVATION_FAIL) {
+    // If evicted block is modified and not a write-through
+    // (already modified lower level)
+    if (wb && (m_config.m_write_policy != WRITE_THROUGH)) {
+      mem_fetch *wb = m_memfetch_creator->alloc(
+          evicted.m_block_addr, m_wrbk_type, evicted.m_modified_size, true,
+          m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle);
+      send_write_request(wb, cache_event(WRITE_BACK_REQUEST_SENT, evicted),
+                         time, events);
+    }
+    return MISS;
+  }
+  return RESERVATION_FAIL;
 }
 
 /// No write-allocate miss: Simply send write request to lower level memory
-enum cache_request_status
-data_cache::wr_miss_no_wa( new_addr_type addr,
-                           unsigned cache_index,
-                           mem_fetch *mf,
-                           unsigned time,
-                           std::list<cache_event> &events,
-                           enum cache_request_status status )
-{
-    if(miss_queue_full(0)) {
-    	m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
-    	return RESERVATION_FAIL; // cannot handle request this cycle
-    }
+enum cache_request_status data_cache::wr_miss_no_wa(
+    new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+    std::list<cache_event> &events, enum cache_request_status status) {
+  if (miss_queue_full(0)) {
+    m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
+    return RESERVATION_FAIL;  // cannot handle request this cycle
+  }
 
+  // on miss, generate write through (no write buffering -- too many threads for
+  // that)
+  send_write_request(mf, cache_event(WRITE_REQUEST_SENT), time, events);
 
-    // on miss, generate write through (no write buffering -- too many threads for that)
-    send_write_request(mf, cache_event(WRITE_REQUEST_SENT), time, events);
-
-    return MISS;
+  return MISS;
 }
 
 /****** Read hit functions (Set by config file) ******/
 
 /// Baseline read hit: Update LRU status of block.
 // Special case for atomic instructions -> Mark block as modified
-enum cache_request_status
-data_cache::rd_hit_base( new_addr_type addr,
-                         unsigned cache_index,
-                         mem_fetch *mf,
-                         unsigned time,
-                         std::list<cache_event> &events,
-                         enum cache_request_status status )
-{
-    new_addr_type block_addr = m_config.block_addr(addr);
-    m_tag_array->access(block_addr,time,cache_index,mf);
-    // Atomics treated as global read/write requests - Perform read, mark line as
-    // MODIFIED
-    if(mf->isatomic()){ 
-        assert(mf->get_access_type() == GLOBAL_ACC_R);
-        cache_block_t* block = m_tag_array->get_block(cache_index);
-        block->set_status(MODIFIED, mf->get_access_sector_mask()) ;  // mark line as dirty
-    }
-    return HIT;
+enum cache_request_status data_cache::rd_hit_base(
+    new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+    std::list<cache_event> &events, enum cache_request_status status) {
+  new_addr_type block_addr = m_config.block_addr(addr);
+  m_tag_array->access(block_addr, time, cache_index, mf);
+  // Atomics treated as global read/write requests - Perform read, mark line as
+  // MODIFIED
+  if (mf->isatomic()) {
+    assert(mf->get_access_type() == GLOBAL_ACC_R);
+    cache_block_t *block = m_tag_array->get_block(cache_index);
+    block->set_status(MODIFIED,
+                      mf->get_access_sector_mask());  // mark line as dirty
+  }
+  return HIT;
 }
 
 /****** Read miss functions (Set by config file) ******/
 
 /// Baseline read miss: Send read request to lower level memory,
 // perform write-back as necessary
-enum cache_request_status
-data_cache::rd_miss_base( new_addr_type addr,
-                          unsigned cache_index,
-                          mem_fetch *mf,
-                          unsigned time,
-                          std::list<cache_event> &events,
-                          enum cache_request_status status ){
-    if(miss_queue_full(1)) {
-        // cannot handle request this cycle
-        // (might need to generate two requests)
-    	m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
-        return RESERVATION_FAIL; 
-    }
+enum cache_request_status data_cache::rd_miss_base(
+    new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+    std::list<cache_event> &events, enum cache_request_status status) {
+  if (miss_queue_full(1)) {
+    // cannot handle request this cycle
+    // (might need to generate two requests)
+    m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
+    return RESERVATION_FAIL;
+  }
 
-    new_addr_type block_addr = m_config.block_addr(addr);
-    bool do_miss = false;
-    bool wb = false;
-    evicted_block_info evicted;
-    send_read_request( addr,
-                       block_addr,
-                       cache_index,
-                       mf, time, do_miss, wb, evicted, events, false, false);
+  new_addr_type block_addr = m_config.block_addr(addr);
+  bool do_miss = false;
+  bool wb = false;
+  evicted_block_info evicted;
+  send_read_request(addr, block_addr, cache_index, mf, time, do_miss, wb,
+                    evicted, events, false, false);
 
-    if( do_miss ){
-        // If evicted block is modified and not a write-through
-        // (already modified lower level)
-        if(wb && (m_config.m_write_policy != WRITE_THROUGH) ){ 
-            mem_fetch *wb = m_memfetch_creator->alloc(evicted.m_block_addr,
-                m_wrbk_type,evicted.m_modified_size,true,m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle);
-        send_write_request(wb, WRITE_BACK_REQUEST_SENT, time, events);
+  if (do_miss) {
+    // If evicted block is modified and not a write-through
+    // (already modified lower level)
+    if (wb && (m_config.m_write_policy != WRITE_THROUGH)) {
+      mem_fetch *wb = m_memfetch_creator->alloc(
+          evicted.m_block_addr, m_wrbk_type, evicted.m_modified_size, true,
+          m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle);
+      send_write_request(wb, WRITE_BACK_REQUEST_SENT, time, events);
     }
-        return MISS;
-    }
-        return RESERVATION_FAIL;
+    return MISS;
+  }
+  return RESERVATION_FAIL;
 }
 
 /// Access cache for read_only_cache: returns RESERVATION_FAIL if
 // request could not be accepted (for any reason)
-enum cache_request_status
-read_only_cache::access( new_addr_type addr,
-                         mem_fetch *mf,
-                         unsigned time,
-                         std::list<cache_event> &events )
-{
-    assert( mf->get_data_size() <= m_config.get_atom_sz());
-    assert(m_config.m_write_policy == READ_ONLY);
-    assert(!mf->get_is_write());
-    new_addr_type block_addr = m_config.block_addr(addr);
-    unsigned cache_index = (unsigned)-1;
-    enum cache_request_status status = m_tag_array->probe(block_addr,cache_index,mf);
-    enum cache_request_status cache_status = RESERVATION_FAIL;
+enum cache_request_status read_only_cache::access(
+    new_addr_type addr, mem_fetch *mf, unsigned time,
+    std::list<cache_event> &events) {
+  assert(mf->get_data_size() <= m_config.get_atom_sz());
+  assert(m_config.m_write_policy == READ_ONLY);
+  assert(!mf->get_is_write());
+  new_addr_type block_addr = m_config.block_addr(addr);
+  unsigned cache_index = (unsigned)-1;
+  enum cache_request_status status =
+      m_tag_array->probe(block_addr, cache_index, mf);
+  enum cache_request_status cache_status = RESERVATION_FAIL;
 
-    if ( status == HIT ) {
-        cache_status = m_tag_array->access(block_addr,time,cache_index,mf); // update LRU state
-    }else if ( status != RESERVATION_FAIL ) {
-        if(!miss_queue_full(0)){
-            bool do_miss=false;
-            send_read_request(addr, block_addr, cache_index, mf, time, do_miss, events, true, false);
-            if(do_miss)
-                cache_status = MISS;
-            else
-                cache_status = RESERVATION_FAIL;
-        }else{
-            cache_status = RESERVATION_FAIL;
-            m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
-        }
-    }else {
-    	m_stats.inc_fail_stats(mf->get_access_type(), LINE_ALLOC_FAIL);
+  if (status == HIT) {
+    cache_status = m_tag_array->access(block_addr, time, cache_index,
+                                       mf);  // update LRU state
+  } else if (status != RESERVATION_FAIL) {
+    if (!miss_queue_full(0)) {
+      bool do_miss = false;
+      send_read_request(addr, block_addr, cache_index, mf, time, do_miss,
+                        events, true, false);
+      if (do_miss)
+        cache_status = MISS;
+      else
+        cache_status = RESERVATION_FAIL;
+    } else {
+      cache_status = RESERVATION_FAIL;
+      m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
     }
+  } else {
+    m_stats.inc_fail_stats(mf->get_access_type(), LINE_ALLOC_FAIL);
+  }
 
-    m_stats.inc_stats(mf->get_access_type(), m_stats.select_stats_status(status, cache_status));
-    m_stats.inc_stats_pw(mf->get_access_type(), m_stats.select_stats_status(status, cache_status));
-    return cache_status;
+  m_stats.inc_stats(mf->get_access_type(),
+                    m_stats.select_stats_status(status, cache_status));
+  m_stats.inc_stats_pw(mf->get_access_type(),
+                       m_stats.select_stats_status(status, cache_status));
+  return cache_status;
 }
 
 //! A general function that takes the result of a tag_array probe
 //  and performs the correspding functions based on the cache configuration
 //  The access fucntion calls this function
-enum cache_request_status
-data_cache::process_tag_probe( bool wr,
-                               enum cache_request_status probe_status,
-                               new_addr_type addr,
-                               unsigned cache_index,
-                               mem_fetch* mf,
-                               unsigned time,
-                               std::list<cache_event>& events )
-{
-    // Each function pointer ( m_[rd/wr]_[hit/miss] ) is set in the
-    // data_cache constructor to reflect the corresponding cache configuration
-    // options. Function pointers were used to avoid many long conditional
-    // branches resulting from many cache configuration options.
-    cache_request_status access_status = probe_status;
-    if(wr){ // Write
-        if(probe_status == HIT){
-            access_status = (this->*m_wr_hit)( addr,
-                                      cache_index,
-                                      mf, time, events, probe_status );
-        }else if ( (probe_status != RESERVATION_FAIL) || (probe_status == RESERVATION_FAIL && m_config.m_write_alloc_policy == NO_WRITE_ALLOCATE) ) {
-            access_status = (this->*m_wr_miss)( addr,
-                                       cache_index,
-                                       mf, time, events, probe_status );
-        }else {
-        	//the only reason for reservation fail here is LINE_ALLOC_FAIL (i.e all lines are reserved)
-        	m_stats.inc_fail_stats(mf->get_access_type(), LINE_ALLOC_FAIL);
-        }
-    }else{ // Read
-        if(probe_status == HIT){
-            access_status = (this->*m_rd_hit)( addr,
-                                      cache_index,
-                                      mf, time, events, probe_status );
-        }else if ( probe_status != RESERVATION_FAIL ) {
-            access_status = (this->*m_rd_miss)( addr,
-                                       cache_index,
-                                       mf, time, events, probe_status );
-        }else {
-        	//the only reason for reservation fail here is LINE_ALLOC_FAIL (i.e all lines are reserved)
-        	m_stats.inc_fail_stats(mf->get_access_type(), LINE_ALLOC_FAIL);
-        }
+enum cache_request_status data_cache::process_tag_probe(
+    bool wr, enum cache_request_status probe_status, new_addr_type addr,
+    unsigned cache_index, mem_fetch *mf, unsigned time,
+    std::list<cache_event> &events) {
+  // Each function pointer ( m_[rd/wr]_[hit/miss] ) is set in the
+  // data_cache constructor to reflect the corresponding cache configuration
+  // options. Function pointers were used to avoid many long conditional
+  // branches resulting from many cache configuration options.
+  cache_request_status access_status = probe_status;
+  if (wr) {  // Write
+    if (probe_status == HIT) {
+      access_status =
+          (this->*m_wr_hit)(addr, cache_index, mf, time, events, probe_status);
+    } else if ((probe_status != RESERVATION_FAIL) ||
+               (probe_status == RESERVATION_FAIL &&
+                m_config.m_write_alloc_policy == NO_WRITE_ALLOCATE)) {
+      access_status =
+          (this->*m_wr_miss)(addr, cache_index, mf, time, events, probe_status);
+    } else {
+      // the only reason for reservation fail here is LINE_ALLOC_FAIL (i.e all
+      // lines are reserved)
+      m_stats.inc_fail_stats(mf->get_access_type(), LINE_ALLOC_FAIL);
     }
+  } else {  // Read
+    if (probe_status == HIT) {
+      access_status =
+          (this->*m_rd_hit)(addr, cache_index, mf, time, events, probe_status);
+    } else if (probe_status != RESERVATION_FAIL) {
+      access_status =
+          (this->*m_rd_miss)(addr, cache_index, mf, time, events, probe_status);
+    } else {
+      // the only reason for reservation fail here is LINE_ALLOC_FAIL (i.e all
+      // lines are reserved)
+      m_stats.inc_fail_stats(mf->get_access_type(), LINE_ALLOC_FAIL);
+    }
+  }
 
-    m_bandwidth_management.use_data_port(mf, access_status, events); 
-    return access_status;
+  m_bandwidth_management.use_data_port(mf, access_status, events);
+  return access_status;
 }
 
 // Both the L1 and L2 currently use the same access function.
@@ -1645,51 +1650,41 @@ data_cache::process_tag_probe( bool wr,
 // of caching policies.
 // Both the L1 and L2 override this function to provide a means of
 // performing actions specific to each cache when such actions are implemnted.
-enum cache_request_status
-data_cache::access( new_addr_type addr,
-                    mem_fetch *mf,
-                    unsigned time,
-                    std::list<cache_event> &events )
-{
-
-    assert( mf->get_data_size() <= m_config.get_atom_sz());
-    bool wr = mf->get_is_write();
-    new_addr_type block_addr = m_config.block_addr(addr);
-    unsigned cache_index = (unsigned)-1;
-    enum cache_request_status probe_status
-        = m_tag_array->probe( block_addr, cache_index, mf, true);
-    enum cache_request_status access_status
-        = process_tag_probe( wr, probe_status, addr, cache_index, mf, time, events );
-    m_stats.inc_stats(mf->get_access_type(),
-        m_stats.select_stats_status(probe_status, access_status));
-    m_stats.inc_stats_pw(mf->get_access_type(),
-        m_stats.select_stats_status(probe_status, access_status));
-    return access_status;
+enum cache_request_status data_cache::access(new_addr_type addr, mem_fetch *mf,
+                                             unsigned time,
+                                             std::list<cache_event> &events) {
+  assert(mf->get_data_size() <= m_config.get_atom_sz());
+  bool wr = mf->get_is_write();
+  new_addr_type block_addr = m_config.block_addr(addr);
+  unsigned cache_index = (unsigned)-1;
+  enum cache_request_status probe_status =
+      m_tag_array->probe(block_addr, cache_index, mf, true);
+  enum cache_request_status access_status =
+      process_tag_probe(wr, probe_status, addr, cache_index, mf, time, events);
+  m_stats.inc_stats(mf->get_access_type(),
+                    m_stats.select_stats_status(probe_status, access_status));
+  m_stats.inc_stats_pw(mf->get_access_type(), m_stats.select_stats_status(
+                                                  probe_status, access_status));
+  return access_status;
 }
 
 /// This is meant to model the first level data cache in Fermi.
 /// It is write-evict (global) or write-back (local) at the
 /// granularity of individual blocks (Set by GPGPU-Sim configuration file)
 /// (the policy used in fermi according to the CUDA manual)
-enum cache_request_status
-l1_cache::access( new_addr_type addr,
-                  mem_fetch *mf,
-                  unsigned time,
-                  std::list<cache_event> &events )
-{
-    return data_cache::access( addr, mf, time, events );
+enum cache_request_status l1_cache::access(new_addr_type addr, mem_fetch *mf,
+                                           unsigned time,
+                                           std::list<cache_event> &events) {
+  return data_cache::access(addr, mf, time, events);
 }
 
 // The l2 cache access function calls the base data_cache access
 // implementation.  When the L2 needs to diverge from L1, L2 specific
 // changes should be made here.
-enum cache_request_status
-l2_cache::access( new_addr_type addr,
-                  mem_fetch *mf,
-                  unsigned time,
-                  std::list<cache_event> &events )
-{
-    return data_cache::access( addr, mf, time, events );
+enum cache_request_status l2_cache::access(new_addr_type addr, mem_fetch *mf,
+                                           unsigned time,
+                                           std::list<cache_event> &events) {
+  return data_cache::access(addr, mf, time, events);
 }
 
 /// Access function for tex_cache
@@ -1697,141 +1692,144 @@ l2_cache::access( new_addr_type addr,
 /// otherwise returns HIT_RESERVED or MISS; NOTE: *never* returns HIT
 /// since unlike a normal CPU cache, a "HIT" in texture cache does not
 /// mean the data is ready (still need to get through fragment fifo)
-enum cache_request_status tex_cache::access( new_addr_type addr, mem_fetch *mf,
-    unsigned time, std::list<cache_event> &events )
-{
-    if ( m_fragment_fifo.full() || m_request_fifo.full() || m_rob.full() )
-        return RESERVATION_FAIL;
+enum cache_request_status tex_cache::access(new_addr_type addr, mem_fetch *mf,
+                                            unsigned time,
+                                            std::list<cache_event> &events) {
+  if (m_fragment_fifo.full() || m_request_fifo.full() || m_rob.full())
+    return RESERVATION_FAIL;
 
-    assert( mf->get_data_size() <= m_config.get_line_sz());
+  assert(mf->get_data_size() <= m_config.get_line_sz());
 
-    // at this point, we will accept the request : access tags and immediately allocate line
-    new_addr_type block_addr = m_config.block_addr(addr);
-    unsigned cache_index = (unsigned)-1;
-    enum cache_request_status status = m_tags.access(block_addr,time,cache_index,mf);
-    enum cache_request_status cache_status = RESERVATION_FAIL;
-    assert( status != RESERVATION_FAIL );
-    assert( status != HIT_RESERVED ); // as far as tags are concerned: HIT or MISS
-    m_fragment_fifo.push( fragment_entry(mf,cache_index,status==MISS,mf->get_data_size()) );
-    if ( status == MISS ) {
-        // we need to send a memory request...
-        unsigned rob_index = m_rob.push( rob_entry(cache_index, mf, block_addr) );
-        m_extra_mf_fields[mf] = extra_mf_fields(rob_index, m_config);
-        mf->set_data_size(m_config.get_line_sz());
-        m_tags.fill(cache_index,time,mf); // mark block as valid
-        m_request_fifo.push(mf);
-        mf->set_status(m_request_queue_status,time);
-        events.push_back(cache_event(READ_REQUEST_SENT));
-        cache_status = MISS;
-    } else {
-        // the value *will* *be* in the cache already
-        cache_status = HIT_RESERVED;
-    }
-    m_stats.inc_stats(mf->get_access_type(), m_stats.select_stats_status(status, cache_status));
-    m_stats.inc_stats_pw(mf->get_access_type(), m_stats.select_stats_status(status, cache_status));
-    return cache_status;
+  // at this point, we will accept the request : access tags and immediately
+  // allocate line
+  new_addr_type block_addr = m_config.block_addr(addr);
+  unsigned cache_index = (unsigned)-1;
+  enum cache_request_status status =
+      m_tags.access(block_addr, time, cache_index, mf);
+  enum cache_request_status cache_status = RESERVATION_FAIL;
+  assert(status != RESERVATION_FAIL);
+  assert(status != HIT_RESERVED);  // as far as tags are concerned: HIT or MISS
+  m_fragment_fifo.push(
+      fragment_entry(mf, cache_index, status == MISS, mf->get_data_size()));
+  if (status == MISS) {
+    // we need to send a memory request...
+    unsigned rob_index = m_rob.push(rob_entry(cache_index, mf, block_addr));
+    m_extra_mf_fields[mf] = extra_mf_fields(rob_index, m_config);
+    mf->set_data_size(m_config.get_line_sz());
+    m_tags.fill(cache_index, time, mf);  // mark block as valid
+    m_request_fifo.push(mf);
+    mf->set_status(m_request_queue_status, time);
+    events.push_back(cache_event(READ_REQUEST_SENT));
+    cache_status = MISS;
+  } else {
+    // the value *will* *be* in the cache already
+    cache_status = HIT_RESERVED;
+  }
+  m_stats.inc_stats(mf->get_access_type(),
+                    m_stats.select_stats_status(status, cache_status));
+  m_stats.inc_stats_pw(mf->get_access_type(),
+                       m_stats.select_stats_status(status, cache_status));
+  return cache_status;
 }
 
-void tex_cache::cycle(){
-    // send next request to lower level of memory
-    if ( !m_request_fifo.empty() ) {
-        mem_fetch *mf = m_request_fifo.peek();
-        if ( !m_memport->full(mf->get_ctrl_size(),false) ) {
-            m_request_fifo.pop();
-            m_memport->push(mf);
-        }
+void tex_cache::cycle() {
+  // send next request to lower level of memory
+  if (!m_request_fifo.empty()) {
+    mem_fetch *mf = m_request_fifo.peek();
+    if (!m_memport->full(mf->get_ctrl_size(), false)) {
+      m_request_fifo.pop();
+      m_memport->push(mf);
     }
-    // read ready lines from cache
-    if ( !m_fragment_fifo.empty() && !m_result_fifo.full() ) {
-        const fragment_entry &e = m_fragment_fifo.peek();
-        if ( e.m_miss ) {
-            // check head of reorder buffer to see if data is back from memory
-            unsigned rob_index = m_rob.next_pop_index();
-            const rob_entry &r = m_rob.peek(rob_index);
-            assert( r.m_request == e.m_request );
-            //assert( r.m_block_addr == m_config.block_addr(e.m_request->get_addr()) );
-            if ( r.m_ready ) {
-                assert( r.m_index == e.m_cache_index );
-                m_cache[r.m_index].m_valid = true;
-                m_cache[r.m_index].m_block_addr = r.m_block_addr;
-                m_result_fifo.push(e.m_request);
-                m_rob.pop();
-                m_fragment_fifo.pop();
-            }
-        } else {
-            // hit:
-            assert( m_cache[e.m_cache_index].m_valid );
-            assert( m_cache[e.m_cache_index].m_block_addr
-                == m_config.block_addr(e.m_request->get_addr()) );
-            m_result_fifo.push( e.m_request );
-            m_fragment_fifo.pop();
-        }
+  }
+  // read ready lines from cache
+  if (!m_fragment_fifo.empty() && !m_result_fifo.full()) {
+    const fragment_entry &e = m_fragment_fifo.peek();
+    if (e.m_miss) {
+      // check head of reorder buffer to see if data is back from memory
+      unsigned rob_index = m_rob.next_pop_index();
+      const rob_entry &r = m_rob.peek(rob_index);
+      assert(r.m_request == e.m_request);
+      // assert( r.m_block_addr == m_config.block_addr(e.m_request->get_addr())
+      // );
+      if (r.m_ready) {
+        assert(r.m_index == e.m_cache_index);
+        m_cache[r.m_index].m_valid = true;
+        m_cache[r.m_index].m_block_addr = r.m_block_addr;
+        m_result_fifo.push(e.m_request);
+        m_rob.pop();
+        m_fragment_fifo.pop();
+      }
+    } else {
+      // hit:
+      assert(m_cache[e.m_cache_index].m_valid);
+      assert(m_cache[e.m_cache_index].m_block_addr ==
+             m_config.block_addr(e.m_request->get_addr()));
+      m_result_fifo.push(e.m_request);
+      m_fragment_fifo.pop();
     }
+  }
 }
 
 /// Place returning cache block into reorder buffer
-void tex_cache::fill( mem_fetch *mf, unsigned time )
-{
-	if(m_config.m_mshr_type == SECTOR_TEX_FIFO) {
-	assert(mf->get_original_mf());
-	extra_mf_fields_lookup::iterator e = m_extra_mf_fields.find(mf->get_original_mf());
-    assert( e != m_extra_mf_fields.end() );
+void tex_cache::fill(mem_fetch *mf, unsigned time) {
+  if (m_config.m_mshr_type == SECTOR_TEX_FIFO) {
+    assert(mf->get_original_mf());
+    extra_mf_fields_lookup::iterator e =
+        m_extra_mf_fields.find(mf->get_original_mf());
+    assert(e != m_extra_mf_fields.end());
     e->second.pending_read--;
 
-    if(e->second.pending_read > 0) {
-    	//wait for the other requests to come back
-    	delete mf;
-    	return;
-      } else {
-    	mem_fetch *temp = mf;
-    	mf = mf->get_original_mf();
-    	delete temp;
-      }
-	}
+    if (e->second.pending_read > 0) {
+      // wait for the other requests to come back
+      delete mf;
+      return;
+    } else {
+      mem_fetch *temp = mf;
+      mf = mf->get_original_mf();
+      delete temp;
+    }
+  }
 
-    extra_mf_fields_lookup::iterator e = m_extra_mf_fields.find(mf);
-    assert( e != m_extra_mf_fields.end() );
-    assert( e->second.m_valid );
-    assert( !m_rob.empty() );
-    mf->set_status(m_rob_status,time);
+  extra_mf_fields_lookup::iterator e = m_extra_mf_fields.find(mf);
+  assert(e != m_extra_mf_fields.end());
+  assert(e->second.m_valid);
+  assert(!m_rob.empty());
+  mf->set_status(m_rob_status, time);
 
-    unsigned rob_index = e->second.m_rob_index;
-    rob_entry &r = m_rob.peek(rob_index);
-    assert( !r.m_ready );
-    r.m_ready = true;
-    r.m_time = time;
-    assert( r.m_block_addr == m_config.block_addr(mf->get_addr()) );
+  unsigned rob_index = e->second.m_rob_index;
+  rob_entry &r = m_rob.peek(rob_index);
+  assert(!r.m_ready);
+  r.m_ready = true;
+  r.m_time = time;
+  assert(r.m_block_addr == m_config.block_addr(mf->get_addr()));
 }
 
-void tex_cache::display_state( FILE *fp ) const
-{
-    fprintf(fp,"%s (texture cache) state:\n", m_name.c_str() );
-    fprintf(fp,"fragment fifo entries  = %u / %u\n",
-        m_fragment_fifo.size(), m_fragment_fifo.capacity() );
-    fprintf(fp,"reorder buffer entries = %u / %u\n",
-        m_rob.size(), m_rob.capacity() );
-    fprintf(fp,"request fifo entries   = %u / %u\n",
-        m_request_fifo.size(), m_request_fifo.capacity() );
-    if ( !m_rob.empty() )
-        fprintf(fp,"reorder buffer contents:\n");
-    for ( int n=m_rob.size()-1; n>=0; n-- ) {
-        unsigned index = (m_rob.next_pop_index() + n)%m_rob.capacity();
-        const rob_entry &r = m_rob.peek(index);
-        fprintf(fp, "tex rob[%3d] : %s ",
-            index, (r.m_ready?"ready  ":"pending") );
-        if ( r.m_ready )
-            fprintf(fp,"@%6u", r.m_time );
-        else
-            fprintf(fp,"       ");
-        fprintf(fp,"[idx=%4u]",r.m_index);
-        r.m_request->print(fp,false);
-    }
-    if ( !m_fragment_fifo.empty() ) {
-        fprintf(fp,"fragment fifo (oldest) :");
-        fragment_entry &f = m_fragment_fifo.peek();
-        fprintf(fp,"%s:          ", f.m_miss?"miss":"hit ");
-        f.m_request->print(fp,false);
-    }
+void tex_cache::display_state(FILE *fp) const {
+  fprintf(fp, "%s (texture cache) state:\n", m_name.c_str());
+  fprintf(fp, "fragment fifo entries  = %u / %u\n", m_fragment_fifo.size(),
+          m_fragment_fifo.capacity());
+  fprintf(fp, "reorder buffer entries = %u / %u\n", m_rob.size(),
+          m_rob.capacity());
+  fprintf(fp, "request fifo entries   = %u / %u\n", m_request_fifo.size(),
+          m_request_fifo.capacity());
+  if (!m_rob.empty()) fprintf(fp, "reorder buffer contents:\n");
+  for (int n = m_rob.size() - 1; n >= 0; n--) {
+    unsigned index = (m_rob.next_pop_index() + n) % m_rob.capacity();
+    const rob_entry &r = m_rob.peek(index);
+    fprintf(fp, "tex rob[%3d] : %s ", index,
+            (r.m_ready ? "ready  " : "pending"));
+    if (r.m_ready)
+      fprintf(fp, "@%6u", r.m_time);
+    else
+      fprintf(fp, "       ");
+    fprintf(fp, "[idx=%4u]", r.m_index);
+    r.m_request->print(fp, false);
+  }
+  if (!m_fragment_fifo.empty()) {
+    fprintf(fp, "fragment fifo (oldest) :");
+    fragment_entry &f = m_fragment_fifo.peek();
+    fprintf(fp, "%s:          ", f.m_miss ? "miss" : "hit ");
+    f.m_request->print(fp, false);
+  }
 }
 /******************************************************************************************************************************************/
-

--- a/src/gpgpu-sim/gpu-cache.cc
+++ b/src/gpgpu-sim/gpu-cache.cc
@@ -7,1637 +7,1631 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #include "gpu-cache.h"
+#include <assert.h>
 #include "gpu-sim.h"
 #include "stat-tool.h"
-#include <assert.h>
 
-// used to allocate memory that is large enough to adapt the changes in cache size across kernels
+// used to allocate memory that is large enough to adapt the changes in cache
+// size across kernels
 
-const char * cache_request_status_str(enum cache_request_status status) 
-{
-   static const char * static_cache_request_status_str[] = {
-      "HIT",
-      "HIT_RESERVED",
-      "MISS",
-      "RESERVATION_FAIL",
-	  "SECTOR_MISS"
-   }; 
+const char *cache_request_status_str(enum cache_request_status status) {
+  static const char *static_cache_request_status_str[] = {
+      "HIT", "HIT_RESERVED", "MISS", "RESERVATION_FAIL", "SECTOR_MISS"};
 
-   assert(sizeof(static_cache_request_status_str) / sizeof(const char*) == NUM_CACHE_REQUEST_STATUS); 
-   assert(status < NUM_CACHE_REQUEST_STATUS); 
+  assert(sizeof(static_cache_request_status_str) / sizeof(const char *) ==
+         NUM_CACHE_REQUEST_STATUS);
+  assert(status < NUM_CACHE_REQUEST_STATUS);
 
-   return static_cache_request_status_str[status]; 
+  return static_cache_request_status_str[status];
 }
 
-const char * cache_fail_status_str(enum cache_reservation_fail_reason status)
-{
-   static const char * static_cache_reservation_fail_reason_str[] = {
-	  "LINE_ALLOC_FAIL",
-	  "MISS_QUEUE_FULL",
-	  "MSHR_ENRTY_FAIL",
-      "MSHR_MERGE_ENRTY_FAIL",
-      "MSHR_RW_PENDING"
-   };
+const char *cache_fail_status_str(enum cache_reservation_fail_reason status) {
+  static const char *static_cache_reservation_fail_reason_str[] = {
+      "LINE_ALLOC_FAIL", "MISS_QUEUE_FULL", "MSHR_ENRTY_FAIL",
+      "MSHR_MERGE_ENRTY_FAIL", "MSHR_RW_PENDING"};
 
-   assert(sizeof(static_cache_reservation_fail_reason_str) / sizeof(const char*) == NUM_CACHE_RESERVATION_FAIL_STATUS);
-   assert(status < NUM_CACHE_RESERVATION_FAIL_STATUS);
+  assert(sizeof(static_cache_reservation_fail_reason_str) /
+             sizeof(const char *) ==
+         NUM_CACHE_RESERVATION_FAIL_STATUS);
+  assert(status < NUM_CACHE_RESERVATION_FAIL_STATUS);
 
-   return static_cache_reservation_fail_reason_str[status];
+  return static_cache_reservation_fail_reason_str[status];
 }
 
-unsigned l1d_cache_config::set_bank(new_addr_type addr) const{
-
-	if(m_cache_type == SECTOR)
-		return (addr >> m_sector_sz_log2) & (l1_banks-1);
-	else
-		return (addr >> m_line_sz_log2) & (l1_banks-1);
+unsigned l1d_cache_config::set_bank(new_addr_type addr) const {
+  if (m_cache_type == SECTOR)
+    return (addr >> m_sector_sz_log2) & (l1_banks - 1);
+  else
+    return (addr >> m_line_sz_log2) & (l1_banks - 1);
 }
 
-unsigned l1d_cache_config::set_index(new_addr_type addr) const{
-    unsigned set_index = m_nset; // Default to linear set index function
-    unsigned lower_xor = 0;
-    unsigned upper_xor = 0;
+unsigned l1d_cache_config::set_index(new_addr_type addr) const {
+  unsigned set_index = m_nset;  // Default to linear set index function
+  unsigned lower_xor = 0;
+  unsigned upper_xor = 0;
 
-    switch(m_set_index_function){
+  switch (m_set_index_function) {
     case FERMI_HASH_SET_FUNCTION:
     case BITWISE_XORING_FUNCTION:
-        /*
-        * Set Indexing function from "A Detailed GPU Cache Model Based on Reuse Distance Theory"
-        * Cedric Nugteren et al.
-        * HPCA 2014
-        */
-        if(m_nset == 32 || m_nset == 64){
-            // Lower xor value is bits 7-11
-            lower_xor = (addr >> m_line_sz_log2) & 0x1F;
+      /*
+       * Set Indexing function from "A Detailed GPU Cache Model Based on Reuse
+       * Distance Theory" Cedric Nugteren et al. HPCA 2014
+       */
+      if (m_nset == 32 || m_nset == 64) {
+        // Lower xor value is bits 7-11
+        lower_xor = (addr >> m_line_sz_log2) & 0x1F;
 
-            // Upper xor value is bits 13, 14, 15, 17, and 19
-            upper_xor  = (addr & 0xE000)  >> 13; // Bits 13, 14, 15
-            upper_xor |= (addr & 0x20000) >> 14; // Bit 17
-            upper_xor |= (addr & 0x80000) >> 15; // Bit 19
+        // Upper xor value is bits 13, 14, 15, 17, and 19
+        upper_xor = (addr & 0xE000) >> 13;    // Bits 13, 14, 15
+        upper_xor |= (addr & 0x20000) >> 14;  // Bit 17
+        upper_xor |= (addr & 0x80000) >> 15;  // Bit 19
 
-            set_index = (lower_xor ^ upper_xor);
+        set_index = (lower_xor ^ upper_xor);
 
-            // 48KB cache prepends the set_index with bit 12
-            if(m_nset == 64)
-                set_index |= (addr & 0x1000) >> 7;
+        // 48KB cache prepends the set_index with bit 12
+        if (m_nset == 64) set_index |= (addr & 0x1000) >> 7;
 
-        }else{ /* Else incorrect number of sets for the hashing function */
-            assert("\nGPGPU-Sim cache configuration error: The number of sets should be "
-                    "32 or 64 for the hashing set index function.\n" && 0);
-        }
-        break;
+      } else { /* Else incorrect number of sets for the hashing function */
+        assert(
+            "\nGPGPU-Sim cache configuration error: The number of sets should "
+            "be "
+            "32 or 64 for the hashing set index function.\n" &&
+            0);
+      }
+      break;
 
     case HASH_IPOLY_FUNCTION:
-    	/*
-		* Set Indexing function from "Pseudo-randomly interleaved memory."
-		* Rau, B. R et al.
-		* ISCA 1991
-		*
-		* "Sacat: streaming-aware conflict-avoiding thrashing-resistant gpgpu cache management scheme."
-		* Khairy et al.
-		* IEEE TPDS 2017.
-    	*/
-    	if(m_nset == 32 || m_nset == 64){
-		std::bitset<64> a(addr);
-		std::bitset<6> index;
-		index[0] = a[25]^a[24]^a[23]^a[22]^a[21]^a[18]^a[17]^a[15]^a[12]^a[7]; //10
-		index[1] = a[26]^a[25]^a[24]^a[23]^a[22]^a[19]^a[18]^a[16]^a[13]^a[8]; //10
-		index[2] = a[26]^a[22]^a[21]^a[20]^a[19]^a[18]^a[15]^a[14]^a[12]^a[9]; //10
-		index[3] = a[23]^a[22]^a[21]^a[20]^a[19]^a[16]^a[15]^a[13]^a[10]; //9
-		index[4] = a[24]^a[23]^a[22]^a[21]^a[20]^a[17]^a[16]^a[14]^a[11]; //9
+      /*
+       * Set Indexing function from "Pseudo-randomly interleaved memory."
+       * Rau, B. R et al.
+       * ISCA 1991
+       *
+       * "Sacat: streaming-aware conflict-avoiding thrashing-resistant gpgpu
+       * cache management scheme." Khairy et al. IEEE TPDS 2017.
+       */
+      if (m_nset == 32 || m_nset == 64) {
+        std::bitset<64> a(addr);
+        std::bitset<6> index;
+        index[0] = a[25] ^ a[24] ^ a[23] ^ a[22] ^ a[21] ^ a[18] ^ a[17] ^
+                   a[15] ^ a[12] ^ a[7];  // 10
+        index[1] = a[26] ^ a[25] ^ a[24] ^ a[23] ^ a[22] ^ a[19] ^ a[18] ^
+                   a[16] ^ a[13] ^ a[8];  // 10
+        index[2] = a[26] ^ a[22] ^ a[21] ^ a[20] ^ a[19] ^ a[18] ^ a[15] ^
+                   a[14] ^ a[12] ^ a[9];  // 10
+        index[3] = a[23] ^ a[22] ^ a[21] ^ a[20] ^ a[19] ^ a[16] ^ a[15] ^
+                   a[13] ^ a[10];  // 9
+        index[4] = a[24] ^ a[23] ^ a[22] ^ a[21] ^ a[20] ^ a[17] ^ a[16] ^
+                   a[14] ^ a[11];  // 9
 
-		 if(m_nset == 64)
-			 index[5] = a[12];
+        if (m_nset == 64) index[5] = a[12];
 
-		set_index = index.to_ulong();
+        set_index = index.to_ulong();
 
-    	}else{ /* Else incorrect number of sets for the hashing function */
-    	            assert("\nGPGPU-Sim cache configuration error: The number of sets should be "
-    	                    "32 or 64 for the hashing set index function.\n" && 0);
-    	 }
-        break;
+      } else { /* Else incorrect number of sets for the hashing function */
+        assert(
+            "\nGPGPU-Sim cache configuration error: The number of sets should "
+            "be "
+            "32 or 64 for the hashing set index function.\n" &&
+            0);
+      }
+      break;
 
     case CUSTOM_SET_FUNCTION:
-        /* No custom set function implemented */
-        break;
+      /* No custom set function implemented */
+      break;
 
     case LINEAR_SET_FUNCTION:
-        set_index = (addr >> m_line_sz_log2) & (m_nset-1);
-        break;
+      set_index = (addr >> m_line_sz_log2) & (m_nset - 1);
+      break;
 
     default:
-    	 assert("\nUndefined set index function.\n" && 0);
-    	 break;
-    }
+      assert("\nUndefined set index function.\n" && 0);
+      break;
+  }
 
-    // Linear function selected or custom set index function not implemented
-    assert((set_index < m_nset) && "\nError: Set index out of bounds. This is caused by "
-            "an incorrect or unimplemented custom set index function.\n");
+  // Linear function selected or custom set index function not implemented
+  assert((set_index < m_nset) &&
+         "\nError: Set index out of bounds. This is caused by "
+         "an incorrect or unimplemented custom set index function.\n");
 
-    return set_index;
+  return set_index;
 }
 
-void l2_cache_config::init(linear_to_raw_address_translation *address_mapping){
-	cache_config::init(m_config_string,FuncCachePreferNone);
-	m_address_mapping = address_mapping;
+void l2_cache_config::init(linear_to_raw_address_translation *address_mapping) {
+  cache_config::init(m_config_string, FuncCachePreferNone);
+  m_address_mapping = address_mapping;
 }
 
-unsigned l2_cache_config::set_index(new_addr_type addr) const{
-	if(!m_address_mapping){
-		return(addr >> m_line_sz_log2) & (m_nset-1);
-	}else{
-		// Calculate set index without memory partition bits to reduce set camping
-		new_addr_type part_addr = m_address_mapping->partition_address(addr);
-		return(part_addr >> m_line_sz_log2) & (m_nset -1);
-	}
+unsigned l2_cache_config::set_index(new_addr_type addr) const {
+  if (!m_address_mapping) {
+    return (addr >> m_line_sz_log2) & (m_nset - 1);
+  } else {
+    // Calculate set index without memory partition bits to reduce set camping
+    new_addr_type part_addr = m_address_mapping->partition_address(addr);
+    return (part_addr >> m_line_sz_log2) & (m_nset - 1);
+  }
 }
 
-tag_array::~tag_array() 
-{
-	unsigned cache_lines_num = m_config.get_max_num_lines();
-	for(unsigned i=0; i<cache_lines_num; ++i)
-		delete m_lines[i];
-    delete[] m_lines;
+tag_array::~tag_array() {
+  unsigned cache_lines_num = m_config.get_max_num_lines();
+  for (unsigned i = 0; i < cache_lines_num; ++i) delete m_lines[i];
+  delete[] m_lines;
 }
 
-tag_array::tag_array( cache_config &config,
-                      int core_id,
-                      int type_id,
-                      cache_block_t** new_lines)
-    : m_config( config ),
-      m_lines( new_lines )
-{
-    init( core_id, type_id );
+tag_array::tag_array(cache_config &config, int core_id, int type_id,
+                     cache_block_t **new_lines)
+    : m_config(config), m_lines(new_lines) {
+  init(core_id, type_id);
 }
 
-void tag_array::update_cache_parameters(cache_config &config)
-{
-	m_config=config;
+void tag_array::update_cache_parameters(cache_config &config) {
+  m_config = config;
 }
 
-tag_array::tag_array( cache_config &config,
-                      int core_id,
-                      int type_id )
-    : m_config( config )
-{
-    //assert( m_config.m_write_policy == READ_ONLY ); Old assert
-	unsigned cache_lines_num = config.get_max_num_lines();
-	m_lines = new cache_block_t*[cache_lines_num];
-	if(config.m_cache_type == NORMAL)
-	{
-		for(unsigned i=0; i<cache_lines_num; ++i)
-			m_lines[i] = new line_cache_block();
-	}
-	else if(config.m_cache_type == SECTOR)
-	{
-		for(unsigned i=0; i<cache_lines_num; ++i)
-			m_lines[i] = new sector_cache_block();
-	}
-	else
-		assert(0);
+tag_array::tag_array(cache_config &config, int core_id, int type_id)
+    : m_config(config) {
+  // assert( m_config.m_write_policy == READ_ONLY ); Old assert
+  unsigned cache_lines_num = config.get_max_num_lines();
+  m_lines = new cache_block_t *[cache_lines_num];
+  if (config.m_cache_type == NORMAL) {
+    for (unsigned i = 0; i < cache_lines_num; ++i)
+      m_lines[i] = new line_cache_block();
+  } else if (config.m_cache_type == SECTOR) {
+    for (unsigned i = 0; i < cache_lines_num; ++i)
+      m_lines[i] = new sector_cache_block();
+  } else
+    assert(0);
 
-    init( core_id, type_id );
+  init(core_id, type_id);
 }
 
-void tag_array::init( int core_id, int type_id )
-{
-    m_access = 0;
-    m_miss = 0;
-    m_pending_hit = 0;
-    m_res_fail = 0;
-    m_sector_miss = 0;
-    // initialize snapshot counters for visualizer
-    m_prev_snapshot_access = 0;
-    m_prev_snapshot_miss = 0;
-    m_prev_snapshot_pending_hit = 0;
-    m_core_id = core_id; 
-    m_type_id = type_id;
-    is_used = false;
+void tag_array::init(int core_id, int type_id) {
+  m_access = 0;
+  m_miss = 0;
+  m_pending_hit = 0;
+  m_res_fail = 0;
+  m_sector_miss = 0;
+  // initialize snapshot counters for visualizer
+  m_prev_snapshot_access = 0;
+  m_prev_snapshot_miss = 0;
+  m_prev_snapshot_pending_hit = 0;
+  m_core_id = core_id;
+  m_type_id = type_id;
+  is_used = false;
 }
 
-void tag_array::add_pending_line(mem_fetch *mf){
-	assert(mf);
-	new_addr_type addr = m_config.block_addr(mf->get_addr());
-	line_table::const_iterator i = pending_lines.find(addr);
-	if ( i == pending_lines.end() ) {
-		pending_lines[addr] = mf->get_inst().get_uid();
-	}
+void tag_array::add_pending_line(mem_fetch *mf) {
+  assert(mf);
+  new_addr_type addr = m_config.block_addr(mf->get_addr());
+  line_table::const_iterator i = pending_lines.find(addr);
+  if (i == pending_lines.end()) {
+    pending_lines[addr] = mf->get_inst().get_uid();
+  }
 }
 
-void tag_array::remove_pending_line(mem_fetch *mf){
-	assert(mf);
-	new_addr_type addr = m_config.block_addr(mf->get_addr());
-	line_table::const_iterator i = pending_lines.find(addr);
-	if ( i != pending_lines.end() ) {
-		pending_lines.erase(addr);
-	}
+void tag_array::remove_pending_line(mem_fetch *mf) {
+  assert(mf);
+  new_addr_type addr = m_config.block_addr(mf->get_addr());
+  line_table::const_iterator i = pending_lines.find(addr);
+  if (i != pending_lines.end()) {
+    pending_lines.erase(addr);
+  }
 }
 
-enum cache_request_status tag_array::probe( new_addr_type addr, unsigned &idx, mem_fetch* mf, bool probe_mode) const {
-    mem_access_sector_mask_t mask = mf->get_access_sector_mask();
-    return probe(addr, idx, mask, probe_mode, mf);
+enum cache_request_status tag_array::probe(new_addr_type addr, unsigned &idx,
+                                           mem_fetch *mf,
+                                           bool probe_mode) const {
+  mem_access_sector_mask_t mask = mf->get_access_sector_mask();
+  return probe(addr, idx, mask, probe_mode, mf);
 }
 
+enum cache_request_status tag_array::probe(new_addr_type addr, unsigned &idx,
+                                           mem_access_sector_mask_t mask,
+                                           bool probe_mode,
+                                           mem_fetch *mf) const {
+  // assert( m_config.m_write_policy == READ_ONLY );
+  unsigned set_index = m_config.set_index(addr);
+  new_addr_type tag = m_config.tag(addr);
 
-enum cache_request_status tag_array::probe( new_addr_type addr, unsigned &idx, mem_access_sector_mask_t mask, bool probe_mode, mem_fetch* mf) const {
-    //assert( m_config.m_write_policy == READ_ONLY );
-    unsigned set_index = m_config.set_index(addr);
-    new_addr_type tag = m_config.tag(addr);
+  unsigned invalid_line = (unsigned)-1;
+  unsigned valid_line = (unsigned)-1;
+  unsigned long long valid_timestamp = (unsigned)-1;
 
-    unsigned invalid_line = (unsigned)-1;
-    unsigned valid_line = (unsigned)-1;
-    unsigned long long valid_timestamp = (unsigned)-1;
+  bool all_reserved = true;
 
-    bool all_reserved = true;
-
-    // check for hit or pending hit
-    for (unsigned way=0; way<m_config.m_assoc; way++) {
-        unsigned index = set_index*m_config.m_assoc+way;
-        cache_block_t *line = m_lines[index];
-        if (line->m_tag == tag) {
-            if ( line->get_status(mask) == RESERVED ) {
-                idx = index;
-                return HIT_RESERVED;
-            } else if ( line->get_status(mask) == VALID ) {
-                idx = index;
-                return HIT;
-            } else if ( line->get_status(mask) == MODIFIED) {
-            	if(line->is_readable(mask)) {
-					idx = index;
-					return HIT;
-            	}
-            	else {
-            		idx = index;
-            		return SECTOR_MISS;
-            	}
-
-            } else if ( line->is_valid_line() && line->get_status(mask) == INVALID ) {
-                idx = index;
-                return SECTOR_MISS;
-            }else {
-                assert( line->get_status(mask) == INVALID );
-            }
+  // check for hit or pending hit
+  for (unsigned way = 0; way < m_config.m_assoc; way++) {
+    unsigned index = set_index * m_config.m_assoc + way;
+    cache_block_t *line = m_lines[index];
+    if (line->m_tag == tag) {
+      if (line->get_status(mask) == RESERVED) {
+        idx = index;
+        return HIT_RESERVED;
+      } else if (line->get_status(mask) == VALID) {
+        idx = index;
+        return HIT;
+      } else if (line->get_status(mask) == MODIFIED) {
+        if (line->is_readable(mask)) {
+          idx = index;
+          return HIT;
+        } else {
+          idx = index;
+          return SECTOR_MISS;
         }
-        if (!line->is_reserved_line()) {
-            all_reserved = false;
-            if (line->is_invalid_line()) {
-                invalid_line = index;
-            } else {
-                // valid line : keep track of most appropriate replacement candidate
-                if ( m_config.m_replacement_policy == LRU ) {
-                    if ( line->get_last_access_time() < valid_timestamp ) {
-                        valid_timestamp = line->get_last_access_time();
-                        valid_line = index;
-                    }
-                } else if ( m_config.m_replacement_policy == FIFO ) {
-                    if ( line->get_alloc_time() < valid_timestamp ) {
-                        valid_timestamp = line->get_alloc_time();
-                        valid_line = index;
-                    }
-                }
-            }
+
+      } else if (line->is_valid_line() && line->get_status(mask) == INVALID) {
+        idx = index;
+        return SECTOR_MISS;
+      } else {
+        assert(line->get_status(mask) == INVALID);
+      }
+    }
+    if (!line->is_reserved_line()) {
+      all_reserved = false;
+      if (line->is_invalid_line()) {
+        invalid_line = index;
+      } else {
+        // valid line : keep track of most appropriate replacement candidate
+        if (m_config.m_replacement_policy == LRU) {
+          if (line->get_last_access_time() < valid_timestamp) {
+            valid_timestamp = line->get_last_access_time();
+            valid_line = index;
+          }
+        } else if (m_config.m_replacement_policy == FIFO) {
+          if (line->get_alloc_time() < valid_timestamp) {
+            valid_timestamp = line->get_alloc_time();
+            valid_line = index;
+          }
         }
+      }
     }
-    if ( all_reserved ) {
-        assert( m_config.m_alloc_policy == ON_MISS ); 
-        return RESERVATION_FAIL; // miss and not enough space in cache to allocate on miss
+  }
+  if (all_reserved) {
+    assert(m_config.m_alloc_policy == ON_MISS);
+    return RESERVATION_FAIL;  // miss and not enough space in cache to allocate
+                              // on miss
+  }
+
+  if (invalid_line != (unsigned)-1) {
+    idx = invalid_line;
+  } else if (valid_line != (unsigned)-1) {
+    idx = valid_line;
+  } else
+    abort();  // if an unreserved block exists, it is either invalid or
+              // replaceable
+
+  if (probe_mode && m_config.is_streaming()) {
+    line_table::const_iterator i =
+        pending_lines.find(m_config.block_addr(addr));
+    assert(mf);
+    if (!mf->is_write() && i != pending_lines.end()) {
+      if (i->second != mf->get_inst().get_uid()) return SECTOR_MISS;
     }
+  }
 
-    if ( invalid_line != (unsigned)-1 ) {
-        idx = invalid_line;
-    } else if ( valid_line != (unsigned)-1) {
-        idx = valid_line;
-    } else abort(); // if an unreserved block exists, it is either invalid or replaceable 
-
-
-    if(probe_mode && m_config.is_streaming()){
-		line_table::const_iterator i = pending_lines.find(m_config.block_addr(addr));
-		assert(mf);
-		if ( !mf->is_write() && i != pending_lines.end() ) {
-			 if(i->second != mf->get_inst().get_uid())
-				 return SECTOR_MISS;
-		}
-    }
-
-    return MISS;
+  return MISS;
 }
 
-enum cache_request_status tag_array::access( new_addr_type addr, unsigned time, unsigned &idx, mem_fetch* mf)
-{
-    bool wb=false;
-    evicted_block_info evicted;
-    enum cache_request_status result = access(addr,time,idx,wb,evicted,mf);
-    assert(!wb);
-    return result;
+enum cache_request_status tag_array::access(new_addr_type addr, unsigned time,
+                                            unsigned &idx, mem_fetch *mf) {
+  bool wb = false;
+  evicted_block_info evicted;
+  enum cache_request_status result = access(addr, time, idx, wb, evicted, mf);
+  assert(!wb);
+  return result;
 }
 
-enum cache_request_status tag_array::access( new_addr_type addr, unsigned time, unsigned &idx, bool &wb, evicted_block_info &evicted, mem_fetch* mf )
-{
-    m_access++;
-    is_used = true;
-    shader_cache_access_log(m_core_id, m_type_id, 0); // log accesses to cache
-    enum cache_request_status status = probe(addr,idx,mf);
-    switch (status) {
-    case HIT_RESERVED: 
-        m_pending_hit++;
-    case HIT: 
-        m_lines[idx]->set_last_access_time(time, mf->get_access_sector_mask());
-        break;
+enum cache_request_status tag_array::access(new_addr_type addr, unsigned time,
+                                            unsigned &idx, bool &wb,
+                                            evicted_block_info &evicted,
+                                            mem_fetch *mf) {
+  m_access++;
+  is_used = true;
+  shader_cache_access_log(m_core_id, m_type_id, 0);  // log accesses to cache
+  enum cache_request_status status = probe(addr, idx, mf);
+  switch (status) {
+    case HIT_RESERVED:
+      m_pending_hit++;
+    case HIT:
+      m_lines[idx]->set_last_access_time(time, mf->get_access_sector_mask());
+      break;
     case MISS:
-        m_miss++;
-        shader_cache_access_log(m_core_id, m_type_id, 1); // log cache misses
-        if ( m_config.m_alloc_policy == ON_MISS ) {
-            if( m_lines[idx]->is_modified_line()) {
-                wb = true;
-                evicted.set_info(m_lines[idx]->m_block_addr, m_lines[idx]->get_modified_size());
-            }
-            m_lines[idx]->allocate( m_config.tag(addr), m_config.block_addr(addr), time, mf->get_access_sector_mask());
+      m_miss++;
+      shader_cache_access_log(m_core_id, m_type_id, 1);  // log cache misses
+      if (m_config.m_alloc_policy == ON_MISS) {
+        if (m_lines[idx]->is_modified_line()) {
+          wb = true;
+          evicted.set_info(m_lines[idx]->m_block_addr,
+                           m_lines[idx]->get_modified_size());
         }
-        break;
+        m_lines[idx]->allocate(m_config.tag(addr), m_config.block_addr(addr),
+                               time, mf->get_access_sector_mask());
+      }
+      break;
     case SECTOR_MISS:
-    	assert(m_config.m_cache_type == SECTOR);
-    	m_sector_miss++;
-		shader_cache_access_log(m_core_id, m_type_id, 1); // log cache misses
-		if ( m_config.m_alloc_policy == ON_MISS ) {
-			((sector_cache_block*)m_lines[idx])->allocate_sector( time, mf->get_access_sector_mask() );
-		}
-		break;
+      assert(m_config.m_cache_type == SECTOR);
+      m_sector_miss++;
+      shader_cache_access_log(m_core_id, m_type_id, 1);  // log cache misses
+      if (m_config.m_alloc_policy == ON_MISS) {
+        ((sector_cache_block *)m_lines[idx])
+            ->allocate_sector(time, mf->get_access_sector_mask());
+      }
+      break;
     case RESERVATION_FAIL:
-        m_res_fail++;
-        shader_cache_access_log(m_core_id, m_type_id, 1); // log cache misses
-        break;
+      m_res_fail++;
+      shader_cache_access_log(m_core_id, m_type_id, 1);  // log cache misses
+      break;
     default:
-        fprintf( stderr, "tag_array::access - Error: Unknown"
-            "cache_request_status %d\n", status );
-        abort();
+      fprintf(stderr,
+              "tag_array::access - Error: Unknown"
+              "cache_request_status %d\n",
+              status);
+      abort();
+  }
+  return status;
+}
+
+void tag_array::fill(new_addr_type addr, unsigned time, mem_fetch *mf) {
+  fill(addr, time, mf->get_access_sector_mask());
+}
+
+void tag_array::fill(new_addr_type addr, unsigned time,
+                     mem_access_sector_mask_t mask) {
+  // assert( m_config.m_alloc_policy == ON_FILL );
+  unsigned idx;
+  enum cache_request_status status = probe(addr, idx, mask);
+  // assert(status==MISS||status==SECTOR_MISS); // MSHR should have prevented
+  // redundant memory request
+  if (status == MISS)
+    m_lines[idx]->allocate(m_config.tag(addr), m_config.block_addr(addr), time,
+                           mask);
+  else if (status == SECTOR_MISS) {
+    assert(m_config.m_cache_type == SECTOR);
+    ((sector_cache_block *)m_lines[idx])->allocate_sector(time, mask);
+  }
+
+  m_lines[idx]->fill(time, mask);
+}
+
+void tag_array::fill(unsigned index, unsigned time, mem_fetch *mf) {
+  assert(m_config.m_alloc_policy == ON_MISS);
+  m_lines[index]->fill(time, mf->get_access_sector_mask());
+}
+
+// TODO: we need write back the flushed data to the upper level
+void tag_array::flush() {
+  if (!is_used) return;
+
+  for (unsigned i = 0; i < m_config.get_num_lines(); i++)
+    if (m_lines[i]->is_modified_line()) {
+      for (unsigned j = 0; j < SECTOR_CHUNCK_SIZE; j++)
+        m_lines[i]->set_status(INVALID, mem_access_sector_mask_t().set(j));
     }
-    return status;
+
+  is_used = false;
 }
 
-void tag_array::fill( new_addr_type addr, unsigned time, mem_fetch* mf)
-{
-    fill(addr, time, mf->get_access_sector_mask());
+void tag_array::invalidate() {
+  if (!is_used) return;
+
+  for (unsigned i = 0; i < m_config.get_num_lines(); i++)
+    for (unsigned j = 0; j < SECTOR_CHUNCK_SIZE; j++)
+      m_lines[i]->set_status(INVALID, mem_access_sector_mask_t().set(j));
+
+  is_used = false;
 }
 
-void tag_array::fill( new_addr_type addr, unsigned time, mem_access_sector_mask_t mask )
-{
-    //assert( m_config.m_alloc_policy == ON_FILL );
-    unsigned idx;
-    enum cache_request_status status = probe(addr,idx,mask);
-    //assert(status==MISS||status==SECTOR_MISS); // MSHR should have prevented redundant memory request
-    if(status==MISS)
-    	m_lines[idx]->allocate( m_config.tag(addr), m_config.block_addr(addr), time, mask );
-    else if (status==SECTOR_MISS) {
-    	assert(m_config.m_cache_type == SECTOR);
-    	((sector_cache_block*)m_lines[idx])->allocate_sector( time, mask );
-    }
+float tag_array::windowed_miss_rate() const {
+  unsigned n_access = m_access - m_prev_snapshot_access;
+  unsigned n_miss = (m_miss + m_sector_miss) - m_prev_snapshot_miss;
+  // unsigned n_pending_hit = m_pending_hit - m_prev_snapshot_pending_hit;
 
-    m_lines[idx]->fill(time, mask);
+  float missrate = 0.0f;
+  if (n_access != 0) missrate = (float)(n_miss + m_sector_miss) / n_access;
+  return missrate;
 }
 
-void tag_array::fill( unsigned index, unsigned time, mem_fetch* mf)
-{
-    assert( m_config.m_alloc_policy == ON_MISS );
-    m_lines[index]->fill(time, mf->get_access_sector_mask());
+void tag_array::new_window() {
+  m_prev_snapshot_access = m_access;
+  m_prev_snapshot_miss = m_miss;
+  m_prev_snapshot_miss = m_miss + m_sector_miss;
+  m_prev_snapshot_pending_hit = m_pending_hit;
 }
 
-
-//TODO: we need write back the flushed data to the upper level
-void tag_array::flush() 
-{
-	if(!is_used)
-		return;
-
-    for (unsigned i=0; i < m_config.get_num_lines(); i++)
-    	if(m_lines[i]->is_modified_line()) {
-    	for(unsigned j=0; j < SECTOR_CHUNCK_SIZE; j++)
-    		m_lines[i]->set_status(INVALID, mem_access_sector_mask_t().set(j)) ;
-    	}
-
-    is_used = false;
+void tag_array::print(FILE *stream, unsigned &total_access,
+                      unsigned &total_misses) const {
+  m_config.print(stream);
+  fprintf(stream,
+          "\t\tAccess = %d, Miss = %d, Sector_Miss = %d, Total_Miss = %d "
+          "(%.3g), PendingHit = %d (%.3g)\n",
+          m_access, m_miss, m_sector_miss, (m_miss + m_sector_miss),
+          (float)(m_miss + m_sector_miss) / m_access, m_pending_hit,
+          (float)m_pending_hit / m_access);
+  total_misses += (m_miss + m_sector_miss);
+  total_access += m_access;
 }
 
-void tag_array::invalidate()
-{
-	if(!is_used)
-		return;
-
-    for (unsigned i=0; i < m_config.get_num_lines(); i++)
-    	for(unsigned j=0; j < SECTOR_CHUNCK_SIZE; j++)
-    		m_lines[i]->set_status(INVALID, mem_access_sector_mask_t().set(j)) ;
-
-    is_used = false;
+void tag_array::get_stats(unsigned &total_access, unsigned &total_misses,
+                          unsigned &total_hit_res,
+                          unsigned &total_res_fail) const {
+  // Update statistics from the tag array
+  total_access = m_access;
+  total_misses = (m_miss + m_sector_miss);
+  total_hit_res = m_pending_hit;
+  total_res_fail = m_res_fail;
 }
 
-float tag_array::windowed_miss_rate( ) const
-{
-    unsigned n_access    = m_access - m_prev_snapshot_access;
-    unsigned n_miss      = (m_miss+m_sector_miss) - m_prev_snapshot_miss;
-    // unsigned n_pending_hit = m_pending_hit - m_prev_snapshot_pending_hit;
-
-    float missrate = 0.0f;
-    if (n_access != 0)
-        missrate = (float) (n_miss+m_sector_miss) / n_access;
-    return missrate;
+bool was_write_sent(const std::list<cache_event> &events) {
+  for (std::list<cache_event>::const_iterator e = events.begin();
+       e != events.end(); e++) {
+    if ((*e).m_cache_event_type == WRITE_REQUEST_SENT) return true;
+  }
+  return false;
 }
 
-void tag_array::new_window()
-{
-    m_prev_snapshot_access = m_access;
-    m_prev_snapshot_miss = m_miss;
-    m_prev_snapshot_miss = m_miss + m_sector_miss;
-    m_prev_snapshot_pending_hit = m_pending_hit;
+bool was_writeback_sent(const std::list<cache_event> &events,
+                        cache_event &wb_event) {
+  for (std::list<cache_event>::const_iterator e = events.begin();
+       e != events.end(); e++) {
+    if ((*e).m_cache_event_type == WRITE_BACK_REQUEST_SENT) wb_event = *e;
+    return true;
+  }
+  return false;
 }
 
-void tag_array::print( FILE *stream, unsigned &total_access, unsigned &total_misses ) const
-{
-    m_config.print(stream);
-    fprintf( stream, "\t\tAccess = %d, Miss = %d, Sector_Miss = %d, Total_Miss = %d (%.3g), PendingHit = %d (%.3g)\n",
-             m_access, m_miss, m_sector_miss, (m_miss+m_sector_miss), (float) (m_miss+m_sector_miss) / m_access,
-             m_pending_hit, (float) m_pending_hit / m_access);
-    total_misses+=(m_miss+m_sector_miss);
-    total_access+=m_access;
+bool was_read_sent(const std::list<cache_event> &events) {
+  for (std::list<cache_event>::const_iterator e = events.begin();
+       e != events.end(); e++) {
+    if ((*e).m_cache_event_type == READ_REQUEST_SENT) return true;
+  }
+  return false;
 }
 
-void tag_array::get_stats(unsigned &total_access, unsigned &total_misses, unsigned &total_hit_res, unsigned &total_res_fail) const{
-    // Update statistics from the tag array
-    total_access    = m_access;
-    total_misses    = (m_miss+m_sector_miss);
-    total_hit_res   = m_pending_hit;
-    total_res_fail  = m_res_fail;
+bool was_writeallocate_sent(const std::list<cache_event> &events) {
+  for (std::list<cache_event>::const_iterator e = events.begin();
+       e != events.end(); e++) {
+    if ((*e).m_cache_event_type == WRITE_ALLOCATE_SENT) return true;
+  }
+  return false;
 }
-
-
-bool was_write_sent( const std::list<cache_event> &events )
-{
-    for( std::list<cache_event>::const_iterator e=events.begin(); e!=events.end(); e++ ) {
-        if( (*e).m_cache_event_type == WRITE_REQUEST_SENT )
-            return true;
-    }
-    return false;
-}
-
-bool was_writeback_sent( const std::list<cache_event> &events, cache_event& wb_event)
-{
-    for( std::list<cache_event>::const_iterator e=events.begin(); e!=events.end(); e++ ) {
-        if( (*e).m_cache_event_type == WRITE_BACK_REQUEST_SENT )
-        	wb_event = *e;
-            return true;
-    }
-    return false;
-}
-
-bool was_read_sent( const std::list<cache_event> &events )
-{
-    for( std::list<cache_event>::const_iterator e=events.begin(); e!=events.end(); e++ ) {
-        if( (*e).m_cache_event_type == READ_REQUEST_SENT )
-            return true;
-    }
-    return false;
-}
-
-bool was_writeallocate_sent( const std::list<cache_event> &events )
-{
-    for( std::list<cache_event>::const_iterator e=events.begin(); e!=events.end(); e++ ) {
-        if( (*e).m_cache_event_type == WRITE_ALLOCATE_SENT )
-            return true;
-    }
-    return false;
-}
-/****************************************************************** MSHR ******************************************************************/
+/****************************************************************** MSHR
+ * ******************************************************************/
 
 /// Checks if there is a pending request to the lower memory level already
-bool mshr_table::probe( new_addr_type block_addr ) const{
-    table::const_iterator a = m_data.find(block_addr);
-    return a != m_data.end();
+bool mshr_table::probe(new_addr_type block_addr) const {
+  table::const_iterator a = m_data.find(block_addr);
+  return a != m_data.end();
 }
 
 /// Checks if there is space for tracking a new memory access
-bool mshr_table::full( new_addr_type block_addr ) const{
-    table::const_iterator i=m_data.find(block_addr);
-    if ( i != m_data.end() )
-        return i->second.m_list.size() >= m_max_merged;
-    else
-        return m_data.size() >= m_num_entries;
+bool mshr_table::full(new_addr_type block_addr) const {
+  table::const_iterator i = m_data.find(block_addr);
+  if (i != m_data.end())
+    return i->second.m_list.size() >= m_max_merged;
+  else
+    return m_data.size() >= m_num_entries;
 }
 
 /// Add or merge this access
-void mshr_table::add( new_addr_type block_addr, mem_fetch *mf ){
-	m_data[block_addr].m_list.push_back(mf);
-	assert( m_data.size() <= m_num_entries );
-	assert( m_data[block_addr].m_list.size() <= m_max_merged );
-	// indicate that this MSHR entry contains an atomic operation
-	if ( mf->isatomic() ) {
-		m_data[block_addr].m_has_atomic = true;
-	}
+void mshr_table::add(new_addr_type block_addr, mem_fetch *mf) {
+  m_data[block_addr].m_list.push_back(mf);
+  assert(m_data.size() <= m_num_entries);
+  assert(m_data[block_addr].m_list.size() <= m_max_merged);
+  // indicate that this MSHR entry contains an atomic operation
+  if (mf->isatomic()) {
+    m_data[block_addr].m_has_atomic = true;
+  }
 }
 
 /// check is_read_after_write_pending
-bool mshr_table::is_read_after_write_pending( new_addr_type block_addr){
-	std::list<mem_fetch*> my_list = m_data[block_addr].m_list;
-	bool write_found = false;
-	for (std::list<mem_fetch*>::iterator it=my_list.begin(); it != my_list.end(); ++it)
-	{
-		if((*it)->is_write()) //Pending Write Request
-			write_found = true;
-		else if(write_found)   //Pending Read Request and we found previous Write
-				return true;
-	}
+bool mshr_table::is_read_after_write_pending(new_addr_type block_addr) {
+  std::list<mem_fetch *> my_list = m_data[block_addr].m_list;
+  bool write_found = false;
+  for (std::list<mem_fetch *>::iterator it = my_list.begin();
+       it != my_list.end(); ++it) {
+    if ((*it)->is_write())  // Pending Write Request
+      write_found = true;
+    else if (write_found)  // Pending Read Request and we found previous Write
+      return true;
+  }
 
-	return false;
-
+  return false;
 }
 
 /// Accept a new cache fill response: mark entry ready for processing
-void mshr_table::mark_ready( new_addr_type block_addr, bool &has_atomic ){
-    assert( !busy() );
-    table::iterator a = m_data.find(block_addr);
-    assert( a != m_data.end() );
-    m_current_response.push_back( block_addr );
-    has_atomic = a->second.m_has_atomic;
-    assert( m_current_response.size() <= m_data.size() );
+void mshr_table::mark_ready(new_addr_type block_addr, bool &has_atomic) {
+  assert(!busy());
+  table::iterator a = m_data.find(block_addr);
+  assert(a != m_data.end());
+  m_current_response.push_back(block_addr);
+  has_atomic = a->second.m_has_atomic;
+  assert(m_current_response.size() <= m_data.size());
 }
 
 /// Returns next ready access
-mem_fetch *mshr_table::next_access(){
-    assert( access_ready() );
-    new_addr_type block_addr = m_current_response.front();
-    assert( !m_data[block_addr].m_list.empty() );
-    mem_fetch *result = m_data[block_addr].m_list.front();
-    m_data[block_addr].m_list.pop_front();
-    if ( m_data[block_addr].m_list.empty() ) {
-        // release entry
-        m_data.erase(block_addr);
-        m_current_response.pop_front();
+mem_fetch *mshr_table::next_access() {
+  assert(access_ready());
+  new_addr_type block_addr = m_current_response.front();
+  assert(!m_data[block_addr].m_list.empty());
+  mem_fetch *result = m_data[block_addr].m_list.front();
+  m_data[block_addr].m_list.pop_front();
+  if (m_data[block_addr].m_list.empty()) {
+    // release entry
+    m_data.erase(block_addr);
+    m_current_response.pop_front();
+  }
+  return result;
+}
+
+void mshr_table::display(FILE *fp) const {
+  fprintf(fp, "MSHR contents\n");
+  for (table::const_iterator e = m_data.begin(); e != m_data.end(); ++e) {
+    unsigned block_addr = e->first;
+    fprintf(fp, "MSHR: tag=0x%06x, atomic=%d %zu entries : ", block_addr,
+            e->second.m_has_atomic, e->second.m_list.size());
+    if (!e->second.m_list.empty()) {
+      mem_fetch *mf = e->second.m_list.front();
+      fprintf(fp, "%p :", mf);
+      mf->print(fp);
+    } else {
+      fprintf(fp, " no memory requests???\n");
     }
-    return result;
+  }
+}
+/***************************************************************** Caches
+ * *****************************************************************/
+cache_stats::cache_stats() {
+  m_stats.resize(NUM_MEM_ACCESS_TYPE);
+  m_stats_pw.resize(NUM_MEM_ACCESS_TYPE);
+  m_fail_stats.resize(NUM_MEM_ACCESS_TYPE);
+  for (unsigned i = 0; i < NUM_MEM_ACCESS_TYPE; ++i) {
+    m_stats[i].resize(NUM_CACHE_REQUEST_STATUS, 0);
+    m_stats_pw[i].resize(NUM_CACHE_REQUEST_STATUS, 0);
+    m_fail_stats[i].resize(NUM_CACHE_RESERVATION_FAIL_STATUS, 0);
+  }
+  m_cache_port_available_cycles = 0;
+  m_cache_data_port_busy_cycles = 0;
+  m_cache_fill_port_busy_cycles = 0;
 }
 
-void mshr_table::display( FILE *fp ) const{
-    fprintf(fp,"MSHR contents\n");
-    for ( table::const_iterator e=m_data.begin(); e!=m_data.end(); ++e ) {
-        unsigned block_addr = e->first;
-        fprintf(fp,"MSHR: tag=0x%06x, atomic=%d %zu entries : ", block_addr, e->second.m_has_atomic, e->second.m_list.size());
-        if ( !e->second.m_list.empty() ) {
-            mem_fetch *mf = e->second.m_list.front();
-            fprintf(fp,"%p :",mf);
-            mf->print(fp);
-        } else {
-            fprintf(fp," no memory requests???\n");
-        }
+void cache_stats::clear() {
+  ///
+  /// Zero out all current cache statistics
+  ///
+  for (unsigned i = 0; i < NUM_MEM_ACCESS_TYPE; ++i) {
+    std::fill(m_stats[i].begin(), m_stats[i].end(), 0);
+    std::fill(m_fail_stats[i].begin(), m_fail_stats[i].end(), 0);
+  }
+  m_cache_port_available_cycles = 0;
+  m_cache_data_port_busy_cycles = 0;
+  m_cache_fill_port_busy_cycles = 0;
+}
+
+void cache_stats::clear_pw() {
+  ///
+  /// Zero out per-window cache statistics
+  ///
+  for (unsigned i = 0; i < NUM_MEM_ACCESS_TYPE; ++i) {
+    std::fill(m_stats_pw[i].begin(), m_stats_pw[i].end(), 0);
+  }
+}
+
+void cache_stats::inc_stats(int access_type, int access_outcome) {
+  ///
+  /// Increment the stat corresponding to (access_type, access_outcome) by 1.
+  ///
+  if (!check_valid(access_type, access_outcome))
+    assert(0 && "Unknown cache access type or access outcome");
+
+  m_stats[access_type][access_outcome]++;
+}
+
+void cache_stats::inc_stats_pw(int access_type, int access_outcome) {
+  ///
+  /// Increment the corresponding per-window cache stat
+  ///
+  if (!check_valid(access_type, access_outcome))
+    assert(0 && "Unknown cache access type or access outcome");
+  m_stats_pw[access_type][access_outcome]++;
+}
+
+void cache_stats::inc_fail_stats(int access_type, int fail_outcome) {
+  if (!check_fail_valid(access_type, fail_outcome))
+    assert(0 && "Unknown cache access type or access fail");
+
+  m_fail_stats[access_type][fail_outcome]++;
+}
+
+enum cache_request_status cache_stats::select_stats_status(
+    enum cache_request_status probe, enum cache_request_status access) const {
+  ///
+  /// This function selects how the cache access outcome should be counted.
+  /// HIT_RESERVED is considered as a MISS in the cores, however, it should be
+  /// counted as a HIT_RESERVED in the caches.
+  ///
+  if (probe == HIT_RESERVED && access != RESERVATION_FAIL)
+    return probe;
+  else if (probe == SECTOR_MISS && access == MISS)
+    return probe;
+  else
+    return access;
+}
+
+unsigned long long &cache_stats::operator()(int access_type, int access_outcome,
+                                            bool fail_outcome) {
+  ///
+  /// Simple method to read/modify the stat corresponding to (access_type,
+  /// access_outcome) Used overloaded () to avoid the need for separate
+  /// read/write member functions
+  ///
+  if (fail_outcome) {
+    if (!check_fail_valid(access_type, access_outcome))
+      assert(0 && "Unknown cache access type or fail outcome");
+
+    return m_fail_stats[access_type][access_outcome];
+  } else {
+    if (!check_valid(access_type, access_outcome))
+      assert(0 && "Unknown cache access type or access outcome");
+
+    return m_stats[access_type][access_outcome];
+  }
+}
+
+unsigned long long cache_stats::operator()(int access_type, int access_outcome,
+                                           bool fail_outcome) const {
+  ///
+  /// Const accessor into m_stats.
+  ///
+  if (fail_outcome) {
+    if (!check_fail_valid(access_type, access_outcome))
+      assert(0 && "Unknown cache access type or fail outcome");
+
+    return m_fail_stats[access_type][access_outcome];
+  } else {
+    if (!check_valid(access_type, access_outcome))
+      assert(0 && "Unknown cache access type or access outcome");
+
+    return m_stats[access_type][access_outcome];
+  }
+}
+
+cache_stats cache_stats::operator+(const cache_stats &cs) {
+  ///
+  /// Overloaded + operator to allow for simple stat accumulation
+  ///
+  cache_stats ret;
+  for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
+    for (unsigned status = 0; status < NUM_CACHE_REQUEST_STATUS; ++status) {
+      ret(type, status, false) =
+          m_stats[type][status] + cs(type, status, false);
     }
-}
-/***************************************************************** Caches *****************************************************************/
-cache_stats::cache_stats(){
-    m_stats.resize(NUM_MEM_ACCESS_TYPE);
-    m_stats_pw.resize(NUM_MEM_ACCESS_TYPE);
-    m_fail_stats.resize(NUM_MEM_ACCESS_TYPE);
-    for(unsigned i=0; i<NUM_MEM_ACCESS_TYPE; ++i){
-        m_stats[i].resize(NUM_CACHE_REQUEST_STATUS, 0);
-        m_stats_pw[i].resize(NUM_CACHE_REQUEST_STATUS, 0);
-		m_fail_stats[i].resize(NUM_CACHE_RESERVATION_FAIL_STATUS, 0);
-	}
-    m_cache_port_available_cycles = 0; 
-    m_cache_data_port_busy_cycles = 0; 
-    m_cache_fill_port_busy_cycles = 0; 
-}
-
-void cache_stats::clear(){
-    ///
-    /// Zero out all current cache statistics
-    ///
-    for(unsigned i=0; i<NUM_MEM_ACCESS_TYPE; ++i){
-        std::fill(m_stats[i].begin(), m_stats[i].end(), 0);
-		std::fill(m_fail_stats[i].begin(), m_fail_stats[i].end(), 0);
-	}
-    m_cache_port_available_cycles = 0; 
-    m_cache_data_port_busy_cycles = 0; 
-    m_cache_fill_port_busy_cycles = 0; 
-}
-
-void cache_stats::clear_pw(){
-    ///
-    /// Zero out per-window cache statistics
-    ///
-    for(unsigned i=0; i<NUM_MEM_ACCESS_TYPE; ++i){
-        std::fill(m_stats_pw[i].begin(), m_stats_pw[i].end(), 0);
-	}
-}
-
-void cache_stats::inc_stats(int access_type, int access_outcome){
-    ///
-    /// Increment the stat corresponding to (access_type, access_outcome) by 1.
-    ///
-    if(!check_valid(access_type, access_outcome))
-        assert(0 && "Unknown cache access type or access outcome");
-
-    m_stats[access_type][access_outcome]++;
-}
-
-void cache_stats::inc_stats_pw(int access_type, int access_outcome){
-    ///
-    /// Increment the corresponding per-window cache stat
-    ///
-    if(!check_valid(access_type, access_outcome))
-        assert(0 && "Unknown cache access type or access outcome");
-    m_stats_pw[access_type][access_outcome]++;
-}
-
-void cache_stats::inc_fail_stats(int access_type, int fail_outcome){
-
-	if(!check_fail_valid(access_type, fail_outcome))
-		 assert(0 && "Unknown cache access type or access fail");
-
-	m_fail_stats[access_type][fail_outcome]++;
-}
-
-
-enum cache_request_status cache_stats::select_stats_status(enum cache_request_status probe, enum cache_request_status access) const {
-	///
-	/// This function selects how the cache access outcome should be counted. HIT_RESERVED is considered as a MISS
-	/// in the cores, however, it should be counted as a HIT_RESERVED in the caches.
-	///
-	if(probe == HIT_RESERVED && access != RESERVATION_FAIL)
-		return probe;
-	else if(probe == SECTOR_MISS && access == MISS)
-		return probe;
-	else
-		return access;
-}
-
-unsigned long long &cache_stats::operator()(int access_type, int access_outcome, bool fail_outcome){
-    ///
-    /// Simple method to read/modify the stat corresponding to (access_type, access_outcome)
-    /// Used overloaded () to avoid the need for separate read/write member functions
-    ///
-	if(fail_outcome) {
-		if(!check_fail_valid(access_type, access_outcome))
-			assert(0 && "Unknown cache access type or fail outcome");
-
-		return m_fail_stats[access_type][access_outcome];
-	}
-	else {
-		if(!check_valid(access_type, access_outcome))
-			assert(0 && "Unknown cache access type or access outcome");
-
-		return m_stats[access_type][access_outcome];
-	}
-}
-
-unsigned long long cache_stats::operator()(int access_type, int access_outcome, bool fail_outcome) const{
-    ///
-    /// Const accessor into m_stats.
-    ///
-	if(fail_outcome) {
-		if(!check_fail_valid(access_type, access_outcome))
-			assert(0 && "Unknown cache access type or fail outcome");
-
-		return m_fail_stats[access_type][access_outcome];
-	}
-	else {
-		if(!check_valid(access_type, access_outcome))
-			assert(0 && "Unknown cache access type or access outcome");
-
-		return m_stats[access_type][access_outcome];
-	}
-}
-
-cache_stats cache_stats::operator+(const cache_stats &cs){
-    ///
-    /// Overloaded + operator to allow for simple stat accumulation
-    ///
-    cache_stats ret;
-    for(unsigned type=0; type<NUM_MEM_ACCESS_TYPE; ++type){
-        for(unsigned status=0; status<NUM_CACHE_REQUEST_STATUS; ++status){
-            ret(type, status, false) = m_stats[type][status] + cs(type, status, false);
-        }
-		for(unsigned status=0; status<NUM_CACHE_RESERVATION_FAIL_STATUS; ++status){
-			   ret(type, status, true) = m_fail_stats[type][status] + cs(type, status, true);
-		   }
-        }
-    ret.m_cache_port_available_cycles = m_cache_port_available_cycles + cs.m_cache_port_available_cycles; 
-    ret.m_cache_data_port_busy_cycles = m_cache_data_port_busy_cycles + cs.m_cache_data_port_busy_cycles; 
-    ret.m_cache_fill_port_busy_cycles = m_cache_fill_port_busy_cycles + cs.m_cache_fill_port_busy_cycles; 
-    return ret;
-}
-
-cache_stats &cache_stats::operator+=(const cache_stats &cs){
-    ///
-    /// Overloaded += operator to allow for simple stat accumulation
-    ///
-    for(unsigned type=0; type<NUM_MEM_ACCESS_TYPE; ++type){
-        for(unsigned status=0; status<NUM_CACHE_REQUEST_STATUS; ++status){
-            m_stats[type][status] += cs(type, status, false);
-        }
-        for(unsigned status=0; status<NUM_CACHE_REQUEST_STATUS; ++status){
-            m_stats_pw[type][status] += cs(type, status, false);
-        }
-        for(unsigned status=0; status<NUM_CACHE_RESERVATION_FAIL_STATUS; ++status){
-            m_fail_stats[type][status] += cs(type, status, true);
-	   }
+    for (unsigned status = 0; status < NUM_CACHE_RESERVATION_FAIL_STATUS;
+         ++status) {
+      ret(type, status, true) =
+          m_fail_stats[type][status] + cs(type, status, true);
     }
-    m_cache_port_available_cycles += cs.m_cache_port_available_cycles; 
-    m_cache_data_port_busy_cycles += cs.m_cache_data_port_busy_cycles; 
-    m_cache_fill_port_busy_cycles += cs.m_cache_fill_port_busy_cycles; 
-    return *this;
+  }
+  ret.m_cache_port_available_cycles =
+      m_cache_port_available_cycles + cs.m_cache_port_available_cycles;
+  ret.m_cache_data_port_busy_cycles =
+      m_cache_data_port_busy_cycles + cs.m_cache_data_port_busy_cycles;
+  ret.m_cache_fill_port_busy_cycles =
+      m_cache_fill_port_busy_cycles + cs.m_cache_fill_port_busy_cycles;
+  return ret;
 }
 
-void cache_stats::print_stats(FILE *fout, const char *cache_name) const{
-    ///
-    /// Print out each non-zero cache statistic for every memory access type and status
-    /// "cache_name" defaults to "Cache_stats" when no argument is provided, otherwise
-    /// the provided name is used.
-    /// The printed format is "<cache_name>[<request_type>][<request_status>] = <stat_value>"
-    ///
-    std::vector< unsigned > total_access;
-    total_access.resize(NUM_MEM_ACCESS_TYPE, 0);
-    std::string m_cache_name = cache_name;
-    for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
-        for (unsigned status = 0; status < NUM_CACHE_REQUEST_STATUS; ++status) {
-            fprintf(fout, "\t%s[%s][%s] = %llu\n",
-                m_cache_name.c_str(),
+cache_stats &cache_stats::operator+=(const cache_stats &cs) {
+  ///
+  /// Overloaded += operator to allow for simple stat accumulation
+  ///
+  for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
+    for (unsigned status = 0; status < NUM_CACHE_REQUEST_STATUS; ++status) {
+      m_stats[type][status] += cs(type, status, false);
+    }
+    for (unsigned status = 0; status < NUM_CACHE_REQUEST_STATUS; ++status) {
+      m_stats_pw[type][status] += cs(type, status, false);
+    }
+    for (unsigned status = 0; status < NUM_CACHE_RESERVATION_FAIL_STATUS;
+         ++status) {
+      m_fail_stats[type][status] += cs(type, status, true);
+    }
+  }
+  m_cache_port_available_cycles += cs.m_cache_port_available_cycles;
+  m_cache_data_port_busy_cycles += cs.m_cache_data_port_busy_cycles;
+  m_cache_fill_port_busy_cycles += cs.m_cache_fill_port_busy_cycles;
+  return *this;
+}
+
+void cache_stats::print_stats(FILE *fout, const char *cache_name) const {
+  ///
+  /// Print out each non-zero cache statistic for every memory access type and
+  /// status "cache_name" defaults to "Cache_stats" when no argument is
+  /// provided, otherwise the provided name is used. The printed format is
+  /// "<cache_name>[<request_type>][<request_status>] = <stat_value>"
+  ///
+  std::vector<unsigned> total_access;
+  total_access.resize(NUM_MEM_ACCESS_TYPE, 0);
+  std::string m_cache_name = cache_name;
+  for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
+    for (unsigned status = 0; status < NUM_CACHE_REQUEST_STATUS; ++status) {
+      fprintf(fout, "\t%s[%s][%s] = %llu\n", m_cache_name.c_str(),
+              mem_access_type_str((enum mem_access_type)type),
+              cache_request_status_str((enum cache_request_status)status),
+              m_stats[type][status]);
+
+      if (status != RESERVATION_FAIL)
+        total_access[type] += m_stats[type][status];
+    }
+  }
+  for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
+    if (total_access[type] > 0)
+      fprintf(fout, "\t%s[%s][%s] = %u\n", m_cache_name.c_str(),
+              mem_access_type_str((enum mem_access_type)type), "TOTAL_ACCESS",
+              total_access[type]);
+  }
+}
+
+void cache_stats::print_fail_stats(FILE *fout, const char *cache_name) const {
+  std::string m_cache_name = cache_name;
+  for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
+    for (unsigned fail = 0; fail < NUM_CACHE_RESERVATION_FAIL_STATUS; ++fail) {
+      if (m_fail_stats[type][fail] > 0) {
+        fprintf(fout, "\t%s[%s][%s] = %llu\n", m_cache_name.c_str(),
                 mem_access_type_str((enum mem_access_type)type),
-                cache_request_status_str((enum cache_request_status)status),
-                m_stats[type][status]);
+                cache_fail_status_str((enum cache_reservation_fail_reason)fail),
+                m_fail_stats[type][fail]);
+      }
+    }
+  }
+}
 
-            if(status != RESERVATION_FAIL)
-            	 total_access[type]+= m_stats[type][status];
+void cache_sub_stats::print_port_stats(FILE *fout,
+                                       const char *cache_name) const {
+  float data_port_util = 0.0f;
+  if (port_available_cycles > 0) {
+    data_port_util = (float)data_port_busy_cycles / port_available_cycles;
+  }
+  fprintf(fout, "%s_data_port_util = %.3f\n", cache_name, data_port_util);
+  float fill_port_util = 0.0f;
+  if (port_available_cycles > 0) {
+    fill_port_util = (float)fill_port_busy_cycles / port_available_cycles;
+  }
+  fprintf(fout, "%s_fill_port_util = %.3f\n", cache_name, fill_port_util);
+}
+
+unsigned long long cache_stats::get_stats(
+    enum mem_access_type *access_type, unsigned num_access_type,
+    enum cache_request_status *access_status,
+    unsigned num_access_status) const {
+  ///
+  /// Returns a sum of the stats corresponding to each "access_type" and
+  /// "access_status" pair. "access_type" is an array of "num_access_type"
+  /// mem_access_types. "access_status" is an array of "num_access_status"
+  /// cache_request_statuses.
+  ///
+  unsigned long long total = 0;
+  for (unsigned type = 0; type < num_access_type; ++type) {
+    for (unsigned status = 0; status < num_access_status; ++status) {
+      if (!check_valid((int)access_type[type], (int)access_status[status]))
+        assert(0 && "Unknown cache access type or access outcome");
+      total += m_stats[access_type[type]][access_status[status]];
+    }
+  }
+  return total;
+}
+
+void cache_stats::get_sub_stats(struct cache_sub_stats &css) const {
+  ///
+  /// Overwrites "css" with the appropriate statistics from this cache.
+  ///
+  struct cache_sub_stats t_css;
+  t_css.clear();
+
+  for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
+    for (unsigned status = 0; status < NUM_CACHE_REQUEST_STATUS; ++status) {
+      if (status == HIT || status == MISS || status == SECTOR_MISS ||
+          status == HIT_RESERVED)
+        t_css.accesses += m_stats[type][status];
+
+      if (status == MISS || status == SECTOR_MISS)
+        t_css.misses += m_stats[type][status];
+
+      if (status == HIT_RESERVED) t_css.pending_hits += m_stats[type][status];
+
+      if (status == RESERVATION_FAIL) t_css.res_fails += m_stats[type][status];
+    }
+  }
+
+  t_css.port_available_cycles = m_cache_port_available_cycles;
+  t_css.data_port_busy_cycles = m_cache_data_port_busy_cycles;
+  t_css.fill_port_busy_cycles = m_cache_fill_port_busy_cycles;
+
+  css = t_css;
+}
+
+void cache_stats::get_sub_stats_pw(struct cache_sub_stats_pw &css) const {
+  ///
+  /// Overwrites "css" with the appropriate statistics from this cache.
+  ///
+  struct cache_sub_stats_pw t_css;
+  t_css.clear();
+
+  for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
+    for (unsigned status = 0; status < NUM_CACHE_REQUEST_STATUS; ++status) {
+      if (status == HIT || status == MISS || status == SECTOR_MISS ||
+          status == HIT_RESERVED)
+        t_css.accesses += m_stats_pw[type][status];
+
+      if (status == HIT) {
+        if (type == GLOBAL_ACC_R || type == CONST_ACC_R || type == INST_ACC_R) {
+          t_css.read_hits += m_stats_pw[type][status];
+        } else if (type == GLOBAL_ACC_W) {
+          t_css.write_hits += m_stats_pw[type][status];
         }
-    }
-    for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
-    	 if(total_access[type] > 0)
-    	  fprintf(fout, "\t%s[%s][%s] = %u\n",
-				m_cache_name.c_str(),
-				mem_access_type_str((enum mem_access_type)type),
-				"TOTAL_ACCESS",
-				total_access[type]);
-    }
-}
+      }
 
-void cache_stats::print_fail_stats(FILE *fout, const char *cache_name) const{
-	std::string m_cache_name = cache_name;
-	    for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
-	        for (unsigned fail = 0; fail < NUM_CACHE_RESERVATION_FAIL_STATUS; ++fail) {
-	            if(m_fail_stats[type][fail] > 0){
-	                fprintf(fout, "\t%s[%s][%s] = %llu\n",
-	                    m_cache_name.c_str(),
-	                    mem_access_type_str((enum mem_access_type)type),
-						cache_fail_status_str((enum cache_reservation_fail_reason)fail),
-						m_fail_stats[type][fail]);
-	            }
-	        }
-	    }
-}
-
-void cache_sub_stats::print_port_stats(FILE *fout, const char *cache_name) const
-{
-    float data_port_util = 0.0f; 
-    if (port_available_cycles > 0) {
-        data_port_util = (float) data_port_busy_cycles / port_available_cycles; 
-    }
-    fprintf(fout, "%s_data_port_util = %.3f\n", cache_name, data_port_util); 
-    float fill_port_util = 0.0f; 
-    if (port_available_cycles > 0) {
-        fill_port_util = (float) fill_port_busy_cycles / port_available_cycles; 
-    }
-    fprintf(fout, "%s_fill_port_util = %.3f\n", cache_name, fill_port_util); 
-}
-
-unsigned long long cache_stats::get_stats(enum mem_access_type *access_type, unsigned num_access_type, enum cache_request_status *access_status, unsigned num_access_status) const{
-    ///
-    /// Returns a sum of the stats corresponding to each "access_type" and "access_status" pair.
-    /// "access_type" is an array of "num_access_type" mem_access_types.
-    /// "access_status" is an array of "num_access_status" cache_request_statuses.
-    ///
-    unsigned long long total=0;
-    for(unsigned type =0; type < num_access_type; ++type){
-        for(unsigned status=0; status < num_access_status; ++status){
-            if(!check_valid((int)access_type[type], (int)access_status[status]))
-                assert(0 && "Unknown cache access type or access outcome");
-            total += m_stats[access_type[type]][access_status[status]];
+      if (status == MISS || status == SECTOR_MISS) {
+        if (type == GLOBAL_ACC_R || type == CONST_ACC_R || type == INST_ACC_R) {
+          t_css.read_misses += m_stats_pw[type][status];
+        } else if (type == GLOBAL_ACC_W) {
+          t_css.write_misses += m_stats_pw[type][status];
         }
-    }
-    return total;
-}
+      }
 
-void cache_stats::get_sub_stats(struct cache_sub_stats &css) const{
-    ///
-    /// Overwrites "css" with the appropriate statistics from this cache.
-    ///
-    struct cache_sub_stats t_css;
-    t_css.clear();
-
-    for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
-        for (unsigned status = 0; status < NUM_CACHE_REQUEST_STATUS; ++status) {
-            if(status == HIT || status == MISS || status == SECTOR_MISS || status == HIT_RESERVED)
-                t_css.accesses += m_stats[type][status];
-
-            if(status == MISS || status == SECTOR_MISS)
-                t_css.misses += m_stats[type][status];
-
-            if(status == HIT_RESERVED)
-                t_css.pending_hits += m_stats[type][status];
-
-            if(status == RESERVATION_FAIL)
-                t_css.res_fails += m_stats[type][status];
+      if (status == HIT_RESERVED) {
+        if (type == GLOBAL_ACC_R || type == CONST_ACC_R || type == INST_ACC_R) {
+          t_css.read_pending_hits += m_stats_pw[type][status];
+        } else if (type == GLOBAL_ACC_W) {
+          t_css.write_pending_hits += m_stats_pw[type][status];
         }
-    }
+      }
 
-    t_css.port_available_cycles = m_cache_port_available_cycles; 
-    t_css.data_port_busy_cycles = m_cache_data_port_busy_cycles; 
-    t_css.fill_port_busy_cycles = m_cache_fill_port_busy_cycles; 
-
-    css = t_css;
-}
-
-void cache_stats::get_sub_stats_pw(struct cache_sub_stats_pw &css) const{
-    ///
-    /// Overwrites "css" with the appropriate statistics from this cache.
-    ///
-    struct cache_sub_stats_pw t_css;
-    t_css.clear();
-
-    for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
-        for (unsigned status = 0; status < NUM_CACHE_REQUEST_STATUS; ++status) {
-            if(status == HIT || status == MISS || status == SECTOR_MISS || status == HIT_RESERVED)
-                t_css.accesses += m_stats_pw[type][status];
-
-            if(status == HIT){
-                if(type == GLOBAL_ACC_R || type == CONST_ACC_R || type == INST_ACC_R){
-                    t_css.read_hits += m_stats_pw[type][status];
-                } else if(type == GLOBAL_ACC_W){
-                    t_css.write_hits += m_stats_pw[type][status];
-                }
-            }
-
-            if(status == MISS || status == SECTOR_MISS){
-                if(type == GLOBAL_ACC_R || type == CONST_ACC_R || type == INST_ACC_R){
-                    t_css.read_misses += m_stats_pw[type][status];
-                } else if(type == GLOBAL_ACC_W){
-                    t_css.write_misses += m_stats_pw[type][status];
-                }
-            }
-
-            if(status == HIT_RESERVED){
-                if(type == GLOBAL_ACC_R || type == CONST_ACC_R || type == INST_ACC_R){
-                    t_css.read_pending_hits += m_stats_pw[type][status];
-                } else if(type == GLOBAL_ACC_W){
-                    t_css.write_pending_hits += m_stats_pw[type][status];
-                }
-            }
-
-            if(status == RESERVATION_FAIL){
-                if(type == GLOBAL_ACC_R || type == CONST_ACC_R || type == INST_ACC_R){
-                    t_css.read_res_fails += m_stats_pw[type][status];
-                } else if(type == GLOBAL_ACC_W){
-                    t_css.write_res_fails += m_stats_pw[type][status];
-                }
-            }
+      if (status == RESERVATION_FAIL) {
+        if (type == GLOBAL_ACC_R || type == CONST_ACC_R || type == INST_ACC_R) {
+          t_css.read_res_fails += m_stats_pw[type][status];
+        } else if (type == GLOBAL_ACC_W) {
+          t_css.write_res_fails += m_stats_pw[type][status];
         }
+      }
     }
+  }
 
-    css = t_css;
+  css = t_css;
 }
 
-bool cache_stats::check_valid(int type, int status) const{
-    ///
-    /// Verify a valid access_type/access_status
-    ///
-    if((type >= 0) && (type < NUM_MEM_ACCESS_TYPE) && (status >= 0) && (status < NUM_CACHE_REQUEST_STATUS))
-        return true;
-    else
-        return false;
+bool cache_stats::check_valid(int type, int status) const {
+  ///
+  /// Verify a valid access_type/access_status
+  ///
+  if ((type >= 0) && (type < NUM_MEM_ACCESS_TYPE) && (status >= 0) &&
+      (status < NUM_CACHE_REQUEST_STATUS))
+    return true;
+  else
+    return false;
 }
 
-bool cache_stats::check_fail_valid(int type, int fail) const{
-    ///
-    /// Verify a valid access_type/access_status
-    ///
-    if((type >= 0) && (type < NUM_MEM_ACCESS_TYPE) && (fail >= 0) && (fail < NUM_CACHE_RESERVATION_FAIL_STATUS))
-        return true;
-    else
-        return false;
+bool cache_stats::check_fail_valid(int type, int fail) const {
+  ///
+  /// Verify a valid access_type/access_status
+  ///
+  if ((type >= 0) && (type < NUM_MEM_ACCESS_TYPE) && (fail >= 0) &&
+      (fail < NUM_CACHE_RESERVATION_FAIL_STATUS))
+    return true;
+  else
+    return false;
 }
 
-void cache_stats::sample_cache_port_utility(bool data_port_busy, bool fill_port_busy) 
-{
-    m_cache_port_available_cycles += 1; 
-    if (data_port_busy) {
-        m_cache_data_port_busy_cycles += 1; 
-    } 
-    if (fill_port_busy) {
-        m_cache_fill_port_busy_cycles += 1; 
-    } 
+void cache_stats::sample_cache_port_utility(bool data_port_busy,
+                                            bool fill_port_busy) {
+  m_cache_port_available_cycles += 1;
+  if (data_port_busy) {
+    m_cache_data_port_busy_cycles += 1;
+  }
+  if (fill_port_busy) {
+    m_cache_fill_port_busy_cycles += 1;
+  }
 }
 
-baseline_cache::bandwidth_management::bandwidth_management(cache_config &config) 
-: m_config(config)
-{
-    m_data_port_occupied_cycles = 0; 
-    m_fill_port_occupied_cycles = 0; 
+baseline_cache::bandwidth_management::bandwidth_management(cache_config &config)
+    : m_config(config) {
+  m_data_port_occupied_cycles = 0;
+  m_fill_port_occupied_cycles = 0;
 }
 
-/// use the data port based on the outcome and events generated by the mem_fetch request 
-void baseline_cache::bandwidth_management::use_data_port(mem_fetch *mf, enum cache_request_status outcome, const std::list<cache_event> &events)
-{
-    unsigned data_size = mf->get_data_size(); 
-    unsigned port_width = m_config.m_data_port_width; 
-    switch (outcome) {
+/// use the data port based on the outcome and events generated by the mem_fetch
+/// request
+void baseline_cache::bandwidth_management::use_data_port(
+    mem_fetch *mf, enum cache_request_status outcome,
+    const std::list<cache_event> &events) {
+  unsigned data_size = mf->get_data_size();
+  unsigned port_width = m_config.m_data_port_width;
+  switch (outcome) {
     case HIT: {
-        unsigned data_cycles = data_size / port_width + ((data_size % port_width > 0)? 1 : 0); 
-        m_data_port_occupied_cycles += data_cycles; 
-        } break; 
+      unsigned data_cycles =
+          data_size / port_width + ((data_size % port_width > 0) ? 1 : 0);
+      m_data_port_occupied_cycles += data_cycles;
+    } break;
     case HIT_RESERVED:
     case MISS: {
-        // the data array is accessed to read out the entire line for write-back 
-    	// in case of sector cache we need to write bank only the modified sectors
-    	cache_event ev(WRITE_BACK_REQUEST_SENT);
-        if (was_writeback_sent(events, ev)) {
-            unsigned data_cycles = ev.m_evicted_block.m_modified_size / port_width;
-            m_data_port_occupied_cycles += data_cycles; 
-        }
-        } break; 
+      // the data array is accessed to read out the entire line for write-back
+      // in case of sector cache we need to write bank only the modified sectors
+      cache_event ev(WRITE_BACK_REQUEST_SENT);
+      if (was_writeback_sent(events, ev)) {
+        unsigned data_cycles = ev.m_evicted_block.m_modified_size / port_width;
+        m_data_port_occupied_cycles += data_cycles;
+      }
+    } break;
     case SECTOR_MISS:
     case RESERVATION_FAIL:
-        // Does not consume any port bandwidth 
-        break; 
-    default: 
-        assert(0); 
-        break; 
-    } 
+      // Does not consume any port bandwidth
+      break;
+    default:
+      assert(0);
+      break;
+  }
 }
 
-/// use the fill port 
-void baseline_cache::bandwidth_management::use_fill_port(mem_fetch *mf)
-{
-    // assume filling the entire line with the returned request 
-    unsigned fill_cycles = m_config.get_atom_sz() / m_config.m_data_port_width;
-    m_fill_port_occupied_cycles += fill_cycles; 
+/// use the fill port
+void baseline_cache::bandwidth_management::use_fill_port(mem_fetch *mf) {
+  // assume filling the entire line with the returned request
+  unsigned fill_cycles = m_config.get_atom_sz() / m_config.m_data_port_width;
+  m_fill_port_occupied_cycles += fill_cycles;
 }
 
-/// called every cache cycle to free up the ports 
-void baseline_cache::bandwidth_management::replenish_port_bandwidth()
-{
-    if (m_data_port_occupied_cycles > 0) {
-        m_data_port_occupied_cycles -= 1; 
-    }
-    assert(m_data_port_occupied_cycles >= 0); 
+/// called every cache cycle to free up the ports
+void baseline_cache::bandwidth_management::replenish_port_bandwidth() {
+  if (m_data_port_occupied_cycles > 0) {
+    m_data_port_occupied_cycles -= 1;
+  }
+  assert(m_data_port_occupied_cycles >= 0);
 
-    if (m_fill_port_occupied_cycles > 0) {
-        m_fill_port_occupied_cycles -= 1; 
-    }
-    assert(m_fill_port_occupied_cycles >= 0); 
+  if (m_fill_port_occupied_cycles > 0) {
+    m_fill_port_occupied_cycles -= 1;
+  }
+  assert(m_fill_port_occupied_cycles >= 0);
 }
 
-/// query for data port availability 
-bool baseline_cache::bandwidth_management::data_port_free() const
-{
-    return (m_data_port_occupied_cycles == 0); 
+/// query for data port availability
+bool baseline_cache::bandwidth_management::data_port_free() const {
+  return (m_data_port_occupied_cycles == 0);
 }
 
-/// query for fill port availability 
-bool baseline_cache::bandwidth_management::fill_port_free() const
-{
-    return (m_fill_port_occupied_cycles == 0); 
+/// query for fill port availability
+bool baseline_cache::bandwidth_management::fill_port_free() const {
+  return (m_fill_port_occupied_cycles == 0);
 }
 
 /// Sends next request to lower level of memory
-void baseline_cache::cycle(){
-    if ( !m_miss_queue.empty() ) {
-        mem_fetch *mf = m_miss_queue.front();
-        if ( !m_memport->full(mf->size(),mf->get_is_write()) ) {
-            m_miss_queue.pop_front();
-            m_memport->push(mf);
-        }
+void baseline_cache::cycle() {
+  if (!m_miss_queue.empty()) {
+    mem_fetch *mf = m_miss_queue.front();
+    if (!m_memport->full(mf->size(), mf->get_is_write())) {
+      m_miss_queue.pop_front();
+      m_memport->push(mf);
     }
-    bool data_port_busy = !m_bandwidth_management.data_port_free(); 
-    bool fill_port_busy = !m_bandwidth_management.fill_port_free(); 
-    m_stats.sample_cache_port_utility(data_port_busy, fill_port_busy); 
-    m_bandwidth_management.replenish_port_bandwidth(); 
+  }
+  bool data_port_busy = !m_bandwidth_management.data_port_free();
+  bool fill_port_busy = !m_bandwidth_management.fill_port_free();
+  m_stats.sample_cache_port_utility(data_port_busy, fill_port_busy);
+  m_bandwidth_management.replenish_port_bandwidth();
 }
 
-/// Interface for response from lower memory level (model bandwidth restictions in caller)
-void baseline_cache::fill(mem_fetch *mf, unsigned time){
-
-	if(m_config.m_mshr_type == SECTOR_ASSOC) {
-	assert(mf->get_original_mf());
-	extra_mf_fields_lookup::iterator e = m_extra_mf_fields.find(mf->get_original_mf());
-    assert( e != m_extra_mf_fields.end() );
+/// Interface for response from lower memory level (model bandwidth restictions
+/// in caller)
+void baseline_cache::fill(mem_fetch *mf, unsigned time) {
+  if (m_config.m_mshr_type == SECTOR_ASSOC) {
+    assert(mf->get_original_mf());
+    extra_mf_fields_lookup::iterator e =
+        m_extra_mf_fields.find(mf->get_original_mf());
+    assert(e != m_extra_mf_fields.end());
     e->second.pending_read--;
 
-    if(e->second.pending_read > 0) {
-    	//wait for the other requests to come back
-    	delete mf;
-    	return;
-      } else {
-    	mem_fetch *temp = mf;
-    	mf = mf->get_original_mf();
-    	delete temp;
-      }
-	}
+    if (e->second.pending_read > 0) {
+      // wait for the other requests to come back
+      delete mf;
+      return;
+    } else {
+      mem_fetch *temp = mf;
+      mf = mf->get_original_mf();
+      delete temp;
+    }
+  }
 
-    extra_mf_fields_lookup::iterator e = m_extra_mf_fields.find(mf);
-    assert( e != m_extra_mf_fields.end() );
-    assert( e->second.m_valid );
-    mf->set_data_size( e->second.m_data_size );
-    mf->set_addr( e->second.m_addr );
-    if ( m_config.m_alloc_policy == ON_MISS )
-        m_tag_array->fill(e->second.m_cache_index,time,mf);
-    else if ( m_config.m_alloc_policy == ON_FILL ) {
-        m_tag_array->fill(e->second.m_block_addr,time,mf);
-        if(m_config.is_streaming())
-        	m_tag_array->remove_pending_line(mf);
-    }
-    else abort();
-    bool has_atomic = false;
-    m_mshrs.mark_ready(e->second.m_block_addr, has_atomic);
-    if (has_atomic) {
-        assert(m_config.m_alloc_policy == ON_MISS);
-        cache_block_t* block = m_tag_array->get_block(e->second.m_cache_index);
-        block->set_status(MODIFIED, mf->get_access_sector_mask()); // mark line as dirty for atomic operation
-    }
-    m_extra_mf_fields.erase(mf);
-    m_bandwidth_management.use_fill_port(mf); 
+  extra_mf_fields_lookup::iterator e = m_extra_mf_fields.find(mf);
+  assert(e != m_extra_mf_fields.end());
+  assert(e->second.m_valid);
+  mf->set_data_size(e->second.m_data_size);
+  mf->set_addr(e->second.m_addr);
+  if (m_config.m_alloc_policy == ON_MISS)
+    m_tag_array->fill(e->second.m_cache_index, time, mf);
+  else if (m_config.m_alloc_policy == ON_FILL) {
+    m_tag_array->fill(e->second.m_block_addr, time, mf);
+    if (m_config.is_streaming()) m_tag_array->remove_pending_line(mf);
+  } else
+    abort();
+  bool has_atomic = false;
+  m_mshrs.mark_ready(e->second.m_block_addr, has_atomic);
+  if (has_atomic) {
+    assert(m_config.m_alloc_policy == ON_MISS);
+    cache_block_t *block = m_tag_array->get_block(e->second.m_cache_index);
+    block->set_status(MODIFIED,
+                      mf->get_access_sector_mask());  // mark line as dirty for
+                                                      // atomic operation
+  }
+  m_extra_mf_fields.erase(mf);
+  m_bandwidth_management.use_fill_port(mf);
 }
 
 /// Checks if mf is waiting to be filled by lower memory level
-bool baseline_cache::waiting_for_fill( mem_fetch *mf ){
-    extra_mf_fields_lookup::iterator e = m_extra_mf_fields.find(mf);
-    return e != m_extra_mf_fields.end();
+bool baseline_cache::waiting_for_fill(mem_fetch *mf) {
+  extra_mf_fields_lookup::iterator e = m_extra_mf_fields.find(mf);
+  return e != m_extra_mf_fields.end();
 }
 
-void baseline_cache::print(FILE *fp, unsigned &accesses, unsigned &misses) const{
-    fprintf( fp, "Cache %s:\t", m_name.c_str() );
-    m_tag_array->print(fp,accesses,misses);
+void baseline_cache::print(FILE *fp, unsigned &accesses,
+                           unsigned &misses) const {
+  fprintf(fp, "Cache %s:\t", m_name.c_str());
+  m_tag_array->print(fp, accesses, misses);
 }
 
-void baseline_cache::display_state( FILE *fp ) const{
-    fprintf(fp,"Cache %s:\n", m_name.c_str() );
-    m_mshrs.display(fp);
-    fprintf(fp,"\n");
+void baseline_cache::display_state(FILE *fp) const {
+  fprintf(fp, "Cache %s:\n", m_name.c_str());
+  m_mshrs.display(fp);
+  fprintf(fp, "\n");
 }
 
 /// Read miss handler without writeback
-void baseline_cache::send_read_request(new_addr_type addr, new_addr_type block_addr, unsigned cache_index, mem_fetch *mf,
-		unsigned time, bool &do_miss, std::list<cache_event> &events, bool read_only, bool wa){
-
-	bool wb=false;
-	evicted_block_info e;
-	send_read_request(addr, block_addr, cache_index, mf, time, do_miss, wb, e, events, read_only, wa);
+void baseline_cache::send_read_request(new_addr_type addr,
+                                       new_addr_type block_addr,
+                                       unsigned cache_index, mem_fetch *mf,
+                                       unsigned time, bool &do_miss,
+                                       std::list<cache_event> &events,
+                                       bool read_only, bool wa) {
+  bool wb = false;
+  evicted_block_info e;
+  send_read_request(addr, block_addr, cache_index, mf, time, do_miss, wb, e,
+                    events, read_only, wa);
 }
 
 /// Read miss handler. Check MSHR hit or MSHR available
-void baseline_cache::send_read_request(new_addr_type addr, new_addr_type block_addr, unsigned cache_index, mem_fetch *mf,
-		unsigned time, bool &do_miss, bool &wb, evicted_block_info &evicted, std::list<cache_event> &events, bool read_only, bool wa){
-
-	new_addr_type mshr_addr = m_config.mshr_addr(mf->get_addr());
-    bool mshr_hit = m_mshrs.probe(mshr_addr);
-    bool mshr_avail = !m_mshrs.full(mshr_addr);
-    if ( mshr_hit && mshr_avail ) {
-    	if(read_only)
-    		m_tag_array->access(block_addr,time,cache_index,mf);
-    	else
-    		m_tag_array->access(block_addr,time,cache_index,wb,evicted,mf);
-
-        m_mshrs.add(mshr_addr,mf);
-        do_miss = true;
-
-    } else if ( !mshr_hit && mshr_avail && (m_miss_queue.size() < m_config.m_miss_queue_size) ) {
-    	if(read_only)
-    		m_tag_array->access(block_addr,time,cache_index,mf);
-    	else
-    		m_tag_array->access(block_addr,time,cache_index,wb,evicted,mf);
-
-        m_mshrs.add(mshr_addr,mf);
-        if(m_config.is_streaming() && m_config.m_cache_type == SECTOR){
-			m_tag_array->add_pending_line(mf);
-		}
-        m_extra_mf_fields[mf] = extra_mf_fields(mshr_addr,mf->get_addr(),cache_index, mf->get_data_size(), m_config);
-        mf->set_data_size( m_config.get_atom_sz() );
-        mf->set_addr( mshr_addr );
-        m_miss_queue.push_back(mf);
-        mf->set_status(m_miss_queue_status,time);
-        if(!wa)
-        	events.push_back(cache_event(READ_REQUEST_SENT));
-
-        do_miss = true;
-    }
-    else if(mshr_hit && !mshr_avail)
-        m_stats.inc_fail_stats(mf->get_access_type(), MSHR_MERGE_ENRTY_FAIL);
-    else if (!mshr_hit && !mshr_avail)
-    	 m_stats.inc_fail_stats(mf->get_access_type(), MSHR_ENRTY_FAIL);
+void baseline_cache::send_read_request(new_addr_type addr,
+                                       new_addr_type block_addr,
+                                       unsigned cache_index, mem_fetch *mf,
+                                       unsigned time, bool &do_miss, bool &wb,
+                                       evicted_block_info &evicted,
+                                       std::list<cache_event> &events,
+                                       bool read_only, bool wa) {
+  new_addr_type mshr_addr = m_config.mshr_addr(mf->get_addr());
+  bool mshr_hit = m_mshrs.probe(mshr_addr);
+  bool mshr_avail = !m_mshrs.full(mshr_addr);
+  if (mshr_hit && mshr_avail) {
+    if (read_only)
+      m_tag_array->access(block_addr, time, cache_index, mf);
     else
-    	assert(0);
-}
+      m_tag_array->access(block_addr, time, cache_index, wb, evicted, mf);
 
+    m_mshrs.add(mshr_addr, mf);
+    do_miss = true;
+
+  } else if (!mshr_hit && mshr_avail &&
+             (m_miss_queue.size() < m_config.m_miss_queue_size)) {
+    if (read_only)
+      m_tag_array->access(block_addr, time, cache_index, mf);
+    else
+      m_tag_array->access(block_addr, time, cache_index, wb, evicted, mf);
+
+    m_mshrs.add(mshr_addr, mf);
+    if (m_config.is_streaming() && m_config.m_cache_type == SECTOR) {
+      m_tag_array->add_pending_line(mf);
+    }
+    m_extra_mf_fields[mf] = extra_mf_fields(
+        mshr_addr, mf->get_addr(), cache_index, mf->get_data_size(), m_config);
+    mf->set_data_size(m_config.get_atom_sz());
+    mf->set_addr(mshr_addr);
+    m_miss_queue.push_back(mf);
+    mf->set_status(m_miss_queue_status, time);
+    if (!wa) events.push_back(cache_event(READ_REQUEST_SENT));
+
+    do_miss = true;
+  } else if (mshr_hit && !mshr_avail)
+    m_stats.inc_fail_stats(mf->get_access_type(), MSHR_MERGE_ENRTY_FAIL);
+  else if (!mshr_hit && !mshr_avail)
+    m_stats.inc_fail_stats(mf->get_access_type(), MSHR_ENRTY_FAIL);
+  else
+    assert(0);
+}
 
 /// Sends write request to lower level memory (write or writeback)
-void data_cache::send_write_request(mem_fetch *mf, cache_event request, unsigned time, std::list<cache_event> &events){
-
-	events.push_back(request);
-    m_miss_queue.push_back(mf);
-    mf->set_status(m_miss_queue_status,time);
+void data_cache::send_write_request(mem_fetch *mf, cache_event request,
+                                    unsigned time,
+                                    std::list<cache_event> &events) {
+  events.push_back(request);
+  m_miss_queue.push_back(mf);
+  mf->set_status(m_miss_queue_status, time);
 }
-
 
 /****** Write-hit functions (Set by config file) ******/
 
 /// Write-back hit: Mark block as modified
-cache_request_status data_cache::wr_hit_wb(new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time, std::list<cache_event> &events, enum cache_request_status status ){
-	new_addr_type block_addr = m_config.block_addr(addr);
-	m_tag_array->access(block_addr,time,cache_index,mf); // update LRU state
-	cache_block_t* block = m_tag_array->get_block(cache_index);
-	block->set_status(MODIFIED, mf->get_access_sector_mask());
+cache_request_status data_cache::wr_hit_wb(new_addr_type addr,
+                                           unsigned cache_index, mem_fetch *mf,
+                                           unsigned time,
+                                           std::list<cache_event> &events,
+                                           enum cache_request_status status) {
+  new_addr_type block_addr = m_config.block_addr(addr);
+  m_tag_array->access(block_addr, time, cache_index, mf);  // update LRU state
+  cache_block_t *block = m_tag_array->get_block(cache_index);
+  block->set_status(MODIFIED, mf->get_access_sector_mask());
 
-	return HIT;
+  return HIT;
 }
 
 /// Write-through hit: Directly send request to lower level memory
-cache_request_status data_cache::wr_hit_wt(new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time, std::list<cache_event> &events, enum cache_request_status status ){
-	if(miss_queue_full(0)) {
-		m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
-		return RESERVATION_FAIL; // cannot handle request this cycle
-	}
+cache_request_status data_cache::wr_hit_wt(new_addr_type addr,
+                                           unsigned cache_index, mem_fetch *mf,
+                                           unsigned time,
+                                           std::list<cache_event> &events,
+                                           enum cache_request_status status) {
+  if (miss_queue_full(0)) {
+    m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
+    return RESERVATION_FAIL;  // cannot handle request this cycle
+  }
 
-	new_addr_type block_addr = m_config.block_addr(addr);
-	m_tag_array->access(block_addr,time,cache_index,mf); // update LRU state
-	cache_block_t* block = m_tag_array->get_block(cache_index);
-	block->set_status(MODIFIED, mf->get_access_sector_mask());
+  new_addr_type block_addr = m_config.block_addr(addr);
+  m_tag_array->access(block_addr, time, cache_index, mf);  // update LRU state
+  cache_block_t *block = m_tag_array->get_block(cache_index);
+  block->set_status(MODIFIED, mf->get_access_sector_mask());
 
-	// generate a write-through
-	send_write_request(mf, cache_event(WRITE_REQUEST_SENT), time, events);
+  // generate a write-through
+  send_write_request(mf, cache_event(WRITE_REQUEST_SENT), time, events);
 
-	return HIT;
+  return HIT;
 }
 
-/// Write-evict hit: Send request to lower level memory and invalidate corresponding block
-cache_request_status data_cache::wr_hit_we(new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time, std::list<cache_event> &events, enum cache_request_status status ){
-	if(miss_queue_full(0)) {
-		m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
-		return RESERVATION_FAIL; // cannot handle request this cycle
-	}
+/// Write-evict hit: Send request to lower level memory and invalidate
+/// corresponding block
+cache_request_status data_cache::wr_hit_we(new_addr_type addr,
+                                           unsigned cache_index, mem_fetch *mf,
+                                           unsigned time,
+                                           std::list<cache_event> &events,
+                                           enum cache_request_status status) {
+  if (miss_queue_full(0)) {
+    m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
+    return RESERVATION_FAIL;  // cannot handle request this cycle
+  }
 
-	// generate a write-through/evict
-	cache_block_t* block = m_tag_array->get_block(cache_index);
-	send_write_request(mf, cache_event(WRITE_REQUEST_SENT), time, events);
+  // generate a write-through/evict
+  cache_block_t *block = m_tag_array->get_block(cache_index);
+  send_write_request(mf, cache_event(WRITE_REQUEST_SENT), time, events);
 
-	// Invalidate block
-	block->set_status(INVALID, mf->get_access_sector_mask());
+  // Invalidate block
+  block->set_status(INVALID, mf->get_access_sector_mask());
 
-	return HIT;
+  return HIT;
 }
 
 /// Global write-evict, local write-back: Useful for private caches
-enum cache_request_status data_cache::wr_hit_global_we_local_wb(new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time, std::list<cache_event> &events, enum cache_request_status status ){
-	bool evict = (mf->get_access_type() == GLOBAL_ACC_W); // evict a line that hits on global memory write
-	if(evict)
-		return wr_hit_we(addr, cache_index, mf, time, events, status); // Write-evict
-	else
-		return wr_hit_wb(addr, cache_index, mf, time, events, status); // Write-back
+enum cache_request_status data_cache::wr_hit_global_we_local_wb(
+    new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+    std::list<cache_event> &events, enum cache_request_status status) {
+  bool evict = (mf->get_access_type() ==
+                GLOBAL_ACC_W);  // evict a line that hits on global memory write
+  if (evict)
+    return wr_hit_we(addr, cache_index, mf, time, events,
+                     status);  // Write-evict
+  else
+    return wr_hit_wb(addr, cache_index, mf, time, events,
+                     status);  // Write-back
 }
 
 /****** Write-miss functions (Set by config file) ******/
 
 /// Write-allocate miss: Send write request to lower level memory
 // and send a read request for the same block
-enum cache_request_status
-data_cache::wr_miss_wa_naive( new_addr_type addr,
-                        unsigned cache_index, mem_fetch *mf,
-                        unsigned time, std::list<cache_event> &events,
-                        enum cache_request_status status )
-{
-    new_addr_type block_addr = m_config.block_addr(addr);
-    new_addr_type mshr_addr = m_config.mshr_addr(mf->get_addr());
+enum cache_request_status data_cache::wr_miss_wa_naive(
+    new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+    std::list<cache_event> &events, enum cache_request_status status) {
+  new_addr_type block_addr = m_config.block_addr(addr);
+  new_addr_type mshr_addr = m_config.mshr_addr(mf->get_addr());
 
-    // Write allocate, maximum 3 requests (write miss, read request, write back request)
-    // Conservatively ensure the worst-case request can be handled this cycle
-    bool mshr_hit = m_mshrs.probe(mshr_addr);
-    bool mshr_avail = !m_mshrs.full(mshr_addr);
-    if(miss_queue_full(2) 
-        || (!(mshr_hit && mshr_avail) 
-        && !(!mshr_hit && mshr_avail && (m_miss_queue.size() < m_config.m_miss_queue_size)))) {
-    	//check what is the exactly the failure reason
-    	 if(miss_queue_full(2) )
-    		 m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
-         else if(mshr_hit && !mshr_avail)
-    	      m_stats.inc_fail_stats(mf->get_access_type(), MSHR_MERGE_ENRTY_FAIL);
-    	 else if (!mshr_hit && !mshr_avail)
-    	    m_stats.inc_fail_stats(mf->get_access_type(), MSHR_ENRTY_FAIL);
-    	 else
-    		 assert(0);
+  // Write allocate, maximum 3 requests (write miss, read request, write back
+  // request) Conservatively ensure the worst-case request can be handled this
+  // cycle
+  bool mshr_hit = m_mshrs.probe(mshr_addr);
+  bool mshr_avail = !m_mshrs.full(mshr_addr);
+  if (miss_queue_full(2) ||
+      (!(mshr_hit && mshr_avail) &&
+       !(!mshr_hit && mshr_avail &&
+         (m_miss_queue.size() < m_config.m_miss_queue_size)))) {
+    // check what is the exactly the failure reason
+    if (miss_queue_full(2))
+      m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
+    else if (mshr_hit && !mshr_avail)
+      m_stats.inc_fail_stats(mf->get_access_type(), MSHR_MERGE_ENRTY_FAIL);
+    else if (!mshr_hit && !mshr_avail)
+      m_stats.inc_fail_stats(mf->get_access_type(), MSHR_ENRTY_FAIL);
+    else
+      assert(0);
 
-        return RESERVATION_FAIL;
+    return RESERVATION_FAIL;
+  }
+
+  send_write_request(mf, cache_event(WRITE_REQUEST_SENT), time, events);
+  // Tries to send write allocate request, returns true on success and false on
+  // failure
+  // if(!send_write_allocate(mf, addr, block_addr, cache_index, time, events))
+  //    return RESERVATION_FAIL;
+
+  const mem_access_t *ma =
+      new mem_access_t(m_wr_alloc_type, mf->get_addr(), m_config.get_atom_sz(),
+                       false,  // Now performing a read
+                       mf->get_access_warp_mask(), mf->get_access_byte_mask(),
+                       mf->get_access_sector_mask(), m_gpu->gpgpu_ctx);
+
+  mem_fetch *n_mf =
+      new mem_fetch(*ma, NULL, mf->get_ctrl_size(), mf->get_wid(),
+                    mf->get_sid(), mf->get_tpc(), mf->get_mem_config(),
+                    m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle);
+
+  bool do_miss = false;
+  bool wb = false;
+  evicted_block_info evicted;
+
+  // Send read request resulting from write miss
+  send_read_request(addr, block_addr, cache_index, n_mf, time, do_miss, wb,
+                    evicted, events, false, true);
+
+  events.push_back(cache_event(WRITE_ALLOCATE_SENT));
+
+  if (do_miss) {
+    // If evicted block is modified and not a write-through
+    // (already modified lower level)
+    if (wb && (m_config.m_write_policy != WRITE_THROUGH)) {
+      assert(status ==
+             MISS);  // SECTOR_MISS and HIT_RESERVED should not send write back
+      mem_fetch *wb = m_memfetch_creator->alloc(
+          evicted.m_block_addr, m_wrbk_type, evicted.m_modified_size, true,
+          m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle);
+      send_write_request(wb, cache_event(WRITE_BACK_REQUEST_SENT, evicted),
+                         time, events);
+    }
+    return MISS;
+  }
+
+  return RESERVATION_FAIL;
+}
+
+enum cache_request_status data_cache::wr_miss_wa_fetch_on_write(
+    new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+    std::list<cache_event> &events, enum cache_request_status status) {
+  new_addr_type block_addr = m_config.block_addr(addr);
+  new_addr_type mshr_addr = m_config.mshr_addr(mf->get_addr());
+
+  if (mf->get_access_byte_mask().count() == m_config.get_atom_sz()) {
+    // if the request writes to the whole cache line/sector, then, write and set
+    // cache line Modified. and no need to send read request to memory or reserve
+    // mshr
+
+    if (miss_queue_full(0)) {
+      m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
+      return RESERVATION_FAIL;  // cannot handle request this cycle
     }
 
-    send_write_request(mf, cache_event(WRITE_REQUEST_SENT), time, events);
-    // Tries to send write allocate request, returns true on success and false on failure
-    //if(!send_write_allocate(mf, addr, block_addr, cache_index, time, events))
-    //    return RESERVATION_FAIL;
-
-    const mem_access_t *ma = new  mem_access_t( m_wr_alloc_type,
-                        mf->get_addr(),
-						m_config.get_atom_sz(),
-                        false, // Now performing a read
-                        mf->get_access_warp_mask(),
-                        mf->get_access_byte_mask(),
-		                mf->get_access_sector_mask(),
-				m_gpu->gpgpu_ctx);
-
-    mem_fetch *n_mf = new mem_fetch( *ma,
-                    NULL,
-                    mf->get_ctrl_size(),
-                    mf->get_wid(),
-                    mf->get_sid(),
-                    mf->get_tpc(),
-                    mf->get_mem_config(),
-					m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle);
-
-    bool do_miss = false;
     bool wb = false;
     evicted_block_info evicted;
 
-    // Send read request resulting from write miss
+    cache_request_status status =
+        m_tag_array->access(block_addr, time, cache_index, wb, evicted, mf);
+    assert(status != HIT);
+    cache_block_t *block = m_tag_array->get_block(cache_index);
+    block->set_status(MODIFIED, mf->get_access_sector_mask());
+    if (status == HIT_RESERVED)
+      block->set_ignore_on_fill(true, mf->get_access_sector_mask());
+
+    if (status != RESERVATION_FAIL) {
+      // If evicted block is modified and not a write-through
+      // (already modified lower level)
+      if (wb && (m_config.m_write_policy != WRITE_THROUGH)) {
+        mem_fetch *wb = m_memfetch_creator->alloc(
+            evicted.m_block_addr, m_wrbk_type, evicted.m_modified_size, true,
+            m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle);
+        send_write_request(wb, cache_event(WRITE_BACK_REQUEST_SENT, evicted),
+                           time, events);
+      }
+      return MISS;
+    }
+    return RESERVATION_FAIL;
+  } else {
+    bool mshr_hit = m_mshrs.probe(mshr_addr);
+    bool mshr_avail = !m_mshrs.full(mshr_addr);
+    if (miss_queue_full(1) ||
+        (!(mshr_hit && mshr_avail) &&
+         !(!mshr_hit && mshr_avail &&
+           (m_miss_queue.size() < m_config.m_miss_queue_size)))) {
+      // check what is the exactly the failure reason
+      if (miss_queue_full(1))
+        m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
+      else if (mshr_hit && !mshr_avail)
+        m_stats.inc_fail_stats(mf->get_access_type(), MSHR_MERGE_ENRTY_FAIL);
+      else if (!mshr_hit && !mshr_avail)
+        m_stats.inc_fail_stats(mf->get_access_type(), MSHR_ENRTY_FAIL);
+      else
+        assert(0);
+
+      return RESERVATION_FAIL;
+    }
+
+    // prevent Write - Read - Write in pending mshr
+    // allowing another write will override the value of the first write, and
+    // the pending read request will read incorrect result from the second write
+    if (m_mshrs.probe(mshr_addr) &&
+        m_mshrs.is_read_after_write_pending(mshr_addr) && mf->is_write()) {
+      // assert(0);
+      m_stats.inc_fail_stats(mf->get_access_type(), MSHR_RW_PENDING);
+      return RESERVATION_FAIL;
+    }
+
+    const mem_access_t *ma = new mem_access_t(
+        m_wr_alloc_type, mf->get_addr(), m_config.get_atom_sz(),
+        false,  // Now performing a read
+        mf->get_access_warp_mask(), mf->get_access_byte_mask(),
+        mf->get_access_sector_mask(), m_gpu->gpgpu_ctx);
+
+    mem_fetch *n_mf = new mem_fetch(
+        *ma, NULL, mf->get_ctrl_size(), mf->get_wid(), mf->get_sid(),
+        mf->get_tpc(), mf->get_mem_config(),
+        m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle, NULL, mf);
+
+    new_addr_type block_addr = m_config.block_addr(addr);
+    bool do_miss = false;
+    bool wb = false;
+    evicted_block_info evicted;
     send_read_request(addr, block_addr, cache_index, n_mf, time, do_miss, wb,
-        evicted, events, false, true);
+                      evicted, events, false, true);
+
+    cache_block_t *block = m_tag_array->get_block(cache_index);
+    block->set_modified_on_fill(true, mf->get_access_sector_mask());
 
     events.push_back(cache_event(WRITE_ALLOCATE_SENT));
 
-    if( do_miss ){
-        // If evicted block is modified and not a write-through
-        // (already modified lower level)
-        if( wb && (m_config.m_write_policy != WRITE_THROUGH) ) { 
-        	assert(status == MISS);   //SECTOR_MISS and HIT_RESERVED should not send write back
-            mem_fetch *wb = m_memfetch_creator->alloc(evicted.m_block_addr,
-                m_wrbk_type,evicted.m_modified_size,true,m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle);
-            send_write_request(wb, cache_event(WRITE_BACK_REQUEST_SENT, evicted), time, events);
-        }
-        return MISS;
+    if (do_miss) {
+      // If evicted block is modified and not a write-through
+      // (already modified lower level)
+      if (wb && (m_config.m_write_policy != WRITE_THROUGH)) {
+        mem_fetch *wb = m_memfetch_creator->alloc(
+            evicted.m_block_addr, m_wrbk_type, evicted.m_modified_size, true,
+            m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle);
+        send_write_request(wb, cache_event(WRITE_BACK_REQUEST_SENT, evicted),
+                           time, events);
+      }
+      return MISS;
     }
-
     return RESERVATION_FAIL;
+  }
 }
 
+enum cache_request_status data_cache::wr_miss_wa_lazy_fetch_on_read(
+    new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+    std::list<cache_event> &events, enum cache_request_status status) {
+  new_addr_type block_addr = m_config.block_addr(addr);
 
-enum cache_request_status
-data_cache::wr_miss_wa_fetch_on_write( new_addr_type addr,
-                        unsigned cache_index, mem_fetch *mf,
-                        unsigned time, std::list<cache_event> &events,
-                        enum cache_request_status status )
-{
-    new_addr_type block_addr = m_config.block_addr(addr);
-    new_addr_type mshr_addr = m_config.mshr_addr(mf->get_addr());
+  // if the request writes to the whole cache line/sector, then, write and set
+  // cache line Modified. and no need to send read request to memory or reserve
+  // mshr
 
-	if(mf->get_access_byte_mask().count() == m_config.get_atom_sz())
-	{
-		//if the request writes to the whole cache line/sector, then, write and set cache line Modified.
-		//and no need to send read request to memory or reserve mshr
+  if (miss_queue_full(0)) {
+    m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
+    return RESERVATION_FAIL;  // cannot handle request this cycle
+  }
 
-		if(miss_queue_full(0)) {
-			m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
-			return RESERVATION_FAIL; // cannot handle request this cycle
-		}
+  bool wb = false;
+  evicted_block_info evicted;
 
-		bool wb = false;
-		evicted_block_info evicted;
+  cache_request_status m_status =
+      m_tag_array->access(block_addr, time, cache_index, wb, evicted, mf);
+  assert(m_status != HIT);
+  cache_block_t *block = m_tag_array->get_block(cache_index);
+  block->set_status(MODIFIED, mf->get_access_sector_mask());
+  if (m_status == HIT_RESERVED) {
+    block->set_ignore_on_fill(true, mf->get_access_sector_mask());
+    block->set_modified_on_fill(true, mf->get_access_sector_mask());
+  }
 
-		cache_request_status status =  m_tag_array->access(block_addr,time,cache_index,wb,evicted,mf);
-		assert(status != HIT);
-		cache_block_t* block = m_tag_array->get_block(cache_index);
-		block->set_status(MODIFIED, mf->get_access_sector_mask());
-		if(status == HIT_RESERVED)
-			block->set_ignore_on_fill(true, mf->get_access_sector_mask());
+  if (mf->get_access_byte_mask().count() == m_config.get_atom_sz()) {
+    block->set_m_readable(true, mf->get_access_sector_mask());
+  } else {
+    block->set_m_readable(false, mf->get_access_sector_mask());
+  }
 
-		if( status != RESERVATION_FAIL ){
-			   // If evicted block is modified and not a write-through
-			   // (already modified lower level)
-			   if( wb && (m_config.m_write_policy != WRITE_THROUGH) ) {
-				   mem_fetch *wb = m_memfetch_creator->alloc(evicted.m_block_addr,
-					   m_wrbk_type,evicted.m_modified_size,true,m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle);
-				   send_write_request(wb, cache_event(WRITE_BACK_REQUEST_SENT, evicted), time, events);
-			   }
-			   return MISS;
-		   }
-		return RESERVATION_FAIL;
-	}
-	else
-	{
-		bool mshr_hit = m_mshrs.probe(mshr_addr);
-		bool mshr_avail = !m_mshrs.full(mshr_addr);
-		if(miss_queue_full(1)
-			|| (!(mshr_hit && mshr_avail)
-			&& !(!mshr_hit && mshr_avail && (m_miss_queue.size() < m_config.m_miss_queue_size)))) {
-			//check what is the exactly the failure reason
-			 if(miss_queue_full(1) )
-				 m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
-			 else if(mshr_hit && !mshr_avail)
-				  m_stats.inc_fail_stats(mf->get_access_type(), MSHR_MERGE_ENRTY_FAIL);
-			 else if (!mshr_hit && !mshr_avail)
-				m_stats.inc_fail_stats(mf->get_access_type(), MSHR_ENRTY_FAIL);
-			 else
-				 assert(0);
-
-			return RESERVATION_FAIL;
-		}
-
-
-		  //prevent Write - Read - Write in pending mshr
-		  //allowing another write will override the value of the first write, and the pending read request will read incorrect result from the second write
-		  if(m_mshrs.probe(mshr_addr) && m_mshrs.is_read_after_write_pending(mshr_addr) && mf->is_write())
-		  {
-			  //assert(0);
-			  m_stats.inc_fail_stats(mf->get_access_type(), MSHR_RW_PENDING);
-			  return RESERVATION_FAIL;
-		  }
-
-		  const mem_access_t *ma = new  mem_access_t( m_wr_alloc_type,
-									mf->get_addr(),
-									m_config.get_atom_sz(),
-									false, // Now performing a read
-									mf->get_access_warp_mask(),
-									mf->get_access_byte_mask(),
-									mf->get_access_sector_mask(),
-									m_gpu->gpgpu_ctx);
-
-		  mem_fetch *n_mf = new mem_fetch( *ma,
-								NULL,
-								mf->get_ctrl_size(),
-								mf->get_wid(),
-								mf->get_sid(),
-								mf->get_tpc(),
-								mf->get_mem_config(),
-								m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle,
-								NULL,
-								mf);
-
-
-			new_addr_type block_addr = m_config.block_addr(addr);
-			bool do_miss = false;
-			bool wb = false;
-			evicted_block_info evicted;
-			send_read_request( addr,
-							   block_addr,
-							   cache_index,
-							   n_mf, time, do_miss, wb, evicted, events, false, true);
-
-			cache_block_t* block = m_tag_array->get_block(cache_index);
-			block->set_modified_on_fill(true, mf->get_access_sector_mask());
-
-			events.push_back(cache_event(WRITE_ALLOCATE_SENT));
-
-			if( do_miss ){
-				// If evicted block is modified and not a write-through
-				// (already modified lower level)
-				if(wb && (m_config.m_write_policy != WRITE_THROUGH) ){
-					mem_fetch *wb = m_memfetch_creator->alloc(evicted.m_block_addr,
-						m_wrbk_type,evicted.m_modified_size,true,m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle);
-					send_write_request(wb, cache_event(WRITE_BACK_REQUEST_SENT, evicted), time, events);
-			}
-				return MISS;
-			}
-	   return RESERVATION_FAIL;
-	}
-}
-
-enum cache_request_status
-data_cache::wr_miss_wa_lazy_fetch_on_read( new_addr_type addr,
-                        unsigned cache_index, mem_fetch *mf,
-                        unsigned time, std::list<cache_event> &events,
-                        enum cache_request_status status )
-{
-
-	    new_addr_type block_addr = m_config.block_addr(addr);
-
-		//if the request writes to the whole cache line/sector, then, write and set cache line Modified.
-		//and no need to send read request to memory or reserve mshr
-
-		if(miss_queue_full(0)) {
-			m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
-			return RESERVATION_FAIL; // cannot handle request this cycle
-		}
-
-		bool wb = false;
-		evicted_block_info evicted;
-
-		cache_request_status m_status =  m_tag_array->access(block_addr,time,cache_index,wb,evicted,mf);
-		assert(m_status != HIT);
-		cache_block_t* block = m_tag_array->get_block(cache_index);
-		block->set_status(MODIFIED, mf->get_access_sector_mask());
-		if(m_status == HIT_RESERVED) {
-			block->set_ignore_on_fill(true, mf->get_access_sector_mask());
-			block->set_modified_on_fill(true, mf->get_access_sector_mask());
-		}
-
-		if(mf->get_access_byte_mask().count() == m_config.get_atom_sz())
-		{
-			block->set_m_readable(true, mf->get_access_sector_mask());
-		} else
-		{
-			block->set_m_readable(false, mf->get_access_sector_mask());
-		}
-
-		if( m_status != RESERVATION_FAIL ){
-			   // If evicted block is modified and not a write-through
-			   // (already modified lower level)
-			   if( wb && (m_config.m_write_policy != WRITE_THROUGH) ) {
-				   mem_fetch *wb = m_memfetch_creator->alloc(evicted.m_block_addr,
-					   m_wrbk_type,evicted.m_modified_size,true,m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle);
-				   send_write_request(wb, cache_event(WRITE_BACK_REQUEST_SENT, evicted), time, events);
-			   }
-			   return MISS;
-		   }
-		return RESERVATION_FAIL;
+  if (m_status != RESERVATION_FAIL) {
+    // If evicted block is modified and not a write-through
+    // (already modified lower level)
+    if (wb && (m_config.m_write_policy != WRITE_THROUGH)) {
+      mem_fetch *wb = m_memfetch_creator->alloc(
+          evicted.m_block_addr, m_wrbk_type, evicted.m_modified_size, true,
+          m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle);
+      send_write_request(wb, cache_event(WRITE_BACK_REQUEST_SENT, evicted),
+                         time, events);
+    }
+    return MISS;
+  }
+  return RESERVATION_FAIL;
 }
 
 /// No write-allocate miss: Simply send write request to lower level memory
-enum cache_request_status
-data_cache::wr_miss_no_wa( new_addr_type addr,
-                           unsigned cache_index,
-                           mem_fetch *mf,
-                           unsigned time,
-                           std::list<cache_event> &events,
-                           enum cache_request_status status )
-{
-    if(miss_queue_full(0)) {
-    	m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
-    	return RESERVATION_FAIL; // cannot handle request this cycle
-    }
+enum cache_request_status data_cache::wr_miss_no_wa(
+    new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+    std::list<cache_event> &events, enum cache_request_status status) {
+  if (miss_queue_full(0)) {
+    m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
+    return RESERVATION_FAIL;  // cannot handle request this cycle
+  }
 
+  // on miss, generate write through (no write buffering -- too many threads for
+  // that)
+  send_write_request(mf, cache_event(WRITE_REQUEST_SENT), time, events);
 
-    // on miss, generate write through (no write buffering -- too many threads for that)
-    send_write_request(mf, cache_event(WRITE_REQUEST_SENT), time, events);
-
-    return MISS;
+  return MISS;
 }
 
 /****** Read hit functions (Set by config file) ******/
 
 /// Baseline read hit: Update LRU status of block.
 // Special case for atomic instructions -> Mark block as modified
-enum cache_request_status
-data_cache::rd_hit_base( new_addr_type addr,
-                         unsigned cache_index,
-                         mem_fetch *mf,
-                         unsigned time,
-                         std::list<cache_event> &events,
-                         enum cache_request_status status )
-{
-    new_addr_type block_addr = m_config.block_addr(addr);
-    m_tag_array->access(block_addr,time,cache_index,mf);
-    // Atomics treated as global read/write requests - Perform read, mark line as
-    // MODIFIED
-    if(mf->isatomic()){ 
-        assert(mf->get_access_type() == GLOBAL_ACC_R);
-        cache_block_t* block = m_tag_array->get_block(cache_index);
-        block->set_status(MODIFIED, mf->get_access_sector_mask()) ;  // mark line as dirty
-    }
-    return HIT;
+enum cache_request_status data_cache::rd_hit_base(
+    new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+    std::list<cache_event> &events, enum cache_request_status status) {
+  new_addr_type block_addr = m_config.block_addr(addr);
+  m_tag_array->access(block_addr, time, cache_index, mf);
+  // Atomics treated as global read/write requests - Perform read, mark line as
+  // MODIFIED
+  if (mf->isatomic()) {
+    assert(mf->get_access_type() == GLOBAL_ACC_R);
+    cache_block_t *block = m_tag_array->get_block(cache_index);
+    block->set_status(MODIFIED,
+                      mf->get_access_sector_mask());  // mark line as dirty
+  }
+  return HIT;
 }
 
 /****** Read miss functions (Set by config file) ******/
 
 /// Baseline read miss: Send read request to lower level memory,
 // perform write-back as necessary
-enum cache_request_status
-data_cache::rd_miss_base( new_addr_type addr,
-                          unsigned cache_index,
-                          mem_fetch *mf,
-                          unsigned time,
-                          std::list<cache_event> &events,
-                          enum cache_request_status status ){
-    if(miss_queue_full(1)) {
-        // cannot handle request this cycle
-        // (might need to generate two requests)
-    	m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
-        return RESERVATION_FAIL; 
-    }
+enum cache_request_status data_cache::rd_miss_base(
+    new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+    std::list<cache_event> &events, enum cache_request_status status) {
+  if (miss_queue_full(1)) {
+    // cannot handle request this cycle
+    // (might need to generate two requests)
+    m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
+    return RESERVATION_FAIL;
+  }
 
-    new_addr_type block_addr = m_config.block_addr(addr);
-    bool do_miss = false;
-    bool wb = false;
-    evicted_block_info evicted;
-    send_read_request( addr,
-                       block_addr,
-                       cache_index,
-                       mf, time, do_miss, wb, evicted, events, false, false);
+  new_addr_type block_addr = m_config.block_addr(addr);
+  bool do_miss = false;
+  bool wb = false;
+  evicted_block_info evicted;
+  send_read_request(addr, block_addr, cache_index, mf, time, do_miss, wb,
+                    evicted, events, false, false);
 
-    if( do_miss ){
-        // If evicted block is modified and not a write-through
-        // (already modified lower level)
-        if(wb && (m_config.m_write_policy != WRITE_THROUGH) ){ 
-            mem_fetch *wb = m_memfetch_creator->alloc(evicted.m_block_addr,
-                m_wrbk_type,evicted.m_modified_size,true,m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle);
-        send_write_request(wb, WRITE_BACK_REQUEST_SENT, time, events);
+  if (do_miss) {
+    // If evicted block is modified and not a write-through
+    // (already modified lower level)
+    if (wb && (m_config.m_write_policy != WRITE_THROUGH)) {
+      mem_fetch *wb = m_memfetch_creator->alloc(
+          evicted.m_block_addr, m_wrbk_type, evicted.m_modified_size, true,
+          m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle);
+      send_write_request(wb, WRITE_BACK_REQUEST_SENT, time, events);
     }
-        return MISS;
-    }
-        return RESERVATION_FAIL;
+    return MISS;
+  }
+  return RESERVATION_FAIL;
 }
 
 /// Access cache for read_only_cache: returns RESERVATION_FAIL if
 // request could not be accepted (for any reason)
-enum cache_request_status
-read_only_cache::access( new_addr_type addr,
-                         mem_fetch *mf,
-                         unsigned time,
-                         std::list<cache_event> &events )
-{
-    assert( mf->get_data_size() <= m_config.get_atom_sz());
-    assert(m_config.m_write_policy == READ_ONLY);
-    assert(!mf->get_is_write());
-    new_addr_type block_addr = m_config.block_addr(addr);
-    unsigned cache_index = (unsigned)-1;
-    enum cache_request_status status = m_tag_array->probe(block_addr,cache_index,mf);
-    enum cache_request_status cache_status = RESERVATION_FAIL;
+enum cache_request_status read_only_cache::access(
+    new_addr_type addr, mem_fetch *mf, unsigned time,
+    std::list<cache_event> &events) {
+  assert(mf->get_data_size() <= m_config.get_atom_sz());
+  assert(m_config.m_write_policy == READ_ONLY);
+  assert(!mf->get_is_write());
+  new_addr_type block_addr = m_config.block_addr(addr);
+  unsigned cache_index = (unsigned)-1;
+  enum cache_request_status status =
+      m_tag_array->probe(block_addr, cache_index, mf);
+  enum cache_request_status cache_status = RESERVATION_FAIL;
 
-    if ( status == HIT ) {
-        cache_status = m_tag_array->access(block_addr,time,cache_index,mf); // update LRU state
-    }else if ( status != RESERVATION_FAIL ) {
-        if(!miss_queue_full(0)){
-            bool do_miss=false;
-            send_read_request(addr, block_addr, cache_index, mf, time, do_miss, events, true, false);
-            if(do_miss)
-                cache_status = MISS;
-            else
-                cache_status = RESERVATION_FAIL;
-        }else{
-            cache_status = RESERVATION_FAIL;
-            m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
-        }
-    }else {
-    	m_stats.inc_fail_stats(mf->get_access_type(), LINE_ALLOC_FAIL);
+  if (status == HIT) {
+    cache_status = m_tag_array->access(block_addr, time, cache_index,
+                                       mf);  // update LRU state
+  } else if (status != RESERVATION_FAIL) {
+    if (!miss_queue_full(0)) {
+      bool do_miss = false;
+      send_read_request(addr, block_addr, cache_index, mf, time, do_miss,
+                        events, true, false);
+      if (do_miss)
+        cache_status = MISS;
+      else
+        cache_status = RESERVATION_FAIL;
+    } else {
+      cache_status = RESERVATION_FAIL;
+      m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
     }
+  } else {
+    m_stats.inc_fail_stats(mf->get_access_type(), LINE_ALLOC_FAIL);
+  }
 
-    m_stats.inc_stats(mf->get_access_type(), m_stats.select_stats_status(status, cache_status));
-    m_stats.inc_stats_pw(mf->get_access_type(), m_stats.select_stats_status(status, cache_status));
-    return cache_status;
+  m_stats.inc_stats(mf->get_access_type(),
+                    m_stats.select_stats_status(status, cache_status));
+  m_stats.inc_stats_pw(mf->get_access_type(),
+                       m_stats.select_stats_status(status, cache_status));
+  return cache_status;
 }
 
 //! A general function that takes the result of a tag_array probe
 //  and performs the correspding functions based on the cache configuration
 //  The access fucntion calls this function
-enum cache_request_status
-data_cache::process_tag_probe( bool wr,
-                               enum cache_request_status probe_status,
-                               new_addr_type addr,
-                               unsigned cache_index,
-                               mem_fetch* mf,
-                               unsigned time,
-                               std::list<cache_event>& events )
-{
-    // Each function pointer ( m_[rd/wr]_[hit/miss] ) is set in the
-    // data_cache constructor to reflect the corresponding cache configuration
-    // options. Function pointers were used to avoid many long conditional
-    // branches resulting from many cache configuration options.
-    cache_request_status access_status = probe_status;
-    if(wr){ // Write
-        if(probe_status == HIT){
-            access_status = (this->*m_wr_hit)( addr,
-                                      cache_index,
-                                      mf, time, events, probe_status );
-        }else if ( (probe_status != RESERVATION_FAIL) || (probe_status == RESERVATION_FAIL && m_config.m_write_alloc_policy == NO_WRITE_ALLOCATE) ) {
-            access_status = (this->*m_wr_miss)( addr,
-                                       cache_index,
-                                       mf, time, events, probe_status );
-        }else {
-        	//the only reason for reservation fail here is LINE_ALLOC_FAIL (i.e all lines are reserved)
-        	m_stats.inc_fail_stats(mf->get_access_type(), LINE_ALLOC_FAIL);
-        }
-    }else{ // Read
-        if(probe_status == HIT){
-            access_status = (this->*m_rd_hit)( addr,
-                                      cache_index,
-                                      mf, time, events, probe_status );
-        }else if ( probe_status != RESERVATION_FAIL ) {
-            access_status = (this->*m_rd_miss)( addr,
-                                       cache_index,
-                                       mf, time, events, probe_status );
-        }else {
-        	//the only reason for reservation fail here is LINE_ALLOC_FAIL (i.e all lines are reserved)
-        	m_stats.inc_fail_stats(mf->get_access_type(), LINE_ALLOC_FAIL);
-        }
+enum cache_request_status data_cache::process_tag_probe(
+    bool wr, enum cache_request_status probe_status, new_addr_type addr,
+    unsigned cache_index, mem_fetch *mf, unsigned time,
+    std::list<cache_event> &events) {
+  // Each function pointer ( m_[rd/wr]_[hit/miss] ) is set in the
+  // data_cache constructor to reflect the corresponding cache configuration
+  // options. Function pointers were used to avoid many long conditional
+  // branches resulting from many cache configuration options.
+  cache_request_status access_status = probe_status;
+  if (wr) {  // Write
+    if (probe_status == HIT) {
+      access_status =
+          (this->*m_wr_hit)(addr, cache_index, mf, time, events, probe_status);
+    } else if ((probe_status != RESERVATION_FAIL) ||
+               (probe_status == RESERVATION_FAIL &&
+                m_config.m_write_alloc_policy == NO_WRITE_ALLOCATE)) {
+      access_status =
+          (this->*m_wr_miss)(addr, cache_index, mf, time, events, probe_status);
+    } else {
+      // the only reason for reservation fail here is LINE_ALLOC_FAIL (i.e all
+      // lines are reserved)
+      m_stats.inc_fail_stats(mf->get_access_type(), LINE_ALLOC_FAIL);
     }
+  } else {  // Read
+    if (probe_status == HIT) {
+      access_status =
+          (this->*m_rd_hit)(addr, cache_index, mf, time, events, probe_status);
+    } else if (probe_status != RESERVATION_FAIL) {
+      access_status =
+          (this->*m_rd_miss)(addr, cache_index, mf, time, events, probe_status);
+    } else {
+      // the only reason for reservation fail here is LINE_ALLOC_FAIL (i.e all
+      // lines are reserved)
+      m_stats.inc_fail_stats(mf->get_access_type(), LINE_ALLOC_FAIL);
+    }
+  }
 
-    m_bandwidth_management.use_data_port(mf, access_status, events); 
-    return access_status;
+  m_bandwidth_management.use_data_port(mf, access_status, events);
+  return access_status;
 }
 
 // Both the L1 and L2 currently use the same access function.
@@ -1645,51 +1639,41 @@ data_cache::process_tag_probe( bool wr,
 // of caching policies.
 // Both the L1 and L2 override this function to provide a means of
 // performing actions specific to each cache when such actions are implemnted.
-enum cache_request_status
-data_cache::access( new_addr_type addr,
-                    mem_fetch *mf,
-                    unsigned time,
-                    std::list<cache_event> &events )
-{
-
-    assert( mf->get_data_size() <= m_config.get_atom_sz());
-    bool wr = mf->get_is_write();
-    new_addr_type block_addr = m_config.block_addr(addr);
-    unsigned cache_index = (unsigned)-1;
-    enum cache_request_status probe_status
-        = m_tag_array->probe( block_addr, cache_index, mf, true);
-    enum cache_request_status access_status
-        = process_tag_probe( wr, probe_status, addr, cache_index, mf, time, events );
-    m_stats.inc_stats(mf->get_access_type(),
-        m_stats.select_stats_status(probe_status, access_status));
-    m_stats.inc_stats_pw(mf->get_access_type(),
-        m_stats.select_stats_status(probe_status, access_status));
-    return access_status;
+enum cache_request_status data_cache::access(new_addr_type addr, mem_fetch *mf,
+                                             unsigned time,
+                                             std::list<cache_event> &events) {
+  assert(mf->get_data_size() <= m_config.get_atom_sz());
+  bool wr = mf->get_is_write();
+  new_addr_type block_addr = m_config.block_addr(addr);
+  unsigned cache_index = (unsigned)-1;
+  enum cache_request_status probe_status =
+      m_tag_array->probe(block_addr, cache_index, mf, true);
+  enum cache_request_status access_status =
+      process_tag_probe(wr, probe_status, addr, cache_index, mf, time, events);
+  m_stats.inc_stats(mf->get_access_type(),
+                    m_stats.select_stats_status(probe_status, access_status));
+  m_stats.inc_stats_pw(mf->get_access_type(), m_stats.select_stats_status(
+                                                  probe_status, access_status));
+  return access_status;
 }
 
 /// This is meant to model the first level data cache in Fermi.
 /// It is write-evict (global) or write-back (local) at the
 /// granularity of individual blocks (Set by GPGPU-Sim configuration file)
 /// (the policy used in fermi according to the CUDA manual)
-enum cache_request_status
-l1_cache::access( new_addr_type addr,
-                  mem_fetch *mf,
-                  unsigned time,
-                  std::list<cache_event> &events )
-{
-    return data_cache::access( addr, mf, time, events );
+enum cache_request_status l1_cache::access(new_addr_type addr, mem_fetch *mf,
+                                           unsigned time,
+                                           std::list<cache_event> &events) {
+  return data_cache::access(addr, mf, time, events);
 }
 
 // The l2 cache access function calls the base data_cache access
 // implementation.  When the L2 needs to diverge from L1, L2 specific
 // changes should be made here.
-enum cache_request_status
-l2_cache::access( new_addr_type addr,
-                  mem_fetch *mf,
-                  unsigned time,
-                  std::list<cache_event> &events )
-{
-    return data_cache::access( addr, mf, time, events );
+enum cache_request_status l2_cache::access(new_addr_type addr, mem_fetch *mf,
+                                           unsigned time,
+                                           std::list<cache_event> &events) {
+  return data_cache::access(addr, mf, time, events);
 }
 
 /// Access function for tex_cache
@@ -1697,141 +1681,144 @@ l2_cache::access( new_addr_type addr,
 /// otherwise returns HIT_RESERVED or MISS; NOTE: *never* returns HIT
 /// since unlike a normal CPU cache, a "HIT" in texture cache does not
 /// mean the data is ready (still need to get through fragment fifo)
-enum cache_request_status tex_cache::access( new_addr_type addr, mem_fetch *mf,
-    unsigned time, std::list<cache_event> &events )
-{
-    if ( m_fragment_fifo.full() || m_request_fifo.full() || m_rob.full() )
-        return RESERVATION_FAIL;
+enum cache_request_status tex_cache::access(new_addr_type addr, mem_fetch *mf,
+                                            unsigned time,
+                                            std::list<cache_event> &events) {
+  if (m_fragment_fifo.full() || m_request_fifo.full() || m_rob.full())
+    return RESERVATION_FAIL;
 
-    assert( mf->get_data_size() <= m_config.get_line_sz());
+  assert(mf->get_data_size() <= m_config.get_line_sz());
 
-    // at this point, we will accept the request : access tags and immediately allocate line
-    new_addr_type block_addr = m_config.block_addr(addr);
-    unsigned cache_index = (unsigned)-1;
-    enum cache_request_status status = m_tags.access(block_addr,time,cache_index,mf);
-    enum cache_request_status cache_status = RESERVATION_FAIL;
-    assert( status != RESERVATION_FAIL );
-    assert( status != HIT_RESERVED ); // as far as tags are concerned: HIT or MISS
-    m_fragment_fifo.push( fragment_entry(mf,cache_index,status==MISS,mf->get_data_size()) );
-    if ( status == MISS ) {
-        // we need to send a memory request...
-        unsigned rob_index = m_rob.push( rob_entry(cache_index, mf, block_addr) );
-        m_extra_mf_fields[mf] = extra_mf_fields(rob_index, m_config);
-        mf->set_data_size(m_config.get_line_sz());
-        m_tags.fill(cache_index,time,mf); // mark block as valid
-        m_request_fifo.push(mf);
-        mf->set_status(m_request_queue_status,time);
-        events.push_back(cache_event(READ_REQUEST_SENT));
-        cache_status = MISS;
-    } else {
-        // the value *will* *be* in the cache already
-        cache_status = HIT_RESERVED;
-    }
-    m_stats.inc_stats(mf->get_access_type(), m_stats.select_stats_status(status, cache_status));
-    m_stats.inc_stats_pw(mf->get_access_type(), m_stats.select_stats_status(status, cache_status));
-    return cache_status;
+  // at this point, we will accept the request : access tags and immediately
+  // allocate line
+  new_addr_type block_addr = m_config.block_addr(addr);
+  unsigned cache_index = (unsigned)-1;
+  enum cache_request_status status =
+      m_tags.access(block_addr, time, cache_index, mf);
+  enum cache_request_status cache_status = RESERVATION_FAIL;
+  assert(status != RESERVATION_FAIL);
+  assert(status != HIT_RESERVED);  // as far as tags are concerned: HIT or MISS
+  m_fragment_fifo.push(
+      fragment_entry(mf, cache_index, status == MISS, mf->get_data_size()));
+  if (status == MISS) {
+    // we need to send a memory request...
+    unsigned rob_index = m_rob.push(rob_entry(cache_index, mf, block_addr));
+    m_extra_mf_fields[mf] = extra_mf_fields(rob_index, m_config);
+    mf->set_data_size(m_config.get_line_sz());
+    m_tags.fill(cache_index, time, mf);  // mark block as valid
+    m_request_fifo.push(mf);
+    mf->set_status(m_request_queue_status, time);
+    events.push_back(cache_event(READ_REQUEST_SENT));
+    cache_status = MISS;
+  } else {
+    // the value *will* *be* in the cache already
+    cache_status = HIT_RESERVED;
+  }
+  m_stats.inc_stats(mf->get_access_type(),
+                    m_stats.select_stats_status(status, cache_status));
+  m_stats.inc_stats_pw(mf->get_access_type(),
+                       m_stats.select_stats_status(status, cache_status));
+  return cache_status;
 }
 
-void tex_cache::cycle(){
-    // send next request to lower level of memory
-    if ( !m_request_fifo.empty() ) {
-        mem_fetch *mf = m_request_fifo.peek();
-        if ( !m_memport->full(mf->get_ctrl_size(),false) ) {
-            m_request_fifo.pop();
-            m_memport->push(mf);
-        }
+void tex_cache::cycle() {
+  // send next request to lower level of memory
+  if (!m_request_fifo.empty()) {
+    mem_fetch *mf = m_request_fifo.peek();
+    if (!m_memport->full(mf->get_ctrl_size(), false)) {
+      m_request_fifo.pop();
+      m_memport->push(mf);
     }
-    // read ready lines from cache
-    if ( !m_fragment_fifo.empty() && !m_result_fifo.full() ) {
-        const fragment_entry &e = m_fragment_fifo.peek();
-        if ( e.m_miss ) {
-            // check head of reorder buffer to see if data is back from memory
-            unsigned rob_index = m_rob.next_pop_index();
-            const rob_entry &r = m_rob.peek(rob_index);
-            assert( r.m_request == e.m_request );
-            //assert( r.m_block_addr == m_config.block_addr(e.m_request->get_addr()) );
-            if ( r.m_ready ) {
-                assert( r.m_index == e.m_cache_index );
-                m_cache[r.m_index].m_valid = true;
-                m_cache[r.m_index].m_block_addr = r.m_block_addr;
-                m_result_fifo.push(e.m_request);
-                m_rob.pop();
-                m_fragment_fifo.pop();
-            }
-        } else {
-            // hit:
-            assert( m_cache[e.m_cache_index].m_valid );
-            assert( m_cache[e.m_cache_index].m_block_addr
-                == m_config.block_addr(e.m_request->get_addr()) );
-            m_result_fifo.push( e.m_request );
-            m_fragment_fifo.pop();
-        }
+  }
+  // read ready lines from cache
+  if (!m_fragment_fifo.empty() && !m_result_fifo.full()) {
+    const fragment_entry &e = m_fragment_fifo.peek();
+    if (e.m_miss) {
+      // check head of reorder buffer to see if data is back from memory
+      unsigned rob_index = m_rob.next_pop_index();
+      const rob_entry &r = m_rob.peek(rob_index);
+      assert(r.m_request == e.m_request);
+      // assert( r.m_block_addr == m_config.block_addr(e.m_request->get_addr())
+      // );
+      if (r.m_ready) {
+        assert(r.m_index == e.m_cache_index);
+        m_cache[r.m_index].m_valid = true;
+        m_cache[r.m_index].m_block_addr = r.m_block_addr;
+        m_result_fifo.push(e.m_request);
+        m_rob.pop();
+        m_fragment_fifo.pop();
+      }
+    } else {
+      // hit:
+      assert(m_cache[e.m_cache_index].m_valid);
+      assert(m_cache[e.m_cache_index].m_block_addr ==
+             m_config.block_addr(e.m_request->get_addr()));
+      m_result_fifo.push(e.m_request);
+      m_fragment_fifo.pop();
     }
+  }
 }
 
 /// Place returning cache block into reorder buffer
-void tex_cache::fill( mem_fetch *mf, unsigned time )
-{
-	if(m_config.m_mshr_type == SECTOR_TEX_FIFO) {
-	assert(mf->get_original_mf());
-	extra_mf_fields_lookup::iterator e = m_extra_mf_fields.find(mf->get_original_mf());
-    assert( e != m_extra_mf_fields.end() );
+void tex_cache::fill(mem_fetch *mf, unsigned time) {
+  if (m_config.m_mshr_type == SECTOR_TEX_FIFO) {
+    assert(mf->get_original_mf());
+    extra_mf_fields_lookup::iterator e =
+        m_extra_mf_fields.find(mf->get_original_mf());
+    assert(e != m_extra_mf_fields.end());
     e->second.pending_read--;
 
-    if(e->second.pending_read > 0) {
-    	//wait for the other requests to come back
-    	delete mf;
-    	return;
-      } else {
-    	mem_fetch *temp = mf;
-    	mf = mf->get_original_mf();
-    	delete temp;
-      }
-	}
+    if (e->second.pending_read > 0) {
+      // wait for the other requests to come back
+      delete mf;
+      return;
+    } else {
+      mem_fetch *temp = mf;
+      mf = mf->get_original_mf();
+      delete temp;
+    }
+  }
 
-    extra_mf_fields_lookup::iterator e = m_extra_mf_fields.find(mf);
-    assert( e != m_extra_mf_fields.end() );
-    assert( e->second.m_valid );
-    assert( !m_rob.empty() );
-    mf->set_status(m_rob_status,time);
+  extra_mf_fields_lookup::iterator e = m_extra_mf_fields.find(mf);
+  assert(e != m_extra_mf_fields.end());
+  assert(e->second.m_valid);
+  assert(!m_rob.empty());
+  mf->set_status(m_rob_status, time);
 
-    unsigned rob_index = e->second.m_rob_index;
-    rob_entry &r = m_rob.peek(rob_index);
-    assert( !r.m_ready );
-    r.m_ready = true;
-    r.m_time = time;
-    assert( r.m_block_addr == m_config.block_addr(mf->get_addr()) );
+  unsigned rob_index = e->second.m_rob_index;
+  rob_entry &r = m_rob.peek(rob_index);
+  assert(!r.m_ready);
+  r.m_ready = true;
+  r.m_time = time;
+  assert(r.m_block_addr == m_config.block_addr(mf->get_addr()));
 }
 
-void tex_cache::display_state( FILE *fp ) const
-{
-    fprintf(fp,"%s (texture cache) state:\n", m_name.c_str() );
-    fprintf(fp,"fragment fifo entries  = %u / %u\n",
-        m_fragment_fifo.size(), m_fragment_fifo.capacity() );
-    fprintf(fp,"reorder buffer entries = %u / %u\n",
-        m_rob.size(), m_rob.capacity() );
-    fprintf(fp,"request fifo entries   = %u / %u\n",
-        m_request_fifo.size(), m_request_fifo.capacity() );
-    if ( !m_rob.empty() )
-        fprintf(fp,"reorder buffer contents:\n");
-    for ( int n=m_rob.size()-1; n>=0; n-- ) {
-        unsigned index = (m_rob.next_pop_index() + n)%m_rob.capacity();
-        const rob_entry &r = m_rob.peek(index);
-        fprintf(fp, "tex rob[%3d] : %s ",
-            index, (r.m_ready?"ready  ":"pending") );
-        if ( r.m_ready )
-            fprintf(fp,"@%6u", r.m_time );
-        else
-            fprintf(fp,"       ");
-        fprintf(fp,"[idx=%4u]",r.m_index);
-        r.m_request->print(fp,false);
-    }
-    if ( !m_fragment_fifo.empty() ) {
-        fprintf(fp,"fragment fifo (oldest) :");
-        fragment_entry &f = m_fragment_fifo.peek();
-        fprintf(fp,"%s:          ", f.m_miss?"miss":"hit ");
-        f.m_request->print(fp,false);
-    }
+void tex_cache::display_state(FILE *fp) const {
+  fprintf(fp, "%s (texture cache) state:\n", m_name.c_str());
+  fprintf(fp, "fragment fifo entries  = %u / %u\n", m_fragment_fifo.size(),
+          m_fragment_fifo.capacity());
+  fprintf(fp, "reorder buffer entries = %u / %u\n", m_rob.size(),
+          m_rob.capacity());
+  fprintf(fp, "request fifo entries   = %u / %u\n", m_request_fifo.size(),
+          m_request_fifo.capacity());
+  if (!m_rob.empty()) fprintf(fp, "reorder buffer contents:\n");
+  for (int n = m_rob.size() - 1; n >= 0; n--) {
+    unsigned index = (m_rob.next_pop_index() + n) % m_rob.capacity();
+    const rob_entry &r = m_rob.peek(index);
+    fprintf(fp, "tex rob[%3d] : %s ", index,
+            (r.m_ready ? "ready  " : "pending"));
+    if (r.m_ready)
+      fprintf(fp, "@%6u", r.m_time);
+    else
+      fprintf(fp, "       ");
+    fprintf(fp, "[idx=%4u]", r.m_index);
+    r.m_request->print(fp, false);
+  }
+  if (!m_fragment_fifo.empty()) {
+    fprintf(fp, "fragment fifo (oldest) :");
+    fragment_entry &f = m_fragment_fifo.peek();
+    fprintf(fp, "%s:          ", f.m_miss ? "miss" : "hit ");
+    f.m_request->print(fp, false);
+  }
 }
 /******************************************************************************************************************************************/
-

--- a/src/gpgpu-sim/gpu-cache.cc
+++ b/src/gpgpu-sim/gpu-cache.cc
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -28,1621 +26,1618 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "gpu-cache.h"
-#include <assert.h>
 #include "gpu-sim.h"
 #include "stat-tool.h"
+#include <assert.h>
 
-// used to allocate memory that is large enough to adapt the changes in cache
-// size across kernels
+// used to allocate memory that is large enough to adapt the changes in cache size across kernels
 
-const char *cache_request_status_str(enum cache_request_status status) {
-  static const char *static_cache_request_status_str[] = {
-      "HIT", "HIT_RESERVED", "MISS", "RESERVATION_FAIL", "SECTOR_MISS"};
+const char * cache_request_status_str(enum cache_request_status status) 
+{
+   static const char * static_cache_request_status_str[] = {
+      "HIT",
+      "HIT_RESERVED",
+      "MISS",
+      "RESERVATION_FAIL",
+	  "SECTOR_MISS"
+   }; 
 
-  assert(sizeof(static_cache_request_status_str) / sizeof(const char *) ==
-         NUM_CACHE_REQUEST_STATUS);
-  assert(status < NUM_CACHE_REQUEST_STATUS);
+   assert(sizeof(static_cache_request_status_str) / sizeof(const char*) == NUM_CACHE_REQUEST_STATUS); 
+   assert(status < NUM_CACHE_REQUEST_STATUS); 
 
-  return static_cache_request_status_str[status];
+   return static_cache_request_status_str[status]; 
 }
 
-const char *cache_fail_status_str(enum cache_reservation_fail_reason status) {
-  static const char *static_cache_reservation_fail_reason_str[] = {
-      "LINE_ALLOC_FAIL", "MISS_QUEUE_FULL", "MSHR_ENRTY_FAIL",
-      "MSHR_MERGE_ENRTY_FAIL", "MSHR_RW_PENDING"};
+const char * cache_fail_status_str(enum cache_reservation_fail_reason status)
+{
+   static const char * static_cache_reservation_fail_reason_str[] = {
+	  "LINE_ALLOC_FAIL",
+	  "MISS_QUEUE_FULL",
+	  "MSHR_ENRTY_FAIL",
+      "MSHR_MERGE_ENRTY_FAIL",
+      "MSHR_RW_PENDING"
+   };
 
-  assert(sizeof(static_cache_reservation_fail_reason_str) /
-             sizeof(const char *) ==
-         NUM_CACHE_RESERVATION_FAIL_STATUS);
-  assert(status < NUM_CACHE_RESERVATION_FAIL_STATUS);
+   assert(sizeof(static_cache_reservation_fail_reason_str) / sizeof(const char*) == NUM_CACHE_RESERVATION_FAIL_STATUS);
+   assert(status < NUM_CACHE_RESERVATION_FAIL_STATUS);
 
-  return static_cache_reservation_fail_reason_str[status];
+   return static_cache_reservation_fail_reason_str[status];
 }
 
-unsigned l1d_cache_config::set_bank(new_addr_type addr) const {
-  if (m_cache_type == SECTOR)
-    return (addr >> m_sector_sz_log2) & (l1_banks - 1);
-  else
-    return (addr >> m_line_sz_log2) & (l1_banks - 1);
+unsigned l1d_cache_config::set_bank(new_addr_type addr) const{
+
+	if(m_cache_type == SECTOR)
+		return (addr >> m_sector_sz_log2) & (l1_banks-1);
+	else
+		return (addr >> m_line_sz_log2) & (l1_banks-1);
 }
 
-unsigned l1d_cache_config::set_index(new_addr_type addr) const {
-  unsigned set_index = m_nset;  // Default to linear set index function
-  unsigned lower_xor = 0;
-  unsigned upper_xor = 0;
+unsigned l1d_cache_config::set_index(new_addr_type addr) const{
+    unsigned set_index = m_nset; // Default to linear set index function
+    unsigned lower_xor = 0;
+    unsigned upper_xor = 0;
 
-  switch (m_set_index_function) {
+    switch(m_set_index_function){
     case FERMI_HASH_SET_FUNCTION:
     case BITWISE_XORING_FUNCTION:
-      /*
-      * Set Indexing function from "A Detailed GPU Cache Model Based on Reuse
-      * Distance Theory"
-      * Cedric Nugteren et al.
-      * HPCA 2014
-      */
-      if (m_nset == 32 || m_nset == 64) {
-        // Lower xor value is bits 7-11
-        lower_xor = (addr >> m_line_sz_log2) & 0x1F;
+        /*
+        * Set Indexing function from "A Detailed GPU Cache Model Based on Reuse Distance Theory"
+        * Cedric Nugteren et al.
+        * HPCA 2014
+        */
+        if(m_nset == 32 || m_nset == 64){
+            // Lower xor value is bits 7-11
+            lower_xor = (addr >> m_line_sz_log2) & 0x1F;
 
-        // Upper xor value is bits 13, 14, 15, 17, and 19
-        upper_xor = (addr & 0xE000) >> 13;    // Bits 13, 14, 15
-        upper_xor |= (addr & 0x20000) >> 14;  // Bit 17
-        upper_xor |= (addr & 0x80000) >> 15;  // Bit 19
+            // Upper xor value is bits 13, 14, 15, 17, and 19
+            upper_xor  = (addr & 0xE000)  >> 13; // Bits 13, 14, 15
+            upper_xor |= (addr & 0x20000) >> 14; // Bit 17
+            upper_xor |= (addr & 0x80000) >> 15; // Bit 19
 
-        set_index = (lower_xor ^ upper_xor);
+            set_index = (lower_xor ^ upper_xor);
 
-        // 48KB cache prepends the set_index with bit 12
-        if (m_nset == 64) set_index |= (addr & 0x1000) >> 7;
+            // 48KB cache prepends the set_index with bit 12
+            if(m_nset == 64)
+                set_index |= (addr & 0x1000) >> 7;
 
-      } else { /* Else incorrect number of sets for the hashing function */
-        assert(
-            "\nGPGPU-Sim cache configuration error: The number of sets should "
-            "be "
-            "32 or 64 for the hashing set index function.\n" &&
-            0);
-      }
-      break;
+        }else{ /* Else incorrect number of sets for the hashing function */
+            assert("\nGPGPU-Sim cache configuration error: The number of sets should be "
+                    "32 or 64 for the hashing set index function.\n" && 0);
+        }
+        break;
 
     case HASH_IPOLY_FUNCTION:
-      /*
-              * Set Indexing function from "Pseudo-randomly interleaved memory."
-              * Rau, B. R et al.
-              * ISCA 1991
-              *
-              * "Sacat: streaming-aware conflict-avoiding thrashing-resistant
-       * gpgpu cache management scheme."
-              * Khairy et al.
-              * IEEE TPDS 2017.
-      */
-      if (m_nset == 32 || m_nset == 64) {
-        std::bitset<64> a(addr);
-        std::bitset<6> index;
-        index[0] = a[25] ^ a[24] ^ a[23] ^ a[22] ^ a[21] ^ a[18] ^ a[17] ^
-                   a[15] ^ a[12] ^ a[7];  // 10
-        index[1] = a[26] ^ a[25] ^ a[24] ^ a[23] ^ a[22] ^ a[19] ^ a[18] ^
-                   a[16] ^ a[13] ^ a[8];  // 10
-        index[2] = a[26] ^ a[22] ^ a[21] ^ a[20] ^ a[19] ^ a[18] ^ a[15] ^
-                   a[14] ^ a[12] ^ a[9];  // 10
-        index[3] = a[23] ^ a[22] ^ a[21] ^ a[20] ^ a[19] ^ a[16] ^ a[15] ^
-                   a[13] ^ a[10];  // 9
-        index[4] = a[24] ^ a[23] ^ a[22] ^ a[21] ^ a[20] ^ a[17] ^ a[16] ^
-                   a[14] ^ a[11];  // 9
+    	/*
+		* Set Indexing function from "Pseudo-randomly interleaved memory."
+		* Rau, B. R et al.
+		* ISCA 1991
+		*
+		* "Sacat: streaming-aware conflict-avoiding thrashing-resistant gpgpu cache management scheme."
+		* Khairy et al.
+		* IEEE TPDS 2017.
+    	*/
+    	if(m_nset == 32 || m_nset == 64){
+		std::bitset<64> a(addr);
+		std::bitset<6> index;
+		index[0] = a[25]^a[24]^a[23]^a[22]^a[21]^a[18]^a[17]^a[15]^a[12]^a[7]; //10
+		index[1] = a[26]^a[25]^a[24]^a[23]^a[22]^a[19]^a[18]^a[16]^a[13]^a[8]; //10
+		index[2] = a[26]^a[22]^a[21]^a[20]^a[19]^a[18]^a[15]^a[14]^a[12]^a[9]; //10
+		index[3] = a[23]^a[22]^a[21]^a[20]^a[19]^a[16]^a[15]^a[13]^a[10]; //9
+		index[4] = a[24]^a[23]^a[22]^a[21]^a[20]^a[17]^a[16]^a[14]^a[11]; //9
 
-        if (m_nset == 64) index[5] = a[12];
+		 if(m_nset == 64)
+			 index[5] = a[12];
 
-        set_index = index.to_ulong();
+		set_index = index.to_ulong();
 
-      } else { /* Else incorrect number of sets for the hashing function */
-        assert(
-            "\nGPGPU-Sim cache configuration error: The number of sets should "
-            "be "
-            "32 or 64 for the hashing set index function.\n" &&
-            0);
-      }
-      break;
+    	}else{ /* Else incorrect number of sets for the hashing function */
+    	            assert("\nGPGPU-Sim cache configuration error: The number of sets should be "
+    	                    "32 or 64 for the hashing set index function.\n" && 0);
+    	 }
+        break;
 
     case CUSTOM_SET_FUNCTION:
-      /* No custom set function implemented */
-      break;
+        /* No custom set function implemented */
+        break;
 
     case LINEAR_SET_FUNCTION:
-      set_index = (addr >> m_line_sz_log2) & (m_nset - 1);
-      break;
+        set_index = (addr >> m_line_sz_log2) & (m_nset-1);
+        break;
 
     default:
-      assert("\nUndefined set index function.\n" && 0);
-      break;
-  }
+    	 assert("\nUndefined set index function.\n" && 0);
+    	 break;
+    }
 
-  // Linear function selected or custom set index function not implemented
-  assert((set_index < m_nset) &&
-         "\nError: Set index out of bounds. This is caused by "
-         "an incorrect or unimplemented custom set index function.\n");
+    // Linear function selected or custom set index function not implemented
+    assert((set_index < m_nset) && "\nError: Set index out of bounds. This is caused by "
+            "an incorrect or unimplemented custom set index function.\n");
 
-  return set_index;
+    return set_index;
 }
 
-void l2_cache_config::init(linear_to_raw_address_translation *address_mapping) {
-  cache_config::init(m_config_string, FuncCachePreferNone);
-  m_address_mapping = address_mapping;
+void l2_cache_config::init(linear_to_raw_address_translation *address_mapping){
+	cache_config::init(m_config_string,FuncCachePreferNone);
+	m_address_mapping = address_mapping;
 }
 
-unsigned l2_cache_config::set_index(new_addr_type addr) const {
-  if (!m_address_mapping) {
-    return (addr >> m_line_sz_log2) & (m_nset - 1);
-  } else {
-    // Calculate set index without memory partition bits to reduce set camping
-    new_addr_type part_addr = m_address_mapping->partition_address(addr);
-    return (part_addr >> m_line_sz_log2) & (m_nset - 1);
-  }
+unsigned l2_cache_config::set_index(new_addr_type addr) const{
+	if(!m_address_mapping){
+		return(addr >> m_line_sz_log2) & (m_nset-1);
+	}else{
+		// Calculate set index without memory partition bits to reduce set camping
+		new_addr_type part_addr = m_address_mapping->partition_address(addr);
+		return(part_addr >> m_line_sz_log2) & (m_nset -1);
+	}
 }
 
-tag_array::~tag_array() {
-  unsigned cache_lines_num = m_config.get_max_num_lines();
-  for (unsigned i = 0; i < cache_lines_num; ++i) delete m_lines[i];
-  delete[] m_lines;
+tag_array::~tag_array() 
+{
+	unsigned cache_lines_num = m_config.get_max_num_lines();
+	for(unsigned i=0; i<cache_lines_num; ++i)
+		delete m_lines[i];
+    delete[] m_lines;
 }
 
-tag_array::tag_array(cache_config &config, int core_id, int type_id,
-                     cache_block_t **new_lines)
-    : m_config(config), m_lines(new_lines) {
-  init(core_id, type_id);
+tag_array::tag_array( cache_config &config,
+                      int core_id,
+                      int type_id,
+                      cache_block_t** new_lines)
+    : m_config( config ),
+      m_lines( new_lines )
+{
+    init( core_id, type_id );
 }
 
-void tag_array::update_cache_parameters(cache_config &config) {
-  m_config = config;
+void tag_array::update_cache_parameters(cache_config &config)
+{
+	m_config=config;
 }
 
-tag_array::tag_array(cache_config &config, int core_id, int type_id)
-    : m_config(config) {
-  // assert( m_config.m_write_policy == READ_ONLY ); Old assert
-  unsigned cache_lines_num = config.get_max_num_lines();
-  m_lines = new cache_block_t *[cache_lines_num];
-  if (config.m_cache_type == NORMAL) {
-    for (unsigned i = 0; i < cache_lines_num; ++i)
-      m_lines[i] = new line_cache_block();
-  } else if (config.m_cache_type == SECTOR) {
-    for (unsigned i = 0; i < cache_lines_num; ++i)
-      m_lines[i] = new sector_cache_block();
-  } else
-    assert(0);
+tag_array::tag_array( cache_config &config,
+                      int core_id,
+                      int type_id )
+    : m_config( config )
+{
+    //assert( m_config.m_write_policy == READ_ONLY ); Old assert
+	unsigned cache_lines_num = config.get_max_num_lines();
+	m_lines = new cache_block_t*[cache_lines_num];
+	if(config.m_cache_type == NORMAL)
+	{
+		for(unsigned i=0; i<cache_lines_num; ++i)
+			m_lines[i] = new line_cache_block();
+	}
+	else if(config.m_cache_type == SECTOR)
+	{
+		for(unsigned i=0; i<cache_lines_num; ++i)
+			m_lines[i] = new sector_cache_block();
+	}
+	else
+		assert(0);
 
-  init(core_id, type_id);
+    init( core_id, type_id );
 }
 
-void tag_array::init(int core_id, int type_id) {
-  m_access = 0;
-  m_miss = 0;
-  m_pending_hit = 0;
-  m_res_fail = 0;
-  m_sector_miss = 0;
-  // initialize snapshot counters for visualizer
-  m_prev_snapshot_access = 0;
-  m_prev_snapshot_miss = 0;
-  m_prev_snapshot_pending_hit = 0;
-  m_core_id = core_id;
-  m_type_id = type_id;
-  is_used = false;
+void tag_array::init( int core_id, int type_id )
+{
+    m_access = 0;
+    m_miss = 0;
+    m_pending_hit = 0;
+    m_res_fail = 0;
+    m_sector_miss = 0;
+    // initialize snapshot counters for visualizer
+    m_prev_snapshot_access = 0;
+    m_prev_snapshot_miss = 0;
+    m_prev_snapshot_pending_hit = 0;
+    m_core_id = core_id; 
+    m_type_id = type_id;
+    is_used = false;
 }
 
-void tag_array::add_pending_line(mem_fetch *mf) {
-  assert(mf);
-  new_addr_type addr = m_config.block_addr(mf->get_addr());
-  line_table::const_iterator i = pending_lines.find(addr);
-  if (i == pending_lines.end()) {
-    pending_lines[addr] = mf->get_inst().get_uid();
-  }
+void tag_array::add_pending_line(mem_fetch *mf){
+	assert(mf);
+	new_addr_type addr = m_config.block_addr(mf->get_addr());
+	line_table::const_iterator i = pending_lines.find(addr);
+	if ( i == pending_lines.end() ) {
+		pending_lines[addr] = mf->get_inst().get_uid();
+	}
 }
 
-void tag_array::remove_pending_line(mem_fetch *mf) {
-  assert(mf);
-  new_addr_type addr = m_config.block_addr(mf->get_addr());
-  line_table::const_iterator i = pending_lines.find(addr);
-  if (i != pending_lines.end()) {
-    pending_lines.erase(addr);
-  }
+void tag_array::remove_pending_line(mem_fetch *mf){
+	assert(mf);
+	new_addr_type addr = m_config.block_addr(mf->get_addr());
+	line_table::const_iterator i = pending_lines.find(addr);
+	if ( i != pending_lines.end() ) {
+		pending_lines.erase(addr);
+	}
 }
 
-enum cache_request_status tag_array::probe(new_addr_type addr, unsigned &idx,
-                                           mem_fetch *mf,
-                                           bool probe_mode) const {
-  mem_access_sector_mask_t mask = mf->get_access_sector_mask();
-  return probe(addr, idx, mask, probe_mode, mf);
+enum cache_request_status tag_array::probe( new_addr_type addr, unsigned &idx, mem_fetch* mf, bool probe_mode) const {
+    mem_access_sector_mask_t mask = mf->get_access_sector_mask();
+    return probe(addr, idx, mask, probe_mode, mf);
 }
 
-enum cache_request_status tag_array::probe(new_addr_type addr, unsigned &idx,
-                                           mem_access_sector_mask_t mask,
-                                           bool probe_mode,
-                                           mem_fetch *mf) const {
-  // assert( m_config.m_write_policy == READ_ONLY );
-  unsigned set_index = m_config.set_index(addr);
-  new_addr_type tag = m_config.tag(addr);
 
-  unsigned invalid_line = (unsigned)-1;
-  unsigned valid_line = (unsigned)-1;
-  unsigned long long valid_timestamp = (unsigned)-1;
+enum cache_request_status tag_array::probe( new_addr_type addr, unsigned &idx, mem_access_sector_mask_t mask, bool probe_mode, mem_fetch* mf) const {
+    //assert( m_config.m_write_policy == READ_ONLY );
+    unsigned set_index = m_config.set_index(addr);
+    new_addr_type tag = m_config.tag(addr);
 
-  bool all_reserved = true;
+    unsigned invalid_line = (unsigned)-1;
+    unsigned valid_line = (unsigned)-1;
+    unsigned long long valid_timestamp = (unsigned)-1;
 
-  // check for hit or pending hit
-  for (unsigned way = 0; way < m_config.m_assoc; way++) {
-    unsigned index = set_index * m_config.m_assoc + way;
-    cache_block_t *line = m_lines[index];
-    if (line->m_tag == tag) {
-      if (line->get_status(mask) == RESERVED) {
-        idx = index;
-        return HIT_RESERVED;
-      } else if (line->get_status(mask) == VALID) {
-        idx = index;
-        return HIT;
-      } else if (line->get_status(mask) == MODIFIED) {
-        if (line->is_readable(mask)) {
-          idx = index;
-          return HIT;
-        } else {
-          idx = index;
-          return SECTOR_MISS;
+    bool all_reserved = true;
+
+    // check for hit or pending hit
+    for (unsigned way=0; way<m_config.m_assoc; way++) {
+        unsigned index = set_index*m_config.m_assoc+way;
+        cache_block_t *line = m_lines[index];
+        if (line->m_tag == tag) {
+            if ( line->get_status(mask) == RESERVED ) {
+                idx = index;
+                return HIT_RESERVED;
+            } else if ( line->get_status(mask) == VALID ) {
+                idx = index;
+                return HIT;
+            } else if ( line->get_status(mask) == MODIFIED) {
+            	if(line->is_readable(mask)) {
+					idx = index;
+					return HIT;
+            	}
+            	else {
+            		idx = index;
+            		return SECTOR_MISS;
+            	}
+
+            } else if ( line->is_valid_line() && line->get_status(mask) == INVALID ) {
+                idx = index;
+                return SECTOR_MISS;
+            }else {
+                assert( line->get_status(mask) == INVALID );
+            }
         }
-
-      } else if (line->is_valid_line() && line->get_status(mask) == INVALID) {
-        idx = index;
-        return SECTOR_MISS;
-      } else {
-        assert(line->get_status(mask) == INVALID);
-      }
-    }
-    if (!line->is_reserved_line()) {
-      all_reserved = false;
-      if (line->is_invalid_line()) {
-        invalid_line = index;
-      } else {
-        // valid line : keep track of most appropriate replacement candidate
-        if (m_config.m_replacement_policy == LRU) {
-          if (line->get_last_access_time() < valid_timestamp) {
-            valid_timestamp = line->get_last_access_time();
-            valid_line = index;
-          }
-        } else if (m_config.m_replacement_policy == FIFO) {
-          if (line->get_alloc_time() < valid_timestamp) {
-            valid_timestamp = line->get_alloc_time();
-            valid_line = index;
-          }
+        if (!line->is_reserved_line()) {
+            all_reserved = false;
+            if (line->is_invalid_line()) {
+                invalid_line = index;
+            } else {
+                // valid line : keep track of most appropriate replacement candidate
+                if ( m_config.m_replacement_policy == LRU ) {
+                    if ( line->get_last_access_time() < valid_timestamp ) {
+                        valid_timestamp = line->get_last_access_time();
+                        valid_line = index;
+                    }
+                } else if ( m_config.m_replacement_policy == FIFO ) {
+                    if ( line->get_alloc_time() < valid_timestamp ) {
+                        valid_timestamp = line->get_alloc_time();
+                        valid_line = index;
+                    }
+                }
+            }
         }
-      }
     }
-  }
-  if (all_reserved) {
-    assert(m_config.m_alloc_policy == ON_MISS);
-    return RESERVATION_FAIL;  // miss and not enough space in cache to allocate
-                              // on miss
-  }
-
-  if (invalid_line != (unsigned)-1) {
-    idx = invalid_line;
-  } else if (valid_line != (unsigned)-1) {
-    idx = valid_line;
-  } else
-    abort();  // if an unreserved block exists, it is either invalid or
-              // replaceable
-
-  if (probe_mode && m_config.is_streaming()) {
-    line_table::const_iterator i =
-        pending_lines.find(m_config.block_addr(addr));
-    assert(mf);
-    if (!mf->is_write() && i != pending_lines.end()) {
-      if (i->second != mf->get_inst().get_uid()) return SECTOR_MISS;
+    if ( all_reserved ) {
+        assert( m_config.m_alloc_policy == ON_MISS ); 
+        return RESERVATION_FAIL; // miss and not enough space in cache to allocate on miss
     }
-  }
 
-  return MISS;
+    if ( invalid_line != (unsigned)-1 ) {
+        idx = invalid_line;
+    } else if ( valid_line != (unsigned)-1) {
+        idx = valid_line;
+    } else abort(); // if an unreserved block exists, it is either invalid or replaceable 
+
+
+    if(probe_mode && m_config.is_streaming()){
+		line_table::const_iterator i = pending_lines.find(m_config.block_addr(addr));
+		assert(mf);
+		if ( !mf->is_write() && i != pending_lines.end() ) {
+			 if(i->second != mf->get_inst().get_uid())
+				 return SECTOR_MISS;
+		}
+    }
+
+    return MISS;
 }
 
-enum cache_request_status tag_array::access(new_addr_type addr, unsigned time,
-                                            unsigned &idx, mem_fetch *mf) {
-  bool wb = false;
-  evicted_block_info evicted;
-  enum cache_request_status result = access(addr, time, idx, wb, evicted, mf);
-  assert(!wb);
-  return result;
+enum cache_request_status tag_array::access( new_addr_type addr, unsigned time, unsigned &idx, mem_fetch* mf)
+{
+    bool wb=false;
+    evicted_block_info evicted;
+    enum cache_request_status result = access(addr,time,idx,wb,evicted,mf);
+    assert(!wb);
+    return result;
 }
 
-enum cache_request_status tag_array::access(new_addr_type addr, unsigned time,
-                                            unsigned &idx, bool &wb,
-                                            evicted_block_info &evicted,
-                                            mem_fetch *mf) {
-  m_access++;
-  is_used = true;
-  shader_cache_access_log(m_core_id, m_type_id, 0);  // log accesses to cache
-  enum cache_request_status status = probe(addr, idx, mf);
-  switch (status) {
-    case HIT_RESERVED:
-      m_pending_hit++;
-    case HIT:
-      m_lines[idx]->set_last_access_time(time, mf->get_access_sector_mask());
-      break;
+enum cache_request_status tag_array::access( new_addr_type addr, unsigned time, unsigned &idx, bool &wb, evicted_block_info &evicted, mem_fetch* mf )
+{
+    m_access++;
+    is_used = true;
+    shader_cache_access_log(m_core_id, m_type_id, 0); // log accesses to cache
+    enum cache_request_status status = probe(addr,idx,mf);
+    switch (status) {
+    case HIT_RESERVED: 
+        m_pending_hit++;
+    case HIT: 
+        m_lines[idx]->set_last_access_time(time, mf->get_access_sector_mask());
+        break;
     case MISS:
-      m_miss++;
-      shader_cache_access_log(m_core_id, m_type_id, 1);  // log cache misses
-      if (m_config.m_alloc_policy == ON_MISS) {
-        if (m_lines[idx]->is_modified_line()) {
-          wb = true;
-          evicted.set_info(m_lines[idx]->m_block_addr,
-                           m_lines[idx]->get_modified_size());
+        m_miss++;
+        shader_cache_access_log(m_core_id, m_type_id, 1); // log cache misses
+        if ( m_config.m_alloc_policy == ON_MISS ) {
+            if( m_lines[idx]->is_modified_line()) {
+                wb = true;
+                evicted.set_info(m_lines[idx]->m_block_addr, m_lines[idx]->get_modified_size());
+            }
+            m_lines[idx]->allocate( m_config.tag(addr), m_config.block_addr(addr), time, mf->get_access_sector_mask());
         }
-        m_lines[idx]->allocate(m_config.tag(addr), m_config.block_addr(addr),
-                               time, mf->get_access_sector_mask());
-      }
-      break;
+        break;
     case SECTOR_MISS:
-      assert(m_config.m_cache_type == SECTOR);
-      m_sector_miss++;
-      shader_cache_access_log(m_core_id, m_type_id, 1);  // log cache misses
-      if (m_config.m_alloc_policy == ON_MISS) {
-        ((sector_cache_block *)m_lines[idx])
-            ->allocate_sector(time, mf->get_access_sector_mask());
-      }
-      break;
+    	assert(m_config.m_cache_type == SECTOR);
+    	m_sector_miss++;
+		shader_cache_access_log(m_core_id, m_type_id, 1); // log cache misses
+		if ( m_config.m_alloc_policy == ON_MISS ) {
+			((sector_cache_block*)m_lines[idx])->allocate_sector( time, mf->get_access_sector_mask() );
+		}
+		break;
     case RESERVATION_FAIL:
-      m_res_fail++;
-      shader_cache_access_log(m_core_id, m_type_id, 1);  // log cache misses
-      break;
+        m_res_fail++;
+        shader_cache_access_log(m_core_id, m_type_id, 1); // log cache misses
+        break;
     default:
-      fprintf(stderr,
-              "tag_array::access - Error: Unknown"
-              "cache_request_status %d\n",
-              status);
-      abort();
-  }
-  return status;
+        fprintf( stderr, "tag_array::access - Error: Unknown"
+            "cache_request_status %d\n", status );
+        abort();
+    }
+    return status;
 }
 
-void tag_array::fill(new_addr_type addr, unsigned time, mem_fetch *mf) {
-  fill(addr, time, mf->get_access_sector_mask());
+void tag_array::fill( new_addr_type addr, unsigned time, mem_fetch* mf)
+{
+    fill(addr, time, mf->get_access_sector_mask());
 }
 
-void tag_array::fill(new_addr_type addr, unsigned time,
-                     mem_access_sector_mask_t mask) {
-  // assert( m_config.m_alloc_policy == ON_FILL );
-  unsigned idx;
-  enum cache_request_status status = probe(addr, idx, mask);
-  // assert(status==MISS||status==SECTOR_MISS); // MSHR should have prevented
-  // redundant memory request
-  if (status == MISS)
-    m_lines[idx]->allocate(m_config.tag(addr), m_config.block_addr(addr), time,
-                           mask);
-  else if (status == SECTOR_MISS) {
-    assert(m_config.m_cache_type == SECTOR);
-    ((sector_cache_block *)m_lines[idx])->allocate_sector(time, mask);
-  }
-
-  m_lines[idx]->fill(time, mask);
-}
-
-void tag_array::fill(unsigned index, unsigned time, mem_fetch *mf) {
-  assert(m_config.m_alloc_policy == ON_MISS);
-  m_lines[index]->fill(time, mf->get_access_sector_mask());
-}
-
-// TODO: we need write back the flushed data to the upper level
-void tag_array::flush() {
-  if (!is_used) return;
-
-  for (unsigned i = 0; i < m_config.get_num_lines(); i++)
-    if (m_lines[i]->is_modified_line()) {
-      for (unsigned j = 0; j < SECTOR_CHUNCK_SIZE; j++)
-        m_lines[i]->set_status(INVALID, mem_access_sector_mask_t().set(j));
+void tag_array::fill( new_addr_type addr, unsigned time, mem_access_sector_mask_t mask )
+{
+    //assert( m_config.m_alloc_policy == ON_FILL );
+    unsigned idx;
+    enum cache_request_status status = probe(addr,idx,mask);
+    //assert(status==MISS||status==SECTOR_MISS); // MSHR should have prevented redundant memory request
+    if(status==MISS)
+    	m_lines[idx]->allocate( m_config.tag(addr), m_config.block_addr(addr), time, mask );
+    else if (status==SECTOR_MISS) {
+    	assert(m_config.m_cache_type == SECTOR);
+    	((sector_cache_block*)m_lines[idx])->allocate_sector( time, mask );
     }
 
-  is_used = false;
+    m_lines[idx]->fill(time, mask);
 }
 
-void tag_array::invalidate() {
-  if (!is_used) return;
-
-  for (unsigned i = 0; i < m_config.get_num_lines(); i++)
-    for (unsigned j = 0; j < SECTOR_CHUNCK_SIZE; j++)
-      m_lines[i]->set_status(INVALID, mem_access_sector_mask_t().set(j));
-
-  is_used = false;
+void tag_array::fill( unsigned index, unsigned time, mem_fetch* mf)
+{
+    assert( m_config.m_alloc_policy == ON_MISS );
+    m_lines[index]->fill(time, mf->get_access_sector_mask());
 }
 
-float tag_array::windowed_miss_rate() const {
-  unsigned n_access = m_access - m_prev_snapshot_access;
-  unsigned n_miss = (m_miss + m_sector_miss) - m_prev_snapshot_miss;
-  // unsigned n_pending_hit = m_pending_hit - m_prev_snapshot_pending_hit;
 
-  float missrate = 0.0f;
-  if (n_access != 0) missrate = (float)(n_miss + m_sector_miss) / n_access;
-  return missrate;
+//TODO: we need write back the flushed data to the upper level
+void tag_array::flush() 
+{
+	if(!is_used)
+		return;
+
+    for (unsigned i=0; i < m_config.get_num_lines(); i++)
+    	if(m_lines[i]->is_modified_line()) {
+    	for(unsigned j=0; j < SECTOR_CHUNCK_SIZE; j++)
+    		m_lines[i]->set_status(INVALID, mem_access_sector_mask_t().set(j)) ;
+    	}
+
+    is_used = false;
 }
 
-void tag_array::new_window() {
-  m_prev_snapshot_access = m_access;
-  m_prev_snapshot_miss = m_miss;
-  m_prev_snapshot_miss = m_miss + m_sector_miss;
-  m_prev_snapshot_pending_hit = m_pending_hit;
+void tag_array::invalidate()
+{
+	if(!is_used)
+		return;
+
+    for (unsigned i=0; i < m_config.get_num_lines(); i++)
+    	for(unsigned j=0; j < SECTOR_CHUNCK_SIZE; j++)
+    		m_lines[i]->set_status(INVALID, mem_access_sector_mask_t().set(j)) ;
+
+    is_used = false;
 }
 
-void tag_array::print(FILE *stream, unsigned &total_access,
-                      unsigned &total_misses) const {
-  m_config.print(stream);
-  fprintf(stream,
-          "\t\tAccess = %d, Miss = %d, Sector_Miss = %d, Total_Miss = %d "
-          "(%.3g), PendingHit = %d (%.3g)\n",
-          m_access, m_miss, m_sector_miss, (m_miss + m_sector_miss),
-          (float)(m_miss + m_sector_miss) / m_access, m_pending_hit,
-          (float)m_pending_hit / m_access);
-  total_misses += (m_miss + m_sector_miss);
-  total_access += m_access;
+float tag_array::windowed_miss_rate( ) const
+{
+    unsigned n_access    = m_access - m_prev_snapshot_access;
+    unsigned n_miss      = (m_miss+m_sector_miss) - m_prev_snapshot_miss;
+    // unsigned n_pending_hit = m_pending_hit - m_prev_snapshot_pending_hit;
+
+    float missrate = 0.0f;
+    if (n_access != 0)
+        missrate = (float) (n_miss+m_sector_miss) / n_access;
+    return missrate;
 }
 
-void tag_array::get_stats(unsigned &total_access, unsigned &total_misses,
-                          unsigned &total_hit_res,
-                          unsigned &total_res_fail) const {
-  // Update statistics from the tag array
-  total_access = m_access;
-  total_misses = (m_miss + m_sector_miss);
-  total_hit_res = m_pending_hit;
-  total_res_fail = m_res_fail;
+void tag_array::new_window()
+{
+    m_prev_snapshot_access = m_access;
+    m_prev_snapshot_miss = m_miss;
+    m_prev_snapshot_miss = m_miss + m_sector_miss;
+    m_prev_snapshot_pending_hit = m_pending_hit;
 }
 
-bool was_write_sent(const std::list<cache_event> &events) {
-  for (std::list<cache_event>::const_iterator e = events.begin();
-       e != events.end(); e++) {
-    if ((*e).m_cache_event_type == WRITE_REQUEST_SENT) return true;
-  }
-  return false;
+void tag_array::print( FILE *stream, unsigned &total_access, unsigned &total_misses ) const
+{
+    m_config.print(stream);
+    fprintf( stream, "\t\tAccess = %d, Miss = %d, Sector_Miss = %d, Total_Miss = %d (%.3g), PendingHit = %d (%.3g)\n",
+             m_access, m_miss, m_sector_miss, (m_miss+m_sector_miss), (float) (m_miss+m_sector_miss) / m_access,
+             m_pending_hit, (float) m_pending_hit / m_access);
+    total_misses+=(m_miss+m_sector_miss);
+    total_access+=m_access;
 }
 
-bool was_writeback_sent(const std::list<cache_event> &events,
-                        cache_event &wb_event) {
-  for (std::list<cache_event>::const_iterator e = events.begin();
-       e != events.end(); e++) {
-    if ((*e).m_cache_event_type == WRITE_BACK_REQUEST_SENT) wb_event = *e;
-    return true;
-  }
-  return false;
+void tag_array::get_stats(unsigned &total_access, unsigned &total_misses, unsigned &total_hit_res, unsigned &total_res_fail) const{
+    // Update statistics from the tag array
+    total_access    = m_access;
+    total_misses    = (m_miss+m_sector_miss);
+    total_hit_res   = m_pending_hit;
+    total_res_fail  = m_res_fail;
 }
 
-bool was_read_sent(const std::list<cache_event> &events) {
-  for (std::list<cache_event>::const_iterator e = events.begin();
-       e != events.end(); e++) {
-    if ((*e).m_cache_event_type == READ_REQUEST_SENT) return true;
-  }
-  return false;
+
+bool was_write_sent( const std::list<cache_event> &events )
+{
+    for( std::list<cache_event>::const_iterator e=events.begin(); e!=events.end(); e++ ) {
+        if( (*e).m_cache_event_type == WRITE_REQUEST_SENT )
+            return true;
+    }
+    return false;
 }
 
-bool was_writeallocate_sent(const std::list<cache_event> &events) {
-  for (std::list<cache_event>::const_iterator e = events.begin();
-       e != events.end(); e++) {
-    if ((*e).m_cache_event_type == WRITE_ALLOCATE_SENT) return true;
-  }
-  return false;
+bool was_writeback_sent( const std::list<cache_event> &events, cache_event& wb_event)
+{
+    for( std::list<cache_event>::const_iterator e=events.begin(); e!=events.end(); e++ ) {
+        if( (*e).m_cache_event_type == WRITE_BACK_REQUEST_SENT )
+        	wb_event = *e;
+            return true;
+    }
+    return false;
 }
-/****************************************************************** MSHR
- * ******************************************************************/
+
+bool was_read_sent( const std::list<cache_event> &events )
+{
+    for( std::list<cache_event>::const_iterator e=events.begin(); e!=events.end(); e++ ) {
+        if( (*e).m_cache_event_type == READ_REQUEST_SENT )
+            return true;
+    }
+    return false;
+}
+
+bool was_writeallocate_sent( const std::list<cache_event> &events )
+{
+    for( std::list<cache_event>::const_iterator e=events.begin(); e!=events.end(); e++ ) {
+        if( (*e).m_cache_event_type == WRITE_ALLOCATE_SENT )
+            return true;
+    }
+    return false;
+}
+/****************************************************************** MSHR ******************************************************************/
 
 /// Checks if there is a pending request to the lower memory level already
-bool mshr_table::probe(new_addr_type block_addr) const {
-  table::const_iterator a = m_data.find(block_addr);
-  return a != m_data.end();
+bool mshr_table::probe( new_addr_type block_addr ) const{
+    table::const_iterator a = m_data.find(block_addr);
+    return a != m_data.end();
 }
 
 /// Checks if there is space for tracking a new memory access
-bool mshr_table::full(new_addr_type block_addr) const {
-  table::const_iterator i = m_data.find(block_addr);
-  if (i != m_data.end())
-    return i->second.m_list.size() >= m_max_merged;
-  else
-    return m_data.size() >= m_num_entries;
+bool mshr_table::full( new_addr_type block_addr ) const{
+    table::const_iterator i=m_data.find(block_addr);
+    if ( i != m_data.end() )
+        return i->second.m_list.size() >= m_max_merged;
+    else
+        return m_data.size() >= m_num_entries;
 }
 
 /// Add or merge this access
-void mshr_table::add(new_addr_type block_addr, mem_fetch *mf) {
-  m_data[block_addr].m_list.push_back(mf);
-  assert(m_data.size() <= m_num_entries);
-  assert(m_data[block_addr].m_list.size() <= m_max_merged);
-  // indicate that this MSHR entry contains an atomic operation
-  if (mf->isatomic()) {
-    m_data[block_addr].m_has_atomic = true;
-  }
+void mshr_table::add( new_addr_type block_addr, mem_fetch *mf ){
+	m_data[block_addr].m_list.push_back(mf);
+	assert( m_data.size() <= m_num_entries );
+	assert( m_data[block_addr].m_list.size() <= m_max_merged );
+	// indicate that this MSHR entry contains an atomic operation
+	if ( mf->isatomic() ) {
+		m_data[block_addr].m_has_atomic = true;
+	}
 }
 
 /// check is_read_after_write_pending
-bool mshr_table::is_read_after_write_pending(new_addr_type block_addr) {
-  std::list<mem_fetch *> my_list = m_data[block_addr].m_list;
-  bool write_found = false;
-  for (std::list<mem_fetch *>::iterator it = my_list.begin();
-       it != my_list.end(); ++it) {
-    if ((*it)->is_write())  // Pending Write Request
-      write_found = true;
-    else if (write_found)  // Pending Read Request and we found previous Write
-      return true;
-  }
+bool mshr_table::is_read_after_write_pending( new_addr_type block_addr){
+	std::list<mem_fetch*> my_list = m_data[block_addr].m_list;
+	bool write_found = false;
+	for (std::list<mem_fetch*>::iterator it=my_list.begin(); it != my_list.end(); ++it)
+	{
+		if((*it)->is_write()) //Pending Write Request
+			write_found = true;
+		else if(write_found)   //Pending Read Request and we found previous Write
+				return true;
+	}
 
-  return false;
+	return false;
+
 }
 
 /// Accept a new cache fill response: mark entry ready for processing
-void mshr_table::mark_ready(new_addr_type block_addr, bool &has_atomic) {
-  assert(!busy());
-  table::iterator a = m_data.find(block_addr);
-  assert(a != m_data.end());
-  m_current_response.push_back(block_addr);
-  has_atomic = a->second.m_has_atomic;
-  assert(m_current_response.size() <= m_data.size());
+void mshr_table::mark_ready( new_addr_type block_addr, bool &has_atomic ){
+    assert( !busy() );
+    table::iterator a = m_data.find(block_addr);
+    assert( a != m_data.end() );
+    m_current_response.push_back( block_addr );
+    has_atomic = a->second.m_has_atomic;
+    assert( m_current_response.size() <= m_data.size() );
 }
 
 /// Returns next ready access
-mem_fetch *mshr_table::next_access() {
-  assert(access_ready());
-  new_addr_type block_addr = m_current_response.front();
-  assert(!m_data[block_addr].m_list.empty());
-  mem_fetch *result = m_data[block_addr].m_list.front();
-  m_data[block_addr].m_list.pop_front();
-  if (m_data[block_addr].m_list.empty()) {
-    // release entry
-    m_data.erase(block_addr);
-    m_current_response.pop_front();
-  }
-  return result;
-}
-
-void mshr_table::display(FILE *fp) const {
-  fprintf(fp, "MSHR contents\n");
-  for (table::const_iterator e = m_data.begin(); e != m_data.end(); ++e) {
-    unsigned block_addr = e->first;
-    fprintf(fp, "MSHR: tag=0x%06x, atomic=%d %zu entries : ", block_addr,
-            e->second.m_has_atomic, e->second.m_list.size());
-    if (!e->second.m_list.empty()) {
-      mem_fetch *mf = e->second.m_list.front();
-      fprintf(fp, "%p :", mf);
-      mf->print(fp);
-    } else {
-      fprintf(fp, " no memory requests???\n");
+mem_fetch *mshr_table::next_access(){
+    assert( access_ready() );
+    new_addr_type block_addr = m_current_response.front();
+    assert( !m_data[block_addr].m_list.empty() );
+    mem_fetch *result = m_data[block_addr].m_list.front();
+    m_data[block_addr].m_list.pop_front();
+    if ( m_data[block_addr].m_list.empty() ) {
+        // release entry
+        m_data.erase(block_addr);
+        m_current_response.pop_front();
     }
-  }
-}
-/***************************************************************** Caches
- * *****************************************************************/
-cache_stats::cache_stats() {
-  m_stats.resize(NUM_MEM_ACCESS_TYPE);
-  m_stats_pw.resize(NUM_MEM_ACCESS_TYPE);
-  m_fail_stats.resize(NUM_MEM_ACCESS_TYPE);
-  for (unsigned i = 0; i < NUM_MEM_ACCESS_TYPE; ++i) {
-    m_stats[i].resize(NUM_CACHE_REQUEST_STATUS, 0);
-    m_stats_pw[i].resize(NUM_CACHE_REQUEST_STATUS, 0);
-    m_fail_stats[i].resize(NUM_CACHE_RESERVATION_FAIL_STATUS, 0);
-  }
-  m_cache_port_available_cycles = 0;
-  m_cache_data_port_busy_cycles = 0;
-  m_cache_fill_port_busy_cycles = 0;
+    return result;
 }
 
-void cache_stats::clear() {
-  ///
-  /// Zero out all current cache statistics
-  ///
-  for (unsigned i = 0; i < NUM_MEM_ACCESS_TYPE; ++i) {
-    std::fill(m_stats[i].begin(), m_stats[i].end(), 0);
-    std::fill(m_fail_stats[i].begin(), m_fail_stats[i].end(), 0);
-  }
-  m_cache_port_available_cycles = 0;
-  m_cache_data_port_busy_cycles = 0;
-  m_cache_fill_port_busy_cycles = 0;
-}
-
-void cache_stats::clear_pw() {
-  ///
-  /// Zero out per-window cache statistics
-  ///
-  for (unsigned i = 0; i < NUM_MEM_ACCESS_TYPE; ++i) {
-    std::fill(m_stats_pw[i].begin(), m_stats_pw[i].end(), 0);
-  }
-}
-
-void cache_stats::inc_stats(int access_type, int access_outcome) {
-  ///
-  /// Increment the stat corresponding to (access_type, access_outcome) by 1.
-  ///
-  if (!check_valid(access_type, access_outcome))
-    assert(0 && "Unknown cache access type or access outcome");
-
-  m_stats[access_type][access_outcome]++;
-}
-
-void cache_stats::inc_stats_pw(int access_type, int access_outcome) {
-  ///
-  /// Increment the corresponding per-window cache stat
-  ///
-  if (!check_valid(access_type, access_outcome))
-    assert(0 && "Unknown cache access type or access outcome");
-  m_stats_pw[access_type][access_outcome]++;
-}
-
-void cache_stats::inc_fail_stats(int access_type, int fail_outcome) {
-  if (!check_fail_valid(access_type, fail_outcome))
-    assert(0 && "Unknown cache access type or access fail");
-
-  m_fail_stats[access_type][fail_outcome]++;
-}
-
-enum cache_request_status cache_stats::select_stats_status(
-    enum cache_request_status probe, enum cache_request_status access) const {
-  ///
-  /// This function selects how the cache access outcome should be counted.
-  /// HIT_RESERVED is considered as a MISS
-  /// in the cores, however, it should be counted as a HIT_RESERVED in the
-  /// caches.
-  ///
-  if (probe == HIT_RESERVED && access != RESERVATION_FAIL)
-    return probe;
-  else if (probe == SECTOR_MISS && access == MISS)
-    return probe;
-  else
-    return access;
-}
-
-unsigned long long &cache_stats::operator()(int access_type, int access_outcome,
-                                            bool fail_outcome) {
-  ///
-  /// Simple method to read/modify the stat corresponding to (access_type,
-  /// access_outcome)
-  /// Used overloaded () to avoid the need for separate read/write member
-  /// functions
-  ///
-  if (fail_outcome) {
-    if (!check_fail_valid(access_type, access_outcome))
-      assert(0 && "Unknown cache access type or fail outcome");
-
-    return m_fail_stats[access_type][access_outcome];
-  } else {
-    if (!check_valid(access_type, access_outcome))
-      assert(0 && "Unknown cache access type or access outcome");
-
-    return m_stats[access_type][access_outcome];
-  }
-}
-
-unsigned long long cache_stats::operator()(int access_type, int access_outcome,
-                                           bool fail_outcome) const {
-  ///
-  /// Const accessor into m_stats.
-  ///
-  if (fail_outcome) {
-    if (!check_fail_valid(access_type, access_outcome))
-      assert(0 && "Unknown cache access type or fail outcome");
-
-    return m_fail_stats[access_type][access_outcome];
-  } else {
-    if (!check_valid(access_type, access_outcome))
-      assert(0 && "Unknown cache access type or access outcome");
-
-    return m_stats[access_type][access_outcome];
-  }
-}
-
-cache_stats cache_stats::operator+(const cache_stats &cs) {
-  ///
-  /// Overloaded + operator to allow for simple stat accumulation
-  ///
-  cache_stats ret;
-  for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
-    for (unsigned status = 0; status < NUM_CACHE_REQUEST_STATUS; ++status) {
-      ret(type, status, false) =
-          m_stats[type][status] + cs(type, status, false);
+void mshr_table::display( FILE *fp ) const{
+    fprintf(fp,"MSHR contents\n");
+    for ( table::const_iterator e=m_data.begin(); e!=m_data.end(); ++e ) {
+        unsigned block_addr = e->first;
+        fprintf(fp,"MSHR: tag=0x%06x, atomic=%d %zu entries : ", block_addr, e->second.m_has_atomic, e->second.m_list.size());
+        if ( !e->second.m_list.empty() ) {
+            mem_fetch *mf = e->second.m_list.front();
+            fprintf(fp,"%p :",mf);
+            mf->print(fp);
+        } else {
+            fprintf(fp," no memory requests???\n");
+        }
     }
-    for (unsigned status = 0; status < NUM_CACHE_RESERVATION_FAIL_STATUS;
-         ++status) {
-      ret(type, status, true) =
-          m_fail_stats[type][status] + cs(type, status, true);
-    }
-  }
-  ret.m_cache_port_available_cycles =
-      m_cache_port_available_cycles + cs.m_cache_port_available_cycles;
-  ret.m_cache_data_port_busy_cycles =
-      m_cache_data_port_busy_cycles + cs.m_cache_data_port_busy_cycles;
-  ret.m_cache_fill_port_busy_cycles =
-      m_cache_fill_port_busy_cycles + cs.m_cache_fill_port_busy_cycles;
-  return ret;
+}
+/***************************************************************** Caches *****************************************************************/
+cache_stats::cache_stats(){
+    m_stats.resize(NUM_MEM_ACCESS_TYPE);
+    m_stats_pw.resize(NUM_MEM_ACCESS_TYPE);
+    m_fail_stats.resize(NUM_MEM_ACCESS_TYPE);
+    for(unsigned i=0; i<NUM_MEM_ACCESS_TYPE; ++i){
+        m_stats[i].resize(NUM_CACHE_REQUEST_STATUS, 0);
+        m_stats_pw[i].resize(NUM_CACHE_REQUEST_STATUS, 0);
+		m_fail_stats[i].resize(NUM_CACHE_RESERVATION_FAIL_STATUS, 0);
+	}
+    m_cache_port_available_cycles = 0; 
+    m_cache_data_port_busy_cycles = 0; 
+    m_cache_fill_port_busy_cycles = 0; 
 }
 
-cache_stats &cache_stats::operator+=(const cache_stats &cs) {
-  ///
-  /// Overloaded += operator to allow for simple stat accumulation
-  ///
-  for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
-    for (unsigned status = 0; status < NUM_CACHE_REQUEST_STATUS; ++status) {
-      m_stats[type][status] += cs(type, status, false);
-    }
-    for (unsigned status = 0; status < NUM_CACHE_REQUEST_STATUS; ++status) {
-      m_stats_pw[type][status] += cs(type, status, false);
-    }
-    for (unsigned status = 0; status < NUM_CACHE_RESERVATION_FAIL_STATUS;
-         ++status) {
-      m_fail_stats[type][status] += cs(type, status, true);
-    }
-  }
-  m_cache_port_available_cycles += cs.m_cache_port_available_cycles;
-  m_cache_data_port_busy_cycles += cs.m_cache_data_port_busy_cycles;
-  m_cache_fill_port_busy_cycles += cs.m_cache_fill_port_busy_cycles;
-  return *this;
+void cache_stats::clear(){
+    ///
+    /// Zero out all current cache statistics
+    ///
+    for(unsigned i=0; i<NUM_MEM_ACCESS_TYPE; ++i){
+        std::fill(m_stats[i].begin(), m_stats[i].end(), 0);
+		std::fill(m_fail_stats[i].begin(), m_fail_stats[i].end(), 0);
+	}
+    m_cache_port_available_cycles = 0; 
+    m_cache_data_port_busy_cycles = 0; 
+    m_cache_fill_port_busy_cycles = 0; 
 }
 
-void cache_stats::print_stats(FILE *fout, const char *cache_name) const {
-  ///
-  /// Print out each non-zero cache statistic for every memory access type and
-  /// status
-  /// "cache_name" defaults to "Cache_stats" when no argument is provided,
-  /// otherwise
-  /// the provided name is used.
-  /// The printed format is "<cache_name>[<request_type>][<request_status>] =
-  /// <stat_value>"
-  ///
-  std::vector<unsigned> total_access;
-  total_access.resize(NUM_MEM_ACCESS_TYPE, 0);
-  std::string m_cache_name = cache_name;
-  for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
-    for (unsigned status = 0; status < NUM_CACHE_REQUEST_STATUS; ++status) {
-      fprintf(fout, "\t%s[%s][%s] = %llu\n", m_cache_name.c_str(),
-              mem_access_type_str((enum mem_access_type)type),
-              cache_request_status_str((enum cache_request_status)status),
-              m_stats[type][status]);
-
-      if (status != RESERVATION_FAIL)
-        total_access[type] += m_stats[type][status];
-    }
-  }
-  for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
-    if (total_access[type] > 0)
-      fprintf(fout, "\t%s[%s][%s] = %u\n", m_cache_name.c_str(),
-              mem_access_type_str((enum mem_access_type)type), "TOTAL_ACCESS",
-              total_access[type]);
-  }
+void cache_stats::clear_pw(){
+    ///
+    /// Zero out per-window cache statistics
+    ///
+    for(unsigned i=0; i<NUM_MEM_ACCESS_TYPE; ++i){
+        std::fill(m_stats_pw[i].begin(), m_stats_pw[i].end(), 0);
+	}
 }
 
-void cache_stats::print_fail_stats(FILE *fout, const char *cache_name) const {
-  std::string m_cache_name = cache_name;
-  for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
-    for (unsigned fail = 0; fail < NUM_CACHE_RESERVATION_FAIL_STATUS; ++fail) {
-      if (m_fail_stats[type][fail] > 0) {
-        fprintf(fout, "\t%s[%s][%s] = %llu\n", m_cache_name.c_str(),
-                mem_access_type_str((enum mem_access_type)type),
-                cache_fail_status_str((enum cache_reservation_fail_reason)fail),
-                m_fail_stats[type][fail]);
-      }
-    }
-  }
-}
-
-void cache_sub_stats::print_port_stats(FILE *fout,
-                                       const char *cache_name) const {
-  float data_port_util = 0.0f;
-  if (port_available_cycles > 0) {
-    data_port_util = (float)data_port_busy_cycles / port_available_cycles;
-  }
-  fprintf(fout, "%s_data_port_util = %.3f\n", cache_name, data_port_util);
-  float fill_port_util = 0.0f;
-  if (port_available_cycles > 0) {
-    fill_port_util = (float)fill_port_busy_cycles / port_available_cycles;
-  }
-  fprintf(fout, "%s_fill_port_util = %.3f\n", cache_name, fill_port_util);
-}
-
-unsigned long long cache_stats::get_stats(
-    enum mem_access_type *access_type, unsigned num_access_type,
-    enum cache_request_status *access_status,
-    unsigned num_access_status) const {
-  ///
-  /// Returns a sum of the stats corresponding to each "access_type" and
-  /// "access_status" pair.
-  /// "access_type" is an array of "num_access_type" mem_access_types.
-  /// "access_status" is an array of "num_access_status" cache_request_statuses.
-  ///
-  unsigned long long total = 0;
-  for (unsigned type = 0; type < num_access_type; ++type) {
-    for (unsigned status = 0; status < num_access_status; ++status) {
-      if (!check_valid((int)access_type[type], (int)access_status[status]))
+void cache_stats::inc_stats(int access_type, int access_outcome){
+    ///
+    /// Increment the stat corresponding to (access_type, access_outcome) by 1.
+    ///
+    if(!check_valid(access_type, access_outcome))
         assert(0 && "Unknown cache access type or access outcome");
-      total += m_stats[access_type[type]][access_status[status]];
+
+    m_stats[access_type][access_outcome]++;
+}
+
+void cache_stats::inc_stats_pw(int access_type, int access_outcome){
+    ///
+    /// Increment the corresponding per-window cache stat
+    ///
+    if(!check_valid(access_type, access_outcome))
+        assert(0 && "Unknown cache access type or access outcome");
+    m_stats_pw[access_type][access_outcome]++;
+}
+
+void cache_stats::inc_fail_stats(int access_type, int fail_outcome){
+
+	if(!check_fail_valid(access_type, fail_outcome))
+		 assert(0 && "Unknown cache access type or access fail");
+
+	m_fail_stats[access_type][fail_outcome]++;
+}
+
+
+enum cache_request_status cache_stats::select_stats_status(enum cache_request_status probe, enum cache_request_status access) const {
+	///
+	/// This function selects how the cache access outcome should be counted. HIT_RESERVED is considered as a MISS
+	/// in the cores, however, it should be counted as a HIT_RESERVED in the caches.
+	///
+	if(probe == HIT_RESERVED && access != RESERVATION_FAIL)
+		return probe;
+	else if(probe == SECTOR_MISS && access == MISS)
+		return probe;
+	else
+		return access;
+}
+
+unsigned long long &cache_stats::operator()(int access_type, int access_outcome, bool fail_outcome){
+    ///
+    /// Simple method to read/modify the stat corresponding to (access_type, access_outcome)
+    /// Used overloaded () to avoid the need for separate read/write member functions
+    ///
+	if(fail_outcome) {
+		if(!check_fail_valid(access_type, access_outcome))
+			assert(0 && "Unknown cache access type or fail outcome");
+
+		return m_fail_stats[access_type][access_outcome];
+	}
+	else {
+		if(!check_valid(access_type, access_outcome))
+			assert(0 && "Unknown cache access type or access outcome");
+
+		return m_stats[access_type][access_outcome];
+	}
+}
+
+unsigned long long cache_stats::operator()(int access_type, int access_outcome, bool fail_outcome) const{
+    ///
+    /// Const accessor into m_stats.
+    ///
+	if(fail_outcome) {
+		if(!check_fail_valid(access_type, access_outcome))
+			assert(0 && "Unknown cache access type or fail outcome");
+
+		return m_fail_stats[access_type][access_outcome];
+	}
+	else {
+		if(!check_valid(access_type, access_outcome))
+			assert(0 && "Unknown cache access type or access outcome");
+
+		return m_stats[access_type][access_outcome];
+	}
+}
+
+cache_stats cache_stats::operator+(const cache_stats &cs){
+    ///
+    /// Overloaded + operator to allow for simple stat accumulation
+    ///
+    cache_stats ret;
+    for(unsigned type=0; type<NUM_MEM_ACCESS_TYPE; ++type){
+        for(unsigned status=0; status<NUM_CACHE_REQUEST_STATUS; ++status){
+            ret(type, status, false) = m_stats[type][status] + cs(type, status, false);
+        }
+		for(unsigned status=0; status<NUM_CACHE_RESERVATION_FAIL_STATUS; ++status){
+			   ret(type, status, true) = m_fail_stats[type][status] + cs(type, status, true);
+		   }
+        }
+    ret.m_cache_port_available_cycles = m_cache_port_available_cycles + cs.m_cache_port_available_cycles; 
+    ret.m_cache_data_port_busy_cycles = m_cache_data_port_busy_cycles + cs.m_cache_data_port_busy_cycles; 
+    ret.m_cache_fill_port_busy_cycles = m_cache_fill_port_busy_cycles + cs.m_cache_fill_port_busy_cycles; 
+    return ret;
+}
+
+cache_stats &cache_stats::operator+=(const cache_stats &cs){
+    ///
+    /// Overloaded += operator to allow for simple stat accumulation
+    ///
+    for(unsigned type=0; type<NUM_MEM_ACCESS_TYPE; ++type){
+        for(unsigned status=0; status<NUM_CACHE_REQUEST_STATUS; ++status){
+            m_stats[type][status] += cs(type, status, false);
+        }
+        for(unsigned status=0; status<NUM_CACHE_REQUEST_STATUS; ++status){
+            m_stats_pw[type][status] += cs(type, status, false);
+        }
+        for(unsigned status=0; status<NUM_CACHE_RESERVATION_FAIL_STATUS; ++status){
+            m_fail_stats[type][status] += cs(type, status, true);
+	   }
     }
-  }
-  return total;
+    m_cache_port_available_cycles += cs.m_cache_port_available_cycles; 
+    m_cache_data_port_busy_cycles += cs.m_cache_data_port_busy_cycles; 
+    m_cache_fill_port_busy_cycles += cs.m_cache_fill_port_busy_cycles; 
+    return *this;
 }
 
-void cache_stats::get_sub_stats(struct cache_sub_stats &css) const {
-  ///
-  /// Overwrites "css" with the appropriate statistics from this cache.
-  ///
-  struct cache_sub_stats t_css;
-  t_css.clear();
+void cache_stats::print_stats(FILE *fout, const char *cache_name) const{
+    ///
+    /// Print out each non-zero cache statistic for every memory access type and status
+    /// "cache_name" defaults to "Cache_stats" when no argument is provided, otherwise
+    /// the provided name is used.
+    /// The printed format is "<cache_name>[<request_type>][<request_status>] = <stat_value>"
+    ///
+    std::vector< unsigned > total_access;
+    total_access.resize(NUM_MEM_ACCESS_TYPE, 0);
+    std::string m_cache_name = cache_name;
+    for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
+        for (unsigned status = 0; status < NUM_CACHE_REQUEST_STATUS; ++status) {
+            fprintf(fout, "\t%s[%s][%s] = %llu\n",
+                m_cache_name.c_str(),
+                mem_access_type_str((enum mem_access_type)type),
+                cache_request_status_str((enum cache_request_status)status),
+                m_stats[type][status]);
 
-  for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
-    for (unsigned status = 0; status < NUM_CACHE_REQUEST_STATUS; ++status) {
-      if (status == HIT || status == MISS || status == SECTOR_MISS ||
-          status == HIT_RESERVED)
-        t_css.accesses += m_stats[type][status];
-
-      if (status == MISS || status == SECTOR_MISS)
-        t_css.misses += m_stats[type][status];
-
-      if (status == HIT_RESERVED) t_css.pending_hits += m_stats[type][status];
-
-      if (status == RESERVATION_FAIL) t_css.res_fails += m_stats[type][status];
+            if(status != RESERVATION_FAIL)
+            	 total_access[type]+= m_stats[type][status];
+        }
     }
-  }
-
-  t_css.port_available_cycles = m_cache_port_available_cycles;
-  t_css.data_port_busy_cycles = m_cache_data_port_busy_cycles;
-  t_css.fill_port_busy_cycles = m_cache_fill_port_busy_cycles;
-
-  css = t_css;
-}
-
-void cache_stats::get_sub_stats_pw(struct cache_sub_stats_pw &css) const {
-  ///
-  /// Overwrites "css" with the appropriate statistics from this cache.
-  ///
-  struct cache_sub_stats_pw t_css;
-  t_css.clear();
-
-  for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
-    for (unsigned status = 0; status < NUM_CACHE_REQUEST_STATUS; ++status) {
-      if (status == HIT || status == MISS || status == SECTOR_MISS ||
-          status == HIT_RESERVED)
-        t_css.accesses += m_stats_pw[type][status];
-
-      if (status == HIT) {
-        if (type == GLOBAL_ACC_R || type == CONST_ACC_R || type == INST_ACC_R) {
-          t_css.read_hits += m_stats_pw[type][status];
-        } else if (type == GLOBAL_ACC_W) {
-          t_css.write_hits += m_stats_pw[type][status];
-        }
-      }
-
-      if (status == MISS || status == SECTOR_MISS) {
-        if (type == GLOBAL_ACC_R || type == CONST_ACC_R || type == INST_ACC_R) {
-          t_css.read_misses += m_stats_pw[type][status];
-        } else if (type == GLOBAL_ACC_W) {
-          t_css.write_misses += m_stats_pw[type][status];
-        }
-      }
-
-      if (status == HIT_RESERVED) {
-        if (type == GLOBAL_ACC_R || type == CONST_ACC_R || type == INST_ACC_R) {
-          t_css.read_pending_hits += m_stats_pw[type][status];
-        } else if (type == GLOBAL_ACC_W) {
-          t_css.write_pending_hits += m_stats_pw[type][status];
-        }
-      }
-
-      if (status == RESERVATION_FAIL) {
-        if (type == GLOBAL_ACC_R || type == CONST_ACC_R || type == INST_ACC_R) {
-          t_css.read_res_fails += m_stats_pw[type][status];
-        } else if (type == GLOBAL_ACC_W) {
-          t_css.write_res_fails += m_stats_pw[type][status];
-        }
-      }
+    for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
+    	 if(total_access[type] > 0)
+    	  fprintf(fout, "\t%s[%s][%s] = %u\n",
+				m_cache_name.c_str(),
+				mem_access_type_str((enum mem_access_type)type),
+				"TOTAL_ACCESS",
+				total_access[type]);
     }
-  }
-
-  css = t_css;
 }
 
-bool cache_stats::check_valid(int type, int status) const {
-  ///
-  /// Verify a valid access_type/access_status
-  ///
-  if ((type >= 0) && (type < NUM_MEM_ACCESS_TYPE) && (status >= 0) &&
-      (status < NUM_CACHE_REQUEST_STATUS))
-    return true;
-  else
-    return false;
+void cache_stats::print_fail_stats(FILE *fout, const char *cache_name) const{
+	std::string m_cache_name = cache_name;
+	    for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
+	        for (unsigned fail = 0; fail < NUM_CACHE_RESERVATION_FAIL_STATUS; ++fail) {
+	            if(m_fail_stats[type][fail] > 0){
+	                fprintf(fout, "\t%s[%s][%s] = %llu\n",
+	                    m_cache_name.c_str(),
+	                    mem_access_type_str((enum mem_access_type)type),
+						cache_fail_status_str((enum cache_reservation_fail_reason)fail),
+						m_fail_stats[type][fail]);
+	            }
+	        }
+	    }
 }
 
-bool cache_stats::check_fail_valid(int type, int fail) const {
-  ///
-  /// Verify a valid access_type/access_status
-  ///
-  if ((type >= 0) && (type < NUM_MEM_ACCESS_TYPE) && (fail >= 0) &&
-      (fail < NUM_CACHE_RESERVATION_FAIL_STATUS))
-    return true;
-  else
-    return false;
+void cache_sub_stats::print_port_stats(FILE *fout, const char *cache_name) const
+{
+    float data_port_util = 0.0f; 
+    if (port_available_cycles > 0) {
+        data_port_util = (float) data_port_busy_cycles / port_available_cycles; 
+    }
+    fprintf(fout, "%s_data_port_util = %.3f\n", cache_name, data_port_util); 
+    float fill_port_util = 0.0f; 
+    if (port_available_cycles > 0) {
+        fill_port_util = (float) fill_port_busy_cycles / port_available_cycles; 
+    }
+    fprintf(fout, "%s_fill_port_util = %.3f\n", cache_name, fill_port_util); 
 }
 
-void cache_stats::sample_cache_port_utility(bool data_port_busy,
-                                            bool fill_port_busy) {
-  m_cache_port_available_cycles += 1;
-  if (data_port_busy) {
-    m_cache_data_port_busy_cycles += 1;
-  }
-  if (fill_port_busy) {
-    m_cache_fill_port_busy_cycles += 1;
-  }
+unsigned long long cache_stats::get_stats(enum mem_access_type *access_type, unsigned num_access_type, enum cache_request_status *access_status, unsigned num_access_status) const{
+    ///
+    /// Returns a sum of the stats corresponding to each "access_type" and "access_status" pair.
+    /// "access_type" is an array of "num_access_type" mem_access_types.
+    /// "access_status" is an array of "num_access_status" cache_request_statuses.
+    ///
+    unsigned long long total=0;
+    for(unsigned type =0; type < num_access_type; ++type){
+        for(unsigned status=0; status < num_access_status; ++status){
+            if(!check_valid((int)access_type[type], (int)access_status[status]))
+                assert(0 && "Unknown cache access type or access outcome");
+            total += m_stats[access_type[type]][access_status[status]];
+        }
+    }
+    return total;
 }
 
-baseline_cache::bandwidth_management::bandwidth_management(cache_config &config)
-    : m_config(config) {
-  m_data_port_occupied_cycles = 0;
-  m_fill_port_occupied_cycles = 0;
+void cache_stats::get_sub_stats(struct cache_sub_stats &css) const{
+    ///
+    /// Overwrites "css" with the appropriate statistics from this cache.
+    ///
+    struct cache_sub_stats t_css;
+    t_css.clear();
+
+    for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
+        for (unsigned status = 0; status < NUM_CACHE_REQUEST_STATUS; ++status) {
+            if(status == HIT || status == MISS || status == SECTOR_MISS || status == HIT_RESERVED)
+                t_css.accesses += m_stats[type][status];
+
+            if(status == MISS || status == SECTOR_MISS)
+                t_css.misses += m_stats[type][status];
+
+            if(status == HIT_RESERVED)
+                t_css.pending_hits += m_stats[type][status];
+
+            if(status == RESERVATION_FAIL)
+                t_css.res_fails += m_stats[type][status];
+        }
+    }
+
+    t_css.port_available_cycles = m_cache_port_available_cycles; 
+    t_css.data_port_busy_cycles = m_cache_data_port_busy_cycles; 
+    t_css.fill_port_busy_cycles = m_cache_fill_port_busy_cycles; 
+
+    css = t_css;
 }
 
-/// use the data port based on the outcome and events generated by the mem_fetch
-/// request
-void baseline_cache::bandwidth_management::use_data_port(
-    mem_fetch *mf, enum cache_request_status outcome,
-    const std::list<cache_event> &events) {
-  unsigned data_size = mf->get_data_size();
-  unsigned port_width = m_config.m_data_port_width;
-  switch (outcome) {
+void cache_stats::get_sub_stats_pw(struct cache_sub_stats_pw &css) const{
+    ///
+    /// Overwrites "css" with the appropriate statistics from this cache.
+    ///
+    struct cache_sub_stats_pw t_css;
+    t_css.clear();
+
+    for (unsigned type = 0; type < NUM_MEM_ACCESS_TYPE; ++type) {
+        for (unsigned status = 0; status < NUM_CACHE_REQUEST_STATUS; ++status) {
+            if(status == HIT || status == MISS || status == SECTOR_MISS || status == HIT_RESERVED)
+                t_css.accesses += m_stats_pw[type][status];
+
+            if(status == HIT){
+                if(type == GLOBAL_ACC_R || type == CONST_ACC_R || type == INST_ACC_R){
+                    t_css.read_hits += m_stats_pw[type][status];
+                } else if(type == GLOBAL_ACC_W){
+                    t_css.write_hits += m_stats_pw[type][status];
+                }
+            }
+
+            if(status == MISS || status == SECTOR_MISS){
+                if(type == GLOBAL_ACC_R || type == CONST_ACC_R || type == INST_ACC_R){
+                    t_css.read_misses += m_stats_pw[type][status];
+                } else if(type == GLOBAL_ACC_W){
+                    t_css.write_misses += m_stats_pw[type][status];
+                }
+            }
+
+            if(status == HIT_RESERVED){
+                if(type == GLOBAL_ACC_R || type == CONST_ACC_R || type == INST_ACC_R){
+                    t_css.read_pending_hits += m_stats_pw[type][status];
+                } else if(type == GLOBAL_ACC_W){
+                    t_css.write_pending_hits += m_stats_pw[type][status];
+                }
+            }
+
+            if(status == RESERVATION_FAIL){
+                if(type == GLOBAL_ACC_R || type == CONST_ACC_R || type == INST_ACC_R){
+                    t_css.read_res_fails += m_stats_pw[type][status];
+                } else if(type == GLOBAL_ACC_W){
+                    t_css.write_res_fails += m_stats_pw[type][status];
+                }
+            }
+        }
+    }
+
+    css = t_css;
+}
+
+bool cache_stats::check_valid(int type, int status) const{
+    ///
+    /// Verify a valid access_type/access_status
+    ///
+    if((type >= 0) && (type < NUM_MEM_ACCESS_TYPE) && (status >= 0) && (status < NUM_CACHE_REQUEST_STATUS))
+        return true;
+    else
+        return false;
+}
+
+bool cache_stats::check_fail_valid(int type, int fail) const{
+    ///
+    /// Verify a valid access_type/access_status
+    ///
+    if((type >= 0) && (type < NUM_MEM_ACCESS_TYPE) && (fail >= 0) && (fail < NUM_CACHE_RESERVATION_FAIL_STATUS))
+        return true;
+    else
+        return false;
+}
+
+void cache_stats::sample_cache_port_utility(bool data_port_busy, bool fill_port_busy) 
+{
+    m_cache_port_available_cycles += 1; 
+    if (data_port_busy) {
+        m_cache_data_port_busy_cycles += 1; 
+    } 
+    if (fill_port_busy) {
+        m_cache_fill_port_busy_cycles += 1; 
+    } 
+}
+
+baseline_cache::bandwidth_management::bandwidth_management(cache_config &config) 
+: m_config(config)
+{
+    m_data_port_occupied_cycles = 0; 
+    m_fill_port_occupied_cycles = 0; 
+}
+
+/// use the data port based on the outcome and events generated by the mem_fetch request 
+void baseline_cache::bandwidth_management::use_data_port(mem_fetch *mf, enum cache_request_status outcome, const std::list<cache_event> &events)
+{
+    unsigned data_size = mf->get_data_size(); 
+    unsigned port_width = m_config.m_data_port_width; 
+    switch (outcome) {
     case HIT: {
-      unsigned data_cycles =
-          data_size / port_width + ((data_size % port_width > 0) ? 1 : 0);
-      m_data_port_occupied_cycles += data_cycles;
-    } break;
+        unsigned data_cycles = data_size / port_width + ((data_size % port_width > 0)? 1 : 0); 
+        m_data_port_occupied_cycles += data_cycles; 
+        } break; 
     case HIT_RESERVED:
     case MISS: {
-      // the data array is accessed to read out the entire line for write-back
-      // in case of sector cache we need to write bank only the modified sectors
-      cache_event ev(WRITE_BACK_REQUEST_SENT);
-      if (was_writeback_sent(events, ev)) {
-        unsigned data_cycles = ev.m_evicted_block.m_modified_size / port_width;
-        m_data_port_occupied_cycles += data_cycles;
-      }
-    } break;
+        // the data array is accessed to read out the entire line for write-back 
+    	// in case of sector cache we need to write bank only the modified sectors
+    	cache_event ev(WRITE_BACK_REQUEST_SENT);
+        if (was_writeback_sent(events, ev)) {
+            unsigned data_cycles = ev.m_evicted_block.m_modified_size / port_width;
+            m_data_port_occupied_cycles += data_cycles; 
+        }
+        } break; 
     case SECTOR_MISS:
     case RESERVATION_FAIL:
-      // Does not consume any port bandwidth
-      break;
-    default:
-      assert(0);
-      break;
-  }
+        // Does not consume any port bandwidth 
+        break; 
+    default: 
+        assert(0); 
+        break; 
+    } 
 }
 
-/// use the fill port
-void baseline_cache::bandwidth_management::use_fill_port(mem_fetch *mf) {
-  // assume filling the entire line with the returned request
-  unsigned fill_cycles = m_config.get_atom_sz() / m_config.m_data_port_width;
-  m_fill_port_occupied_cycles += fill_cycles;
+/// use the fill port 
+void baseline_cache::bandwidth_management::use_fill_port(mem_fetch *mf)
+{
+    // assume filling the entire line with the returned request 
+    unsigned fill_cycles = m_config.get_atom_sz() / m_config.m_data_port_width;
+    m_fill_port_occupied_cycles += fill_cycles; 
 }
 
-/// called every cache cycle to free up the ports
-void baseline_cache::bandwidth_management::replenish_port_bandwidth() {
-  if (m_data_port_occupied_cycles > 0) {
-    m_data_port_occupied_cycles -= 1;
-  }
-  assert(m_data_port_occupied_cycles >= 0);
+/// called every cache cycle to free up the ports 
+void baseline_cache::bandwidth_management::replenish_port_bandwidth()
+{
+    if (m_data_port_occupied_cycles > 0) {
+        m_data_port_occupied_cycles -= 1; 
+    }
+    assert(m_data_port_occupied_cycles >= 0); 
 
-  if (m_fill_port_occupied_cycles > 0) {
-    m_fill_port_occupied_cycles -= 1;
-  }
-  assert(m_fill_port_occupied_cycles >= 0);
+    if (m_fill_port_occupied_cycles > 0) {
+        m_fill_port_occupied_cycles -= 1; 
+    }
+    assert(m_fill_port_occupied_cycles >= 0); 
 }
 
-/// query for data port availability
-bool baseline_cache::bandwidth_management::data_port_free() const {
-  return (m_data_port_occupied_cycles == 0);
+/// query for data port availability 
+bool baseline_cache::bandwidth_management::data_port_free() const
+{
+    return (m_data_port_occupied_cycles == 0); 
 }
 
-/// query for fill port availability
-bool baseline_cache::bandwidth_management::fill_port_free() const {
-  return (m_fill_port_occupied_cycles == 0);
+/// query for fill port availability 
+bool baseline_cache::bandwidth_management::fill_port_free() const
+{
+    return (m_fill_port_occupied_cycles == 0); 
 }
 
 /// Sends next request to lower level of memory
-void baseline_cache::cycle() {
-  if (!m_miss_queue.empty()) {
-    mem_fetch *mf = m_miss_queue.front();
-    if (!m_memport->full(mf->size(), mf->get_is_write())) {
-      m_miss_queue.pop_front();
-      m_memport->push(mf);
+void baseline_cache::cycle(){
+    if ( !m_miss_queue.empty() ) {
+        mem_fetch *mf = m_miss_queue.front();
+        if ( !m_memport->full(mf->size(),mf->get_is_write()) ) {
+            m_miss_queue.pop_front();
+            m_memport->push(mf);
+        }
     }
-  }
-  bool data_port_busy = !m_bandwidth_management.data_port_free();
-  bool fill_port_busy = !m_bandwidth_management.fill_port_free();
-  m_stats.sample_cache_port_utility(data_port_busy, fill_port_busy);
-  m_bandwidth_management.replenish_port_bandwidth();
+    bool data_port_busy = !m_bandwidth_management.data_port_free(); 
+    bool fill_port_busy = !m_bandwidth_management.fill_port_free(); 
+    m_stats.sample_cache_port_utility(data_port_busy, fill_port_busy); 
+    m_bandwidth_management.replenish_port_bandwidth(); 
 }
 
-/// Interface for response from lower memory level (model bandwidth restictions
-/// in caller)
-void baseline_cache::fill(mem_fetch *mf, unsigned time) {
-  if (m_config.m_mshr_type == SECTOR_ASSOC) {
-    assert(mf->get_original_mf());
-    extra_mf_fields_lookup::iterator e =
-        m_extra_mf_fields.find(mf->get_original_mf());
-    assert(e != m_extra_mf_fields.end());
+/// Interface for response from lower memory level (model bandwidth restictions in caller)
+void baseline_cache::fill(mem_fetch *mf, unsigned time){
+
+	if(m_config.m_mshr_type == SECTOR_ASSOC) {
+	assert(mf->get_original_mf());
+	extra_mf_fields_lookup::iterator e = m_extra_mf_fields.find(mf->get_original_mf());
+    assert( e != m_extra_mf_fields.end() );
     e->second.pending_read--;
 
-    if (e->second.pending_read > 0) {
-      // wait for the other requests to come back
-      delete mf;
-      return;
-    } else {
-      mem_fetch *temp = mf;
-      mf = mf->get_original_mf();
-      delete temp;
-    }
-  }
+    if(e->second.pending_read > 0) {
+    	//wait for the other requests to come back
+    	delete mf;
+    	return;
+      } else {
+    	mem_fetch *temp = mf;
+    	mf = mf->get_original_mf();
+    	delete temp;
+      }
+	}
 
-  extra_mf_fields_lookup::iterator e = m_extra_mf_fields.find(mf);
-  assert(e != m_extra_mf_fields.end());
-  assert(e->second.m_valid);
-  mf->set_data_size(e->second.m_data_size);
-  mf->set_addr(e->second.m_addr);
-  if (m_config.m_alloc_policy == ON_MISS)
-    m_tag_array->fill(e->second.m_cache_index, time, mf);
-  else if (m_config.m_alloc_policy == ON_FILL) {
-    m_tag_array->fill(e->second.m_block_addr, time, mf);
-    if (m_config.is_streaming()) m_tag_array->remove_pending_line(mf);
-  } else
-    abort();
-  bool has_atomic = false;
-  m_mshrs.mark_ready(e->second.m_block_addr, has_atomic);
-  if (has_atomic) {
-    assert(m_config.m_alloc_policy == ON_MISS);
-    cache_block_t *block = m_tag_array->get_block(e->second.m_cache_index);
-    block->set_status(MODIFIED, mf->get_access_sector_mask());  // mark line as
-                                                                // dirty for
-                                                                // atomic
-                                                                // operation
-  }
-  m_extra_mf_fields.erase(mf);
-  m_bandwidth_management.use_fill_port(mf);
+    extra_mf_fields_lookup::iterator e = m_extra_mf_fields.find(mf);
+    assert( e != m_extra_mf_fields.end() );
+    assert( e->second.m_valid );
+    mf->set_data_size( e->second.m_data_size );
+    mf->set_addr( e->second.m_addr );
+    if ( m_config.m_alloc_policy == ON_MISS )
+        m_tag_array->fill(e->second.m_cache_index,time,mf);
+    else if ( m_config.m_alloc_policy == ON_FILL ) {
+        m_tag_array->fill(e->second.m_block_addr,time,mf);
+        if(m_config.is_streaming())
+        	m_tag_array->remove_pending_line(mf);
+    }
+    else abort();
+    bool has_atomic = false;
+    m_mshrs.mark_ready(e->second.m_block_addr, has_atomic);
+    if (has_atomic) {
+        assert(m_config.m_alloc_policy == ON_MISS);
+        cache_block_t* block = m_tag_array->get_block(e->second.m_cache_index);
+        block->set_status(MODIFIED, mf->get_access_sector_mask()); // mark line as dirty for atomic operation
+    }
+    m_extra_mf_fields.erase(mf);
+    m_bandwidth_management.use_fill_port(mf); 
 }
 
 /// Checks if mf is waiting to be filled by lower memory level
-bool baseline_cache::waiting_for_fill(mem_fetch *mf) {
-  extra_mf_fields_lookup::iterator e = m_extra_mf_fields.find(mf);
-  return e != m_extra_mf_fields.end();
+bool baseline_cache::waiting_for_fill( mem_fetch *mf ){
+    extra_mf_fields_lookup::iterator e = m_extra_mf_fields.find(mf);
+    return e != m_extra_mf_fields.end();
 }
 
-void baseline_cache::print(FILE *fp, unsigned &accesses,
-                           unsigned &misses) const {
-  fprintf(fp, "Cache %s:\t", m_name.c_str());
-  m_tag_array->print(fp, accesses, misses);
+void baseline_cache::print(FILE *fp, unsigned &accesses, unsigned &misses) const{
+    fprintf( fp, "Cache %s:\t", m_name.c_str() );
+    m_tag_array->print(fp,accesses,misses);
 }
 
-void baseline_cache::display_state(FILE *fp) const {
-  fprintf(fp, "Cache %s:\n", m_name.c_str());
-  m_mshrs.display(fp);
-  fprintf(fp, "\n");
+void baseline_cache::display_state( FILE *fp ) const{
+    fprintf(fp,"Cache %s:\n", m_name.c_str() );
+    m_mshrs.display(fp);
+    fprintf(fp,"\n");
 }
 
 /// Read miss handler without writeback
-void baseline_cache::send_read_request(new_addr_type addr,
-                                       new_addr_type block_addr,
-                                       unsigned cache_index, mem_fetch *mf,
-                                       unsigned time, bool &do_miss,
-                                       std::list<cache_event> &events,
-                                       bool read_only, bool wa) {
-  bool wb = false;
-  evicted_block_info e;
-  send_read_request(addr, block_addr, cache_index, mf, time, do_miss, wb, e,
-                    events, read_only, wa);
+void baseline_cache::send_read_request(new_addr_type addr, new_addr_type block_addr, unsigned cache_index, mem_fetch *mf,
+		unsigned time, bool &do_miss, std::list<cache_event> &events, bool read_only, bool wa){
+
+	bool wb=false;
+	evicted_block_info e;
+	send_read_request(addr, block_addr, cache_index, mf, time, do_miss, wb, e, events, read_only, wa);
 }
 
 /// Read miss handler. Check MSHR hit or MSHR available
-void baseline_cache::send_read_request(new_addr_type addr,
-                                       new_addr_type block_addr,
-                                       unsigned cache_index, mem_fetch *mf,
-                                       unsigned time, bool &do_miss, bool &wb,
-                                       evicted_block_info &evicted,
-                                       std::list<cache_event> &events,
-                                       bool read_only, bool wa) {
-  new_addr_type mshr_addr = m_config.mshr_addr(mf->get_addr());
-  bool mshr_hit = m_mshrs.probe(mshr_addr);
-  bool mshr_avail = !m_mshrs.full(mshr_addr);
-  if (mshr_hit && mshr_avail) {
-    if (read_only)
-      m_tag_array->access(block_addr, time, cache_index, mf);
-    else
-      m_tag_array->access(block_addr, time, cache_index, wb, evicted, mf);
+void baseline_cache::send_read_request(new_addr_type addr, new_addr_type block_addr, unsigned cache_index, mem_fetch *mf,
+		unsigned time, bool &do_miss, bool &wb, evicted_block_info &evicted, std::list<cache_event> &events, bool read_only, bool wa){
 
-    m_mshrs.add(mshr_addr, mf);
-    do_miss = true;
+	new_addr_type mshr_addr = m_config.mshr_addr(mf->get_addr());
+    bool mshr_hit = m_mshrs.probe(mshr_addr);
+    bool mshr_avail = !m_mshrs.full(mshr_addr);
+    if ( mshr_hit && mshr_avail ) {
+    	if(read_only)
+    		m_tag_array->access(block_addr,time,cache_index,mf);
+    	else
+    		m_tag_array->access(block_addr,time,cache_index,wb,evicted,mf);
 
-  } else if (!mshr_hit && mshr_avail &&
-             (m_miss_queue.size() < m_config.m_miss_queue_size)) {
-    if (read_only)
-      m_tag_array->access(block_addr, time, cache_index, mf);
-    else
-      m_tag_array->access(block_addr, time, cache_index, wb, evicted, mf);
+        m_mshrs.add(mshr_addr,mf);
+        do_miss = true;
 
-    m_mshrs.add(mshr_addr, mf);
-    if (m_config.is_streaming() && m_config.m_cache_type == SECTOR) {
-      m_tag_array->add_pending_line(mf);
+    } else if ( !mshr_hit && mshr_avail && (m_miss_queue.size() < m_config.m_miss_queue_size) ) {
+    	if(read_only)
+    		m_tag_array->access(block_addr,time,cache_index,mf);
+    	else
+    		m_tag_array->access(block_addr,time,cache_index,wb,evicted,mf);
+
+        m_mshrs.add(mshr_addr,mf);
+        if(m_config.is_streaming() && m_config.m_cache_type == SECTOR){
+			m_tag_array->add_pending_line(mf);
+		}
+        m_extra_mf_fields[mf] = extra_mf_fields(mshr_addr,mf->get_addr(),cache_index, mf->get_data_size(), m_config);
+        mf->set_data_size( m_config.get_atom_sz() );
+        mf->set_addr( mshr_addr );
+        m_miss_queue.push_back(mf);
+        mf->set_status(m_miss_queue_status,time);
+        if(!wa)
+        	events.push_back(cache_event(READ_REQUEST_SENT));
+
+        do_miss = true;
     }
-    m_extra_mf_fields[mf] = extra_mf_fields(
-        mshr_addr, mf->get_addr(), cache_index, mf->get_data_size(), m_config);
-    mf->set_data_size(m_config.get_atom_sz());
-    mf->set_addr(mshr_addr);
-    m_miss_queue.push_back(mf);
-    mf->set_status(m_miss_queue_status, time);
-    if (!wa) events.push_back(cache_event(READ_REQUEST_SENT));
-
-    do_miss = true;
-  } else if (mshr_hit && !mshr_avail)
-    m_stats.inc_fail_stats(mf->get_access_type(), MSHR_MERGE_ENRTY_FAIL);
-  else if (!mshr_hit && !mshr_avail)
-    m_stats.inc_fail_stats(mf->get_access_type(), MSHR_ENRTY_FAIL);
-  else
-    assert(0);
+    else if(mshr_hit && !mshr_avail)
+        m_stats.inc_fail_stats(mf->get_access_type(), MSHR_MERGE_ENRTY_FAIL);
+    else if (!mshr_hit && !mshr_avail)
+    	 m_stats.inc_fail_stats(mf->get_access_type(), MSHR_ENRTY_FAIL);
+    else
+    	assert(0);
 }
+
 
 /// Sends write request to lower level memory (write or writeback)
-void data_cache::send_write_request(mem_fetch *mf, cache_event request,
-                                    unsigned time,
-                                    std::list<cache_event> &events) {
-  events.push_back(request);
-  m_miss_queue.push_back(mf);
-  mf->set_status(m_miss_queue_status, time);
+void data_cache::send_write_request(mem_fetch *mf, cache_event request, unsigned time, std::list<cache_event> &events){
+
+	events.push_back(request);
+    m_miss_queue.push_back(mf);
+    mf->set_status(m_miss_queue_status,time);
 }
+
 
 /****** Write-hit functions (Set by config file) ******/
 
 /// Write-back hit: Mark block as modified
-cache_request_status data_cache::wr_hit_wb(new_addr_type addr,
-                                           unsigned cache_index, mem_fetch *mf,
-                                           unsigned time,
-                                           std::list<cache_event> &events,
-                                           enum cache_request_status status) {
-  new_addr_type block_addr = m_config.block_addr(addr);
-  m_tag_array->access(block_addr, time, cache_index, mf);  // update LRU state
-  cache_block_t *block = m_tag_array->get_block(cache_index);
-  block->set_status(MODIFIED, mf->get_access_sector_mask());
+cache_request_status data_cache::wr_hit_wb(new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time, std::list<cache_event> &events, enum cache_request_status status ){
+	new_addr_type block_addr = m_config.block_addr(addr);
+	m_tag_array->access(block_addr,time,cache_index,mf); // update LRU state
+	cache_block_t* block = m_tag_array->get_block(cache_index);
+	block->set_status(MODIFIED, mf->get_access_sector_mask());
 
-  return HIT;
+	return HIT;
 }
 
 /// Write-through hit: Directly send request to lower level memory
-cache_request_status data_cache::wr_hit_wt(new_addr_type addr,
-                                           unsigned cache_index, mem_fetch *mf,
-                                           unsigned time,
-                                           std::list<cache_event> &events,
-                                           enum cache_request_status status) {
-  if (miss_queue_full(0)) {
-    m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
-    return RESERVATION_FAIL;  // cannot handle request this cycle
-  }
+cache_request_status data_cache::wr_hit_wt(new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time, std::list<cache_event> &events, enum cache_request_status status ){
+	if(miss_queue_full(0)) {
+		m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
+		return RESERVATION_FAIL; // cannot handle request this cycle
+	}
 
-  new_addr_type block_addr = m_config.block_addr(addr);
-  m_tag_array->access(block_addr, time, cache_index, mf);  // update LRU state
-  cache_block_t *block = m_tag_array->get_block(cache_index);
-  block->set_status(MODIFIED, mf->get_access_sector_mask());
+	new_addr_type block_addr = m_config.block_addr(addr);
+	m_tag_array->access(block_addr,time,cache_index,mf); // update LRU state
+	cache_block_t* block = m_tag_array->get_block(cache_index);
+	block->set_status(MODIFIED, mf->get_access_sector_mask());
 
-  // generate a write-through
-  send_write_request(mf, cache_event(WRITE_REQUEST_SENT), time, events);
+	// generate a write-through
+	send_write_request(mf, cache_event(WRITE_REQUEST_SENT), time, events);
 
-  return HIT;
+	return HIT;
 }
 
-/// Write-evict hit: Send request to lower level memory and invalidate
-/// corresponding block
-cache_request_status data_cache::wr_hit_we(new_addr_type addr,
-                                           unsigned cache_index, mem_fetch *mf,
-                                           unsigned time,
-                                           std::list<cache_event> &events,
-                                           enum cache_request_status status) {
-  if (miss_queue_full(0)) {
-    m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
-    return RESERVATION_FAIL;  // cannot handle request this cycle
-  }
+/// Write-evict hit: Send request to lower level memory and invalidate corresponding block
+cache_request_status data_cache::wr_hit_we(new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time, std::list<cache_event> &events, enum cache_request_status status ){
+	if(miss_queue_full(0)) {
+		m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
+		return RESERVATION_FAIL; // cannot handle request this cycle
+	}
 
-  // generate a write-through/evict
-  cache_block_t *block = m_tag_array->get_block(cache_index);
-  send_write_request(mf, cache_event(WRITE_REQUEST_SENT), time, events);
+	// generate a write-through/evict
+	cache_block_t* block = m_tag_array->get_block(cache_index);
+	send_write_request(mf, cache_event(WRITE_REQUEST_SENT), time, events);
 
-  // Invalidate block
-  block->set_status(INVALID, mf->get_access_sector_mask());
+	// Invalidate block
+	block->set_status(INVALID, mf->get_access_sector_mask());
 
-  return HIT;
+	return HIT;
 }
 
 /// Global write-evict, local write-back: Useful for private caches
-enum cache_request_status data_cache::wr_hit_global_we_local_wb(
-    new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
-    std::list<cache_event> &events, enum cache_request_status status) {
-  bool evict = (mf->get_access_type() ==
-                GLOBAL_ACC_W);  // evict a line that hits on global memory write
-  if (evict)
-    return wr_hit_we(addr, cache_index, mf, time, events,
-                     status);  // Write-evict
-  else
-    return wr_hit_wb(addr, cache_index, mf, time, events,
-                     status);  // Write-back
+enum cache_request_status data_cache::wr_hit_global_we_local_wb(new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time, std::list<cache_event> &events, enum cache_request_status status ){
+	bool evict = (mf->get_access_type() == GLOBAL_ACC_W); // evict a line that hits on global memory write
+	if(evict)
+		return wr_hit_we(addr, cache_index, mf, time, events, status); // Write-evict
+	else
+		return wr_hit_wb(addr, cache_index, mf, time, events, status); // Write-back
 }
 
 /****** Write-miss functions (Set by config file) ******/
 
 /// Write-allocate miss: Send write request to lower level memory
 // and send a read request for the same block
-enum cache_request_status data_cache::wr_miss_wa_naive(
-    new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
-    std::list<cache_event> &events, enum cache_request_status status) {
-  new_addr_type block_addr = m_config.block_addr(addr);
-  new_addr_type mshr_addr = m_config.mshr_addr(mf->get_addr());
+enum cache_request_status
+data_cache::wr_miss_wa_naive( new_addr_type addr,
+                        unsigned cache_index, mem_fetch *mf,
+                        unsigned time, std::list<cache_event> &events,
+                        enum cache_request_status status )
+{
+    new_addr_type block_addr = m_config.block_addr(addr);
+    new_addr_type mshr_addr = m_config.mshr_addr(mf->get_addr());
 
-  // Write allocate, maximum 3 requests (write miss, read request, write back
-  // request)
-  // Conservatively ensure the worst-case request can be handled this cycle
-  bool mshr_hit = m_mshrs.probe(mshr_addr);
-  bool mshr_avail = !m_mshrs.full(mshr_addr);
-  if (miss_queue_full(2) ||
-      (!(mshr_hit && mshr_avail) &&
-       !(!mshr_hit && mshr_avail &&
-         (m_miss_queue.size() < m_config.m_miss_queue_size)))) {
-    // check what is the exactly the failure reason
-    if (miss_queue_full(2))
-      m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
-    else if (mshr_hit && !mshr_avail)
-      m_stats.inc_fail_stats(mf->get_access_type(), MSHR_MERGE_ENRTY_FAIL);
-    else if (!mshr_hit && !mshr_avail)
-      m_stats.inc_fail_stats(mf->get_access_type(), MSHR_ENRTY_FAIL);
-    else
-      assert(0);
-
-    return RESERVATION_FAIL;
-  }
-
-  send_write_request(mf, cache_event(WRITE_REQUEST_SENT), time, events);
-  // Tries to send write allocate request, returns true on success and false on
-  // failure
-  // if(!send_write_allocate(mf, addr, block_addr, cache_index, time, events))
-  //    return RESERVATION_FAIL;
-
-  const mem_access_t *ma =
-      new mem_access_t(m_wr_alloc_type, mf->get_addr(), m_config.get_atom_sz(),
-                       false,  // Now performing a read
-                       mf->get_access_warp_mask(), mf->get_access_byte_mask(),
-                       mf->get_access_sector_mask(), m_gpu->gpgpu_ctx);
-
-  mem_fetch *n_mf =
-      new mem_fetch(*ma, NULL, mf->get_ctrl_size(), mf->get_wid(),
-                    mf->get_sid(), mf->get_tpc(), mf->get_mem_config(),
-                    m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle);
-
-  bool do_miss = false;
-  bool wb = false;
-  evicted_block_info evicted;
-
-  // Send read request resulting from write miss
-  send_read_request(addr, block_addr, cache_index, n_mf, time, do_miss, wb,
-                    evicted, events, false, true);
-
-  events.push_back(cache_event(WRITE_ALLOCATE_SENT));
-
-  if (do_miss) {
-    // If evicted block is modified and not a write-through
-    // (already modified lower level)
-    if (wb && (m_config.m_write_policy != WRITE_THROUGH)) {
-      assert(status ==
-             MISS);  // SECTOR_MISS and HIT_RESERVED should not send write back
-      mem_fetch *wb = m_memfetch_creator->alloc(
-          evicted.m_block_addr, m_wrbk_type, evicted.m_modified_size, true,
-          m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle);
-      send_write_request(wb, cache_event(WRITE_BACK_REQUEST_SENT, evicted),
-                         time, events);
-    }
-    return MISS;
-  }
-
-  return RESERVATION_FAIL;
-}
-
-enum cache_request_status data_cache::wr_miss_wa_fetch_on_write(
-    new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
-    std::list<cache_event> &events, enum cache_request_status status) {
-  new_addr_type block_addr = m_config.block_addr(addr);
-  new_addr_type mshr_addr = m_config.mshr_addr(mf->get_addr());
-
-  if (mf->get_access_byte_mask().count() == m_config.get_atom_sz()) {
-    // if the request writes to the whole cache line/sector, then, write and set
-    // cache line Modified.
-    // and no need to send read request to memory or reserve mshr
-
-    if (miss_queue_full(0)) {
-      m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
-      return RESERVATION_FAIL;  // cannot handle request this cycle
-    }
-
-    bool wb = false;
-    evicted_block_info evicted;
-
-    cache_request_status status =
-        m_tag_array->access(block_addr, time, cache_index, wb, evicted, mf);
-    assert(status != HIT);
-    cache_block_t *block = m_tag_array->get_block(cache_index);
-    block->set_status(MODIFIED, mf->get_access_sector_mask());
-    if (status == HIT_RESERVED)
-      block->set_ignore_on_fill(true, mf->get_access_sector_mask());
-
-    if (status != RESERVATION_FAIL) {
-      // If evicted block is modified and not a write-through
-      // (already modified lower level)
-      if (wb && (m_config.m_write_policy != WRITE_THROUGH)) {
-        mem_fetch *wb = m_memfetch_creator->alloc(
-            evicted.m_block_addr, m_wrbk_type, evicted.m_modified_size, true,
-            m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle);
-        send_write_request(wb, cache_event(WRITE_BACK_REQUEST_SENT, evicted),
-                           time, events);
-      }
-      return MISS;
-    }
-    return RESERVATION_FAIL;
-  } else {
+    // Write allocate, maximum 3 requests (write miss, read request, write back request)
+    // Conservatively ensure the worst-case request can be handled this cycle
     bool mshr_hit = m_mshrs.probe(mshr_addr);
     bool mshr_avail = !m_mshrs.full(mshr_addr);
-    if (miss_queue_full(1) ||
-        (!(mshr_hit && mshr_avail) &&
-         !(!mshr_hit && mshr_avail &&
-           (m_miss_queue.size() < m_config.m_miss_queue_size)))) {
-      // check what is the exactly the failure reason
-      if (miss_queue_full(1))
-        m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
-      else if (mshr_hit && !mshr_avail)
-        m_stats.inc_fail_stats(mf->get_access_type(), MSHR_MERGE_ENRTY_FAIL);
-      else if (!mshr_hit && !mshr_avail)
-        m_stats.inc_fail_stats(mf->get_access_type(), MSHR_ENRTY_FAIL);
-      else
-        assert(0);
+    if(miss_queue_full(2) 
+        || (!(mshr_hit && mshr_avail) 
+        && !(!mshr_hit && mshr_avail && (m_miss_queue.size() < m_config.m_miss_queue_size)))) {
+    	//check what is the exactly the failure reason
+    	 if(miss_queue_full(2) )
+    		 m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
+         else if(mshr_hit && !mshr_avail)
+    	      m_stats.inc_fail_stats(mf->get_access_type(), MSHR_MERGE_ENRTY_FAIL);
+    	 else if (!mshr_hit && !mshr_avail)
+    	    m_stats.inc_fail_stats(mf->get_access_type(), MSHR_ENRTY_FAIL);
+    	 else
+    		 assert(0);
 
-      return RESERVATION_FAIL;
+        return RESERVATION_FAIL;
     }
 
-    // prevent Write - Read - Write in pending mshr
-    // allowing another write will override the value of the first write, and
-    // the pending read request will read incorrect result from the second write
-    if (m_mshrs.probe(mshr_addr) &&
-        m_mshrs.is_read_after_write_pending(mshr_addr) && mf->is_write()) {
-      // assert(0);
-      m_stats.inc_fail_stats(mf->get_access_type(), MSHR_RW_PENDING);
-      return RESERVATION_FAIL;
-    }
+    send_write_request(mf, cache_event(WRITE_REQUEST_SENT), time, events);
+    // Tries to send write allocate request, returns true on success and false on failure
+    //if(!send_write_allocate(mf, addr, block_addr, cache_index, time, events))
+    //    return RESERVATION_FAIL;
 
-    const mem_access_t *ma = new mem_access_t(
-        m_wr_alloc_type, mf->get_addr(), m_config.get_atom_sz(),
-        false,  // Now performing a read
-        mf->get_access_warp_mask(), mf->get_access_byte_mask(),
-        mf->get_access_sector_mask(), m_gpu->gpgpu_ctx);
+    const mem_access_t *ma = new  mem_access_t( m_wr_alloc_type,
+                        mf->get_addr(),
+						m_config.get_atom_sz(),
+                        false, // Now performing a read
+                        mf->get_access_warp_mask(),
+                        mf->get_access_byte_mask(),
+		                mf->get_access_sector_mask(),
+				m_gpu->gpgpu_ctx);
 
-    mem_fetch *n_mf = new mem_fetch(
-        *ma, NULL, mf->get_ctrl_size(), mf->get_wid(), mf->get_sid(),
-        mf->get_tpc(), mf->get_mem_config(),
-        m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle, NULL, mf);
+    mem_fetch *n_mf = new mem_fetch( *ma,
+                    NULL,
+                    mf->get_ctrl_size(),
+                    mf->get_wid(),
+                    mf->get_sid(),
+                    mf->get_tpc(),
+                    mf->get_mem_config(),
+					m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle);
 
-    new_addr_type block_addr = m_config.block_addr(addr);
     bool do_miss = false;
     bool wb = false;
     evicted_block_info evicted;
-    send_read_request(addr, block_addr, cache_index, n_mf, time, do_miss, wb,
-                      evicted, events, false, true);
 
-    cache_block_t *block = m_tag_array->get_block(cache_index);
-    block->set_modified_on_fill(true, mf->get_access_sector_mask());
+    // Send read request resulting from write miss
+    send_read_request(addr, block_addr, cache_index, n_mf, time, do_miss, wb,
+        evicted, events, false, true);
 
     events.push_back(cache_event(WRITE_ALLOCATE_SENT));
 
-    if (do_miss) {
-      // If evicted block is modified and not a write-through
-      // (already modified lower level)
-      if (wb && (m_config.m_write_policy != WRITE_THROUGH)) {
-        mem_fetch *wb = m_memfetch_creator->alloc(
-            evicted.m_block_addr, m_wrbk_type, evicted.m_modified_size, true,
-            m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle);
-        send_write_request(wb, cache_event(WRITE_BACK_REQUEST_SENT, evicted),
-                           time, events);
-      }
-      return MISS;
+    if( do_miss ){
+        // If evicted block is modified and not a write-through
+        // (already modified lower level)
+        if( wb && (m_config.m_write_policy != WRITE_THROUGH) ) { 
+        	assert(status == MISS);   //SECTOR_MISS and HIT_RESERVED should not send write back
+            mem_fetch *wb = m_memfetch_creator->alloc(evicted.m_block_addr,
+                m_wrbk_type,evicted.m_modified_size,true,m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle);
+            send_write_request(wb, cache_event(WRITE_BACK_REQUEST_SENT, evicted), time, events);
+        }
+        return MISS;
     }
+
     return RESERVATION_FAIL;
-  }
 }
 
-enum cache_request_status data_cache::wr_miss_wa_lazy_fetch_on_read(
-    new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
-    std::list<cache_event> &events, enum cache_request_status status) {
-  new_addr_type block_addr = m_config.block_addr(addr);
 
-  // if the request writes to the whole cache line/sector, then, write and set
-  // cache line Modified.
-  // and no need to send read request to memory or reserve mshr
+enum cache_request_status
+data_cache::wr_miss_wa_fetch_on_write( new_addr_type addr,
+                        unsigned cache_index, mem_fetch *mf,
+                        unsigned time, std::list<cache_event> &events,
+                        enum cache_request_status status )
+{
+    new_addr_type block_addr = m_config.block_addr(addr);
+    new_addr_type mshr_addr = m_config.mshr_addr(mf->get_addr());
 
-  if (miss_queue_full(0)) {
-    m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
-    return RESERVATION_FAIL;  // cannot handle request this cycle
-  }
+	if(mf->get_access_byte_mask().count() == m_config.get_atom_sz())
+	{
+		//if the request writes to the whole cache line/sector, then, write and set cache line Modified.
+		//and no need to send read request to memory or reserve mshr
 
-  bool wb = false;
-  evicted_block_info evicted;
+		if(miss_queue_full(0)) {
+			m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
+			return RESERVATION_FAIL; // cannot handle request this cycle
+		}
 
-  cache_request_status m_status =
-      m_tag_array->access(block_addr, time, cache_index, wb, evicted, mf);
-  assert(m_status != HIT);
-  cache_block_t *block = m_tag_array->get_block(cache_index);
-  block->set_status(MODIFIED, mf->get_access_sector_mask());
-  if (m_status == HIT_RESERVED) {
-    block->set_ignore_on_fill(true, mf->get_access_sector_mask());
-    block->set_modified_on_fill(true, mf->get_access_sector_mask());
-  }
+		bool wb = false;
+		evicted_block_info evicted;
 
-  if (mf->get_access_byte_mask().count() == m_config.get_atom_sz()) {
-    block->set_m_readable(true, mf->get_access_sector_mask());
-  } else {
-    block->set_m_readable(false, mf->get_access_sector_mask());
-  }
+		cache_request_status status =  m_tag_array->access(block_addr,time,cache_index,wb,evicted,mf);
+		assert(status != HIT);
+		cache_block_t* block = m_tag_array->get_block(cache_index);
+		block->set_status(MODIFIED, mf->get_access_sector_mask());
+		if(status == HIT_RESERVED)
+			block->set_ignore_on_fill(true, mf->get_access_sector_mask());
 
-  if (m_status != RESERVATION_FAIL) {
-    // If evicted block is modified and not a write-through
-    // (already modified lower level)
-    if (wb && (m_config.m_write_policy != WRITE_THROUGH)) {
-      mem_fetch *wb = m_memfetch_creator->alloc(
-          evicted.m_block_addr, m_wrbk_type, evicted.m_modified_size, true,
-          m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle);
-      send_write_request(wb, cache_event(WRITE_BACK_REQUEST_SENT, evicted),
-                         time, events);
-    }
-    return MISS;
-  }
-  return RESERVATION_FAIL;
+		if( status != RESERVATION_FAIL ){
+			   // If evicted block is modified and not a write-through
+			   // (already modified lower level)
+			   if( wb && (m_config.m_write_policy != WRITE_THROUGH) ) {
+				   mem_fetch *wb = m_memfetch_creator->alloc(evicted.m_block_addr,
+					   m_wrbk_type,evicted.m_modified_size,true,m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle);
+				   send_write_request(wb, cache_event(WRITE_BACK_REQUEST_SENT, evicted), time, events);
+			   }
+			   return MISS;
+		   }
+		return RESERVATION_FAIL;
+	}
+	else
+	{
+		bool mshr_hit = m_mshrs.probe(mshr_addr);
+		bool mshr_avail = !m_mshrs.full(mshr_addr);
+		if(miss_queue_full(1)
+			|| (!(mshr_hit && mshr_avail)
+			&& !(!mshr_hit && mshr_avail && (m_miss_queue.size() < m_config.m_miss_queue_size)))) {
+			//check what is the exactly the failure reason
+			 if(miss_queue_full(1) )
+				 m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
+			 else if(mshr_hit && !mshr_avail)
+				  m_stats.inc_fail_stats(mf->get_access_type(), MSHR_MERGE_ENRTY_FAIL);
+			 else if (!mshr_hit && !mshr_avail)
+				m_stats.inc_fail_stats(mf->get_access_type(), MSHR_ENRTY_FAIL);
+			 else
+				 assert(0);
+
+			return RESERVATION_FAIL;
+		}
+
+
+		  //prevent Write - Read - Write in pending mshr
+		  //allowing another write will override the value of the first write, and the pending read request will read incorrect result from the second write
+		  if(m_mshrs.probe(mshr_addr) && m_mshrs.is_read_after_write_pending(mshr_addr) && mf->is_write())
+		  {
+			  //assert(0);
+			  m_stats.inc_fail_stats(mf->get_access_type(), MSHR_RW_PENDING);
+			  return RESERVATION_FAIL;
+		  }
+
+		  const mem_access_t *ma = new  mem_access_t( m_wr_alloc_type,
+									mf->get_addr(),
+									m_config.get_atom_sz(),
+									false, // Now performing a read
+									mf->get_access_warp_mask(),
+									mf->get_access_byte_mask(),
+									mf->get_access_sector_mask(),
+									m_gpu->gpgpu_ctx);
+
+		  mem_fetch *n_mf = new mem_fetch( *ma,
+								NULL,
+								mf->get_ctrl_size(),
+								mf->get_wid(),
+								mf->get_sid(),
+								mf->get_tpc(),
+								mf->get_mem_config(),
+								m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle,
+								NULL,
+								mf);
+
+
+			new_addr_type block_addr = m_config.block_addr(addr);
+			bool do_miss = false;
+			bool wb = false;
+			evicted_block_info evicted;
+			send_read_request( addr,
+							   block_addr,
+							   cache_index,
+							   n_mf, time, do_miss, wb, evicted, events, false, true);
+
+			cache_block_t* block = m_tag_array->get_block(cache_index);
+			block->set_modified_on_fill(true, mf->get_access_sector_mask());
+
+			events.push_back(cache_event(WRITE_ALLOCATE_SENT));
+
+			if( do_miss ){
+				// If evicted block is modified and not a write-through
+				// (already modified lower level)
+				if(wb && (m_config.m_write_policy != WRITE_THROUGH) ){
+					mem_fetch *wb = m_memfetch_creator->alloc(evicted.m_block_addr,
+						m_wrbk_type,evicted.m_modified_size,true,m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle);
+					send_write_request(wb, cache_event(WRITE_BACK_REQUEST_SENT, evicted), time, events);
+			}
+				return MISS;
+			}
+	   return RESERVATION_FAIL;
+	}
+}
+
+enum cache_request_status
+data_cache::wr_miss_wa_lazy_fetch_on_read( new_addr_type addr,
+                        unsigned cache_index, mem_fetch *mf,
+                        unsigned time, std::list<cache_event> &events,
+                        enum cache_request_status status )
+{
+
+	    new_addr_type block_addr = m_config.block_addr(addr);
+
+		//if the request writes to the whole cache line/sector, then, write and set cache line Modified.
+		//and no need to send read request to memory or reserve mshr
+
+		if(miss_queue_full(0)) {
+			m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
+			return RESERVATION_FAIL; // cannot handle request this cycle
+		}
+
+		bool wb = false;
+		evicted_block_info evicted;
+
+		cache_request_status m_status =  m_tag_array->access(block_addr,time,cache_index,wb,evicted,mf);
+		assert(m_status != HIT);
+		cache_block_t* block = m_tag_array->get_block(cache_index);
+		block->set_status(MODIFIED, mf->get_access_sector_mask());
+		if(m_status == HIT_RESERVED) {
+			block->set_ignore_on_fill(true, mf->get_access_sector_mask());
+			block->set_modified_on_fill(true, mf->get_access_sector_mask());
+		}
+
+		if(mf->get_access_byte_mask().count() == m_config.get_atom_sz())
+		{
+			block->set_m_readable(true, mf->get_access_sector_mask());
+		} else
+		{
+			block->set_m_readable(false, mf->get_access_sector_mask());
+		}
+
+		if( m_status != RESERVATION_FAIL ){
+			   // If evicted block is modified and not a write-through
+			   // (already modified lower level)
+			   if( wb && (m_config.m_write_policy != WRITE_THROUGH) ) {
+				   mem_fetch *wb = m_memfetch_creator->alloc(evicted.m_block_addr,
+					   m_wrbk_type,evicted.m_modified_size,true,m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle);
+				   send_write_request(wb, cache_event(WRITE_BACK_REQUEST_SENT, evicted), time, events);
+			   }
+			   return MISS;
+		   }
+		return RESERVATION_FAIL;
 }
 
 /// No write-allocate miss: Simply send write request to lower level memory
-enum cache_request_status data_cache::wr_miss_no_wa(
-    new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
-    std::list<cache_event> &events, enum cache_request_status status) {
-  if (miss_queue_full(0)) {
-    m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
-    return RESERVATION_FAIL;  // cannot handle request this cycle
-  }
+enum cache_request_status
+data_cache::wr_miss_no_wa( new_addr_type addr,
+                           unsigned cache_index,
+                           mem_fetch *mf,
+                           unsigned time,
+                           std::list<cache_event> &events,
+                           enum cache_request_status status )
+{
+    if(miss_queue_full(0)) {
+    	m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
+    	return RESERVATION_FAIL; // cannot handle request this cycle
+    }
 
-  // on miss, generate write through (no write buffering -- too many threads for
-  // that)
-  send_write_request(mf, cache_event(WRITE_REQUEST_SENT), time, events);
 
-  return MISS;
+    // on miss, generate write through (no write buffering -- too many threads for that)
+    send_write_request(mf, cache_event(WRITE_REQUEST_SENT), time, events);
+
+    return MISS;
 }
 
 /****** Read hit functions (Set by config file) ******/
 
 /// Baseline read hit: Update LRU status of block.
 // Special case for atomic instructions -> Mark block as modified
-enum cache_request_status data_cache::rd_hit_base(
-    new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
-    std::list<cache_event> &events, enum cache_request_status status) {
-  new_addr_type block_addr = m_config.block_addr(addr);
-  m_tag_array->access(block_addr, time, cache_index, mf);
-  // Atomics treated as global read/write requests - Perform read, mark line as
-  // MODIFIED
-  if (mf->isatomic()) {
-    assert(mf->get_access_type() == GLOBAL_ACC_R);
-    cache_block_t *block = m_tag_array->get_block(cache_index);
-    block->set_status(MODIFIED,
-                      mf->get_access_sector_mask());  // mark line as dirty
-  }
-  return HIT;
+enum cache_request_status
+data_cache::rd_hit_base( new_addr_type addr,
+                         unsigned cache_index,
+                         mem_fetch *mf,
+                         unsigned time,
+                         std::list<cache_event> &events,
+                         enum cache_request_status status )
+{
+    new_addr_type block_addr = m_config.block_addr(addr);
+    m_tag_array->access(block_addr,time,cache_index,mf);
+    // Atomics treated as global read/write requests - Perform read, mark line as
+    // MODIFIED
+    if(mf->isatomic()){ 
+        assert(mf->get_access_type() == GLOBAL_ACC_R);
+        cache_block_t* block = m_tag_array->get_block(cache_index);
+        block->set_status(MODIFIED, mf->get_access_sector_mask()) ;  // mark line as dirty
+    }
+    return HIT;
 }
 
 /****** Read miss functions (Set by config file) ******/
 
 /// Baseline read miss: Send read request to lower level memory,
 // perform write-back as necessary
-enum cache_request_status data_cache::rd_miss_base(
-    new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
-    std::list<cache_event> &events, enum cache_request_status status) {
-  if (miss_queue_full(1)) {
-    // cannot handle request this cycle
-    // (might need to generate two requests)
-    m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
-    return RESERVATION_FAIL;
-  }
-
-  new_addr_type block_addr = m_config.block_addr(addr);
-  bool do_miss = false;
-  bool wb = false;
-  evicted_block_info evicted;
-  send_read_request(addr, block_addr, cache_index, mf, time, do_miss, wb,
-                    evicted, events, false, false);
-
-  if (do_miss) {
-    // If evicted block is modified and not a write-through
-    // (already modified lower level)
-    if (wb && (m_config.m_write_policy != WRITE_THROUGH)) {
-      mem_fetch *wb = m_memfetch_creator->alloc(
-          evicted.m_block_addr, m_wrbk_type, evicted.m_modified_size, true,
-          m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle);
-      send_write_request(wb, WRITE_BACK_REQUEST_SENT, time, events);
+enum cache_request_status
+data_cache::rd_miss_base( new_addr_type addr,
+                          unsigned cache_index,
+                          mem_fetch *mf,
+                          unsigned time,
+                          std::list<cache_event> &events,
+                          enum cache_request_status status ){
+    if(miss_queue_full(1)) {
+        // cannot handle request this cycle
+        // (might need to generate two requests)
+    	m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
+        return RESERVATION_FAIL; 
     }
-    return MISS;
-  }
-  return RESERVATION_FAIL;
+
+    new_addr_type block_addr = m_config.block_addr(addr);
+    bool do_miss = false;
+    bool wb = false;
+    evicted_block_info evicted;
+    send_read_request( addr,
+                       block_addr,
+                       cache_index,
+                       mf, time, do_miss, wb, evicted, events, false, false);
+
+    if( do_miss ){
+        // If evicted block is modified and not a write-through
+        // (already modified lower level)
+        if(wb && (m_config.m_write_policy != WRITE_THROUGH) ){ 
+            mem_fetch *wb = m_memfetch_creator->alloc(evicted.m_block_addr,
+                m_wrbk_type,evicted.m_modified_size,true,m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle);
+        send_write_request(wb, WRITE_BACK_REQUEST_SENT, time, events);
+    }
+        return MISS;
+    }
+        return RESERVATION_FAIL;
 }
 
 /// Access cache for read_only_cache: returns RESERVATION_FAIL if
 // request could not be accepted (for any reason)
-enum cache_request_status read_only_cache::access(
-    new_addr_type addr, mem_fetch *mf, unsigned time,
-    std::list<cache_event> &events) {
-  assert(mf->get_data_size() <= m_config.get_atom_sz());
-  assert(m_config.m_write_policy == READ_ONLY);
-  assert(!mf->get_is_write());
-  new_addr_type block_addr = m_config.block_addr(addr);
-  unsigned cache_index = (unsigned)-1;
-  enum cache_request_status status =
-      m_tag_array->probe(block_addr, cache_index, mf);
-  enum cache_request_status cache_status = RESERVATION_FAIL;
+enum cache_request_status
+read_only_cache::access( new_addr_type addr,
+                         mem_fetch *mf,
+                         unsigned time,
+                         std::list<cache_event> &events )
+{
+    assert( mf->get_data_size() <= m_config.get_atom_sz());
+    assert(m_config.m_write_policy == READ_ONLY);
+    assert(!mf->get_is_write());
+    new_addr_type block_addr = m_config.block_addr(addr);
+    unsigned cache_index = (unsigned)-1;
+    enum cache_request_status status = m_tag_array->probe(block_addr,cache_index,mf);
+    enum cache_request_status cache_status = RESERVATION_FAIL;
 
-  if (status == HIT) {
-    cache_status = m_tag_array->access(block_addr, time, cache_index,
-                                       mf);  // update LRU state
-  } else if (status != RESERVATION_FAIL) {
-    if (!miss_queue_full(0)) {
-      bool do_miss = false;
-      send_read_request(addr, block_addr, cache_index, mf, time, do_miss,
-                        events, true, false);
-      if (do_miss)
-        cache_status = MISS;
-      else
-        cache_status = RESERVATION_FAIL;
-    } else {
-      cache_status = RESERVATION_FAIL;
-      m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
+    if ( status == HIT ) {
+        cache_status = m_tag_array->access(block_addr,time,cache_index,mf); // update LRU state
+    }else if ( status != RESERVATION_FAIL ) {
+        if(!miss_queue_full(0)){
+            bool do_miss=false;
+            send_read_request(addr, block_addr, cache_index, mf, time, do_miss, events, true, false);
+            if(do_miss)
+                cache_status = MISS;
+            else
+                cache_status = RESERVATION_FAIL;
+        }else{
+            cache_status = RESERVATION_FAIL;
+            m_stats.inc_fail_stats(mf->get_access_type(), MISS_QUEUE_FULL);
+        }
+    }else {
+    	m_stats.inc_fail_stats(mf->get_access_type(), LINE_ALLOC_FAIL);
     }
-  } else {
-    m_stats.inc_fail_stats(mf->get_access_type(), LINE_ALLOC_FAIL);
-  }
 
-  m_stats.inc_stats(mf->get_access_type(),
-                    m_stats.select_stats_status(status, cache_status));
-  m_stats.inc_stats_pw(mf->get_access_type(),
-                       m_stats.select_stats_status(status, cache_status));
-  return cache_status;
+    m_stats.inc_stats(mf->get_access_type(), m_stats.select_stats_status(status, cache_status));
+    m_stats.inc_stats_pw(mf->get_access_type(), m_stats.select_stats_status(status, cache_status));
+    return cache_status;
 }
 
 //! A general function that takes the result of a tag_array probe
 //  and performs the correspding functions based on the cache configuration
 //  The access fucntion calls this function
-enum cache_request_status data_cache::process_tag_probe(
-    bool wr, enum cache_request_status probe_status, new_addr_type addr,
-    unsigned cache_index, mem_fetch *mf, unsigned time,
-    std::list<cache_event> &events) {
-  // Each function pointer ( m_[rd/wr]_[hit/miss] ) is set in the
-  // data_cache constructor to reflect the corresponding cache configuration
-  // options. Function pointers were used to avoid many long conditional
-  // branches resulting from many cache configuration options.
-  cache_request_status access_status = probe_status;
-  if (wr) {  // Write
-    if (probe_status == HIT) {
-      access_status =
-          (this->*m_wr_hit)(addr, cache_index, mf, time, events, probe_status);
-    } else if ((probe_status != RESERVATION_FAIL) ||
-               (probe_status == RESERVATION_FAIL &&
-                m_config.m_write_alloc_policy == NO_WRITE_ALLOCATE)) {
-      access_status =
-          (this->*m_wr_miss)(addr, cache_index, mf, time, events, probe_status);
-    } else {
-      // the only reason for reservation fail here is LINE_ALLOC_FAIL (i.e all
-      // lines are reserved)
-      m_stats.inc_fail_stats(mf->get_access_type(), LINE_ALLOC_FAIL);
+enum cache_request_status
+data_cache::process_tag_probe( bool wr,
+                               enum cache_request_status probe_status,
+                               new_addr_type addr,
+                               unsigned cache_index,
+                               mem_fetch* mf,
+                               unsigned time,
+                               std::list<cache_event>& events )
+{
+    // Each function pointer ( m_[rd/wr]_[hit/miss] ) is set in the
+    // data_cache constructor to reflect the corresponding cache configuration
+    // options. Function pointers were used to avoid many long conditional
+    // branches resulting from many cache configuration options.
+    cache_request_status access_status = probe_status;
+    if(wr){ // Write
+        if(probe_status == HIT){
+            access_status = (this->*m_wr_hit)( addr,
+                                      cache_index,
+                                      mf, time, events, probe_status );
+        }else if ( (probe_status != RESERVATION_FAIL) || (probe_status == RESERVATION_FAIL && m_config.m_write_alloc_policy == NO_WRITE_ALLOCATE) ) {
+            access_status = (this->*m_wr_miss)( addr,
+                                       cache_index,
+                                       mf, time, events, probe_status );
+        }else {
+        	//the only reason for reservation fail here is LINE_ALLOC_FAIL (i.e all lines are reserved)
+        	m_stats.inc_fail_stats(mf->get_access_type(), LINE_ALLOC_FAIL);
+        }
+    }else{ // Read
+        if(probe_status == HIT){
+            access_status = (this->*m_rd_hit)( addr,
+                                      cache_index,
+                                      mf, time, events, probe_status );
+        }else if ( probe_status != RESERVATION_FAIL ) {
+            access_status = (this->*m_rd_miss)( addr,
+                                       cache_index,
+                                       mf, time, events, probe_status );
+        }else {
+        	//the only reason for reservation fail here is LINE_ALLOC_FAIL (i.e all lines are reserved)
+        	m_stats.inc_fail_stats(mf->get_access_type(), LINE_ALLOC_FAIL);
+        }
     }
-  } else {  // Read
-    if (probe_status == HIT) {
-      access_status =
-          (this->*m_rd_hit)(addr, cache_index, mf, time, events, probe_status);
-    } else if (probe_status != RESERVATION_FAIL) {
-      access_status =
-          (this->*m_rd_miss)(addr, cache_index, mf, time, events, probe_status);
-    } else {
-      // the only reason for reservation fail here is LINE_ALLOC_FAIL (i.e all
-      // lines are reserved)
-      m_stats.inc_fail_stats(mf->get_access_type(), LINE_ALLOC_FAIL);
-    }
-  }
 
-  m_bandwidth_management.use_data_port(mf, access_status, events);
-  return access_status;
+    m_bandwidth_management.use_data_port(mf, access_status, events); 
+    return access_status;
 }
 
 // Both the L1 and L2 currently use the same access function.
@@ -1650,41 +1645,51 @@ enum cache_request_status data_cache::process_tag_probe(
 // of caching policies.
 // Both the L1 and L2 override this function to provide a means of
 // performing actions specific to each cache when such actions are implemnted.
-enum cache_request_status data_cache::access(new_addr_type addr, mem_fetch *mf,
-                                             unsigned time,
-                                             std::list<cache_event> &events) {
-  assert(mf->get_data_size() <= m_config.get_atom_sz());
-  bool wr = mf->get_is_write();
-  new_addr_type block_addr = m_config.block_addr(addr);
-  unsigned cache_index = (unsigned)-1;
-  enum cache_request_status probe_status =
-      m_tag_array->probe(block_addr, cache_index, mf, true);
-  enum cache_request_status access_status =
-      process_tag_probe(wr, probe_status, addr, cache_index, mf, time, events);
-  m_stats.inc_stats(mf->get_access_type(),
-                    m_stats.select_stats_status(probe_status, access_status));
-  m_stats.inc_stats_pw(mf->get_access_type(), m_stats.select_stats_status(
-                                                  probe_status, access_status));
-  return access_status;
+enum cache_request_status
+data_cache::access( new_addr_type addr,
+                    mem_fetch *mf,
+                    unsigned time,
+                    std::list<cache_event> &events )
+{
+
+    assert( mf->get_data_size() <= m_config.get_atom_sz());
+    bool wr = mf->get_is_write();
+    new_addr_type block_addr = m_config.block_addr(addr);
+    unsigned cache_index = (unsigned)-1;
+    enum cache_request_status probe_status
+        = m_tag_array->probe( block_addr, cache_index, mf, true);
+    enum cache_request_status access_status
+        = process_tag_probe( wr, probe_status, addr, cache_index, mf, time, events );
+    m_stats.inc_stats(mf->get_access_type(),
+        m_stats.select_stats_status(probe_status, access_status));
+    m_stats.inc_stats_pw(mf->get_access_type(),
+        m_stats.select_stats_status(probe_status, access_status));
+    return access_status;
 }
 
 /// This is meant to model the first level data cache in Fermi.
 /// It is write-evict (global) or write-back (local) at the
 /// granularity of individual blocks (Set by GPGPU-Sim configuration file)
 /// (the policy used in fermi according to the CUDA manual)
-enum cache_request_status l1_cache::access(new_addr_type addr, mem_fetch *mf,
-                                           unsigned time,
-                                           std::list<cache_event> &events) {
-  return data_cache::access(addr, mf, time, events);
+enum cache_request_status
+l1_cache::access( new_addr_type addr,
+                  mem_fetch *mf,
+                  unsigned time,
+                  std::list<cache_event> &events )
+{
+    return data_cache::access( addr, mf, time, events );
 }
 
 // The l2 cache access function calls the base data_cache access
 // implementation.  When the L2 needs to diverge from L1, L2 specific
 // changes should be made here.
-enum cache_request_status l2_cache::access(new_addr_type addr, mem_fetch *mf,
-                                           unsigned time,
-                                           std::list<cache_event> &events) {
-  return data_cache::access(addr, mf, time, events);
+enum cache_request_status
+l2_cache::access( new_addr_type addr,
+                  mem_fetch *mf,
+                  unsigned time,
+                  std::list<cache_event> &events )
+{
+    return data_cache::access( addr, mf, time, events );
 }
 
 /// Access function for tex_cache
@@ -1692,144 +1697,141 @@ enum cache_request_status l2_cache::access(new_addr_type addr, mem_fetch *mf,
 /// otherwise returns HIT_RESERVED or MISS; NOTE: *never* returns HIT
 /// since unlike a normal CPU cache, a "HIT" in texture cache does not
 /// mean the data is ready (still need to get through fragment fifo)
-enum cache_request_status tex_cache::access(new_addr_type addr, mem_fetch *mf,
-                                            unsigned time,
-                                            std::list<cache_event> &events) {
-  if (m_fragment_fifo.full() || m_request_fifo.full() || m_rob.full())
-    return RESERVATION_FAIL;
+enum cache_request_status tex_cache::access( new_addr_type addr, mem_fetch *mf,
+    unsigned time, std::list<cache_event> &events )
+{
+    if ( m_fragment_fifo.full() || m_request_fifo.full() || m_rob.full() )
+        return RESERVATION_FAIL;
 
-  assert(mf->get_data_size() <= m_config.get_line_sz());
+    assert( mf->get_data_size() <= m_config.get_line_sz());
 
-  // at this point, we will accept the request : access tags and immediately
-  // allocate line
-  new_addr_type block_addr = m_config.block_addr(addr);
-  unsigned cache_index = (unsigned)-1;
-  enum cache_request_status status =
-      m_tags.access(block_addr, time, cache_index, mf);
-  enum cache_request_status cache_status = RESERVATION_FAIL;
-  assert(status != RESERVATION_FAIL);
-  assert(status != HIT_RESERVED);  // as far as tags are concerned: HIT or MISS
-  m_fragment_fifo.push(
-      fragment_entry(mf, cache_index, status == MISS, mf->get_data_size()));
-  if (status == MISS) {
-    // we need to send a memory request...
-    unsigned rob_index = m_rob.push(rob_entry(cache_index, mf, block_addr));
-    m_extra_mf_fields[mf] = extra_mf_fields(rob_index, m_config);
-    mf->set_data_size(m_config.get_line_sz());
-    m_tags.fill(cache_index, time, mf);  // mark block as valid
-    m_request_fifo.push(mf);
-    mf->set_status(m_request_queue_status, time);
-    events.push_back(cache_event(READ_REQUEST_SENT));
-    cache_status = MISS;
-  } else {
-    // the value *will* *be* in the cache already
-    cache_status = HIT_RESERVED;
-  }
-  m_stats.inc_stats(mf->get_access_type(),
-                    m_stats.select_stats_status(status, cache_status));
-  m_stats.inc_stats_pw(mf->get_access_type(),
-                       m_stats.select_stats_status(status, cache_status));
-  return cache_status;
+    // at this point, we will accept the request : access tags and immediately allocate line
+    new_addr_type block_addr = m_config.block_addr(addr);
+    unsigned cache_index = (unsigned)-1;
+    enum cache_request_status status = m_tags.access(block_addr,time,cache_index,mf);
+    enum cache_request_status cache_status = RESERVATION_FAIL;
+    assert( status != RESERVATION_FAIL );
+    assert( status != HIT_RESERVED ); // as far as tags are concerned: HIT or MISS
+    m_fragment_fifo.push( fragment_entry(mf,cache_index,status==MISS,mf->get_data_size()) );
+    if ( status == MISS ) {
+        // we need to send a memory request...
+        unsigned rob_index = m_rob.push( rob_entry(cache_index, mf, block_addr) );
+        m_extra_mf_fields[mf] = extra_mf_fields(rob_index, m_config);
+        mf->set_data_size(m_config.get_line_sz());
+        m_tags.fill(cache_index,time,mf); // mark block as valid
+        m_request_fifo.push(mf);
+        mf->set_status(m_request_queue_status,time);
+        events.push_back(cache_event(READ_REQUEST_SENT));
+        cache_status = MISS;
+    } else {
+        // the value *will* *be* in the cache already
+        cache_status = HIT_RESERVED;
+    }
+    m_stats.inc_stats(mf->get_access_type(), m_stats.select_stats_status(status, cache_status));
+    m_stats.inc_stats_pw(mf->get_access_type(), m_stats.select_stats_status(status, cache_status));
+    return cache_status;
 }
 
-void tex_cache::cycle() {
-  // send next request to lower level of memory
-  if (!m_request_fifo.empty()) {
-    mem_fetch *mf = m_request_fifo.peek();
-    if (!m_memport->full(mf->get_ctrl_size(), false)) {
-      m_request_fifo.pop();
-      m_memport->push(mf);
+void tex_cache::cycle(){
+    // send next request to lower level of memory
+    if ( !m_request_fifo.empty() ) {
+        mem_fetch *mf = m_request_fifo.peek();
+        if ( !m_memport->full(mf->get_ctrl_size(),false) ) {
+            m_request_fifo.pop();
+            m_memport->push(mf);
+        }
     }
-  }
-  // read ready lines from cache
-  if (!m_fragment_fifo.empty() && !m_result_fifo.full()) {
-    const fragment_entry &e = m_fragment_fifo.peek();
-    if (e.m_miss) {
-      // check head of reorder buffer to see if data is back from memory
-      unsigned rob_index = m_rob.next_pop_index();
-      const rob_entry &r = m_rob.peek(rob_index);
-      assert(r.m_request == e.m_request);
-      // assert( r.m_block_addr == m_config.block_addr(e.m_request->get_addr())
-      // );
-      if (r.m_ready) {
-        assert(r.m_index == e.m_cache_index);
-        m_cache[r.m_index].m_valid = true;
-        m_cache[r.m_index].m_block_addr = r.m_block_addr;
-        m_result_fifo.push(e.m_request);
-        m_rob.pop();
-        m_fragment_fifo.pop();
-      }
-    } else {
-      // hit:
-      assert(m_cache[e.m_cache_index].m_valid);
-      assert(m_cache[e.m_cache_index].m_block_addr ==
-             m_config.block_addr(e.m_request->get_addr()));
-      m_result_fifo.push(e.m_request);
-      m_fragment_fifo.pop();
+    // read ready lines from cache
+    if ( !m_fragment_fifo.empty() && !m_result_fifo.full() ) {
+        const fragment_entry &e = m_fragment_fifo.peek();
+        if ( e.m_miss ) {
+            // check head of reorder buffer to see if data is back from memory
+            unsigned rob_index = m_rob.next_pop_index();
+            const rob_entry &r = m_rob.peek(rob_index);
+            assert( r.m_request == e.m_request );
+            //assert( r.m_block_addr == m_config.block_addr(e.m_request->get_addr()) );
+            if ( r.m_ready ) {
+                assert( r.m_index == e.m_cache_index );
+                m_cache[r.m_index].m_valid = true;
+                m_cache[r.m_index].m_block_addr = r.m_block_addr;
+                m_result_fifo.push(e.m_request);
+                m_rob.pop();
+                m_fragment_fifo.pop();
+            }
+        } else {
+            // hit:
+            assert( m_cache[e.m_cache_index].m_valid );
+            assert( m_cache[e.m_cache_index].m_block_addr
+                == m_config.block_addr(e.m_request->get_addr()) );
+            m_result_fifo.push( e.m_request );
+            m_fragment_fifo.pop();
+        }
     }
-  }
 }
 
 /// Place returning cache block into reorder buffer
-void tex_cache::fill(mem_fetch *mf, unsigned time) {
-  if (m_config.m_mshr_type == SECTOR_TEX_FIFO) {
-    assert(mf->get_original_mf());
-    extra_mf_fields_lookup::iterator e =
-        m_extra_mf_fields.find(mf->get_original_mf());
-    assert(e != m_extra_mf_fields.end());
+void tex_cache::fill( mem_fetch *mf, unsigned time )
+{
+	if(m_config.m_mshr_type == SECTOR_TEX_FIFO) {
+	assert(mf->get_original_mf());
+	extra_mf_fields_lookup::iterator e = m_extra_mf_fields.find(mf->get_original_mf());
+    assert( e != m_extra_mf_fields.end() );
     e->second.pending_read--;
 
-    if (e->second.pending_read > 0) {
-      // wait for the other requests to come back
-      delete mf;
-      return;
-    } else {
-      mem_fetch *temp = mf;
-      mf = mf->get_original_mf();
-      delete temp;
-    }
-  }
+    if(e->second.pending_read > 0) {
+    	//wait for the other requests to come back
+    	delete mf;
+    	return;
+      } else {
+    	mem_fetch *temp = mf;
+    	mf = mf->get_original_mf();
+    	delete temp;
+      }
+	}
 
-  extra_mf_fields_lookup::iterator e = m_extra_mf_fields.find(mf);
-  assert(e != m_extra_mf_fields.end());
-  assert(e->second.m_valid);
-  assert(!m_rob.empty());
-  mf->set_status(m_rob_status, time);
+    extra_mf_fields_lookup::iterator e = m_extra_mf_fields.find(mf);
+    assert( e != m_extra_mf_fields.end() );
+    assert( e->second.m_valid );
+    assert( !m_rob.empty() );
+    mf->set_status(m_rob_status,time);
 
-  unsigned rob_index = e->second.m_rob_index;
-  rob_entry &r = m_rob.peek(rob_index);
-  assert(!r.m_ready);
-  r.m_ready = true;
-  r.m_time = time;
-  assert(r.m_block_addr == m_config.block_addr(mf->get_addr()));
+    unsigned rob_index = e->second.m_rob_index;
+    rob_entry &r = m_rob.peek(rob_index);
+    assert( !r.m_ready );
+    r.m_ready = true;
+    r.m_time = time;
+    assert( r.m_block_addr == m_config.block_addr(mf->get_addr()) );
 }
 
-void tex_cache::display_state(FILE *fp) const {
-  fprintf(fp, "%s (texture cache) state:\n", m_name.c_str());
-  fprintf(fp, "fragment fifo entries  = %u / %u\n", m_fragment_fifo.size(),
-          m_fragment_fifo.capacity());
-  fprintf(fp, "reorder buffer entries = %u / %u\n", m_rob.size(),
-          m_rob.capacity());
-  fprintf(fp, "request fifo entries   = %u / %u\n", m_request_fifo.size(),
-          m_request_fifo.capacity());
-  if (!m_rob.empty()) fprintf(fp, "reorder buffer contents:\n");
-  for (int n = m_rob.size() - 1; n >= 0; n--) {
-    unsigned index = (m_rob.next_pop_index() + n) % m_rob.capacity();
-    const rob_entry &r = m_rob.peek(index);
-    fprintf(fp, "tex rob[%3d] : %s ", index,
-            (r.m_ready ? "ready  " : "pending"));
-    if (r.m_ready)
-      fprintf(fp, "@%6u", r.m_time);
-    else
-      fprintf(fp, "       ");
-    fprintf(fp, "[idx=%4u]", r.m_index);
-    r.m_request->print(fp, false);
-  }
-  if (!m_fragment_fifo.empty()) {
-    fprintf(fp, "fragment fifo (oldest) :");
-    fragment_entry &f = m_fragment_fifo.peek();
-    fprintf(fp, "%s:          ", f.m_miss ? "miss" : "hit ");
-    f.m_request->print(fp, false);
-  }
+void tex_cache::display_state( FILE *fp ) const
+{
+    fprintf(fp,"%s (texture cache) state:\n", m_name.c_str() );
+    fprintf(fp,"fragment fifo entries  = %u / %u\n",
+        m_fragment_fifo.size(), m_fragment_fifo.capacity() );
+    fprintf(fp,"reorder buffer entries = %u / %u\n",
+        m_rob.size(), m_rob.capacity() );
+    fprintf(fp,"request fifo entries   = %u / %u\n",
+        m_request_fifo.size(), m_request_fifo.capacity() );
+    if ( !m_rob.empty() )
+        fprintf(fp,"reorder buffer contents:\n");
+    for ( int n=m_rob.size()-1; n>=0; n-- ) {
+        unsigned index = (m_rob.next_pop_index() + n)%m_rob.capacity();
+        const rob_entry &r = m_rob.peek(index);
+        fprintf(fp, "tex rob[%3d] : %s ",
+            index, (r.m_ready?"ready  ":"pending") );
+        if ( r.m_ready )
+            fprintf(fp,"@%6u", r.m_time );
+        else
+            fprintf(fp,"       ");
+        fprintf(fp,"[idx=%4u]",r.m_index);
+        r.m_request->print(fp,false);
+    }
+    if ( !m_fragment_fifo.empty() ) {
+        fprintf(fp,"fragment fifo (oldest) :");
+        fragment_entry &f = m_fragment_fifo.peek();
+        fprintf(fp,"%s:          ", f.m_miss?"miss":"hit ");
+        f.m_request->print(fp,false);
+    }
 }
 /******************************************************************************************************************************************/
+

--- a/src/gpgpu-sim/gpu-cache.h
+++ b/src/gpgpu-sim/gpu-cache.h
@@ -547,13 +547,14 @@ class cache_config {
     }
     if (m_alloc_policy == STREAMING) {
       // For streaming cache, we set the alloc policy to be on-fill to remove
-      // all line_alloc_fail stalls we set the MSHRs to be equal to max allocated
-      // cache lines. This is possible by moving TAG to be shared between cache
-      // line and MSHR enrty (i.e. for each cache line, there is an MSHR rntey
-      // associated with it) This is the easiest think we can think about to
-      // model (mimic) L1 streaming cache in Pascal and Volta Based on our
-      // microbenchmakrs, MSHRs entries have been increasing substantially in
-      // Pascal and Volta For more information about streaming cache, see:
+      // all line_alloc_fail stalls we set the MSHRs to be equal to max
+      // allocated cache lines. This is possible by moving TAG to be shared
+      // between cache line and MSHR enrty (i.e. for each cache line, there is
+      // an MSHR rntey associated with it) This is the easiest think we can
+      // think about to model (mimic) L1 streaming cache in Pascal and Volta
+      // Based on our microbenchmakrs, MSHRs entries have been increasing
+      // substantially in Pascal and Volta For more information about streaming
+      // cache, see:
       // http://on-demand.gputechconf.com/gtc/2017/presentation/s7798-luke-durant-inside-volta.pdf
       // https://ieeexplore.ieee.org/document/8344474/
       m_is_streaming = true;
@@ -1303,9 +1304,9 @@ class baseline_cache : public cache_t {
     const cache_config &m_config;
 
     int m_data_port_occupied_cycles;  //< Number of cycle that the data port
-                                      //remains used
+                                      // remains used
     int m_fill_port_occupied_cycles;  //< Number of cycle that the fill port
-                                      //remains used
+                                      // remains used
   };
 
   bandwidth_management m_bandwidth_management;

--- a/src/gpgpu-sim/gpu-cache.h
+++ b/src/gpgpu-sim/gpu-cache.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -30,464 +32,420 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "gpu-misc.h"
-#include "mem_fetch.h"
 #include "../abstract_hardware_model.h"
 #include "../tr1_hash_map.h"
+#include "gpu-misc.h"
+#include "mem_fetch.h"
 
-#include "addrdec.h"
 #include <iostream>
+#include "addrdec.h"
 
 #define MAX_DEFAULT_CACHE_SIZE_MULTIBLIER 4
 
-enum cache_block_state {
-    INVALID=0,
-    RESERVED,
-    VALID,
-    MODIFIED
-};
+enum cache_block_state { INVALID = 0, RESERVED, VALID, MODIFIED };
 
 enum cache_request_status {
-    HIT = 0,
-    HIT_RESERVED,
-    MISS,
-    RESERVATION_FAIL, 
-	SECTOR_MISS,
-    NUM_CACHE_REQUEST_STATUS
+  HIT = 0,
+  HIT_RESERVED,
+  MISS,
+  RESERVATION_FAIL,
+  SECTOR_MISS,
+  NUM_CACHE_REQUEST_STATUS
 };
 
 enum cache_reservation_fail_reason {
-	LINE_ALLOC_FAIL= 0,// all line are reserved
-	MISS_QUEUE_FULL,   // MISS queue (i.e. interconnect or DRAM) is full
-	MSHR_ENRTY_FAIL,
-	MSHR_MERGE_ENRTY_FAIL,
-	MSHR_RW_PENDING,
-    NUM_CACHE_RESERVATION_FAIL_STATUS
+  LINE_ALLOC_FAIL = 0,  // all line are reserved
+  MISS_QUEUE_FULL,      // MISS queue (i.e. interconnect or DRAM) is full
+  MSHR_ENRTY_FAIL,
+  MSHR_MERGE_ENRTY_FAIL,
+  MSHR_RW_PENDING,
+  NUM_CACHE_RESERVATION_FAIL_STATUS
 };
 
 enum cache_event_type {
-    WRITE_BACK_REQUEST_SENT,
-    READ_REQUEST_SENT,
-    WRITE_REQUEST_SENT,
-	WRITE_ALLOCATE_SENT
+  WRITE_BACK_REQUEST_SENT,
+  READ_REQUEST_SENT,
+  WRITE_REQUEST_SENT,
+  WRITE_ALLOCATE_SENT
 };
 
 struct evicted_block_info {
-	new_addr_type m_block_addr;
-	unsigned m_modified_size;
-	evicted_block_info() {
-		m_block_addr = 0;
-		m_modified_size = 0;
-	}
-	void set_info(new_addr_type block_addr, unsigned modified_size){
-		m_block_addr = block_addr;
-		m_modified_size = modified_size;
-	}
+  new_addr_type m_block_addr;
+  unsigned m_modified_size;
+  evicted_block_info() {
+    m_block_addr = 0;
+    m_modified_size = 0;
+  }
+  void set_info(new_addr_type block_addr, unsigned modified_size) {
+    m_block_addr = block_addr;
+    m_modified_size = modified_size;
+  }
 };
 
 struct cache_event {
-	enum cache_event_type m_cache_event_type;
-	evicted_block_info m_evicted_block; //if it was write_back event, fill the the evicted block info
+  enum cache_event_type m_cache_event_type;
+  evicted_block_info m_evicted_block;  // if it was write_back event, fill the
+                                       // the evicted block info
 
-	cache_event(enum cache_event_type m_cache_event){
-		m_cache_event_type = m_cache_event;
-	}
+  cache_event(enum cache_event_type m_cache_event) {
+    m_cache_event_type = m_cache_event;
+  }
 
-	cache_event(enum cache_event_type cache_event, evicted_block_info evicted_block){
-	m_cache_event_type = cache_event;
-	m_evicted_block = evicted_block;
-	}
+  cache_event(enum cache_event_type cache_event,
+              evicted_block_info evicted_block) {
+    m_cache_event_type = cache_event;
+    m_evicted_block = evicted_block;
+  }
 };
 
-const char * cache_request_status_str(enum cache_request_status status); 
+const char *cache_request_status_str(enum cache_request_status status);
 
 struct cache_block_t {
-    cache_block_t()
-    {
-        m_tag=0;
-        m_block_addr=0;
-    }
+  cache_block_t() {
+    m_tag = 0;
+    m_block_addr = 0;
+  }
 
-    virtual void allocate( new_addr_type tag, new_addr_type block_addr, unsigned time, mem_access_sector_mask_t sector_mask) = 0;
-    virtual void fill( unsigned time, mem_access_sector_mask_t sector_mask) = 0;
+  virtual void allocate(new_addr_type tag, new_addr_type block_addr,
+                        unsigned time,
+                        mem_access_sector_mask_t sector_mask) = 0;
+  virtual void fill(unsigned time, mem_access_sector_mask_t sector_mask) = 0;
 
-    virtual bool is_invalid_line() = 0;
-    virtual bool is_valid_line() = 0;
-    virtual bool is_reserved_line() = 0;
-    virtual bool is_modified_line() = 0;
+  virtual bool is_invalid_line() = 0;
+  virtual bool is_valid_line() = 0;
+  virtual bool is_reserved_line() = 0;
+  virtual bool is_modified_line() = 0;
 
-    virtual enum cache_block_state get_status( mem_access_sector_mask_t sector_mask) = 0;
-    virtual void set_status(enum cache_block_state m_status, mem_access_sector_mask_t sector_mask) = 0;
+  virtual enum cache_block_state get_status(
+      mem_access_sector_mask_t sector_mask) = 0;
+  virtual void set_status(enum cache_block_state m_status,
+                          mem_access_sector_mask_t sector_mask) = 0;
 
-    virtual unsigned long long get_last_access_time() = 0;
-    virtual void set_last_access_time(unsigned long long time, mem_access_sector_mask_t sector_mask) = 0;
-    virtual unsigned long long get_alloc_time() = 0;
-    virtual void set_ignore_on_fill(bool m_ignore, mem_access_sector_mask_t sector_mask) = 0;
-    virtual void set_modified_on_fill(bool m_modified, mem_access_sector_mask_t sector_mask) = 0;
-    virtual unsigned get_modified_size() = 0;
-    virtual void set_m_readable(bool readable, mem_access_sector_mask_t sector_mask)=0;
-    virtual bool is_readable(mem_access_sector_mask_t sector_mask)=0;
-    virtual void print_status()=0;
-    virtual ~cache_block_t() {}
+  virtual unsigned long long get_last_access_time() = 0;
+  virtual void set_last_access_time(unsigned long long time,
+                                    mem_access_sector_mask_t sector_mask) = 0;
+  virtual unsigned long long get_alloc_time() = 0;
+  virtual void set_ignore_on_fill(bool m_ignore,
+                                  mem_access_sector_mask_t sector_mask) = 0;
+  virtual void set_modified_on_fill(bool m_modified,
+                                    mem_access_sector_mask_t sector_mask) = 0;
+  virtual unsigned get_modified_size() = 0;
+  virtual void set_m_readable(bool readable,
+                              mem_access_sector_mask_t sector_mask) = 0;
+  virtual bool is_readable(mem_access_sector_mask_t sector_mask) = 0;
+  virtual void print_status() = 0;
+  virtual ~cache_block_t() {}
 
-
-    new_addr_type    m_tag;
-    new_addr_type    m_block_addr;
-
+  new_addr_type m_tag;
+  new_addr_type m_block_addr;
 };
 
-struct line_cache_block: public cache_block_t  {
-	line_cache_block()
-	    {
-	        m_alloc_time=0;
-	        m_fill_time=0;
-	        m_last_access_time=0;
-	        m_status=INVALID;
-	        m_ignore_on_fill_status = false;
-	        m_set_modified_on_fill = false;
-	        m_readable = true;
-	    }
-	    void allocate( new_addr_type tag, new_addr_type block_addr, unsigned time, mem_access_sector_mask_t sector_mask)
-	    {
-	        m_tag=tag;
-	        m_block_addr=block_addr;
-	        m_alloc_time=time;
-	        m_last_access_time=time;
-	        m_fill_time=0;
-	        m_status=RESERVED;
-	        m_ignore_on_fill_status = false;
-	        m_set_modified_on_fill = false;
-	    }
-		void fill( unsigned time, mem_access_sector_mask_t sector_mask )
-	    {
-	    	//if(!m_ignore_on_fill_status)
-	    	//	assert( m_status == RESERVED );
+struct line_cache_block : public cache_block_t {
+  line_cache_block() {
+    m_alloc_time = 0;
+    m_fill_time = 0;
+    m_last_access_time = 0;
+    m_status = INVALID;
+    m_ignore_on_fill_status = false;
+    m_set_modified_on_fill = false;
+    m_readable = true;
+  }
+  void allocate(new_addr_type tag, new_addr_type block_addr, unsigned time,
+                mem_access_sector_mask_t sector_mask) {
+    m_tag = tag;
+    m_block_addr = block_addr;
+    m_alloc_time = time;
+    m_last_access_time = time;
+    m_fill_time = 0;
+    m_status = RESERVED;
+    m_ignore_on_fill_status = false;
+    m_set_modified_on_fill = false;
+  }
+  void fill(unsigned time, mem_access_sector_mask_t sector_mask) {
+    // if(!m_ignore_on_fill_status)
+    //	assert( m_status == RESERVED );
 
-	    	m_status = m_set_modified_on_fill? MODIFIED : VALID;
+    m_status = m_set_modified_on_fill ? MODIFIED : VALID;
 
-	        m_fill_time=time;
-	    }
-		virtual bool is_invalid_line()
-	    {
-	    	return m_status == INVALID;
-	    }
-		virtual bool is_valid_line()
-	    {
-	    	 return m_status == VALID;
-	    }
-		virtual bool is_reserved_line()
-	    {
-	    	 return m_status == RESERVED;
-	    }
-		virtual bool is_modified_line()
-	    {
-	    	return m_status == MODIFIED;
-	    }
+    m_fill_time = time;
+  }
+  virtual bool is_invalid_line() { return m_status == INVALID; }
+  virtual bool is_valid_line() { return m_status == VALID; }
+  virtual bool is_reserved_line() { return m_status == RESERVED; }
+  virtual bool is_modified_line() { return m_status == MODIFIED; }
 
-		virtual enum cache_block_state get_status(mem_access_sector_mask_t sector_mask)
-	    {
-	    	return m_status;
-	    }
-		virtual void set_status(enum cache_block_state status, mem_access_sector_mask_t sector_mask)
-	    {
-	    	m_status = status;
-	    }
-		virtual unsigned long long get_last_access_time()
-		{
-			return m_last_access_time;
-		}
-		virtual void set_last_access_time(unsigned long long time, mem_access_sector_mask_t sector_mask)
-	    {
-	    	m_last_access_time = time;
-	    }
-		virtual unsigned long long get_alloc_time()
-	    {
-	    	return m_alloc_time;
-	    }
-		virtual void set_ignore_on_fill(bool m_ignore, mem_access_sector_mask_t sector_mask)
-		{
-			m_ignore_on_fill_status = m_ignore;
-		}
-		virtual void set_modified_on_fill(bool m_modified, mem_access_sector_mask_t sector_mask)
-		{
-	    	m_set_modified_on_fill = m_modified;
-		}
-		virtual unsigned  get_modified_size()
-		{
-			return SECTOR_CHUNCK_SIZE * SECTOR_SIZE;   //i.e. cache line size
-		}
-		virtual void set_m_readable(bool readable, mem_access_sector_mask_t sector_mask)
-		{
-			m_readable = readable;
-		}
-		virtual bool is_readable(mem_access_sector_mask_t sector_mask) {
-			return m_readable;
-		}
-		virtual void print_status() {
-			 printf("m_block_addr is %llu, status = %u\n", m_block_addr, m_status);
-		}
+  virtual enum cache_block_state get_status(
+      mem_access_sector_mask_t sector_mask) {
+    return m_status;
+  }
+  virtual void set_status(enum cache_block_state status,
+                          mem_access_sector_mask_t sector_mask) {
+    m_status = status;
+  }
+  virtual unsigned long long get_last_access_time() {
+    return m_last_access_time;
+  }
+  virtual void set_last_access_time(unsigned long long time,
+                                    mem_access_sector_mask_t sector_mask) {
+    m_last_access_time = time;
+  }
+  virtual unsigned long long get_alloc_time() { return m_alloc_time; }
+  virtual void set_ignore_on_fill(bool m_ignore,
+                                  mem_access_sector_mask_t sector_mask) {
+    m_ignore_on_fill_status = m_ignore;
+  }
+  virtual void set_modified_on_fill(bool m_modified,
+                                    mem_access_sector_mask_t sector_mask) {
+    m_set_modified_on_fill = m_modified;
+  }
+  virtual unsigned get_modified_size() {
+    return SECTOR_CHUNCK_SIZE * SECTOR_SIZE;  // i.e. cache line size
+  }
+  virtual void set_m_readable(bool readable,
+                              mem_access_sector_mask_t sector_mask) {
+    m_readable = readable;
+  }
+  virtual bool is_readable(mem_access_sector_mask_t sector_mask) {
+    return m_readable;
+  }
+  virtual void print_status() {
+    printf("m_block_addr is %llu, status = %u\n", m_block_addr, m_status);
+  }
 
-
-private:
-	    unsigned long long     m_alloc_time;
-	    unsigned long long     m_last_access_time;
-	    unsigned long long     m_fill_time;
-	    cache_block_state    m_status;
-	    bool m_ignore_on_fill_status;
-	    bool m_set_modified_on_fill;
-	    bool m_readable;
+ private:
+  unsigned long long m_alloc_time;
+  unsigned long long m_last_access_time;
+  unsigned long long m_fill_time;
+  cache_block_state m_status;
+  bool m_ignore_on_fill_status;
+  bool m_set_modified_on_fill;
+  bool m_readable;
 };
 
 struct sector_cache_block : public cache_block_t {
-	sector_cache_block()
-    {
-		init();
+  sector_cache_block() { init(); }
+
+  void init() {
+    for (unsigned i = 0; i < SECTOR_CHUNCK_SIZE; ++i) {
+      m_sector_alloc_time[i] = 0;
+      m_sector_fill_time[i] = 0;
+      m_last_sector_access_time[i] = 0;
+      m_status[i] = INVALID;
+      m_ignore_on_fill_status[i] = false;
+      m_set_modified_on_fill[i] = false;
+      m_readable[i] = true;
     }
+    m_line_alloc_time = 0;
+    m_line_last_access_time = 0;
+    m_line_fill_time = 0;
+  }
 
-	void init() {
-		for(unsigned i =0; i< SECTOR_CHUNCK_SIZE; ++i) {
-			m_sector_alloc_time[i]= 0;
-			m_sector_fill_time[i]= 0;
-			m_last_sector_access_time[i]= 0;
-			m_status[i]= INVALID;
-			m_ignore_on_fill_status[i] = false;
-			m_set_modified_on_fill[i] = false;
-			m_readable[i] = true;
-			}
-			m_line_alloc_time=0;
-			m_line_last_access_time=0;
-			m_line_fill_time=0;
-	}
+  virtual void allocate(new_addr_type tag, new_addr_type block_addr,
+                        unsigned time, mem_access_sector_mask_t sector_mask) {
+    allocate_line(tag, block_addr, time, sector_mask);
+  }
 
-	virtual void allocate( new_addr_type tag, new_addr_type block_addr, unsigned time, mem_access_sector_mask_t sector_mask )
-    {
-    	allocate_line( tag,  block_addr,  time, sector_mask );
-    }
+  void allocate_line(new_addr_type tag, new_addr_type block_addr, unsigned time,
+                     mem_access_sector_mask_t sector_mask) {
+    // allocate a new line
+    // assert(m_block_addr != 0 && m_block_addr != block_addr);
+    init();
+    m_tag = tag;
+    m_block_addr = block_addr;
 
-    void allocate_line( new_addr_type tag, new_addr_type block_addr, unsigned time, mem_access_sector_mask_t sector_mask )
-	{
-		//allocate a new line
-		//assert(m_block_addr != 0 && m_block_addr != block_addr);
-		init();
-		m_tag=tag;
-		m_block_addr=block_addr;
+    unsigned sidx = get_sector_index(sector_mask);
 
-		unsigned sidx = get_sector_index(sector_mask);
+    // set sector stats
+    m_sector_alloc_time[sidx] = time;
+    m_last_sector_access_time[sidx] = time;
+    m_sector_fill_time[sidx] = 0;
+    m_status[sidx] = RESERVED;
+    m_ignore_on_fill_status[sidx] = false;
+    m_set_modified_on_fill[sidx] = false;
 
-		//set sector stats
-		m_sector_alloc_time[sidx]=time;
-		m_last_sector_access_time[sidx]=time;
-		m_sector_fill_time[sidx]=0;
-		m_status[sidx]=RESERVED;
-		m_ignore_on_fill_status[sidx] = false;
-		m_set_modified_on_fill[sidx] = false;
+    // set line stats
+    m_line_alloc_time = time;  // only set this for the first allocated sector
+    m_line_last_access_time = time;
+    m_line_fill_time = 0;
+  }
 
-		//set line stats
-		m_line_alloc_time=time;   //only set this for the first allocated sector
-		m_line_last_access_time=time;
-		m_line_fill_time=0;
-	}
+  void allocate_sector(unsigned time, mem_access_sector_mask_t sector_mask) {
+    // allocate invalid sector of this allocated valid line
+    assert(is_valid_line());
+    unsigned sidx = get_sector_index(sector_mask);
 
-    void allocate_sector(unsigned time, mem_access_sector_mask_t sector_mask )
-	{
-    	//allocate invalid sector of this allocated valid line
-    	assert(is_valid_line());
-		unsigned sidx = get_sector_index(sector_mask);
+    // set sector stats
+    m_sector_alloc_time[sidx] = time;
+    m_last_sector_access_time[sidx] = time;
+    m_sector_fill_time[sidx] = 0;
+    if (m_status[sidx] == MODIFIED)  // this should be the case only for
+                                     // fetch-on-write policy //TO DO
+      m_set_modified_on_fill[sidx] = true;
+    else
+      m_set_modified_on_fill[sidx] = false;
 
-		//set sector stats
-		m_sector_alloc_time[sidx]=time;
-		m_last_sector_access_time[sidx]=time;
-		m_sector_fill_time[sidx]=0;
-		if(m_status[sidx]==MODIFIED)    //this should be the case only for fetch-on-write policy //TO DO
-			m_set_modified_on_fill[sidx] = true;
-		else
-			m_set_modified_on_fill[sidx] = false;
+    m_status[sidx] = RESERVED;
+    m_ignore_on_fill_status[sidx] = false;
+    // m_set_modified_on_fill[sidx] = false;
+    m_readable[sidx] = true;
 
-		m_status[sidx]=RESERVED;
-		m_ignore_on_fill_status[sidx] = false;
-		//m_set_modified_on_fill[sidx] = false;
-		m_readable[sidx] = true;
+    // set line stats
+    m_line_last_access_time = time;
+    m_line_fill_time = 0;
+  }
 
-		//set line stats
-		m_line_last_access_time=time;
-		m_line_fill_time=0;
-	}
-
-    virtual void fill( unsigned time, mem_access_sector_mask_t sector_mask)
-    {
-    	unsigned sidx = get_sector_index(sector_mask);
+  virtual void fill(unsigned time, mem_access_sector_mask_t sector_mask) {
+    unsigned sidx = get_sector_index(sector_mask);
 
     //	if(!m_ignore_on_fill_status[sidx])
     //	         assert( m_status[sidx] == RESERVED );
 
-    	m_status[sidx] = m_set_modified_on_fill[sidx]? MODIFIED : VALID;
+    m_status[sidx] = m_set_modified_on_fill[sidx] ? MODIFIED : VALID;
 
-        m_sector_fill_time[sidx]=time;
-        m_line_fill_time=time;
+    m_sector_fill_time[sidx] = time;
+    m_line_fill_time = time;
+  }
+  virtual bool is_invalid_line() {
+    // all the sectors should be invalid
+    for (unsigned i = 0; i < SECTOR_CHUNCK_SIZE; ++i) {
+      if (m_status[i] != INVALID) return false;
     }
-    virtual bool is_invalid_line() {
-    	//all the sectors should be invalid
-    	for(unsigned i =0; i< SECTOR_CHUNCK_SIZE; ++i) {
-    		if (m_status[i] != INVALID)
-    			return false;
-    	}
-    	return true;
+    return true;
+  }
+  virtual bool is_valid_line() { return !(is_invalid_line()); }
+  virtual bool is_reserved_line() {
+    // if any of the sector is reserved, then the line is reserved
+    for (unsigned i = 0; i < SECTOR_CHUNCK_SIZE; ++i) {
+      if (m_status[i] == RESERVED) return true;
     }
-    virtual bool is_valid_line() { return  !(is_invalid_line()); }
-    virtual bool is_reserved_line() {
-    	//if any of the sector is reserved, then the line is reserved
-		for(unsigned i =0; i< SECTOR_CHUNCK_SIZE; ++i) {
-			if (m_status[i] == RESERVED)
-				return true;
-		}
-		return false;
+    return false;
+  }
+  virtual bool is_modified_line() {
+    // if any of the sector is modified, then the line is modified
+    for (unsigned i = 0; i < SECTOR_CHUNCK_SIZE; ++i) {
+      if (m_status[i] == MODIFIED) return true;
     }
-    virtual bool is_modified_line() {
-    	//if any of the sector is modified, then the line is modified
-    	for(unsigned i =0; i< SECTOR_CHUNCK_SIZE; ++i) {
-			if (m_status[i] == MODIFIED)
-				return true;
-		}
-		return false;
+    return false;
+  }
+
+  virtual enum cache_block_state get_status(
+      mem_access_sector_mask_t sector_mask) {
+    unsigned sidx = get_sector_index(sector_mask);
+
+    return m_status[sidx];
+  }
+
+  virtual void set_status(enum cache_block_state status,
+                          mem_access_sector_mask_t sector_mask) {
+    unsigned sidx = get_sector_index(sector_mask);
+    m_status[sidx] = status;
+  }
+
+  virtual unsigned long long get_last_access_time() {
+    return m_line_last_access_time;
+  }
+
+  virtual void set_last_access_time(unsigned long long time,
+                                    mem_access_sector_mask_t sector_mask) {
+    unsigned sidx = get_sector_index(sector_mask);
+
+    m_last_sector_access_time[sidx] = time;
+    m_line_last_access_time = time;
+  }
+
+  virtual unsigned long long get_alloc_time() { return m_line_alloc_time; }
+
+  virtual void set_ignore_on_fill(bool m_ignore,
+                                  mem_access_sector_mask_t sector_mask) {
+    unsigned sidx = get_sector_index(sector_mask);
+    m_ignore_on_fill_status[sidx] = m_ignore;
+  }
+
+  virtual void set_modified_on_fill(bool m_modified,
+                                    mem_access_sector_mask_t sector_mask) {
+    unsigned sidx = get_sector_index(sector_mask);
+    m_set_modified_on_fill[sidx] = m_modified;
+  }
+
+  virtual void set_m_readable(bool readable,
+                              mem_access_sector_mask_t sector_mask) {
+    unsigned sidx = get_sector_index(sector_mask);
+    m_readable[sidx] = readable;
+  }
+
+  virtual bool is_readable(mem_access_sector_mask_t sector_mask) {
+    unsigned sidx = get_sector_index(sector_mask);
+    return m_readable[sidx];
+  }
+
+  virtual unsigned get_modified_size() {
+    unsigned modified = 0;
+    for (unsigned i = 0; i < SECTOR_CHUNCK_SIZE; ++i) {
+      if (m_status[i] == MODIFIED) modified++;
     }
+    return modified * SECTOR_SIZE;
+  }
 
-    virtual enum cache_block_state get_status(mem_access_sector_mask_t sector_mask)
-	{
-    	unsigned sidx = get_sector_index(sector_mask);
+  virtual void print_status() {
+    printf("m_block_addr is %llu, status = %u %u %u %u\n", m_block_addr,
+           m_status[0], m_status[1], m_status[2], m_status[3]);
+  }
 
-		return m_status[sidx];
-	}
+ private:
+  unsigned m_sector_alloc_time[SECTOR_CHUNCK_SIZE];
+  unsigned m_last_sector_access_time[SECTOR_CHUNCK_SIZE];
+  unsigned m_sector_fill_time[SECTOR_CHUNCK_SIZE];
+  unsigned m_line_alloc_time;
+  unsigned m_line_last_access_time;
+  unsigned m_line_fill_time;
+  cache_block_state m_status[SECTOR_CHUNCK_SIZE];
+  bool m_ignore_on_fill_status[SECTOR_CHUNCK_SIZE];
+  bool m_set_modified_on_fill[SECTOR_CHUNCK_SIZE];
+  bool m_readable[SECTOR_CHUNCK_SIZE];
 
-    virtual void set_status(enum cache_block_state status, mem_access_sector_mask_t sector_mask)
-	{
-		unsigned sidx = get_sector_index(sector_mask);
-		m_status[sidx] = status;
-	}
-
-    virtual unsigned long long get_last_access_time()
-	{
-		return m_line_last_access_time;
-	}
-
-    virtual void set_last_access_time(unsigned long long time, mem_access_sector_mask_t sector_mask)
-	{
-		unsigned sidx = get_sector_index(sector_mask);
-
-		m_last_sector_access_time[sidx] = time;
-		m_line_last_access_time = time;
-	}
-
-    virtual unsigned long long get_alloc_time()
-	{
-		return m_line_alloc_time;
-	}
-
-    virtual void set_ignore_on_fill(bool m_ignore, mem_access_sector_mask_t sector_mask)
-	{
-		unsigned sidx = get_sector_index(sector_mask);
-		m_ignore_on_fill_status[sidx] = m_ignore;
-	}
-
-    virtual void set_modified_on_fill(bool m_modified, mem_access_sector_mask_t sector_mask)
-	{
-		unsigned sidx = get_sector_index(sector_mask);
-		m_set_modified_on_fill[sidx] = m_modified;
-	}
-
-    virtual void set_m_readable(bool readable, mem_access_sector_mask_t sector_mask)
-    {
-    	unsigned sidx = get_sector_index(sector_mask);
-    	m_readable[sidx] = readable;
+  unsigned get_sector_index(mem_access_sector_mask_t sector_mask) {
+    assert(sector_mask.count() == 1);
+    for (unsigned i = 0; i < SECTOR_CHUNCK_SIZE; ++i) {
+      if (sector_mask.to_ulong() & (1 << i)) return i;
     }
-
-    virtual bool is_readable(mem_access_sector_mask_t sector_mask) {
-    	unsigned sidx = get_sector_index(sector_mask);
-    	return m_readable[sidx];
-	}
-
-    virtual unsigned  get_modified_size()
-	{
-		unsigned modified=0;
-		for(unsigned i =0; i< SECTOR_CHUNCK_SIZE; ++i) {
-			if (m_status[i] == MODIFIED)
-				modified++;
-		}
-		return modified * SECTOR_SIZE;
-	}
-
-    virtual void print_status() {
-    	 printf("m_block_addr is %llu, status = %u %u %u %u\n", m_block_addr, m_status[0], m_status[1], m_status[2], m_status[3]);
-    }
-
-
-private:
-    unsigned m_sector_alloc_time[SECTOR_CHUNCK_SIZE];
-    unsigned m_last_sector_access_time[SECTOR_CHUNCK_SIZE];
-    unsigned m_sector_fill_time[SECTOR_CHUNCK_SIZE];
-    unsigned m_line_alloc_time;
-    unsigned m_line_last_access_time;
-    unsigned m_line_fill_time;
-    cache_block_state    m_status[SECTOR_CHUNCK_SIZE];
-    bool m_ignore_on_fill_status[SECTOR_CHUNCK_SIZE];
-    bool m_set_modified_on_fill[SECTOR_CHUNCK_SIZE];
-    bool m_readable[SECTOR_CHUNCK_SIZE];
-
-    unsigned get_sector_index(mem_access_sector_mask_t sector_mask)
-    {
-    	assert(sector_mask.count() == 1);
-    	for(unsigned i =0; i< SECTOR_CHUNCK_SIZE; ++i) {
-    		if(sector_mask.to_ulong() & (1<<i))
-    			return i;
-    	}
-    }
+  }
 };
 
-enum replacement_policy_t {
-    LRU,
-    FIFO
-};
+enum replacement_policy_t { LRU, FIFO };
 
 enum write_policy_t {
-    READ_ONLY,
-    WRITE_BACK,
-    WRITE_THROUGH,
-    WRITE_EVICT,
-    LOCAL_WB_GLOBAL_WT
+  READ_ONLY,
+  WRITE_BACK,
+  WRITE_THROUGH,
+  WRITE_EVICT,
+  LOCAL_WB_GLOBAL_WT
 };
 
-enum allocation_policy_t {
-    ON_MISS,
-    ON_FILL,
-	STREAMING
-};
-
+enum allocation_policy_t { ON_MISS, ON_FILL, STREAMING };
 
 enum write_allocate_policy_t {
-	NO_WRITE_ALLOCATE,
-	WRITE_ALLOCATE,
-	FETCH_ON_WRITE,
-	LAZY_FETCH_ON_READ
+  NO_WRITE_ALLOCATE,
+  WRITE_ALLOCATE,
+  FETCH_ON_WRITE,
+  LAZY_FETCH_ON_READ
 };
 
 enum mshr_config_t {
-    TEX_FIFO, // Tex cache
-    ASSOC, // normal cache
-	SECTOR_TEX_FIFO,  //Tex cache sends requests to high-level sector cache
-	SECTOR_ASSOC // normal cache sends requests to high-level sector cache
+  TEX_FIFO,         // Tex cache
+  ASSOC,            // normal cache
+  SECTOR_TEX_FIFO,  // Tex cache sends requests to high-level sector cache
+  SECTOR_ASSOC      // normal cache sends requests to high-level sector cache
 };
 
-enum set_index_function{
-	LINEAR_SET_FUNCTION = 0,
-	BITWISE_XORING_FUNCTION,
-	HASH_IPOLY_FUNCTION,
-	FERMI_HASH_SET_FUNCTION,
-    CUSTOM_SET_FUNCTION
+enum set_index_function {
+  LINEAR_SET_FUNCTION = 0,
+  BITWISE_XORING_FUNCTION,
+  HASH_IPOLY_FUNCTION,
+  FERMI_HASH_SET_FUNCTION,
+  CUSTOM_SET_FUNCTION
 };
 
-enum cache_type{
-    NORMAL = 0,
-    SECTOR
-};
+enum cache_type { NORMAL = 0, SECTOR };
 
 #define MAX_WARP_PER_SHADER 64
 #define INCT_TOTAL_BUFFER 64
@@ -496,541 +454,611 @@ enum cache_type{
 #define MAX_WARP_PER_SHADER 64
 
 class cache_config {
-public:
-    cache_config() 
-    { 
-        m_valid = false; 
-        m_disabled = false;
-        m_config_string = NULL; // set by option parser
-        m_config_stringPrefL1 = NULL;
-        m_config_stringPrefShared = NULL;
-        m_data_port_width = 0;
+ public:
+  cache_config() {
+    m_valid = false;
+    m_disabled = false;
+    m_config_string = NULL;  // set by option parser
+    m_config_stringPrefL1 = NULL;
+    m_config_stringPrefShared = NULL;
+    m_data_port_width = 0;
+    m_set_index_function = LINEAR_SET_FUNCTION;
+    m_is_streaming = false;
+  }
+  void init(char *config, FuncCache status) {
+    cache_status = status;
+    assert(config);
+    char ct, rp, wp, ap, mshr_type, wap, sif;
+
+    int ntok =
+        sscanf(config, "%c:%u:%u:%u,%c:%c:%c:%c:%c,%c:%u:%u,%u:%u,%u", &ct,
+               &m_nset, &m_line_sz, &m_assoc, &rp, &wp, &ap, &wap, &sif,
+               &mshr_type, &m_mshr_entries, &m_mshr_max_merge,
+               &m_miss_queue_size, &m_result_fifo_entries, &m_data_port_width);
+
+    if (ntok < 12) {
+      if (!strcmp(config, "none")) {
+        m_disabled = true;
+        return;
+      }
+      exit_parse_error();
+    }
+
+    switch (ct) {
+      case 'N':
+        m_cache_type = NORMAL;
+        break;
+      case 'S':
+        m_cache_type = SECTOR;
+        break;
+      default:
+        exit_parse_error();
+    }
+    switch (rp) {
+      case 'L':
+        m_replacement_policy = LRU;
+        break;
+      case 'F':
+        m_replacement_policy = FIFO;
+        break;
+      default:
+        exit_parse_error();
+    }
+    switch (rp) {
+      case 'L':
+        m_replacement_policy = LRU;
+        break;
+      case 'F':
+        m_replacement_policy = FIFO;
+        break;
+      default:
+        exit_parse_error();
+    }
+    switch (wp) {
+      case 'R':
+        m_write_policy = READ_ONLY;
+        break;
+      case 'B':
+        m_write_policy = WRITE_BACK;
+        break;
+      case 'T':
+        m_write_policy = WRITE_THROUGH;
+        break;
+      case 'E':
+        m_write_policy = WRITE_EVICT;
+        break;
+      case 'L':
+        m_write_policy = LOCAL_WB_GLOBAL_WT;
+        break;
+      default:
+        exit_parse_error();
+    }
+    switch (ap) {
+      case 'm':
+        m_alloc_policy = ON_MISS;
+        break;
+      case 'f':
+        m_alloc_policy = ON_FILL;
+        break;
+      case 's':
+        m_alloc_policy = STREAMING;
+        break;
+      default:
+        exit_parse_error();
+    }
+    if (m_alloc_policy == STREAMING) {
+      // For streaming cache, we set the alloc policy to be on-fill to remove
+      // all line_alloc_fail stalls
+      // we set the MSHRs to be equal to max allocated cache lines. This is
+      // possible by moving TAG to be shared between cache line and MSHR enrty
+      // (i.e. for each cache line, there is an MSHR rntey associated with it)
+      // This is the easiest think we can think about to model (mimic) L1
+      // streaming cache in Pascal and Volta
+      // Based on our microbenchmakrs, MSHRs entries have been increasing
+      // substantially in Pascal and Volta
+      // For more information about streaming cache, see:
+      // http://on-demand.gputechconf.com/gtc/2017/presentation/s7798-luke-durant-inside-volta.pdf
+      // https://ieeexplore.ieee.org/document/8344474/
+      m_is_streaming = true;
+      m_alloc_policy = ON_FILL;
+      m_mshr_entries = m_nset * m_assoc * MAX_DEFAULT_CACHE_SIZE_MULTIBLIER;
+      if (m_cache_type == SECTOR) m_mshr_entries *= SECTOR_CHUNCK_SIZE;
+      m_mshr_max_merge = MAX_WARP_PER_SM;
+    }
+    switch (mshr_type) {
+      case 'F':
+        m_mshr_type = TEX_FIFO;
+        assert(ntok == 14);
+        break;
+      case 'T':
+        m_mshr_type = SECTOR_TEX_FIFO;
+        assert(ntok == 14);
+        break;
+      case 'A':
+        m_mshr_type = ASSOC;
+        break;
+      case 'S':
+        m_mshr_type = SECTOR_ASSOC;
+        break;
+      default:
+        exit_parse_error();
+    }
+    m_line_sz_log2 = LOGB2(m_line_sz);
+    m_nset_log2 = LOGB2(m_nset);
+    m_valid = true;
+    m_atom_sz = (m_cache_type == SECTOR) ? SECTOR_SIZE : m_line_sz;
+    m_sector_sz_log2 = LOGB2(SECTOR_SIZE);
+    original_m_assoc = m_assoc;
+
+    // For more details about difference between FETCH_ON_WRITE and WRITE
+    // VALIDAE policies
+    // Read: Jouppi, Norman P. "Cache write policies and performance". ISCA 93.
+    // WRITE_ALLOCATE is the old write policy in GPGPU-sim 3.x, that send WRITE
+    // and READ for every write request
+    switch (wap) {
+      case 'N':
+        m_write_alloc_policy = NO_WRITE_ALLOCATE;
+        break;
+      case 'W':
+        m_write_alloc_policy = WRITE_ALLOCATE;
+        break;
+      case 'F':
+        m_write_alloc_policy = FETCH_ON_WRITE;
+        break;
+      case 'L':
+        m_write_alloc_policy = LAZY_FETCH_ON_READ;
+        break;
+      default:
+        exit_parse_error();
+    }
+
+    // detect invalid configuration
+    if (m_alloc_policy == ON_FILL and m_write_policy == WRITE_BACK) {
+      // A writeback cache with allocate-on-fill policy will inevitably lead to
+      // deadlock:
+      // The deadlock happens when an incoming cache-fill evicts a dirty
+      // line, generating a writeback request.  If the memory subsystem
+      // is congested, the interconnection network may not have
+      // sufficient buffer for the writeback request.  This stalls the
+      // incoming cache-fill.  The stall may propagate through the memory
+      // subsystem back to the output port of the same core, creating a
+      // deadlock where the wrtieback request and the incoming cache-fill
+      // are stalling each other.
+      assert(0 &&
+             "Invalid cache configuration: Writeback cache cannot allocate new "
+             "line on fill. ");
+    }
+
+    if ((m_write_alloc_policy == FETCH_ON_WRITE ||
+         m_write_alloc_policy == LAZY_FETCH_ON_READ) &&
+        m_alloc_policy == ON_FILL) {
+      assert(0 &&
+             "Invalid cache configuration: FETCH_ON_WRITE and "
+             "LAZY_FETCH_ON_READ cannot work properly with ON_FILL policy. "
+             "Cache must be ON_MISS. ");
+    }
+    if (m_cache_type == SECTOR) {
+      assert(m_line_sz / SECTOR_SIZE == SECTOR_CHUNCK_SIZE &&
+             m_line_sz % SECTOR_SIZE == 0);
+    }
+
+    // default: port to data array width and granularity = line size
+    if (m_data_port_width == 0) {
+      m_data_port_width = m_line_sz;
+    }
+    assert(m_line_sz % m_data_port_width == 0);
+
+    switch (sif) {
+      case 'H':
+        m_set_index_function = FERMI_HASH_SET_FUNCTION;
+        break;
+      case 'P':
+        m_set_index_function = HASH_IPOLY_FUNCTION;
+        break;
+      case 'C':
+        m_set_index_function = CUSTOM_SET_FUNCTION;
+        break;
+      case 'L':
         m_set_index_function = LINEAR_SET_FUNCTION;
-        m_is_streaming = false;
+        break;
+      default:
+        exit_parse_error();
     }
-    void init(char * config, FuncCache status)
-    {
-    	cache_status= status;
-        assert( config );
-        char ct, rp, wp, ap, mshr_type, wap, sif;
+  }
+  bool disabled() const { return m_disabled; }
+  unsigned get_line_sz() const {
+    assert(m_valid);
+    return m_line_sz;
+  }
+  unsigned get_atom_sz() const {
+    assert(m_valid);
+    return m_atom_sz;
+  }
+  unsigned get_num_lines() const {
+    assert(m_valid);
+    return m_nset * m_assoc;
+  }
+  unsigned get_max_num_lines() const {
+    assert(m_valid);
+    return MAX_DEFAULT_CACHE_SIZE_MULTIBLIER * m_nset * original_m_assoc;
+  }
+  void print(FILE *fp) const {
+    fprintf(fp, "Size = %d B (%d Set x %d-way x %d byte line)\n",
+            m_line_sz * m_nset * m_assoc, m_nset, m_assoc, m_line_sz);
+  }
 
-
-        int ntok = sscanf(config,"%c:%u:%u:%u,%c:%c:%c:%c:%c,%c:%u:%u,%u:%u,%u",
-                          &ct, &m_nset, &m_line_sz, &m_assoc, &rp, &wp, &ap, &wap,
-                          &sif,&mshr_type,&m_mshr_entries,&m_mshr_max_merge,
-                          &m_miss_queue_size, &m_result_fifo_entries,
-                          &m_data_port_width);
-
-        if ( ntok < 12 ) {
-            if ( !strcmp(config,"none") ) {
-                m_disabled = true;
-                return;
-            }
-            exit_parse_error();
-        }
-
-        switch (ct) {
-			   case 'N': m_cache_type = NORMAL; break;
-			   case 'S': m_cache_type = SECTOR; break;
-			   default: exit_parse_error();
-        }
-        switch (rp) {
-               case 'L': m_replacement_policy = LRU; break;
-               case 'F': m_replacement_policy = FIFO; break;
-               default: exit_parse_error();
-        }
-        switch (rp) {
-        case 'L': m_replacement_policy = LRU; break;
-        case 'F': m_replacement_policy = FIFO; break;
-        default: exit_parse_error();
-        }
-        switch (wp) {
-        case 'R': m_write_policy = READ_ONLY; break;
-        case 'B': m_write_policy = WRITE_BACK; break;
-        case 'T': m_write_policy = WRITE_THROUGH; break;
-        case 'E': m_write_policy = WRITE_EVICT; break;
-        case 'L': m_write_policy = LOCAL_WB_GLOBAL_WT; break;
-        default: exit_parse_error();
-        }
-        switch (ap) {
-        case 'm': m_alloc_policy = ON_MISS; break;
-        case 'f': m_alloc_policy = ON_FILL; break;
-        case 's': m_alloc_policy = STREAMING; break;
-        default: exit_parse_error();
-        }
-        if(m_alloc_policy == STREAMING) {
-        	//For streaming cache, we set the alloc policy to be on-fill to remove all line_alloc_fail stalls
-        	//we set the MSHRs to be equal to max allocated cache lines. This is possible by moving TAG to be shared between cache line and MSHR enrty (i.e. for each cache line, there is an MSHR rntey associated with it)
-        	//This is the easiest think we can think about to model (mimic) L1 streaming cache in Pascal and Volta
-        	//Based on our microbenchmakrs, MSHRs entries have been increasing substantially in Pascal and Volta
-        	//For more information about streaming cache, see:
-        	// http://on-demand.gputechconf.com/gtc/2017/presentation/s7798-luke-durant-inside-volta.pdf
-        	// https://ieeexplore.ieee.org/document/8344474/
-        	m_is_streaming = true;
-			m_alloc_policy = ON_FILL;
-			m_mshr_entries = m_nset*m_assoc*MAX_DEFAULT_CACHE_SIZE_MULTIBLIER;
-			if(m_cache_type == SECTOR)
-				m_mshr_entries *=  SECTOR_CHUNCK_SIZE;
-			m_mshr_max_merge = MAX_WARP_PER_SM;
-        }
-        switch (mshr_type) {
-        case 'F': m_mshr_type = TEX_FIFO; assert(ntok==14); break;
-        case 'T': m_mshr_type = SECTOR_TEX_FIFO; assert(ntok==14); break;
-        case 'A': m_mshr_type = ASSOC; break;
-        case 'S' : m_mshr_type = SECTOR_ASSOC; break;
-        default: exit_parse_error();
-        }
-        m_line_sz_log2 = LOGB2(m_line_sz);
-        m_nset_log2 = LOGB2(m_nset);
-        m_valid = true;
-        m_atom_sz = (m_cache_type == SECTOR)? SECTOR_SIZE : m_line_sz;
-        m_sector_sz_log2 = LOGB2(SECTOR_SIZE);
-        original_m_assoc = m_assoc;
-
-        //For more details about difference between FETCH_ON_WRITE and WRITE VALIDAE policies
-        //Read: Jouppi, Norman P. "Cache write policies and performance". ISCA 93.
-        //WRITE_ALLOCATE is the old write policy in GPGPU-sim 3.x, that send WRITE and READ for every write request
-        switch(wap){
-        case 'N': m_write_alloc_policy = NO_WRITE_ALLOCATE; break;
-        case 'W': m_write_alloc_policy = WRITE_ALLOCATE; break;
-        case 'F': m_write_alloc_policy = FETCH_ON_WRITE; break;
-        case 'L': m_write_alloc_policy = LAZY_FETCH_ON_READ; break;
-		default: exit_parse_error();
-        }
-
-        // detect invalid configuration 
-        if (m_alloc_policy == ON_FILL and m_write_policy == WRITE_BACK) {
-            // A writeback cache with allocate-on-fill policy will inevitably lead to deadlock:  
-            // The deadlock happens when an incoming cache-fill evicts a dirty
-            // line, generating a writeback request.  If the memory subsystem
-            // is congested, the interconnection network may not have
-            // sufficient buffer for the writeback request.  This stalls the
-            // incoming cache-fill.  The stall may propagate through the memory
-            // subsystem back to the output port of the same core, creating a
-            // deadlock where the wrtieback request and the incoming cache-fill
-            // are stalling each other.  
-            assert(0 && "Invalid cache configuration: Writeback cache cannot allocate new line on fill. "); 
-        }
-
-        if((m_write_alloc_policy == FETCH_ON_WRITE || m_write_alloc_policy == LAZY_FETCH_ON_READ )&& m_alloc_policy == ON_FILL)
-		{
-			assert(0 && "Invalid cache configuration: FETCH_ON_WRITE and LAZY_FETCH_ON_READ cannot work properly with ON_FILL policy. Cache must be ON_MISS. ");
-		}
-        if(m_cache_type == SECTOR)
-		{
-			assert(m_line_sz / SECTOR_SIZE == SECTOR_CHUNCK_SIZE && m_line_sz % SECTOR_SIZE == 0);
-		}
-
-        // default: port to data array width and granularity = line size 
-        if (m_data_port_width == 0) {
-            m_data_port_width = m_line_sz; 
-        }
-        assert(m_line_sz % m_data_port_width == 0); 
-
-        switch(sif){
-        case 'H': m_set_index_function = FERMI_HASH_SET_FUNCTION; break;
-        case 'P': m_set_index_function = HASH_IPOLY_FUNCTION; break;
-        case 'C': m_set_index_function = CUSTOM_SET_FUNCTION; break;
-        case 'L': m_set_index_function = LINEAR_SET_FUNCTION; break;
-        default: exit_parse_error();
-        }
+  virtual unsigned set_index(new_addr_type addr) const {
+    if (m_set_index_function != LINEAR_SET_FUNCTION) {
+      printf(
+          "\nGPGPU-Sim cache configuration error: Hashing or "
+          "custom set index function selected in configuration "
+          "file for a cache that has not overloaded the set_index "
+          "function\n");
+      abort();
     }
-    bool disabled() const { return m_disabled;}
-    unsigned get_line_sz() const
-    {
-        assert( m_valid );
-        return m_line_sz;
-    }
-    unsigned get_atom_sz() const
-	{
-		assert( m_valid );
-		return m_atom_sz;
-	}
-    unsigned get_num_lines() const
-    {
-        assert( m_valid );
-        return m_nset * m_assoc;
-    }
-    unsigned get_max_num_lines() const
-    {
-        assert( m_valid );
-        return MAX_DEFAULT_CACHE_SIZE_MULTIBLIER * m_nset * original_m_assoc;
-    }
-    void print( FILE *fp ) const
-    {
-        fprintf( fp, "Size = %d B (%d Set x %d-way x %d byte line)\n", 
-                 m_line_sz * m_nset * m_assoc,
-                 m_nset, m_assoc, m_line_sz );
-    }
+    return (addr >> m_line_sz_log2) & (m_nset - 1);
+  }
 
-    virtual unsigned set_index( new_addr_type addr ) const
-    {
-        if(m_set_index_function != LINEAR_SET_FUNCTION){
-            printf("\nGPGPU-Sim cache configuration error: Hashing or "
-                    "custom set index function selected in configuration "
-                    "file for a cache that has not overloaded the set_index "
-                    "function\n");
-            abort();
-        }
-        return(addr >> m_line_sz_log2) & (m_nset-1);
-    }
+  new_addr_type tag(new_addr_type addr) const {
+    // For generality, the tag includes both index and tag. This allows for more
+    // complex set index
+    // calculations that can result in different indexes mapping to the same
+    // set, thus the full
+    // tag + index is required to check for hit/miss. Tag is now identical to
+    // the block address.
 
-    new_addr_type tag( new_addr_type addr ) const
-    {
-        // For generality, the tag includes both index and tag. This allows for more complex set index
-        // calculations that can result in different indexes mapping to the same set, thus the full
-        // tag + index is required to check for hit/miss. Tag is now identical to the block address.
+    // return addr >> (m_line_sz_log2+m_nset_log2);
+    return addr & ~(new_addr_type)(m_line_sz - 1);
+  }
+  new_addr_type block_addr(new_addr_type addr) const {
+    return addr & ~(new_addr_type)(m_line_sz - 1);
+  }
+  new_addr_type mshr_addr(new_addr_type addr) const {
+    return addr & ~(new_addr_type)(m_atom_sz - 1);
+  }
+  enum mshr_config_t get_mshr_type() const { return m_mshr_type; }
+  void set_assoc(unsigned n) {
+    // set new assoc. L1 cache dynamically resized in Volta
+    m_assoc = n;
+  }
+  unsigned get_nset() const {
+    assert(m_valid);
+    return m_nset;
+  }
+  unsigned get_total_size_inKB() const {
+    assert(m_valid);
+    return (m_assoc * m_nset * m_line_sz) / 1024;
+  }
+  bool is_streaming() { return m_is_streaming; }
+  FuncCache get_cache_status() { return cache_status; }
+  char *m_config_string;
+  char *m_config_stringPrefL1;
+  char *m_config_stringPrefShared;
+  FuncCache cache_status;
 
-        //return addr >> (m_line_sz_log2+m_nset_log2);
-        return addr & ~(new_addr_type)(m_line_sz-1);
-    }
-    new_addr_type block_addr( new_addr_type addr ) const
-    {
-        return addr & ~(new_addr_type)(m_line_sz-1);
-    }
-    new_addr_type mshr_addr( new_addr_type addr ) const
-	{
-    	return addr & ~(new_addr_type)(m_atom_sz-1);
-	}
-    enum mshr_config_t get_mshr_type() const
-	{
-    	return m_mshr_type;
-	}
-    void set_assoc(unsigned n)
-	{
-    	//set new assoc. L1 cache dynamically resized in Volta
-    	m_assoc = n;
-	}
-    unsigned get_nset() const
-	{
-		assert( m_valid );
-		return m_nset;
-	}
-    unsigned get_total_size_inKB() const
-	{
-		assert( m_valid );
-		return (m_assoc*m_nset*m_line_sz)/1024;
-	}
-    bool is_streaming() {
-    	return m_is_streaming;
-    }
-    FuncCache get_cache_status() {return cache_status;}
-    char *m_config_string;
-    char *m_config_stringPrefL1;
-    char *m_config_stringPrefShared;
-    FuncCache cache_status;
+ protected:
+  void exit_parse_error() {
+    printf("GPGPU-Sim uArch: cache configuration parsing error (%s)\n",
+           m_config_string);
+    abort();
+  }
 
-protected:
-    void exit_parse_error()
-    {
-        printf("GPGPU-Sim uArch: cache configuration parsing error (%s)\n", m_config_string );
-        abort();
-    }
+  bool m_valid;
+  bool m_disabled;
+  unsigned m_line_sz;
+  unsigned m_line_sz_log2;
+  unsigned m_nset;
+  unsigned m_nset_log2;
+  unsigned m_assoc;
+  unsigned m_atom_sz;
+  unsigned m_sector_sz_log2;
+  unsigned original_m_assoc;
+  bool m_is_streaming;
 
-    bool m_valid;
-    bool m_disabled;
-    unsigned m_line_sz;
-    unsigned m_line_sz_log2;
-    unsigned m_nset;
-    unsigned m_nset_log2;
-    unsigned m_assoc;
-    unsigned m_atom_sz;
-    unsigned m_sector_sz_log2;
-    unsigned original_m_assoc;
-    bool m_is_streaming;
+  enum replacement_policy_t m_replacement_policy;  // 'L' = LRU, 'F' = FIFO
+  enum write_policy_t
+      m_write_policy;  // 'T' = write through, 'B' = write back, 'R' = read only
+  enum allocation_policy_t
+      m_alloc_policy;  // 'm' = allocate on miss, 'f' = allocate on fill
+  enum mshr_config_t m_mshr_type;
+  enum cache_type m_cache_type;
 
-    enum replacement_policy_t m_replacement_policy; // 'L' = LRU, 'F' = FIFO
-    enum write_policy_t m_write_policy;             // 'T' = write through, 'B' = write back, 'R' = read only
-    enum allocation_policy_t m_alloc_policy;        // 'm' = allocate on miss, 'f' = allocate on fill
-    enum mshr_config_t m_mshr_type;
-    enum cache_type m_cache_type;
+  write_allocate_policy_t
+      m_write_alloc_policy;  // 'W' = Write allocate, 'N' = No write allocate
 
-    write_allocate_policy_t m_write_alloc_policy;	// 'W' = Write allocate, 'N' = No write allocate
+  union {
+    unsigned m_mshr_entries;
+    unsigned m_fragment_fifo_entries;
+  };
+  union {
+    unsigned m_mshr_max_merge;
+    unsigned m_request_fifo_entries;
+  };
+  union {
+    unsigned m_miss_queue_size;
+    unsigned m_rob_entries;
+  };
+  unsigned m_result_fifo_entries;
+  unsigned m_data_port_width;  //< number of byte the cache can access per cycle
+  enum set_index_function
+      m_set_index_function;  // Hash, linear, or custom set index function
 
-    union {
-        unsigned m_mshr_entries;
-        unsigned m_fragment_fifo_entries;
-    };
-    union {
-        unsigned m_mshr_max_merge;
-        unsigned m_request_fifo_entries;
-    };
-    union {
-        unsigned m_miss_queue_size;
-        unsigned m_rob_entries;
-    };
-    unsigned m_result_fifo_entries;
-    unsigned m_data_port_width; //< number of byte the cache can access per cycle 
-    enum set_index_function m_set_index_function; // Hash, linear, or custom set index function
-
-    friend class tag_array;
-    friend class baseline_cache;
-    friend class read_only_cache;
-    friend class tex_cache;
-    friend class data_cache;
-    friend class l1_cache;
-    friend class l2_cache;
-    friend class memory_sub_partition;
+  friend class tag_array;
+  friend class baseline_cache;
+  friend class read_only_cache;
+  friend class tex_cache;
+  friend class data_cache;
+  friend class l1_cache;
+  friend class l2_cache;
+  friend class memory_sub_partition;
 };
 
-class l1d_cache_config : public cache_config{
-public:
-	l1d_cache_config() : cache_config(){}
-	virtual unsigned set_index(new_addr_type addr) const;
-    unsigned set_bank(new_addr_type addr) const;
-	unsigned l1_latency;
-	unsigned l1_banks;
+class l1d_cache_config : public cache_config {
+ public:
+  l1d_cache_config() : cache_config() {}
+  virtual unsigned set_index(new_addr_type addr) const;
+  unsigned set_bank(new_addr_type addr) const;
+  unsigned l1_latency;
+  unsigned l1_banks;
 };
 
 class l2_cache_config : public cache_config {
-public:
-	l2_cache_config() : cache_config(){}
-	void init(linear_to_raw_address_translation *address_mapping);
-	virtual unsigned set_index(new_addr_type addr) const;
+ public:
+  l2_cache_config() : cache_config() {}
+  void init(linear_to_raw_address_translation *address_mapping);
+  virtual unsigned set_index(new_addr_type addr) const;
 
-private:
-	linear_to_raw_address_translation *m_address_mapping;
+ private:
+  linear_to_raw_address_translation *m_address_mapping;
 };
 
 class tag_array {
-public:
-    // Use this constructor
-    tag_array(cache_config &config, int core_id, int type_id );
-    ~tag_array();
+ public:
+  // Use this constructor
+  tag_array(cache_config &config, int core_id, int type_id);
+  ~tag_array();
 
-    enum cache_request_status probe( new_addr_type addr, unsigned &idx, mem_fetch* mf, bool probe_mode=false ) const;
-    enum cache_request_status probe( new_addr_type addr, unsigned &idx, mem_access_sector_mask_t mask, bool probe_mode=false, mem_fetch* mf = NULL ) const;
-    enum cache_request_status access( new_addr_type addr, unsigned time, unsigned &idx, mem_fetch* mf );
-    enum cache_request_status access( new_addr_type addr, unsigned time, unsigned &idx, bool &wb, evicted_block_info &evicted, mem_fetch* mf );
+  enum cache_request_status probe(new_addr_type addr, unsigned &idx,
+                                  mem_fetch *mf, bool probe_mode = false) const;
+  enum cache_request_status probe(new_addr_type addr, unsigned &idx,
+                                  mem_access_sector_mask_t mask,
+                                  bool probe_mode = false,
+                                  mem_fetch *mf = NULL) const;
+  enum cache_request_status access(new_addr_type addr, unsigned time,
+                                   unsigned &idx, mem_fetch *mf);
+  enum cache_request_status access(new_addr_type addr, unsigned time,
+                                   unsigned &idx, bool &wb,
+                                   evicted_block_info &evicted, mem_fetch *mf);
 
-    void fill( new_addr_type addr, unsigned time, mem_fetch* mf );
-    void fill( unsigned idx, unsigned time, mem_fetch* mf );
-    void fill( new_addr_type addr, unsigned time, mem_access_sector_mask_t mask );
+  void fill(new_addr_type addr, unsigned time, mem_fetch *mf);
+  void fill(unsigned idx, unsigned time, mem_fetch *mf);
+  void fill(new_addr_type addr, unsigned time, mem_access_sector_mask_t mask);
 
-    unsigned size() const { return m_config.get_num_lines();}
-    cache_block_t* get_block(unsigned idx) { return m_lines[idx];}
+  unsigned size() const { return m_config.get_num_lines(); }
+  cache_block_t *get_block(unsigned idx) { return m_lines[idx]; }
 
-    void flush(); // flush all written entries
-    void invalidate(); // invalidate all entries
-    void new_window();
+  void flush();       // flush all written entries
+  void invalidate();  // invalidate all entries
+  void new_window();
 
-    void print( FILE *stream, unsigned &total_access, unsigned &total_misses ) const;
-    float windowed_miss_rate( ) const;
-    void get_stats(unsigned &total_access, unsigned &total_misses, unsigned &total_hit_res, unsigned &total_res_fail) const;
+  void print(FILE *stream, unsigned &total_access,
+             unsigned &total_misses) const;
+  float windowed_miss_rate() const;
+  void get_stats(unsigned &total_access, unsigned &total_misses,
+                 unsigned &total_hit_res, unsigned &total_res_fail) const;
 
-	void update_cache_parameters(cache_config &config);
-	void add_pending_line(mem_fetch *mf);
-	void remove_pending_line(mem_fetch *mf);
-protected:
-    // This constructor is intended for use only from derived classes that wish to
-    // avoid unnecessary memory allocation that takes place in the
-    // other tag_array constructor
-    tag_array( cache_config &config,
-               int core_id,
-               int type_id,
-               cache_block_t** new_lines );
-    void init( int core_id, int type_id );
+  void update_cache_parameters(cache_config &config);
+  void add_pending_line(mem_fetch *mf);
+  void remove_pending_line(mem_fetch *mf);
 
-protected:
+ protected:
+  // This constructor is intended for use only from derived classes that wish to
+  // avoid unnecessary memory allocation that takes place in the
+  // other tag_array constructor
+  tag_array(cache_config &config, int core_id, int type_id,
+            cache_block_t **new_lines);
+  void init(int core_id, int type_id);
 
-    cache_config &m_config;
+ protected:
+  cache_config &m_config;
 
-    cache_block_t **m_lines; /* nbanks x nset x assoc lines in total */
+  cache_block_t **m_lines; /* nbanks x nset x assoc lines in total */
 
-    unsigned m_access;
-    unsigned m_miss;
-    unsigned m_pending_hit; // number of cache miss that hit a line that is allocated but not filled
-    unsigned m_res_fail;
-    unsigned m_sector_miss;
+  unsigned m_access;
+  unsigned m_miss;
+  unsigned m_pending_hit;  // number of cache miss that hit a line that is
+                           // allocated but not filled
+  unsigned m_res_fail;
+  unsigned m_sector_miss;
 
-    // performance counters for calculating the amount of misses within a time window
-    unsigned m_prev_snapshot_access;
-    unsigned m_prev_snapshot_miss;
-    unsigned m_prev_snapshot_pending_hit;
+  // performance counters for calculating the amount of misses within a time
+  // window
+  unsigned m_prev_snapshot_access;
+  unsigned m_prev_snapshot_miss;
+  unsigned m_prev_snapshot_pending_hit;
 
-    int m_core_id; // which shader core is using this
-    int m_type_id; // what kind of cache is this (normal, texture, constant)
+  int m_core_id;  // which shader core is using this
+  int m_type_id;  // what kind of cache is this (normal, texture, constant)
 
-    bool is_used;  //a flag if the whole cache has ever been accessed before
+  bool is_used;  // a flag if the whole cache has ever been accessed before
 
-    typedef tr1_hash_map<new_addr_type,unsigned> line_table;
-    line_table pending_lines;
+  typedef tr1_hash_map<new_addr_type, unsigned> line_table;
+  line_table pending_lines;
 };
 
 class mshr_table {
-public:
-    mshr_table( unsigned num_entries, unsigned max_merged)
-    : m_num_entries(num_entries),
-    m_max_merged(max_merged)
+ public:
+  mshr_table(unsigned num_entries, unsigned max_merged)
+      : m_num_entries(num_entries),
+        m_max_merged(max_merged)
 #if (tr1_hash_map_ismap == 0)
-    ,m_data(2*num_entries)
+        ,
+        m_data(2 * num_entries)
 #endif
-    {
-    }
+  {
+  }
 
-    /// Checks if there is a pending request to the lower memory level already
-    bool probe( new_addr_type block_addr ) const;
-    /// Checks if there is space for tracking a new memory access
-    bool full( new_addr_type block_addr ) const;
-    /// Add or merge this access
-    void add( new_addr_type block_addr, mem_fetch *mf );
-    /// Returns true if cannot accept new fill responses
-    bool busy() const {return false;}
-    /// Accept a new cache fill response: mark entry ready for processing
-    void mark_ready( new_addr_type block_addr, bool &has_atomic );
-    /// Returns true if ready accesses exist
-    bool access_ready() const {return !m_current_response.empty();}
-    /// Returns next ready access
-    mem_fetch *next_access();
-    void display( FILE *fp ) const;
-    // Returns true if there is a pending read after write
-    bool is_read_after_write_pending(new_addr_type block_addr);
+  /// Checks if there is a pending request to the lower memory level already
+  bool probe(new_addr_type block_addr) const;
+  /// Checks if there is space for tracking a new memory access
+  bool full(new_addr_type block_addr) const;
+  /// Add or merge this access
+  void add(new_addr_type block_addr, mem_fetch *mf);
+  /// Returns true if cannot accept new fill responses
+  bool busy() const { return false; }
+  /// Accept a new cache fill response: mark entry ready for processing
+  void mark_ready(new_addr_type block_addr, bool &has_atomic);
+  /// Returns true if ready accesses exist
+  bool access_ready() const { return !m_current_response.empty(); }
+  /// Returns next ready access
+  mem_fetch *next_access();
+  void display(FILE *fp) const;
+  // Returns true if there is a pending read after write
+  bool is_read_after_write_pending(new_addr_type block_addr);
 
-    void check_mshr_parameters( unsigned num_entries, unsigned max_merged )
-    {
-    	assert(m_num_entries==num_entries && "Change of MSHR parameters between kernels is not allowed");
-    	assert(m_max_merged==max_merged && "Change of MSHR parameters between kernels is not allowed");
-    }
+  void check_mshr_parameters(unsigned num_entries, unsigned max_merged) {
+    assert(m_num_entries == num_entries &&
+           "Change of MSHR parameters between kernels is not allowed");
+    assert(m_max_merged == max_merged &&
+           "Change of MSHR parameters between kernels is not allowed");
+  }
 
-private:
+ private:
+  // finite sized, fully associative table, with a finite maximum number of
+  // merged requests
+  const unsigned m_num_entries;
+  const unsigned m_max_merged;
 
-    // finite sized, fully associative table, with a finite maximum number of merged requests
-    const unsigned m_num_entries;
-    const unsigned m_max_merged;
+  struct mshr_entry {
+    std::list<mem_fetch *> m_list;
+    bool m_has_atomic;
+    mshr_entry() : m_has_atomic(false) {}
+  };
+  typedef tr1_hash_map<new_addr_type, mshr_entry> table;
+  typedef tr1_hash_map<new_addr_type, mshr_entry> line_table;
+  table m_data;
+  line_table pending_lines;
 
-    struct mshr_entry {
-        std::list<mem_fetch*> m_list;
-        bool m_has_atomic; 
-        mshr_entry() : m_has_atomic(false) { }
-    }; 
-    typedef tr1_hash_map<new_addr_type,mshr_entry> table;
-    typedef tr1_hash_map<new_addr_type,mshr_entry> line_table;
-    table m_data;
-    line_table pending_lines;
-
-    // it may take several cycles to process the merged requests
-    bool m_current_response_ready;
-    std::list<new_addr_type> m_current_response;
+  // it may take several cycles to process the merged requests
+  bool m_current_response_ready;
+  std::list<new_addr_type> m_current_response;
 };
 
-
-/***************************************************************** Caches *****************************************************************/
+/***************************************************************** Caches
+ * *****************************************************************/
 ///
-/// Simple struct to maintain cache accesses, misses, pending hits, and reservation fails.
+/// Simple struct to maintain cache accesses, misses, pending hits, and
+/// reservation fails.
 ///
-struct cache_sub_stats{
-    unsigned long long accesses;
-    unsigned long long misses;
-    unsigned long long pending_hits;
-    unsigned long long res_fails;
+struct cache_sub_stats {
+  unsigned long long accesses;
+  unsigned long long misses;
+  unsigned long long pending_hits;
+  unsigned long long res_fails;
 
-    unsigned long long port_available_cycles; 
-    unsigned long long data_port_busy_cycles; 
-    unsigned long long fill_port_busy_cycles; 
+  unsigned long long port_available_cycles;
+  unsigned long long data_port_busy_cycles;
+  unsigned long long fill_port_busy_cycles;
 
-    cache_sub_stats(){
-        clear();
-    }
-    void clear(){
-        accesses = 0;
-        misses = 0;
-        pending_hits = 0;
-        res_fails = 0;
-        port_available_cycles = 0; 
-        data_port_busy_cycles = 0; 
-        fill_port_busy_cycles = 0; 
-    }
-    cache_sub_stats &operator+=(const cache_sub_stats &css){
-        ///
-        /// Overloading += operator to easily accumulate stats
-        ///
-        accesses += css.accesses;
-        misses += css.misses;
-        pending_hits += css.pending_hits;
-        res_fails += css.res_fails;
-        port_available_cycles += css.port_available_cycles; 
-        data_port_busy_cycles += css.data_port_busy_cycles; 
-        fill_port_busy_cycles += css.fill_port_busy_cycles; 
-        return *this;
-    }
+  cache_sub_stats() { clear(); }
+  void clear() {
+    accesses = 0;
+    misses = 0;
+    pending_hits = 0;
+    res_fails = 0;
+    port_available_cycles = 0;
+    data_port_busy_cycles = 0;
+    fill_port_busy_cycles = 0;
+  }
+  cache_sub_stats &operator+=(const cache_sub_stats &css) {
+    ///
+    /// Overloading += operator to easily accumulate stats
+    ///
+    accesses += css.accesses;
+    misses += css.misses;
+    pending_hits += css.pending_hits;
+    res_fails += css.res_fails;
+    port_available_cycles += css.port_available_cycles;
+    data_port_busy_cycles += css.data_port_busy_cycles;
+    fill_port_busy_cycles += css.fill_port_busy_cycles;
+    return *this;
+  }
 
-    cache_sub_stats operator+(const cache_sub_stats &cs){
-        ///
-        /// Overloading + operator to easily accumulate stats
-        ///
-        cache_sub_stats ret;
-        ret.accesses = accesses + cs.accesses;
-        ret.misses = misses + cs.misses;
-        ret.pending_hits = pending_hits + cs.pending_hits;
-        ret.res_fails = res_fails + cs.res_fails;
-        ret.port_available_cycles = port_available_cycles + cs.port_available_cycles; 
-        ret.data_port_busy_cycles = data_port_busy_cycles + cs.data_port_busy_cycles; 
-        ret.fill_port_busy_cycles = fill_port_busy_cycles + cs.fill_port_busy_cycles; 
-        return ret;
-    }
+  cache_sub_stats operator+(const cache_sub_stats &cs) {
+    ///
+    /// Overloading + operator to easily accumulate stats
+    ///
+    cache_sub_stats ret;
+    ret.accesses = accesses + cs.accesses;
+    ret.misses = misses + cs.misses;
+    ret.pending_hits = pending_hits + cs.pending_hits;
+    ret.res_fails = res_fails + cs.res_fails;
+    ret.port_available_cycles =
+        port_available_cycles + cs.port_available_cycles;
+    ret.data_port_busy_cycles =
+        data_port_busy_cycles + cs.data_port_busy_cycles;
+    ret.fill_port_busy_cycles =
+        fill_port_busy_cycles + cs.fill_port_busy_cycles;
+    return ret;
+  }
 
-    void print_port_stats(FILE *fout, const char *cache_name) const; 
+  void print_port_stats(FILE *fout, const char *cache_name) const;
 };
-
 
 // Used for collecting AerialVision per-window statistics
-struct cache_sub_stats_pw{
-    unsigned accesses;
-    unsigned write_misses;
-    unsigned write_hits;
-    unsigned write_pending_hits;
-    unsigned write_res_fails;
+struct cache_sub_stats_pw {
+  unsigned accesses;
+  unsigned write_misses;
+  unsigned write_hits;
+  unsigned write_pending_hits;
+  unsigned write_res_fails;
 
-    unsigned read_misses;
-    unsigned read_hits;
-    unsigned read_pending_hits;
-    unsigned read_res_fails;
+  unsigned read_misses;
+  unsigned read_hits;
+  unsigned read_pending_hits;
+  unsigned read_res_fails;
 
-    cache_sub_stats_pw(){
-        clear();
-    }
-    void clear(){
-        accesses = 0;
-        write_misses = 0;
-        write_hits = 0;
-        write_pending_hits = 0;
-        write_res_fails = 0;
-        read_misses = 0;
-        read_hits = 0;
-        read_pending_hits = 0;
-        read_res_fails = 0;
-    }
-    cache_sub_stats_pw &operator+=(const cache_sub_stats_pw &css){
-        ///
-        /// Overloading += operator to easily accumulate stats
-        ///
-        accesses += css.accesses;
-        write_misses += css.write_misses;
-        read_misses += css.read_misses;
-        write_pending_hits += css.write_pending_hits;
-        read_pending_hits += css.read_pending_hits;
-        write_res_fails += css.write_res_fails;
-        read_res_fails += css.read_res_fails;
-        return *this;
-    }
+  cache_sub_stats_pw() { clear(); }
+  void clear() {
+    accesses = 0;
+    write_misses = 0;
+    write_hits = 0;
+    write_pending_hits = 0;
+    write_res_fails = 0;
+    read_misses = 0;
+    read_hits = 0;
+    read_pending_hits = 0;
+    read_res_fails = 0;
+  }
+  cache_sub_stats_pw &operator+=(const cache_sub_stats_pw &css) {
+    ///
+    /// Overloading += operator to easily accumulate stats
+    ///
+    accesses += css.accesses;
+    write_misses += css.write_misses;
+    read_misses += css.read_misses;
+    write_pending_hits += css.write_pending_hits;
+    read_pending_hits += css.read_pending_hits;
+    write_res_fails += css.write_res_fails;
+    read_res_fails += css.read_res_fails;
+    return *this;
+  }
 
-    cache_sub_stats_pw operator+(const cache_sub_stats_pw &cs){
-        ///
-        /// Overloading + operator to easily accumulate stats
-        ///
-        cache_sub_stats_pw ret;
-        ret.accesses = accesses + cs.accesses;
-        ret.write_misses = write_misses + cs.write_misses;
-        ret.read_misses = read_misses + cs.read_misses;
-        ret.write_pending_hits = write_pending_hits + cs.write_pending_hits;
-        ret.read_pending_hits = read_pending_hits + cs.read_pending_hits;
-        ret.write_res_fails = write_res_fails + cs.write_res_fails;
-        ret.read_res_fails = read_res_fails + cs.read_res_fails;
-        return ret;
-    }
-
+  cache_sub_stats_pw operator+(const cache_sub_stats_pw &cs) {
+    ///
+    /// Overloading + operator to easily accumulate stats
+    ///
+    cache_sub_stats_pw ret;
+    ret.accesses = accesses + cs.accesses;
+    ret.write_misses = write_misses + cs.write_misses;
+    ret.read_misses = read_misses + cs.read_misses;
+    ret.write_pending_hits = write_pending_hits + cs.write_pending_hits;
+    ret.read_pending_hits = read_pending_hits + cs.read_pending_hits;
+    ret.write_res_fails = write_res_fails + cs.write_res_fails;
+    ret.read_res_fails = read_res_fails + cs.read_res_fails;
+    return ret;
+  }
 };
-
 
 ///
 /// Cache_stats
@@ -1039,484 +1067,469 @@ struct cache_sub_stats_pw{
 /// 'cache_request_status' : [mem_access_type][cache_request_status]
 ///
 class cache_stats {
-public:
-    cache_stats();
-    void clear();
-    // Clear AerialVision cache stats after each window
-    void clear_pw();
-    void inc_stats(int access_type, int access_outcome);
-    // Increment AerialVision cache stats
-    void inc_stats_pw(int access_type, int access_outcome);
-    void inc_fail_stats(int access_type, int fail_outcome);
-    enum cache_request_status select_stats_status(enum cache_request_status probe, enum cache_request_status access) const;
-    unsigned long long &operator()(int access_type, int access_outcome, bool fail_outcome);
-    unsigned long long operator()(int access_type, int access_outcome, bool fail_outcome) const;
-    cache_stats operator+(const cache_stats &cs);
-    cache_stats &operator+=(const cache_stats &cs);
-    void print_stats(FILE *fout, const char *cache_name = "Cache_stats") const;
-    void print_fail_stats(FILE *fout, const char *cache_name = "Cache_fail_stats") const;
+ public:
+  cache_stats();
+  void clear();
+  // Clear AerialVision cache stats after each window
+  void clear_pw();
+  void inc_stats(int access_type, int access_outcome);
+  // Increment AerialVision cache stats
+  void inc_stats_pw(int access_type, int access_outcome);
+  void inc_fail_stats(int access_type, int fail_outcome);
+  enum cache_request_status select_stats_status(
+      enum cache_request_status probe, enum cache_request_status access) const;
+  unsigned long long &operator()(int access_type, int access_outcome,
+                                 bool fail_outcome);
+  unsigned long long operator()(int access_type, int access_outcome,
+                                bool fail_outcome) const;
+  cache_stats operator+(const cache_stats &cs);
+  cache_stats &operator+=(const cache_stats &cs);
+  void print_stats(FILE *fout, const char *cache_name = "Cache_stats") const;
+  void print_fail_stats(FILE *fout,
+                        const char *cache_name = "Cache_fail_stats") const;
 
-    unsigned long long get_stats(enum mem_access_type *access_type, unsigned num_access_type, enum cache_request_status *access_status, unsigned num_access_status)  const;
-    void get_sub_stats(struct cache_sub_stats &css) const;
+  unsigned long long get_stats(enum mem_access_type *access_type,
+                               unsigned num_access_type,
+                               enum cache_request_status *access_status,
+                               unsigned num_access_status) const;
+  void get_sub_stats(struct cache_sub_stats &css) const;
 
-    // Get per-window cache stats for AerialVision
-    void get_sub_stats_pw(struct cache_sub_stats_pw &css) const;
+  // Get per-window cache stats for AerialVision
+  void get_sub_stats_pw(struct cache_sub_stats_pw &css) const;
 
-    void sample_cache_port_utility(bool data_port_busy, bool fill_port_busy); 
-private:
-    bool check_valid(int type, int status) const;
-    bool check_fail_valid(int type, int fail) const;
+  void sample_cache_port_utility(bool data_port_busy, bool fill_port_busy);
 
+ private:
+  bool check_valid(int type, int status) const;
+  bool check_fail_valid(int type, int fail) const;
 
-    std::vector< std::vector<unsigned long long> > m_stats;
-    // AerialVision cache stats (per-window)
-    std::vector< std::vector<unsigned long long> > m_stats_pw;
-    std::vector< std::vector<unsigned long long> > m_fail_stats;
+  std::vector<std::vector<unsigned long long> > m_stats;
+  // AerialVision cache stats (per-window)
+  std::vector<std::vector<unsigned long long> > m_stats_pw;
+  std::vector<std::vector<unsigned long long> > m_fail_stats;
 
-    unsigned long long m_cache_port_available_cycles; 
-    unsigned long long m_cache_data_port_busy_cycles; 
-    unsigned long long m_cache_fill_port_busy_cycles; 
+  unsigned long long m_cache_port_available_cycles;
+  unsigned long long m_cache_data_port_busy_cycles;
+  unsigned long long m_cache_fill_port_busy_cycles;
 };
 
 class cache_t {
-public:
-    virtual ~cache_t() {}
-    virtual enum cache_request_status access( new_addr_type addr, mem_fetch *mf, unsigned time, std::list<cache_event> &events ) =  0;
+ public:
+  virtual ~cache_t() {}
+  virtual enum cache_request_status access(new_addr_type addr, mem_fetch *mf,
+                                           unsigned time,
+                                           std::list<cache_event> &events) = 0;
 
-    // accessors for cache bandwidth availability 
-    virtual bool data_port_free() const = 0; 
-    virtual bool fill_port_free() const = 0; 
+  // accessors for cache bandwidth availability
+  virtual bool data_port_free() const = 0;
+  virtual bool fill_port_free() const = 0;
 };
 
-bool was_write_sent( const std::list<cache_event> &events );
-bool was_read_sent( const std::list<cache_event> &events );
-bool was_writeallocate_sent( const std::list<cache_event> &events );
+bool was_write_sent(const std::list<cache_event> &events);
+bool was_read_sent(const std::list<cache_event> &events);
+bool was_writeallocate_sent(const std::list<cache_event> &events);
 
 /// Baseline cache
 /// Implements common functions for read_only_cache and data_cache
 /// Each subclass implements its own 'access' function
 class baseline_cache : public cache_t {
-public:
-    baseline_cache( const char *name, cache_config &config, int core_id, int type_id, mem_fetch_interface *memport,
-                     enum mem_fetch_status status )
-    : m_config(config), m_tag_array(new tag_array(config,core_id,type_id)), 
-      m_mshrs(config.m_mshr_entries,config.m_mshr_max_merge),
-      m_bandwidth_management(config) 
-    {
-        init( name, config, memport, status );
+ public:
+  baseline_cache(const char *name, cache_config &config, int core_id,
+                 int type_id, mem_fetch_interface *memport,
+                 enum mem_fetch_status status)
+      : m_config(config),
+        m_tag_array(new tag_array(config, core_id, type_id)),
+        m_mshrs(config.m_mshr_entries, config.m_mshr_max_merge),
+        m_bandwidth_management(config) {
+    init(name, config, memport, status);
+  }
+
+  void init(const char *name, const cache_config &config,
+            mem_fetch_interface *memport, enum mem_fetch_status status) {
+    m_name = name;
+    assert(config.m_mshr_type == ASSOC || config.m_mshr_type == SECTOR_ASSOC);
+    m_memport = memport;
+    m_miss_queue_status = status;
+  }
+
+  virtual ~baseline_cache() { delete m_tag_array; }
+
+  void update_cache_parameters(cache_config &config) {
+    m_config = config;
+    m_tag_array->update_cache_parameters(config);
+    m_mshrs.check_mshr_parameters(config.m_mshr_entries,
+                                  config.m_mshr_max_merge);
+  }
+
+  virtual enum cache_request_status access(new_addr_type addr, mem_fetch *mf,
+                                           unsigned time,
+                                           std::list<cache_event> &events) = 0;
+  /// Sends next request to lower level of memory
+  void cycle();
+  /// Interface for response from lower memory level (model bandwidth
+  /// restictions in caller)
+  void fill(mem_fetch *mf, unsigned time);
+  /// Checks if mf is waiting to be filled by lower memory level
+  bool waiting_for_fill(mem_fetch *mf);
+  /// Are any (accepted) accesses that had to wait for memory now ready? (does
+  /// not include accesses that "HIT")
+  bool access_ready() const { return m_mshrs.access_ready(); }
+  /// Pop next ready access (does not include accesses that "HIT")
+  mem_fetch *next_access() { return m_mshrs.next_access(); }
+  // flash invalidate all entries in cache
+  void flush() { m_tag_array->flush(); }
+  void invalidate() { m_tag_array->invalidate(); }
+  void print(FILE *fp, unsigned &accesses, unsigned &misses) const;
+  void display_state(FILE *fp) const;
+
+  // Stat collection
+  const cache_stats &get_stats() const { return m_stats; }
+  unsigned get_stats(enum mem_access_type *access_type,
+                     unsigned num_access_type,
+                     enum cache_request_status *access_status,
+                     unsigned num_access_status) const {
+    return m_stats.get_stats(access_type, num_access_type, access_status,
+                             num_access_status);
+  }
+  void get_sub_stats(struct cache_sub_stats &css) const {
+    m_stats.get_sub_stats(css);
+  }
+  // Clear per-window stats for AerialVision support
+  void clear_pw() { m_stats.clear_pw(); }
+  // Per-window sub stats for AerialVision support
+  void get_sub_stats_pw(struct cache_sub_stats_pw &css) const {
+    m_stats.get_sub_stats_pw(css);
+  }
+
+  // accessors for cache bandwidth availability
+  bool data_port_free() const {
+    return m_bandwidth_management.data_port_free();
+  }
+  bool fill_port_free() const {
+    return m_bandwidth_management.fill_port_free();
+  }
+
+  // This is a gapping hole we are poking in the system to quickly handle
+  // filling the cache on cudamemcopies. We don't care about anything other than
+  // L2 state after the memcopy - so just force the tag array to act as though
+  // something is read or written without doing anything else.
+  void force_tag_access(new_addr_type addr, unsigned time,
+                        mem_access_sector_mask_t mask) {
+    m_tag_array->fill(addr, time, mask);
+  }
+
+ protected:
+  // Constructor that can be used by derived classes with custom tag arrays
+  baseline_cache(const char *name, cache_config &config, int core_id,
+                 int type_id, mem_fetch_interface *memport,
+                 enum mem_fetch_status status, tag_array *new_tag_array)
+      : m_config(config),
+        m_tag_array(new_tag_array),
+        m_mshrs(config.m_mshr_entries, config.m_mshr_max_merge),
+        m_bandwidth_management(config) {
+    init(name, config, memport, status);
+  }
+
+ protected:
+  std::string m_name;
+  cache_config &m_config;
+  tag_array *m_tag_array;
+  mshr_table m_mshrs;
+  std::list<mem_fetch *> m_miss_queue;
+  enum mem_fetch_status m_miss_queue_status;
+  mem_fetch_interface *m_memport;
+
+  struct extra_mf_fields {
+    extra_mf_fields() { m_valid = false; }
+    extra_mf_fields(new_addr_type a, new_addr_type ad, unsigned i, unsigned d,
+                    const cache_config &m_config) {
+      m_valid = true;
+      m_block_addr = a;
+      m_addr = ad;
+      m_cache_index = i;
+      m_data_size = d;
+      pending_read = m_config.m_mshr_type == SECTOR_ASSOC
+                         ? m_config.m_line_sz / SECTOR_SIZE
+                         : 0;
     }
+    bool m_valid;
+    new_addr_type m_block_addr;
+    new_addr_type m_addr;
+    unsigned m_cache_index;
+    unsigned m_data_size;
+    // this variable is used when a load request generates multiple load
+    // transactions
+    // For example, a read request from non-sector L1 request sends a request to
+    // sector L2
+    unsigned pending_read;
+  };
 
-    void init( const char *name,
-               const cache_config &config,
-               mem_fetch_interface *memport,
-               enum mem_fetch_status status )
-    {
-        m_name = name;
-        assert(config.m_mshr_type == ASSOC || config.m_mshr_type == SECTOR_ASSOC);
-        m_memport=memport;
-        m_miss_queue_status = status;
-    }
+  typedef std::map<mem_fetch *, extra_mf_fields> extra_mf_fields_lookup;
 
-    virtual ~baseline_cache()
-    {
-        delete m_tag_array;
-    }
+  extra_mf_fields_lookup m_extra_mf_fields;
 
-	void update_cache_parameters(cache_config &config)
-	{
-		m_config=config;
-		m_tag_array->update_cache_parameters(config);
-		m_mshrs.check_mshr_parameters(config.m_mshr_entries,config.m_mshr_max_merge);
-	}
+  cache_stats m_stats;
 
-    virtual enum cache_request_status access( new_addr_type addr, mem_fetch *mf, unsigned time, std::list<cache_event> &events ) =  0;
-    /// Sends next request to lower level of memory
-    void cycle();
-    /// Interface for response from lower memory level (model bandwidth restictions in caller)
-    void fill( mem_fetch *mf, unsigned time );
-    /// Checks if mf is waiting to be filled by lower memory level
-    bool waiting_for_fill( mem_fetch *mf );
-    /// Are any (accepted) accesses that had to wait for memory now ready? (does not include accesses that "HIT")
-    bool access_ready() const {return m_mshrs.access_ready();}
-    /// Pop next ready access (does not include accesses that "HIT")
-    mem_fetch *next_access(){return m_mshrs.next_access();}
-    // flash invalidate all entries in cache
-    void flush(){m_tag_array->flush();}
-    void invalidate(){m_tag_array->invalidate();}
-    void print(FILE *fp, unsigned &accesses, unsigned &misses) const;
-    void display_state( FILE *fp ) const;
+  /// Checks whether this request can be handled on this cycle. num_miss equals
+  /// max # of misses to be handled on this cycle
+  bool miss_queue_full(unsigned num_miss) {
+    return ((m_miss_queue.size() + num_miss) >= m_config.m_miss_queue_size);
+  }
+  /// Read miss handler without writeback
+  void send_read_request(new_addr_type addr, new_addr_type block_addr,
+                         unsigned cache_index, mem_fetch *mf, unsigned time,
+                         bool &do_miss, std::list<cache_event> &events,
+                         bool read_only, bool wa);
+  /// Read miss handler. Check MSHR hit or MSHR available
+  void send_read_request(new_addr_type addr, new_addr_type block_addr,
+                         unsigned cache_index, mem_fetch *mf, unsigned time,
+                         bool &do_miss, bool &wb, evicted_block_info &evicted,
+                         std::list<cache_event> &events, bool read_only,
+                         bool wa);
 
-    // Stat collection
-    const cache_stats &get_stats() const {
-        return m_stats;
-    }
-    unsigned get_stats(enum mem_access_type *access_type, unsigned num_access_type, enum cache_request_status *access_status, unsigned num_access_status)  const{
-        return m_stats.get_stats(access_type, num_access_type, access_status, num_access_status);
-    }
-    void get_sub_stats(struct cache_sub_stats &css) const {
-        m_stats.get_sub_stats(css);
-    }
-    // Clear per-window stats for AerialVision support
-    void clear_pw(){
-        m_stats.clear_pw();
-    }
-    // Per-window sub stats for AerialVision support
-    void get_sub_stats_pw(struct cache_sub_stats_pw &css) const {
-        m_stats.get_sub_stats_pw(css);
-    }
+  /// Sub-class containing all metadata for port bandwidth management
+  class bandwidth_management {
+   public:
+    bandwidth_management(cache_config &config);
 
-    // accessors for cache bandwidth availability 
-    bool data_port_free() const { return m_bandwidth_management.data_port_free(); } 
-    bool fill_port_free() const { return m_bandwidth_management.fill_port_free(); } 
+    /// use the data port based on the outcome and events generated by the
+    /// mem_fetch request
+    void use_data_port(mem_fetch *mf, enum cache_request_status outcome,
+                       const std::list<cache_event> &events);
 
-    // This is a gapping hole we are poking in the system to quickly handle
-    // filling the cache on cudamemcopies. We don't care about anything other than
-    // L2 state after the memcopy - so just force the tag array to act as though
-    // something is read or written without doing anything else.
-    void force_tag_access( new_addr_type addr, unsigned time, mem_access_sector_mask_t mask )
-    {
-        m_tag_array->fill( addr, time, mask );
-    }
+    /// use the fill port
+    void use_fill_port(mem_fetch *mf);
 
-protected:
-    // Constructor that can be used by derived classes with custom tag arrays
-    baseline_cache( const char *name,
-                    cache_config &config,
-                    int core_id,
-                    int type_id,
-                    mem_fetch_interface *memport,
-                    enum mem_fetch_status status,
-                    tag_array* new_tag_array )
-    : m_config(config),
-      m_tag_array( new_tag_array ),
-      m_mshrs(config.m_mshr_entries,config.m_mshr_max_merge), 
-      m_bandwidth_management(config) 
-    {
-        init( name, config, memport, status );
-    }
+    /// called every cache cycle to free up the ports
+    void replenish_port_bandwidth();
 
-protected:
-    std::string m_name;
-    cache_config &m_config;
-    tag_array*  m_tag_array;
-	mshr_table m_mshrs;
-    std::list<mem_fetch*> m_miss_queue;
-    enum mem_fetch_status m_miss_queue_status;
-    mem_fetch_interface *m_memport;
+    /// query for data port availability
+    bool data_port_free() const;
+    /// query for fill port availability
+    bool fill_port_free() const;
 
-    struct extra_mf_fields {
-        extra_mf_fields()  { m_valid = false;}
-        extra_mf_fields( new_addr_type a, new_addr_type ad, unsigned i, unsigned d, const cache_config& m_config)
-        {
-            m_valid = true;
-            m_block_addr = a;
-            m_addr = ad;
-            m_cache_index = i;
-            m_data_size = d;
-        	pending_read = m_config.m_mshr_type == SECTOR_ASSOC? m_config.m_line_sz/SECTOR_SIZE : 0;
+   protected:
+    const cache_config &m_config;
 
-        }
-        bool m_valid;
-        new_addr_type m_block_addr;
-        new_addr_type m_addr;
-        unsigned m_cache_index;
-        unsigned m_data_size;
-        //this variable is used when a load request generates multiple load transactions
-        //For example, a read request from non-sector L1 request sends a request to sector L2
-        unsigned pending_read;
-    };
+    int m_data_port_occupied_cycles;  //< Number of cycle that the data port
+                                      //remains used
+    int m_fill_port_occupied_cycles;  //< Number of cycle that the fill port
+                                      //remains used
+  };
 
-    typedef std::map<mem_fetch*,extra_mf_fields> extra_mf_fields_lookup;
-
-    extra_mf_fields_lookup m_extra_mf_fields;
-
-    cache_stats m_stats;
-
-    /// Checks whether this request can be handled on this cycle. num_miss equals max # of misses to be handled on this cycle
-    bool miss_queue_full(unsigned num_miss){
-    	  return ( (m_miss_queue.size()+num_miss) >= m_config.m_miss_queue_size );
-    }
-    /// Read miss handler without writeback
-    void send_read_request(new_addr_type addr, new_addr_type block_addr, unsigned cache_index, mem_fetch *mf,
-    		unsigned time, bool &do_miss, std::list<cache_event> &events, bool read_only, bool wa);
-    /// Read miss handler. Check MSHR hit or MSHR available
-    void send_read_request(new_addr_type addr, new_addr_type block_addr, unsigned cache_index, mem_fetch *mf,
-    		unsigned time, bool &do_miss, bool &wb, evicted_block_info &evicted, std::list<cache_event> &events, bool read_only, bool wa);
-
-    /// Sub-class containing all metadata for port bandwidth management 
-    class bandwidth_management 
-    {
-    public: 
-        bandwidth_management(cache_config &config); 
-
-        /// use the data port based on the outcome and events generated by the mem_fetch request 
-        void use_data_port(mem_fetch *mf, enum cache_request_status outcome, const std::list<cache_event> &events); 
-
-        /// use the fill port 
-        void use_fill_port(mem_fetch *mf); 
-
-        /// called every cache cycle to free up the ports 
-        void replenish_port_bandwidth(); 
-
-        /// query for data port availability 
-        bool data_port_free() const; 
-        /// query for fill port availability 
-        bool fill_port_free() const; 
-    protected: 
-        const cache_config &m_config; 
-
-        int m_data_port_occupied_cycles; //< Number of cycle that the data port remains used 
-        int m_fill_port_occupied_cycles; //< Number of cycle that the fill port remains used 
-    }; 
-
-    bandwidth_management m_bandwidth_management; 
+  bandwidth_management m_bandwidth_management;
 };
 
 /// Read only cache
 class read_only_cache : public baseline_cache {
-public:
-    read_only_cache( const char *name, cache_config &config, int core_id, int type_id, mem_fetch_interface *memport, enum mem_fetch_status status )
-    : baseline_cache(name,config,core_id,type_id,memport,status){}
+ public:
+  read_only_cache(const char *name, cache_config &config, int core_id,
+                  int type_id, mem_fetch_interface *memport,
+                  enum mem_fetch_status status)
+      : baseline_cache(name, config, core_id, type_id, memport, status) {}
 
-    /// Access cache for read_only_cache: returns RESERVATION_FAIL if request could not be accepted (for any reason)
-    virtual enum cache_request_status access( new_addr_type addr, mem_fetch *mf, unsigned time, std::list<cache_event> &events );
+  /// Access cache for read_only_cache: returns RESERVATION_FAIL if request
+  /// could not be accepted (for any reason)
+  virtual enum cache_request_status access(new_addr_type addr, mem_fetch *mf,
+                                           unsigned time,
+                                           std::list<cache_event> &events);
 
-    virtual ~read_only_cache(){}
+  virtual ~read_only_cache() {}
 
-protected:
-    read_only_cache( const char *name, cache_config &config, int core_id, int type_id, mem_fetch_interface *memport, enum mem_fetch_status status, tag_array* new_tag_array )
-    : baseline_cache(name,config,core_id,type_id,memport,status, new_tag_array){}
+ protected:
+  read_only_cache(const char *name, cache_config &config, int core_id,
+                  int type_id, mem_fetch_interface *memport,
+                  enum mem_fetch_status status, tag_array *new_tag_array)
+      : baseline_cache(name, config, core_id, type_id, memport, status,
+                       new_tag_array) {}
 };
 
 /// Data cache - Implements common functions for L1 and L2 data cache
 class data_cache : public baseline_cache {
-public:
-    data_cache( const char *name, cache_config &config,
-    			int core_id, int type_id, mem_fetch_interface *memport,
-                mem_fetch_allocator *mfcreator, enum mem_fetch_status status,
-                mem_access_type wr_alloc_type, mem_access_type wrbk_type, class gpgpu_sim* gpu )
-    			: baseline_cache(name,config,core_id,type_id,memport,status)
-    {
-        init( mfcreator );
-        m_wr_alloc_type = wr_alloc_type;
-        m_wrbk_type = wrbk_type;
-        m_gpu=gpu;
+ public:
+  data_cache(const char *name, cache_config &config, int core_id, int type_id,
+             mem_fetch_interface *memport, mem_fetch_allocator *mfcreator,
+             enum mem_fetch_status status, mem_access_type wr_alloc_type,
+             mem_access_type wrbk_type, class gpgpu_sim *gpu)
+      : baseline_cache(name, config, core_id, type_id, memport, status) {
+    init(mfcreator);
+    m_wr_alloc_type = wr_alloc_type;
+    m_wrbk_type = wrbk_type;
+    m_gpu = gpu;
+  }
+
+  virtual ~data_cache() {}
+
+  virtual void init(mem_fetch_allocator *mfcreator) {
+    m_memfetch_creator = mfcreator;
+
+    // Set read hit function
+    m_rd_hit = &data_cache::rd_hit_base;
+
+    // Set read miss function
+    m_rd_miss = &data_cache::rd_miss_base;
+
+    // Set write hit function
+    switch (m_config.m_write_policy) {
+      // READ_ONLY is now a separate cache class, config is deprecated
+      case READ_ONLY:
+        assert(0 && "Error: Writable Data_cache set as READ_ONLY\n");
+        break;
+      case WRITE_BACK:
+        m_wr_hit = &data_cache::wr_hit_wb;
+        break;
+      case WRITE_THROUGH:
+        m_wr_hit = &data_cache::wr_hit_wt;
+        break;
+      case WRITE_EVICT:
+        m_wr_hit = &data_cache::wr_hit_we;
+        break;
+      case LOCAL_WB_GLOBAL_WT:
+        m_wr_hit = &data_cache::wr_hit_global_we_local_wb;
+        break;
+      default:
+        assert(0 && "Error: Must set valid cache write policy\n");
+        break;  // Need to set a write hit function
     }
 
-    virtual ~data_cache() {}
-
-    virtual void init( mem_fetch_allocator *mfcreator )
-    {
-        m_memfetch_creator=mfcreator;
-
-        // Set read hit function
-        m_rd_hit = &data_cache::rd_hit_base;
-
-        // Set read miss function
-        m_rd_miss = &data_cache::rd_miss_base;
-
-        // Set write hit function
-        switch(m_config.m_write_policy){
-        // READ_ONLY is now a separate cache class, config is deprecated
-        case READ_ONLY:
-            assert(0 && "Error: Writable Data_cache set as READ_ONLY\n");
-            break; 
-        case WRITE_BACK: m_wr_hit = &data_cache::wr_hit_wb; break;
-        case WRITE_THROUGH: m_wr_hit = &data_cache::wr_hit_wt; break;
-        case WRITE_EVICT: m_wr_hit = &data_cache::wr_hit_we; break;
-        case LOCAL_WB_GLOBAL_WT:
-            m_wr_hit = &data_cache::wr_hit_global_we_local_wb;
-            break;
-        default:
-            assert(0 && "Error: Must set valid cache write policy\n");
-            break; // Need to set a write hit function
-        }
-
-        // Set write miss function
-        switch(m_config.m_write_alloc_policy){
-        case NO_WRITE_ALLOCATE: m_wr_miss = &data_cache::wr_miss_no_wa; break;
-		case WRITE_ALLOCATE: m_wr_miss = &data_cache::wr_miss_wa_naive; break;
-		case FETCH_ON_WRITE: m_wr_miss = &data_cache::wr_miss_wa_fetch_on_write; break;
-		case LAZY_FETCH_ON_READ: m_wr_miss = &data_cache::wr_miss_wa_lazy_fetch_on_read; break;
-        default:
-            assert(0 && "Error: Must set valid cache write miss policy\n");
-            break; // Need to set a write miss function
-        }
+    // Set write miss function
+    switch (m_config.m_write_alloc_policy) {
+      case NO_WRITE_ALLOCATE:
+        m_wr_miss = &data_cache::wr_miss_no_wa;
+        break;
+      case WRITE_ALLOCATE:
+        m_wr_miss = &data_cache::wr_miss_wa_naive;
+        break;
+      case FETCH_ON_WRITE:
+        m_wr_miss = &data_cache::wr_miss_wa_fetch_on_write;
+        break;
+      case LAZY_FETCH_ON_READ:
+        m_wr_miss = &data_cache::wr_miss_wa_lazy_fetch_on_read;
+        break;
+      default:
+        assert(0 && "Error: Must set valid cache write miss policy\n");
+        break;  // Need to set a write miss function
     }
+  }
 
-    virtual enum cache_request_status access( new_addr_type addr,
-                                              mem_fetch *mf,
-                                              unsigned time,
-                                              std::list<cache_event> &events );
-protected:
-    data_cache( const char *name,
-                cache_config &config,
-                int core_id,
-                int type_id,
-                mem_fetch_interface *memport,
-                mem_fetch_allocator *mfcreator,
-                enum mem_fetch_status status,
-                tag_array* new_tag_array,
-                mem_access_type wr_alloc_type,
-                mem_access_type wrbk_type,
-				class gpgpu_sim* gpu )
-    : baseline_cache(name, config, core_id, type_id, memport,status, new_tag_array)
-    {
-        init( mfcreator );
-        m_wr_alloc_type = wr_alloc_type;
-        m_wrbk_type = wrbk_type;
-        m_gpu=gpu;
-    }
+  virtual enum cache_request_status access(new_addr_type addr, mem_fetch *mf,
+                                           unsigned time,
+                                           std::list<cache_event> &events);
 
-    mem_access_type m_wr_alloc_type; // Specifies type of write allocate request (e.g., L1 or L2)
-    mem_access_type m_wrbk_type; // Specifies type of writeback request (e.g., L1 or L2)
-    class gpgpu_sim* m_gpu;
+ protected:
+  data_cache(const char *name, cache_config &config, int core_id, int type_id,
+             mem_fetch_interface *memport, mem_fetch_allocator *mfcreator,
+             enum mem_fetch_status status, tag_array *new_tag_array,
+             mem_access_type wr_alloc_type, mem_access_type wrbk_type,
+             class gpgpu_sim *gpu)
+      : baseline_cache(name, config, core_id, type_id, memport, status,
+                       new_tag_array) {
+    init(mfcreator);
+    m_wr_alloc_type = wr_alloc_type;
+    m_wrbk_type = wrbk_type;
+    m_gpu = gpu;
+  }
 
-    //! A general function that takes the result of a tag_array probe
-    //  and performs the correspding functions based on the cache configuration
-    //  The access fucntion calls this function
-    enum cache_request_status
-        process_tag_probe( bool wr,
-                           enum cache_request_status status,
-                           new_addr_type addr,
-                           unsigned cache_index,
-                           mem_fetch* mf,
-                           unsigned time,
-                           std::list<cache_event>& events );
+  mem_access_type m_wr_alloc_type;  // Specifies type of write allocate request
+                                    // (e.g., L1 or L2)
+  mem_access_type
+      m_wrbk_type;  // Specifies type of writeback request (e.g., L1 or L2)
+  class gpgpu_sim *m_gpu;
 
-protected:
-    mem_fetch_allocator *m_memfetch_creator;
+  //! A general function that takes the result of a tag_array probe
+  //  and performs the correspding functions based on the cache configuration
+  //  The access fucntion calls this function
+  enum cache_request_status process_tag_probe(bool wr,
+                                              enum cache_request_status status,
+                                              new_addr_type addr,
+                                              unsigned cache_index,
+                                              mem_fetch *mf, unsigned time,
+                                              std::list<cache_event> &events);
 
-    // Functions for data cache access
-    /// Sends write request to lower level memory (write or writeback)
-    void send_write_request( mem_fetch *mf,
-                             cache_event request,
-                             unsigned time,
-                             std::list<cache_event> &events);
+ protected:
+  mem_fetch_allocator *m_memfetch_creator;
 
-    // Member Function pointers - Set by configuration options
-    // to the functions below each grouping
-    /******* Write-hit configs *******/
-    enum cache_request_status
-        (data_cache::*m_wr_hit)( new_addr_type addr,
-                                 unsigned cache_index,
-                                 mem_fetch *mf,
-                                 unsigned time,
-                                 std::list<cache_event> &events,
-                                 enum cache_request_status status );
-    /// Marks block as MODIFIED and updates block LRU
-    enum cache_request_status
-        wr_hit_wb( new_addr_type addr,
-                   unsigned cache_index,
-                   mem_fetch *mf,
-                   unsigned time,
-                   std::list<cache_event> &events,
-                   enum cache_request_status status ); // write-back
-    enum cache_request_status
-        wr_hit_wt( new_addr_type addr,
-                   unsigned cache_index,
-                   mem_fetch *mf,
-                   unsigned time,
-                   std::list<cache_event> &events,
-                   enum cache_request_status status ); // write-through
+  // Functions for data cache access
+  /// Sends write request to lower level memory (write or writeback)
+  void send_write_request(mem_fetch *mf, cache_event request, unsigned time,
+                          std::list<cache_event> &events);
 
-    /// Marks block as INVALID and sends write request to lower level memory
-    enum cache_request_status
-        wr_hit_we( new_addr_type addr,
-                   unsigned cache_index,
-                   mem_fetch *mf,
-                   unsigned time,
-                   std::list<cache_event> &events,
-                   enum cache_request_status status ); // write-evict
-    enum cache_request_status
-        wr_hit_global_we_local_wb( new_addr_type addr,
-                                   unsigned cache_index,
-                                   mem_fetch *mf,
-                                   unsigned time,
-                                   std::list<cache_event> &events,
-                                   enum cache_request_status status );
-        // global write-evict, local write-back
+  // Member Function pointers - Set by configuration options
+  // to the functions below each grouping
+  /******* Write-hit configs *******/
+  enum cache_request_status (data_cache::*m_wr_hit)(
+      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+      std::list<cache_event> &events, enum cache_request_status status);
+  /// Marks block as MODIFIED and updates block LRU
+  enum cache_request_status wr_hit_wb(
+      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+      std::list<cache_event> &events,
+      enum cache_request_status status);  // write-back
+  enum cache_request_status wr_hit_wt(
+      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+      std::list<cache_event> &events,
+      enum cache_request_status status);  // write-through
 
+  /// Marks block as INVALID and sends write request to lower level memory
+  enum cache_request_status wr_hit_we(
+      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+      std::list<cache_event> &events,
+      enum cache_request_status status);  // write-evict
+  enum cache_request_status wr_hit_global_we_local_wb(
+      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+      std::list<cache_event> &events, enum cache_request_status status);
+  // global write-evict, local write-back
 
-    /******* Write-miss configs *******/
-    enum cache_request_status
-        (data_cache::*m_wr_miss)( new_addr_type addr,
-                                  unsigned cache_index,
-                                  mem_fetch *mf,
-                                  unsigned time,
-                                  std::list<cache_event> &events,
-                                  enum cache_request_status status );
-    /// Sends read request, and possible write-back request,
-    //  to lower level memory for a write miss with write-allocate
-    enum cache_request_status
-    	wr_miss_wa_naive( new_addr_type addr,
-                        unsigned cache_index,
-                        mem_fetch *mf,
-                        unsigned time,
-                        std::list<cache_event> &events,
-                        enum cache_request_status status ); // write-allocate-send-write-and-read-request
-	enum cache_request_status
-			   wr_miss_wa_fetch_on_write( new_addr_type addr,
-							unsigned cache_index,
-							mem_fetch *mf,
-							unsigned time,
-							std::list<cache_event> &events,
-							enum cache_request_status status ); // write-allocate with fetch-on-every-write
-	enum cache_request_status
-				   wr_miss_wa_lazy_fetch_on_read( new_addr_type addr,
-								unsigned cache_index,
-								mem_fetch *mf,
-								unsigned time,
-								std::list<cache_event> &events,
-								enum cache_request_status status ); // write-allocate with read-fetch-only
-	enum cache_request_status
-				wr_miss_wa_write_validate( new_addr_type addr,
-							unsigned cache_index,
-							mem_fetch *mf,
-							unsigned time,
-							std::list<cache_event> &events,
-							enum cache_request_status status ); // write-allocate that writes with no read fetch
-    enum cache_request_status
-        wr_miss_no_wa( new_addr_type addr,
-                       unsigned cache_index,
-                       mem_fetch *mf,
-                       unsigned time,
-                       std::list<cache_event> &events,
-                       enum cache_request_status status ); // no write-allocate
+  /******* Write-miss configs *******/
+  enum cache_request_status (data_cache::*m_wr_miss)(
+      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+      std::list<cache_event> &events, enum cache_request_status status);
+  /// Sends read request, and possible write-back request,
+  //  to lower level memory for a write miss with write-allocate
+  enum cache_request_status wr_miss_wa_naive(
+      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+      std::list<cache_event> &events,
+      enum cache_request_status
+          status);  // write-allocate-send-write-and-read-request
+  enum cache_request_status wr_miss_wa_fetch_on_write(
+      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+      std::list<cache_event> &events,
+      enum cache_request_status
+          status);  // write-allocate with fetch-on-every-write
+  enum cache_request_status wr_miss_wa_lazy_fetch_on_read(
+      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+      std::list<cache_event> &events,
+      enum cache_request_status status);  // write-allocate with read-fetch-only
+  enum cache_request_status wr_miss_wa_write_validate(
+      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+      std::list<cache_event> &events,
+      enum cache_request_status
+          status);  // write-allocate that writes with no read fetch
+  enum cache_request_status wr_miss_no_wa(
+      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+      std::list<cache_event> &events,
+      enum cache_request_status status);  // no write-allocate
 
-    // Currently no separate functions for reads
-    /******* Read-hit configs *******/
-    enum cache_request_status
-        (data_cache::*m_rd_hit)( new_addr_type addr,
-                                 unsigned cache_index,
-                                 mem_fetch *mf,
-                                 unsigned time,
-                                 std::list<cache_event> &events,
-                                 enum cache_request_status status );
-    enum cache_request_status
-        rd_hit_base( new_addr_type addr,
-                     unsigned cache_index,
-                     mem_fetch *mf,
-                     unsigned time,
-                     std::list<cache_event> &events,
-                     enum cache_request_status status );
+  // Currently no separate functions for reads
+  /******* Read-hit configs *******/
+  enum cache_request_status (data_cache::*m_rd_hit)(
+      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+      std::list<cache_event> &events, enum cache_request_status status);
+  enum cache_request_status rd_hit_base(new_addr_type addr,
+                                        unsigned cache_index, mem_fetch *mf,
+                                        unsigned time,
+                                        std::list<cache_event> &events,
+                                        enum cache_request_status status);
 
-    /******* Read-miss configs *******/
-    enum cache_request_status
-        (data_cache::*m_rd_miss)( new_addr_type addr,
-                                  unsigned cache_index,
-                                  mem_fetch *mf,
-                                  unsigned time,
-                                  std::list<cache_event> &events,
-                                  enum cache_request_status status );
-    enum cache_request_status
-        rd_miss_base( new_addr_type addr,
-                      unsigned cache_index,
-                      mem_fetch*mf,
-                      unsigned time,
-                      std::list<cache_event> &events,
-                      enum cache_request_status status );
-
+  /******* Read-miss configs *******/
+  enum cache_request_status (data_cache::*m_rd_miss)(
+      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+      std::list<cache_event> &events, enum cache_request_status status);
+  enum cache_request_status rd_miss_base(new_addr_type addr,
+                                         unsigned cache_index, mem_fetch *mf,
+                                         unsigned time,
+                                         std::list<cache_event> &events,
+                                         enum cache_request_status status);
 };
 
 /// This is meant to model the first level data cache in Fermi.
@@ -1524,243 +1537,242 @@ protected:
 /// the granularity of individual blocks
 /// (the policy used in fermi according to the CUDA manual)
 class l1_cache : public data_cache {
-public:
-    l1_cache(const char *name, cache_config &config,
-            int core_id, int type_id, mem_fetch_interface *memport,
-            mem_fetch_allocator *mfcreator, enum mem_fetch_status status, class gpgpu_sim* gpu )
-            : data_cache(name,config,core_id,type_id,memport,mfcreator,status, L1_WR_ALLOC_R, L1_WRBK_ACC, gpu){}
+ public:
+  l1_cache(const char *name, cache_config &config, int core_id, int type_id,
+           mem_fetch_interface *memport, mem_fetch_allocator *mfcreator,
+           enum mem_fetch_status status, class gpgpu_sim *gpu)
+      : data_cache(name, config, core_id, type_id, memport, mfcreator, status,
+                   L1_WR_ALLOC_R, L1_WRBK_ACC, gpu) {}
 
-    virtual ~l1_cache(){}
+  virtual ~l1_cache() {}
 
-    virtual enum cache_request_status
-        access( new_addr_type addr,
-                mem_fetch *mf,
-                unsigned time,
-                std::list<cache_event> &events );
+  virtual enum cache_request_status access(new_addr_type addr, mem_fetch *mf,
+                                           unsigned time,
+                                           std::list<cache_event> &events);
 
-protected:
-    l1_cache( const char *name,
-              cache_config &config,
-              int core_id,
-              int type_id,
-              mem_fetch_interface *memport,
-              mem_fetch_allocator *mfcreator,
-              enum mem_fetch_status status,
-              tag_array* new_tag_array,
-			  class gpgpu_sim* gpu)
-    : data_cache( name,
-                  config,
-                  core_id,type_id,memport,mfcreator,status, new_tag_array, L1_WR_ALLOC_R, L1_WRBK_ACC, gpu ){}
-
+ protected:
+  l1_cache(const char *name, cache_config &config, int core_id, int type_id,
+           mem_fetch_interface *memport, mem_fetch_allocator *mfcreator,
+           enum mem_fetch_status status, tag_array *new_tag_array,
+           class gpgpu_sim *gpu)
+      : data_cache(name, config, core_id, type_id, memport, mfcreator, status,
+                   new_tag_array, L1_WR_ALLOC_R, L1_WRBK_ACC, gpu) {}
 };
 
 /// Models second level shared cache with global write-back
 /// and write-allocate policies
 class l2_cache : public data_cache {
-public:
-    l2_cache(const char *name,  cache_config &config,
-            int core_id, int type_id, mem_fetch_interface *memport,
-            mem_fetch_allocator *mfcreator, enum mem_fetch_status status, class gpgpu_sim* gpu )
-            : data_cache(name,config,core_id,type_id,memport,mfcreator,status, L2_WR_ALLOC_R, L2_WRBK_ACC, gpu){}
+ public:
+  l2_cache(const char *name, cache_config &config, int core_id, int type_id,
+           mem_fetch_interface *memport, mem_fetch_allocator *mfcreator,
+           enum mem_fetch_status status, class gpgpu_sim *gpu)
+      : data_cache(name, config, core_id, type_id, memport, mfcreator, status,
+                   L2_WR_ALLOC_R, L2_WRBK_ACC, gpu) {}
 
-    virtual ~l2_cache() {}
+  virtual ~l2_cache() {}
 
-    virtual enum cache_request_status
-        access( new_addr_type addr,
-                mem_fetch *mf,
-                unsigned time,
-                std::list<cache_event> &events );
+  virtual enum cache_request_status access(new_addr_type addr, mem_fetch *mf,
+                                           unsigned time,
+                                           std::list<cache_event> &events);
 };
 
 /*****************************************************************************/
 
 // See the following paper to understand this cache model:
-// 
-// Igehy, et al., Prefetching in a Texture Cache Architecture, 
+//
+// Igehy, et al., Prefetching in a Texture Cache Architecture,
 // Proceedings of the 1998 Eurographics/SIGGRAPH Workshop on Graphics Hardware
 // http://www-graphics.stanford.edu/papers/texture_prefetch/
 class tex_cache : public cache_t {
-public:
-    tex_cache( const char *name, cache_config &config, int core_id, int type_id, mem_fetch_interface *memport,
-               enum mem_fetch_status request_status, 
-               enum mem_fetch_status rob_status )
-    : m_config(config), 
-    m_tags(config,core_id,type_id), 
-    m_fragment_fifo(config.m_fragment_fifo_entries), 
-    m_request_fifo(config.m_request_fifo_entries),
-    m_rob(config.m_rob_entries),
-    m_result_fifo(config.m_result_fifo_entries)
-    {
-        m_name = name;
-        assert(config.m_mshr_type == TEX_FIFO || config.m_mshr_type == SECTOR_TEX_FIFO );
-        assert(config.m_write_policy == READ_ONLY);
-        assert(config.m_alloc_policy == ON_MISS);
-        m_memport=memport;
-        m_cache = new data_block[ config.get_num_lines() ];
-        m_request_queue_status = request_status;
-        m_rob_status = rob_status;
+ public:
+  tex_cache(const char *name, cache_config &config, int core_id, int type_id,
+            mem_fetch_interface *memport, enum mem_fetch_status request_status,
+            enum mem_fetch_status rob_status)
+      : m_config(config),
+        m_tags(config, core_id, type_id),
+        m_fragment_fifo(config.m_fragment_fifo_entries),
+        m_request_fifo(config.m_request_fifo_entries),
+        m_rob(config.m_rob_entries),
+        m_result_fifo(config.m_result_fifo_entries) {
+    m_name = name;
+    assert(config.m_mshr_type == TEX_FIFO ||
+           config.m_mshr_type == SECTOR_TEX_FIFO);
+    assert(config.m_write_policy == READ_ONLY);
+    assert(config.m_alloc_policy == ON_MISS);
+    m_memport = memport;
+    m_cache = new data_block[config.get_num_lines()];
+    m_request_queue_status = request_status;
+    m_rob_status = rob_status;
+  }
+
+  /// Access function for tex_cache
+  /// return values: RESERVATION_FAIL if request could not be accepted
+  /// otherwise returns HIT_RESERVED or MISS; NOTE: *never* returns HIT
+  /// since unlike a normal CPU cache, a "HIT" in texture cache does not
+  /// mean the data is ready (still need to get through fragment fifo)
+  enum cache_request_status access(new_addr_type addr, mem_fetch *mf,
+                                   unsigned time,
+                                   std::list<cache_event> &events);
+  void cycle();
+  /// Place returning cache block into reorder buffer
+  void fill(mem_fetch *mf, unsigned time);
+  /// Are any (accepted) accesses that had to wait for memory now ready? (does
+  /// not include accesses that "HIT")
+  bool access_ready() const { return !m_result_fifo.empty(); }
+  /// Pop next ready access (includes both accesses that "HIT" and those that
+  /// "MISS")
+  mem_fetch *next_access() { return m_result_fifo.pop(); }
+  void display_state(FILE *fp) const;
+
+  // accessors for cache bandwidth availability - stubs for now
+  bool data_port_free() const { return true; }
+  bool fill_port_free() const { return true; }
+
+  // Stat collection
+  const cache_stats &get_stats() const { return m_stats; }
+  unsigned get_stats(enum mem_access_type *access_type,
+                     unsigned num_access_type,
+                     enum cache_request_status *access_status,
+                     unsigned num_access_status) const {
+    return m_stats.get_stats(access_type, num_access_type, access_status,
+                             num_access_status);
+  }
+
+  void get_sub_stats(struct cache_sub_stats &css) const {
+    m_stats.get_sub_stats(css);
+  }
+
+ private:
+  std::string m_name;
+  const cache_config &m_config;
+
+  struct fragment_entry {
+    fragment_entry() {}
+    fragment_entry(mem_fetch *mf, unsigned idx, bool m, unsigned d) {
+      m_request = mf;
+      m_cache_index = idx;
+      m_miss = m;
+      m_data_size = d;
+    }
+    mem_fetch *m_request;    // request information
+    unsigned m_cache_index;  // where to look for data
+    bool m_miss;             // true if sent memory request
+    unsigned m_data_size;
+  };
+
+  struct rob_entry {
+    rob_entry() {
+      m_ready = false;
+      m_time = 0;
+      m_request = NULL;
+    }
+    rob_entry(unsigned i, mem_fetch *mf, new_addr_type a) {
+      m_ready = false;
+      m_index = i;
+      m_time = 0;
+      m_request = mf;
+      m_block_addr = a;
+    }
+    bool m_ready;
+    unsigned m_time;   // which cycle did this entry become ready?
+    unsigned m_index;  // where in cache should block be placed?
+    mem_fetch *m_request;
+    new_addr_type m_block_addr;
+  };
+
+  struct data_block {
+    data_block() { m_valid = false; }
+    bool m_valid;
+    new_addr_type m_block_addr;
+  };
+
+  // TODO: replace fifo_pipeline with this?
+  template <class T>
+  class fifo {
+   public:
+    fifo(unsigned size) {
+      m_size = size;
+      m_num = 0;
+      m_head = 0;
+      m_tail = 0;
+      m_data = new T[size];
+    }
+    bool full() const { return m_num == m_size; }
+    bool empty() const { return m_num == 0; }
+    unsigned size() const { return m_num; }
+    unsigned capacity() const { return m_size; }
+    unsigned push(const T &e) {
+      assert(!full());
+      m_data[m_head] = e;
+      unsigned result = m_head;
+      inc_head();
+      return result;
+    }
+    T pop() {
+      assert(!empty());
+      T result = m_data[m_tail];
+      inc_tail();
+      return result;
+    }
+    const T &peek(unsigned index) const {
+      assert(index < m_size);
+      return m_data[index];
+    }
+    T &peek(unsigned index) {
+      assert(index < m_size);
+      return m_data[index];
+    }
+    T &peek() const { return m_data[m_tail]; }
+    unsigned next_pop_index() const { return m_tail; }
+
+   private:
+    void inc_head() {
+      m_head = (m_head + 1) % m_size;
+      m_num++;
+    }
+    void inc_tail() {
+      assert(m_num > 0);
+      m_tail = (m_tail + 1) % m_size;
+      m_num--;
     }
 
-    /// Access function for tex_cache
-    /// return values: RESERVATION_FAIL if request could not be accepted
-    /// otherwise returns HIT_RESERVED or MISS; NOTE: *never* returns HIT
-    /// since unlike a normal CPU cache, a "HIT" in texture cache does not
-    /// mean the data is ready (still need to get through fragment fifo)
-    enum cache_request_status access( new_addr_type addr, mem_fetch *mf, unsigned time, std::list<cache_event> &events );
-    void cycle();
-    /// Place returning cache block into reorder buffer
-    void fill( mem_fetch *mf, unsigned time );
-    /// Are any (accepted) accesses that had to wait for memory now ready? (does not include accesses that "HIT")
-    bool access_ready() const{return !m_result_fifo.empty();}
-    /// Pop next ready access (includes both accesses that "HIT" and those that "MISS")
-    mem_fetch *next_access(){return m_result_fifo.pop();}
-    void display_state( FILE *fp ) const;
+    unsigned m_head;  // next entry goes here
+    unsigned m_tail;  // oldest entry found here
+    unsigned m_num;   // how many in fifo?
+    unsigned m_size;  // maximum number of entries in fifo
+    T *m_data;
+  };
 
-    // accessors for cache bandwidth availability - stubs for now 
-    bool data_port_free() const { return true; }
-    bool fill_port_free() const { return true; }
+  tag_array m_tags;
+  fifo<fragment_entry> m_fragment_fifo;
+  fifo<mem_fetch *> m_request_fifo;
+  fifo<rob_entry> m_rob;
+  data_block *m_cache;
+  fifo<mem_fetch *> m_result_fifo;  // next completed texture fetch
 
-    // Stat collection
-    const cache_stats &get_stats() const {
-        return m_stats;
+  mem_fetch_interface *m_memport;
+  enum mem_fetch_status m_request_queue_status;
+  enum mem_fetch_status m_rob_status;
+
+  struct extra_mf_fields {
+    extra_mf_fields() { m_valid = false; }
+    extra_mf_fields(unsigned i, const cache_config &m_config) {
+      m_valid = true;
+      m_rob_index = i;
+      pending_read = m_config.m_mshr_type == SECTOR_TEX_FIFO
+                         ? m_config.m_line_sz / SECTOR_SIZE
+                         : 0;
     }
-    unsigned get_stats(enum mem_access_type *access_type, unsigned num_access_type, enum cache_request_status *access_status, unsigned num_access_status) const{
-        return m_stats.get_stats(access_type, num_access_type, access_status, num_access_status);
-    }
+    bool m_valid;
+    unsigned m_rob_index;
+    unsigned pending_read;
+  };
 
-    void get_sub_stats(struct cache_sub_stats &css) const{
-        m_stats.get_sub_stats(css);
-    }
-private:
-    std::string m_name;
-    const cache_config &m_config;
+  cache_stats m_stats;
 
-    struct fragment_entry {
-        fragment_entry() {}
-        fragment_entry( mem_fetch *mf, unsigned idx, bool m, unsigned d )
-        {
-            m_request=mf;
-            m_cache_index=idx;
-            m_miss=m;
-            m_data_size=d;
-        }
-        mem_fetch *m_request;     // request information
-        unsigned   m_cache_index; // where to look for data
-        bool       m_miss;        // true if sent memory request
-        unsigned   m_data_size;
-    };
+  typedef std::map<mem_fetch *, extra_mf_fields> extra_mf_fields_lookup;
 
-    struct rob_entry {
-        rob_entry() { m_ready = false; m_time=0; m_request=NULL;}
-        rob_entry( unsigned i, mem_fetch *mf, new_addr_type a ) 
-        { 
-            m_ready=false; 
-            m_index=i;
-            m_time=0;
-            m_request=mf; 
-            m_block_addr=a;
-        }
-        bool m_ready;
-        unsigned m_time; // which cycle did this entry become ready?
-        unsigned m_index; // where in cache should block be placed?
-        mem_fetch *m_request;
-        new_addr_type m_block_addr;
-    };
-
-    struct data_block {
-        data_block() { m_valid = false;}
-        bool m_valid;
-        new_addr_type m_block_addr;
-    };
-
-    // TODO: replace fifo_pipeline with this?
-    template<class T> class fifo {
-    public:
-        fifo( unsigned size ) 
-        { 
-            m_size=size; 
-            m_num=0; 
-            m_head=0; 
-            m_tail=0; 
-            m_data = new T[size];
-        }
-        bool full() const { return m_num == m_size;}
-        bool empty() const { return m_num == 0;}
-        unsigned size() const { return m_num;}
-        unsigned capacity() const { return m_size;}
-        unsigned push( const T &e ) 
-        { 
-            assert(!full()); 
-            m_data[m_head] = e; 
-            unsigned result = m_head;
-            inc_head(); 
-            return result;
-        }
-        T pop() 
-        { 
-            assert(!empty()); 
-            T result = m_data[m_tail];
-            inc_tail();
-            return result;
-        }
-        const T &peek( unsigned index ) const 
-        { 
-            assert( index < m_size );
-            return m_data[index]; 
-        }
-        T &peek( unsigned index ) 
-        { 
-            assert( index < m_size );
-            return m_data[index]; 
-        }
-        T &peek() const
-        { 
-            return m_data[m_tail]; 
-        }
-        unsigned next_pop_index() const 
-        {
-            return m_tail;
-        }
-    private:
-        void inc_head() { m_head = (m_head+1)%m_size; m_num++;}
-        void inc_tail() { assert(m_num>0); m_tail = (m_tail+1)%m_size; m_num--;}
-
-        unsigned   m_head; // next entry goes here
-        unsigned   m_tail; // oldest entry found here
-        unsigned   m_num;  // how many in fifo?
-        unsigned   m_size; // maximum number of entries in fifo
-        T         *m_data;
-    };
-
-    tag_array               m_tags;
-    fifo<fragment_entry>    m_fragment_fifo;
-    fifo<mem_fetch*>        m_request_fifo;
-    fifo<rob_entry>         m_rob;
-    data_block             *m_cache;
-    fifo<mem_fetch*>        m_result_fifo; // next completed texture fetch
-
-    mem_fetch_interface    *m_memport;
-    enum mem_fetch_status   m_request_queue_status;
-    enum mem_fetch_status   m_rob_status;
-
-    struct extra_mf_fields {
-        extra_mf_fields()  { m_valid = false;}
-        extra_mf_fields( unsigned i, const cache_config &m_config )
-        {
-            m_valid = true;
-            m_rob_index = i;
-            pending_read = m_config.m_mshr_type == SECTOR_TEX_FIFO? m_config.m_line_sz/SECTOR_SIZE : 0;
-        }
-        bool m_valid;
-        unsigned m_rob_index;
-        unsigned pending_read;
-    };
-
-    cache_stats m_stats;
-
-    typedef std::map<mem_fetch*,extra_mf_fields> extra_mf_fields_lookup;
-
-    extra_mf_fields_lookup m_extra_mf_fields;
+  extra_mf_fields_lookup m_extra_mf_fields;
 };
 
 #endif

--- a/src/gpgpu-sim/gpu-cache.h
+++ b/src/gpgpu-sim/gpu-cache.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -32,420 +30,464 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "../abstract_hardware_model.h"
-#include "../tr1_hash_map.h"
 #include "gpu-misc.h"
 #include "mem_fetch.h"
+#include "../abstract_hardware_model.h"
+#include "../tr1_hash_map.h"
 
-#include <iostream>
 #include "addrdec.h"
+#include <iostream>
 
 #define MAX_DEFAULT_CACHE_SIZE_MULTIBLIER 4
 
-enum cache_block_state { INVALID = 0, RESERVED, VALID, MODIFIED };
+enum cache_block_state {
+    INVALID=0,
+    RESERVED,
+    VALID,
+    MODIFIED
+};
 
 enum cache_request_status {
-  HIT = 0,
-  HIT_RESERVED,
-  MISS,
-  RESERVATION_FAIL,
-  SECTOR_MISS,
-  NUM_CACHE_REQUEST_STATUS
+    HIT = 0,
+    HIT_RESERVED,
+    MISS,
+    RESERVATION_FAIL, 
+	SECTOR_MISS,
+    NUM_CACHE_REQUEST_STATUS
 };
 
 enum cache_reservation_fail_reason {
-  LINE_ALLOC_FAIL = 0,  // all line are reserved
-  MISS_QUEUE_FULL,      // MISS queue (i.e. interconnect or DRAM) is full
-  MSHR_ENRTY_FAIL,
-  MSHR_MERGE_ENRTY_FAIL,
-  MSHR_RW_PENDING,
-  NUM_CACHE_RESERVATION_FAIL_STATUS
+	LINE_ALLOC_FAIL= 0,// all line are reserved
+	MISS_QUEUE_FULL,   // MISS queue (i.e. interconnect or DRAM) is full
+	MSHR_ENRTY_FAIL,
+	MSHR_MERGE_ENRTY_FAIL,
+	MSHR_RW_PENDING,
+    NUM_CACHE_RESERVATION_FAIL_STATUS
 };
 
 enum cache_event_type {
-  WRITE_BACK_REQUEST_SENT,
-  READ_REQUEST_SENT,
-  WRITE_REQUEST_SENT,
-  WRITE_ALLOCATE_SENT
+    WRITE_BACK_REQUEST_SENT,
+    READ_REQUEST_SENT,
+    WRITE_REQUEST_SENT,
+	WRITE_ALLOCATE_SENT
 };
 
 struct evicted_block_info {
-  new_addr_type m_block_addr;
-  unsigned m_modified_size;
-  evicted_block_info() {
-    m_block_addr = 0;
-    m_modified_size = 0;
-  }
-  void set_info(new_addr_type block_addr, unsigned modified_size) {
-    m_block_addr = block_addr;
-    m_modified_size = modified_size;
-  }
+	new_addr_type m_block_addr;
+	unsigned m_modified_size;
+	evicted_block_info() {
+		m_block_addr = 0;
+		m_modified_size = 0;
+	}
+	void set_info(new_addr_type block_addr, unsigned modified_size){
+		m_block_addr = block_addr;
+		m_modified_size = modified_size;
+	}
 };
 
 struct cache_event {
-  enum cache_event_type m_cache_event_type;
-  evicted_block_info m_evicted_block;  // if it was write_back event, fill the
-                                       // the evicted block info
+	enum cache_event_type m_cache_event_type;
+	evicted_block_info m_evicted_block; //if it was write_back event, fill the the evicted block info
 
-  cache_event(enum cache_event_type m_cache_event) {
-    m_cache_event_type = m_cache_event;
-  }
+	cache_event(enum cache_event_type m_cache_event){
+		m_cache_event_type = m_cache_event;
+	}
 
-  cache_event(enum cache_event_type cache_event,
-              evicted_block_info evicted_block) {
-    m_cache_event_type = cache_event;
-    m_evicted_block = evicted_block;
-  }
+	cache_event(enum cache_event_type cache_event, evicted_block_info evicted_block){
+	m_cache_event_type = cache_event;
+	m_evicted_block = evicted_block;
+	}
 };
 
-const char *cache_request_status_str(enum cache_request_status status);
+const char * cache_request_status_str(enum cache_request_status status); 
 
 struct cache_block_t {
-  cache_block_t() {
-    m_tag = 0;
-    m_block_addr = 0;
-  }
+    cache_block_t()
+    {
+        m_tag=0;
+        m_block_addr=0;
+    }
 
-  virtual void allocate(new_addr_type tag, new_addr_type block_addr,
-                        unsigned time,
-                        mem_access_sector_mask_t sector_mask) = 0;
-  virtual void fill(unsigned time, mem_access_sector_mask_t sector_mask) = 0;
+    virtual void allocate( new_addr_type tag, new_addr_type block_addr, unsigned time, mem_access_sector_mask_t sector_mask) = 0;
+    virtual void fill( unsigned time, mem_access_sector_mask_t sector_mask) = 0;
 
-  virtual bool is_invalid_line() = 0;
-  virtual bool is_valid_line() = 0;
-  virtual bool is_reserved_line() = 0;
-  virtual bool is_modified_line() = 0;
+    virtual bool is_invalid_line() = 0;
+    virtual bool is_valid_line() = 0;
+    virtual bool is_reserved_line() = 0;
+    virtual bool is_modified_line() = 0;
 
-  virtual enum cache_block_state get_status(
-      mem_access_sector_mask_t sector_mask) = 0;
-  virtual void set_status(enum cache_block_state m_status,
-                          mem_access_sector_mask_t sector_mask) = 0;
+    virtual enum cache_block_state get_status( mem_access_sector_mask_t sector_mask) = 0;
+    virtual void set_status(enum cache_block_state m_status, mem_access_sector_mask_t sector_mask) = 0;
 
-  virtual unsigned long long get_last_access_time() = 0;
-  virtual void set_last_access_time(unsigned long long time,
-                                    mem_access_sector_mask_t sector_mask) = 0;
-  virtual unsigned long long get_alloc_time() = 0;
-  virtual void set_ignore_on_fill(bool m_ignore,
-                                  mem_access_sector_mask_t sector_mask) = 0;
-  virtual void set_modified_on_fill(bool m_modified,
-                                    mem_access_sector_mask_t sector_mask) = 0;
-  virtual unsigned get_modified_size() = 0;
-  virtual void set_m_readable(bool readable,
-                              mem_access_sector_mask_t sector_mask) = 0;
-  virtual bool is_readable(mem_access_sector_mask_t sector_mask) = 0;
-  virtual void print_status() = 0;
-  virtual ~cache_block_t() {}
+    virtual unsigned long long get_last_access_time() = 0;
+    virtual void set_last_access_time(unsigned long long time, mem_access_sector_mask_t sector_mask) = 0;
+    virtual unsigned long long get_alloc_time() = 0;
+    virtual void set_ignore_on_fill(bool m_ignore, mem_access_sector_mask_t sector_mask) = 0;
+    virtual void set_modified_on_fill(bool m_modified, mem_access_sector_mask_t sector_mask) = 0;
+    virtual unsigned get_modified_size() = 0;
+    virtual void set_m_readable(bool readable, mem_access_sector_mask_t sector_mask)=0;
+    virtual bool is_readable(mem_access_sector_mask_t sector_mask)=0;
+    virtual void print_status()=0;
+    virtual ~cache_block_t() {}
 
-  new_addr_type m_tag;
-  new_addr_type m_block_addr;
+
+    new_addr_type    m_tag;
+    new_addr_type    m_block_addr;
+
 };
 
-struct line_cache_block : public cache_block_t {
-  line_cache_block() {
-    m_alloc_time = 0;
-    m_fill_time = 0;
-    m_last_access_time = 0;
-    m_status = INVALID;
-    m_ignore_on_fill_status = false;
-    m_set_modified_on_fill = false;
-    m_readable = true;
-  }
-  void allocate(new_addr_type tag, new_addr_type block_addr, unsigned time,
-                mem_access_sector_mask_t sector_mask) {
-    m_tag = tag;
-    m_block_addr = block_addr;
-    m_alloc_time = time;
-    m_last_access_time = time;
-    m_fill_time = 0;
-    m_status = RESERVED;
-    m_ignore_on_fill_status = false;
-    m_set_modified_on_fill = false;
-  }
-  void fill(unsigned time, mem_access_sector_mask_t sector_mask) {
-    // if(!m_ignore_on_fill_status)
-    //	assert( m_status == RESERVED );
+struct line_cache_block: public cache_block_t  {
+	line_cache_block()
+	    {
+	        m_alloc_time=0;
+	        m_fill_time=0;
+	        m_last_access_time=0;
+	        m_status=INVALID;
+	        m_ignore_on_fill_status = false;
+	        m_set_modified_on_fill = false;
+	        m_readable = true;
+	    }
+	    void allocate( new_addr_type tag, new_addr_type block_addr, unsigned time, mem_access_sector_mask_t sector_mask)
+	    {
+	        m_tag=tag;
+	        m_block_addr=block_addr;
+	        m_alloc_time=time;
+	        m_last_access_time=time;
+	        m_fill_time=0;
+	        m_status=RESERVED;
+	        m_ignore_on_fill_status = false;
+	        m_set_modified_on_fill = false;
+	    }
+		void fill( unsigned time, mem_access_sector_mask_t sector_mask )
+	    {
+	    	//if(!m_ignore_on_fill_status)
+	    	//	assert( m_status == RESERVED );
 
-    m_status = m_set_modified_on_fill ? MODIFIED : VALID;
+	    	m_status = m_set_modified_on_fill? MODIFIED : VALID;
 
-    m_fill_time = time;
-  }
-  virtual bool is_invalid_line() { return m_status == INVALID; }
-  virtual bool is_valid_line() { return m_status == VALID; }
-  virtual bool is_reserved_line() { return m_status == RESERVED; }
-  virtual bool is_modified_line() { return m_status == MODIFIED; }
+	        m_fill_time=time;
+	    }
+		virtual bool is_invalid_line()
+	    {
+	    	return m_status == INVALID;
+	    }
+		virtual bool is_valid_line()
+	    {
+	    	 return m_status == VALID;
+	    }
+		virtual bool is_reserved_line()
+	    {
+	    	 return m_status == RESERVED;
+	    }
+		virtual bool is_modified_line()
+	    {
+	    	return m_status == MODIFIED;
+	    }
 
-  virtual enum cache_block_state get_status(
-      mem_access_sector_mask_t sector_mask) {
-    return m_status;
-  }
-  virtual void set_status(enum cache_block_state status,
-                          mem_access_sector_mask_t sector_mask) {
-    m_status = status;
-  }
-  virtual unsigned long long get_last_access_time() {
-    return m_last_access_time;
-  }
-  virtual void set_last_access_time(unsigned long long time,
-                                    mem_access_sector_mask_t sector_mask) {
-    m_last_access_time = time;
-  }
-  virtual unsigned long long get_alloc_time() { return m_alloc_time; }
-  virtual void set_ignore_on_fill(bool m_ignore,
-                                  mem_access_sector_mask_t sector_mask) {
-    m_ignore_on_fill_status = m_ignore;
-  }
-  virtual void set_modified_on_fill(bool m_modified,
-                                    mem_access_sector_mask_t sector_mask) {
-    m_set_modified_on_fill = m_modified;
-  }
-  virtual unsigned get_modified_size() {
-    return SECTOR_CHUNCK_SIZE * SECTOR_SIZE;  // i.e. cache line size
-  }
-  virtual void set_m_readable(bool readable,
-                              mem_access_sector_mask_t sector_mask) {
-    m_readable = readable;
-  }
-  virtual bool is_readable(mem_access_sector_mask_t sector_mask) {
-    return m_readable;
-  }
-  virtual void print_status() {
-    printf("m_block_addr is %llu, status = %u\n", m_block_addr, m_status);
-  }
+		virtual enum cache_block_state get_status(mem_access_sector_mask_t sector_mask)
+	    {
+	    	return m_status;
+	    }
+		virtual void set_status(enum cache_block_state status, mem_access_sector_mask_t sector_mask)
+	    {
+	    	m_status = status;
+	    }
+		virtual unsigned long long get_last_access_time()
+		{
+			return m_last_access_time;
+		}
+		virtual void set_last_access_time(unsigned long long time, mem_access_sector_mask_t sector_mask)
+	    {
+	    	m_last_access_time = time;
+	    }
+		virtual unsigned long long get_alloc_time()
+	    {
+	    	return m_alloc_time;
+	    }
+		virtual void set_ignore_on_fill(bool m_ignore, mem_access_sector_mask_t sector_mask)
+		{
+			m_ignore_on_fill_status = m_ignore;
+		}
+		virtual void set_modified_on_fill(bool m_modified, mem_access_sector_mask_t sector_mask)
+		{
+	    	m_set_modified_on_fill = m_modified;
+		}
+		virtual unsigned  get_modified_size()
+		{
+			return SECTOR_CHUNCK_SIZE * SECTOR_SIZE;   //i.e. cache line size
+		}
+		virtual void set_m_readable(bool readable, mem_access_sector_mask_t sector_mask)
+		{
+			m_readable = readable;
+		}
+		virtual bool is_readable(mem_access_sector_mask_t sector_mask) {
+			return m_readable;
+		}
+		virtual void print_status() {
+			 printf("m_block_addr is %llu, status = %u\n", m_block_addr, m_status);
+		}
 
- private:
-  unsigned long long m_alloc_time;
-  unsigned long long m_last_access_time;
-  unsigned long long m_fill_time;
-  cache_block_state m_status;
-  bool m_ignore_on_fill_status;
-  bool m_set_modified_on_fill;
-  bool m_readable;
+
+private:
+	    unsigned long long     m_alloc_time;
+	    unsigned long long     m_last_access_time;
+	    unsigned long long     m_fill_time;
+	    cache_block_state    m_status;
+	    bool m_ignore_on_fill_status;
+	    bool m_set_modified_on_fill;
+	    bool m_readable;
 };
 
 struct sector_cache_block : public cache_block_t {
-  sector_cache_block() { init(); }
-
-  void init() {
-    for (unsigned i = 0; i < SECTOR_CHUNCK_SIZE; ++i) {
-      m_sector_alloc_time[i] = 0;
-      m_sector_fill_time[i] = 0;
-      m_last_sector_access_time[i] = 0;
-      m_status[i] = INVALID;
-      m_ignore_on_fill_status[i] = false;
-      m_set_modified_on_fill[i] = false;
-      m_readable[i] = true;
+	sector_cache_block()
+    {
+		init();
     }
-    m_line_alloc_time = 0;
-    m_line_last_access_time = 0;
-    m_line_fill_time = 0;
-  }
 
-  virtual void allocate(new_addr_type tag, new_addr_type block_addr,
-                        unsigned time, mem_access_sector_mask_t sector_mask) {
-    allocate_line(tag, block_addr, time, sector_mask);
-  }
+	void init() {
+		for(unsigned i =0; i< SECTOR_CHUNCK_SIZE; ++i) {
+			m_sector_alloc_time[i]= 0;
+			m_sector_fill_time[i]= 0;
+			m_last_sector_access_time[i]= 0;
+			m_status[i]= INVALID;
+			m_ignore_on_fill_status[i] = false;
+			m_set_modified_on_fill[i] = false;
+			m_readable[i] = true;
+			}
+			m_line_alloc_time=0;
+			m_line_last_access_time=0;
+			m_line_fill_time=0;
+	}
 
-  void allocate_line(new_addr_type tag, new_addr_type block_addr, unsigned time,
-                     mem_access_sector_mask_t sector_mask) {
-    // allocate a new line
-    // assert(m_block_addr != 0 && m_block_addr != block_addr);
-    init();
-    m_tag = tag;
-    m_block_addr = block_addr;
+	virtual void allocate( new_addr_type tag, new_addr_type block_addr, unsigned time, mem_access_sector_mask_t sector_mask )
+    {
+    	allocate_line( tag,  block_addr,  time, sector_mask );
+    }
 
-    unsigned sidx = get_sector_index(sector_mask);
+    void allocate_line( new_addr_type tag, new_addr_type block_addr, unsigned time, mem_access_sector_mask_t sector_mask )
+	{
+		//allocate a new line
+		//assert(m_block_addr != 0 && m_block_addr != block_addr);
+		init();
+		m_tag=tag;
+		m_block_addr=block_addr;
 
-    // set sector stats
-    m_sector_alloc_time[sidx] = time;
-    m_last_sector_access_time[sidx] = time;
-    m_sector_fill_time[sidx] = 0;
-    m_status[sidx] = RESERVED;
-    m_ignore_on_fill_status[sidx] = false;
-    m_set_modified_on_fill[sidx] = false;
+		unsigned sidx = get_sector_index(sector_mask);
 
-    // set line stats
-    m_line_alloc_time = time;  // only set this for the first allocated sector
-    m_line_last_access_time = time;
-    m_line_fill_time = 0;
-  }
+		//set sector stats
+		m_sector_alloc_time[sidx]=time;
+		m_last_sector_access_time[sidx]=time;
+		m_sector_fill_time[sidx]=0;
+		m_status[sidx]=RESERVED;
+		m_ignore_on_fill_status[sidx] = false;
+		m_set_modified_on_fill[sidx] = false;
 
-  void allocate_sector(unsigned time, mem_access_sector_mask_t sector_mask) {
-    // allocate invalid sector of this allocated valid line
-    assert(is_valid_line());
-    unsigned sidx = get_sector_index(sector_mask);
+		//set line stats
+		m_line_alloc_time=time;   //only set this for the first allocated sector
+		m_line_last_access_time=time;
+		m_line_fill_time=0;
+	}
 
-    // set sector stats
-    m_sector_alloc_time[sidx] = time;
-    m_last_sector_access_time[sidx] = time;
-    m_sector_fill_time[sidx] = 0;
-    if (m_status[sidx] == MODIFIED)  // this should be the case only for
-                                     // fetch-on-write policy //TO DO
-      m_set_modified_on_fill[sidx] = true;
-    else
-      m_set_modified_on_fill[sidx] = false;
+    void allocate_sector(unsigned time, mem_access_sector_mask_t sector_mask )
+	{
+    	//allocate invalid sector of this allocated valid line
+    	assert(is_valid_line());
+		unsigned sidx = get_sector_index(sector_mask);
 
-    m_status[sidx] = RESERVED;
-    m_ignore_on_fill_status[sidx] = false;
-    // m_set_modified_on_fill[sidx] = false;
-    m_readable[sidx] = true;
+		//set sector stats
+		m_sector_alloc_time[sidx]=time;
+		m_last_sector_access_time[sidx]=time;
+		m_sector_fill_time[sidx]=0;
+		if(m_status[sidx]==MODIFIED)    //this should be the case only for fetch-on-write policy //TO DO
+			m_set_modified_on_fill[sidx] = true;
+		else
+			m_set_modified_on_fill[sidx] = false;
 
-    // set line stats
-    m_line_last_access_time = time;
-    m_line_fill_time = 0;
-  }
+		m_status[sidx]=RESERVED;
+		m_ignore_on_fill_status[sidx] = false;
+		//m_set_modified_on_fill[sidx] = false;
+		m_readable[sidx] = true;
 
-  virtual void fill(unsigned time, mem_access_sector_mask_t sector_mask) {
-    unsigned sidx = get_sector_index(sector_mask);
+		//set line stats
+		m_line_last_access_time=time;
+		m_line_fill_time=0;
+	}
+
+    virtual void fill( unsigned time, mem_access_sector_mask_t sector_mask)
+    {
+    	unsigned sidx = get_sector_index(sector_mask);
 
     //	if(!m_ignore_on_fill_status[sidx])
     //	         assert( m_status[sidx] == RESERVED );
 
-    m_status[sidx] = m_set_modified_on_fill[sidx] ? MODIFIED : VALID;
+    	m_status[sidx] = m_set_modified_on_fill[sidx]? MODIFIED : VALID;
 
-    m_sector_fill_time[sidx] = time;
-    m_line_fill_time = time;
-  }
-  virtual bool is_invalid_line() {
-    // all the sectors should be invalid
-    for (unsigned i = 0; i < SECTOR_CHUNCK_SIZE; ++i) {
-      if (m_status[i] != INVALID) return false;
+        m_sector_fill_time[sidx]=time;
+        m_line_fill_time=time;
     }
-    return true;
-  }
-  virtual bool is_valid_line() { return !(is_invalid_line()); }
-  virtual bool is_reserved_line() {
-    // if any of the sector is reserved, then the line is reserved
-    for (unsigned i = 0; i < SECTOR_CHUNCK_SIZE; ++i) {
-      if (m_status[i] == RESERVED) return true;
+    virtual bool is_invalid_line() {
+    	//all the sectors should be invalid
+    	for(unsigned i =0; i< SECTOR_CHUNCK_SIZE; ++i) {
+    		if (m_status[i] != INVALID)
+    			return false;
+    	}
+    	return true;
     }
-    return false;
-  }
-  virtual bool is_modified_line() {
-    // if any of the sector is modified, then the line is modified
-    for (unsigned i = 0; i < SECTOR_CHUNCK_SIZE; ++i) {
-      if (m_status[i] == MODIFIED) return true;
+    virtual bool is_valid_line() { return  !(is_invalid_line()); }
+    virtual bool is_reserved_line() {
+    	//if any of the sector is reserved, then the line is reserved
+		for(unsigned i =0; i< SECTOR_CHUNCK_SIZE; ++i) {
+			if (m_status[i] == RESERVED)
+				return true;
+		}
+		return false;
     }
-    return false;
-  }
-
-  virtual enum cache_block_state get_status(
-      mem_access_sector_mask_t sector_mask) {
-    unsigned sidx = get_sector_index(sector_mask);
-
-    return m_status[sidx];
-  }
-
-  virtual void set_status(enum cache_block_state status,
-                          mem_access_sector_mask_t sector_mask) {
-    unsigned sidx = get_sector_index(sector_mask);
-    m_status[sidx] = status;
-  }
-
-  virtual unsigned long long get_last_access_time() {
-    return m_line_last_access_time;
-  }
-
-  virtual void set_last_access_time(unsigned long long time,
-                                    mem_access_sector_mask_t sector_mask) {
-    unsigned sidx = get_sector_index(sector_mask);
-
-    m_last_sector_access_time[sidx] = time;
-    m_line_last_access_time = time;
-  }
-
-  virtual unsigned long long get_alloc_time() { return m_line_alloc_time; }
-
-  virtual void set_ignore_on_fill(bool m_ignore,
-                                  mem_access_sector_mask_t sector_mask) {
-    unsigned sidx = get_sector_index(sector_mask);
-    m_ignore_on_fill_status[sidx] = m_ignore;
-  }
-
-  virtual void set_modified_on_fill(bool m_modified,
-                                    mem_access_sector_mask_t sector_mask) {
-    unsigned sidx = get_sector_index(sector_mask);
-    m_set_modified_on_fill[sidx] = m_modified;
-  }
-
-  virtual void set_m_readable(bool readable,
-                              mem_access_sector_mask_t sector_mask) {
-    unsigned sidx = get_sector_index(sector_mask);
-    m_readable[sidx] = readable;
-  }
-
-  virtual bool is_readable(mem_access_sector_mask_t sector_mask) {
-    unsigned sidx = get_sector_index(sector_mask);
-    return m_readable[sidx];
-  }
-
-  virtual unsigned get_modified_size() {
-    unsigned modified = 0;
-    for (unsigned i = 0; i < SECTOR_CHUNCK_SIZE; ++i) {
-      if (m_status[i] == MODIFIED) modified++;
+    virtual bool is_modified_line() {
+    	//if any of the sector is modified, then the line is modified
+    	for(unsigned i =0; i< SECTOR_CHUNCK_SIZE; ++i) {
+			if (m_status[i] == MODIFIED)
+				return true;
+		}
+		return false;
     }
-    return modified * SECTOR_SIZE;
-  }
 
-  virtual void print_status() {
-    printf("m_block_addr is %llu, status = %u %u %u %u\n", m_block_addr,
-           m_status[0], m_status[1], m_status[2], m_status[3]);
-  }
+    virtual enum cache_block_state get_status(mem_access_sector_mask_t sector_mask)
+	{
+    	unsigned sidx = get_sector_index(sector_mask);
 
- private:
-  unsigned m_sector_alloc_time[SECTOR_CHUNCK_SIZE];
-  unsigned m_last_sector_access_time[SECTOR_CHUNCK_SIZE];
-  unsigned m_sector_fill_time[SECTOR_CHUNCK_SIZE];
-  unsigned m_line_alloc_time;
-  unsigned m_line_last_access_time;
-  unsigned m_line_fill_time;
-  cache_block_state m_status[SECTOR_CHUNCK_SIZE];
-  bool m_ignore_on_fill_status[SECTOR_CHUNCK_SIZE];
-  bool m_set_modified_on_fill[SECTOR_CHUNCK_SIZE];
-  bool m_readable[SECTOR_CHUNCK_SIZE];
+		return m_status[sidx];
+	}
 
-  unsigned get_sector_index(mem_access_sector_mask_t sector_mask) {
-    assert(sector_mask.count() == 1);
-    for (unsigned i = 0; i < SECTOR_CHUNCK_SIZE; ++i) {
-      if (sector_mask.to_ulong() & (1 << i)) return i;
+    virtual void set_status(enum cache_block_state status, mem_access_sector_mask_t sector_mask)
+	{
+		unsigned sidx = get_sector_index(sector_mask);
+		m_status[sidx] = status;
+	}
+
+    virtual unsigned long long get_last_access_time()
+	{
+		return m_line_last_access_time;
+	}
+
+    virtual void set_last_access_time(unsigned long long time, mem_access_sector_mask_t sector_mask)
+	{
+		unsigned sidx = get_sector_index(sector_mask);
+
+		m_last_sector_access_time[sidx] = time;
+		m_line_last_access_time = time;
+	}
+
+    virtual unsigned long long get_alloc_time()
+	{
+		return m_line_alloc_time;
+	}
+
+    virtual void set_ignore_on_fill(bool m_ignore, mem_access_sector_mask_t sector_mask)
+	{
+		unsigned sidx = get_sector_index(sector_mask);
+		m_ignore_on_fill_status[sidx] = m_ignore;
+	}
+
+    virtual void set_modified_on_fill(bool m_modified, mem_access_sector_mask_t sector_mask)
+	{
+		unsigned sidx = get_sector_index(sector_mask);
+		m_set_modified_on_fill[sidx] = m_modified;
+	}
+
+    virtual void set_m_readable(bool readable, mem_access_sector_mask_t sector_mask)
+    {
+    	unsigned sidx = get_sector_index(sector_mask);
+    	m_readable[sidx] = readable;
     }
-  }
+
+    virtual bool is_readable(mem_access_sector_mask_t sector_mask) {
+    	unsigned sidx = get_sector_index(sector_mask);
+    	return m_readable[sidx];
+	}
+
+    virtual unsigned  get_modified_size()
+	{
+		unsigned modified=0;
+		for(unsigned i =0; i< SECTOR_CHUNCK_SIZE; ++i) {
+			if (m_status[i] == MODIFIED)
+				modified++;
+		}
+		return modified * SECTOR_SIZE;
+	}
+
+    virtual void print_status() {
+    	 printf("m_block_addr is %llu, status = %u %u %u %u\n", m_block_addr, m_status[0], m_status[1], m_status[2], m_status[3]);
+    }
+
+
+private:
+    unsigned m_sector_alloc_time[SECTOR_CHUNCK_SIZE];
+    unsigned m_last_sector_access_time[SECTOR_CHUNCK_SIZE];
+    unsigned m_sector_fill_time[SECTOR_CHUNCK_SIZE];
+    unsigned m_line_alloc_time;
+    unsigned m_line_last_access_time;
+    unsigned m_line_fill_time;
+    cache_block_state    m_status[SECTOR_CHUNCK_SIZE];
+    bool m_ignore_on_fill_status[SECTOR_CHUNCK_SIZE];
+    bool m_set_modified_on_fill[SECTOR_CHUNCK_SIZE];
+    bool m_readable[SECTOR_CHUNCK_SIZE];
+
+    unsigned get_sector_index(mem_access_sector_mask_t sector_mask)
+    {
+    	assert(sector_mask.count() == 1);
+    	for(unsigned i =0; i< SECTOR_CHUNCK_SIZE; ++i) {
+    		if(sector_mask.to_ulong() & (1<<i))
+    			return i;
+    	}
+    }
 };
 
-enum replacement_policy_t { LRU, FIFO };
+enum replacement_policy_t {
+    LRU,
+    FIFO
+};
 
 enum write_policy_t {
-  READ_ONLY,
-  WRITE_BACK,
-  WRITE_THROUGH,
-  WRITE_EVICT,
-  LOCAL_WB_GLOBAL_WT
+    READ_ONLY,
+    WRITE_BACK,
+    WRITE_THROUGH,
+    WRITE_EVICT,
+    LOCAL_WB_GLOBAL_WT
 };
 
-enum allocation_policy_t { ON_MISS, ON_FILL, STREAMING };
+enum allocation_policy_t {
+    ON_MISS,
+    ON_FILL,
+	STREAMING
+};
+
 
 enum write_allocate_policy_t {
-  NO_WRITE_ALLOCATE,
-  WRITE_ALLOCATE,
-  FETCH_ON_WRITE,
-  LAZY_FETCH_ON_READ
+	NO_WRITE_ALLOCATE,
+	WRITE_ALLOCATE,
+	FETCH_ON_WRITE,
+	LAZY_FETCH_ON_READ
 };
 
 enum mshr_config_t {
-  TEX_FIFO,         // Tex cache
-  ASSOC,            // normal cache
-  SECTOR_TEX_FIFO,  // Tex cache sends requests to high-level sector cache
-  SECTOR_ASSOC      // normal cache sends requests to high-level sector cache
+    TEX_FIFO, // Tex cache
+    ASSOC, // normal cache
+	SECTOR_TEX_FIFO,  //Tex cache sends requests to high-level sector cache
+	SECTOR_ASSOC // normal cache sends requests to high-level sector cache
 };
 
-enum set_index_function {
-  LINEAR_SET_FUNCTION = 0,
-  BITWISE_XORING_FUNCTION,
-  HASH_IPOLY_FUNCTION,
-  FERMI_HASH_SET_FUNCTION,
-  CUSTOM_SET_FUNCTION
+enum set_index_function{
+	LINEAR_SET_FUNCTION = 0,
+	BITWISE_XORING_FUNCTION,
+	HASH_IPOLY_FUNCTION,
+	FERMI_HASH_SET_FUNCTION,
+    CUSTOM_SET_FUNCTION
 };
 
-enum cache_type { NORMAL = 0, SECTOR };
+enum cache_type{
+    NORMAL = 0,
+    SECTOR
+};
 
 #define MAX_WARP_PER_SHADER 64
 #define INCT_TOTAL_BUFFER 64
@@ -454,611 +496,541 @@ enum cache_type { NORMAL = 0, SECTOR };
 #define MAX_WARP_PER_SHADER 64
 
 class cache_config {
- public:
-  cache_config() {
-    m_valid = false;
-    m_disabled = false;
-    m_config_string = NULL;  // set by option parser
-    m_config_stringPrefL1 = NULL;
-    m_config_stringPrefShared = NULL;
-    m_data_port_width = 0;
-    m_set_index_function = LINEAR_SET_FUNCTION;
-    m_is_streaming = false;
-  }
-  void init(char *config, FuncCache status) {
-    cache_status = status;
-    assert(config);
-    char ct, rp, wp, ap, mshr_type, wap, sif;
-
-    int ntok =
-        sscanf(config, "%c:%u:%u:%u,%c:%c:%c:%c:%c,%c:%u:%u,%u:%u,%u", &ct,
-               &m_nset, &m_line_sz, &m_assoc, &rp, &wp, &ap, &wap, &sif,
-               &mshr_type, &m_mshr_entries, &m_mshr_max_merge,
-               &m_miss_queue_size, &m_result_fifo_entries, &m_data_port_width);
-
-    if (ntok < 12) {
-      if (!strcmp(config, "none")) {
-        m_disabled = true;
-        return;
-      }
-      exit_parse_error();
-    }
-
-    switch (ct) {
-      case 'N':
-        m_cache_type = NORMAL;
-        break;
-      case 'S':
-        m_cache_type = SECTOR;
-        break;
-      default:
-        exit_parse_error();
-    }
-    switch (rp) {
-      case 'L':
-        m_replacement_policy = LRU;
-        break;
-      case 'F':
-        m_replacement_policy = FIFO;
-        break;
-      default:
-        exit_parse_error();
-    }
-    switch (rp) {
-      case 'L':
-        m_replacement_policy = LRU;
-        break;
-      case 'F':
-        m_replacement_policy = FIFO;
-        break;
-      default:
-        exit_parse_error();
-    }
-    switch (wp) {
-      case 'R':
-        m_write_policy = READ_ONLY;
-        break;
-      case 'B':
-        m_write_policy = WRITE_BACK;
-        break;
-      case 'T':
-        m_write_policy = WRITE_THROUGH;
-        break;
-      case 'E':
-        m_write_policy = WRITE_EVICT;
-        break;
-      case 'L':
-        m_write_policy = LOCAL_WB_GLOBAL_WT;
-        break;
-      default:
-        exit_parse_error();
-    }
-    switch (ap) {
-      case 'm':
-        m_alloc_policy = ON_MISS;
-        break;
-      case 'f':
-        m_alloc_policy = ON_FILL;
-        break;
-      case 's':
-        m_alloc_policy = STREAMING;
-        break;
-      default:
-        exit_parse_error();
-    }
-    if (m_alloc_policy == STREAMING) {
-      // For streaming cache, we set the alloc policy to be on-fill to remove
-      // all line_alloc_fail stalls
-      // we set the MSHRs to be equal to max allocated cache lines. This is
-      // possible by moving TAG to be shared between cache line and MSHR enrty
-      // (i.e. for each cache line, there is an MSHR rntey associated with it)
-      // This is the easiest think we can think about to model (mimic) L1
-      // streaming cache in Pascal and Volta
-      // Based on our microbenchmakrs, MSHRs entries have been increasing
-      // substantially in Pascal and Volta
-      // For more information about streaming cache, see:
-      // http://on-demand.gputechconf.com/gtc/2017/presentation/s7798-luke-durant-inside-volta.pdf
-      // https://ieeexplore.ieee.org/document/8344474/
-      m_is_streaming = true;
-      m_alloc_policy = ON_FILL;
-      m_mshr_entries = m_nset * m_assoc * MAX_DEFAULT_CACHE_SIZE_MULTIBLIER;
-      if (m_cache_type == SECTOR) m_mshr_entries *= SECTOR_CHUNCK_SIZE;
-      m_mshr_max_merge = MAX_WARP_PER_SM;
-    }
-    switch (mshr_type) {
-      case 'F':
-        m_mshr_type = TEX_FIFO;
-        assert(ntok == 14);
-        break;
-      case 'T':
-        m_mshr_type = SECTOR_TEX_FIFO;
-        assert(ntok == 14);
-        break;
-      case 'A':
-        m_mshr_type = ASSOC;
-        break;
-      case 'S':
-        m_mshr_type = SECTOR_ASSOC;
-        break;
-      default:
-        exit_parse_error();
-    }
-    m_line_sz_log2 = LOGB2(m_line_sz);
-    m_nset_log2 = LOGB2(m_nset);
-    m_valid = true;
-    m_atom_sz = (m_cache_type == SECTOR) ? SECTOR_SIZE : m_line_sz;
-    m_sector_sz_log2 = LOGB2(SECTOR_SIZE);
-    original_m_assoc = m_assoc;
-
-    // For more details about difference between FETCH_ON_WRITE and WRITE
-    // VALIDAE policies
-    // Read: Jouppi, Norman P. "Cache write policies and performance". ISCA 93.
-    // WRITE_ALLOCATE is the old write policy in GPGPU-sim 3.x, that send WRITE
-    // and READ for every write request
-    switch (wap) {
-      case 'N':
-        m_write_alloc_policy = NO_WRITE_ALLOCATE;
-        break;
-      case 'W':
-        m_write_alloc_policy = WRITE_ALLOCATE;
-        break;
-      case 'F':
-        m_write_alloc_policy = FETCH_ON_WRITE;
-        break;
-      case 'L':
-        m_write_alloc_policy = LAZY_FETCH_ON_READ;
-        break;
-      default:
-        exit_parse_error();
-    }
-
-    // detect invalid configuration
-    if (m_alloc_policy == ON_FILL and m_write_policy == WRITE_BACK) {
-      // A writeback cache with allocate-on-fill policy will inevitably lead to
-      // deadlock:
-      // The deadlock happens when an incoming cache-fill evicts a dirty
-      // line, generating a writeback request.  If the memory subsystem
-      // is congested, the interconnection network may not have
-      // sufficient buffer for the writeback request.  This stalls the
-      // incoming cache-fill.  The stall may propagate through the memory
-      // subsystem back to the output port of the same core, creating a
-      // deadlock where the wrtieback request and the incoming cache-fill
-      // are stalling each other.
-      assert(0 &&
-             "Invalid cache configuration: Writeback cache cannot allocate new "
-             "line on fill. ");
-    }
-
-    if ((m_write_alloc_policy == FETCH_ON_WRITE ||
-         m_write_alloc_policy == LAZY_FETCH_ON_READ) &&
-        m_alloc_policy == ON_FILL) {
-      assert(0 &&
-             "Invalid cache configuration: FETCH_ON_WRITE and "
-             "LAZY_FETCH_ON_READ cannot work properly with ON_FILL policy. "
-             "Cache must be ON_MISS. ");
-    }
-    if (m_cache_type == SECTOR) {
-      assert(m_line_sz / SECTOR_SIZE == SECTOR_CHUNCK_SIZE &&
-             m_line_sz % SECTOR_SIZE == 0);
-    }
-
-    // default: port to data array width and granularity = line size
-    if (m_data_port_width == 0) {
-      m_data_port_width = m_line_sz;
-    }
-    assert(m_line_sz % m_data_port_width == 0);
-
-    switch (sif) {
-      case 'H':
-        m_set_index_function = FERMI_HASH_SET_FUNCTION;
-        break;
-      case 'P':
-        m_set_index_function = HASH_IPOLY_FUNCTION;
-        break;
-      case 'C':
-        m_set_index_function = CUSTOM_SET_FUNCTION;
-        break;
-      case 'L':
+public:
+    cache_config() 
+    { 
+        m_valid = false; 
+        m_disabled = false;
+        m_config_string = NULL; // set by option parser
+        m_config_stringPrefL1 = NULL;
+        m_config_stringPrefShared = NULL;
+        m_data_port_width = 0;
         m_set_index_function = LINEAR_SET_FUNCTION;
-        break;
-      default:
-        exit_parse_error();
+        m_is_streaming = false;
     }
-  }
-  bool disabled() const { return m_disabled; }
-  unsigned get_line_sz() const {
-    assert(m_valid);
-    return m_line_sz;
-  }
-  unsigned get_atom_sz() const {
-    assert(m_valid);
-    return m_atom_sz;
-  }
-  unsigned get_num_lines() const {
-    assert(m_valid);
-    return m_nset * m_assoc;
-  }
-  unsigned get_max_num_lines() const {
-    assert(m_valid);
-    return MAX_DEFAULT_CACHE_SIZE_MULTIBLIER * m_nset * original_m_assoc;
-  }
-  void print(FILE *fp) const {
-    fprintf(fp, "Size = %d B (%d Set x %d-way x %d byte line)\n",
-            m_line_sz * m_nset * m_assoc, m_nset, m_assoc, m_line_sz);
-  }
+    void init(char * config, FuncCache status)
+    {
+    	cache_status= status;
+        assert( config );
+        char ct, rp, wp, ap, mshr_type, wap, sif;
 
-  virtual unsigned set_index(new_addr_type addr) const {
-    if (m_set_index_function != LINEAR_SET_FUNCTION) {
-      printf(
-          "\nGPGPU-Sim cache configuration error: Hashing or "
-          "custom set index function selected in configuration "
-          "file for a cache that has not overloaded the set_index "
-          "function\n");
-      abort();
+
+        int ntok = sscanf(config,"%c:%u:%u:%u,%c:%c:%c:%c:%c,%c:%u:%u,%u:%u,%u",
+                          &ct, &m_nset, &m_line_sz, &m_assoc, &rp, &wp, &ap, &wap,
+                          &sif,&mshr_type,&m_mshr_entries,&m_mshr_max_merge,
+                          &m_miss_queue_size, &m_result_fifo_entries,
+                          &m_data_port_width);
+
+        if ( ntok < 12 ) {
+            if ( !strcmp(config,"none") ) {
+                m_disabled = true;
+                return;
+            }
+            exit_parse_error();
+        }
+
+        switch (ct) {
+			   case 'N': m_cache_type = NORMAL; break;
+			   case 'S': m_cache_type = SECTOR; break;
+			   default: exit_parse_error();
+        }
+        switch (rp) {
+               case 'L': m_replacement_policy = LRU; break;
+               case 'F': m_replacement_policy = FIFO; break;
+               default: exit_parse_error();
+        }
+        switch (rp) {
+        case 'L': m_replacement_policy = LRU; break;
+        case 'F': m_replacement_policy = FIFO; break;
+        default: exit_parse_error();
+        }
+        switch (wp) {
+        case 'R': m_write_policy = READ_ONLY; break;
+        case 'B': m_write_policy = WRITE_BACK; break;
+        case 'T': m_write_policy = WRITE_THROUGH; break;
+        case 'E': m_write_policy = WRITE_EVICT; break;
+        case 'L': m_write_policy = LOCAL_WB_GLOBAL_WT; break;
+        default: exit_parse_error();
+        }
+        switch (ap) {
+        case 'm': m_alloc_policy = ON_MISS; break;
+        case 'f': m_alloc_policy = ON_FILL; break;
+        case 's': m_alloc_policy = STREAMING; break;
+        default: exit_parse_error();
+        }
+        if(m_alloc_policy == STREAMING) {
+        	//For streaming cache, we set the alloc policy to be on-fill to remove all line_alloc_fail stalls
+        	//we set the MSHRs to be equal to max allocated cache lines. This is possible by moving TAG to be shared between cache line and MSHR enrty (i.e. for each cache line, there is an MSHR rntey associated with it)
+        	//This is the easiest think we can think about to model (mimic) L1 streaming cache in Pascal and Volta
+        	//Based on our microbenchmakrs, MSHRs entries have been increasing substantially in Pascal and Volta
+        	//For more information about streaming cache, see:
+        	// http://on-demand.gputechconf.com/gtc/2017/presentation/s7798-luke-durant-inside-volta.pdf
+        	// https://ieeexplore.ieee.org/document/8344474/
+        	m_is_streaming = true;
+			m_alloc_policy = ON_FILL;
+			m_mshr_entries = m_nset*m_assoc*MAX_DEFAULT_CACHE_SIZE_MULTIBLIER;
+			if(m_cache_type == SECTOR)
+				m_mshr_entries *=  SECTOR_CHUNCK_SIZE;
+			m_mshr_max_merge = MAX_WARP_PER_SM;
+        }
+        switch (mshr_type) {
+        case 'F': m_mshr_type = TEX_FIFO; assert(ntok==14); break;
+        case 'T': m_mshr_type = SECTOR_TEX_FIFO; assert(ntok==14); break;
+        case 'A': m_mshr_type = ASSOC; break;
+        case 'S' : m_mshr_type = SECTOR_ASSOC; break;
+        default: exit_parse_error();
+        }
+        m_line_sz_log2 = LOGB2(m_line_sz);
+        m_nset_log2 = LOGB2(m_nset);
+        m_valid = true;
+        m_atom_sz = (m_cache_type == SECTOR)? SECTOR_SIZE : m_line_sz;
+        m_sector_sz_log2 = LOGB2(SECTOR_SIZE);
+        original_m_assoc = m_assoc;
+
+        //For more details about difference between FETCH_ON_WRITE and WRITE VALIDAE policies
+        //Read: Jouppi, Norman P. "Cache write policies and performance". ISCA 93.
+        //WRITE_ALLOCATE is the old write policy in GPGPU-sim 3.x, that send WRITE and READ for every write request
+        switch(wap){
+        case 'N': m_write_alloc_policy = NO_WRITE_ALLOCATE; break;
+        case 'W': m_write_alloc_policy = WRITE_ALLOCATE; break;
+        case 'F': m_write_alloc_policy = FETCH_ON_WRITE; break;
+        case 'L': m_write_alloc_policy = LAZY_FETCH_ON_READ; break;
+		default: exit_parse_error();
+        }
+
+        // detect invalid configuration 
+        if (m_alloc_policy == ON_FILL and m_write_policy == WRITE_BACK) {
+            // A writeback cache with allocate-on-fill policy will inevitably lead to deadlock:  
+            // The deadlock happens when an incoming cache-fill evicts a dirty
+            // line, generating a writeback request.  If the memory subsystem
+            // is congested, the interconnection network may not have
+            // sufficient buffer for the writeback request.  This stalls the
+            // incoming cache-fill.  The stall may propagate through the memory
+            // subsystem back to the output port of the same core, creating a
+            // deadlock where the wrtieback request and the incoming cache-fill
+            // are stalling each other.  
+            assert(0 && "Invalid cache configuration: Writeback cache cannot allocate new line on fill. "); 
+        }
+
+        if((m_write_alloc_policy == FETCH_ON_WRITE || m_write_alloc_policy == LAZY_FETCH_ON_READ )&& m_alloc_policy == ON_FILL)
+		{
+			assert(0 && "Invalid cache configuration: FETCH_ON_WRITE and LAZY_FETCH_ON_READ cannot work properly with ON_FILL policy. Cache must be ON_MISS. ");
+		}
+        if(m_cache_type == SECTOR)
+		{
+			assert(m_line_sz / SECTOR_SIZE == SECTOR_CHUNCK_SIZE && m_line_sz % SECTOR_SIZE == 0);
+		}
+
+        // default: port to data array width and granularity = line size 
+        if (m_data_port_width == 0) {
+            m_data_port_width = m_line_sz; 
+        }
+        assert(m_line_sz % m_data_port_width == 0); 
+
+        switch(sif){
+        case 'H': m_set_index_function = FERMI_HASH_SET_FUNCTION; break;
+        case 'P': m_set_index_function = HASH_IPOLY_FUNCTION; break;
+        case 'C': m_set_index_function = CUSTOM_SET_FUNCTION; break;
+        case 'L': m_set_index_function = LINEAR_SET_FUNCTION; break;
+        default: exit_parse_error();
+        }
     }
-    return (addr >> m_line_sz_log2) & (m_nset - 1);
-  }
+    bool disabled() const { return m_disabled;}
+    unsigned get_line_sz() const
+    {
+        assert( m_valid );
+        return m_line_sz;
+    }
+    unsigned get_atom_sz() const
+	{
+		assert( m_valid );
+		return m_atom_sz;
+	}
+    unsigned get_num_lines() const
+    {
+        assert( m_valid );
+        return m_nset * m_assoc;
+    }
+    unsigned get_max_num_lines() const
+    {
+        assert( m_valid );
+        return MAX_DEFAULT_CACHE_SIZE_MULTIBLIER * m_nset * original_m_assoc;
+    }
+    void print( FILE *fp ) const
+    {
+        fprintf( fp, "Size = %d B (%d Set x %d-way x %d byte line)\n", 
+                 m_line_sz * m_nset * m_assoc,
+                 m_nset, m_assoc, m_line_sz );
+    }
 
-  new_addr_type tag(new_addr_type addr) const {
-    // For generality, the tag includes both index and tag. This allows for more
-    // complex set index
-    // calculations that can result in different indexes mapping to the same
-    // set, thus the full
-    // tag + index is required to check for hit/miss. Tag is now identical to
-    // the block address.
+    virtual unsigned set_index( new_addr_type addr ) const
+    {
+        if(m_set_index_function != LINEAR_SET_FUNCTION){
+            printf("\nGPGPU-Sim cache configuration error: Hashing or "
+                    "custom set index function selected in configuration "
+                    "file for a cache that has not overloaded the set_index "
+                    "function\n");
+            abort();
+        }
+        return(addr >> m_line_sz_log2) & (m_nset-1);
+    }
 
-    // return addr >> (m_line_sz_log2+m_nset_log2);
-    return addr & ~(new_addr_type)(m_line_sz - 1);
-  }
-  new_addr_type block_addr(new_addr_type addr) const {
-    return addr & ~(new_addr_type)(m_line_sz - 1);
-  }
-  new_addr_type mshr_addr(new_addr_type addr) const {
-    return addr & ~(new_addr_type)(m_atom_sz - 1);
-  }
-  enum mshr_config_t get_mshr_type() const { return m_mshr_type; }
-  void set_assoc(unsigned n) {
-    // set new assoc. L1 cache dynamically resized in Volta
-    m_assoc = n;
-  }
-  unsigned get_nset() const {
-    assert(m_valid);
-    return m_nset;
-  }
-  unsigned get_total_size_inKB() const {
-    assert(m_valid);
-    return (m_assoc * m_nset * m_line_sz) / 1024;
-  }
-  bool is_streaming() { return m_is_streaming; }
-  FuncCache get_cache_status() { return cache_status; }
-  char *m_config_string;
-  char *m_config_stringPrefL1;
-  char *m_config_stringPrefShared;
-  FuncCache cache_status;
+    new_addr_type tag( new_addr_type addr ) const
+    {
+        // For generality, the tag includes both index and tag. This allows for more complex set index
+        // calculations that can result in different indexes mapping to the same set, thus the full
+        // tag + index is required to check for hit/miss. Tag is now identical to the block address.
 
- protected:
-  void exit_parse_error() {
-    printf("GPGPU-Sim uArch: cache configuration parsing error (%s)\n",
-           m_config_string);
-    abort();
-  }
+        //return addr >> (m_line_sz_log2+m_nset_log2);
+        return addr & ~(new_addr_type)(m_line_sz-1);
+    }
+    new_addr_type block_addr( new_addr_type addr ) const
+    {
+        return addr & ~(new_addr_type)(m_line_sz-1);
+    }
+    new_addr_type mshr_addr( new_addr_type addr ) const
+	{
+    	return addr & ~(new_addr_type)(m_atom_sz-1);
+	}
+    enum mshr_config_t get_mshr_type() const
+	{
+    	return m_mshr_type;
+	}
+    void set_assoc(unsigned n)
+	{
+    	//set new assoc. L1 cache dynamically resized in Volta
+    	m_assoc = n;
+	}
+    unsigned get_nset() const
+	{
+		assert( m_valid );
+		return m_nset;
+	}
+    unsigned get_total_size_inKB() const
+	{
+		assert( m_valid );
+		return (m_assoc*m_nset*m_line_sz)/1024;
+	}
+    bool is_streaming() {
+    	return m_is_streaming;
+    }
+    FuncCache get_cache_status() {return cache_status;}
+    char *m_config_string;
+    char *m_config_stringPrefL1;
+    char *m_config_stringPrefShared;
+    FuncCache cache_status;
 
-  bool m_valid;
-  bool m_disabled;
-  unsigned m_line_sz;
-  unsigned m_line_sz_log2;
-  unsigned m_nset;
-  unsigned m_nset_log2;
-  unsigned m_assoc;
-  unsigned m_atom_sz;
-  unsigned m_sector_sz_log2;
-  unsigned original_m_assoc;
-  bool m_is_streaming;
+protected:
+    void exit_parse_error()
+    {
+        printf("GPGPU-Sim uArch: cache configuration parsing error (%s)\n", m_config_string );
+        abort();
+    }
 
-  enum replacement_policy_t m_replacement_policy;  // 'L' = LRU, 'F' = FIFO
-  enum write_policy_t
-      m_write_policy;  // 'T' = write through, 'B' = write back, 'R' = read only
-  enum allocation_policy_t
-      m_alloc_policy;  // 'm' = allocate on miss, 'f' = allocate on fill
-  enum mshr_config_t m_mshr_type;
-  enum cache_type m_cache_type;
+    bool m_valid;
+    bool m_disabled;
+    unsigned m_line_sz;
+    unsigned m_line_sz_log2;
+    unsigned m_nset;
+    unsigned m_nset_log2;
+    unsigned m_assoc;
+    unsigned m_atom_sz;
+    unsigned m_sector_sz_log2;
+    unsigned original_m_assoc;
+    bool m_is_streaming;
 
-  write_allocate_policy_t
-      m_write_alloc_policy;  // 'W' = Write allocate, 'N' = No write allocate
+    enum replacement_policy_t m_replacement_policy; // 'L' = LRU, 'F' = FIFO
+    enum write_policy_t m_write_policy;             // 'T' = write through, 'B' = write back, 'R' = read only
+    enum allocation_policy_t m_alloc_policy;        // 'm' = allocate on miss, 'f' = allocate on fill
+    enum mshr_config_t m_mshr_type;
+    enum cache_type m_cache_type;
 
-  union {
-    unsigned m_mshr_entries;
-    unsigned m_fragment_fifo_entries;
-  };
-  union {
-    unsigned m_mshr_max_merge;
-    unsigned m_request_fifo_entries;
-  };
-  union {
-    unsigned m_miss_queue_size;
-    unsigned m_rob_entries;
-  };
-  unsigned m_result_fifo_entries;
-  unsigned m_data_port_width;  //< number of byte the cache can access per cycle
-  enum set_index_function
-      m_set_index_function;  // Hash, linear, or custom set index function
+    write_allocate_policy_t m_write_alloc_policy;	// 'W' = Write allocate, 'N' = No write allocate
 
-  friend class tag_array;
-  friend class baseline_cache;
-  friend class read_only_cache;
-  friend class tex_cache;
-  friend class data_cache;
-  friend class l1_cache;
-  friend class l2_cache;
-  friend class memory_sub_partition;
+    union {
+        unsigned m_mshr_entries;
+        unsigned m_fragment_fifo_entries;
+    };
+    union {
+        unsigned m_mshr_max_merge;
+        unsigned m_request_fifo_entries;
+    };
+    union {
+        unsigned m_miss_queue_size;
+        unsigned m_rob_entries;
+    };
+    unsigned m_result_fifo_entries;
+    unsigned m_data_port_width; //< number of byte the cache can access per cycle 
+    enum set_index_function m_set_index_function; // Hash, linear, or custom set index function
+
+    friend class tag_array;
+    friend class baseline_cache;
+    friend class read_only_cache;
+    friend class tex_cache;
+    friend class data_cache;
+    friend class l1_cache;
+    friend class l2_cache;
+    friend class memory_sub_partition;
 };
 
-class l1d_cache_config : public cache_config {
- public:
-  l1d_cache_config() : cache_config() {}
-  virtual unsigned set_index(new_addr_type addr) const;
-  unsigned set_bank(new_addr_type addr) const;
-  unsigned l1_latency;
-  unsigned l1_banks;
+class l1d_cache_config : public cache_config{
+public:
+	l1d_cache_config() : cache_config(){}
+	virtual unsigned set_index(new_addr_type addr) const;
+    unsigned set_bank(new_addr_type addr) const;
+	unsigned l1_latency;
+	unsigned l1_banks;
 };
 
 class l2_cache_config : public cache_config {
- public:
-  l2_cache_config() : cache_config() {}
-  void init(linear_to_raw_address_translation *address_mapping);
-  virtual unsigned set_index(new_addr_type addr) const;
+public:
+	l2_cache_config() : cache_config(){}
+	void init(linear_to_raw_address_translation *address_mapping);
+	virtual unsigned set_index(new_addr_type addr) const;
 
- private:
-  linear_to_raw_address_translation *m_address_mapping;
+private:
+	linear_to_raw_address_translation *m_address_mapping;
 };
 
 class tag_array {
- public:
-  // Use this constructor
-  tag_array(cache_config &config, int core_id, int type_id);
-  ~tag_array();
+public:
+    // Use this constructor
+    tag_array(cache_config &config, int core_id, int type_id );
+    ~tag_array();
 
-  enum cache_request_status probe(new_addr_type addr, unsigned &idx,
-                                  mem_fetch *mf, bool probe_mode = false) const;
-  enum cache_request_status probe(new_addr_type addr, unsigned &idx,
-                                  mem_access_sector_mask_t mask,
-                                  bool probe_mode = false,
-                                  mem_fetch *mf = NULL) const;
-  enum cache_request_status access(new_addr_type addr, unsigned time,
-                                   unsigned &idx, mem_fetch *mf);
-  enum cache_request_status access(new_addr_type addr, unsigned time,
-                                   unsigned &idx, bool &wb,
-                                   evicted_block_info &evicted, mem_fetch *mf);
+    enum cache_request_status probe( new_addr_type addr, unsigned &idx, mem_fetch* mf, bool probe_mode=false ) const;
+    enum cache_request_status probe( new_addr_type addr, unsigned &idx, mem_access_sector_mask_t mask, bool probe_mode=false, mem_fetch* mf = NULL ) const;
+    enum cache_request_status access( new_addr_type addr, unsigned time, unsigned &idx, mem_fetch* mf );
+    enum cache_request_status access( new_addr_type addr, unsigned time, unsigned &idx, bool &wb, evicted_block_info &evicted, mem_fetch* mf );
 
-  void fill(new_addr_type addr, unsigned time, mem_fetch *mf);
-  void fill(unsigned idx, unsigned time, mem_fetch *mf);
-  void fill(new_addr_type addr, unsigned time, mem_access_sector_mask_t mask);
+    void fill( new_addr_type addr, unsigned time, mem_fetch* mf );
+    void fill( unsigned idx, unsigned time, mem_fetch* mf );
+    void fill( new_addr_type addr, unsigned time, mem_access_sector_mask_t mask );
 
-  unsigned size() const { return m_config.get_num_lines(); }
-  cache_block_t *get_block(unsigned idx) { return m_lines[idx]; }
+    unsigned size() const { return m_config.get_num_lines();}
+    cache_block_t* get_block(unsigned idx) { return m_lines[idx];}
 
-  void flush();       // flush all written entries
-  void invalidate();  // invalidate all entries
-  void new_window();
+    void flush(); // flush all written entries
+    void invalidate(); // invalidate all entries
+    void new_window();
 
-  void print(FILE *stream, unsigned &total_access,
-             unsigned &total_misses) const;
-  float windowed_miss_rate() const;
-  void get_stats(unsigned &total_access, unsigned &total_misses,
-                 unsigned &total_hit_res, unsigned &total_res_fail) const;
+    void print( FILE *stream, unsigned &total_access, unsigned &total_misses ) const;
+    float windowed_miss_rate( ) const;
+    void get_stats(unsigned &total_access, unsigned &total_misses, unsigned &total_hit_res, unsigned &total_res_fail) const;
 
-  void update_cache_parameters(cache_config &config);
-  void add_pending_line(mem_fetch *mf);
-  void remove_pending_line(mem_fetch *mf);
+	void update_cache_parameters(cache_config &config);
+	void add_pending_line(mem_fetch *mf);
+	void remove_pending_line(mem_fetch *mf);
+protected:
+    // This constructor is intended for use only from derived classes that wish to
+    // avoid unnecessary memory allocation that takes place in the
+    // other tag_array constructor
+    tag_array( cache_config &config,
+               int core_id,
+               int type_id,
+               cache_block_t** new_lines );
+    void init( int core_id, int type_id );
 
- protected:
-  // This constructor is intended for use only from derived classes that wish to
-  // avoid unnecessary memory allocation that takes place in the
-  // other tag_array constructor
-  tag_array(cache_config &config, int core_id, int type_id,
-            cache_block_t **new_lines);
-  void init(int core_id, int type_id);
+protected:
 
- protected:
-  cache_config &m_config;
+    cache_config &m_config;
 
-  cache_block_t **m_lines; /* nbanks x nset x assoc lines in total */
+    cache_block_t **m_lines; /* nbanks x nset x assoc lines in total */
 
-  unsigned m_access;
-  unsigned m_miss;
-  unsigned m_pending_hit;  // number of cache miss that hit a line that is
-                           // allocated but not filled
-  unsigned m_res_fail;
-  unsigned m_sector_miss;
+    unsigned m_access;
+    unsigned m_miss;
+    unsigned m_pending_hit; // number of cache miss that hit a line that is allocated but not filled
+    unsigned m_res_fail;
+    unsigned m_sector_miss;
 
-  // performance counters for calculating the amount of misses within a time
-  // window
-  unsigned m_prev_snapshot_access;
-  unsigned m_prev_snapshot_miss;
-  unsigned m_prev_snapshot_pending_hit;
+    // performance counters for calculating the amount of misses within a time window
+    unsigned m_prev_snapshot_access;
+    unsigned m_prev_snapshot_miss;
+    unsigned m_prev_snapshot_pending_hit;
 
-  int m_core_id;  // which shader core is using this
-  int m_type_id;  // what kind of cache is this (normal, texture, constant)
+    int m_core_id; // which shader core is using this
+    int m_type_id; // what kind of cache is this (normal, texture, constant)
 
-  bool is_used;  // a flag if the whole cache has ever been accessed before
+    bool is_used;  //a flag if the whole cache has ever been accessed before
 
-  typedef tr1_hash_map<new_addr_type, unsigned> line_table;
-  line_table pending_lines;
+    typedef tr1_hash_map<new_addr_type,unsigned> line_table;
+    line_table pending_lines;
 };
 
 class mshr_table {
- public:
-  mshr_table(unsigned num_entries, unsigned max_merged)
-      : m_num_entries(num_entries),
-        m_max_merged(max_merged)
+public:
+    mshr_table( unsigned num_entries, unsigned max_merged)
+    : m_num_entries(num_entries),
+    m_max_merged(max_merged)
 #if (tr1_hash_map_ismap == 0)
-        ,
-        m_data(2 * num_entries)
+    ,m_data(2*num_entries)
 #endif
-  {
-  }
+    {
+    }
 
-  /// Checks if there is a pending request to the lower memory level already
-  bool probe(new_addr_type block_addr) const;
-  /// Checks if there is space for tracking a new memory access
-  bool full(new_addr_type block_addr) const;
-  /// Add or merge this access
-  void add(new_addr_type block_addr, mem_fetch *mf);
-  /// Returns true if cannot accept new fill responses
-  bool busy() const { return false; }
-  /// Accept a new cache fill response: mark entry ready for processing
-  void mark_ready(new_addr_type block_addr, bool &has_atomic);
-  /// Returns true if ready accesses exist
-  bool access_ready() const { return !m_current_response.empty(); }
-  /// Returns next ready access
-  mem_fetch *next_access();
-  void display(FILE *fp) const;
-  // Returns true if there is a pending read after write
-  bool is_read_after_write_pending(new_addr_type block_addr);
+    /// Checks if there is a pending request to the lower memory level already
+    bool probe( new_addr_type block_addr ) const;
+    /// Checks if there is space for tracking a new memory access
+    bool full( new_addr_type block_addr ) const;
+    /// Add or merge this access
+    void add( new_addr_type block_addr, mem_fetch *mf );
+    /// Returns true if cannot accept new fill responses
+    bool busy() const {return false;}
+    /// Accept a new cache fill response: mark entry ready for processing
+    void mark_ready( new_addr_type block_addr, bool &has_atomic );
+    /// Returns true if ready accesses exist
+    bool access_ready() const {return !m_current_response.empty();}
+    /// Returns next ready access
+    mem_fetch *next_access();
+    void display( FILE *fp ) const;
+    // Returns true if there is a pending read after write
+    bool is_read_after_write_pending(new_addr_type block_addr);
 
-  void check_mshr_parameters(unsigned num_entries, unsigned max_merged) {
-    assert(m_num_entries == num_entries &&
-           "Change of MSHR parameters between kernels is not allowed");
-    assert(m_max_merged == max_merged &&
-           "Change of MSHR parameters between kernels is not allowed");
-  }
+    void check_mshr_parameters( unsigned num_entries, unsigned max_merged )
+    {
+    	assert(m_num_entries==num_entries && "Change of MSHR parameters between kernels is not allowed");
+    	assert(m_max_merged==max_merged && "Change of MSHR parameters between kernels is not allowed");
+    }
 
- private:
-  // finite sized, fully associative table, with a finite maximum number of
-  // merged requests
-  const unsigned m_num_entries;
-  const unsigned m_max_merged;
+private:
 
-  struct mshr_entry {
-    std::list<mem_fetch *> m_list;
-    bool m_has_atomic;
-    mshr_entry() : m_has_atomic(false) {}
-  };
-  typedef tr1_hash_map<new_addr_type, mshr_entry> table;
-  typedef tr1_hash_map<new_addr_type, mshr_entry> line_table;
-  table m_data;
-  line_table pending_lines;
+    // finite sized, fully associative table, with a finite maximum number of merged requests
+    const unsigned m_num_entries;
+    const unsigned m_max_merged;
 
-  // it may take several cycles to process the merged requests
-  bool m_current_response_ready;
-  std::list<new_addr_type> m_current_response;
+    struct mshr_entry {
+        std::list<mem_fetch*> m_list;
+        bool m_has_atomic; 
+        mshr_entry() : m_has_atomic(false) { }
+    }; 
+    typedef tr1_hash_map<new_addr_type,mshr_entry> table;
+    typedef tr1_hash_map<new_addr_type,mshr_entry> line_table;
+    table m_data;
+    line_table pending_lines;
+
+    // it may take several cycles to process the merged requests
+    bool m_current_response_ready;
+    std::list<new_addr_type> m_current_response;
 };
 
-/***************************************************************** Caches
- * *****************************************************************/
+
+/***************************************************************** Caches *****************************************************************/
 ///
-/// Simple struct to maintain cache accesses, misses, pending hits, and
-/// reservation fails.
+/// Simple struct to maintain cache accesses, misses, pending hits, and reservation fails.
 ///
-struct cache_sub_stats {
-  unsigned long long accesses;
-  unsigned long long misses;
-  unsigned long long pending_hits;
-  unsigned long long res_fails;
+struct cache_sub_stats{
+    unsigned long long accesses;
+    unsigned long long misses;
+    unsigned long long pending_hits;
+    unsigned long long res_fails;
 
-  unsigned long long port_available_cycles;
-  unsigned long long data_port_busy_cycles;
-  unsigned long long fill_port_busy_cycles;
+    unsigned long long port_available_cycles; 
+    unsigned long long data_port_busy_cycles; 
+    unsigned long long fill_port_busy_cycles; 
 
-  cache_sub_stats() { clear(); }
-  void clear() {
-    accesses = 0;
-    misses = 0;
-    pending_hits = 0;
-    res_fails = 0;
-    port_available_cycles = 0;
-    data_port_busy_cycles = 0;
-    fill_port_busy_cycles = 0;
-  }
-  cache_sub_stats &operator+=(const cache_sub_stats &css) {
-    ///
-    /// Overloading += operator to easily accumulate stats
-    ///
-    accesses += css.accesses;
-    misses += css.misses;
-    pending_hits += css.pending_hits;
-    res_fails += css.res_fails;
-    port_available_cycles += css.port_available_cycles;
-    data_port_busy_cycles += css.data_port_busy_cycles;
-    fill_port_busy_cycles += css.fill_port_busy_cycles;
-    return *this;
-  }
+    cache_sub_stats(){
+        clear();
+    }
+    void clear(){
+        accesses = 0;
+        misses = 0;
+        pending_hits = 0;
+        res_fails = 0;
+        port_available_cycles = 0; 
+        data_port_busy_cycles = 0; 
+        fill_port_busy_cycles = 0; 
+    }
+    cache_sub_stats &operator+=(const cache_sub_stats &css){
+        ///
+        /// Overloading += operator to easily accumulate stats
+        ///
+        accesses += css.accesses;
+        misses += css.misses;
+        pending_hits += css.pending_hits;
+        res_fails += css.res_fails;
+        port_available_cycles += css.port_available_cycles; 
+        data_port_busy_cycles += css.data_port_busy_cycles; 
+        fill_port_busy_cycles += css.fill_port_busy_cycles; 
+        return *this;
+    }
 
-  cache_sub_stats operator+(const cache_sub_stats &cs) {
-    ///
-    /// Overloading + operator to easily accumulate stats
-    ///
-    cache_sub_stats ret;
-    ret.accesses = accesses + cs.accesses;
-    ret.misses = misses + cs.misses;
-    ret.pending_hits = pending_hits + cs.pending_hits;
-    ret.res_fails = res_fails + cs.res_fails;
-    ret.port_available_cycles =
-        port_available_cycles + cs.port_available_cycles;
-    ret.data_port_busy_cycles =
-        data_port_busy_cycles + cs.data_port_busy_cycles;
-    ret.fill_port_busy_cycles =
-        fill_port_busy_cycles + cs.fill_port_busy_cycles;
-    return ret;
-  }
+    cache_sub_stats operator+(const cache_sub_stats &cs){
+        ///
+        /// Overloading + operator to easily accumulate stats
+        ///
+        cache_sub_stats ret;
+        ret.accesses = accesses + cs.accesses;
+        ret.misses = misses + cs.misses;
+        ret.pending_hits = pending_hits + cs.pending_hits;
+        ret.res_fails = res_fails + cs.res_fails;
+        ret.port_available_cycles = port_available_cycles + cs.port_available_cycles; 
+        ret.data_port_busy_cycles = data_port_busy_cycles + cs.data_port_busy_cycles; 
+        ret.fill_port_busy_cycles = fill_port_busy_cycles + cs.fill_port_busy_cycles; 
+        return ret;
+    }
 
-  void print_port_stats(FILE *fout, const char *cache_name) const;
+    void print_port_stats(FILE *fout, const char *cache_name) const; 
 };
+
 
 // Used for collecting AerialVision per-window statistics
-struct cache_sub_stats_pw {
-  unsigned accesses;
-  unsigned write_misses;
-  unsigned write_hits;
-  unsigned write_pending_hits;
-  unsigned write_res_fails;
+struct cache_sub_stats_pw{
+    unsigned accesses;
+    unsigned write_misses;
+    unsigned write_hits;
+    unsigned write_pending_hits;
+    unsigned write_res_fails;
 
-  unsigned read_misses;
-  unsigned read_hits;
-  unsigned read_pending_hits;
-  unsigned read_res_fails;
+    unsigned read_misses;
+    unsigned read_hits;
+    unsigned read_pending_hits;
+    unsigned read_res_fails;
 
-  cache_sub_stats_pw() { clear(); }
-  void clear() {
-    accesses = 0;
-    write_misses = 0;
-    write_hits = 0;
-    write_pending_hits = 0;
-    write_res_fails = 0;
-    read_misses = 0;
-    read_hits = 0;
-    read_pending_hits = 0;
-    read_res_fails = 0;
-  }
-  cache_sub_stats_pw &operator+=(const cache_sub_stats_pw &css) {
-    ///
-    /// Overloading += operator to easily accumulate stats
-    ///
-    accesses += css.accesses;
-    write_misses += css.write_misses;
-    read_misses += css.read_misses;
-    write_pending_hits += css.write_pending_hits;
-    read_pending_hits += css.read_pending_hits;
-    write_res_fails += css.write_res_fails;
-    read_res_fails += css.read_res_fails;
-    return *this;
-  }
+    cache_sub_stats_pw(){
+        clear();
+    }
+    void clear(){
+        accesses = 0;
+        write_misses = 0;
+        write_hits = 0;
+        write_pending_hits = 0;
+        write_res_fails = 0;
+        read_misses = 0;
+        read_hits = 0;
+        read_pending_hits = 0;
+        read_res_fails = 0;
+    }
+    cache_sub_stats_pw &operator+=(const cache_sub_stats_pw &css){
+        ///
+        /// Overloading += operator to easily accumulate stats
+        ///
+        accesses += css.accesses;
+        write_misses += css.write_misses;
+        read_misses += css.read_misses;
+        write_pending_hits += css.write_pending_hits;
+        read_pending_hits += css.read_pending_hits;
+        write_res_fails += css.write_res_fails;
+        read_res_fails += css.read_res_fails;
+        return *this;
+    }
 
-  cache_sub_stats_pw operator+(const cache_sub_stats_pw &cs) {
-    ///
-    /// Overloading + operator to easily accumulate stats
-    ///
-    cache_sub_stats_pw ret;
-    ret.accesses = accesses + cs.accesses;
-    ret.write_misses = write_misses + cs.write_misses;
-    ret.read_misses = read_misses + cs.read_misses;
-    ret.write_pending_hits = write_pending_hits + cs.write_pending_hits;
-    ret.read_pending_hits = read_pending_hits + cs.read_pending_hits;
-    ret.write_res_fails = write_res_fails + cs.write_res_fails;
-    ret.read_res_fails = read_res_fails + cs.read_res_fails;
-    return ret;
-  }
+    cache_sub_stats_pw operator+(const cache_sub_stats_pw &cs){
+        ///
+        /// Overloading + operator to easily accumulate stats
+        ///
+        cache_sub_stats_pw ret;
+        ret.accesses = accesses + cs.accesses;
+        ret.write_misses = write_misses + cs.write_misses;
+        ret.read_misses = read_misses + cs.read_misses;
+        ret.write_pending_hits = write_pending_hits + cs.write_pending_hits;
+        ret.read_pending_hits = read_pending_hits + cs.read_pending_hits;
+        ret.write_res_fails = write_res_fails + cs.write_res_fails;
+        ret.read_res_fails = read_res_fails + cs.read_res_fails;
+        return ret;
+    }
+
 };
+
 
 ///
 /// Cache_stats
@@ -1067,469 +1039,484 @@ struct cache_sub_stats_pw {
 /// 'cache_request_status' : [mem_access_type][cache_request_status]
 ///
 class cache_stats {
- public:
-  cache_stats();
-  void clear();
-  // Clear AerialVision cache stats after each window
-  void clear_pw();
-  void inc_stats(int access_type, int access_outcome);
-  // Increment AerialVision cache stats
-  void inc_stats_pw(int access_type, int access_outcome);
-  void inc_fail_stats(int access_type, int fail_outcome);
-  enum cache_request_status select_stats_status(
-      enum cache_request_status probe, enum cache_request_status access) const;
-  unsigned long long &operator()(int access_type, int access_outcome,
-                                 bool fail_outcome);
-  unsigned long long operator()(int access_type, int access_outcome,
-                                bool fail_outcome) const;
-  cache_stats operator+(const cache_stats &cs);
-  cache_stats &operator+=(const cache_stats &cs);
-  void print_stats(FILE *fout, const char *cache_name = "Cache_stats") const;
-  void print_fail_stats(FILE *fout,
-                        const char *cache_name = "Cache_fail_stats") const;
+public:
+    cache_stats();
+    void clear();
+    // Clear AerialVision cache stats after each window
+    void clear_pw();
+    void inc_stats(int access_type, int access_outcome);
+    // Increment AerialVision cache stats
+    void inc_stats_pw(int access_type, int access_outcome);
+    void inc_fail_stats(int access_type, int fail_outcome);
+    enum cache_request_status select_stats_status(enum cache_request_status probe, enum cache_request_status access) const;
+    unsigned long long &operator()(int access_type, int access_outcome, bool fail_outcome);
+    unsigned long long operator()(int access_type, int access_outcome, bool fail_outcome) const;
+    cache_stats operator+(const cache_stats &cs);
+    cache_stats &operator+=(const cache_stats &cs);
+    void print_stats(FILE *fout, const char *cache_name = "Cache_stats") const;
+    void print_fail_stats(FILE *fout, const char *cache_name = "Cache_fail_stats") const;
 
-  unsigned long long get_stats(enum mem_access_type *access_type,
-                               unsigned num_access_type,
-                               enum cache_request_status *access_status,
-                               unsigned num_access_status) const;
-  void get_sub_stats(struct cache_sub_stats &css) const;
+    unsigned long long get_stats(enum mem_access_type *access_type, unsigned num_access_type, enum cache_request_status *access_status, unsigned num_access_status)  const;
+    void get_sub_stats(struct cache_sub_stats &css) const;
 
-  // Get per-window cache stats for AerialVision
-  void get_sub_stats_pw(struct cache_sub_stats_pw &css) const;
+    // Get per-window cache stats for AerialVision
+    void get_sub_stats_pw(struct cache_sub_stats_pw &css) const;
 
-  void sample_cache_port_utility(bool data_port_busy, bool fill_port_busy);
+    void sample_cache_port_utility(bool data_port_busy, bool fill_port_busy); 
+private:
+    bool check_valid(int type, int status) const;
+    bool check_fail_valid(int type, int fail) const;
 
- private:
-  bool check_valid(int type, int status) const;
-  bool check_fail_valid(int type, int fail) const;
 
-  std::vector<std::vector<unsigned long long> > m_stats;
-  // AerialVision cache stats (per-window)
-  std::vector<std::vector<unsigned long long> > m_stats_pw;
-  std::vector<std::vector<unsigned long long> > m_fail_stats;
+    std::vector< std::vector<unsigned long long> > m_stats;
+    // AerialVision cache stats (per-window)
+    std::vector< std::vector<unsigned long long> > m_stats_pw;
+    std::vector< std::vector<unsigned long long> > m_fail_stats;
 
-  unsigned long long m_cache_port_available_cycles;
-  unsigned long long m_cache_data_port_busy_cycles;
-  unsigned long long m_cache_fill_port_busy_cycles;
+    unsigned long long m_cache_port_available_cycles; 
+    unsigned long long m_cache_data_port_busy_cycles; 
+    unsigned long long m_cache_fill_port_busy_cycles; 
 };
 
 class cache_t {
- public:
-  virtual ~cache_t() {}
-  virtual enum cache_request_status access(new_addr_type addr, mem_fetch *mf,
-                                           unsigned time,
-                                           std::list<cache_event> &events) = 0;
+public:
+    virtual ~cache_t() {}
+    virtual enum cache_request_status access( new_addr_type addr, mem_fetch *mf, unsigned time, std::list<cache_event> &events ) =  0;
 
-  // accessors for cache bandwidth availability
-  virtual bool data_port_free() const = 0;
-  virtual bool fill_port_free() const = 0;
+    // accessors for cache bandwidth availability 
+    virtual bool data_port_free() const = 0; 
+    virtual bool fill_port_free() const = 0; 
 };
 
-bool was_write_sent(const std::list<cache_event> &events);
-bool was_read_sent(const std::list<cache_event> &events);
-bool was_writeallocate_sent(const std::list<cache_event> &events);
+bool was_write_sent( const std::list<cache_event> &events );
+bool was_read_sent( const std::list<cache_event> &events );
+bool was_writeallocate_sent( const std::list<cache_event> &events );
 
 /// Baseline cache
 /// Implements common functions for read_only_cache and data_cache
 /// Each subclass implements its own 'access' function
 class baseline_cache : public cache_t {
- public:
-  baseline_cache(const char *name, cache_config &config, int core_id,
-                 int type_id, mem_fetch_interface *memport,
-                 enum mem_fetch_status status)
-      : m_config(config),
-        m_tag_array(new tag_array(config, core_id, type_id)),
-        m_mshrs(config.m_mshr_entries, config.m_mshr_max_merge),
-        m_bandwidth_management(config) {
-    init(name, config, memport, status);
-  }
-
-  void init(const char *name, const cache_config &config,
-            mem_fetch_interface *memport, enum mem_fetch_status status) {
-    m_name = name;
-    assert(config.m_mshr_type == ASSOC || config.m_mshr_type == SECTOR_ASSOC);
-    m_memport = memport;
-    m_miss_queue_status = status;
-  }
-
-  virtual ~baseline_cache() { delete m_tag_array; }
-
-  void update_cache_parameters(cache_config &config) {
-    m_config = config;
-    m_tag_array->update_cache_parameters(config);
-    m_mshrs.check_mshr_parameters(config.m_mshr_entries,
-                                  config.m_mshr_max_merge);
-  }
-
-  virtual enum cache_request_status access(new_addr_type addr, mem_fetch *mf,
-                                           unsigned time,
-                                           std::list<cache_event> &events) = 0;
-  /// Sends next request to lower level of memory
-  void cycle();
-  /// Interface for response from lower memory level (model bandwidth
-  /// restictions in caller)
-  void fill(mem_fetch *mf, unsigned time);
-  /// Checks if mf is waiting to be filled by lower memory level
-  bool waiting_for_fill(mem_fetch *mf);
-  /// Are any (accepted) accesses that had to wait for memory now ready? (does
-  /// not include accesses that "HIT")
-  bool access_ready() const { return m_mshrs.access_ready(); }
-  /// Pop next ready access (does not include accesses that "HIT")
-  mem_fetch *next_access() { return m_mshrs.next_access(); }
-  // flash invalidate all entries in cache
-  void flush() { m_tag_array->flush(); }
-  void invalidate() { m_tag_array->invalidate(); }
-  void print(FILE *fp, unsigned &accesses, unsigned &misses) const;
-  void display_state(FILE *fp) const;
-
-  // Stat collection
-  const cache_stats &get_stats() const { return m_stats; }
-  unsigned get_stats(enum mem_access_type *access_type,
-                     unsigned num_access_type,
-                     enum cache_request_status *access_status,
-                     unsigned num_access_status) const {
-    return m_stats.get_stats(access_type, num_access_type, access_status,
-                             num_access_status);
-  }
-  void get_sub_stats(struct cache_sub_stats &css) const {
-    m_stats.get_sub_stats(css);
-  }
-  // Clear per-window stats for AerialVision support
-  void clear_pw() { m_stats.clear_pw(); }
-  // Per-window sub stats for AerialVision support
-  void get_sub_stats_pw(struct cache_sub_stats_pw &css) const {
-    m_stats.get_sub_stats_pw(css);
-  }
-
-  // accessors for cache bandwidth availability
-  bool data_port_free() const {
-    return m_bandwidth_management.data_port_free();
-  }
-  bool fill_port_free() const {
-    return m_bandwidth_management.fill_port_free();
-  }
-
-  // This is a gapping hole we are poking in the system to quickly handle
-  // filling the cache on cudamemcopies. We don't care about anything other than
-  // L2 state after the memcopy - so just force the tag array to act as though
-  // something is read or written without doing anything else.
-  void force_tag_access(new_addr_type addr, unsigned time,
-                        mem_access_sector_mask_t mask) {
-    m_tag_array->fill(addr, time, mask);
-  }
-
- protected:
-  // Constructor that can be used by derived classes with custom tag arrays
-  baseline_cache(const char *name, cache_config &config, int core_id,
-                 int type_id, mem_fetch_interface *memport,
-                 enum mem_fetch_status status, tag_array *new_tag_array)
-      : m_config(config),
-        m_tag_array(new_tag_array),
-        m_mshrs(config.m_mshr_entries, config.m_mshr_max_merge),
-        m_bandwidth_management(config) {
-    init(name, config, memport, status);
-  }
-
- protected:
-  std::string m_name;
-  cache_config &m_config;
-  tag_array *m_tag_array;
-  mshr_table m_mshrs;
-  std::list<mem_fetch *> m_miss_queue;
-  enum mem_fetch_status m_miss_queue_status;
-  mem_fetch_interface *m_memport;
-
-  struct extra_mf_fields {
-    extra_mf_fields() { m_valid = false; }
-    extra_mf_fields(new_addr_type a, new_addr_type ad, unsigned i, unsigned d,
-                    const cache_config &m_config) {
-      m_valid = true;
-      m_block_addr = a;
-      m_addr = ad;
-      m_cache_index = i;
-      m_data_size = d;
-      pending_read = m_config.m_mshr_type == SECTOR_ASSOC
-                         ? m_config.m_line_sz / SECTOR_SIZE
-                         : 0;
+public:
+    baseline_cache( const char *name, cache_config &config, int core_id, int type_id, mem_fetch_interface *memport,
+                     enum mem_fetch_status status )
+    : m_config(config), m_tag_array(new tag_array(config,core_id,type_id)), 
+      m_mshrs(config.m_mshr_entries,config.m_mshr_max_merge),
+      m_bandwidth_management(config) 
+    {
+        init( name, config, memport, status );
     }
-    bool m_valid;
-    new_addr_type m_block_addr;
-    new_addr_type m_addr;
-    unsigned m_cache_index;
-    unsigned m_data_size;
-    // this variable is used when a load request generates multiple load
-    // transactions
-    // For example, a read request from non-sector L1 request sends a request to
-    // sector L2
-    unsigned pending_read;
-  };
 
-  typedef std::map<mem_fetch *, extra_mf_fields> extra_mf_fields_lookup;
+    void init( const char *name,
+               const cache_config &config,
+               mem_fetch_interface *memport,
+               enum mem_fetch_status status )
+    {
+        m_name = name;
+        assert(config.m_mshr_type == ASSOC || config.m_mshr_type == SECTOR_ASSOC);
+        m_memport=memport;
+        m_miss_queue_status = status;
+    }
 
-  extra_mf_fields_lookup m_extra_mf_fields;
+    virtual ~baseline_cache()
+    {
+        delete m_tag_array;
+    }
 
-  cache_stats m_stats;
+	void update_cache_parameters(cache_config &config)
+	{
+		m_config=config;
+		m_tag_array->update_cache_parameters(config);
+		m_mshrs.check_mshr_parameters(config.m_mshr_entries,config.m_mshr_max_merge);
+	}
 
-  /// Checks whether this request can be handled on this cycle. num_miss equals
-  /// max # of misses to be handled on this cycle
-  bool miss_queue_full(unsigned num_miss) {
-    return ((m_miss_queue.size() + num_miss) >= m_config.m_miss_queue_size);
-  }
-  /// Read miss handler without writeback
-  void send_read_request(new_addr_type addr, new_addr_type block_addr,
-                         unsigned cache_index, mem_fetch *mf, unsigned time,
-                         bool &do_miss, std::list<cache_event> &events,
-                         bool read_only, bool wa);
-  /// Read miss handler. Check MSHR hit or MSHR available
-  void send_read_request(new_addr_type addr, new_addr_type block_addr,
-                         unsigned cache_index, mem_fetch *mf, unsigned time,
-                         bool &do_miss, bool &wb, evicted_block_info &evicted,
-                         std::list<cache_event> &events, bool read_only,
-                         bool wa);
+    virtual enum cache_request_status access( new_addr_type addr, mem_fetch *mf, unsigned time, std::list<cache_event> &events ) =  0;
+    /// Sends next request to lower level of memory
+    void cycle();
+    /// Interface for response from lower memory level (model bandwidth restictions in caller)
+    void fill( mem_fetch *mf, unsigned time );
+    /// Checks if mf is waiting to be filled by lower memory level
+    bool waiting_for_fill( mem_fetch *mf );
+    /// Are any (accepted) accesses that had to wait for memory now ready? (does not include accesses that "HIT")
+    bool access_ready() const {return m_mshrs.access_ready();}
+    /// Pop next ready access (does not include accesses that "HIT")
+    mem_fetch *next_access(){return m_mshrs.next_access();}
+    // flash invalidate all entries in cache
+    void flush(){m_tag_array->flush();}
+    void invalidate(){m_tag_array->invalidate();}
+    void print(FILE *fp, unsigned &accesses, unsigned &misses) const;
+    void display_state( FILE *fp ) const;
 
-  /// Sub-class containing all metadata for port bandwidth management
-  class bandwidth_management {
-   public:
-    bandwidth_management(cache_config &config);
+    // Stat collection
+    const cache_stats &get_stats() const {
+        return m_stats;
+    }
+    unsigned get_stats(enum mem_access_type *access_type, unsigned num_access_type, enum cache_request_status *access_status, unsigned num_access_status)  const{
+        return m_stats.get_stats(access_type, num_access_type, access_status, num_access_status);
+    }
+    void get_sub_stats(struct cache_sub_stats &css) const {
+        m_stats.get_sub_stats(css);
+    }
+    // Clear per-window stats for AerialVision support
+    void clear_pw(){
+        m_stats.clear_pw();
+    }
+    // Per-window sub stats for AerialVision support
+    void get_sub_stats_pw(struct cache_sub_stats_pw &css) const {
+        m_stats.get_sub_stats_pw(css);
+    }
 
-    /// use the data port based on the outcome and events generated by the
-    /// mem_fetch request
-    void use_data_port(mem_fetch *mf, enum cache_request_status outcome,
-                       const std::list<cache_event> &events);
+    // accessors for cache bandwidth availability 
+    bool data_port_free() const { return m_bandwidth_management.data_port_free(); } 
+    bool fill_port_free() const { return m_bandwidth_management.fill_port_free(); } 
 
-    /// use the fill port
-    void use_fill_port(mem_fetch *mf);
+    // This is a gapping hole we are poking in the system to quickly handle
+    // filling the cache on cudamemcopies. We don't care about anything other than
+    // L2 state after the memcopy - so just force the tag array to act as though
+    // something is read or written without doing anything else.
+    void force_tag_access( new_addr_type addr, unsigned time, mem_access_sector_mask_t mask )
+    {
+        m_tag_array->fill( addr, time, mask );
+    }
 
-    /// called every cache cycle to free up the ports
-    void replenish_port_bandwidth();
+protected:
+    // Constructor that can be used by derived classes with custom tag arrays
+    baseline_cache( const char *name,
+                    cache_config &config,
+                    int core_id,
+                    int type_id,
+                    mem_fetch_interface *memport,
+                    enum mem_fetch_status status,
+                    tag_array* new_tag_array )
+    : m_config(config),
+      m_tag_array( new_tag_array ),
+      m_mshrs(config.m_mshr_entries,config.m_mshr_max_merge), 
+      m_bandwidth_management(config) 
+    {
+        init( name, config, memport, status );
+    }
 
-    /// query for data port availability
-    bool data_port_free() const;
-    /// query for fill port availability
-    bool fill_port_free() const;
+protected:
+    std::string m_name;
+    cache_config &m_config;
+    tag_array*  m_tag_array;
+	mshr_table m_mshrs;
+    std::list<mem_fetch*> m_miss_queue;
+    enum mem_fetch_status m_miss_queue_status;
+    mem_fetch_interface *m_memport;
 
-   protected:
-    const cache_config &m_config;
+    struct extra_mf_fields {
+        extra_mf_fields()  { m_valid = false;}
+        extra_mf_fields( new_addr_type a, new_addr_type ad, unsigned i, unsigned d, const cache_config& m_config)
+        {
+            m_valid = true;
+            m_block_addr = a;
+            m_addr = ad;
+            m_cache_index = i;
+            m_data_size = d;
+        	pending_read = m_config.m_mshr_type == SECTOR_ASSOC? m_config.m_line_sz/SECTOR_SIZE : 0;
 
-    int m_data_port_occupied_cycles;  //< Number of cycle that the data port
-                                      //remains used
-    int m_fill_port_occupied_cycles;  //< Number of cycle that the fill port
-                                      //remains used
-  };
+        }
+        bool m_valid;
+        new_addr_type m_block_addr;
+        new_addr_type m_addr;
+        unsigned m_cache_index;
+        unsigned m_data_size;
+        //this variable is used when a load request generates multiple load transactions
+        //For example, a read request from non-sector L1 request sends a request to sector L2
+        unsigned pending_read;
+    };
 
-  bandwidth_management m_bandwidth_management;
+    typedef std::map<mem_fetch*,extra_mf_fields> extra_mf_fields_lookup;
+
+    extra_mf_fields_lookup m_extra_mf_fields;
+
+    cache_stats m_stats;
+
+    /// Checks whether this request can be handled on this cycle. num_miss equals max # of misses to be handled on this cycle
+    bool miss_queue_full(unsigned num_miss){
+    	  return ( (m_miss_queue.size()+num_miss) >= m_config.m_miss_queue_size );
+    }
+    /// Read miss handler without writeback
+    void send_read_request(new_addr_type addr, new_addr_type block_addr, unsigned cache_index, mem_fetch *mf,
+    		unsigned time, bool &do_miss, std::list<cache_event> &events, bool read_only, bool wa);
+    /// Read miss handler. Check MSHR hit or MSHR available
+    void send_read_request(new_addr_type addr, new_addr_type block_addr, unsigned cache_index, mem_fetch *mf,
+    		unsigned time, bool &do_miss, bool &wb, evicted_block_info &evicted, std::list<cache_event> &events, bool read_only, bool wa);
+
+    /// Sub-class containing all metadata for port bandwidth management 
+    class bandwidth_management 
+    {
+    public: 
+        bandwidth_management(cache_config &config); 
+
+        /// use the data port based on the outcome and events generated by the mem_fetch request 
+        void use_data_port(mem_fetch *mf, enum cache_request_status outcome, const std::list<cache_event> &events); 
+
+        /// use the fill port 
+        void use_fill_port(mem_fetch *mf); 
+
+        /// called every cache cycle to free up the ports 
+        void replenish_port_bandwidth(); 
+
+        /// query for data port availability 
+        bool data_port_free() const; 
+        /// query for fill port availability 
+        bool fill_port_free() const; 
+    protected: 
+        const cache_config &m_config; 
+
+        int m_data_port_occupied_cycles; //< Number of cycle that the data port remains used 
+        int m_fill_port_occupied_cycles; //< Number of cycle that the fill port remains used 
+    }; 
+
+    bandwidth_management m_bandwidth_management; 
 };
 
 /// Read only cache
 class read_only_cache : public baseline_cache {
- public:
-  read_only_cache(const char *name, cache_config &config, int core_id,
-                  int type_id, mem_fetch_interface *memport,
-                  enum mem_fetch_status status)
-      : baseline_cache(name, config, core_id, type_id, memport, status) {}
+public:
+    read_only_cache( const char *name, cache_config &config, int core_id, int type_id, mem_fetch_interface *memport, enum mem_fetch_status status )
+    : baseline_cache(name,config,core_id,type_id,memport,status){}
 
-  /// Access cache for read_only_cache: returns RESERVATION_FAIL if request
-  /// could not be accepted (for any reason)
-  virtual enum cache_request_status access(new_addr_type addr, mem_fetch *mf,
-                                           unsigned time,
-                                           std::list<cache_event> &events);
+    /// Access cache for read_only_cache: returns RESERVATION_FAIL if request could not be accepted (for any reason)
+    virtual enum cache_request_status access( new_addr_type addr, mem_fetch *mf, unsigned time, std::list<cache_event> &events );
 
-  virtual ~read_only_cache() {}
+    virtual ~read_only_cache(){}
 
- protected:
-  read_only_cache(const char *name, cache_config &config, int core_id,
-                  int type_id, mem_fetch_interface *memport,
-                  enum mem_fetch_status status, tag_array *new_tag_array)
-      : baseline_cache(name, config, core_id, type_id, memport, status,
-                       new_tag_array) {}
+protected:
+    read_only_cache( const char *name, cache_config &config, int core_id, int type_id, mem_fetch_interface *memport, enum mem_fetch_status status, tag_array* new_tag_array )
+    : baseline_cache(name,config,core_id,type_id,memport,status, new_tag_array){}
 };
 
 /// Data cache - Implements common functions for L1 and L2 data cache
 class data_cache : public baseline_cache {
- public:
-  data_cache(const char *name, cache_config &config, int core_id, int type_id,
-             mem_fetch_interface *memport, mem_fetch_allocator *mfcreator,
-             enum mem_fetch_status status, mem_access_type wr_alloc_type,
-             mem_access_type wrbk_type, class gpgpu_sim *gpu)
-      : baseline_cache(name, config, core_id, type_id, memport, status) {
-    init(mfcreator);
-    m_wr_alloc_type = wr_alloc_type;
-    m_wrbk_type = wrbk_type;
-    m_gpu = gpu;
-  }
-
-  virtual ~data_cache() {}
-
-  virtual void init(mem_fetch_allocator *mfcreator) {
-    m_memfetch_creator = mfcreator;
-
-    // Set read hit function
-    m_rd_hit = &data_cache::rd_hit_base;
-
-    // Set read miss function
-    m_rd_miss = &data_cache::rd_miss_base;
-
-    // Set write hit function
-    switch (m_config.m_write_policy) {
-      // READ_ONLY is now a separate cache class, config is deprecated
-      case READ_ONLY:
-        assert(0 && "Error: Writable Data_cache set as READ_ONLY\n");
-        break;
-      case WRITE_BACK:
-        m_wr_hit = &data_cache::wr_hit_wb;
-        break;
-      case WRITE_THROUGH:
-        m_wr_hit = &data_cache::wr_hit_wt;
-        break;
-      case WRITE_EVICT:
-        m_wr_hit = &data_cache::wr_hit_we;
-        break;
-      case LOCAL_WB_GLOBAL_WT:
-        m_wr_hit = &data_cache::wr_hit_global_we_local_wb;
-        break;
-      default:
-        assert(0 && "Error: Must set valid cache write policy\n");
-        break;  // Need to set a write hit function
+public:
+    data_cache( const char *name, cache_config &config,
+    			int core_id, int type_id, mem_fetch_interface *memport,
+                mem_fetch_allocator *mfcreator, enum mem_fetch_status status,
+                mem_access_type wr_alloc_type, mem_access_type wrbk_type, class gpgpu_sim* gpu )
+    			: baseline_cache(name,config,core_id,type_id,memport,status)
+    {
+        init( mfcreator );
+        m_wr_alloc_type = wr_alloc_type;
+        m_wrbk_type = wrbk_type;
+        m_gpu=gpu;
     }
 
-    // Set write miss function
-    switch (m_config.m_write_alloc_policy) {
-      case NO_WRITE_ALLOCATE:
-        m_wr_miss = &data_cache::wr_miss_no_wa;
-        break;
-      case WRITE_ALLOCATE:
-        m_wr_miss = &data_cache::wr_miss_wa_naive;
-        break;
-      case FETCH_ON_WRITE:
-        m_wr_miss = &data_cache::wr_miss_wa_fetch_on_write;
-        break;
-      case LAZY_FETCH_ON_READ:
-        m_wr_miss = &data_cache::wr_miss_wa_lazy_fetch_on_read;
-        break;
-      default:
-        assert(0 && "Error: Must set valid cache write miss policy\n");
-        break;  // Need to set a write miss function
+    virtual ~data_cache() {}
+
+    virtual void init( mem_fetch_allocator *mfcreator )
+    {
+        m_memfetch_creator=mfcreator;
+
+        // Set read hit function
+        m_rd_hit = &data_cache::rd_hit_base;
+
+        // Set read miss function
+        m_rd_miss = &data_cache::rd_miss_base;
+
+        // Set write hit function
+        switch(m_config.m_write_policy){
+        // READ_ONLY is now a separate cache class, config is deprecated
+        case READ_ONLY:
+            assert(0 && "Error: Writable Data_cache set as READ_ONLY\n");
+            break; 
+        case WRITE_BACK: m_wr_hit = &data_cache::wr_hit_wb; break;
+        case WRITE_THROUGH: m_wr_hit = &data_cache::wr_hit_wt; break;
+        case WRITE_EVICT: m_wr_hit = &data_cache::wr_hit_we; break;
+        case LOCAL_WB_GLOBAL_WT:
+            m_wr_hit = &data_cache::wr_hit_global_we_local_wb;
+            break;
+        default:
+            assert(0 && "Error: Must set valid cache write policy\n");
+            break; // Need to set a write hit function
+        }
+
+        // Set write miss function
+        switch(m_config.m_write_alloc_policy){
+        case NO_WRITE_ALLOCATE: m_wr_miss = &data_cache::wr_miss_no_wa; break;
+		case WRITE_ALLOCATE: m_wr_miss = &data_cache::wr_miss_wa_naive; break;
+		case FETCH_ON_WRITE: m_wr_miss = &data_cache::wr_miss_wa_fetch_on_write; break;
+		case LAZY_FETCH_ON_READ: m_wr_miss = &data_cache::wr_miss_wa_lazy_fetch_on_read; break;
+        default:
+            assert(0 && "Error: Must set valid cache write miss policy\n");
+            break; // Need to set a write miss function
+        }
     }
-  }
 
-  virtual enum cache_request_status access(new_addr_type addr, mem_fetch *mf,
-                                           unsigned time,
-                                           std::list<cache_event> &events);
+    virtual enum cache_request_status access( new_addr_type addr,
+                                              mem_fetch *mf,
+                                              unsigned time,
+                                              std::list<cache_event> &events );
+protected:
+    data_cache( const char *name,
+                cache_config &config,
+                int core_id,
+                int type_id,
+                mem_fetch_interface *memport,
+                mem_fetch_allocator *mfcreator,
+                enum mem_fetch_status status,
+                tag_array* new_tag_array,
+                mem_access_type wr_alloc_type,
+                mem_access_type wrbk_type,
+				class gpgpu_sim* gpu )
+    : baseline_cache(name, config, core_id, type_id, memport,status, new_tag_array)
+    {
+        init( mfcreator );
+        m_wr_alloc_type = wr_alloc_type;
+        m_wrbk_type = wrbk_type;
+        m_gpu=gpu;
+    }
 
- protected:
-  data_cache(const char *name, cache_config &config, int core_id, int type_id,
-             mem_fetch_interface *memport, mem_fetch_allocator *mfcreator,
-             enum mem_fetch_status status, tag_array *new_tag_array,
-             mem_access_type wr_alloc_type, mem_access_type wrbk_type,
-             class gpgpu_sim *gpu)
-      : baseline_cache(name, config, core_id, type_id, memport, status,
-                       new_tag_array) {
-    init(mfcreator);
-    m_wr_alloc_type = wr_alloc_type;
-    m_wrbk_type = wrbk_type;
-    m_gpu = gpu;
-  }
+    mem_access_type m_wr_alloc_type; // Specifies type of write allocate request (e.g., L1 or L2)
+    mem_access_type m_wrbk_type; // Specifies type of writeback request (e.g., L1 or L2)
+    class gpgpu_sim* m_gpu;
 
-  mem_access_type m_wr_alloc_type;  // Specifies type of write allocate request
-                                    // (e.g., L1 or L2)
-  mem_access_type
-      m_wrbk_type;  // Specifies type of writeback request (e.g., L1 or L2)
-  class gpgpu_sim *m_gpu;
+    //! A general function that takes the result of a tag_array probe
+    //  and performs the correspding functions based on the cache configuration
+    //  The access fucntion calls this function
+    enum cache_request_status
+        process_tag_probe( bool wr,
+                           enum cache_request_status status,
+                           new_addr_type addr,
+                           unsigned cache_index,
+                           mem_fetch* mf,
+                           unsigned time,
+                           std::list<cache_event>& events );
 
-  //! A general function that takes the result of a tag_array probe
-  //  and performs the correspding functions based on the cache configuration
-  //  The access fucntion calls this function
-  enum cache_request_status process_tag_probe(bool wr,
-                                              enum cache_request_status status,
-                                              new_addr_type addr,
-                                              unsigned cache_index,
-                                              mem_fetch *mf, unsigned time,
-                                              std::list<cache_event> &events);
+protected:
+    mem_fetch_allocator *m_memfetch_creator;
 
- protected:
-  mem_fetch_allocator *m_memfetch_creator;
+    // Functions for data cache access
+    /// Sends write request to lower level memory (write or writeback)
+    void send_write_request( mem_fetch *mf,
+                             cache_event request,
+                             unsigned time,
+                             std::list<cache_event> &events);
 
-  // Functions for data cache access
-  /// Sends write request to lower level memory (write or writeback)
-  void send_write_request(mem_fetch *mf, cache_event request, unsigned time,
-                          std::list<cache_event> &events);
+    // Member Function pointers - Set by configuration options
+    // to the functions below each grouping
+    /******* Write-hit configs *******/
+    enum cache_request_status
+        (data_cache::*m_wr_hit)( new_addr_type addr,
+                                 unsigned cache_index,
+                                 mem_fetch *mf,
+                                 unsigned time,
+                                 std::list<cache_event> &events,
+                                 enum cache_request_status status );
+    /// Marks block as MODIFIED and updates block LRU
+    enum cache_request_status
+        wr_hit_wb( new_addr_type addr,
+                   unsigned cache_index,
+                   mem_fetch *mf,
+                   unsigned time,
+                   std::list<cache_event> &events,
+                   enum cache_request_status status ); // write-back
+    enum cache_request_status
+        wr_hit_wt( new_addr_type addr,
+                   unsigned cache_index,
+                   mem_fetch *mf,
+                   unsigned time,
+                   std::list<cache_event> &events,
+                   enum cache_request_status status ); // write-through
 
-  // Member Function pointers - Set by configuration options
-  // to the functions below each grouping
-  /******* Write-hit configs *******/
-  enum cache_request_status (data_cache::*m_wr_hit)(
-      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
-      std::list<cache_event> &events, enum cache_request_status status);
-  /// Marks block as MODIFIED and updates block LRU
-  enum cache_request_status wr_hit_wb(
-      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
-      std::list<cache_event> &events,
-      enum cache_request_status status);  // write-back
-  enum cache_request_status wr_hit_wt(
-      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
-      std::list<cache_event> &events,
-      enum cache_request_status status);  // write-through
+    /// Marks block as INVALID and sends write request to lower level memory
+    enum cache_request_status
+        wr_hit_we( new_addr_type addr,
+                   unsigned cache_index,
+                   mem_fetch *mf,
+                   unsigned time,
+                   std::list<cache_event> &events,
+                   enum cache_request_status status ); // write-evict
+    enum cache_request_status
+        wr_hit_global_we_local_wb( new_addr_type addr,
+                                   unsigned cache_index,
+                                   mem_fetch *mf,
+                                   unsigned time,
+                                   std::list<cache_event> &events,
+                                   enum cache_request_status status );
+        // global write-evict, local write-back
 
-  /// Marks block as INVALID and sends write request to lower level memory
-  enum cache_request_status wr_hit_we(
-      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
-      std::list<cache_event> &events,
-      enum cache_request_status status);  // write-evict
-  enum cache_request_status wr_hit_global_we_local_wb(
-      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
-      std::list<cache_event> &events, enum cache_request_status status);
-  // global write-evict, local write-back
 
-  /******* Write-miss configs *******/
-  enum cache_request_status (data_cache::*m_wr_miss)(
-      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
-      std::list<cache_event> &events, enum cache_request_status status);
-  /// Sends read request, and possible write-back request,
-  //  to lower level memory for a write miss with write-allocate
-  enum cache_request_status wr_miss_wa_naive(
-      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
-      std::list<cache_event> &events,
-      enum cache_request_status
-          status);  // write-allocate-send-write-and-read-request
-  enum cache_request_status wr_miss_wa_fetch_on_write(
-      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
-      std::list<cache_event> &events,
-      enum cache_request_status
-          status);  // write-allocate with fetch-on-every-write
-  enum cache_request_status wr_miss_wa_lazy_fetch_on_read(
-      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
-      std::list<cache_event> &events,
-      enum cache_request_status status);  // write-allocate with read-fetch-only
-  enum cache_request_status wr_miss_wa_write_validate(
-      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
-      std::list<cache_event> &events,
-      enum cache_request_status
-          status);  // write-allocate that writes with no read fetch
-  enum cache_request_status wr_miss_no_wa(
-      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
-      std::list<cache_event> &events,
-      enum cache_request_status status);  // no write-allocate
+    /******* Write-miss configs *******/
+    enum cache_request_status
+        (data_cache::*m_wr_miss)( new_addr_type addr,
+                                  unsigned cache_index,
+                                  mem_fetch *mf,
+                                  unsigned time,
+                                  std::list<cache_event> &events,
+                                  enum cache_request_status status );
+    /// Sends read request, and possible write-back request,
+    //  to lower level memory for a write miss with write-allocate
+    enum cache_request_status
+    	wr_miss_wa_naive( new_addr_type addr,
+                        unsigned cache_index,
+                        mem_fetch *mf,
+                        unsigned time,
+                        std::list<cache_event> &events,
+                        enum cache_request_status status ); // write-allocate-send-write-and-read-request
+	enum cache_request_status
+			   wr_miss_wa_fetch_on_write( new_addr_type addr,
+							unsigned cache_index,
+							mem_fetch *mf,
+							unsigned time,
+							std::list<cache_event> &events,
+							enum cache_request_status status ); // write-allocate with fetch-on-every-write
+	enum cache_request_status
+				   wr_miss_wa_lazy_fetch_on_read( new_addr_type addr,
+								unsigned cache_index,
+								mem_fetch *mf,
+								unsigned time,
+								std::list<cache_event> &events,
+								enum cache_request_status status ); // write-allocate with read-fetch-only
+	enum cache_request_status
+				wr_miss_wa_write_validate( new_addr_type addr,
+							unsigned cache_index,
+							mem_fetch *mf,
+							unsigned time,
+							std::list<cache_event> &events,
+							enum cache_request_status status ); // write-allocate that writes with no read fetch
+    enum cache_request_status
+        wr_miss_no_wa( new_addr_type addr,
+                       unsigned cache_index,
+                       mem_fetch *mf,
+                       unsigned time,
+                       std::list<cache_event> &events,
+                       enum cache_request_status status ); // no write-allocate
 
-  // Currently no separate functions for reads
-  /******* Read-hit configs *******/
-  enum cache_request_status (data_cache::*m_rd_hit)(
-      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
-      std::list<cache_event> &events, enum cache_request_status status);
-  enum cache_request_status rd_hit_base(new_addr_type addr,
-                                        unsigned cache_index, mem_fetch *mf,
-                                        unsigned time,
-                                        std::list<cache_event> &events,
-                                        enum cache_request_status status);
+    // Currently no separate functions for reads
+    /******* Read-hit configs *******/
+    enum cache_request_status
+        (data_cache::*m_rd_hit)( new_addr_type addr,
+                                 unsigned cache_index,
+                                 mem_fetch *mf,
+                                 unsigned time,
+                                 std::list<cache_event> &events,
+                                 enum cache_request_status status );
+    enum cache_request_status
+        rd_hit_base( new_addr_type addr,
+                     unsigned cache_index,
+                     mem_fetch *mf,
+                     unsigned time,
+                     std::list<cache_event> &events,
+                     enum cache_request_status status );
 
-  /******* Read-miss configs *******/
-  enum cache_request_status (data_cache::*m_rd_miss)(
-      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
-      std::list<cache_event> &events, enum cache_request_status status);
-  enum cache_request_status rd_miss_base(new_addr_type addr,
-                                         unsigned cache_index, mem_fetch *mf,
-                                         unsigned time,
-                                         std::list<cache_event> &events,
-                                         enum cache_request_status status);
+    /******* Read-miss configs *******/
+    enum cache_request_status
+        (data_cache::*m_rd_miss)( new_addr_type addr,
+                                  unsigned cache_index,
+                                  mem_fetch *mf,
+                                  unsigned time,
+                                  std::list<cache_event> &events,
+                                  enum cache_request_status status );
+    enum cache_request_status
+        rd_miss_base( new_addr_type addr,
+                      unsigned cache_index,
+                      mem_fetch*mf,
+                      unsigned time,
+                      std::list<cache_event> &events,
+                      enum cache_request_status status );
+
 };
 
 /// This is meant to model the first level data cache in Fermi.
@@ -1537,242 +1524,243 @@ class data_cache : public baseline_cache {
 /// the granularity of individual blocks
 /// (the policy used in fermi according to the CUDA manual)
 class l1_cache : public data_cache {
- public:
-  l1_cache(const char *name, cache_config &config, int core_id, int type_id,
-           mem_fetch_interface *memport, mem_fetch_allocator *mfcreator,
-           enum mem_fetch_status status, class gpgpu_sim *gpu)
-      : data_cache(name, config, core_id, type_id, memport, mfcreator, status,
-                   L1_WR_ALLOC_R, L1_WRBK_ACC, gpu) {}
+public:
+    l1_cache(const char *name, cache_config &config,
+            int core_id, int type_id, mem_fetch_interface *memport,
+            mem_fetch_allocator *mfcreator, enum mem_fetch_status status, class gpgpu_sim* gpu )
+            : data_cache(name,config,core_id,type_id,memport,mfcreator,status, L1_WR_ALLOC_R, L1_WRBK_ACC, gpu){}
 
-  virtual ~l1_cache() {}
+    virtual ~l1_cache(){}
 
-  virtual enum cache_request_status access(new_addr_type addr, mem_fetch *mf,
-                                           unsigned time,
-                                           std::list<cache_event> &events);
+    virtual enum cache_request_status
+        access( new_addr_type addr,
+                mem_fetch *mf,
+                unsigned time,
+                std::list<cache_event> &events );
 
- protected:
-  l1_cache(const char *name, cache_config &config, int core_id, int type_id,
-           mem_fetch_interface *memport, mem_fetch_allocator *mfcreator,
-           enum mem_fetch_status status, tag_array *new_tag_array,
-           class gpgpu_sim *gpu)
-      : data_cache(name, config, core_id, type_id, memport, mfcreator, status,
-                   new_tag_array, L1_WR_ALLOC_R, L1_WRBK_ACC, gpu) {}
+protected:
+    l1_cache( const char *name,
+              cache_config &config,
+              int core_id,
+              int type_id,
+              mem_fetch_interface *memport,
+              mem_fetch_allocator *mfcreator,
+              enum mem_fetch_status status,
+              tag_array* new_tag_array,
+			  class gpgpu_sim* gpu)
+    : data_cache( name,
+                  config,
+                  core_id,type_id,memport,mfcreator,status, new_tag_array, L1_WR_ALLOC_R, L1_WRBK_ACC, gpu ){}
+
 };
 
 /// Models second level shared cache with global write-back
 /// and write-allocate policies
 class l2_cache : public data_cache {
- public:
-  l2_cache(const char *name, cache_config &config, int core_id, int type_id,
-           mem_fetch_interface *memport, mem_fetch_allocator *mfcreator,
-           enum mem_fetch_status status, class gpgpu_sim *gpu)
-      : data_cache(name, config, core_id, type_id, memport, mfcreator, status,
-                   L2_WR_ALLOC_R, L2_WRBK_ACC, gpu) {}
+public:
+    l2_cache(const char *name,  cache_config &config,
+            int core_id, int type_id, mem_fetch_interface *memport,
+            mem_fetch_allocator *mfcreator, enum mem_fetch_status status, class gpgpu_sim* gpu )
+            : data_cache(name,config,core_id,type_id,memport,mfcreator,status, L2_WR_ALLOC_R, L2_WRBK_ACC, gpu){}
 
-  virtual ~l2_cache() {}
+    virtual ~l2_cache() {}
 
-  virtual enum cache_request_status access(new_addr_type addr, mem_fetch *mf,
-                                           unsigned time,
-                                           std::list<cache_event> &events);
+    virtual enum cache_request_status
+        access( new_addr_type addr,
+                mem_fetch *mf,
+                unsigned time,
+                std::list<cache_event> &events );
 };
 
 /*****************************************************************************/
 
 // See the following paper to understand this cache model:
-//
-// Igehy, et al., Prefetching in a Texture Cache Architecture,
+// 
+// Igehy, et al., Prefetching in a Texture Cache Architecture, 
 // Proceedings of the 1998 Eurographics/SIGGRAPH Workshop on Graphics Hardware
 // http://www-graphics.stanford.edu/papers/texture_prefetch/
 class tex_cache : public cache_t {
- public:
-  tex_cache(const char *name, cache_config &config, int core_id, int type_id,
-            mem_fetch_interface *memport, enum mem_fetch_status request_status,
-            enum mem_fetch_status rob_status)
-      : m_config(config),
-        m_tags(config, core_id, type_id),
-        m_fragment_fifo(config.m_fragment_fifo_entries),
-        m_request_fifo(config.m_request_fifo_entries),
-        m_rob(config.m_rob_entries),
-        m_result_fifo(config.m_result_fifo_entries) {
-    m_name = name;
-    assert(config.m_mshr_type == TEX_FIFO ||
-           config.m_mshr_type == SECTOR_TEX_FIFO);
-    assert(config.m_write_policy == READ_ONLY);
-    assert(config.m_alloc_policy == ON_MISS);
-    m_memport = memport;
-    m_cache = new data_block[config.get_num_lines()];
-    m_request_queue_status = request_status;
-    m_rob_status = rob_status;
-  }
-
-  /// Access function for tex_cache
-  /// return values: RESERVATION_FAIL if request could not be accepted
-  /// otherwise returns HIT_RESERVED or MISS; NOTE: *never* returns HIT
-  /// since unlike a normal CPU cache, a "HIT" in texture cache does not
-  /// mean the data is ready (still need to get through fragment fifo)
-  enum cache_request_status access(new_addr_type addr, mem_fetch *mf,
-                                   unsigned time,
-                                   std::list<cache_event> &events);
-  void cycle();
-  /// Place returning cache block into reorder buffer
-  void fill(mem_fetch *mf, unsigned time);
-  /// Are any (accepted) accesses that had to wait for memory now ready? (does
-  /// not include accesses that "HIT")
-  bool access_ready() const { return !m_result_fifo.empty(); }
-  /// Pop next ready access (includes both accesses that "HIT" and those that
-  /// "MISS")
-  mem_fetch *next_access() { return m_result_fifo.pop(); }
-  void display_state(FILE *fp) const;
-
-  // accessors for cache bandwidth availability - stubs for now
-  bool data_port_free() const { return true; }
-  bool fill_port_free() const { return true; }
-
-  // Stat collection
-  const cache_stats &get_stats() const { return m_stats; }
-  unsigned get_stats(enum mem_access_type *access_type,
-                     unsigned num_access_type,
-                     enum cache_request_status *access_status,
-                     unsigned num_access_status) const {
-    return m_stats.get_stats(access_type, num_access_type, access_status,
-                             num_access_status);
-  }
-
-  void get_sub_stats(struct cache_sub_stats &css) const {
-    m_stats.get_sub_stats(css);
-  }
-
- private:
-  std::string m_name;
-  const cache_config &m_config;
-
-  struct fragment_entry {
-    fragment_entry() {}
-    fragment_entry(mem_fetch *mf, unsigned idx, bool m, unsigned d) {
-      m_request = mf;
-      m_cache_index = idx;
-      m_miss = m;
-      m_data_size = d;
-    }
-    mem_fetch *m_request;    // request information
-    unsigned m_cache_index;  // where to look for data
-    bool m_miss;             // true if sent memory request
-    unsigned m_data_size;
-  };
-
-  struct rob_entry {
-    rob_entry() {
-      m_ready = false;
-      m_time = 0;
-      m_request = NULL;
-    }
-    rob_entry(unsigned i, mem_fetch *mf, new_addr_type a) {
-      m_ready = false;
-      m_index = i;
-      m_time = 0;
-      m_request = mf;
-      m_block_addr = a;
-    }
-    bool m_ready;
-    unsigned m_time;   // which cycle did this entry become ready?
-    unsigned m_index;  // where in cache should block be placed?
-    mem_fetch *m_request;
-    new_addr_type m_block_addr;
-  };
-
-  struct data_block {
-    data_block() { m_valid = false; }
-    bool m_valid;
-    new_addr_type m_block_addr;
-  };
-
-  // TODO: replace fifo_pipeline with this?
-  template <class T>
-  class fifo {
-   public:
-    fifo(unsigned size) {
-      m_size = size;
-      m_num = 0;
-      m_head = 0;
-      m_tail = 0;
-      m_data = new T[size];
-    }
-    bool full() const { return m_num == m_size; }
-    bool empty() const { return m_num == 0; }
-    unsigned size() const { return m_num; }
-    unsigned capacity() const { return m_size; }
-    unsigned push(const T &e) {
-      assert(!full());
-      m_data[m_head] = e;
-      unsigned result = m_head;
-      inc_head();
-      return result;
-    }
-    T pop() {
-      assert(!empty());
-      T result = m_data[m_tail];
-      inc_tail();
-      return result;
-    }
-    const T &peek(unsigned index) const {
-      assert(index < m_size);
-      return m_data[index];
-    }
-    T &peek(unsigned index) {
-      assert(index < m_size);
-      return m_data[index];
-    }
-    T &peek() const { return m_data[m_tail]; }
-    unsigned next_pop_index() const { return m_tail; }
-
-   private:
-    void inc_head() {
-      m_head = (m_head + 1) % m_size;
-      m_num++;
-    }
-    void inc_tail() {
-      assert(m_num > 0);
-      m_tail = (m_tail + 1) % m_size;
-      m_num--;
+public:
+    tex_cache( const char *name, cache_config &config, int core_id, int type_id, mem_fetch_interface *memport,
+               enum mem_fetch_status request_status, 
+               enum mem_fetch_status rob_status )
+    : m_config(config), 
+    m_tags(config,core_id,type_id), 
+    m_fragment_fifo(config.m_fragment_fifo_entries), 
+    m_request_fifo(config.m_request_fifo_entries),
+    m_rob(config.m_rob_entries),
+    m_result_fifo(config.m_result_fifo_entries)
+    {
+        m_name = name;
+        assert(config.m_mshr_type == TEX_FIFO || config.m_mshr_type == SECTOR_TEX_FIFO );
+        assert(config.m_write_policy == READ_ONLY);
+        assert(config.m_alloc_policy == ON_MISS);
+        m_memport=memport;
+        m_cache = new data_block[ config.get_num_lines() ];
+        m_request_queue_status = request_status;
+        m_rob_status = rob_status;
     }
 
-    unsigned m_head;  // next entry goes here
-    unsigned m_tail;  // oldest entry found here
-    unsigned m_num;   // how many in fifo?
-    unsigned m_size;  // maximum number of entries in fifo
-    T *m_data;
-  };
+    /// Access function for tex_cache
+    /// return values: RESERVATION_FAIL if request could not be accepted
+    /// otherwise returns HIT_RESERVED or MISS; NOTE: *never* returns HIT
+    /// since unlike a normal CPU cache, a "HIT" in texture cache does not
+    /// mean the data is ready (still need to get through fragment fifo)
+    enum cache_request_status access( new_addr_type addr, mem_fetch *mf, unsigned time, std::list<cache_event> &events );
+    void cycle();
+    /// Place returning cache block into reorder buffer
+    void fill( mem_fetch *mf, unsigned time );
+    /// Are any (accepted) accesses that had to wait for memory now ready? (does not include accesses that "HIT")
+    bool access_ready() const{return !m_result_fifo.empty();}
+    /// Pop next ready access (includes both accesses that "HIT" and those that "MISS")
+    mem_fetch *next_access(){return m_result_fifo.pop();}
+    void display_state( FILE *fp ) const;
 
-  tag_array m_tags;
-  fifo<fragment_entry> m_fragment_fifo;
-  fifo<mem_fetch *> m_request_fifo;
-  fifo<rob_entry> m_rob;
-  data_block *m_cache;
-  fifo<mem_fetch *> m_result_fifo;  // next completed texture fetch
+    // accessors for cache bandwidth availability - stubs for now 
+    bool data_port_free() const { return true; }
+    bool fill_port_free() const { return true; }
 
-  mem_fetch_interface *m_memport;
-  enum mem_fetch_status m_request_queue_status;
-  enum mem_fetch_status m_rob_status;
-
-  struct extra_mf_fields {
-    extra_mf_fields() { m_valid = false; }
-    extra_mf_fields(unsigned i, const cache_config &m_config) {
-      m_valid = true;
-      m_rob_index = i;
-      pending_read = m_config.m_mshr_type == SECTOR_TEX_FIFO
-                         ? m_config.m_line_sz / SECTOR_SIZE
-                         : 0;
+    // Stat collection
+    const cache_stats &get_stats() const {
+        return m_stats;
     }
-    bool m_valid;
-    unsigned m_rob_index;
-    unsigned pending_read;
-  };
+    unsigned get_stats(enum mem_access_type *access_type, unsigned num_access_type, enum cache_request_status *access_status, unsigned num_access_status) const{
+        return m_stats.get_stats(access_type, num_access_type, access_status, num_access_status);
+    }
 
-  cache_stats m_stats;
+    void get_sub_stats(struct cache_sub_stats &css) const{
+        m_stats.get_sub_stats(css);
+    }
+private:
+    std::string m_name;
+    const cache_config &m_config;
 
-  typedef std::map<mem_fetch *, extra_mf_fields> extra_mf_fields_lookup;
+    struct fragment_entry {
+        fragment_entry() {}
+        fragment_entry( mem_fetch *mf, unsigned idx, bool m, unsigned d )
+        {
+            m_request=mf;
+            m_cache_index=idx;
+            m_miss=m;
+            m_data_size=d;
+        }
+        mem_fetch *m_request;     // request information
+        unsigned   m_cache_index; // where to look for data
+        bool       m_miss;        // true if sent memory request
+        unsigned   m_data_size;
+    };
 
-  extra_mf_fields_lookup m_extra_mf_fields;
+    struct rob_entry {
+        rob_entry() { m_ready = false; m_time=0; m_request=NULL;}
+        rob_entry( unsigned i, mem_fetch *mf, new_addr_type a ) 
+        { 
+            m_ready=false; 
+            m_index=i;
+            m_time=0;
+            m_request=mf; 
+            m_block_addr=a;
+        }
+        bool m_ready;
+        unsigned m_time; // which cycle did this entry become ready?
+        unsigned m_index; // where in cache should block be placed?
+        mem_fetch *m_request;
+        new_addr_type m_block_addr;
+    };
+
+    struct data_block {
+        data_block() { m_valid = false;}
+        bool m_valid;
+        new_addr_type m_block_addr;
+    };
+
+    // TODO: replace fifo_pipeline with this?
+    template<class T> class fifo {
+    public:
+        fifo( unsigned size ) 
+        { 
+            m_size=size; 
+            m_num=0; 
+            m_head=0; 
+            m_tail=0; 
+            m_data = new T[size];
+        }
+        bool full() const { return m_num == m_size;}
+        bool empty() const { return m_num == 0;}
+        unsigned size() const { return m_num;}
+        unsigned capacity() const { return m_size;}
+        unsigned push( const T &e ) 
+        { 
+            assert(!full()); 
+            m_data[m_head] = e; 
+            unsigned result = m_head;
+            inc_head(); 
+            return result;
+        }
+        T pop() 
+        { 
+            assert(!empty()); 
+            T result = m_data[m_tail];
+            inc_tail();
+            return result;
+        }
+        const T &peek( unsigned index ) const 
+        { 
+            assert( index < m_size );
+            return m_data[index]; 
+        }
+        T &peek( unsigned index ) 
+        { 
+            assert( index < m_size );
+            return m_data[index]; 
+        }
+        T &peek() const
+        { 
+            return m_data[m_tail]; 
+        }
+        unsigned next_pop_index() const 
+        {
+            return m_tail;
+        }
+    private:
+        void inc_head() { m_head = (m_head+1)%m_size; m_num++;}
+        void inc_tail() { assert(m_num>0); m_tail = (m_tail+1)%m_size; m_num--;}
+
+        unsigned   m_head; // next entry goes here
+        unsigned   m_tail; // oldest entry found here
+        unsigned   m_num;  // how many in fifo?
+        unsigned   m_size; // maximum number of entries in fifo
+        T         *m_data;
+    };
+
+    tag_array               m_tags;
+    fifo<fragment_entry>    m_fragment_fifo;
+    fifo<mem_fetch*>        m_request_fifo;
+    fifo<rob_entry>         m_rob;
+    data_block             *m_cache;
+    fifo<mem_fetch*>        m_result_fifo; // next completed texture fetch
+
+    mem_fetch_interface    *m_memport;
+    enum mem_fetch_status   m_request_queue_status;
+    enum mem_fetch_status   m_rob_status;
+
+    struct extra_mf_fields {
+        extra_mf_fields()  { m_valid = false;}
+        extra_mf_fields( unsigned i, const cache_config &m_config )
+        {
+            m_valid = true;
+            m_rob_index = i;
+            pending_read = m_config.m_mshr_type == SECTOR_TEX_FIFO? m_config.m_line_sz/SECTOR_SIZE : 0;
+        }
+        bool m_valid;
+        unsigned m_rob_index;
+        unsigned pending_read;
+    };
+
+    cache_stats m_stats;
+
+    typedef std::map<mem_fetch*,extra_mf_fields> extra_mf_fields_lookup;
+
+    extra_mf_fields_lookup m_extra_mf_fields;
 };
 
 #endif

--- a/src/gpgpu-sim/gpu-cache.h
+++ b/src/gpgpu-sim/gpu-cache.h
@@ -7,487 +7,444 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef GPU_CACHE_H
 #define GPU_CACHE_H
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "gpu-misc.h"
-#include "mem_fetch.h"
 #include "../abstract_hardware_model.h"
 #include "../tr1_hash_map.h"
+#include "gpu-misc.h"
+#include "mem_fetch.h"
 
-#include "addrdec.h"
 #include <iostream>
+#include "addrdec.h"
 
 #define MAX_DEFAULT_CACHE_SIZE_MULTIBLIER 4
 
-enum cache_block_state {
-    INVALID=0,
-    RESERVED,
-    VALID,
-    MODIFIED
-};
+enum cache_block_state { INVALID = 0, RESERVED, VALID, MODIFIED };
 
 enum cache_request_status {
-    HIT = 0,
-    HIT_RESERVED,
-    MISS,
-    RESERVATION_FAIL, 
-	SECTOR_MISS,
-    NUM_CACHE_REQUEST_STATUS
+  HIT = 0,
+  HIT_RESERVED,
+  MISS,
+  RESERVATION_FAIL,
+  SECTOR_MISS,
+  NUM_CACHE_REQUEST_STATUS
 };
 
 enum cache_reservation_fail_reason {
-	LINE_ALLOC_FAIL= 0,// all line are reserved
-	MISS_QUEUE_FULL,   // MISS queue (i.e. interconnect or DRAM) is full
-	MSHR_ENRTY_FAIL,
-	MSHR_MERGE_ENRTY_FAIL,
-	MSHR_RW_PENDING,
-    NUM_CACHE_RESERVATION_FAIL_STATUS
+  LINE_ALLOC_FAIL = 0,  // all line are reserved
+  MISS_QUEUE_FULL,      // MISS queue (i.e. interconnect or DRAM) is full
+  MSHR_ENRTY_FAIL,
+  MSHR_MERGE_ENRTY_FAIL,
+  MSHR_RW_PENDING,
+  NUM_CACHE_RESERVATION_FAIL_STATUS
 };
 
 enum cache_event_type {
-    WRITE_BACK_REQUEST_SENT,
-    READ_REQUEST_SENT,
-    WRITE_REQUEST_SENT,
-	WRITE_ALLOCATE_SENT
+  WRITE_BACK_REQUEST_SENT,
+  READ_REQUEST_SENT,
+  WRITE_REQUEST_SENT,
+  WRITE_ALLOCATE_SENT
 };
 
 struct evicted_block_info {
-	new_addr_type m_block_addr;
-	unsigned m_modified_size;
-	evicted_block_info() {
-		m_block_addr = 0;
-		m_modified_size = 0;
-	}
-	void set_info(new_addr_type block_addr, unsigned modified_size){
-		m_block_addr = block_addr;
-		m_modified_size = modified_size;
-	}
+  new_addr_type m_block_addr;
+  unsigned m_modified_size;
+  evicted_block_info() {
+    m_block_addr = 0;
+    m_modified_size = 0;
+  }
+  void set_info(new_addr_type block_addr, unsigned modified_size) {
+    m_block_addr = block_addr;
+    m_modified_size = modified_size;
+  }
 };
 
 struct cache_event {
-	enum cache_event_type m_cache_event_type;
-	evicted_block_info m_evicted_block; //if it was write_back event, fill the the evicted block info
+  enum cache_event_type m_cache_event_type;
+  evicted_block_info m_evicted_block;  // if it was write_back event, fill the
+                                       // the evicted block info
 
-	cache_event(enum cache_event_type m_cache_event){
-		m_cache_event_type = m_cache_event;
-	}
+  cache_event(enum cache_event_type m_cache_event) {
+    m_cache_event_type = m_cache_event;
+  }
 
-	cache_event(enum cache_event_type cache_event, evicted_block_info evicted_block){
-	m_cache_event_type = cache_event;
-	m_evicted_block = evicted_block;
-	}
+  cache_event(enum cache_event_type cache_event,
+              evicted_block_info evicted_block) {
+    m_cache_event_type = cache_event;
+    m_evicted_block = evicted_block;
+  }
 };
 
-const char * cache_request_status_str(enum cache_request_status status); 
+const char *cache_request_status_str(enum cache_request_status status);
 
 struct cache_block_t {
-    cache_block_t()
-    {
-        m_tag=0;
-        m_block_addr=0;
-    }
+  cache_block_t() {
+    m_tag = 0;
+    m_block_addr = 0;
+  }
 
-    virtual void allocate( new_addr_type tag, new_addr_type block_addr, unsigned time, mem_access_sector_mask_t sector_mask) = 0;
-    virtual void fill( unsigned time, mem_access_sector_mask_t sector_mask) = 0;
+  virtual void allocate(new_addr_type tag, new_addr_type block_addr,
+                        unsigned time,
+                        mem_access_sector_mask_t sector_mask) = 0;
+  virtual void fill(unsigned time, mem_access_sector_mask_t sector_mask) = 0;
 
-    virtual bool is_invalid_line() = 0;
-    virtual bool is_valid_line() = 0;
-    virtual bool is_reserved_line() = 0;
-    virtual bool is_modified_line() = 0;
+  virtual bool is_invalid_line() = 0;
+  virtual bool is_valid_line() = 0;
+  virtual bool is_reserved_line() = 0;
+  virtual bool is_modified_line() = 0;
 
-    virtual enum cache_block_state get_status( mem_access_sector_mask_t sector_mask) = 0;
-    virtual void set_status(enum cache_block_state m_status, mem_access_sector_mask_t sector_mask) = 0;
+  virtual enum cache_block_state get_status(
+      mem_access_sector_mask_t sector_mask) = 0;
+  virtual void set_status(enum cache_block_state m_status,
+                          mem_access_sector_mask_t sector_mask) = 0;
 
-    virtual unsigned long long get_last_access_time() = 0;
-    virtual void set_last_access_time(unsigned long long time, mem_access_sector_mask_t sector_mask) = 0;
-    virtual unsigned long long get_alloc_time() = 0;
-    virtual void set_ignore_on_fill(bool m_ignore, mem_access_sector_mask_t sector_mask) = 0;
-    virtual void set_modified_on_fill(bool m_modified, mem_access_sector_mask_t sector_mask) = 0;
-    virtual unsigned get_modified_size() = 0;
-    virtual void set_m_readable(bool readable, mem_access_sector_mask_t sector_mask)=0;
-    virtual bool is_readable(mem_access_sector_mask_t sector_mask)=0;
-    virtual void print_status()=0;
-    virtual ~cache_block_t() {}
+  virtual unsigned long long get_last_access_time() = 0;
+  virtual void set_last_access_time(unsigned long long time,
+                                    mem_access_sector_mask_t sector_mask) = 0;
+  virtual unsigned long long get_alloc_time() = 0;
+  virtual void set_ignore_on_fill(bool m_ignore,
+                                  mem_access_sector_mask_t sector_mask) = 0;
+  virtual void set_modified_on_fill(bool m_modified,
+                                    mem_access_sector_mask_t sector_mask) = 0;
+  virtual unsigned get_modified_size() = 0;
+  virtual void set_m_readable(bool readable,
+                              mem_access_sector_mask_t sector_mask) = 0;
+  virtual bool is_readable(mem_access_sector_mask_t sector_mask) = 0;
+  virtual void print_status() = 0;
+  virtual ~cache_block_t() {}
 
-
-    new_addr_type    m_tag;
-    new_addr_type    m_block_addr;
-
+  new_addr_type m_tag;
+  new_addr_type m_block_addr;
 };
 
-struct line_cache_block: public cache_block_t  {
-	line_cache_block()
-	    {
-	        m_alloc_time=0;
-	        m_fill_time=0;
-	        m_last_access_time=0;
-	        m_status=INVALID;
-	        m_ignore_on_fill_status = false;
-	        m_set_modified_on_fill = false;
-	        m_readable = true;
-	    }
-	    void allocate( new_addr_type tag, new_addr_type block_addr, unsigned time, mem_access_sector_mask_t sector_mask)
-	    {
-	        m_tag=tag;
-	        m_block_addr=block_addr;
-	        m_alloc_time=time;
-	        m_last_access_time=time;
-	        m_fill_time=0;
-	        m_status=RESERVED;
-	        m_ignore_on_fill_status = false;
-	        m_set_modified_on_fill = false;
-	    }
-		void fill( unsigned time, mem_access_sector_mask_t sector_mask )
-	    {
-	    	//if(!m_ignore_on_fill_status)
-	    	//	assert( m_status == RESERVED );
+struct line_cache_block : public cache_block_t {
+  line_cache_block() {
+    m_alloc_time = 0;
+    m_fill_time = 0;
+    m_last_access_time = 0;
+    m_status = INVALID;
+    m_ignore_on_fill_status = false;
+    m_set_modified_on_fill = false;
+    m_readable = true;
+  }
+  void allocate(new_addr_type tag, new_addr_type block_addr, unsigned time,
+                mem_access_sector_mask_t sector_mask) {
+    m_tag = tag;
+    m_block_addr = block_addr;
+    m_alloc_time = time;
+    m_last_access_time = time;
+    m_fill_time = 0;
+    m_status = RESERVED;
+    m_ignore_on_fill_status = false;
+    m_set_modified_on_fill = false;
+  }
+  void fill(unsigned time, mem_access_sector_mask_t sector_mask) {
+    // if(!m_ignore_on_fill_status)
+    //	assert( m_status == RESERVED );
 
-	    	m_status = m_set_modified_on_fill? MODIFIED : VALID;
+    m_status = m_set_modified_on_fill ? MODIFIED : VALID;
 
-	        m_fill_time=time;
-	    }
-		virtual bool is_invalid_line()
-	    {
-	    	return m_status == INVALID;
-	    }
-		virtual bool is_valid_line()
-	    {
-	    	 return m_status == VALID;
-	    }
-		virtual bool is_reserved_line()
-	    {
-	    	 return m_status == RESERVED;
-	    }
-		virtual bool is_modified_line()
-	    {
-	    	return m_status == MODIFIED;
-	    }
+    m_fill_time = time;
+  }
+  virtual bool is_invalid_line() { return m_status == INVALID; }
+  virtual bool is_valid_line() { return m_status == VALID; }
+  virtual bool is_reserved_line() { return m_status == RESERVED; }
+  virtual bool is_modified_line() { return m_status == MODIFIED; }
 
-		virtual enum cache_block_state get_status(mem_access_sector_mask_t sector_mask)
-	    {
-	    	return m_status;
-	    }
-		virtual void set_status(enum cache_block_state status, mem_access_sector_mask_t sector_mask)
-	    {
-	    	m_status = status;
-	    }
-		virtual unsigned long long get_last_access_time()
-		{
-			return m_last_access_time;
-		}
-		virtual void set_last_access_time(unsigned long long time, mem_access_sector_mask_t sector_mask)
-	    {
-	    	m_last_access_time = time;
-	    }
-		virtual unsigned long long get_alloc_time()
-	    {
-	    	return m_alloc_time;
-	    }
-		virtual void set_ignore_on_fill(bool m_ignore, mem_access_sector_mask_t sector_mask)
-		{
-			m_ignore_on_fill_status = m_ignore;
-		}
-		virtual void set_modified_on_fill(bool m_modified, mem_access_sector_mask_t sector_mask)
-		{
-	    	m_set_modified_on_fill = m_modified;
-		}
-		virtual unsigned  get_modified_size()
-		{
-			return SECTOR_CHUNCK_SIZE * SECTOR_SIZE;   //i.e. cache line size
-		}
-		virtual void set_m_readable(bool readable, mem_access_sector_mask_t sector_mask)
-		{
-			m_readable = readable;
-		}
-		virtual bool is_readable(mem_access_sector_mask_t sector_mask) {
-			return m_readable;
-		}
-		virtual void print_status() {
-			 printf("m_block_addr is %llu, status = %u\n", m_block_addr, m_status);
-		}
+  virtual enum cache_block_state get_status(
+      mem_access_sector_mask_t sector_mask) {
+    return m_status;
+  }
+  virtual void set_status(enum cache_block_state status,
+                          mem_access_sector_mask_t sector_mask) {
+    m_status = status;
+  }
+  virtual unsigned long long get_last_access_time() {
+    return m_last_access_time;
+  }
+  virtual void set_last_access_time(unsigned long long time,
+                                    mem_access_sector_mask_t sector_mask) {
+    m_last_access_time = time;
+  }
+  virtual unsigned long long get_alloc_time() { return m_alloc_time; }
+  virtual void set_ignore_on_fill(bool m_ignore,
+                                  mem_access_sector_mask_t sector_mask) {
+    m_ignore_on_fill_status = m_ignore;
+  }
+  virtual void set_modified_on_fill(bool m_modified,
+                                    mem_access_sector_mask_t sector_mask) {
+    m_set_modified_on_fill = m_modified;
+  }
+  virtual unsigned get_modified_size() {
+    return SECTOR_CHUNCK_SIZE * SECTOR_SIZE;  // i.e. cache line size
+  }
+  virtual void set_m_readable(bool readable,
+                              mem_access_sector_mask_t sector_mask) {
+    m_readable = readable;
+  }
+  virtual bool is_readable(mem_access_sector_mask_t sector_mask) {
+    return m_readable;
+  }
+  virtual void print_status() {
+    printf("m_block_addr is %llu, status = %u\n", m_block_addr, m_status);
+  }
 
-
-private:
-	    unsigned long long     m_alloc_time;
-	    unsigned long long     m_last_access_time;
-	    unsigned long long     m_fill_time;
-	    cache_block_state    m_status;
-	    bool m_ignore_on_fill_status;
-	    bool m_set_modified_on_fill;
-	    bool m_readable;
+ private:
+  unsigned long long m_alloc_time;
+  unsigned long long m_last_access_time;
+  unsigned long long m_fill_time;
+  cache_block_state m_status;
+  bool m_ignore_on_fill_status;
+  bool m_set_modified_on_fill;
+  bool m_readable;
 };
 
 struct sector_cache_block : public cache_block_t {
-	sector_cache_block()
-    {
-		init();
+  sector_cache_block() { init(); }
+
+  void init() {
+    for (unsigned i = 0; i < SECTOR_CHUNCK_SIZE; ++i) {
+      m_sector_alloc_time[i] = 0;
+      m_sector_fill_time[i] = 0;
+      m_last_sector_access_time[i] = 0;
+      m_status[i] = INVALID;
+      m_ignore_on_fill_status[i] = false;
+      m_set_modified_on_fill[i] = false;
+      m_readable[i] = true;
     }
+    m_line_alloc_time = 0;
+    m_line_last_access_time = 0;
+    m_line_fill_time = 0;
+  }
 
-	void init() {
-		for(unsigned i =0; i< SECTOR_CHUNCK_SIZE; ++i) {
-			m_sector_alloc_time[i]= 0;
-			m_sector_fill_time[i]= 0;
-			m_last_sector_access_time[i]= 0;
-			m_status[i]= INVALID;
-			m_ignore_on_fill_status[i] = false;
-			m_set_modified_on_fill[i] = false;
-			m_readable[i] = true;
-			}
-			m_line_alloc_time=0;
-			m_line_last_access_time=0;
-			m_line_fill_time=0;
-	}
+  virtual void allocate(new_addr_type tag, new_addr_type block_addr,
+                        unsigned time, mem_access_sector_mask_t sector_mask) {
+    allocate_line(tag, block_addr, time, sector_mask);
+  }
 
-	virtual void allocate( new_addr_type tag, new_addr_type block_addr, unsigned time, mem_access_sector_mask_t sector_mask )
-    {
-    	allocate_line( tag,  block_addr,  time, sector_mask );
-    }
+  void allocate_line(new_addr_type tag, new_addr_type block_addr, unsigned time,
+                     mem_access_sector_mask_t sector_mask) {
+    // allocate a new line
+    // assert(m_block_addr != 0 && m_block_addr != block_addr);
+    init();
+    m_tag = tag;
+    m_block_addr = block_addr;
 
-    void allocate_line( new_addr_type tag, new_addr_type block_addr, unsigned time, mem_access_sector_mask_t sector_mask )
-	{
-		//allocate a new line
-		//assert(m_block_addr != 0 && m_block_addr != block_addr);
-		init();
-		m_tag=tag;
-		m_block_addr=block_addr;
+    unsigned sidx = get_sector_index(sector_mask);
 
-		unsigned sidx = get_sector_index(sector_mask);
+    // set sector stats
+    m_sector_alloc_time[sidx] = time;
+    m_last_sector_access_time[sidx] = time;
+    m_sector_fill_time[sidx] = 0;
+    m_status[sidx] = RESERVED;
+    m_ignore_on_fill_status[sidx] = false;
+    m_set_modified_on_fill[sidx] = false;
 
-		//set sector stats
-		m_sector_alloc_time[sidx]=time;
-		m_last_sector_access_time[sidx]=time;
-		m_sector_fill_time[sidx]=0;
-		m_status[sidx]=RESERVED;
-		m_ignore_on_fill_status[sidx] = false;
-		m_set_modified_on_fill[sidx] = false;
+    // set line stats
+    m_line_alloc_time = time;  // only set this for the first allocated sector
+    m_line_last_access_time = time;
+    m_line_fill_time = 0;
+  }
 
-		//set line stats
-		m_line_alloc_time=time;   //only set this for the first allocated sector
-		m_line_last_access_time=time;
-		m_line_fill_time=0;
-	}
+  void allocate_sector(unsigned time, mem_access_sector_mask_t sector_mask) {
+    // allocate invalid sector of this allocated valid line
+    assert(is_valid_line());
+    unsigned sidx = get_sector_index(sector_mask);
 
-    void allocate_sector(unsigned time, mem_access_sector_mask_t sector_mask )
-	{
-    	//allocate invalid sector of this allocated valid line
-    	assert(is_valid_line());
-		unsigned sidx = get_sector_index(sector_mask);
+    // set sector stats
+    m_sector_alloc_time[sidx] = time;
+    m_last_sector_access_time[sidx] = time;
+    m_sector_fill_time[sidx] = 0;
+    if (m_status[sidx] == MODIFIED)  // this should be the case only for
+                                     // fetch-on-write policy //TO DO
+      m_set_modified_on_fill[sidx] = true;
+    else
+      m_set_modified_on_fill[sidx] = false;
 
-		//set sector stats
-		m_sector_alloc_time[sidx]=time;
-		m_last_sector_access_time[sidx]=time;
-		m_sector_fill_time[sidx]=0;
-		if(m_status[sidx]==MODIFIED)    //this should be the case only for fetch-on-write policy //TO DO
-			m_set_modified_on_fill[sidx] = true;
-		else
-			m_set_modified_on_fill[sidx] = false;
+    m_status[sidx] = RESERVED;
+    m_ignore_on_fill_status[sidx] = false;
+    // m_set_modified_on_fill[sidx] = false;
+    m_readable[sidx] = true;
 
-		m_status[sidx]=RESERVED;
-		m_ignore_on_fill_status[sidx] = false;
-		//m_set_modified_on_fill[sidx] = false;
-		m_readable[sidx] = true;
+    // set line stats
+    m_line_last_access_time = time;
+    m_line_fill_time = 0;
+  }
 
-		//set line stats
-		m_line_last_access_time=time;
-		m_line_fill_time=0;
-	}
-
-    virtual void fill( unsigned time, mem_access_sector_mask_t sector_mask)
-    {
-    	unsigned sidx = get_sector_index(sector_mask);
+  virtual void fill(unsigned time, mem_access_sector_mask_t sector_mask) {
+    unsigned sidx = get_sector_index(sector_mask);
 
     //	if(!m_ignore_on_fill_status[sidx])
     //	         assert( m_status[sidx] == RESERVED );
 
-    	m_status[sidx] = m_set_modified_on_fill[sidx]? MODIFIED : VALID;
+    m_status[sidx] = m_set_modified_on_fill[sidx] ? MODIFIED : VALID;
 
-        m_sector_fill_time[sidx]=time;
-        m_line_fill_time=time;
+    m_sector_fill_time[sidx] = time;
+    m_line_fill_time = time;
+  }
+  virtual bool is_invalid_line() {
+    // all the sectors should be invalid
+    for (unsigned i = 0; i < SECTOR_CHUNCK_SIZE; ++i) {
+      if (m_status[i] != INVALID) return false;
     }
-    virtual bool is_invalid_line() {
-    	//all the sectors should be invalid
-    	for(unsigned i =0; i< SECTOR_CHUNCK_SIZE; ++i) {
-    		if (m_status[i] != INVALID)
-    			return false;
-    	}
-    	return true;
+    return true;
+  }
+  virtual bool is_valid_line() { return !(is_invalid_line()); }
+  virtual bool is_reserved_line() {
+    // if any of the sector is reserved, then the line is reserved
+    for (unsigned i = 0; i < SECTOR_CHUNCK_SIZE; ++i) {
+      if (m_status[i] == RESERVED) return true;
     }
-    virtual bool is_valid_line() { return  !(is_invalid_line()); }
-    virtual bool is_reserved_line() {
-    	//if any of the sector is reserved, then the line is reserved
-		for(unsigned i =0; i< SECTOR_CHUNCK_SIZE; ++i) {
-			if (m_status[i] == RESERVED)
-				return true;
-		}
-		return false;
+    return false;
+  }
+  virtual bool is_modified_line() {
+    // if any of the sector is modified, then the line is modified
+    for (unsigned i = 0; i < SECTOR_CHUNCK_SIZE; ++i) {
+      if (m_status[i] == MODIFIED) return true;
     }
-    virtual bool is_modified_line() {
-    	//if any of the sector is modified, then the line is modified
-    	for(unsigned i =0; i< SECTOR_CHUNCK_SIZE; ++i) {
-			if (m_status[i] == MODIFIED)
-				return true;
-		}
-		return false;
+    return false;
+  }
+
+  virtual enum cache_block_state get_status(
+      mem_access_sector_mask_t sector_mask) {
+    unsigned sidx = get_sector_index(sector_mask);
+
+    return m_status[sidx];
+  }
+
+  virtual void set_status(enum cache_block_state status,
+                          mem_access_sector_mask_t sector_mask) {
+    unsigned sidx = get_sector_index(sector_mask);
+    m_status[sidx] = status;
+  }
+
+  virtual unsigned long long get_last_access_time() {
+    return m_line_last_access_time;
+  }
+
+  virtual void set_last_access_time(unsigned long long time,
+                                    mem_access_sector_mask_t sector_mask) {
+    unsigned sidx = get_sector_index(sector_mask);
+
+    m_last_sector_access_time[sidx] = time;
+    m_line_last_access_time = time;
+  }
+
+  virtual unsigned long long get_alloc_time() { return m_line_alloc_time; }
+
+  virtual void set_ignore_on_fill(bool m_ignore,
+                                  mem_access_sector_mask_t sector_mask) {
+    unsigned sidx = get_sector_index(sector_mask);
+    m_ignore_on_fill_status[sidx] = m_ignore;
+  }
+
+  virtual void set_modified_on_fill(bool m_modified,
+                                    mem_access_sector_mask_t sector_mask) {
+    unsigned sidx = get_sector_index(sector_mask);
+    m_set_modified_on_fill[sidx] = m_modified;
+  }
+
+  virtual void set_m_readable(bool readable,
+                              mem_access_sector_mask_t sector_mask) {
+    unsigned sidx = get_sector_index(sector_mask);
+    m_readable[sidx] = readable;
+  }
+
+  virtual bool is_readable(mem_access_sector_mask_t sector_mask) {
+    unsigned sidx = get_sector_index(sector_mask);
+    return m_readable[sidx];
+  }
+
+  virtual unsigned get_modified_size() {
+    unsigned modified = 0;
+    for (unsigned i = 0; i < SECTOR_CHUNCK_SIZE; ++i) {
+      if (m_status[i] == MODIFIED) modified++;
     }
+    return modified * SECTOR_SIZE;
+  }
 
-    virtual enum cache_block_state get_status(mem_access_sector_mask_t sector_mask)
-	{
-    	unsigned sidx = get_sector_index(sector_mask);
+  virtual void print_status() {
+    printf("m_block_addr is %llu, status = %u %u %u %u\n", m_block_addr,
+           m_status[0], m_status[1], m_status[2], m_status[3]);
+  }
 
-		return m_status[sidx];
-	}
+ private:
+  unsigned m_sector_alloc_time[SECTOR_CHUNCK_SIZE];
+  unsigned m_last_sector_access_time[SECTOR_CHUNCK_SIZE];
+  unsigned m_sector_fill_time[SECTOR_CHUNCK_SIZE];
+  unsigned m_line_alloc_time;
+  unsigned m_line_last_access_time;
+  unsigned m_line_fill_time;
+  cache_block_state m_status[SECTOR_CHUNCK_SIZE];
+  bool m_ignore_on_fill_status[SECTOR_CHUNCK_SIZE];
+  bool m_set_modified_on_fill[SECTOR_CHUNCK_SIZE];
+  bool m_readable[SECTOR_CHUNCK_SIZE];
 
-    virtual void set_status(enum cache_block_state status, mem_access_sector_mask_t sector_mask)
-	{
-		unsigned sidx = get_sector_index(sector_mask);
-		m_status[sidx] = status;
-	}
-
-    virtual unsigned long long get_last_access_time()
-	{
-		return m_line_last_access_time;
-	}
-
-    virtual void set_last_access_time(unsigned long long time, mem_access_sector_mask_t sector_mask)
-	{
-		unsigned sidx = get_sector_index(sector_mask);
-
-		m_last_sector_access_time[sidx] = time;
-		m_line_last_access_time = time;
-	}
-
-    virtual unsigned long long get_alloc_time()
-	{
-		return m_line_alloc_time;
-	}
-
-    virtual void set_ignore_on_fill(bool m_ignore, mem_access_sector_mask_t sector_mask)
-	{
-		unsigned sidx = get_sector_index(sector_mask);
-		m_ignore_on_fill_status[sidx] = m_ignore;
-	}
-
-    virtual void set_modified_on_fill(bool m_modified, mem_access_sector_mask_t sector_mask)
-	{
-		unsigned sidx = get_sector_index(sector_mask);
-		m_set_modified_on_fill[sidx] = m_modified;
-	}
-
-    virtual void set_m_readable(bool readable, mem_access_sector_mask_t sector_mask)
-    {
-    	unsigned sidx = get_sector_index(sector_mask);
-    	m_readable[sidx] = readable;
+  unsigned get_sector_index(mem_access_sector_mask_t sector_mask) {
+    assert(sector_mask.count() == 1);
+    for (unsigned i = 0; i < SECTOR_CHUNCK_SIZE; ++i) {
+      if (sector_mask.to_ulong() & (1 << i)) return i;
     }
-
-    virtual bool is_readable(mem_access_sector_mask_t sector_mask) {
-    	unsigned sidx = get_sector_index(sector_mask);
-    	return m_readable[sidx];
-	}
-
-    virtual unsigned  get_modified_size()
-	{
-		unsigned modified=0;
-		for(unsigned i =0; i< SECTOR_CHUNCK_SIZE; ++i) {
-			if (m_status[i] == MODIFIED)
-				modified++;
-		}
-		return modified * SECTOR_SIZE;
-	}
-
-    virtual void print_status() {
-    	 printf("m_block_addr is %llu, status = %u %u %u %u\n", m_block_addr, m_status[0], m_status[1], m_status[2], m_status[3]);
-    }
-
-
-private:
-    unsigned m_sector_alloc_time[SECTOR_CHUNCK_SIZE];
-    unsigned m_last_sector_access_time[SECTOR_CHUNCK_SIZE];
-    unsigned m_sector_fill_time[SECTOR_CHUNCK_SIZE];
-    unsigned m_line_alloc_time;
-    unsigned m_line_last_access_time;
-    unsigned m_line_fill_time;
-    cache_block_state    m_status[SECTOR_CHUNCK_SIZE];
-    bool m_ignore_on_fill_status[SECTOR_CHUNCK_SIZE];
-    bool m_set_modified_on_fill[SECTOR_CHUNCK_SIZE];
-    bool m_readable[SECTOR_CHUNCK_SIZE];
-
-    unsigned get_sector_index(mem_access_sector_mask_t sector_mask)
-    {
-    	assert(sector_mask.count() == 1);
-    	for(unsigned i =0; i< SECTOR_CHUNCK_SIZE; ++i) {
-    		if(sector_mask.to_ulong() & (1<<i))
-    			return i;
-    	}
-    }
+  }
 };
 
-enum replacement_policy_t {
-    LRU,
-    FIFO
-};
+enum replacement_policy_t { LRU, FIFO };
 
 enum write_policy_t {
-    READ_ONLY,
-    WRITE_BACK,
-    WRITE_THROUGH,
-    WRITE_EVICT,
-    LOCAL_WB_GLOBAL_WT
+  READ_ONLY,
+  WRITE_BACK,
+  WRITE_THROUGH,
+  WRITE_EVICT,
+  LOCAL_WB_GLOBAL_WT
 };
 
-enum allocation_policy_t {
-    ON_MISS,
-    ON_FILL,
-	STREAMING
-};
-
+enum allocation_policy_t { ON_MISS, ON_FILL, STREAMING };
 
 enum write_allocate_policy_t {
-	NO_WRITE_ALLOCATE,
-	WRITE_ALLOCATE,
-	FETCH_ON_WRITE,
-	LAZY_FETCH_ON_READ
+  NO_WRITE_ALLOCATE,
+  WRITE_ALLOCATE,
+  FETCH_ON_WRITE,
+  LAZY_FETCH_ON_READ
 };
 
 enum mshr_config_t {
-    TEX_FIFO, // Tex cache
-    ASSOC, // normal cache
-	SECTOR_TEX_FIFO,  //Tex cache sends requests to high-level sector cache
-	SECTOR_ASSOC // normal cache sends requests to high-level sector cache
+  TEX_FIFO,         // Tex cache
+  ASSOC,            // normal cache
+  SECTOR_TEX_FIFO,  // Tex cache sends requests to high-level sector cache
+  SECTOR_ASSOC      // normal cache sends requests to high-level sector cache
 };
 
-enum set_index_function{
-	LINEAR_SET_FUNCTION = 0,
-	BITWISE_XORING_FUNCTION,
-	HASH_IPOLY_FUNCTION,
-	FERMI_HASH_SET_FUNCTION,
-    CUSTOM_SET_FUNCTION
+enum set_index_function {
+  LINEAR_SET_FUNCTION = 0,
+  BITWISE_XORING_FUNCTION,
+  HASH_IPOLY_FUNCTION,
+  FERMI_HASH_SET_FUNCTION,
+  CUSTOM_SET_FUNCTION
 };
 
-enum cache_type{
-    NORMAL = 0,
-    SECTOR
-};
+enum cache_type { NORMAL = 0, SECTOR };
 
 #define MAX_WARP_PER_SHADER 64
 #define INCT_TOTAL_BUFFER 64
@@ -496,541 +453,604 @@ enum cache_type{
 #define MAX_WARP_PER_SHADER 64
 
 class cache_config {
-public:
-    cache_config() 
-    { 
-        m_valid = false; 
-        m_disabled = false;
-        m_config_string = NULL; // set by option parser
-        m_config_stringPrefL1 = NULL;
-        m_config_stringPrefShared = NULL;
-        m_data_port_width = 0;
+ public:
+  cache_config() {
+    m_valid = false;
+    m_disabled = false;
+    m_config_string = NULL;  // set by option parser
+    m_config_stringPrefL1 = NULL;
+    m_config_stringPrefShared = NULL;
+    m_data_port_width = 0;
+    m_set_index_function = LINEAR_SET_FUNCTION;
+    m_is_streaming = false;
+  }
+  void init(char *config, FuncCache status) {
+    cache_status = status;
+    assert(config);
+    char ct, rp, wp, ap, mshr_type, wap, sif;
+
+    int ntok =
+        sscanf(config, "%c:%u:%u:%u,%c:%c:%c:%c:%c,%c:%u:%u,%u:%u,%u", &ct,
+               &m_nset, &m_line_sz, &m_assoc, &rp, &wp, &ap, &wap, &sif,
+               &mshr_type, &m_mshr_entries, &m_mshr_max_merge,
+               &m_miss_queue_size, &m_result_fifo_entries, &m_data_port_width);
+
+    if (ntok < 12) {
+      if (!strcmp(config, "none")) {
+        m_disabled = true;
+        return;
+      }
+      exit_parse_error();
+    }
+
+    switch (ct) {
+      case 'N':
+        m_cache_type = NORMAL;
+        break;
+      case 'S':
+        m_cache_type = SECTOR;
+        break;
+      default:
+        exit_parse_error();
+    }
+    switch (rp) {
+      case 'L':
+        m_replacement_policy = LRU;
+        break;
+      case 'F':
+        m_replacement_policy = FIFO;
+        break;
+      default:
+        exit_parse_error();
+    }
+    switch (rp) {
+      case 'L':
+        m_replacement_policy = LRU;
+        break;
+      case 'F':
+        m_replacement_policy = FIFO;
+        break;
+      default:
+        exit_parse_error();
+    }
+    switch (wp) {
+      case 'R':
+        m_write_policy = READ_ONLY;
+        break;
+      case 'B':
+        m_write_policy = WRITE_BACK;
+        break;
+      case 'T':
+        m_write_policy = WRITE_THROUGH;
+        break;
+      case 'E':
+        m_write_policy = WRITE_EVICT;
+        break;
+      case 'L':
+        m_write_policy = LOCAL_WB_GLOBAL_WT;
+        break;
+      default:
+        exit_parse_error();
+    }
+    switch (ap) {
+      case 'm':
+        m_alloc_policy = ON_MISS;
+        break;
+      case 'f':
+        m_alloc_policy = ON_FILL;
+        break;
+      case 's':
+        m_alloc_policy = STREAMING;
+        break;
+      default:
+        exit_parse_error();
+    }
+    if (m_alloc_policy == STREAMING) {
+      // For streaming cache, we set the alloc policy to be on-fill to remove
+      // all line_alloc_fail stalls we set the MSHRs to be equal to max allocated
+      // cache lines. This is possible by moving TAG to be shared between cache
+      // line and MSHR enrty (i.e. for each cache line, there is an MSHR rntey
+      // associated with it) This is the easiest think we can think about to
+      // model (mimic) L1 streaming cache in Pascal and Volta Based on our
+      // microbenchmakrs, MSHRs entries have been increasing substantially in
+      // Pascal and Volta For more information about streaming cache, see:
+      // http://on-demand.gputechconf.com/gtc/2017/presentation/s7798-luke-durant-inside-volta.pdf
+      // https://ieeexplore.ieee.org/document/8344474/
+      m_is_streaming = true;
+      m_alloc_policy = ON_FILL;
+      m_mshr_entries = m_nset * m_assoc * MAX_DEFAULT_CACHE_SIZE_MULTIBLIER;
+      if (m_cache_type == SECTOR) m_mshr_entries *= SECTOR_CHUNCK_SIZE;
+      m_mshr_max_merge = MAX_WARP_PER_SM;
+    }
+    switch (mshr_type) {
+      case 'F':
+        m_mshr_type = TEX_FIFO;
+        assert(ntok == 14);
+        break;
+      case 'T':
+        m_mshr_type = SECTOR_TEX_FIFO;
+        assert(ntok == 14);
+        break;
+      case 'A':
+        m_mshr_type = ASSOC;
+        break;
+      case 'S':
+        m_mshr_type = SECTOR_ASSOC;
+        break;
+      default:
+        exit_parse_error();
+    }
+    m_line_sz_log2 = LOGB2(m_line_sz);
+    m_nset_log2 = LOGB2(m_nset);
+    m_valid = true;
+    m_atom_sz = (m_cache_type == SECTOR) ? SECTOR_SIZE : m_line_sz;
+    m_sector_sz_log2 = LOGB2(SECTOR_SIZE);
+    original_m_assoc = m_assoc;
+
+    // For more details about difference between FETCH_ON_WRITE and WRITE
+    // VALIDAE policies Read: Jouppi, Norman P. "Cache write policies and
+    // performance". ISCA 93. WRITE_ALLOCATE is the old write policy in
+    // GPGPU-sim 3.x, that send WRITE and READ for every write request
+    switch (wap) {
+      case 'N':
+        m_write_alloc_policy = NO_WRITE_ALLOCATE;
+        break;
+      case 'W':
+        m_write_alloc_policy = WRITE_ALLOCATE;
+        break;
+      case 'F':
+        m_write_alloc_policy = FETCH_ON_WRITE;
+        break;
+      case 'L':
+        m_write_alloc_policy = LAZY_FETCH_ON_READ;
+        break;
+      default:
+        exit_parse_error();
+    }
+
+    // detect invalid configuration
+    if (m_alloc_policy == ON_FILL and m_write_policy == WRITE_BACK) {
+      // A writeback cache with allocate-on-fill policy will inevitably lead to
+      // deadlock: The deadlock happens when an incoming cache-fill evicts a
+      // dirty line, generating a writeback request.  If the memory subsystem is
+      // congested, the interconnection network may not have sufficient buffer
+      // for the writeback request.  This stalls the incoming cache-fill.  The
+      // stall may propagate through the memory subsystem back to the output
+      // port of the same core, creating a deadlock where the wrtieback request
+      // and the incoming cache-fill are stalling each other.
+      assert(0 &&
+             "Invalid cache configuration: Writeback cache cannot allocate new "
+             "line on fill. ");
+    }
+
+    if ((m_write_alloc_policy == FETCH_ON_WRITE ||
+         m_write_alloc_policy == LAZY_FETCH_ON_READ) &&
+        m_alloc_policy == ON_FILL) {
+      assert(
+          0 &&
+          "Invalid cache configuration: FETCH_ON_WRITE and LAZY_FETCH_ON_READ "
+          "cannot work properly with ON_FILL policy. Cache must be ON_MISS. ");
+    }
+    if (m_cache_type == SECTOR) {
+      assert(m_line_sz / SECTOR_SIZE == SECTOR_CHUNCK_SIZE &&
+             m_line_sz % SECTOR_SIZE == 0);
+    }
+
+    // default: port to data array width and granularity = line size
+    if (m_data_port_width == 0) {
+      m_data_port_width = m_line_sz;
+    }
+    assert(m_line_sz % m_data_port_width == 0);
+
+    switch (sif) {
+      case 'H':
+        m_set_index_function = FERMI_HASH_SET_FUNCTION;
+        break;
+      case 'P':
+        m_set_index_function = HASH_IPOLY_FUNCTION;
+        break;
+      case 'C':
+        m_set_index_function = CUSTOM_SET_FUNCTION;
+        break;
+      case 'L':
         m_set_index_function = LINEAR_SET_FUNCTION;
-        m_is_streaming = false;
+        break;
+      default:
+        exit_parse_error();
     }
-    void init(char * config, FuncCache status)
-    {
-    	cache_status= status;
-        assert( config );
-        char ct, rp, wp, ap, mshr_type, wap, sif;
+  }
+  bool disabled() const { return m_disabled; }
+  unsigned get_line_sz() const {
+    assert(m_valid);
+    return m_line_sz;
+  }
+  unsigned get_atom_sz() const {
+    assert(m_valid);
+    return m_atom_sz;
+  }
+  unsigned get_num_lines() const {
+    assert(m_valid);
+    return m_nset * m_assoc;
+  }
+  unsigned get_max_num_lines() const {
+    assert(m_valid);
+    return MAX_DEFAULT_CACHE_SIZE_MULTIBLIER * m_nset * original_m_assoc;
+  }
+  void print(FILE *fp) const {
+    fprintf(fp, "Size = %d B (%d Set x %d-way x %d byte line)\n",
+            m_line_sz * m_nset * m_assoc, m_nset, m_assoc, m_line_sz);
+  }
 
-
-        int ntok = sscanf(config,"%c:%u:%u:%u,%c:%c:%c:%c:%c,%c:%u:%u,%u:%u,%u",
-                          &ct, &m_nset, &m_line_sz, &m_assoc, &rp, &wp, &ap, &wap,
-                          &sif,&mshr_type,&m_mshr_entries,&m_mshr_max_merge,
-                          &m_miss_queue_size, &m_result_fifo_entries,
-                          &m_data_port_width);
-
-        if ( ntok < 12 ) {
-            if ( !strcmp(config,"none") ) {
-                m_disabled = true;
-                return;
-            }
-            exit_parse_error();
-        }
-
-        switch (ct) {
-			   case 'N': m_cache_type = NORMAL; break;
-			   case 'S': m_cache_type = SECTOR; break;
-			   default: exit_parse_error();
-        }
-        switch (rp) {
-               case 'L': m_replacement_policy = LRU; break;
-               case 'F': m_replacement_policy = FIFO; break;
-               default: exit_parse_error();
-        }
-        switch (rp) {
-        case 'L': m_replacement_policy = LRU; break;
-        case 'F': m_replacement_policy = FIFO; break;
-        default: exit_parse_error();
-        }
-        switch (wp) {
-        case 'R': m_write_policy = READ_ONLY; break;
-        case 'B': m_write_policy = WRITE_BACK; break;
-        case 'T': m_write_policy = WRITE_THROUGH; break;
-        case 'E': m_write_policy = WRITE_EVICT; break;
-        case 'L': m_write_policy = LOCAL_WB_GLOBAL_WT; break;
-        default: exit_parse_error();
-        }
-        switch (ap) {
-        case 'm': m_alloc_policy = ON_MISS; break;
-        case 'f': m_alloc_policy = ON_FILL; break;
-        case 's': m_alloc_policy = STREAMING; break;
-        default: exit_parse_error();
-        }
-        if(m_alloc_policy == STREAMING) {
-        	//For streaming cache, we set the alloc policy to be on-fill to remove all line_alloc_fail stalls
-        	//we set the MSHRs to be equal to max allocated cache lines. This is possible by moving TAG to be shared between cache line and MSHR enrty (i.e. for each cache line, there is an MSHR rntey associated with it)
-        	//This is the easiest think we can think about to model (mimic) L1 streaming cache in Pascal and Volta
-        	//Based on our microbenchmakrs, MSHRs entries have been increasing substantially in Pascal and Volta
-        	//For more information about streaming cache, see:
-        	// http://on-demand.gputechconf.com/gtc/2017/presentation/s7798-luke-durant-inside-volta.pdf
-        	// https://ieeexplore.ieee.org/document/8344474/
-        	m_is_streaming = true;
-			m_alloc_policy = ON_FILL;
-			m_mshr_entries = m_nset*m_assoc*MAX_DEFAULT_CACHE_SIZE_MULTIBLIER;
-			if(m_cache_type == SECTOR)
-				m_mshr_entries *=  SECTOR_CHUNCK_SIZE;
-			m_mshr_max_merge = MAX_WARP_PER_SM;
-        }
-        switch (mshr_type) {
-        case 'F': m_mshr_type = TEX_FIFO; assert(ntok==14); break;
-        case 'T': m_mshr_type = SECTOR_TEX_FIFO; assert(ntok==14); break;
-        case 'A': m_mshr_type = ASSOC; break;
-        case 'S' : m_mshr_type = SECTOR_ASSOC; break;
-        default: exit_parse_error();
-        }
-        m_line_sz_log2 = LOGB2(m_line_sz);
-        m_nset_log2 = LOGB2(m_nset);
-        m_valid = true;
-        m_atom_sz = (m_cache_type == SECTOR)? SECTOR_SIZE : m_line_sz;
-        m_sector_sz_log2 = LOGB2(SECTOR_SIZE);
-        original_m_assoc = m_assoc;
-
-        //For more details about difference between FETCH_ON_WRITE and WRITE VALIDAE policies
-        //Read: Jouppi, Norman P. "Cache write policies and performance". ISCA 93.
-        //WRITE_ALLOCATE is the old write policy in GPGPU-sim 3.x, that send WRITE and READ for every write request
-        switch(wap){
-        case 'N': m_write_alloc_policy = NO_WRITE_ALLOCATE; break;
-        case 'W': m_write_alloc_policy = WRITE_ALLOCATE; break;
-        case 'F': m_write_alloc_policy = FETCH_ON_WRITE; break;
-        case 'L': m_write_alloc_policy = LAZY_FETCH_ON_READ; break;
-		default: exit_parse_error();
-        }
-
-        // detect invalid configuration 
-        if (m_alloc_policy == ON_FILL and m_write_policy == WRITE_BACK) {
-            // A writeback cache with allocate-on-fill policy will inevitably lead to deadlock:  
-            // The deadlock happens when an incoming cache-fill evicts a dirty
-            // line, generating a writeback request.  If the memory subsystem
-            // is congested, the interconnection network may not have
-            // sufficient buffer for the writeback request.  This stalls the
-            // incoming cache-fill.  The stall may propagate through the memory
-            // subsystem back to the output port of the same core, creating a
-            // deadlock where the wrtieback request and the incoming cache-fill
-            // are stalling each other.  
-            assert(0 && "Invalid cache configuration: Writeback cache cannot allocate new line on fill. "); 
-        }
-
-        if((m_write_alloc_policy == FETCH_ON_WRITE || m_write_alloc_policy == LAZY_FETCH_ON_READ )&& m_alloc_policy == ON_FILL)
-		{
-			assert(0 && "Invalid cache configuration: FETCH_ON_WRITE and LAZY_FETCH_ON_READ cannot work properly with ON_FILL policy. Cache must be ON_MISS. ");
-		}
-        if(m_cache_type == SECTOR)
-		{
-			assert(m_line_sz / SECTOR_SIZE == SECTOR_CHUNCK_SIZE && m_line_sz % SECTOR_SIZE == 0);
-		}
-
-        // default: port to data array width and granularity = line size 
-        if (m_data_port_width == 0) {
-            m_data_port_width = m_line_sz; 
-        }
-        assert(m_line_sz % m_data_port_width == 0); 
-
-        switch(sif){
-        case 'H': m_set_index_function = FERMI_HASH_SET_FUNCTION; break;
-        case 'P': m_set_index_function = HASH_IPOLY_FUNCTION; break;
-        case 'C': m_set_index_function = CUSTOM_SET_FUNCTION; break;
-        case 'L': m_set_index_function = LINEAR_SET_FUNCTION; break;
-        default: exit_parse_error();
-        }
+  virtual unsigned set_index(new_addr_type addr) const {
+    if (m_set_index_function != LINEAR_SET_FUNCTION) {
+      printf(
+          "\nGPGPU-Sim cache configuration error: Hashing or "
+          "custom set index function selected in configuration "
+          "file for a cache that has not overloaded the set_index "
+          "function\n");
+      abort();
     }
-    bool disabled() const { return m_disabled;}
-    unsigned get_line_sz() const
-    {
-        assert( m_valid );
-        return m_line_sz;
-    }
-    unsigned get_atom_sz() const
-	{
-		assert( m_valid );
-		return m_atom_sz;
-	}
-    unsigned get_num_lines() const
-    {
-        assert( m_valid );
-        return m_nset * m_assoc;
-    }
-    unsigned get_max_num_lines() const
-    {
-        assert( m_valid );
-        return MAX_DEFAULT_CACHE_SIZE_MULTIBLIER * m_nset * original_m_assoc;
-    }
-    void print( FILE *fp ) const
-    {
-        fprintf( fp, "Size = %d B (%d Set x %d-way x %d byte line)\n", 
-                 m_line_sz * m_nset * m_assoc,
-                 m_nset, m_assoc, m_line_sz );
-    }
+    return (addr >> m_line_sz_log2) & (m_nset - 1);
+  }
 
-    virtual unsigned set_index( new_addr_type addr ) const
-    {
-        if(m_set_index_function != LINEAR_SET_FUNCTION){
-            printf("\nGPGPU-Sim cache configuration error: Hashing or "
-                    "custom set index function selected in configuration "
-                    "file for a cache that has not overloaded the set_index "
-                    "function\n");
-            abort();
-        }
-        return(addr >> m_line_sz_log2) & (m_nset-1);
-    }
+  new_addr_type tag(new_addr_type addr) const {
+    // For generality, the tag includes both index and tag. This allows for more
+    // complex set index calculations that can result in different indexes
+    // mapping to the same set, thus the full tag + index is required to check
+    // for hit/miss. Tag is now identical to the block address.
 
-    new_addr_type tag( new_addr_type addr ) const
-    {
-        // For generality, the tag includes both index and tag. This allows for more complex set index
-        // calculations that can result in different indexes mapping to the same set, thus the full
-        // tag + index is required to check for hit/miss. Tag is now identical to the block address.
+    // return addr >> (m_line_sz_log2+m_nset_log2);
+    return addr & ~(new_addr_type)(m_line_sz - 1);
+  }
+  new_addr_type block_addr(new_addr_type addr) const {
+    return addr & ~(new_addr_type)(m_line_sz - 1);
+  }
+  new_addr_type mshr_addr(new_addr_type addr) const {
+    return addr & ~(new_addr_type)(m_atom_sz - 1);
+  }
+  enum mshr_config_t get_mshr_type() const { return m_mshr_type; }
+  void set_assoc(unsigned n) {
+    // set new assoc. L1 cache dynamically resized in Volta
+    m_assoc = n;
+  }
+  unsigned get_nset() const {
+    assert(m_valid);
+    return m_nset;
+  }
+  unsigned get_total_size_inKB() const {
+    assert(m_valid);
+    return (m_assoc * m_nset * m_line_sz) / 1024;
+  }
+  bool is_streaming() { return m_is_streaming; }
+  FuncCache get_cache_status() { return cache_status; }
+  char *m_config_string;
+  char *m_config_stringPrefL1;
+  char *m_config_stringPrefShared;
+  FuncCache cache_status;
 
-        //return addr >> (m_line_sz_log2+m_nset_log2);
-        return addr & ~(new_addr_type)(m_line_sz-1);
-    }
-    new_addr_type block_addr( new_addr_type addr ) const
-    {
-        return addr & ~(new_addr_type)(m_line_sz-1);
-    }
-    new_addr_type mshr_addr( new_addr_type addr ) const
-	{
-    	return addr & ~(new_addr_type)(m_atom_sz-1);
-	}
-    enum mshr_config_t get_mshr_type() const
-	{
-    	return m_mshr_type;
-	}
-    void set_assoc(unsigned n)
-	{
-    	//set new assoc. L1 cache dynamically resized in Volta
-    	m_assoc = n;
-	}
-    unsigned get_nset() const
-	{
-		assert( m_valid );
-		return m_nset;
-	}
-    unsigned get_total_size_inKB() const
-	{
-		assert( m_valid );
-		return (m_assoc*m_nset*m_line_sz)/1024;
-	}
-    bool is_streaming() {
-    	return m_is_streaming;
-    }
-    FuncCache get_cache_status() {return cache_status;}
-    char *m_config_string;
-    char *m_config_stringPrefL1;
-    char *m_config_stringPrefShared;
-    FuncCache cache_status;
+ protected:
+  void exit_parse_error() {
+    printf("GPGPU-Sim uArch: cache configuration parsing error (%s)\n",
+           m_config_string);
+    abort();
+  }
 
-protected:
-    void exit_parse_error()
-    {
-        printf("GPGPU-Sim uArch: cache configuration parsing error (%s)\n", m_config_string );
-        abort();
-    }
+  bool m_valid;
+  bool m_disabled;
+  unsigned m_line_sz;
+  unsigned m_line_sz_log2;
+  unsigned m_nset;
+  unsigned m_nset_log2;
+  unsigned m_assoc;
+  unsigned m_atom_sz;
+  unsigned m_sector_sz_log2;
+  unsigned original_m_assoc;
+  bool m_is_streaming;
 
-    bool m_valid;
-    bool m_disabled;
-    unsigned m_line_sz;
-    unsigned m_line_sz_log2;
-    unsigned m_nset;
-    unsigned m_nset_log2;
-    unsigned m_assoc;
-    unsigned m_atom_sz;
-    unsigned m_sector_sz_log2;
-    unsigned original_m_assoc;
-    bool m_is_streaming;
+  enum replacement_policy_t m_replacement_policy;  // 'L' = LRU, 'F' = FIFO
+  enum write_policy_t
+      m_write_policy;  // 'T' = write through, 'B' = write back, 'R' = read only
+  enum allocation_policy_t
+      m_alloc_policy;  // 'm' = allocate on miss, 'f' = allocate on fill
+  enum mshr_config_t m_mshr_type;
+  enum cache_type m_cache_type;
 
-    enum replacement_policy_t m_replacement_policy; // 'L' = LRU, 'F' = FIFO
-    enum write_policy_t m_write_policy;             // 'T' = write through, 'B' = write back, 'R' = read only
-    enum allocation_policy_t m_alloc_policy;        // 'm' = allocate on miss, 'f' = allocate on fill
-    enum mshr_config_t m_mshr_type;
-    enum cache_type m_cache_type;
+  write_allocate_policy_t
+      m_write_alloc_policy;  // 'W' = Write allocate, 'N' = No write allocate
 
-    write_allocate_policy_t m_write_alloc_policy;	// 'W' = Write allocate, 'N' = No write allocate
+  union {
+    unsigned m_mshr_entries;
+    unsigned m_fragment_fifo_entries;
+  };
+  union {
+    unsigned m_mshr_max_merge;
+    unsigned m_request_fifo_entries;
+  };
+  union {
+    unsigned m_miss_queue_size;
+    unsigned m_rob_entries;
+  };
+  unsigned m_result_fifo_entries;
+  unsigned m_data_port_width;  //< number of byte the cache can access per cycle
+  enum set_index_function
+      m_set_index_function;  // Hash, linear, or custom set index function
 
-    union {
-        unsigned m_mshr_entries;
-        unsigned m_fragment_fifo_entries;
-    };
-    union {
-        unsigned m_mshr_max_merge;
-        unsigned m_request_fifo_entries;
-    };
-    union {
-        unsigned m_miss_queue_size;
-        unsigned m_rob_entries;
-    };
-    unsigned m_result_fifo_entries;
-    unsigned m_data_port_width; //< number of byte the cache can access per cycle 
-    enum set_index_function m_set_index_function; // Hash, linear, or custom set index function
-
-    friend class tag_array;
-    friend class baseline_cache;
-    friend class read_only_cache;
-    friend class tex_cache;
-    friend class data_cache;
-    friend class l1_cache;
-    friend class l2_cache;
-    friend class memory_sub_partition;
+  friend class tag_array;
+  friend class baseline_cache;
+  friend class read_only_cache;
+  friend class tex_cache;
+  friend class data_cache;
+  friend class l1_cache;
+  friend class l2_cache;
+  friend class memory_sub_partition;
 };
 
-class l1d_cache_config : public cache_config{
-public:
-	l1d_cache_config() : cache_config(){}
-	virtual unsigned set_index(new_addr_type addr) const;
-    unsigned set_bank(new_addr_type addr) const;
-	unsigned l1_latency;
-	unsigned l1_banks;
+class l1d_cache_config : public cache_config {
+ public:
+  l1d_cache_config() : cache_config() {}
+  virtual unsigned set_index(new_addr_type addr) const;
+  unsigned set_bank(new_addr_type addr) const;
+  unsigned l1_latency;
+  unsigned l1_banks;
 };
 
 class l2_cache_config : public cache_config {
-public:
-	l2_cache_config() : cache_config(){}
-	void init(linear_to_raw_address_translation *address_mapping);
-	virtual unsigned set_index(new_addr_type addr) const;
+ public:
+  l2_cache_config() : cache_config() {}
+  void init(linear_to_raw_address_translation *address_mapping);
+  virtual unsigned set_index(new_addr_type addr) const;
 
-private:
-	linear_to_raw_address_translation *m_address_mapping;
+ private:
+  linear_to_raw_address_translation *m_address_mapping;
 };
 
 class tag_array {
-public:
-    // Use this constructor
-    tag_array(cache_config &config, int core_id, int type_id );
-    ~tag_array();
+ public:
+  // Use this constructor
+  tag_array(cache_config &config, int core_id, int type_id);
+  ~tag_array();
 
-    enum cache_request_status probe( new_addr_type addr, unsigned &idx, mem_fetch* mf, bool probe_mode=false ) const;
-    enum cache_request_status probe( new_addr_type addr, unsigned &idx, mem_access_sector_mask_t mask, bool probe_mode=false, mem_fetch* mf = NULL ) const;
-    enum cache_request_status access( new_addr_type addr, unsigned time, unsigned &idx, mem_fetch* mf );
-    enum cache_request_status access( new_addr_type addr, unsigned time, unsigned &idx, bool &wb, evicted_block_info &evicted, mem_fetch* mf );
+  enum cache_request_status probe(new_addr_type addr, unsigned &idx,
+                                  mem_fetch *mf, bool probe_mode = false) const;
+  enum cache_request_status probe(new_addr_type addr, unsigned &idx,
+                                  mem_access_sector_mask_t mask,
+                                  bool probe_mode = false,
+                                  mem_fetch *mf = NULL) const;
+  enum cache_request_status access(new_addr_type addr, unsigned time,
+                                   unsigned &idx, mem_fetch *mf);
+  enum cache_request_status access(new_addr_type addr, unsigned time,
+                                   unsigned &idx, bool &wb,
+                                   evicted_block_info &evicted, mem_fetch *mf);
 
-    void fill( new_addr_type addr, unsigned time, mem_fetch* mf );
-    void fill( unsigned idx, unsigned time, mem_fetch* mf );
-    void fill( new_addr_type addr, unsigned time, mem_access_sector_mask_t mask );
+  void fill(new_addr_type addr, unsigned time, mem_fetch *mf);
+  void fill(unsigned idx, unsigned time, mem_fetch *mf);
+  void fill(new_addr_type addr, unsigned time, mem_access_sector_mask_t mask);
 
-    unsigned size() const { return m_config.get_num_lines();}
-    cache_block_t* get_block(unsigned idx) { return m_lines[idx];}
+  unsigned size() const { return m_config.get_num_lines(); }
+  cache_block_t *get_block(unsigned idx) { return m_lines[idx]; }
 
-    void flush(); // flush all written entries
-    void invalidate(); // invalidate all entries
-    void new_window();
+  void flush();       // flush all written entries
+  void invalidate();  // invalidate all entries
+  void new_window();
 
-    void print( FILE *stream, unsigned &total_access, unsigned &total_misses ) const;
-    float windowed_miss_rate( ) const;
-    void get_stats(unsigned &total_access, unsigned &total_misses, unsigned &total_hit_res, unsigned &total_res_fail) const;
+  void print(FILE *stream, unsigned &total_access,
+             unsigned &total_misses) const;
+  float windowed_miss_rate() const;
+  void get_stats(unsigned &total_access, unsigned &total_misses,
+                 unsigned &total_hit_res, unsigned &total_res_fail) const;
 
-	void update_cache_parameters(cache_config &config);
-	void add_pending_line(mem_fetch *mf);
-	void remove_pending_line(mem_fetch *mf);
-protected:
-    // This constructor is intended for use only from derived classes that wish to
-    // avoid unnecessary memory allocation that takes place in the
-    // other tag_array constructor
-    tag_array( cache_config &config,
-               int core_id,
-               int type_id,
-               cache_block_t** new_lines );
-    void init( int core_id, int type_id );
+  void update_cache_parameters(cache_config &config);
+  void add_pending_line(mem_fetch *mf);
+  void remove_pending_line(mem_fetch *mf);
 
-protected:
+ protected:
+  // This constructor is intended for use only from derived classes that wish to
+  // avoid unnecessary memory allocation that takes place in the
+  // other tag_array constructor
+  tag_array(cache_config &config, int core_id, int type_id,
+            cache_block_t **new_lines);
+  void init(int core_id, int type_id);
 
-    cache_config &m_config;
+ protected:
+  cache_config &m_config;
 
-    cache_block_t **m_lines; /* nbanks x nset x assoc lines in total */
+  cache_block_t **m_lines; /* nbanks x nset x assoc lines in total */
 
-    unsigned m_access;
-    unsigned m_miss;
-    unsigned m_pending_hit; // number of cache miss that hit a line that is allocated but not filled
-    unsigned m_res_fail;
-    unsigned m_sector_miss;
+  unsigned m_access;
+  unsigned m_miss;
+  unsigned m_pending_hit;  // number of cache miss that hit a line that is
+                           // allocated but not filled
+  unsigned m_res_fail;
+  unsigned m_sector_miss;
 
-    // performance counters for calculating the amount of misses within a time window
-    unsigned m_prev_snapshot_access;
-    unsigned m_prev_snapshot_miss;
-    unsigned m_prev_snapshot_pending_hit;
+  // performance counters for calculating the amount of misses within a time
+  // window
+  unsigned m_prev_snapshot_access;
+  unsigned m_prev_snapshot_miss;
+  unsigned m_prev_snapshot_pending_hit;
 
-    int m_core_id; // which shader core is using this
-    int m_type_id; // what kind of cache is this (normal, texture, constant)
+  int m_core_id;  // which shader core is using this
+  int m_type_id;  // what kind of cache is this (normal, texture, constant)
 
-    bool is_used;  //a flag if the whole cache has ever been accessed before
+  bool is_used;  // a flag if the whole cache has ever been accessed before
 
-    typedef tr1_hash_map<new_addr_type,unsigned> line_table;
-    line_table pending_lines;
+  typedef tr1_hash_map<new_addr_type, unsigned> line_table;
+  line_table pending_lines;
 };
 
 class mshr_table {
-public:
-    mshr_table( unsigned num_entries, unsigned max_merged)
-    : m_num_entries(num_entries),
-    m_max_merged(max_merged)
+ public:
+  mshr_table(unsigned num_entries, unsigned max_merged)
+      : m_num_entries(num_entries),
+        m_max_merged(max_merged)
 #if (tr1_hash_map_ismap == 0)
-    ,m_data(2*num_entries)
+        ,
+        m_data(2 * num_entries)
 #endif
-    {
-    }
+  {
+  }
 
-    /// Checks if there is a pending request to the lower memory level already
-    bool probe( new_addr_type block_addr ) const;
-    /// Checks if there is space for tracking a new memory access
-    bool full( new_addr_type block_addr ) const;
-    /// Add or merge this access
-    void add( new_addr_type block_addr, mem_fetch *mf );
-    /// Returns true if cannot accept new fill responses
-    bool busy() const {return false;}
-    /// Accept a new cache fill response: mark entry ready for processing
-    void mark_ready( new_addr_type block_addr, bool &has_atomic );
-    /// Returns true if ready accesses exist
-    bool access_ready() const {return !m_current_response.empty();}
-    /// Returns next ready access
-    mem_fetch *next_access();
-    void display( FILE *fp ) const;
-    // Returns true if there is a pending read after write
-    bool is_read_after_write_pending(new_addr_type block_addr);
+  /// Checks if there is a pending request to the lower memory level already
+  bool probe(new_addr_type block_addr) const;
+  /// Checks if there is space for tracking a new memory access
+  bool full(new_addr_type block_addr) const;
+  /// Add or merge this access
+  void add(new_addr_type block_addr, mem_fetch *mf);
+  /// Returns true if cannot accept new fill responses
+  bool busy() const { return false; }
+  /// Accept a new cache fill response: mark entry ready for processing
+  void mark_ready(new_addr_type block_addr, bool &has_atomic);
+  /// Returns true if ready accesses exist
+  bool access_ready() const { return !m_current_response.empty(); }
+  /// Returns next ready access
+  mem_fetch *next_access();
+  void display(FILE *fp) const;
+  // Returns true if there is a pending read after write
+  bool is_read_after_write_pending(new_addr_type block_addr);
 
-    void check_mshr_parameters( unsigned num_entries, unsigned max_merged )
-    {
-    	assert(m_num_entries==num_entries && "Change of MSHR parameters between kernels is not allowed");
-    	assert(m_max_merged==max_merged && "Change of MSHR parameters between kernels is not allowed");
-    }
+  void check_mshr_parameters(unsigned num_entries, unsigned max_merged) {
+    assert(m_num_entries == num_entries &&
+           "Change of MSHR parameters between kernels is not allowed");
+    assert(m_max_merged == max_merged &&
+           "Change of MSHR parameters between kernels is not allowed");
+  }
 
-private:
+ private:
+  // finite sized, fully associative table, with a finite maximum number of
+  // merged requests
+  const unsigned m_num_entries;
+  const unsigned m_max_merged;
 
-    // finite sized, fully associative table, with a finite maximum number of merged requests
-    const unsigned m_num_entries;
-    const unsigned m_max_merged;
+  struct mshr_entry {
+    std::list<mem_fetch *> m_list;
+    bool m_has_atomic;
+    mshr_entry() : m_has_atomic(false) {}
+  };
+  typedef tr1_hash_map<new_addr_type, mshr_entry> table;
+  typedef tr1_hash_map<new_addr_type, mshr_entry> line_table;
+  table m_data;
+  line_table pending_lines;
 
-    struct mshr_entry {
-        std::list<mem_fetch*> m_list;
-        bool m_has_atomic; 
-        mshr_entry() : m_has_atomic(false) { }
-    }; 
-    typedef tr1_hash_map<new_addr_type,mshr_entry> table;
-    typedef tr1_hash_map<new_addr_type,mshr_entry> line_table;
-    table m_data;
-    line_table pending_lines;
-
-    // it may take several cycles to process the merged requests
-    bool m_current_response_ready;
-    std::list<new_addr_type> m_current_response;
+  // it may take several cycles to process the merged requests
+  bool m_current_response_ready;
+  std::list<new_addr_type> m_current_response;
 };
 
-
-/***************************************************************** Caches *****************************************************************/
+/***************************************************************** Caches
+ * *****************************************************************/
 ///
-/// Simple struct to maintain cache accesses, misses, pending hits, and reservation fails.
+/// Simple struct to maintain cache accesses, misses, pending hits, and
+/// reservation fails.
 ///
-struct cache_sub_stats{
-    unsigned long long accesses;
-    unsigned long long misses;
-    unsigned long long pending_hits;
-    unsigned long long res_fails;
+struct cache_sub_stats {
+  unsigned long long accesses;
+  unsigned long long misses;
+  unsigned long long pending_hits;
+  unsigned long long res_fails;
 
-    unsigned long long port_available_cycles; 
-    unsigned long long data_port_busy_cycles; 
-    unsigned long long fill_port_busy_cycles; 
+  unsigned long long port_available_cycles;
+  unsigned long long data_port_busy_cycles;
+  unsigned long long fill_port_busy_cycles;
 
-    cache_sub_stats(){
-        clear();
-    }
-    void clear(){
-        accesses = 0;
-        misses = 0;
-        pending_hits = 0;
-        res_fails = 0;
-        port_available_cycles = 0; 
-        data_port_busy_cycles = 0; 
-        fill_port_busy_cycles = 0; 
-    }
-    cache_sub_stats &operator+=(const cache_sub_stats &css){
-        ///
-        /// Overloading += operator to easily accumulate stats
-        ///
-        accesses += css.accesses;
-        misses += css.misses;
-        pending_hits += css.pending_hits;
-        res_fails += css.res_fails;
-        port_available_cycles += css.port_available_cycles; 
-        data_port_busy_cycles += css.data_port_busy_cycles; 
-        fill_port_busy_cycles += css.fill_port_busy_cycles; 
-        return *this;
-    }
+  cache_sub_stats() { clear(); }
+  void clear() {
+    accesses = 0;
+    misses = 0;
+    pending_hits = 0;
+    res_fails = 0;
+    port_available_cycles = 0;
+    data_port_busy_cycles = 0;
+    fill_port_busy_cycles = 0;
+  }
+  cache_sub_stats &operator+=(const cache_sub_stats &css) {
+    ///
+    /// Overloading += operator to easily accumulate stats
+    ///
+    accesses += css.accesses;
+    misses += css.misses;
+    pending_hits += css.pending_hits;
+    res_fails += css.res_fails;
+    port_available_cycles += css.port_available_cycles;
+    data_port_busy_cycles += css.data_port_busy_cycles;
+    fill_port_busy_cycles += css.fill_port_busy_cycles;
+    return *this;
+  }
 
-    cache_sub_stats operator+(const cache_sub_stats &cs){
-        ///
-        /// Overloading + operator to easily accumulate stats
-        ///
-        cache_sub_stats ret;
-        ret.accesses = accesses + cs.accesses;
-        ret.misses = misses + cs.misses;
-        ret.pending_hits = pending_hits + cs.pending_hits;
-        ret.res_fails = res_fails + cs.res_fails;
-        ret.port_available_cycles = port_available_cycles + cs.port_available_cycles; 
-        ret.data_port_busy_cycles = data_port_busy_cycles + cs.data_port_busy_cycles; 
-        ret.fill_port_busy_cycles = fill_port_busy_cycles + cs.fill_port_busy_cycles; 
-        return ret;
-    }
+  cache_sub_stats operator+(const cache_sub_stats &cs) {
+    ///
+    /// Overloading + operator to easily accumulate stats
+    ///
+    cache_sub_stats ret;
+    ret.accesses = accesses + cs.accesses;
+    ret.misses = misses + cs.misses;
+    ret.pending_hits = pending_hits + cs.pending_hits;
+    ret.res_fails = res_fails + cs.res_fails;
+    ret.port_available_cycles =
+        port_available_cycles + cs.port_available_cycles;
+    ret.data_port_busy_cycles =
+        data_port_busy_cycles + cs.data_port_busy_cycles;
+    ret.fill_port_busy_cycles =
+        fill_port_busy_cycles + cs.fill_port_busy_cycles;
+    return ret;
+  }
 
-    void print_port_stats(FILE *fout, const char *cache_name) const; 
+  void print_port_stats(FILE *fout, const char *cache_name) const;
 };
-
 
 // Used for collecting AerialVision per-window statistics
-struct cache_sub_stats_pw{
-    unsigned accesses;
-    unsigned write_misses;
-    unsigned write_hits;
-    unsigned write_pending_hits;
-    unsigned write_res_fails;
+struct cache_sub_stats_pw {
+  unsigned accesses;
+  unsigned write_misses;
+  unsigned write_hits;
+  unsigned write_pending_hits;
+  unsigned write_res_fails;
 
-    unsigned read_misses;
-    unsigned read_hits;
-    unsigned read_pending_hits;
-    unsigned read_res_fails;
+  unsigned read_misses;
+  unsigned read_hits;
+  unsigned read_pending_hits;
+  unsigned read_res_fails;
 
-    cache_sub_stats_pw(){
-        clear();
-    }
-    void clear(){
-        accesses = 0;
-        write_misses = 0;
-        write_hits = 0;
-        write_pending_hits = 0;
-        write_res_fails = 0;
-        read_misses = 0;
-        read_hits = 0;
-        read_pending_hits = 0;
-        read_res_fails = 0;
-    }
-    cache_sub_stats_pw &operator+=(const cache_sub_stats_pw &css){
-        ///
-        /// Overloading += operator to easily accumulate stats
-        ///
-        accesses += css.accesses;
-        write_misses += css.write_misses;
-        read_misses += css.read_misses;
-        write_pending_hits += css.write_pending_hits;
-        read_pending_hits += css.read_pending_hits;
-        write_res_fails += css.write_res_fails;
-        read_res_fails += css.read_res_fails;
-        return *this;
-    }
+  cache_sub_stats_pw() { clear(); }
+  void clear() {
+    accesses = 0;
+    write_misses = 0;
+    write_hits = 0;
+    write_pending_hits = 0;
+    write_res_fails = 0;
+    read_misses = 0;
+    read_hits = 0;
+    read_pending_hits = 0;
+    read_res_fails = 0;
+  }
+  cache_sub_stats_pw &operator+=(const cache_sub_stats_pw &css) {
+    ///
+    /// Overloading += operator to easily accumulate stats
+    ///
+    accesses += css.accesses;
+    write_misses += css.write_misses;
+    read_misses += css.read_misses;
+    write_pending_hits += css.write_pending_hits;
+    read_pending_hits += css.read_pending_hits;
+    write_res_fails += css.write_res_fails;
+    read_res_fails += css.read_res_fails;
+    return *this;
+  }
 
-    cache_sub_stats_pw operator+(const cache_sub_stats_pw &cs){
-        ///
-        /// Overloading + operator to easily accumulate stats
-        ///
-        cache_sub_stats_pw ret;
-        ret.accesses = accesses + cs.accesses;
-        ret.write_misses = write_misses + cs.write_misses;
-        ret.read_misses = read_misses + cs.read_misses;
-        ret.write_pending_hits = write_pending_hits + cs.write_pending_hits;
-        ret.read_pending_hits = read_pending_hits + cs.read_pending_hits;
-        ret.write_res_fails = write_res_fails + cs.write_res_fails;
-        ret.read_res_fails = read_res_fails + cs.read_res_fails;
-        return ret;
-    }
-
+  cache_sub_stats_pw operator+(const cache_sub_stats_pw &cs) {
+    ///
+    /// Overloading + operator to easily accumulate stats
+    ///
+    cache_sub_stats_pw ret;
+    ret.accesses = accesses + cs.accesses;
+    ret.write_misses = write_misses + cs.write_misses;
+    ret.read_misses = read_misses + cs.read_misses;
+    ret.write_pending_hits = write_pending_hits + cs.write_pending_hits;
+    ret.read_pending_hits = read_pending_hits + cs.read_pending_hits;
+    ret.write_res_fails = write_res_fails + cs.write_res_fails;
+    ret.read_res_fails = read_res_fails + cs.read_res_fails;
+    return ret;
+  }
 };
-
 
 ///
 /// Cache_stats
@@ -1039,484 +1059,468 @@ struct cache_sub_stats_pw{
 /// 'cache_request_status' : [mem_access_type][cache_request_status]
 ///
 class cache_stats {
-public:
-    cache_stats();
-    void clear();
-    // Clear AerialVision cache stats after each window
-    void clear_pw();
-    void inc_stats(int access_type, int access_outcome);
-    // Increment AerialVision cache stats
-    void inc_stats_pw(int access_type, int access_outcome);
-    void inc_fail_stats(int access_type, int fail_outcome);
-    enum cache_request_status select_stats_status(enum cache_request_status probe, enum cache_request_status access) const;
-    unsigned long long &operator()(int access_type, int access_outcome, bool fail_outcome);
-    unsigned long long operator()(int access_type, int access_outcome, bool fail_outcome) const;
-    cache_stats operator+(const cache_stats &cs);
-    cache_stats &operator+=(const cache_stats &cs);
-    void print_stats(FILE *fout, const char *cache_name = "Cache_stats") const;
-    void print_fail_stats(FILE *fout, const char *cache_name = "Cache_fail_stats") const;
+ public:
+  cache_stats();
+  void clear();
+  // Clear AerialVision cache stats after each window
+  void clear_pw();
+  void inc_stats(int access_type, int access_outcome);
+  // Increment AerialVision cache stats
+  void inc_stats_pw(int access_type, int access_outcome);
+  void inc_fail_stats(int access_type, int fail_outcome);
+  enum cache_request_status select_stats_status(
+      enum cache_request_status probe, enum cache_request_status access) const;
+  unsigned long long &operator()(int access_type, int access_outcome,
+                                 bool fail_outcome);
+  unsigned long long operator()(int access_type, int access_outcome,
+                                bool fail_outcome) const;
+  cache_stats operator+(const cache_stats &cs);
+  cache_stats &operator+=(const cache_stats &cs);
+  void print_stats(FILE *fout, const char *cache_name = "Cache_stats") const;
+  void print_fail_stats(FILE *fout,
+                        const char *cache_name = "Cache_fail_stats") const;
 
-    unsigned long long get_stats(enum mem_access_type *access_type, unsigned num_access_type, enum cache_request_status *access_status, unsigned num_access_status)  const;
-    void get_sub_stats(struct cache_sub_stats &css) const;
+  unsigned long long get_stats(enum mem_access_type *access_type,
+                               unsigned num_access_type,
+                               enum cache_request_status *access_status,
+                               unsigned num_access_status) const;
+  void get_sub_stats(struct cache_sub_stats &css) const;
 
-    // Get per-window cache stats for AerialVision
-    void get_sub_stats_pw(struct cache_sub_stats_pw &css) const;
+  // Get per-window cache stats for AerialVision
+  void get_sub_stats_pw(struct cache_sub_stats_pw &css) const;
 
-    void sample_cache_port_utility(bool data_port_busy, bool fill_port_busy); 
-private:
-    bool check_valid(int type, int status) const;
-    bool check_fail_valid(int type, int fail) const;
+  void sample_cache_port_utility(bool data_port_busy, bool fill_port_busy);
 
+ private:
+  bool check_valid(int type, int status) const;
+  bool check_fail_valid(int type, int fail) const;
 
-    std::vector< std::vector<unsigned long long> > m_stats;
-    // AerialVision cache stats (per-window)
-    std::vector< std::vector<unsigned long long> > m_stats_pw;
-    std::vector< std::vector<unsigned long long> > m_fail_stats;
+  std::vector<std::vector<unsigned long long> > m_stats;
+  // AerialVision cache stats (per-window)
+  std::vector<std::vector<unsigned long long> > m_stats_pw;
+  std::vector<std::vector<unsigned long long> > m_fail_stats;
 
-    unsigned long long m_cache_port_available_cycles; 
-    unsigned long long m_cache_data_port_busy_cycles; 
-    unsigned long long m_cache_fill_port_busy_cycles; 
+  unsigned long long m_cache_port_available_cycles;
+  unsigned long long m_cache_data_port_busy_cycles;
+  unsigned long long m_cache_fill_port_busy_cycles;
 };
 
 class cache_t {
-public:
-    virtual ~cache_t() {}
-    virtual enum cache_request_status access( new_addr_type addr, mem_fetch *mf, unsigned time, std::list<cache_event> &events ) =  0;
+ public:
+  virtual ~cache_t() {}
+  virtual enum cache_request_status access(new_addr_type addr, mem_fetch *mf,
+                                           unsigned time,
+                                           std::list<cache_event> &events) = 0;
 
-    // accessors for cache bandwidth availability 
-    virtual bool data_port_free() const = 0; 
-    virtual bool fill_port_free() const = 0; 
+  // accessors for cache bandwidth availability
+  virtual bool data_port_free() const = 0;
+  virtual bool fill_port_free() const = 0;
 };
 
-bool was_write_sent( const std::list<cache_event> &events );
-bool was_read_sent( const std::list<cache_event> &events );
-bool was_writeallocate_sent( const std::list<cache_event> &events );
+bool was_write_sent(const std::list<cache_event> &events);
+bool was_read_sent(const std::list<cache_event> &events);
+bool was_writeallocate_sent(const std::list<cache_event> &events);
 
 /// Baseline cache
 /// Implements common functions for read_only_cache and data_cache
 /// Each subclass implements its own 'access' function
 class baseline_cache : public cache_t {
-public:
-    baseline_cache( const char *name, cache_config &config, int core_id, int type_id, mem_fetch_interface *memport,
-                     enum mem_fetch_status status )
-    : m_config(config), m_tag_array(new tag_array(config,core_id,type_id)), 
-      m_mshrs(config.m_mshr_entries,config.m_mshr_max_merge),
-      m_bandwidth_management(config) 
-    {
-        init( name, config, memport, status );
+ public:
+  baseline_cache(const char *name, cache_config &config, int core_id,
+                 int type_id, mem_fetch_interface *memport,
+                 enum mem_fetch_status status)
+      : m_config(config),
+        m_tag_array(new tag_array(config, core_id, type_id)),
+        m_mshrs(config.m_mshr_entries, config.m_mshr_max_merge),
+        m_bandwidth_management(config) {
+    init(name, config, memport, status);
+  }
+
+  void init(const char *name, const cache_config &config,
+            mem_fetch_interface *memport, enum mem_fetch_status status) {
+    m_name = name;
+    assert(config.m_mshr_type == ASSOC || config.m_mshr_type == SECTOR_ASSOC);
+    m_memport = memport;
+    m_miss_queue_status = status;
+  }
+
+  virtual ~baseline_cache() { delete m_tag_array; }
+
+  void update_cache_parameters(cache_config &config) {
+    m_config = config;
+    m_tag_array->update_cache_parameters(config);
+    m_mshrs.check_mshr_parameters(config.m_mshr_entries,
+                                  config.m_mshr_max_merge);
+  }
+
+  virtual enum cache_request_status access(new_addr_type addr, mem_fetch *mf,
+                                           unsigned time,
+                                           std::list<cache_event> &events) = 0;
+  /// Sends next request to lower level of memory
+  void cycle();
+  /// Interface for response from lower memory level (model bandwidth
+  /// restictions in caller)
+  void fill(mem_fetch *mf, unsigned time);
+  /// Checks if mf is waiting to be filled by lower memory level
+  bool waiting_for_fill(mem_fetch *mf);
+  /// Are any (accepted) accesses that had to wait for memory now ready? (does
+  /// not include accesses that "HIT")
+  bool access_ready() const { return m_mshrs.access_ready(); }
+  /// Pop next ready access (does not include accesses that "HIT")
+  mem_fetch *next_access() { return m_mshrs.next_access(); }
+  // flash invalidate all entries in cache
+  void flush() { m_tag_array->flush(); }
+  void invalidate() { m_tag_array->invalidate(); }
+  void print(FILE *fp, unsigned &accesses, unsigned &misses) const;
+  void display_state(FILE *fp) const;
+
+  // Stat collection
+  const cache_stats &get_stats() const { return m_stats; }
+  unsigned get_stats(enum mem_access_type *access_type,
+                     unsigned num_access_type,
+                     enum cache_request_status *access_status,
+                     unsigned num_access_status) const {
+    return m_stats.get_stats(access_type, num_access_type, access_status,
+                             num_access_status);
+  }
+  void get_sub_stats(struct cache_sub_stats &css) const {
+    m_stats.get_sub_stats(css);
+  }
+  // Clear per-window stats for AerialVision support
+  void clear_pw() { m_stats.clear_pw(); }
+  // Per-window sub stats for AerialVision support
+  void get_sub_stats_pw(struct cache_sub_stats_pw &css) const {
+    m_stats.get_sub_stats_pw(css);
+  }
+
+  // accessors for cache bandwidth availability
+  bool data_port_free() const {
+    return m_bandwidth_management.data_port_free();
+  }
+  bool fill_port_free() const {
+    return m_bandwidth_management.fill_port_free();
+  }
+
+  // This is a gapping hole we are poking in the system to quickly handle
+  // filling the cache on cudamemcopies. We don't care about anything other than
+  // L2 state after the memcopy - so just force the tag array to act as though
+  // something is read or written without doing anything else.
+  void force_tag_access(new_addr_type addr, unsigned time,
+                        mem_access_sector_mask_t mask) {
+    m_tag_array->fill(addr, time, mask);
+  }
+
+ protected:
+  // Constructor that can be used by derived classes with custom tag arrays
+  baseline_cache(const char *name, cache_config &config, int core_id,
+                 int type_id, mem_fetch_interface *memport,
+                 enum mem_fetch_status status, tag_array *new_tag_array)
+      : m_config(config),
+        m_tag_array(new_tag_array),
+        m_mshrs(config.m_mshr_entries, config.m_mshr_max_merge),
+        m_bandwidth_management(config) {
+    init(name, config, memport, status);
+  }
+
+ protected:
+  std::string m_name;
+  cache_config &m_config;
+  tag_array *m_tag_array;
+  mshr_table m_mshrs;
+  std::list<mem_fetch *> m_miss_queue;
+  enum mem_fetch_status m_miss_queue_status;
+  mem_fetch_interface *m_memport;
+
+  struct extra_mf_fields {
+    extra_mf_fields() { m_valid = false; }
+    extra_mf_fields(new_addr_type a, new_addr_type ad, unsigned i, unsigned d,
+                    const cache_config &m_config) {
+      m_valid = true;
+      m_block_addr = a;
+      m_addr = ad;
+      m_cache_index = i;
+      m_data_size = d;
+      pending_read = m_config.m_mshr_type == SECTOR_ASSOC
+                         ? m_config.m_line_sz / SECTOR_SIZE
+                         : 0;
     }
+    bool m_valid;
+    new_addr_type m_block_addr;
+    new_addr_type m_addr;
+    unsigned m_cache_index;
+    unsigned m_data_size;
+    // this variable is used when a load request generates multiple load
+    // transactions For example, a read request from non-sector L1 request sends
+    // a request to sector L2
+    unsigned pending_read;
+  };
 
-    void init( const char *name,
-               const cache_config &config,
-               mem_fetch_interface *memport,
-               enum mem_fetch_status status )
-    {
-        m_name = name;
-        assert(config.m_mshr_type == ASSOC || config.m_mshr_type == SECTOR_ASSOC);
-        m_memport=memport;
-        m_miss_queue_status = status;
-    }
+  typedef std::map<mem_fetch *, extra_mf_fields> extra_mf_fields_lookup;
 
-    virtual ~baseline_cache()
-    {
-        delete m_tag_array;
-    }
+  extra_mf_fields_lookup m_extra_mf_fields;
 
-	void update_cache_parameters(cache_config &config)
-	{
-		m_config=config;
-		m_tag_array->update_cache_parameters(config);
-		m_mshrs.check_mshr_parameters(config.m_mshr_entries,config.m_mshr_max_merge);
-	}
+  cache_stats m_stats;
 
-    virtual enum cache_request_status access( new_addr_type addr, mem_fetch *mf, unsigned time, std::list<cache_event> &events ) =  0;
-    /// Sends next request to lower level of memory
-    void cycle();
-    /// Interface for response from lower memory level (model bandwidth restictions in caller)
-    void fill( mem_fetch *mf, unsigned time );
-    /// Checks if mf is waiting to be filled by lower memory level
-    bool waiting_for_fill( mem_fetch *mf );
-    /// Are any (accepted) accesses that had to wait for memory now ready? (does not include accesses that "HIT")
-    bool access_ready() const {return m_mshrs.access_ready();}
-    /// Pop next ready access (does not include accesses that "HIT")
-    mem_fetch *next_access(){return m_mshrs.next_access();}
-    // flash invalidate all entries in cache
-    void flush(){m_tag_array->flush();}
-    void invalidate(){m_tag_array->invalidate();}
-    void print(FILE *fp, unsigned &accesses, unsigned &misses) const;
-    void display_state( FILE *fp ) const;
+  /// Checks whether this request can be handled on this cycle. num_miss equals
+  /// max # of misses to be handled on this cycle
+  bool miss_queue_full(unsigned num_miss) {
+    return ((m_miss_queue.size() + num_miss) >= m_config.m_miss_queue_size);
+  }
+  /// Read miss handler without writeback
+  void send_read_request(new_addr_type addr, new_addr_type block_addr,
+                         unsigned cache_index, mem_fetch *mf, unsigned time,
+                         bool &do_miss, std::list<cache_event> &events,
+                         bool read_only, bool wa);
+  /// Read miss handler. Check MSHR hit or MSHR available
+  void send_read_request(new_addr_type addr, new_addr_type block_addr,
+                         unsigned cache_index, mem_fetch *mf, unsigned time,
+                         bool &do_miss, bool &wb, evicted_block_info &evicted,
+                         std::list<cache_event> &events, bool read_only,
+                         bool wa);
 
-    // Stat collection
-    const cache_stats &get_stats() const {
-        return m_stats;
-    }
-    unsigned get_stats(enum mem_access_type *access_type, unsigned num_access_type, enum cache_request_status *access_status, unsigned num_access_status)  const{
-        return m_stats.get_stats(access_type, num_access_type, access_status, num_access_status);
-    }
-    void get_sub_stats(struct cache_sub_stats &css) const {
-        m_stats.get_sub_stats(css);
-    }
-    // Clear per-window stats for AerialVision support
-    void clear_pw(){
-        m_stats.clear_pw();
-    }
-    // Per-window sub stats for AerialVision support
-    void get_sub_stats_pw(struct cache_sub_stats_pw &css) const {
-        m_stats.get_sub_stats_pw(css);
-    }
+  /// Sub-class containing all metadata for port bandwidth management
+  class bandwidth_management {
+   public:
+    bandwidth_management(cache_config &config);
 
-    // accessors for cache bandwidth availability 
-    bool data_port_free() const { return m_bandwidth_management.data_port_free(); } 
-    bool fill_port_free() const { return m_bandwidth_management.fill_port_free(); } 
+    /// use the data port based on the outcome and events generated by the
+    /// mem_fetch request
+    void use_data_port(mem_fetch *mf, enum cache_request_status outcome,
+                       const std::list<cache_event> &events);
 
-    // This is a gapping hole we are poking in the system to quickly handle
-    // filling the cache on cudamemcopies. We don't care about anything other than
-    // L2 state after the memcopy - so just force the tag array to act as though
-    // something is read or written without doing anything else.
-    void force_tag_access( new_addr_type addr, unsigned time, mem_access_sector_mask_t mask )
-    {
-        m_tag_array->fill( addr, time, mask );
-    }
+    /// use the fill port
+    void use_fill_port(mem_fetch *mf);
 
-protected:
-    // Constructor that can be used by derived classes with custom tag arrays
-    baseline_cache( const char *name,
-                    cache_config &config,
-                    int core_id,
-                    int type_id,
-                    mem_fetch_interface *memport,
-                    enum mem_fetch_status status,
-                    tag_array* new_tag_array )
-    : m_config(config),
-      m_tag_array( new_tag_array ),
-      m_mshrs(config.m_mshr_entries,config.m_mshr_max_merge), 
-      m_bandwidth_management(config) 
-    {
-        init( name, config, memport, status );
-    }
+    /// called every cache cycle to free up the ports
+    void replenish_port_bandwidth();
 
-protected:
-    std::string m_name;
-    cache_config &m_config;
-    tag_array*  m_tag_array;
-	mshr_table m_mshrs;
-    std::list<mem_fetch*> m_miss_queue;
-    enum mem_fetch_status m_miss_queue_status;
-    mem_fetch_interface *m_memport;
+    /// query for data port availability
+    bool data_port_free() const;
+    /// query for fill port availability
+    bool fill_port_free() const;
 
-    struct extra_mf_fields {
-        extra_mf_fields()  { m_valid = false;}
-        extra_mf_fields( new_addr_type a, new_addr_type ad, unsigned i, unsigned d, const cache_config& m_config)
-        {
-            m_valid = true;
-            m_block_addr = a;
-            m_addr = ad;
-            m_cache_index = i;
-            m_data_size = d;
-        	pending_read = m_config.m_mshr_type == SECTOR_ASSOC? m_config.m_line_sz/SECTOR_SIZE : 0;
+   protected:
+    const cache_config &m_config;
 
-        }
-        bool m_valid;
-        new_addr_type m_block_addr;
-        new_addr_type m_addr;
-        unsigned m_cache_index;
-        unsigned m_data_size;
-        //this variable is used when a load request generates multiple load transactions
-        //For example, a read request from non-sector L1 request sends a request to sector L2
-        unsigned pending_read;
-    };
+    int m_data_port_occupied_cycles;  //< Number of cycle that the data port
+                                      //remains used
+    int m_fill_port_occupied_cycles;  //< Number of cycle that the fill port
+                                      //remains used
+  };
 
-    typedef std::map<mem_fetch*,extra_mf_fields> extra_mf_fields_lookup;
-
-    extra_mf_fields_lookup m_extra_mf_fields;
-
-    cache_stats m_stats;
-
-    /// Checks whether this request can be handled on this cycle. num_miss equals max # of misses to be handled on this cycle
-    bool miss_queue_full(unsigned num_miss){
-    	  return ( (m_miss_queue.size()+num_miss) >= m_config.m_miss_queue_size );
-    }
-    /// Read miss handler without writeback
-    void send_read_request(new_addr_type addr, new_addr_type block_addr, unsigned cache_index, mem_fetch *mf,
-    		unsigned time, bool &do_miss, std::list<cache_event> &events, bool read_only, bool wa);
-    /// Read miss handler. Check MSHR hit or MSHR available
-    void send_read_request(new_addr_type addr, new_addr_type block_addr, unsigned cache_index, mem_fetch *mf,
-    		unsigned time, bool &do_miss, bool &wb, evicted_block_info &evicted, std::list<cache_event> &events, bool read_only, bool wa);
-
-    /// Sub-class containing all metadata for port bandwidth management 
-    class bandwidth_management 
-    {
-    public: 
-        bandwidth_management(cache_config &config); 
-
-        /// use the data port based on the outcome and events generated by the mem_fetch request 
-        void use_data_port(mem_fetch *mf, enum cache_request_status outcome, const std::list<cache_event> &events); 
-
-        /// use the fill port 
-        void use_fill_port(mem_fetch *mf); 
-
-        /// called every cache cycle to free up the ports 
-        void replenish_port_bandwidth(); 
-
-        /// query for data port availability 
-        bool data_port_free() const; 
-        /// query for fill port availability 
-        bool fill_port_free() const; 
-    protected: 
-        const cache_config &m_config; 
-
-        int m_data_port_occupied_cycles; //< Number of cycle that the data port remains used 
-        int m_fill_port_occupied_cycles; //< Number of cycle that the fill port remains used 
-    }; 
-
-    bandwidth_management m_bandwidth_management; 
+  bandwidth_management m_bandwidth_management;
 };
 
 /// Read only cache
 class read_only_cache : public baseline_cache {
-public:
-    read_only_cache( const char *name, cache_config &config, int core_id, int type_id, mem_fetch_interface *memport, enum mem_fetch_status status )
-    : baseline_cache(name,config,core_id,type_id,memport,status){}
+ public:
+  read_only_cache(const char *name, cache_config &config, int core_id,
+                  int type_id, mem_fetch_interface *memport,
+                  enum mem_fetch_status status)
+      : baseline_cache(name, config, core_id, type_id, memport, status) {}
 
-    /// Access cache for read_only_cache: returns RESERVATION_FAIL if request could not be accepted (for any reason)
-    virtual enum cache_request_status access( new_addr_type addr, mem_fetch *mf, unsigned time, std::list<cache_event> &events );
+  /// Access cache for read_only_cache: returns RESERVATION_FAIL if request
+  /// could not be accepted (for any reason)
+  virtual enum cache_request_status access(new_addr_type addr, mem_fetch *mf,
+                                           unsigned time,
+                                           std::list<cache_event> &events);
 
-    virtual ~read_only_cache(){}
+  virtual ~read_only_cache() {}
 
-protected:
-    read_only_cache( const char *name, cache_config &config, int core_id, int type_id, mem_fetch_interface *memport, enum mem_fetch_status status, tag_array* new_tag_array )
-    : baseline_cache(name,config,core_id,type_id,memport,status, new_tag_array){}
+ protected:
+  read_only_cache(const char *name, cache_config &config, int core_id,
+                  int type_id, mem_fetch_interface *memport,
+                  enum mem_fetch_status status, tag_array *new_tag_array)
+      : baseline_cache(name, config, core_id, type_id, memport, status,
+                       new_tag_array) {}
 };
 
 /// Data cache - Implements common functions for L1 and L2 data cache
 class data_cache : public baseline_cache {
-public:
-    data_cache( const char *name, cache_config &config,
-    			int core_id, int type_id, mem_fetch_interface *memport,
-                mem_fetch_allocator *mfcreator, enum mem_fetch_status status,
-                mem_access_type wr_alloc_type, mem_access_type wrbk_type, class gpgpu_sim* gpu )
-    			: baseline_cache(name,config,core_id,type_id,memport,status)
-    {
-        init( mfcreator );
-        m_wr_alloc_type = wr_alloc_type;
-        m_wrbk_type = wrbk_type;
-        m_gpu=gpu;
+ public:
+  data_cache(const char *name, cache_config &config, int core_id, int type_id,
+             mem_fetch_interface *memport, mem_fetch_allocator *mfcreator,
+             enum mem_fetch_status status, mem_access_type wr_alloc_type,
+             mem_access_type wrbk_type, class gpgpu_sim *gpu)
+      : baseline_cache(name, config, core_id, type_id, memport, status) {
+    init(mfcreator);
+    m_wr_alloc_type = wr_alloc_type;
+    m_wrbk_type = wrbk_type;
+    m_gpu = gpu;
+  }
+
+  virtual ~data_cache() {}
+
+  virtual void init(mem_fetch_allocator *mfcreator) {
+    m_memfetch_creator = mfcreator;
+
+    // Set read hit function
+    m_rd_hit = &data_cache::rd_hit_base;
+
+    // Set read miss function
+    m_rd_miss = &data_cache::rd_miss_base;
+
+    // Set write hit function
+    switch (m_config.m_write_policy) {
+      // READ_ONLY is now a separate cache class, config is deprecated
+      case READ_ONLY:
+        assert(0 && "Error: Writable Data_cache set as READ_ONLY\n");
+        break;
+      case WRITE_BACK:
+        m_wr_hit = &data_cache::wr_hit_wb;
+        break;
+      case WRITE_THROUGH:
+        m_wr_hit = &data_cache::wr_hit_wt;
+        break;
+      case WRITE_EVICT:
+        m_wr_hit = &data_cache::wr_hit_we;
+        break;
+      case LOCAL_WB_GLOBAL_WT:
+        m_wr_hit = &data_cache::wr_hit_global_we_local_wb;
+        break;
+      default:
+        assert(0 && "Error: Must set valid cache write policy\n");
+        break;  // Need to set a write hit function
     }
 
-    virtual ~data_cache() {}
-
-    virtual void init( mem_fetch_allocator *mfcreator )
-    {
-        m_memfetch_creator=mfcreator;
-
-        // Set read hit function
-        m_rd_hit = &data_cache::rd_hit_base;
-
-        // Set read miss function
-        m_rd_miss = &data_cache::rd_miss_base;
-
-        // Set write hit function
-        switch(m_config.m_write_policy){
-        // READ_ONLY is now a separate cache class, config is deprecated
-        case READ_ONLY:
-            assert(0 && "Error: Writable Data_cache set as READ_ONLY\n");
-            break; 
-        case WRITE_BACK: m_wr_hit = &data_cache::wr_hit_wb; break;
-        case WRITE_THROUGH: m_wr_hit = &data_cache::wr_hit_wt; break;
-        case WRITE_EVICT: m_wr_hit = &data_cache::wr_hit_we; break;
-        case LOCAL_WB_GLOBAL_WT:
-            m_wr_hit = &data_cache::wr_hit_global_we_local_wb;
-            break;
-        default:
-            assert(0 && "Error: Must set valid cache write policy\n");
-            break; // Need to set a write hit function
-        }
-
-        // Set write miss function
-        switch(m_config.m_write_alloc_policy){
-        case NO_WRITE_ALLOCATE: m_wr_miss = &data_cache::wr_miss_no_wa; break;
-		case WRITE_ALLOCATE: m_wr_miss = &data_cache::wr_miss_wa_naive; break;
-		case FETCH_ON_WRITE: m_wr_miss = &data_cache::wr_miss_wa_fetch_on_write; break;
-		case LAZY_FETCH_ON_READ: m_wr_miss = &data_cache::wr_miss_wa_lazy_fetch_on_read; break;
-        default:
-            assert(0 && "Error: Must set valid cache write miss policy\n");
-            break; // Need to set a write miss function
-        }
+    // Set write miss function
+    switch (m_config.m_write_alloc_policy) {
+      case NO_WRITE_ALLOCATE:
+        m_wr_miss = &data_cache::wr_miss_no_wa;
+        break;
+      case WRITE_ALLOCATE:
+        m_wr_miss = &data_cache::wr_miss_wa_naive;
+        break;
+      case FETCH_ON_WRITE:
+        m_wr_miss = &data_cache::wr_miss_wa_fetch_on_write;
+        break;
+      case LAZY_FETCH_ON_READ:
+        m_wr_miss = &data_cache::wr_miss_wa_lazy_fetch_on_read;
+        break;
+      default:
+        assert(0 && "Error: Must set valid cache write miss policy\n");
+        break;  // Need to set a write miss function
     }
+  }
 
-    virtual enum cache_request_status access( new_addr_type addr,
-                                              mem_fetch *mf,
-                                              unsigned time,
-                                              std::list<cache_event> &events );
-protected:
-    data_cache( const char *name,
-                cache_config &config,
-                int core_id,
-                int type_id,
-                mem_fetch_interface *memport,
-                mem_fetch_allocator *mfcreator,
-                enum mem_fetch_status status,
-                tag_array* new_tag_array,
-                mem_access_type wr_alloc_type,
-                mem_access_type wrbk_type,
-				class gpgpu_sim* gpu )
-    : baseline_cache(name, config, core_id, type_id, memport,status, new_tag_array)
-    {
-        init( mfcreator );
-        m_wr_alloc_type = wr_alloc_type;
-        m_wrbk_type = wrbk_type;
-        m_gpu=gpu;
-    }
+  virtual enum cache_request_status access(new_addr_type addr, mem_fetch *mf,
+                                           unsigned time,
+                                           std::list<cache_event> &events);
 
-    mem_access_type m_wr_alloc_type; // Specifies type of write allocate request (e.g., L1 or L2)
-    mem_access_type m_wrbk_type; // Specifies type of writeback request (e.g., L1 or L2)
-    class gpgpu_sim* m_gpu;
+ protected:
+  data_cache(const char *name, cache_config &config, int core_id, int type_id,
+             mem_fetch_interface *memport, mem_fetch_allocator *mfcreator,
+             enum mem_fetch_status status, tag_array *new_tag_array,
+             mem_access_type wr_alloc_type, mem_access_type wrbk_type,
+             class gpgpu_sim *gpu)
+      : baseline_cache(name, config, core_id, type_id, memport, status,
+                       new_tag_array) {
+    init(mfcreator);
+    m_wr_alloc_type = wr_alloc_type;
+    m_wrbk_type = wrbk_type;
+    m_gpu = gpu;
+  }
 
-    //! A general function that takes the result of a tag_array probe
-    //  and performs the correspding functions based on the cache configuration
-    //  The access fucntion calls this function
-    enum cache_request_status
-        process_tag_probe( bool wr,
-                           enum cache_request_status status,
-                           new_addr_type addr,
-                           unsigned cache_index,
-                           mem_fetch* mf,
-                           unsigned time,
-                           std::list<cache_event>& events );
+  mem_access_type m_wr_alloc_type;  // Specifies type of write allocate request
+                                    // (e.g., L1 or L2)
+  mem_access_type
+      m_wrbk_type;  // Specifies type of writeback request (e.g., L1 or L2)
+  class gpgpu_sim *m_gpu;
 
-protected:
-    mem_fetch_allocator *m_memfetch_creator;
+  //! A general function that takes the result of a tag_array probe
+  //  and performs the correspding functions based on the cache configuration
+  //  The access fucntion calls this function
+  enum cache_request_status process_tag_probe(bool wr,
+                                              enum cache_request_status status,
+                                              new_addr_type addr,
+                                              unsigned cache_index,
+                                              mem_fetch *mf, unsigned time,
+                                              std::list<cache_event> &events);
 
-    // Functions for data cache access
-    /// Sends write request to lower level memory (write or writeback)
-    void send_write_request( mem_fetch *mf,
-                             cache_event request,
-                             unsigned time,
-                             std::list<cache_event> &events);
+ protected:
+  mem_fetch_allocator *m_memfetch_creator;
 
-    // Member Function pointers - Set by configuration options
-    // to the functions below each grouping
-    /******* Write-hit configs *******/
-    enum cache_request_status
-        (data_cache::*m_wr_hit)( new_addr_type addr,
-                                 unsigned cache_index,
-                                 mem_fetch *mf,
-                                 unsigned time,
-                                 std::list<cache_event> &events,
-                                 enum cache_request_status status );
-    /// Marks block as MODIFIED and updates block LRU
-    enum cache_request_status
-        wr_hit_wb( new_addr_type addr,
-                   unsigned cache_index,
-                   mem_fetch *mf,
-                   unsigned time,
-                   std::list<cache_event> &events,
-                   enum cache_request_status status ); // write-back
-    enum cache_request_status
-        wr_hit_wt( new_addr_type addr,
-                   unsigned cache_index,
-                   mem_fetch *mf,
-                   unsigned time,
-                   std::list<cache_event> &events,
-                   enum cache_request_status status ); // write-through
+  // Functions for data cache access
+  /// Sends write request to lower level memory (write or writeback)
+  void send_write_request(mem_fetch *mf, cache_event request, unsigned time,
+                          std::list<cache_event> &events);
 
-    /// Marks block as INVALID and sends write request to lower level memory
-    enum cache_request_status
-        wr_hit_we( new_addr_type addr,
-                   unsigned cache_index,
-                   mem_fetch *mf,
-                   unsigned time,
-                   std::list<cache_event> &events,
-                   enum cache_request_status status ); // write-evict
-    enum cache_request_status
-        wr_hit_global_we_local_wb( new_addr_type addr,
-                                   unsigned cache_index,
-                                   mem_fetch *mf,
-                                   unsigned time,
-                                   std::list<cache_event> &events,
-                                   enum cache_request_status status );
-        // global write-evict, local write-back
+  // Member Function pointers - Set by configuration options
+  // to the functions below each grouping
+  /******* Write-hit configs *******/
+  enum cache_request_status (data_cache::*m_wr_hit)(
+      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+      std::list<cache_event> &events, enum cache_request_status status);
+  /// Marks block as MODIFIED and updates block LRU
+  enum cache_request_status wr_hit_wb(
+      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+      std::list<cache_event> &events,
+      enum cache_request_status status);  // write-back
+  enum cache_request_status wr_hit_wt(
+      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+      std::list<cache_event> &events,
+      enum cache_request_status status);  // write-through
 
+  /// Marks block as INVALID and sends write request to lower level memory
+  enum cache_request_status wr_hit_we(
+      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+      std::list<cache_event> &events,
+      enum cache_request_status status);  // write-evict
+  enum cache_request_status wr_hit_global_we_local_wb(
+      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+      std::list<cache_event> &events, enum cache_request_status status);
+  // global write-evict, local write-back
 
-    /******* Write-miss configs *******/
-    enum cache_request_status
-        (data_cache::*m_wr_miss)( new_addr_type addr,
-                                  unsigned cache_index,
-                                  mem_fetch *mf,
-                                  unsigned time,
-                                  std::list<cache_event> &events,
-                                  enum cache_request_status status );
-    /// Sends read request, and possible write-back request,
-    //  to lower level memory for a write miss with write-allocate
-    enum cache_request_status
-    	wr_miss_wa_naive( new_addr_type addr,
-                        unsigned cache_index,
-                        mem_fetch *mf,
-                        unsigned time,
-                        std::list<cache_event> &events,
-                        enum cache_request_status status ); // write-allocate-send-write-and-read-request
-	enum cache_request_status
-			   wr_miss_wa_fetch_on_write( new_addr_type addr,
-							unsigned cache_index,
-							mem_fetch *mf,
-							unsigned time,
-							std::list<cache_event> &events,
-							enum cache_request_status status ); // write-allocate with fetch-on-every-write
-	enum cache_request_status
-				   wr_miss_wa_lazy_fetch_on_read( new_addr_type addr,
-								unsigned cache_index,
-								mem_fetch *mf,
-								unsigned time,
-								std::list<cache_event> &events,
-								enum cache_request_status status ); // write-allocate with read-fetch-only
-	enum cache_request_status
-				wr_miss_wa_write_validate( new_addr_type addr,
-							unsigned cache_index,
-							mem_fetch *mf,
-							unsigned time,
-							std::list<cache_event> &events,
-							enum cache_request_status status ); // write-allocate that writes with no read fetch
-    enum cache_request_status
-        wr_miss_no_wa( new_addr_type addr,
-                       unsigned cache_index,
-                       mem_fetch *mf,
-                       unsigned time,
-                       std::list<cache_event> &events,
-                       enum cache_request_status status ); // no write-allocate
+  /******* Write-miss configs *******/
+  enum cache_request_status (data_cache::*m_wr_miss)(
+      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+      std::list<cache_event> &events, enum cache_request_status status);
+  /// Sends read request, and possible write-back request,
+  //  to lower level memory for a write miss with write-allocate
+  enum cache_request_status wr_miss_wa_naive(
+      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+      std::list<cache_event> &events,
+      enum cache_request_status
+          status);  // write-allocate-send-write-and-read-request
+  enum cache_request_status wr_miss_wa_fetch_on_write(
+      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+      std::list<cache_event> &events,
+      enum cache_request_status
+          status);  // write-allocate with fetch-on-every-write
+  enum cache_request_status wr_miss_wa_lazy_fetch_on_read(
+      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+      std::list<cache_event> &events,
+      enum cache_request_status status);  // write-allocate with read-fetch-only
+  enum cache_request_status wr_miss_wa_write_validate(
+      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+      std::list<cache_event> &events,
+      enum cache_request_status
+          status);  // write-allocate that writes with no read fetch
+  enum cache_request_status wr_miss_no_wa(
+      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+      std::list<cache_event> &events,
+      enum cache_request_status status);  // no write-allocate
 
-    // Currently no separate functions for reads
-    /******* Read-hit configs *******/
-    enum cache_request_status
-        (data_cache::*m_rd_hit)( new_addr_type addr,
-                                 unsigned cache_index,
-                                 mem_fetch *mf,
-                                 unsigned time,
-                                 std::list<cache_event> &events,
-                                 enum cache_request_status status );
-    enum cache_request_status
-        rd_hit_base( new_addr_type addr,
-                     unsigned cache_index,
-                     mem_fetch *mf,
-                     unsigned time,
-                     std::list<cache_event> &events,
-                     enum cache_request_status status );
+  // Currently no separate functions for reads
+  /******* Read-hit configs *******/
+  enum cache_request_status (data_cache::*m_rd_hit)(
+      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+      std::list<cache_event> &events, enum cache_request_status status);
+  enum cache_request_status rd_hit_base(new_addr_type addr,
+                                        unsigned cache_index, mem_fetch *mf,
+                                        unsigned time,
+                                        std::list<cache_event> &events,
+                                        enum cache_request_status status);
 
-    /******* Read-miss configs *******/
-    enum cache_request_status
-        (data_cache::*m_rd_miss)( new_addr_type addr,
-                                  unsigned cache_index,
-                                  mem_fetch *mf,
-                                  unsigned time,
-                                  std::list<cache_event> &events,
-                                  enum cache_request_status status );
-    enum cache_request_status
-        rd_miss_base( new_addr_type addr,
-                      unsigned cache_index,
-                      mem_fetch*mf,
-                      unsigned time,
-                      std::list<cache_event> &events,
-                      enum cache_request_status status );
-
+  /******* Read-miss configs *******/
+  enum cache_request_status (data_cache::*m_rd_miss)(
+      new_addr_type addr, unsigned cache_index, mem_fetch *mf, unsigned time,
+      std::list<cache_event> &events, enum cache_request_status status);
+  enum cache_request_status rd_miss_base(new_addr_type addr,
+                                         unsigned cache_index, mem_fetch *mf,
+                                         unsigned time,
+                                         std::list<cache_event> &events,
+                                         enum cache_request_status status);
 };
 
 /// This is meant to model the first level data cache in Fermi.
@@ -1524,243 +1528,242 @@ protected:
 /// the granularity of individual blocks
 /// (the policy used in fermi according to the CUDA manual)
 class l1_cache : public data_cache {
-public:
-    l1_cache(const char *name, cache_config &config,
-            int core_id, int type_id, mem_fetch_interface *memport,
-            mem_fetch_allocator *mfcreator, enum mem_fetch_status status, class gpgpu_sim* gpu )
-            : data_cache(name,config,core_id,type_id,memport,mfcreator,status, L1_WR_ALLOC_R, L1_WRBK_ACC, gpu){}
+ public:
+  l1_cache(const char *name, cache_config &config, int core_id, int type_id,
+           mem_fetch_interface *memport, mem_fetch_allocator *mfcreator,
+           enum mem_fetch_status status, class gpgpu_sim *gpu)
+      : data_cache(name, config, core_id, type_id, memport, mfcreator, status,
+                   L1_WR_ALLOC_R, L1_WRBK_ACC, gpu) {}
 
-    virtual ~l1_cache(){}
+  virtual ~l1_cache() {}
 
-    virtual enum cache_request_status
-        access( new_addr_type addr,
-                mem_fetch *mf,
-                unsigned time,
-                std::list<cache_event> &events );
+  virtual enum cache_request_status access(new_addr_type addr, mem_fetch *mf,
+                                           unsigned time,
+                                           std::list<cache_event> &events);
 
-protected:
-    l1_cache( const char *name,
-              cache_config &config,
-              int core_id,
-              int type_id,
-              mem_fetch_interface *memport,
-              mem_fetch_allocator *mfcreator,
-              enum mem_fetch_status status,
-              tag_array* new_tag_array,
-			  class gpgpu_sim* gpu)
-    : data_cache( name,
-                  config,
-                  core_id,type_id,memport,mfcreator,status, new_tag_array, L1_WR_ALLOC_R, L1_WRBK_ACC, gpu ){}
-
+ protected:
+  l1_cache(const char *name, cache_config &config, int core_id, int type_id,
+           mem_fetch_interface *memport, mem_fetch_allocator *mfcreator,
+           enum mem_fetch_status status, tag_array *new_tag_array,
+           class gpgpu_sim *gpu)
+      : data_cache(name, config, core_id, type_id, memport, mfcreator, status,
+                   new_tag_array, L1_WR_ALLOC_R, L1_WRBK_ACC, gpu) {}
 };
 
 /// Models second level shared cache with global write-back
 /// and write-allocate policies
 class l2_cache : public data_cache {
-public:
-    l2_cache(const char *name,  cache_config &config,
-            int core_id, int type_id, mem_fetch_interface *memport,
-            mem_fetch_allocator *mfcreator, enum mem_fetch_status status, class gpgpu_sim* gpu )
-            : data_cache(name,config,core_id,type_id,memport,mfcreator,status, L2_WR_ALLOC_R, L2_WRBK_ACC, gpu){}
+ public:
+  l2_cache(const char *name, cache_config &config, int core_id, int type_id,
+           mem_fetch_interface *memport, mem_fetch_allocator *mfcreator,
+           enum mem_fetch_status status, class gpgpu_sim *gpu)
+      : data_cache(name, config, core_id, type_id, memport, mfcreator, status,
+                   L2_WR_ALLOC_R, L2_WRBK_ACC, gpu) {}
 
-    virtual ~l2_cache() {}
+  virtual ~l2_cache() {}
 
-    virtual enum cache_request_status
-        access( new_addr_type addr,
-                mem_fetch *mf,
-                unsigned time,
-                std::list<cache_event> &events );
+  virtual enum cache_request_status access(new_addr_type addr, mem_fetch *mf,
+                                           unsigned time,
+                                           std::list<cache_event> &events);
 };
 
 /*****************************************************************************/
 
 // See the following paper to understand this cache model:
-// 
-// Igehy, et al., Prefetching in a Texture Cache Architecture, 
+//
+// Igehy, et al., Prefetching in a Texture Cache Architecture,
 // Proceedings of the 1998 Eurographics/SIGGRAPH Workshop on Graphics Hardware
 // http://www-graphics.stanford.edu/papers/texture_prefetch/
 class tex_cache : public cache_t {
-public:
-    tex_cache( const char *name, cache_config &config, int core_id, int type_id, mem_fetch_interface *memport,
-               enum mem_fetch_status request_status, 
-               enum mem_fetch_status rob_status )
-    : m_config(config), 
-    m_tags(config,core_id,type_id), 
-    m_fragment_fifo(config.m_fragment_fifo_entries), 
-    m_request_fifo(config.m_request_fifo_entries),
-    m_rob(config.m_rob_entries),
-    m_result_fifo(config.m_result_fifo_entries)
-    {
-        m_name = name;
-        assert(config.m_mshr_type == TEX_FIFO || config.m_mshr_type == SECTOR_TEX_FIFO );
-        assert(config.m_write_policy == READ_ONLY);
-        assert(config.m_alloc_policy == ON_MISS);
-        m_memport=memport;
-        m_cache = new data_block[ config.get_num_lines() ];
-        m_request_queue_status = request_status;
-        m_rob_status = rob_status;
+ public:
+  tex_cache(const char *name, cache_config &config, int core_id, int type_id,
+            mem_fetch_interface *memport, enum mem_fetch_status request_status,
+            enum mem_fetch_status rob_status)
+      : m_config(config),
+        m_tags(config, core_id, type_id),
+        m_fragment_fifo(config.m_fragment_fifo_entries),
+        m_request_fifo(config.m_request_fifo_entries),
+        m_rob(config.m_rob_entries),
+        m_result_fifo(config.m_result_fifo_entries) {
+    m_name = name;
+    assert(config.m_mshr_type == TEX_FIFO ||
+           config.m_mshr_type == SECTOR_TEX_FIFO);
+    assert(config.m_write_policy == READ_ONLY);
+    assert(config.m_alloc_policy == ON_MISS);
+    m_memport = memport;
+    m_cache = new data_block[config.get_num_lines()];
+    m_request_queue_status = request_status;
+    m_rob_status = rob_status;
+  }
+
+  /// Access function for tex_cache
+  /// return values: RESERVATION_FAIL if request could not be accepted
+  /// otherwise returns HIT_RESERVED or MISS; NOTE: *never* returns HIT
+  /// since unlike a normal CPU cache, a "HIT" in texture cache does not
+  /// mean the data is ready (still need to get through fragment fifo)
+  enum cache_request_status access(new_addr_type addr, mem_fetch *mf,
+                                   unsigned time,
+                                   std::list<cache_event> &events);
+  void cycle();
+  /// Place returning cache block into reorder buffer
+  void fill(mem_fetch *mf, unsigned time);
+  /// Are any (accepted) accesses that had to wait for memory now ready? (does
+  /// not include accesses that "HIT")
+  bool access_ready() const { return !m_result_fifo.empty(); }
+  /// Pop next ready access (includes both accesses that "HIT" and those that
+  /// "MISS")
+  mem_fetch *next_access() { return m_result_fifo.pop(); }
+  void display_state(FILE *fp) const;
+
+  // accessors for cache bandwidth availability - stubs for now
+  bool data_port_free() const { return true; }
+  bool fill_port_free() const { return true; }
+
+  // Stat collection
+  const cache_stats &get_stats() const { return m_stats; }
+  unsigned get_stats(enum mem_access_type *access_type,
+                     unsigned num_access_type,
+                     enum cache_request_status *access_status,
+                     unsigned num_access_status) const {
+    return m_stats.get_stats(access_type, num_access_type, access_status,
+                             num_access_status);
+  }
+
+  void get_sub_stats(struct cache_sub_stats &css) const {
+    m_stats.get_sub_stats(css);
+  }
+
+ private:
+  std::string m_name;
+  const cache_config &m_config;
+
+  struct fragment_entry {
+    fragment_entry() {}
+    fragment_entry(mem_fetch *mf, unsigned idx, bool m, unsigned d) {
+      m_request = mf;
+      m_cache_index = idx;
+      m_miss = m;
+      m_data_size = d;
+    }
+    mem_fetch *m_request;    // request information
+    unsigned m_cache_index;  // where to look for data
+    bool m_miss;             // true if sent memory request
+    unsigned m_data_size;
+  };
+
+  struct rob_entry {
+    rob_entry() {
+      m_ready = false;
+      m_time = 0;
+      m_request = NULL;
+    }
+    rob_entry(unsigned i, mem_fetch *mf, new_addr_type a) {
+      m_ready = false;
+      m_index = i;
+      m_time = 0;
+      m_request = mf;
+      m_block_addr = a;
+    }
+    bool m_ready;
+    unsigned m_time;   // which cycle did this entry become ready?
+    unsigned m_index;  // where in cache should block be placed?
+    mem_fetch *m_request;
+    new_addr_type m_block_addr;
+  };
+
+  struct data_block {
+    data_block() { m_valid = false; }
+    bool m_valid;
+    new_addr_type m_block_addr;
+  };
+
+  // TODO: replace fifo_pipeline with this?
+  template <class T>
+  class fifo {
+   public:
+    fifo(unsigned size) {
+      m_size = size;
+      m_num = 0;
+      m_head = 0;
+      m_tail = 0;
+      m_data = new T[size];
+    }
+    bool full() const { return m_num == m_size; }
+    bool empty() const { return m_num == 0; }
+    unsigned size() const { return m_num; }
+    unsigned capacity() const { return m_size; }
+    unsigned push(const T &e) {
+      assert(!full());
+      m_data[m_head] = e;
+      unsigned result = m_head;
+      inc_head();
+      return result;
+    }
+    T pop() {
+      assert(!empty());
+      T result = m_data[m_tail];
+      inc_tail();
+      return result;
+    }
+    const T &peek(unsigned index) const {
+      assert(index < m_size);
+      return m_data[index];
+    }
+    T &peek(unsigned index) {
+      assert(index < m_size);
+      return m_data[index];
+    }
+    T &peek() const { return m_data[m_tail]; }
+    unsigned next_pop_index() const { return m_tail; }
+
+   private:
+    void inc_head() {
+      m_head = (m_head + 1) % m_size;
+      m_num++;
+    }
+    void inc_tail() {
+      assert(m_num > 0);
+      m_tail = (m_tail + 1) % m_size;
+      m_num--;
     }
 
-    /// Access function for tex_cache
-    /// return values: RESERVATION_FAIL if request could not be accepted
-    /// otherwise returns HIT_RESERVED or MISS; NOTE: *never* returns HIT
-    /// since unlike a normal CPU cache, a "HIT" in texture cache does not
-    /// mean the data is ready (still need to get through fragment fifo)
-    enum cache_request_status access( new_addr_type addr, mem_fetch *mf, unsigned time, std::list<cache_event> &events );
-    void cycle();
-    /// Place returning cache block into reorder buffer
-    void fill( mem_fetch *mf, unsigned time );
-    /// Are any (accepted) accesses that had to wait for memory now ready? (does not include accesses that "HIT")
-    bool access_ready() const{return !m_result_fifo.empty();}
-    /// Pop next ready access (includes both accesses that "HIT" and those that "MISS")
-    mem_fetch *next_access(){return m_result_fifo.pop();}
-    void display_state( FILE *fp ) const;
+    unsigned m_head;  // next entry goes here
+    unsigned m_tail;  // oldest entry found here
+    unsigned m_num;   // how many in fifo?
+    unsigned m_size;  // maximum number of entries in fifo
+    T *m_data;
+  };
 
-    // accessors for cache bandwidth availability - stubs for now 
-    bool data_port_free() const { return true; }
-    bool fill_port_free() const { return true; }
+  tag_array m_tags;
+  fifo<fragment_entry> m_fragment_fifo;
+  fifo<mem_fetch *> m_request_fifo;
+  fifo<rob_entry> m_rob;
+  data_block *m_cache;
+  fifo<mem_fetch *> m_result_fifo;  // next completed texture fetch
 
-    // Stat collection
-    const cache_stats &get_stats() const {
-        return m_stats;
+  mem_fetch_interface *m_memport;
+  enum mem_fetch_status m_request_queue_status;
+  enum mem_fetch_status m_rob_status;
+
+  struct extra_mf_fields {
+    extra_mf_fields() { m_valid = false; }
+    extra_mf_fields(unsigned i, const cache_config &m_config) {
+      m_valid = true;
+      m_rob_index = i;
+      pending_read = m_config.m_mshr_type == SECTOR_TEX_FIFO
+                         ? m_config.m_line_sz / SECTOR_SIZE
+                         : 0;
     }
-    unsigned get_stats(enum mem_access_type *access_type, unsigned num_access_type, enum cache_request_status *access_status, unsigned num_access_status) const{
-        return m_stats.get_stats(access_type, num_access_type, access_status, num_access_status);
-    }
+    bool m_valid;
+    unsigned m_rob_index;
+    unsigned pending_read;
+  };
 
-    void get_sub_stats(struct cache_sub_stats &css) const{
-        m_stats.get_sub_stats(css);
-    }
-private:
-    std::string m_name;
-    const cache_config &m_config;
+  cache_stats m_stats;
 
-    struct fragment_entry {
-        fragment_entry() {}
-        fragment_entry( mem_fetch *mf, unsigned idx, bool m, unsigned d )
-        {
-            m_request=mf;
-            m_cache_index=idx;
-            m_miss=m;
-            m_data_size=d;
-        }
-        mem_fetch *m_request;     // request information
-        unsigned   m_cache_index; // where to look for data
-        bool       m_miss;        // true if sent memory request
-        unsigned   m_data_size;
-    };
+  typedef std::map<mem_fetch *, extra_mf_fields> extra_mf_fields_lookup;
 
-    struct rob_entry {
-        rob_entry() { m_ready = false; m_time=0; m_request=NULL;}
-        rob_entry( unsigned i, mem_fetch *mf, new_addr_type a ) 
-        { 
-            m_ready=false; 
-            m_index=i;
-            m_time=0;
-            m_request=mf; 
-            m_block_addr=a;
-        }
-        bool m_ready;
-        unsigned m_time; // which cycle did this entry become ready?
-        unsigned m_index; // where in cache should block be placed?
-        mem_fetch *m_request;
-        new_addr_type m_block_addr;
-    };
-
-    struct data_block {
-        data_block() { m_valid = false;}
-        bool m_valid;
-        new_addr_type m_block_addr;
-    };
-
-    // TODO: replace fifo_pipeline with this?
-    template<class T> class fifo {
-    public:
-        fifo( unsigned size ) 
-        { 
-            m_size=size; 
-            m_num=0; 
-            m_head=0; 
-            m_tail=0; 
-            m_data = new T[size];
-        }
-        bool full() const { return m_num == m_size;}
-        bool empty() const { return m_num == 0;}
-        unsigned size() const { return m_num;}
-        unsigned capacity() const { return m_size;}
-        unsigned push( const T &e ) 
-        { 
-            assert(!full()); 
-            m_data[m_head] = e; 
-            unsigned result = m_head;
-            inc_head(); 
-            return result;
-        }
-        T pop() 
-        { 
-            assert(!empty()); 
-            T result = m_data[m_tail];
-            inc_tail();
-            return result;
-        }
-        const T &peek( unsigned index ) const 
-        { 
-            assert( index < m_size );
-            return m_data[index]; 
-        }
-        T &peek( unsigned index ) 
-        { 
-            assert( index < m_size );
-            return m_data[index]; 
-        }
-        T &peek() const
-        { 
-            return m_data[m_tail]; 
-        }
-        unsigned next_pop_index() const 
-        {
-            return m_tail;
-        }
-    private:
-        void inc_head() { m_head = (m_head+1)%m_size; m_num++;}
-        void inc_tail() { assert(m_num>0); m_tail = (m_tail+1)%m_size; m_num--;}
-
-        unsigned   m_head; // next entry goes here
-        unsigned   m_tail; // oldest entry found here
-        unsigned   m_num;  // how many in fifo?
-        unsigned   m_size; // maximum number of entries in fifo
-        T         *m_data;
-    };
-
-    tag_array               m_tags;
-    fifo<fragment_entry>    m_fragment_fifo;
-    fifo<mem_fetch*>        m_request_fifo;
-    fifo<rob_entry>         m_rob;
-    data_block             *m_cache;
-    fifo<mem_fetch*>        m_result_fifo; // next completed texture fetch
-
-    mem_fetch_interface    *m_memport;
-    enum mem_fetch_status   m_request_queue_status;
-    enum mem_fetch_status   m_rob_status;
-
-    struct extra_mf_fields {
-        extra_mf_fields()  { m_valid = false;}
-        extra_mf_fields( unsigned i, const cache_config &m_config )
-        {
-            m_valid = true;
-            m_rob_index = i;
-            pending_read = m_config.m_mshr_type == SECTOR_TEX_FIFO? m_config.m_line_sz/SECTOR_SIZE : 0;
-        }
-        bool m_valid;
-        unsigned m_rob_index;
-        unsigned pending_read;
-    };
-
-    cache_stats m_stats;
-
-    typedef std::map<mem_fetch*,extra_mf_fields> extra_mf_fields_lookup;
-
-    extra_mf_fields_lookup m_extra_mf_fields;
+  extra_mf_fields_lookup m_extra_mf_fields;
 };
 
 #endif

--- a/src/gpgpu-sim/gpu-cache.h
+++ b/src/gpgpu-sim/gpu-cache.h
@@ -1312,9 +1312,9 @@ class baseline_cache : public cache_t {
     const cache_config &m_config;
 
     int m_data_port_occupied_cycles;  //< Number of cycle that the data port
-                                      //remains used
+                                      // remains used
     int m_fill_port_occupied_cycles;  //< Number of cycle that the fill port
-                                      //remains used
+                                      // remains used
   };
 
   bandwidth_management m_bandwidth_management;

--- a/src/gpgpu-sim/gpu-cache.h
+++ b/src/gpgpu-sim/gpu-cache.h
@@ -1312,9 +1312,9 @@ class baseline_cache : public cache_t {
     const cache_config &m_config;
 
     int m_data_port_occupied_cycles;  //< Number of cycle that the data port
-                                      // remains used
+                                      //remains used
     int m_fill_port_occupied_cycles;  //< Number of cycle that the fill port
-                                      // remains used
+                                      //remains used
   };
 
   bandwidth_management m_bandwidth_management;

--- a/src/gpgpu-sim/gpu-misc.cc
+++ b/src/gpgpu-sim/gpu-misc.cc
@@ -7,37 +7,48 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #include "gpu-misc.h"
 
-unsigned int LOGB2( unsigned int v ) {
-   unsigned int shift;
-   unsigned int r;
+unsigned int LOGB2(unsigned int v) {
+  unsigned int shift;
+  unsigned int r;
 
-   r = 0;
+  r = 0;
 
-   shift = (( v & 0xFFFF0000) != 0 ) << 4; v >>= shift; r |= shift;
-   shift = (( v & 0xFF00    ) != 0 ) << 3; v >>= shift; r |= shift;
-   shift = (( v & 0xF0      ) != 0 ) << 2; v >>= shift; r |= shift;
-   shift = (( v & 0xC       ) != 0 ) << 1; v >>= shift; r |= shift;
-   shift = (( v & 0x2       ) != 0 ) << 0; v >>= shift; r |= shift;
+  shift = ((v & 0xFFFF0000) != 0) << 4;
+  v >>= shift;
+  r |= shift;
+  shift = ((v & 0xFF00) != 0) << 3;
+  v >>= shift;
+  r |= shift;
+  shift = ((v & 0xF0) != 0) << 2;
+  v >>= shift;
+  r |= shift;
+  shift = ((v & 0xC) != 0) << 1;
+  v >>= shift;
+  r |= shift;
+  shift = ((v & 0x2) != 0) << 0;
+  v >>= shift;
+  r |= shift;
 
-   return r;
+  return r;
 }

--- a/src/gpgpu-sim/gpu-misc.cc
+++ b/src/gpgpu-sim/gpu-misc.cc
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -27,17 +29,27 @@
 
 #include "gpu-misc.h"
 
-unsigned int LOGB2( unsigned int v ) {
-   unsigned int shift;
-   unsigned int r;
+unsigned int LOGB2(unsigned int v) {
+  unsigned int shift;
+  unsigned int r;
 
-   r = 0;
+  r = 0;
 
-   shift = (( v & 0xFFFF0000) != 0 ) << 4; v >>= shift; r |= shift;
-   shift = (( v & 0xFF00    ) != 0 ) << 3; v >>= shift; r |= shift;
-   shift = (( v & 0xF0      ) != 0 ) << 2; v >>= shift; r |= shift;
-   shift = (( v & 0xC       ) != 0 ) << 1; v >>= shift; r |= shift;
-   shift = (( v & 0x2       ) != 0 ) << 0; v >>= shift; r |= shift;
+  shift = ((v & 0xFFFF0000) != 0) << 4;
+  v >>= shift;
+  r |= shift;
+  shift = ((v & 0xFF00) != 0) << 3;
+  v >>= shift;
+  r |= shift;
+  shift = ((v & 0xF0) != 0) << 2;
+  v >>= shift;
+  r |= shift;
+  shift = ((v & 0xC) != 0) << 1;
+  v >>= shift;
+  r |= shift;
+  shift = ((v & 0x2) != 0) << 0;
+  v >>= shift;
+  r |= shift;
 
-   return r;
+  return r;
 }

--- a/src/gpgpu-sim/gpu-misc.cc
+++ b/src/gpgpu-sim/gpu-misc.cc
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -29,27 +27,17 @@
 
 #include "gpu-misc.h"
 
-unsigned int LOGB2(unsigned int v) {
-  unsigned int shift;
-  unsigned int r;
+unsigned int LOGB2( unsigned int v ) {
+   unsigned int shift;
+   unsigned int r;
 
-  r = 0;
+   r = 0;
 
-  shift = ((v & 0xFFFF0000) != 0) << 4;
-  v >>= shift;
-  r |= shift;
-  shift = ((v & 0xFF00) != 0) << 3;
-  v >>= shift;
-  r |= shift;
-  shift = ((v & 0xF0) != 0) << 2;
-  v >>= shift;
-  r |= shift;
-  shift = ((v & 0xC) != 0) << 1;
-  v >>= shift;
-  r |= shift;
-  shift = ((v & 0x2) != 0) << 0;
-  v >>= shift;
-  r |= shift;
+   shift = (( v & 0xFFFF0000) != 0 ) << 4; v >>= shift; r |= shift;
+   shift = (( v & 0xFF00    ) != 0 ) << 3; v >>= shift; r |= shift;
+   shift = (( v & 0xF0      ) != 0 ) << 2; v >>= shift; r |= shift;
+   shift = (( v & 0xC       ) != 0 ) << 1; v >>= shift; r |= shift;
+   shift = (( v & 0x2       ) != 0 ) << 0; v >>= shift; r |= shift;
 
-  return r;
+   return r;
 }

--- a/src/gpgpu-sim/gpu-misc.h
+++ b/src/gpgpu-sim/gpu-misc.h
@@ -8,35 +8,35 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef GPU_MISC_H
 #define GPU_MISC_H
 
-//enables a verbose printout of all L1 cache misses and all MSHR status changes 
-//good for a single shader configuration
+// enables a verbose printout of all L1 cache misses and all MSHR status changes
+// good for a single shader configuration
 #define DEBUGL1MISS 0
 
-unsigned int LOGB2( unsigned int v );
+unsigned int LOGB2(unsigned int v);
 
-#define gs_min2(a,b) (((a)<(b))?(a):(b))
-#define min3(x,y,z) (((x)<(y) && (x)<(z))?(x):(gs_min2((y),(z))))
+#define gs_min2(a, b) (((a) < (b)) ? (a) : (b))
+#define min3(x, y, z) (((x) < (y) && (x) < (z)) ? (x) : (gs_min2((y), (z))))
 
 #endif
-

--- a/src/gpgpu-sim/gpu-misc.h
+++ b/src/gpgpu-sim/gpu-misc.h
@@ -8,16 +8,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -31,13 +29,14 @@
 #ifndef GPU_MISC_H
 #define GPU_MISC_H
 
-// enables a verbose printout of all L1 cache misses and all MSHR status changes
-// good for a single shader configuration
+//enables a verbose printout of all L1 cache misses and all MSHR status changes 
+//good for a single shader configuration
 #define DEBUGL1MISS 0
 
-unsigned int LOGB2(unsigned int v);
+unsigned int LOGB2( unsigned int v );
 
-#define gs_min2(a, b) (((a) < (b)) ? (a) : (b))
-#define min3(x, y, z) (((x) < (y) && (x) < (z)) ? (x) : (gs_min2((y), (z))))
+#define gs_min2(a,b) (((a)<(b))?(a):(b))
+#define min3(x,y,z) (((x)<(y) && (x)<(z))?(x):(gs_min2((y),(z))))
 
 #endif
+

--- a/src/gpgpu-sim/gpu-misc.h
+++ b/src/gpgpu-sim/gpu-misc.h
@@ -8,14 +8,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -29,14 +31,13 @@
 #ifndef GPU_MISC_H
 #define GPU_MISC_H
 
-//enables a verbose printout of all L1 cache misses and all MSHR status changes 
-//good for a single shader configuration
+// enables a verbose printout of all L1 cache misses and all MSHR status changes
+// good for a single shader configuration
 #define DEBUGL1MISS 0
 
-unsigned int LOGB2( unsigned int v );
+unsigned int LOGB2(unsigned int v);
 
-#define gs_min2(a,b) (((a)<(b))?(a):(b))
-#define min3(x,y,z) (((x)<(y) && (x)<(z))?(x):(gs_min2((y),(z))))
+#define gs_min2(a, b) (((a) < (b)) ? (a) : (b))
+#define min3(x, y, z) (((x) < (y) && (x) < (z)) ? (x) : (gs_min2((y), (z))))
 
 #endif
-

--- a/src/gpgpu-sim/gpu-sim.cc
+++ b/src/gpgpu-sim/gpu-sim.cc
@@ -8,69 +8,68 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #include "gpu-sim.h"
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <math.h>
 #include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include "zlib.h"
 
-
-#include "shader.h"
-#include "shader_trace.h"
 #include "dram.h"
 #include "mem_fetch.h"
+#include "shader.h"
+#include "shader_trace.h"
 
 #include <time.h>
+#include "addrdec.h"
+#include "delayqueue.h"
+#include "dram.h"
 #include "gpu-cache.h"
 #include "gpu-misc.h"
-#include "delayqueue.h"
-#include "shader.h"
 #include "icnt_wrapper.h"
-#include "dram.h"
-#include "addrdec.h"
-#include "stat-tool.h"
 #include "l2cache.h"
+#include "shader.h"
+#include "stat-tool.h"
 
-#include "../cuda-sim/ptx-stats.h"
-#include "../statwrapper.h"
+#include "../../libcuda/gpgpu_context.h"
 #include "../abstract_hardware_model.h"
+#include "../cuda-sim/cuda-sim.h"
+#include "../cuda-sim/cuda_device_runtime.h"
+#include "../cuda-sim/ptx-stats.h"
+#include "../cuda-sim/ptx_ir.h"
 #include "../debug.h"
 #include "../gpgpusim_entrypoint.h"
-#include "../cuda-sim/cuda-sim.h"
-#include "../cuda-sim/ptx_ir.h"
+#include "../statwrapper.h"
 #include "../trace.h"
 #include "mem_latency_stat.h"
 #include "power_stat.h"
-#include "visualizer.h"
 #include "stats.h"
-#include "../cuda-sim/cuda_device_runtime.h"
-#include "../../libcuda/gpgpu_context.h"
+#include "visualizer.h"
 
 #ifdef GPGPUSIM_POWER_MODEL
 #include "power_interface.h"
 #else
-class  gpgpu_sim_wrapper {};
+class gpgpu_sim_wrapper {};
 #endif
 
 #include <stdio.h>
@@ -79,1781 +78,1910 @@ class  gpgpu_sim_wrapper {};
 #include <sstream>
 #include <string>
 
-#define MAX(a,b) (((a)>(b))?(a):(b))
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
 
+bool g_interactive_debugger_enabled = false;
 
-bool g_interactive_debugger_enabled=false;
-
-tr1_hash_map<new_addr_type,unsigned> address_random_interleaving;
+tr1_hash_map<new_addr_type, unsigned> address_random_interleaving;
 
 /* Clock Domains */
 
-#define  CORE  0x01
-#define  L2    0x02
-#define  DRAM  0x04
-#define  ICNT  0x08  
-
+#define CORE 0x01
+#define L2 0x02
+#define DRAM 0x04
+#define ICNT 0x08
 
 #define MEM_LATENCY_STAT_IMPL
 
-
 #include "mem_latency_stat.h"
 
-void power_config::reg_options(class OptionParser * opp)
-{
+void power_config::reg_options(class OptionParser *opp) {
+  option_parser_register(opp, "-gpuwattch_xml_file", OPT_CSTR,
+                         &g_power_config_name, "GPUWattch XML file",
+                         "gpuwattch.xml");
 
+  option_parser_register(opp, "-power_simulation_enabled", OPT_BOOL,
+                         &g_power_simulation_enabled,
+                         "Turn on power simulator (1=On, 0=Off)", "0");
 
-	  option_parser_register(opp, "-gpuwattch_xml_file", OPT_CSTR,
-			  	  	  	  	 &g_power_config_name,"GPUWattch XML file",
-	                   "gpuwattch.xml");
+  option_parser_register(opp, "-power_per_cycle_dump", OPT_BOOL,
+                         &g_power_per_cycle_dump,
+                         "Dump detailed power output each cycle", "0");
 
-	   option_parser_register(opp, "-power_simulation_enabled", OPT_BOOL,
-	                          &g_power_simulation_enabled, "Turn on power simulator (1=On, 0=Off)",
-	                          "0");
+  // Output Data Formats
+  option_parser_register(
+      opp, "-power_trace_enabled", OPT_BOOL, &g_power_trace_enabled,
+      "produce a file for the power trace (1=On, 0=Off)", "0");
 
-	   option_parser_register(opp, "-power_per_cycle_dump", OPT_BOOL,
-	                          &g_power_per_cycle_dump, "Dump detailed power output each cycle",
-	                          "0");
+  option_parser_register(
+      opp, "-power_trace_zlevel", OPT_INT32, &g_power_trace_zlevel,
+      "Compression level of the power trace output log (0=no comp, 9=highest)",
+      "6");
 
-	   // Output Data Formats
-	   option_parser_register(opp, "-power_trace_enabled", OPT_BOOL,
-	                          &g_power_trace_enabled, "produce a file for the power trace (1=On, 0=Off)",
-	                          "0");
+  option_parser_register(
+      opp, "-steady_power_levels_enabled", OPT_BOOL,
+      &g_steady_power_levels_enabled,
+      "produce a file for the steady power levels (1=On, 0=Off)", "0");
 
-	   option_parser_register(opp, "-power_trace_zlevel", OPT_INT32,
-	                          &g_power_trace_zlevel, "Compression level of the power trace output log (0=no comp, 9=highest)",
-	                          "6");
-
-	   option_parser_register(opp, "-steady_power_levels_enabled", OPT_BOOL,
-	                          &g_steady_power_levels_enabled, "produce a file for the steady power levels (1=On, 0=Off)",
-	                          "0");
-
-	   option_parser_register(opp, "-steady_state_definition", OPT_CSTR,
-			   	  &gpu_steady_state_definition, "allowed deviation:number of samples",
-	                 	  "8:4");
-
+  option_parser_register(opp, "-steady_state_definition", OPT_CSTR,
+                         &gpu_steady_state_definition,
+                         "allowed deviation:number of samples", "8:4");
 }
 
-void memory_config::reg_options(class OptionParser * opp)
-{
-    option_parser_register(opp, "-perf_sim_memcpy", OPT_BOOL, &m_perf_sim_memcpy, 
-                                "Fill the L2 cache on memcpy", "1");
-    option_parser_register(opp, "-simple_dram_model", OPT_BOOL, &simple_dram_model,
-                                "simple_dram_model with fixed latency and BW", "0");
-    option_parser_register(opp, "-gpgpu_dram_scheduler", OPT_INT32, &scheduler_type, 
-                                "0 = fifo, 1 = FR-FCFS (defaul)", "1");
-    option_parser_register(opp, "-gpgpu_dram_partition_queues", OPT_CSTR, &gpgpu_L2_queue_config, 
-                           "i2$:$2d:d2$:$2i",
-                           "8:8:8:8");
+void memory_config::reg_options(class OptionParser *opp) {
+  option_parser_register(opp, "-perf_sim_memcpy", OPT_BOOL, &m_perf_sim_memcpy,
+                         "Fill the L2 cache on memcpy", "1");
+  option_parser_register(opp, "-simple_dram_model", OPT_BOOL,
+                         &simple_dram_model,
+                         "simple_dram_model with fixed latency and BW", "0");
+  option_parser_register(opp, "-gpgpu_dram_scheduler", OPT_INT32,
+                         &scheduler_type, "0 = fifo, 1 = FR-FCFS (defaul)",
+                         "1");
+  option_parser_register(opp, "-gpgpu_dram_partition_queues", OPT_CSTR,
+                         &gpgpu_L2_queue_config, "i2$:$2d:d2$:$2i", "8:8:8:8");
 
-    option_parser_register(opp, "-l2_ideal", OPT_BOOL, &l2_ideal, 
-                           "Use a ideal L2 cache that always hit",
-                           "0");
-    option_parser_register(opp, "-gpgpu_cache:dl2", OPT_CSTR, &m_L2_config.m_config_string, 
-                   "unified banked L2 data cache config "
-                   " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_alloc>,<mshr>:<N>:<merge>,<mq>}",
-                   "64:128:8,L:B:m:N,A:16:4,4");
-    option_parser_register(opp, "-gpgpu_cache:dl2_texture_only", OPT_BOOL, &m_L2_texure_only, 
-                           "L2 cache used for texture only",
-                           "1");
-    option_parser_register(opp, "-gpgpu_n_mem", OPT_UINT32, &m_n_mem, 
-                 "number of memory modules (e.g. memory controllers) in gpu",
-                 "8");
-    option_parser_register(opp, "-gpgpu_n_sub_partition_per_mchannel", OPT_UINT32, &m_n_sub_partition_per_memory_channel, 
-                 "number of memory subpartition in each memory module",
-                 "1");
-    option_parser_register(opp, "-gpgpu_n_mem_per_ctrlr", OPT_UINT32, &gpu_n_mem_per_ctrlr, 
-                 "number of memory chips per memory controller",
-                 "1");
-    option_parser_register(opp, "-gpgpu_memlatency_stat", OPT_INT32, &gpgpu_memlatency_stat, 
-                "track and display latency statistics 0x2 enables MC, 0x4 enables queue logs",
-                "0");
-    option_parser_register(opp, "-gpgpu_frfcfs_dram_sched_queue_size", OPT_INT32, &gpgpu_frfcfs_dram_sched_queue_size, 
-                "0 = unlimited (default); # entries per chip",
-                "0");
-    option_parser_register(opp, "-gpgpu_dram_return_queue_size", OPT_INT32, &gpgpu_dram_return_queue_size, 
-                "0 = unlimited (default); # entries per chip",
-                "0");
-    option_parser_register(opp, "-gpgpu_dram_buswidth", OPT_UINT32, &busW, 
-                 "default = 4 bytes (8 bytes per cycle at DDR)",
-                 "4");
-    option_parser_register(opp, "-gpgpu_dram_burst_length", OPT_UINT32, &BL, 
-                 "Burst length of each DRAM request (default = 4 data bus cycle)",
-                 "4");
-    option_parser_register(opp, "-dram_data_command_freq_ratio", OPT_UINT32, &data_command_freq_ratio, 
-                 "Frequency ratio between DRAM data bus and command bus (default = 2 times, i.e. DDR)",
-                 "2");
-    option_parser_register(opp, "-gpgpu_dram_timing_opt", OPT_CSTR, &gpgpu_dram_timing_opt, 
-                "DRAM timing parameters = {nbk:tCCD:tRRD:tRCD:tRAS:tRP:tRC:CL:WL:tCDLR:tWR:nbkgrp:tCCDL:tRTPL}",
-                "4:2:8:12:21:13:34:9:4:5:13:1:0:0");
-    option_parser_register(opp, "-rop_latency", OPT_UINT32, &rop_latency,
-                     "ROP queue latency (default 85)",
-                     "85");
-    option_parser_register(opp, "-dram_latency", OPT_UINT32, &dram_latency,
-                     "DRAM latency (default 30)",
-                     "30");
-    option_parser_register(opp, "-dual_bus_interface", OPT_UINT32, &dual_bus_interface,
-                                        "dual_bus_interface (default = 0) ",
-                                        "0");
-    option_parser_register(opp, "-dram_bnk_indexing_policy", OPT_UINT32, &dram_bnk_indexing_policy,
-                                            "dram_bnk_indexing_policy (0 = normal indexing, 1 = Xoring with the higher bits) (Default = 0)",
-                                            "0");
-    option_parser_register(opp, "-dram_bnkgrp_indexing_policy", OPT_UINT32, &dram_bnkgrp_indexing_policy,
-                                            "dram_bnkgrp_indexing_policy (0 = take higher bits, 1 = take lower bits) (Default = 0)",
-                                            "0");
-    option_parser_register(opp, "-Seperate_Write_Queue_Enable", OPT_BOOL, &seperate_write_queue_enabled,
-                           "Seperate_Write_Queue_Enable",
-                           "0");
-    option_parser_register(opp, "-Write_Queue_Size", OPT_CSTR, &write_queue_size_opt,
-                                  "Write_Queue_Size",
-                                  "32:28:16");
-    option_parser_register(opp, "-Elimnate_rw_turnaround", OPT_BOOL, &elimnate_rw_turnaround,
-                               "elimnate_rw_turnaround i.e set tWTR and tRTW = 0",
-                               "0");
-    option_parser_register(opp, "-icnt_flit_size", OPT_UINT32, &icnt_flit_size,
-                               "icnt_flit_size",
-                               "32");
-    m_address_mapping.addrdec_setoption(opp);
+  option_parser_register(opp, "-l2_ideal", OPT_BOOL, &l2_ideal,
+                         "Use a ideal L2 cache that always hit", "0");
+  option_parser_register(opp, "-gpgpu_cache:dl2", OPT_CSTR,
+                         &m_L2_config.m_config_string,
+                         "unified banked L2 data cache config "
+                         " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_"
+                         "alloc>,<mshr>:<N>:<merge>,<mq>}",
+                         "64:128:8,L:B:m:N,A:16:4,4");
+  option_parser_register(opp, "-gpgpu_cache:dl2_texture_only", OPT_BOOL,
+                         &m_L2_texure_only, "L2 cache used for texture only",
+                         "1");
+  option_parser_register(
+      opp, "-gpgpu_n_mem", OPT_UINT32, &m_n_mem,
+      "number of memory modules (e.g. memory controllers) in gpu", "8");
+  option_parser_register(opp, "-gpgpu_n_sub_partition_per_mchannel", OPT_UINT32,
+                         &m_n_sub_partition_per_memory_channel,
+                         "number of memory subpartition in each memory module",
+                         "1");
+  option_parser_register(opp, "-gpgpu_n_mem_per_ctrlr", OPT_UINT32,
+                         &gpu_n_mem_per_ctrlr,
+                         "number of memory chips per memory controller", "1");
+  option_parser_register(opp, "-gpgpu_memlatency_stat", OPT_INT32,
+                         &gpgpu_memlatency_stat,
+                         "track and display latency statistics 0x2 enables MC, "
+                         "0x4 enables queue logs",
+                         "0");
+  option_parser_register(opp, "-gpgpu_frfcfs_dram_sched_queue_size", OPT_INT32,
+                         &gpgpu_frfcfs_dram_sched_queue_size,
+                         "0 = unlimited (default); # entries per chip", "0");
+  option_parser_register(opp, "-gpgpu_dram_return_queue_size", OPT_INT32,
+                         &gpgpu_dram_return_queue_size,
+                         "0 = unlimited (default); # entries per chip", "0");
+  option_parser_register(opp, "-gpgpu_dram_buswidth", OPT_UINT32, &busW,
+                         "default = 4 bytes (8 bytes per cycle at DDR)", "4");
+  option_parser_register(
+      opp, "-gpgpu_dram_burst_length", OPT_UINT32, &BL,
+      "Burst length of each DRAM request (default = 4 data bus cycle)", "4");
+  option_parser_register(opp, "-dram_data_command_freq_ratio", OPT_UINT32,
+                         &data_command_freq_ratio,
+                         "Frequency ratio between DRAM data bus and command "
+                         "bus (default = 2 times, i.e. DDR)",
+                         "2");
+  option_parser_register(
+      opp, "-gpgpu_dram_timing_opt", OPT_CSTR, &gpgpu_dram_timing_opt,
+      "DRAM timing parameters = "
+      "{nbk:tCCD:tRRD:tRCD:tRAS:tRP:tRC:CL:WL:tCDLR:tWR:nbkgrp:tCCDL:tRTPL}",
+      "4:2:8:12:21:13:34:9:4:5:13:1:0:0");
+  option_parser_register(opp, "-rop_latency", OPT_UINT32, &rop_latency,
+                         "ROP queue latency (default 85)", "85");
+  option_parser_register(opp, "-dram_latency", OPT_UINT32, &dram_latency,
+                         "DRAM latency (default 30)", "30");
+  option_parser_register(opp, "-dual_bus_interface", OPT_UINT32,
+                         &dual_bus_interface,
+                         "dual_bus_interface (default = 0) ", "0");
+  option_parser_register(opp, "-dram_bnk_indexing_policy", OPT_UINT32,
+                         &dram_bnk_indexing_policy,
+                         "dram_bnk_indexing_policy (0 = normal indexing, 1 = "
+                         "Xoring with the higher bits) (Default = 0)",
+                         "0");
+  option_parser_register(opp, "-dram_bnkgrp_indexing_policy", OPT_UINT32,
+                         &dram_bnkgrp_indexing_policy,
+                         "dram_bnkgrp_indexing_policy (0 = take higher bits, 1 "
+                         "= take lower bits) (Default = 0)",
+                         "0");
+  option_parser_register(opp, "-Seperate_Write_Queue_Enable", OPT_BOOL,
+                         &seperate_write_queue_enabled,
+                         "Seperate_Write_Queue_Enable", "0");
+  option_parser_register(opp, "-Write_Queue_Size", OPT_CSTR,
+                         &write_queue_size_opt, "Write_Queue_Size", "32:28:16");
+  option_parser_register(
+      opp, "-Elimnate_rw_turnaround", OPT_BOOL, &elimnate_rw_turnaround,
+      "elimnate_rw_turnaround i.e set tWTR and tRTW = 0", "0");
+  option_parser_register(opp, "-icnt_flit_size", OPT_UINT32, &icnt_flit_size,
+                         "icnt_flit_size", "32");
+  m_address_mapping.addrdec_setoption(opp);
 }
 
-void shader_core_config::reg_options(class OptionParser * opp)
-{
-    option_parser_register(opp, "-gpgpu_simd_model", OPT_INT32, &model, 
-                   "1 = post-dominator", "1");
-    option_parser_register(opp, "-gpgpu_shader_core_pipeline", OPT_CSTR, &gpgpu_shader_core_pipeline_opt, 
-                   "shader core pipeline config, i.e., {<nthread>:<warpsize>}",
-                   "1024:32");
-    option_parser_register(opp, "-gpgpu_tex_cache:l1", OPT_CSTR, &m_L1T_config.m_config_string, 
-                   "per-shader L1 texture cache  (READ-ONLY) config "
-                   " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_alloc>,<mshr>:<N>:<merge>,<mq>:<rf>}",
-                   "8:128:5,L:R:m:N,F:128:4,128:2");
-    option_parser_register(opp, "-gpgpu_const_cache:l1", OPT_CSTR, &m_L1C_config.m_config_string, 
-                   "per-shader L1 constant memory cache  (READ-ONLY) config "
-                   " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_alloc>,<mshr>:<N>:<merge>,<mq>} ",
-                   "64:64:2,L:R:f:N,A:2:32,4" );
-    option_parser_register(opp, "-gpgpu_cache:il1", OPT_CSTR, &m_L1I_config.m_config_string, 
-                   "shader L1 instruction cache config "
-                   " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_alloc>,<mshr>:<N>:<merge>,<mq>} ",
-                   "4:256:4,L:R:f:N,A:2:32,4" );
-    option_parser_register(opp, "-gpgpu_cache:dl1", OPT_CSTR, &m_L1D_config.m_config_string,
-                   "per-shader L1 data cache config "
-                   " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_alloc>,<mshr>:<N>:<merge>,<mq> | none}",
-                   "none" );
-    option_parser_register(opp, "-l1_banks", OPT_UINT32, &m_L1D_config.l1_banks,
-                 "The number of L1 cache banks",
-                 "1");
-    option_parser_register(opp, "-l1_latency", OPT_UINT32, &m_L1D_config.l1_latency,
-                 "L1 Hit Latency",
-                 "1");
-    option_parser_register(opp, "-smem_latency", OPT_UINT32, &smem_latency,
-                 "smem Latency",
-                 "3");
-    option_parser_register(opp, "-gpgpu_cache:dl1PrefL1", OPT_CSTR, &m_L1D_config.m_config_stringPrefL1,
-                   "per-shader L1 data cache config "
-                   " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_alloc>,<mshr>:<N>:<merge>,<mq> | none}",
-                   "none" );
-    option_parser_register(opp, "-gpgpu_cache:dl1PrefShared", OPT_CSTR, &m_L1D_config.m_config_stringPrefShared,
-                   "per-shader L1 data cache config "
-                   " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_alloc>,<mshr>:<N>:<merge>,<mq> | none}",
-                   "none" );
-    option_parser_register(opp, "-gmem_skip_L1D", OPT_BOOL, &gmem_skip_L1D, 
-                   "global memory access skip L1D cache (implements -Xptxas -dlcm=cg, default=no skip)",
-                   "0");
+void shader_core_config::reg_options(class OptionParser *opp) {
+  option_parser_register(opp, "-gpgpu_simd_model", OPT_INT32, &model,
+                         "1 = post-dominator", "1");
+  option_parser_register(
+      opp, "-gpgpu_shader_core_pipeline", OPT_CSTR,
+      &gpgpu_shader_core_pipeline_opt,
+      "shader core pipeline config, i.e., {<nthread>:<warpsize>}", "1024:32");
+  option_parser_register(opp, "-gpgpu_tex_cache:l1", OPT_CSTR,
+                         &m_L1T_config.m_config_string,
+                         "per-shader L1 texture cache  (READ-ONLY) config "
+                         " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_"
+                         "alloc>,<mshr>:<N>:<merge>,<mq>:<rf>}",
+                         "8:128:5,L:R:m:N,F:128:4,128:2");
+  option_parser_register(
+      opp, "-gpgpu_const_cache:l1", OPT_CSTR, &m_L1C_config.m_config_string,
+      "per-shader L1 constant memory cache  (READ-ONLY) config "
+      " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_alloc>,<mshr>:<N>:<"
+      "merge>,<mq>} ",
+      "64:64:2,L:R:f:N,A:2:32,4");
+  option_parser_register(opp, "-gpgpu_cache:il1", OPT_CSTR,
+                         &m_L1I_config.m_config_string,
+                         "shader L1 instruction cache config "
+                         " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_"
+                         "alloc>,<mshr>:<N>:<merge>,<mq>} ",
+                         "4:256:4,L:R:f:N,A:2:32,4");
+  option_parser_register(opp, "-gpgpu_cache:dl1", OPT_CSTR,
+                         &m_L1D_config.m_config_string,
+                         "per-shader L1 data cache config "
+                         " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_"
+                         "alloc>,<mshr>:<N>:<merge>,<mq> | none}",
+                         "none");
+  option_parser_register(opp, "-l1_banks", OPT_UINT32, &m_L1D_config.l1_banks,
+                         "The number of L1 cache banks", "1");
+  option_parser_register(opp, "-l1_latency", OPT_UINT32,
+                         &m_L1D_config.l1_latency, "L1 Hit Latency", "1");
+  option_parser_register(opp, "-smem_latency", OPT_UINT32, &smem_latency,
+                         "smem Latency", "3");
+  option_parser_register(opp, "-gpgpu_cache:dl1PrefL1", OPT_CSTR,
+                         &m_L1D_config.m_config_stringPrefL1,
+                         "per-shader L1 data cache config "
+                         " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_"
+                         "alloc>,<mshr>:<N>:<merge>,<mq> | none}",
+                         "none");
+  option_parser_register(opp, "-gpgpu_cache:dl1PrefShared", OPT_CSTR,
+                         &m_L1D_config.m_config_stringPrefShared,
+                         "per-shader L1 data cache config "
+                         " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_"
+                         "alloc>,<mshr>:<N>:<merge>,<mq> | none}",
+                         "none");
+  option_parser_register(opp, "-gmem_skip_L1D", OPT_BOOL, &gmem_skip_L1D,
+                         "global memory access skip L1D cache (implements "
+                         "-Xptxas -dlcm=cg, default=no skip)",
+                         "0");
 
-    option_parser_register(opp, "-gpgpu_perfect_mem", OPT_BOOL, &gpgpu_perfect_mem, 
-                 "enable perfect memory mode (no cache miss)",
-                 "0");
-    option_parser_register(opp, "-n_regfile_gating_group", OPT_UINT32, &n_regfile_gating_group,
-                 "group of lanes that should be read/written together)",
-                 "4");
-    option_parser_register(opp, "-gpgpu_clock_gated_reg_file", OPT_BOOL, &gpgpu_clock_gated_reg_file,
-                 "enable clock gated reg file for power calculations",
-                 "0");
-    option_parser_register(opp, "-gpgpu_clock_gated_lanes", OPT_BOOL, &gpgpu_clock_gated_lanes,
-                 "enable clock gated lanes for power calculations",
-                 "0");
-    option_parser_register(opp, "-gpgpu_shader_registers", OPT_UINT32, &gpgpu_shader_registers, 
-                 "Number of registers per shader core. Limits number of concurrent CTAs. (default 8192)",
-                 "8192");
-    option_parser_register(opp, "-gpgpu_registers_per_block", OPT_UINT32, &gpgpu_registers_per_block,
-                 "Maximum number of registers per CTA. (default 8192)",
-                 "8192");
-    option_parser_register(opp, "-gpgpu_ignore_resources_limitation", OPT_BOOL, &gpgpu_ignore_resources_limitation,
-                 "gpgpu_ignore_resources_limitation (default 0)",
-                 "0");
-    option_parser_register(opp, "-gpgpu_shader_cta", OPT_UINT32, &max_cta_per_core, 
-                 "Maximum number of concurrent CTAs in shader (default 8)",
-                 "8");
-    option_parser_register(opp, "-gpgpu_num_cta_barriers", OPT_UINT32, &max_barriers_per_cta,
-                 "Maximum number of named barriers per CTA (default 16)",
-                 "16");
-    option_parser_register(opp, "-gpgpu_n_clusters", OPT_UINT32, &n_simt_clusters, 
-                 "number of processing clusters",
-                 "10");
-    option_parser_register(opp, "-gpgpu_n_cores_per_cluster", OPT_UINT32, &n_simt_cores_per_cluster, 
-                 "number of simd cores per cluster",
-                 "3");
-    option_parser_register(opp, "-gpgpu_n_cluster_ejection_buffer_size", OPT_UINT32, &n_simt_ejection_buffer_size, 
-                 "number of packets in ejection buffer",
-                 "8");
-    option_parser_register(opp, "-gpgpu_n_ldst_response_buffer_size", OPT_UINT32, &ldst_unit_response_queue_size, 
-                 "number of response packets in ld/st unit ejection buffer",
-                 "2");
-    option_parser_register(opp, "-gpgpu_shmem_per_block", OPT_UINT32, &gpgpu_shmem_per_block,
-                 "Size of shared memory per thread block or CTA (default 48kB)",
-                 "49152");
-    option_parser_register(opp, "-gpgpu_shmem_size", OPT_UINT32, &gpgpu_shmem_size,
-                 "Size of shared memory per shader core (default 16kB)",
-                 "16384");
-    option_parser_register(opp, "-adaptive_cache_config", OPT_BOOL, &adaptive_volta_cache_config,
-                 "adaptive_cache_config",
-                 "0");
-    option_parser_register(opp, "-gpgpu_shmem_sizeDefault", OPT_UINT32, &gpgpu_shmem_sizeDefault,
-                 "Size of shared memory per shader core (default 16kB)",
-                 "16384");
-    option_parser_register(opp, "-gpgpu_shmem_size_PrefL1", OPT_UINT32, &gpgpu_shmem_sizePrefL1,
-                 "Size of shared memory per shader core (default 16kB)",
-                 "16384");
-    option_parser_register(opp, "-gpgpu_shmem_size_PrefShared", OPT_UINT32, &gpgpu_shmem_sizePrefShared,
-                 "Size of shared memory per shader core (default 16kB)",
-                 "16384");
-    option_parser_register(opp, "-gpgpu_shmem_num_banks", OPT_UINT32, &num_shmem_bank, 
-                 "Number of banks in the shared memory in each shader core (default 16)",
-                 "16");
-    option_parser_register(opp, "-gpgpu_shmem_limited_broadcast", OPT_BOOL, &shmem_limited_broadcast, 
-                 "Limit shared memory to do one broadcast per cycle (default on)",
-                 "1");
-    option_parser_register(opp, "-gpgpu_shmem_warp_parts", OPT_INT32, &mem_warp_parts,  
-                 "Number of portions a warp is divided into for shared memory bank conflict check ",
-                 "2");
-    option_parser_register(opp, "-mem_unit_ports", OPT_INT32, &mem_unit_ports,
-                 "The number of memory transactions allowed per core cycle",
-                 "1");
-    option_parser_register(opp, "-gpgpu_shmem_warp_parts", OPT_INT32, &mem_warp_parts,
-				 "Number of portions a warp is divided into for shared memory bank conflict check ",
-				 "2");
-    option_parser_register(opp, "-gpgpu_warpdistro_shader", OPT_INT32, &gpgpu_warpdistro_shader, 
-                "Specify which shader core to collect the warp size distribution from", 
-                "-1");
-    option_parser_register(opp, "-gpgpu_warp_issue_shader", OPT_INT32, &gpgpu_warp_issue_shader, 
-                "Specify which shader core to collect the warp issue distribution from", 
-                "0");
-    option_parser_register(opp, "-gpgpu_local_mem_map", OPT_BOOL, &gpgpu_local_mem_map, 
-                "Mapping from local memory space address to simulated GPU physical address space (default = enabled)", 
-		"1");
-    option_parser_register(opp, "-gpgpu_num_reg_banks", OPT_INT32, &gpgpu_num_reg_banks, 
-                "Number of register banks (default = 8)", 
-                "8");
-    option_parser_register(opp, "-gpgpu_reg_bank_use_warp_id", OPT_BOOL, &gpgpu_reg_bank_use_warp_id,
-             "Use warp ID in mapping registers to banks (default = off)",
-             "0");
-    option_parser_register(opp, "-sub_core_model", OPT_BOOL, &sub_core_model,
-             "Sub Core Volta/Pascal model (default = off)",
-             "0");
-    option_parser_register(opp, "-enable_specialized_operand_collector", OPT_BOOL, &enable_specialized_operand_collector,
-                "enable_specialized_operand_collector",
-                "1");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_units_sp", OPT_INT32, &gpgpu_operand_collector_num_units_sp,
-                "number of collector units (default = 4)",
-                "4");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_units_dp", OPT_INT32, &gpgpu_operand_collector_num_units_dp,
-                   "number of collector units (default = 0)",
-                   "0");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_units_sfu", OPT_INT32, &gpgpu_operand_collector_num_units_sfu,
-                "number of collector units (default = 4)", 
-                "4");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_units_int", OPT_INT32, &gpgpu_operand_collector_num_units_int,
-                "number of collector units (default = 0)",
-                "0");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_units_tensor_core", OPT_INT32, &gpgpu_operand_collector_num_units_tensor_core,
-                "number of collector units (default = 4)", 
-                "4");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_units_mem", OPT_INT32, &gpgpu_operand_collector_num_units_mem,
-                "number of collector units (default = 2)", 
-                "2");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_units_gen", OPT_INT32, &gpgpu_operand_collector_num_units_gen,
-                "number of collector units (default = 0)", 
-                "0");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_sp", OPT_INT32, &gpgpu_operand_collector_num_in_ports_sp,
-                           "number of collector unit in ports (default = 1)", 
-                           "1");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_dp", OPT_INT32, &gpgpu_operand_collector_num_in_ports_dp,
-                           "number of collector unit in ports (default = 0)",
-                           "0");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_sfu", OPT_INT32, &gpgpu_operand_collector_num_in_ports_sfu,
-                           "number of collector unit in ports (default = 1)", 
-                           "1");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_int", OPT_INT32, &gpgpu_operand_collector_num_in_ports_int,
-                           "number of collector unit in ports (default = 0)",
-                           "0");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_tensor_core", OPT_INT32, &gpgpu_operand_collector_num_in_ports_tensor_core,
-                           "number of collector unit in ports (default = 1)", 
-                           "1");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_mem", OPT_INT32, &gpgpu_operand_collector_num_in_ports_mem,
-                           "number of collector unit in ports (default = 1)", 
-                           "1");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_gen", OPT_INT32, &gpgpu_operand_collector_num_in_ports_gen,
-                           "number of collector unit in ports (default = 0)", 
-                           "0");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_sp", OPT_INT32, &gpgpu_operand_collector_num_out_ports_sp,
-                           "number of collector unit in ports (default = 1)", 
-                           "1");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_dp", OPT_INT32, &gpgpu_operand_collector_num_out_ports_dp,
-                           "number of collector unit in ports (default = 0)",
-                           "0");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_sfu", OPT_INT32, &gpgpu_operand_collector_num_out_ports_sfu,
-                           "number of collector unit in ports (default = 1)", 
-                           "1");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_int", OPT_INT32, &gpgpu_operand_collector_num_out_ports_int,
-                           "number of collector unit in ports (default = 0)",
-                           "0");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_tensor_core", OPT_INT32, &gpgpu_operand_collector_num_out_ports_tensor_core,
-                           "number of collector unit in ports (default = 1)", 
-                           "1");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_mem", OPT_INT32, &gpgpu_operand_collector_num_out_ports_mem,
-                           "number of collector unit in ports (default = 1)", 
-                           "1");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_gen", OPT_INT32, &gpgpu_operand_collector_num_out_ports_gen,
-                           "number of collector unit in ports (default = 0)", 
-                           "0");
-    option_parser_register(opp, "-gpgpu_coalesce_arch", OPT_INT32, &gpgpu_coalesce_arch, 
-    		            "Coalescing arch (GT200 = 13, Fermi = 20)",
-                            "13");
-    option_parser_register(opp, "-gpgpu_num_sched_per_core", OPT_INT32, &gpgpu_num_sched_per_core, 
-                            "Number of warp schedulers per core", 
-                            "1");
-    option_parser_register(opp, "-gpgpu_max_insn_issue_per_warp", OPT_INT32, &gpgpu_max_insn_issue_per_warp,
-    		            "Max number of instructions that can be issued per warp in one cycle by scheduler (either 1 or 2)",
-			    "2");
-    option_parser_register(opp, "-gpgpu_dual_issue_diff_exec_units", OPT_BOOL, &gpgpu_dual_issue_diff_exec_units,
-			    "should dual issue use two different execution unit resources (Default = 1)",
-			    "1");
-    option_parser_register(opp, "-gpgpu_simt_core_sim_order", OPT_INT32, &simt_core_sim_order,
-                            "Select the simulation order of cores in a cluster (0=Fix, 1=Round-Robin)",
-                            "1");
-    option_parser_register(opp, "-gpgpu_pipeline_widths", OPT_CSTR, &pipeline_widths_string,
-                            "Pipeline widths "
-                            "ID_OC_SP,ID_OC_DP,ID_OC_INT,ID_OC_SFU,ID_OC_MEM,OC_EX_SP,OC_EX_DP,OC_EX_INT,OC_EX_SFU,OC_EX_MEM,EX_WB,ID_OC_TENSOR_CORE,OC_EX_TENSOR_CORE",
-                            "1,1,1,1,1,1,1,1,1,1,1,1,1" );
-    option_parser_register(opp, "-gpgpu_tensor_core_avail", OPT_INT32, &gpgpu_tensor_core_avail,
-                            "Tensor Core Available (default=0)",
-                            "0");
-    option_parser_register(opp, "-gpgpu_num_sp_units", OPT_INT32, &gpgpu_num_sp_units,
-                            "Number of SP units (default=1)",
-                            "1");
-    option_parser_register(opp, "-gpgpu_num_dp_units", OPT_INT32, &gpgpu_num_dp_units,
-                            "Number of DP units (default=0)",
-                            "0");
-    option_parser_register(opp, "-gpgpu_num_int_units", OPT_INT32, &gpgpu_num_int_units,
-                            "Number of INT units (default=0)",
-                            "0");
-    option_parser_register(opp, "-gpgpu_num_sfu_units", OPT_INT32, &gpgpu_num_sfu_units,
-                            "Number of SF units (default=1)",
-                            "1");
-    option_parser_register(opp, "-gpgpu_num_tensor_core_units", OPT_INT32, &gpgpu_num_tensor_core_units,
-                            "Number of tensor_core units (default=1)",
-                            "1");
-    option_parser_register(opp, "-gpgpu_num_mem_units", OPT_INT32, &gpgpu_num_mem_units,
-                            "Number if ldst units (default=1) WARNING: not hooked up to anything",
-                             "1");
-    option_parser_register(opp, "-gpgpu_scheduler", OPT_CSTR, &gpgpu_scheduler_string,
-                                "Scheduler configuration: < lrr | gto | two_level_active > "
-                                "If two_level_active:<num_active_warps>:<inner_prioritization>:<outer_prioritization>"
-                                "For complete list of prioritization values see shader.h enum scheduler_prioritization_type"
-                                "Default: gto",
-                                 "gto");
+  option_parser_register(opp, "-gpgpu_perfect_mem", OPT_BOOL,
+                         &gpgpu_perfect_mem,
+                         "enable perfect memory mode (no cache miss)", "0");
+  option_parser_register(
+      opp, "-n_regfile_gating_group", OPT_UINT32, &n_regfile_gating_group,
+      "group of lanes that should be read/written together)", "4");
+  option_parser_register(
+      opp, "-gpgpu_clock_gated_reg_file", OPT_BOOL, &gpgpu_clock_gated_reg_file,
+      "enable clock gated reg file for power calculations", "0");
+  option_parser_register(
+      opp, "-gpgpu_clock_gated_lanes", OPT_BOOL, &gpgpu_clock_gated_lanes,
+      "enable clock gated lanes for power calculations", "0");
+  option_parser_register(opp, "-gpgpu_shader_registers", OPT_UINT32,
+                         &gpgpu_shader_registers,
+                         "Number of registers per shader core. Limits number "
+                         "of concurrent CTAs. (default 8192)",
+                         "8192");
+  option_parser_register(
+      opp, "-gpgpu_registers_per_block", OPT_UINT32, &gpgpu_registers_per_block,
+      "Maximum number of registers per CTA. (default 8192)", "8192");
+  option_parser_register(opp, "-gpgpu_ignore_resources_limitation", OPT_BOOL,
+                         &gpgpu_ignore_resources_limitation,
+                         "gpgpu_ignore_resources_limitation (default 0)", "0");
+  option_parser_register(
+      opp, "-gpgpu_shader_cta", OPT_UINT32, &max_cta_per_core,
+      "Maximum number of concurrent CTAs in shader (default 8)", "8");
+  option_parser_register(
+      opp, "-gpgpu_num_cta_barriers", OPT_UINT32, &max_barriers_per_cta,
+      "Maximum number of named barriers per CTA (default 16)", "16");
+  option_parser_register(opp, "-gpgpu_n_clusters", OPT_UINT32, &n_simt_clusters,
+                         "number of processing clusters", "10");
+  option_parser_register(opp, "-gpgpu_n_cores_per_cluster", OPT_UINT32,
+                         &n_simt_cores_per_cluster,
+                         "number of simd cores per cluster", "3");
+  option_parser_register(opp, "-gpgpu_n_cluster_ejection_buffer_size",
+                         OPT_UINT32, &n_simt_ejection_buffer_size,
+                         "number of packets in ejection buffer", "8");
+  option_parser_register(
+      opp, "-gpgpu_n_ldst_response_buffer_size", OPT_UINT32,
+      &ldst_unit_response_queue_size,
+      "number of response packets in ld/st unit ejection buffer", "2");
+  option_parser_register(
+      opp, "-gpgpu_shmem_per_block", OPT_UINT32, &gpgpu_shmem_per_block,
+      "Size of shared memory per thread block or CTA (default 48kB)", "49152");
+  option_parser_register(
+      opp, "-gpgpu_shmem_size", OPT_UINT32, &gpgpu_shmem_size,
+      "Size of shared memory per shader core (default 16kB)", "16384");
+  option_parser_register(opp, "-adaptive_cache_config", OPT_BOOL,
+                         &adaptive_volta_cache_config, "adaptive_cache_config",
+                         "0");
+  option_parser_register(
+      opp, "-gpgpu_shmem_sizeDefault", OPT_UINT32, &gpgpu_shmem_sizeDefault,
+      "Size of shared memory per shader core (default 16kB)", "16384");
+  option_parser_register(
+      opp, "-gpgpu_shmem_size_PrefL1", OPT_UINT32, &gpgpu_shmem_sizePrefL1,
+      "Size of shared memory per shader core (default 16kB)", "16384");
+  option_parser_register(opp, "-gpgpu_shmem_size_PrefShared", OPT_UINT32,
+                         &gpgpu_shmem_sizePrefShared,
+                         "Size of shared memory per shader core (default 16kB)",
+                         "16384");
+  option_parser_register(
+      opp, "-gpgpu_shmem_num_banks", OPT_UINT32, &num_shmem_bank,
+      "Number of banks in the shared memory in each shader core (default 16)",
+      "16");
+  option_parser_register(
+      opp, "-gpgpu_shmem_limited_broadcast", OPT_BOOL, &shmem_limited_broadcast,
+      "Limit shared memory to do one broadcast per cycle (default on)", "1");
+  option_parser_register(opp, "-gpgpu_shmem_warp_parts", OPT_INT32,
+                         &mem_warp_parts,
+                         "Number of portions a warp is divided into for shared "
+                         "memory bank conflict check ",
+                         "2");
+  option_parser_register(
+      opp, "-mem_unit_ports", OPT_INT32, &mem_unit_ports,
+      "The number of memory transactions allowed per core cycle", "1");
+  option_parser_register(opp, "-gpgpu_shmem_warp_parts", OPT_INT32,
+                         &mem_warp_parts,
+                         "Number of portions a warp is divided into for shared "
+                         "memory bank conflict check ",
+                         "2");
+  option_parser_register(
+      opp, "-gpgpu_warpdistro_shader", OPT_INT32, &gpgpu_warpdistro_shader,
+      "Specify which shader core to collect the warp size distribution from",
+      "-1");
+  option_parser_register(
+      opp, "-gpgpu_warp_issue_shader", OPT_INT32, &gpgpu_warp_issue_shader,
+      "Specify which shader core to collect the warp issue distribution from",
+      "0");
+  option_parser_register(opp, "-gpgpu_local_mem_map", OPT_BOOL,
+                         &gpgpu_local_mem_map,
+                         "Mapping from local memory space address to simulated "
+                         "GPU physical address space (default = enabled)",
+                         "1");
+  option_parser_register(opp, "-gpgpu_num_reg_banks", OPT_INT32,
+                         &gpgpu_num_reg_banks,
+                         "Number of register banks (default = 8)", "8");
+  option_parser_register(
+      opp, "-gpgpu_reg_bank_use_warp_id", OPT_BOOL, &gpgpu_reg_bank_use_warp_id,
+      "Use warp ID in mapping registers to banks (default = off)", "0");
+  option_parser_register(opp, "-sub_core_model", OPT_BOOL, &sub_core_model,
+                         "Sub Core Volta/Pascal model (default = off)", "0");
+  option_parser_register(opp, "-enable_specialized_operand_collector", OPT_BOOL,
+                         &enable_specialized_operand_collector,
+                         "enable_specialized_operand_collector", "1");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_units_sp",
+                         OPT_INT32, &gpgpu_operand_collector_num_units_sp,
+                         "number of collector units (default = 4)", "4");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_units_dp",
+                         OPT_INT32, &gpgpu_operand_collector_num_units_dp,
+                         "number of collector units (default = 0)", "0");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_units_sfu",
+                         OPT_INT32, &gpgpu_operand_collector_num_units_sfu,
+                         "number of collector units (default = 4)", "4");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_units_int",
+                         OPT_INT32, &gpgpu_operand_collector_num_units_int,
+                         "number of collector units (default = 0)", "0");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_units_tensor_core",
+                         OPT_INT32,
+                         &gpgpu_operand_collector_num_units_tensor_core,
+                         "number of collector units (default = 4)", "4");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_units_mem",
+                         OPT_INT32, &gpgpu_operand_collector_num_units_mem,
+                         "number of collector units (default = 2)", "2");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_units_gen",
+                         OPT_INT32, &gpgpu_operand_collector_num_units_gen,
+                         "number of collector units (default = 0)", "0");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_sp",
+                         OPT_INT32, &gpgpu_operand_collector_num_in_ports_sp,
+                         "number of collector unit in ports (default = 1)",
+                         "1");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_dp",
+                         OPT_INT32, &gpgpu_operand_collector_num_in_ports_dp,
+                         "number of collector unit in ports (default = 0)",
+                         "0");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_sfu",
+                         OPT_INT32, &gpgpu_operand_collector_num_in_ports_sfu,
+                         "number of collector unit in ports (default = 1)",
+                         "1");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_int",
+                         OPT_INT32, &gpgpu_operand_collector_num_in_ports_int,
+                         "number of collector unit in ports (default = 0)",
+                         "0");
+  option_parser_register(
+      opp, "-gpgpu_operand_collector_num_in_ports_tensor_core", OPT_INT32,
+      &gpgpu_operand_collector_num_in_ports_tensor_core,
+      "number of collector unit in ports (default = 1)", "1");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_mem",
+                         OPT_INT32, &gpgpu_operand_collector_num_in_ports_mem,
+                         "number of collector unit in ports (default = 1)",
+                         "1");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_gen",
+                         OPT_INT32, &gpgpu_operand_collector_num_in_ports_gen,
+                         "number of collector unit in ports (default = 0)",
+                         "0");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_sp",
+                         OPT_INT32, &gpgpu_operand_collector_num_out_ports_sp,
+                         "number of collector unit in ports (default = 1)",
+                         "1");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_dp",
+                         OPT_INT32, &gpgpu_operand_collector_num_out_ports_dp,
+                         "number of collector unit in ports (default = 0)",
+                         "0");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_sfu",
+                         OPT_INT32, &gpgpu_operand_collector_num_out_ports_sfu,
+                         "number of collector unit in ports (default = 1)",
+                         "1");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_int",
+                         OPT_INT32, &gpgpu_operand_collector_num_out_ports_int,
+                         "number of collector unit in ports (default = 0)",
+                         "0");
+  option_parser_register(
+      opp, "-gpgpu_operand_collector_num_out_ports_tensor_core", OPT_INT32,
+      &gpgpu_operand_collector_num_out_ports_tensor_core,
+      "number of collector unit in ports (default = 1)", "1");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_mem",
+                         OPT_INT32, &gpgpu_operand_collector_num_out_ports_mem,
+                         "number of collector unit in ports (default = 1)",
+                         "1");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_gen",
+                         OPT_INT32, &gpgpu_operand_collector_num_out_ports_gen,
+                         "number of collector unit in ports (default = 0)",
+                         "0");
+  option_parser_register(opp, "-gpgpu_coalesce_arch", OPT_INT32,
+                         &gpgpu_coalesce_arch,
+                         "Coalescing arch (GT200 = 13, Fermi = 20)", "13");
+  option_parser_register(opp, "-gpgpu_num_sched_per_core", OPT_INT32,
+                         &gpgpu_num_sched_per_core,
+                         "Number of warp schedulers per core", "1");
+  option_parser_register(opp, "-gpgpu_max_insn_issue_per_warp", OPT_INT32,
+                         &gpgpu_max_insn_issue_per_warp,
+                         "Max number of instructions that can be issued per "
+                         "warp in one cycle by scheduler (either 1 or 2)",
+                         "2");
+  option_parser_register(opp, "-gpgpu_dual_issue_diff_exec_units", OPT_BOOL,
+                         &gpgpu_dual_issue_diff_exec_units,
+                         "should dual issue use two different execution unit "
+                         "resources (Default = 1)",
+                         "1");
+  option_parser_register(opp, "-gpgpu_simt_core_sim_order", OPT_INT32,
+                         &simt_core_sim_order,
+                         "Select the simulation order of cores in a cluster "
+                         "(0=Fix, 1=Round-Robin)",
+                         "1");
+  option_parser_register(
+      opp, "-gpgpu_pipeline_widths", OPT_CSTR, &pipeline_widths_string,
+      "Pipeline widths "
+      "ID_OC_SP,ID_OC_DP,ID_OC_INT,ID_OC_SFU,ID_OC_MEM,OC_EX_SP,OC_EX_DP,OC_EX_"
+      "INT,OC_EX_SFU,OC_EX_MEM,EX_WB,ID_OC_TENSOR_CORE,OC_EX_TENSOR_CORE",
+      "1,1,1,1,1,1,1,1,1,1,1,1,1");
+  option_parser_register(opp, "-gpgpu_tensor_core_avail", OPT_INT32,
+                         &gpgpu_tensor_core_avail,
+                         "Tensor Core Available (default=0)", "0");
+  option_parser_register(opp, "-gpgpu_num_sp_units", OPT_INT32,
+                         &gpgpu_num_sp_units, "Number of SP units (default=1)",
+                         "1");
+  option_parser_register(opp, "-gpgpu_num_dp_units", OPT_INT32,
+                         &gpgpu_num_dp_units, "Number of DP units (default=0)",
+                         "0");
+  option_parser_register(opp, "-gpgpu_num_int_units", OPT_INT32,
+                         &gpgpu_num_int_units,
+                         "Number of INT units (default=0)", "0");
+  option_parser_register(opp, "-gpgpu_num_sfu_units", OPT_INT32,
+                         &gpgpu_num_sfu_units, "Number of SF units (default=1)",
+                         "1");
+  option_parser_register(opp, "-gpgpu_num_tensor_core_units", OPT_INT32,
+                         &gpgpu_num_tensor_core_units,
+                         "Number of tensor_core units (default=1)", "1");
+  option_parser_register(
+      opp, "-gpgpu_num_mem_units", OPT_INT32, &gpgpu_num_mem_units,
+      "Number if ldst units (default=1) WARNING: not hooked up to anything",
+      "1");
+  option_parser_register(
+      opp, "-gpgpu_scheduler", OPT_CSTR, &gpgpu_scheduler_string,
+      "Scheduler configuration: < lrr | gto | two_level_active > "
+      "If "
+      "two_level_active:<num_active_warps>:<inner_prioritization>:<outer_"
+      "prioritization>"
+      "For complete list of prioritization values see shader.h enum "
+      "scheduler_prioritization_type"
+      "Default: gto",
+      "gto");
 
-    option_parser_register(opp, "-gpgpu_concurrent_kernel_sm", OPT_BOOL, &gpgpu_concurrent_kernel_sm, 
-                "Support concurrent kernels on a SM (default = disabled)", 
-                "0");
-
+  option_parser_register(
+      opp, "-gpgpu_concurrent_kernel_sm", OPT_BOOL, &gpgpu_concurrent_kernel_sm,
+      "Support concurrent kernels on a SM (default = disabled)", "0");
 }
 
-void gpgpu_sim_config::reg_options(option_parser_t opp)
-{
-    gpgpu_functional_sim_config::reg_options(opp);
-    m_shader_config.reg_options(opp);
-    m_memory_config.reg_options(opp);
-    power_config::reg_options(opp);
-   option_parser_register(opp, "-gpgpu_max_cycle", OPT_INT64, &gpu_max_cycle_opt, 
-               "terminates gpu simulation early (0 = no limit)",
-               "0");
-   option_parser_register(opp, "-gpgpu_max_insn", OPT_INT64, &gpu_max_insn_opt, 
-               "terminates gpu simulation early (0 = no limit)",
-               "0");
-   option_parser_register(opp, "-gpgpu_max_cta", OPT_INT32, &gpu_max_cta_opt, 
-               "terminates gpu simulation early (0 = no limit)",
-               "0");
-   option_parser_register(opp, "-gpgpu_runtime_stat", OPT_CSTR, &gpgpu_runtime_stat, 
-                  "display runtime statistics such as dram utilization {<freq>:<flag>}",
-                  "10000:0");
-   option_parser_register(opp, "-liveness_message_freq", OPT_INT64, &liveness_message_freq, 
-               "Minimum number of seconds between simulation liveness messages (0 = always print)",
-               "1");
-   option_parser_register(opp, "-gpgpu_compute_capability_major", OPT_UINT32, &gpgpu_compute_capability_major,
-                 "Major compute capability version number",
-                 "7");
-   option_parser_register(opp, "-gpgpu_compute_capability_minor", OPT_UINT32, &gpgpu_compute_capability_minor,
-                 "Minor compute capability version number",
-                 "0");
-   option_parser_register(opp, "-gpgpu_flush_l1_cache", OPT_BOOL, &gpgpu_flush_l1_cache,
-                "Flush L1 cache at the end of each kernel call",
-                "0");
-   option_parser_register(opp, "-gpgpu_flush_l2_cache", OPT_BOOL, &gpgpu_flush_l2_cache,
-                   "Flush L2 cache at the end of each kernel call",
-                   "0");
-   option_parser_register(opp, "-gpgpu_deadlock_detect", OPT_BOOL, &gpu_deadlock_detect, 
-                "Stop the simulation at deadlock (1=on (default), 0=off)", 
-                "1");
-   option_parser_register(opp, "-gpgpu_ptx_instruction_classification", OPT_INT32,
-               &(gpgpu_ctx->func_sim->gpgpu_ptx_instruction_classification),
-               "if enabled will classify ptx instruction types per kernel (Max 255 kernels now)", 
-               "0");
-   option_parser_register(opp, "-gpgpu_ptx_sim_mode", OPT_INT32, &(gpgpu_ctx->func_sim->g_ptx_sim_mode),
-               "Select between Performance (default) or Functional simulation (1)", 
-               "0");
-   option_parser_register(opp, "-gpgpu_clock_domains", OPT_CSTR, &gpgpu_clock_domains, 
-                  "Clock Domain Frequencies in MhZ {<Core Clock>:<ICNT Clock>:<L2 Clock>:<DRAM Clock>}",
-                  "500.0:2000.0:2000.0:2000.0");
-   option_parser_register(opp, "-gpgpu_max_concurrent_kernel", OPT_INT32, &max_concurrent_kernel,
-                          "maximum kernels that can run concurrently on GPU", "8" );
-   option_parser_register(opp, "-gpgpu_cflog_interval", OPT_INT32, &gpgpu_cflog_interval, 
-               "Interval between each snapshot in control flow logger", 
-               "0");
-   option_parser_register(opp, "-visualizer_enabled", OPT_BOOL,
-                          &g_visualizer_enabled, "Turn on visualizer output (1=On, 0=Off)",
-                          "1");
-   option_parser_register(opp, "-visualizer_outputfile", OPT_CSTR, 
-                          &g_visualizer_filename, "Specifies the output log file for visualizer",
-                          NULL);
-   option_parser_register(opp, "-visualizer_zlevel", OPT_INT32,
-                          &g_visualizer_zlevel, "Compression level of the visualizer output log (0=no comp, 9=highest)",
-                          "6");
-   option_parser_register(opp, "-gpgpu_stack_size_limit", OPT_INT32, &stack_size_limit,
-                          "GPU thread stack size", "1024" );
-   option_parser_register(opp, "-gpgpu_heap_size_limit", OPT_INT32, &heap_size_limit,
-                          "GPU malloc heap size ", "8388608" );
-   option_parser_register(opp, "-gpgpu_runtime_sync_depth_limit", OPT_INT32, &runtime_sync_depth_limit,
-                          "GPU device runtime synchronize depth", "2" );
-   option_parser_register(opp, "-gpgpu_runtime_pending_launch_count_limit", OPT_INT32, &runtime_pending_launch_count_limit,
-                          "GPU device runtime pending launch count", "2048" );
-    option_parser_register(opp, "-trace_enabled", OPT_BOOL, 
-                          &Trace::enabled, "Turn on traces",
-                          "0");
-    option_parser_register(opp, "-trace_components", OPT_CSTR, 
-                          &Trace::config_str, "comma seperated list of traces to enable. "
-                          "Complete list found in trace_streams.tup. "
-                          "Default none",
-                          "none");
-    option_parser_register(opp, "-trace_sampling_core", OPT_INT32, 
-                          &Trace::sampling_core, "The core which is printed using CORE_DPRINTF. Default 0",
-                          "0");
-    option_parser_register(opp, "-trace_sampling_memory_partition", OPT_INT32, 
-                          &Trace::sampling_memory_partition, "The memory partition which is printed using MEMPART_DPRINTF. Default -1 (i.e. all)",
-                          "-1");
-    gpgpu_ctx->stats->ptx_file_line_stats_options(opp);
+void gpgpu_sim_config::reg_options(option_parser_t opp) {
+  gpgpu_functional_sim_config::reg_options(opp);
+  m_shader_config.reg_options(opp);
+  m_memory_config.reg_options(opp);
+  power_config::reg_options(opp);
+  option_parser_register(opp, "-gpgpu_max_cycle", OPT_INT64, &gpu_max_cycle_opt,
+                         "terminates gpu simulation early (0 = no limit)", "0");
+  option_parser_register(opp, "-gpgpu_max_insn", OPT_INT64, &gpu_max_insn_opt,
+                         "terminates gpu simulation early (0 = no limit)", "0");
+  option_parser_register(opp, "-gpgpu_max_cta", OPT_INT32, &gpu_max_cta_opt,
+                         "terminates gpu simulation early (0 = no limit)", "0");
+  option_parser_register(
+      opp, "-gpgpu_runtime_stat", OPT_CSTR, &gpgpu_runtime_stat,
+      "display runtime statistics such as dram utilization {<freq>:<flag>}",
+      "10000:0");
+  option_parser_register(opp, "-liveness_message_freq", OPT_INT64,
+                         &liveness_message_freq,
+                         "Minimum number of seconds between simulation "
+                         "liveness messages (0 = always print)",
+                         "1");
+  option_parser_register(opp, "-gpgpu_compute_capability_major", OPT_UINT32,
+                         &gpgpu_compute_capability_major,
+                         "Major compute capability version number", "7");
+  option_parser_register(opp, "-gpgpu_compute_capability_minor", OPT_UINT32,
+                         &gpgpu_compute_capability_minor,
+                         "Minor compute capability version number", "0");
+  option_parser_register(opp, "-gpgpu_flush_l1_cache", OPT_BOOL,
+                         &gpgpu_flush_l1_cache,
+                         "Flush L1 cache at the end of each kernel call", "0");
+  option_parser_register(opp, "-gpgpu_flush_l2_cache", OPT_BOOL,
+                         &gpgpu_flush_l2_cache,
+                         "Flush L2 cache at the end of each kernel call", "0");
+  option_parser_register(
+      opp, "-gpgpu_deadlock_detect", OPT_BOOL, &gpu_deadlock_detect,
+      "Stop the simulation at deadlock (1=on (default), 0=off)", "1");
+  option_parser_register(
+      opp, "-gpgpu_ptx_instruction_classification", OPT_INT32,
+      &(gpgpu_ctx->func_sim->gpgpu_ptx_instruction_classification),
+      "if enabled will classify ptx instruction types per kernel (Max 255 "
+      "kernels now)",
+      "0");
+  option_parser_register(
+      opp, "-gpgpu_ptx_sim_mode", OPT_INT32,
+      &(gpgpu_ctx->func_sim->g_ptx_sim_mode),
+      "Select between Performance (default) or Functional simulation (1)", "0");
+  option_parser_register(opp, "-gpgpu_clock_domains", OPT_CSTR,
+                         &gpgpu_clock_domains,
+                         "Clock Domain Frequencies in MhZ {<Core Clock>:<ICNT "
+                         "Clock>:<L2 Clock>:<DRAM Clock>}",
+                         "500.0:2000.0:2000.0:2000.0");
+  option_parser_register(
+      opp, "-gpgpu_max_concurrent_kernel", OPT_INT32, &max_concurrent_kernel,
+      "maximum kernels that can run concurrently on GPU", "8");
+  option_parser_register(
+      opp, "-gpgpu_cflog_interval", OPT_INT32, &gpgpu_cflog_interval,
+      "Interval between each snapshot in control flow logger", "0");
+  option_parser_register(opp, "-visualizer_enabled", OPT_BOOL,
+                         &g_visualizer_enabled,
+                         "Turn on visualizer output (1=On, 0=Off)", "1");
+  option_parser_register(opp, "-visualizer_outputfile", OPT_CSTR,
+                         &g_visualizer_filename,
+                         "Specifies the output log file for visualizer", NULL);
+  option_parser_register(
+      opp, "-visualizer_zlevel", OPT_INT32, &g_visualizer_zlevel,
+      "Compression level of the visualizer output log (0=no comp, 9=highest)",
+      "6");
+  option_parser_register(opp, "-gpgpu_stack_size_limit", OPT_INT32,
+                         &stack_size_limit, "GPU thread stack size", "1024");
+  option_parser_register(opp, "-gpgpu_heap_size_limit", OPT_INT32,
+                         &heap_size_limit, "GPU malloc heap size ", "8388608");
+  option_parser_register(opp, "-gpgpu_runtime_sync_depth_limit", OPT_INT32,
+                         &runtime_sync_depth_limit,
+                         "GPU device runtime synchronize depth", "2");
+  option_parser_register(opp, "-gpgpu_runtime_pending_launch_count_limit",
+                         OPT_INT32, &runtime_pending_launch_count_limit,
+                         "GPU device runtime pending launch count", "2048");
+  option_parser_register(opp, "-trace_enabled", OPT_BOOL, &Trace::enabled,
+                         "Turn on traces", "0");
+  option_parser_register(opp, "-trace_components", OPT_CSTR, &Trace::config_str,
+                         "comma seperated list of traces to enable. "
+                         "Complete list found in trace_streams.tup. "
+                         "Default none",
+                         "none");
+  option_parser_register(
+      opp, "-trace_sampling_core", OPT_INT32, &Trace::sampling_core,
+      "The core which is printed using CORE_DPRINTF. Default 0", "0");
+  option_parser_register(opp, "-trace_sampling_memory_partition", OPT_INT32,
+                         &Trace::sampling_memory_partition,
+                         "The memory partition which is printed using "
+                         "MEMPART_DPRINTF. Default -1 (i.e. all)",
+                         "-1");
+  gpgpu_ctx->stats->ptx_file_line_stats_options(opp);
 
-    //Jin: kernel launch latency
-    option_parser_register(opp, "-gpgpu_kernel_launch_latency", OPT_INT32, 
-                          &(gpgpu_ctx->device_runtime->g_kernel_launch_latency), "Kernel launch latency in cycles. Default: 0",
-                          "0");
-    option_parser_register(opp, "-gpgpu_cdp_enabled", OPT_BOOL, 
-                          &(gpgpu_ctx->device_runtime->g_cdp_enabled), "Turn on CDP",
-                          "0");
+  // Jin: kernel launch latency
+  option_parser_register(opp, "-gpgpu_kernel_launch_latency", OPT_INT32,
+                         &(gpgpu_ctx->device_runtime->g_kernel_launch_latency),
+                         "Kernel launch latency in cycles. Default: 0", "0");
+  option_parser_register(opp, "-gpgpu_cdp_enabled", OPT_BOOL,
+                         &(gpgpu_ctx->device_runtime->g_cdp_enabled),
+                         "Turn on CDP", "0");
 }
 
 /////////////////////////////////////////////////////////////////////////////
 
-void increment_x_then_y_then_z( dim3 &i, const dim3 &bound)
-{
-   i.x++;
-   if ( i.x >= bound.x ) {
-      i.x = 0;
-      i.y++;
-      if ( i.y >= bound.y ) {
-         i.y = 0;
-         if( i.z < bound.z ) 
-            i.z++;
-      }
-   }
+void increment_x_then_y_then_z(dim3 &i, const dim3 &bound) {
+  i.x++;
+  if (i.x >= bound.x) {
+    i.x = 0;
+    i.y++;
+    if (i.y >= bound.y) {
+      i.y = 0;
+      if (i.z < bound.z) i.z++;
+    }
+  }
 }
 
-void gpgpu_sim::launch( kernel_info_t *kinfo )
-{
-   unsigned cta_size = kinfo->threads_per_cta();
-   if ( cta_size > m_shader_config->n_thread_per_shader ) {
-      printf("Execution error: Shader kernel CTA (block) size is too large for microarch config.\n");
-      printf("                 CTA size (x*y*z) = %u, max supported = %u\n", cta_size, 
-             m_shader_config->n_thread_per_shader );
-      printf("                 => either change -gpgpu_shader argument in gpgpusim.config file or\n");
-      printf("                 modify the CUDA source to decrease the kernel block size.\n");
-      abort();
-   }
-   unsigned n=0;
-   for(n=0; n < m_running_kernels.size(); n++ ) {
-       if( (NULL==m_running_kernels[n]) || m_running_kernels[n]->done() ) {
-           m_running_kernels[n] = kinfo;
-           break;
-       }
-   }
-   assert(n < m_running_kernels.size());
+void gpgpu_sim::launch(kernel_info_t *kinfo) {
+  unsigned cta_size = kinfo->threads_per_cta();
+  if (cta_size > m_shader_config->n_thread_per_shader) {
+    printf(
+        "Execution error: Shader kernel CTA (block) size is too large for "
+        "microarch config.\n");
+    printf("                 CTA size (x*y*z) = %u, max supported = %u\n",
+           cta_size, m_shader_config->n_thread_per_shader);
+    printf(
+        "                 => either change -gpgpu_shader argument in "
+        "gpgpusim.config file or\n");
+    printf(
+        "                 modify the CUDA source to decrease the kernel block "
+        "size.\n");
+    abort();
+  }
+  unsigned n = 0;
+  for (n = 0; n < m_running_kernels.size(); n++) {
+    if ((NULL == m_running_kernels[n]) || m_running_kernels[n]->done()) {
+      m_running_kernels[n] = kinfo;
+      break;
+    }
+  }
+  assert(n < m_running_kernels.size());
 }
 
-bool gpgpu_sim::can_start_kernel()
-{
-   for(unsigned n=0; n < m_running_kernels.size(); n++ ) {
-       if( (NULL==m_running_kernels[n]) || m_running_kernels[n]->done() ) 
-           return true;
-   }
-   return false;
+bool gpgpu_sim::can_start_kernel() {
+  for (unsigned n = 0; n < m_running_kernels.size(); n++) {
+    if ((NULL == m_running_kernels[n]) || m_running_kernels[n]->done())
+      return true;
+  }
+  return false;
 }
 
 bool gpgpu_sim::hit_max_cta_count() const {
-   if (m_config.gpu_max_cta_opt != 0) {
-      if( (gpu_tot_issued_cta + m_total_cta_launched) >= m_config.gpu_max_cta_opt )
-          return true;
-   }
-   return false;
+  if (m_config.gpu_max_cta_opt != 0) {
+    if ((gpu_tot_issued_cta + m_total_cta_launched) >= m_config.gpu_max_cta_opt)
+      return true;
+  }
+  return false;
 }
 
 bool gpgpu_sim::kernel_more_cta_left(kernel_info_t *kernel) const {
-    if(hit_max_cta_count())
-       return false;
+  if (hit_max_cta_count()) return false;
 
-    if(kernel && !kernel->no_more_ctas_to_run())
-        return true;
+  if (kernel && !kernel->no_more_ctas_to_run()) return true;
 
-    return false;
+  return false;
 }
 
-bool gpgpu_sim::get_more_cta_left() const
-{ 
-   if(hit_max_cta_count())
-      return false;
+bool gpgpu_sim::get_more_cta_left() const {
+  if (hit_max_cta_count()) return false;
 
-   for(unsigned n=0; n < m_running_kernels.size(); n++ ) {
-       if( m_running_kernels[n] && !m_running_kernels[n]->no_more_ctas_to_run() ) 
-           return true;
-   }
-   return false;
+  for (unsigned n = 0; n < m_running_kernels.size(); n++) {
+    if (m_running_kernels[n] && !m_running_kernels[n]->no_more_ctas_to_run())
+      return true;
+  }
+  return false;
 }
 
-kernel_info_t *gpgpu_sim::select_kernel()
-{
-    if(m_running_kernels[m_last_issued_kernel] &&
-        !m_running_kernels[m_last_issued_kernel]->no_more_ctas_to_run()) {
-        unsigned launch_uid = m_running_kernels[m_last_issued_kernel]->get_uid(); 
-        if(std::find(m_executed_kernel_uids.begin(), m_executed_kernel_uids.end(), launch_uid) == m_executed_kernel_uids.end()) {
-            m_running_kernels[m_last_issued_kernel]->start_cycle = gpu_sim_cycle + gpu_tot_sim_cycle;
-            m_executed_kernel_uids.push_back(launch_uid); 
-            m_executed_kernel_names.push_back(m_running_kernels[m_last_issued_kernel]->name()); 
-        }
-        return m_running_kernels[m_last_issued_kernel];
+kernel_info_t *gpgpu_sim::select_kernel() {
+  if (m_running_kernels[m_last_issued_kernel] &&
+      !m_running_kernels[m_last_issued_kernel]->no_more_ctas_to_run()) {
+    unsigned launch_uid = m_running_kernels[m_last_issued_kernel]->get_uid();
+    if (std::find(m_executed_kernel_uids.begin(), m_executed_kernel_uids.end(),
+                  launch_uid) == m_executed_kernel_uids.end()) {
+      m_running_kernels[m_last_issued_kernel]->start_cycle =
+          gpu_sim_cycle + gpu_tot_sim_cycle;
+      m_executed_kernel_uids.push_back(launch_uid);
+      m_executed_kernel_names.push_back(
+          m_running_kernels[m_last_issued_kernel]->name());
     }
+    return m_running_kernels[m_last_issued_kernel];
+  }
 
-    for(unsigned n=0; n < m_running_kernels.size(); n++ ) {
-        unsigned idx = (n+m_last_issued_kernel+1)%m_config.max_concurrent_kernel;
-        if( kernel_more_cta_left(m_running_kernels[idx]) ){
-            m_last_issued_kernel=idx;
-            m_running_kernels[idx]->start_cycle = gpu_sim_cycle + gpu_tot_sim_cycle;
-            // record this kernel for stat print if it is the first time this kernel is selected for execution  
-            unsigned launch_uid = m_running_kernels[idx]->get_uid(); 
-            assert(std::find(m_executed_kernel_uids.begin(), m_executed_kernel_uids.end(), launch_uid) == m_executed_kernel_uids.end());
-            m_executed_kernel_uids.push_back(launch_uid); 
-            m_executed_kernel_names.push_back(m_running_kernels[idx]->name()); 
+  for (unsigned n = 0; n < m_running_kernels.size(); n++) {
+    unsigned idx =
+        (n + m_last_issued_kernel + 1) % m_config.max_concurrent_kernel;
+    if (kernel_more_cta_left(m_running_kernels[idx])) {
+      m_last_issued_kernel = idx;
+      m_running_kernels[idx]->start_cycle = gpu_sim_cycle + gpu_tot_sim_cycle;
+      // record this kernel for stat print if it is the first time this kernel
+      // is selected for execution
+      unsigned launch_uid = m_running_kernels[idx]->get_uid();
+      assert(std::find(m_executed_kernel_uids.begin(),
+                       m_executed_kernel_uids.end(),
+                       launch_uid) == m_executed_kernel_uids.end());
+      m_executed_kernel_uids.push_back(launch_uid);
+      m_executed_kernel_names.push_back(m_running_kernels[idx]->name());
 
-            return m_running_kernels[idx];
-        }
+      return m_running_kernels[idx];
     }
-    return NULL;
+  }
+  return NULL;
 }
 
-unsigned gpgpu_sim::finished_kernel()
-{
-    if( m_finished_kernel.empty() ) 
-        return 0;
-    unsigned result = m_finished_kernel.front();
-    m_finished_kernel.pop_front();
-    return result;
+unsigned gpgpu_sim::finished_kernel() {
+  if (m_finished_kernel.empty()) return 0;
+  unsigned result = m_finished_kernel.front();
+  m_finished_kernel.pop_front();
+  return result;
 }
 
-void gpgpu_sim::set_kernel_done( kernel_info_t *kernel ) 
-{ 
-    unsigned uid = kernel->get_uid();
-    m_finished_kernel.push_back(uid);
-    std::vector<kernel_info_t*>::iterator k;
-    for( k=m_running_kernels.begin(); k!=m_running_kernels.end(); k++ ) {
-        if( *k == kernel ) {
-            kernel->end_cycle = gpu_sim_cycle + gpu_tot_sim_cycle;
-            *k = NULL;
-            break;
-        }
+void gpgpu_sim::set_kernel_done(kernel_info_t *kernel) {
+  unsigned uid = kernel->get_uid();
+  m_finished_kernel.push_back(uid);
+  std::vector<kernel_info_t *>::iterator k;
+  for (k = m_running_kernels.begin(); k != m_running_kernels.end(); k++) {
+    if (*k == kernel) {
+      kernel->end_cycle = gpu_sim_cycle + gpu_tot_sim_cycle;
+      *k = NULL;
+      break;
     }
-    assert( k != m_running_kernels.end() ); 
+  }
+  assert(k != m_running_kernels.end());
 }
 
-void gpgpu_sim::stop_all_running_kernels(){
-    std::vector<kernel_info_t *>::iterator k;
-    for(k = m_running_kernels.begin(); k != m_running_kernels.end(); ++k){
-        if(*k != NULL){ // If a kernel is active
-            set_kernel_done(*k); // Stop the kernel
-            assert(*k==NULL);
-        }
+void gpgpu_sim::stop_all_running_kernels() {
+  std::vector<kernel_info_t *>::iterator k;
+  for (k = m_running_kernels.begin(); k != m_running_kernels.end(); ++k) {
+    if (*k != NULL) {       // If a kernel is active
+      set_kernel_done(*k);  // Stop the kernel
+      assert(*k == NULL);
     }
+  }
 }
 
-gpgpu_sim::gpgpu_sim( const gpgpu_sim_config &config, gpgpu_context* ctx )
-    : gpgpu_t(config, ctx), m_config(config)
-{
-    gpgpu_ctx = ctx;
-    m_shader_config = &m_config.m_shader_config;
-    m_memory_config = &m_config.m_memory_config;
-    ctx->ptx_parser->set_ptx_warp_size(m_shader_config);
-    ptx_file_line_stats_create_exposed_latency_tracker(m_config.num_shader());
+gpgpu_sim::gpgpu_sim(const gpgpu_sim_config &config, gpgpu_context *ctx)
+    : gpgpu_t(config, ctx), m_config(config) {
+  gpgpu_ctx = ctx;
+  m_shader_config = &m_config.m_shader_config;
+  m_memory_config = &m_config.m_memory_config;
+  ctx->ptx_parser->set_ptx_warp_size(m_shader_config);
+  ptx_file_line_stats_create_exposed_latency_tracker(m_config.num_shader());
 
 #ifdef GPGPUSIM_POWER_MODEL
-        m_gpgpusim_wrapper = new gpgpu_sim_wrapper(config.g_power_simulation_enabled,config.g_power_config_name);
+  m_gpgpusim_wrapper = new gpgpu_sim_wrapper(config.g_power_simulation_enabled,
+                                             config.g_power_config_name);
 #endif
 
-    m_shader_stats = new shader_core_stats(m_shader_config);
-    m_memory_stats = new memory_stats_t(m_config.num_shader(),m_shader_config,m_memory_config,this);
-    average_pipeline_duty_cycle = (float *)malloc(sizeof(float));
-    active_sms=(float *)malloc(sizeof(float));
-    m_power_stats = new power_stat_t(m_shader_config,average_pipeline_duty_cycle,active_sms,m_shader_stats,m_memory_config,m_memory_stats);
+  m_shader_stats = new shader_core_stats(m_shader_config);
+  m_memory_stats = new memory_stats_t(m_config.num_shader(), m_shader_config,
+                                      m_memory_config, this);
+  average_pipeline_duty_cycle = (float *)malloc(sizeof(float));
+  active_sms = (float *)malloc(sizeof(float));
+  m_power_stats =
+      new power_stat_t(m_shader_config, average_pipeline_duty_cycle, active_sms,
+                       m_shader_stats, m_memory_config, m_memory_stats);
 
-    gpu_sim_insn = 0;
-    gpu_tot_sim_insn = 0;
-    gpu_tot_issued_cta = 0;
-    m_total_cta_launched = 0;
-    gpu_deadlock = false;
+  gpu_sim_insn = 0;
+  gpu_tot_sim_insn = 0;
+  gpu_tot_issued_cta = 0;
+  m_total_cta_launched = 0;
+  gpu_deadlock = false;
 
-    gpu_stall_dramfull = 0;
-    gpu_stall_icnt2sh = 0;
-    partiton_reqs_in_parallel = 0;
-    partiton_reqs_in_parallel_total = 0;
-    partiton_reqs_in_parallel_util = 0;
-    partiton_reqs_in_parallel_util_total = 0;
-    gpu_sim_cycle_parition_util = 0;
-    gpu_tot_sim_cycle_parition_util = 0;
-    partiton_replys_in_parallel = 0;
-    partiton_replys_in_parallel_total = 0;
+  gpu_stall_dramfull = 0;
+  gpu_stall_icnt2sh = 0;
+  partiton_reqs_in_parallel = 0;
+  partiton_reqs_in_parallel_total = 0;
+  partiton_reqs_in_parallel_util = 0;
+  partiton_reqs_in_parallel_util_total = 0;
+  gpu_sim_cycle_parition_util = 0;
+  gpu_tot_sim_cycle_parition_util = 0;
+  partiton_replys_in_parallel = 0;
+  partiton_replys_in_parallel_total = 0;
 
-    m_cluster = new simt_core_cluster*[m_shader_config->n_simt_clusters];
-    for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) 
-        m_cluster[i] = new simt_core_cluster(this,i,m_shader_config,m_memory_config,m_shader_stats,m_memory_stats);
+  m_cluster = new simt_core_cluster *[m_shader_config->n_simt_clusters];
+  for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++)
+    m_cluster[i] =
+        new simt_core_cluster(this, i, m_shader_config, m_memory_config,
+                              m_shader_stats, m_memory_stats);
 
-    m_memory_partition_unit = new memory_partition_unit*[m_memory_config->m_n_mem];
-    m_memory_sub_partition = new memory_sub_partition*[m_memory_config->m_n_mem_sub_partition];
-    for (unsigned i=0;i<m_memory_config->m_n_mem;i++) {
-        m_memory_partition_unit[i] = new memory_partition_unit(i, m_memory_config, m_memory_stats, this);
-        for (unsigned p = 0; p < m_memory_config->m_n_sub_partition_per_memory_channel; p++) {
-            unsigned submpid = i * m_memory_config->m_n_sub_partition_per_memory_channel + p; 
-            m_memory_sub_partition[submpid] = m_memory_partition_unit[i]->get_sub_partition(p); 
-        }
+  m_memory_partition_unit =
+      new memory_partition_unit *[m_memory_config->m_n_mem];
+  m_memory_sub_partition =
+      new memory_sub_partition *[m_memory_config->m_n_mem_sub_partition];
+  for (unsigned i = 0; i < m_memory_config->m_n_mem; i++) {
+    m_memory_partition_unit[i] =
+        new memory_partition_unit(i, m_memory_config, m_memory_stats, this);
+    for (unsigned p = 0;
+         p < m_memory_config->m_n_sub_partition_per_memory_channel; p++) {
+      unsigned submpid =
+          i * m_memory_config->m_n_sub_partition_per_memory_channel + p;
+      m_memory_sub_partition[submpid] =
+          m_memory_partition_unit[i]->get_sub_partition(p);
     }
+  }
 
-    icnt_wrapper_init();
-    icnt_create(m_shader_config->n_simt_clusters,m_memory_config->m_n_mem_sub_partition);
+  icnt_wrapper_init();
+  icnt_create(m_shader_config->n_simt_clusters,
+              m_memory_config->m_n_mem_sub_partition);
 
-    time_vector_create(NUM_MEM_REQ_STAT);
-    fprintf(stdout, "GPGPU-Sim uArch: performance model initialization complete.\n");
+  time_vector_create(NUM_MEM_REQ_STAT);
+  fprintf(stdout,
+          "GPGPU-Sim uArch: performance model initialization complete.\n");
 
-    m_running_kernels.resize( config.max_concurrent_kernel, NULL );
-    m_last_issued_kernel = 0;
-    m_last_cluster_issue = m_shader_config->n_simt_clusters-1; // this causes first launch to use simt cluster 0
-    *average_pipeline_duty_cycle=0;
-    *active_sms=0;
+  m_running_kernels.resize(config.max_concurrent_kernel, NULL);
+  m_last_issued_kernel = 0;
+  m_last_cluster_issue = m_shader_config->n_simt_clusters -
+                         1;  // this causes first launch to use simt cluster 0
+  *average_pipeline_duty_cycle = 0;
+  *active_sms = 0;
 
-    last_liveness_message_time = 0;
-   
-   //Jin: functional simulation for CDP
-   m_functional_sim = false;
-   m_functional_sim_kernel = NULL;
+  last_liveness_message_time = 0;
+
+  // Jin: functional simulation for CDP
+  m_functional_sim = false;
+  m_functional_sim_kernel = NULL;
 }
 
-int gpgpu_sim::shared_mem_size() const
-{
-   return m_shader_config->gpgpu_shmem_size;
+int gpgpu_sim::shared_mem_size() const {
+  return m_shader_config->gpgpu_shmem_size;
 }
 
-int gpgpu_sim::shared_mem_per_block() const
-{
-   return m_shader_config->gpgpu_shmem_per_block;
+int gpgpu_sim::shared_mem_per_block() const {
+  return m_shader_config->gpgpu_shmem_per_block;
 }
 
-int gpgpu_sim::num_registers_per_core() const
-{
-   return m_shader_config->gpgpu_shader_registers;
+int gpgpu_sim::num_registers_per_core() const {
+  return m_shader_config->gpgpu_shader_registers;
 }
 
-int gpgpu_sim::num_registers_per_block() const
-{
-   return m_shader_config->gpgpu_registers_per_block;
+int gpgpu_sim::num_registers_per_block() const {
+  return m_shader_config->gpgpu_registers_per_block;
 }
 
-int gpgpu_sim::wrp_size() const
-{
-   return m_shader_config->warp_size;
+int gpgpu_sim::wrp_size() const { return m_shader_config->warp_size; }
+
+int gpgpu_sim::shader_clock() const { return m_config.core_freq / 1000; }
+
+int gpgpu_sim::max_cta_per_core() const {
+  return m_shader_config->max_cta_per_core;
 }
 
-int gpgpu_sim::shader_clock() const
-{
-   return m_config.core_freq/1000;
+int gpgpu_sim::get_max_cta(const kernel_info_t &k) const {
+  return m_shader_config->max_cta(k);
 }
 
-int gpgpu_sim::max_cta_per_core() const
-{
-   return m_shader_config->max_cta_per_core;
+void gpgpu_sim::set_prop(cudaDeviceProp *prop) { m_cuda_properties = prop; }
+
+int gpgpu_sim::compute_capability_major() const {
+  return m_config.gpgpu_compute_capability_major;
 }
 
-int gpgpu_sim::get_max_cta( const kernel_info_t &k ) const
-{
-   return m_shader_config->max_cta(k);
+int gpgpu_sim::compute_capability_minor() const {
+  return m_config.gpgpu_compute_capability_minor;
 }
 
-void gpgpu_sim::set_prop( cudaDeviceProp *prop )
-{
-   m_cuda_properties = prop;
+const struct cudaDeviceProp *gpgpu_sim::get_prop() const {
+  return m_cuda_properties;
 }
 
-int gpgpu_sim::compute_capability_major() const
-{
-   return m_config.gpgpu_compute_capability_major;
+enum divergence_support_t gpgpu_sim::simd_model() const {
+  return m_shader_config->model;
 }
 
-int gpgpu_sim::compute_capability_minor() const
-{
-   return m_config.gpgpu_compute_capability_minor;
+void gpgpu_sim_config::init_clock_domains(void) {
+  sscanf(gpgpu_clock_domains, "%lf:%lf:%lf:%lf", &core_freq, &icnt_freq,
+         &l2_freq, &dram_freq);
+  core_freq = core_freq MhZ;
+  icnt_freq = icnt_freq MhZ;
+  l2_freq = l2_freq MhZ;
+  dram_freq = dram_freq MhZ;
+  core_period = 1 / core_freq;
+  icnt_period = 1 / icnt_freq;
+  dram_period = 1 / dram_freq;
+  l2_period = 1 / l2_freq;
+  printf("GPGPU-Sim uArch: clock freqs: %lf:%lf:%lf:%lf\n", core_freq,
+         icnt_freq, l2_freq, dram_freq);
+  printf("GPGPU-Sim uArch: clock periods: %.20lf:%.20lf:%.20lf:%.20lf\n",
+         core_period, icnt_period, l2_period, dram_period);
 }
 
-const struct cudaDeviceProp *gpgpu_sim::get_prop() const
-{
-   return m_cuda_properties;
+void gpgpu_sim::reinit_clock_domains(void) {
+  core_time = 0;
+  dram_time = 0;
+  icnt_time = 0;
+  l2_time = 0;
 }
 
-enum divergence_support_t gpgpu_sim::simd_model() const
-{
-   return m_shader_config->model;
-}
-
-void gpgpu_sim_config::init_clock_domains(void ) 
-{
-   sscanf(gpgpu_clock_domains,"%lf:%lf:%lf:%lf", 
-          &core_freq, &icnt_freq, &l2_freq, &dram_freq);
-   core_freq = core_freq MhZ;
-   icnt_freq = icnt_freq MhZ;
-   l2_freq = l2_freq MhZ;
-   dram_freq = dram_freq MhZ;        
-   core_period = 1/core_freq;
-   icnt_period = 1/icnt_freq;
-   dram_period = 1/dram_freq;
-   l2_period = 1/l2_freq;
-   printf("GPGPU-Sim uArch: clock freqs: %lf:%lf:%lf:%lf\n",core_freq,icnt_freq,l2_freq,dram_freq);
-   printf("GPGPU-Sim uArch: clock periods: %.20lf:%.20lf:%.20lf:%.20lf\n",core_period,icnt_period,l2_period,dram_period);
-}
-
-void gpgpu_sim::reinit_clock_domains(void)
-{
-   core_time = 0;
-   dram_time = 0;
-   icnt_time = 0;
-   l2_time = 0;
-}
-
-bool gpgpu_sim::active()
-{
-    if (m_config.gpu_max_cycle_opt && (gpu_tot_sim_cycle + gpu_sim_cycle) >= m_config.gpu_max_cycle_opt) 
-       return false;
-    if (m_config.gpu_max_insn_opt && (gpu_tot_sim_insn + gpu_sim_insn) >= m_config.gpu_max_insn_opt) 
-       return false;
-    if (m_config.gpu_max_cta_opt && (gpu_tot_issued_cta >= m_config.gpu_max_cta_opt) )
-       return false;
-    if (m_config.gpu_deadlock_detect && gpu_deadlock) 
-       return false;
-    for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) 
-       if( m_cluster[i]->get_not_completed()>0 ) 
-           return true;;
-    for (unsigned i=0;i<m_memory_config->m_n_mem;i++) 
-       if( m_memory_partition_unit[i]->busy()>0 )
-           return true;;
-    if( icnt_busy() )
-        return true;
-    if( get_more_cta_left() )
-        return true;
+bool gpgpu_sim::active() {
+  if (m_config.gpu_max_cycle_opt &&
+      (gpu_tot_sim_cycle + gpu_sim_cycle) >= m_config.gpu_max_cycle_opt)
     return false;
+  if (m_config.gpu_max_insn_opt &&
+      (gpu_tot_sim_insn + gpu_sim_insn) >= m_config.gpu_max_insn_opt)
+    return false;
+  if (m_config.gpu_max_cta_opt &&
+      (gpu_tot_issued_cta >= m_config.gpu_max_cta_opt))
+    return false;
+  if (m_config.gpu_deadlock_detect && gpu_deadlock) return false;
+  for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++)
+    if (m_cluster[i]->get_not_completed() > 0) return true;
+  ;
+  for (unsigned i = 0; i < m_memory_config->m_n_mem; i++)
+    if (m_memory_partition_unit[i]->busy() > 0) return true;
+  ;
+  if (icnt_busy()) return true;
+  if (get_more_cta_left()) return true;
+  return false;
 }
 
-void gpgpu_sim::init()
-{
-    // run a CUDA grid on the GPU microarchitecture simulator
-    gpu_sim_cycle = 0;
-    gpu_sim_insn = 0;
-    last_gpu_sim_insn = 0;
-    m_total_cta_launched=0;
-    partiton_reqs_in_parallel = 0;
-    partiton_replys_in_parallel = 0;
-    partiton_reqs_in_parallel_util = 0;
-    gpu_sim_cycle_parition_util = 0;
+void gpgpu_sim::init() {
+  // run a CUDA grid on the GPU microarchitecture simulator
+  gpu_sim_cycle = 0;
+  gpu_sim_insn = 0;
+  last_gpu_sim_insn = 0;
+  m_total_cta_launched = 0;
+  partiton_reqs_in_parallel = 0;
+  partiton_replys_in_parallel = 0;
+  partiton_reqs_in_parallel_util = 0;
+  gpu_sim_cycle_parition_util = 0;
 
-    reinit_clock_domains();
-    gpgpu_ctx->func_sim->set_param_gpgpu_num_shaders(m_config.num_shader());
-    for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) 
-       m_cluster[i]->reinit();
-    m_shader_stats->new_grid();
-    // initialize the control-flow, memory access, memory latency logger
-    if (m_config.g_visualizer_enabled) {
-        create_thread_CFlogger( gpgpu_ctx, m_config.num_shader(), m_shader_config->n_thread_per_shader, 0, m_config.gpgpu_cflog_interval );
-    }
-    shader_CTA_count_create( m_config.num_shader(), m_config.gpgpu_cflog_interval);
-    if (m_config.gpgpu_cflog_interval != 0) {
-       insn_warp_occ_create( m_config.num_shader(), m_shader_config->warp_size );
-       shader_warp_occ_create( m_config.num_shader(), m_shader_config->warp_size, m_config.gpgpu_cflog_interval);
-       shader_mem_acc_create( m_config.num_shader(), m_memory_config->m_n_mem, 4, m_config.gpgpu_cflog_interval);
-       shader_mem_lat_create( m_config.num_shader(), m_config.gpgpu_cflog_interval);
-       shader_cache_access_create( m_config.num_shader(), 3, m_config.gpgpu_cflog_interval);
-       set_spill_interval (m_config.gpgpu_cflog_interval * 40);
-    }
+  reinit_clock_domains();
+  gpgpu_ctx->func_sim->set_param_gpgpu_num_shaders(m_config.num_shader());
+  for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++)
+    m_cluster[i]->reinit();
+  m_shader_stats->new_grid();
+  // initialize the control-flow, memory access, memory latency logger
+  if (m_config.g_visualizer_enabled) {
+    create_thread_CFlogger(gpgpu_ctx, m_config.num_shader(),
+                           m_shader_config->n_thread_per_shader, 0,
+                           m_config.gpgpu_cflog_interval);
+  }
+  shader_CTA_count_create(m_config.num_shader(), m_config.gpgpu_cflog_interval);
+  if (m_config.gpgpu_cflog_interval != 0) {
+    insn_warp_occ_create(m_config.num_shader(), m_shader_config->warp_size);
+    shader_warp_occ_create(m_config.num_shader(), m_shader_config->warp_size,
+                           m_config.gpgpu_cflog_interval);
+    shader_mem_acc_create(m_config.num_shader(), m_memory_config->m_n_mem, 4,
+                          m_config.gpgpu_cflog_interval);
+    shader_mem_lat_create(m_config.num_shader(), m_config.gpgpu_cflog_interval);
+    shader_cache_access_create(m_config.num_shader(), 3,
+                               m_config.gpgpu_cflog_interval);
+    set_spill_interval(m_config.gpgpu_cflog_interval * 40);
+  }
 
-    if (g_network_mode)
-       icnt_init();
+  if (g_network_mode) icnt_init();
 
     // McPAT initialization function. Called on first launch of GPU
 #ifdef GPGPUSIM_POWER_MODEL
-    if(m_config.g_power_simulation_enabled){
-        init_mcpat(m_config, m_gpgpusim_wrapper, m_config.gpu_stat_sample_freq,  gpu_tot_sim_insn, gpu_sim_insn);
-    }
+  if (m_config.g_power_simulation_enabled) {
+    init_mcpat(m_config, m_gpgpusim_wrapper, m_config.gpu_stat_sample_freq,
+               gpu_tot_sim_insn, gpu_sim_insn);
+  }
 #endif
 }
 
 void gpgpu_sim::update_stats() {
-    m_memory_stats->memlatstat_lat_pw();
-    gpu_tot_sim_cycle += gpu_sim_cycle;
-    gpu_tot_sim_insn += gpu_sim_insn;
-    gpu_tot_issued_cta += m_total_cta_launched;
-    partiton_reqs_in_parallel_total += partiton_reqs_in_parallel;
-    partiton_replys_in_parallel_total += partiton_replys_in_parallel;
-    partiton_reqs_in_parallel_util_total += partiton_reqs_in_parallel_util;
-    gpu_tot_sim_cycle_parition_util += gpu_sim_cycle_parition_util ;
-    gpu_tot_occupancy += gpu_occupancy;
+  m_memory_stats->memlatstat_lat_pw();
+  gpu_tot_sim_cycle += gpu_sim_cycle;
+  gpu_tot_sim_insn += gpu_sim_insn;
+  gpu_tot_issued_cta += m_total_cta_launched;
+  partiton_reqs_in_parallel_total += partiton_reqs_in_parallel;
+  partiton_replys_in_parallel_total += partiton_replys_in_parallel;
+  partiton_reqs_in_parallel_util_total += partiton_reqs_in_parallel_util;
+  gpu_tot_sim_cycle_parition_util += gpu_sim_cycle_parition_util;
+  gpu_tot_occupancy += gpu_occupancy;
 
-    gpu_sim_cycle = 0;
-    partiton_reqs_in_parallel = 0;
-    partiton_replys_in_parallel = 0;
-    partiton_reqs_in_parallel_util = 0;
-    gpu_sim_cycle_parition_util = 0;
-    gpu_sim_insn = 0;
-    m_total_cta_launched = 0;
-    gpu_occupancy = occupancy_stats();
+  gpu_sim_cycle = 0;
+  partiton_reqs_in_parallel = 0;
+  partiton_replys_in_parallel = 0;
+  partiton_reqs_in_parallel_util = 0;
+  gpu_sim_cycle_parition_util = 0;
+  gpu_sim_insn = 0;
+  m_total_cta_launched = 0;
+  gpu_occupancy = occupancy_stats();
 }
 
-void gpgpu_sim::print_stats()
-{
-    gpgpu_ctx->stats->ptx_file_line_stats_write_file();
-    gpu_print_stat();
+void gpgpu_sim::print_stats() {
+  gpgpu_ctx->stats->ptx_file_line_stats_write_file();
+  gpu_print_stat();
 
-    if (g_network_mode) {
-        printf("----------------------------Interconnect-DETAILS--------------------------------\n" );
-        icnt_display_stats();
-        icnt_display_overall_stats();
-        printf("----------------------------END-of-Interconnect-DETAILS-------------------------\n" );
+  if (g_network_mode) {
+    printf(
+        "----------------------------Interconnect-DETAILS----------------------"
+        "----------\n");
+    icnt_display_stats();
+    icnt_display_overall_stats();
+    printf(
+        "----------------------------END-of-Interconnect-DETAILS---------------"
+        "----------\n");
+  }
+}
+
+void gpgpu_sim::deadlock_check() {
+  if (m_config.gpu_deadlock_detect && gpu_deadlock) {
+    fflush(stdout);
+    printf(
+        "\n\nGPGPU-Sim uArch: ERROR ** deadlock detected: last writeback core "
+        "%u @ gpu_sim_cycle %u (+ gpu_tot_sim_cycle %u) (%u cycles ago)\n",
+        gpu_sim_insn_last_update_sid, (unsigned)gpu_sim_insn_last_update,
+        (unsigned)(gpu_tot_sim_cycle - gpu_sim_cycle),
+        (unsigned)(gpu_sim_cycle - gpu_sim_insn_last_update));
+    unsigned num_cores = 0;
+    for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++) {
+      unsigned not_completed = m_cluster[i]->get_not_completed();
+      if (not_completed) {
+        if (!num_cores) {
+          printf(
+              "GPGPU-Sim uArch: DEADLOCK  shader cores no longer committing "
+              "instructions [core(# threads)]:\n");
+          printf("GPGPU-Sim uArch: DEADLOCK  ");
+          m_cluster[i]->print_not_completed(stdout);
+        } else if (num_cores < 8) {
+          m_cluster[i]->print_not_completed(stdout);
+        } else if (num_cores >= 8) {
+          printf(" + others ... ");
+        }
+        num_cores += m_shader_config->n_simt_cores_per_cluster;
+      }
     }
+    printf("\n");
+    for (unsigned i = 0; i < m_memory_config->m_n_mem; i++) {
+      bool busy = m_memory_partition_unit[i]->busy();
+      if (busy)
+        printf("GPGPU-Sim uArch DEADLOCK:  memory partition %u busy\n", i);
+    }
+    if (icnt_busy()) {
+      printf("GPGPU-Sim uArch DEADLOCK:  iterconnect contains traffic\n");
+      icnt_display_state(stdout);
+    }
+    printf(
+        "\nRe-run the simulator in gdb and use debug routines in .gdbinit to "
+        "debug this\n");
+    fflush(stdout);
+    abort();
+  }
 }
 
-void gpgpu_sim::deadlock_check()
-{
-   if (m_config.gpu_deadlock_detect && gpu_deadlock) {
-      fflush(stdout);
-      printf("\n\nGPGPU-Sim uArch: ERROR ** deadlock detected: last writeback core %u @ gpu_sim_cycle %u (+ gpu_tot_sim_cycle %u) (%u cycles ago)\n", 
-             gpu_sim_insn_last_update_sid,
-             (unsigned) gpu_sim_insn_last_update, (unsigned) (gpu_tot_sim_cycle-gpu_sim_cycle),
-             (unsigned) (gpu_sim_cycle - gpu_sim_insn_last_update )); 
-      unsigned num_cores=0;
-      for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) {
-         unsigned not_completed = m_cluster[i]->get_not_completed();
-         if( not_completed ) {
-             if ( !num_cores )  {
-                 printf("GPGPU-Sim uArch: DEADLOCK  shader cores no longer committing instructions [core(# threads)]:\n" );
-                 printf("GPGPU-Sim uArch: DEADLOCK  ");
-                 m_cluster[i]->print_not_completed(stdout);
-             } else if (num_cores < 8 ) {
-                 m_cluster[i]->print_not_completed(stdout);
-             } else if (num_cores >= 8 ) {
-                 printf(" + others ... ");
-             }
-             num_cores+=m_shader_config->n_simt_cores_per_cluster;
-         }
+/// printing the names and uids of a set of executed kernels (usually there is
+/// only one)
+std::string gpgpu_sim::executed_kernel_info_string() {
+  std::stringstream statout;
+
+  statout << "kernel_name = ";
+  for (unsigned int k = 0; k < m_executed_kernel_names.size(); k++) {
+    statout << m_executed_kernel_names[k] << " ";
+  }
+  statout << std::endl;
+  statout << "kernel_launch_uid = ";
+  for (unsigned int k = 0; k < m_executed_kernel_uids.size(); k++) {
+    statout << m_executed_kernel_uids[k] << " ";
+  }
+  statout << std::endl;
+
+  return statout.str();
+}
+void gpgpu_sim::set_cache_config(std::string kernel_name,
+                                 FuncCache cacheConfig) {
+  m_special_cache_config[kernel_name] = cacheConfig;
+}
+
+FuncCache gpgpu_sim::get_cache_config(std::string kernel_name) {
+  for (std::map<std::string, FuncCache>::iterator iter =
+           m_special_cache_config.begin();
+       iter != m_special_cache_config.end(); iter++) {
+    std::string kernel = iter->first;
+    if (kernel_name.compare(kernel) == 0) {
+      return iter->second;
+    }
+  }
+  return (FuncCache)0;
+}
+
+bool gpgpu_sim::has_special_cache_config(std::string kernel_name) {
+  for (std::map<std::string, FuncCache>::iterator iter =
+           m_special_cache_config.begin();
+       iter != m_special_cache_config.end(); iter++) {
+    std::string kernel = iter->first;
+    if (kernel_name.compare(kernel) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void gpgpu_sim::set_cache_config(std::string kernel_name) {
+  if (has_special_cache_config(kernel_name)) {
+    change_cache_config(get_cache_config(kernel_name));
+  } else {
+    change_cache_config(FuncCachePreferNone);
+  }
+}
+
+void gpgpu_sim::change_cache_config(FuncCache cache_config) {
+  if (cache_config != m_shader_config->m_L1D_config.get_cache_status()) {
+    printf("FLUSH L1 Cache at configuration change between kernels\n");
+    for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++) {
+      m_cluster[i]->cache_invalidate();
+    }
+  }
+
+  switch (cache_config) {
+    case FuncCachePreferNone:
+      m_shader_config->m_L1D_config.init(
+          m_shader_config->m_L1D_config.m_config_string, FuncCachePreferNone);
+      m_shader_config->gpgpu_shmem_size =
+          m_shader_config->gpgpu_shmem_sizeDefault;
+      break;
+    case FuncCachePreferL1:
+      if ((m_shader_config->m_L1D_config.m_config_stringPrefL1 == NULL) ||
+          (m_shader_config->gpgpu_shmem_sizePrefL1 == (unsigned)-1)) {
+        printf("WARNING: missing Preferred L1 configuration\n");
+        m_shader_config->m_L1D_config.init(
+            m_shader_config->m_L1D_config.m_config_string, FuncCachePreferNone);
+        m_shader_config->gpgpu_shmem_size =
+            m_shader_config->gpgpu_shmem_sizeDefault;
+
+      } else {
+        m_shader_config->m_L1D_config.init(
+            m_shader_config->m_L1D_config.m_config_stringPrefL1,
+            FuncCachePreferL1);
+        m_shader_config->gpgpu_shmem_size =
+            m_shader_config->gpgpu_shmem_sizePrefL1;
       }
-      printf("\n");
-      for (unsigned i=0;i<m_memory_config->m_n_mem;i++) {
-         bool busy = m_memory_partition_unit[i]->busy();
-         if( busy ) 
-             printf("GPGPU-Sim uArch DEADLOCK:  memory partition %u busy\n", i );
+      break;
+    case FuncCachePreferShared:
+      if ((m_shader_config->m_L1D_config.m_config_stringPrefShared == NULL) ||
+          (m_shader_config->gpgpu_shmem_sizePrefShared == (unsigned)-1)) {
+        printf("WARNING: missing Preferred L1 configuration\n");
+        m_shader_config->m_L1D_config.init(
+            m_shader_config->m_L1D_config.m_config_string, FuncCachePreferNone);
+        m_shader_config->gpgpu_shmem_size =
+            m_shader_config->gpgpu_shmem_sizeDefault;
+      } else {
+        m_shader_config->m_L1D_config.init(
+            m_shader_config->m_L1D_config.m_config_stringPrefShared,
+            FuncCachePreferShared);
+        m_shader_config->gpgpu_shmem_size =
+            m_shader_config->gpgpu_shmem_sizePrefShared;
       }
-      if( icnt_busy() ) {
-         printf("GPGPU-Sim uArch DEADLOCK:  iterconnect contains traffic\n");
-         icnt_display_state( stdout );
-      }
-      printf("\nRe-run the simulator in gdb and use debug routines in .gdbinit to debug this\n");
-      fflush(stdout);
-      abort();
-   }
+      break;
+    default:
+      break;
+  }
 }
 
-/// printing the names and uids of a set of executed kernels (usually there is only one)
-std::string gpgpu_sim::executed_kernel_info_string() 
-{
-   std::stringstream statout; 
-
-   statout << "kernel_name = "; 
-   for (unsigned int k = 0; k < m_executed_kernel_names.size(); k++) {
-      statout << m_executed_kernel_names[k] << " "; 
-   }
-   statout << std::endl; 
-   statout << "kernel_launch_uid = ";
-   for (unsigned int k = 0; k < m_executed_kernel_uids.size(); k++) {
-      statout << m_executed_kernel_uids[k] << " "; 
-   }
-   statout << std::endl; 
-
-   return statout.str(); 
+void gpgpu_sim::clear_executed_kernel_info() {
+  m_executed_kernel_names.clear();
+  m_executed_kernel_uids.clear();
 }
-void gpgpu_sim::set_cache_config(std::string kernel_name,  FuncCache cacheConfig )
-{
-	m_special_cache_config[kernel_name]=cacheConfig ;
-}
+void gpgpu_sim::gpu_print_stat() {
+  FILE *statfout = stdout;
 
-FuncCache gpgpu_sim::get_cache_config(std::string kernel_name)
-{
-	for (	std::map<std::string, FuncCache>::iterator iter = m_special_cache_config.begin(); iter != m_special_cache_config.end(); iter++){
-		    std::string kernel= iter->first;
-			if (kernel_name.compare(kernel) == 0){
-				return iter->second;
-			}
-	}
-	return (FuncCache)0;
-}
+  std::string kernel_info_str = executed_kernel_info_string();
+  fprintf(statfout, "%s", kernel_info_str.c_str());
 
-bool gpgpu_sim::has_special_cache_config(std::string kernel_name)
-{
-	for (	std::map<std::string, FuncCache>::iterator iter = m_special_cache_config.begin(); iter != m_special_cache_config.end(); iter++){
-	    	std::string kernel= iter->first;
-			if (kernel_name.compare(kernel) == 0){
-				return true;
-			}
-	}
-	return false;
-}
+  printf("gpu_sim_cycle = %lld\n", gpu_sim_cycle);
+  printf("gpu_sim_insn = %lld\n", gpu_sim_insn);
+  printf("gpu_ipc = %12.4f\n", (float)gpu_sim_insn / gpu_sim_cycle);
+  printf("gpu_tot_sim_cycle = %lld\n", gpu_tot_sim_cycle + gpu_sim_cycle);
+  printf("gpu_tot_sim_insn = %lld\n", gpu_tot_sim_insn + gpu_sim_insn);
+  printf("gpu_tot_ipc = %12.4f\n", (float)(gpu_tot_sim_insn + gpu_sim_insn) /
+                                       (gpu_tot_sim_cycle + gpu_sim_cycle));
+  printf("gpu_tot_issued_cta = %lld\n",
+         gpu_tot_issued_cta + m_total_cta_launched);
+  printf("gpu_occupancy = %.4f%% \n", gpu_occupancy.get_occ_fraction() * 100);
+  printf("gpu_tot_occupancy = %.4f%% \n",
+         (gpu_occupancy + gpu_tot_occupancy).get_occ_fraction() * 100);
 
+  fprintf(statfout, "max_total_param_size = %llu\n",
+          gpgpu_ctx->device_runtime->g_max_total_param_size);
 
-void gpgpu_sim::set_cache_config(std::string kernel_name)
-{
-	if(has_special_cache_config(kernel_name)){
-		change_cache_config(get_cache_config(kernel_name));
-	}else{
-		change_cache_config(FuncCachePreferNone);
-	}
-}
+  // performance counter for stalls due to congestion.
+  printf("gpu_stall_dramfull = %d\n", gpu_stall_dramfull);
+  printf("gpu_stall_icnt2sh    = %d\n", gpu_stall_icnt2sh);
 
+  // printf("partiton_reqs_in_parallel = %lld\n", partiton_reqs_in_parallel);
+  // printf("partiton_reqs_in_parallel_total    = %lld\n",
+  // partiton_reqs_in_parallel_total );
+  printf("partiton_level_parallism = %12.4f\n",
+         (float)partiton_reqs_in_parallel / gpu_sim_cycle);
+  printf("partiton_level_parallism_total  = %12.4f\n",
+         (float)(partiton_reqs_in_parallel + partiton_reqs_in_parallel_total) /
+             (gpu_tot_sim_cycle + gpu_sim_cycle));
+  // printf("partiton_reqs_in_parallel_util = %lld\n",
+  // partiton_reqs_in_parallel_util);
+  // printf("partiton_reqs_in_parallel_util_total    = %lld\n",
+  // partiton_reqs_in_parallel_util_total ); printf("gpu_sim_cycle_parition_util
+  // = %lld\n", gpu_sim_cycle_parition_util);
+  // printf("gpu_tot_sim_cycle_parition_util    = %lld\n",
+  // gpu_tot_sim_cycle_parition_util );
+  printf("partiton_level_parallism_util = %12.4f\n",
+         (float)partiton_reqs_in_parallel_util / gpu_sim_cycle_parition_util);
+  printf("partiton_level_parallism_util_total  = %12.4f\n",
+         (float)(partiton_reqs_in_parallel_util +
+                 partiton_reqs_in_parallel_util_total) /
+             (gpu_sim_cycle_parition_util + gpu_tot_sim_cycle_parition_util));
+  // printf("partiton_replys_in_parallel = %lld\n",
+  // partiton_replys_in_parallel); printf("partiton_replys_in_parallel_total    =
+  // %lld\n", partiton_replys_in_parallel_total );
+  printf("L2_BW  = %12.4f GB/Sec\n",
+         ((float)(partiton_replys_in_parallel * 32) /
+          (gpu_sim_cycle * m_config.icnt_period)) /
+             1000000000);
+  printf("L2_BW_total  = %12.4f GB/Sec\n",
+         ((float)((partiton_replys_in_parallel +
+                   partiton_replys_in_parallel_total) *
+                  32) /
+          ((gpu_tot_sim_cycle + gpu_sim_cycle) * m_config.icnt_period)) /
+             1000000000);
 
-void gpgpu_sim::change_cache_config(FuncCache cache_config)
-{
-	if(cache_config != m_shader_config->m_L1D_config.get_cache_status()){
-		printf("FLUSH L1 Cache at configuration change between kernels\n");
-		for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) {
-			m_cluster[i]->cache_invalidate();
-	    }
-	}
+  time_t curr_time;
+  time(&curr_time);
+  unsigned long long elapsed_time =
+      MAX(curr_time - gpgpu_ctx->the_gpgpusim->g_simulation_starttime, 1);
+  printf("gpu_total_sim_rate=%u\n",
+         (unsigned)((gpu_tot_sim_insn + gpu_sim_insn) / elapsed_time));
 
-	switch(cache_config){
-	case FuncCachePreferNone:
-		m_shader_config->m_L1D_config.init(m_shader_config->m_L1D_config.m_config_string, FuncCachePreferNone);
-		m_shader_config->gpgpu_shmem_size=m_shader_config->gpgpu_shmem_sizeDefault;
-		break;
-	case FuncCachePreferL1:
-		if((m_shader_config->m_L1D_config.m_config_stringPrefL1 == NULL) || (m_shader_config->gpgpu_shmem_sizePrefL1 == (unsigned)-1))
-		{
-			printf("WARNING: missing Preferred L1 configuration\n");
-			m_shader_config->m_L1D_config.init(m_shader_config->m_L1D_config.m_config_string, FuncCachePreferNone);
-			m_shader_config->gpgpu_shmem_size=m_shader_config->gpgpu_shmem_sizeDefault;
+  // shader_print_l1_miss_stat( stdout );
+  shader_print_cache_stats(stdout);
 
-		}else{
-			m_shader_config->m_L1D_config.init(m_shader_config->m_L1D_config.m_config_stringPrefL1, FuncCachePreferL1);
-			m_shader_config->gpgpu_shmem_size=m_shader_config->gpgpu_shmem_sizePrefL1;
-		}
-		break;
-	case FuncCachePreferShared:
-		if((m_shader_config->m_L1D_config.m_config_stringPrefShared == NULL) || (m_shader_config->gpgpu_shmem_sizePrefShared == (unsigned)-1))
-		{
-			printf("WARNING: missing Preferred L1 configuration\n");
-			m_shader_config->m_L1D_config.init(m_shader_config->m_L1D_config.m_config_string, FuncCachePreferNone);
-			m_shader_config->gpgpu_shmem_size=m_shader_config->gpgpu_shmem_sizeDefault;
-		}else{
-			m_shader_config->m_L1D_config.init(m_shader_config->m_L1D_config.m_config_stringPrefShared, FuncCachePreferShared);
-			m_shader_config->gpgpu_shmem_size=m_shader_config->gpgpu_shmem_sizePrefShared;
-		}
-		break;
-	default:
-		break;
-	}
-}
+  cache_stats core_cache_stats;
+  core_cache_stats.clear();
+  for (unsigned i = 0; i < m_config.num_cluster(); i++) {
+    m_cluster[i]->get_cache_stats(core_cache_stats);
+  }
+  printf("\nTotal_core_cache_stats:\n");
+  core_cache_stats.print_stats(stdout, "Total_core_cache_stats_breakdown");
+  printf("\nTotal_core_cache_fail_stats:\n");
+  core_cache_stats.print_fail_stats(stdout,
+                                    "Total_core_cache_fail_stats_breakdown");
+  shader_print_scheduler_stat(stdout, false);
 
-
-void gpgpu_sim::clear_executed_kernel_info()
-{
-   m_executed_kernel_names.clear();
-   m_executed_kernel_uids.clear();
-}
-void gpgpu_sim::gpu_print_stat() 
-{  
-   FILE *statfout = stdout; 
-
-   std::string kernel_info_str = executed_kernel_info_string(); 
-   fprintf(statfout, "%s", kernel_info_str.c_str()); 
-
-   printf("gpu_sim_cycle = %lld\n", gpu_sim_cycle);
-   printf("gpu_sim_insn = %lld\n", gpu_sim_insn);
-   printf("gpu_ipc = %12.4f\n", (float)gpu_sim_insn / gpu_sim_cycle);
-   printf("gpu_tot_sim_cycle = %lld\n", gpu_tot_sim_cycle+gpu_sim_cycle);
-   printf("gpu_tot_sim_insn = %lld\n", gpu_tot_sim_insn+gpu_sim_insn);
-   printf("gpu_tot_ipc = %12.4f\n", (float)(gpu_tot_sim_insn+gpu_sim_insn) / (gpu_tot_sim_cycle+gpu_sim_cycle));
-   printf("gpu_tot_issued_cta = %lld\n", gpu_tot_issued_cta + m_total_cta_launched);
-   printf("gpu_occupancy = %.4f%% \n", gpu_occupancy.get_occ_fraction() * 100);
-   printf("gpu_tot_occupancy = %.4f%% \n", (gpu_occupancy + gpu_tot_occupancy).get_occ_fraction() * 100);
-
-
-   fprintf(statfout, "max_total_param_size = %llu\n", gpgpu_ctx->device_runtime->g_max_total_param_size);
-
-   // performance counter for stalls due to congestion.
-   printf("gpu_stall_dramfull = %d\n", gpu_stall_dramfull);
-   printf("gpu_stall_icnt2sh    = %d\n", gpu_stall_icnt2sh );
-
-   //printf("partiton_reqs_in_parallel = %lld\n", partiton_reqs_in_parallel);
-   //printf("partiton_reqs_in_parallel_total    = %lld\n", partiton_reqs_in_parallel_total );
-   printf("partiton_level_parallism = %12.4f\n", (float)partiton_reqs_in_parallel / gpu_sim_cycle);
-   printf("partiton_level_parallism_total  = %12.4f\n", (float)(partiton_reqs_in_parallel+partiton_reqs_in_parallel_total) / (gpu_tot_sim_cycle+gpu_sim_cycle) );
-   //printf("partiton_reqs_in_parallel_util = %lld\n", partiton_reqs_in_parallel_util);
-   //printf("partiton_reqs_in_parallel_util_total    = %lld\n", partiton_reqs_in_parallel_util_total );
-   //printf("gpu_sim_cycle_parition_util = %lld\n", gpu_sim_cycle_parition_util);
-   // printf("gpu_tot_sim_cycle_parition_util    = %lld\n", gpu_tot_sim_cycle_parition_util );
-   printf("partiton_level_parallism_util = %12.4f\n", (float)partiton_reqs_in_parallel_util / gpu_sim_cycle_parition_util);
-   printf("partiton_level_parallism_util_total  = %12.4f\n", (float)(partiton_reqs_in_parallel_util+partiton_reqs_in_parallel_util_total) / (gpu_sim_cycle_parition_util+gpu_tot_sim_cycle_parition_util) );
-   //printf("partiton_replys_in_parallel = %lld\n", partiton_replys_in_parallel);
-   //printf("partiton_replys_in_parallel_total    = %lld\n", partiton_replys_in_parallel_total );
-   printf("L2_BW  = %12.4f GB/Sec\n", ((float)(partiton_replys_in_parallel * 32) / (gpu_sim_cycle * m_config.icnt_period)) / 1000000000);
-   printf("L2_BW_total  = %12.4f GB/Sec\n", ((float)((partiton_replys_in_parallel+partiton_replys_in_parallel_total) * 32) / ((gpu_tot_sim_cycle+gpu_sim_cycle) * m_config.icnt_period)) / 1000000000 );
-
-   time_t curr_time;
-   time(&curr_time);
-   unsigned long long elapsed_time = MAX( curr_time - gpgpu_ctx->the_gpgpusim->g_simulation_starttime, 1 );
-   printf( "gpu_total_sim_rate=%u\n", (unsigned)( ( gpu_tot_sim_insn + gpu_sim_insn ) / elapsed_time ) );
-
-   //shader_print_l1_miss_stat( stdout );
-   shader_print_cache_stats(stdout);
-
-   cache_stats core_cache_stats;
-   core_cache_stats.clear();
-   for(unsigned i=0; i<m_config.num_cluster(); i++){
-       m_cluster[i]->get_cache_stats(core_cache_stats);
-   }
-   printf("\nTotal_core_cache_stats:\n");
-   core_cache_stats.print_stats(stdout, "Total_core_cache_stats_breakdown");
-   printf("\nTotal_core_cache_fail_stats:\n");
-   core_cache_stats.print_fail_stats(stdout, "Total_core_cache_fail_stats_breakdown");
-   shader_print_scheduler_stat( stdout, false );
-
-   m_shader_stats->print(stdout);
+  m_shader_stats->print(stdout);
 #ifdef GPGPUSIM_POWER_MODEL
-   if(m_config.g_power_simulation_enabled){
-	   m_gpgpusim_wrapper->print_power_kernel_stats(gpu_sim_cycle, gpu_tot_sim_cycle, gpu_tot_sim_insn + gpu_sim_insn, kernel_info_str, true );
-	   mcpat_reset_perf_count(m_gpgpusim_wrapper);
-   }
+  if (m_config.g_power_simulation_enabled) {
+    m_gpgpusim_wrapper->print_power_kernel_stats(
+        gpu_sim_cycle, gpu_tot_sim_cycle, gpu_tot_sim_insn + gpu_sim_insn,
+        kernel_info_str, true);
+    mcpat_reset_perf_count(m_gpgpusim_wrapper);
+  }
 #endif
 
-   // performance counter that are not local to one shader
-   m_memory_stats->memlatstat_print(m_memory_config->m_n_mem,m_memory_config->nbk);
-   for (unsigned i=0;i<m_memory_config->m_n_mem;i++)
-      m_memory_partition_unit[i]->print(stdout);
+  // performance counter that are not local to one shader
+  m_memory_stats->memlatstat_print(m_memory_config->m_n_mem,
+                                   m_memory_config->nbk);
+  for (unsigned i = 0; i < m_memory_config->m_n_mem; i++)
+    m_memory_partition_unit[i]->print(stdout);
 
-   // L2 cache stats
-   if(!m_memory_config->m_L2_config.disabled()){
-       cache_stats l2_stats;
-       struct cache_sub_stats l2_css;
-       struct cache_sub_stats total_l2_css;
-       l2_stats.clear();
-       l2_css.clear();
-       total_l2_css.clear();
+  // L2 cache stats
+  if (!m_memory_config->m_L2_config.disabled()) {
+    cache_stats l2_stats;
+    struct cache_sub_stats l2_css;
+    struct cache_sub_stats total_l2_css;
+    l2_stats.clear();
+    l2_css.clear();
+    total_l2_css.clear();
 
-       printf("\n========= L2 cache stats =========\n");
-       for (unsigned i=0;i<m_memory_config->m_n_mem_sub_partition;i++){
-           m_memory_sub_partition[i]->accumulate_L2cache_stats(l2_stats);
-           m_memory_sub_partition[i]->get_L2cache_sub_stats(l2_css);
+    printf("\n========= L2 cache stats =========\n");
+    for (unsigned i = 0; i < m_memory_config->m_n_mem_sub_partition; i++) {
+      m_memory_sub_partition[i]->accumulate_L2cache_stats(l2_stats);
+      m_memory_sub_partition[i]->get_L2cache_sub_stats(l2_css);
 
-           fprintf( stdout, "L2_cache_bank[%d]: Access = %llu, Miss = %llu, Miss_rate = %.3lf, Pending_hits = %llu, Reservation_fails = %llu\n",
-                    i, l2_css.accesses, l2_css.misses, (double)l2_css.misses / (double)l2_css.accesses, l2_css.pending_hits, l2_css.res_fails);
+      fprintf(stdout,
+              "L2_cache_bank[%d]: Access = %llu, Miss = %llu, Miss_rate = "
+              "%.3lf, Pending_hits = %llu, Reservation_fails = %llu\n",
+              i, l2_css.accesses, l2_css.misses,
+              (double)l2_css.misses / (double)l2_css.accesses,
+              l2_css.pending_hits, l2_css.res_fails);
 
-           total_l2_css += l2_css;
-       }
-       if (!m_memory_config->m_L2_config.disabled() && m_memory_config->m_L2_config.get_num_lines()) {
-          //L2c_print_cache_stat();
-          printf("L2_total_cache_accesses = %llu\n", total_l2_css.accesses);
-          printf("L2_total_cache_misses = %llu\n", total_l2_css.misses);
-          if(total_l2_css.accesses > 0)
-              printf("L2_total_cache_miss_rate = %.4lf\n", (double)total_l2_css.misses/(double)total_l2_css.accesses);
-          printf("L2_total_cache_pending_hits = %llu\n", total_l2_css.pending_hits);
-          printf("L2_total_cache_reservation_fails = %llu\n", total_l2_css.res_fails);
-          printf("L2_total_cache_breakdown:\n");
-          l2_stats.print_stats(stdout, "L2_cache_stats_breakdown");
-          printf("L2_total_cache_reservation_fail_breakdown:\n");
-          l2_stats.print_fail_stats(stdout, "L2_cache_stats_fail_breakdown");
-          total_l2_css.print_port_stats(stdout, "L2_cache");
-       }
-   }
+      total_l2_css += l2_css;
+    }
+    if (!m_memory_config->m_L2_config.disabled() &&
+        m_memory_config->m_L2_config.get_num_lines()) {
+      // L2c_print_cache_stat();
+      printf("L2_total_cache_accesses = %llu\n", total_l2_css.accesses);
+      printf("L2_total_cache_misses = %llu\n", total_l2_css.misses);
+      if (total_l2_css.accesses > 0)
+        printf("L2_total_cache_miss_rate = %.4lf\n",
+               (double)total_l2_css.misses / (double)total_l2_css.accesses);
+      printf("L2_total_cache_pending_hits = %llu\n", total_l2_css.pending_hits);
+      printf("L2_total_cache_reservation_fails = %llu\n",
+             total_l2_css.res_fails);
+      printf("L2_total_cache_breakdown:\n");
+      l2_stats.print_stats(stdout, "L2_cache_stats_breakdown");
+      printf("L2_total_cache_reservation_fail_breakdown:\n");
+      l2_stats.print_fail_stats(stdout, "L2_cache_stats_fail_breakdown");
+      total_l2_css.print_port_stats(stdout, "L2_cache");
+    }
+  }
 
-   if (m_config.gpgpu_cflog_interval != 0) {
-      spill_log_to_file (stdout, 1, gpu_sim_cycle);
-      insn_warp_occ_print(stdout);
-   }
-   if ( gpgpu_ctx->func_sim->gpgpu_ptx_instruction_classification ) {
-      StatDisp( gpgpu_ctx->func_sim->g_inst_classification_stat[gpgpu_ctx->func_sim->g_ptx_kernel_count]);
-      StatDisp( gpgpu_ctx->func_sim->g_inst_op_classification_stat[gpgpu_ctx->func_sim->g_ptx_kernel_count]);
-   }
+  if (m_config.gpgpu_cflog_interval != 0) {
+    spill_log_to_file(stdout, 1, gpu_sim_cycle);
+    insn_warp_occ_print(stdout);
+  }
+  if (gpgpu_ctx->func_sim->gpgpu_ptx_instruction_classification) {
+    StatDisp(gpgpu_ctx->func_sim->g_inst_classification_stat
+                 [gpgpu_ctx->func_sim->g_ptx_kernel_count]);
+    StatDisp(gpgpu_ctx->func_sim->g_inst_op_classification_stat
+                 [gpgpu_ctx->func_sim->g_ptx_kernel_count]);
+  }
 
 #ifdef GPGPUSIM_POWER_MODEL
-   if(m_config.g_power_simulation_enabled){
-       m_gpgpusim_wrapper->detect_print_steady_state(1,gpu_tot_sim_insn+gpu_sim_insn);
-   }
+  if (m_config.g_power_simulation_enabled) {
+    m_gpgpusim_wrapper->detect_print_steady_state(
+        1, gpu_tot_sim_insn + gpu_sim_insn);
+  }
 #endif
 
+  // Interconnect power stat print
+  long total_simt_to_mem = 0;
+  long total_mem_to_simt = 0;
+  long temp_stm = 0;
+  long temp_mts = 0;
+  for (unsigned i = 0; i < m_config.num_cluster(); i++) {
+    m_cluster[i]->get_icnt_stats(temp_stm, temp_mts);
+    total_simt_to_mem += temp_stm;
+    total_mem_to_simt += temp_mts;
+  }
+  printf("\nicnt_total_pkts_mem_to_simt=%ld\n", total_mem_to_simt);
+  printf("icnt_total_pkts_simt_to_mem=%ld\n", total_simt_to_mem);
 
-   // Interconnect power stat print
-   long total_simt_to_mem=0;
-   long total_mem_to_simt=0;
-   long temp_stm=0;
-   long temp_mts = 0;
-   for(unsigned i=0; i<m_config.num_cluster(); i++){
-	   m_cluster[i]->get_icnt_stats(temp_stm, temp_mts);
-	   total_simt_to_mem += temp_stm;
-	   total_mem_to_simt += temp_mts;
-   }
-   printf("\nicnt_total_pkts_mem_to_simt=%ld\n", total_mem_to_simt);
-   printf("icnt_total_pkts_simt_to_mem=%ld\n", total_simt_to_mem);
+  time_vector_print();
+  fflush(stdout);
 
-   time_vector_print();
-   fflush(stdout);
-
-   clear_executed_kernel_info(); 
+  clear_executed_kernel_info();
 }
-
 
 // performance counter that are not local to one shader
-unsigned gpgpu_sim::threads_per_core() const 
-{ 
-   return m_shader_config->n_thread_per_shader; 
+unsigned gpgpu_sim::threads_per_core() const {
+  return m_shader_config->n_thread_per_shader;
 }
 
-void shader_core_ctx::mem_instruction_stats(const warp_inst_t &inst)
-{
-    unsigned active_count = inst.active_count(); 
-    //this breaks some encapsulation: the is_[space] functions, if you change those, change this.
-    switch (inst.space.get_type()) {
+void shader_core_ctx::mem_instruction_stats(const warp_inst_t &inst) {
+  unsigned active_count = inst.active_count();
+  // this breaks some encapsulation: the is_[space] functions, if you change
+  // those, change this.
+  switch (inst.space.get_type()) {
     case undefined_space:
     case reg_space:
-        break;
+      break;
     case shared_space:
-        m_stats->gpgpu_n_shmem_insn += active_count; 
-        break;
+      m_stats->gpgpu_n_shmem_insn += active_count;
+      break;
     case sstarr_space:
-    	m_stats->gpgpu_n_sstarr_insn += active_count;
-    	break;
+      m_stats->gpgpu_n_sstarr_insn += active_count;
+      break;
     case const_space:
-        m_stats->gpgpu_n_const_insn += active_count;
-        break;
+      m_stats->gpgpu_n_const_insn += active_count;
+      break;
     case param_space_kernel:
     case param_space_local:
-        m_stats->gpgpu_n_param_insn += active_count;
-        break;
+      m_stats->gpgpu_n_param_insn += active_count;
+      break;
     case tex_space:
-        m_stats->gpgpu_n_tex_insn += active_count;
-        break;
+      m_stats->gpgpu_n_tex_insn += active_count;
+      break;
     case global_space:
     case local_space:
-        if( inst.is_store() )
-            m_stats->gpgpu_n_store_insn += active_count;
-        else 
-            m_stats->gpgpu_n_load_insn += active_count;
-        break;
+      if (inst.is_store())
+        m_stats->gpgpu_n_store_insn += active_count;
+      else
+        m_stats->gpgpu_n_load_insn += active_count;
+      break;
     default:
-        abort();
-    }
+      abort();
+  }
 }
-bool shader_core_ctx::can_issue_1block(kernel_info_t & kernel) {
+bool shader_core_ctx::can_issue_1block(kernel_info_t &kernel) {
+  // Jin: concurrent kernels on one SM
+  if (m_config->gpgpu_concurrent_kernel_sm) {
+    if (m_config->max_cta(kernel) < 1) return false;
 
-   //Jin: concurrent kernels on one SM
-   if(m_config->gpgpu_concurrent_kernel_sm) {    
-      if(m_config->max_cta(kernel) < 1)
-           return false;
-
-      return occupy_shader_resource_1block(kernel, false);
-   }
-   else {
-      return (get_n_active_cta() < m_config->max_cta(kernel));
-   } 
+    return occupy_shader_resource_1block(kernel, false);
+  } else {
+    return (get_n_active_cta() < m_config->max_cta(kernel));
+  }
 }
 
 int shader_core_ctx::find_available_hwtid(unsigned int cta_size, bool occupy) {
-   
-   unsigned int step;
-   for(step = 0; step < m_config->n_thread_per_shader; 
-        step += cta_size) {
-
-        unsigned int hw_tid;
-        for(hw_tid = step; hw_tid < step + cta_size;
-            hw_tid++) {
-            if(m_occupied_hwtid.test(hw_tid))
-                break;
-        }
-        if(hw_tid == step + cta_size) //consecutive non-active
-            break;
-   }
-   if(step >= m_config->n_thread_per_shader) //didn't find
-     return -1;
-   else {
-     if(occupy) {
-        for(unsigned hw_tid = step; hw_tid < step + cta_size;
-            hw_tid++)
-            m_occupied_hwtid.set(hw_tid);
-     }
-     return step;
-   }
+  unsigned int step;
+  for (step = 0; step < m_config->n_thread_per_shader; step += cta_size) {
+    unsigned int hw_tid;
+    for (hw_tid = step; hw_tid < step + cta_size; hw_tid++) {
+      if (m_occupied_hwtid.test(hw_tid)) break;
+    }
+    if (hw_tid == step + cta_size)  // consecutive non-active
+      break;
+  }
+  if (step >= m_config->n_thread_per_shader)  // didn't find
+    return -1;
+  else {
+    if (occupy) {
+      for (unsigned hw_tid = step; hw_tid < step + cta_size; hw_tid++)
+        m_occupied_hwtid.set(hw_tid);
+    }
+    return step;
+  }
 }
 
-bool shader_core_ctx::occupy_shader_resource_1block(kernel_info_t & k, bool occupy) {
-   unsigned threads_per_cta  = k.threads_per_cta();
-   const class function_info *kernel = k.entry();
-   unsigned int padded_cta_size = threads_per_cta;
-   unsigned int warp_size = m_config->warp_size; 
-   if (padded_cta_size%warp_size) 
-      padded_cta_size = ((padded_cta_size/warp_size)+1)*(warp_size);
+bool shader_core_ctx::occupy_shader_resource_1block(kernel_info_t &k,
+                                                    bool occupy) {
+  unsigned threads_per_cta = k.threads_per_cta();
+  const class function_info *kernel = k.entry();
+  unsigned int padded_cta_size = threads_per_cta;
+  unsigned int warp_size = m_config->warp_size;
+  if (padded_cta_size % warp_size)
+    padded_cta_size = ((padded_cta_size / warp_size) + 1) * (warp_size);
 
-   if(m_occupied_n_threads + padded_cta_size > m_config->n_thread_per_shader)
-     return false;
+  if (m_occupied_n_threads + padded_cta_size > m_config->n_thread_per_shader)
+    return false;
 
-   if(find_available_hwtid(padded_cta_size, false) == -1)
-     return false;
+  if (find_available_hwtid(padded_cta_size, false) == -1) return false;
 
-   const struct gpgpu_ptx_sim_info *kernel_info = ptx_sim_kernel_info(kernel);
+  const struct gpgpu_ptx_sim_info *kernel_info = ptx_sim_kernel_info(kernel);
 
-   if(m_occupied_shmem + kernel_info->smem > m_config->gpgpu_shmem_size)
-     return false;
+  if (m_occupied_shmem + kernel_info->smem > m_config->gpgpu_shmem_size)
+    return false;
 
-   unsigned int used_regs = padded_cta_size * ((kernel_info->regs+3)&~3);
-   if(m_occupied_regs + used_regs > m_config->gpgpu_shader_registers)
-     return false;
+  unsigned int used_regs = padded_cta_size * ((kernel_info->regs + 3) & ~3);
+  if (m_occupied_regs + used_regs > m_config->gpgpu_shader_registers)
+    return false;
 
-   if(m_occupied_ctas +1 > m_config->max_cta_per_core)
-     return false;
-   
-   if(occupy) {
-       m_occupied_n_threads += padded_cta_size;
-       m_occupied_shmem += kernel_info->smem;
-       m_occupied_regs += (padded_cta_size * ((kernel_info->regs+3)&~3));
-       m_occupied_ctas++;
+  if (m_occupied_ctas + 1 > m_config->max_cta_per_core) return false;
 
-      SHADER_DPRINTF(LIVENESS, "GPGPU-Sim uArch: Occupied %u threads, %u shared mem, %u registers, %u ctas\n",
-            m_occupied_n_threads, m_occupied_shmem, m_occupied_regs, m_occupied_ctas);  
-   }
+  if (occupy) {
+    m_occupied_n_threads += padded_cta_size;
+    m_occupied_shmem += kernel_info->smem;
+    m_occupied_regs += (padded_cta_size * ((kernel_info->regs + 3) & ~3));
+    m_occupied_ctas++;
 
-   return true;
+    SHADER_DPRINTF(LIVENESS,
+                   "GPGPU-Sim uArch: Occupied %u threads, %u shared mem, %u "
+                   "registers, %u ctas\n",
+                   m_occupied_n_threads, m_occupied_shmem, m_occupied_regs,
+                   m_occupied_ctas);
+  }
+
+  return true;
 }
 
-void shader_core_ctx::release_shader_resource_1block(unsigned hw_ctaid, kernel_info_t & k) {
+void shader_core_ctx::release_shader_resource_1block(unsigned hw_ctaid,
+                                                     kernel_info_t &k) {
+  if (m_config->gpgpu_concurrent_kernel_sm) {
+    unsigned threads_per_cta = k.threads_per_cta();
+    const class function_info *kernel = k.entry();
+    unsigned int padded_cta_size = threads_per_cta;
+    unsigned int warp_size = m_config->warp_size;
+    if (padded_cta_size % warp_size)
+      padded_cta_size = ((padded_cta_size / warp_size) + 1) * (warp_size);
 
-   if(m_config->gpgpu_concurrent_kernel_sm) {
-      unsigned threads_per_cta  = k.threads_per_cta();
-      const class function_info *kernel = k.entry();
-      unsigned int padded_cta_size = threads_per_cta;
-      unsigned int warp_size = m_config->warp_size; 
-      if (padded_cta_size%warp_size) 
-         padded_cta_size = ((padded_cta_size/warp_size)+1)*(warp_size);
-   
-      assert(m_occupied_n_threads >= padded_cta_size);
-      m_occupied_n_threads -= padded_cta_size;
-   
-      int start_thread = m_occupied_cta_to_hwtid[hw_ctaid];
-   
-      for(unsigned hwtid = start_thread; hwtid < start_thread + padded_cta_size;
-       hwtid++)
-          m_occupied_hwtid.reset(hwtid);
-      m_occupied_cta_to_hwtid.erase(hw_ctaid);
-   
-      const struct gpgpu_ptx_sim_info *kernel_info = ptx_sim_kernel_info(kernel);
-   
-      assert(m_occupied_shmem >= (unsigned int)kernel_info->smem);
-      m_occupied_shmem -= kernel_info->smem;
-   
-      unsigned int used_regs = padded_cta_size * ((kernel_info->regs+3)&~3);
-      assert(m_occupied_regs >= used_regs);
-      m_occupied_regs -= used_regs;
-   
-      assert(m_occupied_ctas >= 1);
-      m_occupied_ctas--;
-   }
+    assert(m_occupied_n_threads >= padded_cta_size);
+    m_occupied_n_threads -= padded_cta_size;
+
+    int start_thread = m_occupied_cta_to_hwtid[hw_ctaid];
+
+    for (unsigned hwtid = start_thread; hwtid < start_thread + padded_cta_size;
+         hwtid++)
+      m_occupied_hwtid.reset(hwtid);
+    m_occupied_cta_to_hwtid.erase(hw_ctaid);
+
+    const struct gpgpu_ptx_sim_info *kernel_info = ptx_sim_kernel_info(kernel);
+
+    assert(m_occupied_shmem >= (unsigned int)kernel_info->smem);
+    m_occupied_shmem -= kernel_info->smem;
+
+    unsigned int used_regs = padded_cta_size * ((kernel_info->regs + 3) & ~3);
+    assert(m_occupied_regs >= used_regs);
+    m_occupied_regs -= used_regs;
+
+    assert(m_occupied_ctas >= 1);
+    m_occupied_ctas--;
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
 /**
- * Launches a cooperative thread array (CTA). 
- *  
- * @param kernel 
- *    object that tells us which kernel to ask for a CTA from 
+ * Launches a cooperative thread array (CTA).
+ *
+ * @param kernel
+ *    object that tells us which kernel to ask for a CTA from
  */
 
-void shader_core_ctx::issue_block2core( kernel_info_t &kernel ) 
-{
+void shader_core_ctx::issue_block2core(kernel_info_t &kernel) {
+  if (!m_config->gpgpu_concurrent_kernel_sm)
+    set_max_cta(kernel);
+  else
+    assert(occupy_shader_resource_1block(kernel, true));
 
-    if(!m_config->gpgpu_concurrent_kernel_sm)
-        set_max_cta(kernel);
-    else
-        assert(occupy_shader_resource_1block(kernel, true));
+  kernel.inc_running();
 
-    kernel.inc_running();
+  // find a free CTA context
+  unsigned free_cta_hw_id = (unsigned)-1;
 
-    // find a free CTA context 
-    unsigned free_cta_hw_id=(unsigned)-1;
-
-    unsigned max_cta_per_core;
-    if(!m_config->gpgpu_concurrent_kernel_sm)
-        max_cta_per_core = kernel_max_cta_per_shader;
-    else
-        max_cta_per_core = m_config->max_cta_per_core;
-    for (unsigned i=0;i<max_cta_per_core;i++ ) {
-      if( m_cta_status[i]==0 ) {
-         free_cta_hw_id=i;
-         break;
-      }
+  unsigned max_cta_per_core;
+  if (!m_config->gpgpu_concurrent_kernel_sm)
+    max_cta_per_core = kernel_max_cta_per_shader;
+  else
+    max_cta_per_core = m_config->max_cta_per_core;
+  for (unsigned i = 0; i < max_cta_per_core; i++) {
+    if (m_cta_status[i] == 0) {
+      free_cta_hw_id = i;
+      break;
     }
-    assert( free_cta_hw_id!=(unsigned)-1 );
+  }
+  assert(free_cta_hw_id != (unsigned)-1);
 
-    // determine hardware threads and warps that will be used for this CTA
-    int cta_size = kernel.threads_per_cta();
+  // determine hardware threads and warps that will be used for this CTA
+  int cta_size = kernel.threads_per_cta();
 
-    // hw warp id = hw thread id mod warp size, so we need to find a range 
-    // of hardware thread ids corresponding to an integral number of hardware
-    // thread ids
-    int padded_cta_size = cta_size; 
-    if (cta_size%m_config->warp_size)
-      padded_cta_size = ((cta_size/m_config->warp_size)+1)*(m_config->warp_size);
+  // hw warp id = hw thread id mod warp size, so we need to find a range
+  // of hardware thread ids corresponding to an integral number of hardware
+  // thread ids
+  int padded_cta_size = cta_size;
+  if (cta_size % m_config->warp_size)
+    padded_cta_size =
+        ((cta_size / m_config->warp_size) + 1) * (m_config->warp_size);
 
-    unsigned int start_thread, end_thread;
+  unsigned int start_thread, end_thread;
 
-    if(!m_config->gpgpu_concurrent_kernel_sm) {
-        start_thread = free_cta_hw_id * padded_cta_size;
-        end_thread  = start_thread +  cta_size;
+  if (!m_config->gpgpu_concurrent_kernel_sm) {
+    start_thread = free_cta_hw_id * padded_cta_size;
+    end_thread = start_thread + cta_size;
+  } else {
+    start_thread = find_available_hwtid(padded_cta_size, true);
+    assert((int)start_thread != -1);
+    end_thread = start_thread + cta_size;
+    assert(m_occupied_cta_to_hwtid.find(free_cta_hw_id) ==
+           m_occupied_cta_to_hwtid.end());
+    m_occupied_cta_to_hwtid[free_cta_hw_id] = start_thread;
+  }
+
+  // reset the microarchitecture state of the selected hardware thread and warp
+  // contexts
+  reinit(start_thread, end_thread, false);
+
+  // initalize scalar threads and determine which hardware warps they are
+  // allocated to bind functional simulation state of threads to hardware
+  // resources (simulation)
+  warp_set_t warps;
+  unsigned nthreads_in_block = 0;
+  function_info *kernel_func_info = kernel.entry();
+  symbol_table *symtab = kernel_func_info->get_symtab();
+  unsigned ctaid = kernel.get_next_cta_id_single();
+  checkpoint *g_checkpoint = new checkpoint();
+  for (unsigned i = start_thread; i < end_thread; i++) {
+    m_threadState[i].m_cta_id = free_cta_hw_id;
+    unsigned warp_id = i / m_config->warp_size;
+    nthreads_in_block += ptx_sim_init_thread(
+        kernel, &m_thread[i], m_sid, i, cta_size - (i - start_thread),
+        m_config->n_thread_per_shader, this, free_cta_hw_id, warp_id,
+        m_cluster->get_gpu());
+    m_threadState[i].m_active = true;
+    // load thread local memory and register file
+    if (m_gpu->resume_option == 1 && kernel.get_uid() == m_gpu->resume_kernel &&
+        ctaid >= m_gpu->resume_CTA && ctaid < m_gpu->checkpoint_CTA_t) {
+      char fname[2048];
+      snprintf(fname, 2048, "checkpoint_files/thread_%d_%d_reg.txt",
+               i % cta_size, ctaid);
+      m_thread[i]->resume_reg_thread(fname, symtab);
+      char f1name[2048];
+      snprintf(f1name, 2048, "checkpoint_files/local_mem_thread_%d_%d_reg.txt",
+               i % cta_size, ctaid);
+      g_checkpoint->load_global_mem(m_thread[i]->m_local_mem, f1name);
     }
-    else {
-        start_thread = find_available_hwtid(padded_cta_size, true);
-        assert((int)start_thread != -1);
-        end_thread = start_thread + cta_size;
-        assert(m_occupied_cta_to_hwtid.find(free_cta_hw_id) == m_occupied_cta_to_hwtid.end());
-        m_occupied_cta_to_hwtid[free_cta_hw_id]= start_thread;
-    }
+    //
+    warps.set(warp_id);
+  }
+  assert(nthreads_in_block > 0 &&
+         nthreads_in_block <=
+             m_config->n_thread_per_shader);  // should be at least one, but
+                                              // less than max
+  m_cta_status[free_cta_hw_id] = nthreads_in_block;
 
-    // reset the microarchitecture state of the selected hardware thread and warp contexts
-    reinit(start_thread, end_thread,false);
-     
-    // initalize scalar threads and determine which hardware warps they are allocated to
-    // bind functional simulation state of threads to hardware resources (simulation) 
-    warp_set_t warps;
-    unsigned nthreads_in_block= 0;
-    function_info *kernel_func_info = kernel.entry();
-    symbol_table * symtab= kernel_func_info->get_symtab();
-    unsigned ctaid= kernel.get_next_cta_id_single();
-    checkpoint *g_checkpoint=  new checkpoint();
-    for (unsigned i = start_thread; i<end_thread; i++) {
-        m_threadState[i].m_cta_id = free_cta_hw_id;
-        unsigned warp_id = i/m_config->warp_size;
-        nthreads_in_block += ptx_sim_init_thread(kernel,&m_thread[i],m_sid,i,cta_size-(i-start_thread),m_config->n_thread_per_shader,this,free_cta_hw_id,warp_id,m_cluster->get_gpu());
-        m_threadState[i].m_active = true; 
-        // load thread local memory and register file
-        if(m_gpu->resume_option == 1 && kernel.get_uid() == m_gpu->resume_kernel && ctaid >= m_gpu->resume_CTA && ctaid < m_gpu->checkpoint_CTA_t )
-        {
-            char fname[2048];
-            snprintf(fname,2048,"checkpoint_files/thread_%d_%d_reg.txt",i%cta_size,ctaid );
-            m_thread[i]->resume_reg_thread(fname,symtab);
-            char f1name[2048];
-            snprintf(f1name,2048,"checkpoint_files/local_mem_thread_%d_%d_reg.txt",i%cta_size,ctaid);
-            g_checkpoint->load_global_mem(m_thread[i]->m_local_mem, f1name); 
-        }
-        //
-        warps.set( warp_id );
-    }
-    assert( nthreads_in_block > 0 && nthreads_in_block <= m_config->n_thread_per_shader); // should be at least one, but less than max
-    m_cta_status[free_cta_hw_id]=nthreads_in_block;
+  if (m_gpu->resume_option == 1 && kernel.get_uid() == m_gpu->resume_kernel &&
+      ctaid >= m_gpu->resume_CTA && ctaid < m_gpu->checkpoint_CTA_t) {
+    char f1name[2048];
+    snprintf(f1name, 2048, "checkpoint_files/shared_mem_%d.txt", ctaid);
 
-    if(m_gpu->resume_option == 1 && kernel.get_uid() == m_gpu->resume_kernel && ctaid >= m_gpu->resume_CTA && ctaid < m_gpu->checkpoint_CTA_t )
-    {
-        char f1name[2048];
-        snprintf(f1name,2048,"checkpoint_files/shared_mem_%d.txt", ctaid);
-        
-        g_checkpoint->load_global_mem(m_thread[start_thread]->m_shared_mem, f1name);  
-    }
-    // now that we know which warps are used in this CTA, we can allocate
-    // resources for use in CTA-wide barrier operations
-    m_barriers.allocate_barrier(free_cta_hw_id,warps);
+    g_checkpoint->load_global_mem(m_thread[start_thread]->m_shared_mem, f1name);
+  }
+  // now that we know which warps are used in this CTA, we can allocate
+  // resources for use in CTA-wide barrier operations
+  m_barriers.allocate_barrier(free_cta_hw_id, warps);
 
-    // initialize the SIMT stacks and fetch hardware
-    init_warps( free_cta_hw_id, start_thread, end_thread, ctaid, cta_size, kernel.get_uid());
-    m_n_active_cta++;
+  // initialize the SIMT stacks and fetch hardware
+  init_warps(free_cta_hw_id, start_thread, end_thread, ctaid, cta_size,
+             kernel.get_uid());
+  m_n_active_cta++;
 
-    shader_CTA_count_log(m_sid, 1);
-    SHADER_DPRINTF(LIVENESS, "GPGPU-Sim uArch: cta:%2u, start_tid:%4u, end_tid:%4u, initialized @(%lld,%lld)\n", 
-        free_cta_hw_id, start_thread, end_thread, m_gpu->gpu_sim_cycle, m_gpu->gpu_tot_sim_cycle );
-
+  shader_CTA_count_log(m_sid, 1);
+  SHADER_DPRINTF(LIVENESS,
+                 "GPGPU-Sim uArch: cta:%2u, start_tid:%4u, end_tid:%4u, "
+                 "initialized @(%lld,%lld)\n",
+                 free_cta_hw_id, start_thread, end_thread, m_gpu->gpu_sim_cycle,
+                 m_gpu->gpu_tot_sim_cycle);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-void dram_t::dram_log( int task ) 
-{
-   if (task == SAMPLELOG) {
-      StatAddSample(mrqq_Dist, que_length());   
-   } else if (task == DUMPLOG) {
-      printf ("Queue Length DRAM[%d] ",id);StatDisp(mrqq_Dist);
-   }
+void dram_t::dram_log(int task) {
+  if (task == SAMPLELOG) {
+    StatAddSample(mrqq_Dist, que_length());
+  } else if (task == DUMPLOG) {
+    printf("Queue Length DRAM[%d] ", id);
+    StatDisp(mrqq_Dist);
+  }
 }
 
-//Find next clock domain and increment its time
-int gpgpu_sim::next_clock_domain(void) 
-{
-   double smallest = min3(core_time,icnt_time,dram_time);
-   int mask = 0x00;
-   if ( l2_time <= smallest ) {
-      smallest = l2_time;
-      mask |= L2 ;
-      l2_time += m_config.l2_period;
-   }
-   if ( icnt_time <= smallest ) {
-      mask |= ICNT;
-      icnt_time += m_config.icnt_period;
-   }
-   if ( dram_time <= smallest ) {
-      mask |= DRAM;
-      dram_time += m_config.dram_period;
-   }
-   if ( core_time <= smallest ) {
-      mask |= CORE;
-      core_time += m_config.core_period;
-   }
-   return mask;
+// Find next clock domain and increment its time
+int gpgpu_sim::next_clock_domain(void) {
+  double smallest = min3(core_time, icnt_time, dram_time);
+  int mask = 0x00;
+  if (l2_time <= smallest) {
+    smallest = l2_time;
+    mask |= L2;
+    l2_time += m_config.l2_period;
+  }
+  if (icnt_time <= smallest) {
+    mask |= ICNT;
+    icnt_time += m_config.icnt_period;
+  }
+  if (dram_time <= smallest) {
+    mask |= DRAM;
+    dram_time += m_config.dram_period;
+  }
+  if (core_time <= smallest) {
+    mask |= CORE;
+    core_time += m_config.core_period;
+  }
+  return mask;
 }
 
-void gpgpu_sim::issue_block2core()
-{
-    unsigned last_issued = m_last_cluster_issue; 
-    for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) {
-        unsigned idx = (i + last_issued + 1) % m_shader_config->n_simt_clusters;
-        unsigned num = m_cluster[idx]->issue_block2core();
-        if( num ) {
-            m_last_cluster_issue=idx;
-            m_total_cta_launched += num;
-        }
+void gpgpu_sim::issue_block2core() {
+  unsigned last_issued = m_last_cluster_issue;
+  for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++) {
+    unsigned idx = (i + last_issued + 1) % m_shader_config->n_simt_clusters;
+    unsigned num = m_cluster[idx]->issue_block2core();
+    if (num) {
+      m_last_cluster_issue = idx;
+      m_total_cta_launched += num;
     }
+  }
 }
 
-unsigned long long g_single_step=0; // set this in gdb to single step the pipeline
+unsigned long long g_single_step =
+    0;  // set this in gdb to single step the pipeline
 
-void gpgpu_sim::cycle()
-{
-   int clock_mask = next_clock_domain();
+void gpgpu_sim::cycle() {
+  int clock_mask = next_clock_domain();
 
-   if (clock_mask & CORE ) {
-       // shader core loading (pop from ICNT into core) follows CORE clock
-      for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) 
-         m_cluster[i]->icnt_cycle(); 
-   }
-    unsigned partiton_replys_in_parallel_per_cycle = 0;
-    if (clock_mask & ICNT) {
-        // pop from memory controller to interconnect
-        for (unsigned i=0;i<m_memory_config->m_n_mem_sub_partition;i++) {
-            mem_fetch* mf = m_memory_sub_partition[i]->top();
-            if (mf) {
-                unsigned response_size = mf->get_is_write()?mf->get_ctrl_size():mf->size();
-                if ( ::icnt_has_buffer( m_shader_config->mem2device(i), response_size ) ) {
-                    //if (!mf->get_is_write())
-                       mf->set_return_timestamp(gpu_sim_cycle+gpu_tot_sim_cycle);
-                    mf->set_status(IN_ICNT_TO_SHADER,gpu_sim_cycle+gpu_tot_sim_cycle);
-                    ::icnt_push( m_shader_config->mem2device(i), mf->get_tpc(), mf, response_size );
-                    m_memory_sub_partition[i]->pop();
-                    partiton_replys_in_parallel_per_cycle++;
-                } else {
-                    gpu_stall_icnt2sh++;
-                }
-            } else {
-               m_memory_sub_partition[i]->pop();
-            }
+  if (clock_mask & CORE) {
+    // shader core loading (pop from ICNT into core) follows CORE clock
+    for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++)
+      m_cluster[i]->icnt_cycle();
+  }
+  unsigned partiton_replys_in_parallel_per_cycle = 0;
+  if (clock_mask & ICNT) {
+    // pop from memory controller to interconnect
+    for (unsigned i = 0; i < m_memory_config->m_n_mem_sub_partition; i++) {
+      mem_fetch *mf = m_memory_sub_partition[i]->top();
+      if (mf) {
+        unsigned response_size =
+            mf->get_is_write() ? mf->get_ctrl_size() : mf->size();
+        if (::icnt_has_buffer(m_shader_config->mem2device(i), response_size)) {
+          // if (!mf->get_is_write())
+          mf->set_return_timestamp(gpu_sim_cycle + gpu_tot_sim_cycle);
+          mf->set_status(IN_ICNT_TO_SHADER, gpu_sim_cycle + gpu_tot_sim_cycle);
+          ::icnt_push(m_shader_config->mem2device(i), mf->get_tpc(), mf,
+                      response_size);
+          m_memory_sub_partition[i]->pop();
+          partiton_replys_in_parallel_per_cycle++;
+        } else {
+          gpu_stall_icnt2sh++;
         }
+      } else {
+        m_memory_sub_partition[i]->pop();
+      }
     }
-    partiton_replys_in_parallel += partiton_replys_in_parallel_per_cycle;
+  }
+  partiton_replys_in_parallel += partiton_replys_in_parallel_per_cycle;
 
-   if (clock_mask & DRAM) {
-      for (unsigned i=0;i<m_memory_config->m_n_mem;i++){
-    	  if(m_memory_config->simple_dram_model)
-    		  m_memory_partition_unit[i]->simple_dram_model_cycle();
-    	  else
-    		  m_memory_partition_unit[i]->dram_cycle(); // Issue the dram command (scheduler + delay model)
-         // Update performance counters for DRAM
-         m_memory_partition_unit[i]->set_dram_power_stats(m_power_stats->pwr_mem_stat->n_cmd[CURRENT_STAT_IDX][i], m_power_stats->pwr_mem_stat->n_activity[CURRENT_STAT_IDX][i],
-                        m_power_stats->pwr_mem_stat->n_nop[CURRENT_STAT_IDX][i], m_power_stats->pwr_mem_stat->n_act[CURRENT_STAT_IDX][i], m_power_stats->pwr_mem_stat->n_pre[CURRENT_STAT_IDX][i],
-                        m_power_stats->pwr_mem_stat->n_rd[CURRENT_STAT_IDX][i], m_power_stats->pwr_mem_stat->n_wr[CURRENT_STAT_IDX][i], m_power_stats->pwr_mem_stat->n_req[CURRENT_STAT_IDX][i]);
+  if (clock_mask & DRAM) {
+    for (unsigned i = 0; i < m_memory_config->m_n_mem; i++) {
+      if (m_memory_config->simple_dram_model)
+        m_memory_partition_unit[i]->simple_dram_model_cycle();
+      else
+        m_memory_partition_unit[i]
+            ->dram_cycle();  // Issue the dram command (scheduler + delay model)
+      // Update performance counters for DRAM
+      m_memory_partition_unit[i]->set_dram_power_stats(
+          m_power_stats->pwr_mem_stat->n_cmd[CURRENT_STAT_IDX][i],
+          m_power_stats->pwr_mem_stat->n_activity[CURRENT_STAT_IDX][i],
+          m_power_stats->pwr_mem_stat->n_nop[CURRENT_STAT_IDX][i],
+          m_power_stats->pwr_mem_stat->n_act[CURRENT_STAT_IDX][i],
+          m_power_stats->pwr_mem_stat->n_pre[CURRENT_STAT_IDX][i],
+          m_power_stats->pwr_mem_stat->n_rd[CURRENT_STAT_IDX][i],
+          m_power_stats->pwr_mem_stat->n_wr[CURRENT_STAT_IDX][i],
+          m_power_stats->pwr_mem_stat->n_req[CURRENT_STAT_IDX][i]);
+    }
+  }
+
+  // L2 operations follow L2 clock domain
+  unsigned partiton_reqs_in_parallel_per_cycle = 0;
+  if (clock_mask & L2) {
+    m_power_stats->pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].clear();
+    for (unsigned i = 0; i < m_memory_config->m_n_mem_sub_partition; i++) {
+      // move memory request from interconnect into memory partition (if not
+      // backed up) Note:This needs to be called in DRAM clock domain if there is
+      // no L2 cache in the system In the worst case, we may need to push
+      // SECTOR_CHUNCK_SIZE requests, so ensure you have enough buffer for them
+      if (m_memory_sub_partition[i]->full(SECTOR_CHUNCK_SIZE)) {
+        gpu_stall_dramfull++;
+      } else {
+        mem_fetch *mf = (mem_fetch *)icnt_pop(m_shader_config->mem2device(i));
+        m_memory_sub_partition[i]->push(mf, gpu_sim_cycle + gpu_tot_sim_cycle);
+        if (mf) partiton_reqs_in_parallel_per_cycle++;
       }
-   }
+      m_memory_sub_partition[i]->cache_cycle(gpu_sim_cycle + gpu_tot_sim_cycle);
+      m_memory_sub_partition[i]->accumulate_L2cache_stats(
+          m_power_stats->pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX]);
+    }
+  }
+  partiton_reqs_in_parallel += partiton_reqs_in_parallel_per_cycle;
+  if (partiton_reqs_in_parallel_per_cycle > 0) {
+    partiton_reqs_in_parallel_util += partiton_reqs_in_parallel_per_cycle;
+    gpu_sim_cycle_parition_util++;
+  }
 
-   // L2 operations follow L2 clock domain
-   unsigned partiton_reqs_in_parallel_per_cycle = 0;
-   if (clock_mask & L2) {
-       m_power_stats->pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].clear();
-      for (unsigned i=0;i<m_memory_config->m_n_mem_sub_partition;i++) {
-          //move memory request from interconnect into memory partition (if not backed up)
-          //Note:This needs to be called in DRAM clock domain if there is no L2 cache in the system
-    	  //In the worst case, we may need to push SECTOR_CHUNCK_SIZE requests, so ensure you have enough buffer for them
-          if ( m_memory_sub_partition[i]->full(SECTOR_CHUNCK_SIZE) ) {
-             gpu_stall_dramfull++;
-          } else {
-              mem_fetch* mf = (mem_fetch*) icnt_pop( m_shader_config->mem2device(i) );
-              m_memory_sub_partition[i]->push( mf, gpu_sim_cycle + gpu_tot_sim_cycle );
-              if(mf)
-            	  partiton_reqs_in_parallel_per_cycle++;
-          }
-          m_memory_sub_partition[i]->cache_cycle(gpu_sim_cycle+gpu_tot_sim_cycle);
-          m_memory_sub_partition[i]->accumulate_L2cache_stats(m_power_stats->pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX]);
-       }
-   }
-   partiton_reqs_in_parallel += partiton_reqs_in_parallel_per_cycle;
-   if(partiton_reqs_in_parallel_per_cycle > 0){
-	   partiton_reqs_in_parallel_util += partiton_reqs_in_parallel_per_cycle;
-	   gpu_sim_cycle_parition_util++;
-   }
+  if (clock_mask & ICNT) {
+    icnt_transfer();
+  }
 
-   if (clock_mask & ICNT) {
-      icnt_transfer();
-   }
-
-   if (clock_mask & CORE) {
-      // L1 cache + shader core pipeline stages
-      m_power_stats->pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].clear();
-      for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) {
-         if (m_cluster[i]->get_not_completed() || get_more_cta_left() ) {
-               m_cluster[i]->core_cycle();
-               *active_sms+=m_cluster[i]->get_n_active_sms();
-         }
-         // Update core icnt/cache stats for GPUWattch
-         m_cluster[i]->get_icnt_stats(m_power_stats->pwr_mem_stat->n_simt_to_mem[CURRENT_STAT_IDX][i], m_power_stats->pwr_mem_stat->n_mem_to_simt[CURRENT_STAT_IDX][i]);
-         m_cluster[i]->get_cache_stats(m_power_stats->pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX]);
-         m_cluster[i]->get_current_occupancy(gpu_occupancy.aggregate_warp_slot_filled, gpu_occupancy.aggregate_theoretical_warp_slots);
-
+  if (clock_mask & CORE) {
+    // L1 cache + shader core pipeline stages
+    m_power_stats->pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].clear();
+    for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++) {
+      if (m_cluster[i]->get_not_completed() || get_more_cta_left()) {
+        m_cluster[i]->core_cycle();
+        *active_sms += m_cluster[i]->get_n_active_sms();
       }
-      float temp=0;
-      for (unsigned i=0;i<m_shader_config->num_shader();i++){
-        temp+=m_shader_stats->m_pipeline_duty_cycle[i];
-      }
-      temp=temp/m_shader_config->num_shader();
-      *average_pipeline_duty_cycle=((*average_pipeline_duty_cycle)+temp);
-        //cout<<"Average pipeline duty cycle: "<<*average_pipeline_duty_cycle<<endl;
+      // Update core icnt/cache stats for GPUWattch
+      m_cluster[i]->get_icnt_stats(
+          m_power_stats->pwr_mem_stat->n_simt_to_mem[CURRENT_STAT_IDX][i],
+          m_power_stats->pwr_mem_stat->n_mem_to_simt[CURRENT_STAT_IDX][i]);
+      m_cluster[i]->get_cache_stats(
+          m_power_stats->pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX]);
+      m_cluster[i]->get_current_occupancy(
+          gpu_occupancy.aggregate_warp_slot_filled,
+          gpu_occupancy.aggregate_theoretical_warp_slots);
+    }
+    float temp = 0;
+    for (unsigned i = 0; i < m_shader_config->num_shader(); i++) {
+      temp += m_shader_stats->m_pipeline_duty_cycle[i];
+    }
+    temp = temp / m_shader_config->num_shader();
+    *average_pipeline_duty_cycle = ((*average_pipeline_duty_cycle) + temp);
+    // cout<<"Average pipeline duty cycle:
+    // "<<*average_pipeline_duty_cycle<<endl;
 
+    if (g_single_step &&
+        ((gpu_sim_cycle + gpu_tot_sim_cycle) >= g_single_step)) {
+      raise(SIGTRAP);  // Debug breakpoint
+    }
+    gpu_sim_cycle++;
 
-      if( g_single_step && ((gpu_sim_cycle+gpu_tot_sim_cycle) >= g_single_step) ) {
-          raise(SIGTRAP); // Debug breakpoint
-      }
-	 gpu_sim_cycle++;
-	
-      if( g_interactive_debugger_enabled ) 
-         gpgpu_debug();
+    if (g_interactive_debugger_enabled) gpgpu_debug();
 
       // McPAT main cycle (interface with McPAT)
 #ifdef GPGPUSIM_POWER_MODEL
-      if(m_config.g_power_simulation_enabled){
-          mcpat_cycle(m_config, getShaderCoreConfig(), m_gpgpusim_wrapper, m_power_stats, m_config.gpu_stat_sample_freq, gpu_tot_sim_cycle, gpu_sim_cycle, gpu_tot_sim_insn, gpu_sim_insn);
-      }
+    if (m_config.g_power_simulation_enabled) {
+      mcpat_cycle(m_config, getShaderCoreConfig(), m_gpgpusim_wrapper,
+                  m_power_stats, m_config.gpu_stat_sample_freq,
+                  gpu_tot_sim_cycle, gpu_sim_cycle, gpu_tot_sim_insn,
+                  gpu_sim_insn);
+    }
 #endif
 
-      issue_block2core();
-      
-      // Depending on configuration, invalidate the caches once all of threads are completed.
-      int all_threads_complete = 1;
-      if (m_config.gpgpu_flush_l1_cache) {
-         for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) {
-            if (m_cluster[i]->get_not_completed() == 0)
-                m_cluster[i]->cache_invalidate();
-            else
-               all_threads_complete = 0 ;
-         }
-      }
+    issue_block2core();
 
-      if(m_config.gpgpu_flush_l2_cache){
-          if(!m_config.gpgpu_flush_l1_cache){
-              for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) {
-                  if (m_cluster[i]->get_not_completed() != 0){
-                      all_threads_complete = 0 ;
-                      break;
-                  }
-              }
+    // Depending on configuration, invalidate the caches once all of threads are
+    // completed.
+    int all_threads_complete = 1;
+    if (m_config.gpgpu_flush_l1_cache) {
+      for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++) {
+        if (m_cluster[i]->get_not_completed() == 0)
+          m_cluster[i]->cache_invalidate();
+        else
+          all_threads_complete = 0;
+      }
+    }
+
+    if (m_config.gpgpu_flush_l2_cache) {
+      if (!m_config.gpgpu_flush_l1_cache) {
+        for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++) {
+          if (m_cluster[i]->get_not_completed() != 0) {
+            all_threads_complete = 0;
+            break;
           }
-
-         if (all_threads_complete && !m_memory_config->m_L2_config.disabled() ) {
-            printf("Flushed L2 caches...\n");
-            if (m_memory_config->m_L2_config.get_num_lines()) {
-               int dlc = 0;
-               for (unsigned i=0;i<m_memory_config->m_n_mem;i++) {
-                  dlc = m_memory_sub_partition[i]->flushL2();
-                  assert (dlc == 0); // TODO: need to model actual writes to DRAM here
-                  printf("Dirty lines flushed from L2 %d is %d\n", i, dlc  );
-               }
-            }
-         }
+        }
       }
 
-      if (!(gpu_sim_cycle % m_config.gpu_stat_sample_freq)) {
-         time_t days, hrs, minutes, sec;
-         time_t curr_time;
-         time(&curr_time);
-         unsigned long long  elapsed_time = MAX(curr_time - gpgpu_ctx->the_gpgpusim->g_simulation_starttime, 1);
-         if ( (elapsed_time - last_liveness_message_time) >= m_config.liveness_message_freq && DTRACE(LIVENESS) ) {
-            days    = elapsed_time/(3600*24);
-            hrs     = elapsed_time/3600 - 24*days;
-            minutes = elapsed_time/60 - 60*(hrs + 24*days);
-            sec = elapsed_time - 60*(minutes + 60*(hrs + 24*days));
-            
-            unsigned long long active = 0, total = 0;
-            for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) {
-                m_cluster[i]->get_current_occupancy(active, total);
-            }
-            DPRINTFG(LIVENESS, "uArch: inst.: %lld (ipc=%4.1f, occ=%0.4f\% [%llu / %llu]) sim_rate=%u (inst/sec) elapsed = %u:%u:%02u:%02u / %s",
-                   gpu_tot_sim_insn + gpu_sim_insn, 
-                   (double)gpu_sim_insn/(double)gpu_sim_cycle,
-                   float(active)/float(total) * 100, active, total,
-                   (unsigned)((gpu_tot_sim_insn+gpu_sim_insn) / elapsed_time),
-                   (unsigned)days,(unsigned)hrs,(unsigned)minutes,(unsigned)sec,
-                   ctime(&curr_time));
-            fflush(stdout);
-            last_liveness_message_time = elapsed_time; 
-         }
-         visualizer_printstat();
-         m_memory_stats->memlatstat_lat_pw();
-         if (m_config.gpgpu_runtime_stat && (m_config.gpu_runtime_stat_flag != 0) ) {
-            if (m_config.gpu_runtime_stat_flag & GPU_RSTAT_BW_STAT) {
-               for (unsigned i=0;i<m_memory_config->m_n_mem;i++) 
-                  m_memory_partition_unit[i]->print_stat(stdout);
-               printf("maxmrqlatency = %d \n", m_memory_stats->max_mrq_latency);
-               printf("maxmflatency = %d \n", m_memory_stats->max_mf_latency);
-            }
-            if (m_config.gpu_runtime_stat_flag & GPU_RSTAT_SHD_INFO) 
-               shader_print_runtime_stat( stdout );
-            if (m_config.gpu_runtime_stat_flag & GPU_RSTAT_L1MISS) 
-               shader_print_l1_miss_stat( stdout );
-            if (m_config.gpu_runtime_stat_flag & GPU_RSTAT_SCHED) 
-               shader_print_scheduler_stat( stdout, false );
-         }
+      if (all_threads_complete && !m_memory_config->m_L2_config.disabled()) {
+        printf("Flushed L2 caches...\n");
+        if (m_memory_config->m_L2_config.get_num_lines()) {
+          int dlc = 0;
+          for (unsigned i = 0; i < m_memory_config->m_n_mem; i++) {
+            dlc = m_memory_sub_partition[i]->flushL2();
+            assert(dlc == 0);  // TODO: need to model actual writes to DRAM here
+            printf("Dirty lines flushed from L2 %d is %d\n", i, dlc);
+          }
+        }
       }
+    }
 
-      if (!(gpu_sim_cycle % 50000)) {
-         // deadlock detection 
-         if (m_config.gpu_deadlock_detect && gpu_sim_insn == last_gpu_sim_insn) {
-            gpu_deadlock = true;
-         } else {
-            last_gpu_sim_insn = gpu_sim_insn;
-         }
+    if (!(gpu_sim_cycle % m_config.gpu_stat_sample_freq)) {
+      time_t days, hrs, minutes, sec;
+      time_t curr_time;
+      time(&curr_time);
+      unsigned long long elapsed_time =
+          MAX(curr_time - gpgpu_ctx->the_gpgpusim->g_simulation_starttime, 1);
+      if ((elapsed_time - last_liveness_message_time) >=
+              m_config.liveness_message_freq &&
+          DTRACE(LIVENESS)) {
+        days = elapsed_time / (3600 * 24);
+        hrs = elapsed_time / 3600 - 24 * days;
+        minutes = elapsed_time / 60 - 60 * (hrs + 24 * days);
+        sec = elapsed_time - 60 * (minutes + 60 * (hrs + 24 * days));
+
+        unsigned long long active = 0, total = 0;
+        for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++) {
+          m_cluster[i]->get_current_occupancy(active, total);
+        }
+        DPRINTFG(LIVENESS,
+                 "uArch: inst.: %lld (ipc=%4.1f, occ=%0.4f\% [%llu / %llu]) "
+                 "sim_rate=%u (inst/sec) elapsed = %u:%u:%02u:%02u / %s",
+                 gpu_tot_sim_insn + gpu_sim_insn,
+                 (double)gpu_sim_insn / (double)gpu_sim_cycle,
+                 float(active) / float(total) * 100, active, total,
+                 (unsigned)((gpu_tot_sim_insn + gpu_sim_insn) / elapsed_time),
+                 (unsigned)days, (unsigned)hrs, (unsigned)minutes,
+                 (unsigned)sec, ctime(&curr_time));
+        fflush(stdout);
+        last_liveness_message_time = elapsed_time;
       }
-      try_snap_shot(gpu_sim_cycle);
-      spill_log_to_file (stdout, 0, gpu_sim_cycle);
+      visualizer_printstat();
+      m_memory_stats->memlatstat_lat_pw();
+      if (m_config.gpgpu_runtime_stat &&
+          (m_config.gpu_runtime_stat_flag != 0)) {
+        if (m_config.gpu_runtime_stat_flag & GPU_RSTAT_BW_STAT) {
+          for (unsigned i = 0; i < m_memory_config->m_n_mem; i++)
+            m_memory_partition_unit[i]->print_stat(stdout);
+          printf("maxmrqlatency = %d \n", m_memory_stats->max_mrq_latency);
+          printf("maxmflatency = %d \n", m_memory_stats->max_mf_latency);
+        }
+        if (m_config.gpu_runtime_stat_flag & GPU_RSTAT_SHD_INFO)
+          shader_print_runtime_stat(stdout);
+        if (m_config.gpu_runtime_stat_flag & GPU_RSTAT_L1MISS)
+          shader_print_l1_miss_stat(stdout);
+        if (m_config.gpu_runtime_stat_flag & GPU_RSTAT_SCHED)
+          shader_print_scheduler_stat(stdout, false);
+      }
+    }
+
+    if (!(gpu_sim_cycle % 50000)) {
+      // deadlock detection
+      if (m_config.gpu_deadlock_detect && gpu_sim_insn == last_gpu_sim_insn) {
+        gpu_deadlock = true;
+      } else {
+        last_gpu_sim_insn = gpu_sim_insn;
+      }
+    }
+    try_snap_shot(gpu_sim_cycle);
+    spill_log_to_file(stdout, 0, gpu_sim_cycle);
 
 #if (CUDART_VERSION >= 5000)
-      //launch device kernel
-      gpgpu_ctx->device_runtime->launch_one_device_kernel();
+    // launch device kernel
+    gpgpu_ctx->device_runtime->launch_one_device_kernel();
 #endif
-   }
+  }
 }
 
-
-void shader_core_ctx::dump_warp_state( FILE *fout ) const
-{
-   fprintf(fout, "\n");
-   fprintf(fout, "per warp functional simulation status:\n");
-   for (unsigned w=0; w < m_config->max_warps_per_shader; w++ ) 
-       m_warp[w].print(fout);
+void shader_core_ctx::dump_warp_state(FILE *fout) const {
+  fprintf(fout, "\n");
+  fprintf(fout, "per warp functional simulation status:\n");
+  for (unsigned w = 0; w < m_config->max_warps_per_shader; w++)
+    m_warp[w].print(fout);
 }
 
+void gpgpu_sim::perf_memcpy_to_gpu(size_t dst_start_addr, size_t count) {
+  if (m_memory_config->m_perf_sim_memcpy) {
+    assert(dst_start_addr % 32 == 0);
 
-void gpgpu_sim::perf_memcpy_to_gpu( size_t dst_start_addr, size_t count )
-{
-    if (m_memory_config->m_perf_sim_memcpy) {
-       assert (dst_start_addr % 32 == 0);
-
-       for ( unsigned counter = 0; counter < count; counter += 32 ) {
-           const unsigned wr_addr = dst_start_addr + counter;
-           addrdec_t raw_addr;
-           mem_access_sector_mask_t mask;
-           mask.set(wr_addr % 128 / 32);
-           m_memory_config->m_address_mapping.addrdec_tlx( wr_addr, &raw_addr );
-           const unsigned partition_id = raw_addr.sub_partition / m_memory_config->m_n_sub_partition_per_memory_channel;
-           m_memory_partition_unit[ partition_id ]->handle_memcpy_to_gpu( wr_addr, raw_addr.sub_partition, mask );
-       }
+    for (unsigned counter = 0; counter < count; counter += 32) {
+      const unsigned wr_addr = dst_start_addr + counter;
+      addrdec_t raw_addr;
+      mem_access_sector_mask_t mask;
+      mask.set(wr_addr % 128 / 32);
+      m_memory_config->m_address_mapping.addrdec_tlx(wr_addr, &raw_addr);
+      const unsigned partition_id =
+          raw_addr.sub_partition /
+          m_memory_config->m_n_sub_partition_per_memory_channel;
+      m_memory_partition_unit[partition_id]->handle_memcpy_to_gpu(
+          wr_addr, raw_addr.sub_partition, mask);
     }
+  }
 }
 
-void gpgpu_sim::dump_pipeline( int mask, int s, int m ) const
-{
-/*
-   You may want to use this function while running GPGPU-Sim in gdb.
-   One way to do that is add the following to your .gdbinit file:
- 
-      define dp
-         call g_the_gpu.dump_pipeline_impl((0x40|0x4|0x1),$arg0,0)
-      end
- 
-   Then, typing "dp 3" will show the contents of the pipeline for shader core 3.
-*/
+void gpgpu_sim::dump_pipeline(int mask, int s, int m) const {
+  /*
+     You may want to use this function while running GPGPU-Sim in gdb.
+     One way to do that is add the following to your .gdbinit file:
 
-   printf("Dumping pipeline state...\n");
-   if(!mask) mask = 0xFFFFFFFF;
-   for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) {
-      if(s != -1) {
-         i = s;
+        define dp
+           call g_the_gpu.dump_pipeline_impl((0x40|0x4|0x1),$arg0,0)
+        end
+
+     Then, typing "dp 3" will show the contents of the pipeline for shader
+     core 3.
+  */
+
+  printf("Dumping pipeline state...\n");
+  if (!mask) mask = 0xFFFFFFFF;
+  for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++) {
+    if (s != -1) {
+      i = s;
+    }
+    if (mask & 1)
+      m_cluster[m_shader_config->sid_to_cluster(i)]->display_pipeline(
+          i, stdout, 1, mask & 0x2E);
+    if (s != -1) {
+      break;
+    }
+  }
+  if (mask & 0x10000) {
+    for (unsigned i = 0; i < m_memory_config->m_n_mem; i++) {
+      if (m != -1) {
+        i = m;
       }
-      if(mask&1) m_cluster[m_shader_config->sid_to_cluster(i)]->display_pipeline(i,stdout,1,mask & 0x2E);
-      if(s != -1) {
-         break;
+      printf("DRAM / memory controller %u:\n", i);
+      if (mask & 0x100000) m_memory_partition_unit[i]->print_stat(stdout);
+      if (mask & 0x1000000) m_memory_partition_unit[i]->visualize();
+      if (mask & 0x10000000) m_memory_partition_unit[i]->print(stdout);
+      if (m != -1) {
+        break;
       }
-   }
-   if(mask&0x10000) {
-      for (unsigned i=0;i<m_memory_config->m_n_mem;i++) {
-         if(m != -1) {
-            i=m;
-         }
-         printf("DRAM / memory controller %u:\n", i);
-         if(mask&0x100000) m_memory_partition_unit[i]->print_stat(stdout);
-         if(mask&0x1000000)   m_memory_partition_unit[i]->visualize();
-         if(mask&0x10000000)   m_memory_partition_unit[i]->print(stdout);
-         if(m != -1) {
-            break;
-         }
-      }
-   }
-   fflush(stdout);
+    }
+  }
+  fflush(stdout);
 }
 
-const shader_core_config * gpgpu_sim::getShaderCoreConfig()
-{
-   return m_shader_config;
+const shader_core_config *gpgpu_sim::getShaderCoreConfig() {
+  return m_shader_config;
 }
 
-const memory_config * gpgpu_sim::getMemoryConfig()
-{
-   return m_memory_config;
-}
+const memory_config *gpgpu_sim::getMemoryConfig() { return m_memory_config; }
 
-simt_core_cluster * gpgpu_sim::getSIMTCluster()
-{
-   return *m_cluster;
-}
-
+simt_core_cluster *gpgpu_sim::getSIMTCluster() { return *m_cluster; }

--- a/src/gpgpu-sim/gpu-sim.cc
+++ b/src/gpgpu-sim/gpu-sim.cc
@@ -8,14 +8,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -26,51 +28,49 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
 #include "gpu-sim.h"
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <math.h>
 #include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include "zlib.h"
 
-
-#include "shader.h"
-#include "shader_trace.h"
 #include "dram.h"
 #include "mem_fetch.h"
+#include "shader.h"
+#include "shader_trace.h"
 
 #include <time.h>
+#include "addrdec.h"
+#include "delayqueue.h"
+#include "dram.h"
 #include "gpu-cache.h"
 #include "gpu-misc.h"
-#include "delayqueue.h"
-#include "shader.h"
 #include "icnt_wrapper.h"
-#include "dram.h"
-#include "addrdec.h"
-#include "stat-tool.h"
 #include "l2cache.h"
+#include "shader.h"
+#include "stat-tool.h"
 
-#include "../cuda-sim/ptx-stats.h"
-#include "../statwrapper.h"
+#include "../../libcuda/gpgpu_context.h"
 #include "../abstract_hardware_model.h"
+#include "../cuda-sim/cuda-sim.h"
+#include "../cuda-sim/cuda_device_runtime.h"
+#include "../cuda-sim/ptx-stats.h"
+#include "../cuda-sim/ptx_ir.h"
 #include "../debug.h"
 #include "../gpgpusim_entrypoint.h"
-#include "../cuda-sim/cuda-sim.h"
-#include "../cuda-sim/ptx_ir.h"
+#include "../statwrapper.h"
 #include "../trace.h"
 #include "mem_latency_stat.h"
 #include "power_stat.h"
-#include "visualizer.h"
 #include "stats.h"
-#include "../cuda-sim/cuda_device_runtime.h"
-#include "../../libcuda/gpgpu_context.h"
+#include "visualizer.h"
 
 #ifdef GPGPUSIM_POWER_MODEL
 #include "power_interface.h"
 #else
-class  gpgpu_sim_wrapper {};
+class gpgpu_sim_wrapper {};
 #endif
 
 #include <stdio.h>
@@ -79,1781 +79,1915 @@ class  gpgpu_sim_wrapper {};
 #include <sstream>
 #include <string>
 
-#define MAX(a,b) (((a)>(b))?(a):(b))
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
 
+bool g_interactive_debugger_enabled = false;
 
-bool g_interactive_debugger_enabled=false;
-
-tr1_hash_map<new_addr_type,unsigned> address_random_interleaving;
+tr1_hash_map<new_addr_type, unsigned> address_random_interleaving;
 
 /* Clock Domains */
 
-#define  CORE  0x01
-#define  L2    0x02
-#define  DRAM  0x04
-#define  ICNT  0x08  
-
+#define CORE 0x01
+#define L2 0x02
+#define DRAM 0x04
+#define ICNT 0x08
 
 #define MEM_LATENCY_STAT_IMPL
 
-
 #include "mem_latency_stat.h"
 
-void power_config::reg_options(class OptionParser * opp)
-{
+void power_config::reg_options(class OptionParser *opp) {
+  option_parser_register(opp, "-gpuwattch_xml_file", OPT_CSTR,
+                         &g_power_config_name, "GPUWattch XML file",
+                         "gpuwattch.xml");
 
+  option_parser_register(opp, "-power_simulation_enabled", OPT_BOOL,
+                         &g_power_simulation_enabled,
+                         "Turn on power simulator (1=On, 0=Off)", "0");
 
-	  option_parser_register(opp, "-gpuwattch_xml_file", OPT_CSTR,
-			  	  	  	  	 &g_power_config_name,"GPUWattch XML file",
-	                   "gpuwattch.xml");
+  option_parser_register(opp, "-power_per_cycle_dump", OPT_BOOL,
+                         &g_power_per_cycle_dump,
+                         "Dump detailed power output each cycle", "0");
 
-	   option_parser_register(opp, "-power_simulation_enabled", OPT_BOOL,
-	                          &g_power_simulation_enabled, "Turn on power simulator (1=On, 0=Off)",
-	                          "0");
+  // Output Data Formats
+  option_parser_register(
+      opp, "-power_trace_enabled", OPT_BOOL, &g_power_trace_enabled,
+      "produce a file for the power trace (1=On, 0=Off)", "0");
 
-	   option_parser_register(opp, "-power_per_cycle_dump", OPT_BOOL,
-	                          &g_power_per_cycle_dump, "Dump detailed power output each cycle",
-	                          "0");
+  option_parser_register(
+      opp, "-power_trace_zlevel", OPT_INT32, &g_power_trace_zlevel,
+      "Compression level of the power trace output log (0=no comp, 9=highest)",
+      "6");
 
-	   // Output Data Formats
-	   option_parser_register(opp, "-power_trace_enabled", OPT_BOOL,
-	                          &g_power_trace_enabled, "produce a file for the power trace (1=On, 0=Off)",
-	                          "0");
+  option_parser_register(
+      opp, "-steady_power_levels_enabled", OPT_BOOL,
+      &g_steady_power_levels_enabled,
+      "produce a file for the steady power levels (1=On, 0=Off)", "0");
 
-	   option_parser_register(opp, "-power_trace_zlevel", OPT_INT32,
-	                          &g_power_trace_zlevel, "Compression level of the power trace output log (0=no comp, 9=highest)",
-	                          "6");
-
-	   option_parser_register(opp, "-steady_power_levels_enabled", OPT_BOOL,
-	                          &g_steady_power_levels_enabled, "produce a file for the steady power levels (1=On, 0=Off)",
-	                          "0");
-
-	   option_parser_register(opp, "-steady_state_definition", OPT_CSTR,
-			   	  &gpu_steady_state_definition, "allowed deviation:number of samples",
-	                 	  "8:4");
-
+  option_parser_register(opp, "-steady_state_definition", OPT_CSTR,
+                         &gpu_steady_state_definition,
+                         "allowed deviation:number of samples", "8:4");
 }
 
-void memory_config::reg_options(class OptionParser * opp)
-{
-    option_parser_register(opp, "-perf_sim_memcpy", OPT_BOOL, &m_perf_sim_memcpy, 
-                                "Fill the L2 cache on memcpy", "1");
-    option_parser_register(opp, "-simple_dram_model", OPT_BOOL, &simple_dram_model,
-                                "simple_dram_model with fixed latency and BW", "0");
-    option_parser_register(opp, "-gpgpu_dram_scheduler", OPT_INT32, &scheduler_type, 
-                                "0 = fifo, 1 = FR-FCFS (defaul)", "1");
-    option_parser_register(opp, "-gpgpu_dram_partition_queues", OPT_CSTR, &gpgpu_L2_queue_config, 
-                           "i2$:$2d:d2$:$2i",
-                           "8:8:8:8");
+void memory_config::reg_options(class OptionParser *opp) {
+  option_parser_register(opp, "-perf_sim_memcpy", OPT_BOOL, &m_perf_sim_memcpy,
+                         "Fill the L2 cache on memcpy", "1");
+  option_parser_register(opp, "-simple_dram_model", OPT_BOOL,
+                         &simple_dram_model,
+                         "simple_dram_model with fixed latency and BW", "0");
+  option_parser_register(opp, "-gpgpu_dram_scheduler", OPT_INT32,
+                         &scheduler_type, "0 = fifo, 1 = FR-FCFS (defaul)",
+                         "1");
+  option_parser_register(opp, "-gpgpu_dram_partition_queues", OPT_CSTR,
+                         &gpgpu_L2_queue_config, "i2$:$2d:d2$:$2i", "8:8:8:8");
 
-    option_parser_register(opp, "-l2_ideal", OPT_BOOL, &l2_ideal, 
-                           "Use a ideal L2 cache that always hit",
-                           "0");
-    option_parser_register(opp, "-gpgpu_cache:dl2", OPT_CSTR, &m_L2_config.m_config_string, 
-                   "unified banked L2 data cache config "
-                   " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_alloc>,<mshr>:<N>:<merge>,<mq>}",
-                   "64:128:8,L:B:m:N,A:16:4,4");
-    option_parser_register(opp, "-gpgpu_cache:dl2_texture_only", OPT_BOOL, &m_L2_texure_only, 
-                           "L2 cache used for texture only",
-                           "1");
-    option_parser_register(opp, "-gpgpu_n_mem", OPT_UINT32, &m_n_mem, 
-                 "number of memory modules (e.g. memory controllers) in gpu",
-                 "8");
-    option_parser_register(opp, "-gpgpu_n_sub_partition_per_mchannel", OPT_UINT32, &m_n_sub_partition_per_memory_channel, 
-                 "number of memory subpartition in each memory module",
-                 "1");
-    option_parser_register(opp, "-gpgpu_n_mem_per_ctrlr", OPT_UINT32, &gpu_n_mem_per_ctrlr, 
-                 "number of memory chips per memory controller",
-                 "1");
-    option_parser_register(opp, "-gpgpu_memlatency_stat", OPT_INT32, &gpgpu_memlatency_stat, 
-                "track and display latency statistics 0x2 enables MC, 0x4 enables queue logs",
-                "0");
-    option_parser_register(opp, "-gpgpu_frfcfs_dram_sched_queue_size", OPT_INT32, &gpgpu_frfcfs_dram_sched_queue_size, 
-                "0 = unlimited (default); # entries per chip",
-                "0");
-    option_parser_register(opp, "-gpgpu_dram_return_queue_size", OPT_INT32, &gpgpu_dram_return_queue_size, 
-                "0 = unlimited (default); # entries per chip",
-                "0");
-    option_parser_register(opp, "-gpgpu_dram_buswidth", OPT_UINT32, &busW, 
-                 "default = 4 bytes (8 bytes per cycle at DDR)",
-                 "4");
-    option_parser_register(opp, "-gpgpu_dram_burst_length", OPT_UINT32, &BL, 
-                 "Burst length of each DRAM request (default = 4 data bus cycle)",
-                 "4");
-    option_parser_register(opp, "-dram_data_command_freq_ratio", OPT_UINT32, &data_command_freq_ratio, 
-                 "Frequency ratio between DRAM data bus and command bus (default = 2 times, i.e. DDR)",
-                 "2");
-    option_parser_register(opp, "-gpgpu_dram_timing_opt", OPT_CSTR, &gpgpu_dram_timing_opt, 
-                "DRAM timing parameters = {nbk:tCCD:tRRD:tRCD:tRAS:tRP:tRC:CL:WL:tCDLR:tWR:nbkgrp:tCCDL:tRTPL}",
-                "4:2:8:12:21:13:34:9:4:5:13:1:0:0");
-    option_parser_register(opp, "-rop_latency", OPT_UINT32, &rop_latency,
-                     "ROP queue latency (default 85)",
-                     "85");
-    option_parser_register(opp, "-dram_latency", OPT_UINT32, &dram_latency,
-                     "DRAM latency (default 30)",
-                     "30");
-    option_parser_register(opp, "-dual_bus_interface", OPT_UINT32, &dual_bus_interface,
-                                        "dual_bus_interface (default = 0) ",
-                                        "0");
-    option_parser_register(opp, "-dram_bnk_indexing_policy", OPT_UINT32, &dram_bnk_indexing_policy,
-                                            "dram_bnk_indexing_policy (0 = normal indexing, 1 = Xoring with the higher bits) (Default = 0)",
-                                            "0");
-    option_parser_register(opp, "-dram_bnkgrp_indexing_policy", OPT_UINT32, &dram_bnkgrp_indexing_policy,
-                                            "dram_bnkgrp_indexing_policy (0 = take higher bits, 1 = take lower bits) (Default = 0)",
-                                            "0");
-    option_parser_register(opp, "-Seperate_Write_Queue_Enable", OPT_BOOL, &seperate_write_queue_enabled,
-                           "Seperate_Write_Queue_Enable",
-                           "0");
-    option_parser_register(opp, "-Write_Queue_Size", OPT_CSTR, &write_queue_size_opt,
-                                  "Write_Queue_Size",
-                                  "32:28:16");
-    option_parser_register(opp, "-Elimnate_rw_turnaround", OPT_BOOL, &elimnate_rw_turnaround,
-                               "elimnate_rw_turnaround i.e set tWTR and tRTW = 0",
-                               "0");
-    option_parser_register(opp, "-icnt_flit_size", OPT_UINT32, &icnt_flit_size,
-                               "icnt_flit_size",
-                               "32");
-    m_address_mapping.addrdec_setoption(opp);
+  option_parser_register(opp, "-l2_ideal", OPT_BOOL, &l2_ideal,
+                         "Use a ideal L2 cache that always hit", "0");
+  option_parser_register(opp, "-gpgpu_cache:dl2", OPT_CSTR,
+                         &m_L2_config.m_config_string,
+                         "unified banked L2 data cache config "
+                         " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_"
+                         "alloc>,<mshr>:<N>:<merge>,<mq>}",
+                         "64:128:8,L:B:m:N,A:16:4,4");
+  option_parser_register(opp, "-gpgpu_cache:dl2_texture_only", OPT_BOOL,
+                         &m_L2_texure_only, "L2 cache used for texture only",
+                         "1");
+  option_parser_register(
+      opp, "-gpgpu_n_mem", OPT_UINT32, &m_n_mem,
+      "number of memory modules (e.g. memory controllers) in gpu", "8");
+  option_parser_register(opp, "-gpgpu_n_sub_partition_per_mchannel", OPT_UINT32,
+                         &m_n_sub_partition_per_memory_channel,
+                         "number of memory subpartition in each memory module",
+                         "1");
+  option_parser_register(opp, "-gpgpu_n_mem_per_ctrlr", OPT_UINT32,
+                         &gpu_n_mem_per_ctrlr,
+                         "number of memory chips per memory controller", "1");
+  option_parser_register(opp, "-gpgpu_memlatency_stat", OPT_INT32,
+                         &gpgpu_memlatency_stat,
+                         "track and display latency statistics 0x2 enables MC, "
+                         "0x4 enables queue logs",
+                         "0");
+  option_parser_register(opp, "-gpgpu_frfcfs_dram_sched_queue_size", OPT_INT32,
+                         &gpgpu_frfcfs_dram_sched_queue_size,
+                         "0 = unlimited (default); # entries per chip", "0");
+  option_parser_register(opp, "-gpgpu_dram_return_queue_size", OPT_INT32,
+                         &gpgpu_dram_return_queue_size,
+                         "0 = unlimited (default); # entries per chip", "0");
+  option_parser_register(opp, "-gpgpu_dram_buswidth", OPT_UINT32, &busW,
+                         "default = 4 bytes (8 bytes per cycle at DDR)", "4");
+  option_parser_register(
+      opp, "-gpgpu_dram_burst_length", OPT_UINT32, &BL,
+      "Burst length of each DRAM request (default = 4 data bus cycle)", "4");
+  option_parser_register(opp, "-dram_data_command_freq_ratio", OPT_UINT32,
+                         &data_command_freq_ratio,
+                         "Frequency ratio between DRAM data bus and command "
+                         "bus (default = 2 times, i.e. DDR)",
+                         "2");
+  option_parser_register(
+      opp, "-gpgpu_dram_timing_opt", OPT_CSTR, &gpgpu_dram_timing_opt,
+      "DRAM timing parameters = "
+      "{nbk:tCCD:tRRD:tRCD:tRAS:tRP:tRC:CL:WL:tCDLR:tWR:nbkgrp:tCCDL:tRTPL}",
+      "4:2:8:12:21:13:34:9:4:5:13:1:0:0");
+  option_parser_register(opp, "-rop_latency", OPT_UINT32, &rop_latency,
+                         "ROP queue latency (default 85)", "85");
+  option_parser_register(opp, "-dram_latency", OPT_UINT32, &dram_latency,
+                         "DRAM latency (default 30)", "30");
+  option_parser_register(opp, "-dual_bus_interface", OPT_UINT32,
+                         &dual_bus_interface,
+                         "dual_bus_interface (default = 0) ", "0");
+  option_parser_register(opp, "-dram_bnk_indexing_policy", OPT_UINT32,
+                         &dram_bnk_indexing_policy,
+                         "dram_bnk_indexing_policy (0 = normal indexing, 1 = "
+                         "Xoring with the higher bits) (Default = 0)",
+                         "0");
+  option_parser_register(opp, "-dram_bnkgrp_indexing_policy", OPT_UINT32,
+                         &dram_bnkgrp_indexing_policy,
+                         "dram_bnkgrp_indexing_policy (0 = take higher bits, 1 "
+                         "= take lower bits) (Default = 0)",
+                         "0");
+  option_parser_register(opp, "-Seperate_Write_Queue_Enable", OPT_BOOL,
+                         &seperate_write_queue_enabled,
+                         "Seperate_Write_Queue_Enable", "0");
+  option_parser_register(opp, "-Write_Queue_Size", OPT_CSTR,
+                         &write_queue_size_opt, "Write_Queue_Size", "32:28:16");
+  option_parser_register(
+      opp, "-Elimnate_rw_turnaround", OPT_BOOL, &elimnate_rw_turnaround,
+      "elimnate_rw_turnaround i.e set tWTR and tRTW = 0", "0");
+  option_parser_register(opp, "-icnt_flit_size", OPT_UINT32, &icnt_flit_size,
+                         "icnt_flit_size", "32");
+  m_address_mapping.addrdec_setoption(opp);
 }
 
-void shader_core_config::reg_options(class OptionParser * opp)
-{
-    option_parser_register(opp, "-gpgpu_simd_model", OPT_INT32, &model, 
-                   "1 = post-dominator", "1");
-    option_parser_register(opp, "-gpgpu_shader_core_pipeline", OPT_CSTR, &gpgpu_shader_core_pipeline_opt, 
-                   "shader core pipeline config, i.e., {<nthread>:<warpsize>}",
-                   "1024:32");
-    option_parser_register(opp, "-gpgpu_tex_cache:l1", OPT_CSTR, &m_L1T_config.m_config_string, 
-                   "per-shader L1 texture cache  (READ-ONLY) config "
-                   " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_alloc>,<mshr>:<N>:<merge>,<mq>:<rf>}",
-                   "8:128:5,L:R:m:N,F:128:4,128:2");
-    option_parser_register(opp, "-gpgpu_const_cache:l1", OPT_CSTR, &m_L1C_config.m_config_string, 
-                   "per-shader L1 constant memory cache  (READ-ONLY) config "
-                   " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_alloc>,<mshr>:<N>:<merge>,<mq>} ",
-                   "64:64:2,L:R:f:N,A:2:32,4" );
-    option_parser_register(opp, "-gpgpu_cache:il1", OPT_CSTR, &m_L1I_config.m_config_string, 
-                   "shader L1 instruction cache config "
-                   " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_alloc>,<mshr>:<N>:<merge>,<mq>} ",
-                   "4:256:4,L:R:f:N,A:2:32,4" );
-    option_parser_register(opp, "-gpgpu_cache:dl1", OPT_CSTR, &m_L1D_config.m_config_string,
-                   "per-shader L1 data cache config "
-                   " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_alloc>,<mshr>:<N>:<merge>,<mq> | none}",
-                   "none" );
-    option_parser_register(opp, "-l1_banks", OPT_UINT32, &m_L1D_config.l1_banks,
-                 "The number of L1 cache banks",
-                 "1");
-    option_parser_register(opp, "-l1_latency", OPT_UINT32, &m_L1D_config.l1_latency,
-                 "L1 Hit Latency",
-                 "1");
-    option_parser_register(opp, "-smem_latency", OPT_UINT32, &smem_latency,
-                 "smem Latency",
-                 "3");
-    option_parser_register(opp, "-gpgpu_cache:dl1PrefL1", OPT_CSTR, &m_L1D_config.m_config_stringPrefL1,
-                   "per-shader L1 data cache config "
-                   " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_alloc>,<mshr>:<N>:<merge>,<mq> | none}",
-                   "none" );
-    option_parser_register(opp, "-gpgpu_cache:dl1PrefShared", OPT_CSTR, &m_L1D_config.m_config_stringPrefShared,
-                   "per-shader L1 data cache config "
-                   " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_alloc>,<mshr>:<N>:<merge>,<mq> | none}",
-                   "none" );
-    option_parser_register(opp, "-gmem_skip_L1D", OPT_BOOL, &gmem_skip_L1D, 
-                   "global memory access skip L1D cache (implements -Xptxas -dlcm=cg, default=no skip)",
-                   "0");
+void shader_core_config::reg_options(class OptionParser *opp) {
+  option_parser_register(opp, "-gpgpu_simd_model", OPT_INT32, &model,
+                         "1 = post-dominator", "1");
+  option_parser_register(
+      opp, "-gpgpu_shader_core_pipeline", OPT_CSTR,
+      &gpgpu_shader_core_pipeline_opt,
+      "shader core pipeline config, i.e., {<nthread>:<warpsize>}", "1024:32");
+  option_parser_register(opp, "-gpgpu_tex_cache:l1", OPT_CSTR,
+                         &m_L1T_config.m_config_string,
+                         "per-shader L1 texture cache  (READ-ONLY) config "
+                         " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_"
+                         "alloc>,<mshr>:<N>:<merge>,<mq>:<rf>}",
+                         "8:128:5,L:R:m:N,F:128:4,128:2");
+  option_parser_register(
+      opp, "-gpgpu_const_cache:l1", OPT_CSTR, &m_L1C_config.m_config_string,
+      "per-shader L1 constant memory cache  (READ-ONLY) config "
+      " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_alloc>,<mshr>:<N>:<"
+      "merge>,<mq>} ",
+      "64:64:2,L:R:f:N,A:2:32,4");
+  option_parser_register(opp, "-gpgpu_cache:il1", OPT_CSTR,
+                         &m_L1I_config.m_config_string,
+                         "shader L1 instruction cache config "
+                         " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_"
+                         "alloc>,<mshr>:<N>:<merge>,<mq>} ",
+                         "4:256:4,L:R:f:N,A:2:32,4");
+  option_parser_register(opp, "-gpgpu_cache:dl1", OPT_CSTR,
+                         &m_L1D_config.m_config_string,
+                         "per-shader L1 data cache config "
+                         " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_"
+                         "alloc>,<mshr>:<N>:<merge>,<mq> | none}",
+                         "none");
+  option_parser_register(opp, "-l1_banks", OPT_UINT32, &m_L1D_config.l1_banks,
+                         "The number of L1 cache banks", "1");
+  option_parser_register(opp, "-l1_latency", OPT_UINT32,
+                         &m_L1D_config.l1_latency, "L1 Hit Latency", "1");
+  option_parser_register(opp, "-smem_latency", OPT_UINT32, &smem_latency,
+                         "smem Latency", "3");
+  option_parser_register(opp, "-gpgpu_cache:dl1PrefL1", OPT_CSTR,
+                         &m_L1D_config.m_config_stringPrefL1,
+                         "per-shader L1 data cache config "
+                         " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_"
+                         "alloc>,<mshr>:<N>:<merge>,<mq> | none}",
+                         "none");
+  option_parser_register(opp, "-gpgpu_cache:dl1PrefShared", OPT_CSTR,
+                         &m_L1D_config.m_config_stringPrefShared,
+                         "per-shader L1 data cache config "
+                         " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_"
+                         "alloc>,<mshr>:<N>:<merge>,<mq> | none}",
+                         "none");
+  option_parser_register(opp, "-gmem_skip_L1D", OPT_BOOL, &gmem_skip_L1D,
+                         "global memory access skip L1D cache (implements "
+                         "-Xptxas -dlcm=cg, default=no skip)",
+                         "0");
 
-    option_parser_register(opp, "-gpgpu_perfect_mem", OPT_BOOL, &gpgpu_perfect_mem, 
-                 "enable perfect memory mode (no cache miss)",
-                 "0");
-    option_parser_register(opp, "-n_regfile_gating_group", OPT_UINT32, &n_regfile_gating_group,
-                 "group of lanes that should be read/written together)",
-                 "4");
-    option_parser_register(opp, "-gpgpu_clock_gated_reg_file", OPT_BOOL, &gpgpu_clock_gated_reg_file,
-                 "enable clock gated reg file for power calculations",
-                 "0");
-    option_parser_register(opp, "-gpgpu_clock_gated_lanes", OPT_BOOL, &gpgpu_clock_gated_lanes,
-                 "enable clock gated lanes for power calculations",
-                 "0");
-    option_parser_register(opp, "-gpgpu_shader_registers", OPT_UINT32, &gpgpu_shader_registers, 
-                 "Number of registers per shader core. Limits number of concurrent CTAs. (default 8192)",
-                 "8192");
-    option_parser_register(opp, "-gpgpu_registers_per_block", OPT_UINT32, &gpgpu_registers_per_block,
-                 "Maximum number of registers per CTA. (default 8192)",
-                 "8192");
-    option_parser_register(opp, "-gpgpu_ignore_resources_limitation", OPT_BOOL, &gpgpu_ignore_resources_limitation,
-                 "gpgpu_ignore_resources_limitation (default 0)",
-                 "0");
-    option_parser_register(opp, "-gpgpu_shader_cta", OPT_UINT32, &max_cta_per_core, 
-                 "Maximum number of concurrent CTAs in shader (default 8)",
-                 "8");
-    option_parser_register(opp, "-gpgpu_num_cta_barriers", OPT_UINT32, &max_barriers_per_cta,
-                 "Maximum number of named barriers per CTA (default 16)",
-                 "16");
-    option_parser_register(opp, "-gpgpu_n_clusters", OPT_UINT32, &n_simt_clusters, 
-                 "number of processing clusters",
-                 "10");
-    option_parser_register(opp, "-gpgpu_n_cores_per_cluster", OPT_UINT32, &n_simt_cores_per_cluster, 
-                 "number of simd cores per cluster",
-                 "3");
-    option_parser_register(opp, "-gpgpu_n_cluster_ejection_buffer_size", OPT_UINT32, &n_simt_ejection_buffer_size, 
-                 "number of packets in ejection buffer",
-                 "8");
-    option_parser_register(opp, "-gpgpu_n_ldst_response_buffer_size", OPT_UINT32, &ldst_unit_response_queue_size, 
-                 "number of response packets in ld/st unit ejection buffer",
-                 "2");
-    option_parser_register(opp, "-gpgpu_shmem_per_block", OPT_UINT32, &gpgpu_shmem_per_block,
-                 "Size of shared memory per thread block or CTA (default 48kB)",
-                 "49152");
-    option_parser_register(opp, "-gpgpu_shmem_size", OPT_UINT32, &gpgpu_shmem_size,
-                 "Size of shared memory per shader core (default 16kB)",
-                 "16384");
-    option_parser_register(opp, "-adaptive_cache_config", OPT_BOOL, &adaptive_volta_cache_config,
-                 "adaptive_cache_config",
-                 "0");
-    option_parser_register(opp, "-gpgpu_shmem_sizeDefault", OPT_UINT32, &gpgpu_shmem_sizeDefault,
-                 "Size of shared memory per shader core (default 16kB)",
-                 "16384");
-    option_parser_register(opp, "-gpgpu_shmem_size_PrefL1", OPT_UINT32, &gpgpu_shmem_sizePrefL1,
-                 "Size of shared memory per shader core (default 16kB)",
-                 "16384");
-    option_parser_register(opp, "-gpgpu_shmem_size_PrefShared", OPT_UINT32, &gpgpu_shmem_sizePrefShared,
-                 "Size of shared memory per shader core (default 16kB)",
-                 "16384");
-    option_parser_register(opp, "-gpgpu_shmem_num_banks", OPT_UINT32, &num_shmem_bank, 
-                 "Number of banks in the shared memory in each shader core (default 16)",
-                 "16");
-    option_parser_register(opp, "-gpgpu_shmem_limited_broadcast", OPT_BOOL, &shmem_limited_broadcast, 
-                 "Limit shared memory to do one broadcast per cycle (default on)",
-                 "1");
-    option_parser_register(opp, "-gpgpu_shmem_warp_parts", OPT_INT32, &mem_warp_parts,  
-                 "Number of portions a warp is divided into for shared memory bank conflict check ",
-                 "2");
-    option_parser_register(opp, "-mem_unit_ports", OPT_INT32, &mem_unit_ports,
-                 "The number of memory transactions allowed per core cycle",
-                 "1");
-    option_parser_register(opp, "-gpgpu_shmem_warp_parts", OPT_INT32, &mem_warp_parts,
-				 "Number of portions a warp is divided into for shared memory bank conflict check ",
-				 "2");
-    option_parser_register(opp, "-gpgpu_warpdistro_shader", OPT_INT32, &gpgpu_warpdistro_shader, 
-                "Specify which shader core to collect the warp size distribution from", 
-                "-1");
-    option_parser_register(opp, "-gpgpu_warp_issue_shader", OPT_INT32, &gpgpu_warp_issue_shader, 
-                "Specify which shader core to collect the warp issue distribution from", 
-                "0");
-    option_parser_register(opp, "-gpgpu_local_mem_map", OPT_BOOL, &gpgpu_local_mem_map, 
-                "Mapping from local memory space address to simulated GPU physical address space (default = enabled)", 
-		"1");
-    option_parser_register(opp, "-gpgpu_num_reg_banks", OPT_INT32, &gpgpu_num_reg_banks, 
-                "Number of register banks (default = 8)", 
-                "8");
-    option_parser_register(opp, "-gpgpu_reg_bank_use_warp_id", OPT_BOOL, &gpgpu_reg_bank_use_warp_id,
-             "Use warp ID in mapping registers to banks (default = off)",
-             "0");
-    option_parser_register(opp, "-sub_core_model", OPT_BOOL, &sub_core_model,
-             "Sub Core Volta/Pascal model (default = off)",
-             "0");
-    option_parser_register(opp, "-enable_specialized_operand_collector", OPT_BOOL, &enable_specialized_operand_collector,
-                "enable_specialized_operand_collector",
-                "1");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_units_sp", OPT_INT32, &gpgpu_operand_collector_num_units_sp,
-                "number of collector units (default = 4)",
-                "4");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_units_dp", OPT_INT32, &gpgpu_operand_collector_num_units_dp,
-                   "number of collector units (default = 0)",
-                   "0");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_units_sfu", OPT_INT32, &gpgpu_operand_collector_num_units_sfu,
-                "number of collector units (default = 4)", 
-                "4");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_units_int", OPT_INT32, &gpgpu_operand_collector_num_units_int,
-                "number of collector units (default = 0)",
-                "0");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_units_tensor_core", OPT_INT32, &gpgpu_operand_collector_num_units_tensor_core,
-                "number of collector units (default = 4)", 
-                "4");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_units_mem", OPT_INT32, &gpgpu_operand_collector_num_units_mem,
-                "number of collector units (default = 2)", 
-                "2");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_units_gen", OPT_INT32, &gpgpu_operand_collector_num_units_gen,
-                "number of collector units (default = 0)", 
-                "0");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_sp", OPT_INT32, &gpgpu_operand_collector_num_in_ports_sp,
-                           "number of collector unit in ports (default = 1)", 
-                           "1");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_dp", OPT_INT32, &gpgpu_operand_collector_num_in_ports_dp,
-                           "number of collector unit in ports (default = 0)",
-                           "0");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_sfu", OPT_INT32, &gpgpu_operand_collector_num_in_ports_sfu,
-                           "number of collector unit in ports (default = 1)", 
-                           "1");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_int", OPT_INT32, &gpgpu_operand_collector_num_in_ports_int,
-                           "number of collector unit in ports (default = 0)",
-                           "0");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_tensor_core", OPT_INT32, &gpgpu_operand_collector_num_in_ports_tensor_core,
-                           "number of collector unit in ports (default = 1)", 
-                           "1");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_mem", OPT_INT32, &gpgpu_operand_collector_num_in_ports_mem,
-                           "number of collector unit in ports (default = 1)", 
-                           "1");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_gen", OPT_INT32, &gpgpu_operand_collector_num_in_ports_gen,
-                           "number of collector unit in ports (default = 0)", 
-                           "0");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_sp", OPT_INT32, &gpgpu_operand_collector_num_out_ports_sp,
-                           "number of collector unit in ports (default = 1)", 
-                           "1");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_dp", OPT_INT32, &gpgpu_operand_collector_num_out_ports_dp,
-                           "number of collector unit in ports (default = 0)",
-                           "0");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_sfu", OPT_INT32, &gpgpu_operand_collector_num_out_ports_sfu,
-                           "number of collector unit in ports (default = 1)", 
-                           "1");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_int", OPT_INT32, &gpgpu_operand_collector_num_out_ports_int,
-                           "number of collector unit in ports (default = 0)",
-                           "0");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_tensor_core", OPT_INT32, &gpgpu_operand_collector_num_out_ports_tensor_core,
-                           "number of collector unit in ports (default = 1)", 
-                           "1");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_mem", OPT_INT32, &gpgpu_operand_collector_num_out_ports_mem,
-                           "number of collector unit in ports (default = 1)", 
-                           "1");
-    option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_gen", OPT_INT32, &gpgpu_operand_collector_num_out_ports_gen,
-                           "number of collector unit in ports (default = 0)", 
-                           "0");
-    option_parser_register(opp, "-gpgpu_coalesce_arch", OPT_INT32, &gpgpu_coalesce_arch, 
-    		            "Coalescing arch (GT200 = 13, Fermi = 20)",
-                            "13");
-    option_parser_register(opp, "-gpgpu_num_sched_per_core", OPT_INT32, &gpgpu_num_sched_per_core, 
-                            "Number of warp schedulers per core", 
-                            "1");
-    option_parser_register(opp, "-gpgpu_max_insn_issue_per_warp", OPT_INT32, &gpgpu_max_insn_issue_per_warp,
-    		            "Max number of instructions that can be issued per warp in one cycle by scheduler (either 1 or 2)",
-			    "2");
-    option_parser_register(opp, "-gpgpu_dual_issue_diff_exec_units", OPT_BOOL, &gpgpu_dual_issue_diff_exec_units,
-			    "should dual issue use two different execution unit resources (Default = 1)",
-			    "1");
-    option_parser_register(opp, "-gpgpu_simt_core_sim_order", OPT_INT32, &simt_core_sim_order,
-                            "Select the simulation order of cores in a cluster (0=Fix, 1=Round-Robin)",
-                            "1");
-    option_parser_register(opp, "-gpgpu_pipeline_widths", OPT_CSTR, &pipeline_widths_string,
-                            "Pipeline widths "
-                            "ID_OC_SP,ID_OC_DP,ID_OC_INT,ID_OC_SFU,ID_OC_MEM,OC_EX_SP,OC_EX_DP,OC_EX_INT,OC_EX_SFU,OC_EX_MEM,EX_WB,ID_OC_TENSOR_CORE,OC_EX_TENSOR_CORE",
-                            "1,1,1,1,1,1,1,1,1,1,1,1,1" );
-    option_parser_register(opp, "-gpgpu_tensor_core_avail", OPT_INT32, &gpgpu_tensor_core_avail,
-                            "Tensor Core Available (default=0)",
-                            "0");
-    option_parser_register(opp, "-gpgpu_num_sp_units", OPT_INT32, &gpgpu_num_sp_units,
-                            "Number of SP units (default=1)",
-                            "1");
-    option_parser_register(opp, "-gpgpu_num_dp_units", OPT_INT32, &gpgpu_num_dp_units,
-                            "Number of DP units (default=0)",
-                            "0");
-    option_parser_register(opp, "-gpgpu_num_int_units", OPT_INT32, &gpgpu_num_int_units,
-                            "Number of INT units (default=0)",
-                            "0");
-    option_parser_register(opp, "-gpgpu_num_sfu_units", OPT_INT32, &gpgpu_num_sfu_units,
-                            "Number of SF units (default=1)",
-                            "1");
-    option_parser_register(opp, "-gpgpu_num_tensor_core_units", OPT_INT32, &gpgpu_num_tensor_core_units,
-                            "Number of tensor_core units (default=1)",
-                            "1");
-    option_parser_register(opp, "-gpgpu_num_mem_units", OPT_INT32, &gpgpu_num_mem_units,
-                            "Number if ldst units (default=1) WARNING: not hooked up to anything",
-                             "1");
-    option_parser_register(opp, "-gpgpu_scheduler", OPT_CSTR, &gpgpu_scheduler_string,
-                                "Scheduler configuration: < lrr | gto | two_level_active > "
-                                "If two_level_active:<num_active_warps>:<inner_prioritization>:<outer_prioritization>"
-                                "For complete list of prioritization values see shader.h enum scheduler_prioritization_type"
-                                "Default: gto",
-                                 "gto");
+  option_parser_register(opp, "-gpgpu_perfect_mem", OPT_BOOL,
+                         &gpgpu_perfect_mem,
+                         "enable perfect memory mode (no cache miss)", "0");
+  option_parser_register(
+      opp, "-n_regfile_gating_group", OPT_UINT32, &n_regfile_gating_group,
+      "group of lanes that should be read/written together)", "4");
+  option_parser_register(
+      opp, "-gpgpu_clock_gated_reg_file", OPT_BOOL, &gpgpu_clock_gated_reg_file,
+      "enable clock gated reg file for power calculations", "0");
+  option_parser_register(
+      opp, "-gpgpu_clock_gated_lanes", OPT_BOOL, &gpgpu_clock_gated_lanes,
+      "enable clock gated lanes for power calculations", "0");
+  option_parser_register(opp, "-gpgpu_shader_registers", OPT_UINT32,
+                         &gpgpu_shader_registers,
+                         "Number of registers per shader core. Limits number "
+                         "of concurrent CTAs. (default 8192)",
+                         "8192");
+  option_parser_register(
+      opp, "-gpgpu_registers_per_block", OPT_UINT32, &gpgpu_registers_per_block,
+      "Maximum number of registers per CTA. (default 8192)", "8192");
+  option_parser_register(opp, "-gpgpu_ignore_resources_limitation", OPT_BOOL,
+                         &gpgpu_ignore_resources_limitation,
+                         "gpgpu_ignore_resources_limitation (default 0)", "0");
+  option_parser_register(
+      opp, "-gpgpu_shader_cta", OPT_UINT32, &max_cta_per_core,
+      "Maximum number of concurrent CTAs in shader (default 8)", "8");
+  option_parser_register(
+      opp, "-gpgpu_num_cta_barriers", OPT_UINT32, &max_barriers_per_cta,
+      "Maximum number of named barriers per CTA (default 16)", "16");
+  option_parser_register(opp, "-gpgpu_n_clusters", OPT_UINT32, &n_simt_clusters,
+                         "number of processing clusters", "10");
+  option_parser_register(opp, "-gpgpu_n_cores_per_cluster", OPT_UINT32,
+                         &n_simt_cores_per_cluster,
+                         "number of simd cores per cluster", "3");
+  option_parser_register(opp, "-gpgpu_n_cluster_ejection_buffer_size",
+                         OPT_UINT32, &n_simt_ejection_buffer_size,
+                         "number of packets in ejection buffer", "8");
+  option_parser_register(
+      opp, "-gpgpu_n_ldst_response_buffer_size", OPT_UINT32,
+      &ldst_unit_response_queue_size,
+      "number of response packets in ld/st unit ejection buffer", "2");
+  option_parser_register(
+      opp, "-gpgpu_shmem_per_block", OPT_UINT32, &gpgpu_shmem_per_block,
+      "Size of shared memory per thread block or CTA (default 48kB)", "49152");
+  option_parser_register(
+      opp, "-gpgpu_shmem_size", OPT_UINT32, &gpgpu_shmem_size,
+      "Size of shared memory per shader core (default 16kB)", "16384");
+  option_parser_register(opp, "-adaptive_cache_config", OPT_BOOL,
+                         &adaptive_volta_cache_config, "adaptive_cache_config",
+                         "0");
+  option_parser_register(
+      opp, "-gpgpu_shmem_sizeDefault", OPT_UINT32, &gpgpu_shmem_sizeDefault,
+      "Size of shared memory per shader core (default 16kB)", "16384");
+  option_parser_register(
+      opp, "-gpgpu_shmem_size_PrefL1", OPT_UINT32, &gpgpu_shmem_sizePrefL1,
+      "Size of shared memory per shader core (default 16kB)", "16384");
+  option_parser_register(opp, "-gpgpu_shmem_size_PrefShared", OPT_UINT32,
+                         &gpgpu_shmem_sizePrefShared,
+                         "Size of shared memory per shader core (default 16kB)",
+                         "16384");
+  option_parser_register(
+      opp, "-gpgpu_shmem_num_banks", OPT_UINT32, &num_shmem_bank,
+      "Number of banks in the shared memory in each shader core (default 16)",
+      "16");
+  option_parser_register(
+      opp, "-gpgpu_shmem_limited_broadcast", OPT_BOOL, &shmem_limited_broadcast,
+      "Limit shared memory to do one broadcast per cycle (default on)", "1");
+  option_parser_register(opp, "-gpgpu_shmem_warp_parts", OPT_INT32,
+                         &mem_warp_parts,
+                         "Number of portions a warp is divided into for shared "
+                         "memory bank conflict check ",
+                         "2");
+  option_parser_register(
+      opp, "-mem_unit_ports", OPT_INT32, &mem_unit_ports,
+      "The number of memory transactions allowed per core cycle", "1");
+  option_parser_register(opp, "-gpgpu_shmem_warp_parts", OPT_INT32,
+                         &mem_warp_parts,
+                         "Number of portions a warp is divided into for shared "
+                         "memory bank conflict check ",
+                         "2");
+  option_parser_register(
+      opp, "-gpgpu_warpdistro_shader", OPT_INT32, &gpgpu_warpdistro_shader,
+      "Specify which shader core to collect the warp size distribution from",
+      "-1");
+  option_parser_register(
+      opp, "-gpgpu_warp_issue_shader", OPT_INT32, &gpgpu_warp_issue_shader,
+      "Specify which shader core to collect the warp issue distribution from",
+      "0");
+  option_parser_register(opp, "-gpgpu_local_mem_map", OPT_BOOL,
+                         &gpgpu_local_mem_map,
+                         "Mapping from local memory space address to simulated "
+                         "GPU physical address space (default = enabled)",
+                         "1");
+  option_parser_register(opp, "-gpgpu_num_reg_banks", OPT_INT32,
+                         &gpgpu_num_reg_banks,
+                         "Number of register banks (default = 8)", "8");
+  option_parser_register(
+      opp, "-gpgpu_reg_bank_use_warp_id", OPT_BOOL, &gpgpu_reg_bank_use_warp_id,
+      "Use warp ID in mapping registers to banks (default = off)", "0");
+  option_parser_register(opp, "-sub_core_model", OPT_BOOL, &sub_core_model,
+                         "Sub Core Volta/Pascal model (default = off)", "0");
+  option_parser_register(opp, "-enable_specialized_operand_collector", OPT_BOOL,
+                         &enable_specialized_operand_collector,
+                         "enable_specialized_operand_collector", "1");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_units_sp",
+                         OPT_INT32, &gpgpu_operand_collector_num_units_sp,
+                         "number of collector units (default = 4)", "4");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_units_dp",
+                         OPT_INT32, &gpgpu_operand_collector_num_units_dp,
+                         "number of collector units (default = 0)", "0");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_units_sfu",
+                         OPT_INT32, &gpgpu_operand_collector_num_units_sfu,
+                         "number of collector units (default = 4)", "4");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_units_int",
+                         OPT_INT32, &gpgpu_operand_collector_num_units_int,
+                         "number of collector units (default = 0)", "0");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_units_tensor_core",
+                         OPT_INT32,
+                         &gpgpu_operand_collector_num_units_tensor_core,
+                         "number of collector units (default = 4)", "4");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_units_mem",
+                         OPT_INT32, &gpgpu_operand_collector_num_units_mem,
+                         "number of collector units (default = 2)", "2");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_units_gen",
+                         OPT_INT32, &gpgpu_operand_collector_num_units_gen,
+                         "number of collector units (default = 0)", "0");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_sp",
+                         OPT_INT32, &gpgpu_operand_collector_num_in_ports_sp,
+                         "number of collector unit in ports (default = 1)",
+                         "1");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_dp",
+                         OPT_INT32, &gpgpu_operand_collector_num_in_ports_dp,
+                         "number of collector unit in ports (default = 0)",
+                         "0");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_sfu",
+                         OPT_INT32, &gpgpu_operand_collector_num_in_ports_sfu,
+                         "number of collector unit in ports (default = 1)",
+                         "1");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_int",
+                         OPT_INT32, &gpgpu_operand_collector_num_in_ports_int,
+                         "number of collector unit in ports (default = 0)",
+                         "0");
+  option_parser_register(
+      opp, "-gpgpu_operand_collector_num_in_ports_tensor_core", OPT_INT32,
+      &gpgpu_operand_collector_num_in_ports_tensor_core,
+      "number of collector unit in ports (default = 1)", "1");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_mem",
+                         OPT_INT32, &gpgpu_operand_collector_num_in_ports_mem,
+                         "number of collector unit in ports (default = 1)",
+                         "1");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_gen",
+                         OPT_INT32, &gpgpu_operand_collector_num_in_ports_gen,
+                         "number of collector unit in ports (default = 0)",
+                         "0");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_sp",
+                         OPT_INT32, &gpgpu_operand_collector_num_out_ports_sp,
+                         "number of collector unit in ports (default = 1)",
+                         "1");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_dp",
+                         OPT_INT32, &gpgpu_operand_collector_num_out_ports_dp,
+                         "number of collector unit in ports (default = 0)",
+                         "0");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_sfu",
+                         OPT_INT32, &gpgpu_operand_collector_num_out_ports_sfu,
+                         "number of collector unit in ports (default = 1)",
+                         "1");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_int",
+                         OPT_INT32, &gpgpu_operand_collector_num_out_ports_int,
+                         "number of collector unit in ports (default = 0)",
+                         "0");
+  option_parser_register(
+      opp, "-gpgpu_operand_collector_num_out_ports_tensor_core", OPT_INT32,
+      &gpgpu_operand_collector_num_out_ports_tensor_core,
+      "number of collector unit in ports (default = 1)", "1");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_mem",
+                         OPT_INT32, &gpgpu_operand_collector_num_out_ports_mem,
+                         "number of collector unit in ports (default = 1)",
+                         "1");
+  option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_gen",
+                         OPT_INT32, &gpgpu_operand_collector_num_out_ports_gen,
+                         "number of collector unit in ports (default = 0)",
+                         "0");
+  option_parser_register(opp, "-gpgpu_coalesce_arch", OPT_INT32,
+                         &gpgpu_coalesce_arch,
+                         "Coalescing arch (GT200 = 13, Fermi = 20)", "13");
+  option_parser_register(opp, "-gpgpu_num_sched_per_core", OPT_INT32,
+                         &gpgpu_num_sched_per_core,
+                         "Number of warp schedulers per core", "1");
+  option_parser_register(opp, "-gpgpu_max_insn_issue_per_warp", OPT_INT32,
+                         &gpgpu_max_insn_issue_per_warp,
+                         "Max number of instructions that can be issued per "
+                         "warp in one cycle by scheduler (either 1 or 2)",
+                         "2");
+  option_parser_register(opp, "-gpgpu_dual_issue_diff_exec_units", OPT_BOOL,
+                         &gpgpu_dual_issue_diff_exec_units,
+                         "should dual issue use two different execution unit "
+                         "resources (Default = 1)",
+                         "1");
+  option_parser_register(opp, "-gpgpu_simt_core_sim_order", OPT_INT32,
+                         &simt_core_sim_order,
+                         "Select the simulation order of cores in a cluster "
+                         "(0=Fix, 1=Round-Robin)",
+                         "1");
+  option_parser_register(
+      opp, "-gpgpu_pipeline_widths", OPT_CSTR, &pipeline_widths_string,
+      "Pipeline widths "
+      "ID_OC_SP,ID_OC_DP,ID_OC_INT,ID_OC_SFU,ID_OC_MEM,OC_EX_SP,OC_EX_DP,OC_EX_"
+      "INT,OC_EX_SFU,OC_EX_MEM,EX_WB,ID_OC_TENSOR_CORE,OC_EX_TENSOR_CORE",
+      "1,1,1,1,1,1,1,1,1,1,1,1,1");
+  option_parser_register(opp, "-gpgpu_tensor_core_avail", OPT_INT32,
+                         &gpgpu_tensor_core_avail,
+                         "Tensor Core Available (default=0)", "0");
+  option_parser_register(opp, "-gpgpu_num_sp_units", OPT_INT32,
+                         &gpgpu_num_sp_units, "Number of SP units (default=1)",
+                         "1");
+  option_parser_register(opp, "-gpgpu_num_dp_units", OPT_INT32,
+                         &gpgpu_num_dp_units, "Number of DP units (default=0)",
+                         "0");
+  option_parser_register(opp, "-gpgpu_num_int_units", OPT_INT32,
+                         &gpgpu_num_int_units,
+                         "Number of INT units (default=0)", "0");
+  option_parser_register(opp, "-gpgpu_num_sfu_units", OPT_INT32,
+                         &gpgpu_num_sfu_units, "Number of SF units (default=1)",
+                         "1");
+  option_parser_register(opp, "-gpgpu_num_tensor_core_units", OPT_INT32,
+                         &gpgpu_num_tensor_core_units,
+                         "Number of tensor_core units (default=1)", "1");
+  option_parser_register(
+      opp, "-gpgpu_num_mem_units", OPT_INT32, &gpgpu_num_mem_units,
+      "Number if ldst units (default=1) WARNING: not hooked up to anything",
+      "1");
+  option_parser_register(
+      opp, "-gpgpu_scheduler", OPT_CSTR, &gpgpu_scheduler_string,
+      "Scheduler configuration: < lrr | gto | two_level_active > "
+      "If "
+      "two_level_active:<num_active_warps>:<inner_prioritization>:<outer_"
+      "prioritization>"
+      "For complete list of prioritization values see shader.h enum "
+      "scheduler_prioritization_type"
+      "Default: gto",
+      "gto");
 
-    option_parser_register(opp, "-gpgpu_concurrent_kernel_sm", OPT_BOOL, &gpgpu_concurrent_kernel_sm, 
-                "Support concurrent kernels on a SM (default = disabled)", 
-                "0");
-
+  option_parser_register(
+      opp, "-gpgpu_concurrent_kernel_sm", OPT_BOOL, &gpgpu_concurrent_kernel_sm,
+      "Support concurrent kernels on a SM (default = disabled)", "0");
 }
 
-void gpgpu_sim_config::reg_options(option_parser_t opp)
-{
-    gpgpu_functional_sim_config::reg_options(opp);
-    m_shader_config.reg_options(opp);
-    m_memory_config.reg_options(opp);
-    power_config::reg_options(opp);
-   option_parser_register(opp, "-gpgpu_max_cycle", OPT_INT64, &gpu_max_cycle_opt, 
-               "terminates gpu simulation early (0 = no limit)",
-               "0");
-   option_parser_register(opp, "-gpgpu_max_insn", OPT_INT64, &gpu_max_insn_opt, 
-               "terminates gpu simulation early (0 = no limit)",
-               "0");
-   option_parser_register(opp, "-gpgpu_max_cta", OPT_INT32, &gpu_max_cta_opt, 
-               "terminates gpu simulation early (0 = no limit)",
-               "0");
-   option_parser_register(opp, "-gpgpu_runtime_stat", OPT_CSTR, &gpgpu_runtime_stat, 
-                  "display runtime statistics such as dram utilization {<freq>:<flag>}",
-                  "10000:0");
-   option_parser_register(opp, "-liveness_message_freq", OPT_INT64, &liveness_message_freq, 
-               "Minimum number of seconds between simulation liveness messages (0 = always print)",
-               "1");
-   option_parser_register(opp, "-gpgpu_compute_capability_major", OPT_UINT32, &gpgpu_compute_capability_major,
-                 "Major compute capability version number",
-                 "7");
-   option_parser_register(opp, "-gpgpu_compute_capability_minor", OPT_UINT32, &gpgpu_compute_capability_minor,
-                 "Minor compute capability version number",
-                 "0");
-   option_parser_register(opp, "-gpgpu_flush_l1_cache", OPT_BOOL, &gpgpu_flush_l1_cache,
-                "Flush L1 cache at the end of each kernel call",
-                "0");
-   option_parser_register(opp, "-gpgpu_flush_l2_cache", OPT_BOOL, &gpgpu_flush_l2_cache,
-                   "Flush L2 cache at the end of each kernel call",
-                   "0");
-   option_parser_register(opp, "-gpgpu_deadlock_detect", OPT_BOOL, &gpu_deadlock_detect, 
-                "Stop the simulation at deadlock (1=on (default), 0=off)", 
-                "1");
-   option_parser_register(opp, "-gpgpu_ptx_instruction_classification", OPT_INT32,
-               &(gpgpu_ctx->func_sim->gpgpu_ptx_instruction_classification),
-               "if enabled will classify ptx instruction types per kernel (Max 255 kernels now)", 
-               "0");
-   option_parser_register(opp, "-gpgpu_ptx_sim_mode", OPT_INT32, &(gpgpu_ctx->func_sim->g_ptx_sim_mode),
-               "Select between Performance (default) or Functional simulation (1)", 
-               "0");
-   option_parser_register(opp, "-gpgpu_clock_domains", OPT_CSTR, &gpgpu_clock_domains, 
-                  "Clock Domain Frequencies in MhZ {<Core Clock>:<ICNT Clock>:<L2 Clock>:<DRAM Clock>}",
-                  "500.0:2000.0:2000.0:2000.0");
-   option_parser_register(opp, "-gpgpu_max_concurrent_kernel", OPT_INT32, &max_concurrent_kernel,
-                          "maximum kernels that can run concurrently on GPU", "8" );
-   option_parser_register(opp, "-gpgpu_cflog_interval", OPT_INT32, &gpgpu_cflog_interval, 
-               "Interval between each snapshot in control flow logger", 
-               "0");
-   option_parser_register(opp, "-visualizer_enabled", OPT_BOOL,
-                          &g_visualizer_enabled, "Turn on visualizer output (1=On, 0=Off)",
-                          "1");
-   option_parser_register(opp, "-visualizer_outputfile", OPT_CSTR, 
-                          &g_visualizer_filename, "Specifies the output log file for visualizer",
-                          NULL);
-   option_parser_register(opp, "-visualizer_zlevel", OPT_INT32,
-                          &g_visualizer_zlevel, "Compression level of the visualizer output log (0=no comp, 9=highest)",
-                          "6");
-   option_parser_register(opp, "-gpgpu_stack_size_limit", OPT_INT32, &stack_size_limit,
-                          "GPU thread stack size", "1024" );
-   option_parser_register(opp, "-gpgpu_heap_size_limit", OPT_INT32, &heap_size_limit,
-                          "GPU malloc heap size ", "8388608" );
-   option_parser_register(opp, "-gpgpu_runtime_sync_depth_limit", OPT_INT32, &runtime_sync_depth_limit,
-                          "GPU device runtime synchronize depth", "2" );
-   option_parser_register(opp, "-gpgpu_runtime_pending_launch_count_limit", OPT_INT32, &runtime_pending_launch_count_limit,
-                          "GPU device runtime pending launch count", "2048" );
-    option_parser_register(opp, "-trace_enabled", OPT_BOOL, 
-                          &Trace::enabled, "Turn on traces",
-                          "0");
-    option_parser_register(opp, "-trace_components", OPT_CSTR, 
-                          &Trace::config_str, "comma seperated list of traces to enable. "
-                          "Complete list found in trace_streams.tup. "
-                          "Default none",
-                          "none");
-    option_parser_register(opp, "-trace_sampling_core", OPT_INT32, 
-                          &Trace::sampling_core, "The core which is printed using CORE_DPRINTF. Default 0",
-                          "0");
-    option_parser_register(opp, "-trace_sampling_memory_partition", OPT_INT32, 
-                          &Trace::sampling_memory_partition, "The memory partition which is printed using MEMPART_DPRINTF. Default -1 (i.e. all)",
-                          "-1");
-    gpgpu_ctx->stats->ptx_file_line_stats_options(opp);
+void gpgpu_sim_config::reg_options(option_parser_t opp) {
+  gpgpu_functional_sim_config::reg_options(opp);
+  m_shader_config.reg_options(opp);
+  m_memory_config.reg_options(opp);
+  power_config::reg_options(opp);
+  option_parser_register(opp, "-gpgpu_max_cycle", OPT_INT64, &gpu_max_cycle_opt,
+                         "terminates gpu simulation early (0 = no limit)", "0");
+  option_parser_register(opp, "-gpgpu_max_insn", OPT_INT64, &gpu_max_insn_opt,
+                         "terminates gpu simulation early (0 = no limit)", "0");
+  option_parser_register(opp, "-gpgpu_max_cta", OPT_INT32, &gpu_max_cta_opt,
+                         "terminates gpu simulation early (0 = no limit)", "0");
+  option_parser_register(
+      opp, "-gpgpu_runtime_stat", OPT_CSTR, &gpgpu_runtime_stat,
+      "display runtime statistics such as dram utilization {<freq>:<flag>}",
+      "10000:0");
+  option_parser_register(opp, "-liveness_message_freq", OPT_INT64,
+                         &liveness_message_freq,
+                         "Minimum number of seconds between simulation "
+                         "liveness messages (0 = always print)",
+                         "1");
+  option_parser_register(opp, "-gpgpu_compute_capability_major", OPT_UINT32,
+                         &gpgpu_compute_capability_major,
+                         "Major compute capability version number", "7");
+  option_parser_register(opp, "-gpgpu_compute_capability_minor", OPT_UINT32,
+                         &gpgpu_compute_capability_minor,
+                         "Minor compute capability version number", "0");
+  option_parser_register(opp, "-gpgpu_flush_l1_cache", OPT_BOOL,
+                         &gpgpu_flush_l1_cache,
+                         "Flush L1 cache at the end of each kernel call", "0");
+  option_parser_register(opp, "-gpgpu_flush_l2_cache", OPT_BOOL,
+                         &gpgpu_flush_l2_cache,
+                         "Flush L2 cache at the end of each kernel call", "0");
+  option_parser_register(
+      opp, "-gpgpu_deadlock_detect", OPT_BOOL, &gpu_deadlock_detect,
+      "Stop the simulation at deadlock (1=on (default), 0=off)", "1");
+  option_parser_register(
+      opp, "-gpgpu_ptx_instruction_classification", OPT_INT32,
+      &(gpgpu_ctx->func_sim->gpgpu_ptx_instruction_classification),
+      "if enabled will classify ptx instruction types per kernel (Max 255 "
+      "kernels now)",
+      "0");
+  option_parser_register(
+      opp, "-gpgpu_ptx_sim_mode", OPT_INT32,
+      &(gpgpu_ctx->func_sim->g_ptx_sim_mode),
+      "Select between Performance (default) or Functional simulation (1)", "0");
+  option_parser_register(opp, "-gpgpu_clock_domains", OPT_CSTR,
+                         &gpgpu_clock_domains,
+                         "Clock Domain Frequencies in MhZ {<Core Clock>:<ICNT "
+                         "Clock>:<L2 Clock>:<DRAM Clock>}",
+                         "500.0:2000.0:2000.0:2000.0");
+  option_parser_register(
+      opp, "-gpgpu_max_concurrent_kernel", OPT_INT32, &max_concurrent_kernel,
+      "maximum kernels that can run concurrently on GPU", "8");
+  option_parser_register(
+      opp, "-gpgpu_cflog_interval", OPT_INT32, &gpgpu_cflog_interval,
+      "Interval between each snapshot in control flow logger", "0");
+  option_parser_register(opp, "-visualizer_enabled", OPT_BOOL,
+                         &g_visualizer_enabled,
+                         "Turn on visualizer output (1=On, 0=Off)", "1");
+  option_parser_register(opp, "-visualizer_outputfile", OPT_CSTR,
+                         &g_visualizer_filename,
+                         "Specifies the output log file for visualizer", NULL);
+  option_parser_register(
+      opp, "-visualizer_zlevel", OPT_INT32, &g_visualizer_zlevel,
+      "Compression level of the visualizer output log (0=no comp, 9=highest)",
+      "6");
+  option_parser_register(opp, "-gpgpu_stack_size_limit", OPT_INT32,
+                         &stack_size_limit, "GPU thread stack size", "1024");
+  option_parser_register(opp, "-gpgpu_heap_size_limit", OPT_INT32,
+                         &heap_size_limit, "GPU malloc heap size ", "8388608");
+  option_parser_register(opp, "-gpgpu_runtime_sync_depth_limit", OPT_INT32,
+                         &runtime_sync_depth_limit,
+                         "GPU device runtime synchronize depth", "2");
+  option_parser_register(opp, "-gpgpu_runtime_pending_launch_count_limit",
+                         OPT_INT32, &runtime_pending_launch_count_limit,
+                         "GPU device runtime pending launch count", "2048");
+  option_parser_register(opp, "-trace_enabled", OPT_BOOL, &Trace::enabled,
+                         "Turn on traces", "0");
+  option_parser_register(opp, "-trace_components", OPT_CSTR, &Trace::config_str,
+                         "comma seperated list of traces to enable. "
+                         "Complete list found in trace_streams.tup. "
+                         "Default none",
+                         "none");
+  option_parser_register(
+      opp, "-trace_sampling_core", OPT_INT32, &Trace::sampling_core,
+      "The core which is printed using CORE_DPRINTF. Default 0", "0");
+  option_parser_register(opp, "-trace_sampling_memory_partition", OPT_INT32,
+                         &Trace::sampling_memory_partition,
+                         "The memory partition which is printed using "
+                         "MEMPART_DPRINTF. Default -1 (i.e. all)",
+                         "-1");
+  gpgpu_ctx->stats->ptx_file_line_stats_options(opp);
 
-    //Jin: kernel launch latency
-    option_parser_register(opp, "-gpgpu_kernel_launch_latency", OPT_INT32, 
-                          &(gpgpu_ctx->device_runtime->g_kernel_launch_latency), "Kernel launch latency in cycles. Default: 0",
-                          "0");
-    option_parser_register(opp, "-gpgpu_cdp_enabled", OPT_BOOL, 
-                          &(gpgpu_ctx->device_runtime->g_cdp_enabled), "Turn on CDP",
-                          "0");
+  // Jin: kernel launch latency
+  option_parser_register(opp, "-gpgpu_kernel_launch_latency", OPT_INT32,
+                         &(gpgpu_ctx->device_runtime->g_kernel_launch_latency),
+                         "Kernel launch latency in cycles. Default: 0", "0");
+  option_parser_register(opp, "-gpgpu_cdp_enabled", OPT_BOOL,
+                         &(gpgpu_ctx->device_runtime->g_cdp_enabled),
+                         "Turn on CDP", "0");
 }
 
 /////////////////////////////////////////////////////////////////////////////
 
-void increment_x_then_y_then_z( dim3 &i, const dim3 &bound)
-{
-   i.x++;
-   if ( i.x >= bound.x ) {
-      i.x = 0;
-      i.y++;
-      if ( i.y >= bound.y ) {
-         i.y = 0;
-         if( i.z < bound.z ) 
-            i.z++;
-      }
-   }
+void increment_x_then_y_then_z(dim3 &i, const dim3 &bound) {
+  i.x++;
+  if (i.x >= bound.x) {
+    i.x = 0;
+    i.y++;
+    if (i.y >= bound.y) {
+      i.y = 0;
+      if (i.z < bound.z) i.z++;
+    }
+  }
 }
 
-void gpgpu_sim::launch( kernel_info_t *kinfo )
-{
-   unsigned cta_size = kinfo->threads_per_cta();
-   if ( cta_size > m_shader_config->n_thread_per_shader ) {
-      printf("Execution error: Shader kernel CTA (block) size is too large for microarch config.\n");
-      printf("                 CTA size (x*y*z) = %u, max supported = %u\n", cta_size, 
-             m_shader_config->n_thread_per_shader );
-      printf("                 => either change -gpgpu_shader argument in gpgpusim.config file or\n");
-      printf("                 modify the CUDA source to decrease the kernel block size.\n");
-      abort();
-   }
-   unsigned n=0;
-   for(n=0; n < m_running_kernels.size(); n++ ) {
-       if( (NULL==m_running_kernels[n]) || m_running_kernels[n]->done() ) {
-           m_running_kernels[n] = kinfo;
-           break;
-       }
-   }
-   assert(n < m_running_kernels.size());
+void gpgpu_sim::launch(kernel_info_t *kinfo) {
+  unsigned cta_size = kinfo->threads_per_cta();
+  if (cta_size > m_shader_config->n_thread_per_shader) {
+    printf(
+        "Execution error: Shader kernel CTA (block) size is too large for "
+        "microarch config.\n");
+    printf("                 CTA size (x*y*z) = %u, max supported = %u\n",
+           cta_size, m_shader_config->n_thread_per_shader);
+    printf(
+        "                 => either change -gpgpu_shader argument in "
+        "gpgpusim.config file or\n");
+    printf(
+        "                 modify the CUDA source to decrease the kernel block "
+        "size.\n");
+    abort();
+  }
+  unsigned n = 0;
+  for (n = 0; n < m_running_kernels.size(); n++) {
+    if ((NULL == m_running_kernels[n]) || m_running_kernels[n]->done()) {
+      m_running_kernels[n] = kinfo;
+      break;
+    }
+  }
+  assert(n < m_running_kernels.size());
 }
 
-bool gpgpu_sim::can_start_kernel()
-{
-   for(unsigned n=0; n < m_running_kernels.size(); n++ ) {
-       if( (NULL==m_running_kernels[n]) || m_running_kernels[n]->done() ) 
-           return true;
-   }
-   return false;
+bool gpgpu_sim::can_start_kernel() {
+  for (unsigned n = 0; n < m_running_kernels.size(); n++) {
+    if ((NULL == m_running_kernels[n]) || m_running_kernels[n]->done())
+      return true;
+  }
+  return false;
 }
 
 bool gpgpu_sim::hit_max_cta_count() const {
-   if (m_config.gpu_max_cta_opt != 0) {
-      if( (gpu_tot_issued_cta + m_total_cta_launched) >= m_config.gpu_max_cta_opt )
-          return true;
-   }
-   return false;
+  if (m_config.gpu_max_cta_opt != 0) {
+    if ((gpu_tot_issued_cta + m_total_cta_launched) >= m_config.gpu_max_cta_opt)
+      return true;
+  }
+  return false;
 }
 
 bool gpgpu_sim::kernel_more_cta_left(kernel_info_t *kernel) const {
-    if(hit_max_cta_count())
-       return false;
+  if (hit_max_cta_count()) return false;
 
-    if(kernel && !kernel->no_more_ctas_to_run())
-        return true;
+  if (kernel && !kernel->no_more_ctas_to_run()) return true;
 
-    return false;
+  return false;
 }
 
-bool gpgpu_sim::get_more_cta_left() const
-{ 
-   if(hit_max_cta_count())
-      return false;
+bool gpgpu_sim::get_more_cta_left() const {
+  if (hit_max_cta_count()) return false;
 
-   for(unsigned n=0; n < m_running_kernels.size(); n++ ) {
-       if( m_running_kernels[n] && !m_running_kernels[n]->no_more_ctas_to_run() ) 
-           return true;
-   }
-   return false;
+  for (unsigned n = 0; n < m_running_kernels.size(); n++) {
+    if (m_running_kernels[n] && !m_running_kernels[n]->no_more_ctas_to_run())
+      return true;
+  }
+  return false;
 }
 
-kernel_info_t *gpgpu_sim::select_kernel()
-{
-    if(m_running_kernels[m_last_issued_kernel] &&
-        !m_running_kernels[m_last_issued_kernel]->no_more_ctas_to_run()) {
-        unsigned launch_uid = m_running_kernels[m_last_issued_kernel]->get_uid(); 
-        if(std::find(m_executed_kernel_uids.begin(), m_executed_kernel_uids.end(), launch_uid) == m_executed_kernel_uids.end()) {
-            m_running_kernels[m_last_issued_kernel]->start_cycle = gpu_sim_cycle + gpu_tot_sim_cycle;
-            m_executed_kernel_uids.push_back(launch_uid); 
-            m_executed_kernel_names.push_back(m_running_kernels[m_last_issued_kernel]->name()); 
-        }
-        return m_running_kernels[m_last_issued_kernel];
+kernel_info_t *gpgpu_sim::select_kernel() {
+  if (m_running_kernels[m_last_issued_kernel] &&
+      !m_running_kernels[m_last_issued_kernel]->no_more_ctas_to_run()) {
+    unsigned launch_uid = m_running_kernels[m_last_issued_kernel]->get_uid();
+    if (std::find(m_executed_kernel_uids.begin(), m_executed_kernel_uids.end(),
+                  launch_uid) == m_executed_kernel_uids.end()) {
+      m_running_kernels[m_last_issued_kernel]->start_cycle =
+          gpu_sim_cycle + gpu_tot_sim_cycle;
+      m_executed_kernel_uids.push_back(launch_uid);
+      m_executed_kernel_names.push_back(
+          m_running_kernels[m_last_issued_kernel]->name());
     }
+    return m_running_kernels[m_last_issued_kernel];
+  }
 
-    for(unsigned n=0; n < m_running_kernels.size(); n++ ) {
-        unsigned idx = (n+m_last_issued_kernel+1)%m_config.max_concurrent_kernel;
-        if( kernel_more_cta_left(m_running_kernels[idx]) ){
-            m_last_issued_kernel=idx;
-            m_running_kernels[idx]->start_cycle = gpu_sim_cycle + gpu_tot_sim_cycle;
-            // record this kernel for stat print if it is the first time this kernel is selected for execution  
-            unsigned launch_uid = m_running_kernels[idx]->get_uid(); 
-            assert(std::find(m_executed_kernel_uids.begin(), m_executed_kernel_uids.end(), launch_uid) == m_executed_kernel_uids.end());
-            m_executed_kernel_uids.push_back(launch_uid); 
-            m_executed_kernel_names.push_back(m_running_kernels[idx]->name()); 
+  for (unsigned n = 0; n < m_running_kernels.size(); n++) {
+    unsigned idx =
+        (n + m_last_issued_kernel + 1) % m_config.max_concurrent_kernel;
+    if (kernel_more_cta_left(m_running_kernels[idx])) {
+      m_last_issued_kernel = idx;
+      m_running_kernels[idx]->start_cycle = gpu_sim_cycle + gpu_tot_sim_cycle;
+      // record this kernel for stat print if it is the first time this kernel
+      // is selected for execution
+      unsigned launch_uid = m_running_kernels[idx]->get_uid();
+      assert(std::find(m_executed_kernel_uids.begin(),
+                       m_executed_kernel_uids.end(),
+                       launch_uid) == m_executed_kernel_uids.end());
+      m_executed_kernel_uids.push_back(launch_uid);
+      m_executed_kernel_names.push_back(m_running_kernels[idx]->name());
 
-            return m_running_kernels[idx];
-        }
+      return m_running_kernels[idx];
     }
-    return NULL;
+  }
+  return NULL;
 }
 
-unsigned gpgpu_sim::finished_kernel()
-{
-    if( m_finished_kernel.empty() ) 
-        return 0;
-    unsigned result = m_finished_kernel.front();
-    m_finished_kernel.pop_front();
-    return result;
+unsigned gpgpu_sim::finished_kernel() {
+  if (m_finished_kernel.empty()) return 0;
+  unsigned result = m_finished_kernel.front();
+  m_finished_kernel.pop_front();
+  return result;
 }
 
-void gpgpu_sim::set_kernel_done( kernel_info_t *kernel ) 
-{ 
-    unsigned uid = kernel->get_uid();
-    m_finished_kernel.push_back(uid);
-    std::vector<kernel_info_t*>::iterator k;
-    for( k=m_running_kernels.begin(); k!=m_running_kernels.end(); k++ ) {
-        if( *k == kernel ) {
-            kernel->end_cycle = gpu_sim_cycle + gpu_tot_sim_cycle;
-            *k = NULL;
-            break;
-        }
+void gpgpu_sim::set_kernel_done(kernel_info_t *kernel) {
+  unsigned uid = kernel->get_uid();
+  m_finished_kernel.push_back(uid);
+  std::vector<kernel_info_t *>::iterator k;
+  for (k = m_running_kernels.begin(); k != m_running_kernels.end(); k++) {
+    if (*k == kernel) {
+      kernel->end_cycle = gpu_sim_cycle + gpu_tot_sim_cycle;
+      *k = NULL;
+      break;
     }
-    assert( k != m_running_kernels.end() ); 
+  }
+  assert(k != m_running_kernels.end());
 }
 
-void gpgpu_sim::stop_all_running_kernels(){
-    std::vector<kernel_info_t *>::iterator k;
-    for(k = m_running_kernels.begin(); k != m_running_kernels.end(); ++k){
-        if(*k != NULL){ // If a kernel is active
-            set_kernel_done(*k); // Stop the kernel
-            assert(*k==NULL);
-        }
+void gpgpu_sim::stop_all_running_kernels() {
+  std::vector<kernel_info_t *>::iterator k;
+  for (k = m_running_kernels.begin(); k != m_running_kernels.end(); ++k) {
+    if (*k != NULL) {       // If a kernel is active
+      set_kernel_done(*k);  // Stop the kernel
+      assert(*k == NULL);
     }
+  }
 }
 
-gpgpu_sim::gpgpu_sim( const gpgpu_sim_config &config, gpgpu_context* ctx )
-    : gpgpu_t(config, ctx), m_config(config)
-{
-    gpgpu_ctx = ctx;
-    m_shader_config = &m_config.m_shader_config;
-    m_memory_config = &m_config.m_memory_config;
-    ctx->ptx_parser->set_ptx_warp_size(m_shader_config);
-    ptx_file_line_stats_create_exposed_latency_tracker(m_config.num_shader());
+gpgpu_sim::gpgpu_sim(const gpgpu_sim_config &config, gpgpu_context *ctx)
+    : gpgpu_t(config, ctx), m_config(config) {
+  gpgpu_ctx = ctx;
+  m_shader_config = &m_config.m_shader_config;
+  m_memory_config = &m_config.m_memory_config;
+  ctx->ptx_parser->set_ptx_warp_size(m_shader_config);
+  ptx_file_line_stats_create_exposed_latency_tracker(m_config.num_shader());
 
 #ifdef GPGPUSIM_POWER_MODEL
-        m_gpgpusim_wrapper = new gpgpu_sim_wrapper(config.g_power_simulation_enabled,config.g_power_config_name);
+  m_gpgpusim_wrapper = new gpgpu_sim_wrapper(config.g_power_simulation_enabled,
+                                             config.g_power_config_name);
 #endif
 
-    m_shader_stats = new shader_core_stats(m_shader_config);
-    m_memory_stats = new memory_stats_t(m_config.num_shader(),m_shader_config,m_memory_config,this);
-    average_pipeline_duty_cycle = (float *)malloc(sizeof(float));
-    active_sms=(float *)malloc(sizeof(float));
-    m_power_stats = new power_stat_t(m_shader_config,average_pipeline_duty_cycle,active_sms,m_shader_stats,m_memory_config,m_memory_stats);
+  m_shader_stats = new shader_core_stats(m_shader_config);
+  m_memory_stats = new memory_stats_t(m_config.num_shader(), m_shader_config,
+                                      m_memory_config, this);
+  average_pipeline_duty_cycle = (float *)malloc(sizeof(float));
+  active_sms = (float *)malloc(sizeof(float));
+  m_power_stats =
+      new power_stat_t(m_shader_config, average_pipeline_duty_cycle, active_sms,
+                       m_shader_stats, m_memory_config, m_memory_stats);
 
-    gpu_sim_insn = 0;
-    gpu_tot_sim_insn = 0;
-    gpu_tot_issued_cta = 0;
-    m_total_cta_launched = 0;
-    gpu_deadlock = false;
+  gpu_sim_insn = 0;
+  gpu_tot_sim_insn = 0;
+  gpu_tot_issued_cta = 0;
+  m_total_cta_launched = 0;
+  gpu_deadlock = false;
 
-    gpu_stall_dramfull = 0;
-    gpu_stall_icnt2sh = 0;
-    partiton_reqs_in_parallel = 0;
-    partiton_reqs_in_parallel_total = 0;
-    partiton_reqs_in_parallel_util = 0;
-    partiton_reqs_in_parallel_util_total = 0;
-    gpu_sim_cycle_parition_util = 0;
-    gpu_tot_sim_cycle_parition_util = 0;
-    partiton_replys_in_parallel = 0;
-    partiton_replys_in_parallel_total = 0;
+  gpu_stall_dramfull = 0;
+  gpu_stall_icnt2sh = 0;
+  partiton_reqs_in_parallel = 0;
+  partiton_reqs_in_parallel_total = 0;
+  partiton_reqs_in_parallel_util = 0;
+  partiton_reqs_in_parallel_util_total = 0;
+  gpu_sim_cycle_parition_util = 0;
+  gpu_tot_sim_cycle_parition_util = 0;
+  partiton_replys_in_parallel = 0;
+  partiton_replys_in_parallel_total = 0;
 
-    m_cluster = new simt_core_cluster*[m_shader_config->n_simt_clusters];
-    for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) 
-        m_cluster[i] = new simt_core_cluster(this,i,m_shader_config,m_memory_config,m_shader_stats,m_memory_stats);
+  m_cluster = new simt_core_cluster *[m_shader_config->n_simt_clusters];
+  for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++)
+    m_cluster[i] =
+        new simt_core_cluster(this, i, m_shader_config, m_memory_config,
+                              m_shader_stats, m_memory_stats);
 
-    m_memory_partition_unit = new memory_partition_unit*[m_memory_config->m_n_mem];
-    m_memory_sub_partition = new memory_sub_partition*[m_memory_config->m_n_mem_sub_partition];
-    for (unsigned i=0;i<m_memory_config->m_n_mem;i++) {
-        m_memory_partition_unit[i] = new memory_partition_unit(i, m_memory_config, m_memory_stats, this);
-        for (unsigned p = 0; p < m_memory_config->m_n_sub_partition_per_memory_channel; p++) {
-            unsigned submpid = i * m_memory_config->m_n_sub_partition_per_memory_channel + p; 
-            m_memory_sub_partition[submpid] = m_memory_partition_unit[i]->get_sub_partition(p); 
-        }
+  m_memory_partition_unit =
+      new memory_partition_unit *[m_memory_config->m_n_mem];
+  m_memory_sub_partition =
+      new memory_sub_partition *[m_memory_config->m_n_mem_sub_partition];
+  for (unsigned i = 0; i < m_memory_config->m_n_mem; i++) {
+    m_memory_partition_unit[i] =
+        new memory_partition_unit(i, m_memory_config, m_memory_stats, this);
+    for (unsigned p = 0;
+         p < m_memory_config->m_n_sub_partition_per_memory_channel; p++) {
+      unsigned submpid =
+          i * m_memory_config->m_n_sub_partition_per_memory_channel + p;
+      m_memory_sub_partition[submpid] =
+          m_memory_partition_unit[i]->get_sub_partition(p);
     }
+  }
 
-    icnt_wrapper_init();
-    icnt_create(m_shader_config->n_simt_clusters,m_memory_config->m_n_mem_sub_partition);
+  icnt_wrapper_init();
+  icnt_create(m_shader_config->n_simt_clusters,
+              m_memory_config->m_n_mem_sub_partition);
 
-    time_vector_create(NUM_MEM_REQ_STAT);
-    fprintf(stdout, "GPGPU-Sim uArch: performance model initialization complete.\n");
+  time_vector_create(NUM_MEM_REQ_STAT);
+  fprintf(stdout,
+          "GPGPU-Sim uArch: performance model initialization complete.\n");
 
-    m_running_kernels.resize( config.max_concurrent_kernel, NULL );
-    m_last_issued_kernel = 0;
-    m_last_cluster_issue = m_shader_config->n_simt_clusters-1; // this causes first launch to use simt cluster 0
-    *average_pipeline_duty_cycle=0;
-    *active_sms=0;
+  m_running_kernels.resize(config.max_concurrent_kernel, NULL);
+  m_last_issued_kernel = 0;
+  m_last_cluster_issue = m_shader_config->n_simt_clusters -
+                         1;  // this causes first launch to use simt cluster 0
+  *average_pipeline_duty_cycle = 0;
+  *active_sms = 0;
 
-    last_liveness_message_time = 0;
-   
-   //Jin: functional simulation for CDP
-   m_functional_sim = false;
-   m_functional_sim_kernel = NULL;
+  last_liveness_message_time = 0;
+
+  // Jin: functional simulation for CDP
+  m_functional_sim = false;
+  m_functional_sim_kernel = NULL;
 }
 
-int gpgpu_sim::shared_mem_size() const
-{
-   return m_shader_config->gpgpu_shmem_size;
+int gpgpu_sim::shared_mem_size() const {
+  return m_shader_config->gpgpu_shmem_size;
 }
 
-int gpgpu_sim::shared_mem_per_block() const
-{
-   return m_shader_config->gpgpu_shmem_per_block;
+int gpgpu_sim::shared_mem_per_block() const {
+  return m_shader_config->gpgpu_shmem_per_block;
 }
 
-int gpgpu_sim::num_registers_per_core() const
-{
-   return m_shader_config->gpgpu_shader_registers;
+int gpgpu_sim::num_registers_per_core() const {
+  return m_shader_config->gpgpu_shader_registers;
 }
 
-int gpgpu_sim::num_registers_per_block() const
-{
-   return m_shader_config->gpgpu_registers_per_block;
+int gpgpu_sim::num_registers_per_block() const {
+  return m_shader_config->gpgpu_registers_per_block;
 }
 
-int gpgpu_sim::wrp_size() const
-{
-   return m_shader_config->warp_size;
+int gpgpu_sim::wrp_size() const { return m_shader_config->warp_size; }
+
+int gpgpu_sim::shader_clock() const { return m_config.core_freq / 1000; }
+
+int gpgpu_sim::max_cta_per_core() const {
+  return m_shader_config->max_cta_per_core;
 }
 
-int gpgpu_sim::shader_clock() const
-{
-   return m_config.core_freq/1000;
+int gpgpu_sim::get_max_cta(const kernel_info_t &k) const {
+  return m_shader_config->max_cta(k);
 }
 
-int gpgpu_sim::max_cta_per_core() const
-{
-   return m_shader_config->max_cta_per_core;
+void gpgpu_sim::set_prop(cudaDeviceProp *prop) { m_cuda_properties = prop; }
+
+int gpgpu_sim::compute_capability_major() const {
+  return m_config.gpgpu_compute_capability_major;
 }
 
-int gpgpu_sim::get_max_cta( const kernel_info_t &k ) const
-{
-   return m_shader_config->max_cta(k);
+int gpgpu_sim::compute_capability_minor() const {
+  return m_config.gpgpu_compute_capability_minor;
 }
 
-void gpgpu_sim::set_prop( cudaDeviceProp *prop )
-{
-   m_cuda_properties = prop;
+const struct cudaDeviceProp *gpgpu_sim::get_prop() const {
+  return m_cuda_properties;
 }
 
-int gpgpu_sim::compute_capability_major() const
-{
-   return m_config.gpgpu_compute_capability_major;
+enum divergence_support_t gpgpu_sim::simd_model() const {
+  return m_shader_config->model;
 }
 
-int gpgpu_sim::compute_capability_minor() const
-{
-   return m_config.gpgpu_compute_capability_minor;
+void gpgpu_sim_config::init_clock_domains(void) {
+  sscanf(gpgpu_clock_domains, "%lf:%lf:%lf:%lf", &core_freq, &icnt_freq,
+         &l2_freq, &dram_freq);
+  core_freq = core_freq MhZ;
+  icnt_freq = icnt_freq MhZ;
+  l2_freq = l2_freq MhZ;
+  dram_freq = dram_freq MhZ;
+  core_period = 1 / core_freq;
+  icnt_period = 1 / icnt_freq;
+  dram_period = 1 / dram_freq;
+  l2_period = 1 / l2_freq;
+  printf("GPGPU-Sim uArch: clock freqs: %lf:%lf:%lf:%lf\n", core_freq,
+         icnt_freq, l2_freq, dram_freq);
+  printf("GPGPU-Sim uArch: clock periods: %.20lf:%.20lf:%.20lf:%.20lf\n",
+         core_period, icnt_period, l2_period, dram_period);
 }
 
-const struct cudaDeviceProp *gpgpu_sim::get_prop() const
-{
-   return m_cuda_properties;
+void gpgpu_sim::reinit_clock_domains(void) {
+  core_time = 0;
+  dram_time = 0;
+  icnt_time = 0;
+  l2_time = 0;
 }
 
-enum divergence_support_t gpgpu_sim::simd_model() const
-{
-   return m_shader_config->model;
-}
-
-void gpgpu_sim_config::init_clock_domains(void ) 
-{
-   sscanf(gpgpu_clock_domains,"%lf:%lf:%lf:%lf", 
-          &core_freq, &icnt_freq, &l2_freq, &dram_freq);
-   core_freq = core_freq MhZ;
-   icnt_freq = icnt_freq MhZ;
-   l2_freq = l2_freq MhZ;
-   dram_freq = dram_freq MhZ;        
-   core_period = 1/core_freq;
-   icnt_period = 1/icnt_freq;
-   dram_period = 1/dram_freq;
-   l2_period = 1/l2_freq;
-   printf("GPGPU-Sim uArch: clock freqs: %lf:%lf:%lf:%lf\n",core_freq,icnt_freq,l2_freq,dram_freq);
-   printf("GPGPU-Sim uArch: clock periods: %.20lf:%.20lf:%.20lf:%.20lf\n",core_period,icnt_period,l2_period,dram_period);
-}
-
-void gpgpu_sim::reinit_clock_domains(void)
-{
-   core_time = 0;
-   dram_time = 0;
-   icnt_time = 0;
-   l2_time = 0;
-}
-
-bool gpgpu_sim::active()
-{
-    if (m_config.gpu_max_cycle_opt && (gpu_tot_sim_cycle + gpu_sim_cycle) >= m_config.gpu_max_cycle_opt) 
-       return false;
-    if (m_config.gpu_max_insn_opt && (gpu_tot_sim_insn + gpu_sim_insn) >= m_config.gpu_max_insn_opt) 
-       return false;
-    if (m_config.gpu_max_cta_opt && (gpu_tot_issued_cta >= m_config.gpu_max_cta_opt) )
-       return false;
-    if (m_config.gpu_deadlock_detect && gpu_deadlock) 
-       return false;
-    for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) 
-       if( m_cluster[i]->get_not_completed()>0 ) 
-           return true;;
-    for (unsigned i=0;i<m_memory_config->m_n_mem;i++) 
-       if( m_memory_partition_unit[i]->busy()>0 )
-           return true;;
-    if( icnt_busy() )
-        return true;
-    if( get_more_cta_left() )
-        return true;
+bool gpgpu_sim::active() {
+  if (m_config.gpu_max_cycle_opt &&
+      (gpu_tot_sim_cycle + gpu_sim_cycle) >= m_config.gpu_max_cycle_opt)
     return false;
+  if (m_config.gpu_max_insn_opt &&
+      (gpu_tot_sim_insn + gpu_sim_insn) >= m_config.gpu_max_insn_opt)
+    return false;
+  if (m_config.gpu_max_cta_opt &&
+      (gpu_tot_issued_cta >= m_config.gpu_max_cta_opt))
+    return false;
+  if (m_config.gpu_deadlock_detect && gpu_deadlock) return false;
+  for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++)
+    if (m_cluster[i]->get_not_completed() > 0) return true;
+  ;
+  for (unsigned i = 0; i < m_memory_config->m_n_mem; i++)
+    if (m_memory_partition_unit[i]->busy() > 0) return true;
+  ;
+  if (icnt_busy()) return true;
+  if (get_more_cta_left()) return true;
+  return false;
 }
 
-void gpgpu_sim::init()
-{
-    // run a CUDA grid on the GPU microarchitecture simulator
-    gpu_sim_cycle = 0;
-    gpu_sim_insn = 0;
-    last_gpu_sim_insn = 0;
-    m_total_cta_launched=0;
-    partiton_reqs_in_parallel = 0;
-    partiton_replys_in_parallel = 0;
-    partiton_reqs_in_parallel_util = 0;
-    gpu_sim_cycle_parition_util = 0;
+void gpgpu_sim::init() {
+  // run a CUDA grid on the GPU microarchitecture simulator
+  gpu_sim_cycle = 0;
+  gpu_sim_insn = 0;
+  last_gpu_sim_insn = 0;
+  m_total_cta_launched = 0;
+  partiton_reqs_in_parallel = 0;
+  partiton_replys_in_parallel = 0;
+  partiton_reqs_in_parallel_util = 0;
+  gpu_sim_cycle_parition_util = 0;
 
-    reinit_clock_domains();
-    gpgpu_ctx->func_sim->set_param_gpgpu_num_shaders(m_config.num_shader());
-    for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) 
-       m_cluster[i]->reinit();
-    m_shader_stats->new_grid();
-    // initialize the control-flow, memory access, memory latency logger
-    if (m_config.g_visualizer_enabled) {
-        create_thread_CFlogger( gpgpu_ctx, m_config.num_shader(), m_shader_config->n_thread_per_shader, 0, m_config.gpgpu_cflog_interval );
-    }
-    shader_CTA_count_create( m_config.num_shader(), m_config.gpgpu_cflog_interval);
-    if (m_config.gpgpu_cflog_interval != 0) {
-       insn_warp_occ_create( m_config.num_shader(), m_shader_config->warp_size );
-       shader_warp_occ_create( m_config.num_shader(), m_shader_config->warp_size, m_config.gpgpu_cflog_interval);
-       shader_mem_acc_create( m_config.num_shader(), m_memory_config->m_n_mem, 4, m_config.gpgpu_cflog_interval);
-       shader_mem_lat_create( m_config.num_shader(), m_config.gpgpu_cflog_interval);
-       shader_cache_access_create( m_config.num_shader(), 3, m_config.gpgpu_cflog_interval);
-       set_spill_interval (m_config.gpgpu_cflog_interval * 40);
-    }
+  reinit_clock_domains();
+  gpgpu_ctx->func_sim->set_param_gpgpu_num_shaders(m_config.num_shader());
+  for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++)
+    m_cluster[i]->reinit();
+  m_shader_stats->new_grid();
+  // initialize the control-flow, memory access, memory latency logger
+  if (m_config.g_visualizer_enabled) {
+    create_thread_CFlogger(gpgpu_ctx, m_config.num_shader(),
+                           m_shader_config->n_thread_per_shader, 0,
+                           m_config.gpgpu_cflog_interval);
+  }
+  shader_CTA_count_create(m_config.num_shader(), m_config.gpgpu_cflog_interval);
+  if (m_config.gpgpu_cflog_interval != 0) {
+    insn_warp_occ_create(m_config.num_shader(), m_shader_config->warp_size);
+    shader_warp_occ_create(m_config.num_shader(), m_shader_config->warp_size,
+                           m_config.gpgpu_cflog_interval);
+    shader_mem_acc_create(m_config.num_shader(), m_memory_config->m_n_mem, 4,
+                          m_config.gpgpu_cflog_interval);
+    shader_mem_lat_create(m_config.num_shader(), m_config.gpgpu_cflog_interval);
+    shader_cache_access_create(m_config.num_shader(), 3,
+                               m_config.gpgpu_cflog_interval);
+    set_spill_interval(m_config.gpgpu_cflog_interval * 40);
+  }
 
-    if (g_network_mode)
-       icnt_init();
+  if (g_network_mode) icnt_init();
 
-    // McPAT initialization function. Called on first launch of GPU
+// McPAT initialization function. Called on first launch of GPU
 #ifdef GPGPUSIM_POWER_MODEL
-    if(m_config.g_power_simulation_enabled){
-        init_mcpat(m_config, m_gpgpusim_wrapper, m_config.gpu_stat_sample_freq,  gpu_tot_sim_insn, gpu_sim_insn);
-    }
+  if (m_config.g_power_simulation_enabled) {
+    init_mcpat(m_config, m_gpgpusim_wrapper, m_config.gpu_stat_sample_freq,
+               gpu_tot_sim_insn, gpu_sim_insn);
+  }
 #endif
 }
 
 void gpgpu_sim::update_stats() {
-    m_memory_stats->memlatstat_lat_pw();
-    gpu_tot_sim_cycle += gpu_sim_cycle;
-    gpu_tot_sim_insn += gpu_sim_insn;
-    gpu_tot_issued_cta += m_total_cta_launched;
-    partiton_reqs_in_parallel_total += partiton_reqs_in_parallel;
-    partiton_replys_in_parallel_total += partiton_replys_in_parallel;
-    partiton_reqs_in_parallel_util_total += partiton_reqs_in_parallel_util;
-    gpu_tot_sim_cycle_parition_util += gpu_sim_cycle_parition_util ;
-    gpu_tot_occupancy += gpu_occupancy;
+  m_memory_stats->memlatstat_lat_pw();
+  gpu_tot_sim_cycle += gpu_sim_cycle;
+  gpu_tot_sim_insn += gpu_sim_insn;
+  gpu_tot_issued_cta += m_total_cta_launched;
+  partiton_reqs_in_parallel_total += partiton_reqs_in_parallel;
+  partiton_replys_in_parallel_total += partiton_replys_in_parallel;
+  partiton_reqs_in_parallel_util_total += partiton_reqs_in_parallel_util;
+  gpu_tot_sim_cycle_parition_util += gpu_sim_cycle_parition_util;
+  gpu_tot_occupancy += gpu_occupancy;
 
-    gpu_sim_cycle = 0;
-    partiton_reqs_in_parallel = 0;
-    partiton_replys_in_parallel = 0;
-    partiton_reqs_in_parallel_util = 0;
-    gpu_sim_cycle_parition_util = 0;
-    gpu_sim_insn = 0;
-    m_total_cta_launched = 0;
-    gpu_occupancy = occupancy_stats();
+  gpu_sim_cycle = 0;
+  partiton_reqs_in_parallel = 0;
+  partiton_replys_in_parallel = 0;
+  partiton_reqs_in_parallel_util = 0;
+  gpu_sim_cycle_parition_util = 0;
+  gpu_sim_insn = 0;
+  m_total_cta_launched = 0;
+  gpu_occupancy = occupancy_stats();
 }
 
-void gpgpu_sim::print_stats()
-{
-    gpgpu_ctx->stats->ptx_file_line_stats_write_file();
-    gpu_print_stat();
+void gpgpu_sim::print_stats() {
+  gpgpu_ctx->stats->ptx_file_line_stats_write_file();
+  gpu_print_stat();
 
-    if (g_network_mode) {
-        printf("----------------------------Interconnect-DETAILS--------------------------------\n" );
-        icnt_display_stats();
-        icnt_display_overall_stats();
-        printf("----------------------------END-of-Interconnect-DETAILS-------------------------\n" );
+  if (g_network_mode) {
+    printf(
+        "----------------------------Interconnect-DETAILS----------------------"
+        "----------\n");
+    icnt_display_stats();
+    icnt_display_overall_stats();
+    printf(
+        "----------------------------END-of-Interconnect-DETAILS---------------"
+        "----------\n");
+  }
+}
+
+void gpgpu_sim::deadlock_check() {
+  if (m_config.gpu_deadlock_detect && gpu_deadlock) {
+    fflush(stdout);
+    printf(
+        "\n\nGPGPU-Sim uArch: ERROR ** deadlock detected: last writeback core "
+        "%u @ gpu_sim_cycle %u (+ gpu_tot_sim_cycle %u) (%u cycles ago)\n",
+        gpu_sim_insn_last_update_sid, (unsigned)gpu_sim_insn_last_update,
+        (unsigned)(gpu_tot_sim_cycle - gpu_sim_cycle),
+        (unsigned)(gpu_sim_cycle - gpu_sim_insn_last_update));
+    unsigned num_cores = 0;
+    for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++) {
+      unsigned not_completed = m_cluster[i]->get_not_completed();
+      if (not_completed) {
+        if (!num_cores) {
+          printf(
+              "GPGPU-Sim uArch: DEADLOCK  shader cores no longer committing "
+              "instructions [core(# threads)]:\n");
+          printf("GPGPU-Sim uArch: DEADLOCK  ");
+          m_cluster[i]->print_not_completed(stdout);
+        } else if (num_cores < 8) {
+          m_cluster[i]->print_not_completed(stdout);
+        } else if (num_cores >= 8) {
+          printf(" + others ... ");
+        }
+        num_cores += m_shader_config->n_simt_cores_per_cluster;
+      }
     }
+    printf("\n");
+    for (unsigned i = 0; i < m_memory_config->m_n_mem; i++) {
+      bool busy = m_memory_partition_unit[i]->busy();
+      if (busy)
+        printf("GPGPU-Sim uArch DEADLOCK:  memory partition %u busy\n", i);
+    }
+    if (icnt_busy()) {
+      printf("GPGPU-Sim uArch DEADLOCK:  iterconnect contains traffic\n");
+      icnt_display_state(stdout);
+    }
+    printf(
+        "\nRe-run the simulator in gdb and use debug routines in .gdbinit to "
+        "debug this\n");
+    fflush(stdout);
+    abort();
+  }
 }
 
-void gpgpu_sim::deadlock_check()
-{
-   if (m_config.gpu_deadlock_detect && gpu_deadlock) {
-      fflush(stdout);
-      printf("\n\nGPGPU-Sim uArch: ERROR ** deadlock detected: last writeback core %u @ gpu_sim_cycle %u (+ gpu_tot_sim_cycle %u) (%u cycles ago)\n", 
-             gpu_sim_insn_last_update_sid,
-             (unsigned) gpu_sim_insn_last_update, (unsigned) (gpu_tot_sim_cycle-gpu_sim_cycle),
-             (unsigned) (gpu_sim_cycle - gpu_sim_insn_last_update )); 
-      unsigned num_cores=0;
-      for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) {
-         unsigned not_completed = m_cluster[i]->get_not_completed();
-         if( not_completed ) {
-             if ( !num_cores )  {
-                 printf("GPGPU-Sim uArch: DEADLOCK  shader cores no longer committing instructions [core(# threads)]:\n" );
-                 printf("GPGPU-Sim uArch: DEADLOCK  ");
-                 m_cluster[i]->print_not_completed(stdout);
-             } else if (num_cores < 8 ) {
-                 m_cluster[i]->print_not_completed(stdout);
-             } else if (num_cores >= 8 ) {
-                 printf(" + others ... ");
-             }
-             num_cores+=m_shader_config->n_simt_cores_per_cluster;
-         }
+/// printing the names and uids of a set of executed kernels (usually there is
+/// only one)
+std::string gpgpu_sim::executed_kernel_info_string() {
+  std::stringstream statout;
+
+  statout << "kernel_name = ";
+  for (unsigned int k = 0; k < m_executed_kernel_names.size(); k++) {
+    statout << m_executed_kernel_names[k] << " ";
+  }
+  statout << std::endl;
+  statout << "kernel_launch_uid = ";
+  for (unsigned int k = 0; k < m_executed_kernel_uids.size(); k++) {
+    statout << m_executed_kernel_uids[k] << " ";
+  }
+  statout << std::endl;
+
+  return statout.str();
+}
+void gpgpu_sim::set_cache_config(std::string kernel_name,
+                                 FuncCache cacheConfig) {
+  m_special_cache_config[kernel_name] = cacheConfig;
+}
+
+FuncCache gpgpu_sim::get_cache_config(std::string kernel_name) {
+  for (std::map<std::string, FuncCache>::iterator iter =
+           m_special_cache_config.begin();
+       iter != m_special_cache_config.end(); iter++) {
+    std::string kernel = iter->first;
+    if (kernel_name.compare(kernel) == 0) {
+      return iter->second;
+    }
+  }
+  return (FuncCache)0;
+}
+
+bool gpgpu_sim::has_special_cache_config(std::string kernel_name) {
+  for (std::map<std::string, FuncCache>::iterator iter =
+           m_special_cache_config.begin();
+       iter != m_special_cache_config.end(); iter++) {
+    std::string kernel = iter->first;
+    if (kernel_name.compare(kernel) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void gpgpu_sim::set_cache_config(std::string kernel_name) {
+  if (has_special_cache_config(kernel_name)) {
+    change_cache_config(get_cache_config(kernel_name));
+  } else {
+    change_cache_config(FuncCachePreferNone);
+  }
+}
+
+void gpgpu_sim::change_cache_config(FuncCache cache_config) {
+  if (cache_config != m_shader_config->m_L1D_config.get_cache_status()) {
+    printf("FLUSH L1 Cache at configuration change between kernels\n");
+    for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++) {
+      m_cluster[i]->cache_invalidate();
+    }
+  }
+
+  switch (cache_config) {
+    case FuncCachePreferNone:
+      m_shader_config->m_L1D_config.init(
+          m_shader_config->m_L1D_config.m_config_string, FuncCachePreferNone);
+      m_shader_config->gpgpu_shmem_size =
+          m_shader_config->gpgpu_shmem_sizeDefault;
+      break;
+    case FuncCachePreferL1:
+      if ((m_shader_config->m_L1D_config.m_config_stringPrefL1 == NULL) ||
+          (m_shader_config->gpgpu_shmem_sizePrefL1 == (unsigned)-1)) {
+        printf("WARNING: missing Preferred L1 configuration\n");
+        m_shader_config->m_L1D_config.init(
+            m_shader_config->m_L1D_config.m_config_string, FuncCachePreferNone);
+        m_shader_config->gpgpu_shmem_size =
+            m_shader_config->gpgpu_shmem_sizeDefault;
+
+      } else {
+        m_shader_config->m_L1D_config.init(
+            m_shader_config->m_L1D_config.m_config_stringPrefL1,
+            FuncCachePreferL1);
+        m_shader_config->gpgpu_shmem_size =
+            m_shader_config->gpgpu_shmem_sizePrefL1;
       }
-      printf("\n");
-      for (unsigned i=0;i<m_memory_config->m_n_mem;i++) {
-         bool busy = m_memory_partition_unit[i]->busy();
-         if( busy ) 
-             printf("GPGPU-Sim uArch DEADLOCK:  memory partition %u busy\n", i );
+      break;
+    case FuncCachePreferShared:
+      if ((m_shader_config->m_L1D_config.m_config_stringPrefShared == NULL) ||
+          (m_shader_config->gpgpu_shmem_sizePrefShared == (unsigned)-1)) {
+        printf("WARNING: missing Preferred L1 configuration\n");
+        m_shader_config->m_L1D_config.init(
+            m_shader_config->m_L1D_config.m_config_string, FuncCachePreferNone);
+        m_shader_config->gpgpu_shmem_size =
+            m_shader_config->gpgpu_shmem_sizeDefault;
+      } else {
+        m_shader_config->m_L1D_config.init(
+            m_shader_config->m_L1D_config.m_config_stringPrefShared,
+            FuncCachePreferShared);
+        m_shader_config->gpgpu_shmem_size =
+            m_shader_config->gpgpu_shmem_sizePrefShared;
       }
-      if( icnt_busy() ) {
-         printf("GPGPU-Sim uArch DEADLOCK:  iterconnect contains traffic\n");
-         icnt_display_state( stdout );
-      }
-      printf("\nRe-run the simulator in gdb and use debug routines in .gdbinit to debug this\n");
-      fflush(stdout);
-      abort();
-   }
+      break;
+    default:
+      break;
+  }
 }
 
-/// printing the names and uids of a set of executed kernels (usually there is only one)
-std::string gpgpu_sim::executed_kernel_info_string() 
-{
-   std::stringstream statout; 
-
-   statout << "kernel_name = "; 
-   for (unsigned int k = 0; k < m_executed_kernel_names.size(); k++) {
-      statout << m_executed_kernel_names[k] << " "; 
-   }
-   statout << std::endl; 
-   statout << "kernel_launch_uid = ";
-   for (unsigned int k = 0; k < m_executed_kernel_uids.size(); k++) {
-      statout << m_executed_kernel_uids[k] << " "; 
-   }
-   statout << std::endl; 
-
-   return statout.str(); 
+void gpgpu_sim::clear_executed_kernel_info() {
+  m_executed_kernel_names.clear();
+  m_executed_kernel_uids.clear();
 }
-void gpgpu_sim::set_cache_config(std::string kernel_name,  FuncCache cacheConfig )
-{
-	m_special_cache_config[kernel_name]=cacheConfig ;
-}
+void gpgpu_sim::gpu_print_stat() {
+  FILE *statfout = stdout;
 
-FuncCache gpgpu_sim::get_cache_config(std::string kernel_name)
-{
-	for (	std::map<std::string, FuncCache>::iterator iter = m_special_cache_config.begin(); iter != m_special_cache_config.end(); iter++){
-		    std::string kernel= iter->first;
-			if (kernel_name.compare(kernel) == 0){
-				return iter->second;
-			}
-	}
-	return (FuncCache)0;
-}
+  std::string kernel_info_str = executed_kernel_info_string();
+  fprintf(statfout, "%s", kernel_info_str.c_str());
 
-bool gpgpu_sim::has_special_cache_config(std::string kernel_name)
-{
-	for (	std::map<std::string, FuncCache>::iterator iter = m_special_cache_config.begin(); iter != m_special_cache_config.end(); iter++){
-	    	std::string kernel= iter->first;
-			if (kernel_name.compare(kernel) == 0){
-				return true;
-			}
-	}
-	return false;
-}
+  printf("gpu_sim_cycle = %lld\n", gpu_sim_cycle);
+  printf("gpu_sim_insn = %lld\n", gpu_sim_insn);
+  printf("gpu_ipc = %12.4f\n", (float)gpu_sim_insn / gpu_sim_cycle);
+  printf("gpu_tot_sim_cycle = %lld\n", gpu_tot_sim_cycle + gpu_sim_cycle);
+  printf("gpu_tot_sim_insn = %lld\n", gpu_tot_sim_insn + gpu_sim_insn);
+  printf("gpu_tot_ipc = %12.4f\n", (float)(gpu_tot_sim_insn + gpu_sim_insn) /
+                                       (gpu_tot_sim_cycle + gpu_sim_cycle));
+  printf("gpu_tot_issued_cta = %lld\n",
+         gpu_tot_issued_cta + m_total_cta_launched);
+  printf("gpu_occupancy = %.4f%% \n", gpu_occupancy.get_occ_fraction() * 100);
+  printf("gpu_tot_occupancy = %.4f%% \n",
+         (gpu_occupancy + gpu_tot_occupancy).get_occ_fraction() * 100);
 
+  fprintf(statfout, "max_total_param_size = %llu\n",
+          gpgpu_ctx->device_runtime->g_max_total_param_size);
 
-void gpgpu_sim::set_cache_config(std::string kernel_name)
-{
-	if(has_special_cache_config(kernel_name)){
-		change_cache_config(get_cache_config(kernel_name));
-	}else{
-		change_cache_config(FuncCachePreferNone);
-	}
-}
+  // performance counter for stalls due to congestion.
+  printf("gpu_stall_dramfull = %d\n", gpu_stall_dramfull);
+  printf("gpu_stall_icnt2sh    = %d\n", gpu_stall_icnt2sh);
 
+  // printf("partiton_reqs_in_parallel = %lld\n", partiton_reqs_in_parallel);
+  // printf("partiton_reqs_in_parallel_total    = %lld\n",
+  // partiton_reqs_in_parallel_total );
+  printf("partiton_level_parallism = %12.4f\n",
+         (float)partiton_reqs_in_parallel / gpu_sim_cycle);
+  printf("partiton_level_parallism_total  = %12.4f\n",
+         (float)(partiton_reqs_in_parallel + partiton_reqs_in_parallel_total) /
+             (gpu_tot_sim_cycle + gpu_sim_cycle));
+  // printf("partiton_reqs_in_parallel_util = %lld\n",
+  // partiton_reqs_in_parallel_util);
+  // printf("partiton_reqs_in_parallel_util_total    = %lld\n",
+  // partiton_reqs_in_parallel_util_total );
+  // printf("gpu_sim_cycle_parition_util = %lld\n",
+  // gpu_sim_cycle_parition_util);
+  // printf("gpu_tot_sim_cycle_parition_util    = %lld\n",
+  // gpu_tot_sim_cycle_parition_util );
+  printf("partiton_level_parallism_util = %12.4f\n",
+         (float)partiton_reqs_in_parallel_util / gpu_sim_cycle_parition_util);
+  printf("partiton_level_parallism_util_total  = %12.4f\n",
+         (float)(partiton_reqs_in_parallel_util +
+                 partiton_reqs_in_parallel_util_total) /
+             (gpu_sim_cycle_parition_util + gpu_tot_sim_cycle_parition_util));
+  // printf("partiton_replys_in_parallel = %lld\n",
+  // partiton_replys_in_parallel);
+  // printf("partiton_replys_in_parallel_total    = %lld\n",
+  // partiton_replys_in_parallel_total );
+  printf("L2_BW  = %12.4f GB/Sec\n",
+         ((float)(partiton_replys_in_parallel * 32) /
+          (gpu_sim_cycle * m_config.icnt_period)) /
+             1000000000);
+  printf("L2_BW_total  = %12.4f GB/Sec\n",
+         ((float)((partiton_replys_in_parallel +
+                   partiton_replys_in_parallel_total) *
+                  32) /
+          ((gpu_tot_sim_cycle + gpu_sim_cycle) * m_config.icnt_period)) /
+             1000000000);
 
-void gpgpu_sim::change_cache_config(FuncCache cache_config)
-{
-	if(cache_config != m_shader_config->m_L1D_config.get_cache_status()){
-		printf("FLUSH L1 Cache at configuration change between kernels\n");
-		for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) {
-			m_cluster[i]->cache_invalidate();
-	    }
-	}
+  time_t curr_time;
+  time(&curr_time);
+  unsigned long long elapsed_time =
+      MAX(curr_time - gpgpu_ctx->the_gpgpusim->g_simulation_starttime, 1);
+  printf("gpu_total_sim_rate=%u\n",
+         (unsigned)((gpu_tot_sim_insn + gpu_sim_insn) / elapsed_time));
 
-	switch(cache_config){
-	case FuncCachePreferNone:
-		m_shader_config->m_L1D_config.init(m_shader_config->m_L1D_config.m_config_string, FuncCachePreferNone);
-		m_shader_config->gpgpu_shmem_size=m_shader_config->gpgpu_shmem_sizeDefault;
-		break;
-	case FuncCachePreferL1:
-		if((m_shader_config->m_L1D_config.m_config_stringPrefL1 == NULL) || (m_shader_config->gpgpu_shmem_sizePrefL1 == (unsigned)-1))
-		{
-			printf("WARNING: missing Preferred L1 configuration\n");
-			m_shader_config->m_L1D_config.init(m_shader_config->m_L1D_config.m_config_string, FuncCachePreferNone);
-			m_shader_config->gpgpu_shmem_size=m_shader_config->gpgpu_shmem_sizeDefault;
+  // shader_print_l1_miss_stat( stdout );
+  shader_print_cache_stats(stdout);
 
-		}else{
-			m_shader_config->m_L1D_config.init(m_shader_config->m_L1D_config.m_config_stringPrefL1, FuncCachePreferL1);
-			m_shader_config->gpgpu_shmem_size=m_shader_config->gpgpu_shmem_sizePrefL1;
-		}
-		break;
-	case FuncCachePreferShared:
-		if((m_shader_config->m_L1D_config.m_config_stringPrefShared == NULL) || (m_shader_config->gpgpu_shmem_sizePrefShared == (unsigned)-1))
-		{
-			printf("WARNING: missing Preferred L1 configuration\n");
-			m_shader_config->m_L1D_config.init(m_shader_config->m_L1D_config.m_config_string, FuncCachePreferNone);
-			m_shader_config->gpgpu_shmem_size=m_shader_config->gpgpu_shmem_sizeDefault;
-		}else{
-			m_shader_config->m_L1D_config.init(m_shader_config->m_L1D_config.m_config_stringPrefShared, FuncCachePreferShared);
-			m_shader_config->gpgpu_shmem_size=m_shader_config->gpgpu_shmem_sizePrefShared;
-		}
-		break;
-	default:
-		break;
-	}
-}
+  cache_stats core_cache_stats;
+  core_cache_stats.clear();
+  for (unsigned i = 0; i < m_config.num_cluster(); i++) {
+    m_cluster[i]->get_cache_stats(core_cache_stats);
+  }
+  printf("\nTotal_core_cache_stats:\n");
+  core_cache_stats.print_stats(stdout, "Total_core_cache_stats_breakdown");
+  printf("\nTotal_core_cache_fail_stats:\n");
+  core_cache_stats.print_fail_stats(stdout,
+                                    "Total_core_cache_fail_stats_breakdown");
+  shader_print_scheduler_stat(stdout, false);
 
-
-void gpgpu_sim::clear_executed_kernel_info()
-{
-   m_executed_kernel_names.clear();
-   m_executed_kernel_uids.clear();
-}
-void gpgpu_sim::gpu_print_stat() 
-{  
-   FILE *statfout = stdout; 
-
-   std::string kernel_info_str = executed_kernel_info_string(); 
-   fprintf(statfout, "%s", kernel_info_str.c_str()); 
-
-   printf("gpu_sim_cycle = %lld\n", gpu_sim_cycle);
-   printf("gpu_sim_insn = %lld\n", gpu_sim_insn);
-   printf("gpu_ipc = %12.4f\n", (float)gpu_sim_insn / gpu_sim_cycle);
-   printf("gpu_tot_sim_cycle = %lld\n", gpu_tot_sim_cycle+gpu_sim_cycle);
-   printf("gpu_tot_sim_insn = %lld\n", gpu_tot_sim_insn+gpu_sim_insn);
-   printf("gpu_tot_ipc = %12.4f\n", (float)(gpu_tot_sim_insn+gpu_sim_insn) / (gpu_tot_sim_cycle+gpu_sim_cycle));
-   printf("gpu_tot_issued_cta = %lld\n", gpu_tot_issued_cta + m_total_cta_launched);
-   printf("gpu_occupancy = %.4f%% \n", gpu_occupancy.get_occ_fraction() * 100);
-   printf("gpu_tot_occupancy = %.4f%% \n", (gpu_occupancy + gpu_tot_occupancy).get_occ_fraction() * 100);
-
-
-   fprintf(statfout, "max_total_param_size = %llu\n", gpgpu_ctx->device_runtime->g_max_total_param_size);
-
-   // performance counter for stalls due to congestion.
-   printf("gpu_stall_dramfull = %d\n", gpu_stall_dramfull);
-   printf("gpu_stall_icnt2sh    = %d\n", gpu_stall_icnt2sh );
-
-   //printf("partiton_reqs_in_parallel = %lld\n", partiton_reqs_in_parallel);
-   //printf("partiton_reqs_in_parallel_total    = %lld\n", partiton_reqs_in_parallel_total );
-   printf("partiton_level_parallism = %12.4f\n", (float)partiton_reqs_in_parallel / gpu_sim_cycle);
-   printf("partiton_level_parallism_total  = %12.4f\n", (float)(partiton_reqs_in_parallel+partiton_reqs_in_parallel_total) / (gpu_tot_sim_cycle+gpu_sim_cycle) );
-   //printf("partiton_reqs_in_parallel_util = %lld\n", partiton_reqs_in_parallel_util);
-   //printf("partiton_reqs_in_parallel_util_total    = %lld\n", partiton_reqs_in_parallel_util_total );
-   //printf("gpu_sim_cycle_parition_util = %lld\n", gpu_sim_cycle_parition_util);
-   // printf("gpu_tot_sim_cycle_parition_util    = %lld\n", gpu_tot_sim_cycle_parition_util );
-   printf("partiton_level_parallism_util = %12.4f\n", (float)partiton_reqs_in_parallel_util / gpu_sim_cycle_parition_util);
-   printf("partiton_level_parallism_util_total  = %12.4f\n", (float)(partiton_reqs_in_parallel_util+partiton_reqs_in_parallel_util_total) / (gpu_sim_cycle_parition_util+gpu_tot_sim_cycle_parition_util) );
-   //printf("partiton_replys_in_parallel = %lld\n", partiton_replys_in_parallel);
-   //printf("partiton_replys_in_parallel_total    = %lld\n", partiton_replys_in_parallel_total );
-   printf("L2_BW  = %12.4f GB/Sec\n", ((float)(partiton_replys_in_parallel * 32) / (gpu_sim_cycle * m_config.icnt_period)) / 1000000000);
-   printf("L2_BW_total  = %12.4f GB/Sec\n", ((float)((partiton_replys_in_parallel+partiton_replys_in_parallel_total) * 32) / ((gpu_tot_sim_cycle+gpu_sim_cycle) * m_config.icnt_period)) / 1000000000 );
-
-   time_t curr_time;
-   time(&curr_time);
-   unsigned long long elapsed_time = MAX( curr_time - gpgpu_ctx->the_gpgpusim->g_simulation_starttime, 1 );
-   printf( "gpu_total_sim_rate=%u\n", (unsigned)( ( gpu_tot_sim_insn + gpu_sim_insn ) / elapsed_time ) );
-
-   //shader_print_l1_miss_stat( stdout );
-   shader_print_cache_stats(stdout);
-
-   cache_stats core_cache_stats;
-   core_cache_stats.clear();
-   for(unsigned i=0; i<m_config.num_cluster(); i++){
-       m_cluster[i]->get_cache_stats(core_cache_stats);
-   }
-   printf("\nTotal_core_cache_stats:\n");
-   core_cache_stats.print_stats(stdout, "Total_core_cache_stats_breakdown");
-   printf("\nTotal_core_cache_fail_stats:\n");
-   core_cache_stats.print_fail_stats(stdout, "Total_core_cache_fail_stats_breakdown");
-   shader_print_scheduler_stat( stdout, false );
-
-   m_shader_stats->print(stdout);
+  m_shader_stats->print(stdout);
 #ifdef GPGPUSIM_POWER_MODEL
-   if(m_config.g_power_simulation_enabled){
-	   m_gpgpusim_wrapper->print_power_kernel_stats(gpu_sim_cycle, gpu_tot_sim_cycle, gpu_tot_sim_insn + gpu_sim_insn, kernel_info_str, true );
-	   mcpat_reset_perf_count(m_gpgpusim_wrapper);
-   }
+  if (m_config.g_power_simulation_enabled) {
+    m_gpgpusim_wrapper->print_power_kernel_stats(
+        gpu_sim_cycle, gpu_tot_sim_cycle, gpu_tot_sim_insn + gpu_sim_insn,
+        kernel_info_str, true);
+    mcpat_reset_perf_count(m_gpgpusim_wrapper);
+  }
 #endif
 
-   // performance counter that are not local to one shader
-   m_memory_stats->memlatstat_print(m_memory_config->m_n_mem,m_memory_config->nbk);
-   for (unsigned i=0;i<m_memory_config->m_n_mem;i++)
-      m_memory_partition_unit[i]->print(stdout);
+  // performance counter that are not local to one shader
+  m_memory_stats->memlatstat_print(m_memory_config->m_n_mem,
+                                   m_memory_config->nbk);
+  for (unsigned i = 0; i < m_memory_config->m_n_mem; i++)
+    m_memory_partition_unit[i]->print(stdout);
 
-   // L2 cache stats
-   if(!m_memory_config->m_L2_config.disabled()){
-       cache_stats l2_stats;
-       struct cache_sub_stats l2_css;
-       struct cache_sub_stats total_l2_css;
-       l2_stats.clear();
-       l2_css.clear();
-       total_l2_css.clear();
+  // L2 cache stats
+  if (!m_memory_config->m_L2_config.disabled()) {
+    cache_stats l2_stats;
+    struct cache_sub_stats l2_css;
+    struct cache_sub_stats total_l2_css;
+    l2_stats.clear();
+    l2_css.clear();
+    total_l2_css.clear();
 
-       printf("\n========= L2 cache stats =========\n");
-       for (unsigned i=0;i<m_memory_config->m_n_mem_sub_partition;i++){
-           m_memory_sub_partition[i]->accumulate_L2cache_stats(l2_stats);
-           m_memory_sub_partition[i]->get_L2cache_sub_stats(l2_css);
+    printf("\n========= L2 cache stats =========\n");
+    for (unsigned i = 0; i < m_memory_config->m_n_mem_sub_partition; i++) {
+      m_memory_sub_partition[i]->accumulate_L2cache_stats(l2_stats);
+      m_memory_sub_partition[i]->get_L2cache_sub_stats(l2_css);
 
-           fprintf( stdout, "L2_cache_bank[%d]: Access = %llu, Miss = %llu, Miss_rate = %.3lf, Pending_hits = %llu, Reservation_fails = %llu\n",
-                    i, l2_css.accesses, l2_css.misses, (double)l2_css.misses / (double)l2_css.accesses, l2_css.pending_hits, l2_css.res_fails);
+      fprintf(stdout,
+              "L2_cache_bank[%d]: Access = %llu, Miss = %llu, Miss_rate = "
+              "%.3lf, Pending_hits = %llu, Reservation_fails = %llu\n",
+              i, l2_css.accesses, l2_css.misses,
+              (double)l2_css.misses / (double)l2_css.accesses,
+              l2_css.pending_hits, l2_css.res_fails);
 
-           total_l2_css += l2_css;
-       }
-       if (!m_memory_config->m_L2_config.disabled() && m_memory_config->m_L2_config.get_num_lines()) {
-          //L2c_print_cache_stat();
-          printf("L2_total_cache_accesses = %llu\n", total_l2_css.accesses);
-          printf("L2_total_cache_misses = %llu\n", total_l2_css.misses);
-          if(total_l2_css.accesses > 0)
-              printf("L2_total_cache_miss_rate = %.4lf\n", (double)total_l2_css.misses/(double)total_l2_css.accesses);
-          printf("L2_total_cache_pending_hits = %llu\n", total_l2_css.pending_hits);
-          printf("L2_total_cache_reservation_fails = %llu\n", total_l2_css.res_fails);
-          printf("L2_total_cache_breakdown:\n");
-          l2_stats.print_stats(stdout, "L2_cache_stats_breakdown");
-          printf("L2_total_cache_reservation_fail_breakdown:\n");
-          l2_stats.print_fail_stats(stdout, "L2_cache_stats_fail_breakdown");
-          total_l2_css.print_port_stats(stdout, "L2_cache");
-       }
-   }
+      total_l2_css += l2_css;
+    }
+    if (!m_memory_config->m_L2_config.disabled() &&
+        m_memory_config->m_L2_config.get_num_lines()) {
+      // L2c_print_cache_stat();
+      printf("L2_total_cache_accesses = %llu\n", total_l2_css.accesses);
+      printf("L2_total_cache_misses = %llu\n", total_l2_css.misses);
+      if (total_l2_css.accesses > 0)
+        printf("L2_total_cache_miss_rate = %.4lf\n",
+               (double)total_l2_css.misses / (double)total_l2_css.accesses);
+      printf("L2_total_cache_pending_hits = %llu\n", total_l2_css.pending_hits);
+      printf("L2_total_cache_reservation_fails = %llu\n",
+             total_l2_css.res_fails);
+      printf("L2_total_cache_breakdown:\n");
+      l2_stats.print_stats(stdout, "L2_cache_stats_breakdown");
+      printf("L2_total_cache_reservation_fail_breakdown:\n");
+      l2_stats.print_fail_stats(stdout, "L2_cache_stats_fail_breakdown");
+      total_l2_css.print_port_stats(stdout, "L2_cache");
+    }
+  }
 
-   if (m_config.gpgpu_cflog_interval != 0) {
-      spill_log_to_file (stdout, 1, gpu_sim_cycle);
-      insn_warp_occ_print(stdout);
-   }
-   if ( gpgpu_ctx->func_sim->gpgpu_ptx_instruction_classification ) {
-      StatDisp( gpgpu_ctx->func_sim->g_inst_classification_stat[gpgpu_ctx->func_sim->g_ptx_kernel_count]);
-      StatDisp( gpgpu_ctx->func_sim->g_inst_op_classification_stat[gpgpu_ctx->func_sim->g_ptx_kernel_count]);
-   }
+  if (m_config.gpgpu_cflog_interval != 0) {
+    spill_log_to_file(stdout, 1, gpu_sim_cycle);
+    insn_warp_occ_print(stdout);
+  }
+  if (gpgpu_ctx->func_sim->gpgpu_ptx_instruction_classification) {
+    StatDisp(gpgpu_ctx->func_sim->g_inst_classification_stat
+                 [gpgpu_ctx->func_sim->g_ptx_kernel_count]);
+    StatDisp(gpgpu_ctx->func_sim->g_inst_op_classification_stat
+                 [gpgpu_ctx->func_sim->g_ptx_kernel_count]);
+  }
 
 #ifdef GPGPUSIM_POWER_MODEL
-   if(m_config.g_power_simulation_enabled){
-       m_gpgpusim_wrapper->detect_print_steady_state(1,gpu_tot_sim_insn+gpu_sim_insn);
-   }
+  if (m_config.g_power_simulation_enabled) {
+    m_gpgpusim_wrapper->detect_print_steady_state(
+        1, gpu_tot_sim_insn + gpu_sim_insn);
+  }
 #endif
 
+  // Interconnect power stat print
+  long total_simt_to_mem = 0;
+  long total_mem_to_simt = 0;
+  long temp_stm = 0;
+  long temp_mts = 0;
+  for (unsigned i = 0; i < m_config.num_cluster(); i++) {
+    m_cluster[i]->get_icnt_stats(temp_stm, temp_mts);
+    total_simt_to_mem += temp_stm;
+    total_mem_to_simt += temp_mts;
+  }
+  printf("\nicnt_total_pkts_mem_to_simt=%ld\n", total_mem_to_simt);
+  printf("icnt_total_pkts_simt_to_mem=%ld\n", total_simt_to_mem);
 
-   // Interconnect power stat print
-   long total_simt_to_mem=0;
-   long total_mem_to_simt=0;
-   long temp_stm=0;
-   long temp_mts = 0;
-   for(unsigned i=0; i<m_config.num_cluster(); i++){
-	   m_cluster[i]->get_icnt_stats(temp_stm, temp_mts);
-	   total_simt_to_mem += temp_stm;
-	   total_mem_to_simt += temp_mts;
-   }
-   printf("\nicnt_total_pkts_mem_to_simt=%ld\n", total_mem_to_simt);
-   printf("icnt_total_pkts_simt_to_mem=%ld\n", total_simt_to_mem);
+  time_vector_print();
+  fflush(stdout);
 
-   time_vector_print();
-   fflush(stdout);
-
-   clear_executed_kernel_info(); 
+  clear_executed_kernel_info();
 }
-
 
 // performance counter that are not local to one shader
-unsigned gpgpu_sim::threads_per_core() const 
-{ 
-   return m_shader_config->n_thread_per_shader; 
+unsigned gpgpu_sim::threads_per_core() const {
+  return m_shader_config->n_thread_per_shader;
 }
 
-void shader_core_ctx::mem_instruction_stats(const warp_inst_t &inst)
-{
-    unsigned active_count = inst.active_count(); 
-    //this breaks some encapsulation: the is_[space] functions, if you change those, change this.
-    switch (inst.space.get_type()) {
+void shader_core_ctx::mem_instruction_stats(const warp_inst_t &inst) {
+  unsigned active_count = inst.active_count();
+  // this breaks some encapsulation: the is_[space] functions, if you change
+  // those, change this.
+  switch (inst.space.get_type()) {
     case undefined_space:
     case reg_space:
-        break;
+      break;
     case shared_space:
-        m_stats->gpgpu_n_shmem_insn += active_count; 
-        break;
+      m_stats->gpgpu_n_shmem_insn += active_count;
+      break;
     case sstarr_space:
-    	m_stats->gpgpu_n_sstarr_insn += active_count;
-    	break;
+      m_stats->gpgpu_n_sstarr_insn += active_count;
+      break;
     case const_space:
-        m_stats->gpgpu_n_const_insn += active_count;
-        break;
+      m_stats->gpgpu_n_const_insn += active_count;
+      break;
     case param_space_kernel:
     case param_space_local:
-        m_stats->gpgpu_n_param_insn += active_count;
-        break;
+      m_stats->gpgpu_n_param_insn += active_count;
+      break;
     case tex_space:
-        m_stats->gpgpu_n_tex_insn += active_count;
-        break;
+      m_stats->gpgpu_n_tex_insn += active_count;
+      break;
     case global_space:
     case local_space:
-        if( inst.is_store() )
-            m_stats->gpgpu_n_store_insn += active_count;
-        else 
-            m_stats->gpgpu_n_load_insn += active_count;
-        break;
+      if (inst.is_store())
+        m_stats->gpgpu_n_store_insn += active_count;
+      else
+        m_stats->gpgpu_n_load_insn += active_count;
+      break;
     default:
-        abort();
-    }
+      abort();
+  }
 }
-bool shader_core_ctx::can_issue_1block(kernel_info_t & kernel) {
+bool shader_core_ctx::can_issue_1block(kernel_info_t &kernel) {
+  // Jin: concurrent kernels on one SM
+  if (m_config->gpgpu_concurrent_kernel_sm) {
+    if (m_config->max_cta(kernel) < 1) return false;
 
-   //Jin: concurrent kernels on one SM
-   if(m_config->gpgpu_concurrent_kernel_sm) {    
-      if(m_config->max_cta(kernel) < 1)
-           return false;
-
-      return occupy_shader_resource_1block(kernel, false);
-   }
-   else {
-      return (get_n_active_cta() < m_config->max_cta(kernel));
-   } 
+    return occupy_shader_resource_1block(kernel, false);
+  } else {
+    return (get_n_active_cta() < m_config->max_cta(kernel));
+  }
 }
 
 int shader_core_ctx::find_available_hwtid(unsigned int cta_size, bool occupy) {
-   
-   unsigned int step;
-   for(step = 0; step < m_config->n_thread_per_shader; 
-        step += cta_size) {
-
-        unsigned int hw_tid;
-        for(hw_tid = step; hw_tid < step + cta_size;
-            hw_tid++) {
-            if(m_occupied_hwtid.test(hw_tid))
-                break;
-        }
-        if(hw_tid == step + cta_size) //consecutive non-active
-            break;
-   }
-   if(step >= m_config->n_thread_per_shader) //didn't find
-     return -1;
-   else {
-     if(occupy) {
-        for(unsigned hw_tid = step; hw_tid < step + cta_size;
-            hw_tid++)
-            m_occupied_hwtid.set(hw_tid);
-     }
-     return step;
-   }
+  unsigned int step;
+  for (step = 0; step < m_config->n_thread_per_shader; step += cta_size) {
+    unsigned int hw_tid;
+    for (hw_tid = step; hw_tid < step + cta_size; hw_tid++) {
+      if (m_occupied_hwtid.test(hw_tid)) break;
+    }
+    if (hw_tid == step + cta_size)  // consecutive non-active
+      break;
+  }
+  if (step >= m_config->n_thread_per_shader)  // didn't find
+    return -1;
+  else {
+    if (occupy) {
+      for (unsigned hw_tid = step; hw_tid < step + cta_size; hw_tid++)
+        m_occupied_hwtid.set(hw_tid);
+    }
+    return step;
+  }
 }
 
-bool shader_core_ctx::occupy_shader_resource_1block(kernel_info_t & k, bool occupy) {
-   unsigned threads_per_cta  = k.threads_per_cta();
-   const class function_info *kernel = k.entry();
-   unsigned int padded_cta_size = threads_per_cta;
-   unsigned int warp_size = m_config->warp_size; 
-   if (padded_cta_size%warp_size) 
-      padded_cta_size = ((padded_cta_size/warp_size)+1)*(warp_size);
+bool shader_core_ctx::occupy_shader_resource_1block(kernel_info_t &k,
+                                                    bool occupy) {
+  unsigned threads_per_cta = k.threads_per_cta();
+  const class function_info *kernel = k.entry();
+  unsigned int padded_cta_size = threads_per_cta;
+  unsigned int warp_size = m_config->warp_size;
+  if (padded_cta_size % warp_size)
+    padded_cta_size = ((padded_cta_size / warp_size) + 1) * (warp_size);
 
-   if(m_occupied_n_threads + padded_cta_size > m_config->n_thread_per_shader)
-     return false;
+  if (m_occupied_n_threads + padded_cta_size > m_config->n_thread_per_shader)
+    return false;
 
-   if(find_available_hwtid(padded_cta_size, false) == -1)
-     return false;
+  if (find_available_hwtid(padded_cta_size, false) == -1) return false;
 
-   const struct gpgpu_ptx_sim_info *kernel_info = ptx_sim_kernel_info(kernel);
+  const struct gpgpu_ptx_sim_info *kernel_info = ptx_sim_kernel_info(kernel);
 
-   if(m_occupied_shmem + kernel_info->smem > m_config->gpgpu_shmem_size)
-     return false;
+  if (m_occupied_shmem + kernel_info->smem > m_config->gpgpu_shmem_size)
+    return false;
 
-   unsigned int used_regs = padded_cta_size * ((kernel_info->regs+3)&~3);
-   if(m_occupied_regs + used_regs > m_config->gpgpu_shader_registers)
-     return false;
+  unsigned int used_regs = padded_cta_size * ((kernel_info->regs + 3) & ~3);
+  if (m_occupied_regs + used_regs > m_config->gpgpu_shader_registers)
+    return false;
 
-   if(m_occupied_ctas +1 > m_config->max_cta_per_core)
-     return false;
-   
-   if(occupy) {
-       m_occupied_n_threads += padded_cta_size;
-       m_occupied_shmem += kernel_info->smem;
-       m_occupied_regs += (padded_cta_size * ((kernel_info->regs+3)&~3));
-       m_occupied_ctas++;
+  if (m_occupied_ctas + 1 > m_config->max_cta_per_core) return false;
 
-      SHADER_DPRINTF(LIVENESS, "GPGPU-Sim uArch: Occupied %u threads, %u shared mem, %u registers, %u ctas\n",
-            m_occupied_n_threads, m_occupied_shmem, m_occupied_regs, m_occupied_ctas);  
-   }
+  if (occupy) {
+    m_occupied_n_threads += padded_cta_size;
+    m_occupied_shmem += kernel_info->smem;
+    m_occupied_regs += (padded_cta_size * ((kernel_info->regs + 3) & ~3));
+    m_occupied_ctas++;
 
-   return true;
+    SHADER_DPRINTF(LIVENESS,
+                   "GPGPU-Sim uArch: Occupied %u threads, %u shared mem, %u "
+                   "registers, %u ctas\n",
+                   m_occupied_n_threads, m_occupied_shmem, m_occupied_regs,
+                   m_occupied_ctas);
+  }
+
+  return true;
 }
 
-void shader_core_ctx::release_shader_resource_1block(unsigned hw_ctaid, kernel_info_t & k) {
+void shader_core_ctx::release_shader_resource_1block(unsigned hw_ctaid,
+                                                     kernel_info_t &k) {
+  if (m_config->gpgpu_concurrent_kernel_sm) {
+    unsigned threads_per_cta = k.threads_per_cta();
+    const class function_info *kernel = k.entry();
+    unsigned int padded_cta_size = threads_per_cta;
+    unsigned int warp_size = m_config->warp_size;
+    if (padded_cta_size % warp_size)
+      padded_cta_size = ((padded_cta_size / warp_size) + 1) * (warp_size);
 
-   if(m_config->gpgpu_concurrent_kernel_sm) {
-      unsigned threads_per_cta  = k.threads_per_cta();
-      const class function_info *kernel = k.entry();
-      unsigned int padded_cta_size = threads_per_cta;
-      unsigned int warp_size = m_config->warp_size; 
-      if (padded_cta_size%warp_size) 
-         padded_cta_size = ((padded_cta_size/warp_size)+1)*(warp_size);
-   
-      assert(m_occupied_n_threads >= padded_cta_size);
-      m_occupied_n_threads -= padded_cta_size;
-   
-      int start_thread = m_occupied_cta_to_hwtid[hw_ctaid];
-   
-      for(unsigned hwtid = start_thread; hwtid < start_thread + padded_cta_size;
-       hwtid++)
-          m_occupied_hwtid.reset(hwtid);
-      m_occupied_cta_to_hwtid.erase(hw_ctaid);
-   
-      const struct gpgpu_ptx_sim_info *kernel_info = ptx_sim_kernel_info(kernel);
-   
-      assert(m_occupied_shmem >= (unsigned int)kernel_info->smem);
-      m_occupied_shmem -= kernel_info->smem;
-   
-      unsigned int used_regs = padded_cta_size * ((kernel_info->regs+3)&~3);
-      assert(m_occupied_regs >= used_regs);
-      m_occupied_regs -= used_regs;
-   
-      assert(m_occupied_ctas >= 1);
-      m_occupied_ctas--;
-   }
+    assert(m_occupied_n_threads >= padded_cta_size);
+    m_occupied_n_threads -= padded_cta_size;
+
+    int start_thread = m_occupied_cta_to_hwtid[hw_ctaid];
+
+    for (unsigned hwtid = start_thread; hwtid < start_thread + padded_cta_size;
+         hwtid++)
+      m_occupied_hwtid.reset(hwtid);
+    m_occupied_cta_to_hwtid.erase(hw_ctaid);
+
+    const struct gpgpu_ptx_sim_info *kernel_info = ptx_sim_kernel_info(kernel);
+
+    assert(m_occupied_shmem >= (unsigned int)kernel_info->smem);
+    m_occupied_shmem -= kernel_info->smem;
+
+    unsigned int used_regs = padded_cta_size * ((kernel_info->regs + 3) & ~3);
+    assert(m_occupied_regs >= used_regs);
+    m_occupied_regs -= used_regs;
+
+    assert(m_occupied_ctas >= 1);
+    m_occupied_ctas--;
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
 /**
- * Launches a cooperative thread array (CTA). 
- *  
- * @param kernel 
- *    object that tells us which kernel to ask for a CTA from 
+ * Launches a cooperative thread array (CTA).
+ *
+ * @param kernel
+ *    object that tells us which kernel to ask for a CTA from
  */
 
-void shader_core_ctx::issue_block2core( kernel_info_t &kernel ) 
-{
+void shader_core_ctx::issue_block2core(kernel_info_t &kernel) {
+  if (!m_config->gpgpu_concurrent_kernel_sm)
+    set_max_cta(kernel);
+  else
+    assert(occupy_shader_resource_1block(kernel, true));
 
-    if(!m_config->gpgpu_concurrent_kernel_sm)
-        set_max_cta(kernel);
-    else
-        assert(occupy_shader_resource_1block(kernel, true));
+  kernel.inc_running();
 
-    kernel.inc_running();
+  // find a free CTA context
+  unsigned free_cta_hw_id = (unsigned)-1;
 
-    // find a free CTA context 
-    unsigned free_cta_hw_id=(unsigned)-1;
-
-    unsigned max_cta_per_core;
-    if(!m_config->gpgpu_concurrent_kernel_sm)
-        max_cta_per_core = kernel_max_cta_per_shader;
-    else
-        max_cta_per_core = m_config->max_cta_per_core;
-    for (unsigned i=0;i<max_cta_per_core;i++ ) {
-      if( m_cta_status[i]==0 ) {
-         free_cta_hw_id=i;
-         break;
-      }
+  unsigned max_cta_per_core;
+  if (!m_config->gpgpu_concurrent_kernel_sm)
+    max_cta_per_core = kernel_max_cta_per_shader;
+  else
+    max_cta_per_core = m_config->max_cta_per_core;
+  for (unsigned i = 0; i < max_cta_per_core; i++) {
+    if (m_cta_status[i] == 0) {
+      free_cta_hw_id = i;
+      break;
     }
-    assert( free_cta_hw_id!=(unsigned)-1 );
+  }
+  assert(free_cta_hw_id != (unsigned)-1);
 
-    // determine hardware threads and warps that will be used for this CTA
-    int cta_size = kernel.threads_per_cta();
+  // determine hardware threads and warps that will be used for this CTA
+  int cta_size = kernel.threads_per_cta();
 
-    // hw warp id = hw thread id mod warp size, so we need to find a range 
-    // of hardware thread ids corresponding to an integral number of hardware
-    // thread ids
-    int padded_cta_size = cta_size; 
-    if (cta_size%m_config->warp_size)
-      padded_cta_size = ((cta_size/m_config->warp_size)+1)*(m_config->warp_size);
+  // hw warp id = hw thread id mod warp size, so we need to find a range
+  // of hardware thread ids corresponding to an integral number of hardware
+  // thread ids
+  int padded_cta_size = cta_size;
+  if (cta_size % m_config->warp_size)
+    padded_cta_size =
+        ((cta_size / m_config->warp_size) + 1) * (m_config->warp_size);
 
-    unsigned int start_thread, end_thread;
+  unsigned int start_thread, end_thread;
 
-    if(!m_config->gpgpu_concurrent_kernel_sm) {
-        start_thread = free_cta_hw_id * padded_cta_size;
-        end_thread  = start_thread +  cta_size;
+  if (!m_config->gpgpu_concurrent_kernel_sm) {
+    start_thread = free_cta_hw_id * padded_cta_size;
+    end_thread = start_thread + cta_size;
+  } else {
+    start_thread = find_available_hwtid(padded_cta_size, true);
+    assert((int)start_thread != -1);
+    end_thread = start_thread + cta_size;
+    assert(m_occupied_cta_to_hwtid.find(free_cta_hw_id) ==
+           m_occupied_cta_to_hwtid.end());
+    m_occupied_cta_to_hwtid[free_cta_hw_id] = start_thread;
+  }
+
+  // reset the microarchitecture state of the selected hardware thread and warp
+  // contexts
+  reinit(start_thread, end_thread, false);
+
+  // initalize scalar threads and determine which hardware warps they are
+  // allocated to
+  // bind functional simulation state of threads to hardware resources
+  // (simulation)
+  warp_set_t warps;
+  unsigned nthreads_in_block = 0;
+  function_info *kernel_func_info = kernel.entry();
+  symbol_table *symtab = kernel_func_info->get_symtab();
+  unsigned ctaid = kernel.get_next_cta_id_single();
+  checkpoint *g_checkpoint = new checkpoint();
+  for (unsigned i = start_thread; i < end_thread; i++) {
+    m_threadState[i].m_cta_id = free_cta_hw_id;
+    unsigned warp_id = i / m_config->warp_size;
+    nthreads_in_block += ptx_sim_init_thread(
+        kernel, &m_thread[i], m_sid, i, cta_size - (i - start_thread),
+        m_config->n_thread_per_shader, this, free_cta_hw_id, warp_id,
+        m_cluster->get_gpu());
+    m_threadState[i].m_active = true;
+    // load thread local memory and register file
+    if (m_gpu->resume_option == 1 && kernel.get_uid() == m_gpu->resume_kernel &&
+        ctaid >= m_gpu->resume_CTA && ctaid < m_gpu->checkpoint_CTA_t) {
+      char fname[2048];
+      snprintf(fname, 2048, "checkpoint_files/thread_%d_%d_reg.txt",
+               i % cta_size, ctaid);
+      m_thread[i]->resume_reg_thread(fname, symtab);
+      char f1name[2048];
+      snprintf(f1name, 2048, "checkpoint_files/local_mem_thread_%d_%d_reg.txt",
+               i % cta_size, ctaid);
+      g_checkpoint->load_global_mem(m_thread[i]->m_local_mem, f1name);
     }
-    else {
-        start_thread = find_available_hwtid(padded_cta_size, true);
-        assert((int)start_thread != -1);
-        end_thread = start_thread + cta_size;
-        assert(m_occupied_cta_to_hwtid.find(free_cta_hw_id) == m_occupied_cta_to_hwtid.end());
-        m_occupied_cta_to_hwtid[free_cta_hw_id]= start_thread;
-    }
+    //
+    warps.set(warp_id);
+  }
+  assert(nthreads_in_block > 0 &&
+         nthreads_in_block <= m_config->n_thread_per_shader);  // should be at
+                                                               // least one, but
+                                                               // less than max
+  m_cta_status[free_cta_hw_id] = nthreads_in_block;
 
-    // reset the microarchitecture state of the selected hardware thread and warp contexts
-    reinit(start_thread, end_thread,false);
-     
-    // initalize scalar threads and determine which hardware warps they are allocated to
-    // bind functional simulation state of threads to hardware resources (simulation) 
-    warp_set_t warps;
-    unsigned nthreads_in_block= 0;
-    function_info *kernel_func_info = kernel.entry();
-    symbol_table * symtab= kernel_func_info->get_symtab();
-    unsigned ctaid= kernel.get_next_cta_id_single();
-    checkpoint *g_checkpoint=  new checkpoint();
-    for (unsigned i = start_thread; i<end_thread; i++) {
-        m_threadState[i].m_cta_id = free_cta_hw_id;
-        unsigned warp_id = i/m_config->warp_size;
-        nthreads_in_block += ptx_sim_init_thread(kernel,&m_thread[i],m_sid,i,cta_size-(i-start_thread),m_config->n_thread_per_shader,this,free_cta_hw_id,warp_id,m_cluster->get_gpu());
-        m_threadState[i].m_active = true; 
-        // load thread local memory and register file
-        if(m_gpu->resume_option == 1 && kernel.get_uid() == m_gpu->resume_kernel && ctaid >= m_gpu->resume_CTA && ctaid < m_gpu->checkpoint_CTA_t )
-        {
-            char fname[2048];
-            snprintf(fname,2048,"checkpoint_files/thread_%d_%d_reg.txt",i%cta_size,ctaid );
-            m_thread[i]->resume_reg_thread(fname,symtab);
-            char f1name[2048];
-            snprintf(f1name,2048,"checkpoint_files/local_mem_thread_%d_%d_reg.txt",i%cta_size,ctaid);
-            g_checkpoint->load_global_mem(m_thread[i]->m_local_mem, f1name); 
-        }
-        //
-        warps.set( warp_id );
-    }
-    assert( nthreads_in_block > 0 && nthreads_in_block <= m_config->n_thread_per_shader); // should be at least one, but less than max
-    m_cta_status[free_cta_hw_id]=nthreads_in_block;
+  if (m_gpu->resume_option == 1 && kernel.get_uid() == m_gpu->resume_kernel &&
+      ctaid >= m_gpu->resume_CTA && ctaid < m_gpu->checkpoint_CTA_t) {
+    char f1name[2048];
+    snprintf(f1name, 2048, "checkpoint_files/shared_mem_%d.txt", ctaid);
 
-    if(m_gpu->resume_option == 1 && kernel.get_uid() == m_gpu->resume_kernel && ctaid >= m_gpu->resume_CTA && ctaid < m_gpu->checkpoint_CTA_t )
-    {
-        char f1name[2048];
-        snprintf(f1name,2048,"checkpoint_files/shared_mem_%d.txt", ctaid);
-        
-        g_checkpoint->load_global_mem(m_thread[start_thread]->m_shared_mem, f1name);  
-    }
-    // now that we know which warps are used in this CTA, we can allocate
-    // resources for use in CTA-wide barrier operations
-    m_barriers.allocate_barrier(free_cta_hw_id,warps);
+    g_checkpoint->load_global_mem(m_thread[start_thread]->m_shared_mem, f1name);
+  }
+  // now that we know which warps are used in this CTA, we can allocate
+  // resources for use in CTA-wide barrier operations
+  m_barriers.allocate_barrier(free_cta_hw_id, warps);
 
-    // initialize the SIMT stacks and fetch hardware
-    init_warps( free_cta_hw_id, start_thread, end_thread, ctaid, cta_size, kernel.get_uid());
-    m_n_active_cta++;
+  // initialize the SIMT stacks and fetch hardware
+  init_warps(free_cta_hw_id, start_thread, end_thread, ctaid, cta_size,
+             kernel.get_uid());
+  m_n_active_cta++;
 
-    shader_CTA_count_log(m_sid, 1);
-    SHADER_DPRINTF(LIVENESS, "GPGPU-Sim uArch: cta:%2u, start_tid:%4u, end_tid:%4u, initialized @(%lld,%lld)\n", 
-        free_cta_hw_id, start_thread, end_thread, m_gpu->gpu_sim_cycle, m_gpu->gpu_tot_sim_cycle );
-
+  shader_CTA_count_log(m_sid, 1);
+  SHADER_DPRINTF(LIVENESS,
+                 "GPGPU-Sim uArch: cta:%2u, start_tid:%4u, end_tid:%4u, "
+                 "initialized @(%lld,%lld)\n",
+                 free_cta_hw_id, start_thread, end_thread, m_gpu->gpu_sim_cycle,
+                 m_gpu->gpu_tot_sim_cycle);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-void dram_t::dram_log( int task ) 
-{
-   if (task == SAMPLELOG) {
-      StatAddSample(mrqq_Dist, que_length());   
-   } else if (task == DUMPLOG) {
-      printf ("Queue Length DRAM[%d] ",id);StatDisp(mrqq_Dist);
-   }
+void dram_t::dram_log(int task) {
+  if (task == SAMPLELOG) {
+    StatAddSample(mrqq_Dist, que_length());
+  } else if (task == DUMPLOG) {
+    printf("Queue Length DRAM[%d] ", id);
+    StatDisp(mrqq_Dist);
+  }
 }
 
-//Find next clock domain and increment its time
-int gpgpu_sim::next_clock_domain(void) 
-{
-   double smallest = min3(core_time,icnt_time,dram_time);
-   int mask = 0x00;
-   if ( l2_time <= smallest ) {
-      smallest = l2_time;
-      mask |= L2 ;
-      l2_time += m_config.l2_period;
-   }
-   if ( icnt_time <= smallest ) {
-      mask |= ICNT;
-      icnt_time += m_config.icnt_period;
-   }
-   if ( dram_time <= smallest ) {
-      mask |= DRAM;
-      dram_time += m_config.dram_period;
-   }
-   if ( core_time <= smallest ) {
-      mask |= CORE;
-      core_time += m_config.core_period;
-   }
-   return mask;
+// Find next clock domain and increment its time
+int gpgpu_sim::next_clock_domain(void) {
+  double smallest = min3(core_time, icnt_time, dram_time);
+  int mask = 0x00;
+  if (l2_time <= smallest) {
+    smallest = l2_time;
+    mask |= L2;
+    l2_time += m_config.l2_period;
+  }
+  if (icnt_time <= smallest) {
+    mask |= ICNT;
+    icnt_time += m_config.icnt_period;
+  }
+  if (dram_time <= smallest) {
+    mask |= DRAM;
+    dram_time += m_config.dram_period;
+  }
+  if (core_time <= smallest) {
+    mask |= CORE;
+    core_time += m_config.core_period;
+  }
+  return mask;
 }
 
-void gpgpu_sim::issue_block2core()
-{
-    unsigned last_issued = m_last_cluster_issue; 
-    for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) {
-        unsigned idx = (i + last_issued + 1) % m_shader_config->n_simt_clusters;
-        unsigned num = m_cluster[idx]->issue_block2core();
-        if( num ) {
-            m_last_cluster_issue=idx;
-            m_total_cta_launched += num;
-        }
+void gpgpu_sim::issue_block2core() {
+  unsigned last_issued = m_last_cluster_issue;
+  for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++) {
+    unsigned idx = (i + last_issued + 1) % m_shader_config->n_simt_clusters;
+    unsigned num = m_cluster[idx]->issue_block2core();
+    if (num) {
+      m_last_cluster_issue = idx;
+      m_total_cta_launched += num;
     }
+  }
 }
 
-unsigned long long g_single_step=0; // set this in gdb to single step the pipeline
+unsigned long long g_single_step =
+    0;  // set this in gdb to single step the pipeline
 
-void gpgpu_sim::cycle()
-{
-   int clock_mask = next_clock_domain();
+void gpgpu_sim::cycle() {
+  int clock_mask = next_clock_domain();
 
-   if (clock_mask & CORE ) {
-       // shader core loading (pop from ICNT into core) follows CORE clock
-      for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) 
-         m_cluster[i]->icnt_cycle(); 
-   }
-    unsigned partiton_replys_in_parallel_per_cycle = 0;
-    if (clock_mask & ICNT) {
-        // pop from memory controller to interconnect
-        for (unsigned i=0;i<m_memory_config->m_n_mem_sub_partition;i++) {
-            mem_fetch* mf = m_memory_sub_partition[i]->top();
-            if (mf) {
-                unsigned response_size = mf->get_is_write()?mf->get_ctrl_size():mf->size();
-                if ( ::icnt_has_buffer( m_shader_config->mem2device(i), response_size ) ) {
-                    //if (!mf->get_is_write())
-                       mf->set_return_timestamp(gpu_sim_cycle+gpu_tot_sim_cycle);
-                    mf->set_status(IN_ICNT_TO_SHADER,gpu_sim_cycle+gpu_tot_sim_cycle);
-                    ::icnt_push( m_shader_config->mem2device(i), mf->get_tpc(), mf, response_size );
-                    m_memory_sub_partition[i]->pop();
-                    partiton_replys_in_parallel_per_cycle++;
-                } else {
-                    gpu_stall_icnt2sh++;
-                }
-            } else {
-               m_memory_sub_partition[i]->pop();
-            }
+  if (clock_mask & CORE) {
+    // shader core loading (pop from ICNT into core) follows CORE clock
+    for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++)
+      m_cluster[i]->icnt_cycle();
+  }
+  unsigned partiton_replys_in_parallel_per_cycle = 0;
+  if (clock_mask & ICNT) {
+    // pop from memory controller to interconnect
+    for (unsigned i = 0; i < m_memory_config->m_n_mem_sub_partition; i++) {
+      mem_fetch *mf = m_memory_sub_partition[i]->top();
+      if (mf) {
+        unsigned response_size =
+            mf->get_is_write() ? mf->get_ctrl_size() : mf->size();
+        if (::icnt_has_buffer(m_shader_config->mem2device(i), response_size)) {
+          // if (!mf->get_is_write())
+          mf->set_return_timestamp(gpu_sim_cycle + gpu_tot_sim_cycle);
+          mf->set_status(IN_ICNT_TO_SHADER, gpu_sim_cycle + gpu_tot_sim_cycle);
+          ::icnt_push(m_shader_config->mem2device(i), mf->get_tpc(), mf,
+                      response_size);
+          m_memory_sub_partition[i]->pop();
+          partiton_replys_in_parallel_per_cycle++;
+        } else {
+          gpu_stall_icnt2sh++;
         }
+      } else {
+        m_memory_sub_partition[i]->pop();
+      }
     }
-    partiton_replys_in_parallel += partiton_replys_in_parallel_per_cycle;
+  }
+  partiton_replys_in_parallel += partiton_replys_in_parallel_per_cycle;
 
-   if (clock_mask & DRAM) {
-      for (unsigned i=0;i<m_memory_config->m_n_mem;i++){
-    	  if(m_memory_config->simple_dram_model)
-    		  m_memory_partition_unit[i]->simple_dram_model_cycle();
-    	  else
-    		  m_memory_partition_unit[i]->dram_cycle(); // Issue the dram command (scheduler + delay model)
-         // Update performance counters for DRAM
-         m_memory_partition_unit[i]->set_dram_power_stats(m_power_stats->pwr_mem_stat->n_cmd[CURRENT_STAT_IDX][i], m_power_stats->pwr_mem_stat->n_activity[CURRENT_STAT_IDX][i],
-                        m_power_stats->pwr_mem_stat->n_nop[CURRENT_STAT_IDX][i], m_power_stats->pwr_mem_stat->n_act[CURRENT_STAT_IDX][i], m_power_stats->pwr_mem_stat->n_pre[CURRENT_STAT_IDX][i],
-                        m_power_stats->pwr_mem_stat->n_rd[CURRENT_STAT_IDX][i], m_power_stats->pwr_mem_stat->n_wr[CURRENT_STAT_IDX][i], m_power_stats->pwr_mem_stat->n_req[CURRENT_STAT_IDX][i]);
+  if (clock_mask & DRAM) {
+    for (unsigned i = 0; i < m_memory_config->m_n_mem; i++) {
+      if (m_memory_config->simple_dram_model)
+        m_memory_partition_unit[i]->simple_dram_model_cycle();
+      else
+        m_memory_partition_unit[i]
+            ->dram_cycle();  // Issue the dram command (scheduler + delay model)
+      // Update performance counters for DRAM
+      m_memory_partition_unit[i]->set_dram_power_stats(
+          m_power_stats->pwr_mem_stat->n_cmd[CURRENT_STAT_IDX][i],
+          m_power_stats->pwr_mem_stat->n_activity[CURRENT_STAT_IDX][i],
+          m_power_stats->pwr_mem_stat->n_nop[CURRENT_STAT_IDX][i],
+          m_power_stats->pwr_mem_stat->n_act[CURRENT_STAT_IDX][i],
+          m_power_stats->pwr_mem_stat->n_pre[CURRENT_STAT_IDX][i],
+          m_power_stats->pwr_mem_stat->n_rd[CURRENT_STAT_IDX][i],
+          m_power_stats->pwr_mem_stat->n_wr[CURRENT_STAT_IDX][i],
+          m_power_stats->pwr_mem_stat->n_req[CURRENT_STAT_IDX][i]);
+    }
+  }
+
+  // L2 operations follow L2 clock domain
+  unsigned partiton_reqs_in_parallel_per_cycle = 0;
+  if (clock_mask & L2) {
+    m_power_stats->pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].clear();
+    for (unsigned i = 0; i < m_memory_config->m_n_mem_sub_partition; i++) {
+      // move memory request from interconnect into memory partition (if not
+      // backed up)
+      // Note:This needs to be called in DRAM clock domain if there is no L2
+      // cache in the system
+      // In the worst case, we may need to push SECTOR_CHUNCK_SIZE requests, so
+      // ensure you have enough buffer for them
+      if (m_memory_sub_partition[i]->full(SECTOR_CHUNCK_SIZE)) {
+        gpu_stall_dramfull++;
+      } else {
+        mem_fetch *mf = (mem_fetch *)icnt_pop(m_shader_config->mem2device(i));
+        m_memory_sub_partition[i]->push(mf, gpu_sim_cycle + gpu_tot_sim_cycle);
+        if (mf) partiton_reqs_in_parallel_per_cycle++;
       }
-   }
+      m_memory_sub_partition[i]->cache_cycle(gpu_sim_cycle + gpu_tot_sim_cycle);
+      m_memory_sub_partition[i]->accumulate_L2cache_stats(
+          m_power_stats->pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX]);
+    }
+  }
+  partiton_reqs_in_parallel += partiton_reqs_in_parallel_per_cycle;
+  if (partiton_reqs_in_parallel_per_cycle > 0) {
+    partiton_reqs_in_parallel_util += partiton_reqs_in_parallel_per_cycle;
+    gpu_sim_cycle_parition_util++;
+  }
 
-   // L2 operations follow L2 clock domain
-   unsigned partiton_reqs_in_parallel_per_cycle = 0;
-   if (clock_mask & L2) {
-       m_power_stats->pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].clear();
-      for (unsigned i=0;i<m_memory_config->m_n_mem_sub_partition;i++) {
-          //move memory request from interconnect into memory partition (if not backed up)
-          //Note:This needs to be called in DRAM clock domain if there is no L2 cache in the system
-    	  //In the worst case, we may need to push SECTOR_CHUNCK_SIZE requests, so ensure you have enough buffer for them
-          if ( m_memory_sub_partition[i]->full(SECTOR_CHUNCK_SIZE) ) {
-             gpu_stall_dramfull++;
-          } else {
-              mem_fetch* mf = (mem_fetch*) icnt_pop( m_shader_config->mem2device(i) );
-              m_memory_sub_partition[i]->push( mf, gpu_sim_cycle + gpu_tot_sim_cycle );
-              if(mf)
-            	  partiton_reqs_in_parallel_per_cycle++;
-          }
-          m_memory_sub_partition[i]->cache_cycle(gpu_sim_cycle+gpu_tot_sim_cycle);
-          m_memory_sub_partition[i]->accumulate_L2cache_stats(m_power_stats->pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX]);
-       }
-   }
-   partiton_reqs_in_parallel += partiton_reqs_in_parallel_per_cycle;
-   if(partiton_reqs_in_parallel_per_cycle > 0){
-	   partiton_reqs_in_parallel_util += partiton_reqs_in_parallel_per_cycle;
-	   gpu_sim_cycle_parition_util++;
-   }
+  if (clock_mask & ICNT) {
+    icnt_transfer();
+  }
 
-   if (clock_mask & ICNT) {
-      icnt_transfer();
-   }
-
-   if (clock_mask & CORE) {
-      // L1 cache + shader core pipeline stages
-      m_power_stats->pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].clear();
-      for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) {
-         if (m_cluster[i]->get_not_completed() || get_more_cta_left() ) {
-               m_cluster[i]->core_cycle();
-               *active_sms+=m_cluster[i]->get_n_active_sms();
-         }
-         // Update core icnt/cache stats for GPUWattch
-         m_cluster[i]->get_icnt_stats(m_power_stats->pwr_mem_stat->n_simt_to_mem[CURRENT_STAT_IDX][i], m_power_stats->pwr_mem_stat->n_mem_to_simt[CURRENT_STAT_IDX][i]);
-         m_cluster[i]->get_cache_stats(m_power_stats->pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX]);
-         m_cluster[i]->get_current_occupancy(gpu_occupancy.aggregate_warp_slot_filled, gpu_occupancy.aggregate_theoretical_warp_slots);
-
+  if (clock_mask & CORE) {
+    // L1 cache + shader core pipeline stages
+    m_power_stats->pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].clear();
+    for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++) {
+      if (m_cluster[i]->get_not_completed() || get_more_cta_left()) {
+        m_cluster[i]->core_cycle();
+        *active_sms += m_cluster[i]->get_n_active_sms();
       }
-      float temp=0;
-      for (unsigned i=0;i<m_shader_config->num_shader();i++){
-        temp+=m_shader_stats->m_pipeline_duty_cycle[i];
-      }
-      temp=temp/m_shader_config->num_shader();
-      *average_pipeline_duty_cycle=((*average_pipeline_duty_cycle)+temp);
-        //cout<<"Average pipeline duty cycle: "<<*average_pipeline_duty_cycle<<endl;
+      // Update core icnt/cache stats for GPUWattch
+      m_cluster[i]->get_icnt_stats(
+          m_power_stats->pwr_mem_stat->n_simt_to_mem[CURRENT_STAT_IDX][i],
+          m_power_stats->pwr_mem_stat->n_mem_to_simt[CURRENT_STAT_IDX][i]);
+      m_cluster[i]->get_cache_stats(
+          m_power_stats->pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX]);
+      m_cluster[i]->get_current_occupancy(
+          gpu_occupancy.aggregate_warp_slot_filled,
+          gpu_occupancy.aggregate_theoretical_warp_slots);
+    }
+    float temp = 0;
+    for (unsigned i = 0; i < m_shader_config->num_shader(); i++) {
+      temp += m_shader_stats->m_pipeline_duty_cycle[i];
+    }
+    temp = temp / m_shader_config->num_shader();
+    *average_pipeline_duty_cycle = ((*average_pipeline_duty_cycle) + temp);
+    // cout<<"Average pipeline duty cycle:
+    // "<<*average_pipeline_duty_cycle<<endl;
 
+    if (g_single_step &&
+        ((gpu_sim_cycle + gpu_tot_sim_cycle) >= g_single_step)) {
+      raise(SIGTRAP);  // Debug breakpoint
+    }
+    gpu_sim_cycle++;
 
-      if( g_single_step && ((gpu_sim_cycle+gpu_tot_sim_cycle) >= g_single_step) ) {
-          raise(SIGTRAP); // Debug breakpoint
-      }
-	 gpu_sim_cycle++;
-	
-      if( g_interactive_debugger_enabled ) 
-         gpgpu_debug();
+    if (g_interactive_debugger_enabled) gpgpu_debug();
 
-      // McPAT main cycle (interface with McPAT)
+// McPAT main cycle (interface with McPAT)
 #ifdef GPGPUSIM_POWER_MODEL
-      if(m_config.g_power_simulation_enabled){
-          mcpat_cycle(m_config, getShaderCoreConfig(), m_gpgpusim_wrapper, m_power_stats, m_config.gpu_stat_sample_freq, gpu_tot_sim_cycle, gpu_sim_cycle, gpu_tot_sim_insn, gpu_sim_insn);
-      }
+    if (m_config.g_power_simulation_enabled) {
+      mcpat_cycle(m_config, getShaderCoreConfig(), m_gpgpusim_wrapper,
+                  m_power_stats, m_config.gpu_stat_sample_freq,
+                  gpu_tot_sim_cycle, gpu_sim_cycle, gpu_tot_sim_insn,
+                  gpu_sim_insn);
+    }
 #endif
 
-      issue_block2core();
-      
-      // Depending on configuration, invalidate the caches once all of threads are completed.
-      int all_threads_complete = 1;
-      if (m_config.gpgpu_flush_l1_cache) {
-         for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) {
-            if (m_cluster[i]->get_not_completed() == 0)
-                m_cluster[i]->cache_invalidate();
-            else
-               all_threads_complete = 0 ;
-         }
-      }
+    issue_block2core();
 
-      if(m_config.gpgpu_flush_l2_cache){
-          if(!m_config.gpgpu_flush_l1_cache){
-              for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) {
-                  if (m_cluster[i]->get_not_completed() != 0){
-                      all_threads_complete = 0 ;
-                      break;
-                  }
-              }
+    // Depending on configuration, invalidate the caches once all of threads are
+    // completed.
+    int all_threads_complete = 1;
+    if (m_config.gpgpu_flush_l1_cache) {
+      for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++) {
+        if (m_cluster[i]->get_not_completed() == 0)
+          m_cluster[i]->cache_invalidate();
+        else
+          all_threads_complete = 0;
+      }
+    }
+
+    if (m_config.gpgpu_flush_l2_cache) {
+      if (!m_config.gpgpu_flush_l1_cache) {
+        for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++) {
+          if (m_cluster[i]->get_not_completed() != 0) {
+            all_threads_complete = 0;
+            break;
           }
-
-         if (all_threads_complete && !m_memory_config->m_L2_config.disabled() ) {
-            printf("Flushed L2 caches...\n");
-            if (m_memory_config->m_L2_config.get_num_lines()) {
-               int dlc = 0;
-               for (unsigned i=0;i<m_memory_config->m_n_mem;i++) {
-                  dlc = m_memory_sub_partition[i]->flushL2();
-                  assert (dlc == 0); // TODO: need to model actual writes to DRAM here
-                  printf("Dirty lines flushed from L2 %d is %d\n", i, dlc  );
-               }
-            }
-         }
+        }
       }
 
-      if (!(gpu_sim_cycle % m_config.gpu_stat_sample_freq)) {
-         time_t days, hrs, minutes, sec;
-         time_t curr_time;
-         time(&curr_time);
-         unsigned long long  elapsed_time = MAX(curr_time - gpgpu_ctx->the_gpgpusim->g_simulation_starttime, 1);
-         if ( (elapsed_time - last_liveness_message_time) >= m_config.liveness_message_freq && DTRACE(LIVENESS) ) {
-            days    = elapsed_time/(3600*24);
-            hrs     = elapsed_time/3600 - 24*days;
-            minutes = elapsed_time/60 - 60*(hrs + 24*days);
-            sec = elapsed_time - 60*(minutes + 60*(hrs + 24*days));
-            
-            unsigned long long active = 0, total = 0;
-            for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) {
-                m_cluster[i]->get_current_occupancy(active, total);
-            }
-            DPRINTFG(LIVENESS, "uArch: inst.: %lld (ipc=%4.1f, occ=%0.4f\% [%llu / %llu]) sim_rate=%u (inst/sec) elapsed = %u:%u:%02u:%02u / %s",
-                   gpu_tot_sim_insn + gpu_sim_insn, 
-                   (double)gpu_sim_insn/(double)gpu_sim_cycle,
-                   float(active)/float(total) * 100, active, total,
-                   (unsigned)((gpu_tot_sim_insn+gpu_sim_insn) / elapsed_time),
-                   (unsigned)days,(unsigned)hrs,(unsigned)minutes,(unsigned)sec,
-                   ctime(&curr_time));
-            fflush(stdout);
-            last_liveness_message_time = elapsed_time; 
-         }
-         visualizer_printstat();
-         m_memory_stats->memlatstat_lat_pw();
-         if (m_config.gpgpu_runtime_stat && (m_config.gpu_runtime_stat_flag != 0) ) {
-            if (m_config.gpu_runtime_stat_flag & GPU_RSTAT_BW_STAT) {
-               for (unsigned i=0;i<m_memory_config->m_n_mem;i++) 
-                  m_memory_partition_unit[i]->print_stat(stdout);
-               printf("maxmrqlatency = %d \n", m_memory_stats->max_mrq_latency);
-               printf("maxmflatency = %d \n", m_memory_stats->max_mf_latency);
-            }
-            if (m_config.gpu_runtime_stat_flag & GPU_RSTAT_SHD_INFO) 
-               shader_print_runtime_stat( stdout );
-            if (m_config.gpu_runtime_stat_flag & GPU_RSTAT_L1MISS) 
-               shader_print_l1_miss_stat( stdout );
-            if (m_config.gpu_runtime_stat_flag & GPU_RSTAT_SCHED) 
-               shader_print_scheduler_stat( stdout, false );
-         }
+      if (all_threads_complete && !m_memory_config->m_L2_config.disabled()) {
+        printf("Flushed L2 caches...\n");
+        if (m_memory_config->m_L2_config.get_num_lines()) {
+          int dlc = 0;
+          for (unsigned i = 0; i < m_memory_config->m_n_mem; i++) {
+            dlc = m_memory_sub_partition[i]->flushL2();
+            assert(dlc == 0);  // TODO: need to model actual writes to DRAM here
+            printf("Dirty lines flushed from L2 %d is %d\n", i, dlc);
+          }
+        }
       }
+    }
 
-      if (!(gpu_sim_cycle % 50000)) {
-         // deadlock detection 
-         if (m_config.gpu_deadlock_detect && gpu_sim_insn == last_gpu_sim_insn) {
-            gpu_deadlock = true;
-         } else {
-            last_gpu_sim_insn = gpu_sim_insn;
-         }
+    if (!(gpu_sim_cycle % m_config.gpu_stat_sample_freq)) {
+      time_t days, hrs, minutes, sec;
+      time_t curr_time;
+      time(&curr_time);
+      unsigned long long elapsed_time =
+          MAX(curr_time - gpgpu_ctx->the_gpgpusim->g_simulation_starttime, 1);
+      if ((elapsed_time - last_liveness_message_time) >=
+              m_config.liveness_message_freq &&
+          DTRACE(LIVENESS)) {
+        days = elapsed_time / (3600 * 24);
+        hrs = elapsed_time / 3600 - 24 * days;
+        minutes = elapsed_time / 60 - 60 * (hrs + 24 * days);
+        sec = elapsed_time - 60 * (minutes + 60 * (hrs + 24 * days));
+
+        unsigned long long active = 0, total = 0;
+        for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++) {
+          m_cluster[i]->get_current_occupancy(active, total);
+        }
+        DPRINTFG(LIVENESS,
+                 "uArch: inst.: %lld (ipc=%4.1f, occ=%0.4f\% [%llu / %llu]) "
+                 "sim_rate=%u (inst/sec) elapsed = %u:%u:%02u:%02u / %s",
+                 gpu_tot_sim_insn + gpu_sim_insn,
+                 (double)gpu_sim_insn / (double)gpu_sim_cycle,
+                 float(active) / float(total) * 100, active, total,
+                 (unsigned)((gpu_tot_sim_insn + gpu_sim_insn) / elapsed_time),
+                 (unsigned)days, (unsigned)hrs, (unsigned)minutes,
+                 (unsigned)sec, ctime(&curr_time));
+        fflush(stdout);
+        last_liveness_message_time = elapsed_time;
       }
-      try_snap_shot(gpu_sim_cycle);
-      spill_log_to_file (stdout, 0, gpu_sim_cycle);
+      visualizer_printstat();
+      m_memory_stats->memlatstat_lat_pw();
+      if (m_config.gpgpu_runtime_stat &&
+          (m_config.gpu_runtime_stat_flag != 0)) {
+        if (m_config.gpu_runtime_stat_flag & GPU_RSTAT_BW_STAT) {
+          for (unsigned i = 0; i < m_memory_config->m_n_mem; i++)
+            m_memory_partition_unit[i]->print_stat(stdout);
+          printf("maxmrqlatency = %d \n", m_memory_stats->max_mrq_latency);
+          printf("maxmflatency = %d \n", m_memory_stats->max_mf_latency);
+        }
+        if (m_config.gpu_runtime_stat_flag & GPU_RSTAT_SHD_INFO)
+          shader_print_runtime_stat(stdout);
+        if (m_config.gpu_runtime_stat_flag & GPU_RSTAT_L1MISS)
+          shader_print_l1_miss_stat(stdout);
+        if (m_config.gpu_runtime_stat_flag & GPU_RSTAT_SCHED)
+          shader_print_scheduler_stat(stdout, false);
+      }
+    }
+
+    if (!(gpu_sim_cycle % 50000)) {
+      // deadlock detection
+      if (m_config.gpu_deadlock_detect && gpu_sim_insn == last_gpu_sim_insn) {
+        gpu_deadlock = true;
+      } else {
+        last_gpu_sim_insn = gpu_sim_insn;
+      }
+    }
+    try_snap_shot(gpu_sim_cycle);
+    spill_log_to_file(stdout, 0, gpu_sim_cycle);
 
 #if (CUDART_VERSION >= 5000)
-      //launch device kernel
-      gpgpu_ctx->device_runtime->launch_one_device_kernel();
+    // launch device kernel
+    gpgpu_ctx->device_runtime->launch_one_device_kernel();
 #endif
-   }
+  }
 }
 
-
-void shader_core_ctx::dump_warp_state( FILE *fout ) const
-{
-   fprintf(fout, "\n");
-   fprintf(fout, "per warp functional simulation status:\n");
-   for (unsigned w=0; w < m_config->max_warps_per_shader; w++ ) 
-       m_warp[w].print(fout);
+void shader_core_ctx::dump_warp_state(FILE *fout) const {
+  fprintf(fout, "\n");
+  fprintf(fout, "per warp functional simulation status:\n");
+  for (unsigned w = 0; w < m_config->max_warps_per_shader; w++)
+    m_warp[w].print(fout);
 }
 
+void gpgpu_sim::perf_memcpy_to_gpu(size_t dst_start_addr, size_t count) {
+  if (m_memory_config->m_perf_sim_memcpy) {
+    assert(dst_start_addr % 32 == 0);
 
-void gpgpu_sim::perf_memcpy_to_gpu( size_t dst_start_addr, size_t count )
-{
-    if (m_memory_config->m_perf_sim_memcpy) {
-       assert (dst_start_addr % 32 == 0);
-
-       for ( unsigned counter = 0; counter < count; counter += 32 ) {
-           const unsigned wr_addr = dst_start_addr + counter;
-           addrdec_t raw_addr;
-           mem_access_sector_mask_t mask;
-           mask.set(wr_addr % 128 / 32);
-           m_memory_config->m_address_mapping.addrdec_tlx( wr_addr, &raw_addr );
-           const unsigned partition_id = raw_addr.sub_partition / m_memory_config->m_n_sub_partition_per_memory_channel;
-           m_memory_partition_unit[ partition_id ]->handle_memcpy_to_gpu( wr_addr, raw_addr.sub_partition, mask );
-       }
+    for (unsigned counter = 0; counter < count; counter += 32) {
+      const unsigned wr_addr = dst_start_addr + counter;
+      addrdec_t raw_addr;
+      mem_access_sector_mask_t mask;
+      mask.set(wr_addr % 128 / 32);
+      m_memory_config->m_address_mapping.addrdec_tlx(wr_addr, &raw_addr);
+      const unsigned partition_id =
+          raw_addr.sub_partition /
+          m_memory_config->m_n_sub_partition_per_memory_channel;
+      m_memory_partition_unit[partition_id]->handle_memcpy_to_gpu(
+          wr_addr, raw_addr.sub_partition, mask);
     }
+  }
 }
 
-void gpgpu_sim::dump_pipeline( int mask, int s, int m ) const
-{
-/*
-   You may want to use this function while running GPGPU-Sim in gdb.
-   One way to do that is add the following to your .gdbinit file:
- 
-      define dp
-         call g_the_gpu.dump_pipeline_impl((0x40|0x4|0x1),$arg0,0)
-      end
- 
-   Then, typing "dp 3" will show the contents of the pipeline for shader core 3.
-*/
+void gpgpu_sim::dump_pipeline(int mask, int s, int m) const {
+  /*
+     You may want to use this function while running GPGPU-Sim in gdb.
+     One way to do that is add the following to your .gdbinit file:
 
-   printf("Dumping pipeline state...\n");
-   if(!mask) mask = 0xFFFFFFFF;
-   for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) {
-      if(s != -1) {
-         i = s;
+        define dp
+           call g_the_gpu.dump_pipeline_impl((0x40|0x4|0x1),$arg0,0)
+        end
+
+     Then, typing "dp 3" will show the contents of the pipeline for shader core
+     3.
+  */
+
+  printf("Dumping pipeline state...\n");
+  if (!mask) mask = 0xFFFFFFFF;
+  for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++) {
+    if (s != -1) {
+      i = s;
+    }
+    if (mask & 1)
+      m_cluster[m_shader_config->sid_to_cluster(i)]->display_pipeline(
+          i, stdout, 1, mask & 0x2E);
+    if (s != -1) {
+      break;
+    }
+  }
+  if (mask & 0x10000) {
+    for (unsigned i = 0; i < m_memory_config->m_n_mem; i++) {
+      if (m != -1) {
+        i = m;
       }
-      if(mask&1) m_cluster[m_shader_config->sid_to_cluster(i)]->display_pipeline(i,stdout,1,mask & 0x2E);
-      if(s != -1) {
-         break;
+      printf("DRAM / memory controller %u:\n", i);
+      if (mask & 0x100000) m_memory_partition_unit[i]->print_stat(stdout);
+      if (mask & 0x1000000) m_memory_partition_unit[i]->visualize();
+      if (mask & 0x10000000) m_memory_partition_unit[i]->print(stdout);
+      if (m != -1) {
+        break;
       }
-   }
-   if(mask&0x10000) {
-      for (unsigned i=0;i<m_memory_config->m_n_mem;i++) {
-         if(m != -1) {
-            i=m;
-         }
-         printf("DRAM / memory controller %u:\n", i);
-         if(mask&0x100000) m_memory_partition_unit[i]->print_stat(stdout);
-         if(mask&0x1000000)   m_memory_partition_unit[i]->visualize();
-         if(mask&0x10000000)   m_memory_partition_unit[i]->print(stdout);
-         if(m != -1) {
-            break;
-         }
-      }
-   }
-   fflush(stdout);
+    }
+  }
+  fflush(stdout);
 }
 
-const shader_core_config * gpgpu_sim::getShaderCoreConfig()
-{
-   return m_shader_config;
+const shader_core_config *gpgpu_sim::getShaderCoreConfig() {
+  return m_shader_config;
 }
 
-const memory_config * gpgpu_sim::getMemoryConfig()
-{
-   return m_memory_config;
-}
+const memory_config *gpgpu_sim::getMemoryConfig() { return m_memory_config; }
 
-simt_core_cluster * gpgpu_sim::getSIMTCluster()
-{
-   return *m_cluster;
-}
-
+simt_core_cluster *gpgpu_sim::getSIMTCluster() { return *m_cluster; }

--- a/src/gpgpu-sim/gpu-sim.cc
+++ b/src/gpgpu-sim/gpu-sim.cc
@@ -1224,7 +1224,7 @@ void gpgpu_sim::gpu_print_stat() {
                  partiton_reqs_in_parallel_util_total) /
              (gpu_sim_cycle_parition_util + gpu_tot_sim_cycle_parition_util));
   // printf("partiton_replys_in_parallel = %lld\n",
-  // partiton_replys_in_parallel); printf("partiton_replys_in_parallel_total    =
+  // partiton_replys_in_parallel); printf("partiton_replys_in_parallel_total =
   // %lld\n", partiton_replys_in_parallel_total );
   printf("L2_BW  = %12.4f GB/Sec\n",
          ((float)(partiton_replys_in_parallel * 32) /
@@ -1735,8 +1735,8 @@ void gpgpu_sim::cycle() {
     m_power_stats->pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].clear();
     for (unsigned i = 0; i < m_memory_config->m_n_mem_sub_partition; i++) {
       // move memory request from interconnect into memory partition (if not
-      // backed up) Note:This needs to be called in DRAM clock domain if there is
-      // no L2 cache in the system In the worst case, we may need to push
+      // backed up) Note:This needs to be called in DRAM clock domain if there
+      // is no L2 cache in the system In the worst case, we may need to push
       // SECTOR_CHUNCK_SIZE requests, so ensure you have enough buffer for them
       if (m_memory_sub_partition[i]->full(SECTOR_CHUNCK_SIZE)) {
         gpu_stall_dramfull++;

--- a/src/gpgpu-sim/gpu-sim.cc
+++ b/src/gpgpu-sim/gpu-sim.cc
@@ -8,16 +8,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -28,49 +26,51 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
 #include "gpu-sim.h"
 
-#include <math.h>
-#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <math.h>
+#include <signal.h>
 #include "zlib.h"
 
-#include "dram.h"
-#include "mem_fetch.h"
+
 #include "shader.h"
 #include "shader_trace.h"
+#include "dram.h"
+#include "mem_fetch.h"
 
 #include <time.h>
-#include "addrdec.h"
-#include "delayqueue.h"
-#include "dram.h"
 #include "gpu-cache.h"
 #include "gpu-misc.h"
-#include "icnt_wrapper.h"
-#include "l2cache.h"
+#include "delayqueue.h"
 #include "shader.h"
+#include "icnt_wrapper.h"
+#include "dram.h"
+#include "addrdec.h"
 #include "stat-tool.h"
+#include "l2cache.h"
 
-#include "../../libcuda/gpgpu_context.h"
-#include "../abstract_hardware_model.h"
-#include "../cuda-sim/cuda-sim.h"
-#include "../cuda-sim/cuda_device_runtime.h"
 #include "../cuda-sim/ptx-stats.h"
-#include "../cuda-sim/ptx_ir.h"
+#include "../statwrapper.h"
+#include "../abstract_hardware_model.h"
 #include "../debug.h"
 #include "../gpgpusim_entrypoint.h"
-#include "../statwrapper.h"
+#include "../cuda-sim/cuda-sim.h"
+#include "../cuda-sim/ptx_ir.h"
 #include "../trace.h"
 #include "mem_latency_stat.h"
 #include "power_stat.h"
-#include "stats.h"
 #include "visualizer.h"
+#include "stats.h"
+#include "../cuda-sim/cuda_device_runtime.h"
+#include "../../libcuda/gpgpu_context.h"
 
 #ifdef GPGPUSIM_POWER_MODEL
 #include "power_interface.h"
 #else
-class gpgpu_sim_wrapper {};
+class  gpgpu_sim_wrapper {};
 #endif
 
 #include <stdio.h>
@@ -79,1915 +79,1781 @@ class gpgpu_sim_wrapper {};
 #include <sstream>
 #include <string>
 
-#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#define MAX(a,b) (((a)>(b))?(a):(b))
 
-bool g_interactive_debugger_enabled = false;
 
-tr1_hash_map<new_addr_type, unsigned> address_random_interleaving;
+bool g_interactive_debugger_enabled=false;
+
+tr1_hash_map<new_addr_type,unsigned> address_random_interleaving;
 
 /* Clock Domains */
 
-#define CORE 0x01
-#define L2 0x02
-#define DRAM 0x04
-#define ICNT 0x08
+#define  CORE  0x01
+#define  L2    0x02
+#define  DRAM  0x04
+#define  ICNT  0x08  
+
 
 #define MEM_LATENCY_STAT_IMPL
 
+
 #include "mem_latency_stat.h"
 
-void power_config::reg_options(class OptionParser *opp) {
-  option_parser_register(opp, "-gpuwattch_xml_file", OPT_CSTR,
-                         &g_power_config_name, "GPUWattch XML file",
-                         "gpuwattch.xml");
+void power_config::reg_options(class OptionParser * opp)
+{
 
-  option_parser_register(opp, "-power_simulation_enabled", OPT_BOOL,
-                         &g_power_simulation_enabled,
-                         "Turn on power simulator (1=On, 0=Off)", "0");
 
-  option_parser_register(opp, "-power_per_cycle_dump", OPT_BOOL,
-                         &g_power_per_cycle_dump,
-                         "Dump detailed power output each cycle", "0");
+	  option_parser_register(opp, "-gpuwattch_xml_file", OPT_CSTR,
+			  	  	  	  	 &g_power_config_name,"GPUWattch XML file",
+	                   "gpuwattch.xml");
 
-  // Output Data Formats
-  option_parser_register(
-      opp, "-power_trace_enabled", OPT_BOOL, &g_power_trace_enabled,
-      "produce a file for the power trace (1=On, 0=Off)", "0");
+	   option_parser_register(opp, "-power_simulation_enabled", OPT_BOOL,
+	                          &g_power_simulation_enabled, "Turn on power simulator (1=On, 0=Off)",
+	                          "0");
 
-  option_parser_register(
-      opp, "-power_trace_zlevel", OPT_INT32, &g_power_trace_zlevel,
-      "Compression level of the power trace output log (0=no comp, 9=highest)",
-      "6");
+	   option_parser_register(opp, "-power_per_cycle_dump", OPT_BOOL,
+	                          &g_power_per_cycle_dump, "Dump detailed power output each cycle",
+	                          "0");
 
-  option_parser_register(
-      opp, "-steady_power_levels_enabled", OPT_BOOL,
-      &g_steady_power_levels_enabled,
-      "produce a file for the steady power levels (1=On, 0=Off)", "0");
+	   // Output Data Formats
+	   option_parser_register(opp, "-power_trace_enabled", OPT_BOOL,
+	                          &g_power_trace_enabled, "produce a file for the power trace (1=On, 0=Off)",
+	                          "0");
 
-  option_parser_register(opp, "-steady_state_definition", OPT_CSTR,
-                         &gpu_steady_state_definition,
-                         "allowed deviation:number of samples", "8:4");
+	   option_parser_register(opp, "-power_trace_zlevel", OPT_INT32,
+	                          &g_power_trace_zlevel, "Compression level of the power trace output log (0=no comp, 9=highest)",
+	                          "6");
+
+	   option_parser_register(opp, "-steady_power_levels_enabled", OPT_BOOL,
+	                          &g_steady_power_levels_enabled, "produce a file for the steady power levels (1=On, 0=Off)",
+	                          "0");
+
+	   option_parser_register(opp, "-steady_state_definition", OPT_CSTR,
+			   	  &gpu_steady_state_definition, "allowed deviation:number of samples",
+	                 	  "8:4");
+
 }
 
-void memory_config::reg_options(class OptionParser *opp) {
-  option_parser_register(opp, "-perf_sim_memcpy", OPT_BOOL, &m_perf_sim_memcpy,
-                         "Fill the L2 cache on memcpy", "1");
-  option_parser_register(opp, "-simple_dram_model", OPT_BOOL,
-                         &simple_dram_model,
-                         "simple_dram_model with fixed latency and BW", "0");
-  option_parser_register(opp, "-gpgpu_dram_scheduler", OPT_INT32,
-                         &scheduler_type, "0 = fifo, 1 = FR-FCFS (defaul)",
-                         "1");
-  option_parser_register(opp, "-gpgpu_dram_partition_queues", OPT_CSTR,
-                         &gpgpu_L2_queue_config, "i2$:$2d:d2$:$2i", "8:8:8:8");
+void memory_config::reg_options(class OptionParser * opp)
+{
+    option_parser_register(opp, "-perf_sim_memcpy", OPT_BOOL, &m_perf_sim_memcpy, 
+                                "Fill the L2 cache on memcpy", "1");
+    option_parser_register(opp, "-simple_dram_model", OPT_BOOL, &simple_dram_model,
+                                "simple_dram_model with fixed latency and BW", "0");
+    option_parser_register(opp, "-gpgpu_dram_scheduler", OPT_INT32, &scheduler_type, 
+                                "0 = fifo, 1 = FR-FCFS (defaul)", "1");
+    option_parser_register(opp, "-gpgpu_dram_partition_queues", OPT_CSTR, &gpgpu_L2_queue_config, 
+                           "i2$:$2d:d2$:$2i",
+                           "8:8:8:8");
 
-  option_parser_register(opp, "-l2_ideal", OPT_BOOL, &l2_ideal,
-                         "Use a ideal L2 cache that always hit", "0");
-  option_parser_register(opp, "-gpgpu_cache:dl2", OPT_CSTR,
-                         &m_L2_config.m_config_string,
-                         "unified banked L2 data cache config "
-                         " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_"
-                         "alloc>,<mshr>:<N>:<merge>,<mq>}",
-                         "64:128:8,L:B:m:N,A:16:4,4");
-  option_parser_register(opp, "-gpgpu_cache:dl2_texture_only", OPT_BOOL,
-                         &m_L2_texure_only, "L2 cache used for texture only",
-                         "1");
-  option_parser_register(
-      opp, "-gpgpu_n_mem", OPT_UINT32, &m_n_mem,
-      "number of memory modules (e.g. memory controllers) in gpu", "8");
-  option_parser_register(opp, "-gpgpu_n_sub_partition_per_mchannel", OPT_UINT32,
-                         &m_n_sub_partition_per_memory_channel,
-                         "number of memory subpartition in each memory module",
-                         "1");
-  option_parser_register(opp, "-gpgpu_n_mem_per_ctrlr", OPT_UINT32,
-                         &gpu_n_mem_per_ctrlr,
-                         "number of memory chips per memory controller", "1");
-  option_parser_register(opp, "-gpgpu_memlatency_stat", OPT_INT32,
-                         &gpgpu_memlatency_stat,
-                         "track and display latency statistics 0x2 enables MC, "
-                         "0x4 enables queue logs",
-                         "0");
-  option_parser_register(opp, "-gpgpu_frfcfs_dram_sched_queue_size", OPT_INT32,
-                         &gpgpu_frfcfs_dram_sched_queue_size,
-                         "0 = unlimited (default); # entries per chip", "0");
-  option_parser_register(opp, "-gpgpu_dram_return_queue_size", OPT_INT32,
-                         &gpgpu_dram_return_queue_size,
-                         "0 = unlimited (default); # entries per chip", "0");
-  option_parser_register(opp, "-gpgpu_dram_buswidth", OPT_UINT32, &busW,
-                         "default = 4 bytes (8 bytes per cycle at DDR)", "4");
-  option_parser_register(
-      opp, "-gpgpu_dram_burst_length", OPT_UINT32, &BL,
-      "Burst length of each DRAM request (default = 4 data bus cycle)", "4");
-  option_parser_register(opp, "-dram_data_command_freq_ratio", OPT_UINT32,
-                         &data_command_freq_ratio,
-                         "Frequency ratio between DRAM data bus and command "
-                         "bus (default = 2 times, i.e. DDR)",
-                         "2");
-  option_parser_register(
-      opp, "-gpgpu_dram_timing_opt", OPT_CSTR, &gpgpu_dram_timing_opt,
-      "DRAM timing parameters = "
-      "{nbk:tCCD:tRRD:tRCD:tRAS:tRP:tRC:CL:WL:tCDLR:tWR:nbkgrp:tCCDL:tRTPL}",
-      "4:2:8:12:21:13:34:9:4:5:13:1:0:0");
-  option_parser_register(opp, "-rop_latency", OPT_UINT32, &rop_latency,
-                         "ROP queue latency (default 85)", "85");
-  option_parser_register(opp, "-dram_latency", OPT_UINT32, &dram_latency,
-                         "DRAM latency (default 30)", "30");
-  option_parser_register(opp, "-dual_bus_interface", OPT_UINT32,
-                         &dual_bus_interface,
-                         "dual_bus_interface (default = 0) ", "0");
-  option_parser_register(opp, "-dram_bnk_indexing_policy", OPT_UINT32,
-                         &dram_bnk_indexing_policy,
-                         "dram_bnk_indexing_policy (0 = normal indexing, 1 = "
-                         "Xoring with the higher bits) (Default = 0)",
-                         "0");
-  option_parser_register(opp, "-dram_bnkgrp_indexing_policy", OPT_UINT32,
-                         &dram_bnkgrp_indexing_policy,
-                         "dram_bnkgrp_indexing_policy (0 = take higher bits, 1 "
-                         "= take lower bits) (Default = 0)",
-                         "0");
-  option_parser_register(opp, "-Seperate_Write_Queue_Enable", OPT_BOOL,
-                         &seperate_write_queue_enabled,
-                         "Seperate_Write_Queue_Enable", "0");
-  option_parser_register(opp, "-Write_Queue_Size", OPT_CSTR,
-                         &write_queue_size_opt, "Write_Queue_Size", "32:28:16");
-  option_parser_register(
-      opp, "-Elimnate_rw_turnaround", OPT_BOOL, &elimnate_rw_turnaround,
-      "elimnate_rw_turnaround i.e set tWTR and tRTW = 0", "0");
-  option_parser_register(opp, "-icnt_flit_size", OPT_UINT32, &icnt_flit_size,
-                         "icnt_flit_size", "32");
-  m_address_mapping.addrdec_setoption(opp);
+    option_parser_register(opp, "-l2_ideal", OPT_BOOL, &l2_ideal, 
+                           "Use a ideal L2 cache that always hit",
+                           "0");
+    option_parser_register(opp, "-gpgpu_cache:dl2", OPT_CSTR, &m_L2_config.m_config_string, 
+                   "unified banked L2 data cache config "
+                   " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_alloc>,<mshr>:<N>:<merge>,<mq>}",
+                   "64:128:8,L:B:m:N,A:16:4,4");
+    option_parser_register(opp, "-gpgpu_cache:dl2_texture_only", OPT_BOOL, &m_L2_texure_only, 
+                           "L2 cache used for texture only",
+                           "1");
+    option_parser_register(opp, "-gpgpu_n_mem", OPT_UINT32, &m_n_mem, 
+                 "number of memory modules (e.g. memory controllers) in gpu",
+                 "8");
+    option_parser_register(opp, "-gpgpu_n_sub_partition_per_mchannel", OPT_UINT32, &m_n_sub_partition_per_memory_channel, 
+                 "number of memory subpartition in each memory module",
+                 "1");
+    option_parser_register(opp, "-gpgpu_n_mem_per_ctrlr", OPT_UINT32, &gpu_n_mem_per_ctrlr, 
+                 "number of memory chips per memory controller",
+                 "1");
+    option_parser_register(opp, "-gpgpu_memlatency_stat", OPT_INT32, &gpgpu_memlatency_stat, 
+                "track and display latency statistics 0x2 enables MC, 0x4 enables queue logs",
+                "0");
+    option_parser_register(opp, "-gpgpu_frfcfs_dram_sched_queue_size", OPT_INT32, &gpgpu_frfcfs_dram_sched_queue_size, 
+                "0 = unlimited (default); # entries per chip",
+                "0");
+    option_parser_register(opp, "-gpgpu_dram_return_queue_size", OPT_INT32, &gpgpu_dram_return_queue_size, 
+                "0 = unlimited (default); # entries per chip",
+                "0");
+    option_parser_register(opp, "-gpgpu_dram_buswidth", OPT_UINT32, &busW, 
+                 "default = 4 bytes (8 bytes per cycle at DDR)",
+                 "4");
+    option_parser_register(opp, "-gpgpu_dram_burst_length", OPT_UINT32, &BL, 
+                 "Burst length of each DRAM request (default = 4 data bus cycle)",
+                 "4");
+    option_parser_register(opp, "-dram_data_command_freq_ratio", OPT_UINT32, &data_command_freq_ratio, 
+                 "Frequency ratio between DRAM data bus and command bus (default = 2 times, i.e. DDR)",
+                 "2");
+    option_parser_register(opp, "-gpgpu_dram_timing_opt", OPT_CSTR, &gpgpu_dram_timing_opt, 
+                "DRAM timing parameters = {nbk:tCCD:tRRD:tRCD:tRAS:tRP:tRC:CL:WL:tCDLR:tWR:nbkgrp:tCCDL:tRTPL}",
+                "4:2:8:12:21:13:34:9:4:5:13:1:0:0");
+    option_parser_register(opp, "-rop_latency", OPT_UINT32, &rop_latency,
+                     "ROP queue latency (default 85)",
+                     "85");
+    option_parser_register(opp, "-dram_latency", OPT_UINT32, &dram_latency,
+                     "DRAM latency (default 30)",
+                     "30");
+    option_parser_register(opp, "-dual_bus_interface", OPT_UINT32, &dual_bus_interface,
+                                        "dual_bus_interface (default = 0) ",
+                                        "0");
+    option_parser_register(opp, "-dram_bnk_indexing_policy", OPT_UINT32, &dram_bnk_indexing_policy,
+                                            "dram_bnk_indexing_policy (0 = normal indexing, 1 = Xoring with the higher bits) (Default = 0)",
+                                            "0");
+    option_parser_register(opp, "-dram_bnkgrp_indexing_policy", OPT_UINT32, &dram_bnkgrp_indexing_policy,
+                                            "dram_bnkgrp_indexing_policy (0 = take higher bits, 1 = take lower bits) (Default = 0)",
+                                            "0");
+    option_parser_register(opp, "-Seperate_Write_Queue_Enable", OPT_BOOL, &seperate_write_queue_enabled,
+                           "Seperate_Write_Queue_Enable",
+                           "0");
+    option_parser_register(opp, "-Write_Queue_Size", OPT_CSTR, &write_queue_size_opt,
+                                  "Write_Queue_Size",
+                                  "32:28:16");
+    option_parser_register(opp, "-Elimnate_rw_turnaround", OPT_BOOL, &elimnate_rw_turnaround,
+                               "elimnate_rw_turnaround i.e set tWTR and tRTW = 0",
+                               "0");
+    option_parser_register(opp, "-icnt_flit_size", OPT_UINT32, &icnt_flit_size,
+                               "icnt_flit_size",
+                               "32");
+    m_address_mapping.addrdec_setoption(opp);
 }
 
-void shader_core_config::reg_options(class OptionParser *opp) {
-  option_parser_register(opp, "-gpgpu_simd_model", OPT_INT32, &model,
-                         "1 = post-dominator", "1");
-  option_parser_register(
-      opp, "-gpgpu_shader_core_pipeline", OPT_CSTR,
-      &gpgpu_shader_core_pipeline_opt,
-      "shader core pipeline config, i.e., {<nthread>:<warpsize>}", "1024:32");
-  option_parser_register(opp, "-gpgpu_tex_cache:l1", OPT_CSTR,
-                         &m_L1T_config.m_config_string,
-                         "per-shader L1 texture cache  (READ-ONLY) config "
-                         " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_"
-                         "alloc>,<mshr>:<N>:<merge>,<mq>:<rf>}",
-                         "8:128:5,L:R:m:N,F:128:4,128:2");
-  option_parser_register(
-      opp, "-gpgpu_const_cache:l1", OPT_CSTR, &m_L1C_config.m_config_string,
-      "per-shader L1 constant memory cache  (READ-ONLY) config "
-      " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_alloc>,<mshr>:<N>:<"
-      "merge>,<mq>} ",
-      "64:64:2,L:R:f:N,A:2:32,4");
-  option_parser_register(opp, "-gpgpu_cache:il1", OPT_CSTR,
-                         &m_L1I_config.m_config_string,
-                         "shader L1 instruction cache config "
-                         " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_"
-                         "alloc>,<mshr>:<N>:<merge>,<mq>} ",
-                         "4:256:4,L:R:f:N,A:2:32,4");
-  option_parser_register(opp, "-gpgpu_cache:dl1", OPT_CSTR,
-                         &m_L1D_config.m_config_string,
-                         "per-shader L1 data cache config "
-                         " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_"
-                         "alloc>,<mshr>:<N>:<merge>,<mq> | none}",
-                         "none");
-  option_parser_register(opp, "-l1_banks", OPT_UINT32, &m_L1D_config.l1_banks,
-                         "The number of L1 cache banks", "1");
-  option_parser_register(opp, "-l1_latency", OPT_UINT32,
-                         &m_L1D_config.l1_latency, "L1 Hit Latency", "1");
-  option_parser_register(opp, "-smem_latency", OPT_UINT32, &smem_latency,
-                         "smem Latency", "3");
-  option_parser_register(opp, "-gpgpu_cache:dl1PrefL1", OPT_CSTR,
-                         &m_L1D_config.m_config_stringPrefL1,
-                         "per-shader L1 data cache config "
-                         " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_"
-                         "alloc>,<mshr>:<N>:<merge>,<mq> | none}",
-                         "none");
-  option_parser_register(opp, "-gpgpu_cache:dl1PrefShared", OPT_CSTR,
-                         &m_L1D_config.m_config_stringPrefShared,
-                         "per-shader L1 data cache config "
-                         " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_"
-                         "alloc>,<mshr>:<N>:<merge>,<mq> | none}",
-                         "none");
-  option_parser_register(opp, "-gmem_skip_L1D", OPT_BOOL, &gmem_skip_L1D,
-                         "global memory access skip L1D cache (implements "
-                         "-Xptxas -dlcm=cg, default=no skip)",
-                         "0");
+void shader_core_config::reg_options(class OptionParser * opp)
+{
+    option_parser_register(opp, "-gpgpu_simd_model", OPT_INT32, &model, 
+                   "1 = post-dominator", "1");
+    option_parser_register(opp, "-gpgpu_shader_core_pipeline", OPT_CSTR, &gpgpu_shader_core_pipeline_opt, 
+                   "shader core pipeline config, i.e., {<nthread>:<warpsize>}",
+                   "1024:32");
+    option_parser_register(opp, "-gpgpu_tex_cache:l1", OPT_CSTR, &m_L1T_config.m_config_string, 
+                   "per-shader L1 texture cache  (READ-ONLY) config "
+                   " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_alloc>,<mshr>:<N>:<merge>,<mq>:<rf>}",
+                   "8:128:5,L:R:m:N,F:128:4,128:2");
+    option_parser_register(opp, "-gpgpu_const_cache:l1", OPT_CSTR, &m_L1C_config.m_config_string, 
+                   "per-shader L1 constant memory cache  (READ-ONLY) config "
+                   " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_alloc>,<mshr>:<N>:<merge>,<mq>} ",
+                   "64:64:2,L:R:f:N,A:2:32,4" );
+    option_parser_register(opp, "-gpgpu_cache:il1", OPT_CSTR, &m_L1I_config.m_config_string, 
+                   "shader L1 instruction cache config "
+                   " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_alloc>,<mshr>:<N>:<merge>,<mq>} ",
+                   "4:256:4,L:R:f:N,A:2:32,4" );
+    option_parser_register(opp, "-gpgpu_cache:dl1", OPT_CSTR, &m_L1D_config.m_config_string,
+                   "per-shader L1 data cache config "
+                   " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_alloc>,<mshr>:<N>:<merge>,<mq> | none}",
+                   "none" );
+    option_parser_register(opp, "-l1_banks", OPT_UINT32, &m_L1D_config.l1_banks,
+                 "The number of L1 cache banks",
+                 "1");
+    option_parser_register(opp, "-l1_latency", OPT_UINT32, &m_L1D_config.l1_latency,
+                 "L1 Hit Latency",
+                 "1");
+    option_parser_register(opp, "-smem_latency", OPT_UINT32, &smem_latency,
+                 "smem Latency",
+                 "3");
+    option_parser_register(opp, "-gpgpu_cache:dl1PrefL1", OPT_CSTR, &m_L1D_config.m_config_stringPrefL1,
+                   "per-shader L1 data cache config "
+                   " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_alloc>,<mshr>:<N>:<merge>,<mq> | none}",
+                   "none" );
+    option_parser_register(opp, "-gpgpu_cache:dl1PrefShared", OPT_CSTR, &m_L1D_config.m_config_stringPrefShared,
+                   "per-shader L1 data cache config "
+                   " {<nsets>:<bsize>:<assoc>,<rep>:<wr>:<alloc>:<wr_alloc>,<mshr>:<N>:<merge>,<mq> | none}",
+                   "none" );
+    option_parser_register(opp, "-gmem_skip_L1D", OPT_BOOL, &gmem_skip_L1D, 
+                   "global memory access skip L1D cache (implements -Xptxas -dlcm=cg, default=no skip)",
+                   "0");
 
-  option_parser_register(opp, "-gpgpu_perfect_mem", OPT_BOOL,
-                         &gpgpu_perfect_mem,
-                         "enable perfect memory mode (no cache miss)", "0");
-  option_parser_register(
-      opp, "-n_regfile_gating_group", OPT_UINT32, &n_regfile_gating_group,
-      "group of lanes that should be read/written together)", "4");
-  option_parser_register(
-      opp, "-gpgpu_clock_gated_reg_file", OPT_BOOL, &gpgpu_clock_gated_reg_file,
-      "enable clock gated reg file for power calculations", "0");
-  option_parser_register(
-      opp, "-gpgpu_clock_gated_lanes", OPT_BOOL, &gpgpu_clock_gated_lanes,
-      "enable clock gated lanes for power calculations", "0");
-  option_parser_register(opp, "-gpgpu_shader_registers", OPT_UINT32,
-                         &gpgpu_shader_registers,
-                         "Number of registers per shader core. Limits number "
-                         "of concurrent CTAs. (default 8192)",
-                         "8192");
-  option_parser_register(
-      opp, "-gpgpu_registers_per_block", OPT_UINT32, &gpgpu_registers_per_block,
-      "Maximum number of registers per CTA. (default 8192)", "8192");
-  option_parser_register(opp, "-gpgpu_ignore_resources_limitation", OPT_BOOL,
-                         &gpgpu_ignore_resources_limitation,
-                         "gpgpu_ignore_resources_limitation (default 0)", "0");
-  option_parser_register(
-      opp, "-gpgpu_shader_cta", OPT_UINT32, &max_cta_per_core,
-      "Maximum number of concurrent CTAs in shader (default 8)", "8");
-  option_parser_register(
-      opp, "-gpgpu_num_cta_barriers", OPT_UINT32, &max_barriers_per_cta,
-      "Maximum number of named barriers per CTA (default 16)", "16");
-  option_parser_register(opp, "-gpgpu_n_clusters", OPT_UINT32, &n_simt_clusters,
-                         "number of processing clusters", "10");
-  option_parser_register(opp, "-gpgpu_n_cores_per_cluster", OPT_UINT32,
-                         &n_simt_cores_per_cluster,
-                         "number of simd cores per cluster", "3");
-  option_parser_register(opp, "-gpgpu_n_cluster_ejection_buffer_size",
-                         OPT_UINT32, &n_simt_ejection_buffer_size,
-                         "number of packets in ejection buffer", "8");
-  option_parser_register(
-      opp, "-gpgpu_n_ldst_response_buffer_size", OPT_UINT32,
-      &ldst_unit_response_queue_size,
-      "number of response packets in ld/st unit ejection buffer", "2");
-  option_parser_register(
-      opp, "-gpgpu_shmem_per_block", OPT_UINT32, &gpgpu_shmem_per_block,
-      "Size of shared memory per thread block or CTA (default 48kB)", "49152");
-  option_parser_register(
-      opp, "-gpgpu_shmem_size", OPT_UINT32, &gpgpu_shmem_size,
-      "Size of shared memory per shader core (default 16kB)", "16384");
-  option_parser_register(opp, "-adaptive_cache_config", OPT_BOOL,
-                         &adaptive_volta_cache_config, "adaptive_cache_config",
-                         "0");
-  option_parser_register(
-      opp, "-gpgpu_shmem_sizeDefault", OPT_UINT32, &gpgpu_shmem_sizeDefault,
-      "Size of shared memory per shader core (default 16kB)", "16384");
-  option_parser_register(
-      opp, "-gpgpu_shmem_size_PrefL1", OPT_UINT32, &gpgpu_shmem_sizePrefL1,
-      "Size of shared memory per shader core (default 16kB)", "16384");
-  option_parser_register(opp, "-gpgpu_shmem_size_PrefShared", OPT_UINT32,
-                         &gpgpu_shmem_sizePrefShared,
-                         "Size of shared memory per shader core (default 16kB)",
-                         "16384");
-  option_parser_register(
-      opp, "-gpgpu_shmem_num_banks", OPT_UINT32, &num_shmem_bank,
-      "Number of banks in the shared memory in each shader core (default 16)",
-      "16");
-  option_parser_register(
-      opp, "-gpgpu_shmem_limited_broadcast", OPT_BOOL, &shmem_limited_broadcast,
-      "Limit shared memory to do one broadcast per cycle (default on)", "1");
-  option_parser_register(opp, "-gpgpu_shmem_warp_parts", OPT_INT32,
-                         &mem_warp_parts,
-                         "Number of portions a warp is divided into for shared "
-                         "memory bank conflict check ",
-                         "2");
-  option_parser_register(
-      opp, "-mem_unit_ports", OPT_INT32, &mem_unit_ports,
-      "The number of memory transactions allowed per core cycle", "1");
-  option_parser_register(opp, "-gpgpu_shmem_warp_parts", OPT_INT32,
-                         &mem_warp_parts,
-                         "Number of portions a warp is divided into for shared "
-                         "memory bank conflict check ",
-                         "2");
-  option_parser_register(
-      opp, "-gpgpu_warpdistro_shader", OPT_INT32, &gpgpu_warpdistro_shader,
-      "Specify which shader core to collect the warp size distribution from",
-      "-1");
-  option_parser_register(
-      opp, "-gpgpu_warp_issue_shader", OPT_INT32, &gpgpu_warp_issue_shader,
-      "Specify which shader core to collect the warp issue distribution from",
-      "0");
-  option_parser_register(opp, "-gpgpu_local_mem_map", OPT_BOOL,
-                         &gpgpu_local_mem_map,
-                         "Mapping from local memory space address to simulated "
-                         "GPU physical address space (default = enabled)",
-                         "1");
-  option_parser_register(opp, "-gpgpu_num_reg_banks", OPT_INT32,
-                         &gpgpu_num_reg_banks,
-                         "Number of register banks (default = 8)", "8");
-  option_parser_register(
-      opp, "-gpgpu_reg_bank_use_warp_id", OPT_BOOL, &gpgpu_reg_bank_use_warp_id,
-      "Use warp ID in mapping registers to banks (default = off)", "0");
-  option_parser_register(opp, "-sub_core_model", OPT_BOOL, &sub_core_model,
-                         "Sub Core Volta/Pascal model (default = off)", "0");
-  option_parser_register(opp, "-enable_specialized_operand_collector", OPT_BOOL,
-                         &enable_specialized_operand_collector,
-                         "enable_specialized_operand_collector", "1");
-  option_parser_register(opp, "-gpgpu_operand_collector_num_units_sp",
-                         OPT_INT32, &gpgpu_operand_collector_num_units_sp,
-                         "number of collector units (default = 4)", "4");
-  option_parser_register(opp, "-gpgpu_operand_collector_num_units_dp",
-                         OPT_INT32, &gpgpu_operand_collector_num_units_dp,
-                         "number of collector units (default = 0)", "0");
-  option_parser_register(opp, "-gpgpu_operand_collector_num_units_sfu",
-                         OPT_INT32, &gpgpu_operand_collector_num_units_sfu,
-                         "number of collector units (default = 4)", "4");
-  option_parser_register(opp, "-gpgpu_operand_collector_num_units_int",
-                         OPT_INT32, &gpgpu_operand_collector_num_units_int,
-                         "number of collector units (default = 0)", "0");
-  option_parser_register(opp, "-gpgpu_operand_collector_num_units_tensor_core",
-                         OPT_INT32,
-                         &gpgpu_operand_collector_num_units_tensor_core,
-                         "number of collector units (default = 4)", "4");
-  option_parser_register(opp, "-gpgpu_operand_collector_num_units_mem",
-                         OPT_INT32, &gpgpu_operand_collector_num_units_mem,
-                         "number of collector units (default = 2)", "2");
-  option_parser_register(opp, "-gpgpu_operand_collector_num_units_gen",
-                         OPT_INT32, &gpgpu_operand_collector_num_units_gen,
-                         "number of collector units (default = 0)", "0");
-  option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_sp",
-                         OPT_INT32, &gpgpu_operand_collector_num_in_ports_sp,
-                         "number of collector unit in ports (default = 1)",
-                         "1");
-  option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_dp",
-                         OPT_INT32, &gpgpu_operand_collector_num_in_ports_dp,
-                         "number of collector unit in ports (default = 0)",
-                         "0");
-  option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_sfu",
-                         OPT_INT32, &gpgpu_operand_collector_num_in_ports_sfu,
-                         "number of collector unit in ports (default = 1)",
-                         "1");
-  option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_int",
-                         OPT_INT32, &gpgpu_operand_collector_num_in_ports_int,
-                         "number of collector unit in ports (default = 0)",
-                         "0");
-  option_parser_register(
-      opp, "-gpgpu_operand_collector_num_in_ports_tensor_core", OPT_INT32,
-      &gpgpu_operand_collector_num_in_ports_tensor_core,
-      "number of collector unit in ports (default = 1)", "1");
-  option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_mem",
-                         OPT_INT32, &gpgpu_operand_collector_num_in_ports_mem,
-                         "number of collector unit in ports (default = 1)",
-                         "1");
-  option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_gen",
-                         OPT_INT32, &gpgpu_operand_collector_num_in_ports_gen,
-                         "number of collector unit in ports (default = 0)",
-                         "0");
-  option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_sp",
-                         OPT_INT32, &gpgpu_operand_collector_num_out_ports_sp,
-                         "number of collector unit in ports (default = 1)",
-                         "1");
-  option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_dp",
-                         OPT_INT32, &gpgpu_operand_collector_num_out_ports_dp,
-                         "number of collector unit in ports (default = 0)",
-                         "0");
-  option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_sfu",
-                         OPT_INT32, &gpgpu_operand_collector_num_out_ports_sfu,
-                         "number of collector unit in ports (default = 1)",
-                         "1");
-  option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_int",
-                         OPT_INT32, &gpgpu_operand_collector_num_out_ports_int,
-                         "number of collector unit in ports (default = 0)",
-                         "0");
-  option_parser_register(
-      opp, "-gpgpu_operand_collector_num_out_ports_tensor_core", OPT_INT32,
-      &gpgpu_operand_collector_num_out_ports_tensor_core,
-      "number of collector unit in ports (default = 1)", "1");
-  option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_mem",
-                         OPT_INT32, &gpgpu_operand_collector_num_out_ports_mem,
-                         "number of collector unit in ports (default = 1)",
-                         "1");
-  option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_gen",
-                         OPT_INT32, &gpgpu_operand_collector_num_out_ports_gen,
-                         "number of collector unit in ports (default = 0)",
-                         "0");
-  option_parser_register(opp, "-gpgpu_coalesce_arch", OPT_INT32,
-                         &gpgpu_coalesce_arch,
-                         "Coalescing arch (GT200 = 13, Fermi = 20)", "13");
-  option_parser_register(opp, "-gpgpu_num_sched_per_core", OPT_INT32,
-                         &gpgpu_num_sched_per_core,
-                         "Number of warp schedulers per core", "1");
-  option_parser_register(opp, "-gpgpu_max_insn_issue_per_warp", OPT_INT32,
-                         &gpgpu_max_insn_issue_per_warp,
-                         "Max number of instructions that can be issued per "
-                         "warp in one cycle by scheduler (either 1 or 2)",
-                         "2");
-  option_parser_register(opp, "-gpgpu_dual_issue_diff_exec_units", OPT_BOOL,
-                         &gpgpu_dual_issue_diff_exec_units,
-                         "should dual issue use two different execution unit "
-                         "resources (Default = 1)",
-                         "1");
-  option_parser_register(opp, "-gpgpu_simt_core_sim_order", OPT_INT32,
-                         &simt_core_sim_order,
-                         "Select the simulation order of cores in a cluster "
-                         "(0=Fix, 1=Round-Robin)",
-                         "1");
-  option_parser_register(
-      opp, "-gpgpu_pipeline_widths", OPT_CSTR, &pipeline_widths_string,
-      "Pipeline widths "
-      "ID_OC_SP,ID_OC_DP,ID_OC_INT,ID_OC_SFU,ID_OC_MEM,OC_EX_SP,OC_EX_DP,OC_EX_"
-      "INT,OC_EX_SFU,OC_EX_MEM,EX_WB,ID_OC_TENSOR_CORE,OC_EX_TENSOR_CORE",
-      "1,1,1,1,1,1,1,1,1,1,1,1,1");
-  option_parser_register(opp, "-gpgpu_tensor_core_avail", OPT_INT32,
-                         &gpgpu_tensor_core_avail,
-                         "Tensor Core Available (default=0)", "0");
-  option_parser_register(opp, "-gpgpu_num_sp_units", OPT_INT32,
-                         &gpgpu_num_sp_units, "Number of SP units (default=1)",
-                         "1");
-  option_parser_register(opp, "-gpgpu_num_dp_units", OPT_INT32,
-                         &gpgpu_num_dp_units, "Number of DP units (default=0)",
-                         "0");
-  option_parser_register(opp, "-gpgpu_num_int_units", OPT_INT32,
-                         &gpgpu_num_int_units,
-                         "Number of INT units (default=0)", "0");
-  option_parser_register(opp, "-gpgpu_num_sfu_units", OPT_INT32,
-                         &gpgpu_num_sfu_units, "Number of SF units (default=1)",
-                         "1");
-  option_parser_register(opp, "-gpgpu_num_tensor_core_units", OPT_INT32,
-                         &gpgpu_num_tensor_core_units,
-                         "Number of tensor_core units (default=1)", "1");
-  option_parser_register(
-      opp, "-gpgpu_num_mem_units", OPT_INT32, &gpgpu_num_mem_units,
-      "Number if ldst units (default=1) WARNING: not hooked up to anything",
-      "1");
-  option_parser_register(
-      opp, "-gpgpu_scheduler", OPT_CSTR, &gpgpu_scheduler_string,
-      "Scheduler configuration: < lrr | gto | two_level_active > "
-      "If "
-      "two_level_active:<num_active_warps>:<inner_prioritization>:<outer_"
-      "prioritization>"
-      "For complete list of prioritization values see shader.h enum "
-      "scheduler_prioritization_type"
-      "Default: gto",
-      "gto");
+    option_parser_register(opp, "-gpgpu_perfect_mem", OPT_BOOL, &gpgpu_perfect_mem, 
+                 "enable perfect memory mode (no cache miss)",
+                 "0");
+    option_parser_register(opp, "-n_regfile_gating_group", OPT_UINT32, &n_regfile_gating_group,
+                 "group of lanes that should be read/written together)",
+                 "4");
+    option_parser_register(opp, "-gpgpu_clock_gated_reg_file", OPT_BOOL, &gpgpu_clock_gated_reg_file,
+                 "enable clock gated reg file for power calculations",
+                 "0");
+    option_parser_register(opp, "-gpgpu_clock_gated_lanes", OPT_BOOL, &gpgpu_clock_gated_lanes,
+                 "enable clock gated lanes for power calculations",
+                 "0");
+    option_parser_register(opp, "-gpgpu_shader_registers", OPT_UINT32, &gpgpu_shader_registers, 
+                 "Number of registers per shader core. Limits number of concurrent CTAs. (default 8192)",
+                 "8192");
+    option_parser_register(opp, "-gpgpu_registers_per_block", OPT_UINT32, &gpgpu_registers_per_block,
+                 "Maximum number of registers per CTA. (default 8192)",
+                 "8192");
+    option_parser_register(opp, "-gpgpu_ignore_resources_limitation", OPT_BOOL, &gpgpu_ignore_resources_limitation,
+                 "gpgpu_ignore_resources_limitation (default 0)",
+                 "0");
+    option_parser_register(opp, "-gpgpu_shader_cta", OPT_UINT32, &max_cta_per_core, 
+                 "Maximum number of concurrent CTAs in shader (default 8)",
+                 "8");
+    option_parser_register(opp, "-gpgpu_num_cta_barriers", OPT_UINT32, &max_barriers_per_cta,
+                 "Maximum number of named barriers per CTA (default 16)",
+                 "16");
+    option_parser_register(opp, "-gpgpu_n_clusters", OPT_UINT32, &n_simt_clusters, 
+                 "number of processing clusters",
+                 "10");
+    option_parser_register(opp, "-gpgpu_n_cores_per_cluster", OPT_UINT32, &n_simt_cores_per_cluster, 
+                 "number of simd cores per cluster",
+                 "3");
+    option_parser_register(opp, "-gpgpu_n_cluster_ejection_buffer_size", OPT_UINT32, &n_simt_ejection_buffer_size, 
+                 "number of packets in ejection buffer",
+                 "8");
+    option_parser_register(opp, "-gpgpu_n_ldst_response_buffer_size", OPT_UINT32, &ldst_unit_response_queue_size, 
+                 "number of response packets in ld/st unit ejection buffer",
+                 "2");
+    option_parser_register(opp, "-gpgpu_shmem_per_block", OPT_UINT32, &gpgpu_shmem_per_block,
+                 "Size of shared memory per thread block or CTA (default 48kB)",
+                 "49152");
+    option_parser_register(opp, "-gpgpu_shmem_size", OPT_UINT32, &gpgpu_shmem_size,
+                 "Size of shared memory per shader core (default 16kB)",
+                 "16384");
+    option_parser_register(opp, "-adaptive_cache_config", OPT_BOOL, &adaptive_volta_cache_config,
+                 "adaptive_cache_config",
+                 "0");
+    option_parser_register(opp, "-gpgpu_shmem_sizeDefault", OPT_UINT32, &gpgpu_shmem_sizeDefault,
+                 "Size of shared memory per shader core (default 16kB)",
+                 "16384");
+    option_parser_register(opp, "-gpgpu_shmem_size_PrefL1", OPT_UINT32, &gpgpu_shmem_sizePrefL1,
+                 "Size of shared memory per shader core (default 16kB)",
+                 "16384");
+    option_parser_register(opp, "-gpgpu_shmem_size_PrefShared", OPT_UINT32, &gpgpu_shmem_sizePrefShared,
+                 "Size of shared memory per shader core (default 16kB)",
+                 "16384");
+    option_parser_register(opp, "-gpgpu_shmem_num_banks", OPT_UINT32, &num_shmem_bank, 
+                 "Number of banks in the shared memory in each shader core (default 16)",
+                 "16");
+    option_parser_register(opp, "-gpgpu_shmem_limited_broadcast", OPT_BOOL, &shmem_limited_broadcast, 
+                 "Limit shared memory to do one broadcast per cycle (default on)",
+                 "1");
+    option_parser_register(opp, "-gpgpu_shmem_warp_parts", OPT_INT32, &mem_warp_parts,  
+                 "Number of portions a warp is divided into for shared memory bank conflict check ",
+                 "2");
+    option_parser_register(opp, "-mem_unit_ports", OPT_INT32, &mem_unit_ports,
+                 "The number of memory transactions allowed per core cycle",
+                 "1");
+    option_parser_register(opp, "-gpgpu_shmem_warp_parts", OPT_INT32, &mem_warp_parts,
+				 "Number of portions a warp is divided into for shared memory bank conflict check ",
+				 "2");
+    option_parser_register(opp, "-gpgpu_warpdistro_shader", OPT_INT32, &gpgpu_warpdistro_shader, 
+                "Specify which shader core to collect the warp size distribution from", 
+                "-1");
+    option_parser_register(opp, "-gpgpu_warp_issue_shader", OPT_INT32, &gpgpu_warp_issue_shader, 
+                "Specify which shader core to collect the warp issue distribution from", 
+                "0");
+    option_parser_register(opp, "-gpgpu_local_mem_map", OPT_BOOL, &gpgpu_local_mem_map, 
+                "Mapping from local memory space address to simulated GPU physical address space (default = enabled)", 
+		"1");
+    option_parser_register(opp, "-gpgpu_num_reg_banks", OPT_INT32, &gpgpu_num_reg_banks, 
+                "Number of register banks (default = 8)", 
+                "8");
+    option_parser_register(opp, "-gpgpu_reg_bank_use_warp_id", OPT_BOOL, &gpgpu_reg_bank_use_warp_id,
+             "Use warp ID in mapping registers to banks (default = off)",
+             "0");
+    option_parser_register(opp, "-sub_core_model", OPT_BOOL, &sub_core_model,
+             "Sub Core Volta/Pascal model (default = off)",
+             "0");
+    option_parser_register(opp, "-enable_specialized_operand_collector", OPT_BOOL, &enable_specialized_operand_collector,
+                "enable_specialized_operand_collector",
+                "1");
+    option_parser_register(opp, "-gpgpu_operand_collector_num_units_sp", OPT_INT32, &gpgpu_operand_collector_num_units_sp,
+                "number of collector units (default = 4)",
+                "4");
+    option_parser_register(opp, "-gpgpu_operand_collector_num_units_dp", OPT_INT32, &gpgpu_operand_collector_num_units_dp,
+                   "number of collector units (default = 0)",
+                   "0");
+    option_parser_register(opp, "-gpgpu_operand_collector_num_units_sfu", OPT_INT32, &gpgpu_operand_collector_num_units_sfu,
+                "number of collector units (default = 4)", 
+                "4");
+    option_parser_register(opp, "-gpgpu_operand_collector_num_units_int", OPT_INT32, &gpgpu_operand_collector_num_units_int,
+                "number of collector units (default = 0)",
+                "0");
+    option_parser_register(opp, "-gpgpu_operand_collector_num_units_tensor_core", OPT_INT32, &gpgpu_operand_collector_num_units_tensor_core,
+                "number of collector units (default = 4)", 
+                "4");
+    option_parser_register(opp, "-gpgpu_operand_collector_num_units_mem", OPT_INT32, &gpgpu_operand_collector_num_units_mem,
+                "number of collector units (default = 2)", 
+                "2");
+    option_parser_register(opp, "-gpgpu_operand_collector_num_units_gen", OPT_INT32, &gpgpu_operand_collector_num_units_gen,
+                "number of collector units (default = 0)", 
+                "0");
+    option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_sp", OPT_INT32, &gpgpu_operand_collector_num_in_ports_sp,
+                           "number of collector unit in ports (default = 1)", 
+                           "1");
+    option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_dp", OPT_INT32, &gpgpu_operand_collector_num_in_ports_dp,
+                           "number of collector unit in ports (default = 0)",
+                           "0");
+    option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_sfu", OPT_INT32, &gpgpu_operand_collector_num_in_ports_sfu,
+                           "number of collector unit in ports (default = 1)", 
+                           "1");
+    option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_int", OPT_INT32, &gpgpu_operand_collector_num_in_ports_int,
+                           "number of collector unit in ports (default = 0)",
+                           "0");
+    option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_tensor_core", OPT_INT32, &gpgpu_operand_collector_num_in_ports_tensor_core,
+                           "number of collector unit in ports (default = 1)", 
+                           "1");
+    option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_mem", OPT_INT32, &gpgpu_operand_collector_num_in_ports_mem,
+                           "number of collector unit in ports (default = 1)", 
+                           "1");
+    option_parser_register(opp, "-gpgpu_operand_collector_num_in_ports_gen", OPT_INT32, &gpgpu_operand_collector_num_in_ports_gen,
+                           "number of collector unit in ports (default = 0)", 
+                           "0");
+    option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_sp", OPT_INT32, &gpgpu_operand_collector_num_out_ports_sp,
+                           "number of collector unit in ports (default = 1)", 
+                           "1");
+    option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_dp", OPT_INT32, &gpgpu_operand_collector_num_out_ports_dp,
+                           "number of collector unit in ports (default = 0)",
+                           "0");
+    option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_sfu", OPT_INT32, &gpgpu_operand_collector_num_out_ports_sfu,
+                           "number of collector unit in ports (default = 1)", 
+                           "1");
+    option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_int", OPT_INT32, &gpgpu_operand_collector_num_out_ports_int,
+                           "number of collector unit in ports (default = 0)",
+                           "0");
+    option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_tensor_core", OPT_INT32, &gpgpu_operand_collector_num_out_ports_tensor_core,
+                           "number of collector unit in ports (default = 1)", 
+                           "1");
+    option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_mem", OPT_INT32, &gpgpu_operand_collector_num_out_ports_mem,
+                           "number of collector unit in ports (default = 1)", 
+                           "1");
+    option_parser_register(opp, "-gpgpu_operand_collector_num_out_ports_gen", OPT_INT32, &gpgpu_operand_collector_num_out_ports_gen,
+                           "number of collector unit in ports (default = 0)", 
+                           "0");
+    option_parser_register(opp, "-gpgpu_coalesce_arch", OPT_INT32, &gpgpu_coalesce_arch, 
+    		            "Coalescing arch (GT200 = 13, Fermi = 20)",
+                            "13");
+    option_parser_register(opp, "-gpgpu_num_sched_per_core", OPT_INT32, &gpgpu_num_sched_per_core, 
+                            "Number of warp schedulers per core", 
+                            "1");
+    option_parser_register(opp, "-gpgpu_max_insn_issue_per_warp", OPT_INT32, &gpgpu_max_insn_issue_per_warp,
+    		            "Max number of instructions that can be issued per warp in one cycle by scheduler (either 1 or 2)",
+			    "2");
+    option_parser_register(opp, "-gpgpu_dual_issue_diff_exec_units", OPT_BOOL, &gpgpu_dual_issue_diff_exec_units,
+			    "should dual issue use two different execution unit resources (Default = 1)",
+			    "1");
+    option_parser_register(opp, "-gpgpu_simt_core_sim_order", OPT_INT32, &simt_core_sim_order,
+                            "Select the simulation order of cores in a cluster (0=Fix, 1=Round-Robin)",
+                            "1");
+    option_parser_register(opp, "-gpgpu_pipeline_widths", OPT_CSTR, &pipeline_widths_string,
+                            "Pipeline widths "
+                            "ID_OC_SP,ID_OC_DP,ID_OC_INT,ID_OC_SFU,ID_OC_MEM,OC_EX_SP,OC_EX_DP,OC_EX_INT,OC_EX_SFU,OC_EX_MEM,EX_WB,ID_OC_TENSOR_CORE,OC_EX_TENSOR_CORE",
+                            "1,1,1,1,1,1,1,1,1,1,1,1,1" );
+    option_parser_register(opp, "-gpgpu_tensor_core_avail", OPT_INT32, &gpgpu_tensor_core_avail,
+                            "Tensor Core Available (default=0)",
+                            "0");
+    option_parser_register(opp, "-gpgpu_num_sp_units", OPT_INT32, &gpgpu_num_sp_units,
+                            "Number of SP units (default=1)",
+                            "1");
+    option_parser_register(opp, "-gpgpu_num_dp_units", OPT_INT32, &gpgpu_num_dp_units,
+                            "Number of DP units (default=0)",
+                            "0");
+    option_parser_register(opp, "-gpgpu_num_int_units", OPT_INT32, &gpgpu_num_int_units,
+                            "Number of INT units (default=0)",
+                            "0");
+    option_parser_register(opp, "-gpgpu_num_sfu_units", OPT_INT32, &gpgpu_num_sfu_units,
+                            "Number of SF units (default=1)",
+                            "1");
+    option_parser_register(opp, "-gpgpu_num_tensor_core_units", OPT_INT32, &gpgpu_num_tensor_core_units,
+                            "Number of tensor_core units (default=1)",
+                            "1");
+    option_parser_register(opp, "-gpgpu_num_mem_units", OPT_INT32, &gpgpu_num_mem_units,
+                            "Number if ldst units (default=1) WARNING: not hooked up to anything",
+                             "1");
+    option_parser_register(opp, "-gpgpu_scheduler", OPT_CSTR, &gpgpu_scheduler_string,
+                                "Scheduler configuration: < lrr | gto | two_level_active > "
+                                "If two_level_active:<num_active_warps>:<inner_prioritization>:<outer_prioritization>"
+                                "For complete list of prioritization values see shader.h enum scheduler_prioritization_type"
+                                "Default: gto",
+                                 "gto");
 
-  option_parser_register(
-      opp, "-gpgpu_concurrent_kernel_sm", OPT_BOOL, &gpgpu_concurrent_kernel_sm,
-      "Support concurrent kernels on a SM (default = disabled)", "0");
+    option_parser_register(opp, "-gpgpu_concurrent_kernel_sm", OPT_BOOL, &gpgpu_concurrent_kernel_sm, 
+                "Support concurrent kernels on a SM (default = disabled)", 
+                "0");
+
 }
 
-void gpgpu_sim_config::reg_options(option_parser_t opp) {
-  gpgpu_functional_sim_config::reg_options(opp);
-  m_shader_config.reg_options(opp);
-  m_memory_config.reg_options(opp);
-  power_config::reg_options(opp);
-  option_parser_register(opp, "-gpgpu_max_cycle", OPT_INT64, &gpu_max_cycle_opt,
-                         "terminates gpu simulation early (0 = no limit)", "0");
-  option_parser_register(opp, "-gpgpu_max_insn", OPT_INT64, &gpu_max_insn_opt,
-                         "terminates gpu simulation early (0 = no limit)", "0");
-  option_parser_register(opp, "-gpgpu_max_cta", OPT_INT32, &gpu_max_cta_opt,
-                         "terminates gpu simulation early (0 = no limit)", "0");
-  option_parser_register(
-      opp, "-gpgpu_runtime_stat", OPT_CSTR, &gpgpu_runtime_stat,
-      "display runtime statistics such as dram utilization {<freq>:<flag>}",
-      "10000:0");
-  option_parser_register(opp, "-liveness_message_freq", OPT_INT64,
-                         &liveness_message_freq,
-                         "Minimum number of seconds between simulation "
-                         "liveness messages (0 = always print)",
-                         "1");
-  option_parser_register(opp, "-gpgpu_compute_capability_major", OPT_UINT32,
-                         &gpgpu_compute_capability_major,
-                         "Major compute capability version number", "7");
-  option_parser_register(opp, "-gpgpu_compute_capability_minor", OPT_UINT32,
-                         &gpgpu_compute_capability_minor,
-                         "Minor compute capability version number", "0");
-  option_parser_register(opp, "-gpgpu_flush_l1_cache", OPT_BOOL,
-                         &gpgpu_flush_l1_cache,
-                         "Flush L1 cache at the end of each kernel call", "0");
-  option_parser_register(opp, "-gpgpu_flush_l2_cache", OPT_BOOL,
-                         &gpgpu_flush_l2_cache,
-                         "Flush L2 cache at the end of each kernel call", "0");
-  option_parser_register(
-      opp, "-gpgpu_deadlock_detect", OPT_BOOL, &gpu_deadlock_detect,
-      "Stop the simulation at deadlock (1=on (default), 0=off)", "1");
-  option_parser_register(
-      opp, "-gpgpu_ptx_instruction_classification", OPT_INT32,
-      &(gpgpu_ctx->func_sim->gpgpu_ptx_instruction_classification),
-      "if enabled will classify ptx instruction types per kernel (Max 255 "
-      "kernels now)",
-      "0");
-  option_parser_register(
-      opp, "-gpgpu_ptx_sim_mode", OPT_INT32,
-      &(gpgpu_ctx->func_sim->g_ptx_sim_mode),
-      "Select between Performance (default) or Functional simulation (1)", "0");
-  option_parser_register(opp, "-gpgpu_clock_domains", OPT_CSTR,
-                         &gpgpu_clock_domains,
-                         "Clock Domain Frequencies in MhZ {<Core Clock>:<ICNT "
-                         "Clock>:<L2 Clock>:<DRAM Clock>}",
-                         "500.0:2000.0:2000.0:2000.0");
-  option_parser_register(
-      opp, "-gpgpu_max_concurrent_kernel", OPT_INT32, &max_concurrent_kernel,
-      "maximum kernels that can run concurrently on GPU", "8");
-  option_parser_register(
-      opp, "-gpgpu_cflog_interval", OPT_INT32, &gpgpu_cflog_interval,
-      "Interval between each snapshot in control flow logger", "0");
-  option_parser_register(opp, "-visualizer_enabled", OPT_BOOL,
-                         &g_visualizer_enabled,
-                         "Turn on visualizer output (1=On, 0=Off)", "1");
-  option_parser_register(opp, "-visualizer_outputfile", OPT_CSTR,
-                         &g_visualizer_filename,
-                         "Specifies the output log file for visualizer", NULL);
-  option_parser_register(
-      opp, "-visualizer_zlevel", OPT_INT32, &g_visualizer_zlevel,
-      "Compression level of the visualizer output log (0=no comp, 9=highest)",
-      "6");
-  option_parser_register(opp, "-gpgpu_stack_size_limit", OPT_INT32,
-                         &stack_size_limit, "GPU thread stack size", "1024");
-  option_parser_register(opp, "-gpgpu_heap_size_limit", OPT_INT32,
-                         &heap_size_limit, "GPU malloc heap size ", "8388608");
-  option_parser_register(opp, "-gpgpu_runtime_sync_depth_limit", OPT_INT32,
-                         &runtime_sync_depth_limit,
-                         "GPU device runtime synchronize depth", "2");
-  option_parser_register(opp, "-gpgpu_runtime_pending_launch_count_limit",
-                         OPT_INT32, &runtime_pending_launch_count_limit,
-                         "GPU device runtime pending launch count", "2048");
-  option_parser_register(opp, "-trace_enabled", OPT_BOOL, &Trace::enabled,
-                         "Turn on traces", "0");
-  option_parser_register(opp, "-trace_components", OPT_CSTR, &Trace::config_str,
-                         "comma seperated list of traces to enable. "
-                         "Complete list found in trace_streams.tup. "
-                         "Default none",
-                         "none");
-  option_parser_register(
-      opp, "-trace_sampling_core", OPT_INT32, &Trace::sampling_core,
-      "The core which is printed using CORE_DPRINTF. Default 0", "0");
-  option_parser_register(opp, "-trace_sampling_memory_partition", OPT_INT32,
-                         &Trace::sampling_memory_partition,
-                         "The memory partition which is printed using "
-                         "MEMPART_DPRINTF. Default -1 (i.e. all)",
-                         "-1");
-  gpgpu_ctx->stats->ptx_file_line_stats_options(opp);
+void gpgpu_sim_config::reg_options(option_parser_t opp)
+{
+    gpgpu_functional_sim_config::reg_options(opp);
+    m_shader_config.reg_options(opp);
+    m_memory_config.reg_options(opp);
+    power_config::reg_options(opp);
+   option_parser_register(opp, "-gpgpu_max_cycle", OPT_INT64, &gpu_max_cycle_opt, 
+               "terminates gpu simulation early (0 = no limit)",
+               "0");
+   option_parser_register(opp, "-gpgpu_max_insn", OPT_INT64, &gpu_max_insn_opt, 
+               "terminates gpu simulation early (0 = no limit)",
+               "0");
+   option_parser_register(opp, "-gpgpu_max_cta", OPT_INT32, &gpu_max_cta_opt, 
+               "terminates gpu simulation early (0 = no limit)",
+               "0");
+   option_parser_register(opp, "-gpgpu_runtime_stat", OPT_CSTR, &gpgpu_runtime_stat, 
+                  "display runtime statistics such as dram utilization {<freq>:<flag>}",
+                  "10000:0");
+   option_parser_register(opp, "-liveness_message_freq", OPT_INT64, &liveness_message_freq, 
+               "Minimum number of seconds between simulation liveness messages (0 = always print)",
+               "1");
+   option_parser_register(opp, "-gpgpu_compute_capability_major", OPT_UINT32, &gpgpu_compute_capability_major,
+                 "Major compute capability version number",
+                 "7");
+   option_parser_register(opp, "-gpgpu_compute_capability_minor", OPT_UINT32, &gpgpu_compute_capability_minor,
+                 "Minor compute capability version number",
+                 "0");
+   option_parser_register(opp, "-gpgpu_flush_l1_cache", OPT_BOOL, &gpgpu_flush_l1_cache,
+                "Flush L1 cache at the end of each kernel call",
+                "0");
+   option_parser_register(opp, "-gpgpu_flush_l2_cache", OPT_BOOL, &gpgpu_flush_l2_cache,
+                   "Flush L2 cache at the end of each kernel call",
+                   "0");
+   option_parser_register(opp, "-gpgpu_deadlock_detect", OPT_BOOL, &gpu_deadlock_detect, 
+                "Stop the simulation at deadlock (1=on (default), 0=off)", 
+                "1");
+   option_parser_register(opp, "-gpgpu_ptx_instruction_classification", OPT_INT32,
+               &(gpgpu_ctx->func_sim->gpgpu_ptx_instruction_classification),
+               "if enabled will classify ptx instruction types per kernel (Max 255 kernels now)", 
+               "0");
+   option_parser_register(opp, "-gpgpu_ptx_sim_mode", OPT_INT32, &(gpgpu_ctx->func_sim->g_ptx_sim_mode),
+               "Select between Performance (default) or Functional simulation (1)", 
+               "0");
+   option_parser_register(opp, "-gpgpu_clock_domains", OPT_CSTR, &gpgpu_clock_domains, 
+                  "Clock Domain Frequencies in MhZ {<Core Clock>:<ICNT Clock>:<L2 Clock>:<DRAM Clock>}",
+                  "500.0:2000.0:2000.0:2000.0");
+   option_parser_register(opp, "-gpgpu_max_concurrent_kernel", OPT_INT32, &max_concurrent_kernel,
+                          "maximum kernels that can run concurrently on GPU", "8" );
+   option_parser_register(opp, "-gpgpu_cflog_interval", OPT_INT32, &gpgpu_cflog_interval, 
+               "Interval between each snapshot in control flow logger", 
+               "0");
+   option_parser_register(opp, "-visualizer_enabled", OPT_BOOL,
+                          &g_visualizer_enabled, "Turn on visualizer output (1=On, 0=Off)",
+                          "1");
+   option_parser_register(opp, "-visualizer_outputfile", OPT_CSTR, 
+                          &g_visualizer_filename, "Specifies the output log file for visualizer",
+                          NULL);
+   option_parser_register(opp, "-visualizer_zlevel", OPT_INT32,
+                          &g_visualizer_zlevel, "Compression level of the visualizer output log (0=no comp, 9=highest)",
+                          "6");
+   option_parser_register(opp, "-gpgpu_stack_size_limit", OPT_INT32, &stack_size_limit,
+                          "GPU thread stack size", "1024" );
+   option_parser_register(opp, "-gpgpu_heap_size_limit", OPT_INT32, &heap_size_limit,
+                          "GPU malloc heap size ", "8388608" );
+   option_parser_register(opp, "-gpgpu_runtime_sync_depth_limit", OPT_INT32, &runtime_sync_depth_limit,
+                          "GPU device runtime synchronize depth", "2" );
+   option_parser_register(opp, "-gpgpu_runtime_pending_launch_count_limit", OPT_INT32, &runtime_pending_launch_count_limit,
+                          "GPU device runtime pending launch count", "2048" );
+    option_parser_register(opp, "-trace_enabled", OPT_BOOL, 
+                          &Trace::enabled, "Turn on traces",
+                          "0");
+    option_parser_register(opp, "-trace_components", OPT_CSTR, 
+                          &Trace::config_str, "comma seperated list of traces to enable. "
+                          "Complete list found in trace_streams.tup. "
+                          "Default none",
+                          "none");
+    option_parser_register(opp, "-trace_sampling_core", OPT_INT32, 
+                          &Trace::sampling_core, "The core which is printed using CORE_DPRINTF. Default 0",
+                          "0");
+    option_parser_register(opp, "-trace_sampling_memory_partition", OPT_INT32, 
+                          &Trace::sampling_memory_partition, "The memory partition which is printed using MEMPART_DPRINTF. Default -1 (i.e. all)",
+                          "-1");
+    gpgpu_ctx->stats->ptx_file_line_stats_options(opp);
 
-  // Jin: kernel launch latency
-  option_parser_register(opp, "-gpgpu_kernel_launch_latency", OPT_INT32,
-                         &(gpgpu_ctx->device_runtime->g_kernel_launch_latency),
-                         "Kernel launch latency in cycles. Default: 0", "0");
-  option_parser_register(opp, "-gpgpu_cdp_enabled", OPT_BOOL,
-                         &(gpgpu_ctx->device_runtime->g_cdp_enabled),
-                         "Turn on CDP", "0");
+    //Jin: kernel launch latency
+    option_parser_register(opp, "-gpgpu_kernel_launch_latency", OPT_INT32, 
+                          &(gpgpu_ctx->device_runtime->g_kernel_launch_latency), "Kernel launch latency in cycles. Default: 0",
+                          "0");
+    option_parser_register(opp, "-gpgpu_cdp_enabled", OPT_BOOL, 
+                          &(gpgpu_ctx->device_runtime->g_cdp_enabled), "Turn on CDP",
+                          "0");
 }
 
 /////////////////////////////////////////////////////////////////////////////
 
-void increment_x_then_y_then_z(dim3 &i, const dim3 &bound) {
-  i.x++;
-  if (i.x >= bound.x) {
-    i.x = 0;
-    i.y++;
-    if (i.y >= bound.y) {
-      i.y = 0;
-      if (i.z < bound.z) i.z++;
-    }
-  }
+void increment_x_then_y_then_z( dim3 &i, const dim3 &bound)
+{
+   i.x++;
+   if ( i.x >= bound.x ) {
+      i.x = 0;
+      i.y++;
+      if ( i.y >= bound.y ) {
+         i.y = 0;
+         if( i.z < bound.z ) 
+            i.z++;
+      }
+   }
 }
 
-void gpgpu_sim::launch(kernel_info_t *kinfo) {
-  unsigned cta_size = kinfo->threads_per_cta();
-  if (cta_size > m_shader_config->n_thread_per_shader) {
-    printf(
-        "Execution error: Shader kernel CTA (block) size is too large for "
-        "microarch config.\n");
-    printf("                 CTA size (x*y*z) = %u, max supported = %u\n",
-           cta_size, m_shader_config->n_thread_per_shader);
-    printf(
-        "                 => either change -gpgpu_shader argument in "
-        "gpgpusim.config file or\n");
-    printf(
-        "                 modify the CUDA source to decrease the kernel block "
-        "size.\n");
-    abort();
-  }
-  unsigned n = 0;
-  for (n = 0; n < m_running_kernels.size(); n++) {
-    if ((NULL == m_running_kernels[n]) || m_running_kernels[n]->done()) {
-      m_running_kernels[n] = kinfo;
-      break;
-    }
-  }
-  assert(n < m_running_kernels.size());
+void gpgpu_sim::launch( kernel_info_t *kinfo )
+{
+   unsigned cta_size = kinfo->threads_per_cta();
+   if ( cta_size > m_shader_config->n_thread_per_shader ) {
+      printf("Execution error: Shader kernel CTA (block) size is too large for microarch config.\n");
+      printf("                 CTA size (x*y*z) = %u, max supported = %u\n", cta_size, 
+             m_shader_config->n_thread_per_shader );
+      printf("                 => either change -gpgpu_shader argument in gpgpusim.config file or\n");
+      printf("                 modify the CUDA source to decrease the kernel block size.\n");
+      abort();
+   }
+   unsigned n=0;
+   for(n=0; n < m_running_kernels.size(); n++ ) {
+       if( (NULL==m_running_kernels[n]) || m_running_kernels[n]->done() ) {
+           m_running_kernels[n] = kinfo;
+           break;
+       }
+   }
+   assert(n < m_running_kernels.size());
 }
 
-bool gpgpu_sim::can_start_kernel() {
-  for (unsigned n = 0; n < m_running_kernels.size(); n++) {
-    if ((NULL == m_running_kernels[n]) || m_running_kernels[n]->done())
-      return true;
-  }
-  return false;
+bool gpgpu_sim::can_start_kernel()
+{
+   for(unsigned n=0; n < m_running_kernels.size(); n++ ) {
+       if( (NULL==m_running_kernels[n]) || m_running_kernels[n]->done() ) 
+           return true;
+   }
+   return false;
 }
 
 bool gpgpu_sim::hit_max_cta_count() const {
-  if (m_config.gpu_max_cta_opt != 0) {
-    if ((gpu_tot_issued_cta + m_total_cta_launched) >= m_config.gpu_max_cta_opt)
-      return true;
-  }
-  return false;
+   if (m_config.gpu_max_cta_opt != 0) {
+      if( (gpu_tot_issued_cta + m_total_cta_launched) >= m_config.gpu_max_cta_opt )
+          return true;
+   }
+   return false;
 }
 
 bool gpgpu_sim::kernel_more_cta_left(kernel_info_t *kernel) const {
-  if (hit_max_cta_count()) return false;
+    if(hit_max_cta_count())
+       return false;
 
-  if (kernel && !kernel->no_more_ctas_to_run()) return true;
+    if(kernel && !kernel->no_more_ctas_to_run())
+        return true;
 
-  return false;
+    return false;
 }
 
-bool gpgpu_sim::get_more_cta_left() const {
-  if (hit_max_cta_count()) return false;
+bool gpgpu_sim::get_more_cta_left() const
+{ 
+   if(hit_max_cta_count())
+      return false;
 
-  for (unsigned n = 0; n < m_running_kernels.size(); n++) {
-    if (m_running_kernels[n] && !m_running_kernels[n]->no_more_ctas_to_run())
-      return true;
-  }
-  return false;
+   for(unsigned n=0; n < m_running_kernels.size(); n++ ) {
+       if( m_running_kernels[n] && !m_running_kernels[n]->no_more_ctas_to_run() ) 
+           return true;
+   }
+   return false;
 }
 
-kernel_info_t *gpgpu_sim::select_kernel() {
-  if (m_running_kernels[m_last_issued_kernel] &&
-      !m_running_kernels[m_last_issued_kernel]->no_more_ctas_to_run()) {
-    unsigned launch_uid = m_running_kernels[m_last_issued_kernel]->get_uid();
-    if (std::find(m_executed_kernel_uids.begin(), m_executed_kernel_uids.end(),
-                  launch_uid) == m_executed_kernel_uids.end()) {
-      m_running_kernels[m_last_issued_kernel]->start_cycle =
-          gpu_sim_cycle + gpu_tot_sim_cycle;
-      m_executed_kernel_uids.push_back(launch_uid);
-      m_executed_kernel_names.push_back(
-          m_running_kernels[m_last_issued_kernel]->name());
+kernel_info_t *gpgpu_sim::select_kernel()
+{
+    if(m_running_kernels[m_last_issued_kernel] &&
+        !m_running_kernels[m_last_issued_kernel]->no_more_ctas_to_run()) {
+        unsigned launch_uid = m_running_kernels[m_last_issued_kernel]->get_uid(); 
+        if(std::find(m_executed_kernel_uids.begin(), m_executed_kernel_uids.end(), launch_uid) == m_executed_kernel_uids.end()) {
+            m_running_kernels[m_last_issued_kernel]->start_cycle = gpu_sim_cycle + gpu_tot_sim_cycle;
+            m_executed_kernel_uids.push_back(launch_uid); 
+            m_executed_kernel_names.push_back(m_running_kernels[m_last_issued_kernel]->name()); 
+        }
+        return m_running_kernels[m_last_issued_kernel];
     }
-    return m_running_kernels[m_last_issued_kernel];
-  }
 
-  for (unsigned n = 0; n < m_running_kernels.size(); n++) {
-    unsigned idx =
-        (n + m_last_issued_kernel + 1) % m_config.max_concurrent_kernel;
-    if (kernel_more_cta_left(m_running_kernels[idx])) {
-      m_last_issued_kernel = idx;
-      m_running_kernels[idx]->start_cycle = gpu_sim_cycle + gpu_tot_sim_cycle;
-      // record this kernel for stat print if it is the first time this kernel
-      // is selected for execution
-      unsigned launch_uid = m_running_kernels[idx]->get_uid();
-      assert(std::find(m_executed_kernel_uids.begin(),
-                       m_executed_kernel_uids.end(),
-                       launch_uid) == m_executed_kernel_uids.end());
-      m_executed_kernel_uids.push_back(launch_uid);
-      m_executed_kernel_names.push_back(m_running_kernels[idx]->name());
+    for(unsigned n=0; n < m_running_kernels.size(); n++ ) {
+        unsigned idx = (n+m_last_issued_kernel+1)%m_config.max_concurrent_kernel;
+        if( kernel_more_cta_left(m_running_kernels[idx]) ){
+            m_last_issued_kernel=idx;
+            m_running_kernels[idx]->start_cycle = gpu_sim_cycle + gpu_tot_sim_cycle;
+            // record this kernel for stat print if it is the first time this kernel is selected for execution  
+            unsigned launch_uid = m_running_kernels[idx]->get_uid(); 
+            assert(std::find(m_executed_kernel_uids.begin(), m_executed_kernel_uids.end(), launch_uid) == m_executed_kernel_uids.end());
+            m_executed_kernel_uids.push_back(launch_uid); 
+            m_executed_kernel_names.push_back(m_running_kernels[idx]->name()); 
 
-      return m_running_kernels[idx];
+            return m_running_kernels[idx];
+        }
     }
-  }
-  return NULL;
+    return NULL;
 }
 
-unsigned gpgpu_sim::finished_kernel() {
-  if (m_finished_kernel.empty()) return 0;
-  unsigned result = m_finished_kernel.front();
-  m_finished_kernel.pop_front();
-  return result;
+unsigned gpgpu_sim::finished_kernel()
+{
+    if( m_finished_kernel.empty() ) 
+        return 0;
+    unsigned result = m_finished_kernel.front();
+    m_finished_kernel.pop_front();
+    return result;
 }
 
-void gpgpu_sim::set_kernel_done(kernel_info_t *kernel) {
-  unsigned uid = kernel->get_uid();
-  m_finished_kernel.push_back(uid);
-  std::vector<kernel_info_t *>::iterator k;
-  for (k = m_running_kernels.begin(); k != m_running_kernels.end(); k++) {
-    if (*k == kernel) {
-      kernel->end_cycle = gpu_sim_cycle + gpu_tot_sim_cycle;
-      *k = NULL;
-      break;
+void gpgpu_sim::set_kernel_done( kernel_info_t *kernel ) 
+{ 
+    unsigned uid = kernel->get_uid();
+    m_finished_kernel.push_back(uid);
+    std::vector<kernel_info_t*>::iterator k;
+    for( k=m_running_kernels.begin(); k!=m_running_kernels.end(); k++ ) {
+        if( *k == kernel ) {
+            kernel->end_cycle = gpu_sim_cycle + gpu_tot_sim_cycle;
+            *k = NULL;
+            break;
+        }
     }
-  }
-  assert(k != m_running_kernels.end());
+    assert( k != m_running_kernels.end() ); 
 }
 
-void gpgpu_sim::stop_all_running_kernels() {
-  std::vector<kernel_info_t *>::iterator k;
-  for (k = m_running_kernels.begin(); k != m_running_kernels.end(); ++k) {
-    if (*k != NULL) {       // If a kernel is active
-      set_kernel_done(*k);  // Stop the kernel
-      assert(*k == NULL);
+void gpgpu_sim::stop_all_running_kernels(){
+    std::vector<kernel_info_t *>::iterator k;
+    for(k = m_running_kernels.begin(); k != m_running_kernels.end(); ++k){
+        if(*k != NULL){ // If a kernel is active
+            set_kernel_done(*k); // Stop the kernel
+            assert(*k==NULL);
+        }
     }
-  }
 }
 
-gpgpu_sim::gpgpu_sim(const gpgpu_sim_config &config, gpgpu_context *ctx)
-    : gpgpu_t(config, ctx), m_config(config) {
-  gpgpu_ctx = ctx;
-  m_shader_config = &m_config.m_shader_config;
-  m_memory_config = &m_config.m_memory_config;
-  ctx->ptx_parser->set_ptx_warp_size(m_shader_config);
-  ptx_file_line_stats_create_exposed_latency_tracker(m_config.num_shader());
+gpgpu_sim::gpgpu_sim( const gpgpu_sim_config &config, gpgpu_context* ctx )
+    : gpgpu_t(config, ctx), m_config(config)
+{
+    gpgpu_ctx = ctx;
+    m_shader_config = &m_config.m_shader_config;
+    m_memory_config = &m_config.m_memory_config;
+    ctx->ptx_parser->set_ptx_warp_size(m_shader_config);
+    ptx_file_line_stats_create_exposed_latency_tracker(m_config.num_shader());
 
 #ifdef GPGPUSIM_POWER_MODEL
-  m_gpgpusim_wrapper = new gpgpu_sim_wrapper(config.g_power_simulation_enabled,
-                                             config.g_power_config_name);
+        m_gpgpusim_wrapper = new gpgpu_sim_wrapper(config.g_power_simulation_enabled,config.g_power_config_name);
 #endif
 
-  m_shader_stats = new shader_core_stats(m_shader_config);
-  m_memory_stats = new memory_stats_t(m_config.num_shader(), m_shader_config,
-                                      m_memory_config, this);
-  average_pipeline_duty_cycle = (float *)malloc(sizeof(float));
-  active_sms = (float *)malloc(sizeof(float));
-  m_power_stats =
-      new power_stat_t(m_shader_config, average_pipeline_duty_cycle, active_sms,
-                       m_shader_stats, m_memory_config, m_memory_stats);
+    m_shader_stats = new shader_core_stats(m_shader_config);
+    m_memory_stats = new memory_stats_t(m_config.num_shader(),m_shader_config,m_memory_config,this);
+    average_pipeline_duty_cycle = (float *)malloc(sizeof(float));
+    active_sms=(float *)malloc(sizeof(float));
+    m_power_stats = new power_stat_t(m_shader_config,average_pipeline_duty_cycle,active_sms,m_shader_stats,m_memory_config,m_memory_stats);
 
-  gpu_sim_insn = 0;
-  gpu_tot_sim_insn = 0;
-  gpu_tot_issued_cta = 0;
-  m_total_cta_launched = 0;
-  gpu_deadlock = false;
+    gpu_sim_insn = 0;
+    gpu_tot_sim_insn = 0;
+    gpu_tot_issued_cta = 0;
+    m_total_cta_launched = 0;
+    gpu_deadlock = false;
 
-  gpu_stall_dramfull = 0;
-  gpu_stall_icnt2sh = 0;
-  partiton_reqs_in_parallel = 0;
-  partiton_reqs_in_parallel_total = 0;
-  partiton_reqs_in_parallel_util = 0;
-  partiton_reqs_in_parallel_util_total = 0;
-  gpu_sim_cycle_parition_util = 0;
-  gpu_tot_sim_cycle_parition_util = 0;
-  partiton_replys_in_parallel = 0;
-  partiton_replys_in_parallel_total = 0;
+    gpu_stall_dramfull = 0;
+    gpu_stall_icnt2sh = 0;
+    partiton_reqs_in_parallel = 0;
+    partiton_reqs_in_parallel_total = 0;
+    partiton_reqs_in_parallel_util = 0;
+    partiton_reqs_in_parallel_util_total = 0;
+    gpu_sim_cycle_parition_util = 0;
+    gpu_tot_sim_cycle_parition_util = 0;
+    partiton_replys_in_parallel = 0;
+    partiton_replys_in_parallel_total = 0;
 
-  m_cluster = new simt_core_cluster *[m_shader_config->n_simt_clusters];
-  for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++)
-    m_cluster[i] =
-        new simt_core_cluster(this, i, m_shader_config, m_memory_config,
-                              m_shader_stats, m_memory_stats);
+    m_cluster = new simt_core_cluster*[m_shader_config->n_simt_clusters];
+    for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) 
+        m_cluster[i] = new simt_core_cluster(this,i,m_shader_config,m_memory_config,m_shader_stats,m_memory_stats);
 
-  m_memory_partition_unit =
-      new memory_partition_unit *[m_memory_config->m_n_mem];
-  m_memory_sub_partition =
-      new memory_sub_partition *[m_memory_config->m_n_mem_sub_partition];
-  for (unsigned i = 0; i < m_memory_config->m_n_mem; i++) {
-    m_memory_partition_unit[i] =
-        new memory_partition_unit(i, m_memory_config, m_memory_stats, this);
-    for (unsigned p = 0;
-         p < m_memory_config->m_n_sub_partition_per_memory_channel; p++) {
-      unsigned submpid =
-          i * m_memory_config->m_n_sub_partition_per_memory_channel + p;
-      m_memory_sub_partition[submpid] =
-          m_memory_partition_unit[i]->get_sub_partition(p);
+    m_memory_partition_unit = new memory_partition_unit*[m_memory_config->m_n_mem];
+    m_memory_sub_partition = new memory_sub_partition*[m_memory_config->m_n_mem_sub_partition];
+    for (unsigned i=0;i<m_memory_config->m_n_mem;i++) {
+        m_memory_partition_unit[i] = new memory_partition_unit(i, m_memory_config, m_memory_stats, this);
+        for (unsigned p = 0; p < m_memory_config->m_n_sub_partition_per_memory_channel; p++) {
+            unsigned submpid = i * m_memory_config->m_n_sub_partition_per_memory_channel + p; 
+            m_memory_sub_partition[submpid] = m_memory_partition_unit[i]->get_sub_partition(p); 
+        }
     }
-  }
 
-  icnt_wrapper_init();
-  icnt_create(m_shader_config->n_simt_clusters,
-              m_memory_config->m_n_mem_sub_partition);
+    icnt_wrapper_init();
+    icnt_create(m_shader_config->n_simt_clusters,m_memory_config->m_n_mem_sub_partition);
 
-  time_vector_create(NUM_MEM_REQ_STAT);
-  fprintf(stdout,
-          "GPGPU-Sim uArch: performance model initialization complete.\n");
+    time_vector_create(NUM_MEM_REQ_STAT);
+    fprintf(stdout, "GPGPU-Sim uArch: performance model initialization complete.\n");
 
-  m_running_kernels.resize(config.max_concurrent_kernel, NULL);
-  m_last_issued_kernel = 0;
-  m_last_cluster_issue = m_shader_config->n_simt_clusters -
-                         1;  // this causes first launch to use simt cluster 0
-  *average_pipeline_duty_cycle = 0;
-  *active_sms = 0;
+    m_running_kernels.resize( config.max_concurrent_kernel, NULL );
+    m_last_issued_kernel = 0;
+    m_last_cluster_issue = m_shader_config->n_simt_clusters-1; // this causes first launch to use simt cluster 0
+    *average_pipeline_duty_cycle=0;
+    *active_sms=0;
 
-  last_liveness_message_time = 0;
-
-  // Jin: functional simulation for CDP
-  m_functional_sim = false;
-  m_functional_sim_kernel = NULL;
+    last_liveness_message_time = 0;
+   
+   //Jin: functional simulation for CDP
+   m_functional_sim = false;
+   m_functional_sim_kernel = NULL;
 }
 
-int gpgpu_sim::shared_mem_size() const {
-  return m_shader_config->gpgpu_shmem_size;
+int gpgpu_sim::shared_mem_size() const
+{
+   return m_shader_config->gpgpu_shmem_size;
 }
 
-int gpgpu_sim::shared_mem_per_block() const {
-  return m_shader_config->gpgpu_shmem_per_block;
+int gpgpu_sim::shared_mem_per_block() const
+{
+   return m_shader_config->gpgpu_shmem_per_block;
 }
 
-int gpgpu_sim::num_registers_per_core() const {
-  return m_shader_config->gpgpu_shader_registers;
+int gpgpu_sim::num_registers_per_core() const
+{
+   return m_shader_config->gpgpu_shader_registers;
 }
 
-int gpgpu_sim::num_registers_per_block() const {
-  return m_shader_config->gpgpu_registers_per_block;
+int gpgpu_sim::num_registers_per_block() const
+{
+   return m_shader_config->gpgpu_registers_per_block;
 }
 
-int gpgpu_sim::wrp_size() const { return m_shader_config->warp_size; }
-
-int gpgpu_sim::shader_clock() const { return m_config.core_freq / 1000; }
-
-int gpgpu_sim::max_cta_per_core() const {
-  return m_shader_config->max_cta_per_core;
+int gpgpu_sim::wrp_size() const
+{
+   return m_shader_config->warp_size;
 }
 
-int gpgpu_sim::get_max_cta(const kernel_info_t &k) const {
-  return m_shader_config->max_cta(k);
+int gpgpu_sim::shader_clock() const
+{
+   return m_config.core_freq/1000;
 }
 
-void gpgpu_sim::set_prop(cudaDeviceProp *prop) { m_cuda_properties = prop; }
-
-int gpgpu_sim::compute_capability_major() const {
-  return m_config.gpgpu_compute_capability_major;
+int gpgpu_sim::max_cta_per_core() const
+{
+   return m_shader_config->max_cta_per_core;
 }
 
-int gpgpu_sim::compute_capability_minor() const {
-  return m_config.gpgpu_compute_capability_minor;
+int gpgpu_sim::get_max_cta( const kernel_info_t &k ) const
+{
+   return m_shader_config->max_cta(k);
 }
 
-const struct cudaDeviceProp *gpgpu_sim::get_prop() const {
-  return m_cuda_properties;
+void gpgpu_sim::set_prop( cudaDeviceProp *prop )
+{
+   m_cuda_properties = prop;
 }
 
-enum divergence_support_t gpgpu_sim::simd_model() const {
-  return m_shader_config->model;
+int gpgpu_sim::compute_capability_major() const
+{
+   return m_config.gpgpu_compute_capability_major;
 }
 
-void gpgpu_sim_config::init_clock_domains(void) {
-  sscanf(gpgpu_clock_domains, "%lf:%lf:%lf:%lf", &core_freq, &icnt_freq,
-         &l2_freq, &dram_freq);
-  core_freq = core_freq MhZ;
-  icnt_freq = icnt_freq MhZ;
-  l2_freq = l2_freq MhZ;
-  dram_freq = dram_freq MhZ;
-  core_period = 1 / core_freq;
-  icnt_period = 1 / icnt_freq;
-  dram_period = 1 / dram_freq;
-  l2_period = 1 / l2_freq;
-  printf("GPGPU-Sim uArch: clock freqs: %lf:%lf:%lf:%lf\n", core_freq,
-         icnt_freq, l2_freq, dram_freq);
-  printf("GPGPU-Sim uArch: clock periods: %.20lf:%.20lf:%.20lf:%.20lf\n",
-         core_period, icnt_period, l2_period, dram_period);
+int gpgpu_sim::compute_capability_minor() const
+{
+   return m_config.gpgpu_compute_capability_minor;
 }
 
-void gpgpu_sim::reinit_clock_domains(void) {
-  core_time = 0;
-  dram_time = 0;
-  icnt_time = 0;
-  l2_time = 0;
+const struct cudaDeviceProp *gpgpu_sim::get_prop() const
+{
+   return m_cuda_properties;
 }
 
-bool gpgpu_sim::active() {
-  if (m_config.gpu_max_cycle_opt &&
-      (gpu_tot_sim_cycle + gpu_sim_cycle) >= m_config.gpu_max_cycle_opt)
+enum divergence_support_t gpgpu_sim::simd_model() const
+{
+   return m_shader_config->model;
+}
+
+void gpgpu_sim_config::init_clock_domains(void ) 
+{
+   sscanf(gpgpu_clock_domains,"%lf:%lf:%lf:%lf", 
+          &core_freq, &icnt_freq, &l2_freq, &dram_freq);
+   core_freq = core_freq MhZ;
+   icnt_freq = icnt_freq MhZ;
+   l2_freq = l2_freq MhZ;
+   dram_freq = dram_freq MhZ;        
+   core_period = 1/core_freq;
+   icnt_period = 1/icnt_freq;
+   dram_period = 1/dram_freq;
+   l2_period = 1/l2_freq;
+   printf("GPGPU-Sim uArch: clock freqs: %lf:%lf:%lf:%lf\n",core_freq,icnt_freq,l2_freq,dram_freq);
+   printf("GPGPU-Sim uArch: clock periods: %.20lf:%.20lf:%.20lf:%.20lf\n",core_period,icnt_period,l2_period,dram_period);
+}
+
+void gpgpu_sim::reinit_clock_domains(void)
+{
+   core_time = 0;
+   dram_time = 0;
+   icnt_time = 0;
+   l2_time = 0;
+}
+
+bool gpgpu_sim::active()
+{
+    if (m_config.gpu_max_cycle_opt && (gpu_tot_sim_cycle + gpu_sim_cycle) >= m_config.gpu_max_cycle_opt) 
+       return false;
+    if (m_config.gpu_max_insn_opt && (gpu_tot_sim_insn + gpu_sim_insn) >= m_config.gpu_max_insn_opt) 
+       return false;
+    if (m_config.gpu_max_cta_opt && (gpu_tot_issued_cta >= m_config.gpu_max_cta_opt) )
+       return false;
+    if (m_config.gpu_deadlock_detect && gpu_deadlock) 
+       return false;
+    for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) 
+       if( m_cluster[i]->get_not_completed()>0 ) 
+           return true;;
+    for (unsigned i=0;i<m_memory_config->m_n_mem;i++) 
+       if( m_memory_partition_unit[i]->busy()>0 )
+           return true;;
+    if( icnt_busy() )
+        return true;
+    if( get_more_cta_left() )
+        return true;
     return false;
-  if (m_config.gpu_max_insn_opt &&
-      (gpu_tot_sim_insn + gpu_sim_insn) >= m_config.gpu_max_insn_opt)
-    return false;
-  if (m_config.gpu_max_cta_opt &&
-      (gpu_tot_issued_cta >= m_config.gpu_max_cta_opt))
-    return false;
-  if (m_config.gpu_deadlock_detect && gpu_deadlock) return false;
-  for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++)
-    if (m_cluster[i]->get_not_completed() > 0) return true;
-  ;
-  for (unsigned i = 0; i < m_memory_config->m_n_mem; i++)
-    if (m_memory_partition_unit[i]->busy() > 0) return true;
-  ;
-  if (icnt_busy()) return true;
-  if (get_more_cta_left()) return true;
-  return false;
 }
 
-void gpgpu_sim::init() {
-  // run a CUDA grid on the GPU microarchitecture simulator
-  gpu_sim_cycle = 0;
-  gpu_sim_insn = 0;
-  last_gpu_sim_insn = 0;
-  m_total_cta_launched = 0;
-  partiton_reqs_in_parallel = 0;
-  partiton_replys_in_parallel = 0;
-  partiton_reqs_in_parallel_util = 0;
-  gpu_sim_cycle_parition_util = 0;
+void gpgpu_sim::init()
+{
+    // run a CUDA grid on the GPU microarchitecture simulator
+    gpu_sim_cycle = 0;
+    gpu_sim_insn = 0;
+    last_gpu_sim_insn = 0;
+    m_total_cta_launched=0;
+    partiton_reqs_in_parallel = 0;
+    partiton_replys_in_parallel = 0;
+    partiton_reqs_in_parallel_util = 0;
+    gpu_sim_cycle_parition_util = 0;
 
-  reinit_clock_domains();
-  gpgpu_ctx->func_sim->set_param_gpgpu_num_shaders(m_config.num_shader());
-  for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++)
-    m_cluster[i]->reinit();
-  m_shader_stats->new_grid();
-  // initialize the control-flow, memory access, memory latency logger
-  if (m_config.g_visualizer_enabled) {
-    create_thread_CFlogger(gpgpu_ctx, m_config.num_shader(),
-                           m_shader_config->n_thread_per_shader, 0,
-                           m_config.gpgpu_cflog_interval);
-  }
-  shader_CTA_count_create(m_config.num_shader(), m_config.gpgpu_cflog_interval);
-  if (m_config.gpgpu_cflog_interval != 0) {
-    insn_warp_occ_create(m_config.num_shader(), m_shader_config->warp_size);
-    shader_warp_occ_create(m_config.num_shader(), m_shader_config->warp_size,
-                           m_config.gpgpu_cflog_interval);
-    shader_mem_acc_create(m_config.num_shader(), m_memory_config->m_n_mem, 4,
-                          m_config.gpgpu_cflog_interval);
-    shader_mem_lat_create(m_config.num_shader(), m_config.gpgpu_cflog_interval);
-    shader_cache_access_create(m_config.num_shader(), 3,
-                               m_config.gpgpu_cflog_interval);
-    set_spill_interval(m_config.gpgpu_cflog_interval * 40);
-  }
+    reinit_clock_domains();
+    gpgpu_ctx->func_sim->set_param_gpgpu_num_shaders(m_config.num_shader());
+    for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) 
+       m_cluster[i]->reinit();
+    m_shader_stats->new_grid();
+    // initialize the control-flow, memory access, memory latency logger
+    if (m_config.g_visualizer_enabled) {
+        create_thread_CFlogger( gpgpu_ctx, m_config.num_shader(), m_shader_config->n_thread_per_shader, 0, m_config.gpgpu_cflog_interval );
+    }
+    shader_CTA_count_create( m_config.num_shader(), m_config.gpgpu_cflog_interval);
+    if (m_config.gpgpu_cflog_interval != 0) {
+       insn_warp_occ_create( m_config.num_shader(), m_shader_config->warp_size );
+       shader_warp_occ_create( m_config.num_shader(), m_shader_config->warp_size, m_config.gpgpu_cflog_interval);
+       shader_mem_acc_create( m_config.num_shader(), m_memory_config->m_n_mem, 4, m_config.gpgpu_cflog_interval);
+       shader_mem_lat_create( m_config.num_shader(), m_config.gpgpu_cflog_interval);
+       shader_cache_access_create( m_config.num_shader(), 3, m_config.gpgpu_cflog_interval);
+       set_spill_interval (m_config.gpgpu_cflog_interval * 40);
+    }
 
-  if (g_network_mode) icnt_init();
+    if (g_network_mode)
+       icnt_init();
 
-// McPAT initialization function. Called on first launch of GPU
+    // McPAT initialization function. Called on first launch of GPU
 #ifdef GPGPUSIM_POWER_MODEL
-  if (m_config.g_power_simulation_enabled) {
-    init_mcpat(m_config, m_gpgpusim_wrapper, m_config.gpu_stat_sample_freq,
-               gpu_tot_sim_insn, gpu_sim_insn);
-  }
+    if(m_config.g_power_simulation_enabled){
+        init_mcpat(m_config, m_gpgpusim_wrapper, m_config.gpu_stat_sample_freq,  gpu_tot_sim_insn, gpu_sim_insn);
+    }
 #endif
 }
 
 void gpgpu_sim::update_stats() {
-  m_memory_stats->memlatstat_lat_pw();
-  gpu_tot_sim_cycle += gpu_sim_cycle;
-  gpu_tot_sim_insn += gpu_sim_insn;
-  gpu_tot_issued_cta += m_total_cta_launched;
-  partiton_reqs_in_parallel_total += partiton_reqs_in_parallel;
-  partiton_replys_in_parallel_total += partiton_replys_in_parallel;
-  partiton_reqs_in_parallel_util_total += partiton_reqs_in_parallel_util;
-  gpu_tot_sim_cycle_parition_util += gpu_sim_cycle_parition_util;
-  gpu_tot_occupancy += gpu_occupancy;
+    m_memory_stats->memlatstat_lat_pw();
+    gpu_tot_sim_cycle += gpu_sim_cycle;
+    gpu_tot_sim_insn += gpu_sim_insn;
+    gpu_tot_issued_cta += m_total_cta_launched;
+    partiton_reqs_in_parallel_total += partiton_reqs_in_parallel;
+    partiton_replys_in_parallel_total += partiton_replys_in_parallel;
+    partiton_reqs_in_parallel_util_total += partiton_reqs_in_parallel_util;
+    gpu_tot_sim_cycle_parition_util += gpu_sim_cycle_parition_util ;
+    gpu_tot_occupancy += gpu_occupancy;
 
-  gpu_sim_cycle = 0;
-  partiton_reqs_in_parallel = 0;
-  partiton_replys_in_parallel = 0;
-  partiton_reqs_in_parallel_util = 0;
-  gpu_sim_cycle_parition_util = 0;
-  gpu_sim_insn = 0;
-  m_total_cta_launched = 0;
-  gpu_occupancy = occupancy_stats();
+    gpu_sim_cycle = 0;
+    partiton_reqs_in_parallel = 0;
+    partiton_replys_in_parallel = 0;
+    partiton_reqs_in_parallel_util = 0;
+    gpu_sim_cycle_parition_util = 0;
+    gpu_sim_insn = 0;
+    m_total_cta_launched = 0;
+    gpu_occupancy = occupancy_stats();
 }
 
-void gpgpu_sim::print_stats() {
-  gpgpu_ctx->stats->ptx_file_line_stats_write_file();
-  gpu_print_stat();
+void gpgpu_sim::print_stats()
+{
+    gpgpu_ctx->stats->ptx_file_line_stats_write_file();
+    gpu_print_stat();
 
-  if (g_network_mode) {
-    printf(
-        "----------------------------Interconnect-DETAILS----------------------"
-        "----------\n");
-    icnt_display_stats();
-    icnt_display_overall_stats();
-    printf(
-        "----------------------------END-of-Interconnect-DETAILS---------------"
-        "----------\n");
-  }
+    if (g_network_mode) {
+        printf("----------------------------Interconnect-DETAILS--------------------------------\n" );
+        icnt_display_stats();
+        icnt_display_overall_stats();
+        printf("----------------------------END-of-Interconnect-DETAILS-------------------------\n" );
+    }
 }
 
-void gpgpu_sim::deadlock_check() {
-  if (m_config.gpu_deadlock_detect && gpu_deadlock) {
-    fflush(stdout);
-    printf(
-        "\n\nGPGPU-Sim uArch: ERROR ** deadlock detected: last writeback core "
-        "%u @ gpu_sim_cycle %u (+ gpu_tot_sim_cycle %u) (%u cycles ago)\n",
-        gpu_sim_insn_last_update_sid, (unsigned)gpu_sim_insn_last_update,
-        (unsigned)(gpu_tot_sim_cycle - gpu_sim_cycle),
-        (unsigned)(gpu_sim_cycle - gpu_sim_insn_last_update));
-    unsigned num_cores = 0;
-    for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++) {
-      unsigned not_completed = m_cluster[i]->get_not_completed();
-      if (not_completed) {
-        if (!num_cores) {
-          printf(
-              "GPGPU-Sim uArch: DEADLOCK  shader cores no longer committing "
-              "instructions [core(# threads)]:\n");
-          printf("GPGPU-Sim uArch: DEADLOCK  ");
-          m_cluster[i]->print_not_completed(stdout);
-        } else if (num_cores < 8) {
-          m_cluster[i]->print_not_completed(stdout);
-        } else if (num_cores >= 8) {
-          printf(" + others ... ");
-        }
-        num_cores += m_shader_config->n_simt_cores_per_cluster;
+void gpgpu_sim::deadlock_check()
+{
+   if (m_config.gpu_deadlock_detect && gpu_deadlock) {
+      fflush(stdout);
+      printf("\n\nGPGPU-Sim uArch: ERROR ** deadlock detected: last writeback core %u @ gpu_sim_cycle %u (+ gpu_tot_sim_cycle %u) (%u cycles ago)\n", 
+             gpu_sim_insn_last_update_sid,
+             (unsigned) gpu_sim_insn_last_update, (unsigned) (gpu_tot_sim_cycle-gpu_sim_cycle),
+             (unsigned) (gpu_sim_cycle - gpu_sim_insn_last_update )); 
+      unsigned num_cores=0;
+      for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) {
+         unsigned not_completed = m_cluster[i]->get_not_completed();
+         if( not_completed ) {
+             if ( !num_cores )  {
+                 printf("GPGPU-Sim uArch: DEADLOCK  shader cores no longer committing instructions [core(# threads)]:\n" );
+                 printf("GPGPU-Sim uArch: DEADLOCK  ");
+                 m_cluster[i]->print_not_completed(stdout);
+             } else if (num_cores < 8 ) {
+                 m_cluster[i]->print_not_completed(stdout);
+             } else if (num_cores >= 8 ) {
+                 printf(" + others ... ");
+             }
+             num_cores+=m_shader_config->n_simt_cores_per_cluster;
+         }
       }
-    }
-    printf("\n");
-    for (unsigned i = 0; i < m_memory_config->m_n_mem; i++) {
-      bool busy = m_memory_partition_unit[i]->busy();
-      if (busy)
-        printf("GPGPU-Sim uArch DEADLOCK:  memory partition %u busy\n", i);
-    }
-    if (icnt_busy()) {
-      printf("GPGPU-Sim uArch DEADLOCK:  iterconnect contains traffic\n");
-      icnt_display_state(stdout);
-    }
-    printf(
-        "\nRe-run the simulator in gdb and use debug routines in .gdbinit to "
-        "debug this\n");
-    fflush(stdout);
-    abort();
-  }
-}
-
-/// printing the names and uids of a set of executed kernels (usually there is
-/// only one)
-std::string gpgpu_sim::executed_kernel_info_string() {
-  std::stringstream statout;
-
-  statout << "kernel_name = ";
-  for (unsigned int k = 0; k < m_executed_kernel_names.size(); k++) {
-    statout << m_executed_kernel_names[k] << " ";
-  }
-  statout << std::endl;
-  statout << "kernel_launch_uid = ";
-  for (unsigned int k = 0; k < m_executed_kernel_uids.size(); k++) {
-    statout << m_executed_kernel_uids[k] << " ";
-  }
-  statout << std::endl;
-
-  return statout.str();
-}
-void gpgpu_sim::set_cache_config(std::string kernel_name,
-                                 FuncCache cacheConfig) {
-  m_special_cache_config[kernel_name] = cacheConfig;
-}
-
-FuncCache gpgpu_sim::get_cache_config(std::string kernel_name) {
-  for (std::map<std::string, FuncCache>::iterator iter =
-           m_special_cache_config.begin();
-       iter != m_special_cache_config.end(); iter++) {
-    std::string kernel = iter->first;
-    if (kernel_name.compare(kernel) == 0) {
-      return iter->second;
-    }
-  }
-  return (FuncCache)0;
-}
-
-bool gpgpu_sim::has_special_cache_config(std::string kernel_name) {
-  for (std::map<std::string, FuncCache>::iterator iter =
-           m_special_cache_config.begin();
-       iter != m_special_cache_config.end(); iter++) {
-    std::string kernel = iter->first;
-    if (kernel_name.compare(kernel) == 0) {
-      return true;
-    }
-  }
-  return false;
-}
-
-void gpgpu_sim::set_cache_config(std::string kernel_name) {
-  if (has_special_cache_config(kernel_name)) {
-    change_cache_config(get_cache_config(kernel_name));
-  } else {
-    change_cache_config(FuncCachePreferNone);
-  }
-}
-
-void gpgpu_sim::change_cache_config(FuncCache cache_config) {
-  if (cache_config != m_shader_config->m_L1D_config.get_cache_status()) {
-    printf("FLUSH L1 Cache at configuration change between kernels\n");
-    for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++) {
-      m_cluster[i]->cache_invalidate();
-    }
-  }
-
-  switch (cache_config) {
-    case FuncCachePreferNone:
-      m_shader_config->m_L1D_config.init(
-          m_shader_config->m_L1D_config.m_config_string, FuncCachePreferNone);
-      m_shader_config->gpgpu_shmem_size =
-          m_shader_config->gpgpu_shmem_sizeDefault;
-      break;
-    case FuncCachePreferL1:
-      if ((m_shader_config->m_L1D_config.m_config_stringPrefL1 == NULL) ||
-          (m_shader_config->gpgpu_shmem_sizePrefL1 == (unsigned)-1)) {
-        printf("WARNING: missing Preferred L1 configuration\n");
-        m_shader_config->m_L1D_config.init(
-            m_shader_config->m_L1D_config.m_config_string, FuncCachePreferNone);
-        m_shader_config->gpgpu_shmem_size =
-            m_shader_config->gpgpu_shmem_sizeDefault;
-
-      } else {
-        m_shader_config->m_L1D_config.init(
-            m_shader_config->m_L1D_config.m_config_stringPrefL1,
-            FuncCachePreferL1);
-        m_shader_config->gpgpu_shmem_size =
-            m_shader_config->gpgpu_shmem_sizePrefL1;
+      printf("\n");
+      for (unsigned i=0;i<m_memory_config->m_n_mem;i++) {
+         bool busy = m_memory_partition_unit[i]->busy();
+         if( busy ) 
+             printf("GPGPU-Sim uArch DEADLOCK:  memory partition %u busy\n", i );
       }
-      break;
-    case FuncCachePreferShared:
-      if ((m_shader_config->m_L1D_config.m_config_stringPrefShared == NULL) ||
-          (m_shader_config->gpgpu_shmem_sizePrefShared == (unsigned)-1)) {
-        printf("WARNING: missing Preferred L1 configuration\n");
-        m_shader_config->m_L1D_config.init(
-            m_shader_config->m_L1D_config.m_config_string, FuncCachePreferNone);
-        m_shader_config->gpgpu_shmem_size =
-            m_shader_config->gpgpu_shmem_sizeDefault;
-      } else {
-        m_shader_config->m_L1D_config.init(
-            m_shader_config->m_L1D_config.m_config_stringPrefShared,
-            FuncCachePreferShared);
-        m_shader_config->gpgpu_shmem_size =
-            m_shader_config->gpgpu_shmem_sizePrefShared;
+      if( icnt_busy() ) {
+         printf("GPGPU-Sim uArch DEADLOCK:  iterconnect contains traffic\n");
+         icnt_display_state( stdout );
       }
-      break;
-    default:
-      break;
-  }
+      printf("\nRe-run the simulator in gdb and use debug routines in .gdbinit to debug this\n");
+      fflush(stdout);
+      abort();
+   }
 }
 
-void gpgpu_sim::clear_executed_kernel_info() {
-  m_executed_kernel_names.clear();
-  m_executed_kernel_uids.clear();
+/// printing the names and uids of a set of executed kernels (usually there is only one)
+std::string gpgpu_sim::executed_kernel_info_string() 
+{
+   std::stringstream statout; 
+
+   statout << "kernel_name = "; 
+   for (unsigned int k = 0; k < m_executed_kernel_names.size(); k++) {
+      statout << m_executed_kernel_names[k] << " "; 
+   }
+   statout << std::endl; 
+   statout << "kernel_launch_uid = ";
+   for (unsigned int k = 0; k < m_executed_kernel_uids.size(); k++) {
+      statout << m_executed_kernel_uids[k] << " "; 
+   }
+   statout << std::endl; 
+
+   return statout.str(); 
 }
-void gpgpu_sim::gpu_print_stat() {
-  FILE *statfout = stdout;
+void gpgpu_sim::set_cache_config(std::string kernel_name,  FuncCache cacheConfig )
+{
+	m_special_cache_config[kernel_name]=cacheConfig ;
+}
 
-  std::string kernel_info_str = executed_kernel_info_string();
-  fprintf(statfout, "%s", kernel_info_str.c_str());
+FuncCache gpgpu_sim::get_cache_config(std::string kernel_name)
+{
+	for (	std::map<std::string, FuncCache>::iterator iter = m_special_cache_config.begin(); iter != m_special_cache_config.end(); iter++){
+		    std::string kernel= iter->first;
+			if (kernel_name.compare(kernel) == 0){
+				return iter->second;
+			}
+	}
+	return (FuncCache)0;
+}
 
-  printf("gpu_sim_cycle = %lld\n", gpu_sim_cycle);
-  printf("gpu_sim_insn = %lld\n", gpu_sim_insn);
-  printf("gpu_ipc = %12.4f\n", (float)gpu_sim_insn / gpu_sim_cycle);
-  printf("gpu_tot_sim_cycle = %lld\n", gpu_tot_sim_cycle + gpu_sim_cycle);
-  printf("gpu_tot_sim_insn = %lld\n", gpu_tot_sim_insn + gpu_sim_insn);
-  printf("gpu_tot_ipc = %12.4f\n", (float)(gpu_tot_sim_insn + gpu_sim_insn) /
-                                       (gpu_tot_sim_cycle + gpu_sim_cycle));
-  printf("gpu_tot_issued_cta = %lld\n",
-         gpu_tot_issued_cta + m_total_cta_launched);
-  printf("gpu_occupancy = %.4f%% \n", gpu_occupancy.get_occ_fraction() * 100);
-  printf("gpu_tot_occupancy = %.4f%% \n",
-         (gpu_occupancy + gpu_tot_occupancy).get_occ_fraction() * 100);
+bool gpgpu_sim::has_special_cache_config(std::string kernel_name)
+{
+	for (	std::map<std::string, FuncCache>::iterator iter = m_special_cache_config.begin(); iter != m_special_cache_config.end(); iter++){
+	    	std::string kernel= iter->first;
+			if (kernel_name.compare(kernel) == 0){
+				return true;
+			}
+	}
+	return false;
+}
 
-  fprintf(statfout, "max_total_param_size = %llu\n",
-          gpgpu_ctx->device_runtime->g_max_total_param_size);
 
-  // performance counter for stalls due to congestion.
-  printf("gpu_stall_dramfull = %d\n", gpu_stall_dramfull);
-  printf("gpu_stall_icnt2sh    = %d\n", gpu_stall_icnt2sh);
+void gpgpu_sim::set_cache_config(std::string kernel_name)
+{
+	if(has_special_cache_config(kernel_name)){
+		change_cache_config(get_cache_config(kernel_name));
+	}else{
+		change_cache_config(FuncCachePreferNone);
+	}
+}
 
-  // printf("partiton_reqs_in_parallel = %lld\n", partiton_reqs_in_parallel);
-  // printf("partiton_reqs_in_parallel_total    = %lld\n",
-  // partiton_reqs_in_parallel_total );
-  printf("partiton_level_parallism = %12.4f\n",
-         (float)partiton_reqs_in_parallel / gpu_sim_cycle);
-  printf("partiton_level_parallism_total  = %12.4f\n",
-         (float)(partiton_reqs_in_parallel + partiton_reqs_in_parallel_total) /
-             (gpu_tot_sim_cycle + gpu_sim_cycle));
-  // printf("partiton_reqs_in_parallel_util = %lld\n",
-  // partiton_reqs_in_parallel_util);
-  // printf("partiton_reqs_in_parallel_util_total    = %lld\n",
-  // partiton_reqs_in_parallel_util_total );
-  // printf("gpu_sim_cycle_parition_util = %lld\n",
-  // gpu_sim_cycle_parition_util);
-  // printf("gpu_tot_sim_cycle_parition_util    = %lld\n",
-  // gpu_tot_sim_cycle_parition_util );
-  printf("partiton_level_parallism_util = %12.4f\n",
-         (float)partiton_reqs_in_parallel_util / gpu_sim_cycle_parition_util);
-  printf("partiton_level_parallism_util_total  = %12.4f\n",
-         (float)(partiton_reqs_in_parallel_util +
-                 partiton_reqs_in_parallel_util_total) /
-             (gpu_sim_cycle_parition_util + gpu_tot_sim_cycle_parition_util));
-  // printf("partiton_replys_in_parallel = %lld\n",
-  // partiton_replys_in_parallel);
-  // printf("partiton_replys_in_parallel_total    = %lld\n",
-  // partiton_replys_in_parallel_total );
-  printf("L2_BW  = %12.4f GB/Sec\n",
-         ((float)(partiton_replys_in_parallel * 32) /
-          (gpu_sim_cycle * m_config.icnt_period)) /
-             1000000000);
-  printf("L2_BW_total  = %12.4f GB/Sec\n",
-         ((float)((partiton_replys_in_parallel +
-                   partiton_replys_in_parallel_total) *
-                  32) /
-          ((gpu_tot_sim_cycle + gpu_sim_cycle) * m_config.icnt_period)) /
-             1000000000);
 
-  time_t curr_time;
-  time(&curr_time);
-  unsigned long long elapsed_time =
-      MAX(curr_time - gpgpu_ctx->the_gpgpusim->g_simulation_starttime, 1);
-  printf("gpu_total_sim_rate=%u\n",
-         (unsigned)((gpu_tot_sim_insn + gpu_sim_insn) / elapsed_time));
+void gpgpu_sim::change_cache_config(FuncCache cache_config)
+{
+	if(cache_config != m_shader_config->m_L1D_config.get_cache_status()){
+		printf("FLUSH L1 Cache at configuration change between kernels\n");
+		for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) {
+			m_cluster[i]->cache_invalidate();
+	    }
+	}
 
-  // shader_print_l1_miss_stat( stdout );
-  shader_print_cache_stats(stdout);
+	switch(cache_config){
+	case FuncCachePreferNone:
+		m_shader_config->m_L1D_config.init(m_shader_config->m_L1D_config.m_config_string, FuncCachePreferNone);
+		m_shader_config->gpgpu_shmem_size=m_shader_config->gpgpu_shmem_sizeDefault;
+		break;
+	case FuncCachePreferL1:
+		if((m_shader_config->m_L1D_config.m_config_stringPrefL1 == NULL) || (m_shader_config->gpgpu_shmem_sizePrefL1 == (unsigned)-1))
+		{
+			printf("WARNING: missing Preferred L1 configuration\n");
+			m_shader_config->m_L1D_config.init(m_shader_config->m_L1D_config.m_config_string, FuncCachePreferNone);
+			m_shader_config->gpgpu_shmem_size=m_shader_config->gpgpu_shmem_sizeDefault;
 
-  cache_stats core_cache_stats;
-  core_cache_stats.clear();
-  for (unsigned i = 0; i < m_config.num_cluster(); i++) {
-    m_cluster[i]->get_cache_stats(core_cache_stats);
-  }
-  printf("\nTotal_core_cache_stats:\n");
-  core_cache_stats.print_stats(stdout, "Total_core_cache_stats_breakdown");
-  printf("\nTotal_core_cache_fail_stats:\n");
-  core_cache_stats.print_fail_stats(stdout,
-                                    "Total_core_cache_fail_stats_breakdown");
-  shader_print_scheduler_stat(stdout, false);
+		}else{
+			m_shader_config->m_L1D_config.init(m_shader_config->m_L1D_config.m_config_stringPrefL1, FuncCachePreferL1);
+			m_shader_config->gpgpu_shmem_size=m_shader_config->gpgpu_shmem_sizePrefL1;
+		}
+		break;
+	case FuncCachePreferShared:
+		if((m_shader_config->m_L1D_config.m_config_stringPrefShared == NULL) || (m_shader_config->gpgpu_shmem_sizePrefShared == (unsigned)-1))
+		{
+			printf("WARNING: missing Preferred L1 configuration\n");
+			m_shader_config->m_L1D_config.init(m_shader_config->m_L1D_config.m_config_string, FuncCachePreferNone);
+			m_shader_config->gpgpu_shmem_size=m_shader_config->gpgpu_shmem_sizeDefault;
+		}else{
+			m_shader_config->m_L1D_config.init(m_shader_config->m_L1D_config.m_config_stringPrefShared, FuncCachePreferShared);
+			m_shader_config->gpgpu_shmem_size=m_shader_config->gpgpu_shmem_sizePrefShared;
+		}
+		break;
+	default:
+		break;
+	}
+}
 
-  m_shader_stats->print(stdout);
+
+void gpgpu_sim::clear_executed_kernel_info()
+{
+   m_executed_kernel_names.clear();
+   m_executed_kernel_uids.clear();
+}
+void gpgpu_sim::gpu_print_stat() 
+{  
+   FILE *statfout = stdout; 
+
+   std::string kernel_info_str = executed_kernel_info_string(); 
+   fprintf(statfout, "%s", kernel_info_str.c_str()); 
+
+   printf("gpu_sim_cycle = %lld\n", gpu_sim_cycle);
+   printf("gpu_sim_insn = %lld\n", gpu_sim_insn);
+   printf("gpu_ipc = %12.4f\n", (float)gpu_sim_insn / gpu_sim_cycle);
+   printf("gpu_tot_sim_cycle = %lld\n", gpu_tot_sim_cycle+gpu_sim_cycle);
+   printf("gpu_tot_sim_insn = %lld\n", gpu_tot_sim_insn+gpu_sim_insn);
+   printf("gpu_tot_ipc = %12.4f\n", (float)(gpu_tot_sim_insn+gpu_sim_insn) / (gpu_tot_sim_cycle+gpu_sim_cycle));
+   printf("gpu_tot_issued_cta = %lld\n", gpu_tot_issued_cta + m_total_cta_launched);
+   printf("gpu_occupancy = %.4f%% \n", gpu_occupancy.get_occ_fraction() * 100);
+   printf("gpu_tot_occupancy = %.4f%% \n", (gpu_occupancy + gpu_tot_occupancy).get_occ_fraction() * 100);
+
+
+   fprintf(statfout, "max_total_param_size = %llu\n", gpgpu_ctx->device_runtime->g_max_total_param_size);
+
+   // performance counter for stalls due to congestion.
+   printf("gpu_stall_dramfull = %d\n", gpu_stall_dramfull);
+   printf("gpu_stall_icnt2sh    = %d\n", gpu_stall_icnt2sh );
+
+   //printf("partiton_reqs_in_parallel = %lld\n", partiton_reqs_in_parallel);
+   //printf("partiton_reqs_in_parallel_total    = %lld\n", partiton_reqs_in_parallel_total );
+   printf("partiton_level_parallism = %12.4f\n", (float)partiton_reqs_in_parallel / gpu_sim_cycle);
+   printf("partiton_level_parallism_total  = %12.4f\n", (float)(partiton_reqs_in_parallel+partiton_reqs_in_parallel_total) / (gpu_tot_sim_cycle+gpu_sim_cycle) );
+   //printf("partiton_reqs_in_parallel_util = %lld\n", partiton_reqs_in_parallel_util);
+   //printf("partiton_reqs_in_parallel_util_total    = %lld\n", partiton_reqs_in_parallel_util_total );
+   //printf("gpu_sim_cycle_parition_util = %lld\n", gpu_sim_cycle_parition_util);
+   // printf("gpu_tot_sim_cycle_parition_util    = %lld\n", gpu_tot_sim_cycle_parition_util );
+   printf("partiton_level_parallism_util = %12.4f\n", (float)partiton_reqs_in_parallel_util / gpu_sim_cycle_parition_util);
+   printf("partiton_level_parallism_util_total  = %12.4f\n", (float)(partiton_reqs_in_parallel_util+partiton_reqs_in_parallel_util_total) / (gpu_sim_cycle_parition_util+gpu_tot_sim_cycle_parition_util) );
+   //printf("partiton_replys_in_parallel = %lld\n", partiton_replys_in_parallel);
+   //printf("partiton_replys_in_parallel_total    = %lld\n", partiton_replys_in_parallel_total );
+   printf("L2_BW  = %12.4f GB/Sec\n", ((float)(partiton_replys_in_parallel * 32) / (gpu_sim_cycle * m_config.icnt_period)) / 1000000000);
+   printf("L2_BW_total  = %12.4f GB/Sec\n", ((float)((partiton_replys_in_parallel+partiton_replys_in_parallel_total) * 32) / ((gpu_tot_sim_cycle+gpu_sim_cycle) * m_config.icnt_period)) / 1000000000 );
+
+   time_t curr_time;
+   time(&curr_time);
+   unsigned long long elapsed_time = MAX( curr_time - gpgpu_ctx->the_gpgpusim->g_simulation_starttime, 1 );
+   printf( "gpu_total_sim_rate=%u\n", (unsigned)( ( gpu_tot_sim_insn + gpu_sim_insn ) / elapsed_time ) );
+
+   //shader_print_l1_miss_stat( stdout );
+   shader_print_cache_stats(stdout);
+
+   cache_stats core_cache_stats;
+   core_cache_stats.clear();
+   for(unsigned i=0; i<m_config.num_cluster(); i++){
+       m_cluster[i]->get_cache_stats(core_cache_stats);
+   }
+   printf("\nTotal_core_cache_stats:\n");
+   core_cache_stats.print_stats(stdout, "Total_core_cache_stats_breakdown");
+   printf("\nTotal_core_cache_fail_stats:\n");
+   core_cache_stats.print_fail_stats(stdout, "Total_core_cache_fail_stats_breakdown");
+   shader_print_scheduler_stat( stdout, false );
+
+   m_shader_stats->print(stdout);
 #ifdef GPGPUSIM_POWER_MODEL
-  if (m_config.g_power_simulation_enabled) {
-    m_gpgpusim_wrapper->print_power_kernel_stats(
-        gpu_sim_cycle, gpu_tot_sim_cycle, gpu_tot_sim_insn + gpu_sim_insn,
-        kernel_info_str, true);
-    mcpat_reset_perf_count(m_gpgpusim_wrapper);
-  }
+   if(m_config.g_power_simulation_enabled){
+	   m_gpgpusim_wrapper->print_power_kernel_stats(gpu_sim_cycle, gpu_tot_sim_cycle, gpu_tot_sim_insn + gpu_sim_insn, kernel_info_str, true );
+	   mcpat_reset_perf_count(m_gpgpusim_wrapper);
+   }
 #endif
 
-  // performance counter that are not local to one shader
-  m_memory_stats->memlatstat_print(m_memory_config->m_n_mem,
-                                   m_memory_config->nbk);
-  for (unsigned i = 0; i < m_memory_config->m_n_mem; i++)
-    m_memory_partition_unit[i]->print(stdout);
+   // performance counter that are not local to one shader
+   m_memory_stats->memlatstat_print(m_memory_config->m_n_mem,m_memory_config->nbk);
+   for (unsigned i=0;i<m_memory_config->m_n_mem;i++)
+      m_memory_partition_unit[i]->print(stdout);
 
-  // L2 cache stats
-  if (!m_memory_config->m_L2_config.disabled()) {
-    cache_stats l2_stats;
-    struct cache_sub_stats l2_css;
-    struct cache_sub_stats total_l2_css;
-    l2_stats.clear();
-    l2_css.clear();
-    total_l2_css.clear();
+   // L2 cache stats
+   if(!m_memory_config->m_L2_config.disabled()){
+       cache_stats l2_stats;
+       struct cache_sub_stats l2_css;
+       struct cache_sub_stats total_l2_css;
+       l2_stats.clear();
+       l2_css.clear();
+       total_l2_css.clear();
 
-    printf("\n========= L2 cache stats =========\n");
-    for (unsigned i = 0; i < m_memory_config->m_n_mem_sub_partition; i++) {
-      m_memory_sub_partition[i]->accumulate_L2cache_stats(l2_stats);
-      m_memory_sub_partition[i]->get_L2cache_sub_stats(l2_css);
+       printf("\n========= L2 cache stats =========\n");
+       for (unsigned i=0;i<m_memory_config->m_n_mem_sub_partition;i++){
+           m_memory_sub_partition[i]->accumulate_L2cache_stats(l2_stats);
+           m_memory_sub_partition[i]->get_L2cache_sub_stats(l2_css);
 
-      fprintf(stdout,
-              "L2_cache_bank[%d]: Access = %llu, Miss = %llu, Miss_rate = "
-              "%.3lf, Pending_hits = %llu, Reservation_fails = %llu\n",
-              i, l2_css.accesses, l2_css.misses,
-              (double)l2_css.misses / (double)l2_css.accesses,
-              l2_css.pending_hits, l2_css.res_fails);
+           fprintf( stdout, "L2_cache_bank[%d]: Access = %llu, Miss = %llu, Miss_rate = %.3lf, Pending_hits = %llu, Reservation_fails = %llu\n",
+                    i, l2_css.accesses, l2_css.misses, (double)l2_css.misses / (double)l2_css.accesses, l2_css.pending_hits, l2_css.res_fails);
 
-      total_l2_css += l2_css;
-    }
-    if (!m_memory_config->m_L2_config.disabled() &&
-        m_memory_config->m_L2_config.get_num_lines()) {
-      // L2c_print_cache_stat();
-      printf("L2_total_cache_accesses = %llu\n", total_l2_css.accesses);
-      printf("L2_total_cache_misses = %llu\n", total_l2_css.misses);
-      if (total_l2_css.accesses > 0)
-        printf("L2_total_cache_miss_rate = %.4lf\n",
-               (double)total_l2_css.misses / (double)total_l2_css.accesses);
-      printf("L2_total_cache_pending_hits = %llu\n", total_l2_css.pending_hits);
-      printf("L2_total_cache_reservation_fails = %llu\n",
-             total_l2_css.res_fails);
-      printf("L2_total_cache_breakdown:\n");
-      l2_stats.print_stats(stdout, "L2_cache_stats_breakdown");
-      printf("L2_total_cache_reservation_fail_breakdown:\n");
-      l2_stats.print_fail_stats(stdout, "L2_cache_stats_fail_breakdown");
-      total_l2_css.print_port_stats(stdout, "L2_cache");
-    }
-  }
+           total_l2_css += l2_css;
+       }
+       if (!m_memory_config->m_L2_config.disabled() && m_memory_config->m_L2_config.get_num_lines()) {
+          //L2c_print_cache_stat();
+          printf("L2_total_cache_accesses = %llu\n", total_l2_css.accesses);
+          printf("L2_total_cache_misses = %llu\n", total_l2_css.misses);
+          if(total_l2_css.accesses > 0)
+              printf("L2_total_cache_miss_rate = %.4lf\n", (double)total_l2_css.misses/(double)total_l2_css.accesses);
+          printf("L2_total_cache_pending_hits = %llu\n", total_l2_css.pending_hits);
+          printf("L2_total_cache_reservation_fails = %llu\n", total_l2_css.res_fails);
+          printf("L2_total_cache_breakdown:\n");
+          l2_stats.print_stats(stdout, "L2_cache_stats_breakdown");
+          printf("L2_total_cache_reservation_fail_breakdown:\n");
+          l2_stats.print_fail_stats(stdout, "L2_cache_stats_fail_breakdown");
+          total_l2_css.print_port_stats(stdout, "L2_cache");
+       }
+   }
 
-  if (m_config.gpgpu_cflog_interval != 0) {
-    spill_log_to_file(stdout, 1, gpu_sim_cycle);
-    insn_warp_occ_print(stdout);
-  }
-  if (gpgpu_ctx->func_sim->gpgpu_ptx_instruction_classification) {
-    StatDisp(gpgpu_ctx->func_sim->g_inst_classification_stat
-                 [gpgpu_ctx->func_sim->g_ptx_kernel_count]);
-    StatDisp(gpgpu_ctx->func_sim->g_inst_op_classification_stat
-                 [gpgpu_ctx->func_sim->g_ptx_kernel_count]);
-  }
+   if (m_config.gpgpu_cflog_interval != 0) {
+      spill_log_to_file (stdout, 1, gpu_sim_cycle);
+      insn_warp_occ_print(stdout);
+   }
+   if ( gpgpu_ctx->func_sim->gpgpu_ptx_instruction_classification ) {
+      StatDisp( gpgpu_ctx->func_sim->g_inst_classification_stat[gpgpu_ctx->func_sim->g_ptx_kernel_count]);
+      StatDisp( gpgpu_ctx->func_sim->g_inst_op_classification_stat[gpgpu_ctx->func_sim->g_ptx_kernel_count]);
+   }
 
 #ifdef GPGPUSIM_POWER_MODEL
-  if (m_config.g_power_simulation_enabled) {
-    m_gpgpusim_wrapper->detect_print_steady_state(
-        1, gpu_tot_sim_insn + gpu_sim_insn);
-  }
+   if(m_config.g_power_simulation_enabled){
+       m_gpgpusim_wrapper->detect_print_steady_state(1,gpu_tot_sim_insn+gpu_sim_insn);
+   }
 #endif
 
-  // Interconnect power stat print
-  long total_simt_to_mem = 0;
-  long total_mem_to_simt = 0;
-  long temp_stm = 0;
-  long temp_mts = 0;
-  for (unsigned i = 0; i < m_config.num_cluster(); i++) {
-    m_cluster[i]->get_icnt_stats(temp_stm, temp_mts);
-    total_simt_to_mem += temp_stm;
-    total_mem_to_simt += temp_mts;
-  }
-  printf("\nicnt_total_pkts_mem_to_simt=%ld\n", total_mem_to_simt);
-  printf("icnt_total_pkts_simt_to_mem=%ld\n", total_simt_to_mem);
 
-  time_vector_print();
-  fflush(stdout);
+   // Interconnect power stat print
+   long total_simt_to_mem=0;
+   long total_mem_to_simt=0;
+   long temp_stm=0;
+   long temp_mts = 0;
+   for(unsigned i=0; i<m_config.num_cluster(); i++){
+	   m_cluster[i]->get_icnt_stats(temp_stm, temp_mts);
+	   total_simt_to_mem += temp_stm;
+	   total_mem_to_simt += temp_mts;
+   }
+   printf("\nicnt_total_pkts_mem_to_simt=%ld\n", total_mem_to_simt);
+   printf("icnt_total_pkts_simt_to_mem=%ld\n", total_simt_to_mem);
 
-  clear_executed_kernel_info();
+   time_vector_print();
+   fflush(stdout);
+
+   clear_executed_kernel_info(); 
 }
+
 
 // performance counter that are not local to one shader
-unsigned gpgpu_sim::threads_per_core() const {
-  return m_shader_config->n_thread_per_shader;
+unsigned gpgpu_sim::threads_per_core() const 
+{ 
+   return m_shader_config->n_thread_per_shader; 
 }
 
-void shader_core_ctx::mem_instruction_stats(const warp_inst_t &inst) {
-  unsigned active_count = inst.active_count();
-  // this breaks some encapsulation: the is_[space] functions, if you change
-  // those, change this.
-  switch (inst.space.get_type()) {
+void shader_core_ctx::mem_instruction_stats(const warp_inst_t &inst)
+{
+    unsigned active_count = inst.active_count(); 
+    //this breaks some encapsulation: the is_[space] functions, if you change those, change this.
+    switch (inst.space.get_type()) {
     case undefined_space:
     case reg_space:
-      break;
+        break;
     case shared_space:
-      m_stats->gpgpu_n_shmem_insn += active_count;
-      break;
+        m_stats->gpgpu_n_shmem_insn += active_count; 
+        break;
     case sstarr_space:
-      m_stats->gpgpu_n_sstarr_insn += active_count;
-      break;
+    	m_stats->gpgpu_n_sstarr_insn += active_count;
+    	break;
     case const_space:
-      m_stats->gpgpu_n_const_insn += active_count;
-      break;
+        m_stats->gpgpu_n_const_insn += active_count;
+        break;
     case param_space_kernel:
     case param_space_local:
-      m_stats->gpgpu_n_param_insn += active_count;
-      break;
+        m_stats->gpgpu_n_param_insn += active_count;
+        break;
     case tex_space:
-      m_stats->gpgpu_n_tex_insn += active_count;
-      break;
+        m_stats->gpgpu_n_tex_insn += active_count;
+        break;
     case global_space:
     case local_space:
-      if (inst.is_store())
-        m_stats->gpgpu_n_store_insn += active_count;
-      else
-        m_stats->gpgpu_n_load_insn += active_count;
-      break;
+        if( inst.is_store() )
+            m_stats->gpgpu_n_store_insn += active_count;
+        else 
+            m_stats->gpgpu_n_load_insn += active_count;
+        break;
     default:
-      abort();
-  }
+        abort();
+    }
 }
-bool shader_core_ctx::can_issue_1block(kernel_info_t &kernel) {
-  // Jin: concurrent kernels on one SM
-  if (m_config->gpgpu_concurrent_kernel_sm) {
-    if (m_config->max_cta(kernel) < 1) return false;
+bool shader_core_ctx::can_issue_1block(kernel_info_t & kernel) {
 
-    return occupy_shader_resource_1block(kernel, false);
-  } else {
-    return (get_n_active_cta() < m_config->max_cta(kernel));
-  }
+   //Jin: concurrent kernels on one SM
+   if(m_config->gpgpu_concurrent_kernel_sm) {    
+      if(m_config->max_cta(kernel) < 1)
+           return false;
+
+      return occupy_shader_resource_1block(kernel, false);
+   }
+   else {
+      return (get_n_active_cta() < m_config->max_cta(kernel));
+   } 
 }
 
 int shader_core_ctx::find_available_hwtid(unsigned int cta_size, bool occupy) {
-  unsigned int step;
-  for (step = 0; step < m_config->n_thread_per_shader; step += cta_size) {
-    unsigned int hw_tid;
-    for (hw_tid = step; hw_tid < step + cta_size; hw_tid++) {
-      if (m_occupied_hwtid.test(hw_tid)) break;
-    }
-    if (hw_tid == step + cta_size)  // consecutive non-active
-      break;
-  }
-  if (step >= m_config->n_thread_per_shader)  // didn't find
-    return -1;
-  else {
-    if (occupy) {
-      for (unsigned hw_tid = step; hw_tid < step + cta_size; hw_tid++)
-        m_occupied_hwtid.set(hw_tid);
-    }
-    return step;
-  }
+   
+   unsigned int step;
+   for(step = 0; step < m_config->n_thread_per_shader; 
+        step += cta_size) {
+
+        unsigned int hw_tid;
+        for(hw_tid = step; hw_tid < step + cta_size;
+            hw_tid++) {
+            if(m_occupied_hwtid.test(hw_tid))
+                break;
+        }
+        if(hw_tid == step + cta_size) //consecutive non-active
+            break;
+   }
+   if(step >= m_config->n_thread_per_shader) //didn't find
+     return -1;
+   else {
+     if(occupy) {
+        for(unsigned hw_tid = step; hw_tid < step + cta_size;
+            hw_tid++)
+            m_occupied_hwtid.set(hw_tid);
+     }
+     return step;
+   }
 }
 
-bool shader_core_ctx::occupy_shader_resource_1block(kernel_info_t &k,
-                                                    bool occupy) {
-  unsigned threads_per_cta = k.threads_per_cta();
-  const class function_info *kernel = k.entry();
-  unsigned int padded_cta_size = threads_per_cta;
-  unsigned int warp_size = m_config->warp_size;
-  if (padded_cta_size % warp_size)
-    padded_cta_size = ((padded_cta_size / warp_size) + 1) * (warp_size);
+bool shader_core_ctx::occupy_shader_resource_1block(kernel_info_t & k, bool occupy) {
+   unsigned threads_per_cta  = k.threads_per_cta();
+   const class function_info *kernel = k.entry();
+   unsigned int padded_cta_size = threads_per_cta;
+   unsigned int warp_size = m_config->warp_size; 
+   if (padded_cta_size%warp_size) 
+      padded_cta_size = ((padded_cta_size/warp_size)+1)*(warp_size);
 
-  if (m_occupied_n_threads + padded_cta_size > m_config->n_thread_per_shader)
-    return false;
+   if(m_occupied_n_threads + padded_cta_size > m_config->n_thread_per_shader)
+     return false;
 
-  if (find_available_hwtid(padded_cta_size, false) == -1) return false;
+   if(find_available_hwtid(padded_cta_size, false) == -1)
+     return false;
 
-  const struct gpgpu_ptx_sim_info *kernel_info = ptx_sim_kernel_info(kernel);
+   const struct gpgpu_ptx_sim_info *kernel_info = ptx_sim_kernel_info(kernel);
 
-  if (m_occupied_shmem + kernel_info->smem > m_config->gpgpu_shmem_size)
-    return false;
+   if(m_occupied_shmem + kernel_info->smem > m_config->gpgpu_shmem_size)
+     return false;
 
-  unsigned int used_regs = padded_cta_size * ((kernel_info->regs + 3) & ~3);
-  if (m_occupied_regs + used_regs > m_config->gpgpu_shader_registers)
-    return false;
+   unsigned int used_regs = padded_cta_size * ((kernel_info->regs+3)&~3);
+   if(m_occupied_regs + used_regs > m_config->gpgpu_shader_registers)
+     return false;
 
-  if (m_occupied_ctas + 1 > m_config->max_cta_per_core) return false;
+   if(m_occupied_ctas +1 > m_config->max_cta_per_core)
+     return false;
+   
+   if(occupy) {
+       m_occupied_n_threads += padded_cta_size;
+       m_occupied_shmem += kernel_info->smem;
+       m_occupied_regs += (padded_cta_size * ((kernel_info->regs+3)&~3));
+       m_occupied_ctas++;
 
-  if (occupy) {
-    m_occupied_n_threads += padded_cta_size;
-    m_occupied_shmem += kernel_info->smem;
-    m_occupied_regs += (padded_cta_size * ((kernel_info->regs + 3) & ~3));
-    m_occupied_ctas++;
+      SHADER_DPRINTF(LIVENESS, "GPGPU-Sim uArch: Occupied %u threads, %u shared mem, %u registers, %u ctas\n",
+            m_occupied_n_threads, m_occupied_shmem, m_occupied_regs, m_occupied_ctas);  
+   }
 
-    SHADER_DPRINTF(LIVENESS,
-                   "GPGPU-Sim uArch: Occupied %u threads, %u shared mem, %u "
-                   "registers, %u ctas\n",
-                   m_occupied_n_threads, m_occupied_shmem, m_occupied_regs,
-                   m_occupied_ctas);
-  }
-
-  return true;
+   return true;
 }
 
-void shader_core_ctx::release_shader_resource_1block(unsigned hw_ctaid,
-                                                     kernel_info_t &k) {
-  if (m_config->gpgpu_concurrent_kernel_sm) {
-    unsigned threads_per_cta = k.threads_per_cta();
-    const class function_info *kernel = k.entry();
-    unsigned int padded_cta_size = threads_per_cta;
-    unsigned int warp_size = m_config->warp_size;
-    if (padded_cta_size % warp_size)
-      padded_cta_size = ((padded_cta_size / warp_size) + 1) * (warp_size);
+void shader_core_ctx::release_shader_resource_1block(unsigned hw_ctaid, kernel_info_t & k) {
 
-    assert(m_occupied_n_threads >= padded_cta_size);
-    m_occupied_n_threads -= padded_cta_size;
-
-    int start_thread = m_occupied_cta_to_hwtid[hw_ctaid];
-
-    for (unsigned hwtid = start_thread; hwtid < start_thread + padded_cta_size;
-         hwtid++)
-      m_occupied_hwtid.reset(hwtid);
-    m_occupied_cta_to_hwtid.erase(hw_ctaid);
-
-    const struct gpgpu_ptx_sim_info *kernel_info = ptx_sim_kernel_info(kernel);
-
-    assert(m_occupied_shmem >= (unsigned int)kernel_info->smem);
-    m_occupied_shmem -= kernel_info->smem;
-
-    unsigned int used_regs = padded_cta_size * ((kernel_info->regs + 3) & ~3);
-    assert(m_occupied_regs >= used_regs);
-    m_occupied_regs -= used_regs;
-
-    assert(m_occupied_ctas >= 1);
-    m_occupied_ctas--;
-  }
+   if(m_config->gpgpu_concurrent_kernel_sm) {
+      unsigned threads_per_cta  = k.threads_per_cta();
+      const class function_info *kernel = k.entry();
+      unsigned int padded_cta_size = threads_per_cta;
+      unsigned int warp_size = m_config->warp_size; 
+      if (padded_cta_size%warp_size) 
+         padded_cta_size = ((padded_cta_size/warp_size)+1)*(warp_size);
+   
+      assert(m_occupied_n_threads >= padded_cta_size);
+      m_occupied_n_threads -= padded_cta_size;
+   
+      int start_thread = m_occupied_cta_to_hwtid[hw_ctaid];
+   
+      for(unsigned hwtid = start_thread; hwtid < start_thread + padded_cta_size;
+       hwtid++)
+          m_occupied_hwtid.reset(hwtid);
+      m_occupied_cta_to_hwtid.erase(hw_ctaid);
+   
+      const struct gpgpu_ptx_sim_info *kernel_info = ptx_sim_kernel_info(kernel);
+   
+      assert(m_occupied_shmem >= (unsigned int)kernel_info->smem);
+      m_occupied_shmem -= kernel_info->smem;
+   
+      unsigned int used_regs = padded_cta_size * ((kernel_info->regs+3)&~3);
+      assert(m_occupied_regs >= used_regs);
+      m_occupied_regs -= used_regs;
+   
+      assert(m_occupied_ctas >= 1);
+      m_occupied_ctas--;
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
 /**
- * Launches a cooperative thread array (CTA).
- *
- * @param kernel
- *    object that tells us which kernel to ask for a CTA from
+ * Launches a cooperative thread array (CTA). 
+ *  
+ * @param kernel 
+ *    object that tells us which kernel to ask for a CTA from 
  */
 
-void shader_core_ctx::issue_block2core(kernel_info_t &kernel) {
-  if (!m_config->gpgpu_concurrent_kernel_sm)
-    set_max_cta(kernel);
-  else
-    assert(occupy_shader_resource_1block(kernel, true));
+void shader_core_ctx::issue_block2core( kernel_info_t &kernel ) 
+{
 
-  kernel.inc_running();
+    if(!m_config->gpgpu_concurrent_kernel_sm)
+        set_max_cta(kernel);
+    else
+        assert(occupy_shader_resource_1block(kernel, true));
 
-  // find a free CTA context
-  unsigned free_cta_hw_id = (unsigned)-1;
+    kernel.inc_running();
 
-  unsigned max_cta_per_core;
-  if (!m_config->gpgpu_concurrent_kernel_sm)
-    max_cta_per_core = kernel_max_cta_per_shader;
-  else
-    max_cta_per_core = m_config->max_cta_per_core;
-  for (unsigned i = 0; i < max_cta_per_core; i++) {
-    if (m_cta_status[i] == 0) {
-      free_cta_hw_id = i;
-      break;
+    // find a free CTA context 
+    unsigned free_cta_hw_id=(unsigned)-1;
+
+    unsigned max_cta_per_core;
+    if(!m_config->gpgpu_concurrent_kernel_sm)
+        max_cta_per_core = kernel_max_cta_per_shader;
+    else
+        max_cta_per_core = m_config->max_cta_per_core;
+    for (unsigned i=0;i<max_cta_per_core;i++ ) {
+      if( m_cta_status[i]==0 ) {
+         free_cta_hw_id=i;
+         break;
+      }
     }
-  }
-  assert(free_cta_hw_id != (unsigned)-1);
+    assert( free_cta_hw_id!=(unsigned)-1 );
 
-  // determine hardware threads and warps that will be used for this CTA
-  int cta_size = kernel.threads_per_cta();
+    // determine hardware threads and warps that will be used for this CTA
+    int cta_size = kernel.threads_per_cta();
 
-  // hw warp id = hw thread id mod warp size, so we need to find a range
-  // of hardware thread ids corresponding to an integral number of hardware
-  // thread ids
-  int padded_cta_size = cta_size;
-  if (cta_size % m_config->warp_size)
-    padded_cta_size =
-        ((cta_size / m_config->warp_size) + 1) * (m_config->warp_size);
+    // hw warp id = hw thread id mod warp size, so we need to find a range 
+    // of hardware thread ids corresponding to an integral number of hardware
+    // thread ids
+    int padded_cta_size = cta_size; 
+    if (cta_size%m_config->warp_size)
+      padded_cta_size = ((cta_size/m_config->warp_size)+1)*(m_config->warp_size);
 
-  unsigned int start_thread, end_thread;
+    unsigned int start_thread, end_thread;
 
-  if (!m_config->gpgpu_concurrent_kernel_sm) {
-    start_thread = free_cta_hw_id * padded_cta_size;
-    end_thread = start_thread + cta_size;
-  } else {
-    start_thread = find_available_hwtid(padded_cta_size, true);
-    assert((int)start_thread != -1);
-    end_thread = start_thread + cta_size;
-    assert(m_occupied_cta_to_hwtid.find(free_cta_hw_id) ==
-           m_occupied_cta_to_hwtid.end());
-    m_occupied_cta_to_hwtid[free_cta_hw_id] = start_thread;
-  }
-
-  // reset the microarchitecture state of the selected hardware thread and warp
-  // contexts
-  reinit(start_thread, end_thread, false);
-
-  // initalize scalar threads and determine which hardware warps they are
-  // allocated to
-  // bind functional simulation state of threads to hardware resources
-  // (simulation)
-  warp_set_t warps;
-  unsigned nthreads_in_block = 0;
-  function_info *kernel_func_info = kernel.entry();
-  symbol_table *symtab = kernel_func_info->get_symtab();
-  unsigned ctaid = kernel.get_next_cta_id_single();
-  checkpoint *g_checkpoint = new checkpoint();
-  for (unsigned i = start_thread; i < end_thread; i++) {
-    m_threadState[i].m_cta_id = free_cta_hw_id;
-    unsigned warp_id = i / m_config->warp_size;
-    nthreads_in_block += ptx_sim_init_thread(
-        kernel, &m_thread[i], m_sid, i, cta_size - (i - start_thread),
-        m_config->n_thread_per_shader, this, free_cta_hw_id, warp_id,
-        m_cluster->get_gpu());
-    m_threadState[i].m_active = true;
-    // load thread local memory and register file
-    if (m_gpu->resume_option == 1 && kernel.get_uid() == m_gpu->resume_kernel &&
-        ctaid >= m_gpu->resume_CTA && ctaid < m_gpu->checkpoint_CTA_t) {
-      char fname[2048];
-      snprintf(fname, 2048, "checkpoint_files/thread_%d_%d_reg.txt",
-               i % cta_size, ctaid);
-      m_thread[i]->resume_reg_thread(fname, symtab);
-      char f1name[2048];
-      snprintf(f1name, 2048, "checkpoint_files/local_mem_thread_%d_%d_reg.txt",
-               i % cta_size, ctaid);
-      g_checkpoint->load_global_mem(m_thread[i]->m_local_mem, f1name);
+    if(!m_config->gpgpu_concurrent_kernel_sm) {
+        start_thread = free_cta_hw_id * padded_cta_size;
+        end_thread  = start_thread +  cta_size;
     }
-    //
-    warps.set(warp_id);
-  }
-  assert(nthreads_in_block > 0 &&
-         nthreads_in_block <= m_config->n_thread_per_shader);  // should be at
-                                                               // least one, but
-                                                               // less than max
-  m_cta_status[free_cta_hw_id] = nthreads_in_block;
+    else {
+        start_thread = find_available_hwtid(padded_cta_size, true);
+        assert((int)start_thread != -1);
+        end_thread = start_thread + cta_size;
+        assert(m_occupied_cta_to_hwtid.find(free_cta_hw_id) == m_occupied_cta_to_hwtid.end());
+        m_occupied_cta_to_hwtid[free_cta_hw_id]= start_thread;
+    }
 
-  if (m_gpu->resume_option == 1 && kernel.get_uid() == m_gpu->resume_kernel &&
-      ctaid >= m_gpu->resume_CTA && ctaid < m_gpu->checkpoint_CTA_t) {
-    char f1name[2048];
-    snprintf(f1name, 2048, "checkpoint_files/shared_mem_%d.txt", ctaid);
+    // reset the microarchitecture state of the selected hardware thread and warp contexts
+    reinit(start_thread, end_thread,false);
+     
+    // initalize scalar threads and determine which hardware warps they are allocated to
+    // bind functional simulation state of threads to hardware resources (simulation) 
+    warp_set_t warps;
+    unsigned nthreads_in_block= 0;
+    function_info *kernel_func_info = kernel.entry();
+    symbol_table * symtab= kernel_func_info->get_symtab();
+    unsigned ctaid= kernel.get_next_cta_id_single();
+    checkpoint *g_checkpoint=  new checkpoint();
+    for (unsigned i = start_thread; i<end_thread; i++) {
+        m_threadState[i].m_cta_id = free_cta_hw_id;
+        unsigned warp_id = i/m_config->warp_size;
+        nthreads_in_block += ptx_sim_init_thread(kernel,&m_thread[i],m_sid,i,cta_size-(i-start_thread),m_config->n_thread_per_shader,this,free_cta_hw_id,warp_id,m_cluster->get_gpu());
+        m_threadState[i].m_active = true; 
+        // load thread local memory and register file
+        if(m_gpu->resume_option == 1 && kernel.get_uid() == m_gpu->resume_kernel && ctaid >= m_gpu->resume_CTA && ctaid < m_gpu->checkpoint_CTA_t )
+        {
+            char fname[2048];
+            snprintf(fname,2048,"checkpoint_files/thread_%d_%d_reg.txt",i%cta_size,ctaid );
+            m_thread[i]->resume_reg_thread(fname,symtab);
+            char f1name[2048];
+            snprintf(f1name,2048,"checkpoint_files/local_mem_thread_%d_%d_reg.txt",i%cta_size,ctaid);
+            g_checkpoint->load_global_mem(m_thread[i]->m_local_mem, f1name); 
+        }
+        //
+        warps.set( warp_id );
+    }
+    assert( nthreads_in_block > 0 && nthreads_in_block <= m_config->n_thread_per_shader); // should be at least one, but less than max
+    m_cta_status[free_cta_hw_id]=nthreads_in_block;
 
-    g_checkpoint->load_global_mem(m_thread[start_thread]->m_shared_mem, f1name);
-  }
-  // now that we know which warps are used in this CTA, we can allocate
-  // resources for use in CTA-wide barrier operations
-  m_barriers.allocate_barrier(free_cta_hw_id, warps);
+    if(m_gpu->resume_option == 1 && kernel.get_uid() == m_gpu->resume_kernel && ctaid >= m_gpu->resume_CTA && ctaid < m_gpu->checkpoint_CTA_t )
+    {
+        char f1name[2048];
+        snprintf(f1name,2048,"checkpoint_files/shared_mem_%d.txt", ctaid);
+        
+        g_checkpoint->load_global_mem(m_thread[start_thread]->m_shared_mem, f1name);  
+    }
+    // now that we know which warps are used in this CTA, we can allocate
+    // resources for use in CTA-wide barrier operations
+    m_barriers.allocate_barrier(free_cta_hw_id,warps);
 
-  // initialize the SIMT stacks and fetch hardware
-  init_warps(free_cta_hw_id, start_thread, end_thread, ctaid, cta_size,
-             kernel.get_uid());
-  m_n_active_cta++;
+    // initialize the SIMT stacks and fetch hardware
+    init_warps( free_cta_hw_id, start_thread, end_thread, ctaid, cta_size, kernel.get_uid());
+    m_n_active_cta++;
 
-  shader_CTA_count_log(m_sid, 1);
-  SHADER_DPRINTF(LIVENESS,
-                 "GPGPU-Sim uArch: cta:%2u, start_tid:%4u, end_tid:%4u, "
-                 "initialized @(%lld,%lld)\n",
-                 free_cta_hw_id, start_thread, end_thread, m_gpu->gpu_sim_cycle,
-                 m_gpu->gpu_tot_sim_cycle);
+    shader_CTA_count_log(m_sid, 1);
+    SHADER_DPRINTF(LIVENESS, "GPGPU-Sim uArch: cta:%2u, start_tid:%4u, end_tid:%4u, initialized @(%lld,%lld)\n", 
+        free_cta_hw_id, start_thread, end_thread, m_gpu->gpu_sim_cycle, m_gpu->gpu_tot_sim_cycle );
+
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-void dram_t::dram_log(int task) {
-  if (task == SAMPLELOG) {
-    StatAddSample(mrqq_Dist, que_length());
-  } else if (task == DUMPLOG) {
-    printf("Queue Length DRAM[%d] ", id);
-    StatDisp(mrqq_Dist);
-  }
+void dram_t::dram_log( int task ) 
+{
+   if (task == SAMPLELOG) {
+      StatAddSample(mrqq_Dist, que_length());   
+   } else if (task == DUMPLOG) {
+      printf ("Queue Length DRAM[%d] ",id);StatDisp(mrqq_Dist);
+   }
 }
 
-// Find next clock domain and increment its time
-int gpgpu_sim::next_clock_domain(void) {
-  double smallest = min3(core_time, icnt_time, dram_time);
-  int mask = 0x00;
-  if (l2_time <= smallest) {
-    smallest = l2_time;
-    mask |= L2;
-    l2_time += m_config.l2_period;
-  }
-  if (icnt_time <= smallest) {
-    mask |= ICNT;
-    icnt_time += m_config.icnt_period;
-  }
-  if (dram_time <= smallest) {
-    mask |= DRAM;
-    dram_time += m_config.dram_period;
-  }
-  if (core_time <= smallest) {
-    mask |= CORE;
-    core_time += m_config.core_period;
-  }
-  return mask;
+//Find next clock domain and increment its time
+int gpgpu_sim::next_clock_domain(void) 
+{
+   double smallest = min3(core_time,icnt_time,dram_time);
+   int mask = 0x00;
+   if ( l2_time <= smallest ) {
+      smallest = l2_time;
+      mask |= L2 ;
+      l2_time += m_config.l2_period;
+   }
+   if ( icnt_time <= smallest ) {
+      mask |= ICNT;
+      icnt_time += m_config.icnt_period;
+   }
+   if ( dram_time <= smallest ) {
+      mask |= DRAM;
+      dram_time += m_config.dram_period;
+   }
+   if ( core_time <= smallest ) {
+      mask |= CORE;
+      core_time += m_config.core_period;
+   }
+   return mask;
 }
 
-void gpgpu_sim::issue_block2core() {
-  unsigned last_issued = m_last_cluster_issue;
-  for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++) {
-    unsigned idx = (i + last_issued + 1) % m_shader_config->n_simt_clusters;
-    unsigned num = m_cluster[idx]->issue_block2core();
-    if (num) {
-      m_last_cluster_issue = idx;
-      m_total_cta_launched += num;
-    }
-  }
-}
-
-unsigned long long g_single_step =
-    0;  // set this in gdb to single step the pipeline
-
-void gpgpu_sim::cycle() {
-  int clock_mask = next_clock_domain();
-
-  if (clock_mask & CORE) {
-    // shader core loading (pop from ICNT into core) follows CORE clock
-    for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++)
-      m_cluster[i]->icnt_cycle();
-  }
-  unsigned partiton_replys_in_parallel_per_cycle = 0;
-  if (clock_mask & ICNT) {
-    // pop from memory controller to interconnect
-    for (unsigned i = 0; i < m_memory_config->m_n_mem_sub_partition; i++) {
-      mem_fetch *mf = m_memory_sub_partition[i]->top();
-      if (mf) {
-        unsigned response_size =
-            mf->get_is_write() ? mf->get_ctrl_size() : mf->size();
-        if (::icnt_has_buffer(m_shader_config->mem2device(i), response_size)) {
-          // if (!mf->get_is_write())
-          mf->set_return_timestamp(gpu_sim_cycle + gpu_tot_sim_cycle);
-          mf->set_status(IN_ICNT_TO_SHADER, gpu_sim_cycle + gpu_tot_sim_cycle);
-          ::icnt_push(m_shader_config->mem2device(i), mf->get_tpc(), mf,
-                      response_size);
-          m_memory_sub_partition[i]->pop();
-          partiton_replys_in_parallel_per_cycle++;
-        } else {
-          gpu_stall_icnt2sh++;
+void gpgpu_sim::issue_block2core()
+{
+    unsigned last_issued = m_last_cluster_issue; 
+    for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) {
+        unsigned idx = (i + last_issued + 1) % m_shader_config->n_simt_clusters;
+        unsigned num = m_cluster[idx]->issue_block2core();
+        if( num ) {
+            m_last_cluster_issue=idx;
+            m_total_cta_launched += num;
         }
-      } else {
-        m_memory_sub_partition[i]->pop();
+    }
+}
+
+unsigned long long g_single_step=0; // set this in gdb to single step the pipeline
+
+void gpgpu_sim::cycle()
+{
+   int clock_mask = next_clock_domain();
+
+   if (clock_mask & CORE ) {
+       // shader core loading (pop from ICNT into core) follows CORE clock
+      for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) 
+         m_cluster[i]->icnt_cycle(); 
+   }
+    unsigned partiton_replys_in_parallel_per_cycle = 0;
+    if (clock_mask & ICNT) {
+        // pop from memory controller to interconnect
+        for (unsigned i=0;i<m_memory_config->m_n_mem_sub_partition;i++) {
+            mem_fetch* mf = m_memory_sub_partition[i]->top();
+            if (mf) {
+                unsigned response_size = mf->get_is_write()?mf->get_ctrl_size():mf->size();
+                if ( ::icnt_has_buffer( m_shader_config->mem2device(i), response_size ) ) {
+                    //if (!mf->get_is_write())
+                       mf->set_return_timestamp(gpu_sim_cycle+gpu_tot_sim_cycle);
+                    mf->set_status(IN_ICNT_TO_SHADER,gpu_sim_cycle+gpu_tot_sim_cycle);
+                    ::icnt_push( m_shader_config->mem2device(i), mf->get_tpc(), mf, response_size );
+                    m_memory_sub_partition[i]->pop();
+                    partiton_replys_in_parallel_per_cycle++;
+                } else {
+                    gpu_stall_icnt2sh++;
+                }
+            } else {
+               m_memory_sub_partition[i]->pop();
+            }
+        }
+    }
+    partiton_replys_in_parallel += partiton_replys_in_parallel_per_cycle;
+
+   if (clock_mask & DRAM) {
+      for (unsigned i=0;i<m_memory_config->m_n_mem;i++){
+    	  if(m_memory_config->simple_dram_model)
+    		  m_memory_partition_unit[i]->simple_dram_model_cycle();
+    	  else
+    		  m_memory_partition_unit[i]->dram_cycle(); // Issue the dram command (scheduler + delay model)
+         // Update performance counters for DRAM
+         m_memory_partition_unit[i]->set_dram_power_stats(m_power_stats->pwr_mem_stat->n_cmd[CURRENT_STAT_IDX][i], m_power_stats->pwr_mem_stat->n_activity[CURRENT_STAT_IDX][i],
+                        m_power_stats->pwr_mem_stat->n_nop[CURRENT_STAT_IDX][i], m_power_stats->pwr_mem_stat->n_act[CURRENT_STAT_IDX][i], m_power_stats->pwr_mem_stat->n_pre[CURRENT_STAT_IDX][i],
+                        m_power_stats->pwr_mem_stat->n_rd[CURRENT_STAT_IDX][i], m_power_stats->pwr_mem_stat->n_wr[CURRENT_STAT_IDX][i], m_power_stats->pwr_mem_stat->n_req[CURRENT_STAT_IDX][i]);
       }
-    }
-  }
-  partiton_replys_in_parallel += partiton_replys_in_parallel_per_cycle;
+   }
 
-  if (clock_mask & DRAM) {
-    for (unsigned i = 0; i < m_memory_config->m_n_mem; i++) {
-      if (m_memory_config->simple_dram_model)
-        m_memory_partition_unit[i]->simple_dram_model_cycle();
-      else
-        m_memory_partition_unit[i]
-            ->dram_cycle();  // Issue the dram command (scheduler + delay model)
-      // Update performance counters for DRAM
-      m_memory_partition_unit[i]->set_dram_power_stats(
-          m_power_stats->pwr_mem_stat->n_cmd[CURRENT_STAT_IDX][i],
-          m_power_stats->pwr_mem_stat->n_activity[CURRENT_STAT_IDX][i],
-          m_power_stats->pwr_mem_stat->n_nop[CURRENT_STAT_IDX][i],
-          m_power_stats->pwr_mem_stat->n_act[CURRENT_STAT_IDX][i],
-          m_power_stats->pwr_mem_stat->n_pre[CURRENT_STAT_IDX][i],
-          m_power_stats->pwr_mem_stat->n_rd[CURRENT_STAT_IDX][i],
-          m_power_stats->pwr_mem_stat->n_wr[CURRENT_STAT_IDX][i],
-          m_power_stats->pwr_mem_stat->n_req[CURRENT_STAT_IDX][i]);
-    }
-  }
+   // L2 operations follow L2 clock domain
+   unsigned partiton_reqs_in_parallel_per_cycle = 0;
+   if (clock_mask & L2) {
+       m_power_stats->pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].clear();
+      for (unsigned i=0;i<m_memory_config->m_n_mem_sub_partition;i++) {
+          //move memory request from interconnect into memory partition (if not backed up)
+          //Note:This needs to be called in DRAM clock domain if there is no L2 cache in the system
+    	  //In the worst case, we may need to push SECTOR_CHUNCK_SIZE requests, so ensure you have enough buffer for them
+          if ( m_memory_sub_partition[i]->full(SECTOR_CHUNCK_SIZE) ) {
+             gpu_stall_dramfull++;
+          } else {
+              mem_fetch* mf = (mem_fetch*) icnt_pop( m_shader_config->mem2device(i) );
+              m_memory_sub_partition[i]->push( mf, gpu_sim_cycle + gpu_tot_sim_cycle );
+              if(mf)
+            	  partiton_reqs_in_parallel_per_cycle++;
+          }
+          m_memory_sub_partition[i]->cache_cycle(gpu_sim_cycle+gpu_tot_sim_cycle);
+          m_memory_sub_partition[i]->accumulate_L2cache_stats(m_power_stats->pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX]);
+       }
+   }
+   partiton_reqs_in_parallel += partiton_reqs_in_parallel_per_cycle;
+   if(partiton_reqs_in_parallel_per_cycle > 0){
+	   partiton_reqs_in_parallel_util += partiton_reqs_in_parallel_per_cycle;
+	   gpu_sim_cycle_parition_util++;
+   }
 
-  // L2 operations follow L2 clock domain
-  unsigned partiton_reqs_in_parallel_per_cycle = 0;
-  if (clock_mask & L2) {
-    m_power_stats->pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].clear();
-    for (unsigned i = 0; i < m_memory_config->m_n_mem_sub_partition; i++) {
-      // move memory request from interconnect into memory partition (if not
-      // backed up)
-      // Note:This needs to be called in DRAM clock domain if there is no L2
-      // cache in the system
-      // In the worst case, we may need to push SECTOR_CHUNCK_SIZE requests, so
-      // ensure you have enough buffer for them
-      if (m_memory_sub_partition[i]->full(SECTOR_CHUNCK_SIZE)) {
-        gpu_stall_dramfull++;
-      } else {
-        mem_fetch *mf = (mem_fetch *)icnt_pop(m_shader_config->mem2device(i));
-        m_memory_sub_partition[i]->push(mf, gpu_sim_cycle + gpu_tot_sim_cycle);
-        if (mf) partiton_reqs_in_parallel_per_cycle++;
+   if (clock_mask & ICNT) {
+      icnt_transfer();
+   }
+
+   if (clock_mask & CORE) {
+      // L1 cache + shader core pipeline stages
+      m_power_stats->pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].clear();
+      for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) {
+         if (m_cluster[i]->get_not_completed() || get_more_cta_left() ) {
+               m_cluster[i]->core_cycle();
+               *active_sms+=m_cluster[i]->get_n_active_sms();
+         }
+         // Update core icnt/cache stats for GPUWattch
+         m_cluster[i]->get_icnt_stats(m_power_stats->pwr_mem_stat->n_simt_to_mem[CURRENT_STAT_IDX][i], m_power_stats->pwr_mem_stat->n_mem_to_simt[CURRENT_STAT_IDX][i]);
+         m_cluster[i]->get_cache_stats(m_power_stats->pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX]);
+         m_cluster[i]->get_current_occupancy(gpu_occupancy.aggregate_warp_slot_filled, gpu_occupancy.aggregate_theoretical_warp_slots);
+
       }
-      m_memory_sub_partition[i]->cache_cycle(gpu_sim_cycle + gpu_tot_sim_cycle);
-      m_memory_sub_partition[i]->accumulate_L2cache_stats(
-          m_power_stats->pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX]);
-    }
-  }
-  partiton_reqs_in_parallel += partiton_reqs_in_parallel_per_cycle;
-  if (partiton_reqs_in_parallel_per_cycle > 0) {
-    partiton_reqs_in_parallel_util += partiton_reqs_in_parallel_per_cycle;
-    gpu_sim_cycle_parition_util++;
-  }
-
-  if (clock_mask & ICNT) {
-    icnt_transfer();
-  }
-
-  if (clock_mask & CORE) {
-    // L1 cache + shader core pipeline stages
-    m_power_stats->pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].clear();
-    for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++) {
-      if (m_cluster[i]->get_not_completed() || get_more_cta_left()) {
-        m_cluster[i]->core_cycle();
-        *active_sms += m_cluster[i]->get_n_active_sms();
+      float temp=0;
+      for (unsigned i=0;i<m_shader_config->num_shader();i++){
+        temp+=m_shader_stats->m_pipeline_duty_cycle[i];
       }
-      // Update core icnt/cache stats for GPUWattch
-      m_cluster[i]->get_icnt_stats(
-          m_power_stats->pwr_mem_stat->n_simt_to_mem[CURRENT_STAT_IDX][i],
-          m_power_stats->pwr_mem_stat->n_mem_to_simt[CURRENT_STAT_IDX][i]);
-      m_cluster[i]->get_cache_stats(
-          m_power_stats->pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX]);
-      m_cluster[i]->get_current_occupancy(
-          gpu_occupancy.aggregate_warp_slot_filled,
-          gpu_occupancy.aggregate_theoretical_warp_slots);
-    }
-    float temp = 0;
-    for (unsigned i = 0; i < m_shader_config->num_shader(); i++) {
-      temp += m_shader_stats->m_pipeline_duty_cycle[i];
-    }
-    temp = temp / m_shader_config->num_shader();
-    *average_pipeline_duty_cycle = ((*average_pipeline_duty_cycle) + temp);
-    // cout<<"Average pipeline duty cycle:
-    // "<<*average_pipeline_duty_cycle<<endl;
+      temp=temp/m_shader_config->num_shader();
+      *average_pipeline_duty_cycle=((*average_pipeline_duty_cycle)+temp);
+        //cout<<"Average pipeline duty cycle: "<<*average_pipeline_duty_cycle<<endl;
 
-    if (g_single_step &&
-        ((gpu_sim_cycle + gpu_tot_sim_cycle) >= g_single_step)) {
-      raise(SIGTRAP);  // Debug breakpoint
-    }
-    gpu_sim_cycle++;
 
-    if (g_interactive_debugger_enabled) gpgpu_debug();
+      if( g_single_step && ((gpu_sim_cycle+gpu_tot_sim_cycle) >= g_single_step) ) {
+          raise(SIGTRAP); // Debug breakpoint
+      }
+	 gpu_sim_cycle++;
+	
+      if( g_interactive_debugger_enabled ) 
+         gpgpu_debug();
 
-// McPAT main cycle (interface with McPAT)
+      // McPAT main cycle (interface with McPAT)
 #ifdef GPGPUSIM_POWER_MODEL
-    if (m_config.g_power_simulation_enabled) {
-      mcpat_cycle(m_config, getShaderCoreConfig(), m_gpgpusim_wrapper,
-                  m_power_stats, m_config.gpu_stat_sample_freq,
-                  gpu_tot_sim_cycle, gpu_sim_cycle, gpu_tot_sim_insn,
-                  gpu_sim_insn);
-    }
+      if(m_config.g_power_simulation_enabled){
+          mcpat_cycle(m_config, getShaderCoreConfig(), m_gpgpusim_wrapper, m_power_stats, m_config.gpu_stat_sample_freq, gpu_tot_sim_cycle, gpu_sim_cycle, gpu_tot_sim_insn, gpu_sim_insn);
+      }
 #endif
 
-    issue_block2core();
-
-    // Depending on configuration, invalidate the caches once all of threads are
-    // completed.
-    int all_threads_complete = 1;
-    if (m_config.gpgpu_flush_l1_cache) {
-      for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++) {
-        if (m_cluster[i]->get_not_completed() == 0)
-          m_cluster[i]->cache_invalidate();
-        else
-          all_threads_complete = 0;
+      issue_block2core();
+      
+      // Depending on configuration, invalidate the caches once all of threads are completed.
+      int all_threads_complete = 1;
+      if (m_config.gpgpu_flush_l1_cache) {
+         for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) {
+            if (m_cluster[i]->get_not_completed() == 0)
+                m_cluster[i]->cache_invalidate();
+            else
+               all_threads_complete = 0 ;
+         }
       }
-    }
 
-    if (m_config.gpgpu_flush_l2_cache) {
-      if (!m_config.gpgpu_flush_l1_cache) {
-        for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++) {
-          if (m_cluster[i]->get_not_completed() != 0) {
-            all_threads_complete = 0;
-            break;
+      if(m_config.gpgpu_flush_l2_cache){
+          if(!m_config.gpgpu_flush_l1_cache){
+              for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) {
+                  if (m_cluster[i]->get_not_completed() != 0){
+                      all_threads_complete = 0 ;
+                      break;
+                  }
+              }
           }
-        }
+
+         if (all_threads_complete && !m_memory_config->m_L2_config.disabled() ) {
+            printf("Flushed L2 caches...\n");
+            if (m_memory_config->m_L2_config.get_num_lines()) {
+               int dlc = 0;
+               for (unsigned i=0;i<m_memory_config->m_n_mem;i++) {
+                  dlc = m_memory_sub_partition[i]->flushL2();
+                  assert (dlc == 0); // TODO: need to model actual writes to DRAM here
+                  printf("Dirty lines flushed from L2 %d is %d\n", i, dlc  );
+               }
+            }
+         }
       }
 
-      if (all_threads_complete && !m_memory_config->m_L2_config.disabled()) {
-        printf("Flushed L2 caches...\n");
-        if (m_memory_config->m_L2_config.get_num_lines()) {
-          int dlc = 0;
-          for (unsigned i = 0; i < m_memory_config->m_n_mem; i++) {
-            dlc = m_memory_sub_partition[i]->flushL2();
-            assert(dlc == 0);  // TODO: need to model actual writes to DRAM here
-            printf("Dirty lines flushed from L2 %d is %d\n", i, dlc);
-          }
-        }
+      if (!(gpu_sim_cycle % m_config.gpu_stat_sample_freq)) {
+         time_t days, hrs, minutes, sec;
+         time_t curr_time;
+         time(&curr_time);
+         unsigned long long  elapsed_time = MAX(curr_time - gpgpu_ctx->the_gpgpusim->g_simulation_starttime, 1);
+         if ( (elapsed_time - last_liveness_message_time) >= m_config.liveness_message_freq && DTRACE(LIVENESS) ) {
+            days    = elapsed_time/(3600*24);
+            hrs     = elapsed_time/3600 - 24*days;
+            minutes = elapsed_time/60 - 60*(hrs + 24*days);
+            sec = elapsed_time - 60*(minutes + 60*(hrs + 24*days));
+            
+            unsigned long long active = 0, total = 0;
+            for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) {
+                m_cluster[i]->get_current_occupancy(active, total);
+            }
+            DPRINTFG(LIVENESS, "uArch: inst.: %lld (ipc=%4.1f, occ=%0.4f\% [%llu / %llu]) sim_rate=%u (inst/sec) elapsed = %u:%u:%02u:%02u / %s",
+                   gpu_tot_sim_insn + gpu_sim_insn, 
+                   (double)gpu_sim_insn/(double)gpu_sim_cycle,
+                   float(active)/float(total) * 100, active, total,
+                   (unsigned)((gpu_tot_sim_insn+gpu_sim_insn) / elapsed_time),
+                   (unsigned)days,(unsigned)hrs,(unsigned)minutes,(unsigned)sec,
+                   ctime(&curr_time));
+            fflush(stdout);
+            last_liveness_message_time = elapsed_time; 
+         }
+         visualizer_printstat();
+         m_memory_stats->memlatstat_lat_pw();
+         if (m_config.gpgpu_runtime_stat && (m_config.gpu_runtime_stat_flag != 0) ) {
+            if (m_config.gpu_runtime_stat_flag & GPU_RSTAT_BW_STAT) {
+               for (unsigned i=0;i<m_memory_config->m_n_mem;i++) 
+                  m_memory_partition_unit[i]->print_stat(stdout);
+               printf("maxmrqlatency = %d \n", m_memory_stats->max_mrq_latency);
+               printf("maxmflatency = %d \n", m_memory_stats->max_mf_latency);
+            }
+            if (m_config.gpu_runtime_stat_flag & GPU_RSTAT_SHD_INFO) 
+               shader_print_runtime_stat( stdout );
+            if (m_config.gpu_runtime_stat_flag & GPU_RSTAT_L1MISS) 
+               shader_print_l1_miss_stat( stdout );
+            if (m_config.gpu_runtime_stat_flag & GPU_RSTAT_SCHED) 
+               shader_print_scheduler_stat( stdout, false );
+         }
       }
-    }
 
-    if (!(gpu_sim_cycle % m_config.gpu_stat_sample_freq)) {
-      time_t days, hrs, minutes, sec;
-      time_t curr_time;
-      time(&curr_time);
-      unsigned long long elapsed_time =
-          MAX(curr_time - gpgpu_ctx->the_gpgpusim->g_simulation_starttime, 1);
-      if ((elapsed_time - last_liveness_message_time) >=
-              m_config.liveness_message_freq &&
-          DTRACE(LIVENESS)) {
-        days = elapsed_time / (3600 * 24);
-        hrs = elapsed_time / 3600 - 24 * days;
-        minutes = elapsed_time / 60 - 60 * (hrs + 24 * days);
-        sec = elapsed_time - 60 * (minutes + 60 * (hrs + 24 * days));
-
-        unsigned long long active = 0, total = 0;
-        for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++) {
-          m_cluster[i]->get_current_occupancy(active, total);
-        }
-        DPRINTFG(LIVENESS,
-                 "uArch: inst.: %lld (ipc=%4.1f, occ=%0.4f\% [%llu / %llu]) "
-                 "sim_rate=%u (inst/sec) elapsed = %u:%u:%02u:%02u / %s",
-                 gpu_tot_sim_insn + gpu_sim_insn,
-                 (double)gpu_sim_insn / (double)gpu_sim_cycle,
-                 float(active) / float(total) * 100, active, total,
-                 (unsigned)((gpu_tot_sim_insn + gpu_sim_insn) / elapsed_time),
-                 (unsigned)days, (unsigned)hrs, (unsigned)minutes,
-                 (unsigned)sec, ctime(&curr_time));
-        fflush(stdout);
-        last_liveness_message_time = elapsed_time;
+      if (!(gpu_sim_cycle % 50000)) {
+         // deadlock detection 
+         if (m_config.gpu_deadlock_detect && gpu_sim_insn == last_gpu_sim_insn) {
+            gpu_deadlock = true;
+         } else {
+            last_gpu_sim_insn = gpu_sim_insn;
+         }
       }
-      visualizer_printstat();
-      m_memory_stats->memlatstat_lat_pw();
-      if (m_config.gpgpu_runtime_stat &&
-          (m_config.gpu_runtime_stat_flag != 0)) {
-        if (m_config.gpu_runtime_stat_flag & GPU_RSTAT_BW_STAT) {
-          for (unsigned i = 0; i < m_memory_config->m_n_mem; i++)
-            m_memory_partition_unit[i]->print_stat(stdout);
-          printf("maxmrqlatency = %d \n", m_memory_stats->max_mrq_latency);
-          printf("maxmflatency = %d \n", m_memory_stats->max_mf_latency);
-        }
-        if (m_config.gpu_runtime_stat_flag & GPU_RSTAT_SHD_INFO)
-          shader_print_runtime_stat(stdout);
-        if (m_config.gpu_runtime_stat_flag & GPU_RSTAT_L1MISS)
-          shader_print_l1_miss_stat(stdout);
-        if (m_config.gpu_runtime_stat_flag & GPU_RSTAT_SCHED)
-          shader_print_scheduler_stat(stdout, false);
-      }
-    }
-
-    if (!(gpu_sim_cycle % 50000)) {
-      // deadlock detection
-      if (m_config.gpu_deadlock_detect && gpu_sim_insn == last_gpu_sim_insn) {
-        gpu_deadlock = true;
-      } else {
-        last_gpu_sim_insn = gpu_sim_insn;
-      }
-    }
-    try_snap_shot(gpu_sim_cycle);
-    spill_log_to_file(stdout, 0, gpu_sim_cycle);
+      try_snap_shot(gpu_sim_cycle);
+      spill_log_to_file (stdout, 0, gpu_sim_cycle);
 
 #if (CUDART_VERSION >= 5000)
-    // launch device kernel
-    gpgpu_ctx->device_runtime->launch_one_device_kernel();
+      //launch device kernel
+      gpgpu_ctx->device_runtime->launch_one_device_kernel();
 #endif
-  }
+   }
 }
 
-void shader_core_ctx::dump_warp_state(FILE *fout) const {
-  fprintf(fout, "\n");
-  fprintf(fout, "per warp functional simulation status:\n");
-  for (unsigned w = 0; w < m_config->max_warps_per_shader; w++)
-    m_warp[w].print(fout);
+
+void shader_core_ctx::dump_warp_state( FILE *fout ) const
+{
+   fprintf(fout, "\n");
+   fprintf(fout, "per warp functional simulation status:\n");
+   for (unsigned w=0; w < m_config->max_warps_per_shader; w++ ) 
+       m_warp[w].print(fout);
 }
 
-void gpgpu_sim::perf_memcpy_to_gpu(size_t dst_start_addr, size_t count) {
-  if (m_memory_config->m_perf_sim_memcpy) {
-    assert(dst_start_addr % 32 == 0);
 
-    for (unsigned counter = 0; counter < count; counter += 32) {
-      const unsigned wr_addr = dst_start_addr + counter;
-      addrdec_t raw_addr;
-      mem_access_sector_mask_t mask;
-      mask.set(wr_addr % 128 / 32);
-      m_memory_config->m_address_mapping.addrdec_tlx(wr_addr, &raw_addr);
-      const unsigned partition_id =
-          raw_addr.sub_partition /
-          m_memory_config->m_n_sub_partition_per_memory_channel;
-      m_memory_partition_unit[partition_id]->handle_memcpy_to_gpu(
-          wr_addr, raw_addr.sub_partition, mask);
+void gpgpu_sim::perf_memcpy_to_gpu( size_t dst_start_addr, size_t count )
+{
+    if (m_memory_config->m_perf_sim_memcpy) {
+       assert (dst_start_addr % 32 == 0);
+
+       for ( unsigned counter = 0; counter < count; counter += 32 ) {
+           const unsigned wr_addr = dst_start_addr + counter;
+           addrdec_t raw_addr;
+           mem_access_sector_mask_t mask;
+           mask.set(wr_addr % 128 / 32);
+           m_memory_config->m_address_mapping.addrdec_tlx( wr_addr, &raw_addr );
+           const unsigned partition_id = raw_addr.sub_partition / m_memory_config->m_n_sub_partition_per_memory_channel;
+           m_memory_partition_unit[ partition_id ]->handle_memcpy_to_gpu( wr_addr, raw_addr.sub_partition, mask );
+       }
     }
-  }
 }
 
-void gpgpu_sim::dump_pipeline(int mask, int s, int m) const {
-  /*
-     You may want to use this function while running GPGPU-Sim in gdb.
-     One way to do that is add the following to your .gdbinit file:
+void gpgpu_sim::dump_pipeline( int mask, int s, int m ) const
+{
+/*
+   You may want to use this function while running GPGPU-Sim in gdb.
+   One way to do that is add the following to your .gdbinit file:
+ 
+      define dp
+         call g_the_gpu.dump_pipeline_impl((0x40|0x4|0x1),$arg0,0)
+      end
+ 
+   Then, typing "dp 3" will show the contents of the pipeline for shader core 3.
+*/
 
-        define dp
-           call g_the_gpu.dump_pipeline_impl((0x40|0x4|0x1),$arg0,0)
-        end
-
-     Then, typing "dp 3" will show the contents of the pipeline for shader core
-     3.
-  */
-
-  printf("Dumping pipeline state...\n");
-  if (!mask) mask = 0xFFFFFFFF;
-  for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++) {
-    if (s != -1) {
-      i = s;
-    }
-    if (mask & 1)
-      m_cluster[m_shader_config->sid_to_cluster(i)]->display_pipeline(
-          i, stdout, 1, mask & 0x2E);
-    if (s != -1) {
-      break;
-    }
-  }
-  if (mask & 0x10000) {
-    for (unsigned i = 0; i < m_memory_config->m_n_mem; i++) {
-      if (m != -1) {
-        i = m;
+   printf("Dumping pipeline state...\n");
+   if(!mask) mask = 0xFFFFFFFF;
+   for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++) {
+      if(s != -1) {
+         i = s;
       }
-      printf("DRAM / memory controller %u:\n", i);
-      if (mask & 0x100000) m_memory_partition_unit[i]->print_stat(stdout);
-      if (mask & 0x1000000) m_memory_partition_unit[i]->visualize();
-      if (mask & 0x10000000) m_memory_partition_unit[i]->print(stdout);
-      if (m != -1) {
-        break;
+      if(mask&1) m_cluster[m_shader_config->sid_to_cluster(i)]->display_pipeline(i,stdout,1,mask & 0x2E);
+      if(s != -1) {
+         break;
       }
-    }
-  }
-  fflush(stdout);
+   }
+   if(mask&0x10000) {
+      for (unsigned i=0;i<m_memory_config->m_n_mem;i++) {
+         if(m != -1) {
+            i=m;
+         }
+         printf("DRAM / memory controller %u:\n", i);
+         if(mask&0x100000) m_memory_partition_unit[i]->print_stat(stdout);
+         if(mask&0x1000000)   m_memory_partition_unit[i]->visualize();
+         if(mask&0x10000000)   m_memory_partition_unit[i]->print(stdout);
+         if(m != -1) {
+            break;
+         }
+      }
+   }
+   fflush(stdout);
 }
 
-const shader_core_config *gpgpu_sim::getShaderCoreConfig() {
-  return m_shader_config;
+const shader_core_config * gpgpu_sim::getShaderCoreConfig()
+{
+   return m_shader_config;
 }
 
-const memory_config *gpgpu_sim::getMemoryConfig() { return m_memory_config; }
+const memory_config * gpgpu_sim::getMemoryConfig()
+{
+   return m_memory_config;
+}
 
-simt_core_cluster *gpgpu_sim::getSIMTCluster() { return *m_cluster; }
+simt_core_cluster * gpgpu_sim::getSIMTCluster()
+{
+   return *m_cluster;
+}
+

--- a/src/gpgpu-sim/gpu-sim.h
+++ b/src/gpgpu-sim/gpu-sim.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -30,22 +28,24 @@
 #ifndef GPU_SIM_H
 #define GPU_SIM_H
 
-#include <stdio.h>
-#include <fstream>
-#include <iostream>
-#include <list>
-#include "../abstract_hardware_model.h"
 #include "../option_parser.h"
+#include "../abstract_hardware_model.h"
 #include "../trace.h"
 #include "addrdec.h"
-#include "gpu-cache.h"
 #include "shader.h"
+#include "gpu-cache.h"
+#include <iostream>
+#include <fstream>
+#include <list>
+#include <stdio.h>
+
+
 
 // constants for statistics printouts
 #define GPU_RSTAT_SHD_INFO 0x1
-#define GPU_RSTAT_BW_STAT 0x2
+#define GPU_RSTAT_BW_STAT  0x2
 #define GPU_RSTAT_WARP_DIS 0x4
-#define GPU_RSTAT_DWF_MAP 0x8
+#define GPU_RSTAT_DWF_MAP  0x8
 #define GPU_RSTAT_L1MISS 0x10
 #define GPU_RSTAT_PDOM 0x20
 #define GPU_RSTAT_SCHED 0x40
@@ -65,618 +65,584 @@
 
 class gpgpu_context;
 
-extern tr1_hash_map<new_addr_type, unsigned> address_random_interleaving;
+extern tr1_hash_map<new_addr_type,unsigned> address_random_interleaving;
 
-enum dram_ctrl_t { DRAM_FIFO = 0, DRAM_FRFCFS = 1 };
+enum dram_ctrl_t {
+   DRAM_FIFO=0,
+   DRAM_FRFCFS=1
+};
+
+
 
 struct power_config {
-  power_config() { m_valid = true; }
-  void init() {
-    // initialize file name if it is not set
-    time_t curr_time;
-    time(&curr_time);
-    char *date = ctime(&curr_time);
-    char *s = date;
-    while (*s) {
-      if (*s == ' ' || *s == '\t' || *s == ':') *s = '-';
-      if (*s == '\n' || *s == '\r') *s = 0;
-      s++;
-    }
-    char buf1[1024];
-    snprintf(buf1, 1024, "gpgpusim_power_report__%s.log", date);
-    g_power_filename = strdup(buf1);
-    char buf2[1024];
-    snprintf(buf2, 1024, "gpgpusim_power_trace_report__%s.log.gz", date);
-    g_power_trace_filename = strdup(buf2);
-    char buf3[1024];
-    snprintf(buf3, 1024, "gpgpusim_metric_trace_report__%s.log.gz", date);
-    g_metric_trace_filename = strdup(buf3);
-    char buf4[1024];
-    snprintf(buf4, 1024, "gpgpusim_steady_state_tracking_report__%s.log.gz",
-             date);
-    g_steady_state_tracking_filename = strdup(buf4);
+	power_config()
+	{
+		m_valid = true;
+	}
+	void init()
+	{
 
-    if (g_steady_power_levels_enabled) {
-      sscanf(gpu_steady_state_definition, "%lf:%lf",
-             &gpu_steady_power_deviation, &gpu_steady_min_period);
-    }
+        // initialize file name if it is not set
+        time_t curr_time;
+        time(&curr_time);
+        char *date = ctime(&curr_time);
+        char *s = date;
+        while (*s) {
+            if (*s == ' ' || *s == '\t' || *s == ':') *s = '-';
+            if (*s == '\n' || *s == '\r' ) *s = 0;
+            s++;
+        }
+        char buf1[1024];
+        snprintf(buf1,1024,"gpgpusim_power_report__%s.log",date);
+        g_power_filename = strdup(buf1);
+        char buf2[1024];
+        snprintf(buf2,1024,"gpgpusim_power_trace_report__%s.log.gz",date);
+        g_power_trace_filename = strdup(buf2);
+        char buf3[1024];
+        snprintf(buf3,1024,"gpgpusim_metric_trace_report__%s.log.gz",date);
+        g_metric_trace_filename = strdup(buf3);
+        char buf4[1024];
+        snprintf(buf4,1024,"gpgpusim_steady_state_tracking_report__%s.log.gz",date);
+        g_steady_state_tracking_filename = strdup(buf4);
 
-    // NOTE: After changing the nonlinear model to only scaling idle core,
-    // NOTE: The min_inc_per_active_sm is not used any more
-    if (g_use_nonlinear_model)
-      sscanf(gpu_nonlinear_model_config, "%lf:%lf", &gpu_idle_core_power,
-             &gpu_min_inc_per_active_sm);
-  }
-  void reg_options(class OptionParser *opp);
+        if(g_steady_power_levels_enabled){
+            sscanf(gpu_steady_state_definition,"%lf:%lf", &gpu_steady_power_deviation,&gpu_steady_min_period);
+        }
 
-  char *g_power_config_name;
+        //NOTE: After changing the nonlinear model to only scaling idle core,
+        //NOTE: The min_inc_per_active_sm is not used any more
+		if (g_use_nonlinear_model)
+		    sscanf(gpu_nonlinear_model_config,"%lf:%lf", &gpu_idle_core_power,&gpu_min_inc_per_active_sm);
 
-  bool m_valid;
-  bool g_power_simulation_enabled;
-  bool g_power_trace_enabled;
-  bool g_steady_power_levels_enabled;
-  bool g_power_per_cycle_dump;
-  bool g_power_simulator_debug;
-  char *g_power_filename;
-  char *g_power_trace_filename;
-  char *g_metric_trace_filename;
-  char *g_steady_state_tracking_filename;
-  int g_power_trace_zlevel;
-  char *gpu_steady_state_definition;
-  double gpu_steady_power_deviation;
-  double gpu_steady_min_period;
+	}
+	void reg_options(class OptionParser * opp);
 
-  // Nonlinear power model
-  bool g_use_nonlinear_model;
-  char *gpu_nonlinear_model_config;
-  double gpu_idle_core_power;
-  double gpu_min_inc_per_active_sm;
+	char *g_power_config_name;
+
+	bool m_valid;
+    bool g_power_simulation_enabled;
+    bool g_power_trace_enabled;
+    bool g_steady_power_levels_enabled;
+    bool g_power_per_cycle_dump;
+    bool g_power_simulator_debug;
+    char *g_power_filename;
+    char *g_power_trace_filename;
+    char *g_metric_trace_filename;
+    char * g_steady_state_tracking_filename;
+    int g_power_trace_zlevel;
+    char * gpu_steady_state_definition;
+    double gpu_steady_power_deviation;
+    double gpu_steady_min_period;
+
+    //Nonlinear power model
+    bool g_use_nonlinear_model;
+    char * gpu_nonlinear_model_config;
+    double gpu_idle_core_power;
+    double gpu_min_inc_per_active_sm;
+
+
 };
+
 
 class memory_config {
- public:
-  memory_config(gpgpu_context *ctx) {
-    m_valid = false;
-    gpgpu_dram_timing_opt = NULL;
-    gpgpu_L2_queue_config = NULL;
-    gpgpu_ctx = ctx;
-  }
-  void init() {
-    assert(gpgpu_dram_timing_opt);
-    if (strchr(gpgpu_dram_timing_opt, '=') == NULL) {
-      // dram timing option in ordered variables (legacy)
-      // Disabling bank groups if their values are not specified
-      nbkgrp = 1;
-      tCCDL = 0;
-      tRTPL = 0;
-      sscanf(gpgpu_dram_timing_opt, "%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d",
-             &nbk, &tCCD, &tRRD, &tRCD, &tRAS, &tRP, &tRC, &CL, &WL, &tCDLR,
-             &tWR, &nbkgrp, &tCCDL, &tRTPL);
-    } else {
-      // named dram timing options (unordered)
-      option_parser_t dram_opp = option_parser_create();
+    public:
+   memory_config(gpgpu_context* ctx)
+   {
+       m_valid = false;
+       gpgpu_dram_timing_opt=NULL;
+       gpgpu_L2_queue_config=NULL;
+       gpgpu_ctx = ctx;
+   }
+   void init()
+   {
+      assert(gpgpu_dram_timing_opt);
+      if (strchr(gpgpu_dram_timing_opt, '=') == NULL) {
+         // dram timing option in ordered variables (legacy)
+         // Disabling bank groups if their values are not specified
+         nbkgrp = 1;
+         tCCDL = 0;
+         tRTPL = 0;
+         sscanf(gpgpu_dram_timing_opt,"%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d",
+                &nbk,&tCCD,&tRRD,&tRCD,&tRAS,&tRP,&tRC,&CL,&WL,&tCDLR,&tWR,&nbkgrp,&tCCDL,&tRTPL);
+      } else {
+         // named dram timing options (unordered)
+         option_parser_t dram_opp = option_parser_create(); 
 
-      option_parser_register(dram_opp, "nbk", OPT_UINT32, &nbk,
-                             "number of banks", "");
-      option_parser_register(dram_opp, "CCD", OPT_UINT32, &tCCD,
-                             "column to column delay", "");
-      option_parser_register(
-          dram_opp, "RRD", OPT_UINT32, &tRRD,
-          "minimal delay between activation of rows in different banks", "");
-      option_parser_register(dram_opp, "RCD", OPT_UINT32, &tRCD,
-                             "row to column delay", "");
-      option_parser_register(dram_opp, "RAS", OPT_UINT32, &tRAS,
-                             "time needed to activate row", "");
-      option_parser_register(dram_opp, "RP", OPT_UINT32, &tRP,
-                             "time needed to precharge (deactivate) row", "");
-      option_parser_register(dram_opp, "RC", OPT_UINT32, &tRC, "row cycle time",
-                             "");
-      option_parser_register(dram_opp, "CDLR", OPT_UINT32, &tCDLR,
-                             "switching from write to read (changes tWTR)", "");
-      option_parser_register(dram_opp, "WR", OPT_UINT32, &tWR,
-                             "last data-in to row precharge", "");
+         option_parser_register(dram_opp, "nbk",  OPT_UINT32, &nbk,   "number of banks", ""); 
+         option_parser_register(dram_opp, "CCD",  OPT_UINT32, &tCCD,  "column to column delay", ""); 
+         option_parser_register(dram_opp, "RRD",  OPT_UINT32, &tRRD,  "minimal delay between activation of rows in different banks", ""); 
+         option_parser_register(dram_opp, "RCD",  OPT_UINT32, &tRCD,  "row to column delay", ""); 
+         option_parser_register(dram_opp, "RAS",  OPT_UINT32, &tRAS,  "time needed to activate row", ""); 
+         option_parser_register(dram_opp, "RP",   OPT_UINT32, &tRP,   "time needed to precharge (deactivate) row", ""); 
+         option_parser_register(dram_opp, "RC",   OPT_UINT32, &tRC,   "row cycle time", ""); 
+         option_parser_register(dram_opp, "CDLR", OPT_UINT32, &tCDLR, "switching from write to read (changes tWTR)", ""); 
+         option_parser_register(dram_opp, "WR",   OPT_UINT32, &tWR,   "last data-in to row precharge", ""); 
 
-      option_parser_register(dram_opp, "CL", OPT_UINT32, &CL, "CAS latency",
-                             "");
-      option_parser_register(dram_opp, "WL", OPT_UINT32, &WL, "Write latency",
-                             "");
+         option_parser_register(dram_opp, "CL", OPT_UINT32, &CL, "CAS latency", ""); 
+         option_parser_register(dram_opp, "WL", OPT_UINT32, &WL, "Write latency", ""); 
 
-      // Disabling bank groups if their values are not specified
-      option_parser_register(dram_opp, "nbkgrp", OPT_UINT32, &nbkgrp,
-                             "number of bank groups", "1");
-      option_parser_register(
-          dram_opp, "CCDL", OPT_UINT32, &tCCDL,
-          "column to column delay between accesses to different bank groups",
-          "0");
-      option_parser_register(
-          dram_opp, "RTPL", OPT_UINT32, &tRTPL,
-          "read to precharge delay between accesses to different bank groups",
-          "0");
+         //Disabling bank groups if their values are not specified
+         option_parser_register(dram_opp, "nbkgrp", OPT_UINT32, &nbkgrp, "number of bank groups", "1"); 
+         option_parser_register(dram_opp, "CCDL",   OPT_UINT32, &tCCDL,  "column to column delay between accesses to different bank groups", "0"); 
+         option_parser_register(dram_opp, "RTPL",   OPT_UINT32, &tRTPL,  "read to precharge delay between accesses to different bank groups", "0"); 
 
-      option_parser_delimited_string(dram_opp, gpgpu_dram_timing_opt, "=:;");
-      fprintf(stdout, "DRAM Timing Options:\n");
-      option_parser_print(dram_opp, stdout);
-      option_parser_destroy(dram_opp);
-    }
+         option_parser_delimited_string(dram_opp, gpgpu_dram_timing_opt, "=:;"); 
+         fprintf(stdout, "DRAM Timing Options:\n"); 
+         option_parser_print(dram_opp, stdout); 
+         option_parser_destroy(dram_opp); 
+      }
 
-    int nbkt = nbk / nbkgrp;
-    unsigned i;
-    for (i = 0; nbkt > 0; i++) {
-      nbkt = nbkt >> 1;
-    }
-    bk_tag_length = i - 1;
-    assert(nbkgrp > 0 && "Number of bank groups cannot be zero");
-    tRCDWR = tRCD - (WL + 1);
-    if (elimnate_rw_turnaround) {
-      tRTW = 0;
-      tWTR = 0;
-    } else {
-      tRTW = (CL + (BL / data_command_freq_ratio) + 2 - WL);
-      tWTR = (WL + (BL / data_command_freq_ratio) + tCDLR);
-    }
-    tWTP = (WL + (BL / data_command_freq_ratio) + tWR);
-    dram_atom_size = BL * busW * gpu_n_mem_per_ctrlr;  // burst length x bus
-                                                       // width x # chips per
-                                                       // partition
+      int nbkt = nbk/nbkgrp;
+      unsigned i;
+      for (i=0; nbkt>0; i++) {
+          nbkt = nbkt>>1;
+      }
+      bk_tag_length = i-1;
+      assert(nbkgrp>0 && "Number of bank groups cannot be zero");
+      tRCDWR = tRCD-(WL+1);
+      if(elimnate_rw_turnaround)
+      {
+    	  tRTW = 0;
+    	  tWTR = 0;
+      } else {
+      tRTW = (CL+(BL/data_command_freq_ratio)+2-WL);
+      tWTR = (WL+(BL/data_command_freq_ratio)+tCDLR);
+      }
+      tWTP = (WL+(BL/data_command_freq_ratio)+tWR);
+      dram_atom_size = BL * busW * gpu_n_mem_per_ctrlr; // burst length x bus width x # chips per partition 
 
-    assert(m_n_sub_partition_per_memory_channel > 0);
-    assert((nbk % m_n_sub_partition_per_memory_channel == 0) &&
-           "Number of DRAM banks must be a perfect multiple of memory sub "
-           "partition");
-    m_n_mem_sub_partition = m_n_mem * m_n_sub_partition_per_memory_channel;
-    fprintf(stdout, "Total number of memory sub partition = %u\n",
-            m_n_mem_sub_partition);
+      assert( m_n_sub_partition_per_memory_channel > 0 ); 
+      assert( (nbk % m_n_sub_partition_per_memory_channel == 0) 
+              && "Number of DRAM banks must be a perfect multiple of memory sub partition"); 
+      m_n_mem_sub_partition = m_n_mem * m_n_sub_partition_per_memory_channel; 
+      fprintf(stdout, "Total number of memory sub partition = %u\n", m_n_mem_sub_partition); 
 
-    m_address_mapping.init(m_n_mem, m_n_sub_partition_per_memory_channel);
-    m_L2_config.init(&m_address_mapping);
+      m_address_mapping.init(m_n_mem, m_n_sub_partition_per_memory_channel);
+      m_L2_config.init(&m_address_mapping);
 
-    m_valid = true;
+      m_valid = true;
 
-    sscanf(write_queue_size_opt, "%d:%d:%d",
-           &gpgpu_frfcfs_dram_write_queue_size, &write_high_watermark,
-           &write_low_watermark);
-  }
-  void reg_options(class OptionParser *opp);
+      sscanf(write_queue_size_opt,"%d:%d:%d",
+                     &gpgpu_frfcfs_dram_write_queue_size,&write_high_watermark,&write_low_watermark);
+   }
+   void reg_options(class OptionParser * opp);
 
-  bool m_valid;
-  mutable l2_cache_config m_L2_config;
-  bool m_L2_texure_only;
+   bool m_valid;
+   mutable l2_cache_config m_L2_config;
+   bool m_L2_texure_only;
 
-  char *gpgpu_dram_timing_opt;
-  char *gpgpu_L2_queue_config;
-  bool l2_ideal;
-  unsigned gpgpu_frfcfs_dram_sched_queue_size;
-  unsigned gpgpu_dram_return_queue_size;
-  enum dram_ctrl_t scheduler_type;
-  bool gpgpu_memlatency_stat;
-  unsigned m_n_mem;
-  unsigned m_n_sub_partition_per_memory_channel;
-  unsigned m_n_mem_sub_partition;
-  unsigned gpu_n_mem_per_ctrlr;
+   char *gpgpu_dram_timing_opt;
+   char *gpgpu_L2_queue_config;
+   bool l2_ideal;
+   unsigned gpgpu_frfcfs_dram_sched_queue_size;
+   unsigned gpgpu_dram_return_queue_size;
+   enum dram_ctrl_t scheduler_type;
+   bool gpgpu_memlatency_stat;
+   unsigned m_n_mem;
+   unsigned m_n_sub_partition_per_memory_channel;
+   unsigned m_n_mem_sub_partition;
+   unsigned gpu_n_mem_per_ctrlr;
 
-  unsigned rop_latency;
-  unsigned dram_latency;
+   unsigned rop_latency;
+   unsigned dram_latency;
 
-  // DRAM parameters
+   // DRAM parameters
 
-  unsigned tCCDL;  // column to column delay when bank groups are enabled
-  unsigned tRTPL;  // read to precharge delay when bank groups are enabled for
-                   // GDDR5 this is identical to RTPS, if for other DRAM this is
-                   // different, you will need to split them in two
+   unsigned tCCDL;  //column to column delay when bank groups are enabled
+   unsigned tRTPL;  //read to precharge delay when bank groups are enabled for GDDR5 this is identical to RTPS, if for other DRAM this is different, you will need to split them in two
 
-  unsigned tCCD;  // column to column delay
-  unsigned tRRD;  // minimal time required between activation of rows in
-                  // different banks
-  unsigned tRCD;  // row to column delay - time required to activate a row
-                  // before a read
-  unsigned tRCDWR;  // row to column delay for a write command
-  unsigned tRAS;    // time needed to activate row
-  unsigned tRP;     // row precharge ie. deactivate row
-  unsigned
-      tRC;  // row cycle time ie. precharge current, then activate different row
-  unsigned tCDLR;  // Last data-in to Read command (switching from write to
-                   // read)
-  unsigned tWR;  // Last data-in to Row precharge
+   unsigned tCCD;   //column to column delay
+   unsigned tRRD;   //minimal time required between activation of rows in different banks
+   unsigned tRCD;   //row to column delay - time required to activate a row before a read
+   unsigned tRCDWR; //row to column delay for a write command
+   unsigned tRAS;   //time needed to activate row
+   unsigned tRP;    //row precharge ie. deactivate row
+   unsigned tRC;    //row cycle time ie. precharge current, then activate different row
+   unsigned tCDLR;  //Last data-in to Read command (switching from write to read)
+   unsigned tWR;    //Last data-in to Row precharge 
 
-  unsigned CL;    // CAS latency
-  unsigned WL;    // WRITE latency
-  unsigned BL;    // Burst Length in bytes (4 in GDDR3, 8 in GDDR5)
-  unsigned tRTW;  // time to switch from read to write
-  unsigned tWTR;  // time to switch from write to read
-  unsigned tWTP;  // time to switch from write to precharge in the same bank
-  unsigned busW;
+   unsigned CL;     //CAS latency
+   unsigned WL;     //WRITE latency
+   unsigned BL;     //Burst Length in bytes (4 in GDDR3, 8 in GDDR5)
+   unsigned tRTW;   //time to switch from read to write
+   unsigned tWTR;   //time to switch from write to read 
+   unsigned tWTP;   //time to switch from write to precharge in the same bank
+   unsigned busW;
 
-  unsigned nbkgrp;  // number of bank groups (has to be power of 2)
-  unsigned
-      bk_tag_length;  // number of bits that define a bank inside a bank group
+   unsigned nbkgrp; // number of bank groups (has to be power of 2)
+   unsigned bk_tag_length; //number of bits that define a bank inside a bank group
 
-  unsigned nbk;
+   unsigned nbk;
 
-  bool elimnate_rw_turnaround;
+   bool elimnate_rw_turnaround;
 
-  unsigned data_command_freq_ratio;  // frequency ratio between DRAM data bus
-                                     // and command bus (2 for GDDR3, 4 for
-                                     // GDDR5)
-  unsigned
-      dram_atom_size;  // number of bytes transferred per read or write command
+   unsigned data_command_freq_ratio; // frequency ratio between DRAM data bus and command bus (2 for GDDR3, 4 for GDDR5)
+   unsigned dram_atom_size; // number of bytes transferred per read or write command 
 
-  linear_to_raw_address_translation m_address_mapping;
+   linear_to_raw_address_translation m_address_mapping;
 
-  unsigned icnt_flit_size;
+   unsigned icnt_flit_size;
 
-  unsigned dram_bnk_indexing_policy;
-  unsigned dram_bnkgrp_indexing_policy;
-  bool dual_bus_interface;
+   unsigned dram_bnk_indexing_policy;
+   unsigned dram_bnkgrp_indexing_policy;
+   bool dual_bus_interface;
 
-  bool seperate_write_queue_enabled;
-  char *write_queue_size_opt;
-  unsigned gpgpu_frfcfs_dram_write_queue_size;
-  unsigned write_high_watermark;
-  unsigned write_low_watermark;
-  bool m_perf_sim_memcpy;
-  bool simple_dram_model;
+   bool seperate_write_queue_enabled;
+   char *write_queue_size_opt;
+   unsigned gpgpu_frfcfs_dram_write_queue_size;
+   unsigned write_high_watermark;
+   unsigned write_low_watermark;
+   bool m_perf_sim_memcpy;
+   bool simple_dram_model;
 
-  gpgpu_context *gpgpu_ctx;
+   gpgpu_context* gpgpu_ctx;
 };
+
 
 extern bool g_interactive_debugger_enabled;
 
-class gpgpu_sim_config : public power_config,
-                         public gpgpu_functional_sim_config {
- public:
-  gpgpu_sim_config(gpgpu_context *ctx)
-      : m_shader_config(ctx), m_memory_config(ctx) {
-    m_valid = false;
-    gpgpu_ctx = ctx;
-  }
-  void reg_options(class OptionParser *opp);
-  void init() {
-    gpu_stat_sample_freq = 10000;
-    gpu_runtime_stat_flag = 0;
-    sscanf(gpgpu_runtime_stat, "%d:%x", &gpu_stat_sample_freq,
-           &gpu_runtime_stat_flag);
-    m_shader_config.init();
-    ptx_set_tex_cache_linesize(m_shader_config.m_L1T_config.get_line_sz());
-    m_memory_config.init();
-    init_clock_domains();
-    power_config::init();
-    Trace::init();
-
-    // initialize file name if it is not set
-    time_t curr_time;
-    time(&curr_time);
-    char *date = ctime(&curr_time);
-    char *s = date;
-    while (*s) {
-      if (*s == ' ' || *s == '\t' || *s == ':') *s = '-';
-      if (*s == '\n' || *s == '\r') *s = 0;
-      s++;
+class gpgpu_sim_config : public power_config, public gpgpu_functional_sim_config {
+public:
+    gpgpu_sim_config(gpgpu_context* ctx): m_shader_config(ctx), m_memory_config(ctx) {
+	m_valid = false;
+	gpgpu_ctx = ctx;
     }
-    char buf[1024];
-    snprintf(buf, 1024, "gpgpusim_visualizer__%s.log.gz", date);
-    g_visualizer_filename = strdup(buf);
+    void reg_options(class OptionParser * opp);
+    void init() 
+    {
+        gpu_stat_sample_freq = 10000;
+        gpu_runtime_stat_flag = 0;
+        sscanf(gpgpu_runtime_stat, "%d:%x", &gpu_stat_sample_freq, &gpu_runtime_stat_flag);
+        m_shader_config.init();
+        ptx_set_tex_cache_linesize(m_shader_config.m_L1T_config.get_line_sz());
+        m_memory_config.init();
+        init_clock_domains(); 
+        power_config::init();
+        Trace::init();
 
-    m_valid = true;
-  }
 
-  unsigned num_shader() const { return m_shader_config.num_shader(); }
-  unsigned num_cluster() const { return m_shader_config.n_simt_clusters; }
-  unsigned get_max_concurrent_kernel() const { return max_concurrent_kernel; }
-  unsigned checkpoint_option;
+        // initialize file name if it is not set 
+        time_t curr_time;
+        time(&curr_time);
+        char *date = ctime(&curr_time);
+        char *s = date;
+        while (*s) {
+            if (*s == ' ' || *s == '\t' || *s == ':') *s = '-';
+            if (*s == '\n' || *s == '\r' ) *s = 0;
+            s++;
+        }
+        char buf[1024];
+        snprintf(buf,1024,"gpgpusim_visualizer__%s.log.gz",date);
+        g_visualizer_filename = strdup(buf);
 
-  size_t stack_limit() const { return stack_size_limit; }
-  size_t heap_limit() const { return heap_size_limit; }
-  size_t sync_depth_limit() const { return runtime_sync_depth_limit; }
-  size_t pending_launch_count_limit() const {
-    return runtime_pending_launch_count_limit;
-  }
+        m_valid=true;
+    }
 
- private:
-  void init_clock_domains(void);
+    unsigned num_shader() const { return m_shader_config.num_shader(); }
+    unsigned num_cluster() const { return m_shader_config.n_simt_clusters; }
+    unsigned get_max_concurrent_kernel() const { return max_concurrent_kernel; }
+    unsigned checkpoint_option;
 
-  // backward pointer
-  class gpgpu_context *gpgpu_ctx;
-  bool m_valid;
-  shader_core_config m_shader_config;
-  memory_config m_memory_config;
-  // clock domains - frequency
-  double core_freq;
-  double icnt_freq;
-  double dram_freq;
-  double l2_freq;
-  double core_period;
-  double icnt_period;
-  double dram_period;
-  double l2_period;
+    size_t stack_limit() const {return stack_size_limit; }
+    size_t heap_limit() const {return heap_size_limit; }
+    size_t sync_depth_limit() const {return runtime_sync_depth_limit; }
+    size_t pending_launch_count_limit() const {return runtime_pending_launch_count_limit;}
 
-  // GPGPU-Sim timing model options
-  unsigned long long gpu_max_cycle_opt;
-  unsigned long long gpu_max_insn_opt;
-  unsigned gpu_max_cta_opt;
-  char *gpgpu_runtime_stat;
-  bool gpgpu_flush_l1_cache;
-  bool gpgpu_flush_l2_cache;
-  bool gpu_deadlock_detect;
-  int gpgpu_frfcfs_dram_sched_queue_size;
-  int gpgpu_cflog_interval;
-  char *gpgpu_clock_domains;
-  unsigned max_concurrent_kernel;
+private:
+    void init_clock_domains(void ); 
 
-  // visualizer
-  bool g_visualizer_enabled;
-  char *g_visualizer_filename;
-  int g_visualizer_zlevel;
 
-  // statistics collection
-  int gpu_stat_sample_freq;
-  int gpu_runtime_stat_flag;
+    // backward pointer
+    class gpgpu_context* gpgpu_ctx;
+    bool m_valid;
+    shader_core_config m_shader_config;
+    memory_config m_memory_config;
+    // clock domains - frequency
+    double core_freq;
+    double icnt_freq;
+    double dram_freq;
+    double l2_freq;
+    double core_period;
+    double icnt_period;
+    double dram_period;
+    double l2_period;
 
-  // Device Limits
-  size_t stack_size_limit;
-  size_t heap_size_limit;
-  size_t runtime_sync_depth_limit;
-  size_t runtime_pending_launch_count_limit;
+    // GPGPU-Sim timing model options
+    unsigned long long gpu_max_cycle_opt;
+    unsigned long long gpu_max_insn_opt;
+    unsigned gpu_max_cta_opt;
+    char *gpgpu_runtime_stat;
+    bool  gpgpu_flush_l1_cache;
+    bool  gpgpu_flush_l2_cache;
+    bool  gpu_deadlock_detect;
+    int   gpgpu_frfcfs_dram_sched_queue_size; 
+    int   gpgpu_cflog_interval;
+    char * gpgpu_clock_domains;
+    unsigned max_concurrent_kernel;
 
-  // gpu compute capability options
-  unsigned int gpgpu_compute_capability_major;
-  unsigned int gpgpu_compute_capability_minor;
-  unsigned long long liveness_message_freq;
+    // visualizer
+    bool  g_visualizer_enabled;
+    char *g_visualizer_filename;
+    int   g_visualizer_zlevel;
 
-  friend class gpgpu_sim;
+
+    // statistics collection
+    int gpu_stat_sample_freq;
+    int gpu_runtime_stat_flag;
+
+    // Device Limits
+    size_t stack_size_limit;
+    size_t heap_size_limit;
+    size_t runtime_sync_depth_limit;
+    size_t runtime_pending_launch_count_limit;	
+
+ //gpu compute capability options
+    unsigned int gpgpu_compute_capability_major;
+    unsigned int gpgpu_compute_capability_minor;
+    unsigned long long liveness_message_freq; 
+
+    friend class gpgpu_sim;
 };
 
 struct occupancy_stats {
-  occupancy_stats()
-      : aggregate_warp_slot_filled(0), aggregate_theoretical_warp_slots(0) {}
-  occupancy_stats(unsigned long long wsf, unsigned long long tws)
-      : aggregate_warp_slot_filled(wsf),
-        aggregate_theoretical_warp_slots(tws) {}
+    occupancy_stats() : aggregate_warp_slot_filled(0), aggregate_theoretical_warp_slots(0){}
+    occupancy_stats( unsigned long long wsf, unsigned long long tws )
+        : aggregate_warp_slot_filled(wsf), aggregate_theoretical_warp_slots(tws){}
 
-  unsigned long long aggregate_warp_slot_filled;
-  unsigned long long aggregate_theoretical_warp_slots;
+    unsigned long long aggregate_warp_slot_filled;
+    unsigned long long aggregate_theoretical_warp_slots;
 
-  float get_occ_fraction() const {
-    return float(aggregate_warp_slot_filled) /
-           float(aggregate_theoretical_warp_slots);
-  }
+    float get_occ_fraction() const {
+        return float(aggregate_warp_slot_filled) / float(aggregate_theoretical_warp_slots);
+    }
 
-  occupancy_stats &operator+=(const occupancy_stats &rhs) {
-    aggregate_warp_slot_filled += rhs.aggregate_warp_slot_filled;
-    aggregate_theoretical_warp_slots += rhs.aggregate_theoretical_warp_slots;
-    return *this;
-  }
+    occupancy_stats& operator+=(const occupancy_stats& rhs) {
+        aggregate_warp_slot_filled += rhs.aggregate_warp_slot_filled;
+        aggregate_theoretical_warp_slots += rhs.aggregate_theoretical_warp_slots;
+        return *this;
+    }
 
-  occupancy_stats operator+(const occupancy_stats &rhs) const {
-    return occupancy_stats(
-        aggregate_warp_slot_filled + rhs.aggregate_warp_slot_filled,
-        aggregate_theoretical_warp_slots +
-            rhs.aggregate_theoretical_warp_slots);
-  }
+    occupancy_stats operator+(const occupancy_stats& rhs) const{
+        return occupancy_stats( aggregate_warp_slot_filled + rhs.aggregate_warp_slot_filled,
+                                aggregate_theoretical_warp_slots + rhs.aggregate_theoretical_warp_slots
+                               );
+    }
 };
 
 class gpgpu_context;
 class ptx_instruction;
 
 class watchpoint_event {
- public:
-  watchpoint_event() {
-    m_thread = NULL;
-    m_inst = NULL;
-  }
-  watchpoint_event(const ptx_thread_info *thd, const ptx_instruction *pI) {
-    m_thread = thd;
-    m_inst = pI;
-  }
-  const ptx_thread_info *thread() const { return m_thread; }
-  const ptx_instruction *inst() const { return m_inst; }
-
- private:
-  const ptx_thread_info *m_thread;
-  const ptx_instruction *m_inst;
+public:
+   watchpoint_event()
+   {
+      m_thread=NULL;
+      m_inst=NULL;
+   }
+   watchpoint_event(const ptx_thread_info *thd, const ptx_instruction *pI)
+   {
+      m_thread=thd;
+      m_inst = pI;
+   }
+   const ptx_thread_info *thread() const { return m_thread; }
+   const ptx_instruction *inst() const { return m_inst; }
+private:
+   const ptx_thread_info *m_thread;
+   const ptx_instruction *m_inst;
 };
 
 class gpgpu_sim : public gpgpu_t {
- public:
-  gpgpu_sim(const gpgpu_sim_config &config, gpgpu_context *ctx);
+public:
+   gpgpu_sim( const gpgpu_sim_config &config, gpgpu_context* ctx );
 
-  void set_prop(struct cudaDeviceProp *prop);
+   void set_prop( struct cudaDeviceProp *prop );
 
-  void launch(kernel_info_t *kinfo);
-  bool can_start_kernel();
-  unsigned finished_kernel();
-  void set_kernel_done(kernel_info_t *kernel);
-  void stop_all_running_kernels();
+   void launch( kernel_info_t *kinfo );
+   bool can_start_kernel();
+   unsigned finished_kernel();
+   void set_kernel_done( kernel_info_t *kernel );
+   void stop_all_running_kernels();
 
-  void init();
-  void cycle();
-  bool active();
-  bool cycle_insn_cta_max_hit() {
-    return (m_config.gpu_max_cycle_opt &&
-            (gpu_tot_sim_cycle + gpu_sim_cycle) >=
-                m_config.gpu_max_cycle_opt) ||
-           (m_config.gpu_max_insn_opt &&
-            (gpu_tot_sim_insn + gpu_sim_insn) >= m_config.gpu_max_insn_opt) ||
-           (m_config.gpu_max_cta_opt &&
-            (gpu_tot_issued_cta >= m_config.gpu_max_cta_opt));
-  }
-  void print_stats();
-  void update_stats();
-  void deadlock_check();
+   void init();
+   void cycle();
+   bool active(); 
+   bool cycle_insn_cta_max_hit() {
+       return (m_config.gpu_max_cycle_opt && (gpu_tot_sim_cycle + gpu_sim_cycle) >= m_config.gpu_max_cycle_opt) ||
+           (m_config.gpu_max_insn_opt && (gpu_tot_sim_insn + gpu_sim_insn) >= m_config.gpu_max_insn_opt) ||
+           (m_config.gpu_max_cta_opt && (gpu_tot_issued_cta >= m_config.gpu_max_cta_opt) );
+   }
+   void print_stats();
+   void update_stats();
+   void deadlock_check();
 
-  void get_pdom_stack_top_info(unsigned sid, unsigned tid, unsigned *pc,
-                               unsigned *rpc);
+   void get_pdom_stack_top_info( unsigned sid, unsigned tid, unsigned *pc, unsigned *rpc );
 
-  int shared_mem_size() const;
-  int shared_mem_per_block() const;
-  int compute_capability_major() const;
-  int compute_capability_minor() const;
-  int num_registers_per_core() const;
-  int num_registers_per_block() const;
-  int wrp_size() const;
-  int shader_clock() const;
-  int max_cta_per_core() const;
-  int get_max_cta(const kernel_info_t &k) const;
-  const struct cudaDeviceProp *get_prop() const;
-  enum divergence_support_t simd_model() const;
+   int shared_mem_size() const;
+   int shared_mem_per_block() const;
+   int compute_capability_major() const;
+   int compute_capability_minor() const;
+   int num_registers_per_core() const;
+   int num_registers_per_block() const;
+   int wrp_size() const;
+   int shader_clock() const;
+   int max_cta_per_core() const;
+   int get_max_cta( const kernel_info_t &k ) const;
+   const struct cudaDeviceProp *get_prop() const;
+   enum divergence_support_t simd_model() const; 
 
-  unsigned threads_per_core() const;
-  bool get_more_cta_left() const;
-  bool kernel_more_cta_left(kernel_info_t *kernel) const;
-  bool hit_max_cta_count() const;
-  kernel_info_t *select_kernel();
+   unsigned threads_per_core() const;
+   bool get_more_cta_left() const;
+   bool kernel_more_cta_left(kernel_info_t *kernel) const;
+   bool hit_max_cta_count() const;
+   kernel_info_t *select_kernel();
 
-  const gpgpu_sim_config &get_config() const { return m_config; }
-  void gpu_print_stat();
-  void dump_pipeline(int mask, int s, int m) const;
+   const gpgpu_sim_config &get_config() const { return m_config; }
+   void gpu_print_stat();
+   void dump_pipeline( int mask, int s, int m ) const;
 
-  void perf_memcpy_to_gpu(size_t dst_start_addr, size_t count);
+    void perf_memcpy_to_gpu( size_t dst_start_addr, size_t count );
 
-  // The next three functions added to be used by the functional simulation
-  // function
+   //The next three functions added to be used by the functional simulation function
+   
+   //! Get shader core configuration
+   /*!
+    * Returning the configuration of the shader core, used by the functional simulation only so far
+    */
+   const shader_core_config * getShaderCoreConfig();
+   
+   
+   //! Get shader core Memory Configuration
+    /*!
+    * Returning the memory configuration of the shader core, used by the functional simulation only so far
+    */
+   const memory_config * getMemoryConfig();
+   
+   
+   //! Get shader core SIMT cluster
+   /*!
+    * Returning the cluster of of the shader core, used by the functional simulation so far
+    */
+    simt_core_cluster * getSIMTCluster();
 
-  //! Get shader core configuration
-  /*!
-   * Returning the configuration of the shader core, used by the functional
-   * simulation only so far
-   */
-  const shader_core_config *getShaderCoreConfig();
+    void hit_watchpoint( unsigned watchpoint_num, ptx_thread_info *thd, const ptx_instruction *pI );
 
-  //! Get shader core Memory Configuration
-  /*!
-  * Returning the memory configuration of the shader core, used by the
-  * functional simulation only so far
-  */
-  const memory_config *getMemoryConfig();
+    // backward pointer
+    class gpgpu_context* gpgpu_ctx;
 
-  //! Get shader core SIMT cluster
-  /*!
-   * Returning the cluster of of the shader core, used by the functional
-   * simulation so far
-   */
-  simt_core_cluster *getSIMTCluster();
+private:
+   // clocks
+   void reinit_clock_domains(void);
+   int  next_clock_domain(void);
+   void issue_block2core();
+   void print_dram_stats(FILE *fout) const;
+   void shader_print_runtime_stat( FILE *fout );
+   void shader_print_l1_miss_stat( FILE *fout ) const;
+   void shader_print_cache_stats( FILE *fout ) const;
+   void shader_print_scheduler_stat( FILE* fout, bool print_dynamic_info ) const;
+   void visualizer_printstat();
+   void print_shader_cycle_distro( FILE *fout ) const;
 
-  void hit_watchpoint(unsigned watchpoint_num, ptx_thread_info *thd,
-                      const ptx_instruction *pI);
+   void gpgpu_debug();
 
-  // backward pointer
-  class gpgpu_context *gpgpu_ctx;
+///// data /////
 
- private:
-  // clocks
-  void reinit_clock_domains(void);
-  int next_clock_domain(void);
-  void issue_block2core();
-  void print_dram_stats(FILE *fout) const;
-  void shader_print_runtime_stat(FILE *fout);
-  void shader_print_l1_miss_stat(FILE *fout) const;
-  void shader_print_cache_stats(FILE *fout) const;
-  void shader_print_scheduler_stat(FILE *fout, bool print_dynamic_info) const;
-  void visualizer_printstat();
-  void print_shader_cycle_distro(FILE *fout) const;
+   class simt_core_cluster **m_cluster;
+   class memory_partition_unit **m_memory_partition_unit;
+   class memory_sub_partition **m_memory_sub_partition;
 
-  void gpgpu_debug();
+   std::vector<kernel_info_t*> m_running_kernels;
+   unsigned m_last_issued_kernel;
 
-  ///// data /////
+   std::list<unsigned> m_finished_kernel;
+   // m_total_cta_launched == per-kernel count. gpu_tot_issued_cta == global count.
+   unsigned long long m_total_cta_launched;
+   unsigned long long gpu_tot_issued_cta;
 
-  class simt_core_cluster **m_cluster;
-  class memory_partition_unit **m_memory_partition_unit;
-  class memory_sub_partition **m_memory_sub_partition;
+   unsigned m_last_cluster_issue;
+   float * average_pipeline_duty_cycle;
+   float * active_sms;
+   // time of next rising edge 
+   double core_time;
+   double icnt_time;
+   double dram_time;
+   double l2_time;
 
-  std::vector<kernel_info_t *> m_running_kernels;
-  unsigned m_last_issued_kernel;
+   // debug
+   bool gpu_deadlock;
 
-  std::list<unsigned> m_finished_kernel;
-  // m_total_cta_launched == per-kernel count. gpu_tot_issued_cta == global
-  // count.
-  unsigned long long m_total_cta_launched;
-  unsigned long long gpu_tot_issued_cta;
+   //// configuration parameters ////
+   const gpgpu_sim_config &m_config;
+  
+   const struct cudaDeviceProp     *m_cuda_properties;
+   const shader_core_config *m_shader_config;
+   const memory_config      *m_memory_config;
 
-  unsigned m_last_cluster_issue;
-  float *average_pipeline_duty_cycle;
-  float *active_sms;
-  // time of next rising edge
-  double core_time;
-  double icnt_time;
-  double dram_time;
-  double l2_time;
+   // stats
+   class shader_core_stats  *m_shader_stats;
+   class memory_stats_t     *m_memory_stats;
+   class power_stat_t *m_power_stats;
+   class gpgpu_sim_wrapper *m_gpgpusim_wrapper;
+   unsigned long long  last_gpu_sim_insn;
 
-  // debug
-  bool gpu_deadlock;
+   unsigned long long  last_liveness_message_time; 
 
-  //// configuration parameters ////
-  const gpgpu_sim_config &m_config;
+   std::map<std::string, FuncCache> m_special_cache_config;
 
-  const struct cudaDeviceProp *m_cuda_properties;
-  const shader_core_config *m_shader_config;
-  const memory_config *m_memory_config;
+   std::vector<std::string> m_executed_kernel_names; //< names of kernel for stat printout 
+   std::vector<unsigned> m_executed_kernel_uids; //< uids of kernel launches for stat printout
+   std::map<unsigned,watchpoint_event> g_watchpoint_hits;
 
-  // stats
-  class shader_core_stats *m_shader_stats;
-  class memory_stats_t *m_memory_stats;
-  class power_stat_t *m_power_stats;
-  class gpgpu_sim_wrapper *m_gpgpusim_wrapper;
-  unsigned long long last_gpu_sim_insn;
+   std::string executed_kernel_info_string(); //< format the kernel information into a string for stat printout
+   void clear_executed_kernel_info(); //< clear the kernel information after stat printout
 
-  unsigned long long last_liveness_message_time;
 
-  std::map<std::string, FuncCache> m_special_cache_config;
+public:
+   unsigned long long  gpu_sim_insn;
+   unsigned long long  gpu_tot_sim_insn;
+   unsigned long long  gpu_sim_insn_last_update;
+   unsigned gpu_sim_insn_last_update_sid;
+   occupancy_stats gpu_occupancy;
+   occupancy_stats gpu_tot_occupancy;
 
-  std::vector<std::string>
-      m_executed_kernel_names;  //< names of kernel for stat printout
-  std::vector<unsigned>
-      m_executed_kernel_uids;  //< uids of kernel launches for stat printout
-  std::map<unsigned, watchpoint_event> g_watchpoint_hits;
+   // performance counter for stalls due to congestion.
+   unsigned int gpu_stall_dramfull;
+   unsigned int gpu_stall_icnt2sh;
+   unsigned long long partiton_reqs_in_parallel;
+   unsigned long long partiton_reqs_in_parallel_total;
+   unsigned long long partiton_reqs_in_parallel_util;
+   unsigned long long partiton_reqs_in_parallel_util_total;
+   unsigned long long  gpu_sim_cycle_parition_util;
+   unsigned long long  gpu_tot_sim_cycle_parition_util;
+   unsigned long long partiton_replys_in_parallel;
+   unsigned long long partiton_replys_in_parallel_total;
 
-  std::string executed_kernel_info_string();  //< format the kernel information
-                                              //into a string for stat printout
-  void clear_executed_kernel_info();  //< clear the kernel information after
-                                      //stat printout
 
- public:
-  unsigned long long gpu_sim_insn;
-  unsigned long long gpu_tot_sim_insn;
-  unsigned long long gpu_sim_insn_last_update;
-  unsigned gpu_sim_insn_last_update_sid;
-  occupancy_stats gpu_occupancy;
-  occupancy_stats gpu_tot_occupancy;
+   FuncCache get_cache_config(std::string kernel_name);
+   void set_cache_config(std::string kernel_name, FuncCache cacheConfig );
+   bool has_special_cache_config(std::string kernel_name);
+   void change_cache_config(FuncCache cache_config);
+   void set_cache_config(std::string kernel_name);
 
-  // performance counter for stalls due to congestion.
-  unsigned int gpu_stall_dramfull;
-  unsigned int gpu_stall_icnt2sh;
-  unsigned long long partiton_reqs_in_parallel;
-  unsigned long long partiton_reqs_in_parallel_total;
-  unsigned long long partiton_reqs_in_parallel_util;
-  unsigned long long partiton_reqs_in_parallel_util_total;
-  unsigned long long gpu_sim_cycle_parition_util;
-  unsigned long long gpu_tot_sim_cycle_parition_util;
-  unsigned long long partiton_replys_in_parallel;
-  unsigned long long partiton_replys_in_parallel_total;
+   //Jin: functional simulation for CDP
+private:
+   //set by stream operation every time a functoinal simulation is done
+   bool m_functional_sim;
+   kernel_info_t * m_functional_sim_kernel;
 
-  FuncCache get_cache_config(std::string kernel_name);
-  void set_cache_config(std::string kernel_name, FuncCache cacheConfig);
-  bool has_special_cache_config(std::string kernel_name);
-  void change_cache_config(FuncCache cache_config);
-  void set_cache_config(std::string kernel_name);
-
-  // Jin: functional simulation for CDP
- private:
-  // set by stream operation every time a functoinal simulation is done
-  bool m_functional_sim;
-  kernel_info_t *m_functional_sim_kernel;
-
- public:
-  bool is_functional_sim() { return m_functional_sim; }
-  kernel_info_t *get_functional_kernel() { return m_functional_sim_kernel; }
-  void functional_launch(kernel_info_t *k) {
-    m_functional_sim = true;
-    m_functional_sim_kernel = k;
-  }
-  void finish_functional_sim(kernel_info_t *k) {
-    assert(m_functional_sim);
-    assert(m_functional_sim_kernel == k);
-    m_functional_sim = false;
-    m_functional_sim_kernel = NULL;
-  }
+public:
+   bool is_functional_sim() { return m_functional_sim; }
+   kernel_info_t * get_functional_kernel() { return m_functional_sim_kernel; }
+   void functional_launch(kernel_info_t * k) {
+     m_functional_sim = true;
+     m_functional_sim_kernel = k;
+   }
+   void finish_functional_sim(kernel_info_t * k) {
+     assert(m_functional_sim);
+     assert(m_functional_sim_kernel == k);
+     m_functional_sim = false;
+     m_functional_sim_kernel = NULL;
+   }
 };
+
 
 #endif

--- a/src/gpgpu-sim/gpu-sim.h
+++ b/src/gpgpu-sim/gpu-sim.h
@@ -264,11 +264,11 @@ class memory_config {
                    // GDDR5 this is identical to RTPS, if for other DRAM this is
                    // different, you will need to split them in two
 
-  unsigned tCCD;    // column to column delay
-  unsigned tRRD;    // minimal time required between activation of rows in
-                    // different banks
-  unsigned tRCD;    // row to column delay - time required to activate a row
-                    // before a read
+  unsigned tCCD;  // column to column delay
+  unsigned tRRD;  // minimal time required between activation of rows in
+                  // different banks
+  unsigned tRCD;  // row to column delay - time required to activate a row
+                  // before a read
   unsigned tRCDWR;  // row to column delay for a write command
   unsigned tRAS;    // time needed to activate row
   unsigned tRP;     // row precharge ie. deactivate row
@@ -276,7 +276,7 @@ class memory_config {
       tRC;  // row cycle time ie. precharge current, then activate different row
   unsigned tCDLR;  // Last data-in to Read command (switching from write to
                    // read)
-  unsigned tWR;    // Last data-in to Row precharge
+  unsigned tWR;  // Last data-in to Row precharge
 
   unsigned CL;    // CAS latency
   unsigned WL;    // WRITE latency
@@ -628,9 +628,9 @@ class gpgpu_sim : public gpgpu_t {
   std::map<unsigned, watchpoint_event> g_watchpoint_hits;
 
   std::string executed_kernel_info_string();  //< format the kernel information
-                                              // into a string for stat printout
+                                              //into a string for stat printout
   void clear_executed_kernel_info();  //< clear the kernel information after
-                                      // stat printout
+                                      //stat printout
 
  public:
   unsigned long long gpu_sim_insn;

--- a/src/gpgpu-sim/gpu-sim.h
+++ b/src/gpgpu-sim/gpu-sim.h
@@ -264,11 +264,11 @@ class memory_config {
                    // GDDR5 this is identical to RTPS, if for other DRAM this is
                    // different, you will need to split them in two
 
-  unsigned tCCD;  // column to column delay
-  unsigned tRRD;  // minimal time required between activation of rows in
-                  // different banks
-  unsigned tRCD;  // row to column delay - time required to activate a row
-                  // before a read
+  unsigned tCCD;    // column to column delay
+  unsigned tRRD;    // minimal time required between activation of rows in
+                    // different banks
+  unsigned tRCD;    // row to column delay - time required to activate a row
+                    // before a read
   unsigned tRCDWR;  // row to column delay for a write command
   unsigned tRAS;    // time needed to activate row
   unsigned tRP;     // row precharge ie. deactivate row
@@ -276,7 +276,7 @@ class memory_config {
       tRC;  // row cycle time ie. precharge current, then activate different row
   unsigned tCDLR;  // Last data-in to Read command (switching from write to
                    // read)
-  unsigned tWR;  // Last data-in to Row precharge
+  unsigned tWR;    // Last data-in to Row precharge
 
   unsigned CL;    // CAS latency
   unsigned WL;    // WRITE latency
@@ -628,9 +628,9 @@ class gpgpu_sim : public gpgpu_t {
   std::map<unsigned, watchpoint_event> g_watchpoint_hits;
 
   std::string executed_kernel_info_string();  //< format the kernel information
-                                              //into a string for stat printout
+                                              // into a string for stat printout
   void clear_executed_kernel_info();  //< clear the kernel information after
-                                      //stat printout
+                                      // stat printout
 
  public:
   unsigned long long gpu_sim_insn;

--- a/src/gpgpu-sim/gpu-sim.h
+++ b/src/gpgpu-sim/gpu-sim.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -28,24 +30,22 @@
 #ifndef GPU_SIM_H
 #define GPU_SIM_H
 
-#include "../option_parser.h"
+#include <stdio.h>
+#include <fstream>
+#include <iostream>
+#include <list>
 #include "../abstract_hardware_model.h"
+#include "../option_parser.h"
 #include "../trace.h"
 #include "addrdec.h"
-#include "shader.h"
 #include "gpu-cache.h"
-#include <iostream>
-#include <fstream>
-#include <list>
-#include <stdio.h>
-
-
+#include "shader.h"
 
 // constants for statistics printouts
 #define GPU_RSTAT_SHD_INFO 0x1
-#define GPU_RSTAT_BW_STAT  0x2
+#define GPU_RSTAT_BW_STAT 0x2
 #define GPU_RSTAT_WARP_DIS 0x4
-#define GPU_RSTAT_DWF_MAP  0x8
+#define GPU_RSTAT_DWF_MAP 0x8
 #define GPU_RSTAT_L1MISS 0x10
 #define GPU_RSTAT_PDOM 0x20
 #define GPU_RSTAT_SCHED 0x40
@@ -65,584 +65,618 @@
 
 class gpgpu_context;
 
-extern tr1_hash_map<new_addr_type,unsigned> address_random_interleaving;
+extern tr1_hash_map<new_addr_type, unsigned> address_random_interleaving;
 
-enum dram_ctrl_t {
-   DRAM_FIFO=0,
-   DRAM_FRFCFS=1
-};
-
-
+enum dram_ctrl_t { DRAM_FIFO = 0, DRAM_FRFCFS = 1 };
 
 struct power_config {
-	power_config()
-	{
-		m_valid = true;
-	}
-	void init()
-	{
+  power_config() { m_valid = true; }
+  void init() {
+    // initialize file name if it is not set
+    time_t curr_time;
+    time(&curr_time);
+    char *date = ctime(&curr_time);
+    char *s = date;
+    while (*s) {
+      if (*s == ' ' || *s == '\t' || *s == ':') *s = '-';
+      if (*s == '\n' || *s == '\r') *s = 0;
+      s++;
+    }
+    char buf1[1024];
+    snprintf(buf1, 1024, "gpgpusim_power_report__%s.log", date);
+    g_power_filename = strdup(buf1);
+    char buf2[1024];
+    snprintf(buf2, 1024, "gpgpusim_power_trace_report__%s.log.gz", date);
+    g_power_trace_filename = strdup(buf2);
+    char buf3[1024];
+    snprintf(buf3, 1024, "gpgpusim_metric_trace_report__%s.log.gz", date);
+    g_metric_trace_filename = strdup(buf3);
+    char buf4[1024];
+    snprintf(buf4, 1024, "gpgpusim_steady_state_tracking_report__%s.log.gz",
+             date);
+    g_steady_state_tracking_filename = strdup(buf4);
 
-        // initialize file name if it is not set
-        time_t curr_time;
-        time(&curr_time);
-        char *date = ctime(&curr_time);
-        char *s = date;
-        while (*s) {
-            if (*s == ' ' || *s == '\t' || *s == ':') *s = '-';
-            if (*s == '\n' || *s == '\r' ) *s = 0;
-            s++;
-        }
-        char buf1[1024];
-        snprintf(buf1,1024,"gpgpusim_power_report__%s.log",date);
-        g_power_filename = strdup(buf1);
-        char buf2[1024];
-        snprintf(buf2,1024,"gpgpusim_power_trace_report__%s.log.gz",date);
-        g_power_trace_filename = strdup(buf2);
-        char buf3[1024];
-        snprintf(buf3,1024,"gpgpusim_metric_trace_report__%s.log.gz",date);
-        g_metric_trace_filename = strdup(buf3);
-        char buf4[1024];
-        snprintf(buf4,1024,"gpgpusim_steady_state_tracking_report__%s.log.gz",date);
-        g_steady_state_tracking_filename = strdup(buf4);
+    if (g_steady_power_levels_enabled) {
+      sscanf(gpu_steady_state_definition, "%lf:%lf",
+             &gpu_steady_power_deviation, &gpu_steady_min_period);
+    }
 
-        if(g_steady_power_levels_enabled){
-            sscanf(gpu_steady_state_definition,"%lf:%lf", &gpu_steady_power_deviation,&gpu_steady_min_period);
-        }
+    // NOTE: After changing the nonlinear model to only scaling idle core,
+    // NOTE: The min_inc_per_active_sm is not used any more
+    if (g_use_nonlinear_model)
+      sscanf(gpu_nonlinear_model_config, "%lf:%lf", &gpu_idle_core_power,
+             &gpu_min_inc_per_active_sm);
+  }
+  void reg_options(class OptionParser *opp);
 
-        //NOTE: After changing the nonlinear model to only scaling idle core,
-        //NOTE: The min_inc_per_active_sm is not used any more
-		if (g_use_nonlinear_model)
-		    sscanf(gpu_nonlinear_model_config,"%lf:%lf", &gpu_idle_core_power,&gpu_min_inc_per_active_sm);
+  char *g_power_config_name;
 
-	}
-	void reg_options(class OptionParser * opp);
+  bool m_valid;
+  bool g_power_simulation_enabled;
+  bool g_power_trace_enabled;
+  bool g_steady_power_levels_enabled;
+  bool g_power_per_cycle_dump;
+  bool g_power_simulator_debug;
+  char *g_power_filename;
+  char *g_power_trace_filename;
+  char *g_metric_trace_filename;
+  char *g_steady_state_tracking_filename;
+  int g_power_trace_zlevel;
+  char *gpu_steady_state_definition;
+  double gpu_steady_power_deviation;
+  double gpu_steady_min_period;
 
-	char *g_power_config_name;
-
-	bool m_valid;
-    bool g_power_simulation_enabled;
-    bool g_power_trace_enabled;
-    bool g_steady_power_levels_enabled;
-    bool g_power_per_cycle_dump;
-    bool g_power_simulator_debug;
-    char *g_power_filename;
-    char *g_power_trace_filename;
-    char *g_metric_trace_filename;
-    char * g_steady_state_tracking_filename;
-    int g_power_trace_zlevel;
-    char * gpu_steady_state_definition;
-    double gpu_steady_power_deviation;
-    double gpu_steady_min_period;
-
-    //Nonlinear power model
-    bool g_use_nonlinear_model;
-    char * gpu_nonlinear_model_config;
-    double gpu_idle_core_power;
-    double gpu_min_inc_per_active_sm;
-
-
+  // Nonlinear power model
+  bool g_use_nonlinear_model;
+  char *gpu_nonlinear_model_config;
+  double gpu_idle_core_power;
+  double gpu_min_inc_per_active_sm;
 };
-
 
 class memory_config {
-    public:
-   memory_config(gpgpu_context* ctx)
-   {
-       m_valid = false;
-       gpgpu_dram_timing_opt=NULL;
-       gpgpu_L2_queue_config=NULL;
-       gpgpu_ctx = ctx;
-   }
-   void init()
-   {
-      assert(gpgpu_dram_timing_opt);
-      if (strchr(gpgpu_dram_timing_opt, '=') == NULL) {
-         // dram timing option in ordered variables (legacy)
-         // Disabling bank groups if their values are not specified
-         nbkgrp = 1;
-         tCCDL = 0;
-         tRTPL = 0;
-         sscanf(gpgpu_dram_timing_opt,"%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d",
-                &nbk,&tCCD,&tRRD,&tRCD,&tRAS,&tRP,&tRC,&CL,&WL,&tCDLR,&tWR,&nbkgrp,&tCCDL,&tRTPL);
-      } else {
-         // named dram timing options (unordered)
-         option_parser_t dram_opp = option_parser_create(); 
+ public:
+  memory_config(gpgpu_context *ctx) {
+    m_valid = false;
+    gpgpu_dram_timing_opt = NULL;
+    gpgpu_L2_queue_config = NULL;
+    gpgpu_ctx = ctx;
+  }
+  void init() {
+    assert(gpgpu_dram_timing_opt);
+    if (strchr(gpgpu_dram_timing_opt, '=') == NULL) {
+      // dram timing option in ordered variables (legacy)
+      // Disabling bank groups if their values are not specified
+      nbkgrp = 1;
+      tCCDL = 0;
+      tRTPL = 0;
+      sscanf(gpgpu_dram_timing_opt, "%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d",
+             &nbk, &tCCD, &tRRD, &tRCD, &tRAS, &tRP, &tRC, &CL, &WL, &tCDLR,
+             &tWR, &nbkgrp, &tCCDL, &tRTPL);
+    } else {
+      // named dram timing options (unordered)
+      option_parser_t dram_opp = option_parser_create();
 
-         option_parser_register(dram_opp, "nbk",  OPT_UINT32, &nbk,   "number of banks", ""); 
-         option_parser_register(dram_opp, "CCD",  OPT_UINT32, &tCCD,  "column to column delay", ""); 
-         option_parser_register(dram_opp, "RRD",  OPT_UINT32, &tRRD,  "minimal delay between activation of rows in different banks", ""); 
-         option_parser_register(dram_opp, "RCD",  OPT_UINT32, &tRCD,  "row to column delay", ""); 
-         option_parser_register(dram_opp, "RAS",  OPT_UINT32, &tRAS,  "time needed to activate row", ""); 
-         option_parser_register(dram_opp, "RP",   OPT_UINT32, &tRP,   "time needed to precharge (deactivate) row", ""); 
-         option_parser_register(dram_opp, "RC",   OPT_UINT32, &tRC,   "row cycle time", ""); 
-         option_parser_register(dram_opp, "CDLR", OPT_UINT32, &tCDLR, "switching from write to read (changes tWTR)", ""); 
-         option_parser_register(dram_opp, "WR",   OPT_UINT32, &tWR,   "last data-in to row precharge", ""); 
+      option_parser_register(dram_opp, "nbk", OPT_UINT32, &nbk,
+                             "number of banks", "");
+      option_parser_register(dram_opp, "CCD", OPT_UINT32, &tCCD,
+                             "column to column delay", "");
+      option_parser_register(
+          dram_opp, "RRD", OPT_UINT32, &tRRD,
+          "minimal delay between activation of rows in different banks", "");
+      option_parser_register(dram_opp, "RCD", OPT_UINT32, &tRCD,
+                             "row to column delay", "");
+      option_parser_register(dram_opp, "RAS", OPT_UINT32, &tRAS,
+                             "time needed to activate row", "");
+      option_parser_register(dram_opp, "RP", OPT_UINT32, &tRP,
+                             "time needed to precharge (deactivate) row", "");
+      option_parser_register(dram_opp, "RC", OPT_UINT32, &tRC, "row cycle time",
+                             "");
+      option_parser_register(dram_opp, "CDLR", OPT_UINT32, &tCDLR,
+                             "switching from write to read (changes tWTR)", "");
+      option_parser_register(dram_opp, "WR", OPT_UINT32, &tWR,
+                             "last data-in to row precharge", "");
 
-         option_parser_register(dram_opp, "CL", OPT_UINT32, &CL, "CAS latency", ""); 
-         option_parser_register(dram_opp, "WL", OPT_UINT32, &WL, "Write latency", ""); 
+      option_parser_register(dram_opp, "CL", OPT_UINT32, &CL, "CAS latency",
+                             "");
+      option_parser_register(dram_opp, "WL", OPT_UINT32, &WL, "Write latency",
+                             "");
 
-         //Disabling bank groups if their values are not specified
-         option_parser_register(dram_opp, "nbkgrp", OPT_UINT32, &nbkgrp, "number of bank groups", "1"); 
-         option_parser_register(dram_opp, "CCDL",   OPT_UINT32, &tCCDL,  "column to column delay between accesses to different bank groups", "0"); 
-         option_parser_register(dram_opp, "RTPL",   OPT_UINT32, &tRTPL,  "read to precharge delay between accesses to different bank groups", "0"); 
+      // Disabling bank groups if their values are not specified
+      option_parser_register(dram_opp, "nbkgrp", OPT_UINT32, &nbkgrp,
+                             "number of bank groups", "1");
+      option_parser_register(
+          dram_opp, "CCDL", OPT_UINT32, &tCCDL,
+          "column to column delay between accesses to different bank groups",
+          "0");
+      option_parser_register(
+          dram_opp, "RTPL", OPT_UINT32, &tRTPL,
+          "read to precharge delay between accesses to different bank groups",
+          "0");
 
-         option_parser_delimited_string(dram_opp, gpgpu_dram_timing_opt, "=:;"); 
-         fprintf(stdout, "DRAM Timing Options:\n"); 
-         option_parser_print(dram_opp, stdout); 
-         option_parser_destroy(dram_opp); 
-      }
+      option_parser_delimited_string(dram_opp, gpgpu_dram_timing_opt, "=:;");
+      fprintf(stdout, "DRAM Timing Options:\n");
+      option_parser_print(dram_opp, stdout);
+      option_parser_destroy(dram_opp);
+    }
 
-      int nbkt = nbk/nbkgrp;
-      unsigned i;
-      for (i=0; nbkt>0; i++) {
-          nbkt = nbkt>>1;
-      }
-      bk_tag_length = i-1;
-      assert(nbkgrp>0 && "Number of bank groups cannot be zero");
-      tRCDWR = tRCD-(WL+1);
-      if(elimnate_rw_turnaround)
-      {
-    	  tRTW = 0;
-    	  tWTR = 0;
-      } else {
-      tRTW = (CL+(BL/data_command_freq_ratio)+2-WL);
-      tWTR = (WL+(BL/data_command_freq_ratio)+tCDLR);
-      }
-      tWTP = (WL+(BL/data_command_freq_ratio)+tWR);
-      dram_atom_size = BL * busW * gpu_n_mem_per_ctrlr; // burst length x bus width x # chips per partition 
+    int nbkt = nbk / nbkgrp;
+    unsigned i;
+    for (i = 0; nbkt > 0; i++) {
+      nbkt = nbkt >> 1;
+    }
+    bk_tag_length = i - 1;
+    assert(nbkgrp > 0 && "Number of bank groups cannot be zero");
+    tRCDWR = tRCD - (WL + 1);
+    if (elimnate_rw_turnaround) {
+      tRTW = 0;
+      tWTR = 0;
+    } else {
+      tRTW = (CL + (BL / data_command_freq_ratio) + 2 - WL);
+      tWTR = (WL + (BL / data_command_freq_ratio) + tCDLR);
+    }
+    tWTP = (WL + (BL / data_command_freq_ratio) + tWR);
+    dram_atom_size = BL * busW * gpu_n_mem_per_ctrlr;  // burst length x bus
+                                                       // width x # chips per
+                                                       // partition
 
-      assert( m_n_sub_partition_per_memory_channel > 0 ); 
-      assert( (nbk % m_n_sub_partition_per_memory_channel == 0) 
-              && "Number of DRAM banks must be a perfect multiple of memory sub partition"); 
-      m_n_mem_sub_partition = m_n_mem * m_n_sub_partition_per_memory_channel; 
-      fprintf(stdout, "Total number of memory sub partition = %u\n", m_n_mem_sub_partition); 
+    assert(m_n_sub_partition_per_memory_channel > 0);
+    assert((nbk % m_n_sub_partition_per_memory_channel == 0) &&
+           "Number of DRAM banks must be a perfect multiple of memory sub "
+           "partition");
+    m_n_mem_sub_partition = m_n_mem * m_n_sub_partition_per_memory_channel;
+    fprintf(stdout, "Total number of memory sub partition = %u\n",
+            m_n_mem_sub_partition);
 
-      m_address_mapping.init(m_n_mem, m_n_sub_partition_per_memory_channel);
-      m_L2_config.init(&m_address_mapping);
+    m_address_mapping.init(m_n_mem, m_n_sub_partition_per_memory_channel);
+    m_L2_config.init(&m_address_mapping);
 
-      m_valid = true;
+    m_valid = true;
 
-      sscanf(write_queue_size_opt,"%d:%d:%d",
-                     &gpgpu_frfcfs_dram_write_queue_size,&write_high_watermark,&write_low_watermark);
-   }
-   void reg_options(class OptionParser * opp);
+    sscanf(write_queue_size_opt, "%d:%d:%d",
+           &gpgpu_frfcfs_dram_write_queue_size, &write_high_watermark,
+           &write_low_watermark);
+  }
+  void reg_options(class OptionParser *opp);
 
-   bool m_valid;
-   mutable l2_cache_config m_L2_config;
-   bool m_L2_texure_only;
+  bool m_valid;
+  mutable l2_cache_config m_L2_config;
+  bool m_L2_texure_only;
 
-   char *gpgpu_dram_timing_opt;
-   char *gpgpu_L2_queue_config;
-   bool l2_ideal;
-   unsigned gpgpu_frfcfs_dram_sched_queue_size;
-   unsigned gpgpu_dram_return_queue_size;
-   enum dram_ctrl_t scheduler_type;
-   bool gpgpu_memlatency_stat;
-   unsigned m_n_mem;
-   unsigned m_n_sub_partition_per_memory_channel;
-   unsigned m_n_mem_sub_partition;
-   unsigned gpu_n_mem_per_ctrlr;
+  char *gpgpu_dram_timing_opt;
+  char *gpgpu_L2_queue_config;
+  bool l2_ideal;
+  unsigned gpgpu_frfcfs_dram_sched_queue_size;
+  unsigned gpgpu_dram_return_queue_size;
+  enum dram_ctrl_t scheduler_type;
+  bool gpgpu_memlatency_stat;
+  unsigned m_n_mem;
+  unsigned m_n_sub_partition_per_memory_channel;
+  unsigned m_n_mem_sub_partition;
+  unsigned gpu_n_mem_per_ctrlr;
 
-   unsigned rop_latency;
-   unsigned dram_latency;
+  unsigned rop_latency;
+  unsigned dram_latency;
 
-   // DRAM parameters
+  // DRAM parameters
 
-   unsigned tCCDL;  //column to column delay when bank groups are enabled
-   unsigned tRTPL;  //read to precharge delay when bank groups are enabled for GDDR5 this is identical to RTPS, if for other DRAM this is different, you will need to split them in two
+  unsigned tCCDL;  // column to column delay when bank groups are enabled
+  unsigned tRTPL;  // read to precharge delay when bank groups are enabled for
+                   // GDDR5 this is identical to RTPS, if for other DRAM this is
+                   // different, you will need to split them in two
 
-   unsigned tCCD;   //column to column delay
-   unsigned tRRD;   //minimal time required between activation of rows in different banks
-   unsigned tRCD;   //row to column delay - time required to activate a row before a read
-   unsigned tRCDWR; //row to column delay for a write command
-   unsigned tRAS;   //time needed to activate row
-   unsigned tRP;    //row precharge ie. deactivate row
-   unsigned tRC;    //row cycle time ie. precharge current, then activate different row
-   unsigned tCDLR;  //Last data-in to Read command (switching from write to read)
-   unsigned tWR;    //Last data-in to Row precharge 
+  unsigned tCCD;  // column to column delay
+  unsigned tRRD;  // minimal time required between activation of rows in
+                  // different banks
+  unsigned tRCD;  // row to column delay - time required to activate a row
+                  // before a read
+  unsigned tRCDWR;  // row to column delay for a write command
+  unsigned tRAS;    // time needed to activate row
+  unsigned tRP;     // row precharge ie. deactivate row
+  unsigned
+      tRC;  // row cycle time ie. precharge current, then activate different row
+  unsigned tCDLR;  // Last data-in to Read command (switching from write to
+                   // read)
+  unsigned tWR;  // Last data-in to Row precharge
 
-   unsigned CL;     //CAS latency
-   unsigned WL;     //WRITE latency
-   unsigned BL;     //Burst Length in bytes (4 in GDDR3, 8 in GDDR5)
-   unsigned tRTW;   //time to switch from read to write
-   unsigned tWTR;   //time to switch from write to read 
-   unsigned tWTP;   //time to switch from write to precharge in the same bank
-   unsigned busW;
+  unsigned CL;    // CAS latency
+  unsigned WL;    // WRITE latency
+  unsigned BL;    // Burst Length in bytes (4 in GDDR3, 8 in GDDR5)
+  unsigned tRTW;  // time to switch from read to write
+  unsigned tWTR;  // time to switch from write to read
+  unsigned tWTP;  // time to switch from write to precharge in the same bank
+  unsigned busW;
 
-   unsigned nbkgrp; // number of bank groups (has to be power of 2)
-   unsigned bk_tag_length; //number of bits that define a bank inside a bank group
+  unsigned nbkgrp;  // number of bank groups (has to be power of 2)
+  unsigned
+      bk_tag_length;  // number of bits that define a bank inside a bank group
 
-   unsigned nbk;
+  unsigned nbk;
 
-   bool elimnate_rw_turnaround;
+  bool elimnate_rw_turnaround;
 
-   unsigned data_command_freq_ratio; // frequency ratio between DRAM data bus and command bus (2 for GDDR3, 4 for GDDR5)
-   unsigned dram_atom_size; // number of bytes transferred per read or write command 
+  unsigned data_command_freq_ratio;  // frequency ratio between DRAM data bus
+                                     // and command bus (2 for GDDR3, 4 for
+                                     // GDDR5)
+  unsigned
+      dram_atom_size;  // number of bytes transferred per read or write command
 
-   linear_to_raw_address_translation m_address_mapping;
+  linear_to_raw_address_translation m_address_mapping;
 
-   unsigned icnt_flit_size;
+  unsigned icnt_flit_size;
 
-   unsigned dram_bnk_indexing_policy;
-   unsigned dram_bnkgrp_indexing_policy;
-   bool dual_bus_interface;
+  unsigned dram_bnk_indexing_policy;
+  unsigned dram_bnkgrp_indexing_policy;
+  bool dual_bus_interface;
 
-   bool seperate_write_queue_enabled;
-   char *write_queue_size_opt;
-   unsigned gpgpu_frfcfs_dram_write_queue_size;
-   unsigned write_high_watermark;
-   unsigned write_low_watermark;
-   bool m_perf_sim_memcpy;
-   bool simple_dram_model;
+  bool seperate_write_queue_enabled;
+  char *write_queue_size_opt;
+  unsigned gpgpu_frfcfs_dram_write_queue_size;
+  unsigned write_high_watermark;
+  unsigned write_low_watermark;
+  bool m_perf_sim_memcpy;
+  bool simple_dram_model;
 
-   gpgpu_context* gpgpu_ctx;
+  gpgpu_context *gpgpu_ctx;
 };
-
 
 extern bool g_interactive_debugger_enabled;
 
-class gpgpu_sim_config : public power_config, public gpgpu_functional_sim_config {
-public:
-    gpgpu_sim_config(gpgpu_context* ctx): m_shader_config(ctx), m_memory_config(ctx) {
-	m_valid = false;
-	gpgpu_ctx = ctx;
+class gpgpu_sim_config : public power_config,
+                         public gpgpu_functional_sim_config {
+ public:
+  gpgpu_sim_config(gpgpu_context *ctx)
+      : m_shader_config(ctx), m_memory_config(ctx) {
+    m_valid = false;
+    gpgpu_ctx = ctx;
+  }
+  void reg_options(class OptionParser *opp);
+  void init() {
+    gpu_stat_sample_freq = 10000;
+    gpu_runtime_stat_flag = 0;
+    sscanf(gpgpu_runtime_stat, "%d:%x", &gpu_stat_sample_freq,
+           &gpu_runtime_stat_flag);
+    m_shader_config.init();
+    ptx_set_tex_cache_linesize(m_shader_config.m_L1T_config.get_line_sz());
+    m_memory_config.init();
+    init_clock_domains();
+    power_config::init();
+    Trace::init();
+
+    // initialize file name if it is not set
+    time_t curr_time;
+    time(&curr_time);
+    char *date = ctime(&curr_time);
+    char *s = date;
+    while (*s) {
+      if (*s == ' ' || *s == '\t' || *s == ':') *s = '-';
+      if (*s == '\n' || *s == '\r') *s = 0;
+      s++;
     }
-    void reg_options(class OptionParser * opp);
-    void init() 
-    {
-        gpu_stat_sample_freq = 10000;
-        gpu_runtime_stat_flag = 0;
-        sscanf(gpgpu_runtime_stat, "%d:%x", &gpu_stat_sample_freq, &gpu_runtime_stat_flag);
-        m_shader_config.init();
-        ptx_set_tex_cache_linesize(m_shader_config.m_L1T_config.get_line_sz());
-        m_memory_config.init();
-        init_clock_domains(); 
-        power_config::init();
-        Trace::init();
+    char buf[1024];
+    snprintf(buf, 1024, "gpgpusim_visualizer__%s.log.gz", date);
+    g_visualizer_filename = strdup(buf);
 
+    m_valid = true;
+  }
 
-        // initialize file name if it is not set 
-        time_t curr_time;
-        time(&curr_time);
-        char *date = ctime(&curr_time);
-        char *s = date;
-        while (*s) {
-            if (*s == ' ' || *s == '\t' || *s == ':') *s = '-';
-            if (*s == '\n' || *s == '\r' ) *s = 0;
-            s++;
-        }
-        char buf[1024];
-        snprintf(buf,1024,"gpgpusim_visualizer__%s.log.gz",date);
-        g_visualizer_filename = strdup(buf);
+  unsigned num_shader() const { return m_shader_config.num_shader(); }
+  unsigned num_cluster() const { return m_shader_config.n_simt_clusters; }
+  unsigned get_max_concurrent_kernel() const { return max_concurrent_kernel; }
+  unsigned checkpoint_option;
 
-        m_valid=true;
-    }
+  size_t stack_limit() const { return stack_size_limit; }
+  size_t heap_limit() const { return heap_size_limit; }
+  size_t sync_depth_limit() const { return runtime_sync_depth_limit; }
+  size_t pending_launch_count_limit() const {
+    return runtime_pending_launch_count_limit;
+  }
 
-    unsigned num_shader() const { return m_shader_config.num_shader(); }
-    unsigned num_cluster() const { return m_shader_config.n_simt_clusters; }
-    unsigned get_max_concurrent_kernel() const { return max_concurrent_kernel; }
-    unsigned checkpoint_option;
+ private:
+  void init_clock_domains(void);
 
-    size_t stack_limit() const {return stack_size_limit; }
-    size_t heap_limit() const {return heap_size_limit; }
-    size_t sync_depth_limit() const {return runtime_sync_depth_limit; }
-    size_t pending_launch_count_limit() const {return runtime_pending_launch_count_limit;}
+  // backward pointer
+  class gpgpu_context *gpgpu_ctx;
+  bool m_valid;
+  shader_core_config m_shader_config;
+  memory_config m_memory_config;
+  // clock domains - frequency
+  double core_freq;
+  double icnt_freq;
+  double dram_freq;
+  double l2_freq;
+  double core_period;
+  double icnt_period;
+  double dram_period;
+  double l2_period;
 
-private:
-    void init_clock_domains(void ); 
+  // GPGPU-Sim timing model options
+  unsigned long long gpu_max_cycle_opt;
+  unsigned long long gpu_max_insn_opt;
+  unsigned gpu_max_cta_opt;
+  char *gpgpu_runtime_stat;
+  bool gpgpu_flush_l1_cache;
+  bool gpgpu_flush_l2_cache;
+  bool gpu_deadlock_detect;
+  int gpgpu_frfcfs_dram_sched_queue_size;
+  int gpgpu_cflog_interval;
+  char *gpgpu_clock_domains;
+  unsigned max_concurrent_kernel;
 
+  // visualizer
+  bool g_visualizer_enabled;
+  char *g_visualizer_filename;
+  int g_visualizer_zlevel;
 
-    // backward pointer
-    class gpgpu_context* gpgpu_ctx;
-    bool m_valid;
-    shader_core_config m_shader_config;
-    memory_config m_memory_config;
-    // clock domains - frequency
-    double core_freq;
-    double icnt_freq;
-    double dram_freq;
-    double l2_freq;
-    double core_period;
-    double icnt_period;
-    double dram_period;
-    double l2_period;
+  // statistics collection
+  int gpu_stat_sample_freq;
+  int gpu_runtime_stat_flag;
 
-    // GPGPU-Sim timing model options
-    unsigned long long gpu_max_cycle_opt;
-    unsigned long long gpu_max_insn_opt;
-    unsigned gpu_max_cta_opt;
-    char *gpgpu_runtime_stat;
-    bool  gpgpu_flush_l1_cache;
-    bool  gpgpu_flush_l2_cache;
-    bool  gpu_deadlock_detect;
-    int   gpgpu_frfcfs_dram_sched_queue_size; 
-    int   gpgpu_cflog_interval;
-    char * gpgpu_clock_domains;
-    unsigned max_concurrent_kernel;
+  // Device Limits
+  size_t stack_size_limit;
+  size_t heap_size_limit;
+  size_t runtime_sync_depth_limit;
+  size_t runtime_pending_launch_count_limit;
 
-    // visualizer
-    bool  g_visualizer_enabled;
-    char *g_visualizer_filename;
-    int   g_visualizer_zlevel;
+  // gpu compute capability options
+  unsigned int gpgpu_compute_capability_major;
+  unsigned int gpgpu_compute_capability_minor;
+  unsigned long long liveness_message_freq;
 
-
-    // statistics collection
-    int gpu_stat_sample_freq;
-    int gpu_runtime_stat_flag;
-
-    // Device Limits
-    size_t stack_size_limit;
-    size_t heap_size_limit;
-    size_t runtime_sync_depth_limit;
-    size_t runtime_pending_launch_count_limit;	
-
- //gpu compute capability options
-    unsigned int gpgpu_compute_capability_major;
-    unsigned int gpgpu_compute_capability_minor;
-    unsigned long long liveness_message_freq; 
-
-    friend class gpgpu_sim;
+  friend class gpgpu_sim;
 };
 
 struct occupancy_stats {
-    occupancy_stats() : aggregate_warp_slot_filled(0), aggregate_theoretical_warp_slots(0){}
-    occupancy_stats( unsigned long long wsf, unsigned long long tws )
-        : aggregate_warp_slot_filled(wsf), aggregate_theoretical_warp_slots(tws){}
+  occupancy_stats()
+      : aggregate_warp_slot_filled(0), aggregate_theoretical_warp_slots(0) {}
+  occupancy_stats(unsigned long long wsf, unsigned long long tws)
+      : aggregate_warp_slot_filled(wsf),
+        aggregate_theoretical_warp_slots(tws) {}
 
-    unsigned long long aggregate_warp_slot_filled;
-    unsigned long long aggregate_theoretical_warp_slots;
+  unsigned long long aggregate_warp_slot_filled;
+  unsigned long long aggregate_theoretical_warp_slots;
 
-    float get_occ_fraction() const {
-        return float(aggregate_warp_slot_filled) / float(aggregate_theoretical_warp_slots);
-    }
+  float get_occ_fraction() const {
+    return float(aggregate_warp_slot_filled) /
+           float(aggregate_theoretical_warp_slots);
+  }
 
-    occupancy_stats& operator+=(const occupancy_stats& rhs) {
-        aggregate_warp_slot_filled += rhs.aggregate_warp_slot_filled;
-        aggregate_theoretical_warp_slots += rhs.aggregate_theoretical_warp_slots;
-        return *this;
-    }
+  occupancy_stats &operator+=(const occupancy_stats &rhs) {
+    aggregate_warp_slot_filled += rhs.aggregate_warp_slot_filled;
+    aggregate_theoretical_warp_slots += rhs.aggregate_theoretical_warp_slots;
+    return *this;
+  }
 
-    occupancy_stats operator+(const occupancy_stats& rhs) const{
-        return occupancy_stats( aggregate_warp_slot_filled + rhs.aggregate_warp_slot_filled,
-                                aggregate_theoretical_warp_slots + rhs.aggregate_theoretical_warp_slots
-                               );
-    }
+  occupancy_stats operator+(const occupancy_stats &rhs) const {
+    return occupancy_stats(
+        aggregate_warp_slot_filled + rhs.aggregate_warp_slot_filled,
+        aggregate_theoretical_warp_slots +
+            rhs.aggregate_theoretical_warp_slots);
+  }
 };
 
 class gpgpu_context;
 class ptx_instruction;
 
 class watchpoint_event {
-public:
-   watchpoint_event()
-   {
-      m_thread=NULL;
-      m_inst=NULL;
-   }
-   watchpoint_event(const ptx_thread_info *thd, const ptx_instruction *pI)
-   {
-      m_thread=thd;
-      m_inst = pI;
-   }
-   const ptx_thread_info *thread() const { return m_thread; }
-   const ptx_instruction *inst() const { return m_inst; }
-private:
-   const ptx_thread_info *m_thread;
-   const ptx_instruction *m_inst;
+ public:
+  watchpoint_event() {
+    m_thread = NULL;
+    m_inst = NULL;
+  }
+  watchpoint_event(const ptx_thread_info *thd, const ptx_instruction *pI) {
+    m_thread = thd;
+    m_inst = pI;
+  }
+  const ptx_thread_info *thread() const { return m_thread; }
+  const ptx_instruction *inst() const { return m_inst; }
+
+ private:
+  const ptx_thread_info *m_thread;
+  const ptx_instruction *m_inst;
 };
 
 class gpgpu_sim : public gpgpu_t {
-public:
-   gpgpu_sim( const gpgpu_sim_config &config, gpgpu_context* ctx );
+ public:
+  gpgpu_sim(const gpgpu_sim_config &config, gpgpu_context *ctx);
 
-   void set_prop( struct cudaDeviceProp *prop );
+  void set_prop(struct cudaDeviceProp *prop);
 
-   void launch( kernel_info_t *kinfo );
-   bool can_start_kernel();
-   unsigned finished_kernel();
-   void set_kernel_done( kernel_info_t *kernel );
-   void stop_all_running_kernels();
+  void launch(kernel_info_t *kinfo);
+  bool can_start_kernel();
+  unsigned finished_kernel();
+  void set_kernel_done(kernel_info_t *kernel);
+  void stop_all_running_kernels();
 
-   void init();
-   void cycle();
-   bool active(); 
-   bool cycle_insn_cta_max_hit() {
-       return (m_config.gpu_max_cycle_opt && (gpu_tot_sim_cycle + gpu_sim_cycle) >= m_config.gpu_max_cycle_opt) ||
-           (m_config.gpu_max_insn_opt && (gpu_tot_sim_insn + gpu_sim_insn) >= m_config.gpu_max_insn_opt) ||
-           (m_config.gpu_max_cta_opt && (gpu_tot_issued_cta >= m_config.gpu_max_cta_opt) );
-   }
-   void print_stats();
-   void update_stats();
-   void deadlock_check();
+  void init();
+  void cycle();
+  bool active();
+  bool cycle_insn_cta_max_hit() {
+    return (m_config.gpu_max_cycle_opt &&
+            (gpu_tot_sim_cycle + gpu_sim_cycle) >=
+                m_config.gpu_max_cycle_opt) ||
+           (m_config.gpu_max_insn_opt &&
+            (gpu_tot_sim_insn + gpu_sim_insn) >= m_config.gpu_max_insn_opt) ||
+           (m_config.gpu_max_cta_opt &&
+            (gpu_tot_issued_cta >= m_config.gpu_max_cta_opt));
+  }
+  void print_stats();
+  void update_stats();
+  void deadlock_check();
 
-   void get_pdom_stack_top_info( unsigned sid, unsigned tid, unsigned *pc, unsigned *rpc );
+  void get_pdom_stack_top_info(unsigned sid, unsigned tid, unsigned *pc,
+                               unsigned *rpc);
 
-   int shared_mem_size() const;
-   int shared_mem_per_block() const;
-   int compute_capability_major() const;
-   int compute_capability_minor() const;
-   int num_registers_per_core() const;
-   int num_registers_per_block() const;
-   int wrp_size() const;
-   int shader_clock() const;
-   int max_cta_per_core() const;
-   int get_max_cta( const kernel_info_t &k ) const;
-   const struct cudaDeviceProp *get_prop() const;
-   enum divergence_support_t simd_model() const; 
+  int shared_mem_size() const;
+  int shared_mem_per_block() const;
+  int compute_capability_major() const;
+  int compute_capability_minor() const;
+  int num_registers_per_core() const;
+  int num_registers_per_block() const;
+  int wrp_size() const;
+  int shader_clock() const;
+  int max_cta_per_core() const;
+  int get_max_cta(const kernel_info_t &k) const;
+  const struct cudaDeviceProp *get_prop() const;
+  enum divergence_support_t simd_model() const;
 
-   unsigned threads_per_core() const;
-   bool get_more_cta_left() const;
-   bool kernel_more_cta_left(kernel_info_t *kernel) const;
-   bool hit_max_cta_count() const;
-   kernel_info_t *select_kernel();
+  unsigned threads_per_core() const;
+  bool get_more_cta_left() const;
+  bool kernel_more_cta_left(kernel_info_t *kernel) const;
+  bool hit_max_cta_count() const;
+  kernel_info_t *select_kernel();
 
-   const gpgpu_sim_config &get_config() const { return m_config; }
-   void gpu_print_stat();
-   void dump_pipeline( int mask, int s, int m ) const;
+  const gpgpu_sim_config &get_config() const { return m_config; }
+  void gpu_print_stat();
+  void dump_pipeline(int mask, int s, int m) const;
 
-    void perf_memcpy_to_gpu( size_t dst_start_addr, size_t count );
+  void perf_memcpy_to_gpu(size_t dst_start_addr, size_t count);
 
-   //The next three functions added to be used by the functional simulation function
-   
-   //! Get shader core configuration
-   /*!
-    * Returning the configuration of the shader core, used by the functional simulation only so far
-    */
-   const shader_core_config * getShaderCoreConfig();
-   
-   
-   //! Get shader core Memory Configuration
-    /*!
-    * Returning the memory configuration of the shader core, used by the functional simulation only so far
-    */
-   const memory_config * getMemoryConfig();
-   
-   
-   //! Get shader core SIMT cluster
-   /*!
-    * Returning the cluster of of the shader core, used by the functional simulation so far
-    */
-    simt_core_cluster * getSIMTCluster();
+  // The next three functions added to be used by the functional simulation
+  // function
 
-    void hit_watchpoint( unsigned watchpoint_num, ptx_thread_info *thd, const ptx_instruction *pI );
+  //! Get shader core configuration
+  /*!
+   * Returning the configuration of the shader core, used by the functional
+   * simulation only so far
+   */
+  const shader_core_config *getShaderCoreConfig();
 
-    // backward pointer
-    class gpgpu_context* gpgpu_ctx;
+  //! Get shader core Memory Configuration
+  /*!
+  * Returning the memory configuration of the shader core, used by the
+  * functional simulation only so far
+  */
+  const memory_config *getMemoryConfig();
 
-private:
-   // clocks
-   void reinit_clock_domains(void);
-   int  next_clock_domain(void);
-   void issue_block2core();
-   void print_dram_stats(FILE *fout) const;
-   void shader_print_runtime_stat( FILE *fout );
-   void shader_print_l1_miss_stat( FILE *fout ) const;
-   void shader_print_cache_stats( FILE *fout ) const;
-   void shader_print_scheduler_stat( FILE* fout, bool print_dynamic_info ) const;
-   void visualizer_printstat();
-   void print_shader_cycle_distro( FILE *fout ) const;
+  //! Get shader core SIMT cluster
+  /*!
+   * Returning the cluster of of the shader core, used by the functional
+   * simulation so far
+   */
+  simt_core_cluster *getSIMTCluster();
 
-   void gpgpu_debug();
+  void hit_watchpoint(unsigned watchpoint_num, ptx_thread_info *thd,
+                      const ptx_instruction *pI);
 
-///// data /////
+  // backward pointer
+  class gpgpu_context *gpgpu_ctx;
 
-   class simt_core_cluster **m_cluster;
-   class memory_partition_unit **m_memory_partition_unit;
-   class memory_sub_partition **m_memory_sub_partition;
+ private:
+  // clocks
+  void reinit_clock_domains(void);
+  int next_clock_domain(void);
+  void issue_block2core();
+  void print_dram_stats(FILE *fout) const;
+  void shader_print_runtime_stat(FILE *fout);
+  void shader_print_l1_miss_stat(FILE *fout) const;
+  void shader_print_cache_stats(FILE *fout) const;
+  void shader_print_scheduler_stat(FILE *fout, bool print_dynamic_info) const;
+  void visualizer_printstat();
+  void print_shader_cycle_distro(FILE *fout) const;
 
-   std::vector<kernel_info_t*> m_running_kernels;
-   unsigned m_last_issued_kernel;
+  void gpgpu_debug();
 
-   std::list<unsigned> m_finished_kernel;
-   // m_total_cta_launched == per-kernel count. gpu_tot_issued_cta == global count.
-   unsigned long long m_total_cta_launched;
-   unsigned long long gpu_tot_issued_cta;
+  ///// data /////
 
-   unsigned m_last_cluster_issue;
-   float * average_pipeline_duty_cycle;
-   float * active_sms;
-   // time of next rising edge 
-   double core_time;
-   double icnt_time;
-   double dram_time;
-   double l2_time;
+  class simt_core_cluster **m_cluster;
+  class memory_partition_unit **m_memory_partition_unit;
+  class memory_sub_partition **m_memory_sub_partition;
 
-   // debug
-   bool gpu_deadlock;
+  std::vector<kernel_info_t *> m_running_kernels;
+  unsigned m_last_issued_kernel;
 
-   //// configuration parameters ////
-   const gpgpu_sim_config &m_config;
-  
-   const struct cudaDeviceProp     *m_cuda_properties;
-   const shader_core_config *m_shader_config;
-   const memory_config      *m_memory_config;
+  std::list<unsigned> m_finished_kernel;
+  // m_total_cta_launched == per-kernel count. gpu_tot_issued_cta == global
+  // count.
+  unsigned long long m_total_cta_launched;
+  unsigned long long gpu_tot_issued_cta;
 
-   // stats
-   class shader_core_stats  *m_shader_stats;
-   class memory_stats_t     *m_memory_stats;
-   class power_stat_t *m_power_stats;
-   class gpgpu_sim_wrapper *m_gpgpusim_wrapper;
-   unsigned long long  last_gpu_sim_insn;
+  unsigned m_last_cluster_issue;
+  float *average_pipeline_duty_cycle;
+  float *active_sms;
+  // time of next rising edge
+  double core_time;
+  double icnt_time;
+  double dram_time;
+  double l2_time;
 
-   unsigned long long  last_liveness_message_time; 
+  // debug
+  bool gpu_deadlock;
 
-   std::map<std::string, FuncCache> m_special_cache_config;
+  //// configuration parameters ////
+  const gpgpu_sim_config &m_config;
 
-   std::vector<std::string> m_executed_kernel_names; //< names of kernel for stat printout 
-   std::vector<unsigned> m_executed_kernel_uids; //< uids of kernel launches for stat printout
-   std::map<unsigned,watchpoint_event> g_watchpoint_hits;
+  const struct cudaDeviceProp *m_cuda_properties;
+  const shader_core_config *m_shader_config;
+  const memory_config *m_memory_config;
 
-   std::string executed_kernel_info_string(); //< format the kernel information into a string for stat printout
-   void clear_executed_kernel_info(); //< clear the kernel information after stat printout
+  // stats
+  class shader_core_stats *m_shader_stats;
+  class memory_stats_t *m_memory_stats;
+  class power_stat_t *m_power_stats;
+  class gpgpu_sim_wrapper *m_gpgpusim_wrapper;
+  unsigned long long last_gpu_sim_insn;
 
+  unsigned long long last_liveness_message_time;
 
-public:
-   unsigned long long  gpu_sim_insn;
-   unsigned long long  gpu_tot_sim_insn;
-   unsigned long long  gpu_sim_insn_last_update;
-   unsigned gpu_sim_insn_last_update_sid;
-   occupancy_stats gpu_occupancy;
-   occupancy_stats gpu_tot_occupancy;
+  std::map<std::string, FuncCache> m_special_cache_config;
 
-   // performance counter for stalls due to congestion.
-   unsigned int gpu_stall_dramfull;
-   unsigned int gpu_stall_icnt2sh;
-   unsigned long long partiton_reqs_in_parallel;
-   unsigned long long partiton_reqs_in_parallel_total;
-   unsigned long long partiton_reqs_in_parallel_util;
-   unsigned long long partiton_reqs_in_parallel_util_total;
-   unsigned long long  gpu_sim_cycle_parition_util;
-   unsigned long long  gpu_tot_sim_cycle_parition_util;
-   unsigned long long partiton_replys_in_parallel;
-   unsigned long long partiton_replys_in_parallel_total;
+  std::vector<std::string>
+      m_executed_kernel_names;  //< names of kernel for stat printout
+  std::vector<unsigned>
+      m_executed_kernel_uids;  //< uids of kernel launches for stat printout
+  std::map<unsigned, watchpoint_event> g_watchpoint_hits;
 
+  std::string executed_kernel_info_string();  //< format the kernel information
+                                              //into a string for stat printout
+  void clear_executed_kernel_info();  //< clear the kernel information after
+                                      //stat printout
 
-   FuncCache get_cache_config(std::string kernel_name);
-   void set_cache_config(std::string kernel_name, FuncCache cacheConfig );
-   bool has_special_cache_config(std::string kernel_name);
-   void change_cache_config(FuncCache cache_config);
-   void set_cache_config(std::string kernel_name);
+ public:
+  unsigned long long gpu_sim_insn;
+  unsigned long long gpu_tot_sim_insn;
+  unsigned long long gpu_sim_insn_last_update;
+  unsigned gpu_sim_insn_last_update_sid;
+  occupancy_stats gpu_occupancy;
+  occupancy_stats gpu_tot_occupancy;
 
-   //Jin: functional simulation for CDP
-private:
-   //set by stream operation every time a functoinal simulation is done
-   bool m_functional_sim;
-   kernel_info_t * m_functional_sim_kernel;
+  // performance counter for stalls due to congestion.
+  unsigned int gpu_stall_dramfull;
+  unsigned int gpu_stall_icnt2sh;
+  unsigned long long partiton_reqs_in_parallel;
+  unsigned long long partiton_reqs_in_parallel_total;
+  unsigned long long partiton_reqs_in_parallel_util;
+  unsigned long long partiton_reqs_in_parallel_util_total;
+  unsigned long long gpu_sim_cycle_parition_util;
+  unsigned long long gpu_tot_sim_cycle_parition_util;
+  unsigned long long partiton_replys_in_parallel;
+  unsigned long long partiton_replys_in_parallel_total;
 
-public:
-   bool is_functional_sim() { return m_functional_sim; }
-   kernel_info_t * get_functional_kernel() { return m_functional_sim_kernel; }
-   void functional_launch(kernel_info_t * k) {
-     m_functional_sim = true;
-     m_functional_sim_kernel = k;
-   }
-   void finish_functional_sim(kernel_info_t * k) {
-     assert(m_functional_sim);
-     assert(m_functional_sim_kernel == k);
-     m_functional_sim = false;
-     m_functional_sim_kernel = NULL;
-   }
+  FuncCache get_cache_config(std::string kernel_name);
+  void set_cache_config(std::string kernel_name, FuncCache cacheConfig);
+  bool has_special_cache_config(std::string kernel_name);
+  void change_cache_config(FuncCache cache_config);
+  void set_cache_config(std::string kernel_name);
+
+  // Jin: functional simulation for CDP
+ private:
+  // set by stream operation every time a functoinal simulation is done
+  bool m_functional_sim;
+  kernel_info_t *m_functional_sim_kernel;
+
+ public:
+  bool is_functional_sim() { return m_functional_sim; }
+  kernel_info_t *get_functional_kernel() { return m_functional_sim_kernel; }
+  void functional_launch(kernel_info_t *k) {
+    m_functional_sim = true;
+    m_functional_sim_kernel = k;
+  }
+  void finish_functional_sim(kernel_info_t *k) {
+    assert(m_functional_sim);
+    assert(m_functional_sim_kernel == k);
+    m_functional_sim = false;
+    m_functional_sim_kernel = NULL;
+  }
 };
-
 
 #endif

--- a/src/gpgpu-sim/gpu-sim.h
+++ b/src/gpgpu-sim/gpu-sim.h
@@ -7,45 +7,44 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef GPU_SIM_H
 #define GPU_SIM_H
 
-#include "../option_parser.h"
+#include <stdio.h>
+#include <fstream>
+#include <iostream>
+#include <list>
 #include "../abstract_hardware_model.h"
+#include "../option_parser.h"
 #include "../trace.h"
 #include "addrdec.h"
-#include "shader.h"
 #include "gpu-cache.h"
-#include <iostream>
-#include <fstream>
-#include <list>
-#include <stdio.h>
-
-
+#include "shader.h"
 
 // constants for statistics printouts
 #define GPU_RSTAT_SHD_INFO 0x1
-#define GPU_RSTAT_BW_STAT  0x2
+#define GPU_RSTAT_BW_STAT 0x2
 #define GPU_RSTAT_WARP_DIS 0x4
-#define GPU_RSTAT_DWF_MAP  0x8
+#define GPU_RSTAT_DWF_MAP 0x8
 #define GPU_RSTAT_L1MISS 0x10
 #define GPU_RSTAT_PDOM 0x20
 #define GPU_RSTAT_SCHED 0x40
@@ -65,584 +64,617 @@
 
 class gpgpu_context;
 
-extern tr1_hash_map<new_addr_type,unsigned> address_random_interleaving;
+extern tr1_hash_map<new_addr_type, unsigned> address_random_interleaving;
 
-enum dram_ctrl_t {
-   DRAM_FIFO=0,
-   DRAM_FRFCFS=1
-};
-
-
+enum dram_ctrl_t { DRAM_FIFO = 0, DRAM_FRFCFS = 1 };
 
 struct power_config {
-	power_config()
-	{
-		m_valid = true;
-	}
-	void init()
-	{
+  power_config() { m_valid = true; }
+  void init() {
+    // initialize file name if it is not set
+    time_t curr_time;
+    time(&curr_time);
+    char *date = ctime(&curr_time);
+    char *s = date;
+    while (*s) {
+      if (*s == ' ' || *s == '\t' || *s == ':') *s = '-';
+      if (*s == '\n' || *s == '\r') *s = 0;
+      s++;
+    }
+    char buf1[1024];
+    snprintf(buf1, 1024, "gpgpusim_power_report__%s.log", date);
+    g_power_filename = strdup(buf1);
+    char buf2[1024];
+    snprintf(buf2, 1024, "gpgpusim_power_trace_report__%s.log.gz", date);
+    g_power_trace_filename = strdup(buf2);
+    char buf3[1024];
+    snprintf(buf3, 1024, "gpgpusim_metric_trace_report__%s.log.gz", date);
+    g_metric_trace_filename = strdup(buf3);
+    char buf4[1024];
+    snprintf(buf4, 1024, "gpgpusim_steady_state_tracking_report__%s.log.gz",
+             date);
+    g_steady_state_tracking_filename = strdup(buf4);
 
-        // initialize file name if it is not set
-        time_t curr_time;
-        time(&curr_time);
-        char *date = ctime(&curr_time);
-        char *s = date;
-        while (*s) {
-            if (*s == ' ' || *s == '\t' || *s == ':') *s = '-';
-            if (*s == '\n' || *s == '\r' ) *s = 0;
-            s++;
-        }
-        char buf1[1024];
-        snprintf(buf1,1024,"gpgpusim_power_report__%s.log",date);
-        g_power_filename = strdup(buf1);
-        char buf2[1024];
-        snprintf(buf2,1024,"gpgpusim_power_trace_report__%s.log.gz",date);
-        g_power_trace_filename = strdup(buf2);
-        char buf3[1024];
-        snprintf(buf3,1024,"gpgpusim_metric_trace_report__%s.log.gz",date);
-        g_metric_trace_filename = strdup(buf3);
-        char buf4[1024];
-        snprintf(buf4,1024,"gpgpusim_steady_state_tracking_report__%s.log.gz",date);
-        g_steady_state_tracking_filename = strdup(buf4);
+    if (g_steady_power_levels_enabled) {
+      sscanf(gpu_steady_state_definition, "%lf:%lf",
+             &gpu_steady_power_deviation, &gpu_steady_min_period);
+    }
 
-        if(g_steady_power_levels_enabled){
-            sscanf(gpu_steady_state_definition,"%lf:%lf", &gpu_steady_power_deviation,&gpu_steady_min_period);
-        }
+    // NOTE: After changing the nonlinear model to only scaling idle core,
+    // NOTE: The min_inc_per_active_sm is not used any more
+    if (g_use_nonlinear_model)
+      sscanf(gpu_nonlinear_model_config, "%lf:%lf", &gpu_idle_core_power,
+             &gpu_min_inc_per_active_sm);
+  }
+  void reg_options(class OptionParser *opp);
 
-        //NOTE: After changing the nonlinear model to only scaling idle core,
-        //NOTE: The min_inc_per_active_sm is not used any more
-		if (g_use_nonlinear_model)
-		    sscanf(gpu_nonlinear_model_config,"%lf:%lf", &gpu_idle_core_power,&gpu_min_inc_per_active_sm);
+  char *g_power_config_name;
 
-	}
-	void reg_options(class OptionParser * opp);
+  bool m_valid;
+  bool g_power_simulation_enabled;
+  bool g_power_trace_enabled;
+  bool g_steady_power_levels_enabled;
+  bool g_power_per_cycle_dump;
+  bool g_power_simulator_debug;
+  char *g_power_filename;
+  char *g_power_trace_filename;
+  char *g_metric_trace_filename;
+  char *g_steady_state_tracking_filename;
+  int g_power_trace_zlevel;
+  char *gpu_steady_state_definition;
+  double gpu_steady_power_deviation;
+  double gpu_steady_min_period;
 
-	char *g_power_config_name;
-
-	bool m_valid;
-    bool g_power_simulation_enabled;
-    bool g_power_trace_enabled;
-    bool g_steady_power_levels_enabled;
-    bool g_power_per_cycle_dump;
-    bool g_power_simulator_debug;
-    char *g_power_filename;
-    char *g_power_trace_filename;
-    char *g_metric_trace_filename;
-    char * g_steady_state_tracking_filename;
-    int g_power_trace_zlevel;
-    char * gpu_steady_state_definition;
-    double gpu_steady_power_deviation;
-    double gpu_steady_min_period;
-
-    //Nonlinear power model
-    bool g_use_nonlinear_model;
-    char * gpu_nonlinear_model_config;
-    double gpu_idle_core_power;
-    double gpu_min_inc_per_active_sm;
-
-
+  // Nonlinear power model
+  bool g_use_nonlinear_model;
+  char *gpu_nonlinear_model_config;
+  double gpu_idle_core_power;
+  double gpu_min_inc_per_active_sm;
 };
-
 
 class memory_config {
-    public:
-   memory_config(gpgpu_context* ctx)
-   {
-       m_valid = false;
-       gpgpu_dram_timing_opt=NULL;
-       gpgpu_L2_queue_config=NULL;
-       gpgpu_ctx = ctx;
-   }
-   void init()
-   {
-      assert(gpgpu_dram_timing_opt);
-      if (strchr(gpgpu_dram_timing_opt, '=') == NULL) {
-         // dram timing option in ordered variables (legacy)
-         // Disabling bank groups if their values are not specified
-         nbkgrp = 1;
-         tCCDL = 0;
-         tRTPL = 0;
-         sscanf(gpgpu_dram_timing_opt,"%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d",
-                &nbk,&tCCD,&tRRD,&tRCD,&tRAS,&tRP,&tRC,&CL,&WL,&tCDLR,&tWR,&nbkgrp,&tCCDL,&tRTPL);
-      } else {
-         // named dram timing options (unordered)
-         option_parser_t dram_opp = option_parser_create(); 
+ public:
+  memory_config(gpgpu_context *ctx) {
+    m_valid = false;
+    gpgpu_dram_timing_opt = NULL;
+    gpgpu_L2_queue_config = NULL;
+    gpgpu_ctx = ctx;
+  }
+  void init() {
+    assert(gpgpu_dram_timing_opt);
+    if (strchr(gpgpu_dram_timing_opt, '=') == NULL) {
+      // dram timing option in ordered variables (legacy)
+      // Disabling bank groups if their values are not specified
+      nbkgrp = 1;
+      tCCDL = 0;
+      tRTPL = 0;
+      sscanf(gpgpu_dram_timing_opt, "%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d",
+             &nbk, &tCCD, &tRRD, &tRCD, &tRAS, &tRP, &tRC, &CL, &WL, &tCDLR,
+             &tWR, &nbkgrp, &tCCDL, &tRTPL);
+    } else {
+      // named dram timing options (unordered)
+      option_parser_t dram_opp = option_parser_create();
 
-         option_parser_register(dram_opp, "nbk",  OPT_UINT32, &nbk,   "number of banks", ""); 
-         option_parser_register(dram_opp, "CCD",  OPT_UINT32, &tCCD,  "column to column delay", ""); 
-         option_parser_register(dram_opp, "RRD",  OPT_UINT32, &tRRD,  "minimal delay between activation of rows in different banks", ""); 
-         option_parser_register(dram_opp, "RCD",  OPT_UINT32, &tRCD,  "row to column delay", ""); 
-         option_parser_register(dram_opp, "RAS",  OPT_UINT32, &tRAS,  "time needed to activate row", ""); 
-         option_parser_register(dram_opp, "RP",   OPT_UINT32, &tRP,   "time needed to precharge (deactivate) row", ""); 
-         option_parser_register(dram_opp, "RC",   OPT_UINT32, &tRC,   "row cycle time", ""); 
-         option_parser_register(dram_opp, "CDLR", OPT_UINT32, &tCDLR, "switching from write to read (changes tWTR)", ""); 
-         option_parser_register(dram_opp, "WR",   OPT_UINT32, &tWR,   "last data-in to row precharge", ""); 
+      option_parser_register(dram_opp, "nbk", OPT_UINT32, &nbk,
+                             "number of banks", "");
+      option_parser_register(dram_opp, "CCD", OPT_UINT32, &tCCD,
+                             "column to column delay", "");
+      option_parser_register(
+          dram_opp, "RRD", OPT_UINT32, &tRRD,
+          "minimal delay between activation of rows in different banks", "");
+      option_parser_register(dram_opp, "RCD", OPT_UINT32, &tRCD,
+                             "row to column delay", "");
+      option_parser_register(dram_opp, "RAS", OPT_UINT32, &tRAS,
+                             "time needed to activate row", "");
+      option_parser_register(dram_opp, "RP", OPT_UINT32, &tRP,
+                             "time needed to precharge (deactivate) row", "");
+      option_parser_register(dram_opp, "RC", OPT_UINT32, &tRC, "row cycle time",
+                             "");
+      option_parser_register(dram_opp, "CDLR", OPT_UINT32, &tCDLR,
+                             "switching from write to read (changes tWTR)", "");
+      option_parser_register(dram_opp, "WR", OPT_UINT32, &tWR,
+                             "last data-in to row precharge", "");
 
-         option_parser_register(dram_opp, "CL", OPT_UINT32, &CL, "CAS latency", ""); 
-         option_parser_register(dram_opp, "WL", OPT_UINT32, &WL, "Write latency", ""); 
+      option_parser_register(dram_opp, "CL", OPT_UINT32, &CL, "CAS latency",
+                             "");
+      option_parser_register(dram_opp, "WL", OPT_UINT32, &WL, "Write latency",
+                             "");
 
-         //Disabling bank groups if their values are not specified
-         option_parser_register(dram_opp, "nbkgrp", OPT_UINT32, &nbkgrp, "number of bank groups", "1"); 
-         option_parser_register(dram_opp, "CCDL",   OPT_UINT32, &tCCDL,  "column to column delay between accesses to different bank groups", "0"); 
-         option_parser_register(dram_opp, "RTPL",   OPT_UINT32, &tRTPL,  "read to precharge delay between accesses to different bank groups", "0"); 
+      // Disabling bank groups if their values are not specified
+      option_parser_register(dram_opp, "nbkgrp", OPT_UINT32, &nbkgrp,
+                             "number of bank groups", "1");
+      option_parser_register(
+          dram_opp, "CCDL", OPT_UINT32, &tCCDL,
+          "column to column delay between accesses to different bank groups",
+          "0");
+      option_parser_register(
+          dram_opp, "RTPL", OPT_UINT32, &tRTPL,
+          "read to precharge delay between accesses to different bank groups",
+          "0");
 
-         option_parser_delimited_string(dram_opp, gpgpu_dram_timing_opt, "=:;"); 
-         fprintf(stdout, "DRAM Timing Options:\n"); 
-         option_parser_print(dram_opp, stdout); 
-         option_parser_destroy(dram_opp); 
-      }
+      option_parser_delimited_string(dram_opp, gpgpu_dram_timing_opt, "=:;");
+      fprintf(stdout, "DRAM Timing Options:\n");
+      option_parser_print(dram_opp, stdout);
+      option_parser_destroy(dram_opp);
+    }
 
-      int nbkt = nbk/nbkgrp;
-      unsigned i;
-      for (i=0; nbkt>0; i++) {
-          nbkt = nbkt>>1;
-      }
-      bk_tag_length = i-1;
-      assert(nbkgrp>0 && "Number of bank groups cannot be zero");
-      tRCDWR = tRCD-(WL+1);
-      if(elimnate_rw_turnaround)
-      {
-    	  tRTW = 0;
-    	  tWTR = 0;
-      } else {
-      tRTW = (CL+(BL/data_command_freq_ratio)+2-WL);
-      tWTR = (WL+(BL/data_command_freq_ratio)+tCDLR);
-      }
-      tWTP = (WL+(BL/data_command_freq_ratio)+tWR);
-      dram_atom_size = BL * busW * gpu_n_mem_per_ctrlr; // burst length x bus width x # chips per partition 
+    int nbkt = nbk / nbkgrp;
+    unsigned i;
+    for (i = 0; nbkt > 0; i++) {
+      nbkt = nbkt >> 1;
+    }
+    bk_tag_length = i - 1;
+    assert(nbkgrp > 0 && "Number of bank groups cannot be zero");
+    tRCDWR = tRCD - (WL + 1);
+    if (elimnate_rw_turnaround) {
+      tRTW = 0;
+      tWTR = 0;
+    } else {
+      tRTW = (CL + (BL / data_command_freq_ratio) + 2 - WL);
+      tWTR = (WL + (BL / data_command_freq_ratio) + tCDLR);
+    }
+    tWTP = (WL + (BL / data_command_freq_ratio) + tWR);
+    dram_atom_size =
+        BL * busW * gpu_n_mem_per_ctrlr;  // burst length x bus width x # chips
+                                          // per partition
 
-      assert( m_n_sub_partition_per_memory_channel > 0 ); 
-      assert( (nbk % m_n_sub_partition_per_memory_channel == 0) 
-              && "Number of DRAM banks must be a perfect multiple of memory sub partition"); 
-      m_n_mem_sub_partition = m_n_mem * m_n_sub_partition_per_memory_channel; 
-      fprintf(stdout, "Total number of memory sub partition = %u\n", m_n_mem_sub_partition); 
+    assert(m_n_sub_partition_per_memory_channel > 0);
+    assert((nbk % m_n_sub_partition_per_memory_channel == 0) &&
+           "Number of DRAM banks must be a perfect multiple of memory sub "
+           "partition");
+    m_n_mem_sub_partition = m_n_mem * m_n_sub_partition_per_memory_channel;
+    fprintf(stdout, "Total number of memory sub partition = %u\n",
+            m_n_mem_sub_partition);
 
-      m_address_mapping.init(m_n_mem, m_n_sub_partition_per_memory_channel);
-      m_L2_config.init(&m_address_mapping);
+    m_address_mapping.init(m_n_mem, m_n_sub_partition_per_memory_channel);
+    m_L2_config.init(&m_address_mapping);
 
-      m_valid = true;
+    m_valid = true;
 
-      sscanf(write_queue_size_opt,"%d:%d:%d",
-                     &gpgpu_frfcfs_dram_write_queue_size,&write_high_watermark,&write_low_watermark);
-   }
-   void reg_options(class OptionParser * opp);
+    sscanf(write_queue_size_opt, "%d:%d:%d",
+           &gpgpu_frfcfs_dram_write_queue_size, &write_high_watermark,
+           &write_low_watermark);
+  }
+  void reg_options(class OptionParser *opp);
 
-   bool m_valid;
-   mutable l2_cache_config m_L2_config;
-   bool m_L2_texure_only;
+  bool m_valid;
+  mutable l2_cache_config m_L2_config;
+  bool m_L2_texure_only;
 
-   char *gpgpu_dram_timing_opt;
-   char *gpgpu_L2_queue_config;
-   bool l2_ideal;
-   unsigned gpgpu_frfcfs_dram_sched_queue_size;
-   unsigned gpgpu_dram_return_queue_size;
-   enum dram_ctrl_t scheduler_type;
-   bool gpgpu_memlatency_stat;
-   unsigned m_n_mem;
-   unsigned m_n_sub_partition_per_memory_channel;
-   unsigned m_n_mem_sub_partition;
-   unsigned gpu_n_mem_per_ctrlr;
+  char *gpgpu_dram_timing_opt;
+  char *gpgpu_L2_queue_config;
+  bool l2_ideal;
+  unsigned gpgpu_frfcfs_dram_sched_queue_size;
+  unsigned gpgpu_dram_return_queue_size;
+  enum dram_ctrl_t scheduler_type;
+  bool gpgpu_memlatency_stat;
+  unsigned m_n_mem;
+  unsigned m_n_sub_partition_per_memory_channel;
+  unsigned m_n_mem_sub_partition;
+  unsigned gpu_n_mem_per_ctrlr;
 
-   unsigned rop_latency;
-   unsigned dram_latency;
+  unsigned rop_latency;
+  unsigned dram_latency;
 
-   // DRAM parameters
+  // DRAM parameters
 
-   unsigned tCCDL;  //column to column delay when bank groups are enabled
-   unsigned tRTPL;  //read to precharge delay when bank groups are enabled for GDDR5 this is identical to RTPS, if for other DRAM this is different, you will need to split them in two
+  unsigned tCCDL;  // column to column delay when bank groups are enabled
+  unsigned tRTPL;  // read to precharge delay when bank groups are enabled for
+                   // GDDR5 this is identical to RTPS, if for other DRAM this is
+                   // different, you will need to split them in two
 
-   unsigned tCCD;   //column to column delay
-   unsigned tRRD;   //minimal time required between activation of rows in different banks
-   unsigned tRCD;   //row to column delay - time required to activate a row before a read
-   unsigned tRCDWR; //row to column delay for a write command
-   unsigned tRAS;   //time needed to activate row
-   unsigned tRP;    //row precharge ie. deactivate row
-   unsigned tRC;    //row cycle time ie. precharge current, then activate different row
-   unsigned tCDLR;  //Last data-in to Read command (switching from write to read)
-   unsigned tWR;    //Last data-in to Row precharge 
+  unsigned tCCD;  // column to column delay
+  unsigned tRRD;  // minimal time required between activation of rows in
+                  // different banks
+  unsigned tRCD;  // row to column delay - time required to activate a row
+                  // before a read
+  unsigned tRCDWR;  // row to column delay for a write command
+  unsigned tRAS;    // time needed to activate row
+  unsigned tRP;     // row precharge ie. deactivate row
+  unsigned
+      tRC;  // row cycle time ie. precharge current, then activate different row
+  unsigned tCDLR;  // Last data-in to Read command (switching from write to
+                   // read)
+  unsigned tWR;  // Last data-in to Row precharge
 
-   unsigned CL;     //CAS latency
-   unsigned WL;     //WRITE latency
-   unsigned BL;     //Burst Length in bytes (4 in GDDR3, 8 in GDDR5)
-   unsigned tRTW;   //time to switch from read to write
-   unsigned tWTR;   //time to switch from write to read 
-   unsigned tWTP;   //time to switch from write to precharge in the same bank
-   unsigned busW;
+  unsigned CL;    // CAS latency
+  unsigned WL;    // WRITE latency
+  unsigned BL;    // Burst Length in bytes (4 in GDDR3, 8 in GDDR5)
+  unsigned tRTW;  // time to switch from read to write
+  unsigned tWTR;  // time to switch from write to read
+  unsigned tWTP;  // time to switch from write to precharge in the same bank
+  unsigned busW;
 
-   unsigned nbkgrp; // number of bank groups (has to be power of 2)
-   unsigned bk_tag_length; //number of bits that define a bank inside a bank group
+  unsigned nbkgrp;  // number of bank groups (has to be power of 2)
+  unsigned
+      bk_tag_length;  // number of bits that define a bank inside a bank group
 
-   unsigned nbk;
+  unsigned nbk;
 
-   bool elimnate_rw_turnaround;
+  bool elimnate_rw_turnaround;
 
-   unsigned data_command_freq_ratio; // frequency ratio between DRAM data bus and command bus (2 for GDDR3, 4 for GDDR5)
-   unsigned dram_atom_size; // number of bytes transferred per read or write command 
+  unsigned
+      data_command_freq_ratio;  // frequency ratio between DRAM data bus and
+                                // command bus (2 for GDDR3, 4 for GDDR5)
+  unsigned
+      dram_atom_size;  // number of bytes transferred per read or write command
 
-   linear_to_raw_address_translation m_address_mapping;
+  linear_to_raw_address_translation m_address_mapping;
 
-   unsigned icnt_flit_size;
+  unsigned icnt_flit_size;
 
-   unsigned dram_bnk_indexing_policy;
-   unsigned dram_bnkgrp_indexing_policy;
-   bool dual_bus_interface;
+  unsigned dram_bnk_indexing_policy;
+  unsigned dram_bnkgrp_indexing_policy;
+  bool dual_bus_interface;
 
-   bool seperate_write_queue_enabled;
-   char *write_queue_size_opt;
-   unsigned gpgpu_frfcfs_dram_write_queue_size;
-   unsigned write_high_watermark;
-   unsigned write_low_watermark;
-   bool m_perf_sim_memcpy;
-   bool simple_dram_model;
+  bool seperate_write_queue_enabled;
+  char *write_queue_size_opt;
+  unsigned gpgpu_frfcfs_dram_write_queue_size;
+  unsigned write_high_watermark;
+  unsigned write_low_watermark;
+  bool m_perf_sim_memcpy;
+  bool simple_dram_model;
 
-   gpgpu_context* gpgpu_ctx;
+  gpgpu_context *gpgpu_ctx;
 };
-
 
 extern bool g_interactive_debugger_enabled;
 
-class gpgpu_sim_config : public power_config, public gpgpu_functional_sim_config {
-public:
-    gpgpu_sim_config(gpgpu_context* ctx): m_shader_config(ctx), m_memory_config(ctx) {
-	m_valid = false;
-	gpgpu_ctx = ctx;
+class gpgpu_sim_config : public power_config,
+                         public gpgpu_functional_sim_config {
+ public:
+  gpgpu_sim_config(gpgpu_context *ctx)
+      : m_shader_config(ctx), m_memory_config(ctx) {
+    m_valid = false;
+    gpgpu_ctx = ctx;
+  }
+  void reg_options(class OptionParser *opp);
+  void init() {
+    gpu_stat_sample_freq = 10000;
+    gpu_runtime_stat_flag = 0;
+    sscanf(gpgpu_runtime_stat, "%d:%x", &gpu_stat_sample_freq,
+           &gpu_runtime_stat_flag);
+    m_shader_config.init();
+    ptx_set_tex_cache_linesize(m_shader_config.m_L1T_config.get_line_sz());
+    m_memory_config.init();
+    init_clock_domains();
+    power_config::init();
+    Trace::init();
+
+    // initialize file name if it is not set
+    time_t curr_time;
+    time(&curr_time);
+    char *date = ctime(&curr_time);
+    char *s = date;
+    while (*s) {
+      if (*s == ' ' || *s == '\t' || *s == ':') *s = '-';
+      if (*s == '\n' || *s == '\r') *s = 0;
+      s++;
     }
-    void reg_options(class OptionParser * opp);
-    void init() 
-    {
-        gpu_stat_sample_freq = 10000;
-        gpu_runtime_stat_flag = 0;
-        sscanf(gpgpu_runtime_stat, "%d:%x", &gpu_stat_sample_freq, &gpu_runtime_stat_flag);
-        m_shader_config.init();
-        ptx_set_tex_cache_linesize(m_shader_config.m_L1T_config.get_line_sz());
-        m_memory_config.init();
-        init_clock_domains(); 
-        power_config::init();
-        Trace::init();
+    char buf[1024];
+    snprintf(buf, 1024, "gpgpusim_visualizer__%s.log.gz", date);
+    g_visualizer_filename = strdup(buf);
 
+    m_valid = true;
+  }
 
-        // initialize file name if it is not set 
-        time_t curr_time;
-        time(&curr_time);
-        char *date = ctime(&curr_time);
-        char *s = date;
-        while (*s) {
-            if (*s == ' ' || *s == '\t' || *s == ':') *s = '-';
-            if (*s == '\n' || *s == '\r' ) *s = 0;
-            s++;
-        }
-        char buf[1024];
-        snprintf(buf,1024,"gpgpusim_visualizer__%s.log.gz",date);
-        g_visualizer_filename = strdup(buf);
+  unsigned num_shader() const { return m_shader_config.num_shader(); }
+  unsigned num_cluster() const { return m_shader_config.n_simt_clusters; }
+  unsigned get_max_concurrent_kernel() const { return max_concurrent_kernel; }
+  unsigned checkpoint_option;
 
-        m_valid=true;
-    }
+  size_t stack_limit() const { return stack_size_limit; }
+  size_t heap_limit() const { return heap_size_limit; }
+  size_t sync_depth_limit() const { return runtime_sync_depth_limit; }
+  size_t pending_launch_count_limit() const {
+    return runtime_pending_launch_count_limit;
+  }
 
-    unsigned num_shader() const { return m_shader_config.num_shader(); }
-    unsigned num_cluster() const { return m_shader_config.n_simt_clusters; }
-    unsigned get_max_concurrent_kernel() const { return max_concurrent_kernel; }
-    unsigned checkpoint_option;
+ private:
+  void init_clock_domains(void);
 
-    size_t stack_limit() const {return stack_size_limit; }
-    size_t heap_limit() const {return heap_size_limit; }
-    size_t sync_depth_limit() const {return runtime_sync_depth_limit; }
-    size_t pending_launch_count_limit() const {return runtime_pending_launch_count_limit;}
+  // backward pointer
+  class gpgpu_context *gpgpu_ctx;
+  bool m_valid;
+  shader_core_config m_shader_config;
+  memory_config m_memory_config;
+  // clock domains - frequency
+  double core_freq;
+  double icnt_freq;
+  double dram_freq;
+  double l2_freq;
+  double core_period;
+  double icnt_period;
+  double dram_period;
+  double l2_period;
 
-private:
-    void init_clock_domains(void ); 
+  // GPGPU-Sim timing model options
+  unsigned long long gpu_max_cycle_opt;
+  unsigned long long gpu_max_insn_opt;
+  unsigned gpu_max_cta_opt;
+  char *gpgpu_runtime_stat;
+  bool gpgpu_flush_l1_cache;
+  bool gpgpu_flush_l2_cache;
+  bool gpu_deadlock_detect;
+  int gpgpu_frfcfs_dram_sched_queue_size;
+  int gpgpu_cflog_interval;
+  char *gpgpu_clock_domains;
+  unsigned max_concurrent_kernel;
 
+  // visualizer
+  bool g_visualizer_enabled;
+  char *g_visualizer_filename;
+  int g_visualizer_zlevel;
 
-    // backward pointer
-    class gpgpu_context* gpgpu_ctx;
-    bool m_valid;
-    shader_core_config m_shader_config;
-    memory_config m_memory_config;
-    // clock domains - frequency
-    double core_freq;
-    double icnt_freq;
-    double dram_freq;
-    double l2_freq;
-    double core_period;
-    double icnt_period;
-    double dram_period;
-    double l2_period;
+  // statistics collection
+  int gpu_stat_sample_freq;
+  int gpu_runtime_stat_flag;
 
-    // GPGPU-Sim timing model options
-    unsigned long long gpu_max_cycle_opt;
-    unsigned long long gpu_max_insn_opt;
-    unsigned gpu_max_cta_opt;
-    char *gpgpu_runtime_stat;
-    bool  gpgpu_flush_l1_cache;
-    bool  gpgpu_flush_l2_cache;
-    bool  gpu_deadlock_detect;
-    int   gpgpu_frfcfs_dram_sched_queue_size; 
-    int   gpgpu_cflog_interval;
-    char * gpgpu_clock_domains;
-    unsigned max_concurrent_kernel;
+  // Device Limits
+  size_t stack_size_limit;
+  size_t heap_size_limit;
+  size_t runtime_sync_depth_limit;
+  size_t runtime_pending_launch_count_limit;
 
-    // visualizer
-    bool  g_visualizer_enabled;
-    char *g_visualizer_filename;
-    int   g_visualizer_zlevel;
+  // gpu compute capability options
+  unsigned int gpgpu_compute_capability_major;
+  unsigned int gpgpu_compute_capability_minor;
+  unsigned long long liveness_message_freq;
 
-
-    // statistics collection
-    int gpu_stat_sample_freq;
-    int gpu_runtime_stat_flag;
-
-    // Device Limits
-    size_t stack_size_limit;
-    size_t heap_size_limit;
-    size_t runtime_sync_depth_limit;
-    size_t runtime_pending_launch_count_limit;	
-
- //gpu compute capability options
-    unsigned int gpgpu_compute_capability_major;
-    unsigned int gpgpu_compute_capability_minor;
-    unsigned long long liveness_message_freq; 
-
-    friend class gpgpu_sim;
+  friend class gpgpu_sim;
 };
 
 struct occupancy_stats {
-    occupancy_stats() : aggregate_warp_slot_filled(0), aggregate_theoretical_warp_slots(0){}
-    occupancy_stats( unsigned long long wsf, unsigned long long tws )
-        : aggregate_warp_slot_filled(wsf), aggregate_theoretical_warp_slots(tws){}
+  occupancy_stats()
+      : aggregate_warp_slot_filled(0), aggregate_theoretical_warp_slots(0) {}
+  occupancy_stats(unsigned long long wsf, unsigned long long tws)
+      : aggregate_warp_slot_filled(wsf),
+        aggregate_theoretical_warp_slots(tws) {}
 
-    unsigned long long aggregate_warp_slot_filled;
-    unsigned long long aggregate_theoretical_warp_slots;
+  unsigned long long aggregate_warp_slot_filled;
+  unsigned long long aggregate_theoretical_warp_slots;
 
-    float get_occ_fraction() const {
-        return float(aggregate_warp_slot_filled) / float(aggregate_theoretical_warp_slots);
-    }
+  float get_occ_fraction() const {
+    return float(aggregate_warp_slot_filled) /
+           float(aggregate_theoretical_warp_slots);
+  }
 
-    occupancy_stats& operator+=(const occupancy_stats& rhs) {
-        aggregate_warp_slot_filled += rhs.aggregate_warp_slot_filled;
-        aggregate_theoretical_warp_slots += rhs.aggregate_theoretical_warp_slots;
-        return *this;
-    }
+  occupancy_stats &operator+=(const occupancy_stats &rhs) {
+    aggregate_warp_slot_filled += rhs.aggregate_warp_slot_filled;
+    aggregate_theoretical_warp_slots += rhs.aggregate_theoretical_warp_slots;
+    return *this;
+  }
 
-    occupancy_stats operator+(const occupancy_stats& rhs) const{
-        return occupancy_stats( aggregate_warp_slot_filled + rhs.aggregate_warp_slot_filled,
-                                aggregate_theoretical_warp_slots + rhs.aggregate_theoretical_warp_slots
-                               );
-    }
+  occupancy_stats operator+(const occupancy_stats &rhs) const {
+    return occupancy_stats(
+        aggregate_warp_slot_filled + rhs.aggregate_warp_slot_filled,
+        aggregate_theoretical_warp_slots +
+            rhs.aggregate_theoretical_warp_slots);
+  }
 };
 
 class gpgpu_context;
 class ptx_instruction;
 
 class watchpoint_event {
-public:
-   watchpoint_event()
-   {
-      m_thread=NULL;
-      m_inst=NULL;
-   }
-   watchpoint_event(const ptx_thread_info *thd, const ptx_instruction *pI)
-   {
-      m_thread=thd;
-      m_inst = pI;
-   }
-   const ptx_thread_info *thread() const { return m_thread; }
-   const ptx_instruction *inst() const { return m_inst; }
-private:
-   const ptx_thread_info *m_thread;
-   const ptx_instruction *m_inst;
+ public:
+  watchpoint_event() {
+    m_thread = NULL;
+    m_inst = NULL;
+  }
+  watchpoint_event(const ptx_thread_info *thd, const ptx_instruction *pI) {
+    m_thread = thd;
+    m_inst = pI;
+  }
+  const ptx_thread_info *thread() const { return m_thread; }
+  const ptx_instruction *inst() const { return m_inst; }
+
+ private:
+  const ptx_thread_info *m_thread;
+  const ptx_instruction *m_inst;
 };
 
 class gpgpu_sim : public gpgpu_t {
-public:
-   gpgpu_sim( const gpgpu_sim_config &config, gpgpu_context* ctx );
+ public:
+  gpgpu_sim(const gpgpu_sim_config &config, gpgpu_context *ctx);
 
-   void set_prop( struct cudaDeviceProp *prop );
+  void set_prop(struct cudaDeviceProp *prop);
 
-   void launch( kernel_info_t *kinfo );
-   bool can_start_kernel();
-   unsigned finished_kernel();
-   void set_kernel_done( kernel_info_t *kernel );
-   void stop_all_running_kernels();
+  void launch(kernel_info_t *kinfo);
+  bool can_start_kernel();
+  unsigned finished_kernel();
+  void set_kernel_done(kernel_info_t *kernel);
+  void stop_all_running_kernels();
 
-   void init();
-   void cycle();
-   bool active(); 
-   bool cycle_insn_cta_max_hit() {
-       return (m_config.gpu_max_cycle_opt && (gpu_tot_sim_cycle + gpu_sim_cycle) >= m_config.gpu_max_cycle_opt) ||
-           (m_config.gpu_max_insn_opt && (gpu_tot_sim_insn + gpu_sim_insn) >= m_config.gpu_max_insn_opt) ||
-           (m_config.gpu_max_cta_opt && (gpu_tot_issued_cta >= m_config.gpu_max_cta_opt) );
-   }
-   void print_stats();
-   void update_stats();
-   void deadlock_check();
+  void init();
+  void cycle();
+  bool active();
+  bool cycle_insn_cta_max_hit() {
+    return (m_config.gpu_max_cycle_opt && (gpu_tot_sim_cycle + gpu_sim_cycle) >=
+                                              m_config.gpu_max_cycle_opt) ||
+           (m_config.gpu_max_insn_opt &&
+            (gpu_tot_sim_insn + gpu_sim_insn) >= m_config.gpu_max_insn_opt) ||
+           (m_config.gpu_max_cta_opt &&
+            (gpu_tot_issued_cta >= m_config.gpu_max_cta_opt));
+  }
+  void print_stats();
+  void update_stats();
+  void deadlock_check();
 
-   void get_pdom_stack_top_info( unsigned sid, unsigned tid, unsigned *pc, unsigned *rpc );
+  void get_pdom_stack_top_info(unsigned sid, unsigned tid, unsigned *pc,
+                               unsigned *rpc);
 
-   int shared_mem_size() const;
-   int shared_mem_per_block() const;
-   int compute_capability_major() const;
-   int compute_capability_minor() const;
-   int num_registers_per_core() const;
-   int num_registers_per_block() const;
-   int wrp_size() const;
-   int shader_clock() const;
-   int max_cta_per_core() const;
-   int get_max_cta( const kernel_info_t &k ) const;
-   const struct cudaDeviceProp *get_prop() const;
-   enum divergence_support_t simd_model() const; 
+  int shared_mem_size() const;
+  int shared_mem_per_block() const;
+  int compute_capability_major() const;
+  int compute_capability_minor() const;
+  int num_registers_per_core() const;
+  int num_registers_per_block() const;
+  int wrp_size() const;
+  int shader_clock() const;
+  int max_cta_per_core() const;
+  int get_max_cta(const kernel_info_t &k) const;
+  const struct cudaDeviceProp *get_prop() const;
+  enum divergence_support_t simd_model() const;
 
-   unsigned threads_per_core() const;
-   bool get_more_cta_left() const;
-   bool kernel_more_cta_left(kernel_info_t *kernel) const;
-   bool hit_max_cta_count() const;
-   kernel_info_t *select_kernel();
+  unsigned threads_per_core() const;
+  bool get_more_cta_left() const;
+  bool kernel_more_cta_left(kernel_info_t *kernel) const;
+  bool hit_max_cta_count() const;
+  kernel_info_t *select_kernel();
 
-   const gpgpu_sim_config &get_config() const { return m_config; }
-   void gpu_print_stat();
-   void dump_pipeline( int mask, int s, int m ) const;
+  const gpgpu_sim_config &get_config() const { return m_config; }
+  void gpu_print_stat();
+  void dump_pipeline(int mask, int s, int m) const;
 
-    void perf_memcpy_to_gpu( size_t dst_start_addr, size_t count );
+  void perf_memcpy_to_gpu(size_t dst_start_addr, size_t count);
 
-   //The next three functions added to be used by the functional simulation function
-   
-   //! Get shader core configuration
-   /*!
-    * Returning the configuration of the shader core, used by the functional simulation only so far
-    */
-   const shader_core_config * getShaderCoreConfig();
-   
-   
-   //! Get shader core Memory Configuration
-    /*!
-    * Returning the memory configuration of the shader core, used by the functional simulation only so far
-    */
-   const memory_config * getMemoryConfig();
-   
-   
-   //! Get shader core SIMT cluster
-   /*!
-    * Returning the cluster of of the shader core, used by the functional simulation so far
-    */
-    simt_core_cluster * getSIMTCluster();
+  // The next three functions added to be used by the functional simulation
+  // function
 
-    void hit_watchpoint( unsigned watchpoint_num, ptx_thread_info *thd, const ptx_instruction *pI );
+  //! Get shader core configuration
+  /*!
+   * Returning the configuration of the shader core, used by the functional
+   * simulation only so far
+   */
+  const shader_core_config *getShaderCoreConfig();
 
-    // backward pointer
-    class gpgpu_context* gpgpu_ctx;
+  //! Get shader core Memory Configuration
+  /*!
+   * Returning the memory configuration of the shader core, used by the
+   * functional simulation only so far
+   */
+  const memory_config *getMemoryConfig();
 
-private:
-   // clocks
-   void reinit_clock_domains(void);
-   int  next_clock_domain(void);
-   void issue_block2core();
-   void print_dram_stats(FILE *fout) const;
-   void shader_print_runtime_stat( FILE *fout );
-   void shader_print_l1_miss_stat( FILE *fout ) const;
-   void shader_print_cache_stats( FILE *fout ) const;
-   void shader_print_scheduler_stat( FILE* fout, bool print_dynamic_info ) const;
-   void visualizer_printstat();
-   void print_shader_cycle_distro( FILE *fout ) const;
+  //! Get shader core SIMT cluster
+  /*!
+   * Returning the cluster of of the shader core, used by the functional
+   * simulation so far
+   */
+  simt_core_cluster *getSIMTCluster();
 
-   void gpgpu_debug();
+  void hit_watchpoint(unsigned watchpoint_num, ptx_thread_info *thd,
+                      const ptx_instruction *pI);
 
-///// data /////
+  // backward pointer
+  class gpgpu_context *gpgpu_ctx;
 
-   class simt_core_cluster **m_cluster;
-   class memory_partition_unit **m_memory_partition_unit;
-   class memory_sub_partition **m_memory_sub_partition;
+ private:
+  // clocks
+  void reinit_clock_domains(void);
+  int next_clock_domain(void);
+  void issue_block2core();
+  void print_dram_stats(FILE *fout) const;
+  void shader_print_runtime_stat(FILE *fout);
+  void shader_print_l1_miss_stat(FILE *fout) const;
+  void shader_print_cache_stats(FILE *fout) const;
+  void shader_print_scheduler_stat(FILE *fout, bool print_dynamic_info) const;
+  void visualizer_printstat();
+  void print_shader_cycle_distro(FILE *fout) const;
 
-   std::vector<kernel_info_t*> m_running_kernels;
-   unsigned m_last_issued_kernel;
+  void gpgpu_debug();
 
-   std::list<unsigned> m_finished_kernel;
-   // m_total_cta_launched == per-kernel count. gpu_tot_issued_cta == global count.
-   unsigned long long m_total_cta_launched;
-   unsigned long long gpu_tot_issued_cta;
+  ///// data /////
 
-   unsigned m_last_cluster_issue;
-   float * average_pipeline_duty_cycle;
-   float * active_sms;
-   // time of next rising edge 
-   double core_time;
-   double icnt_time;
-   double dram_time;
-   double l2_time;
+  class simt_core_cluster **m_cluster;
+  class memory_partition_unit **m_memory_partition_unit;
+  class memory_sub_partition **m_memory_sub_partition;
 
-   // debug
-   bool gpu_deadlock;
+  std::vector<kernel_info_t *> m_running_kernels;
+  unsigned m_last_issued_kernel;
 
-   //// configuration parameters ////
-   const gpgpu_sim_config &m_config;
-  
-   const struct cudaDeviceProp     *m_cuda_properties;
-   const shader_core_config *m_shader_config;
-   const memory_config      *m_memory_config;
+  std::list<unsigned> m_finished_kernel;
+  // m_total_cta_launched == per-kernel count. gpu_tot_issued_cta == global
+  // count.
+  unsigned long long m_total_cta_launched;
+  unsigned long long gpu_tot_issued_cta;
 
-   // stats
-   class shader_core_stats  *m_shader_stats;
-   class memory_stats_t     *m_memory_stats;
-   class power_stat_t *m_power_stats;
-   class gpgpu_sim_wrapper *m_gpgpusim_wrapper;
-   unsigned long long  last_gpu_sim_insn;
+  unsigned m_last_cluster_issue;
+  float *average_pipeline_duty_cycle;
+  float *active_sms;
+  // time of next rising edge
+  double core_time;
+  double icnt_time;
+  double dram_time;
+  double l2_time;
 
-   unsigned long long  last_liveness_message_time; 
+  // debug
+  bool gpu_deadlock;
 
-   std::map<std::string, FuncCache> m_special_cache_config;
+  //// configuration parameters ////
+  const gpgpu_sim_config &m_config;
 
-   std::vector<std::string> m_executed_kernel_names; //< names of kernel for stat printout 
-   std::vector<unsigned> m_executed_kernel_uids; //< uids of kernel launches for stat printout
-   std::map<unsigned,watchpoint_event> g_watchpoint_hits;
+  const struct cudaDeviceProp *m_cuda_properties;
+  const shader_core_config *m_shader_config;
+  const memory_config *m_memory_config;
 
-   std::string executed_kernel_info_string(); //< format the kernel information into a string for stat printout
-   void clear_executed_kernel_info(); //< clear the kernel information after stat printout
+  // stats
+  class shader_core_stats *m_shader_stats;
+  class memory_stats_t *m_memory_stats;
+  class power_stat_t *m_power_stats;
+  class gpgpu_sim_wrapper *m_gpgpusim_wrapper;
+  unsigned long long last_gpu_sim_insn;
 
+  unsigned long long last_liveness_message_time;
 
-public:
-   unsigned long long  gpu_sim_insn;
-   unsigned long long  gpu_tot_sim_insn;
-   unsigned long long  gpu_sim_insn_last_update;
-   unsigned gpu_sim_insn_last_update_sid;
-   occupancy_stats gpu_occupancy;
-   occupancy_stats gpu_tot_occupancy;
+  std::map<std::string, FuncCache> m_special_cache_config;
 
-   // performance counter for stalls due to congestion.
-   unsigned int gpu_stall_dramfull;
-   unsigned int gpu_stall_icnt2sh;
-   unsigned long long partiton_reqs_in_parallel;
-   unsigned long long partiton_reqs_in_parallel_total;
-   unsigned long long partiton_reqs_in_parallel_util;
-   unsigned long long partiton_reqs_in_parallel_util_total;
-   unsigned long long  gpu_sim_cycle_parition_util;
-   unsigned long long  gpu_tot_sim_cycle_parition_util;
-   unsigned long long partiton_replys_in_parallel;
-   unsigned long long partiton_replys_in_parallel_total;
+  std::vector<std::string>
+      m_executed_kernel_names;  //< names of kernel for stat printout
+  std::vector<unsigned>
+      m_executed_kernel_uids;  //< uids of kernel launches for stat printout
+  std::map<unsigned, watchpoint_event> g_watchpoint_hits;
 
+  std::string executed_kernel_info_string();  //< format the kernel information
+                                              //into a string for stat printout
+  void clear_executed_kernel_info();  //< clear the kernel information after
+                                      //stat printout
 
-   FuncCache get_cache_config(std::string kernel_name);
-   void set_cache_config(std::string kernel_name, FuncCache cacheConfig );
-   bool has_special_cache_config(std::string kernel_name);
-   void change_cache_config(FuncCache cache_config);
-   void set_cache_config(std::string kernel_name);
+ public:
+  unsigned long long gpu_sim_insn;
+  unsigned long long gpu_tot_sim_insn;
+  unsigned long long gpu_sim_insn_last_update;
+  unsigned gpu_sim_insn_last_update_sid;
+  occupancy_stats gpu_occupancy;
+  occupancy_stats gpu_tot_occupancy;
 
-   //Jin: functional simulation for CDP
-private:
-   //set by stream operation every time a functoinal simulation is done
-   bool m_functional_sim;
-   kernel_info_t * m_functional_sim_kernel;
+  // performance counter for stalls due to congestion.
+  unsigned int gpu_stall_dramfull;
+  unsigned int gpu_stall_icnt2sh;
+  unsigned long long partiton_reqs_in_parallel;
+  unsigned long long partiton_reqs_in_parallel_total;
+  unsigned long long partiton_reqs_in_parallel_util;
+  unsigned long long partiton_reqs_in_parallel_util_total;
+  unsigned long long gpu_sim_cycle_parition_util;
+  unsigned long long gpu_tot_sim_cycle_parition_util;
+  unsigned long long partiton_replys_in_parallel;
+  unsigned long long partiton_replys_in_parallel_total;
 
-public:
-   bool is_functional_sim() { return m_functional_sim; }
-   kernel_info_t * get_functional_kernel() { return m_functional_sim_kernel; }
-   void functional_launch(kernel_info_t * k) {
-     m_functional_sim = true;
-     m_functional_sim_kernel = k;
-   }
-   void finish_functional_sim(kernel_info_t * k) {
-     assert(m_functional_sim);
-     assert(m_functional_sim_kernel == k);
-     m_functional_sim = false;
-     m_functional_sim_kernel = NULL;
-   }
+  FuncCache get_cache_config(std::string kernel_name);
+  void set_cache_config(std::string kernel_name, FuncCache cacheConfig);
+  bool has_special_cache_config(std::string kernel_name);
+  void change_cache_config(FuncCache cache_config);
+  void set_cache_config(std::string kernel_name);
+
+  // Jin: functional simulation for CDP
+ private:
+  // set by stream operation every time a functoinal simulation is done
+  bool m_functional_sim;
+  kernel_info_t *m_functional_sim_kernel;
+
+ public:
+  bool is_functional_sim() { return m_functional_sim; }
+  kernel_info_t *get_functional_kernel() { return m_functional_sim_kernel; }
+  void functional_launch(kernel_info_t *k) {
+    m_functional_sim = true;
+    m_functional_sim_kernel = k;
+  }
+  void finish_functional_sim(kernel_info_t *k) {
+    assert(m_functional_sim);
+    assert(m_functional_sim_kernel == k);
+    m_functional_sim = false;
+    m_functional_sim_kernel = NULL;
+  }
 };
-
 
 #endif

--- a/src/gpgpu-sim/gpu-sim.h
+++ b/src/gpgpu-sim/gpu-sim.h
@@ -263,11 +263,11 @@ class memory_config {
                    // GDDR5 this is identical to RTPS, if for other DRAM this is
                    // different, you will need to split them in two
 
-  unsigned tCCD;  // column to column delay
-  unsigned tRRD;  // minimal time required between activation of rows in
-                  // different banks
-  unsigned tRCD;  // row to column delay - time required to activate a row
-                  // before a read
+  unsigned tCCD;    // column to column delay
+  unsigned tRRD;    // minimal time required between activation of rows in
+                    // different banks
+  unsigned tRCD;    // row to column delay - time required to activate a row
+                    // before a read
   unsigned tRCDWR;  // row to column delay for a write command
   unsigned tRAS;    // time needed to activate row
   unsigned tRP;     // row precharge ie. deactivate row
@@ -275,7 +275,7 @@ class memory_config {
       tRC;  // row cycle time ie. precharge current, then activate different row
   unsigned tCDLR;  // Last data-in to Read command (switching from write to
                    // read)
-  unsigned tWR;  // Last data-in to Row precharge
+  unsigned tWR;    // Last data-in to Row precharge
 
   unsigned CL;    // CAS latency
   unsigned WL;    // WRITE latency
@@ -626,9 +626,9 @@ class gpgpu_sim : public gpgpu_t {
   std::map<unsigned, watchpoint_event> g_watchpoint_hits;
 
   std::string executed_kernel_info_string();  //< format the kernel information
-                                              //into a string for stat printout
+                                              // into a string for stat printout
   void clear_executed_kernel_info();  //< clear the kernel information after
-                                      //stat printout
+                                      // stat printout
 
  public:
   unsigned long long gpu_sim_insn;

--- a/src/gpgpu-sim/histogram.cc
+++ b/src/gpgpu-sim/histogram.cc
@@ -7,118 +7,131 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #include "histogram.h"
 
 #include <assert.h>
 
-binned_histogram::binned_histogram (std::string name, int nbins, int* bins) 
-   : m_name(name), m_nbins(nbins), m_bins(NULL), m_bin_cnts(new int[m_nbins]), m_maximum(0), m_sum(0) 
-{
-   if (bins) {
-      m_bins = new int[m_nbins];
-      for (int i = 0; i < nbins; i++) {
-         m_bins[i] = bins[i];
-      }
-   }
+binned_histogram::binned_histogram(std::string name, int nbins, int* bins)
+    : m_name(name),
+      m_nbins(nbins),
+      m_bins(NULL),
+      m_bin_cnts(new int[m_nbins]),
+      m_maximum(0),
+      m_sum(0) {
+  if (bins) {
+    m_bins = new int[m_nbins];
+    for (int i = 0; i < nbins; i++) {
+      m_bins[i] = bins[i];
+    }
+  }
 
-   reset_bins();
+  reset_bins();
 }
 
-binned_histogram::binned_histogram (const binned_histogram& other)
-   : m_name(other.m_name), m_nbins(other.m_nbins), m_bins(NULL), 
-     m_bin_cnts(new int[m_nbins]), m_maximum(0), m_sum(0)
-{
-   for (int i = 0; i < m_nbins; i++) {
-      m_bin_cnts[i] = other.m_bin_cnts[i];
-   }
+binned_histogram::binned_histogram(const binned_histogram& other)
+    : m_name(other.m_name),
+      m_nbins(other.m_nbins),
+      m_bins(NULL),
+      m_bin_cnts(new int[m_nbins]),
+      m_maximum(0),
+      m_sum(0) {
+  for (int i = 0; i < m_nbins; i++) {
+    m_bin_cnts[i] = other.m_bin_cnts[i];
+  }
 }
 
-void binned_histogram::reset_bins () {
-   for (int i = 0; i < m_nbins; i++) {
-      m_bin_cnts[i] = 0;
-   }
+void binned_histogram::reset_bins() {
+  for (int i = 0; i < m_nbins; i++) {
+    m_bin_cnts[i] = 0;
+  }
 }
 
-void binned_histogram::add2bin (int sample) {
-   assert(0);
-   m_maximum = (sample > m_maximum)? sample : m_maximum;
+void binned_histogram::add2bin(int sample) {
+  assert(0);
+  m_maximum = (sample > m_maximum) ? sample : m_maximum;
 }
 
-void binned_histogram::fprint (FILE *fout) const
-{
-   if (m_name.c_str() != NULL) fprintf(fout, "%s = ", m_name.c_str());
-   int total_sample = 0;
-   for (int i = 0; i < m_nbins; i++) {
-      fprintf(fout, "%d ", m_bin_cnts[i]);
-      total_sample += m_bin_cnts[i];
-   }
-   fprintf(fout, "max=%d ", m_maximum);
-   float avg = 0.0f;
-   if (total_sample > 0) {
-      avg = (float)m_sum / total_sample;
-   }
-   fprintf(fout, "avg=%0.2f ", avg);
+void binned_histogram::fprint(FILE* fout) const {
+  if (m_name.c_str() != NULL) fprintf(fout, "%s = ", m_name.c_str());
+  int total_sample = 0;
+  for (int i = 0; i < m_nbins; i++) {
+    fprintf(fout, "%d ", m_bin_cnts[i]);
+    total_sample += m_bin_cnts[i];
+  }
+  fprintf(fout, "max=%d ", m_maximum);
+  float avg = 0.0f;
+  if (total_sample > 0) {
+    avg = (float)m_sum / total_sample;
+  }
+  fprintf(fout, "avg=%0.2f ", avg);
 }
 
-binned_histogram::~binned_histogram () {
-   if (m_bins) delete[] m_bins;
-   delete[] m_bin_cnts;
+binned_histogram::~binned_histogram() {
+  if (m_bins) delete[] m_bins;
+  delete[] m_bin_cnts;
 }
 
-pow2_histogram::pow2_histogram (std::string name, int nbins, int* bins) 
-   : binned_histogram (name, nbins, bins) {}
+pow2_histogram::pow2_histogram(std::string name, int nbins, int* bins)
+    : binned_histogram(name, nbins, bins) {}
 
-void pow2_histogram::add2bin (int sample) {
-   assert(sample >= 0);
-   
-   int bin;
-   int v = sample;
-   register unsigned int shift;
+void pow2_histogram::add2bin(int sample) {
+  assert(sample >= 0);
 
-   bin =   (v > 0xFFFF) << 4; v >>= bin;
-   shift = (v > 0xFF  ) << 3; v >>= shift; bin |= shift;
-   shift = (v > 0xF   ) << 2; v >>= shift; bin |= shift;
-   shift = (v > 0x3   ) << 1; v >>= shift; bin |= shift;
-                                           bin |= (v >> 1);
-   bin += (sample > 0)? 1:0;
-   
-   m_bin_cnts[bin] += 1;
-   
-   m_maximum = (sample > m_maximum)? sample : m_maximum;
-   m_sum += sample;
+  int bin;
+  int v = sample;
+  register unsigned int shift;
+
+  bin = (v > 0xFFFF) << 4;
+  v >>= bin;
+  shift = (v > 0xFF) << 3;
+  v >>= shift;
+  bin |= shift;
+  shift = (v > 0xF) << 2;
+  v >>= shift;
+  bin |= shift;
+  shift = (v > 0x3) << 1;
+  v >>= shift;
+  bin |= shift;
+  bin |= (v >> 1);
+  bin += (sample > 0) ? 1 : 0;
+
+  m_bin_cnts[bin] += 1;
+
+  m_maximum = (sample > m_maximum) ? sample : m_maximum;
+  m_sum += sample;
 }
 
-linear_histogram::linear_histogram (int stride, const char *name, int nbins, int* bins) 
-   : binned_histogram (name, nbins, bins), m_stride(stride)
-{
-}
+linear_histogram::linear_histogram(int stride, const char* name, int nbins,
+                                   int* bins)
+    : binned_histogram(name, nbins, bins), m_stride(stride) {}
 
-void linear_histogram::add2bin (int sample) {
-   assert(sample >= 0);
+void linear_histogram::add2bin(int sample) {
+  assert(sample >= 0);
 
-   int bin = sample / m_stride;      
-   if (bin >= m_nbins) bin = m_nbins - 1;
-   
-   m_bin_cnts[bin] += 1;
-   
-   m_maximum = (sample > m_maximum)? sample : m_maximum;
-   m_sum += sample;
+  int bin = sample / m_stride;
+  if (bin >= m_nbins) bin = m_nbins - 1;
+
+  m_bin_cnts[bin] += 1;
+
+  m_maximum = (sample > m_maximum) ? sample : m_maximum;
+  m_sum += sample;
 }

--- a/src/gpgpu-sim/histogram.cc
+++ b/src/gpgpu-sim/histogram.cc
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -31,108 +29,96 @@
 
 #include <assert.h>
 
-binned_histogram::binned_histogram(std::string name, int nbins, int* bins)
-    : m_name(name),
-      m_nbins(nbins),
-      m_bins(NULL),
-      m_bin_cnts(new int[m_nbins]),
-      m_maximum(0),
-      m_sum(0) {
-  if (bins) {
-    m_bins = new int[m_nbins];
-    for (int i = 0; i < nbins; i++) {
-      m_bins[i] = bins[i];
-    }
-  }
+binned_histogram::binned_histogram (std::string name, int nbins, int* bins) 
+   : m_name(name), m_nbins(nbins), m_bins(NULL), m_bin_cnts(new int[m_nbins]), m_maximum(0), m_sum(0) 
+{
+   if (bins) {
+      m_bins = new int[m_nbins];
+      for (int i = 0; i < nbins; i++) {
+         m_bins[i] = bins[i];
+      }
+   }
 
-  reset_bins();
+   reset_bins();
 }
 
-binned_histogram::binned_histogram(const binned_histogram& other)
-    : m_name(other.m_name),
-      m_nbins(other.m_nbins),
-      m_bins(NULL),
-      m_bin_cnts(new int[m_nbins]),
-      m_maximum(0),
-      m_sum(0) {
-  for (int i = 0; i < m_nbins; i++) {
-    m_bin_cnts[i] = other.m_bin_cnts[i];
-  }
+binned_histogram::binned_histogram (const binned_histogram& other)
+   : m_name(other.m_name), m_nbins(other.m_nbins), m_bins(NULL), 
+     m_bin_cnts(new int[m_nbins]), m_maximum(0), m_sum(0)
+{
+   for (int i = 0; i < m_nbins; i++) {
+      m_bin_cnts[i] = other.m_bin_cnts[i];
+   }
 }
 
-void binned_histogram::reset_bins() {
-  for (int i = 0; i < m_nbins; i++) {
-    m_bin_cnts[i] = 0;
-  }
+void binned_histogram::reset_bins () {
+   for (int i = 0; i < m_nbins; i++) {
+      m_bin_cnts[i] = 0;
+   }
 }
 
-void binned_histogram::add2bin(int sample) {
-  assert(0);
-  m_maximum = (sample > m_maximum) ? sample : m_maximum;
+void binned_histogram::add2bin (int sample) {
+   assert(0);
+   m_maximum = (sample > m_maximum)? sample : m_maximum;
 }
 
-void binned_histogram::fprint(FILE* fout) const {
-  if (m_name.c_str() != NULL) fprintf(fout, "%s = ", m_name.c_str());
-  int total_sample = 0;
-  for (int i = 0; i < m_nbins; i++) {
-    fprintf(fout, "%d ", m_bin_cnts[i]);
-    total_sample += m_bin_cnts[i];
-  }
-  fprintf(fout, "max=%d ", m_maximum);
-  float avg = 0.0f;
-  if (total_sample > 0) {
-    avg = (float)m_sum / total_sample;
-  }
-  fprintf(fout, "avg=%0.2f ", avg);
+void binned_histogram::fprint (FILE *fout) const
+{
+   if (m_name.c_str() != NULL) fprintf(fout, "%s = ", m_name.c_str());
+   int total_sample = 0;
+   for (int i = 0; i < m_nbins; i++) {
+      fprintf(fout, "%d ", m_bin_cnts[i]);
+      total_sample += m_bin_cnts[i];
+   }
+   fprintf(fout, "max=%d ", m_maximum);
+   float avg = 0.0f;
+   if (total_sample > 0) {
+      avg = (float)m_sum / total_sample;
+   }
+   fprintf(fout, "avg=%0.2f ", avg);
 }
 
-binned_histogram::~binned_histogram() {
-  if (m_bins) delete[] m_bins;
-  delete[] m_bin_cnts;
+binned_histogram::~binned_histogram () {
+   if (m_bins) delete[] m_bins;
+   delete[] m_bin_cnts;
 }
 
-pow2_histogram::pow2_histogram(std::string name, int nbins, int* bins)
-    : binned_histogram(name, nbins, bins) {}
+pow2_histogram::pow2_histogram (std::string name, int nbins, int* bins) 
+   : binned_histogram (name, nbins, bins) {}
 
-void pow2_histogram::add2bin(int sample) {
-  assert(sample >= 0);
+void pow2_histogram::add2bin (int sample) {
+   assert(sample >= 0);
+   
+   int bin;
+   int v = sample;
+   register unsigned int shift;
 
-  int bin;
-  int v = sample;
-  register unsigned int shift;
-
-  bin = (v > 0xFFFF) << 4;
-  v >>= bin;
-  shift = (v > 0xFF) << 3;
-  v >>= shift;
-  bin |= shift;
-  shift = (v > 0xF) << 2;
-  v >>= shift;
-  bin |= shift;
-  shift = (v > 0x3) << 1;
-  v >>= shift;
-  bin |= shift;
-  bin |= (v >> 1);
-  bin += (sample > 0) ? 1 : 0;
-
-  m_bin_cnts[bin] += 1;
-
-  m_maximum = (sample > m_maximum) ? sample : m_maximum;
-  m_sum += sample;
+   bin =   (v > 0xFFFF) << 4; v >>= bin;
+   shift = (v > 0xFF  ) << 3; v >>= shift; bin |= shift;
+   shift = (v > 0xF   ) << 2; v >>= shift; bin |= shift;
+   shift = (v > 0x3   ) << 1; v >>= shift; bin |= shift;
+                                           bin |= (v >> 1);
+   bin += (sample > 0)? 1:0;
+   
+   m_bin_cnts[bin] += 1;
+   
+   m_maximum = (sample > m_maximum)? sample : m_maximum;
+   m_sum += sample;
 }
 
-linear_histogram::linear_histogram(int stride, const char* name, int nbins,
-                                   int* bins)
-    : binned_histogram(name, nbins, bins), m_stride(stride) {}
+linear_histogram::linear_histogram (int stride, const char *name, int nbins, int* bins) 
+   : binned_histogram (name, nbins, bins), m_stride(stride)
+{
+}
 
-void linear_histogram::add2bin(int sample) {
-  assert(sample >= 0);
+void linear_histogram::add2bin (int sample) {
+   assert(sample >= 0);
 
-  int bin = sample / m_stride;
-  if (bin >= m_nbins) bin = m_nbins - 1;
-
-  m_bin_cnts[bin] += 1;
-
-  m_maximum = (sample > m_maximum) ? sample : m_maximum;
-  m_sum += sample;
+   int bin = sample / m_stride;      
+   if (bin >= m_nbins) bin = m_nbins - 1;
+   
+   m_bin_cnts[bin] += 1;
+   
+   m_maximum = (sample > m_maximum)? sample : m_maximum;
+   m_sum += sample;
 }

--- a/src/gpgpu-sim/histogram.cc
+++ b/src/gpgpu-sim/histogram.cc
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -29,96 +31,108 @@
 
 #include <assert.h>
 
-binned_histogram::binned_histogram (std::string name, int nbins, int* bins) 
-   : m_name(name), m_nbins(nbins), m_bins(NULL), m_bin_cnts(new int[m_nbins]), m_maximum(0), m_sum(0) 
-{
-   if (bins) {
-      m_bins = new int[m_nbins];
-      for (int i = 0; i < nbins; i++) {
-         m_bins[i] = bins[i];
-      }
-   }
+binned_histogram::binned_histogram(std::string name, int nbins, int* bins)
+    : m_name(name),
+      m_nbins(nbins),
+      m_bins(NULL),
+      m_bin_cnts(new int[m_nbins]),
+      m_maximum(0),
+      m_sum(0) {
+  if (bins) {
+    m_bins = new int[m_nbins];
+    for (int i = 0; i < nbins; i++) {
+      m_bins[i] = bins[i];
+    }
+  }
 
-   reset_bins();
+  reset_bins();
 }
 
-binned_histogram::binned_histogram (const binned_histogram& other)
-   : m_name(other.m_name), m_nbins(other.m_nbins), m_bins(NULL), 
-     m_bin_cnts(new int[m_nbins]), m_maximum(0), m_sum(0)
-{
-   for (int i = 0; i < m_nbins; i++) {
-      m_bin_cnts[i] = other.m_bin_cnts[i];
-   }
+binned_histogram::binned_histogram(const binned_histogram& other)
+    : m_name(other.m_name),
+      m_nbins(other.m_nbins),
+      m_bins(NULL),
+      m_bin_cnts(new int[m_nbins]),
+      m_maximum(0),
+      m_sum(0) {
+  for (int i = 0; i < m_nbins; i++) {
+    m_bin_cnts[i] = other.m_bin_cnts[i];
+  }
 }
 
-void binned_histogram::reset_bins () {
-   for (int i = 0; i < m_nbins; i++) {
-      m_bin_cnts[i] = 0;
-   }
+void binned_histogram::reset_bins() {
+  for (int i = 0; i < m_nbins; i++) {
+    m_bin_cnts[i] = 0;
+  }
 }
 
-void binned_histogram::add2bin (int sample) {
-   assert(0);
-   m_maximum = (sample > m_maximum)? sample : m_maximum;
+void binned_histogram::add2bin(int sample) {
+  assert(0);
+  m_maximum = (sample > m_maximum) ? sample : m_maximum;
 }
 
-void binned_histogram::fprint (FILE *fout) const
-{
-   if (m_name.c_str() != NULL) fprintf(fout, "%s = ", m_name.c_str());
-   int total_sample = 0;
-   for (int i = 0; i < m_nbins; i++) {
-      fprintf(fout, "%d ", m_bin_cnts[i]);
-      total_sample += m_bin_cnts[i];
-   }
-   fprintf(fout, "max=%d ", m_maximum);
-   float avg = 0.0f;
-   if (total_sample > 0) {
-      avg = (float)m_sum / total_sample;
-   }
-   fprintf(fout, "avg=%0.2f ", avg);
+void binned_histogram::fprint(FILE* fout) const {
+  if (m_name.c_str() != NULL) fprintf(fout, "%s = ", m_name.c_str());
+  int total_sample = 0;
+  for (int i = 0; i < m_nbins; i++) {
+    fprintf(fout, "%d ", m_bin_cnts[i]);
+    total_sample += m_bin_cnts[i];
+  }
+  fprintf(fout, "max=%d ", m_maximum);
+  float avg = 0.0f;
+  if (total_sample > 0) {
+    avg = (float)m_sum / total_sample;
+  }
+  fprintf(fout, "avg=%0.2f ", avg);
 }
 
-binned_histogram::~binned_histogram () {
-   if (m_bins) delete[] m_bins;
-   delete[] m_bin_cnts;
+binned_histogram::~binned_histogram() {
+  if (m_bins) delete[] m_bins;
+  delete[] m_bin_cnts;
 }
 
-pow2_histogram::pow2_histogram (std::string name, int nbins, int* bins) 
-   : binned_histogram (name, nbins, bins) {}
+pow2_histogram::pow2_histogram(std::string name, int nbins, int* bins)
+    : binned_histogram(name, nbins, bins) {}
 
-void pow2_histogram::add2bin (int sample) {
-   assert(sample >= 0);
-   
-   int bin;
-   int v = sample;
-   register unsigned int shift;
+void pow2_histogram::add2bin(int sample) {
+  assert(sample >= 0);
 
-   bin =   (v > 0xFFFF) << 4; v >>= bin;
-   shift = (v > 0xFF  ) << 3; v >>= shift; bin |= shift;
-   shift = (v > 0xF   ) << 2; v >>= shift; bin |= shift;
-   shift = (v > 0x3   ) << 1; v >>= shift; bin |= shift;
-                                           bin |= (v >> 1);
-   bin += (sample > 0)? 1:0;
-   
-   m_bin_cnts[bin] += 1;
-   
-   m_maximum = (sample > m_maximum)? sample : m_maximum;
-   m_sum += sample;
+  int bin;
+  int v = sample;
+  register unsigned int shift;
+
+  bin = (v > 0xFFFF) << 4;
+  v >>= bin;
+  shift = (v > 0xFF) << 3;
+  v >>= shift;
+  bin |= shift;
+  shift = (v > 0xF) << 2;
+  v >>= shift;
+  bin |= shift;
+  shift = (v > 0x3) << 1;
+  v >>= shift;
+  bin |= shift;
+  bin |= (v >> 1);
+  bin += (sample > 0) ? 1 : 0;
+
+  m_bin_cnts[bin] += 1;
+
+  m_maximum = (sample > m_maximum) ? sample : m_maximum;
+  m_sum += sample;
 }
 
-linear_histogram::linear_histogram (int stride, const char *name, int nbins, int* bins) 
-   : binned_histogram (name, nbins, bins), m_stride(stride)
-{
-}
+linear_histogram::linear_histogram(int stride, const char* name, int nbins,
+                                   int* bins)
+    : binned_histogram(name, nbins, bins), m_stride(stride) {}
 
-void linear_histogram::add2bin (int sample) {
-   assert(sample >= 0);
+void linear_histogram::add2bin(int sample) {
+  assert(sample >= 0);
 
-   int bin = sample / m_stride;      
-   if (bin >= m_nbins) bin = m_nbins - 1;
-   
-   m_bin_cnts[bin] += 1;
-   
-   m_maximum = (sample > m_maximum)? sample : m_maximum;
-   m_sum += sample;
+  int bin = sample / m_stride;
+  if (bin >= m_nbins) bin = m_nbins - 1;
+
+  m_bin_cnts[bin] += 1;
+
+  m_maximum = (sample > m_maximum) ? sample : m_maximum;
+  m_sum += sample;
 }

--- a/src/gpgpu-sim/histogram.h
+++ b/src/gpgpu-sim/histogram.h
@@ -7,23 +7,24 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef HISTOGRAM_H
 #define HISTOGRAM_H
@@ -34,44 +35,46 @@
 #include <string>
 
 class binned_histogram {
-public:
-    // creators
-   binned_histogram (std::string name = "", int nbins = 32, int* bins = NULL);
-   binned_histogram (const binned_histogram& other);
-   virtual ~binned_histogram ();
+ public:
+  // creators
+  binned_histogram(std::string name = "", int nbins = 32, int* bins = NULL);
+  binned_histogram(const binned_histogram& other);
+  virtual ~binned_histogram();
 
-   // modifiers:
-   void reset_bins ();
-   void add2bin (int sample);
+  // modifiers:
+  void reset_bins();
+  void add2bin(int sample);
 
-   // accessors:
-   void fprint (FILE *fout) const;
+  // accessors:
+  void fprint(FILE* fout) const;
 
-protected:
-   std::string m_name;
-   int m_nbins;
-   int *m_bins;        // bin boundaries
-   int *m_bin_cnts;    // counters
-   int m_maximum;      // the maximum sample
-   signed long long int m_sum; // for calculating the average
+ protected:
+  std::string m_name;
+  int m_nbins;
+  int* m_bins;                 // bin boundaries
+  int* m_bin_cnts;             // counters
+  int m_maximum;               // the maximum sample
+  signed long long int m_sum;  // for calculating the average
 };
 
 class pow2_histogram : public binned_histogram {
-public:
-   pow2_histogram ( std::string name = "", int nbins = 32, int* bins = NULL);
-   ~pow2_histogram() {}
+ public:
+  pow2_histogram(std::string name = "", int nbins = 32, int* bins = NULL);
+  ~pow2_histogram() {}
 
-   void add2bin (int sample);
+  void add2bin(int sample);
 };
 
 class linear_histogram : public binned_histogram {
-public:
-   linear_histogram (int stride = 1, const char *name = NULL, int nbins = 32, int* bins = NULL);
-   ~linear_histogram() {}
+ public:
+  linear_histogram(int stride = 1, const char* name = NULL, int nbins = 32,
+                   int* bins = NULL);
+  ~linear_histogram() {}
 
-   void add2bin (int sample);
-private:
-   int m_stride;
+  void add2bin(int sample);
+
+ private:
+  int m_stride;
 };
 
 #endif

--- a/src/gpgpu-sim/histogram.h
+++ b/src/gpgpu-sim/histogram.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -34,44 +36,46 @@
 #include <string>
 
 class binned_histogram {
-public:
-    // creators
-   binned_histogram (std::string name = "", int nbins = 32, int* bins = NULL);
-   binned_histogram (const binned_histogram& other);
-   virtual ~binned_histogram ();
+ public:
+  // creators
+  binned_histogram(std::string name = "", int nbins = 32, int* bins = NULL);
+  binned_histogram(const binned_histogram& other);
+  virtual ~binned_histogram();
 
-   // modifiers:
-   void reset_bins ();
-   void add2bin (int sample);
+  // modifiers:
+  void reset_bins();
+  void add2bin(int sample);
 
-   // accessors:
-   void fprint (FILE *fout) const;
+  // accessors:
+  void fprint(FILE* fout) const;
 
-protected:
-   std::string m_name;
-   int m_nbins;
-   int *m_bins;        // bin boundaries
-   int *m_bin_cnts;    // counters
-   int m_maximum;      // the maximum sample
-   signed long long int m_sum; // for calculating the average
+ protected:
+  std::string m_name;
+  int m_nbins;
+  int* m_bins;                 // bin boundaries
+  int* m_bin_cnts;             // counters
+  int m_maximum;               // the maximum sample
+  signed long long int m_sum;  // for calculating the average
 };
 
 class pow2_histogram : public binned_histogram {
-public:
-   pow2_histogram ( std::string name = "", int nbins = 32, int* bins = NULL);
-   ~pow2_histogram() {}
+ public:
+  pow2_histogram(std::string name = "", int nbins = 32, int* bins = NULL);
+  ~pow2_histogram() {}
 
-   void add2bin (int sample);
+  void add2bin(int sample);
 };
 
 class linear_histogram : public binned_histogram {
-public:
-   linear_histogram (int stride = 1, const char *name = NULL, int nbins = 32, int* bins = NULL);
-   ~linear_histogram() {}
+ public:
+  linear_histogram(int stride = 1, const char* name = NULL, int nbins = 32,
+                   int* bins = NULL);
+  ~linear_histogram() {}
 
-   void add2bin (int sample);
-private:
-   int m_stride;
+  void add2bin(int sample);
+
+ private:
+  int m_stride;
 };
 
 #endif

--- a/src/gpgpu-sim/histogram.h
+++ b/src/gpgpu-sim/histogram.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -36,46 +34,44 @@
 #include <string>
 
 class binned_histogram {
- public:
-  // creators
-  binned_histogram(std::string name = "", int nbins = 32, int* bins = NULL);
-  binned_histogram(const binned_histogram& other);
-  virtual ~binned_histogram();
+public:
+    // creators
+   binned_histogram (std::string name = "", int nbins = 32, int* bins = NULL);
+   binned_histogram (const binned_histogram& other);
+   virtual ~binned_histogram ();
 
-  // modifiers:
-  void reset_bins();
-  void add2bin(int sample);
+   // modifiers:
+   void reset_bins ();
+   void add2bin (int sample);
 
-  // accessors:
-  void fprint(FILE* fout) const;
+   // accessors:
+   void fprint (FILE *fout) const;
 
- protected:
-  std::string m_name;
-  int m_nbins;
-  int* m_bins;                 // bin boundaries
-  int* m_bin_cnts;             // counters
-  int m_maximum;               // the maximum sample
-  signed long long int m_sum;  // for calculating the average
+protected:
+   std::string m_name;
+   int m_nbins;
+   int *m_bins;        // bin boundaries
+   int *m_bin_cnts;    // counters
+   int m_maximum;      // the maximum sample
+   signed long long int m_sum; // for calculating the average
 };
 
 class pow2_histogram : public binned_histogram {
- public:
-  pow2_histogram(std::string name = "", int nbins = 32, int* bins = NULL);
-  ~pow2_histogram() {}
+public:
+   pow2_histogram ( std::string name = "", int nbins = 32, int* bins = NULL);
+   ~pow2_histogram() {}
 
-  void add2bin(int sample);
+   void add2bin (int sample);
 };
 
 class linear_histogram : public binned_histogram {
- public:
-  linear_histogram(int stride = 1, const char* name = NULL, int nbins = 32,
-                   int* bins = NULL);
-  ~linear_histogram() {}
+public:
+   linear_histogram (int stride = 1, const char *name = NULL, int nbins = 32, int* bins = NULL);
+   ~linear_histogram() {}
 
-  void add2bin(int sample);
-
- private:
-  int m_stride;
+   void add2bin (int sample);
+private:
+   int m_stride;
 };
 
 #endif

--- a/src/gpgpu-sim/icnt_wrapper.cc
+++ b/src/gpgpu-sim/icnt_wrapper.cc
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -33,163 +31,196 @@
 #include "../intersim2/interconnect_interface.hpp"
 #include "local_interconnect.h"
 
-icnt_create_p icnt_create;
-icnt_init_p icnt_init;
-icnt_has_buffer_p icnt_has_buffer;
-icnt_push_p icnt_push;
-icnt_pop_p icnt_pop;
-icnt_transfer_p icnt_transfer;
-icnt_busy_p icnt_busy;
-icnt_display_stats_p icnt_display_stats;
-icnt_display_overall_stats_p icnt_display_overall_stats;
-icnt_display_state_p icnt_display_state;
-icnt_get_flit_size_p icnt_get_flit_size;
 
-unsigned g_network_mode;
+icnt_create_p                icnt_create;
+icnt_init_p                  icnt_init;
+icnt_has_buffer_p            icnt_has_buffer;
+icnt_push_p                  icnt_push;
+icnt_pop_p                   icnt_pop;
+icnt_transfer_p              icnt_transfer;
+icnt_busy_p                  icnt_busy;
+icnt_display_stats_p         icnt_display_stats;
+icnt_display_overall_stats_p icnt_display_overall_stats;
+icnt_display_state_p         icnt_display_state;
+icnt_get_flit_size_p         icnt_get_flit_size;
+
+unsigned   g_network_mode;
 char* g_network_config_filename;
 
+
 struct inct_config g_inct_config;
-LocalInterconnect* g_localicnt_interface;
+LocalInterconnect *g_localicnt_interface;
 
 #include "../option_parser.h"
 
 // Wrapper to intersim2 to accompany old icnt_wrapper
 // TODO: use delegate/boost/c++11<funtion> instead
 
-static void intersim2_create(unsigned int n_shader, unsigned int n_mem) {
-  g_icnt_interface->CreateInterconnect(n_shader, n_mem);
+static void intersim2_create(unsigned int n_shader, unsigned int n_mem)
+{
+   g_icnt_interface->CreateInterconnect(n_shader, n_mem);
 }
 
-static void intersim2_init() { g_icnt_interface->Init(); }
-
-static bool intersim2_has_buffer(unsigned input, unsigned int size) {
-  return g_icnt_interface->HasBuffer(input, size);
+static void intersim2_init()
+{
+   g_icnt_interface->Init();
 }
 
-static void intersim2_push(unsigned input, unsigned output, void* data,
-                           unsigned int size) {
-  g_icnt_interface->Push(input, output, data, size);
+static bool intersim2_has_buffer(unsigned input, unsigned int size)
+{
+   return g_icnt_interface->HasBuffer(input, size);
 }
 
-static void* intersim2_pop(unsigned output) {
-  return g_icnt_interface->Pop(output);
+static void intersim2_push(unsigned input, unsigned output, void* data, unsigned int size)
+{
+   g_icnt_interface->Push(input, output, data, size);
 }
 
-static void intersim2_transfer() { g_icnt_interface->Advance(); }
-
-static bool intersim2_busy() { return g_icnt_interface->Busy(); }
-
-static void intersim2_display_stats() { g_icnt_interface->DisplayStats(); }
-
-static void intersim2_display_overall_stats() {
-  g_icnt_interface->DisplayOverallStats();
+static void* intersim2_pop(unsigned output)
+{
+   return g_icnt_interface->Pop(output);
 }
 
-static void intersim2_display_state(FILE* fp) {
-  g_icnt_interface->DisplayState(fp);
+static void intersim2_transfer()
+{
+   g_icnt_interface->Advance();
 }
 
-static unsigned intersim2_get_flit_size() {
-  return g_icnt_interface->GetFlitSize();
+static bool intersim2_busy()
+{
+   return g_icnt_interface->Busy();
 }
+
+static void intersim2_display_stats()
+{
+   g_icnt_interface->DisplayStats();
+}
+
+static void intersim2_display_overall_stats()
+{
+   g_icnt_interface->DisplayOverallStats();
+}
+
+static void intersim2_display_state(FILE *fp)
+{
+   g_icnt_interface->DisplayState(fp);
+}
+
+static unsigned intersim2_get_flit_size()
+{
+   return g_icnt_interface->GetFlitSize();
+}
+
 
 //////////////////////////////////////////////////////
 
-static void LocalInterconnect_create(unsigned int n_shader,
-                                     unsigned int n_mem) {
-  g_localicnt_interface->CreateInterconnect(n_shader, n_mem);
+static void LocalInterconnect_create(unsigned int n_shader, unsigned int n_mem)
+{
+   g_localicnt_interface->CreateInterconnect(n_shader, n_mem);
 }
 
-static void LocalInterconnect_init() { g_localicnt_interface->Init(); }
-
-static bool LocalInterconnect_has_buffer(unsigned input, unsigned int size) {
-  return g_localicnt_interface->HasBuffer(input, size);
+static void LocalInterconnect_init()
+{
+   g_localicnt_interface->Init();
 }
 
-static void LocalInterconnect_push(unsigned input, unsigned output, void* data,
-                                   unsigned int size) {
-  g_localicnt_interface->Push(input, output, data, size);
+static bool LocalInterconnect_has_buffer(unsigned input, unsigned int size)
+{
+   return g_localicnt_interface->HasBuffer(input, size);
 }
 
-static void* LocalInterconnect_pop(unsigned output) {
-  return g_localicnt_interface->Pop(output);
+static void LocalInterconnect_push(unsigned input, unsigned output, void* data, unsigned int size)
+{
+   g_localicnt_interface->Push(input, output, data, size);
 }
 
-static void LocalInterconnect_transfer() { g_localicnt_interface->Advance(); }
-
-static bool LocalInterconnect_busy() { return g_localicnt_interface->Busy(); }
-
-static void LocalInterconnect_display_stats() {
-  g_localicnt_interface->DisplayStats();
+static void* LocalInterconnect_pop(unsigned output)
+{
+   return g_localicnt_interface->Pop(output);
 }
 
-static void LocalInterconnect_display_overall_stats() {
-  g_localicnt_interface->DisplayOverallStats();
+static void LocalInterconnect_transfer()
+{
+   g_localicnt_interface->Advance();
 }
 
-static void LocalInterconnect_display_state(FILE* fp) {
-  g_localicnt_interface->DisplayState(fp);
+static bool LocalInterconnect_busy()
+{
+   return g_localicnt_interface->Busy();
 }
 
-static unsigned LocalInterconnect_get_flit_size() {
-  return g_localicnt_interface->GetFlitSize();
+static void LocalInterconnect_display_stats()
+{
+   g_localicnt_interface->DisplayStats();
 }
+
+static void LocalInterconnect_display_overall_stats()
+{
+   g_localicnt_interface->DisplayOverallStats();
+}
+
+static void LocalInterconnect_display_state(FILE *fp)
+{
+   g_localicnt_interface->DisplayState(fp);
+}
+
+static unsigned LocalInterconnect_get_flit_size()
+{
+   return g_localicnt_interface->GetFlitSize();
+}
+
 
 ///////////////////////////
 
-void icnt_reg_options(class OptionParser* opp) {
-  option_parser_register(opp, "-network_mode", OPT_INT32, &g_network_mode,
-                         "Interconnection network mode", "1");
-  option_parser_register(opp, "-inter_config_file", OPT_CSTR,
-                         &g_network_config_filename,
-                         "Interconnection network config file", "mesh");
+void icnt_reg_options( class OptionParser * opp )
+{
+   option_parser_register(opp, "-network_mode", OPT_INT32, &g_network_mode, "Interconnection network mode", "1");
+   option_parser_register(opp, "-inter_config_file", OPT_CSTR, &g_network_config_filename, "Interconnection network config file", "mesh");
 
-  // parameters for local xbar
-  option_parser_register(opp, "-inct_in_buffer_limit", OPT_UINT32,
-                         &g_inct_config.in_buffer_limit, "in_buffer_limit",
-                         "64");
-  option_parser_register(opp, "-inct_out_buffer_limit", OPT_UINT32,
-                         &g_inct_config.out_buffer_limit, "out_buffer_limit",
-                         "64");
-  option_parser_register(opp, "-inct_subnets", OPT_UINT32,
-                         &g_inct_config.subnets, "subnets", "2");
-  option_parser_register(opp, "-arbiter_algo", OPT_UINT32,
-                         &g_inct_config.arbiter_algo, "arbiter_algo", "1");
+
+   //parameters for local xbar
+   option_parser_register(opp, "-inct_in_buffer_limit", OPT_UINT32, &g_inct_config.in_buffer_limit, "in_buffer_limit", "64");
+   option_parser_register(opp, "-inct_out_buffer_limit", OPT_UINT32, &g_inct_config.out_buffer_limit, "out_buffer_limit", "64");
+   option_parser_register(opp, "-inct_subnets", OPT_UINT32, &g_inct_config.subnets, "subnets", "2");
+   option_parser_register(opp, "-arbiter_algo", OPT_UINT32, &g_inct_config.arbiter_algo, "arbiter_algo", "1");
+
+
 }
 
-void icnt_wrapper_init() {
-  switch (g_network_mode) {
-    case INTERSIM:
-      // FIXME: delete the object: may add icnt_done wrapper
-      g_icnt_interface = InterconnectInterface::New(g_network_config_filename);
-      icnt_create = intersim2_create;
-      icnt_init = intersim2_init;
-      icnt_has_buffer = intersim2_has_buffer;
-      icnt_push = intersim2_push;
-      icnt_pop = intersim2_pop;
-      icnt_transfer = intersim2_transfer;
-      icnt_busy = intersim2_busy;
-      icnt_display_stats = intersim2_display_stats;
-      icnt_display_overall_stats = intersim2_display_overall_stats;
-      icnt_display_state = intersim2_display_state;
-      icnt_get_flit_size = intersim2_get_flit_size;
-      break;
-    case LOCAL_XBAR:
-      g_localicnt_interface = LocalInterconnect::New(g_inct_config);
-      icnt_create = LocalInterconnect_create;
-      icnt_init = LocalInterconnect_init;
-      icnt_has_buffer = LocalInterconnect_has_buffer;
-      icnt_push = LocalInterconnect_push;
-      icnt_pop = LocalInterconnect_pop;
-      icnt_transfer = LocalInterconnect_transfer;
-      icnt_busy = LocalInterconnect_busy;
-      icnt_display_stats = LocalInterconnect_display_stats;
-      icnt_display_overall_stats = LocalInterconnect_display_overall_stats;
-      icnt_display_state = LocalInterconnect_display_state;
-      icnt_get_flit_size = LocalInterconnect_get_flit_size;
-      break;
-    default:
-      assert(0);
-      break;
-  }
+void icnt_wrapper_init()
+{
+   switch (g_network_mode) {
+      case INTERSIM:
+         //FIXME: delete the object: may add icnt_done wrapper
+         g_icnt_interface = InterconnectInterface::New(g_network_config_filename);
+         icnt_create     = intersim2_create;
+         icnt_init       = intersim2_init;
+         icnt_has_buffer = intersim2_has_buffer;
+         icnt_push       = intersim2_push;
+         icnt_pop        = intersim2_pop;
+         icnt_transfer   = intersim2_transfer;
+         icnt_busy       = intersim2_busy;
+         icnt_display_stats = intersim2_display_stats;
+         icnt_display_overall_stats = intersim2_display_overall_stats;
+         icnt_display_state = intersim2_display_state;
+         icnt_get_flit_size = intersim2_get_flit_size;
+         break;
+      case LOCAL_XBAR:
+         g_localicnt_interface = LocalInterconnect::New(g_inct_config);
+         icnt_create     = LocalInterconnect_create;
+         icnt_init       = LocalInterconnect_init;
+         icnt_has_buffer = LocalInterconnect_has_buffer;
+         icnt_push       = LocalInterconnect_push;
+         icnt_pop        = LocalInterconnect_pop;
+         icnt_transfer   = LocalInterconnect_transfer;
+         icnt_busy       = LocalInterconnect_busy;
+         icnt_display_stats = LocalInterconnect_display_stats;
+         icnt_display_overall_stats = LocalInterconnect_display_overall_stats;
+         icnt_display_state = LocalInterconnect_display_state;
+         icnt_get_flit_size = LocalInterconnect_get_flit_size;
+         break;
+      default:
+         assert(0);
+         break;
+   }
 }

--- a/src/gpgpu-sim/icnt_wrapper.cc
+++ b/src/gpgpu-sim/icnt_wrapper.cc
@@ -7,23 +7,24 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #include "icnt_wrapper.h"
 #include <assert.h>
@@ -31,196 +32,163 @@
 #include "../intersim2/interconnect_interface.hpp"
 #include "local_interconnect.h"
 
-
-icnt_create_p                icnt_create;
-icnt_init_p                  icnt_init;
-icnt_has_buffer_p            icnt_has_buffer;
-icnt_push_p                  icnt_push;
-icnt_pop_p                   icnt_pop;
-icnt_transfer_p              icnt_transfer;
-icnt_busy_p                  icnt_busy;
-icnt_display_stats_p         icnt_display_stats;
+icnt_create_p icnt_create;
+icnt_init_p icnt_init;
+icnt_has_buffer_p icnt_has_buffer;
+icnt_push_p icnt_push;
+icnt_pop_p icnt_pop;
+icnt_transfer_p icnt_transfer;
+icnt_busy_p icnt_busy;
+icnt_display_stats_p icnt_display_stats;
 icnt_display_overall_stats_p icnt_display_overall_stats;
-icnt_display_state_p         icnt_display_state;
-icnt_get_flit_size_p         icnt_get_flit_size;
+icnt_display_state_p icnt_display_state;
+icnt_get_flit_size_p icnt_get_flit_size;
 
-unsigned   g_network_mode;
+unsigned g_network_mode;
 char* g_network_config_filename;
 
-
 struct inct_config g_inct_config;
-LocalInterconnect *g_localicnt_interface;
+LocalInterconnect* g_localicnt_interface;
 
 #include "../option_parser.h"
 
 // Wrapper to intersim2 to accompany old icnt_wrapper
 // TODO: use delegate/boost/c++11<funtion> instead
 
-static void intersim2_create(unsigned int n_shader, unsigned int n_mem)
-{
-   g_icnt_interface->CreateInterconnect(n_shader, n_mem);
+static void intersim2_create(unsigned int n_shader, unsigned int n_mem) {
+  g_icnt_interface->CreateInterconnect(n_shader, n_mem);
 }
 
-static void intersim2_init()
-{
-   g_icnt_interface->Init();
+static void intersim2_init() { g_icnt_interface->Init(); }
+
+static bool intersim2_has_buffer(unsigned input, unsigned int size) {
+  return g_icnt_interface->HasBuffer(input, size);
 }
 
-static bool intersim2_has_buffer(unsigned input, unsigned int size)
-{
-   return g_icnt_interface->HasBuffer(input, size);
+static void intersim2_push(unsigned input, unsigned output, void* data,
+                           unsigned int size) {
+  g_icnt_interface->Push(input, output, data, size);
 }
 
-static void intersim2_push(unsigned input, unsigned output, void* data, unsigned int size)
-{
-   g_icnt_interface->Push(input, output, data, size);
+static void* intersim2_pop(unsigned output) {
+  return g_icnt_interface->Pop(output);
 }
 
-static void* intersim2_pop(unsigned output)
-{
-   return g_icnt_interface->Pop(output);
+static void intersim2_transfer() { g_icnt_interface->Advance(); }
+
+static bool intersim2_busy() { return g_icnt_interface->Busy(); }
+
+static void intersim2_display_stats() { g_icnt_interface->DisplayStats(); }
+
+static void intersim2_display_overall_stats() {
+  g_icnt_interface->DisplayOverallStats();
 }
 
-static void intersim2_transfer()
-{
-   g_icnt_interface->Advance();
+static void intersim2_display_state(FILE* fp) {
+  g_icnt_interface->DisplayState(fp);
 }
 
-static bool intersim2_busy()
-{
-   return g_icnt_interface->Busy();
+static unsigned intersim2_get_flit_size() {
+  return g_icnt_interface->GetFlitSize();
 }
-
-static void intersim2_display_stats()
-{
-   g_icnt_interface->DisplayStats();
-}
-
-static void intersim2_display_overall_stats()
-{
-   g_icnt_interface->DisplayOverallStats();
-}
-
-static void intersim2_display_state(FILE *fp)
-{
-   g_icnt_interface->DisplayState(fp);
-}
-
-static unsigned intersim2_get_flit_size()
-{
-   return g_icnt_interface->GetFlitSize();
-}
-
 
 //////////////////////////////////////////////////////
 
-static void LocalInterconnect_create(unsigned int n_shader, unsigned int n_mem)
-{
-   g_localicnt_interface->CreateInterconnect(n_shader, n_mem);
+static void LocalInterconnect_create(unsigned int n_shader,
+                                     unsigned int n_mem) {
+  g_localicnt_interface->CreateInterconnect(n_shader, n_mem);
 }
 
-static void LocalInterconnect_init()
-{
-   g_localicnt_interface->Init();
+static void LocalInterconnect_init() { g_localicnt_interface->Init(); }
+
+static bool LocalInterconnect_has_buffer(unsigned input, unsigned int size) {
+  return g_localicnt_interface->HasBuffer(input, size);
 }
 
-static bool LocalInterconnect_has_buffer(unsigned input, unsigned int size)
-{
-   return g_localicnt_interface->HasBuffer(input, size);
+static void LocalInterconnect_push(unsigned input, unsigned output, void* data,
+                                   unsigned int size) {
+  g_localicnt_interface->Push(input, output, data, size);
 }
 
-static void LocalInterconnect_push(unsigned input, unsigned output, void* data, unsigned int size)
-{
-   g_localicnt_interface->Push(input, output, data, size);
+static void* LocalInterconnect_pop(unsigned output) {
+  return g_localicnt_interface->Pop(output);
 }
 
-static void* LocalInterconnect_pop(unsigned output)
-{
-   return g_localicnt_interface->Pop(output);
+static void LocalInterconnect_transfer() { g_localicnt_interface->Advance(); }
+
+static bool LocalInterconnect_busy() { return g_localicnt_interface->Busy(); }
+
+static void LocalInterconnect_display_stats() {
+  g_localicnt_interface->DisplayStats();
 }
 
-static void LocalInterconnect_transfer()
-{
-   g_localicnt_interface->Advance();
+static void LocalInterconnect_display_overall_stats() {
+  g_localicnt_interface->DisplayOverallStats();
 }
 
-static bool LocalInterconnect_busy()
-{
-   return g_localicnt_interface->Busy();
+static void LocalInterconnect_display_state(FILE* fp) {
+  g_localicnt_interface->DisplayState(fp);
 }
 
-static void LocalInterconnect_display_stats()
-{
-   g_localicnt_interface->DisplayStats();
+static unsigned LocalInterconnect_get_flit_size() {
+  return g_localicnt_interface->GetFlitSize();
 }
-
-static void LocalInterconnect_display_overall_stats()
-{
-   g_localicnt_interface->DisplayOverallStats();
-}
-
-static void LocalInterconnect_display_state(FILE *fp)
-{
-   g_localicnt_interface->DisplayState(fp);
-}
-
-static unsigned LocalInterconnect_get_flit_size()
-{
-   return g_localicnt_interface->GetFlitSize();
-}
-
 
 ///////////////////////////
 
-void icnt_reg_options( class OptionParser * opp )
-{
-   option_parser_register(opp, "-network_mode", OPT_INT32, &g_network_mode, "Interconnection network mode", "1");
-   option_parser_register(opp, "-inter_config_file", OPT_CSTR, &g_network_config_filename, "Interconnection network config file", "mesh");
+void icnt_reg_options(class OptionParser* opp) {
+  option_parser_register(opp, "-network_mode", OPT_INT32, &g_network_mode,
+                         "Interconnection network mode", "1");
+  option_parser_register(opp, "-inter_config_file", OPT_CSTR,
+                         &g_network_config_filename,
+                         "Interconnection network config file", "mesh");
 
-
-   //parameters for local xbar
-   option_parser_register(opp, "-inct_in_buffer_limit", OPT_UINT32, &g_inct_config.in_buffer_limit, "in_buffer_limit", "64");
-   option_parser_register(opp, "-inct_out_buffer_limit", OPT_UINT32, &g_inct_config.out_buffer_limit, "out_buffer_limit", "64");
-   option_parser_register(opp, "-inct_subnets", OPT_UINT32, &g_inct_config.subnets, "subnets", "2");
-   option_parser_register(opp, "-arbiter_algo", OPT_UINT32, &g_inct_config.arbiter_algo, "arbiter_algo", "1");
-
-
+  // parameters for local xbar
+  option_parser_register(opp, "-inct_in_buffer_limit", OPT_UINT32,
+                         &g_inct_config.in_buffer_limit, "in_buffer_limit",
+                         "64");
+  option_parser_register(opp, "-inct_out_buffer_limit", OPT_UINT32,
+                         &g_inct_config.out_buffer_limit, "out_buffer_limit",
+                         "64");
+  option_parser_register(opp, "-inct_subnets", OPT_UINT32,
+                         &g_inct_config.subnets, "subnets", "2");
+  option_parser_register(opp, "-arbiter_algo", OPT_UINT32,
+                         &g_inct_config.arbiter_algo, "arbiter_algo", "1");
 }
 
-void icnt_wrapper_init()
-{
-   switch (g_network_mode) {
-      case INTERSIM:
-         //FIXME: delete the object: may add icnt_done wrapper
-         g_icnt_interface = InterconnectInterface::New(g_network_config_filename);
-         icnt_create     = intersim2_create;
-         icnt_init       = intersim2_init;
-         icnt_has_buffer = intersim2_has_buffer;
-         icnt_push       = intersim2_push;
-         icnt_pop        = intersim2_pop;
-         icnt_transfer   = intersim2_transfer;
-         icnt_busy       = intersim2_busy;
-         icnt_display_stats = intersim2_display_stats;
-         icnt_display_overall_stats = intersim2_display_overall_stats;
-         icnt_display_state = intersim2_display_state;
-         icnt_get_flit_size = intersim2_get_flit_size;
-         break;
-      case LOCAL_XBAR:
-         g_localicnt_interface = LocalInterconnect::New(g_inct_config);
-         icnt_create     = LocalInterconnect_create;
-         icnt_init       = LocalInterconnect_init;
-         icnt_has_buffer = LocalInterconnect_has_buffer;
-         icnt_push       = LocalInterconnect_push;
-         icnt_pop        = LocalInterconnect_pop;
-         icnt_transfer   = LocalInterconnect_transfer;
-         icnt_busy       = LocalInterconnect_busy;
-         icnt_display_stats = LocalInterconnect_display_stats;
-         icnt_display_overall_stats = LocalInterconnect_display_overall_stats;
-         icnt_display_state = LocalInterconnect_display_state;
-         icnt_get_flit_size = LocalInterconnect_get_flit_size;
-         break;
-      default:
-         assert(0);
-         break;
-   }
+void icnt_wrapper_init() {
+  switch (g_network_mode) {
+    case INTERSIM:
+      // FIXME: delete the object: may add icnt_done wrapper
+      g_icnt_interface = InterconnectInterface::New(g_network_config_filename);
+      icnt_create = intersim2_create;
+      icnt_init = intersim2_init;
+      icnt_has_buffer = intersim2_has_buffer;
+      icnt_push = intersim2_push;
+      icnt_pop = intersim2_pop;
+      icnt_transfer = intersim2_transfer;
+      icnt_busy = intersim2_busy;
+      icnt_display_stats = intersim2_display_stats;
+      icnt_display_overall_stats = intersim2_display_overall_stats;
+      icnt_display_state = intersim2_display_state;
+      icnt_get_flit_size = intersim2_get_flit_size;
+      break;
+    case LOCAL_XBAR:
+      g_localicnt_interface = LocalInterconnect::New(g_inct_config);
+      icnt_create = LocalInterconnect_create;
+      icnt_init = LocalInterconnect_init;
+      icnt_has_buffer = LocalInterconnect_has_buffer;
+      icnt_push = LocalInterconnect_push;
+      icnt_pop = LocalInterconnect_pop;
+      icnt_transfer = LocalInterconnect_transfer;
+      icnt_busy = LocalInterconnect_busy;
+      icnt_display_stats = LocalInterconnect_display_stats;
+      icnt_display_overall_stats = LocalInterconnect_display_overall_stats;
+      icnt_display_state = LocalInterconnect_display_state;
+      icnt_get_flit_size = LocalInterconnect_get_flit_size;
+      break;
+    default:
+      assert(0);
+      break;
+  }
 }

--- a/src/gpgpu-sim/icnt_wrapper.cc
+++ b/src/gpgpu-sim/icnt_wrapper.cc
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -31,196 +33,163 @@
 #include "../intersim2/interconnect_interface.hpp"
 #include "local_interconnect.h"
 
-
-icnt_create_p                icnt_create;
-icnt_init_p                  icnt_init;
-icnt_has_buffer_p            icnt_has_buffer;
-icnt_push_p                  icnt_push;
-icnt_pop_p                   icnt_pop;
-icnt_transfer_p              icnt_transfer;
-icnt_busy_p                  icnt_busy;
-icnt_display_stats_p         icnt_display_stats;
+icnt_create_p icnt_create;
+icnt_init_p icnt_init;
+icnt_has_buffer_p icnt_has_buffer;
+icnt_push_p icnt_push;
+icnt_pop_p icnt_pop;
+icnt_transfer_p icnt_transfer;
+icnt_busy_p icnt_busy;
+icnt_display_stats_p icnt_display_stats;
 icnt_display_overall_stats_p icnt_display_overall_stats;
-icnt_display_state_p         icnt_display_state;
-icnt_get_flit_size_p         icnt_get_flit_size;
+icnt_display_state_p icnt_display_state;
+icnt_get_flit_size_p icnt_get_flit_size;
 
-unsigned   g_network_mode;
+unsigned g_network_mode;
 char* g_network_config_filename;
 
-
 struct inct_config g_inct_config;
-LocalInterconnect *g_localicnt_interface;
+LocalInterconnect* g_localicnt_interface;
 
 #include "../option_parser.h"
 
 // Wrapper to intersim2 to accompany old icnt_wrapper
 // TODO: use delegate/boost/c++11<funtion> instead
 
-static void intersim2_create(unsigned int n_shader, unsigned int n_mem)
-{
-   g_icnt_interface->CreateInterconnect(n_shader, n_mem);
+static void intersim2_create(unsigned int n_shader, unsigned int n_mem) {
+  g_icnt_interface->CreateInterconnect(n_shader, n_mem);
 }
 
-static void intersim2_init()
-{
-   g_icnt_interface->Init();
+static void intersim2_init() { g_icnt_interface->Init(); }
+
+static bool intersim2_has_buffer(unsigned input, unsigned int size) {
+  return g_icnt_interface->HasBuffer(input, size);
 }
 
-static bool intersim2_has_buffer(unsigned input, unsigned int size)
-{
-   return g_icnt_interface->HasBuffer(input, size);
+static void intersim2_push(unsigned input, unsigned output, void* data,
+                           unsigned int size) {
+  g_icnt_interface->Push(input, output, data, size);
 }
 
-static void intersim2_push(unsigned input, unsigned output, void* data, unsigned int size)
-{
-   g_icnt_interface->Push(input, output, data, size);
+static void* intersim2_pop(unsigned output) {
+  return g_icnt_interface->Pop(output);
 }
 
-static void* intersim2_pop(unsigned output)
-{
-   return g_icnt_interface->Pop(output);
+static void intersim2_transfer() { g_icnt_interface->Advance(); }
+
+static bool intersim2_busy() { return g_icnt_interface->Busy(); }
+
+static void intersim2_display_stats() { g_icnt_interface->DisplayStats(); }
+
+static void intersim2_display_overall_stats() {
+  g_icnt_interface->DisplayOverallStats();
 }
 
-static void intersim2_transfer()
-{
-   g_icnt_interface->Advance();
+static void intersim2_display_state(FILE* fp) {
+  g_icnt_interface->DisplayState(fp);
 }
 
-static bool intersim2_busy()
-{
-   return g_icnt_interface->Busy();
+static unsigned intersim2_get_flit_size() {
+  return g_icnt_interface->GetFlitSize();
 }
-
-static void intersim2_display_stats()
-{
-   g_icnt_interface->DisplayStats();
-}
-
-static void intersim2_display_overall_stats()
-{
-   g_icnt_interface->DisplayOverallStats();
-}
-
-static void intersim2_display_state(FILE *fp)
-{
-   g_icnt_interface->DisplayState(fp);
-}
-
-static unsigned intersim2_get_flit_size()
-{
-   return g_icnt_interface->GetFlitSize();
-}
-
 
 //////////////////////////////////////////////////////
 
-static void LocalInterconnect_create(unsigned int n_shader, unsigned int n_mem)
-{
-   g_localicnt_interface->CreateInterconnect(n_shader, n_mem);
+static void LocalInterconnect_create(unsigned int n_shader,
+                                     unsigned int n_mem) {
+  g_localicnt_interface->CreateInterconnect(n_shader, n_mem);
 }
 
-static void LocalInterconnect_init()
-{
-   g_localicnt_interface->Init();
+static void LocalInterconnect_init() { g_localicnt_interface->Init(); }
+
+static bool LocalInterconnect_has_buffer(unsigned input, unsigned int size) {
+  return g_localicnt_interface->HasBuffer(input, size);
 }
 
-static bool LocalInterconnect_has_buffer(unsigned input, unsigned int size)
-{
-   return g_localicnt_interface->HasBuffer(input, size);
+static void LocalInterconnect_push(unsigned input, unsigned output, void* data,
+                                   unsigned int size) {
+  g_localicnt_interface->Push(input, output, data, size);
 }
 
-static void LocalInterconnect_push(unsigned input, unsigned output, void* data, unsigned int size)
-{
-   g_localicnt_interface->Push(input, output, data, size);
+static void* LocalInterconnect_pop(unsigned output) {
+  return g_localicnt_interface->Pop(output);
 }
 
-static void* LocalInterconnect_pop(unsigned output)
-{
-   return g_localicnt_interface->Pop(output);
+static void LocalInterconnect_transfer() { g_localicnt_interface->Advance(); }
+
+static bool LocalInterconnect_busy() { return g_localicnt_interface->Busy(); }
+
+static void LocalInterconnect_display_stats() {
+  g_localicnt_interface->DisplayStats();
 }
 
-static void LocalInterconnect_transfer()
-{
-   g_localicnt_interface->Advance();
+static void LocalInterconnect_display_overall_stats() {
+  g_localicnt_interface->DisplayOverallStats();
 }
 
-static bool LocalInterconnect_busy()
-{
-   return g_localicnt_interface->Busy();
+static void LocalInterconnect_display_state(FILE* fp) {
+  g_localicnt_interface->DisplayState(fp);
 }
 
-static void LocalInterconnect_display_stats()
-{
-   g_localicnt_interface->DisplayStats();
+static unsigned LocalInterconnect_get_flit_size() {
+  return g_localicnt_interface->GetFlitSize();
 }
-
-static void LocalInterconnect_display_overall_stats()
-{
-   g_localicnt_interface->DisplayOverallStats();
-}
-
-static void LocalInterconnect_display_state(FILE *fp)
-{
-   g_localicnt_interface->DisplayState(fp);
-}
-
-static unsigned LocalInterconnect_get_flit_size()
-{
-   return g_localicnt_interface->GetFlitSize();
-}
-
 
 ///////////////////////////
 
-void icnt_reg_options( class OptionParser * opp )
-{
-   option_parser_register(opp, "-network_mode", OPT_INT32, &g_network_mode, "Interconnection network mode", "1");
-   option_parser_register(opp, "-inter_config_file", OPT_CSTR, &g_network_config_filename, "Interconnection network config file", "mesh");
+void icnt_reg_options(class OptionParser* opp) {
+  option_parser_register(opp, "-network_mode", OPT_INT32, &g_network_mode,
+                         "Interconnection network mode", "1");
+  option_parser_register(opp, "-inter_config_file", OPT_CSTR,
+                         &g_network_config_filename,
+                         "Interconnection network config file", "mesh");
 
-
-   //parameters for local xbar
-   option_parser_register(opp, "-inct_in_buffer_limit", OPT_UINT32, &g_inct_config.in_buffer_limit, "in_buffer_limit", "64");
-   option_parser_register(opp, "-inct_out_buffer_limit", OPT_UINT32, &g_inct_config.out_buffer_limit, "out_buffer_limit", "64");
-   option_parser_register(opp, "-inct_subnets", OPT_UINT32, &g_inct_config.subnets, "subnets", "2");
-   option_parser_register(opp, "-arbiter_algo", OPT_UINT32, &g_inct_config.arbiter_algo, "arbiter_algo", "1");
-
-
+  // parameters for local xbar
+  option_parser_register(opp, "-inct_in_buffer_limit", OPT_UINT32,
+                         &g_inct_config.in_buffer_limit, "in_buffer_limit",
+                         "64");
+  option_parser_register(opp, "-inct_out_buffer_limit", OPT_UINT32,
+                         &g_inct_config.out_buffer_limit, "out_buffer_limit",
+                         "64");
+  option_parser_register(opp, "-inct_subnets", OPT_UINT32,
+                         &g_inct_config.subnets, "subnets", "2");
+  option_parser_register(opp, "-arbiter_algo", OPT_UINT32,
+                         &g_inct_config.arbiter_algo, "arbiter_algo", "1");
 }
 
-void icnt_wrapper_init()
-{
-   switch (g_network_mode) {
-      case INTERSIM:
-         //FIXME: delete the object: may add icnt_done wrapper
-         g_icnt_interface = InterconnectInterface::New(g_network_config_filename);
-         icnt_create     = intersim2_create;
-         icnt_init       = intersim2_init;
-         icnt_has_buffer = intersim2_has_buffer;
-         icnt_push       = intersim2_push;
-         icnt_pop        = intersim2_pop;
-         icnt_transfer   = intersim2_transfer;
-         icnt_busy       = intersim2_busy;
-         icnt_display_stats = intersim2_display_stats;
-         icnt_display_overall_stats = intersim2_display_overall_stats;
-         icnt_display_state = intersim2_display_state;
-         icnt_get_flit_size = intersim2_get_flit_size;
-         break;
-      case LOCAL_XBAR:
-         g_localicnt_interface = LocalInterconnect::New(g_inct_config);
-         icnt_create     = LocalInterconnect_create;
-         icnt_init       = LocalInterconnect_init;
-         icnt_has_buffer = LocalInterconnect_has_buffer;
-         icnt_push       = LocalInterconnect_push;
-         icnt_pop        = LocalInterconnect_pop;
-         icnt_transfer   = LocalInterconnect_transfer;
-         icnt_busy       = LocalInterconnect_busy;
-         icnt_display_stats = LocalInterconnect_display_stats;
-         icnt_display_overall_stats = LocalInterconnect_display_overall_stats;
-         icnt_display_state = LocalInterconnect_display_state;
-         icnt_get_flit_size = LocalInterconnect_get_flit_size;
-         break;
-      default:
-         assert(0);
-         break;
-   }
+void icnt_wrapper_init() {
+  switch (g_network_mode) {
+    case INTERSIM:
+      // FIXME: delete the object: may add icnt_done wrapper
+      g_icnt_interface = InterconnectInterface::New(g_network_config_filename);
+      icnt_create = intersim2_create;
+      icnt_init = intersim2_init;
+      icnt_has_buffer = intersim2_has_buffer;
+      icnt_push = intersim2_push;
+      icnt_pop = intersim2_pop;
+      icnt_transfer = intersim2_transfer;
+      icnt_busy = intersim2_busy;
+      icnt_display_stats = intersim2_display_stats;
+      icnt_display_overall_stats = intersim2_display_overall_stats;
+      icnt_display_state = intersim2_display_state;
+      icnt_get_flit_size = intersim2_get_flit_size;
+      break;
+    case LOCAL_XBAR:
+      g_localicnt_interface = LocalInterconnect::New(g_inct_config);
+      icnt_create = LocalInterconnect_create;
+      icnt_init = LocalInterconnect_init;
+      icnt_has_buffer = LocalInterconnect_has_buffer;
+      icnt_push = LocalInterconnect_push;
+      icnt_pop = LocalInterconnect_pop;
+      icnt_transfer = LocalInterconnect_transfer;
+      icnt_busy = LocalInterconnect_busy;
+      icnt_display_stats = LocalInterconnect_display_stats;
+      icnt_display_overall_stats = LocalInterconnect_display_overall_stats;
+      icnt_display_state = LocalInterconnect_display_state;
+      icnt_get_flit_size = LocalInterconnect_get_flit_size;
+      break;
+    default:
+      assert(0);
+      break;
+  }
 }

--- a/src/gpgpu-sim/icnt_wrapper.h
+++ b/src/gpgpu-sim/icnt_wrapper.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -34,37 +32,42 @@
 
 // functional interface to the interconnect
 
-typedef void (*icnt_create_p)(unsigned n_shader, unsigned n_mem);
-typedef void (*icnt_init_p)();
+typedef void (*icnt_create_p)(unsigned n_shader,  unsigned n_mem);
+typedef void (*icnt_init_p)( );
 typedef bool (*icnt_has_buffer_p)(unsigned input, unsigned int size);
-typedef void (*icnt_push_p)(unsigned input, unsigned output, void* data,
-                            unsigned int size);
+typedef void (*icnt_push_p)(unsigned input, unsigned output, void* data, unsigned int size);
 typedef void* (*icnt_pop_p)(unsigned output);
-typedef void (*icnt_transfer_p)();
-typedef bool (*icnt_busy_p)();
-typedef void (*icnt_drain_p)();
-typedef void (*icnt_display_stats_p)();
-typedef void (*icnt_display_overall_stats_p)();
+typedef void (*icnt_transfer_p)( );
+typedef bool (*icnt_busy_p)( );
+typedef void (*icnt_drain_p)( );
+typedef void (*icnt_display_stats_p)( );
+typedef void (*icnt_display_overall_stats_p)( );
 typedef void (*icnt_display_state_p)(FILE* fp);
 typedef unsigned (*icnt_get_flit_size_p)();
 
-extern icnt_create_p icnt_create;
-extern icnt_init_p icnt_init;
+extern icnt_create_p     icnt_create;
+extern icnt_init_p       icnt_init;
 extern icnt_has_buffer_p icnt_has_buffer;
-extern icnt_push_p icnt_push;
-extern icnt_pop_p icnt_pop;
-extern icnt_transfer_p icnt_transfer;
-extern icnt_busy_p icnt_busy;
-extern icnt_drain_p icnt_drain;
+extern icnt_push_p       icnt_push;
+extern icnt_pop_p        icnt_pop;
+extern icnt_transfer_p   icnt_transfer;
+extern icnt_busy_p       icnt_busy;
+extern icnt_drain_p      icnt_drain;
 extern icnt_display_stats_p icnt_display_stats;
 extern icnt_display_overall_stats_p icnt_display_overall_stats;
 extern icnt_display_state_p icnt_display_state;
 extern icnt_get_flit_size_p icnt_get_flit_size;
 extern unsigned g_network_mode;
 
-enum network_mode { INTERSIM = 1, LOCAL_XBAR = 2, N_NETWORK_MODE };
+enum network_mode {
+   INTERSIM = 1,
+   LOCAL_XBAR = 2,
+   N_NETWORK_MODE
+};
+
+
 
 void icnt_wrapper_init();
-void icnt_reg_options(class OptionParser* opp);
+void icnt_reg_options( class OptionParser * opp );
 
 #endif

--- a/src/gpgpu-sim/icnt_wrapper.h
+++ b/src/gpgpu-sim/icnt_wrapper.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -32,42 +34,37 @@
 
 // functional interface to the interconnect
 
-typedef void (*icnt_create_p)(unsigned n_shader,  unsigned n_mem);
-typedef void (*icnt_init_p)( );
+typedef void (*icnt_create_p)(unsigned n_shader, unsigned n_mem);
+typedef void (*icnt_init_p)();
 typedef bool (*icnt_has_buffer_p)(unsigned input, unsigned int size);
-typedef void (*icnt_push_p)(unsigned input, unsigned output, void* data, unsigned int size);
+typedef void (*icnt_push_p)(unsigned input, unsigned output, void* data,
+                            unsigned int size);
 typedef void* (*icnt_pop_p)(unsigned output);
-typedef void (*icnt_transfer_p)( );
-typedef bool (*icnt_busy_p)( );
-typedef void (*icnt_drain_p)( );
-typedef void (*icnt_display_stats_p)( );
-typedef void (*icnt_display_overall_stats_p)( );
+typedef void (*icnt_transfer_p)();
+typedef bool (*icnt_busy_p)();
+typedef void (*icnt_drain_p)();
+typedef void (*icnt_display_stats_p)();
+typedef void (*icnt_display_overall_stats_p)();
 typedef void (*icnt_display_state_p)(FILE* fp);
 typedef unsigned (*icnt_get_flit_size_p)();
 
-extern icnt_create_p     icnt_create;
-extern icnt_init_p       icnt_init;
+extern icnt_create_p icnt_create;
+extern icnt_init_p icnt_init;
 extern icnt_has_buffer_p icnt_has_buffer;
-extern icnt_push_p       icnt_push;
-extern icnt_pop_p        icnt_pop;
-extern icnt_transfer_p   icnt_transfer;
-extern icnt_busy_p       icnt_busy;
-extern icnt_drain_p      icnt_drain;
+extern icnt_push_p icnt_push;
+extern icnt_pop_p icnt_pop;
+extern icnt_transfer_p icnt_transfer;
+extern icnt_busy_p icnt_busy;
+extern icnt_drain_p icnt_drain;
 extern icnt_display_stats_p icnt_display_stats;
 extern icnt_display_overall_stats_p icnt_display_overall_stats;
 extern icnt_display_state_p icnt_display_state;
 extern icnt_get_flit_size_p icnt_get_flit_size;
 extern unsigned g_network_mode;
 
-enum network_mode {
-   INTERSIM = 1,
-   LOCAL_XBAR = 2,
-   N_NETWORK_MODE
-};
-
-
+enum network_mode { INTERSIM = 1, LOCAL_XBAR = 2, N_NETWORK_MODE };
 
 void icnt_wrapper_init();
-void icnt_reg_options( class OptionParser * opp );
+void icnt_reg_options(class OptionParser* opp);
 
 #endif

--- a/src/gpgpu-sim/icnt_wrapper.h
+++ b/src/gpgpu-sim/icnt_wrapper.h
@@ -7,23 +7,24 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef ICNT_WRAPPER_H
 #define ICNT_WRAPPER_H
@@ -32,42 +33,37 @@
 
 // functional interface to the interconnect
 
-typedef void (*icnt_create_p)(unsigned n_shader,  unsigned n_mem);
-typedef void (*icnt_init_p)( );
+typedef void (*icnt_create_p)(unsigned n_shader, unsigned n_mem);
+typedef void (*icnt_init_p)();
 typedef bool (*icnt_has_buffer_p)(unsigned input, unsigned int size);
-typedef void (*icnt_push_p)(unsigned input, unsigned output, void* data, unsigned int size);
+typedef void (*icnt_push_p)(unsigned input, unsigned output, void* data,
+                            unsigned int size);
 typedef void* (*icnt_pop_p)(unsigned output);
-typedef void (*icnt_transfer_p)( );
-typedef bool (*icnt_busy_p)( );
-typedef void (*icnt_drain_p)( );
-typedef void (*icnt_display_stats_p)( );
-typedef void (*icnt_display_overall_stats_p)( );
+typedef void (*icnt_transfer_p)();
+typedef bool (*icnt_busy_p)();
+typedef void (*icnt_drain_p)();
+typedef void (*icnt_display_stats_p)();
+typedef void (*icnt_display_overall_stats_p)();
 typedef void (*icnt_display_state_p)(FILE* fp);
 typedef unsigned (*icnt_get_flit_size_p)();
 
-extern icnt_create_p     icnt_create;
-extern icnt_init_p       icnt_init;
+extern icnt_create_p icnt_create;
+extern icnt_init_p icnt_init;
 extern icnt_has_buffer_p icnt_has_buffer;
-extern icnt_push_p       icnt_push;
-extern icnt_pop_p        icnt_pop;
-extern icnt_transfer_p   icnt_transfer;
-extern icnt_busy_p       icnt_busy;
-extern icnt_drain_p      icnt_drain;
+extern icnt_push_p icnt_push;
+extern icnt_pop_p icnt_pop;
+extern icnt_transfer_p icnt_transfer;
+extern icnt_busy_p icnt_busy;
+extern icnt_drain_p icnt_drain;
 extern icnt_display_stats_p icnt_display_stats;
 extern icnt_display_overall_stats_p icnt_display_overall_stats;
 extern icnt_display_state_p icnt_display_state;
 extern icnt_get_flit_size_p icnt_get_flit_size;
 extern unsigned g_network_mode;
 
-enum network_mode {
-   INTERSIM = 1,
-   LOCAL_XBAR = 2,
-   N_NETWORK_MODE
-};
-
-
+enum network_mode { INTERSIM = 1, LOCAL_XBAR = 2, N_NETWORK_MODE };
 
 void icnt_wrapper_init();
-void icnt_reg_options( class OptionParser * opp );
+void icnt_reg_options(class OptionParser* opp);
 
 #endif

--- a/src/gpgpu-sim/l2cache.cc
+++ b/src/gpgpu-sim/l2cache.cc
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -25,797 +27,835 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include <list>
 #include <set>
 
+#include "../abstract_hardware_model.h"
 #include "../option_parser.h"
-#include "mem_fetch.h"
+#include "../statwrapper.h"
 #include "dram.h"
 #include "gpu-cache.h"
+#include "gpu-sim.h"
 #include "histogram.h"
 #include "l2cache.h"
-#include "../statwrapper.h"
-#include "../abstract_hardware_model.h"
-#include "gpu-sim.h"
-#include "shader.h"
-#include "mem_latency_stat.h"
 #include "l2cache_trace.h"
+#include "mem_fetch.h"
+#include "mem_latency_stat.h"
+#include "shader.h"
 
-
-mem_fetch * partition_mf_allocator::alloc(new_addr_type addr, mem_access_type type, unsigned size, bool wr, unsigned long long cycle ) const
-{
-    assert( wr );
-    mem_access_t access( type, addr, size, wr, m_memory_config->gpgpu_ctx );
-    mem_fetch *mf = new mem_fetch( access, 
-                                   NULL,
-                                   WRITE_PACKET_SIZE, 
-                                   -1, 
-                                   -1, 
-                                   -1,
-                                   m_memory_config,
-								   cycle);
-    return mf;
+mem_fetch *partition_mf_allocator::alloc(new_addr_type addr,
+                                         mem_access_type type, unsigned size,
+                                         bool wr,
+                                         unsigned long long cycle) const {
+  assert(wr);
+  mem_access_t access(type, addr, size, wr, m_memory_config->gpgpu_ctx);
+  mem_fetch *mf = new mem_fetch(access, NULL, WRITE_PACKET_SIZE, -1, -1, -1,
+                                m_memory_config, cycle);
+  return mf;
 }
 
-memory_partition_unit::memory_partition_unit( unsigned partition_id, 
-                                              const memory_config *config,
-                                              class memory_stats_t *stats,
-											  class gpgpu_sim* gpu)
-: m_id(partition_id), m_config(config), m_stats(stats), m_arbitration_metadata(config), m_gpu(gpu)
-{
-    m_dram = new dram_t(m_id,m_config,m_stats,this,gpu);
+memory_partition_unit::memory_partition_unit(unsigned partition_id,
+                                             const memory_config *config,
+                                             class memory_stats_t *stats,
+                                             class gpgpu_sim *gpu)
+    : m_id(partition_id),
+      m_config(config),
+      m_stats(stats),
+      m_arbitration_metadata(config),
+      m_gpu(gpu) {
+  m_dram = new dram_t(m_id, m_config, m_stats, this, gpu);
 
-    m_sub_partition = new memory_sub_partition*[m_config->m_n_sub_partition_per_memory_channel]; 
-    for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel; p++) {
-        unsigned sub_partition_id = m_id * m_config->m_n_sub_partition_per_memory_channel + p; 
-        m_sub_partition[p] = new memory_sub_partition(sub_partition_id, m_config, stats, gpu);
+  m_sub_partition = new memory_sub_partition
+      *[m_config->m_n_sub_partition_per_memory_channel];
+  for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel;
+       p++) {
+    unsigned sub_partition_id =
+        m_id * m_config->m_n_sub_partition_per_memory_channel + p;
+    m_sub_partition[p] =
+        new memory_sub_partition(sub_partition_id, m_config, stats, gpu);
+  }
+}
+
+void memory_partition_unit::handle_memcpy_to_gpu(
+    size_t addr, unsigned global_subpart_id, mem_access_sector_mask_t mask) {
+  unsigned p = global_sub_partition_id_to_local_id(global_subpart_id);
+  std::string mystring = mask.to_string<char, std::string::traits_type,
+                                        std::string::allocator_type>();
+  MEMPART_DPRINTF(
+      "Copy Engine Request Received For Address=%zx, local_subpart=%u, "
+      "global_subpart=%u, sector_mask=%s \n",
+      addr, p, global_subpart_id, mystring.c_str());
+  m_sub_partition[p]->force_l2_tag_update(
+      addr, m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle, mask);
+}
+
+memory_partition_unit::~memory_partition_unit() {
+  delete m_dram;
+  for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel;
+       p++) {
+    delete m_sub_partition[p];
+  }
+  delete[] m_sub_partition;
+}
+
+memory_partition_unit::arbitration_metadata::arbitration_metadata(
+    const memory_config *config)
+    : m_last_borrower(config->m_n_sub_partition_per_memory_channel - 1),
+      m_private_credit(config->m_n_sub_partition_per_memory_channel, 0),
+      m_shared_credit(0) {
+  // each sub partition get at least 1 credit for forward progress
+  // the rest is shared among with other partitions
+  m_private_credit_limit = 1;
+  m_shared_credit_limit = config->gpgpu_frfcfs_dram_sched_queue_size +
+                          config->gpgpu_dram_return_queue_size -
+                          (config->m_n_sub_partition_per_memory_channel - 1);
+  if (config->seperate_write_queue_enabled)
+    m_shared_credit_limit += config->gpgpu_frfcfs_dram_write_queue_size;
+  if (config->gpgpu_frfcfs_dram_sched_queue_size == 0 or
+      config->gpgpu_dram_return_queue_size == 0) {
+    m_shared_credit_limit =
+        0;  // no limit if either of the queue has no limit in size
+  }
+  assert(m_shared_credit_limit >= 0);
+}
+
+bool memory_partition_unit::arbitration_metadata::has_credits(
+    int inner_sub_partition_id) const {
+  int spid = inner_sub_partition_id;
+  if (m_private_credit[spid] < m_private_credit_limit) {
+    return true;
+  } else if (m_shared_credit_limit == 0 ||
+             m_shared_credit < m_shared_credit_limit) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+void memory_partition_unit::arbitration_metadata::borrow_credit(
+    int inner_sub_partition_id) {
+  int spid = inner_sub_partition_id;
+  if (m_private_credit[spid] < m_private_credit_limit) {
+    m_private_credit[spid] += 1;
+  } else if (m_shared_credit_limit == 0 ||
+             m_shared_credit < m_shared_credit_limit) {
+    m_shared_credit += 1;
+  } else {
+    assert(0 && "DRAM arbitration error: Borrowing from depleted credit!");
+  }
+  m_last_borrower = spid;
+}
+
+void memory_partition_unit::arbitration_metadata::return_credit(
+    int inner_sub_partition_id) {
+  int spid = inner_sub_partition_id;
+  if (m_private_credit[spid] > 0) {
+    m_private_credit[spid] -= 1;
+  } else {
+    m_shared_credit -= 1;
+  }
+  assert((m_shared_credit >= 0) &&
+         "DRAM arbitration error: Returning more than available credits!");
+}
+
+void memory_partition_unit::arbitration_metadata::print(FILE *fp) const {
+  fprintf(fp, "private_credit = ");
+  for (unsigned p = 0; p < m_private_credit.size(); p++) {
+    fprintf(fp, "%d ", m_private_credit[p]);
+  }
+  fprintf(fp, "(limit = %d)\n", m_private_credit_limit);
+  fprintf(fp, "shared_credit = %d (limit = %d)\n", m_shared_credit,
+          m_shared_credit_limit);
+}
+
+bool memory_partition_unit::busy() const {
+  bool busy = false;
+  for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel;
+       p++) {
+    if (m_sub_partition[p]->busy()) {
+      busy = true;
     }
-
+  }
+  return busy;
 }
 
-void memory_partition_unit::handle_memcpy_to_gpu( size_t addr, unsigned global_subpart_id, mem_access_sector_mask_t mask )
-{
-    unsigned p = global_sub_partition_id_to_local_id(global_subpart_id);
-    std::string mystring =
-        mask.to_string<char,std::string::traits_type,std::string::allocator_type>();
-    MEMPART_DPRINTF("Copy Engine Request Received For Address=%zx, local_subpart=%u, global_subpart=%u, sector_mask=%s \n", addr, p, global_subpart_id, mystring.c_str()); 
-    m_sub_partition[p]->force_l2_tag_update(addr,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle, mask);
+void memory_partition_unit::cache_cycle(unsigned cycle) {
+  for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel;
+       p++) {
+    m_sub_partition[p]->cache_cycle(cycle);
+  }
 }
 
-memory_partition_unit::~memory_partition_unit() 
-{
-    delete m_dram; 
-    for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel; p++) {
-        delete m_sub_partition[p]; 
-    } 
-    delete[] m_sub_partition; 
+void memory_partition_unit::visualizer_print(gzFile visualizer_file) const {
+  m_dram->visualizer_print(visualizer_file);
+  for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel;
+       p++) {
+    m_sub_partition[p]->visualizer_print(visualizer_file);
+  }
 }
 
-memory_partition_unit::arbitration_metadata::arbitration_metadata(const memory_config *config)
-: m_last_borrower(config->m_n_sub_partition_per_memory_channel - 1), 
-  m_private_credit(config->m_n_sub_partition_per_memory_channel, 0), 
-  m_shared_credit(0) 
-{
-    // each sub partition get at least 1 credit for forward progress 
-    // the rest is shared among with other partitions 
-    m_private_credit_limit = 1; 
-    m_shared_credit_limit = config->gpgpu_frfcfs_dram_sched_queue_size 
-                            + config->gpgpu_dram_return_queue_size 
-                            - (config->m_n_sub_partition_per_memory_channel - 1);
-    if(config->seperate_write_queue_enabled )
-    	m_shared_credit_limit += config->gpgpu_frfcfs_dram_write_queue_size;
-    if (config->gpgpu_frfcfs_dram_sched_queue_size == 0 
-        or config->gpgpu_dram_return_queue_size == 0) 
-    {
-        m_shared_credit_limit = 0; // no limit if either of the queue has no limit in size 
-    }
-    assert(m_shared_credit_limit >= 0); 
+// determine whether a given subpartition can issue to DRAM
+bool memory_partition_unit::can_issue_to_dram(int inner_sub_partition_id) {
+  int spid = inner_sub_partition_id;
+  bool sub_partition_contention = m_sub_partition[spid]->dram_L2_queue_full();
+  bool has_dram_resource = m_arbitration_metadata.has_credits(spid);
+
+  MEMPART_DPRINTF(
+      "sub partition %d sub_partition_contention=%c has_dram_resource=%c\n",
+      spid, (sub_partition_contention) ? 'T' : 'F',
+      (has_dram_resource) ? 'T' : 'F');
+
+  return (has_dram_resource && !sub_partition_contention);
 }
 
-bool memory_partition_unit::arbitration_metadata::has_credits(int inner_sub_partition_id) const 
-{
-    int spid = inner_sub_partition_id; 
-    if (m_private_credit[spid] < m_private_credit_limit) {
-        return true; 
-    } else if (m_shared_credit_limit == 0 || m_shared_credit < m_shared_credit_limit) {
-        return true; 
-    } else {
-        return false; 
-    }
+int memory_partition_unit::global_sub_partition_id_to_local_id(
+    int global_sub_partition_id) const {
+  return (global_sub_partition_id -
+          m_id * m_config->m_n_sub_partition_per_memory_channel);
 }
 
-void memory_partition_unit::arbitration_metadata::borrow_credit(int inner_sub_partition_id) 
-{
-    int spid = inner_sub_partition_id; 
-    if (m_private_credit[spid] < m_private_credit_limit) {
-        m_private_credit[spid] += 1; 
-    } else if (m_shared_credit_limit == 0 || m_shared_credit < m_shared_credit_limit) {
-        m_shared_credit += 1; 
-    } else {
-        assert(0 && "DRAM arbitration error: Borrowing from depleted credit!"); 
-    }
-    m_last_borrower = spid; 
-}
+void memory_partition_unit::simple_dram_model_cycle() {
+  // pop completed memory request from dram and push it to dram-to-L2 queue
+  // of the original sub partition
+  if (!m_dram_latency_queue.empty() &&
+      ((m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle) >=
+       m_dram_latency_queue.front().ready_cycle)) {
+    mem_fetch *mf_return = m_dram_latency_queue.front().req;
+    if (mf_return->get_access_type() != L1_WRBK_ACC &&
+        mf_return->get_access_type() != L2_WRBK_ACC) {
+      mf_return->set_reply();
 
-void memory_partition_unit::arbitration_metadata::return_credit(int inner_sub_partition_id) 
-{
-    int spid = inner_sub_partition_id; 
-    if (m_private_credit[spid] > 0) {
-        m_private_credit[spid] -= 1; 
-    } else {
-        m_shared_credit -= 1; 
-    } 
-    assert((m_shared_credit >= 0) && "DRAM arbitration error: Returning more than available credits!"); 
-}
-
-void memory_partition_unit::arbitration_metadata::print( FILE *fp ) const 
-{
-    fprintf(fp, "private_credit = "); 
-    for (unsigned p = 0; p < m_private_credit.size(); p++) {
-        fprintf(fp, "%d ", m_private_credit[p]); 
-    }
-    fprintf(fp, "(limit = %d)\n", m_private_credit_limit); 
-    fprintf(fp, "shared_credit = %d (limit = %d)\n", m_shared_credit, m_shared_credit_limit); 
-}
-
-bool memory_partition_unit::busy() const 
-{
-    bool busy = false; 
-    for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel; p++) {
-        if (m_sub_partition[p]->busy()) {
-            busy = true; 
-        }
-    }
-    return busy; 
-}
-
-void memory_partition_unit::cache_cycle(unsigned cycle) 
-{
-    for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel; p++) {
-        m_sub_partition[p]->cache_cycle(cycle); 
-    }
-}
-
-void memory_partition_unit::visualizer_print( gzFile visualizer_file ) const 
-{
-    m_dram->visualizer_print(visualizer_file);
-    for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel; p++) {
-        m_sub_partition[p]->visualizer_print(visualizer_file); 
-    }
-}
-
-// determine whether a given subpartition can issue to DRAM 
-bool memory_partition_unit::can_issue_to_dram(int inner_sub_partition_id) 
-{
-    int spid = inner_sub_partition_id; 
-    bool sub_partition_contention = m_sub_partition[spid]->dram_L2_queue_full(); 
-    bool has_dram_resource = m_arbitration_metadata.has_credits(spid); 
-
-    MEMPART_DPRINTF("sub partition %d sub_partition_contention=%c has_dram_resource=%c\n", 
-                    spid, (sub_partition_contention)? 'T':'F', (has_dram_resource)? 'T':'F'); 
-
-    return (has_dram_resource && !sub_partition_contention); 
-}
-
-int memory_partition_unit::global_sub_partition_id_to_local_id(int global_sub_partition_id) const
-{
-    return (global_sub_partition_id - m_id * m_config->m_n_sub_partition_per_memory_channel); 
-}
-
-void memory_partition_unit::simple_dram_model_cycle()
-{
-
-	// pop completed memory request from dram and push it to dram-to-L2 queue
-	// of the original sub partition
-	if (!m_dram_latency_queue.empty() && ( (m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle) >= m_dram_latency_queue.front().ready_cycle )) {
-		 mem_fetch* mf_return = m_dram_latency_queue.front().req;
-		 if( mf_return->get_access_type() != L1_WRBK_ACC && mf_return->get_access_type() != L2_WRBK_ACC ) {
-			 mf_return->set_reply();
-
-		    unsigned dest_global_spid = mf_return->get_sub_partition_id();
-			int dest_spid = global_sub_partition_id_to_local_id(dest_global_spid);
-			assert(m_sub_partition[dest_spid]->get_id() == dest_global_spid);
-			if (!m_sub_partition[dest_spid]->dram_L2_queue_full()) {
-				if( mf_return->get_access_type() == L1_WRBK_ACC ) {
-					m_sub_partition[dest_spid]->set_done(mf_return);
-					delete mf_return;
-				} else {
-					m_sub_partition[dest_spid]->dram_L2_queue_push(mf_return);
-					mf_return->set_status(IN_PARTITION_DRAM_TO_L2_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-					m_arbitration_metadata.return_credit(dest_spid);
-					MEMPART_DPRINTF("mem_fetch request %p return from dram to sub partition %d\n", mf_return, dest_spid);
-				}
-				m_dram_latency_queue.pop_front();
-			}
-
-		  } else {
-			 this->set_done(mf_return);
-			 delete mf_return;
-			 m_dram_latency_queue.pop_front();
-		  }
-	}
-
-   // mem_fetch *mf = m_sub_partition[spid]->L2_dram_queue_top();
-	//if( !m_dram->full(mf->is_write()) ) {
-		// L2->DRAM queue to DRAM latency queue
-		// Arbitrate among multiple L2 subpartitions
-		int last_issued_partition = m_arbitration_metadata.last_borrower();
-		for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel; p++) {
-			int spid = (p + last_issued_partition + 1) % m_config->m_n_sub_partition_per_memory_channel;
-			if (!m_sub_partition[spid]->L2_dram_queue_empty() && can_issue_to_dram(spid)) {
-				mem_fetch *mf = m_sub_partition[spid]->L2_dram_queue_top();
-				if(m_dram->full(mf->is_write()) )
-					break;
-
-				m_sub_partition[spid]->L2_dram_queue_pop();
-				MEMPART_DPRINTF("Issue mem_fetch request %p from sub partition %d to dram\n", mf, spid);
-				dram_delay_t d;
-				d.req = mf;
-				d.ready_cycle = m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle + m_config->dram_latency;
-				m_dram_latency_queue.push_back(d);
-				mf->set_status(IN_PARTITION_DRAM_LATENCY_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-				m_arbitration_metadata.borrow_credit(spid);
-				break;  // the DRAM should only accept one request per cycle
-			}
-		}
-	//}
-
-}
-
-void memory_partition_unit::dram_cycle()
-{ 
-    // pop completed memory request from dram and push it to dram-to-L2 queue 
-    // of the original sub partition 
-    mem_fetch* mf_return = m_dram->return_queue_top();
-    if (mf_return) {
-        unsigned dest_global_spid = mf_return->get_sub_partition_id(); 
-        int dest_spid = global_sub_partition_id_to_local_id(dest_global_spid); 
-        assert(m_sub_partition[dest_spid]->get_id() == dest_global_spid); 
-        if (!m_sub_partition[dest_spid]->dram_L2_queue_full()) {
-            if( mf_return->get_access_type() == L1_WRBK_ACC ) {
-                m_sub_partition[dest_spid]->set_done(mf_return); 
-                delete mf_return;
-            } else {
-                m_sub_partition[dest_spid]->dram_L2_queue_push(mf_return);
-                mf_return->set_status(IN_PARTITION_DRAM_TO_L2_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-                m_arbitration_metadata.return_credit(dest_spid); 
-                MEMPART_DPRINTF("mem_fetch request %p return from dram to sub partition %d\n", mf_return, dest_spid); 
-            }
-            m_dram->return_queue_pop(); 
-        }
-    } else {
-        m_dram->return_queue_pop(); 
-    }
-    
-    m_dram->cycle();
-    m_dram->dram_log(SAMPLELOG);
-
-   // mem_fetch *mf = m_sub_partition[spid]->L2_dram_queue_top();
-    //if( !m_dram->full(mf->is_write()) ) {
-        // L2->DRAM queue to DRAM latency queue
-        // Arbitrate among multiple L2 subpartitions 
-        int last_issued_partition = m_arbitration_metadata.last_borrower(); 
-        for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel; p++) {
-            int spid = (p + last_issued_partition + 1) % m_config->m_n_sub_partition_per_memory_channel; 
-            if (!m_sub_partition[spid]->L2_dram_queue_empty() && can_issue_to_dram(spid)) {
-                mem_fetch *mf = m_sub_partition[spid]->L2_dram_queue_top();
-                if(m_dram->full(mf->is_write()) )
-                	break;
-
-                m_sub_partition[spid]->L2_dram_queue_pop();
-                MEMPART_DPRINTF("Issue mem_fetch request %p from sub partition %d to dram\n", mf, spid); 
-                dram_delay_t d;
-                d.req = mf;
-                d.ready_cycle = m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle + m_config->dram_latency;
-                m_dram_latency_queue.push_back(d);
-                mf->set_status(IN_PARTITION_DRAM_LATENCY_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-                m_arbitration_metadata.borrow_credit(spid); 
-                break;  // the DRAM should only accept one request per cycle 
-            }
-        }
-    //}
-
-    // DRAM latency queue
-    if( !m_dram_latency_queue.empty() && ( (m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle) >= m_dram_latency_queue.front().ready_cycle ) && !m_dram->full(m_dram_latency_queue.front().req->is_write()) ) {
-    	mem_fetch* mf = m_dram_latency_queue.front().req;
-    	m_dram_latency_queue.pop_front();
-        m_dram->push(mf);
-    }
-}
-
-void memory_partition_unit::set_done( mem_fetch *mf )
-{
-    unsigned global_spid = mf->get_sub_partition_id(); 
-    int spid = global_sub_partition_id_to_local_id(global_spid); 
-    assert(m_sub_partition[spid]->get_id() == global_spid); 
-    if (mf->get_access_type() == L1_WRBK_ACC || mf->get_access_type() == L2_WRBK_ACC) {
-        m_arbitration_metadata.return_credit(spid); 
-        MEMPART_DPRINTF("mem_fetch request %p return from dram to sub partition %d\n", mf, spid); 
-    }
-    m_sub_partition[spid]->set_done(mf); 
-}
-
-void memory_partition_unit::set_dram_power_stats(unsigned &n_cmd,
-                                                 unsigned &n_activity,
-                                                 unsigned &n_nop,
-                                                 unsigned &n_act,
-                                                 unsigned &n_pre,
-                                                 unsigned &n_rd,
-                                                 unsigned &n_wr,
-                                                 unsigned &n_req) const
-{
-    m_dram->set_dram_power_stats(n_cmd, n_activity, n_nop, n_act, n_pre, n_rd, n_wr, n_req);
-}
-
-void memory_partition_unit::print( FILE *fp ) const
-{
-    fprintf(fp, "Memory Partition %u: \n", m_id); 
-    for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel; p++) {
-        m_sub_partition[p]->print(fp); 
-    }
-    fprintf(fp, "In Dram Latency Queue (total = %zd): \n", m_dram_latency_queue.size()); 
-    for (std::list<dram_delay_t>::const_iterator mf_dlq = m_dram_latency_queue.begin(); 
-         mf_dlq != m_dram_latency_queue.end(); ++mf_dlq) {
-        mem_fetch *mf = mf_dlq->req; 
-        fprintf(fp, "Ready @ %llu - ", mf_dlq->ready_cycle); 
-        if (mf) 
-            mf->print(fp); 
-        else 
-            fprintf(fp, " <NULL mem_fetch?>\n"); 
-    }
-    m_dram->print(fp); 
-}
-
-memory_sub_partition::memory_sub_partition( unsigned sub_partition_id, 
-                                            const memory_config *config,
-                                            class memory_stats_t *stats,
-											class gpgpu_sim* gpu)
-{
-    m_id = sub_partition_id;
-    m_config=config;
-    m_stats=stats;
-    m_gpu = gpu;
-    m_memcpy_cycle_offset = 0;
-
-    assert(m_id < m_config->m_n_mem_sub_partition); 
-
-    char L2c_name[32];
-    snprintf(L2c_name, 32, "L2_bank_%03d", m_id);
-    m_L2interface = new L2interface(this);
-    m_mf_allocator = new partition_mf_allocator(config);
-
-    if(!m_config->m_L2_config.disabled())
-       m_L2cache = new l2_cache(L2c_name,m_config->m_L2_config,-1,-1,m_L2interface,m_mf_allocator,IN_PARTITION_L2_MISS_QUEUE, gpu);
-
-    unsigned int icnt_L2;
-    unsigned int L2_dram;
-    unsigned int dram_L2;
-    unsigned int L2_icnt;
-    sscanf(m_config->gpgpu_L2_queue_config,"%u:%u:%u:%u", &icnt_L2,&L2_dram,&dram_L2,&L2_icnt );
-    m_icnt_L2_queue = new fifo_pipeline<mem_fetch>("icnt-to-L2",0,icnt_L2); 
-    m_L2_dram_queue = new fifo_pipeline<mem_fetch>("L2-to-dram",0,L2_dram);
-    m_dram_L2_queue = new fifo_pipeline<mem_fetch>("dram-to-L2",0,dram_L2);
-    m_L2_icnt_queue = new fifo_pipeline<mem_fetch>("L2-to-icnt",0,L2_icnt);
-    wb_addr=-1;
-}
-
-memory_sub_partition::~memory_sub_partition()
-{
-    delete m_icnt_L2_queue;
-    delete m_L2_dram_queue;
-    delete m_dram_L2_queue;
-    delete m_L2_icnt_queue;
-    delete m_L2cache;
-    delete m_L2interface;
-}
-
-void memory_sub_partition::cache_cycle( unsigned cycle )
-{
-    // L2 fill responses
-    if( !m_config->m_L2_config.disabled()) {
-       if ( m_L2cache->access_ready() && !m_L2_icnt_queue->full() ) {
-           mem_fetch *mf = m_L2cache->next_access();
-           if(mf->get_access_type() != L2_WR_ALLOC_R){ // Don't pass write allocate read request back to upper level cache
-				mf->set_reply();
-				mf->set_status(IN_PARTITION_L2_TO_ICNT_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-				m_L2_icnt_queue->push(mf);
-           }else{
-        	    if(m_config->m_L2_config.m_write_alloc_policy == FETCH_ON_WRITE)
-        	    {
-        	    	mem_fetch* original_wr_mf = mf->get_original_wr_mf();
-					assert(original_wr_mf);
-					original_wr_mf->set_reply();
-					original_wr_mf->set_status(IN_PARTITION_L2_TO_ICNT_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-					m_L2_icnt_queue->push(original_wr_mf);
-        	    }
-				m_request_tracker.erase(mf);
-				delete mf;
-           }
-       }
-    }
-
-    // DRAM to L2 (texture) and icnt (not texture)
-    if ( !m_dram_L2_queue->empty() ) {
-        mem_fetch *mf = m_dram_L2_queue->top();
-        if ( !m_config->m_L2_config.disabled() && m_L2cache->waiting_for_fill(mf) ) {
-            if (m_L2cache->fill_port_free()) {
-                mf->set_status(IN_PARTITION_L2_FILL_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-                m_L2cache->fill(mf,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle+m_memcpy_cycle_offset);
-                m_dram_L2_queue->pop();
-            }
-        } else if ( !m_L2_icnt_queue->full() ) {
-        	if(mf->is_write() && mf->get_type() == WRITE_ACK)
-            mf->set_status(IN_PARTITION_L2_TO_ICNT_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-            m_L2_icnt_queue->push(mf);
-            m_dram_L2_queue->pop();
-        }
-    }
-
-    // prior L2 misses inserted into m_L2_dram_queue here
-    if( !m_config->m_L2_config.disabled() )
-       m_L2cache->cycle();
-
-    // new L2 texture accesses and/or non-texture accesses
-    if ( !m_L2_dram_queue->full() && !m_icnt_L2_queue->empty() ) {
-        mem_fetch *mf = m_icnt_L2_queue->top();
-        if ( !m_config->m_L2_config.disabled() &&
-              ( (m_config->m_L2_texure_only && mf->istexture()) || (!m_config->m_L2_texure_only) )
-           ) {
-            // L2 is enabled and access is for L2
-            bool output_full = m_L2_icnt_queue->full(); 
-            bool port_free = m_L2cache->data_port_free(); 
-            if ( !output_full && port_free ) {
-                std::list<cache_event> events;
-                enum cache_request_status status = m_L2cache->access(mf->get_addr(),mf,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle+m_memcpy_cycle_offset,events);
-                bool write_sent = was_write_sent(events);
-                bool read_sent = was_read_sent(events);
-                MEM_SUBPART_DPRINTF("Probing L2 cache Address=%llx, status=%u\n", mf->get_addr(), status); 
-
-                if ( status == HIT ) {
-                    if( !write_sent ) {
-                        // L2 cache replies
-                        assert(!read_sent);
-                        if( mf->get_access_type() == L1_WRBK_ACC ) {
-                            m_request_tracker.erase(mf);
-                            delete mf;
-                        } else {
-                            mf->set_reply();
-                            mf->set_status(IN_PARTITION_L2_TO_ICNT_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-                            m_L2_icnt_queue->push(mf);
-                        }
-                        m_icnt_L2_queue->pop();
-                    } else {
-                        assert(write_sent);
-                        m_icnt_L2_queue->pop();
-                    }
-                } else if ( status != RESERVATION_FAIL ) {
-                	if(mf->is_write() && (m_config->m_L2_config.m_write_alloc_policy == FETCH_ON_WRITE || m_config->m_L2_config.m_write_alloc_policy == LAZY_FETCH_ON_READ) && !was_writeallocate_sent(events)) {
-                		mf->set_reply();
-                		mf->set_status(IN_PARTITION_L2_TO_ICNT_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-                		m_L2_icnt_queue->push(mf);
-                	}
-                    // L2 cache accepted request
-                    m_icnt_L2_queue->pop();
-                } else {
-                    assert(!write_sent);
-                    assert(!read_sent);
-                    // L2 cache lock-up: will try again next cycle
-                }
-            }
+      unsigned dest_global_spid = mf_return->get_sub_partition_id();
+      int dest_spid = global_sub_partition_id_to_local_id(dest_global_spid);
+      assert(m_sub_partition[dest_spid]->get_id() == dest_global_spid);
+      if (!m_sub_partition[dest_spid]->dram_L2_queue_full()) {
+        if (mf_return->get_access_type() == L1_WRBK_ACC) {
+          m_sub_partition[dest_spid]->set_done(mf_return);
+          delete mf_return;
         } else {
-            // L2 is disabled or non-texture access to texture-only L2
-            mf->set_status(IN_PARTITION_L2_TO_DRAM_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-            m_L2_dram_queue->push(mf);
-            m_icnt_L2_queue->pop();
+          m_sub_partition[dest_spid]->dram_L2_queue_push(mf_return);
+          mf_return->set_status(
+              IN_PARTITION_DRAM_TO_L2_QUEUE,
+              m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+          m_arbitration_metadata.return_credit(dest_spid);
+          MEMPART_DPRINTF(
+              "mem_fetch request %p return from dram to sub partition %d\n",
+              mf_return, dest_spid);
         }
+        m_dram_latency_queue.pop_front();
+      }
+
+    } else {
+      this->set_done(mf_return);
+      delete mf_return;
+      m_dram_latency_queue.pop_front();
     }
+  }
 
-    // ROP delay queue
-    if( !m_rop.empty() && (cycle >= m_rop.front().ready_cycle) && !m_icnt_L2_queue->full() ) {
-        mem_fetch* mf = m_rop.front().req;
-        m_rop.pop();
-        m_icnt_L2_queue->push(mf);
-        mf->set_status(IN_PARTITION_ICNT_TO_L2_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
+  // mem_fetch *mf = m_sub_partition[spid]->L2_dram_queue_top();
+  // if( !m_dram->full(mf->is_write()) ) {
+  // L2->DRAM queue to DRAM latency queue
+  // Arbitrate among multiple L2 subpartitions
+  int last_issued_partition = m_arbitration_metadata.last_borrower();
+  for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel;
+       p++) {
+    int spid = (p + last_issued_partition + 1) %
+               m_config->m_n_sub_partition_per_memory_channel;
+    if (!m_sub_partition[spid]->L2_dram_queue_empty() &&
+        can_issue_to_dram(spid)) {
+      mem_fetch *mf = m_sub_partition[spid]->L2_dram_queue_top();
+      if (m_dram->full(mf->is_write())) break;
+
+      m_sub_partition[spid]->L2_dram_queue_pop();
+      MEMPART_DPRINTF(
+          "Issue mem_fetch request %p from sub partition %d to dram\n", mf,
+          spid);
+      dram_delay_t d;
+      d.req = mf;
+      d.ready_cycle = m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle +
+                      m_config->dram_latency;
+      m_dram_latency_queue.push_back(d);
+      mf->set_status(IN_PARTITION_DRAM_LATENCY_QUEUE,
+                     m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+      m_arbitration_metadata.borrow_credit(spid);
+      break;  // the DRAM should only accept one request per cycle
     }
+  }
+  //}
 }
 
-bool memory_sub_partition::full() const
-{
-    return m_icnt_L2_queue->full();
+void memory_partition_unit::dram_cycle() {
+  // pop completed memory request from dram and push it to dram-to-L2 queue
+  // of the original sub partition
+  mem_fetch *mf_return = m_dram->return_queue_top();
+  if (mf_return) {
+    unsigned dest_global_spid = mf_return->get_sub_partition_id();
+    int dest_spid = global_sub_partition_id_to_local_id(dest_global_spid);
+    assert(m_sub_partition[dest_spid]->get_id() == dest_global_spid);
+    if (!m_sub_partition[dest_spid]->dram_L2_queue_full()) {
+      if (mf_return->get_access_type() == L1_WRBK_ACC) {
+        m_sub_partition[dest_spid]->set_done(mf_return);
+        delete mf_return;
+      } else {
+        m_sub_partition[dest_spid]->dram_L2_queue_push(mf_return);
+        mf_return->set_status(IN_PARTITION_DRAM_TO_L2_QUEUE,
+                              m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+        m_arbitration_metadata.return_credit(dest_spid);
+        MEMPART_DPRINTF(
+            "mem_fetch request %p return from dram to sub partition %d\n",
+            mf_return, dest_spid);
+      }
+      m_dram->return_queue_pop();
+    }
+  } else {
+    m_dram->return_queue_pop();
+  }
+
+  m_dram->cycle();
+  m_dram->dram_log(SAMPLELOG);
+
+  // mem_fetch *mf = m_sub_partition[spid]->L2_dram_queue_top();
+  // if( !m_dram->full(mf->is_write()) ) {
+  // L2->DRAM queue to DRAM latency queue
+  // Arbitrate among multiple L2 subpartitions
+  int last_issued_partition = m_arbitration_metadata.last_borrower();
+  for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel;
+       p++) {
+    int spid = (p + last_issued_partition + 1) %
+               m_config->m_n_sub_partition_per_memory_channel;
+    if (!m_sub_partition[spid]->L2_dram_queue_empty() &&
+        can_issue_to_dram(spid)) {
+      mem_fetch *mf = m_sub_partition[spid]->L2_dram_queue_top();
+      if (m_dram->full(mf->is_write())) break;
+
+      m_sub_partition[spid]->L2_dram_queue_pop();
+      MEMPART_DPRINTF(
+          "Issue mem_fetch request %p from sub partition %d to dram\n", mf,
+          spid);
+      dram_delay_t d;
+      d.req = mf;
+      d.ready_cycle = m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle +
+                      m_config->dram_latency;
+      m_dram_latency_queue.push_back(d);
+      mf->set_status(IN_PARTITION_DRAM_LATENCY_QUEUE,
+                     m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+      m_arbitration_metadata.borrow_credit(spid);
+      break;  // the DRAM should only accept one request per cycle
+    }
+  }
+  //}
+
+  // DRAM latency queue
+  if (!m_dram_latency_queue.empty() &&
+      ((m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle) >=
+       m_dram_latency_queue.front().ready_cycle) &&
+      !m_dram->full(m_dram_latency_queue.front().req->is_write())) {
+    mem_fetch *mf = m_dram_latency_queue.front().req;
+    m_dram_latency_queue.pop_front();
+    m_dram->push(mf);
+  }
 }
 
-bool memory_sub_partition::full(unsigned size) const
-{
-    return m_icnt_L2_queue->is_avilable_size(size);
+void memory_partition_unit::set_done(mem_fetch *mf) {
+  unsigned global_spid = mf->get_sub_partition_id();
+  int spid = global_sub_partition_id_to_local_id(global_spid);
+  assert(m_sub_partition[spid]->get_id() == global_spid);
+  if (mf->get_access_type() == L1_WRBK_ACC ||
+      mf->get_access_type() == L2_WRBK_ACC) {
+    m_arbitration_metadata.return_credit(spid);
+    MEMPART_DPRINTF(
+        "mem_fetch request %p return from dram to sub partition %d\n", mf,
+        spid);
+  }
+  m_sub_partition[spid]->set_done(mf);
 }
 
-bool memory_sub_partition::L2_dram_queue_empty() const
-{
-   return m_L2_dram_queue->empty(); 
+void memory_partition_unit::set_dram_power_stats(
+    unsigned &n_cmd, unsigned &n_activity, unsigned &n_nop, unsigned &n_act,
+    unsigned &n_pre, unsigned &n_rd, unsigned &n_wr, unsigned &n_req) const {
+  m_dram->set_dram_power_stats(n_cmd, n_activity, n_nop, n_act, n_pre, n_rd,
+                               n_wr, n_req);
 }
 
-class mem_fetch* memory_sub_partition::L2_dram_queue_top() const
-{
-   return m_L2_dram_queue->top(); 
+void memory_partition_unit::print(FILE *fp) const {
+  fprintf(fp, "Memory Partition %u: \n", m_id);
+  for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel;
+       p++) {
+    m_sub_partition[p]->print(fp);
+  }
+  fprintf(fp, "In Dram Latency Queue (total = %zd): \n",
+          m_dram_latency_queue.size());
+  for (std::list<dram_delay_t>::const_iterator mf_dlq =
+           m_dram_latency_queue.begin();
+       mf_dlq != m_dram_latency_queue.end(); ++mf_dlq) {
+    mem_fetch *mf = mf_dlq->req;
+    fprintf(fp, "Ready @ %llu - ", mf_dlq->ready_cycle);
+    if (mf)
+      mf->print(fp);
+    else
+      fprintf(fp, " <NULL mem_fetch?>\n");
+  }
+  m_dram->print(fp);
 }
 
-void memory_sub_partition::L2_dram_queue_pop() 
-{
-   m_L2_dram_queue->pop(); 
+memory_sub_partition::memory_sub_partition(unsigned sub_partition_id,
+                                           const memory_config *config,
+                                           class memory_stats_t *stats,
+                                           class gpgpu_sim *gpu) {
+  m_id = sub_partition_id;
+  m_config = config;
+  m_stats = stats;
+  m_gpu = gpu;
+  m_memcpy_cycle_offset = 0;
+
+  assert(m_id < m_config->m_n_mem_sub_partition);
+
+  char L2c_name[32];
+  snprintf(L2c_name, 32, "L2_bank_%03d", m_id);
+  m_L2interface = new L2interface(this);
+  m_mf_allocator = new partition_mf_allocator(config);
+
+  if (!m_config->m_L2_config.disabled())
+    m_L2cache =
+        new l2_cache(L2c_name, m_config->m_L2_config, -1, -1, m_L2interface,
+                     m_mf_allocator, IN_PARTITION_L2_MISS_QUEUE, gpu);
+
+  unsigned int icnt_L2;
+  unsigned int L2_dram;
+  unsigned int dram_L2;
+  unsigned int L2_icnt;
+  sscanf(m_config->gpgpu_L2_queue_config, "%u:%u:%u:%u", &icnt_L2, &L2_dram,
+         &dram_L2, &L2_icnt);
+  m_icnt_L2_queue = new fifo_pipeline<mem_fetch>("icnt-to-L2", 0, icnt_L2);
+  m_L2_dram_queue = new fifo_pipeline<mem_fetch>("L2-to-dram", 0, L2_dram);
+  m_dram_L2_queue = new fifo_pipeline<mem_fetch>("dram-to-L2", 0, dram_L2);
+  m_L2_icnt_queue = new fifo_pipeline<mem_fetch>("L2-to-icnt", 0, L2_icnt);
+  wb_addr = -1;
 }
 
-bool memory_sub_partition::dram_L2_queue_full() const
-{
-   return m_dram_L2_queue->full(); 
+memory_sub_partition::~memory_sub_partition() {
+  delete m_icnt_L2_queue;
+  delete m_L2_dram_queue;
+  delete m_dram_L2_queue;
+  delete m_L2_icnt_queue;
+  delete m_L2cache;
+  delete m_L2interface;
 }
 
-void memory_sub_partition::dram_L2_queue_push( class mem_fetch* mf )
-{
-   m_dram_L2_queue->push(mf); 
-}
-
-void memory_sub_partition::print_cache_stat(unsigned &accesses, unsigned &misses) const
-{
-    FILE *fp = stdout;
-    if( !m_config->m_L2_config.disabled() )
-       m_L2cache->print(fp,accesses,misses);
-}
-
-void memory_sub_partition::print( FILE *fp ) const
-{
-    if ( !m_request_tracker.empty() ) {
-        fprintf(fp,"Memory Sub Parition %u: pending memory requests:\n", m_id);
-        for ( std::set<mem_fetch*>::const_iterator r=m_request_tracker.begin(); r != m_request_tracker.end(); ++r ) {
-            mem_fetch *mf = *r;
-            if ( mf )
-                mf->print(fp);
-            else
-                fprintf(fp," <NULL mem_fetch?>\n");
+void memory_sub_partition::cache_cycle(unsigned cycle) {
+  // L2 fill responses
+  if (!m_config->m_L2_config.disabled()) {
+    if (m_L2cache->access_ready() && !m_L2_icnt_queue->full()) {
+      mem_fetch *mf = m_L2cache->next_access();
+      if (mf->get_access_type() !=
+          L2_WR_ALLOC_R) {  // Don't pass write allocate read request back to
+                            // upper level cache
+        mf->set_reply();
+        mf->set_status(IN_PARTITION_L2_TO_ICNT_QUEUE,
+                       m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+        m_L2_icnt_queue->push(mf);
+      } else {
+        if (m_config->m_L2_config.m_write_alloc_policy == FETCH_ON_WRITE) {
+          mem_fetch *original_wr_mf = mf->get_original_wr_mf();
+          assert(original_wr_mf);
+          original_wr_mf->set_reply();
+          original_wr_mf->set_status(
+              IN_PARTITION_L2_TO_ICNT_QUEUE,
+              m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+          m_L2_icnt_queue->push(original_wr_mf);
         }
-    }
-    if( !m_config->m_L2_config.disabled() )
-       m_L2cache->display_state(fp);
-}
-
-void memory_stats_t::visualizer_print( gzFile visualizer_file )
-{
-   gzprintf(visualizer_file, "Ltwowritemiss: %d\n", L2_write_miss);
-   gzprintf(visualizer_file, "Ltwowritehit: %d\n",  L2_write_hit);
-   gzprintf(visualizer_file, "Ltworeadmiss: %d\n", L2_read_miss);
-   gzprintf(visualizer_file, "Ltworeadhit: %d\n", L2_read_hit);
-   clear_L2_stats_pw();
-
-   if (num_mfs)
-      gzprintf(visualizer_file, "averagemflatency: %lld\n", mf_total_lat/num_mfs);
-}
-
-void memory_stats_t::clear_L2_stats_pw(){
-    L2_write_miss = 0;
-    L2_write_hit = 0;
-    L2_read_miss = 0;
-    L2_read_hit = 0;
-}
-
-void gpgpu_sim::print_dram_stats(FILE *fout) const
-{
-	unsigned cmd=0;
-	unsigned activity=0;
-	unsigned nop=0;
-	unsigned act=0;
-	unsigned pre=0;
-	unsigned rd=0;
-	unsigned wr=0;
-	unsigned req=0;
-	unsigned tot_cmd=0;
-	unsigned tot_nop=0;
-	unsigned tot_act=0;
-	unsigned tot_pre=0;
-	unsigned tot_rd=0;
-	unsigned tot_wr=0;
-	unsigned tot_req=0;
-
-	for (unsigned i=0;i<m_memory_config->m_n_mem;i++){
-		m_memory_partition_unit[i]->set_dram_power_stats(cmd,activity,nop,act,pre,rd,wr,req);
-		tot_cmd+=cmd;
-		tot_nop+=nop;
-		tot_act+=act;
-		tot_pre+=pre;
-		tot_rd+=rd;
-		tot_wr+=wr;
-		tot_req+=req;
-	}
-    fprintf(fout,"gpgpu_n_dram_reads = %d\n",tot_rd );
-    fprintf(fout,"gpgpu_n_dram_writes = %d\n",tot_wr );
-    fprintf(fout,"gpgpu_n_dram_activate = %d\n",tot_act );
-    fprintf(fout,"gpgpu_n_dram_commands = %d\n",tot_cmd);
-    fprintf(fout,"gpgpu_n_dram_noops = %d\n",tot_nop );
-    fprintf(fout,"gpgpu_n_dram_precharges = %d\n",tot_pre );
-    fprintf(fout,"gpgpu_n_dram_requests = %d\n",tot_req );
-}
-
-unsigned memory_sub_partition::flushL2() 
-{ 
-    if (!m_config->m_L2_config.disabled()) {
-        m_L2cache->flush(); 
-    }
-    return 0;   //TODO: write the flushed data to the main memory
-}
-
-unsigned memory_sub_partition::invalidateL2()
-{
-    if (!m_config->m_L2_config.disabled()) {
-        m_L2cache->invalidate();
-    }
-    return 0;
-}
-
-bool memory_sub_partition::busy() const 
-{
-    return !m_request_tracker.empty();
-}
-
-std::vector<mem_fetch*> memory_sub_partition::breakdown_request_to_sector_requests(mem_fetch* mf)
-{
-	std::vector<mem_fetch*> result;
-
-	if(mf->get_data_size() == SECTOR_SIZE && mf->get_access_sector_mask().count() == 1) {
-		result.push_back(mf);
-	} else if (mf->get_data_size() == 128 || mf->get_data_size() == 64) {
-        //We only accept 32, 64 and 128 bytes reqs
-		unsigned start=0, end=0;
-		if(mf->get_data_size() == 128) {
-			start=0; end=3;
-		} else if (mf->get_data_size() == 64 && mf->get_access_sector_mask().to_string() == "1100") {
-			start=2; end=3;
-		} else if (mf->get_data_size() == 64 && mf->get_access_sector_mask().to_string() == "0011") {
-			start=0; end=1;
-		} else if (mf->get_data_size() == 64 && (mf->get_access_sector_mask().to_string() == "1111" || mf->get_access_sector_mask().to_string() == "0000")) {
-			if(mf->get_addr() % 128 == 0) {
-				start=0; end=1;
-			} else {
-				start=2; end=3;
-			}
-		} else
-			{
-			    printf("Invalid sector received, address = 0x%06llx, sector mask = %s, data size = %d",
-			    		mf->get_addr(), mf->get_access_sector_mask(), mf->get_data_size());
-				assert(0 && "Undefined sector mask is received");
-			}
-
-		std::bitset<SECTOR_SIZE*SECTOR_CHUNCK_SIZE> byte_sector_mask;
-		byte_sector_mask.reset();
-		for(unsigned  k=start*SECTOR_SIZE; k< SECTOR_SIZE; ++k)
-			byte_sector_mask.set(k);
-
-		for(unsigned j=start, i=0; j<= end ; ++j, ++i){
-
-			const mem_access_t *ma = new  mem_access_t( mf->get_access_type(),
-									mf->get_addr() + SECTOR_SIZE*i,
-									SECTOR_SIZE,
-									mf->is_write(),
-									mf->get_access_warp_mask(),
-									mf->get_access_byte_mask() & byte_sector_mask,
-									std::bitset<SECTOR_CHUNCK_SIZE>().set(j),
-									m_gpu->gpgpu_ctx);
-
-			 mem_fetch *n_mf = new mem_fetch( *ma,
-								NULL,
-								mf->get_ctrl_size(),
-								mf->get_wid(),
-								mf->get_sid(),
-								mf->get_tpc(),
-								mf->get_mem_config(),
-								m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle,
-								mf);
-
-			 result.push_back(n_mf);
-			 byte_sector_mask <<= SECTOR_SIZE;
-		}
-	} else {
-		 printf("Invalid sector received, address = 0x%06llx, sector mask = %d, byte mask = , data size = %u",
-					    		mf->get_addr(), mf->get_access_sector_mask().count(), mf->get_data_size());
-		 assert(0 && "Undefined data size is received");
-	}
-
-	return result;
-}
-
-void memory_sub_partition::push( mem_fetch* m_req, unsigned long long cycle )
-{
-    if (m_req) {
-    	m_stats->memlatstat_icnt2mem_pop(m_req);
-    	std::vector<mem_fetch*> reqs;
-    	if(m_config->m_L2_config.m_cache_type == SECTOR)
-    		reqs = breakdown_request_to_sector_requests(m_req);
-    	else
-    		reqs.push_back(m_req);
-
-    	for(unsigned i=0; i<reqs.size(); ++i) {
-    		mem_fetch* req = reqs[i];
-			m_request_tracker.insert(req);
-			if( req->istexture() ) {
-				m_icnt_L2_queue->push(req);
-				req->set_status(IN_PARTITION_ICNT_TO_L2_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-			} else {
-				rop_delay_t r;
-				r.req = req;
-				r.ready_cycle = cycle + m_config->rop_latency;
-				m_rop.push(r);
-				req->set_status(IN_PARTITION_ROP_DELAY,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-			}
-    	}
-    }
-}
-
-mem_fetch* memory_sub_partition::pop() 
-{
-    mem_fetch* mf = m_L2_icnt_queue->pop();
-    m_request_tracker.erase(mf);
-    if ( mf && mf->isatomic() )
-        mf->do_atomic();
-    if( mf && (mf->get_access_type() == L2_WRBK_ACC || mf->get_access_type() == L1_WRBK_ACC) ) {
-        delete mf;
-        mf = NULL;
-    } 
-    return mf;
-}
-
-mem_fetch* memory_sub_partition::top() 
-{
-    mem_fetch *mf = m_L2_icnt_queue->top();
-    if( mf && (mf->get_access_type() == L2_WRBK_ACC || mf->get_access_type() == L1_WRBK_ACC) ) {
-        m_L2_icnt_queue->pop();
         m_request_tracker.erase(mf);
         delete mf;
-        mf = NULL;
-    } 
-    return mf;
+      }
+    }
+  }
+
+  // DRAM to L2 (texture) and icnt (not texture)
+  if (!m_dram_L2_queue->empty()) {
+    mem_fetch *mf = m_dram_L2_queue->top();
+    if (!m_config->m_L2_config.disabled() && m_L2cache->waiting_for_fill(mf)) {
+      if (m_L2cache->fill_port_free()) {
+        mf->set_status(IN_PARTITION_L2_FILL_QUEUE,
+                       m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+        m_L2cache->fill(mf, m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle +
+                                m_memcpy_cycle_offset);
+        m_dram_L2_queue->pop();
+      }
+    } else if (!m_L2_icnt_queue->full()) {
+      if (mf->is_write() && mf->get_type() == WRITE_ACK)
+        mf->set_status(IN_PARTITION_L2_TO_ICNT_QUEUE,
+                       m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+      m_L2_icnt_queue->push(mf);
+      m_dram_L2_queue->pop();
+    }
+  }
+
+  // prior L2 misses inserted into m_L2_dram_queue here
+  if (!m_config->m_L2_config.disabled()) m_L2cache->cycle();
+
+  // new L2 texture accesses and/or non-texture accesses
+  if (!m_L2_dram_queue->full() && !m_icnt_L2_queue->empty()) {
+    mem_fetch *mf = m_icnt_L2_queue->top();
+    if (!m_config->m_L2_config.disabled() &&
+        ((m_config->m_L2_texure_only && mf->istexture()) ||
+         (!m_config->m_L2_texure_only))) {
+      // L2 is enabled and access is for L2
+      bool output_full = m_L2_icnt_queue->full();
+      bool port_free = m_L2cache->data_port_free();
+      if (!output_full && port_free) {
+        std::list<cache_event> events;
+        enum cache_request_status status =
+            m_L2cache->access(mf->get_addr(), mf,
+                              m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle +
+                                  m_memcpy_cycle_offset,
+                              events);
+        bool write_sent = was_write_sent(events);
+        bool read_sent = was_read_sent(events);
+        MEM_SUBPART_DPRINTF("Probing L2 cache Address=%llx, status=%u\n",
+                            mf->get_addr(), status);
+
+        if (status == HIT) {
+          if (!write_sent) {
+            // L2 cache replies
+            assert(!read_sent);
+            if (mf->get_access_type() == L1_WRBK_ACC) {
+              m_request_tracker.erase(mf);
+              delete mf;
+            } else {
+              mf->set_reply();
+              mf->set_status(IN_PARTITION_L2_TO_ICNT_QUEUE,
+                             m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+              m_L2_icnt_queue->push(mf);
+            }
+            m_icnt_L2_queue->pop();
+          } else {
+            assert(write_sent);
+            m_icnt_L2_queue->pop();
+          }
+        } else if (status != RESERVATION_FAIL) {
+          if (mf->is_write() &&
+              (m_config->m_L2_config.m_write_alloc_policy == FETCH_ON_WRITE ||
+               m_config->m_L2_config.m_write_alloc_policy ==
+                   LAZY_FETCH_ON_READ) &&
+              !was_writeallocate_sent(events)) {
+            mf->set_reply();
+            mf->set_status(IN_PARTITION_L2_TO_ICNT_QUEUE,
+                           m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+            m_L2_icnt_queue->push(mf);
+          }
+          // L2 cache accepted request
+          m_icnt_L2_queue->pop();
+        } else {
+          assert(!write_sent);
+          assert(!read_sent);
+          // L2 cache lock-up: will try again next cycle
+        }
+      }
+    } else {
+      // L2 is disabled or non-texture access to texture-only L2
+      mf->set_status(IN_PARTITION_L2_TO_DRAM_QUEUE,
+                     m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+      m_L2_dram_queue->push(mf);
+      m_icnt_L2_queue->pop();
+    }
+  }
+
+  // ROP delay queue
+  if (!m_rop.empty() && (cycle >= m_rop.front().ready_cycle) &&
+      !m_icnt_L2_queue->full()) {
+    mem_fetch *mf = m_rop.front().req;
+    m_rop.pop();
+    m_icnt_L2_queue->push(mf);
+    mf->set_status(IN_PARTITION_ICNT_TO_L2_QUEUE,
+                   m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+  }
 }
 
-void memory_sub_partition::set_done( mem_fetch *mf )
-{
+bool memory_sub_partition::full() const { return m_icnt_L2_queue->full(); }
+
+bool memory_sub_partition::full(unsigned size) const {
+  return m_icnt_L2_queue->is_avilable_size(size);
+}
+
+bool memory_sub_partition::L2_dram_queue_empty() const {
+  return m_L2_dram_queue->empty();
+}
+
+class mem_fetch *memory_sub_partition::L2_dram_queue_top() const {
+  return m_L2_dram_queue->top();
+}
+
+void memory_sub_partition::L2_dram_queue_pop() { m_L2_dram_queue->pop(); }
+
+bool memory_sub_partition::dram_L2_queue_full() const {
+  return m_dram_L2_queue->full();
+}
+
+void memory_sub_partition::dram_L2_queue_push(class mem_fetch *mf) {
+  m_dram_L2_queue->push(mf);
+}
+
+void memory_sub_partition::print_cache_stat(unsigned &accesses,
+                                            unsigned &misses) const {
+  FILE *fp = stdout;
+  if (!m_config->m_L2_config.disabled()) m_L2cache->print(fp, accesses, misses);
+}
+
+void memory_sub_partition::print(FILE *fp) const {
+  if (!m_request_tracker.empty()) {
+    fprintf(fp, "Memory Sub Parition %u: pending memory requests:\n", m_id);
+    for (std::set<mem_fetch *>::const_iterator r = m_request_tracker.begin();
+         r != m_request_tracker.end(); ++r) {
+      mem_fetch *mf = *r;
+      if (mf)
+        mf->print(fp);
+      else
+        fprintf(fp, " <NULL mem_fetch?>\n");
+    }
+  }
+  if (!m_config->m_L2_config.disabled()) m_L2cache->display_state(fp);
+}
+
+void memory_stats_t::visualizer_print(gzFile visualizer_file) {
+  gzprintf(visualizer_file, "Ltwowritemiss: %d\n", L2_write_miss);
+  gzprintf(visualizer_file, "Ltwowritehit: %d\n", L2_write_hit);
+  gzprintf(visualizer_file, "Ltworeadmiss: %d\n", L2_read_miss);
+  gzprintf(visualizer_file, "Ltworeadhit: %d\n", L2_read_hit);
+  clear_L2_stats_pw();
+
+  if (num_mfs)
+    gzprintf(visualizer_file, "averagemflatency: %lld\n",
+             mf_total_lat / num_mfs);
+}
+
+void memory_stats_t::clear_L2_stats_pw() {
+  L2_write_miss = 0;
+  L2_write_hit = 0;
+  L2_read_miss = 0;
+  L2_read_hit = 0;
+}
+
+void gpgpu_sim::print_dram_stats(FILE *fout) const {
+  unsigned cmd = 0;
+  unsigned activity = 0;
+  unsigned nop = 0;
+  unsigned act = 0;
+  unsigned pre = 0;
+  unsigned rd = 0;
+  unsigned wr = 0;
+  unsigned req = 0;
+  unsigned tot_cmd = 0;
+  unsigned tot_nop = 0;
+  unsigned tot_act = 0;
+  unsigned tot_pre = 0;
+  unsigned tot_rd = 0;
+  unsigned tot_wr = 0;
+  unsigned tot_req = 0;
+
+  for (unsigned i = 0; i < m_memory_config->m_n_mem; i++) {
+    m_memory_partition_unit[i]->set_dram_power_stats(cmd, activity, nop, act,
+                                                     pre, rd, wr, req);
+    tot_cmd += cmd;
+    tot_nop += nop;
+    tot_act += act;
+    tot_pre += pre;
+    tot_rd += rd;
+    tot_wr += wr;
+    tot_req += req;
+  }
+  fprintf(fout, "gpgpu_n_dram_reads = %d\n", tot_rd);
+  fprintf(fout, "gpgpu_n_dram_writes = %d\n", tot_wr);
+  fprintf(fout, "gpgpu_n_dram_activate = %d\n", tot_act);
+  fprintf(fout, "gpgpu_n_dram_commands = %d\n", tot_cmd);
+  fprintf(fout, "gpgpu_n_dram_noops = %d\n", tot_nop);
+  fprintf(fout, "gpgpu_n_dram_precharges = %d\n", tot_pre);
+  fprintf(fout, "gpgpu_n_dram_requests = %d\n", tot_req);
+}
+
+unsigned memory_sub_partition::flushL2() {
+  if (!m_config->m_L2_config.disabled()) {
+    m_L2cache->flush();
+  }
+  return 0;  // TODO: write the flushed data to the main memory
+}
+
+unsigned memory_sub_partition::invalidateL2() {
+  if (!m_config->m_L2_config.disabled()) {
+    m_L2cache->invalidate();
+  }
+  return 0;
+}
+
+bool memory_sub_partition::busy() const { return !m_request_tracker.empty(); }
+
+std::vector<mem_fetch *>
+memory_sub_partition::breakdown_request_to_sector_requests(mem_fetch *mf) {
+  std::vector<mem_fetch *> result;
+
+  if (mf->get_data_size() == SECTOR_SIZE &&
+      mf->get_access_sector_mask().count() == 1) {
+    result.push_back(mf);
+  } else if (mf->get_data_size() == 128 || mf->get_data_size() == 64) {
+    // We only accept 32, 64 and 128 bytes reqs
+    unsigned start = 0, end = 0;
+    if (mf->get_data_size() == 128) {
+      start = 0;
+      end = 3;
+    } else if (mf->get_data_size() == 64 &&
+               mf->get_access_sector_mask().to_string() == "1100") {
+      start = 2;
+      end = 3;
+    } else if (mf->get_data_size() == 64 &&
+               mf->get_access_sector_mask().to_string() == "0011") {
+      start = 0;
+      end = 1;
+    } else if (mf->get_data_size() == 64 &&
+               (mf->get_access_sector_mask().to_string() == "1111" ||
+                mf->get_access_sector_mask().to_string() == "0000")) {
+      if (mf->get_addr() % 128 == 0) {
+        start = 0;
+        end = 1;
+      } else {
+        start = 2;
+        end = 3;
+      }
+    } else {
+      printf(
+          "Invalid sector received, address = 0x%06llx, sector mask = %s, data "
+          "size = %d",
+          mf->get_addr(), mf->get_access_sector_mask(), mf->get_data_size());
+      assert(0 && "Undefined sector mask is received");
+    }
+
+    std::bitset<SECTOR_SIZE * SECTOR_CHUNCK_SIZE> byte_sector_mask;
+    byte_sector_mask.reset();
+    for (unsigned k = start * SECTOR_SIZE; k < SECTOR_SIZE; ++k)
+      byte_sector_mask.set(k);
+
+    for (unsigned j = start, i = 0; j <= end; ++j, ++i) {
+      const mem_access_t *ma = new mem_access_t(
+          mf->get_access_type(), mf->get_addr() + SECTOR_SIZE * i, SECTOR_SIZE,
+          mf->is_write(), mf->get_access_warp_mask(),
+          mf->get_access_byte_mask() & byte_sector_mask,
+          std::bitset<SECTOR_CHUNCK_SIZE>().set(j), m_gpu->gpgpu_ctx);
+
+      mem_fetch *n_mf =
+          new mem_fetch(*ma, NULL, mf->get_ctrl_size(), mf->get_wid(),
+                        mf->get_sid(), mf->get_tpc(), mf->get_mem_config(),
+                        m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle, mf);
+
+      result.push_back(n_mf);
+      byte_sector_mask <<= SECTOR_SIZE;
+    }
+  } else {
+    printf(
+        "Invalid sector received, address = 0x%06llx, sector mask = %d, byte "
+        "mask = , data size = %u",
+        mf->get_addr(), mf->get_access_sector_mask().count(),
+        mf->get_data_size());
+    assert(0 && "Undefined data size is received");
+  }
+
+  return result;
+}
+
+void memory_sub_partition::push(mem_fetch *m_req, unsigned long long cycle) {
+  if (m_req) {
+    m_stats->memlatstat_icnt2mem_pop(m_req);
+    std::vector<mem_fetch *> reqs;
+    if (m_config->m_L2_config.m_cache_type == SECTOR)
+      reqs = breakdown_request_to_sector_requests(m_req);
+    else
+      reqs.push_back(m_req);
+
+    for (unsigned i = 0; i < reqs.size(); ++i) {
+      mem_fetch *req = reqs[i];
+      m_request_tracker.insert(req);
+      if (req->istexture()) {
+        m_icnt_L2_queue->push(req);
+        req->set_status(IN_PARTITION_ICNT_TO_L2_QUEUE,
+                        m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+      } else {
+        rop_delay_t r;
+        r.req = req;
+        r.ready_cycle = cycle + m_config->rop_latency;
+        m_rop.push(r);
+        req->set_status(IN_PARTITION_ROP_DELAY,
+                        m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+      }
+    }
+  }
+}
+
+mem_fetch *memory_sub_partition::pop() {
+  mem_fetch *mf = m_L2_icnt_queue->pop();
+  m_request_tracker.erase(mf);
+  if (mf && mf->isatomic()) mf->do_atomic();
+  if (mf && (mf->get_access_type() == L2_WRBK_ACC ||
+             mf->get_access_type() == L1_WRBK_ACC)) {
+    delete mf;
+    mf = NULL;
+  }
+  return mf;
+}
+
+mem_fetch *memory_sub_partition::top() {
+  mem_fetch *mf = m_L2_icnt_queue->top();
+  if (mf && (mf->get_access_type() == L2_WRBK_ACC ||
+             mf->get_access_type() == L1_WRBK_ACC)) {
+    m_L2_icnt_queue->pop();
     m_request_tracker.erase(mf);
+    delete mf;
+    mf = NULL;
+  }
+  return mf;
 }
 
-void memory_sub_partition::accumulate_L2cache_stats(class cache_stats &l2_stats) const {
-    if (!m_config->m_L2_config.disabled()) {
-        l2_stats += m_L2cache->get_stats();
-    }
+void memory_sub_partition::set_done(mem_fetch *mf) {
+  m_request_tracker.erase(mf);
 }
 
-void memory_sub_partition::get_L2cache_sub_stats(struct cache_sub_stats &css) const{
-    if (!m_config->m_L2_config.disabled()) {
-        m_L2cache->get_sub_stats(css);
-    }
+void memory_sub_partition::accumulate_L2cache_stats(
+    class cache_stats &l2_stats) const {
+  if (!m_config->m_L2_config.disabled()) {
+    l2_stats += m_L2cache->get_stats();
+  }
 }
 
-void memory_sub_partition::get_L2cache_sub_stats_pw(struct cache_sub_stats_pw &css) const{
-    if (!m_config->m_L2_config.disabled()) {
-        m_L2cache->get_sub_stats_pw(css);
-    }
+void memory_sub_partition::get_L2cache_sub_stats(
+    struct cache_sub_stats &css) const {
+  if (!m_config->m_L2_config.disabled()) {
+    m_L2cache->get_sub_stats(css);
+  }
+}
+
+void memory_sub_partition::get_L2cache_sub_stats_pw(
+    struct cache_sub_stats_pw &css) const {
+  if (!m_config->m_L2_config.disabled()) {
+    m_L2cache->get_sub_stats_pw(css);
+  }
 }
 
 void memory_sub_partition::clear_L2cache_stats_pw() {
-    if (!m_config->m_L2_config.disabled()) {
-        m_L2cache->clear_pw();
-    }
+  if (!m_config->m_L2_config.disabled()) {
+    m_L2cache->clear_pw();
+  }
 }
 
-void memory_sub_partition::visualizer_print( gzFile visualizer_file )
-{
-    // Support for L2 AerialVision stats
-    // Per-sub-partition stats would be trivial to extend from this
-    cache_sub_stats_pw temp_sub_stats;
-    get_L2cache_sub_stats_pw(temp_sub_stats);
+void memory_sub_partition::visualizer_print(gzFile visualizer_file) {
+  // Support for L2 AerialVision stats
+  // Per-sub-partition stats would be trivial to extend from this
+  cache_sub_stats_pw temp_sub_stats;
+  get_L2cache_sub_stats_pw(temp_sub_stats);
 
-    m_stats->L2_read_miss += temp_sub_stats.read_misses;
-    m_stats->L2_write_miss += temp_sub_stats.write_misses;
-    m_stats->L2_read_hit += temp_sub_stats.read_hits;
-    m_stats->L2_write_hit += temp_sub_stats.write_hits;
+  m_stats->L2_read_miss += temp_sub_stats.read_misses;
+  m_stats->L2_write_miss += temp_sub_stats.write_misses;
+  m_stats->L2_read_hit += temp_sub_stats.read_hits;
+  m_stats->L2_write_hit += temp_sub_stats.write_hits;
 
-    clear_L2cache_stats_pw();
+  clear_L2cache_stats_pw();
 }

--- a/src/gpgpu-sim/l2cache.cc
+++ b/src/gpgpu-sim/l2cache.cc
@@ -7,815 +7,854 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include <list>
 #include <set>
 
+#include "../abstract_hardware_model.h"
 #include "../option_parser.h"
-#include "mem_fetch.h"
+#include "../statwrapper.h"
 #include "dram.h"
 #include "gpu-cache.h"
+#include "gpu-sim.h"
 #include "histogram.h"
 #include "l2cache.h"
-#include "../statwrapper.h"
-#include "../abstract_hardware_model.h"
-#include "gpu-sim.h"
-#include "shader.h"
-#include "mem_latency_stat.h"
 #include "l2cache_trace.h"
+#include "mem_fetch.h"
+#include "mem_latency_stat.h"
+#include "shader.h"
 
-
-mem_fetch * partition_mf_allocator::alloc(new_addr_type addr, mem_access_type type, unsigned size, bool wr, unsigned long long cycle ) const
-{
-    assert( wr );
-    mem_access_t access( type, addr, size, wr, m_memory_config->gpgpu_ctx );
-    mem_fetch *mf = new mem_fetch( access, 
-                                   NULL,
-                                   WRITE_PACKET_SIZE, 
-                                   -1, 
-                                   -1, 
-                                   -1,
-                                   m_memory_config,
-								   cycle);
-    return mf;
+mem_fetch *partition_mf_allocator::alloc(new_addr_type addr,
+                                         mem_access_type type, unsigned size,
+                                         bool wr,
+                                         unsigned long long cycle) const {
+  assert(wr);
+  mem_access_t access(type, addr, size, wr, m_memory_config->gpgpu_ctx);
+  mem_fetch *mf = new mem_fetch(access, NULL, WRITE_PACKET_SIZE, -1, -1, -1,
+                                m_memory_config, cycle);
+  return mf;
 }
 
-memory_partition_unit::memory_partition_unit( unsigned partition_id, 
-                                              const memory_config *config,
-                                              class memory_stats_t *stats,
-											  class gpgpu_sim* gpu)
-: m_id(partition_id), m_config(config), m_stats(stats), m_arbitration_metadata(config), m_gpu(gpu)
-{
-    m_dram = new dram_t(m_id,m_config,m_stats,this,gpu);
+memory_partition_unit::memory_partition_unit(unsigned partition_id,
+                                             const memory_config *config,
+                                             class memory_stats_t *stats,
+                                             class gpgpu_sim *gpu)
+    : m_id(partition_id),
+      m_config(config),
+      m_stats(stats),
+      m_arbitration_metadata(config),
+      m_gpu(gpu) {
+  m_dram = new dram_t(m_id, m_config, m_stats, this, gpu);
 
-    m_sub_partition = new memory_sub_partition*[m_config->m_n_sub_partition_per_memory_channel]; 
-    for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel; p++) {
-        unsigned sub_partition_id = m_id * m_config->m_n_sub_partition_per_memory_channel + p; 
-        m_sub_partition[p] = new memory_sub_partition(sub_partition_id, m_config, stats, gpu);
+  m_sub_partition = new memory_sub_partition
+      *[m_config->m_n_sub_partition_per_memory_channel];
+  for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel;
+       p++) {
+    unsigned sub_partition_id =
+        m_id * m_config->m_n_sub_partition_per_memory_channel + p;
+    m_sub_partition[p] =
+        new memory_sub_partition(sub_partition_id, m_config, stats, gpu);
+  }
+}
+
+void memory_partition_unit::handle_memcpy_to_gpu(
+    size_t addr, unsigned global_subpart_id, mem_access_sector_mask_t mask) {
+  unsigned p = global_sub_partition_id_to_local_id(global_subpart_id);
+  std::string mystring = mask.to_string<char, std::string::traits_type,
+                                        std::string::allocator_type>();
+  MEMPART_DPRINTF(
+      "Copy Engine Request Received For Address=%zx, local_subpart=%u, "
+      "global_subpart=%u, sector_mask=%s \n",
+      addr, p, global_subpart_id, mystring.c_str());
+  m_sub_partition[p]->force_l2_tag_update(
+      addr, m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle, mask);
+}
+
+memory_partition_unit::~memory_partition_unit() {
+  delete m_dram;
+  for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel;
+       p++) {
+    delete m_sub_partition[p];
+  }
+  delete[] m_sub_partition;
+}
+
+memory_partition_unit::arbitration_metadata::arbitration_metadata(
+    const memory_config *config)
+    : m_last_borrower(config->m_n_sub_partition_per_memory_channel - 1),
+      m_private_credit(config->m_n_sub_partition_per_memory_channel, 0),
+      m_shared_credit(0) {
+  // each sub partition get at least 1 credit for forward progress
+  // the rest is shared among with other partitions
+  m_private_credit_limit = 1;
+  m_shared_credit_limit = config->gpgpu_frfcfs_dram_sched_queue_size +
+                          config->gpgpu_dram_return_queue_size -
+                          (config->m_n_sub_partition_per_memory_channel - 1);
+  if (config->seperate_write_queue_enabled)
+    m_shared_credit_limit += config->gpgpu_frfcfs_dram_write_queue_size;
+  if (config->gpgpu_frfcfs_dram_sched_queue_size == 0 or
+      config->gpgpu_dram_return_queue_size == 0) {
+    m_shared_credit_limit =
+        0;  // no limit if either of the queue has no limit in size
+  }
+  assert(m_shared_credit_limit >= 0);
+}
+
+bool memory_partition_unit::arbitration_metadata::has_credits(
+    int inner_sub_partition_id) const {
+  int spid = inner_sub_partition_id;
+  if (m_private_credit[spid] < m_private_credit_limit) {
+    return true;
+  } else if (m_shared_credit_limit == 0 ||
+             m_shared_credit < m_shared_credit_limit) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+void memory_partition_unit::arbitration_metadata::borrow_credit(
+    int inner_sub_partition_id) {
+  int spid = inner_sub_partition_id;
+  if (m_private_credit[spid] < m_private_credit_limit) {
+    m_private_credit[spid] += 1;
+  } else if (m_shared_credit_limit == 0 ||
+             m_shared_credit < m_shared_credit_limit) {
+    m_shared_credit += 1;
+  } else {
+    assert(0 && "DRAM arbitration error: Borrowing from depleted credit!");
+  }
+  m_last_borrower = spid;
+}
+
+void memory_partition_unit::arbitration_metadata::return_credit(
+    int inner_sub_partition_id) {
+  int spid = inner_sub_partition_id;
+  if (m_private_credit[spid] > 0) {
+    m_private_credit[spid] -= 1;
+  } else {
+    m_shared_credit -= 1;
+  }
+  assert((m_shared_credit >= 0) &&
+         "DRAM arbitration error: Returning more than available credits!");
+}
+
+void memory_partition_unit::arbitration_metadata::print(FILE *fp) const {
+  fprintf(fp, "private_credit = ");
+  for (unsigned p = 0; p < m_private_credit.size(); p++) {
+    fprintf(fp, "%d ", m_private_credit[p]);
+  }
+  fprintf(fp, "(limit = %d)\n", m_private_credit_limit);
+  fprintf(fp, "shared_credit = %d (limit = %d)\n", m_shared_credit,
+          m_shared_credit_limit);
+}
+
+bool memory_partition_unit::busy() const {
+  bool busy = false;
+  for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel;
+       p++) {
+    if (m_sub_partition[p]->busy()) {
+      busy = true;
     }
-
+  }
+  return busy;
 }
 
-void memory_partition_unit::handle_memcpy_to_gpu( size_t addr, unsigned global_subpart_id, mem_access_sector_mask_t mask )
-{
-    unsigned p = global_sub_partition_id_to_local_id(global_subpart_id);
-    std::string mystring =
-        mask.to_string<char,std::string::traits_type,std::string::allocator_type>();
-    MEMPART_DPRINTF("Copy Engine Request Received For Address=%zx, local_subpart=%u, global_subpart=%u, sector_mask=%s \n", addr, p, global_subpart_id, mystring.c_str()); 
-    m_sub_partition[p]->force_l2_tag_update(addr,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle, mask);
+void memory_partition_unit::cache_cycle(unsigned cycle) {
+  for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel;
+       p++) {
+    m_sub_partition[p]->cache_cycle(cycle);
+  }
 }
 
-memory_partition_unit::~memory_partition_unit() 
-{
-    delete m_dram; 
-    for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel; p++) {
-        delete m_sub_partition[p]; 
-    } 
-    delete[] m_sub_partition; 
+void memory_partition_unit::visualizer_print(gzFile visualizer_file) const {
+  m_dram->visualizer_print(visualizer_file);
+  for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel;
+       p++) {
+    m_sub_partition[p]->visualizer_print(visualizer_file);
+  }
 }
 
-memory_partition_unit::arbitration_metadata::arbitration_metadata(const memory_config *config)
-: m_last_borrower(config->m_n_sub_partition_per_memory_channel - 1), 
-  m_private_credit(config->m_n_sub_partition_per_memory_channel, 0), 
-  m_shared_credit(0) 
-{
-    // each sub partition get at least 1 credit for forward progress 
-    // the rest is shared among with other partitions 
-    m_private_credit_limit = 1; 
-    m_shared_credit_limit = config->gpgpu_frfcfs_dram_sched_queue_size 
-                            + config->gpgpu_dram_return_queue_size 
-                            - (config->m_n_sub_partition_per_memory_channel - 1);
-    if(config->seperate_write_queue_enabled )
-    	m_shared_credit_limit += config->gpgpu_frfcfs_dram_write_queue_size;
-    if (config->gpgpu_frfcfs_dram_sched_queue_size == 0 
-        or config->gpgpu_dram_return_queue_size == 0) 
-    {
-        m_shared_credit_limit = 0; // no limit if either of the queue has no limit in size 
-    }
-    assert(m_shared_credit_limit >= 0); 
+// determine whether a given subpartition can issue to DRAM
+bool memory_partition_unit::can_issue_to_dram(int inner_sub_partition_id) {
+  int spid = inner_sub_partition_id;
+  bool sub_partition_contention = m_sub_partition[spid]->dram_L2_queue_full();
+  bool has_dram_resource = m_arbitration_metadata.has_credits(spid);
+
+  MEMPART_DPRINTF(
+      "sub partition %d sub_partition_contention=%c has_dram_resource=%c\n",
+      spid, (sub_partition_contention) ? 'T' : 'F',
+      (has_dram_resource) ? 'T' : 'F');
+
+  return (has_dram_resource && !sub_partition_contention);
 }
 
-bool memory_partition_unit::arbitration_metadata::has_credits(int inner_sub_partition_id) const 
-{
-    int spid = inner_sub_partition_id; 
-    if (m_private_credit[spid] < m_private_credit_limit) {
-        return true; 
-    } else if (m_shared_credit_limit == 0 || m_shared_credit < m_shared_credit_limit) {
-        return true; 
-    } else {
-        return false; 
-    }
+int memory_partition_unit::global_sub_partition_id_to_local_id(
+    int global_sub_partition_id) const {
+  return (global_sub_partition_id -
+          m_id * m_config->m_n_sub_partition_per_memory_channel);
 }
 
-void memory_partition_unit::arbitration_metadata::borrow_credit(int inner_sub_partition_id) 
-{
-    int spid = inner_sub_partition_id; 
-    if (m_private_credit[spid] < m_private_credit_limit) {
-        m_private_credit[spid] += 1; 
-    } else if (m_shared_credit_limit == 0 || m_shared_credit < m_shared_credit_limit) {
-        m_shared_credit += 1; 
-    } else {
-        assert(0 && "DRAM arbitration error: Borrowing from depleted credit!"); 
-    }
-    m_last_borrower = spid; 
-}
+void memory_partition_unit::simple_dram_model_cycle() {
+  // pop completed memory request from dram and push it to dram-to-L2 queue
+  // of the original sub partition
+  if (!m_dram_latency_queue.empty() &&
+      ((m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle) >=
+       m_dram_latency_queue.front().ready_cycle)) {
+    mem_fetch *mf_return = m_dram_latency_queue.front().req;
+    if (mf_return->get_access_type() != L1_WRBK_ACC &&
+        mf_return->get_access_type() != L2_WRBK_ACC) {
+      mf_return->set_reply();
 
-void memory_partition_unit::arbitration_metadata::return_credit(int inner_sub_partition_id) 
-{
-    int spid = inner_sub_partition_id; 
-    if (m_private_credit[spid] > 0) {
-        m_private_credit[spid] -= 1; 
-    } else {
-        m_shared_credit -= 1; 
-    } 
-    assert((m_shared_credit >= 0) && "DRAM arbitration error: Returning more than available credits!"); 
-}
-
-void memory_partition_unit::arbitration_metadata::print( FILE *fp ) const 
-{
-    fprintf(fp, "private_credit = "); 
-    for (unsigned p = 0; p < m_private_credit.size(); p++) {
-        fprintf(fp, "%d ", m_private_credit[p]); 
-    }
-    fprintf(fp, "(limit = %d)\n", m_private_credit_limit); 
-    fprintf(fp, "shared_credit = %d (limit = %d)\n", m_shared_credit, m_shared_credit_limit); 
-}
-
-bool memory_partition_unit::busy() const 
-{
-    bool busy = false; 
-    for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel; p++) {
-        if (m_sub_partition[p]->busy()) {
-            busy = true; 
-        }
-    }
-    return busy; 
-}
-
-void memory_partition_unit::cache_cycle(unsigned cycle) 
-{
-    for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel; p++) {
-        m_sub_partition[p]->cache_cycle(cycle); 
-    }
-}
-
-void memory_partition_unit::visualizer_print( gzFile visualizer_file ) const 
-{
-    m_dram->visualizer_print(visualizer_file);
-    for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel; p++) {
-        m_sub_partition[p]->visualizer_print(visualizer_file); 
-    }
-}
-
-// determine whether a given subpartition can issue to DRAM 
-bool memory_partition_unit::can_issue_to_dram(int inner_sub_partition_id) 
-{
-    int spid = inner_sub_partition_id; 
-    bool sub_partition_contention = m_sub_partition[spid]->dram_L2_queue_full(); 
-    bool has_dram_resource = m_arbitration_metadata.has_credits(spid); 
-
-    MEMPART_DPRINTF("sub partition %d sub_partition_contention=%c has_dram_resource=%c\n", 
-                    spid, (sub_partition_contention)? 'T':'F', (has_dram_resource)? 'T':'F'); 
-
-    return (has_dram_resource && !sub_partition_contention); 
-}
-
-int memory_partition_unit::global_sub_partition_id_to_local_id(int global_sub_partition_id) const
-{
-    return (global_sub_partition_id - m_id * m_config->m_n_sub_partition_per_memory_channel); 
-}
-
-void memory_partition_unit::simple_dram_model_cycle()
-{
-
-	// pop completed memory request from dram and push it to dram-to-L2 queue
-	// of the original sub partition
-	if (!m_dram_latency_queue.empty() && ( (m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle) >= m_dram_latency_queue.front().ready_cycle )) {
-		 mem_fetch* mf_return = m_dram_latency_queue.front().req;
-		 if( mf_return->get_access_type() != L1_WRBK_ACC && mf_return->get_access_type() != L2_WRBK_ACC ) {
-			 mf_return->set_reply();
-
-		    unsigned dest_global_spid = mf_return->get_sub_partition_id();
-			int dest_spid = global_sub_partition_id_to_local_id(dest_global_spid);
-			assert(m_sub_partition[dest_spid]->get_id() == dest_global_spid);
-			if (!m_sub_partition[dest_spid]->dram_L2_queue_full()) {
-				if( mf_return->get_access_type() == L1_WRBK_ACC ) {
-					m_sub_partition[dest_spid]->set_done(mf_return);
-					delete mf_return;
-				} else {
-					m_sub_partition[dest_spid]->dram_L2_queue_push(mf_return);
-					mf_return->set_status(IN_PARTITION_DRAM_TO_L2_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-					m_arbitration_metadata.return_credit(dest_spid);
-					MEMPART_DPRINTF("mem_fetch request %p return from dram to sub partition %d\n", mf_return, dest_spid);
-				}
-				m_dram_latency_queue.pop_front();
-			}
-
-		  } else {
-			 this->set_done(mf_return);
-			 delete mf_return;
-			 m_dram_latency_queue.pop_front();
-		  }
-	}
-
-   // mem_fetch *mf = m_sub_partition[spid]->L2_dram_queue_top();
-	//if( !m_dram->full(mf->is_write()) ) {
-		// L2->DRAM queue to DRAM latency queue
-		// Arbitrate among multiple L2 subpartitions
-		int last_issued_partition = m_arbitration_metadata.last_borrower();
-		for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel; p++) {
-			int spid = (p + last_issued_partition + 1) % m_config->m_n_sub_partition_per_memory_channel;
-			if (!m_sub_partition[spid]->L2_dram_queue_empty() && can_issue_to_dram(spid)) {
-				mem_fetch *mf = m_sub_partition[spid]->L2_dram_queue_top();
-				if(m_dram->full(mf->is_write()) )
-					break;
-
-				m_sub_partition[spid]->L2_dram_queue_pop();
-				MEMPART_DPRINTF("Issue mem_fetch request %p from sub partition %d to dram\n", mf, spid);
-				dram_delay_t d;
-				d.req = mf;
-				d.ready_cycle = m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle + m_config->dram_latency;
-				m_dram_latency_queue.push_back(d);
-				mf->set_status(IN_PARTITION_DRAM_LATENCY_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-				m_arbitration_metadata.borrow_credit(spid);
-				break;  // the DRAM should only accept one request per cycle
-			}
-		}
-	//}
-
-}
-
-void memory_partition_unit::dram_cycle()
-{ 
-    // pop completed memory request from dram and push it to dram-to-L2 queue 
-    // of the original sub partition 
-    mem_fetch* mf_return = m_dram->return_queue_top();
-    if (mf_return) {
-        unsigned dest_global_spid = mf_return->get_sub_partition_id(); 
-        int dest_spid = global_sub_partition_id_to_local_id(dest_global_spid); 
-        assert(m_sub_partition[dest_spid]->get_id() == dest_global_spid); 
-        if (!m_sub_partition[dest_spid]->dram_L2_queue_full()) {
-            if( mf_return->get_access_type() == L1_WRBK_ACC ) {
-                m_sub_partition[dest_spid]->set_done(mf_return); 
-                delete mf_return;
-            } else {
-                m_sub_partition[dest_spid]->dram_L2_queue_push(mf_return);
-                mf_return->set_status(IN_PARTITION_DRAM_TO_L2_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-                m_arbitration_metadata.return_credit(dest_spid); 
-                MEMPART_DPRINTF("mem_fetch request %p return from dram to sub partition %d\n", mf_return, dest_spid); 
-            }
-            m_dram->return_queue_pop(); 
-        }
-    } else {
-        m_dram->return_queue_pop(); 
-    }
-    
-    m_dram->cycle();
-    m_dram->dram_log(SAMPLELOG);
-
-   // mem_fetch *mf = m_sub_partition[spid]->L2_dram_queue_top();
-    //if( !m_dram->full(mf->is_write()) ) {
-        // L2->DRAM queue to DRAM latency queue
-        // Arbitrate among multiple L2 subpartitions 
-        int last_issued_partition = m_arbitration_metadata.last_borrower(); 
-        for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel; p++) {
-            int spid = (p + last_issued_partition + 1) % m_config->m_n_sub_partition_per_memory_channel; 
-            if (!m_sub_partition[spid]->L2_dram_queue_empty() && can_issue_to_dram(spid)) {
-                mem_fetch *mf = m_sub_partition[spid]->L2_dram_queue_top();
-                if(m_dram->full(mf->is_write()) )
-                	break;
-
-                m_sub_partition[spid]->L2_dram_queue_pop();
-                MEMPART_DPRINTF("Issue mem_fetch request %p from sub partition %d to dram\n", mf, spid); 
-                dram_delay_t d;
-                d.req = mf;
-                d.ready_cycle = m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle + m_config->dram_latency;
-                m_dram_latency_queue.push_back(d);
-                mf->set_status(IN_PARTITION_DRAM_LATENCY_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-                m_arbitration_metadata.borrow_credit(spid); 
-                break;  // the DRAM should only accept one request per cycle 
-            }
-        }
-    //}
-
-    // DRAM latency queue
-    if( !m_dram_latency_queue.empty() && ( (m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle) >= m_dram_latency_queue.front().ready_cycle ) && !m_dram->full(m_dram_latency_queue.front().req->is_write()) ) {
-    	mem_fetch* mf = m_dram_latency_queue.front().req;
-    	m_dram_latency_queue.pop_front();
-        m_dram->push(mf);
-    }
-}
-
-void memory_partition_unit::set_done( mem_fetch *mf )
-{
-    unsigned global_spid = mf->get_sub_partition_id(); 
-    int spid = global_sub_partition_id_to_local_id(global_spid); 
-    assert(m_sub_partition[spid]->get_id() == global_spid); 
-    if (mf->get_access_type() == L1_WRBK_ACC || mf->get_access_type() == L2_WRBK_ACC) {
-        m_arbitration_metadata.return_credit(spid); 
-        MEMPART_DPRINTF("mem_fetch request %p return from dram to sub partition %d\n", mf, spid); 
-    }
-    m_sub_partition[spid]->set_done(mf); 
-}
-
-void memory_partition_unit::set_dram_power_stats(unsigned &n_cmd,
-                                                 unsigned &n_activity,
-                                                 unsigned &n_nop,
-                                                 unsigned &n_act,
-                                                 unsigned &n_pre,
-                                                 unsigned &n_rd,
-                                                 unsigned &n_wr,
-                                                 unsigned &n_req) const
-{
-    m_dram->set_dram_power_stats(n_cmd, n_activity, n_nop, n_act, n_pre, n_rd, n_wr, n_req);
-}
-
-void memory_partition_unit::print( FILE *fp ) const
-{
-    fprintf(fp, "Memory Partition %u: \n", m_id); 
-    for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel; p++) {
-        m_sub_partition[p]->print(fp); 
-    }
-    fprintf(fp, "In Dram Latency Queue (total = %zd): \n", m_dram_latency_queue.size()); 
-    for (std::list<dram_delay_t>::const_iterator mf_dlq = m_dram_latency_queue.begin(); 
-         mf_dlq != m_dram_latency_queue.end(); ++mf_dlq) {
-        mem_fetch *mf = mf_dlq->req; 
-        fprintf(fp, "Ready @ %llu - ", mf_dlq->ready_cycle); 
-        if (mf) 
-            mf->print(fp); 
-        else 
-            fprintf(fp, " <NULL mem_fetch?>\n"); 
-    }
-    m_dram->print(fp); 
-}
-
-memory_sub_partition::memory_sub_partition( unsigned sub_partition_id, 
-                                            const memory_config *config,
-                                            class memory_stats_t *stats,
-											class gpgpu_sim* gpu)
-{
-    m_id = sub_partition_id;
-    m_config=config;
-    m_stats=stats;
-    m_gpu = gpu;
-    m_memcpy_cycle_offset = 0;
-
-    assert(m_id < m_config->m_n_mem_sub_partition); 
-
-    char L2c_name[32];
-    snprintf(L2c_name, 32, "L2_bank_%03d", m_id);
-    m_L2interface = new L2interface(this);
-    m_mf_allocator = new partition_mf_allocator(config);
-
-    if(!m_config->m_L2_config.disabled())
-       m_L2cache = new l2_cache(L2c_name,m_config->m_L2_config,-1,-1,m_L2interface,m_mf_allocator,IN_PARTITION_L2_MISS_QUEUE, gpu);
-
-    unsigned int icnt_L2;
-    unsigned int L2_dram;
-    unsigned int dram_L2;
-    unsigned int L2_icnt;
-    sscanf(m_config->gpgpu_L2_queue_config,"%u:%u:%u:%u", &icnt_L2,&L2_dram,&dram_L2,&L2_icnt );
-    m_icnt_L2_queue = new fifo_pipeline<mem_fetch>("icnt-to-L2",0,icnt_L2); 
-    m_L2_dram_queue = new fifo_pipeline<mem_fetch>("L2-to-dram",0,L2_dram);
-    m_dram_L2_queue = new fifo_pipeline<mem_fetch>("dram-to-L2",0,dram_L2);
-    m_L2_icnt_queue = new fifo_pipeline<mem_fetch>("L2-to-icnt",0,L2_icnt);
-    wb_addr=-1;
-}
-
-memory_sub_partition::~memory_sub_partition()
-{
-    delete m_icnt_L2_queue;
-    delete m_L2_dram_queue;
-    delete m_dram_L2_queue;
-    delete m_L2_icnt_queue;
-    delete m_L2cache;
-    delete m_L2interface;
-}
-
-void memory_sub_partition::cache_cycle( unsigned cycle )
-{
-    // L2 fill responses
-    if( !m_config->m_L2_config.disabled()) {
-       if ( m_L2cache->access_ready() && !m_L2_icnt_queue->full() ) {
-           mem_fetch *mf = m_L2cache->next_access();
-           if(mf->get_access_type() != L2_WR_ALLOC_R){ // Don't pass write allocate read request back to upper level cache
-				mf->set_reply();
-				mf->set_status(IN_PARTITION_L2_TO_ICNT_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-				m_L2_icnt_queue->push(mf);
-           }else{
-        	    if(m_config->m_L2_config.m_write_alloc_policy == FETCH_ON_WRITE)
-        	    {
-        	    	mem_fetch* original_wr_mf = mf->get_original_wr_mf();
-					assert(original_wr_mf);
-					original_wr_mf->set_reply();
-					original_wr_mf->set_status(IN_PARTITION_L2_TO_ICNT_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-					m_L2_icnt_queue->push(original_wr_mf);
-        	    }
-				m_request_tracker.erase(mf);
-				delete mf;
-           }
-       }
-    }
-
-    // DRAM to L2 (texture) and icnt (not texture)
-    if ( !m_dram_L2_queue->empty() ) {
-        mem_fetch *mf = m_dram_L2_queue->top();
-        if ( !m_config->m_L2_config.disabled() && m_L2cache->waiting_for_fill(mf) ) {
-            if (m_L2cache->fill_port_free()) {
-                mf->set_status(IN_PARTITION_L2_FILL_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-                m_L2cache->fill(mf,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle+m_memcpy_cycle_offset);
-                m_dram_L2_queue->pop();
-            }
-        } else if ( !m_L2_icnt_queue->full() ) {
-        	if(mf->is_write() && mf->get_type() == WRITE_ACK)
-            mf->set_status(IN_PARTITION_L2_TO_ICNT_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-            m_L2_icnt_queue->push(mf);
-            m_dram_L2_queue->pop();
-        }
-    }
-
-    // prior L2 misses inserted into m_L2_dram_queue here
-    if( !m_config->m_L2_config.disabled() )
-       m_L2cache->cycle();
-
-    // new L2 texture accesses and/or non-texture accesses
-    if ( !m_L2_dram_queue->full() && !m_icnt_L2_queue->empty() ) {
-        mem_fetch *mf = m_icnt_L2_queue->top();
-        if ( !m_config->m_L2_config.disabled() &&
-              ( (m_config->m_L2_texure_only && mf->istexture()) || (!m_config->m_L2_texure_only) )
-           ) {
-            // L2 is enabled and access is for L2
-            bool output_full = m_L2_icnt_queue->full(); 
-            bool port_free = m_L2cache->data_port_free(); 
-            if ( !output_full && port_free ) {
-                std::list<cache_event> events;
-                enum cache_request_status status = m_L2cache->access(mf->get_addr(),mf,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle+m_memcpy_cycle_offset,events);
-                bool write_sent = was_write_sent(events);
-                bool read_sent = was_read_sent(events);
-                MEM_SUBPART_DPRINTF("Probing L2 cache Address=%llx, status=%u\n", mf->get_addr(), status); 
-
-                if ( status == HIT ) {
-                    if( !write_sent ) {
-                        // L2 cache replies
-                        assert(!read_sent);
-                        if( mf->get_access_type() == L1_WRBK_ACC ) {
-                            m_request_tracker.erase(mf);
-                            delete mf;
-                        } else {
-                            mf->set_reply();
-                            mf->set_status(IN_PARTITION_L2_TO_ICNT_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-                            m_L2_icnt_queue->push(mf);
-                        }
-                        m_icnt_L2_queue->pop();
-                    } else {
-                        assert(write_sent);
-                        m_icnt_L2_queue->pop();
-                    }
-                } else if ( status != RESERVATION_FAIL ) {
-                	if(mf->is_write() && (m_config->m_L2_config.m_write_alloc_policy == FETCH_ON_WRITE || m_config->m_L2_config.m_write_alloc_policy == LAZY_FETCH_ON_READ) && !was_writeallocate_sent(events)) {
-                		mf->set_reply();
-                		mf->set_status(IN_PARTITION_L2_TO_ICNT_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-                		m_L2_icnt_queue->push(mf);
-                	}
-                    // L2 cache accepted request
-                    m_icnt_L2_queue->pop();
-                } else {
-                    assert(!write_sent);
-                    assert(!read_sent);
-                    // L2 cache lock-up: will try again next cycle
-                }
-            }
+      unsigned dest_global_spid = mf_return->get_sub_partition_id();
+      int dest_spid = global_sub_partition_id_to_local_id(dest_global_spid);
+      assert(m_sub_partition[dest_spid]->get_id() == dest_global_spid);
+      if (!m_sub_partition[dest_spid]->dram_L2_queue_full()) {
+        if (mf_return->get_access_type() == L1_WRBK_ACC) {
+          m_sub_partition[dest_spid]->set_done(mf_return);
+          delete mf_return;
         } else {
-            // L2 is disabled or non-texture access to texture-only L2
-            mf->set_status(IN_PARTITION_L2_TO_DRAM_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-            m_L2_dram_queue->push(mf);
-            m_icnt_L2_queue->pop();
+          m_sub_partition[dest_spid]->dram_L2_queue_push(mf_return);
+          mf_return->set_status(
+              IN_PARTITION_DRAM_TO_L2_QUEUE,
+              m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+          m_arbitration_metadata.return_credit(dest_spid);
+          MEMPART_DPRINTF(
+              "mem_fetch request %p return from dram to sub partition %d\n",
+              mf_return, dest_spid);
         }
+        m_dram_latency_queue.pop_front();
+      }
+
+    } else {
+      this->set_done(mf_return);
+      delete mf_return;
+      m_dram_latency_queue.pop_front();
     }
+  }
 
-    // ROP delay queue
-    if( !m_rop.empty() && (cycle >= m_rop.front().ready_cycle) && !m_icnt_L2_queue->full() ) {
-        mem_fetch* mf = m_rop.front().req;
-        m_rop.pop();
-        m_icnt_L2_queue->push(mf);
-        mf->set_status(IN_PARTITION_ICNT_TO_L2_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
+  // mem_fetch *mf = m_sub_partition[spid]->L2_dram_queue_top();
+  // if( !m_dram->full(mf->is_write()) ) {
+  // L2->DRAM queue to DRAM latency queue
+  // Arbitrate among multiple L2 subpartitions
+  int last_issued_partition = m_arbitration_metadata.last_borrower();
+  for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel;
+       p++) {
+    int spid = (p + last_issued_partition + 1) %
+               m_config->m_n_sub_partition_per_memory_channel;
+    if (!m_sub_partition[spid]->L2_dram_queue_empty() &&
+        can_issue_to_dram(spid)) {
+      mem_fetch *mf = m_sub_partition[spid]->L2_dram_queue_top();
+      if (m_dram->full(mf->is_write())) break;
+
+      m_sub_partition[spid]->L2_dram_queue_pop();
+      MEMPART_DPRINTF(
+          "Issue mem_fetch request %p from sub partition %d to dram\n", mf,
+          spid);
+      dram_delay_t d;
+      d.req = mf;
+      d.ready_cycle = m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle +
+                      m_config->dram_latency;
+      m_dram_latency_queue.push_back(d);
+      mf->set_status(IN_PARTITION_DRAM_LATENCY_QUEUE,
+                     m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+      m_arbitration_metadata.borrow_credit(spid);
+      break;  // the DRAM should only accept one request per cycle
     }
+  }
+  //}
 }
 
-bool memory_sub_partition::full() const
-{
-    return m_icnt_L2_queue->full();
+void memory_partition_unit::dram_cycle() {
+  // pop completed memory request from dram and push it to dram-to-L2 queue
+  // of the original sub partition
+  mem_fetch *mf_return = m_dram->return_queue_top();
+  if (mf_return) {
+    unsigned dest_global_spid = mf_return->get_sub_partition_id();
+    int dest_spid = global_sub_partition_id_to_local_id(dest_global_spid);
+    assert(m_sub_partition[dest_spid]->get_id() == dest_global_spid);
+    if (!m_sub_partition[dest_spid]->dram_L2_queue_full()) {
+      if (mf_return->get_access_type() == L1_WRBK_ACC) {
+        m_sub_partition[dest_spid]->set_done(mf_return);
+        delete mf_return;
+      } else {
+        m_sub_partition[dest_spid]->dram_L2_queue_push(mf_return);
+        mf_return->set_status(IN_PARTITION_DRAM_TO_L2_QUEUE,
+                              m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+        m_arbitration_metadata.return_credit(dest_spid);
+        MEMPART_DPRINTF(
+            "mem_fetch request %p return from dram to sub partition %d\n",
+            mf_return, dest_spid);
+      }
+      m_dram->return_queue_pop();
+    }
+  } else {
+    m_dram->return_queue_pop();
+  }
+
+  m_dram->cycle();
+  m_dram->dram_log(SAMPLELOG);
+
+  // mem_fetch *mf = m_sub_partition[spid]->L2_dram_queue_top();
+  // if( !m_dram->full(mf->is_write()) ) {
+  // L2->DRAM queue to DRAM latency queue
+  // Arbitrate among multiple L2 subpartitions
+  int last_issued_partition = m_arbitration_metadata.last_borrower();
+  for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel;
+       p++) {
+    int spid = (p + last_issued_partition + 1) %
+               m_config->m_n_sub_partition_per_memory_channel;
+    if (!m_sub_partition[spid]->L2_dram_queue_empty() &&
+        can_issue_to_dram(spid)) {
+      mem_fetch *mf = m_sub_partition[spid]->L2_dram_queue_top();
+      if (m_dram->full(mf->is_write())) break;
+
+      m_sub_partition[spid]->L2_dram_queue_pop();
+      MEMPART_DPRINTF(
+          "Issue mem_fetch request %p from sub partition %d to dram\n", mf,
+          spid);
+      dram_delay_t d;
+      d.req = mf;
+      d.ready_cycle = m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle +
+                      m_config->dram_latency;
+      m_dram_latency_queue.push_back(d);
+      mf->set_status(IN_PARTITION_DRAM_LATENCY_QUEUE,
+                     m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+      m_arbitration_metadata.borrow_credit(spid);
+      break;  // the DRAM should only accept one request per cycle
+    }
+  }
+  //}
+
+  // DRAM latency queue
+  if (!m_dram_latency_queue.empty() &&
+      ((m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle) >=
+       m_dram_latency_queue.front().ready_cycle) &&
+      !m_dram->full(m_dram_latency_queue.front().req->is_write())) {
+    mem_fetch *mf = m_dram_latency_queue.front().req;
+    m_dram_latency_queue.pop_front();
+    m_dram->push(mf);
+  }
 }
 
-bool memory_sub_partition::full(unsigned size) const
-{
-    return m_icnt_L2_queue->is_avilable_size(size);
+void memory_partition_unit::set_done(mem_fetch *mf) {
+  unsigned global_spid = mf->get_sub_partition_id();
+  int spid = global_sub_partition_id_to_local_id(global_spid);
+  assert(m_sub_partition[spid]->get_id() == global_spid);
+  if (mf->get_access_type() == L1_WRBK_ACC ||
+      mf->get_access_type() == L2_WRBK_ACC) {
+    m_arbitration_metadata.return_credit(spid);
+    MEMPART_DPRINTF(
+        "mem_fetch request %p return from dram to sub partition %d\n", mf,
+        spid);
+  }
+  m_sub_partition[spid]->set_done(mf);
 }
 
-bool memory_sub_partition::L2_dram_queue_empty() const
-{
-   return m_L2_dram_queue->empty(); 
+void memory_partition_unit::set_dram_power_stats(
+    unsigned &n_cmd, unsigned &n_activity, unsigned &n_nop, unsigned &n_act,
+    unsigned &n_pre, unsigned &n_rd, unsigned &n_wr, unsigned &n_req) const {
+  m_dram->set_dram_power_stats(n_cmd, n_activity, n_nop, n_act, n_pre, n_rd,
+                               n_wr, n_req);
 }
 
-class mem_fetch* memory_sub_partition::L2_dram_queue_top() const
-{
-   return m_L2_dram_queue->top(); 
+void memory_partition_unit::print(FILE *fp) const {
+  fprintf(fp, "Memory Partition %u: \n", m_id);
+  for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel;
+       p++) {
+    m_sub_partition[p]->print(fp);
+  }
+  fprintf(fp, "In Dram Latency Queue (total = %zd): \n",
+          m_dram_latency_queue.size());
+  for (std::list<dram_delay_t>::const_iterator mf_dlq =
+           m_dram_latency_queue.begin();
+       mf_dlq != m_dram_latency_queue.end(); ++mf_dlq) {
+    mem_fetch *mf = mf_dlq->req;
+    fprintf(fp, "Ready @ %llu - ", mf_dlq->ready_cycle);
+    if (mf)
+      mf->print(fp);
+    else
+      fprintf(fp, " <NULL mem_fetch?>\n");
+  }
+  m_dram->print(fp);
 }
 
-void memory_sub_partition::L2_dram_queue_pop() 
-{
-   m_L2_dram_queue->pop(); 
+memory_sub_partition::memory_sub_partition(unsigned sub_partition_id,
+                                           const memory_config *config,
+                                           class memory_stats_t *stats,
+                                           class gpgpu_sim *gpu) {
+  m_id = sub_partition_id;
+  m_config = config;
+  m_stats = stats;
+  m_gpu = gpu;
+  m_memcpy_cycle_offset = 0;
+
+  assert(m_id < m_config->m_n_mem_sub_partition);
+
+  char L2c_name[32];
+  snprintf(L2c_name, 32, "L2_bank_%03d", m_id);
+  m_L2interface = new L2interface(this);
+  m_mf_allocator = new partition_mf_allocator(config);
+
+  if (!m_config->m_L2_config.disabled())
+    m_L2cache =
+        new l2_cache(L2c_name, m_config->m_L2_config, -1, -1, m_L2interface,
+                     m_mf_allocator, IN_PARTITION_L2_MISS_QUEUE, gpu);
+
+  unsigned int icnt_L2;
+  unsigned int L2_dram;
+  unsigned int dram_L2;
+  unsigned int L2_icnt;
+  sscanf(m_config->gpgpu_L2_queue_config, "%u:%u:%u:%u", &icnt_L2, &L2_dram,
+         &dram_L2, &L2_icnt);
+  m_icnt_L2_queue = new fifo_pipeline<mem_fetch>("icnt-to-L2", 0, icnt_L2);
+  m_L2_dram_queue = new fifo_pipeline<mem_fetch>("L2-to-dram", 0, L2_dram);
+  m_dram_L2_queue = new fifo_pipeline<mem_fetch>("dram-to-L2", 0, dram_L2);
+  m_L2_icnt_queue = new fifo_pipeline<mem_fetch>("L2-to-icnt", 0, L2_icnt);
+  wb_addr = -1;
 }
 
-bool memory_sub_partition::dram_L2_queue_full() const
-{
-   return m_dram_L2_queue->full(); 
+memory_sub_partition::~memory_sub_partition() {
+  delete m_icnt_L2_queue;
+  delete m_L2_dram_queue;
+  delete m_dram_L2_queue;
+  delete m_L2_icnt_queue;
+  delete m_L2cache;
+  delete m_L2interface;
 }
 
-void memory_sub_partition::dram_L2_queue_push( class mem_fetch* mf )
-{
-   m_dram_L2_queue->push(mf); 
-}
-
-void memory_sub_partition::print_cache_stat(unsigned &accesses, unsigned &misses) const
-{
-    FILE *fp = stdout;
-    if( !m_config->m_L2_config.disabled() )
-       m_L2cache->print(fp,accesses,misses);
-}
-
-void memory_sub_partition::print( FILE *fp ) const
-{
-    if ( !m_request_tracker.empty() ) {
-        fprintf(fp,"Memory Sub Parition %u: pending memory requests:\n", m_id);
-        for ( std::set<mem_fetch*>::const_iterator r=m_request_tracker.begin(); r != m_request_tracker.end(); ++r ) {
-            mem_fetch *mf = *r;
-            if ( mf )
-                mf->print(fp);
-            else
-                fprintf(fp," <NULL mem_fetch?>\n");
+void memory_sub_partition::cache_cycle(unsigned cycle) {
+  // L2 fill responses
+  if (!m_config->m_L2_config.disabled()) {
+    if (m_L2cache->access_ready() && !m_L2_icnt_queue->full()) {
+      mem_fetch *mf = m_L2cache->next_access();
+      if (mf->get_access_type() !=
+          L2_WR_ALLOC_R) {  // Don't pass write allocate read request back to
+                            // upper level cache
+        mf->set_reply();
+        mf->set_status(IN_PARTITION_L2_TO_ICNT_QUEUE,
+                       m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+        m_L2_icnt_queue->push(mf);
+      } else {
+        if (m_config->m_L2_config.m_write_alloc_policy == FETCH_ON_WRITE) {
+          mem_fetch *original_wr_mf = mf->get_original_wr_mf();
+          assert(original_wr_mf);
+          original_wr_mf->set_reply();
+          original_wr_mf->set_status(
+              IN_PARTITION_L2_TO_ICNT_QUEUE,
+              m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+          m_L2_icnt_queue->push(original_wr_mf);
         }
-    }
-    if( !m_config->m_L2_config.disabled() )
-       m_L2cache->display_state(fp);
-}
-
-void memory_stats_t::visualizer_print( gzFile visualizer_file )
-{
-   gzprintf(visualizer_file, "Ltwowritemiss: %d\n", L2_write_miss);
-   gzprintf(visualizer_file, "Ltwowritehit: %d\n",  L2_write_hit);
-   gzprintf(visualizer_file, "Ltworeadmiss: %d\n", L2_read_miss);
-   gzprintf(visualizer_file, "Ltworeadhit: %d\n", L2_read_hit);
-   clear_L2_stats_pw();
-
-   if (num_mfs)
-      gzprintf(visualizer_file, "averagemflatency: %lld\n", mf_total_lat/num_mfs);
-}
-
-void memory_stats_t::clear_L2_stats_pw(){
-    L2_write_miss = 0;
-    L2_write_hit = 0;
-    L2_read_miss = 0;
-    L2_read_hit = 0;
-}
-
-void gpgpu_sim::print_dram_stats(FILE *fout) const
-{
-	unsigned cmd=0;
-	unsigned activity=0;
-	unsigned nop=0;
-	unsigned act=0;
-	unsigned pre=0;
-	unsigned rd=0;
-	unsigned wr=0;
-	unsigned req=0;
-	unsigned tot_cmd=0;
-	unsigned tot_nop=0;
-	unsigned tot_act=0;
-	unsigned tot_pre=0;
-	unsigned tot_rd=0;
-	unsigned tot_wr=0;
-	unsigned tot_req=0;
-
-	for (unsigned i=0;i<m_memory_config->m_n_mem;i++){
-		m_memory_partition_unit[i]->set_dram_power_stats(cmd,activity,nop,act,pre,rd,wr,req);
-		tot_cmd+=cmd;
-		tot_nop+=nop;
-		tot_act+=act;
-		tot_pre+=pre;
-		tot_rd+=rd;
-		tot_wr+=wr;
-		tot_req+=req;
-	}
-    fprintf(fout,"gpgpu_n_dram_reads = %d\n",tot_rd );
-    fprintf(fout,"gpgpu_n_dram_writes = %d\n",tot_wr );
-    fprintf(fout,"gpgpu_n_dram_activate = %d\n",tot_act );
-    fprintf(fout,"gpgpu_n_dram_commands = %d\n",tot_cmd);
-    fprintf(fout,"gpgpu_n_dram_noops = %d\n",tot_nop );
-    fprintf(fout,"gpgpu_n_dram_precharges = %d\n",tot_pre );
-    fprintf(fout,"gpgpu_n_dram_requests = %d\n",tot_req );
-}
-
-unsigned memory_sub_partition::flushL2() 
-{ 
-    if (!m_config->m_L2_config.disabled()) {
-        m_L2cache->flush(); 
-    }
-    return 0;   //TODO: write the flushed data to the main memory
-}
-
-unsigned memory_sub_partition::invalidateL2()
-{
-    if (!m_config->m_L2_config.disabled()) {
-        m_L2cache->invalidate();
-    }
-    return 0;
-}
-
-bool memory_sub_partition::busy() const 
-{
-    return !m_request_tracker.empty();
-}
-
-std::vector<mem_fetch*> memory_sub_partition::breakdown_request_to_sector_requests(mem_fetch* mf)
-{
-	std::vector<mem_fetch*> result;
-
-	if(mf->get_data_size() == SECTOR_SIZE && mf->get_access_sector_mask().count() == 1) {
-		result.push_back(mf);
-	} else if (mf->get_data_size() == 128 || mf->get_data_size() == 64) {
-        //We only accept 32, 64 and 128 bytes reqs
-		unsigned start=0, end=0;
-		if(mf->get_data_size() == 128) {
-			start=0; end=3;
-		} else if (mf->get_data_size() == 64 && mf->get_access_sector_mask().to_string() == "1100") {
-			start=2; end=3;
-		} else if (mf->get_data_size() == 64 && mf->get_access_sector_mask().to_string() == "0011") {
-			start=0; end=1;
-		} else if (mf->get_data_size() == 64 && (mf->get_access_sector_mask().to_string() == "1111" || mf->get_access_sector_mask().to_string() == "0000")) {
-			if(mf->get_addr() % 128 == 0) {
-				start=0; end=1;
-			} else {
-				start=2; end=3;
-			}
-		} else
-			{
-			    printf("Invalid sector received, address = 0x%06llx, sector mask = %s, data size = %d",
-			    		mf->get_addr(), mf->get_access_sector_mask(), mf->get_data_size());
-				assert(0 && "Undefined sector mask is received");
-			}
-
-		std::bitset<SECTOR_SIZE*SECTOR_CHUNCK_SIZE> byte_sector_mask;
-		byte_sector_mask.reset();
-		for(unsigned  k=start*SECTOR_SIZE; k< SECTOR_SIZE; ++k)
-			byte_sector_mask.set(k);
-
-		for(unsigned j=start, i=0; j<= end ; ++j, ++i){
-
-			const mem_access_t *ma = new  mem_access_t( mf->get_access_type(),
-									mf->get_addr() + SECTOR_SIZE*i,
-									SECTOR_SIZE,
-									mf->is_write(),
-									mf->get_access_warp_mask(),
-									mf->get_access_byte_mask() & byte_sector_mask,
-									std::bitset<SECTOR_CHUNCK_SIZE>().set(j),
-									m_gpu->gpgpu_ctx);
-
-			 mem_fetch *n_mf = new mem_fetch( *ma,
-								NULL,
-								mf->get_ctrl_size(),
-								mf->get_wid(),
-								mf->get_sid(),
-								mf->get_tpc(),
-								mf->get_mem_config(),
-								m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle,
-								mf);
-
-			 result.push_back(n_mf);
-			 byte_sector_mask <<= SECTOR_SIZE;
-		}
-	} else {
-		 printf("Invalid sector received, address = 0x%06llx, sector mask = %d, byte mask = , data size = %u",
-					    		mf->get_addr(), mf->get_access_sector_mask().count(), mf->get_data_size());
-		 assert(0 && "Undefined data size is received");
-	}
-
-	return result;
-}
-
-void memory_sub_partition::push( mem_fetch* m_req, unsigned long long cycle )
-{
-    if (m_req) {
-    	m_stats->memlatstat_icnt2mem_pop(m_req);
-    	std::vector<mem_fetch*> reqs;
-    	if(m_config->m_L2_config.m_cache_type == SECTOR)
-    		reqs = breakdown_request_to_sector_requests(m_req);
-    	else
-    		reqs.push_back(m_req);
-
-    	for(unsigned i=0; i<reqs.size(); ++i) {
-    		mem_fetch* req = reqs[i];
-			m_request_tracker.insert(req);
-			if( req->istexture() ) {
-				m_icnt_L2_queue->push(req);
-				req->set_status(IN_PARTITION_ICNT_TO_L2_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-			} else {
-				rop_delay_t r;
-				r.req = req;
-				r.ready_cycle = cycle + m_config->rop_latency;
-				m_rop.push(r);
-				req->set_status(IN_PARTITION_ROP_DELAY,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-			}
-    	}
-    }
-}
-
-mem_fetch* memory_sub_partition::pop() 
-{
-    mem_fetch* mf = m_L2_icnt_queue->pop();
-    m_request_tracker.erase(mf);
-    if ( mf && mf->isatomic() )
-        mf->do_atomic();
-    if( mf && (mf->get_access_type() == L2_WRBK_ACC || mf->get_access_type() == L1_WRBK_ACC) ) {
-        delete mf;
-        mf = NULL;
-    } 
-    return mf;
-}
-
-mem_fetch* memory_sub_partition::top() 
-{
-    mem_fetch *mf = m_L2_icnt_queue->top();
-    if( mf && (mf->get_access_type() == L2_WRBK_ACC || mf->get_access_type() == L1_WRBK_ACC) ) {
-        m_L2_icnt_queue->pop();
         m_request_tracker.erase(mf);
         delete mf;
-        mf = NULL;
-    } 
-    return mf;
+      }
+    }
+  }
+
+  // DRAM to L2 (texture) and icnt (not texture)
+  if (!m_dram_L2_queue->empty()) {
+    mem_fetch *mf = m_dram_L2_queue->top();
+    if (!m_config->m_L2_config.disabled() && m_L2cache->waiting_for_fill(mf)) {
+      if (m_L2cache->fill_port_free()) {
+        mf->set_status(IN_PARTITION_L2_FILL_QUEUE,
+                       m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+        m_L2cache->fill(mf, m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle +
+                                m_memcpy_cycle_offset);
+        m_dram_L2_queue->pop();
+      }
+    } else if (!m_L2_icnt_queue->full()) {
+      if (mf->is_write() && mf->get_type() == WRITE_ACK)
+        mf->set_status(IN_PARTITION_L2_TO_ICNT_QUEUE,
+                       m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+      m_L2_icnt_queue->push(mf);
+      m_dram_L2_queue->pop();
+    }
+  }
+
+  // prior L2 misses inserted into m_L2_dram_queue here
+  if (!m_config->m_L2_config.disabled()) m_L2cache->cycle();
+
+  // new L2 texture accesses and/or non-texture accesses
+  if (!m_L2_dram_queue->full() && !m_icnt_L2_queue->empty()) {
+    mem_fetch *mf = m_icnt_L2_queue->top();
+    if (!m_config->m_L2_config.disabled() &&
+        ((m_config->m_L2_texure_only && mf->istexture()) ||
+         (!m_config->m_L2_texure_only))) {
+      // L2 is enabled and access is for L2
+      bool output_full = m_L2_icnt_queue->full();
+      bool port_free = m_L2cache->data_port_free();
+      if (!output_full && port_free) {
+        std::list<cache_event> events;
+        enum cache_request_status status =
+            m_L2cache->access(mf->get_addr(), mf,
+                              m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle +
+                                  m_memcpy_cycle_offset,
+                              events);
+        bool write_sent = was_write_sent(events);
+        bool read_sent = was_read_sent(events);
+        MEM_SUBPART_DPRINTF("Probing L2 cache Address=%llx, status=%u\n",
+                            mf->get_addr(), status);
+
+        if (status == HIT) {
+          if (!write_sent) {
+            // L2 cache replies
+            assert(!read_sent);
+            if (mf->get_access_type() == L1_WRBK_ACC) {
+              m_request_tracker.erase(mf);
+              delete mf;
+            } else {
+              mf->set_reply();
+              mf->set_status(IN_PARTITION_L2_TO_ICNT_QUEUE,
+                             m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+              m_L2_icnt_queue->push(mf);
+            }
+            m_icnt_L2_queue->pop();
+          } else {
+            assert(write_sent);
+            m_icnt_L2_queue->pop();
+          }
+        } else if (status != RESERVATION_FAIL) {
+          if (mf->is_write() &&
+              (m_config->m_L2_config.m_write_alloc_policy == FETCH_ON_WRITE ||
+               m_config->m_L2_config.m_write_alloc_policy ==
+                   LAZY_FETCH_ON_READ) &&
+              !was_writeallocate_sent(events)) {
+            mf->set_reply();
+            mf->set_status(IN_PARTITION_L2_TO_ICNT_QUEUE,
+                           m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+            m_L2_icnt_queue->push(mf);
+          }
+          // L2 cache accepted request
+          m_icnt_L2_queue->pop();
+        } else {
+          assert(!write_sent);
+          assert(!read_sent);
+          // L2 cache lock-up: will try again next cycle
+        }
+      }
+    } else {
+      // L2 is disabled or non-texture access to texture-only L2
+      mf->set_status(IN_PARTITION_L2_TO_DRAM_QUEUE,
+                     m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+      m_L2_dram_queue->push(mf);
+      m_icnt_L2_queue->pop();
+    }
+  }
+
+  // ROP delay queue
+  if (!m_rop.empty() && (cycle >= m_rop.front().ready_cycle) &&
+      !m_icnt_L2_queue->full()) {
+    mem_fetch *mf = m_rop.front().req;
+    m_rop.pop();
+    m_icnt_L2_queue->push(mf);
+    mf->set_status(IN_PARTITION_ICNT_TO_L2_QUEUE,
+                   m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+  }
 }
 
-void memory_sub_partition::set_done( mem_fetch *mf )
-{
+bool memory_sub_partition::full() const { return m_icnt_L2_queue->full(); }
+
+bool memory_sub_partition::full(unsigned size) const {
+  return m_icnt_L2_queue->is_avilable_size(size);
+}
+
+bool memory_sub_partition::L2_dram_queue_empty() const {
+  return m_L2_dram_queue->empty();
+}
+
+class mem_fetch *memory_sub_partition::L2_dram_queue_top() const {
+  return m_L2_dram_queue->top();
+}
+
+void memory_sub_partition::L2_dram_queue_pop() { m_L2_dram_queue->pop(); }
+
+bool memory_sub_partition::dram_L2_queue_full() const {
+  return m_dram_L2_queue->full();
+}
+
+void memory_sub_partition::dram_L2_queue_push(class mem_fetch *mf) {
+  m_dram_L2_queue->push(mf);
+}
+
+void memory_sub_partition::print_cache_stat(unsigned &accesses,
+                                            unsigned &misses) const {
+  FILE *fp = stdout;
+  if (!m_config->m_L2_config.disabled()) m_L2cache->print(fp, accesses, misses);
+}
+
+void memory_sub_partition::print(FILE *fp) const {
+  if (!m_request_tracker.empty()) {
+    fprintf(fp, "Memory Sub Parition %u: pending memory requests:\n", m_id);
+    for (std::set<mem_fetch *>::const_iterator r = m_request_tracker.begin();
+         r != m_request_tracker.end(); ++r) {
+      mem_fetch *mf = *r;
+      if (mf)
+        mf->print(fp);
+      else
+        fprintf(fp, " <NULL mem_fetch?>\n");
+    }
+  }
+  if (!m_config->m_L2_config.disabled()) m_L2cache->display_state(fp);
+}
+
+void memory_stats_t::visualizer_print(gzFile visualizer_file) {
+  gzprintf(visualizer_file, "Ltwowritemiss: %d\n", L2_write_miss);
+  gzprintf(visualizer_file, "Ltwowritehit: %d\n", L2_write_hit);
+  gzprintf(visualizer_file, "Ltworeadmiss: %d\n", L2_read_miss);
+  gzprintf(visualizer_file, "Ltworeadhit: %d\n", L2_read_hit);
+  clear_L2_stats_pw();
+
+  if (num_mfs)
+    gzprintf(visualizer_file, "averagemflatency: %lld\n",
+             mf_total_lat / num_mfs);
+}
+
+void memory_stats_t::clear_L2_stats_pw() {
+  L2_write_miss = 0;
+  L2_write_hit = 0;
+  L2_read_miss = 0;
+  L2_read_hit = 0;
+}
+
+void gpgpu_sim::print_dram_stats(FILE *fout) const {
+  unsigned cmd = 0;
+  unsigned activity = 0;
+  unsigned nop = 0;
+  unsigned act = 0;
+  unsigned pre = 0;
+  unsigned rd = 0;
+  unsigned wr = 0;
+  unsigned req = 0;
+  unsigned tot_cmd = 0;
+  unsigned tot_nop = 0;
+  unsigned tot_act = 0;
+  unsigned tot_pre = 0;
+  unsigned tot_rd = 0;
+  unsigned tot_wr = 0;
+  unsigned tot_req = 0;
+
+  for (unsigned i = 0; i < m_memory_config->m_n_mem; i++) {
+    m_memory_partition_unit[i]->set_dram_power_stats(cmd, activity, nop, act,
+                                                     pre, rd, wr, req);
+    tot_cmd += cmd;
+    tot_nop += nop;
+    tot_act += act;
+    tot_pre += pre;
+    tot_rd += rd;
+    tot_wr += wr;
+    tot_req += req;
+  }
+  fprintf(fout, "gpgpu_n_dram_reads = %d\n", tot_rd);
+  fprintf(fout, "gpgpu_n_dram_writes = %d\n", tot_wr);
+  fprintf(fout, "gpgpu_n_dram_activate = %d\n", tot_act);
+  fprintf(fout, "gpgpu_n_dram_commands = %d\n", tot_cmd);
+  fprintf(fout, "gpgpu_n_dram_noops = %d\n", tot_nop);
+  fprintf(fout, "gpgpu_n_dram_precharges = %d\n", tot_pre);
+  fprintf(fout, "gpgpu_n_dram_requests = %d\n", tot_req);
+}
+
+unsigned memory_sub_partition::flushL2() {
+  if (!m_config->m_L2_config.disabled()) {
+    m_L2cache->flush();
+  }
+  return 0;  // TODO: write the flushed data to the main memory
+}
+
+unsigned memory_sub_partition::invalidateL2() {
+  if (!m_config->m_L2_config.disabled()) {
+    m_L2cache->invalidate();
+  }
+  return 0;
+}
+
+bool memory_sub_partition::busy() const { return !m_request_tracker.empty(); }
+
+std::vector<mem_fetch *>
+memory_sub_partition::breakdown_request_to_sector_requests(mem_fetch *mf) {
+  std::vector<mem_fetch *> result;
+
+  if (mf->get_data_size() == SECTOR_SIZE &&
+      mf->get_access_sector_mask().count() == 1) {
+    result.push_back(mf);
+  } else if (mf->get_data_size() == 128 || mf->get_data_size() == 64) {
+    // We only accept 32, 64 and 128 bytes reqs
+    unsigned start = 0, end = 0;
+    if (mf->get_data_size() == 128) {
+      start = 0;
+      end = 3;
+    } else if (mf->get_data_size() == 64 &&
+               mf->get_access_sector_mask().to_string() == "1100") {
+      start = 2;
+      end = 3;
+    } else if (mf->get_data_size() == 64 &&
+               mf->get_access_sector_mask().to_string() == "0011") {
+      start = 0;
+      end = 1;
+    } else if (mf->get_data_size() == 64 &&
+               (mf->get_access_sector_mask().to_string() == "1111" ||
+                mf->get_access_sector_mask().to_string() == "0000")) {
+      if (mf->get_addr() % 128 == 0) {
+        start = 0;
+        end = 1;
+      } else {
+        start = 2;
+        end = 3;
+      }
+    } else {
+      printf(
+          "Invalid sector received, address = 0x%06llx, sector mask = %s, data "
+          "size = %d",
+          mf->get_addr(), mf->get_access_sector_mask(), mf->get_data_size());
+      assert(0 && "Undefined sector mask is received");
+    }
+
+    std::bitset<SECTOR_SIZE * SECTOR_CHUNCK_SIZE> byte_sector_mask;
+    byte_sector_mask.reset();
+    for (unsigned k = start * SECTOR_SIZE; k < SECTOR_SIZE; ++k)
+      byte_sector_mask.set(k);
+
+    for (unsigned j = start, i = 0; j <= end; ++j, ++i) {
+      const mem_access_t *ma = new mem_access_t(
+          mf->get_access_type(), mf->get_addr() + SECTOR_SIZE * i, SECTOR_SIZE,
+          mf->is_write(), mf->get_access_warp_mask(),
+          mf->get_access_byte_mask() & byte_sector_mask,
+          std::bitset<SECTOR_CHUNCK_SIZE>().set(j), m_gpu->gpgpu_ctx);
+
+      mem_fetch *n_mf =
+          new mem_fetch(*ma, NULL, mf->get_ctrl_size(), mf->get_wid(),
+                        mf->get_sid(), mf->get_tpc(), mf->get_mem_config(),
+                        m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle, mf);
+
+      result.push_back(n_mf);
+      byte_sector_mask <<= SECTOR_SIZE;
+    }
+  } else {
+    printf(
+        "Invalid sector received, address = 0x%06llx, sector mask = %d, byte "
+        "mask = , data size = %u",
+        mf->get_addr(), mf->get_access_sector_mask().count(),
+        mf->get_data_size());
+    assert(0 && "Undefined data size is received");
+  }
+
+  return result;
+}
+
+void memory_sub_partition::push(mem_fetch *m_req, unsigned long long cycle) {
+  if (m_req) {
+    m_stats->memlatstat_icnt2mem_pop(m_req);
+    std::vector<mem_fetch *> reqs;
+    if (m_config->m_L2_config.m_cache_type == SECTOR)
+      reqs = breakdown_request_to_sector_requests(m_req);
+    else
+      reqs.push_back(m_req);
+
+    for (unsigned i = 0; i < reqs.size(); ++i) {
+      mem_fetch *req = reqs[i];
+      m_request_tracker.insert(req);
+      if (req->istexture()) {
+        m_icnt_L2_queue->push(req);
+        req->set_status(IN_PARTITION_ICNT_TO_L2_QUEUE,
+                        m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+      } else {
+        rop_delay_t r;
+        r.req = req;
+        r.ready_cycle = cycle + m_config->rop_latency;
+        m_rop.push(r);
+        req->set_status(IN_PARTITION_ROP_DELAY,
+                        m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+      }
+    }
+  }
+}
+
+mem_fetch *memory_sub_partition::pop() {
+  mem_fetch *mf = m_L2_icnt_queue->pop();
+  m_request_tracker.erase(mf);
+  if (mf && mf->isatomic()) mf->do_atomic();
+  if (mf && (mf->get_access_type() == L2_WRBK_ACC ||
+             mf->get_access_type() == L1_WRBK_ACC)) {
+    delete mf;
+    mf = NULL;
+  }
+  return mf;
+}
+
+mem_fetch *memory_sub_partition::top() {
+  mem_fetch *mf = m_L2_icnt_queue->top();
+  if (mf && (mf->get_access_type() == L2_WRBK_ACC ||
+             mf->get_access_type() == L1_WRBK_ACC)) {
+    m_L2_icnt_queue->pop();
     m_request_tracker.erase(mf);
+    delete mf;
+    mf = NULL;
+  }
+  return mf;
 }
 
-void memory_sub_partition::accumulate_L2cache_stats(class cache_stats &l2_stats) const {
-    if (!m_config->m_L2_config.disabled()) {
-        l2_stats += m_L2cache->get_stats();
-    }
+void memory_sub_partition::set_done(mem_fetch *mf) {
+  m_request_tracker.erase(mf);
 }
 
-void memory_sub_partition::get_L2cache_sub_stats(struct cache_sub_stats &css) const{
-    if (!m_config->m_L2_config.disabled()) {
-        m_L2cache->get_sub_stats(css);
-    }
+void memory_sub_partition::accumulate_L2cache_stats(
+    class cache_stats &l2_stats) const {
+  if (!m_config->m_L2_config.disabled()) {
+    l2_stats += m_L2cache->get_stats();
+  }
 }
 
-void memory_sub_partition::get_L2cache_sub_stats_pw(struct cache_sub_stats_pw &css) const{
-    if (!m_config->m_L2_config.disabled()) {
-        m_L2cache->get_sub_stats_pw(css);
-    }
+void memory_sub_partition::get_L2cache_sub_stats(
+    struct cache_sub_stats &css) const {
+  if (!m_config->m_L2_config.disabled()) {
+    m_L2cache->get_sub_stats(css);
+  }
+}
+
+void memory_sub_partition::get_L2cache_sub_stats_pw(
+    struct cache_sub_stats_pw &css) const {
+  if (!m_config->m_L2_config.disabled()) {
+    m_L2cache->get_sub_stats_pw(css);
+  }
 }
 
 void memory_sub_partition::clear_L2cache_stats_pw() {
-    if (!m_config->m_L2_config.disabled()) {
-        m_L2cache->clear_pw();
-    }
+  if (!m_config->m_L2_config.disabled()) {
+    m_L2cache->clear_pw();
+  }
 }
 
-void memory_sub_partition::visualizer_print( gzFile visualizer_file )
-{
-    // Support for L2 AerialVision stats
-    // Per-sub-partition stats would be trivial to extend from this
-    cache_sub_stats_pw temp_sub_stats;
-    get_L2cache_sub_stats_pw(temp_sub_stats);
+void memory_sub_partition::visualizer_print(gzFile visualizer_file) {
+  // Support for L2 AerialVision stats
+  // Per-sub-partition stats would be trivial to extend from this
+  cache_sub_stats_pw temp_sub_stats;
+  get_L2cache_sub_stats_pw(temp_sub_stats);
 
-    m_stats->L2_read_miss += temp_sub_stats.read_misses;
-    m_stats->L2_write_miss += temp_sub_stats.write_misses;
-    m_stats->L2_read_hit += temp_sub_stats.read_hits;
-    m_stats->L2_write_hit += temp_sub_stats.write_hits;
+  m_stats->L2_read_miss += temp_sub_stats.read_misses;
+  m_stats->L2_write_miss += temp_sub_stats.write_misses;
+  m_stats->L2_read_hit += temp_sub_stats.read_hits;
+  m_stats->L2_write_hit += temp_sub_stats.write_hits;
 
-    clear_L2cache_stats_pw();
+  clear_L2cache_stats_pw();
 }

--- a/src/gpgpu-sim/l2cache.cc
+++ b/src/gpgpu-sim/l2cache.cc
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -27,835 +25,797 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <stdio.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 
 #include <list>
 #include <set>
 
-#include "../abstract_hardware_model.h"
 #include "../option_parser.h"
-#include "../statwrapper.h"
+#include "mem_fetch.h"
 #include "dram.h"
 #include "gpu-cache.h"
-#include "gpu-sim.h"
 #include "histogram.h"
 #include "l2cache.h"
-#include "l2cache_trace.h"
-#include "mem_fetch.h"
-#include "mem_latency_stat.h"
+#include "../statwrapper.h"
+#include "../abstract_hardware_model.h"
+#include "gpu-sim.h"
 #include "shader.h"
+#include "mem_latency_stat.h"
+#include "l2cache_trace.h"
 
-mem_fetch *partition_mf_allocator::alloc(new_addr_type addr,
-                                         mem_access_type type, unsigned size,
-                                         bool wr,
-                                         unsigned long long cycle) const {
-  assert(wr);
-  mem_access_t access(type, addr, size, wr, m_memory_config->gpgpu_ctx);
-  mem_fetch *mf = new mem_fetch(access, NULL, WRITE_PACKET_SIZE, -1, -1, -1,
-                                m_memory_config, cycle);
-  return mf;
+
+mem_fetch * partition_mf_allocator::alloc(new_addr_type addr, mem_access_type type, unsigned size, bool wr, unsigned long long cycle ) const
+{
+    assert( wr );
+    mem_access_t access( type, addr, size, wr, m_memory_config->gpgpu_ctx );
+    mem_fetch *mf = new mem_fetch( access, 
+                                   NULL,
+                                   WRITE_PACKET_SIZE, 
+                                   -1, 
+                                   -1, 
+                                   -1,
+                                   m_memory_config,
+								   cycle);
+    return mf;
 }
 
-memory_partition_unit::memory_partition_unit(unsigned partition_id,
-                                             const memory_config *config,
-                                             class memory_stats_t *stats,
-                                             class gpgpu_sim *gpu)
-    : m_id(partition_id),
-      m_config(config),
-      m_stats(stats),
-      m_arbitration_metadata(config),
-      m_gpu(gpu) {
-  m_dram = new dram_t(m_id, m_config, m_stats, this, gpu);
+memory_partition_unit::memory_partition_unit( unsigned partition_id, 
+                                              const memory_config *config,
+                                              class memory_stats_t *stats,
+											  class gpgpu_sim* gpu)
+: m_id(partition_id), m_config(config), m_stats(stats), m_arbitration_metadata(config), m_gpu(gpu)
+{
+    m_dram = new dram_t(m_id,m_config,m_stats,this,gpu);
 
-  m_sub_partition = new memory_sub_partition
-      *[m_config->m_n_sub_partition_per_memory_channel];
-  for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel;
-       p++) {
-    unsigned sub_partition_id =
-        m_id * m_config->m_n_sub_partition_per_memory_channel + p;
-    m_sub_partition[p] =
-        new memory_sub_partition(sub_partition_id, m_config, stats, gpu);
-  }
-}
-
-void memory_partition_unit::handle_memcpy_to_gpu(
-    size_t addr, unsigned global_subpart_id, mem_access_sector_mask_t mask) {
-  unsigned p = global_sub_partition_id_to_local_id(global_subpart_id);
-  std::string mystring = mask.to_string<char, std::string::traits_type,
-                                        std::string::allocator_type>();
-  MEMPART_DPRINTF(
-      "Copy Engine Request Received For Address=%zx, local_subpart=%u, "
-      "global_subpart=%u, sector_mask=%s \n",
-      addr, p, global_subpart_id, mystring.c_str());
-  m_sub_partition[p]->force_l2_tag_update(
-      addr, m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle, mask);
-}
-
-memory_partition_unit::~memory_partition_unit() {
-  delete m_dram;
-  for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel;
-       p++) {
-    delete m_sub_partition[p];
-  }
-  delete[] m_sub_partition;
-}
-
-memory_partition_unit::arbitration_metadata::arbitration_metadata(
-    const memory_config *config)
-    : m_last_borrower(config->m_n_sub_partition_per_memory_channel - 1),
-      m_private_credit(config->m_n_sub_partition_per_memory_channel, 0),
-      m_shared_credit(0) {
-  // each sub partition get at least 1 credit for forward progress
-  // the rest is shared among with other partitions
-  m_private_credit_limit = 1;
-  m_shared_credit_limit = config->gpgpu_frfcfs_dram_sched_queue_size +
-                          config->gpgpu_dram_return_queue_size -
-                          (config->m_n_sub_partition_per_memory_channel - 1);
-  if (config->seperate_write_queue_enabled)
-    m_shared_credit_limit += config->gpgpu_frfcfs_dram_write_queue_size;
-  if (config->gpgpu_frfcfs_dram_sched_queue_size == 0 or
-      config->gpgpu_dram_return_queue_size == 0) {
-    m_shared_credit_limit =
-        0;  // no limit if either of the queue has no limit in size
-  }
-  assert(m_shared_credit_limit >= 0);
-}
-
-bool memory_partition_unit::arbitration_metadata::has_credits(
-    int inner_sub_partition_id) const {
-  int spid = inner_sub_partition_id;
-  if (m_private_credit[spid] < m_private_credit_limit) {
-    return true;
-  } else if (m_shared_credit_limit == 0 ||
-             m_shared_credit < m_shared_credit_limit) {
-    return true;
-  } else {
-    return false;
-  }
-}
-
-void memory_partition_unit::arbitration_metadata::borrow_credit(
-    int inner_sub_partition_id) {
-  int spid = inner_sub_partition_id;
-  if (m_private_credit[spid] < m_private_credit_limit) {
-    m_private_credit[spid] += 1;
-  } else if (m_shared_credit_limit == 0 ||
-             m_shared_credit < m_shared_credit_limit) {
-    m_shared_credit += 1;
-  } else {
-    assert(0 && "DRAM arbitration error: Borrowing from depleted credit!");
-  }
-  m_last_borrower = spid;
-}
-
-void memory_partition_unit::arbitration_metadata::return_credit(
-    int inner_sub_partition_id) {
-  int spid = inner_sub_partition_id;
-  if (m_private_credit[spid] > 0) {
-    m_private_credit[spid] -= 1;
-  } else {
-    m_shared_credit -= 1;
-  }
-  assert((m_shared_credit >= 0) &&
-         "DRAM arbitration error: Returning more than available credits!");
-}
-
-void memory_partition_unit::arbitration_metadata::print(FILE *fp) const {
-  fprintf(fp, "private_credit = ");
-  for (unsigned p = 0; p < m_private_credit.size(); p++) {
-    fprintf(fp, "%d ", m_private_credit[p]);
-  }
-  fprintf(fp, "(limit = %d)\n", m_private_credit_limit);
-  fprintf(fp, "shared_credit = %d (limit = %d)\n", m_shared_credit,
-          m_shared_credit_limit);
-}
-
-bool memory_partition_unit::busy() const {
-  bool busy = false;
-  for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel;
-       p++) {
-    if (m_sub_partition[p]->busy()) {
-      busy = true;
+    m_sub_partition = new memory_sub_partition*[m_config->m_n_sub_partition_per_memory_channel]; 
+    for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel; p++) {
+        unsigned sub_partition_id = m_id * m_config->m_n_sub_partition_per_memory_channel + p; 
+        m_sub_partition[p] = new memory_sub_partition(sub_partition_id, m_config, stats, gpu);
     }
-  }
-  return busy;
+
 }
 
-void memory_partition_unit::cache_cycle(unsigned cycle) {
-  for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel;
-       p++) {
-    m_sub_partition[p]->cache_cycle(cycle);
-  }
+void memory_partition_unit::handle_memcpy_to_gpu( size_t addr, unsigned global_subpart_id, mem_access_sector_mask_t mask )
+{
+    unsigned p = global_sub_partition_id_to_local_id(global_subpart_id);
+    std::string mystring =
+        mask.to_string<char,std::string::traits_type,std::string::allocator_type>();
+    MEMPART_DPRINTF("Copy Engine Request Received For Address=%zx, local_subpart=%u, global_subpart=%u, sector_mask=%s \n", addr, p, global_subpart_id, mystring.c_str()); 
+    m_sub_partition[p]->force_l2_tag_update(addr,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle, mask);
 }
 
-void memory_partition_unit::visualizer_print(gzFile visualizer_file) const {
-  m_dram->visualizer_print(visualizer_file);
-  for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel;
-       p++) {
-    m_sub_partition[p]->visualizer_print(visualizer_file);
-  }
+memory_partition_unit::~memory_partition_unit() 
+{
+    delete m_dram; 
+    for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel; p++) {
+        delete m_sub_partition[p]; 
+    } 
+    delete[] m_sub_partition; 
 }
 
-// determine whether a given subpartition can issue to DRAM
-bool memory_partition_unit::can_issue_to_dram(int inner_sub_partition_id) {
-  int spid = inner_sub_partition_id;
-  bool sub_partition_contention = m_sub_partition[spid]->dram_L2_queue_full();
-  bool has_dram_resource = m_arbitration_metadata.has_credits(spid);
-
-  MEMPART_DPRINTF(
-      "sub partition %d sub_partition_contention=%c has_dram_resource=%c\n",
-      spid, (sub_partition_contention) ? 'T' : 'F',
-      (has_dram_resource) ? 'T' : 'F');
-
-  return (has_dram_resource && !sub_partition_contention);
+memory_partition_unit::arbitration_metadata::arbitration_metadata(const memory_config *config)
+: m_last_borrower(config->m_n_sub_partition_per_memory_channel - 1), 
+  m_private_credit(config->m_n_sub_partition_per_memory_channel, 0), 
+  m_shared_credit(0) 
+{
+    // each sub partition get at least 1 credit for forward progress 
+    // the rest is shared among with other partitions 
+    m_private_credit_limit = 1; 
+    m_shared_credit_limit = config->gpgpu_frfcfs_dram_sched_queue_size 
+                            + config->gpgpu_dram_return_queue_size 
+                            - (config->m_n_sub_partition_per_memory_channel - 1);
+    if(config->seperate_write_queue_enabled )
+    	m_shared_credit_limit += config->gpgpu_frfcfs_dram_write_queue_size;
+    if (config->gpgpu_frfcfs_dram_sched_queue_size == 0 
+        or config->gpgpu_dram_return_queue_size == 0) 
+    {
+        m_shared_credit_limit = 0; // no limit if either of the queue has no limit in size 
+    }
+    assert(m_shared_credit_limit >= 0); 
 }
 
-int memory_partition_unit::global_sub_partition_id_to_local_id(
-    int global_sub_partition_id) const {
-  return (global_sub_partition_id -
-          m_id * m_config->m_n_sub_partition_per_memory_channel);
-}
-
-void memory_partition_unit::simple_dram_model_cycle() {
-  // pop completed memory request from dram and push it to dram-to-L2 queue
-  // of the original sub partition
-  if (!m_dram_latency_queue.empty() &&
-      ((m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle) >=
-       m_dram_latency_queue.front().ready_cycle)) {
-    mem_fetch *mf_return = m_dram_latency_queue.front().req;
-    if (mf_return->get_access_type() != L1_WRBK_ACC &&
-        mf_return->get_access_type() != L2_WRBK_ACC) {
-      mf_return->set_reply();
-
-      unsigned dest_global_spid = mf_return->get_sub_partition_id();
-      int dest_spid = global_sub_partition_id_to_local_id(dest_global_spid);
-      assert(m_sub_partition[dest_spid]->get_id() == dest_global_spid);
-      if (!m_sub_partition[dest_spid]->dram_L2_queue_full()) {
-        if (mf_return->get_access_type() == L1_WRBK_ACC) {
-          m_sub_partition[dest_spid]->set_done(mf_return);
-          delete mf_return;
-        } else {
-          m_sub_partition[dest_spid]->dram_L2_queue_push(mf_return);
-          mf_return->set_status(
-              IN_PARTITION_DRAM_TO_L2_QUEUE,
-              m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-          m_arbitration_metadata.return_credit(dest_spid);
-          MEMPART_DPRINTF(
-              "mem_fetch request %p return from dram to sub partition %d\n",
-              mf_return, dest_spid);
-        }
-        m_dram_latency_queue.pop_front();
-      }
-
+bool memory_partition_unit::arbitration_metadata::has_credits(int inner_sub_partition_id) const 
+{
+    int spid = inner_sub_partition_id; 
+    if (m_private_credit[spid] < m_private_credit_limit) {
+        return true; 
+    } else if (m_shared_credit_limit == 0 || m_shared_credit < m_shared_credit_limit) {
+        return true; 
     } else {
-      this->set_done(mf_return);
-      delete mf_return;
-      m_dram_latency_queue.pop_front();
+        return false; 
     }
-  }
+}
 
-  // mem_fetch *mf = m_sub_partition[spid]->L2_dram_queue_top();
-  // if( !m_dram->full(mf->is_write()) ) {
-  // L2->DRAM queue to DRAM latency queue
-  // Arbitrate among multiple L2 subpartitions
-  int last_issued_partition = m_arbitration_metadata.last_borrower();
-  for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel;
-       p++) {
-    int spid = (p + last_issued_partition + 1) %
-               m_config->m_n_sub_partition_per_memory_channel;
-    if (!m_sub_partition[spid]->L2_dram_queue_empty() &&
-        can_issue_to_dram(spid)) {
-      mem_fetch *mf = m_sub_partition[spid]->L2_dram_queue_top();
-      if (m_dram->full(mf->is_write())) break;
-
-      m_sub_partition[spid]->L2_dram_queue_pop();
-      MEMPART_DPRINTF(
-          "Issue mem_fetch request %p from sub partition %d to dram\n", mf,
-          spid);
-      dram_delay_t d;
-      d.req = mf;
-      d.ready_cycle = m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle +
-                      m_config->dram_latency;
-      m_dram_latency_queue.push_back(d);
-      mf->set_status(IN_PARTITION_DRAM_LATENCY_QUEUE,
-                     m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-      m_arbitration_metadata.borrow_credit(spid);
-      break;  // the DRAM should only accept one request per cycle
+void memory_partition_unit::arbitration_metadata::borrow_credit(int inner_sub_partition_id) 
+{
+    int spid = inner_sub_partition_id; 
+    if (m_private_credit[spid] < m_private_credit_limit) {
+        m_private_credit[spid] += 1; 
+    } else if (m_shared_credit_limit == 0 || m_shared_credit < m_shared_credit_limit) {
+        m_shared_credit += 1; 
+    } else {
+        assert(0 && "DRAM arbitration error: Borrowing from depleted credit!"); 
     }
-  }
-  //}
+    m_last_borrower = spid; 
 }
 
-void memory_partition_unit::dram_cycle() {
-  // pop completed memory request from dram and push it to dram-to-L2 queue
-  // of the original sub partition
-  mem_fetch *mf_return = m_dram->return_queue_top();
-  if (mf_return) {
-    unsigned dest_global_spid = mf_return->get_sub_partition_id();
-    int dest_spid = global_sub_partition_id_to_local_id(dest_global_spid);
-    assert(m_sub_partition[dest_spid]->get_id() == dest_global_spid);
-    if (!m_sub_partition[dest_spid]->dram_L2_queue_full()) {
-      if (mf_return->get_access_type() == L1_WRBK_ACC) {
-        m_sub_partition[dest_spid]->set_done(mf_return);
-        delete mf_return;
-      } else {
-        m_sub_partition[dest_spid]->dram_L2_queue_push(mf_return);
-        mf_return->set_status(IN_PARTITION_DRAM_TO_L2_QUEUE,
-                              m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-        m_arbitration_metadata.return_credit(dest_spid);
-        MEMPART_DPRINTF(
-            "mem_fetch request %p return from dram to sub partition %d\n",
-            mf_return, dest_spid);
-      }
-      m_dram->return_queue_pop();
+void memory_partition_unit::arbitration_metadata::return_credit(int inner_sub_partition_id) 
+{
+    int spid = inner_sub_partition_id; 
+    if (m_private_credit[spid] > 0) {
+        m_private_credit[spid] -= 1; 
+    } else {
+        m_shared_credit -= 1; 
+    } 
+    assert((m_shared_credit >= 0) && "DRAM arbitration error: Returning more than available credits!"); 
+}
+
+void memory_partition_unit::arbitration_metadata::print( FILE *fp ) const 
+{
+    fprintf(fp, "private_credit = "); 
+    for (unsigned p = 0; p < m_private_credit.size(); p++) {
+        fprintf(fp, "%d ", m_private_credit[p]); 
     }
-  } else {
-    m_dram->return_queue_pop();
-  }
-
-  m_dram->cycle();
-  m_dram->dram_log(SAMPLELOG);
-
-  // mem_fetch *mf = m_sub_partition[spid]->L2_dram_queue_top();
-  // if( !m_dram->full(mf->is_write()) ) {
-  // L2->DRAM queue to DRAM latency queue
-  // Arbitrate among multiple L2 subpartitions
-  int last_issued_partition = m_arbitration_metadata.last_borrower();
-  for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel;
-       p++) {
-    int spid = (p + last_issued_partition + 1) %
-               m_config->m_n_sub_partition_per_memory_channel;
-    if (!m_sub_partition[spid]->L2_dram_queue_empty() &&
-        can_issue_to_dram(spid)) {
-      mem_fetch *mf = m_sub_partition[spid]->L2_dram_queue_top();
-      if (m_dram->full(mf->is_write())) break;
-
-      m_sub_partition[spid]->L2_dram_queue_pop();
-      MEMPART_DPRINTF(
-          "Issue mem_fetch request %p from sub partition %d to dram\n", mf,
-          spid);
-      dram_delay_t d;
-      d.req = mf;
-      d.ready_cycle = m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle +
-                      m_config->dram_latency;
-      m_dram_latency_queue.push_back(d);
-      mf->set_status(IN_PARTITION_DRAM_LATENCY_QUEUE,
-                     m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-      m_arbitration_metadata.borrow_credit(spid);
-      break;  // the DRAM should only accept one request per cycle
-    }
-  }
-  //}
-
-  // DRAM latency queue
-  if (!m_dram_latency_queue.empty() &&
-      ((m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle) >=
-       m_dram_latency_queue.front().ready_cycle) &&
-      !m_dram->full(m_dram_latency_queue.front().req->is_write())) {
-    mem_fetch *mf = m_dram_latency_queue.front().req;
-    m_dram_latency_queue.pop_front();
-    m_dram->push(mf);
-  }
+    fprintf(fp, "(limit = %d)\n", m_private_credit_limit); 
+    fprintf(fp, "shared_credit = %d (limit = %d)\n", m_shared_credit, m_shared_credit_limit); 
 }
 
-void memory_partition_unit::set_done(mem_fetch *mf) {
-  unsigned global_spid = mf->get_sub_partition_id();
-  int spid = global_sub_partition_id_to_local_id(global_spid);
-  assert(m_sub_partition[spid]->get_id() == global_spid);
-  if (mf->get_access_type() == L1_WRBK_ACC ||
-      mf->get_access_type() == L2_WRBK_ACC) {
-    m_arbitration_metadata.return_credit(spid);
-    MEMPART_DPRINTF(
-        "mem_fetch request %p return from dram to sub partition %d\n", mf,
-        spid);
-  }
-  m_sub_partition[spid]->set_done(mf);
-}
-
-void memory_partition_unit::set_dram_power_stats(
-    unsigned &n_cmd, unsigned &n_activity, unsigned &n_nop, unsigned &n_act,
-    unsigned &n_pre, unsigned &n_rd, unsigned &n_wr, unsigned &n_req) const {
-  m_dram->set_dram_power_stats(n_cmd, n_activity, n_nop, n_act, n_pre, n_rd,
-                               n_wr, n_req);
-}
-
-void memory_partition_unit::print(FILE *fp) const {
-  fprintf(fp, "Memory Partition %u: \n", m_id);
-  for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel;
-       p++) {
-    m_sub_partition[p]->print(fp);
-  }
-  fprintf(fp, "In Dram Latency Queue (total = %zd): \n",
-          m_dram_latency_queue.size());
-  for (std::list<dram_delay_t>::const_iterator mf_dlq =
-           m_dram_latency_queue.begin();
-       mf_dlq != m_dram_latency_queue.end(); ++mf_dlq) {
-    mem_fetch *mf = mf_dlq->req;
-    fprintf(fp, "Ready @ %llu - ", mf_dlq->ready_cycle);
-    if (mf)
-      mf->print(fp);
-    else
-      fprintf(fp, " <NULL mem_fetch?>\n");
-  }
-  m_dram->print(fp);
-}
-
-memory_sub_partition::memory_sub_partition(unsigned sub_partition_id,
-                                           const memory_config *config,
-                                           class memory_stats_t *stats,
-                                           class gpgpu_sim *gpu) {
-  m_id = sub_partition_id;
-  m_config = config;
-  m_stats = stats;
-  m_gpu = gpu;
-  m_memcpy_cycle_offset = 0;
-
-  assert(m_id < m_config->m_n_mem_sub_partition);
-
-  char L2c_name[32];
-  snprintf(L2c_name, 32, "L2_bank_%03d", m_id);
-  m_L2interface = new L2interface(this);
-  m_mf_allocator = new partition_mf_allocator(config);
-
-  if (!m_config->m_L2_config.disabled())
-    m_L2cache =
-        new l2_cache(L2c_name, m_config->m_L2_config, -1, -1, m_L2interface,
-                     m_mf_allocator, IN_PARTITION_L2_MISS_QUEUE, gpu);
-
-  unsigned int icnt_L2;
-  unsigned int L2_dram;
-  unsigned int dram_L2;
-  unsigned int L2_icnt;
-  sscanf(m_config->gpgpu_L2_queue_config, "%u:%u:%u:%u", &icnt_L2, &L2_dram,
-         &dram_L2, &L2_icnt);
-  m_icnt_L2_queue = new fifo_pipeline<mem_fetch>("icnt-to-L2", 0, icnt_L2);
-  m_L2_dram_queue = new fifo_pipeline<mem_fetch>("L2-to-dram", 0, L2_dram);
-  m_dram_L2_queue = new fifo_pipeline<mem_fetch>("dram-to-L2", 0, dram_L2);
-  m_L2_icnt_queue = new fifo_pipeline<mem_fetch>("L2-to-icnt", 0, L2_icnt);
-  wb_addr = -1;
-}
-
-memory_sub_partition::~memory_sub_partition() {
-  delete m_icnt_L2_queue;
-  delete m_L2_dram_queue;
-  delete m_dram_L2_queue;
-  delete m_L2_icnt_queue;
-  delete m_L2cache;
-  delete m_L2interface;
-}
-
-void memory_sub_partition::cache_cycle(unsigned cycle) {
-  // L2 fill responses
-  if (!m_config->m_L2_config.disabled()) {
-    if (m_L2cache->access_ready() && !m_L2_icnt_queue->full()) {
-      mem_fetch *mf = m_L2cache->next_access();
-      if (mf->get_access_type() !=
-          L2_WR_ALLOC_R) {  // Don't pass write allocate read request back to
-                            // upper level cache
-        mf->set_reply();
-        mf->set_status(IN_PARTITION_L2_TO_ICNT_QUEUE,
-                       m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-        m_L2_icnt_queue->push(mf);
-      } else {
-        if (m_config->m_L2_config.m_write_alloc_policy == FETCH_ON_WRITE) {
-          mem_fetch *original_wr_mf = mf->get_original_wr_mf();
-          assert(original_wr_mf);
-          original_wr_mf->set_reply();
-          original_wr_mf->set_status(
-              IN_PARTITION_L2_TO_ICNT_QUEUE,
-              m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-          m_L2_icnt_queue->push(original_wr_mf);
+bool memory_partition_unit::busy() const 
+{
+    bool busy = false; 
+    for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel; p++) {
+        if (m_sub_partition[p]->busy()) {
+            busy = true; 
         }
+    }
+    return busy; 
+}
+
+void memory_partition_unit::cache_cycle(unsigned cycle) 
+{
+    for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel; p++) {
+        m_sub_partition[p]->cache_cycle(cycle); 
+    }
+}
+
+void memory_partition_unit::visualizer_print( gzFile visualizer_file ) const 
+{
+    m_dram->visualizer_print(visualizer_file);
+    for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel; p++) {
+        m_sub_partition[p]->visualizer_print(visualizer_file); 
+    }
+}
+
+// determine whether a given subpartition can issue to DRAM 
+bool memory_partition_unit::can_issue_to_dram(int inner_sub_partition_id) 
+{
+    int spid = inner_sub_partition_id; 
+    bool sub_partition_contention = m_sub_partition[spid]->dram_L2_queue_full(); 
+    bool has_dram_resource = m_arbitration_metadata.has_credits(spid); 
+
+    MEMPART_DPRINTF("sub partition %d sub_partition_contention=%c has_dram_resource=%c\n", 
+                    spid, (sub_partition_contention)? 'T':'F', (has_dram_resource)? 'T':'F'); 
+
+    return (has_dram_resource && !sub_partition_contention); 
+}
+
+int memory_partition_unit::global_sub_partition_id_to_local_id(int global_sub_partition_id) const
+{
+    return (global_sub_partition_id - m_id * m_config->m_n_sub_partition_per_memory_channel); 
+}
+
+void memory_partition_unit::simple_dram_model_cycle()
+{
+
+	// pop completed memory request from dram and push it to dram-to-L2 queue
+	// of the original sub partition
+	if (!m_dram_latency_queue.empty() && ( (m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle) >= m_dram_latency_queue.front().ready_cycle )) {
+		 mem_fetch* mf_return = m_dram_latency_queue.front().req;
+		 if( mf_return->get_access_type() != L1_WRBK_ACC && mf_return->get_access_type() != L2_WRBK_ACC ) {
+			 mf_return->set_reply();
+
+		    unsigned dest_global_spid = mf_return->get_sub_partition_id();
+			int dest_spid = global_sub_partition_id_to_local_id(dest_global_spid);
+			assert(m_sub_partition[dest_spid]->get_id() == dest_global_spid);
+			if (!m_sub_partition[dest_spid]->dram_L2_queue_full()) {
+				if( mf_return->get_access_type() == L1_WRBK_ACC ) {
+					m_sub_partition[dest_spid]->set_done(mf_return);
+					delete mf_return;
+				} else {
+					m_sub_partition[dest_spid]->dram_L2_queue_push(mf_return);
+					mf_return->set_status(IN_PARTITION_DRAM_TO_L2_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
+					m_arbitration_metadata.return_credit(dest_spid);
+					MEMPART_DPRINTF("mem_fetch request %p return from dram to sub partition %d\n", mf_return, dest_spid);
+				}
+				m_dram_latency_queue.pop_front();
+			}
+
+		  } else {
+			 this->set_done(mf_return);
+			 delete mf_return;
+			 m_dram_latency_queue.pop_front();
+		  }
+	}
+
+   // mem_fetch *mf = m_sub_partition[spid]->L2_dram_queue_top();
+	//if( !m_dram->full(mf->is_write()) ) {
+		// L2->DRAM queue to DRAM latency queue
+		// Arbitrate among multiple L2 subpartitions
+		int last_issued_partition = m_arbitration_metadata.last_borrower();
+		for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel; p++) {
+			int spid = (p + last_issued_partition + 1) % m_config->m_n_sub_partition_per_memory_channel;
+			if (!m_sub_partition[spid]->L2_dram_queue_empty() && can_issue_to_dram(spid)) {
+				mem_fetch *mf = m_sub_partition[spid]->L2_dram_queue_top();
+				if(m_dram->full(mf->is_write()) )
+					break;
+
+				m_sub_partition[spid]->L2_dram_queue_pop();
+				MEMPART_DPRINTF("Issue mem_fetch request %p from sub partition %d to dram\n", mf, spid);
+				dram_delay_t d;
+				d.req = mf;
+				d.ready_cycle = m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle + m_config->dram_latency;
+				m_dram_latency_queue.push_back(d);
+				mf->set_status(IN_PARTITION_DRAM_LATENCY_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
+				m_arbitration_metadata.borrow_credit(spid);
+				break;  // the DRAM should only accept one request per cycle
+			}
+		}
+	//}
+
+}
+
+void memory_partition_unit::dram_cycle()
+{ 
+    // pop completed memory request from dram and push it to dram-to-L2 queue 
+    // of the original sub partition 
+    mem_fetch* mf_return = m_dram->return_queue_top();
+    if (mf_return) {
+        unsigned dest_global_spid = mf_return->get_sub_partition_id(); 
+        int dest_spid = global_sub_partition_id_to_local_id(dest_global_spid); 
+        assert(m_sub_partition[dest_spid]->get_id() == dest_global_spid); 
+        if (!m_sub_partition[dest_spid]->dram_L2_queue_full()) {
+            if( mf_return->get_access_type() == L1_WRBK_ACC ) {
+                m_sub_partition[dest_spid]->set_done(mf_return); 
+                delete mf_return;
+            } else {
+                m_sub_partition[dest_spid]->dram_L2_queue_push(mf_return);
+                mf_return->set_status(IN_PARTITION_DRAM_TO_L2_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
+                m_arbitration_metadata.return_credit(dest_spid); 
+                MEMPART_DPRINTF("mem_fetch request %p return from dram to sub partition %d\n", mf_return, dest_spid); 
+            }
+            m_dram->return_queue_pop(); 
+        }
+    } else {
+        m_dram->return_queue_pop(); 
+    }
+    
+    m_dram->cycle();
+    m_dram->dram_log(SAMPLELOG);
+
+   // mem_fetch *mf = m_sub_partition[spid]->L2_dram_queue_top();
+    //if( !m_dram->full(mf->is_write()) ) {
+        // L2->DRAM queue to DRAM latency queue
+        // Arbitrate among multiple L2 subpartitions 
+        int last_issued_partition = m_arbitration_metadata.last_borrower(); 
+        for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel; p++) {
+            int spid = (p + last_issued_partition + 1) % m_config->m_n_sub_partition_per_memory_channel; 
+            if (!m_sub_partition[spid]->L2_dram_queue_empty() && can_issue_to_dram(spid)) {
+                mem_fetch *mf = m_sub_partition[spid]->L2_dram_queue_top();
+                if(m_dram->full(mf->is_write()) )
+                	break;
+
+                m_sub_partition[spid]->L2_dram_queue_pop();
+                MEMPART_DPRINTF("Issue mem_fetch request %p from sub partition %d to dram\n", mf, spid); 
+                dram_delay_t d;
+                d.req = mf;
+                d.ready_cycle = m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle + m_config->dram_latency;
+                m_dram_latency_queue.push_back(d);
+                mf->set_status(IN_PARTITION_DRAM_LATENCY_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
+                m_arbitration_metadata.borrow_credit(spid); 
+                break;  // the DRAM should only accept one request per cycle 
+            }
+        }
+    //}
+
+    // DRAM latency queue
+    if( !m_dram_latency_queue.empty() && ( (m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle) >= m_dram_latency_queue.front().ready_cycle ) && !m_dram->full(m_dram_latency_queue.front().req->is_write()) ) {
+    	mem_fetch* mf = m_dram_latency_queue.front().req;
+    	m_dram_latency_queue.pop_front();
+        m_dram->push(mf);
+    }
+}
+
+void memory_partition_unit::set_done( mem_fetch *mf )
+{
+    unsigned global_spid = mf->get_sub_partition_id(); 
+    int spid = global_sub_partition_id_to_local_id(global_spid); 
+    assert(m_sub_partition[spid]->get_id() == global_spid); 
+    if (mf->get_access_type() == L1_WRBK_ACC || mf->get_access_type() == L2_WRBK_ACC) {
+        m_arbitration_metadata.return_credit(spid); 
+        MEMPART_DPRINTF("mem_fetch request %p return from dram to sub partition %d\n", mf, spid); 
+    }
+    m_sub_partition[spid]->set_done(mf); 
+}
+
+void memory_partition_unit::set_dram_power_stats(unsigned &n_cmd,
+                                                 unsigned &n_activity,
+                                                 unsigned &n_nop,
+                                                 unsigned &n_act,
+                                                 unsigned &n_pre,
+                                                 unsigned &n_rd,
+                                                 unsigned &n_wr,
+                                                 unsigned &n_req) const
+{
+    m_dram->set_dram_power_stats(n_cmd, n_activity, n_nop, n_act, n_pre, n_rd, n_wr, n_req);
+}
+
+void memory_partition_unit::print( FILE *fp ) const
+{
+    fprintf(fp, "Memory Partition %u: \n", m_id); 
+    for (unsigned p = 0; p < m_config->m_n_sub_partition_per_memory_channel; p++) {
+        m_sub_partition[p]->print(fp); 
+    }
+    fprintf(fp, "In Dram Latency Queue (total = %zd): \n", m_dram_latency_queue.size()); 
+    for (std::list<dram_delay_t>::const_iterator mf_dlq = m_dram_latency_queue.begin(); 
+         mf_dlq != m_dram_latency_queue.end(); ++mf_dlq) {
+        mem_fetch *mf = mf_dlq->req; 
+        fprintf(fp, "Ready @ %llu - ", mf_dlq->ready_cycle); 
+        if (mf) 
+            mf->print(fp); 
+        else 
+            fprintf(fp, " <NULL mem_fetch?>\n"); 
+    }
+    m_dram->print(fp); 
+}
+
+memory_sub_partition::memory_sub_partition( unsigned sub_partition_id, 
+                                            const memory_config *config,
+                                            class memory_stats_t *stats,
+											class gpgpu_sim* gpu)
+{
+    m_id = sub_partition_id;
+    m_config=config;
+    m_stats=stats;
+    m_gpu = gpu;
+    m_memcpy_cycle_offset = 0;
+
+    assert(m_id < m_config->m_n_mem_sub_partition); 
+
+    char L2c_name[32];
+    snprintf(L2c_name, 32, "L2_bank_%03d", m_id);
+    m_L2interface = new L2interface(this);
+    m_mf_allocator = new partition_mf_allocator(config);
+
+    if(!m_config->m_L2_config.disabled())
+       m_L2cache = new l2_cache(L2c_name,m_config->m_L2_config,-1,-1,m_L2interface,m_mf_allocator,IN_PARTITION_L2_MISS_QUEUE, gpu);
+
+    unsigned int icnt_L2;
+    unsigned int L2_dram;
+    unsigned int dram_L2;
+    unsigned int L2_icnt;
+    sscanf(m_config->gpgpu_L2_queue_config,"%u:%u:%u:%u", &icnt_L2,&L2_dram,&dram_L2,&L2_icnt );
+    m_icnt_L2_queue = new fifo_pipeline<mem_fetch>("icnt-to-L2",0,icnt_L2); 
+    m_L2_dram_queue = new fifo_pipeline<mem_fetch>("L2-to-dram",0,L2_dram);
+    m_dram_L2_queue = new fifo_pipeline<mem_fetch>("dram-to-L2",0,dram_L2);
+    m_L2_icnt_queue = new fifo_pipeline<mem_fetch>("L2-to-icnt",0,L2_icnt);
+    wb_addr=-1;
+}
+
+memory_sub_partition::~memory_sub_partition()
+{
+    delete m_icnt_L2_queue;
+    delete m_L2_dram_queue;
+    delete m_dram_L2_queue;
+    delete m_L2_icnt_queue;
+    delete m_L2cache;
+    delete m_L2interface;
+}
+
+void memory_sub_partition::cache_cycle( unsigned cycle )
+{
+    // L2 fill responses
+    if( !m_config->m_L2_config.disabled()) {
+       if ( m_L2cache->access_ready() && !m_L2_icnt_queue->full() ) {
+           mem_fetch *mf = m_L2cache->next_access();
+           if(mf->get_access_type() != L2_WR_ALLOC_R){ // Don't pass write allocate read request back to upper level cache
+				mf->set_reply();
+				mf->set_status(IN_PARTITION_L2_TO_ICNT_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
+				m_L2_icnt_queue->push(mf);
+           }else{
+        	    if(m_config->m_L2_config.m_write_alloc_policy == FETCH_ON_WRITE)
+        	    {
+        	    	mem_fetch* original_wr_mf = mf->get_original_wr_mf();
+					assert(original_wr_mf);
+					original_wr_mf->set_reply();
+					original_wr_mf->set_status(IN_PARTITION_L2_TO_ICNT_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
+					m_L2_icnt_queue->push(original_wr_mf);
+        	    }
+				m_request_tracker.erase(mf);
+				delete mf;
+           }
+       }
+    }
+
+    // DRAM to L2 (texture) and icnt (not texture)
+    if ( !m_dram_L2_queue->empty() ) {
+        mem_fetch *mf = m_dram_L2_queue->top();
+        if ( !m_config->m_L2_config.disabled() && m_L2cache->waiting_for_fill(mf) ) {
+            if (m_L2cache->fill_port_free()) {
+                mf->set_status(IN_PARTITION_L2_FILL_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
+                m_L2cache->fill(mf,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle+m_memcpy_cycle_offset);
+                m_dram_L2_queue->pop();
+            }
+        } else if ( !m_L2_icnt_queue->full() ) {
+        	if(mf->is_write() && mf->get_type() == WRITE_ACK)
+            mf->set_status(IN_PARTITION_L2_TO_ICNT_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
+            m_L2_icnt_queue->push(mf);
+            m_dram_L2_queue->pop();
+        }
+    }
+
+    // prior L2 misses inserted into m_L2_dram_queue here
+    if( !m_config->m_L2_config.disabled() )
+       m_L2cache->cycle();
+
+    // new L2 texture accesses and/or non-texture accesses
+    if ( !m_L2_dram_queue->full() && !m_icnt_L2_queue->empty() ) {
+        mem_fetch *mf = m_icnt_L2_queue->top();
+        if ( !m_config->m_L2_config.disabled() &&
+              ( (m_config->m_L2_texure_only && mf->istexture()) || (!m_config->m_L2_texure_only) )
+           ) {
+            // L2 is enabled and access is for L2
+            bool output_full = m_L2_icnt_queue->full(); 
+            bool port_free = m_L2cache->data_port_free(); 
+            if ( !output_full && port_free ) {
+                std::list<cache_event> events;
+                enum cache_request_status status = m_L2cache->access(mf->get_addr(),mf,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle+m_memcpy_cycle_offset,events);
+                bool write_sent = was_write_sent(events);
+                bool read_sent = was_read_sent(events);
+                MEM_SUBPART_DPRINTF("Probing L2 cache Address=%llx, status=%u\n", mf->get_addr(), status); 
+
+                if ( status == HIT ) {
+                    if( !write_sent ) {
+                        // L2 cache replies
+                        assert(!read_sent);
+                        if( mf->get_access_type() == L1_WRBK_ACC ) {
+                            m_request_tracker.erase(mf);
+                            delete mf;
+                        } else {
+                            mf->set_reply();
+                            mf->set_status(IN_PARTITION_L2_TO_ICNT_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
+                            m_L2_icnt_queue->push(mf);
+                        }
+                        m_icnt_L2_queue->pop();
+                    } else {
+                        assert(write_sent);
+                        m_icnt_L2_queue->pop();
+                    }
+                } else if ( status != RESERVATION_FAIL ) {
+                	if(mf->is_write() && (m_config->m_L2_config.m_write_alloc_policy == FETCH_ON_WRITE || m_config->m_L2_config.m_write_alloc_policy == LAZY_FETCH_ON_READ) && !was_writeallocate_sent(events)) {
+                		mf->set_reply();
+                		mf->set_status(IN_PARTITION_L2_TO_ICNT_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
+                		m_L2_icnt_queue->push(mf);
+                	}
+                    // L2 cache accepted request
+                    m_icnt_L2_queue->pop();
+                } else {
+                    assert(!write_sent);
+                    assert(!read_sent);
+                    // L2 cache lock-up: will try again next cycle
+                }
+            }
+        } else {
+            // L2 is disabled or non-texture access to texture-only L2
+            mf->set_status(IN_PARTITION_L2_TO_DRAM_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
+            m_L2_dram_queue->push(mf);
+            m_icnt_L2_queue->pop();
+        }
+    }
+
+    // ROP delay queue
+    if( !m_rop.empty() && (cycle >= m_rop.front().ready_cycle) && !m_icnt_L2_queue->full() ) {
+        mem_fetch* mf = m_rop.front().req;
+        m_rop.pop();
+        m_icnt_L2_queue->push(mf);
+        mf->set_status(IN_PARTITION_ICNT_TO_L2_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
+    }
+}
+
+bool memory_sub_partition::full() const
+{
+    return m_icnt_L2_queue->full();
+}
+
+bool memory_sub_partition::full(unsigned size) const
+{
+    return m_icnt_L2_queue->is_avilable_size(size);
+}
+
+bool memory_sub_partition::L2_dram_queue_empty() const
+{
+   return m_L2_dram_queue->empty(); 
+}
+
+class mem_fetch* memory_sub_partition::L2_dram_queue_top() const
+{
+   return m_L2_dram_queue->top(); 
+}
+
+void memory_sub_partition::L2_dram_queue_pop() 
+{
+   m_L2_dram_queue->pop(); 
+}
+
+bool memory_sub_partition::dram_L2_queue_full() const
+{
+   return m_dram_L2_queue->full(); 
+}
+
+void memory_sub_partition::dram_L2_queue_push( class mem_fetch* mf )
+{
+   m_dram_L2_queue->push(mf); 
+}
+
+void memory_sub_partition::print_cache_stat(unsigned &accesses, unsigned &misses) const
+{
+    FILE *fp = stdout;
+    if( !m_config->m_L2_config.disabled() )
+       m_L2cache->print(fp,accesses,misses);
+}
+
+void memory_sub_partition::print( FILE *fp ) const
+{
+    if ( !m_request_tracker.empty() ) {
+        fprintf(fp,"Memory Sub Parition %u: pending memory requests:\n", m_id);
+        for ( std::set<mem_fetch*>::const_iterator r=m_request_tracker.begin(); r != m_request_tracker.end(); ++r ) {
+            mem_fetch *mf = *r;
+            if ( mf )
+                mf->print(fp);
+            else
+                fprintf(fp," <NULL mem_fetch?>\n");
+        }
+    }
+    if( !m_config->m_L2_config.disabled() )
+       m_L2cache->display_state(fp);
+}
+
+void memory_stats_t::visualizer_print( gzFile visualizer_file )
+{
+   gzprintf(visualizer_file, "Ltwowritemiss: %d\n", L2_write_miss);
+   gzprintf(visualizer_file, "Ltwowritehit: %d\n",  L2_write_hit);
+   gzprintf(visualizer_file, "Ltworeadmiss: %d\n", L2_read_miss);
+   gzprintf(visualizer_file, "Ltworeadhit: %d\n", L2_read_hit);
+   clear_L2_stats_pw();
+
+   if (num_mfs)
+      gzprintf(visualizer_file, "averagemflatency: %lld\n", mf_total_lat/num_mfs);
+}
+
+void memory_stats_t::clear_L2_stats_pw(){
+    L2_write_miss = 0;
+    L2_write_hit = 0;
+    L2_read_miss = 0;
+    L2_read_hit = 0;
+}
+
+void gpgpu_sim::print_dram_stats(FILE *fout) const
+{
+	unsigned cmd=0;
+	unsigned activity=0;
+	unsigned nop=0;
+	unsigned act=0;
+	unsigned pre=0;
+	unsigned rd=0;
+	unsigned wr=0;
+	unsigned req=0;
+	unsigned tot_cmd=0;
+	unsigned tot_nop=0;
+	unsigned tot_act=0;
+	unsigned tot_pre=0;
+	unsigned tot_rd=0;
+	unsigned tot_wr=0;
+	unsigned tot_req=0;
+
+	for (unsigned i=0;i<m_memory_config->m_n_mem;i++){
+		m_memory_partition_unit[i]->set_dram_power_stats(cmd,activity,nop,act,pre,rd,wr,req);
+		tot_cmd+=cmd;
+		tot_nop+=nop;
+		tot_act+=act;
+		tot_pre+=pre;
+		tot_rd+=rd;
+		tot_wr+=wr;
+		tot_req+=req;
+	}
+    fprintf(fout,"gpgpu_n_dram_reads = %d\n",tot_rd );
+    fprintf(fout,"gpgpu_n_dram_writes = %d\n",tot_wr );
+    fprintf(fout,"gpgpu_n_dram_activate = %d\n",tot_act );
+    fprintf(fout,"gpgpu_n_dram_commands = %d\n",tot_cmd);
+    fprintf(fout,"gpgpu_n_dram_noops = %d\n",tot_nop );
+    fprintf(fout,"gpgpu_n_dram_precharges = %d\n",tot_pre );
+    fprintf(fout,"gpgpu_n_dram_requests = %d\n",tot_req );
+}
+
+unsigned memory_sub_partition::flushL2() 
+{ 
+    if (!m_config->m_L2_config.disabled()) {
+        m_L2cache->flush(); 
+    }
+    return 0;   //TODO: write the flushed data to the main memory
+}
+
+unsigned memory_sub_partition::invalidateL2()
+{
+    if (!m_config->m_L2_config.disabled()) {
+        m_L2cache->invalidate();
+    }
+    return 0;
+}
+
+bool memory_sub_partition::busy() const 
+{
+    return !m_request_tracker.empty();
+}
+
+std::vector<mem_fetch*> memory_sub_partition::breakdown_request_to_sector_requests(mem_fetch* mf)
+{
+	std::vector<mem_fetch*> result;
+
+	if(mf->get_data_size() == SECTOR_SIZE && mf->get_access_sector_mask().count() == 1) {
+		result.push_back(mf);
+	} else if (mf->get_data_size() == 128 || mf->get_data_size() == 64) {
+        //We only accept 32, 64 and 128 bytes reqs
+		unsigned start=0, end=0;
+		if(mf->get_data_size() == 128) {
+			start=0; end=3;
+		} else if (mf->get_data_size() == 64 && mf->get_access_sector_mask().to_string() == "1100") {
+			start=2; end=3;
+		} else if (mf->get_data_size() == 64 && mf->get_access_sector_mask().to_string() == "0011") {
+			start=0; end=1;
+		} else if (mf->get_data_size() == 64 && (mf->get_access_sector_mask().to_string() == "1111" || mf->get_access_sector_mask().to_string() == "0000")) {
+			if(mf->get_addr() % 128 == 0) {
+				start=0; end=1;
+			} else {
+				start=2; end=3;
+			}
+		} else
+			{
+			    printf("Invalid sector received, address = 0x%06llx, sector mask = %s, data size = %d",
+			    		mf->get_addr(), mf->get_access_sector_mask(), mf->get_data_size());
+				assert(0 && "Undefined sector mask is received");
+			}
+
+		std::bitset<SECTOR_SIZE*SECTOR_CHUNCK_SIZE> byte_sector_mask;
+		byte_sector_mask.reset();
+		for(unsigned  k=start*SECTOR_SIZE; k< SECTOR_SIZE; ++k)
+			byte_sector_mask.set(k);
+
+		for(unsigned j=start, i=0; j<= end ; ++j, ++i){
+
+			const mem_access_t *ma = new  mem_access_t( mf->get_access_type(),
+									mf->get_addr() + SECTOR_SIZE*i,
+									SECTOR_SIZE,
+									mf->is_write(),
+									mf->get_access_warp_mask(),
+									mf->get_access_byte_mask() & byte_sector_mask,
+									std::bitset<SECTOR_CHUNCK_SIZE>().set(j),
+									m_gpu->gpgpu_ctx);
+
+			 mem_fetch *n_mf = new mem_fetch( *ma,
+								NULL,
+								mf->get_ctrl_size(),
+								mf->get_wid(),
+								mf->get_sid(),
+								mf->get_tpc(),
+								mf->get_mem_config(),
+								m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle,
+								mf);
+
+			 result.push_back(n_mf);
+			 byte_sector_mask <<= SECTOR_SIZE;
+		}
+	} else {
+		 printf("Invalid sector received, address = 0x%06llx, sector mask = %d, byte mask = , data size = %u",
+					    		mf->get_addr(), mf->get_access_sector_mask().count(), mf->get_data_size());
+		 assert(0 && "Undefined data size is received");
+	}
+
+	return result;
+}
+
+void memory_sub_partition::push( mem_fetch* m_req, unsigned long long cycle )
+{
+    if (m_req) {
+    	m_stats->memlatstat_icnt2mem_pop(m_req);
+    	std::vector<mem_fetch*> reqs;
+    	if(m_config->m_L2_config.m_cache_type == SECTOR)
+    		reqs = breakdown_request_to_sector_requests(m_req);
+    	else
+    		reqs.push_back(m_req);
+
+    	for(unsigned i=0; i<reqs.size(); ++i) {
+    		mem_fetch* req = reqs[i];
+			m_request_tracker.insert(req);
+			if( req->istexture() ) {
+				m_icnt_L2_queue->push(req);
+				req->set_status(IN_PARTITION_ICNT_TO_L2_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
+			} else {
+				rop_delay_t r;
+				r.req = req;
+				r.ready_cycle = cycle + m_config->rop_latency;
+				m_rop.push(r);
+				req->set_status(IN_PARTITION_ROP_DELAY,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
+			}
+    	}
+    }
+}
+
+mem_fetch* memory_sub_partition::pop() 
+{
+    mem_fetch* mf = m_L2_icnt_queue->pop();
+    m_request_tracker.erase(mf);
+    if ( mf && mf->isatomic() )
+        mf->do_atomic();
+    if( mf && (mf->get_access_type() == L2_WRBK_ACC || mf->get_access_type() == L1_WRBK_ACC) ) {
+        delete mf;
+        mf = NULL;
+    } 
+    return mf;
+}
+
+mem_fetch* memory_sub_partition::top() 
+{
+    mem_fetch *mf = m_L2_icnt_queue->top();
+    if( mf && (mf->get_access_type() == L2_WRBK_ACC || mf->get_access_type() == L1_WRBK_ACC) ) {
+        m_L2_icnt_queue->pop();
         m_request_tracker.erase(mf);
         delete mf;
-      }
-    }
-  }
-
-  // DRAM to L2 (texture) and icnt (not texture)
-  if (!m_dram_L2_queue->empty()) {
-    mem_fetch *mf = m_dram_L2_queue->top();
-    if (!m_config->m_L2_config.disabled() && m_L2cache->waiting_for_fill(mf)) {
-      if (m_L2cache->fill_port_free()) {
-        mf->set_status(IN_PARTITION_L2_FILL_QUEUE,
-                       m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-        m_L2cache->fill(mf, m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle +
-                                m_memcpy_cycle_offset);
-        m_dram_L2_queue->pop();
-      }
-    } else if (!m_L2_icnt_queue->full()) {
-      if (mf->is_write() && mf->get_type() == WRITE_ACK)
-        mf->set_status(IN_PARTITION_L2_TO_ICNT_QUEUE,
-                       m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-      m_L2_icnt_queue->push(mf);
-      m_dram_L2_queue->pop();
-    }
-  }
-
-  // prior L2 misses inserted into m_L2_dram_queue here
-  if (!m_config->m_L2_config.disabled()) m_L2cache->cycle();
-
-  // new L2 texture accesses and/or non-texture accesses
-  if (!m_L2_dram_queue->full() && !m_icnt_L2_queue->empty()) {
-    mem_fetch *mf = m_icnt_L2_queue->top();
-    if (!m_config->m_L2_config.disabled() &&
-        ((m_config->m_L2_texure_only && mf->istexture()) ||
-         (!m_config->m_L2_texure_only))) {
-      // L2 is enabled and access is for L2
-      bool output_full = m_L2_icnt_queue->full();
-      bool port_free = m_L2cache->data_port_free();
-      if (!output_full && port_free) {
-        std::list<cache_event> events;
-        enum cache_request_status status =
-            m_L2cache->access(mf->get_addr(), mf,
-                              m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle +
-                                  m_memcpy_cycle_offset,
-                              events);
-        bool write_sent = was_write_sent(events);
-        bool read_sent = was_read_sent(events);
-        MEM_SUBPART_DPRINTF("Probing L2 cache Address=%llx, status=%u\n",
-                            mf->get_addr(), status);
-
-        if (status == HIT) {
-          if (!write_sent) {
-            // L2 cache replies
-            assert(!read_sent);
-            if (mf->get_access_type() == L1_WRBK_ACC) {
-              m_request_tracker.erase(mf);
-              delete mf;
-            } else {
-              mf->set_reply();
-              mf->set_status(IN_PARTITION_L2_TO_ICNT_QUEUE,
-                             m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-              m_L2_icnt_queue->push(mf);
-            }
-            m_icnt_L2_queue->pop();
-          } else {
-            assert(write_sent);
-            m_icnt_L2_queue->pop();
-          }
-        } else if (status != RESERVATION_FAIL) {
-          if (mf->is_write() &&
-              (m_config->m_L2_config.m_write_alloc_policy == FETCH_ON_WRITE ||
-               m_config->m_L2_config.m_write_alloc_policy ==
-                   LAZY_FETCH_ON_READ) &&
-              !was_writeallocate_sent(events)) {
-            mf->set_reply();
-            mf->set_status(IN_PARTITION_L2_TO_ICNT_QUEUE,
-                           m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-            m_L2_icnt_queue->push(mf);
-          }
-          // L2 cache accepted request
-          m_icnt_L2_queue->pop();
-        } else {
-          assert(!write_sent);
-          assert(!read_sent);
-          // L2 cache lock-up: will try again next cycle
-        }
-      }
-    } else {
-      // L2 is disabled or non-texture access to texture-only L2
-      mf->set_status(IN_PARTITION_L2_TO_DRAM_QUEUE,
-                     m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-      m_L2_dram_queue->push(mf);
-      m_icnt_L2_queue->pop();
-    }
-  }
-
-  // ROP delay queue
-  if (!m_rop.empty() && (cycle >= m_rop.front().ready_cycle) &&
-      !m_icnt_L2_queue->full()) {
-    mem_fetch *mf = m_rop.front().req;
-    m_rop.pop();
-    m_icnt_L2_queue->push(mf);
-    mf->set_status(IN_PARTITION_ICNT_TO_L2_QUEUE,
-                   m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-  }
+        mf = NULL;
+    } 
+    return mf;
 }
 
-bool memory_sub_partition::full() const { return m_icnt_L2_queue->full(); }
-
-bool memory_sub_partition::full(unsigned size) const {
-  return m_icnt_L2_queue->is_avilable_size(size);
-}
-
-bool memory_sub_partition::L2_dram_queue_empty() const {
-  return m_L2_dram_queue->empty();
-}
-
-class mem_fetch *memory_sub_partition::L2_dram_queue_top() const {
-  return m_L2_dram_queue->top();
-}
-
-void memory_sub_partition::L2_dram_queue_pop() { m_L2_dram_queue->pop(); }
-
-bool memory_sub_partition::dram_L2_queue_full() const {
-  return m_dram_L2_queue->full();
-}
-
-void memory_sub_partition::dram_L2_queue_push(class mem_fetch *mf) {
-  m_dram_L2_queue->push(mf);
-}
-
-void memory_sub_partition::print_cache_stat(unsigned &accesses,
-                                            unsigned &misses) const {
-  FILE *fp = stdout;
-  if (!m_config->m_L2_config.disabled()) m_L2cache->print(fp, accesses, misses);
-}
-
-void memory_sub_partition::print(FILE *fp) const {
-  if (!m_request_tracker.empty()) {
-    fprintf(fp, "Memory Sub Parition %u: pending memory requests:\n", m_id);
-    for (std::set<mem_fetch *>::const_iterator r = m_request_tracker.begin();
-         r != m_request_tracker.end(); ++r) {
-      mem_fetch *mf = *r;
-      if (mf)
-        mf->print(fp);
-      else
-        fprintf(fp, " <NULL mem_fetch?>\n");
-    }
-  }
-  if (!m_config->m_L2_config.disabled()) m_L2cache->display_state(fp);
-}
-
-void memory_stats_t::visualizer_print(gzFile visualizer_file) {
-  gzprintf(visualizer_file, "Ltwowritemiss: %d\n", L2_write_miss);
-  gzprintf(visualizer_file, "Ltwowritehit: %d\n", L2_write_hit);
-  gzprintf(visualizer_file, "Ltworeadmiss: %d\n", L2_read_miss);
-  gzprintf(visualizer_file, "Ltworeadhit: %d\n", L2_read_hit);
-  clear_L2_stats_pw();
-
-  if (num_mfs)
-    gzprintf(visualizer_file, "averagemflatency: %lld\n",
-             mf_total_lat / num_mfs);
-}
-
-void memory_stats_t::clear_L2_stats_pw() {
-  L2_write_miss = 0;
-  L2_write_hit = 0;
-  L2_read_miss = 0;
-  L2_read_hit = 0;
-}
-
-void gpgpu_sim::print_dram_stats(FILE *fout) const {
-  unsigned cmd = 0;
-  unsigned activity = 0;
-  unsigned nop = 0;
-  unsigned act = 0;
-  unsigned pre = 0;
-  unsigned rd = 0;
-  unsigned wr = 0;
-  unsigned req = 0;
-  unsigned tot_cmd = 0;
-  unsigned tot_nop = 0;
-  unsigned tot_act = 0;
-  unsigned tot_pre = 0;
-  unsigned tot_rd = 0;
-  unsigned tot_wr = 0;
-  unsigned tot_req = 0;
-
-  for (unsigned i = 0; i < m_memory_config->m_n_mem; i++) {
-    m_memory_partition_unit[i]->set_dram_power_stats(cmd, activity, nop, act,
-                                                     pre, rd, wr, req);
-    tot_cmd += cmd;
-    tot_nop += nop;
-    tot_act += act;
-    tot_pre += pre;
-    tot_rd += rd;
-    tot_wr += wr;
-    tot_req += req;
-  }
-  fprintf(fout, "gpgpu_n_dram_reads = %d\n", tot_rd);
-  fprintf(fout, "gpgpu_n_dram_writes = %d\n", tot_wr);
-  fprintf(fout, "gpgpu_n_dram_activate = %d\n", tot_act);
-  fprintf(fout, "gpgpu_n_dram_commands = %d\n", tot_cmd);
-  fprintf(fout, "gpgpu_n_dram_noops = %d\n", tot_nop);
-  fprintf(fout, "gpgpu_n_dram_precharges = %d\n", tot_pre);
-  fprintf(fout, "gpgpu_n_dram_requests = %d\n", tot_req);
-}
-
-unsigned memory_sub_partition::flushL2() {
-  if (!m_config->m_L2_config.disabled()) {
-    m_L2cache->flush();
-  }
-  return 0;  // TODO: write the flushed data to the main memory
-}
-
-unsigned memory_sub_partition::invalidateL2() {
-  if (!m_config->m_L2_config.disabled()) {
-    m_L2cache->invalidate();
-  }
-  return 0;
-}
-
-bool memory_sub_partition::busy() const { return !m_request_tracker.empty(); }
-
-std::vector<mem_fetch *>
-memory_sub_partition::breakdown_request_to_sector_requests(mem_fetch *mf) {
-  std::vector<mem_fetch *> result;
-
-  if (mf->get_data_size() == SECTOR_SIZE &&
-      mf->get_access_sector_mask().count() == 1) {
-    result.push_back(mf);
-  } else if (mf->get_data_size() == 128 || mf->get_data_size() == 64) {
-    // We only accept 32, 64 and 128 bytes reqs
-    unsigned start = 0, end = 0;
-    if (mf->get_data_size() == 128) {
-      start = 0;
-      end = 3;
-    } else if (mf->get_data_size() == 64 &&
-               mf->get_access_sector_mask().to_string() == "1100") {
-      start = 2;
-      end = 3;
-    } else if (mf->get_data_size() == 64 &&
-               mf->get_access_sector_mask().to_string() == "0011") {
-      start = 0;
-      end = 1;
-    } else if (mf->get_data_size() == 64 &&
-               (mf->get_access_sector_mask().to_string() == "1111" ||
-                mf->get_access_sector_mask().to_string() == "0000")) {
-      if (mf->get_addr() % 128 == 0) {
-        start = 0;
-        end = 1;
-      } else {
-        start = 2;
-        end = 3;
-      }
-    } else {
-      printf(
-          "Invalid sector received, address = 0x%06llx, sector mask = %s, data "
-          "size = %d",
-          mf->get_addr(), mf->get_access_sector_mask(), mf->get_data_size());
-      assert(0 && "Undefined sector mask is received");
-    }
-
-    std::bitset<SECTOR_SIZE * SECTOR_CHUNCK_SIZE> byte_sector_mask;
-    byte_sector_mask.reset();
-    for (unsigned k = start * SECTOR_SIZE; k < SECTOR_SIZE; ++k)
-      byte_sector_mask.set(k);
-
-    for (unsigned j = start, i = 0; j <= end; ++j, ++i) {
-      const mem_access_t *ma = new mem_access_t(
-          mf->get_access_type(), mf->get_addr() + SECTOR_SIZE * i, SECTOR_SIZE,
-          mf->is_write(), mf->get_access_warp_mask(),
-          mf->get_access_byte_mask() & byte_sector_mask,
-          std::bitset<SECTOR_CHUNCK_SIZE>().set(j), m_gpu->gpgpu_ctx);
-
-      mem_fetch *n_mf =
-          new mem_fetch(*ma, NULL, mf->get_ctrl_size(), mf->get_wid(),
-                        mf->get_sid(), mf->get_tpc(), mf->get_mem_config(),
-                        m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle, mf);
-
-      result.push_back(n_mf);
-      byte_sector_mask <<= SECTOR_SIZE;
-    }
-  } else {
-    printf(
-        "Invalid sector received, address = 0x%06llx, sector mask = %d, byte "
-        "mask = , data size = %u",
-        mf->get_addr(), mf->get_access_sector_mask().count(),
-        mf->get_data_size());
-    assert(0 && "Undefined data size is received");
-  }
-
-  return result;
-}
-
-void memory_sub_partition::push(mem_fetch *m_req, unsigned long long cycle) {
-  if (m_req) {
-    m_stats->memlatstat_icnt2mem_pop(m_req);
-    std::vector<mem_fetch *> reqs;
-    if (m_config->m_L2_config.m_cache_type == SECTOR)
-      reqs = breakdown_request_to_sector_requests(m_req);
-    else
-      reqs.push_back(m_req);
-
-    for (unsigned i = 0; i < reqs.size(); ++i) {
-      mem_fetch *req = reqs[i];
-      m_request_tracker.insert(req);
-      if (req->istexture()) {
-        m_icnt_L2_queue->push(req);
-        req->set_status(IN_PARTITION_ICNT_TO_L2_QUEUE,
-                        m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-      } else {
-        rop_delay_t r;
-        r.req = req;
-        r.ready_cycle = cycle + m_config->rop_latency;
-        m_rop.push(r);
-        req->set_status(IN_PARTITION_ROP_DELAY,
-                        m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-      }
-    }
-  }
-}
-
-mem_fetch *memory_sub_partition::pop() {
-  mem_fetch *mf = m_L2_icnt_queue->pop();
-  m_request_tracker.erase(mf);
-  if (mf && mf->isatomic()) mf->do_atomic();
-  if (mf && (mf->get_access_type() == L2_WRBK_ACC ||
-             mf->get_access_type() == L1_WRBK_ACC)) {
-    delete mf;
-    mf = NULL;
-  }
-  return mf;
-}
-
-mem_fetch *memory_sub_partition::top() {
-  mem_fetch *mf = m_L2_icnt_queue->top();
-  if (mf && (mf->get_access_type() == L2_WRBK_ACC ||
-             mf->get_access_type() == L1_WRBK_ACC)) {
-    m_L2_icnt_queue->pop();
+void memory_sub_partition::set_done( mem_fetch *mf )
+{
     m_request_tracker.erase(mf);
-    delete mf;
-    mf = NULL;
-  }
-  return mf;
 }
 
-void memory_sub_partition::set_done(mem_fetch *mf) {
-  m_request_tracker.erase(mf);
+void memory_sub_partition::accumulate_L2cache_stats(class cache_stats &l2_stats) const {
+    if (!m_config->m_L2_config.disabled()) {
+        l2_stats += m_L2cache->get_stats();
+    }
 }
 
-void memory_sub_partition::accumulate_L2cache_stats(
-    class cache_stats &l2_stats) const {
-  if (!m_config->m_L2_config.disabled()) {
-    l2_stats += m_L2cache->get_stats();
-  }
+void memory_sub_partition::get_L2cache_sub_stats(struct cache_sub_stats &css) const{
+    if (!m_config->m_L2_config.disabled()) {
+        m_L2cache->get_sub_stats(css);
+    }
 }
 
-void memory_sub_partition::get_L2cache_sub_stats(
-    struct cache_sub_stats &css) const {
-  if (!m_config->m_L2_config.disabled()) {
-    m_L2cache->get_sub_stats(css);
-  }
-}
-
-void memory_sub_partition::get_L2cache_sub_stats_pw(
-    struct cache_sub_stats_pw &css) const {
-  if (!m_config->m_L2_config.disabled()) {
-    m_L2cache->get_sub_stats_pw(css);
-  }
+void memory_sub_partition::get_L2cache_sub_stats_pw(struct cache_sub_stats_pw &css) const{
+    if (!m_config->m_L2_config.disabled()) {
+        m_L2cache->get_sub_stats_pw(css);
+    }
 }
 
 void memory_sub_partition::clear_L2cache_stats_pw() {
-  if (!m_config->m_L2_config.disabled()) {
-    m_L2cache->clear_pw();
-  }
+    if (!m_config->m_L2_config.disabled()) {
+        m_L2cache->clear_pw();
+    }
 }
 
-void memory_sub_partition::visualizer_print(gzFile visualizer_file) {
-  // Support for L2 AerialVision stats
-  // Per-sub-partition stats would be trivial to extend from this
-  cache_sub_stats_pw temp_sub_stats;
-  get_L2cache_sub_stats_pw(temp_sub_stats);
+void memory_sub_partition::visualizer_print( gzFile visualizer_file )
+{
+    // Support for L2 AerialVision stats
+    // Per-sub-partition stats would be trivial to extend from this
+    cache_sub_stats_pw temp_sub_stats;
+    get_L2cache_sub_stats_pw(temp_sub_stats);
 
-  m_stats->L2_read_miss += temp_sub_stats.read_misses;
-  m_stats->L2_write_miss += temp_sub_stats.write_misses;
-  m_stats->L2_read_hit += temp_sub_stats.read_hits;
-  m_stats->L2_write_hit += temp_sub_stats.write_hits;
+    m_stats->L2_read_miss += temp_sub_stats.read_misses;
+    m_stats->L2_write_miss += temp_sub_stats.write_misses;
+    m_stats->L2_read_hit += temp_sub_stats.read_hits;
+    m_stats->L2_write_hit += temp_sub_stats.write_hits;
 
-  clear_L2cache_stats_pw();
+    clear_L2cache_stats_pw();
 }

--- a/src/gpgpu-sim/l2cache.h
+++ b/src/gpgpu-sim/l2cache.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -30,8 +28,8 @@
 #ifndef MC_PARTITION_INCLUDED
 #define MC_PARTITION_INCLUDED
 
-#include "../abstract_hardware_model.h"
 #include "dram.h"
+#include "../abstract_hardware_model.h"
 
 #include <list>
 #include <queue>
@@ -39,224 +37,222 @@
 class mem_fetch;
 
 class partition_mf_allocator : public mem_fetch_allocator {
- public:
-  partition_mf_allocator(const memory_config *config) {
-    m_memory_config = config;
-  }
-  virtual mem_fetch *alloc(const class warp_inst_t &inst,
-                           const mem_access_t &access,
-                           unsigned long long cycle) const {
-    abort();
-    return NULL;
-  }
-  virtual mem_fetch *alloc(new_addr_type addr, mem_access_type type,
-                           unsigned size, bool wr,
-                           unsigned long long cycle) const;
-
- private:
-  const memory_config *m_memory_config;
+public:
+    partition_mf_allocator( const memory_config *config )
+    {
+        m_memory_config = config;
+    }
+    virtual mem_fetch * alloc(const class warp_inst_t &inst, const mem_access_t &access, unsigned long long cycle) const
+    {
+        abort();
+        return NULL;
+    }
+    virtual mem_fetch * alloc(new_addr_type addr, mem_access_type type, unsigned size, bool wr, unsigned long long cycle) const;
+private:
+    const memory_config *m_memory_config;
 };
 
-// Memory partition unit contains all the units assolcated with a single DRAM
-// channel.
-// - It arbitrates the DRAM channel among multiple sub partitions.
-// - It does not connect directly with the interconnection network.
-class memory_partition_unit {
- public:
-  memory_partition_unit(unsigned partition_id, const memory_config *config,
-                        class memory_stats_t *stats, class gpgpu_sim *gpu);
-  ~memory_partition_unit();
+// Memory partition unit contains all the units assolcated with a single DRAM channel. 
+// - It arbitrates the DRAM channel among multiple sub partitions.  
+// - It does not connect directly with the interconnection network. 
+class memory_partition_unit
+{
+public: 
+   memory_partition_unit( unsigned partition_id, const memory_config *config, class memory_stats_t *stats, class gpgpu_sim* gpu );
+   ~memory_partition_unit(); 
 
-  bool busy() const;
+   bool busy() const;
 
-  void cache_cycle(unsigned cycle);
-  void dram_cycle();
-  void simple_dram_model_cycle();
+   void cache_cycle( unsigned cycle );
+   void dram_cycle();
+   void simple_dram_model_cycle();
 
-  void set_done(mem_fetch *mf);
+   void set_done( mem_fetch *mf );
 
-  void visualizer_print(gzFile visualizer_file) const;
-  void print_stat(FILE *fp) { m_dram->print_stat(fp); }
-  void visualize() const { m_dram->visualize(); }
-  void print(FILE *fp) const;
-  void handle_memcpy_to_gpu(size_t dst_start_addr, unsigned subpart_id,
-                            mem_access_sector_mask_t mask);
+   void visualizer_print( gzFile visualizer_file ) const;
+   void print_stat( FILE *fp ) { m_dram->print_stat(fp); }
+   void visualize() const { m_dram->visualize(); }
+   void print( FILE *fp ) const;
+   void handle_memcpy_to_gpu( size_t dst_start_addr, unsigned subpart_id, mem_access_sector_mask_t mask );
 
-  class memory_sub_partition *get_sub_partition(int sub_partition_id) {
-    return m_sub_partition[sub_partition_id];
-  }
+   class memory_sub_partition * get_sub_partition(int sub_partition_id) 
+   {
+      return m_sub_partition[sub_partition_id]; 
+   }
 
-  // Power model
-  void set_dram_power_stats(unsigned &n_cmd, unsigned &n_activity,
-                            unsigned &n_nop, unsigned &n_act, unsigned &n_pre,
-                            unsigned &n_rd, unsigned &n_wr,
-                            unsigned &n_req) const;
+   // Power model
+   void set_dram_power_stats(unsigned &n_cmd,
+                             unsigned &n_activity,
+                             unsigned &n_nop,
+                             unsigned &n_act,
+                             unsigned &n_pre,
+                             unsigned &n_rd,
+                             unsigned &n_wr,
+                             unsigned &n_req) const;
 
-  int global_sub_partition_id_to_local_id(int global_sub_partition_id) const;
+   int global_sub_partition_id_to_local_id(int global_sub_partition_id) const; 
 
-  unsigned get_mpid() const { return m_id; }
+   unsigned get_mpid() const { return m_id; }
 
-  class gpgpu_sim *get_mgpu() const {
-    return m_gpu;
-  }
+   class gpgpu_sim* get_mgpu() const { return m_gpu; }
 
- private:
-  unsigned m_id;
-  const memory_config *m_config;
-  class memory_stats_t *m_stats;
-  class memory_sub_partition **m_sub_partition;
-  class dram_t *m_dram;
+private: 
 
-  class arbitration_metadata {
-   public:
-    arbitration_metadata(const memory_config *config);
+   unsigned m_id;
+   const memory_config *m_config;
+   class memory_stats_t *m_stats;
+   class memory_sub_partition **m_sub_partition; 
+   class dram_t *m_dram;
 
-    // check if a subpartition still has credit
-    bool has_credits(int inner_sub_partition_id) const;
-    // borrow a credit for a subpartition
-    void borrow_credit(int inner_sub_partition_id);
-    // return a credit from a subpartition
-    void return_credit(int inner_sub_partition_id);
+   class arbitration_metadata
+   {
+   public: 
+      arbitration_metadata(const memory_config *config);
 
-    // return the last subpartition that borrowed credit
-    int last_borrower() const { return m_last_borrower; }
+      // check if a subpartition still has credit 
+      bool has_credits(int inner_sub_partition_id) const; 
+      // borrow a credit for a subpartition 
+      void borrow_credit(int inner_sub_partition_id); 
+      // return a credit from a subpartition 
+      void return_credit(int inner_sub_partition_id); 
 
-    void print(FILE *fp) const;
+      // return the last subpartition that borrowed credit 
+      int last_borrower() const { return m_last_borrower; } 
 
-   private:
-    // id of the last subpartition that borrowed credit
-    int m_last_borrower;
+      void print( FILE *fp ) const; 
+   private: 
+      // id of the last subpartition that borrowed credit 
+      int m_last_borrower; 
 
-    int m_shared_credit_limit;
-    int m_private_credit_limit;
+      int m_shared_credit_limit; 
+      int m_private_credit_limit; 
 
-    // credits borrowed by the subpartitions
-    std::vector<int> m_private_credit;
-    int m_shared_credit;
-  };
-  arbitration_metadata m_arbitration_metadata;
+      // credits borrowed by the subpartitions
+      std::vector<int> m_private_credit; 
+      int m_shared_credit; 
+   }; 
+   arbitration_metadata m_arbitration_metadata;
 
-  // determine wheither a given subpartition can issue to DRAM
-  bool can_issue_to_dram(int inner_sub_partition_id);
+   // determine wheither a given subpartition can issue to DRAM 
+   bool can_issue_to_dram(int inner_sub_partition_id); 
 
-  // model DRAM access scheduler latency (fixed latency between L2 and DRAM)
-  struct dram_delay_t {
-    unsigned long long ready_cycle;
-    class mem_fetch *req;
-  };
-  std::list<dram_delay_t> m_dram_latency_queue;
+   // model DRAM access scheduler latency (fixed latency between L2 and DRAM)
+   struct dram_delay_t
+   {
+      unsigned long long ready_cycle;
+      class mem_fetch* req;
+   };
+   std::list<dram_delay_t> m_dram_latency_queue;
 
-  class gpgpu_sim *m_gpu;
+   class gpgpu_sim* m_gpu;
 };
 
-class memory_sub_partition {
- public:
-  memory_sub_partition(unsigned sub_partition_id, const memory_config *config,
-                       class memory_stats_t *stats, class gpgpu_sim *gpu);
-  ~memory_sub_partition();
+class memory_sub_partition
+{
+public:
+   memory_sub_partition( unsigned sub_partition_id, const memory_config *config, class memory_stats_t *stats, class gpgpu_sim* gpu );
+   ~memory_sub_partition(); 
 
-  unsigned get_id() const { return m_id; }
+   unsigned get_id() const { return m_id; } 
 
-  bool busy() const;
+   bool busy() const;
 
-  void cache_cycle(unsigned cycle);
+   void cache_cycle( unsigned cycle );
 
-  bool full() const;
-  bool full(unsigned size) const;
-  void push(class mem_fetch *mf, unsigned long long clock_cycle);
-  class mem_fetch *pop();
-  class mem_fetch *top();
-  void set_done(mem_fetch *mf);
+   bool full() const;
+   bool full(unsigned size) const;
+   void push( class mem_fetch* mf, unsigned long long clock_cycle );
+   class mem_fetch* pop(); 
+   class mem_fetch* top();
+   void set_done( mem_fetch *mf );
 
-  unsigned flushL2();
-  unsigned invalidateL2();
+   unsigned flushL2();
+   unsigned invalidateL2();
 
-  // interface to L2_dram_queue
-  bool L2_dram_queue_empty() const;
-  class mem_fetch *L2_dram_queue_top() const;
-  void L2_dram_queue_pop();
+   // interface to L2_dram_queue
+   bool L2_dram_queue_empty() const; 
+   class mem_fetch* L2_dram_queue_top() const; 
+   void L2_dram_queue_pop(); 
 
-  // interface to dram_L2_queue
-  bool dram_L2_queue_full() const;
-  void dram_L2_queue_push(class mem_fetch *mf);
+   // interface to dram_L2_queue
+   bool dram_L2_queue_full() const; 
+   void dram_L2_queue_push( class mem_fetch* mf ); 
 
-  void visualizer_print(gzFile visualizer_file);
-  void print_cache_stat(unsigned &accesses, unsigned &misses) const;
-  void print(FILE *fp) const;
+   void visualizer_print( gzFile visualizer_file );
+   void print_cache_stat(unsigned &accesses, unsigned &misses) const;
+   void print( FILE *fp ) const;
 
-  void accumulate_L2cache_stats(class cache_stats &l2_stats) const;
-  void get_L2cache_sub_stats(struct cache_sub_stats &css) const;
+   void accumulate_L2cache_stats(class cache_stats &l2_stats) const;
+   void get_L2cache_sub_stats(struct cache_sub_stats &css) const;
 
-  // Support for getting per-window L2 stats for AerialVision
-  void get_L2cache_sub_stats_pw(struct cache_sub_stats_pw &css) const;
-  void clear_L2cache_stats_pw();
+   // Support for getting per-window L2 stats for AerialVision
+   void get_L2cache_sub_stats_pw(struct cache_sub_stats_pw &css) const;
+   void clear_L2cache_stats_pw();
 
-  void force_l2_tag_update(new_addr_type addr, unsigned time,
-                           mem_access_sector_mask_t mask) {
-    m_L2cache->force_tag_access(addr, m_memcpy_cycle_offset + time, mask);
-    m_memcpy_cycle_offset += 1;
-  }
+   void force_l2_tag_update(new_addr_type addr, unsigned time, mem_access_sector_mask_t mask)
+   {
+        m_L2cache->force_tag_access( addr, m_memcpy_cycle_offset + time, mask );
+        m_memcpy_cycle_offset += 1;
+   }
 
- private:
-  // data
-  unsigned m_id;  //< the global sub partition ID
-  const memory_config *m_config;
-  class l2_cache *m_L2cache;
-  class L2interface *m_L2interface;
-  class gpgpu_sim *m_gpu;
-  partition_mf_allocator *m_mf_allocator;
+private:
+// data
+   unsigned m_id;  //< the global sub partition ID
+   const memory_config *m_config;
+   class l2_cache *m_L2cache;
+   class L2interface *m_L2interface;
+   class gpgpu_sim* m_gpu;
+   partition_mf_allocator *m_mf_allocator;
 
-  // model delay of ROP units with a fixed latency
-  struct rop_delay_t {
-    unsigned long long ready_cycle;
-    class mem_fetch *req;
-  };
-  std::queue<rop_delay_t> m_rop;
+   // model delay of ROP units with a fixed latency
+   struct rop_delay_t
+   {
+    	unsigned long long ready_cycle;
+    	class mem_fetch* req;
+   };
+   std::queue<rop_delay_t> m_rop;
 
-  // these are various FIFOs between units within a memory partition
-  fifo_pipeline<mem_fetch> *m_icnt_L2_queue;
-  fifo_pipeline<mem_fetch> *m_L2_dram_queue;
-  fifo_pipeline<mem_fetch> *m_dram_L2_queue;
-  fifo_pipeline<mem_fetch> *m_L2_icnt_queue;  // L2 cache hit response queue
+   // these are various FIFOs between units within a memory partition
+   fifo_pipeline<mem_fetch> *m_icnt_L2_queue;
+   fifo_pipeline<mem_fetch> *m_L2_dram_queue;
+   fifo_pipeline<mem_fetch> *m_dram_L2_queue;
+   fifo_pipeline<mem_fetch> *m_L2_icnt_queue; // L2 cache hit response queue
 
-  class mem_fetch *L2dramout;
-  unsigned long long int wb_addr;
+   class mem_fetch *L2dramout; 
+   unsigned long long int wb_addr;
 
-  class memory_stats_t *m_stats;
+   class memory_stats_t *m_stats;
 
-  std::set<mem_fetch *> m_request_tracker;
+   std::set<mem_fetch*> m_request_tracker;
 
-  friend class L2interface;
+   friend class L2interface;
 
-  std::vector<mem_fetch *> breakdown_request_to_sector_requests(mem_fetch *mf);
+   std::vector<mem_fetch*> breakdown_request_to_sector_requests(mem_fetch* mf);
 
-  // This is a cycle offset that has to be applied to the l2 accesses to account
-  // for
-  // the cudamemcpy read/writes. We want GPGPU-Sim to only count cycles for
-  // kernel execution
-  // but we want cudamemcpy to go through the L2. Everytime an access is made
-  // from cudamemcpy
-  // this counter is incremented, and when the l2 is accessed (in both
-  // cudamemcpyies and otherwise)
-  // this value is added to the gpgpu-sim cycle counters.
-  unsigned m_memcpy_cycle_offset;
+   // This is a cycle offset that has to be applied to the l2 accesses to account for
+   // the cudamemcpy read/writes. We want GPGPU-Sim to only count cycles for kernel execution
+   // but we want cudamemcpy to go through the L2. Everytime an access is made from cudamemcpy
+   // this counter is incremented, and when the l2 is accessed (in both cudamemcpyies and otherwise)
+   // this value is added to the gpgpu-sim cycle counters.
+   unsigned m_memcpy_cycle_offset;
 };
 
 class L2interface : public mem_fetch_interface {
- public:
-  L2interface(memory_sub_partition *unit) { m_unit = unit; }
-  virtual ~L2interface() {}
-  virtual bool full(unsigned size, bool write) const {
-    // assume read and write packets all same size
-    return m_unit->m_L2_dram_queue->full();
-  }
-  virtual void push(mem_fetch *mf) {
-    mf->set_status(IN_PARTITION_L2_TO_DRAM_QUEUE, 0 /*FIXME*/);
-    m_unit->m_L2_dram_queue->push(mf);
-  }
-
- private:
-  memory_sub_partition *m_unit;
+public:
+    L2interface( memory_sub_partition *unit ) { m_unit=unit; }
+    virtual ~L2interface() {}
+    virtual bool full( unsigned size, bool write) const 
+    {
+        // assume read and write packets all same size
+        return m_unit->m_L2_dram_queue->full();
+    }
+    virtual void push(mem_fetch *mf) 
+    {
+        mf->set_status(IN_PARTITION_L2_TO_DRAM_QUEUE,0/*FIXME*/);
+        m_unit->m_L2_dram_queue->push(mf);
+    }
+private:
+    memory_sub_partition *m_unit;
 };
 
 #endif

--- a/src/gpgpu-sim/l2cache.h
+++ b/src/gpgpu-sim/l2cache.h
@@ -7,29 +7,30 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef MC_PARTITION_INCLUDED
 #define MC_PARTITION_INCLUDED
 
-#include "dram.h"
 #include "../abstract_hardware_model.h"
+#include "dram.h"
 
 #include <list>
 #include <queue>
@@ -37,222 +38,221 @@
 class mem_fetch;
 
 class partition_mf_allocator : public mem_fetch_allocator {
-public:
-    partition_mf_allocator( const memory_config *config )
-    {
-        m_memory_config = config;
-    }
-    virtual mem_fetch * alloc(const class warp_inst_t &inst, const mem_access_t &access, unsigned long long cycle) const
-    {
-        abort();
-        return NULL;
-    }
-    virtual mem_fetch * alloc(new_addr_type addr, mem_access_type type, unsigned size, bool wr, unsigned long long cycle) const;
-private:
-    const memory_config *m_memory_config;
+ public:
+  partition_mf_allocator(const memory_config *config) {
+    m_memory_config = config;
+  }
+  virtual mem_fetch *alloc(const class warp_inst_t &inst,
+                           const mem_access_t &access,
+                           unsigned long long cycle) const {
+    abort();
+    return NULL;
+  }
+  virtual mem_fetch *alloc(new_addr_type addr, mem_access_type type,
+                           unsigned size, bool wr,
+                           unsigned long long cycle) const;
+
+ private:
+  const memory_config *m_memory_config;
 };
 
-// Memory partition unit contains all the units assolcated with a single DRAM channel. 
-// - It arbitrates the DRAM channel among multiple sub partitions.  
-// - It does not connect directly with the interconnection network. 
-class memory_partition_unit
-{
-public: 
-   memory_partition_unit( unsigned partition_id, const memory_config *config, class memory_stats_t *stats, class gpgpu_sim* gpu );
-   ~memory_partition_unit(); 
+// Memory partition unit contains all the units assolcated with a single DRAM
+// channel.
+// - It arbitrates the DRAM channel among multiple sub partitions.
+// - It does not connect directly with the interconnection network.
+class memory_partition_unit {
+ public:
+  memory_partition_unit(unsigned partition_id, const memory_config *config,
+                        class memory_stats_t *stats, class gpgpu_sim *gpu);
+  ~memory_partition_unit();
 
-   bool busy() const;
+  bool busy() const;
 
-   void cache_cycle( unsigned cycle );
-   void dram_cycle();
-   void simple_dram_model_cycle();
+  void cache_cycle(unsigned cycle);
+  void dram_cycle();
+  void simple_dram_model_cycle();
 
-   void set_done( mem_fetch *mf );
+  void set_done(mem_fetch *mf);
 
-   void visualizer_print( gzFile visualizer_file ) const;
-   void print_stat( FILE *fp ) { m_dram->print_stat(fp); }
-   void visualize() const { m_dram->visualize(); }
-   void print( FILE *fp ) const;
-   void handle_memcpy_to_gpu( size_t dst_start_addr, unsigned subpart_id, mem_access_sector_mask_t mask );
+  void visualizer_print(gzFile visualizer_file) const;
+  void print_stat(FILE *fp) { m_dram->print_stat(fp); }
+  void visualize() const { m_dram->visualize(); }
+  void print(FILE *fp) const;
+  void handle_memcpy_to_gpu(size_t dst_start_addr, unsigned subpart_id,
+                            mem_access_sector_mask_t mask);
 
-   class memory_sub_partition * get_sub_partition(int sub_partition_id) 
-   {
-      return m_sub_partition[sub_partition_id]; 
-   }
+  class memory_sub_partition *get_sub_partition(int sub_partition_id) {
+    return m_sub_partition[sub_partition_id];
+  }
 
-   // Power model
-   void set_dram_power_stats(unsigned &n_cmd,
-                             unsigned &n_activity,
-                             unsigned &n_nop,
-                             unsigned &n_act,
-                             unsigned &n_pre,
-                             unsigned &n_rd,
-                             unsigned &n_wr,
-                             unsigned &n_req) const;
+  // Power model
+  void set_dram_power_stats(unsigned &n_cmd, unsigned &n_activity,
+                            unsigned &n_nop, unsigned &n_act, unsigned &n_pre,
+                            unsigned &n_rd, unsigned &n_wr,
+                            unsigned &n_req) const;
 
-   int global_sub_partition_id_to_local_id(int global_sub_partition_id) const; 
+  int global_sub_partition_id_to_local_id(int global_sub_partition_id) const;
 
-   unsigned get_mpid() const { return m_id; }
+  unsigned get_mpid() const { return m_id; }
 
-   class gpgpu_sim* get_mgpu() const { return m_gpu; }
+  class gpgpu_sim *get_mgpu() const {
+    return m_gpu;
+  }
 
-private: 
+ private:
+  unsigned m_id;
+  const memory_config *m_config;
+  class memory_stats_t *m_stats;
+  class memory_sub_partition **m_sub_partition;
+  class dram_t *m_dram;
 
-   unsigned m_id;
-   const memory_config *m_config;
-   class memory_stats_t *m_stats;
-   class memory_sub_partition **m_sub_partition; 
-   class dram_t *m_dram;
+  class arbitration_metadata {
+   public:
+    arbitration_metadata(const memory_config *config);
 
-   class arbitration_metadata
-   {
-   public: 
-      arbitration_metadata(const memory_config *config);
+    // check if a subpartition still has credit
+    bool has_credits(int inner_sub_partition_id) const;
+    // borrow a credit for a subpartition
+    void borrow_credit(int inner_sub_partition_id);
+    // return a credit from a subpartition
+    void return_credit(int inner_sub_partition_id);
 
-      // check if a subpartition still has credit 
-      bool has_credits(int inner_sub_partition_id) const; 
-      // borrow a credit for a subpartition 
-      void borrow_credit(int inner_sub_partition_id); 
-      // return a credit from a subpartition 
-      void return_credit(int inner_sub_partition_id); 
+    // return the last subpartition that borrowed credit
+    int last_borrower() const { return m_last_borrower; }
 
-      // return the last subpartition that borrowed credit 
-      int last_borrower() const { return m_last_borrower; } 
+    void print(FILE *fp) const;
 
-      void print( FILE *fp ) const; 
-   private: 
-      // id of the last subpartition that borrowed credit 
-      int m_last_borrower; 
+   private:
+    // id of the last subpartition that borrowed credit
+    int m_last_borrower;
 
-      int m_shared_credit_limit; 
-      int m_private_credit_limit; 
+    int m_shared_credit_limit;
+    int m_private_credit_limit;
 
-      // credits borrowed by the subpartitions
-      std::vector<int> m_private_credit; 
-      int m_shared_credit; 
-   }; 
-   arbitration_metadata m_arbitration_metadata;
+    // credits borrowed by the subpartitions
+    std::vector<int> m_private_credit;
+    int m_shared_credit;
+  };
+  arbitration_metadata m_arbitration_metadata;
 
-   // determine wheither a given subpartition can issue to DRAM 
-   bool can_issue_to_dram(int inner_sub_partition_id); 
+  // determine wheither a given subpartition can issue to DRAM
+  bool can_issue_to_dram(int inner_sub_partition_id);
 
-   // model DRAM access scheduler latency (fixed latency between L2 and DRAM)
-   struct dram_delay_t
-   {
-      unsigned long long ready_cycle;
-      class mem_fetch* req;
-   };
-   std::list<dram_delay_t> m_dram_latency_queue;
+  // model DRAM access scheduler latency (fixed latency between L2 and DRAM)
+  struct dram_delay_t {
+    unsigned long long ready_cycle;
+    class mem_fetch *req;
+  };
+  std::list<dram_delay_t> m_dram_latency_queue;
 
-   class gpgpu_sim* m_gpu;
+  class gpgpu_sim *m_gpu;
 };
 
-class memory_sub_partition
-{
-public:
-   memory_sub_partition( unsigned sub_partition_id, const memory_config *config, class memory_stats_t *stats, class gpgpu_sim* gpu );
-   ~memory_sub_partition(); 
+class memory_sub_partition {
+ public:
+  memory_sub_partition(unsigned sub_partition_id, const memory_config *config,
+                       class memory_stats_t *stats, class gpgpu_sim *gpu);
+  ~memory_sub_partition();
 
-   unsigned get_id() const { return m_id; } 
+  unsigned get_id() const { return m_id; }
 
-   bool busy() const;
+  bool busy() const;
 
-   void cache_cycle( unsigned cycle );
+  void cache_cycle(unsigned cycle);
 
-   bool full() const;
-   bool full(unsigned size) const;
-   void push( class mem_fetch* mf, unsigned long long clock_cycle );
-   class mem_fetch* pop(); 
-   class mem_fetch* top();
-   void set_done( mem_fetch *mf );
+  bool full() const;
+  bool full(unsigned size) const;
+  void push(class mem_fetch *mf, unsigned long long clock_cycle);
+  class mem_fetch *pop();
+  class mem_fetch *top();
+  void set_done(mem_fetch *mf);
 
-   unsigned flushL2();
-   unsigned invalidateL2();
+  unsigned flushL2();
+  unsigned invalidateL2();
 
-   // interface to L2_dram_queue
-   bool L2_dram_queue_empty() const; 
-   class mem_fetch* L2_dram_queue_top() const; 
-   void L2_dram_queue_pop(); 
+  // interface to L2_dram_queue
+  bool L2_dram_queue_empty() const;
+  class mem_fetch *L2_dram_queue_top() const;
+  void L2_dram_queue_pop();
 
-   // interface to dram_L2_queue
-   bool dram_L2_queue_full() const; 
-   void dram_L2_queue_push( class mem_fetch* mf ); 
+  // interface to dram_L2_queue
+  bool dram_L2_queue_full() const;
+  void dram_L2_queue_push(class mem_fetch *mf);
 
-   void visualizer_print( gzFile visualizer_file );
-   void print_cache_stat(unsigned &accesses, unsigned &misses) const;
-   void print( FILE *fp ) const;
+  void visualizer_print(gzFile visualizer_file);
+  void print_cache_stat(unsigned &accesses, unsigned &misses) const;
+  void print(FILE *fp) const;
 
-   void accumulate_L2cache_stats(class cache_stats &l2_stats) const;
-   void get_L2cache_sub_stats(struct cache_sub_stats &css) const;
+  void accumulate_L2cache_stats(class cache_stats &l2_stats) const;
+  void get_L2cache_sub_stats(struct cache_sub_stats &css) const;
 
-   // Support for getting per-window L2 stats for AerialVision
-   void get_L2cache_sub_stats_pw(struct cache_sub_stats_pw &css) const;
-   void clear_L2cache_stats_pw();
+  // Support for getting per-window L2 stats for AerialVision
+  void get_L2cache_sub_stats_pw(struct cache_sub_stats_pw &css) const;
+  void clear_L2cache_stats_pw();
 
-   void force_l2_tag_update(new_addr_type addr, unsigned time, mem_access_sector_mask_t mask)
-   {
-        m_L2cache->force_tag_access( addr, m_memcpy_cycle_offset + time, mask );
-        m_memcpy_cycle_offset += 1;
-   }
+  void force_l2_tag_update(new_addr_type addr, unsigned time,
+                           mem_access_sector_mask_t mask) {
+    m_L2cache->force_tag_access(addr, m_memcpy_cycle_offset + time, mask);
+    m_memcpy_cycle_offset += 1;
+  }
 
-private:
-// data
-   unsigned m_id;  //< the global sub partition ID
-   const memory_config *m_config;
-   class l2_cache *m_L2cache;
-   class L2interface *m_L2interface;
-   class gpgpu_sim* m_gpu;
-   partition_mf_allocator *m_mf_allocator;
+ private:
+  // data
+  unsigned m_id;  //< the global sub partition ID
+  const memory_config *m_config;
+  class l2_cache *m_L2cache;
+  class L2interface *m_L2interface;
+  class gpgpu_sim *m_gpu;
+  partition_mf_allocator *m_mf_allocator;
 
-   // model delay of ROP units with a fixed latency
-   struct rop_delay_t
-   {
-    	unsigned long long ready_cycle;
-    	class mem_fetch* req;
-   };
-   std::queue<rop_delay_t> m_rop;
+  // model delay of ROP units with a fixed latency
+  struct rop_delay_t {
+    unsigned long long ready_cycle;
+    class mem_fetch *req;
+  };
+  std::queue<rop_delay_t> m_rop;
 
-   // these are various FIFOs between units within a memory partition
-   fifo_pipeline<mem_fetch> *m_icnt_L2_queue;
-   fifo_pipeline<mem_fetch> *m_L2_dram_queue;
-   fifo_pipeline<mem_fetch> *m_dram_L2_queue;
-   fifo_pipeline<mem_fetch> *m_L2_icnt_queue; // L2 cache hit response queue
+  // these are various FIFOs between units within a memory partition
+  fifo_pipeline<mem_fetch> *m_icnt_L2_queue;
+  fifo_pipeline<mem_fetch> *m_L2_dram_queue;
+  fifo_pipeline<mem_fetch> *m_dram_L2_queue;
+  fifo_pipeline<mem_fetch> *m_L2_icnt_queue;  // L2 cache hit response queue
 
-   class mem_fetch *L2dramout; 
-   unsigned long long int wb_addr;
+  class mem_fetch *L2dramout;
+  unsigned long long int wb_addr;
 
-   class memory_stats_t *m_stats;
+  class memory_stats_t *m_stats;
 
-   std::set<mem_fetch*> m_request_tracker;
+  std::set<mem_fetch *> m_request_tracker;
 
-   friend class L2interface;
+  friend class L2interface;
 
-   std::vector<mem_fetch*> breakdown_request_to_sector_requests(mem_fetch* mf);
+  std::vector<mem_fetch *> breakdown_request_to_sector_requests(mem_fetch *mf);
 
-   // This is a cycle offset that has to be applied to the l2 accesses to account for
-   // the cudamemcpy read/writes. We want GPGPU-Sim to only count cycles for kernel execution
-   // but we want cudamemcpy to go through the L2. Everytime an access is made from cudamemcpy
-   // this counter is incremented, and when the l2 is accessed (in both cudamemcpyies and otherwise)
-   // this value is added to the gpgpu-sim cycle counters.
-   unsigned m_memcpy_cycle_offset;
+  // This is a cycle offset that has to be applied to the l2 accesses to account
+  // for the cudamemcpy read/writes. We want GPGPU-Sim to only count cycles for
+  // kernel execution but we want cudamemcpy to go through the L2. Everytime an
+  // access is made from cudamemcpy this counter is incremented, and when the l2
+  // is accessed (in both cudamemcpyies and otherwise) this value is added to
+  // the gpgpu-sim cycle counters.
+  unsigned m_memcpy_cycle_offset;
 };
 
 class L2interface : public mem_fetch_interface {
-public:
-    L2interface( memory_sub_partition *unit ) { m_unit=unit; }
-    virtual ~L2interface() {}
-    virtual bool full( unsigned size, bool write) const 
-    {
-        // assume read and write packets all same size
-        return m_unit->m_L2_dram_queue->full();
-    }
-    virtual void push(mem_fetch *mf) 
-    {
-        mf->set_status(IN_PARTITION_L2_TO_DRAM_QUEUE,0/*FIXME*/);
-        m_unit->m_L2_dram_queue->push(mf);
-    }
-private:
-    memory_sub_partition *m_unit;
+ public:
+  L2interface(memory_sub_partition *unit) { m_unit = unit; }
+  virtual ~L2interface() {}
+  virtual bool full(unsigned size, bool write) const {
+    // assume read and write packets all same size
+    return m_unit->m_L2_dram_queue->full();
+  }
+  virtual void push(mem_fetch *mf) {
+    mf->set_status(IN_PARTITION_L2_TO_DRAM_QUEUE, 0 /*FIXME*/);
+    m_unit->m_L2_dram_queue->push(mf);
+  }
+
+ private:
+  memory_sub_partition *m_unit;
 };
 
 #endif

--- a/src/gpgpu-sim/l2cache.h
+++ b/src/gpgpu-sim/l2cache.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -28,8 +30,8 @@
 #ifndef MC_PARTITION_INCLUDED
 #define MC_PARTITION_INCLUDED
 
-#include "dram.h"
 #include "../abstract_hardware_model.h"
+#include "dram.h"
 
 #include <list>
 #include <queue>
@@ -37,222 +39,224 @@
 class mem_fetch;
 
 class partition_mf_allocator : public mem_fetch_allocator {
-public:
-    partition_mf_allocator( const memory_config *config )
-    {
-        m_memory_config = config;
-    }
-    virtual mem_fetch * alloc(const class warp_inst_t &inst, const mem_access_t &access, unsigned long long cycle) const
-    {
-        abort();
-        return NULL;
-    }
-    virtual mem_fetch * alloc(new_addr_type addr, mem_access_type type, unsigned size, bool wr, unsigned long long cycle) const;
-private:
-    const memory_config *m_memory_config;
+ public:
+  partition_mf_allocator(const memory_config *config) {
+    m_memory_config = config;
+  }
+  virtual mem_fetch *alloc(const class warp_inst_t &inst,
+                           const mem_access_t &access,
+                           unsigned long long cycle) const {
+    abort();
+    return NULL;
+  }
+  virtual mem_fetch *alloc(new_addr_type addr, mem_access_type type,
+                           unsigned size, bool wr,
+                           unsigned long long cycle) const;
+
+ private:
+  const memory_config *m_memory_config;
 };
 
-// Memory partition unit contains all the units assolcated with a single DRAM channel. 
-// - It arbitrates the DRAM channel among multiple sub partitions.  
-// - It does not connect directly with the interconnection network. 
-class memory_partition_unit
-{
-public: 
-   memory_partition_unit( unsigned partition_id, const memory_config *config, class memory_stats_t *stats, class gpgpu_sim* gpu );
-   ~memory_partition_unit(); 
+// Memory partition unit contains all the units assolcated with a single DRAM
+// channel.
+// - It arbitrates the DRAM channel among multiple sub partitions.
+// - It does not connect directly with the interconnection network.
+class memory_partition_unit {
+ public:
+  memory_partition_unit(unsigned partition_id, const memory_config *config,
+                        class memory_stats_t *stats, class gpgpu_sim *gpu);
+  ~memory_partition_unit();
 
-   bool busy() const;
+  bool busy() const;
 
-   void cache_cycle( unsigned cycle );
-   void dram_cycle();
-   void simple_dram_model_cycle();
+  void cache_cycle(unsigned cycle);
+  void dram_cycle();
+  void simple_dram_model_cycle();
 
-   void set_done( mem_fetch *mf );
+  void set_done(mem_fetch *mf);
 
-   void visualizer_print( gzFile visualizer_file ) const;
-   void print_stat( FILE *fp ) { m_dram->print_stat(fp); }
-   void visualize() const { m_dram->visualize(); }
-   void print( FILE *fp ) const;
-   void handle_memcpy_to_gpu( size_t dst_start_addr, unsigned subpart_id, mem_access_sector_mask_t mask );
+  void visualizer_print(gzFile visualizer_file) const;
+  void print_stat(FILE *fp) { m_dram->print_stat(fp); }
+  void visualize() const { m_dram->visualize(); }
+  void print(FILE *fp) const;
+  void handle_memcpy_to_gpu(size_t dst_start_addr, unsigned subpart_id,
+                            mem_access_sector_mask_t mask);
 
-   class memory_sub_partition * get_sub_partition(int sub_partition_id) 
-   {
-      return m_sub_partition[sub_partition_id]; 
-   }
+  class memory_sub_partition *get_sub_partition(int sub_partition_id) {
+    return m_sub_partition[sub_partition_id];
+  }
 
-   // Power model
-   void set_dram_power_stats(unsigned &n_cmd,
-                             unsigned &n_activity,
-                             unsigned &n_nop,
-                             unsigned &n_act,
-                             unsigned &n_pre,
-                             unsigned &n_rd,
-                             unsigned &n_wr,
-                             unsigned &n_req) const;
+  // Power model
+  void set_dram_power_stats(unsigned &n_cmd, unsigned &n_activity,
+                            unsigned &n_nop, unsigned &n_act, unsigned &n_pre,
+                            unsigned &n_rd, unsigned &n_wr,
+                            unsigned &n_req) const;
 
-   int global_sub_partition_id_to_local_id(int global_sub_partition_id) const; 
+  int global_sub_partition_id_to_local_id(int global_sub_partition_id) const;
 
-   unsigned get_mpid() const { return m_id; }
+  unsigned get_mpid() const { return m_id; }
 
-   class gpgpu_sim* get_mgpu() const { return m_gpu; }
+  class gpgpu_sim *get_mgpu() const {
+    return m_gpu;
+  }
 
-private: 
+ private:
+  unsigned m_id;
+  const memory_config *m_config;
+  class memory_stats_t *m_stats;
+  class memory_sub_partition **m_sub_partition;
+  class dram_t *m_dram;
 
-   unsigned m_id;
-   const memory_config *m_config;
-   class memory_stats_t *m_stats;
-   class memory_sub_partition **m_sub_partition; 
-   class dram_t *m_dram;
+  class arbitration_metadata {
+   public:
+    arbitration_metadata(const memory_config *config);
 
-   class arbitration_metadata
-   {
-   public: 
-      arbitration_metadata(const memory_config *config);
+    // check if a subpartition still has credit
+    bool has_credits(int inner_sub_partition_id) const;
+    // borrow a credit for a subpartition
+    void borrow_credit(int inner_sub_partition_id);
+    // return a credit from a subpartition
+    void return_credit(int inner_sub_partition_id);
 
-      // check if a subpartition still has credit 
-      bool has_credits(int inner_sub_partition_id) const; 
-      // borrow a credit for a subpartition 
-      void borrow_credit(int inner_sub_partition_id); 
-      // return a credit from a subpartition 
-      void return_credit(int inner_sub_partition_id); 
+    // return the last subpartition that borrowed credit
+    int last_borrower() const { return m_last_borrower; }
 
-      // return the last subpartition that borrowed credit 
-      int last_borrower() const { return m_last_borrower; } 
+    void print(FILE *fp) const;
 
-      void print( FILE *fp ) const; 
-   private: 
-      // id of the last subpartition that borrowed credit 
-      int m_last_borrower; 
+   private:
+    // id of the last subpartition that borrowed credit
+    int m_last_borrower;
 
-      int m_shared_credit_limit; 
-      int m_private_credit_limit; 
+    int m_shared_credit_limit;
+    int m_private_credit_limit;
 
-      // credits borrowed by the subpartitions
-      std::vector<int> m_private_credit; 
-      int m_shared_credit; 
-   }; 
-   arbitration_metadata m_arbitration_metadata;
+    // credits borrowed by the subpartitions
+    std::vector<int> m_private_credit;
+    int m_shared_credit;
+  };
+  arbitration_metadata m_arbitration_metadata;
 
-   // determine wheither a given subpartition can issue to DRAM 
-   bool can_issue_to_dram(int inner_sub_partition_id); 
+  // determine wheither a given subpartition can issue to DRAM
+  bool can_issue_to_dram(int inner_sub_partition_id);
 
-   // model DRAM access scheduler latency (fixed latency between L2 and DRAM)
-   struct dram_delay_t
-   {
-      unsigned long long ready_cycle;
-      class mem_fetch* req;
-   };
-   std::list<dram_delay_t> m_dram_latency_queue;
+  // model DRAM access scheduler latency (fixed latency between L2 and DRAM)
+  struct dram_delay_t {
+    unsigned long long ready_cycle;
+    class mem_fetch *req;
+  };
+  std::list<dram_delay_t> m_dram_latency_queue;
 
-   class gpgpu_sim* m_gpu;
+  class gpgpu_sim *m_gpu;
 };
 
-class memory_sub_partition
-{
-public:
-   memory_sub_partition( unsigned sub_partition_id, const memory_config *config, class memory_stats_t *stats, class gpgpu_sim* gpu );
-   ~memory_sub_partition(); 
+class memory_sub_partition {
+ public:
+  memory_sub_partition(unsigned sub_partition_id, const memory_config *config,
+                       class memory_stats_t *stats, class gpgpu_sim *gpu);
+  ~memory_sub_partition();
 
-   unsigned get_id() const { return m_id; } 
+  unsigned get_id() const { return m_id; }
 
-   bool busy() const;
+  bool busy() const;
 
-   void cache_cycle( unsigned cycle );
+  void cache_cycle(unsigned cycle);
 
-   bool full() const;
-   bool full(unsigned size) const;
-   void push( class mem_fetch* mf, unsigned long long clock_cycle );
-   class mem_fetch* pop(); 
-   class mem_fetch* top();
-   void set_done( mem_fetch *mf );
+  bool full() const;
+  bool full(unsigned size) const;
+  void push(class mem_fetch *mf, unsigned long long clock_cycle);
+  class mem_fetch *pop();
+  class mem_fetch *top();
+  void set_done(mem_fetch *mf);
 
-   unsigned flushL2();
-   unsigned invalidateL2();
+  unsigned flushL2();
+  unsigned invalidateL2();
 
-   // interface to L2_dram_queue
-   bool L2_dram_queue_empty() const; 
-   class mem_fetch* L2_dram_queue_top() const; 
-   void L2_dram_queue_pop(); 
+  // interface to L2_dram_queue
+  bool L2_dram_queue_empty() const;
+  class mem_fetch *L2_dram_queue_top() const;
+  void L2_dram_queue_pop();
 
-   // interface to dram_L2_queue
-   bool dram_L2_queue_full() const; 
-   void dram_L2_queue_push( class mem_fetch* mf ); 
+  // interface to dram_L2_queue
+  bool dram_L2_queue_full() const;
+  void dram_L2_queue_push(class mem_fetch *mf);
 
-   void visualizer_print( gzFile visualizer_file );
-   void print_cache_stat(unsigned &accesses, unsigned &misses) const;
-   void print( FILE *fp ) const;
+  void visualizer_print(gzFile visualizer_file);
+  void print_cache_stat(unsigned &accesses, unsigned &misses) const;
+  void print(FILE *fp) const;
 
-   void accumulate_L2cache_stats(class cache_stats &l2_stats) const;
-   void get_L2cache_sub_stats(struct cache_sub_stats &css) const;
+  void accumulate_L2cache_stats(class cache_stats &l2_stats) const;
+  void get_L2cache_sub_stats(struct cache_sub_stats &css) const;
 
-   // Support for getting per-window L2 stats for AerialVision
-   void get_L2cache_sub_stats_pw(struct cache_sub_stats_pw &css) const;
-   void clear_L2cache_stats_pw();
+  // Support for getting per-window L2 stats for AerialVision
+  void get_L2cache_sub_stats_pw(struct cache_sub_stats_pw &css) const;
+  void clear_L2cache_stats_pw();
 
-   void force_l2_tag_update(new_addr_type addr, unsigned time, mem_access_sector_mask_t mask)
-   {
-        m_L2cache->force_tag_access( addr, m_memcpy_cycle_offset + time, mask );
-        m_memcpy_cycle_offset += 1;
-   }
+  void force_l2_tag_update(new_addr_type addr, unsigned time,
+                           mem_access_sector_mask_t mask) {
+    m_L2cache->force_tag_access(addr, m_memcpy_cycle_offset + time, mask);
+    m_memcpy_cycle_offset += 1;
+  }
 
-private:
-// data
-   unsigned m_id;  //< the global sub partition ID
-   const memory_config *m_config;
-   class l2_cache *m_L2cache;
-   class L2interface *m_L2interface;
-   class gpgpu_sim* m_gpu;
-   partition_mf_allocator *m_mf_allocator;
+ private:
+  // data
+  unsigned m_id;  //< the global sub partition ID
+  const memory_config *m_config;
+  class l2_cache *m_L2cache;
+  class L2interface *m_L2interface;
+  class gpgpu_sim *m_gpu;
+  partition_mf_allocator *m_mf_allocator;
 
-   // model delay of ROP units with a fixed latency
-   struct rop_delay_t
-   {
-    	unsigned long long ready_cycle;
-    	class mem_fetch* req;
-   };
-   std::queue<rop_delay_t> m_rop;
+  // model delay of ROP units with a fixed latency
+  struct rop_delay_t {
+    unsigned long long ready_cycle;
+    class mem_fetch *req;
+  };
+  std::queue<rop_delay_t> m_rop;
 
-   // these are various FIFOs between units within a memory partition
-   fifo_pipeline<mem_fetch> *m_icnt_L2_queue;
-   fifo_pipeline<mem_fetch> *m_L2_dram_queue;
-   fifo_pipeline<mem_fetch> *m_dram_L2_queue;
-   fifo_pipeline<mem_fetch> *m_L2_icnt_queue; // L2 cache hit response queue
+  // these are various FIFOs between units within a memory partition
+  fifo_pipeline<mem_fetch> *m_icnt_L2_queue;
+  fifo_pipeline<mem_fetch> *m_L2_dram_queue;
+  fifo_pipeline<mem_fetch> *m_dram_L2_queue;
+  fifo_pipeline<mem_fetch> *m_L2_icnt_queue;  // L2 cache hit response queue
 
-   class mem_fetch *L2dramout; 
-   unsigned long long int wb_addr;
+  class mem_fetch *L2dramout;
+  unsigned long long int wb_addr;
 
-   class memory_stats_t *m_stats;
+  class memory_stats_t *m_stats;
 
-   std::set<mem_fetch*> m_request_tracker;
+  std::set<mem_fetch *> m_request_tracker;
 
-   friend class L2interface;
+  friend class L2interface;
 
-   std::vector<mem_fetch*> breakdown_request_to_sector_requests(mem_fetch* mf);
+  std::vector<mem_fetch *> breakdown_request_to_sector_requests(mem_fetch *mf);
 
-   // This is a cycle offset that has to be applied to the l2 accesses to account for
-   // the cudamemcpy read/writes. We want GPGPU-Sim to only count cycles for kernel execution
-   // but we want cudamemcpy to go through the L2. Everytime an access is made from cudamemcpy
-   // this counter is incremented, and when the l2 is accessed (in both cudamemcpyies and otherwise)
-   // this value is added to the gpgpu-sim cycle counters.
-   unsigned m_memcpy_cycle_offset;
+  // This is a cycle offset that has to be applied to the l2 accesses to account
+  // for
+  // the cudamemcpy read/writes. We want GPGPU-Sim to only count cycles for
+  // kernel execution
+  // but we want cudamemcpy to go through the L2. Everytime an access is made
+  // from cudamemcpy
+  // this counter is incremented, and when the l2 is accessed (in both
+  // cudamemcpyies and otherwise)
+  // this value is added to the gpgpu-sim cycle counters.
+  unsigned m_memcpy_cycle_offset;
 };
 
 class L2interface : public mem_fetch_interface {
-public:
-    L2interface( memory_sub_partition *unit ) { m_unit=unit; }
-    virtual ~L2interface() {}
-    virtual bool full( unsigned size, bool write) const 
-    {
-        // assume read and write packets all same size
-        return m_unit->m_L2_dram_queue->full();
-    }
-    virtual void push(mem_fetch *mf) 
-    {
-        mf->set_status(IN_PARTITION_L2_TO_DRAM_QUEUE,0/*FIXME*/);
-        m_unit->m_L2_dram_queue->push(mf);
-    }
-private:
-    memory_sub_partition *m_unit;
+ public:
+  L2interface(memory_sub_partition *unit) { m_unit = unit; }
+  virtual ~L2interface() {}
+  virtual bool full(unsigned size, bool write) const {
+    // assume read and write packets all same size
+    return m_unit->m_L2_dram_queue->full();
+  }
+  virtual void push(mem_fetch *mf) {
+    mf->set_status(IN_PARTITION_L2_TO_DRAM_QUEUE, 0 /*FIXME*/);
+    m_unit->m_L2_dram_queue->push(mf);
+  }
+
+ private:
+  memory_sub_partition *m_unit;
 };
 
 #endif

--- a/src/gpgpu-sim/l2cache_trace.h
+++ b/src/gpgpu-sim/l2cache_trace.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2011, Tor M. Aamodt, Tim Rogers, Wilson W. L. Fung 
+// Copyright (c) 2009-2011, Tor M. Aamodt, Tim Rogers, Wilson W. L. Fung
 // The University of British Columbia
 // All rights reserved.
 //
@@ -7,65 +7,73 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
-#pragma once 
+#pragma once
 
 #include "../trace.h"
 
 #if TRACING_ON
 
 #define MEMPART_PRINT_STR SIM_PRINT_STR " %d - "
-#define MEMPART_DTRACE(x)  ( DTRACE(x) && (Trace::sampling_memory_partition == -1 || Trace::sampling_memory_partition == (int)get_mpid()) )
+#define MEMPART_DTRACE(x)                                  \
+  (DTRACE(x) && (Trace::sampling_memory_partition == -1 || \
+                 Trace::sampling_memory_partition == (int)get_mpid()))
 
 #define MEM_SUBPART_PRINT_STR SIM_PRINT_STR " %d - "
-#define MEM_SUBPART_DTRACE(x)  ( DTRACE(x) && (Trace::sampling_memory_partition == -1 || Trace::sampling_memory_partition == (int)m_id) )
+#define MEM_SUBPART_DTRACE(x)                              \
+  (DTRACE(x) && (Trace::sampling_memory_partition == -1 || \
+                 Trace::sampling_memory_partition == (int)m_id))
 
 // Intended to be called from inside components of a memory partition
 // Depends on a get_mpid() function
-#define MEMPART_DPRINTF(...) do {\
-    if (MEMPART_DTRACE(MEMORY_PARTITION_UNIT)) {\
-        printf( MEMPART_PRINT_STR,\
-                m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle,\
-                Trace::trace_streams_str[Trace::MEMORY_PARTITION_UNIT],\
-                get_mpid() );\
-        printf(__VA_ARGS__);\
-    }\
-} while (0)
+#define MEMPART_DPRINTF(...)                                                   \
+  do {                                                                         \
+    if (MEMPART_DTRACE(MEMORY_PARTITION_UNIT)) {                               \
+      printf(                                                                  \
+          MEMPART_PRINT_STR, m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle,  \
+          Trace::trace_streams_str[Trace::MEMORY_PARTITION_UNIT], get_mpid()); \
+      printf(__VA_ARGS__);                                                     \
+    }                                                                          \
+  } while (0)
 
-#define MEM_SUBPART_DPRINTF(...) do {\
-    if (MEM_SUBPART_DTRACE(MEMORY_PARTITION_UNIT)) {\
-        printf( MEM_SUBPART_PRINT_STR,\
-                m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle,\
-                Trace::trace_streams_str[Trace::MEMORY_SUBPARTITION_UNIT],\
-                m_id );\
-        printf(__VA_ARGS__);\
-    }\
-} while (0)
+#define MEM_SUBPART_DPRINTF(...)                                               \
+  do {                                                                         \
+    if (MEM_SUBPART_DTRACE(MEMORY_PARTITION_UNIT)) {                           \
+      printf(MEM_SUBPART_PRINT_STR,                                            \
+             m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle,                  \
+             Trace::trace_streams_str[Trace::MEMORY_SUBPARTITION_UNIT], m_id); \
+      printf(__VA_ARGS__);                                                     \
+    }                                                                          \
+  } while (0)
 
 #else
 
-#define MEMPART_DTRACE(x)  (false)
-#define MEMPART_DPRINTF(x, ...) do {} while (0)
+#define MEMPART_DTRACE(x) (false)
+#define MEMPART_DPRINTF(x, ...) \
+  do {                          \
+  } while (0)
 
-#define MEM_SUBPART_DTRACE(x)  (false)
-#define MEM_SUBPART_DPRINTF(x, ...) do {} while (0)
+#define MEM_SUBPART_DTRACE(x) (false)
+#define MEM_SUBPART_DPRINTF(x, ...) \
+  do {                              \
+  } while (0)
 
 #endif
-

--- a/src/gpgpu-sim/l2cache_trace.h
+++ b/src/gpgpu-sim/l2cache_trace.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2011, Tor M. Aamodt, Tim Rogers, Wilson W. L. Fung
+// Copyright (c) 2009-2011, Tor M. Aamodt, Tim Rogers, Wilson W. L. Fung 
 // The University of British Columbia
 // All rights reserved.
 //
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -27,54 +25,47 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#pragma once
+#pragma once 
 
 #include "../trace.h"
 
 #if TRACING_ON
 
 #define MEMPART_PRINT_STR SIM_PRINT_STR " %d - "
-#define MEMPART_DTRACE(x)                                  \
-  (DTRACE(x) && (Trace::sampling_memory_partition == -1 || \
-                 Trace::sampling_memory_partition == (int)get_mpid()))
+#define MEMPART_DTRACE(x)  ( DTRACE(x) && (Trace::sampling_memory_partition == -1 || Trace::sampling_memory_partition == (int)get_mpid()) )
 
 #define MEM_SUBPART_PRINT_STR SIM_PRINT_STR " %d - "
-#define MEM_SUBPART_DTRACE(x)                              \
-  (DTRACE(x) && (Trace::sampling_memory_partition == -1 || \
-                 Trace::sampling_memory_partition == (int)m_id))
+#define MEM_SUBPART_DTRACE(x)  ( DTRACE(x) && (Trace::sampling_memory_partition == -1 || Trace::sampling_memory_partition == (int)m_id) )
 
 // Intended to be called from inside components of a memory partition
 // Depends on a get_mpid() function
-#define MEMPART_DPRINTF(...)                                                   \
-  do {                                                                         \
-    if (MEMPART_DTRACE(MEMORY_PARTITION_UNIT)) {                               \
-      printf(                                                                  \
-          MEMPART_PRINT_STR, m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle,  \
-          Trace::trace_streams_str[Trace::MEMORY_PARTITION_UNIT], get_mpid()); \
-      printf(__VA_ARGS__);                                                     \
-    }                                                                          \
-  } while (0)
+#define MEMPART_DPRINTF(...) do {\
+    if (MEMPART_DTRACE(MEMORY_PARTITION_UNIT)) {\
+        printf( MEMPART_PRINT_STR,\
+                m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle,\
+                Trace::trace_streams_str[Trace::MEMORY_PARTITION_UNIT],\
+                get_mpid() );\
+        printf(__VA_ARGS__);\
+    }\
+} while (0)
 
-#define MEM_SUBPART_DPRINTF(...)                                               \
-  do {                                                                         \
-    if (MEM_SUBPART_DTRACE(MEMORY_PARTITION_UNIT)) {                           \
-      printf(MEM_SUBPART_PRINT_STR,                                            \
-             m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle,                  \
-             Trace::trace_streams_str[Trace::MEMORY_SUBPARTITION_UNIT], m_id); \
-      printf(__VA_ARGS__);                                                     \
-    }                                                                          \
-  } while (0)
+#define MEM_SUBPART_DPRINTF(...) do {\
+    if (MEM_SUBPART_DTRACE(MEMORY_PARTITION_UNIT)) {\
+        printf( MEM_SUBPART_PRINT_STR,\
+                m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle,\
+                Trace::trace_streams_str[Trace::MEMORY_SUBPARTITION_UNIT],\
+                m_id );\
+        printf(__VA_ARGS__);\
+    }\
+} while (0)
 
 #else
 
-#define MEMPART_DTRACE(x) (false)
-#define MEMPART_DPRINTF(x, ...) \
-  do {                          \
-  } while (0)
+#define MEMPART_DTRACE(x)  (false)
+#define MEMPART_DPRINTF(x, ...) do {} while (0)
 
-#define MEM_SUBPART_DTRACE(x) (false)
-#define MEM_SUBPART_DPRINTF(x, ...) \
-  do {                              \
-  } while (0)
+#define MEM_SUBPART_DTRACE(x)  (false)
+#define MEM_SUBPART_DPRINTF(x, ...) do {} while (0)
 
 #endif
+

--- a/src/gpgpu-sim/l2cache_trace.h
+++ b/src/gpgpu-sim/l2cache_trace.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2011, Tor M. Aamodt, Tim Rogers, Wilson W. L. Fung 
+// Copyright (c) 2009-2011, Tor M. Aamodt, Tim Rogers, Wilson W. L. Fung
 // The University of British Columbia
 // All rights reserved.
 //
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -25,47 +27,54 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#pragma once 
+#pragma once
 
 #include "../trace.h"
 
 #if TRACING_ON
 
 #define MEMPART_PRINT_STR SIM_PRINT_STR " %d - "
-#define MEMPART_DTRACE(x)  ( DTRACE(x) && (Trace::sampling_memory_partition == -1 || Trace::sampling_memory_partition == (int)get_mpid()) )
+#define MEMPART_DTRACE(x)                                  \
+  (DTRACE(x) && (Trace::sampling_memory_partition == -1 || \
+                 Trace::sampling_memory_partition == (int)get_mpid()))
 
 #define MEM_SUBPART_PRINT_STR SIM_PRINT_STR " %d - "
-#define MEM_SUBPART_DTRACE(x)  ( DTRACE(x) && (Trace::sampling_memory_partition == -1 || Trace::sampling_memory_partition == (int)m_id) )
+#define MEM_SUBPART_DTRACE(x)                              \
+  (DTRACE(x) && (Trace::sampling_memory_partition == -1 || \
+                 Trace::sampling_memory_partition == (int)m_id))
 
 // Intended to be called from inside components of a memory partition
 // Depends on a get_mpid() function
-#define MEMPART_DPRINTF(...) do {\
-    if (MEMPART_DTRACE(MEMORY_PARTITION_UNIT)) {\
-        printf( MEMPART_PRINT_STR,\
-                m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle,\
-                Trace::trace_streams_str[Trace::MEMORY_PARTITION_UNIT],\
-                get_mpid() );\
-        printf(__VA_ARGS__);\
-    }\
-} while (0)
+#define MEMPART_DPRINTF(...)                                                   \
+  do {                                                                         \
+    if (MEMPART_DTRACE(MEMORY_PARTITION_UNIT)) {                               \
+      printf(                                                                  \
+          MEMPART_PRINT_STR, m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle,  \
+          Trace::trace_streams_str[Trace::MEMORY_PARTITION_UNIT], get_mpid()); \
+      printf(__VA_ARGS__);                                                     \
+    }                                                                          \
+  } while (0)
 
-#define MEM_SUBPART_DPRINTF(...) do {\
-    if (MEM_SUBPART_DTRACE(MEMORY_PARTITION_UNIT)) {\
-        printf( MEM_SUBPART_PRINT_STR,\
-                m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle,\
-                Trace::trace_streams_str[Trace::MEMORY_SUBPARTITION_UNIT],\
-                m_id );\
-        printf(__VA_ARGS__);\
-    }\
-} while (0)
+#define MEM_SUBPART_DPRINTF(...)                                               \
+  do {                                                                         \
+    if (MEM_SUBPART_DTRACE(MEMORY_PARTITION_UNIT)) {                           \
+      printf(MEM_SUBPART_PRINT_STR,                                            \
+             m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle,                  \
+             Trace::trace_streams_str[Trace::MEMORY_SUBPARTITION_UNIT], m_id); \
+      printf(__VA_ARGS__);                                                     \
+    }                                                                          \
+  } while (0)
 
 #else
 
-#define MEMPART_DTRACE(x)  (false)
-#define MEMPART_DPRINTF(x, ...) do {} while (0)
+#define MEMPART_DTRACE(x) (false)
+#define MEMPART_DPRINTF(x, ...) \
+  do {                          \
+  } while (0)
 
-#define MEM_SUBPART_DTRACE(x)  (false)
-#define MEM_SUBPART_DPRINTF(x, ...) do {} while (0)
+#define MEM_SUBPART_DTRACE(x) (false)
+#define MEM_SUBPART_DPRINTF(x, ...) \
+  do {                              \
+  } while (0)
 
 #endif
-

--- a/src/gpgpu-sim/local_interconnect.cc
+++ b/src/gpgpu-sim/local_interconnect.cc
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -25,353 +27,343 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include <algorithm>
+#include <cmath>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <sstream>
-#include <iomanip>
-#include <cmath>
 #include <utility>
-#include <algorithm>
 
 #include "local_interconnect.h"
 #include "mem_fetch.h"
 
-xbar_router::xbar_router(unsigned router_id, enum Interconnect_type m_type, unsigned n_shader, unsigned n_mem, unsigned m_in_buffer_limit, unsigned m_out_buffer_limit, enum Arbiteration_type m_arbit_type)
-{
-	m_id=router_id;
-	router_type=m_type;
-	_n_mem = n_mem;
-	_n_shader = n_shader;
-	total_nodes = n_shader+n_mem;
-	in_buffers.resize(total_nodes);
-	out_buffers.resize(total_nodes);
-	next_node.resize(total_nodes,0);
-	in_buffer_limit = m_in_buffer_limit;
-	out_buffer_limit = m_out_buffer_limit;
-	arbit_type = m_arbit_type;
-	next_node_id=0;
-	if(m_type == REQ_NET) {
-		active_in_buffers=n_shader;
-		active_out_buffers=n_mem;
-	}
-	else if(m_type == REPLY_NET) {
-		active_in_buffers=n_mem;
-		active_out_buffers=n_shader;
-	}
+xbar_router::xbar_router(unsigned router_id, enum Interconnect_type m_type,
+                         unsigned n_shader, unsigned n_mem,
+                         unsigned m_in_buffer_limit,
+                         unsigned m_out_buffer_limit,
+                         enum Arbiteration_type m_arbit_type) {
+  m_id = router_id;
+  router_type = m_type;
+  _n_mem = n_mem;
+  _n_shader = n_shader;
+  total_nodes = n_shader + n_mem;
+  in_buffers.resize(total_nodes);
+  out_buffers.resize(total_nodes);
+  next_node.resize(total_nodes, 0);
+  in_buffer_limit = m_in_buffer_limit;
+  out_buffer_limit = m_out_buffer_limit;
+  arbit_type = m_arbit_type;
+  next_node_id = 0;
+  if (m_type == REQ_NET) {
+    active_in_buffers = n_shader;
+    active_out_buffers = n_mem;
+  } else if (m_type == REPLY_NET) {
+    active_in_buffers = n_mem;
+    active_out_buffers = n_shader;
+  }
 
-	cycles = 0;
-	conflicts= 0;
-	out_buffer_full=0;
-	in_buffer_full=0;
-	out_buffer_util=0;
-	in_buffer_util=0;
-	packets_num=0;
+  cycles = 0;
+  conflicts = 0;
+  out_buffer_full = 0;
+  in_buffer_full = 0;
+  out_buffer_util = 0;
+  in_buffer_util = 0;
+  packets_num = 0;
 }
 
+xbar_router::~xbar_router() {}
 
-xbar_router::~xbar_router()
-{
-
+void xbar_router::Push(unsigned input_deviceID, unsigned output_deviceID,
+                       void* data, unsigned int size) {
+  assert(input_deviceID < total_nodes);
+  in_buffers[input_deviceID].push(Packet(data, output_deviceID));
+  packets_num++;
 }
 
-void xbar_router::Push(unsigned input_deviceID, unsigned output_deviceID, void* data, unsigned int size)
-{
-	assert(input_deviceID < total_nodes);
-	in_buffers[input_deviceID].push(Packet(data, output_deviceID));
-	packets_num++;
+void* xbar_router::Pop(unsigned ouput_deviceID) {
+  assert(ouput_deviceID < total_nodes);
+  void* data = NULL;
+
+  if (!out_buffers[ouput_deviceID].empty()) {
+    data = out_buffers[ouput_deviceID].front().data;
+    out_buffers[ouput_deviceID].pop();
+  }
+
+  return data;
 }
 
-void* xbar_router::Pop(unsigned ouput_deviceID)
-{
-	assert(ouput_deviceID < total_nodes);
-	void* data = NULL;
+bool xbar_router::Has_Buffer_In(unsigned input_deviceID, unsigned size,
+                                bool update_counter) {
+  assert(input_deviceID < total_nodes);
 
-	if(!out_buffers[ouput_deviceID].empty()) {
-		data = out_buffers[ouput_deviceID].front().data;
-		out_buffers[ouput_deviceID].pop();
-	}
+  bool has_buffer =
+      (in_buffers[input_deviceID].size() + size <= in_buffer_limit);
+  if (update_counter && !has_buffer) in_buffer_full++;
 
-	return data;
+  return has_buffer;
 }
 
-
-bool xbar_router::Has_Buffer_In(unsigned input_deviceID, unsigned size, bool update_counter){
-
-	assert(input_deviceID < total_nodes);
-
-	bool has_buffer = (in_buffers[input_deviceID].size() + size <= in_buffer_limit);
-	if(update_counter && !has_buffer)
-		in_buffer_full++;
-
-	return has_buffer;
-
-}
-
-bool xbar_router::Has_Buffer_Out(unsigned output_deviceID, unsigned size){
-	return (out_buffers[output_deviceID].size() + size <= out_buffer_limit);
+bool xbar_router::Has_Buffer_Out(unsigned output_deviceID, unsigned size) {
+  return (out_buffers[output_deviceID].size() + size <= out_buffer_limit);
 }
 
 void xbar_router::Advance() {
-
-	if(arbit_type == NAIVE_RR)
-		RR_Advance();
-	else if(arbit_type == iSLIP)
-		iSLIP_Advance();
-	else
-		assert(0);
-
+  if (arbit_type == NAIVE_RR)
+    RR_Advance();
+  else if (arbit_type == iSLIP)
+    iSLIP_Advance();
+  else
+    assert(0);
 }
 
 void xbar_router::RR_Advance() {
-	cycles++;
+  cycles++;
 
-	vector<bool> issued(total_nodes, false);
+  vector<bool> issued(total_nodes, false);
 
-	for(unsigned i=0; i<total_nodes; ++i){
-		unsigned node_id = (i+next_node_id)%total_nodes;
+  for (unsigned i = 0; i < total_nodes; ++i) {
+    unsigned node_id = (i + next_node_id) % total_nodes;
 
-		if(!in_buffers[node_id].empty()) {
-			Packet _packet = in_buffers[node_id].front();
-			//ensure that the outbuffer has space and not issued before in this cycle
-			if(Has_Buffer_Out(_packet.output_deviceID, 1)){
-				if(!issued[_packet.output_deviceID]) {
-					out_buffers[_packet.output_deviceID].push(_packet);
-					in_buffers[node_id].pop();
-					issued[_packet.output_deviceID]=true;
-				}
-				else
-					conflicts++;
-			}
-			else {
-				out_buffer_full++;
+    if (!in_buffers[node_id].empty()) {
+      Packet _packet = in_buffers[node_id].front();
+      // ensure that the outbuffer has space and not issued before in this cycle
+      if (Has_Buffer_Out(_packet.output_deviceID, 1)) {
+        if (!issued[_packet.output_deviceID]) {
+          out_buffers[_packet.output_deviceID].push(_packet);
+          in_buffers[node_id].pop();
+          issued[_packet.output_deviceID] = true;
+        } else
+          conflicts++;
+      } else {
+        out_buffer_full++;
 
-				if(issued[_packet.output_deviceID])
-					conflicts++;
-			}
-		}
-	}
+        if (issued[_packet.output_deviceID]) conflicts++;
+      }
+    }
+  }
 
-	next_node_id = (++next_node_id % total_nodes);
+  next_node_id = (++next_node_id % total_nodes);
 
-	//collect some stats about buffer util
-	for(unsigned i=0; i<total_nodes; ++i){
-		in_buffer_util+=in_buffers[i].size();
-		out_buffer_util+=out_buffers[i].size();
-	}
+  // collect some stats about buffer util
+  for (unsigned i = 0; i < total_nodes; ++i) {
+    in_buffer_util += in_buffers[i].size();
+    out_buffer_util += out_buffers[i].size();
+  }
 }
 
-//iSLIP algorithm
-//McKeown, Nick. "The iSLIP scheduling algorithm for input-queued switches." IEEE/ACM transactions on networking 2 (1999): 188-201.
-//https://www.cs.rutgers.edu/~sn624/552-F18/papers/islip.pdf
+// iSLIP algorithm
+// McKeown, Nick. "The iSLIP scheduling algorithm for input-queued switches."
+// IEEE/ACM transactions on networking 2 (1999): 188-201.
+// https://www.cs.rutgers.edu/~sn624/552-F18/papers/islip.pdf
 void xbar_router::iSLIP_Advance() {
-	cycles++;
+  cycles++;
 
-	vector<unsigned> node_tmp;
+  vector<unsigned> node_tmp;
 
+  // calcaulte how many conflicts are there for stats
+  for (unsigned i = 0; i < total_nodes; ++i) {
+    if (!in_buffers[i].empty()) {
+      Packet _packet_tmp = in_buffers[i].front();
+      if (!node_tmp.empty()) {
+        if (std::find(node_tmp.begin(), node_tmp.end(),
+                      _packet_tmp.output_deviceID) != node_tmp.end()) {
+          conflicts++;
+        } else
+          node_tmp.push_back(_packet_tmp.output_deviceID);
+      } else {
+        node_tmp.push_back(_packet_tmp.output_deviceID);
+      }
+    }
+  }
 
-	//calcaulte how many conflicts are there for stats
-	for (unsigned i=0; i<total_nodes; ++i){
-		
-		if(!in_buffers[i].empty()){
-			Packet _packet_tmp = in_buffers[i].front();
-			if (!node_tmp.empty()){
-				if (std::find(node_tmp.begin(), node_tmp.end(), _packet_tmp.output_deviceID)!=node_tmp.end()){
-					conflicts++;
-				}
-				else 
-					node_tmp.push_back(_packet_tmp.output_deviceID);
-			}
-			else{
-				node_tmp.push_back(_packet_tmp.output_deviceID);
-			}
-		}
-	}
+  // do iSLIP
+  for (unsigned i = 0; i < total_nodes; ++i) {
+    if (Has_Buffer_Out(i, 1)) {
+      for (unsigned j = 0; j < total_nodes; ++j) {
+        unsigned node_id = (j + next_node[i]) % total_nodes;
 
+        if (!in_buffers[node_id].empty()) {
+          Packet _packet = in_buffers[node_id].front();
+          if (_packet.output_deviceID == i) {
+            out_buffers[_packet.output_deviceID].push(_packet);
+            in_buffers[node_id].pop();
+            next_node[i] = (++node_id % total_nodes);
+            break;
+          }
+        }
+      }
+    } else
+      out_buffer_full++;
+  }
 
-	//do iSLIP
-	for(unsigned i=0; i<total_nodes; ++i){
-
-		if(Has_Buffer_Out(i, 1)) {
-			for(unsigned j=0; j<total_nodes; ++j){
-				unsigned node_id = (j+next_node[i])%total_nodes;
-
-				if(!in_buffers[node_id].empty()) {
-					Packet _packet = in_buffers[node_id].front();
-					if(_packet.output_deviceID==i){
-						out_buffers[_packet.output_deviceID].push(_packet);
-						in_buffers[node_id].pop();
-						next_node[i] = (++node_id % total_nodes);
-						break;
-					}
-				}
-			}
-		}
-		else
-			out_buffer_full++;
-	}
-
-	//collect some stats about buffer util
-	for(unsigned i=0; i<total_nodes; ++i){
-		in_buffer_util+=in_buffers[i].size();
-		out_buffer_util+=out_buffers[i].size();
-	}
+  // collect some stats about buffer util
+  for (unsigned i = 0; i < total_nodes; ++i) {
+    in_buffer_util += in_buffers[i].size();
+    out_buffer_util += out_buffers[i].size();
+  }
 }
-
-
 
 bool xbar_router::Busy() const {
+  for (unsigned i = 0; i < total_nodes; ++i) {
+    if (!in_buffers[i].empty()) return true;
 
-	for(unsigned i=0; i<total_nodes; ++i){
-		if(!in_buffers[i].empty())
-			return true;
-
-		if(!out_buffers[i].empty())
-			return true;
-	}
-	return false;
+    if (!out_buffers[i].empty()) return true;
+  }
+  return false;
 }
-
 
 ////////////////////////////////////////////////////
 /////////////LocalInterconnect/////////////////////
 
-//assume all the packets are one flit
+// assume all the packets are one flit
 #define LOCAL_INCT_FLIT_SIZE 40
 
-LocalInterconnect* LocalInterconnect::New(const struct inct_config& m_localinct_config)
-{
+LocalInterconnect* LocalInterconnect::New(
+    const struct inct_config& m_localinct_config) {
+  LocalInterconnect* icnt_interface = new LocalInterconnect(m_localinct_config);
 
-	LocalInterconnect* icnt_interface = new LocalInterconnect(m_localinct_config);
-
-	return icnt_interface;
+  return icnt_interface;
 }
 
-LocalInterconnect::LocalInterconnect(const struct inct_config& m_localinct_config): m_inct_config(m_localinct_config){
-	n_shader=0;
-	n_mem=0;
-	n_subnets = m_localinct_config.subnets;
+LocalInterconnect::LocalInterconnect(
+    const struct inct_config& m_localinct_config)
+    : m_inct_config(m_localinct_config) {
+  n_shader = 0;
+  n_mem = 0;
+  n_subnets = m_localinct_config.subnets;
 }
 
-LocalInterconnect::~LocalInterconnect(){
-	for (unsigned i = 0; i < m_inct_config.subnets; ++i) {
-		delete net[i];
-	}
+LocalInterconnect::~LocalInterconnect() {
+  for (unsigned i = 0; i < m_inct_config.subnets; ++i) {
+    delete net[i];
+  }
 }
 
-void LocalInterconnect::CreateInterconnect(unsigned m_n_shader, unsigned m_n_mem){
-	n_shader = m_n_shader;
-	n_mem = m_n_mem;
+void LocalInterconnect::CreateInterconnect(unsigned m_n_shader,
+                                           unsigned m_n_mem) {
+  n_shader = m_n_shader;
+  n_mem = m_n_mem;
 
-	net.resize(n_subnets);
-	for (unsigned i = 0; i < n_subnets; ++i) {
-		net[i] = new xbar_router( i, static_cast<Interconnect_type>(i), m_n_shader, m_n_mem, m_inct_config.in_buffer_limit, m_inct_config.out_buffer_limit,m_inct_config.arbiter_algo);
-	}
-
+  net.resize(n_subnets);
+  for (unsigned i = 0; i < n_subnets; ++i) {
+    net[i] = new xbar_router(i, static_cast<Interconnect_type>(i), m_n_shader,
+                             m_n_mem, m_inct_config.in_buffer_limit,
+                             m_inct_config.out_buffer_limit,
+                             m_inct_config.arbiter_algo);
+  }
 }
-
 
 void LocalInterconnect::Init() {
-	//empty
-	//there is nothing to do
-
+  // empty
+  // there is nothing to do
 }
 
-void LocalInterconnect::Push(unsigned input_deviceID, unsigned output_deviceID, void* data, unsigned int size){
+void LocalInterconnect::Push(unsigned input_deviceID, unsigned output_deviceID,
+                             void* data, unsigned int size) {
+  unsigned subnet;
+  if (n_subnets == 1) {
+    subnet = 0;
+  } else {
+    if (input_deviceID < n_shader) {
+      subnet = 0;
+    } else {
+      subnet = 1;
+    }
+  }
 
-	unsigned subnet;
-	if (n_subnets == 1) {
-		subnet = 0;
-	} else {
-		if (input_deviceID < n_shader ) {
-			subnet = 0;
-		} else {
-			subnet = 1;
-		}
-	}
+  // it should have free buffer
+  // assume all the packets have size of one
+  // no flits are implemented
+  assert(net[subnet]->Has_Buffer_In(input_deviceID, 1));
 
-	// it should have free buffer
-	//assume all the packets have size of one
-	//no flits are implemented
-	assert(net[subnet]->Has_Buffer_In(input_deviceID, 1));
-
-	net[subnet]->Push(input_deviceID, output_deviceID, data, size);
-
+  net[subnet]->Push(input_deviceID, output_deviceID, data, size);
 }
 
-void* LocalInterconnect::Pop(unsigned ouput_deviceID){
+void* LocalInterconnect::Pop(unsigned ouput_deviceID) {
+  // 0-_n_shader-1 indicates reply(network 1), otherwise request(network 0)
+  int subnet = 0;
+  if (ouput_deviceID < n_shader) subnet = 1;
 
-	// 0-_n_shader-1 indicates reply(network 1), otherwise request(network 0)
-	int subnet = 0;
-	if (ouput_deviceID < n_shader)
-		subnet = 1;
-
-	return net[subnet]->Pop(ouput_deviceID);
-
+  return net[subnet]->Pop(ouput_deviceID);
 }
 
-void LocalInterconnect::Advance(){
-
-	for (unsigned i = 0; i < n_subnets; ++i) {
-		net[i]->Advance();
-	}
-
+void LocalInterconnect::Advance() {
+  for (unsigned i = 0; i < n_subnets; ++i) {
+    net[i]->Advance();
+  }
 }
 
-bool  LocalInterconnect::Busy() const{
-
-	for (unsigned i = 0; i < n_subnets; ++i) {
-		if(net[i]->Busy())
-			return true;
-	}
-	return false;
+bool LocalInterconnect::Busy() const {
+  for (unsigned i = 0; i < n_subnets; ++i) {
+    if (net[i]->Busy()) return true;
+  }
+  return false;
 }
 
-bool  LocalInterconnect::HasBuffer(unsigned deviceID, unsigned int size) const{
+bool LocalInterconnect::HasBuffer(unsigned deviceID, unsigned int size) const {
+  bool has_buffer = false;
 
-	bool has_buffer = false;
+  if ((n_subnets > 1) && deviceID >= n_shader)  // deviceID is memory node
+    has_buffer = net[REPLY_NET]->Has_Buffer_In(deviceID, 1, true);
+  else
+    has_buffer = net[REQ_NET]->Has_Buffer_In(deviceID, 1, true);
 
-	if ((n_subnets>1) && deviceID >= n_shader) // deviceID is memory node
-		has_buffer = net[REPLY_NET]->Has_Buffer_In(deviceID, 1, true);
-	else
-		has_buffer = net[REQ_NET]->Has_Buffer_In(deviceID, 1, true);
-
-	return has_buffer;
-
+  return has_buffer;
 }
 
-void  LocalInterconnect::DisplayStats() const{
+void LocalInterconnect::DisplayStats() const {
+  cout << "Req_Network_injected_packets_num = " << net[REQ_NET]->packets_num
+       << endl;
+  cout << "Req_Network_cycles = " << net[REQ_NET]->cycles << endl;
+  cout << "Req_Network_injected_packets_per_cycle = "
+       << (float)(net[REQ_NET]->packets_num) / (net[REQ_NET]->cycles) << endl;
+  cout << "Req_Network_conflicts_per_cycle = "
+       << (float)(net[REQ_NET]->conflicts) / (net[REQ_NET]->cycles) << endl;
+  cout << "Req_Network_in_buffer_full_per_cycle = "
+       << (float)(net[REQ_NET]->in_buffer_full) / (net[REQ_NET]->cycles)
+       << endl;
+  cout << "Req_Network_in_buffer_avg_util = "
+       << ((float)(net[REQ_NET]->in_buffer_util) / (net[REQ_NET]->cycles) /
+           net[REQ_NET]->active_in_buffers)
+       << endl;
+  cout << "Req_Network_out_buffer_full_per_cycle = "
+       << (float)(net[REQ_NET]->out_buffer_full) / (net[REQ_NET]->cycles)
+       << endl;
+  cout << "Req_Network_out_buffer_avg_util = "
+       << ((float)(net[REQ_NET]->out_buffer_util) / (net[REQ_NET]->cycles) /
+           net[REQ_NET]->active_out_buffers)
+       << endl;
 
-	cout<<"Req_Network_injected_packets_num = "<<net[REQ_NET]->packets_num<<endl;
-	cout<<"Req_Network_cycles = "<<net[REQ_NET]->cycles<<endl;
-	cout<<"Req_Network_injected_packets_per_cycle = "<<(float)(net[REQ_NET]->packets_num) / (net[REQ_NET]->cycles)<<endl;
-	cout<<"Req_Network_conflicts_per_cycle = "<<(float)(net[REQ_NET]->conflicts) / (net[REQ_NET]->cycles)<<endl;
-	cout<<"Req_Network_in_buffer_full_per_cycle = "<<(float)(net[REQ_NET]->in_buffer_full) / (net[REQ_NET]->cycles)<<endl;
-	cout<<"Req_Network_in_buffer_avg_util = "<<((float)(net[REQ_NET]->in_buffer_util) / (net[REQ_NET]->cycles) / net[REQ_NET]->active_in_buffers)<<endl;
-	cout<<"Req_Network_out_buffer_full_per_cycle = "<<(float)(net[REQ_NET]->out_buffer_full) / (net[REQ_NET]->cycles)<<endl;
-	cout<<"Req_Network_out_buffer_avg_util = "<<((float)(net[REQ_NET]->out_buffer_util) / (net[REQ_NET]->cycles) / net[REQ_NET]->active_out_buffers)<<endl;
-
-	cout<<endl;
-	cout<<"Reply_Network_injected_packets_num = "<<net[REPLY_NET]->packets_num<<endl;
-	cout<<"Reply_Network_cycles = "<<net[REPLY_NET]->cycles<<endl;
-	cout<<"Reply_Network_injected_packets_per_cycle = "<<(float)(net[REPLY_NET]->packets_num) / (net[REPLY_NET]->cycles)<<endl;
-	cout<<"Reply_Network_conflicts_per_cycle = "<<(float)(net[REPLY_NET]->conflicts) / (net[REPLY_NET]->cycles)<<endl;
-	cout<<"Reply_Network_in_buffer_full_per_cycle = "<<(float)(net[REPLY_NET]->in_buffer_full) / (net[REPLY_NET]->cycles)<<endl;
-	cout<<"Reply_Network_in_buffer_avg_util = "<<((float)(net[REPLY_NET]->in_buffer_util) / (net[REPLY_NET]->cycles) / net[REPLY_NET]->active_in_buffers)<<endl;
-	cout<<"Reply_Network_out_buffer_full_per_cycle = "<<(float)(net[REPLY_NET]->out_buffer_full) / (net[REPLY_NET]->cycles)<<endl;
-	cout<<"Reply_Network_out_buffer_avg_util= "<<((float)(net[REPLY_NET]->out_buffer_util) / (net[REPLY_NET]->cycles) / net[REPLY_NET]->active_out_buffers)<<endl;
-
+  cout << endl;
+  cout << "Reply_Network_injected_packets_num = " << net[REPLY_NET]->packets_num
+       << endl;
+  cout << "Reply_Network_cycles = " << net[REPLY_NET]->cycles << endl;
+  cout << "Reply_Network_injected_packets_per_cycle = "
+       << (float)(net[REPLY_NET]->packets_num) / (net[REPLY_NET]->cycles)
+       << endl;
+  cout << "Reply_Network_conflicts_per_cycle = "
+       << (float)(net[REPLY_NET]->conflicts) / (net[REPLY_NET]->cycles) << endl;
+  cout << "Reply_Network_in_buffer_full_per_cycle = "
+       << (float)(net[REPLY_NET]->in_buffer_full) / (net[REPLY_NET]->cycles)
+       << endl;
+  cout << "Reply_Network_in_buffer_avg_util = "
+       << ((float)(net[REPLY_NET]->in_buffer_util) / (net[REPLY_NET]->cycles) /
+           net[REPLY_NET]->active_in_buffers)
+       << endl;
+  cout << "Reply_Network_out_buffer_full_per_cycle = "
+       << (float)(net[REPLY_NET]->out_buffer_full) / (net[REPLY_NET]->cycles)
+       << endl;
+  cout << "Reply_Network_out_buffer_avg_util= "
+       << ((float)(net[REPLY_NET]->out_buffer_util) / (net[REPLY_NET]->cycles) /
+           net[REPLY_NET]->active_out_buffers)
+       << endl;
 }
 
-void  LocalInterconnect::DisplayOverallStats() const{
+void LocalInterconnect::DisplayOverallStats() const {}
 
+unsigned LocalInterconnect::GetFlitSize() const { return LOCAL_INCT_FLIT_SIZE; }
+
+void LocalInterconnect::DisplayState(FILE* fp) const {
+  fprintf(fp, "GPGPU-Sim uArch: ICNT:Display State: Under implementation\n");
 }
-
-unsigned  LocalInterconnect::GetFlitSize() const{
-	return LOCAL_INCT_FLIT_SIZE;
-}
-
-void  LocalInterconnect::DisplayState(FILE* fp) const{
-
-	fprintf(fp, "GPGPU-Sim uArch: ICNT:Display State: Under implementation\n");
-}
-

--- a/src/gpgpu-sim/local_interconnect.cc
+++ b/src/gpgpu-sim/local_interconnect.cc
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -27,343 +25,353 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <algorithm>
-#include <cmath>
 #include <fstream>
-#include <iomanip>
 #include <iostream>
 #include <sstream>
+#include <iomanip>
+#include <cmath>
 #include <utility>
+#include <algorithm>
 
 #include "local_interconnect.h"
 #include "mem_fetch.h"
 
-xbar_router::xbar_router(unsigned router_id, enum Interconnect_type m_type,
-                         unsigned n_shader, unsigned n_mem,
-                         unsigned m_in_buffer_limit,
-                         unsigned m_out_buffer_limit,
-                         enum Arbiteration_type m_arbit_type) {
-  m_id = router_id;
-  router_type = m_type;
-  _n_mem = n_mem;
-  _n_shader = n_shader;
-  total_nodes = n_shader + n_mem;
-  in_buffers.resize(total_nodes);
-  out_buffers.resize(total_nodes);
-  next_node.resize(total_nodes, 0);
-  in_buffer_limit = m_in_buffer_limit;
-  out_buffer_limit = m_out_buffer_limit;
-  arbit_type = m_arbit_type;
-  next_node_id = 0;
-  if (m_type == REQ_NET) {
-    active_in_buffers = n_shader;
-    active_out_buffers = n_mem;
-  } else if (m_type == REPLY_NET) {
-    active_in_buffers = n_mem;
-    active_out_buffers = n_shader;
-  }
+xbar_router::xbar_router(unsigned router_id, enum Interconnect_type m_type, unsigned n_shader, unsigned n_mem, unsigned m_in_buffer_limit, unsigned m_out_buffer_limit, enum Arbiteration_type m_arbit_type)
+{
+	m_id=router_id;
+	router_type=m_type;
+	_n_mem = n_mem;
+	_n_shader = n_shader;
+	total_nodes = n_shader+n_mem;
+	in_buffers.resize(total_nodes);
+	out_buffers.resize(total_nodes);
+	next_node.resize(total_nodes,0);
+	in_buffer_limit = m_in_buffer_limit;
+	out_buffer_limit = m_out_buffer_limit;
+	arbit_type = m_arbit_type;
+	next_node_id=0;
+	if(m_type == REQ_NET) {
+		active_in_buffers=n_shader;
+		active_out_buffers=n_mem;
+	}
+	else if(m_type == REPLY_NET) {
+		active_in_buffers=n_mem;
+		active_out_buffers=n_shader;
+	}
 
-  cycles = 0;
-  conflicts = 0;
-  out_buffer_full = 0;
-  in_buffer_full = 0;
-  out_buffer_util = 0;
-  in_buffer_util = 0;
-  packets_num = 0;
+	cycles = 0;
+	conflicts= 0;
+	out_buffer_full=0;
+	in_buffer_full=0;
+	out_buffer_util=0;
+	in_buffer_util=0;
+	packets_num=0;
 }
 
-xbar_router::~xbar_router() {}
 
-void xbar_router::Push(unsigned input_deviceID, unsigned output_deviceID,
-                       void* data, unsigned int size) {
-  assert(input_deviceID < total_nodes);
-  in_buffers[input_deviceID].push(Packet(data, output_deviceID));
-  packets_num++;
+xbar_router::~xbar_router()
+{
+
 }
 
-void* xbar_router::Pop(unsigned ouput_deviceID) {
-  assert(ouput_deviceID < total_nodes);
-  void* data = NULL;
-
-  if (!out_buffers[ouput_deviceID].empty()) {
-    data = out_buffers[ouput_deviceID].front().data;
-    out_buffers[ouput_deviceID].pop();
-  }
-
-  return data;
+void xbar_router::Push(unsigned input_deviceID, unsigned output_deviceID, void* data, unsigned int size)
+{
+	assert(input_deviceID < total_nodes);
+	in_buffers[input_deviceID].push(Packet(data, output_deviceID));
+	packets_num++;
 }
 
-bool xbar_router::Has_Buffer_In(unsigned input_deviceID, unsigned size,
-                                bool update_counter) {
-  assert(input_deviceID < total_nodes);
+void* xbar_router::Pop(unsigned ouput_deviceID)
+{
+	assert(ouput_deviceID < total_nodes);
+	void* data = NULL;
 
-  bool has_buffer =
-      (in_buffers[input_deviceID].size() + size <= in_buffer_limit);
-  if (update_counter && !has_buffer) in_buffer_full++;
+	if(!out_buffers[ouput_deviceID].empty()) {
+		data = out_buffers[ouput_deviceID].front().data;
+		out_buffers[ouput_deviceID].pop();
+	}
 
-  return has_buffer;
+	return data;
 }
 
-bool xbar_router::Has_Buffer_Out(unsigned output_deviceID, unsigned size) {
-  return (out_buffers[output_deviceID].size() + size <= out_buffer_limit);
+
+bool xbar_router::Has_Buffer_In(unsigned input_deviceID, unsigned size, bool update_counter){
+
+	assert(input_deviceID < total_nodes);
+
+	bool has_buffer = (in_buffers[input_deviceID].size() + size <= in_buffer_limit);
+	if(update_counter && !has_buffer)
+		in_buffer_full++;
+
+	return has_buffer;
+
+}
+
+bool xbar_router::Has_Buffer_Out(unsigned output_deviceID, unsigned size){
+	return (out_buffers[output_deviceID].size() + size <= out_buffer_limit);
 }
 
 void xbar_router::Advance() {
-  if (arbit_type == NAIVE_RR)
-    RR_Advance();
-  else if (arbit_type == iSLIP)
-    iSLIP_Advance();
-  else
-    assert(0);
+
+	if(arbit_type == NAIVE_RR)
+		RR_Advance();
+	else if(arbit_type == iSLIP)
+		iSLIP_Advance();
+	else
+		assert(0);
+
 }
 
 void xbar_router::RR_Advance() {
-  cycles++;
+	cycles++;
 
-  vector<bool> issued(total_nodes, false);
+	vector<bool> issued(total_nodes, false);
 
-  for (unsigned i = 0; i < total_nodes; ++i) {
-    unsigned node_id = (i + next_node_id) % total_nodes;
+	for(unsigned i=0; i<total_nodes; ++i){
+		unsigned node_id = (i+next_node_id)%total_nodes;
 
-    if (!in_buffers[node_id].empty()) {
-      Packet _packet = in_buffers[node_id].front();
-      // ensure that the outbuffer has space and not issued before in this cycle
-      if (Has_Buffer_Out(_packet.output_deviceID, 1)) {
-        if (!issued[_packet.output_deviceID]) {
-          out_buffers[_packet.output_deviceID].push(_packet);
-          in_buffers[node_id].pop();
-          issued[_packet.output_deviceID] = true;
-        } else
-          conflicts++;
-      } else {
-        out_buffer_full++;
+		if(!in_buffers[node_id].empty()) {
+			Packet _packet = in_buffers[node_id].front();
+			//ensure that the outbuffer has space and not issued before in this cycle
+			if(Has_Buffer_Out(_packet.output_deviceID, 1)){
+				if(!issued[_packet.output_deviceID]) {
+					out_buffers[_packet.output_deviceID].push(_packet);
+					in_buffers[node_id].pop();
+					issued[_packet.output_deviceID]=true;
+				}
+				else
+					conflicts++;
+			}
+			else {
+				out_buffer_full++;
 
-        if (issued[_packet.output_deviceID]) conflicts++;
-      }
-    }
-  }
+				if(issued[_packet.output_deviceID])
+					conflicts++;
+			}
+		}
+	}
 
-  next_node_id = (++next_node_id % total_nodes);
+	next_node_id = (++next_node_id % total_nodes);
 
-  // collect some stats about buffer util
-  for (unsigned i = 0; i < total_nodes; ++i) {
-    in_buffer_util += in_buffers[i].size();
-    out_buffer_util += out_buffers[i].size();
-  }
+	//collect some stats about buffer util
+	for(unsigned i=0; i<total_nodes; ++i){
+		in_buffer_util+=in_buffers[i].size();
+		out_buffer_util+=out_buffers[i].size();
+	}
 }
 
-// iSLIP algorithm
-// McKeown, Nick. "The iSLIP scheduling algorithm for input-queued switches."
-// IEEE/ACM transactions on networking 2 (1999): 188-201.
-// https://www.cs.rutgers.edu/~sn624/552-F18/papers/islip.pdf
+//iSLIP algorithm
+//McKeown, Nick. "The iSLIP scheduling algorithm for input-queued switches." IEEE/ACM transactions on networking 2 (1999): 188-201.
+//https://www.cs.rutgers.edu/~sn624/552-F18/papers/islip.pdf
 void xbar_router::iSLIP_Advance() {
-  cycles++;
+	cycles++;
 
-  vector<unsigned> node_tmp;
+	vector<unsigned> node_tmp;
 
-  // calcaulte how many conflicts are there for stats
-  for (unsigned i = 0; i < total_nodes; ++i) {
-    if (!in_buffers[i].empty()) {
-      Packet _packet_tmp = in_buffers[i].front();
-      if (!node_tmp.empty()) {
-        if (std::find(node_tmp.begin(), node_tmp.end(),
-                      _packet_tmp.output_deviceID) != node_tmp.end()) {
-          conflicts++;
-        } else
-          node_tmp.push_back(_packet_tmp.output_deviceID);
-      } else {
-        node_tmp.push_back(_packet_tmp.output_deviceID);
-      }
-    }
-  }
 
-  // do iSLIP
-  for (unsigned i = 0; i < total_nodes; ++i) {
-    if (Has_Buffer_Out(i, 1)) {
-      for (unsigned j = 0; j < total_nodes; ++j) {
-        unsigned node_id = (j + next_node[i]) % total_nodes;
+	//calcaulte how many conflicts are there for stats
+	for (unsigned i=0; i<total_nodes; ++i){
+		
+		if(!in_buffers[i].empty()){
+			Packet _packet_tmp = in_buffers[i].front();
+			if (!node_tmp.empty()){
+				if (std::find(node_tmp.begin(), node_tmp.end(), _packet_tmp.output_deviceID)!=node_tmp.end()){
+					conflicts++;
+				}
+				else 
+					node_tmp.push_back(_packet_tmp.output_deviceID);
+			}
+			else{
+				node_tmp.push_back(_packet_tmp.output_deviceID);
+			}
+		}
+	}
 
-        if (!in_buffers[node_id].empty()) {
-          Packet _packet = in_buffers[node_id].front();
-          if (_packet.output_deviceID == i) {
-            out_buffers[_packet.output_deviceID].push(_packet);
-            in_buffers[node_id].pop();
-            next_node[i] = (++node_id % total_nodes);
-            break;
-          }
-        }
-      }
-    } else
-      out_buffer_full++;
-  }
 
-  // collect some stats about buffer util
-  for (unsigned i = 0; i < total_nodes; ++i) {
-    in_buffer_util += in_buffers[i].size();
-    out_buffer_util += out_buffers[i].size();
-  }
+	//do iSLIP
+	for(unsigned i=0; i<total_nodes; ++i){
+
+		if(Has_Buffer_Out(i, 1)) {
+			for(unsigned j=0; j<total_nodes; ++j){
+				unsigned node_id = (j+next_node[i])%total_nodes;
+
+				if(!in_buffers[node_id].empty()) {
+					Packet _packet = in_buffers[node_id].front();
+					if(_packet.output_deviceID==i){
+						out_buffers[_packet.output_deviceID].push(_packet);
+						in_buffers[node_id].pop();
+						next_node[i] = (++node_id % total_nodes);
+						break;
+					}
+				}
+			}
+		}
+		else
+			out_buffer_full++;
+	}
+
+	//collect some stats about buffer util
+	for(unsigned i=0; i<total_nodes; ++i){
+		in_buffer_util+=in_buffers[i].size();
+		out_buffer_util+=out_buffers[i].size();
+	}
 }
+
+
 
 bool xbar_router::Busy() const {
-  for (unsigned i = 0; i < total_nodes; ++i) {
-    if (!in_buffers[i].empty()) return true;
 
-    if (!out_buffers[i].empty()) return true;
-  }
-  return false;
+	for(unsigned i=0; i<total_nodes; ++i){
+		if(!in_buffers[i].empty())
+			return true;
+
+		if(!out_buffers[i].empty())
+			return true;
+	}
+	return false;
 }
+
 
 ////////////////////////////////////////////////////
 /////////////LocalInterconnect/////////////////////
 
-// assume all the packets are one flit
+//assume all the packets are one flit
 #define LOCAL_INCT_FLIT_SIZE 40
 
-LocalInterconnect* LocalInterconnect::New(
-    const struct inct_config& m_localinct_config) {
-  LocalInterconnect* icnt_interface = new LocalInterconnect(m_localinct_config);
+LocalInterconnect* LocalInterconnect::New(const struct inct_config& m_localinct_config)
+{
 
-  return icnt_interface;
+	LocalInterconnect* icnt_interface = new LocalInterconnect(m_localinct_config);
+
+	return icnt_interface;
 }
 
-LocalInterconnect::LocalInterconnect(
-    const struct inct_config& m_localinct_config)
-    : m_inct_config(m_localinct_config) {
-  n_shader = 0;
-  n_mem = 0;
-  n_subnets = m_localinct_config.subnets;
+LocalInterconnect::LocalInterconnect(const struct inct_config& m_localinct_config): m_inct_config(m_localinct_config){
+	n_shader=0;
+	n_mem=0;
+	n_subnets = m_localinct_config.subnets;
 }
 
-LocalInterconnect::~LocalInterconnect() {
-  for (unsigned i = 0; i < m_inct_config.subnets; ++i) {
-    delete net[i];
-  }
+LocalInterconnect::~LocalInterconnect(){
+	for (unsigned i = 0; i < m_inct_config.subnets; ++i) {
+		delete net[i];
+	}
 }
 
-void LocalInterconnect::CreateInterconnect(unsigned m_n_shader,
-                                           unsigned m_n_mem) {
-  n_shader = m_n_shader;
-  n_mem = m_n_mem;
+void LocalInterconnect::CreateInterconnect(unsigned m_n_shader, unsigned m_n_mem){
+	n_shader = m_n_shader;
+	n_mem = m_n_mem;
 
-  net.resize(n_subnets);
-  for (unsigned i = 0; i < n_subnets; ++i) {
-    net[i] = new xbar_router(i, static_cast<Interconnect_type>(i), m_n_shader,
-                             m_n_mem, m_inct_config.in_buffer_limit,
-                             m_inct_config.out_buffer_limit,
-                             m_inct_config.arbiter_algo);
-  }
+	net.resize(n_subnets);
+	for (unsigned i = 0; i < n_subnets; ++i) {
+		net[i] = new xbar_router( i, static_cast<Interconnect_type>(i), m_n_shader, m_n_mem, m_inct_config.in_buffer_limit, m_inct_config.out_buffer_limit,m_inct_config.arbiter_algo);
+	}
+
 }
+
 
 void LocalInterconnect::Init() {
-  // empty
-  // there is nothing to do
+	//empty
+	//there is nothing to do
+
 }
 
-void LocalInterconnect::Push(unsigned input_deviceID, unsigned output_deviceID,
-                             void* data, unsigned int size) {
-  unsigned subnet;
-  if (n_subnets == 1) {
-    subnet = 0;
-  } else {
-    if (input_deviceID < n_shader) {
-      subnet = 0;
-    } else {
-      subnet = 1;
-    }
-  }
+void LocalInterconnect::Push(unsigned input_deviceID, unsigned output_deviceID, void* data, unsigned int size){
 
-  // it should have free buffer
-  // assume all the packets have size of one
-  // no flits are implemented
-  assert(net[subnet]->Has_Buffer_In(input_deviceID, 1));
+	unsigned subnet;
+	if (n_subnets == 1) {
+		subnet = 0;
+	} else {
+		if (input_deviceID < n_shader ) {
+			subnet = 0;
+		} else {
+			subnet = 1;
+		}
+	}
 
-  net[subnet]->Push(input_deviceID, output_deviceID, data, size);
+	// it should have free buffer
+	//assume all the packets have size of one
+	//no flits are implemented
+	assert(net[subnet]->Has_Buffer_In(input_deviceID, 1));
+
+	net[subnet]->Push(input_deviceID, output_deviceID, data, size);
+
 }
 
-void* LocalInterconnect::Pop(unsigned ouput_deviceID) {
-  // 0-_n_shader-1 indicates reply(network 1), otherwise request(network 0)
-  int subnet = 0;
-  if (ouput_deviceID < n_shader) subnet = 1;
+void* LocalInterconnect::Pop(unsigned ouput_deviceID){
 
-  return net[subnet]->Pop(ouput_deviceID);
+	// 0-_n_shader-1 indicates reply(network 1), otherwise request(network 0)
+	int subnet = 0;
+	if (ouput_deviceID < n_shader)
+		subnet = 1;
+
+	return net[subnet]->Pop(ouput_deviceID);
+
 }
 
-void LocalInterconnect::Advance() {
-  for (unsigned i = 0; i < n_subnets; ++i) {
-    net[i]->Advance();
-  }
+void LocalInterconnect::Advance(){
+
+	for (unsigned i = 0; i < n_subnets; ++i) {
+		net[i]->Advance();
+	}
+
 }
 
-bool LocalInterconnect::Busy() const {
-  for (unsigned i = 0; i < n_subnets; ++i) {
-    if (net[i]->Busy()) return true;
-  }
-  return false;
+bool  LocalInterconnect::Busy() const{
+
+	for (unsigned i = 0; i < n_subnets; ++i) {
+		if(net[i]->Busy())
+			return true;
+	}
+	return false;
 }
 
-bool LocalInterconnect::HasBuffer(unsigned deviceID, unsigned int size) const {
-  bool has_buffer = false;
+bool  LocalInterconnect::HasBuffer(unsigned deviceID, unsigned int size) const{
 
-  if ((n_subnets > 1) && deviceID >= n_shader)  // deviceID is memory node
-    has_buffer = net[REPLY_NET]->Has_Buffer_In(deviceID, 1, true);
-  else
-    has_buffer = net[REQ_NET]->Has_Buffer_In(deviceID, 1, true);
+	bool has_buffer = false;
 
-  return has_buffer;
+	if ((n_subnets>1) && deviceID >= n_shader) // deviceID is memory node
+		has_buffer = net[REPLY_NET]->Has_Buffer_In(deviceID, 1, true);
+	else
+		has_buffer = net[REQ_NET]->Has_Buffer_In(deviceID, 1, true);
+
+	return has_buffer;
+
 }
 
-void LocalInterconnect::DisplayStats() const {
-  cout << "Req_Network_injected_packets_num = " << net[REQ_NET]->packets_num
-       << endl;
-  cout << "Req_Network_cycles = " << net[REQ_NET]->cycles << endl;
-  cout << "Req_Network_injected_packets_per_cycle = "
-       << (float)(net[REQ_NET]->packets_num) / (net[REQ_NET]->cycles) << endl;
-  cout << "Req_Network_conflicts_per_cycle = "
-       << (float)(net[REQ_NET]->conflicts) / (net[REQ_NET]->cycles) << endl;
-  cout << "Req_Network_in_buffer_full_per_cycle = "
-       << (float)(net[REQ_NET]->in_buffer_full) / (net[REQ_NET]->cycles)
-       << endl;
-  cout << "Req_Network_in_buffer_avg_util = "
-       << ((float)(net[REQ_NET]->in_buffer_util) / (net[REQ_NET]->cycles) /
-           net[REQ_NET]->active_in_buffers)
-       << endl;
-  cout << "Req_Network_out_buffer_full_per_cycle = "
-       << (float)(net[REQ_NET]->out_buffer_full) / (net[REQ_NET]->cycles)
-       << endl;
-  cout << "Req_Network_out_buffer_avg_util = "
-       << ((float)(net[REQ_NET]->out_buffer_util) / (net[REQ_NET]->cycles) /
-           net[REQ_NET]->active_out_buffers)
-       << endl;
+void  LocalInterconnect::DisplayStats() const{
 
-  cout << endl;
-  cout << "Reply_Network_injected_packets_num = " << net[REPLY_NET]->packets_num
-       << endl;
-  cout << "Reply_Network_cycles = " << net[REPLY_NET]->cycles << endl;
-  cout << "Reply_Network_injected_packets_per_cycle = "
-       << (float)(net[REPLY_NET]->packets_num) / (net[REPLY_NET]->cycles)
-       << endl;
-  cout << "Reply_Network_conflicts_per_cycle = "
-       << (float)(net[REPLY_NET]->conflicts) / (net[REPLY_NET]->cycles) << endl;
-  cout << "Reply_Network_in_buffer_full_per_cycle = "
-       << (float)(net[REPLY_NET]->in_buffer_full) / (net[REPLY_NET]->cycles)
-       << endl;
-  cout << "Reply_Network_in_buffer_avg_util = "
-       << ((float)(net[REPLY_NET]->in_buffer_util) / (net[REPLY_NET]->cycles) /
-           net[REPLY_NET]->active_in_buffers)
-       << endl;
-  cout << "Reply_Network_out_buffer_full_per_cycle = "
-       << (float)(net[REPLY_NET]->out_buffer_full) / (net[REPLY_NET]->cycles)
-       << endl;
-  cout << "Reply_Network_out_buffer_avg_util= "
-       << ((float)(net[REPLY_NET]->out_buffer_util) / (net[REPLY_NET]->cycles) /
-           net[REPLY_NET]->active_out_buffers)
-       << endl;
+	cout<<"Req_Network_injected_packets_num = "<<net[REQ_NET]->packets_num<<endl;
+	cout<<"Req_Network_cycles = "<<net[REQ_NET]->cycles<<endl;
+	cout<<"Req_Network_injected_packets_per_cycle = "<<(float)(net[REQ_NET]->packets_num) / (net[REQ_NET]->cycles)<<endl;
+	cout<<"Req_Network_conflicts_per_cycle = "<<(float)(net[REQ_NET]->conflicts) / (net[REQ_NET]->cycles)<<endl;
+	cout<<"Req_Network_in_buffer_full_per_cycle = "<<(float)(net[REQ_NET]->in_buffer_full) / (net[REQ_NET]->cycles)<<endl;
+	cout<<"Req_Network_in_buffer_avg_util = "<<((float)(net[REQ_NET]->in_buffer_util) / (net[REQ_NET]->cycles) / net[REQ_NET]->active_in_buffers)<<endl;
+	cout<<"Req_Network_out_buffer_full_per_cycle = "<<(float)(net[REQ_NET]->out_buffer_full) / (net[REQ_NET]->cycles)<<endl;
+	cout<<"Req_Network_out_buffer_avg_util = "<<((float)(net[REQ_NET]->out_buffer_util) / (net[REQ_NET]->cycles) / net[REQ_NET]->active_out_buffers)<<endl;
+
+	cout<<endl;
+	cout<<"Reply_Network_injected_packets_num = "<<net[REPLY_NET]->packets_num<<endl;
+	cout<<"Reply_Network_cycles = "<<net[REPLY_NET]->cycles<<endl;
+	cout<<"Reply_Network_injected_packets_per_cycle = "<<(float)(net[REPLY_NET]->packets_num) / (net[REPLY_NET]->cycles)<<endl;
+	cout<<"Reply_Network_conflicts_per_cycle = "<<(float)(net[REPLY_NET]->conflicts) / (net[REPLY_NET]->cycles)<<endl;
+	cout<<"Reply_Network_in_buffer_full_per_cycle = "<<(float)(net[REPLY_NET]->in_buffer_full) / (net[REPLY_NET]->cycles)<<endl;
+	cout<<"Reply_Network_in_buffer_avg_util = "<<((float)(net[REPLY_NET]->in_buffer_util) / (net[REPLY_NET]->cycles) / net[REPLY_NET]->active_in_buffers)<<endl;
+	cout<<"Reply_Network_out_buffer_full_per_cycle = "<<(float)(net[REPLY_NET]->out_buffer_full) / (net[REPLY_NET]->cycles)<<endl;
+	cout<<"Reply_Network_out_buffer_avg_util= "<<((float)(net[REPLY_NET]->out_buffer_util) / (net[REPLY_NET]->cycles) / net[REPLY_NET]->active_out_buffers)<<endl;
+
 }
 
-void LocalInterconnect::DisplayOverallStats() const {}
+void  LocalInterconnect::DisplayOverallStats() const{
 
-unsigned LocalInterconnect::GetFlitSize() const { return LOCAL_INCT_FLIT_SIZE; }
-
-void LocalInterconnect::DisplayState(FILE* fp) const {
-  fprintf(fp, "GPGPU-Sim uArch: ICNT:Display State: Under implementation\n");
 }
+
+unsigned  LocalInterconnect::GetFlitSize() const{
+	return LOCAL_INCT_FLIT_SIZE;
+}
+
+void  LocalInterconnect::DisplayState(FILE* fp) const{
+
+	fprintf(fp, "GPGPU-Sim uArch: ICNT:Display State: Under implementation\n");
+}
+

--- a/src/gpgpu-sim/local_interconnect.cc
+++ b/src/gpgpu-sim/local_interconnect.cc
@@ -7,371 +7,362 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
+#include <algorithm>
+#include <cmath>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <sstream>
-#include <iomanip>
-#include <cmath>
 #include <utility>
-#include <algorithm>
 
 #include "local_interconnect.h"
 #include "mem_fetch.h"
 
-xbar_router::xbar_router(unsigned router_id, enum Interconnect_type m_type, unsigned n_shader, unsigned n_mem, unsigned m_in_buffer_limit, unsigned m_out_buffer_limit, enum Arbiteration_type m_arbit_type)
-{
-	m_id=router_id;
-	router_type=m_type;
-	_n_mem = n_mem;
-	_n_shader = n_shader;
-	total_nodes = n_shader+n_mem;
-	in_buffers.resize(total_nodes);
-	out_buffers.resize(total_nodes);
-	next_node.resize(total_nodes,0);
-	in_buffer_limit = m_in_buffer_limit;
-	out_buffer_limit = m_out_buffer_limit;
-	arbit_type = m_arbit_type;
-	next_node_id=0;
-	if(m_type == REQ_NET) {
-		active_in_buffers=n_shader;
-		active_out_buffers=n_mem;
-	}
-	else if(m_type == REPLY_NET) {
-		active_in_buffers=n_mem;
-		active_out_buffers=n_shader;
-	}
+xbar_router::xbar_router(unsigned router_id, enum Interconnect_type m_type,
+                         unsigned n_shader, unsigned n_mem,
+                         unsigned m_in_buffer_limit,
+                         unsigned m_out_buffer_limit,
+                         enum Arbiteration_type m_arbit_type) {
+  m_id = router_id;
+  router_type = m_type;
+  _n_mem = n_mem;
+  _n_shader = n_shader;
+  total_nodes = n_shader + n_mem;
+  in_buffers.resize(total_nodes);
+  out_buffers.resize(total_nodes);
+  next_node.resize(total_nodes, 0);
+  in_buffer_limit = m_in_buffer_limit;
+  out_buffer_limit = m_out_buffer_limit;
+  arbit_type = m_arbit_type;
+  next_node_id = 0;
+  if (m_type == REQ_NET) {
+    active_in_buffers = n_shader;
+    active_out_buffers = n_mem;
+  } else if (m_type == REPLY_NET) {
+    active_in_buffers = n_mem;
+    active_out_buffers = n_shader;
+  }
 
-	cycles = 0;
-	conflicts= 0;
-	out_buffer_full=0;
-	in_buffer_full=0;
-	out_buffer_util=0;
-	in_buffer_util=0;
-	packets_num=0;
+  cycles = 0;
+  conflicts = 0;
+  out_buffer_full = 0;
+  in_buffer_full = 0;
+  out_buffer_util = 0;
+  in_buffer_util = 0;
+  packets_num = 0;
 }
 
+xbar_router::~xbar_router() {}
 
-xbar_router::~xbar_router()
-{
-
+void xbar_router::Push(unsigned input_deviceID, unsigned output_deviceID,
+                       void* data, unsigned int size) {
+  assert(input_deviceID < total_nodes);
+  in_buffers[input_deviceID].push(Packet(data, output_deviceID));
+  packets_num++;
 }
 
-void xbar_router::Push(unsigned input_deviceID, unsigned output_deviceID, void* data, unsigned int size)
-{
-	assert(input_deviceID < total_nodes);
-	in_buffers[input_deviceID].push(Packet(data, output_deviceID));
-	packets_num++;
+void* xbar_router::Pop(unsigned ouput_deviceID) {
+  assert(ouput_deviceID < total_nodes);
+  void* data = NULL;
+
+  if (!out_buffers[ouput_deviceID].empty()) {
+    data = out_buffers[ouput_deviceID].front().data;
+    out_buffers[ouput_deviceID].pop();
+  }
+
+  return data;
 }
 
-void* xbar_router::Pop(unsigned ouput_deviceID)
-{
-	assert(ouput_deviceID < total_nodes);
-	void* data = NULL;
+bool xbar_router::Has_Buffer_In(unsigned input_deviceID, unsigned size,
+                                bool update_counter) {
+  assert(input_deviceID < total_nodes);
 
-	if(!out_buffers[ouput_deviceID].empty()) {
-		data = out_buffers[ouput_deviceID].front().data;
-		out_buffers[ouput_deviceID].pop();
-	}
+  bool has_buffer =
+      (in_buffers[input_deviceID].size() + size <= in_buffer_limit);
+  if (update_counter && !has_buffer) in_buffer_full++;
 
-	return data;
+  return has_buffer;
 }
 
-
-bool xbar_router::Has_Buffer_In(unsigned input_deviceID, unsigned size, bool update_counter){
-
-	assert(input_deviceID < total_nodes);
-
-	bool has_buffer = (in_buffers[input_deviceID].size() + size <= in_buffer_limit);
-	if(update_counter && !has_buffer)
-		in_buffer_full++;
-
-	return has_buffer;
-
-}
-
-bool xbar_router::Has_Buffer_Out(unsigned output_deviceID, unsigned size){
-	return (out_buffers[output_deviceID].size() + size <= out_buffer_limit);
+bool xbar_router::Has_Buffer_Out(unsigned output_deviceID, unsigned size) {
+  return (out_buffers[output_deviceID].size() + size <= out_buffer_limit);
 }
 
 void xbar_router::Advance() {
-
-	if(arbit_type == NAIVE_RR)
-		RR_Advance();
-	else if(arbit_type == iSLIP)
-		iSLIP_Advance();
-	else
-		assert(0);
-
+  if (arbit_type == NAIVE_RR)
+    RR_Advance();
+  else if (arbit_type == iSLIP)
+    iSLIP_Advance();
+  else
+    assert(0);
 }
 
 void xbar_router::RR_Advance() {
-	cycles++;
+  cycles++;
 
-	vector<bool> issued(total_nodes, false);
+  vector<bool> issued(total_nodes, false);
 
-	for(unsigned i=0; i<total_nodes; ++i){
-		unsigned node_id = (i+next_node_id)%total_nodes;
+  for (unsigned i = 0; i < total_nodes; ++i) {
+    unsigned node_id = (i + next_node_id) % total_nodes;
 
-		if(!in_buffers[node_id].empty()) {
-			Packet _packet = in_buffers[node_id].front();
-			//ensure that the outbuffer has space and not issued before in this cycle
-			if(Has_Buffer_Out(_packet.output_deviceID, 1)){
-				if(!issued[_packet.output_deviceID]) {
-					out_buffers[_packet.output_deviceID].push(_packet);
-					in_buffers[node_id].pop();
-					issued[_packet.output_deviceID]=true;
-				}
-				else
-					conflicts++;
-			}
-			else {
-				out_buffer_full++;
+    if (!in_buffers[node_id].empty()) {
+      Packet _packet = in_buffers[node_id].front();
+      // ensure that the outbuffer has space and not issued before in this cycle
+      if (Has_Buffer_Out(_packet.output_deviceID, 1)) {
+        if (!issued[_packet.output_deviceID]) {
+          out_buffers[_packet.output_deviceID].push(_packet);
+          in_buffers[node_id].pop();
+          issued[_packet.output_deviceID] = true;
+        } else
+          conflicts++;
+      } else {
+        out_buffer_full++;
 
-				if(issued[_packet.output_deviceID])
-					conflicts++;
-			}
-		}
-	}
+        if (issued[_packet.output_deviceID]) conflicts++;
+      }
+    }
+  }
 
-	next_node_id = (++next_node_id % total_nodes);
+  next_node_id = (++next_node_id % total_nodes);
 
-	//collect some stats about buffer util
-	for(unsigned i=0; i<total_nodes; ++i){
-		in_buffer_util+=in_buffers[i].size();
-		out_buffer_util+=out_buffers[i].size();
-	}
+  // collect some stats about buffer util
+  for (unsigned i = 0; i < total_nodes; ++i) {
+    in_buffer_util += in_buffers[i].size();
+    out_buffer_util += out_buffers[i].size();
+  }
 }
 
-//iSLIP algorithm
-//McKeown, Nick. "The iSLIP scheduling algorithm for input-queued switches." IEEE/ACM transactions on networking 2 (1999): 188-201.
-//https://www.cs.rutgers.edu/~sn624/552-F18/papers/islip.pdf
+// iSLIP algorithm
+// McKeown, Nick. "The iSLIP scheduling algorithm for input-queued switches."
+// IEEE/ACM transactions on networking 2 (1999): 188-201.
+// https://www.cs.rutgers.edu/~sn624/552-F18/papers/islip.pdf
 void xbar_router::iSLIP_Advance() {
-	cycles++;
+  cycles++;
 
-	vector<unsigned> node_tmp;
+  vector<unsigned> node_tmp;
 
+  // calcaulte how many conflicts are there for stats
+  for (unsigned i = 0; i < total_nodes; ++i) {
+    if (!in_buffers[i].empty()) {
+      Packet _packet_tmp = in_buffers[i].front();
+      if (!node_tmp.empty()) {
+        if (std::find(node_tmp.begin(), node_tmp.end(),
+                      _packet_tmp.output_deviceID) != node_tmp.end()) {
+          conflicts++;
+        } else
+          node_tmp.push_back(_packet_tmp.output_deviceID);
+      } else {
+        node_tmp.push_back(_packet_tmp.output_deviceID);
+      }
+    }
+  }
 
-	//calcaulte how many conflicts are there for stats
-	for (unsigned i=0; i<total_nodes; ++i){
-		
-		if(!in_buffers[i].empty()){
-			Packet _packet_tmp = in_buffers[i].front();
-			if (!node_tmp.empty()){
-				if (std::find(node_tmp.begin(), node_tmp.end(), _packet_tmp.output_deviceID)!=node_tmp.end()){
-					conflicts++;
-				}
-				else 
-					node_tmp.push_back(_packet_tmp.output_deviceID);
-			}
-			else{
-				node_tmp.push_back(_packet_tmp.output_deviceID);
-			}
-		}
-	}
+  // do iSLIP
+  for (unsigned i = 0; i < total_nodes; ++i) {
+    if (Has_Buffer_Out(i, 1)) {
+      for (unsigned j = 0; j < total_nodes; ++j) {
+        unsigned node_id = (j + next_node[i]) % total_nodes;
 
+        if (!in_buffers[node_id].empty()) {
+          Packet _packet = in_buffers[node_id].front();
+          if (_packet.output_deviceID == i) {
+            out_buffers[_packet.output_deviceID].push(_packet);
+            in_buffers[node_id].pop();
+            next_node[i] = (++node_id % total_nodes);
+            break;
+          }
+        }
+      }
+    } else
+      out_buffer_full++;
+  }
 
-	//do iSLIP
-	for(unsigned i=0; i<total_nodes; ++i){
-
-		if(Has_Buffer_Out(i, 1)) {
-			for(unsigned j=0; j<total_nodes; ++j){
-				unsigned node_id = (j+next_node[i])%total_nodes;
-
-				if(!in_buffers[node_id].empty()) {
-					Packet _packet = in_buffers[node_id].front();
-					if(_packet.output_deviceID==i){
-						out_buffers[_packet.output_deviceID].push(_packet);
-						in_buffers[node_id].pop();
-						next_node[i] = (++node_id % total_nodes);
-						break;
-					}
-				}
-			}
-		}
-		else
-			out_buffer_full++;
-	}
-
-	//collect some stats about buffer util
-	for(unsigned i=0; i<total_nodes; ++i){
-		in_buffer_util+=in_buffers[i].size();
-		out_buffer_util+=out_buffers[i].size();
-	}
+  // collect some stats about buffer util
+  for (unsigned i = 0; i < total_nodes; ++i) {
+    in_buffer_util += in_buffers[i].size();
+    out_buffer_util += out_buffers[i].size();
+  }
 }
-
-
 
 bool xbar_router::Busy() const {
+  for (unsigned i = 0; i < total_nodes; ++i) {
+    if (!in_buffers[i].empty()) return true;
 
-	for(unsigned i=0; i<total_nodes; ++i){
-		if(!in_buffers[i].empty())
-			return true;
-
-		if(!out_buffers[i].empty())
-			return true;
-	}
-	return false;
+    if (!out_buffers[i].empty()) return true;
+  }
+  return false;
 }
-
 
 ////////////////////////////////////////////////////
 /////////////LocalInterconnect/////////////////////
 
-//assume all the packets are one flit
+// assume all the packets are one flit
 #define LOCAL_INCT_FLIT_SIZE 40
 
-LocalInterconnect* LocalInterconnect::New(const struct inct_config& m_localinct_config)
-{
+LocalInterconnect* LocalInterconnect::New(
+    const struct inct_config& m_localinct_config) {
+  LocalInterconnect* icnt_interface = new LocalInterconnect(m_localinct_config);
 
-	LocalInterconnect* icnt_interface = new LocalInterconnect(m_localinct_config);
-
-	return icnt_interface;
+  return icnt_interface;
 }
 
-LocalInterconnect::LocalInterconnect(const struct inct_config& m_localinct_config): m_inct_config(m_localinct_config){
-	n_shader=0;
-	n_mem=0;
-	n_subnets = m_localinct_config.subnets;
+LocalInterconnect::LocalInterconnect(
+    const struct inct_config& m_localinct_config)
+    : m_inct_config(m_localinct_config) {
+  n_shader = 0;
+  n_mem = 0;
+  n_subnets = m_localinct_config.subnets;
 }
 
-LocalInterconnect::~LocalInterconnect(){
-	for (unsigned i = 0; i < m_inct_config.subnets; ++i) {
-		delete net[i];
-	}
+LocalInterconnect::~LocalInterconnect() {
+  for (unsigned i = 0; i < m_inct_config.subnets; ++i) {
+    delete net[i];
+  }
 }
 
-void LocalInterconnect::CreateInterconnect(unsigned m_n_shader, unsigned m_n_mem){
-	n_shader = m_n_shader;
-	n_mem = m_n_mem;
+void LocalInterconnect::CreateInterconnect(unsigned m_n_shader,
+                                           unsigned m_n_mem) {
+  n_shader = m_n_shader;
+  n_mem = m_n_mem;
 
-	net.resize(n_subnets);
-	for (unsigned i = 0; i < n_subnets; ++i) {
-		net[i] = new xbar_router( i, static_cast<Interconnect_type>(i), m_n_shader, m_n_mem, m_inct_config.in_buffer_limit, m_inct_config.out_buffer_limit,m_inct_config.arbiter_algo);
-	}
-
+  net.resize(n_subnets);
+  for (unsigned i = 0; i < n_subnets; ++i) {
+    net[i] = new xbar_router(i, static_cast<Interconnect_type>(i), m_n_shader,
+                             m_n_mem, m_inct_config.in_buffer_limit,
+                             m_inct_config.out_buffer_limit,
+                             m_inct_config.arbiter_algo);
+  }
 }
-
 
 void LocalInterconnect::Init() {
-	//empty
-	//there is nothing to do
-
+  // empty
+  // there is nothing to do
 }
 
-void LocalInterconnect::Push(unsigned input_deviceID, unsigned output_deviceID, void* data, unsigned int size){
+void LocalInterconnect::Push(unsigned input_deviceID, unsigned output_deviceID,
+                             void* data, unsigned int size) {
+  unsigned subnet;
+  if (n_subnets == 1) {
+    subnet = 0;
+  } else {
+    if (input_deviceID < n_shader) {
+      subnet = 0;
+    } else {
+      subnet = 1;
+    }
+  }
 
-	unsigned subnet;
-	if (n_subnets == 1) {
-		subnet = 0;
-	} else {
-		if (input_deviceID < n_shader ) {
-			subnet = 0;
-		} else {
-			subnet = 1;
-		}
-	}
+  // it should have free buffer
+  // assume all the packets have size of one
+  // no flits are implemented
+  assert(net[subnet]->Has_Buffer_In(input_deviceID, 1));
 
-	// it should have free buffer
-	//assume all the packets have size of one
-	//no flits are implemented
-	assert(net[subnet]->Has_Buffer_In(input_deviceID, 1));
-
-	net[subnet]->Push(input_deviceID, output_deviceID, data, size);
-
+  net[subnet]->Push(input_deviceID, output_deviceID, data, size);
 }
 
-void* LocalInterconnect::Pop(unsigned ouput_deviceID){
+void* LocalInterconnect::Pop(unsigned ouput_deviceID) {
+  // 0-_n_shader-1 indicates reply(network 1), otherwise request(network 0)
+  int subnet = 0;
+  if (ouput_deviceID < n_shader) subnet = 1;
 
-	// 0-_n_shader-1 indicates reply(network 1), otherwise request(network 0)
-	int subnet = 0;
-	if (ouput_deviceID < n_shader)
-		subnet = 1;
-
-	return net[subnet]->Pop(ouput_deviceID);
-
+  return net[subnet]->Pop(ouput_deviceID);
 }
 
-void LocalInterconnect::Advance(){
-
-	for (unsigned i = 0; i < n_subnets; ++i) {
-		net[i]->Advance();
-	}
-
+void LocalInterconnect::Advance() {
+  for (unsigned i = 0; i < n_subnets; ++i) {
+    net[i]->Advance();
+  }
 }
 
-bool  LocalInterconnect::Busy() const{
-
-	for (unsigned i = 0; i < n_subnets; ++i) {
-		if(net[i]->Busy())
-			return true;
-	}
-	return false;
+bool LocalInterconnect::Busy() const {
+  for (unsigned i = 0; i < n_subnets; ++i) {
+    if (net[i]->Busy()) return true;
+  }
+  return false;
 }
 
-bool  LocalInterconnect::HasBuffer(unsigned deviceID, unsigned int size) const{
+bool LocalInterconnect::HasBuffer(unsigned deviceID, unsigned int size) const {
+  bool has_buffer = false;
 
-	bool has_buffer = false;
+  if ((n_subnets > 1) && deviceID >= n_shader)  // deviceID is memory node
+    has_buffer = net[REPLY_NET]->Has_Buffer_In(deviceID, 1, true);
+  else
+    has_buffer = net[REQ_NET]->Has_Buffer_In(deviceID, 1, true);
 
-	if ((n_subnets>1) && deviceID >= n_shader) // deviceID is memory node
-		has_buffer = net[REPLY_NET]->Has_Buffer_In(deviceID, 1, true);
-	else
-		has_buffer = net[REQ_NET]->Has_Buffer_In(deviceID, 1, true);
-
-	return has_buffer;
-
+  return has_buffer;
 }
 
-void  LocalInterconnect::DisplayStats() const{
+void LocalInterconnect::DisplayStats() const {
+  cout << "Req_Network_injected_packets_num = " << net[REQ_NET]->packets_num
+       << endl;
+  cout << "Req_Network_cycles = " << net[REQ_NET]->cycles << endl;
+  cout << "Req_Network_injected_packets_per_cycle = "
+       << (float)(net[REQ_NET]->packets_num) / (net[REQ_NET]->cycles) << endl;
+  cout << "Req_Network_conflicts_per_cycle = "
+       << (float)(net[REQ_NET]->conflicts) / (net[REQ_NET]->cycles) << endl;
+  cout << "Req_Network_in_buffer_full_per_cycle = "
+       << (float)(net[REQ_NET]->in_buffer_full) / (net[REQ_NET]->cycles)
+       << endl;
+  cout << "Req_Network_in_buffer_avg_util = "
+       << ((float)(net[REQ_NET]->in_buffer_util) / (net[REQ_NET]->cycles) /
+           net[REQ_NET]->active_in_buffers)
+       << endl;
+  cout << "Req_Network_out_buffer_full_per_cycle = "
+       << (float)(net[REQ_NET]->out_buffer_full) / (net[REQ_NET]->cycles)
+       << endl;
+  cout << "Req_Network_out_buffer_avg_util = "
+       << ((float)(net[REQ_NET]->out_buffer_util) / (net[REQ_NET]->cycles) /
+           net[REQ_NET]->active_out_buffers)
+       << endl;
 
-	cout<<"Req_Network_injected_packets_num = "<<net[REQ_NET]->packets_num<<endl;
-	cout<<"Req_Network_cycles = "<<net[REQ_NET]->cycles<<endl;
-	cout<<"Req_Network_injected_packets_per_cycle = "<<(float)(net[REQ_NET]->packets_num) / (net[REQ_NET]->cycles)<<endl;
-	cout<<"Req_Network_conflicts_per_cycle = "<<(float)(net[REQ_NET]->conflicts) / (net[REQ_NET]->cycles)<<endl;
-	cout<<"Req_Network_in_buffer_full_per_cycle = "<<(float)(net[REQ_NET]->in_buffer_full) / (net[REQ_NET]->cycles)<<endl;
-	cout<<"Req_Network_in_buffer_avg_util = "<<((float)(net[REQ_NET]->in_buffer_util) / (net[REQ_NET]->cycles) / net[REQ_NET]->active_in_buffers)<<endl;
-	cout<<"Req_Network_out_buffer_full_per_cycle = "<<(float)(net[REQ_NET]->out_buffer_full) / (net[REQ_NET]->cycles)<<endl;
-	cout<<"Req_Network_out_buffer_avg_util = "<<((float)(net[REQ_NET]->out_buffer_util) / (net[REQ_NET]->cycles) / net[REQ_NET]->active_out_buffers)<<endl;
-
-	cout<<endl;
-	cout<<"Reply_Network_injected_packets_num = "<<net[REPLY_NET]->packets_num<<endl;
-	cout<<"Reply_Network_cycles = "<<net[REPLY_NET]->cycles<<endl;
-	cout<<"Reply_Network_injected_packets_per_cycle = "<<(float)(net[REPLY_NET]->packets_num) / (net[REPLY_NET]->cycles)<<endl;
-	cout<<"Reply_Network_conflicts_per_cycle = "<<(float)(net[REPLY_NET]->conflicts) / (net[REPLY_NET]->cycles)<<endl;
-	cout<<"Reply_Network_in_buffer_full_per_cycle = "<<(float)(net[REPLY_NET]->in_buffer_full) / (net[REPLY_NET]->cycles)<<endl;
-	cout<<"Reply_Network_in_buffer_avg_util = "<<((float)(net[REPLY_NET]->in_buffer_util) / (net[REPLY_NET]->cycles) / net[REPLY_NET]->active_in_buffers)<<endl;
-	cout<<"Reply_Network_out_buffer_full_per_cycle = "<<(float)(net[REPLY_NET]->out_buffer_full) / (net[REPLY_NET]->cycles)<<endl;
-	cout<<"Reply_Network_out_buffer_avg_util= "<<((float)(net[REPLY_NET]->out_buffer_util) / (net[REPLY_NET]->cycles) / net[REPLY_NET]->active_out_buffers)<<endl;
-
+  cout << endl;
+  cout << "Reply_Network_injected_packets_num = " << net[REPLY_NET]->packets_num
+       << endl;
+  cout << "Reply_Network_cycles = " << net[REPLY_NET]->cycles << endl;
+  cout << "Reply_Network_injected_packets_per_cycle = "
+       << (float)(net[REPLY_NET]->packets_num) / (net[REPLY_NET]->cycles)
+       << endl;
+  cout << "Reply_Network_conflicts_per_cycle = "
+       << (float)(net[REPLY_NET]->conflicts) / (net[REPLY_NET]->cycles) << endl;
+  cout << "Reply_Network_in_buffer_full_per_cycle = "
+       << (float)(net[REPLY_NET]->in_buffer_full) / (net[REPLY_NET]->cycles)
+       << endl;
+  cout << "Reply_Network_in_buffer_avg_util = "
+       << ((float)(net[REPLY_NET]->in_buffer_util) / (net[REPLY_NET]->cycles) /
+           net[REPLY_NET]->active_in_buffers)
+       << endl;
+  cout << "Reply_Network_out_buffer_full_per_cycle = "
+       << (float)(net[REPLY_NET]->out_buffer_full) / (net[REPLY_NET]->cycles)
+       << endl;
+  cout << "Reply_Network_out_buffer_avg_util= "
+       << ((float)(net[REPLY_NET]->out_buffer_util) / (net[REPLY_NET]->cycles) /
+           net[REPLY_NET]->active_out_buffers)
+       << endl;
 }
 
-void  LocalInterconnect::DisplayOverallStats() const{
+void LocalInterconnect::DisplayOverallStats() const {}
 
+unsigned LocalInterconnect::GetFlitSize() const { return LOCAL_INCT_FLIT_SIZE; }
+
+void LocalInterconnect::DisplayState(FILE* fp) const {
+  fprintf(fp, "GPGPU-Sim uArch: ICNT:Display State: Under implementation\n");
 }
-
-unsigned  LocalInterconnect::GetFlitSize() const{
-	return LOCAL_INCT_FLIT_SIZE;
-}
-
-void  LocalInterconnect::DisplayState(FILE* fp) const{
-
-	fprintf(fp, "GPGPU-Sim uArch: ICNT:Display State: Under implementation\n");
-}
-

--- a/src/gpgpu-sim/local_interconnect.h
+++ b/src/gpgpu-sim/local_interconnect.h
@@ -7,134 +7,124 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef _LOCAL_INTERCONNECT_HPP_
 #define _LOCAL_INTERCONNECT_HPP_
 
-#include <vector>
-#include <queue>
 #include <iostream>
 #include <map>
+#include <queue>
+#include <vector>
 using namespace std;
 
+enum Interconnect_type { REQ_NET = 0, REPLY_NET = 1 };
 
-enum Interconnect_type {
-	REQ_NET=0,
-	REPLY_NET=1
-};
+enum Arbiteration_type { NAIVE_RR = 0, iSLIP = 1 };
 
-enum Arbiteration_type {
-	NAIVE_RR=0,
-	iSLIP=1
-};
-
-struct inct_config
-{
-	//config for local interconnect
-	unsigned   in_buffer_limit;
-	unsigned   out_buffer_limit;
-	unsigned   subnets;
-	Arbiteration_type   arbiter_algo;
+struct inct_config {
+  // config for local interconnect
+  unsigned in_buffer_limit;
+  unsigned out_buffer_limit;
+  unsigned subnets;
+  Arbiteration_type arbiter_algo;
 };
 
 class xbar_router {
+ public:
+  xbar_router(unsigned router_id, enum Interconnect_type m_type,
+              unsigned n_shader, unsigned n_mem, unsigned m_in_buffer_limit,
+              unsigned m_out_buffer_limit, enum Arbiteration_type m_arbit_type);
+  ~xbar_router();
+  void Push(unsigned input_deviceID, unsigned output_deviceID, void* data,
+            unsigned int size);
+  void* Pop(unsigned ouput_deviceID);
+  void Advance();
 
-public:
-	xbar_router(unsigned router_id, enum Interconnect_type m_type, unsigned n_shader, unsigned n_mem, unsigned m_in_buffer_limit, unsigned m_out_buffer_limit, enum Arbiteration_type m_arbit_type);
-	~xbar_router();
-	void Push(unsigned input_deviceID, unsigned output_deviceID, void* data, unsigned int size);
-	void* Pop(unsigned ouput_deviceID);
-	void Advance( );
+  bool Busy() const;
+  bool Has_Buffer_In(unsigned input_deviceID, unsigned size,
+                     bool update_counter = false);
+  bool Has_Buffer_Out(unsigned output_deviceID, unsigned size);
 
+  // some stats
+  unsigned long long cycles;
+  unsigned long long conflicts;
+  unsigned long long out_buffer_full;
+  unsigned long long out_buffer_util;
+  unsigned long long in_buffer_full;
+  unsigned long long in_buffer_util;
+  unsigned long long packets_num;
 
-	bool Busy() const;
-	bool Has_Buffer_In(unsigned input_deviceID, unsigned size, bool update_counter=false);
-	bool Has_Buffer_Out(unsigned output_deviceID, unsigned size);
+ private:
+  void iSLIP_Advance();
+  void RR_Advance();
 
-	//some stats
-	unsigned long long cycles;
-	unsigned long long conflicts;
-	unsigned long long out_buffer_full;
-	unsigned long long out_buffer_util;
-	unsigned long long in_buffer_full;
-	unsigned long long in_buffer_util;
-	unsigned long long packets_num;
+  struct Packet {
+    Packet(void* m_data, unsigned m_output_deviceID) {
+      data = m_data;
+      output_deviceID = m_output_deviceID;
+    }
+    void* data;
+    unsigned output_deviceID;
+  };
+  vector<queue<Packet> > in_buffers;
+  vector<queue<Packet> > out_buffers;
+  unsigned _n_shader, _n_mem, total_nodes;
+  unsigned in_buffer_limit, out_buffer_limit;
+  vector<unsigned> next_node;  // used for iSLIP arbit
+  unsigned next_node_id;       // used for RR arbit
+  unsigned m_id;
+  enum Interconnect_type router_type;
+  unsigned active_in_buffers, active_out_buffers;
+  Arbiteration_type arbit_type;
 
-private:
-	void iSLIP_Advance();
-	void RR_Advance();
-
-	struct Packet{
-		Packet(void* m_data, unsigned m_output_deviceID) {
-			data = m_data;
-			output_deviceID = m_output_deviceID;
-		}
-		void* data;
-		unsigned output_deviceID;
-	};
-	vector<queue<Packet> > in_buffers;
-	vector<queue<Packet> > out_buffers;
-	unsigned _n_shader, _n_mem, total_nodes;
-	unsigned in_buffer_limit, out_buffer_limit;
-	vector<unsigned> next_node;  //used for iSLIP arbit
-	unsigned next_node_id;   //used for RR arbit
-	unsigned m_id;
-	enum Interconnect_type router_type;
-	unsigned active_in_buffers,active_out_buffers;
-	Arbiteration_type arbit_type;
-
-	friend class LocalInterconnect;
-
+  friend class LocalInterconnect;
 };
 
 class LocalInterconnect {
-public:
-	LocalInterconnect(const struct inct_config& m_localinct_config);
-	~LocalInterconnect();
-	static LocalInterconnect* New(const struct inct_config& m_inct_config);
-	void CreateInterconnect(unsigned n_shader, unsigned n_mem);
+ public:
+  LocalInterconnect(const struct inct_config& m_localinct_config);
+  ~LocalInterconnect();
+  static LocalInterconnect* New(const struct inct_config& m_inct_config);
+  void CreateInterconnect(unsigned n_shader, unsigned n_mem);
 
-	//node side functions
-	void Init();
-	void Push(unsigned input_deviceID, unsigned output_deviceID, void* data, unsigned int size);
-	void* Pop(unsigned ouput_deviceID);
-	void Advance();
-	bool Busy() const;
-	bool HasBuffer(unsigned deviceID, unsigned int size) const;
-	void DisplayStats() const;
-	void DisplayOverallStats() const;
-	unsigned GetFlitSize() const;
+  // node side functions
+  void Init();
+  void Push(unsigned input_deviceID, unsigned output_deviceID, void* data,
+            unsigned int size);
+  void* Pop(unsigned ouput_deviceID);
+  void Advance();
+  bool Busy() const;
+  bool HasBuffer(unsigned deviceID, unsigned int size) const;
+  void DisplayStats() const;
+  void DisplayOverallStats() const;
+  unsigned GetFlitSize() const;
 
-	void DisplayState(FILE* fp) const;
+  void DisplayState(FILE* fp) const;
 
+ protected:
+  const inct_config& m_inct_config;
 
-protected:
-
-	const inct_config& m_inct_config;
-
-	unsigned n_shader, n_mem;
-	unsigned n_subnets;
-	vector<xbar_router *> net;
-
+  unsigned n_shader, n_mem;
+  unsigned n_subnets;
+  vector<xbar_router*> net;
 };
 
 #endif
-
-

--- a/src/gpgpu-sim/local_interconnect.h
+++ b/src/gpgpu-sim/local_interconnect.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -28,113 +30,102 @@
 #ifndef _LOCAL_INTERCONNECT_HPP_
 #define _LOCAL_INTERCONNECT_HPP_
 
-#include <vector>
-#include <queue>
 #include <iostream>
 #include <map>
+#include <queue>
+#include <vector>
 using namespace std;
 
+enum Interconnect_type { REQ_NET = 0, REPLY_NET = 1 };
 
-enum Interconnect_type {
-	REQ_NET=0,
-	REPLY_NET=1
-};
+enum Arbiteration_type { NAIVE_RR = 0, iSLIP = 1 };
 
-enum Arbiteration_type {
-	NAIVE_RR=0,
-	iSLIP=1
-};
-
-struct inct_config
-{
-	//config for local interconnect
-	unsigned   in_buffer_limit;
-	unsigned   out_buffer_limit;
-	unsigned   subnets;
-	Arbiteration_type   arbiter_algo;
+struct inct_config {
+  // config for local interconnect
+  unsigned in_buffer_limit;
+  unsigned out_buffer_limit;
+  unsigned subnets;
+  Arbiteration_type arbiter_algo;
 };
 
 class xbar_router {
+ public:
+  xbar_router(unsigned router_id, enum Interconnect_type m_type,
+              unsigned n_shader, unsigned n_mem, unsigned m_in_buffer_limit,
+              unsigned m_out_buffer_limit, enum Arbiteration_type m_arbit_type);
+  ~xbar_router();
+  void Push(unsigned input_deviceID, unsigned output_deviceID, void* data,
+            unsigned int size);
+  void* Pop(unsigned ouput_deviceID);
+  void Advance();
 
-public:
-	xbar_router(unsigned router_id, enum Interconnect_type m_type, unsigned n_shader, unsigned n_mem, unsigned m_in_buffer_limit, unsigned m_out_buffer_limit, enum Arbiteration_type m_arbit_type);
-	~xbar_router();
-	void Push(unsigned input_deviceID, unsigned output_deviceID, void* data, unsigned int size);
-	void* Pop(unsigned ouput_deviceID);
-	void Advance( );
+  bool Busy() const;
+  bool Has_Buffer_In(unsigned input_deviceID, unsigned size,
+                     bool update_counter = false);
+  bool Has_Buffer_Out(unsigned output_deviceID, unsigned size);
 
+  // some stats
+  unsigned long long cycles;
+  unsigned long long conflicts;
+  unsigned long long out_buffer_full;
+  unsigned long long out_buffer_util;
+  unsigned long long in_buffer_full;
+  unsigned long long in_buffer_util;
+  unsigned long long packets_num;
 
-	bool Busy() const;
-	bool Has_Buffer_In(unsigned input_deviceID, unsigned size, bool update_counter=false);
-	bool Has_Buffer_Out(unsigned output_deviceID, unsigned size);
+ private:
+  void iSLIP_Advance();
+  void RR_Advance();
 
-	//some stats
-	unsigned long long cycles;
-	unsigned long long conflicts;
-	unsigned long long out_buffer_full;
-	unsigned long long out_buffer_util;
-	unsigned long long in_buffer_full;
-	unsigned long long in_buffer_util;
-	unsigned long long packets_num;
+  struct Packet {
+    Packet(void* m_data, unsigned m_output_deviceID) {
+      data = m_data;
+      output_deviceID = m_output_deviceID;
+    }
+    void* data;
+    unsigned output_deviceID;
+  };
+  vector<queue<Packet> > in_buffers;
+  vector<queue<Packet> > out_buffers;
+  unsigned _n_shader, _n_mem, total_nodes;
+  unsigned in_buffer_limit, out_buffer_limit;
+  vector<unsigned> next_node;  // used for iSLIP arbit
+  unsigned next_node_id;       // used for RR arbit
+  unsigned m_id;
+  enum Interconnect_type router_type;
+  unsigned active_in_buffers, active_out_buffers;
+  Arbiteration_type arbit_type;
 
-private:
-	void iSLIP_Advance();
-	void RR_Advance();
-
-	struct Packet{
-		Packet(void* m_data, unsigned m_output_deviceID) {
-			data = m_data;
-			output_deviceID = m_output_deviceID;
-		}
-		void* data;
-		unsigned output_deviceID;
-	};
-	vector<queue<Packet> > in_buffers;
-	vector<queue<Packet> > out_buffers;
-	unsigned _n_shader, _n_mem, total_nodes;
-	unsigned in_buffer_limit, out_buffer_limit;
-	vector<unsigned> next_node;  //used for iSLIP arbit
-	unsigned next_node_id;   //used for RR arbit
-	unsigned m_id;
-	enum Interconnect_type router_type;
-	unsigned active_in_buffers,active_out_buffers;
-	Arbiteration_type arbit_type;
-
-	friend class LocalInterconnect;
-
+  friend class LocalInterconnect;
 };
 
 class LocalInterconnect {
-public:
-	LocalInterconnect(const struct inct_config& m_localinct_config);
-	~LocalInterconnect();
-	static LocalInterconnect* New(const struct inct_config& m_inct_config);
-	void CreateInterconnect(unsigned n_shader, unsigned n_mem);
+ public:
+  LocalInterconnect(const struct inct_config& m_localinct_config);
+  ~LocalInterconnect();
+  static LocalInterconnect* New(const struct inct_config& m_inct_config);
+  void CreateInterconnect(unsigned n_shader, unsigned n_mem);
 
-	//node side functions
-	void Init();
-	void Push(unsigned input_deviceID, unsigned output_deviceID, void* data, unsigned int size);
-	void* Pop(unsigned ouput_deviceID);
-	void Advance();
-	bool Busy() const;
-	bool HasBuffer(unsigned deviceID, unsigned int size) const;
-	void DisplayStats() const;
-	void DisplayOverallStats() const;
-	unsigned GetFlitSize() const;
+  // node side functions
+  void Init();
+  void Push(unsigned input_deviceID, unsigned output_deviceID, void* data,
+            unsigned int size);
+  void* Pop(unsigned ouput_deviceID);
+  void Advance();
+  bool Busy() const;
+  bool HasBuffer(unsigned deviceID, unsigned int size) const;
+  void DisplayStats() const;
+  void DisplayOverallStats() const;
+  unsigned GetFlitSize() const;
 
-	void DisplayState(FILE* fp) const;
+  void DisplayState(FILE* fp) const;
 
+ protected:
+  const inct_config& m_inct_config;
 
-protected:
-
-	const inct_config& m_inct_config;
-
-	unsigned n_shader, n_mem;
-	unsigned n_subnets;
-	vector<xbar_router *> net;
-
+  unsigned n_shader, n_mem;
+  unsigned n_subnets;
+  vector<xbar_router*> net;
 };
 
 #endif
-
-

--- a/src/gpgpu-sim/local_interconnect.h
+++ b/src/gpgpu-sim/local_interconnect.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -30,102 +28,113 @@
 #ifndef _LOCAL_INTERCONNECT_HPP_
 #define _LOCAL_INTERCONNECT_HPP_
 
+#include <vector>
+#include <queue>
 #include <iostream>
 #include <map>
-#include <queue>
-#include <vector>
 using namespace std;
 
-enum Interconnect_type { REQ_NET = 0, REPLY_NET = 1 };
 
-enum Arbiteration_type { NAIVE_RR = 0, iSLIP = 1 };
+enum Interconnect_type {
+	REQ_NET=0,
+	REPLY_NET=1
+};
 
-struct inct_config {
-  // config for local interconnect
-  unsigned in_buffer_limit;
-  unsigned out_buffer_limit;
-  unsigned subnets;
-  Arbiteration_type arbiter_algo;
+enum Arbiteration_type {
+	NAIVE_RR=0,
+	iSLIP=1
+};
+
+struct inct_config
+{
+	//config for local interconnect
+	unsigned   in_buffer_limit;
+	unsigned   out_buffer_limit;
+	unsigned   subnets;
+	Arbiteration_type   arbiter_algo;
 };
 
 class xbar_router {
- public:
-  xbar_router(unsigned router_id, enum Interconnect_type m_type,
-              unsigned n_shader, unsigned n_mem, unsigned m_in_buffer_limit,
-              unsigned m_out_buffer_limit, enum Arbiteration_type m_arbit_type);
-  ~xbar_router();
-  void Push(unsigned input_deviceID, unsigned output_deviceID, void* data,
-            unsigned int size);
-  void* Pop(unsigned ouput_deviceID);
-  void Advance();
 
-  bool Busy() const;
-  bool Has_Buffer_In(unsigned input_deviceID, unsigned size,
-                     bool update_counter = false);
-  bool Has_Buffer_Out(unsigned output_deviceID, unsigned size);
+public:
+	xbar_router(unsigned router_id, enum Interconnect_type m_type, unsigned n_shader, unsigned n_mem, unsigned m_in_buffer_limit, unsigned m_out_buffer_limit, enum Arbiteration_type m_arbit_type);
+	~xbar_router();
+	void Push(unsigned input_deviceID, unsigned output_deviceID, void* data, unsigned int size);
+	void* Pop(unsigned ouput_deviceID);
+	void Advance( );
 
-  // some stats
-  unsigned long long cycles;
-  unsigned long long conflicts;
-  unsigned long long out_buffer_full;
-  unsigned long long out_buffer_util;
-  unsigned long long in_buffer_full;
-  unsigned long long in_buffer_util;
-  unsigned long long packets_num;
 
- private:
-  void iSLIP_Advance();
-  void RR_Advance();
+	bool Busy() const;
+	bool Has_Buffer_In(unsigned input_deviceID, unsigned size, bool update_counter=false);
+	bool Has_Buffer_Out(unsigned output_deviceID, unsigned size);
 
-  struct Packet {
-    Packet(void* m_data, unsigned m_output_deviceID) {
-      data = m_data;
-      output_deviceID = m_output_deviceID;
-    }
-    void* data;
-    unsigned output_deviceID;
-  };
-  vector<queue<Packet> > in_buffers;
-  vector<queue<Packet> > out_buffers;
-  unsigned _n_shader, _n_mem, total_nodes;
-  unsigned in_buffer_limit, out_buffer_limit;
-  vector<unsigned> next_node;  // used for iSLIP arbit
-  unsigned next_node_id;       // used for RR arbit
-  unsigned m_id;
-  enum Interconnect_type router_type;
-  unsigned active_in_buffers, active_out_buffers;
-  Arbiteration_type arbit_type;
+	//some stats
+	unsigned long long cycles;
+	unsigned long long conflicts;
+	unsigned long long out_buffer_full;
+	unsigned long long out_buffer_util;
+	unsigned long long in_buffer_full;
+	unsigned long long in_buffer_util;
+	unsigned long long packets_num;
 
-  friend class LocalInterconnect;
+private:
+	void iSLIP_Advance();
+	void RR_Advance();
+
+	struct Packet{
+		Packet(void* m_data, unsigned m_output_deviceID) {
+			data = m_data;
+			output_deviceID = m_output_deviceID;
+		}
+		void* data;
+		unsigned output_deviceID;
+	};
+	vector<queue<Packet> > in_buffers;
+	vector<queue<Packet> > out_buffers;
+	unsigned _n_shader, _n_mem, total_nodes;
+	unsigned in_buffer_limit, out_buffer_limit;
+	vector<unsigned> next_node;  //used for iSLIP arbit
+	unsigned next_node_id;   //used for RR arbit
+	unsigned m_id;
+	enum Interconnect_type router_type;
+	unsigned active_in_buffers,active_out_buffers;
+	Arbiteration_type arbit_type;
+
+	friend class LocalInterconnect;
+
 };
 
 class LocalInterconnect {
- public:
-  LocalInterconnect(const struct inct_config& m_localinct_config);
-  ~LocalInterconnect();
-  static LocalInterconnect* New(const struct inct_config& m_inct_config);
-  void CreateInterconnect(unsigned n_shader, unsigned n_mem);
+public:
+	LocalInterconnect(const struct inct_config& m_localinct_config);
+	~LocalInterconnect();
+	static LocalInterconnect* New(const struct inct_config& m_inct_config);
+	void CreateInterconnect(unsigned n_shader, unsigned n_mem);
 
-  // node side functions
-  void Init();
-  void Push(unsigned input_deviceID, unsigned output_deviceID, void* data,
-            unsigned int size);
-  void* Pop(unsigned ouput_deviceID);
-  void Advance();
-  bool Busy() const;
-  bool HasBuffer(unsigned deviceID, unsigned int size) const;
-  void DisplayStats() const;
-  void DisplayOverallStats() const;
-  unsigned GetFlitSize() const;
+	//node side functions
+	void Init();
+	void Push(unsigned input_deviceID, unsigned output_deviceID, void* data, unsigned int size);
+	void* Pop(unsigned ouput_deviceID);
+	void Advance();
+	bool Busy() const;
+	bool HasBuffer(unsigned deviceID, unsigned int size) const;
+	void DisplayStats() const;
+	void DisplayOverallStats() const;
+	unsigned GetFlitSize() const;
 
-  void DisplayState(FILE* fp) const;
+	void DisplayState(FILE* fp) const;
 
- protected:
-  const inct_config& m_inct_config;
 
-  unsigned n_shader, n_mem;
-  unsigned n_subnets;
-  vector<xbar_router*> net;
+protected:
+
+	const inct_config& m_inct_config;
+
+	unsigned n_shader, n_mem;
+	unsigned n_subnets;
+	vector<xbar_router *> net;
+
 };
 
 #endif
+
+

--- a/src/gpgpu-sim/mem_fetch.cc
+++ b/src/gpgpu-sim/mem_fetch.cc
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -26,118 +28,111 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "mem_fetch.h"
+#include "gpu-sim.h"
 #include "mem_latency_stat.h"
 #include "shader.h"
 #include "visualizer.h"
-#include "gpu-sim.h"
 
-unsigned mem_fetch::sm_next_mf_request_uid=1;
+unsigned mem_fetch::sm_next_mf_request_uid = 1;
 
-mem_fetch::mem_fetch( const mem_access_t &access, 
-                      const warp_inst_t *inst,
-                      unsigned ctrl_size, 
-                      unsigned wid,
-                      unsigned sid, 
-                      unsigned tpc, 
-                      const memory_config *config,
-					  unsigned long long cycle,
-					  mem_fetch *m_original_mf,
-					  mem_fetch *m_original_wr_mf):m_access(access)
+mem_fetch::mem_fetch(const mem_access_t &access, const warp_inst_t *inst,
+                     unsigned ctrl_size, unsigned wid, unsigned sid,
+                     unsigned tpc, const memory_config *config,
+                     unsigned long long cycle, mem_fetch *m_original_mf,
+                     mem_fetch *m_original_wr_mf)
+    : m_access(access)
 
 {
-   m_request_uid = sm_next_mf_request_uid++;
-   m_access = access;
-   if( inst ) { 
-       m_inst = *inst;
-       assert( wid == m_inst.warp_id() );
-   }
-   m_data_size = access.get_size();
-   m_ctrl_size = ctrl_size;
-   m_sid = sid;
-   m_tpc = tpc;
-   m_wid = wid;
-   config->m_address_mapping.addrdec_tlx(access.get_addr(),&m_raw_addr);
-   m_partition_addr = config->m_address_mapping.partition_address(access.get_addr());
-   m_type = m_access.is_write()?WRITE_REQUEST:READ_REQUEST;
-   m_timestamp = cycle;
-   m_timestamp2 = 0;
-   m_status = MEM_FETCH_INITIALIZED;
-   m_status_change = cycle;
-   m_mem_config = config;
-   icnt_flit_size = config->icnt_flit_size;
-   original_mf = m_original_mf;
-   original_wr_mf = m_original_wr_mf;
+  m_request_uid = sm_next_mf_request_uid++;
+  m_access = access;
+  if (inst) {
+    m_inst = *inst;
+    assert(wid == m_inst.warp_id());
+  }
+  m_data_size = access.get_size();
+  m_ctrl_size = ctrl_size;
+  m_sid = sid;
+  m_tpc = tpc;
+  m_wid = wid;
+  config->m_address_mapping.addrdec_tlx(access.get_addr(), &m_raw_addr);
+  m_partition_addr =
+      config->m_address_mapping.partition_address(access.get_addr());
+  m_type = m_access.is_write() ? WRITE_REQUEST : READ_REQUEST;
+  m_timestamp = cycle;
+  m_timestamp2 = 0;
+  m_status = MEM_FETCH_INITIALIZED;
+  m_status_change = cycle;
+  m_mem_config = config;
+  icnt_flit_size = config->icnt_flit_size;
+  original_mf = m_original_mf;
+  original_wr_mf = m_original_wr_mf;
 }
 
-mem_fetch::~mem_fetch()
-{
-    m_status = MEM_FETCH_DELETED;
-}
+mem_fetch::~mem_fetch() { m_status = MEM_FETCH_DELETED; }
 
-#define MF_TUP_BEGIN(X) static const char* Status_str[] = {
+#define MF_TUP_BEGIN(X) static const char *Status_str[] = {
 #define MF_TUP(X) #X
-#define MF_TUP_END(X) };
+#define MF_TUP_END(X) \
+  }                   \
+  ;
 #include "mem_fetch_status.tup"
 #undef MF_TUP_BEGIN
 #undef MF_TUP
 #undef MF_TUP_END
 
-void mem_fetch::print( FILE *fp, bool print_inst ) const
-{
-    if( this == NULL ) {
-        fprintf(fp," <NULL mem_fetch pointer>\n");
-        return;
-    }
-    fprintf(fp,"  mf: uid=%6u, sid%02u:w%02u, part=%u, ", m_request_uid, m_sid, m_wid, m_raw_addr.chip );
-    m_access.print(fp);
-    if( (unsigned)m_status < NUM_MEM_REQ_STAT ) 
-       fprintf(fp," status = %s (%llu), ", Status_str[m_status], m_status_change );
-    else
-       fprintf(fp," status = %u??? (%llu), ", m_status, m_status_change );
-    if( !m_inst.empty() && print_inst ) m_inst.print(fp);
-    else fprintf(fp,"\n");
+void mem_fetch::print(FILE *fp, bool print_inst) const {
+  if (this == NULL) {
+    fprintf(fp, " <NULL mem_fetch pointer>\n");
+    return;
+  }
+  fprintf(fp, "  mf: uid=%6u, sid%02u:w%02u, part=%u, ", m_request_uid, m_sid,
+          m_wid, m_raw_addr.chip);
+  m_access.print(fp);
+  if ((unsigned)m_status < NUM_MEM_REQ_STAT)
+    fprintf(fp, " status = %s (%llu), ", Status_str[m_status], m_status_change);
+  else
+    fprintf(fp, " status = %u??? (%llu), ", m_status, m_status_change);
+  if (!m_inst.empty() && print_inst)
+    m_inst.print(fp);
+  else
+    fprintf(fp, "\n");
 }
 
-void mem_fetch::set_status( enum mem_fetch_status status, unsigned long long cycle ) 
-{
-    m_status = status;
-    m_status_change = cycle;
+void mem_fetch::set_status(enum mem_fetch_status status,
+                           unsigned long long cycle) {
+  m_status = status;
+  m_status_change = cycle;
 }
 
-bool mem_fetch::isatomic() const
-{
-   if( m_inst.empty() ) return false;
-   return m_inst.isatomic();
+bool mem_fetch::isatomic() const {
+  if (m_inst.empty()) return false;
+  return m_inst.isatomic();
 }
 
-void mem_fetch::do_atomic()
-{
-    m_inst.do_atomic( m_access.get_warp_mask() );
+void mem_fetch::do_atomic() { m_inst.do_atomic(m_access.get_warp_mask()); }
+
+bool mem_fetch::istexture() const {
+  if (m_inst.empty()) return false;
+  return m_inst.space.get_type() == tex_space;
 }
 
-bool mem_fetch::istexture() const
-{
-    if( m_inst.empty() ) return false;
-    return m_inst.space.get_type() == tex_space;
+bool mem_fetch::isconst() const {
+  if (m_inst.empty()) return false;
+  return (m_inst.space.get_type() == const_space) ||
+         (m_inst.space.get_type() == param_space_kernel);
 }
 
-bool mem_fetch::isconst() const
-{ 
-    if( m_inst.empty() ) return false;
-    return (m_inst.space.get_type() == const_space) || (m_inst.space.get_type() == param_space_kernel);
+/// Returns number of flits traversing interconnect. simt_to_mem specifies the
+/// direction
+unsigned mem_fetch::get_num_flits(bool simt_to_mem) {
+  unsigned sz = 0;
+  // If atomic, write going to memory, or read coming back from memory, size =
+  // ctrl + data. Else, only ctrl
+  if (isatomic() || (simt_to_mem && get_is_write()) ||
+      !(simt_to_mem || get_is_write()))
+    sz = size();
+  else
+    sz = get_ctrl_size();
+
+  return (sz / icnt_flit_size) + ((sz % icnt_flit_size) ? 1 : 0);
 }
-
-/// Returns number of flits traversing interconnect. simt_to_mem specifies the direction
-unsigned mem_fetch::get_num_flits(bool simt_to_mem){
-	unsigned sz=0;
-	// If atomic, write going to memory, or read coming back from memory, size = ctrl + data. Else, only ctrl
-	if( isatomic() || (simt_to_mem && get_is_write()) || !(simt_to_mem || get_is_write()) )
-		sz = size();
-	else
-		sz = get_ctrl_size();
-
-	return (sz/icnt_flit_size) + ( (sz % icnt_flit_size)? 1:0);
-}
-
-
-

--- a/src/gpgpu-sim/mem_fetch.cc
+++ b/src/gpgpu-sim/mem_fetch.cc
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -28,111 +26,118 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "mem_fetch.h"
-#include "gpu-sim.h"
 #include "mem_latency_stat.h"
 #include "shader.h"
 #include "visualizer.h"
+#include "gpu-sim.h"
 
-unsigned mem_fetch::sm_next_mf_request_uid = 1;
+unsigned mem_fetch::sm_next_mf_request_uid=1;
 
-mem_fetch::mem_fetch(const mem_access_t &access, const warp_inst_t *inst,
-                     unsigned ctrl_size, unsigned wid, unsigned sid,
-                     unsigned tpc, const memory_config *config,
-                     unsigned long long cycle, mem_fetch *m_original_mf,
-                     mem_fetch *m_original_wr_mf)
-    : m_access(access)
+mem_fetch::mem_fetch( const mem_access_t &access, 
+                      const warp_inst_t *inst,
+                      unsigned ctrl_size, 
+                      unsigned wid,
+                      unsigned sid, 
+                      unsigned tpc, 
+                      const memory_config *config,
+					  unsigned long long cycle,
+					  mem_fetch *m_original_mf,
+					  mem_fetch *m_original_wr_mf):m_access(access)
 
 {
-  m_request_uid = sm_next_mf_request_uid++;
-  m_access = access;
-  if (inst) {
-    m_inst = *inst;
-    assert(wid == m_inst.warp_id());
-  }
-  m_data_size = access.get_size();
-  m_ctrl_size = ctrl_size;
-  m_sid = sid;
-  m_tpc = tpc;
-  m_wid = wid;
-  config->m_address_mapping.addrdec_tlx(access.get_addr(), &m_raw_addr);
-  m_partition_addr =
-      config->m_address_mapping.partition_address(access.get_addr());
-  m_type = m_access.is_write() ? WRITE_REQUEST : READ_REQUEST;
-  m_timestamp = cycle;
-  m_timestamp2 = 0;
-  m_status = MEM_FETCH_INITIALIZED;
-  m_status_change = cycle;
-  m_mem_config = config;
-  icnt_flit_size = config->icnt_flit_size;
-  original_mf = m_original_mf;
-  original_wr_mf = m_original_wr_mf;
+   m_request_uid = sm_next_mf_request_uid++;
+   m_access = access;
+   if( inst ) { 
+       m_inst = *inst;
+       assert( wid == m_inst.warp_id() );
+   }
+   m_data_size = access.get_size();
+   m_ctrl_size = ctrl_size;
+   m_sid = sid;
+   m_tpc = tpc;
+   m_wid = wid;
+   config->m_address_mapping.addrdec_tlx(access.get_addr(),&m_raw_addr);
+   m_partition_addr = config->m_address_mapping.partition_address(access.get_addr());
+   m_type = m_access.is_write()?WRITE_REQUEST:READ_REQUEST;
+   m_timestamp = cycle;
+   m_timestamp2 = 0;
+   m_status = MEM_FETCH_INITIALIZED;
+   m_status_change = cycle;
+   m_mem_config = config;
+   icnt_flit_size = config->icnt_flit_size;
+   original_mf = m_original_mf;
+   original_wr_mf = m_original_wr_mf;
 }
 
-mem_fetch::~mem_fetch() { m_status = MEM_FETCH_DELETED; }
+mem_fetch::~mem_fetch()
+{
+    m_status = MEM_FETCH_DELETED;
+}
 
-#define MF_TUP_BEGIN(X) static const char *Status_str[] = {
+#define MF_TUP_BEGIN(X) static const char* Status_str[] = {
 #define MF_TUP(X) #X
-#define MF_TUP_END(X) \
-  }                   \
-  ;
+#define MF_TUP_END(X) };
 #include "mem_fetch_status.tup"
 #undef MF_TUP_BEGIN
 #undef MF_TUP
 #undef MF_TUP_END
 
-void mem_fetch::print(FILE *fp, bool print_inst) const {
-  if (this == NULL) {
-    fprintf(fp, " <NULL mem_fetch pointer>\n");
-    return;
-  }
-  fprintf(fp, "  mf: uid=%6u, sid%02u:w%02u, part=%u, ", m_request_uid, m_sid,
-          m_wid, m_raw_addr.chip);
-  m_access.print(fp);
-  if ((unsigned)m_status < NUM_MEM_REQ_STAT)
-    fprintf(fp, " status = %s (%llu), ", Status_str[m_status], m_status_change);
-  else
-    fprintf(fp, " status = %u??? (%llu), ", m_status, m_status_change);
-  if (!m_inst.empty() && print_inst)
-    m_inst.print(fp);
-  else
-    fprintf(fp, "\n");
+void mem_fetch::print( FILE *fp, bool print_inst ) const
+{
+    if( this == NULL ) {
+        fprintf(fp," <NULL mem_fetch pointer>\n");
+        return;
+    }
+    fprintf(fp,"  mf: uid=%6u, sid%02u:w%02u, part=%u, ", m_request_uid, m_sid, m_wid, m_raw_addr.chip );
+    m_access.print(fp);
+    if( (unsigned)m_status < NUM_MEM_REQ_STAT ) 
+       fprintf(fp," status = %s (%llu), ", Status_str[m_status], m_status_change );
+    else
+       fprintf(fp," status = %u??? (%llu), ", m_status, m_status_change );
+    if( !m_inst.empty() && print_inst ) m_inst.print(fp);
+    else fprintf(fp,"\n");
 }
 
-void mem_fetch::set_status(enum mem_fetch_status status,
-                           unsigned long long cycle) {
-  m_status = status;
-  m_status_change = cycle;
+void mem_fetch::set_status( enum mem_fetch_status status, unsigned long long cycle ) 
+{
+    m_status = status;
+    m_status_change = cycle;
 }
 
-bool mem_fetch::isatomic() const {
-  if (m_inst.empty()) return false;
-  return m_inst.isatomic();
+bool mem_fetch::isatomic() const
+{
+   if( m_inst.empty() ) return false;
+   return m_inst.isatomic();
 }
 
-void mem_fetch::do_atomic() { m_inst.do_atomic(m_access.get_warp_mask()); }
-
-bool mem_fetch::istexture() const {
-  if (m_inst.empty()) return false;
-  return m_inst.space.get_type() == tex_space;
+void mem_fetch::do_atomic()
+{
+    m_inst.do_atomic( m_access.get_warp_mask() );
 }
 
-bool mem_fetch::isconst() const {
-  if (m_inst.empty()) return false;
-  return (m_inst.space.get_type() == const_space) ||
-         (m_inst.space.get_type() == param_space_kernel);
+bool mem_fetch::istexture() const
+{
+    if( m_inst.empty() ) return false;
+    return m_inst.space.get_type() == tex_space;
 }
 
-/// Returns number of flits traversing interconnect. simt_to_mem specifies the
-/// direction
-unsigned mem_fetch::get_num_flits(bool simt_to_mem) {
-  unsigned sz = 0;
-  // If atomic, write going to memory, or read coming back from memory, size =
-  // ctrl + data. Else, only ctrl
-  if (isatomic() || (simt_to_mem && get_is_write()) ||
-      !(simt_to_mem || get_is_write()))
-    sz = size();
-  else
-    sz = get_ctrl_size();
-
-  return (sz / icnt_flit_size) + ((sz % icnt_flit_size) ? 1 : 0);
+bool mem_fetch::isconst() const
+{ 
+    if( m_inst.empty() ) return false;
+    return (m_inst.space.get_type() == const_space) || (m_inst.space.get_type() == param_space_kernel);
 }
+
+/// Returns number of flits traversing interconnect. simt_to_mem specifies the direction
+unsigned mem_fetch::get_num_flits(bool simt_to_mem){
+	unsigned sz=0;
+	// If atomic, write going to memory, or read coming back from memory, size = ctrl + data. Else, only ctrl
+	if( isatomic() || (simt_to_mem && get_is_write()) || !(simt_to_mem || get_is_write()) )
+		sz = size();
+	else
+		sz = get_ctrl_size();
+
+	return (sz/icnt_flit_size) + ( (sz % icnt_flit_size)? 1:0);
+}
+
+
+

--- a/src/gpgpu-sim/mem_fetch.cc
+++ b/src/gpgpu-sim/mem_fetch.cc
@@ -7,137 +7,131 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #include "mem_fetch.h"
+#include "gpu-sim.h"
 #include "mem_latency_stat.h"
 #include "shader.h"
 #include "visualizer.h"
-#include "gpu-sim.h"
 
-unsigned mem_fetch::sm_next_mf_request_uid=1;
+unsigned mem_fetch::sm_next_mf_request_uid = 1;
 
-mem_fetch::mem_fetch( const mem_access_t &access, 
-                      const warp_inst_t *inst,
-                      unsigned ctrl_size, 
-                      unsigned wid,
-                      unsigned sid, 
-                      unsigned tpc, 
-                      const memory_config *config,
-					  unsigned long long cycle,
-					  mem_fetch *m_original_mf,
-					  mem_fetch *m_original_wr_mf):m_access(access)
+mem_fetch::mem_fetch(const mem_access_t &access, const warp_inst_t *inst,
+                     unsigned ctrl_size, unsigned wid, unsigned sid,
+                     unsigned tpc, const memory_config *config,
+                     unsigned long long cycle, mem_fetch *m_original_mf,
+                     mem_fetch *m_original_wr_mf)
+    : m_access(access)
 
 {
-   m_request_uid = sm_next_mf_request_uid++;
-   m_access = access;
-   if( inst ) { 
-       m_inst = *inst;
-       assert( wid == m_inst.warp_id() );
-   }
-   m_data_size = access.get_size();
-   m_ctrl_size = ctrl_size;
-   m_sid = sid;
-   m_tpc = tpc;
-   m_wid = wid;
-   config->m_address_mapping.addrdec_tlx(access.get_addr(),&m_raw_addr);
-   m_partition_addr = config->m_address_mapping.partition_address(access.get_addr());
-   m_type = m_access.is_write()?WRITE_REQUEST:READ_REQUEST;
-   m_timestamp = cycle;
-   m_timestamp2 = 0;
-   m_status = MEM_FETCH_INITIALIZED;
-   m_status_change = cycle;
-   m_mem_config = config;
-   icnt_flit_size = config->icnt_flit_size;
-   original_mf = m_original_mf;
-   original_wr_mf = m_original_wr_mf;
+  m_request_uid = sm_next_mf_request_uid++;
+  m_access = access;
+  if (inst) {
+    m_inst = *inst;
+    assert(wid == m_inst.warp_id());
+  }
+  m_data_size = access.get_size();
+  m_ctrl_size = ctrl_size;
+  m_sid = sid;
+  m_tpc = tpc;
+  m_wid = wid;
+  config->m_address_mapping.addrdec_tlx(access.get_addr(), &m_raw_addr);
+  m_partition_addr =
+      config->m_address_mapping.partition_address(access.get_addr());
+  m_type = m_access.is_write() ? WRITE_REQUEST : READ_REQUEST;
+  m_timestamp = cycle;
+  m_timestamp2 = 0;
+  m_status = MEM_FETCH_INITIALIZED;
+  m_status_change = cycle;
+  m_mem_config = config;
+  icnt_flit_size = config->icnt_flit_size;
+  original_mf = m_original_mf;
+  original_wr_mf = m_original_wr_mf;
 }
 
-mem_fetch::~mem_fetch()
-{
-    m_status = MEM_FETCH_DELETED;
-}
+mem_fetch::~mem_fetch() { m_status = MEM_FETCH_DELETED; }
 
-#define MF_TUP_BEGIN(X) static const char* Status_str[] = {
+#define MF_TUP_BEGIN(X) static const char *Status_str[] = {
 #define MF_TUP(X) #X
-#define MF_TUP_END(X) };
+#define MF_TUP_END(X) \
+  }                   \
+  ;
 #include "mem_fetch_status.tup"
 #undef MF_TUP_BEGIN
 #undef MF_TUP
 #undef MF_TUP_END
 
-void mem_fetch::print( FILE *fp, bool print_inst ) const
-{
-    if( this == NULL ) {
-        fprintf(fp," <NULL mem_fetch pointer>\n");
-        return;
-    }
-    fprintf(fp,"  mf: uid=%6u, sid%02u:w%02u, part=%u, ", m_request_uid, m_sid, m_wid, m_raw_addr.chip );
-    m_access.print(fp);
-    if( (unsigned)m_status < NUM_MEM_REQ_STAT ) 
-       fprintf(fp," status = %s (%llu), ", Status_str[m_status], m_status_change );
-    else
-       fprintf(fp," status = %u??? (%llu), ", m_status, m_status_change );
-    if( !m_inst.empty() && print_inst ) m_inst.print(fp);
-    else fprintf(fp,"\n");
+void mem_fetch::print(FILE *fp, bool print_inst) const {
+  if (this == NULL) {
+    fprintf(fp, " <NULL mem_fetch pointer>\n");
+    return;
+  }
+  fprintf(fp, "  mf: uid=%6u, sid%02u:w%02u, part=%u, ", m_request_uid, m_sid,
+          m_wid, m_raw_addr.chip);
+  m_access.print(fp);
+  if ((unsigned)m_status < NUM_MEM_REQ_STAT)
+    fprintf(fp, " status = %s (%llu), ", Status_str[m_status], m_status_change);
+  else
+    fprintf(fp, " status = %u??? (%llu), ", m_status, m_status_change);
+  if (!m_inst.empty() && print_inst)
+    m_inst.print(fp);
+  else
+    fprintf(fp, "\n");
 }
 
-void mem_fetch::set_status( enum mem_fetch_status status, unsigned long long cycle ) 
-{
-    m_status = status;
-    m_status_change = cycle;
+void mem_fetch::set_status(enum mem_fetch_status status,
+                           unsigned long long cycle) {
+  m_status = status;
+  m_status_change = cycle;
 }
 
-bool mem_fetch::isatomic() const
-{
-   if( m_inst.empty() ) return false;
-   return m_inst.isatomic();
+bool mem_fetch::isatomic() const {
+  if (m_inst.empty()) return false;
+  return m_inst.isatomic();
 }
 
-void mem_fetch::do_atomic()
-{
-    m_inst.do_atomic( m_access.get_warp_mask() );
+void mem_fetch::do_atomic() { m_inst.do_atomic(m_access.get_warp_mask()); }
+
+bool mem_fetch::istexture() const {
+  if (m_inst.empty()) return false;
+  return m_inst.space.get_type() == tex_space;
 }
 
-bool mem_fetch::istexture() const
-{
-    if( m_inst.empty() ) return false;
-    return m_inst.space.get_type() == tex_space;
+bool mem_fetch::isconst() const {
+  if (m_inst.empty()) return false;
+  return (m_inst.space.get_type() == const_space) ||
+         (m_inst.space.get_type() == param_space_kernel);
 }
 
-bool mem_fetch::isconst() const
-{ 
-    if( m_inst.empty() ) return false;
-    return (m_inst.space.get_type() == const_space) || (m_inst.space.get_type() == param_space_kernel);
+/// Returns number of flits traversing interconnect. simt_to_mem specifies the
+/// direction
+unsigned mem_fetch::get_num_flits(bool simt_to_mem) {
+  unsigned sz = 0;
+  // If atomic, write going to memory, or read coming back from memory, size =
+  // ctrl + data. Else, only ctrl
+  if (isatomic() || (simt_to_mem && get_is_write()) ||
+      !(simt_to_mem || get_is_write()))
+    sz = size();
+  else
+    sz = get_ctrl_size();
+
+  return (sz / icnt_flit_size) + ((sz % icnt_flit_size) ? 1 : 0);
 }
-
-/// Returns number of flits traversing interconnect. simt_to_mem specifies the direction
-unsigned mem_fetch::get_num_flits(bool simt_to_mem){
-	unsigned sz=0;
-	// If atomic, write going to memory, or read coming back from memory, size = ctrl + data. Else, only ctrl
-	if( isatomic() || (simt_to_mem && get_is_write()) || !(simt_to_mem || get_is_write()) )
-		sz = size();
-	else
-		sz = get_ctrl_size();
-
-	return (sz/icnt_flit_size) + ( (sz % icnt_flit_size)? 1:0);
-}
-
-
-

--- a/src/gpgpu-sim/mem_fetch.h
+++ b/src/gpgpu-sim/mem_fetch.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -28,20 +30,22 @@
 #ifndef MEM_FETCH_H
 #define MEM_FETCH_H
 
-#include "addrdec.h"
-#include "../abstract_hardware_model.h"
 #include <bitset>
+#include "../abstract_hardware_model.h"
+#include "addrdec.h"
 
 enum mf_type {
-   READ_REQUEST = 0,
-   WRITE_REQUEST,
-   READ_REPLY, // send to shader
-   WRITE_ACK
+  READ_REQUEST = 0,
+  WRITE_REQUEST,
+  READ_REPLY,  // send to shader
+  WRITE_ACK
 };
 
 #define MF_TUP_BEGIN(X) enum X {
 #define MF_TUP(X) X
-#define MF_TUP_END(X) };
+#define MF_TUP_END(X) \
+  }                   \
+  ;
 #include "mem_fetch_status.tup"
 #undef MF_TUP_BEGIN
 #undef MF_TUP
@@ -49,113 +53,124 @@ enum mf_type {
 
 class memory_config;
 class mem_fetch {
-public:
-    mem_fetch( const mem_access_t &access, 
-               const warp_inst_t *inst,
-               unsigned ctrl_size, 
-               unsigned wid,
-               unsigned sid, 
-               unsigned tpc, 
-               const memory_config *config,
-			   unsigned long long cycle,
-			   mem_fetch *original_mf = NULL,
-			   mem_fetch *original_wr_mf = NULL);
-   ~mem_fetch();
+ public:
+  mem_fetch(const mem_access_t &access, const warp_inst_t *inst,
+            unsigned ctrl_size, unsigned wid, unsigned sid, unsigned tpc,
+            const memory_config *config, unsigned long long cycle,
+            mem_fetch *original_mf = NULL, mem_fetch *original_wr_mf = NULL);
+  ~mem_fetch();
 
-   void set_status( enum mem_fetch_status status, unsigned long long cycle );
-   void set_reply() 
-   { 
-       assert( m_access.get_type() != L1_WRBK_ACC && m_access.get_type() != L2_WRBK_ACC );
-       if( m_type==READ_REQUEST ) {
-           assert( !get_is_write() );
-           m_type = READ_REPLY;
-       } else if( m_type == WRITE_REQUEST ) {
-           assert( get_is_write() );
-           m_type = WRITE_ACK;
-       }
-   }
-   void do_atomic();
+  void set_status(enum mem_fetch_status status, unsigned long long cycle);
+  void set_reply() {
+    assert(m_access.get_type() != L1_WRBK_ACC &&
+           m_access.get_type() != L2_WRBK_ACC);
+    if (m_type == READ_REQUEST) {
+      assert(!get_is_write());
+      m_type = READ_REPLY;
+    } else if (m_type == WRITE_REQUEST) {
+      assert(get_is_write());
+      m_type = WRITE_ACK;
+    }
+  }
+  void do_atomic();
 
-   void print( FILE *fp, bool print_inst = true ) const;
+  void print(FILE *fp, bool print_inst = true) const;
 
-   const addrdec_t &get_tlx_addr() const { return m_raw_addr; }
-   unsigned get_data_size() const { return m_data_size; }
-   void     set_data_size( unsigned size ) { m_data_size=size; }
-   unsigned get_ctrl_size() const { return m_ctrl_size; }
-   unsigned size() const { return m_data_size+m_ctrl_size; }
-   bool is_write() {return m_access.is_write();}
-   void set_addr(new_addr_type addr) { m_access.set_addr(addr); }
-   new_addr_type get_addr() const { return m_access.get_addr(); }
-   unsigned get_access_size() const { return m_access.get_size(); }
-   new_addr_type get_partition_addr() const { return m_partition_addr; }
-   unsigned get_sub_partition_id() const { return m_raw_addr.sub_partition; }
-   bool     get_is_write() const { return m_access.is_write(); }
-   unsigned get_request_uid() const { return m_request_uid; }
-   unsigned get_sid() const { return m_sid; }
-   unsigned get_tpc() const { return m_tpc; }
-   unsigned get_wid() const { return m_wid; }
-   bool istexture() const;
-   bool isconst() const;
-   enum mf_type get_type() const { return m_type; }
-   bool isatomic() const;
+  const addrdec_t &get_tlx_addr() const { return m_raw_addr; }
+  unsigned get_data_size() const { return m_data_size; }
+  void set_data_size(unsigned size) { m_data_size = size; }
+  unsigned get_ctrl_size() const { return m_ctrl_size; }
+  unsigned size() const { return m_data_size + m_ctrl_size; }
+  bool is_write() { return m_access.is_write(); }
+  void set_addr(new_addr_type addr) { m_access.set_addr(addr); }
+  new_addr_type get_addr() const { return m_access.get_addr(); }
+  unsigned get_access_size() const { return m_access.get_size(); }
+  new_addr_type get_partition_addr() const { return m_partition_addr; }
+  unsigned get_sub_partition_id() const { return m_raw_addr.sub_partition; }
+  bool get_is_write() const { return m_access.is_write(); }
+  unsigned get_request_uid() const { return m_request_uid; }
+  unsigned get_sid() const { return m_sid; }
+  unsigned get_tpc() const { return m_tpc; }
+  unsigned get_wid() const { return m_wid; }
+  bool istexture() const;
+  bool isconst() const;
+  enum mf_type get_type() const { return m_type; }
+  bool isatomic() const;
 
-   void set_return_timestamp( unsigned t ) { m_timestamp2=t; }
-   void set_icnt_receive_time( unsigned t ) { m_icnt_receive_time=t; }
-   unsigned get_timestamp() const { return m_timestamp; }
-   unsigned get_return_timestamp() const { return m_timestamp2; }
-   unsigned get_icnt_receive_time() const { return m_icnt_receive_time; }
+  void set_return_timestamp(unsigned t) { m_timestamp2 = t; }
+  void set_icnt_receive_time(unsigned t) { m_icnt_receive_time = t; }
+  unsigned get_timestamp() const { return m_timestamp; }
+  unsigned get_return_timestamp() const { return m_timestamp2; }
+  unsigned get_icnt_receive_time() const { return m_icnt_receive_time; }
 
-   enum mem_access_type get_access_type() const { return m_access.get_type(); }
-   const active_mask_t& get_access_warp_mask() const { return m_access.get_warp_mask(); }
-   mem_access_byte_mask_t get_access_byte_mask() const { return m_access.get_byte_mask(); }
-   mem_access_sector_mask_t get_access_sector_mask() const { return m_access.get_sector_mask(); }
+  enum mem_access_type get_access_type() const { return m_access.get_type(); }
+  const active_mask_t &get_access_warp_mask() const {
+    return m_access.get_warp_mask();
+  }
+  mem_access_byte_mask_t get_access_byte_mask() const {
+    return m_access.get_byte_mask();
+  }
+  mem_access_sector_mask_t get_access_sector_mask() const {
+    return m_access.get_sector_mask();
+  }
 
-   address_type get_pc() const { return m_inst.empty()?-1:m_inst.pc; }
-   const warp_inst_t &get_inst() { return m_inst; }
-   enum mem_fetch_status get_status() const { return m_status; }
+  address_type get_pc() const { return m_inst.empty() ? -1 : m_inst.pc; }
+  const warp_inst_t &get_inst() { return m_inst; }
+  enum mem_fetch_status get_status() const { return m_status; }
 
-   const memory_config *get_mem_config(){return m_mem_config;}
+  const memory_config *get_mem_config() { return m_mem_config; }
 
-   unsigned get_num_flits(bool simt_to_mem);
+  unsigned get_num_flits(bool simt_to_mem);
 
-   mem_fetch* get_original_mf() { return original_mf; }
-   mem_fetch* get_original_wr_mf()  { return original_wr_mf; }
+  mem_fetch *get_original_mf() { return original_mf; }
+  mem_fetch *get_original_wr_mf() { return original_wr_mf; }
 
-private:
-   // request source information
-   unsigned m_request_uid;
-   unsigned m_sid;
-   unsigned m_tpc;
-   unsigned m_wid;
+ private:
+  // request source information
+  unsigned m_request_uid;
+  unsigned m_sid;
+  unsigned m_tpc;
+  unsigned m_wid;
 
-   // where is this request now?
-   enum mem_fetch_status m_status;
-   unsigned long long m_status_change;
+  // where is this request now?
+  enum mem_fetch_status m_status;
+  unsigned long long m_status_change;
 
-   // request type, address, size, mask
-   mem_access_t m_access;
-   unsigned m_data_size; // how much data is being written
-   unsigned m_ctrl_size; // how big would all this meta data be in hardware (does not necessarily match actual size of mem_fetch)
-   new_addr_type m_partition_addr; // linear physical address *within* dram partition (partition bank select bits squeezed out)
-   addrdec_t m_raw_addr; // raw physical address (i.e., decoded DRAM chip-row-bank-column address)
-   enum mf_type m_type;
+  // request type, address, size, mask
+  mem_access_t m_access;
+  unsigned m_data_size;  // how much data is being written
+  unsigned m_ctrl_size;  // how big would all this meta data be in hardware
+                         // (does not necessarily match actual size of
+                         // mem_fetch)
+  new_addr_type m_partition_addr;  // linear physical address *within* dram
+                                   // partition (partition bank select bits
+                                   // squeezed out)
+  addrdec_t m_raw_addr;            // raw physical address (i.e., decoded DRAM
+                                   // chip-row-bank-column address)
+  enum mf_type m_type;
 
-   // statistics
-   unsigned m_timestamp;  // set to gpu_sim_cycle+gpu_tot_sim_cycle at struct creation
-   unsigned m_timestamp2; // set to gpu_sim_cycle+gpu_tot_sim_cycle when pushed onto icnt to shader; only used for reads
-   unsigned m_icnt_receive_time; // set to gpu_sim_cycle + interconnect_latency when fixed icnt latency mode is enabled
+  // statistics
+  unsigned
+      m_timestamp;  // set to gpu_sim_cycle+gpu_tot_sim_cycle at struct creation
+  unsigned m_timestamp2;  // set to gpu_sim_cycle+gpu_tot_sim_cycle when pushed
+                          // onto icnt to shader; only used for reads
+  unsigned m_icnt_receive_time;  // set to gpu_sim_cycle + interconnect_latency
+                                 // when fixed icnt latency mode is enabled
 
-   // requesting instruction (put last so mem_fetch prints nicer in gdb)
-   warp_inst_t m_inst;
+  // requesting instruction (put last so mem_fetch prints nicer in gdb)
+  warp_inst_t m_inst;
 
-   static unsigned sm_next_mf_request_uid;
+  static unsigned sm_next_mf_request_uid;
 
-   const memory_config *m_mem_config;
-   unsigned icnt_flit_size;
+  const memory_config *m_mem_config;
+  unsigned icnt_flit_size;
 
-   mem_fetch* original_mf;  //this pointer is set up when a request is divided into sector requests at L2 cache (if the req size > L2 sector size), so the pointer refers to the original request
-   mem_fetch* original_wr_mf;  //this pointer refers to the original write req, when fetch-on-write policy is used
-
+  mem_fetch *original_mf;  // this pointer is set up when a request is divided
+                           // into sector requests at L2 cache (if the req size
+                           // > L2 sector size), so the pointer refers to the
+                           // original request
+  mem_fetch *original_wr_mf;  // this pointer refers to the original write req,
+                              // when fetch-on-write policy is used
 };
 
 #endif

--- a/src/gpgpu-sim/mem_fetch.h
+++ b/src/gpgpu-sim/mem_fetch.h
@@ -7,41 +7,44 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef MEM_FETCH_H
 #define MEM_FETCH_H
 
-#include "addrdec.h"
-#include "../abstract_hardware_model.h"
 #include <bitset>
+#include "../abstract_hardware_model.h"
+#include "addrdec.h"
 
 enum mf_type {
-   READ_REQUEST = 0,
-   WRITE_REQUEST,
-   READ_REPLY, // send to shader
-   WRITE_ACK
+  READ_REQUEST = 0,
+  WRITE_REQUEST,
+  READ_REPLY,  // send to shader
+  WRITE_ACK
 };
 
 #define MF_TUP_BEGIN(X) enum X {
 #define MF_TUP(X) X
-#define MF_TUP_END(X) };
+#define MF_TUP_END(X) \
+  }                   \
+  ;
 #include "mem_fetch_status.tup"
 #undef MF_TUP_BEGIN
 #undef MF_TUP
@@ -49,113 +52,124 @@ enum mf_type {
 
 class memory_config;
 class mem_fetch {
-public:
-    mem_fetch( const mem_access_t &access, 
-               const warp_inst_t *inst,
-               unsigned ctrl_size, 
-               unsigned wid,
-               unsigned sid, 
-               unsigned tpc, 
-               const memory_config *config,
-			   unsigned long long cycle,
-			   mem_fetch *original_mf = NULL,
-			   mem_fetch *original_wr_mf = NULL);
-   ~mem_fetch();
+ public:
+  mem_fetch(const mem_access_t &access, const warp_inst_t *inst,
+            unsigned ctrl_size, unsigned wid, unsigned sid, unsigned tpc,
+            const memory_config *config, unsigned long long cycle,
+            mem_fetch *original_mf = NULL, mem_fetch *original_wr_mf = NULL);
+  ~mem_fetch();
 
-   void set_status( enum mem_fetch_status status, unsigned long long cycle );
-   void set_reply() 
-   { 
-       assert( m_access.get_type() != L1_WRBK_ACC && m_access.get_type() != L2_WRBK_ACC );
-       if( m_type==READ_REQUEST ) {
-           assert( !get_is_write() );
-           m_type = READ_REPLY;
-       } else if( m_type == WRITE_REQUEST ) {
-           assert( get_is_write() );
-           m_type = WRITE_ACK;
-       }
-   }
-   void do_atomic();
+  void set_status(enum mem_fetch_status status, unsigned long long cycle);
+  void set_reply() {
+    assert(m_access.get_type() != L1_WRBK_ACC &&
+           m_access.get_type() != L2_WRBK_ACC);
+    if (m_type == READ_REQUEST) {
+      assert(!get_is_write());
+      m_type = READ_REPLY;
+    } else if (m_type == WRITE_REQUEST) {
+      assert(get_is_write());
+      m_type = WRITE_ACK;
+    }
+  }
+  void do_atomic();
 
-   void print( FILE *fp, bool print_inst = true ) const;
+  void print(FILE *fp, bool print_inst = true) const;
 
-   const addrdec_t &get_tlx_addr() const { return m_raw_addr; }
-   unsigned get_data_size() const { return m_data_size; }
-   void     set_data_size( unsigned size ) { m_data_size=size; }
-   unsigned get_ctrl_size() const { return m_ctrl_size; }
-   unsigned size() const { return m_data_size+m_ctrl_size; }
-   bool is_write() {return m_access.is_write();}
-   void set_addr(new_addr_type addr) { m_access.set_addr(addr); }
-   new_addr_type get_addr() const { return m_access.get_addr(); }
-   unsigned get_access_size() const { return m_access.get_size(); }
-   new_addr_type get_partition_addr() const { return m_partition_addr; }
-   unsigned get_sub_partition_id() const { return m_raw_addr.sub_partition; }
-   bool     get_is_write() const { return m_access.is_write(); }
-   unsigned get_request_uid() const { return m_request_uid; }
-   unsigned get_sid() const { return m_sid; }
-   unsigned get_tpc() const { return m_tpc; }
-   unsigned get_wid() const { return m_wid; }
-   bool istexture() const;
-   bool isconst() const;
-   enum mf_type get_type() const { return m_type; }
-   bool isatomic() const;
+  const addrdec_t &get_tlx_addr() const { return m_raw_addr; }
+  unsigned get_data_size() const { return m_data_size; }
+  void set_data_size(unsigned size) { m_data_size = size; }
+  unsigned get_ctrl_size() const { return m_ctrl_size; }
+  unsigned size() const { return m_data_size + m_ctrl_size; }
+  bool is_write() { return m_access.is_write(); }
+  void set_addr(new_addr_type addr) { m_access.set_addr(addr); }
+  new_addr_type get_addr() const { return m_access.get_addr(); }
+  unsigned get_access_size() const { return m_access.get_size(); }
+  new_addr_type get_partition_addr() const { return m_partition_addr; }
+  unsigned get_sub_partition_id() const { return m_raw_addr.sub_partition; }
+  bool get_is_write() const { return m_access.is_write(); }
+  unsigned get_request_uid() const { return m_request_uid; }
+  unsigned get_sid() const { return m_sid; }
+  unsigned get_tpc() const { return m_tpc; }
+  unsigned get_wid() const { return m_wid; }
+  bool istexture() const;
+  bool isconst() const;
+  enum mf_type get_type() const { return m_type; }
+  bool isatomic() const;
 
-   void set_return_timestamp( unsigned t ) { m_timestamp2=t; }
-   void set_icnt_receive_time( unsigned t ) { m_icnt_receive_time=t; }
-   unsigned get_timestamp() const { return m_timestamp; }
-   unsigned get_return_timestamp() const { return m_timestamp2; }
-   unsigned get_icnt_receive_time() const { return m_icnt_receive_time; }
+  void set_return_timestamp(unsigned t) { m_timestamp2 = t; }
+  void set_icnt_receive_time(unsigned t) { m_icnt_receive_time = t; }
+  unsigned get_timestamp() const { return m_timestamp; }
+  unsigned get_return_timestamp() const { return m_timestamp2; }
+  unsigned get_icnt_receive_time() const { return m_icnt_receive_time; }
 
-   enum mem_access_type get_access_type() const { return m_access.get_type(); }
-   const active_mask_t& get_access_warp_mask() const { return m_access.get_warp_mask(); }
-   mem_access_byte_mask_t get_access_byte_mask() const { return m_access.get_byte_mask(); }
-   mem_access_sector_mask_t get_access_sector_mask() const { return m_access.get_sector_mask(); }
+  enum mem_access_type get_access_type() const { return m_access.get_type(); }
+  const active_mask_t &get_access_warp_mask() const {
+    return m_access.get_warp_mask();
+  }
+  mem_access_byte_mask_t get_access_byte_mask() const {
+    return m_access.get_byte_mask();
+  }
+  mem_access_sector_mask_t get_access_sector_mask() const {
+    return m_access.get_sector_mask();
+  }
 
-   address_type get_pc() const { return m_inst.empty()?-1:m_inst.pc; }
-   const warp_inst_t &get_inst() { return m_inst; }
-   enum mem_fetch_status get_status() const { return m_status; }
+  address_type get_pc() const { return m_inst.empty() ? -1 : m_inst.pc; }
+  const warp_inst_t &get_inst() { return m_inst; }
+  enum mem_fetch_status get_status() const { return m_status; }
 
-   const memory_config *get_mem_config(){return m_mem_config;}
+  const memory_config *get_mem_config() { return m_mem_config; }
 
-   unsigned get_num_flits(bool simt_to_mem);
+  unsigned get_num_flits(bool simt_to_mem);
 
-   mem_fetch* get_original_mf() { return original_mf; }
-   mem_fetch* get_original_wr_mf()  { return original_wr_mf; }
+  mem_fetch *get_original_mf() { return original_mf; }
+  mem_fetch *get_original_wr_mf() { return original_wr_mf; }
 
-private:
-   // request source information
-   unsigned m_request_uid;
-   unsigned m_sid;
-   unsigned m_tpc;
-   unsigned m_wid;
+ private:
+  // request source information
+  unsigned m_request_uid;
+  unsigned m_sid;
+  unsigned m_tpc;
+  unsigned m_wid;
 
-   // where is this request now?
-   enum mem_fetch_status m_status;
-   unsigned long long m_status_change;
+  // where is this request now?
+  enum mem_fetch_status m_status;
+  unsigned long long m_status_change;
 
-   // request type, address, size, mask
-   mem_access_t m_access;
-   unsigned m_data_size; // how much data is being written
-   unsigned m_ctrl_size; // how big would all this meta data be in hardware (does not necessarily match actual size of mem_fetch)
-   new_addr_type m_partition_addr; // linear physical address *within* dram partition (partition bank select bits squeezed out)
-   addrdec_t m_raw_addr; // raw physical address (i.e., decoded DRAM chip-row-bank-column address)
-   enum mf_type m_type;
+  // request type, address, size, mask
+  mem_access_t m_access;
+  unsigned m_data_size;  // how much data is being written
+  unsigned
+      m_ctrl_size;  // how big would all this meta data be in hardware (does not
+                    // necessarily match actual size of mem_fetch)
+  new_addr_type
+      m_partition_addr;  // linear physical address *within* dram partition
+                         // (partition bank select bits squeezed out)
+  addrdec_t m_raw_addr;  // raw physical address (i.e., decoded DRAM
+                         // chip-row-bank-column address)
+  enum mf_type m_type;
 
-   // statistics
-   unsigned m_timestamp;  // set to gpu_sim_cycle+gpu_tot_sim_cycle at struct creation
-   unsigned m_timestamp2; // set to gpu_sim_cycle+gpu_tot_sim_cycle when pushed onto icnt to shader; only used for reads
-   unsigned m_icnt_receive_time; // set to gpu_sim_cycle + interconnect_latency when fixed icnt latency mode is enabled
+  // statistics
+  unsigned
+      m_timestamp;  // set to gpu_sim_cycle+gpu_tot_sim_cycle at struct creation
+  unsigned m_timestamp2;  // set to gpu_sim_cycle+gpu_tot_sim_cycle when pushed
+                          // onto icnt to shader; only used for reads
+  unsigned m_icnt_receive_time;  // set to gpu_sim_cycle + interconnect_latency
+                                 // when fixed icnt latency mode is enabled
 
-   // requesting instruction (put last so mem_fetch prints nicer in gdb)
-   warp_inst_t m_inst;
+  // requesting instruction (put last so mem_fetch prints nicer in gdb)
+  warp_inst_t m_inst;
 
-   static unsigned sm_next_mf_request_uid;
+  static unsigned sm_next_mf_request_uid;
 
-   const memory_config *m_mem_config;
-   unsigned icnt_flit_size;
+  const memory_config *m_mem_config;
+  unsigned icnt_flit_size;
 
-   mem_fetch* original_mf;  //this pointer is set up when a request is divided into sector requests at L2 cache (if the req size > L2 sector size), so the pointer refers to the original request
-   mem_fetch* original_wr_mf;  //this pointer refers to the original write req, when fetch-on-write policy is used
-
+  mem_fetch
+      *original_mf;  // this pointer is set up when a request is divided into
+                     // sector requests at L2 cache (if the req size > L2 sector
+                     // size), so the pointer refers to the original request
+  mem_fetch *original_wr_mf;  // this pointer refers to the original write req,
+                              // when fetch-on-write policy is used
 };
 
 #endif

--- a/src/gpgpu-sim/mem_fetch.h
+++ b/src/gpgpu-sim/mem_fetch.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -30,22 +28,20 @@
 #ifndef MEM_FETCH_H
 #define MEM_FETCH_H
 
-#include <bitset>
-#include "../abstract_hardware_model.h"
 #include "addrdec.h"
+#include "../abstract_hardware_model.h"
+#include <bitset>
 
 enum mf_type {
-  READ_REQUEST = 0,
-  WRITE_REQUEST,
-  READ_REPLY,  // send to shader
-  WRITE_ACK
+   READ_REQUEST = 0,
+   WRITE_REQUEST,
+   READ_REPLY, // send to shader
+   WRITE_ACK
 };
 
 #define MF_TUP_BEGIN(X) enum X {
 #define MF_TUP(X) X
-#define MF_TUP_END(X) \
-  }                   \
-  ;
+#define MF_TUP_END(X) };
 #include "mem_fetch_status.tup"
 #undef MF_TUP_BEGIN
 #undef MF_TUP
@@ -53,124 +49,113 @@ enum mf_type {
 
 class memory_config;
 class mem_fetch {
- public:
-  mem_fetch(const mem_access_t &access, const warp_inst_t *inst,
-            unsigned ctrl_size, unsigned wid, unsigned sid, unsigned tpc,
-            const memory_config *config, unsigned long long cycle,
-            mem_fetch *original_mf = NULL, mem_fetch *original_wr_mf = NULL);
-  ~mem_fetch();
+public:
+    mem_fetch( const mem_access_t &access, 
+               const warp_inst_t *inst,
+               unsigned ctrl_size, 
+               unsigned wid,
+               unsigned sid, 
+               unsigned tpc, 
+               const memory_config *config,
+			   unsigned long long cycle,
+			   mem_fetch *original_mf = NULL,
+			   mem_fetch *original_wr_mf = NULL);
+   ~mem_fetch();
 
-  void set_status(enum mem_fetch_status status, unsigned long long cycle);
-  void set_reply() {
-    assert(m_access.get_type() != L1_WRBK_ACC &&
-           m_access.get_type() != L2_WRBK_ACC);
-    if (m_type == READ_REQUEST) {
-      assert(!get_is_write());
-      m_type = READ_REPLY;
-    } else if (m_type == WRITE_REQUEST) {
-      assert(get_is_write());
-      m_type = WRITE_ACK;
-    }
-  }
-  void do_atomic();
+   void set_status( enum mem_fetch_status status, unsigned long long cycle );
+   void set_reply() 
+   { 
+       assert( m_access.get_type() != L1_WRBK_ACC && m_access.get_type() != L2_WRBK_ACC );
+       if( m_type==READ_REQUEST ) {
+           assert( !get_is_write() );
+           m_type = READ_REPLY;
+       } else if( m_type == WRITE_REQUEST ) {
+           assert( get_is_write() );
+           m_type = WRITE_ACK;
+       }
+   }
+   void do_atomic();
 
-  void print(FILE *fp, bool print_inst = true) const;
+   void print( FILE *fp, bool print_inst = true ) const;
 
-  const addrdec_t &get_tlx_addr() const { return m_raw_addr; }
-  unsigned get_data_size() const { return m_data_size; }
-  void set_data_size(unsigned size) { m_data_size = size; }
-  unsigned get_ctrl_size() const { return m_ctrl_size; }
-  unsigned size() const { return m_data_size + m_ctrl_size; }
-  bool is_write() { return m_access.is_write(); }
-  void set_addr(new_addr_type addr) { m_access.set_addr(addr); }
-  new_addr_type get_addr() const { return m_access.get_addr(); }
-  unsigned get_access_size() const { return m_access.get_size(); }
-  new_addr_type get_partition_addr() const { return m_partition_addr; }
-  unsigned get_sub_partition_id() const { return m_raw_addr.sub_partition; }
-  bool get_is_write() const { return m_access.is_write(); }
-  unsigned get_request_uid() const { return m_request_uid; }
-  unsigned get_sid() const { return m_sid; }
-  unsigned get_tpc() const { return m_tpc; }
-  unsigned get_wid() const { return m_wid; }
-  bool istexture() const;
-  bool isconst() const;
-  enum mf_type get_type() const { return m_type; }
-  bool isatomic() const;
+   const addrdec_t &get_tlx_addr() const { return m_raw_addr; }
+   unsigned get_data_size() const { return m_data_size; }
+   void     set_data_size( unsigned size ) { m_data_size=size; }
+   unsigned get_ctrl_size() const { return m_ctrl_size; }
+   unsigned size() const { return m_data_size+m_ctrl_size; }
+   bool is_write() {return m_access.is_write();}
+   void set_addr(new_addr_type addr) { m_access.set_addr(addr); }
+   new_addr_type get_addr() const { return m_access.get_addr(); }
+   unsigned get_access_size() const { return m_access.get_size(); }
+   new_addr_type get_partition_addr() const { return m_partition_addr; }
+   unsigned get_sub_partition_id() const { return m_raw_addr.sub_partition; }
+   bool     get_is_write() const { return m_access.is_write(); }
+   unsigned get_request_uid() const { return m_request_uid; }
+   unsigned get_sid() const { return m_sid; }
+   unsigned get_tpc() const { return m_tpc; }
+   unsigned get_wid() const { return m_wid; }
+   bool istexture() const;
+   bool isconst() const;
+   enum mf_type get_type() const { return m_type; }
+   bool isatomic() const;
 
-  void set_return_timestamp(unsigned t) { m_timestamp2 = t; }
-  void set_icnt_receive_time(unsigned t) { m_icnt_receive_time = t; }
-  unsigned get_timestamp() const { return m_timestamp; }
-  unsigned get_return_timestamp() const { return m_timestamp2; }
-  unsigned get_icnt_receive_time() const { return m_icnt_receive_time; }
+   void set_return_timestamp( unsigned t ) { m_timestamp2=t; }
+   void set_icnt_receive_time( unsigned t ) { m_icnt_receive_time=t; }
+   unsigned get_timestamp() const { return m_timestamp; }
+   unsigned get_return_timestamp() const { return m_timestamp2; }
+   unsigned get_icnt_receive_time() const { return m_icnt_receive_time; }
 
-  enum mem_access_type get_access_type() const { return m_access.get_type(); }
-  const active_mask_t &get_access_warp_mask() const {
-    return m_access.get_warp_mask();
-  }
-  mem_access_byte_mask_t get_access_byte_mask() const {
-    return m_access.get_byte_mask();
-  }
-  mem_access_sector_mask_t get_access_sector_mask() const {
-    return m_access.get_sector_mask();
-  }
+   enum mem_access_type get_access_type() const { return m_access.get_type(); }
+   const active_mask_t& get_access_warp_mask() const { return m_access.get_warp_mask(); }
+   mem_access_byte_mask_t get_access_byte_mask() const { return m_access.get_byte_mask(); }
+   mem_access_sector_mask_t get_access_sector_mask() const { return m_access.get_sector_mask(); }
 
-  address_type get_pc() const { return m_inst.empty() ? -1 : m_inst.pc; }
-  const warp_inst_t &get_inst() { return m_inst; }
-  enum mem_fetch_status get_status() const { return m_status; }
+   address_type get_pc() const { return m_inst.empty()?-1:m_inst.pc; }
+   const warp_inst_t &get_inst() { return m_inst; }
+   enum mem_fetch_status get_status() const { return m_status; }
 
-  const memory_config *get_mem_config() { return m_mem_config; }
+   const memory_config *get_mem_config(){return m_mem_config;}
 
-  unsigned get_num_flits(bool simt_to_mem);
+   unsigned get_num_flits(bool simt_to_mem);
 
-  mem_fetch *get_original_mf() { return original_mf; }
-  mem_fetch *get_original_wr_mf() { return original_wr_mf; }
+   mem_fetch* get_original_mf() { return original_mf; }
+   mem_fetch* get_original_wr_mf()  { return original_wr_mf; }
 
- private:
-  // request source information
-  unsigned m_request_uid;
-  unsigned m_sid;
-  unsigned m_tpc;
-  unsigned m_wid;
+private:
+   // request source information
+   unsigned m_request_uid;
+   unsigned m_sid;
+   unsigned m_tpc;
+   unsigned m_wid;
 
-  // where is this request now?
-  enum mem_fetch_status m_status;
-  unsigned long long m_status_change;
+   // where is this request now?
+   enum mem_fetch_status m_status;
+   unsigned long long m_status_change;
 
-  // request type, address, size, mask
-  mem_access_t m_access;
-  unsigned m_data_size;  // how much data is being written
-  unsigned m_ctrl_size;  // how big would all this meta data be in hardware
-                         // (does not necessarily match actual size of
-                         // mem_fetch)
-  new_addr_type m_partition_addr;  // linear physical address *within* dram
-                                   // partition (partition bank select bits
-                                   // squeezed out)
-  addrdec_t m_raw_addr;            // raw physical address (i.e., decoded DRAM
-                                   // chip-row-bank-column address)
-  enum mf_type m_type;
+   // request type, address, size, mask
+   mem_access_t m_access;
+   unsigned m_data_size; // how much data is being written
+   unsigned m_ctrl_size; // how big would all this meta data be in hardware (does not necessarily match actual size of mem_fetch)
+   new_addr_type m_partition_addr; // linear physical address *within* dram partition (partition bank select bits squeezed out)
+   addrdec_t m_raw_addr; // raw physical address (i.e., decoded DRAM chip-row-bank-column address)
+   enum mf_type m_type;
 
-  // statistics
-  unsigned
-      m_timestamp;  // set to gpu_sim_cycle+gpu_tot_sim_cycle at struct creation
-  unsigned m_timestamp2;  // set to gpu_sim_cycle+gpu_tot_sim_cycle when pushed
-                          // onto icnt to shader; only used for reads
-  unsigned m_icnt_receive_time;  // set to gpu_sim_cycle + interconnect_latency
-                                 // when fixed icnt latency mode is enabled
+   // statistics
+   unsigned m_timestamp;  // set to gpu_sim_cycle+gpu_tot_sim_cycle at struct creation
+   unsigned m_timestamp2; // set to gpu_sim_cycle+gpu_tot_sim_cycle when pushed onto icnt to shader; only used for reads
+   unsigned m_icnt_receive_time; // set to gpu_sim_cycle + interconnect_latency when fixed icnt latency mode is enabled
 
-  // requesting instruction (put last so mem_fetch prints nicer in gdb)
-  warp_inst_t m_inst;
+   // requesting instruction (put last so mem_fetch prints nicer in gdb)
+   warp_inst_t m_inst;
 
-  static unsigned sm_next_mf_request_uid;
+   static unsigned sm_next_mf_request_uid;
 
-  const memory_config *m_mem_config;
-  unsigned icnt_flit_size;
+   const memory_config *m_mem_config;
+   unsigned icnt_flit_size;
 
-  mem_fetch *original_mf;  // this pointer is set up when a request is divided
-                           // into sector requests at L2 cache (if the req size
-                           // > L2 sector size), so the pointer refers to the
-                           // original request
-  mem_fetch *original_wr_mf;  // this pointer refers to the original write req,
-                              // when fetch-on-write policy is used
+   mem_fetch* original_mf;  //this pointer is set up when a request is divided into sector requests at L2 cache (if the req size > L2 sector size), so the pointer refers to the original request
+   mem_fetch* original_wr_mf;  //this pointer refers to the original write req, when fetch-on-write policy is used
+
 };
 
 #endif

--- a/src/gpgpu-sim/mem_latency_stat.cc
+++ b/src/gpgpu-sim/mem_latency_stat.cc
@@ -8,16 +8,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -28,494 +26,456 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "mem_latency_stat.h"
 #include "../abstract_hardware_model.h"
-#include "../cuda-sim/ptx-stats.h"
-#include "dram.h"
-#include "gpu-cache.h"
-#include "gpu-misc.h"
+#include "mem_latency_stat.h"
 #include "gpu-sim.h"
-#include "mem_fetch.h"
+#include "gpu-misc.h"
+#include "gpu-cache.h"
 #include "shader.h"
+#include "mem_fetch.h"
 #include "stat-tool.h"
+#include "../cuda-sim/ptx-stats.h"
 #include "visualizer.h"
+#include "dram.h"
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
 #include "../../libcuda/gpgpu_context.h"
 
-memory_stats_t::memory_stats_t(unsigned n_shader,
-                               const shader_core_config *shader_config,
-                               const memory_config *mem_config,
-                               const class gpgpu_sim *gpu) {
-  assert(mem_config->m_valid);
-  assert(shader_config->m_valid);
+memory_stats_t::memory_stats_t( unsigned n_shader, const shader_core_config *shader_config, const memory_config *mem_config, const class gpgpu_sim* gpu )
+{
+   assert( mem_config->m_valid );
+   assert( shader_config->m_valid );
 
-  unsigned i, j;
+   unsigned i,j;
 
-  concurrent_row_access =
-      (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
-  num_activates =
-      (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
-  row_access =
-      (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
-  max_conc_access2samerow =
-      (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
-  max_servicetime2samerow =
-      (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
 
-  for (unsigned i = 0; i < mem_config->m_n_mem; i++) {
-    concurrent_row_access[i] =
-        (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
-    row_access[i] =
-        (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
-    num_activates[i] =
-        (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
-    max_conc_access2samerow[i] =
-        (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
-    max_servicetime2samerow[i] =
-        (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
-  }
+   concurrent_row_access = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
+   num_activates = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
+   row_access = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
+   max_conc_access2samerow = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
+   max_servicetime2samerow = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
 
-  m_n_shader = n_shader;
-  m_memory_config = mem_config;
-  m_gpu = gpu;
-  total_n_access = 0;
-  total_n_reads = 0;
-  total_n_writes = 0;
-  max_mrq_latency = 0;
-  max_dq_latency = 0;
-  max_mf_latency = 0;
-  max_icnt2mem_latency = 0;
-  max_icnt2sh_latency = 0;
-  tot_icnt2mem_latency = 0;
-  tot_icnt2sh_latency = 0;
-  tot_mrq_num = 0;
-  tot_mrq_latency = 0;
-  memset(mrq_lat_table, 0, sizeof(unsigned) * 32);
-  memset(dq_lat_table, 0, sizeof(unsigned) * 32);
-  memset(mf_lat_table, 0, sizeof(unsigned) * 32);
-  memset(icnt2mem_lat_table, 0, sizeof(unsigned) * 24);
-  memset(icnt2sh_lat_table, 0, sizeof(unsigned) * 24);
-  memset(mf_lat_pw_table, 0, sizeof(unsigned) * 32);
-  mf_num_lat_pw = 0;
-  max_warps =
-      n_shader *
-      (shader_config->n_thread_per_shader / shader_config->warp_size + 1);
-  mf_tot_lat_pw = 0;  // total latency summed up per window. divide by
-                      // mf_num_lat_pw to obtain average latency Per Window
-  mf_total_lat = 0;
-  num_mfs = 0;
-  printf("*** Initializing Memory Statistics ***\n");
-  totalbankreads =
-      (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
-  totalbankwrites =
-      (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
-  totalbankaccesses =
-      (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
-  mf_total_lat_table = (unsigned long long int **)calloc(
-      mem_config->m_n_mem, sizeof(unsigned long long *));
-  mf_max_lat_table =
-      (unsigned **)calloc(mem_config->m_n_mem, sizeof(unsigned *));
-  bankreads = (unsigned int ***)calloc(n_shader, sizeof(unsigned int **));
-  bankwrites = (unsigned int ***)calloc(n_shader, sizeof(unsigned int **));
-  num_MCBs_accessed = (unsigned int *)calloc(
-      mem_config->m_n_mem * mem_config->nbk, sizeof(unsigned int));
-  if (mem_config->gpgpu_frfcfs_dram_sched_queue_size) {
-    position_of_mrq_chosen = (unsigned int *)calloc(
-        mem_config->gpgpu_frfcfs_dram_sched_queue_size, sizeof(unsigned int));
-  } else
-    position_of_mrq_chosen = (unsigned int *)calloc(1024, sizeof(unsigned int));
-  for (i = 0; i < n_shader; i++) {
-    bankreads[i] =
-        (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
-    bankwrites[i] =
-        (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
-    for (j = 0; j < mem_config->m_n_mem; j++) {
-      bankreads[i][j] =
-          (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
-      bankwrites[i][j] =
-          (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
-    }
-  }
+   for (unsigned i=0;i<mem_config->m_n_mem ;i++ ) {
+      concurrent_row_access[i] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
+      row_access[i] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
+      num_activates[i] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
+      max_conc_access2samerow[i] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
+      max_servicetime2samerow[i] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
+   }
 
-  for (i = 0; i < mem_config->m_n_mem; i++) {
-    totalbankreads[i] =
-        (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
-    totalbankwrites[i] =
-        (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
-    totalbankaccesses[i] =
-        (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
-    mf_total_lat_table[i] = (unsigned long long int *)calloc(
-        mem_config->nbk, sizeof(unsigned long long int));
-    mf_max_lat_table[i] = (unsigned *)calloc(mem_config->nbk, sizeof(unsigned));
-  }
 
-  mem_access_type_stats =
-      (unsigned ***)malloc(NUM_MEM_ACCESS_TYPE * sizeof(unsigned **));
-  for (i = 0; i < NUM_MEM_ACCESS_TYPE; i++) {
-    int j;
-    mem_access_type_stats[i] =
-        (unsigned **)calloc(mem_config->m_n_mem, sizeof(unsigned *));
-    for (j = 0; (unsigned)j < mem_config->m_n_mem; j++) {
-      mem_access_type_stats[i][j] =
-          (unsigned *)calloc((mem_config->nbk + 1), sizeof(unsigned *));
-    }
-  }
+   m_n_shader=n_shader;
+   m_memory_config=mem_config;
+   m_gpu=gpu;
+   total_n_access=0;
+   total_n_reads=0;
+   total_n_writes=0;
+   max_mrq_latency = 0;
+   max_dq_latency = 0;
+   max_mf_latency = 0;
+   max_icnt2mem_latency = 0;
+   max_icnt2sh_latency = 0;
+   tot_icnt2mem_latency = 0;
+   tot_icnt2sh_latency = 0;
+   tot_mrq_num = 0;
+   tot_mrq_latency = 0;
+   memset(mrq_lat_table, 0, sizeof(unsigned)*32);
+   memset(dq_lat_table, 0, sizeof(unsigned)*32);
+   memset(mf_lat_table, 0, sizeof(unsigned)*32);
+   memset(icnt2mem_lat_table, 0, sizeof(unsigned)*24);
+   memset(icnt2sh_lat_table, 0, sizeof(unsigned)*24);
+   memset(mf_lat_pw_table, 0, sizeof(unsigned)*32);
+   mf_num_lat_pw = 0;
+   max_warps = n_shader * (shader_config->n_thread_per_shader / shader_config->warp_size+1);
+   mf_tot_lat_pw = 0; //total latency summed up per window. divide by mf_num_lat_pw to obtain average latency Per Window
+   mf_total_lat = 0;
+   num_mfs = 0;
+   printf("*** Initializing Memory Statistics ***\n");
+   totalbankreads = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
+   totalbankwrites = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
+   totalbankaccesses = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
+   mf_total_lat_table = (unsigned long long int **) calloc(mem_config->m_n_mem, sizeof(unsigned long long *));
+   mf_max_lat_table = (unsigned **) calloc(mem_config->m_n_mem, sizeof(unsigned *));
+   bankreads = (unsigned int***) calloc(n_shader, sizeof(unsigned int**));
+   bankwrites = (unsigned int***) calloc(n_shader, sizeof(unsigned int**));
+   num_MCBs_accessed = (unsigned int*) calloc(mem_config->m_n_mem*mem_config->nbk, sizeof(unsigned int));
+   if (mem_config->gpgpu_frfcfs_dram_sched_queue_size) {
+      position_of_mrq_chosen = (unsigned int*) calloc(mem_config->gpgpu_frfcfs_dram_sched_queue_size, sizeof(unsigned int));
+   } else
+      position_of_mrq_chosen = (unsigned int*) calloc(1024, sizeof(unsigned int));
+   for (i=0;i<n_shader ;i++ ) {
+      bankreads[i] = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
+      bankwrites[i] = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
+      for (j=0;j<mem_config->m_n_mem ;j++ ) {
+         bankreads[i][j] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
+         bankwrites[i][j] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
+      }
+   }
 
-  // AerialVision L2 stats
-  L2_read_miss = 0;
-  L2_write_miss = 0;
-  L2_read_hit = 0;
-  L2_write_hit = 0;
+   for (i=0;i<mem_config->m_n_mem ;i++ ) {
+      totalbankreads[i] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
+      totalbankwrites[i] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
+      totalbankaccesses[i] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
+      mf_total_lat_table[i] = (unsigned long long int*) calloc(mem_config->nbk, sizeof(unsigned long long int));
+      mf_max_lat_table[i] = (unsigned *) calloc(mem_config->nbk, sizeof(unsigned));
+   }
 
-  L2_cbtoL2length =
-      (unsigned int *)calloc(mem_config->m_n_mem, sizeof(unsigned int));
-  L2_cbtoL2writelength =
-      (unsigned int *)calloc(mem_config->m_n_mem, sizeof(unsigned int));
-  L2_L2tocblength =
-      (unsigned int *)calloc(mem_config->m_n_mem, sizeof(unsigned int));
-  L2_dramtoL2length =
-      (unsigned int *)calloc(mem_config->m_n_mem, sizeof(unsigned int));
-  L2_dramtoL2writelength =
-      (unsigned int *)calloc(mem_config->m_n_mem, sizeof(unsigned int));
-  L2_L2todramlength =
-      (unsigned int *)calloc(mem_config->m_n_mem, sizeof(unsigned int));
+   mem_access_type_stats = (unsigned ***) malloc(NUM_MEM_ACCESS_TYPE * sizeof(unsigned **));
+   for (i = 0; i < NUM_MEM_ACCESS_TYPE; i++) {
+      int j;
+      mem_access_type_stats[i] = (unsigned **) calloc(mem_config->m_n_mem, sizeof(unsigned*));
+      for (j=0; (unsigned) j< mem_config->m_n_mem; j++) {
+         mem_access_type_stats[i][j] = (unsigned *) calloc((mem_config->nbk+1), sizeof(unsigned*));
+      }
+   }
+
+   // AerialVision L2 stats
+   L2_read_miss = 0;
+   L2_write_miss = 0;
+   L2_read_hit = 0;
+   L2_write_hit = 0;
+
+   L2_cbtoL2length = (unsigned int*) calloc(mem_config->m_n_mem, sizeof(unsigned int));
+   L2_cbtoL2writelength = (unsigned int*) calloc(mem_config->m_n_mem, sizeof(unsigned int));
+   L2_L2tocblength = (unsigned int*) calloc(mem_config->m_n_mem, sizeof(unsigned int));
+   L2_dramtoL2length = (unsigned int*) calloc(mem_config->m_n_mem, sizeof(unsigned int));
+   L2_dramtoL2writelength = (unsigned int*) calloc(mem_config->m_n_mem, sizeof(unsigned int));
+   L2_L2todramlength = (unsigned int*) calloc(mem_config->m_n_mem, sizeof(unsigned int));
 }
 
 // record the total latency
-unsigned memory_stats_t::memlatstat_done(mem_fetch *mf) {
-  unsigned mf_latency;
-  mf_latency =
-      (m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle) - mf->get_timestamp();
-  mf_num_lat_pw++;
-  mf_tot_lat_pw += mf_latency;
-  unsigned idx = LOGB2(mf_latency);
-  assert(idx < 32);
-  mf_lat_table[idx]++;
-  shader_mem_lat_log(mf->get_sid(), mf_latency);
-  mf_total_lat_table[mf->get_tlx_addr().chip][mf->get_tlx_addr().bk] +=
-      mf_latency;
-  if (mf_latency > max_mf_latency) max_mf_latency = mf_latency;
-  return mf_latency;
+unsigned memory_stats_t::memlatstat_done(mem_fetch *mf )
+{
+   unsigned mf_latency;
+   mf_latency = (m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle) - mf->get_timestamp();
+   mf_num_lat_pw++;
+   mf_tot_lat_pw += mf_latency;
+   unsigned idx = LOGB2(mf_latency);
+   assert(idx<32);
+   mf_lat_table[idx]++;
+   shader_mem_lat_log(mf->get_sid(), mf_latency);
+   mf_total_lat_table[mf->get_tlx_addr().chip][mf->get_tlx_addr().bk] += mf_latency;
+   if (mf_latency > max_mf_latency)
+      max_mf_latency = mf_latency;
+   return mf_latency;
 }
 
-void memory_stats_t::memlatstat_read_done(mem_fetch *mf) {
-  if (m_memory_config->gpgpu_memlatency_stat) {
-    unsigned mf_latency = memlatstat_done(mf);
-    if (mf_latency >
-        mf_max_lat_table[mf->get_tlx_addr().chip][mf->get_tlx_addr().bk])
-      mf_max_lat_table[mf->get_tlx_addr().chip][mf->get_tlx_addr().bk] =
-          mf_latency;
-    unsigned icnt2sh_latency;
-    icnt2sh_latency = (m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle) -
-                      mf->get_return_timestamp();
-    tot_icnt2sh_latency += icnt2sh_latency;
-    icnt2sh_lat_table[LOGB2(icnt2sh_latency)]++;
-    if (icnt2sh_latency > max_icnt2sh_latency)
-      max_icnt2sh_latency = icnt2sh_latency;
-  }
+void memory_stats_t::memlatstat_read_done(mem_fetch *mf)
+{
+   if (m_memory_config->gpgpu_memlatency_stat) {
+      unsigned mf_latency = memlatstat_done(mf);
+      if (mf_latency > mf_max_lat_table[mf->get_tlx_addr().chip][mf->get_tlx_addr().bk]) 
+         mf_max_lat_table[mf->get_tlx_addr().chip][mf->get_tlx_addr().bk] = mf_latency;
+      unsigned icnt2sh_latency;
+      icnt2sh_latency = (m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle) - mf->get_return_timestamp();
+      tot_icnt2sh_latency += icnt2sh_latency;
+      icnt2sh_lat_table[LOGB2(icnt2sh_latency)]++;
+      if (icnt2sh_latency > max_icnt2sh_latency)
+         max_icnt2sh_latency = icnt2sh_latency;
+   }
 }
 
-void memory_stats_t::memlatstat_dram_access(mem_fetch *mf) {
-  unsigned dram_id = mf->get_tlx_addr().chip;
-  unsigned bank = mf->get_tlx_addr().bk;
-  if (m_memory_config->gpgpu_memlatency_stat) {
-    if (mf->get_is_write()) {
-      if (mf->get_sid() < m_n_shader) {  // do not count L2_writebacks here
-        bankwrites[mf->get_sid()][dram_id][bank]++;
-        shader_mem_acc_log(mf->get_sid(), dram_id, bank, 'w');
+void memory_stats_t::memlatstat_dram_access(mem_fetch *mf)
+{
+   unsigned dram_id = mf->get_tlx_addr().chip;
+   unsigned bank = mf->get_tlx_addr().bk;
+   if (m_memory_config->gpgpu_memlatency_stat) { 
+      if (mf->get_is_write()) {
+         if ( mf->get_sid() < m_n_shader  ) {   //do not count L2_writebacks here 
+            bankwrites[mf->get_sid()][dram_id][bank]++;
+            shader_mem_acc_log( mf->get_sid(), dram_id, bank, 'w');
+         }
+         totalbankwrites[dram_id][bank]++;
+      } else {
+         bankreads[mf->get_sid()][dram_id][bank]++;
+         shader_mem_acc_log( mf->get_sid(), dram_id, bank, 'r');
+         totalbankreads[dram_id][bank]++;
       }
-      totalbankwrites[dram_id][bank]++;
-    } else {
-      bankreads[mf->get_sid()][dram_id][bank]++;
-      shader_mem_acc_log(mf->get_sid(), dram_id, bank, 'r');
-      totalbankreads[dram_id][bank]++;
-    }
-    mem_access_type_stats[mf->get_access_type()][dram_id][bank]++;
-  }
-  if (mf->get_pc() != (unsigned)-1)
-    m_gpu->gpgpu_ctx->stats->ptx_file_line_stats_add_dram_traffic(
-        mf->get_pc(), mf->get_data_size());
+      mem_access_type_stats[mf->get_access_type()][dram_id][bank]++;
+   }
+   if (mf->get_pc() != (unsigned)-1) 
+      m_gpu->gpgpu_ctx->stats->ptx_file_line_stats_add_dram_traffic(mf->get_pc(), mf->get_data_size());
 }
 
-void memory_stats_t::memlatstat_icnt2mem_pop(mem_fetch *mf) {
-  if (m_memory_config->gpgpu_memlatency_stat) {
-    unsigned icnt2mem_latency;
-    icnt2mem_latency =
-        (m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle) - mf->get_timestamp();
-    tot_icnt2mem_latency += icnt2mem_latency;
-    icnt2mem_lat_table[LOGB2(icnt2mem_latency)]++;
-    if (icnt2mem_latency > max_icnt2mem_latency)
-      max_icnt2mem_latency = icnt2mem_latency;
-  }
+void memory_stats_t::memlatstat_icnt2mem_pop(mem_fetch *mf)
+{
+   if (m_memory_config->gpgpu_memlatency_stat) {
+      unsigned icnt2mem_latency;
+      icnt2mem_latency = (m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle) - mf->get_timestamp();
+      tot_icnt2mem_latency += icnt2mem_latency;
+      icnt2mem_lat_table[LOGB2(icnt2mem_latency)]++;
+      if (icnt2mem_latency > max_icnt2mem_latency)
+         max_icnt2mem_latency = icnt2mem_latency;
+   }
 }
 
-void memory_stats_t::memlatstat_lat_pw() {
-  if (mf_num_lat_pw && m_memory_config->gpgpu_memlatency_stat) {
-    assert(mf_tot_lat_pw);
-    mf_total_lat += mf_tot_lat_pw;
-    num_mfs += mf_num_lat_pw;
-    mf_lat_pw_table[LOGB2(mf_tot_lat_pw / mf_num_lat_pw)]++;
-    mf_tot_lat_pw = 0;
-    mf_num_lat_pw = 0;
-  }
+void memory_stats_t::memlatstat_lat_pw()
+{
+   if (mf_num_lat_pw && m_memory_config->gpgpu_memlatency_stat) {
+      assert(mf_tot_lat_pw);
+      mf_total_lat += mf_tot_lat_pw;
+      num_mfs += mf_num_lat_pw;
+      mf_lat_pw_table[LOGB2(mf_tot_lat_pw/mf_num_lat_pw)]++;
+      mf_tot_lat_pw = 0;
+      mf_num_lat_pw = 0;
+   }
 }
 
-void memory_stats_t::memlatstat_print(unsigned n_mem, unsigned gpu_mem_n_bk) {
-  unsigned i, j, k, l, m;
-  unsigned max_bank_accesses, min_bank_accesses, max_chip_accesses,
-      min_chip_accesses;
 
-  if (m_memory_config->gpgpu_memlatency_stat) {
-    printf("maxmflatency = %d \n", max_mf_latency);
-    printf("max_icnt2mem_latency = %d \n", max_icnt2mem_latency);
-    printf("maxmrqlatency = %d \n", max_mrq_latency);
-    // printf("maxdqlatency = %d \n", max_dq_latency);
-    printf("max_icnt2sh_latency = %d \n", max_icnt2sh_latency);
-    if (num_mfs) {
-      printf("averagemflatency = %lld \n", mf_total_lat / num_mfs);
-      printf("avg_icnt2mem_latency = %lld \n", tot_icnt2mem_latency / num_mfs);
-      if (tot_mrq_num)
-        printf("avg_mrq_latency = %lld \n", tot_mrq_latency / tot_mrq_num);
+void memory_stats_t::memlatstat_print( unsigned n_mem, unsigned gpu_mem_n_bk )
+{
+   unsigned i,j,k,l,m;
+   unsigned max_bank_accesses, min_bank_accesses, max_chip_accesses, min_chip_accesses;
 
-      printf("avg_icnt2sh_latency = %lld \n", tot_icnt2sh_latency / num_mfs);
-    }
-    printf("mrq_lat_table:");
-    for (i = 0; i < 32; i++) {
-      printf("%d \t", mrq_lat_table[i]);
-    }
-    printf("\n");
-    printf("dq_lat_table:");
-    for (i = 0; i < 32; i++) {
-      printf("%d \t", dq_lat_table[i]);
-    }
-    printf("\n");
-    printf("mf_lat_table:");
-    for (i = 0; i < 32; i++) {
-      printf("%d \t", mf_lat_table[i]);
-    }
-    printf("\n");
-    printf("icnt2mem_lat_table:");
-    for (i = 0; i < 24; i++) {
-      printf("%d \t", icnt2mem_lat_table[i]);
-    }
-    printf("\n");
-    printf("icnt2sh_lat_table:");
-    for (i = 0; i < 24; i++) {
-      printf("%d \t", icnt2sh_lat_table[i]);
-    }
-    printf("\n");
-    printf("mf_lat_pw_table:");
-    for (i = 0; i < 32; i++) {
-      printf("%d \t", mf_lat_pw_table[i]);
-    }
-    printf("\n");
+   if (m_memory_config->gpgpu_memlatency_stat) {
+	   printf("maxmflatency = %d \n", max_mf_latency);
+	   printf("max_icnt2mem_latency = %d \n", max_icnt2mem_latency);
+      printf("maxmrqlatency = %d \n", max_mrq_latency);
+      //printf("maxdqlatency = %d \n", max_dq_latency);
+      printf("max_icnt2sh_latency = %d \n", max_icnt2sh_latency);
+      if (num_mfs) {
+         printf("averagemflatency = %lld \n", mf_total_lat/num_mfs);
+         printf("avg_icnt2mem_latency = %lld \n", tot_icnt2mem_latency/num_mfs);
+         if(tot_mrq_num)
+        	 printf("avg_mrq_latency = %lld \n", tot_mrq_latency/tot_mrq_num);
 
-    /*MAXIMUM CONCURRENT ACCESSES TO SAME ROW*/
-    printf("maximum concurrent accesses to same row:\n");
-    for (i = 0; i < n_mem; i++) {
-      printf("dram[%d]: ", i);
-      for (j = 0; j < gpu_mem_n_bk; j++) {
-        printf("%9d ", max_conc_access2samerow[i][j]);
+         printf("avg_icnt2sh_latency = %lld \n", tot_icnt2sh_latency/num_mfs);
+      }
+      printf("mrq_lat_table:");
+      for (i=0; i< 32; i++) {
+         printf("%d \t", mrq_lat_table[i]);
       }
       printf("\n");
-    }
-
-    /*MAXIMUM SERVICE TIME TO SAME ROW*/
-    printf("maximum service time to same row:\n");
-    for (i = 0; i < n_mem; i++) {
-      printf("dram[%d]: ", i);
-      for (j = 0; j < gpu_mem_n_bk; j++) {
-        printf("%9d ", max_servicetime2samerow[i][j]);
+      printf("dq_lat_table:");
+      for (i=0; i< 32; i++) {
+         printf("%d \t", dq_lat_table[i]);
       }
       printf("\n");
-    }
-
-    /*AVERAGE ROW ACCESSES PER ACTIVATE*/
-    int total_row_accesses = 0;
-    int total_num_activates = 0;
-    printf("average row accesses per activate:\n");
-    for (i = 0; i < n_mem; i++) {
-      printf("dram[%d]: ", i);
-      for (j = 0; j < gpu_mem_n_bk; j++) {
-        total_row_accesses += row_access[i][j];
-        total_num_activates += num_activates[i][j];
-        printf("%9f ", (float)row_access[i][j] / num_activates[i][j]);
+      printf("mf_lat_table:");
+      for (i=0; i< 32; i++) {
+         printf("%d \t", mf_lat_table[i]);
       }
       printf("\n");
-    }
-    printf("average row locality = %d/%d = %f\n", total_row_accesses,
-           total_num_activates,
-           (float)total_row_accesses / total_num_activates);
-    /*MEMORY ACCESSES*/
-    k = 0;
-    l = 0;
-    m = 0;
-    max_bank_accesses = 0;
-    max_chip_accesses = 0;
-    min_bank_accesses = 0xFFFFFFFF;
-    min_chip_accesses = 0xFFFFFFFF;
-    printf("number of total memory accesses made:\n");
-    for (i = 0; i < n_mem; i++) {
-      printf("dram[%d]: ", i);
-      for (j = 0; j < gpu_mem_n_bk; j++) {
-        l = totalbankaccesses[i][j];
-        if (l < min_bank_accesses) min_bank_accesses = l;
-        if (l > max_bank_accesses) max_bank_accesses = l;
-        k += l;
-        m += l;
-        printf("%9d ", l);
+      printf("icnt2mem_lat_table:");
+      for (i=0; i< 24; i++) {
+         printf("%d \t", icnt2mem_lat_table[i]);
       }
-      if (m < min_chip_accesses) min_chip_accesses = m;
-      if (m > max_chip_accesses) max_chip_accesses = m;
+      printf("\n");
+      printf("icnt2sh_lat_table:");
+      for (i=0; i< 24; i++) {
+         printf("%d \t", icnt2sh_lat_table[i]);
+      }
+      printf("\n");
+      printf("mf_lat_pw_table:");
+      for (i=0; i< 32; i++) {
+         printf("%d \t", mf_lat_pw_table[i]);
+      }
+      printf("\n");
+
+      /*MAXIMUM CONCURRENT ACCESSES TO SAME ROW*/
+      printf("maximum concurrent accesses to same row:\n");
+      for (i=0;i<n_mem ;i++ ) {
+         printf("dram[%d]: ", i);
+         for (j=0;j<gpu_mem_n_bk;j++ ) {
+            printf("%9d ",max_conc_access2samerow[i][j]);
+         }
+         printf("\n");
+      }
+
+      /*MAXIMUM SERVICE TIME TO SAME ROW*/
+      printf("maximum service time to same row:\n");
+      for (i=0;i<n_mem ;i++ ) {
+         printf("dram[%d]: ", i);
+         for (j=0;j<gpu_mem_n_bk;j++ ) {
+            printf("%9d ",max_servicetime2samerow[i][j]);
+         }
+         printf("\n");
+      }
+
+      /*AVERAGE ROW ACCESSES PER ACTIVATE*/
+      int total_row_accesses = 0;
+      int total_num_activates = 0;
+      printf("average row accesses per activate:\n");
+      for (i=0;i<n_mem ;i++ ) {
+         printf("dram[%d]: ", i);
+         for (j=0;j<gpu_mem_n_bk;j++ ) {
+            total_row_accesses += row_access[i][j];
+            total_num_activates += num_activates[i][j];
+            printf("%9f ",(float) row_access[i][j]/num_activates[i][j]);
+         }
+         printf("\n");
+      }
+      printf("average row locality = %d/%d = %f\n", total_row_accesses, total_num_activates, (float)total_row_accesses/total_num_activates);
+      /*MEMORY ACCESSES*/
+      k = 0;
+      l = 0;
       m = 0;
-      printf("\n");
-    }
-    printf("total accesses: %d\n", k);
-    if (min_bank_accesses)
-      printf("bank skew: %d/%d = %4.2f\n", max_bank_accesses, min_bank_accesses,
-             (float)max_bank_accesses / min_bank_accesses);
-    else
-      printf("min_bank_accesses = 0!\n");
-    if (min_chip_accesses)
-      printf("chip skew: %d/%d = %4.2f\n", max_chip_accesses, min_chip_accesses,
-             (float)max_chip_accesses / min_chip_accesses);
-    else
-      printf("min_chip_accesses = 0!\n");
-
-    /*READ ACCESSES*/
-    k = 0;
-    l = 0;
-    m = 0;
-    max_bank_accesses = 0;
-    max_chip_accesses = 0;
-    min_bank_accesses = 0xFFFFFFFF;
-    min_chip_accesses = 0xFFFFFFFF;
-    printf("number of total read accesses:\n");
-    for (i = 0; i < n_mem; i++) {
-      printf("dram[%d]: ", i);
-      for (j = 0; j < gpu_mem_n_bk; j++) {
-        l = totalbankreads[i][j];
-        if (l < min_bank_accesses) min_bank_accesses = l;
-        if (l > max_bank_accesses) max_bank_accesses = l;
-        k += l;
-        m += l;
-        printf("%9d ", l);
+      max_bank_accesses = 0;
+      max_chip_accesses = 0;
+      min_bank_accesses = 0xFFFFFFFF;
+      min_chip_accesses = 0xFFFFFFFF;
+      printf("number of total memory accesses made:\n");
+      for (i=0;i<n_mem ;i++ ) {
+         printf("dram[%d]: ", i);
+         for (j=0;j<gpu_mem_n_bk;j++ ) {
+            l = totalbankaccesses[i][j];
+            if (l < min_bank_accesses)
+               min_bank_accesses = l;
+            if (l > max_bank_accesses)
+               max_bank_accesses = l;
+            k += l;
+            m += l;
+            printf("%9d ",l);
+         }
+         if (m < min_chip_accesses)
+            min_chip_accesses = m;
+         if (m > max_chip_accesses)
+            max_chip_accesses = m;
+         m = 0;
+         printf("\n");
       }
-      if (m < min_chip_accesses) min_chip_accesses = m;
-      if (m > max_chip_accesses) max_chip_accesses = m;
+      printf("total accesses: %d\n", k);
+      if (min_bank_accesses)
+         printf("bank skew: %d/%d = %4.2f\n", max_bank_accesses, min_bank_accesses, (float)max_bank_accesses/min_bank_accesses);
+      else
+         printf("min_bank_accesses = 0!\n");
+      if (min_chip_accesses)
+         printf("chip skew: %d/%d = %4.2f\n", max_chip_accesses, min_chip_accesses, (float)max_chip_accesses/min_chip_accesses);
+      else
+         printf("min_chip_accesses = 0!\n");
+
+      /*READ ACCESSES*/
+      k = 0;
+      l = 0;
       m = 0;
-      printf("\n");
-    }
-    printf("total dram reads = %d\n", k);
-    if (min_bank_accesses)
-      printf("bank skew: %d/%d = %4.2f\n", max_bank_accesses, min_bank_accesses,
-             (float)max_bank_accesses / min_bank_accesses);
-    else
-      printf("min_bank_accesses = 0!\n");
-    if (min_chip_accesses)
-      printf("chip skew: %d/%d = %4.2f\n", max_chip_accesses, min_chip_accesses,
-             (float)max_chip_accesses / min_chip_accesses);
-    else
-      printf("min_chip_accesses = 0!\n");
-
-    /*WRITE ACCESSES*/
-    k = 0;
-    l = 0;
-    m = 0;
-    max_bank_accesses = 0;
-    max_chip_accesses = 0;
-    min_bank_accesses = 0xFFFFFFFF;
-    min_chip_accesses = 0xFFFFFFFF;
-    printf("number of total write accesses:\n");
-    for (i = 0; i < n_mem; i++) {
-      printf("dram[%d]: ", i);
-      for (j = 0; j < gpu_mem_n_bk; j++) {
-        l = totalbankwrites[i][j];
-        if (l < min_bank_accesses) min_bank_accesses = l;
-        if (l > max_bank_accesses) max_bank_accesses = l;
-        k += l;
-        m += l;
-        printf("%9d ", l);
+      max_bank_accesses = 0;
+      max_chip_accesses = 0;
+      min_bank_accesses = 0xFFFFFFFF;
+      min_chip_accesses = 0xFFFFFFFF;
+      printf("number of total read accesses:\n");
+      for (i=0;i<n_mem ;i++ ) {
+         printf("dram[%d]: ", i);
+         for (j=0;j<gpu_mem_n_bk;j++ ) {
+            l = totalbankreads[i][j];
+            if (l < min_bank_accesses)
+               min_bank_accesses = l;
+            if (l > max_bank_accesses)
+               max_bank_accesses = l;
+            k += l;
+            m += l;
+            printf("%9d ",l);
+         }
+         if (m < min_chip_accesses)
+            min_chip_accesses = m;
+         if (m > max_chip_accesses)
+            max_chip_accesses = m;
+         m = 0;
+         printf("\n");
       }
-      if (m < min_chip_accesses) min_chip_accesses = m;
-      if (m > max_chip_accesses) max_chip_accesses = m;
+      printf("total dram reads = %d\n", k);
+      if (min_bank_accesses)
+         printf("bank skew: %d/%d = %4.2f\n", max_bank_accesses, min_bank_accesses, (float)max_bank_accesses/min_bank_accesses);
+      else
+         printf("min_bank_accesses = 0!\n");
+      if (min_chip_accesses)
+         printf("chip skew: %d/%d = %4.2f\n", max_chip_accesses, min_chip_accesses, (float)max_chip_accesses/min_chip_accesses);
+      else
+         printf("min_chip_accesses = 0!\n");
+
+      /*WRITE ACCESSES*/
+      k = 0;
+      l = 0;
       m = 0;
-      printf("\n");
-    }
-    printf("total dram writes = %d\n", k);
-    if (min_bank_accesses)
-      printf("bank skew: %d/%d = %4.2f\n", max_bank_accesses, min_bank_accesses,
-             (float)max_bank_accesses / min_bank_accesses);
-    else
-      printf("min_bank_accesses = 0!\n");
-    if (min_chip_accesses)
-      printf("chip skew: %d/%d = %4.2f\n", max_chip_accesses, min_chip_accesses,
-             (float)max_chip_accesses / min_chip_accesses);
-    else
-      printf("min_chip_accesses = 0!\n");
+      max_bank_accesses = 0;
+      max_chip_accesses = 0;
+      min_bank_accesses = 0xFFFFFFFF;
+      min_chip_accesses = 0xFFFFFFFF;
+      printf("number of total write accesses:\n");
+      for (i=0;i<n_mem ;i++ ) {
+         printf("dram[%d]: ", i);
+         for (j=0;j<gpu_mem_n_bk;j++ ) {
+            l = totalbankwrites[i][j];
+            if (l < min_bank_accesses)
+               min_bank_accesses = l;
+            if (l > max_bank_accesses)
+               max_bank_accesses = l;
+            k += l;
+            m += l;
+            printf("%9d ",l);
+         }
+         if (m < min_chip_accesses)
+            min_chip_accesses = m;
+         if (m > max_chip_accesses)
+            max_chip_accesses = m;
+         m = 0;
+         printf("\n");
+      }
+      printf("total dram writes = %d\n", k);
+      if (min_bank_accesses)
+         printf("bank skew: %d/%d = %4.2f\n", max_bank_accesses, min_bank_accesses, (float)max_bank_accesses/min_bank_accesses);
+      else
+         printf("min_bank_accesses = 0!\n");
+      if (min_chip_accesses)
+         printf("chip skew: %d/%d = %4.2f\n", max_chip_accesses, min_chip_accesses, (float)max_chip_accesses/min_chip_accesses);
+      else
+         printf("min_chip_accesses = 0!\n");
 
-    /*AVERAGE MF LATENCY PER BANK*/
-    printf("average mf latency per bank:\n");
-    for (i = 0; i < n_mem; i++) {
-      printf("dram[%d]: ", i);
-      for (j = 0; j < gpu_mem_n_bk; j++) {
-        k = totalbankwrites[i][j] + totalbankreads[i][j];
-        if (k)
-          printf("%10lld", mf_total_lat_table[i][j] / k);
-        else
-          printf("    none  ");
+
+      /*AVERAGE MF LATENCY PER BANK*/
+      printf("average mf latency per bank:\n");
+      for (i=0;i<n_mem ;i++ ) {
+         printf("dram[%d]: ", i);
+         for (j=0;j<gpu_mem_n_bk;j++ ) {
+            k = totalbankwrites[i][j] + totalbankreads[i][j];
+            if (k)
+               printf("%10lld", mf_total_lat_table[i][j] / k);
+            else
+               printf("    none  ");
+         }
+         printf("\n");
+      }
+
+      /*MAXIMUM MF LATENCY PER BANK*/
+      printf("maximum mf latency per bank:\n");
+      for (i=0;i<n_mem ;i++ ) {
+         printf("dram[%d]: ", i);
+         for (j=0;j<gpu_mem_n_bk;j++ ) {
+            printf("%10d", mf_max_lat_table[i][j]);
+         }
+         printf("\n");
+      }
+   }
+
+   if (m_memory_config->gpgpu_memlatency_stat & GPU_MEMLATSTAT_MC) {
+      printf("\nNumber of Memory Banks Accessed per Memory Operation per Warp (from 0):\n");
+      unsigned long long accum_MCBs_accessed = 0;
+      unsigned long long tot_mem_ops_per_warp = 0;
+      for (i=0;i< n_mem*gpu_mem_n_bk ; i++ ) {
+         accum_MCBs_accessed += i*num_MCBs_accessed[i];
+         tot_mem_ops_per_warp += num_MCBs_accessed[i];
+         printf("%d\t", num_MCBs_accessed[i]);
+      }
+
+      printf("\nAverage # of Memory Banks Accessed per Memory Operation per Warp=%f\n", (float)accum_MCBs_accessed/tot_mem_ops_per_warp);
+
+      //printf("\nAverage Difference Between First and Last Response from Memory System per warp = ");
+
+
+      printf("\nposition of mrq chosen\n");
+
+      if (!m_memory_config->gpgpu_frfcfs_dram_sched_queue_size)
+         j = 1024;
+      else
+         j = m_memory_config->gpgpu_frfcfs_dram_sched_queue_size;
+      k=0;l=0;
+      for (i=0;i< j; i++ ) {
+         printf("%d\t", position_of_mrq_chosen[i]);
+         k += position_of_mrq_chosen[i];
+         l += i*position_of_mrq_chosen[i];
       }
       printf("\n");
-    }
-
-    /*MAXIMUM MF LATENCY PER BANK*/
-    printf("maximum mf latency per bank:\n");
-    for (i = 0; i < n_mem; i++) {
-      printf("dram[%d]: ", i);
-      for (j = 0; j < gpu_mem_n_bk; j++) {
-        printf("%10d", mf_max_lat_table[i][j]);
-      }
-      printf("\n");
-    }
-  }
-
-  if (m_memory_config->gpgpu_memlatency_stat & GPU_MEMLATSTAT_MC) {
-    printf(
-        "\nNumber of Memory Banks Accessed per Memory Operation per Warp (from "
-        "0):\n");
-    unsigned long long accum_MCBs_accessed = 0;
-    unsigned long long tot_mem_ops_per_warp = 0;
-    for (i = 0; i < n_mem * gpu_mem_n_bk; i++) {
-      accum_MCBs_accessed += i * num_MCBs_accessed[i];
-      tot_mem_ops_per_warp += num_MCBs_accessed[i];
-      printf("%d\t", num_MCBs_accessed[i]);
-    }
-
-    printf(
-        "\nAverage # of Memory Banks Accessed per Memory Operation per "
-        "Warp=%f\n",
-        (float)accum_MCBs_accessed / tot_mem_ops_per_warp);
-
-    // printf("\nAverage Difference Between First and Last Response from Memory
-    // System per warp = ");
-
-    printf("\nposition of mrq chosen\n");
-
-    if (!m_memory_config->gpgpu_frfcfs_dram_sched_queue_size)
-      j = 1024;
-    else
-      j = m_memory_config->gpgpu_frfcfs_dram_sched_queue_size;
-    k = 0;
-    l = 0;
-    for (i = 0; i < j; i++) {
-      printf("%d\t", position_of_mrq_chosen[i]);
-      k += position_of_mrq_chosen[i];
-      l += i * position_of_mrq_chosen[i];
-    }
-    printf("\n");
-    printf("\naverage position of mrq chosen = %f\n", (float)l / k);
-  }
+      printf("\naverage position of mrq chosen = %f\n", (float)l/k);
+   }
 }

--- a/src/gpgpu-sim/mem_latency_stat.cc
+++ b/src/gpgpu-sim/mem_latency_stat.cc
@@ -8,14 +8,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -26,456 +28,494 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "../abstract_hardware_model.h"
 #include "mem_latency_stat.h"
-#include "gpu-sim.h"
-#include "gpu-misc.h"
-#include "gpu-cache.h"
-#include "shader.h"
-#include "mem_fetch.h"
-#include "stat-tool.h"
+#include "../abstract_hardware_model.h"
 #include "../cuda-sim/ptx-stats.h"
-#include "visualizer.h"
 #include "dram.h"
+#include "gpu-cache.h"
+#include "gpu-misc.h"
+#include "gpu-sim.h"
+#include "mem_fetch.h"
+#include "shader.h"
+#include "stat-tool.h"
+#include "visualizer.h"
 
-#include <string.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include "../../libcuda/gpgpu_context.h"
 
-memory_stats_t::memory_stats_t( unsigned n_shader, const shader_core_config *shader_config, const memory_config *mem_config, const class gpgpu_sim* gpu )
-{
-   assert( mem_config->m_valid );
-   assert( shader_config->m_valid );
+memory_stats_t::memory_stats_t(unsigned n_shader,
+                               const shader_core_config *shader_config,
+                               const memory_config *mem_config,
+                               const class gpgpu_sim *gpu) {
+  assert(mem_config->m_valid);
+  assert(shader_config->m_valid);
 
-   unsigned i,j;
+  unsigned i, j;
 
+  concurrent_row_access =
+      (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
+  num_activates =
+      (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
+  row_access =
+      (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
+  max_conc_access2samerow =
+      (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
+  max_servicetime2samerow =
+      (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
 
-   concurrent_row_access = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
-   num_activates = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
-   row_access = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
-   max_conc_access2samerow = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
-   max_servicetime2samerow = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
+  for (unsigned i = 0; i < mem_config->m_n_mem; i++) {
+    concurrent_row_access[i] =
+        (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
+    row_access[i] =
+        (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
+    num_activates[i] =
+        (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
+    max_conc_access2samerow[i] =
+        (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
+    max_servicetime2samerow[i] =
+        (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
+  }
 
-   for (unsigned i=0;i<mem_config->m_n_mem ;i++ ) {
-      concurrent_row_access[i] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
-      row_access[i] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
-      num_activates[i] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
-      max_conc_access2samerow[i] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
-      max_servicetime2samerow[i] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
-   }
+  m_n_shader = n_shader;
+  m_memory_config = mem_config;
+  m_gpu = gpu;
+  total_n_access = 0;
+  total_n_reads = 0;
+  total_n_writes = 0;
+  max_mrq_latency = 0;
+  max_dq_latency = 0;
+  max_mf_latency = 0;
+  max_icnt2mem_latency = 0;
+  max_icnt2sh_latency = 0;
+  tot_icnt2mem_latency = 0;
+  tot_icnt2sh_latency = 0;
+  tot_mrq_num = 0;
+  tot_mrq_latency = 0;
+  memset(mrq_lat_table, 0, sizeof(unsigned) * 32);
+  memset(dq_lat_table, 0, sizeof(unsigned) * 32);
+  memset(mf_lat_table, 0, sizeof(unsigned) * 32);
+  memset(icnt2mem_lat_table, 0, sizeof(unsigned) * 24);
+  memset(icnt2sh_lat_table, 0, sizeof(unsigned) * 24);
+  memset(mf_lat_pw_table, 0, sizeof(unsigned) * 32);
+  mf_num_lat_pw = 0;
+  max_warps =
+      n_shader *
+      (shader_config->n_thread_per_shader / shader_config->warp_size + 1);
+  mf_tot_lat_pw = 0;  // total latency summed up per window. divide by
+                      // mf_num_lat_pw to obtain average latency Per Window
+  mf_total_lat = 0;
+  num_mfs = 0;
+  printf("*** Initializing Memory Statistics ***\n");
+  totalbankreads =
+      (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
+  totalbankwrites =
+      (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
+  totalbankaccesses =
+      (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
+  mf_total_lat_table = (unsigned long long int **)calloc(
+      mem_config->m_n_mem, sizeof(unsigned long long *));
+  mf_max_lat_table =
+      (unsigned **)calloc(mem_config->m_n_mem, sizeof(unsigned *));
+  bankreads = (unsigned int ***)calloc(n_shader, sizeof(unsigned int **));
+  bankwrites = (unsigned int ***)calloc(n_shader, sizeof(unsigned int **));
+  num_MCBs_accessed = (unsigned int *)calloc(
+      mem_config->m_n_mem * mem_config->nbk, sizeof(unsigned int));
+  if (mem_config->gpgpu_frfcfs_dram_sched_queue_size) {
+    position_of_mrq_chosen = (unsigned int *)calloc(
+        mem_config->gpgpu_frfcfs_dram_sched_queue_size, sizeof(unsigned int));
+  } else
+    position_of_mrq_chosen = (unsigned int *)calloc(1024, sizeof(unsigned int));
+  for (i = 0; i < n_shader; i++) {
+    bankreads[i] =
+        (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
+    bankwrites[i] =
+        (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
+    for (j = 0; j < mem_config->m_n_mem; j++) {
+      bankreads[i][j] =
+          (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
+      bankwrites[i][j] =
+          (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
+    }
+  }
 
+  for (i = 0; i < mem_config->m_n_mem; i++) {
+    totalbankreads[i] =
+        (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
+    totalbankwrites[i] =
+        (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
+    totalbankaccesses[i] =
+        (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
+    mf_total_lat_table[i] = (unsigned long long int *)calloc(
+        mem_config->nbk, sizeof(unsigned long long int));
+    mf_max_lat_table[i] = (unsigned *)calloc(mem_config->nbk, sizeof(unsigned));
+  }
 
-   m_n_shader=n_shader;
-   m_memory_config=mem_config;
-   m_gpu=gpu;
-   total_n_access=0;
-   total_n_reads=0;
-   total_n_writes=0;
-   max_mrq_latency = 0;
-   max_dq_latency = 0;
-   max_mf_latency = 0;
-   max_icnt2mem_latency = 0;
-   max_icnt2sh_latency = 0;
-   tot_icnt2mem_latency = 0;
-   tot_icnt2sh_latency = 0;
-   tot_mrq_num = 0;
-   tot_mrq_latency = 0;
-   memset(mrq_lat_table, 0, sizeof(unsigned)*32);
-   memset(dq_lat_table, 0, sizeof(unsigned)*32);
-   memset(mf_lat_table, 0, sizeof(unsigned)*32);
-   memset(icnt2mem_lat_table, 0, sizeof(unsigned)*24);
-   memset(icnt2sh_lat_table, 0, sizeof(unsigned)*24);
-   memset(mf_lat_pw_table, 0, sizeof(unsigned)*32);
-   mf_num_lat_pw = 0;
-   max_warps = n_shader * (shader_config->n_thread_per_shader / shader_config->warp_size+1);
-   mf_tot_lat_pw = 0; //total latency summed up per window. divide by mf_num_lat_pw to obtain average latency Per Window
-   mf_total_lat = 0;
-   num_mfs = 0;
-   printf("*** Initializing Memory Statistics ***\n");
-   totalbankreads = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
-   totalbankwrites = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
-   totalbankaccesses = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
-   mf_total_lat_table = (unsigned long long int **) calloc(mem_config->m_n_mem, sizeof(unsigned long long *));
-   mf_max_lat_table = (unsigned **) calloc(mem_config->m_n_mem, sizeof(unsigned *));
-   bankreads = (unsigned int***) calloc(n_shader, sizeof(unsigned int**));
-   bankwrites = (unsigned int***) calloc(n_shader, sizeof(unsigned int**));
-   num_MCBs_accessed = (unsigned int*) calloc(mem_config->m_n_mem*mem_config->nbk, sizeof(unsigned int));
-   if (mem_config->gpgpu_frfcfs_dram_sched_queue_size) {
-      position_of_mrq_chosen = (unsigned int*) calloc(mem_config->gpgpu_frfcfs_dram_sched_queue_size, sizeof(unsigned int));
-   } else
-      position_of_mrq_chosen = (unsigned int*) calloc(1024, sizeof(unsigned int));
-   for (i=0;i<n_shader ;i++ ) {
-      bankreads[i] = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
-      bankwrites[i] = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
-      for (j=0;j<mem_config->m_n_mem ;j++ ) {
-         bankreads[i][j] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
-         bankwrites[i][j] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
-      }
-   }
+  mem_access_type_stats =
+      (unsigned ***)malloc(NUM_MEM_ACCESS_TYPE * sizeof(unsigned **));
+  for (i = 0; i < NUM_MEM_ACCESS_TYPE; i++) {
+    int j;
+    mem_access_type_stats[i] =
+        (unsigned **)calloc(mem_config->m_n_mem, sizeof(unsigned *));
+    for (j = 0; (unsigned)j < mem_config->m_n_mem; j++) {
+      mem_access_type_stats[i][j] =
+          (unsigned *)calloc((mem_config->nbk + 1), sizeof(unsigned *));
+    }
+  }
 
-   for (i=0;i<mem_config->m_n_mem ;i++ ) {
-      totalbankreads[i] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
-      totalbankwrites[i] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
-      totalbankaccesses[i] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
-      mf_total_lat_table[i] = (unsigned long long int*) calloc(mem_config->nbk, sizeof(unsigned long long int));
-      mf_max_lat_table[i] = (unsigned *) calloc(mem_config->nbk, sizeof(unsigned));
-   }
+  // AerialVision L2 stats
+  L2_read_miss = 0;
+  L2_write_miss = 0;
+  L2_read_hit = 0;
+  L2_write_hit = 0;
 
-   mem_access_type_stats = (unsigned ***) malloc(NUM_MEM_ACCESS_TYPE * sizeof(unsigned **));
-   for (i = 0; i < NUM_MEM_ACCESS_TYPE; i++) {
-      int j;
-      mem_access_type_stats[i] = (unsigned **) calloc(mem_config->m_n_mem, sizeof(unsigned*));
-      for (j=0; (unsigned) j< mem_config->m_n_mem; j++) {
-         mem_access_type_stats[i][j] = (unsigned *) calloc((mem_config->nbk+1), sizeof(unsigned*));
-      }
-   }
-
-   // AerialVision L2 stats
-   L2_read_miss = 0;
-   L2_write_miss = 0;
-   L2_read_hit = 0;
-   L2_write_hit = 0;
-
-   L2_cbtoL2length = (unsigned int*) calloc(mem_config->m_n_mem, sizeof(unsigned int));
-   L2_cbtoL2writelength = (unsigned int*) calloc(mem_config->m_n_mem, sizeof(unsigned int));
-   L2_L2tocblength = (unsigned int*) calloc(mem_config->m_n_mem, sizeof(unsigned int));
-   L2_dramtoL2length = (unsigned int*) calloc(mem_config->m_n_mem, sizeof(unsigned int));
-   L2_dramtoL2writelength = (unsigned int*) calloc(mem_config->m_n_mem, sizeof(unsigned int));
-   L2_L2todramlength = (unsigned int*) calloc(mem_config->m_n_mem, sizeof(unsigned int));
+  L2_cbtoL2length =
+      (unsigned int *)calloc(mem_config->m_n_mem, sizeof(unsigned int));
+  L2_cbtoL2writelength =
+      (unsigned int *)calloc(mem_config->m_n_mem, sizeof(unsigned int));
+  L2_L2tocblength =
+      (unsigned int *)calloc(mem_config->m_n_mem, sizeof(unsigned int));
+  L2_dramtoL2length =
+      (unsigned int *)calloc(mem_config->m_n_mem, sizeof(unsigned int));
+  L2_dramtoL2writelength =
+      (unsigned int *)calloc(mem_config->m_n_mem, sizeof(unsigned int));
+  L2_L2todramlength =
+      (unsigned int *)calloc(mem_config->m_n_mem, sizeof(unsigned int));
 }
 
 // record the total latency
-unsigned memory_stats_t::memlatstat_done(mem_fetch *mf )
-{
-   unsigned mf_latency;
-   mf_latency = (m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle) - mf->get_timestamp();
-   mf_num_lat_pw++;
-   mf_tot_lat_pw += mf_latency;
-   unsigned idx = LOGB2(mf_latency);
-   assert(idx<32);
-   mf_lat_table[idx]++;
-   shader_mem_lat_log(mf->get_sid(), mf_latency);
-   mf_total_lat_table[mf->get_tlx_addr().chip][mf->get_tlx_addr().bk] += mf_latency;
-   if (mf_latency > max_mf_latency)
-      max_mf_latency = mf_latency;
-   return mf_latency;
+unsigned memory_stats_t::memlatstat_done(mem_fetch *mf) {
+  unsigned mf_latency;
+  mf_latency =
+      (m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle) - mf->get_timestamp();
+  mf_num_lat_pw++;
+  mf_tot_lat_pw += mf_latency;
+  unsigned idx = LOGB2(mf_latency);
+  assert(idx < 32);
+  mf_lat_table[idx]++;
+  shader_mem_lat_log(mf->get_sid(), mf_latency);
+  mf_total_lat_table[mf->get_tlx_addr().chip][mf->get_tlx_addr().bk] +=
+      mf_latency;
+  if (mf_latency > max_mf_latency) max_mf_latency = mf_latency;
+  return mf_latency;
 }
 
-void memory_stats_t::memlatstat_read_done(mem_fetch *mf)
-{
-   if (m_memory_config->gpgpu_memlatency_stat) {
-      unsigned mf_latency = memlatstat_done(mf);
-      if (mf_latency > mf_max_lat_table[mf->get_tlx_addr().chip][mf->get_tlx_addr().bk]) 
-         mf_max_lat_table[mf->get_tlx_addr().chip][mf->get_tlx_addr().bk] = mf_latency;
-      unsigned icnt2sh_latency;
-      icnt2sh_latency = (m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle) - mf->get_return_timestamp();
-      tot_icnt2sh_latency += icnt2sh_latency;
-      icnt2sh_lat_table[LOGB2(icnt2sh_latency)]++;
-      if (icnt2sh_latency > max_icnt2sh_latency)
-         max_icnt2sh_latency = icnt2sh_latency;
-   }
+void memory_stats_t::memlatstat_read_done(mem_fetch *mf) {
+  if (m_memory_config->gpgpu_memlatency_stat) {
+    unsigned mf_latency = memlatstat_done(mf);
+    if (mf_latency >
+        mf_max_lat_table[mf->get_tlx_addr().chip][mf->get_tlx_addr().bk])
+      mf_max_lat_table[mf->get_tlx_addr().chip][mf->get_tlx_addr().bk] =
+          mf_latency;
+    unsigned icnt2sh_latency;
+    icnt2sh_latency = (m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle) -
+                      mf->get_return_timestamp();
+    tot_icnt2sh_latency += icnt2sh_latency;
+    icnt2sh_lat_table[LOGB2(icnt2sh_latency)]++;
+    if (icnt2sh_latency > max_icnt2sh_latency)
+      max_icnt2sh_latency = icnt2sh_latency;
+  }
 }
 
-void memory_stats_t::memlatstat_dram_access(mem_fetch *mf)
-{
-   unsigned dram_id = mf->get_tlx_addr().chip;
-   unsigned bank = mf->get_tlx_addr().bk;
-   if (m_memory_config->gpgpu_memlatency_stat) { 
-      if (mf->get_is_write()) {
-         if ( mf->get_sid() < m_n_shader  ) {   //do not count L2_writebacks here 
-            bankwrites[mf->get_sid()][dram_id][bank]++;
-            shader_mem_acc_log( mf->get_sid(), dram_id, bank, 'w');
-         }
-         totalbankwrites[dram_id][bank]++;
-      } else {
-         bankreads[mf->get_sid()][dram_id][bank]++;
-         shader_mem_acc_log( mf->get_sid(), dram_id, bank, 'r');
-         totalbankreads[dram_id][bank]++;
+void memory_stats_t::memlatstat_dram_access(mem_fetch *mf) {
+  unsigned dram_id = mf->get_tlx_addr().chip;
+  unsigned bank = mf->get_tlx_addr().bk;
+  if (m_memory_config->gpgpu_memlatency_stat) {
+    if (mf->get_is_write()) {
+      if (mf->get_sid() < m_n_shader) {  // do not count L2_writebacks here
+        bankwrites[mf->get_sid()][dram_id][bank]++;
+        shader_mem_acc_log(mf->get_sid(), dram_id, bank, 'w');
       }
-      mem_access_type_stats[mf->get_access_type()][dram_id][bank]++;
-   }
-   if (mf->get_pc() != (unsigned)-1) 
-      m_gpu->gpgpu_ctx->stats->ptx_file_line_stats_add_dram_traffic(mf->get_pc(), mf->get_data_size());
+      totalbankwrites[dram_id][bank]++;
+    } else {
+      bankreads[mf->get_sid()][dram_id][bank]++;
+      shader_mem_acc_log(mf->get_sid(), dram_id, bank, 'r');
+      totalbankreads[dram_id][bank]++;
+    }
+    mem_access_type_stats[mf->get_access_type()][dram_id][bank]++;
+  }
+  if (mf->get_pc() != (unsigned)-1)
+    m_gpu->gpgpu_ctx->stats->ptx_file_line_stats_add_dram_traffic(
+        mf->get_pc(), mf->get_data_size());
 }
 
-void memory_stats_t::memlatstat_icnt2mem_pop(mem_fetch *mf)
-{
-   if (m_memory_config->gpgpu_memlatency_stat) {
-      unsigned icnt2mem_latency;
-      icnt2mem_latency = (m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle) - mf->get_timestamp();
-      tot_icnt2mem_latency += icnt2mem_latency;
-      icnt2mem_lat_table[LOGB2(icnt2mem_latency)]++;
-      if (icnt2mem_latency > max_icnt2mem_latency)
-         max_icnt2mem_latency = icnt2mem_latency;
-   }
+void memory_stats_t::memlatstat_icnt2mem_pop(mem_fetch *mf) {
+  if (m_memory_config->gpgpu_memlatency_stat) {
+    unsigned icnt2mem_latency;
+    icnt2mem_latency =
+        (m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle) - mf->get_timestamp();
+    tot_icnt2mem_latency += icnt2mem_latency;
+    icnt2mem_lat_table[LOGB2(icnt2mem_latency)]++;
+    if (icnt2mem_latency > max_icnt2mem_latency)
+      max_icnt2mem_latency = icnt2mem_latency;
+  }
 }
 
-void memory_stats_t::memlatstat_lat_pw()
-{
-   if (mf_num_lat_pw && m_memory_config->gpgpu_memlatency_stat) {
-      assert(mf_tot_lat_pw);
-      mf_total_lat += mf_tot_lat_pw;
-      num_mfs += mf_num_lat_pw;
-      mf_lat_pw_table[LOGB2(mf_tot_lat_pw/mf_num_lat_pw)]++;
-      mf_tot_lat_pw = 0;
-      mf_num_lat_pw = 0;
-   }
+void memory_stats_t::memlatstat_lat_pw() {
+  if (mf_num_lat_pw && m_memory_config->gpgpu_memlatency_stat) {
+    assert(mf_tot_lat_pw);
+    mf_total_lat += mf_tot_lat_pw;
+    num_mfs += mf_num_lat_pw;
+    mf_lat_pw_table[LOGB2(mf_tot_lat_pw / mf_num_lat_pw)]++;
+    mf_tot_lat_pw = 0;
+    mf_num_lat_pw = 0;
+  }
 }
 
+void memory_stats_t::memlatstat_print(unsigned n_mem, unsigned gpu_mem_n_bk) {
+  unsigned i, j, k, l, m;
+  unsigned max_bank_accesses, min_bank_accesses, max_chip_accesses,
+      min_chip_accesses;
 
-void memory_stats_t::memlatstat_print( unsigned n_mem, unsigned gpu_mem_n_bk )
-{
-   unsigned i,j,k,l,m;
-   unsigned max_bank_accesses, min_bank_accesses, max_chip_accesses, min_chip_accesses;
+  if (m_memory_config->gpgpu_memlatency_stat) {
+    printf("maxmflatency = %d \n", max_mf_latency);
+    printf("max_icnt2mem_latency = %d \n", max_icnt2mem_latency);
+    printf("maxmrqlatency = %d \n", max_mrq_latency);
+    // printf("maxdqlatency = %d \n", max_dq_latency);
+    printf("max_icnt2sh_latency = %d \n", max_icnt2sh_latency);
+    if (num_mfs) {
+      printf("averagemflatency = %lld \n", mf_total_lat / num_mfs);
+      printf("avg_icnt2mem_latency = %lld \n", tot_icnt2mem_latency / num_mfs);
+      if (tot_mrq_num)
+        printf("avg_mrq_latency = %lld \n", tot_mrq_latency / tot_mrq_num);
 
-   if (m_memory_config->gpgpu_memlatency_stat) {
-	   printf("maxmflatency = %d \n", max_mf_latency);
-	   printf("max_icnt2mem_latency = %d \n", max_icnt2mem_latency);
-      printf("maxmrqlatency = %d \n", max_mrq_latency);
-      //printf("maxdqlatency = %d \n", max_dq_latency);
-      printf("max_icnt2sh_latency = %d \n", max_icnt2sh_latency);
-      if (num_mfs) {
-         printf("averagemflatency = %lld \n", mf_total_lat/num_mfs);
-         printf("avg_icnt2mem_latency = %lld \n", tot_icnt2mem_latency/num_mfs);
-         if(tot_mrq_num)
-        	 printf("avg_mrq_latency = %lld \n", tot_mrq_latency/tot_mrq_num);
+      printf("avg_icnt2sh_latency = %lld \n", tot_icnt2sh_latency / num_mfs);
+    }
+    printf("mrq_lat_table:");
+    for (i = 0; i < 32; i++) {
+      printf("%d \t", mrq_lat_table[i]);
+    }
+    printf("\n");
+    printf("dq_lat_table:");
+    for (i = 0; i < 32; i++) {
+      printf("%d \t", dq_lat_table[i]);
+    }
+    printf("\n");
+    printf("mf_lat_table:");
+    for (i = 0; i < 32; i++) {
+      printf("%d \t", mf_lat_table[i]);
+    }
+    printf("\n");
+    printf("icnt2mem_lat_table:");
+    for (i = 0; i < 24; i++) {
+      printf("%d \t", icnt2mem_lat_table[i]);
+    }
+    printf("\n");
+    printf("icnt2sh_lat_table:");
+    for (i = 0; i < 24; i++) {
+      printf("%d \t", icnt2sh_lat_table[i]);
+    }
+    printf("\n");
+    printf("mf_lat_pw_table:");
+    for (i = 0; i < 32; i++) {
+      printf("%d \t", mf_lat_pw_table[i]);
+    }
+    printf("\n");
 
-         printf("avg_icnt2sh_latency = %lld \n", tot_icnt2sh_latency/num_mfs);
-      }
-      printf("mrq_lat_table:");
-      for (i=0; i< 32; i++) {
-         printf("%d \t", mrq_lat_table[i]);
+    /*MAXIMUM CONCURRENT ACCESSES TO SAME ROW*/
+    printf("maximum concurrent accesses to same row:\n");
+    for (i = 0; i < n_mem; i++) {
+      printf("dram[%d]: ", i);
+      for (j = 0; j < gpu_mem_n_bk; j++) {
+        printf("%9d ", max_conc_access2samerow[i][j]);
       }
       printf("\n");
-      printf("dq_lat_table:");
-      for (i=0; i< 32; i++) {
-         printf("%d \t", dq_lat_table[i]);
-      }
-      printf("\n");
-      printf("mf_lat_table:");
-      for (i=0; i< 32; i++) {
-         printf("%d \t", mf_lat_table[i]);
-      }
-      printf("\n");
-      printf("icnt2mem_lat_table:");
-      for (i=0; i< 24; i++) {
-         printf("%d \t", icnt2mem_lat_table[i]);
-      }
-      printf("\n");
-      printf("icnt2sh_lat_table:");
-      for (i=0; i< 24; i++) {
-         printf("%d \t", icnt2sh_lat_table[i]);
-      }
-      printf("\n");
-      printf("mf_lat_pw_table:");
-      for (i=0; i< 32; i++) {
-         printf("%d \t", mf_lat_pw_table[i]);
-      }
-      printf("\n");
+    }
 
-      /*MAXIMUM CONCURRENT ACCESSES TO SAME ROW*/
-      printf("maximum concurrent accesses to same row:\n");
-      for (i=0;i<n_mem ;i++ ) {
-         printf("dram[%d]: ", i);
-         for (j=0;j<gpu_mem_n_bk;j++ ) {
-            printf("%9d ",max_conc_access2samerow[i][j]);
-         }
-         printf("\n");
+    /*MAXIMUM SERVICE TIME TO SAME ROW*/
+    printf("maximum service time to same row:\n");
+    for (i = 0; i < n_mem; i++) {
+      printf("dram[%d]: ", i);
+      for (j = 0; j < gpu_mem_n_bk; j++) {
+        printf("%9d ", max_servicetime2samerow[i][j]);
       }
+      printf("\n");
+    }
 
-      /*MAXIMUM SERVICE TIME TO SAME ROW*/
-      printf("maximum service time to same row:\n");
-      for (i=0;i<n_mem ;i++ ) {
-         printf("dram[%d]: ", i);
-         for (j=0;j<gpu_mem_n_bk;j++ ) {
-            printf("%9d ",max_servicetime2samerow[i][j]);
-         }
-         printf("\n");
+    /*AVERAGE ROW ACCESSES PER ACTIVATE*/
+    int total_row_accesses = 0;
+    int total_num_activates = 0;
+    printf("average row accesses per activate:\n");
+    for (i = 0; i < n_mem; i++) {
+      printf("dram[%d]: ", i);
+      for (j = 0; j < gpu_mem_n_bk; j++) {
+        total_row_accesses += row_access[i][j];
+        total_num_activates += num_activates[i][j];
+        printf("%9f ", (float)row_access[i][j] / num_activates[i][j]);
       }
-
-      /*AVERAGE ROW ACCESSES PER ACTIVATE*/
-      int total_row_accesses = 0;
-      int total_num_activates = 0;
-      printf("average row accesses per activate:\n");
-      for (i=0;i<n_mem ;i++ ) {
-         printf("dram[%d]: ", i);
-         for (j=0;j<gpu_mem_n_bk;j++ ) {
-            total_row_accesses += row_access[i][j];
-            total_num_activates += num_activates[i][j];
-            printf("%9f ",(float) row_access[i][j]/num_activates[i][j]);
-         }
-         printf("\n");
+      printf("\n");
+    }
+    printf("average row locality = %d/%d = %f\n", total_row_accesses,
+           total_num_activates,
+           (float)total_row_accesses / total_num_activates);
+    /*MEMORY ACCESSES*/
+    k = 0;
+    l = 0;
+    m = 0;
+    max_bank_accesses = 0;
+    max_chip_accesses = 0;
+    min_bank_accesses = 0xFFFFFFFF;
+    min_chip_accesses = 0xFFFFFFFF;
+    printf("number of total memory accesses made:\n");
+    for (i = 0; i < n_mem; i++) {
+      printf("dram[%d]: ", i);
+      for (j = 0; j < gpu_mem_n_bk; j++) {
+        l = totalbankaccesses[i][j];
+        if (l < min_bank_accesses) min_bank_accesses = l;
+        if (l > max_bank_accesses) max_bank_accesses = l;
+        k += l;
+        m += l;
+        printf("%9d ", l);
       }
-      printf("average row locality = %d/%d = %f\n", total_row_accesses, total_num_activates, (float)total_row_accesses/total_num_activates);
-      /*MEMORY ACCESSES*/
-      k = 0;
-      l = 0;
+      if (m < min_chip_accesses) min_chip_accesses = m;
+      if (m > max_chip_accesses) max_chip_accesses = m;
       m = 0;
-      max_bank_accesses = 0;
-      max_chip_accesses = 0;
-      min_bank_accesses = 0xFFFFFFFF;
-      min_chip_accesses = 0xFFFFFFFF;
-      printf("number of total memory accesses made:\n");
-      for (i=0;i<n_mem ;i++ ) {
-         printf("dram[%d]: ", i);
-         for (j=0;j<gpu_mem_n_bk;j++ ) {
-            l = totalbankaccesses[i][j];
-            if (l < min_bank_accesses)
-               min_bank_accesses = l;
-            if (l > max_bank_accesses)
-               max_bank_accesses = l;
-            k += l;
-            m += l;
-            printf("%9d ",l);
-         }
-         if (m < min_chip_accesses)
-            min_chip_accesses = m;
-         if (m > max_chip_accesses)
-            max_chip_accesses = m;
-         m = 0;
-         printf("\n");
-      }
-      printf("total accesses: %d\n", k);
-      if (min_bank_accesses)
-         printf("bank skew: %d/%d = %4.2f\n", max_bank_accesses, min_bank_accesses, (float)max_bank_accesses/min_bank_accesses);
-      else
-         printf("min_bank_accesses = 0!\n");
-      if (min_chip_accesses)
-         printf("chip skew: %d/%d = %4.2f\n", max_chip_accesses, min_chip_accesses, (float)max_chip_accesses/min_chip_accesses);
-      else
-         printf("min_chip_accesses = 0!\n");
+      printf("\n");
+    }
+    printf("total accesses: %d\n", k);
+    if (min_bank_accesses)
+      printf("bank skew: %d/%d = %4.2f\n", max_bank_accesses, min_bank_accesses,
+             (float)max_bank_accesses / min_bank_accesses);
+    else
+      printf("min_bank_accesses = 0!\n");
+    if (min_chip_accesses)
+      printf("chip skew: %d/%d = %4.2f\n", max_chip_accesses, min_chip_accesses,
+             (float)max_chip_accesses / min_chip_accesses);
+    else
+      printf("min_chip_accesses = 0!\n");
 
-      /*READ ACCESSES*/
-      k = 0;
-      l = 0;
+    /*READ ACCESSES*/
+    k = 0;
+    l = 0;
+    m = 0;
+    max_bank_accesses = 0;
+    max_chip_accesses = 0;
+    min_bank_accesses = 0xFFFFFFFF;
+    min_chip_accesses = 0xFFFFFFFF;
+    printf("number of total read accesses:\n");
+    for (i = 0; i < n_mem; i++) {
+      printf("dram[%d]: ", i);
+      for (j = 0; j < gpu_mem_n_bk; j++) {
+        l = totalbankreads[i][j];
+        if (l < min_bank_accesses) min_bank_accesses = l;
+        if (l > max_bank_accesses) max_bank_accesses = l;
+        k += l;
+        m += l;
+        printf("%9d ", l);
+      }
+      if (m < min_chip_accesses) min_chip_accesses = m;
+      if (m > max_chip_accesses) max_chip_accesses = m;
       m = 0;
-      max_bank_accesses = 0;
-      max_chip_accesses = 0;
-      min_bank_accesses = 0xFFFFFFFF;
-      min_chip_accesses = 0xFFFFFFFF;
-      printf("number of total read accesses:\n");
-      for (i=0;i<n_mem ;i++ ) {
-         printf("dram[%d]: ", i);
-         for (j=0;j<gpu_mem_n_bk;j++ ) {
-            l = totalbankreads[i][j];
-            if (l < min_bank_accesses)
-               min_bank_accesses = l;
-            if (l > max_bank_accesses)
-               max_bank_accesses = l;
-            k += l;
-            m += l;
-            printf("%9d ",l);
-         }
-         if (m < min_chip_accesses)
-            min_chip_accesses = m;
-         if (m > max_chip_accesses)
-            max_chip_accesses = m;
-         m = 0;
-         printf("\n");
-      }
-      printf("total dram reads = %d\n", k);
-      if (min_bank_accesses)
-         printf("bank skew: %d/%d = %4.2f\n", max_bank_accesses, min_bank_accesses, (float)max_bank_accesses/min_bank_accesses);
-      else
-         printf("min_bank_accesses = 0!\n");
-      if (min_chip_accesses)
-         printf("chip skew: %d/%d = %4.2f\n", max_chip_accesses, min_chip_accesses, (float)max_chip_accesses/min_chip_accesses);
-      else
-         printf("min_chip_accesses = 0!\n");
+      printf("\n");
+    }
+    printf("total dram reads = %d\n", k);
+    if (min_bank_accesses)
+      printf("bank skew: %d/%d = %4.2f\n", max_bank_accesses, min_bank_accesses,
+             (float)max_bank_accesses / min_bank_accesses);
+    else
+      printf("min_bank_accesses = 0!\n");
+    if (min_chip_accesses)
+      printf("chip skew: %d/%d = %4.2f\n", max_chip_accesses, min_chip_accesses,
+             (float)max_chip_accesses / min_chip_accesses);
+    else
+      printf("min_chip_accesses = 0!\n");
 
-      /*WRITE ACCESSES*/
-      k = 0;
-      l = 0;
+    /*WRITE ACCESSES*/
+    k = 0;
+    l = 0;
+    m = 0;
+    max_bank_accesses = 0;
+    max_chip_accesses = 0;
+    min_bank_accesses = 0xFFFFFFFF;
+    min_chip_accesses = 0xFFFFFFFF;
+    printf("number of total write accesses:\n");
+    for (i = 0; i < n_mem; i++) {
+      printf("dram[%d]: ", i);
+      for (j = 0; j < gpu_mem_n_bk; j++) {
+        l = totalbankwrites[i][j];
+        if (l < min_bank_accesses) min_bank_accesses = l;
+        if (l > max_bank_accesses) max_bank_accesses = l;
+        k += l;
+        m += l;
+        printf("%9d ", l);
+      }
+      if (m < min_chip_accesses) min_chip_accesses = m;
+      if (m > max_chip_accesses) max_chip_accesses = m;
       m = 0;
-      max_bank_accesses = 0;
-      max_chip_accesses = 0;
-      min_bank_accesses = 0xFFFFFFFF;
-      min_chip_accesses = 0xFFFFFFFF;
-      printf("number of total write accesses:\n");
-      for (i=0;i<n_mem ;i++ ) {
-         printf("dram[%d]: ", i);
-         for (j=0;j<gpu_mem_n_bk;j++ ) {
-            l = totalbankwrites[i][j];
-            if (l < min_bank_accesses)
-               min_bank_accesses = l;
-            if (l > max_bank_accesses)
-               max_bank_accesses = l;
-            k += l;
-            m += l;
-            printf("%9d ",l);
-         }
-         if (m < min_chip_accesses)
-            min_chip_accesses = m;
-         if (m > max_chip_accesses)
-            max_chip_accesses = m;
-         m = 0;
-         printf("\n");
-      }
-      printf("total dram writes = %d\n", k);
-      if (min_bank_accesses)
-         printf("bank skew: %d/%d = %4.2f\n", max_bank_accesses, min_bank_accesses, (float)max_bank_accesses/min_bank_accesses);
-      else
-         printf("min_bank_accesses = 0!\n");
-      if (min_chip_accesses)
-         printf("chip skew: %d/%d = %4.2f\n", max_chip_accesses, min_chip_accesses, (float)max_chip_accesses/min_chip_accesses);
-      else
-         printf("min_chip_accesses = 0!\n");
+      printf("\n");
+    }
+    printf("total dram writes = %d\n", k);
+    if (min_bank_accesses)
+      printf("bank skew: %d/%d = %4.2f\n", max_bank_accesses, min_bank_accesses,
+             (float)max_bank_accesses / min_bank_accesses);
+    else
+      printf("min_bank_accesses = 0!\n");
+    if (min_chip_accesses)
+      printf("chip skew: %d/%d = %4.2f\n", max_chip_accesses, min_chip_accesses,
+             (float)max_chip_accesses / min_chip_accesses);
+    else
+      printf("min_chip_accesses = 0!\n");
 
-
-      /*AVERAGE MF LATENCY PER BANK*/
-      printf("average mf latency per bank:\n");
-      for (i=0;i<n_mem ;i++ ) {
-         printf("dram[%d]: ", i);
-         for (j=0;j<gpu_mem_n_bk;j++ ) {
-            k = totalbankwrites[i][j] + totalbankreads[i][j];
-            if (k)
-               printf("%10lld", mf_total_lat_table[i][j] / k);
-            else
-               printf("    none  ");
-         }
-         printf("\n");
-      }
-
-      /*MAXIMUM MF LATENCY PER BANK*/
-      printf("maximum mf latency per bank:\n");
-      for (i=0;i<n_mem ;i++ ) {
-         printf("dram[%d]: ", i);
-         for (j=0;j<gpu_mem_n_bk;j++ ) {
-            printf("%10d", mf_max_lat_table[i][j]);
-         }
-         printf("\n");
-      }
-   }
-
-   if (m_memory_config->gpgpu_memlatency_stat & GPU_MEMLATSTAT_MC) {
-      printf("\nNumber of Memory Banks Accessed per Memory Operation per Warp (from 0):\n");
-      unsigned long long accum_MCBs_accessed = 0;
-      unsigned long long tot_mem_ops_per_warp = 0;
-      for (i=0;i< n_mem*gpu_mem_n_bk ; i++ ) {
-         accum_MCBs_accessed += i*num_MCBs_accessed[i];
-         tot_mem_ops_per_warp += num_MCBs_accessed[i];
-         printf("%d\t", num_MCBs_accessed[i]);
-      }
-
-      printf("\nAverage # of Memory Banks Accessed per Memory Operation per Warp=%f\n", (float)accum_MCBs_accessed/tot_mem_ops_per_warp);
-
-      //printf("\nAverage Difference Between First and Last Response from Memory System per warp = ");
-
-
-      printf("\nposition of mrq chosen\n");
-
-      if (!m_memory_config->gpgpu_frfcfs_dram_sched_queue_size)
-         j = 1024;
-      else
-         j = m_memory_config->gpgpu_frfcfs_dram_sched_queue_size;
-      k=0;l=0;
-      for (i=0;i< j; i++ ) {
-         printf("%d\t", position_of_mrq_chosen[i]);
-         k += position_of_mrq_chosen[i];
-         l += i*position_of_mrq_chosen[i];
+    /*AVERAGE MF LATENCY PER BANK*/
+    printf("average mf latency per bank:\n");
+    for (i = 0; i < n_mem; i++) {
+      printf("dram[%d]: ", i);
+      for (j = 0; j < gpu_mem_n_bk; j++) {
+        k = totalbankwrites[i][j] + totalbankreads[i][j];
+        if (k)
+          printf("%10lld", mf_total_lat_table[i][j] / k);
+        else
+          printf("    none  ");
       }
       printf("\n");
-      printf("\naverage position of mrq chosen = %f\n", (float)l/k);
-   }
+    }
+
+    /*MAXIMUM MF LATENCY PER BANK*/
+    printf("maximum mf latency per bank:\n");
+    for (i = 0; i < n_mem; i++) {
+      printf("dram[%d]: ", i);
+      for (j = 0; j < gpu_mem_n_bk; j++) {
+        printf("%10d", mf_max_lat_table[i][j]);
+      }
+      printf("\n");
+    }
+  }
+
+  if (m_memory_config->gpgpu_memlatency_stat & GPU_MEMLATSTAT_MC) {
+    printf(
+        "\nNumber of Memory Banks Accessed per Memory Operation per Warp (from "
+        "0):\n");
+    unsigned long long accum_MCBs_accessed = 0;
+    unsigned long long tot_mem_ops_per_warp = 0;
+    for (i = 0; i < n_mem * gpu_mem_n_bk; i++) {
+      accum_MCBs_accessed += i * num_MCBs_accessed[i];
+      tot_mem_ops_per_warp += num_MCBs_accessed[i];
+      printf("%d\t", num_MCBs_accessed[i]);
+    }
+
+    printf(
+        "\nAverage # of Memory Banks Accessed per Memory Operation per "
+        "Warp=%f\n",
+        (float)accum_MCBs_accessed / tot_mem_ops_per_warp);
+
+    // printf("\nAverage Difference Between First and Last Response from Memory
+    // System per warp = ");
+
+    printf("\nposition of mrq chosen\n");
+
+    if (!m_memory_config->gpgpu_frfcfs_dram_sched_queue_size)
+      j = 1024;
+    else
+      j = m_memory_config->gpgpu_frfcfs_dram_sched_queue_size;
+    k = 0;
+    l = 0;
+    for (i = 0; i < j; i++) {
+      printf("%d\t", position_of_mrq_chosen[i]);
+      k += position_of_mrq_chosen[i];
+      l += i * position_of_mrq_chosen[i];
+    }
+    printf("\n");
+    printf("\naverage position of mrq chosen = %f\n", (float)l / k);
+  }
 }

--- a/src/gpgpu-sim/mem_latency_stat.cc
+++ b/src/gpgpu-sim/mem_latency_stat.cc
@@ -8,474 +8,513 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
-#include "../abstract_hardware_model.h"
 #include "mem_latency_stat.h"
-#include "gpu-sim.h"
-#include "gpu-misc.h"
-#include "gpu-cache.h"
-#include "shader.h"
-#include "mem_fetch.h"
-#include "stat-tool.h"
+#include "../abstract_hardware_model.h"
 #include "../cuda-sim/ptx-stats.h"
-#include "visualizer.h"
 #include "dram.h"
+#include "gpu-cache.h"
+#include "gpu-misc.h"
+#include "gpu-sim.h"
+#include "mem_fetch.h"
+#include "shader.h"
+#include "stat-tool.h"
+#include "visualizer.h"
 
-#include <string.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include "../../libcuda/gpgpu_context.h"
 
-memory_stats_t::memory_stats_t( unsigned n_shader, const shader_core_config *shader_config, const memory_config *mem_config, const class gpgpu_sim* gpu )
-{
-   assert( mem_config->m_valid );
-   assert( shader_config->m_valid );
+memory_stats_t::memory_stats_t(unsigned n_shader,
+                               const shader_core_config *shader_config,
+                               const memory_config *mem_config,
+                               const class gpgpu_sim *gpu) {
+  assert(mem_config->m_valid);
+  assert(shader_config->m_valid);
 
-   unsigned i,j;
+  unsigned i, j;
 
+  concurrent_row_access =
+      (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
+  num_activates =
+      (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
+  row_access =
+      (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
+  max_conc_access2samerow =
+      (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
+  max_servicetime2samerow =
+      (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
 
-   concurrent_row_access = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
-   num_activates = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
-   row_access = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
-   max_conc_access2samerow = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
-   max_servicetime2samerow = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
+  for (unsigned i = 0; i < mem_config->m_n_mem; i++) {
+    concurrent_row_access[i] =
+        (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
+    row_access[i] =
+        (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
+    num_activates[i] =
+        (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
+    max_conc_access2samerow[i] =
+        (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
+    max_servicetime2samerow[i] =
+        (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
+  }
 
-   for (unsigned i=0;i<mem_config->m_n_mem ;i++ ) {
-      concurrent_row_access[i] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
-      row_access[i] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
-      num_activates[i] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
-      max_conc_access2samerow[i] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
-      max_servicetime2samerow[i] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
-   }
+  m_n_shader = n_shader;
+  m_memory_config = mem_config;
+  m_gpu = gpu;
+  total_n_access = 0;
+  total_n_reads = 0;
+  total_n_writes = 0;
+  max_mrq_latency = 0;
+  max_dq_latency = 0;
+  max_mf_latency = 0;
+  max_icnt2mem_latency = 0;
+  max_icnt2sh_latency = 0;
+  tot_icnt2mem_latency = 0;
+  tot_icnt2sh_latency = 0;
+  tot_mrq_num = 0;
+  tot_mrq_latency = 0;
+  memset(mrq_lat_table, 0, sizeof(unsigned) * 32);
+  memset(dq_lat_table, 0, sizeof(unsigned) * 32);
+  memset(mf_lat_table, 0, sizeof(unsigned) * 32);
+  memset(icnt2mem_lat_table, 0, sizeof(unsigned) * 24);
+  memset(icnt2sh_lat_table, 0, sizeof(unsigned) * 24);
+  memset(mf_lat_pw_table, 0, sizeof(unsigned) * 32);
+  mf_num_lat_pw = 0;
+  max_warps =
+      n_shader *
+      (shader_config->n_thread_per_shader / shader_config->warp_size + 1);
+  mf_tot_lat_pw = 0;  // total latency summed up per window. divide by
+                      // mf_num_lat_pw to obtain average latency Per Window
+  mf_total_lat = 0;
+  num_mfs = 0;
+  printf("*** Initializing Memory Statistics ***\n");
+  totalbankreads =
+      (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
+  totalbankwrites =
+      (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
+  totalbankaccesses =
+      (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
+  mf_total_lat_table = (unsigned long long int **)calloc(
+      mem_config->m_n_mem, sizeof(unsigned long long *));
+  mf_max_lat_table =
+      (unsigned **)calloc(mem_config->m_n_mem, sizeof(unsigned *));
+  bankreads = (unsigned int ***)calloc(n_shader, sizeof(unsigned int **));
+  bankwrites = (unsigned int ***)calloc(n_shader, sizeof(unsigned int **));
+  num_MCBs_accessed = (unsigned int *)calloc(
+      mem_config->m_n_mem * mem_config->nbk, sizeof(unsigned int));
+  if (mem_config->gpgpu_frfcfs_dram_sched_queue_size) {
+    position_of_mrq_chosen = (unsigned int *)calloc(
+        mem_config->gpgpu_frfcfs_dram_sched_queue_size, sizeof(unsigned int));
+  } else
+    position_of_mrq_chosen = (unsigned int *)calloc(1024, sizeof(unsigned int));
+  for (i = 0; i < n_shader; i++) {
+    bankreads[i] =
+        (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
+    bankwrites[i] =
+        (unsigned int **)calloc(mem_config->m_n_mem, sizeof(unsigned int *));
+    for (j = 0; j < mem_config->m_n_mem; j++) {
+      bankreads[i][j] =
+          (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
+      bankwrites[i][j] =
+          (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
+    }
+  }
 
+  for (i = 0; i < mem_config->m_n_mem; i++) {
+    totalbankreads[i] =
+        (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
+    totalbankwrites[i] =
+        (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
+    totalbankaccesses[i] =
+        (unsigned int *)calloc(mem_config->nbk, sizeof(unsigned int));
+    mf_total_lat_table[i] = (unsigned long long int *)calloc(
+        mem_config->nbk, sizeof(unsigned long long int));
+    mf_max_lat_table[i] = (unsigned *)calloc(mem_config->nbk, sizeof(unsigned));
+  }
 
-   m_n_shader=n_shader;
-   m_memory_config=mem_config;
-   m_gpu=gpu;
-   total_n_access=0;
-   total_n_reads=0;
-   total_n_writes=0;
-   max_mrq_latency = 0;
-   max_dq_latency = 0;
-   max_mf_latency = 0;
-   max_icnt2mem_latency = 0;
-   max_icnt2sh_latency = 0;
-   tot_icnt2mem_latency = 0;
-   tot_icnt2sh_latency = 0;
-   tot_mrq_num = 0;
-   tot_mrq_latency = 0;
-   memset(mrq_lat_table, 0, sizeof(unsigned)*32);
-   memset(dq_lat_table, 0, sizeof(unsigned)*32);
-   memset(mf_lat_table, 0, sizeof(unsigned)*32);
-   memset(icnt2mem_lat_table, 0, sizeof(unsigned)*24);
-   memset(icnt2sh_lat_table, 0, sizeof(unsigned)*24);
-   memset(mf_lat_pw_table, 0, sizeof(unsigned)*32);
-   mf_num_lat_pw = 0;
-   max_warps = n_shader * (shader_config->n_thread_per_shader / shader_config->warp_size+1);
-   mf_tot_lat_pw = 0; //total latency summed up per window. divide by mf_num_lat_pw to obtain average latency Per Window
-   mf_total_lat = 0;
-   num_mfs = 0;
-   printf("*** Initializing Memory Statistics ***\n");
-   totalbankreads = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
-   totalbankwrites = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
-   totalbankaccesses = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
-   mf_total_lat_table = (unsigned long long int **) calloc(mem_config->m_n_mem, sizeof(unsigned long long *));
-   mf_max_lat_table = (unsigned **) calloc(mem_config->m_n_mem, sizeof(unsigned *));
-   bankreads = (unsigned int***) calloc(n_shader, sizeof(unsigned int**));
-   bankwrites = (unsigned int***) calloc(n_shader, sizeof(unsigned int**));
-   num_MCBs_accessed = (unsigned int*) calloc(mem_config->m_n_mem*mem_config->nbk, sizeof(unsigned int));
-   if (mem_config->gpgpu_frfcfs_dram_sched_queue_size) {
-      position_of_mrq_chosen = (unsigned int*) calloc(mem_config->gpgpu_frfcfs_dram_sched_queue_size, sizeof(unsigned int));
-   } else
-      position_of_mrq_chosen = (unsigned int*) calloc(1024, sizeof(unsigned int));
-   for (i=0;i<n_shader ;i++ ) {
-      bankreads[i] = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
-      bankwrites[i] = (unsigned int**) calloc(mem_config->m_n_mem, sizeof(unsigned int*));
-      for (j=0;j<mem_config->m_n_mem ;j++ ) {
-         bankreads[i][j] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
-         bankwrites[i][j] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
-      }
-   }
+  mem_access_type_stats =
+      (unsigned ***)malloc(NUM_MEM_ACCESS_TYPE * sizeof(unsigned **));
+  for (i = 0; i < NUM_MEM_ACCESS_TYPE; i++) {
+    int j;
+    mem_access_type_stats[i] =
+        (unsigned **)calloc(mem_config->m_n_mem, sizeof(unsigned *));
+    for (j = 0; (unsigned)j < mem_config->m_n_mem; j++) {
+      mem_access_type_stats[i][j] =
+          (unsigned *)calloc((mem_config->nbk + 1), sizeof(unsigned *));
+    }
+  }
 
-   for (i=0;i<mem_config->m_n_mem ;i++ ) {
-      totalbankreads[i] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
-      totalbankwrites[i] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
-      totalbankaccesses[i] = (unsigned int*) calloc(mem_config->nbk, sizeof(unsigned int));
-      mf_total_lat_table[i] = (unsigned long long int*) calloc(mem_config->nbk, sizeof(unsigned long long int));
-      mf_max_lat_table[i] = (unsigned *) calloc(mem_config->nbk, sizeof(unsigned));
-   }
+  // AerialVision L2 stats
+  L2_read_miss = 0;
+  L2_write_miss = 0;
+  L2_read_hit = 0;
+  L2_write_hit = 0;
 
-   mem_access_type_stats = (unsigned ***) malloc(NUM_MEM_ACCESS_TYPE * sizeof(unsigned **));
-   for (i = 0; i < NUM_MEM_ACCESS_TYPE; i++) {
-      int j;
-      mem_access_type_stats[i] = (unsigned **) calloc(mem_config->m_n_mem, sizeof(unsigned*));
-      for (j=0; (unsigned) j< mem_config->m_n_mem; j++) {
-         mem_access_type_stats[i][j] = (unsigned *) calloc((mem_config->nbk+1), sizeof(unsigned*));
-      }
-   }
-
-   // AerialVision L2 stats
-   L2_read_miss = 0;
-   L2_write_miss = 0;
-   L2_read_hit = 0;
-   L2_write_hit = 0;
-
-   L2_cbtoL2length = (unsigned int*) calloc(mem_config->m_n_mem, sizeof(unsigned int));
-   L2_cbtoL2writelength = (unsigned int*) calloc(mem_config->m_n_mem, sizeof(unsigned int));
-   L2_L2tocblength = (unsigned int*) calloc(mem_config->m_n_mem, sizeof(unsigned int));
-   L2_dramtoL2length = (unsigned int*) calloc(mem_config->m_n_mem, sizeof(unsigned int));
-   L2_dramtoL2writelength = (unsigned int*) calloc(mem_config->m_n_mem, sizeof(unsigned int));
-   L2_L2todramlength = (unsigned int*) calloc(mem_config->m_n_mem, sizeof(unsigned int));
+  L2_cbtoL2length =
+      (unsigned int *)calloc(mem_config->m_n_mem, sizeof(unsigned int));
+  L2_cbtoL2writelength =
+      (unsigned int *)calloc(mem_config->m_n_mem, sizeof(unsigned int));
+  L2_L2tocblength =
+      (unsigned int *)calloc(mem_config->m_n_mem, sizeof(unsigned int));
+  L2_dramtoL2length =
+      (unsigned int *)calloc(mem_config->m_n_mem, sizeof(unsigned int));
+  L2_dramtoL2writelength =
+      (unsigned int *)calloc(mem_config->m_n_mem, sizeof(unsigned int));
+  L2_L2todramlength =
+      (unsigned int *)calloc(mem_config->m_n_mem, sizeof(unsigned int));
 }
 
 // record the total latency
-unsigned memory_stats_t::memlatstat_done(mem_fetch *mf )
-{
-   unsigned mf_latency;
-   mf_latency = (m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle) - mf->get_timestamp();
-   mf_num_lat_pw++;
-   mf_tot_lat_pw += mf_latency;
-   unsigned idx = LOGB2(mf_latency);
-   assert(idx<32);
-   mf_lat_table[idx]++;
-   shader_mem_lat_log(mf->get_sid(), mf_latency);
-   mf_total_lat_table[mf->get_tlx_addr().chip][mf->get_tlx_addr().bk] += mf_latency;
-   if (mf_latency > max_mf_latency)
-      max_mf_latency = mf_latency;
-   return mf_latency;
+unsigned memory_stats_t::memlatstat_done(mem_fetch *mf) {
+  unsigned mf_latency;
+  mf_latency =
+      (m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle) - mf->get_timestamp();
+  mf_num_lat_pw++;
+  mf_tot_lat_pw += mf_latency;
+  unsigned idx = LOGB2(mf_latency);
+  assert(idx < 32);
+  mf_lat_table[idx]++;
+  shader_mem_lat_log(mf->get_sid(), mf_latency);
+  mf_total_lat_table[mf->get_tlx_addr().chip][mf->get_tlx_addr().bk] +=
+      mf_latency;
+  if (mf_latency > max_mf_latency) max_mf_latency = mf_latency;
+  return mf_latency;
 }
 
-void memory_stats_t::memlatstat_read_done(mem_fetch *mf)
-{
-   if (m_memory_config->gpgpu_memlatency_stat) {
-      unsigned mf_latency = memlatstat_done(mf);
-      if (mf_latency > mf_max_lat_table[mf->get_tlx_addr().chip][mf->get_tlx_addr().bk]) 
-         mf_max_lat_table[mf->get_tlx_addr().chip][mf->get_tlx_addr().bk] = mf_latency;
-      unsigned icnt2sh_latency;
-      icnt2sh_latency = (m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle) - mf->get_return_timestamp();
-      tot_icnt2sh_latency += icnt2sh_latency;
-      icnt2sh_lat_table[LOGB2(icnt2sh_latency)]++;
-      if (icnt2sh_latency > max_icnt2sh_latency)
-         max_icnt2sh_latency = icnt2sh_latency;
-   }
+void memory_stats_t::memlatstat_read_done(mem_fetch *mf) {
+  if (m_memory_config->gpgpu_memlatency_stat) {
+    unsigned mf_latency = memlatstat_done(mf);
+    if (mf_latency >
+        mf_max_lat_table[mf->get_tlx_addr().chip][mf->get_tlx_addr().bk])
+      mf_max_lat_table[mf->get_tlx_addr().chip][mf->get_tlx_addr().bk] =
+          mf_latency;
+    unsigned icnt2sh_latency;
+    icnt2sh_latency = (m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle) -
+                      mf->get_return_timestamp();
+    tot_icnt2sh_latency += icnt2sh_latency;
+    icnt2sh_lat_table[LOGB2(icnt2sh_latency)]++;
+    if (icnt2sh_latency > max_icnt2sh_latency)
+      max_icnt2sh_latency = icnt2sh_latency;
+  }
 }
 
-void memory_stats_t::memlatstat_dram_access(mem_fetch *mf)
-{
-   unsigned dram_id = mf->get_tlx_addr().chip;
-   unsigned bank = mf->get_tlx_addr().bk;
-   if (m_memory_config->gpgpu_memlatency_stat) { 
-      if (mf->get_is_write()) {
-         if ( mf->get_sid() < m_n_shader  ) {   //do not count L2_writebacks here 
-            bankwrites[mf->get_sid()][dram_id][bank]++;
-            shader_mem_acc_log( mf->get_sid(), dram_id, bank, 'w');
-         }
-         totalbankwrites[dram_id][bank]++;
-      } else {
-         bankreads[mf->get_sid()][dram_id][bank]++;
-         shader_mem_acc_log( mf->get_sid(), dram_id, bank, 'r');
-         totalbankreads[dram_id][bank]++;
+void memory_stats_t::memlatstat_dram_access(mem_fetch *mf) {
+  unsigned dram_id = mf->get_tlx_addr().chip;
+  unsigned bank = mf->get_tlx_addr().bk;
+  if (m_memory_config->gpgpu_memlatency_stat) {
+    if (mf->get_is_write()) {
+      if (mf->get_sid() < m_n_shader) {  // do not count L2_writebacks here
+        bankwrites[mf->get_sid()][dram_id][bank]++;
+        shader_mem_acc_log(mf->get_sid(), dram_id, bank, 'w');
       }
-      mem_access_type_stats[mf->get_access_type()][dram_id][bank]++;
-   }
-   if (mf->get_pc() != (unsigned)-1) 
-      m_gpu->gpgpu_ctx->stats->ptx_file_line_stats_add_dram_traffic(mf->get_pc(), mf->get_data_size());
+      totalbankwrites[dram_id][bank]++;
+    } else {
+      bankreads[mf->get_sid()][dram_id][bank]++;
+      shader_mem_acc_log(mf->get_sid(), dram_id, bank, 'r');
+      totalbankreads[dram_id][bank]++;
+    }
+    mem_access_type_stats[mf->get_access_type()][dram_id][bank]++;
+  }
+  if (mf->get_pc() != (unsigned)-1)
+    m_gpu->gpgpu_ctx->stats->ptx_file_line_stats_add_dram_traffic(
+        mf->get_pc(), mf->get_data_size());
 }
 
-void memory_stats_t::memlatstat_icnt2mem_pop(mem_fetch *mf)
-{
-   if (m_memory_config->gpgpu_memlatency_stat) {
-      unsigned icnt2mem_latency;
-      icnt2mem_latency = (m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle) - mf->get_timestamp();
-      tot_icnt2mem_latency += icnt2mem_latency;
-      icnt2mem_lat_table[LOGB2(icnt2mem_latency)]++;
-      if (icnt2mem_latency > max_icnt2mem_latency)
-         max_icnt2mem_latency = icnt2mem_latency;
-   }
+void memory_stats_t::memlatstat_icnt2mem_pop(mem_fetch *mf) {
+  if (m_memory_config->gpgpu_memlatency_stat) {
+    unsigned icnt2mem_latency;
+    icnt2mem_latency =
+        (m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle) - mf->get_timestamp();
+    tot_icnt2mem_latency += icnt2mem_latency;
+    icnt2mem_lat_table[LOGB2(icnt2mem_latency)]++;
+    if (icnt2mem_latency > max_icnt2mem_latency)
+      max_icnt2mem_latency = icnt2mem_latency;
+  }
 }
 
-void memory_stats_t::memlatstat_lat_pw()
-{
-   if (mf_num_lat_pw && m_memory_config->gpgpu_memlatency_stat) {
-      assert(mf_tot_lat_pw);
-      mf_total_lat += mf_tot_lat_pw;
-      num_mfs += mf_num_lat_pw;
-      mf_lat_pw_table[LOGB2(mf_tot_lat_pw/mf_num_lat_pw)]++;
-      mf_tot_lat_pw = 0;
-      mf_num_lat_pw = 0;
-   }
+void memory_stats_t::memlatstat_lat_pw() {
+  if (mf_num_lat_pw && m_memory_config->gpgpu_memlatency_stat) {
+    assert(mf_tot_lat_pw);
+    mf_total_lat += mf_tot_lat_pw;
+    num_mfs += mf_num_lat_pw;
+    mf_lat_pw_table[LOGB2(mf_tot_lat_pw / mf_num_lat_pw)]++;
+    mf_tot_lat_pw = 0;
+    mf_num_lat_pw = 0;
+  }
 }
 
+void memory_stats_t::memlatstat_print(unsigned n_mem, unsigned gpu_mem_n_bk) {
+  unsigned i, j, k, l, m;
+  unsigned max_bank_accesses, min_bank_accesses, max_chip_accesses,
+      min_chip_accesses;
 
-void memory_stats_t::memlatstat_print( unsigned n_mem, unsigned gpu_mem_n_bk )
-{
-   unsigned i,j,k,l,m;
-   unsigned max_bank_accesses, min_bank_accesses, max_chip_accesses, min_chip_accesses;
+  if (m_memory_config->gpgpu_memlatency_stat) {
+    printf("maxmflatency = %d \n", max_mf_latency);
+    printf("max_icnt2mem_latency = %d \n", max_icnt2mem_latency);
+    printf("maxmrqlatency = %d \n", max_mrq_latency);
+    // printf("maxdqlatency = %d \n", max_dq_latency);
+    printf("max_icnt2sh_latency = %d \n", max_icnt2sh_latency);
+    if (num_mfs) {
+      printf("averagemflatency = %lld \n", mf_total_lat / num_mfs);
+      printf("avg_icnt2mem_latency = %lld \n", tot_icnt2mem_latency / num_mfs);
+      if (tot_mrq_num)
+        printf("avg_mrq_latency = %lld \n", tot_mrq_latency / tot_mrq_num);
 
-   if (m_memory_config->gpgpu_memlatency_stat) {
-	   printf("maxmflatency = %d \n", max_mf_latency);
-	   printf("max_icnt2mem_latency = %d \n", max_icnt2mem_latency);
-      printf("maxmrqlatency = %d \n", max_mrq_latency);
-      //printf("maxdqlatency = %d \n", max_dq_latency);
-      printf("max_icnt2sh_latency = %d \n", max_icnt2sh_latency);
-      if (num_mfs) {
-         printf("averagemflatency = %lld \n", mf_total_lat/num_mfs);
-         printf("avg_icnt2mem_latency = %lld \n", tot_icnt2mem_latency/num_mfs);
-         if(tot_mrq_num)
-        	 printf("avg_mrq_latency = %lld \n", tot_mrq_latency/tot_mrq_num);
+      printf("avg_icnt2sh_latency = %lld \n", tot_icnt2sh_latency / num_mfs);
+    }
+    printf("mrq_lat_table:");
+    for (i = 0; i < 32; i++) {
+      printf("%d \t", mrq_lat_table[i]);
+    }
+    printf("\n");
+    printf("dq_lat_table:");
+    for (i = 0; i < 32; i++) {
+      printf("%d \t", dq_lat_table[i]);
+    }
+    printf("\n");
+    printf("mf_lat_table:");
+    for (i = 0; i < 32; i++) {
+      printf("%d \t", mf_lat_table[i]);
+    }
+    printf("\n");
+    printf("icnt2mem_lat_table:");
+    for (i = 0; i < 24; i++) {
+      printf("%d \t", icnt2mem_lat_table[i]);
+    }
+    printf("\n");
+    printf("icnt2sh_lat_table:");
+    for (i = 0; i < 24; i++) {
+      printf("%d \t", icnt2sh_lat_table[i]);
+    }
+    printf("\n");
+    printf("mf_lat_pw_table:");
+    for (i = 0; i < 32; i++) {
+      printf("%d \t", mf_lat_pw_table[i]);
+    }
+    printf("\n");
 
-         printf("avg_icnt2sh_latency = %lld \n", tot_icnt2sh_latency/num_mfs);
-      }
-      printf("mrq_lat_table:");
-      for (i=0; i< 32; i++) {
-         printf("%d \t", mrq_lat_table[i]);
+    /*MAXIMUM CONCURRENT ACCESSES TO SAME ROW*/
+    printf("maximum concurrent accesses to same row:\n");
+    for (i = 0; i < n_mem; i++) {
+      printf("dram[%d]: ", i);
+      for (j = 0; j < gpu_mem_n_bk; j++) {
+        printf("%9d ", max_conc_access2samerow[i][j]);
       }
       printf("\n");
-      printf("dq_lat_table:");
-      for (i=0; i< 32; i++) {
-         printf("%d \t", dq_lat_table[i]);
-      }
-      printf("\n");
-      printf("mf_lat_table:");
-      for (i=0; i< 32; i++) {
-         printf("%d \t", mf_lat_table[i]);
-      }
-      printf("\n");
-      printf("icnt2mem_lat_table:");
-      for (i=0; i< 24; i++) {
-         printf("%d \t", icnt2mem_lat_table[i]);
-      }
-      printf("\n");
-      printf("icnt2sh_lat_table:");
-      for (i=0; i< 24; i++) {
-         printf("%d \t", icnt2sh_lat_table[i]);
-      }
-      printf("\n");
-      printf("mf_lat_pw_table:");
-      for (i=0; i< 32; i++) {
-         printf("%d \t", mf_lat_pw_table[i]);
-      }
-      printf("\n");
+    }
 
-      /*MAXIMUM CONCURRENT ACCESSES TO SAME ROW*/
-      printf("maximum concurrent accesses to same row:\n");
-      for (i=0;i<n_mem ;i++ ) {
-         printf("dram[%d]: ", i);
-         for (j=0;j<gpu_mem_n_bk;j++ ) {
-            printf("%9d ",max_conc_access2samerow[i][j]);
-         }
-         printf("\n");
+    /*MAXIMUM SERVICE TIME TO SAME ROW*/
+    printf("maximum service time to same row:\n");
+    for (i = 0; i < n_mem; i++) {
+      printf("dram[%d]: ", i);
+      for (j = 0; j < gpu_mem_n_bk; j++) {
+        printf("%9d ", max_servicetime2samerow[i][j]);
       }
+      printf("\n");
+    }
 
-      /*MAXIMUM SERVICE TIME TO SAME ROW*/
-      printf("maximum service time to same row:\n");
-      for (i=0;i<n_mem ;i++ ) {
-         printf("dram[%d]: ", i);
-         for (j=0;j<gpu_mem_n_bk;j++ ) {
-            printf("%9d ",max_servicetime2samerow[i][j]);
-         }
-         printf("\n");
+    /*AVERAGE ROW ACCESSES PER ACTIVATE*/
+    int total_row_accesses = 0;
+    int total_num_activates = 0;
+    printf("average row accesses per activate:\n");
+    for (i = 0; i < n_mem; i++) {
+      printf("dram[%d]: ", i);
+      for (j = 0; j < gpu_mem_n_bk; j++) {
+        total_row_accesses += row_access[i][j];
+        total_num_activates += num_activates[i][j];
+        printf("%9f ", (float)row_access[i][j] / num_activates[i][j]);
       }
-
-      /*AVERAGE ROW ACCESSES PER ACTIVATE*/
-      int total_row_accesses = 0;
-      int total_num_activates = 0;
-      printf("average row accesses per activate:\n");
-      for (i=0;i<n_mem ;i++ ) {
-         printf("dram[%d]: ", i);
-         for (j=0;j<gpu_mem_n_bk;j++ ) {
-            total_row_accesses += row_access[i][j];
-            total_num_activates += num_activates[i][j];
-            printf("%9f ",(float) row_access[i][j]/num_activates[i][j]);
-         }
-         printf("\n");
+      printf("\n");
+    }
+    printf("average row locality = %d/%d = %f\n", total_row_accesses,
+           total_num_activates,
+           (float)total_row_accesses / total_num_activates);
+    /*MEMORY ACCESSES*/
+    k = 0;
+    l = 0;
+    m = 0;
+    max_bank_accesses = 0;
+    max_chip_accesses = 0;
+    min_bank_accesses = 0xFFFFFFFF;
+    min_chip_accesses = 0xFFFFFFFF;
+    printf("number of total memory accesses made:\n");
+    for (i = 0; i < n_mem; i++) {
+      printf("dram[%d]: ", i);
+      for (j = 0; j < gpu_mem_n_bk; j++) {
+        l = totalbankaccesses[i][j];
+        if (l < min_bank_accesses) min_bank_accesses = l;
+        if (l > max_bank_accesses) max_bank_accesses = l;
+        k += l;
+        m += l;
+        printf("%9d ", l);
       }
-      printf("average row locality = %d/%d = %f\n", total_row_accesses, total_num_activates, (float)total_row_accesses/total_num_activates);
-      /*MEMORY ACCESSES*/
-      k = 0;
-      l = 0;
+      if (m < min_chip_accesses) min_chip_accesses = m;
+      if (m > max_chip_accesses) max_chip_accesses = m;
       m = 0;
-      max_bank_accesses = 0;
-      max_chip_accesses = 0;
-      min_bank_accesses = 0xFFFFFFFF;
-      min_chip_accesses = 0xFFFFFFFF;
-      printf("number of total memory accesses made:\n");
-      for (i=0;i<n_mem ;i++ ) {
-         printf("dram[%d]: ", i);
-         for (j=0;j<gpu_mem_n_bk;j++ ) {
-            l = totalbankaccesses[i][j];
-            if (l < min_bank_accesses)
-               min_bank_accesses = l;
-            if (l > max_bank_accesses)
-               max_bank_accesses = l;
-            k += l;
-            m += l;
-            printf("%9d ",l);
-         }
-         if (m < min_chip_accesses)
-            min_chip_accesses = m;
-         if (m > max_chip_accesses)
-            max_chip_accesses = m;
-         m = 0;
-         printf("\n");
-      }
-      printf("total accesses: %d\n", k);
-      if (min_bank_accesses)
-         printf("bank skew: %d/%d = %4.2f\n", max_bank_accesses, min_bank_accesses, (float)max_bank_accesses/min_bank_accesses);
-      else
-         printf("min_bank_accesses = 0!\n");
-      if (min_chip_accesses)
-         printf("chip skew: %d/%d = %4.2f\n", max_chip_accesses, min_chip_accesses, (float)max_chip_accesses/min_chip_accesses);
-      else
-         printf("min_chip_accesses = 0!\n");
+      printf("\n");
+    }
+    printf("total accesses: %d\n", k);
+    if (min_bank_accesses)
+      printf("bank skew: %d/%d = %4.2f\n", max_bank_accesses, min_bank_accesses,
+             (float)max_bank_accesses / min_bank_accesses);
+    else
+      printf("min_bank_accesses = 0!\n");
+    if (min_chip_accesses)
+      printf("chip skew: %d/%d = %4.2f\n", max_chip_accesses, min_chip_accesses,
+             (float)max_chip_accesses / min_chip_accesses);
+    else
+      printf("min_chip_accesses = 0!\n");
 
-      /*READ ACCESSES*/
-      k = 0;
-      l = 0;
+    /*READ ACCESSES*/
+    k = 0;
+    l = 0;
+    m = 0;
+    max_bank_accesses = 0;
+    max_chip_accesses = 0;
+    min_bank_accesses = 0xFFFFFFFF;
+    min_chip_accesses = 0xFFFFFFFF;
+    printf("number of total read accesses:\n");
+    for (i = 0; i < n_mem; i++) {
+      printf("dram[%d]: ", i);
+      for (j = 0; j < gpu_mem_n_bk; j++) {
+        l = totalbankreads[i][j];
+        if (l < min_bank_accesses) min_bank_accesses = l;
+        if (l > max_bank_accesses) max_bank_accesses = l;
+        k += l;
+        m += l;
+        printf("%9d ", l);
+      }
+      if (m < min_chip_accesses) min_chip_accesses = m;
+      if (m > max_chip_accesses) max_chip_accesses = m;
       m = 0;
-      max_bank_accesses = 0;
-      max_chip_accesses = 0;
-      min_bank_accesses = 0xFFFFFFFF;
-      min_chip_accesses = 0xFFFFFFFF;
-      printf("number of total read accesses:\n");
-      for (i=0;i<n_mem ;i++ ) {
-         printf("dram[%d]: ", i);
-         for (j=0;j<gpu_mem_n_bk;j++ ) {
-            l = totalbankreads[i][j];
-            if (l < min_bank_accesses)
-               min_bank_accesses = l;
-            if (l > max_bank_accesses)
-               max_bank_accesses = l;
-            k += l;
-            m += l;
-            printf("%9d ",l);
-         }
-         if (m < min_chip_accesses)
-            min_chip_accesses = m;
-         if (m > max_chip_accesses)
-            max_chip_accesses = m;
-         m = 0;
-         printf("\n");
-      }
-      printf("total dram reads = %d\n", k);
-      if (min_bank_accesses)
-         printf("bank skew: %d/%d = %4.2f\n", max_bank_accesses, min_bank_accesses, (float)max_bank_accesses/min_bank_accesses);
-      else
-         printf("min_bank_accesses = 0!\n");
-      if (min_chip_accesses)
-         printf("chip skew: %d/%d = %4.2f\n", max_chip_accesses, min_chip_accesses, (float)max_chip_accesses/min_chip_accesses);
-      else
-         printf("min_chip_accesses = 0!\n");
+      printf("\n");
+    }
+    printf("total dram reads = %d\n", k);
+    if (min_bank_accesses)
+      printf("bank skew: %d/%d = %4.2f\n", max_bank_accesses, min_bank_accesses,
+             (float)max_bank_accesses / min_bank_accesses);
+    else
+      printf("min_bank_accesses = 0!\n");
+    if (min_chip_accesses)
+      printf("chip skew: %d/%d = %4.2f\n", max_chip_accesses, min_chip_accesses,
+             (float)max_chip_accesses / min_chip_accesses);
+    else
+      printf("min_chip_accesses = 0!\n");
 
-      /*WRITE ACCESSES*/
-      k = 0;
-      l = 0;
+    /*WRITE ACCESSES*/
+    k = 0;
+    l = 0;
+    m = 0;
+    max_bank_accesses = 0;
+    max_chip_accesses = 0;
+    min_bank_accesses = 0xFFFFFFFF;
+    min_chip_accesses = 0xFFFFFFFF;
+    printf("number of total write accesses:\n");
+    for (i = 0; i < n_mem; i++) {
+      printf("dram[%d]: ", i);
+      for (j = 0; j < gpu_mem_n_bk; j++) {
+        l = totalbankwrites[i][j];
+        if (l < min_bank_accesses) min_bank_accesses = l;
+        if (l > max_bank_accesses) max_bank_accesses = l;
+        k += l;
+        m += l;
+        printf("%9d ", l);
+      }
+      if (m < min_chip_accesses) min_chip_accesses = m;
+      if (m > max_chip_accesses) max_chip_accesses = m;
       m = 0;
-      max_bank_accesses = 0;
-      max_chip_accesses = 0;
-      min_bank_accesses = 0xFFFFFFFF;
-      min_chip_accesses = 0xFFFFFFFF;
-      printf("number of total write accesses:\n");
-      for (i=0;i<n_mem ;i++ ) {
-         printf("dram[%d]: ", i);
-         for (j=0;j<gpu_mem_n_bk;j++ ) {
-            l = totalbankwrites[i][j];
-            if (l < min_bank_accesses)
-               min_bank_accesses = l;
-            if (l > max_bank_accesses)
-               max_bank_accesses = l;
-            k += l;
-            m += l;
-            printf("%9d ",l);
-         }
-         if (m < min_chip_accesses)
-            min_chip_accesses = m;
-         if (m > max_chip_accesses)
-            max_chip_accesses = m;
-         m = 0;
-         printf("\n");
-      }
-      printf("total dram writes = %d\n", k);
-      if (min_bank_accesses)
-         printf("bank skew: %d/%d = %4.2f\n", max_bank_accesses, min_bank_accesses, (float)max_bank_accesses/min_bank_accesses);
-      else
-         printf("min_bank_accesses = 0!\n");
-      if (min_chip_accesses)
-         printf("chip skew: %d/%d = %4.2f\n", max_chip_accesses, min_chip_accesses, (float)max_chip_accesses/min_chip_accesses);
-      else
-         printf("min_chip_accesses = 0!\n");
+      printf("\n");
+    }
+    printf("total dram writes = %d\n", k);
+    if (min_bank_accesses)
+      printf("bank skew: %d/%d = %4.2f\n", max_bank_accesses, min_bank_accesses,
+             (float)max_bank_accesses / min_bank_accesses);
+    else
+      printf("min_bank_accesses = 0!\n");
+    if (min_chip_accesses)
+      printf("chip skew: %d/%d = %4.2f\n", max_chip_accesses, min_chip_accesses,
+             (float)max_chip_accesses / min_chip_accesses);
+    else
+      printf("min_chip_accesses = 0!\n");
 
-
-      /*AVERAGE MF LATENCY PER BANK*/
-      printf("average mf latency per bank:\n");
-      for (i=0;i<n_mem ;i++ ) {
-         printf("dram[%d]: ", i);
-         for (j=0;j<gpu_mem_n_bk;j++ ) {
-            k = totalbankwrites[i][j] + totalbankreads[i][j];
-            if (k)
-               printf("%10lld", mf_total_lat_table[i][j] / k);
-            else
-               printf("    none  ");
-         }
-         printf("\n");
-      }
-
-      /*MAXIMUM MF LATENCY PER BANK*/
-      printf("maximum mf latency per bank:\n");
-      for (i=0;i<n_mem ;i++ ) {
-         printf("dram[%d]: ", i);
-         for (j=0;j<gpu_mem_n_bk;j++ ) {
-            printf("%10d", mf_max_lat_table[i][j]);
-         }
-         printf("\n");
-      }
-   }
-
-   if (m_memory_config->gpgpu_memlatency_stat & GPU_MEMLATSTAT_MC) {
-      printf("\nNumber of Memory Banks Accessed per Memory Operation per Warp (from 0):\n");
-      unsigned long long accum_MCBs_accessed = 0;
-      unsigned long long tot_mem_ops_per_warp = 0;
-      for (i=0;i< n_mem*gpu_mem_n_bk ; i++ ) {
-         accum_MCBs_accessed += i*num_MCBs_accessed[i];
-         tot_mem_ops_per_warp += num_MCBs_accessed[i];
-         printf("%d\t", num_MCBs_accessed[i]);
-      }
-
-      printf("\nAverage # of Memory Banks Accessed per Memory Operation per Warp=%f\n", (float)accum_MCBs_accessed/tot_mem_ops_per_warp);
-
-      //printf("\nAverage Difference Between First and Last Response from Memory System per warp = ");
-
-
-      printf("\nposition of mrq chosen\n");
-
-      if (!m_memory_config->gpgpu_frfcfs_dram_sched_queue_size)
-         j = 1024;
-      else
-         j = m_memory_config->gpgpu_frfcfs_dram_sched_queue_size;
-      k=0;l=0;
-      for (i=0;i< j; i++ ) {
-         printf("%d\t", position_of_mrq_chosen[i]);
-         k += position_of_mrq_chosen[i];
-         l += i*position_of_mrq_chosen[i];
+    /*AVERAGE MF LATENCY PER BANK*/
+    printf("average mf latency per bank:\n");
+    for (i = 0; i < n_mem; i++) {
+      printf("dram[%d]: ", i);
+      for (j = 0; j < gpu_mem_n_bk; j++) {
+        k = totalbankwrites[i][j] + totalbankreads[i][j];
+        if (k)
+          printf("%10lld", mf_total_lat_table[i][j] / k);
+        else
+          printf("    none  ");
       }
       printf("\n");
-      printf("\naverage position of mrq chosen = %f\n", (float)l/k);
-   }
+    }
+
+    /*MAXIMUM MF LATENCY PER BANK*/
+    printf("maximum mf latency per bank:\n");
+    for (i = 0; i < n_mem; i++) {
+      printf("dram[%d]: ", i);
+      for (j = 0; j < gpu_mem_n_bk; j++) {
+        printf("%10d", mf_max_lat_table[i][j]);
+      }
+      printf("\n");
+    }
+  }
+
+  if (m_memory_config->gpgpu_memlatency_stat & GPU_MEMLATSTAT_MC) {
+    printf(
+        "\nNumber of Memory Banks Accessed per Memory Operation per Warp (from "
+        "0):\n");
+    unsigned long long accum_MCBs_accessed = 0;
+    unsigned long long tot_mem_ops_per_warp = 0;
+    for (i = 0; i < n_mem * gpu_mem_n_bk; i++) {
+      accum_MCBs_accessed += i * num_MCBs_accessed[i];
+      tot_mem_ops_per_warp += num_MCBs_accessed[i];
+      printf("%d\t", num_MCBs_accessed[i]);
+    }
+
+    printf(
+        "\nAverage # of Memory Banks Accessed per Memory Operation per "
+        "Warp=%f\n",
+        (float)accum_MCBs_accessed / tot_mem_ops_per_warp);
+
+    // printf("\nAverage Difference Between First and Last Response from Memory
+    // System per warp = ");
+
+    printf("\nposition of mrq chosen\n");
+
+    if (!m_memory_config->gpgpu_frfcfs_dram_sched_queue_size)
+      j = 1024;
+    else
+      j = m_memory_config->gpgpu_frfcfs_dram_sched_queue_size;
+    k = 0;
+    l = 0;
+    for (i = 0; i < j; i++) {
+      printf("%d\t", position_of_mrq_chosen[i]);
+      k += position_of_mrq_chosen[i];
+      l += i * position_of_mrq_chosen[i];
+    }
+    printf("\n");
+    printf("\naverage position of mrq chosen = %f\n", (float)l / k);
+  }
 }

--- a/src/gpgpu-sim/mem_latency_stat.h
+++ b/src/gpgpu-sim/mem_latency_stat.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -36,94 +34,87 @@
 
 class memory_config;
 class memory_stats_t {
- public:
-  memory_stats_t(unsigned n_shader,
-                 const class shader_core_config *shader_config,
-                 const memory_config *mem_config, const class gpgpu_sim *gpu);
+public:
+   memory_stats_t( unsigned n_shader, 
+                   const class shader_core_config *shader_config, 
+                   const memory_config *mem_config,
+				   const class gpgpu_sim* gpu);
 
-  unsigned memlatstat_done(class mem_fetch *mf);
-  void memlatstat_read_done(class mem_fetch *mf);
-  void memlatstat_dram_access(class mem_fetch *mf);
-  void memlatstat_icnt2mem_pop(class mem_fetch *mf);
-  void memlatstat_lat_pw();
-  void memlatstat_print(unsigned n_mem, unsigned gpu_mem_n_bk);
+   unsigned memlatstat_done( class mem_fetch *mf );
+   void memlatstat_read_done( class mem_fetch *mf );
+   void memlatstat_dram_access( class mem_fetch *mf );
+   void memlatstat_icnt2mem_pop( class mem_fetch *mf);
+   void memlatstat_lat_pw();
+   void memlatstat_print(unsigned n_mem, unsigned gpu_mem_n_bk);
 
-  void visualizer_print(gzFile visualizer_file);
+   void visualizer_print( gzFile visualizer_file );
 
-  // Reset local L2 stats that are aggregated each sampling window
-  void clear_L2_stats_pw();
+   // Reset local L2 stats that are aggregated each sampling window
+   void clear_L2_stats_pw();
 
-  unsigned m_n_shader;
+   unsigned m_n_shader;
 
-  const shader_core_config *m_shader_config;
-  const memory_config *m_memory_config;
-  const class gpgpu_sim *m_gpu;
+   const shader_core_config *m_shader_config;
+   const memory_config *m_memory_config;
+   const class gpgpu_sim* m_gpu;
 
-  unsigned max_mrq_latency;
-  unsigned max_dq_latency;
-  unsigned max_mf_latency;
-  unsigned max_icnt2mem_latency;
-  unsigned long long int tot_icnt2mem_latency;
-  unsigned long long int tot_icnt2sh_latency;
-  unsigned long long int tot_mrq_latency;
-  unsigned long long int tot_mrq_num;
-  unsigned max_icnt2sh_latency;
-  unsigned mrq_lat_table[32];
-  unsigned dq_lat_table[32];
-  unsigned mf_lat_table[32];
-  unsigned icnt2mem_lat_table[24];
-  unsigned icnt2sh_lat_table[24];
-  unsigned mf_lat_pw_table[32];  // table storing values of mf latency Per
-                                 // Window
-  unsigned mf_num_lat_pw;
-  unsigned max_warps;
-  unsigned mf_tot_lat_pw;  // total latency summed up per window. divide by
-                           // mf_num_lat_pw to obtain average latency Per Window
-  unsigned long long int mf_total_lat;
-  unsigned long long int *
-      *mf_total_lat_table;      // mf latency sums[dram chip id][bank id]
-  unsigned **mf_max_lat_table;  // mf latency sums[dram chip id][bank id]
-  unsigned num_mfs;
-  unsigned int ***bankwrites;  // bankwrites[shader id][dram chip id][bank id]
-  unsigned int ***bankreads;   // bankreads[shader id][dram chip id][bank id]
-  unsigned int **totalbankwrites;    // bankwrites[dram chip id][bank id]
-  unsigned int **totalbankreads;     // bankreads[dram chip id][bank id]
-  unsigned int **totalbankaccesses;  // bankaccesses[dram chip id][bank id]
-  unsigned int *num_MCBs_accessed;   // tracks how many memory controllers are
-                                    // accessed whenever any thread in a warp
-                                    // misses in cache
-  unsigned int *position_of_mrq_chosen;  // position of mrq in m_queue chosen
+   unsigned max_mrq_latency;
+   unsigned max_dq_latency;
+   unsigned max_mf_latency;
+   unsigned max_icnt2mem_latency;
+   unsigned long long int tot_icnt2mem_latency;
+   unsigned long long int tot_icnt2sh_latency;
+   unsigned long long int tot_mrq_latency;
+   unsigned long long int tot_mrq_num;
+   unsigned max_icnt2sh_latency;
+   unsigned mrq_lat_table[32];
+   unsigned dq_lat_table[32];
+   unsigned mf_lat_table[32];
+   unsigned icnt2mem_lat_table[24];
+   unsigned icnt2sh_lat_table[24];
+   unsigned mf_lat_pw_table[32]; //table storing values of mf latency Per Window
+   unsigned mf_num_lat_pw;
+   unsigned max_warps;
+   unsigned mf_tot_lat_pw; //total latency summed up per window. divide by mf_num_lat_pw to obtain average latency Per Window
+   unsigned long long int mf_total_lat;
+   unsigned long long int ** mf_total_lat_table; //mf latency sums[dram chip id][bank id]
+   unsigned ** mf_max_lat_table; //mf latency sums[dram chip id][bank id]
+   unsigned num_mfs;
+   unsigned int ***bankwrites; //bankwrites[shader id][dram chip id][bank id]
+   unsigned int ***bankreads; //bankreads[shader id][dram chip id][bank id]
+   unsigned int **totalbankwrites; //bankwrites[dram chip id][bank id]
+   unsigned int **totalbankreads; //bankreads[dram chip id][bank id]
+   unsigned int **totalbankaccesses; //bankaccesses[dram chip id][bank id]
+   unsigned int *num_MCBs_accessed; //tracks how many memory controllers are accessed whenever any thread in a warp misses in cache
+   unsigned int *position_of_mrq_chosen; //position of mrq in m_queue chosen 
+   
+   unsigned ***mem_access_type_stats; // dram access type classification
 
-  unsigned ***mem_access_type_stats;  // dram access type classification
+   // AerialVision L2 stats
+   unsigned L2_read_miss;
+   unsigned L2_write_miss;
+   unsigned L2_read_hit;
+   unsigned L2_write_hit;
 
-  // AerialVision L2 stats
-  unsigned L2_read_miss;
-  unsigned L2_write_miss;
-  unsigned L2_read_hit;
-  unsigned L2_write_hit;
+   // L2 cache stats
+   unsigned int *L2_cbtoL2length;
+   unsigned int *L2_cbtoL2writelength;
+   unsigned int *L2_L2tocblength;
+   unsigned int *L2_dramtoL2length;
+   unsigned int *L2_dramtoL2writelength;
+   unsigned int *L2_L2todramlength;
 
-  // L2 cache stats
-  unsigned int *L2_cbtoL2length;
-  unsigned int *L2_cbtoL2writelength;
-  unsigned int *L2_L2tocblength;
-  unsigned int *L2_dramtoL2length;
-  unsigned int *L2_dramtoL2writelength;
-  unsigned int *L2_L2todramlength;
+   // DRAM access row locality stats 
+   unsigned int **concurrent_row_access; //concurrent_row_access[dram chip id][bank id]
+   unsigned int **num_activates; //num_activates[dram chip id][bank id]
+   unsigned int **row_access; //row_access[dram chip id][bank id]
+   unsigned int **max_conc_access2samerow; //max_conc_access2samerow[dram chip id][bank id]
+   unsigned int **max_servicetime2samerow; //max_servicetime2samerow[dram chip id][bank id]
 
-  // DRAM access row locality stats
-  unsigned int *
-      *concurrent_row_access;    // concurrent_row_access[dram chip id][bank id]
-  unsigned int **num_activates;  // num_activates[dram chip id][bank id]
-  unsigned int **row_access;     // row_access[dram chip id][bank id]
-  unsigned int **max_conc_access2samerow;  // max_conc_access2samerow[dram chip
-                                           // id][bank id]
-  unsigned int **max_servicetime2samerow;  // max_servicetime2samerow[dram chip
-                                           // id][bank id]
-
-  // Power stats
-  unsigned total_n_access;
-  unsigned total_n_reads;
-  unsigned total_n_writes;
+   // Power stats
+   unsigned total_n_access;
+   unsigned total_n_reads;
+   unsigned total_n_writes;
 };
 
 #endif /*MEM_LATENCY_STAT_H*/

--- a/src/gpgpu-sim/mem_latency_stat.h
+++ b/src/gpgpu-sim/mem_latency_stat.h
@@ -90,8 +90,8 @@ class memory_stats_t {
   unsigned int **totalbankreads;     // bankreads[dram chip id][bank id]
   unsigned int **totalbankaccesses;  // bankaccesses[dram chip id][bank id]
   unsigned int *num_MCBs_accessed;   // tracks how many memory controllers are
-                                     // accessed whenever any thread in a warp
-                                     // misses in cache
+                                    // accessed whenever any thread in a warp
+                                    // misses in cache
   unsigned int *position_of_mrq_chosen;  // position of mrq in m_queue chosen
 
   unsigned ***mem_access_type_stats;  // dram access type classification

--- a/src/gpgpu-sim/mem_latency_stat.h
+++ b/src/gpgpu-sim/mem_latency_stat.h
@@ -90,8 +90,8 @@ class memory_stats_t {
   unsigned int **totalbankreads;     // bankreads[dram chip id][bank id]
   unsigned int **totalbankaccesses;  // bankaccesses[dram chip id][bank id]
   unsigned int *num_MCBs_accessed;   // tracks how many memory controllers are
-                                    // accessed whenever any thread in a warp
-                                    // misses in cache
+                                     // accessed whenever any thread in a warp
+                                     // misses in cache
   unsigned int *position_of_mrq_chosen;  // position of mrq in m_queue chosen
 
   unsigned ***mem_access_type_stats;  // dram access type classification

--- a/src/gpgpu-sim/mem_latency_stat.h
+++ b/src/gpgpu-sim/mem_latency_stat.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -34,87 +36,94 @@
 
 class memory_config;
 class memory_stats_t {
-public:
-   memory_stats_t( unsigned n_shader, 
-                   const class shader_core_config *shader_config, 
-                   const memory_config *mem_config,
-				   const class gpgpu_sim* gpu);
+ public:
+  memory_stats_t(unsigned n_shader,
+                 const class shader_core_config *shader_config,
+                 const memory_config *mem_config, const class gpgpu_sim *gpu);
 
-   unsigned memlatstat_done( class mem_fetch *mf );
-   void memlatstat_read_done( class mem_fetch *mf );
-   void memlatstat_dram_access( class mem_fetch *mf );
-   void memlatstat_icnt2mem_pop( class mem_fetch *mf);
-   void memlatstat_lat_pw();
-   void memlatstat_print(unsigned n_mem, unsigned gpu_mem_n_bk);
+  unsigned memlatstat_done(class mem_fetch *mf);
+  void memlatstat_read_done(class mem_fetch *mf);
+  void memlatstat_dram_access(class mem_fetch *mf);
+  void memlatstat_icnt2mem_pop(class mem_fetch *mf);
+  void memlatstat_lat_pw();
+  void memlatstat_print(unsigned n_mem, unsigned gpu_mem_n_bk);
 
-   void visualizer_print( gzFile visualizer_file );
+  void visualizer_print(gzFile visualizer_file);
 
-   // Reset local L2 stats that are aggregated each sampling window
-   void clear_L2_stats_pw();
+  // Reset local L2 stats that are aggregated each sampling window
+  void clear_L2_stats_pw();
 
-   unsigned m_n_shader;
+  unsigned m_n_shader;
 
-   const shader_core_config *m_shader_config;
-   const memory_config *m_memory_config;
-   const class gpgpu_sim* m_gpu;
+  const shader_core_config *m_shader_config;
+  const memory_config *m_memory_config;
+  const class gpgpu_sim *m_gpu;
 
-   unsigned max_mrq_latency;
-   unsigned max_dq_latency;
-   unsigned max_mf_latency;
-   unsigned max_icnt2mem_latency;
-   unsigned long long int tot_icnt2mem_latency;
-   unsigned long long int tot_icnt2sh_latency;
-   unsigned long long int tot_mrq_latency;
-   unsigned long long int tot_mrq_num;
-   unsigned max_icnt2sh_latency;
-   unsigned mrq_lat_table[32];
-   unsigned dq_lat_table[32];
-   unsigned mf_lat_table[32];
-   unsigned icnt2mem_lat_table[24];
-   unsigned icnt2sh_lat_table[24];
-   unsigned mf_lat_pw_table[32]; //table storing values of mf latency Per Window
-   unsigned mf_num_lat_pw;
-   unsigned max_warps;
-   unsigned mf_tot_lat_pw; //total latency summed up per window. divide by mf_num_lat_pw to obtain average latency Per Window
-   unsigned long long int mf_total_lat;
-   unsigned long long int ** mf_total_lat_table; //mf latency sums[dram chip id][bank id]
-   unsigned ** mf_max_lat_table; //mf latency sums[dram chip id][bank id]
-   unsigned num_mfs;
-   unsigned int ***bankwrites; //bankwrites[shader id][dram chip id][bank id]
-   unsigned int ***bankreads; //bankreads[shader id][dram chip id][bank id]
-   unsigned int **totalbankwrites; //bankwrites[dram chip id][bank id]
-   unsigned int **totalbankreads; //bankreads[dram chip id][bank id]
-   unsigned int **totalbankaccesses; //bankaccesses[dram chip id][bank id]
-   unsigned int *num_MCBs_accessed; //tracks how many memory controllers are accessed whenever any thread in a warp misses in cache
-   unsigned int *position_of_mrq_chosen; //position of mrq in m_queue chosen 
-   
-   unsigned ***mem_access_type_stats; // dram access type classification
+  unsigned max_mrq_latency;
+  unsigned max_dq_latency;
+  unsigned max_mf_latency;
+  unsigned max_icnt2mem_latency;
+  unsigned long long int tot_icnt2mem_latency;
+  unsigned long long int tot_icnt2sh_latency;
+  unsigned long long int tot_mrq_latency;
+  unsigned long long int tot_mrq_num;
+  unsigned max_icnt2sh_latency;
+  unsigned mrq_lat_table[32];
+  unsigned dq_lat_table[32];
+  unsigned mf_lat_table[32];
+  unsigned icnt2mem_lat_table[24];
+  unsigned icnt2sh_lat_table[24];
+  unsigned mf_lat_pw_table[32];  // table storing values of mf latency Per
+                                 // Window
+  unsigned mf_num_lat_pw;
+  unsigned max_warps;
+  unsigned mf_tot_lat_pw;  // total latency summed up per window. divide by
+                           // mf_num_lat_pw to obtain average latency Per Window
+  unsigned long long int mf_total_lat;
+  unsigned long long int *
+      *mf_total_lat_table;      // mf latency sums[dram chip id][bank id]
+  unsigned **mf_max_lat_table;  // mf latency sums[dram chip id][bank id]
+  unsigned num_mfs;
+  unsigned int ***bankwrites;  // bankwrites[shader id][dram chip id][bank id]
+  unsigned int ***bankreads;   // bankreads[shader id][dram chip id][bank id]
+  unsigned int **totalbankwrites;    // bankwrites[dram chip id][bank id]
+  unsigned int **totalbankreads;     // bankreads[dram chip id][bank id]
+  unsigned int **totalbankaccesses;  // bankaccesses[dram chip id][bank id]
+  unsigned int *num_MCBs_accessed;   // tracks how many memory controllers are
+                                    // accessed whenever any thread in a warp
+                                    // misses in cache
+  unsigned int *position_of_mrq_chosen;  // position of mrq in m_queue chosen
 
-   // AerialVision L2 stats
-   unsigned L2_read_miss;
-   unsigned L2_write_miss;
-   unsigned L2_read_hit;
-   unsigned L2_write_hit;
+  unsigned ***mem_access_type_stats;  // dram access type classification
 
-   // L2 cache stats
-   unsigned int *L2_cbtoL2length;
-   unsigned int *L2_cbtoL2writelength;
-   unsigned int *L2_L2tocblength;
-   unsigned int *L2_dramtoL2length;
-   unsigned int *L2_dramtoL2writelength;
-   unsigned int *L2_L2todramlength;
+  // AerialVision L2 stats
+  unsigned L2_read_miss;
+  unsigned L2_write_miss;
+  unsigned L2_read_hit;
+  unsigned L2_write_hit;
 
-   // DRAM access row locality stats 
-   unsigned int **concurrent_row_access; //concurrent_row_access[dram chip id][bank id]
-   unsigned int **num_activates; //num_activates[dram chip id][bank id]
-   unsigned int **row_access; //row_access[dram chip id][bank id]
-   unsigned int **max_conc_access2samerow; //max_conc_access2samerow[dram chip id][bank id]
-   unsigned int **max_servicetime2samerow; //max_servicetime2samerow[dram chip id][bank id]
+  // L2 cache stats
+  unsigned int *L2_cbtoL2length;
+  unsigned int *L2_cbtoL2writelength;
+  unsigned int *L2_L2tocblength;
+  unsigned int *L2_dramtoL2length;
+  unsigned int *L2_dramtoL2writelength;
+  unsigned int *L2_L2todramlength;
 
-   // Power stats
-   unsigned total_n_access;
-   unsigned total_n_reads;
-   unsigned total_n_writes;
+  // DRAM access row locality stats
+  unsigned int *
+      *concurrent_row_access;    // concurrent_row_access[dram chip id][bank id]
+  unsigned int **num_activates;  // num_activates[dram chip id][bank id]
+  unsigned int **row_access;     // row_access[dram chip id][bank id]
+  unsigned int **max_conc_access2samerow;  // max_conc_access2samerow[dram chip
+                                           // id][bank id]
+  unsigned int **max_servicetime2samerow;  // max_servicetime2samerow[dram chip
+                                           // id][bank id]
+
+  // Power stats
+  unsigned total_n_access;
+  unsigned total_n_reads;
+  unsigned total_n_writes;
 };
 
 #endif /*MEM_LATENCY_STAT_H*/

--- a/src/gpgpu-sim/mem_latency_stat.h
+++ b/src/gpgpu-sim/mem_latency_stat.h
@@ -7,23 +7,24 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef MEM_LATENCY_STAT_H
 #define MEM_LATENCY_STAT_H
@@ -34,87 +35,94 @@
 
 class memory_config;
 class memory_stats_t {
-public:
-   memory_stats_t( unsigned n_shader, 
-                   const class shader_core_config *shader_config, 
-                   const memory_config *mem_config,
-				   const class gpgpu_sim* gpu);
+ public:
+  memory_stats_t(unsigned n_shader,
+                 const class shader_core_config *shader_config,
+                 const memory_config *mem_config, const class gpgpu_sim *gpu);
 
-   unsigned memlatstat_done( class mem_fetch *mf );
-   void memlatstat_read_done( class mem_fetch *mf );
-   void memlatstat_dram_access( class mem_fetch *mf );
-   void memlatstat_icnt2mem_pop( class mem_fetch *mf);
-   void memlatstat_lat_pw();
-   void memlatstat_print(unsigned n_mem, unsigned gpu_mem_n_bk);
+  unsigned memlatstat_done(class mem_fetch *mf);
+  void memlatstat_read_done(class mem_fetch *mf);
+  void memlatstat_dram_access(class mem_fetch *mf);
+  void memlatstat_icnt2mem_pop(class mem_fetch *mf);
+  void memlatstat_lat_pw();
+  void memlatstat_print(unsigned n_mem, unsigned gpu_mem_n_bk);
 
-   void visualizer_print( gzFile visualizer_file );
+  void visualizer_print(gzFile visualizer_file);
 
-   // Reset local L2 stats that are aggregated each sampling window
-   void clear_L2_stats_pw();
+  // Reset local L2 stats that are aggregated each sampling window
+  void clear_L2_stats_pw();
 
-   unsigned m_n_shader;
+  unsigned m_n_shader;
 
-   const shader_core_config *m_shader_config;
-   const memory_config *m_memory_config;
-   const class gpgpu_sim* m_gpu;
+  const shader_core_config *m_shader_config;
+  const memory_config *m_memory_config;
+  const class gpgpu_sim *m_gpu;
 
-   unsigned max_mrq_latency;
-   unsigned max_dq_latency;
-   unsigned max_mf_latency;
-   unsigned max_icnt2mem_latency;
-   unsigned long long int tot_icnt2mem_latency;
-   unsigned long long int tot_icnt2sh_latency;
-   unsigned long long int tot_mrq_latency;
-   unsigned long long int tot_mrq_num;
-   unsigned max_icnt2sh_latency;
-   unsigned mrq_lat_table[32];
-   unsigned dq_lat_table[32];
-   unsigned mf_lat_table[32];
-   unsigned icnt2mem_lat_table[24];
-   unsigned icnt2sh_lat_table[24];
-   unsigned mf_lat_pw_table[32]; //table storing values of mf latency Per Window
-   unsigned mf_num_lat_pw;
-   unsigned max_warps;
-   unsigned mf_tot_lat_pw; //total latency summed up per window. divide by mf_num_lat_pw to obtain average latency Per Window
-   unsigned long long int mf_total_lat;
-   unsigned long long int ** mf_total_lat_table; //mf latency sums[dram chip id][bank id]
-   unsigned ** mf_max_lat_table; //mf latency sums[dram chip id][bank id]
-   unsigned num_mfs;
-   unsigned int ***bankwrites; //bankwrites[shader id][dram chip id][bank id]
-   unsigned int ***bankreads; //bankreads[shader id][dram chip id][bank id]
-   unsigned int **totalbankwrites; //bankwrites[dram chip id][bank id]
-   unsigned int **totalbankreads; //bankreads[dram chip id][bank id]
-   unsigned int **totalbankaccesses; //bankaccesses[dram chip id][bank id]
-   unsigned int *num_MCBs_accessed; //tracks how many memory controllers are accessed whenever any thread in a warp misses in cache
-   unsigned int *position_of_mrq_chosen; //position of mrq in m_queue chosen 
-   
-   unsigned ***mem_access_type_stats; // dram access type classification
+  unsigned max_mrq_latency;
+  unsigned max_dq_latency;
+  unsigned max_mf_latency;
+  unsigned max_icnt2mem_latency;
+  unsigned long long int tot_icnt2mem_latency;
+  unsigned long long int tot_icnt2sh_latency;
+  unsigned long long int tot_mrq_latency;
+  unsigned long long int tot_mrq_num;
+  unsigned max_icnt2sh_latency;
+  unsigned mrq_lat_table[32];
+  unsigned dq_lat_table[32];
+  unsigned mf_lat_table[32];
+  unsigned icnt2mem_lat_table[24];
+  unsigned icnt2sh_lat_table[24];
+  unsigned mf_lat_pw_table[32];  // table storing values of mf latency Per
+                                 // Window
+  unsigned mf_num_lat_pw;
+  unsigned max_warps;
+  unsigned mf_tot_lat_pw;  // total latency summed up per window. divide by
+                           // mf_num_lat_pw to obtain average latency Per Window
+  unsigned long long int mf_total_lat;
+  unsigned long long int *
+      *mf_total_lat_table;      // mf latency sums[dram chip id][bank id]
+  unsigned **mf_max_lat_table;  // mf latency sums[dram chip id][bank id]
+  unsigned num_mfs;
+  unsigned int ***bankwrites;  // bankwrites[shader id][dram chip id][bank id]
+  unsigned int ***bankreads;   // bankreads[shader id][dram chip id][bank id]
+  unsigned int **totalbankwrites;    // bankwrites[dram chip id][bank id]
+  unsigned int **totalbankreads;     // bankreads[dram chip id][bank id]
+  unsigned int **totalbankaccesses;  // bankaccesses[dram chip id][bank id]
+  unsigned int
+      *num_MCBs_accessed;  // tracks how many memory controllers are accessed
+                           // whenever any thread in a warp misses in cache
+  unsigned int *position_of_mrq_chosen;  // position of mrq in m_queue chosen
 
-   // AerialVision L2 stats
-   unsigned L2_read_miss;
-   unsigned L2_write_miss;
-   unsigned L2_read_hit;
-   unsigned L2_write_hit;
+  unsigned ***mem_access_type_stats;  // dram access type classification
 
-   // L2 cache stats
-   unsigned int *L2_cbtoL2length;
-   unsigned int *L2_cbtoL2writelength;
-   unsigned int *L2_L2tocblength;
-   unsigned int *L2_dramtoL2length;
-   unsigned int *L2_dramtoL2writelength;
-   unsigned int *L2_L2todramlength;
+  // AerialVision L2 stats
+  unsigned L2_read_miss;
+  unsigned L2_write_miss;
+  unsigned L2_read_hit;
+  unsigned L2_write_hit;
 
-   // DRAM access row locality stats 
-   unsigned int **concurrent_row_access; //concurrent_row_access[dram chip id][bank id]
-   unsigned int **num_activates; //num_activates[dram chip id][bank id]
-   unsigned int **row_access; //row_access[dram chip id][bank id]
-   unsigned int **max_conc_access2samerow; //max_conc_access2samerow[dram chip id][bank id]
-   unsigned int **max_servicetime2samerow; //max_servicetime2samerow[dram chip id][bank id]
+  // L2 cache stats
+  unsigned int *L2_cbtoL2length;
+  unsigned int *L2_cbtoL2writelength;
+  unsigned int *L2_L2tocblength;
+  unsigned int *L2_dramtoL2length;
+  unsigned int *L2_dramtoL2writelength;
+  unsigned int *L2_L2todramlength;
 
-   // Power stats
-   unsigned total_n_access;
-   unsigned total_n_reads;
-   unsigned total_n_writes;
+  // DRAM access row locality stats
+  unsigned int *
+      *concurrent_row_access;    // concurrent_row_access[dram chip id][bank id]
+  unsigned int **num_activates;  // num_activates[dram chip id][bank id]
+  unsigned int **row_access;     // row_access[dram chip id][bank id]
+  unsigned int **max_conc_access2samerow;  // max_conc_access2samerow[dram chip
+                                           // id][bank id]
+  unsigned int **max_servicetime2samerow;  // max_servicetime2samerow[dram chip
+                                           // id][bank id]
+
+  // Power stats
+  unsigned total_n_access;
+  unsigned total_n_reads;
+  unsigned total_n_writes;
 };
 
 #endif /*MEM_LATENCY_STAT_H*/

--- a/src/gpgpu-sim/power_interface.cc
+++ b/src/gpgpu-sim/power_interface.cc
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -27,99 +29,127 @@
 
 #include "power_interface.h"
 
-void init_mcpat(const gpgpu_sim_config &config, class gpgpu_sim_wrapper *wrapper, unsigned stat_sample_freq, unsigned tot_inst, unsigned inst){
-
-	wrapper->init_mcpat(config.g_power_config_name, config.g_power_filename, config.g_power_trace_filename,
-	    			config.g_metric_trace_filename,config.g_steady_state_tracking_filename,config.g_power_simulation_enabled,
-	    			config.g_power_trace_enabled,config.g_steady_power_levels_enabled,config.g_power_per_cycle_dump,
-	    			config.gpu_steady_power_deviation,config.gpu_steady_min_period,config.g_power_trace_zlevel,
-	    			tot_inst+inst,stat_sample_freq
-	    			);
-
+void init_mcpat(const gpgpu_sim_config &config,
+                class gpgpu_sim_wrapper *wrapper, unsigned stat_sample_freq,
+                unsigned tot_inst, unsigned inst) {
+  wrapper->init_mcpat(
+      config.g_power_config_name, config.g_power_filename,
+      config.g_power_trace_filename, config.g_metric_trace_filename,
+      config.g_steady_state_tracking_filename,
+      config.g_power_simulation_enabled, config.g_power_trace_enabled,
+      config.g_steady_power_levels_enabled, config.g_power_per_cycle_dump,
+      config.gpu_steady_power_deviation, config.gpu_steady_min_period,
+      config.g_power_trace_zlevel, tot_inst + inst, stat_sample_freq);
 }
 
-void mcpat_cycle(const gpgpu_sim_config &config, const shader_core_config *shdr_config, class gpgpu_sim_wrapper *wrapper, class power_stat_t *power_stats, unsigned stat_sample_freq, unsigned tot_cycle, unsigned cycle, unsigned tot_inst, unsigned inst){
+void mcpat_cycle(const gpgpu_sim_config &config,
+                 const shader_core_config *shdr_config,
+                 class gpgpu_sim_wrapper *wrapper,
+                 class power_stat_t *power_stats, unsigned stat_sample_freq,
+                 unsigned tot_cycle, unsigned cycle, unsigned tot_inst,
+                 unsigned inst) {
+  static bool mcpat_init = true;
 
-	static bool mcpat_init=true;
+  if (mcpat_init) {  // If first cycle, don't have any power numbers yet
+    mcpat_init = false;
+    return;
+  }
 
-	if(mcpat_init){ // If first cycle, don't have any power numbers yet
-		mcpat_init=false;
-		return;
-	}
+  if ((tot_cycle + cycle) % stat_sample_freq == 0) {
+    wrapper->set_inst_power(
+        shdr_config->gpgpu_clock_gated_lanes, stat_sample_freq,
+        stat_sample_freq, power_stats->get_total_inst(),
+        power_stats->get_total_int_inst(), power_stats->get_total_fp_inst(),
+        power_stats->get_l1d_read_accesses(),
+        power_stats->get_l1d_write_accesses(),
+        power_stats->get_committed_inst());
 
-	if ((tot_cycle+cycle) % stat_sample_freq == 0) {
+    // Single RF for both int and fp ops
+    wrapper->set_regfile_power(power_stats->get_regfile_reads(),
+                               power_stats->get_regfile_writes(),
+                               power_stats->get_non_regfile_operands());
 
-		wrapper->set_inst_power(shdr_config->gpgpu_clock_gated_lanes,
-				stat_sample_freq, stat_sample_freq,
-				power_stats->get_total_inst(), power_stats->get_total_int_inst(),
-				power_stats->get_total_fp_inst(), power_stats->get_l1d_read_accesses(),
-				power_stats->get_l1d_write_accesses(), power_stats->get_committed_inst());
+    // Instruction cache stats
+    wrapper->set_icache_power(power_stats->get_inst_c_hits(),
+                              power_stats->get_inst_c_misses());
 
-		// Single RF for both int and fp ops
-		wrapper->set_regfile_power(power_stats->get_regfile_reads(), power_stats->get_regfile_writes(), power_stats->get_non_regfile_operands());
+    // Constant Cache, shared memory, texture cache
+    wrapper->set_ccache_power(power_stats->get_constant_c_hits(),
+                              power_stats->get_constant_c_misses());
+    wrapper->set_tcache_power(power_stats->get_texture_c_hits(),
+                              power_stats->get_texture_c_misses());
+    wrapper->set_shrd_mem_power(power_stats->get_shmem_read_access());
 
-		//Instruction cache stats
-		wrapper->set_icache_power(power_stats->get_inst_c_hits(), power_stats->get_inst_c_misses());
+    wrapper->set_l1cache_power(
+        power_stats->get_l1d_read_hits(), power_stats->get_l1d_read_misses(),
+        power_stats->get_l1d_write_hits(), power_stats->get_l1d_write_misses());
 
-		//Constant Cache, shared memory, texture cache
-		wrapper->set_ccache_power(power_stats->get_constant_c_hits(), power_stats->get_constant_c_misses());
-		wrapper->set_tcache_power(power_stats->get_texture_c_hits(), power_stats->get_texture_c_misses());
-		wrapper->set_shrd_mem_power(power_stats->get_shmem_read_access());
+    wrapper->set_l2cache_power(
+        power_stats->get_l2_read_hits(), power_stats->get_l2_read_misses(),
+        power_stats->get_l2_write_hits(), power_stats->get_l2_write_misses());
 
-		wrapper->set_l1cache_power(power_stats->get_l1d_read_hits(), power_stats->get_l1d_read_misses(),
-				power_stats->get_l1d_write_hits(), power_stats->get_l1d_write_misses());
+    float active_sms = (*power_stats->m_active_sms) / stat_sample_freq;
+    float num_cores = shdr_config->num_shader();
+    float num_idle_core = num_cores - active_sms;
+    wrapper->set_idle_core_power(num_idle_core);
 
+    // pipeline power - pipeline_duty_cycle *= percent_active_sms;
+    float pipeline_duty_cycle =
+        ((*power_stats->m_average_pipeline_duty_cycle / (stat_sample_freq)) <
+         0.8)
+            ? ((*power_stats->m_average_pipeline_duty_cycle) / stat_sample_freq)
+            : 0.8;
+    wrapper->set_duty_cycle_power(pipeline_duty_cycle);
 
-		wrapper->set_l2cache_power(power_stats->get_l2_read_hits(), power_stats->get_l2_read_misses(),
-				power_stats->get_l2_write_hits(), power_stats->get_l2_write_misses());
+    // Memory Controller
+    wrapper->set_mem_ctrl_power(power_stats->get_dram_rd(),
+                                power_stats->get_dram_wr(),
+                                power_stats->get_dram_pre());
 
+    // Execution pipeline accesses
+    // FPU (SP) accesses, Integer ALU (not present in Tesla), Sfu accesses
+    wrapper->set_exec_unit_power(power_stats->get_tot_fpu_accessess(),
+                                 power_stats->get_ialu_accessess(),
+                                 power_stats->get_tot_sfu_accessess());
 
-		float active_sms=(*power_stats->m_active_sms)/stat_sample_freq;
-		float num_cores = shdr_config->num_shader();
-		float num_idle_core = num_cores - active_sms;
-		wrapper->set_idle_core_power(num_idle_core);
+    // Average active lanes for sp and sfu pipelines
+    float avg_sp_active_lanes =
+        (power_stats->get_sp_active_lanes()) / stat_sample_freq;
+    float avg_sfu_active_lanes =
+        (power_stats->get_sfu_active_lanes()) / stat_sample_freq;
+    assert(avg_sp_active_lanes <= 32);
+    assert(avg_sfu_active_lanes <= 32);
+    wrapper->set_active_lanes_power(
+        (power_stats->get_sp_active_lanes()) / stat_sample_freq,
+        (power_stats->get_sfu_active_lanes()) / stat_sample_freq);
 
-		//pipeline power - pipeline_duty_cycle *= percent_active_sms;
-		float pipeline_duty_cycle=((*power_stats->m_average_pipeline_duty_cycle/( stat_sample_freq)) < 0.8)?((*power_stats->m_average_pipeline_duty_cycle)/stat_sample_freq):0.8;
-		wrapper->set_duty_cycle_power(pipeline_duty_cycle);
+    double n_icnt_simt_to_mem =
+        (double)power_stats->get_icnt_simt_to_mem();  // # flits from SIMT
+                                                      // clusters to memory
+                                                      // partitions
+    double n_icnt_mem_to_simt =
+        (double)power_stats->get_icnt_mem_to_simt();  // # flits from memory
+                                                      // partitions to SIMT
+                                                      // clusters
+    wrapper->set_NoC_power(
+        n_icnt_mem_to_simt,
+        n_icnt_simt_to_mem);  // Number of flits traversing the interconnect
 
-		//Memory Controller
-		wrapper->set_mem_ctrl_power(power_stats->get_dram_rd(), power_stats->get_dram_wr(), power_stats->get_dram_pre());
+    wrapper->compute();
 
-		//Execution pipeline accesses
-		//FPU (SP) accesses, Integer ALU (not present in Tesla), Sfu accesses
-		wrapper->set_exec_unit_power(power_stats->get_tot_fpu_accessess(), power_stats->get_ialu_accessess(), power_stats->get_tot_sfu_accessess());
+    wrapper->update_components_power();
+    wrapper->print_trace_files();
+    power_stats->save_stats();
 
-		//Average active lanes for sp and sfu pipelines
-		float avg_sp_active_lanes=(power_stats->get_sp_active_lanes())/stat_sample_freq;
-		float avg_sfu_active_lanes=(power_stats->get_sfu_active_lanes())/stat_sample_freq;
-		assert(avg_sp_active_lanes<=32);
-		assert(avg_sfu_active_lanes<=32);
-		wrapper->set_active_lanes_power((power_stats->get_sp_active_lanes())/stat_sample_freq,
-				(power_stats->get_sfu_active_lanes())/stat_sample_freq);
+    wrapper->detect_print_steady_state(0, tot_inst + inst);
 
+    wrapper->power_metrics_calculations();
 
-		double n_icnt_simt_to_mem = (double)power_stats->get_icnt_simt_to_mem(); // # flits from SIMT clusters to memory partitions
-		double n_icnt_mem_to_simt = (double)power_stats->get_icnt_mem_to_simt(); // # flits from memory partitions to SIMT clusters
-		wrapper->set_NoC_power(n_icnt_mem_to_simt, n_icnt_simt_to_mem); // Number of flits traversing the interconnect
-
-		wrapper->compute();
-
-
-		wrapper->update_components_power();
-		wrapper->print_trace_files();
-		power_stats->save_stats();
-
-		wrapper->detect_print_steady_state(0,tot_inst+inst);
-
-		wrapper->power_metrics_calculations();
-
-
-		wrapper->dump();
-	}
-	//wrapper->close_files();
+    wrapper->dump();
+  }
+  // wrapper->close_files();
 }
 
-void mcpat_reset_perf_count(class gpgpu_sim_wrapper *wrapper){
-	wrapper->reset_counters();
+void mcpat_reset_perf_count(class gpgpu_sim_wrapper *wrapper) {
+  wrapper->reset_counters();
 }

--- a/src/gpgpu-sim/power_interface.cc
+++ b/src/gpgpu-sim/power_interface.cc
@@ -7,119 +7,148 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #include "power_interface.h"
 
-void init_mcpat(const gpgpu_sim_config &config, class gpgpu_sim_wrapper *wrapper, unsigned stat_sample_freq, unsigned tot_inst, unsigned inst){
-
-	wrapper->init_mcpat(config.g_power_config_name, config.g_power_filename, config.g_power_trace_filename,
-	    			config.g_metric_trace_filename,config.g_steady_state_tracking_filename,config.g_power_simulation_enabled,
-	    			config.g_power_trace_enabled,config.g_steady_power_levels_enabled,config.g_power_per_cycle_dump,
-	    			config.gpu_steady_power_deviation,config.gpu_steady_min_period,config.g_power_trace_zlevel,
-	    			tot_inst+inst,stat_sample_freq
-	    			);
-
+void init_mcpat(const gpgpu_sim_config &config,
+                class gpgpu_sim_wrapper *wrapper, unsigned stat_sample_freq,
+                unsigned tot_inst, unsigned inst) {
+  wrapper->init_mcpat(
+      config.g_power_config_name, config.g_power_filename,
+      config.g_power_trace_filename, config.g_metric_trace_filename,
+      config.g_steady_state_tracking_filename,
+      config.g_power_simulation_enabled, config.g_power_trace_enabled,
+      config.g_steady_power_levels_enabled, config.g_power_per_cycle_dump,
+      config.gpu_steady_power_deviation, config.gpu_steady_min_period,
+      config.g_power_trace_zlevel, tot_inst + inst, stat_sample_freq);
 }
 
-void mcpat_cycle(const gpgpu_sim_config &config, const shader_core_config *shdr_config, class gpgpu_sim_wrapper *wrapper, class power_stat_t *power_stats, unsigned stat_sample_freq, unsigned tot_cycle, unsigned cycle, unsigned tot_inst, unsigned inst){
+void mcpat_cycle(const gpgpu_sim_config &config,
+                 const shader_core_config *shdr_config,
+                 class gpgpu_sim_wrapper *wrapper,
+                 class power_stat_t *power_stats, unsigned stat_sample_freq,
+                 unsigned tot_cycle, unsigned cycle, unsigned tot_inst,
+                 unsigned inst) {
+  static bool mcpat_init = true;
 
-	static bool mcpat_init=true;
+  if (mcpat_init) {  // If first cycle, don't have any power numbers yet
+    mcpat_init = false;
+    return;
+  }
 
-	if(mcpat_init){ // If first cycle, don't have any power numbers yet
-		mcpat_init=false;
-		return;
-	}
+  if ((tot_cycle + cycle) % stat_sample_freq == 0) {
+    wrapper->set_inst_power(
+        shdr_config->gpgpu_clock_gated_lanes, stat_sample_freq,
+        stat_sample_freq, power_stats->get_total_inst(),
+        power_stats->get_total_int_inst(), power_stats->get_total_fp_inst(),
+        power_stats->get_l1d_read_accesses(),
+        power_stats->get_l1d_write_accesses(),
+        power_stats->get_committed_inst());
 
-	if ((tot_cycle+cycle) % stat_sample_freq == 0) {
+    // Single RF for both int and fp ops
+    wrapper->set_regfile_power(power_stats->get_regfile_reads(),
+                               power_stats->get_regfile_writes(),
+                               power_stats->get_non_regfile_operands());
 
-		wrapper->set_inst_power(shdr_config->gpgpu_clock_gated_lanes,
-				stat_sample_freq, stat_sample_freq,
-				power_stats->get_total_inst(), power_stats->get_total_int_inst(),
-				power_stats->get_total_fp_inst(), power_stats->get_l1d_read_accesses(),
-				power_stats->get_l1d_write_accesses(), power_stats->get_committed_inst());
+    // Instruction cache stats
+    wrapper->set_icache_power(power_stats->get_inst_c_hits(),
+                              power_stats->get_inst_c_misses());
 
-		// Single RF for both int and fp ops
-		wrapper->set_regfile_power(power_stats->get_regfile_reads(), power_stats->get_regfile_writes(), power_stats->get_non_regfile_operands());
+    // Constant Cache, shared memory, texture cache
+    wrapper->set_ccache_power(power_stats->get_constant_c_hits(),
+                              power_stats->get_constant_c_misses());
+    wrapper->set_tcache_power(power_stats->get_texture_c_hits(),
+                              power_stats->get_texture_c_misses());
+    wrapper->set_shrd_mem_power(power_stats->get_shmem_read_access());
 
-		//Instruction cache stats
-		wrapper->set_icache_power(power_stats->get_inst_c_hits(), power_stats->get_inst_c_misses());
+    wrapper->set_l1cache_power(
+        power_stats->get_l1d_read_hits(), power_stats->get_l1d_read_misses(),
+        power_stats->get_l1d_write_hits(), power_stats->get_l1d_write_misses());
 
-		//Constant Cache, shared memory, texture cache
-		wrapper->set_ccache_power(power_stats->get_constant_c_hits(), power_stats->get_constant_c_misses());
-		wrapper->set_tcache_power(power_stats->get_texture_c_hits(), power_stats->get_texture_c_misses());
-		wrapper->set_shrd_mem_power(power_stats->get_shmem_read_access());
+    wrapper->set_l2cache_power(
+        power_stats->get_l2_read_hits(), power_stats->get_l2_read_misses(),
+        power_stats->get_l2_write_hits(), power_stats->get_l2_write_misses());
 
-		wrapper->set_l1cache_power(power_stats->get_l1d_read_hits(), power_stats->get_l1d_read_misses(),
-				power_stats->get_l1d_write_hits(), power_stats->get_l1d_write_misses());
+    float active_sms = (*power_stats->m_active_sms) / stat_sample_freq;
+    float num_cores = shdr_config->num_shader();
+    float num_idle_core = num_cores - active_sms;
+    wrapper->set_idle_core_power(num_idle_core);
 
+    // pipeline power - pipeline_duty_cycle *= percent_active_sms;
+    float pipeline_duty_cycle =
+        ((*power_stats->m_average_pipeline_duty_cycle / (stat_sample_freq)) <
+         0.8)
+            ? ((*power_stats->m_average_pipeline_duty_cycle) / stat_sample_freq)
+            : 0.8;
+    wrapper->set_duty_cycle_power(pipeline_duty_cycle);
 
-		wrapper->set_l2cache_power(power_stats->get_l2_read_hits(), power_stats->get_l2_read_misses(),
-				power_stats->get_l2_write_hits(), power_stats->get_l2_write_misses());
+    // Memory Controller
+    wrapper->set_mem_ctrl_power(power_stats->get_dram_rd(),
+                                power_stats->get_dram_wr(),
+                                power_stats->get_dram_pre());
 
+    // Execution pipeline accesses
+    // FPU (SP) accesses, Integer ALU (not present in Tesla), Sfu accesses
+    wrapper->set_exec_unit_power(power_stats->get_tot_fpu_accessess(),
+                                 power_stats->get_ialu_accessess(),
+                                 power_stats->get_tot_sfu_accessess());
 
-		float active_sms=(*power_stats->m_active_sms)/stat_sample_freq;
-		float num_cores = shdr_config->num_shader();
-		float num_idle_core = num_cores - active_sms;
-		wrapper->set_idle_core_power(num_idle_core);
+    // Average active lanes for sp and sfu pipelines
+    float avg_sp_active_lanes =
+        (power_stats->get_sp_active_lanes()) / stat_sample_freq;
+    float avg_sfu_active_lanes =
+        (power_stats->get_sfu_active_lanes()) / stat_sample_freq;
+    assert(avg_sp_active_lanes <= 32);
+    assert(avg_sfu_active_lanes <= 32);
+    wrapper->set_active_lanes_power(
+        (power_stats->get_sp_active_lanes()) / stat_sample_freq,
+        (power_stats->get_sfu_active_lanes()) / stat_sample_freq);
 
-		//pipeline power - pipeline_duty_cycle *= percent_active_sms;
-		float pipeline_duty_cycle=((*power_stats->m_average_pipeline_duty_cycle/( stat_sample_freq)) < 0.8)?((*power_stats->m_average_pipeline_duty_cycle)/stat_sample_freq):0.8;
-		wrapper->set_duty_cycle_power(pipeline_duty_cycle);
+    double n_icnt_simt_to_mem =
+        (double)
+            power_stats->get_icnt_simt_to_mem();  // # flits from SIMT clusters
+                                                  // to memory partitions
+    double n_icnt_mem_to_simt =
+        (double)
+            power_stats->get_icnt_mem_to_simt();  // # flits from memory
+                                                  // partitions to SIMT clusters
+    wrapper->set_NoC_power(
+        n_icnt_mem_to_simt,
+        n_icnt_simt_to_mem);  // Number of flits traversing the interconnect
 
-		//Memory Controller
-		wrapper->set_mem_ctrl_power(power_stats->get_dram_rd(), power_stats->get_dram_wr(), power_stats->get_dram_pre());
+    wrapper->compute();
 
-		//Execution pipeline accesses
-		//FPU (SP) accesses, Integer ALU (not present in Tesla), Sfu accesses
-		wrapper->set_exec_unit_power(power_stats->get_tot_fpu_accessess(), power_stats->get_ialu_accessess(), power_stats->get_tot_sfu_accessess());
+    wrapper->update_components_power();
+    wrapper->print_trace_files();
+    power_stats->save_stats();
 
-		//Average active lanes for sp and sfu pipelines
-		float avg_sp_active_lanes=(power_stats->get_sp_active_lanes())/stat_sample_freq;
-		float avg_sfu_active_lanes=(power_stats->get_sfu_active_lanes())/stat_sample_freq;
-		assert(avg_sp_active_lanes<=32);
-		assert(avg_sfu_active_lanes<=32);
-		wrapper->set_active_lanes_power((power_stats->get_sp_active_lanes())/stat_sample_freq,
-				(power_stats->get_sfu_active_lanes())/stat_sample_freq);
+    wrapper->detect_print_steady_state(0, tot_inst + inst);
 
+    wrapper->power_metrics_calculations();
 
-		double n_icnt_simt_to_mem = (double)power_stats->get_icnt_simt_to_mem(); // # flits from SIMT clusters to memory partitions
-		double n_icnt_mem_to_simt = (double)power_stats->get_icnt_mem_to_simt(); // # flits from memory partitions to SIMT clusters
-		wrapper->set_NoC_power(n_icnt_mem_to_simt, n_icnt_simt_to_mem); // Number of flits traversing the interconnect
-
-		wrapper->compute();
-
-
-		wrapper->update_components_power();
-		wrapper->print_trace_files();
-		power_stats->save_stats();
-
-		wrapper->detect_print_steady_state(0,tot_inst+inst);
-
-		wrapper->power_metrics_calculations();
-
-
-		wrapper->dump();
-	}
-	//wrapper->close_files();
+    wrapper->dump();
+  }
+  // wrapper->close_files();
 }
 
-void mcpat_reset_perf_count(class gpgpu_sim_wrapper *wrapper){
-	wrapper->reset_counters();
+void mcpat_reset_perf_count(class gpgpu_sim_wrapper *wrapper) {
+  wrapper->reset_counters();
 }

--- a/src/gpgpu-sim/power_interface.cc
+++ b/src/gpgpu-sim/power_interface.cc
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -29,127 +27,99 @@
 
 #include "power_interface.h"
 
-void init_mcpat(const gpgpu_sim_config &config,
-                class gpgpu_sim_wrapper *wrapper, unsigned stat_sample_freq,
-                unsigned tot_inst, unsigned inst) {
-  wrapper->init_mcpat(
-      config.g_power_config_name, config.g_power_filename,
-      config.g_power_trace_filename, config.g_metric_trace_filename,
-      config.g_steady_state_tracking_filename,
-      config.g_power_simulation_enabled, config.g_power_trace_enabled,
-      config.g_steady_power_levels_enabled, config.g_power_per_cycle_dump,
-      config.gpu_steady_power_deviation, config.gpu_steady_min_period,
-      config.g_power_trace_zlevel, tot_inst + inst, stat_sample_freq);
+void init_mcpat(const gpgpu_sim_config &config, class gpgpu_sim_wrapper *wrapper, unsigned stat_sample_freq, unsigned tot_inst, unsigned inst){
+
+	wrapper->init_mcpat(config.g_power_config_name, config.g_power_filename, config.g_power_trace_filename,
+	    			config.g_metric_trace_filename,config.g_steady_state_tracking_filename,config.g_power_simulation_enabled,
+	    			config.g_power_trace_enabled,config.g_steady_power_levels_enabled,config.g_power_per_cycle_dump,
+	    			config.gpu_steady_power_deviation,config.gpu_steady_min_period,config.g_power_trace_zlevel,
+	    			tot_inst+inst,stat_sample_freq
+	    			);
+
 }
 
-void mcpat_cycle(const gpgpu_sim_config &config,
-                 const shader_core_config *shdr_config,
-                 class gpgpu_sim_wrapper *wrapper,
-                 class power_stat_t *power_stats, unsigned stat_sample_freq,
-                 unsigned tot_cycle, unsigned cycle, unsigned tot_inst,
-                 unsigned inst) {
-  static bool mcpat_init = true;
+void mcpat_cycle(const gpgpu_sim_config &config, const shader_core_config *shdr_config, class gpgpu_sim_wrapper *wrapper, class power_stat_t *power_stats, unsigned stat_sample_freq, unsigned tot_cycle, unsigned cycle, unsigned tot_inst, unsigned inst){
 
-  if (mcpat_init) {  // If first cycle, don't have any power numbers yet
-    mcpat_init = false;
-    return;
-  }
+	static bool mcpat_init=true;
 
-  if ((tot_cycle + cycle) % stat_sample_freq == 0) {
-    wrapper->set_inst_power(
-        shdr_config->gpgpu_clock_gated_lanes, stat_sample_freq,
-        stat_sample_freq, power_stats->get_total_inst(),
-        power_stats->get_total_int_inst(), power_stats->get_total_fp_inst(),
-        power_stats->get_l1d_read_accesses(),
-        power_stats->get_l1d_write_accesses(),
-        power_stats->get_committed_inst());
+	if(mcpat_init){ // If first cycle, don't have any power numbers yet
+		mcpat_init=false;
+		return;
+	}
 
-    // Single RF for both int and fp ops
-    wrapper->set_regfile_power(power_stats->get_regfile_reads(),
-                               power_stats->get_regfile_writes(),
-                               power_stats->get_non_regfile_operands());
+	if ((tot_cycle+cycle) % stat_sample_freq == 0) {
 
-    // Instruction cache stats
-    wrapper->set_icache_power(power_stats->get_inst_c_hits(),
-                              power_stats->get_inst_c_misses());
+		wrapper->set_inst_power(shdr_config->gpgpu_clock_gated_lanes,
+				stat_sample_freq, stat_sample_freq,
+				power_stats->get_total_inst(), power_stats->get_total_int_inst(),
+				power_stats->get_total_fp_inst(), power_stats->get_l1d_read_accesses(),
+				power_stats->get_l1d_write_accesses(), power_stats->get_committed_inst());
 
-    // Constant Cache, shared memory, texture cache
-    wrapper->set_ccache_power(power_stats->get_constant_c_hits(),
-                              power_stats->get_constant_c_misses());
-    wrapper->set_tcache_power(power_stats->get_texture_c_hits(),
-                              power_stats->get_texture_c_misses());
-    wrapper->set_shrd_mem_power(power_stats->get_shmem_read_access());
+		// Single RF for both int and fp ops
+		wrapper->set_regfile_power(power_stats->get_regfile_reads(), power_stats->get_regfile_writes(), power_stats->get_non_regfile_operands());
 
-    wrapper->set_l1cache_power(
-        power_stats->get_l1d_read_hits(), power_stats->get_l1d_read_misses(),
-        power_stats->get_l1d_write_hits(), power_stats->get_l1d_write_misses());
+		//Instruction cache stats
+		wrapper->set_icache_power(power_stats->get_inst_c_hits(), power_stats->get_inst_c_misses());
 
-    wrapper->set_l2cache_power(
-        power_stats->get_l2_read_hits(), power_stats->get_l2_read_misses(),
-        power_stats->get_l2_write_hits(), power_stats->get_l2_write_misses());
+		//Constant Cache, shared memory, texture cache
+		wrapper->set_ccache_power(power_stats->get_constant_c_hits(), power_stats->get_constant_c_misses());
+		wrapper->set_tcache_power(power_stats->get_texture_c_hits(), power_stats->get_texture_c_misses());
+		wrapper->set_shrd_mem_power(power_stats->get_shmem_read_access());
 
-    float active_sms = (*power_stats->m_active_sms) / stat_sample_freq;
-    float num_cores = shdr_config->num_shader();
-    float num_idle_core = num_cores - active_sms;
-    wrapper->set_idle_core_power(num_idle_core);
+		wrapper->set_l1cache_power(power_stats->get_l1d_read_hits(), power_stats->get_l1d_read_misses(),
+				power_stats->get_l1d_write_hits(), power_stats->get_l1d_write_misses());
 
-    // pipeline power - pipeline_duty_cycle *= percent_active_sms;
-    float pipeline_duty_cycle =
-        ((*power_stats->m_average_pipeline_duty_cycle / (stat_sample_freq)) <
-         0.8)
-            ? ((*power_stats->m_average_pipeline_duty_cycle) / stat_sample_freq)
-            : 0.8;
-    wrapper->set_duty_cycle_power(pipeline_duty_cycle);
 
-    // Memory Controller
-    wrapper->set_mem_ctrl_power(power_stats->get_dram_rd(),
-                                power_stats->get_dram_wr(),
-                                power_stats->get_dram_pre());
+		wrapper->set_l2cache_power(power_stats->get_l2_read_hits(), power_stats->get_l2_read_misses(),
+				power_stats->get_l2_write_hits(), power_stats->get_l2_write_misses());
 
-    // Execution pipeline accesses
-    // FPU (SP) accesses, Integer ALU (not present in Tesla), Sfu accesses
-    wrapper->set_exec_unit_power(power_stats->get_tot_fpu_accessess(),
-                                 power_stats->get_ialu_accessess(),
-                                 power_stats->get_tot_sfu_accessess());
 
-    // Average active lanes for sp and sfu pipelines
-    float avg_sp_active_lanes =
-        (power_stats->get_sp_active_lanes()) / stat_sample_freq;
-    float avg_sfu_active_lanes =
-        (power_stats->get_sfu_active_lanes()) / stat_sample_freq;
-    assert(avg_sp_active_lanes <= 32);
-    assert(avg_sfu_active_lanes <= 32);
-    wrapper->set_active_lanes_power(
-        (power_stats->get_sp_active_lanes()) / stat_sample_freq,
-        (power_stats->get_sfu_active_lanes()) / stat_sample_freq);
+		float active_sms=(*power_stats->m_active_sms)/stat_sample_freq;
+		float num_cores = shdr_config->num_shader();
+		float num_idle_core = num_cores - active_sms;
+		wrapper->set_idle_core_power(num_idle_core);
 
-    double n_icnt_simt_to_mem =
-        (double)power_stats->get_icnt_simt_to_mem();  // # flits from SIMT
-                                                      // clusters to memory
-                                                      // partitions
-    double n_icnt_mem_to_simt =
-        (double)power_stats->get_icnt_mem_to_simt();  // # flits from memory
-                                                      // partitions to SIMT
-                                                      // clusters
-    wrapper->set_NoC_power(
-        n_icnt_mem_to_simt,
-        n_icnt_simt_to_mem);  // Number of flits traversing the interconnect
+		//pipeline power - pipeline_duty_cycle *= percent_active_sms;
+		float pipeline_duty_cycle=((*power_stats->m_average_pipeline_duty_cycle/( stat_sample_freq)) < 0.8)?((*power_stats->m_average_pipeline_duty_cycle)/stat_sample_freq):0.8;
+		wrapper->set_duty_cycle_power(pipeline_duty_cycle);
 
-    wrapper->compute();
+		//Memory Controller
+		wrapper->set_mem_ctrl_power(power_stats->get_dram_rd(), power_stats->get_dram_wr(), power_stats->get_dram_pre());
 
-    wrapper->update_components_power();
-    wrapper->print_trace_files();
-    power_stats->save_stats();
+		//Execution pipeline accesses
+		//FPU (SP) accesses, Integer ALU (not present in Tesla), Sfu accesses
+		wrapper->set_exec_unit_power(power_stats->get_tot_fpu_accessess(), power_stats->get_ialu_accessess(), power_stats->get_tot_sfu_accessess());
 
-    wrapper->detect_print_steady_state(0, tot_inst + inst);
+		//Average active lanes for sp and sfu pipelines
+		float avg_sp_active_lanes=(power_stats->get_sp_active_lanes())/stat_sample_freq;
+		float avg_sfu_active_lanes=(power_stats->get_sfu_active_lanes())/stat_sample_freq;
+		assert(avg_sp_active_lanes<=32);
+		assert(avg_sfu_active_lanes<=32);
+		wrapper->set_active_lanes_power((power_stats->get_sp_active_lanes())/stat_sample_freq,
+				(power_stats->get_sfu_active_lanes())/stat_sample_freq);
 
-    wrapper->power_metrics_calculations();
 
-    wrapper->dump();
-  }
-  // wrapper->close_files();
+		double n_icnt_simt_to_mem = (double)power_stats->get_icnt_simt_to_mem(); // # flits from SIMT clusters to memory partitions
+		double n_icnt_mem_to_simt = (double)power_stats->get_icnt_mem_to_simt(); // # flits from memory partitions to SIMT clusters
+		wrapper->set_NoC_power(n_icnt_mem_to_simt, n_icnt_simt_to_mem); // Number of flits traversing the interconnect
+
+		wrapper->compute();
+
+
+		wrapper->update_components_power();
+		wrapper->print_trace_files();
+		power_stats->save_stats();
+
+		wrapper->detect_print_steady_state(0,tot_inst+inst);
+
+		wrapper->power_metrics_calculations();
+
+
+		wrapper->dump();
+	}
+	//wrapper->close_files();
 }
 
-void mcpat_reset_perf_count(class gpgpu_sim_wrapper *wrapper) {
-  wrapper->reset_counters();
+void mcpat_reset_perf_count(class gpgpu_sim_wrapper *wrapper){
+	wrapper->reset_counters();
 }

--- a/src/gpgpu-sim/power_interface.h
+++ b/src/gpgpu-sim/power_interface.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -34,17 +32,12 @@
 #include "power_stat.h"
 #include "shader.h"
 
+
 #include "gpgpu_sim_wrapper.h"
 
-void init_mcpat(const gpgpu_sim_config &config,
-                class gpgpu_sim_wrapper *wrapper, unsigned stat_sample_freq,
-                unsigned tot_inst, unsigned inst);
-void mcpat_cycle(const gpgpu_sim_config &config,
-                 const shader_core_config *shdr_config,
-                 class gpgpu_sim_wrapper *wrapper,
-                 class power_stat_t *power_stats, unsigned stat_sample_freq,
-                 unsigned tot_cycle, unsigned cycle, unsigned tot_inst,
-                 unsigned inst);
+void init_mcpat(const gpgpu_sim_config &config, class gpgpu_sim_wrapper *wrapper, unsigned stat_sample_freq, unsigned tot_inst, unsigned inst);
+void mcpat_cycle(const gpgpu_sim_config &config, const shader_core_config *shdr_config, class gpgpu_sim_wrapper *wrapper, class power_stat_t *power_stats,
+        unsigned stat_sample_freq, unsigned tot_cycle, unsigned cycle, unsigned tot_inst, unsigned inst);
 void mcpat_reset_perf_count(class gpgpu_sim_wrapper *wrapper);
 
 #endif /* POWER_INTERFACE_H_ */

--- a/src/gpgpu-sim/power_interface.h
+++ b/src/gpgpu-sim/power_interface.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -32,12 +34,17 @@
 #include "power_stat.h"
 #include "shader.h"
 
-
 #include "gpgpu_sim_wrapper.h"
 
-void init_mcpat(const gpgpu_sim_config &config, class gpgpu_sim_wrapper *wrapper, unsigned stat_sample_freq, unsigned tot_inst, unsigned inst);
-void mcpat_cycle(const gpgpu_sim_config &config, const shader_core_config *shdr_config, class gpgpu_sim_wrapper *wrapper, class power_stat_t *power_stats,
-        unsigned stat_sample_freq, unsigned tot_cycle, unsigned cycle, unsigned tot_inst, unsigned inst);
+void init_mcpat(const gpgpu_sim_config &config,
+                class gpgpu_sim_wrapper *wrapper, unsigned stat_sample_freq,
+                unsigned tot_inst, unsigned inst);
+void mcpat_cycle(const gpgpu_sim_config &config,
+                 const shader_core_config *shdr_config,
+                 class gpgpu_sim_wrapper *wrapper,
+                 class power_stat_t *power_stats, unsigned stat_sample_freq,
+                 unsigned tot_cycle, unsigned cycle, unsigned tot_inst,
+                 unsigned inst);
 void mcpat_reset_perf_count(class gpgpu_sim_wrapper *wrapper);
 
 #endif /* POWER_INTERFACE_H_ */

--- a/src/gpgpu-sim/power_interface.h
+++ b/src/gpgpu-sim/power_interface.h
@@ -7,23 +7,24 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef POWER_INTERFACE_H_
 #define POWER_INTERFACE_H_
@@ -32,12 +33,17 @@
 #include "power_stat.h"
 #include "shader.h"
 
-
 #include "gpgpu_sim_wrapper.h"
 
-void init_mcpat(const gpgpu_sim_config &config, class gpgpu_sim_wrapper *wrapper, unsigned stat_sample_freq, unsigned tot_inst, unsigned inst);
-void mcpat_cycle(const gpgpu_sim_config &config, const shader_core_config *shdr_config, class gpgpu_sim_wrapper *wrapper, class power_stat_t *power_stats,
-        unsigned stat_sample_freq, unsigned tot_cycle, unsigned cycle, unsigned tot_inst, unsigned inst);
+void init_mcpat(const gpgpu_sim_config &config,
+                class gpgpu_sim_wrapper *wrapper, unsigned stat_sample_freq,
+                unsigned tot_inst, unsigned inst);
+void mcpat_cycle(const gpgpu_sim_config &config,
+                 const shader_core_config *shdr_config,
+                 class gpgpu_sim_wrapper *wrapper,
+                 class power_stat_t *power_stats, unsigned stat_sample_freq,
+                 unsigned tot_cycle, unsigned cycle, unsigned tot_inst,
+                 unsigned inst);
 void mcpat_reset_perf_count(class gpgpu_sim_wrapper *wrapper);
 
 #endif /* POWER_INTERFACE_H_ */

--- a/src/gpgpu-sim/power_stat.cc
+++ b/src/gpgpu-sim/power_stat.cc
@@ -7,287 +7,365 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
-#include "../abstract_hardware_model.h"
 #include "power_stat.h"
-#include "gpu-sim.h"
-#include "gpu-misc.h"
-#include "shader.h"
-#include "mem_fetch.h"
-#include "stat-tool.h"
+#include "../abstract_hardware_model.h"
 #include "../cuda-sim/ptx-stats.h"
-#include "visualizer.h"
 #include "dram.h"
+#include "gpu-misc.h"
+#include "gpu-sim.h"
+#include "mem_fetch.h"
+#include "shader.h"
+#include "stat-tool.h"
+#include "visualizer.h"
 
-#include <string.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
+power_mem_stat_t::power_mem_stat_t(const memory_config *mem_config,
+                                   const shader_core_config *shdr_config,
+                                   memory_stats_t *mem_stats,
+                                   shader_core_stats *shdr_stats) {
+  assert(mem_config->m_valid);
+  m_mem_stats = mem_stats;
+  m_config = mem_config;
+  m_core_stats = shdr_stats;
+  m_core_config = shdr_config;
 
-
-power_mem_stat_t::power_mem_stat_t(const memory_config *mem_config, const shader_core_config *shdr_config, memory_stats_t *mem_stats, shader_core_stats *shdr_stats){
-	   assert( mem_config->m_valid );
-	   m_mem_stats = mem_stats;
-	   m_config = mem_config;
-	   m_core_stats = shdr_stats;
-	   m_core_config = shdr_config;
-
-	   init();
+  init();
 }
 
-void power_mem_stat_t::init(){
+void power_mem_stat_t::init() {
+  shmem_read_access[CURRENT_STAT_IDX] =
+      m_core_stats->gpgpu_n_shmem_bank_access;  // Shared memory access
+  shmem_read_access[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_core_config->num_shader(), sizeof(unsigned));
 
-    shmem_read_access[CURRENT_STAT_IDX] = m_core_stats->gpgpu_n_shmem_bank_access; 	// Shared memory access
-    shmem_read_access[PREV_STAT_IDX] = (unsigned *)calloc(m_core_config->num_shader(),sizeof(unsigned));
+  for (unsigned i = 0; i < NUM_STAT_IDX; ++i) {
+    core_cache_stats[i].clear();
+    l2_cache_stats[i].clear();
 
-    for(unsigned i=0; i<NUM_STAT_IDX; ++i){
-        core_cache_stats[i].clear();
-        l2_cache_stats[i].clear();
+    n_cmd[i] = (unsigned *)calloc(m_config->m_n_mem, sizeof(unsigned));
+    n_activity[i] = (unsigned *)calloc(m_config->m_n_mem, sizeof(unsigned));
+    n_nop[i] = (unsigned *)calloc(m_config->m_n_mem, sizeof(unsigned));
+    n_act[i] = (unsigned *)calloc(m_config->m_n_mem, sizeof(unsigned));
+    n_pre[i] = (unsigned *)calloc(m_config->m_n_mem, sizeof(unsigned));
+    n_rd[i] = (unsigned *)calloc(m_config->m_n_mem, sizeof(unsigned));
+    n_wr[i] = (unsigned *)calloc(m_config->m_n_mem, sizeof(unsigned));
+    n_req[i] = (unsigned *)calloc(m_config->m_n_mem, sizeof(unsigned));
 
-        n_cmd[i] = (unsigned *)calloc(m_config->m_n_mem,sizeof(unsigned));
-        n_activity[i] = (unsigned *)calloc(m_config->m_n_mem,sizeof(unsigned));
-        n_nop[i] = (unsigned *)calloc(m_config->m_n_mem,sizeof(unsigned));
-        n_act[i] = (unsigned *)calloc(m_config->m_n_mem,sizeof(unsigned));
-        n_pre[i] = (unsigned *)calloc(m_config->m_n_mem,sizeof(unsigned));
-        n_rd[i] = (unsigned *)calloc(m_config->m_n_mem,sizeof(unsigned));
-        n_wr[i] = (unsigned *)calloc(m_config->m_n_mem,sizeof(unsigned));
-        n_req[i] = (unsigned *)calloc(m_config->m_n_mem,sizeof(unsigned));
-
-        // Interconnect stats
-        n_mem_to_simt[i] = (long *)calloc(m_core_config->n_simt_clusters,sizeof(long)); // Counted at SM
-        n_simt_to_mem[i] = (long *)calloc(m_core_config->n_simt_clusters,sizeof(long)); // Counted at SM
-    }
+    // Interconnect stats
+    n_mem_to_simt[i] = (long *)calloc(m_core_config->n_simt_clusters,
+                                      sizeof(long));  // Counted at SM
+    n_simt_to_mem[i] = (long *)calloc(m_core_config->n_simt_clusters,
+                                      sizeof(long));  // Counted at SM
+  }
 }
 
-void power_mem_stat_t::save_stats(){
+void power_mem_stat_t::save_stats() {
+  core_cache_stats[PREV_STAT_IDX] = core_cache_stats[CURRENT_STAT_IDX];
+  l2_cache_stats[PREV_STAT_IDX] = l2_cache_stats[CURRENT_STAT_IDX];
 
-    core_cache_stats[PREV_STAT_IDX] = core_cache_stats[CURRENT_STAT_IDX];
-    l2_cache_stats[PREV_STAT_IDX] = l2_cache_stats[CURRENT_STAT_IDX];
+  for (unsigned i = 0; i < m_core_config->num_shader(); ++i) {
+    shmem_read_access[PREV_STAT_IDX][i] =
+        shmem_read_access[CURRENT_STAT_IDX][i];  // Shared memory access
+  }
 
-    for(unsigned i=0; i<m_core_config->num_shader(); ++i){
-        shmem_read_access[PREV_STAT_IDX][i] = shmem_read_access[CURRENT_STAT_IDX][i] ; 	// Shared memory access
-    }
+  for (unsigned i = 0; i < m_config->m_n_mem; ++i) {
+    n_cmd[PREV_STAT_IDX][i] = n_cmd[CURRENT_STAT_IDX][i];
+    n_activity[PREV_STAT_IDX][i] = n_activity[CURRENT_STAT_IDX][i];
+    n_nop[PREV_STAT_IDX][i] = n_nop[CURRENT_STAT_IDX][i];
+    n_act[PREV_STAT_IDX][i] = n_act[CURRENT_STAT_IDX][i];
+    n_pre[PREV_STAT_IDX][i] = n_pre[CURRENT_STAT_IDX][i];
+    n_rd[PREV_STAT_IDX][i] = n_rd[CURRENT_STAT_IDX][i];
+    n_wr[PREV_STAT_IDX][i] = n_wr[CURRENT_STAT_IDX][i];
+    n_req[PREV_STAT_IDX][i] = n_req[CURRENT_STAT_IDX][i];
+  }
 
-    for(unsigned i=0; i<m_config->m_n_mem; ++i){
-        n_cmd[PREV_STAT_IDX][i] = n_cmd[CURRENT_STAT_IDX][i];
-        n_activity[PREV_STAT_IDX][i] = n_activity[CURRENT_STAT_IDX][i];
-        n_nop[PREV_STAT_IDX][i] = n_nop[CURRENT_STAT_IDX][i];
-        n_act[PREV_STAT_IDX][i] = n_act[CURRENT_STAT_IDX][i];
-        n_pre[PREV_STAT_IDX][i] = n_pre[CURRENT_STAT_IDX][i];
-        n_rd[PREV_STAT_IDX][i] = n_rd[CURRENT_STAT_IDX][i];
-        n_wr[PREV_STAT_IDX][i] = n_wr[CURRENT_STAT_IDX][i];
-        n_req[PREV_STAT_IDX][i] = n_req[CURRENT_STAT_IDX][i];
-    }
-
-    for(unsigned i=0; i<m_core_config->n_simt_clusters;i++){
-        n_simt_to_mem[PREV_STAT_IDX][i] = n_simt_to_mem[CURRENT_STAT_IDX][i]; // Interconnect
-        n_mem_to_simt[PREV_STAT_IDX][i] = n_mem_to_simt[CURRENT_STAT_IDX][i]; // Interconnect
-    }
+  for (unsigned i = 0; i < m_core_config->n_simt_clusters; i++) {
+    n_simt_to_mem[PREV_STAT_IDX][i] =
+        n_simt_to_mem[CURRENT_STAT_IDX][i];  // Interconnect
+    n_mem_to_simt[PREV_STAT_IDX][i] =
+        n_mem_to_simt[CURRENT_STAT_IDX][i];  // Interconnect
+  }
 }
 
-void power_mem_stat_t::visualizer_print( gzFile power_visualizer_file ){
+void power_mem_stat_t::visualizer_print(gzFile power_visualizer_file) {}
 
+void power_mem_stat_t::print(FILE *fout) const {
+  fprintf(fout, "\n\n==========Power Metrics -- Memory==========\n");
+  unsigned total_mem_reads = 0;
+  unsigned total_mem_writes = 0;
+  for (unsigned i = 0; i < m_config->m_n_mem; ++i) {
+    total_mem_reads += n_rd[CURRENT_STAT_IDX][i];
+    total_mem_writes += n_wr[CURRENT_STAT_IDX][i];
+  }
+  fprintf(fout, "Total memory controller accesses: %u\n",
+          total_mem_reads + total_mem_writes);
+  fprintf(fout, "Total memory controller reads: %u\n", total_mem_reads);
+  fprintf(fout, "Total memory controller writes: %u\n", total_mem_writes);
+
+  fprintf(fout, "Core cache stats:\n");
+  core_cache_stats->print_stats(fout);
+  fprintf(fout, "L2 cache stats:\n");
+  l2_cache_stats->print_stats(fout);
 }
 
-void power_mem_stat_t::print (FILE *fout) const {
-	fprintf(fout, "\n\n==========Power Metrics -- Memory==========\n");
-    unsigned total_mem_reads=0;
-    unsigned total_mem_writes=0;
-    for(unsigned i=0; i<m_config->m_n_mem; ++i){
-        total_mem_reads += n_rd[CURRENT_STAT_IDX][i];
-        total_mem_writes += n_wr[CURRENT_STAT_IDX][i];
-    }
-    fprintf(fout, "Total memory controller accesses: %u\n", total_mem_reads+total_mem_writes);
-    fprintf(fout, "Total memory controller reads: %u\n", total_mem_reads);
-    fprintf(fout, "Total memory controller writes: %u\n", total_mem_writes);
+power_core_stat_t::power_core_stat_t(const shader_core_config *shader_config,
+                                     shader_core_stats *core_stats) {
+  assert(shader_config->m_valid);
+  m_config = shader_config;
+  shader_core_power_stats_pod *pod = this;
+  memset(pod, 0, sizeof(shader_core_power_stats_pod));
+  m_core_stats = core_stats;
 
-    fprintf(fout, "Core cache stats:\n");
-    core_cache_stats->print_stats(fout);
-    fprintf(fout, "L2 cache stats:\n");
-    l2_cache_stats->print_stats(fout);
+  init();
 }
 
+void power_core_stat_t::visualizer_print(gzFile visualizer_file) {}
 
-power_core_stat_t::power_core_stat_t( const shader_core_config *shader_config, shader_core_stats *core_stats )
-{
-     	assert( shader_config->m_valid );
-        m_config = shader_config;
-        shader_core_power_stats_pod *pod = this;
-        memset(pod,0,sizeof(shader_core_power_stats_pod));
-        m_core_stats=core_stats;
+void power_core_stat_t::print(FILE *fout) {
+  // per core statistics
+  fprintf(fout, "Power Metrics: \n");
+  for (unsigned i = 0; i < m_config->num_shader(); i++) {
+    fprintf(fout, "core %u:\n", i);
+    fprintf(fout, "\tpipeline duty cycle =%f\n",
+            m_pipeline_duty_cycle[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal Deocded Instructions=%u\n",
+            m_num_decoded_insn[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal FP Deocded Instructions=%u\n",
+            m_num_FPdecoded_insn[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal INT Deocded Instructions=%u\n",
+            m_num_INTdecoded_insn[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal LOAD Queued Instructions=%u\n",
+            m_num_loadqueued_insn[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal STORE Queued Instructions=%u\n",
+            m_num_storequeued_insn[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal IALU Acesses=%u\n",
+            m_num_ialu_acesses[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal FP Acesses=%u\n",
+            m_num_fp_acesses[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal IMUL Acesses=%u\n",
+            m_num_imul_acesses[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal IMUL24 Acesses=%u\n",
+            m_num_imul24_acesses[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal IMUL32 Acesses=%u\n",
+            m_num_imul32_acesses[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal IDIV Acesses=%u\n",
+            m_num_idiv_acesses[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal FPMUL Acesses=%u\n",
+            m_num_fpmul_acesses[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal SFU Acesses=%u\n",
+            m_num_trans_acesses[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal FPDIV Acesses=%u\n",
+            m_num_fpdiv_acesses[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal SFU Acesses=%u\n",
+            m_num_sfu_acesses[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal SP Acesses=%u\n",
+            m_num_sp_acesses[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal MEM Acesses=%u\n",
+            m_num_mem_acesses[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal SFU Commissions=%u\n",
+            m_num_sfu_committed[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal SP Commissions=%u\n",
+            m_num_sp_committed[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal MEM Commissions=%u\n",
+            m_num_mem_committed[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal REG Reads=%u\n",
+            m_read_regfile_acesses[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal REG Writes=%u\n",
+            m_write_regfile_acesses[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal NON REG=%u\n",
+            m_non_rf_operands[CURRENT_STAT_IDX][i]);
+  }
+}
+void power_core_stat_t::init() {
+  m_pipeline_duty_cycle[CURRENT_STAT_IDX] = m_core_stats->m_pipeline_duty_cycle;
+  m_num_decoded_insn[CURRENT_STAT_IDX] = m_core_stats->m_num_decoded_insn;
+  m_num_FPdecoded_insn[CURRENT_STAT_IDX] = m_core_stats->m_num_FPdecoded_insn;
+  m_num_INTdecoded_insn[CURRENT_STAT_IDX] = m_core_stats->m_num_INTdecoded_insn;
+  m_num_storequeued_insn[CURRENT_STAT_IDX] =
+      m_core_stats->m_num_storequeued_insn;
+  m_num_loadqueued_insn[CURRENT_STAT_IDX] = m_core_stats->m_num_loadqueued_insn;
+  m_num_ialu_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_ialu_acesses;
+  m_num_fp_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_fp_acesses;
+  m_num_imul_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_imul_acesses;
+  m_num_imul24_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_imul24_acesses;
+  m_num_imul32_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_imul32_acesses;
+  m_num_fpmul_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_fpmul_acesses;
+  m_num_idiv_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_idiv_acesses;
+  m_num_fpdiv_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_fpdiv_acesses;
+  m_num_sp_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_sp_acesses;
+  m_num_sfu_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_sfu_acesses;
+  m_num_trans_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_trans_acesses;
+  m_num_mem_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_mem_acesses;
+  m_num_sp_committed[CURRENT_STAT_IDX] = m_core_stats->m_num_sp_committed;
+  m_num_sfu_committed[CURRENT_STAT_IDX] = m_core_stats->m_num_sfu_committed;
+  m_num_mem_committed[CURRENT_STAT_IDX] = m_core_stats->m_num_mem_committed;
+  m_read_regfile_acesses[CURRENT_STAT_IDX] =
+      m_core_stats->m_read_regfile_acesses;
+  m_write_regfile_acesses[CURRENT_STAT_IDX] =
+      m_core_stats->m_write_regfile_acesses;
+  m_non_rf_operands[CURRENT_STAT_IDX] = m_core_stats->m_non_rf_operands;
+  m_active_sp_lanes[CURRENT_STAT_IDX] = m_core_stats->m_active_sp_lanes;
+  m_active_sfu_lanes[CURRENT_STAT_IDX] = m_core_stats->m_active_sfu_lanes;
+  m_num_tex_inst[CURRENT_STAT_IDX] = m_core_stats->m_num_tex_inst;
 
-        init();
-
+  m_pipeline_duty_cycle[PREV_STAT_IDX] =
+      (float *)calloc(m_config->num_shader(), sizeof(float));
+  m_num_decoded_insn[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_FPdecoded_insn[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_INTdecoded_insn[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_storequeued_insn[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_loadqueued_insn[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_ialu_acesses[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_fp_acesses[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_tex_inst[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_imul_acesses[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_imul24_acesses[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_imul32_acesses[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_fpmul_acesses[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_idiv_acesses[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_fpdiv_acesses[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_sp_acesses[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_sfu_acesses[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_trans_acesses[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_mem_acesses[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_sp_committed[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_sfu_committed[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_mem_committed[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_read_regfile_acesses[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_write_regfile_acesses[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_non_rf_operands[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_active_sp_lanes[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_active_sfu_lanes[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
 }
 
-void power_core_stat_t::visualizer_print( gzFile visualizer_file )
-{
-
+void power_core_stat_t::save_stats() {
+  for (unsigned i = 0; i < m_config->num_shader(); ++i) {
+    m_pipeline_duty_cycle[PREV_STAT_IDX][i] =
+        m_pipeline_duty_cycle[CURRENT_STAT_IDX][i];
+    m_num_decoded_insn[PREV_STAT_IDX][i] =
+        m_num_decoded_insn[CURRENT_STAT_IDX][i];
+    m_num_FPdecoded_insn[PREV_STAT_IDX][i] =
+        m_num_FPdecoded_insn[CURRENT_STAT_IDX][i];
+    m_num_INTdecoded_insn[PREV_STAT_IDX][i] =
+        m_num_INTdecoded_insn[CURRENT_STAT_IDX][i];
+    m_num_storequeued_insn[PREV_STAT_IDX][i] =
+        m_num_storequeued_insn[CURRENT_STAT_IDX][i];
+    m_num_loadqueued_insn[PREV_STAT_IDX][i] =
+        m_num_loadqueued_insn[CURRENT_STAT_IDX][i];
+    m_num_ialu_acesses[PREV_STAT_IDX][i] =
+        m_num_ialu_acesses[CURRENT_STAT_IDX][i];
+    m_num_fp_acesses[PREV_STAT_IDX][i] = m_num_fp_acesses[CURRENT_STAT_IDX][i];
+    m_num_tex_inst[PREV_STAT_IDX][i] = m_num_tex_inst[CURRENT_STAT_IDX][i];
+    m_num_imul_acesses[PREV_STAT_IDX][i] =
+        m_num_imul_acesses[CURRENT_STAT_IDX][i];
+    m_num_imul24_acesses[PREV_STAT_IDX][i] =
+        m_num_imul24_acesses[CURRENT_STAT_IDX][i];
+    m_num_imul32_acesses[PREV_STAT_IDX][i] =
+        m_num_imul32_acesses[CURRENT_STAT_IDX][i];
+    m_num_fpmul_acesses[PREV_STAT_IDX][i] =
+        m_num_fpmul_acesses[CURRENT_STAT_IDX][i];
+    m_num_idiv_acesses[PREV_STAT_IDX][i] =
+        m_num_idiv_acesses[CURRENT_STAT_IDX][i];
+    m_num_fpdiv_acesses[PREV_STAT_IDX][i] =
+        m_num_fpdiv_acesses[CURRENT_STAT_IDX][i];
+    m_num_sp_acesses[PREV_STAT_IDX][i] = m_num_sp_acesses[CURRENT_STAT_IDX][i];
+    m_num_sfu_acesses[PREV_STAT_IDX][i] =
+        m_num_sfu_acesses[CURRENT_STAT_IDX][i];
+    m_num_trans_acesses[PREV_STAT_IDX][i] =
+        m_num_trans_acesses[CURRENT_STAT_IDX][i];
+    m_num_mem_acesses[PREV_STAT_IDX][i] =
+        m_num_mem_acesses[CURRENT_STAT_IDX][i];
+    m_num_sp_committed[PREV_STAT_IDX][i] =
+        m_num_sp_committed[CURRENT_STAT_IDX][i];
+    m_num_sfu_committed[PREV_STAT_IDX][i] =
+        m_num_sfu_committed[CURRENT_STAT_IDX][i];
+    m_num_mem_committed[PREV_STAT_IDX][i] =
+        m_num_mem_committed[CURRENT_STAT_IDX][i];
+    m_read_regfile_acesses[PREV_STAT_IDX][i] =
+        m_read_regfile_acesses[CURRENT_STAT_IDX][i];
+    m_write_regfile_acesses[PREV_STAT_IDX][i] =
+        m_write_regfile_acesses[CURRENT_STAT_IDX][i];
+    m_non_rf_operands[PREV_STAT_IDX][i] =
+        m_non_rf_operands[CURRENT_STAT_IDX][i];
+    m_active_sp_lanes[PREV_STAT_IDX][i] =
+        m_active_sp_lanes[CURRENT_STAT_IDX][i];
+    m_active_sfu_lanes[PREV_STAT_IDX][i] =
+        m_active_sfu_lanes[CURRENT_STAT_IDX][i];
+  }
 }
 
-void power_core_stat_t::print (FILE *fout)
-{
-	// per core statistics
-    fprintf(fout,"Power Metrics: \n");
-    for(unsigned i=0; i<m_config->num_shader();i++){
-        fprintf(fout,"core %u:\n",i);
-        fprintf(fout,"\tpipeline duty cycle =%f\n",m_pipeline_duty_cycle[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal Deocded Instructions=%u\n",m_num_decoded_insn[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal FP Deocded Instructions=%u\n",m_num_FPdecoded_insn[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal INT Deocded Instructions=%u\n",m_num_INTdecoded_insn[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal LOAD Queued Instructions=%u\n",m_num_loadqueued_insn[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal STORE Queued Instructions=%u\n",m_num_storequeued_insn[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal IALU Acesses=%u\n",m_num_ialu_acesses[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal FP Acesses=%u\n",m_num_fp_acesses[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal IMUL Acesses=%u\n",m_num_imul_acesses[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal IMUL24 Acesses=%u\n",m_num_imul24_acesses[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal IMUL32 Acesses=%u\n",m_num_imul32_acesses[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal IDIV Acesses=%u\n",m_num_idiv_acesses[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal FPMUL Acesses=%u\n",m_num_fpmul_acesses[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal SFU Acesses=%u\n",m_num_trans_acesses[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal FPDIV Acesses=%u\n",m_num_fpdiv_acesses[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal SFU Acesses=%u\n",m_num_sfu_acesses[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal SP Acesses=%u\n",m_num_sp_acesses[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal MEM Acesses=%u\n",m_num_mem_acesses[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal SFU Commissions=%u\n",m_num_sfu_committed[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal SP Commissions=%u\n",m_num_sp_committed[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal MEM Commissions=%u\n",m_num_mem_committed[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal REG Reads=%u\n",m_read_regfile_acesses[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal REG Writes=%u\n",m_write_regfile_acesses[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal NON REG=%u\n",m_non_rf_operands[CURRENT_STAT_IDX][i]);
-    }
-}
-void power_core_stat_t::init()
-{
-    m_pipeline_duty_cycle[CURRENT_STAT_IDX]=m_core_stats->m_pipeline_duty_cycle;
-    m_num_decoded_insn[CURRENT_STAT_IDX]=m_core_stats->m_num_decoded_insn;
-    m_num_FPdecoded_insn[CURRENT_STAT_IDX]=m_core_stats->m_num_FPdecoded_insn;
-    m_num_INTdecoded_insn[CURRENT_STAT_IDX]=m_core_stats->m_num_INTdecoded_insn;
-    m_num_storequeued_insn[CURRENT_STAT_IDX]=m_core_stats->m_num_storequeued_insn;
-    m_num_loadqueued_insn[CURRENT_STAT_IDX]=m_core_stats->m_num_loadqueued_insn;
-    m_num_ialu_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_ialu_acesses;
-    m_num_fp_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_fp_acesses;
-    m_num_imul_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_imul_acesses;
-    m_num_imul24_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_imul24_acesses;
-    m_num_imul32_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_imul32_acesses;
-    m_num_fpmul_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_fpmul_acesses;
-    m_num_idiv_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_idiv_acesses;
-    m_num_fpdiv_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_fpdiv_acesses;
-    m_num_sp_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_sp_acesses;
-    m_num_sfu_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_sfu_acesses;
-    m_num_trans_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_trans_acesses;
-    m_num_mem_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_mem_acesses;
-    m_num_sp_committed[CURRENT_STAT_IDX]=m_core_stats->m_num_sp_committed;
-    m_num_sfu_committed[CURRENT_STAT_IDX]=m_core_stats->m_num_sfu_committed;
-    m_num_mem_committed[CURRENT_STAT_IDX]=m_core_stats->m_num_mem_committed;
-    m_read_regfile_acesses[CURRENT_STAT_IDX]=m_core_stats->m_read_regfile_acesses;
-    m_write_regfile_acesses[CURRENT_STAT_IDX]=m_core_stats->m_write_regfile_acesses;
-    m_non_rf_operands[CURRENT_STAT_IDX]=m_core_stats->m_non_rf_operands;
-    m_active_sp_lanes[CURRENT_STAT_IDX]=m_core_stats->m_active_sp_lanes;
-    m_active_sfu_lanes[CURRENT_STAT_IDX]=m_core_stats->m_active_sfu_lanes;
-    m_num_tex_inst[CURRENT_STAT_IDX]=m_core_stats->m_num_tex_inst;
-
-
-    m_pipeline_duty_cycle[PREV_STAT_IDX]=(float*)calloc(m_config->num_shader(),sizeof(float));
-    m_num_decoded_insn[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_FPdecoded_insn[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_INTdecoded_insn[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_storequeued_insn[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_loadqueued_insn[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_ialu_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_fp_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_tex_inst[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_imul_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_imul24_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_imul32_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_fpmul_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_idiv_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_fpdiv_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_sp_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_sfu_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_trans_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_mem_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_sp_committed[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_sfu_committed[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_mem_committed[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_read_regfile_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_write_regfile_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_non_rf_operands[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_active_sp_lanes[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_active_sfu_lanes[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
+power_stat_t::power_stat_t(const shader_core_config *shader_config,
+                           float *average_pipeline_duty_cycle,
+                           float *active_sms, shader_core_stats *shader_stats,
+                           const memory_config *mem_config,
+                           memory_stats_t *memory_stats) {
+  assert(shader_config->m_valid);
+  assert(mem_config->m_valid);
+  pwr_core_stat = new power_core_stat_t(shader_config, shader_stats);
+  pwr_mem_stat = new power_mem_stat_t(mem_config, shader_config, memory_stats,
+                                      shader_stats);
+  m_average_pipeline_duty_cycle = average_pipeline_duty_cycle;
+  m_active_sms = active_sms;
+  m_config = shader_config;
+  m_mem_config = mem_config;
 }
 
-void power_core_stat_t::save_stats(){
-for(unsigned i=0; i<m_config->num_shader(); ++i){
-    m_pipeline_duty_cycle[PREV_STAT_IDX][i]=m_pipeline_duty_cycle[CURRENT_STAT_IDX][i];
-    m_num_decoded_insn[PREV_STAT_IDX][i]=	m_num_decoded_insn[CURRENT_STAT_IDX][i];
-    m_num_FPdecoded_insn[PREV_STAT_IDX][i]=m_num_FPdecoded_insn[CURRENT_STAT_IDX][i];
-    m_num_INTdecoded_insn[PREV_STAT_IDX][i]=m_num_INTdecoded_insn[CURRENT_STAT_IDX][i];
-    m_num_storequeued_insn[PREV_STAT_IDX][i]=m_num_storequeued_insn[CURRENT_STAT_IDX][i];
-    m_num_loadqueued_insn[PREV_STAT_IDX][i]=m_num_loadqueued_insn[CURRENT_STAT_IDX][i];
-    m_num_ialu_acesses[PREV_STAT_IDX][i]=m_num_ialu_acesses[CURRENT_STAT_IDX][i];
-    m_num_fp_acesses[PREV_STAT_IDX][i]=m_num_fp_acesses[CURRENT_STAT_IDX][i];
-    m_num_tex_inst[PREV_STAT_IDX][i]=m_num_tex_inst[CURRENT_STAT_IDX][i];
-    m_num_imul_acesses[PREV_STAT_IDX][i]=m_num_imul_acesses[CURRENT_STAT_IDX][i];
-    m_num_imul24_acesses[PREV_STAT_IDX][i]=m_num_imul24_acesses[CURRENT_STAT_IDX][i];
-    m_num_imul32_acesses[PREV_STAT_IDX][i]=m_num_imul32_acesses[CURRENT_STAT_IDX][i];
-    m_num_fpmul_acesses[PREV_STAT_IDX][i]=m_num_fpmul_acesses[CURRENT_STAT_IDX][i];
-    m_num_idiv_acesses[PREV_STAT_IDX][i]=m_num_idiv_acesses[CURRENT_STAT_IDX][i];
-    m_num_fpdiv_acesses[PREV_STAT_IDX][i]=m_num_fpdiv_acesses[CURRENT_STAT_IDX][i];
-    m_num_sp_acesses[PREV_STAT_IDX][i]=m_num_sp_acesses[CURRENT_STAT_IDX][i];
-    m_num_sfu_acesses[PREV_STAT_IDX][i]=m_num_sfu_acesses[CURRENT_STAT_IDX][i];
-    m_num_trans_acesses[PREV_STAT_IDX][i]=m_num_trans_acesses[CURRENT_STAT_IDX][i];
-    m_num_mem_acesses[PREV_STAT_IDX][i]=m_num_mem_acesses[CURRENT_STAT_IDX][i];
-    m_num_sp_committed[PREV_STAT_IDX][i]=m_num_sp_committed[CURRENT_STAT_IDX][i];
-    m_num_sfu_committed[PREV_STAT_IDX][i]=m_num_sfu_committed[CURRENT_STAT_IDX][i];
-    m_num_mem_committed[PREV_STAT_IDX][i]=m_num_mem_committed[CURRENT_STAT_IDX][i];
-    m_read_regfile_acesses[PREV_STAT_IDX][i]=m_read_regfile_acesses[CURRENT_STAT_IDX][i];
-    m_write_regfile_acesses[PREV_STAT_IDX][i]=m_write_regfile_acesses[CURRENT_STAT_IDX][i];
-    m_non_rf_operands[PREV_STAT_IDX][i]=m_non_rf_operands[CURRENT_STAT_IDX][i];
-    m_active_sp_lanes[PREV_STAT_IDX][i]=m_active_sp_lanes[CURRENT_STAT_IDX][i];
-    m_active_sfu_lanes[PREV_STAT_IDX][i]=m_active_sfu_lanes[CURRENT_STAT_IDX][i];
-    }
+void power_stat_t::visualizer_print(gzFile visualizer_file) {
+  pwr_core_stat->visualizer_print(visualizer_file);
+  pwr_mem_stat->visualizer_print(visualizer_file);
 }
 
-power_stat_t::power_stat_t( const shader_core_config *shader_config,float * average_pipeline_duty_cycle,float *active_sms,shader_core_stats * shader_stats, const memory_config *mem_config,memory_stats_t * memory_stats)
-{
-	assert( shader_config->m_valid );
-	assert( mem_config->m_valid );
-	pwr_core_stat= new power_core_stat_t(shader_config,shader_stats);
-	pwr_mem_stat= new power_mem_stat_t(mem_config,shader_config, memory_stats, shader_stats);
-	m_average_pipeline_duty_cycle=average_pipeline_duty_cycle;
-	m_active_sms=active_sms;
-	m_config = shader_config;
-	m_mem_config = mem_config;
+void power_stat_t::print(FILE *fout) const {
+  fprintf(fout, "average_pipeline_duty_cycle=%f\n",
+          *m_average_pipeline_duty_cycle);
+  pwr_core_stat->print(fout);
+  pwr_mem_stat->print(fout);
 }
-
-void power_stat_t::visualizer_print( gzFile visualizer_file )
-{
-	pwr_core_stat->visualizer_print(visualizer_file);
-	pwr_mem_stat->visualizer_print(visualizer_file);
-}
-
-void power_stat_t::print (FILE *fout) const
-{
-	fprintf(fout,"average_pipeline_duty_cycle=%f\n",*m_average_pipeline_duty_cycle);
-	pwr_core_stat->print(fout);
-	pwr_mem_stat->print(fout);
-}
-

--- a/src/gpgpu-sim/power_stat.cc
+++ b/src/gpgpu-sim/power_stat.cc
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -27,346 +25,269 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "power_stat.h"
 #include "../abstract_hardware_model.h"
-#include "../cuda-sim/ptx-stats.h"
-#include "dram.h"
-#include "gpu-misc.h"
+#include "power_stat.h"
 #include "gpu-sim.h"
-#include "mem_fetch.h"
+#include "gpu-misc.h"
 #include "shader.h"
+#include "mem_fetch.h"
 #include "stat-tool.h"
+#include "../cuda-sim/ptx-stats.h"
 #include "visualizer.h"
+#include "dram.h"
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
 
-power_mem_stat_t::power_mem_stat_t(const memory_config *mem_config,
-                                   const shader_core_config *shdr_config,
-                                   memory_stats_t *mem_stats,
-                                   shader_core_stats *shdr_stats) {
-  assert(mem_config->m_valid);
-  m_mem_stats = mem_stats;
-  m_config = mem_config;
-  m_core_stats = shdr_stats;
-  m_core_config = shdr_config;
 
-  init();
+
+power_mem_stat_t::power_mem_stat_t(const memory_config *mem_config, const shader_core_config *shdr_config, memory_stats_t *mem_stats, shader_core_stats *shdr_stats){
+	   assert( mem_config->m_valid );
+	   m_mem_stats = mem_stats;
+	   m_config = mem_config;
+	   m_core_stats = shdr_stats;
+	   m_core_config = shdr_config;
+
+	   init();
 }
 
-void power_mem_stat_t::init() {
-  shmem_read_access[CURRENT_STAT_IDX] =
-      m_core_stats->gpgpu_n_shmem_bank_access;  // Shared memory access
-  shmem_read_access[PREV_STAT_IDX] =
-      (unsigned *)calloc(m_core_config->num_shader(), sizeof(unsigned));
+void power_mem_stat_t::init(){
 
-  for (unsigned i = 0; i < NUM_STAT_IDX; ++i) {
-    core_cache_stats[i].clear();
-    l2_cache_stats[i].clear();
+    shmem_read_access[CURRENT_STAT_IDX] = m_core_stats->gpgpu_n_shmem_bank_access; 	// Shared memory access
+    shmem_read_access[PREV_STAT_IDX] = (unsigned *)calloc(m_core_config->num_shader(),sizeof(unsigned));
 
-    n_cmd[i] = (unsigned *)calloc(m_config->m_n_mem, sizeof(unsigned));
-    n_activity[i] = (unsigned *)calloc(m_config->m_n_mem, sizeof(unsigned));
-    n_nop[i] = (unsigned *)calloc(m_config->m_n_mem, sizeof(unsigned));
-    n_act[i] = (unsigned *)calloc(m_config->m_n_mem, sizeof(unsigned));
-    n_pre[i] = (unsigned *)calloc(m_config->m_n_mem, sizeof(unsigned));
-    n_rd[i] = (unsigned *)calloc(m_config->m_n_mem, sizeof(unsigned));
-    n_wr[i] = (unsigned *)calloc(m_config->m_n_mem, sizeof(unsigned));
-    n_req[i] = (unsigned *)calloc(m_config->m_n_mem, sizeof(unsigned));
+    for(unsigned i=0; i<NUM_STAT_IDX; ++i){
+        core_cache_stats[i].clear();
+        l2_cache_stats[i].clear();
 
-    // Interconnect stats
-    n_mem_to_simt[i] = (long *)calloc(m_core_config->n_simt_clusters,
-                                      sizeof(long));  // Counted at SM
-    n_simt_to_mem[i] = (long *)calloc(m_core_config->n_simt_clusters,
-                                      sizeof(long));  // Counted at SM
-  }
+        n_cmd[i] = (unsigned *)calloc(m_config->m_n_mem,sizeof(unsigned));
+        n_activity[i] = (unsigned *)calloc(m_config->m_n_mem,sizeof(unsigned));
+        n_nop[i] = (unsigned *)calloc(m_config->m_n_mem,sizeof(unsigned));
+        n_act[i] = (unsigned *)calloc(m_config->m_n_mem,sizeof(unsigned));
+        n_pre[i] = (unsigned *)calloc(m_config->m_n_mem,sizeof(unsigned));
+        n_rd[i] = (unsigned *)calloc(m_config->m_n_mem,sizeof(unsigned));
+        n_wr[i] = (unsigned *)calloc(m_config->m_n_mem,sizeof(unsigned));
+        n_req[i] = (unsigned *)calloc(m_config->m_n_mem,sizeof(unsigned));
+
+        // Interconnect stats
+        n_mem_to_simt[i] = (long *)calloc(m_core_config->n_simt_clusters,sizeof(long)); // Counted at SM
+        n_simt_to_mem[i] = (long *)calloc(m_core_config->n_simt_clusters,sizeof(long)); // Counted at SM
+    }
 }
 
-void power_mem_stat_t::save_stats() {
-  core_cache_stats[PREV_STAT_IDX] = core_cache_stats[CURRENT_STAT_IDX];
-  l2_cache_stats[PREV_STAT_IDX] = l2_cache_stats[CURRENT_STAT_IDX];
+void power_mem_stat_t::save_stats(){
 
-  for (unsigned i = 0; i < m_core_config->num_shader(); ++i) {
-    shmem_read_access[PREV_STAT_IDX][i] =
-        shmem_read_access[CURRENT_STAT_IDX][i];  // Shared memory access
-  }
+    core_cache_stats[PREV_STAT_IDX] = core_cache_stats[CURRENT_STAT_IDX];
+    l2_cache_stats[PREV_STAT_IDX] = l2_cache_stats[CURRENT_STAT_IDX];
 
-  for (unsigned i = 0; i < m_config->m_n_mem; ++i) {
-    n_cmd[PREV_STAT_IDX][i] = n_cmd[CURRENT_STAT_IDX][i];
-    n_activity[PREV_STAT_IDX][i] = n_activity[CURRENT_STAT_IDX][i];
-    n_nop[PREV_STAT_IDX][i] = n_nop[CURRENT_STAT_IDX][i];
-    n_act[PREV_STAT_IDX][i] = n_act[CURRENT_STAT_IDX][i];
-    n_pre[PREV_STAT_IDX][i] = n_pre[CURRENT_STAT_IDX][i];
-    n_rd[PREV_STAT_IDX][i] = n_rd[CURRENT_STAT_IDX][i];
-    n_wr[PREV_STAT_IDX][i] = n_wr[CURRENT_STAT_IDX][i];
-    n_req[PREV_STAT_IDX][i] = n_req[CURRENT_STAT_IDX][i];
-  }
+    for(unsigned i=0; i<m_core_config->num_shader(); ++i){
+        shmem_read_access[PREV_STAT_IDX][i] = shmem_read_access[CURRENT_STAT_IDX][i] ; 	// Shared memory access
+    }
 
-  for (unsigned i = 0; i < m_core_config->n_simt_clusters; i++) {
-    n_simt_to_mem[PREV_STAT_IDX][i] =
-        n_simt_to_mem[CURRENT_STAT_IDX][i];  // Interconnect
-    n_mem_to_simt[PREV_STAT_IDX][i] =
-        n_mem_to_simt[CURRENT_STAT_IDX][i];  // Interconnect
-  }
+    for(unsigned i=0; i<m_config->m_n_mem; ++i){
+        n_cmd[PREV_STAT_IDX][i] = n_cmd[CURRENT_STAT_IDX][i];
+        n_activity[PREV_STAT_IDX][i] = n_activity[CURRENT_STAT_IDX][i];
+        n_nop[PREV_STAT_IDX][i] = n_nop[CURRENT_STAT_IDX][i];
+        n_act[PREV_STAT_IDX][i] = n_act[CURRENT_STAT_IDX][i];
+        n_pre[PREV_STAT_IDX][i] = n_pre[CURRENT_STAT_IDX][i];
+        n_rd[PREV_STAT_IDX][i] = n_rd[CURRENT_STAT_IDX][i];
+        n_wr[PREV_STAT_IDX][i] = n_wr[CURRENT_STAT_IDX][i];
+        n_req[PREV_STAT_IDX][i] = n_req[CURRENT_STAT_IDX][i];
+    }
+
+    for(unsigned i=0; i<m_core_config->n_simt_clusters;i++){
+        n_simt_to_mem[PREV_STAT_IDX][i] = n_simt_to_mem[CURRENT_STAT_IDX][i]; // Interconnect
+        n_mem_to_simt[PREV_STAT_IDX][i] = n_mem_to_simt[CURRENT_STAT_IDX][i]; // Interconnect
+    }
 }
 
-void power_mem_stat_t::visualizer_print(gzFile power_visualizer_file) {}
+void power_mem_stat_t::visualizer_print( gzFile power_visualizer_file ){
 
-void power_mem_stat_t::print(FILE *fout) const {
-  fprintf(fout, "\n\n==========Power Metrics -- Memory==========\n");
-  unsigned total_mem_reads = 0;
-  unsigned total_mem_writes = 0;
-  for (unsigned i = 0; i < m_config->m_n_mem; ++i) {
-    total_mem_reads += n_rd[CURRENT_STAT_IDX][i];
-    total_mem_writes += n_wr[CURRENT_STAT_IDX][i];
-  }
-  fprintf(fout, "Total memory controller accesses: %u\n",
-          total_mem_reads + total_mem_writes);
-  fprintf(fout, "Total memory controller reads: %u\n", total_mem_reads);
-  fprintf(fout, "Total memory controller writes: %u\n", total_mem_writes);
-
-  fprintf(fout, "Core cache stats:\n");
-  core_cache_stats->print_stats(fout);
-  fprintf(fout, "L2 cache stats:\n");
-  l2_cache_stats->print_stats(fout);
 }
 
-power_core_stat_t::power_core_stat_t(const shader_core_config *shader_config,
-                                     shader_core_stats *core_stats) {
-  assert(shader_config->m_valid);
-  m_config = shader_config;
-  shader_core_power_stats_pod *pod = this;
-  memset(pod, 0, sizeof(shader_core_power_stats_pod));
-  m_core_stats = core_stats;
+void power_mem_stat_t::print (FILE *fout) const {
+	fprintf(fout, "\n\n==========Power Metrics -- Memory==========\n");
+    unsigned total_mem_reads=0;
+    unsigned total_mem_writes=0;
+    for(unsigned i=0; i<m_config->m_n_mem; ++i){
+        total_mem_reads += n_rd[CURRENT_STAT_IDX][i];
+        total_mem_writes += n_wr[CURRENT_STAT_IDX][i];
+    }
+    fprintf(fout, "Total memory controller accesses: %u\n", total_mem_reads+total_mem_writes);
+    fprintf(fout, "Total memory controller reads: %u\n", total_mem_reads);
+    fprintf(fout, "Total memory controller writes: %u\n", total_mem_writes);
 
-  init();
+    fprintf(fout, "Core cache stats:\n");
+    core_cache_stats->print_stats(fout);
+    fprintf(fout, "L2 cache stats:\n");
+    l2_cache_stats->print_stats(fout);
 }
 
-void power_core_stat_t::visualizer_print(gzFile visualizer_file) {}
 
-void power_core_stat_t::print(FILE *fout) {
-  // per core statistics
-  fprintf(fout, "Power Metrics: \n");
-  for (unsigned i = 0; i < m_config->num_shader(); i++) {
-    fprintf(fout, "core %u:\n", i);
-    fprintf(fout, "\tpipeline duty cycle =%f\n",
-            m_pipeline_duty_cycle[CURRENT_STAT_IDX][i]);
-    fprintf(fout, "\tTotal Deocded Instructions=%u\n",
-            m_num_decoded_insn[CURRENT_STAT_IDX][i]);
-    fprintf(fout, "\tTotal FP Deocded Instructions=%u\n",
-            m_num_FPdecoded_insn[CURRENT_STAT_IDX][i]);
-    fprintf(fout, "\tTotal INT Deocded Instructions=%u\n",
-            m_num_INTdecoded_insn[CURRENT_STAT_IDX][i]);
-    fprintf(fout, "\tTotal LOAD Queued Instructions=%u\n",
-            m_num_loadqueued_insn[CURRENT_STAT_IDX][i]);
-    fprintf(fout, "\tTotal STORE Queued Instructions=%u\n",
-            m_num_storequeued_insn[CURRENT_STAT_IDX][i]);
-    fprintf(fout, "\tTotal IALU Acesses=%u\n",
-            m_num_ialu_acesses[CURRENT_STAT_IDX][i]);
-    fprintf(fout, "\tTotal FP Acesses=%u\n",
-            m_num_fp_acesses[CURRENT_STAT_IDX][i]);
-    fprintf(fout, "\tTotal IMUL Acesses=%u\n",
-            m_num_imul_acesses[CURRENT_STAT_IDX][i]);
-    fprintf(fout, "\tTotal IMUL24 Acesses=%u\n",
-            m_num_imul24_acesses[CURRENT_STAT_IDX][i]);
-    fprintf(fout, "\tTotal IMUL32 Acesses=%u\n",
-            m_num_imul32_acesses[CURRENT_STAT_IDX][i]);
-    fprintf(fout, "\tTotal IDIV Acesses=%u\n",
-            m_num_idiv_acesses[CURRENT_STAT_IDX][i]);
-    fprintf(fout, "\tTotal FPMUL Acesses=%u\n",
-            m_num_fpmul_acesses[CURRENT_STAT_IDX][i]);
-    fprintf(fout, "\tTotal SFU Acesses=%u\n",
-            m_num_trans_acesses[CURRENT_STAT_IDX][i]);
-    fprintf(fout, "\tTotal FPDIV Acesses=%u\n",
-            m_num_fpdiv_acesses[CURRENT_STAT_IDX][i]);
-    fprintf(fout, "\tTotal SFU Acesses=%u\n",
-            m_num_sfu_acesses[CURRENT_STAT_IDX][i]);
-    fprintf(fout, "\tTotal SP Acesses=%u\n",
-            m_num_sp_acesses[CURRENT_STAT_IDX][i]);
-    fprintf(fout, "\tTotal MEM Acesses=%u\n",
-            m_num_mem_acesses[CURRENT_STAT_IDX][i]);
-    fprintf(fout, "\tTotal SFU Commissions=%u\n",
-            m_num_sfu_committed[CURRENT_STAT_IDX][i]);
-    fprintf(fout, "\tTotal SP Commissions=%u\n",
-            m_num_sp_committed[CURRENT_STAT_IDX][i]);
-    fprintf(fout, "\tTotal MEM Commissions=%u\n",
-            m_num_mem_committed[CURRENT_STAT_IDX][i]);
-    fprintf(fout, "\tTotal REG Reads=%u\n",
-            m_read_regfile_acesses[CURRENT_STAT_IDX][i]);
-    fprintf(fout, "\tTotal REG Writes=%u\n",
-            m_write_regfile_acesses[CURRENT_STAT_IDX][i]);
-    fprintf(fout, "\tTotal NON REG=%u\n",
-            m_non_rf_operands[CURRENT_STAT_IDX][i]);
-  }
-}
-void power_core_stat_t::init() {
-  m_pipeline_duty_cycle[CURRENT_STAT_IDX] = m_core_stats->m_pipeline_duty_cycle;
-  m_num_decoded_insn[CURRENT_STAT_IDX] = m_core_stats->m_num_decoded_insn;
-  m_num_FPdecoded_insn[CURRENT_STAT_IDX] = m_core_stats->m_num_FPdecoded_insn;
-  m_num_INTdecoded_insn[CURRENT_STAT_IDX] = m_core_stats->m_num_INTdecoded_insn;
-  m_num_storequeued_insn[CURRENT_STAT_IDX] =
-      m_core_stats->m_num_storequeued_insn;
-  m_num_loadqueued_insn[CURRENT_STAT_IDX] = m_core_stats->m_num_loadqueued_insn;
-  m_num_ialu_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_ialu_acesses;
-  m_num_fp_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_fp_acesses;
-  m_num_imul_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_imul_acesses;
-  m_num_imul24_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_imul24_acesses;
-  m_num_imul32_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_imul32_acesses;
-  m_num_fpmul_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_fpmul_acesses;
-  m_num_idiv_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_idiv_acesses;
-  m_num_fpdiv_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_fpdiv_acesses;
-  m_num_sp_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_sp_acesses;
-  m_num_sfu_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_sfu_acesses;
-  m_num_trans_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_trans_acesses;
-  m_num_mem_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_mem_acesses;
-  m_num_sp_committed[CURRENT_STAT_IDX] = m_core_stats->m_num_sp_committed;
-  m_num_sfu_committed[CURRENT_STAT_IDX] = m_core_stats->m_num_sfu_committed;
-  m_num_mem_committed[CURRENT_STAT_IDX] = m_core_stats->m_num_mem_committed;
-  m_read_regfile_acesses[CURRENT_STAT_IDX] =
-      m_core_stats->m_read_regfile_acesses;
-  m_write_regfile_acesses[CURRENT_STAT_IDX] =
-      m_core_stats->m_write_regfile_acesses;
-  m_non_rf_operands[CURRENT_STAT_IDX] = m_core_stats->m_non_rf_operands;
-  m_active_sp_lanes[CURRENT_STAT_IDX] = m_core_stats->m_active_sp_lanes;
-  m_active_sfu_lanes[CURRENT_STAT_IDX] = m_core_stats->m_active_sfu_lanes;
-  m_num_tex_inst[CURRENT_STAT_IDX] = m_core_stats->m_num_tex_inst;
+power_core_stat_t::power_core_stat_t( const shader_core_config *shader_config, shader_core_stats *core_stats )
+{
+     	assert( shader_config->m_valid );
+        m_config = shader_config;
+        shader_core_power_stats_pod *pod = this;
+        memset(pod,0,sizeof(shader_core_power_stats_pod));
+        m_core_stats=core_stats;
 
-  m_pipeline_duty_cycle[PREV_STAT_IDX] =
-      (float *)calloc(m_config->num_shader(), sizeof(float));
-  m_num_decoded_insn[PREV_STAT_IDX] =
-      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
-  m_num_FPdecoded_insn[PREV_STAT_IDX] =
-      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
-  m_num_INTdecoded_insn[PREV_STAT_IDX] =
-      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
-  m_num_storequeued_insn[PREV_STAT_IDX] =
-      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
-  m_num_loadqueued_insn[PREV_STAT_IDX] =
-      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
-  m_num_ialu_acesses[PREV_STAT_IDX] =
-      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
-  m_num_fp_acesses[PREV_STAT_IDX] =
-      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
-  m_num_tex_inst[PREV_STAT_IDX] =
-      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
-  m_num_imul_acesses[PREV_STAT_IDX] =
-      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
-  m_num_imul24_acesses[PREV_STAT_IDX] =
-      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
-  m_num_imul32_acesses[PREV_STAT_IDX] =
-      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
-  m_num_fpmul_acesses[PREV_STAT_IDX] =
-      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
-  m_num_idiv_acesses[PREV_STAT_IDX] =
-      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
-  m_num_fpdiv_acesses[PREV_STAT_IDX] =
-      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
-  m_num_sp_acesses[PREV_STAT_IDX] =
-      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
-  m_num_sfu_acesses[PREV_STAT_IDX] =
-      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
-  m_num_trans_acesses[PREV_STAT_IDX] =
-      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
-  m_num_mem_acesses[PREV_STAT_IDX] =
-      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
-  m_num_sp_committed[PREV_STAT_IDX] =
-      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
-  m_num_sfu_committed[PREV_STAT_IDX] =
-      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
-  m_num_mem_committed[PREV_STAT_IDX] =
-      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
-  m_read_regfile_acesses[PREV_STAT_IDX] =
-      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
-  m_write_regfile_acesses[PREV_STAT_IDX] =
-      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
-  m_non_rf_operands[PREV_STAT_IDX] =
-      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
-  m_active_sp_lanes[PREV_STAT_IDX] =
-      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
-  m_active_sfu_lanes[PREV_STAT_IDX] =
-      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+        init();
+
 }
 
-void power_core_stat_t::save_stats() {
-  for (unsigned i = 0; i < m_config->num_shader(); ++i) {
-    m_pipeline_duty_cycle[PREV_STAT_IDX][i] =
-        m_pipeline_duty_cycle[CURRENT_STAT_IDX][i];
-    m_num_decoded_insn[PREV_STAT_IDX][i] =
-        m_num_decoded_insn[CURRENT_STAT_IDX][i];
-    m_num_FPdecoded_insn[PREV_STAT_IDX][i] =
-        m_num_FPdecoded_insn[CURRENT_STAT_IDX][i];
-    m_num_INTdecoded_insn[PREV_STAT_IDX][i] =
-        m_num_INTdecoded_insn[CURRENT_STAT_IDX][i];
-    m_num_storequeued_insn[PREV_STAT_IDX][i] =
-        m_num_storequeued_insn[CURRENT_STAT_IDX][i];
-    m_num_loadqueued_insn[PREV_STAT_IDX][i] =
-        m_num_loadqueued_insn[CURRENT_STAT_IDX][i];
-    m_num_ialu_acesses[PREV_STAT_IDX][i] =
-        m_num_ialu_acesses[CURRENT_STAT_IDX][i];
-    m_num_fp_acesses[PREV_STAT_IDX][i] = m_num_fp_acesses[CURRENT_STAT_IDX][i];
-    m_num_tex_inst[PREV_STAT_IDX][i] = m_num_tex_inst[CURRENT_STAT_IDX][i];
-    m_num_imul_acesses[PREV_STAT_IDX][i] =
-        m_num_imul_acesses[CURRENT_STAT_IDX][i];
-    m_num_imul24_acesses[PREV_STAT_IDX][i] =
-        m_num_imul24_acesses[CURRENT_STAT_IDX][i];
-    m_num_imul32_acesses[PREV_STAT_IDX][i] =
-        m_num_imul32_acesses[CURRENT_STAT_IDX][i];
-    m_num_fpmul_acesses[PREV_STAT_IDX][i] =
-        m_num_fpmul_acesses[CURRENT_STAT_IDX][i];
-    m_num_idiv_acesses[PREV_STAT_IDX][i] =
-        m_num_idiv_acesses[CURRENT_STAT_IDX][i];
-    m_num_fpdiv_acesses[PREV_STAT_IDX][i] =
-        m_num_fpdiv_acesses[CURRENT_STAT_IDX][i];
-    m_num_sp_acesses[PREV_STAT_IDX][i] = m_num_sp_acesses[CURRENT_STAT_IDX][i];
-    m_num_sfu_acesses[PREV_STAT_IDX][i] =
-        m_num_sfu_acesses[CURRENT_STAT_IDX][i];
-    m_num_trans_acesses[PREV_STAT_IDX][i] =
-        m_num_trans_acesses[CURRENT_STAT_IDX][i];
-    m_num_mem_acesses[PREV_STAT_IDX][i] =
-        m_num_mem_acesses[CURRENT_STAT_IDX][i];
-    m_num_sp_committed[PREV_STAT_IDX][i] =
-        m_num_sp_committed[CURRENT_STAT_IDX][i];
-    m_num_sfu_committed[PREV_STAT_IDX][i] =
-        m_num_sfu_committed[CURRENT_STAT_IDX][i];
-    m_num_mem_committed[PREV_STAT_IDX][i] =
-        m_num_mem_committed[CURRENT_STAT_IDX][i];
-    m_read_regfile_acesses[PREV_STAT_IDX][i] =
-        m_read_regfile_acesses[CURRENT_STAT_IDX][i];
-    m_write_regfile_acesses[PREV_STAT_IDX][i] =
-        m_write_regfile_acesses[CURRENT_STAT_IDX][i];
-    m_non_rf_operands[PREV_STAT_IDX][i] =
-        m_non_rf_operands[CURRENT_STAT_IDX][i];
-    m_active_sp_lanes[PREV_STAT_IDX][i] =
-        m_active_sp_lanes[CURRENT_STAT_IDX][i];
-    m_active_sfu_lanes[PREV_STAT_IDX][i] =
-        m_active_sfu_lanes[CURRENT_STAT_IDX][i];
-  }
+void power_core_stat_t::visualizer_print( gzFile visualizer_file )
+{
+
 }
 
-power_stat_t::power_stat_t(const shader_core_config *shader_config,
-                           float *average_pipeline_duty_cycle,
-                           float *active_sms, shader_core_stats *shader_stats,
-                           const memory_config *mem_config,
-                           memory_stats_t *memory_stats) {
-  assert(shader_config->m_valid);
-  assert(mem_config->m_valid);
-  pwr_core_stat = new power_core_stat_t(shader_config, shader_stats);
-  pwr_mem_stat = new power_mem_stat_t(mem_config, shader_config, memory_stats,
-                                      shader_stats);
-  m_average_pipeline_duty_cycle = average_pipeline_duty_cycle;
-  m_active_sms = active_sms;
-  m_config = shader_config;
-  m_mem_config = mem_config;
+void power_core_stat_t::print (FILE *fout)
+{
+	// per core statistics
+    fprintf(fout,"Power Metrics: \n");
+    for(unsigned i=0; i<m_config->num_shader();i++){
+        fprintf(fout,"core %u:\n",i);
+        fprintf(fout,"\tpipeline duty cycle =%f\n",m_pipeline_duty_cycle[CURRENT_STAT_IDX][i]);
+        fprintf(fout,"\tTotal Deocded Instructions=%u\n",m_num_decoded_insn[CURRENT_STAT_IDX][i]);
+        fprintf(fout,"\tTotal FP Deocded Instructions=%u\n",m_num_FPdecoded_insn[CURRENT_STAT_IDX][i]);
+        fprintf(fout,"\tTotal INT Deocded Instructions=%u\n",m_num_INTdecoded_insn[CURRENT_STAT_IDX][i]);
+        fprintf(fout,"\tTotal LOAD Queued Instructions=%u\n",m_num_loadqueued_insn[CURRENT_STAT_IDX][i]);
+        fprintf(fout,"\tTotal STORE Queued Instructions=%u\n",m_num_storequeued_insn[CURRENT_STAT_IDX][i]);
+        fprintf(fout,"\tTotal IALU Acesses=%u\n",m_num_ialu_acesses[CURRENT_STAT_IDX][i]);
+        fprintf(fout,"\tTotal FP Acesses=%u\n",m_num_fp_acesses[CURRENT_STAT_IDX][i]);
+        fprintf(fout,"\tTotal IMUL Acesses=%u\n",m_num_imul_acesses[CURRENT_STAT_IDX][i]);
+        fprintf(fout,"\tTotal IMUL24 Acesses=%u\n",m_num_imul24_acesses[CURRENT_STAT_IDX][i]);
+        fprintf(fout,"\tTotal IMUL32 Acesses=%u\n",m_num_imul32_acesses[CURRENT_STAT_IDX][i]);
+        fprintf(fout,"\tTotal IDIV Acesses=%u\n",m_num_idiv_acesses[CURRENT_STAT_IDX][i]);
+        fprintf(fout,"\tTotal FPMUL Acesses=%u\n",m_num_fpmul_acesses[CURRENT_STAT_IDX][i]);
+        fprintf(fout,"\tTotal SFU Acesses=%u\n",m_num_trans_acesses[CURRENT_STAT_IDX][i]);
+        fprintf(fout,"\tTotal FPDIV Acesses=%u\n",m_num_fpdiv_acesses[CURRENT_STAT_IDX][i]);
+        fprintf(fout,"\tTotal SFU Acesses=%u\n",m_num_sfu_acesses[CURRENT_STAT_IDX][i]);
+        fprintf(fout,"\tTotal SP Acesses=%u\n",m_num_sp_acesses[CURRENT_STAT_IDX][i]);
+        fprintf(fout,"\tTotal MEM Acesses=%u\n",m_num_mem_acesses[CURRENT_STAT_IDX][i]);
+        fprintf(fout,"\tTotal SFU Commissions=%u\n",m_num_sfu_committed[CURRENT_STAT_IDX][i]);
+        fprintf(fout,"\tTotal SP Commissions=%u\n",m_num_sp_committed[CURRENT_STAT_IDX][i]);
+        fprintf(fout,"\tTotal MEM Commissions=%u\n",m_num_mem_committed[CURRENT_STAT_IDX][i]);
+        fprintf(fout,"\tTotal REG Reads=%u\n",m_read_regfile_acesses[CURRENT_STAT_IDX][i]);
+        fprintf(fout,"\tTotal REG Writes=%u\n",m_write_regfile_acesses[CURRENT_STAT_IDX][i]);
+        fprintf(fout,"\tTotal NON REG=%u\n",m_non_rf_operands[CURRENT_STAT_IDX][i]);
+    }
+}
+void power_core_stat_t::init()
+{
+    m_pipeline_duty_cycle[CURRENT_STAT_IDX]=m_core_stats->m_pipeline_duty_cycle;
+    m_num_decoded_insn[CURRENT_STAT_IDX]=m_core_stats->m_num_decoded_insn;
+    m_num_FPdecoded_insn[CURRENT_STAT_IDX]=m_core_stats->m_num_FPdecoded_insn;
+    m_num_INTdecoded_insn[CURRENT_STAT_IDX]=m_core_stats->m_num_INTdecoded_insn;
+    m_num_storequeued_insn[CURRENT_STAT_IDX]=m_core_stats->m_num_storequeued_insn;
+    m_num_loadqueued_insn[CURRENT_STAT_IDX]=m_core_stats->m_num_loadqueued_insn;
+    m_num_ialu_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_ialu_acesses;
+    m_num_fp_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_fp_acesses;
+    m_num_imul_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_imul_acesses;
+    m_num_imul24_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_imul24_acesses;
+    m_num_imul32_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_imul32_acesses;
+    m_num_fpmul_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_fpmul_acesses;
+    m_num_idiv_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_idiv_acesses;
+    m_num_fpdiv_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_fpdiv_acesses;
+    m_num_sp_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_sp_acesses;
+    m_num_sfu_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_sfu_acesses;
+    m_num_trans_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_trans_acesses;
+    m_num_mem_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_mem_acesses;
+    m_num_sp_committed[CURRENT_STAT_IDX]=m_core_stats->m_num_sp_committed;
+    m_num_sfu_committed[CURRENT_STAT_IDX]=m_core_stats->m_num_sfu_committed;
+    m_num_mem_committed[CURRENT_STAT_IDX]=m_core_stats->m_num_mem_committed;
+    m_read_regfile_acesses[CURRENT_STAT_IDX]=m_core_stats->m_read_regfile_acesses;
+    m_write_regfile_acesses[CURRENT_STAT_IDX]=m_core_stats->m_write_regfile_acesses;
+    m_non_rf_operands[CURRENT_STAT_IDX]=m_core_stats->m_non_rf_operands;
+    m_active_sp_lanes[CURRENT_STAT_IDX]=m_core_stats->m_active_sp_lanes;
+    m_active_sfu_lanes[CURRENT_STAT_IDX]=m_core_stats->m_active_sfu_lanes;
+    m_num_tex_inst[CURRENT_STAT_IDX]=m_core_stats->m_num_tex_inst;
+
+
+    m_pipeline_duty_cycle[PREV_STAT_IDX]=(float*)calloc(m_config->num_shader(),sizeof(float));
+    m_num_decoded_insn[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
+    m_num_FPdecoded_insn[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
+    m_num_INTdecoded_insn[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
+    m_num_storequeued_insn[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
+    m_num_loadqueued_insn[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
+    m_num_ialu_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
+    m_num_fp_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
+    m_num_tex_inst[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
+    m_num_imul_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
+    m_num_imul24_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
+    m_num_imul32_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
+    m_num_fpmul_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
+    m_num_idiv_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
+    m_num_fpdiv_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
+    m_num_sp_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
+    m_num_sfu_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
+    m_num_trans_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
+    m_num_mem_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
+    m_num_sp_committed[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
+    m_num_sfu_committed[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
+    m_num_mem_committed[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
+    m_read_regfile_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
+    m_write_regfile_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
+    m_non_rf_operands[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
+    m_active_sp_lanes[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
+    m_active_sfu_lanes[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
 }
 
-void power_stat_t::visualizer_print(gzFile visualizer_file) {
-  pwr_core_stat->visualizer_print(visualizer_file);
-  pwr_mem_stat->visualizer_print(visualizer_file);
+void power_core_stat_t::save_stats(){
+for(unsigned i=0; i<m_config->num_shader(); ++i){
+    m_pipeline_duty_cycle[PREV_STAT_IDX][i]=m_pipeline_duty_cycle[CURRENT_STAT_IDX][i];
+    m_num_decoded_insn[PREV_STAT_IDX][i]=	m_num_decoded_insn[CURRENT_STAT_IDX][i];
+    m_num_FPdecoded_insn[PREV_STAT_IDX][i]=m_num_FPdecoded_insn[CURRENT_STAT_IDX][i];
+    m_num_INTdecoded_insn[PREV_STAT_IDX][i]=m_num_INTdecoded_insn[CURRENT_STAT_IDX][i];
+    m_num_storequeued_insn[PREV_STAT_IDX][i]=m_num_storequeued_insn[CURRENT_STAT_IDX][i];
+    m_num_loadqueued_insn[PREV_STAT_IDX][i]=m_num_loadqueued_insn[CURRENT_STAT_IDX][i];
+    m_num_ialu_acesses[PREV_STAT_IDX][i]=m_num_ialu_acesses[CURRENT_STAT_IDX][i];
+    m_num_fp_acesses[PREV_STAT_IDX][i]=m_num_fp_acesses[CURRENT_STAT_IDX][i];
+    m_num_tex_inst[PREV_STAT_IDX][i]=m_num_tex_inst[CURRENT_STAT_IDX][i];
+    m_num_imul_acesses[PREV_STAT_IDX][i]=m_num_imul_acesses[CURRENT_STAT_IDX][i];
+    m_num_imul24_acesses[PREV_STAT_IDX][i]=m_num_imul24_acesses[CURRENT_STAT_IDX][i];
+    m_num_imul32_acesses[PREV_STAT_IDX][i]=m_num_imul32_acesses[CURRENT_STAT_IDX][i];
+    m_num_fpmul_acesses[PREV_STAT_IDX][i]=m_num_fpmul_acesses[CURRENT_STAT_IDX][i];
+    m_num_idiv_acesses[PREV_STAT_IDX][i]=m_num_idiv_acesses[CURRENT_STAT_IDX][i];
+    m_num_fpdiv_acesses[PREV_STAT_IDX][i]=m_num_fpdiv_acesses[CURRENT_STAT_IDX][i];
+    m_num_sp_acesses[PREV_STAT_IDX][i]=m_num_sp_acesses[CURRENT_STAT_IDX][i];
+    m_num_sfu_acesses[PREV_STAT_IDX][i]=m_num_sfu_acesses[CURRENT_STAT_IDX][i];
+    m_num_trans_acesses[PREV_STAT_IDX][i]=m_num_trans_acesses[CURRENT_STAT_IDX][i];
+    m_num_mem_acesses[PREV_STAT_IDX][i]=m_num_mem_acesses[CURRENT_STAT_IDX][i];
+    m_num_sp_committed[PREV_STAT_IDX][i]=m_num_sp_committed[CURRENT_STAT_IDX][i];
+    m_num_sfu_committed[PREV_STAT_IDX][i]=m_num_sfu_committed[CURRENT_STAT_IDX][i];
+    m_num_mem_committed[PREV_STAT_IDX][i]=m_num_mem_committed[CURRENT_STAT_IDX][i];
+    m_read_regfile_acesses[PREV_STAT_IDX][i]=m_read_regfile_acesses[CURRENT_STAT_IDX][i];
+    m_write_regfile_acesses[PREV_STAT_IDX][i]=m_write_regfile_acesses[CURRENT_STAT_IDX][i];
+    m_non_rf_operands[PREV_STAT_IDX][i]=m_non_rf_operands[CURRENT_STAT_IDX][i];
+    m_active_sp_lanes[PREV_STAT_IDX][i]=m_active_sp_lanes[CURRENT_STAT_IDX][i];
+    m_active_sfu_lanes[PREV_STAT_IDX][i]=m_active_sfu_lanes[CURRENT_STAT_IDX][i];
+    }
 }
 
-void power_stat_t::print(FILE *fout) const {
-  fprintf(fout, "average_pipeline_duty_cycle=%f\n",
-          *m_average_pipeline_duty_cycle);
-  pwr_core_stat->print(fout);
-  pwr_mem_stat->print(fout);
+power_stat_t::power_stat_t( const shader_core_config *shader_config,float * average_pipeline_duty_cycle,float *active_sms,shader_core_stats * shader_stats, const memory_config *mem_config,memory_stats_t * memory_stats)
+{
+	assert( shader_config->m_valid );
+	assert( mem_config->m_valid );
+	pwr_core_stat= new power_core_stat_t(shader_config,shader_stats);
+	pwr_mem_stat= new power_mem_stat_t(mem_config,shader_config, memory_stats, shader_stats);
+	m_average_pipeline_duty_cycle=average_pipeline_duty_cycle;
+	m_active_sms=active_sms;
+	m_config = shader_config;
+	m_mem_config = mem_config;
 }
+
+void power_stat_t::visualizer_print( gzFile visualizer_file )
+{
+	pwr_core_stat->visualizer_print(visualizer_file);
+	pwr_mem_stat->visualizer_print(visualizer_file);
+}
+
+void power_stat_t::print (FILE *fout) const
+{
+	fprintf(fout,"average_pipeline_duty_cycle=%f\n",*m_average_pipeline_duty_cycle);
+	pwr_core_stat->print(fout);
+	pwr_mem_stat->print(fout);
+}
+

--- a/src/gpgpu-sim/power_stat.cc
+++ b/src/gpgpu-sim/power_stat.cc
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -25,269 +27,346 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "../abstract_hardware_model.h"
 #include "power_stat.h"
-#include "gpu-sim.h"
-#include "gpu-misc.h"
-#include "shader.h"
-#include "mem_fetch.h"
-#include "stat-tool.h"
+#include "../abstract_hardware_model.h"
 #include "../cuda-sim/ptx-stats.h"
-#include "visualizer.h"
 #include "dram.h"
+#include "gpu-misc.h"
+#include "gpu-sim.h"
+#include "mem_fetch.h"
+#include "shader.h"
+#include "stat-tool.h"
+#include "visualizer.h"
 
-#include <string.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
+power_mem_stat_t::power_mem_stat_t(const memory_config *mem_config,
+                                   const shader_core_config *shdr_config,
+                                   memory_stats_t *mem_stats,
+                                   shader_core_stats *shdr_stats) {
+  assert(mem_config->m_valid);
+  m_mem_stats = mem_stats;
+  m_config = mem_config;
+  m_core_stats = shdr_stats;
+  m_core_config = shdr_config;
 
-
-power_mem_stat_t::power_mem_stat_t(const memory_config *mem_config, const shader_core_config *shdr_config, memory_stats_t *mem_stats, shader_core_stats *shdr_stats){
-	   assert( mem_config->m_valid );
-	   m_mem_stats = mem_stats;
-	   m_config = mem_config;
-	   m_core_stats = shdr_stats;
-	   m_core_config = shdr_config;
-
-	   init();
+  init();
 }
 
-void power_mem_stat_t::init(){
+void power_mem_stat_t::init() {
+  shmem_read_access[CURRENT_STAT_IDX] =
+      m_core_stats->gpgpu_n_shmem_bank_access;  // Shared memory access
+  shmem_read_access[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_core_config->num_shader(), sizeof(unsigned));
 
-    shmem_read_access[CURRENT_STAT_IDX] = m_core_stats->gpgpu_n_shmem_bank_access; 	// Shared memory access
-    shmem_read_access[PREV_STAT_IDX] = (unsigned *)calloc(m_core_config->num_shader(),sizeof(unsigned));
+  for (unsigned i = 0; i < NUM_STAT_IDX; ++i) {
+    core_cache_stats[i].clear();
+    l2_cache_stats[i].clear();
 
-    for(unsigned i=0; i<NUM_STAT_IDX; ++i){
-        core_cache_stats[i].clear();
-        l2_cache_stats[i].clear();
+    n_cmd[i] = (unsigned *)calloc(m_config->m_n_mem, sizeof(unsigned));
+    n_activity[i] = (unsigned *)calloc(m_config->m_n_mem, sizeof(unsigned));
+    n_nop[i] = (unsigned *)calloc(m_config->m_n_mem, sizeof(unsigned));
+    n_act[i] = (unsigned *)calloc(m_config->m_n_mem, sizeof(unsigned));
+    n_pre[i] = (unsigned *)calloc(m_config->m_n_mem, sizeof(unsigned));
+    n_rd[i] = (unsigned *)calloc(m_config->m_n_mem, sizeof(unsigned));
+    n_wr[i] = (unsigned *)calloc(m_config->m_n_mem, sizeof(unsigned));
+    n_req[i] = (unsigned *)calloc(m_config->m_n_mem, sizeof(unsigned));
 
-        n_cmd[i] = (unsigned *)calloc(m_config->m_n_mem,sizeof(unsigned));
-        n_activity[i] = (unsigned *)calloc(m_config->m_n_mem,sizeof(unsigned));
-        n_nop[i] = (unsigned *)calloc(m_config->m_n_mem,sizeof(unsigned));
-        n_act[i] = (unsigned *)calloc(m_config->m_n_mem,sizeof(unsigned));
-        n_pre[i] = (unsigned *)calloc(m_config->m_n_mem,sizeof(unsigned));
-        n_rd[i] = (unsigned *)calloc(m_config->m_n_mem,sizeof(unsigned));
-        n_wr[i] = (unsigned *)calloc(m_config->m_n_mem,sizeof(unsigned));
-        n_req[i] = (unsigned *)calloc(m_config->m_n_mem,sizeof(unsigned));
-
-        // Interconnect stats
-        n_mem_to_simt[i] = (long *)calloc(m_core_config->n_simt_clusters,sizeof(long)); // Counted at SM
-        n_simt_to_mem[i] = (long *)calloc(m_core_config->n_simt_clusters,sizeof(long)); // Counted at SM
-    }
+    // Interconnect stats
+    n_mem_to_simt[i] = (long *)calloc(m_core_config->n_simt_clusters,
+                                      sizeof(long));  // Counted at SM
+    n_simt_to_mem[i] = (long *)calloc(m_core_config->n_simt_clusters,
+                                      sizeof(long));  // Counted at SM
+  }
 }
 
-void power_mem_stat_t::save_stats(){
+void power_mem_stat_t::save_stats() {
+  core_cache_stats[PREV_STAT_IDX] = core_cache_stats[CURRENT_STAT_IDX];
+  l2_cache_stats[PREV_STAT_IDX] = l2_cache_stats[CURRENT_STAT_IDX];
 
-    core_cache_stats[PREV_STAT_IDX] = core_cache_stats[CURRENT_STAT_IDX];
-    l2_cache_stats[PREV_STAT_IDX] = l2_cache_stats[CURRENT_STAT_IDX];
+  for (unsigned i = 0; i < m_core_config->num_shader(); ++i) {
+    shmem_read_access[PREV_STAT_IDX][i] =
+        shmem_read_access[CURRENT_STAT_IDX][i];  // Shared memory access
+  }
 
-    for(unsigned i=0; i<m_core_config->num_shader(); ++i){
-        shmem_read_access[PREV_STAT_IDX][i] = shmem_read_access[CURRENT_STAT_IDX][i] ; 	// Shared memory access
-    }
+  for (unsigned i = 0; i < m_config->m_n_mem; ++i) {
+    n_cmd[PREV_STAT_IDX][i] = n_cmd[CURRENT_STAT_IDX][i];
+    n_activity[PREV_STAT_IDX][i] = n_activity[CURRENT_STAT_IDX][i];
+    n_nop[PREV_STAT_IDX][i] = n_nop[CURRENT_STAT_IDX][i];
+    n_act[PREV_STAT_IDX][i] = n_act[CURRENT_STAT_IDX][i];
+    n_pre[PREV_STAT_IDX][i] = n_pre[CURRENT_STAT_IDX][i];
+    n_rd[PREV_STAT_IDX][i] = n_rd[CURRENT_STAT_IDX][i];
+    n_wr[PREV_STAT_IDX][i] = n_wr[CURRENT_STAT_IDX][i];
+    n_req[PREV_STAT_IDX][i] = n_req[CURRENT_STAT_IDX][i];
+  }
 
-    for(unsigned i=0; i<m_config->m_n_mem; ++i){
-        n_cmd[PREV_STAT_IDX][i] = n_cmd[CURRENT_STAT_IDX][i];
-        n_activity[PREV_STAT_IDX][i] = n_activity[CURRENT_STAT_IDX][i];
-        n_nop[PREV_STAT_IDX][i] = n_nop[CURRENT_STAT_IDX][i];
-        n_act[PREV_STAT_IDX][i] = n_act[CURRENT_STAT_IDX][i];
-        n_pre[PREV_STAT_IDX][i] = n_pre[CURRENT_STAT_IDX][i];
-        n_rd[PREV_STAT_IDX][i] = n_rd[CURRENT_STAT_IDX][i];
-        n_wr[PREV_STAT_IDX][i] = n_wr[CURRENT_STAT_IDX][i];
-        n_req[PREV_STAT_IDX][i] = n_req[CURRENT_STAT_IDX][i];
-    }
-
-    for(unsigned i=0; i<m_core_config->n_simt_clusters;i++){
-        n_simt_to_mem[PREV_STAT_IDX][i] = n_simt_to_mem[CURRENT_STAT_IDX][i]; // Interconnect
-        n_mem_to_simt[PREV_STAT_IDX][i] = n_mem_to_simt[CURRENT_STAT_IDX][i]; // Interconnect
-    }
+  for (unsigned i = 0; i < m_core_config->n_simt_clusters; i++) {
+    n_simt_to_mem[PREV_STAT_IDX][i] =
+        n_simt_to_mem[CURRENT_STAT_IDX][i];  // Interconnect
+    n_mem_to_simt[PREV_STAT_IDX][i] =
+        n_mem_to_simt[CURRENT_STAT_IDX][i];  // Interconnect
+  }
 }
 
-void power_mem_stat_t::visualizer_print( gzFile power_visualizer_file ){
+void power_mem_stat_t::visualizer_print(gzFile power_visualizer_file) {}
 
+void power_mem_stat_t::print(FILE *fout) const {
+  fprintf(fout, "\n\n==========Power Metrics -- Memory==========\n");
+  unsigned total_mem_reads = 0;
+  unsigned total_mem_writes = 0;
+  for (unsigned i = 0; i < m_config->m_n_mem; ++i) {
+    total_mem_reads += n_rd[CURRENT_STAT_IDX][i];
+    total_mem_writes += n_wr[CURRENT_STAT_IDX][i];
+  }
+  fprintf(fout, "Total memory controller accesses: %u\n",
+          total_mem_reads + total_mem_writes);
+  fprintf(fout, "Total memory controller reads: %u\n", total_mem_reads);
+  fprintf(fout, "Total memory controller writes: %u\n", total_mem_writes);
+
+  fprintf(fout, "Core cache stats:\n");
+  core_cache_stats->print_stats(fout);
+  fprintf(fout, "L2 cache stats:\n");
+  l2_cache_stats->print_stats(fout);
 }
 
-void power_mem_stat_t::print (FILE *fout) const {
-	fprintf(fout, "\n\n==========Power Metrics -- Memory==========\n");
-    unsigned total_mem_reads=0;
-    unsigned total_mem_writes=0;
-    for(unsigned i=0; i<m_config->m_n_mem; ++i){
-        total_mem_reads += n_rd[CURRENT_STAT_IDX][i];
-        total_mem_writes += n_wr[CURRENT_STAT_IDX][i];
-    }
-    fprintf(fout, "Total memory controller accesses: %u\n", total_mem_reads+total_mem_writes);
-    fprintf(fout, "Total memory controller reads: %u\n", total_mem_reads);
-    fprintf(fout, "Total memory controller writes: %u\n", total_mem_writes);
+power_core_stat_t::power_core_stat_t(const shader_core_config *shader_config,
+                                     shader_core_stats *core_stats) {
+  assert(shader_config->m_valid);
+  m_config = shader_config;
+  shader_core_power_stats_pod *pod = this;
+  memset(pod, 0, sizeof(shader_core_power_stats_pod));
+  m_core_stats = core_stats;
 
-    fprintf(fout, "Core cache stats:\n");
-    core_cache_stats->print_stats(fout);
-    fprintf(fout, "L2 cache stats:\n");
-    l2_cache_stats->print_stats(fout);
+  init();
 }
 
+void power_core_stat_t::visualizer_print(gzFile visualizer_file) {}
 
-power_core_stat_t::power_core_stat_t( const shader_core_config *shader_config, shader_core_stats *core_stats )
-{
-     	assert( shader_config->m_valid );
-        m_config = shader_config;
-        shader_core_power_stats_pod *pod = this;
-        memset(pod,0,sizeof(shader_core_power_stats_pod));
-        m_core_stats=core_stats;
+void power_core_stat_t::print(FILE *fout) {
+  // per core statistics
+  fprintf(fout, "Power Metrics: \n");
+  for (unsigned i = 0; i < m_config->num_shader(); i++) {
+    fprintf(fout, "core %u:\n", i);
+    fprintf(fout, "\tpipeline duty cycle =%f\n",
+            m_pipeline_duty_cycle[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal Deocded Instructions=%u\n",
+            m_num_decoded_insn[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal FP Deocded Instructions=%u\n",
+            m_num_FPdecoded_insn[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal INT Deocded Instructions=%u\n",
+            m_num_INTdecoded_insn[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal LOAD Queued Instructions=%u\n",
+            m_num_loadqueued_insn[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal STORE Queued Instructions=%u\n",
+            m_num_storequeued_insn[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal IALU Acesses=%u\n",
+            m_num_ialu_acesses[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal FP Acesses=%u\n",
+            m_num_fp_acesses[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal IMUL Acesses=%u\n",
+            m_num_imul_acesses[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal IMUL24 Acesses=%u\n",
+            m_num_imul24_acesses[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal IMUL32 Acesses=%u\n",
+            m_num_imul32_acesses[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal IDIV Acesses=%u\n",
+            m_num_idiv_acesses[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal FPMUL Acesses=%u\n",
+            m_num_fpmul_acesses[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal SFU Acesses=%u\n",
+            m_num_trans_acesses[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal FPDIV Acesses=%u\n",
+            m_num_fpdiv_acesses[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal SFU Acesses=%u\n",
+            m_num_sfu_acesses[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal SP Acesses=%u\n",
+            m_num_sp_acesses[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal MEM Acesses=%u\n",
+            m_num_mem_acesses[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal SFU Commissions=%u\n",
+            m_num_sfu_committed[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal SP Commissions=%u\n",
+            m_num_sp_committed[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal MEM Commissions=%u\n",
+            m_num_mem_committed[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal REG Reads=%u\n",
+            m_read_regfile_acesses[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal REG Writes=%u\n",
+            m_write_regfile_acesses[CURRENT_STAT_IDX][i]);
+    fprintf(fout, "\tTotal NON REG=%u\n",
+            m_non_rf_operands[CURRENT_STAT_IDX][i]);
+  }
+}
+void power_core_stat_t::init() {
+  m_pipeline_duty_cycle[CURRENT_STAT_IDX] = m_core_stats->m_pipeline_duty_cycle;
+  m_num_decoded_insn[CURRENT_STAT_IDX] = m_core_stats->m_num_decoded_insn;
+  m_num_FPdecoded_insn[CURRENT_STAT_IDX] = m_core_stats->m_num_FPdecoded_insn;
+  m_num_INTdecoded_insn[CURRENT_STAT_IDX] = m_core_stats->m_num_INTdecoded_insn;
+  m_num_storequeued_insn[CURRENT_STAT_IDX] =
+      m_core_stats->m_num_storequeued_insn;
+  m_num_loadqueued_insn[CURRENT_STAT_IDX] = m_core_stats->m_num_loadqueued_insn;
+  m_num_ialu_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_ialu_acesses;
+  m_num_fp_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_fp_acesses;
+  m_num_imul_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_imul_acesses;
+  m_num_imul24_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_imul24_acesses;
+  m_num_imul32_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_imul32_acesses;
+  m_num_fpmul_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_fpmul_acesses;
+  m_num_idiv_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_idiv_acesses;
+  m_num_fpdiv_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_fpdiv_acesses;
+  m_num_sp_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_sp_acesses;
+  m_num_sfu_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_sfu_acesses;
+  m_num_trans_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_trans_acesses;
+  m_num_mem_acesses[CURRENT_STAT_IDX] = m_core_stats->m_num_mem_acesses;
+  m_num_sp_committed[CURRENT_STAT_IDX] = m_core_stats->m_num_sp_committed;
+  m_num_sfu_committed[CURRENT_STAT_IDX] = m_core_stats->m_num_sfu_committed;
+  m_num_mem_committed[CURRENT_STAT_IDX] = m_core_stats->m_num_mem_committed;
+  m_read_regfile_acesses[CURRENT_STAT_IDX] =
+      m_core_stats->m_read_regfile_acesses;
+  m_write_regfile_acesses[CURRENT_STAT_IDX] =
+      m_core_stats->m_write_regfile_acesses;
+  m_non_rf_operands[CURRENT_STAT_IDX] = m_core_stats->m_non_rf_operands;
+  m_active_sp_lanes[CURRENT_STAT_IDX] = m_core_stats->m_active_sp_lanes;
+  m_active_sfu_lanes[CURRENT_STAT_IDX] = m_core_stats->m_active_sfu_lanes;
+  m_num_tex_inst[CURRENT_STAT_IDX] = m_core_stats->m_num_tex_inst;
 
-        init();
-
+  m_pipeline_duty_cycle[PREV_STAT_IDX] =
+      (float *)calloc(m_config->num_shader(), sizeof(float));
+  m_num_decoded_insn[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_FPdecoded_insn[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_INTdecoded_insn[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_storequeued_insn[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_loadqueued_insn[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_ialu_acesses[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_fp_acesses[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_tex_inst[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_imul_acesses[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_imul24_acesses[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_imul32_acesses[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_fpmul_acesses[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_idiv_acesses[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_fpdiv_acesses[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_sp_acesses[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_sfu_acesses[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_trans_acesses[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_mem_acesses[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_sp_committed[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_sfu_committed[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_num_mem_committed[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_read_regfile_acesses[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_write_regfile_acesses[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_non_rf_operands[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_active_sp_lanes[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
+  m_active_sfu_lanes[PREV_STAT_IDX] =
+      (unsigned *)calloc(m_config->num_shader(), sizeof(unsigned));
 }
 
-void power_core_stat_t::visualizer_print( gzFile visualizer_file )
-{
-
+void power_core_stat_t::save_stats() {
+  for (unsigned i = 0; i < m_config->num_shader(); ++i) {
+    m_pipeline_duty_cycle[PREV_STAT_IDX][i] =
+        m_pipeline_duty_cycle[CURRENT_STAT_IDX][i];
+    m_num_decoded_insn[PREV_STAT_IDX][i] =
+        m_num_decoded_insn[CURRENT_STAT_IDX][i];
+    m_num_FPdecoded_insn[PREV_STAT_IDX][i] =
+        m_num_FPdecoded_insn[CURRENT_STAT_IDX][i];
+    m_num_INTdecoded_insn[PREV_STAT_IDX][i] =
+        m_num_INTdecoded_insn[CURRENT_STAT_IDX][i];
+    m_num_storequeued_insn[PREV_STAT_IDX][i] =
+        m_num_storequeued_insn[CURRENT_STAT_IDX][i];
+    m_num_loadqueued_insn[PREV_STAT_IDX][i] =
+        m_num_loadqueued_insn[CURRENT_STAT_IDX][i];
+    m_num_ialu_acesses[PREV_STAT_IDX][i] =
+        m_num_ialu_acesses[CURRENT_STAT_IDX][i];
+    m_num_fp_acesses[PREV_STAT_IDX][i] = m_num_fp_acesses[CURRENT_STAT_IDX][i];
+    m_num_tex_inst[PREV_STAT_IDX][i] = m_num_tex_inst[CURRENT_STAT_IDX][i];
+    m_num_imul_acesses[PREV_STAT_IDX][i] =
+        m_num_imul_acesses[CURRENT_STAT_IDX][i];
+    m_num_imul24_acesses[PREV_STAT_IDX][i] =
+        m_num_imul24_acesses[CURRENT_STAT_IDX][i];
+    m_num_imul32_acesses[PREV_STAT_IDX][i] =
+        m_num_imul32_acesses[CURRENT_STAT_IDX][i];
+    m_num_fpmul_acesses[PREV_STAT_IDX][i] =
+        m_num_fpmul_acesses[CURRENT_STAT_IDX][i];
+    m_num_idiv_acesses[PREV_STAT_IDX][i] =
+        m_num_idiv_acesses[CURRENT_STAT_IDX][i];
+    m_num_fpdiv_acesses[PREV_STAT_IDX][i] =
+        m_num_fpdiv_acesses[CURRENT_STAT_IDX][i];
+    m_num_sp_acesses[PREV_STAT_IDX][i] = m_num_sp_acesses[CURRENT_STAT_IDX][i];
+    m_num_sfu_acesses[PREV_STAT_IDX][i] =
+        m_num_sfu_acesses[CURRENT_STAT_IDX][i];
+    m_num_trans_acesses[PREV_STAT_IDX][i] =
+        m_num_trans_acesses[CURRENT_STAT_IDX][i];
+    m_num_mem_acesses[PREV_STAT_IDX][i] =
+        m_num_mem_acesses[CURRENT_STAT_IDX][i];
+    m_num_sp_committed[PREV_STAT_IDX][i] =
+        m_num_sp_committed[CURRENT_STAT_IDX][i];
+    m_num_sfu_committed[PREV_STAT_IDX][i] =
+        m_num_sfu_committed[CURRENT_STAT_IDX][i];
+    m_num_mem_committed[PREV_STAT_IDX][i] =
+        m_num_mem_committed[CURRENT_STAT_IDX][i];
+    m_read_regfile_acesses[PREV_STAT_IDX][i] =
+        m_read_regfile_acesses[CURRENT_STAT_IDX][i];
+    m_write_regfile_acesses[PREV_STAT_IDX][i] =
+        m_write_regfile_acesses[CURRENT_STAT_IDX][i];
+    m_non_rf_operands[PREV_STAT_IDX][i] =
+        m_non_rf_operands[CURRENT_STAT_IDX][i];
+    m_active_sp_lanes[PREV_STAT_IDX][i] =
+        m_active_sp_lanes[CURRENT_STAT_IDX][i];
+    m_active_sfu_lanes[PREV_STAT_IDX][i] =
+        m_active_sfu_lanes[CURRENT_STAT_IDX][i];
+  }
 }
 
-void power_core_stat_t::print (FILE *fout)
-{
-	// per core statistics
-    fprintf(fout,"Power Metrics: \n");
-    for(unsigned i=0; i<m_config->num_shader();i++){
-        fprintf(fout,"core %u:\n",i);
-        fprintf(fout,"\tpipeline duty cycle =%f\n",m_pipeline_duty_cycle[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal Deocded Instructions=%u\n",m_num_decoded_insn[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal FP Deocded Instructions=%u\n",m_num_FPdecoded_insn[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal INT Deocded Instructions=%u\n",m_num_INTdecoded_insn[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal LOAD Queued Instructions=%u\n",m_num_loadqueued_insn[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal STORE Queued Instructions=%u\n",m_num_storequeued_insn[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal IALU Acesses=%u\n",m_num_ialu_acesses[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal FP Acesses=%u\n",m_num_fp_acesses[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal IMUL Acesses=%u\n",m_num_imul_acesses[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal IMUL24 Acesses=%u\n",m_num_imul24_acesses[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal IMUL32 Acesses=%u\n",m_num_imul32_acesses[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal IDIV Acesses=%u\n",m_num_idiv_acesses[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal FPMUL Acesses=%u\n",m_num_fpmul_acesses[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal SFU Acesses=%u\n",m_num_trans_acesses[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal FPDIV Acesses=%u\n",m_num_fpdiv_acesses[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal SFU Acesses=%u\n",m_num_sfu_acesses[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal SP Acesses=%u\n",m_num_sp_acesses[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal MEM Acesses=%u\n",m_num_mem_acesses[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal SFU Commissions=%u\n",m_num_sfu_committed[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal SP Commissions=%u\n",m_num_sp_committed[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal MEM Commissions=%u\n",m_num_mem_committed[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal REG Reads=%u\n",m_read_regfile_acesses[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal REG Writes=%u\n",m_write_regfile_acesses[CURRENT_STAT_IDX][i]);
-        fprintf(fout,"\tTotal NON REG=%u\n",m_non_rf_operands[CURRENT_STAT_IDX][i]);
-    }
-}
-void power_core_stat_t::init()
-{
-    m_pipeline_duty_cycle[CURRENT_STAT_IDX]=m_core_stats->m_pipeline_duty_cycle;
-    m_num_decoded_insn[CURRENT_STAT_IDX]=m_core_stats->m_num_decoded_insn;
-    m_num_FPdecoded_insn[CURRENT_STAT_IDX]=m_core_stats->m_num_FPdecoded_insn;
-    m_num_INTdecoded_insn[CURRENT_STAT_IDX]=m_core_stats->m_num_INTdecoded_insn;
-    m_num_storequeued_insn[CURRENT_STAT_IDX]=m_core_stats->m_num_storequeued_insn;
-    m_num_loadqueued_insn[CURRENT_STAT_IDX]=m_core_stats->m_num_loadqueued_insn;
-    m_num_ialu_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_ialu_acesses;
-    m_num_fp_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_fp_acesses;
-    m_num_imul_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_imul_acesses;
-    m_num_imul24_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_imul24_acesses;
-    m_num_imul32_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_imul32_acesses;
-    m_num_fpmul_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_fpmul_acesses;
-    m_num_idiv_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_idiv_acesses;
-    m_num_fpdiv_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_fpdiv_acesses;
-    m_num_sp_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_sp_acesses;
-    m_num_sfu_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_sfu_acesses;
-    m_num_trans_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_trans_acesses;
-    m_num_mem_acesses[CURRENT_STAT_IDX]=m_core_stats->m_num_mem_acesses;
-    m_num_sp_committed[CURRENT_STAT_IDX]=m_core_stats->m_num_sp_committed;
-    m_num_sfu_committed[CURRENT_STAT_IDX]=m_core_stats->m_num_sfu_committed;
-    m_num_mem_committed[CURRENT_STAT_IDX]=m_core_stats->m_num_mem_committed;
-    m_read_regfile_acesses[CURRENT_STAT_IDX]=m_core_stats->m_read_regfile_acesses;
-    m_write_regfile_acesses[CURRENT_STAT_IDX]=m_core_stats->m_write_regfile_acesses;
-    m_non_rf_operands[CURRENT_STAT_IDX]=m_core_stats->m_non_rf_operands;
-    m_active_sp_lanes[CURRENT_STAT_IDX]=m_core_stats->m_active_sp_lanes;
-    m_active_sfu_lanes[CURRENT_STAT_IDX]=m_core_stats->m_active_sfu_lanes;
-    m_num_tex_inst[CURRENT_STAT_IDX]=m_core_stats->m_num_tex_inst;
-
-
-    m_pipeline_duty_cycle[PREV_STAT_IDX]=(float*)calloc(m_config->num_shader(),sizeof(float));
-    m_num_decoded_insn[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_FPdecoded_insn[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_INTdecoded_insn[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_storequeued_insn[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_loadqueued_insn[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_ialu_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_fp_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_tex_inst[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_imul_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_imul24_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_imul32_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_fpmul_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_idiv_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_fpdiv_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_sp_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_sfu_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_trans_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_mem_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_sp_committed[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_sfu_committed[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_num_mem_committed[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_read_regfile_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_write_regfile_acesses[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_non_rf_operands[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_active_sp_lanes[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
-    m_active_sfu_lanes[PREV_STAT_IDX]=(unsigned *)calloc(m_config->num_shader(),sizeof(unsigned));
+power_stat_t::power_stat_t(const shader_core_config *shader_config,
+                           float *average_pipeline_duty_cycle,
+                           float *active_sms, shader_core_stats *shader_stats,
+                           const memory_config *mem_config,
+                           memory_stats_t *memory_stats) {
+  assert(shader_config->m_valid);
+  assert(mem_config->m_valid);
+  pwr_core_stat = new power_core_stat_t(shader_config, shader_stats);
+  pwr_mem_stat = new power_mem_stat_t(mem_config, shader_config, memory_stats,
+                                      shader_stats);
+  m_average_pipeline_duty_cycle = average_pipeline_duty_cycle;
+  m_active_sms = active_sms;
+  m_config = shader_config;
+  m_mem_config = mem_config;
 }
 
-void power_core_stat_t::save_stats(){
-for(unsigned i=0; i<m_config->num_shader(); ++i){
-    m_pipeline_duty_cycle[PREV_STAT_IDX][i]=m_pipeline_duty_cycle[CURRENT_STAT_IDX][i];
-    m_num_decoded_insn[PREV_STAT_IDX][i]=	m_num_decoded_insn[CURRENT_STAT_IDX][i];
-    m_num_FPdecoded_insn[PREV_STAT_IDX][i]=m_num_FPdecoded_insn[CURRENT_STAT_IDX][i];
-    m_num_INTdecoded_insn[PREV_STAT_IDX][i]=m_num_INTdecoded_insn[CURRENT_STAT_IDX][i];
-    m_num_storequeued_insn[PREV_STAT_IDX][i]=m_num_storequeued_insn[CURRENT_STAT_IDX][i];
-    m_num_loadqueued_insn[PREV_STAT_IDX][i]=m_num_loadqueued_insn[CURRENT_STAT_IDX][i];
-    m_num_ialu_acesses[PREV_STAT_IDX][i]=m_num_ialu_acesses[CURRENT_STAT_IDX][i];
-    m_num_fp_acesses[PREV_STAT_IDX][i]=m_num_fp_acesses[CURRENT_STAT_IDX][i];
-    m_num_tex_inst[PREV_STAT_IDX][i]=m_num_tex_inst[CURRENT_STAT_IDX][i];
-    m_num_imul_acesses[PREV_STAT_IDX][i]=m_num_imul_acesses[CURRENT_STAT_IDX][i];
-    m_num_imul24_acesses[PREV_STAT_IDX][i]=m_num_imul24_acesses[CURRENT_STAT_IDX][i];
-    m_num_imul32_acesses[PREV_STAT_IDX][i]=m_num_imul32_acesses[CURRENT_STAT_IDX][i];
-    m_num_fpmul_acesses[PREV_STAT_IDX][i]=m_num_fpmul_acesses[CURRENT_STAT_IDX][i];
-    m_num_idiv_acesses[PREV_STAT_IDX][i]=m_num_idiv_acesses[CURRENT_STAT_IDX][i];
-    m_num_fpdiv_acesses[PREV_STAT_IDX][i]=m_num_fpdiv_acesses[CURRENT_STAT_IDX][i];
-    m_num_sp_acesses[PREV_STAT_IDX][i]=m_num_sp_acesses[CURRENT_STAT_IDX][i];
-    m_num_sfu_acesses[PREV_STAT_IDX][i]=m_num_sfu_acesses[CURRENT_STAT_IDX][i];
-    m_num_trans_acesses[PREV_STAT_IDX][i]=m_num_trans_acesses[CURRENT_STAT_IDX][i];
-    m_num_mem_acesses[PREV_STAT_IDX][i]=m_num_mem_acesses[CURRENT_STAT_IDX][i];
-    m_num_sp_committed[PREV_STAT_IDX][i]=m_num_sp_committed[CURRENT_STAT_IDX][i];
-    m_num_sfu_committed[PREV_STAT_IDX][i]=m_num_sfu_committed[CURRENT_STAT_IDX][i];
-    m_num_mem_committed[PREV_STAT_IDX][i]=m_num_mem_committed[CURRENT_STAT_IDX][i];
-    m_read_regfile_acesses[PREV_STAT_IDX][i]=m_read_regfile_acesses[CURRENT_STAT_IDX][i];
-    m_write_regfile_acesses[PREV_STAT_IDX][i]=m_write_regfile_acesses[CURRENT_STAT_IDX][i];
-    m_non_rf_operands[PREV_STAT_IDX][i]=m_non_rf_operands[CURRENT_STAT_IDX][i];
-    m_active_sp_lanes[PREV_STAT_IDX][i]=m_active_sp_lanes[CURRENT_STAT_IDX][i];
-    m_active_sfu_lanes[PREV_STAT_IDX][i]=m_active_sfu_lanes[CURRENT_STAT_IDX][i];
-    }
+void power_stat_t::visualizer_print(gzFile visualizer_file) {
+  pwr_core_stat->visualizer_print(visualizer_file);
+  pwr_mem_stat->visualizer_print(visualizer_file);
 }
 
-power_stat_t::power_stat_t( const shader_core_config *shader_config,float * average_pipeline_duty_cycle,float *active_sms,shader_core_stats * shader_stats, const memory_config *mem_config,memory_stats_t * memory_stats)
-{
-	assert( shader_config->m_valid );
-	assert( mem_config->m_valid );
-	pwr_core_stat= new power_core_stat_t(shader_config,shader_stats);
-	pwr_mem_stat= new power_mem_stat_t(mem_config,shader_config, memory_stats, shader_stats);
-	m_average_pipeline_duty_cycle=average_pipeline_duty_cycle;
-	m_active_sms=active_sms;
-	m_config = shader_config;
-	m_mem_config = mem_config;
+void power_stat_t::print(FILE *fout) const {
+  fprintf(fout, "average_pipeline_duty_cycle=%f\n",
+          *m_average_pipeline_duty_cycle);
+  pwr_core_stat->print(fout);
+  pwr_mem_stat->print(fout);
 }
-
-void power_stat_t::visualizer_print( gzFile visualizer_file )
-{
-	pwr_core_stat->visualizer_print(visualizer_file);
-	pwr_mem_stat->visualizer_print(visualizer_file);
-}
-
-void power_stat_t::print (FILE *fout) const
-{
-	fprintf(fout,"average_pipeline_duty_cycle=%f\n",*m_average_pipeline_duty_cycle);
-	pwr_core_stat->print(fout);
-	pwr_mem_stat->print(fout);
-}
-

--- a/src/gpgpu-sim/power_stat.h
+++ b/src/gpgpu-sim/power_stat.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -32,750 +30,599 @@
 
 #include <stdio.h>
 #include <zlib.h>
-#include "gpu-sim.h"
 #include "mem_latency_stat.h"
+#include "gpu-sim.h"
 
-typedef enum _stat_idx {
-  CURRENT_STAT_IDX = 0,  // Current activity count
-  PREV_STAT_IDX,         // Previous sample activity count
-  NUM_STAT_IDX           // Total number of samples
-} stat_idx;
+typedef enum _stat_idx{
+    CURRENT_STAT_IDX = 0,    // Current activity count
+    PREV_STAT_IDX,           // Previous sample activity count
+    NUM_STAT_IDX     // Total number of samples
+}stat_idx;
+
 
 struct shader_core_power_stats_pod {
-  // [CURRENT_STAT_IDX] = CURRENT_STAT_IDX stat, [PREV_STAT_IDX] = last reading
-  float *m_pipeline_duty_cycle[NUM_STAT_IDX];
-  unsigned *m_num_decoded_insn[NUM_STAT_IDX];  // number of instructions
-                                               // committed by this shader core
-  unsigned *m_num_FPdecoded_insn[NUM_STAT_IDX];   // number of instructions
-                                                  // committed by this shader
-                                                  // core
-  unsigned *m_num_INTdecoded_insn[NUM_STAT_IDX];  // number of instructions
-                                                  // committed by this shader
-                                                  // core
-  unsigned *m_num_storequeued_insn[NUM_STAT_IDX];
-  unsigned *m_num_loadqueued_insn[NUM_STAT_IDX];
-  unsigned *m_num_ialu_acesses[NUM_STAT_IDX];
-  unsigned *m_num_fp_acesses[NUM_STAT_IDX];
-  unsigned *m_num_tex_inst[NUM_STAT_IDX];
-  unsigned *m_num_imul_acesses[NUM_STAT_IDX];
-  unsigned *m_num_imul32_acesses[NUM_STAT_IDX];
-  unsigned *m_num_imul24_acesses[NUM_STAT_IDX];
-  unsigned *m_num_fpmul_acesses[NUM_STAT_IDX];
-  unsigned *m_num_idiv_acesses[NUM_STAT_IDX];
-  unsigned *m_num_fpdiv_acesses[NUM_STAT_IDX];
-  unsigned *m_num_sp_acesses[NUM_STAT_IDX];
-  unsigned *m_num_sfu_acesses[NUM_STAT_IDX];
-  unsigned *m_num_trans_acesses[NUM_STAT_IDX];
-  unsigned *m_num_mem_acesses[NUM_STAT_IDX];
-  unsigned *m_num_sp_committed[NUM_STAT_IDX];
-  unsigned *m_num_sfu_committed[NUM_STAT_IDX];
-  unsigned *m_num_mem_committed[NUM_STAT_IDX];
-  unsigned *m_active_sp_lanes[NUM_STAT_IDX];
-  unsigned *m_active_sfu_lanes[NUM_STAT_IDX];
-  unsigned *m_read_regfile_acesses[NUM_STAT_IDX];
-  unsigned *m_write_regfile_acesses[NUM_STAT_IDX];
-  unsigned *m_non_rf_operands[NUM_STAT_IDX];
+    // [CURRENT_STAT_IDX] = CURRENT_STAT_IDX stat, [PREV_STAT_IDX] = last reading
+    float *m_pipeline_duty_cycle[NUM_STAT_IDX];
+    unsigned *m_num_decoded_insn[NUM_STAT_IDX]; // number of instructions committed by this shader core
+    unsigned *m_num_FPdecoded_insn[NUM_STAT_IDX]; // number of instructions committed by this shader core
+    unsigned *m_num_INTdecoded_insn[NUM_STAT_IDX]; // number of instructions committed by this shader core
+    unsigned *m_num_storequeued_insn[NUM_STAT_IDX];
+    unsigned *m_num_loadqueued_insn[NUM_STAT_IDX];
+    unsigned *m_num_ialu_acesses[NUM_STAT_IDX];
+    unsigned *m_num_fp_acesses[NUM_STAT_IDX];
+    unsigned *m_num_tex_inst[NUM_STAT_IDX];
+    unsigned *m_num_imul_acesses[NUM_STAT_IDX];
+    unsigned *m_num_imul32_acesses[NUM_STAT_IDX];
+    unsigned *m_num_imul24_acesses[NUM_STAT_IDX];
+    unsigned *m_num_fpmul_acesses[NUM_STAT_IDX];
+    unsigned *m_num_idiv_acesses[NUM_STAT_IDX];
+    unsigned *m_num_fpdiv_acesses[NUM_STAT_IDX];
+    unsigned *m_num_sp_acesses[NUM_STAT_IDX];
+    unsigned *m_num_sfu_acesses[NUM_STAT_IDX];
+    unsigned *m_num_trans_acesses[NUM_STAT_IDX];
+    unsigned *m_num_mem_acesses[NUM_STAT_IDX];
+    unsigned *m_num_sp_committed[NUM_STAT_IDX];
+    unsigned *m_num_sfu_committed[NUM_STAT_IDX];
+    unsigned *m_num_mem_committed[NUM_STAT_IDX];
+    unsigned *m_active_sp_lanes[NUM_STAT_IDX];
+    unsigned *m_active_sfu_lanes[NUM_STAT_IDX];
+    unsigned *m_read_regfile_acesses[NUM_STAT_IDX];
+    unsigned *m_write_regfile_acesses[NUM_STAT_IDX];
+    unsigned *m_non_rf_operands[NUM_STAT_IDX];
 };
 
 class power_core_stat_t : public shader_core_power_stats_pod {
- public:
-  power_core_stat_t(const shader_core_config *shader_config,
-                    shader_core_stats *core_stats);
-  void visualizer_print(gzFile visualizer_file);
-  void print(FILE *fout);
-  void init();
-  void save_stats();
+public:
+   power_core_stat_t(const shader_core_config *shader_config, shader_core_stats *core_stats);
+   void visualizer_print( gzFile visualizer_file );
+   void print (FILE *fout);
+   void init();
+   void save_stats();
 
- private:
-  shader_core_stats *m_core_stats;
-  const shader_core_config *m_config;
-  float average_duty_cycle;
+private:
+   shader_core_stats * m_core_stats;
+   const shader_core_config *m_config;
+   float average_duty_cycle;
+
+
 };
 
-struct mem_power_stats_pod {
-  // [CURRENT_STAT_IDX] = CURRENT_STAT_IDX stat, [PREV_STAT_IDX] = last reading
-  class cache_stats core_cache_stats[NUM_STAT_IDX];  // Total core stats
-  class cache_stats l2_cache_stats[NUM_STAT_IDX];    // Total L2 partition stats
+struct mem_power_stats_pod{
+    // [CURRENT_STAT_IDX] = CURRENT_STAT_IDX stat, [PREV_STAT_IDX] = last reading
+    class cache_stats core_cache_stats[NUM_STAT_IDX]; // Total core stats
+    class cache_stats l2_cache_stats[NUM_STAT_IDX]; // Total L2 partition stats
 
-  unsigned *shmem_read_access[NUM_STAT_IDX];  // Shared memory access
+    unsigned *shmem_read_access[NUM_STAT_IDX];   // Shared memory access
 
-  // Low level DRAM stats
-  unsigned *n_cmd[NUM_STAT_IDX];
-  unsigned *n_activity[NUM_STAT_IDX];
-  unsigned *n_nop[NUM_STAT_IDX];
-  unsigned *n_act[NUM_STAT_IDX];
-  unsigned *n_pre[NUM_STAT_IDX];
-  unsigned *n_rd[NUM_STAT_IDX];
-  unsigned *n_wr[NUM_STAT_IDX];
-  unsigned *n_req[NUM_STAT_IDX];
+    // Low level DRAM stats
+    unsigned *n_cmd[NUM_STAT_IDX];
+    unsigned *n_activity[NUM_STAT_IDX];
+    unsigned *n_nop[NUM_STAT_IDX];
+    unsigned *n_act[NUM_STAT_IDX];
+    unsigned *n_pre[NUM_STAT_IDX];
+    unsigned *n_rd[NUM_STAT_IDX];
+    unsigned *n_wr[NUM_STAT_IDX];
+    unsigned *n_req[NUM_STAT_IDX];
 
-  // Interconnect stats
-  long *n_simt_to_mem[NUM_STAT_IDX];
-  long *n_mem_to_simt[NUM_STAT_IDX];
+    // Interconnect stats
+    long *n_simt_to_mem[NUM_STAT_IDX];
+    long *n_mem_to_simt[NUM_STAT_IDX];
 };
 
-class power_mem_stat_t : public mem_power_stats_pod {
- public:
-  power_mem_stat_t(const memory_config *mem_config,
-                   const shader_core_config *shdr_config,
-                   memory_stats_t *mem_stats, shader_core_stats *shdr_stats);
-  void visualizer_print(gzFile visualizer_file);
-  void print(FILE *fout) const;
-  void init();
-  void save_stats();
 
- private:
-  memory_stats_t *m_mem_stats;
-  shader_core_stats *m_core_stats;
-  const memory_config *m_config;
-  const shader_core_config *m_core_config;
+
+class power_mem_stat_t : public mem_power_stats_pod{
+public:
+   power_mem_stat_t(const memory_config *mem_config, const shader_core_config *shdr_config, memory_stats_t *mem_stats, shader_core_stats *shdr_stats);
+   void visualizer_print( gzFile visualizer_file );
+   void print (FILE *fout) const;
+   void init();
+   void save_stats();
+private:
+   memory_stats_t *m_mem_stats;
+   shader_core_stats * m_core_stats;
+   const memory_config *m_config;
+   const shader_core_config *m_core_config;
 };
+
 
 class power_stat_t {
- public:
-  power_stat_t(const shader_core_config *shader_config,
-               float *average_pipeline_duty_cycle, float *active_sms,
-               shader_core_stats *shader_stats, const memory_config *mem_config,
-               memory_stats_t *memory_stats);
-  void visualizer_print(gzFile visualizer_file);
-  void print(FILE *fout) const;
-  void save_stats() {
-    pwr_core_stat->save_stats();
-    pwr_mem_stat->save_stats();
-    *m_average_pipeline_duty_cycle = 0;
-    *m_active_sms = 0;
-  }
+public:
+   power_stat_t( const shader_core_config *shader_config,float * average_pipeline_duty_cycle,float * active_sms,shader_core_stats * shader_stats, const memory_config *mem_config,memory_stats_t * memory_stats);
+   void visualizer_print( gzFile visualizer_file );
+   void print (FILE *fout) const;
+   void save_stats(){
+	   pwr_core_stat->save_stats();
+	   pwr_mem_stat->save_stats();
+	   *m_average_pipeline_duty_cycle=0;
+	   *m_active_sms=0;
+   }
 
-  unsigned get_total_inst() {
-    unsigned total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst += (pwr_core_stat->m_num_decoded_insn[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_decoded_insn[PREV_STAT_IDX][i]);
+    unsigned get_total_inst(){
+        unsigned total_inst=0;
+        for(unsigned i=0; i<m_config->num_shader();i++){
+            total_inst+=(pwr_core_stat->m_num_decoded_insn[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_decoded_insn[PREV_STAT_IDX][i]);
+        }
+        return total_inst;
     }
-    return total_inst;
-  }
-  unsigned get_total_int_inst() {
-    unsigned total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst +=
-          (pwr_core_stat->m_num_INTdecoded_insn[CURRENT_STAT_IDX][i]) -
-          (pwr_core_stat->m_num_INTdecoded_insn[PREV_STAT_IDX][i]);
+    unsigned get_total_int_inst(){
+        unsigned total_inst=0;
+        for(unsigned i=0; i<m_config->num_shader();i++){
+            total_inst+=(pwr_core_stat->m_num_INTdecoded_insn[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_INTdecoded_insn[PREV_STAT_IDX][i]);
+        }
+        return total_inst;
     }
-    return total_inst;
-  }
-  unsigned get_total_fp_inst() {
-    unsigned total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst += (pwr_core_stat->m_num_FPdecoded_insn[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_FPdecoded_insn[PREV_STAT_IDX][i]);
+    unsigned get_total_fp_inst(){
+        unsigned total_inst=0;
+        for(unsigned i=0; i<m_config->num_shader();i++){
+            total_inst+=(pwr_core_stat->m_num_FPdecoded_insn[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_FPdecoded_insn[PREV_STAT_IDX][i]);
+        }
+        return total_inst;
     }
-    return total_inst;
-  }
-  unsigned get_total_load_inst() {
-    unsigned total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst +=
-          (pwr_core_stat->m_num_loadqueued_insn[CURRENT_STAT_IDX][i]) -
-          (pwr_core_stat->m_num_loadqueued_insn[PREV_STAT_IDX][i]);
+    unsigned get_total_load_inst(){
+        unsigned total_inst=0;
+        for(unsigned i=0; i<m_config->num_shader();i++){
+            total_inst+=(pwr_core_stat->m_num_loadqueued_insn[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_loadqueued_insn[PREV_STAT_IDX][i]);
+        }
+        return total_inst;
     }
-    return total_inst;
-  }
-  unsigned get_total_store_inst() {
-    unsigned total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst +=
-          (pwr_core_stat->m_num_storequeued_insn[CURRENT_STAT_IDX][i]) -
-          (pwr_core_stat->m_num_storequeued_insn[PREV_STAT_IDX][i]);
+    unsigned get_total_store_inst(){
+        unsigned total_inst=0;
+        for(unsigned i=0; i<m_config->num_shader();i++){
+            total_inst+=(pwr_core_stat->m_num_storequeued_insn[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_storequeued_insn[PREV_STAT_IDX][i]);
+        }
+        return total_inst;
     }
-    return total_inst;
-  }
-  unsigned get_sp_committed_inst() {
-    unsigned total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst += (pwr_core_stat->m_num_sp_committed[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_sp_committed[PREV_STAT_IDX][i]);
+    unsigned get_sp_committed_inst(){
+        unsigned total_inst=0;
+        for(unsigned i=0; i<m_config->num_shader();i++){
+            total_inst+=(pwr_core_stat->m_num_sp_committed[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_sp_committed[PREV_STAT_IDX][i]);
+        }
+        return total_inst;
     }
-    return total_inst;
-  }
-  unsigned get_sfu_committed_inst() {
-    unsigned total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst += (pwr_core_stat->m_num_sfu_committed[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_sfu_committed[PREV_STAT_IDX][i]);
+    unsigned get_sfu_committed_inst(){
+        unsigned total_inst=0;
+        for(unsigned i=0; i<m_config->num_shader();i++){
+            total_inst+=(pwr_core_stat->m_num_sfu_committed[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_sfu_committed[PREV_STAT_IDX][i]);
+        }
+        return total_inst;
     }
-    return total_inst;
-  }
-  unsigned get_mem_committed_inst() {
-    unsigned total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst += (pwr_core_stat->m_num_mem_committed[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_mem_committed[PREV_STAT_IDX][i]);
+    unsigned get_mem_committed_inst(){
+        unsigned total_inst=0;
+        for(unsigned i=0; i<m_config->num_shader();i++){
+            total_inst+=(pwr_core_stat->m_num_mem_committed[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_mem_committed[PREV_STAT_IDX][i]);
+        }
+        return total_inst;
     }
-    return total_inst;
-  }
-  unsigned get_committed_inst() {
-    unsigned total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst += (pwr_core_stat->m_num_mem_committed[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_mem_committed[PREV_STAT_IDX][i]) +
-                    (pwr_core_stat->m_num_sfu_committed[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_sfu_committed[PREV_STAT_IDX][i]) +
-                    (pwr_core_stat->m_num_sp_committed[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_sp_committed[PREV_STAT_IDX][i]);
+    unsigned get_committed_inst(){
+        unsigned total_inst=0;
+        for(unsigned i=0; i<m_config->num_shader();i++){
+            total_inst+=(pwr_core_stat->m_num_mem_committed[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_mem_committed[PREV_STAT_IDX][i])
+                    +(pwr_core_stat->m_num_sfu_committed[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_sfu_committed[PREV_STAT_IDX][i])
+                    +(pwr_core_stat->m_num_sp_committed[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_sp_committed[PREV_STAT_IDX][i]);
+        }
+        return total_inst;
     }
-    return total_inst;
-  }
-  unsigned get_regfile_reads() {
-    unsigned total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst +=
-          (pwr_core_stat->m_read_regfile_acesses[CURRENT_STAT_IDX][i]) -
-          (pwr_core_stat->m_read_regfile_acesses[PREV_STAT_IDX][i]);
+    unsigned get_regfile_reads(){
+        unsigned total_inst=0;
+        for(unsigned i=0; i<m_config->num_shader();i++){
+            total_inst+=(pwr_core_stat->m_read_regfile_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_read_regfile_acesses[PREV_STAT_IDX][i]);
+        }
+        return total_inst;
     }
-    return total_inst;
-  }
-  unsigned get_regfile_writes() {
-    unsigned total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst +=
-          (pwr_core_stat->m_write_regfile_acesses[CURRENT_STAT_IDX][i]) -
-          (pwr_core_stat->m_write_regfile_acesses[PREV_STAT_IDX][i]);
-    }
-    return total_inst;
-  }
-
-  float get_pipeline_duty() {
-    float total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst +=
-          (pwr_core_stat->m_pipeline_duty_cycle[CURRENT_STAT_IDX][i]) -
-          (pwr_core_stat->m_pipeline_duty_cycle[PREV_STAT_IDX][i]);
-    }
-    return total_inst;
-  }
-
-  unsigned get_non_regfile_operands() {
-    unsigned total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst += (pwr_core_stat->m_non_rf_operands[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_non_rf_operands[PREV_STAT_IDX][i]);
-    }
-    return total_inst;
-  }
-
-  unsigned get_sp_accessess() {
-    unsigned total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst += (pwr_core_stat->m_num_sp_acesses[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_sp_acesses[PREV_STAT_IDX][i]);
-    }
-    return total_inst;
-  }
-
-  unsigned get_sfu_accessess() {
-    unsigned total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst += (pwr_core_stat->m_num_sfu_acesses[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_sfu_acesses[PREV_STAT_IDX][i]);
-    }
-    return total_inst;
-  }
-  unsigned get_trans_accessess() {
-    unsigned total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst += (pwr_core_stat->m_num_trans_acesses[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_trans_acesses[PREV_STAT_IDX][i]);
-    }
-    return total_inst;
-  }
-
-  unsigned get_mem_accessess() {
-    unsigned total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst += (pwr_core_stat->m_num_mem_acesses[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_mem_acesses[PREV_STAT_IDX][i]);
-    }
-    return total_inst;
-  }
-
-  unsigned get_intdiv_accessess() {
-    unsigned total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst += (pwr_core_stat->m_num_idiv_acesses[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_idiv_acesses[PREV_STAT_IDX][i]);
-    }
-    return total_inst;
-  }
-
-  unsigned get_fpdiv_accessess() {
-    unsigned total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst += (pwr_core_stat->m_num_fpdiv_acesses[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_fpdiv_acesses[PREV_STAT_IDX][i]);
-    }
-    return total_inst;
-  }
-
-  unsigned get_intmul32_accessess() {
-    unsigned total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst += (pwr_core_stat->m_num_imul32_acesses[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_imul32_acesses[PREV_STAT_IDX][i]);
-    }
-    return total_inst;
-  }
-
-  unsigned get_intmul24_accessess() {
-    unsigned total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst += (pwr_core_stat->m_num_imul24_acesses[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_imul24_acesses[PREV_STAT_IDX][i]);
-    }
-    return total_inst;
-  }
-
-  unsigned get_intmul_accessess() {
-    unsigned total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst += (pwr_core_stat->m_num_imul_acesses[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_imul_acesses[PREV_STAT_IDX][i]) +
-                    (pwr_core_stat->m_num_imul24_acesses[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_imul24_acesses[PREV_STAT_IDX][i]) +
-                    (pwr_core_stat->m_num_imul32_acesses[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_imul32_acesses[PREV_STAT_IDX][i]);
-    }
-    return total_inst;
-  }
-
-  unsigned get_fpmul_accessess() {
-    unsigned total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst += (pwr_core_stat->m_num_fp_acesses[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_fp_acesses[PREV_STAT_IDX][i]);
-    }
-    return total_inst;
-  }
-
-  float get_sp_active_lanes() {
-    unsigned total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst += (pwr_core_stat->m_active_sp_lanes[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_active_sp_lanes[PREV_STAT_IDX][i]);
-    }
-    return (total_inst / m_config->num_shader()) / m_config->gpgpu_num_sp_units;
-  }
-
-  float get_sfu_active_lanes() {
-    unsigned total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst += (pwr_core_stat->m_active_sfu_lanes[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_active_sfu_lanes[PREV_STAT_IDX][i]);
+    unsigned get_regfile_writes(){
+        unsigned total_inst=0;
+        for(unsigned i=0; i<m_config->num_shader();i++){
+            total_inst+=(pwr_core_stat->m_write_regfile_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_write_regfile_acesses[PREV_STAT_IDX][i]);
+        }
+        return total_inst;
     }
 
-    return (total_inst / m_config->num_shader()) /
-           m_config->gpgpu_num_sfu_units;
-  }
-
-  unsigned get_tot_fpu_accessess() {
-    unsigned total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst += (pwr_core_stat->m_num_fp_acesses[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_fp_acesses[PREV_STAT_IDX][i]) +
-                    (pwr_core_stat->m_num_fpdiv_acesses[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_fpdiv_acesses[PREV_STAT_IDX][i]) +
-                    (pwr_core_stat->m_num_fpmul_acesses[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_fpmul_acesses[PREV_STAT_IDX][i]) +
-                    (pwr_core_stat->m_num_imul24_acesses[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_imul24_acesses[PREV_STAT_IDX][i]) +
-                    (pwr_core_stat->m_num_imul_acesses[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_imul_acesses[PREV_STAT_IDX][i]);
+    float get_pipeline_duty(){
+        float total_inst=0;
+        for(unsigned i=0; i<m_config->num_shader();i++){
+            total_inst+=(pwr_core_stat->m_pipeline_duty_cycle[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_pipeline_duty_cycle[PREV_STAT_IDX][i]);
+        }
+        return total_inst;
     }
-    total_inst +=
-        get_total_load_inst() + get_total_store_inst() + get_tex_inst();
-    return total_inst;
-  }
 
-  unsigned get_tot_sfu_accessess() {
-    unsigned total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst += (pwr_core_stat->m_num_idiv_acesses[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_idiv_acesses[PREV_STAT_IDX][i]) +
-                    (pwr_core_stat->m_num_imul32_acesses[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_imul32_acesses[PREV_STAT_IDX][i]) +
-                    (pwr_core_stat->m_num_trans_acesses[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_trans_acesses[PREV_STAT_IDX][i]);
+    unsigned get_non_regfile_operands(){
+        unsigned total_inst=0;
+        for(unsigned i=0; i<m_config->num_shader();i++){
+            total_inst+=(pwr_core_stat->m_non_rf_operands[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_non_rf_operands[PREV_STAT_IDX][i]);
+        }
+        return total_inst;
     }
-    return total_inst;
-  }
 
-  unsigned get_ialu_accessess() {
-    unsigned total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst += (pwr_core_stat->m_num_ialu_acesses[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_ialu_acesses[PREV_STAT_IDX][i]);
+    unsigned get_sp_accessess(){
+        unsigned total_inst=0;
+        for(unsigned i=0; i<m_config->num_shader();i++){
+            total_inst+=(pwr_core_stat->m_num_sp_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_sp_acesses[PREV_STAT_IDX][i]);
+        }
+        return total_inst;
     }
-    return total_inst;
-  }
 
-  unsigned get_tex_inst() {
-    unsigned total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst += (pwr_core_stat->m_num_tex_inst[CURRENT_STAT_IDX][i]) -
-                    (pwr_core_stat->m_num_tex_inst[PREV_STAT_IDX][i]);
+    unsigned get_sfu_accessess(){
+        unsigned total_inst=0;
+        for(unsigned i=0; i<m_config->num_shader();i++){
+            total_inst+=(pwr_core_stat->m_num_sfu_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_sfu_acesses[PREV_STAT_IDX][i]);
+        }
+        return total_inst;
     }
-    return total_inst;
-  }
-
-  unsigned get_constant_c_accesses() {
-    enum mem_access_type access_type[] = {CONST_ACC_R};
-    enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
-    unsigned num_access_type =
-        sizeof(access_type) / sizeof(enum mem_access_type);
-    unsigned num_request_status =
-        sizeof(request_status) / sizeof(enum cache_request_status);
-
-    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
-               access_type, num_access_type, request_status,
-               num_request_status)) -
-           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
-               access_type, num_access_type, request_status,
-               num_request_status));
-  }
-  unsigned get_constant_c_misses() {
-    enum mem_access_type access_type[] = {CONST_ACC_R};
-    enum cache_request_status request_status[] = {MISS};
-    unsigned num_access_type =
-        sizeof(access_type) / sizeof(enum mem_access_type);
-    unsigned num_request_status =
-        sizeof(request_status) / sizeof(enum cache_request_status);
-
-    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
-               access_type, num_access_type, request_status,
-               num_request_status)) -
-           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
-               access_type, num_access_type, request_status,
-               num_request_status));
-  }
-  unsigned get_constant_c_hits() {
-    return (get_constant_c_accesses() - get_constant_c_misses());
-  }
-  unsigned get_texture_c_accesses() {
-    enum mem_access_type access_type[] = {TEXTURE_ACC_R};
-    enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
-    unsigned num_access_type =
-        sizeof(access_type) / sizeof(enum mem_access_type);
-    unsigned num_request_status =
-        sizeof(request_status) / sizeof(enum cache_request_status);
-
-    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
-               access_type, num_access_type, request_status,
-               num_request_status)) -
-           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
-               access_type, num_access_type, request_status,
-               num_request_status));
-  }
-  unsigned get_texture_c_misses() {
-    enum mem_access_type access_type[] = {TEXTURE_ACC_R};
-    enum cache_request_status request_status[] = {MISS};
-    unsigned num_access_type =
-        sizeof(access_type) / sizeof(enum mem_access_type);
-    unsigned num_request_status =
-        sizeof(request_status) / sizeof(enum cache_request_status);
-
-    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
-               access_type, num_access_type, request_status,
-               num_request_status)) -
-           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
-               access_type, num_access_type, request_status,
-               num_request_status));
-  }
-  unsigned get_texture_c_hits() {
-    return (get_texture_c_accesses() - get_texture_c_misses());
-  }
-  unsigned get_inst_c_accesses() {
-    enum mem_access_type access_type[] = {INST_ACC_R};
-    enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
-    unsigned num_access_type =
-        sizeof(access_type) / sizeof(enum mem_access_type);
-    unsigned num_request_status =
-        sizeof(request_status) / sizeof(enum cache_request_status);
-
-    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
-               access_type, num_access_type, request_status,
-               num_request_status)) -
-           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
-               access_type, num_access_type, request_status,
-               num_request_status));
-  }
-  unsigned get_inst_c_misses() {
-    enum mem_access_type access_type[] = {INST_ACC_R};
-    enum cache_request_status request_status[] = {MISS};
-    unsigned num_access_type =
-        sizeof(access_type) / sizeof(enum mem_access_type);
-    unsigned num_request_status =
-        sizeof(request_status) / sizeof(enum cache_request_status);
-
-    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
-               access_type, num_access_type, request_status,
-               num_request_status)) -
-           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
-               access_type, num_access_type, request_status,
-               num_request_status));
-  }
-  unsigned get_inst_c_hits() {
-    return (get_inst_c_accesses() - get_inst_c_misses());
-  }
-
-  unsigned get_l1d_read_accesses() {
-    enum mem_access_type access_type[] = {GLOBAL_ACC_R, LOCAL_ACC_R};
-    enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
-    unsigned num_access_type =
-        sizeof(access_type) / sizeof(enum mem_access_type);
-    unsigned num_request_status =
-        sizeof(request_status) / sizeof(enum cache_request_status);
-
-    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
-               access_type, num_access_type, request_status,
-               num_request_status)) -
-           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
-               access_type, num_access_type, request_status,
-               num_request_status));
-  }
-  unsigned get_l1d_read_misses() {
-    enum mem_access_type access_type[] = {GLOBAL_ACC_R, LOCAL_ACC_R};
-    enum cache_request_status request_status[] = {MISS};
-    unsigned num_access_type =
-        sizeof(access_type) / sizeof(enum mem_access_type);
-    unsigned num_request_status =
-        sizeof(request_status) / sizeof(enum cache_request_status);
-
-    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
-               access_type, num_access_type, request_status,
-               num_request_status)) -
-           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
-               access_type, num_access_type, request_status,
-               num_request_status));
-  }
-  unsigned get_l1d_read_hits() {
-    return (get_l1d_read_accesses() - get_l1d_read_misses());
-  }
-  unsigned get_l1d_write_accesses() {
-    enum mem_access_type access_type[] = {GLOBAL_ACC_W, LOCAL_ACC_W};
-    enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
-    unsigned num_access_type =
-        sizeof(access_type) / sizeof(enum mem_access_type);
-    unsigned num_request_status =
-        sizeof(request_status) / sizeof(enum cache_request_status);
-
-    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
-               access_type, num_access_type, request_status,
-               num_request_status)) -
-           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
-               access_type, num_access_type, request_status,
-               num_request_status));
-  }
-  unsigned get_l1d_write_misses() {
-    enum mem_access_type access_type[] = {GLOBAL_ACC_W, LOCAL_ACC_W};
-    enum cache_request_status request_status[] = {MISS};
-    unsigned num_access_type =
-        sizeof(access_type) / sizeof(enum mem_access_type);
-    unsigned num_request_status =
-        sizeof(request_status) / sizeof(enum cache_request_status);
-
-    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
-               access_type, num_access_type, request_status,
-               num_request_status)) -
-           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
-               access_type, num_access_type, request_status,
-               num_request_status));
-  }
-  unsigned get_l1d_write_hits() {
-    return (get_l1d_write_accesses() - get_l1d_write_misses());
-  }
-  unsigned get_cache_misses() {
-    return get_l1d_read_misses() + get_constant_c_misses() +
-           get_l1d_write_misses() + get_texture_c_misses();
-  }
-
-  unsigned get_cache_read_misses() {
-    return get_l1d_read_misses() + get_constant_c_misses() +
-           get_texture_c_misses();
-  }
-
-  unsigned get_cache_write_misses() { return get_l1d_write_misses(); }
-
-  unsigned get_shmem_read_access() {
-    unsigned total_inst = 0;
-    for (unsigned i = 0; i < m_config->num_shader(); i++) {
-      total_inst += (pwr_mem_stat->shmem_read_access[CURRENT_STAT_IDX][i]) -
-                    (pwr_mem_stat->shmem_read_access[PREV_STAT_IDX][i]);
+    unsigned get_trans_accessess(){
+        unsigned total_inst=0;
+        for(unsigned i=0; i<m_config->num_shader();i++){
+            total_inst+=(pwr_core_stat->m_num_trans_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_trans_acesses[PREV_STAT_IDX][i]);
+        }
+        return total_inst;
     }
-    return total_inst;
-  }
 
-  unsigned get_l2_read_accesses() {
-    enum mem_access_type access_type[] = {
-        GLOBAL_ACC_R, LOCAL_ACC_R, CONST_ACC_R, TEXTURE_ACC_R, INST_ACC_R};
-    enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
-    unsigned num_access_type =
-        sizeof(access_type) / sizeof(enum mem_access_type);
-    unsigned num_request_status =
-        sizeof(request_status) / sizeof(enum cache_request_status);
-
-    return (pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].get_stats(
-               access_type, num_access_type, request_status,
-               num_request_status)) -
-           (pwr_mem_stat->l2_cache_stats[PREV_STAT_IDX].get_stats(
-               access_type, num_access_type, request_status,
-               num_request_status));
-  }
-
-  unsigned get_l2_read_misses() {
-    enum mem_access_type access_type[] = {
-        GLOBAL_ACC_R, LOCAL_ACC_R, CONST_ACC_R, TEXTURE_ACC_R, INST_ACC_R};
-    enum cache_request_status request_status[] = {MISS};
-    unsigned num_access_type =
-        sizeof(access_type) / sizeof(enum mem_access_type);
-    unsigned num_request_status =
-        sizeof(request_status) / sizeof(enum cache_request_status);
-
-    return (pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].get_stats(
-               access_type, num_access_type, request_status,
-               num_request_status)) -
-           (pwr_mem_stat->l2_cache_stats[PREV_STAT_IDX].get_stats(
-               access_type, num_access_type, request_status,
-               num_request_status));
-  }
-
-  unsigned get_l2_read_hits() {
-    return (get_l2_read_accesses() - get_l2_read_misses());
-  }
-
-  unsigned get_l2_write_accesses() {
-    enum mem_access_type access_type[] = {GLOBAL_ACC_W, LOCAL_ACC_W,
-                                          L1_WRBK_ACC};
-    enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
-    unsigned num_access_type =
-        sizeof(access_type) / sizeof(enum mem_access_type);
-    unsigned num_request_status =
-        sizeof(request_status) / sizeof(enum cache_request_status);
-
-    return (pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].get_stats(
-               access_type, num_access_type, request_status,
-               num_request_status)) -
-           (pwr_mem_stat->l2_cache_stats[PREV_STAT_IDX].get_stats(
-               access_type, num_access_type, request_status,
-               num_request_status));
-  }
-
-  unsigned get_l2_write_misses() {
-    enum mem_access_type access_type[] = {GLOBAL_ACC_W, LOCAL_ACC_W,
-                                          L1_WRBK_ACC};
-    enum cache_request_status request_status[] = {MISS};
-    unsigned num_access_type =
-        sizeof(access_type) / sizeof(enum mem_access_type);
-    unsigned num_request_status =
-        sizeof(request_status) / sizeof(enum cache_request_status);
-
-    return (pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].get_stats(
-               access_type, num_access_type, request_status,
-               num_request_status)) -
-           (pwr_mem_stat->l2_cache_stats[PREV_STAT_IDX].get_stats(
-               access_type, num_access_type, request_status,
-               num_request_status));
-  }
-  unsigned get_l2_write_hits() {
-    return (get_l2_write_accesses() - get_l2_write_misses());
-  }
-  unsigned get_dram_cmd() {
-    unsigned total = 0;
-    for (unsigned i = 0; i < m_mem_config->m_n_mem; ++i) {
-      total += (pwr_mem_stat->n_cmd[CURRENT_STAT_IDX][i] -
-                pwr_mem_stat->n_cmd[PREV_STAT_IDX][i]);
+    unsigned get_mem_accessess(){
+        unsigned total_inst=0;
+        for(unsigned i=0; i<m_config->num_shader();i++){
+            total_inst+=(pwr_core_stat->m_num_mem_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_mem_acesses[PREV_STAT_IDX][i]);
+        }
+        return total_inst;
     }
-    return total;
-  }
-  unsigned get_dram_activity() {
-    unsigned total = 0;
-    for (unsigned i = 0; i < m_mem_config->m_n_mem; ++i) {
-      total += (pwr_mem_stat->n_activity[CURRENT_STAT_IDX][i] -
-                pwr_mem_stat->n_activity[PREV_STAT_IDX][i]);
-    }
-    return total;
-  }
-  unsigned get_dram_nop() {
-    unsigned total = 0;
-    for (unsigned i = 0; i < m_mem_config->m_n_mem; ++i) {
-      total += (pwr_mem_stat->n_nop[CURRENT_STAT_IDX][i] -
-                pwr_mem_stat->n_nop[PREV_STAT_IDX][i]);
-    }
-    return total;
-  }
-  unsigned get_dram_act() {
-    unsigned total = 0;
-    for (unsigned i = 0; i < m_mem_config->m_n_mem; ++i) {
-      total += (pwr_mem_stat->n_act[CURRENT_STAT_IDX][i] -
-                pwr_mem_stat->n_act[PREV_STAT_IDX][i]);
-    }
-    return total;
-  }
-  unsigned get_dram_pre() {
-    unsigned total = 0;
-    for (unsigned i = 0; i < m_mem_config->m_n_mem; ++i) {
-      total += (pwr_mem_stat->n_pre[CURRENT_STAT_IDX][i] -
-                pwr_mem_stat->n_pre[PREV_STAT_IDX][i]);
-    }
-    return total;
-  }
-  unsigned get_dram_rd() {
-    unsigned total = 0;
-    for (unsigned i = 0; i < m_mem_config->m_n_mem; ++i) {
-      total += (pwr_mem_stat->n_rd[CURRENT_STAT_IDX][i] -
-                pwr_mem_stat->n_rd[PREV_STAT_IDX][i]);
-    }
-    return total;
-  }
-  unsigned get_dram_wr() {
-    unsigned total = 0;
-    for (unsigned i = 0; i < m_mem_config->m_n_mem; ++i) {
-      total += (pwr_mem_stat->n_wr[CURRENT_STAT_IDX][i] -
-                pwr_mem_stat->n_wr[PREV_STAT_IDX][i]);
-    }
-    return total;
-  }
-  unsigned get_dram_req() {
-    unsigned total = 0;
-    for (unsigned i = 0; i < m_mem_config->m_n_mem; ++i) {
-      total += (pwr_mem_stat->n_req[CURRENT_STAT_IDX][i] -
-                pwr_mem_stat->n_req[PREV_STAT_IDX][i]);
-    }
-    return total;
-  }
 
-  long get_icnt_simt_to_mem() {
-    long total = 0;
-    for (unsigned i = 0; i < m_config->n_simt_clusters; ++i) {
-      total += (pwr_mem_stat->n_simt_to_mem[CURRENT_STAT_IDX][i] -
-                pwr_mem_stat->n_simt_to_mem[PREV_STAT_IDX][i]);
+    unsigned get_intdiv_accessess(){
+        unsigned total_inst=0;
+        for(unsigned i=0; i<m_config->num_shader();i++){
+            total_inst+=(pwr_core_stat->m_num_idiv_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_idiv_acesses[PREV_STAT_IDX][i]);
+        }
+        return total_inst;
     }
-    return total;
-  }
 
-  long get_icnt_mem_to_simt() {
-    long total = 0;
-    for (unsigned i = 0; i < m_config->n_simt_clusters; ++i) {
-      total += (pwr_mem_stat->n_mem_to_simt[CURRENT_STAT_IDX][i] -
-                pwr_mem_stat->n_mem_to_simt[PREV_STAT_IDX][i]);
+    unsigned get_fpdiv_accessess(){
+        unsigned total_inst=0;
+        for(unsigned i=0; i<m_config->num_shader();i++){
+            total_inst+=(pwr_core_stat->m_num_fpdiv_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_fpdiv_acesses[PREV_STAT_IDX][i]);
+        }
+        return total_inst;
     }
-    return total;
-  }
 
-  power_core_stat_t *pwr_core_stat;
-  power_mem_stat_t *pwr_mem_stat;
-  float *m_average_pipeline_duty_cycle;
-  float *m_active_sms;
-  const shader_core_config *m_config;
-  const memory_config *m_mem_config;
+    unsigned get_intmul32_accessess(){
+        unsigned total_inst=0;
+        for(unsigned i=0; i<m_config->num_shader();i++){
+            total_inst+=(pwr_core_stat->m_num_imul32_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_imul32_acesses[PREV_STAT_IDX][i]);
+        }
+        return total_inst;
+    }
+
+    unsigned get_intmul24_accessess(){
+        unsigned total_inst=0;
+        for(unsigned i=0; i<m_config->num_shader();i++){
+            total_inst+=(pwr_core_stat->m_num_imul24_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_imul24_acesses[PREV_STAT_IDX][i]);
+        }
+        return total_inst;
+    }
+
+    unsigned get_intmul_accessess(){
+        unsigned total_inst=0;
+        for(unsigned i=0; i<m_config->num_shader();i++){
+            total_inst+=(pwr_core_stat->m_num_imul_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_imul_acesses[PREV_STAT_IDX][i])+
+                    (pwr_core_stat->m_num_imul24_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_imul24_acesses[PREV_STAT_IDX][i])+
+                    (pwr_core_stat->m_num_imul32_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_imul32_acesses[PREV_STAT_IDX][i]);
+        }
+        return total_inst;
+    }
+
+    unsigned get_fpmul_accessess(){
+        unsigned total_inst=0;
+        for(unsigned i=0; i<m_config->num_shader();i++){
+            total_inst+=(pwr_core_stat->m_num_fp_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_fp_acesses[PREV_STAT_IDX][i]);
+        }
+        return total_inst;
+    }
+
+    float get_sp_active_lanes(){
+        unsigned total_inst=0;
+        for(unsigned i=0; i<m_config->num_shader();i++){
+            total_inst+=(pwr_core_stat->m_active_sp_lanes[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_active_sp_lanes[PREV_STAT_IDX][i]);
+        }
+        return (total_inst/m_config->num_shader())/m_config->gpgpu_num_sp_units;
+    }
+
+    float get_sfu_active_lanes(){
+        unsigned total_inst=0;
+        for(unsigned i=0; i<m_config->num_shader();i++){
+            total_inst+=(pwr_core_stat->m_active_sfu_lanes[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_active_sfu_lanes[PREV_STAT_IDX][i]);
+        }
+
+        return (total_inst/m_config->num_shader())/m_config->gpgpu_num_sfu_units;
+    }
+
+    unsigned get_tot_fpu_accessess(){
+        unsigned total_inst=0;
+        for(unsigned i=0; i<m_config->num_shader();i++){
+            total_inst+=(pwr_core_stat->m_num_fp_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_fp_acesses[PREV_STAT_IDX][i])+
+                    (pwr_core_stat->m_num_fpdiv_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_fpdiv_acesses[PREV_STAT_IDX][i])+
+                    (pwr_core_stat->m_num_fpmul_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_fpmul_acesses[PREV_STAT_IDX][i])+
+                    (pwr_core_stat->m_num_imul24_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_imul24_acesses[PREV_STAT_IDX][i])+
+                    (pwr_core_stat->m_num_imul_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_imul_acesses[PREV_STAT_IDX][i]);
+        }
+        total_inst += get_total_load_inst()+get_total_store_inst()+get_tex_inst();
+        return total_inst;
+    }
+
+    unsigned get_tot_sfu_accessess(){
+        unsigned total_inst=0;
+        for(unsigned i=0; i<m_config->num_shader();i++){
+                total_inst+= (pwr_core_stat->m_num_idiv_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_idiv_acesses[PREV_STAT_IDX][i])+
+                            (pwr_core_stat->m_num_imul32_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_imul32_acesses[PREV_STAT_IDX][i])+
+                            (pwr_core_stat->m_num_trans_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_trans_acesses[PREV_STAT_IDX][i]);
+        }
+        return total_inst;
+    }
+
+    unsigned get_ialu_accessess(){
+        unsigned total_inst=0;
+        for(unsigned i=0; i<m_config->num_shader();i++){
+            total_inst+=(pwr_core_stat->m_num_ialu_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_ialu_acesses[PREV_STAT_IDX][i]);
+        }
+        return total_inst;
+    }
+
+    unsigned get_tex_inst(){
+        unsigned total_inst=0;
+        for(unsigned i=0; i<m_config->num_shader();i++){
+            total_inst+=(pwr_core_stat->m_num_tex_inst[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_tex_inst[PREV_STAT_IDX][i]);
+        }
+        return total_inst;
+    }
+
+    unsigned get_constant_c_accesses(){
+        enum mem_access_type access_type[] = {CONST_ACC_R};
+        enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
+        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
+        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+
+        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
+                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
+    }
+    unsigned get_constant_c_misses(){
+        enum mem_access_type access_type[] = {CONST_ACC_R};
+        enum cache_request_status request_status[] = {MISS};
+        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
+        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+
+        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
+                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
+    }
+    unsigned get_constant_c_hits(){
+        return (get_constant_c_accesses()-get_constant_c_misses());
+    }
+    unsigned get_texture_c_accesses(){
+        enum mem_access_type access_type[] = {TEXTURE_ACC_R};
+        enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
+        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
+        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+
+        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
+                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
+    }
+    unsigned get_texture_c_misses(){
+        enum mem_access_type access_type[] = {TEXTURE_ACC_R};
+        enum cache_request_status request_status[] = {MISS};
+        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
+        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+
+        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
+                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
+    }
+    unsigned get_texture_c_hits(){
+        return ( get_texture_c_accesses()- get_texture_c_misses());
+    }
+    unsigned get_inst_c_accesses(){
+        enum mem_access_type access_type[] = {INST_ACC_R};
+        enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
+        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
+        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+
+        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
+                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
+    }
+    unsigned get_inst_c_misses(){
+        enum mem_access_type access_type[] = {INST_ACC_R};
+        enum cache_request_status request_status[] = {MISS};
+        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
+        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+
+        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
+                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
+    }
+    unsigned get_inst_c_hits(){
+        return (get_inst_c_accesses()-get_inst_c_misses());
+    }
+
+    unsigned get_l1d_read_accesses(){
+        enum mem_access_type access_type[] = {GLOBAL_ACC_R, LOCAL_ACC_R};
+        enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
+        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
+        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+
+        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
+                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
+    }
+    unsigned get_l1d_read_misses(){
+        enum mem_access_type access_type[] = {GLOBAL_ACC_R, LOCAL_ACC_R};
+        enum cache_request_status request_status[] = {MISS};
+        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
+        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+
+        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
+                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
+    }
+    unsigned get_l1d_read_hits(){
+        return (get_l1d_read_accesses()-get_l1d_read_misses());
+    }
+    unsigned get_l1d_write_accesses(){
+        enum mem_access_type access_type[] = {GLOBAL_ACC_W, LOCAL_ACC_W};
+        enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
+        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
+        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+
+        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
+                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
+    }
+    unsigned get_l1d_write_misses(){
+        enum mem_access_type access_type[] = {GLOBAL_ACC_W, LOCAL_ACC_W};
+        enum cache_request_status request_status[] = {MISS};
+        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
+        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+
+        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
+                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
+    }
+    unsigned get_l1d_write_hits(){
+        return (get_l1d_write_accesses()-get_l1d_write_misses());
+    }
+    unsigned get_cache_misses(){
+        return get_l1d_read_misses()+get_constant_c_misses()+get_l1d_write_misses()+get_texture_c_misses();
+    }
+	
+    unsigned get_cache_read_misses(){
+        return get_l1d_read_misses()+get_constant_c_misses()+get_texture_c_misses();
+    }
+
+    unsigned get_cache_write_misses(){
+        return get_l1d_write_misses();
+    }
+
+    unsigned get_shmem_read_access(){
+       unsigned total_inst=0;
+       for(unsigned i=0; i<m_config->num_shader();i++){
+           total_inst+=(pwr_mem_stat->shmem_read_access[CURRENT_STAT_IDX][i]) - (pwr_mem_stat->shmem_read_access[PREV_STAT_IDX][i]);
+       }
+       return total_inst;
+    }
+
+    unsigned get_l2_read_accesses(){
+        enum mem_access_type access_type[] = {GLOBAL_ACC_R, LOCAL_ACC_R, CONST_ACC_R, TEXTURE_ACC_R, INST_ACC_R};
+        enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
+        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
+        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+
+        return (pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
+                (pwr_mem_stat->l2_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
+    }
+
+    unsigned get_l2_read_misses(){
+        enum mem_access_type access_type[] = {GLOBAL_ACC_R, LOCAL_ACC_R, CONST_ACC_R, TEXTURE_ACC_R, INST_ACC_R};
+        enum cache_request_status request_status[] = {MISS};
+        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
+        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+
+        return (pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
+                (pwr_mem_stat->l2_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
+    }
+
+    unsigned get_l2_read_hits(){
+        return (get_l2_read_accesses()-get_l2_read_misses());
+    }
+
+    unsigned get_l2_write_accesses(){
+        enum mem_access_type access_type[] = {GLOBAL_ACC_W, LOCAL_ACC_W, L1_WRBK_ACC};
+        enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
+        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
+        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+
+        return (pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
+                (pwr_mem_stat->l2_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
+    }
+
+    unsigned get_l2_write_misses(){
+        enum mem_access_type access_type[] = {GLOBAL_ACC_W, LOCAL_ACC_W, L1_WRBK_ACC};
+        enum cache_request_status request_status[] = {MISS};
+        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
+        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+
+        return (pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
+                (pwr_mem_stat->l2_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
+    }
+    unsigned get_l2_write_hits(){
+        return (get_l2_write_accesses()-get_l2_write_misses());
+    }
+    unsigned get_dram_cmd(){
+        unsigned total=0;
+        for(unsigned i=0; i<m_mem_config->m_n_mem; ++i){
+            total += (pwr_mem_stat->n_cmd[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_cmd[PREV_STAT_IDX][i]);
+        }
+        return total;
+    }
+    unsigned get_dram_activity(){
+        unsigned total=0;
+        for(unsigned i=0; i<m_mem_config->m_n_mem; ++i){
+            total += (pwr_mem_stat->n_activity[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_activity[PREV_STAT_IDX][i]);
+        }
+        return total;
+    }
+    unsigned get_dram_nop(){
+        unsigned total=0;
+        for(unsigned i=0; i<m_mem_config->m_n_mem; ++i){
+            total += (pwr_mem_stat->n_nop[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_nop[PREV_STAT_IDX][i]);
+        }
+        return total;
+    }
+    unsigned get_dram_act(){
+        unsigned total=0;
+        for(unsigned i=0; i<m_mem_config->m_n_mem; ++i){
+            total += (pwr_mem_stat->n_act[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_act[PREV_STAT_IDX][i]);
+        }
+        return total;
+    }
+    unsigned get_dram_pre(){
+        unsigned total=0;
+        for(unsigned i=0; i<m_mem_config->m_n_mem; ++i){
+            total += (pwr_mem_stat->n_pre[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_pre[PREV_STAT_IDX][i]);
+        }
+        return total;
+    }
+    unsigned get_dram_rd(){
+        unsigned total=0;
+        for(unsigned i=0; i<m_mem_config->m_n_mem; ++i){
+            total += (pwr_mem_stat->n_rd[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_rd[PREV_STAT_IDX][i]);
+        }
+        return total;
+    }
+    unsigned get_dram_wr(){
+        unsigned total=0;
+        for(unsigned i=0; i<m_mem_config->m_n_mem; ++i){
+            total += (pwr_mem_stat->n_wr[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_wr[PREV_STAT_IDX][i]);
+        }
+        return total;
+    }
+    unsigned get_dram_req(){
+        unsigned total=0;
+        for(unsigned i=0; i<m_mem_config->m_n_mem; ++i){
+            total += (pwr_mem_stat->n_req[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_req[PREV_STAT_IDX][i]);
+        }
+        return total;
+    }
+
+    long get_icnt_simt_to_mem(){
+        long total=0;
+        for(unsigned i=0; i<m_config->n_simt_clusters; ++i){
+            total += (pwr_mem_stat->n_simt_to_mem[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_simt_to_mem[PREV_STAT_IDX][i]);
+        }
+        return total;
+    }
+
+    long get_icnt_mem_to_simt(){
+        long total=0;
+        for(unsigned i=0; i<m_config->n_simt_clusters; ++i){
+            total += (pwr_mem_stat->n_mem_to_simt[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_mem_to_simt[PREV_STAT_IDX][i]);
+        }
+        return total;
+    }
+
+   power_core_stat_t * pwr_core_stat;
+   power_mem_stat_t * pwr_mem_stat;
+   float * m_average_pipeline_duty_cycle;
+   float * m_active_sms;
+   const shader_core_config *m_config;
+   const memory_config *m_mem_config;
 };
+
 
 #endif /*POWER_LATENCY_STAT_H*/

--- a/src/gpgpu-sim/power_stat.h
+++ b/src/gpgpu-sim/power_stat.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -30,599 +32,750 @@
 
 #include <stdio.h>
 #include <zlib.h>
-#include "mem_latency_stat.h"
 #include "gpu-sim.h"
+#include "mem_latency_stat.h"
 
-typedef enum _stat_idx{
-    CURRENT_STAT_IDX = 0,    // Current activity count
-    PREV_STAT_IDX,           // Previous sample activity count
-    NUM_STAT_IDX     // Total number of samples
-}stat_idx;
-
+typedef enum _stat_idx {
+  CURRENT_STAT_IDX = 0,  // Current activity count
+  PREV_STAT_IDX,         // Previous sample activity count
+  NUM_STAT_IDX           // Total number of samples
+} stat_idx;
 
 struct shader_core_power_stats_pod {
-    // [CURRENT_STAT_IDX] = CURRENT_STAT_IDX stat, [PREV_STAT_IDX] = last reading
-    float *m_pipeline_duty_cycle[NUM_STAT_IDX];
-    unsigned *m_num_decoded_insn[NUM_STAT_IDX]; // number of instructions committed by this shader core
-    unsigned *m_num_FPdecoded_insn[NUM_STAT_IDX]; // number of instructions committed by this shader core
-    unsigned *m_num_INTdecoded_insn[NUM_STAT_IDX]; // number of instructions committed by this shader core
-    unsigned *m_num_storequeued_insn[NUM_STAT_IDX];
-    unsigned *m_num_loadqueued_insn[NUM_STAT_IDX];
-    unsigned *m_num_ialu_acesses[NUM_STAT_IDX];
-    unsigned *m_num_fp_acesses[NUM_STAT_IDX];
-    unsigned *m_num_tex_inst[NUM_STAT_IDX];
-    unsigned *m_num_imul_acesses[NUM_STAT_IDX];
-    unsigned *m_num_imul32_acesses[NUM_STAT_IDX];
-    unsigned *m_num_imul24_acesses[NUM_STAT_IDX];
-    unsigned *m_num_fpmul_acesses[NUM_STAT_IDX];
-    unsigned *m_num_idiv_acesses[NUM_STAT_IDX];
-    unsigned *m_num_fpdiv_acesses[NUM_STAT_IDX];
-    unsigned *m_num_sp_acesses[NUM_STAT_IDX];
-    unsigned *m_num_sfu_acesses[NUM_STAT_IDX];
-    unsigned *m_num_trans_acesses[NUM_STAT_IDX];
-    unsigned *m_num_mem_acesses[NUM_STAT_IDX];
-    unsigned *m_num_sp_committed[NUM_STAT_IDX];
-    unsigned *m_num_sfu_committed[NUM_STAT_IDX];
-    unsigned *m_num_mem_committed[NUM_STAT_IDX];
-    unsigned *m_active_sp_lanes[NUM_STAT_IDX];
-    unsigned *m_active_sfu_lanes[NUM_STAT_IDX];
-    unsigned *m_read_regfile_acesses[NUM_STAT_IDX];
-    unsigned *m_write_regfile_acesses[NUM_STAT_IDX];
-    unsigned *m_non_rf_operands[NUM_STAT_IDX];
+  // [CURRENT_STAT_IDX] = CURRENT_STAT_IDX stat, [PREV_STAT_IDX] = last reading
+  float *m_pipeline_duty_cycle[NUM_STAT_IDX];
+  unsigned *m_num_decoded_insn[NUM_STAT_IDX];  // number of instructions
+                                               // committed by this shader core
+  unsigned *m_num_FPdecoded_insn[NUM_STAT_IDX];   // number of instructions
+                                                  // committed by this shader
+                                                  // core
+  unsigned *m_num_INTdecoded_insn[NUM_STAT_IDX];  // number of instructions
+                                                  // committed by this shader
+                                                  // core
+  unsigned *m_num_storequeued_insn[NUM_STAT_IDX];
+  unsigned *m_num_loadqueued_insn[NUM_STAT_IDX];
+  unsigned *m_num_ialu_acesses[NUM_STAT_IDX];
+  unsigned *m_num_fp_acesses[NUM_STAT_IDX];
+  unsigned *m_num_tex_inst[NUM_STAT_IDX];
+  unsigned *m_num_imul_acesses[NUM_STAT_IDX];
+  unsigned *m_num_imul32_acesses[NUM_STAT_IDX];
+  unsigned *m_num_imul24_acesses[NUM_STAT_IDX];
+  unsigned *m_num_fpmul_acesses[NUM_STAT_IDX];
+  unsigned *m_num_idiv_acesses[NUM_STAT_IDX];
+  unsigned *m_num_fpdiv_acesses[NUM_STAT_IDX];
+  unsigned *m_num_sp_acesses[NUM_STAT_IDX];
+  unsigned *m_num_sfu_acesses[NUM_STAT_IDX];
+  unsigned *m_num_trans_acesses[NUM_STAT_IDX];
+  unsigned *m_num_mem_acesses[NUM_STAT_IDX];
+  unsigned *m_num_sp_committed[NUM_STAT_IDX];
+  unsigned *m_num_sfu_committed[NUM_STAT_IDX];
+  unsigned *m_num_mem_committed[NUM_STAT_IDX];
+  unsigned *m_active_sp_lanes[NUM_STAT_IDX];
+  unsigned *m_active_sfu_lanes[NUM_STAT_IDX];
+  unsigned *m_read_regfile_acesses[NUM_STAT_IDX];
+  unsigned *m_write_regfile_acesses[NUM_STAT_IDX];
+  unsigned *m_non_rf_operands[NUM_STAT_IDX];
 };
 
 class power_core_stat_t : public shader_core_power_stats_pod {
-public:
-   power_core_stat_t(const shader_core_config *shader_config, shader_core_stats *core_stats);
-   void visualizer_print( gzFile visualizer_file );
-   void print (FILE *fout);
-   void init();
-   void save_stats();
+ public:
+  power_core_stat_t(const shader_core_config *shader_config,
+                    shader_core_stats *core_stats);
+  void visualizer_print(gzFile visualizer_file);
+  void print(FILE *fout);
+  void init();
+  void save_stats();
 
-private:
-   shader_core_stats * m_core_stats;
-   const shader_core_config *m_config;
-   float average_duty_cycle;
-
-
+ private:
+  shader_core_stats *m_core_stats;
+  const shader_core_config *m_config;
+  float average_duty_cycle;
 };
 
-struct mem_power_stats_pod{
-    // [CURRENT_STAT_IDX] = CURRENT_STAT_IDX stat, [PREV_STAT_IDX] = last reading
-    class cache_stats core_cache_stats[NUM_STAT_IDX]; // Total core stats
-    class cache_stats l2_cache_stats[NUM_STAT_IDX]; // Total L2 partition stats
+struct mem_power_stats_pod {
+  // [CURRENT_STAT_IDX] = CURRENT_STAT_IDX stat, [PREV_STAT_IDX] = last reading
+  class cache_stats core_cache_stats[NUM_STAT_IDX];  // Total core stats
+  class cache_stats l2_cache_stats[NUM_STAT_IDX];    // Total L2 partition stats
 
-    unsigned *shmem_read_access[NUM_STAT_IDX];   // Shared memory access
+  unsigned *shmem_read_access[NUM_STAT_IDX];  // Shared memory access
 
-    // Low level DRAM stats
-    unsigned *n_cmd[NUM_STAT_IDX];
-    unsigned *n_activity[NUM_STAT_IDX];
-    unsigned *n_nop[NUM_STAT_IDX];
-    unsigned *n_act[NUM_STAT_IDX];
-    unsigned *n_pre[NUM_STAT_IDX];
-    unsigned *n_rd[NUM_STAT_IDX];
-    unsigned *n_wr[NUM_STAT_IDX];
-    unsigned *n_req[NUM_STAT_IDX];
+  // Low level DRAM stats
+  unsigned *n_cmd[NUM_STAT_IDX];
+  unsigned *n_activity[NUM_STAT_IDX];
+  unsigned *n_nop[NUM_STAT_IDX];
+  unsigned *n_act[NUM_STAT_IDX];
+  unsigned *n_pre[NUM_STAT_IDX];
+  unsigned *n_rd[NUM_STAT_IDX];
+  unsigned *n_wr[NUM_STAT_IDX];
+  unsigned *n_req[NUM_STAT_IDX];
 
-    // Interconnect stats
-    long *n_simt_to_mem[NUM_STAT_IDX];
-    long *n_mem_to_simt[NUM_STAT_IDX];
+  // Interconnect stats
+  long *n_simt_to_mem[NUM_STAT_IDX];
+  long *n_mem_to_simt[NUM_STAT_IDX];
 };
 
+class power_mem_stat_t : public mem_power_stats_pod {
+ public:
+  power_mem_stat_t(const memory_config *mem_config,
+                   const shader_core_config *shdr_config,
+                   memory_stats_t *mem_stats, shader_core_stats *shdr_stats);
+  void visualizer_print(gzFile visualizer_file);
+  void print(FILE *fout) const;
+  void init();
+  void save_stats();
 
-
-class power_mem_stat_t : public mem_power_stats_pod{
-public:
-   power_mem_stat_t(const memory_config *mem_config, const shader_core_config *shdr_config, memory_stats_t *mem_stats, shader_core_stats *shdr_stats);
-   void visualizer_print( gzFile visualizer_file );
-   void print (FILE *fout) const;
-   void init();
-   void save_stats();
-private:
-   memory_stats_t *m_mem_stats;
-   shader_core_stats * m_core_stats;
-   const memory_config *m_config;
-   const shader_core_config *m_core_config;
+ private:
+  memory_stats_t *m_mem_stats;
+  shader_core_stats *m_core_stats;
+  const memory_config *m_config;
+  const shader_core_config *m_core_config;
 };
-
 
 class power_stat_t {
-public:
-   power_stat_t( const shader_core_config *shader_config,float * average_pipeline_duty_cycle,float * active_sms,shader_core_stats * shader_stats, const memory_config *mem_config,memory_stats_t * memory_stats);
-   void visualizer_print( gzFile visualizer_file );
-   void print (FILE *fout) const;
-   void save_stats(){
-	   pwr_core_stat->save_stats();
-	   pwr_mem_stat->save_stats();
-	   *m_average_pipeline_duty_cycle=0;
-	   *m_active_sms=0;
-   }
+ public:
+  power_stat_t(const shader_core_config *shader_config,
+               float *average_pipeline_duty_cycle, float *active_sms,
+               shader_core_stats *shader_stats, const memory_config *mem_config,
+               memory_stats_t *memory_stats);
+  void visualizer_print(gzFile visualizer_file);
+  void print(FILE *fout) const;
+  void save_stats() {
+    pwr_core_stat->save_stats();
+    pwr_mem_stat->save_stats();
+    *m_average_pipeline_duty_cycle = 0;
+    *m_active_sms = 0;
+  }
 
-    unsigned get_total_inst(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_decoded_insn[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_decoded_insn[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+  unsigned get_total_inst() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_decoded_insn[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_decoded_insn[PREV_STAT_IDX][i]);
     }
-    unsigned get_total_int_inst(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_INTdecoded_insn[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_INTdecoded_insn[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+    return total_inst;
+  }
+  unsigned get_total_int_inst() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst +=
+          (pwr_core_stat->m_num_INTdecoded_insn[CURRENT_STAT_IDX][i]) -
+          (pwr_core_stat->m_num_INTdecoded_insn[PREV_STAT_IDX][i]);
     }
-    unsigned get_total_fp_inst(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_FPdecoded_insn[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_FPdecoded_insn[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+    return total_inst;
+  }
+  unsigned get_total_fp_inst() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_FPdecoded_insn[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_FPdecoded_insn[PREV_STAT_IDX][i]);
     }
-    unsigned get_total_load_inst(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_loadqueued_insn[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_loadqueued_insn[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+    return total_inst;
+  }
+  unsigned get_total_load_inst() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst +=
+          (pwr_core_stat->m_num_loadqueued_insn[CURRENT_STAT_IDX][i]) -
+          (pwr_core_stat->m_num_loadqueued_insn[PREV_STAT_IDX][i]);
     }
-    unsigned get_total_store_inst(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_storequeued_insn[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_storequeued_insn[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+    return total_inst;
+  }
+  unsigned get_total_store_inst() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst +=
+          (pwr_core_stat->m_num_storequeued_insn[CURRENT_STAT_IDX][i]) -
+          (pwr_core_stat->m_num_storequeued_insn[PREV_STAT_IDX][i]);
     }
-    unsigned get_sp_committed_inst(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_sp_committed[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_sp_committed[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+    return total_inst;
+  }
+  unsigned get_sp_committed_inst() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_sp_committed[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_sp_committed[PREV_STAT_IDX][i]);
     }
-    unsigned get_sfu_committed_inst(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_sfu_committed[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_sfu_committed[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+    return total_inst;
+  }
+  unsigned get_sfu_committed_inst() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_sfu_committed[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_sfu_committed[PREV_STAT_IDX][i]);
     }
-    unsigned get_mem_committed_inst(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_mem_committed[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_mem_committed[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+    return total_inst;
+  }
+  unsigned get_mem_committed_inst() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_mem_committed[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_mem_committed[PREV_STAT_IDX][i]);
     }
-    unsigned get_committed_inst(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_mem_committed[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_mem_committed[PREV_STAT_IDX][i])
-                    +(pwr_core_stat->m_num_sfu_committed[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_sfu_committed[PREV_STAT_IDX][i])
-                    +(pwr_core_stat->m_num_sp_committed[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_sp_committed[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+    return total_inst;
+  }
+  unsigned get_committed_inst() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_mem_committed[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_mem_committed[PREV_STAT_IDX][i]) +
+                    (pwr_core_stat->m_num_sfu_committed[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_sfu_committed[PREV_STAT_IDX][i]) +
+                    (pwr_core_stat->m_num_sp_committed[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_sp_committed[PREV_STAT_IDX][i]);
     }
-    unsigned get_regfile_reads(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_read_regfile_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_read_regfile_acesses[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+    return total_inst;
+  }
+  unsigned get_regfile_reads() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst +=
+          (pwr_core_stat->m_read_regfile_acesses[CURRENT_STAT_IDX][i]) -
+          (pwr_core_stat->m_read_regfile_acesses[PREV_STAT_IDX][i]);
     }
-    unsigned get_regfile_writes(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_write_regfile_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_write_regfile_acesses[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+    return total_inst;
+  }
+  unsigned get_regfile_writes() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst +=
+          (pwr_core_stat->m_write_regfile_acesses[CURRENT_STAT_IDX][i]) -
+          (pwr_core_stat->m_write_regfile_acesses[PREV_STAT_IDX][i]);
     }
+    return total_inst;
+  }
 
-    float get_pipeline_duty(){
-        float total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_pipeline_duty_cycle[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_pipeline_duty_cycle[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+  float get_pipeline_duty() {
+    float total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst +=
+          (pwr_core_stat->m_pipeline_duty_cycle[CURRENT_STAT_IDX][i]) -
+          (pwr_core_stat->m_pipeline_duty_cycle[PREV_STAT_IDX][i]);
     }
+    return total_inst;
+  }
 
-    unsigned get_non_regfile_operands(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_non_rf_operands[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_non_rf_operands[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+  unsigned get_non_regfile_operands() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_non_rf_operands[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_non_rf_operands[PREV_STAT_IDX][i]);
     }
+    return total_inst;
+  }
 
-    unsigned get_sp_accessess(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_sp_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_sp_acesses[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+  unsigned get_sp_accessess() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_sp_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_sp_acesses[PREV_STAT_IDX][i]);
     }
+    return total_inst;
+  }
 
-    unsigned get_sfu_accessess(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_sfu_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_sfu_acesses[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+  unsigned get_sfu_accessess() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_sfu_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_sfu_acesses[PREV_STAT_IDX][i]);
     }
-    unsigned get_trans_accessess(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_trans_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_trans_acesses[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+    return total_inst;
+  }
+  unsigned get_trans_accessess() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_trans_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_trans_acesses[PREV_STAT_IDX][i]);
     }
+    return total_inst;
+  }
 
-    unsigned get_mem_accessess(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_mem_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_mem_acesses[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+  unsigned get_mem_accessess() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_mem_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_mem_acesses[PREV_STAT_IDX][i]);
     }
+    return total_inst;
+  }
 
-    unsigned get_intdiv_accessess(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_idiv_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_idiv_acesses[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+  unsigned get_intdiv_accessess() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_idiv_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_idiv_acesses[PREV_STAT_IDX][i]);
     }
+    return total_inst;
+  }
 
-    unsigned get_fpdiv_accessess(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_fpdiv_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_fpdiv_acesses[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+  unsigned get_fpdiv_accessess() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_fpdiv_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_fpdiv_acesses[PREV_STAT_IDX][i]);
     }
+    return total_inst;
+  }
 
-    unsigned get_intmul32_accessess(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_imul32_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_imul32_acesses[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+  unsigned get_intmul32_accessess() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_imul32_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_imul32_acesses[PREV_STAT_IDX][i]);
     }
+    return total_inst;
+  }
 
-    unsigned get_intmul24_accessess(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_imul24_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_imul24_acesses[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+  unsigned get_intmul24_accessess() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_imul24_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_imul24_acesses[PREV_STAT_IDX][i]);
     }
+    return total_inst;
+  }
 
-    unsigned get_intmul_accessess(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_imul_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_imul_acesses[PREV_STAT_IDX][i])+
-                    (pwr_core_stat->m_num_imul24_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_imul24_acesses[PREV_STAT_IDX][i])+
-                    (pwr_core_stat->m_num_imul32_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_imul32_acesses[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+  unsigned get_intmul_accessess() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_imul_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_imul_acesses[PREV_STAT_IDX][i]) +
+                    (pwr_core_stat->m_num_imul24_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_imul24_acesses[PREV_STAT_IDX][i]) +
+                    (pwr_core_stat->m_num_imul32_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_imul32_acesses[PREV_STAT_IDX][i]);
     }
+    return total_inst;
+  }
 
-    unsigned get_fpmul_accessess(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_fp_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_fp_acesses[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+  unsigned get_fpmul_accessess() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_fp_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_fp_acesses[PREV_STAT_IDX][i]);
     }
+    return total_inst;
+  }
 
-    float get_sp_active_lanes(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_active_sp_lanes[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_active_sp_lanes[PREV_STAT_IDX][i]);
-        }
-        return (total_inst/m_config->num_shader())/m_config->gpgpu_num_sp_units;
+  float get_sp_active_lanes() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_active_sp_lanes[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_active_sp_lanes[PREV_STAT_IDX][i]);
     }
+    return (total_inst / m_config->num_shader()) / m_config->gpgpu_num_sp_units;
+  }
 
-    float get_sfu_active_lanes(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_active_sfu_lanes[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_active_sfu_lanes[PREV_STAT_IDX][i]);
-        }
-
-        return (total_inst/m_config->num_shader())/m_config->gpgpu_num_sfu_units;
-    }
-
-    unsigned get_tot_fpu_accessess(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_fp_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_fp_acesses[PREV_STAT_IDX][i])+
-                    (pwr_core_stat->m_num_fpdiv_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_fpdiv_acesses[PREV_STAT_IDX][i])+
-                    (pwr_core_stat->m_num_fpmul_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_fpmul_acesses[PREV_STAT_IDX][i])+
-                    (pwr_core_stat->m_num_imul24_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_imul24_acesses[PREV_STAT_IDX][i])+
-                    (pwr_core_stat->m_num_imul_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_imul_acesses[PREV_STAT_IDX][i]);
-        }
-        total_inst += get_total_load_inst()+get_total_store_inst()+get_tex_inst();
-        return total_inst;
-    }
-
-    unsigned get_tot_sfu_accessess(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-                total_inst+= (pwr_core_stat->m_num_idiv_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_idiv_acesses[PREV_STAT_IDX][i])+
-                            (pwr_core_stat->m_num_imul32_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_imul32_acesses[PREV_STAT_IDX][i])+
-                            (pwr_core_stat->m_num_trans_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_trans_acesses[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
-    }
-
-    unsigned get_ialu_accessess(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_ialu_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_ialu_acesses[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
-    }
-
-    unsigned get_tex_inst(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_tex_inst[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_tex_inst[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+  float get_sfu_active_lanes() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_active_sfu_lanes[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_active_sfu_lanes[PREV_STAT_IDX][i]);
     }
 
-    unsigned get_constant_c_accesses(){
-        enum mem_access_type access_type[] = {CONST_ACC_R};
-        enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
-        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
-        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+    return (total_inst / m_config->num_shader()) /
+           m_config->gpgpu_num_sfu_units;
+  }
 
-        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
-                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
+  unsigned get_tot_fpu_accessess() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_fp_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_fp_acesses[PREV_STAT_IDX][i]) +
+                    (pwr_core_stat->m_num_fpdiv_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_fpdiv_acesses[PREV_STAT_IDX][i]) +
+                    (pwr_core_stat->m_num_fpmul_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_fpmul_acesses[PREV_STAT_IDX][i]) +
+                    (pwr_core_stat->m_num_imul24_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_imul24_acesses[PREV_STAT_IDX][i]) +
+                    (pwr_core_stat->m_num_imul_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_imul_acesses[PREV_STAT_IDX][i]);
     }
-    unsigned get_constant_c_misses(){
-        enum mem_access_type access_type[] = {CONST_ACC_R};
-        enum cache_request_status request_status[] = {MISS};
-        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
-        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+    total_inst +=
+        get_total_load_inst() + get_total_store_inst() + get_tex_inst();
+    return total_inst;
+  }
 
-        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
-                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
+  unsigned get_tot_sfu_accessess() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_idiv_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_idiv_acesses[PREV_STAT_IDX][i]) +
+                    (pwr_core_stat->m_num_imul32_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_imul32_acesses[PREV_STAT_IDX][i]) +
+                    (pwr_core_stat->m_num_trans_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_trans_acesses[PREV_STAT_IDX][i]);
     }
-    unsigned get_constant_c_hits(){
-        return (get_constant_c_accesses()-get_constant_c_misses());
-    }
-    unsigned get_texture_c_accesses(){
-        enum mem_access_type access_type[] = {TEXTURE_ACC_R};
-        enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
-        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
-        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+    return total_inst;
+  }
 
-        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
-                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
+  unsigned get_ialu_accessess() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_ialu_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_ialu_acesses[PREV_STAT_IDX][i]);
     }
-    unsigned get_texture_c_misses(){
-        enum mem_access_type access_type[] = {TEXTURE_ACC_R};
-        enum cache_request_status request_status[] = {MISS};
-        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
-        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+    return total_inst;
+  }
 
-        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
-                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
+  unsigned get_tex_inst() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_tex_inst[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_tex_inst[PREV_STAT_IDX][i]);
     }
-    unsigned get_texture_c_hits(){
-        return ( get_texture_c_accesses()- get_texture_c_misses());
-    }
-    unsigned get_inst_c_accesses(){
-        enum mem_access_type access_type[] = {INST_ACC_R};
-        enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
-        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
-        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+    return total_inst;
+  }
 
-        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
-                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
-    }
-    unsigned get_inst_c_misses(){
-        enum mem_access_type access_type[] = {INST_ACC_R};
-        enum cache_request_status request_status[] = {MISS};
-        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
-        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+  unsigned get_constant_c_accesses() {
+    enum mem_access_type access_type[] = {CONST_ACC_R};
+    enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
+    unsigned num_access_type =
+        sizeof(access_type) / sizeof(enum mem_access_type);
+    unsigned num_request_status =
+        sizeof(request_status) / sizeof(enum cache_request_status);
 
-        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
-                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
-    }
-    unsigned get_inst_c_hits(){
-        return (get_inst_c_accesses()-get_inst_c_misses());
-    }
+    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status)) -
+           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status));
+  }
+  unsigned get_constant_c_misses() {
+    enum mem_access_type access_type[] = {CONST_ACC_R};
+    enum cache_request_status request_status[] = {MISS};
+    unsigned num_access_type =
+        sizeof(access_type) / sizeof(enum mem_access_type);
+    unsigned num_request_status =
+        sizeof(request_status) / sizeof(enum cache_request_status);
 
-    unsigned get_l1d_read_accesses(){
-        enum mem_access_type access_type[] = {GLOBAL_ACC_R, LOCAL_ACC_R};
-        enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
-        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
-        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status)) -
+           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status));
+  }
+  unsigned get_constant_c_hits() {
+    return (get_constant_c_accesses() - get_constant_c_misses());
+  }
+  unsigned get_texture_c_accesses() {
+    enum mem_access_type access_type[] = {TEXTURE_ACC_R};
+    enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
+    unsigned num_access_type =
+        sizeof(access_type) / sizeof(enum mem_access_type);
+    unsigned num_request_status =
+        sizeof(request_status) / sizeof(enum cache_request_status);
 
-        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
-                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
-    }
-    unsigned get_l1d_read_misses(){
-        enum mem_access_type access_type[] = {GLOBAL_ACC_R, LOCAL_ACC_R};
-        enum cache_request_status request_status[] = {MISS};
-        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
-        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status)) -
+           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status));
+  }
+  unsigned get_texture_c_misses() {
+    enum mem_access_type access_type[] = {TEXTURE_ACC_R};
+    enum cache_request_status request_status[] = {MISS};
+    unsigned num_access_type =
+        sizeof(access_type) / sizeof(enum mem_access_type);
+    unsigned num_request_status =
+        sizeof(request_status) / sizeof(enum cache_request_status);
 
-        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
-                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
-    }
-    unsigned get_l1d_read_hits(){
-        return (get_l1d_read_accesses()-get_l1d_read_misses());
-    }
-    unsigned get_l1d_write_accesses(){
-        enum mem_access_type access_type[] = {GLOBAL_ACC_W, LOCAL_ACC_W};
-        enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
-        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
-        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status)) -
+           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status));
+  }
+  unsigned get_texture_c_hits() {
+    return (get_texture_c_accesses() - get_texture_c_misses());
+  }
+  unsigned get_inst_c_accesses() {
+    enum mem_access_type access_type[] = {INST_ACC_R};
+    enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
+    unsigned num_access_type =
+        sizeof(access_type) / sizeof(enum mem_access_type);
+    unsigned num_request_status =
+        sizeof(request_status) / sizeof(enum cache_request_status);
 
-        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
-                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
-    }
-    unsigned get_l1d_write_misses(){
-        enum mem_access_type access_type[] = {GLOBAL_ACC_W, LOCAL_ACC_W};
-        enum cache_request_status request_status[] = {MISS};
-        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
-        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status)) -
+           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status));
+  }
+  unsigned get_inst_c_misses() {
+    enum mem_access_type access_type[] = {INST_ACC_R};
+    enum cache_request_status request_status[] = {MISS};
+    unsigned num_access_type =
+        sizeof(access_type) / sizeof(enum mem_access_type);
+    unsigned num_request_status =
+        sizeof(request_status) / sizeof(enum cache_request_status);
 
-        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
-                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
-    }
-    unsigned get_l1d_write_hits(){
-        return (get_l1d_write_accesses()-get_l1d_write_misses());
-    }
-    unsigned get_cache_misses(){
-        return get_l1d_read_misses()+get_constant_c_misses()+get_l1d_write_misses()+get_texture_c_misses();
-    }
-	
-    unsigned get_cache_read_misses(){
-        return get_l1d_read_misses()+get_constant_c_misses()+get_texture_c_misses();
-    }
+    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status)) -
+           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status));
+  }
+  unsigned get_inst_c_hits() {
+    return (get_inst_c_accesses() - get_inst_c_misses());
+  }
 
-    unsigned get_cache_write_misses(){
-        return get_l1d_write_misses();
-    }
+  unsigned get_l1d_read_accesses() {
+    enum mem_access_type access_type[] = {GLOBAL_ACC_R, LOCAL_ACC_R};
+    enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
+    unsigned num_access_type =
+        sizeof(access_type) / sizeof(enum mem_access_type);
+    unsigned num_request_status =
+        sizeof(request_status) / sizeof(enum cache_request_status);
 
-    unsigned get_shmem_read_access(){
-       unsigned total_inst=0;
-       for(unsigned i=0; i<m_config->num_shader();i++){
-           total_inst+=(pwr_mem_stat->shmem_read_access[CURRENT_STAT_IDX][i]) - (pwr_mem_stat->shmem_read_access[PREV_STAT_IDX][i]);
-       }
-       return total_inst;
-    }
+    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status)) -
+           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status));
+  }
+  unsigned get_l1d_read_misses() {
+    enum mem_access_type access_type[] = {GLOBAL_ACC_R, LOCAL_ACC_R};
+    enum cache_request_status request_status[] = {MISS};
+    unsigned num_access_type =
+        sizeof(access_type) / sizeof(enum mem_access_type);
+    unsigned num_request_status =
+        sizeof(request_status) / sizeof(enum cache_request_status);
 
-    unsigned get_l2_read_accesses(){
-        enum mem_access_type access_type[] = {GLOBAL_ACC_R, LOCAL_ACC_R, CONST_ACC_R, TEXTURE_ACC_R, INST_ACC_R};
-        enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
-        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
-        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status)) -
+           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status));
+  }
+  unsigned get_l1d_read_hits() {
+    return (get_l1d_read_accesses() - get_l1d_read_misses());
+  }
+  unsigned get_l1d_write_accesses() {
+    enum mem_access_type access_type[] = {GLOBAL_ACC_W, LOCAL_ACC_W};
+    enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
+    unsigned num_access_type =
+        sizeof(access_type) / sizeof(enum mem_access_type);
+    unsigned num_request_status =
+        sizeof(request_status) / sizeof(enum cache_request_status);
 
-        return (pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
-                (pwr_mem_stat->l2_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
-    }
+    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status)) -
+           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status));
+  }
+  unsigned get_l1d_write_misses() {
+    enum mem_access_type access_type[] = {GLOBAL_ACC_W, LOCAL_ACC_W};
+    enum cache_request_status request_status[] = {MISS};
+    unsigned num_access_type =
+        sizeof(access_type) / sizeof(enum mem_access_type);
+    unsigned num_request_status =
+        sizeof(request_status) / sizeof(enum cache_request_status);
 
-    unsigned get_l2_read_misses(){
-        enum mem_access_type access_type[] = {GLOBAL_ACC_R, LOCAL_ACC_R, CONST_ACC_R, TEXTURE_ACC_R, INST_ACC_R};
-        enum cache_request_status request_status[] = {MISS};
-        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
-        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status)) -
+           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status));
+  }
+  unsigned get_l1d_write_hits() {
+    return (get_l1d_write_accesses() - get_l1d_write_misses());
+  }
+  unsigned get_cache_misses() {
+    return get_l1d_read_misses() + get_constant_c_misses() +
+           get_l1d_write_misses() + get_texture_c_misses();
+  }
 
-        return (pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
-                (pwr_mem_stat->l2_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
-    }
+  unsigned get_cache_read_misses() {
+    return get_l1d_read_misses() + get_constant_c_misses() +
+           get_texture_c_misses();
+  }
 
-    unsigned get_l2_read_hits(){
-        return (get_l2_read_accesses()-get_l2_read_misses());
-    }
+  unsigned get_cache_write_misses() { return get_l1d_write_misses(); }
 
-    unsigned get_l2_write_accesses(){
-        enum mem_access_type access_type[] = {GLOBAL_ACC_W, LOCAL_ACC_W, L1_WRBK_ACC};
-        enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
-        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
-        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+  unsigned get_shmem_read_access() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_mem_stat->shmem_read_access[CURRENT_STAT_IDX][i]) -
+                    (pwr_mem_stat->shmem_read_access[PREV_STAT_IDX][i]);
+    }
+    return total_inst;
+  }
 
-        return (pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
-                (pwr_mem_stat->l2_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
-    }
+  unsigned get_l2_read_accesses() {
+    enum mem_access_type access_type[] = {
+        GLOBAL_ACC_R, LOCAL_ACC_R, CONST_ACC_R, TEXTURE_ACC_R, INST_ACC_R};
+    enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
+    unsigned num_access_type =
+        sizeof(access_type) / sizeof(enum mem_access_type);
+    unsigned num_request_status =
+        sizeof(request_status) / sizeof(enum cache_request_status);
 
-    unsigned get_l2_write_misses(){
-        enum mem_access_type access_type[] = {GLOBAL_ACC_W, LOCAL_ACC_W, L1_WRBK_ACC};
-        enum cache_request_status request_status[] = {MISS};
-        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
-        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+    return (pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status)) -
+           (pwr_mem_stat->l2_cache_stats[PREV_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status));
+  }
 
-        return (pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
-                (pwr_mem_stat->l2_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
-    }
-    unsigned get_l2_write_hits(){
-        return (get_l2_write_accesses()-get_l2_write_misses());
-    }
-    unsigned get_dram_cmd(){
-        unsigned total=0;
-        for(unsigned i=0; i<m_mem_config->m_n_mem; ++i){
-            total += (pwr_mem_stat->n_cmd[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_cmd[PREV_STAT_IDX][i]);
-        }
-        return total;
-    }
-    unsigned get_dram_activity(){
-        unsigned total=0;
-        for(unsigned i=0; i<m_mem_config->m_n_mem; ++i){
-            total += (pwr_mem_stat->n_activity[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_activity[PREV_STAT_IDX][i]);
-        }
-        return total;
-    }
-    unsigned get_dram_nop(){
-        unsigned total=0;
-        for(unsigned i=0; i<m_mem_config->m_n_mem; ++i){
-            total += (pwr_mem_stat->n_nop[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_nop[PREV_STAT_IDX][i]);
-        }
-        return total;
-    }
-    unsigned get_dram_act(){
-        unsigned total=0;
-        for(unsigned i=0; i<m_mem_config->m_n_mem; ++i){
-            total += (pwr_mem_stat->n_act[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_act[PREV_STAT_IDX][i]);
-        }
-        return total;
-    }
-    unsigned get_dram_pre(){
-        unsigned total=0;
-        for(unsigned i=0; i<m_mem_config->m_n_mem; ++i){
-            total += (pwr_mem_stat->n_pre[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_pre[PREV_STAT_IDX][i]);
-        }
-        return total;
-    }
-    unsigned get_dram_rd(){
-        unsigned total=0;
-        for(unsigned i=0; i<m_mem_config->m_n_mem; ++i){
-            total += (pwr_mem_stat->n_rd[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_rd[PREV_STAT_IDX][i]);
-        }
-        return total;
-    }
-    unsigned get_dram_wr(){
-        unsigned total=0;
-        for(unsigned i=0; i<m_mem_config->m_n_mem; ++i){
-            total += (pwr_mem_stat->n_wr[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_wr[PREV_STAT_IDX][i]);
-        }
-        return total;
-    }
-    unsigned get_dram_req(){
-        unsigned total=0;
-        for(unsigned i=0; i<m_mem_config->m_n_mem; ++i){
-            total += (pwr_mem_stat->n_req[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_req[PREV_STAT_IDX][i]);
-        }
-        return total;
-    }
+  unsigned get_l2_read_misses() {
+    enum mem_access_type access_type[] = {
+        GLOBAL_ACC_R, LOCAL_ACC_R, CONST_ACC_R, TEXTURE_ACC_R, INST_ACC_R};
+    enum cache_request_status request_status[] = {MISS};
+    unsigned num_access_type =
+        sizeof(access_type) / sizeof(enum mem_access_type);
+    unsigned num_request_status =
+        sizeof(request_status) / sizeof(enum cache_request_status);
 
-    long get_icnt_simt_to_mem(){
-        long total=0;
-        for(unsigned i=0; i<m_config->n_simt_clusters; ++i){
-            total += (pwr_mem_stat->n_simt_to_mem[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_simt_to_mem[PREV_STAT_IDX][i]);
-        }
-        return total;
-    }
+    return (pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status)) -
+           (pwr_mem_stat->l2_cache_stats[PREV_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status));
+  }
 
-    long get_icnt_mem_to_simt(){
-        long total=0;
-        for(unsigned i=0; i<m_config->n_simt_clusters; ++i){
-            total += (pwr_mem_stat->n_mem_to_simt[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_mem_to_simt[PREV_STAT_IDX][i]);
-        }
-        return total;
-    }
+  unsigned get_l2_read_hits() {
+    return (get_l2_read_accesses() - get_l2_read_misses());
+  }
 
-   power_core_stat_t * pwr_core_stat;
-   power_mem_stat_t * pwr_mem_stat;
-   float * m_average_pipeline_duty_cycle;
-   float * m_active_sms;
-   const shader_core_config *m_config;
-   const memory_config *m_mem_config;
+  unsigned get_l2_write_accesses() {
+    enum mem_access_type access_type[] = {GLOBAL_ACC_W, LOCAL_ACC_W,
+                                          L1_WRBK_ACC};
+    enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
+    unsigned num_access_type =
+        sizeof(access_type) / sizeof(enum mem_access_type);
+    unsigned num_request_status =
+        sizeof(request_status) / sizeof(enum cache_request_status);
+
+    return (pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status)) -
+           (pwr_mem_stat->l2_cache_stats[PREV_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status));
+  }
+
+  unsigned get_l2_write_misses() {
+    enum mem_access_type access_type[] = {GLOBAL_ACC_W, LOCAL_ACC_W,
+                                          L1_WRBK_ACC};
+    enum cache_request_status request_status[] = {MISS};
+    unsigned num_access_type =
+        sizeof(access_type) / sizeof(enum mem_access_type);
+    unsigned num_request_status =
+        sizeof(request_status) / sizeof(enum cache_request_status);
+
+    return (pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status)) -
+           (pwr_mem_stat->l2_cache_stats[PREV_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status));
+  }
+  unsigned get_l2_write_hits() {
+    return (get_l2_write_accesses() - get_l2_write_misses());
+  }
+  unsigned get_dram_cmd() {
+    unsigned total = 0;
+    for (unsigned i = 0; i < m_mem_config->m_n_mem; ++i) {
+      total += (pwr_mem_stat->n_cmd[CURRENT_STAT_IDX][i] -
+                pwr_mem_stat->n_cmd[PREV_STAT_IDX][i]);
+    }
+    return total;
+  }
+  unsigned get_dram_activity() {
+    unsigned total = 0;
+    for (unsigned i = 0; i < m_mem_config->m_n_mem; ++i) {
+      total += (pwr_mem_stat->n_activity[CURRENT_STAT_IDX][i] -
+                pwr_mem_stat->n_activity[PREV_STAT_IDX][i]);
+    }
+    return total;
+  }
+  unsigned get_dram_nop() {
+    unsigned total = 0;
+    for (unsigned i = 0; i < m_mem_config->m_n_mem; ++i) {
+      total += (pwr_mem_stat->n_nop[CURRENT_STAT_IDX][i] -
+                pwr_mem_stat->n_nop[PREV_STAT_IDX][i]);
+    }
+    return total;
+  }
+  unsigned get_dram_act() {
+    unsigned total = 0;
+    for (unsigned i = 0; i < m_mem_config->m_n_mem; ++i) {
+      total += (pwr_mem_stat->n_act[CURRENT_STAT_IDX][i] -
+                pwr_mem_stat->n_act[PREV_STAT_IDX][i]);
+    }
+    return total;
+  }
+  unsigned get_dram_pre() {
+    unsigned total = 0;
+    for (unsigned i = 0; i < m_mem_config->m_n_mem; ++i) {
+      total += (pwr_mem_stat->n_pre[CURRENT_STAT_IDX][i] -
+                pwr_mem_stat->n_pre[PREV_STAT_IDX][i]);
+    }
+    return total;
+  }
+  unsigned get_dram_rd() {
+    unsigned total = 0;
+    for (unsigned i = 0; i < m_mem_config->m_n_mem; ++i) {
+      total += (pwr_mem_stat->n_rd[CURRENT_STAT_IDX][i] -
+                pwr_mem_stat->n_rd[PREV_STAT_IDX][i]);
+    }
+    return total;
+  }
+  unsigned get_dram_wr() {
+    unsigned total = 0;
+    for (unsigned i = 0; i < m_mem_config->m_n_mem; ++i) {
+      total += (pwr_mem_stat->n_wr[CURRENT_STAT_IDX][i] -
+                pwr_mem_stat->n_wr[PREV_STAT_IDX][i]);
+    }
+    return total;
+  }
+  unsigned get_dram_req() {
+    unsigned total = 0;
+    for (unsigned i = 0; i < m_mem_config->m_n_mem; ++i) {
+      total += (pwr_mem_stat->n_req[CURRENT_STAT_IDX][i] -
+                pwr_mem_stat->n_req[PREV_STAT_IDX][i]);
+    }
+    return total;
+  }
+
+  long get_icnt_simt_to_mem() {
+    long total = 0;
+    for (unsigned i = 0; i < m_config->n_simt_clusters; ++i) {
+      total += (pwr_mem_stat->n_simt_to_mem[CURRENT_STAT_IDX][i] -
+                pwr_mem_stat->n_simt_to_mem[PREV_STAT_IDX][i]);
+    }
+    return total;
+  }
+
+  long get_icnt_mem_to_simt() {
+    long total = 0;
+    for (unsigned i = 0; i < m_config->n_simt_clusters; ++i) {
+      total += (pwr_mem_stat->n_mem_to_simt[CURRENT_STAT_IDX][i] -
+                pwr_mem_stat->n_mem_to_simt[PREV_STAT_IDX][i]);
+    }
+    return total;
+  }
+
+  power_core_stat_t *pwr_core_stat;
+  power_mem_stat_t *pwr_mem_stat;
+  float *m_average_pipeline_duty_cycle;
+  float *m_active_sms;
+  const shader_core_config *m_config;
+  const memory_config *m_mem_config;
 };
-
 
 #endif /*POWER_LATENCY_STAT_H*/

--- a/src/gpgpu-sim/power_stat.h
+++ b/src/gpgpu-sim/power_stat.h
@@ -7,622 +7,774 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef POWER_STAT_H
 #define POWER_STAT_H
 
 #include <stdio.h>
 #include <zlib.h>
-#include "mem_latency_stat.h"
 #include "gpu-sim.h"
+#include "mem_latency_stat.h"
 
-typedef enum _stat_idx{
-    CURRENT_STAT_IDX = 0,    // Current activity count
-    PREV_STAT_IDX,           // Previous sample activity count
-    NUM_STAT_IDX     // Total number of samples
-}stat_idx;
-
+typedef enum _stat_idx {
+  CURRENT_STAT_IDX = 0,  // Current activity count
+  PREV_STAT_IDX,         // Previous sample activity count
+  NUM_STAT_IDX           // Total number of samples
+} stat_idx;
 
 struct shader_core_power_stats_pod {
-    // [CURRENT_STAT_IDX] = CURRENT_STAT_IDX stat, [PREV_STAT_IDX] = last reading
-    float *m_pipeline_duty_cycle[NUM_STAT_IDX];
-    unsigned *m_num_decoded_insn[NUM_STAT_IDX]; // number of instructions committed by this shader core
-    unsigned *m_num_FPdecoded_insn[NUM_STAT_IDX]; // number of instructions committed by this shader core
-    unsigned *m_num_INTdecoded_insn[NUM_STAT_IDX]; // number of instructions committed by this shader core
-    unsigned *m_num_storequeued_insn[NUM_STAT_IDX];
-    unsigned *m_num_loadqueued_insn[NUM_STAT_IDX];
-    unsigned *m_num_ialu_acesses[NUM_STAT_IDX];
-    unsigned *m_num_fp_acesses[NUM_STAT_IDX];
-    unsigned *m_num_tex_inst[NUM_STAT_IDX];
-    unsigned *m_num_imul_acesses[NUM_STAT_IDX];
-    unsigned *m_num_imul32_acesses[NUM_STAT_IDX];
-    unsigned *m_num_imul24_acesses[NUM_STAT_IDX];
-    unsigned *m_num_fpmul_acesses[NUM_STAT_IDX];
-    unsigned *m_num_idiv_acesses[NUM_STAT_IDX];
-    unsigned *m_num_fpdiv_acesses[NUM_STAT_IDX];
-    unsigned *m_num_sp_acesses[NUM_STAT_IDX];
-    unsigned *m_num_sfu_acesses[NUM_STAT_IDX];
-    unsigned *m_num_trans_acesses[NUM_STAT_IDX];
-    unsigned *m_num_mem_acesses[NUM_STAT_IDX];
-    unsigned *m_num_sp_committed[NUM_STAT_IDX];
-    unsigned *m_num_sfu_committed[NUM_STAT_IDX];
-    unsigned *m_num_mem_committed[NUM_STAT_IDX];
-    unsigned *m_active_sp_lanes[NUM_STAT_IDX];
-    unsigned *m_active_sfu_lanes[NUM_STAT_IDX];
-    unsigned *m_read_regfile_acesses[NUM_STAT_IDX];
-    unsigned *m_write_regfile_acesses[NUM_STAT_IDX];
-    unsigned *m_non_rf_operands[NUM_STAT_IDX];
+  // [CURRENT_STAT_IDX] = CURRENT_STAT_IDX stat, [PREV_STAT_IDX] = last reading
+  float *m_pipeline_duty_cycle[NUM_STAT_IDX];
+  unsigned *m_num_decoded_insn[NUM_STAT_IDX];  // number of instructions
+                                               // committed by this shader core
+  unsigned
+      *m_num_FPdecoded_insn[NUM_STAT_IDX];  // number of instructions committed
+                                            // by this shader core
+  unsigned
+      *m_num_INTdecoded_insn[NUM_STAT_IDX];  // number of instructions committed
+                                             // by this shader core
+  unsigned *m_num_storequeued_insn[NUM_STAT_IDX];
+  unsigned *m_num_loadqueued_insn[NUM_STAT_IDX];
+  unsigned *m_num_ialu_acesses[NUM_STAT_IDX];
+  unsigned *m_num_fp_acesses[NUM_STAT_IDX];
+  unsigned *m_num_tex_inst[NUM_STAT_IDX];
+  unsigned *m_num_imul_acesses[NUM_STAT_IDX];
+  unsigned *m_num_imul32_acesses[NUM_STAT_IDX];
+  unsigned *m_num_imul24_acesses[NUM_STAT_IDX];
+  unsigned *m_num_fpmul_acesses[NUM_STAT_IDX];
+  unsigned *m_num_idiv_acesses[NUM_STAT_IDX];
+  unsigned *m_num_fpdiv_acesses[NUM_STAT_IDX];
+  unsigned *m_num_sp_acesses[NUM_STAT_IDX];
+  unsigned *m_num_sfu_acesses[NUM_STAT_IDX];
+  unsigned *m_num_trans_acesses[NUM_STAT_IDX];
+  unsigned *m_num_mem_acesses[NUM_STAT_IDX];
+  unsigned *m_num_sp_committed[NUM_STAT_IDX];
+  unsigned *m_num_sfu_committed[NUM_STAT_IDX];
+  unsigned *m_num_mem_committed[NUM_STAT_IDX];
+  unsigned *m_active_sp_lanes[NUM_STAT_IDX];
+  unsigned *m_active_sfu_lanes[NUM_STAT_IDX];
+  unsigned *m_read_regfile_acesses[NUM_STAT_IDX];
+  unsigned *m_write_regfile_acesses[NUM_STAT_IDX];
+  unsigned *m_non_rf_operands[NUM_STAT_IDX];
 };
 
 class power_core_stat_t : public shader_core_power_stats_pod {
-public:
-   power_core_stat_t(const shader_core_config *shader_config, shader_core_stats *core_stats);
-   void visualizer_print( gzFile visualizer_file );
-   void print (FILE *fout);
-   void init();
-   void save_stats();
+ public:
+  power_core_stat_t(const shader_core_config *shader_config,
+                    shader_core_stats *core_stats);
+  void visualizer_print(gzFile visualizer_file);
+  void print(FILE *fout);
+  void init();
+  void save_stats();
 
-private:
-   shader_core_stats * m_core_stats;
-   const shader_core_config *m_config;
-   float average_duty_cycle;
-
-
+ private:
+  shader_core_stats *m_core_stats;
+  const shader_core_config *m_config;
+  float average_duty_cycle;
 };
 
-struct mem_power_stats_pod{
-    // [CURRENT_STAT_IDX] = CURRENT_STAT_IDX stat, [PREV_STAT_IDX] = last reading
-    class cache_stats core_cache_stats[NUM_STAT_IDX]; // Total core stats
-    class cache_stats l2_cache_stats[NUM_STAT_IDX]; // Total L2 partition stats
+struct mem_power_stats_pod {
+  // [CURRENT_STAT_IDX] = CURRENT_STAT_IDX stat, [PREV_STAT_IDX] = last reading
+  class cache_stats core_cache_stats[NUM_STAT_IDX];  // Total core stats
+  class cache_stats l2_cache_stats[NUM_STAT_IDX];    // Total L2 partition stats
 
-    unsigned *shmem_read_access[NUM_STAT_IDX];   // Shared memory access
+  unsigned *shmem_read_access[NUM_STAT_IDX];  // Shared memory access
 
-    // Low level DRAM stats
-    unsigned *n_cmd[NUM_STAT_IDX];
-    unsigned *n_activity[NUM_STAT_IDX];
-    unsigned *n_nop[NUM_STAT_IDX];
-    unsigned *n_act[NUM_STAT_IDX];
-    unsigned *n_pre[NUM_STAT_IDX];
-    unsigned *n_rd[NUM_STAT_IDX];
-    unsigned *n_wr[NUM_STAT_IDX];
-    unsigned *n_req[NUM_STAT_IDX];
+  // Low level DRAM stats
+  unsigned *n_cmd[NUM_STAT_IDX];
+  unsigned *n_activity[NUM_STAT_IDX];
+  unsigned *n_nop[NUM_STAT_IDX];
+  unsigned *n_act[NUM_STAT_IDX];
+  unsigned *n_pre[NUM_STAT_IDX];
+  unsigned *n_rd[NUM_STAT_IDX];
+  unsigned *n_wr[NUM_STAT_IDX];
+  unsigned *n_req[NUM_STAT_IDX];
 
-    // Interconnect stats
-    long *n_simt_to_mem[NUM_STAT_IDX];
-    long *n_mem_to_simt[NUM_STAT_IDX];
+  // Interconnect stats
+  long *n_simt_to_mem[NUM_STAT_IDX];
+  long *n_mem_to_simt[NUM_STAT_IDX];
 };
 
+class power_mem_stat_t : public mem_power_stats_pod {
+ public:
+  power_mem_stat_t(const memory_config *mem_config,
+                   const shader_core_config *shdr_config,
+                   memory_stats_t *mem_stats, shader_core_stats *shdr_stats);
+  void visualizer_print(gzFile visualizer_file);
+  void print(FILE *fout) const;
+  void init();
+  void save_stats();
 
-
-class power_mem_stat_t : public mem_power_stats_pod{
-public:
-   power_mem_stat_t(const memory_config *mem_config, const shader_core_config *shdr_config, memory_stats_t *mem_stats, shader_core_stats *shdr_stats);
-   void visualizer_print( gzFile visualizer_file );
-   void print (FILE *fout) const;
-   void init();
-   void save_stats();
-private:
-   memory_stats_t *m_mem_stats;
-   shader_core_stats * m_core_stats;
-   const memory_config *m_config;
-   const shader_core_config *m_core_config;
+ private:
+  memory_stats_t *m_mem_stats;
+  shader_core_stats *m_core_stats;
+  const memory_config *m_config;
+  const shader_core_config *m_core_config;
 };
-
 
 class power_stat_t {
-public:
-   power_stat_t( const shader_core_config *shader_config,float * average_pipeline_duty_cycle,float * active_sms,shader_core_stats * shader_stats, const memory_config *mem_config,memory_stats_t * memory_stats);
-   void visualizer_print( gzFile visualizer_file );
-   void print (FILE *fout) const;
-   void save_stats(){
-	   pwr_core_stat->save_stats();
-	   pwr_mem_stat->save_stats();
-	   *m_average_pipeline_duty_cycle=0;
-	   *m_active_sms=0;
-   }
+ public:
+  power_stat_t(const shader_core_config *shader_config,
+               float *average_pipeline_duty_cycle, float *active_sms,
+               shader_core_stats *shader_stats, const memory_config *mem_config,
+               memory_stats_t *memory_stats);
+  void visualizer_print(gzFile visualizer_file);
+  void print(FILE *fout) const;
+  void save_stats() {
+    pwr_core_stat->save_stats();
+    pwr_mem_stat->save_stats();
+    *m_average_pipeline_duty_cycle = 0;
+    *m_active_sms = 0;
+  }
 
-    unsigned get_total_inst(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_decoded_insn[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_decoded_insn[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+  unsigned get_total_inst() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_decoded_insn[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_decoded_insn[PREV_STAT_IDX][i]);
     }
-    unsigned get_total_int_inst(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_INTdecoded_insn[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_INTdecoded_insn[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+    return total_inst;
+  }
+  unsigned get_total_int_inst() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst +=
+          (pwr_core_stat->m_num_INTdecoded_insn[CURRENT_STAT_IDX][i]) -
+          (pwr_core_stat->m_num_INTdecoded_insn[PREV_STAT_IDX][i]);
     }
-    unsigned get_total_fp_inst(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_FPdecoded_insn[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_FPdecoded_insn[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+    return total_inst;
+  }
+  unsigned get_total_fp_inst() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_FPdecoded_insn[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_FPdecoded_insn[PREV_STAT_IDX][i]);
     }
-    unsigned get_total_load_inst(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_loadqueued_insn[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_loadqueued_insn[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+    return total_inst;
+  }
+  unsigned get_total_load_inst() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst +=
+          (pwr_core_stat->m_num_loadqueued_insn[CURRENT_STAT_IDX][i]) -
+          (pwr_core_stat->m_num_loadqueued_insn[PREV_STAT_IDX][i]);
     }
-    unsigned get_total_store_inst(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_storequeued_insn[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_storequeued_insn[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+    return total_inst;
+  }
+  unsigned get_total_store_inst() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst +=
+          (pwr_core_stat->m_num_storequeued_insn[CURRENT_STAT_IDX][i]) -
+          (pwr_core_stat->m_num_storequeued_insn[PREV_STAT_IDX][i]);
     }
-    unsigned get_sp_committed_inst(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_sp_committed[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_sp_committed[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+    return total_inst;
+  }
+  unsigned get_sp_committed_inst() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_sp_committed[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_sp_committed[PREV_STAT_IDX][i]);
     }
-    unsigned get_sfu_committed_inst(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_sfu_committed[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_sfu_committed[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+    return total_inst;
+  }
+  unsigned get_sfu_committed_inst() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_sfu_committed[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_sfu_committed[PREV_STAT_IDX][i]);
     }
-    unsigned get_mem_committed_inst(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_mem_committed[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_mem_committed[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+    return total_inst;
+  }
+  unsigned get_mem_committed_inst() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_mem_committed[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_mem_committed[PREV_STAT_IDX][i]);
     }
-    unsigned get_committed_inst(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_mem_committed[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_mem_committed[PREV_STAT_IDX][i])
-                    +(pwr_core_stat->m_num_sfu_committed[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_sfu_committed[PREV_STAT_IDX][i])
-                    +(pwr_core_stat->m_num_sp_committed[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_sp_committed[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+    return total_inst;
+  }
+  unsigned get_committed_inst() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_mem_committed[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_mem_committed[PREV_STAT_IDX][i]) +
+                    (pwr_core_stat->m_num_sfu_committed[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_sfu_committed[PREV_STAT_IDX][i]) +
+                    (pwr_core_stat->m_num_sp_committed[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_sp_committed[PREV_STAT_IDX][i]);
     }
-    unsigned get_regfile_reads(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_read_regfile_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_read_regfile_acesses[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+    return total_inst;
+  }
+  unsigned get_regfile_reads() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst +=
+          (pwr_core_stat->m_read_regfile_acesses[CURRENT_STAT_IDX][i]) -
+          (pwr_core_stat->m_read_regfile_acesses[PREV_STAT_IDX][i]);
     }
-    unsigned get_regfile_writes(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_write_regfile_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_write_regfile_acesses[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+    return total_inst;
+  }
+  unsigned get_regfile_writes() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst +=
+          (pwr_core_stat->m_write_regfile_acesses[CURRENT_STAT_IDX][i]) -
+          (pwr_core_stat->m_write_regfile_acesses[PREV_STAT_IDX][i]);
     }
+    return total_inst;
+  }
 
-    float get_pipeline_duty(){
-        float total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_pipeline_duty_cycle[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_pipeline_duty_cycle[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+  float get_pipeline_duty() {
+    float total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst +=
+          (pwr_core_stat->m_pipeline_duty_cycle[CURRENT_STAT_IDX][i]) -
+          (pwr_core_stat->m_pipeline_duty_cycle[PREV_STAT_IDX][i]);
     }
+    return total_inst;
+  }
 
-    unsigned get_non_regfile_operands(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_non_rf_operands[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_non_rf_operands[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+  unsigned get_non_regfile_operands() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_non_rf_operands[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_non_rf_operands[PREV_STAT_IDX][i]);
     }
+    return total_inst;
+  }
 
-    unsigned get_sp_accessess(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_sp_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_sp_acesses[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+  unsigned get_sp_accessess() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_sp_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_sp_acesses[PREV_STAT_IDX][i]);
     }
+    return total_inst;
+  }
 
-    unsigned get_sfu_accessess(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_sfu_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_sfu_acesses[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+  unsigned get_sfu_accessess() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_sfu_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_sfu_acesses[PREV_STAT_IDX][i]);
     }
-    unsigned get_trans_accessess(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_trans_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_trans_acesses[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+    return total_inst;
+  }
+  unsigned get_trans_accessess() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_trans_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_trans_acesses[PREV_STAT_IDX][i]);
     }
+    return total_inst;
+  }
 
-    unsigned get_mem_accessess(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_mem_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_mem_acesses[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+  unsigned get_mem_accessess() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_mem_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_mem_acesses[PREV_STAT_IDX][i]);
     }
+    return total_inst;
+  }
 
-    unsigned get_intdiv_accessess(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_idiv_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_idiv_acesses[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+  unsigned get_intdiv_accessess() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_idiv_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_idiv_acesses[PREV_STAT_IDX][i]);
     }
+    return total_inst;
+  }
 
-    unsigned get_fpdiv_accessess(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_fpdiv_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_fpdiv_acesses[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+  unsigned get_fpdiv_accessess() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_fpdiv_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_fpdiv_acesses[PREV_STAT_IDX][i]);
     }
+    return total_inst;
+  }
 
-    unsigned get_intmul32_accessess(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_imul32_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_imul32_acesses[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+  unsigned get_intmul32_accessess() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_imul32_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_imul32_acesses[PREV_STAT_IDX][i]);
     }
+    return total_inst;
+  }
 
-    unsigned get_intmul24_accessess(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_imul24_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_imul24_acesses[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+  unsigned get_intmul24_accessess() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_imul24_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_imul24_acesses[PREV_STAT_IDX][i]);
     }
+    return total_inst;
+  }
 
-    unsigned get_intmul_accessess(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_imul_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_imul_acesses[PREV_STAT_IDX][i])+
-                    (pwr_core_stat->m_num_imul24_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_imul24_acesses[PREV_STAT_IDX][i])+
-                    (pwr_core_stat->m_num_imul32_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_imul32_acesses[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+  unsigned get_intmul_accessess() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_imul_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_imul_acesses[PREV_STAT_IDX][i]) +
+                    (pwr_core_stat->m_num_imul24_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_imul24_acesses[PREV_STAT_IDX][i]) +
+                    (pwr_core_stat->m_num_imul32_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_imul32_acesses[PREV_STAT_IDX][i]);
     }
+    return total_inst;
+  }
 
-    unsigned get_fpmul_accessess(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_fp_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_fp_acesses[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+  unsigned get_fpmul_accessess() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_fp_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_fp_acesses[PREV_STAT_IDX][i]);
     }
+    return total_inst;
+  }
 
-    float get_sp_active_lanes(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_active_sp_lanes[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_active_sp_lanes[PREV_STAT_IDX][i]);
-        }
-        return (total_inst/m_config->num_shader())/m_config->gpgpu_num_sp_units;
+  float get_sp_active_lanes() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_active_sp_lanes[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_active_sp_lanes[PREV_STAT_IDX][i]);
     }
+    return (total_inst / m_config->num_shader()) / m_config->gpgpu_num_sp_units;
+  }
 
-    float get_sfu_active_lanes(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_active_sfu_lanes[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_active_sfu_lanes[PREV_STAT_IDX][i]);
-        }
-
-        return (total_inst/m_config->num_shader())/m_config->gpgpu_num_sfu_units;
-    }
-
-    unsigned get_tot_fpu_accessess(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_fp_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_fp_acesses[PREV_STAT_IDX][i])+
-                    (pwr_core_stat->m_num_fpdiv_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_fpdiv_acesses[PREV_STAT_IDX][i])+
-                    (pwr_core_stat->m_num_fpmul_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_fpmul_acesses[PREV_STAT_IDX][i])+
-                    (pwr_core_stat->m_num_imul24_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_imul24_acesses[PREV_STAT_IDX][i])+
-                    (pwr_core_stat->m_num_imul_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_imul_acesses[PREV_STAT_IDX][i]);
-        }
-        total_inst += get_total_load_inst()+get_total_store_inst()+get_tex_inst();
-        return total_inst;
-    }
-
-    unsigned get_tot_sfu_accessess(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-                total_inst+= (pwr_core_stat->m_num_idiv_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_idiv_acesses[PREV_STAT_IDX][i])+
-                            (pwr_core_stat->m_num_imul32_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_imul32_acesses[PREV_STAT_IDX][i])+
-                            (pwr_core_stat->m_num_trans_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_trans_acesses[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
-    }
-
-    unsigned get_ialu_accessess(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_ialu_acesses[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_ialu_acesses[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
-    }
-
-    unsigned get_tex_inst(){
-        unsigned total_inst=0;
-        for(unsigned i=0; i<m_config->num_shader();i++){
-            total_inst+=(pwr_core_stat->m_num_tex_inst[CURRENT_STAT_IDX][i]) - (pwr_core_stat->m_num_tex_inst[PREV_STAT_IDX][i]);
-        }
-        return total_inst;
+  float get_sfu_active_lanes() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_active_sfu_lanes[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_active_sfu_lanes[PREV_STAT_IDX][i]);
     }
 
-    unsigned get_constant_c_accesses(){
-        enum mem_access_type access_type[] = {CONST_ACC_R};
-        enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
-        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
-        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+    return (total_inst / m_config->num_shader()) /
+           m_config->gpgpu_num_sfu_units;
+  }
 
-        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
-                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
+  unsigned get_tot_fpu_accessess() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_fp_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_fp_acesses[PREV_STAT_IDX][i]) +
+                    (pwr_core_stat->m_num_fpdiv_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_fpdiv_acesses[PREV_STAT_IDX][i]) +
+                    (pwr_core_stat->m_num_fpmul_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_fpmul_acesses[PREV_STAT_IDX][i]) +
+                    (pwr_core_stat->m_num_imul24_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_imul24_acesses[PREV_STAT_IDX][i]) +
+                    (pwr_core_stat->m_num_imul_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_imul_acesses[PREV_STAT_IDX][i]);
     }
-    unsigned get_constant_c_misses(){
-        enum mem_access_type access_type[] = {CONST_ACC_R};
-        enum cache_request_status request_status[] = {MISS};
-        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
-        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+    total_inst +=
+        get_total_load_inst() + get_total_store_inst() + get_tex_inst();
+    return total_inst;
+  }
 
-        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
-                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
+  unsigned get_tot_sfu_accessess() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_idiv_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_idiv_acesses[PREV_STAT_IDX][i]) +
+                    (pwr_core_stat->m_num_imul32_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_imul32_acesses[PREV_STAT_IDX][i]) +
+                    (pwr_core_stat->m_num_trans_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_trans_acesses[PREV_STAT_IDX][i]);
     }
-    unsigned get_constant_c_hits(){
-        return (get_constant_c_accesses()-get_constant_c_misses());
-    }
-    unsigned get_texture_c_accesses(){
-        enum mem_access_type access_type[] = {TEXTURE_ACC_R};
-        enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
-        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
-        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+    return total_inst;
+  }
 
-        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
-                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
+  unsigned get_ialu_accessess() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_ialu_acesses[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_ialu_acesses[PREV_STAT_IDX][i]);
     }
-    unsigned get_texture_c_misses(){
-        enum mem_access_type access_type[] = {TEXTURE_ACC_R};
-        enum cache_request_status request_status[] = {MISS};
-        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
-        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+    return total_inst;
+  }
 
-        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
-                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
+  unsigned get_tex_inst() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_core_stat->m_num_tex_inst[CURRENT_STAT_IDX][i]) -
+                    (pwr_core_stat->m_num_tex_inst[PREV_STAT_IDX][i]);
     }
-    unsigned get_texture_c_hits(){
-        return ( get_texture_c_accesses()- get_texture_c_misses());
-    }
-    unsigned get_inst_c_accesses(){
-        enum mem_access_type access_type[] = {INST_ACC_R};
-        enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
-        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
-        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+    return total_inst;
+  }
 
-        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
-                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
-    }
-    unsigned get_inst_c_misses(){
-        enum mem_access_type access_type[] = {INST_ACC_R};
-        enum cache_request_status request_status[] = {MISS};
-        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
-        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+  unsigned get_constant_c_accesses() {
+    enum mem_access_type access_type[] = {CONST_ACC_R};
+    enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
+    unsigned num_access_type =
+        sizeof(access_type) / sizeof(enum mem_access_type);
+    unsigned num_request_status =
+        sizeof(request_status) / sizeof(enum cache_request_status);
 
-        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
-                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
-    }
-    unsigned get_inst_c_hits(){
-        return (get_inst_c_accesses()-get_inst_c_misses());
-    }
+    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status)) -
+           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status));
+  }
+  unsigned get_constant_c_misses() {
+    enum mem_access_type access_type[] = {CONST_ACC_R};
+    enum cache_request_status request_status[] = {MISS};
+    unsigned num_access_type =
+        sizeof(access_type) / sizeof(enum mem_access_type);
+    unsigned num_request_status =
+        sizeof(request_status) / sizeof(enum cache_request_status);
 
-    unsigned get_l1d_read_accesses(){
-        enum mem_access_type access_type[] = {GLOBAL_ACC_R, LOCAL_ACC_R};
-        enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
-        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
-        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status)) -
+           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status));
+  }
+  unsigned get_constant_c_hits() {
+    return (get_constant_c_accesses() - get_constant_c_misses());
+  }
+  unsigned get_texture_c_accesses() {
+    enum mem_access_type access_type[] = {TEXTURE_ACC_R};
+    enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
+    unsigned num_access_type =
+        sizeof(access_type) / sizeof(enum mem_access_type);
+    unsigned num_request_status =
+        sizeof(request_status) / sizeof(enum cache_request_status);
 
-        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
-                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
-    }
-    unsigned get_l1d_read_misses(){
-        enum mem_access_type access_type[] = {GLOBAL_ACC_R, LOCAL_ACC_R};
-        enum cache_request_status request_status[] = {MISS};
-        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
-        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status)) -
+           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status));
+  }
+  unsigned get_texture_c_misses() {
+    enum mem_access_type access_type[] = {TEXTURE_ACC_R};
+    enum cache_request_status request_status[] = {MISS};
+    unsigned num_access_type =
+        sizeof(access_type) / sizeof(enum mem_access_type);
+    unsigned num_request_status =
+        sizeof(request_status) / sizeof(enum cache_request_status);
 
-        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
-                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
-    }
-    unsigned get_l1d_read_hits(){
-        return (get_l1d_read_accesses()-get_l1d_read_misses());
-    }
-    unsigned get_l1d_write_accesses(){
-        enum mem_access_type access_type[] = {GLOBAL_ACC_W, LOCAL_ACC_W};
-        enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
-        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
-        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status)) -
+           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status));
+  }
+  unsigned get_texture_c_hits() {
+    return (get_texture_c_accesses() - get_texture_c_misses());
+  }
+  unsigned get_inst_c_accesses() {
+    enum mem_access_type access_type[] = {INST_ACC_R};
+    enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
+    unsigned num_access_type =
+        sizeof(access_type) / sizeof(enum mem_access_type);
+    unsigned num_request_status =
+        sizeof(request_status) / sizeof(enum cache_request_status);
 
-        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
-                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
-    }
-    unsigned get_l1d_write_misses(){
-        enum mem_access_type access_type[] = {GLOBAL_ACC_W, LOCAL_ACC_W};
-        enum cache_request_status request_status[] = {MISS};
-        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
-        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status)) -
+           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status));
+  }
+  unsigned get_inst_c_misses() {
+    enum mem_access_type access_type[] = {INST_ACC_R};
+    enum cache_request_status request_status[] = {MISS};
+    unsigned num_access_type =
+        sizeof(access_type) / sizeof(enum mem_access_type);
+    unsigned num_request_status =
+        sizeof(request_status) / sizeof(enum cache_request_status);
 
-        return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
-                (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
-    }
-    unsigned get_l1d_write_hits(){
-        return (get_l1d_write_accesses()-get_l1d_write_misses());
-    }
-    unsigned get_cache_misses(){
-        return get_l1d_read_misses()+get_constant_c_misses()+get_l1d_write_misses()+get_texture_c_misses();
-    }
-	
-    unsigned get_cache_read_misses(){
-        return get_l1d_read_misses()+get_constant_c_misses()+get_texture_c_misses();
-    }
+    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status)) -
+           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status));
+  }
+  unsigned get_inst_c_hits() {
+    return (get_inst_c_accesses() - get_inst_c_misses());
+  }
 
-    unsigned get_cache_write_misses(){
-        return get_l1d_write_misses();
-    }
+  unsigned get_l1d_read_accesses() {
+    enum mem_access_type access_type[] = {GLOBAL_ACC_R, LOCAL_ACC_R};
+    enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
+    unsigned num_access_type =
+        sizeof(access_type) / sizeof(enum mem_access_type);
+    unsigned num_request_status =
+        sizeof(request_status) / sizeof(enum cache_request_status);
 
-    unsigned get_shmem_read_access(){
-       unsigned total_inst=0;
-       for(unsigned i=0; i<m_config->num_shader();i++){
-           total_inst+=(pwr_mem_stat->shmem_read_access[CURRENT_STAT_IDX][i]) - (pwr_mem_stat->shmem_read_access[PREV_STAT_IDX][i]);
-       }
-       return total_inst;
-    }
+    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status)) -
+           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status));
+  }
+  unsigned get_l1d_read_misses() {
+    enum mem_access_type access_type[] = {GLOBAL_ACC_R, LOCAL_ACC_R};
+    enum cache_request_status request_status[] = {MISS};
+    unsigned num_access_type =
+        sizeof(access_type) / sizeof(enum mem_access_type);
+    unsigned num_request_status =
+        sizeof(request_status) / sizeof(enum cache_request_status);
 
-    unsigned get_l2_read_accesses(){
-        enum mem_access_type access_type[] = {GLOBAL_ACC_R, LOCAL_ACC_R, CONST_ACC_R, TEXTURE_ACC_R, INST_ACC_R};
-        enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
-        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
-        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status)) -
+           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status));
+  }
+  unsigned get_l1d_read_hits() {
+    return (get_l1d_read_accesses() - get_l1d_read_misses());
+  }
+  unsigned get_l1d_write_accesses() {
+    enum mem_access_type access_type[] = {GLOBAL_ACC_W, LOCAL_ACC_W};
+    enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
+    unsigned num_access_type =
+        sizeof(access_type) / sizeof(enum mem_access_type);
+    unsigned num_request_status =
+        sizeof(request_status) / sizeof(enum cache_request_status);
 
-        return (pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
-                (pwr_mem_stat->l2_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
-    }
+    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status)) -
+           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status));
+  }
+  unsigned get_l1d_write_misses() {
+    enum mem_access_type access_type[] = {GLOBAL_ACC_W, LOCAL_ACC_W};
+    enum cache_request_status request_status[] = {MISS};
+    unsigned num_access_type =
+        sizeof(access_type) / sizeof(enum mem_access_type);
+    unsigned num_request_status =
+        sizeof(request_status) / sizeof(enum cache_request_status);
 
-    unsigned get_l2_read_misses(){
-        enum mem_access_type access_type[] = {GLOBAL_ACC_R, LOCAL_ACC_R, CONST_ACC_R, TEXTURE_ACC_R, INST_ACC_R};
-        enum cache_request_status request_status[] = {MISS};
-        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
-        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+    return (pwr_mem_stat->core_cache_stats[CURRENT_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status)) -
+           (pwr_mem_stat->core_cache_stats[PREV_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status));
+  }
+  unsigned get_l1d_write_hits() {
+    return (get_l1d_write_accesses() - get_l1d_write_misses());
+  }
+  unsigned get_cache_misses() {
+    return get_l1d_read_misses() + get_constant_c_misses() +
+           get_l1d_write_misses() + get_texture_c_misses();
+  }
 
-        return (pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
-                (pwr_mem_stat->l2_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
-    }
+  unsigned get_cache_read_misses() {
+    return get_l1d_read_misses() + get_constant_c_misses() +
+           get_texture_c_misses();
+  }
 
-    unsigned get_l2_read_hits(){
-        return (get_l2_read_accesses()-get_l2_read_misses());
-    }
+  unsigned get_cache_write_misses() { return get_l1d_write_misses(); }
 
-    unsigned get_l2_write_accesses(){
-        enum mem_access_type access_type[] = {GLOBAL_ACC_W, LOCAL_ACC_W, L1_WRBK_ACC};
-        enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
-        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
-        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+  unsigned get_shmem_read_access() {
+    unsigned total_inst = 0;
+    for (unsigned i = 0; i < m_config->num_shader(); i++) {
+      total_inst += (pwr_mem_stat->shmem_read_access[CURRENT_STAT_IDX][i]) -
+                    (pwr_mem_stat->shmem_read_access[PREV_STAT_IDX][i]);
+    }
+    return total_inst;
+  }
 
-        return (pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
-                (pwr_mem_stat->l2_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
-    }
+  unsigned get_l2_read_accesses() {
+    enum mem_access_type access_type[] = {
+        GLOBAL_ACC_R, LOCAL_ACC_R, CONST_ACC_R, TEXTURE_ACC_R, INST_ACC_R};
+    enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
+    unsigned num_access_type =
+        sizeof(access_type) / sizeof(enum mem_access_type);
+    unsigned num_request_status =
+        sizeof(request_status) / sizeof(enum cache_request_status);
 
-    unsigned get_l2_write_misses(){
-        enum mem_access_type access_type[] = {GLOBAL_ACC_W, LOCAL_ACC_W, L1_WRBK_ACC};
-        enum cache_request_status request_status[] = {MISS};
-        unsigned num_access_type = sizeof(access_type)/sizeof(enum mem_access_type);
-        unsigned num_request_status = sizeof(request_status)/sizeof(enum cache_request_status);
+    return (pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status)) -
+           (pwr_mem_stat->l2_cache_stats[PREV_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status));
+  }
 
-        return (pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status)) -
-                (pwr_mem_stat->l2_cache_stats[PREV_STAT_IDX].get_stats(access_type, num_access_type, request_status, num_request_status));
-    }
-    unsigned get_l2_write_hits(){
-        return (get_l2_write_accesses()-get_l2_write_misses());
-    }
-    unsigned get_dram_cmd(){
-        unsigned total=0;
-        for(unsigned i=0; i<m_mem_config->m_n_mem; ++i){
-            total += (pwr_mem_stat->n_cmd[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_cmd[PREV_STAT_IDX][i]);
-        }
-        return total;
-    }
-    unsigned get_dram_activity(){
-        unsigned total=0;
-        for(unsigned i=0; i<m_mem_config->m_n_mem; ++i){
-            total += (pwr_mem_stat->n_activity[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_activity[PREV_STAT_IDX][i]);
-        }
-        return total;
-    }
-    unsigned get_dram_nop(){
-        unsigned total=0;
-        for(unsigned i=0; i<m_mem_config->m_n_mem; ++i){
-            total += (pwr_mem_stat->n_nop[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_nop[PREV_STAT_IDX][i]);
-        }
-        return total;
-    }
-    unsigned get_dram_act(){
-        unsigned total=0;
-        for(unsigned i=0; i<m_mem_config->m_n_mem; ++i){
-            total += (pwr_mem_stat->n_act[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_act[PREV_STAT_IDX][i]);
-        }
-        return total;
-    }
-    unsigned get_dram_pre(){
-        unsigned total=0;
-        for(unsigned i=0; i<m_mem_config->m_n_mem; ++i){
-            total += (pwr_mem_stat->n_pre[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_pre[PREV_STAT_IDX][i]);
-        }
-        return total;
-    }
-    unsigned get_dram_rd(){
-        unsigned total=0;
-        for(unsigned i=0; i<m_mem_config->m_n_mem; ++i){
-            total += (pwr_mem_stat->n_rd[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_rd[PREV_STAT_IDX][i]);
-        }
-        return total;
-    }
-    unsigned get_dram_wr(){
-        unsigned total=0;
-        for(unsigned i=0; i<m_mem_config->m_n_mem; ++i){
-            total += (pwr_mem_stat->n_wr[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_wr[PREV_STAT_IDX][i]);
-        }
-        return total;
-    }
-    unsigned get_dram_req(){
-        unsigned total=0;
-        for(unsigned i=0; i<m_mem_config->m_n_mem; ++i){
-            total += (pwr_mem_stat->n_req[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_req[PREV_STAT_IDX][i]);
-        }
-        return total;
-    }
+  unsigned get_l2_read_misses() {
+    enum mem_access_type access_type[] = {
+        GLOBAL_ACC_R, LOCAL_ACC_R, CONST_ACC_R, TEXTURE_ACC_R, INST_ACC_R};
+    enum cache_request_status request_status[] = {MISS};
+    unsigned num_access_type =
+        sizeof(access_type) / sizeof(enum mem_access_type);
+    unsigned num_request_status =
+        sizeof(request_status) / sizeof(enum cache_request_status);
 
-    long get_icnt_simt_to_mem(){
-        long total=0;
-        for(unsigned i=0; i<m_config->n_simt_clusters; ++i){
-            total += (pwr_mem_stat->n_simt_to_mem[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_simt_to_mem[PREV_STAT_IDX][i]);
-        }
-        return total;
-    }
+    return (pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status)) -
+           (pwr_mem_stat->l2_cache_stats[PREV_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status));
+  }
 
-    long get_icnt_mem_to_simt(){
-        long total=0;
-        for(unsigned i=0; i<m_config->n_simt_clusters; ++i){
-            total += (pwr_mem_stat->n_mem_to_simt[CURRENT_STAT_IDX][i] - pwr_mem_stat->n_mem_to_simt[PREV_STAT_IDX][i]);
-        }
-        return total;
-    }
+  unsigned get_l2_read_hits() {
+    return (get_l2_read_accesses() - get_l2_read_misses());
+  }
 
-   power_core_stat_t * pwr_core_stat;
-   power_mem_stat_t * pwr_mem_stat;
-   float * m_average_pipeline_duty_cycle;
-   float * m_active_sms;
-   const shader_core_config *m_config;
-   const memory_config *m_mem_config;
+  unsigned get_l2_write_accesses() {
+    enum mem_access_type access_type[] = {GLOBAL_ACC_W, LOCAL_ACC_W,
+                                          L1_WRBK_ACC};
+    enum cache_request_status request_status[] = {HIT, MISS, HIT_RESERVED};
+    unsigned num_access_type =
+        sizeof(access_type) / sizeof(enum mem_access_type);
+    unsigned num_request_status =
+        sizeof(request_status) / sizeof(enum cache_request_status);
+
+    return (pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status)) -
+           (pwr_mem_stat->l2_cache_stats[PREV_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status));
+  }
+
+  unsigned get_l2_write_misses() {
+    enum mem_access_type access_type[] = {GLOBAL_ACC_W, LOCAL_ACC_W,
+                                          L1_WRBK_ACC};
+    enum cache_request_status request_status[] = {MISS};
+    unsigned num_access_type =
+        sizeof(access_type) / sizeof(enum mem_access_type);
+    unsigned num_request_status =
+        sizeof(request_status) / sizeof(enum cache_request_status);
+
+    return (pwr_mem_stat->l2_cache_stats[CURRENT_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status)) -
+           (pwr_mem_stat->l2_cache_stats[PREV_STAT_IDX].get_stats(
+               access_type, num_access_type, request_status,
+               num_request_status));
+  }
+  unsigned get_l2_write_hits() {
+    return (get_l2_write_accesses() - get_l2_write_misses());
+  }
+  unsigned get_dram_cmd() {
+    unsigned total = 0;
+    for (unsigned i = 0; i < m_mem_config->m_n_mem; ++i) {
+      total += (pwr_mem_stat->n_cmd[CURRENT_STAT_IDX][i] -
+                pwr_mem_stat->n_cmd[PREV_STAT_IDX][i]);
+    }
+    return total;
+  }
+  unsigned get_dram_activity() {
+    unsigned total = 0;
+    for (unsigned i = 0; i < m_mem_config->m_n_mem; ++i) {
+      total += (pwr_mem_stat->n_activity[CURRENT_STAT_IDX][i] -
+                pwr_mem_stat->n_activity[PREV_STAT_IDX][i]);
+    }
+    return total;
+  }
+  unsigned get_dram_nop() {
+    unsigned total = 0;
+    for (unsigned i = 0; i < m_mem_config->m_n_mem; ++i) {
+      total += (pwr_mem_stat->n_nop[CURRENT_STAT_IDX][i] -
+                pwr_mem_stat->n_nop[PREV_STAT_IDX][i]);
+    }
+    return total;
+  }
+  unsigned get_dram_act() {
+    unsigned total = 0;
+    for (unsigned i = 0; i < m_mem_config->m_n_mem; ++i) {
+      total += (pwr_mem_stat->n_act[CURRENT_STAT_IDX][i] -
+                pwr_mem_stat->n_act[PREV_STAT_IDX][i]);
+    }
+    return total;
+  }
+  unsigned get_dram_pre() {
+    unsigned total = 0;
+    for (unsigned i = 0; i < m_mem_config->m_n_mem; ++i) {
+      total += (pwr_mem_stat->n_pre[CURRENT_STAT_IDX][i] -
+                pwr_mem_stat->n_pre[PREV_STAT_IDX][i]);
+    }
+    return total;
+  }
+  unsigned get_dram_rd() {
+    unsigned total = 0;
+    for (unsigned i = 0; i < m_mem_config->m_n_mem; ++i) {
+      total += (pwr_mem_stat->n_rd[CURRENT_STAT_IDX][i] -
+                pwr_mem_stat->n_rd[PREV_STAT_IDX][i]);
+    }
+    return total;
+  }
+  unsigned get_dram_wr() {
+    unsigned total = 0;
+    for (unsigned i = 0; i < m_mem_config->m_n_mem; ++i) {
+      total += (pwr_mem_stat->n_wr[CURRENT_STAT_IDX][i] -
+                pwr_mem_stat->n_wr[PREV_STAT_IDX][i]);
+    }
+    return total;
+  }
+  unsigned get_dram_req() {
+    unsigned total = 0;
+    for (unsigned i = 0; i < m_mem_config->m_n_mem; ++i) {
+      total += (pwr_mem_stat->n_req[CURRENT_STAT_IDX][i] -
+                pwr_mem_stat->n_req[PREV_STAT_IDX][i]);
+    }
+    return total;
+  }
+
+  long get_icnt_simt_to_mem() {
+    long total = 0;
+    for (unsigned i = 0; i < m_config->n_simt_clusters; ++i) {
+      total += (pwr_mem_stat->n_simt_to_mem[CURRENT_STAT_IDX][i] -
+                pwr_mem_stat->n_simt_to_mem[PREV_STAT_IDX][i]);
+    }
+    return total;
+  }
+
+  long get_icnt_mem_to_simt() {
+    long total = 0;
+    for (unsigned i = 0; i < m_config->n_simt_clusters; ++i) {
+      total += (pwr_mem_stat->n_mem_to_simt[CURRENT_STAT_IDX][i] -
+                pwr_mem_stat->n_mem_to_simt[PREV_STAT_IDX][i]);
+    }
+    return total;
+  }
+
+  power_core_stat_t *pwr_core_stat;
+  power_mem_stat_t *pwr_mem_stat;
+  float *m_average_pipeline_duty_cycle;
+  float *m_active_sms;
+  const shader_core_config *m_config;
+  const memory_config *m_mem_config;
 };
-
 
 #endif /*POWER_LATENCY_STAT_H*/

--- a/src/gpgpu-sim/scoreboard.cc
+++ b/src/gpgpu-sim/scoreboard.cc
@@ -7,159 +7,148 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #include "scoreboard.h"
-#include "shader.h"
 #include "../cuda-sim/ptx_sim.h"
+#include "shader.h"
 #include "shader_trace.h"
 
+// Constructor
+Scoreboard::Scoreboard(unsigned sid, unsigned n_warps, class gpgpu_t* gpu)
+    : longopregs() {
+  m_sid = sid;
+  // Initialize size of table
+  reg_table.resize(n_warps);
+  longopregs.resize(n_warps);
 
-//Constructor
-Scoreboard::Scoreboard( unsigned sid, unsigned n_warps, class gpgpu_t* gpu )
-: longopregs()
-{
-	m_sid = sid;
-	//Initialize size of table
-	reg_table.resize(n_warps);
-	longopregs.resize(n_warps);
-
-	m_gpu = gpu;
+  m_gpu = gpu;
 }
 
 // Print scoreboard contents
-void Scoreboard::printContents() const
-{
-	printf("scoreboard contents (sid=%d): \n", m_sid);
-	for(unsigned i=0; i<reg_table.size(); i++) {
-		if(reg_table[i].size() == 0 ) continue;
-		printf("  wid = %2d: ", i);
-		std::set<unsigned>::const_iterator it;
-		for( it=reg_table[i].begin() ; it != reg_table[i].end(); it++ )
-			printf("%u ", *it);
-		printf("\n");
-	}
+void Scoreboard::printContents() const {
+  printf("scoreboard contents (sid=%d): \n", m_sid);
+  for (unsigned i = 0; i < reg_table.size(); i++) {
+    if (reg_table[i].size() == 0) continue;
+    printf("  wid = %2d: ", i);
+    std::set<unsigned>::const_iterator it;
+    for (it = reg_table[i].begin(); it != reg_table[i].end(); it++)
+      printf("%u ", *it);
+    printf("\n");
+  }
 }
 
-void Scoreboard::reserveRegister(unsigned wid, unsigned regnum) 
-{
-	if( !(reg_table[wid].find(regnum) == reg_table[wid].end()) ){
-		printf("Error: trying to reserve an already reserved register (sid=%d, wid=%d, regnum=%d).", m_sid, wid, regnum);
-        abort();
-	}
-    SHADER_DPRINTF( SCOREBOARD,
-                    "Reserved Register - warp:%d, reg: %d\n", wid, regnum );
-	reg_table[wid].insert(regnum);
+void Scoreboard::reserveRegister(unsigned wid, unsigned regnum) {
+  if (!(reg_table[wid].find(regnum) == reg_table[wid].end())) {
+    printf(
+        "Error: trying to reserve an already reserved register (sid=%d, "
+        "wid=%d, regnum=%d).",
+        m_sid, wid, regnum);
+    abort();
+  }
+  SHADER_DPRINTF(SCOREBOARD, "Reserved Register - warp:%d, reg: %d\n", wid,
+                 regnum);
+  reg_table[wid].insert(regnum);
 }
 
 // Unmark register as write-pending
-void Scoreboard::releaseRegister(unsigned wid, unsigned regnum) 
-{
-	if( !(reg_table[wid].find(regnum) != reg_table[wid].end()) ) 
-        return;
-    SHADER_DPRINTF( SCOREBOARD,
-                    "Release register - warp:%d, reg: %d\n", wid, regnum );
-	reg_table[wid].erase(regnum);
+void Scoreboard::releaseRegister(unsigned wid, unsigned regnum) {
+  if (!(reg_table[wid].find(regnum) != reg_table[wid].end())) return;
+  SHADER_DPRINTF(SCOREBOARD, "Release register - warp:%d, reg: %d\n", wid,
+                 regnum);
+  reg_table[wid].erase(regnum);
 }
 
-const bool Scoreboard::islongop (unsigned warp_id,unsigned regnum) {
-	return longopregs[warp_id].find(regnum) != longopregs[warp_id].end();
+const bool Scoreboard::islongop(unsigned warp_id, unsigned regnum) {
+  return longopregs[warp_id].find(regnum) != longopregs[warp_id].end();
 }
 
-void Scoreboard::reserveRegisters(const class warp_inst_t* inst) 
-{
-    for( unsigned r=0; r < MAX_OUTPUT_VALUES; r++) {
-        if(inst->out[r] > 0) {
-            reserveRegister(inst->warp_id(), inst->out[r]);
-            SHADER_DPRINTF( SCOREBOARD,
-                            "Reserved register - warp:%d, reg: %d\n",
-                            inst->warp_id(),
-                            inst->out[r] );
-        }
+void Scoreboard::reserveRegisters(const class warp_inst_t* inst) {
+  for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++) {
+    if (inst->out[r] > 0) {
+      reserveRegister(inst->warp_id(), inst->out[r]);
+      SHADER_DPRINTF(SCOREBOARD, "Reserved register - warp:%d, reg: %d\n",
+                     inst->warp_id(), inst->out[r]);
     }
+  }
 
-    //Keep track of long operations
-    if (inst->is_load() &&
-    		(	inst->space.get_type() == global_space ||
-    			inst->space.get_type() == local_space ||
-                inst->space.get_type() == param_space_kernel ||
-                inst->space.get_type() == param_space_local ||
-                inst->space.get_type() == param_space_unclassified ||
-    			inst->space.get_type() == tex_space)){
-    	for ( unsigned r=0; r<MAX_OUTPUT_VALUES; r++) {
-    		if(inst->out[r] > 0) {
-                SHADER_DPRINTF( SCOREBOARD,
-                                "New longopreg marked - warp:%d, reg: %d\n",
-                                inst->warp_id(),
-                                inst->out[r] );
-                longopregs[inst->warp_id()].insert(inst->out[r]);
-            }
-    	}
+  // Keep track of long operations
+  if (inst->is_load() && (inst->space.get_type() == global_space ||
+                          inst->space.get_type() == local_space ||
+                          inst->space.get_type() == param_space_kernel ||
+                          inst->space.get_type() == param_space_local ||
+                          inst->space.get_type() == param_space_unclassified ||
+                          inst->space.get_type() == tex_space)) {
+    for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++) {
+      if (inst->out[r] > 0) {
+        SHADER_DPRINTF(SCOREBOARD, "New longopreg marked - warp:%d, reg: %d\n",
+                       inst->warp_id(), inst->out[r]);
+        longopregs[inst->warp_id()].insert(inst->out[r]);
+      }
     }
+  }
 }
 
 // Release registers for an instruction
-void Scoreboard::releaseRegisters(const class warp_inst_t *inst) 
-{
-    for( unsigned r=0; r < MAX_OUTPUT_VALUES; r++) {
-        if(inst->out[r] > 0) {
-            SHADER_DPRINTF( SCOREBOARD,
-                            "Register Released - warp:%d, reg: %d\n",
-                            inst->warp_id(),
-                            inst->out[r] );
-            releaseRegister(inst->warp_id(), inst->out[r]);
-            longopregs[inst->warp_id()].erase(inst->out[r]);
-        }
+void Scoreboard::releaseRegisters(const class warp_inst_t* inst) {
+  for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++) {
+    if (inst->out[r] > 0) {
+      SHADER_DPRINTF(SCOREBOARD, "Register Released - warp:%d, reg: %d\n",
+                     inst->warp_id(), inst->out[r]);
+      releaseRegister(inst->warp_id(), inst->out[r]);
+      longopregs[inst->warp_id()].erase(inst->out[r]);
     }
+  }
 }
 
-/** 
- * Checks to see if registers used by an instruction are reserved in the scoreboard
- *  
- * @return 
+/**
+ * Checks to see if registers used by an instruction are reserved in the
+ *scoreboard
+ *
+ * @return
  * true if WAW or RAW hazard (no WAR since in-order issue)
- **/ 
-bool Scoreboard::checkCollision( unsigned wid, const class inst_t *inst ) const
-{
-	// Get list of all input and output registers
-	std::set<int> inst_regs;
+ **/
+bool Scoreboard::checkCollision(unsigned wid, const class inst_t* inst) const {
+  // Get list of all input and output registers
+  std::set<int> inst_regs;
 
-	for(unsigned iii=0; iii < inst->outcount; iii++)
-		inst_regs.insert(inst->out[iii]);
+  for (unsigned iii = 0; iii < inst->outcount; iii++)
+    inst_regs.insert(inst->out[iii]);
 
-	for(unsigned jjj=0;jjj<inst->incount;jjj++)
-		inst_regs.insert(inst->in[jjj]);
+  for (unsigned jjj = 0; jjj < inst->incount; jjj++)
+    inst_regs.insert(inst->in[jjj]);
 
-        if(inst->pred > 0) inst_regs.insert(inst->pred);
-	if(inst->ar1 > 0) inst_regs.insert(inst->ar1);
-	if(inst->ar2 > 0) inst_regs.insert(inst->ar2);
+  if (inst->pred > 0) inst_regs.insert(inst->pred);
+  if (inst->ar1 > 0) inst_regs.insert(inst->ar1);
+  if (inst->ar2 > 0) inst_regs.insert(inst->ar2);
 
-	// Check for collision, get the intersection of reserved registers and instruction registers
-	std::set<int>::const_iterator it2;
-	for ( it2=inst_regs.begin() ; it2 != inst_regs.end(); it2++ )
-		if(reg_table[wid].find(*it2) != reg_table[wid].end()) {
-			return true;
-		}
-	return false;
+  // Check for collision, get the intersection of reserved registers and
+  // instruction registers
+  std::set<int>::const_iterator it2;
+  for (it2 = inst_regs.begin(); it2 != inst_regs.end(); it2++)
+    if (reg_table[wid].find(*it2) != reg_table[wid].end()) {
+      return true;
+    }
+  return false;
 }
 
-bool Scoreboard::pendingWrites(unsigned wid) const
-{
-	return !reg_table[wid].empty();
+bool Scoreboard::pendingWrites(unsigned wid) const {
+  return !reg_table[wid].empty();
 }

--- a/src/gpgpu-sim/scoreboard.cc
+++ b/src/gpgpu-sim/scoreboard.cc
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -26,140 +28,128 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "scoreboard.h"
-#include "shader.h"
 #include "../cuda-sim/ptx_sim.h"
+#include "shader.h"
 #include "shader_trace.h"
 
+// Constructor
+Scoreboard::Scoreboard(unsigned sid, unsigned n_warps, class gpgpu_t* gpu)
+    : longopregs() {
+  m_sid = sid;
+  // Initialize size of table
+  reg_table.resize(n_warps);
+  longopregs.resize(n_warps);
 
-//Constructor
-Scoreboard::Scoreboard( unsigned sid, unsigned n_warps, class gpgpu_t* gpu )
-: longopregs()
-{
-	m_sid = sid;
-	//Initialize size of table
-	reg_table.resize(n_warps);
-	longopregs.resize(n_warps);
-
-	m_gpu = gpu;
+  m_gpu = gpu;
 }
 
 // Print scoreboard contents
-void Scoreboard::printContents() const
-{
-	printf("scoreboard contents (sid=%d): \n", m_sid);
-	for(unsigned i=0; i<reg_table.size(); i++) {
-		if(reg_table[i].size() == 0 ) continue;
-		printf("  wid = %2d: ", i);
-		std::set<unsigned>::const_iterator it;
-		for( it=reg_table[i].begin() ; it != reg_table[i].end(); it++ )
-			printf("%u ", *it);
-		printf("\n");
-	}
+void Scoreboard::printContents() const {
+  printf("scoreboard contents (sid=%d): \n", m_sid);
+  for (unsigned i = 0; i < reg_table.size(); i++) {
+    if (reg_table[i].size() == 0) continue;
+    printf("  wid = %2d: ", i);
+    std::set<unsigned>::const_iterator it;
+    for (it = reg_table[i].begin(); it != reg_table[i].end(); it++)
+      printf("%u ", *it);
+    printf("\n");
+  }
 }
 
-void Scoreboard::reserveRegister(unsigned wid, unsigned regnum) 
-{
-	if( !(reg_table[wid].find(regnum) == reg_table[wid].end()) ){
-		printf("Error: trying to reserve an already reserved register (sid=%d, wid=%d, regnum=%d).", m_sid, wid, regnum);
-        abort();
-	}
-    SHADER_DPRINTF( SCOREBOARD,
-                    "Reserved Register - warp:%d, reg: %d\n", wid, regnum );
-	reg_table[wid].insert(regnum);
+void Scoreboard::reserveRegister(unsigned wid, unsigned regnum) {
+  if (!(reg_table[wid].find(regnum) == reg_table[wid].end())) {
+    printf(
+        "Error: trying to reserve an already reserved register (sid=%d, "
+        "wid=%d, regnum=%d).",
+        m_sid, wid, regnum);
+    abort();
+  }
+  SHADER_DPRINTF(SCOREBOARD, "Reserved Register - warp:%d, reg: %d\n", wid,
+                 regnum);
+  reg_table[wid].insert(regnum);
 }
 
 // Unmark register as write-pending
-void Scoreboard::releaseRegister(unsigned wid, unsigned regnum) 
-{
-	if( !(reg_table[wid].find(regnum) != reg_table[wid].end()) ) 
-        return;
-    SHADER_DPRINTF( SCOREBOARD,
-                    "Release register - warp:%d, reg: %d\n", wid, regnum );
-	reg_table[wid].erase(regnum);
+void Scoreboard::releaseRegister(unsigned wid, unsigned regnum) {
+  if (!(reg_table[wid].find(regnum) != reg_table[wid].end())) return;
+  SHADER_DPRINTF(SCOREBOARD, "Release register - warp:%d, reg: %d\n", wid,
+                 regnum);
+  reg_table[wid].erase(regnum);
 }
 
-const bool Scoreboard::islongop (unsigned warp_id,unsigned regnum) {
-	return longopregs[warp_id].find(regnum) != longopregs[warp_id].end();
+const bool Scoreboard::islongop(unsigned warp_id, unsigned regnum) {
+  return longopregs[warp_id].find(regnum) != longopregs[warp_id].end();
 }
 
-void Scoreboard::reserveRegisters(const class warp_inst_t* inst) 
-{
-    for( unsigned r=0; r < MAX_OUTPUT_VALUES; r++) {
-        if(inst->out[r] > 0) {
-            reserveRegister(inst->warp_id(), inst->out[r]);
-            SHADER_DPRINTF( SCOREBOARD,
-                            "Reserved register - warp:%d, reg: %d\n",
-                            inst->warp_id(),
-                            inst->out[r] );
-        }
+void Scoreboard::reserveRegisters(const class warp_inst_t* inst) {
+  for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++) {
+    if (inst->out[r] > 0) {
+      reserveRegister(inst->warp_id(), inst->out[r]);
+      SHADER_DPRINTF(SCOREBOARD, "Reserved register - warp:%d, reg: %d\n",
+                     inst->warp_id(), inst->out[r]);
     }
+  }
 
-    //Keep track of long operations
-    if (inst->is_load() &&
-    		(	inst->space.get_type() == global_space ||
-    			inst->space.get_type() == local_space ||
-                inst->space.get_type() == param_space_kernel ||
-                inst->space.get_type() == param_space_local ||
-                inst->space.get_type() == param_space_unclassified ||
-    			inst->space.get_type() == tex_space)){
-    	for ( unsigned r=0; r<MAX_OUTPUT_VALUES; r++) {
-    		if(inst->out[r] > 0) {
-                SHADER_DPRINTF( SCOREBOARD,
-                                "New longopreg marked - warp:%d, reg: %d\n",
-                                inst->warp_id(),
-                                inst->out[r] );
-                longopregs[inst->warp_id()].insert(inst->out[r]);
-            }
-    	}
+  // Keep track of long operations
+  if (inst->is_load() && (inst->space.get_type() == global_space ||
+                          inst->space.get_type() == local_space ||
+                          inst->space.get_type() == param_space_kernel ||
+                          inst->space.get_type() == param_space_local ||
+                          inst->space.get_type() == param_space_unclassified ||
+                          inst->space.get_type() == tex_space)) {
+    for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++) {
+      if (inst->out[r] > 0) {
+        SHADER_DPRINTF(SCOREBOARD, "New longopreg marked - warp:%d, reg: %d\n",
+                       inst->warp_id(), inst->out[r]);
+        longopregs[inst->warp_id()].insert(inst->out[r]);
+      }
     }
+  }
 }
 
 // Release registers for an instruction
-void Scoreboard::releaseRegisters(const class warp_inst_t *inst) 
-{
-    for( unsigned r=0; r < MAX_OUTPUT_VALUES; r++) {
-        if(inst->out[r] > 0) {
-            SHADER_DPRINTF( SCOREBOARD,
-                            "Register Released - warp:%d, reg: %d\n",
-                            inst->warp_id(),
-                            inst->out[r] );
-            releaseRegister(inst->warp_id(), inst->out[r]);
-            longopregs[inst->warp_id()].erase(inst->out[r]);
-        }
+void Scoreboard::releaseRegisters(const class warp_inst_t* inst) {
+  for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++) {
+    if (inst->out[r] > 0) {
+      SHADER_DPRINTF(SCOREBOARD, "Register Released - warp:%d, reg: %d\n",
+                     inst->warp_id(), inst->out[r]);
+      releaseRegister(inst->warp_id(), inst->out[r]);
+      longopregs[inst->warp_id()].erase(inst->out[r]);
     }
+  }
 }
 
-/** 
- * Checks to see if registers used by an instruction are reserved in the scoreboard
- *  
- * @return 
+/**
+ * Checks to see if registers used by an instruction are reserved in the
+ *scoreboard
+ *
+ * @return
  * true if WAW or RAW hazard (no WAR since in-order issue)
- **/ 
-bool Scoreboard::checkCollision( unsigned wid, const class inst_t *inst ) const
-{
-	// Get list of all input and output registers
-	std::set<int> inst_regs;
+ **/
+bool Scoreboard::checkCollision(unsigned wid, const class inst_t* inst) const {
+  // Get list of all input and output registers
+  std::set<int> inst_regs;
 
-	for(unsigned iii=0; iii < inst->outcount; iii++)
-		inst_regs.insert(inst->out[iii]);
+  for (unsigned iii = 0; iii < inst->outcount; iii++)
+    inst_regs.insert(inst->out[iii]);
 
-	for(unsigned jjj=0;jjj<inst->incount;jjj++)
-		inst_regs.insert(inst->in[jjj]);
+  for (unsigned jjj = 0; jjj < inst->incount; jjj++)
+    inst_regs.insert(inst->in[jjj]);
 
-        if(inst->pred > 0) inst_regs.insert(inst->pred);
-	if(inst->ar1 > 0) inst_regs.insert(inst->ar1);
-	if(inst->ar2 > 0) inst_regs.insert(inst->ar2);
+  if (inst->pred > 0) inst_regs.insert(inst->pred);
+  if (inst->ar1 > 0) inst_regs.insert(inst->ar1);
+  if (inst->ar2 > 0) inst_regs.insert(inst->ar2);
 
-	// Check for collision, get the intersection of reserved registers and instruction registers
-	std::set<int>::const_iterator it2;
-	for ( it2=inst_regs.begin() ; it2 != inst_regs.end(); it2++ )
-		if(reg_table[wid].find(*it2) != reg_table[wid].end()) {
-			return true;
-		}
-	return false;
+  // Check for collision, get the intersection of reserved registers and
+  // instruction registers
+  std::set<int>::const_iterator it2;
+  for (it2 = inst_regs.begin(); it2 != inst_regs.end(); it2++)
+    if (reg_table[wid].find(*it2) != reg_table[wid].end()) {
+      return true;
+    }
+  return false;
 }
 
-bool Scoreboard::pendingWrites(unsigned wid) const
-{
-	return !reg_table[wid].empty();
+bool Scoreboard::pendingWrites(unsigned wid) const {
+  return !reg_table[wid].empty();
 }

--- a/src/gpgpu-sim/scoreboard.cc
+++ b/src/gpgpu-sim/scoreboard.cc
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -28,128 +26,140 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "scoreboard.h"
-#include "../cuda-sim/ptx_sim.h"
 #include "shader.h"
+#include "../cuda-sim/ptx_sim.h"
 #include "shader_trace.h"
 
-// Constructor
-Scoreboard::Scoreboard(unsigned sid, unsigned n_warps, class gpgpu_t* gpu)
-    : longopregs() {
-  m_sid = sid;
-  // Initialize size of table
-  reg_table.resize(n_warps);
-  longopregs.resize(n_warps);
 
-  m_gpu = gpu;
+//Constructor
+Scoreboard::Scoreboard( unsigned sid, unsigned n_warps, class gpgpu_t* gpu )
+: longopregs()
+{
+	m_sid = sid;
+	//Initialize size of table
+	reg_table.resize(n_warps);
+	longopregs.resize(n_warps);
+
+	m_gpu = gpu;
 }
 
 // Print scoreboard contents
-void Scoreboard::printContents() const {
-  printf("scoreboard contents (sid=%d): \n", m_sid);
-  for (unsigned i = 0; i < reg_table.size(); i++) {
-    if (reg_table[i].size() == 0) continue;
-    printf("  wid = %2d: ", i);
-    std::set<unsigned>::const_iterator it;
-    for (it = reg_table[i].begin(); it != reg_table[i].end(); it++)
-      printf("%u ", *it);
-    printf("\n");
-  }
+void Scoreboard::printContents() const
+{
+	printf("scoreboard contents (sid=%d): \n", m_sid);
+	for(unsigned i=0; i<reg_table.size(); i++) {
+		if(reg_table[i].size() == 0 ) continue;
+		printf("  wid = %2d: ", i);
+		std::set<unsigned>::const_iterator it;
+		for( it=reg_table[i].begin() ; it != reg_table[i].end(); it++ )
+			printf("%u ", *it);
+		printf("\n");
+	}
 }
 
-void Scoreboard::reserveRegister(unsigned wid, unsigned regnum) {
-  if (!(reg_table[wid].find(regnum) == reg_table[wid].end())) {
-    printf(
-        "Error: trying to reserve an already reserved register (sid=%d, "
-        "wid=%d, regnum=%d).",
-        m_sid, wid, regnum);
-    abort();
-  }
-  SHADER_DPRINTF(SCOREBOARD, "Reserved Register - warp:%d, reg: %d\n", wid,
-                 regnum);
-  reg_table[wid].insert(regnum);
+void Scoreboard::reserveRegister(unsigned wid, unsigned regnum) 
+{
+	if( !(reg_table[wid].find(regnum) == reg_table[wid].end()) ){
+		printf("Error: trying to reserve an already reserved register (sid=%d, wid=%d, regnum=%d).", m_sid, wid, regnum);
+        abort();
+	}
+    SHADER_DPRINTF( SCOREBOARD,
+                    "Reserved Register - warp:%d, reg: %d\n", wid, regnum );
+	reg_table[wid].insert(regnum);
 }
 
 // Unmark register as write-pending
-void Scoreboard::releaseRegister(unsigned wid, unsigned regnum) {
-  if (!(reg_table[wid].find(regnum) != reg_table[wid].end())) return;
-  SHADER_DPRINTF(SCOREBOARD, "Release register - warp:%d, reg: %d\n", wid,
-                 regnum);
-  reg_table[wid].erase(regnum);
+void Scoreboard::releaseRegister(unsigned wid, unsigned regnum) 
+{
+	if( !(reg_table[wid].find(regnum) != reg_table[wid].end()) ) 
+        return;
+    SHADER_DPRINTF( SCOREBOARD,
+                    "Release register - warp:%d, reg: %d\n", wid, regnum );
+	reg_table[wid].erase(regnum);
 }
 
-const bool Scoreboard::islongop(unsigned warp_id, unsigned regnum) {
-  return longopregs[warp_id].find(regnum) != longopregs[warp_id].end();
+const bool Scoreboard::islongop (unsigned warp_id,unsigned regnum) {
+	return longopregs[warp_id].find(regnum) != longopregs[warp_id].end();
 }
 
-void Scoreboard::reserveRegisters(const class warp_inst_t* inst) {
-  for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++) {
-    if (inst->out[r] > 0) {
-      reserveRegister(inst->warp_id(), inst->out[r]);
-      SHADER_DPRINTF(SCOREBOARD, "Reserved register - warp:%d, reg: %d\n",
-                     inst->warp_id(), inst->out[r]);
+void Scoreboard::reserveRegisters(const class warp_inst_t* inst) 
+{
+    for( unsigned r=0; r < MAX_OUTPUT_VALUES; r++) {
+        if(inst->out[r] > 0) {
+            reserveRegister(inst->warp_id(), inst->out[r]);
+            SHADER_DPRINTF( SCOREBOARD,
+                            "Reserved register - warp:%d, reg: %d\n",
+                            inst->warp_id(),
+                            inst->out[r] );
+        }
     }
-  }
 
-  // Keep track of long operations
-  if (inst->is_load() && (inst->space.get_type() == global_space ||
-                          inst->space.get_type() == local_space ||
-                          inst->space.get_type() == param_space_kernel ||
-                          inst->space.get_type() == param_space_local ||
-                          inst->space.get_type() == param_space_unclassified ||
-                          inst->space.get_type() == tex_space)) {
-    for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++) {
-      if (inst->out[r] > 0) {
-        SHADER_DPRINTF(SCOREBOARD, "New longopreg marked - warp:%d, reg: %d\n",
-                       inst->warp_id(), inst->out[r]);
-        longopregs[inst->warp_id()].insert(inst->out[r]);
-      }
+    //Keep track of long operations
+    if (inst->is_load() &&
+    		(	inst->space.get_type() == global_space ||
+    			inst->space.get_type() == local_space ||
+                inst->space.get_type() == param_space_kernel ||
+                inst->space.get_type() == param_space_local ||
+                inst->space.get_type() == param_space_unclassified ||
+    			inst->space.get_type() == tex_space)){
+    	for ( unsigned r=0; r<MAX_OUTPUT_VALUES; r++) {
+    		if(inst->out[r] > 0) {
+                SHADER_DPRINTF( SCOREBOARD,
+                                "New longopreg marked - warp:%d, reg: %d\n",
+                                inst->warp_id(),
+                                inst->out[r] );
+                longopregs[inst->warp_id()].insert(inst->out[r]);
+            }
+    	}
     }
-  }
 }
 
 // Release registers for an instruction
-void Scoreboard::releaseRegisters(const class warp_inst_t* inst) {
-  for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++) {
-    if (inst->out[r] > 0) {
-      SHADER_DPRINTF(SCOREBOARD, "Register Released - warp:%d, reg: %d\n",
-                     inst->warp_id(), inst->out[r]);
-      releaseRegister(inst->warp_id(), inst->out[r]);
-      longopregs[inst->warp_id()].erase(inst->out[r]);
+void Scoreboard::releaseRegisters(const class warp_inst_t *inst) 
+{
+    for( unsigned r=0; r < MAX_OUTPUT_VALUES; r++) {
+        if(inst->out[r] > 0) {
+            SHADER_DPRINTF( SCOREBOARD,
+                            "Register Released - warp:%d, reg: %d\n",
+                            inst->warp_id(),
+                            inst->out[r] );
+            releaseRegister(inst->warp_id(), inst->out[r]);
+            longopregs[inst->warp_id()].erase(inst->out[r]);
+        }
     }
-  }
 }
 
-/**
- * Checks to see if registers used by an instruction are reserved in the
- *scoreboard
- *
- * @return
+/** 
+ * Checks to see if registers used by an instruction are reserved in the scoreboard
+ *  
+ * @return 
  * true if WAW or RAW hazard (no WAR since in-order issue)
- **/
-bool Scoreboard::checkCollision(unsigned wid, const class inst_t* inst) const {
-  // Get list of all input and output registers
-  std::set<int> inst_regs;
+ **/ 
+bool Scoreboard::checkCollision( unsigned wid, const class inst_t *inst ) const
+{
+	// Get list of all input and output registers
+	std::set<int> inst_regs;
 
-  for (unsigned iii = 0; iii < inst->outcount; iii++)
-    inst_regs.insert(inst->out[iii]);
+	for(unsigned iii=0; iii < inst->outcount; iii++)
+		inst_regs.insert(inst->out[iii]);
 
-  for (unsigned jjj = 0; jjj < inst->incount; jjj++)
-    inst_regs.insert(inst->in[jjj]);
+	for(unsigned jjj=0;jjj<inst->incount;jjj++)
+		inst_regs.insert(inst->in[jjj]);
 
-  if (inst->pred > 0) inst_regs.insert(inst->pred);
-  if (inst->ar1 > 0) inst_regs.insert(inst->ar1);
-  if (inst->ar2 > 0) inst_regs.insert(inst->ar2);
+        if(inst->pred > 0) inst_regs.insert(inst->pred);
+	if(inst->ar1 > 0) inst_regs.insert(inst->ar1);
+	if(inst->ar2 > 0) inst_regs.insert(inst->ar2);
 
-  // Check for collision, get the intersection of reserved registers and
-  // instruction registers
-  std::set<int>::const_iterator it2;
-  for (it2 = inst_regs.begin(); it2 != inst_regs.end(); it2++)
-    if (reg_table[wid].find(*it2) != reg_table[wid].end()) {
-      return true;
-    }
-  return false;
+	// Check for collision, get the intersection of reserved registers and instruction registers
+	std::set<int>::const_iterator it2;
+	for ( it2=inst_regs.begin() ; it2 != inst_regs.end(); it2++ )
+		if(reg_table[wid].find(*it2) != reg_table[wid].end()) {
+			return true;
+		}
+	return false;
 }
 
-bool Scoreboard::pendingWrites(unsigned wid) const {
-  return !reg_table[wid].empty();
+bool Scoreboard::pendingWrites(unsigned wid) const
+{
+	return !reg_table[wid].empty();
 }

--- a/src/gpgpu-sim/scoreboard.h
+++ b/src/gpgpu-sim/scoreboard.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -27,8 +29,8 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <vector>
 #include <set>
+#include <vector>
 #include "assert.h"
 
 #ifndef SCOREBOARD_H_
@@ -37,31 +39,31 @@
 #include "../abstract_hardware_model.h"
 
 class Scoreboard {
-public:
-    Scoreboard( unsigned sid, unsigned n_warps, class gpgpu_t* gpu );
+ public:
+  Scoreboard(unsigned sid, unsigned n_warps, class gpgpu_t *gpu);
 
-    void reserveRegisters(const warp_inst_t *inst);
-    void releaseRegisters(const warp_inst_t *inst);
-    void releaseRegister(unsigned wid, unsigned regnum);
+  void reserveRegisters(const warp_inst_t *inst);
+  void releaseRegisters(const warp_inst_t *inst);
+  void releaseRegister(unsigned wid, unsigned regnum);
 
-    bool checkCollision(unsigned wid, const inst_t *inst) const;
-    bool pendingWrites(unsigned wid) const;
-    void printContents() const;
-    const bool islongop(unsigned warp_id, unsigned regnum);
-private:
-    void reserveRegister(unsigned wid, unsigned regnum);
-    int get_sid() const { return m_sid; }
+  bool checkCollision(unsigned wid, const inst_t *inst) const;
+  bool pendingWrites(unsigned wid) const;
+  void printContents() const;
+  const bool islongop(unsigned warp_id, unsigned regnum);
 
-    unsigned m_sid;
+ private:
+  void reserveRegister(unsigned wid, unsigned regnum);
+  int get_sid() const { return m_sid; }
 
-    // keeps track of pending writes to registers
-    // indexed by warp id, reg_id => pending write count
-    std::vector< std::set<unsigned> > reg_table;
-    //Register that depend on a long operation (global, local or tex memory)
-    std::vector< std::set<unsigned> > longopregs;
+  unsigned m_sid;
 
-    class gpgpu_t* m_gpu;
+  // keeps track of pending writes to registers
+  // indexed by warp id, reg_id => pending write count
+  std::vector<std::set<unsigned> > reg_table;
+  // Register that depend on a long operation (global, local or tex memory)
+  std::vector<std::set<unsigned> > longopregs;
+
+  class gpgpu_t *m_gpu;
 };
-
 
 #endif /* SCOREBOARD_H_ */

--- a/src/gpgpu-sim/scoreboard.h
+++ b/src/gpgpu-sim/scoreboard.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -29,8 +27,8 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <set>
 #include <vector>
+#include <set>
 #include "assert.h"
 
 #ifndef SCOREBOARD_H_
@@ -39,31 +37,31 @@
 #include "../abstract_hardware_model.h"
 
 class Scoreboard {
- public:
-  Scoreboard(unsigned sid, unsigned n_warps, class gpgpu_t *gpu);
+public:
+    Scoreboard( unsigned sid, unsigned n_warps, class gpgpu_t* gpu );
 
-  void reserveRegisters(const warp_inst_t *inst);
-  void releaseRegisters(const warp_inst_t *inst);
-  void releaseRegister(unsigned wid, unsigned regnum);
+    void reserveRegisters(const warp_inst_t *inst);
+    void releaseRegisters(const warp_inst_t *inst);
+    void releaseRegister(unsigned wid, unsigned regnum);
 
-  bool checkCollision(unsigned wid, const inst_t *inst) const;
-  bool pendingWrites(unsigned wid) const;
-  void printContents() const;
-  const bool islongop(unsigned warp_id, unsigned regnum);
+    bool checkCollision(unsigned wid, const inst_t *inst) const;
+    bool pendingWrites(unsigned wid) const;
+    void printContents() const;
+    const bool islongop(unsigned warp_id, unsigned regnum);
+private:
+    void reserveRegister(unsigned wid, unsigned regnum);
+    int get_sid() const { return m_sid; }
 
- private:
-  void reserveRegister(unsigned wid, unsigned regnum);
-  int get_sid() const { return m_sid; }
+    unsigned m_sid;
 
-  unsigned m_sid;
+    // keeps track of pending writes to registers
+    // indexed by warp id, reg_id => pending write count
+    std::vector< std::set<unsigned> > reg_table;
+    //Register that depend on a long operation (global, local or tex memory)
+    std::vector< std::set<unsigned> > longopregs;
 
-  // keeps track of pending writes to registers
-  // indexed by warp id, reg_id => pending write count
-  std::vector<std::set<unsigned> > reg_table;
-  // Register that depend on a long operation (global, local or tex memory)
-  std::vector<std::set<unsigned> > longopregs;
-
-  class gpgpu_t *m_gpu;
+    class gpgpu_t* m_gpu;
 };
+
 
 #endif /* SCOREBOARD_H_ */

--- a/src/gpgpu-sim/scoreboard.h
+++ b/src/gpgpu-sim/scoreboard.h
@@ -7,28 +7,29 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <vector>
 #include <set>
+#include <vector>
 #include "assert.h"
 
 #ifndef SCOREBOARD_H_
@@ -37,31 +38,31 @@
 #include "../abstract_hardware_model.h"
 
 class Scoreboard {
-public:
-    Scoreboard( unsigned sid, unsigned n_warps, class gpgpu_t* gpu );
+ public:
+  Scoreboard(unsigned sid, unsigned n_warps, class gpgpu_t *gpu);
 
-    void reserveRegisters(const warp_inst_t *inst);
-    void releaseRegisters(const warp_inst_t *inst);
-    void releaseRegister(unsigned wid, unsigned regnum);
+  void reserveRegisters(const warp_inst_t *inst);
+  void releaseRegisters(const warp_inst_t *inst);
+  void releaseRegister(unsigned wid, unsigned regnum);
 
-    bool checkCollision(unsigned wid, const inst_t *inst) const;
-    bool pendingWrites(unsigned wid) const;
-    void printContents() const;
-    const bool islongop(unsigned warp_id, unsigned regnum);
-private:
-    void reserveRegister(unsigned wid, unsigned regnum);
-    int get_sid() const { return m_sid; }
+  bool checkCollision(unsigned wid, const inst_t *inst) const;
+  bool pendingWrites(unsigned wid) const;
+  void printContents() const;
+  const bool islongop(unsigned warp_id, unsigned regnum);
 
-    unsigned m_sid;
+ private:
+  void reserveRegister(unsigned wid, unsigned regnum);
+  int get_sid() const { return m_sid; }
 
-    // keeps track of pending writes to registers
-    // indexed by warp id, reg_id => pending write count
-    std::vector< std::set<unsigned> > reg_table;
-    //Register that depend on a long operation (global, local or tex memory)
-    std::vector< std::set<unsigned> > longopregs;
+  unsigned m_sid;
 
-    class gpgpu_t* m_gpu;
+  // keeps track of pending writes to registers
+  // indexed by warp id, reg_id => pending write count
+  std::vector<std::set<unsigned> > reg_table;
+  // Register that depend on a long operation (global, local or tex memory)
+  std::vector<std::set<unsigned> > longopregs;
+
+  class gpgpu_t *m_gpu;
 };
-
 
 #endif /* SCOREBOARD_H_ */

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2011, Tor M. Aamodt, Wilson W.L. Fung, Ali Bakhoda,
-// George L. Yuan, Andrew Turner, Inderpreet Singh 
+// George L. Yuan, Andrew Turner, Inderpreet Singh
 // The University of British Columbia
 // All rights reserved.
 //
@@ -8,14 +8,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -26,2042 +28,2137 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <float.h>
 #include "shader.h"
+#include <float.h>
+#include <limits.h>
+#include <string.h>
+#include "../../libcuda/gpgpu_context.h"
+#include "../cuda-sim/cuda-sim.h"
+#include "../cuda-sim/ptx-stats.h"
+#include "../cuda-sim/ptx_sim.h"
+#include "../statwrapper.h"
 #include "addrdec.h"
 #include "dram.h"
-#include "stat-tool.h"
 #include "gpu-misc.h"
-#include "../cuda-sim/ptx_sim.h"
-#include "../cuda-sim/ptx-stats.h"
-#include "../cuda-sim/cuda-sim.h"
 #include "gpu-sim.h"
+#include "icnt_wrapper.h"
 #include "mem_fetch.h"
 #include "mem_latency_stat.h"
-#include "visualizer.h"
-#include "../statwrapper.h"
-#include "icnt_wrapper.h"
-#include <string.h>
-#include <limits.h>
-#include "traffic_breakdown.h"
 #include "shader_trace.h"
-#include "../../libcuda/gpgpu_context.h"
+#include "stat-tool.h"
+#include "traffic_breakdown.h"
+#include "visualizer.h"
 
 #define PRIORITIZE_MSHR_OVER_WB 1
-#define MAX(a,b) (((a)>(b))?(a):(b))
-#define MIN(a,b) (((a)<(b))?(a):(b))
-    
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
 
-mem_fetch *shader_core_mem_fetch_allocator::alloc( new_addr_type addr, mem_access_type type, unsigned size, bool wr, unsigned long long cycle ) const
-{
-    mem_access_t access( type, addr, size, wr, m_memory_config->gpgpu_ctx);
-    mem_fetch *mf = new mem_fetch( access, 
-	    NULL,
-	    wr?WRITE_PACKET_SIZE:READ_PACKET_SIZE, 
-	    -1, 
-	    m_core_id, 
-	    m_cluster_id,
-	    m_memory_config,
-	    cycle);
-    return mf;
+mem_fetch *shader_core_mem_fetch_allocator::alloc(
+    new_addr_type addr, mem_access_type type, unsigned size, bool wr,
+    unsigned long long cycle) const {
+  mem_access_t access(type, addr, size, wr, m_memory_config->gpgpu_ctx);
+  mem_fetch *mf =
+      new mem_fetch(access, NULL, wr ? WRITE_PACKET_SIZE : READ_PACKET_SIZE, -1,
+                    m_core_id, m_cluster_id, m_memory_config, cycle);
+  return mf;
 }
 /////////////////////////////////////////////////////////////////////////////
 
-std::list<unsigned> shader_core_ctx::get_regs_written( const inst_t &fvt ) const
-{
-   std::list<unsigned> result;
-   for( unsigned op=0; op < MAX_REG_OPERANDS; op++ ) {
-      int reg_num = fvt.arch_reg.dst[op]; // this math needs to match that used in function_info::ptx_decode_inst
-      if( reg_num >= 0 ) // valid register
-         result.push_back(reg_num);
-   }
-   return result;
+std::list<unsigned> shader_core_ctx::get_regs_written(const inst_t &fvt) const {
+  std::list<unsigned> result;
+  for (unsigned op = 0; op < MAX_REG_OPERANDS; op++) {
+    int reg_num = fvt.arch_reg.dst[op];  // this math needs to match that used
+                                         // in function_info::ptx_decode_inst
+    if (reg_num >= 0)                    // valid register
+      result.push_back(reg_num);
+  }
+  return result;
 }
 
-shader_core_ctx::shader_core_ctx( class gpgpu_sim *gpu, 
-                                  class simt_core_cluster *cluster,
-                                  unsigned shader_id,
-                                  unsigned tpc_id,
-                                  const shader_core_config *config,
-                                  const memory_config *mem_config,
-                                  shader_core_stats *stats )
-   : core_t( gpu, NULL, config->warp_size, config->n_thread_per_shader ),
-     m_barriers( this, config->max_warps_per_shader, config->max_cta_per_core, config->max_barriers_per_cta, config->warp_size ),
-     m_active_warps(0), m_dynamic_warp_id(0)
-{
-    m_cluster = cluster;
-    m_config = config;
-    m_memory_config = mem_config;
-    m_stats = stats;
-    unsigned warp_size=config->warp_size;
-    Issue_Prio = 0;
-    
-    m_sid = shader_id;
-    m_tpc = tpc_id;
-    
-    m_pipeline_reg.reserve(N_PIPELINE_STAGES);
-    for (int j = 0; j<N_PIPELINE_STAGES; j++) {
-        m_pipeline_reg.push_back(register_set(m_config->pipe_widths[j],pipeline_stage_name_decode[j]));
+shader_core_ctx::shader_core_ctx(class gpgpu_sim *gpu,
+                                 class simt_core_cluster *cluster,
+                                 unsigned shader_id, unsigned tpc_id,
+                                 const shader_core_config *config,
+                                 const memory_config *mem_config,
+                                 shader_core_stats *stats)
+    : core_t(gpu, NULL, config->warp_size, config->n_thread_per_shader),
+      m_barriers(this, config->max_warps_per_shader, config->max_cta_per_core,
+                 config->max_barriers_per_cta, config->warp_size),
+      m_active_warps(0),
+      m_dynamic_warp_id(0) {
+  m_cluster = cluster;
+  m_config = config;
+  m_memory_config = mem_config;
+  m_stats = stats;
+  unsigned warp_size = config->warp_size;
+  Issue_Prio = 0;
+
+  m_sid = shader_id;
+  m_tpc = tpc_id;
+
+  m_pipeline_reg.reserve(N_PIPELINE_STAGES);
+  for (int j = 0; j < N_PIPELINE_STAGES; j++) {
+    m_pipeline_reg.push_back(
+        register_set(m_config->pipe_widths[j], pipeline_stage_name_decode[j]));
+  }
+  if (m_config->sub_core_model) {
+    // in subcore model, each scheduler should has its own issue register, so
+    // num scheduler = reg width
+    assert(m_config->gpgpu_num_sched_per_core ==
+           m_pipeline_reg[ID_OC_SP].get_size());
+    assert(m_config->gpgpu_num_sched_per_core ==
+           m_pipeline_reg[ID_OC_SFU].get_size());
+    assert(m_config->gpgpu_num_sched_per_core ==
+           m_pipeline_reg[ID_OC_MEM].get_size());
+    if (m_config->gpgpu_tensor_core_avail)
+      assert(m_config->gpgpu_num_sched_per_core ==
+             m_pipeline_reg[ID_OC_TENSOR_CORE].get_size());
+    if (m_config->gpgpu_num_dp_units > 0)
+      assert(m_config->gpgpu_num_sched_per_core ==
+             m_pipeline_reg[ID_OC_DP].get_size());
+    if (m_config->gpgpu_num_int_units > 0)
+      assert(m_config->gpgpu_num_sched_per_core ==
+             m_pipeline_reg[ID_OC_INT].get_size());
+  }
+
+  m_threadState =
+      (thread_ctx_t *)calloc(sizeof(thread_ctx_t), config->n_thread_per_shader);
+
+  m_not_completed = 0;
+  m_active_threads.reset();
+  m_n_active_cta = 0;
+  for (unsigned i = 0; i < MAX_CTA_PER_SHADER; i++) m_cta_status[i] = 0;
+  for (unsigned i = 0; i < config->n_thread_per_shader; i++) {
+    m_thread[i] = NULL;
+    m_threadState[i].m_cta_id = -1;
+    m_threadState[i].m_active = false;
+  }
+
+  // m_icnt = new shader_memory_interface(this,cluster);
+  if (m_config->gpgpu_perfect_mem) {
+    m_icnt = new perfect_memory_interface(this, cluster);
+  } else {
+    m_icnt = new shader_memory_interface(this, cluster);
+  }
+  m_mem_fetch_allocator =
+      new shader_core_mem_fetch_allocator(shader_id, tpc_id, mem_config);
+
+  // fetch
+  m_last_warp_fetched = 0;
+
+#define STRSIZE 1024
+  char name[STRSIZE];
+  snprintf(name, STRSIZE, "L1I_%03d", m_sid);
+  m_L1I = new read_only_cache(name, m_config->m_L1I_config, m_sid,
+                              get_shader_instruction_cache_id(), m_icnt,
+                              IN_L1I_MISS_QUEUE);
+
+  m_warp.resize(m_config->max_warps_per_shader, shd_warp_t(this, warp_size));
+  m_scoreboard = new Scoreboard(m_sid, m_config->max_warps_per_shader, gpu);
+
+  // scedulers
+  // must currently occur after all inputs have been initialized.
+  std::string sched_config = m_config->gpgpu_scheduler_string;
+  const concrete_scheduler scheduler =
+      sched_config.find("lrr") != std::string::npos
+          ? CONCRETE_SCHEDULER_LRR
+          : sched_config.find("two_level_active") != std::string::npos
+                ? CONCRETE_SCHEDULER_TWO_LEVEL_ACTIVE
+                : sched_config.find("gto") != std::string::npos
+                      ? CONCRETE_SCHEDULER_GTO
+                      : sched_config.find("old") != std::string::npos
+                            ? CONCRETE_SCHEDULER_OLDEST_FIRST
+                            : sched_config.find("warp_limiting") !=
+                                      std::string::npos
+                                  ? CONCRETE_SCHEDULER_WARP_LIMITING
+                                  : NUM_CONCRETE_SCHEDULERS;
+  assert(scheduler != NUM_CONCRETE_SCHEDULERS);
+
+  for (unsigned i = 0; i < m_config->gpgpu_num_sched_per_core; i++) {
+    switch (scheduler) {
+      case CONCRETE_SCHEDULER_LRR:
+        schedulers.push_back(new lrr_scheduler(
+            m_stats, this, m_scoreboard, m_simt_stack, &m_warp,
+            &m_pipeline_reg[ID_OC_SP], &m_pipeline_reg[ID_OC_DP],
+            &m_pipeline_reg[ID_OC_SFU], &m_pipeline_reg[ID_OC_INT],
+            &m_pipeline_reg[ID_OC_TENSOR_CORE], &m_pipeline_reg[ID_OC_MEM], i));
+        break;
+      case CONCRETE_SCHEDULER_TWO_LEVEL_ACTIVE:
+        schedulers.push_back(new two_level_active_scheduler(
+            m_stats, this, m_scoreboard, m_simt_stack, &m_warp,
+            &m_pipeline_reg[ID_OC_SP], &m_pipeline_reg[ID_OC_DP],
+            &m_pipeline_reg[ID_OC_SFU], &m_pipeline_reg[ID_OC_INT],
+            &m_pipeline_reg[ID_OC_TENSOR_CORE], &m_pipeline_reg[ID_OC_MEM], i,
+            config->gpgpu_scheduler_string));
+        break;
+      case CONCRETE_SCHEDULER_GTO:
+        schedulers.push_back(new gto_scheduler(
+            m_stats, this, m_scoreboard, m_simt_stack, &m_warp,
+            &m_pipeline_reg[ID_OC_SP], &m_pipeline_reg[ID_OC_DP],
+            &m_pipeline_reg[ID_OC_SFU], &m_pipeline_reg[ID_OC_INT],
+            &m_pipeline_reg[ID_OC_TENSOR_CORE], &m_pipeline_reg[ID_OC_MEM], i));
+        break;
+      case CONCRETE_SCHEDULER_OLDEST_FIRST:
+        schedulers.push_back(new oldest_scheduler(
+            m_stats, this, m_scoreboard, m_simt_stack, &m_warp,
+            &m_pipeline_reg[ID_OC_SP], &m_pipeline_reg[ID_OC_DP],
+            &m_pipeline_reg[ID_OC_SFU], &m_pipeline_reg[ID_OC_INT],
+            &m_pipeline_reg[ID_OC_TENSOR_CORE], &m_pipeline_reg[ID_OC_MEM], i));
+        break;
+      case CONCRETE_SCHEDULER_WARP_LIMITING:
+        schedulers.push_back(new swl_scheduler(
+            m_stats, this, m_scoreboard, m_simt_stack, &m_warp,
+            &m_pipeline_reg[ID_OC_SP], &m_pipeline_reg[ID_OC_DP],
+            &m_pipeline_reg[ID_OC_SFU], &m_pipeline_reg[ID_OC_INT],
+            &m_pipeline_reg[ID_OC_TENSOR_CORE], &m_pipeline_reg[ID_OC_MEM], i,
+            config->gpgpu_scheduler_string));
+        break;
+      default:
+        abort();
+    };
+  }
+
+  for (unsigned i = 0; i < m_warp.size(); i++) {
+    // distribute i's evenly though schedulers;
+    schedulers[i % m_config->gpgpu_num_sched_per_core]->add_supervised_warp_id(
+        i);
+  }
+  for (unsigned i = 0; i < m_config->gpgpu_num_sched_per_core; ++i) {
+    schedulers[i]->done_adding_supervised_warps();
+  }
+
+  // op collector configuration
+
+  enum { SP_CUS, DP_CUS, SFU_CUS, TENSOR_CORE_CUS, INT_CUS, MEM_CUS, GEN_CUS };
+
+  opndcoll_rfu_t::port_vector_t in_ports;
+  opndcoll_rfu_t::port_vector_t out_ports;
+  opndcoll_rfu_t::uint_vector_t cu_sets;
+
+  // configure generic collectors
+  m_operand_collector.add_cu_set(
+      GEN_CUS, m_config->gpgpu_operand_collector_num_units_gen,
+      m_config->gpgpu_operand_collector_num_out_ports_gen);
+
+  for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_gen;
+       i++) {
+    in_ports.push_back(&m_pipeline_reg[ID_OC_SP]);
+    in_ports.push_back(&m_pipeline_reg[ID_OC_SFU]);
+    in_ports.push_back(&m_pipeline_reg[ID_OC_MEM]);
+    out_ports.push_back(&m_pipeline_reg[OC_EX_SP]);
+    out_ports.push_back(&m_pipeline_reg[OC_EX_SFU]);
+    out_ports.push_back(&m_pipeline_reg[OC_EX_MEM]);
+    if (m_config->gpgpu_tensor_core_avail) {
+      in_ports.push_back(&m_pipeline_reg[ID_OC_TENSOR_CORE]);
+      out_ports.push_back(&m_pipeline_reg[OC_EX_TENSOR_CORE]);
     }
-    if(m_config->sub_core_model) {
-    	//in subcore model, each scheduler should has its own issue register, so num scheduler = reg width
-    	assert(m_config->gpgpu_num_sched_per_core == m_pipeline_reg[ID_OC_SP].get_size() );
-    	assert(m_config->gpgpu_num_sched_per_core == m_pipeline_reg[ID_OC_SFU].get_size() );
-    	assert(m_config->gpgpu_num_sched_per_core == m_pipeline_reg[ID_OC_MEM].get_size() );
-    	if(m_config->gpgpu_tensor_core_avail)
-    		 assert(m_config->gpgpu_num_sched_per_core == m_pipeline_reg[ID_OC_TENSOR_CORE].get_size() );
-    	if(m_config->gpgpu_num_dp_units > 0)
-    		assert(m_config->gpgpu_num_sched_per_core == m_pipeline_reg[ID_OC_DP].get_size() );
-    	if(m_config->gpgpu_num_int_units > 0)
-    	    assert(m_config->gpgpu_num_sched_per_core == m_pipeline_reg[ID_OC_INT].get_size() );
+    if (m_config->gpgpu_num_dp_units > 0) {
+      in_ports.push_back(&m_pipeline_reg[ID_OC_DP]);
+      out_ports.push_back(&m_pipeline_reg[OC_EX_DP]);
     }
-    
-    m_threadState = (thread_ctx_t*) calloc(sizeof(thread_ctx_t), config->n_thread_per_shader);
-    
+    if (m_config->gpgpu_num_int_units > 0) {
+      in_ports.push_back(&m_pipeline_reg[ID_OC_INT]);
+      out_ports.push_back(&m_pipeline_reg[OC_EX_INT]);
+    }
+    cu_sets.push_back((unsigned)GEN_CUS);
+    m_operand_collector.add_port(in_ports, out_ports, cu_sets);
+    in_ports.clear(), out_ports.clear(), cu_sets.clear();
+  }
+
+  if (m_config->enable_specialized_operand_collector) {
+    m_operand_collector.add_cu_set(
+        SP_CUS, m_config->gpgpu_operand_collector_num_units_sp,
+        m_config->gpgpu_operand_collector_num_out_ports_sp);
+    m_operand_collector.add_cu_set(
+        DP_CUS, m_config->gpgpu_operand_collector_num_units_dp,
+        m_config->gpgpu_operand_collector_num_out_ports_dp);
+    m_operand_collector.add_cu_set(
+        TENSOR_CORE_CUS, config->gpgpu_operand_collector_num_units_tensor_core,
+        config->gpgpu_operand_collector_num_out_ports_tensor_core);
+    m_operand_collector.add_cu_set(
+        SFU_CUS, m_config->gpgpu_operand_collector_num_units_sfu,
+        m_config->gpgpu_operand_collector_num_out_ports_sfu);
+    m_operand_collector.add_cu_set(
+        MEM_CUS, m_config->gpgpu_operand_collector_num_units_mem,
+        m_config->gpgpu_operand_collector_num_out_ports_mem);
+    m_operand_collector.add_cu_set(
+        INT_CUS, m_config->gpgpu_operand_collector_num_units_int,
+        m_config->gpgpu_operand_collector_num_out_ports_int);
+
+    for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_sp;
+         i++) {
+      in_ports.push_back(&m_pipeline_reg[ID_OC_SP]);
+      out_ports.push_back(&m_pipeline_reg[OC_EX_SP]);
+      cu_sets.push_back((unsigned)SP_CUS);
+      cu_sets.push_back((unsigned)GEN_CUS);
+      m_operand_collector.add_port(in_ports, out_ports, cu_sets);
+      in_ports.clear(), out_ports.clear(), cu_sets.clear();
+    }
+
+    for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_dp;
+         i++) {
+      in_ports.push_back(&m_pipeline_reg[ID_OC_DP]);
+      out_ports.push_back(&m_pipeline_reg[OC_EX_DP]);
+      cu_sets.push_back((unsigned)DP_CUS);
+      cu_sets.push_back((unsigned)GEN_CUS);
+      m_operand_collector.add_port(in_ports, out_ports, cu_sets);
+      in_ports.clear(), out_ports.clear(), cu_sets.clear();
+    }
+
+    for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_sfu;
+         i++) {
+      in_ports.push_back(&m_pipeline_reg[ID_OC_SFU]);
+      out_ports.push_back(&m_pipeline_reg[OC_EX_SFU]);
+      cu_sets.push_back((unsigned)SFU_CUS);
+      cu_sets.push_back((unsigned)GEN_CUS);
+      m_operand_collector.add_port(in_ports, out_ports, cu_sets);
+      in_ports.clear(), out_ports.clear(), cu_sets.clear();
+    }
+
+    for (unsigned i = 0;
+         i < config->gpgpu_operand_collector_num_in_ports_tensor_core; i++) {
+      in_ports.push_back(&m_pipeline_reg[ID_OC_TENSOR_CORE]);
+      out_ports.push_back(&m_pipeline_reg[OC_EX_TENSOR_CORE]);
+      cu_sets.push_back((unsigned)TENSOR_CORE_CUS);
+      cu_sets.push_back((unsigned)GEN_CUS);
+      m_operand_collector.add_port(in_ports, out_ports, cu_sets);
+      in_ports.clear(), out_ports.clear(), cu_sets.clear();
+    }
+
+    for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_mem;
+         i++) {
+      in_ports.push_back(&m_pipeline_reg[ID_OC_MEM]);
+      out_ports.push_back(&m_pipeline_reg[OC_EX_MEM]);
+      cu_sets.push_back((unsigned)MEM_CUS);
+      cu_sets.push_back((unsigned)GEN_CUS);
+      m_operand_collector.add_port(in_ports, out_ports, cu_sets);
+      in_ports.clear(), out_ports.clear(), cu_sets.clear();
+    }
+
+    for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_int;
+         i++) {
+      in_ports.push_back(&m_pipeline_reg[ID_OC_INT]);
+      out_ports.push_back(&m_pipeline_reg[OC_EX_INT]);
+      cu_sets.push_back((unsigned)INT_CUS);
+      cu_sets.push_back((unsigned)GEN_CUS);
+      m_operand_collector.add_port(in_ports, out_ports, cu_sets);
+      in_ports.clear(), out_ports.clear(), cu_sets.clear();
+    }
+  }
+
+  m_operand_collector.init(m_config->gpgpu_num_reg_banks, this);
+
+  m_num_function_units =
+      m_config->gpgpu_num_sp_units + m_config->gpgpu_num_dp_units +
+      m_config->gpgpu_num_sfu_units + m_config->gpgpu_num_tensor_core_units +
+      m_config->gpgpu_num_int_units +
+      1;  // sp_unit, sfu, dp, tensor, int, ldst_unit
+  // m_dispatch_port = new enum pipeline_stage_name_t[ m_num_function_units ];
+  // m_issue_port = new enum pipeline_stage_name_t[ m_num_function_units ];
+
+  // m_fu = new simd_function_unit*[m_num_function_units];
+
+  for (int k = 0; k < m_config->gpgpu_num_sp_units; k++) {
+    m_fu.push_back(new sp_unit(&m_pipeline_reg[EX_WB], m_config, this));
+    m_dispatch_port.push_back(ID_OC_SP);
+    m_issue_port.push_back(OC_EX_SP);
+  }
+
+  for (int k = 0; k < m_config->gpgpu_num_dp_units; k++) {
+    m_fu.push_back(new dp_unit(&m_pipeline_reg[EX_WB], m_config, this));
+    m_dispatch_port.push_back(ID_OC_DP);
+    m_issue_port.push_back(OC_EX_DP);
+  }
+  for (int k = 0; k < m_config->gpgpu_num_int_units; k++) {
+    m_fu.push_back(new int_unit(&m_pipeline_reg[EX_WB], m_config, this));
+    m_dispatch_port.push_back(ID_OC_INT);
+    m_issue_port.push_back(OC_EX_INT);
+  }
+
+  for (int k = 0; k < m_config->gpgpu_num_sfu_units; k++) {
+    m_fu.push_back(new sfu(&m_pipeline_reg[EX_WB], m_config, this));
+    m_dispatch_port.push_back(ID_OC_SFU);
+    m_issue_port.push_back(OC_EX_SFU);
+  }
+
+  for (int k = 0; k < config->gpgpu_num_tensor_core_units; k++) {
+    m_fu.push_back(new tensor_core(&m_pipeline_reg[EX_WB], m_config, this));
+    m_dispatch_port.push_back(ID_OC_TENSOR_CORE);
+    m_issue_port.push_back(OC_EX_TENSOR_CORE);
+  }
+
+  m_ldst_unit =
+      new ldst_unit(m_icnt, m_mem_fetch_allocator, this, &m_operand_collector,
+                    m_scoreboard, config, mem_config, stats, shader_id, tpc_id);
+  m_fu.push_back(m_ldst_unit);
+  m_dispatch_port.push_back(ID_OC_MEM);
+  m_issue_port.push_back(OC_EX_MEM);
+
+  assert(m_num_function_units == m_fu.size() and
+         m_fu.size() == m_dispatch_port.size() and
+         m_fu.size() == m_issue_port.size());
+
+  // there are as many result buses as the width of the EX_WB stage
+  num_result_bus = config->pipe_widths[EX_WB];
+  for (unsigned i = 0; i < num_result_bus; i++) {
+    this->m_result_bus.push_back(new std::bitset<MAX_ALU_LATENCY>());
+  }
+
+  m_last_inst_gpu_sim_cycle = 0;
+  m_last_inst_gpu_tot_sim_cycle = 0;
+
+  // Jin: for concurrent kernels on a SM
+  m_occupied_n_threads = 0;
+  m_occupied_shmem = 0;
+  m_occupied_regs = 0;
+  m_occupied_ctas = 0;
+  m_occupied_hwtid.reset();
+  m_occupied_cta_to_hwtid.clear();
+}
+
+void shader_core_ctx::reinit(unsigned start_thread, unsigned end_thread,
+                             bool reset_not_completed) {
+  if (reset_not_completed) {
     m_not_completed = 0;
     m_active_threads.reset();
-    m_n_active_cta = 0;
-    for ( unsigned i = 0; i<MAX_CTA_PER_SHADER; i++ ) 
-        m_cta_status[i]=0;
-    for (unsigned i = 0; i<config->n_thread_per_shader; i++) {
-        m_thread[i]= NULL;
-        m_threadState[i].m_cta_id = -1;
-        m_threadState[i].m_active = false;
-    }
-    
-    // m_icnt = new shader_memory_interface(this,cluster);
-    if ( m_config->gpgpu_perfect_mem ) {
-        m_icnt = new perfect_memory_interface(this,cluster);
-    } else {
-        m_icnt = new shader_memory_interface(this,cluster);
-    }
-    m_mem_fetch_allocator = new shader_core_mem_fetch_allocator(shader_id,tpc_id,mem_config);
-    
-    // fetch
-    m_last_warp_fetched = 0;
-    
-    #define STRSIZE 1024
-    char name[STRSIZE];
-    snprintf(name, STRSIZE, "L1I_%03d", m_sid);
-    m_L1I = new read_only_cache( name,m_config->m_L1I_config,m_sid,get_shader_instruction_cache_id(),m_icnt,IN_L1I_MISS_QUEUE);
-    
-    m_warp.resize(m_config->max_warps_per_shader, shd_warp_t(this, warp_size));
-    m_scoreboard = new Scoreboard(m_sid, m_config->max_warps_per_shader, gpu);
-    
-    //scedulers
-    //must currently occur after all inputs have been initialized.
-    std::string sched_config = m_config->gpgpu_scheduler_string;
-    const concrete_scheduler scheduler = sched_config.find("lrr") != std::string::npos ?
-                                         CONCRETE_SCHEDULER_LRR :
-                                         sched_config.find("two_level_active") != std::string::npos ?
-                                         CONCRETE_SCHEDULER_TWO_LEVEL_ACTIVE :
-                                         sched_config.find("gto") != std::string::npos ?
-                                         CONCRETE_SCHEDULER_GTO :
-					 sched_config.find("old") != std::string::npos ?
-					 CONCRETE_SCHEDULER_OLDEST_FIRST :
-                                         sched_config.find("warp_limiting") != std::string::npos ?
-                                         CONCRETE_SCHEDULER_WARP_LIMITING:
-                                         NUM_CONCRETE_SCHEDULERS;
-    assert ( scheduler != NUM_CONCRETE_SCHEDULERS );
-    
-    for (unsigned i = 0; i < m_config->gpgpu_num_sched_per_core; i++) {
-        switch( scheduler )
-        {
-            case CONCRETE_SCHEDULER_LRR:
-                schedulers.push_back(
-                    new lrr_scheduler( m_stats,
-                                       this,
-                                       m_scoreboard,
-                                       m_simt_stack,
-                                       &m_warp,
-                                       &m_pipeline_reg[ID_OC_SP],
-									   &m_pipeline_reg[ID_OC_DP],
-                                       &m_pipeline_reg[ID_OC_SFU],
-									   &m_pipeline_reg[ID_OC_INT],
-                                       &m_pipeline_reg[ID_OC_TENSOR_CORE],
-                                       &m_pipeline_reg[ID_OC_MEM],
-                                       i
-                                     )
-                );
-                break;
-            case CONCRETE_SCHEDULER_TWO_LEVEL_ACTIVE:
-                schedulers.push_back(
-                    new two_level_active_scheduler( m_stats,
-                                                    this,
-                                                    m_scoreboard,
-                                                    m_simt_stack,
-                                                    &m_warp,
-                                                    &m_pipeline_reg[ID_OC_SP],
-													&m_pipeline_reg[ID_OC_DP],
-                                                    &m_pipeline_reg[ID_OC_SFU],
-													&m_pipeline_reg[ID_OC_INT],
-                                                    &m_pipeline_reg[ID_OC_TENSOR_CORE],
-                                                    &m_pipeline_reg[ID_OC_MEM],
-                                                    i,
-                                                    config->gpgpu_scheduler_string
-                                                  )
-                );
-                break;
-            case CONCRETE_SCHEDULER_GTO:
-                schedulers.push_back(
-                    new gto_scheduler( m_stats,
-                                       this,
-                                       m_scoreboard,
-                                       m_simt_stack,
-                                       &m_warp,
-                                       &m_pipeline_reg[ID_OC_SP],
-									   &m_pipeline_reg[ID_OC_DP],
-                                       &m_pipeline_reg[ID_OC_SFU],
-									   &m_pipeline_reg[ID_OC_INT],
-                                       &m_pipeline_reg[ID_OC_TENSOR_CORE],
-                                       &m_pipeline_reg[ID_OC_MEM],
-                                       i
-                                     )
-                );
-                break;
-            case CONCRETE_SCHEDULER_OLDEST_FIRST:
-				schedulers.push_back(
-		    new oldest_scheduler( m_stats,
-					  this,
-					  m_scoreboard,
-					  m_simt_stack,
-					  &m_warp,
-					  &m_pipeline_reg[ID_OC_SP],
-					  &m_pipeline_reg[ID_OC_DP],
-					  &m_pipeline_reg[ID_OC_SFU],
-					  &m_pipeline_reg[ID_OC_INT],
-                      &m_pipeline_reg[ID_OC_TENSOR_CORE],
-					  &m_pipeline_reg[ID_OC_MEM],
-					  i
-					 )
-				);
-				break;
-            case CONCRETE_SCHEDULER_WARP_LIMITING:
-                schedulers.push_back(
-                    new swl_scheduler( m_stats,
-                                       this,
-                                       m_scoreboard,
-                                       m_simt_stack,
-                                       &m_warp,
-                                       &m_pipeline_reg[ID_OC_SP],
-									   &m_pipeline_reg[ID_OC_DP],
-                                       &m_pipeline_reg[ID_OC_SFU],
-									   &m_pipeline_reg[ID_OC_INT],
-                                       &m_pipeline_reg[ID_OC_TENSOR_CORE],
-                                       &m_pipeline_reg[ID_OC_MEM],
-                                       i,
-                                       config->gpgpu_scheduler_string
-                                     )
-                );
-                break;
-            default:
-                abort();
-        };
-    }
-    
-    for (unsigned i = 0; i < m_warp.size(); i++) {
-        //distribute i's evenly though schedulers;
-        schedulers[i%m_config->gpgpu_num_sched_per_core]->add_supervised_warp_id(i);
-    }
-    for ( unsigned i = 0; i < m_config->gpgpu_num_sched_per_core; ++i ) {
-        schedulers[i]->done_adding_supervised_warps();
-    }
-    
-    //op collector configuration
 
-	enum { SP_CUS, DP_CUS, SFU_CUS, TENSOR_CORE_CUS, INT_CUS, MEM_CUS,  GEN_CUS };
-
-    opndcoll_rfu_t::port_vector_t in_ports;
-    opndcoll_rfu_t::port_vector_t out_ports;
-    opndcoll_rfu_t::uint_vector_t cu_sets;
-
-    //configure generic collectors
-    m_operand_collector.add_cu_set(GEN_CUS, m_config->gpgpu_operand_collector_num_units_gen, m_config->gpgpu_operand_collector_num_out_ports_gen);
-
-    for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_gen; i++) {
-        in_ports.push_back(&m_pipeline_reg[ID_OC_SP]);
-        in_ports.push_back(&m_pipeline_reg[ID_OC_SFU]);
-        in_ports.push_back(&m_pipeline_reg[ID_OC_MEM]);
-        out_ports.push_back(&m_pipeline_reg[OC_EX_SP]);
-        out_ports.push_back(&m_pipeline_reg[OC_EX_SFU]);
-        out_ports.push_back(&m_pipeline_reg[OC_EX_MEM]);
-        if(m_config->gpgpu_tensor_core_avail) {
-        	in_ports.push_back(&m_pipeline_reg[ID_OC_TENSOR_CORE]);
-        	out_ports.push_back(&m_pipeline_reg[OC_EX_TENSOR_CORE]);
-        }
-        if(m_config->gpgpu_num_dp_units > 0) {
-			in_ports.push_back(&m_pipeline_reg[ID_OC_DP]);
-			out_ports.push_back(&m_pipeline_reg[OC_EX_DP]);
-        }
-        if(m_config->gpgpu_num_int_units > 0) {
-			in_ports.push_back(&m_pipeline_reg[ID_OC_INT]);
-			out_ports.push_back(&m_pipeline_reg[OC_EX_INT]);
-        }
-        cu_sets.push_back((unsigned)GEN_CUS);
-        m_operand_collector.add_port(in_ports,out_ports,cu_sets);
-        in_ports.clear(),out_ports.clear(),cu_sets.clear();
-    }
-
-    if(m_config->enable_specialized_operand_collector) {
-		m_operand_collector.add_cu_set(SP_CUS, m_config->gpgpu_operand_collector_num_units_sp, m_config->gpgpu_operand_collector_num_out_ports_sp);
-		m_operand_collector.add_cu_set(DP_CUS, m_config->gpgpu_operand_collector_num_units_dp, m_config->gpgpu_operand_collector_num_out_ports_dp);
-	    m_operand_collector.add_cu_set(TENSOR_CORE_CUS, config->gpgpu_operand_collector_num_units_tensor_core, config->gpgpu_operand_collector_num_out_ports_tensor_core);
-	    m_operand_collector.add_cu_set(SFU_CUS, m_config->gpgpu_operand_collector_num_units_sfu, m_config->gpgpu_operand_collector_num_out_ports_sfu);
-		m_operand_collector.add_cu_set(MEM_CUS, m_config->gpgpu_operand_collector_num_units_mem, m_config->gpgpu_operand_collector_num_out_ports_mem);
-		m_operand_collector.add_cu_set(INT_CUS, m_config->gpgpu_operand_collector_num_units_int, m_config->gpgpu_operand_collector_num_out_ports_int);
-
-		for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_sp; i++) {
-			in_ports.push_back(&m_pipeline_reg[ID_OC_SP]);
-			out_ports.push_back(&m_pipeline_reg[OC_EX_SP]);
-			cu_sets.push_back((unsigned)SP_CUS);
-			cu_sets.push_back((unsigned)GEN_CUS);
-			m_operand_collector.add_port(in_ports,out_ports,cu_sets);
-			in_ports.clear(),out_ports.clear(),cu_sets.clear();
-		}
-
-		for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_dp; i++) {
-				in_ports.push_back(&m_pipeline_reg[ID_OC_DP]);
-				out_ports.push_back(&m_pipeline_reg[OC_EX_DP]);
-				cu_sets.push_back((unsigned)DP_CUS);
-				cu_sets.push_back((unsigned)GEN_CUS);
-				m_operand_collector.add_port(in_ports,out_ports,cu_sets);
-				in_ports.clear(),out_ports.clear(),cu_sets.clear();
-			}
-
-		for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_sfu; i++) {
-			in_ports.push_back(&m_pipeline_reg[ID_OC_SFU]);
-			out_ports.push_back(&m_pipeline_reg[OC_EX_SFU]);
-			cu_sets.push_back((unsigned)SFU_CUS);
-			cu_sets.push_back((unsigned)GEN_CUS);
-			m_operand_collector.add_port(in_ports,out_ports,cu_sets);
-			in_ports.clear(),out_ports.clear(),cu_sets.clear();
-		}
-
-	    for (unsigned i = 0; i < config->gpgpu_operand_collector_num_in_ports_tensor_core; i++) {
-	        in_ports.push_back(&m_pipeline_reg[ID_OC_TENSOR_CORE]);
-	        out_ports.push_back(&m_pipeline_reg[OC_EX_TENSOR_CORE]);
-	        cu_sets.push_back((unsigned)TENSOR_CORE_CUS);
-	        cu_sets.push_back((unsigned)GEN_CUS);
-	        m_operand_collector.add_port(in_ports,out_ports,cu_sets);
-	        in_ports.clear(),out_ports.clear(),cu_sets.clear();
-	    }
-
-		for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_mem; i++) {
-			in_ports.push_back(&m_pipeline_reg[ID_OC_MEM]);
-			out_ports.push_back(&m_pipeline_reg[OC_EX_MEM]);
-			cu_sets.push_back((unsigned)MEM_CUS);
-			cu_sets.push_back((unsigned)GEN_CUS);
-			m_operand_collector.add_port(in_ports,out_ports,cu_sets);
-			in_ports.clear(),out_ports.clear(),cu_sets.clear();
-		}
-
-		for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_int; i++) {
-			in_ports.push_back(&m_pipeline_reg[ID_OC_INT]);
-			out_ports.push_back(&m_pipeline_reg[OC_EX_INT]);
-			cu_sets.push_back((unsigned)INT_CUS);
-			cu_sets.push_back((unsigned)GEN_CUS);
-			m_operand_collector.add_port(in_ports,out_ports,cu_sets);
-			in_ports.clear(),out_ports.clear(),cu_sets.clear();
-		}
-    }
-    
-    m_operand_collector.init( m_config->gpgpu_num_reg_banks, this );
-    
-    m_num_function_units = m_config->gpgpu_num_sp_units + m_config->gpgpu_num_dp_units + m_config->gpgpu_num_sfu_units + m_config->gpgpu_num_tensor_core_units + m_config->gpgpu_num_int_units + 1; // sp_unit, sfu, dp, tensor, int, ldst_unit
-    //m_dispatch_port = new enum pipeline_stage_name_t[ m_num_function_units ];
-    //m_issue_port = new enum pipeline_stage_name_t[ m_num_function_units ];
-    
-    //m_fu = new simd_function_unit*[m_num_function_units];
-    
-    for (int k = 0; k < m_config->gpgpu_num_sp_units; k++) {
-        m_fu.push_back(new sp_unit( &m_pipeline_reg[EX_WB], m_config, this ));
-        m_dispatch_port.push_back(ID_OC_SP);
-        m_issue_port.push_back(OC_EX_SP);
-    }
-    
-    for (int k = 0; k < m_config->gpgpu_num_dp_units; k++) {
-            m_fu.push_back(new dp_unit( &m_pipeline_reg[EX_WB], m_config, this ));
-            m_dispatch_port.push_back(ID_OC_DP);
-            m_issue_port.push_back(OC_EX_DP);
-        }
-    for (int k = 0; k < m_config->gpgpu_num_int_units; k++) {
-            m_fu.push_back(new int_unit( &m_pipeline_reg[EX_WB], m_config, this ));
-            m_dispatch_port.push_back(ID_OC_INT);
-            m_issue_port.push_back(OC_EX_INT);
-        }
-
-    for (int k = 0; k < m_config->gpgpu_num_sfu_units; k++) {
-        m_fu.push_back(new sfu( &m_pipeline_reg[EX_WB], m_config, this ));
-        m_dispatch_port.push_back(ID_OC_SFU);
-        m_issue_port.push_back(OC_EX_SFU);
-    }
-       
-    for (int k = 0; k < config->gpgpu_num_tensor_core_units; k++) {
-        m_fu.push_back(new tensor_core( &m_pipeline_reg[EX_WB], m_config, this ));
-        m_dispatch_port.push_back(ID_OC_TENSOR_CORE);
-        m_issue_port.push_back(OC_EX_TENSOR_CORE);
-    }
-
-    m_ldst_unit = new ldst_unit( m_icnt, m_mem_fetch_allocator, this, &m_operand_collector, m_scoreboard, config, mem_config, stats, shader_id, tpc_id );
-    m_fu.push_back(m_ldst_unit);
-    m_dispatch_port.push_back(ID_OC_MEM);
-    m_issue_port.push_back(OC_EX_MEM);
-   
-    assert(m_num_function_units == m_fu.size() and m_fu.size() == m_dispatch_port.size() and m_fu.size() == m_issue_port.size());
-    
-    //there are as many result buses as the width of the EX_WB stage
-    num_result_bus = config->pipe_widths[EX_WB];
-    for(unsigned i=0; i<num_result_bus; i++){
-        this->m_result_bus.push_back(new std::bitset<MAX_ALU_LATENCY>());
-    }
-    
-    m_last_inst_gpu_sim_cycle = 0;
-    m_last_inst_gpu_tot_sim_cycle = 0;
-
-    //Jin: for concurrent kernels on a SM
+    // Jin: for concurrent kernels on a SM
     m_occupied_n_threads = 0;
     m_occupied_shmem = 0;
     m_occupied_regs = 0;
     m_occupied_ctas = 0;
     m_occupied_hwtid.reset();
     m_occupied_cta_to_hwtid.clear();
+    m_active_warps = 0;
+  }
+  for (unsigned i = start_thread; i < end_thread; i++) {
+    m_threadState[i].n_insn = 0;
+    m_threadState[i].m_cta_id = -1;
+  }
+  for (unsigned i = start_thread / m_config->warp_size;
+       i < end_thread / m_config->warp_size; ++i) {
+    m_warp[i].reset();
+    m_simt_stack[i]->reset();
+  }
 }
 
-void shader_core_ctx::reinit(unsigned start_thread, unsigned end_thread, bool reset_not_completed ) 
-{
-   if( reset_not_completed ) {
-       m_not_completed = 0;
-       m_active_threads.reset();
-
-       //Jin: for concurrent kernels on a SM
-       m_occupied_n_threads = 0;
-       m_occupied_shmem = 0;
-       m_occupied_regs = 0;
-       m_occupied_ctas = 0;
-       m_occupied_hwtid.reset();
-       m_occupied_cta_to_hwtid.clear();
-       m_active_warps = 0;
-
-   }
-   for (unsigned i = start_thread; i<end_thread; i++) {
-      m_threadState[i].n_insn = 0;
-      m_threadState[i].m_cta_id = -1;
-   }
-   for (unsigned i = start_thread / m_config->warp_size; i < end_thread / m_config->warp_size; ++i) {
-      m_warp[i].reset();
-      m_simt_stack[i]->reset();
-   }
-}
-
-void shader_core_ctx::init_warps( unsigned cta_id, unsigned start_thread, unsigned end_thread, unsigned ctaid, int cta_size, unsigned kernel_id )
-{
-    address_type start_pc = next_pc(start_thread);
-    if (m_config->model == POST_DOMINATOR) {
-        unsigned start_warp = start_thread / m_config->warp_size;
-        unsigned warp_per_cta =  cta_size / m_config->warp_size;
-        unsigned end_warp = end_thread / m_config->warp_size + ((end_thread % m_config->warp_size)? 1 : 0);
-        for (unsigned i = start_warp; i < end_warp; ++i) {
-            unsigned n_active=0;
-            simt_mask_t active_threads;
-            for (unsigned t = 0; t < m_config->warp_size; t++) {
-                unsigned hwtid = i * m_config->warp_size + t;
-                if ( hwtid < end_thread ) {
-                    n_active++;
-                    assert( !m_active_threads.test(hwtid) );
-                    m_active_threads.set( hwtid );
-                    active_threads.set(t);
-                }
-            }
-            m_simt_stack[i]->launch(start_pc,active_threads);
-
-              if(m_gpu->resume_option == 1 && kernel_id == m_gpu->resume_kernel && ctaid >= m_gpu->resume_CTA && ctaid < m_gpu->checkpoint_CTA_t )
-               { 
-                char fname[2048];
-                snprintf(fname,2048,"checkpoint_files/warp_%d_%d_simt.txt",i%warp_per_cta,ctaid );
-                unsigned pc,rpc;
-                m_simt_stack[i]->resume(fname);
-                m_simt_stack[i]->get_pdom_stack_top_info(&pc,&rpc);
-                for (unsigned t = 0; t < m_config->warp_size; t++) {
-                  m_thread[i * m_config->warp_size + t]->set_npc(pc);
-                  m_thread[i * m_config->warp_size + t]->update_pc();
-                }   
-                start_pc=pc;
-              }
-               
-            m_warp[i].init(start_pc,cta_id,i,active_threads, m_dynamic_warp_id);
-            ++m_dynamic_warp_id;
-            m_not_completed += n_active;
-            ++m_active_warps;
+void shader_core_ctx::init_warps(unsigned cta_id, unsigned start_thread,
+                                 unsigned end_thread, unsigned ctaid,
+                                 int cta_size, unsigned kernel_id) {
+  address_type start_pc = next_pc(start_thread);
+  if (m_config->model == POST_DOMINATOR) {
+    unsigned start_warp = start_thread / m_config->warp_size;
+    unsigned warp_per_cta = cta_size / m_config->warp_size;
+    unsigned end_warp = end_thread / m_config->warp_size +
+                        ((end_thread % m_config->warp_size) ? 1 : 0);
+    for (unsigned i = start_warp; i < end_warp; ++i) {
+      unsigned n_active = 0;
+      simt_mask_t active_threads;
+      for (unsigned t = 0; t < m_config->warp_size; t++) {
+        unsigned hwtid = i * m_config->warp_size + t;
+        if (hwtid < end_thread) {
+          n_active++;
+          assert(!m_active_threads.test(hwtid));
+          m_active_threads.set(hwtid);
+          active_threads.set(t);
+        }
       }
-   }
-}
+      m_simt_stack[i]->launch(start_pc, active_threads);
 
-// return the next pc of a thread 
-address_type shader_core_ctx::next_pc( int tid ) const
-{
-    if( tid == -1 ) 
-        return -1;
-    ptx_thread_info *the_thread = m_thread[tid];
-    if ( the_thread == NULL )
-        return -1;
-    return the_thread->get_pc(); // PC should already be updatd to next PC at this point (was set in shader_decode() last time thread ran)
-}
-
-void gpgpu_sim::get_pdom_stack_top_info( unsigned sid, unsigned tid, unsigned *pc, unsigned *rpc )
-{
-    unsigned cluster_id = m_shader_config->sid_to_cluster(sid);
-    m_cluster[cluster_id]->get_pdom_stack_top_info(sid,tid,pc,rpc);
-}
-
-void shader_core_ctx::get_pdom_stack_top_info( unsigned tid, unsigned *pc, unsigned *rpc ) const
-{
-    unsigned warp_id = tid/m_config->warp_size;
-    m_simt_stack[warp_id]->get_pdom_stack_top_info(pc,rpc);
-}
-
-float shader_core_ctx::get_current_occupancy( unsigned long long & active, unsigned long long & total ) const
-{
-    // To match the achieved_occupancy in nvprof, only SMs that are active are counted toward the occupancy.
-    if ( m_active_warps > 0 ) {
-        total += m_warp.size();
-        active += m_active_warps;
-        return float(active) / float(total);
-    } else {
-        return 0;
-    }
-}
-
-void shader_core_stats::print( FILE* fout ) const
-{
-	unsigned long long  thread_icount_uarch=0;
-	unsigned long long  warp_icount_uarch=0;
-
-    for(unsigned i=0; i < m_config->num_shader(); i++) {
-        thread_icount_uarch += m_num_sim_insn[i];
-        warp_icount_uarch += m_num_sim_winsn[i];
-    }
-    fprintf(fout,"gpgpu_n_tot_thrd_icount = %lld\n", thread_icount_uarch);
-    fprintf(fout,"gpgpu_n_tot_w_icount = %lld\n", warp_icount_uarch);
-
-    fprintf(fout,"gpgpu_n_stall_shd_mem = %d\n", gpgpu_n_stall_shd_mem );
-    fprintf(fout,"gpgpu_n_mem_read_local = %d\n", gpgpu_n_mem_read_local);
-    fprintf(fout,"gpgpu_n_mem_write_local = %d\n", gpgpu_n_mem_write_local);
-    fprintf(fout,"gpgpu_n_mem_read_global = %d\n", gpgpu_n_mem_read_global);
-    fprintf(fout,"gpgpu_n_mem_write_global = %d\n", gpgpu_n_mem_write_global);
-    fprintf(fout,"gpgpu_n_mem_texture = %d\n", gpgpu_n_mem_texture);
-    fprintf(fout,"gpgpu_n_mem_const = %d\n", gpgpu_n_mem_const);
-
-   fprintf(fout, "gpgpu_n_load_insn  = %d\n", gpgpu_n_load_insn);
-   fprintf(fout, "gpgpu_n_store_insn = %d\n", gpgpu_n_store_insn);
-   fprintf(fout, "gpgpu_n_shmem_insn = %d\n", gpgpu_n_shmem_insn);
-   fprintf(fout, "gpgpu_n_sstarr_insn = %d\n", gpgpu_n_sstarr_insn);
-   fprintf(fout, "gpgpu_n_tex_insn = %d\n", gpgpu_n_tex_insn);
-   fprintf(fout, "gpgpu_n_const_mem_insn = %d\n", gpgpu_n_const_insn);
-   fprintf(fout, "gpgpu_n_param_mem_insn = %d\n", gpgpu_n_param_insn);
-
-   fprintf(fout, "gpgpu_n_shmem_bkconflict = %d\n", gpgpu_n_shmem_bkconflict);
-   fprintf(fout, "gpgpu_n_cache_bkconflict = %d\n", gpgpu_n_cache_bkconflict);   
-
-   fprintf(fout, "gpgpu_n_intrawarp_mshr_merge = %d\n", gpgpu_n_intrawarp_mshr_merge);
-   fprintf(fout, "gpgpu_n_cmem_portconflict = %d\n", gpgpu_n_cmem_portconflict);
-
-   fprintf(fout, "gpgpu_stall_shd_mem[c_mem][resource_stall] = %d\n", gpu_stall_shd_mem_breakdown[C_MEM][BK_CONF]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[c_mem][mshr_rc] = %d\n", gpu_stall_shd_mem_breakdown[C_MEM][MSHR_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[c_mem][icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[C_MEM][ICNT_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[c_mem][data_port_stall] = %d\n", gpu_stall_shd_mem_breakdown[C_MEM][DATA_PORT_STALL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[t_mem][mshr_rc] = %d\n", gpu_stall_shd_mem_breakdown[T_MEM][MSHR_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[t_mem][icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[T_MEM][ICNT_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[t_mem][data_port_stall] = %d\n", gpu_stall_shd_mem_breakdown[T_MEM][DATA_PORT_STALL]);
-   fprintf(fout, "gpgpu_stall_shd_mem[s_mem][bk_conf] = %d\n", gpu_stall_shd_mem_breakdown[S_MEM][BK_CONF]);
-   fprintf(fout, "gpgpu_stall_shd_mem[gl_mem][resource_stall] = %d\n",
-           gpu_stall_shd_mem_breakdown[G_MEM_LD][BK_CONF] + 
-           gpu_stall_shd_mem_breakdown[G_MEM_ST][BK_CONF] + 
-           gpu_stall_shd_mem_breakdown[L_MEM_LD][BK_CONF] + 
-           gpu_stall_shd_mem_breakdown[L_MEM_ST][BK_CONF]   
-           ); // coalescing stall at data cache 
-   fprintf(fout, "gpgpu_stall_shd_mem[gl_mem][coal_stall] = %d\n", 
-           gpu_stall_shd_mem_breakdown[G_MEM_LD][COAL_STALL] + 
-           gpu_stall_shd_mem_breakdown[G_MEM_ST][COAL_STALL] + 
-           gpu_stall_shd_mem_breakdown[L_MEM_LD][COAL_STALL] + 
-           gpu_stall_shd_mem_breakdown[L_MEM_ST][COAL_STALL]    
-           ); // coalescing stall + bank conflict at data cache 
-   fprintf(fout, "gpgpu_stall_shd_mem[gl_mem][data_port_stall] = %d\n", 
-           gpu_stall_shd_mem_breakdown[G_MEM_LD][DATA_PORT_STALL] + 
-           gpu_stall_shd_mem_breakdown[G_MEM_ST][DATA_PORT_STALL] + 
-           gpu_stall_shd_mem_breakdown[L_MEM_LD][DATA_PORT_STALL] + 
-           gpu_stall_shd_mem_breakdown[L_MEM_ST][DATA_PORT_STALL]    
-           ); // data port stall at data cache 
-   //fprintf(fout, "gpgpu_stall_shd_mem[g_mem_ld][mshr_rc] = %d\n", gpu_stall_shd_mem_breakdown[G_MEM_LD][MSHR_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[g_mem_ld][icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[G_MEM_LD][ICNT_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[g_mem_ld][wb_icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[G_MEM_LD][WB_ICNT_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[g_mem_ld][wb_rsrv_fail] = %d\n", gpu_stall_shd_mem_breakdown[G_MEM_LD][WB_CACHE_RSRV_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[g_mem_st][mshr_rc] = %d\n", gpu_stall_shd_mem_breakdown[G_MEM_ST][MSHR_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[g_mem_st][icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[G_MEM_ST][ICNT_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[g_mem_st][wb_icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[G_MEM_ST][WB_ICNT_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[g_mem_st][wb_rsrv_fail] = %d\n", gpu_stall_shd_mem_breakdown[G_MEM_ST][WB_CACHE_RSRV_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][mshr_rc] = %d\n", gpu_stall_shd_mem_breakdown[L_MEM_LD][MSHR_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[L_MEM_LD][ICNT_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][wb_icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[L_MEM_LD][WB_ICNT_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][wb_rsrv_fail] = %d\n", gpu_stall_shd_mem_breakdown[L_MEM_LD][WB_CACHE_RSRV_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[l_mem_st][mshr_rc] = %d\n", gpu_stall_shd_mem_breakdown[L_MEM_ST][MSHR_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[l_mem_st][icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[L_MEM_ST][ICNT_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][wb_icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[L_MEM_ST][WB_ICNT_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][wb_rsrv_fail] = %d\n", gpu_stall_shd_mem_breakdown[L_MEM_ST][WB_CACHE_RSRV_FAIL]);
-
-   fprintf(fout, "gpu_reg_bank_conflict_stalls = %d\n", gpu_reg_bank_conflict_stalls);
-
-   fprintf(fout, "Warp Occupancy Distribution:\n");
-   fprintf(fout, "Stall:%d\t", shader_cycle_distro[2]);
-   fprintf(fout, "W0_Idle:%d\t", shader_cycle_distro[0]);
-   fprintf(fout, "W0_Scoreboard:%d", shader_cycle_distro[1]);
-   for (unsigned i = 3; i < m_config->warp_size + 3; i++) 
-      fprintf(fout, "\tW%d:%d", i-2, shader_cycle_distro[i]);
-   fprintf(fout, "\n");
-   fprintf(fout, "single_issue_nums: ");
-   for (unsigned i = 0; i < m_config->gpgpu_num_sched_per_core; i++)
-        fprintf(fout, "WS%d:%d\t", i, single_issue_nums[i]);
-   fprintf(fout, "\n");
-   fprintf(fout, "dual_issue_nums: ");
-   for (unsigned i = 0; i < m_config->gpgpu_num_sched_per_core; i++)
-          fprintf(fout, "WS%d:%d\t", i, dual_issue_nums[i]);
-   fprintf(fout, "\n");
-
-   m_outgoing_traffic_stats->print(fout); 
-   m_incoming_traffic_stats->print(fout); 
-}
-
-void shader_core_stats::event_warp_issued( unsigned s_id, unsigned warp_id, unsigned num_issued, unsigned dynamic_warp_id ) {
-    assert( warp_id <= m_config->max_warps_per_shader );
-    for ( unsigned i = 0; i < num_issued; ++i ) {
-        if ( m_shader_dynamic_warp_issue_distro[ s_id ].size() <= dynamic_warp_id ) {
-            m_shader_dynamic_warp_issue_distro[ s_id ].resize(dynamic_warp_id + 1);
+      if (m_gpu->resume_option == 1 && kernel_id == m_gpu->resume_kernel &&
+          ctaid >= m_gpu->resume_CTA && ctaid < m_gpu->checkpoint_CTA_t) {
+        char fname[2048];
+        snprintf(fname, 2048, "checkpoint_files/warp_%d_%d_simt.txt",
+                 i % warp_per_cta, ctaid);
+        unsigned pc, rpc;
+        m_simt_stack[i]->resume(fname);
+        m_simt_stack[i]->get_pdom_stack_top_info(&pc, &rpc);
+        for (unsigned t = 0; t < m_config->warp_size; t++) {
+          m_thread[i * m_config->warp_size + t]->set_npc(pc);
+          m_thread[i * m_config->warp_size + t]->update_pc();
         }
-        ++m_shader_dynamic_warp_issue_distro[ s_id ][ dynamic_warp_id ];
-        if ( m_shader_warp_slot_issue_distro[ s_id ].size() <= warp_id ) {
-            m_shader_warp_slot_issue_distro[ s_id ].resize(warp_id + 1);
-        }
-        ++m_shader_warp_slot_issue_distro[ s_id ][ warp_id ];
+        start_pc = pc;
+      }
+
+      m_warp[i].init(start_pc, cta_id, i, active_threads, m_dynamic_warp_id);
+      ++m_dynamic_warp_id;
+      m_not_completed += n_active;
+      ++m_active_warps;
     }
+  }
 }
 
-void shader_core_stats::visualizer_print( gzFile visualizer_file )
-{
-    // warp divergence breakdown
-    gzprintf(visualizer_file, "WarpDivergenceBreakdown:");
-    unsigned int total=0;
-    unsigned int cf = (m_config->gpgpu_warpdistro_shader==-1)?m_config->num_shader():1;
-    gzprintf(visualizer_file, " %d", (shader_cycle_distro[0] - last_shader_cycle_distro[0]) / cf );
-    gzprintf(visualizer_file, " %d", (shader_cycle_distro[1] - last_shader_cycle_distro[1]) / cf );
-    gzprintf(visualizer_file, " %d", (shader_cycle_distro[2] - last_shader_cycle_distro[2]) / cf );
-    for (unsigned i=0; i<m_config->warp_size+3; i++) {
-       if ( i>=3 ) {
-          total += (shader_cycle_distro[i] - last_shader_cycle_distro[i]);
-          if ( ((i-3) % (m_config->warp_size/8)) == ((m_config->warp_size/8)-1) ) {
-             gzprintf(visualizer_file, " %d", total / cf );
-             total=0;
-          }
-       }
-       last_shader_cycle_distro[i] = shader_cycle_distro[i];
-    }
-    gzprintf(visualizer_file,"\n");
-
-    // warp issue breakdown
-    unsigned sid = m_config->gpgpu_warp_issue_shader;
-    unsigned count = 0;
-    unsigned warp_id_issued_sum = 0;
-    gzprintf(visualizer_file, "WarpIssueSlotBreakdown:");
-    if(m_shader_warp_slot_issue_distro[sid].size() > 0){
-        for ( std::vector<unsigned>::const_iterator iter = m_shader_warp_slot_issue_distro[ sid ].begin();
-              iter != m_shader_warp_slot_issue_distro[ sid ].end(); iter++, count++ ) {
-            unsigned diff = count < m_last_shader_warp_slot_issue_distro.size() ?
-                            *iter - m_last_shader_warp_slot_issue_distro[ count ] :
-                            *iter;
-            gzprintf( visualizer_file, " %d", diff );
-            warp_id_issued_sum += diff;
-        }
-        m_last_shader_warp_slot_issue_distro = m_shader_warp_slot_issue_distro[ sid ];
-    }else{
-        gzprintf( visualizer_file, " 0");
-    }
-    gzprintf(visualizer_file,"\n");
-
-    #define DYNAMIC_WARP_PRINT_RESOLUTION 32
-    unsigned total_issued_this_resolution = 0;
-    unsigned dynamic_id_issued_sum = 0;
-    count = 0;
-    gzprintf(visualizer_file, "WarpIssueDynamicIdBreakdown:");
-    if(m_shader_dynamic_warp_issue_distro[sid].size() > 0){
-        for ( std::vector<unsigned>::const_iterator iter = m_shader_dynamic_warp_issue_distro[ sid ].begin();
-              iter != m_shader_dynamic_warp_issue_distro[ sid ].end(); iter++, count++ ) {
-            unsigned diff = count < m_last_shader_dynamic_warp_issue_distro.size() ?
-                            *iter - m_last_shader_dynamic_warp_issue_distro[ count ] :
-                            *iter;
-            total_issued_this_resolution += diff;
-            if ( ( count + 1 ) % DYNAMIC_WARP_PRINT_RESOLUTION == 0 ) {
-                gzprintf( visualizer_file, " %d", total_issued_this_resolution );
-                dynamic_id_issued_sum += total_issued_this_resolution;
-                total_issued_this_resolution = 0;
-            }
-        }
-        if ( count % DYNAMIC_WARP_PRINT_RESOLUTION != 0 ) {
-            gzprintf( visualizer_file, " %d", total_issued_this_resolution );
-            dynamic_id_issued_sum += total_issued_this_resolution;
-        }
-        m_last_shader_dynamic_warp_issue_distro = m_shader_dynamic_warp_issue_distro[ sid ];
-        assert( warp_id_issued_sum == dynamic_id_issued_sum );
-    }else{
-        gzprintf( visualizer_file, " 0");
-    }
-    gzprintf(visualizer_file,"\n");
-
-    // overall cache miss rates
-    gzprintf(visualizer_file, "gpgpu_n_cache_bkconflict: %d\n", gpgpu_n_cache_bkconflict);
-    gzprintf(visualizer_file, "gpgpu_n_shmem_bkconflict: %d\n", gpgpu_n_shmem_bkconflict);     
-
-
-   // instruction count per shader core
-   gzprintf(visualizer_file, "shaderinsncount:  ");
-   for (unsigned i=0;i<m_config->num_shader();i++) 
-      gzprintf(visualizer_file, "%u ", m_num_sim_insn[i] );
-   gzprintf(visualizer_file, "\n");
-   // warp instruction count per shader core
-   gzprintf(visualizer_file, "shaderwarpinsncount:  ");
-   for (unsigned i=0;i<m_config->num_shader();i++)
-      gzprintf(visualizer_file, "%u ", m_num_sim_winsn[i] );
-   gzprintf(visualizer_file, "\n");
-   // warp divergence per shader core
-   gzprintf(visualizer_file, "shaderwarpdiv: ");
-   for (unsigned i=0;i<m_config->num_shader();i++) 
-      gzprintf(visualizer_file, "%u ", m_n_diverge[i] );
-   gzprintf(visualizer_file, "\n");
+// return the next pc of a thread
+address_type shader_core_ctx::next_pc(int tid) const {
+  if (tid == -1) return -1;
+  ptx_thread_info *the_thread = m_thread[tid];
+  if (the_thread == NULL) return -1;
+  return the_thread->get_pc();  // PC should already be updatd to next PC at
+                                // this point (was set in shader_decode() last
+                                // time thread ran)
 }
 
-#define PROGRAM_MEM_START 0xF0000000 /* should be distinct from other memory spaces... 
-                                        check ptx_ir.h to verify this does not overlap 
-                                        other memory spaces */
-void shader_core_ctx::decode()
-{
-    if( m_inst_fetch_buffer.m_valid ) {
-        // decode 1 or 2 instructions and place them into ibuffer
-        address_type pc = m_inst_fetch_buffer.m_pc;
-        const warp_inst_t* pI1 = m_gpu->gpgpu_ctx->ptx_fetch_inst(pc);
-        m_warp[m_inst_fetch_buffer.m_warp_id].ibuffer_fill(0,pI1);
+void gpgpu_sim::get_pdom_stack_top_info(unsigned sid, unsigned tid,
+                                        unsigned *pc, unsigned *rpc) {
+  unsigned cluster_id = m_shader_config->sid_to_cluster(sid);
+  m_cluster[cluster_id]->get_pdom_stack_top_info(sid, tid, pc, rpc);
+}
+
+void shader_core_ctx::get_pdom_stack_top_info(unsigned tid, unsigned *pc,
+                                              unsigned *rpc) const {
+  unsigned warp_id = tid / m_config->warp_size;
+  m_simt_stack[warp_id]->get_pdom_stack_top_info(pc, rpc);
+}
+
+float shader_core_ctx::get_current_occupancy(unsigned long long &active,
+                                             unsigned long long &total) const {
+  // To match the achieved_occupancy in nvprof, only SMs that are active are
+  // counted toward the occupancy.
+  if (m_active_warps > 0) {
+    total += m_warp.size();
+    active += m_active_warps;
+    return float(active) / float(total);
+  } else {
+    return 0;
+  }
+}
+
+void shader_core_stats::print(FILE *fout) const {
+  unsigned long long thread_icount_uarch = 0;
+  unsigned long long warp_icount_uarch = 0;
+
+  for (unsigned i = 0; i < m_config->num_shader(); i++) {
+    thread_icount_uarch += m_num_sim_insn[i];
+    warp_icount_uarch += m_num_sim_winsn[i];
+  }
+  fprintf(fout, "gpgpu_n_tot_thrd_icount = %lld\n", thread_icount_uarch);
+  fprintf(fout, "gpgpu_n_tot_w_icount = %lld\n", warp_icount_uarch);
+
+  fprintf(fout, "gpgpu_n_stall_shd_mem = %d\n", gpgpu_n_stall_shd_mem);
+  fprintf(fout, "gpgpu_n_mem_read_local = %d\n", gpgpu_n_mem_read_local);
+  fprintf(fout, "gpgpu_n_mem_write_local = %d\n", gpgpu_n_mem_write_local);
+  fprintf(fout, "gpgpu_n_mem_read_global = %d\n", gpgpu_n_mem_read_global);
+  fprintf(fout, "gpgpu_n_mem_write_global = %d\n", gpgpu_n_mem_write_global);
+  fprintf(fout, "gpgpu_n_mem_texture = %d\n", gpgpu_n_mem_texture);
+  fprintf(fout, "gpgpu_n_mem_const = %d\n", gpgpu_n_mem_const);
+
+  fprintf(fout, "gpgpu_n_load_insn  = %d\n", gpgpu_n_load_insn);
+  fprintf(fout, "gpgpu_n_store_insn = %d\n", gpgpu_n_store_insn);
+  fprintf(fout, "gpgpu_n_shmem_insn = %d\n", gpgpu_n_shmem_insn);
+  fprintf(fout, "gpgpu_n_sstarr_insn = %d\n", gpgpu_n_sstarr_insn);
+  fprintf(fout, "gpgpu_n_tex_insn = %d\n", gpgpu_n_tex_insn);
+  fprintf(fout, "gpgpu_n_const_mem_insn = %d\n", gpgpu_n_const_insn);
+  fprintf(fout, "gpgpu_n_param_mem_insn = %d\n", gpgpu_n_param_insn);
+
+  fprintf(fout, "gpgpu_n_shmem_bkconflict = %d\n", gpgpu_n_shmem_bkconflict);
+  fprintf(fout, "gpgpu_n_cache_bkconflict = %d\n", gpgpu_n_cache_bkconflict);
+
+  fprintf(fout, "gpgpu_n_intrawarp_mshr_merge = %d\n",
+          gpgpu_n_intrawarp_mshr_merge);
+  fprintf(fout, "gpgpu_n_cmem_portconflict = %d\n", gpgpu_n_cmem_portconflict);
+
+  fprintf(fout, "gpgpu_stall_shd_mem[c_mem][resource_stall] = %d\n",
+          gpu_stall_shd_mem_breakdown[C_MEM][BK_CONF]);
+  // fprintf(fout, "gpgpu_stall_shd_mem[c_mem][mshr_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[C_MEM][MSHR_RC_FAIL]);
+  // fprintf(fout, "gpgpu_stall_shd_mem[c_mem][icnt_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[C_MEM][ICNT_RC_FAIL]);
+  // fprintf(fout, "gpgpu_stall_shd_mem[c_mem][data_port_stall] = %d\n",
+  // gpu_stall_shd_mem_breakdown[C_MEM][DATA_PORT_STALL]);
+  // fprintf(fout, "gpgpu_stall_shd_mem[t_mem][mshr_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[T_MEM][MSHR_RC_FAIL]);
+  // fprintf(fout, "gpgpu_stall_shd_mem[t_mem][icnt_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[T_MEM][ICNT_RC_FAIL]);
+  // fprintf(fout, "gpgpu_stall_shd_mem[t_mem][data_port_stall] = %d\n",
+  // gpu_stall_shd_mem_breakdown[T_MEM][DATA_PORT_STALL]);
+  fprintf(fout, "gpgpu_stall_shd_mem[s_mem][bk_conf] = %d\n",
+          gpu_stall_shd_mem_breakdown[S_MEM][BK_CONF]);
+  fprintf(fout, "gpgpu_stall_shd_mem[gl_mem][resource_stall] = %d\n",
+          gpu_stall_shd_mem_breakdown[G_MEM_LD][BK_CONF] +
+              gpu_stall_shd_mem_breakdown[G_MEM_ST][BK_CONF] +
+              gpu_stall_shd_mem_breakdown[L_MEM_LD][BK_CONF] +
+              gpu_stall_shd_mem_breakdown[L_MEM_ST][BK_CONF]);  // coalescing
+                                                                // stall at data
+                                                                // cache
+  fprintf(fout, "gpgpu_stall_shd_mem[gl_mem][coal_stall] = %d\n",
+          gpu_stall_shd_mem_breakdown[G_MEM_LD][COAL_STALL] +
+              gpu_stall_shd_mem_breakdown[G_MEM_ST][COAL_STALL] +
+              gpu_stall_shd_mem_breakdown[L_MEM_LD][COAL_STALL] +
+              gpu_stall_shd_mem_breakdown[L_MEM_ST][COAL_STALL]);  // coalescing
+                                                                   // stall +
+                                                                   // bank
+                                                                   // conflict
+                                                                   // at data
+                                                                   // cache
+  fprintf(fout, "gpgpu_stall_shd_mem[gl_mem][data_port_stall] = %d\n",
+          gpu_stall_shd_mem_breakdown[G_MEM_LD][DATA_PORT_STALL] +
+              gpu_stall_shd_mem_breakdown[G_MEM_ST][DATA_PORT_STALL] +
+              gpu_stall_shd_mem_breakdown[L_MEM_LD][DATA_PORT_STALL] +
+              gpu_stall_shd_mem_breakdown[L_MEM_ST]
+                                         [DATA_PORT_STALL]);  // data port stall
+                                                              // at data cache
+  // fprintf(fout, "gpgpu_stall_shd_mem[g_mem_ld][mshr_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[G_MEM_LD][MSHR_RC_FAIL]);
+  // fprintf(fout, "gpgpu_stall_shd_mem[g_mem_ld][icnt_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[G_MEM_LD][ICNT_RC_FAIL]);
+  // fprintf(fout, "gpgpu_stall_shd_mem[g_mem_ld][wb_icnt_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[G_MEM_LD][WB_ICNT_RC_FAIL]);
+  // fprintf(fout, "gpgpu_stall_shd_mem[g_mem_ld][wb_rsrv_fail] = %d\n",
+  // gpu_stall_shd_mem_breakdown[G_MEM_LD][WB_CACHE_RSRV_FAIL]);
+  // fprintf(fout, "gpgpu_stall_shd_mem[g_mem_st][mshr_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[G_MEM_ST][MSHR_RC_FAIL]);
+  // fprintf(fout, "gpgpu_stall_shd_mem[g_mem_st][icnt_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[G_MEM_ST][ICNT_RC_FAIL]);
+  // fprintf(fout, "gpgpu_stall_shd_mem[g_mem_st][wb_icnt_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[G_MEM_ST][WB_ICNT_RC_FAIL]);
+  // fprintf(fout, "gpgpu_stall_shd_mem[g_mem_st][wb_rsrv_fail] = %d\n",
+  // gpu_stall_shd_mem_breakdown[G_MEM_ST][WB_CACHE_RSRV_FAIL]);
+  // fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][mshr_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[L_MEM_LD][MSHR_RC_FAIL]);
+  // fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][icnt_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[L_MEM_LD][ICNT_RC_FAIL]);
+  // fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][wb_icnt_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[L_MEM_LD][WB_ICNT_RC_FAIL]);
+  // fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][wb_rsrv_fail] = %d\n",
+  // gpu_stall_shd_mem_breakdown[L_MEM_LD][WB_CACHE_RSRV_FAIL]);
+  // fprintf(fout, "gpgpu_stall_shd_mem[l_mem_st][mshr_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[L_MEM_ST][MSHR_RC_FAIL]);
+  // fprintf(fout, "gpgpu_stall_shd_mem[l_mem_st][icnt_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[L_MEM_ST][ICNT_RC_FAIL]);
+  // fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][wb_icnt_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[L_MEM_ST][WB_ICNT_RC_FAIL]);
+  // fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][wb_rsrv_fail] = %d\n",
+  // gpu_stall_shd_mem_breakdown[L_MEM_ST][WB_CACHE_RSRV_FAIL]);
+
+  fprintf(fout, "gpu_reg_bank_conflict_stalls = %d\n",
+          gpu_reg_bank_conflict_stalls);
+
+  fprintf(fout, "Warp Occupancy Distribution:\n");
+  fprintf(fout, "Stall:%d\t", shader_cycle_distro[2]);
+  fprintf(fout, "W0_Idle:%d\t", shader_cycle_distro[0]);
+  fprintf(fout, "W0_Scoreboard:%d", shader_cycle_distro[1]);
+  for (unsigned i = 3; i < m_config->warp_size + 3; i++)
+    fprintf(fout, "\tW%d:%d", i - 2, shader_cycle_distro[i]);
+  fprintf(fout, "\n");
+  fprintf(fout, "single_issue_nums: ");
+  for (unsigned i = 0; i < m_config->gpgpu_num_sched_per_core; i++)
+    fprintf(fout, "WS%d:%d\t", i, single_issue_nums[i]);
+  fprintf(fout, "\n");
+  fprintf(fout, "dual_issue_nums: ");
+  for (unsigned i = 0; i < m_config->gpgpu_num_sched_per_core; i++)
+    fprintf(fout, "WS%d:%d\t", i, dual_issue_nums[i]);
+  fprintf(fout, "\n");
+
+  m_outgoing_traffic_stats->print(fout);
+  m_incoming_traffic_stats->print(fout);
+}
+
+void shader_core_stats::event_warp_issued(unsigned s_id, unsigned warp_id,
+                                          unsigned num_issued,
+                                          unsigned dynamic_warp_id) {
+  assert(warp_id <= m_config->max_warps_per_shader);
+  for (unsigned i = 0; i < num_issued; ++i) {
+    if (m_shader_dynamic_warp_issue_distro[s_id].size() <= dynamic_warp_id) {
+      m_shader_dynamic_warp_issue_distro[s_id].resize(dynamic_warp_id + 1);
+    }
+    ++m_shader_dynamic_warp_issue_distro[s_id][dynamic_warp_id];
+    if (m_shader_warp_slot_issue_distro[s_id].size() <= warp_id) {
+      m_shader_warp_slot_issue_distro[s_id].resize(warp_id + 1);
+    }
+    ++m_shader_warp_slot_issue_distro[s_id][warp_id];
+  }
+}
+
+void shader_core_stats::visualizer_print(gzFile visualizer_file) {
+  // warp divergence breakdown
+  gzprintf(visualizer_file, "WarpDivergenceBreakdown:");
+  unsigned int total = 0;
+  unsigned int cf =
+      (m_config->gpgpu_warpdistro_shader == -1) ? m_config->num_shader() : 1;
+  gzprintf(visualizer_file, " %d",
+           (shader_cycle_distro[0] - last_shader_cycle_distro[0]) / cf);
+  gzprintf(visualizer_file, " %d",
+           (shader_cycle_distro[1] - last_shader_cycle_distro[1]) / cf);
+  gzprintf(visualizer_file, " %d",
+           (shader_cycle_distro[2] - last_shader_cycle_distro[2]) / cf);
+  for (unsigned i = 0; i < m_config->warp_size + 3; i++) {
+    if (i >= 3) {
+      total += (shader_cycle_distro[i] - last_shader_cycle_distro[i]);
+      if (((i - 3) % (m_config->warp_size / 8)) ==
+          ((m_config->warp_size / 8) - 1)) {
+        gzprintf(visualizer_file, " %d", total / cf);
+        total = 0;
+      }
+    }
+    last_shader_cycle_distro[i] = shader_cycle_distro[i];
+  }
+  gzprintf(visualizer_file, "\n");
+
+  // warp issue breakdown
+  unsigned sid = m_config->gpgpu_warp_issue_shader;
+  unsigned count = 0;
+  unsigned warp_id_issued_sum = 0;
+  gzprintf(visualizer_file, "WarpIssueSlotBreakdown:");
+  if (m_shader_warp_slot_issue_distro[sid].size() > 0) {
+    for (std::vector<unsigned>::const_iterator
+             iter = m_shader_warp_slot_issue_distro[sid].begin();
+         iter != m_shader_warp_slot_issue_distro[sid].end(); iter++, count++) {
+      unsigned diff = count < m_last_shader_warp_slot_issue_distro.size()
+                          ? *iter - m_last_shader_warp_slot_issue_distro[count]
+                          : *iter;
+      gzprintf(visualizer_file, " %d", diff);
+      warp_id_issued_sum += diff;
+    }
+    m_last_shader_warp_slot_issue_distro = m_shader_warp_slot_issue_distro[sid];
+  } else {
+    gzprintf(visualizer_file, " 0");
+  }
+  gzprintf(visualizer_file, "\n");
+
+#define DYNAMIC_WARP_PRINT_RESOLUTION 32
+  unsigned total_issued_this_resolution = 0;
+  unsigned dynamic_id_issued_sum = 0;
+  count = 0;
+  gzprintf(visualizer_file, "WarpIssueDynamicIdBreakdown:");
+  if (m_shader_dynamic_warp_issue_distro[sid].size() > 0) {
+    for (std::vector<unsigned>::const_iterator
+             iter = m_shader_dynamic_warp_issue_distro[sid].begin();
+         iter != m_shader_dynamic_warp_issue_distro[sid].end();
+         iter++, count++) {
+      unsigned diff =
+          count < m_last_shader_dynamic_warp_issue_distro.size()
+              ? *iter - m_last_shader_dynamic_warp_issue_distro[count]
+              : *iter;
+      total_issued_this_resolution += diff;
+      if ((count + 1) % DYNAMIC_WARP_PRINT_RESOLUTION == 0) {
+        gzprintf(visualizer_file, " %d", total_issued_this_resolution);
+        dynamic_id_issued_sum += total_issued_this_resolution;
+        total_issued_this_resolution = 0;
+      }
+    }
+    if (count % DYNAMIC_WARP_PRINT_RESOLUTION != 0) {
+      gzprintf(visualizer_file, " %d", total_issued_this_resolution);
+      dynamic_id_issued_sum += total_issued_this_resolution;
+    }
+    m_last_shader_dynamic_warp_issue_distro =
+        m_shader_dynamic_warp_issue_distro[sid];
+    assert(warp_id_issued_sum == dynamic_id_issued_sum);
+  } else {
+    gzprintf(visualizer_file, " 0");
+  }
+  gzprintf(visualizer_file, "\n");
+
+  // overall cache miss rates
+  gzprintf(visualizer_file, "gpgpu_n_cache_bkconflict: %d\n",
+           gpgpu_n_cache_bkconflict);
+  gzprintf(visualizer_file, "gpgpu_n_shmem_bkconflict: %d\n",
+           gpgpu_n_shmem_bkconflict);
+
+  // instruction count per shader core
+  gzprintf(visualizer_file, "shaderinsncount:  ");
+  for (unsigned i = 0; i < m_config->num_shader(); i++)
+    gzprintf(visualizer_file, "%u ", m_num_sim_insn[i]);
+  gzprintf(visualizer_file, "\n");
+  // warp instruction count per shader core
+  gzprintf(visualizer_file, "shaderwarpinsncount:  ");
+  for (unsigned i = 0; i < m_config->num_shader(); i++)
+    gzprintf(visualizer_file, "%u ", m_num_sim_winsn[i]);
+  gzprintf(visualizer_file, "\n");
+  // warp divergence per shader core
+  gzprintf(visualizer_file, "shaderwarpdiv: ");
+  for (unsigned i = 0; i < m_config->num_shader(); i++)
+    gzprintf(visualizer_file, "%u ", m_n_diverge[i]);
+  gzprintf(visualizer_file, "\n");
+}
+
+#define PROGRAM_MEM_START                                      \
+  0xF0000000 /* should be distinct from other memory spaces... \
+                check ptx_ir.h to verify this does not overlap \
+                other memory spaces */
+void shader_core_ctx::decode() {
+  if (m_inst_fetch_buffer.m_valid) {
+    // decode 1 or 2 instructions and place them into ibuffer
+    address_type pc = m_inst_fetch_buffer.m_pc;
+    const warp_inst_t *pI1 = m_gpu->gpgpu_ctx->ptx_fetch_inst(pc);
+    m_warp[m_inst_fetch_buffer.m_warp_id].ibuffer_fill(0, pI1);
+    m_warp[m_inst_fetch_buffer.m_warp_id].inc_inst_in_pipeline();
+    if (pI1) {
+      m_stats->m_num_decoded_insn[m_sid]++;
+      if (pI1->oprnd_type == INT_OP) {
+        m_stats->m_num_INTdecoded_insn[m_sid]++;
+      } else if (pI1->oprnd_type == FP_OP) {
+        m_stats->m_num_FPdecoded_insn[m_sid]++;
+      }
+      const warp_inst_t *pI2 =
+          m_gpu->gpgpu_ctx->ptx_fetch_inst(pc + pI1->isize);
+      if (pI2) {
+        m_warp[m_inst_fetch_buffer.m_warp_id].ibuffer_fill(1, pI2);
         m_warp[m_inst_fetch_buffer.m_warp_id].inc_inst_in_pipeline();
-        if( pI1 ) {
-            m_stats->m_num_decoded_insn[m_sid]++;
-            if(pI1->oprnd_type==INT_OP){
-                m_stats->m_num_INTdecoded_insn[m_sid]++;
-            }else if(pI1->oprnd_type==FP_OP) {
-            	m_stats->m_num_FPdecoded_insn[m_sid]++;
-            }
-           const warp_inst_t* pI2 = m_gpu->gpgpu_ctx->ptx_fetch_inst(pc+pI1->isize);
-           if( pI2 ) {
-               m_warp[m_inst_fetch_buffer.m_warp_id].ibuffer_fill(1,pI2);
-               m_warp[m_inst_fetch_buffer.m_warp_id].inc_inst_in_pipeline();
-               m_stats->m_num_decoded_insn[m_sid]++;
-               if(pI2->oprnd_type==INT_OP){
-                   m_stats->m_num_INTdecoded_insn[m_sid]++;
-               }else if(pI2->oprnd_type==FP_OP) {
-            	   m_stats->m_num_FPdecoded_insn[m_sid]++;
-               }
-           }
+        m_stats->m_num_decoded_insn[m_sid]++;
+        if (pI2->oprnd_type == INT_OP) {
+          m_stats->m_num_INTdecoded_insn[m_sid]++;
+        } else if (pI2->oprnd_type == FP_OP) {
+          m_stats->m_num_FPdecoded_insn[m_sid]++;
         }
-        m_inst_fetch_buffer.m_valid = false;
+      }
     }
+    m_inst_fetch_buffer.m_valid = false;
+  }
 }
 
-void shader_core_ctx::fetch()
-{
+void shader_core_ctx::fetch() {
+  if (!m_inst_fetch_buffer.m_valid) {
+    if (m_L1I->access_ready()) {
+      mem_fetch *mf = m_L1I->next_access();
+      m_warp[mf->get_wid()].clear_imiss_pending();
+      m_inst_fetch_buffer = ifetch_buffer_t(
+          m_warp[mf->get_wid()].get_pc(), mf->get_access_size(), mf->get_wid());
+      assert(m_warp[mf->get_wid()].get_pc() ==
+             (mf->get_addr() - PROGRAM_MEM_START));  // Verify that we got the
+                                                     // instruction we were
+                                                     // expecting.
+      m_inst_fetch_buffer.m_valid = true;
+      m_warp[mf->get_wid()].set_last_fetch(m_gpu->gpu_sim_cycle);
+      delete mf;
+    } else {
+      // find an active warp with space in instruction buffer that is not
+      // already waiting on a cache miss
+      // and get next 1-2 instructions from i-cache...
+      for (unsigned i = 0; i < m_config->max_warps_per_shader; i++) {
+        unsigned warp_id =
+            (m_last_warp_fetched + 1 + i) % m_config->max_warps_per_shader;
 
-    if( !m_inst_fetch_buffer.m_valid ) {
-        if( m_L1I->access_ready() ) {
-            mem_fetch *mf = m_L1I->next_access();
-            m_warp[mf->get_wid()].clear_imiss_pending();
-            m_inst_fetch_buffer = ifetch_buffer_t(m_warp[mf->get_wid()].get_pc(), mf->get_access_size(), mf->get_wid());
-            assert( m_warp[mf->get_wid()].get_pc() == (mf->get_addr()-PROGRAM_MEM_START)); // Verify that we got the instruction we were expecting.
-            m_inst_fetch_buffer.m_valid = true;
-            m_warp[mf->get_wid()].set_last_fetch(m_gpu->gpu_sim_cycle);
+        // this code checks if this warp has finished executing and can be
+        // reclaimed
+        if (m_warp[warp_id].hardware_done() &&
+            !m_scoreboard->pendingWrites(warp_id) &&
+            !m_warp[warp_id].done_exit()) {
+          bool did_exit = false;
+          for (unsigned t = 0; t < m_config->warp_size; t++) {
+            unsigned tid = warp_id * m_config->warp_size + t;
+            if (m_threadState[tid].m_active == true) {
+              m_threadState[tid].m_active = false;
+              unsigned cta_id = m_warp[warp_id].get_cta_id();
+              register_cta_thread_exit(cta_id, &(m_thread[tid]->get_kernel()));
+              m_not_completed -= 1;
+              m_active_threads.reset(tid);
+              assert(m_thread[tid] != NULL);
+              did_exit = true;
+            }
+          }
+          if (did_exit) m_warp[warp_id].set_done_exit();
+          --m_active_warps;
+          assert(m_active_warps >= 0);
+        }
+
+        // this code fetches instructions from the i-cache or generates memory
+        // requests
+        if (!m_warp[warp_id].functional_done() &&
+            !m_warp[warp_id].imiss_pending() &&
+            m_warp[warp_id].ibuffer_empty()) {
+          address_type pc = m_warp[warp_id].get_pc();
+          address_type ppc = pc + PROGRAM_MEM_START;
+          unsigned nbytes = 16;
+          unsigned offset_in_block =
+              pc & (m_config->m_L1I_config.get_line_sz() - 1);
+          if ((offset_in_block + nbytes) > m_config->m_L1I_config.get_line_sz())
+            nbytes = (m_config->m_L1I_config.get_line_sz() - offset_in_block);
+
+          // TODO: replace with use of allocator
+          // mem_fetch *mf = m_mem_fetch_allocator->alloc()
+          mem_access_t acc(INST_ACC_R, ppc, nbytes, false, m_gpu->gpgpu_ctx);
+          mem_fetch *mf = new mem_fetch(
+              acc, NULL /*we don't have an instruction yet*/, READ_PACKET_SIZE,
+              warp_id, m_sid, m_tpc, m_memory_config,
+              m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle);
+          std::list<cache_event> events;
+          enum cache_request_status status = m_L1I->access(
+              (new_addr_type)ppc, mf,
+              m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle, events);
+          if (status == MISS) {
+            m_last_warp_fetched = warp_id;
+            m_warp[warp_id].set_imiss_pending();
+            m_warp[warp_id].set_last_fetch(m_gpu->gpu_sim_cycle);
+          } else if (status == HIT) {
+            m_last_warp_fetched = warp_id;
+            m_inst_fetch_buffer = ifetch_buffer_t(pc, nbytes, warp_id);
+            m_warp[warp_id].set_last_fetch(m_gpu->gpu_sim_cycle);
             delete mf;
+          } else {
+            m_last_warp_fetched = warp_id;
+            assert(status == RESERVATION_FAIL);
+            delete mf;
+          }
+          break;
         }
-        else {
-            // find an active warp with space in instruction buffer that is not already waiting on a cache miss
-            // and get next 1-2 instructions from i-cache...
-            for( unsigned i=0; i < m_config->max_warps_per_shader; i++ ) {
-                unsigned warp_id = (m_last_warp_fetched+1+i) % m_config->max_warps_per_shader;
-
-                // this code checks if this warp has finished executing and can be reclaimed
-                if( m_warp[warp_id].hardware_done() && !m_scoreboard->pendingWrites(warp_id) && !m_warp[warp_id].done_exit() ) {
-                    bool did_exit=false;
-                    for( unsigned t=0; t<m_config->warp_size;t++) {
-                        unsigned tid=warp_id*m_config->warp_size+t;
-                        if( m_threadState[tid].m_active == true ) {
-                            m_threadState[tid].m_active = false; 
-                            unsigned cta_id = m_warp[warp_id].get_cta_id();
-                            register_cta_thread_exit(cta_id, &(m_thread[tid]->get_kernel()));
-                            m_not_completed -= 1;
-                            m_active_threads.reset(tid);
-                            assert( m_thread[tid]!= NULL );
-                            did_exit=true;
-                        }
-                    }
-                    if( did_exit ) 
-                        m_warp[warp_id].set_done_exit();
-                        --m_active_warps;
-                        assert(m_active_warps >= 0);
-                }
-
-                // this code fetches instructions from the i-cache or generates memory requests
-                if( !m_warp[warp_id].functional_done() && !m_warp[warp_id].imiss_pending() && m_warp[warp_id].ibuffer_empty() ) {
-                    address_type pc  = m_warp[warp_id].get_pc();
-                    address_type ppc = pc + PROGRAM_MEM_START;
-                    unsigned nbytes=16;
-                    unsigned offset_in_block = pc & (m_config->m_L1I_config.get_line_sz()-1);
-                    if( (offset_in_block+nbytes) > m_config->m_L1I_config.get_line_sz() )
-                        nbytes = (m_config->m_L1I_config.get_line_sz()-offset_in_block);
-
-                    // TODO: replace with use of allocator
-                    // mem_fetch *mf = m_mem_fetch_allocator->alloc()
-                    mem_access_t acc(INST_ACC_R,ppc,nbytes,false, m_gpu->gpgpu_ctx);
-                    mem_fetch *mf = new mem_fetch(acc,
-                            NULL/*we don't have an instruction yet*/,
-                            READ_PACKET_SIZE,
-                            warp_id,
-                            m_sid,
-                            m_tpc,
-                            m_memory_config,
-							m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle
-							);
-                    std::list<cache_event> events;
-                    enum cache_request_status status = m_L1I->access( (new_addr_type)ppc, mf, m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle,events);
-                    if( status == MISS ) {
-                        m_last_warp_fetched=warp_id;
-                        m_warp[warp_id].set_imiss_pending();
-                        m_warp[warp_id].set_last_fetch(m_gpu->gpu_sim_cycle);
-                    } else if( status == HIT ) {
-                        m_last_warp_fetched=warp_id;
-                        m_inst_fetch_buffer = ifetch_buffer_t(pc,nbytes,warp_id);
-                        m_warp[warp_id].set_last_fetch(m_gpu->gpu_sim_cycle);
-                        delete mf;
-                    } else {
-                        m_last_warp_fetched=warp_id;
-                        assert( status == RESERVATION_FAIL );
-                        delete mf;
-                    }
-                    break;
-                }
-            }
-        }
+      }
     }
+  }
 
-    m_L1I->cycle();
+  m_L1I->cycle();
 }
 
-void shader_core_ctx::func_exec_inst( warp_inst_t &inst )
-{
-    execute_warp_inst_t(inst);
-    if( inst.is_load() || inst.is_store() )
-    {
-	inst.generate_mem_accesses();
-        //inst.print_m_accessq();	
-    }	
+void shader_core_ctx::func_exec_inst(warp_inst_t &inst) {
+  execute_warp_inst_t(inst);
+  if (inst.is_load() || inst.is_store()) {
+    inst.generate_mem_accesses();
+    // inst.print_m_accessq();
+  }
 }
 
-void shader_core_ctx::issue_warp( register_set& pipe_reg_set, const warp_inst_t* next_inst, const active_mask_t &active_mask, unsigned warp_id, unsigned sch_id )
-{
-	warp_inst_t** pipe_reg = pipe_reg_set.get_free(m_config->sub_core_model, sch_id);
-    assert(pipe_reg);
+void shader_core_ctx::issue_warp(register_set &pipe_reg_set,
+                                 const warp_inst_t *next_inst,
+                                 const active_mask_t &active_mask,
+                                 unsigned warp_id, unsigned sch_id) {
+  warp_inst_t **pipe_reg =
+      pipe_reg_set.get_free(m_config->sub_core_model, sch_id);
+  assert(pipe_reg);
 
-    m_warp[warp_id].ibuffer_free();
-    assert(next_inst->valid());
-    **pipe_reg = *next_inst; // static instruction information
-    (*pipe_reg)->issue( active_mask, warp_id, m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle, m_warp[warp_id].get_dynamic_warp_id(), sch_id ); // dynamic instruction information
-    m_stats->shader_cycle_distro[2+(*pipe_reg)->active_count()]++;
-    func_exec_inst( **pipe_reg );
-    if( next_inst->op == BARRIER_OP ){
-        m_warp[warp_id].store_info_of_last_inst_at_barrier(*pipe_reg);
-        m_barriers.warp_reaches_barrier(m_warp[warp_id].get_cta_id(),warp_id,const_cast<warp_inst_t*> (next_inst));
+  m_warp[warp_id].ibuffer_free();
+  assert(next_inst->valid());
+  **pipe_reg = *next_inst;  // static instruction information
+  (*pipe_reg)->issue(active_mask, warp_id,
+                     m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle,
+                     m_warp[warp_id].get_dynamic_warp_id(),
+                     sch_id);  // dynamic instruction information
+  m_stats->shader_cycle_distro[2 + (*pipe_reg)->active_count()]++;
+  func_exec_inst(**pipe_reg);
+  if (next_inst->op == BARRIER_OP) {
+    m_warp[warp_id].store_info_of_last_inst_at_barrier(*pipe_reg);
+    m_barriers.warp_reaches_barrier(m_warp[warp_id].get_cta_id(), warp_id,
+                                    const_cast<warp_inst_t *>(next_inst));
 
-    }else if( next_inst->op == MEMORY_BARRIER_OP ){
-        m_warp[warp_id].set_membar();
-    }
+  } else if (next_inst->op == MEMORY_BARRIER_OP) {
+    m_warp[warp_id].set_membar();
+  }
 
-    updateSIMTStack(warp_id,*pipe_reg);
-    m_scoreboard->reserveRegisters(*pipe_reg);
-    m_warp[warp_id].set_next_pc(next_inst->pc + next_inst->isize);
+  updateSIMTStack(warp_id, *pipe_reg);
+  m_scoreboard->reserveRegisters(*pipe_reg);
+  m_warp[warp_id].set_next_pc(next_inst->pc + next_inst->isize);
 }
 
-void shader_core_ctx::issue(){
+void shader_core_ctx::issue() {
+  // Ensure fair round robin issu between schedulers
+  unsigned j;
+  for (unsigned i = 0; i < schedulers.size(); i++) {
+    j = (Issue_Prio + i) % schedulers.size();
+    schedulers[j]->cycle();
+  }
+  Issue_Prio = (Issue_Prio + 1) % schedulers.size();
 
-     //Ensure fair round robin issu between schedulers 
-     unsigned j;
-     for (unsigned i = 0; i < schedulers.size(); i++) {
-	j = (Issue_Prio + i) % schedulers.size();
-	  schedulers[j]->cycle();
-     }
-     Issue_Prio = (Issue_Prio+1)% schedulers.size();
-
-    //really is issue;
-    //for (unsigned i = 0; i < schedulers.size(); i++) {
-    //    schedulers[i]->cycle();
-    //}
+  // really is issue;
+  // for (unsigned i = 0; i < schedulers.size(); i++) {
+  //    schedulers[i]->cycle();
+  //}
 }
 
-shd_warp_t& scheduler_unit::warp(int i){
-    return (*m_warp)[i];
-}
-
+shd_warp_t &scheduler_unit::warp(int i) { return (*m_warp)[i]; }
 
 /**
- * A general function to order things in a Loose Round Robin way. The simplist use of this
- * function would be to implement a loose RR scheduler between all the warps assigned to this core.
- * A more sophisticated usage would be to order a set of "fetch groups" in a RR fashion.
- * In the first case, the templated class variable would be a simple unsigned int representing the
- * warp_id.  In the 2lvl case, T could be a struct or a list representing a set of warp_ids.
- * @param result_list: The resultant list the caller wants returned.  This list is cleared and then populated
+ * A general function to order things in a Loose Round Robin way. The simplist
+ * use of this
+ * function would be to implement a loose RR scheduler between all the warps
+ * assigned to this core.
+ * A more sophisticated usage would be to order a set of "fetch groups" in a RR
+ * fashion.
+ * In the first case, the templated class variable would be a simple unsigned
+ * int representing the
+ * warp_id.  In the 2lvl case, T could be a struct or a list representing a set
+ * of warp_ids.
+ * @param result_list: The resultant list the caller wants returned.  This list
+ * is cleared and then populated
  *                     in a loose round robin way
- * @param input_list: The list of things that should be put into the result_list. For a simple scheduler
+ * @param input_list: The list of things that should be put into the
+ * result_list. For a simple scheduler
  *                    this can simply be the m_supervised_warps list.
- * @param last_issued_from_input:  An iterator pointing the last member in the input_list that issued.
- *                                 Since this function orders in a RR fashion, the object pointed
- *                                 to by this iterator will be last in the prioritization list
- * @param num_warps_to_add: The number of warps you want the scheudler to pick between this cycle.
- *                          Normally, this will be all the warps availible on the core, i.e.
- *                          m_supervised_warps.size(). However, a more sophisticated scheduler may wish to
- *                          limit this number. If the number if < m_supervised_warps.size(), then only
- *                          the warps with highest RR priority will be placed in the result_list.
+ * @param last_issued_from_input:  An iterator pointing the last member in the
+ * input_list that issued.
+ *                                 Since this function orders in a RR fashion,
+ * the object pointed
+ *                                 to by this iterator will be last in the
+ * prioritization list
+ * @param num_warps_to_add: The number of warps you want the scheudler to pick
+ * between this cycle.
+ *                          Normally, this will be all the warps availible on
+ * the core, i.e.
+ *                          m_supervised_warps.size(). However, a more
+ * sophisticated scheduler may wish to
+ *                          limit this number. If the number if <
+ * m_supervised_warps.size(), then only
+ *                          the warps with highest RR priority will be placed in
+ * the result_list.
  */
-    template < class T >
-void scheduler_unit::order_lrr( std::vector< T >& result_list,
-        const typename std::vector< T >& input_list,
-        const typename std::vector< T >::const_iterator& last_issued_from_input,
-        unsigned num_warps_to_add )
-{
-    assert( num_warps_to_add <= input_list.size() );
-    result_list.clear();
-    typename std::vector< T >::const_iterator iter
-        = ( last_issued_from_input ==  input_list.end() ) ? input_list.begin()
-        : last_issued_from_input + 1;
+template <class T>
+void scheduler_unit::order_lrr(
+    std::vector<T> &result_list, const typename std::vector<T> &input_list,
+    const typename std::vector<T>::const_iterator &last_issued_from_input,
+    unsigned num_warps_to_add) {
+  assert(num_warps_to_add <= input_list.size());
+  result_list.clear();
+  typename std::vector<T>::const_iterator iter =
+      (last_issued_from_input == input_list.end()) ? input_list.begin()
+                                                   : last_issued_from_input + 1;
 
-    for ( unsigned count = 0;
-            count < num_warps_to_add;
-            ++iter, ++count) {
-        if ( iter ==  input_list.end() ) {
-            iter = input_list.begin();
-        }
-        result_list.push_back( *iter );
+  for (unsigned count = 0; count < num_warps_to_add; ++iter, ++count) {
+    if (iter == input_list.end()) {
+      iter = input_list.begin();
     }
+    result_list.push_back(*iter);
+  }
 }
 
 /**
  * A general function to order things in an priority-based way.
  * The core usage of the function is similar to order_lrr.
- * The explanation of the additional parameters (beyond order_lrr) explains the further extensions.
- * @param ordering: An enum that determines how the age function will be treated in prioritization
+ * The explanation of the additional parameters (beyond order_lrr) explains the
+ * further extensions.
+ * @param ordering: An enum that determines how the age function will be treated
+ * in prioritization
  *                  see the definition of OrderingType.
- * @param priority_function: This function is used to sort the input_list.  It is passed to stl::sort as
- *                           the sorting fucntion. So, if you wanted to sort a list of integer warp_ids
- *                           with the oldest warps having the most priority, then the priority_function
+ * @param priority_function: This function is used to sort the input_list.  It
+ * is passed to stl::sort as
+ *                           the sorting fucntion. So, if you wanted to sort a
+ * list of integer warp_ids
+ *                           with the oldest warps having the most priority,
+ * then the priority_function
  *                           would compare the age of the two warps.
  */
-    template < class T >
-void scheduler_unit::order_by_priority( std::vector< T >& result_list,
-        const typename std::vector< T >& input_list,
-        const typename std::vector< T >::const_iterator& last_issued_from_input,
-        unsigned num_warps_to_add,
-        OrderingType ordering,
-        bool (*priority_func)(T lhs, T rhs) )
-{
-    assert( num_warps_to_add <= input_list.size() );
-    result_list.clear();
-    typename std::vector< T > temp = input_list;
+template <class T>
+void scheduler_unit::order_by_priority(
+    std::vector<T> &result_list, const typename std::vector<T> &input_list,
+    const typename std::vector<T>::const_iterator &last_issued_from_input,
+    unsigned num_warps_to_add, OrderingType ordering,
+    bool (*priority_func)(T lhs, T rhs)) {
+  assert(num_warps_to_add <= input_list.size());
+  result_list.clear();
+  typename std::vector<T> temp = input_list;
 
-    if ( ORDERING_GREEDY_THEN_PRIORITY_FUNC == ordering ) {
-        T greedy_value = *last_issued_from_input;
-        result_list.push_back( greedy_value );
+  if (ORDERING_GREEDY_THEN_PRIORITY_FUNC == ordering) {
+    T greedy_value = *last_issued_from_input;
+    result_list.push_back(greedy_value);
 
-        std::sort( temp.begin(), temp.end(), priority_func );
-        typename std::vector< T >::iterator iter = temp.begin();
-        for ( unsigned count = 0; count < num_warps_to_add; ++count, ++iter ) {
-            if ( *iter != greedy_value ) {
-                result_list.push_back( *iter );
-            }
-        }
-    } else if ( ORDERED_PRIORITY_FUNC_ONLY == ordering ) {
-        std::sort( temp.begin(), temp.end(), priority_func );
-        typename std::vector< T >::iterator iter = temp.begin();
-        for ( unsigned count = 0; count < num_warps_to_add; ++count, ++iter ) {
-            result_list.push_back( *iter );
-        }
-    } else {
-        fprintf( stderr, "Unknown ordering - %d\n", ordering );
-        abort();
-    }
-}
-
-void scheduler_unit::cycle()
-{
-    SCHED_DPRINTF( "scheduler_unit::cycle()\n" );
-    bool valid_inst = false;  // there was one warp with a valid instruction to issue (didn't require flush due to control hazard)
-    bool ready_inst = false;  // of the valid instructions, there was one not waiting for pending register writes
-    bool issued_inst = false; // of these we issued one
-
-    order_warps();
-    for ( std::vector< shd_warp_t* >::const_iterator iter = m_next_cycle_prioritized_warps.begin();
-          iter != m_next_cycle_prioritized_warps.end();
-          iter++ ) {
-        // Don't consider warps that are not yet valid
-        if ( (*iter) == NULL || (*iter)->done_exit() ) {
-            continue;
-        }
-        SCHED_DPRINTF( "Testing (warp_id %u, dynamic_warp_id %u)\n",
-                       (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id() );
-        unsigned warp_id = (*iter)->get_warp_id();
-        unsigned checked=0;
-        unsigned issued=0;
-        exec_unit_type_t previous_issued_inst_exec_type = exec_unit_type_t::NONE;
-        unsigned max_issue = m_shader->m_config->gpgpu_max_insn_issue_per_warp;
-        bool diff_exec_units = m_shader->m_config->gpgpu_dual_issue_diff_exec_units;  //In tis mode, we only allow dual issue to diff execution units (as in Maxwell and Pascal)
-
-        while( !warp(warp_id).waiting() && !warp(warp_id).ibuffer_empty() && (checked < max_issue) && (checked <= issued) && (issued < max_issue) ) {
-            const warp_inst_t *pI = warp(warp_id).ibuffer_next_inst();
-            //Jin: handle cdp latency;
-            if(pI && pI->m_is_cdp && warp(warp_id).m_cdp_latency > 0) {
-                assert(warp(warp_id).m_cdp_dummy);
-                warp(warp_id).m_cdp_latency--;
-                break;
-            }
-
-            bool valid = warp(warp_id).ibuffer_next_valid();
-            bool warp_inst_issued = false;
-            unsigned pc,rpc;
-            m_simt_stack[warp_id]->get_pdom_stack_top_info(&pc,&rpc);
-            SCHED_DPRINTF( "Warp (warp_id %u, dynamic_warp_id %u) has valid instruction (%s)\n",
-                           (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id(),
-                           m_shader->m_config->gpgpu_ctx->func_sim->ptx_get_insn_str( pc).c_str() );
-            if( pI ) {
-                assert(valid);
-                if( pc != pI->pc ) {
-                    SCHED_DPRINTF( "Warp (warp_id %u, dynamic_warp_id %u) control hazard instruction flush\n",
-                                   (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id() );
-                    // control hazard
-                    warp(warp_id).set_next_pc(pc);
-                    warp(warp_id).ibuffer_flush();
-                } else {
-                    valid_inst = true;
-                    if ( !m_scoreboard->checkCollision(warp_id, pI) ) {
-                        SCHED_DPRINTF( "Warp (warp_id %u, dynamic_warp_id %u) passes scoreboard\n",
-                                       (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id() );
-                        ready_inst = true;
-                        const active_mask_t &active_mask = m_simt_stack[warp_id]->get_active_mask();
-                        assert( warp(warp_id).inst_in_pipeline() );
-
-                        if ( (pI->op == LOAD_OP) || (pI->op == STORE_OP) || (pI->op == MEMORY_BARRIER_OP)||(pI->op==TENSOR_CORE_LOAD_OP)||(pI->op==TENSOR_CORE_STORE_OP) ) {
-                        	if( m_mem_out->has_free(m_shader->m_config->sub_core_model, m_id) && (!diff_exec_units || previous_issued_inst_exec_type != exec_unit_type_t::MEM)) {
-                                m_shader->issue_warp(*m_mem_out,pI,active_mask,warp_id,m_id);
-                                issued++;
-                                issued_inst=true;
-                                warp_inst_issued = true;
-                                previous_issued_inst_exec_type = exec_unit_type_t::MEM;
-                            }
-                        } else {
-
-                            bool sp_pipe_avail = m_sp_out->has_free(m_shader->m_config->sub_core_model, m_id);
-                            bool sfu_pipe_avail = m_sfu_out->has_free(m_shader->m_config->sub_core_model, m_id);
-                            bool tensor_core_pipe_avail = m_tensor_core_out->has_free(m_shader->m_config->sub_core_model, m_id);
-                            bool dp_pipe_avail = m_dp_out->has_free(m_shader->m_config->sub_core_model, m_id);
-                            bool int_pipe_avail = m_int_out->has_free(m_shader->m_config->sub_core_model, m_id);
-
-                            //This code need to be refactored
-                            if(pI->op != TENSOR_CORE_OP && pI->op != SFU_OP && pI->op != DP_OP) {
-                                
-									bool execute_on_SP = false;
-									bool execute_on_INT = false;
-
-									//if INT unit pipline exist, then execute ALU and INT operations on INT unit and SP-FPU on SP unit (like in Volta)
-									//if INT unit pipline does not exist, then execute all ALU, INT and SP operations on SP unit (as in Fermi, Pascal GPUs)
-									if(m_shader->m_config->gpgpu_num_int_units > 0 &&
-											int_pipe_avail &&
-											pI->op != SP_OP &&
-											!(diff_exec_units && previous_issued_inst_exec_type == exec_unit_type_t::INT))
-										execute_on_INT = true;
-									else if (sp_pipe_avail &&
-											(m_shader->m_config->gpgpu_num_int_units == 0 ||
-											(m_shader->m_config->gpgpu_num_int_units > 0 && pI->op == SP_OP)) &&
-											!(diff_exec_units && previous_issued_inst_exec_type == exec_unit_type_t::SP) )
-										execute_on_SP = true;
-
-
-									if(execute_on_INT || execute_on_SP) {
-										//Jin: special for CDP api
-										if(pI->m_is_cdp && !warp(warp_id).m_cdp_dummy) {
-											assert(warp(warp_id).m_cdp_latency == 0);
-
-											if(pI->m_is_cdp == 1)
-												warp(warp_id).m_cdp_latency = m_shader->m_config->gpgpu_ctx->func_sim->cdp_latency[pI->m_is_cdp - 1];
-											else //cudaLaunchDeviceV2 and cudaGetParameterBufferV2
-												warp(warp_id).m_cdp_latency = m_shader->m_config->gpgpu_ctx->func_sim->cdp_latency[pI->m_is_cdp - 1]
-													+ m_shader->m_config->gpgpu_ctx->func_sim->cdp_latency[pI->m_is_cdp] * active_mask.count();
-											warp(warp_id).m_cdp_dummy = true;
-											break;
-										}
-										else if(pI->m_is_cdp && warp(warp_id).m_cdp_dummy) {
-											assert(warp(warp_id).m_cdp_latency == 0);
-											warp(warp_id).m_cdp_dummy = false;
-										}
-									}
-
-									if(execute_on_SP) {
-										m_shader->issue_warp(*m_sp_out,pI,active_mask,warp_id,m_id);
-										issued++;
-										issued_inst=true;
-										warp_inst_issued = true;
-										previous_issued_inst_exec_type = exec_unit_type_t::SP;
-									} else if (execute_on_INT) {
-										m_shader->issue_warp(*m_int_out,pI,active_mask,warp_id,m_id);
-										issued++;
-										issued_inst=true;
-										warp_inst_issued = true;
-										previous_issued_inst_exec_type = exec_unit_type_t::INT;
-                                   }
-                            } else if ( (m_shader->m_config->gpgpu_num_dp_units > 0) && (pI->op == DP_OP) && !(diff_exec_units && previous_issued_inst_exec_type == exec_unit_type_t::DP)) {
-                                if( dp_pipe_avail ) {
-                                    m_shader->issue_warp(*m_dp_out,pI,active_mask,warp_id,m_id);
-                                    issued++;
-                                    issued_inst=true;
-                                    warp_inst_issued = true;
-                                    previous_issued_inst_exec_type = exec_unit_type_t::DP;
-                                }
-                            }  //If the DP units = 0 (like in Fermi archi), then execute DP inst on SFU unit
-                            else if ( ((m_shader->m_config->gpgpu_num_dp_units == 0 && pI->op == DP_OP) || (pI->op == SFU_OP) || (pI->op == ALU_SFU_OP)) && !(diff_exec_units && previous_issued_inst_exec_type == exec_unit_type_t::SFU)) {
-                                if( sfu_pipe_avail ) {
-                                    m_shader->issue_warp(*m_sfu_out,pI,active_mask,warp_id,m_id);
-                                    issued++;
-                                    issued_inst=true;
-                                    warp_inst_issued = true;
-                                    previous_issued_inst_exec_type = exec_unit_type_t::SFU;
-                                }
-                            }                         
-                             else if ( (pI->op == TENSOR_CORE_OP) && !(diff_exec_units && previous_issued_inst_exec_type == exec_unit_type_t::SP) ) {
-                                if( tensor_core_pipe_avail ) {
-                                    m_shader->issue_warp(*m_tensor_core_out,pI,active_mask,warp_id,m_id);
-                                    issued++;
-                                    issued_inst=true;
-                                    warp_inst_issued = true;
-                                    previous_issued_inst_exec_type = exec_unit_type_t::TENSOR;
-                                }
-			    }
-                         }//end of else
-                   } else {
-
-                        SCHED_DPRINTF( "Warp (warp_id %u, dynamic_warp_id %u) fails scoreboard\n",
-                                       (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id() );
-                   }
-                }
-            } else if( valid ) {
-               // this case can happen after a return instruction in diverged warp
-               SCHED_DPRINTF( "Warp (warp_id %u, dynamic_warp_id %u) return from diverged warp flush\n",
-                              (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id() );
-               warp(warp_id).set_next_pc(pc);
-               warp(warp_id).ibuffer_flush();
-            }
-            if(warp_inst_issued) {
-                SCHED_DPRINTF( "Warp (warp_id %u, dynamic_warp_id %u) issued %u instructions\n",
-                               (*iter)->get_warp_id(),
-                               (*iter)->get_dynamic_warp_id(),
-                               issued );
-                do_on_warp_issued( warp_id, issued, iter );
-            }
-            checked++;
-        }
-        if ( issued ) {
-            // This might be a bit inefficient, but we need to maintain
-            // two ordered list for proper scheduler execution.
-            // We could remove the need for this loop by associating a
-            // supervised_is index with each entry in the m_next_cycle_prioritized_warps
-            // vector. For now, just run through until you find the right warp_id
-            for ( std::vector< shd_warp_t* >::const_iterator supervised_iter = m_supervised_warps.begin();
-                  supervised_iter != m_supervised_warps.end();
-                  ++supervised_iter ) {
-                if ( *iter == *supervised_iter ) {
-                    m_last_supervised_issued = supervised_iter;
-                }
-            }
-
-            if(issued == 1)
-            	m_stats->single_issue_nums[m_id]++;
-            else if(issued > 1)
-            	m_stats->dual_issue_nums[m_id]++;
-            else
-            	abort();   //issued should be > 0
-
-            break;
-        } 
-    }
-
-    // issue stall statistics:
-    if( !valid_inst ) 
-        m_stats->shader_cycle_distro[0]++; // idle or control hazard
-    else if( !ready_inst ) 
-        m_stats->shader_cycle_distro[1]++; // waiting for RAW hazards (possibly due to memory) 
-    else if( !issued_inst ) 
-        m_stats->shader_cycle_distro[2]++; // pipeline stalled
-}
-
-void scheduler_unit::do_on_warp_issued( unsigned warp_id,
-                                        unsigned num_issued,
-                                        const std::vector< shd_warp_t* >::const_iterator& prioritized_iter )
-{
-    m_stats->event_warp_issued( m_shader->get_sid(),
-                                warp_id,
-                                num_issued,
-                                warp(warp_id).get_dynamic_warp_id() );
-    warp(warp_id).ibuffer_step();
-}
-
-bool scheduler_unit::sort_warps_by_oldest_dynamic_id(shd_warp_t* lhs, shd_warp_t* rhs)
-{
-    if (rhs && lhs) {
-        if ( lhs->done_exit() || lhs->waiting() ) {
-            return false;
-        } else if ( rhs->done_exit() || rhs->waiting() ) {
-            return true;
-        } else {
-            return lhs->get_dynamic_warp_id() < rhs->get_dynamic_warp_id();
-        }
-    } else {
-        return lhs < rhs;
-    }
-}
-
-void lrr_scheduler::order_warps()
-{
-    order_lrr( m_next_cycle_prioritized_warps,
-               m_supervised_warps,
-               m_last_supervised_issued,
-               m_supervised_warps.size() );
-}
-
-void gto_scheduler::order_warps()
-{
-    order_by_priority( m_next_cycle_prioritized_warps,
-                       m_supervised_warps,
-                       m_last_supervised_issued,
-                       m_supervised_warps.size(),
-                       ORDERING_GREEDY_THEN_PRIORITY_FUNC,
-                       scheduler_unit::sort_warps_by_oldest_dynamic_id );
-}
-
-void oldest_scheduler::order_warps()
-{
-    order_by_priority( m_next_cycle_prioritized_warps,
-                       m_supervised_warps,
-                       m_last_supervised_issued,
-                       m_supervised_warps.size(),
-		       ORDERED_PRIORITY_FUNC_ONLY,
-                       scheduler_unit::sort_warps_by_oldest_dynamic_id );
-}
-
-void
-two_level_active_scheduler::do_on_warp_issued( unsigned warp_id,
-                                               unsigned num_issued,
-                                               const std::vector< shd_warp_t* >::const_iterator& prioritized_iter )
-{
-    scheduler_unit::do_on_warp_issued( warp_id, num_issued, prioritized_iter );
-    if ( SCHEDULER_PRIORITIZATION_LRR == m_inner_level_prioritization ) {
-        std::vector< shd_warp_t* > new_active; 
-        order_lrr( new_active,
-                   m_next_cycle_prioritized_warps,
-                   prioritized_iter,
-                   m_next_cycle_prioritized_warps.size() );
-        m_next_cycle_prioritized_warps = new_active;
-    } else {
-        fprintf( stderr,
-                 "Unimplemented m_inner_level_prioritization: %d\n",
-                 m_inner_level_prioritization );
-        abort();
-    }
-}
-
-void two_level_active_scheduler::order_warps()
-{
-    //Move waiting warps to m_pending_warps
-    unsigned num_demoted = 0;
-    for (   std::vector< shd_warp_t* >::iterator iter = m_next_cycle_prioritized_warps.begin();
-            iter != m_next_cycle_prioritized_warps.end(); ) {
-        bool waiting = (*iter)->waiting();
-        for (int i=0; i<MAX_INPUT_VALUES; i++){
-            const warp_inst_t* inst = (*iter)->ibuffer_next_inst();
-            //Is the instruction waiting on a long operation?
-            if ( inst && inst->in[i] > 0 && this->m_scoreboard->islongop((*iter)->get_warp_id(), inst->in[i])){
-                waiting = true;
-            }
-        }
-
-        if( waiting ) {
-            m_pending_warps.push_back(*iter);
-            iter = m_next_cycle_prioritized_warps.erase(iter);
-            SCHED_DPRINTF( "DEMOTED warp_id=%d, dynamic_warp_id=%d\n",
-                           (*iter)->get_warp_id(),
-                           (*iter)->get_dynamic_warp_id() );
-            ++num_demoted;
-        } else {
-            ++iter;
-        }
-    }
-
-    //If there is space in m_next_cycle_prioritized_warps, promote the next m_pending_warps
-    unsigned num_promoted = 0;
-    if ( SCHEDULER_PRIORITIZATION_SRR == m_outer_level_prioritization ) {
-        while ( m_next_cycle_prioritized_warps.size() < m_max_active_warps ) {
-            m_next_cycle_prioritized_warps.push_back(m_pending_warps.front());
-            m_pending_warps.pop_front();
-            SCHED_DPRINTF( "PROMOTED warp_id=%d, dynamic_warp_id=%d\n",
-                           (m_next_cycle_prioritized_warps.back())->get_warp_id(),
-                           (m_next_cycle_prioritized_warps.back())->get_dynamic_warp_id() );
-            ++num_promoted;
-        }
-    } else {
-        fprintf( stderr,
-                 "Unimplemented m_outer_level_prioritization: %d\n",
-                 m_outer_level_prioritization );
-        abort();
-    }
-    assert( num_promoted == num_demoted );
-}
-
-swl_scheduler::swl_scheduler ( shader_core_stats* stats, shader_core_ctx* shader,
-                               Scoreboard* scoreboard, simt_stack** simt,
-                               std::vector<shd_warp_t>* warp,
-                               register_set* sp_out,
-							   register_set* dp_out,
-                               register_set* sfu_out,
-							   register_set* int_out,
-                               register_set* tensor_core_out,
-                               register_set* mem_out,
-                               int id,
-                               char* config_string )
-    : scheduler_unit ( stats, shader, scoreboard, simt, warp, sp_out, dp_out, sfu_out, int_out, tensor_core_out, mem_out, id )
-{
-    unsigned m_prioritization_readin;
-    int ret = sscanf( config_string,
-                      "warp_limiting:%d:%d",
-                      &m_prioritization_readin,
-                      &m_num_warps_to_limit
-                     );
-    assert( 2 == ret );
-    m_prioritization = (scheduler_prioritization_type)m_prioritization_readin;
-    // Currently only GTO is implemented
-    assert( m_prioritization == SCHEDULER_PRIORITIZATION_GTO );
-    assert( m_num_warps_to_limit <= shader->get_config()->max_warps_per_shader );
-}
-
-void swl_scheduler::order_warps()
-{
-    if ( SCHEDULER_PRIORITIZATION_GTO == m_prioritization ) {
-        order_by_priority( m_next_cycle_prioritized_warps,
-                           m_supervised_warps,
-                           m_last_supervised_issued,
-                           MIN( m_num_warps_to_limit, m_supervised_warps.size() ),
-                           ORDERING_GREEDY_THEN_PRIORITY_FUNC,
-                           scheduler_unit::sort_warps_by_oldest_dynamic_id );
-    } else {
-        fprintf(stderr, "swl_scheduler m_prioritization = %d\n", m_prioritization);
-        abort();
-    }
-}
-
-void shader_core_ctx::read_operands()
-{
-}
-
-address_type coalesced_segment(address_type addr, unsigned segment_size_lg2bytes)
-{
-   return  (addr >> segment_size_lg2bytes);
-}
-
-// Returns numbers of addresses in translated_addrs, each addr points to a 4B (32-bit) word
-unsigned shader_core_ctx::translate_local_memaddr( address_type localaddr, unsigned tid, unsigned num_shader, unsigned datasize, new_addr_type* translated_addrs )
-{
-   // During functional execution, each thread sees its own memory space for local memory, but these
-   // need to be mapped to a shared address space for timing simulation.  We do that mapping here.
-
-   address_type thread_base = 0;
-   unsigned max_concurrent_threads=0;
-   if (m_config->gpgpu_local_mem_map) {
-      // Dnew = D*N + T%nTpC + nTpC*C
-      // N = nTpC*nCpS*nS (max concurent threads)
-      // C = nS*K + S (hw cta number per gpu)
-      // K = T/nTpC   (hw cta number per core)
-      // D = data index
-      // T = thread
-      // nTpC = number of threads per CTA
-      // nCpS = number of CTA per shader
-      // 
-      // for a given local memory address threads in a CTA map to contiguous addresses,
-      // then distribute across memory space by CTAs from successive shader cores first, 
-      // then by successive CTA in same shader core
-      thread_base = 4*(kernel_padded_threads_per_cta * (m_sid + num_shader * (tid / kernel_padded_threads_per_cta))
-                       + tid % kernel_padded_threads_per_cta); 
-      max_concurrent_threads = kernel_padded_threads_per_cta * kernel_max_cta_per_shader * num_shader;
-   } else {
-      // legacy mapping that maps the same address in the local memory space of all threads 
-      // to a single contiguous address region 
-      thread_base = 4*(m_config->n_thread_per_shader * m_sid + tid);
-      max_concurrent_threads = num_shader * m_config->n_thread_per_shader;
-   }
-   assert( thread_base < 4/*word size*/*max_concurrent_threads );
-
-   // If requested datasize > 4B, split into multiple 4B accesses
-   // otherwise do one sub-4 byte memory access
-   unsigned num_accesses = 0;
-
-   if(datasize >= 4) {
-      // >4B access, split into 4B chunks
-      assert(datasize%4 == 0);   // Must be a multiple of 4B
-      num_accesses = datasize/4;
-      assert(num_accesses <= MAX_ACCESSES_PER_INSN_PER_THREAD); // max 32B
-      assert(localaddr%4 == 0); // Address must be 4B aligned - required if accessing 4B per request, otherwise access will overflow into next thread's space
-      for(unsigned i=0; i<num_accesses; i++) {
-          address_type local_word = localaddr/4 + i;
-          address_type linear_address = local_word*max_concurrent_threads*4 + thread_base + LOCAL_GENERIC_START;
-          translated_addrs[i] = linear_address;
+    std::sort(temp.begin(), temp.end(), priority_func);
+    typename std::vector<T>::iterator iter = temp.begin();
+    for (unsigned count = 0; count < num_warps_to_add; ++count, ++iter) {
+      if (*iter != greedy_value) {
+        result_list.push_back(*iter);
       }
-   } else {
-      // Sub-4B access, do only one access
-      assert(datasize > 0);
-      num_accesses = 1;
-      address_type local_word = localaddr/4;
-      address_type local_word_offset = localaddr%4;
-      assert( (localaddr+datasize-1)/4  == local_word ); // Make sure access doesn't overflow into next 4B chunk
-      address_type linear_address = local_word*max_concurrent_threads*4 + local_word_offset + thread_base + LOCAL_GENERIC_START;
-      translated_addrs[0] = linear_address;
-   }
-   return num_accesses;
+    }
+  } else if (ORDERED_PRIORITY_FUNC_ONLY == ordering) {
+    std::sort(temp.begin(), temp.end(), priority_func);
+    typename std::vector<T>::iterator iter = temp.begin();
+    for (unsigned count = 0; count < num_warps_to_add; ++count, ++iter) {
+      result_list.push_back(*iter);
+    }
+  } else {
+    fprintf(stderr, "Unknown ordering - %d\n", ordering);
+    abort();
+  }
+}
+
+void scheduler_unit::cycle() {
+  SCHED_DPRINTF("scheduler_unit::cycle()\n");
+  bool valid_inst = false;   // there was one warp with a valid instruction to
+                             // issue (didn't require flush due to control
+                             // hazard)
+  bool ready_inst = false;   // of the valid instructions, there was one not
+                             // waiting for pending register writes
+  bool issued_inst = false;  // of these we issued one
+
+  order_warps();
+  for (std::vector<shd_warp_t *>::const_iterator iter =
+           m_next_cycle_prioritized_warps.begin();
+       iter != m_next_cycle_prioritized_warps.end(); iter++) {
+    // Don't consider warps that are not yet valid
+    if ((*iter) == NULL || (*iter)->done_exit()) {
+      continue;
+    }
+    SCHED_DPRINTF("Testing (warp_id %u, dynamic_warp_id %u)\n",
+                  (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id());
+    unsigned warp_id = (*iter)->get_warp_id();
+    unsigned checked = 0;
+    unsigned issued = 0;
+    exec_unit_type_t previous_issued_inst_exec_type = exec_unit_type_t::NONE;
+    unsigned max_issue = m_shader->m_config->gpgpu_max_insn_issue_per_warp;
+    bool diff_exec_units =
+        m_shader->m_config->gpgpu_dual_issue_diff_exec_units;  // In tis mode,
+                                                               // we only allow
+                                                               // dual issue to
+                                                               // diff execution
+                                                               // units (as in
+                                                               // Maxwell and
+                                                               // Pascal)
+
+    while (!warp(warp_id).waiting() && !warp(warp_id).ibuffer_empty() &&
+           (checked < max_issue) && (checked <= issued) &&
+           (issued < max_issue)) {
+      const warp_inst_t *pI = warp(warp_id).ibuffer_next_inst();
+      // Jin: handle cdp latency;
+      if (pI && pI->m_is_cdp && warp(warp_id).m_cdp_latency > 0) {
+        assert(warp(warp_id).m_cdp_dummy);
+        warp(warp_id).m_cdp_latency--;
+        break;
+      }
+
+      bool valid = warp(warp_id).ibuffer_next_valid();
+      bool warp_inst_issued = false;
+      unsigned pc, rpc;
+      m_simt_stack[warp_id]->get_pdom_stack_top_info(&pc, &rpc);
+      SCHED_DPRINTF(
+          "Warp (warp_id %u, dynamic_warp_id %u) has valid instruction (%s)\n",
+          (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id(),
+          m_shader->m_config->gpgpu_ctx->func_sim->ptx_get_insn_str(pc)
+              .c_str());
+      if (pI) {
+        assert(valid);
+        if (pc != pI->pc) {
+          SCHED_DPRINTF(
+              "Warp (warp_id %u, dynamic_warp_id %u) control hazard "
+              "instruction flush\n",
+              (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id());
+          // control hazard
+          warp(warp_id).set_next_pc(pc);
+          warp(warp_id).ibuffer_flush();
+        } else {
+          valid_inst = true;
+          if (!m_scoreboard->checkCollision(warp_id, pI)) {
+            SCHED_DPRINTF(
+                "Warp (warp_id %u, dynamic_warp_id %u) passes scoreboard\n",
+                (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id());
+            ready_inst = true;
+            const active_mask_t &active_mask =
+                m_simt_stack[warp_id]->get_active_mask();
+            assert(warp(warp_id).inst_in_pipeline());
+
+            if ((pI->op == LOAD_OP) || (pI->op == STORE_OP) ||
+                (pI->op == MEMORY_BARRIER_OP) ||
+                (pI->op == TENSOR_CORE_LOAD_OP) ||
+                (pI->op == TENSOR_CORE_STORE_OP)) {
+              if (m_mem_out->has_free(m_shader->m_config->sub_core_model,
+                                      m_id) &&
+                  (!diff_exec_units ||
+                   previous_issued_inst_exec_type != exec_unit_type_t::MEM)) {
+                m_shader->issue_warp(*m_mem_out, pI, active_mask, warp_id,
+                                     m_id);
+                issued++;
+                issued_inst = true;
+                warp_inst_issued = true;
+                previous_issued_inst_exec_type = exec_unit_type_t::MEM;
+              }
+            } else {
+              bool sp_pipe_avail =
+                  m_sp_out->has_free(m_shader->m_config->sub_core_model, m_id);
+              bool sfu_pipe_avail =
+                  m_sfu_out->has_free(m_shader->m_config->sub_core_model, m_id);
+              bool tensor_core_pipe_avail = m_tensor_core_out->has_free(
+                  m_shader->m_config->sub_core_model, m_id);
+              bool dp_pipe_avail =
+                  m_dp_out->has_free(m_shader->m_config->sub_core_model, m_id);
+              bool int_pipe_avail =
+                  m_int_out->has_free(m_shader->m_config->sub_core_model, m_id);
+
+              // This code need to be refactored
+              if (pI->op != TENSOR_CORE_OP && pI->op != SFU_OP &&
+                  pI->op != DP_OP) {
+                bool execute_on_SP = false;
+                bool execute_on_INT = false;
+
+                // if INT unit pipline exist, then execute ALU and INT
+                // operations on INT unit and SP-FPU on SP unit (like in Volta)
+                // if INT unit pipline does not exist, then execute all ALU, INT
+                // and SP operations on SP unit (as in Fermi, Pascal GPUs)
+                if (m_shader->m_config->gpgpu_num_int_units > 0 &&
+                    int_pipe_avail && pI->op != SP_OP &&
+                    !(diff_exec_units &&
+                      previous_issued_inst_exec_type == exec_unit_type_t::INT))
+                  execute_on_INT = true;
+                else if (sp_pipe_avail &&
+                         (m_shader->m_config->gpgpu_num_int_units == 0 ||
+                          (m_shader->m_config->gpgpu_num_int_units > 0 &&
+                           pI->op == SP_OP)) &&
+                         !(diff_exec_units &&
+                           previous_issued_inst_exec_type ==
+                               exec_unit_type_t::SP))
+                  execute_on_SP = true;
+
+                if (execute_on_INT || execute_on_SP) {
+                  // Jin: special for CDP api
+                  if (pI->m_is_cdp && !warp(warp_id).m_cdp_dummy) {
+                    assert(warp(warp_id).m_cdp_latency == 0);
+
+                    if (pI->m_is_cdp == 1)
+                      warp(warp_id).m_cdp_latency =
+                          m_shader->m_config->gpgpu_ctx->func_sim
+                              ->cdp_latency[pI->m_is_cdp - 1];
+                    else  // cudaLaunchDeviceV2 and cudaGetParameterBufferV2
+                      warp(warp_id).m_cdp_latency =
+                          m_shader->m_config->gpgpu_ctx->func_sim
+                              ->cdp_latency[pI->m_is_cdp - 1] +
+                          m_shader->m_config->gpgpu_ctx->func_sim
+                                  ->cdp_latency[pI->m_is_cdp] *
+                              active_mask.count();
+                    warp(warp_id).m_cdp_dummy = true;
+                    break;
+                  } else if (pI->m_is_cdp && warp(warp_id).m_cdp_dummy) {
+                    assert(warp(warp_id).m_cdp_latency == 0);
+                    warp(warp_id).m_cdp_dummy = false;
+                  }
+                }
+
+                if (execute_on_SP) {
+                  m_shader->issue_warp(*m_sp_out, pI, active_mask, warp_id,
+                                       m_id);
+                  issued++;
+                  issued_inst = true;
+                  warp_inst_issued = true;
+                  previous_issued_inst_exec_type = exec_unit_type_t::SP;
+                } else if (execute_on_INT) {
+                  m_shader->issue_warp(*m_int_out, pI, active_mask, warp_id,
+                                       m_id);
+                  issued++;
+                  issued_inst = true;
+                  warp_inst_issued = true;
+                  previous_issued_inst_exec_type = exec_unit_type_t::INT;
+                }
+              } else if ((m_shader->m_config->gpgpu_num_dp_units > 0) &&
+                         (pI->op == DP_OP) &&
+                         !(diff_exec_units &&
+                           previous_issued_inst_exec_type ==
+                               exec_unit_type_t::DP)) {
+                if (dp_pipe_avail) {
+                  m_shader->issue_warp(*m_dp_out, pI, active_mask, warp_id,
+                                       m_id);
+                  issued++;
+                  issued_inst = true;
+                  warp_inst_issued = true;
+                  previous_issued_inst_exec_type = exec_unit_type_t::DP;
+                }
+              }  // If the DP units = 0 (like in Fermi archi), then execute DP
+                 // inst on SFU unit
+              else if (((m_shader->m_config->gpgpu_num_dp_units == 0 &&
+                         pI->op == DP_OP) ||
+                        (pI->op == SFU_OP) || (pI->op == ALU_SFU_OP)) &&
+                       !(diff_exec_units &&
+                         previous_issued_inst_exec_type ==
+                             exec_unit_type_t::SFU)) {
+                if (sfu_pipe_avail) {
+                  m_shader->issue_warp(*m_sfu_out, pI, active_mask, warp_id,
+                                       m_id);
+                  issued++;
+                  issued_inst = true;
+                  warp_inst_issued = true;
+                  previous_issued_inst_exec_type = exec_unit_type_t::SFU;
+                }
+              } else if ((pI->op == TENSOR_CORE_OP) &&
+                         !(diff_exec_units &&
+                           previous_issued_inst_exec_type ==
+                               exec_unit_type_t::SP)) {
+                if (tensor_core_pipe_avail) {
+                  m_shader->issue_warp(*m_tensor_core_out, pI, active_mask,
+                                       warp_id, m_id);
+                  issued++;
+                  issued_inst = true;
+                  warp_inst_issued = true;
+                  previous_issued_inst_exec_type = exec_unit_type_t::TENSOR;
+                }
+              }
+            }  // end of else
+          } else {
+            SCHED_DPRINTF(
+                "Warp (warp_id %u, dynamic_warp_id %u) fails scoreboard\n",
+                (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id());
+          }
+        }
+      } else if (valid) {
+        // this case can happen after a return instruction in diverged warp
+        SCHED_DPRINTF(
+            "Warp (warp_id %u, dynamic_warp_id %u) return from diverged warp "
+            "flush\n",
+            (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id());
+        warp(warp_id).set_next_pc(pc);
+        warp(warp_id).ibuffer_flush();
+      }
+      if (warp_inst_issued) {
+        SCHED_DPRINTF(
+            "Warp (warp_id %u, dynamic_warp_id %u) issued %u instructions\n",
+            (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id(), issued);
+        do_on_warp_issued(warp_id, issued, iter);
+      }
+      checked++;
+    }
+    if (issued) {
+      // This might be a bit inefficient, but we need to maintain
+      // two ordered list for proper scheduler execution.
+      // We could remove the need for this loop by associating a
+      // supervised_is index with each entry in the
+      // m_next_cycle_prioritized_warps
+      // vector. For now, just run through until you find the right warp_id
+      for (std::vector<shd_warp_t *>::const_iterator supervised_iter =
+               m_supervised_warps.begin();
+           supervised_iter != m_supervised_warps.end(); ++supervised_iter) {
+        if (*iter == *supervised_iter) {
+          m_last_supervised_issued = supervised_iter;
+        }
+      }
+
+      if (issued == 1)
+        m_stats->single_issue_nums[m_id]++;
+      else if (issued > 1)
+        m_stats->dual_issue_nums[m_id]++;
+      else
+        abort();  // issued should be > 0
+
+      break;
+    }
+  }
+
+  // issue stall statistics:
+  if (!valid_inst)
+    m_stats->shader_cycle_distro[0]++;  // idle or control hazard
+  else if (!ready_inst)
+    m_stats->shader_cycle_distro[1]++;  // waiting for RAW hazards (possibly due
+                                        // to memory)
+  else if (!issued_inst)
+    m_stats->shader_cycle_distro[2]++;  // pipeline stalled
+}
+
+void scheduler_unit::do_on_warp_issued(
+    unsigned warp_id, unsigned num_issued,
+    const std::vector<shd_warp_t *>::const_iterator &prioritized_iter) {
+  m_stats->event_warp_issued(m_shader->get_sid(), warp_id, num_issued,
+                             warp(warp_id).get_dynamic_warp_id());
+  warp(warp_id).ibuffer_step();
+}
+
+bool scheduler_unit::sort_warps_by_oldest_dynamic_id(shd_warp_t *lhs,
+                                                     shd_warp_t *rhs) {
+  if (rhs && lhs) {
+    if (lhs->done_exit() || lhs->waiting()) {
+      return false;
+    } else if (rhs->done_exit() || rhs->waiting()) {
+      return true;
+    } else {
+      return lhs->get_dynamic_warp_id() < rhs->get_dynamic_warp_id();
+    }
+  } else {
+    return lhs < rhs;
+  }
+}
+
+void lrr_scheduler::order_warps() {
+  order_lrr(m_next_cycle_prioritized_warps, m_supervised_warps,
+            m_last_supervised_issued, m_supervised_warps.size());
+}
+
+void gto_scheduler::order_warps() {
+  order_by_priority(m_next_cycle_prioritized_warps, m_supervised_warps,
+                    m_last_supervised_issued, m_supervised_warps.size(),
+                    ORDERING_GREEDY_THEN_PRIORITY_FUNC,
+                    scheduler_unit::sort_warps_by_oldest_dynamic_id);
+}
+
+void oldest_scheduler::order_warps() {
+  order_by_priority(m_next_cycle_prioritized_warps, m_supervised_warps,
+                    m_last_supervised_issued, m_supervised_warps.size(),
+                    ORDERED_PRIORITY_FUNC_ONLY,
+                    scheduler_unit::sort_warps_by_oldest_dynamic_id);
+}
+
+void two_level_active_scheduler::do_on_warp_issued(
+    unsigned warp_id, unsigned num_issued,
+    const std::vector<shd_warp_t *>::const_iterator &prioritized_iter) {
+  scheduler_unit::do_on_warp_issued(warp_id, num_issued, prioritized_iter);
+  if (SCHEDULER_PRIORITIZATION_LRR == m_inner_level_prioritization) {
+    std::vector<shd_warp_t *> new_active;
+    order_lrr(new_active, m_next_cycle_prioritized_warps, prioritized_iter,
+              m_next_cycle_prioritized_warps.size());
+    m_next_cycle_prioritized_warps = new_active;
+  } else {
+    fprintf(stderr, "Unimplemented m_inner_level_prioritization: %d\n",
+            m_inner_level_prioritization);
+    abort();
+  }
+}
+
+void two_level_active_scheduler::order_warps() {
+  // Move waiting warps to m_pending_warps
+  unsigned num_demoted = 0;
+  for (std::vector<shd_warp_t *>::iterator iter =
+           m_next_cycle_prioritized_warps.begin();
+       iter != m_next_cycle_prioritized_warps.end();) {
+    bool waiting = (*iter)->waiting();
+    for (int i = 0; i < MAX_INPUT_VALUES; i++) {
+      const warp_inst_t *inst = (*iter)->ibuffer_next_inst();
+      // Is the instruction waiting on a long operation?
+      if (inst && inst->in[i] > 0 &&
+          this->m_scoreboard->islongop((*iter)->get_warp_id(), inst->in[i])) {
+        waiting = true;
+      }
+    }
+
+    if (waiting) {
+      m_pending_warps.push_back(*iter);
+      iter = m_next_cycle_prioritized_warps.erase(iter);
+      SCHED_DPRINTF("DEMOTED warp_id=%d, dynamic_warp_id=%d\n",
+                    (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id());
+      ++num_demoted;
+    } else {
+      ++iter;
+    }
+  }
+
+  // If there is space in m_next_cycle_prioritized_warps, promote the next
+  // m_pending_warps
+  unsigned num_promoted = 0;
+  if (SCHEDULER_PRIORITIZATION_SRR == m_outer_level_prioritization) {
+    while (m_next_cycle_prioritized_warps.size() < m_max_active_warps) {
+      m_next_cycle_prioritized_warps.push_back(m_pending_warps.front());
+      m_pending_warps.pop_front();
+      SCHED_DPRINTF(
+          "PROMOTED warp_id=%d, dynamic_warp_id=%d\n",
+          (m_next_cycle_prioritized_warps.back())->get_warp_id(),
+          (m_next_cycle_prioritized_warps.back())->get_dynamic_warp_id());
+      ++num_promoted;
+    }
+  } else {
+    fprintf(stderr, "Unimplemented m_outer_level_prioritization: %d\n",
+            m_outer_level_prioritization);
+    abort();
+  }
+  assert(num_promoted == num_demoted);
+}
+
+swl_scheduler::swl_scheduler(shader_core_stats *stats, shader_core_ctx *shader,
+                             Scoreboard *scoreboard, simt_stack **simt,
+                             std::vector<shd_warp_t> *warp,
+                             register_set *sp_out, register_set *dp_out,
+                             register_set *sfu_out, register_set *int_out,
+                             register_set *tensor_core_out,
+                             register_set *mem_out, int id, char *config_string)
+    : scheduler_unit(stats, shader, scoreboard, simt, warp, sp_out, dp_out,
+                     sfu_out, int_out, tensor_core_out, mem_out, id) {
+  unsigned m_prioritization_readin;
+  int ret = sscanf(config_string, "warp_limiting:%d:%d",
+                   &m_prioritization_readin, &m_num_warps_to_limit);
+  assert(2 == ret);
+  m_prioritization = (scheduler_prioritization_type)m_prioritization_readin;
+  // Currently only GTO is implemented
+  assert(m_prioritization == SCHEDULER_PRIORITIZATION_GTO);
+  assert(m_num_warps_to_limit <= shader->get_config()->max_warps_per_shader);
+}
+
+void swl_scheduler::order_warps() {
+  if (SCHEDULER_PRIORITIZATION_GTO == m_prioritization) {
+    order_by_priority(m_next_cycle_prioritized_warps, m_supervised_warps,
+                      m_last_supervised_issued,
+                      MIN(m_num_warps_to_limit, m_supervised_warps.size()),
+                      ORDERING_GREEDY_THEN_PRIORITY_FUNC,
+                      scheduler_unit::sort_warps_by_oldest_dynamic_id);
+  } else {
+    fprintf(stderr, "swl_scheduler m_prioritization = %d\n", m_prioritization);
+    abort();
+  }
+}
+
+void shader_core_ctx::read_operands() {}
+
+address_type coalesced_segment(address_type addr,
+                               unsigned segment_size_lg2bytes) {
+  return (addr >> segment_size_lg2bytes);
+}
+
+// Returns numbers of addresses in translated_addrs, each addr points to a 4B
+// (32-bit) word
+unsigned shader_core_ctx::translate_local_memaddr(
+    address_type localaddr, unsigned tid, unsigned num_shader,
+    unsigned datasize, new_addr_type *translated_addrs) {
+  // During functional execution, each thread sees its own memory space for
+  // local memory, but these
+  // need to be mapped to a shared address space for timing simulation.  We do
+  // that mapping here.
+
+  address_type thread_base = 0;
+  unsigned max_concurrent_threads = 0;
+  if (m_config->gpgpu_local_mem_map) {
+    // Dnew = D*N + T%nTpC + nTpC*C
+    // N = nTpC*nCpS*nS (max concurent threads)
+    // C = nS*K + S (hw cta number per gpu)
+    // K = T/nTpC   (hw cta number per core)
+    // D = data index
+    // T = thread
+    // nTpC = number of threads per CTA
+    // nCpS = number of CTA per shader
+    //
+    // for a given local memory address threads in a CTA map to contiguous
+    // addresses,
+    // then distribute across memory space by CTAs from successive shader cores
+    // first,
+    // then by successive CTA in same shader core
+    thread_base =
+        4 * (kernel_padded_threads_per_cta *
+                 (m_sid + num_shader * (tid / kernel_padded_threads_per_cta)) +
+             tid % kernel_padded_threads_per_cta);
+    max_concurrent_threads =
+        kernel_padded_threads_per_cta * kernel_max_cta_per_shader * num_shader;
+  } else {
+    // legacy mapping that maps the same address in the local memory space of
+    // all threads
+    // to a single contiguous address region
+    thread_base = 4 * (m_config->n_thread_per_shader * m_sid + tid);
+    max_concurrent_threads = num_shader * m_config->n_thread_per_shader;
+  }
+  assert(thread_base < 4 /*word size*/ * max_concurrent_threads);
+
+  // If requested datasize > 4B, split into multiple 4B accesses
+  // otherwise do one sub-4 byte memory access
+  unsigned num_accesses = 0;
+
+  if (datasize >= 4) {
+    // >4B access, split into 4B chunks
+    assert(datasize % 4 == 0);  // Must be a multiple of 4B
+    num_accesses = datasize / 4;
+    assert(num_accesses <= MAX_ACCESSES_PER_INSN_PER_THREAD);  // max 32B
+    assert(localaddr % 4 == 0);  // Address must be 4B aligned - required if
+                                 // accessing 4B per request, otherwise access
+                                 // will overflow into next thread's space
+    for (unsigned i = 0; i < num_accesses; i++) {
+      address_type local_word = localaddr / 4 + i;
+      address_type linear_address = local_word * max_concurrent_threads * 4 +
+                                    thread_base + LOCAL_GENERIC_START;
+      translated_addrs[i] = linear_address;
+    }
+  } else {
+    // Sub-4B access, do only one access
+    assert(datasize > 0);
+    num_accesses = 1;
+    address_type local_word = localaddr / 4;
+    address_type local_word_offset = localaddr % 4;
+    assert((localaddr + datasize - 1) / 4 ==
+           local_word);  // Make sure access doesn't overflow into next 4B chunk
+    address_type linear_address = local_word * max_concurrent_threads * 4 +
+                                  local_word_offset + thread_base +
+                                  LOCAL_GENERIC_START;
+    translated_addrs[0] = linear_address;
+  }
+  return num_accesses;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
-int shader_core_ctx::test_res_bus(int latency){
-	for(unsigned i=0; i<num_result_bus; i++){
-		if(!m_result_bus[i]->test(latency)){return i;}
-	}
-	return -1;
-}
-
-void shader_core_ctx::execute()
-{
-	for(unsigned i=0; i<num_result_bus; i++){
-		*(m_result_bus[i]) >>=1;
-	}
-    for( unsigned n=0; n < m_num_function_units; n++ ) {
-        unsigned multiplier = m_fu[n]->clock_multiplier();
-        for( unsigned c=0; c < multiplier; c++ ) 
-            m_fu[n]->cycle();
-        m_fu[n]->active_lanes_in_pipeline();
-        enum pipeline_stage_name_t issue_port = m_issue_port[n];
-        register_set& issue_inst = m_pipeline_reg[ issue_port ];
-        warp_inst_t** ready_reg = issue_inst.get_ready();
-        if( issue_inst.has_ready() && m_fu[n]->can_issue( **ready_reg ) ) {
-            bool schedule_wb_now = !m_fu[n]->stallable();
-            int resbus = -1;
-            if( schedule_wb_now && (resbus=test_res_bus( (*ready_reg)->latency ))!=-1 ) {
-                assert( (*ready_reg)->latency < MAX_ALU_LATENCY );
-                m_result_bus[resbus]->set( (*ready_reg)->latency );
-                m_fu[n]->issue( issue_inst );
-            } else if( !schedule_wb_now ) {
-                m_fu[n]->issue( issue_inst );
-            } else {
-                // stall issue (cannot reserve result bus)
-            }
-        }
+int shader_core_ctx::test_res_bus(int latency) {
+  for (unsigned i = 0; i < num_result_bus; i++) {
+    if (!m_result_bus[i]->test(latency)) {
+      return i;
     }
+  }
+  return -1;
 }
 
-void ldst_unit::print_cache_stats( FILE *fp, unsigned& dl1_accesses, unsigned& dl1_misses ) {
-   if( m_L1D ) {
-       m_L1D->print( fp, dl1_accesses, dl1_misses );
-   }
+void shader_core_ctx::execute() {
+  for (unsigned i = 0; i < num_result_bus; i++) {
+    *(m_result_bus[i]) >>= 1;
+  }
+  for (unsigned n = 0; n < m_num_function_units; n++) {
+    unsigned multiplier = m_fu[n]->clock_multiplier();
+    for (unsigned c = 0; c < multiplier; c++) m_fu[n]->cycle();
+    m_fu[n]->active_lanes_in_pipeline();
+    enum pipeline_stage_name_t issue_port = m_issue_port[n];
+    register_set &issue_inst = m_pipeline_reg[issue_port];
+    warp_inst_t **ready_reg = issue_inst.get_ready();
+    if (issue_inst.has_ready() && m_fu[n]->can_issue(**ready_reg)) {
+      bool schedule_wb_now = !m_fu[n]->stallable();
+      int resbus = -1;
+      if (schedule_wb_now &&
+          (resbus = test_res_bus((*ready_reg)->latency)) != -1) {
+        assert((*ready_reg)->latency < MAX_ALU_LATENCY);
+        m_result_bus[resbus]->set((*ready_reg)->latency);
+        m_fu[n]->issue(issue_inst);
+      } else if (!schedule_wb_now) {
+        m_fu[n]->issue(issue_inst);
+      } else {
+        // stall issue (cannot reserve result bus)
+      }
+    }
+  }
+}
+
+void ldst_unit::print_cache_stats(FILE *fp, unsigned &dl1_accesses,
+                                  unsigned &dl1_misses) {
+  if (m_L1D) {
+    m_L1D->print(fp, dl1_accesses, dl1_misses);
+  }
 }
 
 void ldst_unit::get_cache_stats(cache_stats &cs) {
-    // Adds stats to 'cs' from each cache
-    if(m_L1D)
-        cs += m_L1D->get_stats();
-    if(m_L1C)
-        cs += m_L1C->get_stats();
-    if(m_L1T)
-        cs += m_L1T->get_stats();
-
+  // Adds stats to 'cs' from each cache
+  if (m_L1D) cs += m_L1D->get_stats();
+  if (m_L1C) cs += m_L1C->get_stats();
+  if (m_L1T) cs += m_L1T->get_stats();
 }
 
-void ldst_unit::get_L1D_sub_stats(struct cache_sub_stats &css) const{
-    if(m_L1D)
-        m_L1D->get_sub_stats(css);
+void ldst_unit::get_L1D_sub_stats(struct cache_sub_stats &css) const {
+  if (m_L1D) m_L1D->get_sub_stats(css);
 }
-void ldst_unit::get_L1C_sub_stats(struct cache_sub_stats &css) const{
-    if(m_L1C)
-        m_L1C->get_sub_stats(css);
+void ldst_unit::get_L1C_sub_stats(struct cache_sub_stats &css) const {
+  if (m_L1C) m_L1C->get_sub_stats(css);
 }
-void ldst_unit::get_L1T_sub_stats(struct cache_sub_stats &css) const{
-    if(m_L1T)
-        m_L1T->get_sub_stats(css);
+void ldst_unit::get_L1T_sub_stats(struct cache_sub_stats &css) const {
+  if (m_L1T) m_L1T->get_sub_stats(css);
 }
 
-void shader_core_ctx::warp_inst_complete(const warp_inst_t &inst)
-{
-
-  #if 0
+void shader_core_ctx::warp_inst_complete(const warp_inst_t &inst) {
+#if 0
       printf("[warp_inst_complete] uid=%u core=%u warp=%u pc=%#x @ time=%llu issued@%llu\n",
              inst.get_uid(), m_sid, inst.warp_id(), inst.pc, gpu_tot_sim_cycle + gpu_sim_cycle, inst.get_issue_cycle());
-  #endif
+#endif
 
-  if(inst.op_pipe==SP__OP)
-	  m_stats->m_num_sp_committed[m_sid]++;
-  else if(inst.op_pipe==SFU__OP)
-	  m_stats->m_num_sfu_committed[m_sid]++;
-  else if(inst.op_pipe==MEM__OP)
-	  m_stats->m_num_mem_committed[m_sid]++;
+  if (inst.op_pipe == SP__OP)
+    m_stats->m_num_sp_committed[m_sid]++;
+  else if (inst.op_pipe == SFU__OP)
+    m_stats->m_num_sfu_committed[m_sid]++;
+  else if (inst.op_pipe == MEM__OP)
+    m_stats->m_num_mem_committed[m_sid]++;
 
-  if(m_config->gpgpu_clock_gated_lanes==false)
-	  m_stats->m_num_sim_insn[m_sid] += m_config->warp_size;
+  if (m_config->gpgpu_clock_gated_lanes == false)
+    m_stats->m_num_sim_insn[m_sid] += m_config->warp_size;
   else
-	  m_stats->m_num_sim_insn[m_sid] += inst.active_count();
+    m_stats->m_num_sim_insn[m_sid] += inst.active_count();
 
   m_stats->m_num_sim_winsn[m_sid]++;
   m_gpu->gpu_sim_insn += inst.active_count();
   inst.completed(m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle);
 }
 
-void shader_core_ctx::writeback()
-{
+void shader_core_ctx::writeback() {
+  unsigned max_committed_thread_instructions =
+      m_config->warp_size *
+      (m_config->pipe_widths[EX_WB]);  // from the functional units
+  m_stats->m_pipeline_duty_cycle[m_sid] =
+      ((float)(m_stats->m_num_sim_insn[m_sid] -
+               m_stats->m_last_num_sim_insn[m_sid])) /
+      max_committed_thread_instructions;
 
-	unsigned max_committed_thread_instructions=m_config->warp_size * (m_config->pipe_widths[EX_WB]); //from the functional units
-	m_stats->m_pipeline_duty_cycle[m_sid]=((float)(m_stats->m_num_sim_insn[m_sid]-m_stats->m_last_num_sim_insn[m_sid]))/max_committed_thread_instructions;
+  m_stats->m_last_num_sim_insn[m_sid] = m_stats->m_num_sim_insn[m_sid];
+  m_stats->m_last_num_sim_winsn[m_sid] = m_stats->m_num_sim_winsn[m_sid];
 
-    m_stats->m_last_num_sim_insn[m_sid]=m_stats->m_num_sim_insn[m_sid];
-    m_stats->m_last_num_sim_winsn[m_sid]=m_stats->m_num_sim_winsn[m_sid];
+  warp_inst_t **preg = m_pipeline_reg[EX_WB].get_ready();
+  warp_inst_t *pipe_reg = (preg == NULL) ? NULL : *preg;
+  while (preg and !pipe_reg->empty()) {
+    /*
+     * Right now, the writeback stage drains all waiting instructions
+     * assuming there are enough ports in the register file or the
+     * conflicts are resolved at issue.
+     */
+    /*
+     * The operand collector writeback can generally generate a stall
+     * However, here, the pipelines should be un-stallable. This is
+     * guaranteed because this is the first time the writeback function
+     * is called after the operand collector's step function, which
+     * resets the allocations. There is one case which could result in
+     * the writeback function returning false (stall), which is when
+     * an instruction tries to modify two registers (GPR and predicate)
+     * To handle this case, we ignore the return value (thus allowing
+     * no stalling).
+     */
 
-    warp_inst_t** preg = m_pipeline_reg[EX_WB].get_ready();
-    warp_inst_t* pipe_reg = (preg==NULL)? NULL:*preg;
-    while( preg and !pipe_reg->empty()) {
-    	/*
-    	 * Right now, the writeback stage drains all waiting instructions
-    	 * assuming there are enough ports in the register file or the
-    	 * conflicts are resolved at issue.
-    	 */
-    	/*
-    	 * The operand collector writeback can generally generate a stall
-    	 * However, here, the pipelines should be un-stallable. This is
-    	 * guaranteed because this is the first time the writeback function
-    	 * is called after the operand collector's step function, which
-    	 * resets the allocations. There is one case which could result in
-    	 * the writeback function returning false (stall), which is when
-    	 * an instruction tries to modify two registers (GPR and predicate)
-    	 * To handle this case, we ignore the return value (thus allowing
-    	 * no stalling).
-    	 */
-
-        m_operand_collector.writeback(*pipe_reg);
-        unsigned warp_id = pipe_reg->warp_id();
-        m_scoreboard->releaseRegisters( pipe_reg );
-        m_warp[warp_id].dec_inst_in_pipeline();
-        warp_inst_complete(*pipe_reg);
-        m_gpu->gpu_sim_insn_last_update_sid = m_sid;
-        m_gpu->gpu_sim_insn_last_update = m_gpu->gpu_sim_cycle;
-        m_last_inst_gpu_sim_cycle = m_gpu->gpu_sim_cycle;
-        m_last_inst_gpu_tot_sim_cycle = m_gpu->gpu_tot_sim_cycle;
-        pipe_reg->clear();
-        preg = m_pipeline_reg[EX_WB].get_ready();
-        pipe_reg = (preg==NULL)? NULL:*preg;
-    }
+    m_operand_collector.writeback(*pipe_reg);
+    unsigned warp_id = pipe_reg->warp_id();
+    m_scoreboard->releaseRegisters(pipe_reg);
+    m_warp[warp_id].dec_inst_in_pipeline();
+    warp_inst_complete(*pipe_reg);
+    m_gpu->gpu_sim_insn_last_update_sid = m_sid;
+    m_gpu->gpu_sim_insn_last_update = m_gpu->gpu_sim_cycle;
+    m_last_inst_gpu_sim_cycle = m_gpu->gpu_sim_cycle;
+    m_last_inst_gpu_tot_sim_cycle = m_gpu->gpu_tot_sim_cycle;
+    pipe_reg->clear();
+    preg = m_pipeline_reg[EX_WB].get_ready();
+    pipe_reg = (preg == NULL) ? NULL : *preg;
+  }
 }
 
-bool ldst_unit::shared_cycle( warp_inst_t &inst, mem_stage_stall_type &rc_fail, mem_stage_access_type &fail_type)
-{
-   if( inst.space.get_type() != shared_space )
-       return true;
+bool ldst_unit::shared_cycle(warp_inst_t &inst, mem_stage_stall_type &rc_fail,
+                             mem_stage_access_type &fail_type) {
+  if (inst.space.get_type() != shared_space) return true;
 
-   if(inst.has_dispatch_delay()){
-	   m_stats->gpgpu_n_shmem_bank_access[m_sid]++;
-   }
+  if (inst.has_dispatch_delay()) {
+    m_stats->gpgpu_n_shmem_bank_access[m_sid]++;
+  }
 
-   bool stall = inst.dispatch_delay();
-   if( stall ) {
-       fail_type = S_MEM;
-       rc_fail = BK_CONF;
-   } else 
-       rc_fail = NO_RC_FAIL;
-   return !stall; 
+  bool stall = inst.dispatch_delay();
+  if (stall) {
+    fail_type = S_MEM;
+    rc_fail = BK_CONF;
+  } else
+    rc_fail = NO_RC_FAIL;
+  return !stall;
 }
 
-mem_stage_stall_type
-ldst_unit::process_cache_access( cache_t* cache,
-                                 new_addr_type address,
-                                 warp_inst_t &inst,
-                                 std::list<cache_event>& events,
-                                 mem_fetch *mf,
-                                 enum cache_request_status status )
-{
-    mem_stage_stall_type result = NO_RC_FAIL;
-    bool write_sent = was_write_sent(events);
-    bool read_sent = was_read_sent(events);
-    if( write_sent ) {
-    	unsigned inc_ack = (m_config->m_L1D_config.get_mshr_type() == SECTOR_ASSOC)?
-    			(mf->get_data_size()/SECTOR_SIZE) : 1;
+mem_stage_stall_type ldst_unit::process_cache_access(
+    cache_t *cache, new_addr_type address, warp_inst_t &inst,
+    std::list<cache_event> &events, mem_fetch *mf,
+    enum cache_request_status status) {
+  mem_stage_stall_type result = NO_RC_FAIL;
+  bool write_sent = was_write_sent(events);
+  bool read_sent = was_read_sent(events);
+  if (write_sent) {
+    unsigned inc_ack = (m_config->m_L1D_config.get_mshr_type() == SECTOR_ASSOC)
+                           ? (mf->get_data_size() / SECTOR_SIZE)
+                           : 1;
 
-		for(unsigned i=0; i< inc_ack; ++i)
-			m_core->inc_store_req( inst.warp_id() );
-
+    for (unsigned i = 0; i < inc_ack; ++i)
+      m_core->inc_store_req(inst.warp_id());
+  }
+  if (status == HIT) {
+    assert(!read_sent);
+    inst.accessq_pop_back();
+    if (inst.is_load()) {
+      for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++)
+        if (inst.out[r] > 0) m_pending_writes[inst.warp_id()][inst.out[r]]--;
     }
-    if ( status == HIT ) {
-        assert( !read_sent );
-        inst.accessq_pop_back();
-        if ( inst.is_load() ) {
-            for ( unsigned r=0; r < MAX_OUTPUT_VALUES; r++)
-                if (inst.out[r] > 0)
-                    m_pending_writes[inst.warp_id()][inst.out[r]]--; 
+    if (!write_sent) delete mf;
+  } else if (status == RESERVATION_FAIL) {
+    result = BK_CONF;
+    assert(!read_sent);
+    assert(!write_sent);
+    delete mf;
+  } else {
+    assert(status == MISS || status == HIT_RESERVED);
+    // inst.clear_active( access.get_warp_mask() ); // threads in mf writeback
+    // when mf returns
+    inst.accessq_pop_back();
+  }
+  if (!inst.accessq_empty() && result == NO_RC_FAIL) result = COAL_STALL;
+  return result;
+}
+
+mem_stage_stall_type ldst_unit::process_memory_access_queue(cache_t *cache,
+                                                            warp_inst_t &inst) {
+  mem_stage_stall_type result = NO_RC_FAIL;
+  if (inst.accessq_empty()) return result;
+
+  if (!cache->data_port_free()) return DATA_PORT_STALL;
+
+  // const mem_access_t &access = inst.accessq_back();
+  mem_fetch *mf = m_mf_allocator->alloc(
+      inst, inst.accessq_back(),
+      m_core->get_gpu()->gpu_sim_cycle + m_core->get_gpu()->gpu_tot_sim_cycle);
+  std::list<cache_event> events;
+  enum cache_request_status status = cache->access(
+      mf->get_addr(), mf,
+      m_core->get_gpu()->gpu_sim_cycle + m_core->get_gpu()->gpu_tot_sim_cycle,
+      events);
+  return process_cache_access(cache, mf->get_addr(), inst, events, mf, status);
+}
+
+mem_stage_stall_type ldst_unit::process_memory_access_queue_l1cache(
+    l1_cache *cache, warp_inst_t &inst) {
+  mem_stage_stall_type result = NO_RC_FAIL;
+  if (inst.accessq_empty()) return result;
+
+  if (m_config->m_L1D_config.l1_latency > 0) {
+    for (int j = 0; j < m_config->m_L1D_config.l1_banks;
+         j++) {  // We can handle at max l1_banks reqs per cycle
+
+      if (inst.accessq_empty()) return result;
+
+      mem_fetch *mf = m_mf_allocator->alloc(
+          inst, inst.accessq_back(), m_core->get_gpu()->gpu_sim_cycle +
+                                         m_core->get_gpu()->gpu_tot_sim_cycle);
+      unsigned bank_id = m_config->m_L1D_config.set_bank(mf->get_addr());
+      assert(bank_id < m_config->m_L1D_config.l1_banks);
+
+      if ((l1_latency_queue[bank_id][m_config->m_L1D_config.l1_latency - 1]) ==
+          NULL) {
+        l1_latency_queue[bank_id][m_config->m_L1D_config.l1_latency - 1] = mf;
+
+        if (mf->get_inst().is_store()) {
+          unsigned inc_ack =
+              (m_config->m_L1D_config.get_mshr_type() == SECTOR_ASSOC)
+                  ? (mf->get_data_size() / SECTOR_SIZE)
+                  : 1;
+
+          for (unsigned i = 0; i < inc_ack; ++i)
+            m_core->inc_store_req(inst.warp_id());
         }
-        if( !write_sent ) 
-            delete mf;
-    } else if ( status == RESERVATION_FAIL ) {
+
+        inst.accessq_pop_back();
+      } else {
         result = BK_CONF;
-        assert( !read_sent );
-        assert( !write_sent );
         delete mf;
-    } else {
-        assert( status == MISS || status == HIT_RESERVED );
-        //inst.clear_active( access.get_warp_mask() ); // threads in mf writeback when mf returns
-        inst.accessq_pop_back();
-    }
-    if( !inst.accessq_empty() && result == NO_RC_FAIL)
-        result = COAL_STALL;
-    return result;
-}
-
-mem_stage_stall_type ldst_unit::process_memory_access_queue( cache_t *cache, warp_inst_t &inst )
-{
-    mem_stage_stall_type result = NO_RC_FAIL;
-    if( inst.accessq_empty() )
-        return result;
-
-    if( !cache->data_port_free() ) 
-        return DATA_PORT_STALL; 
-
-    //const mem_access_t &access = inst.accessq_back();
-    mem_fetch *mf = m_mf_allocator->alloc(inst,inst.accessq_back(),m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
-    std::list<cache_event> events;
-    enum cache_request_status status = cache->access(mf->get_addr(),mf,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle,events);
-    return process_cache_access( cache, mf->get_addr(), inst, events, mf, status );
-}
-
-mem_stage_stall_type ldst_unit::process_memory_access_queue_l1cache( l1_cache *cache, warp_inst_t &inst )
-{
-    mem_stage_stall_type result = NO_RC_FAIL;
-    if( inst.accessq_empty() )
-        return result;
-
-    if(m_config->m_L1D_config.l1_latency > 0)
-	{
-    	for(int j=0; j<m_config->m_L1D_config.l1_banks; j++) {  //We can handle at max l1_banks reqs per cycle
-
-    		if( inst.accessq_empty() )
-    		        return result;
-
-    	    mem_fetch *mf = m_mf_allocator->alloc(inst,inst.accessq_back(),m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
-    	    unsigned bank_id = m_config->m_L1D_config.set_bank(mf->get_addr());
-    	    assert(bank_id < m_config->m_L1D_config.l1_banks);
-
-			if((l1_latency_queue[bank_id][m_config->m_L1D_config.l1_latency-1]) == NULL)
-			{
-				l1_latency_queue[bank_id][m_config->m_L1D_config.l1_latency-1] = mf;
-
-				if( mf->get_inst().is_store() ) {
-					unsigned inc_ack = (m_config->m_L1D_config.get_mshr_type() == SECTOR_ASSOC)?
-							(mf->get_data_size()/SECTOR_SIZE) : 1;
-
-					for(unsigned i=0; i< inc_ack; ++i)
-						m_core->inc_store_req( inst.warp_id() );
-				}
-
-				inst.accessq_pop_back();
-			}
-			else
-			{
-				result = BK_CONF;
-				delete mf;
-				break;   //do not try again, just break from the loop and try the next cycle
-			}
-    	}
-		if( !inst.accessq_empty() &&  result !=BK_CONF)
-		   result = COAL_STALL;
-
-	     return result;
-	}
-    else
-    {
-	    mem_fetch *mf = m_mf_allocator->alloc(inst,inst.accessq_back(),m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
-		std::list<cache_event> events;
-		enum cache_request_status status = cache->access(mf->get_addr(),mf,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle,events);
-		return process_cache_access( cache, mf->get_addr(), inst, events, mf, status );
-    }
-}
-
-void ldst_unit::L1_latency_queue_cycle()
-{
-	for(int j=0; j<m_config->m_L1D_config.l1_banks; j++) {
-		if((l1_latency_queue[j][0]) != NULL)
-		{
-				mem_fetch* mf_next = l1_latency_queue[j][0];
-				std::list<cache_event> events;
-				enum cache_request_status status = m_L1D->access(mf_next->get_addr(),mf_next,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle,events);
-
-			   bool write_sent = was_write_sent(events);
-			   bool read_sent = was_read_sent(events);
-
-			   if ( status == HIT ) {
-				   assert( !read_sent );
-				   l1_latency_queue[j][0] = NULL;
-				   if ( mf_next->get_inst().is_load() ) {
-					   for ( unsigned r=0; r < MAX_OUTPUT_VALUES; r++)
-						   if (mf_next->get_inst().out[r] > 0)
-						   {
-							   assert(m_pending_writes[mf_next->get_inst().warp_id()][mf_next->get_inst().out[r]]>0);
-							   unsigned still_pending = --m_pending_writes[mf_next->get_inst().warp_id()][mf_next->get_inst().out[r]];
-							   if(!still_pending)
-							   {
-								m_pending_writes[mf_next->get_inst().warp_id()].erase(mf_next->get_inst().out[r]);
-								m_scoreboard->releaseRegister(mf_next->get_inst().warp_id(),mf_next->get_inst().out[r]);
-								m_core->warp_inst_complete(mf_next->get_inst());
-							   }
-						   }
-				   }
-
-				   //For write hit in WB policy
-				   if(mf_next->get_inst().is_store() && !write_sent)
-				   {
-					   unsigned dec_ack = (m_config->m_L1D_config.get_mshr_type() == SECTOR_ASSOC)?
-											(mf_next->get_data_size()/SECTOR_SIZE) : 1;
-
-					   mf_next->set_reply();
-
-					   for(unsigned i=0; i< dec_ack; ++i)
-						  m_core->store_ack(mf_next);
-				   }
-
-				   if( !write_sent )
-					   delete mf_next;
-
-			   } else if ( status == RESERVATION_FAIL ) {
-				   assert( !read_sent );
-				   assert( !write_sent );
-			   } else {
-				   assert( status == MISS || status == HIT_RESERVED );
-				   l1_latency_queue[j][0] = NULL;
-		   }
-		}
-
-		 for( unsigned stage = 0; stage<m_config->m_L1D_config.l1_latency-1; ++stage)
-		  if( l1_latency_queue[j][stage] == NULL) {
-			   l1_latency_queue[j][stage] = l1_latency_queue[j][stage+1] ;
-			   l1_latency_queue[j][stage+1] = NULL;
-		   }
-	}
-
-}
-
-
-
-bool ldst_unit::constant_cycle( warp_inst_t &inst, mem_stage_stall_type &rc_fail, mem_stage_access_type &fail_type)
-{
-   if( inst.empty() || ((inst.space.get_type() != const_space) && (inst.space.get_type() != param_space_kernel)) )
-       return true;
-   if( inst.active_count() == 0 ) 
-       return true;
-   mem_stage_stall_type fail = process_memory_access_queue(m_L1C,inst);
-   if (fail != NO_RC_FAIL){ 
-      rc_fail = fail; //keep other fails if this didn't fail.
-      fail_type = C_MEM;
-      if (rc_fail == BK_CONF or rc_fail == COAL_STALL) {
-         m_stats->gpgpu_n_cmem_portconflict++; //coal stalls aren't really a bank conflict, but this maintains previous behavior.
+        break;  // do not try again, just break from the loop and try the next
+                // cycle
       }
-   }
-   return inst.accessq_empty(); //done if empty.
-}
-
-bool ldst_unit::texture_cycle( warp_inst_t &inst, mem_stage_stall_type &rc_fail, mem_stage_access_type &fail_type)
-{
-   if( inst.empty() || inst.space.get_type() != tex_space )
-       return true;
-   if( inst.active_count() == 0 ) 
-       return true;
-   mem_stage_stall_type fail = process_memory_access_queue(m_L1T,inst);
-   if (fail != NO_RC_FAIL){ 
-      rc_fail = fail; //keep other fails if this didn't fail.
-      fail_type = T_MEM;
-   }
-   return inst.accessq_empty(); //done if empty.
-}
-
-bool ldst_unit::memory_cycle( warp_inst_t &inst, mem_stage_stall_type &stall_reason, mem_stage_access_type &access_type )
-{
-   if( inst.empty() || 
-       ((inst.space.get_type() != global_space) &&
-        (inst.space.get_type() != local_space) &&
-        (inst.space.get_type() != param_space_local)) ) 
-       return true;
-   if( inst.active_count() == 0 ) 
-       return true;
-   assert( !inst.accessq_empty() );
-   mem_stage_stall_type stall_cond = NO_RC_FAIL;
-   const mem_access_t &access = inst.accessq_back();
-
-   bool bypassL1D = false; 
-   if ( CACHE_GLOBAL == inst.cache_op || (m_L1D == NULL) ) {
-       bypassL1D = true; 
-   } else if (inst.space.is_global()) { // global memory access 
-       // skip L1 cache if the option is enabled
-       if (m_core->get_config()->gmem_skip_L1D && (CACHE_L1 != inst.cache_op))
-           bypassL1D = true; 
-   }
-   if( bypassL1D ) {
-       // bypass L1 cache
-       unsigned control_size = inst.is_store() ? WRITE_PACKET_SIZE : READ_PACKET_SIZE;
-       unsigned size = access.get_size() + control_size;
-       //printf("Interconnect:Addr: %x, size=%d\n",access.get_addr(),size);
-       if( m_icnt->full(size, inst.is_store() || inst.isatomic()) ) {
-           stall_cond = ICNT_RC_FAIL;
-       } else {
-           mem_fetch *mf = m_mf_allocator->alloc(inst,access,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
-           m_icnt->push(mf);
-           inst.accessq_pop_back();
-           //inst.clear_active( access.get_warp_mask() );
-           if( inst.is_load() ) { 
-              for( unsigned r=0; r < MAX_OUTPUT_VALUES; r++) 
-                  if(inst.out[r] > 0) 
-                      assert( m_pending_writes[inst.warp_id()][inst.out[r]] > 0 );
-           } else if( inst.is_store() ) 
-              m_core->inc_store_req( inst.warp_id() );
-       }
-   } else {
-       assert( CACHE_UNDEFINED != inst.cache_op );
-       stall_cond = process_memory_access_queue_l1cache(m_L1D,inst);
-   }
-   if( !inst.accessq_empty() && stall_cond == NO_RC_FAIL)
-       stall_cond = COAL_STALL;
-   if (stall_cond != NO_RC_FAIL) {
-      stall_reason = stall_cond;
-      bool iswrite = inst.is_store();
-      if (inst.space.is_local()) 
-         access_type = (iswrite)?L_MEM_ST:L_MEM_LD;
-      else 
-         access_type = (iswrite)?G_MEM_ST:G_MEM_LD;
-   }
-   return inst.accessq_empty(); 
-}
-
-
-bool ldst_unit::response_buffer_full() const
-{
-    return m_response_fifo.size() >= m_config->ldst_unit_response_queue_size;
-}
-
-void ldst_unit::fill( mem_fetch *mf )
-{
-    mf->set_status(IN_SHADER_LDST_RESPONSE_FIFO,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
-    m_response_fifo.push_back(mf);
-}
-
-void ldst_unit::flush(){
-	// Flush L1D cache
-	m_L1D->flush();
-}
-
-void ldst_unit::invalidate(){
-	// Flush L1D cache
-	m_L1D->invalidate();
-}
-
-simd_function_unit::simd_function_unit( const shader_core_config *config )
-{ 
-    m_config=config;
-    m_dispatch_reg = new warp_inst_t(config); 
-}
-
-
-sfu:: sfu(  register_set* result_port, const shader_core_config *config,shader_core_ctx *core  )
-    : pipelined_simd_unit(result_port,config,config->max_sfu_latency,core)
-{ 
-    m_name = "SFU"; 
-}
-
-tensor_core:: tensor_core(  register_set* result_port, const shader_core_config *config,shader_core_ctx *core  )
-    : pipelined_simd_unit(result_port,config,config->max_tensor_core_latency,core)
-{ 
-    m_name = "TENSOR_CORE"; 
-}
-
-void sfu::issue( register_set& source_reg )
-{
-    warp_inst_t** ready_reg = source_reg.get_ready();
-	//m_core->incexecstat((*ready_reg));
-
-	(*ready_reg)->op_pipe=SFU__OP;
-	m_core->incsfu_stat(m_core->get_config()->warp_size,(*ready_reg)->latency);
-	pipelined_simd_unit::issue(source_reg);
-}
-
-void tensor_core::issue( register_set& source_reg )
-{
-    warp_inst_t** ready_reg = source_reg.get_ready();
-	//m_core->incexecstat((*ready_reg));
-
-	(*ready_reg)->op_pipe= TENSOR_CORE__OP;
-	m_core->incsfu_stat(m_core->get_config()->warp_size,(*ready_reg)->latency);
-	pipelined_simd_unit::issue(source_reg);
-}
-
-unsigned pipelined_simd_unit::get_active_lanes_in_pipeline(){
-	active_mask_t active_lanes;
-	active_lanes.reset();
-	 if(m_core->get_gpu()->get_config().g_power_simulation_enabled){
-		for( unsigned stage=0; (stage+1)<m_pipeline_depth; stage++ ){
-			if( !m_pipeline_reg[stage]->empty() )
-				active_lanes|=m_pipeline_reg[stage]->get_active_mask();
-		}
-	 }
-	return active_lanes.count();
-}
-
-void ldst_unit::active_lanes_in_pipeline(){
-	unsigned active_count=pipelined_simd_unit::get_active_lanes_in_pipeline();
-	assert(active_count<=m_core->get_config()->warp_size);
-	m_core->incfumemactivelanes_stat(active_count);
-}
-
-void sp_unit::active_lanes_in_pipeline(){
-	unsigned active_count=pipelined_simd_unit::get_active_lanes_in_pipeline();
-	assert(active_count<=m_core->get_config()->warp_size);
-	m_core->incspactivelanes_stat(active_count);
-	m_core->incfuactivelanes_stat(active_count);
-	m_core->incfumemactivelanes_stat(active_count);
-}
-void dp_unit::active_lanes_in_pipeline(){
-	unsigned active_count=pipelined_simd_unit::get_active_lanes_in_pipeline();
-	assert(active_count<=m_core->get_config()->warp_size);
-	m_core->incspactivelanes_stat(active_count);
-	m_core->incfuactivelanes_stat(active_count);
-	m_core->incfumemactivelanes_stat(active_count);
-}
-
-void int_unit::active_lanes_in_pipeline(){
-	unsigned active_count=pipelined_simd_unit::get_active_lanes_in_pipeline();
-	assert(active_count<=m_core->get_config()->warp_size);
-	m_core->incspactivelanes_stat(active_count);
-	m_core->incfuactivelanes_stat(active_count);
-	m_core->incfumemactivelanes_stat(active_count);
-}
-void sfu::active_lanes_in_pipeline(){
-	unsigned active_count=pipelined_simd_unit::get_active_lanes_in_pipeline();
-	assert(active_count<=m_core->get_config()->warp_size);
-	m_core->incsfuactivelanes_stat(active_count);
-	m_core->incfuactivelanes_stat(active_count);
-	m_core->incfumemactivelanes_stat(active_count);
-}
-
-void tensor_core::active_lanes_in_pipeline(){
-	unsigned active_count=pipelined_simd_unit::get_active_lanes_in_pipeline();
-	assert(active_count<=m_core->get_config()->warp_size);
-	m_core->incsfuactivelanes_stat(active_count);
-	m_core->incfuactivelanes_stat(active_count);
-	m_core->incfumemactivelanes_stat(active_count);
-}
-
-
-sp_unit::sp_unit( register_set* result_port, const shader_core_config *config,shader_core_ctx *core)
-    : pipelined_simd_unit(result_port,config,config->max_sp_latency,core)
-{ 
-    m_name = "SP "; 
-}
-
-dp_unit::dp_unit( register_set* result_port, const shader_core_config *config,shader_core_ctx *core)
-    : pipelined_simd_unit(result_port,config,config->max_dp_latency,core)
-{
-    m_name = "DP ";
-}
-
-int_unit::int_unit( register_set* result_port, const shader_core_config *config,shader_core_ctx *core)
-    : pipelined_simd_unit(result_port,config,config->max_int_latency,core)
-{
-    m_name = "INT ";
-}
-
-void sp_unit :: issue(register_set& source_reg)
-{
-    warp_inst_t** ready_reg = source_reg.get_ready();
-	//m_core->incexecstat((*ready_reg));
-	(*ready_reg)->op_pipe=SP__OP;
-	m_core->incsp_stat(m_core->get_config()->warp_size,(*ready_reg)->latency);
-	pipelined_simd_unit::issue(source_reg);
-}
-
-void dp_unit :: issue(register_set& source_reg)
-{
-    warp_inst_t** ready_reg = source_reg.get_ready();
-	//m_core->incexecstat((*ready_reg));
-	(*ready_reg)->op_pipe=DP__OP;
-	m_core->incsp_stat(m_core->get_config()->warp_size,(*ready_reg)->latency);
-	pipelined_simd_unit::issue(source_reg);
-}
-
-void int_unit :: issue(register_set& source_reg)
-{
-    warp_inst_t** ready_reg = source_reg.get_ready();
-	//m_core->incexecstat((*ready_reg));
-	(*ready_reg)->op_pipe=INTP__OP;
-	m_core->incsp_stat(m_core->get_config()->warp_size,(*ready_reg)->latency);
-	pipelined_simd_unit::issue(source_reg);
-}
-
-pipelined_simd_unit::pipelined_simd_unit( register_set* result_port, const shader_core_config *config, unsigned max_latency,shader_core_ctx *core )
-    : simd_function_unit(config) 
-{
-    m_result_port = result_port;
-    m_pipeline_depth = max_latency;
-    m_pipeline_reg = new warp_inst_t*[m_pipeline_depth];
-    for( unsigned i=0; i < m_pipeline_depth; i++ ) 
-	m_pipeline_reg[i] = new warp_inst_t( config );
-    m_core=core;
-    active_insts_in_pipeline=0;
-}
-
-void pipelined_simd_unit::cycle()
-{
-    if( !m_pipeline_reg[0]->empty() ){
-        m_result_port->move_in(m_pipeline_reg[0]);
-        assert(active_insts_in_pipeline > 0);
-        active_insts_in_pipeline--;
     }
-    if(active_insts_in_pipeline){
-		for( unsigned stage=0; (stage+1)<m_pipeline_depth; stage++ )
-			move_warp(m_pipeline_reg[stage], m_pipeline_reg[stage+1]);
-    }
-    if( !m_dispatch_reg->empty() ) {
-        if( !m_dispatch_reg->dispatch_delay()){
-            int start_stage = m_dispatch_reg->latency - m_dispatch_reg->initiation_interval;
-            move_warp(m_pipeline_reg[start_stage],m_dispatch_reg);
-            active_insts_in_pipeline++;
+    if (!inst.accessq_empty() && result != BK_CONF) result = COAL_STALL;
+
+    return result;
+  } else {
+    mem_fetch *mf = m_mf_allocator->alloc(
+        inst, inst.accessq_back(), m_core->get_gpu()->gpu_sim_cycle +
+                                       m_core->get_gpu()->gpu_tot_sim_cycle);
+    std::list<cache_event> events;
+    enum cache_request_status status = cache->access(
+        mf->get_addr(), mf,
+        m_core->get_gpu()->gpu_sim_cycle + m_core->get_gpu()->gpu_tot_sim_cycle,
+        events);
+    return process_cache_access(cache, mf->get_addr(), inst, events, mf,
+                                status);
+  }
+}
+
+void ldst_unit::L1_latency_queue_cycle() {
+  for (int j = 0; j < m_config->m_L1D_config.l1_banks; j++) {
+    if ((l1_latency_queue[j][0]) != NULL) {
+      mem_fetch *mf_next = l1_latency_queue[j][0];
+      std::list<cache_event> events;
+      enum cache_request_status status =
+          m_L1D->access(mf_next->get_addr(), mf_next,
+                        m_core->get_gpu()->gpu_sim_cycle +
+                            m_core->get_gpu()->gpu_tot_sim_cycle,
+                        events);
+
+      bool write_sent = was_write_sent(events);
+      bool read_sent = was_read_sent(events);
+
+      if (status == HIT) {
+        assert(!read_sent);
+        l1_latency_queue[j][0] = NULL;
+        if (mf_next->get_inst().is_load()) {
+          for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++)
+            if (mf_next->get_inst().out[r] > 0) {
+              assert(m_pending_writes[mf_next->get_inst().warp_id()]
+                                     [mf_next->get_inst().out[r]] > 0);
+              unsigned still_pending =
+                  --m_pending_writes[mf_next->get_inst().warp_id()]
+                                    [mf_next->get_inst().out[r]];
+              if (!still_pending) {
+                m_pending_writes[mf_next->get_inst().warp_id()].erase(
+                    mf_next->get_inst().out[r]);
+                m_scoreboard->releaseRegister(mf_next->get_inst().warp_id(),
+                                              mf_next->get_inst().out[r]);
+                m_core->warp_inst_complete(mf_next->get_inst());
+              }
+            }
         }
+
+        // For write hit in WB policy
+        if (mf_next->get_inst().is_store() && !write_sent) {
+          unsigned dec_ack =
+              (m_config->m_L1D_config.get_mshr_type() == SECTOR_ASSOC)
+                  ? (mf_next->get_data_size() / SECTOR_SIZE)
+                  : 1;
+
+          mf_next->set_reply();
+
+          for (unsigned i = 0; i < dec_ack; ++i) m_core->store_ack(mf_next);
+        }
+
+        if (!write_sent) delete mf_next;
+
+      } else if (status == RESERVATION_FAIL) {
+        assert(!read_sent);
+        assert(!write_sent);
+      } else {
+        assert(status == MISS || status == HIT_RESERVED);
+        l1_latency_queue[j][0] = NULL;
+      }
     }
-    occupied >>=1;
+
+    for (unsigned stage = 0; stage < m_config->m_L1D_config.l1_latency - 1;
+         ++stage)
+      if (l1_latency_queue[j][stage] == NULL) {
+        l1_latency_queue[j][stage] = l1_latency_queue[j][stage + 1];
+        l1_latency_queue[j][stage + 1] = NULL;
+      }
+  }
 }
 
+bool ldst_unit::constant_cycle(warp_inst_t &inst, mem_stage_stall_type &rc_fail,
+                               mem_stage_access_type &fail_type) {
+  if (inst.empty() || ((inst.space.get_type() != const_space) &&
+                       (inst.space.get_type() != param_space_kernel)))
+    return true;
+  if (inst.active_count() == 0) return true;
+  mem_stage_stall_type fail = process_memory_access_queue(m_L1C, inst);
+  if (fail != NO_RC_FAIL) {
+    rc_fail = fail;  // keep other fails if this didn't fail.
+    fail_type = C_MEM;
+    if (rc_fail == BK_CONF or rc_fail == COAL_STALL) {
+      m_stats->gpgpu_n_cmem_portconflict++;  // coal stalls aren't really a bank
+                                             // conflict, but this maintains
+                                             // previous behavior.
+    }
+  }
+  return inst.accessq_empty();  // done if empty.
+}
 
-void pipelined_simd_unit::issue( register_set& source_reg )
-{
-    //move_warp(m_dispatch_reg,source_reg);
-    warp_inst_t** ready_reg = source_reg.get_ready();
-	m_core->incexecstat((*ready_reg));
-	//source_reg.move_out_to(m_dispatch_reg);
-	simd_function_unit::issue(source_reg);
+bool ldst_unit::texture_cycle(warp_inst_t &inst, mem_stage_stall_type &rc_fail,
+                              mem_stage_access_type &fail_type) {
+  if (inst.empty() || inst.space.get_type() != tex_space) return true;
+  if (inst.active_count() == 0) return true;
+  mem_stage_stall_type fail = process_memory_access_queue(m_L1T, inst);
+  if (fail != NO_RC_FAIL) {
+    rc_fail = fail;  // keep other fails if this didn't fail.
+    fail_type = T_MEM;
+  }
+  return inst.accessq_empty();  // done if empty.
+}
+
+bool ldst_unit::memory_cycle(warp_inst_t &inst,
+                             mem_stage_stall_type &stall_reason,
+                             mem_stage_access_type &access_type) {
+  if (inst.empty() || ((inst.space.get_type() != global_space) &&
+                       (inst.space.get_type() != local_space) &&
+                       (inst.space.get_type() != param_space_local)))
+    return true;
+  if (inst.active_count() == 0) return true;
+  assert(!inst.accessq_empty());
+  mem_stage_stall_type stall_cond = NO_RC_FAIL;
+  const mem_access_t &access = inst.accessq_back();
+
+  bool bypassL1D = false;
+  if (CACHE_GLOBAL == inst.cache_op || (m_L1D == NULL)) {
+    bypassL1D = true;
+  } else if (inst.space.is_global()) {  // global memory access
+    // skip L1 cache if the option is enabled
+    if (m_core->get_config()->gmem_skip_L1D && (CACHE_L1 != inst.cache_op))
+      bypassL1D = true;
+  }
+  if (bypassL1D) {
+    // bypass L1 cache
+    unsigned control_size =
+        inst.is_store() ? WRITE_PACKET_SIZE : READ_PACKET_SIZE;
+    unsigned size = access.get_size() + control_size;
+    // printf("Interconnect:Addr: %x, size=%d\n",access.get_addr(),size);
+    if (m_icnt->full(size, inst.is_store() || inst.isatomic())) {
+      stall_cond = ICNT_RC_FAIL;
+    } else {
+      mem_fetch *mf = m_mf_allocator->alloc(
+          inst, access, m_core->get_gpu()->gpu_sim_cycle +
+                            m_core->get_gpu()->gpu_tot_sim_cycle);
+      m_icnt->push(mf);
+      inst.accessq_pop_back();
+      // inst.clear_active( access.get_warp_mask() );
+      if (inst.is_load()) {
+        for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++)
+          if (inst.out[r] > 0)
+            assert(m_pending_writes[inst.warp_id()][inst.out[r]] > 0);
+      } else if (inst.is_store())
+        m_core->inc_store_req(inst.warp_id());
+    }
+  } else {
+    assert(CACHE_UNDEFINED != inst.cache_op);
+    stall_cond = process_memory_access_queue_l1cache(m_L1D, inst);
+  }
+  if (!inst.accessq_empty() && stall_cond == NO_RC_FAIL)
+    stall_cond = COAL_STALL;
+  if (stall_cond != NO_RC_FAIL) {
+    stall_reason = stall_cond;
+    bool iswrite = inst.is_store();
+    if (inst.space.is_local())
+      access_type = (iswrite) ? L_MEM_ST : L_MEM_LD;
+    else
+      access_type = (iswrite) ? G_MEM_ST : G_MEM_LD;
+  }
+  return inst.accessq_empty();
+}
+
+bool ldst_unit::response_buffer_full() const {
+  return m_response_fifo.size() >= m_config->ldst_unit_response_queue_size;
+}
+
+void ldst_unit::fill(mem_fetch *mf) {
+  mf->set_status(
+      IN_SHADER_LDST_RESPONSE_FIFO,
+      m_core->get_gpu()->gpu_sim_cycle + m_core->get_gpu()->gpu_tot_sim_cycle);
+  m_response_fifo.push_back(mf);
+}
+
+void ldst_unit::flush() {
+  // Flush L1D cache
+  m_L1D->flush();
+}
+
+void ldst_unit::invalidate() {
+  // Flush L1D cache
+  m_L1D->invalidate();
+}
+
+simd_function_unit::simd_function_unit(const shader_core_config *config) {
+  m_config = config;
+  m_dispatch_reg = new warp_inst_t(config);
+}
+
+sfu::sfu(register_set *result_port, const shader_core_config *config,
+         shader_core_ctx *core)
+    : pipelined_simd_unit(result_port, config, config->max_sfu_latency, core) {
+  m_name = "SFU";
+}
+
+tensor_core::tensor_core(register_set *result_port,
+                         const shader_core_config *config,
+                         shader_core_ctx *core)
+    : pipelined_simd_unit(result_port, config, config->max_tensor_core_latency,
+                          core) {
+  m_name = "TENSOR_CORE";
+}
+
+void sfu::issue(register_set &source_reg) {
+  warp_inst_t **ready_reg = source_reg.get_ready();
+  // m_core->incexecstat((*ready_reg));
+
+  (*ready_reg)->op_pipe = SFU__OP;
+  m_core->incsfu_stat(m_core->get_config()->warp_size, (*ready_reg)->latency);
+  pipelined_simd_unit::issue(source_reg);
+}
+
+void tensor_core::issue(register_set &source_reg) {
+  warp_inst_t **ready_reg = source_reg.get_ready();
+  // m_core->incexecstat((*ready_reg));
+
+  (*ready_reg)->op_pipe = TENSOR_CORE__OP;
+  m_core->incsfu_stat(m_core->get_config()->warp_size, (*ready_reg)->latency);
+  pipelined_simd_unit::issue(source_reg);
+}
+
+unsigned pipelined_simd_unit::get_active_lanes_in_pipeline() {
+  active_mask_t active_lanes;
+  active_lanes.reset();
+  if (m_core->get_gpu()->get_config().g_power_simulation_enabled) {
+    for (unsigned stage = 0; (stage + 1) < m_pipeline_depth; stage++) {
+      if (!m_pipeline_reg[stage]->empty())
+        active_lanes |= m_pipeline_reg[stage]->get_active_mask();
+    }
+  }
+  return active_lanes.count();
+}
+
+void ldst_unit::active_lanes_in_pipeline() {
+  unsigned active_count = pipelined_simd_unit::get_active_lanes_in_pipeline();
+  assert(active_count <= m_core->get_config()->warp_size);
+  m_core->incfumemactivelanes_stat(active_count);
+}
+
+void sp_unit::active_lanes_in_pipeline() {
+  unsigned active_count = pipelined_simd_unit::get_active_lanes_in_pipeline();
+  assert(active_count <= m_core->get_config()->warp_size);
+  m_core->incspactivelanes_stat(active_count);
+  m_core->incfuactivelanes_stat(active_count);
+  m_core->incfumemactivelanes_stat(active_count);
+}
+void dp_unit::active_lanes_in_pipeline() {
+  unsigned active_count = pipelined_simd_unit::get_active_lanes_in_pipeline();
+  assert(active_count <= m_core->get_config()->warp_size);
+  m_core->incspactivelanes_stat(active_count);
+  m_core->incfuactivelanes_stat(active_count);
+  m_core->incfumemactivelanes_stat(active_count);
+}
+
+void int_unit::active_lanes_in_pipeline() {
+  unsigned active_count = pipelined_simd_unit::get_active_lanes_in_pipeline();
+  assert(active_count <= m_core->get_config()->warp_size);
+  m_core->incspactivelanes_stat(active_count);
+  m_core->incfuactivelanes_stat(active_count);
+  m_core->incfumemactivelanes_stat(active_count);
+}
+void sfu::active_lanes_in_pipeline() {
+  unsigned active_count = pipelined_simd_unit::get_active_lanes_in_pipeline();
+  assert(active_count <= m_core->get_config()->warp_size);
+  m_core->incsfuactivelanes_stat(active_count);
+  m_core->incfuactivelanes_stat(active_count);
+  m_core->incfumemactivelanes_stat(active_count);
+}
+
+void tensor_core::active_lanes_in_pipeline() {
+  unsigned active_count = pipelined_simd_unit::get_active_lanes_in_pipeline();
+  assert(active_count <= m_core->get_config()->warp_size);
+  m_core->incsfuactivelanes_stat(active_count);
+  m_core->incfuactivelanes_stat(active_count);
+  m_core->incfumemactivelanes_stat(active_count);
+}
+
+sp_unit::sp_unit(register_set *result_port, const shader_core_config *config,
+                 shader_core_ctx *core)
+    : pipelined_simd_unit(result_port, config, config->max_sp_latency, core) {
+  m_name = "SP ";
+}
+
+dp_unit::dp_unit(register_set *result_port, const shader_core_config *config,
+                 shader_core_ctx *core)
+    : pipelined_simd_unit(result_port, config, config->max_dp_latency, core) {
+  m_name = "DP ";
+}
+
+int_unit::int_unit(register_set *result_port, const shader_core_config *config,
+                   shader_core_ctx *core)
+    : pipelined_simd_unit(result_port, config, config->max_int_latency, core) {
+  m_name = "INT ";
+}
+
+void sp_unit::issue(register_set &source_reg) {
+  warp_inst_t **ready_reg = source_reg.get_ready();
+  // m_core->incexecstat((*ready_reg));
+  (*ready_reg)->op_pipe = SP__OP;
+  m_core->incsp_stat(m_core->get_config()->warp_size, (*ready_reg)->latency);
+  pipelined_simd_unit::issue(source_reg);
+}
+
+void dp_unit::issue(register_set &source_reg) {
+  warp_inst_t **ready_reg = source_reg.get_ready();
+  // m_core->incexecstat((*ready_reg));
+  (*ready_reg)->op_pipe = DP__OP;
+  m_core->incsp_stat(m_core->get_config()->warp_size, (*ready_reg)->latency);
+  pipelined_simd_unit::issue(source_reg);
+}
+
+void int_unit::issue(register_set &source_reg) {
+  warp_inst_t **ready_reg = source_reg.get_ready();
+  // m_core->incexecstat((*ready_reg));
+  (*ready_reg)->op_pipe = INTP__OP;
+  m_core->incsp_stat(m_core->get_config()->warp_size, (*ready_reg)->latency);
+  pipelined_simd_unit::issue(source_reg);
+}
+
+pipelined_simd_unit::pipelined_simd_unit(register_set *result_port,
+                                         const shader_core_config *config,
+                                         unsigned max_latency,
+                                         shader_core_ctx *core)
+    : simd_function_unit(config) {
+  m_result_port = result_port;
+  m_pipeline_depth = max_latency;
+  m_pipeline_reg = new warp_inst_t *[m_pipeline_depth];
+  for (unsigned i = 0; i < m_pipeline_depth; i++)
+    m_pipeline_reg[i] = new warp_inst_t(config);
+  m_core = core;
+  active_insts_in_pipeline = 0;
+}
+
+void pipelined_simd_unit::cycle() {
+  if (!m_pipeline_reg[0]->empty()) {
+    m_result_port->move_in(m_pipeline_reg[0]);
+    assert(active_insts_in_pipeline > 0);
+    active_insts_in_pipeline--;
+  }
+  if (active_insts_in_pipeline) {
+    for (unsigned stage = 0; (stage + 1) < m_pipeline_depth; stage++)
+      move_warp(m_pipeline_reg[stage], m_pipeline_reg[stage + 1]);
+  }
+  if (!m_dispatch_reg->empty()) {
+    if (!m_dispatch_reg->dispatch_delay()) {
+      int start_stage =
+          m_dispatch_reg->latency - m_dispatch_reg->initiation_interval;
+      move_warp(m_pipeline_reg[start_stage], m_dispatch_reg);
+      active_insts_in_pipeline++;
+    }
+  }
+  occupied >>= 1;
+}
+
+void pipelined_simd_unit::issue(register_set &source_reg) {
+  // move_warp(m_dispatch_reg,source_reg);
+  warp_inst_t **ready_reg = source_reg.get_ready();
+  m_core->incexecstat((*ready_reg));
+  // source_reg.move_out_to(m_dispatch_reg);
+  simd_function_unit::issue(source_reg);
 }
 
 /*
@@ -2073,117 +2170,222 @@ void pipelined_simd_unit::issue( register_set& source_reg )
     }
 */
 
-void ldst_unit::init( mem_fetch_interface *icnt,
-                      shader_core_mem_fetch_allocator *mf_allocator,
-                      shader_core_ctx *core, 
-                      opndcoll_rfu_t *operand_collector,
-                      Scoreboard *scoreboard,
-                      const shader_core_config *config,
-                      const memory_config *mem_config,  
-                      shader_core_stats *stats,
-                      unsigned sid,
-                      unsigned tpc )
-{
-    m_memory_config = mem_config;
-    m_icnt = icnt;
-    m_mf_allocator=mf_allocator;
-    m_core = core;
-    m_operand_collector = operand_collector;
-    m_scoreboard = scoreboard;
-    m_stats = stats;
-    m_sid = sid;
-    m_tpc = tpc;
-    #define STRSIZE 1024
-    char L1T_name[STRSIZE];
-    char L1C_name[STRSIZE];
-    snprintf(L1T_name, STRSIZE, "L1T_%03d", m_sid);
-    snprintf(L1C_name, STRSIZE, "L1C_%03d", m_sid);
-    m_L1T = new tex_cache(L1T_name,m_config->m_L1T_config,m_sid,get_shader_texture_cache_id(),icnt,IN_L1T_MISS_QUEUE,IN_SHADER_L1T_ROB);
-    m_L1C = new read_only_cache(L1C_name,m_config->m_L1C_config,m_sid,get_shader_constant_cache_id(),icnt,IN_L1C_MISS_QUEUE);
-    m_L1D = NULL;
-    m_mem_rc = NO_RC_FAIL;
-    m_num_writeback_clients=5; // = shared memory, global/local (uncached), L1D, L1T, L1C
-    m_writeback_arb = 0;
-    m_next_global=NULL;
-    m_last_inst_gpu_sim_cycle=0;
-    m_last_inst_gpu_tot_sim_cycle=0;
+void ldst_unit::init(mem_fetch_interface *icnt,
+                     shader_core_mem_fetch_allocator *mf_allocator,
+                     shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
+                     Scoreboard *scoreboard, const shader_core_config *config,
+                     const memory_config *mem_config, shader_core_stats *stats,
+                     unsigned sid, unsigned tpc) {
+  m_memory_config = mem_config;
+  m_icnt = icnt;
+  m_mf_allocator = mf_allocator;
+  m_core = core;
+  m_operand_collector = operand_collector;
+  m_scoreboard = scoreboard;
+  m_stats = stats;
+  m_sid = sid;
+  m_tpc = tpc;
+#define STRSIZE 1024
+  char L1T_name[STRSIZE];
+  char L1C_name[STRSIZE];
+  snprintf(L1T_name, STRSIZE, "L1T_%03d", m_sid);
+  snprintf(L1C_name, STRSIZE, "L1C_%03d", m_sid);
+  m_L1T = new tex_cache(L1T_name, m_config->m_L1T_config, m_sid,
+                        get_shader_texture_cache_id(), icnt, IN_L1T_MISS_QUEUE,
+                        IN_SHADER_L1T_ROB);
+  m_L1C = new read_only_cache(L1C_name, m_config->m_L1C_config, m_sid,
+                              get_shader_constant_cache_id(), icnt,
+                              IN_L1C_MISS_QUEUE);
+  m_L1D = NULL;
+  m_mem_rc = NO_RC_FAIL;
+  m_num_writeback_clients =
+      5;  // = shared memory, global/local (uncached), L1D, L1T, L1C
+  m_writeback_arb = 0;
+  m_next_global = NULL;
+  m_last_inst_gpu_sim_cycle = 0;
+  m_last_inst_gpu_tot_sim_cycle = 0;
 }
 
+ldst_unit::ldst_unit(mem_fetch_interface *icnt,
+                     shader_core_mem_fetch_allocator *mf_allocator,
+                     shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
+                     Scoreboard *scoreboard, const shader_core_config *config,
+                     const memory_config *mem_config, shader_core_stats *stats,
+                     unsigned sid, unsigned tpc)
+    : pipelined_simd_unit(NULL, config, config->smem_latency, core),
+      m_next_wb(config) {
+  assert(config->smem_latency > 1);
+  init(icnt, mf_allocator, core, operand_collector, scoreboard, config,
+       mem_config, stats, sid, tpc);
+  if (!m_config->m_L1D_config.disabled()) {
+    char L1D_name[STRSIZE];
+    snprintf(L1D_name, STRSIZE, "L1D_%03d", m_sid);
+    m_L1D = new l1_cache(L1D_name, m_config->m_L1D_config, m_sid,
+                         get_shader_normal_cache_id(), m_icnt, m_mf_allocator,
+                         IN_L1D_MISS_QUEUE, core->get_gpu());
 
-ldst_unit::ldst_unit( mem_fetch_interface *icnt,
-                      shader_core_mem_fetch_allocator *mf_allocator,
-                      shader_core_ctx *core, 
-                      opndcoll_rfu_t *operand_collector,
-                      Scoreboard *scoreboard,
-                      const shader_core_config *config,
-                      const memory_config *mem_config,  
-                      shader_core_stats *stats,
-                      unsigned sid,
-                      unsigned tpc ) : pipelined_simd_unit(NULL,config,config->smem_latency,core), m_next_wb(config)
-{
-	assert(config->smem_latency > 1);
-    init( icnt,
-          mf_allocator,
-          core, 
-          operand_collector,
-          scoreboard,
-          config, 
-          mem_config,  
-          stats, 
-          sid,
-          tpc );
-    if( !m_config->m_L1D_config.disabled() ) {
-        char L1D_name[STRSIZE];
-        snprintf(L1D_name, STRSIZE, "L1D_%03d", m_sid);
-        m_L1D = new l1_cache( L1D_name,
-                              m_config->m_L1D_config,
-                              m_sid,
-                              get_shader_normal_cache_id(),
-                              m_icnt,
-                              m_mf_allocator,
-                              IN_L1D_MISS_QUEUE,
-							  core->get_gpu());
+    l1_latency_queue.resize(m_config->m_L1D_config.l1_banks);
+    assert(m_config->m_L1D_config.l1_latency > 0);
 
-        l1_latency_queue.resize(m_config->m_L1D_config.l1_banks);
-        assert(m_config->m_L1D_config.l1_latency > 0);
+    for (unsigned j = 0; j < m_config->m_L1D_config.l1_banks; j++)
+      l1_latency_queue[j].resize(m_config->m_L1D_config.l1_latency,
+                                 (mem_fetch *)NULL);
+  }
+  m_name = "MEM ";
+}
 
-		for(unsigned j = 0; j < m_config->m_L1D_config.l1_banks; j++ )
-			l1_latency_queue[j].resize(m_config->m_L1D_config.l1_latency,(mem_fetch*)NULL);
+ldst_unit::ldst_unit(mem_fetch_interface *icnt,
+                     shader_core_mem_fetch_allocator *mf_allocator,
+                     shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
+                     Scoreboard *scoreboard, const shader_core_config *config,
+                     const memory_config *mem_config, shader_core_stats *stats,
+                     unsigned sid, unsigned tpc, l1_cache *new_l1d_cache)
+    : pipelined_simd_unit(NULL, config, 3, core),
+      m_L1D(new_l1d_cache),
+      m_next_wb(config) {
+  init(icnt, mf_allocator, core, operand_collector, scoreboard, config,
+       mem_config, stats, sid, tpc);
+}
 
+void ldst_unit::issue(register_set &reg_set) {
+  warp_inst_t *inst = *(reg_set.get_ready());
+
+  // record how many pending register writes/memory accesses there are for this
+  // instruction
+  assert(inst->empty() == false);
+  if (inst->is_load() and inst->space.get_type() != shared_space) {
+    unsigned warp_id = inst->warp_id();
+    unsigned n_accesses = inst->accessq_count();
+    for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++) {
+      unsigned reg_id = inst->out[r];
+      if (reg_id > 0) {
+        m_pending_writes[warp_id][reg_id] += n_accesses;
+      }
     }
-    m_name = "MEM ";
+  }
+
+  inst->op_pipe = MEM__OP;
+  // stat collection
+  m_core->mem_instruction_stats(*inst);
+  m_core->incmem_stat(m_core->get_config()->warp_size, 1);
+  pipelined_simd_unit::issue(reg_set);
 }
 
-ldst_unit::ldst_unit( mem_fetch_interface *icnt,
-                      shader_core_mem_fetch_allocator *mf_allocator,
-                      shader_core_ctx *core, 
-                      opndcoll_rfu_t *operand_collector,
-                      Scoreboard *scoreboard,
-                      const shader_core_config *config,
-                      const memory_config *mem_config,  
-                      shader_core_stats *stats,
-                      unsigned sid,
-                      unsigned tpc,
-                      l1_cache* new_l1d_cache )
-    : pipelined_simd_unit(NULL,config,3,core), m_L1D(new_l1d_cache), m_next_wb(config)
-{
-    init( icnt,
-          mf_allocator,
-          core, 
-          operand_collector,
-          scoreboard,
-          config, 
-          mem_config,  
-          stats, 
-          sid,
-          tpc );
+void ldst_unit::writeback() {
+  // process next instruction that is going to writeback
+  if (!m_next_wb.empty()) {
+    if (m_operand_collector->writeback(m_next_wb)) {
+      bool insn_completed = false;
+      for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++) {
+        if (m_next_wb.out[r] > 0) {
+          if (m_next_wb.space.get_type() != shared_space) {
+            assert(m_pending_writes[m_next_wb.warp_id()][m_next_wb.out[r]] > 0);
+            unsigned still_pending =
+                --m_pending_writes[m_next_wb.warp_id()][m_next_wb.out[r]];
+            if (!still_pending) {
+              m_pending_writes[m_next_wb.warp_id()].erase(m_next_wb.out[r]);
+              m_scoreboard->releaseRegister(m_next_wb.warp_id(),
+                                            m_next_wb.out[r]);
+              insn_completed = true;
+            }
+          } else {  // shared
+            m_scoreboard->releaseRegister(m_next_wb.warp_id(),
+                                          m_next_wb.out[r]);
+            insn_completed = true;
+          }
+        }
+      }
+      if (insn_completed) {
+        m_core->warp_inst_complete(m_next_wb);
+      }
+      m_next_wb.clear();
+      m_last_inst_gpu_sim_cycle = m_core->get_gpu()->gpu_sim_cycle;
+      m_last_inst_gpu_tot_sim_cycle = m_core->get_gpu()->gpu_tot_sim_cycle;
+    }
+  }
+
+  unsigned serviced_client = -1;
+  for (unsigned c = 0; m_next_wb.empty() && (c < m_num_writeback_clients);
+       c++) {
+    unsigned next_client = (c + m_writeback_arb) % m_num_writeback_clients;
+    switch (next_client) {
+      case 0:  // shared memory
+        if (!m_pipeline_reg[0]->empty()) {
+          m_next_wb = *m_pipeline_reg[0];
+          if (m_next_wb.isatomic()) {
+            m_next_wb.do_atomic();
+            m_core->decrement_atomic_count(m_next_wb.warp_id(),
+                                           m_next_wb.active_count());
+          }
+          m_core->dec_inst_in_pipeline(m_pipeline_reg[0]->warp_id());
+          m_pipeline_reg[0]->clear();
+          serviced_client = next_client;
+        }
+        break;
+      case 1:  // texture response
+        if (m_L1T->access_ready()) {
+          mem_fetch *mf = m_L1T->next_access();
+          m_next_wb = mf->get_inst();
+          delete mf;
+          serviced_client = next_client;
+        }
+        break;
+      case 2:  // const cache response
+        if (m_L1C->access_ready()) {
+          mem_fetch *mf = m_L1C->next_access();
+          m_next_wb = mf->get_inst();
+          delete mf;
+          serviced_client = next_client;
+        }
+        break;
+      case 3:  // global/local
+        if (m_next_global) {
+          m_next_wb = m_next_global->get_inst();
+          if (m_next_global->isatomic())
+            m_core->decrement_atomic_count(
+                m_next_global->get_wid(),
+                m_next_global->get_access_warp_mask().count());
+          delete m_next_global;
+          m_next_global = NULL;
+          serviced_client = next_client;
+        }
+        break;
+      case 4:
+        if (m_L1D && m_L1D->access_ready()) {
+          mem_fetch *mf = m_L1D->next_access();
+          m_next_wb = mf->get_inst();
+          delete mf;
+          serviced_client = next_client;
+        }
+        break;
+      default:
+        abort();
+    }
+  }
+  // update arbitration priority only if:
+  // 1. the writeback buffer was available
+  // 2. a client was serviced
+  if (serviced_client != (unsigned)-1) {
+    m_writeback_arb = (serviced_client + 1) % m_num_writeback_clients;
+  }
 }
 
-void ldst_unit:: issue( register_set &reg_set )
+unsigned ldst_unit::clock_multiplier() const {
+  // to model multiple read port, we give multiple cycles for the memory units
+  if (m_config->mem_unit_ports)
+    return m_config->mem_unit_ports;
+  else
+    return m_config->mem_warp_parts;
+}
+/*
+void ldst_unit::issue( register_set &reg_set )
 {
-	warp_inst_t* inst = *(reg_set.get_ready());
+        warp_inst_t* inst = *(reg_set.get_ready());
+   // stat collection
+   m_core->mem_instruction_stats(*inst);
 
-   // record how many pending register writes/memory accesses there are for this instruction
+   // record how many pending register writes/memory accesses there are for this
+instruction
    assert(inst->empty() == false);
    if (inst->is_load() and inst->space.get_type() != shared_space) {
       unsigned warp_id = inst->warp_id();
@@ -2196,1951 +2398,1884 @@ void ldst_unit:: issue( register_set &reg_set )
       }
    }
 
-
-	inst->op_pipe=MEM__OP;
-	// stat collection
-	m_core->mem_instruction_stats(*inst);
-	m_core->incmem_stat(m_core->get_config()->warp_size,1);
-	pipelined_simd_unit::issue(reg_set);
-}
-
-void ldst_unit::writeback()
-{
-    // process next instruction that is going to writeback
-    if( !m_next_wb.empty() ) {
-        if( m_operand_collector->writeback(m_next_wb) ) {
-            bool insn_completed = false; 
-            for( unsigned r=0; r < MAX_OUTPUT_VALUES; r++ ) {
-                if( m_next_wb.out[r] > 0 ) {
-                    if( m_next_wb.space.get_type() != shared_space ) {
-                        assert( m_pending_writes[m_next_wb.warp_id()][m_next_wb.out[r]] > 0 );
-                        unsigned still_pending = --m_pending_writes[m_next_wb.warp_id()][m_next_wb.out[r]];
-                        if( !still_pending ) {
-                            m_pending_writes[m_next_wb.warp_id()].erase(m_next_wb.out[r]);
-                            m_scoreboard->releaseRegister( m_next_wb.warp_id(), m_next_wb.out[r] );
-                            insn_completed = true; 
-                        }
-                    } else { // shared 
-                        m_scoreboard->releaseRegister( m_next_wb.warp_id(), m_next_wb.out[r] );
-                        insn_completed = true; 
-                    }
-                }
-            }
-            if( insn_completed ) {
-                m_core->warp_inst_complete(m_next_wb);
-            }
-            m_next_wb.clear();
-            m_last_inst_gpu_sim_cycle = m_core->get_gpu()->gpu_sim_cycle;
-            m_last_inst_gpu_tot_sim_cycle = m_core->get_gpu()->gpu_tot_sim_cycle;
-        }
-    }
-
-    unsigned serviced_client = -1; 
-    for( unsigned c = 0; m_next_wb.empty() && (c < m_num_writeback_clients); c++ ) {
-        unsigned next_client = (c+m_writeback_arb)%m_num_writeback_clients;
-        switch( next_client ) {
-        case 0: // shared memory 
-            if( !m_pipeline_reg[0]->empty() ) {
-                m_next_wb = *m_pipeline_reg[0];
-                if(m_next_wb.isatomic()) {
-                    m_next_wb.do_atomic();
-                    m_core->decrement_atomic_count(m_next_wb.warp_id(), m_next_wb.active_count());
-                }
-                m_core->dec_inst_in_pipeline(m_pipeline_reg[0]->warp_id());
-                m_pipeline_reg[0]->clear();
-                serviced_client = next_client; 
-            }
-            break;
-        case 1: // texture response
-            if( m_L1T->access_ready() ) {
-                mem_fetch *mf = m_L1T->next_access();
-                m_next_wb = mf->get_inst();
-                delete mf;
-                serviced_client = next_client; 
-            }
-            break;
-        case 2: // const cache response
-            if( m_L1C->access_ready() ) {
-                mem_fetch *mf = m_L1C->next_access();
-                m_next_wb = mf->get_inst();
-                delete mf;
-                serviced_client = next_client; 
-            }
-            break;
-        case 3: // global/local
-            if( m_next_global ) {
-                m_next_wb = m_next_global->get_inst();
-                if( m_next_global->isatomic() ) 
-                    m_core->decrement_atomic_count(m_next_global->get_wid(),m_next_global->get_access_warp_mask().count());
-                delete m_next_global;
-                m_next_global = NULL;
-                serviced_client = next_client; 
-            }
-            break;
-        case 4: 
-            if( m_L1D && m_L1D->access_ready() ) {
-                mem_fetch *mf = m_L1D->next_access();
-                m_next_wb = mf->get_inst();
-                delete mf;
-                serviced_client = next_client; 
-            }
-            break;
-        default: abort();
-        }
-    }
-    // update arbitration priority only if: 
-    // 1. the writeback buffer was available 
-    // 2. a client was serviced 
-    if (serviced_client != (unsigned)-1) {
-        m_writeback_arb = (serviced_client + 1) % m_num_writeback_clients; 
-    }
-}
-
-unsigned ldst_unit::clock_multiplier() const
-{ 
-	//to model multiple read port, we give multiple cycles for the memory units
-	if(m_config->mem_unit_ports)
-		return m_config->mem_unit_ports;
-	else
-		return m_config->mem_warp_parts;
-}
-/*
-void ldst_unit::issue( register_set &reg_set )
-{
-	warp_inst_t* inst = *(reg_set.get_ready());
-   // stat collection
-   m_core->mem_instruction_stats(*inst); 
-
-   // record how many pending register writes/memory accesses there are for this instruction 
-   assert(inst->empty() == false); 
-   if (inst->is_load() and inst->space.get_type() != shared_space) {
-      unsigned warp_id = inst->warp_id(); 
-      unsigned n_accesses = inst->accessq_count(); 
-      for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++) {
-         unsigned reg_id = inst->out[r]; 
-         if (reg_id > 0) {
-            m_pending_writes[warp_id][reg_id] += n_accesses; 
-         }
-      }
-   }
-
    pipelined_simd_unit::issue(reg_set);
 }
 */
-void ldst_unit::cycle()
-{
-   writeback();
-   m_operand_collector->step();
-   for( unsigned stage=0; (stage+1)<m_pipeline_depth; stage++ ) 
-       if( m_pipeline_reg[stage]->empty() && !m_pipeline_reg[stage+1]->empty() )
-            move_warp(m_pipeline_reg[stage], m_pipeline_reg[stage+1]);
+void ldst_unit::cycle() {
+  writeback();
+  m_operand_collector->step();
+  for (unsigned stage = 0; (stage + 1) < m_pipeline_depth; stage++)
+    if (m_pipeline_reg[stage]->empty() && !m_pipeline_reg[stage + 1]->empty())
+      move_warp(m_pipeline_reg[stage], m_pipeline_reg[stage + 1]);
 
-   if( !m_response_fifo.empty() ) {
-       mem_fetch *mf = m_response_fifo.front();
-       if (mf->get_access_type() == TEXTURE_ACC_R) {
-           if (m_L1T->fill_port_free()) {
-               m_L1T->fill(mf,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
-               m_response_fifo.pop_front(); 
-           }
-       } else if (mf->get_access_type() == CONST_ACC_R)  {
-           if (m_L1C->fill_port_free()) {
-               mf->set_status(IN_SHADER_FETCHED,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
-               m_L1C->fill(mf,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
-               m_response_fifo.pop_front(); 
-           }
-       } else {
-    	   if( mf->get_type() == WRITE_ACK || ( m_config->gpgpu_perfect_mem && mf->get_is_write() )) {
-               m_core->store_ack(mf);
-               m_response_fifo.pop_front();
-               delete mf;
-           } else {
-               assert( !mf->get_is_write() ); // L1 cache is write evict, allocate line on load miss only
-
-               bool bypassL1D = false; 
-               if ( CACHE_GLOBAL == mf->get_inst().cache_op || (m_L1D == NULL) ) {
-                   bypassL1D = true; 
-               } else if (mf->get_access_type() == GLOBAL_ACC_R || mf->get_access_type() == GLOBAL_ACC_W) { // global memory access 
-                   if (m_core->get_config()->gmem_skip_L1D)
-                       bypassL1D = true; 
-               }
-               if( bypassL1D ) {
-                   if ( m_next_global == NULL ) {
-                       mf->set_status(IN_SHADER_FETCHED,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
-                       m_response_fifo.pop_front();
-                       m_next_global = mf;
-                   }
-               } else {
-                   if (m_L1D->fill_port_free()) {
-                       m_L1D->fill(mf,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
-                       m_response_fifo.pop_front();
-                   }
-               }
-           }
-       }
-   }
-
-   m_L1T->cycle();
-   m_L1C->cycle();
-   if( m_L1D ) {
-	   m_L1D->cycle();
-	   if(m_config->m_L1D_config.l1_latency > 0)
-	   		L1_latency_queue_cycle();
-   }
-
-   warp_inst_t &pipe_reg = *m_dispatch_reg;
-   enum mem_stage_stall_type rc_fail = NO_RC_FAIL;
-   mem_stage_access_type type;
-   bool done = true;
-   done &= shared_cycle(pipe_reg, rc_fail, type);
-   done &= constant_cycle(pipe_reg, rc_fail, type);
-   done &= texture_cycle(pipe_reg, rc_fail, type);
-   done &= memory_cycle(pipe_reg, rc_fail, type);
-   m_mem_rc = rc_fail;
-
-   if (!done) { // log stall types and return
-      assert(rc_fail != NO_RC_FAIL);
-      m_stats->gpgpu_n_stall_shd_mem++;
-      m_stats->gpu_stall_shd_mem_breakdown[type][rc_fail]++;
-      return;
-   }
-
-   if( !pipe_reg.empty() ) {
-       unsigned warp_id = pipe_reg.warp_id();
-       if( pipe_reg.is_load() ) {
-           if( pipe_reg.space.get_type() == shared_space ) {
-               if( m_pipeline_reg[m_config->smem_latency-1]->empty() ) {
-                   // new shared memory request
-                   move_warp(m_pipeline_reg[m_config->smem_latency-1],m_dispatch_reg);
-                   m_dispatch_reg->clear();
-               }
-           } else {
-               //if( pipe_reg.active_count() > 0 ) {
-               //    if( !m_operand_collector->writeback(pipe_reg) ) 
-               //        return;
-               //} 
-
-               bool pending_requests=false;
-               for( unsigned r=0; r<MAX_OUTPUT_VALUES; r++ ) {
-                   unsigned reg_id = pipe_reg.out[r];
-                   if( reg_id > 0 ) {
-                       if( m_pending_writes[warp_id].find(reg_id) != m_pending_writes[warp_id].end() ) {
-                           if ( m_pending_writes[warp_id][reg_id] > 0 ) {
-                               pending_requests=true;
-                               break;
-                           } else {
-                               // this instruction is done already
-                               m_pending_writes[warp_id].erase(reg_id); 
-                           }
-                       }
-                   }
-               }
-               if( !pending_requests ) {
-                   m_core->warp_inst_complete(*m_dispatch_reg);
-                   m_scoreboard->releaseRegisters(m_dispatch_reg);
-               }
-               m_core->dec_inst_in_pipeline(warp_id);
-               m_dispatch_reg->clear();
-           }
-       } else {
-           // stores exit pipeline here
-           m_core->dec_inst_in_pipeline(warp_id);
-           m_core->warp_inst_complete(*m_dispatch_reg);
-           m_dispatch_reg->clear();
-       }
-   }
-}
-
-void shader_core_ctx::register_cta_thread_exit( unsigned cta_num, kernel_info_t * kernel)
-{
-   assert( m_cta_status[cta_num] > 0 );
-   m_cta_status[cta_num]--;
-   if (!m_cta_status[cta_num]) {
-      m_n_active_cta--;
-      m_barriers.deallocate_barrier(cta_num);
-      shader_CTA_count_unlog(m_sid, 1);
-
-     SHADER_DPRINTF(LIVENESS, "GPGPU-Sim uArch: Finished CTA #%u (%lld,%lld), %u CTAs running\n",
-        cta_num, m_gpu->gpu_sim_cycle, m_gpu->gpu_tot_sim_cycle, m_n_active_cta);
-
-      if( m_n_active_cta == 0 ) {
-        SHADER_DPRINTF(LIVENESS, "GPGPU-Sim uArch: Empty (last released kernel %u \'%s\').\n",
-            kernel->get_uid(), kernel->name().c_str());
-          fflush(stdout);
-
-          //Shader can only be empty when no more cta are dispatched
-          if(kernel != m_kernel) {
-              assert(m_kernel == NULL || !m_gpu->kernel_more_cta_left(m_kernel));
-          }
-          m_kernel = NULL;
+  if (!m_response_fifo.empty()) {
+    mem_fetch *mf = m_response_fifo.front();
+    if (mf->get_access_type() == TEXTURE_ACC_R) {
+      if (m_L1T->fill_port_free()) {
+        m_L1T->fill(mf, m_core->get_gpu()->gpu_sim_cycle +
+                            m_core->get_gpu()->gpu_tot_sim_cycle);
+        m_response_fifo.pop_front();
       }
-
-      //Jin: for concurrent kernels on sm
-      release_shader_resource_1block(cta_num, *kernel);
-      kernel->dec_running();
-      if( !m_gpu->kernel_more_cta_left(kernel) ) {
-          if( !kernel->running() ) {
-              SHADER_DPRINTF(LIVENESS,
-                "GPGPU-Sim uArch: GPU detected kernel %u \'%s\' finished on shader %u.\n", kernel->get_uid(),
-                kernel->name().c_str(), m_sid);
-
-              if(m_kernel == kernel)
-                m_kernel = NULL;
-              m_gpu->set_kernel_done( kernel );
-          }
+    } else if (mf->get_access_type() == CONST_ACC_R) {
+      if (m_L1C->fill_port_free()) {
+        mf->set_status(IN_SHADER_FETCHED,
+                       m_core->get_gpu()->gpu_sim_cycle +
+                           m_core->get_gpu()->gpu_tot_sim_cycle);
+        m_L1C->fill(mf, m_core->get_gpu()->gpu_sim_cycle +
+                            m_core->get_gpu()->gpu_tot_sim_cycle);
+        m_response_fifo.pop_front();
       }
-
-   }
-}
-
-void gpgpu_sim::shader_print_runtime_stat( FILE *fout ) 
-{
-    /*
-   fprintf(fout, "SHD_INSN: ");
-   for (unsigned i=0;i<m_n_shader;i++) 
-      fprintf(fout, "%u ",m_sc[i]->get_num_sim_insn());
-   fprintf(fout, "\n");
-   fprintf(fout, "SHD_THDS: ");
-   for (unsigned i=0;i<m_n_shader;i++) 
-      fprintf(fout, "%u ",m_sc[i]->get_not_completed());
-   fprintf(fout, "\n");
-   fprintf(fout, "SHD_DIVG: ");
-   for (unsigned i=0;i<m_n_shader;i++) 
-      fprintf(fout, "%u ",m_sc[i]->get_n_diverge());
-   fprintf(fout, "\n");
-
-   fprintf(fout, "THD_INSN: ");
-   for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) 
-      fprintf(fout, "%d ", m_sc[0]->get_thread_n_insn(i) );
-   fprintf(fout, "\n");
-   */
-}
-
-
-void gpgpu_sim::shader_print_scheduler_stat( FILE* fout, bool print_dynamic_info ) const
-{
-    // Print out the stats from the sampling shader core
-    const unsigned scheduler_sampling_core = m_shader_config->gpgpu_warp_issue_shader;
-    #define STR_SIZE 55
-    char name_buff[ STR_SIZE ];
-    name_buff[ STR_SIZE - 1 ] = '\0';
-    const std::vector< unsigned >& distro
-        = print_dynamic_info ?
-          m_shader_stats->get_dynamic_warp_issue()[ scheduler_sampling_core ] :
-          m_shader_stats->get_warp_slot_issue()[ scheduler_sampling_core ];
-    if ( print_dynamic_info ) {
-        snprintf( name_buff, STR_SIZE - 1, "dynamic_warp_id" );
     } else {
-        snprintf( name_buff, STR_SIZE - 1, "warp_id" );
-    }
-    fprintf( fout,
-             "Shader %d %s issue ditsribution:\n",
-             scheduler_sampling_core,
-             name_buff );
-    const unsigned num_warp_ids = distro.size();
-    // First print out the warp ids
-    fprintf( fout, "%s:\n", name_buff );
-    for ( unsigned warp_id = 0;
-          warp_id < num_warp_ids;
-          ++warp_id  ) {
-        fprintf( fout, "%d, ", warp_id );
-    }
+      if (mf->get_type() == WRITE_ACK ||
+          (m_config->gpgpu_perfect_mem && mf->get_is_write())) {
+        m_core->store_ack(mf);
+        m_response_fifo.pop_front();
+        delete mf;
+      } else {
+        assert(!mf->get_is_write());  // L1 cache is write evict, allocate line
+                                      // on load miss only
 
-    fprintf( fout, "\ndistro:\n" );
-    // Then print out the distribution of instuctions issued
-    for ( std::vector< unsigned >::const_iterator iter = distro.begin();
-          iter != distro.end();
-          iter++ ) {
-        fprintf( fout, "%d, ", *iter );
+        bool bypassL1D = false;
+        if (CACHE_GLOBAL == mf->get_inst().cache_op || (m_L1D == NULL)) {
+          bypassL1D = true;
+        } else if (mf->get_access_type() == GLOBAL_ACC_R ||
+                   mf->get_access_type() ==
+                       GLOBAL_ACC_W) {  // global memory access
+          if (m_core->get_config()->gmem_skip_L1D) bypassL1D = true;
+        }
+        if (bypassL1D) {
+          if (m_next_global == NULL) {
+            mf->set_status(IN_SHADER_FETCHED,
+                           m_core->get_gpu()->gpu_sim_cycle +
+                               m_core->get_gpu()->gpu_tot_sim_cycle);
+            m_response_fifo.pop_front();
+            m_next_global = mf;
+          }
+        } else {
+          if (m_L1D->fill_port_free()) {
+            m_L1D->fill(mf, m_core->get_gpu()->gpu_sim_cycle +
+                                m_core->get_gpu()->gpu_tot_sim_cycle);
+            m_response_fifo.pop_front();
+          }
+        }
+      }
     }
-    fprintf( fout, "\n" );
+  }
+
+  m_L1T->cycle();
+  m_L1C->cycle();
+  if (m_L1D) {
+    m_L1D->cycle();
+    if (m_config->m_L1D_config.l1_latency > 0) L1_latency_queue_cycle();
+  }
+
+  warp_inst_t &pipe_reg = *m_dispatch_reg;
+  enum mem_stage_stall_type rc_fail = NO_RC_FAIL;
+  mem_stage_access_type type;
+  bool done = true;
+  done &= shared_cycle(pipe_reg, rc_fail, type);
+  done &= constant_cycle(pipe_reg, rc_fail, type);
+  done &= texture_cycle(pipe_reg, rc_fail, type);
+  done &= memory_cycle(pipe_reg, rc_fail, type);
+  m_mem_rc = rc_fail;
+
+  if (!done) {  // log stall types and return
+    assert(rc_fail != NO_RC_FAIL);
+    m_stats->gpgpu_n_stall_shd_mem++;
+    m_stats->gpu_stall_shd_mem_breakdown[type][rc_fail]++;
+    return;
+  }
+
+  if (!pipe_reg.empty()) {
+    unsigned warp_id = pipe_reg.warp_id();
+    if (pipe_reg.is_load()) {
+      if (pipe_reg.space.get_type() == shared_space) {
+        if (m_pipeline_reg[m_config->smem_latency - 1]->empty()) {
+          // new shared memory request
+          move_warp(m_pipeline_reg[m_config->smem_latency - 1], m_dispatch_reg);
+          m_dispatch_reg->clear();
+        }
+      } else {
+        // if( pipe_reg.active_count() > 0 ) {
+        //    if( !m_operand_collector->writeback(pipe_reg) )
+        //        return;
+        //}
+
+        bool pending_requests = false;
+        for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++) {
+          unsigned reg_id = pipe_reg.out[r];
+          if (reg_id > 0) {
+            if (m_pending_writes[warp_id].find(reg_id) !=
+                m_pending_writes[warp_id].end()) {
+              if (m_pending_writes[warp_id][reg_id] > 0) {
+                pending_requests = true;
+                break;
+              } else {
+                // this instruction is done already
+                m_pending_writes[warp_id].erase(reg_id);
+              }
+            }
+          }
+        }
+        if (!pending_requests) {
+          m_core->warp_inst_complete(*m_dispatch_reg);
+          m_scoreboard->releaseRegisters(m_dispatch_reg);
+        }
+        m_core->dec_inst_in_pipeline(warp_id);
+        m_dispatch_reg->clear();
+      }
+    } else {
+      // stores exit pipeline here
+      m_core->dec_inst_in_pipeline(warp_id);
+      m_core->warp_inst_complete(*m_dispatch_reg);
+      m_dispatch_reg->clear();
+    }
+  }
 }
 
-void gpgpu_sim::shader_print_cache_stats( FILE *fout ) const{
+void shader_core_ctx::register_cta_thread_exit(unsigned cta_num,
+                                               kernel_info_t *kernel) {
+  assert(m_cta_status[cta_num] > 0);
+  m_cta_status[cta_num]--;
+  if (!m_cta_status[cta_num]) {
+    m_n_active_cta--;
+    m_barriers.deallocate_barrier(cta_num);
+    shader_CTA_count_unlog(m_sid, 1);
 
-    // L1I
-    struct cache_sub_stats total_css;
-    struct cache_sub_stats css;
+    SHADER_DPRINTF(
+        LIVENESS,
+        "GPGPU-Sim uArch: Finished CTA #%u (%lld,%lld), %u CTAs running\n",
+        cta_num, m_gpu->gpu_sim_cycle, m_gpu->gpu_tot_sim_cycle,
+        m_n_active_cta);
 
-    if(!m_shader_config->m_L1I_config.disabled()){
-        total_css.clear();
-        css.clear();
-        fprintf(fout, "\n========= Core cache stats =========\n");
-        fprintf(fout, "L1I_cache:\n");
-        for ( unsigned i = 0; i < m_shader_config->n_simt_clusters; ++i ) {
-            m_cluster[i]->get_L1I_sub_stats(css);
-            total_css += css;
-        }
-        fprintf(fout, "\tL1I_total_cache_accesses = %llu\n", total_css.accesses);
-        fprintf(fout, "\tL1I_total_cache_misses = %llu\n", total_css.misses);
-        if(total_css.accesses > 0){
-            fprintf(fout, "\tL1I_total_cache_miss_rate = %.4lf\n", (double)total_css.misses / (double)total_css.accesses);
-        }
-        fprintf(fout, "\tL1I_total_cache_pending_hits = %llu\n", total_css.pending_hits);
-        fprintf(fout, "\tL1I_total_cache_reservation_fails = %llu\n", total_css.res_fails);
+    if (m_n_active_cta == 0) {
+      SHADER_DPRINTF(
+          LIVENESS,
+          "GPGPU-Sim uArch: Empty (last released kernel %u \'%s\').\n",
+          kernel->get_uid(), kernel->name().c_str());
+      fflush(stdout);
+
+      // Shader can only be empty when no more cta are dispatched
+      if (kernel != m_kernel) {
+        assert(m_kernel == NULL || !m_gpu->kernel_more_cta_left(m_kernel));
+      }
+      m_kernel = NULL;
     }
 
-    // L1D
-    if(!m_shader_config->m_L1D_config.disabled()){
-        total_css.clear();
-        css.clear();
-        fprintf(fout, "L1D_cache:\n");
-        for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++){
-            m_cluster[i]->get_L1D_sub_stats(css);
+    // Jin: for concurrent kernels on sm
+    release_shader_resource_1block(cta_num, *kernel);
+    kernel->dec_running();
+    if (!m_gpu->kernel_more_cta_left(kernel)) {
+      if (!kernel->running()) {
+        SHADER_DPRINTF(LIVENESS,
+                       "GPGPU-Sim uArch: GPU detected kernel %u \'%s\' "
+                       "finished on shader %u.\n",
+                       kernel->get_uid(), kernel->name().c_str(), m_sid);
 
-            fprintf( stdout, "\tL1D_cache_core[%d]: Access = %llu, Miss = %llu, Miss_rate = %.3lf, Pending_hits = %llu, Reservation_fails = %llu\n",
-                     i, css.accesses, css.misses, (double)css.misses / (double)css.accesses, css.pending_hits, css.res_fails);
-
-            total_css += css;
-        }
-        fprintf(fout, "\tL1D_total_cache_accesses = %llu\n", total_css.accesses);
-        fprintf(fout, "\tL1D_total_cache_misses = %llu\n", total_css.misses);
-        if(total_css.accesses > 0){
-            fprintf(fout, "\tL1D_total_cache_miss_rate = %.4lf\n", (double)total_css.misses / (double)total_css.accesses);
-        }
-        fprintf(fout, "\tL1D_total_cache_pending_hits = %llu\n", total_css.pending_hits);
-        fprintf(fout, "\tL1D_total_cache_reservation_fails = %llu\n", total_css.res_fails);
-        total_css.print_port_stats(fout, "\tL1D_cache"); 
+        if (m_kernel == kernel) m_kernel = NULL;
+        m_gpu->set_kernel_done(kernel);
+      }
     }
-
-    // L1C
-    if(!m_shader_config->m_L1C_config.disabled()){
-        total_css.clear();
-        css.clear();
-        fprintf(fout, "L1C_cache:\n");
-        for ( unsigned i = 0; i < m_shader_config->n_simt_clusters; ++i ) {
-            m_cluster[i]->get_L1C_sub_stats(css);
-            total_css += css;
-        }
-        fprintf(fout, "\tL1C_total_cache_accesses = %llu\n", total_css.accesses);
-        fprintf(fout, "\tL1C_total_cache_misses = %llu\n", total_css.misses);
-        if(total_css.accesses > 0){
-            fprintf(fout, "\tL1C_total_cache_miss_rate = %.4lf\n", (double)total_css.misses / (double)total_css.accesses);
-        }
-        fprintf(fout, "\tL1C_total_cache_pending_hits = %llu\n", total_css.pending_hits);
-        fprintf(fout, "\tL1C_total_cache_reservation_fails = %llu\n", total_css.res_fails);
-    }
-
-    // L1T
-    if(!m_shader_config->m_L1T_config.disabled()){
-        total_css.clear();
-        css.clear();
-        fprintf(fout, "L1T_cache:\n");
-        for ( unsigned i = 0; i < m_shader_config->n_simt_clusters; ++i ) {
-            m_cluster[i]->get_L1T_sub_stats(css);
-            total_css += css;
-        }
-        fprintf(fout, "\tL1T_total_cache_accesses = %llu\n", total_css.accesses);
-        fprintf(fout, "\tL1T_total_cache_misses = %llu\n", total_css.misses);
-        if(total_css.accesses > 0){
-            fprintf(fout, "\tL1T_total_cache_miss_rate = %.4lf\n", (double)total_css.misses / (double)total_css.accesses);
-        }
-        fprintf(fout, "\tL1T_total_cache_pending_hits = %llu\n", total_css.pending_hits);
-        fprintf(fout, "\tL1T_total_cache_reservation_fails = %llu\n", total_css.res_fails);
-    }
+  }
 }
 
-void gpgpu_sim::shader_print_l1_miss_stat( FILE *fout ) const
-{
-   unsigned total_d1_misses = 0, total_d1_accesses = 0;
-   for ( unsigned i = 0; i < m_shader_config->n_simt_clusters; ++i ) {
-         unsigned custer_d1_misses = 0, cluster_d1_accesses = 0;
-         m_cluster[ i ]->print_cache_stats( fout, cluster_d1_accesses, custer_d1_misses );
-         total_d1_misses += custer_d1_misses;
-         total_d1_accesses += cluster_d1_accesses;
-   }
-   fprintf( fout, "total_dl1_misses=%d\n", total_d1_misses );
-   fprintf( fout, "total_dl1_accesses=%d\n", total_d1_accesses );
-   fprintf( fout, "total_dl1_miss_rate= %f\n", (float)total_d1_misses / (float)total_d1_accesses );
-   /*
-   fprintf(fout, "THD_INSN_AC: ");
-   for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) 
-      fprintf(fout, "%d ", m_sc[0]->get_thread_n_insn_ac(i));
-   fprintf(fout, "\n");
-   fprintf(fout, "T_L1_Mss: "); //l1 miss rate per thread
-   for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) 
-      fprintf(fout, "%d ", m_sc[0]->get_thread_n_l1_mis_ac(i));
-   fprintf(fout, "\n");
-   fprintf(fout, "T_L1_Mgs: "); //l1 merged miss rate per thread
-   for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) 
-      fprintf(fout, "%d ", m_sc[0]->get_thread_n_l1_mis_ac(i) - m_sc[0]->get_thread_n_l1_mrghit_ac(i));
-   fprintf(fout, "\n");
-   fprintf(fout, "T_L1_Acc: "); //l1 access per thread
-   for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) 
-      fprintf(fout, "%d ", m_sc[0]->get_thread_n_l1_access_ac(i));
-   fprintf(fout, "\n");
+void gpgpu_sim::shader_print_runtime_stat(FILE *fout) {
+  /*
+ fprintf(fout, "SHD_INSN: ");
+ for (unsigned i=0;i<m_n_shader;i++)
+    fprintf(fout, "%u ",m_sc[i]->get_num_sim_insn());
+ fprintf(fout, "\n");
+ fprintf(fout, "SHD_THDS: ");
+ for (unsigned i=0;i<m_n_shader;i++)
+    fprintf(fout, "%u ",m_sc[i]->get_not_completed());
+ fprintf(fout, "\n");
+ fprintf(fout, "SHD_DIVG: ");
+ for (unsigned i=0;i<m_n_shader;i++)
+    fprintf(fout, "%u ",m_sc[i]->get_n_diverge());
+ fprintf(fout, "\n");
 
-   //per warp
-   int temp =0; 
-   fprintf(fout, "W_L1_Mss: "); //l1 miss rate per warp
-   for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) {
-      temp += m_sc[0]->get_thread_n_l1_mis_ac(i);
-      if (i%m_shader_config->warp_size == (unsigned)(m_shader_config->warp_size-1)) {
-         fprintf(fout, "%d ", temp);
-         temp = 0;
-      }
-   }
-   fprintf(fout, "\n");
-   temp=0;
-   fprintf(fout, "W_L1_Mgs: "); //l1 merged miss rate per warp
-   for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) {
-      temp += (m_sc[0]->get_thread_n_l1_mis_ac(i) - m_sc[0]->get_thread_n_l1_mrghit_ac(i) );
-      if (i%m_shader_config->warp_size == (unsigned)(m_shader_config->warp_size-1)) {
-         fprintf(fout, "%d ", temp);
-         temp = 0;
-      }
-   }
-   fprintf(fout, "\n");
-   temp =0;
-   fprintf(fout, "W_L1_Acc: "); //l1 access per warp
-   for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) {
-      temp += m_sc[0]->get_thread_n_l1_access_ac(i);
-      if (i%m_shader_config->warp_size == (unsigned)(m_shader_config->warp_size-1)) {
-         fprintf(fout, "%d ", temp);
-         temp = 0;
-      }
-   }
-   fprintf(fout, "\n");
-   */
+ fprintf(fout, "THD_INSN: ");
+ for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++)
+    fprintf(fout, "%d ", m_sc[0]->get_thread_n_insn(i) );
+ fprintf(fout, "\n");
+ */
 }
 
-void warp_inst_t::print( FILE *fout ) const
-{
-    if (empty() ) {
-        fprintf(fout,"bubble\n" );
-        return;
-    } else 
-        fprintf(fout,"0x%04x ", pc );
-    fprintf(fout, "w%02d[", m_warp_id);
-    for (unsigned j=0; j<m_config->warp_size; j++)
-        fprintf(fout, "%c", (active(j)?'1':'0') );
-    fprintf(fout, "]: ");
-    m_config->gpgpu_ctx->func_sim->ptx_print_insn( pc, fout );
+void gpgpu_sim::shader_print_scheduler_stat(FILE *fout,
+                                            bool print_dynamic_info) const {
+  // Print out the stats from the sampling shader core
+  const unsigned scheduler_sampling_core =
+      m_shader_config->gpgpu_warp_issue_shader;
+#define STR_SIZE 55
+  char name_buff[STR_SIZE];
+  name_buff[STR_SIZE - 1] = '\0';
+  const std::vector<unsigned> &distro =
+      print_dynamic_info
+          ? m_shader_stats->get_dynamic_warp_issue()[scheduler_sampling_core]
+          : m_shader_stats->get_warp_slot_issue()[scheduler_sampling_core];
+  if (print_dynamic_info) {
+    snprintf(name_buff, STR_SIZE - 1, "dynamic_warp_id");
+  } else {
+    snprintf(name_buff, STR_SIZE - 1, "warp_id");
+  }
+  fprintf(fout, "Shader %d %s issue ditsribution:\n", scheduler_sampling_core,
+          name_buff);
+  const unsigned num_warp_ids = distro.size();
+  // First print out the warp ids
+  fprintf(fout, "%s:\n", name_buff);
+  for (unsigned warp_id = 0; warp_id < num_warp_ids; ++warp_id) {
+    fprintf(fout, "%d, ", warp_id);
+  }
+
+  fprintf(fout, "\ndistro:\n");
+  // Then print out the distribution of instuctions issued
+  for (std::vector<unsigned>::const_iterator iter = distro.begin();
+       iter != distro.end(); iter++) {
+    fprintf(fout, "%d, ", *iter);
+  }
+  fprintf(fout, "\n");
+}
+
+void gpgpu_sim::shader_print_cache_stats(FILE *fout) const {
+  // L1I
+  struct cache_sub_stats total_css;
+  struct cache_sub_stats css;
+
+  if (!m_shader_config->m_L1I_config.disabled()) {
+    total_css.clear();
+    css.clear();
+    fprintf(fout, "\n========= Core cache stats =========\n");
+    fprintf(fout, "L1I_cache:\n");
+    for (unsigned i = 0; i < m_shader_config->n_simt_clusters; ++i) {
+      m_cluster[i]->get_L1I_sub_stats(css);
+      total_css += css;
+    }
+    fprintf(fout, "\tL1I_total_cache_accesses = %llu\n", total_css.accesses);
+    fprintf(fout, "\tL1I_total_cache_misses = %llu\n", total_css.misses);
+    if (total_css.accesses > 0) {
+      fprintf(fout, "\tL1I_total_cache_miss_rate = %.4lf\n",
+              (double)total_css.misses / (double)total_css.accesses);
+    }
+    fprintf(fout, "\tL1I_total_cache_pending_hits = %llu\n",
+            total_css.pending_hits);
+    fprintf(fout, "\tL1I_total_cache_reservation_fails = %llu\n",
+            total_css.res_fails);
+  }
+
+  // L1D
+  if (!m_shader_config->m_L1D_config.disabled()) {
+    total_css.clear();
+    css.clear();
+    fprintf(fout, "L1D_cache:\n");
+    for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++) {
+      m_cluster[i]->get_L1D_sub_stats(css);
+
+      fprintf(stdout,
+              "\tL1D_cache_core[%d]: Access = %llu, Miss = %llu, Miss_rate = "
+              "%.3lf, Pending_hits = %llu, Reservation_fails = %llu\n",
+              i, css.accesses, css.misses,
+              (double)css.misses / (double)css.accesses, css.pending_hits,
+              css.res_fails);
+
+      total_css += css;
+    }
+    fprintf(fout, "\tL1D_total_cache_accesses = %llu\n", total_css.accesses);
+    fprintf(fout, "\tL1D_total_cache_misses = %llu\n", total_css.misses);
+    if (total_css.accesses > 0) {
+      fprintf(fout, "\tL1D_total_cache_miss_rate = %.4lf\n",
+              (double)total_css.misses / (double)total_css.accesses);
+    }
+    fprintf(fout, "\tL1D_total_cache_pending_hits = %llu\n",
+            total_css.pending_hits);
+    fprintf(fout, "\tL1D_total_cache_reservation_fails = %llu\n",
+            total_css.res_fails);
+    total_css.print_port_stats(fout, "\tL1D_cache");
+  }
+
+  // L1C
+  if (!m_shader_config->m_L1C_config.disabled()) {
+    total_css.clear();
+    css.clear();
+    fprintf(fout, "L1C_cache:\n");
+    for (unsigned i = 0; i < m_shader_config->n_simt_clusters; ++i) {
+      m_cluster[i]->get_L1C_sub_stats(css);
+      total_css += css;
+    }
+    fprintf(fout, "\tL1C_total_cache_accesses = %llu\n", total_css.accesses);
+    fprintf(fout, "\tL1C_total_cache_misses = %llu\n", total_css.misses);
+    if (total_css.accesses > 0) {
+      fprintf(fout, "\tL1C_total_cache_miss_rate = %.4lf\n",
+              (double)total_css.misses / (double)total_css.accesses);
+    }
+    fprintf(fout, "\tL1C_total_cache_pending_hits = %llu\n",
+            total_css.pending_hits);
+    fprintf(fout, "\tL1C_total_cache_reservation_fails = %llu\n",
+            total_css.res_fails);
+  }
+
+  // L1T
+  if (!m_shader_config->m_L1T_config.disabled()) {
+    total_css.clear();
+    css.clear();
+    fprintf(fout, "L1T_cache:\n");
+    for (unsigned i = 0; i < m_shader_config->n_simt_clusters; ++i) {
+      m_cluster[i]->get_L1T_sub_stats(css);
+      total_css += css;
+    }
+    fprintf(fout, "\tL1T_total_cache_accesses = %llu\n", total_css.accesses);
+    fprintf(fout, "\tL1T_total_cache_misses = %llu\n", total_css.misses);
+    if (total_css.accesses > 0) {
+      fprintf(fout, "\tL1T_total_cache_miss_rate = %.4lf\n",
+              (double)total_css.misses / (double)total_css.accesses);
+    }
+    fprintf(fout, "\tL1T_total_cache_pending_hits = %llu\n",
+            total_css.pending_hits);
+    fprintf(fout, "\tL1T_total_cache_reservation_fails = %llu\n",
+            total_css.res_fails);
+  }
+}
+
+void gpgpu_sim::shader_print_l1_miss_stat(FILE *fout) const {
+  unsigned total_d1_misses = 0, total_d1_accesses = 0;
+  for (unsigned i = 0; i < m_shader_config->n_simt_clusters; ++i) {
+    unsigned custer_d1_misses = 0, cluster_d1_accesses = 0;
+    m_cluster[i]->print_cache_stats(fout, cluster_d1_accesses,
+                                    custer_d1_misses);
+    total_d1_misses += custer_d1_misses;
+    total_d1_accesses += cluster_d1_accesses;
+  }
+  fprintf(fout, "total_dl1_misses=%d\n", total_d1_misses);
+  fprintf(fout, "total_dl1_accesses=%d\n", total_d1_accesses);
+  fprintf(fout, "total_dl1_miss_rate= %f\n",
+          (float)total_d1_misses / (float)total_d1_accesses);
+  /*
+  fprintf(fout, "THD_INSN_AC: ");
+  for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++)
+     fprintf(fout, "%d ", m_sc[0]->get_thread_n_insn_ac(i));
+  fprintf(fout, "\n");
+  fprintf(fout, "T_L1_Mss: "); //l1 miss rate per thread
+  for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++)
+     fprintf(fout, "%d ", m_sc[0]->get_thread_n_l1_mis_ac(i));
+  fprintf(fout, "\n");
+  fprintf(fout, "T_L1_Mgs: "); //l1 merged miss rate per thread
+  for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++)
+     fprintf(fout, "%d ", m_sc[0]->get_thread_n_l1_mis_ac(i) -
+  m_sc[0]->get_thread_n_l1_mrghit_ac(i));
+  fprintf(fout, "\n");
+  fprintf(fout, "T_L1_Acc: "); //l1 access per thread
+  for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++)
+     fprintf(fout, "%d ", m_sc[0]->get_thread_n_l1_access_ac(i));
+  fprintf(fout, "\n");
+
+  //per warp
+  int temp =0;
+  fprintf(fout, "W_L1_Mss: "); //l1 miss rate per warp
+  for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) {
+     temp += m_sc[0]->get_thread_n_l1_mis_ac(i);
+     if (i%m_shader_config->warp_size ==
+  (unsigned)(m_shader_config->warp_size-1)) {
+        fprintf(fout, "%d ", temp);
+        temp = 0;
+     }
+  }
+  fprintf(fout, "\n");
+  temp=0;
+  fprintf(fout, "W_L1_Mgs: "); //l1 merged miss rate per warp
+  for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) {
+     temp += (m_sc[0]->get_thread_n_l1_mis_ac(i) -
+  m_sc[0]->get_thread_n_l1_mrghit_ac(i) );
+     if (i%m_shader_config->warp_size ==
+  (unsigned)(m_shader_config->warp_size-1)) {
+        fprintf(fout, "%d ", temp);
+        temp = 0;
+     }
+  }
+  fprintf(fout, "\n");
+  temp =0;
+  fprintf(fout, "W_L1_Acc: "); //l1 access per warp
+  for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) {
+     temp += m_sc[0]->get_thread_n_l1_access_ac(i);
+     if (i%m_shader_config->warp_size ==
+  (unsigned)(m_shader_config->warp_size-1)) {
+        fprintf(fout, "%d ", temp);
+        temp = 0;
+     }
+  }
+  fprintf(fout, "\n");
+  */
+}
+
+void warp_inst_t::print(FILE *fout) const {
+  if (empty()) {
+    fprintf(fout, "bubble\n");
+    return;
+  } else
+    fprintf(fout, "0x%04x ", pc);
+  fprintf(fout, "w%02d[", m_warp_id);
+  for (unsigned j = 0; j < m_config->warp_size; j++)
+    fprintf(fout, "%c", (active(j) ? '1' : '0'));
+  fprintf(fout, "]: ");
+  m_config->gpgpu_ctx->func_sim->ptx_print_insn(pc, fout);
+  fprintf(fout, "\n");
+}
+void shader_core_ctx::incexecstat(warp_inst_t *&inst) {
+  if (inst->mem_op == TEX) inctex_stat(inst->active_count(), 1);
+
+  // Latency numbers for next operations are used to scale the power values
+  // for special operations, according observations from microbenchmarking
+  // TODO: put these numbers in the xml configuration
+
+  switch (inst->sp_op) {
+    case INT__OP:
+      incialu_stat(inst->active_count(), 32);
+      break;
+    case INT_MUL_OP:
+      incimul_stat(inst->active_count(), 7.2);
+      break;
+    case INT_MUL24_OP:
+      incimul24_stat(inst->active_count(), 4.2);
+      break;
+    case INT_MUL32_OP:
+      incimul32_stat(inst->active_count(), 4);
+      break;
+    case INT_DIV_OP:
+      incidiv_stat(inst->active_count(), 40);
+      break;
+    case FP__OP:
+      incfpalu_stat(inst->active_count(), 1);
+      break;
+    case FP_MUL_OP:
+      incfpmul_stat(inst->active_count(), 1.8);
+      break;
+    case FP_DIV_OP:
+      incfpdiv_stat(inst->active_count(), 48);
+      break;
+    case FP_SQRT_OP:
+      inctrans_stat(inst->active_count(), 25);
+      break;
+    case FP_LG_OP:
+      inctrans_stat(inst->active_count(), 35);
+      break;
+    case FP_SIN_OP:
+      inctrans_stat(inst->active_count(), 12);
+      break;
+    case FP_EXP_OP:
+      inctrans_stat(inst->active_count(), 35);
+      break;
+    default:
+      break;
+  }
+}
+void shader_core_ctx::print_stage(unsigned int stage, FILE *fout) const {
+  m_pipeline_reg[stage].print(fout);
+  // m_pipeline_reg[stage].print(fout);
+}
+
+void shader_core_ctx::display_simt_state(FILE *fout, int mask) const {
+  if ((mask & 4) && m_config->model == POST_DOMINATOR) {
+    fprintf(fout, "per warp SIMT control-flow state:\n");
+    unsigned n = m_config->n_thread_per_shader / m_config->warp_size;
+    for (unsigned i = 0; i < n; i++) {
+      unsigned nactive = 0;
+      for (unsigned j = 0; j < m_config->warp_size; j++) {
+        unsigned tid = i * m_config->warp_size + j;
+        int done = ptx_thread_done(tid);
+        nactive += (ptx_thread_done(tid) ? 0 : 1);
+        if (done && (mask & 8)) {
+          unsigned done_cycle = m_thread[tid]->donecycle();
+          if (done_cycle) {
+            printf("\n w%02u:t%03u: done @ cycle %u", i, tid, done_cycle);
+          }
+        }
+      }
+      if (nactive == 0) {
+        continue;
+      }
+      m_simt_stack[i]->print(fout);
+    }
     fprintf(fout, "\n");
-}
-void shader_core_ctx::incexecstat(warp_inst_t *&inst)
-{
-	if(inst->mem_op==TEX)
-		inctex_stat(inst->active_count(),1);
-
-    // Latency numbers for next operations are used to scale the power values
-    // for special operations, according observations from microbenchmarking
-    // TODO: put these numbers in the xml configuration
-
-	switch(inst->sp_op){
-	case INT__OP:
-		incialu_stat(inst->active_count(),32);
-		break;
-	case INT_MUL_OP:
-		incimul_stat(inst->active_count(),7.2);
-		break;
-	case INT_MUL24_OP:
-		incimul24_stat(inst->active_count(),4.2);
-		break;
-	case INT_MUL32_OP:
-		incimul32_stat(inst->active_count(),4);
-		break;
-	case INT_DIV_OP:
-		incidiv_stat(inst->active_count(),40);
-		break;
-	case FP__OP:
-		incfpalu_stat(inst->active_count(),1);
-		break;
-	case FP_MUL_OP:
-		incfpmul_stat(inst->active_count(),1.8);
-		break;
-	case FP_DIV_OP:
-		incfpdiv_stat(inst->active_count(),48);
-		break;
-	case FP_SQRT_OP:
-		inctrans_stat(inst->active_count(),25);
-		break;
-	case FP_LG_OP:
-		inctrans_stat(inst->active_count(),35);
-		break;
-	case FP_SIN_OP:
-		inctrans_stat(inst->active_count(),12);
-		break;
-	case FP_EXP_OP:
-		inctrans_stat(inst->active_count(),35);
-		break;
-	default:
-		break;
-	}
-}
-void shader_core_ctx::print_stage(unsigned int stage, FILE *fout ) const
-{
-   m_pipeline_reg[stage].print(fout);
-   //m_pipeline_reg[stage].print(fout);
+  }
 }
 
-void shader_core_ctx::display_simt_state(FILE *fout, int mask ) const
-{
-    if ( (mask & 4) && m_config->model == POST_DOMINATOR ) {
-       fprintf(fout,"per warp SIMT control-flow state:\n");
-       unsigned n = m_config->n_thread_per_shader / m_config->warp_size;
-       for (unsigned i=0; i < n; i++) {
-          unsigned nactive = 0;
-          for (unsigned j=0; j<m_config->warp_size; j++ ) {
-             unsigned tid = i*m_config->warp_size + j;
-             int done = ptx_thread_done(tid);
-             nactive += (ptx_thread_done(tid)?0:1);
-             if ( done && (mask & 8) ) {
-                unsigned done_cycle = m_thread[tid]->donecycle();
-                if ( done_cycle ) {
-                   printf("\n w%02u:t%03u: done @ cycle %u", i, tid, done_cycle );
-                }
-             }
-          }
-          if ( nactive == 0 ) {
-             continue;
-          }
-          m_simt_stack[i]->print(fout);
-       }
-       fprintf(fout,"\n");
+void ldst_unit::print(FILE *fout) const {
+  fprintf(fout, "LD/ST unit  = ");
+  m_dispatch_reg->print(fout);
+  if (m_mem_rc != NO_RC_FAIL) {
+    fprintf(fout, "              LD/ST stall condition: ");
+    switch (m_mem_rc) {
+      case BK_CONF:
+        fprintf(fout, "BK_CONF");
+        break;
+      case MSHR_RC_FAIL:
+        fprintf(fout, "MSHR_RC_FAIL");
+        break;
+      case ICNT_RC_FAIL:
+        fprintf(fout, "ICNT_RC_FAIL");
+        break;
+      case COAL_STALL:
+        fprintf(fout, "COAL_STALL");
+        break;
+      case WB_ICNT_RC_FAIL:
+        fprintf(fout, "WB_ICNT_RC_FAIL");
+        break;
+      case WB_CACHE_RSRV_FAIL:
+        fprintf(fout, "WB_CACHE_RSRV_FAIL");
+        break;
+      case N_MEM_STAGE_STALL_TYPE:
+        fprintf(fout, "N_MEM_STAGE_STALL_TYPE");
+        break;
+      default:
+        abort();
     }
+    fprintf(fout, "\n");
+  }
+  fprintf(fout, "LD/ST wb    = ");
+  m_next_wb.print(fout);
+  fprintf(
+      fout,
+      "Last LD/ST writeback @ %llu + %llu (gpu_sim_cycle+gpu_tot_sim_cycle)\n",
+      m_last_inst_gpu_sim_cycle, m_last_inst_gpu_tot_sim_cycle);
+  fprintf(fout, "Pending register writes:\n");
+  std::map<unsigned /*warp_id*/,
+           std::map<unsigned /*regnum*/, unsigned /*count*/> >::const_iterator
+      w;
+  for (w = m_pending_writes.begin(); w != m_pending_writes.end(); w++) {
+    unsigned warp_id = w->first;
+    const std::map<unsigned /*regnum*/, unsigned /*count*/> &warp_info =
+        w->second;
+    if (warp_info.empty()) continue;
+    fprintf(fout, "  w%2u : ", warp_id);
+    std::map<unsigned /*regnum*/, unsigned /*count*/>::const_iterator r;
+    for (r = warp_info.begin(); r != warp_info.end(); ++r) {
+      fprintf(fout, "  %u(%u)", r->first, r->second);
+    }
+    fprintf(fout, "\n");
+  }
+  m_L1C->display_state(fout);
+  m_L1T->display_state(fout);
+  if (!m_config->m_L1D_config.disabled()) m_L1D->display_state(fout);
+  fprintf(fout, "LD/ST response FIFO (occupancy = %zu):\n",
+          m_response_fifo.size());
+  for (std::list<mem_fetch *>::const_iterator i = m_response_fifo.begin();
+       i != m_response_fifo.end(); i++) {
+    const mem_fetch *mf = *i;
+    mf->print(fout);
+  }
 }
 
-void ldst_unit::print(FILE *fout) const
-{
-    fprintf(fout,"LD/ST unit  = ");
-    m_dispatch_reg->print(fout);
-    if ( m_mem_rc != NO_RC_FAIL ) {
-        fprintf(fout,"              LD/ST stall condition: ");
-        switch ( m_mem_rc ) {
-        case BK_CONF:        fprintf(fout,"BK_CONF"); break;
-        case MSHR_RC_FAIL:   fprintf(fout,"MSHR_RC_FAIL"); break;
-        case ICNT_RC_FAIL:   fprintf(fout,"ICNT_RC_FAIL"); break;
-        case COAL_STALL:     fprintf(fout,"COAL_STALL"); break;
-        case WB_ICNT_RC_FAIL: fprintf(fout,"WB_ICNT_RC_FAIL"); break;
-        case WB_CACHE_RSRV_FAIL: fprintf(fout,"WB_CACHE_RSRV_FAIL"); break;
-        case N_MEM_STAGE_STALL_TYPE: fprintf(fout,"N_MEM_STAGE_STALL_TYPE"); break;
-        default: abort();
+void shader_core_ctx::display_pipeline(FILE *fout, int print_mem,
+                                       int mask) const {
+  fprintf(fout, "=================================================\n");
+  fprintf(fout, "shader %u at cycle %Lu+%Lu (%u threads running)\n", m_sid,
+          m_gpu->gpu_tot_sim_cycle, m_gpu->gpu_sim_cycle, m_not_completed);
+  fprintf(fout, "=================================================\n");
+
+  dump_warp_state(fout);
+  fprintf(fout, "\n");
+
+  m_L1I->display_state(fout);
+
+  fprintf(fout, "IF/ID       = ");
+  if (!m_inst_fetch_buffer.m_valid)
+    fprintf(fout, "bubble\n");
+  else {
+    fprintf(fout, "w%2u : pc = 0x%x, nbytes = %u\n",
+            m_inst_fetch_buffer.m_warp_id, m_inst_fetch_buffer.m_pc,
+            m_inst_fetch_buffer.m_nbytes);
+  }
+  fprintf(fout, "\nibuffer status:\n");
+  for (unsigned i = 0; i < m_config->max_warps_per_shader; i++) {
+    if (!m_warp[i].ibuffer_empty()) m_warp[i].print_ibuffer(fout);
+  }
+  fprintf(fout, "\n");
+  display_simt_state(fout, mask);
+  fprintf(fout, "-------------------------- Scoreboard\n");
+  m_scoreboard->printContents();
+  /*
+     fprintf(fout,"ID/OC (SP)  = ");
+     print_stage(ID_OC_SP, fout);
+     fprintf(fout,"ID/OC (SFU) = ");
+     print_stage(ID_OC_SFU, fout);
+     fprintf(fout,"ID/OC (MEM) = ");
+     print_stage(ID_OC_MEM, fout);
+  */
+  fprintf(fout, "-------------------------- OP COL\n");
+  m_operand_collector.dump(fout);
+  /* fprintf(fout, "OC/EX (SP)  = ");
+     print_stage(OC_EX_SP, fout);
+     fprintf(fout, "OC/EX (SFU) = ");
+     print_stage(OC_EX_SFU, fout);
+     fprintf(fout, "OC/EX (MEM) = ");
+     print_stage(OC_EX_MEM, fout);
+  */
+  fprintf(fout, "-------------------------- Pipe Regs\n");
+
+  for (unsigned i = 0; i < N_PIPELINE_STAGES; i++) {
+    fprintf(fout, "--- %s ---\n", pipeline_stage_name_decode[i]);
+    print_stage(i, fout);
+    fprintf(fout, "\n");
+  }
+
+  fprintf(fout, "-------------------------- Fu\n");
+  for (unsigned n = 0; n < m_num_function_units; n++) {
+    m_fu[n]->print(fout);
+    fprintf(fout, "---------------\n");
+  }
+  fprintf(fout, "-------------------------- other:\n");
+
+  for (unsigned i = 0; i < num_result_bus; i++) {
+    std::string bits = m_result_bus[i]->to_string();
+    fprintf(fout, "EX/WB sched[%d]= %s\n", i, bits.c_str());
+  }
+  fprintf(fout, "EX/WB      = ");
+  print_stage(EX_WB, fout);
+  fprintf(fout, "\n");
+  fprintf(
+      fout,
+      "Last EX/WB writeback @ %llu + %llu (gpu_sim_cycle+gpu_tot_sim_cycle)\n",
+      m_last_inst_gpu_sim_cycle, m_last_inst_gpu_tot_sim_cycle);
+
+  if (m_active_threads.count() <= 2 * m_config->warp_size) {
+    fprintf(fout, "Active Threads : ");
+    unsigned last_warp_id = -1;
+    for (unsigned tid = 0; tid < m_active_threads.size(); tid++) {
+      unsigned warp_id = tid / m_config->warp_size;
+      if (m_active_threads.test(tid)) {
+        if (warp_id != last_warp_id) {
+          fprintf(fout, "\n  warp %u : ", warp_id);
+          last_warp_id = warp_id;
         }
-        fprintf(fout,"\n");
+        fprintf(fout, "%u ", tid);
+      }
     }
-    fprintf(fout,"LD/ST wb    = ");
-    m_next_wb.print(fout);
-    fprintf(fout, "Last LD/ST writeback @ %llu + %llu (gpu_sim_cycle+gpu_tot_sim_cycle)\n",
-                  m_last_inst_gpu_sim_cycle, m_last_inst_gpu_tot_sim_cycle );
-    fprintf(fout,"Pending register writes:\n");
-    std::map<unsigned/*warp_id*/, std::map<unsigned/*regnum*/,unsigned/*count*/> >::const_iterator w;
-    for( w=m_pending_writes.begin(); w!=m_pending_writes.end(); w++ ) {
-        unsigned warp_id = w->first;
-        const std::map<unsigned/*regnum*/,unsigned/*count*/> &warp_info = w->second;
-        if( warp_info.empty() ) 
-            continue;
-        fprintf(fout,"  w%2u : ", warp_id );
-        std::map<unsigned/*regnum*/,unsigned/*count*/>::const_iterator r;
-        for( r=warp_info.begin(); r!=warp_info.end(); ++r ) {
-            fprintf(fout,"  %u(%u)", r->first, r->second );
-        }
-        fprintf(fout,"\n");
-    }
-    m_L1C->display_state(fout);
-    m_L1T->display_state(fout);
-    if( !m_config->m_L1D_config.disabled() )
-    	m_L1D->display_state(fout);
-    fprintf(fout,"LD/ST response FIFO (occupancy = %zu):\n", m_response_fifo.size() );
-    for( std::list<mem_fetch*>::const_iterator i=m_response_fifo.begin(); i != m_response_fifo.end(); i++ ) {
-        const mem_fetch *mf = *i;
-        mf->print(fout);
-    }
+  }
 }
 
-void shader_core_ctx::display_pipeline(FILE *fout, int print_mem, int mask ) const
-{
-   fprintf(fout, "=================================================\n");
-   fprintf(fout, "shader %u at cycle %Lu+%Lu (%u threads running)\n", m_sid, 
-           m_gpu->gpu_tot_sim_cycle, m_gpu->gpu_sim_cycle, m_not_completed);
-   fprintf(fout, "=================================================\n");
+unsigned int shader_core_config::max_cta(const kernel_info_t &k) const {
+  unsigned threads_per_cta = k.threads_per_cta();
+  const class function_info *kernel = k.entry();
+  unsigned int padded_cta_size = threads_per_cta;
+  if (padded_cta_size % warp_size)
+    padded_cta_size = ((padded_cta_size / warp_size) + 1) * (warp_size);
 
-   dump_warp_state(fout);
-   fprintf(fout,"\n");
+  // Limit by n_threads/shader
+  unsigned int result_thread = n_thread_per_shader / padded_cta_size;
 
-   m_L1I->display_state(fout);
+  const struct gpgpu_ptx_sim_info *kernel_info = ptx_sim_kernel_info(kernel);
 
-   fprintf(fout, "IF/ID       = ");
-   if( !m_inst_fetch_buffer.m_valid )
-       fprintf(fout,"bubble\n");
-   else {
-       fprintf(fout,"w%2u : pc = 0x%x, nbytes = %u\n", 
-               m_inst_fetch_buffer.m_warp_id,
-               m_inst_fetch_buffer.m_pc, 
-               m_inst_fetch_buffer.m_nbytes );
-   }
-   fprintf(fout,"\nibuffer status:\n");
-   for( unsigned i=0; i<m_config->max_warps_per_shader; i++) {
-       if( !m_warp[i].ibuffer_empty() ) 
-           m_warp[i].print_ibuffer(fout);
-   }
-   fprintf(fout,"\n");
-   display_simt_state(fout,mask);
-   fprintf(fout, "-------------------------- Scoreboard\n");
-   m_scoreboard->printContents();
-/*
-   fprintf(fout,"ID/OC (SP)  = ");
-   print_stage(ID_OC_SP, fout);
-   fprintf(fout,"ID/OC (SFU) = ");
-   print_stage(ID_OC_SFU, fout);
-   fprintf(fout,"ID/OC (MEM) = ");
-   print_stage(ID_OC_MEM, fout);
-*/
-   fprintf(fout, "-------------------------- OP COL\n");
-   m_operand_collector.dump(fout);
-/* fprintf(fout, "OC/EX (SP)  = ");
-   print_stage(OC_EX_SP, fout);
-   fprintf(fout, "OC/EX (SFU) = ");
-   print_stage(OC_EX_SFU, fout);
-   fprintf(fout, "OC/EX (MEM) = ");
-   print_stage(OC_EX_MEM, fout);
-*/
-   fprintf(fout, "-------------------------- Pipe Regs\n");
+  // Limit by shmem/shader
+  unsigned int result_shmem = (unsigned)-1;
+  if (kernel_info->smem > 0)
+    result_shmem = gpgpu_shmem_size / kernel_info->smem;
 
-   for (unsigned i = 0; i < N_PIPELINE_STAGES; i++) {
-       fprintf(fout,"--- %s ---\n",pipeline_stage_name_decode[i]);
-       print_stage(i,fout);fprintf(fout,"\n");
-   }
+  // Limit by register count, rounded up to multiple of 4.
+  unsigned int result_regs = (unsigned)-1;
+  if (kernel_info->regs > 0)
+    result_regs = gpgpu_shader_registers /
+                  (padded_cta_size * ((kernel_info->regs + 3) & ~3));
 
-   fprintf(fout, "-------------------------- Fu\n");
-   for( unsigned n=0; n < m_num_function_units; n++ ){
-       m_fu[n]->print(fout);
-       fprintf(fout, "---------------\n");
-   }
-   fprintf(fout, "-------------------------- other:\n");
+  // Limit by CTA
+  unsigned int result_cta = max_cta_per_core;
 
-   for(unsigned i=0; i<num_result_bus; i++){
-	   std::string bits = m_result_bus[i]->to_string();
-	   fprintf(fout, "EX/WB sched[%d]= %s\n", i, bits.c_str() );
-   }
-   fprintf(fout, "EX/WB      = ");
-   print_stage(EX_WB, fout);
-   fprintf(fout, "\n");
-   fprintf(fout, "Last EX/WB writeback @ %llu + %llu (gpu_sim_cycle+gpu_tot_sim_cycle)\n",
-                 m_last_inst_gpu_sim_cycle, m_last_inst_gpu_tot_sim_cycle );
+  unsigned result = result_thread;
+  result = gs_min2(result, result_shmem);
+  result = gs_min2(result, result_regs);
+  result = gs_min2(result, result_cta);
 
-   if( m_active_threads.count() <= 2*m_config->warp_size ) {
-       fprintf(fout,"Active Threads : ");
-       unsigned last_warp_id = -1;
-       for(unsigned tid=0; tid < m_active_threads.size(); tid++ ) {
-           unsigned warp_id = tid/m_config->warp_size;
-           if( m_active_threads.test(tid) ) {
-               if( warp_id != last_warp_id ) {
-                   fprintf(fout,"\n  warp %u : ", warp_id );
-                   last_warp_id=warp_id;
-               }
-               fprintf(fout,"%u ", tid );
-           }
-       }
-   }
+  static const struct gpgpu_ptx_sim_info *last_kinfo = NULL;
+  if (last_kinfo !=
+      kernel_info) {  // Only print out stats if kernel_info struct changes
+    last_kinfo = kernel_info;
+    printf("GPGPU-Sim uArch: CTA/core = %u, limited by:", result);
+    if (result == result_thread) printf(" threads");
+    if (result == result_shmem) printf(" shmem");
+    if (result == result_regs) printf(" regs");
+    if (result == result_cta) printf(" cta_limit");
+    printf("\n");
+  }
 
-}
+  // gpu_max_cta_per_shader is limited by number of CTAs if not enough to keep
+  // all cores busy
+  if (k.num_blocks() < result * num_shader()) {
+    result = k.num_blocks() / num_shader();
+    if (k.num_blocks() % num_shader()) result++;
+  }
 
-unsigned int shader_core_config::max_cta( const kernel_info_t &k ) const
-{
-   unsigned threads_per_cta  = k.threads_per_cta();
-   const class function_info *kernel = k.entry();
-   unsigned int padded_cta_size = threads_per_cta;
-   if (padded_cta_size%warp_size) 
-      padded_cta_size = ((padded_cta_size/warp_size)+1)*(warp_size);
+  assert(result <= MAX_CTA_PER_SHADER);
+  if (result < 1) {
+    printf(
+        "GPGPU-Sim uArch: ERROR ** Kernel requires more resources than shader "
+        "has.\n");
+    if (gpgpu_ignore_resources_limitation) {
+      printf(
+          "GPGPU-Sim uArch: gpgpu_ignore_resources_limitation is set, ignore "
+          "the ERROR!\n");
+      return 1;
+    }
+    abort();
+  }
 
-   //Limit by n_threads/shader
-   unsigned int result_thread = n_thread_per_shader / padded_cta_size;
+  if (adaptive_volta_cache_config && !k.volta_cache_config_set) {
+    // For Volta, we assign the remaining shared memory to L1 cache
+    // For more info, see
+    // https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#shared-memory-7-x
+    unsigned total_shmed = kernel_info->smem * result;
+    assert(total_shmed >= 0 && total_shmed <= gpgpu_shmem_size);
+    assert(gpgpu_shmem_size == 98304);     // Volta has 96 KB shared
+    assert(m_L1D_config.get_nset() == 4);  // Volta L1 has four sets
+    if (total_shmed < gpgpu_shmem_size) {
+      if (total_shmed == 0)
+        m_L1D_config.set_assoc(256);  // L1 is 128KB ans shd=0
+      else if (total_shmed > 0 && total_shmed <= 8192)
+        m_L1D_config.set_assoc(240);  // L1 is 120KB ans shd=8KB
+      else if (total_shmed > 8192 && total_shmed <= 16384)
+        m_L1D_config.set_assoc(224);  // L1 is 112KB ans shd=16KB
+      else if (total_shmed > 16384 && total_shmed <= 32768)
+        m_L1D_config.set_assoc(192);  // L1 is 96KB ans shd=32KB
+      else if (total_shmed > 32768 && total_shmed <= 65536)
+        m_L1D_config.set_assoc(128);  // L1 is 64KB ans shd=64KB
+      else if (total_shmed > 65536 && total_shmed <= gpgpu_shmem_size)
+        m_L1D_config.set_assoc(64);  // L1 is 32KB and shd=96KB
+      else
+        assert(0);
 
-   const struct gpgpu_ptx_sim_info *kernel_info = ptx_sim_kernel_info(kernel);
-
-   //Limit by shmem/shader
-   unsigned int result_shmem = (unsigned)-1;
-   if (kernel_info->smem > 0)
-      result_shmem = gpgpu_shmem_size / kernel_info->smem;
-
-   //Limit by register count, rounded up to multiple of 4.
-   unsigned int result_regs = (unsigned)-1;
-   if (kernel_info->regs > 0)
-      result_regs = gpgpu_shader_registers / (padded_cta_size * ((kernel_info->regs+3)&~3));
-
-   //Limit by CTA
-   unsigned int result_cta = max_cta_per_core;
-
-   unsigned result = result_thread;
-   result = gs_min2(result, result_shmem);
-   result = gs_min2(result, result_regs);
-   result = gs_min2(result, result_cta);
-
-   static const struct gpgpu_ptx_sim_info* last_kinfo = NULL;
-   if (last_kinfo != kernel_info) {   //Only print out stats if kernel_info struct changes
-      last_kinfo = kernel_info;
-      printf ("GPGPU-Sim uArch: CTA/core = %u, limited by:", result);
-      if (result == result_thread) printf (" threads");
-      if (result == result_shmem) printf (" shmem");
-      if (result == result_regs) printf (" regs");
-      if (result == result_cta) printf (" cta_limit");
-      printf ("\n");
-   }
-
-    //gpu_max_cta_per_shader is limited by number of CTAs if not enough to keep all cores busy    
-    if( k.num_blocks() < result*num_shader() ) { 
-       result = k.num_blocks() / num_shader();
-       if (k.num_blocks() % num_shader())
-          result++;
+      printf("GPGPU-Sim: Reconfigure L1 cache in Volta Archi to %uKB\n",
+             m_L1D_config.get_total_size_inKB());
     }
 
-    assert( result <= MAX_CTA_PER_SHADER );
-    if (result < 1) {
-       printf ("GPGPU-Sim uArch: ERROR ** Kernel requires more resources than shader has.\n");
-       if(gpgpu_ignore_resources_limitation) {
-    	   printf ("GPGPU-Sim uArch: gpgpu_ignore_resources_limitation is set, ignore the ERROR!\n");
-    	   return 1;
-       }
-       abort();
-    }
+    k.volta_cache_config_set = true;
+  }
 
-    if(adaptive_volta_cache_config && !k.volta_cache_config_set) {
-    	//For Volta, we assign the remaining shared memory to L1 cache
-    	//For more info, see https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#shared-memory-7-x
-    	unsigned total_shmed = kernel_info->smem * result;
-    	assert(total_shmed >=0 && total_shmed <= gpgpu_shmem_size);
-    	assert(gpgpu_shmem_size == 98304); //Volta has 96 KB shared
-    	assert(m_L1D_config.get_nset() == 4);  //Volta L1 has four sets
-    	if(total_shmed < gpgpu_shmem_size){
-    		if(total_shmed == 0)
-    			m_L1D_config.set_assoc(256);  //L1 is 128KB ans shd=0
-    		else if(total_shmed > 0 && total_shmed <= 8192)
-    			m_L1D_config.set_assoc(240);  //L1 is 120KB ans shd=8KB
-    		else if(total_shmed > 8192 && total_shmed <= 16384)
-    		    m_L1D_config.set_assoc(224);  //L1 is 112KB ans shd=16KB
-    		else if(total_shmed > 16384 && total_shmed <= 32768)
-    		    m_L1D_config.set_assoc(192);  //L1 is 96KB ans shd=32KB
-    		else if(total_shmed > 32768 && total_shmed <= 65536)
-    		    m_L1D_config.set_assoc(128);	//L1 is 64KB ans shd=64KB
-    		else if(total_shmed > 65536 && total_shmed <= gpgpu_shmem_size)
-    		     m_L1D_config.set_assoc(64); //L1 is 32KB and shd=96KB
-    		else
-    			assert(0);
-
-    		 printf ("GPGPU-Sim: Reconfigure L1 cache in Volta Archi to %uKB\n", m_L1D_config.get_total_size_inKB());
-    	}
-
-    	k.volta_cache_config_set = true;
-    }
-
-    return result;
+  return result;
 }
 
 void shader_core_config::set_pipeline_latency() {
+  // calculate the max latency  based on the input
 
-		//calculate the max latency  based on the input
+  unsigned int_latency[5];
+  unsigned fp_latency[5];
+  unsigned dp_latency[5];
+  unsigned sfu_latency;
+  unsigned tensor_latency;
 
-		unsigned int_latency[5];
-		unsigned fp_latency[5];
-		unsigned dp_latency[5];
-		unsigned sfu_latency;
-		unsigned tensor_latency;
+  /*
+   * [0] ADD,SUB
+   * [1] MAX,Min
+   * [2] MUL
+   * [3] MAD
+   * [4] DIV
+   */
+  sscanf(gpgpu_ctx->func_sim->opcode_latency_int, "%u,%u,%u,%u,%u",
+         &int_latency[0], &int_latency[1], &int_latency[2], &int_latency[3],
+         &int_latency[4]);
+  sscanf(gpgpu_ctx->func_sim->opcode_latency_fp, "%u,%u,%u,%u,%u",
+         &fp_latency[0], &fp_latency[1], &fp_latency[2], &fp_latency[3],
+         &fp_latency[4]);
+  sscanf(gpgpu_ctx->func_sim->opcode_latency_dp, "%u,%u,%u,%u,%u",
+         &dp_latency[0], &dp_latency[1], &dp_latency[2], &dp_latency[3],
+         &dp_latency[4]);
+  sscanf(gpgpu_ctx->func_sim->opcode_latency_sfu, "%u", &sfu_latency);
+  sscanf(gpgpu_ctx->func_sim->opcode_latency_tensor, "%u", &tensor_latency);
 
-			/*
-			 * [0] ADD,SUB
-			 * [1] MAX,Min
-			 * [2] MUL
-			 * [3] MAD
-			 * [4] DIV
-			 */
-			sscanf(gpgpu_ctx->func_sim->opcode_latency_int, "%u,%u,%u,%u,%u",
-					&int_latency[0],&int_latency[1],&int_latency[2],
-					&int_latency[3],&int_latency[4]);
-			sscanf(gpgpu_ctx->func_sim->opcode_latency_fp, "%u,%u,%u,%u,%u",
-					&fp_latency[0],&fp_latency[1],&fp_latency[2],
-					&fp_latency[3],&fp_latency[4]);
-			sscanf(gpgpu_ctx->func_sim->opcode_latency_dp, "%u,%u,%u,%u,%u",
-					&dp_latency[0],&dp_latency[1],&dp_latency[2],
-					&dp_latency[3],&dp_latency[4]);
-			sscanf(gpgpu_ctx->func_sim->opcode_latency_sfu, "%u",
-					&sfu_latency);
-			sscanf(gpgpu_ctx->func_sim->opcode_latency_tensor, "%u",
-					&tensor_latency);
-
-		//all div operation are executed on sfu
-		//assume that the max latency are dp div or normal sfu_latency
-		max_sfu_latency = std::max(dp_latency[4],sfu_latency);
-		//assume that the max operation has the max latency
-		max_sp_latency = fp_latency[1];
-		max_int_latency = int_latency[1];
-		max_dp_latency = dp_latency[1];
-		max_tensor_core_latency = tensor_latency;
-
+  // all div operation are executed on sfu
+  // assume that the max latency are dp div or normal sfu_latency
+  max_sfu_latency = std::max(dp_latency[4], sfu_latency);
+  // assume that the max operation has the max latency
+  max_sp_latency = fp_latency[1];
+  max_int_latency = int_latency[1];
+  max_dp_latency = dp_latency[1];
+  max_tensor_core_latency = tensor_latency;
 }
 
-void shader_core_ctx::cycle()
-{
-	if(!isactive() && get_not_completed() == 0)
-		return;
+void shader_core_ctx::cycle() {
+  if (!isactive() && get_not_completed() == 0) return;
 
-	m_stats->shader_cycles[m_sid]++;
-    writeback();
-    execute();
-    read_operands();
-    issue();
-    decode();
-    fetch();
+  m_stats->shader_cycles[m_sid]++;
+  writeback();
+  execute();
+  read_operands();
+  issue();
+  decode();
+  fetch();
 }
 
 // Flushes all content of the cache to memory
 
-void shader_core_ctx::cache_flush()
-{
-   m_ldst_unit->flush();
-}
+void shader_core_ctx::cache_flush() { m_ldst_unit->flush(); }
 
-void shader_core_ctx::cache_invalidate()
-{
-   m_ldst_unit->invalidate();
-}
+void shader_core_ctx::cache_invalidate() { m_ldst_unit->invalidate(); }
 
 // modifiers
-std::list<opndcoll_rfu_t::op_t> opndcoll_rfu_t::arbiter_t::allocate_reads() 
-{
-   std::list<op_t> result;  // a list of registers that (a) are in different register banks, (b) do not go to the same operand collector
+std::list<opndcoll_rfu_t::op_t> opndcoll_rfu_t::arbiter_t::allocate_reads() {
+  std::list<op_t> result;  // a list of registers that (a) are in different
+                           // register banks, (b) do not go to the same operand
+                           // collector
 
-   int input;
-   int output;
-   int _inputs = m_num_banks;
-   int _outputs = m_num_collectors;
-   int _square = ( _inputs > _outputs ) ? _inputs : _outputs;
-   assert(_square > 0);
-   int _pri = (int)m_last_cu;
+  int input;
+  int output;
+  int _inputs = m_num_banks;
+  int _outputs = m_num_collectors;
+  int _square = (_inputs > _outputs) ? _inputs : _outputs;
+  assert(_square > 0);
+  int _pri = (int)m_last_cu;
 
-   // Clear matching
-   for ( int i = 0; i < _inputs; ++i ) 
-      _inmatch[i] = -1;
-   for ( int j = 0; j < _outputs; ++j ) 
-      _outmatch[j] = -1;
+  // Clear matching
+  for (int i = 0; i < _inputs; ++i) _inmatch[i] = -1;
+  for (int j = 0; j < _outputs; ++j) _outmatch[j] = -1;
 
-   for( unsigned i=0; i<m_num_banks; i++) {
-      for( unsigned j=0; j<m_num_collectors; j++) {
-         assert( i < (unsigned)_inputs );
-         assert( j < (unsigned)_outputs );
-         _request[i][j] = 0;
+  for (unsigned i = 0; i < m_num_banks; i++) {
+    for (unsigned j = 0; j < m_num_collectors; j++) {
+      assert(i < (unsigned)_inputs);
+      assert(j < (unsigned)_outputs);
+      _request[i][j] = 0;
+    }
+    if (!m_queue[i].empty()) {
+      const op_t &op = m_queue[i].front();
+      int oc_id = op.get_oc_id();
+      assert(i < (unsigned)_inputs);
+      assert(oc_id < _outputs);
+      _request[i][oc_id] = 1;
+    }
+    if (m_allocated_bank[i].is_write()) {
+      assert(i < (unsigned)_inputs);
+      _inmatch[i] = 0;  // write gets priority
+    }
+  }
+
+  ///// wavefront allocator from booksim... --->
+
+  // Loop through diagonals of request matrix
+
+  for (int p = 0; p < _square; ++p) {
+    output = (_pri + p) % _square;
+
+    // Step through the current diagonal
+    for (input = 0; input < _inputs; ++input) {
+      assert(input < _inputs);
+      assert(output < _outputs);
+      if ((output < _outputs) && (_inmatch[input] == -1) &&
+          (_outmatch[output] == -1) &&
+          (_request[input][output] /*.label != -1*/)) {
+        // Grant!
+        _inmatch[input] = output;
+        _outmatch[output] = input;
       }
-      if( !m_queue[i].empty() ) {
-         const op_t &op = m_queue[i].front();
-         int oc_id = op.get_oc_id();
-         assert( i < (unsigned)_inputs );
-         assert( oc_id < _outputs );
-         _request[i][oc_id] = 1;
+
+      output = (output + 1) % _square;
+    }
+  }
+
+  // Round-robin the priority diagonal
+  _pri = (_pri + 1) % _square;
+
+  /// <--- end code from booksim
+
+  m_last_cu = _pri;
+  for (unsigned i = 0; i < m_num_banks; i++) {
+    if (_inmatch[i] != -1) {
+      if (!m_allocated_bank[i].is_write()) {
+        unsigned bank = (unsigned)i;
+        op_t &op = m_queue[bank].front();
+        result.push_back(op);
+        m_queue[bank].pop_front();
       }
-      if( m_allocated_bank[i].is_write() ) {
-         assert( i < (unsigned)_inputs );
-         _inmatch[i] = 0; // write gets priority
-      }
-   }
+    }
+  }
 
-   ///// wavefront allocator from booksim... --->
-   
-   // Loop through diagonals of request matrix
-
-   for ( int p = 0; p < _square; ++p ) {
-      output = ( _pri + p ) % _square;
-
-      // Step through the current diagonal
-      for ( input = 0; input < _inputs; ++input ) {
-          assert( input < _inputs );
-          assert( output < _outputs );
-         if ( ( output < _outputs ) && 
-              ( _inmatch[input] == -1 ) && 
-              ( _outmatch[output] == -1 ) &&
-              ( _request[input][output]/*.label != -1*/ ) ) {
-            // Grant!
-            _inmatch[input] = output;
-            _outmatch[output] = input;
-         }
-
-         output = ( output + 1 ) % _square;
-      }
-   }
-
-   // Round-robin the priority diagonal
-   _pri = ( _pri + 1 ) % _square;
-
-   /// <--- end code from booksim
-
-   m_last_cu = _pri;
-   for( unsigned i=0; i < m_num_banks; i++ ) {
-      if( _inmatch[i] != -1 ) {
-         if( !m_allocated_bank[i].is_write() ) {
-            unsigned bank = (unsigned)i;
-            op_t &op = m_queue[bank].front();
-            result.push_back(op);
-            m_queue[bank].pop_front();
-         }
-      }
-   }
-
-   return result;
+  return result;
 }
 
-barrier_set_t::barrier_set_t(shader_core_ctx *shader,unsigned max_warps_per_core, unsigned max_cta_per_core, unsigned max_barriers_per_cta, unsigned warp_size)
-{
-   m_max_warps_per_core = max_warps_per_core;
-   m_max_cta_per_core = max_cta_per_core;
-   m_max_barriers_per_cta = max_barriers_per_cta;
-   m_warp_size = warp_size;
-   m_shader = shader;
-   if( max_warps_per_core > WARP_PER_CTA_MAX ) {
-      printf("ERROR ** increase WARP_PER_CTA_MAX in shader.h from %u to >= %u or warps per cta in gpgpusim.config\n",
-             WARP_PER_CTA_MAX, max_warps_per_core );
-      exit(1);
-   }
-   if(max_barriers_per_cta > MAX_BARRIERS_PER_CTA){
-	   printf("ERROR ** increase MAX_BARRIERS_PER_CTA in abstract_hardware_model.h from %u to >= %u or barriers per cta in gpgpusim.config\n",
-			   MAX_BARRIERS_PER_CTA, max_barriers_per_cta );
-	   exit(1);
-   }
-   m_warp_active.reset();
-   m_warp_at_barrier.reset();
-   for(unsigned i=0; i<max_barriers_per_cta; i++){
-	   m_bar_id_to_warps[i].reset();
-   }
+barrier_set_t::barrier_set_t(shader_core_ctx *shader,
+                             unsigned max_warps_per_core,
+                             unsigned max_cta_per_core,
+                             unsigned max_barriers_per_cta,
+                             unsigned warp_size) {
+  m_max_warps_per_core = max_warps_per_core;
+  m_max_cta_per_core = max_cta_per_core;
+  m_max_barriers_per_cta = max_barriers_per_cta;
+  m_warp_size = warp_size;
+  m_shader = shader;
+  if (max_warps_per_core > WARP_PER_CTA_MAX) {
+    printf(
+        "ERROR ** increase WARP_PER_CTA_MAX in shader.h from %u to >= %u or "
+        "warps per cta in gpgpusim.config\n",
+        WARP_PER_CTA_MAX, max_warps_per_core);
+    exit(1);
+  }
+  if (max_barriers_per_cta > MAX_BARRIERS_PER_CTA) {
+    printf(
+        "ERROR ** increase MAX_BARRIERS_PER_CTA in abstract_hardware_model.h "
+        "from %u to >= %u or barriers per cta in gpgpusim.config\n",
+        MAX_BARRIERS_PER_CTA, max_barriers_per_cta);
+    exit(1);
+  }
+  m_warp_active.reset();
+  m_warp_at_barrier.reset();
+  for (unsigned i = 0; i < max_barriers_per_cta; i++) {
+    m_bar_id_to_warps[i].reset();
+  }
 }
 
 // during cta allocation
-void barrier_set_t::allocate_barrier( unsigned cta_id, warp_set_t warps )
-{
-   assert( cta_id < m_max_cta_per_core );
-   cta_to_warp_t::iterator w=m_cta_to_warps.find(cta_id);
-   assert( w == m_cta_to_warps.end() ); // cta should not already be active or allocated barrier resources
-   m_cta_to_warps[cta_id] = warps;
-   assert( m_cta_to_warps.size() <= m_max_cta_per_core ); // catch cta's that were not properly deallocated
-  
-   m_warp_active |= warps;
-   m_warp_at_barrier &= ~warps;
-   for(unsigned i=0; i<m_max_barriers_per_cta; i++){
-	   m_bar_id_to_warps[i] &=~warps;
-   }
+void barrier_set_t::allocate_barrier(unsigned cta_id, warp_set_t warps) {
+  assert(cta_id < m_max_cta_per_core);
+  cta_to_warp_t::iterator w = m_cta_to_warps.find(cta_id);
+  assert(w == m_cta_to_warps.end());  // cta should not already be active or
+                                      // allocated barrier resources
+  m_cta_to_warps[cta_id] = warps;
+  assert(m_cta_to_warps.size() <=
+         m_max_cta_per_core);  // catch cta's that were not properly deallocated
 
+  m_warp_active |= warps;
+  m_warp_at_barrier &= ~warps;
+  for (unsigned i = 0; i < m_max_barriers_per_cta; i++) {
+    m_bar_id_to_warps[i] &= ~warps;
+  }
 }
 
 // during cta deallocation
-void barrier_set_t::deallocate_barrier( unsigned cta_id )
-{
-   cta_to_warp_t::iterator w=m_cta_to_warps.find(cta_id);
-   if( w == m_cta_to_warps.end() )
-      return;
-   warp_set_t warps = w->second;
-   warp_set_t at_barrier = warps & m_warp_at_barrier;
-   assert( at_barrier.any() == false ); // no warps stuck at barrier
-   warp_set_t active = warps & m_warp_active;
-   assert( active.any() == false ); // no warps in CTA still running
-   m_warp_active &= ~warps;
-   m_warp_at_barrier &= ~warps;
+void barrier_set_t::deallocate_barrier(unsigned cta_id) {
+  cta_to_warp_t::iterator w = m_cta_to_warps.find(cta_id);
+  if (w == m_cta_to_warps.end()) return;
+  warp_set_t warps = w->second;
+  warp_set_t at_barrier = warps & m_warp_at_barrier;
+  assert(at_barrier.any() == false);  // no warps stuck at barrier
+  warp_set_t active = warps & m_warp_active;
+  assert(active.any() == false);  // no warps in CTA still running
+  m_warp_active &= ~warps;
+  m_warp_at_barrier &= ~warps;
 
-   for(unsigned i=0; i<m_max_barriers_per_cta; i++){
-	   warp_set_t at_a_specific_barrier = warps & m_bar_id_to_warps[i];
-	   assert( at_a_specific_barrier.any() == false ); // no warps stuck at barrier
-	   m_bar_id_to_warps[i] &=~warps;
-   }
-   m_cta_to_warps.erase(w);
+  for (unsigned i = 0; i < m_max_barriers_per_cta; i++) {
+    warp_set_t at_a_specific_barrier = warps & m_bar_id_to_warps[i];
+    assert(at_a_specific_barrier.any() == false);  // no warps stuck at barrier
+    m_bar_id_to_warps[i] &= ~warps;
+  }
+  m_cta_to_warps.erase(w);
 }
 
 // individual warp hits barrier
-void barrier_set_t::warp_reaches_barrier(unsigned cta_id,unsigned warp_id,warp_inst_t* inst)
-{
-	barrier_type bar_type = inst->bar_type;
-	unsigned bar_id = inst->bar_id;
-	unsigned bar_count = inst->bar_count;
-	assert(bar_id!=(unsigned)-1);
-   cta_to_warp_t::iterator w=m_cta_to_warps.find(cta_id);
+void barrier_set_t::warp_reaches_barrier(unsigned cta_id, unsigned warp_id,
+                                         warp_inst_t *inst) {
+  barrier_type bar_type = inst->bar_type;
+  unsigned bar_id = inst->bar_id;
+  unsigned bar_count = inst->bar_count;
+  assert(bar_id != (unsigned)-1);
+  cta_to_warp_t::iterator w = m_cta_to_warps.find(cta_id);
 
-   if( w == m_cta_to_warps.end() ) { // cta is active
-      printf("ERROR ** cta_id %u not found in barrier set on cycle %llu+%llu...\n", cta_id, m_shader->get_gpu()->gpu_tot_sim_cycle, m_shader->get_gpu()->gpu_sim_cycle );
-      dump();
-      abort();
-   }
-   assert( w->second.test(warp_id) == true ); // warp is in cta
-
-   m_bar_id_to_warps[bar_id].set(warp_id);
-   if(bar_type==SYNC || bar_type==RED){
-	   m_warp_at_barrier.set(warp_id);
-   }
-   warp_set_t warps_in_cta = w->second;
-   warp_set_t at_barrier = warps_in_cta & m_bar_id_to_warps[bar_id];
-   warp_set_t active = warps_in_cta & m_warp_active;
-   if(bar_count==(unsigned)-1){
-	   if( at_barrier == active ) {
-		   // all warps have reached barrier, so release waiting warps...
-		   m_bar_id_to_warps[bar_id] &= ~at_barrier;
-		   m_warp_at_barrier &= ~at_barrier;
-		   if(bar_type==RED){
-			   m_shader->broadcast_barrier_reduction(cta_id, bar_id,at_barrier);
-		   }
-	   }
-  }else{
-	  // TODO: check on the hardware if the count should include warp that exited
-	  if ((at_barrier.count() * m_warp_size) == bar_count){
-		   // required number of warps have reached barrier, so release waiting warps...
-		   m_bar_id_to_warps[bar_id] &= ~at_barrier;
-		   m_warp_at_barrier &= ~at_barrier;
-		   if(bar_type==RED){
-			   m_shader->broadcast_barrier_reduction(cta_id, bar_id,at_barrier);
-		   }
-	  }
+  if (w == m_cta_to_warps.end()) {  // cta is active
+    printf(
+        "ERROR ** cta_id %u not found in barrier set on cycle %llu+%llu...\n",
+        cta_id, m_shader->get_gpu()->gpu_tot_sim_cycle,
+        m_shader->get_gpu()->gpu_sim_cycle);
+    dump();
+    abort();
   }
+  assert(w->second.test(warp_id) == true);  // warp is in cta
 
-
+  m_bar_id_to_warps[bar_id].set(warp_id);
+  if (bar_type == SYNC || bar_type == RED) {
+    m_warp_at_barrier.set(warp_id);
+  }
+  warp_set_t warps_in_cta = w->second;
+  warp_set_t at_barrier = warps_in_cta & m_bar_id_to_warps[bar_id];
+  warp_set_t active = warps_in_cta & m_warp_active;
+  if (bar_count == (unsigned)-1) {
+    if (at_barrier == active) {
+      // all warps have reached barrier, so release waiting warps...
+      m_bar_id_to_warps[bar_id] &= ~at_barrier;
+      m_warp_at_barrier &= ~at_barrier;
+      if (bar_type == RED) {
+        m_shader->broadcast_barrier_reduction(cta_id, bar_id, at_barrier);
+      }
+    }
+  } else {
+    // TODO: check on the hardware if the count should include warp that exited
+    if ((at_barrier.count() * m_warp_size) == bar_count) {
+      // required number of warps have reached barrier, so release waiting
+      // warps...
+      m_bar_id_to_warps[bar_id] &= ~at_barrier;
+      m_warp_at_barrier &= ~at_barrier;
+      if (bar_type == RED) {
+        m_shader->broadcast_barrier_reduction(cta_id, bar_id, at_barrier);
+      }
+    }
+  }
 }
 
+// warp reaches exit
+void barrier_set_t::warp_exit(unsigned warp_id) {
+  // caller needs to verify all threads in warp are done, e.g., by checking PDOM
+  // stack to
+  // see it has only one entry during exit_impl()
+  m_warp_active.reset(warp_id);
 
-// warp reaches exit 
-void barrier_set_t::warp_exit( unsigned warp_id )
-{
-   // caller needs to verify all threads in warp are done, e.g., by checking PDOM stack to 
-   // see it has only one entry during exit_impl()
-   m_warp_active.reset(warp_id);
+  // test for barrier release
+  cta_to_warp_t::iterator w = m_cta_to_warps.begin();
+  for (; w != m_cta_to_warps.end(); ++w) {
+    if (w->second.test(warp_id) == true) break;
+  }
+  warp_set_t warps_in_cta = w->second;
+  warp_set_t active = warps_in_cta & m_warp_active;
 
-   // test for barrier release 
-   cta_to_warp_t::iterator w=m_cta_to_warps.begin(); 
-   for (; w != m_cta_to_warps.end(); ++w) {
-      if (w->second.test(warp_id) == true) break; 
-   }
-   warp_set_t warps_in_cta = w->second;
-   warp_set_t active = warps_in_cta & m_warp_active;
-
-   for(unsigned i=0; i<m_max_barriers_per_cta; i++){
-	   warp_set_t at_a_specific_barrier = warps_in_cta & m_bar_id_to_warps[i];
-	   if( at_a_specific_barrier == active ) {
-	      // all warps have reached barrier, so release waiting warps...
-		   m_bar_id_to_warps[i] &= ~at_a_specific_barrier;
-		   m_warp_at_barrier &= ~at_a_specific_barrier;
-	   }
-   }
+  for (unsigned i = 0; i < m_max_barriers_per_cta; i++) {
+    warp_set_t at_a_specific_barrier = warps_in_cta & m_bar_id_to_warps[i];
+    if (at_a_specific_barrier == active) {
+      // all warps have reached barrier, so release waiting warps...
+      m_bar_id_to_warps[i] &= ~at_a_specific_barrier;
+      m_warp_at_barrier &= ~at_a_specific_barrier;
+    }
+  }
 }
 
 // assertions
-bool barrier_set_t::warp_waiting_at_barrier( unsigned warp_id ) const
-{ 
-   return m_warp_at_barrier.test(warp_id);
+bool barrier_set_t::warp_waiting_at_barrier(unsigned warp_id) const {
+  return m_warp_at_barrier.test(warp_id);
 }
 
-void barrier_set_t::dump()
-{
-   printf( "barrier set information\n");
-   printf( "  m_max_cta_per_core = %u\n",  m_max_cta_per_core );
-   printf( "  m_max_warps_per_core = %u\n", m_max_warps_per_core );
-   printf( " m_max_barriers_per_cta =%u\n", m_max_barriers_per_cta);
-   printf( "  cta_to_warps:\n");
-   
-   cta_to_warp_t::const_iterator i;
-   for( i=m_cta_to_warps.begin(); i!=m_cta_to_warps.end(); i++ ) {
-      unsigned cta_id = i->first;
-      warp_set_t warps = i->second;
-      printf("    cta_id %u : %s\n", cta_id, warps.to_string().c_str() );
-   }
-   printf("  warp_active: %s\n", m_warp_active.to_string().c_str() );
-   printf("  warp_at_barrier: %s\n", m_warp_at_barrier.to_string().c_str() );
-   for( unsigned i=0; i<m_max_barriers_per_cta; i++){
-	   warp_set_t warps_reached_barrier = m_bar_id_to_warps[i];
-	   printf("  warp_at_barrier %u: %s\n", i, warps_reached_barrier.to_string().c_str() );
-   }
-   fflush(stdout); 
-}
+void barrier_set_t::dump() {
+  printf("barrier set information\n");
+  printf("  m_max_cta_per_core = %u\n", m_max_cta_per_core);
+  printf("  m_max_warps_per_core = %u\n", m_max_warps_per_core);
+  printf(" m_max_barriers_per_cta =%u\n", m_max_barriers_per_cta);
+  printf("  cta_to_warps:\n");
 
-void shader_core_ctx::warp_exit( unsigned warp_id )
-{
-	bool done = true;
-	for (	unsigned i = warp_id*get_config()->warp_size;
-			i < (warp_id+1)*get_config()->warp_size;
-			i++ ) {
-
-//		if(this->m_thread[i]->m_functional_model_thread_state && this->m_thread[i].m_functional_model_thread_state->donecycle()==0) {
-//			done = false;
-//		}
-
-
-		if (m_thread[i] && !m_thread[i]->is_done()) done = false;
-	}
-	//if (m_warp[warp_id].get_n_completed() == get_config()->warp_size)
-	//if (this->m_simt_stack[warp_id]->get_num_entries() == 0)
-	if (done)
-		m_barriers.warp_exit( warp_id );
-}
-
-bool shader_core_ctx::check_if_non_released_reduction_barrier(warp_inst_t &inst)
-{
-	unsigned warp_id = inst.warp_id();
-	bool bar_red_op = (inst.op == BARRIER_OP) && (inst.bar_type == RED);
-    bool non_released_barrier_reduction = false;
-    bool warp_stucked_at_barrier = warp_waiting_at_barrier(warp_id);
-    bool single_inst_in_pipeline = (m_warp[warp_id].num_issued_inst_in_pipeline()==1);
-    non_released_barrier_reduction = single_inst_in_pipeline and warp_stucked_at_barrier and bar_red_op;
-    printf("non_released_barrier_reduction=%u\n",non_released_barrier_reduction);
-    return non_released_barrier_reduction;
-}
-
-bool shader_core_ctx::warp_waiting_at_barrier( unsigned warp_id ) const
-{
-   return m_barriers.warp_waiting_at_barrier(warp_id);
-}
-
-bool shader_core_ctx::warp_waiting_at_mem_barrier( unsigned warp_id ) 
-{
-   if( !m_warp[warp_id].get_membar() ) 
-      return false;
-   if( !m_scoreboard->pendingWrites(warp_id) ) {
-      m_warp[warp_id].clear_membar();
-      return false;
-   }
-   return true;
-}
-
-void shader_core_ctx::set_max_cta( const kernel_info_t &kernel ) 
-{
-    // calculate the max cta count and cta size for local memory address mapping
-    kernel_max_cta_per_shader = m_config->max_cta(kernel);
-    unsigned int gpu_cta_size = kernel.threads_per_cta();
-    kernel_padded_threads_per_cta = (gpu_cta_size%m_config->warp_size) ? 
-        m_config->warp_size*((gpu_cta_size/m_config->warp_size)+1) : 
-        gpu_cta_size;
-}
-
-void shader_core_ctx::decrement_atomic_count( unsigned wid, unsigned n )
-{
-   assert( m_warp[wid].get_n_atomic() >= n );
-   m_warp[wid].dec_n_atomic(n);
-}
-
-void shader_core_ctx::broadcast_barrier_reduction(unsigned cta_id,unsigned bar_id,warp_set_t warps)
-{
-	for(unsigned i=0; i<m_config->max_warps_per_shader;i++){
-		if(warps.test(i)){
-			const warp_inst_t * inst = m_warp[i].restore_info_of_last_inst_at_barrier();
-			const_cast<warp_inst_t *> (inst)->broadcast_barrier_reduction(inst->get_active_mask());
-		}
-	}
-}
-
-bool shader_core_ctx::fetch_unit_response_buffer_full() const
-{
-    return false;
-}
-
-void shader_core_ctx::accept_fetch_response( mem_fetch *mf )
-{
-    mf->set_status(IN_SHADER_FETCHED,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-    m_L1I->fill(mf,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-}
-
-bool shader_core_ctx::ldst_unit_response_buffer_full() const
-{
-    return m_ldst_unit->response_buffer_full();
-}
-
-void shader_core_ctx::accept_ldst_unit_response(mem_fetch * mf) 
-{
-   m_ldst_unit->fill(mf);
-}
-
-void shader_core_ctx::store_ack( class mem_fetch *mf )
-{
-	assert( mf->get_type() == WRITE_ACK  || ( m_config->gpgpu_perfect_mem && mf->get_is_write() ) );
-    unsigned warp_id = mf->get_wid();
-    m_warp[warp_id].dec_store_req();
-}
-
-void shader_core_ctx::print_cache_stats( FILE *fp, unsigned& dl1_accesses, unsigned& dl1_misses ) {
-   m_ldst_unit->print_cache_stats( fp, dl1_accesses, dl1_misses );
-}
-
-void shader_core_ctx::get_cache_stats(cache_stats &cs){
-    // Adds stats from each cache to 'cs'
-    cs += m_L1I->get_stats(); // Get L1I stats
-    m_ldst_unit->get_cache_stats(cs); // Get L1D, L1C, L1T stats
-}
-
-void shader_core_ctx::get_L1I_sub_stats(struct cache_sub_stats &css) const{
-    if(m_L1I)
-        m_L1I->get_sub_stats(css);
-}
-void shader_core_ctx::get_L1D_sub_stats(struct cache_sub_stats &css) const{
-    m_ldst_unit->get_L1D_sub_stats(css);
-}
-void shader_core_ctx::get_L1C_sub_stats(struct cache_sub_stats &css) const{
-    m_ldst_unit->get_L1C_sub_stats(css);
-}
-void shader_core_ctx::get_L1T_sub_stats(struct cache_sub_stats &css) const{
-    m_ldst_unit->get_L1T_sub_stats(css);
-}
-
-void shader_core_ctx::get_icnt_power_stats(long &n_simt_to_mem, long &n_mem_to_simt) const{
-	n_simt_to_mem += m_stats->n_simt_to_mem[m_sid];
-	n_mem_to_simt += m_stats->n_mem_to_simt[m_sid];
-}
-
-bool shd_warp_t::functional_done() const
-{
-    return get_n_completed() == m_warp_size;
-}
-
-bool shd_warp_t::hardware_done() const
-{
-    return functional_done() && stores_done() && !inst_in_pipeline(); 
-}
-
-bool shd_warp_t::waiting() 
-{
-    if ( functional_done() ) {
-        // waiting to be initialized with a kernel
-        return true;
-    } else if ( m_shader->warp_waiting_at_barrier(m_warp_id) ) {
-        // waiting for other warps in CTA to reach barrier
-        return true;
-    } else if ( m_shader->warp_waiting_at_mem_barrier(m_warp_id) ) {
-        // waiting for memory barrier
-        return true;
-    } else if ( m_n_atomic >0 ) {
-        // waiting for atomic operation to complete at memory:
-        // this stall is not required for accurate timing model, but rather we
-        // stall here since if a call/return instruction occurs in the meantime
-        // the functional execution of the atomic when it hits DRAM can cause
-        // the wrong register to be read.
-        return true;
-    }
-    return false;
-}
-
-void shd_warp_t::print( FILE *fout ) const
-{
-    if( !done_exit() ) {
-        fprintf( fout, "w%02u npc: 0x%04x, done:%c%c%c%c:%2u i:%u s:%u a:%u (done: ", 
-                m_warp_id,
-                m_next_pc,
-                (functional_done()?'f':' '),
-                (stores_done()?'s':' '),
-                (inst_in_pipeline()?' ':'i'),
-                (done_exit()?'e':' '),
-                n_completed,
-                m_inst_in_pipeline, 
-                m_stores_outstanding,
-                m_n_atomic );
-        for (unsigned i = m_warp_id*m_warp_size; i < (m_warp_id+1)*m_warp_size; i++ ) {
-          if ( m_shader->ptx_thread_done(i) ) fprintf(fout,"1");
-          else fprintf(fout,"0");
-          if ( (((i+1)%4) == 0) && (i+1) < (m_warp_id+1)*m_warp_size ) 
-             fprintf(fout,",");
-        }
-        fprintf(fout,") ");
-        fprintf(fout," active=%s", m_active_threads.to_string().c_str() );
-        fprintf(fout," last fetched @ %5llu", m_last_fetch);
-        if( m_imiss_pending ) 
-            fprintf(fout," i-miss pending");
-        fprintf(fout,"\n");
-    }
-}
-
-void shd_warp_t::print_ibuffer( FILE *fout ) const
-{
-    fprintf(fout,"  ibuffer[%2u] : ", m_warp_id );
-    for( unsigned i=0; i < IBUFFER_SIZE; i++) {
-        const inst_t *inst = m_ibuffer[i].m_inst;
-        if( inst ) inst->print_insn(fout);
-        else if( m_ibuffer[i].m_valid ) 
-           fprintf(fout," <invalid instruction> ");
-        else fprintf(fout," <empty> ");
-    }
-    fprintf(fout,"\n");
-}
-
-void opndcoll_rfu_t::add_cu_set(unsigned set_id, unsigned num_cu, unsigned num_dispatch){
-    m_cus[set_id].reserve(num_cu); //this is necessary to stop pointers in m_cu from being invalid do to a resize;
-    for (unsigned i = 0; i < num_cu; i++) {
-        m_cus[set_id].push_back(collector_unit_t());
-        m_cu.push_back(&m_cus[set_id].back());
-    }
-    // for now each collector set gets dedicated dispatch units.
-    for (unsigned i = 0; i < num_dispatch; i++) {
-        m_dispatch_units.push_back(dispatch_unit_t(&m_cus[set_id]));
-    }
-}
-
-
-void opndcoll_rfu_t::add_port(port_vector_t & input, port_vector_t & output, uint_vector_t cu_sets)
-{
-    //m_num_ports++;
-    //m_num_collectors += num_collector_units;
-    //m_input.resize(m_num_ports);
-    //m_output.resize(m_num_ports);
-    //m_num_collector_units.resize(m_num_ports);
-    //m_input[m_num_ports-1]=input_port;
-    //m_output[m_num_ports-1]=output_port;
-    //m_num_collector_units[m_num_ports-1]=num_collector_units;
-    m_in_ports.push_back(input_port_t(input,output,cu_sets));
-}
-
-void opndcoll_rfu_t::init( unsigned num_banks, shader_core_ctx *shader )
-{
-   m_shader=shader;
-   m_arbiter.init(m_cu.size(),num_banks);
-   //for( unsigned n=0; n<m_num_ports;n++ ) 
-   //    m_dispatch_units[m_output[n]].init( m_num_collector_units[n] );
-   m_num_banks = num_banks;
-   m_bank_warp_shift = 0; 
-   m_warp_size = shader->get_config()->warp_size;
-   m_bank_warp_shift = (unsigned)(int) (log(m_warp_size+0.5) / log(2.0));
-   assert( (m_bank_warp_shift == 5) || (m_warp_size != 32) );
-
-   sub_core_model = shader->get_config()->sub_core_model;
-   m_num_warp_sceds = shader->get_config()->gpgpu_num_sched_per_core;
-   if(sub_core_model)
-	   assert(num_banks % shader->get_config()->gpgpu_num_sched_per_core == 0);
-   m_num_banks_per_sched = num_banks / shader->get_config()->gpgpu_num_sched_per_core;
-
-   for( unsigned j=0; j<m_cu.size(); j++) {
-       m_cu[j]->init(j,num_banks,m_bank_warp_shift,shader->get_config(),this, sub_core_model, m_num_banks_per_sched );
-   }
-   m_initialized=true;
-
-
-
-
-}
-
-int register_bank(int regnum, int wid, unsigned num_banks, unsigned bank_warp_shift, bool sub_core_model, unsigned banks_per_sched, unsigned sched_id)
-{
-   int bank = regnum;
-   if (bank_warp_shift)
-      bank += wid;
-   if(sub_core_model) {
-	   unsigned bank_num  = (bank % banks_per_sched) + (sched_id * banks_per_sched);
-	   assert(bank_num < num_banks);
-	   return bank_num;
-   }
-   else
-	   return bank % num_banks;
-}
-
-bool opndcoll_rfu_t::writeback( warp_inst_t &inst )
-{
-   assert( !inst.empty() );
-   std::list<unsigned> regs = m_shader->get_regs_written(inst);
-   for( unsigned op=0; op < MAX_REG_OPERANDS; op++ ) {
-      int reg_num = inst.arch_reg.dst[op]; // this math needs to match that used in function_info::ptx_decode_inst
-      if( reg_num >= 0 ){ // valid register
-         unsigned bank = register_bank(reg_num,inst.warp_id(),m_num_banks,m_bank_warp_shift, sub_core_model, m_num_banks_per_sched, inst.get_schd_id());
-         if( m_arbiter.bank_idle(bank) ) {
-             m_arbiter.allocate_bank_for_write(bank,op_t(&inst,reg_num,m_num_banks,m_bank_warp_shift, sub_core_model, m_num_banks_per_sched, inst.get_schd_id()));
-             inst.arch_reg.dst[op] = -1;
-         } else {
-             return false;
-         }
-      }
-   }
-   for(unsigned i=0;i<(unsigned)regs.size();i++){
-	      if(m_shader->get_config()->gpgpu_clock_gated_reg_file){
-	    	  unsigned active_count=0;
-	    	  for(unsigned i=0;i<m_shader->get_config()->warp_size;i=i+m_shader->get_config()->n_regfile_gating_group){
-	    		  for(unsigned j=0;j<m_shader->get_config()->n_regfile_gating_group;j++){
-	    			  if(inst.get_active_mask().test(i+j)){
-	    				  active_count+=m_shader->get_config()->n_regfile_gating_group;
-	    				  break;
-	    			  }
-	    		  }
-	    	  }
-	    	  m_shader->incregfile_writes(active_count);
-	      }else{
-	    	  m_shader->incregfile_writes(m_shader->get_config()->warp_size);//inst.active_count());
-	      }
-   }
-   return true;
-}
-
-void opndcoll_rfu_t::dispatch_ready_cu()
-{
-   for( unsigned p=0; p < m_dispatch_units.size(); ++p ) {
-      dispatch_unit_t &du = m_dispatch_units[p];
-      collector_unit_t *cu = du.find_ready();
-      if( cu ) {
-    	 for(unsigned i=0;i<(cu->get_num_operands()-cu->get_num_regs());i++){
-   	      if(m_shader->get_config()->gpgpu_clock_gated_reg_file){
-   	    	  unsigned active_count=0;
-   	    	  for(unsigned i=0;i<m_shader->get_config()->warp_size;i=i+m_shader->get_config()->n_regfile_gating_group){
-   	    		  for(unsigned j=0;j<m_shader->get_config()->n_regfile_gating_group;j++){
-   	    			  if(cu->get_active_mask().test(i+j)){
-   	    				  active_count+=m_shader->get_config()->n_regfile_gating_group;
-   	    				  break;
-   	    			  }
-   	    		  }
-   	    	  }
-   	    	  m_shader->incnon_rf_operands(active_count);
-   	      }else{
-    		 m_shader->incnon_rf_operands(m_shader->get_config()->warp_size);//cu->get_active_count());
-   	      }
-    	}
-         cu->dispatch();
-      }
-   }
-}
-
-void opndcoll_rfu_t::allocate_cu( unsigned port_num )
-{
-   input_port_t& inp = m_in_ports[port_num];
-   for (unsigned i = 0; i < inp.m_in.size(); i++) {
-       if( (*inp.m_in[i]).has_ready() ) {
-          //find a free cu 
-          for (unsigned j = 0; j < inp.m_cu_sets.size(); j++) {
-              std::vector<collector_unit_t> & cu_set = m_cus[inp.m_cu_sets[j]];
-	      bool allocated = false;
-              for (unsigned k = 0; k < cu_set.size(); k++) {
-                  if(cu_set[k].is_free()) {
-                     collector_unit_t *cu = &cu_set[k];
-                     allocated = cu->allocate(inp.m_in[i],inp.m_out[i]);
-                     m_arbiter.add_read_requests(cu);
-                     break;
-                  }
-              }
-              if (allocated) break; //cu has been allocated, no need to search more.
-          }
-          break; // can only service a single input, if it failed it will fail for others.
-       }
-   }
-}
-
-void opndcoll_rfu_t::allocate_reads()
-{
-   // process read requests that do not have conflicts
-   std::list<op_t> allocated = m_arbiter.allocate_reads();
-   std::map<unsigned,op_t> read_ops;
-   for( std::list<op_t>::iterator r=allocated.begin(); r!=allocated.end(); r++ ) {
-      const op_t &rr = *r;
-      unsigned reg = rr.get_reg();
-      unsigned wid = rr.get_wid();
-      unsigned bank = register_bank(reg,wid,m_num_banks,m_bank_warp_shift,sub_core_model, m_num_banks_per_sched, rr.get_sid());
-      m_arbiter.allocate_for_read(bank,rr);
-      read_ops[bank] = rr;
-   }
-   std::map<unsigned,op_t>::iterator r;
-   for(r=read_ops.begin();r!=read_ops.end();++r ) {
-      op_t &op = r->second;
-      unsigned cu = op.get_oc_id();
-      unsigned operand = op.get_operand();
-      m_cu[cu]->collect_operand(operand);
-      if(m_shader->get_config()->gpgpu_clock_gated_reg_file){
-    	  unsigned active_count=0;
-    	  for(unsigned i=0;i<m_shader->get_config()->warp_size;i=i+m_shader->get_config()->n_regfile_gating_group){
-    		  for(unsigned j=0;j<m_shader->get_config()->n_regfile_gating_group;j++){
-    			  if(op.get_active_mask().test(i+j)){
-    				  active_count+=m_shader->get_config()->n_regfile_gating_group;
-    				  break;
-    			  }
-    		  }
-    	  }
-    	  m_shader->incregfile_reads(active_count);
-      }else{
-    	  m_shader->incregfile_reads(m_shader->get_config()->warp_size);//op.get_active_count());
-      }
+  cta_to_warp_t::const_iterator i;
+  for (i = m_cta_to_warps.begin(); i != m_cta_to_warps.end(); i++) {
+    unsigned cta_id = i->first;
+    warp_set_t warps = i->second;
+    printf("    cta_id %u : %s\n", cta_id, warps.to_string().c_str());
   }
-} 
-
-bool opndcoll_rfu_t::collector_unit_t::ready() const 
-{ 
-   return (!m_free) && m_not_ready.none() && (*m_output_register).has_free(); 
+  printf("  warp_active: %s\n", m_warp_active.to_string().c_str());
+  printf("  warp_at_barrier: %s\n", m_warp_at_barrier.to_string().c_str());
+  for (unsigned i = 0; i < m_max_barriers_per_cta; i++) {
+    warp_set_t warps_reached_barrier = m_bar_id_to_warps[i];
+    printf("  warp_at_barrier %u: %s\n", i,
+           warps_reached_barrier.to_string().c_str());
+  }
+  fflush(stdout);
 }
 
-void opndcoll_rfu_t::collector_unit_t::dump(FILE *fp, const shader_core_ctx *shader ) const
-{
-   if( m_free ) {
-      fprintf(fp,"    <free>\n");
-   } else {
-      m_warp->print(fp);
-      for( unsigned i=0; i < MAX_REG_OPERANDS*2; i++ ) {
-         if( m_not_ready.test(i) ) {
-            std::string r = m_src_op[i].get_reg_string();
-            fprintf(fp,"    '%s' not ready\n", r.c_str() );
-         }
+void shader_core_ctx::warp_exit(unsigned warp_id) {
+  bool done = true;
+  for (unsigned i = warp_id * get_config()->warp_size;
+       i < (warp_id + 1) * get_config()->warp_size; i++) {
+    //		if(this->m_thread[i]->m_functional_model_thread_state &&
+    //this->m_thread[i].m_functional_model_thread_state->donecycle()==0) {
+    //			done = false;
+    //		}
+
+    if (m_thread[i] && !m_thread[i]->is_done()) done = false;
+  }
+  // if (m_warp[warp_id].get_n_completed() == get_config()->warp_size)
+  // if (this->m_simt_stack[warp_id]->get_num_entries() == 0)
+  if (done) m_barriers.warp_exit(warp_id);
+}
+
+bool shader_core_ctx::check_if_non_released_reduction_barrier(
+    warp_inst_t &inst) {
+  unsigned warp_id = inst.warp_id();
+  bool bar_red_op = (inst.op == BARRIER_OP) && (inst.bar_type == RED);
+  bool non_released_barrier_reduction = false;
+  bool warp_stucked_at_barrier = warp_waiting_at_barrier(warp_id);
+  bool single_inst_in_pipeline =
+      (m_warp[warp_id].num_issued_inst_in_pipeline() == 1);
+  non_released_barrier_reduction =
+      single_inst_in_pipeline and warp_stucked_at_barrier and bar_red_op;
+  printf("non_released_barrier_reduction=%u\n", non_released_barrier_reduction);
+  return non_released_barrier_reduction;
+}
+
+bool shader_core_ctx::warp_waiting_at_barrier(unsigned warp_id) const {
+  return m_barriers.warp_waiting_at_barrier(warp_id);
+}
+
+bool shader_core_ctx::warp_waiting_at_mem_barrier(unsigned warp_id) {
+  if (!m_warp[warp_id].get_membar()) return false;
+  if (!m_scoreboard->pendingWrites(warp_id)) {
+    m_warp[warp_id].clear_membar();
+    return false;
+  }
+  return true;
+}
+
+void shader_core_ctx::set_max_cta(const kernel_info_t &kernel) {
+  // calculate the max cta count and cta size for local memory address mapping
+  kernel_max_cta_per_shader = m_config->max_cta(kernel);
+  unsigned int gpu_cta_size = kernel.threads_per_cta();
+  kernel_padded_threads_per_cta =
+      (gpu_cta_size % m_config->warp_size)
+          ? m_config->warp_size * ((gpu_cta_size / m_config->warp_size) + 1)
+          : gpu_cta_size;
+}
+
+void shader_core_ctx::decrement_atomic_count(unsigned wid, unsigned n) {
+  assert(m_warp[wid].get_n_atomic() >= n);
+  m_warp[wid].dec_n_atomic(n);
+}
+
+void shader_core_ctx::broadcast_barrier_reduction(unsigned cta_id,
+                                                  unsigned bar_id,
+                                                  warp_set_t warps) {
+  for (unsigned i = 0; i < m_config->max_warps_per_shader; i++) {
+    if (warps.test(i)) {
+      const warp_inst_t *inst =
+          m_warp[i].restore_info_of_last_inst_at_barrier();
+      const_cast<warp_inst_t *>(inst)->broadcast_barrier_reduction(
+          inst->get_active_mask());
+    }
+  }
+}
+
+bool shader_core_ctx::fetch_unit_response_buffer_full() const { return false; }
+
+void shader_core_ctx::accept_fetch_response(mem_fetch *mf) {
+  mf->set_status(IN_SHADER_FETCHED,
+                 m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+  m_L1I->fill(mf, m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+}
+
+bool shader_core_ctx::ldst_unit_response_buffer_full() const {
+  return m_ldst_unit->response_buffer_full();
+}
+
+void shader_core_ctx::accept_ldst_unit_response(mem_fetch *mf) {
+  m_ldst_unit->fill(mf);
+}
+
+void shader_core_ctx::store_ack(class mem_fetch *mf) {
+  assert(mf->get_type() == WRITE_ACK ||
+         (m_config->gpgpu_perfect_mem && mf->get_is_write()));
+  unsigned warp_id = mf->get_wid();
+  m_warp[warp_id].dec_store_req();
+}
+
+void shader_core_ctx::print_cache_stats(FILE *fp, unsigned &dl1_accesses,
+                                        unsigned &dl1_misses) {
+  m_ldst_unit->print_cache_stats(fp, dl1_accesses, dl1_misses);
+}
+
+void shader_core_ctx::get_cache_stats(cache_stats &cs) {
+  // Adds stats from each cache to 'cs'
+  cs += m_L1I->get_stats();          // Get L1I stats
+  m_ldst_unit->get_cache_stats(cs);  // Get L1D, L1C, L1T stats
+}
+
+void shader_core_ctx::get_L1I_sub_stats(struct cache_sub_stats &css) const {
+  if (m_L1I) m_L1I->get_sub_stats(css);
+}
+void shader_core_ctx::get_L1D_sub_stats(struct cache_sub_stats &css) const {
+  m_ldst_unit->get_L1D_sub_stats(css);
+}
+void shader_core_ctx::get_L1C_sub_stats(struct cache_sub_stats &css) const {
+  m_ldst_unit->get_L1C_sub_stats(css);
+}
+void shader_core_ctx::get_L1T_sub_stats(struct cache_sub_stats &css) const {
+  m_ldst_unit->get_L1T_sub_stats(css);
+}
+
+void shader_core_ctx::get_icnt_power_stats(long &n_simt_to_mem,
+                                           long &n_mem_to_simt) const {
+  n_simt_to_mem += m_stats->n_simt_to_mem[m_sid];
+  n_mem_to_simt += m_stats->n_mem_to_simt[m_sid];
+}
+
+bool shd_warp_t::functional_done() const {
+  return get_n_completed() == m_warp_size;
+}
+
+bool shd_warp_t::hardware_done() const {
+  return functional_done() && stores_done() && !inst_in_pipeline();
+}
+
+bool shd_warp_t::waiting() {
+  if (functional_done()) {
+    // waiting to be initialized with a kernel
+    return true;
+  } else if (m_shader->warp_waiting_at_barrier(m_warp_id)) {
+    // waiting for other warps in CTA to reach barrier
+    return true;
+  } else if (m_shader->warp_waiting_at_mem_barrier(m_warp_id)) {
+    // waiting for memory barrier
+    return true;
+  } else if (m_n_atomic > 0) {
+    // waiting for atomic operation to complete at memory:
+    // this stall is not required for accurate timing model, but rather we
+    // stall here since if a call/return instruction occurs in the meantime
+    // the functional execution of the atomic when it hits DRAM can cause
+    // the wrong register to be read.
+    return true;
+  }
+  return false;
+}
+
+void shd_warp_t::print(FILE *fout) const {
+  if (!done_exit()) {
+    fprintf(fout, "w%02u npc: 0x%04x, done:%c%c%c%c:%2u i:%u s:%u a:%u (done: ",
+            m_warp_id, m_next_pc, (functional_done() ? 'f' : ' '),
+            (stores_done() ? 's' : ' '), (inst_in_pipeline() ? ' ' : 'i'),
+            (done_exit() ? 'e' : ' '), n_completed, m_inst_in_pipeline,
+            m_stores_outstanding, m_n_atomic);
+    for (unsigned i = m_warp_id * m_warp_size;
+         i < (m_warp_id + 1) * m_warp_size; i++) {
+      if (m_shader->ptx_thread_done(i))
+        fprintf(fout, "1");
+      else
+        fprintf(fout, "0");
+      if ((((i + 1) % 4) == 0) && (i + 1) < (m_warp_id + 1) * m_warp_size)
+        fprintf(fout, ",");
+    }
+    fprintf(fout, ") ");
+    fprintf(fout, " active=%s", m_active_threads.to_string().c_str());
+    fprintf(fout, " last fetched @ %5llu", m_last_fetch);
+    if (m_imiss_pending) fprintf(fout, " i-miss pending");
+    fprintf(fout, "\n");
+  }
+}
+
+void shd_warp_t::print_ibuffer(FILE *fout) const {
+  fprintf(fout, "  ibuffer[%2u] : ", m_warp_id);
+  for (unsigned i = 0; i < IBUFFER_SIZE; i++) {
+    const inst_t *inst = m_ibuffer[i].m_inst;
+    if (inst)
+      inst->print_insn(fout);
+    else if (m_ibuffer[i].m_valid)
+      fprintf(fout, " <invalid instruction> ");
+    else
+      fprintf(fout, " <empty> ");
+  }
+  fprintf(fout, "\n");
+}
+
+void opndcoll_rfu_t::add_cu_set(unsigned set_id, unsigned num_cu,
+                                unsigned num_dispatch) {
+  m_cus[set_id].reserve(num_cu);  // this is necessary to stop pointers in m_cu
+                                  // from being invalid do to a resize;
+  for (unsigned i = 0; i < num_cu; i++) {
+    m_cus[set_id].push_back(collector_unit_t());
+    m_cu.push_back(&m_cus[set_id].back());
+  }
+  // for now each collector set gets dedicated dispatch units.
+  for (unsigned i = 0; i < num_dispatch; i++) {
+    m_dispatch_units.push_back(dispatch_unit_t(&m_cus[set_id]));
+  }
+}
+
+void opndcoll_rfu_t::add_port(port_vector_t &input, port_vector_t &output,
+                              uint_vector_t cu_sets) {
+  // m_num_ports++;
+  // m_num_collectors += num_collector_units;
+  // m_input.resize(m_num_ports);
+  // m_output.resize(m_num_ports);
+  // m_num_collector_units.resize(m_num_ports);
+  // m_input[m_num_ports-1]=input_port;
+  // m_output[m_num_ports-1]=output_port;
+  // m_num_collector_units[m_num_ports-1]=num_collector_units;
+  m_in_ports.push_back(input_port_t(input, output, cu_sets));
+}
+
+void opndcoll_rfu_t::init(unsigned num_banks, shader_core_ctx *shader) {
+  m_shader = shader;
+  m_arbiter.init(m_cu.size(), num_banks);
+  // for( unsigned n=0; n<m_num_ports;n++ )
+  //    m_dispatch_units[m_output[n]].init( m_num_collector_units[n] );
+  m_num_banks = num_banks;
+  m_bank_warp_shift = 0;
+  m_warp_size = shader->get_config()->warp_size;
+  m_bank_warp_shift = (unsigned)(int)(log(m_warp_size + 0.5) / log(2.0));
+  assert((m_bank_warp_shift == 5) || (m_warp_size != 32));
+
+  sub_core_model = shader->get_config()->sub_core_model;
+  m_num_warp_sceds = shader->get_config()->gpgpu_num_sched_per_core;
+  if (sub_core_model)
+    assert(num_banks % shader->get_config()->gpgpu_num_sched_per_core == 0);
+  m_num_banks_per_sched =
+      num_banks / shader->get_config()->gpgpu_num_sched_per_core;
+
+  for (unsigned j = 0; j < m_cu.size(); j++) {
+    m_cu[j]->init(j, num_banks, m_bank_warp_shift, shader->get_config(), this,
+                  sub_core_model, m_num_banks_per_sched);
+  }
+  m_initialized = true;
+}
+
+int register_bank(int regnum, int wid, unsigned num_banks,
+                  unsigned bank_warp_shift, bool sub_core_model,
+                  unsigned banks_per_sched, unsigned sched_id) {
+  int bank = regnum;
+  if (bank_warp_shift) bank += wid;
+  if (sub_core_model) {
+    unsigned bank_num = (bank % banks_per_sched) + (sched_id * banks_per_sched);
+    assert(bank_num < num_banks);
+    return bank_num;
+  } else
+    return bank % num_banks;
+}
+
+bool opndcoll_rfu_t::writeback(warp_inst_t &inst) {
+  assert(!inst.empty());
+  std::list<unsigned> regs = m_shader->get_regs_written(inst);
+  for (unsigned op = 0; op < MAX_REG_OPERANDS; op++) {
+    int reg_num = inst.arch_reg.dst[op];  // this math needs to match that used
+                                          // in function_info::ptx_decode_inst
+    if (reg_num >= 0) {                   // valid register
+      unsigned bank = register_bank(reg_num, inst.warp_id(), m_num_banks,
+                                    m_bank_warp_shift, sub_core_model,
+                                    m_num_banks_per_sched, inst.get_schd_id());
+      if (m_arbiter.bank_idle(bank)) {
+        m_arbiter.allocate_bank_for_write(
+            bank,
+            op_t(&inst, reg_num, m_num_banks, m_bank_warp_shift, sub_core_model,
+                 m_num_banks_per_sched, inst.get_schd_id()));
+        inst.arch_reg.dst[op] = -1;
+      } else {
+        return false;
       }
-   }
-}
-
-void opndcoll_rfu_t::collector_unit_t::init( unsigned n, 
-                                             unsigned num_banks, 
-                                             unsigned log2_warp_size,
-                                             const core_config *config,
-                                             opndcoll_rfu_t *rfu,
-											 bool sub_core_model,
-											 unsigned banks_per_sched)
-{ 
-   m_rfu=rfu;
-   m_cuid=n; 
-   m_num_banks=num_banks;
-   assert(m_warp==NULL); 
-   m_warp = new warp_inst_t(config);
-   m_bank_warp_shift=log2_warp_size;
-   m_sub_core_model = sub_core_model;
-   m_num_banks_per_sched = banks_per_sched;
-}
-
-bool opndcoll_rfu_t::collector_unit_t::allocate( register_set* pipeline_reg_set, register_set* output_reg_set ) 
-{
-   assert(m_free);
-   assert(m_not_ready.none());
-   m_free = false;
-   m_output_register = output_reg_set;
-   warp_inst_t **pipeline_reg = pipeline_reg_set->get_ready();
-   if( (pipeline_reg) and !((*pipeline_reg)->empty()) ) {
-      m_warp_id = (*pipeline_reg)->warp_id();
-      for( unsigned op=0; op < MAX_REG_OPERANDS; op++ ) {
-         int reg_num = (*pipeline_reg)->arch_reg.src[op]; // this math needs to match that used in function_info::ptx_decode_inst
-         if( reg_num >= 0 ) { // valid register
-            m_src_op[op] = op_t( this, op, reg_num, m_num_banks, m_bank_warp_shift, m_sub_core_model, m_num_banks_per_sched, (*pipeline_reg)->get_schd_id() );
-            m_not_ready.set(op);
-         } else 
-            m_src_op[op] = op_t();
-      }
-      //move_warp(m_warp,*pipeline_reg);
-      pipeline_reg_set->move_out_to(m_warp);
-      return true;
-   }
-   return false;
-}
-
-void opndcoll_rfu_t::collector_unit_t::dispatch()
-{
-   assert( m_not_ready.none() );
-   //move_warp(*m_output_register,m_warp);
-   m_output_register->move_in(m_warp);
-   m_free=true;
-   m_output_register = NULL;
-   for( unsigned i=0; i<MAX_REG_OPERANDS*2;i++)
-      m_src_op[i].reset();
-}
-
-simt_core_cluster::simt_core_cluster( class gpgpu_sim *gpu, 
-                                      unsigned cluster_id, 
-                                      const shader_core_config *config, 
-                                      const memory_config *mem_config,
-                                      shader_core_stats *stats, 
-                                      class memory_stats_t *mstats )
-{
-    m_config = config;
-    m_cta_issue_next_core=m_config->n_simt_cores_per_cluster-1; // this causes first launch to use hw cta 0
-    m_cluster_id=cluster_id;
-    m_gpu = gpu;
-    m_stats = stats;
-    m_memory_stats = mstats;
-    m_core = new shader_core_ctx*[ config->n_simt_cores_per_cluster ];
-    for( unsigned i=0; i < config->n_simt_cores_per_cluster; i++ ) {
-        unsigned sid = m_config->cid_to_sid(i,m_cluster_id);
-        m_core[i] = new shader_core_ctx(gpu,this,sid,m_cluster_id,config,mem_config,stats);
-        m_core_sim_order.push_back(i); 
     }
-}
-
-void simt_core_cluster::core_cycle()
-{
-    for( std::list<unsigned>::iterator it = m_core_sim_order.begin(); it != m_core_sim_order.end(); ++it ) {
-        m_core[*it]->cycle();
-    }
-
-    if (m_config->simt_core_sim_order == 1) {
-        m_core_sim_order.splice(m_core_sim_order.end(), m_core_sim_order, m_core_sim_order.begin()); 
-    }
-}
-
-void simt_core_cluster::reinit()
-{
-    for( unsigned i=0; i < m_config->n_simt_cores_per_cluster; i++ ) 
-        m_core[i]->reinit(0,m_config->n_thread_per_shader,true);
-}
-
-unsigned simt_core_cluster::max_cta( const kernel_info_t &kernel )
-{
-    return m_config->n_simt_cores_per_cluster * m_config->max_cta(kernel);
-}
-
-unsigned simt_core_cluster::get_not_completed() const
-{
-    unsigned not_completed=0;
-    for( unsigned i=0; i < m_config->n_simt_cores_per_cluster; i++ ) 
-        not_completed += m_core[i]->get_not_completed();
-    return not_completed;
-}
-
-void simt_core_cluster::print_not_completed( FILE *fp ) const
-{
-    for( unsigned i=0; i < m_config->n_simt_cores_per_cluster; i++ ) {
-        unsigned not_completed=m_core[i]->get_not_completed();
-        unsigned sid=m_config->cid_to_sid(i,m_cluster_id);
-        fprintf(fp,"%u(%u) ", sid, not_completed );
-    }
-}
-
-
-float simt_core_cluster::get_current_occupancy( unsigned long long& active, unsigned long long& total ) const {
-    float aggregate = 0.f;
-    for( unsigned i=0; i < m_config->n_simt_cores_per_cluster; i++ ) {
-        aggregate+=m_core[i]->get_current_occupancy( active, total );
-    }
-    return aggregate / m_config->n_simt_cores_per_cluster;
-}
-
-unsigned simt_core_cluster::get_n_active_cta() const
-{
-    unsigned n=0;
-    for( unsigned i=0; i < m_config->n_simt_cores_per_cluster; i++ ) 
-        n += m_core[i]->get_n_active_cta();
-    return n;
-}
-
-unsigned simt_core_cluster::get_n_active_sms() const
-{
-    unsigned n=0;
-    for( unsigned i=0; i < m_config->n_simt_cores_per_cluster; i++ )
-        n += m_core[i]->isactive();
-    return n;
-}
-
-unsigned simt_core_cluster::issue_block2core()
-{
-    unsigned num_blocks_issued=0;
-    for( unsigned i=0; i < m_config->n_simt_cores_per_cluster; i++ ) {
-        unsigned core = (i+m_cta_issue_next_core+1)%m_config->n_simt_cores_per_cluster;
-
-        kernel_info_t * kernel;
-         //Jin: fetch kernel according to concurrent kernel setting
-        if(m_config->gpgpu_concurrent_kernel_sm) {//concurrent kernel on sm 
-            //always select latest issued kernel
-            kernel_info_t *k = m_gpu->select_kernel();
-            kernel = k;
+  }
+  for (unsigned i = 0; i < (unsigned)regs.size(); i++) {
+    if (m_shader->get_config()->gpgpu_clock_gated_reg_file) {
+      unsigned active_count = 0;
+      for (unsigned i = 0; i < m_shader->get_config()->warp_size;
+           i = i + m_shader->get_config()->n_regfile_gating_group) {
+        for (unsigned j = 0; j < m_shader->get_config()->n_regfile_gating_group;
+             j++) {
+          if (inst.get_active_mask().test(i + j)) {
+            active_count += m_shader->get_config()->n_regfile_gating_group;
+            break;
+          }
         }
-        else {
-            //first select core kernel, if no more cta, get a new kernel
-            //only when core completes
-            kernel = m_core[core]->get_kernel();
-            if( !m_gpu->kernel_more_cta_left(kernel) ) {
-              //wait till current kernel finishes
-              if(m_core[core]->get_not_completed() == 0)
-              {
-                  kernel_info_t *k = m_gpu->select_kernel();
-                  if( k ) 
-                      m_core[core]->set_kernel(k);
-                  kernel = k;
+      }
+      m_shader->incregfile_writes(active_count);
+    } else {
+      m_shader->incregfile_writes(
+          m_shader->get_config()->warp_size);  // inst.active_count());
+    }
+  }
+  return true;
+}
+
+void opndcoll_rfu_t::dispatch_ready_cu() {
+  for (unsigned p = 0; p < m_dispatch_units.size(); ++p) {
+    dispatch_unit_t &du = m_dispatch_units[p];
+    collector_unit_t *cu = du.find_ready();
+    if (cu) {
+      for (unsigned i = 0; i < (cu->get_num_operands() - cu->get_num_regs());
+           i++) {
+        if (m_shader->get_config()->gpgpu_clock_gated_reg_file) {
+          unsigned active_count = 0;
+          for (unsigned i = 0; i < m_shader->get_config()->warp_size;
+               i = i + m_shader->get_config()->n_regfile_gating_group) {
+            for (unsigned j = 0;
+                 j < m_shader->get_config()->n_regfile_gating_group; j++) {
+              if (cu->get_active_mask().test(i + j)) {
+                active_count += m_shader->get_config()->n_regfile_gating_group;
+                break;
               }
             }
-        }
-
-        if( m_gpu->kernel_more_cta_left(kernel) && 
-//            (m_core[core]->get_n_active_cta() < m_config->max_cta(*kernel)) ) {
-            m_core[core]->can_issue_1block(*kernel)) {
-            m_core[core]->issue_block2core(*kernel);
-            num_blocks_issued++;
-            m_cta_issue_next_core=core; 
-            break;
-        }
-    }
-    return num_blocks_issued;
-}
-
-void simt_core_cluster::cache_flush()
-{
-    for( unsigned i=0; i < m_config->n_simt_cores_per_cluster; i++ ) 
-        m_core[i]->cache_flush();
-}
-
-void simt_core_cluster::cache_invalidate()
-{
-    for( unsigned i=0; i < m_config->n_simt_cores_per_cluster; i++ )
-        m_core[i]->cache_invalidate();
-}
-
-bool simt_core_cluster::icnt_injection_buffer_full(unsigned size, bool write)
-{
-    unsigned request_size = size;
-    if (!write) 
-        request_size = READ_PACKET_SIZE;
-    return ! ::icnt_has_buffer(m_cluster_id, request_size);
-}
-
-void simt_core_cluster::icnt_inject_request_packet(class mem_fetch *mf)
-{
-    // stats
-    if (mf->get_is_write()) m_stats->made_write_mfs++;
-    else m_stats->made_read_mfs++;
-    switch (mf->get_access_type()) {
-    case CONST_ACC_R: m_stats->gpgpu_n_mem_const++; break;
-    case TEXTURE_ACC_R: m_stats->gpgpu_n_mem_texture++; break;
-    case GLOBAL_ACC_R: m_stats->gpgpu_n_mem_read_global++; break;
-    //case GLOBAL_ACC_R: m_stats->gpgpu_n_mem_read_global++; printf("read_global%d\n",m_stats->gpgpu_n_mem_read_global); break;
-    case GLOBAL_ACC_W: m_stats->gpgpu_n_mem_write_global++; break;
-    case LOCAL_ACC_R: m_stats->gpgpu_n_mem_read_local++; break;
-    case LOCAL_ACC_W: m_stats->gpgpu_n_mem_write_local++; break;
-    case INST_ACC_R: m_stats->gpgpu_n_mem_read_inst++; break;
-    case L1_WRBK_ACC: m_stats->gpgpu_n_mem_write_global++; break;
-    case L2_WRBK_ACC: m_stats->gpgpu_n_mem_l2_writeback++; break;
-    case L1_WR_ALLOC_R: m_stats->gpgpu_n_mem_l1_write_allocate++; break;
-    case L2_WR_ALLOC_R: m_stats->gpgpu_n_mem_l2_write_allocate++; break;
-    default: assert(0);
-    }
-
-   // The packet size varies depending on the type of request: 
-   // - For write request and atomic request, the packet contains the data 
-   // - For read request (i.e. not write nor atomic), the packet only has control metadata
-   unsigned int packet_size = mf->size(); 
-   if (!mf->get_is_write() && !mf->isatomic()) {
-      packet_size = mf->get_ctrl_size(); 
-   }
-   m_stats->m_outgoing_traffic_stats->record_traffic(mf, packet_size); 
-   unsigned destination = mf->get_sub_partition_id();
-   mf->set_status(IN_ICNT_TO_MEM,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-   if (!mf->get_is_write() && !mf->isatomic())
-      ::icnt_push(m_cluster_id, m_config->mem2device(destination), (void*)mf, mf->get_ctrl_size() );
-   else 
-      ::icnt_push(m_cluster_id, m_config->mem2device(destination), (void*)mf, mf->size());
-}
-
-void simt_core_cluster::icnt_cycle()
-{
-    if( !m_response_fifo.empty() ) {
-        mem_fetch *mf = m_response_fifo.front();
-        unsigned cid = m_config->sid_to_cid(mf->get_sid());
-        if( mf->get_access_type() == INST_ACC_R ) {
-            // instruction fetch response
-            if( !m_core[cid]->fetch_unit_response_buffer_full() ) {
-                m_response_fifo.pop_front();
-                m_core[cid]->accept_fetch_response(mf);
-            }
+          }
+          m_shader->incnon_rf_operands(active_count);
         } else {
-            // data response
-            if( !m_core[cid]->ldst_unit_response_buffer_full() ) {
-                m_response_fifo.pop_front();
-                m_memory_stats->memlatstat_read_done(mf);
-                m_core[cid]->accept_ldst_unit_response(mf);
-            }
+          m_shader->incnon_rf_operands(
+              m_shader->get_config()->warp_size);  // cu->get_active_count());
         }
+      }
+      cu->dispatch();
     }
-    if( m_response_fifo.size() < m_config->n_simt_ejection_buffer_size ) {
-        mem_fetch *mf = (mem_fetch*) ::icnt_pop(m_cluster_id);
-        if (!mf) 
-            return;
-        assert(mf->get_tpc() == m_cluster_id);
-        assert(mf->get_type() == READ_REPLY || mf->get_type() == WRITE_ACK );
-
-        // The packet size varies depending on the type of request: 
-        // - For read request and atomic request, the packet contains the data 
-        // - For write-ack, the packet only has control metadata
-        unsigned int packet_size = (mf->get_is_write())? mf->get_ctrl_size() : mf->size(); 
-        m_stats->m_incoming_traffic_stats->record_traffic(mf, packet_size); 
-        mf->set_status(IN_CLUSTER_TO_SHADER_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-        //m_memory_stats->memlatstat_read_done(mf,m_shader_config->max_warps_per_shader);
-        m_response_fifo.push_back(mf);
-        m_stats->n_mem_to_simt[m_cluster_id] += mf->get_num_flits(false);
-    }
+  }
 }
 
-void simt_core_cluster::get_pdom_stack_top_info( unsigned sid, unsigned tid, unsigned *pc, unsigned *rpc ) const
-{
-    unsigned cid = m_config->sid_to_cid(sid);
-    m_core[cid]->get_pdom_stack_top_info(tid,pc,rpc);
-}
-
-void simt_core_cluster::display_pipeline( unsigned sid, FILE *fout, int print_mem, int mask )
-{
-    m_core[m_config->sid_to_cid(sid)]->display_pipeline(fout,print_mem,mask);
-
-    fprintf(fout,"\n");
-    fprintf(fout,"Cluster %u pipeline state\n", m_cluster_id );
-    fprintf(fout,"Response FIFO (occupancy = %zu):\n", m_response_fifo.size() );
-    for( std::list<mem_fetch*>::const_iterator i=m_response_fifo.begin(); i != m_response_fifo.end(); i++ ) {
-        const mem_fetch *mf = *i;
-        mf->print(fout);
-    }
-}
-
-void simt_core_cluster::print_cache_stats( FILE *fp, unsigned& dl1_accesses, unsigned& dl1_misses ) const {
-   for ( unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i ) {
-      m_core[ i ]->print_cache_stats( fp, dl1_accesses, dl1_misses );
-   }
-}
-
-void simt_core_cluster::get_icnt_stats(long &n_simt_to_mem, long &n_mem_to_simt) const {
-	long simt_to_mem=0;
-	long mem_to_simt=0;
-	for ( unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i ) {
-		m_core[i]->get_icnt_power_stats(simt_to_mem, mem_to_simt);
-	}
-	n_simt_to_mem = simt_to_mem;
-	n_mem_to_simt = mem_to_simt;
-}
-
-void simt_core_cluster::get_cache_stats(cache_stats &cs) const{
-    for ( unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i ) {
-        m_core[i]->get_cache_stats(cs);
-    }
-}
-
-void simt_core_cluster::get_L1I_sub_stats(struct cache_sub_stats &css) const{
-    struct cache_sub_stats temp_css;
-    struct cache_sub_stats total_css;
-    temp_css.clear();
-    total_css.clear();
-    for ( unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i ) {
-        m_core[i]->get_L1I_sub_stats(temp_css);
-        total_css += temp_css;
-    }
-    css = total_css;
-}
-void simt_core_cluster::get_L1D_sub_stats(struct cache_sub_stats &css) const{
-    struct cache_sub_stats temp_css;
-    struct cache_sub_stats total_css;
-    temp_css.clear();
-    total_css.clear();
-    for ( unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i ) {
-        m_core[i]->get_L1D_sub_stats(temp_css);
-        total_css += temp_css;
-    }
-    css = total_css;
-}
-void simt_core_cluster::get_L1C_sub_stats(struct cache_sub_stats &css) const{
-    struct cache_sub_stats temp_css;
-    struct cache_sub_stats total_css;
-    temp_css.clear();
-    total_css.clear();
-    for ( unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i ) {
-        m_core[i]->get_L1C_sub_stats(temp_css);
-        total_css += temp_css;
-    }
-    css = total_css;
-}
-void simt_core_cluster::get_L1T_sub_stats(struct cache_sub_stats &css) const{
-    struct cache_sub_stats temp_css;
-    struct cache_sub_stats total_css;
-    temp_css.clear();
-    total_css.clear();
-    for ( unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i ) {
-        m_core[i]->get_L1T_sub_stats(temp_css);
-        total_css += temp_css;
-    }
-    css = total_css;
-}
-
-void shader_core_ctx::checkExecutionStatusAndUpdate(warp_inst_t &inst, unsigned t, unsigned tid)
-{
-    if(inst.isatomic())
-           m_warp[inst.warp_id()].inc_n_atomic();
-        if (inst.space.is_local() && (inst.is_load() || inst.is_store())) {
-            new_addr_type localaddrs[MAX_ACCESSES_PER_INSN_PER_THREAD];
-            unsigned num_addrs;
-            num_addrs = translate_local_memaddr(inst.get_addr(t), tid, m_config->n_simt_clusters*m_config->n_simt_cores_per_cluster,
-                   inst.data_size, (new_addr_type*) localaddrs );
-            inst.set_addr(t, (new_addr_type*) localaddrs, num_addrs);
+void opndcoll_rfu_t::allocate_cu(unsigned port_num) {
+  input_port_t &inp = m_in_ports[port_num];
+  for (unsigned i = 0; i < inp.m_in.size(); i++) {
+    if ((*inp.m_in[i]).has_ready()) {
+      // find a free cu
+      for (unsigned j = 0; j < inp.m_cu_sets.size(); j++) {
+        std::vector<collector_unit_t> &cu_set = m_cus[inp.m_cu_sets[j]];
+        bool allocated = false;
+        for (unsigned k = 0; k < cu_set.size(); k++) {
+          if (cu_set[k].is_free()) {
+            collector_unit_t *cu = &cu_set[k];
+            allocated = cu->allocate(inp.m_in[i], inp.m_out[i]);
+            m_arbiter.add_read_requests(cu);
+            break;
+          }
         }
-        if ( ptx_thread_done(tid) ) {
-            m_warp[inst.warp_id()].set_completed(t);
-            m_warp[inst.warp_id()].ibuffer_flush();
-        }
-
-    // PC-Histogram Update 
-    unsigned warp_id = inst.warp_id(); 
-    unsigned pc = inst.pc; 
-    for (unsigned t = 0; t < m_config->warp_size; t++) {
-        if (inst.active(t)) {
-            int tid = warp_id * m_config->warp_size + t; 
-            cflog_update_thread_pc(m_sid, tid, pc);  
-        }
+        if (allocated) break;  // cu has been allocated, no need to search more.
+      }
+      break;  // can only service a single input, if it failed it will fail for
+              // others.
     }
+  }
 }
 
+void opndcoll_rfu_t::allocate_reads() {
+  // process read requests that do not have conflicts
+  std::list<op_t> allocated = m_arbiter.allocate_reads();
+  std::map<unsigned, op_t> read_ops;
+  for (std::list<op_t>::iterator r = allocated.begin(); r != allocated.end();
+       r++) {
+    const op_t &rr = *r;
+    unsigned reg = rr.get_reg();
+    unsigned wid = rr.get_wid();
+    unsigned bank =
+        register_bank(reg, wid, m_num_banks, m_bank_warp_shift, sub_core_model,
+                      m_num_banks_per_sched, rr.get_sid());
+    m_arbiter.allocate_for_read(bank, rr);
+    read_ops[bank] = rr;
+  }
+  std::map<unsigned, op_t>::iterator r;
+  for (r = read_ops.begin(); r != read_ops.end(); ++r) {
+    op_t &op = r->second;
+    unsigned cu = op.get_oc_id();
+    unsigned operand = op.get_operand();
+    m_cu[cu]->collect_operand(operand);
+    if (m_shader->get_config()->gpgpu_clock_gated_reg_file) {
+      unsigned active_count = 0;
+      for (unsigned i = 0; i < m_shader->get_config()->warp_size;
+           i = i + m_shader->get_config()->n_regfile_gating_group) {
+        for (unsigned j = 0; j < m_shader->get_config()->n_regfile_gating_group;
+             j++) {
+          if (op.get_active_mask().test(i + j)) {
+            active_count += m_shader->get_config()->n_regfile_gating_group;
+            break;
+          }
+        }
+      }
+      m_shader->incregfile_reads(active_count);
+    } else {
+      m_shader->incregfile_reads(
+          m_shader->get_config()->warp_size);  // op.get_active_count());
+    }
+  }
+}
+
+bool opndcoll_rfu_t::collector_unit_t::ready() const {
+  return (!m_free) && m_not_ready.none() && (*m_output_register).has_free();
+}
+
+void opndcoll_rfu_t::collector_unit_t::dump(
+    FILE *fp, const shader_core_ctx *shader) const {
+  if (m_free) {
+    fprintf(fp, "    <free>\n");
+  } else {
+    m_warp->print(fp);
+    for (unsigned i = 0; i < MAX_REG_OPERANDS * 2; i++) {
+      if (m_not_ready.test(i)) {
+        std::string r = m_src_op[i].get_reg_string();
+        fprintf(fp, "    '%s' not ready\n", r.c_str());
+      }
+    }
+  }
+}
+
+void opndcoll_rfu_t::collector_unit_t::init(unsigned n, unsigned num_banks,
+                                            unsigned log2_warp_size,
+                                            const core_config *config,
+                                            opndcoll_rfu_t *rfu,
+                                            bool sub_core_model,
+                                            unsigned banks_per_sched) {
+  m_rfu = rfu;
+  m_cuid = n;
+  m_num_banks = num_banks;
+  assert(m_warp == NULL);
+  m_warp = new warp_inst_t(config);
+  m_bank_warp_shift = log2_warp_size;
+  m_sub_core_model = sub_core_model;
+  m_num_banks_per_sched = banks_per_sched;
+}
+
+bool opndcoll_rfu_t::collector_unit_t::allocate(register_set *pipeline_reg_set,
+                                                register_set *output_reg_set) {
+  assert(m_free);
+  assert(m_not_ready.none());
+  m_free = false;
+  m_output_register = output_reg_set;
+  warp_inst_t **pipeline_reg = pipeline_reg_set->get_ready();
+  if ((pipeline_reg) and !((*pipeline_reg)->empty())) {
+    m_warp_id = (*pipeline_reg)->warp_id();
+    for (unsigned op = 0; op < MAX_REG_OPERANDS; op++) {
+      int reg_num =
+          (*pipeline_reg)->arch_reg.src[op];  // this math needs to match that
+                                              // used in
+                                              // function_info::ptx_decode_inst
+      if (reg_num >= 0) {                     // valid register
+        m_src_op[op] = op_t(this, op, reg_num, m_num_banks, m_bank_warp_shift,
+                            m_sub_core_model, m_num_banks_per_sched,
+                            (*pipeline_reg)->get_schd_id());
+        m_not_ready.set(op);
+      } else
+        m_src_op[op] = op_t();
+    }
+    // move_warp(m_warp,*pipeline_reg);
+    pipeline_reg_set->move_out_to(m_warp);
+    return true;
+  }
+  return false;
+}
+
+void opndcoll_rfu_t::collector_unit_t::dispatch() {
+  assert(m_not_ready.none());
+  // move_warp(*m_output_register,m_warp);
+  m_output_register->move_in(m_warp);
+  m_free = true;
+  m_output_register = NULL;
+  for (unsigned i = 0; i < MAX_REG_OPERANDS * 2; i++) m_src_op[i].reset();
+}
+
+simt_core_cluster::simt_core_cluster(class gpgpu_sim *gpu, unsigned cluster_id,
+                                     const shader_core_config *config,
+                                     const memory_config *mem_config,
+                                     shader_core_stats *stats,
+                                     class memory_stats_t *mstats) {
+  m_config = config;
+  m_cta_issue_next_core = m_config->n_simt_cores_per_cluster -
+                          1;  // this causes first launch to use hw cta 0
+  m_cluster_id = cluster_id;
+  m_gpu = gpu;
+  m_stats = stats;
+  m_memory_stats = mstats;
+  m_core = new shader_core_ctx *[config->n_simt_cores_per_cluster];
+  for (unsigned i = 0; i < config->n_simt_cores_per_cluster; i++) {
+    unsigned sid = m_config->cid_to_sid(i, m_cluster_id);
+    m_core[i] = new shader_core_ctx(gpu, this, sid, m_cluster_id, config,
+                                    mem_config, stats);
+    m_core_sim_order.push_back(i);
+  }
+}
+
+void simt_core_cluster::core_cycle() {
+  for (std::list<unsigned>::iterator it = m_core_sim_order.begin();
+       it != m_core_sim_order.end(); ++it) {
+    m_core[*it]->cycle();
+  }
+
+  if (m_config->simt_core_sim_order == 1) {
+    m_core_sim_order.splice(m_core_sim_order.end(), m_core_sim_order,
+                            m_core_sim_order.begin());
+  }
+}
+
+void simt_core_cluster::reinit() {
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++)
+    m_core[i]->reinit(0, m_config->n_thread_per_shader, true);
+}
+
+unsigned simt_core_cluster::max_cta(const kernel_info_t &kernel) {
+  return m_config->n_simt_cores_per_cluster * m_config->max_cta(kernel);
+}
+
+unsigned simt_core_cluster::get_not_completed() const {
+  unsigned not_completed = 0;
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++)
+    not_completed += m_core[i]->get_not_completed();
+  return not_completed;
+}
+
+void simt_core_cluster::print_not_completed(FILE *fp) const {
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++) {
+    unsigned not_completed = m_core[i]->get_not_completed();
+    unsigned sid = m_config->cid_to_sid(i, m_cluster_id);
+    fprintf(fp, "%u(%u) ", sid, not_completed);
+  }
+}
+
+float simt_core_cluster::get_current_occupancy(
+    unsigned long long &active, unsigned long long &total) const {
+  float aggregate = 0.f;
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++) {
+    aggregate += m_core[i]->get_current_occupancy(active, total);
+  }
+  return aggregate / m_config->n_simt_cores_per_cluster;
+}
+
+unsigned simt_core_cluster::get_n_active_cta() const {
+  unsigned n = 0;
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++)
+    n += m_core[i]->get_n_active_cta();
+  return n;
+}
+
+unsigned simt_core_cluster::get_n_active_sms() const {
+  unsigned n = 0;
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++)
+    n += m_core[i]->isactive();
+  return n;
+}
+
+unsigned simt_core_cluster::issue_block2core() {
+  unsigned num_blocks_issued = 0;
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++) {
+    unsigned core =
+        (i + m_cta_issue_next_core + 1) % m_config->n_simt_cores_per_cluster;
+
+    kernel_info_t *kernel;
+    // Jin: fetch kernel according to concurrent kernel setting
+    if (m_config->gpgpu_concurrent_kernel_sm) {  // concurrent kernel on sm
+      // always select latest issued kernel
+      kernel_info_t *k = m_gpu->select_kernel();
+      kernel = k;
+    } else {
+      // first select core kernel, if no more cta, get a new kernel
+      // only when core completes
+      kernel = m_core[core]->get_kernel();
+      if (!m_gpu->kernel_more_cta_left(kernel)) {
+        // wait till current kernel finishes
+        if (m_core[core]->get_not_completed() == 0) {
+          kernel_info_t *k = m_gpu->select_kernel();
+          if (k) m_core[core]->set_kernel(k);
+          kernel = k;
+        }
+      }
+    }
+
+    if (m_gpu->kernel_more_cta_left(kernel) &&
+        //            (m_core[core]->get_n_active_cta() <
+        //            m_config->max_cta(*kernel)) ) {
+        m_core[core]->can_issue_1block(*kernel)) {
+      m_core[core]->issue_block2core(*kernel);
+      num_blocks_issued++;
+      m_cta_issue_next_core = core;
+      break;
+    }
+  }
+  return num_blocks_issued;
+}
+
+void simt_core_cluster::cache_flush() {
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++)
+    m_core[i]->cache_flush();
+}
+
+void simt_core_cluster::cache_invalidate() {
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++)
+    m_core[i]->cache_invalidate();
+}
+
+bool simt_core_cluster::icnt_injection_buffer_full(unsigned size, bool write) {
+  unsigned request_size = size;
+  if (!write) request_size = READ_PACKET_SIZE;
+  return !::icnt_has_buffer(m_cluster_id, request_size);
+}
+
+void simt_core_cluster::icnt_inject_request_packet(class mem_fetch *mf) {
+  // stats
+  if (mf->get_is_write())
+    m_stats->made_write_mfs++;
+  else
+    m_stats->made_read_mfs++;
+  switch (mf->get_access_type()) {
+    case CONST_ACC_R:
+      m_stats->gpgpu_n_mem_const++;
+      break;
+    case TEXTURE_ACC_R:
+      m_stats->gpgpu_n_mem_texture++;
+      break;
+    case GLOBAL_ACC_R:
+      m_stats->gpgpu_n_mem_read_global++;
+      break;
+    // case GLOBAL_ACC_R: m_stats->gpgpu_n_mem_read_global++;
+    // printf("read_global%d\n",m_stats->gpgpu_n_mem_read_global); break;
+    case GLOBAL_ACC_W:
+      m_stats->gpgpu_n_mem_write_global++;
+      break;
+    case LOCAL_ACC_R:
+      m_stats->gpgpu_n_mem_read_local++;
+      break;
+    case LOCAL_ACC_W:
+      m_stats->gpgpu_n_mem_write_local++;
+      break;
+    case INST_ACC_R:
+      m_stats->gpgpu_n_mem_read_inst++;
+      break;
+    case L1_WRBK_ACC:
+      m_stats->gpgpu_n_mem_write_global++;
+      break;
+    case L2_WRBK_ACC:
+      m_stats->gpgpu_n_mem_l2_writeback++;
+      break;
+    case L1_WR_ALLOC_R:
+      m_stats->gpgpu_n_mem_l1_write_allocate++;
+      break;
+    case L2_WR_ALLOC_R:
+      m_stats->gpgpu_n_mem_l2_write_allocate++;
+      break;
+    default:
+      assert(0);
+  }
+
+  // The packet size varies depending on the type of request:
+  // - For write request and atomic request, the packet contains the data
+  // - For read request (i.e. not write nor atomic), the packet only has control
+  // metadata
+  unsigned int packet_size = mf->size();
+  if (!mf->get_is_write() && !mf->isatomic()) {
+    packet_size = mf->get_ctrl_size();
+  }
+  m_stats->m_outgoing_traffic_stats->record_traffic(mf, packet_size);
+  unsigned destination = mf->get_sub_partition_id();
+  mf->set_status(IN_ICNT_TO_MEM,
+                 m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+  if (!mf->get_is_write() && !mf->isatomic())
+    ::icnt_push(m_cluster_id, m_config->mem2device(destination), (void *)mf,
+                mf->get_ctrl_size());
+  else
+    ::icnt_push(m_cluster_id, m_config->mem2device(destination), (void *)mf,
+                mf->size());
+}
+
+void simt_core_cluster::icnt_cycle() {
+  if (!m_response_fifo.empty()) {
+    mem_fetch *mf = m_response_fifo.front();
+    unsigned cid = m_config->sid_to_cid(mf->get_sid());
+    if (mf->get_access_type() == INST_ACC_R) {
+      // instruction fetch response
+      if (!m_core[cid]->fetch_unit_response_buffer_full()) {
+        m_response_fifo.pop_front();
+        m_core[cid]->accept_fetch_response(mf);
+      }
+    } else {
+      // data response
+      if (!m_core[cid]->ldst_unit_response_buffer_full()) {
+        m_response_fifo.pop_front();
+        m_memory_stats->memlatstat_read_done(mf);
+        m_core[cid]->accept_ldst_unit_response(mf);
+      }
+    }
+  }
+  if (m_response_fifo.size() < m_config->n_simt_ejection_buffer_size) {
+    mem_fetch *mf = (mem_fetch *)::icnt_pop(m_cluster_id);
+    if (!mf) return;
+    assert(mf->get_tpc() == m_cluster_id);
+    assert(mf->get_type() == READ_REPLY || mf->get_type() == WRITE_ACK);
+
+    // The packet size varies depending on the type of request:
+    // - For read request and atomic request, the packet contains the data
+    // - For write-ack, the packet only has control metadata
+    unsigned int packet_size =
+        (mf->get_is_write()) ? mf->get_ctrl_size() : mf->size();
+    m_stats->m_incoming_traffic_stats->record_traffic(mf, packet_size);
+    mf->set_status(IN_CLUSTER_TO_SHADER_QUEUE,
+                   m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+    // m_memory_stats->memlatstat_read_done(mf,m_shader_config->max_warps_per_shader);
+    m_response_fifo.push_back(mf);
+    m_stats->n_mem_to_simt[m_cluster_id] += mf->get_num_flits(false);
+  }
+}
+
+void simt_core_cluster::get_pdom_stack_top_info(unsigned sid, unsigned tid,
+                                                unsigned *pc,
+                                                unsigned *rpc) const {
+  unsigned cid = m_config->sid_to_cid(sid);
+  m_core[cid]->get_pdom_stack_top_info(tid, pc, rpc);
+}
+
+void simt_core_cluster::display_pipeline(unsigned sid, FILE *fout,
+                                         int print_mem, int mask) {
+  m_core[m_config->sid_to_cid(sid)]->display_pipeline(fout, print_mem, mask);
+
+  fprintf(fout, "\n");
+  fprintf(fout, "Cluster %u pipeline state\n", m_cluster_id);
+  fprintf(fout, "Response FIFO (occupancy = %zu):\n", m_response_fifo.size());
+  for (std::list<mem_fetch *>::const_iterator i = m_response_fifo.begin();
+       i != m_response_fifo.end(); i++) {
+    const mem_fetch *mf = *i;
+    mf->print(fout);
+  }
+}
+
+void simt_core_cluster::print_cache_stats(FILE *fp, unsigned &dl1_accesses,
+                                          unsigned &dl1_misses) const {
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i) {
+    m_core[i]->print_cache_stats(fp, dl1_accesses, dl1_misses);
+  }
+}
+
+void simt_core_cluster::get_icnt_stats(long &n_simt_to_mem,
+                                       long &n_mem_to_simt) const {
+  long simt_to_mem = 0;
+  long mem_to_simt = 0;
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i) {
+    m_core[i]->get_icnt_power_stats(simt_to_mem, mem_to_simt);
+  }
+  n_simt_to_mem = simt_to_mem;
+  n_mem_to_simt = mem_to_simt;
+}
+
+void simt_core_cluster::get_cache_stats(cache_stats &cs) const {
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i) {
+    m_core[i]->get_cache_stats(cs);
+  }
+}
+
+void simt_core_cluster::get_L1I_sub_stats(struct cache_sub_stats &css) const {
+  struct cache_sub_stats temp_css;
+  struct cache_sub_stats total_css;
+  temp_css.clear();
+  total_css.clear();
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i) {
+    m_core[i]->get_L1I_sub_stats(temp_css);
+    total_css += temp_css;
+  }
+  css = total_css;
+}
+void simt_core_cluster::get_L1D_sub_stats(struct cache_sub_stats &css) const {
+  struct cache_sub_stats temp_css;
+  struct cache_sub_stats total_css;
+  temp_css.clear();
+  total_css.clear();
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i) {
+    m_core[i]->get_L1D_sub_stats(temp_css);
+    total_css += temp_css;
+  }
+  css = total_css;
+}
+void simt_core_cluster::get_L1C_sub_stats(struct cache_sub_stats &css) const {
+  struct cache_sub_stats temp_css;
+  struct cache_sub_stats total_css;
+  temp_css.clear();
+  total_css.clear();
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i) {
+    m_core[i]->get_L1C_sub_stats(temp_css);
+    total_css += temp_css;
+  }
+  css = total_css;
+}
+void simt_core_cluster::get_L1T_sub_stats(struct cache_sub_stats &css) const {
+  struct cache_sub_stats temp_css;
+  struct cache_sub_stats total_css;
+  temp_css.clear();
+  total_css.clear();
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i) {
+    m_core[i]->get_L1T_sub_stats(temp_css);
+    total_css += temp_css;
+  }
+  css = total_css;
+}
+
+void shader_core_ctx::checkExecutionStatusAndUpdate(warp_inst_t &inst,
+                                                    unsigned t, unsigned tid) {
+  if (inst.isatomic()) m_warp[inst.warp_id()].inc_n_atomic();
+  if (inst.space.is_local() && (inst.is_load() || inst.is_store())) {
+    new_addr_type localaddrs[MAX_ACCESSES_PER_INSN_PER_THREAD];
+    unsigned num_addrs;
+    num_addrs = translate_local_memaddr(
+        inst.get_addr(t), tid,
+        m_config->n_simt_clusters * m_config->n_simt_cores_per_cluster,
+        inst.data_size, (new_addr_type *)localaddrs);
+    inst.set_addr(t, (new_addr_type *)localaddrs, num_addrs);
+  }
+  if (ptx_thread_done(tid)) {
+    m_warp[inst.warp_id()].set_completed(t);
+    m_warp[inst.warp_id()].ibuffer_flush();
+  }
+
+  // PC-Histogram Update
+  unsigned warp_id = inst.warp_id();
+  unsigned pc = inst.pc;
+  for (unsigned t = 0; t < m_config->warp_size; t++) {
+    if (inst.active(t)) {
+      int tid = warp_id * m_config->warp_size + t;
+      cflog_update_thread_pc(m_sid, tid, pc);
+    }
+  }
+}

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2011, Tor M. Aamodt, Wilson W.L. Fung, Ali Bakhoda,
-// George L. Yuan, Andrew Turner, Inderpreet Singh
+// George L. Yuan, Andrew Turner, Inderpreet Singh 
 // The University of British Columbia
 // All rights reserved.
 //
@@ -8,16 +8,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -28,2137 +26,2042 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "shader.h"
 #include <float.h>
-#include <limits.h>
-#include <string.h>
-#include "../../libcuda/gpgpu_context.h"
-#include "../cuda-sim/cuda-sim.h"
-#include "../cuda-sim/ptx-stats.h"
-#include "../cuda-sim/ptx_sim.h"
-#include "../statwrapper.h"
+#include "shader.h"
 #include "addrdec.h"
 #include "dram.h"
+#include "stat-tool.h"
 #include "gpu-misc.h"
+#include "../cuda-sim/ptx_sim.h"
+#include "../cuda-sim/ptx-stats.h"
+#include "../cuda-sim/cuda-sim.h"
 #include "gpu-sim.h"
-#include "icnt_wrapper.h"
 #include "mem_fetch.h"
 #include "mem_latency_stat.h"
-#include "shader_trace.h"
-#include "stat-tool.h"
-#include "traffic_breakdown.h"
 #include "visualizer.h"
+#include "../statwrapper.h"
+#include "icnt_wrapper.h"
+#include <string.h>
+#include <limits.h>
+#include "traffic_breakdown.h"
+#include "shader_trace.h"
+#include "../../libcuda/gpgpu_context.h"
 
 #define PRIORITIZE_MSHR_OVER_WB 1
-#define MAX(a, b) (((a) > (b)) ? (a) : (b))
-#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#define MAX(a,b) (((a)>(b))?(a):(b))
+#define MIN(a,b) (((a)<(b))?(a):(b))
+    
 
-mem_fetch *shader_core_mem_fetch_allocator::alloc(
-    new_addr_type addr, mem_access_type type, unsigned size, bool wr,
-    unsigned long long cycle) const {
-  mem_access_t access(type, addr, size, wr, m_memory_config->gpgpu_ctx);
-  mem_fetch *mf =
-      new mem_fetch(access, NULL, wr ? WRITE_PACKET_SIZE : READ_PACKET_SIZE, -1,
-                    m_core_id, m_cluster_id, m_memory_config, cycle);
-  return mf;
+mem_fetch *shader_core_mem_fetch_allocator::alloc( new_addr_type addr, mem_access_type type, unsigned size, bool wr, unsigned long long cycle ) const
+{
+    mem_access_t access( type, addr, size, wr, m_memory_config->gpgpu_ctx);
+    mem_fetch *mf = new mem_fetch( access, 
+	    NULL,
+	    wr?WRITE_PACKET_SIZE:READ_PACKET_SIZE, 
+	    -1, 
+	    m_core_id, 
+	    m_cluster_id,
+	    m_memory_config,
+	    cycle);
+    return mf;
 }
 /////////////////////////////////////////////////////////////////////////////
 
-std::list<unsigned> shader_core_ctx::get_regs_written(const inst_t &fvt) const {
-  std::list<unsigned> result;
-  for (unsigned op = 0; op < MAX_REG_OPERANDS; op++) {
-    int reg_num = fvt.arch_reg.dst[op];  // this math needs to match that used
-                                         // in function_info::ptx_decode_inst
-    if (reg_num >= 0)                    // valid register
-      result.push_back(reg_num);
-  }
-  return result;
+std::list<unsigned> shader_core_ctx::get_regs_written( const inst_t &fvt ) const
+{
+   std::list<unsigned> result;
+   for( unsigned op=0; op < MAX_REG_OPERANDS; op++ ) {
+      int reg_num = fvt.arch_reg.dst[op]; // this math needs to match that used in function_info::ptx_decode_inst
+      if( reg_num >= 0 ) // valid register
+         result.push_back(reg_num);
+   }
+   return result;
 }
 
-shader_core_ctx::shader_core_ctx(class gpgpu_sim *gpu,
-                                 class simt_core_cluster *cluster,
-                                 unsigned shader_id, unsigned tpc_id,
-                                 const shader_core_config *config,
-                                 const memory_config *mem_config,
-                                 shader_core_stats *stats)
-    : core_t(gpu, NULL, config->warp_size, config->n_thread_per_shader),
-      m_barriers(this, config->max_warps_per_shader, config->max_cta_per_core,
-                 config->max_barriers_per_cta, config->warp_size),
-      m_active_warps(0),
-      m_dynamic_warp_id(0) {
-  m_cluster = cluster;
-  m_config = config;
-  m_memory_config = mem_config;
-  m_stats = stats;
-  unsigned warp_size = config->warp_size;
-  Issue_Prio = 0;
-
-  m_sid = shader_id;
-  m_tpc = tpc_id;
-
-  m_pipeline_reg.reserve(N_PIPELINE_STAGES);
-  for (int j = 0; j < N_PIPELINE_STAGES; j++) {
-    m_pipeline_reg.push_back(
-        register_set(m_config->pipe_widths[j], pipeline_stage_name_decode[j]));
-  }
-  if (m_config->sub_core_model) {
-    // in subcore model, each scheduler should has its own issue register, so
-    // num scheduler = reg width
-    assert(m_config->gpgpu_num_sched_per_core ==
-           m_pipeline_reg[ID_OC_SP].get_size());
-    assert(m_config->gpgpu_num_sched_per_core ==
-           m_pipeline_reg[ID_OC_SFU].get_size());
-    assert(m_config->gpgpu_num_sched_per_core ==
-           m_pipeline_reg[ID_OC_MEM].get_size());
-    if (m_config->gpgpu_tensor_core_avail)
-      assert(m_config->gpgpu_num_sched_per_core ==
-             m_pipeline_reg[ID_OC_TENSOR_CORE].get_size());
-    if (m_config->gpgpu_num_dp_units > 0)
-      assert(m_config->gpgpu_num_sched_per_core ==
-             m_pipeline_reg[ID_OC_DP].get_size());
-    if (m_config->gpgpu_num_int_units > 0)
-      assert(m_config->gpgpu_num_sched_per_core ==
-             m_pipeline_reg[ID_OC_INT].get_size());
-  }
-
-  m_threadState =
-      (thread_ctx_t *)calloc(sizeof(thread_ctx_t), config->n_thread_per_shader);
-
-  m_not_completed = 0;
-  m_active_threads.reset();
-  m_n_active_cta = 0;
-  for (unsigned i = 0; i < MAX_CTA_PER_SHADER; i++) m_cta_status[i] = 0;
-  for (unsigned i = 0; i < config->n_thread_per_shader; i++) {
-    m_thread[i] = NULL;
-    m_threadState[i].m_cta_id = -1;
-    m_threadState[i].m_active = false;
-  }
-
-  // m_icnt = new shader_memory_interface(this,cluster);
-  if (m_config->gpgpu_perfect_mem) {
-    m_icnt = new perfect_memory_interface(this, cluster);
-  } else {
-    m_icnt = new shader_memory_interface(this, cluster);
-  }
-  m_mem_fetch_allocator =
-      new shader_core_mem_fetch_allocator(shader_id, tpc_id, mem_config);
-
-  // fetch
-  m_last_warp_fetched = 0;
-
-#define STRSIZE 1024
-  char name[STRSIZE];
-  snprintf(name, STRSIZE, "L1I_%03d", m_sid);
-  m_L1I = new read_only_cache(name, m_config->m_L1I_config, m_sid,
-                              get_shader_instruction_cache_id(), m_icnt,
-                              IN_L1I_MISS_QUEUE);
-
-  m_warp.resize(m_config->max_warps_per_shader, shd_warp_t(this, warp_size));
-  m_scoreboard = new Scoreboard(m_sid, m_config->max_warps_per_shader, gpu);
-
-  // scedulers
-  // must currently occur after all inputs have been initialized.
-  std::string sched_config = m_config->gpgpu_scheduler_string;
-  const concrete_scheduler scheduler =
-      sched_config.find("lrr") != std::string::npos
-          ? CONCRETE_SCHEDULER_LRR
-          : sched_config.find("two_level_active") != std::string::npos
-                ? CONCRETE_SCHEDULER_TWO_LEVEL_ACTIVE
-                : sched_config.find("gto") != std::string::npos
-                      ? CONCRETE_SCHEDULER_GTO
-                      : sched_config.find("old") != std::string::npos
-                            ? CONCRETE_SCHEDULER_OLDEST_FIRST
-                            : sched_config.find("warp_limiting") !=
-                                      std::string::npos
-                                  ? CONCRETE_SCHEDULER_WARP_LIMITING
-                                  : NUM_CONCRETE_SCHEDULERS;
-  assert(scheduler != NUM_CONCRETE_SCHEDULERS);
-
-  for (unsigned i = 0; i < m_config->gpgpu_num_sched_per_core; i++) {
-    switch (scheduler) {
-      case CONCRETE_SCHEDULER_LRR:
-        schedulers.push_back(new lrr_scheduler(
-            m_stats, this, m_scoreboard, m_simt_stack, &m_warp,
-            &m_pipeline_reg[ID_OC_SP], &m_pipeline_reg[ID_OC_DP],
-            &m_pipeline_reg[ID_OC_SFU], &m_pipeline_reg[ID_OC_INT],
-            &m_pipeline_reg[ID_OC_TENSOR_CORE], &m_pipeline_reg[ID_OC_MEM], i));
-        break;
-      case CONCRETE_SCHEDULER_TWO_LEVEL_ACTIVE:
-        schedulers.push_back(new two_level_active_scheduler(
-            m_stats, this, m_scoreboard, m_simt_stack, &m_warp,
-            &m_pipeline_reg[ID_OC_SP], &m_pipeline_reg[ID_OC_DP],
-            &m_pipeline_reg[ID_OC_SFU], &m_pipeline_reg[ID_OC_INT],
-            &m_pipeline_reg[ID_OC_TENSOR_CORE], &m_pipeline_reg[ID_OC_MEM], i,
-            config->gpgpu_scheduler_string));
-        break;
-      case CONCRETE_SCHEDULER_GTO:
-        schedulers.push_back(new gto_scheduler(
-            m_stats, this, m_scoreboard, m_simt_stack, &m_warp,
-            &m_pipeline_reg[ID_OC_SP], &m_pipeline_reg[ID_OC_DP],
-            &m_pipeline_reg[ID_OC_SFU], &m_pipeline_reg[ID_OC_INT],
-            &m_pipeline_reg[ID_OC_TENSOR_CORE], &m_pipeline_reg[ID_OC_MEM], i));
-        break;
-      case CONCRETE_SCHEDULER_OLDEST_FIRST:
-        schedulers.push_back(new oldest_scheduler(
-            m_stats, this, m_scoreboard, m_simt_stack, &m_warp,
-            &m_pipeline_reg[ID_OC_SP], &m_pipeline_reg[ID_OC_DP],
-            &m_pipeline_reg[ID_OC_SFU], &m_pipeline_reg[ID_OC_INT],
-            &m_pipeline_reg[ID_OC_TENSOR_CORE], &m_pipeline_reg[ID_OC_MEM], i));
-        break;
-      case CONCRETE_SCHEDULER_WARP_LIMITING:
-        schedulers.push_back(new swl_scheduler(
-            m_stats, this, m_scoreboard, m_simt_stack, &m_warp,
-            &m_pipeline_reg[ID_OC_SP], &m_pipeline_reg[ID_OC_DP],
-            &m_pipeline_reg[ID_OC_SFU], &m_pipeline_reg[ID_OC_INT],
-            &m_pipeline_reg[ID_OC_TENSOR_CORE], &m_pipeline_reg[ID_OC_MEM], i,
-            config->gpgpu_scheduler_string));
-        break;
-      default:
-        abort();
-    };
-  }
-
-  for (unsigned i = 0; i < m_warp.size(); i++) {
-    // distribute i's evenly though schedulers;
-    schedulers[i % m_config->gpgpu_num_sched_per_core]->add_supervised_warp_id(
-        i);
-  }
-  for (unsigned i = 0; i < m_config->gpgpu_num_sched_per_core; ++i) {
-    schedulers[i]->done_adding_supervised_warps();
-  }
-
-  // op collector configuration
-
-  enum { SP_CUS, DP_CUS, SFU_CUS, TENSOR_CORE_CUS, INT_CUS, MEM_CUS, GEN_CUS };
-
-  opndcoll_rfu_t::port_vector_t in_ports;
-  opndcoll_rfu_t::port_vector_t out_ports;
-  opndcoll_rfu_t::uint_vector_t cu_sets;
-
-  // configure generic collectors
-  m_operand_collector.add_cu_set(
-      GEN_CUS, m_config->gpgpu_operand_collector_num_units_gen,
-      m_config->gpgpu_operand_collector_num_out_ports_gen);
-
-  for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_gen;
-       i++) {
-    in_ports.push_back(&m_pipeline_reg[ID_OC_SP]);
-    in_ports.push_back(&m_pipeline_reg[ID_OC_SFU]);
-    in_ports.push_back(&m_pipeline_reg[ID_OC_MEM]);
-    out_ports.push_back(&m_pipeline_reg[OC_EX_SP]);
-    out_ports.push_back(&m_pipeline_reg[OC_EX_SFU]);
-    out_ports.push_back(&m_pipeline_reg[OC_EX_MEM]);
-    if (m_config->gpgpu_tensor_core_avail) {
-      in_ports.push_back(&m_pipeline_reg[ID_OC_TENSOR_CORE]);
-      out_ports.push_back(&m_pipeline_reg[OC_EX_TENSOR_CORE]);
+shader_core_ctx::shader_core_ctx( class gpgpu_sim *gpu, 
+                                  class simt_core_cluster *cluster,
+                                  unsigned shader_id,
+                                  unsigned tpc_id,
+                                  const shader_core_config *config,
+                                  const memory_config *mem_config,
+                                  shader_core_stats *stats )
+   : core_t( gpu, NULL, config->warp_size, config->n_thread_per_shader ),
+     m_barriers( this, config->max_warps_per_shader, config->max_cta_per_core, config->max_barriers_per_cta, config->warp_size ),
+     m_active_warps(0), m_dynamic_warp_id(0)
+{
+    m_cluster = cluster;
+    m_config = config;
+    m_memory_config = mem_config;
+    m_stats = stats;
+    unsigned warp_size=config->warp_size;
+    Issue_Prio = 0;
+    
+    m_sid = shader_id;
+    m_tpc = tpc_id;
+    
+    m_pipeline_reg.reserve(N_PIPELINE_STAGES);
+    for (int j = 0; j<N_PIPELINE_STAGES; j++) {
+        m_pipeline_reg.push_back(register_set(m_config->pipe_widths[j],pipeline_stage_name_decode[j]));
     }
-    if (m_config->gpgpu_num_dp_units > 0) {
-      in_ports.push_back(&m_pipeline_reg[ID_OC_DP]);
-      out_ports.push_back(&m_pipeline_reg[OC_EX_DP]);
+    if(m_config->sub_core_model) {
+    	//in subcore model, each scheduler should has its own issue register, so num scheduler = reg width
+    	assert(m_config->gpgpu_num_sched_per_core == m_pipeline_reg[ID_OC_SP].get_size() );
+    	assert(m_config->gpgpu_num_sched_per_core == m_pipeline_reg[ID_OC_SFU].get_size() );
+    	assert(m_config->gpgpu_num_sched_per_core == m_pipeline_reg[ID_OC_MEM].get_size() );
+    	if(m_config->gpgpu_tensor_core_avail)
+    		 assert(m_config->gpgpu_num_sched_per_core == m_pipeline_reg[ID_OC_TENSOR_CORE].get_size() );
+    	if(m_config->gpgpu_num_dp_units > 0)
+    		assert(m_config->gpgpu_num_sched_per_core == m_pipeline_reg[ID_OC_DP].get_size() );
+    	if(m_config->gpgpu_num_int_units > 0)
+    	    assert(m_config->gpgpu_num_sched_per_core == m_pipeline_reg[ID_OC_INT].get_size() );
     }
-    if (m_config->gpgpu_num_int_units > 0) {
-      in_ports.push_back(&m_pipeline_reg[ID_OC_INT]);
-      out_ports.push_back(&m_pipeline_reg[OC_EX_INT]);
-    }
-    cu_sets.push_back((unsigned)GEN_CUS);
-    m_operand_collector.add_port(in_ports, out_ports, cu_sets);
-    in_ports.clear(), out_ports.clear(), cu_sets.clear();
-  }
-
-  if (m_config->enable_specialized_operand_collector) {
-    m_operand_collector.add_cu_set(
-        SP_CUS, m_config->gpgpu_operand_collector_num_units_sp,
-        m_config->gpgpu_operand_collector_num_out_ports_sp);
-    m_operand_collector.add_cu_set(
-        DP_CUS, m_config->gpgpu_operand_collector_num_units_dp,
-        m_config->gpgpu_operand_collector_num_out_ports_dp);
-    m_operand_collector.add_cu_set(
-        TENSOR_CORE_CUS, config->gpgpu_operand_collector_num_units_tensor_core,
-        config->gpgpu_operand_collector_num_out_ports_tensor_core);
-    m_operand_collector.add_cu_set(
-        SFU_CUS, m_config->gpgpu_operand_collector_num_units_sfu,
-        m_config->gpgpu_operand_collector_num_out_ports_sfu);
-    m_operand_collector.add_cu_set(
-        MEM_CUS, m_config->gpgpu_operand_collector_num_units_mem,
-        m_config->gpgpu_operand_collector_num_out_ports_mem);
-    m_operand_collector.add_cu_set(
-        INT_CUS, m_config->gpgpu_operand_collector_num_units_int,
-        m_config->gpgpu_operand_collector_num_out_ports_int);
-
-    for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_sp;
-         i++) {
-      in_ports.push_back(&m_pipeline_reg[ID_OC_SP]);
-      out_ports.push_back(&m_pipeline_reg[OC_EX_SP]);
-      cu_sets.push_back((unsigned)SP_CUS);
-      cu_sets.push_back((unsigned)GEN_CUS);
-      m_operand_collector.add_port(in_ports, out_ports, cu_sets);
-      in_ports.clear(), out_ports.clear(), cu_sets.clear();
-    }
-
-    for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_dp;
-         i++) {
-      in_ports.push_back(&m_pipeline_reg[ID_OC_DP]);
-      out_ports.push_back(&m_pipeline_reg[OC_EX_DP]);
-      cu_sets.push_back((unsigned)DP_CUS);
-      cu_sets.push_back((unsigned)GEN_CUS);
-      m_operand_collector.add_port(in_ports, out_ports, cu_sets);
-      in_ports.clear(), out_ports.clear(), cu_sets.clear();
-    }
-
-    for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_sfu;
-         i++) {
-      in_ports.push_back(&m_pipeline_reg[ID_OC_SFU]);
-      out_ports.push_back(&m_pipeline_reg[OC_EX_SFU]);
-      cu_sets.push_back((unsigned)SFU_CUS);
-      cu_sets.push_back((unsigned)GEN_CUS);
-      m_operand_collector.add_port(in_ports, out_ports, cu_sets);
-      in_ports.clear(), out_ports.clear(), cu_sets.clear();
-    }
-
-    for (unsigned i = 0;
-         i < config->gpgpu_operand_collector_num_in_ports_tensor_core; i++) {
-      in_ports.push_back(&m_pipeline_reg[ID_OC_TENSOR_CORE]);
-      out_ports.push_back(&m_pipeline_reg[OC_EX_TENSOR_CORE]);
-      cu_sets.push_back((unsigned)TENSOR_CORE_CUS);
-      cu_sets.push_back((unsigned)GEN_CUS);
-      m_operand_collector.add_port(in_ports, out_ports, cu_sets);
-      in_ports.clear(), out_ports.clear(), cu_sets.clear();
-    }
-
-    for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_mem;
-         i++) {
-      in_ports.push_back(&m_pipeline_reg[ID_OC_MEM]);
-      out_ports.push_back(&m_pipeline_reg[OC_EX_MEM]);
-      cu_sets.push_back((unsigned)MEM_CUS);
-      cu_sets.push_back((unsigned)GEN_CUS);
-      m_operand_collector.add_port(in_ports, out_ports, cu_sets);
-      in_ports.clear(), out_ports.clear(), cu_sets.clear();
-    }
-
-    for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_int;
-         i++) {
-      in_ports.push_back(&m_pipeline_reg[ID_OC_INT]);
-      out_ports.push_back(&m_pipeline_reg[OC_EX_INT]);
-      cu_sets.push_back((unsigned)INT_CUS);
-      cu_sets.push_back((unsigned)GEN_CUS);
-      m_operand_collector.add_port(in_ports, out_ports, cu_sets);
-      in_ports.clear(), out_ports.clear(), cu_sets.clear();
-    }
-  }
-
-  m_operand_collector.init(m_config->gpgpu_num_reg_banks, this);
-
-  m_num_function_units =
-      m_config->gpgpu_num_sp_units + m_config->gpgpu_num_dp_units +
-      m_config->gpgpu_num_sfu_units + m_config->gpgpu_num_tensor_core_units +
-      m_config->gpgpu_num_int_units +
-      1;  // sp_unit, sfu, dp, tensor, int, ldst_unit
-  // m_dispatch_port = new enum pipeline_stage_name_t[ m_num_function_units ];
-  // m_issue_port = new enum pipeline_stage_name_t[ m_num_function_units ];
-
-  // m_fu = new simd_function_unit*[m_num_function_units];
-
-  for (int k = 0; k < m_config->gpgpu_num_sp_units; k++) {
-    m_fu.push_back(new sp_unit(&m_pipeline_reg[EX_WB], m_config, this));
-    m_dispatch_port.push_back(ID_OC_SP);
-    m_issue_port.push_back(OC_EX_SP);
-  }
-
-  for (int k = 0; k < m_config->gpgpu_num_dp_units; k++) {
-    m_fu.push_back(new dp_unit(&m_pipeline_reg[EX_WB], m_config, this));
-    m_dispatch_port.push_back(ID_OC_DP);
-    m_issue_port.push_back(OC_EX_DP);
-  }
-  for (int k = 0; k < m_config->gpgpu_num_int_units; k++) {
-    m_fu.push_back(new int_unit(&m_pipeline_reg[EX_WB], m_config, this));
-    m_dispatch_port.push_back(ID_OC_INT);
-    m_issue_port.push_back(OC_EX_INT);
-  }
-
-  for (int k = 0; k < m_config->gpgpu_num_sfu_units; k++) {
-    m_fu.push_back(new sfu(&m_pipeline_reg[EX_WB], m_config, this));
-    m_dispatch_port.push_back(ID_OC_SFU);
-    m_issue_port.push_back(OC_EX_SFU);
-  }
-
-  for (int k = 0; k < config->gpgpu_num_tensor_core_units; k++) {
-    m_fu.push_back(new tensor_core(&m_pipeline_reg[EX_WB], m_config, this));
-    m_dispatch_port.push_back(ID_OC_TENSOR_CORE);
-    m_issue_port.push_back(OC_EX_TENSOR_CORE);
-  }
-
-  m_ldst_unit =
-      new ldst_unit(m_icnt, m_mem_fetch_allocator, this, &m_operand_collector,
-                    m_scoreboard, config, mem_config, stats, shader_id, tpc_id);
-  m_fu.push_back(m_ldst_unit);
-  m_dispatch_port.push_back(ID_OC_MEM);
-  m_issue_port.push_back(OC_EX_MEM);
-
-  assert(m_num_function_units == m_fu.size() and
-         m_fu.size() == m_dispatch_port.size() and
-         m_fu.size() == m_issue_port.size());
-
-  // there are as many result buses as the width of the EX_WB stage
-  num_result_bus = config->pipe_widths[EX_WB];
-  for (unsigned i = 0; i < num_result_bus; i++) {
-    this->m_result_bus.push_back(new std::bitset<MAX_ALU_LATENCY>());
-  }
-
-  m_last_inst_gpu_sim_cycle = 0;
-  m_last_inst_gpu_tot_sim_cycle = 0;
-
-  // Jin: for concurrent kernels on a SM
-  m_occupied_n_threads = 0;
-  m_occupied_shmem = 0;
-  m_occupied_regs = 0;
-  m_occupied_ctas = 0;
-  m_occupied_hwtid.reset();
-  m_occupied_cta_to_hwtid.clear();
-}
-
-void shader_core_ctx::reinit(unsigned start_thread, unsigned end_thread,
-                             bool reset_not_completed) {
-  if (reset_not_completed) {
+    
+    m_threadState = (thread_ctx_t*) calloc(sizeof(thread_ctx_t), config->n_thread_per_shader);
+    
     m_not_completed = 0;
     m_active_threads.reset();
+    m_n_active_cta = 0;
+    for ( unsigned i = 0; i<MAX_CTA_PER_SHADER; i++ ) 
+        m_cta_status[i]=0;
+    for (unsigned i = 0; i<config->n_thread_per_shader; i++) {
+        m_thread[i]= NULL;
+        m_threadState[i].m_cta_id = -1;
+        m_threadState[i].m_active = false;
+    }
+    
+    // m_icnt = new shader_memory_interface(this,cluster);
+    if ( m_config->gpgpu_perfect_mem ) {
+        m_icnt = new perfect_memory_interface(this,cluster);
+    } else {
+        m_icnt = new shader_memory_interface(this,cluster);
+    }
+    m_mem_fetch_allocator = new shader_core_mem_fetch_allocator(shader_id,tpc_id,mem_config);
+    
+    // fetch
+    m_last_warp_fetched = 0;
+    
+    #define STRSIZE 1024
+    char name[STRSIZE];
+    snprintf(name, STRSIZE, "L1I_%03d", m_sid);
+    m_L1I = new read_only_cache( name,m_config->m_L1I_config,m_sid,get_shader_instruction_cache_id(),m_icnt,IN_L1I_MISS_QUEUE);
+    
+    m_warp.resize(m_config->max_warps_per_shader, shd_warp_t(this, warp_size));
+    m_scoreboard = new Scoreboard(m_sid, m_config->max_warps_per_shader, gpu);
+    
+    //scedulers
+    //must currently occur after all inputs have been initialized.
+    std::string sched_config = m_config->gpgpu_scheduler_string;
+    const concrete_scheduler scheduler = sched_config.find("lrr") != std::string::npos ?
+                                         CONCRETE_SCHEDULER_LRR :
+                                         sched_config.find("two_level_active") != std::string::npos ?
+                                         CONCRETE_SCHEDULER_TWO_LEVEL_ACTIVE :
+                                         sched_config.find("gto") != std::string::npos ?
+                                         CONCRETE_SCHEDULER_GTO :
+					 sched_config.find("old") != std::string::npos ?
+					 CONCRETE_SCHEDULER_OLDEST_FIRST :
+                                         sched_config.find("warp_limiting") != std::string::npos ?
+                                         CONCRETE_SCHEDULER_WARP_LIMITING:
+                                         NUM_CONCRETE_SCHEDULERS;
+    assert ( scheduler != NUM_CONCRETE_SCHEDULERS );
+    
+    for (unsigned i = 0; i < m_config->gpgpu_num_sched_per_core; i++) {
+        switch( scheduler )
+        {
+            case CONCRETE_SCHEDULER_LRR:
+                schedulers.push_back(
+                    new lrr_scheduler( m_stats,
+                                       this,
+                                       m_scoreboard,
+                                       m_simt_stack,
+                                       &m_warp,
+                                       &m_pipeline_reg[ID_OC_SP],
+									   &m_pipeline_reg[ID_OC_DP],
+                                       &m_pipeline_reg[ID_OC_SFU],
+									   &m_pipeline_reg[ID_OC_INT],
+                                       &m_pipeline_reg[ID_OC_TENSOR_CORE],
+                                       &m_pipeline_reg[ID_OC_MEM],
+                                       i
+                                     )
+                );
+                break;
+            case CONCRETE_SCHEDULER_TWO_LEVEL_ACTIVE:
+                schedulers.push_back(
+                    new two_level_active_scheduler( m_stats,
+                                                    this,
+                                                    m_scoreboard,
+                                                    m_simt_stack,
+                                                    &m_warp,
+                                                    &m_pipeline_reg[ID_OC_SP],
+													&m_pipeline_reg[ID_OC_DP],
+                                                    &m_pipeline_reg[ID_OC_SFU],
+													&m_pipeline_reg[ID_OC_INT],
+                                                    &m_pipeline_reg[ID_OC_TENSOR_CORE],
+                                                    &m_pipeline_reg[ID_OC_MEM],
+                                                    i,
+                                                    config->gpgpu_scheduler_string
+                                                  )
+                );
+                break;
+            case CONCRETE_SCHEDULER_GTO:
+                schedulers.push_back(
+                    new gto_scheduler( m_stats,
+                                       this,
+                                       m_scoreboard,
+                                       m_simt_stack,
+                                       &m_warp,
+                                       &m_pipeline_reg[ID_OC_SP],
+									   &m_pipeline_reg[ID_OC_DP],
+                                       &m_pipeline_reg[ID_OC_SFU],
+									   &m_pipeline_reg[ID_OC_INT],
+                                       &m_pipeline_reg[ID_OC_TENSOR_CORE],
+                                       &m_pipeline_reg[ID_OC_MEM],
+                                       i
+                                     )
+                );
+                break;
+            case CONCRETE_SCHEDULER_OLDEST_FIRST:
+				schedulers.push_back(
+		    new oldest_scheduler( m_stats,
+					  this,
+					  m_scoreboard,
+					  m_simt_stack,
+					  &m_warp,
+					  &m_pipeline_reg[ID_OC_SP],
+					  &m_pipeline_reg[ID_OC_DP],
+					  &m_pipeline_reg[ID_OC_SFU],
+					  &m_pipeline_reg[ID_OC_INT],
+                      &m_pipeline_reg[ID_OC_TENSOR_CORE],
+					  &m_pipeline_reg[ID_OC_MEM],
+					  i
+					 )
+				);
+				break;
+            case CONCRETE_SCHEDULER_WARP_LIMITING:
+                schedulers.push_back(
+                    new swl_scheduler( m_stats,
+                                       this,
+                                       m_scoreboard,
+                                       m_simt_stack,
+                                       &m_warp,
+                                       &m_pipeline_reg[ID_OC_SP],
+									   &m_pipeline_reg[ID_OC_DP],
+                                       &m_pipeline_reg[ID_OC_SFU],
+									   &m_pipeline_reg[ID_OC_INT],
+                                       &m_pipeline_reg[ID_OC_TENSOR_CORE],
+                                       &m_pipeline_reg[ID_OC_MEM],
+                                       i,
+                                       config->gpgpu_scheduler_string
+                                     )
+                );
+                break;
+            default:
+                abort();
+        };
+    }
+    
+    for (unsigned i = 0; i < m_warp.size(); i++) {
+        //distribute i's evenly though schedulers;
+        schedulers[i%m_config->gpgpu_num_sched_per_core]->add_supervised_warp_id(i);
+    }
+    for ( unsigned i = 0; i < m_config->gpgpu_num_sched_per_core; ++i ) {
+        schedulers[i]->done_adding_supervised_warps();
+    }
+    
+    //op collector configuration
 
-    // Jin: for concurrent kernels on a SM
+	enum { SP_CUS, DP_CUS, SFU_CUS, TENSOR_CORE_CUS, INT_CUS, MEM_CUS,  GEN_CUS };
+
+    opndcoll_rfu_t::port_vector_t in_ports;
+    opndcoll_rfu_t::port_vector_t out_ports;
+    opndcoll_rfu_t::uint_vector_t cu_sets;
+
+    //configure generic collectors
+    m_operand_collector.add_cu_set(GEN_CUS, m_config->gpgpu_operand_collector_num_units_gen, m_config->gpgpu_operand_collector_num_out_ports_gen);
+
+    for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_gen; i++) {
+        in_ports.push_back(&m_pipeline_reg[ID_OC_SP]);
+        in_ports.push_back(&m_pipeline_reg[ID_OC_SFU]);
+        in_ports.push_back(&m_pipeline_reg[ID_OC_MEM]);
+        out_ports.push_back(&m_pipeline_reg[OC_EX_SP]);
+        out_ports.push_back(&m_pipeline_reg[OC_EX_SFU]);
+        out_ports.push_back(&m_pipeline_reg[OC_EX_MEM]);
+        if(m_config->gpgpu_tensor_core_avail) {
+        	in_ports.push_back(&m_pipeline_reg[ID_OC_TENSOR_CORE]);
+        	out_ports.push_back(&m_pipeline_reg[OC_EX_TENSOR_CORE]);
+        }
+        if(m_config->gpgpu_num_dp_units > 0) {
+			in_ports.push_back(&m_pipeline_reg[ID_OC_DP]);
+			out_ports.push_back(&m_pipeline_reg[OC_EX_DP]);
+        }
+        if(m_config->gpgpu_num_int_units > 0) {
+			in_ports.push_back(&m_pipeline_reg[ID_OC_INT]);
+			out_ports.push_back(&m_pipeline_reg[OC_EX_INT]);
+        }
+        cu_sets.push_back((unsigned)GEN_CUS);
+        m_operand_collector.add_port(in_ports,out_ports,cu_sets);
+        in_ports.clear(),out_ports.clear(),cu_sets.clear();
+    }
+
+    if(m_config->enable_specialized_operand_collector) {
+		m_operand_collector.add_cu_set(SP_CUS, m_config->gpgpu_operand_collector_num_units_sp, m_config->gpgpu_operand_collector_num_out_ports_sp);
+		m_operand_collector.add_cu_set(DP_CUS, m_config->gpgpu_operand_collector_num_units_dp, m_config->gpgpu_operand_collector_num_out_ports_dp);
+	    m_operand_collector.add_cu_set(TENSOR_CORE_CUS, config->gpgpu_operand_collector_num_units_tensor_core, config->gpgpu_operand_collector_num_out_ports_tensor_core);
+	    m_operand_collector.add_cu_set(SFU_CUS, m_config->gpgpu_operand_collector_num_units_sfu, m_config->gpgpu_operand_collector_num_out_ports_sfu);
+		m_operand_collector.add_cu_set(MEM_CUS, m_config->gpgpu_operand_collector_num_units_mem, m_config->gpgpu_operand_collector_num_out_ports_mem);
+		m_operand_collector.add_cu_set(INT_CUS, m_config->gpgpu_operand_collector_num_units_int, m_config->gpgpu_operand_collector_num_out_ports_int);
+
+		for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_sp; i++) {
+			in_ports.push_back(&m_pipeline_reg[ID_OC_SP]);
+			out_ports.push_back(&m_pipeline_reg[OC_EX_SP]);
+			cu_sets.push_back((unsigned)SP_CUS);
+			cu_sets.push_back((unsigned)GEN_CUS);
+			m_operand_collector.add_port(in_ports,out_ports,cu_sets);
+			in_ports.clear(),out_ports.clear(),cu_sets.clear();
+		}
+
+		for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_dp; i++) {
+				in_ports.push_back(&m_pipeline_reg[ID_OC_DP]);
+				out_ports.push_back(&m_pipeline_reg[OC_EX_DP]);
+				cu_sets.push_back((unsigned)DP_CUS);
+				cu_sets.push_back((unsigned)GEN_CUS);
+				m_operand_collector.add_port(in_ports,out_ports,cu_sets);
+				in_ports.clear(),out_ports.clear(),cu_sets.clear();
+			}
+
+		for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_sfu; i++) {
+			in_ports.push_back(&m_pipeline_reg[ID_OC_SFU]);
+			out_ports.push_back(&m_pipeline_reg[OC_EX_SFU]);
+			cu_sets.push_back((unsigned)SFU_CUS);
+			cu_sets.push_back((unsigned)GEN_CUS);
+			m_operand_collector.add_port(in_ports,out_ports,cu_sets);
+			in_ports.clear(),out_ports.clear(),cu_sets.clear();
+		}
+
+	    for (unsigned i = 0; i < config->gpgpu_operand_collector_num_in_ports_tensor_core; i++) {
+	        in_ports.push_back(&m_pipeline_reg[ID_OC_TENSOR_CORE]);
+	        out_ports.push_back(&m_pipeline_reg[OC_EX_TENSOR_CORE]);
+	        cu_sets.push_back((unsigned)TENSOR_CORE_CUS);
+	        cu_sets.push_back((unsigned)GEN_CUS);
+	        m_operand_collector.add_port(in_ports,out_ports,cu_sets);
+	        in_ports.clear(),out_ports.clear(),cu_sets.clear();
+	    }
+
+		for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_mem; i++) {
+			in_ports.push_back(&m_pipeline_reg[ID_OC_MEM]);
+			out_ports.push_back(&m_pipeline_reg[OC_EX_MEM]);
+			cu_sets.push_back((unsigned)MEM_CUS);
+			cu_sets.push_back((unsigned)GEN_CUS);
+			m_operand_collector.add_port(in_ports,out_ports,cu_sets);
+			in_ports.clear(),out_ports.clear(),cu_sets.clear();
+		}
+
+		for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_int; i++) {
+			in_ports.push_back(&m_pipeline_reg[ID_OC_INT]);
+			out_ports.push_back(&m_pipeline_reg[OC_EX_INT]);
+			cu_sets.push_back((unsigned)INT_CUS);
+			cu_sets.push_back((unsigned)GEN_CUS);
+			m_operand_collector.add_port(in_ports,out_ports,cu_sets);
+			in_ports.clear(),out_ports.clear(),cu_sets.clear();
+		}
+    }
+    
+    m_operand_collector.init( m_config->gpgpu_num_reg_banks, this );
+    
+    m_num_function_units = m_config->gpgpu_num_sp_units + m_config->gpgpu_num_dp_units + m_config->gpgpu_num_sfu_units + m_config->gpgpu_num_tensor_core_units + m_config->gpgpu_num_int_units + 1; // sp_unit, sfu, dp, tensor, int, ldst_unit
+    //m_dispatch_port = new enum pipeline_stage_name_t[ m_num_function_units ];
+    //m_issue_port = new enum pipeline_stage_name_t[ m_num_function_units ];
+    
+    //m_fu = new simd_function_unit*[m_num_function_units];
+    
+    for (int k = 0; k < m_config->gpgpu_num_sp_units; k++) {
+        m_fu.push_back(new sp_unit( &m_pipeline_reg[EX_WB], m_config, this ));
+        m_dispatch_port.push_back(ID_OC_SP);
+        m_issue_port.push_back(OC_EX_SP);
+    }
+    
+    for (int k = 0; k < m_config->gpgpu_num_dp_units; k++) {
+            m_fu.push_back(new dp_unit( &m_pipeline_reg[EX_WB], m_config, this ));
+            m_dispatch_port.push_back(ID_OC_DP);
+            m_issue_port.push_back(OC_EX_DP);
+        }
+    for (int k = 0; k < m_config->gpgpu_num_int_units; k++) {
+            m_fu.push_back(new int_unit( &m_pipeline_reg[EX_WB], m_config, this ));
+            m_dispatch_port.push_back(ID_OC_INT);
+            m_issue_port.push_back(OC_EX_INT);
+        }
+
+    for (int k = 0; k < m_config->gpgpu_num_sfu_units; k++) {
+        m_fu.push_back(new sfu( &m_pipeline_reg[EX_WB], m_config, this ));
+        m_dispatch_port.push_back(ID_OC_SFU);
+        m_issue_port.push_back(OC_EX_SFU);
+    }
+       
+    for (int k = 0; k < config->gpgpu_num_tensor_core_units; k++) {
+        m_fu.push_back(new tensor_core( &m_pipeline_reg[EX_WB], m_config, this ));
+        m_dispatch_port.push_back(ID_OC_TENSOR_CORE);
+        m_issue_port.push_back(OC_EX_TENSOR_CORE);
+    }
+
+    m_ldst_unit = new ldst_unit( m_icnt, m_mem_fetch_allocator, this, &m_operand_collector, m_scoreboard, config, mem_config, stats, shader_id, tpc_id );
+    m_fu.push_back(m_ldst_unit);
+    m_dispatch_port.push_back(ID_OC_MEM);
+    m_issue_port.push_back(OC_EX_MEM);
+   
+    assert(m_num_function_units == m_fu.size() and m_fu.size() == m_dispatch_port.size() and m_fu.size() == m_issue_port.size());
+    
+    //there are as many result buses as the width of the EX_WB stage
+    num_result_bus = config->pipe_widths[EX_WB];
+    for(unsigned i=0; i<num_result_bus; i++){
+        this->m_result_bus.push_back(new std::bitset<MAX_ALU_LATENCY>());
+    }
+    
+    m_last_inst_gpu_sim_cycle = 0;
+    m_last_inst_gpu_tot_sim_cycle = 0;
+
+    //Jin: for concurrent kernels on a SM
     m_occupied_n_threads = 0;
     m_occupied_shmem = 0;
     m_occupied_regs = 0;
     m_occupied_ctas = 0;
     m_occupied_hwtid.reset();
     m_occupied_cta_to_hwtid.clear();
-    m_active_warps = 0;
-  }
-  for (unsigned i = start_thread; i < end_thread; i++) {
-    m_threadState[i].n_insn = 0;
-    m_threadState[i].m_cta_id = -1;
-  }
-  for (unsigned i = start_thread / m_config->warp_size;
-       i < end_thread / m_config->warp_size; ++i) {
-    m_warp[i].reset();
-    m_simt_stack[i]->reset();
-  }
 }
 
-void shader_core_ctx::init_warps(unsigned cta_id, unsigned start_thread,
-                                 unsigned end_thread, unsigned ctaid,
-                                 int cta_size, unsigned kernel_id) {
-  address_type start_pc = next_pc(start_thread);
-  if (m_config->model == POST_DOMINATOR) {
-    unsigned start_warp = start_thread / m_config->warp_size;
-    unsigned warp_per_cta = cta_size / m_config->warp_size;
-    unsigned end_warp = end_thread / m_config->warp_size +
-                        ((end_thread % m_config->warp_size) ? 1 : 0);
-    for (unsigned i = start_warp; i < end_warp; ++i) {
-      unsigned n_active = 0;
-      simt_mask_t active_threads;
-      for (unsigned t = 0; t < m_config->warp_size; t++) {
-        unsigned hwtid = i * m_config->warp_size + t;
-        if (hwtid < end_thread) {
-          n_active++;
-          assert(!m_active_threads.test(hwtid));
-          m_active_threads.set(hwtid);
-          active_threads.set(t);
-        }
-      }
-      m_simt_stack[i]->launch(start_pc, active_threads);
+void shader_core_ctx::reinit(unsigned start_thread, unsigned end_thread, bool reset_not_completed ) 
+{
+   if( reset_not_completed ) {
+       m_not_completed = 0;
+       m_active_threads.reset();
 
-      if (m_gpu->resume_option == 1 && kernel_id == m_gpu->resume_kernel &&
-          ctaid >= m_gpu->resume_CTA && ctaid < m_gpu->checkpoint_CTA_t) {
-        char fname[2048];
-        snprintf(fname, 2048, "checkpoint_files/warp_%d_%d_simt.txt",
-                 i % warp_per_cta, ctaid);
-        unsigned pc, rpc;
-        m_simt_stack[i]->resume(fname);
-        m_simt_stack[i]->get_pdom_stack_top_info(&pc, &rpc);
-        for (unsigned t = 0; t < m_config->warp_size; t++) {
-          m_thread[i * m_config->warp_size + t]->set_npc(pc);
-          m_thread[i * m_config->warp_size + t]->update_pc();
-        }
-        start_pc = pc;
-      }
+       //Jin: for concurrent kernels on a SM
+       m_occupied_n_threads = 0;
+       m_occupied_shmem = 0;
+       m_occupied_regs = 0;
+       m_occupied_ctas = 0;
+       m_occupied_hwtid.reset();
+       m_occupied_cta_to_hwtid.clear();
+       m_active_warps = 0;
 
-      m_warp[i].init(start_pc, cta_id, i, active_threads, m_dynamic_warp_id);
-      ++m_dynamic_warp_id;
-      m_not_completed += n_active;
-      ++m_active_warps;
-    }
-  }
+   }
+   for (unsigned i = start_thread; i<end_thread; i++) {
+      m_threadState[i].n_insn = 0;
+      m_threadState[i].m_cta_id = -1;
+   }
+   for (unsigned i = start_thread / m_config->warp_size; i < end_thread / m_config->warp_size; ++i) {
+      m_warp[i].reset();
+      m_simt_stack[i]->reset();
+   }
 }
 
-// return the next pc of a thread
-address_type shader_core_ctx::next_pc(int tid) const {
-  if (tid == -1) return -1;
-  ptx_thread_info *the_thread = m_thread[tid];
-  if (the_thread == NULL) return -1;
-  return the_thread->get_pc();  // PC should already be updatd to next PC at
-                                // this point (was set in shader_decode() last
-                                // time thread ran)
-}
-
-void gpgpu_sim::get_pdom_stack_top_info(unsigned sid, unsigned tid,
-                                        unsigned *pc, unsigned *rpc) {
-  unsigned cluster_id = m_shader_config->sid_to_cluster(sid);
-  m_cluster[cluster_id]->get_pdom_stack_top_info(sid, tid, pc, rpc);
-}
-
-void shader_core_ctx::get_pdom_stack_top_info(unsigned tid, unsigned *pc,
-                                              unsigned *rpc) const {
-  unsigned warp_id = tid / m_config->warp_size;
-  m_simt_stack[warp_id]->get_pdom_stack_top_info(pc, rpc);
-}
-
-float shader_core_ctx::get_current_occupancy(unsigned long long &active,
-                                             unsigned long long &total) const {
-  // To match the achieved_occupancy in nvprof, only SMs that are active are
-  // counted toward the occupancy.
-  if (m_active_warps > 0) {
-    total += m_warp.size();
-    active += m_active_warps;
-    return float(active) / float(total);
-  } else {
-    return 0;
-  }
-}
-
-void shader_core_stats::print(FILE *fout) const {
-  unsigned long long thread_icount_uarch = 0;
-  unsigned long long warp_icount_uarch = 0;
-
-  for (unsigned i = 0; i < m_config->num_shader(); i++) {
-    thread_icount_uarch += m_num_sim_insn[i];
-    warp_icount_uarch += m_num_sim_winsn[i];
-  }
-  fprintf(fout, "gpgpu_n_tot_thrd_icount = %lld\n", thread_icount_uarch);
-  fprintf(fout, "gpgpu_n_tot_w_icount = %lld\n", warp_icount_uarch);
-
-  fprintf(fout, "gpgpu_n_stall_shd_mem = %d\n", gpgpu_n_stall_shd_mem);
-  fprintf(fout, "gpgpu_n_mem_read_local = %d\n", gpgpu_n_mem_read_local);
-  fprintf(fout, "gpgpu_n_mem_write_local = %d\n", gpgpu_n_mem_write_local);
-  fprintf(fout, "gpgpu_n_mem_read_global = %d\n", gpgpu_n_mem_read_global);
-  fprintf(fout, "gpgpu_n_mem_write_global = %d\n", gpgpu_n_mem_write_global);
-  fprintf(fout, "gpgpu_n_mem_texture = %d\n", gpgpu_n_mem_texture);
-  fprintf(fout, "gpgpu_n_mem_const = %d\n", gpgpu_n_mem_const);
-
-  fprintf(fout, "gpgpu_n_load_insn  = %d\n", gpgpu_n_load_insn);
-  fprintf(fout, "gpgpu_n_store_insn = %d\n", gpgpu_n_store_insn);
-  fprintf(fout, "gpgpu_n_shmem_insn = %d\n", gpgpu_n_shmem_insn);
-  fprintf(fout, "gpgpu_n_sstarr_insn = %d\n", gpgpu_n_sstarr_insn);
-  fprintf(fout, "gpgpu_n_tex_insn = %d\n", gpgpu_n_tex_insn);
-  fprintf(fout, "gpgpu_n_const_mem_insn = %d\n", gpgpu_n_const_insn);
-  fprintf(fout, "gpgpu_n_param_mem_insn = %d\n", gpgpu_n_param_insn);
-
-  fprintf(fout, "gpgpu_n_shmem_bkconflict = %d\n", gpgpu_n_shmem_bkconflict);
-  fprintf(fout, "gpgpu_n_cache_bkconflict = %d\n", gpgpu_n_cache_bkconflict);
-
-  fprintf(fout, "gpgpu_n_intrawarp_mshr_merge = %d\n",
-          gpgpu_n_intrawarp_mshr_merge);
-  fprintf(fout, "gpgpu_n_cmem_portconflict = %d\n", gpgpu_n_cmem_portconflict);
-
-  fprintf(fout, "gpgpu_stall_shd_mem[c_mem][resource_stall] = %d\n",
-          gpu_stall_shd_mem_breakdown[C_MEM][BK_CONF]);
-  // fprintf(fout, "gpgpu_stall_shd_mem[c_mem][mshr_rc] = %d\n",
-  // gpu_stall_shd_mem_breakdown[C_MEM][MSHR_RC_FAIL]);
-  // fprintf(fout, "gpgpu_stall_shd_mem[c_mem][icnt_rc] = %d\n",
-  // gpu_stall_shd_mem_breakdown[C_MEM][ICNT_RC_FAIL]);
-  // fprintf(fout, "gpgpu_stall_shd_mem[c_mem][data_port_stall] = %d\n",
-  // gpu_stall_shd_mem_breakdown[C_MEM][DATA_PORT_STALL]);
-  // fprintf(fout, "gpgpu_stall_shd_mem[t_mem][mshr_rc] = %d\n",
-  // gpu_stall_shd_mem_breakdown[T_MEM][MSHR_RC_FAIL]);
-  // fprintf(fout, "gpgpu_stall_shd_mem[t_mem][icnt_rc] = %d\n",
-  // gpu_stall_shd_mem_breakdown[T_MEM][ICNT_RC_FAIL]);
-  // fprintf(fout, "gpgpu_stall_shd_mem[t_mem][data_port_stall] = %d\n",
-  // gpu_stall_shd_mem_breakdown[T_MEM][DATA_PORT_STALL]);
-  fprintf(fout, "gpgpu_stall_shd_mem[s_mem][bk_conf] = %d\n",
-          gpu_stall_shd_mem_breakdown[S_MEM][BK_CONF]);
-  fprintf(fout, "gpgpu_stall_shd_mem[gl_mem][resource_stall] = %d\n",
-          gpu_stall_shd_mem_breakdown[G_MEM_LD][BK_CONF] +
-              gpu_stall_shd_mem_breakdown[G_MEM_ST][BK_CONF] +
-              gpu_stall_shd_mem_breakdown[L_MEM_LD][BK_CONF] +
-              gpu_stall_shd_mem_breakdown[L_MEM_ST][BK_CONF]);  // coalescing
-                                                                // stall at data
-                                                                // cache
-  fprintf(fout, "gpgpu_stall_shd_mem[gl_mem][coal_stall] = %d\n",
-          gpu_stall_shd_mem_breakdown[G_MEM_LD][COAL_STALL] +
-              gpu_stall_shd_mem_breakdown[G_MEM_ST][COAL_STALL] +
-              gpu_stall_shd_mem_breakdown[L_MEM_LD][COAL_STALL] +
-              gpu_stall_shd_mem_breakdown[L_MEM_ST][COAL_STALL]);  // coalescing
-                                                                   // stall +
-                                                                   // bank
-                                                                   // conflict
-                                                                   // at data
-                                                                   // cache
-  fprintf(fout, "gpgpu_stall_shd_mem[gl_mem][data_port_stall] = %d\n",
-          gpu_stall_shd_mem_breakdown[G_MEM_LD][DATA_PORT_STALL] +
-              gpu_stall_shd_mem_breakdown[G_MEM_ST][DATA_PORT_STALL] +
-              gpu_stall_shd_mem_breakdown[L_MEM_LD][DATA_PORT_STALL] +
-              gpu_stall_shd_mem_breakdown[L_MEM_ST]
-                                         [DATA_PORT_STALL]);  // data port stall
-                                                              // at data cache
-  // fprintf(fout, "gpgpu_stall_shd_mem[g_mem_ld][mshr_rc] = %d\n",
-  // gpu_stall_shd_mem_breakdown[G_MEM_LD][MSHR_RC_FAIL]);
-  // fprintf(fout, "gpgpu_stall_shd_mem[g_mem_ld][icnt_rc] = %d\n",
-  // gpu_stall_shd_mem_breakdown[G_MEM_LD][ICNT_RC_FAIL]);
-  // fprintf(fout, "gpgpu_stall_shd_mem[g_mem_ld][wb_icnt_rc] = %d\n",
-  // gpu_stall_shd_mem_breakdown[G_MEM_LD][WB_ICNT_RC_FAIL]);
-  // fprintf(fout, "gpgpu_stall_shd_mem[g_mem_ld][wb_rsrv_fail] = %d\n",
-  // gpu_stall_shd_mem_breakdown[G_MEM_LD][WB_CACHE_RSRV_FAIL]);
-  // fprintf(fout, "gpgpu_stall_shd_mem[g_mem_st][mshr_rc] = %d\n",
-  // gpu_stall_shd_mem_breakdown[G_MEM_ST][MSHR_RC_FAIL]);
-  // fprintf(fout, "gpgpu_stall_shd_mem[g_mem_st][icnt_rc] = %d\n",
-  // gpu_stall_shd_mem_breakdown[G_MEM_ST][ICNT_RC_FAIL]);
-  // fprintf(fout, "gpgpu_stall_shd_mem[g_mem_st][wb_icnt_rc] = %d\n",
-  // gpu_stall_shd_mem_breakdown[G_MEM_ST][WB_ICNT_RC_FAIL]);
-  // fprintf(fout, "gpgpu_stall_shd_mem[g_mem_st][wb_rsrv_fail] = %d\n",
-  // gpu_stall_shd_mem_breakdown[G_MEM_ST][WB_CACHE_RSRV_FAIL]);
-  // fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][mshr_rc] = %d\n",
-  // gpu_stall_shd_mem_breakdown[L_MEM_LD][MSHR_RC_FAIL]);
-  // fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][icnt_rc] = %d\n",
-  // gpu_stall_shd_mem_breakdown[L_MEM_LD][ICNT_RC_FAIL]);
-  // fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][wb_icnt_rc] = %d\n",
-  // gpu_stall_shd_mem_breakdown[L_MEM_LD][WB_ICNT_RC_FAIL]);
-  // fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][wb_rsrv_fail] = %d\n",
-  // gpu_stall_shd_mem_breakdown[L_MEM_LD][WB_CACHE_RSRV_FAIL]);
-  // fprintf(fout, "gpgpu_stall_shd_mem[l_mem_st][mshr_rc] = %d\n",
-  // gpu_stall_shd_mem_breakdown[L_MEM_ST][MSHR_RC_FAIL]);
-  // fprintf(fout, "gpgpu_stall_shd_mem[l_mem_st][icnt_rc] = %d\n",
-  // gpu_stall_shd_mem_breakdown[L_MEM_ST][ICNT_RC_FAIL]);
-  // fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][wb_icnt_rc] = %d\n",
-  // gpu_stall_shd_mem_breakdown[L_MEM_ST][WB_ICNT_RC_FAIL]);
-  // fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][wb_rsrv_fail] = %d\n",
-  // gpu_stall_shd_mem_breakdown[L_MEM_ST][WB_CACHE_RSRV_FAIL]);
-
-  fprintf(fout, "gpu_reg_bank_conflict_stalls = %d\n",
-          gpu_reg_bank_conflict_stalls);
-
-  fprintf(fout, "Warp Occupancy Distribution:\n");
-  fprintf(fout, "Stall:%d\t", shader_cycle_distro[2]);
-  fprintf(fout, "W0_Idle:%d\t", shader_cycle_distro[0]);
-  fprintf(fout, "W0_Scoreboard:%d", shader_cycle_distro[1]);
-  for (unsigned i = 3; i < m_config->warp_size + 3; i++)
-    fprintf(fout, "\tW%d:%d", i - 2, shader_cycle_distro[i]);
-  fprintf(fout, "\n");
-  fprintf(fout, "single_issue_nums: ");
-  for (unsigned i = 0; i < m_config->gpgpu_num_sched_per_core; i++)
-    fprintf(fout, "WS%d:%d\t", i, single_issue_nums[i]);
-  fprintf(fout, "\n");
-  fprintf(fout, "dual_issue_nums: ");
-  for (unsigned i = 0; i < m_config->gpgpu_num_sched_per_core; i++)
-    fprintf(fout, "WS%d:%d\t", i, dual_issue_nums[i]);
-  fprintf(fout, "\n");
-
-  m_outgoing_traffic_stats->print(fout);
-  m_incoming_traffic_stats->print(fout);
-}
-
-void shader_core_stats::event_warp_issued(unsigned s_id, unsigned warp_id,
-                                          unsigned num_issued,
-                                          unsigned dynamic_warp_id) {
-  assert(warp_id <= m_config->max_warps_per_shader);
-  for (unsigned i = 0; i < num_issued; ++i) {
-    if (m_shader_dynamic_warp_issue_distro[s_id].size() <= dynamic_warp_id) {
-      m_shader_dynamic_warp_issue_distro[s_id].resize(dynamic_warp_id + 1);
-    }
-    ++m_shader_dynamic_warp_issue_distro[s_id][dynamic_warp_id];
-    if (m_shader_warp_slot_issue_distro[s_id].size() <= warp_id) {
-      m_shader_warp_slot_issue_distro[s_id].resize(warp_id + 1);
-    }
-    ++m_shader_warp_slot_issue_distro[s_id][warp_id];
-  }
-}
-
-void shader_core_stats::visualizer_print(gzFile visualizer_file) {
-  // warp divergence breakdown
-  gzprintf(visualizer_file, "WarpDivergenceBreakdown:");
-  unsigned int total = 0;
-  unsigned int cf =
-      (m_config->gpgpu_warpdistro_shader == -1) ? m_config->num_shader() : 1;
-  gzprintf(visualizer_file, " %d",
-           (shader_cycle_distro[0] - last_shader_cycle_distro[0]) / cf);
-  gzprintf(visualizer_file, " %d",
-           (shader_cycle_distro[1] - last_shader_cycle_distro[1]) / cf);
-  gzprintf(visualizer_file, " %d",
-           (shader_cycle_distro[2] - last_shader_cycle_distro[2]) / cf);
-  for (unsigned i = 0; i < m_config->warp_size + 3; i++) {
-    if (i >= 3) {
-      total += (shader_cycle_distro[i] - last_shader_cycle_distro[i]);
-      if (((i - 3) % (m_config->warp_size / 8)) ==
-          ((m_config->warp_size / 8) - 1)) {
-        gzprintf(visualizer_file, " %d", total / cf);
-        total = 0;
-      }
-    }
-    last_shader_cycle_distro[i] = shader_cycle_distro[i];
-  }
-  gzprintf(visualizer_file, "\n");
-
-  // warp issue breakdown
-  unsigned sid = m_config->gpgpu_warp_issue_shader;
-  unsigned count = 0;
-  unsigned warp_id_issued_sum = 0;
-  gzprintf(visualizer_file, "WarpIssueSlotBreakdown:");
-  if (m_shader_warp_slot_issue_distro[sid].size() > 0) {
-    for (std::vector<unsigned>::const_iterator
-             iter = m_shader_warp_slot_issue_distro[sid].begin();
-         iter != m_shader_warp_slot_issue_distro[sid].end(); iter++, count++) {
-      unsigned diff = count < m_last_shader_warp_slot_issue_distro.size()
-                          ? *iter - m_last_shader_warp_slot_issue_distro[count]
-                          : *iter;
-      gzprintf(visualizer_file, " %d", diff);
-      warp_id_issued_sum += diff;
-    }
-    m_last_shader_warp_slot_issue_distro = m_shader_warp_slot_issue_distro[sid];
-  } else {
-    gzprintf(visualizer_file, " 0");
-  }
-  gzprintf(visualizer_file, "\n");
-
-#define DYNAMIC_WARP_PRINT_RESOLUTION 32
-  unsigned total_issued_this_resolution = 0;
-  unsigned dynamic_id_issued_sum = 0;
-  count = 0;
-  gzprintf(visualizer_file, "WarpIssueDynamicIdBreakdown:");
-  if (m_shader_dynamic_warp_issue_distro[sid].size() > 0) {
-    for (std::vector<unsigned>::const_iterator
-             iter = m_shader_dynamic_warp_issue_distro[sid].begin();
-         iter != m_shader_dynamic_warp_issue_distro[sid].end();
-         iter++, count++) {
-      unsigned diff =
-          count < m_last_shader_dynamic_warp_issue_distro.size()
-              ? *iter - m_last_shader_dynamic_warp_issue_distro[count]
-              : *iter;
-      total_issued_this_resolution += diff;
-      if ((count + 1) % DYNAMIC_WARP_PRINT_RESOLUTION == 0) {
-        gzprintf(visualizer_file, " %d", total_issued_this_resolution);
-        dynamic_id_issued_sum += total_issued_this_resolution;
-        total_issued_this_resolution = 0;
-      }
-    }
-    if (count % DYNAMIC_WARP_PRINT_RESOLUTION != 0) {
-      gzprintf(visualizer_file, " %d", total_issued_this_resolution);
-      dynamic_id_issued_sum += total_issued_this_resolution;
-    }
-    m_last_shader_dynamic_warp_issue_distro =
-        m_shader_dynamic_warp_issue_distro[sid];
-    assert(warp_id_issued_sum == dynamic_id_issued_sum);
-  } else {
-    gzprintf(visualizer_file, " 0");
-  }
-  gzprintf(visualizer_file, "\n");
-
-  // overall cache miss rates
-  gzprintf(visualizer_file, "gpgpu_n_cache_bkconflict: %d\n",
-           gpgpu_n_cache_bkconflict);
-  gzprintf(visualizer_file, "gpgpu_n_shmem_bkconflict: %d\n",
-           gpgpu_n_shmem_bkconflict);
-
-  // instruction count per shader core
-  gzprintf(visualizer_file, "shaderinsncount:  ");
-  for (unsigned i = 0; i < m_config->num_shader(); i++)
-    gzprintf(visualizer_file, "%u ", m_num_sim_insn[i]);
-  gzprintf(visualizer_file, "\n");
-  // warp instruction count per shader core
-  gzprintf(visualizer_file, "shaderwarpinsncount:  ");
-  for (unsigned i = 0; i < m_config->num_shader(); i++)
-    gzprintf(visualizer_file, "%u ", m_num_sim_winsn[i]);
-  gzprintf(visualizer_file, "\n");
-  // warp divergence per shader core
-  gzprintf(visualizer_file, "shaderwarpdiv: ");
-  for (unsigned i = 0; i < m_config->num_shader(); i++)
-    gzprintf(visualizer_file, "%u ", m_n_diverge[i]);
-  gzprintf(visualizer_file, "\n");
-}
-
-#define PROGRAM_MEM_START                                      \
-  0xF0000000 /* should be distinct from other memory spaces... \
-                check ptx_ir.h to verify this does not overlap \
-                other memory spaces */
-void shader_core_ctx::decode() {
-  if (m_inst_fetch_buffer.m_valid) {
-    // decode 1 or 2 instructions and place them into ibuffer
-    address_type pc = m_inst_fetch_buffer.m_pc;
-    const warp_inst_t *pI1 = m_gpu->gpgpu_ctx->ptx_fetch_inst(pc);
-    m_warp[m_inst_fetch_buffer.m_warp_id].ibuffer_fill(0, pI1);
-    m_warp[m_inst_fetch_buffer.m_warp_id].inc_inst_in_pipeline();
-    if (pI1) {
-      m_stats->m_num_decoded_insn[m_sid]++;
-      if (pI1->oprnd_type == INT_OP) {
-        m_stats->m_num_INTdecoded_insn[m_sid]++;
-      } else if (pI1->oprnd_type == FP_OP) {
-        m_stats->m_num_FPdecoded_insn[m_sid]++;
-      }
-      const warp_inst_t *pI2 =
-          m_gpu->gpgpu_ctx->ptx_fetch_inst(pc + pI1->isize);
-      if (pI2) {
-        m_warp[m_inst_fetch_buffer.m_warp_id].ibuffer_fill(1, pI2);
-        m_warp[m_inst_fetch_buffer.m_warp_id].inc_inst_in_pipeline();
-        m_stats->m_num_decoded_insn[m_sid]++;
-        if (pI2->oprnd_type == INT_OP) {
-          m_stats->m_num_INTdecoded_insn[m_sid]++;
-        } else if (pI2->oprnd_type == FP_OP) {
-          m_stats->m_num_FPdecoded_insn[m_sid]++;
-        }
-      }
-    }
-    m_inst_fetch_buffer.m_valid = false;
-  }
-}
-
-void shader_core_ctx::fetch() {
-  if (!m_inst_fetch_buffer.m_valid) {
-    if (m_L1I->access_ready()) {
-      mem_fetch *mf = m_L1I->next_access();
-      m_warp[mf->get_wid()].clear_imiss_pending();
-      m_inst_fetch_buffer = ifetch_buffer_t(
-          m_warp[mf->get_wid()].get_pc(), mf->get_access_size(), mf->get_wid());
-      assert(m_warp[mf->get_wid()].get_pc() ==
-             (mf->get_addr() - PROGRAM_MEM_START));  // Verify that we got the
-                                                     // instruction we were
-                                                     // expecting.
-      m_inst_fetch_buffer.m_valid = true;
-      m_warp[mf->get_wid()].set_last_fetch(m_gpu->gpu_sim_cycle);
-      delete mf;
-    } else {
-      // find an active warp with space in instruction buffer that is not
-      // already waiting on a cache miss
-      // and get next 1-2 instructions from i-cache...
-      for (unsigned i = 0; i < m_config->max_warps_per_shader; i++) {
-        unsigned warp_id =
-            (m_last_warp_fetched + 1 + i) % m_config->max_warps_per_shader;
-
-        // this code checks if this warp has finished executing and can be
-        // reclaimed
-        if (m_warp[warp_id].hardware_done() &&
-            !m_scoreboard->pendingWrites(warp_id) &&
-            !m_warp[warp_id].done_exit()) {
-          bool did_exit = false;
-          for (unsigned t = 0; t < m_config->warp_size; t++) {
-            unsigned tid = warp_id * m_config->warp_size + t;
-            if (m_threadState[tid].m_active == true) {
-              m_threadState[tid].m_active = false;
-              unsigned cta_id = m_warp[warp_id].get_cta_id();
-              register_cta_thread_exit(cta_id, &(m_thread[tid]->get_kernel()));
-              m_not_completed -= 1;
-              m_active_threads.reset(tid);
-              assert(m_thread[tid] != NULL);
-              did_exit = true;
+void shader_core_ctx::init_warps( unsigned cta_id, unsigned start_thread, unsigned end_thread, unsigned ctaid, int cta_size, unsigned kernel_id )
+{
+    address_type start_pc = next_pc(start_thread);
+    if (m_config->model == POST_DOMINATOR) {
+        unsigned start_warp = start_thread / m_config->warp_size;
+        unsigned warp_per_cta =  cta_size / m_config->warp_size;
+        unsigned end_warp = end_thread / m_config->warp_size + ((end_thread % m_config->warp_size)? 1 : 0);
+        for (unsigned i = start_warp; i < end_warp; ++i) {
+            unsigned n_active=0;
+            simt_mask_t active_threads;
+            for (unsigned t = 0; t < m_config->warp_size; t++) {
+                unsigned hwtid = i * m_config->warp_size + t;
+                if ( hwtid < end_thread ) {
+                    n_active++;
+                    assert( !m_active_threads.test(hwtid) );
+                    m_active_threads.set( hwtid );
+                    active_threads.set(t);
+                }
             }
-          }
-          if (did_exit) m_warp[warp_id].set_done_exit();
-          --m_active_warps;
-          assert(m_active_warps >= 0);
-        }
+            m_simt_stack[i]->launch(start_pc,active_threads);
 
-        // this code fetches instructions from the i-cache or generates memory
-        // requests
-        if (!m_warp[warp_id].functional_done() &&
-            !m_warp[warp_id].imiss_pending() &&
-            m_warp[warp_id].ibuffer_empty()) {
-          address_type pc = m_warp[warp_id].get_pc();
-          address_type ppc = pc + PROGRAM_MEM_START;
-          unsigned nbytes = 16;
-          unsigned offset_in_block =
-              pc & (m_config->m_L1I_config.get_line_sz() - 1);
-          if ((offset_in_block + nbytes) > m_config->m_L1I_config.get_line_sz())
-            nbytes = (m_config->m_L1I_config.get_line_sz() - offset_in_block);
-
-          // TODO: replace with use of allocator
-          // mem_fetch *mf = m_mem_fetch_allocator->alloc()
-          mem_access_t acc(INST_ACC_R, ppc, nbytes, false, m_gpu->gpgpu_ctx);
-          mem_fetch *mf = new mem_fetch(
-              acc, NULL /*we don't have an instruction yet*/, READ_PACKET_SIZE,
-              warp_id, m_sid, m_tpc, m_memory_config,
-              m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle);
-          std::list<cache_event> events;
-          enum cache_request_status status = m_L1I->access(
-              (new_addr_type)ppc, mf,
-              m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle, events);
-          if (status == MISS) {
-            m_last_warp_fetched = warp_id;
-            m_warp[warp_id].set_imiss_pending();
-            m_warp[warp_id].set_last_fetch(m_gpu->gpu_sim_cycle);
-          } else if (status == HIT) {
-            m_last_warp_fetched = warp_id;
-            m_inst_fetch_buffer = ifetch_buffer_t(pc, nbytes, warp_id);
-            m_warp[warp_id].set_last_fetch(m_gpu->gpu_sim_cycle);
-            delete mf;
-          } else {
-            m_last_warp_fetched = warp_id;
-            assert(status == RESERVATION_FAIL);
-            delete mf;
-          }
-          break;
-        }
+              if(m_gpu->resume_option == 1 && kernel_id == m_gpu->resume_kernel && ctaid >= m_gpu->resume_CTA && ctaid < m_gpu->checkpoint_CTA_t )
+               { 
+                char fname[2048];
+                snprintf(fname,2048,"checkpoint_files/warp_%d_%d_simt.txt",i%warp_per_cta,ctaid );
+                unsigned pc,rpc;
+                m_simt_stack[i]->resume(fname);
+                m_simt_stack[i]->get_pdom_stack_top_info(&pc,&rpc);
+                for (unsigned t = 0; t < m_config->warp_size; t++) {
+                  m_thread[i * m_config->warp_size + t]->set_npc(pc);
+                  m_thread[i * m_config->warp_size + t]->update_pc();
+                }   
+                start_pc=pc;
+              }
+               
+            m_warp[i].init(start_pc,cta_id,i,active_threads, m_dynamic_warp_id);
+            ++m_dynamic_warp_id;
+            m_not_completed += n_active;
+            ++m_active_warps;
       }
+   }
+}
+
+// return the next pc of a thread 
+address_type shader_core_ctx::next_pc( int tid ) const
+{
+    if( tid == -1 ) 
+        return -1;
+    ptx_thread_info *the_thread = m_thread[tid];
+    if ( the_thread == NULL )
+        return -1;
+    return the_thread->get_pc(); // PC should already be updatd to next PC at this point (was set in shader_decode() last time thread ran)
+}
+
+void gpgpu_sim::get_pdom_stack_top_info( unsigned sid, unsigned tid, unsigned *pc, unsigned *rpc )
+{
+    unsigned cluster_id = m_shader_config->sid_to_cluster(sid);
+    m_cluster[cluster_id]->get_pdom_stack_top_info(sid,tid,pc,rpc);
+}
+
+void shader_core_ctx::get_pdom_stack_top_info( unsigned tid, unsigned *pc, unsigned *rpc ) const
+{
+    unsigned warp_id = tid/m_config->warp_size;
+    m_simt_stack[warp_id]->get_pdom_stack_top_info(pc,rpc);
+}
+
+float shader_core_ctx::get_current_occupancy( unsigned long long & active, unsigned long long & total ) const
+{
+    // To match the achieved_occupancy in nvprof, only SMs that are active are counted toward the occupancy.
+    if ( m_active_warps > 0 ) {
+        total += m_warp.size();
+        active += m_active_warps;
+        return float(active) / float(total);
+    } else {
+        return 0;
     }
-  }
-
-  m_L1I->cycle();
 }
 
-void shader_core_ctx::func_exec_inst(warp_inst_t &inst) {
-  execute_warp_inst_t(inst);
-  if (inst.is_load() || inst.is_store()) {
-    inst.generate_mem_accesses();
-    // inst.print_m_accessq();
-  }
+void shader_core_stats::print( FILE* fout ) const
+{
+	unsigned long long  thread_icount_uarch=0;
+	unsigned long long  warp_icount_uarch=0;
+
+    for(unsigned i=0; i < m_config->num_shader(); i++) {
+        thread_icount_uarch += m_num_sim_insn[i];
+        warp_icount_uarch += m_num_sim_winsn[i];
+    }
+    fprintf(fout,"gpgpu_n_tot_thrd_icount = %lld\n", thread_icount_uarch);
+    fprintf(fout,"gpgpu_n_tot_w_icount = %lld\n", warp_icount_uarch);
+
+    fprintf(fout,"gpgpu_n_stall_shd_mem = %d\n", gpgpu_n_stall_shd_mem );
+    fprintf(fout,"gpgpu_n_mem_read_local = %d\n", gpgpu_n_mem_read_local);
+    fprintf(fout,"gpgpu_n_mem_write_local = %d\n", gpgpu_n_mem_write_local);
+    fprintf(fout,"gpgpu_n_mem_read_global = %d\n", gpgpu_n_mem_read_global);
+    fprintf(fout,"gpgpu_n_mem_write_global = %d\n", gpgpu_n_mem_write_global);
+    fprintf(fout,"gpgpu_n_mem_texture = %d\n", gpgpu_n_mem_texture);
+    fprintf(fout,"gpgpu_n_mem_const = %d\n", gpgpu_n_mem_const);
+
+   fprintf(fout, "gpgpu_n_load_insn  = %d\n", gpgpu_n_load_insn);
+   fprintf(fout, "gpgpu_n_store_insn = %d\n", gpgpu_n_store_insn);
+   fprintf(fout, "gpgpu_n_shmem_insn = %d\n", gpgpu_n_shmem_insn);
+   fprintf(fout, "gpgpu_n_sstarr_insn = %d\n", gpgpu_n_sstarr_insn);
+   fprintf(fout, "gpgpu_n_tex_insn = %d\n", gpgpu_n_tex_insn);
+   fprintf(fout, "gpgpu_n_const_mem_insn = %d\n", gpgpu_n_const_insn);
+   fprintf(fout, "gpgpu_n_param_mem_insn = %d\n", gpgpu_n_param_insn);
+
+   fprintf(fout, "gpgpu_n_shmem_bkconflict = %d\n", gpgpu_n_shmem_bkconflict);
+   fprintf(fout, "gpgpu_n_cache_bkconflict = %d\n", gpgpu_n_cache_bkconflict);   
+
+   fprintf(fout, "gpgpu_n_intrawarp_mshr_merge = %d\n", gpgpu_n_intrawarp_mshr_merge);
+   fprintf(fout, "gpgpu_n_cmem_portconflict = %d\n", gpgpu_n_cmem_portconflict);
+
+   fprintf(fout, "gpgpu_stall_shd_mem[c_mem][resource_stall] = %d\n", gpu_stall_shd_mem_breakdown[C_MEM][BK_CONF]);
+   //fprintf(fout, "gpgpu_stall_shd_mem[c_mem][mshr_rc] = %d\n", gpu_stall_shd_mem_breakdown[C_MEM][MSHR_RC_FAIL]);
+   //fprintf(fout, "gpgpu_stall_shd_mem[c_mem][icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[C_MEM][ICNT_RC_FAIL]);
+   //fprintf(fout, "gpgpu_stall_shd_mem[c_mem][data_port_stall] = %d\n", gpu_stall_shd_mem_breakdown[C_MEM][DATA_PORT_STALL]);
+   //fprintf(fout, "gpgpu_stall_shd_mem[t_mem][mshr_rc] = %d\n", gpu_stall_shd_mem_breakdown[T_MEM][MSHR_RC_FAIL]);
+   //fprintf(fout, "gpgpu_stall_shd_mem[t_mem][icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[T_MEM][ICNT_RC_FAIL]);
+   //fprintf(fout, "gpgpu_stall_shd_mem[t_mem][data_port_stall] = %d\n", gpu_stall_shd_mem_breakdown[T_MEM][DATA_PORT_STALL]);
+   fprintf(fout, "gpgpu_stall_shd_mem[s_mem][bk_conf] = %d\n", gpu_stall_shd_mem_breakdown[S_MEM][BK_CONF]);
+   fprintf(fout, "gpgpu_stall_shd_mem[gl_mem][resource_stall] = %d\n",
+           gpu_stall_shd_mem_breakdown[G_MEM_LD][BK_CONF] + 
+           gpu_stall_shd_mem_breakdown[G_MEM_ST][BK_CONF] + 
+           gpu_stall_shd_mem_breakdown[L_MEM_LD][BK_CONF] + 
+           gpu_stall_shd_mem_breakdown[L_MEM_ST][BK_CONF]   
+           ); // coalescing stall at data cache 
+   fprintf(fout, "gpgpu_stall_shd_mem[gl_mem][coal_stall] = %d\n", 
+           gpu_stall_shd_mem_breakdown[G_MEM_LD][COAL_STALL] + 
+           gpu_stall_shd_mem_breakdown[G_MEM_ST][COAL_STALL] + 
+           gpu_stall_shd_mem_breakdown[L_MEM_LD][COAL_STALL] + 
+           gpu_stall_shd_mem_breakdown[L_MEM_ST][COAL_STALL]    
+           ); // coalescing stall + bank conflict at data cache 
+   fprintf(fout, "gpgpu_stall_shd_mem[gl_mem][data_port_stall] = %d\n", 
+           gpu_stall_shd_mem_breakdown[G_MEM_LD][DATA_PORT_STALL] + 
+           gpu_stall_shd_mem_breakdown[G_MEM_ST][DATA_PORT_STALL] + 
+           gpu_stall_shd_mem_breakdown[L_MEM_LD][DATA_PORT_STALL] + 
+           gpu_stall_shd_mem_breakdown[L_MEM_ST][DATA_PORT_STALL]    
+           ); // data port stall at data cache 
+   //fprintf(fout, "gpgpu_stall_shd_mem[g_mem_ld][mshr_rc] = %d\n", gpu_stall_shd_mem_breakdown[G_MEM_LD][MSHR_RC_FAIL]);
+   //fprintf(fout, "gpgpu_stall_shd_mem[g_mem_ld][icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[G_MEM_LD][ICNT_RC_FAIL]);
+   //fprintf(fout, "gpgpu_stall_shd_mem[g_mem_ld][wb_icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[G_MEM_LD][WB_ICNT_RC_FAIL]);
+   //fprintf(fout, "gpgpu_stall_shd_mem[g_mem_ld][wb_rsrv_fail] = %d\n", gpu_stall_shd_mem_breakdown[G_MEM_LD][WB_CACHE_RSRV_FAIL]);
+   //fprintf(fout, "gpgpu_stall_shd_mem[g_mem_st][mshr_rc] = %d\n", gpu_stall_shd_mem_breakdown[G_MEM_ST][MSHR_RC_FAIL]);
+   //fprintf(fout, "gpgpu_stall_shd_mem[g_mem_st][icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[G_MEM_ST][ICNT_RC_FAIL]);
+   //fprintf(fout, "gpgpu_stall_shd_mem[g_mem_st][wb_icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[G_MEM_ST][WB_ICNT_RC_FAIL]);
+   //fprintf(fout, "gpgpu_stall_shd_mem[g_mem_st][wb_rsrv_fail] = %d\n", gpu_stall_shd_mem_breakdown[G_MEM_ST][WB_CACHE_RSRV_FAIL]);
+   //fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][mshr_rc] = %d\n", gpu_stall_shd_mem_breakdown[L_MEM_LD][MSHR_RC_FAIL]);
+   //fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[L_MEM_LD][ICNT_RC_FAIL]);
+   //fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][wb_icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[L_MEM_LD][WB_ICNT_RC_FAIL]);
+   //fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][wb_rsrv_fail] = %d\n", gpu_stall_shd_mem_breakdown[L_MEM_LD][WB_CACHE_RSRV_FAIL]);
+   //fprintf(fout, "gpgpu_stall_shd_mem[l_mem_st][mshr_rc] = %d\n", gpu_stall_shd_mem_breakdown[L_MEM_ST][MSHR_RC_FAIL]);
+   //fprintf(fout, "gpgpu_stall_shd_mem[l_mem_st][icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[L_MEM_ST][ICNT_RC_FAIL]);
+   //fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][wb_icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[L_MEM_ST][WB_ICNT_RC_FAIL]);
+   //fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][wb_rsrv_fail] = %d\n", gpu_stall_shd_mem_breakdown[L_MEM_ST][WB_CACHE_RSRV_FAIL]);
+
+   fprintf(fout, "gpu_reg_bank_conflict_stalls = %d\n", gpu_reg_bank_conflict_stalls);
+
+   fprintf(fout, "Warp Occupancy Distribution:\n");
+   fprintf(fout, "Stall:%d\t", shader_cycle_distro[2]);
+   fprintf(fout, "W0_Idle:%d\t", shader_cycle_distro[0]);
+   fprintf(fout, "W0_Scoreboard:%d", shader_cycle_distro[1]);
+   for (unsigned i = 3; i < m_config->warp_size + 3; i++) 
+      fprintf(fout, "\tW%d:%d", i-2, shader_cycle_distro[i]);
+   fprintf(fout, "\n");
+   fprintf(fout, "single_issue_nums: ");
+   for (unsigned i = 0; i < m_config->gpgpu_num_sched_per_core; i++)
+        fprintf(fout, "WS%d:%d\t", i, single_issue_nums[i]);
+   fprintf(fout, "\n");
+   fprintf(fout, "dual_issue_nums: ");
+   for (unsigned i = 0; i < m_config->gpgpu_num_sched_per_core; i++)
+          fprintf(fout, "WS%d:%d\t", i, dual_issue_nums[i]);
+   fprintf(fout, "\n");
+
+   m_outgoing_traffic_stats->print(fout); 
+   m_incoming_traffic_stats->print(fout); 
 }
 
-void shader_core_ctx::issue_warp(register_set &pipe_reg_set,
-                                 const warp_inst_t *next_inst,
-                                 const active_mask_t &active_mask,
-                                 unsigned warp_id, unsigned sch_id) {
-  warp_inst_t **pipe_reg =
-      pipe_reg_set.get_free(m_config->sub_core_model, sch_id);
-  assert(pipe_reg);
-
-  m_warp[warp_id].ibuffer_free();
-  assert(next_inst->valid());
-  **pipe_reg = *next_inst;  // static instruction information
-  (*pipe_reg)->issue(active_mask, warp_id,
-                     m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle,
-                     m_warp[warp_id].get_dynamic_warp_id(),
-                     sch_id);  // dynamic instruction information
-  m_stats->shader_cycle_distro[2 + (*pipe_reg)->active_count()]++;
-  func_exec_inst(**pipe_reg);
-  if (next_inst->op == BARRIER_OP) {
-    m_warp[warp_id].store_info_of_last_inst_at_barrier(*pipe_reg);
-    m_barriers.warp_reaches_barrier(m_warp[warp_id].get_cta_id(), warp_id,
-                                    const_cast<warp_inst_t *>(next_inst));
-
-  } else if (next_inst->op == MEMORY_BARRIER_OP) {
-    m_warp[warp_id].set_membar();
-  }
-
-  updateSIMTStack(warp_id, *pipe_reg);
-  m_scoreboard->reserveRegisters(*pipe_reg);
-  m_warp[warp_id].set_next_pc(next_inst->pc + next_inst->isize);
+void shader_core_stats::event_warp_issued( unsigned s_id, unsigned warp_id, unsigned num_issued, unsigned dynamic_warp_id ) {
+    assert( warp_id <= m_config->max_warps_per_shader );
+    for ( unsigned i = 0; i < num_issued; ++i ) {
+        if ( m_shader_dynamic_warp_issue_distro[ s_id ].size() <= dynamic_warp_id ) {
+            m_shader_dynamic_warp_issue_distro[ s_id ].resize(dynamic_warp_id + 1);
+        }
+        ++m_shader_dynamic_warp_issue_distro[ s_id ][ dynamic_warp_id ];
+        if ( m_shader_warp_slot_issue_distro[ s_id ].size() <= warp_id ) {
+            m_shader_warp_slot_issue_distro[ s_id ].resize(warp_id + 1);
+        }
+        ++m_shader_warp_slot_issue_distro[ s_id ][ warp_id ];
+    }
 }
 
-void shader_core_ctx::issue() {
-  // Ensure fair round robin issu between schedulers
-  unsigned j;
-  for (unsigned i = 0; i < schedulers.size(); i++) {
-    j = (Issue_Prio + i) % schedulers.size();
-    schedulers[j]->cycle();
-  }
-  Issue_Prio = (Issue_Prio + 1) % schedulers.size();
+void shader_core_stats::visualizer_print( gzFile visualizer_file )
+{
+    // warp divergence breakdown
+    gzprintf(visualizer_file, "WarpDivergenceBreakdown:");
+    unsigned int total=0;
+    unsigned int cf = (m_config->gpgpu_warpdistro_shader==-1)?m_config->num_shader():1;
+    gzprintf(visualizer_file, " %d", (shader_cycle_distro[0] - last_shader_cycle_distro[0]) / cf );
+    gzprintf(visualizer_file, " %d", (shader_cycle_distro[1] - last_shader_cycle_distro[1]) / cf );
+    gzprintf(visualizer_file, " %d", (shader_cycle_distro[2] - last_shader_cycle_distro[2]) / cf );
+    for (unsigned i=0; i<m_config->warp_size+3; i++) {
+       if ( i>=3 ) {
+          total += (shader_cycle_distro[i] - last_shader_cycle_distro[i]);
+          if ( ((i-3) % (m_config->warp_size/8)) == ((m_config->warp_size/8)-1) ) {
+             gzprintf(visualizer_file, " %d", total / cf );
+             total=0;
+          }
+       }
+       last_shader_cycle_distro[i] = shader_cycle_distro[i];
+    }
+    gzprintf(visualizer_file,"\n");
 
-  // really is issue;
-  // for (unsigned i = 0; i < schedulers.size(); i++) {
-  //    schedulers[i]->cycle();
-  //}
+    // warp issue breakdown
+    unsigned sid = m_config->gpgpu_warp_issue_shader;
+    unsigned count = 0;
+    unsigned warp_id_issued_sum = 0;
+    gzprintf(visualizer_file, "WarpIssueSlotBreakdown:");
+    if(m_shader_warp_slot_issue_distro[sid].size() > 0){
+        for ( std::vector<unsigned>::const_iterator iter = m_shader_warp_slot_issue_distro[ sid ].begin();
+              iter != m_shader_warp_slot_issue_distro[ sid ].end(); iter++, count++ ) {
+            unsigned diff = count < m_last_shader_warp_slot_issue_distro.size() ?
+                            *iter - m_last_shader_warp_slot_issue_distro[ count ] :
+                            *iter;
+            gzprintf( visualizer_file, " %d", diff );
+            warp_id_issued_sum += diff;
+        }
+        m_last_shader_warp_slot_issue_distro = m_shader_warp_slot_issue_distro[ sid ];
+    }else{
+        gzprintf( visualizer_file, " 0");
+    }
+    gzprintf(visualizer_file,"\n");
+
+    #define DYNAMIC_WARP_PRINT_RESOLUTION 32
+    unsigned total_issued_this_resolution = 0;
+    unsigned dynamic_id_issued_sum = 0;
+    count = 0;
+    gzprintf(visualizer_file, "WarpIssueDynamicIdBreakdown:");
+    if(m_shader_dynamic_warp_issue_distro[sid].size() > 0){
+        for ( std::vector<unsigned>::const_iterator iter = m_shader_dynamic_warp_issue_distro[ sid ].begin();
+              iter != m_shader_dynamic_warp_issue_distro[ sid ].end(); iter++, count++ ) {
+            unsigned diff = count < m_last_shader_dynamic_warp_issue_distro.size() ?
+                            *iter - m_last_shader_dynamic_warp_issue_distro[ count ] :
+                            *iter;
+            total_issued_this_resolution += diff;
+            if ( ( count + 1 ) % DYNAMIC_WARP_PRINT_RESOLUTION == 0 ) {
+                gzprintf( visualizer_file, " %d", total_issued_this_resolution );
+                dynamic_id_issued_sum += total_issued_this_resolution;
+                total_issued_this_resolution = 0;
+            }
+        }
+        if ( count % DYNAMIC_WARP_PRINT_RESOLUTION != 0 ) {
+            gzprintf( visualizer_file, " %d", total_issued_this_resolution );
+            dynamic_id_issued_sum += total_issued_this_resolution;
+        }
+        m_last_shader_dynamic_warp_issue_distro = m_shader_dynamic_warp_issue_distro[ sid ];
+        assert( warp_id_issued_sum == dynamic_id_issued_sum );
+    }else{
+        gzprintf( visualizer_file, " 0");
+    }
+    gzprintf(visualizer_file,"\n");
+
+    // overall cache miss rates
+    gzprintf(visualizer_file, "gpgpu_n_cache_bkconflict: %d\n", gpgpu_n_cache_bkconflict);
+    gzprintf(visualizer_file, "gpgpu_n_shmem_bkconflict: %d\n", gpgpu_n_shmem_bkconflict);     
+
+
+   // instruction count per shader core
+   gzprintf(visualizer_file, "shaderinsncount:  ");
+   for (unsigned i=0;i<m_config->num_shader();i++) 
+      gzprintf(visualizer_file, "%u ", m_num_sim_insn[i] );
+   gzprintf(visualizer_file, "\n");
+   // warp instruction count per shader core
+   gzprintf(visualizer_file, "shaderwarpinsncount:  ");
+   for (unsigned i=0;i<m_config->num_shader();i++)
+      gzprintf(visualizer_file, "%u ", m_num_sim_winsn[i] );
+   gzprintf(visualizer_file, "\n");
+   // warp divergence per shader core
+   gzprintf(visualizer_file, "shaderwarpdiv: ");
+   for (unsigned i=0;i<m_config->num_shader();i++) 
+      gzprintf(visualizer_file, "%u ", m_n_diverge[i] );
+   gzprintf(visualizer_file, "\n");
 }
 
-shd_warp_t &scheduler_unit::warp(int i) { return (*m_warp)[i]; }
+#define PROGRAM_MEM_START 0xF0000000 /* should be distinct from other memory spaces... 
+                                        check ptx_ir.h to verify this does not overlap 
+                                        other memory spaces */
+void shader_core_ctx::decode()
+{
+    if( m_inst_fetch_buffer.m_valid ) {
+        // decode 1 or 2 instructions and place them into ibuffer
+        address_type pc = m_inst_fetch_buffer.m_pc;
+        const warp_inst_t* pI1 = m_gpu->gpgpu_ctx->ptx_fetch_inst(pc);
+        m_warp[m_inst_fetch_buffer.m_warp_id].ibuffer_fill(0,pI1);
+        m_warp[m_inst_fetch_buffer.m_warp_id].inc_inst_in_pipeline();
+        if( pI1 ) {
+            m_stats->m_num_decoded_insn[m_sid]++;
+            if(pI1->oprnd_type==INT_OP){
+                m_stats->m_num_INTdecoded_insn[m_sid]++;
+            }else if(pI1->oprnd_type==FP_OP) {
+            	m_stats->m_num_FPdecoded_insn[m_sid]++;
+            }
+           const warp_inst_t* pI2 = m_gpu->gpgpu_ctx->ptx_fetch_inst(pc+pI1->isize);
+           if( pI2 ) {
+               m_warp[m_inst_fetch_buffer.m_warp_id].ibuffer_fill(1,pI2);
+               m_warp[m_inst_fetch_buffer.m_warp_id].inc_inst_in_pipeline();
+               m_stats->m_num_decoded_insn[m_sid]++;
+               if(pI2->oprnd_type==INT_OP){
+                   m_stats->m_num_INTdecoded_insn[m_sid]++;
+               }else if(pI2->oprnd_type==FP_OP) {
+            	   m_stats->m_num_FPdecoded_insn[m_sid]++;
+               }
+           }
+        }
+        m_inst_fetch_buffer.m_valid = false;
+    }
+}
+
+void shader_core_ctx::fetch()
+{
+
+    if( !m_inst_fetch_buffer.m_valid ) {
+        if( m_L1I->access_ready() ) {
+            mem_fetch *mf = m_L1I->next_access();
+            m_warp[mf->get_wid()].clear_imiss_pending();
+            m_inst_fetch_buffer = ifetch_buffer_t(m_warp[mf->get_wid()].get_pc(), mf->get_access_size(), mf->get_wid());
+            assert( m_warp[mf->get_wid()].get_pc() == (mf->get_addr()-PROGRAM_MEM_START)); // Verify that we got the instruction we were expecting.
+            m_inst_fetch_buffer.m_valid = true;
+            m_warp[mf->get_wid()].set_last_fetch(m_gpu->gpu_sim_cycle);
+            delete mf;
+        }
+        else {
+            // find an active warp with space in instruction buffer that is not already waiting on a cache miss
+            // and get next 1-2 instructions from i-cache...
+            for( unsigned i=0; i < m_config->max_warps_per_shader; i++ ) {
+                unsigned warp_id = (m_last_warp_fetched+1+i) % m_config->max_warps_per_shader;
+
+                // this code checks if this warp has finished executing and can be reclaimed
+                if( m_warp[warp_id].hardware_done() && !m_scoreboard->pendingWrites(warp_id) && !m_warp[warp_id].done_exit() ) {
+                    bool did_exit=false;
+                    for( unsigned t=0; t<m_config->warp_size;t++) {
+                        unsigned tid=warp_id*m_config->warp_size+t;
+                        if( m_threadState[tid].m_active == true ) {
+                            m_threadState[tid].m_active = false; 
+                            unsigned cta_id = m_warp[warp_id].get_cta_id();
+                            register_cta_thread_exit(cta_id, &(m_thread[tid]->get_kernel()));
+                            m_not_completed -= 1;
+                            m_active_threads.reset(tid);
+                            assert( m_thread[tid]!= NULL );
+                            did_exit=true;
+                        }
+                    }
+                    if( did_exit ) 
+                        m_warp[warp_id].set_done_exit();
+                        --m_active_warps;
+                        assert(m_active_warps >= 0);
+                }
+
+                // this code fetches instructions from the i-cache or generates memory requests
+                if( !m_warp[warp_id].functional_done() && !m_warp[warp_id].imiss_pending() && m_warp[warp_id].ibuffer_empty() ) {
+                    address_type pc  = m_warp[warp_id].get_pc();
+                    address_type ppc = pc + PROGRAM_MEM_START;
+                    unsigned nbytes=16;
+                    unsigned offset_in_block = pc & (m_config->m_L1I_config.get_line_sz()-1);
+                    if( (offset_in_block+nbytes) > m_config->m_L1I_config.get_line_sz() )
+                        nbytes = (m_config->m_L1I_config.get_line_sz()-offset_in_block);
+
+                    // TODO: replace with use of allocator
+                    // mem_fetch *mf = m_mem_fetch_allocator->alloc()
+                    mem_access_t acc(INST_ACC_R,ppc,nbytes,false, m_gpu->gpgpu_ctx);
+                    mem_fetch *mf = new mem_fetch(acc,
+                            NULL/*we don't have an instruction yet*/,
+                            READ_PACKET_SIZE,
+                            warp_id,
+                            m_sid,
+                            m_tpc,
+                            m_memory_config,
+							m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle
+							);
+                    std::list<cache_event> events;
+                    enum cache_request_status status = m_L1I->access( (new_addr_type)ppc, mf, m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle,events);
+                    if( status == MISS ) {
+                        m_last_warp_fetched=warp_id;
+                        m_warp[warp_id].set_imiss_pending();
+                        m_warp[warp_id].set_last_fetch(m_gpu->gpu_sim_cycle);
+                    } else if( status == HIT ) {
+                        m_last_warp_fetched=warp_id;
+                        m_inst_fetch_buffer = ifetch_buffer_t(pc,nbytes,warp_id);
+                        m_warp[warp_id].set_last_fetch(m_gpu->gpu_sim_cycle);
+                        delete mf;
+                    } else {
+                        m_last_warp_fetched=warp_id;
+                        assert( status == RESERVATION_FAIL );
+                        delete mf;
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    m_L1I->cycle();
+}
+
+void shader_core_ctx::func_exec_inst( warp_inst_t &inst )
+{
+    execute_warp_inst_t(inst);
+    if( inst.is_load() || inst.is_store() )
+    {
+	inst.generate_mem_accesses();
+        //inst.print_m_accessq();	
+    }	
+}
+
+void shader_core_ctx::issue_warp( register_set& pipe_reg_set, const warp_inst_t* next_inst, const active_mask_t &active_mask, unsigned warp_id, unsigned sch_id )
+{
+	warp_inst_t** pipe_reg = pipe_reg_set.get_free(m_config->sub_core_model, sch_id);
+    assert(pipe_reg);
+
+    m_warp[warp_id].ibuffer_free();
+    assert(next_inst->valid());
+    **pipe_reg = *next_inst; // static instruction information
+    (*pipe_reg)->issue( active_mask, warp_id, m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle, m_warp[warp_id].get_dynamic_warp_id(), sch_id ); // dynamic instruction information
+    m_stats->shader_cycle_distro[2+(*pipe_reg)->active_count()]++;
+    func_exec_inst( **pipe_reg );
+    if( next_inst->op == BARRIER_OP ){
+        m_warp[warp_id].store_info_of_last_inst_at_barrier(*pipe_reg);
+        m_barriers.warp_reaches_barrier(m_warp[warp_id].get_cta_id(),warp_id,const_cast<warp_inst_t*> (next_inst));
+
+    }else if( next_inst->op == MEMORY_BARRIER_OP ){
+        m_warp[warp_id].set_membar();
+    }
+
+    updateSIMTStack(warp_id,*pipe_reg);
+    m_scoreboard->reserveRegisters(*pipe_reg);
+    m_warp[warp_id].set_next_pc(next_inst->pc + next_inst->isize);
+}
+
+void shader_core_ctx::issue(){
+
+     //Ensure fair round robin issu between schedulers 
+     unsigned j;
+     for (unsigned i = 0; i < schedulers.size(); i++) {
+	j = (Issue_Prio + i) % schedulers.size();
+	  schedulers[j]->cycle();
+     }
+     Issue_Prio = (Issue_Prio+1)% schedulers.size();
+
+    //really is issue;
+    //for (unsigned i = 0; i < schedulers.size(); i++) {
+    //    schedulers[i]->cycle();
+    //}
+}
+
+shd_warp_t& scheduler_unit::warp(int i){
+    return (*m_warp)[i];
+}
+
 
 /**
- * A general function to order things in a Loose Round Robin way. The simplist
- * use of this
- * function would be to implement a loose RR scheduler between all the warps
- * assigned to this core.
- * A more sophisticated usage would be to order a set of "fetch groups" in a RR
- * fashion.
- * In the first case, the templated class variable would be a simple unsigned
- * int representing the
- * warp_id.  In the 2lvl case, T could be a struct or a list representing a set
- * of warp_ids.
- * @param result_list: The resultant list the caller wants returned.  This list
- * is cleared and then populated
+ * A general function to order things in a Loose Round Robin way. The simplist use of this
+ * function would be to implement a loose RR scheduler between all the warps assigned to this core.
+ * A more sophisticated usage would be to order a set of "fetch groups" in a RR fashion.
+ * In the first case, the templated class variable would be a simple unsigned int representing the
+ * warp_id.  In the 2lvl case, T could be a struct or a list representing a set of warp_ids.
+ * @param result_list: The resultant list the caller wants returned.  This list is cleared and then populated
  *                     in a loose round robin way
- * @param input_list: The list of things that should be put into the
- * result_list. For a simple scheduler
+ * @param input_list: The list of things that should be put into the result_list. For a simple scheduler
  *                    this can simply be the m_supervised_warps list.
- * @param last_issued_from_input:  An iterator pointing the last member in the
- * input_list that issued.
- *                                 Since this function orders in a RR fashion,
- * the object pointed
- *                                 to by this iterator will be last in the
- * prioritization list
- * @param num_warps_to_add: The number of warps you want the scheudler to pick
- * between this cycle.
- *                          Normally, this will be all the warps availible on
- * the core, i.e.
- *                          m_supervised_warps.size(). However, a more
- * sophisticated scheduler may wish to
- *                          limit this number. If the number if <
- * m_supervised_warps.size(), then only
- *                          the warps with highest RR priority will be placed in
- * the result_list.
+ * @param last_issued_from_input:  An iterator pointing the last member in the input_list that issued.
+ *                                 Since this function orders in a RR fashion, the object pointed
+ *                                 to by this iterator will be last in the prioritization list
+ * @param num_warps_to_add: The number of warps you want the scheudler to pick between this cycle.
+ *                          Normally, this will be all the warps availible on the core, i.e.
+ *                          m_supervised_warps.size(). However, a more sophisticated scheduler may wish to
+ *                          limit this number. If the number if < m_supervised_warps.size(), then only
+ *                          the warps with highest RR priority will be placed in the result_list.
  */
-template <class T>
-void scheduler_unit::order_lrr(
-    std::vector<T> &result_list, const typename std::vector<T> &input_list,
-    const typename std::vector<T>::const_iterator &last_issued_from_input,
-    unsigned num_warps_to_add) {
-  assert(num_warps_to_add <= input_list.size());
-  result_list.clear();
-  typename std::vector<T>::const_iterator iter =
-      (last_issued_from_input == input_list.end()) ? input_list.begin()
-                                                   : last_issued_from_input + 1;
+    template < class T >
+void scheduler_unit::order_lrr( std::vector< T >& result_list,
+        const typename std::vector< T >& input_list,
+        const typename std::vector< T >::const_iterator& last_issued_from_input,
+        unsigned num_warps_to_add )
+{
+    assert( num_warps_to_add <= input_list.size() );
+    result_list.clear();
+    typename std::vector< T >::const_iterator iter
+        = ( last_issued_from_input ==  input_list.end() ) ? input_list.begin()
+        : last_issued_from_input + 1;
 
-  for (unsigned count = 0; count < num_warps_to_add; ++iter, ++count) {
-    if (iter == input_list.end()) {
-      iter = input_list.begin();
+    for ( unsigned count = 0;
+            count < num_warps_to_add;
+            ++iter, ++count) {
+        if ( iter ==  input_list.end() ) {
+            iter = input_list.begin();
+        }
+        result_list.push_back( *iter );
     }
-    result_list.push_back(*iter);
-  }
 }
 
 /**
  * A general function to order things in an priority-based way.
  * The core usage of the function is similar to order_lrr.
- * The explanation of the additional parameters (beyond order_lrr) explains the
- * further extensions.
- * @param ordering: An enum that determines how the age function will be treated
- * in prioritization
+ * The explanation of the additional parameters (beyond order_lrr) explains the further extensions.
+ * @param ordering: An enum that determines how the age function will be treated in prioritization
  *                  see the definition of OrderingType.
- * @param priority_function: This function is used to sort the input_list.  It
- * is passed to stl::sort as
- *                           the sorting fucntion. So, if you wanted to sort a
- * list of integer warp_ids
- *                           with the oldest warps having the most priority,
- * then the priority_function
+ * @param priority_function: This function is used to sort the input_list.  It is passed to stl::sort as
+ *                           the sorting fucntion. So, if you wanted to sort a list of integer warp_ids
+ *                           with the oldest warps having the most priority, then the priority_function
  *                           would compare the age of the two warps.
  */
-template <class T>
-void scheduler_unit::order_by_priority(
-    std::vector<T> &result_list, const typename std::vector<T> &input_list,
-    const typename std::vector<T>::const_iterator &last_issued_from_input,
-    unsigned num_warps_to_add, OrderingType ordering,
-    bool (*priority_func)(T lhs, T rhs)) {
-  assert(num_warps_to_add <= input_list.size());
-  result_list.clear();
-  typename std::vector<T> temp = input_list;
+    template < class T >
+void scheduler_unit::order_by_priority( std::vector< T >& result_list,
+        const typename std::vector< T >& input_list,
+        const typename std::vector< T >::const_iterator& last_issued_from_input,
+        unsigned num_warps_to_add,
+        OrderingType ordering,
+        bool (*priority_func)(T lhs, T rhs) )
+{
+    assert( num_warps_to_add <= input_list.size() );
+    result_list.clear();
+    typename std::vector< T > temp = input_list;
 
-  if (ORDERING_GREEDY_THEN_PRIORITY_FUNC == ordering) {
-    T greedy_value = *last_issued_from_input;
-    result_list.push_back(greedy_value);
+    if ( ORDERING_GREEDY_THEN_PRIORITY_FUNC == ordering ) {
+        T greedy_value = *last_issued_from_input;
+        result_list.push_back( greedy_value );
 
-    std::sort(temp.begin(), temp.end(), priority_func);
-    typename std::vector<T>::iterator iter = temp.begin();
-    for (unsigned count = 0; count < num_warps_to_add; ++count, ++iter) {
-      if (*iter != greedy_value) {
-        result_list.push_back(*iter);
-      }
+        std::sort( temp.begin(), temp.end(), priority_func );
+        typename std::vector< T >::iterator iter = temp.begin();
+        for ( unsigned count = 0; count < num_warps_to_add; ++count, ++iter ) {
+            if ( *iter != greedy_value ) {
+                result_list.push_back( *iter );
+            }
+        }
+    } else if ( ORDERED_PRIORITY_FUNC_ONLY == ordering ) {
+        std::sort( temp.begin(), temp.end(), priority_func );
+        typename std::vector< T >::iterator iter = temp.begin();
+        for ( unsigned count = 0; count < num_warps_to_add; ++count, ++iter ) {
+            result_list.push_back( *iter );
+        }
+    } else {
+        fprintf( stderr, "Unknown ordering - %d\n", ordering );
+        abort();
     }
-  } else if (ORDERED_PRIORITY_FUNC_ONLY == ordering) {
-    std::sort(temp.begin(), temp.end(), priority_func);
-    typename std::vector<T>::iterator iter = temp.begin();
-    for (unsigned count = 0; count < num_warps_to_add; ++count, ++iter) {
-      result_list.push_back(*iter);
-    }
-  } else {
-    fprintf(stderr, "Unknown ordering - %d\n", ordering);
-    abort();
-  }
 }
 
-void scheduler_unit::cycle() {
-  SCHED_DPRINTF("scheduler_unit::cycle()\n");
-  bool valid_inst = false;   // there was one warp with a valid instruction to
-                             // issue (didn't require flush due to control
-                             // hazard)
-  bool ready_inst = false;   // of the valid instructions, there was one not
-                             // waiting for pending register writes
-  bool issued_inst = false;  // of these we issued one
+void scheduler_unit::cycle()
+{
+    SCHED_DPRINTF( "scheduler_unit::cycle()\n" );
+    bool valid_inst = false;  // there was one warp with a valid instruction to issue (didn't require flush due to control hazard)
+    bool ready_inst = false;  // of the valid instructions, there was one not waiting for pending register writes
+    bool issued_inst = false; // of these we issued one
 
-  order_warps();
-  for (std::vector<shd_warp_t *>::const_iterator iter =
-           m_next_cycle_prioritized_warps.begin();
-       iter != m_next_cycle_prioritized_warps.end(); iter++) {
-    // Don't consider warps that are not yet valid
-    if ((*iter) == NULL || (*iter)->done_exit()) {
-      continue;
+    order_warps();
+    for ( std::vector< shd_warp_t* >::const_iterator iter = m_next_cycle_prioritized_warps.begin();
+          iter != m_next_cycle_prioritized_warps.end();
+          iter++ ) {
+        // Don't consider warps that are not yet valid
+        if ( (*iter) == NULL || (*iter)->done_exit() ) {
+            continue;
+        }
+        SCHED_DPRINTF( "Testing (warp_id %u, dynamic_warp_id %u)\n",
+                       (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id() );
+        unsigned warp_id = (*iter)->get_warp_id();
+        unsigned checked=0;
+        unsigned issued=0;
+        exec_unit_type_t previous_issued_inst_exec_type = exec_unit_type_t::NONE;
+        unsigned max_issue = m_shader->m_config->gpgpu_max_insn_issue_per_warp;
+        bool diff_exec_units = m_shader->m_config->gpgpu_dual_issue_diff_exec_units;  //In tis mode, we only allow dual issue to diff execution units (as in Maxwell and Pascal)
+
+        while( !warp(warp_id).waiting() && !warp(warp_id).ibuffer_empty() && (checked < max_issue) && (checked <= issued) && (issued < max_issue) ) {
+            const warp_inst_t *pI = warp(warp_id).ibuffer_next_inst();
+            //Jin: handle cdp latency;
+            if(pI && pI->m_is_cdp && warp(warp_id).m_cdp_latency > 0) {
+                assert(warp(warp_id).m_cdp_dummy);
+                warp(warp_id).m_cdp_latency--;
+                break;
+            }
+
+            bool valid = warp(warp_id).ibuffer_next_valid();
+            bool warp_inst_issued = false;
+            unsigned pc,rpc;
+            m_simt_stack[warp_id]->get_pdom_stack_top_info(&pc,&rpc);
+            SCHED_DPRINTF( "Warp (warp_id %u, dynamic_warp_id %u) has valid instruction (%s)\n",
+                           (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id(),
+                           m_shader->m_config->gpgpu_ctx->func_sim->ptx_get_insn_str( pc).c_str() );
+            if( pI ) {
+                assert(valid);
+                if( pc != pI->pc ) {
+                    SCHED_DPRINTF( "Warp (warp_id %u, dynamic_warp_id %u) control hazard instruction flush\n",
+                                   (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id() );
+                    // control hazard
+                    warp(warp_id).set_next_pc(pc);
+                    warp(warp_id).ibuffer_flush();
+                } else {
+                    valid_inst = true;
+                    if ( !m_scoreboard->checkCollision(warp_id, pI) ) {
+                        SCHED_DPRINTF( "Warp (warp_id %u, dynamic_warp_id %u) passes scoreboard\n",
+                                       (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id() );
+                        ready_inst = true;
+                        const active_mask_t &active_mask = m_simt_stack[warp_id]->get_active_mask();
+                        assert( warp(warp_id).inst_in_pipeline() );
+
+                        if ( (pI->op == LOAD_OP) || (pI->op == STORE_OP) || (pI->op == MEMORY_BARRIER_OP)||(pI->op==TENSOR_CORE_LOAD_OP)||(pI->op==TENSOR_CORE_STORE_OP) ) {
+                        	if( m_mem_out->has_free(m_shader->m_config->sub_core_model, m_id) && (!diff_exec_units || previous_issued_inst_exec_type != exec_unit_type_t::MEM)) {
+                                m_shader->issue_warp(*m_mem_out,pI,active_mask,warp_id,m_id);
+                                issued++;
+                                issued_inst=true;
+                                warp_inst_issued = true;
+                                previous_issued_inst_exec_type = exec_unit_type_t::MEM;
+                            }
+                        } else {
+
+                            bool sp_pipe_avail = m_sp_out->has_free(m_shader->m_config->sub_core_model, m_id);
+                            bool sfu_pipe_avail = m_sfu_out->has_free(m_shader->m_config->sub_core_model, m_id);
+                            bool tensor_core_pipe_avail = m_tensor_core_out->has_free(m_shader->m_config->sub_core_model, m_id);
+                            bool dp_pipe_avail = m_dp_out->has_free(m_shader->m_config->sub_core_model, m_id);
+                            bool int_pipe_avail = m_int_out->has_free(m_shader->m_config->sub_core_model, m_id);
+
+                            //This code need to be refactored
+                            if(pI->op != TENSOR_CORE_OP && pI->op != SFU_OP && pI->op != DP_OP) {
+                                
+									bool execute_on_SP = false;
+									bool execute_on_INT = false;
+
+									//if INT unit pipline exist, then execute ALU and INT operations on INT unit and SP-FPU on SP unit (like in Volta)
+									//if INT unit pipline does not exist, then execute all ALU, INT and SP operations on SP unit (as in Fermi, Pascal GPUs)
+									if(m_shader->m_config->gpgpu_num_int_units > 0 &&
+											int_pipe_avail &&
+											pI->op != SP_OP &&
+											!(diff_exec_units && previous_issued_inst_exec_type == exec_unit_type_t::INT))
+										execute_on_INT = true;
+									else if (sp_pipe_avail &&
+											(m_shader->m_config->gpgpu_num_int_units == 0 ||
+											(m_shader->m_config->gpgpu_num_int_units > 0 && pI->op == SP_OP)) &&
+											!(diff_exec_units && previous_issued_inst_exec_type == exec_unit_type_t::SP) )
+										execute_on_SP = true;
+
+
+									if(execute_on_INT || execute_on_SP) {
+										//Jin: special for CDP api
+										if(pI->m_is_cdp && !warp(warp_id).m_cdp_dummy) {
+											assert(warp(warp_id).m_cdp_latency == 0);
+
+											if(pI->m_is_cdp == 1)
+												warp(warp_id).m_cdp_latency = m_shader->m_config->gpgpu_ctx->func_sim->cdp_latency[pI->m_is_cdp - 1];
+											else //cudaLaunchDeviceV2 and cudaGetParameterBufferV2
+												warp(warp_id).m_cdp_latency = m_shader->m_config->gpgpu_ctx->func_sim->cdp_latency[pI->m_is_cdp - 1]
+													+ m_shader->m_config->gpgpu_ctx->func_sim->cdp_latency[pI->m_is_cdp] * active_mask.count();
+											warp(warp_id).m_cdp_dummy = true;
+											break;
+										}
+										else if(pI->m_is_cdp && warp(warp_id).m_cdp_dummy) {
+											assert(warp(warp_id).m_cdp_latency == 0);
+											warp(warp_id).m_cdp_dummy = false;
+										}
+									}
+
+									if(execute_on_SP) {
+										m_shader->issue_warp(*m_sp_out,pI,active_mask,warp_id,m_id);
+										issued++;
+										issued_inst=true;
+										warp_inst_issued = true;
+										previous_issued_inst_exec_type = exec_unit_type_t::SP;
+									} else if (execute_on_INT) {
+										m_shader->issue_warp(*m_int_out,pI,active_mask,warp_id,m_id);
+										issued++;
+										issued_inst=true;
+										warp_inst_issued = true;
+										previous_issued_inst_exec_type = exec_unit_type_t::INT;
+                                   }
+                            } else if ( (m_shader->m_config->gpgpu_num_dp_units > 0) && (pI->op == DP_OP) && !(diff_exec_units && previous_issued_inst_exec_type == exec_unit_type_t::DP)) {
+                                if( dp_pipe_avail ) {
+                                    m_shader->issue_warp(*m_dp_out,pI,active_mask,warp_id,m_id);
+                                    issued++;
+                                    issued_inst=true;
+                                    warp_inst_issued = true;
+                                    previous_issued_inst_exec_type = exec_unit_type_t::DP;
+                                }
+                            }  //If the DP units = 0 (like in Fermi archi), then execute DP inst on SFU unit
+                            else if ( ((m_shader->m_config->gpgpu_num_dp_units == 0 && pI->op == DP_OP) || (pI->op == SFU_OP) || (pI->op == ALU_SFU_OP)) && !(diff_exec_units && previous_issued_inst_exec_type == exec_unit_type_t::SFU)) {
+                                if( sfu_pipe_avail ) {
+                                    m_shader->issue_warp(*m_sfu_out,pI,active_mask,warp_id,m_id);
+                                    issued++;
+                                    issued_inst=true;
+                                    warp_inst_issued = true;
+                                    previous_issued_inst_exec_type = exec_unit_type_t::SFU;
+                                }
+                            }                         
+                             else if ( (pI->op == TENSOR_CORE_OP) && !(diff_exec_units && previous_issued_inst_exec_type == exec_unit_type_t::SP) ) {
+                                if( tensor_core_pipe_avail ) {
+                                    m_shader->issue_warp(*m_tensor_core_out,pI,active_mask,warp_id,m_id);
+                                    issued++;
+                                    issued_inst=true;
+                                    warp_inst_issued = true;
+                                    previous_issued_inst_exec_type = exec_unit_type_t::TENSOR;
+                                }
+			    }
+                         }//end of else
+                   } else {
+
+                        SCHED_DPRINTF( "Warp (warp_id %u, dynamic_warp_id %u) fails scoreboard\n",
+                                       (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id() );
+                   }
+                }
+            } else if( valid ) {
+               // this case can happen after a return instruction in diverged warp
+               SCHED_DPRINTF( "Warp (warp_id %u, dynamic_warp_id %u) return from diverged warp flush\n",
+                              (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id() );
+               warp(warp_id).set_next_pc(pc);
+               warp(warp_id).ibuffer_flush();
+            }
+            if(warp_inst_issued) {
+                SCHED_DPRINTF( "Warp (warp_id %u, dynamic_warp_id %u) issued %u instructions\n",
+                               (*iter)->get_warp_id(),
+                               (*iter)->get_dynamic_warp_id(),
+                               issued );
+                do_on_warp_issued( warp_id, issued, iter );
+            }
+            checked++;
+        }
+        if ( issued ) {
+            // This might be a bit inefficient, but we need to maintain
+            // two ordered list for proper scheduler execution.
+            // We could remove the need for this loop by associating a
+            // supervised_is index with each entry in the m_next_cycle_prioritized_warps
+            // vector. For now, just run through until you find the right warp_id
+            for ( std::vector< shd_warp_t* >::const_iterator supervised_iter = m_supervised_warps.begin();
+                  supervised_iter != m_supervised_warps.end();
+                  ++supervised_iter ) {
+                if ( *iter == *supervised_iter ) {
+                    m_last_supervised_issued = supervised_iter;
+                }
+            }
+
+            if(issued == 1)
+            	m_stats->single_issue_nums[m_id]++;
+            else if(issued > 1)
+            	m_stats->dual_issue_nums[m_id]++;
+            else
+            	abort();   //issued should be > 0
+
+            break;
+        } 
     }
-    SCHED_DPRINTF("Testing (warp_id %u, dynamic_warp_id %u)\n",
-                  (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id());
-    unsigned warp_id = (*iter)->get_warp_id();
-    unsigned checked = 0;
-    unsigned issued = 0;
-    exec_unit_type_t previous_issued_inst_exec_type = exec_unit_type_t::NONE;
-    unsigned max_issue = m_shader->m_config->gpgpu_max_insn_issue_per_warp;
-    bool diff_exec_units =
-        m_shader->m_config->gpgpu_dual_issue_diff_exec_units;  // In tis mode,
-                                                               // we only allow
-                                                               // dual issue to
-                                                               // diff execution
-                                                               // units (as in
-                                                               // Maxwell and
-                                                               // Pascal)
 
-    while (!warp(warp_id).waiting() && !warp(warp_id).ibuffer_empty() &&
-           (checked < max_issue) && (checked <= issued) &&
-           (issued < max_issue)) {
-      const warp_inst_t *pI = warp(warp_id).ibuffer_next_inst();
-      // Jin: handle cdp latency;
-      if (pI && pI->m_is_cdp && warp(warp_id).m_cdp_latency > 0) {
-        assert(warp(warp_id).m_cdp_dummy);
-        warp(warp_id).m_cdp_latency--;
-        break;
-      }
+    // issue stall statistics:
+    if( !valid_inst ) 
+        m_stats->shader_cycle_distro[0]++; // idle or control hazard
+    else if( !ready_inst ) 
+        m_stats->shader_cycle_distro[1]++; // waiting for RAW hazards (possibly due to memory) 
+    else if( !issued_inst ) 
+        m_stats->shader_cycle_distro[2]++; // pipeline stalled
+}
 
-      bool valid = warp(warp_id).ibuffer_next_valid();
-      bool warp_inst_issued = false;
-      unsigned pc, rpc;
-      m_simt_stack[warp_id]->get_pdom_stack_top_info(&pc, &rpc);
-      SCHED_DPRINTF(
-          "Warp (warp_id %u, dynamic_warp_id %u) has valid instruction (%s)\n",
-          (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id(),
-          m_shader->m_config->gpgpu_ctx->func_sim->ptx_get_insn_str(pc)
-              .c_str());
-      if (pI) {
-        assert(valid);
-        if (pc != pI->pc) {
-          SCHED_DPRINTF(
-              "Warp (warp_id %u, dynamic_warp_id %u) control hazard "
-              "instruction flush\n",
-              (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id());
-          // control hazard
-          warp(warp_id).set_next_pc(pc);
-          warp(warp_id).ibuffer_flush();
+void scheduler_unit::do_on_warp_issued( unsigned warp_id,
+                                        unsigned num_issued,
+                                        const std::vector< shd_warp_t* >::const_iterator& prioritized_iter )
+{
+    m_stats->event_warp_issued( m_shader->get_sid(),
+                                warp_id,
+                                num_issued,
+                                warp(warp_id).get_dynamic_warp_id() );
+    warp(warp_id).ibuffer_step();
+}
+
+bool scheduler_unit::sort_warps_by_oldest_dynamic_id(shd_warp_t* lhs, shd_warp_t* rhs)
+{
+    if (rhs && lhs) {
+        if ( lhs->done_exit() || lhs->waiting() ) {
+            return false;
+        } else if ( rhs->done_exit() || rhs->waiting() ) {
+            return true;
         } else {
-          valid_inst = true;
-          if (!m_scoreboard->checkCollision(warp_id, pI)) {
-            SCHED_DPRINTF(
-                "Warp (warp_id %u, dynamic_warp_id %u) passes scoreboard\n",
-                (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id());
-            ready_inst = true;
-            const active_mask_t &active_mask =
-                m_simt_stack[warp_id]->get_active_mask();
-            assert(warp(warp_id).inst_in_pipeline());
-
-            if ((pI->op == LOAD_OP) || (pI->op == STORE_OP) ||
-                (pI->op == MEMORY_BARRIER_OP) ||
-                (pI->op == TENSOR_CORE_LOAD_OP) ||
-                (pI->op == TENSOR_CORE_STORE_OP)) {
-              if (m_mem_out->has_free(m_shader->m_config->sub_core_model,
-                                      m_id) &&
-                  (!diff_exec_units ||
-                   previous_issued_inst_exec_type != exec_unit_type_t::MEM)) {
-                m_shader->issue_warp(*m_mem_out, pI, active_mask, warp_id,
-                                     m_id);
-                issued++;
-                issued_inst = true;
-                warp_inst_issued = true;
-                previous_issued_inst_exec_type = exec_unit_type_t::MEM;
-              }
-            } else {
-              bool sp_pipe_avail =
-                  m_sp_out->has_free(m_shader->m_config->sub_core_model, m_id);
-              bool sfu_pipe_avail =
-                  m_sfu_out->has_free(m_shader->m_config->sub_core_model, m_id);
-              bool tensor_core_pipe_avail = m_tensor_core_out->has_free(
-                  m_shader->m_config->sub_core_model, m_id);
-              bool dp_pipe_avail =
-                  m_dp_out->has_free(m_shader->m_config->sub_core_model, m_id);
-              bool int_pipe_avail =
-                  m_int_out->has_free(m_shader->m_config->sub_core_model, m_id);
-
-              // This code need to be refactored
-              if (pI->op != TENSOR_CORE_OP && pI->op != SFU_OP &&
-                  pI->op != DP_OP) {
-                bool execute_on_SP = false;
-                bool execute_on_INT = false;
-
-                // if INT unit pipline exist, then execute ALU and INT
-                // operations on INT unit and SP-FPU on SP unit (like in Volta)
-                // if INT unit pipline does not exist, then execute all ALU, INT
-                // and SP operations on SP unit (as in Fermi, Pascal GPUs)
-                if (m_shader->m_config->gpgpu_num_int_units > 0 &&
-                    int_pipe_avail && pI->op != SP_OP &&
-                    !(diff_exec_units &&
-                      previous_issued_inst_exec_type == exec_unit_type_t::INT))
-                  execute_on_INT = true;
-                else if (sp_pipe_avail &&
-                         (m_shader->m_config->gpgpu_num_int_units == 0 ||
-                          (m_shader->m_config->gpgpu_num_int_units > 0 &&
-                           pI->op == SP_OP)) &&
-                         !(diff_exec_units &&
-                           previous_issued_inst_exec_type ==
-                               exec_unit_type_t::SP))
-                  execute_on_SP = true;
-
-                if (execute_on_INT || execute_on_SP) {
-                  // Jin: special for CDP api
-                  if (pI->m_is_cdp && !warp(warp_id).m_cdp_dummy) {
-                    assert(warp(warp_id).m_cdp_latency == 0);
-
-                    if (pI->m_is_cdp == 1)
-                      warp(warp_id).m_cdp_latency =
-                          m_shader->m_config->gpgpu_ctx->func_sim
-                              ->cdp_latency[pI->m_is_cdp - 1];
-                    else  // cudaLaunchDeviceV2 and cudaGetParameterBufferV2
-                      warp(warp_id).m_cdp_latency =
-                          m_shader->m_config->gpgpu_ctx->func_sim
-                              ->cdp_latency[pI->m_is_cdp - 1] +
-                          m_shader->m_config->gpgpu_ctx->func_sim
-                                  ->cdp_latency[pI->m_is_cdp] *
-                              active_mask.count();
-                    warp(warp_id).m_cdp_dummy = true;
-                    break;
-                  } else if (pI->m_is_cdp && warp(warp_id).m_cdp_dummy) {
-                    assert(warp(warp_id).m_cdp_latency == 0);
-                    warp(warp_id).m_cdp_dummy = false;
-                  }
-                }
-
-                if (execute_on_SP) {
-                  m_shader->issue_warp(*m_sp_out, pI, active_mask, warp_id,
-                                       m_id);
-                  issued++;
-                  issued_inst = true;
-                  warp_inst_issued = true;
-                  previous_issued_inst_exec_type = exec_unit_type_t::SP;
-                } else if (execute_on_INT) {
-                  m_shader->issue_warp(*m_int_out, pI, active_mask, warp_id,
-                                       m_id);
-                  issued++;
-                  issued_inst = true;
-                  warp_inst_issued = true;
-                  previous_issued_inst_exec_type = exec_unit_type_t::INT;
-                }
-              } else if ((m_shader->m_config->gpgpu_num_dp_units > 0) &&
-                         (pI->op == DP_OP) &&
-                         !(diff_exec_units &&
-                           previous_issued_inst_exec_type ==
-                               exec_unit_type_t::DP)) {
-                if (dp_pipe_avail) {
-                  m_shader->issue_warp(*m_dp_out, pI, active_mask, warp_id,
-                                       m_id);
-                  issued++;
-                  issued_inst = true;
-                  warp_inst_issued = true;
-                  previous_issued_inst_exec_type = exec_unit_type_t::DP;
-                }
-              }  // If the DP units = 0 (like in Fermi archi), then execute DP
-                 // inst on SFU unit
-              else if (((m_shader->m_config->gpgpu_num_dp_units == 0 &&
-                         pI->op == DP_OP) ||
-                        (pI->op == SFU_OP) || (pI->op == ALU_SFU_OP)) &&
-                       !(diff_exec_units &&
-                         previous_issued_inst_exec_type ==
-                             exec_unit_type_t::SFU)) {
-                if (sfu_pipe_avail) {
-                  m_shader->issue_warp(*m_sfu_out, pI, active_mask, warp_id,
-                                       m_id);
-                  issued++;
-                  issued_inst = true;
-                  warp_inst_issued = true;
-                  previous_issued_inst_exec_type = exec_unit_type_t::SFU;
-                }
-              } else if ((pI->op == TENSOR_CORE_OP) &&
-                         !(diff_exec_units &&
-                           previous_issued_inst_exec_type ==
-                               exec_unit_type_t::SP)) {
-                if (tensor_core_pipe_avail) {
-                  m_shader->issue_warp(*m_tensor_core_out, pI, active_mask,
-                                       warp_id, m_id);
-                  issued++;
-                  issued_inst = true;
-                  warp_inst_issued = true;
-                  previous_issued_inst_exec_type = exec_unit_type_t::TENSOR;
-                }
-              }
-            }  // end of else
-          } else {
-            SCHED_DPRINTF(
-                "Warp (warp_id %u, dynamic_warp_id %u) fails scoreboard\n",
-                (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id());
-          }
+            return lhs->get_dynamic_warp_id() < rhs->get_dynamic_warp_id();
         }
-      } else if (valid) {
-        // this case can happen after a return instruction in diverged warp
-        SCHED_DPRINTF(
-            "Warp (warp_id %u, dynamic_warp_id %u) return from diverged warp "
-            "flush\n",
-            (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id());
-        warp(warp_id).set_next_pc(pc);
-        warp(warp_id).ibuffer_flush();
-      }
-      if (warp_inst_issued) {
-        SCHED_DPRINTF(
-            "Warp (warp_id %u, dynamic_warp_id %u) issued %u instructions\n",
-            (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id(), issued);
-        do_on_warp_issued(warp_id, issued, iter);
-      }
-      checked++;
+    } else {
+        return lhs < rhs;
     }
-    if (issued) {
-      // This might be a bit inefficient, but we need to maintain
-      // two ordered list for proper scheduler execution.
-      // We could remove the need for this loop by associating a
-      // supervised_is index with each entry in the
-      // m_next_cycle_prioritized_warps
-      // vector. For now, just run through until you find the right warp_id
-      for (std::vector<shd_warp_t *>::const_iterator supervised_iter =
-               m_supervised_warps.begin();
-           supervised_iter != m_supervised_warps.end(); ++supervised_iter) {
-        if (*iter == *supervised_iter) {
-          m_last_supervised_issued = supervised_iter;
+}
+
+void lrr_scheduler::order_warps()
+{
+    order_lrr( m_next_cycle_prioritized_warps,
+               m_supervised_warps,
+               m_last_supervised_issued,
+               m_supervised_warps.size() );
+}
+
+void gto_scheduler::order_warps()
+{
+    order_by_priority( m_next_cycle_prioritized_warps,
+                       m_supervised_warps,
+                       m_last_supervised_issued,
+                       m_supervised_warps.size(),
+                       ORDERING_GREEDY_THEN_PRIORITY_FUNC,
+                       scheduler_unit::sort_warps_by_oldest_dynamic_id );
+}
+
+void oldest_scheduler::order_warps()
+{
+    order_by_priority( m_next_cycle_prioritized_warps,
+                       m_supervised_warps,
+                       m_last_supervised_issued,
+                       m_supervised_warps.size(),
+		       ORDERED_PRIORITY_FUNC_ONLY,
+                       scheduler_unit::sort_warps_by_oldest_dynamic_id );
+}
+
+void
+two_level_active_scheduler::do_on_warp_issued( unsigned warp_id,
+                                               unsigned num_issued,
+                                               const std::vector< shd_warp_t* >::const_iterator& prioritized_iter )
+{
+    scheduler_unit::do_on_warp_issued( warp_id, num_issued, prioritized_iter );
+    if ( SCHEDULER_PRIORITIZATION_LRR == m_inner_level_prioritization ) {
+        std::vector< shd_warp_t* > new_active; 
+        order_lrr( new_active,
+                   m_next_cycle_prioritized_warps,
+                   prioritized_iter,
+                   m_next_cycle_prioritized_warps.size() );
+        m_next_cycle_prioritized_warps = new_active;
+    } else {
+        fprintf( stderr,
+                 "Unimplemented m_inner_level_prioritization: %d\n",
+                 m_inner_level_prioritization );
+        abort();
+    }
+}
+
+void two_level_active_scheduler::order_warps()
+{
+    //Move waiting warps to m_pending_warps
+    unsigned num_demoted = 0;
+    for (   std::vector< shd_warp_t* >::iterator iter = m_next_cycle_prioritized_warps.begin();
+            iter != m_next_cycle_prioritized_warps.end(); ) {
+        bool waiting = (*iter)->waiting();
+        for (int i=0; i<MAX_INPUT_VALUES; i++){
+            const warp_inst_t* inst = (*iter)->ibuffer_next_inst();
+            //Is the instruction waiting on a long operation?
+            if ( inst && inst->in[i] > 0 && this->m_scoreboard->islongop((*iter)->get_warp_id(), inst->in[i])){
+                waiting = true;
+            }
         }
-      }
 
-      if (issued == 1)
-        m_stats->single_issue_nums[m_id]++;
-      else if (issued > 1)
-        m_stats->dual_issue_nums[m_id]++;
-      else
-        abort();  // issued should be > 0
-
-      break;
+        if( waiting ) {
+            m_pending_warps.push_back(*iter);
+            iter = m_next_cycle_prioritized_warps.erase(iter);
+            SCHED_DPRINTF( "DEMOTED warp_id=%d, dynamic_warp_id=%d\n",
+                           (*iter)->get_warp_id(),
+                           (*iter)->get_dynamic_warp_id() );
+            ++num_demoted;
+        } else {
+            ++iter;
+        }
     }
-  }
 
-  // issue stall statistics:
-  if (!valid_inst)
-    m_stats->shader_cycle_distro[0]++;  // idle or control hazard
-  else if (!ready_inst)
-    m_stats->shader_cycle_distro[1]++;  // waiting for RAW hazards (possibly due
-                                        // to memory)
-  else if (!issued_inst)
-    m_stats->shader_cycle_distro[2]++;  // pipeline stalled
-}
-
-void scheduler_unit::do_on_warp_issued(
-    unsigned warp_id, unsigned num_issued,
-    const std::vector<shd_warp_t *>::const_iterator &prioritized_iter) {
-  m_stats->event_warp_issued(m_shader->get_sid(), warp_id, num_issued,
-                             warp(warp_id).get_dynamic_warp_id());
-  warp(warp_id).ibuffer_step();
-}
-
-bool scheduler_unit::sort_warps_by_oldest_dynamic_id(shd_warp_t *lhs,
-                                                     shd_warp_t *rhs) {
-  if (rhs && lhs) {
-    if (lhs->done_exit() || lhs->waiting()) {
-      return false;
-    } else if (rhs->done_exit() || rhs->waiting()) {
-      return true;
+    //If there is space in m_next_cycle_prioritized_warps, promote the next m_pending_warps
+    unsigned num_promoted = 0;
+    if ( SCHEDULER_PRIORITIZATION_SRR == m_outer_level_prioritization ) {
+        while ( m_next_cycle_prioritized_warps.size() < m_max_active_warps ) {
+            m_next_cycle_prioritized_warps.push_back(m_pending_warps.front());
+            m_pending_warps.pop_front();
+            SCHED_DPRINTF( "PROMOTED warp_id=%d, dynamic_warp_id=%d\n",
+                           (m_next_cycle_prioritized_warps.back())->get_warp_id(),
+                           (m_next_cycle_prioritized_warps.back())->get_dynamic_warp_id() );
+            ++num_promoted;
+        }
     } else {
-      return lhs->get_dynamic_warp_id() < rhs->get_dynamic_warp_id();
+        fprintf( stderr,
+                 "Unimplemented m_outer_level_prioritization: %d\n",
+                 m_outer_level_prioritization );
+        abort();
     }
-  } else {
-    return lhs < rhs;
-  }
+    assert( num_promoted == num_demoted );
 }
 
-void lrr_scheduler::order_warps() {
-  order_lrr(m_next_cycle_prioritized_warps, m_supervised_warps,
-            m_last_supervised_issued, m_supervised_warps.size());
+swl_scheduler::swl_scheduler ( shader_core_stats* stats, shader_core_ctx* shader,
+                               Scoreboard* scoreboard, simt_stack** simt,
+                               std::vector<shd_warp_t>* warp,
+                               register_set* sp_out,
+							   register_set* dp_out,
+                               register_set* sfu_out,
+							   register_set* int_out,
+                               register_set* tensor_core_out,
+                               register_set* mem_out,
+                               int id,
+                               char* config_string )
+    : scheduler_unit ( stats, shader, scoreboard, simt, warp, sp_out, dp_out, sfu_out, int_out, tensor_core_out, mem_out, id )
+{
+    unsigned m_prioritization_readin;
+    int ret = sscanf( config_string,
+                      "warp_limiting:%d:%d",
+                      &m_prioritization_readin,
+                      &m_num_warps_to_limit
+                     );
+    assert( 2 == ret );
+    m_prioritization = (scheduler_prioritization_type)m_prioritization_readin;
+    // Currently only GTO is implemented
+    assert( m_prioritization == SCHEDULER_PRIORITIZATION_GTO );
+    assert( m_num_warps_to_limit <= shader->get_config()->max_warps_per_shader );
 }
 
-void gto_scheduler::order_warps() {
-  order_by_priority(m_next_cycle_prioritized_warps, m_supervised_warps,
-                    m_last_supervised_issued, m_supervised_warps.size(),
-                    ORDERING_GREEDY_THEN_PRIORITY_FUNC,
-                    scheduler_unit::sort_warps_by_oldest_dynamic_id);
-}
-
-void oldest_scheduler::order_warps() {
-  order_by_priority(m_next_cycle_prioritized_warps, m_supervised_warps,
-                    m_last_supervised_issued, m_supervised_warps.size(),
-                    ORDERED_PRIORITY_FUNC_ONLY,
-                    scheduler_unit::sort_warps_by_oldest_dynamic_id);
-}
-
-void two_level_active_scheduler::do_on_warp_issued(
-    unsigned warp_id, unsigned num_issued,
-    const std::vector<shd_warp_t *>::const_iterator &prioritized_iter) {
-  scheduler_unit::do_on_warp_issued(warp_id, num_issued, prioritized_iter);
-  if (SCHEDULER_PRIORITIZATION_LRR == m_inner_level_prioritization) {
-    std::vector<shd_warp_t *> new_active;
-    order_lrr(new_active, m_next_cycle_prioritized_warps, prioritized_iter,
-              m_next_cycle_prioritized_warps.size());
-    m_next_cycle_prioritized_warps = new_active;
-  } else {
-    fprintf(stderr, "Unimplemented m_inner_level_prioritization: %d\n",
-            m_inner_level_prioritization);
-    abort();
-  }
-}
-
-void two_level_active_scheduler::order_warps() {
-  // Move waiting warps to m_pending_warps
-  unsigned num_demoted = 0;
-  for (std::vector<shd_warp_t *>::iterator iter =
-           m_next_cycle_prioritized_warps.begin();
-       iter != m_next_cycle_prioritized_warps.end();) {
-    bool waiting = (*iter)->waiting();
-    for (int i = 0; i < MAX_INPUT_VALUES; i++) {
-      const warp_inst_t *inst = (*iter)->ibuffer_next_inst();
-      // Is the instruction waiting on a long operation?
-      if (inst && inst->in[i] > 0 &&
-          this->m_scoreboard->islongop((*iter)->get_warp_id(), inst->in[i])) {
-        waiting = true;
-      }
-    }
-
-    if (waiting) {
-      m_pending_warps.push_back(*iter);
-      iter = m_next_cycle_prioritized_warps.erase(iter);
-      SCHED_DPRINTF("DEMOTED warp_id=%d, dynamic_warp_id=%d\n",
-                    (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id());
-      ++num_demoted;
+void swl_scheduler::order_warps()
+{
+    if ( SCHEDULER_PRIORITIZATION_GTO == m_prioritization ) {
+        order_by_priority( m_next_cycle_prioritized_warps,
+                           m_supervised_warps,
+                           m_last_supervised_issued,
+                           MIN( m_num_warps_to_limit, m_supervised_warps.size() ),
+                           ORDERING_GREEDY_THEN_PRIORITY_FUNC,
+                           scheduler_unit::sort_warps_by_oldest_dynamic_id );
     } else {
-      ++iter;
+        fprintf(stderr, "swl_scheduler m_prioritization = %d\n", m_prioritization);
+        abort();
     }
-  }
-
-  // If there is space in m_next_cycle_prioritized_warps, promote the next
-  // m_pending_warps
-  unsigned num_promoted = 0;
-  if (SCHEDULER_PRIORITIZATION_SRR == m_outer_level_prioritization) {
-    while (m_next_cycle_prioritized_warps.size() < m_max_active_warps) {
-      m_next_cycle_prioritized_warps.push_back(m_pending_warps.front());
-      m_pending_warps.pop_front();
-      SCHED_DPRINTF(
-          "PROMOTED warp_id=%d, dynamic_warp_id=%d\n",
-          (m_next_cycle_prioritized_warps.back())->get_warp_id(),
-          (m_next_cycle_prioritized_warps.back())->get_dynamic_warp_id());
-      ++num_promoted;
-    }
-  } else {
-    fprintf(stderr, "Unimplemented m_outer_level_prioritization: %d\n",
-            m_outer_level_prioritization);
-    abort();
-  }
-  assert(num_promoted == num_demoted);
 }
 
-swl_scheduler::swl_scheduler(shader_core_stats *stats, shader_core_ctx *shader,
-                             Scoreboard *scoreboard, simt_stack **simt,
-                             std::vector<shd_warp_t> *warp,
-                             register_set *sp_out, register_set *dp_out,
-                             register_set *sfu_out, register_set *int_out,
-                             register_set *tensor_core_out,
-                             register_set *mem_out, int id, char *config_string)
-    : scheduler_unit(stats, shader, scoreboard, simt, warp, sp_out, dp_out,
-                     sfu_out, int_out, tensor_core_out, mem_out, id) {
-  unsigned m_prioritization_readin;
-  int ret = sscanf(config_string, "warp_limiting:%d:%d",
-                   &m_prioritization_readin, &m_num_warps_to_limit);
-  assert(2 == ret);
-  m_prioritization = (scheduler_prioritization_type)m_prioritization_readin;
-  // Currently only GTO is implemented
-  assert(m_prioritization == SCHEDULER_PRIORITIZATION_GTO);
-  assert(m_num_warps_to_limit <= shader->get_config()->max_warps_per_shader);
+void shader_core_ctx::read_operands()
+{
 }
 
-void swl_scheduler::order_warps() {
-  if (SCHEDULER_PRIORITIZATION_GTO == m_prioritization) {
-    order_by_priority(m_next_cycle_prioritized_warps, m_supervised_warps,
-                      m_last_supervised_issued,
-                      MIN(m_num_warps_to_limit, m_supervised_warps.size()),
-                      ORDERING_GREEDY_THEN_PRIORITY_FUNC,
-                      scheduler_unit::sort_warps_by_oldest_dynamic_id);
-  } else {
-    fprintf(stderr, "swl_scheduler m_prioritization = %d\n", m_prioritization);
-    abort();
-  }
+address_type coalesced_segment(address_type addr, unsigned segment_size_lg2bytes)
+{
+   return  (addr >> segment_size_lg2bytes);
 }
 
-void shader_core_ctx::read_operands() {}
+// Returns numbers of addresses in translated_addrs, each addr points to a 4B (32-bit) word
+unsigned shader_core_ctx::translate_local_memaddr( address_type localaddr, unsigned tid, unsigned num_shader, unsigned datasize, new_addr_type* translated_addrs )
+{
+   // During functional execution, each thread sees its own memory space for local memory, but these
+   // need to be mapped to a shared address space for timing simulation.  We do that mapping here.
 
-address_type coalesced_segment(address_type addr,
-                               unsigned segment_size_lg2bytes) {
-  return (addr >> segment_size_lg2bytes);
-}
+   address_type thread_base = 0;
+   unsigned max_concurrent_threads=0;
+   if (m_config->gpgpu_local_mem_map) {
+      // Dnew = D*N + T%nTpC + nTpC*C
+      // N = nTpC*nCpS*nS (max concurent threads)
+      // C = nS*K + S (hw cta number per gpu)
+      // K = T/nTpC   (hw cta number per core)
+      // D = data index
+      // T = thread
+      // nTpC = number of threads per CTA
+      // nCpS = number of CTA per shader
+      // 
+      // for a given local memory address threads in a CTA map to contiguous addresses,
+      // then distribute across memory space by CTAs from successive shader cores first, 
+      // then by successive CTA in same shader core
+      thread_base = 4*(kernel_padded_threads_per_cta * (m_sid + num_shader * (tid / kernel_padded_threads_per_cta))
+                       + tid % kernel_padded_threads_per_cta); 
+      max_concurrent_threads = kernel_padded_threads_per_cta * kernel_max_cta_per_shader * num_shader;
+   } else {
+      // legacy mapping that maps the same address in the local memory space of all threads 
+      // to a single contiguous address region 
+      thread_base = 4*(m_config->n_thread_per_shader * m_sid + tid);
+      max_concurrent_threads = num_shader * m_config->n_thread_per_shader;
+   }
+   assert( thread_base < 4/*word size*/*max_concurrent_threads );
 
-// Returns numbers of addresses in translated_addrs, each addr points to a 4B
-// (32-bit) word
-unsigned shader_core_ctx::translate_local_memaddr(
-    address_type localaddr, unsigned tid, unsigned num_shader,
-    unsigned datasize, new_addr_type *translated_addrs) {
-  // During functional execution, each thread sees its own memory space for
-  // local memory, but these
-  // need to be mapped to a shared address space for timing simulation.  We do
-  // that mapping here.
+   // If requested datasize > 4B, split into multiple 4B accesses
+   // otherwise do one sub-4 byte memory access
+   unsigned num_accesses = 0;
 
-  address_type thread_base = 0;
-  unsigned max_concurrent_threads = 0;
-  if (m_config->gpgpu_local_mem_map) {
-    // Dnew = D*N + T%nTpC + nTpC*C
-    // N = nTpC*nCpS*nS (max concurent threads)
-    // C = nS*K + S (hw cta number per gpu)
-    // K = T/nTpC   (hw cta number per core)
-    // D = data index
-    // T = thread
-    // nTpC = number of threads per CTA
-    // nCpS = number of CTA per shader
-    //
-    // for a given local memory address threads in a CTA map to contiguous
-    // addresses,
-    // then distribute across memory space by CTAs from successive shader cores
-    // first,
-    // then by successive CTA in same shader core
-    thread_base =
-        4 * (kernel_padded_threads_per_cta *
-                 (m_sid + num_shader * (tid / kernel_padded_threads_per_cta)) +
-             tid % kernel_padded_threads_per_cta);
-    max_concurrent_threads =
-        kernel_padded_threads_per_cta * kernel_max_cta_per_shader * num_shader;
-  } else {
-    // legacy mapping that maps the same address in the local memory space of
-    // all threads
-    // to a single contiguous address region
-    thread_base = 4 * (m_config->n_thread_per_shader * m_sid + tid);
-    max_concurrent_threads = num_shader * m_config->n_thread_per_shader;
-  }
-  assert(thread_base < 4 /*word size*/ * max_concurrent_threads);
-
-  // If requested datasize > 4B, split into multiple 4B accesses
-  // otherwise do one sub-4 byte memory access
-  unsigned num_accesses = 0;
-
-  if (datasize >= 4) {
-    // >4B access, split into 4B chunks
-    assert(datasize % 4 == 0);  // Must be a multiple of 4B
-    num_accesses = datasize / 4;
-    assert(num_accesses <= MAX_ACCESSES_PER_INSN_PER_THREAD);  // max 32B
-    assert(localaddr % 4 == 0);  // Address must be 4B aligned - required if
-                                 // accessing 4B per request, otherwise access
-                                 // will overflow into next thread's space
-    for (unsigned i = 0; i < num_accesses; i++) {
-      address_type local_word = localaddr / 4 + i;
-      address_type linear_address = local_word * max_concurrent_threads * 4 +
-                                    thread_base + LOCAL_GENERIC_START;
-      translated_addrs[i] = linear_address;
-    }
-  } else {
-    // Sub-4B access, do only one access
-    assert(datasize > 0);
-    num_accesses = 1;
-    address_type local_word = localaddr / 4;
-    address_type local_word_offset = localaddr % 4;
-    assert((localaddr + datasize - 1) / 4 ==
-           local_word);  // Make sure access doesn't overflow into next 4B chunk
-    address_type linear_address = local_word * max_concurrent_threads * 4 +
-                                  local_word_offset + thread_base +
-                                  LOCAL_GENERIC_START;
-    translated_addrs[0] = linear_address;
-  }
-  return num_accesses;
+   if(datasize >= 4) {
+      // >4B access, split into 4B chunks
+      assert(datasize%4 == 0);   // Must be a multiple of 4B
+      num_accesses = datasize/4;
+      assert(num_accesses <= MAX_ACCESSES_PER_INSN_PER_THREAD); // max 32B
+      assert(localaddr%4 == 0); // Address must be 4B aligned - required if accessing 4B per request, otherwise access will overflow into next thread's space
+      for(unsigned i=0; i<num_accesses; i++) {
+          address_type local_word = localaddr/4 + i;
+          address_type linear_address = local_word*max_concurrent_threads*4 + thread_base + LOCAL_GENERIC_START;
+          translated_addrs[i] = linear_address;
+      }
+   } else {
+      // Sub-4B access, do only one access
+      assert(datasize > 0);
+      num_accesses = 1;
+      address_type local_word = localaddr/4;
+      address_type local_word_offset = localaddr%4;
+      assert( (localaddr+datasize-1)/4  == local_word ); // Make sure access doesn't overflow into next 4B chunk
+      address_type linear_address = local_word*max_concurrent_threads*4 + local_word_offset + thread_base + LOCAL_GENERIC_START;
+      translated_addrs[0] = linear_address;
+   }
+   return num_accesses;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
-int shader_core_ctx::test_res_bus(int latency) {
-  for (unsigned i = 0; i < num_result_bus; i++) {
-    if (!m_result_bus[i]->test(latency)) {
-      return i;
-    }
-  }
-  return -1;
+int shader_core_ctx::test_res_bus(int latency){
+	for(unsigned i=0; i<num_result_bus; i++){
+		if(!m_result_bus[i]->test(latency)){return i;}
+	}
+	return -1;
 }
 
-void shader_core_ctx::execute() {
-  for (unsigned i = 0; i < num_result_bus; i++) {
-    *(m_result_bus[i]) >>= 1;
-  }
-  for (unsigned n = 0; n < m_num_function_units; n++) {
-    unsigned multiplier = m_fu[n]->clock_multiplier();
-    for (unsigned c = 0; c < multiplier; c++) m_fu[n]->cycle();
-    m_fu[n]->active_lanes_in_pipeline();
-    enum pipeline_stage_name_t issue_port = m_issue_port[n];
-    register_set &issue_inst = m_pipeline_reg[issue_port];
-    warp_inst_t **ready_reg = issue_inst.get_ready();
-    if (issue_inst.has_ready() && m_fu[n]->can_issue(**ready_reg)) {
-      bool schedule_wb_now = !m_fu[n]->stallable();
-      int resbus = -1;
-      if (schedule_wb_now &&
-          (resbus = test_res_bus((*ready_reg)->latency)) != -1) {
-        assert((*ready_reg)->latency < MAX_ALU_LATENCY);
-        m_result_bus[resbus]->set((*ready_reg)->latency);
-        m_fu[n]->issue(issue_inst);
-      } else if (!schedule_wb_now) {
-        m_fu[n]->issue(issue_inst);
-      } else {
-        // stall issue (cannot reserve result bus)
-      }
+void shader_core_ctx::execute()
+{
+	for(unsigned i=0; i<num_result_bus; i++){
+		*(m_result_bus[i]) >>=1;
+	}
+    for( unsigned n=0; n < m_num_function_units; n++ ) {
+        unsigned multiplier = m_fu[n]->clock_multiplier();
+        for( unsigned c=0; c < multiplier; c++ ) 
+            m_fu[n]->cycle();
+        m_fu[n]->active_lanes_in_pipeline();
+        enum pipeline_stage_name_t issue_port = m_issue_port[n];
+        register_set& issue_inst = m_pipeline_reg[ issue_port ];
+        warp_inst_t** ready_reg = issue_inst.get_ready();
+        if( issue_inst.has_ready() && m_fu[n]->can_issue( **ready_reg ) ) {
+            bool schedule_wb_now = !m_fu[n]->stallable();
+            int resbus = -1;
+            if( schedule_wb_now && (resbus=test_res_bus( (*ready_reg)->latency ))!=-1 ) {
+                assert( (*ready_reg)->latency < MAX_ALU_LATENCY );
+                m_result_bus[resbus]->set( (*ready_reg)->latency );
+                m_fu[n]->issue( issue_inst );
+            } else if( !schedule_wb_now ) {
+                m_fu[n]->issue( issue_inst );
+            } else {
+                // stall issue (cannot reserve result bus)
+            }
+        }
     }
-  }
 }
 
-void ldst_unit::print_cache_stats(FILE *fp, unsigned &dl1_accesses,
-                                  unsigned &dl1_misses) {
-  if (m_L1D) {
-    m_L1D->print(fp, dl1_accesses, dl1_misses);
-  }
+void ldst_unit::print_cache_stats( FILE *fp, unsigned& dl1_accesses, unsigned& dl1_misses ) {
+   if( m_L1D ) {
+       m_L1D->print( fp, dl1_accesses, dl1_misses );
+   }
 }
 
 void ldst_unit::get_cache_stats(cache_stats &cs) {
-  // Adds stats to 'cs' from each cache
-  if (m_L1D) cs += m_L1D->get_stats();
-  if (m_L1C) cs += m_L1C->get_stats();
-  if (m_L1T) cs += m_L1T->get_stats();
+    // Adds stats to 'cs' from each cache
+    if(m_L1D)
+        cs += m_L1D->get_stats();
+    if(m_L1C)
+        cs += m_L1C->get_stats();
+    if(m_L1T)
+        cs += m_L1T->get_stats();
+
 }
 
-void ldst_unit::get_L1D_sub_stats(struct cache_sub_stats &css) const {
-  if (m_L1D) m_L1D->get_sub_stats(css);
+void ldst_unit::get_L1D_sub_stats(struct cache_sub_stats &css) const{
+    if(m_L1D)
+        m_L1D->get_sub_stats(css);
 }
-void ldst_unit::get_L1C_sub_stats(struct cache_sub_stats &css) const {
-  if (m_L1C) m_L1C->get_sub_stats(css);
+void ldst_unit::get_L1C_sub_stats(struct cache_sub_stats &css) const{
+    if(m_L1C)
+        m_L1C->get_sub_stats(css);
 }
-void ldst_unit::get_L1T_sub_stats(struct cache_sub_stats &css) const {
-  if (m_L1T) m_L1T->get_sub_stats(css);
+void ldst_unit::get_L1T_sub_stats(struct cache_sub_stats &css) const{
+    if(m_L1T)
+        m_L1T->get_sub_stats(css);
 }
 
-void shader_core_ctx::warp_inst_complete(const warp_inst_t &inst) {
-#if 0
+void shader_core_ctx::warp_inst_complete(const warp_inst_t &inst)
+{
+
+  #if 0
       printf("[warp_inst_complete] uid=%u core=%u warp=%u pc=%#x @ time=%llu issued@%llu\n",
              inst.get_uid(), m_sid, inst.warp_id(), inst.pc, gpu_tot_sim_cycle + gpu_sim_cycle, inst.get_issue_cycle());
-#endif
+  #endif
 
-  if (inst.op_pipe == SP__OP)
-    m_stats->m_num_sp_committed[m_sid]++;
-  else if (inst.op_pipe == SFU__OP)
-    m_stats->m_num_sfu_committed[m_sid]++;
-  else if (inst.op_pipe == MEM__OP)
-    m_stats->m_num_mem_committed[m_sid]++;
+  if(inst.op_pipe==SP__OP)
+	  m_stats->m_num_sp_committed[m_sid]++;
+  else if(inst.op_pipe==SFU__OP)
+	  m_stats->m_num_sfu_committed[m_sid]++;
+  else if(inst.op_pipe==MEM__OP)
+	  m_stats->m_num_mem_committed[m_sid]++;
 
-  if (m_config->gpgpu_clock_gated_lanes == false)
-    m_stats->m_num_sim_insn[m_sid] += m_config->warp_size;
+  if(m_config->gpgpu_clock_gated_lanes==false)
+	  m_stats->m_num_sim_insn[m_sid] += m_config->warp_size;
   else
-    m_stats->m_num_sim_insn[m_sid] += inst.active_count();
+	  m_stats->m_num_sim_insn[m_sid] += inst.active_count();
 
   m_stats->m_num_sim_winsn[m_sid]++;
   m_gpu->gpu_sim_insn += inst.active_count();
   inst.completed(m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle);
 }
 
-void shader_core_ctx::writeback() {
-  unsigned max_committed_thread_instructions =
-      m_config->warp_size *
-      (m_config->pipe_widths[EX_WB]);  // from the functional units
-  m_stats->m_pipeline_duty_cycle[m_sid] =
-      ((float)(m_stats->m_num_sim_insn[m_sid] -
-               m_stats->m_last_num_sim_insn[m_sid])) /
-      max_committed_thread_instructions;
+void shader_core_ctx::writeback()
+{
 
-  m_stats->m_last_num_sim_insn[m_sid] = m_stats->m_num_sim_insn[m_sid];
-  m_stats->m_last_num_sim_winsn[m_sid] = m_stats->m_num_sim_winsn[m_sid];
+	unsigned max_committed_thread_instructions=m_config->warp_size * (m_config->pipe_widths[EX_WB]); //from the functional units
+	m_stats->m_pipeline_duty_cycle[m_sid]=((float)(m_stats->m_num_sim_insn[m_sid]-m_stats->m_last_num_sim_insn[m_sid]))/max_committed_thread_instructions;
 
-  warp_inst_t **preg = m_pipeline_reg[EX_WB].get_ready();
-  warp_inst_t *pipe_reg = (preg == NULL) ? NULL : *preg;
-  while (preg and !pipe_reg->empty()) {
-    /*
-     * Right now, the writeback stage drains all waiting instructions
-     * assuming there are enough ports in the register file or the
-     * conflicts are resolved at issue.
-     */
-    /*
-     * The operand collector writeback can generally generate a stall
-     * However, here, the pipelines should be un-stallable. This is
-     * guaranteed because this is the first time the writeback function
-     * is called after the operand collector's step function, which
-     * resets the allocations. There is one case which could result in
-     * the writeback function returning false (stall), which is when
-     * an instruction tries to modify two registers (GPR and predicate)
-     * To handle this case, we ignore the return value (thus allowing
-     * no stalling).
-     */
+    m_stats->m_last_num_sim_insn[m_sid]=m_stats->m_num_sim_insn[m_sid];
+    m_stats->m_last_num_sim_winsn[m_sid]=m_stats->m_num_sim_winsn[m_sid];
 
-    m_operand_collector.writeback(*pipe_reg);
-    unsigned warp_id = pipe_reg->warp_id();
-    m_scoreboard->releaseRegisters(pipe_reg);
-    m_warp[warp_id].dec_inst_in_pipeline();
-    warp_inst_complete(*pipe_reg);
-    m_gpu->gpu_sim_insn_last_update_sid = m_sid;
-    m_gpu->gpu_sim_insn_last_update = m_gpu->gpu_sim_cycle;
-    m_last_inst_gpu_sim_cycle = m_gpu->gpu_sim_cycle;
-    m_last_inst_gpu_tot_sim_cycle = m_gpu->gpu_tot_sim_cycle;
-    pipe_reg->clear();
-    preg = m_pipeline_reg[EX_WB].get_ready();
-    pipe_reg = (preg == NULL) ? NULL : *preg;
-  }
-}
+    warp_inst_t** preg = m_pipeline_reg[EX_WB].get_ready();
+    warp_inst_t* pipe_reg = (preg==NULL)? NULL:*preg;
+    while( preg and !pipe_reg->empty()) {
+    	/*
+    	 * Right now, the writeback stage drains all waiting instructions
+    	 * assuming there are enough ports in the register file or the
+    	 * conflicts are resolved at issue.
+    	 */
+    	/*
+    	 * The operand collector writeback can generally generate a stall
+    	 * However, here, the pipelines should be un-stallable. This is
+    	 * guaranteed because this is the first time the writeback function
+    	 * is called after the operand collector's step function, which
+    	 * resets the allocations. There is one case which could result in
+    	 * the writeback function returning false (stall), which is when
+    	 * an instruction tries to modify two registers (GPR and predicate)
+    	 * To handle this case, we ignore the return value (thus allowing
+    	 * no stalling).
+    	 */
 
-bool ldst_unit::shared_cycle(warp_inst_t &inst, mem_stage_stall_type &rc_fail,
-                             mem_stage_access_type &fail_type) {
-  if (inst.space.get_type() != shared_space) return true;
-
-  if (inst.has_dispatch_delay()) {
-    m_stats->gpgpu_n_shmem_bank_access[m_sid]++;
-  }
-
-  bool stall = inst.dispatch_delay();
-  if (stall) {
-    fail_type = S_MEM;
-    rc_fail = BK_CONF;
-  } else
-    rc_fail = NO_RC_FAIL;
-  return !stall;
-}
-
-mem_stage_stall_type ldst_unit::process_cache_access(
-    cache_t *cache, new_addr_type address, warp_inst_t &inst,
-    std::list<cache_event> &events, mem_fetch *mf,
-    enum cache_request_status status) {
-  mem_stage_stall_type result = NO_RC_FAIL;
-  bool write_sent = was_write_sent(events);
-  bool read_sent = was_read_sent(events);
-  if (write_sent) {
-    unsigned inc_ack = (m_config->m_L1D_config.get_mshr_type() == SECTOR_ASSOC)
-                           ? (mf->get_data_size() / SECTOR_SIZE)
-                           : 1;
-
-    for (unsigned i = 0; i < inc_ack; ++i)
-      m_core->inc_store_req(inst.warp_id());
-  }
-  if (status == HIT) {
-    assert(!read_sent);
-    inst.accessq_pop_back();
-    if (inst.is_load()) {
-      for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++)
-        if (inst.out[r] > 0) m_pending_writes[inst.warp_id()][inst.out[r]]--;
+        m_operand_collector.writeback(*pipe_reg);
+        unsigned warp_id = pipe_reg->warp_id();
+        m_scoreboard->releaseRegisters( pipe_reg );
+        m_warp[warp_id].dec_inst_in_pipeline();
+        warp_inst_complete(*pipe_reg);
+        m_gpu->gpu_sim_insn_last_update_sid = m_sid;
+        m_gpu->gpu_sim_insn_last_update = m_gpu->gpu_sim_cycle;
+        m_last_inst_gpu_sim_cycle = m_gpu->gpu_sim_cycle;
+        m_last_inst_gpu_tot_sim_cycle = m_gpu->gpu_tot_sim_cycle;
+        pipe_reg->clear();
+        preg = m_pipeline_reg[EX_WB].get_ready();
+        pipe_reg = (preg==NULL)? NULL:*preg;
     }
-    if (!write_sent) delete mf;
-  } else if (status == RESERVATION_FAIL) {
-    result = BK_CONF;
-    assert(!read_sent);
-    assert(!write_sent);
-    delete mf;
-  } else {
-    assert(status == MISS || status == HIT_RESERVED);
-    // inst.clear_active( access.get_warp_mask() ); // threads in mf writeback
-    // when mf returns
-    inst.accessq_pop_back();
-  }
-  if (!inst.accessq_empty() && result == NO_RC_FAIL) result = COAL_STALL;
-  return result;
 }
 
-mem_stage_stall_type ldst_unit::process_memory_access_queue(cache_t *cache,
-                                                            warp_inst_t &inst) {
-  mem_stage_stall_type result = NO_RC_FAIL;
-  if (inst.accessq_empty()) return result;
+bool ldst_unit::shared_cycle( warp_inst_t &inst, mem_stage_stall_type &rc_fail, mem_stage_access_type &fail_type)
+{
+   if( inst.space.get_type() != shared_space )
+       return true;
 
-  if (!cache->data_port_free()) return DATA_PORT_STALL;
+   if(inst.has_dispatch_delay()){
+	   m_stats->gpgpu_n_shmem_bank_access[m_sid]++;
+   }
 
-  // const mem_access_t &access = inst.accessq_back();
-  mem_fetch *mf = m_mf_allocator->alloc(
-      inst, inst.accessq_back(),
-      m_core->get_gpu()->gpu_sim_cycle + m_core->get_gpu()->gpu_tot_sim_cycle);
-  std::list<cache_event> events;
-  enum cache_request_status status = cache->access(
-      mf->get_addr(), mf,
-      m_core->get_gpu()->gpu_sim_cycle + m_core->get_gpu()->gpu_tot_sim_cycle,
-      events);
-  return process_cache_access(cache, mf->get_addr(), inst, events, mf, status);
+   bool stall = inst.dispatch_delay();
+   if( stall ) {
+       fail_type = S_MEM;
+       rc_fail = BK_CONF;
+   } else 
+       rc_fail = NO_RC_FAIL;
+   return !stall; 
 }
 
-mem_stage_stall_type ldst_unit::process_memory_access_queue_l1cache(
-    l1_cache *cache, warp_inst_t &inst) {
-  mem_stage_stall_type result = NO_RC_FAIL;
-  if (inst.accessq_empty()) return result;
+mem_stage_stall_type
+ldst_unit::process_cache_access( cache_t* cache,
+                                 new_addr_type address,
+                                 warp_inst_t &inst,
+                                 std::list<cache_event>& events,
+                                 mem_fetch *mf,
+                                 enum cache_request_status status )
+{
+    mem_stage_stall_type result = NO_RC_FAIL;
+    bool write_sent = was_write_sent(events);
+    bool read_sent = was_read_sent(events);
+    if( write_sent ) {
+    	unsigned inc_ack = (m_config->m_L1D_config.get_mshr_type() == SECTOR_ASSOC)?
+    			(mf->get_data_size()/SECTOR_SIZE) : 1;
 
-  if (m_config->m_L1D_config.l1_latency > 0) {
-    for (int j = 0; j < m_config->m_L1D_config.l1_banks;
-         j++) {  // We can handle at max l1_banks reqs per cycle
+		for(unsigned i=0; i< inc_ack; ++i)
+			m_core->inc_store_req( inst.warp_id() );
 
-      if (inst.accessq_empty()) return result;
-
-      mem_fetch *mf = m_mf_allocator->alloc(
-          inst, inst.accessq_back(), m_core->get_gpu()->gpu_sim_cycle +
-                                         m_core->get_gpu()->gpu_tot_sim_cycle);
-      unsigned bank_id = m_config->m_L1D_config.set_bank(mf->get_addr());
-      assert(bank_id < m_config->m_L1D_config.l1_banks);
-
-      if ((l1_latency_queue[bank_id][m_config->m_L1D_config.l1_latency - 1]) ==
-          NULL) {
-        l1_latency_queue[bank_id][m_config->m_L1D_config.l1_latency - 1] = mf;
-
-        if (mf->get_inst().is_store()) {
-          unsigned inc_ack =
-              (m_config->m_L1D_config.get_mshr_type() == SECTOR_ASSOC)
-                  ? (mf->get_data_size() / SECTOR_SIZE)
-                  : 1;
-
-          for (unsigned i = 0; i < inc_ack; ++i)
-            m_core->inc_store_req(inst.warp_id());
-        }
-
+    }
+    if ( status == HIT ) {
+        assert( !read_sent );
         inst.accessq_pop_back();
-      } else {
+        if ( inst.is_load() ) {
+            for ( unsigned r=0; r < MAX_OUTPUT_VALUES; r++)
+                if (inst.out[r] > 0)
+                    m_pending_writes[inst.warp_id()][inst.out[r]]--; 
+        }
+        if( !write_sent ) 
+            delete mf;
+    } else if ( status == RESERVATION_FAIL ) {
         result = BK_CONF;
+        assert( !read_sent );
+        assert( !write_sent );
         delete mf;
-        break;  // do not try again, just break from the loop and try the next
-                // cycle
-      }
-    }
-    if (!inst.accessq_empty() && result != BK_CONF) result = COAL_STALL;
-
-    return result;
-  } else {
-    mem_fetch *mf = m_mf_allocator->alloc(
-        inst, inst.accessq_back(), m_core->get_gpu()->gpu_sim_cycle +
-                                       m_core->get_gpu()->gpu_tot_sim_cycle);
-    std::list<cache_event> events;
-    enum cache_request_status status = cache->access(
-        mf->get_addr(), mf,
-        m_core->get_gpu()->gpu_sim_cycle + m_core->get_gpu()->gpu_tot_sim_cycle,
-        events);
-    return process_cache_access(cache, mf->get_addr(), inst, events, mf,
-                                status);
-  }
-}
-
-void ldst_unit::L1_latency_queue_cycle() {
-  for (int j = 0; j < m_config->m_L1D_config.l1_banks; j++) {
-    if ((l1_latency_queue[j][0]) != NULL) {
-      mem_fetch *mf_next = l1_latency_queue[j][0];
-      std::list<cache_event> events;
-      enum cache_request_status status =
-          m_L1D->access(mf_next->get_addr(), mf_next,
-                        m_core->get_gpu()->gpu_sim_cycle +
-                            m_core->get_gpu()->gpu_tot_sim_cycle,
-                        events);
-
-      bool write_sent = was_write_sent(events);
-      bool read_sent = was_read_sent(events);
-
-      if (status == HIT) {
-        assert(!read_sent);
-        l1_latency_queue[j][0] = NULL;
-        if (mf_next->get_inst().is_load()) {
-          for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++)
-            if (mf_next->get_inst().out[r] > 0) {
-              assert(m_pending_writes[mf_next->get_inst().warp_id()]
-                                     [mf_next->get_inst().out[r]] > 0);
-              unsigned still_pending =
-                  --m_pending_writes[mf_next->get_inst().warp_id()]
-                                    [mf_next->get_inst().out[r]];
-              if (!still_pending) {
-                m_pending_writes[mf_next->get_inst().warp_id()].erase(
-                    mf_next->get_inst().out[r]);
-                m_scoreboard->releaseRegister(mf_next->get_inst().warp_id(),
-                                              mf_next->get_inst().out[r]);
-                m_core->warp_inst_complete(mf_next->get_inst());
-              }
-            }
-        }
-
-        // For write hit in WB policy
-        if (mf_next->get_inst().is_store() && !write_sent) {
-          unsigned dec_ack =
-              (m_config->m_L1D_config.get_mshr_type() == SECTOR_ASSOC)
-                  ? (mf_next->get_data_size() / SECTOR_SIZE)
-                  : 1;
-
-          mf_next->set_reply();
-
-          for (unsigned i = 0; i < dec_ack; ++i) m_core->store_ack(mf_next);
-        }
-
-        if (!write_sent) delete mf_next;
-
-      } else if (status == RESERVATION_FAIL) {
-        assert(!read_sent);
-        assert(!write_sent);
-      } else {
-        assert(status == MISS || status == HIT_RESERVED);
-        l1_latency_queue[j][0] = NULL;
-      }
-    }
-
-    for (unsigned stage = 0; stage < m_config->m_L1D_config.l1_latency - 1;
-         ++stage)
-      if (l1_latency_queue[j][stage] == NULL) {
-        l1_latency_queue[j][stage] = l1_latency_queue[j][stage + 1];
-        l1_latency_queue[j][stage + 1] = NULL;
-      }
-  }
-}
-
-bool ldst_unit::constant_cycle(warp_inst_t &inst, mem_stage_stall_type &rc_fail,
-                               mem_stage_access_type &fail_type) {
-  if (inst.empty() || ((inst.space.get_type() != const_space) &&
-                       (inst.space.get_type() != param_space_kernel)))
-    return true;
-  if (inst.active_count() == 0) return true;
-  mem_stage_stall_type fail = process_memory_access_queue(m_L1C, inst);
-  if (fail != NO_RC_FAIL) {
-    rc_fail = fail;  // keep other fails if this didn't fail.
-    fail_type = C_MEM;
-    if (rc_fail == BK_CONF or rc_fail == COAL_STALL) {
-      m_stats->gpgpu_n_cmem_portconflict++;  // coal stalls aren't really a bank
-                                             // conflict, but this maintains
-                                             // previous behavior.
-    }
-  }
-  return inst.accessq_empty();  // done if empty.
-}
-
-bool ldst_unit::texture_cycle(warp_inst_t &inst, mem_stage_stall_type &rc_fail,
-                              mem_stage_access_type &fail_type) {
-  if (inst.empty() || inst.space.get_type() != tex_space) return true;
-  if (inst.active_count() == 0) return true;
-  mem_stage_stall_type fail = process_memory_access_queue(m_L1T, inst);
-  if (fail != NO_RC_FAIL) {
-    rc_fail = fail;  // keep other fails if this didn't fail.
-    fail_type = T_MEM;
-  }
-  return inst.accessq_empty();  // done if empty.
-}
-
-bool ldst_unit::memory_cycle(warp_inst_t &inst,
-                             mem_stage_stall_type &stall_reason,
-                             mem_stage_access_type &access_type) {
-  if (inst.empty() || ((inst.space.get_type() != global_space) &&
-                       (inst.space.get_type() != local_space) &&
-                       (inst.space.get_type() != param_space_local)))
-    return true;
-  if (inst.active_count() == 0) return true;
-  assert(!inst.accessq_empty());
-  mem_stage_stall_type stall_cond = NO_RC_FAIL;
-  const mem_access_t &access = inst.accessq_back();
-
-  bool bypassL1D = false;
-  if (CACHE_GLOBAL == inst.cache_op || (m_L1D == NULL)) {
-    bypassL1D = true;
-  } else if (inst.space.is_global()) {  // global memory access
-    // skip L1 cache if the option is enabled
-    if (m_core->get_config()->gmem_skip_L1D && (CACHE_L1 != inst.cache_op))
-      bypassL1D = true;
-  }
-  if (bypassL1D) {
-    // bypass L1 cache
-    unsigned control_size =
-        inst.is_store() ? WRITE_PACKET_SIZE : READ_PACKET_SIZE;
-    unsigned size = access.get_size() + control_size;
-    // printf("Interconnect:Addr: %x, size=%d\n",access.get_addr(),size);
-    if (m_icnt->full(size, inst.is_store() || inst.isatomic())) {
-      stall_cond = ICNT_RC_FAIL;
     } else {
-      mem_fetch *mf = m_mf_allocator->alloc(
-          inst, access, m_core->get_gpu()->gpu_sim_cycle +
-                            m_core->get_gpu()->gpu_tot_sim_cycle);
-      m_icnt->push(mf);
-      inst.accessq_pop_back();
-      // inst.clear_active( access.get_warp_mask() );
-      if (inst.is_load()) {
-        for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++)
-          if (inst.out[r] > 0)
-            assert(m_pending_writes[inst.warp_id()][inst.out[r]] > 0);
-      } else if (inst.is_store())
-        m_core->inc_store_req(inst.warp_id());
+        assert( status == MISS || status == HIT_RESERVED );
+        //inst.clear_active( access.get_warp_mask() ); // threads in mf writeback when mf returns
+        inst.accessq_pop_back();
     }
-  } else {
-    assert(CACHE_UNDEFINED != inst.cache_op);
-    stall_cond = process_memory_access_queue_l1cache(m_L1D, inst);
-  }
-  if (!inst.accessq_empty() && stall_cond == NO_RC_FAIL)
-    stall_cond = COAL_STALL;
-  if (stall_cond != NO_RC_FAIL) {
-    stall_reason = stall_cond;
-    bool iswrite = inst.is_store();
-    if (inst.space.is_local())
-      access_type = (iswrite) ? L_MEM_ST : L_MEM_LD;
+    if( !inst.accessq_empty() && result == NO_RC_FAIL)
+        result = COAL_STALL;
+    return result;
+}
+
+mem_stage_stall_type ldst_unit::process_memory_access_queue( cache_t *cache, warp_inst_t &inst )
+{
+    mem_stage_stall_type result = NO_RC_FAIL;
+    if( inst.accessq_empty() )
+        return result;
+
+    if( !cache->data_port_free() ) 
+        return DATA_PORT_STALL; 
+
+    //const mem_access_t &access = inst.accessq_back();
+    mem_fetch *mf = m_mf_allocator->alloc(inst,inst.accessq_back(),m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
+    std::list<cache_event> events;
+    enum cache_request_status status = cache->access(mf->get_addr(),mf,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle,events);
+    return process_cache_access( cache, mf->get_addr(), inst, events, mf, status );
+}
+
+mem_stage_stall_type ldst_unit::process_memory_access_queue_l1cache( l1_cache *cache, warp_inst_t &inst )
+{
+    mem_stage_stall_type result = NO_RC_FAIL;
+    if( inst.accessq_empty() )
+        return result;
+
+    if(m_config->m_L1D_config.l1_latency > 0)
+	{
+    	for(int j=0; j<m_config->m_L1D_config.l1_banks; j++) {  //We can handle at max l1_banks reqs per cycle
+
+    		if( inst.accessq_empty() )
+    		        return result;
+
+    	    mem_fetch *mf = m_mf_allocator->alloc(inst,inst.accessq_back(),m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
+    	    unsigned bank_id = m_config->m_L1D_config.set_bank(mf->get_addr());
+    	    assert(bank_id < m_config->m_L1D_config.l1_banks);
+
+			if((l1_latency_queue[bank_id][m_config->m_L1D_config.l1_latency-1]) == NULL)
+			{
+				l1_latency_queue[bank_id][m_config->m_L1D_config.l1_latency-1] = mf;
+
+				if( mf->get_inst().is_store() ) {
+					unsigned inc_ack = (m_config->m_L1D_config.get_mshr_type() == SECTOR_ASSOC)?
+							(mf->get_data_size()/SECTOR_SIZE) : 1;
+
+					for(unsigned i=0; i< inc_ack; ++i)
+						m_core->inc_store_req( inst.warp_id() );
+				}
+
+				inst.accessq_pop_back();
+			}
+			else
+			{
+				result = BK_CONF;
+				delete mf;
+				break;   //do not try again, just break from the loop and try the next cycle
+			}
+    	}
+		if( !inst.accessq_empty() &&  result !=BK_CONF)
+		   result = COAL_STALL;
+
+	     return result;
+	}
     else
-      access_type = (iswrite) ? G_MEM_ST : G_MEM_LD;
-  }
-  return inst.accessq_empty();
-}
-
-bool ldst_unit::response_buffer_full() const {
-  return m_response_fifo.size() >= m_config->ldst_unit_response_queue_size;
-}
-
-void ldst_unit::fill(mem_fetch *mf) {
-  mf->set_status(
-      IN_SHADER_LDST_RESPONSE_FIFO,
-      m_core->get_gpu()->gpu_sim_cycle + m_core->get_gpu()->gpu_tot_sim_cycle);
-  m_response_fifo.push_back(mf);
-}
-
-void ldst_unit::flush() {
-  // Flush L1D cache
-  m_L1D->flush();
-}
-
-void ldst_unit::invalidate() {
-  // Flush L1D cache
-  m_L1D->invalidate();
-}
-
-simd_function_unit::simd_function_unit(const shader_core_config *config) {
-  m_config = config;
-  m_dispatch_reg = new warp_inst_t(config);
-}
-
-sfu::sfu(register_set *result_port, const shader_core_config *config,
-         shader_core_ctx *core)
-    : pipelined_simd_unit(result_port, config, config->max_sfu_latency, core) {
-  m_name = "SFU";
-}
-
-tensor_core::tensor_core(register_set *result_port,
-                         const shader_core_config *config,
-                         shader_core_ctx *core)
-    : pipelined_simd_unit(result_port, config, config->max_tensor_core_latency,
-                          core) {
-  m_name = "TENSOR_CORE";
-}
-
-void sfu::issue(register_set &source_reg) {
-  warp_inst_t **ready_reg = source_reg.get_ready();
-  // m_core->incexecstat((*ready_reg));
-
-  (*ready_reg)->op_pipe = SFU__OP;
-  m_core->incsfu_stat(m_core->get_config()->warp_size, (*ready_reg)->latency);
-  pipelined_simd_unit::issue(source_reg);
-}
-
-void tensor_core::issue(register_set &source_reg) {
-  warp_inst_t **ready_reg = source_reg.get_ready();
-  // m_core->incexecstat((*ready_reg));
-
-  (*ready_reg)->op_pipe = TENSOR_CORE__OP;
-  m_core->incsfu_stat(m_core->get_config()->warp_size, (*ready_reg)->latency);
-  pipelined_simd_unit::issue(source_reg);
-}
-
-unsigned pipelined_simd_unit::get_active_lanes_in_pipeline() {
-  active_mask_t active_lanes;
-  active_lanes.reset();
-  if (m_core->get_gpu()->get_config().g_power_simulation_enabled) {
-    for (unsigned stage = 0; (stage + 1) < m_pipeline_depth; stage++) {
-      if (!m_pipeline_reg[stage]->empty())
-        active_lanes |= m_pipeline_reg[stage]->get_active_mask();
+    {
+	    mem_fetch *mf = m_mf_allocator->alloc(inst,inst.accessq_back(),m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
+		std::list<cache_event> events;
+		enum cache_request_status status = cache->access(mf->get_addr(),mf,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle,events);
+		return process_cache_access( cache, mf->get_addr(), inst, events, mf, status );
     }
-  }
-  return active_lanes.count();
 }
 
-void ldst_unit::active_lanes_in_pipeline() {
-  unsigned active_count = pipelined_simd_unit::get_active_lanes_in_pipeline();
-  assert(active_count <= m_core->get_config()->warp_size);
-  m_core->incfumemactivelanes_stat(active_count);
+void ldst_unit::L1_latency_queue_cycle()
+{
+	for(int j=0; j<m_config->m_L1D_config.l1_banks; j++) {
+		if((l1_latency_queue[j][0]) != NULL)
+		{
+				mem_fetch* mf_next = l1_latency_queue[j][0];
+				std::list<cache_event> events;
+				enum cache_request_status status = m_L1D->access(mf_next->get_addr(),mf_next,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle,events);
+
+			   bool write_sent = was_write_sent(events);
+			   bool read_sent = was_read_sent(events);
+
+			   if ( status == HIT ) {
+				   assert( !read_sent );
+				   l1_latency_queue[j][0] = NULL;
+				   if ( mf_next->get_inst().is_load() ) {
+					   for ( unsigned r=0; r < MAX_OUTPUT_VALUES; r++)
+						   if (mf_next->get_inst().out[r] > 0)
+						   {
+							   assert(m_pending_writes[mf_next->get_inst().warp_id()][mf_next->get_inst().out[r]]>0);
+							   unsigned still_pending = --m_pending_writes[mf_next->get_inst().warp_id()][mf_next->get_inst().out[r]];
+							   if(!still_pending)
+							   {
+								m_pending_writes[mf_next->get_inst().warp_id()].erase(mf_next->get_inst().out[r]);
+								m_scoreboard->releaseRegister(mf_next->get_inst().warp_id(),mf_next->get_inst().out[r]);
+								m_core->warp_inst_complete(mf_next->get_inst());
+							   }
+						   }
+				   }
+
+				   //For write hit in WB policy
+				   if(mf_next->get_inst().is_store() && !write_sent)
+				   {
+					   unsigned dec_ack = (m_config->m_L1D_config.get_mshr_type() == SECTOR_ASSOC)?
+											(mf_next->get_data_size()/SECTOR_SIZE) : 1;
+
+					   mf_next->set_reply();
+
+					   for(unsigned i=0; i< dec_ack; ++i)
+						  m_core->store_ack(mf_next);
+				   }
+
+				   if( !write_sent )
+					   delete mf_next;
+
+			   } else if ( status == RESERVATION_FAIL ) {
+				   assert( !read_sent );
+				   assert( !write_sent );
+			   } else {
+				   assert( status == MISS || status == HIT_RESERVED );
+				   l1_latency_queue[j][0] = NULL;
+		   }
+		}
+
+		 for( unsigned stage = 0; stage<m_config->m_L1D_config.l1_latency-1; ++stage)
+		  if( l1_latency_queue[j][stage] == NULL) {
+			   l1_latency_queue[j][stage] = l1_latency_queue[j][stage+1] ;
+			   l1_latency_queue[j][stage+1] = NULL;
+		   }
+	}
+
 }
 
-void sp_unit::active_lanes_in_pipeline() {
-  unsigned active_count = pipelined_simd_unit::get_active_lanes_in_pipeline();
-  assert(active_count <= m_core->get_config()->warp_size);
-  m_core->incspactivelanes_stat(active_count);
-  m_core->incfuactivelanes_stat(active_count);
-  m_core->incfumemactivelanes_stat(active_count);
-}
-void dp_unit::active_lanes_in_pipeline() {
-  unsigned active_count = pipelined_simd_unit::get_active_lanes_in_pipeline();
-  assert(active_count <= m_core->get_config()->warp_size);
-  m_core->incspactivelanes_stat(active_count);
-  m_core->incfuactivelanes_stat(active_count);
-  m_core->incfumemactivelanes_stat(active_count);
+
+
+bool ldst_unit::constant_cycle( warp_inst_t &inst, mem_stage_stall_type &rc_fail, mem_stage_access_type &fail_type)
+{
+   if( inst.empty() || ((inst.space.get_type() != const_space) && (inst.space.get_type() != param_space_kernel)) )
+       return true;
+   if( inst.active_count() == 0 ) 
+       return true;
+   mem_stage_stall_type fail = process_memory_access_queue(m_L1C,inst);
+   if (fail != NO_RC_FAIL){ 
+      rc_fail = fail; //keep other fails if this didn't fail.
+      fail_type = C_MEM;
+      if (rc_fail == BK_CONF or rc_fail == COAL_STALL) {
+         m_stats->gpgpu_n_cmem_portconflict++; //coal stalls aren't really a bank conflict, but this maintains previous behavior.
+      }
+   }
+   return inst.accessq_empty(); //done if empty.
 }
 
-void int_unit::active_lanes_in_pipeline() {
-  unsigned active_count = pipelined_simd_unit::get_active_lanes_in_pipeline();
-  assert(active_count <= m_core->get_config()->warp_size);
-  m_core->incspactivelanes_stat(active_count);
-  m_core->incfuactivelanes_stat(active_count);
-  m_core->incfumemactivelanes_stat(active_count);
-}
-void sfu::active_lanes_in_pipeline() {
-  unsigned active_count = pipelined_simd_unit::get_active_lanes_in_pipeline();
-  assert(active_count <= m_core->get_config()->warp_size);
-  m_core->incsfuactivelanes_stat(active_count);
-  m_core->incfuactivelanes_stat(active_count);
-  m_core->incfumemactivelanes_stat(active_count);
-}
-
-void tensor_core::active_lanes_in_pipeline() {
-  unsigned active_count = pipelined_simd_unit::get_active_lanes_in_pipeline();
-  assert(active_count <= m_core->get_config()->warp_size);
-  m_core->incsfuactivelanes_stat(active_count);
-  m_core->incfuactivelanes_stat(active_count);
-  m_core->incfumemactivelanes_stat(active_count);
+bool ldst_unit::texture_cycle( warp_inst_t &inst, mem_stage_stall_type &rc_fail, mem_stage_access_type &fail_type)
+{
+   if( inst.empty() || inst.space.get_type() != tex_space )
+       return true;
+   if( inst.active_count() == 0 ) 
+       return true;
+   mem_stage_stall_type fail = process_memory_access_queue(m_L1T,inst);
+   if (fail != NO_RC_FAIL){ 
+      rc_fail = fail; //keep other fails if this didn't fail.
+      fail_type = T_MEM;
+   }
+   return inst.accessq_empty(); //done if empty.
 }
 
-sp_unit::sp_unit(register_set *result_port, const shader_core_config *config,
-                 shader_core_ctx *core)
-    : pipelined_simd_unit(result_port, config, config->max_sp_latency, core) {
-  m_name = "SP ";
+bool ldst_unit::memory_cycle( warp_inst_t &inst, mem_stage_stall_type &stall_reason, mem_stage_access_type &access_type )
+{
+   if( inst.empty() || 
+       ((inst.space.get_type() != global_space) &&
+        (inst.space.get_type() != local_space) &&
+        (inst.space.get_type() != param_space_local)) ) 
+       return true;
+   if( inst.active_count() == 0 ) 
+       return true;
+   assert( !inst.accessq_empty() );
+   mem_stage_stall_type stall_cond = NO_RC_FAIL;
+   const mem_access_t &access = inst.accessq_back();
+
+   bool bypassL1D = false; 
+   if ( CACHE_GLOBAL == inst.cache_op || (m_L1D == NULL) ) {
+       bypassL1D = true; 
+   } else if (inst.space.is_global()) { // global memory access 
+       // skip L1 cache if the option is enabled
+       if (m_core->get_config()->gmem_skip_L1D && (CACHE_L1 != inst.cache_op))
+           bypassL1D = true; 
+   }
+   if( bypassL1D ) {
+       // bypass L1 cache
+       unsigned control_size = inst.is_store() ? WRITE_PACKET_SIZE : READ_PACKET_SIZE;
+       unsigned size = access.get_size() + control_size;
+       //printf("Interconnect:Addr: %x, size=%d\n",access.get_addr(),size);
+       if( m_icnt->full(size, inst.is_store() || inst.isatomic()) ) {
+           stall_cond = ICNT_RC_FAIL;
+       } else {
+           mem_fetch *mf = m_mf_allocator->alloc(inst,access,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
+           m_icnt->push(mf);
+           inst.accessq_pop_back();
+           //inst.clear_active( access.get_warp_mask() );
+           if( inst.is_load() ) { 
+              for( unsigned r=0; r < MAX_OUTPUT_VALUES; r++) 
+                  if(inst.out[r] > 0) 
+                      assert( m_pending_writes[inst.warp_id()][inst.out[r]] > 0 );
+           } else if( inst.is_store() ) 
+              m_core->inc_store_req( inst.warp_id() );
+       }
+   } else {
+       assert( CACHE_UNDEFINED != inst.cache_op );
+       stall_cond = process_memory_access_queue_l1cache(m_L1D,inst);
+   }
+   if( !inst.accessq_empty() && stall_cond == NO_RC_FAIL)
+       stall_cond = COAL_STALL;
+   if (stall_cond != NO_RC_FAIL) {
+      stall_reason = stall_cond;
+      bool iswrite = inst.is_store();
+      if (inst.space.is_local()) 
+         access_type = (iswrite)?L_MEM_ST:L_MEM_LD;
+      else 
+         access_type = (iswrite)?G_MEM_ST:G_MEM_LD;
+   }
+   return inst.accessq_empty(); 
 }
 
-dp_unit::dp_unit(register_set *result_port, const shader_core_config *config,
-                 shader_core_ctx *core)
-    : pipelined_simd_unit(result_port, config, config->max_dp_latency, core) {
-  m_name = "DP ";
+
+bool ldst_unit::response_buffer_full() const
+{
+    return m_response_fifo.size() >= m_config->ldst_unit_response_queue_size;
 }
 
-int_unit::int_unit(register_set *result_port, const shader_core_config *config,
-                   shader_core_ctx *core)
-    : pipelined_simd_unit(result_port, config, config->max_int_latency, core) {
-  m_name = "INT ";
+void ldst_unit::fill( mem_fetch *mf )
+{
+    mf->set_status(IN_SHADER_LDST_RESPONSE_FIFO,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
+    m_response_fifo.push_back(mf);
 }
 
-void sp_unit::issue(register_set &source_reg) {
-  warp_inst_t **ready_reg = source_reg.get_ready();
-  // m_core->incexecstat((*ready_reg));
-  (*ready_reg)->op_pipe = SP__OP;
-  m_core->incsp_stat(m_core->get_config()->warp_size, (*ready_reg)->latency);
-  pipelined_simd_unit::issue(source_reg);
+void ldst_unit::flush(){
+	// Flush L1D cache
+	m_L1D->flush();
 }
 
-void dp_unit::issue(register_set &source_reg) {
-  warp_inst_t **ready_reg = source_reg.get_ready();
-  // m_core->incexecstat((*ready_reg));
-  (*ready_reg)->op_pipe = DP__OP;
-  m_core->incsp_stat(m_core->get_config()->warp_size, (*ready_reg)->latency);
-  pipelined_simd_unit::issue(source_reg);
+void ldst_unit::invalidate(){
+	// Flush L1D cache
+	m_L1D->invalidate();
 }
 
-void int_unit::issue(register_set &source_reg) {
-  warp_inst_t **ready_reg = source_reg.get_ready();
-  // m_core->incexecstat((*ready_reg));
-  (*ready_reg)->op_pipe = INTP__OP;
-  m_core->incsp_stat(m_core->get_config()->warp_size, (*ready_reg)->latency);
-  pipelined_simd_unit::issue(source_reg);
+simd_function_unit::simd_function_unit( const shader_core_config *config )
+{ 
+    m_config=config;
+    m_dispatch_reg = new warp_inst_t(config); 
 }
 
-pipelined_simd_unit::pipelined_simd_unit(register_set *result_port,
-                                         const shader_core_config *config,
-                                         unsigned max_latency,
-                                         shader_core_ctx *core)
-    : simd_function_unit(config) {
-  m_result_port = result_port;
-  m_pipeline_depth = max_latency;
-  m_pipeline_reg = new warp_inst_t *[m_pipeline_depth];
-  for (unsigned i = 0; i < m_pipeline_depth; i++)
-    m_pipeline_reg[i] = new warp_inst_t(config);
-  m_core = core;
-  active_insts_in_pipeline = 0;
+
+sfu:: sfu(  register_set* result_port, const shader_core_config *config,shader_core_ctx *core  )
+    : pipelined_simd_unit(result_port,config,config->max_sfu_latency,core)
+{ 
+    m_name = "SFU"; 
 }
 
-void pipelined_simd_unit::cycle() {
-  if (!m_pipeline_reg[0]->empty()) {
-    m_result_port->move_in(m_pipeline_reg[0]);
-    assert(active_insts_in_pipeline > 0);
-    active_insts_in_pipeline--;
-  }
-  if (active_insts_in_pipeline) {
-    for (unsigned stage = 0; (stage + 1) < m_pipeline_depth; stage++)
-      move_warp(m_pipeline_reg[stage], m_pipeline_reg[stage + 1]);
-  }
-  if (!m_dispatch_reg->empty()) {
-    if (!m_dispatch_reg->dispatch_delay()) {
-      int start_stage =
-          m_dispatch_reg->latency - m_dispatch_reg->initiation_interval;
-      move_warp(m_pipeline_reg[start_stage], m_dispatch_reg);
-      active_insts_in_pipeline++;
+tensor_core:: tensor_core(  register_set* result_port, const shader_core_config *config,shader_core_ctx *core  )
+    : pipelined_simd_unit(result_port,config,config->max_tensor_core_latency,core)
+{ 
+    m_name = "TENSOR_CORE"; 
+}
+
+void sfu::issue( register_set& source_reg )
+{
+    warp_inst_t** ready_reg = source_reg.get_ready();
+	//m_core->incexecstat((*ready_reg));
+
+	(*ready_reg)->op_pipe=SFU__OP;
+	m_core->incsfu_stat(m_core->get_config()->warp_size,(*ready_reg)->latency);
+	pipelined_simd_unit::issue(source_reg);
+}
+
+void tensor_core::issue( register_set& source_reg )
+{
+    warp_inst_t** ready_reg = source_reg.get_ready();
+	//m_core->incexecstat((*ready_reg));
+
+	(*ready_reg)->op_pipe= TENSOR_CORE__OP;
+	m_core->incsfu_stat(m_core->get_config()->warp_size,(*ready_reg)->latency);
+	pipelined_simd_unit::issue(source_reg);
+}
+
+unsigned pipelined_simd_unit::get_active_lanes_in_pipeline(){
+	active_mask_t active_lanes;
+	active_lanes.reset();
+	 if(m_core->get_gpu()->get_config().g_power_simulation_enabled){
+		for( unsigned stage=0; (stage+1)<m_pipeline_depth; stage++ ){
+			if( !m_pipeline_reg[stage]->empty() )
+				active_lanes|=m_pipeline_reg[stage]->get_active_mask();
+		}
+	 }
+	return active_lanes.count();
+}
+
+void ldst_unit::active_lanes_in_pipeline(){
+	unsigned active_count=pipelined_simd_unit::get_active_lanes_in_pipeline();
+	assert(active_count<=m_core->get_config()->warp_size);
+	m_core->incfumemactivelanes_stat(active_count);
+}
+
+void sp_unit::active_lanes_in_pipeline(){
+	unsigned active_count=pipelined_simd_unit::get_active_lanes_in_pipeline();
+	assert(active_count<=m_core->get_config()->warp_size);
+	m_core->incspactivelanes_stat(active_count);
+	m_core->incfuactivelanes_stat(active_count);
+	m_core->incfumemactivelanes_stat(active_count);
+}
+void dp_unit::active_lanes_in_pipeline(){
+	unsigned active_count=pipelined_simd_unit::get_active_lanes_in_pipeline();
+	assert(active_count<=m_core->get_config()->warp_size);
+	m_core->incspactivelanes_stat(active_count);
+	m_core->incfuactivelanes_stat(active_count);
+	m_core->incfumemactivelanes_stat(active_count);
+}
+
+void int_unit::active_lanes_in_pipeline(){
+	unsigned active_count=pipelined_simd_unit::get_active_lanes_in_pipeline();
+	assert(active_count<=m_core->get_config()->warp_size);
+	m_core->incspactivelanes_stat(active_count);
+	m_core->incfuactivelanes_stat(active_count);
+	m_core->incfumemactivelanes_stat(active_count);
+}
+void sfu::active_lanes_in_pipeline(){
+	unsigned active_count=pipelined_simd_unit::get_active_lanes_in_pipeline();
+	assert(active_count<=m_core->get_config()->warp_size);
+	m_core->incsfuactivelanes_stat(active_count);
+	m_core->incfuactivelanes_stat(active_count);
+	m_core->incfumemactivelanes_stat(active_count);
+}
+
+void tensor_core::active_lanes_in_pipeline(){
+	unsigned active_count=pipelined_simd_unit::get_active_lanes_in_pipeline();
+	assert(active_count<=m_core->get_config()->warp_size);
+	m_core->incsfuactivelanes_stat(active_count);
+	m_core->incfuactivelanes_stat(active_count);
+	m_core->incfumemactivelanes_stat(active_count);
+}
+
+
+sp_unit::sp_unit( register_set* result_port, const shader_core_config *config,shader_core_ctx *core)
+    : pipelined_simd_unit(result_port,config,config->max_sp_latency,core)
+{ 
+    m_name = "SP "; 
+}
+
+dp_unit::dp_unit( register_set* result_port, const shader_core_config *config,shader_core_ctx *core)
+    : pipelined_simd_unit(result_port,config,config->max_dp_latency,core)
+{
+    m_name = "DP ";
+}
+
+int_unit::int_unit( register_set* result_port, const shader_core_config *config,shader_core_ctx *core)
+    : pipelined_simd_unit(result_port,config,config->max_int_latency,core)
+{
+    m_name = "INT ";
+}
+
+void sp_unit :: issue(register_set& source_reg)
+{
+    warp_inst_t** ready_reg = source_reg.get_ready();
+	//m_core->incexecstat((*ready_reg));
+	(*ready_reg)->op_pipe=SP__OP;
+	m_core->incsp_stat(m_core->get_config()->warp_size,(*ready_reg)->latency);
+	pipelined_simd_unit::issue(source_reg);
+}
+
+void dp_unit :: issue(register_set& source_reg)
+{
+    warp_inst_t** ready_reg = source_reg.get_ready();
+	//m_core->incexecstat((*ready_reg));
+	(*ready_reg)->op_pipe=DP__OP;
+	m_core->incsp_stat(m_core->get_config()->warp_size,(*ready_reg)->latency);
+	pipelined_simd_unit::issue(source_reg);
+}
+
+void int_unit :: issue(register_set& source_reg)
+{
+    warp_inst_t** ready_reg = source_reg.get_ready();
+	//m_core->incexecstat((*ready_reg));
+	(*ready_reg)->op_pipe=INTP__OP;
+	m_core->incsp_stat(m_core->get_config()->warp_size,(*ready_reg)->latency);
+	pipelined_simd_unit::issue(source_reg);
+}
+
+pipelined_simd_unit::pipelined_simd_unit( register_set* result_port, const shader_core_config *config, unsigned max_latency,shader_core_ctx *core )
+    : simd_function_unit(config) 
+{
+    m_result_port = result_port;
+    m_pipeline_depth = max_latency;
+    m_pipeline_reg = new warp_inst_t*[m_pipeline_depth];
+    for( unsigned i=0; i < m_pipeline_depth; i++ ) 
+	m_pipeline_reg[i] = new warp_inst_t( config );
+    m_core=core;
+    active_insts_in_pipeline=0;
+}
+
+void pipelined_simd_unit::cycle()
+{
+    if( !m_pipeline_reg[0]->empty() ){
+        m_result_port->move_in(m_pipeline_reg[0]);
+        assert(active_insts_in_pipeline > 0);
+        active_insts_in_pipeline--;
     }
-  }
-  occupied >>= 1;
+    if(active_insts_in_pipeline){
+		for( unsigned stage=0; (stage+1)<m_pipeline_depth; stage++ )
+			move_warp(m_pipeline_reg[stage], m_pipeline_reg[stage+1]);
+    }
+    if( !m_dispatch_reg->empty() ) {
+        if( !m_dispatch_reg->dispatch_delay()){
+            int start_stage = m_dispatch_reg->latency - m_dispatch_reg->initiation_interval;
+            move_warp(m_pipeline_reg[start_stage],m_dispatch_reg);
+            active_insts_in_pipeline++;
+        }
+    }
+    occupied >>=1;
 }
 
-void pipelined_simd_unit::issue(register_set &source_reg) {
-  // move_warp(m_dispatch_reg,source_reg);
-  warp_inst_t **ready_reg = source_reg.get_ready();
-  m_core->incexecstat((*ready_reg));
-  // source_reg.move_out_to(m_dispatch_reg);
-  simd_function_unit::issue(source_reg);
+
+void pipelined_simd_unit::issue( register_set& source_reg )
+{
+    //move_warp(m_dispatch_reg,source_reg);
+    warp_inst_t** ready_reg = source_reg.get_ready();
+	m_core->incexecstat((*ready_reg));
+	//source_reg.move_out_to(m_dispatch_reg);
+	simd_function_unit::issue(source_reg);
 }
 
 /*
@@ -2170,222 +2073,117 @@ void pipelined_simd_unit::issue(register_set &source_reg) {
     }
 */
 
-void ldst_unit::init(mem_fetch_interface *icnt,
-                     shader_core_mem_fetch_allocator *mf_allocator,
-                     shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
-                     Scoreboard *scoreboard, const shader_core_config *config,
-                     const memory_config *mem_config, shader_core_stats *stats,
-                     unsigned sid, unsigned tpc) {
-  m_memory_config = mem_config;
-  m_icnt = icnt;
-  m_mf_allocator = mf_allocator;
-  m_core = core;
-  m_operand_collector = operand_collector;
-  m_scoreboard = scoreboard;
-  m_stats = stats;
-  m_sid = sid;
-  m_tpc = tpc;
-#define STRSIZE 1024
-  char L1T_name[STRSIZE];
-  char L1C_name[STRSIZE];
-  snprintf(L1T_name, STRSIZE, "L1T_%03d", m_sid);
-  snprintf(L1C_name, STRSIZE, "L1C_%03d", m_sid);
-  m_L1T = new tex_cache(L1T_name, m_config->m_L1T_config, m_sid,
-                        get_shader_texture_cache_id(), icnt, IN_L1T_MISS_QUEUE,
-                        IN_SHADER_L1T_ROB);
-  m_L1C = new read_only_cache(L1C_name, m_config->m_L1C_config, m_sid,
-                              get_shader_constant_cache_id(), icnt,
-                              IN_L1C_MISS_QUEUE);
-  m_L1D = NULL;
-  m_mem_rc = NO_RC_FAIL;
-  m_num_writeback_clients =
-      5;  // = shared memory, global/local (uncached), L1D, L1T, L1C
-  m_writeback_arb = 0;
-  m_next_global = NULL;
-  m_last_inst_gpu_sim_cycle = 0;
-  m_last_inst_gpu_tot_sim_cycle = 0;
-}
-
-ldst_unit::ldst_unit(mem_fetch_interface *icnt,
-                     shader_core_mem_fetch_allocator *mf_allocator,
-                     shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
-                     Scoreboard *scoreboard, const shader_core_config *config,
-                     const memory_config *mem_config, shader_core_stats *stats,
-                     unsigned sid, unsigned tpc)
-    : pipelined_simd_unit(NULL, config, config->smem_latency, core),
-      m_next_wb(config) {
-  assert(config->smem_latency > 1);
-  init(icnt, mf_allocator, core, operand_collector, scoreboard, config,
-       mem_config, stats, sid, tpc);
-  if (!m_config->m_L1D_config.disabled()) {
-    char L1D_name[STRSIZE];
-    snprintf(L1D_name, STRSIZE, "L1D_%03d", m_sid);
-    m_L1D = new l1_cache(L1D_name, m_config->m_L1D_config, m_sid,
-                         get_shader_normal_cache_id(), m_icnt, m_mf_allocator,
-                         IN_L1D_MISS_QUEUE, core->get_gpu());
-
-    l1_latency_queue.resize(m_config->m_L1D_config.l1_banks);
-    assert(m_config->m_L1D_config.l1_latency > 0);
-
-    for (unsigned j = 0; j < m_config->m_L1D_config.l1_banks; j++)
-      l1_latency_queue[j].resize(m_config->m_L1D_config.l1_latency,
-                                 (mem_fetch *)NULL);
-  }
-  m_name = "MEM ";
-}
-
-ldst_unit::ldst_unit(mem_fetch_interface *icnt,
-                     shader_core_mem_fetch_allocator *mf_allocator,
-                     shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
-                     Scoreboard *scoreboard, const shader_core_config *config,
-                     const memory_config *mem_config, shader_core_stats *stats,
-                     unsigned sid, unsigned tpc, l1_cache *new_l1d_cache)
-    : pipelined_simd_unit(NULL, config, 3, core),
-      m_L1D(new_l1d_cache),
-      m_next_wb(config) {
-  init(icnt, mf_allocator, core, operand_collector, scoreboard, config,
-       mem_config, stats, sid, tpc);
-}
-
-void ldst_unit::issue(register_set &reg_set) {
-  warp_inst_t *inst = *(reg_set.get_ready());
-
-  // record how many pending register writes/memory accesses there are for this
-  // instruction
-  assert(inst->empty() == false);
-  if (inst->is_load() and inst->space.get_type() != shared_space) {
-    unsigned warp_id = inst->warp_id();
-    unsigned n_accesses = inst->accessq_count();
-    for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++) {
-      unsigned reg_id = inst->out[r];
-      if (reg_id > 0) {
-        m_pending_writes[warp_id][reg_id] += n_accesses;
-      }
-    }
-  }
-
-  inst->op_pipe = MEM__OP;
-  // stat collection
-  m_core->mem_instruction_stats(*inst);
-  m_core->incmem_stat(m_core->get_config()->warp_size, 1);
-  pipelined_simd_unit::issue(reg_set);
-}
-
-void ldst_unit::writeback() {
-  // process next instruction that is going to writeback
-  if (!m_next_wb.empty()) {
-    if (m_operand_collector->writeback(m_next_wb)) {
-      bool insn_completed = false;
-      for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++) {
-        if (m_next_wb.out[r] > 0) {
-          if (m_next_wb.space.get_type() != shared_space) {
-            assert(m_pending_writes[m_next_wb.warp_id()][m_next_wb.out[r]] > 0);
-            unsigned still_pending =
-                --m_pending_writes[m_next_wb.warp_id()][m_next_wb.out[r]];
-            if (!still_pending) {
-              m_pending_writes[m_next_wb.warp_id()].erase(m_next_wb.out[r]);
-              m_scoreboard->releaseRegister(m_next_wb.warp_id(),
-                                            m_next_wb.out[r]);
-              insn_completed = true;
-            }
-          } else {  // shared
-            m_scoreboard->releaseRegister(m_next_wb.warp_id(),
-                                          m_next_wb.out[r]);
-            insn_completed = true;
-          }
-        }
-      }
-      if (insn_completed) {
-        m_core->warp_inst_complete(m_next_wb);
-      }
-      m_next_wb.clear();
-      m_last_inst_gpu_sim_cycle = m_core->get_gpu()->gpu_sim_cycle;
-      m_last_inst_gpu_tot_sim_cycle = m_core->get_gpu()->gpu_tot_sim_cycle;
-    }
-  }
-
-  unsigned serviced_client = -1;
-  for (unsigned c = 0; m_next_wb.empty() && (c < m_num_writeback_clients);
-       c++) {
-    unsigned next_client = (c + m_writeback_arb) % m_num_writeback_clients;
-    switch (next_client) {
-      case 0:  // shared memory
-        if (!m_pipeline_reg[0]->empty()) {
-          m_next_wb = *m_pipeline_reg[0];
-          if (m_next_wb.isatomic()) {
-            m_next_wb.do_atomic();
-            m_core->decrement_atomic_count(m_next_wb.warp_id(),
-                                           m_next_wb.active_count());
-          }
-          m_core->dec_inst_in_pipeline(m_pipeline_reg[0]->warp_id());
-          m_pipeline_reg[0]->clear();
-          serviced_client = next_client;
-        }
-        break;
-      case 1:  // texture response
-        if (m_L1T->access_ready()) {
-          mem_fetch *mf = m_L1T->next_access();
-          m_next_wb = mf->get_inst();
-          delete mf;
-          serviced_client = next_client;
-        }
-        break;
-      case 2:  // const cache response
-        if (m_L1C->access_ready()) {
-          mem_fetch *mf = m_L1C->next_access();
-          m_next_wb = mf->get_inst();
-          delete mf;
-          serviced_client = next_client;
-        }
-        break;
-      case 3:  // global/local
-        if (m_next_global) {
-          m_next_wb = m_next_global->get_inst();
-          if (m_next_global->isatomic())
-            m_core->decrement_atomic_count(
-                m_next_global->get_wid(),
-                m_next_global->get_access_warp_mask().count());
-          delete m_next_global;
-          m_next_global = NULL;
-          serviced_client = next_client;
-        }
-        break;
-      case 4:
-        if (m_L1D && m_L1D->access_ready()) {
-          mem_fetch *mf = m_L1D->next_access();
-          m_next_wb = mf->get_inst();
-          delete mf;
-          serviced_client = next_client;
-        }
-        break;
-      default:
-        abort();
-    }
-  }
-  // update arbitration priority only if:
-  // 1. the writeback buffer was available
-  // 2. a client was serviced
-  if (serviced_client != (unsigned)-1) {
-    m_writeback_arb = (serviced_client + 1) % m_num_writeback_clients;
-  }
-}
-
-unsigned ldst_unit::clock_multiplier() const {
-  // to model multiple read port, we give multiple cycles for the memory units
-  if (m_config->mem_unit_ports)
-    return m_config->mem_unit_ports;
-  else
-    return m_config->mem_warp_parts;
-}
-/*
-void ldst_unit::issue( register_set &reg_set )
+void ldst_unit::init( mem_fetch_interface *icnt,
+                      shader_core_mem_fetch_allocator *mf_allocator,
+                      shader_core_ctx *core, 
+                      opndcoll_rfu_t *operand_collector,
+                      Scoreboard *scoreboard,
+                      const shader_core_config *config,
+                      const memory_config *mem_config,  
+                      shader_core_stats *stats,
+                      unsigned sid,
+                      unsigned tpc )
 {
-        warp_inst_t* inst = *(reg_set.get_ready());
-   // stat collection
-   m_core->mem_instruction_stats(*inst);
+    m_memory_config = mem_config;
+    m_icnt = icnt;
+    m_mf_allocator=mf_allocator;
+    m_core = core;
+    m_operand_collector = operand_collector;
+    m_scoreboard = scoreboard;
+    m_stats = stats;
+    m_sid = sid;
+    m_tpc = tpc;
+    #define STRSIZE 1024
+    char L1T_name[STRSIZE];
+    char L1C_name[STRSIZE];
+    snprintf(L1T_name, STRSIZE, "L1T_%03d", m_sid);
+    snprintf(L1C_name, STRSIZE, "L1C_%03d", m_sid);
+    m_L1T = new tex_cache(L1T_name,m_config->m_L1T_config,m_sid,get_shader_texture_cache_id(),icnt,IN_L1T_MISS_QUEUE,IN_SHADER_L1T_ROB);
+    m_L1C = new read_only_cache(L1C_name,m_config->m_L1C_config,m_sid,get_shader_constant_cache_id(),icnt,IN_L1C_MISS_QUEUE);
+    m_L1D = NULL;
+    m_mem_rc = NO_RC_FAIL;
+    m_num_writeback_clients=5; // = shared memory, global/local (uncached), L1D, L1T, L1C
+    m_writeback_arb = 0;
+    m_next_global=NULL;
+    m_last_inst_gpu_sim_cycle=0;
+    m_last_inst_gpu_tot_sim_cycle=0;
+}
 
-   // record how many pending register writes/memory accesses there are for this
-instruction
+
+ldst_unit::ldst_unit( mem_fetch_interface *icnt,
+                      shader_core_mem_fetch_allocator *mf_allocator,
+                      shader_core_ctx *core, 
+                      opndcoll_rfu_t *operand_collector,
+                      Scoreboard *scoreboard,
+                      const shader_core_config *config,
+                      const memory_config *mem_config,  
+                      shader_core_stats *stats,
+                      unsigned sid,
+                      unsigned tpc ) : pipelined_simd_unit(NULL,config,config->smem_latency,core), m_next_wb(config)
+{
+	assert(config->smem_latency > 1);
+    init( icnt,
+          mf_allocator,
+          core, 
+          operand_collector,
+          scoreboard,
+          config, 
+          mem_config,  
+          stats, 
+          sid,
+          tpc );
+    if( !m_config->m_L1D_config.disabled() ) {
+        char L1D_name[STRSIZE];
+        snprintf(L1D_name, STRSIZE, "L1D_%03d", m_sid);
+        m_L1D = new l1_cache( L1D_name,
+                              m_config->m_L1D_config,
+                              m_sid,
+                              get_shader_normal_cache_id(),
+                              m_icnt,
+                              m_mf_allocator,
+                              IN_L1D_MISS_QUEUE,
+							  core->get_gpu());
+
+        l1_latency_queue.resize(m_config->m_L1D_config.l1_banks);
+        assert(m_config->m_L1D_config.l1_latency > 0);
+
+		for(unsigned j = 0; j < m_config->m_L1D_config.l1_banks; j++ )
+			l1_latency_queue[j].resize(m_config->m_L1D_config.l1_latency,(mem_fetch*)NULL);
+
+    }
+    m_name = "MEM ";
+}
+
+ldst_unit::ldst_unit( mem_fetch_interface *icnt,
+                      shader_core_mem_fetch_allocator *mf_allocator,
+                      shader_core_ctx *core, 
+                      opndcoll_rfu_t *operand_collector,
+                      Scoreboard *scoreboard,
+                      const shader_core_config *config,
+                      const memory_config *mem_config,  
+                      shader_core_stats *stats,
+                      unsigned sid,
+                      unsigned tpc,
+                      l1_cache* new_l1d_cache )
+    : pipelined_simd_unit(NULL,config,3,core), m_L1D(new_l1d_cache), m_next_wb(config)
+{
+    init( icnt,
+          mf_allocator,
+          core, 
+          operand_collector,
+          scoreboard,
+          config, 
+          mem_config,  
+          stats, 
+          sid,
+          tpc );
+}
+
+void ldst_unit:: issue( register_set &reg_set )
+{
+	warp_inst_t* inst = *(reg_set.get_ready());
+
+   // record how many pending register writes/memory accesses there are for this instruction
    assert(inst->empty() == false);
    if (inst->is_load() and inst->space.get_type() != shared_space) {
       unsigned warp_id = inst->warp_id();
@@ -2398,1884 +2196,1951 @@ instruction
       }
    }
 
+
+	inst->op_pipe=MEM__OP;
+	// stat collection
+	m_core->mem_instruction_stats(*inst);
+	m_core->incmem_stat(m_core->get_config()->warp_size,1);
+	pipelined_simd_unit::issue(reg_set);
+}
+
+void ldst_unit::writeback()
+{
+    // process next instruction that is going to writeback
+    if( !m_next_wb.empty() ) {
+        if( m_operand_collector->writeback(m_next_wb) ) {
+            bool insn_completed = false; 
+            for( unsigned r=0; r < MAX_OUTPUT_VALUES; r++ ) {
+                if( m_next_wb.out[r] > 0 ) {
+                    if( m_next_wb.space.get_type() != shared_space ) {
+                        assert( m_pending_writes[m_next_wb.warp_id()][m_next_wb.out[r]] > 0 );
+                        unsigned still_pending = --m_pending_writes[m_next_wb.warp_id()][m_next_wb.out[r]];
+                        if( !still_pending ) {
+                            m_pending_writes[m_next_wb.warp_id()].erase(m_next_wb.out[r]);
+                            m_scoreboard->releaseRegister( m_next_wb.warp_id(), m_next_wb.out[r] );
+                            insn_completed = true; 
+                        }
+                    } else { // shared 
+                        m_scoreboard->releaseRegister( m_next_wb.warp_id(), m_next_wb.out[r] );
+                        insn_completed = true; 
+                    }
+                }
+            }
+            if( insn_completed ) {
+                m_core->warp_inst_complete(m_next_wb);
+            }
+            m_next_wb.clear();
+            m_last_inst_gpu_sim_cycle = m_core->get_gpu()->gpu_sim_cycle;
+            m_last_inst_gpu_tot_sim_cycle = m_core->get_gpu()->gpu_tot_sim_cycle;
+        }
+    }
+
+    unsigned serviced_client = -1; 
+    for( unsigned c = 0; m_next_wb.empty() && (c < m_num_writeback_clients); c++ ) {
+        unsigned next_client = (c+m_writeback_arb)%m_num_writeback_clients;
+        switch( next_client ) {
+        case 0: // shared memory 
+            if( !m_pipeline_reg[0]->empty() ) {
+                m_next_wb = *m_pipeline_reg[0];
+                if(m_next_wb.isatomic()) {
+                    m_next_wb.do_atomic();
+                    m_core->decrement_atomic_count(m_next_wb.warp_id(), m_next_wb.active_count());
+                }
+                m_core->dec_inst_in_pipeline(m_pipeline_reg[0]->warp_id());
+                m_pipeline_reg[0]->clear();
+                serviced_client = next_client; 
+            }
+            break;
+        case 1: // texture response
+            if( m_L1T->access_ready() ) {
+                mem_fetch *mf = m_L1T->next_access();
+                m_next_wb = mf->get_inst();
+                delete mf;
+                serviced_client = next_client; 
+            }
+            break;
+        case 2: // const cache response
+            if( m_L1C->access_ready() ) {
+                mem_fetch *mf = m_L1C->next_access();
+                m_next_wb = mf->get_inst();
+                delete mf;
+                serviced_client = next_client; 
+            }
+            break;
+        case 3: // global/local
+            if( m_next_global ) {
+                m_next_wb = m_next_global->get_inst();
+                if( m_next_global->isatomic() ) 
+                    m_core->decrement_atomic_count(m_next_global->get_wid(),m_next_global->get_access_warp_mask().count());
+                delete m_next_global;
+                m_next_global = NULL;
+                serviced_client = next_client; 
+            }
+            break;
+        case 4: 
+            if( m_L1D && m_L1D->access_ready() ) {
+                mem_fetch *mf = m_L1D->next_access();
+                m_next_wb = mf->get_inst();
+                delete mf;
+                serviced_client = next_client; 
+            }
+            break;
+        default: abort();
+        }
+    }
+    // update arbitration priority only if: 
+    // 1. the writeback buffer was available 
+    // 2. a client was serviced 
+    if (serviced_client != (unsigned)-1) {
+        m_writeback_arb = (serviced_client + 1) % m_num_writeback_clients; 
+    }
+}
+
+unsigned ldst_unit::clock_multiplier() const
+{ 
+	//to model multiple read port, we give multiple cycles for the memory units
+	if(m_config->mem_unit_ports)
+		return m_config->mem_unit_ports;
+	else
+		return m_config->mem_warp_parts;
+}
+/*
+void ldst_unit::issue( register_set &reg_set )
+{
+	warp_inst_t* inst = *(reg_set.get_ready());
+   // stat collection
+   m_core->mem_instruction_stats(*inst); 
+
+   // record how many pending register writes/memory accesses there are for this instruction 
+   assert(inst->empty() == false); 
+   if (inst->is_load() and inst->space.get_type() != shared_space) {
+      unsigned warp_id = inst->warp_id(); 
+      unsigned n_accesses = inst->accessq_count(); 
+      for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++) {
+         unsigned reg_id = inst->out[r]; 
+         if (reg_id > 0) {
+            m_pending_writes[warp_id][reg_id] += n_accesses; 
+         }
+      }
+   }
+
    pipelined_simd_unit::issue(reg_set);
 }
 */
-void ldst_unit::cycle() {
-  writeback();
-  m_operand_collector->step();
-  for (unsigned stage = 0; (stage + 1) < m_pipeline_depth; stage++)
-    if (m_pipeline_reg[stage]->empty() && !m_pipeline_reg[stage + 1]->empty())
-      move_warp(m_pipeline_reg[stage], m_pipeline_reg[stage + 1]);
+void ldst_unit::cycle()
+{
+   writeback();
+   m_operand_collector->step();
+   for( unsigned stage=0; (stage+1)<m_pipeline_depth; stage++ ) 
+       if( m_pipeline_reg[stage]->empty() && !m_pipeline_reg[stage+1]->empty() )
+            move_warp(m_pipeline_reg[stage], m_pipeline_reg[stage+1]);
 
-  if (!m_response_fifo.empty()) {
-    mem_fetch *mf = m_response_fifo.front();
-    if (mf->get_access_type() == TEXTURE_ACC_R) {
-      if (m_L1T->fill_port_free()) {
-        m_L1T->fill(mf, m_core->get_gpu()->gpu_sim_cycle +
-                            m_core->get_gpu()->gpu_tot_sim_cycle);
-        m_response_fifo.pop_front();
+   if( !m_response_fifo.empty() ) {
+       mem_fetch *mf = m_response_fifo.front();
+       if (mf->get_access_type() == TEXTURE_ACC_R) {
+           if (m_L1T->fill_port_free()) {
+               m_L1T->fill(mf,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
+               m_response_fifo.pop_front(); 
+           }
+       } else if (mf->get_access_type() == CONST_ACC_R)  {
+           if (m_L1C->fill_port_free()) {
+               mf->set_status(IN_SHADER_FETCHED,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
+               m_L1C->fill(mf,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
+               m_response_fifo.pop_front(); 
+           }
+       } else {
+    	   if( mf->get_type() == WRITE_ACK || ( m_config->gpgpu_perfect_mem && mf->get_is_write() )) {
+               m_core->store_ack(mf);
+               m_response_fifo.pop_front();
+               delete mf;
+           } else {
+               assert( !mf->get_is_write() ); // L1 cache is write evict, allocate line on load miss only
+
+               bool bypassL1D = false; 
+               if ( CACHE_GLOBAL == mf->get_inst().cache_op || (m_L1D == NULL) ) {
+                   bypassL1D = true; 
+               } else if (mf->get_access_type() == GLOBAL_ACC_R || mf->get_access_type() == GLOBAL_ACC_W) { // global memory access 
+                   if (m_core->get_config()->gmem_skip_L1D)
+                       bypassL1D = true; 
+               }
+               if( bypassL1D ) {
+                   if ( m_next_global == NULL ) {
+                       mf->set_status(IN_SHADER_FETCHED,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
+                       m_response_fifo.pop_front();
+                       m_next_global = mf;
+                   }
+               } else {
+                   if (m_L1D->fill_port_free()) {
+                       m_L1D->fill(mf,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
+                       m_response_fifo.pop_front();
+                   }
+               }
+           }
+       }
+   }
+
+   m_L1T->cycle();
+   m_L1C->cycle();
+   if( m_L1D ) {
+	   m_L1D->cycle();
+	   if(m_config->m_L1D_config.l1_latency > 0)
+	   		L1_latency_queue_cycle();
+   }
+
+   warp_inst_t &pipe_reg = *m_dispatch_reg;
+   enum mem_stage_stall_type rc_fail = NO_RC_FAIL;
+   mem_stage_access_type type;
+   bool done = true;
+   done &= shared_cycle(pipe_reg, rc_fail, type);
+   done &= constant_cycle(pipe_reg, rc_fail, type);
+   done &= texture_cycle(pipe_reg, rc_fail, type);
+   done &= memory_cycle(pipe_reg, rc_fail, type);
+   m_mem_rc = rc_fail;
+
+   if (!done) { // log stall types and return
+      assert(rc_fail != NO_RC_FAIL);
+      m_stats->gpgpu_n_stall_shd_mem++;
+      m_stats->gpu_stall_shd_mem_breakdown[type][rc_fail]++;
+      return;
+   }
+
+   if( !pipe_reg.empty() ) {
+       unsigned warp_id = pipe_reg.warp_id();
+       if( pipe_reg.is_load() ) {
+           if( pipe_reg.space.get_type() == shared_space ) {
+               if( m_pipeline_reg[m_config->smem_latency-1]->empty() ) {
+                   // new shared memory request
+                   move_warp(m_pipeline_reg[m_config->smem_latency-1],m_dispatch_reg);
+                   m_dispatch_reg->clear();
+               }
+           } else {
+               //if( pipe_reg.active_count() > 0 ) {
+               //    if( !m_operand_collector->writeback(pipe_reg) ) 
+               //        return;
+               //} 
+
+               bool pending_requests=false;
+               for( unsigned r=0; r<MAX_OUTPUT_VALUES; r++ ) {
+                   unsigned reg_id = pipe_reg.out[r];
+                   if( reg_id > 0 ) {
+                       if( m_pending_writes[warp_id].find(reg_id) != m_pending_writes[warp_id].end() ) {
+                           if ( m_pending_writes[warp_id][reg_id] > 0 ) {
+                               pending_requests=true;
+                               break;
+                           } else {
+                               // this instruction is done already
+                               m_pending_writes[warp_id].erase(reg_id); 
+                           }
+                       }
+                   }
+               }
+               if( !pending_requests ) {
+                   m_core->warp_inst_complete(*m_dispatch_reg);
+                   m_scoreboard->releaseRegisters(m_dispatch_reg);
+               }
+               m_core->dec_inst_in_pipeline(warp_id);
+               m_dispatch_reg->clear();
+           }
+       } else {
+           // stores exit pipeline here
+           m_core->dec_inst_in_pipeline(warp_id);
+           m_core->warp_inst_complete(*m_dispatch_reg);
+           m_dispatch_reg->clear();
+       }
+   }
+}
+
+void shader_core_ctx::register_cta_thread_exit( unsigned cta_num, kernel_info_t * kernel)
+{
+   assert( m_cta_status[cta_num] > 0 );
+   m_cta_status[cta_num]--;
+   if (!m_cta_status[cta_num]) {
+      m_n_active_cta--;
+      m_barriers.deallocate_barrier(cta_num);
+      shader_CTA_count_unlog(m_sid, 1);
+
+     SHADER_DPRINTF(LIVENESS, "GPGPU-Sim uArch: Finished CTA #%u (%lld,%lld), %u CTAs running\n",
+        cta_num, m_gpu->gpu_sim_cycle, m_gpu->gpu_tot_sim_cycle, m_n_active_cta);
+
+      if( m_n_active_cta == 0 ) {
+        SHADER_DPRINTF(LIVENESS, "GPGPU-Sim uArch: Empty (last released kernel %u \'%s\').\n",
+            kernel->get_uid(), kernel->name().c_str());
+          fflush(stdout);
+
+          //Shader can only be empty when no more cta are dispatched
+          if(kernel != m_kernel) {
+              assert(m_kernel == NULL || !m_gpu->kernel_more_cta_left(m_kernel));
+          }
+          m_kernel = NULL;
       }
-    } else if (mf->get_access_type() == CONST_ACC_R) {
-      if (m_L1C->fill_port_free()) {
-        mf->set_status(IN_SHADER_FETCHED,
-                       m_core->get_gpu()->gpu_sim_cycle +
-                           m_core->get_gpu()->gpu_tot_sim_cycle);
-        m_L1C->fill(mf, m_core->get_gpu()->gpu_sim_cycle +
-                            m_core->get_gpu()->gpu_tot_sim_cycle);
-        m_response_fifo.pop_front();
+
+      //Jin: for concurrent kernels on sm
+      release_shader_resource_1block(cta_num, *kernel);
+      kernel->dec_running();
+      if( !m_gpu->kernel_more_cta_left(kernel) ) {
+          if( !kernel->running() ) {
+              SHADER_DPRINTF(LIVENESS,
+                "GPGPU-Sim uArch: GPU detected kernel %u \'%s\' finished on shader %u.\n", kernel->get_uid(),
+                kernel->name().c_str(), m_sid);
+
+              if(m_kernel == kernel)
+                m_kernel = NULL;
+              m_gpu->set_kernel_done( kernel );
+          }
       }
+
+   }
+}
+
+void gpgpu_sim::shader_print_runtime_stat( FILE *fout ) 
+{
+    /*
+   fprintf(fout, "SHD_INSN: ");
+   for (unsigned i=0;i<m_n_shader;i++) 
+      fprintf(fout, "%u ",m_sc[i]->get_num_sim_insn());
+   fprintf(fout, "\n");
+   fprintf(fout, "SHD_THDS: ");
+   for (unsigned i=0;i<m_n_shader;i++) 
+      fprintf(fout, "%u ",m_sc[i]->get_not_completed());
+   fprintf(fout, "\n");
+   fprintf(fout, "SHD_DIVG: ");
+   for (unsigned i=0;i<m_n_shader;i++) 
+      fprintf(fout, "%u ",m_sc[i]->get_n_diverge());
+   fprintf(fout, "\n");
+
+   fprintf(fout, "THD_INSN: ");
+   for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) 
+      fprintf(fout, "%d ", m_sc[0]->get_thread_n_insn(i) );
+   fprintf(fout, "\n");
+   */
+}
+
+
+void gpgpu_sim::shader_print_scheduler_stat( FILE* fout, bool print_dynamic_info ) const
+{
+    // Print out the stats from the sampling shader core
+    const unsigned scheduler_sampling_core = m_shader_config->gpgpu_warp_issue_shader;
+    #define STR_SIZE 55
+    char name_buff[ STR_SIZE ];
+    name_buff[ STR_SIZE - 1 ] = '\0';
+    const std::vector< unsigned >& distro
+        = print_dynamic_info ?
+          m_shader_stats->get_dynamic_warp_issue()[ scheduler_sampling_core ] :
+          m_shader_stats->get_warp_slot_issue()[ scheduler_sampling_core ];
+    if ( print_dynamic_info ) {
+        snprintf( name_buff, STR_SIZE - 1, "dynamic_warp_id" );
     } else {
-      if (mf->get_type() == WRITE_ACK ||
-          (m_config->gpgpu_perfect_mem && mf->get_is_write())) {
-        m_core->store_ack(mf);
-        m_response_fifo.pop_front();
-        delete mf;
-      } else {
-        assert(!mf->get_is_write());  // L1 cache is write evict, allocate line
-                                      // on load miss only
+        snprintf( name_buff, STR_SIZE - 1, "warp_id" );
+    }
+    fprintf( fout,
+             "Shader %d %s issue ditsribution:\n",
+             scheduler_sampling_core,
+             name_buff );
+    const unsigned num_warp_ids = distro.size();
+    // First print out the warp ids
+    fprintf( fout, "%s:\n", name_buff );
+    for ( unsigned warp_id = 0;
+          warp_id < num_warp_ids;
+          ++warp_id  ) {
+        fprintf( fout, "%d, ", warp_id );
+    }
 
-        bool bypassL1D = false;
-        if (CACHE_GLOBAL == mf->get_inst().cache_op || (m_L1D == NULL)) {
-          bypassL1D = true;
-        } else if (mf->get_access_type() == GLOBAL_ACC_R ||
-                   mf->get_access_type() ==
-                       GLOBAL_ACC_W) {  // global memory access
-          if (m_core->get_config()->gmem_skip_L1D) bypassL1D = true;
+    fprintf( fout, "\ndistro:\n" );
+    // Then print out the distribution of instuctions issued
+    for ( std::vector< unsigned >::const_iterator iter = distro.begin();
+          iter != distro.end();
+          iter++ ) {
+        fprintf( fout, "%d, ", *iter );
+    }
+    fprintf( fout, "\n" );
+}
+
+void gpgpu_sim::shader_print_cache_stats( FILE *fout ) const{
+
+    // L1I
+    struct cache_sub_stats total_css;
+    struct cache_sub_stats css;
+
+    if(!m_shader_config->m_L1I_config.disabled()){
+        total_css.clear();
+        css.clear();
+        fprintf(fout, "\n========= Core cache stats =========\n");
+        fprintf(fout, "L1I_cache:\n");
+        for ( unsigned i = 0; i < m_shader_config->n_simt_clusters; ++i ) {
+            m_cluster[i]->get_L1I_sub_stats(css);
+            total_css += css;
         }
-        if (bypassL1D) {
-          if (m_next_global == NULL) {
-            mf->set_status(IN_SHADER_FETCHED,
-                           m_core->get_gpu()->gpu_sim_cycle +
-                               m_core->get_gpu()->gpu_tot_sim_cycle);
-            m_response_fifo.pop_front();
-            m_next_global = mf;
-          }
-        } else {
-          if (m_L1D->fill_port_free()) {
-            m_L1D->fill(mf, m_core->get_gpu()->gpu_sim_cycle +
-                                m_core->get_gpu()->gpu_tot_sim_cycle);
-            m_response_fifo.pop_front();
-          }
+        fprintf(fout, "\tL1I_total_cache_accesses = %llu\n", total_css.accesses);
+        fprintf(fout, "\tL1I_total_cache_misses = %llu\n", total_css.misses);
+        if(total_css.accesses > 0){
+            fprintf(fout, "\tL1I_total_cache_miss_rate = %.4lf\n", (double)total_css.misses / (double)total_css.accesses);
         }
-      }
+        fprintf(fout, "\tL1I_total_cache_pending_hits = %llu\n", total_css.pending_hits);
+        fprintf(fout, "\tL1I_total_cache_reservation_fails = %llu\n", total_css.res_fails);
     }
-  }
 
-  m_L1T->cycle();
-  m_L1C->cycle();
-  if (m_L1D) {
-    m_L1D->cycle();
-    if (m_config->m_L1D_config.l1_latency > 0) L1_latency_queue_cycle();
-  }
+    // L1D
+    if(!m_shader_config->m_L1D_config.disabled()){
+        total_css.clear();
+        css.clear();
+        fprintf(fout, "L1D_cache:\n");
+        for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++){
+            m_cluster[i]->get_L1D_sub_stats(css);
 
-  warp_inst_t &pipe_reg = *m_dispatch_reg;
-  enum mem_stage_stall_type rc_fail = NO_RC_FAIL;
-  mem_stage_access_type type;
-  bool done = true;
-  done &= shared_cycle(pipe_reg, rc_fail, type);
-  done &= constant_cycle(pipe_reg, rc_fail, type);
-  done &= texture_cycle(pipe_reg, rc_fail, type);
-  done &= memory_cycle(pipe_reg, rc_fail, type);
-  m_mem_rc = rc_fail;
+            fprintf( stdout, "\tL1D_cache_core[%d]: Access = %llu, Miss = %llu, Miss_rate = %.3lf, Pending_hits = %llu, Reservation_fails = %llu\n",
+                     i, css.accesses, css.misses, (double)css.misses / (double)css.accesses, css.pending_hits, css.res_fails);
 
-  if (!done) {  // log stall types and return
-    assert(rc_fail != NO_RC_FAIL);
-    m_stats->gpgpu_n_stall_shd_mem++;
-    m_stats->gpu_stall_shd_mem_breakdown[type][rc_fail]++;
-    return;
-  }
-
-  if (!pipe_reg.empty()) {
-    unsigned warp_id = pipe_reg.warp_id();
-    if (pipe_reg.is_load()) {
-      if (pipe_reg.space.get_type() == shared_space) {
-        if (m_pipeline_reg[m_config->smem_latency - 1]->empty()) {
-          // new shared memory request
-          move_warp(m_pipeline_reg[m_config->smem_latency - 1], m_dispatch_reg);
-          m_dispatch_reg->clear();
+            total_css += css;
         }
-      } else {
-        // if( pipe_reg.active_count() > 0 ) {
-        //    if( !m_operand_collector->writeback(pipe_reg) )
-        //        return;
-        //}
-
-        bool pending_requests = false;
-        for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++) {
-          unsigned reg_id = pipe_reg.out[r];
-          if (reg_id > 0) {
-            if (m_pending_writes[warp_id].find(reg_id) !=
-                m_pending_writes[warp_id].end()) {
-              if (m_pending_writes[warp_id][reg_id] > 0) {
-                pending_requests = true;
-                break;
-              } else {
-                // this instruction is done already
-                m_pending_writes[warp_id].erase(reg_id);
-              }
-            }
-          }
+        fprintf(fout, "\tL1D_total_cache_accesses = %llu\n", total_css.accesses);
+        fprintf(fout, "\tL1D_total_cache_misses = %llu\n", total_css.misses);
+        if(total_css.accesses > 0){
+            fprintf(fout, "\tL1D_total_cache_miss_rate = %.4lf\n", (double)total_css.misses / (double)total_css.accesses);
         }
-        if (!pending_requests) {
-          m_core->warp_inst_complete(*m_dispatch_reg);
-          m_scoreboard->releaseRegisters(m_dispatch_reg);
+        fprintf(fout, "\tL1D_total_cache_pending_hits = %llu\n", total_css.pending_hits);
+        fprintf(fout, "\tL1D_total_cache_reservation_fails = %llu\n", total_css.res_fails);
+        total_css.print_port_stats(fout, "\tL1D_cache"); 
+    }
+
+    // L1C
+    if(!m_shader_config->m_L1C_config.disabled()){
+        total_css.clear();
+        css.clear();
+        fprintf(fout, "L1C_cache:\n");
+        for ( unsigned i = 0; i < m_shader_config->n_simt_clusters; ++i ) {
+            m_cluster[i]->get_L1C_sub_stats(css);
+            total_css += css;
         }
-        m_core->dec_inst_in_pipeline(warp_id);
-        m_dispatch_reg->clear();
-      }
-    } else {
-      // stores exit pipeline here
-      m_core->dec_inst_in_pipeline(warp_id);
-      m_core->warp_inst_complete(*m_dispatch_reg);
-      m_dispatch_reg->clear();
-    }
-  }
-}
-
-void shader_core_ctx::register_cta_thread_exit(unsigned cta_num,
-                                               kernel_info_t *kernel) {
-  assert(m_cta_status[cta_num] > 0);
-  m_cta_status[cta_num]--;
-  if (!m_cta_status[cta_num]) {
-    m_n_active_cta--;
-    m_barriers.deallocate_barrier(cta_num);
-    shader_CTA_count_unlog(m_sid, 1);
-
-    SHADER_DPRINTF(
-        LIVENESS,
-        "GPGPU-Sim uArch: Finished CTA #%u (%lld,%lld), %u CTAs running\n",
-        cta_num, m_gpu->gpu_sim_cycle, m_gpu->gpu_tot_sim_cycle,
-        m_n_active_cta);
-
-    if (m_n_active_cta == 0) {
-      SHADER_DPRINTF(
-          LIVENESS,
-          "GPGPU-Sim uArch: Empty (last released kernel %u \'%s\').\n",
-          kernel->get_uid(), kernel->name().c_str());
-      fflush(stdout);
-
-      // Shader can only be empty when no more cta are dispatched
-      if (kernel != m_kernel) {
-        assert(m_kernel == NULL || !m_gpu->kernel_more_cta_left(m_kernel));
-      }
-      m_kernel = NULL;
-    }
-
-    // Jin: for concurrent kernels on sm
-    release_shader_resource_1block(cta_num, *kernel);
-    kernel->dec_running();
-    if (!m_gpu->kernel_more_cta_left(kernel)) {
-      if (!kernel->running()) {
-        SHADER_DPRINTF(LIVENESS,
-                       "GPGPU-Sim uArch: GPU detected kernel %u \'%s\' "
-                       "finished on shader %u.\n",
-                       kernel->get_uid(), kernel->name().c_str(), m_sid);
-
-        if (m_kernel == kernel) m_kernel = NULL;
-        m_gpu->set_kernel_done(kernel);
-      }
-    }
-  }
-}
-
-void gpgpu_sim::shader_print_runtime_stat(FILE *fout) {
-  /*
- fprintf(fout, "SHD_INSN: ");
- for (unsigned i=0;i<m_n_shader;i++)
-    fprintf(fout, "%u ",m_sc[i]->get_num_sim_insn());
- fprintf(fout, "\n");
- fprintf(fout, "SHD_THDS: ");
- for (unsigned i=0;i<m_n_shader;i++)
-    fprintf(fout, "%u ",m_sc[i]->get_not_completed());
- fprintf(fout, "\n");
- fprintf(fout, "SHD_DIVG: ");
- for (unsigned i=0;i<m_n_shader;i++)
-    fprintf(fout, "%u ",m_sc[i]->get_n_diverge());
- fprintf(fout, "\n");
-
- fprintf(fout, "THD_INSN: ");
- for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++)
-    fprintf(fout, "%d ", m_sc[0]->get_thread_n_insn(i) );
- fprintf(fout, "\n");
- */
-}
-
-void gpgpu_sim::shader_print_scheduler_stat(FILE *fout,
-                                            bool print_dynamic_info) const {
-  // Print out the stats from the sampling shader core
-  const unsigned scheduler_sampling_core =
-      m_shader_config->gpgpu_warp_issue_shader;
-#define STR_SIZE 55
-  char name_buff[STR_SIZE];
-  name_buff[STR_SIZE - 1] = '\0';
-  const std::vector<unsigned> &distro =
-      print_dynamic_info
-          ? m_shader_stats->get_dynamic_warp_issue()[scheduler_sampling_core]
-          : m_shader_stats->get_warp_slot_issue()[scheduler_sampling_core];
-  if (print_dynamic_info) {
-    snprintf(name_buff, STR_SIZE - 1, "dynamic_warp_id");
-  } else {
-    snprintf(name_buff, STR_SIZE - 1, "warp_id");
-  }
-  fprintf(fout, "Shader %d %s issue ditsribution:\n", scheduler_sampling_core,
-          name_buff);
-  const unsigned num_warp_ids = distro.size();
-  // First print out the warp ids
-  fprintf(fout, "%s:\n", name_buff);
-  for (unsigned warp_id = 0; warp_id < num_warp_ids; ++warp_id) {
-    fprintf(fout, "%d, ", warp_id);
-  }
-
-  fprintf(fout, "\ndistro:\n");
-  // Then print out the distribution of instuctions issued
-  for (std::vector<unsigned>::const_iterator iter = distro.begin();
-       iter != distro.end(); iter++) {
-    fprintf(fout, "%d, ", *iter);
-  }
-  fprintf(fout, "\n");
-}
-
-void gpgpu_sim::shader_print_cache_stats(FILE *fout) const {
-  // L1I
-  struct cache_sub_stats total_css;
-  struct cache_sub_stats css;
-
-  if (!m_shader_config->m_L1I_config.disabled()) {
-    total_css.clear();
-    css.clear();
-    fprintf(fout, "\n========= Core cache stats =========\n");
-    fprintf(fout, "L1I_cache:\n");
-    for (unsigned i = 0; i < m_shader_config->n_simt_clusters; ++i) {
-      m_cluster[i]->get_L1I_sub_stats(css);
-      total_css += css;
-    }
-    fprintf(fout, "\tL1I_total_cache_accesses = %llu\n", total_css.accesses);
-    fprintf(fout, "\tL1I_total_cache_misses = %llu\n", total_css.misses);
-    if (total_css.accesses > 0) {
-      fprintf(fout, "\tL1I_total_cache_miss_rate = %.4lf\n",
-              (double)total_css.misses / (double)total_css.accesses);
-    }
-    fprintf(fout, "\tL1I_total_cache_pending_hits = %llu\n",
-            total_css.pending_hits);
-    fprintf(fout, "\tL1I_total_cache_reservation_fails = %llu\n",
-            total_css.res_fails);
-  }
-
-  // L1D
-  if (!m_shader_config->m_L1D_config.disabled()) {
-    total_css.clear();
-    css.clear();
-    fprintf(fout, "L1D_cache:\n");
-    for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++) {
-      m_cluster[i]->get_L1D_sub_stats(css);
-
-      fprintf(stdout,
-              "\tL1D_cache_core[%d]: Access = %llu, Miss = %llu, Miss_rate = "
-              "%.3lf, Pending_hits = %llu, Reservation_fails = %llu\n",
-              i, css.accesses, css.misses,
-              (double)css.misses / (double)css.accesses, css.pending_hits,
-              css.res_fails);
-
-      total_css += css;
-    }
-    fprintf(fout, "\tL1D_total_cache_accesses = %llu\n", total_css.accesses);
-    fprintf(fout, "\tL1D_total_cache_misses = %llu\n", total_css.misses);
-    if (total_css.accesses > 0) {
-      fprintf(fout, "\tL1D_total_cache_miss_rate = %.4lf\n",
-              (double)total_css.misses / (double)total_css.accesses);
-    }
-    fprintf(fout, "\tL1D_total_cache_pending_hits = %llu\n",
-            total_css.pending_hits);
-    fprintf(fout, "\tL1D_total_cache_reservation_fails = %llu\n",
-            total_css.res_fails);
-    total_css.print_port_stats(fout, "\tL1D_cache");
-  }
-
-  // L1C
-  if (!m_shader_config->m_L1C_config.disabled()) {
-    total_css.clear();
-    css.clear();
-    fprintf(fout, "L1C_cache:\n");
-    for (unsigned i = 0; i < m_shader_config->n_simt_clusters; ++i) {
-      m_cluster[i]->get_L1C_sub_stats(css);
-      total_css += css;
-    }
-    fprintf(fout, "\tL1C_total_cache_accesses = %llu\n", total_css.accesses);
-    fprintf(fout, "\tL1C_total_cache_misses = %llu\n", total_css.misses);
-    if (total_css.accesses > 0) {
-      fprintf(fout, "\tL1C_total_cache_miss_rate = %.4lf\n",
-              (double)total_css.misses / (double)total_css.accesses);
-    }
-    fprintf(fout, "\tL1C_total_cache_pending_hits = %llu\n",
-            total_css.pending_hits);
-    fprintf(fout, "\tL1C_total_cache_reservation_fails = %llu\n",
-            total_css.res_fails);
-  }
-
-  // L1T
-  if (!m_shader_config->m_L1T_config.disabled()) {
-    total_css.clear();
-    css.clear();
-    fprintf(fout, "L1T_cache:\n");
-    for (unsigned i = 0; i < m_shader_config->n_simt_clusters; ++i) {
-      m_cluster[i]->get_L1T_sub_stats(css);
-      total_css += css;
-    }
-    fprintf(fout, "\tL1T_total_cache_accesses = %llu\n", total_css.accesses);
-    fprintf(fout, "\tL1T_total_cache_misses = %llu\n", total_css.misses);
-    if (total_css.accesses > 0) {
-      fprintf(fout, "\tL1T_total_cache_miss_rate = %.4lf\n",
-              (double)total_css.misses / (double)total_css.accesses);
-    }
-    fprintf(fout, "\tL1T_total_cache_pending_hits = %llu\n",
-            total_css.pending_hits);
-    fprintf(fout, "\tL1T_total_cache_reservation_fails = %llu\n",
-            total_css.res_fails);
-  }
-}
-
-void gpgpu_sim::shader_print_l1_miss_stat(FILE *fout) const {
-  unsigned total_d1_misses = 0, total_d1_accesses = 0;
-  for (unsigned i = 0; i < m_shader_config->n_simt_clusters; ++i) {
-    unsigned custer_d1_misses = 0, cluster_d1_accesses = 0;
-    m_cluster[i]->print_cache_stats(fout, cluster_d1_accesses,
-                                    custer_d1_misses);
-    total_d1_misses += custer_d1_misses;
-    total_d1_accesses += cluster_d1_accesses;
-  }
-  fprintf(fout, "total_dl1_misses=%d\n", total_d1_misses);
-  fprintf(fout, "total_dl1_accesses=%d\n", total_d1_accesses);
-  fprintf(fout, "total_dl1_miss_rate= %f\n",
-          (float)total_d1_misses / (float)total_d1_accesses);
-  /*
-  fprintf(fout, "THD_INSN_AC: ");
-  for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++)
-     fprintf(fout, "%d ", m_sc[0]->get_thread_n_insn_ac(i));
-  fprintf(fout, "\n");
-  fprintf(fout, "T_L1_Mss: "); //l1 miss rate per thread
-  for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++)
-     fprintf(fout, "%d ", m_sc[0]->get_thread_n_l1_mis_ac(i));
-  fprintf(fout, "\n");
-  fprintf(fout, "T_L1_Mgs: "); //l1 merged miss rate per thread
-  for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++)
-     fprintf(fout, "%d ", m_sc[0]->get_thread_n_l1_mis_ac(i) -
-  m_sc[0]->get_thread_n_l1_mrghit_ac(i));
-  fprintf(fout, "\n");
-  fprintf(fout, "T_L1_Acc: "); //l1 access per thread
-  for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++)
-     fprintf(fout, "%d ", m_sc[0]->get_thread_n_l1_access_ac(i));
-  fprintf(fout, "\n");
-
-  //per warp
-  int temp =0;
-  fprintf(fout, "W_L1_Mss: "); //l1 miss rate per warp
-  for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) {
-     temp += m_sc[0]->get_thread_n_l1_mis_ac(i);
-     if (i%m_shader_config->warp_size ==
-  (unsigned)(m_shader_config->warp_size-1)) {
-        fprintf(fout, "%d ", temp);
-        temp = 0;
-     }
-  }
-  fprintf(fout, "\n");
-  temp=0;
-  fprintf(fout, "W_L1_Mgs: "); //l1 merged miss rate per warp
-  for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) {
-     temp += (m_sc[0]->get_thread_n_l1_mis_ac(i) -
-  m_sc[0]->get_thread_n_l1_mrghit_ac(i) );
-     if (i%m_shader_config->warp_size ==
-  (unsigned)(m_shader_config->warp_size-1)) {
-        fprintf(fout, "%d ", temp);
-        temp = 0;
-     }
-  }
-  fprintf(fout, "\n");
-  temp =0;
-  fprintf(fout, "W_L1_Acc: "); //l1 access per warp
-  for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) {
-     temp += m_sc[0]->get_thread_n_l1_access_ac(i);
-     if (i%m_shader_config->warp_size ==
-  (unsigned)(m_shader_config->warp_size-1)) {
-        fprintf(fout, "%d ", temp);
-        temp = 0;
-     }
-  }
-  fprintf(fout, "\n");
-  */
-}
-
-void warp_inst_t::print(FILE *fout) const {
-  if (empty()) {
-    fprintf(fout, "bubble\n");
-    return;
-  } else
-    fprintf(fout, "0x%04x ", pc);
-  fprintf(fout, "w%02d[", m_warp_id);
-  for (unsigned j = 0; j < m_config->warp_size; j++)
-    fprintf(fout, "%c", (active(j) ? '1' : '0'));
-  fprintf(fout, "]: ");
-  m_config->gpgpu_ctx->func_sim->ptx_print_insn(pc, fout);
-  fprintf(fout, "\n");
-}
-void shader_core_ctx::incexecstat(warp_inst_t *&inst) {
-  if (inst->mem_op == TEX) inctex_stat(inst->active_count(), 1);
-
-  // Latency numbers for next operations are used to scale the power values
-  // for special operations, according observations from microbenchmarking
-  // TODO: put these numbers in the xml configuration
-
-  switch (inst->sp_op) {
-    case INT__OP:
-      incialu_stat(inst->active_count(), 32);
-      break;
-    case INT_MUL_OP:
-      incimul_stat(inst->active_count(), 7.2);
-      break;
-    case INT_MUL24_OP:
-      incimul24_stat(inst->active_count(), 4.2);
-      break;
-    case INT_MUL32_OP:
-      incimul32_stat(inst->active_count(), 4);
-      break;
-    case INT_DIV_OP:
-      incidiv_stat(inst->active_count(), 40);
-      break;
-    case FP__OP:
-      incfpalu_stat(inst->active_count(), 1);
-      break;
-    case FP_MUL_OP:
-      incfpmul_stat(inst->active_count(), 1.8);
-      break;
-    case FP_DIV_OP:
-      incfpdiv_stat(inst->active_count(), 48);
-      break;
-    case FP_SQRT_OP:
-      inctrans_stat(inst->active_count(), 25);
-      break;
-    case FP_LG_OP:
-      inctrans_stat(inst->active_count(), 35);
-      break;
-    case FP_SIN_OP:
-      inctrans_stat(inst->active_count(), 12);
-      break;
-    case FP_EXP_OP:
-      inctrans_stat(inst->active_count(), 35);
-      break;
-    default:
-      break;
-  }
-}
-void shader_core_ctx::print_stage(unsigned int stage, FILE *fout) const {
-  m_pipeline_reg[stage].print(fout);
-  // m_pipeline_reg[stage].print(fout);
-}
-
-void shader_core_ctx::display_simt_state(FILE *fout, int mask) const {
-  if ((mask & 4) && m_config->model == POST_DOMINATOR) {
-    fprintf(fout, "per warp SIMT control-flow state:\n");
-    unsigned n = m_config->n_thread_per_shader / m_config->warp_size;
-    for (unsigned i = 0; i < n; i++) {
-      unsigned nactive = 0;
-      for (unsigned j = 0; j < m_config->warp_size; j++) {
-        unsigned tid = i * m_config->warp_size + j;
-        int done = ptx_thread_done(tid);
-        nactive += (ptx_thread_done(tid) ? 0 : 1);
-        if (done && (mask & 8)) {
-          unsigned done_cycle = m_thread[tid]->donecycle();
-          if (done_cycle) {
-            printf("\n w%02u:t%03u: done @ cycle %u", i, tid, done_cycle);
-          }
+        fprintf(fout, "\tL1C_total_cache_accesses = %llu\n", total_css.accesses);
+        fprintf(fout, "\tL1C_total_cache_misses = %llu\n", total_css.misses);
+        if(total_css.accesses > 0){
+            fprintf(fout, "\tL1C_total_cache_miss_rate = %.4lf\n", (double)total_css.misses / (double)total_css.accesses);
         }
-      }
-      if (nactive == 0) {
-        continue;
-      }
-      m_simt_stack[i]->print(fout);
+        fprintf(fout, "\tL1C_total_cache_pending_hits = %llu\n", total_css.pending_hits);
+        fprintf(fout, "\tL1C_total_cache_reservation_fails = %llu\n", total_css.res_fails);
     }
+
+    // L1T
+    if(!m_shader_config->m_L1T_config.disabled()){
+        total_css.clear();
+        css.clear();
+        fprintf(fout, "L1T_cache:\n");
+        for ( unsigned i = 0; i < m_shader_config->n_simt_clusters; ++i ) {
+            m_cluster[i]->get_L1T_sub_stats(css);
+            total_css += css;
+        }
+        fprintf(fout, "\tL1T_total_cache_accesses = %llu\n", total_css.accesses);
+        fprintf(fout, "\tL1T_total_cache_misses = %llu\n", total_css.misses);
+        if(total_css.accesses > 0){
+            fprintf(fout, "\tL1T_total_cache_miss_rate = %.4lf\n", (double)total_css.misses / (double)total_css.accesses);
+        }
+        fprintf(fout, "\tL1T_total_cache_pending_hits = %llu\n", total_css.pending_hits);
+        fprintf(fout, "\tL1T_total_cache_reservation_fails = %llu\n", total_css.res_fails);
+    }
+}
+
+void gpgpu_sim::shader_print_l1_miss_stat( FILE *fout ) const
+{
+   unsigned total_d1_misses = 0, total_d1_accesses = 0;
+   for ( unsigned i = 0; i < m_shader_config->n_simt_clusters; ++i ) {
+         unsigned custer_d1_misses = 0, cluster_d1_accesses = 0;
+         m_cluster[ i ]->print_cache_stats( fout, cluster_d1_accesses, custer_d1_misses );
+         total_d1_misses += custer_d1_misses;
+         total_d1_accesses += cluster_d1_accesses;
+   }
+   fprintf( fout, "total_dl1_misses=%d\n", total_d1_misses );
+   fprintf( fout, "total_dl1_accesses=%d\n", total_d1_accesses );
+   fprintf( fout, "total_dl1_miss_rate= %f\n", (float)total_d1_misses / (float)total_d1_accesses );
+   /*
+   fprintf(fout, "THD_INSN_AC: ");
+   for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) 
+      fprintf(fout, "%d ", m_sc[0]->get_thread_n_insn_ac(i));
+   fprintf(fout, "\n");
+   fprintf(fout, "T_L1_Mss: "); //l1 miss rate per thread
+   for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) 
+      fprintf(fout, "%d ", m_sc[0]->get_thread_n_l1_mis_ac(i));
+   fprintf(fout, "\n");
+   fprintf(fout, "T_L1_Mgs: "); //l1 merged miss rate per thread
+   for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) 
+      fprintf(fout, "%d ", m_sc[0]->get_thread_n_l1_mis_ac(i) - m_sc[0]->get_thread_n_l1_mrghit_ac(i));
+   fprintf(fout, "\n");
+   fprintf(fout, "T_L1_Acc: "); //l1 access per thread
+   for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) 
+      fprintf(fout, "%d ", m_sc[0]->get_thread_n_l1_access_ac(i));
+   fprintf(fout, "\n");
+
+   //per warp
+   int temp =0; 
+   fprintf(fout, "W_L1_Mss: "); //l1 miss rate per warp
+   for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) {
+      temp += m_sc[0]->get_thread_n_l1_mis_ac(i);
+      if (i%m_shader_config->warp_size == (unsigned)(m_shader_config->warp_size-1)) {
+         fprintf(fout, "%d ", temp);
+         temp = 0;
+      }
+   }
+   fprintf(fout, "\n");
+   temp=0;
+   fprintf(fout, "W_L1_Mgs: "); //l1 merged miss rate per warp
+   for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) {
+      temp += (m_sc[0]->get_thread_n_l1_mis_ac(i) - m_sc[0]->get_thread_n_l1_mrghit_ac(i) );
+      if (i%m_shader_config->warp_size == (unsigned)(m_shader_config->warp_size-1)) {
+         fprintf(fout, "%d ", temp);
+         temp = 0;
+      }
+   }
+   fprintf(fout, "\n");
+   temp =0;
+   fprintf(fout, "W_L1_Acc: "); //l1 access per warp
+   for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) {
+      temp += m_sc[0]->get_thread_n_l1_access_ac(i);
+      if (i%m_shader_config->warp_size == (unsigned)(m_shader_config->warp_size-1)) {
+         fprintf(fout, "%d ", temp);
+         temp = 0;
+      }
+   }
+   fprintf(fout, "\n");
+   */
+}
+
+void warp_inst_t::print( FILE *fout ) const
+{
+    if (empty() ) {
+        fprintf(fout,"bubble\n" );
+        return;
+    } else 
+        fprintf(fout,"0x%04x ", pc );
+    fprintf(fout, "w%02d[", m_warp_id);
+    for (unsigned j=0; j<m_config->warp_size; j++)
+        fprintf(fout, "%c", (active(j)?'1':'0') );
+    fprintf(fout, "]: ");
+    m_config->gpgpu_ctx->func_sim->ptx_print_insn( pc, fout );
     fprintf(fout, "\n");
-  }
+}
+void shader_core_ctx::incexecstat(warp_inst_t *&inst)
+{
+	if(inst->mem_op==TEX)
+		inctex_stat(inst->active_count(),1);
+
+    // Latency numbers for next operations are used to scale the power values
+    // for special operations, according observations from microbenchmarking
+    // TODO: put these numbers in the xml configuration
+
+	switch(inst->sp_op){
+	case INT__OP:
+		incialu_stat(inst->active_count(),32);
+		break;
+	case INT_MUL_OP:
+		incimul_stat(inst->active_count(),7.2);
+		break;
+	case INT_MUL24_OP:
+		incimul24_stat(inst->active_count(),4.2);
+		break;
+	case INT_MUL32_OP:
+		incimul32_stat(inst->active_count(),4);
+		break;
+	case INT_DIV_OP:
+		incidiv_stat(inst->active_count(),40);
+		break;
+	case FP__OP:
+		incfpalu_stat(inst->active_count(),1);
+		break;
+	case FP_MUL_OP:
+		incfpmul_stat(inst->active_count(),1.8);
+		break;
+	case FP_DIV_OP:
+		incfpdiv_stat(inst->active_count(),48);
+		break;
+	case FP_SQRT_OP:
+		inctrans_stat(inst->active_count(),25);
+		break;
+	case FP_LG_OP:
+		inctrans_stat(inst->active_count(),35);
+		break;
+	case FP_SIN_OP:
+		inctrans_stat(inst->active_count(),12);
+		break;
+	case FP_EXP_OP:
+		inctrans_stat(inst->active_count(),35);
+		break;
+	default:
+		break;
+	}
+}
+void shader_core_ctx::print_stage(unsigned int stage, FILE *fout ) const
+{
+   m_pipeline_reg[stage].print(fout);
+   //m_pipeline_reg[stage].print(fout);
 }
 
-void ldst_unit::print(FILE *fout) const {
-  fprintf(fout, "LD/ST unit  = ");
-  m_dispatch_reg->print(fout);
-  if (m_mem_rc != NO_RC_FAIL) {
-    fprintf(fout, "              LD/ST stall condition: ");
-    switch (m_mem_rc) {
-      case BK_CONF:
-        fprintf(fout, "BK_CONF");
-        break;
-      case MSHR_RC_FAIL:
-        fprintf(fout, "MSHR_RC_FAIL");
-        break;
-      case ICNT_RC_FAIL:
-        fprintf(fout, "ICNT_RC_FAIL");
-        break;
-      case COAL_STALL:
-        fprintf(fout, "COAL_STALL");
-        break;
-      case WB_ICNT_RC_FAIL:
-        fprintf(fout, "WB_ICNT_RC_FAIL");
-        break;
-      case WB_CACHE_RSRV_FAIL:
-        fprintf(fout, "WB_CACHE_RSRV_FAIL");
-        break;
-      case N_MEM_STAGE_STALL_TYPE:
-        fprintf(fout, "N_MEM_STAGE_STALL_TYPE");
-        break;
-      default:
-        abort();
+void shader_core_ctx::display_simt_state(FILE *fout, int mask ) const
+{
+    if ( (mask & 4) && m_config->model == POST_DOMINATOR ) {
+       fprintf(fout,"per warp SIMT control-flow state:\n");
+       unsigned n = m_config->n_thread_per_shader / m_config->warp_size;
+       for (unsigned i=0; i < n; i++) {
+          unsigned nactive = 0;
+          for (unsigned j=0; j<m_config->warp_size; j++ ) {
+             unsigned tid = i*m_config->warp_size + j;
+             int done = ptx_thread_done(tid);
+             nactive += (ptx_thread_done(tid)?0:1);
+             if ( done && (mask & 8) ) {
+                unsigned done_cycle = m_thread[tid]->donecycle();
+                if ( done_cycle ) {
+                   printf("\n w%02u:t%03u: done @ cycle %u", i, tid, done_cycle );
+                }
+             }
+          }
+          if ( nactive == 0 ) {
+             continue;
+          }
+          m_simt_stack[i]->print(fout);
+       }
+       fprintf(fout,"\n");
     }
-    fprintf(fout, "\n");
-  }
-  fprintf(fout, "LD/ST wb    = ");
-  m_next_wb.print(fout);
-  fprintf(
-      fout,
-      "Last LD/ST writeback @ %llu + %llu (gpu_sim_cycle+gpu_tot_sim_cycle)\n",
-      m_last_inst_gpu_sim_cycle, m_last_inst_gpu_tot_sim_cycle);
-  fprintf(fout, "Pending register writes:\n");
-  std::map<unsigned /*warp_id*/,
-           std::map<unsigned /*regnum*/, unsigned /*count*/> >::const_iterator
-      w;
-  for (w = m_pending_writes.begin(); w != m_pending_writes.end(); w++) {
-    unsigned warp_id = w->first;
-    const std::map<unsigned /*regnum*/, unsigned /*count*/> &warp_info =
-        w->second;
-    if (warp_info.empty()) continue;
-    fprintf(fout, "  w%2u : ", warp_id);
-    std::map<unsigned /*regnum*/, unsigned /*count*/>::const_iterator r;
-    for (r = warp_info.begin(); r != warp_info.end(); ++r) {
-      fprintf(fout, "  %u(%u)", r->first, r->second);
-    }
-    fprintf(fout, "\n");
-  }
-  m_L1C->display_state(fout);
-  m_L1T->display_state(fout);
-  if (!m_config->m_L1D_config.disabled()) m_L1D->display_state(fout);
-  fprintf(fout, "LD/ST response FIFO (occupancy = %zu):\n",
-          m_response_fifo.size());
-  for (std::list<mem_fetch *>::const_iterator i = m_response_fifo.begin();
-       i != m_response_fifo.end(); i++) {
-    const mem_fetch *mf = *i;
-    mf->print(fout);
-  }
 }
 
-void shader_core_ctx::display_pipeline(FILE *fout, int print_mem,
-                                       int mask) const {
-  fprintf(fout, "=================================================\n");
-  fprintf(fout, "shader %u at cycle %Lu+%Lu (%u threads running)\n", m_sid,
-          m_gpu->gpu_tot_sim_cycle, m_gpu->gpu_sim_cycle, m_not_completed);
-  fprintf(fout, "=================================================\n");
-
-  dump_warp_state(fout);
-  fprintf(fout, "\n");
-
-  m_L1I->display_state(fout);
-
-  fprintf(fout, "IF/ID       = ");
-  if (!m_inst_fetch_buffer.m_valid)
-    fprintf(fout, "bubble\n");
-  else {
-    fprintf(fout, "w%2u : pc = 0x%x, nbytes = %u\n",
-            m_inst_fetch_buffer.m_warp_id, m_inst_fetch_buffer.m_pc,
-            m_inst_fetch_buffer.m_nbytes);
-  }
-  fprintf(fout, "\nibuffer status:\n");
-  for (unsigned i = 0; i < m_config->max_warps_per_shader; i++) {
-    if (!m_warp[i].ibuffer_empty()) m_warp[i].print_ibuffer(fout);
-  }
-  fprintf(fout, "\n");
-  display_simt_state(fout, mask);
-  fprintf(fout, "-------------------------- Scoreboard\n");
-  m_scoreboard->printContents();
-  /*
-     fprintf(fout,"ID/OC (SP)  = ");
-     print_stage(ID_OC_SP, fout);
-     fprintf(fout,"ID/OC (SFU) = ");
-     print_stage(ID_OC_SFU, fout);
-     fprintf(fout,"ID/OC (MEM) = ");
-     print_stage(ID_OC_MEM, fout);
-  */
-  fprintf(fout, "-------------------------- OP COL\n");
-  m_operand_collector.dump(fout);
-  /* fprintf(fout, "OC/EX (SP)  = ");
-     print_stage(OC_EX_SP, fout);
-     fprintf(fout, "OC/EX (SFU) = ");
-     print_stage(OC_EX_SFU, fout);
-     fprintf(fout, "OC/EX (MEM) = ");
-     print_stage(OC_EX_MEM, fout);
-  */
-  fprintf(fout, "-------------------------- Pipe Regs\n");
-
-  for (unsigned i = 0; i < N_PIPELINE_STAGES; i++) {
-    fprintf(fout, "--- %s ---\n", pipeline_stage_name_decode[i]);
-    print_stage(i, fout);
-    fprintf(fout, "\n");
-  }
-
-  fprintf(fout, "-------------------------- Fu\n");
-  for (unsigned n = 0; n < m_num_function_units; n++) {
-    m_fu[n]->print(fout);
-    fprintf(fout, "---------------\n");
-  }
-  fprintf(fout, "-------------------------- other:\n");
-
-  for (unsigned i = 0; i < num_result_bus; i++) {
-    std::string bits = m_result_bus[i]->to_string();
-    fprintf(fout, "EX/WB sched[%d]= %s\n", i, bits.c_str());
-  }
-  fprintf(fout, "EX/WB      = ");
-  print_stage(EX_WB, fout);
-  fprintf(fout, "\n");
-  fprintf(
-      fout,
-      "Last EX/WB writeback @ %llu + %llu (gpu_sim_cycle+gpu_tot_sim_cycle)\n",
-      m_last_inst_gpu_sim_cycle, m_last_inst_gpu_tot_sim_cycle);
-
-  if (m_active_threads.count() <= 2 * m_config->warp_size) {
-    fprintf(fout, "Active Threads : ");
-    unsigned last_warp_id = -1;
-    for (unsigned tid = 0; tid < m_active_threads.size(); tid++) {
-      unsigned warp_id = tid / m_config->warp_size;
-      if (m_active_threads.test(tid)) {
-        if (warp_id != last_warp_id) {
-          fprintf(fout, "\n  warp %u : ", warp_id);
-          last_warp_id = warp_id;
+void ldst_unit::print(FILE *fout) const
+{
+    fprintf(fout,"LD/ST unit  = ");
+    m_dispatch_reg->print(fout);
+    if ( m_mem_rc != NO_RC_FAIL ) {
+        fprintf(fout,"              LD/ST stall condition: ");
+        switch ( m_mem_rc ) {
+        case BK_CONF:        fprintf(fout,"BK_CONF"); break;
+        case MSHR_RC_FAIL:   fprintf(fout,"MSHR_RC_FAIL"); break;
+        case ICNT_RC_FAIL:   fprintf(fout,"ICNT_RC_FAIL"); break;
+        case COAL_STALL:     fprintf(fout,"COAL_STALL"); break;
+        case WB_ICNT_RC_FAIL: fprintf(fout,"WB_ICNT_RC_FAIL"); break;
+        case WB_CACHE_RSRV_FAIL: fprintf(fout,"WB_CACHE_RSRV_FAIL"); break;
+        case N_MEM_STAGE_STALL_TYPE: fprintf(fout,"N_MEM_STAGE_STALL_TYPE"); break;
+        default: abort();
         }
-        fprintf(fout, "%u ", tid);
-      }
+        fprintf(fout,"\n");
     }
-  }
+    fprintf(fout,"LD/ST wb    = ");
+    m_next_wb.print(fout);
+    fprintf(fout, "Last LD/ST writeback @ %llu + %llu (gpu_sim_cycle+gpu_tot_sim_cycle)\n",
+                  m_last_inst_gpu_sim_cycle, m_last_inst_gpu_tot_sim_cycle );
+    fprintf(fout,"Pending register writes:\n");
+    std::map<unsigned/*warp_id*/, std::map<unsigned/*regnum*/,unsigned/*count*/> >::const_iterator w;
+    for( w=m_pending_writes.begin(); w!=m_pending_writes.end(); w++ ) {
+        unsigned warp_id = w->first;
+        const std::map<unsigned/*regnum*/,unsigned/*count*/> &warp_info = w->second;
+        if( warp_info.empty() ) 
+            continue;
+        fprintf(fout,"  w%2u : ", warp_id );
+        std::map<unsigned/*regnum*/,unsigned/*count*/>::const_iterator r;
+        for( r=warp_info.begin(); r!=warp_info.end(); ++r ) {
+            fprintf(fout,"  %u(%u)", r->first, r->second );
+        }
+        fprintf(fout,"\n");
+    }
+    m_L1C->display_state(fout);
+    m_L1T->display_state(fout);
+    if( !m_config->m_L1D_config.disabled() )
+    	m_L1D->display_state(fout);
+    fprintf(fout,"LD/ST response FIFO (occupancy = %zu):\n", m_response_fifo.size() );
+    for( std::list<mem_fetch*>::const_iterator i=m_response_fifo.begin(); i != m_response_fifo.end(); i++ ) {
+        const mem_fetch *mf = *i;
+        mf->print(fout);
+    }
 }
 
-unsigned int shader_core_config::max_cta(const kernel_info_t &k) const {
-  unsigned threads_per_cta = k.threads_per_cta();
-  const class function_info *kernel = k.entry();
-  unsigned int padded_cta_size = threads_per_cta;
-  if (padded_cta_size % warp_size)
-    padded_cta_size = ((padded_cta_size / warp_size) + 1) * (warp_size);
+void shader_core_ctx::display_pipeline(FILE *fout, int print_mem, int mask ) const
+{
+   fprintf(fout, "=================================================\n");
+   fprintf(fout, "shader %u at cycle %Lu+%Lu (%u threads running)\n", m_sid, 
+           m_gpu->gpu_tot_sim_cycle, m_gpu->gpu_sim_cycle, m_not_completed);
+   fprintf(fout, "=================================================\n");
 
-  // Limit by n_threads/shader
-  unsigned int result_thread = n_thread_per_shader / padded_cta_size;
+   dump_warp_state(fout);
+   fprintf(fout,"\n");
 
-  const struct gpgpu_ptx_sim_info *kernel_info = ptx_sim_kernel_info(kernel);
+   m_L1I->display_state(fout);
 
-  // Limit by shmem/shader
-  unsigned int result_shmem = (unsigned)-1;
-  if (kernel_info->smem > 0)
-    result_shmem = gpgpu_shmem_size / kernel_info->smem;
+   fprintf(fout, "IF/ID       = ");
+   if( !m_inst_fetch_buffer.m_valid )
+       fprintf(fout,"bubble\n");
+   else {
+       fprintf(fout,"w%2u : pc = 0x%x, nbytes = %u\n", 
+               m_inst_fetch_buffer.m_warp_id,
+               m_inst_fetch_buffer.m_pc, 
+               m_inst_fetch_buffer.m_nbytes );
+   }
+   fprintf(fout,"\nibuffer status:\n");
+   for( unsigned i=0; i<m_config->max_warps_per_shader; i++) {
+       if( !m_warp[i].ibuffer_empty() ) 
+           m_warp[i].print_ibuffer(fout);
+   }
+   fprintf(fout,"\n");
+   display_simt_state(fout,mask);
+   fprintf(fout, "-------------------------- Scoreboard\n");
+   m_scoreboard->printContents();
+/*
+   fprintf(fout,"ID/OC (SP)  = ");
+   print_stage(ID_OC_SP, fout);
+   fprintf(fout,"ID/OC (SFU) = ");
+   print_stage(ID_OC_SFU, fout);
+   fprintf(fout,"ID/OC (MEM) = ");
+   print_stage(ID_OC_MEM, fout);
+*/
+   fprintf(fout, "-------------------------- OP COL\n");
+   m_operand_collector.dump(fout);
+/* fprintf(fout, "OC/EX (SP)  = ");
+   print_stage(OC_EX_SP, fout);
+   fprintf(fout, "OC/EX (SFU) = ");
+   print_stage(OC_EX_SFU, fout);
+   fprintf(fout, "OC/EX (MEM) = ");
+   print_stage(OC_EX_MEM, fout);
+*/
+   fprintf(fout, "-------------------------- Pipe Regs\n");
 
-  // Limit by register count, rounded up to multiple of 4.
-  unsigned int result_regs = (unsigned)-1;
-  if (kernel_info->regs > 0)
-    result_regs = gpgpu_shader_registers /
-                  (padded_cta_size * ((kernel_info->regs + 3) & ~3));
+   for (unsigned i = 0; i < N_PIPELINE_STAGES; i++) {
+       fprintf(fout,"--- %s ---\n",pipeline_stage_name_decode[i]);
+       print_stage(i,fout);fprintf(fout,"\n");
+   }
 
-  // Limit by CTA
-  unsigned int result_cta = max_cta_per_core;
+   fprintf(fout, "-------------------------- Fu\n");
+   for( unsigned n=0; n < m_num_function_units; n++ ){
+       m_fu[n]->print(fout);
+       fprintf(fout, "---------------\n");
+   }
+   fprintf(fout, "-------------------------- other:\n");
 
-  unsigned result = result_thread;
-  result = gs_min2(result, result_shmem);
-  result = gs_min2(result, result_regs);
-  result = gs_min2(result, result_cta);
+   for(unsigned i=0; i<num_result_bus; i++){
+	   std::string bits = m_result_bus[i]->to_string();
+	   fprintf(fout, "EX/WB sched[%d]= %s\n", i, bits.c_str() );
+   }
+   fprintf(fout, "EX/WB      = ");
+   print_stage(EX_WB, fout);
+   fprintf(fout, "\n");
+   fprintf(fout, "Last EX/WB writeback @ %llu + %llu (gpu_sim_cycle+gpu_tot_sim_cycle)\n",
+                 m_last_inst_gpu_sim_cycle, m_last_inst_gpu_tot_sim_cycle );
 
-  static const struct gpgpu_ptx_sim_info *last_kinfo = NULL;
-  if (last_kinfo !=
-      kernel_info) {  // Only print out stats if kernel_info struct changes
-    last_kinfo = kernel_info;
-    printf("GPGPU-Sim uArch: CTA/core = %u, limited by:", result);
-    if (result == result_thread) printf(" threads");
-    if (result == result_shmem) printf(" shmem");
-    if (result == result_regs) printf(" regs");
-    if (result == result_cta) printf(" cta_limit");
-    printf("\n");
-  }
+   if( m_active_threads.count() <= 2*m_config->warp_size ) {
+       fprintf(fout,"Active Threads : ");
+       unsigned last_warp_id = -1;
+       for(unsigned tid=0; tid < m_active_threads.size(); tid++ ) {
+           unsigned warp_id = tid/m_config->warp_size;
+           if( m_active_threads.test(tid) ) {
+               if( warp_id != last_warp_id ) {
+                   fprintf(fout,"\n  warp %u : ", warp_id );
+                   last_warp_id=warp_id;
+               }
+               fprintf(fout,"%u ", tid );
+           }
+       }
+   }
 
-  // gpu_max_cta_per_shader is limited by number of CTAs if not enough to keep
-  // all cores busy
-  if (k.num_blocks() < result * num_shader()) {
-    result = k.num_blocks() / num_shader();
-    if (k.num_blocks() % num_shader()) result++;
-  }
+}
 
-  assert(result <= MAX_CTA_PER_SHADER);
-  if (result < 1) {
-    printf(
-        "GPGPU-Sim uArch: ERROR ** Kernel requires more resources than shader "
-        "has.\n");
-    if (gpgpu_ignore_resources_limitation) {
-      printf(
-          "GPGPU-Sim uArch: gpgpu_ignore_resources_limitation is set, ignore "
-          "the ERROR!\n");
-      return 1;
+unsigned int shader_core_config::max_cta( const kernel_info_t &k ) const
+{
+   unsigned threads_per_cta  = k.threads_per_cta();
+   const class function_info *kernel = k.entry();
+   unsigned int padded_cta_size = threads_per_cta;
+   if (padded_cta_size%warp_size) 
+      padded_cta_size = ((padded_cta_size/warp_size)+1)*(warp_size);
+
+   //Limit by n_threads/shader
+   unsigned int result_thread = n_thread_per_shader / padded_cta_size;
+
+   const struct gpgpu_ptx_sim_info *kernel_info = ptx_sim_kernel_info(kernel);
+
+   //Limit by shmem/shader
+   unsigned int result_shmem = (unsigned)-1;
+   if (kernel_info->smem > 0)
+      result_shmem = gpgpu_shmem_size / kernel_info->smem;
+
+   //Limit by register count, rounded up to multiple of 4.
+   unsigned int result_regs = (unsigned)-1;
+   if (kernel_info->regs > 0)
+      result_regs = gpgpu_shader_registers / (padded_cta_size * ((kernel_info->regs+3)&~3));
+
+   //Limit by CTA
+   unsigned int result_cta = max_cta_per_core;
+
+   unsigned result = result_thread;
+   result = gs_min2(result, result_shmem);
+   result = gs_min2(result, result_regs);
+   result = gs_min2(result, result_cta);
+
+   static const struct gpgpu_ptx_sim_info* last_kinfo = NULL;
+   if (last_kinfo != kernel_info) {   //Only print out stats if kernel_info struct changes
+      last_kinfo = kernel_info;
+      printf ("GPGPU-Sim uArch: CTA/core = %u, limited by:", result);
+      if (result == result_thread) printf (" threads");
+      if (result == result_shmem) printf (" shmem");
+      if (result == result_regs) printf (" regs");
+      if (result == result_cta) printf (" cta_limit");
+      printf ("\n");
+   }
+
+    //gpu_max_cta_per_shader is limited by number of CTAs if not enough to keep all cores busy    
+    if( k.num_blocks() < result*num_shader() ) { 
+       result = k.num_blocks() / num_shader();
+       if (k.num_blocks() % num_shader())
+          result++;
     }
-    abort();
-  }
 
-  if (adaptive_volta_cache_config && !k.volta_cache_config_set) {
-    // For Volta, we assign the remaining shared memory to L1 cache
-    // For more info, see
-    // https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#shared-memory-7-x
-    unsigned total_shmed = kernel_info->smem * result;
-    assert(total_shmed >= 0 && total_shmed <= gpgpu_shmem_size);
-    assert(gpgpu_shmem_size == 98304);     // Volta has 96 KB shared
-    assert(m_L1D_config.get_nset() == 4);  // Volta L1 has four sets
-    if (total_shmed < gpgpu_shmem_size) {
-      if (total_shmed == 0)
-        m_L1D_config.set_assoc(256);  // L1 is 128KB ans shd=0
-      else if (total_shmed > 0 && total_shmed <= 8192)
-        m_L1D_config.set_assoc(240);  // L1 is 120KB ans shd=8KB
-      else if (total_shmed > 8192 && total_shmed <= 16384)
-        m_L1D_config.set_assoc(224);  // L1 is 112KB ans shd=16KB
-      else if (total_shmed > 16384 && total_shmed <= 32768)
-        m_L1D_config.set_assoc(192);  // L1 is 96KB ans shd=32KB
-      else if (total_shmed > 32768 && total_shmed <= 65536)
-        m_L1D_config.set_assoc(128);  // L1 is 64KB ans shd=64KB
-      else if (total_shmed > 65536 && total_shmed <= gpgpu_shmem_size)
-        m_L1D_config.set_assoc(64);  // L1 is 32KB and shd=96KB
-      else
-        assert(0);
-
-      printf("GPGPU-Sim: Reconfigure L1 cache in Volta Archi to %uKB\n",
-             m_L1D_config.get_total_size_inKB());
+    assert( result <= MAX_CTA_PER_SHADER );
+    if (result < 1) {
+       printf ("GPGPU-Sim uArch: ERROR ** Kernel requires more resources than shader has.\n");
+       if(gpgpu_ignore_resources_limitation) {
+    	   printf ("GPGPU-Sim uArch: gpgpu_ignore_resources_limitation is set, ignore the ERROR!\n");
+    	   return 1;
+       }
+       abort();
     }
 
-    k.volta_cache_config_set = true;
-  }
+    if(adaptive_volta_cache_config && !k.volta_cache_config_set) {
+    	//For Volta, we assign the remaining shared memory to L1 cache
+    	//For more info, see https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#shared-memory-7-x
+    	unsigned total_shmed = kernel_info->smem * result;
+    	assert(total_shmed >=0 && total_shmed <= gpgpu_shmem_size);
+    	assert(gpgpu_shmem_size == 98304); //Volta has 96 KB shared
+    	assert(m_L1D_config.get_nset() == 4);  //Volta L1 has four sets
+    	if(total_shmed < gpgpu_shmem_size){
+    		if(total_shmed == 0)
+    			m_L1D_config.set_assoc(256);  //L1 is 128KB ans shd=0
+    		else if(total_shmed > 0 && total_shmed <= 8192)
+    			m_L1D_config.set_assoc(240);  //L1 is 120KB ans shd=8KB
+    		else if(total_shmed > 8192 && total_shmed <= 16384)
+    		    m_L1D_config.set_assoc(224);  //L1 is 112KB ans shd=16KB
+    		else if(total_shmed > 16384 && total_shmed <= 32768)
+    		    m_L1D_config.set_assoc(192);  //L1 is 96KB ans shd=32KB
+    		else if(total_shmed > 32768 && total_shmed <= 65536)
+    		    m_L1D_config.set_assoc(128);	//L1 is 64KB ans shd=64KB
+    		else if(total_shmed > 65536 && total_shmed <= gpgpu_shmem_size)
+    		     m_L1D_config.set_assoc(64); //L1 is 32KB and shd=96KB
+    		else
+    			assert(0);
 
-  return result;
+    		 printf ("GPGPU-Sim: Reconfigure L1 cache in Volta Archi to %uKB\n", m_L1D_config.get_total_size_inKB());
+    	}
+
+    	k.volta_cache_config_set = true;
+    }
+
+    return result;
 }
 
 void shader_core_config::set_pipeline_latency() {
-  // calculate the max latency  based on the input
 
-  unsigned int_latency[5];
-  unsigned fp_latency[5];
-  unsigned dp_latency[5];
-  unsigned sfu_latency;
-  unsigned tensor_latency;
+		//calculate the max latency  based on the input
 
-  /*
-   * [0] ADD,SUB
-   * [1] MAX,Min
-   * [2] MUL
-   * [3] MAD
-   * [4] DIV
-   */
-  sscanf(gpgpu_ctx->func_sim->opcode_latency_int, "%u,%u,%u,%u,%u",
-         &int_latency[0], &int_latency[1], &int_latency[2], &int_latency[3],
-         &int_latency[4]);
-  sscanf(gpgpu_ctx->func_sim->opcode_latency_fp, "%u,%u,%u,%u,%u",
-         &fp_latency[0], &fp_latency[1], &fp_latency[2], &fp_latency[3],
-         &fp_latency[4]);
-  sscanf(gpgpu_ctx->func_sim->opcode_latency_dp, "%u,%u,%u,%u,%u",
-         &dp_latency[0], &dp_latency[1], &dp_latency[2], &dp_latency[3],
-         &dp_latency[4]);
-  sscanf(gpgpu_ctx->func_sim->opcode_latency_sfu, "%u", &sfu_latency);
-  sscanf(gpgpu_ctx->func_sim->opcode_latency_tensor, "%u", &tensor_latency);
+		unsigned int_latency[5];
+		unsigned fp_latency[5];
+		unsigned dp_latency[5];
+		unsigned sfu_latency;
+		unsigned tensor_latency;
 
-  // all div operation are executed on sfu
-  // assume that the max latency are dp div or normal sfu_latency
-  max_sfu_latency = std::max(dp_latency[4], sfu_latency);
-  // assume that the max operation has the max latency
-  max_sp_latency = fp_latency[1];
-  max_int_latency = int_latency[1];
-  max_dp_latency = dp_latency[1];
-  max_tensor_core_latency = tensor_latency;
+			/*
+			 * [0] ADD,SUB
+			 * [1] MAX,Min
+			 * [2] MUL
+			 * [3] MAD
+			 * [4] DIV
+			 */
+			sscanf(gpgpu_ctx->func_sim->opcode_latency_int, "%u,%u,%u,%u,%u",
+					&int_latency[0],&int_latency[1],&int_latency[2],
+					&int_latency[3],&int_latency[4]);
+			sscanf(gpgpu_ctx->func_sim->opcode_latency_fp, "%u,%u,%u,%u,%u",
+					&fp_latency[0],&fp_latency[1],&fp_latency[2],
+					&fp_latency[3],&fp_latency[4]);
+			sscanf(gpgpu_ctx->func_sim->opcode_latency_dp, "%u,%u,%u,%u,%u",
+					&dp_latency[0],&dp_latency[1],&dp_latency[2],
+					&dp_latency[3],&dp_latency[4]);
+			sscanf(gpgpu_ctx->func_sim->opcode_latency_sfu, "%u",
+					&sfu_latency);
+			sscanf(gpgpu_ctx->func_sim->opcode_latency_tensor, "%u",
+					&tensor_latency);
+
+		//all div operation are executed on sfu
+		//assume that the max latency are dp div or normal sfu_latency
+		max_sfu_latency = std::max(dp_latency[4],sfu_latency);
+		//assume that the max operation has the max latency
+		max_sp_latency = fp_latency[1];
+		max_int_latency = int_latency[1];
+		max_dp_latency = dp_latency[1];
+		max_tensor_core_latency = tensor_latency;
+
 }
 
-void shader_core_ctx::cycle() {
-  if (!isactive() && get_not_completed() == 0) return;
+void shader_core_ctx::cycle()
+{
+	if(!isactive() && get_not_completed() == 0)
+		return;
 
-  m_stats->shader_cycles[m_sid]++;
-  writeback();
-  execute();
-  read_operands();
-  issue();
-  decode();
-  fetch();
+	m_stats->shader_cycles[m_sid]++;
+    writeback();
+    execute();
+    read_operands();
+    issue();
+    decode();
+    fetch();
 }
 
 // Flushes all content of the cache to memory
 
-void shader_core_ctx::cache_flush() { m_ldst_unit->flush(); }
-
-void shader_core_ctx::cache_invalidate() { m_ldst_unit->invalidate(); }
-
-// modifiers
-std::list<opndcoll_rfu_t::op_t> opndcoll_rfu_t::arbiter_t::allocate_reads() {
-  std::list<op_t> result;  // a list of registers that (a) are in different
-                           // register banks, (b) do not go to the same operand
-                           // collector
-
-  int input;
-  int output;
-  int _inputs = m_num_banks;
-  int _outputs = m_num_collectors;
-  int _square = (_inputs > _outputs) ? _inputs : _outputs;
-  assert(_square > 0);
-  int _pri = (int)m_last_cu;
-
-  // Clear matching
-  for (int i = 0; i < _inputs; ++i) _inmatch[i] = -1;
-  for (int j = 0; j < _outputs; ++j) _outmatch[j] = -1;
-
-  for (unsigned i = 0; i < m_num_banks; i++) {
-    for (unsigned j = 0; j < m_num_collectors; j++) {
-      assert(i < (unsigned)_inputs);
-      assert(j < (unsigned)_outputs);
-      _request[i][j] = 0;
-    }
-    if (!m_queue[i].empty()) {
-      const op_t &op = m_queue[i].front();
-      int oc_id = op.get_oc_id();
-      assert(i < (unsigned)_inputs);
-      assert(oc_id < _outputs);
-      _request[i][oc_id] = 1;
-    }
-    if (m_allocated_bank[i].is_write()) {
-      assert(i < (unsigned)_inputs);
-      _inmatch[i] = 0;  // write gets priority
-    }
-  }
-
-  ///// wavefront allocator from booksim... --->
-
-  // Loop through diagonals of request matrix
-
-  for (int p = 0; p < _square; ++p) {
-    output = (_pri + p) % _square;
-
-    // Step through the current diagonal
-    for (input = 0; input < _inputs; ++input) {
-      assert(input < _inputs);
-      assert(output < _outputs);
-      if ((output < _outputs) && (_inmatch[input] == -1) &&
-          (_outmatch[output] == -1) &&
-          (_request[input][output] /*.label != -1*/)) {
-        // Grant!
-        _inmatch[input] = output;
-        _outmatch[output] = input;
-      }
-
-      output = (output + 1) % _square;
-    }
-  }
-
-  // Round-robin the priority diagonal
-  _pri = (_pri + 1) % _square;
-
-  /// <--- end code from booksim
-
-  m_last_cu = _pri;
-  for (unsigned i = 0; i < m_num_banks; i++) {
-    if (_inmatch[i] != -1) {
-      if (!m_allocated_bank[i].is_write()) {
-        unsigned bank = (unsigned)i;
-        op_t &op = m_queue[bank].front();
-        result.push_back(op);
-        m_queue[bank].pop_front();
-      }
-    }
-  }
-
-  return result;
+void shader_core_ctx::cache_flush()
+{
+   m_ldst_unit->flush();
 }
 
-barrier_set_t::barrier_set_t(shader_core_ctx *shader,
-                             unsigned max_warps_per_core,
-                             unsigned max_cta_per_core,
-                             unsigned max_barriers_per_cta,
-                             unsigned warp_size) {
-  m_max_warps_per_core = max_warps_per_core;
-  m_max_cta_per_core = max_cta_per_core;
-  m_max_barriers_per_cta = max_barriers_per_cta;
-  m_warp_size = warp_size;
-  m_shader = shader;
-  if (max_warps_per_core > WARP_PER_CTA_MAX) {
-    printf(
-        "ERROR ** increase WARP_PER_CTA_MAX in shader.h from %u to >= %u or "
-        "warps per cta in gpgpusim.config\n",
-        WARP_PER_CTA_MAX, max_warps_per_core);
-    exit(1);
-  }
-  if (max_barriers_per_cta > MAX_BARRIERS_PER_CTA) {
-    printf(
-        "ERROR ** increase MAX_BARRIERS_PER_CTA in abstract_hardware_model.h "
-        "from %u to >= %u or barriers per cta in gpgpusim.config\n",
-        MAX_BARRIERS_PER_CTA, max_barriers_per_cta);
-    exit(1);
-  }
-  m_warp_active.reset();
-  m_warp_at_barrier.reset();
-  for (unsigned i = 0; i < max_barriers_per_cta; i++) {
-    m_bar_id_to_warps[i].reset();
-  }
+void shader_core_ctx::cache_invalidate()
+{
+   m_ldst_unit->invalidate();
+}
+
+// modifiers
+std::list<opndcoll_rfu_t::op_t> opndcoll_rfu_t::arbiter_t::allocate_reads() 
+{
+   std::list<op_t> result;  // a list of registers that (a) are in different register banks, (b) do not go to the same operand collector
+
+   int input;
+   int output;
+   int _inputs = m_num_banks;
+   int _outputs = m_num_collectors;
+   int _square = ( _inputs > _outputs ) ? _inputs : _outputs;
+   assert(_square > 0);
+   int _pri = (int)m_last_cu;
+
+   // Clear matching
+   for ( int i = 0; i < _inputs; ++i ) 
+      _inmatch[i] = -1;
+   for ( int j = 0; j < _outputs; ++j ) 
+      _outmatch[j] = -1;
+
+   for( unsigned i=0; i<m_num_banks; i++) {
+      for( unsigned j=0; j<m_num_collectors; j++) {
+         assert( i < (unsigned)_inputs );
+         assert( j < (unsigned)_outputs );
+         _request[i][j] = 0;
+      }
+      if( !m_queue[i].empty() ) {
+         const op_t &op = m_queue[i].front();
+         int oc_id = op.get_oc_id();
+         assert( i < (unsigned)_inputs );
+         assert( oc_id < _outputs );
+         _request[i][oc_id] = 1;
+      }
+      if( m_allocated_bank[i].is_write() ) {
+         assert( i < (unsigned)_inputs );
+         _inmatch[i] = 0; // write gets priority
+      }
+   }
+
+   ///// wavefront allocator from booksim... --->
+   
+   // Loop through diagonals of request matrix
+
+   for ( int p = 0; p < _square; ++p ) {
+      output = ( _pri + p ) % _square;
+
+      // Step through the current diagonal
+      for ( input = 0; input < _inputs; ++input ) {
+          assert( input < _inputs );
+          assert( output < _outputs );
+         if ( ( output < _outputs ) && 
+              ( _inmatch[input] == -1 ) && 
+              ( _outmatch[output] == -1 ) &&
+              ( _request[input][output]/*.label != -1*/ ) ) {
+            // Grant!
+            _inmatch[input] = output;
+            _outmatch[output] = input;
+         }
+
+         output = ( output + 1 ) % _square;
+      }
+   }
+
+   // Round-robin the priority diagonal
+   _pri = ( _pri + 1 ) % _square;
+
+   /// <--- end code from booksim
+
+   m_last_cu = _pri;
+   for( unsigned i=0; i < m_num_banks; i++ ) {
+      if( _inmatch[i] != -1 ) {
+         if( !m_allocated_bank[i].is_write() ) {
+            unsigned bank = (unsigned)i;
+            op_t &op = m_queue[bank].front();
+            result.push_back(op);
+            m_queue[bank].pop_front();
+         }
+      }
+   }
+
+   return result;
+}
+
+barrier_set_t::barrier_set_t(shader_core_ctx *shader,unsigned max_warps_per_core, unsigned max_cta_per_core, unsigned max_barriers_per_cta, unsigned warp_size)
+{
+   m_max_warps_per_core = max_warps_per_core;
+   m_max_cta_per_core = max_cta_per_core;
+   m_max_barriers_per_cta = max_barriers_per_cta;
+   m_warp_size = warp_size;
+   m_shader = shader;
+   if( max_warps_per_core > WARP_PER_CTA_MAX ) {
+      printf("ERROR ** increase WARP_PER_CTA_MAX in shader.h from %u to >= %u or warps per cta in gpgpusim.config\n",
+             WARP_PER_CTA_MAX, max_warps_per_core );
+      exit(1);
+   }
+   if(max_barriers_per_cta > MAX_BARRIERS_PER_CTA){
+	   printf("ERROR ** increase MAX_BARRIERS_PER_CTA in abstract_hardware_model.h from %u to >= %u or barriers per cta in gpgpusim.config\n",
+			   MAX_BARRIERS_PER_CTA, max_barriers_per_cta );
+	   exit(1);
+   }
+   m_warp_active.reset();
+   m_warp_at_barrier.reset();
+   for(unsigned i=0; i<max_barriers_per_cta; i++){
+	   m_bar_id_to_warps[i].reset();
+   }
 }
 
 // during cta allocation
-void barrier_set_t::allocate_barrier(unsigned cta_id, warp_set_t warps) {
-  assert(cta_id < m_max_cta_per_core);
-  cta_to_warp_t::iterator w = m_cta_to_warps.find(cta_id);
-  assert(w == m_cta_to_warps.end());  // cta should not already be active or
-                                      // allocated barrier resources
-  m_cta_to_warps[cta_id] = warps;
-  assert(m_cta_to_warps.size() <=
-         m_max_cta_per_core);  // catch cta's that were not properly deallocated
+void barrier_set_t::allocate_barrier( unsigned cta_id, warp_set_t warps )
+{
+   assert( cta_id < m_max_cta_per_core );
+   cta_to_warp_t::iterator w=m_cta_to_warps.find(cta_id);
+   assert( w == m_cta_to_warps.end() ); // cta should not already be active or allocated barrier resources
+   m_cta_to_warps[cta_id] = warps;
+   assert( m_cta_to_warps.size() <= m_max_cta_per_core ); // catch cta's that were not properly deallocated
+  
+   m_warp_active |= warps;
+   m_warp_at_barrier &= ~warps;
+   for(unsigned i=0; i<m_max_barriers_per_cta; i++){
+	   m_bar_id_to_warps[i] &=~warps;
+   }
 
-  m_warp_active |= warps;
-  m_warp_at_barrier &= ~warps;
-  for (unsigned i = 0; i < m_max_barriers_per_cta; i++) {
-    m_bar_id_to_warps[i] &= ~warps;
-  }
 }
 
 // during cta deallocation
-void barrier_set_t::deallocate_barrier(unsigned cta_id) {
-  cta_to_warp_t::iterator w = m_cta_to_warps.find(cta_id);
-  if (w == m_cta_to_warps.end()) return;
-  warp_set_t warps = w->second;
-  warp_set_t at_barrier = warps & m_warp_at_barrier;
-  assert(at_barrier.any() == false);  // no warps stuck at barrier
-  warp_set_t active = warps & m_warp_active;
-  assert(active.any() == false);  // no warps in CTA still running
-  m_warp_active &= ~warps;
-  m_warp_at_barrier &= ~warps;
+void barrier_set_t::deallocate_barrier( unsigned cta_id )
+{
+   cta_to_warp_t::iterator w=m_cta_to_warps.find(cta_id);
+   if( w == m_cta_to_warps.end() )
+      return;
+   warp_set_t warps = w->second;
+   warp_set_t at_barrier = warps & m_warp_at_barrier;
+   assert( at_barrier.any() == false ); // no warps stuck at barrier
+   warp_set_t active = warps & m_warp_active;
+   assert( active.any() == false ); // no warps in CTA still running
+   m_warp_active &= ~warps;
+   m_warp_at_barrier &= ~warps;
 
-  for (unsigned i = 0; i < m_max_barriers_per_cta; i++) {
-    warp_set_t at_a_specific_barrier = warps & m_bar_id_to_warps[i];
-    assert(at_a_specific_barrier.any() == false);  // no warps stuck at barrier
-    m_bar_id_to_warps[i] &= ~warps;
-  }
-  m_cta_to_warps.erase(w);
+   for(unsigned i=0; i<m_max_barriers_per_cta; i++){
+	   warp_set_t at_a_specific_barrier = warps & m_bar_id_to_warps[i];
+	   assert( at_a_specific_barrier.any() == false ); // no warps stuck at barrier
+	   m_bar_id_to_warps[i] &=~warps;
+   }
+   m_cta_to_warps.erase(w);
 }
 
 // individual warp hits barrier
-void barrier_set_t::warp_reaches_barrier(unsigned cta_id, unsigned warp_id,
-                                         warp_inst_t *inst) {
-  barrier_type bar_type = inst->bar_type;
-  unsigned bar_id = inst->bar_id;
-  unsigned bar_count = inst->bar_count;
-  assert(bar_id != (unsigned)-1);
-  cta_to_warp_t::iterator w = m_cta_to_warps.find(cta_id);
+void barrier_set_t::warp_reaches_barrier(unsigned cta_id,unsigned warp_id,warp_inst_t* inst)
+{
+	barrier_type bar_type = inst->bar_type;
+	unsigned bar_id = inst->bar_id;
+	unsigned bar_count = inst->bar_count;
+	assert(bar_id!=(unsigned)-1);
+   cta_to_warp_t::iterator w=m_cta_to_warps.find(cta_id);
 
-  if (w == m_cta_to_warps.end()) {  // cta is active
-    printf(
-        "ERROR ** cta_id %u not found in barrier set on cycle %llu+%llu...\n",
-        cta_id, m_shader->get_gpu()->gpu_tot_sim_cycle,
-        m_shader->get_gpu()->gpu_sim_cycle);
-    dump();
-    abort();
-  }
-  assert(w->second.test(warp_id) == true);  // warp is in cta
+   if( w == m_cta_to_warps.end() ) { // cta is active
+      printf("ERROR ** cta_id %u not found in barrier set on cycle %llu+%llu...\n", cta_id, m_shader->get_gpu()->gpu_tot_sim_cycle, m_shader->get_gpu()->gpu_sim_cycle );
+      dump();
+      abort();
+   }
+   assert( w->second.test(warp_id) == true ); // warp is in cta
 
-  m_bar_id_to_warps[bar_id].set(warp_id);
-  if (bar_type == SYNC || bar_type == RED) {
-    m_warp_at_barrier.set(warp_id);
+   m_bar_id_to_warps[bar_id].set(warp_id);
+   if(bar_type==SYNC || bar_type==RED){
+	   m_warp_at_barrier.set(warp_id);
+   }
+   warp_set_t warps_in_cta = w->second;
+   warp_set_t at_barrier = warps_in_cta & m_bar_id_to_warps[bar_id];
+   warp_set_t active = warps_in_cta & m_warp_active;
+   if(bar_count==(unsigned)-1){
+	   if( at_barrier == active ) {
+		   // all warps have reached barrier, so release waiting warps...
+		   m_bar_id_to_warps[bar_id] &= ~at_barrier;
+		   m_warp_at_barrier &= ~at_barrier;
+		   if(bar_type==RED){
+			   m_shader->broadcast_barrier_reduction(cta_id, bar_id,at_barrier);
+		   }
+	   }
+  }else{
+	  // TODO: check on the hardware if the count should include warp that exited
+	  if ((at_barrier.count() * m_warp_size) == bar_count){
+		   // required number of warps have reached barrier, so release waiting warps...
+		   m_bar_id_to_warps[bar_id] &= ~at_barrier;
+		   m_warp_at_barrier &= ~at_barrier;
+		   if(bar_type==RED){
+			   m_shader->broadcast_barrier_reduction(cta_id, bar_id,at_barrier);
+		   }
+	  }
   }
-  warp_set_t warps_in_cta = w->second;
-  warp_set_t at_barrier = warps_in_cta & m_bar_id_to_warps[bar_id];
-  warp_set_t active = warps_in_cta & m_warp_active;
-  if (bar_count == (unsigned)-1) {
-    if (at_barrier == active) {
-      // all warps have reached barrier, so release waiting warps...
-      m_bar_id_to_warps[bar_id] &= ~at_barrier;
-      m_warp_at_barrier &= ~at_barrier;
-      if (bar_type == RED) {
-        m_shader->broadcast_barrier_reduction(cta_id, bar_id, at_barrier);
-      }
-    }
-  } else {
-    // TODO: check on the hardware if the count should include warp that exited
-    if ((at_barrier.count() * m_warp_size) == bar_count) {
-      // required number of warps have reached barrier, so release waiting
-      // warps...
-      m_bar_id_to_warps[bar_id] &= ~at_barrier;
-      m_warp_at_barrier &= ~at_barrier;
-      if (bar_type == RED) {
-        m_shader->broadcast_barrier_reduction(cta_id, bar_id, at_barrier);
-      }
-    }
-  }
+
+
 }
 
-// warp reaches exit
-void barrier_set_t::warp_exit(unsigned warp_id) {
-  // caller needs to verify all threads in warp are done, e.g., by checking PDOM
-  // stack to
-  // see it has only one entry during exit_impl()
-  m_warp_active.reset(warp_id);
 
-  // test for barrier release
-  cta_to_warp_t::iterator w = m_cta_to_warps.begin();
-  for (; w != m_cta_to_warps.end(); ++w) {
-    if (w->second.test(warp_id) == true) break;
-  }
-  warp_set_t warps_in_cta = w->second;
-  warp_set_t active = warps_in_cta & m_warp_active;
+// warp reaches exit 
+void barrier_set_t::warp_exit( unsigned warp_id )
+{
+   // caller needs to verify all threads in warp are done, e.g., by checking PDOM stack to 
+   // see it has only one entry during exit_impl()
+   m_warp_active.reset(warp_id);
 
-  for (unsigned i = 0; i < m_max_barriers_per_cta; i++) {
-    warp_set_t at_a_specific_barrier = warps_in_cta & m_bar_id_to_warps[i];
-    if (at_a_specific_barrier == active) {
-      // all warps have reached barrier, so release waiting warps...
-      m_bar_id_to_warps[i] &= ~at_a_specific_barrier;
-      m_warp_at_barrier &= ~at_a_specific_barrier;
-    }
-  }
+   // test for barrier release 
+   cta_to_warp_t::iterator w=m_cta_to_warps.begin(); 
+   for (; w != m_cta_to_warps.end(); ++w) {
+      if (w->second.test(warp_id) == true) break; 
+   }
+   warp_set_t warps_in_cta = w->second;
+   warp_set_t active = warps_in_cta & m_warp_active;
+
+   for(unsigned i=0; i<m_max_barriers_per_cta; i++){
+	   warp_set_t at_a_specific_barrier = warps_in_cta & m_bar_id_to_warps[i];
+	   if( at_a_specific_barrier == active ) {
+	      // all warps have reached barrier, so release waiting warps...
+		   m_bar_id_to_warps[i] &= ~at_a_specific_barrier;
+		   m_warp_at_barrier &= ~at_a_specific_barrier;
+	   }
+   }
 }
 
 // assertions
-bool barrier_set_t::warp_waiting_at_barrier(unsigned warp_id) const {
-  return m_warp_at_barrier.test(warp_id);
+bool barrier_set_t::warp_waiting_at_barrier( unsigned warp_id ) const
+{ 
+   return m_warp_at_barrier.test(warp_id);
 }
 
-void barrier_set_t::dump() {
-  printf("barrier set information\n");
-  printf("  m_max_cta_per_core = %u\n", m_max_cta_per_core);
-  printf("  m_max_warps_per_core = %u\n", m_max_warps_per_core);
-  printf(" m_max_barriers_per_cta =%u\n", m_max_barriers_per_cta);
-  printf("  cta_to_warps:\n");
-
-  cta_to_warp_t::const_iterator i;
-  for (i = m_cta_to_warps.begin(); i != m_cta_to_warps.end(); i++) {
-    unsigned cta_id = i->first;
-    warp_set_t warps = i->second;
-    printf("    cta_id %u : %s\n", cta_id, warps.to_string().c_str());
-  }
-  printf("  warp_active: %s\n", m_warp_active.to_string().c_str());
-  printf("  warp_at_barrier: %s\n", m_warp_at_barrier.to_string().c_str());
-  for (unsigned i = 0; i < m_max_barriers_per_cta; i++) {
-    warp_set_t warps_reached_barrier = m_bar_id_to_warps[i];
-    printf("  warp_at_barrier %u: %s\n", i,
-           warps_reached_barrier.to_string().c_str());
-  }
-  fflush(stdout);
+void barrier_set_t::dump()
+{
+   printf( "barrier set information\n");
+   printf( "  m_max_cta_per_core = %u\n",  m_max_cta_per_core );
+   printf( "  m_max_warps_per_core = %u\n", m_max_warps_per_core );
+   printf( " m_max_barriers_per_cta =%u\n", m_max_barriers_per_cta);
+   printf( "  cta_to_warps:\n");
+   
+   cta_to_warp_t::const_iterator i;
+   for( i=m_cta_to_warps.begin(); i!=m_cta_to_warps.end(); i++ ) {
+      unsigned cta_id = i->first;
+      warp_set_t warps = i->second;
+      printf("    cta_id %u : %s\n", cta_id, warps.to_string().c_str() );
+   }
+   printf("  warp_active: %s\n", m_warp_active.to_string().c_str() );
+   printf("  warp_at_barrier: %s\n", m_warp_at_barrier.to_string().c_str() );
+   for( unsigned i=0; i<m_max_barriers_per_cta; i++){
+	   warp_set_t warps_reached_barrier = m_bar_id_to_warps[i];
+	   printf("  warp_at_barrier %u: %s\n", i, warps_reached_barrier.to_string().c_str() );
+   }
+   fflush(stdout); 
 }
 
-void shader_core_ctx::warp_exit(unsigned warp_id) {
-  bool done = true;
-  for (unsigned i = warp_id * get_config()->warp_size;
-       i < (warp_id + 1) * get_config()->warp_size; i++) {
-    //		if(this->m_thread[i]->m_functional_model_thread_state &&
-    //this->m_thread[i].m_functional_model_thread_state->donecycle()==0) {
-    //			done = false;
-    //		}
+void shader_core_ctx::warp_exit( unsigned warp_id )
+{
+	bool done = true;
+	for (	unsigned i = warp_id*get_config()->warp_size;
+			i < (warp_id+1)*get_config()->warp_size;
+			i++ ) {
 
-    if (m_thread[i] && !m_thread[i]->is_done()) done = false;
-  }
-  // if (m_warp[warp_id].get_n_completed() == get_config()->warp_size)
-  // if (this->m_simt_stack[warp_id]->get_num_entries() == 0)
-  if (done) m_barriers.warp_exit(warp_id);
+//		if(this->m_thread[i]->m_functional_model_thread_state && this->m_thread[i].m_functional_model_thread_state->donecycle()==0) {
+//			done = false;
+//		}
+
+
+		if (m_thread[i] && !m_thread[i]->is_done()) done = false;
+	}
+	//if (m_warp[warp_id].get_n_completed() == get_config()->warp_size)
+	//if (this->m_simt_stack[warp_id]->get_num_entries() == 0)
+	if (done)
+		m_barriers.warp_exit( warp_id );
 }
 
-bool shader_core_ctx::check_if_non_released_reduction_barrier(
-    warp_inst_t &inst) {
-  unsigned warp_id = inst.warp_id();
-  bool bar_red_op = (inst.op == BARRIER_OP) && (inst.bar_type == RED);
-  bool non_released_barrier_reduction = false;
-  bool warp_stucked_at_barrier = warp_waiting_at_barrier(warp_id);
-  bool single_inst_in_pipeline =
-      (m_warp[warp_id].num_issued_inst_in_pipeline() == 1);
-  non_released_barrier_reduction =
-      single_inst_in_pipeline and warp_stucked_at_barrier and bar_red_op;
-  printf("non_released_barrier_reduction=%u\n", non_released_barrier_reduction);
-  return non_released_barrier_reduction;
+bool shader_core_ctx::check_if_non_released_reduction_barrier(warp_inst_t &inst)
+{
+	unsigned warp_id = inst.warp_id();
+	bool bar_red_op = (inst.op == BARRIER_OP) && (inst.bar_type == RED);
+    bool non_released_barrier_reduction = false;
+    bool warp_stucked_at_barrier = warp_waiting_at_barrier(warp_id);
+    bool single_inst_in_pipeline = (m_warp[warp_id].num_issued_inst_in_pipeline()==1);
+    non_released_barrier_reduction = single_inst_in_pipeline and warp_stucked_at_barrier and bar_red_op;
+    printf("non_released_barrier_reduction=%u\n",non_released_barrier_reduction);
+    return non_released_barrier_reduction;
 }
 
-bool shader_core_ctx::warp_waiting_at_barrier(unsigned warp_id) const {
-  return m_barriers.warp_waiting_at_barrier(warp_id);
+bool shader_core_ctx::warp_waiting_at_barrier( unsigned warp_id ) const
+{
+   return m_barriers.warp_waiting_at_barrier(warp_id);
 }
 
-bool shader_core_ctx::warp_waiting_at_mem_barrier(unsigned warp_id) {
-  if (!m_warp[warp_id].get_membar()) return false;
-  if (!m_scoreboard->pendingWrites(warp_id)) {
-    m_warp[warp_id].clear_membar();
+bool shader_core_ctx::warp_waiting_at_mem_barrier( unsigned warp_id ) 
+{
+   if( !m_warp[warp_id].get_membar() ) 
+      return false;
+   if( !m_scoreboard->pendingWrites(warp_id) ) {
+      m_warp[warp_id].clear_membar();
+      return false;
+   }
+   return true;
+}
+
+void shader_core_ctx::set_max_cta( const kernel_info_t &kernel ) 
+{
+    // calculate the max cta count and cta size for local memory address mapping
+    kernel_max_cta_per_shader = m_config->max_cta(kernel);
+    unsigned int gpu_cta_size = kernel.threads_per_cta();
+    kernel_padded_threads_per_cta = (gpu_cta_size%m_config->warp_size) ? 
+        m_config->warp_size*((gpu_cta_size/m_config->warp_size)+1) : 
+        gpu_cta_size;
+}
+
+void shader_core_ctx::decrement_atomic_count( unsigned wid, unsigned n )
+{
+   assert( m_warp[wid].get_n_atomic() >= n );
+   m_warp[wid].dec_n_atomic(n);
+}
+
+void shader_core_ctx::broadcast_barrier_reduction(unsigned cta_id,unsigned bar_id,warp_set_t warps)
+{
+	for(unsigned i=0; i<m_config->max_warps_per_shader;i++){
+		if(warps.test(i)){
+			const warp_inst_t * inst = m_warp[i].restore_info_of_last_inst_at_barrier();
+			const_cast<warp_inst_t *> (inst)->broadcast_barrier_reduction(inst->get_active_mask());
+		}
+	}
+}
+
+bool shader_core_ctx::fetch_unit_response_buffer_full() const
+{
     return false;
-  }
-  return true;
 }
 
-void shader_core_ctx::set_max_cta(const kernel_info_t &kernel) {
-  // calculate the max cta count and cta size for local memory address mapping
-  kernel_max_cta_per_shader = m_config->max_cta(kernel);
-  unsigned int gpu_cta_size = kernel.threads_per_cta();
-  kernel_padded_threads_per_cta =
-      (gpu_cta_size % m_config->warp_size)
-          ? m_config->warp_size * ((gpu_cta_size / m_config->warp_size) + 1)
-          : gpu_cta_size;
+void shader_core_ctx::accept_fetch_response( mem_fetch *mf )
+{
+    mf->set_status(IN_SHADER_FETCHED,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
+    m_L1I->fill(mf,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
 }
 
-void shader_core_ctx::decrement_atomic_count(unsigned wid, unsigned n) {
-  assert(m_warp[wid].get_n_atomic() >= n);
-  m_warp[wid].dec_n_atomic(n);
+bool shader_core_ctx::ldst_unit_response_buffer_full() const
+{
+    return m_ldst_unit->response_buffer_full();
 }
 
-void shader_core_ctx::broadcast_barrier_reduction(unsigned cta_id,
-                                                  unsigned bar_id,
-                                                  warp_set_t warps) {
-  for (unsigned i = 0; i < m_config->max_warps_per_shader; i++) {
-    if (warps.test(i)) {
-      const warp_inst_t *inst =
-          m_warp[i].restore_info_of_last_inst_at_barrier();
-      const_cast<warp_inst_t *>(inst)->broadcast_barrier_reduction(
-          inst->get_active_mask());
+void shader_core_ctx::accept_ldst_unit_response(mem_fetch * mf) 
+{
+   m_ldst_unit->fill(mf);
+}
+
+void shader_core_ctx::store_ack( class mem_fetch *mf )
+{
+	assert( mf->get_type() == WRITE_ACK  || ( m_config->gpgpu_perfect_mem && mf->get_is_write() ) );
+    unsigned warp_id = mf->get_wid();
+    m_warp[warp_id].dec_store_req();
+}
+
+void shader_core_ctx::print_cache_stats( FILE *fp, unsigned& dl1_accesses, unsigned& dl1_misses ) {
+   m_ldst_unit->print_cache_stats( fp, dl1_accesses, dl1_misses );
+}
+
+void shader_core_ctx::get_cache_stats(cache_stats &cs){
+    // Adds stats from each cache to 'cs'
+    cs += m_L1I->get_stats(); // Get L1I stats
+    m_ldst_unit->get_cache_stats(cs); // Get L1D, L1C, L1T stats
+}
+
+void shader_core_ctx::get_L1I_sub_stats(struct cache_sub_stats &css) const{
+    if(m_L1I)
+        m_L1I->get_sub_stats(css);
+}
+void shader_core_ctx::get_L1D_sub_stats(struct cache_sub_stats &css) const{
+    m_ldst_unit->get_L1D_sub_stats(css);
+}
+void shader_core_ctx::get_L1C_sub_stats(struct cache_sub_stats &css) const{
+    m_ldst_unit->get_L1C_sub_stats(css);
+}
+void shader_core_ctx::get_L1T_sub_stats(struct cache_sub_stats &css) const{
+    m_ldst_unit->get_L1T_sub_stats(css);
+}
+
+void shader_core_ctx::get_icnt_power_stats(long &n_simt_to_mem, long &n_mem_to_simt) const{
+	n_simt_to_mem += m_stats->n_simt_to_mem[m_sid];
+	n_mem_to_simt += m_stats->n_mem_to_simt[m_sid];
+}
+
+bool shd_warp_t::functional_done() const
+{
+    return get_n_completed() == m_warp_size;
+}
+
+bool shd_warp_t::hardware_done() const
+{
+    return functional_done() && stores_done() && !inst_in_pipeline(); 
+}
+
+bool shd_warp_t::waiting() 
+{
+    if ( functional_done() ) {
+        // waiting to be initialized with a kernel
+        return true;
+    } else if ( m_shader->warp_waiting_at_barrier(m_warp_id) ) {
+        // waiting for other warps in CTA to reach barrier
+        return true;
+    } else if ( m_shader->warp_waiting_at_mem_barrier(m_warp_id) ) {
+        // waiting for memory barrier
+        return true;
+    } else if ( m_n_atomic >0 ) {
+        // waiting for atomic operation to complete at memory:
+        // this stall is not required for accurate timing model, but rather we
+        // stall here since if a call/return instruction occurs in the meantime
+        // the functional execution of the atomic when it hits DRAM can cause
+        // the wrong register to be read.
+        return true;
     }
-  }
+    return false;
 }
 
-bool shader_core_ctx::fetch_unit_response_buffer_full() const { return false; }
-
-void shader_core_ctx::accept_fetch_response(mem_fetch *mf) {
-  mf->set_status(IN_SHADER_FETCHED,
-                 m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-  m_L1I->fill(mf, m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-}
-
-bool shader_core_ctx::ldst_unit_response_buffer_full() const {
-  return m_ldst_unit->response_buffer_full();
-}
-
-void shader_core_ctx::accept_ldst_unit_response(mem_fetch *mf) {
-  m_ldst_unit->fill(mf);
-}
-
-void shader_core_ctx::store_ack(class mem_fetch *mf) {
-  assert(mf->get_type() == WRITE_ACK ||
-         (m_config->gpgpu_perfect_mem && mf->get_is_write()));
-  unsigned warp_id = mf->get_wid();
-  m_warp[warp_id].dec_store_req();
-}
-
-void shader_core_ctx::print_cache_stats(FILE *fp, unsigned &dl1_accesses,
-                                        unsigned &dl1_misses) {
-  m_ldst_unit->print_cache_stats(fp, dl1_accesses, dl1_misses);
-}
-
-void shader_core_ctx::get_cache_stats(cache_stats &cs) {
-  // Adds stats from each cache to 'cs'
-  cs += m_L1I->get_stats();          // Get L1I stats
-  m_ldst_unit->get_cache_stats(cs);  // Get L1D, L1C, L1T stats
-}
-
-void shader_core_ctx::get_L1I_sub_stats(struct cache_sub_stats &css) const {
-  if (m_L1I) m_L1I->get_sub_stats(css);
-}
-void shader_core_ctx::get_L1D_sub_stats(struct cache_sub_stats &css) const {
-  m_ldst_unit->get_L1D_sub_stats(css);
-}
-void shader_core_ctx::get_L1C_sub_stats(struct cache_sub_stats &css) const {
-  m_ldst_unit->get_L1C_sub_stats(css);
-}
-void shader_core_ctx::get_L1T_sub_stats(struct cache_sub_stats &css) const {
-  m_ldst_unit->get_L1T_sub_stats(css);
-}
-
-void shader_core_ctx::get_icnt_power_stats(long &n_simt_to_mem,
-                                           long &n_mem_to_simt) const {
-  n_simt_to_mem += m_stats->n_simt_to_mem[m_sid];
-  n_mem_to_simt += m_stats->n_mem_to_simt[m_sid];
-}
-
-bool shd_warp_t::functional_done() const {
-  return get_n_completed() == m_warp_size;
-}
-
-bool shd_warp_t::hardware_done() const {
-  return functional_done() && stores_done() && !inst_in_pipeline();
-}
-
-bool shd_warp_t::waiting() {
-  if (functional_done()) {
-    // waiting to be initialized with a kernel
-    return true;
-  } else if (m_shader->warp_waiting_at_barrier(m_warp_id)) {
-    // waiting for other warps in CTA to reach barrier
-    return true;
-  } else if (m_shader->warp_waiting_at_mem_barrier(m_warp_id)) {
-    // waiting for memory barrier
-    return true;
-  } else if (m_n_atomic > 0) {
-    // waiting for atomic operation to complete at memory:
-    // this stall is not required for accurate timing model, but rather we
-    // stall here since if a call/return instruction occurs in the meantime
-    // the functional execution of the atomic when it hits DRAM can cause
-    // the wrong register to be read.
-    return true;
-  }
-  return false;
-}
-
-void shd_warp_t::print(FILE *fout) const {
-  if (!done_exit()) {
-    fprintf(fout, "w%02u npc: 0x%04x, done:%c%c%c%c:%2u i:%u s:%u a:%u (done: ",
-            m_warp_id, m_next_pc, (functional_done() ? 'f' : ' '),
-            (stores_done() ? 's' : ' '), (inst_in_pipeline() ? ' ' : 'i'),
-            (done_exit() ? 'e' : ' '), n_completed, m_inst_in_pipeline,
-            m_stores_outstanding, m_n_atomic);
-    for (unsigned i = m_warp_id * m_warp_size;
-         i < (m_warp_id + 1) * m_warp_size; i++) {
-      if (m_shader->ptx_thread_done(i))
-        fprintf(fout, "1");
-      else
-        fprintf(fout, "0");
-      if ((((i + 1) % 4) == 0) && (i + 1) < (m_warp_id + 1) * m_warp_size)
-        fprintf(fout, ",");
-    }
-    fprintf(fout, ") ");
-    fprintf(fout, " active=%s", m_active_threads.to_string().c_str());
-    fprintf(fout, " last fetched @ %5llu", m_last_fetch);
-    if (m_imiss_pending) fprintf(fout, " i-miss pending");
-    fprintf(fout, "\n");
-  }
-}
-
-void shd_warp_t::print_ibuffer(FILE *fout) const {
-  fprintf(fout, "  ibuffer[%2u] : ", m_warp_id);
-  for (unsigned i = 0; i < IBUFFER_SIZE; i++) {
-    const inst_t *inst = m_ibuffer[i].m_inst;
-    if (inst)
-      inst->print_insn(fout);
-    else if (m_ibuffer[i].m_valid)
-      fprintf(fout, " <invalid instruction> ");
-    else
-      fprintf(fout, " <empty> ");
-  }
-  fprintf(fout, "\n");
-}
-
-void opndcoll_rfu_t::add_cu_set(unsigned set_id, unsigned num_cu,
-                                unsigned num_dispatch) {
-  m_cus[set_id].reserve(num_cu);  // this is necessary to stop pointers in m_cu
-                                  // from being invalid do to a resize;
-  for (unsigned i = 0; i < num_cu; i++) {
-    m_cus[set_id].push_back(collector_unit_t());
-    m_cu.push_back(&m_cus[set_id].back());
-  }
-  // for now each collector set gets dedicated dispatch units.
-  for (unsigned i = 0; i < num_dispatch; i++) {
-    m_dispatch_units.push_back(dispatch_unit_t(&m_cus[set_id]));
-  }
-}
-
-void opndcoll_rfu_t::add_port(port_vector_t &input, port_vector_t &output,
-                              uint_vector_t cu_sets) {
-  // m_num_ports++;
-  // m_num_collectors += num_collector_units;
-  // m_input.resize(m_num_ports);
-  // m_output.resize(m_num_ports);
-  // m_num_collector_units.resize(m_num_ports);
-  // m_input[m_num_ports-1]=input_port;
-  // m_output[m_num_ports-1]=output_port;
-  // m_num_collector_units[m_num_ports-1]=num_collector_units;
-  m_in_ports.push_back(input_port_t(input, output, cu_sets));
-}
-
-void opndcoll_rfu_t::init(unsigned num_banks, shader_core_ctx *shader) {
-  m_shader = shader;
-  m_arbiter.init(m_cu.size(), num_banks);
-  // for( unsigned n=0; n<m_num_ports;n++ )
-  //    m_dispatch_units[m_output[n]].init( m_num_collector_units[n] );
-  m_num_banks = num_banks;
-  m_bank_warp_shift = 0;
-  m_warp_size = shader->get_config()->warp_size;
-  m_bank_warp_shift = (unsigned)(int)(log(m_warp_size + 0.5) / log(2.0));
-  assert((m_bank_warp_shift == 5) || (m_warp_size != 32));
-
-  sub_core_model = shader->get_config()->sub_core_model;
-  m_num_warp_sceds = shader->get_config()->gpgpu_num_sched_per_core;
-  if (sub_core_model)
-    assert(num_banks % shader->get_config()->gpgpu_num_sched_per_core == 0);
-  m_num_banks_per_sched =
-      num_banks / shader->get_config()->gpgpu_num_sched_per_core;
-
-  for (unsigned j = 0; j < m_cu.size(); j++) {
-    m_cu[j]->init(j, num_banks, m_bank_warp_shift, shader->get_config(), this,
-                  sub_core_model, m_num_banks_per_sched);
-  }
-  m_initialized = true;
-}
-
-int register_bank(int regnum, int wid, unsigned num_banks,
-                  unsigned bank_warp_shift, bool sub_core_model,
-                  unsigned banks_per_sched, unsigned sched_id) {
-  int bank = regnum;
-  if (bank_warp_shift) bank += wid;
-  if (sub_core_model) {
-    unsigned bank_num = (bank % banks_per_sched) + (sched_id * banks_per_sched);
-    assert(bank_num < num_banks);
-    return bank_num;
-  } else
-    return bank % num_banks;
-}
-
-bool opndcoll_rfu_t::writeback(warp_inst_t &inst) {
-  assert(!inst.empty());
-  std::list<unsigned> regs = m_shader->get_regs_written(inst);
-  for (unsigned op = 0; op < MAX_REG_OPERANDS; op++) {
-    int reg_num = inst.arch_reg.dst[op];  // this math needs to match that used
-                                          // in function_info::ptx_decode_inst
-    if (reg_num >= 0) {                   // valid register
-      unsigned bank = register_bank(reg_num, inst.warp_id(), m_num_banks,
-                                    m_bank_warp_shift, sub_core_model,
-                                    m_num_banks_per_sched, inst.get_schd_id());
-      if (m_arbiter.bank_idle(bank)) {
-        m_arbiter.allocate_bank_for_write(
-            bank,
-            op_t(&inst, reg_num, m_num_banks, m_bank_warp_shift, sub_core_model,
-                 m_num_banks_per_sched, inst.get_schd_id()));
-        inst.arch_reg.dst[op] = -1;
-      } else {
-        return false;
-      }
-    }
-  }
-  for (unsigned i = 0; i < (unsigned)regs.size(); i++) {
-    if (m_shader->get_config()->gpgpu_clock_gated_reg_file) {
-      unsigned active_count = 0;
-      for (unsigned i = 0; i < m_shader->get_config()->warp_size;
-           i = i + m_shader->get_config()->n_regfile_gating_group) {
-        for (unsigned j = 0; j < m_shader->get_config()->n_regfile_gating_group;
-             j++) {
-          if (inst.get_active_mask().test(i + j)) {
-            active_count += m_shader->get_config()->n_regfile_gating_group;
-            break;
-          }
+void shd_warp_t::print( FILE *fout ) const
+{
+    if( !done_exit() ) {
+        fprintf( fout, "w%02u npc: 0x%04x, done:%c%c%c%c:%2u i:%u s:%u a:%u (done: ", 
+                m_warp_id,
+                m_next_pc,
+                (functional_done()?'f':' '),
+                (stores_done()?'s':' '),
+                (inst_in_pipeline()?' ':'i'),
+                (done_exit()?'e':' '),
+                n_completed,
+                m_inst_in_pipeline, 
+                m_stores_outstanding,
+                m_n_atomic );
+        for (unsigned i = m_warp_id*m_warp_size; i < (m_warp_id+1)*m_warp_size; i++ ) {
+          if ( m_shader->ptx_thread_done(i) ) fprintf(fout,"1");
+          else fprintf(fout,"0");
+          if ( (((i+1)%4) == 0) && (i+1) < (m_warp_id+1)*m_warp_size ) 
+             fprintf(fout,",");
         }
-      }
-      m_shader->incregfile_writes(active_count);
-    } else {
-      m_shader->incregfile_writes(
-          m_shader->get_config()->warp_size);  // inst.active_count());
+        fprintf(fout,") ");
+        fprintf(fout," active=%s", m_active_threads.to_string().c_str() );
+        fprintf(fout," last fetched @ %5llu", m_last_fetch);
+        if( m_imiss_pending ) 
+            fprintf(fout," i-miss pending");
+        fprintf(fout,"\n");
     }
-  }
-  return true;
 }
 
-void opndcoll_rfu_t::dispatch_ready_cu() {
-  for (unsigned p = 0; p < m_dispatch_units.size(); ++p) {
-    dispatch_unit_t &du = m_dispatch_units[p];
-    collector_unit_t *cu = du.find_ready();
-    if (cu) {
-      for (unsigned i = 0; i < (cu->get_num_operands() - cu->get_num_regs());
-           i++) {
-        if (m_shader->get_config()->gpgpu_clock_gated_reg_file) {
-          unsigned active_count = 0;
-          for (unsigned i = 0; i < m_shader->get_config()->warp_size;
-               i = i + m_shader->get_config()->n_regfile_gating_group) {
-            for (unsigned j = 0;
-                 j < m_shader->get_config()->n_regfile_gating_group; j++) {
-              if (cu->get_active_mask().test(i + j)) {
-                active_count += m_shader->get_config()->n_regfile_gating_group;
-                break;
+void shd_warp_t::print_ibuffer( FILE *fout ) const
+{
+    fprintf(fout,"  ibuffer[%2u] : ", m_warp_id );
+    for( unsigned i=0; i < IBUFFER_SIZE; i++) {
+        const inst_t *inst = m_ibuffer[i].m_inst;
+        if( inst ) inst->print_insn(fout);
+        else if( m_ibuffer[i].m_valid ) 
+           fprintf(fout," <invalid instruction> ");
+        else fprintf(fout," <empty> ");
+    }
+    fprintf(fout,"\n");
+}
+
+void opndcoll_rfu_t::add_cu_set(unsigned set_id, unsigned num_cu, unsigned num_dispatch){
+    m_cus[set_id].reserve(num_cu); //this is necessary to stop pointers in m_cu from being invalid do to a resize;
+    for (unsigned i = 0; i < num_cu; i++) {
+        m_cus[set_id].push_back(collector_unit_t());
+        m_cu.push_back(&m_cus[set_id].back());
+    }
+    // for now each collector set gets dedicated dispatch units.
+    for (unsigned i = 0; i < num_dispatch; i++) {
+        m_dispatch_units.push_back(dispatch_unit_t(&m_cus[set_id]));
+    }
+}
+
+
+void opndcoll_rfu_t::add_port(port_vector_t & input, port_vector_t & output, uint_vector_t cu_sets)
+{
+    //m_num_ports++;
+    //m_num_collectors += num_collector_units;
+    //m_input.resize(m_num_ports);
+    //m_output.resize(m_num_ports);
+    //m_num_collector_units.resize(m_num_ports);
+    //m_input[m_num_ports-1]=input_port;
+    //m_output[m_num_ports-1]=output_port;
+    //m_num_collector_units[m_num_ports-1]=num_collector_units;
+    m_in_ports.push_back(input_port_t(input,output,cu_sets));
+}
+
+void opndcoll_rfu_t::init( unsigned num_banks, shader_core_ctx *shader )
+{
+   m_shader=shader;
+   m_arbiter.init(m_cu.size(),num_banks);
+   //for( unsigned n=0; n<m_num_ports;n++ ) 
+   //    m_dispatch_units[m_output[n]].init( m_num_collector_units[n] );
+   m_num_banks = num_banks;
+   m_bank_warp_shift = 0; 
+   m_warp_size = shader->get_config()->warp_size;
+   m_bank_warp_shift = (unsigned)(int) (log(m_warp_size+0.5) / log(2.0));
+   assert( (m_bank_warp_shift == 5) || (m_warp_size != 32) );
+
+   sub_core_model = shader->get_config()->sub_core_model;
+   m_num_warp_sceds = shader->get_config()->gpgpu_num_sched_per_core;
+   if(sub_core_model)
+	   assert(num_banks % shader->get_config()->gpgpu_num_sched_per_core == 0);
+   m_num_banks_per_sched = num_banks / shader->get_config()->gpgpu_num_sched_per_core;
+
+   for( unsigned j=0; j<m_cu.size(); j++) {
+       m_cu[j]->init(j,num_banks,m_bank_warp_shift,shader->get_config(),this, sub_core_model, m_num_banks_per_sched );
+   }
+   m_initialized=true;
+
+
+
+
+}
+
+int register_bank(int regnum, int wid, unsigned num_banks, unsigned bank_warp_shift, bool sub_core_model, unsigned banks_per_sched, unsigned sched_id)
+{
+   int bank = regnum;
+   if (bank_warp_shift)
+      bank += wid;
+   if(sub_core_model) {
+	   unsigned bank_num  = (bank % banks_per_sched) + (sched_id * banks_per_sched);
+	   assert(bank_num < num_banks);
+	   return bank_num;
+   }
+   else
+	   return bank % num_banks;
+}
+
+bool opndcoll_rfu_t::writeback( warp_inst_t &inst )
+{
+   assert( !inst.empty() );
+   std::list<unsigned> regs = m_shader->get_regs_written(inst);
+   for( unsigned op=0; op < MAX_REG_OPERANDS; op++ ) {
+      int reg_num = inst.arch_reg.dst[op]; // this math needs to match that used in function_info::ptx_decode_inst
+      if( reg_num >= 0 ){ // valid register
+         unsigned bank = register_bank(reg_num,inst.warp_id(),m_num_banks,m_bank_warp_shift, sub_core_model, m_num_banks_per_sched, inst.get_schd_id());
+         if( m_arbiter.bank_idle(bank) ) {
+             m_arbiter.allocate_bank_for_write(bank,op_t(&inst,reg_num,m_num_banks,m_bank_warp_shift, sub_core_model, m_num_banks_per_sched, inst.get_schd_id()));
+             inst.arch_reg.dst[op] = -1;
+         } else {
+             return false;
+         }
+      }
+   }
+   for(unsigned i=0;i<(unsigned)regs.size();i++){
+	      if(m_shader->get_config()->gpgpu_clock_gated_reg_file){
+	    	  unsigned active_count=0;
+	    	  for(unsigned i=0;i<m_shader->get_config()->warp_size;i=i+m_shader->get_config()->n_regfile_gating_group){
+	    		  for(unsigned j=0;j<m_shader->get_config()->n_regfile_gating_group;j++){
+	    			  if(inst.get_active_mask().test(i+j)){
+	    				  active_count+=m_shader->get_config()->n_regfile_gating_group;
+	    				  break;
+	    			  }
+	    		  }
+	    	  }
+	    	  m_shader->incregfile_writes(active_count);
+	      }else{
+	    	  m_shader->incregfile_writes(m_shader->get_config()->warp_size);//inst.active_count());
+	      }
+   }
+   return true;
+}
+
+void opndcoll_rfu_t::dispatch_ready_cu()
+{
+   for( unsigned p=0; p < m_dispatch_units.size(); ++p ) {
+      dispatch_unit_t &du = m_dispatch_units[p];
+      collector_unit_t *cu = du.find_ready();
+      if( cu ) {
+    	 for(unsigned i=0;i<(cu->get_num_operands()-cu->get_num_regs());i++){
+   	      if(m_shader->get_config()->gpgpu_clock_gated_reg_file){
+   	    	  unsigned active_count=0;
+   	    	  for(unsigned i=0;i<m_shader->get_config()->warp_size;i=i+m_shader->get_config()->n_regfile_gating_group){
+   	    		  for(unsigned j=0;j<m_shader->get_config()->n_regfile_gating_group;j++){
+   	    			  if(cu->get_active_mask().test(i+j)){
+   	    				  active_count+=m_shader->get_config()->n_regfile_gating_group;
+   	    				  break;
+   	    			  }
+   	    		  }
+   	    	  }
+   	    	  m_shader->incnon_rf_operands(active_count);
+   	      }else{
+    		 m_shader->incnon_rf_operands(m_shader->get_config()->warp_size);//cu->get_active_count());
+   	      }
+    	}
+         cu->dispatch();
+      }
+   }
+}
+
+void opndcoll_rfu_t::allocate_cu( unsigned port_num )
+{
+   input_port_t& inp = m_in_ports[port_num];
+   for (unsigned i = 0; i < inp.m_in.size(); i++) {
+       if( (*inp.m_in[i]).has_ready() ) {
+          //find a free cu 
+          for (unsigned j = 0; j < inp.m_cu_sets.size(); j++) {
+              std::vector<collector_unit_t> & cu_set = m_cus[inp.m_cu_sets[j]];
+	      bool allocated = false;
+              for (unsigned k = 0; k < cu_set.size(); k++) {
+                  if(cu_set[k].is_free()) {
+                     collector_unit_t *cu = &cu_set[k];
+                     allocated = cu->allocate(inp.m_in[i],inp.m_out[i]);
+                     m_arbiter.add_read_requests(cu);
+                     break;
+                  }
+              }
+              if (allocated) break; //cu has been allocated, no need to search more.
+          }
+          break; // can only service a single input, if it failed it will fail for others.
+       }
+   }
+}
+
+void opndcoll_rfu_t::allocate_reads()
+{
+   // process read requests that do not have conflicts
+   std::list<op_t> allocated = m_arbiter.allocate_reads();
+   std::map<unsigned,op_t> read_ops;
+   for( std::list<op_t>::iterator r=allocated.begin(); r!=allocated.end(); r++ ) {
+      const op_t &rr = *r;
+      unsigned reg = rr.get_reg();
+      unsigned wid = rr.get_wid();
+      unsigned bank = register_bank(reg,wid,m_num_banks,m_bank_warp_shift,sub_core_model, m_num_banks_per_sched, rr.get_sid());
+      m_arbiter.allocate_for_read(bank,rr);
+      read_ops[bank] = rr;
+   }
+   std::map<unsigned,op_t>::iterator r;
+   for(r=read_ops.begin();r!=read_ops.end();++r ) {
+      op_t &op = r->second;
+      unsigned cu = op.get_oc_id();
+      unsigned operand = op.get_operand();
+      m_cu[cu]->collect_operand(operand);
+      if(m_shader->get_config()->gpgpu_clock_gated_reg_file){
+    	  unsigned active_count=0;
+    	  for(unsigned i=0;i<m_shader->get_config()->warp_size;i=i+m_shader->get_config()->n_regfile_gating_group){
+    		  for(unsigned j=0;j<m_shader->get_config()->n_regfile_gating_group;j++){
+    			  if(op.get_active_mask().test(i+j)){
+    				  active_count+=m_shader->get_config()->n_regfile_gating_group;
+    				  break;
+    			  }
+    		  }
+    	  }
+    	  m_shader->incregfile_reads(active_count);
+      }else{
+    	  m_shader->incregfile_reads(m_shader->get_config()->warp_size);//op.get_active_count());
+      }
+  }
+} 
+
+bool opndcoll_rfu_t::collector_unit_t::ready() const 
+{ 
+   return (!m_free) && m_not_ready.none() && (*m_output_register).has_free(); 
+}
+
+void opndcoll_rfu_t::collector_unit_t::dump(FILE *fp, const shader_core_ctx *shader ) const
+{
+   if( m_free ) {
+      fprintf(fp,"    <free>\n");
+   } else {
+      m_warp->print(fp);
+      for( unsigned i=0; i < MAX_REG_OPERANDS*2; i++ ) {
+         if( m_not_ready.test(i) ) {
+            std::string r = m_src_op[i].get_reg_string();
+            fprintf(fp,"    '%s' not ready\n", r.c_str() );
+         }
+      }
+   }
+}
+
+void opndcoll_rfu_t::collector_unit_t::init( unsigned n, 
+                                             unsigned num_banks, 
+                                             unsigned log2_warp_size,
+                                             const core_config *config,
+                                             opndcoll_rfu_t *rfu,
+											 bool sub_core_model,
+											 unsigned banks_per_sched)
+{ 
+   m_rfu=rfu;
+   m_cuid=n; 
+   m_num_banks=num_banks;
+   assert(m_warp==NULL); 
+   m_warp = new warp_inst_t(config);
+   m_bank_warp_shift=log2_warp_size;
+   m_sub_core_model = sub_core_model;
+   m_num_banks_per_sched = banks_per_sched;
+}
+
+bool opndcoll_rfu_t::collector_unit_t::allocate( register_set* pipeline_reg_set, register_set* output_reg_set ) 
+{
+   assert(m_free);
+   assert(m_not_ready.none());
+   m_free = false;
+   m_output_register = output_reg_set;
+   warp_inst_t **pipeline_reg = pipeline_reg_set->get_ready();
+   if( (pipeline_reg) and !((*pipeline_reg)->empty()) ) {
+      m_warp_id = (*pipeline_reg)->warp_id();
+      for( unsigned op=0; op < MAX_REG_OPERANDS; op++ ) {
+         int reg_num = (*pipeline_reg)->arch_reg.src[op]; // this math needs to match that used in function_info::ptx_decode_inst
+         if( reg_num >= 0 ) { // valid register
+            m_src_op[op] = op_t( this, op, reg_num, m_num_banks, m_bank_warp_shift, m_sub_core_model, m_num_banks_per_sched, (*pipeline_reg)->get_schd_id() );
+            m_not_ready.set(op);
+         } else 
+            m_src_op[op] = op_t();
+      }
+      //move_warp(m_warp,*pipeline_reg);
+      pipeline_reg_set->move_out_to(m_warp);
+      return true;
+   }
+   return false;
+}
+
+void opndcoll_rfu_t::collector_unit_t::dispatch()
+{
+   assert( m_not_ready.none() );
+   //move_warp(*m_output_register,m_warp);
+   m_output_register->move_in(m_warp);
+   m_free=true;
+   m_output_register = NULL;
+   for( unsigned i=0; i<MAX_REG_OPERANDS*2;i++)
+      m_src_op[i].reset();
+}
+
+simt_core_cluster::simt_core_cluster( class gpgpu_sim *gpu, 
+                                      unsigned cluster_id, 
+                                      const shader_core_config *config, 
+                                      const memory_config *mem_config,
+                                      shader_core_stats *stats, 
+                                      class memory_stats_t *mstats )
+{
+    m_config = config;
+    m_cta_issue_next_core=m_config->n_simt_cores_per_cluster-1; // this causes first launch to use hw cta 0
+    m_cluster_id=cluster_id;
+    m_gpu = gpu;
+    m_stats = stats;
+    m_memory_stats = mstats;
+    m_core = new shader_core_ctx*[ config->n_simt_cores_per_cluster ];
+    for( unsigned i=0; i < config->n_simt_cores_per_cluster; i++ ) {
+        unsigned sid = m_config->cid_to_sid(i,m_cluster_id);
+        m_core[i] = new shader_core_ctx(gpu,this,sid,m_cluster_id,config,mem_config,stats);
+        m_core_sim_order.push_back(i); 
+    }
+}
+
+void simt_core_cluster::core_cycle()
+{
+    for( std::list<unsigned>::iterator it = m_core_sim_order.begin(); it != m_core_sim_order.end(); ++it ) {
+        m_core[*it]->cycle();
+    }
+
+    if (m_config->simt_core_sim_order == 1) {
+        m_core_sim_order.splice(m_core_sim_order.end(), m_core_sim_order, m_core_sim_order.begin()); 
+    }
+}
+
+void simt_core_cluster::reinit()
+{
+    for( unsigned i=0; i < m_config->n_simt_cores_per_cluster; i++ ) 
+        m_core[i]->reinit(0,m_config->n_thread_per_shader,true);
+}
+
+unsigned simt_core_cluster::max_cta( const kernel_info_t &kernel )
+{
+    return m_config->n_simt_cores_per_cluster * m_config->max_cta(kernel);
+}
+
+unsigned simt_core_cluster::get_not_completed() const
+{
+    unsigned not_completed=0;
+    for( unsigned i=0; i < m_config->n_simt_cores_per_cluster; i++ ) 
+        not_completed += m_core[i]->get_not_completed();
+    return not_completed;
+}
+
+void simt_core_cluster::print_not_completed( FILE *fp ) const
+{
+    for( unsigned i=0; i < m_config->n_simt_cores_per_cluster; i++ ) {
+        unsigned not_completed=m_core[i]->get_not_completed();
+        unsigned sid=m_config->cid_to_sid(i,m_cluster_id);
+        fprintf(fp,"%u(%u) ", sid, not_completed );
+    }
+}
+
+
+float simt_core_cluster::get_current_occupancy( unsigned long long& active, unsigned long long& total ) const {
+    float aggregate = 0.f;
+    for( unsigned i=0; i < m_config->n_simt_cores_per_cluster; i++ ) {
+        aggregate+=m_core[i]->get_current_occupancy( active, total );
+    }
+    return aggregate / m_config->n_simt_cores_per_cluster;
+}
+
+unsigned simt_core_cluster::get_n_active_cta() const
+{
+    unsigned n=0;
+    for( unsigned i=0; i < m_config->n_simt_cores_per_cluster; i++ ) 
+        n += m_core[i]->get_n_active_cta();
+    return n;
+}
+
+unsigned simt_core_cluster::get_n_active_sms() const
+{
+    unsigned n=0;
+    for( unsigned i=0; i < m_config->n_simt_cores_per_cluster; i++ )
+        n += m_core[i]->isactive();
+    return n;
+}
+
+unsigned simt_core_cluster::issue_block2core()
+{
+    unsigned num_blocks_issued=0;
+    for( unsigned i=0; i < m_config->n_simt_cores_per_cluster; i++ ) {
+        unsigned core = (i+m_cta_issue_next_core+1)%m_config->n_simt_cores_per_cluster;
+
+        kernel_info_t * kernel;
+         //Jin: fetch kernel according to concurrent kernel setting
+        if(m_config->gpgpu_concurrent_kernel_sm) {//concurrent kernel on sm 
+            //always select latest issued kernel
+            kernel_info_t *k = m_gpu->select_kernel();
+            kernel = k;
+        }
+        else {
+            //first select core kernel, if no more cta, get a new kernel
+            //only when core completes
+            kernel = m_core[core]->get_kernel();
+            if( !m_gpu->kernel_more_cta_left(kernel) ) {
+              //wait till current kernel finishes
+              if(m_core[core]->get_not_completed() == 0)
+              {
+                  kernel_info_t *k = m_gpu->select_kernel();
+                  if( k ) 
+                      m_core[core]->set_kernel(k);
+                  kernel = k;
               }
             }
-          }
-          m_shader->incnon_rf_operands(active_count);
+        }
+
+        if( m_gpu->kernel_more_cta_left(kernel) && 
+//            (m_core[core]->get_n_active_cta() < m_config->max_cta(*kernel)) ) {
+            m_core[core]->can_issue_1block(*kernel)) {
+            m_core[core]->issue_block2core(*kernel);
+            num_blocks_issued++;
+            m_cta_issue_next_core=core; 
+            break;
+        }
+    }
+    return num_blocks_issued;
+}
+
+void simt_core_cluster::cache_flush()
+{
+    for( unsigned i=0; i < m_config->n_simt_cores_per_cluster; i++ ) 
+        m_core[i]->cache_flush();
+}
+
+void simt_core_cluster::cache_invalidate()
+{
+    for( unsigned i=0; i < m_config->n_simt_cores_per_cluster; i++ )
+        m_core[i]->cache_invalidate();
+}
+
+bool simt_core_cluster::icnt_injection_buffer_full(unsigned size, bool write)
+{
+    unsigned request_size = size;
+    if (!write) 
+        request_size = READ_PACKET_SIZE;
+    return ! ::icnt_has_buffer(m_cluster_id, request_size);
+}
+
+void simt_core_cluster::icnt_inject_request_packet(class mem_fetch *mf)
+{
+    // stats
+    if (mf->get_is_write()) m_stats->made_write_mfs++;
+    else m_stats->made_read_mfs++;
+    switch (mf->get_access_type()) {
+    case CONST_ACC_R: m_stats->gpgpu_n_mem_const++; break;
+    case TEXTURE_ACC_R: m_stats->gpgpu_n_mem_texture++; break;
+    case GLOBAL_ACC_R: m_stats->gpgpu_n_mem_read_global++; break;
+    //case GLOBAL_ACC_R: m_stats->gpgpu_n_mem_read_global++; printf("read_global%d\n",m_stats->gpgpu_n_mem_read_global); break;
+    case GLOBAL_ACC_W: m_stats->gpgpu_n_mem_write_global++; break;
+    case LOCAL_ACC_R: m_stats->gpgpu_n_mem_read_local++; break;
+    case LOCAL_ACC_W: m_stats->gpgpu_n_mem_write_local++; break;
+    case INST_ACC_R: m_stats->gpgpu_n_mem_read_inst++; break;
+    case L1_WRBK_ACC: m_stats->gpgpu_n_mem_write_global++; break;
+    case L2_WRBK_ACC: m_stats->gpgpu_n_mem_l2_writeback++; break;
+    case L1_WR_ALLOC_R: m_stats->gpgpu_n_mem_l1_write_allocate++; break;
+    case L2_WR_ALLOC_R: m_stats->gpgpu_n_mem_l2_write_allocate++; break;
+    default: assert(0);
+    }
+
+   // The packet size varies depending on the type of request: 
+   // - For write request and atomic request, the packet contains the data 
+   // - For read request (i.e. not write nor atomic), the packet only has control metadata
+   unsigned int packet_size = mf->size(); 
+   if (!mf->get_is_write() && !mf->isatomic()) {
+      packet_size = mf->get_ctrl_size(); 
+   }
+   m_stats->m_outgoing_traffic_stats->record_traffic(mf, packet_size); 
+   unsigned destination = mf->get_sub_partition_id();
+   mf->set_status(IN_ICNT_TO_MEM,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
+   if (!mf->get_is_write() && !mf->isatomic())
+      ::icnt_push(m_cluster_id, m_config->mem2device(destination), (void*)mf, mf->get_ctrl_size() );
+   else 
+      ::icnt_push(m_cluster_id, m_config->mem2device(destination), (void*)mf, mf->size());
+}
+
+void simt_core_cluster::icnt_cycle()
+{
+    if( !m_response_fifo.empty() ) {
+        mem_fetch *mf = m_response_fifo.front();
+        unsigned cid = m_config->sid_to_cid(mf->get_sid());
+        if( mf->get_access_type() == INST_ACC_R ) {
+            // instruction fetch response
+            if( !m_core[cid]->fetch_unit_response_buffer_full() ) {
+                m_response_fifo.pop_front();
+                m_core[cid]->accept_fetch_response(mf);
+            }
         } else {
-          m_shader->incnon_rf_operands(
-              m_shader->get_config()->warp_size);  // cu->get_active_count());
+            // data response
+            if( !m_core[cid]->ldst_unit_response_buffer_full() ) {
+                m_response_fifo.pop_front();
+                m_memory_stats->memlatstat_read_done(mf);
+                m_core[cid]->accept_ldst_unit_response(mf);
+            }
         }
-      }
-      cu->dispatch();
     }
-  }
+    if( m_response_fifo.size() < m_config->n_simt_ejection_buffer_size ) {
+        mem_fetch *mf = (mem_fetch*) ::icnt_pop(m_cluster_id);
+        if (!mf) 
+            return;
+        assert(mf->get_tpc() == m_cluster_id);
+        assert(mf->get_type() == READ_REPLY || mf->get_type() == WRITE_ACK );
+
+        // The packet size varies depending on the type of request: 
+        // - For read request and atomic request, the packet contains the data 
+        // - For write-ack, the packet only has control metadata
+        unsigned int packet_size = (mf->get_is_write())? mf->get_ctrl_size() : mf->size(); 
+        m_stats->m_incoming_traffic_stats->record_traffic(mf, packet_size); 
+        mf->set_status(IN_CLUSTER_TO_SHADER_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
+        //m_memory_stats->memlatstat_read_done(mf,m_shader_config->max_warps_per_shader);
+        m_response_fifo.push_back(mf);
+        m_stats->n_mem_to_simt[m_cluster_id] += mf->get_num_flits(false);
+    }
 }
 
-void opndcoll_rfu_t::allocate_cu(unsigned port_num) {
-  input_port_t &inp = m_in_ports[port_num];
-  for (unsigned i = 0; i < inp.m_in.size(); i++) {
-    if ((*inp.m_in[i]).has_ready()) {
-      // find a free cu
-      for (unsigned j = 0; j < inp.m_cu_sets.size(); j++) {
-        std::vector<collector_unit_t> &cu_set = m_cus[inp.m_cu_sets[j]];
-        bool allocated = false;
-        for (unsigned k = 0; k < cu_set.size(); k++) {
-          if (cu_set[k].is_free()) {
-            collector_unit_t *cu = &cu_set[k];
-            allocated = cu->allocate(inp.m_in[i], inp.m_out[i]);
-            m_arbiter.add_read_requests(cu);
-            break;
-          }
+void simt_core_cluster::get_pdom_stack_top_info( unsigned sid, unsigned tid, unsigned *pc, unsigned *rpc ) const
+{
+    unsigned cid = m_config->sid_to_cid(sid);
+    m_core[cid]->get_pdom_stack_top_info(tid,pc,rpc);
+}
+
+void simt_core_cluster::display_pipeline( unsigned sid, FILE *fout, int print_mem, int mask )
+{
+    m_core[m_config->sid_to_cid(sid)]->display_pipeline(fout,print_mem,mask);
+
+    fprintf(fout,"\n");
+    fprintf(fout,"Cluster %u pipeline state\n", m_cluster_id );
+    fprintf(fout,"Response FIFO (occupancy = %zu):\n", m_response_fifo.size() );
+    for( std::list<mem_fetch*>::const_iterator i=m_response_fifo.begin(); i != m_response_fifo.end(); i++ ) {
+        const mem_fetch *mf = *i;
+        mf->print(fout);
+    }
+}
+
+void simt_core_cluster::print_cache_stats( FILE *fp, unsigned& dl1_accesses, unsigned& dl1_misses ) const {
+   for ( unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i ) {
+      m_core[ i ]->print_cache_stats( fp, dl1_accesses, dl1_misses );
+   }
+}
+
+void simt_core_cluster::get_icnt_stats(long &n_simt_to_mem, long &n_mem_to_simt) const {
+	long simt_to_mem=0;
+	long mem_to_simt=0;
+	for ( unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i ) {
+		m_core[i]->get_icnt_power_stats(simt_to_mem, mem_to_simt);
+	}
+	n_simt_to_mem = simt_to_mem;
+	n_mem_to_simt = mem_to_simt;
+}
+
+void simt_core_cluster::get_cache_stats(cache_stats &cs) const{
+    for ( unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i ) {
+        m_core[i]->get_cache_stats(cs);
+    }
+}
+
+void simt_core_cluster::get_L1I_sub_stats(struct cache_sub_stats &css) const{
+    struct cache_sub_stats temp_css;
+    struct cache_sub_stats total_css;
+    temp_css.clear();
+    total_css.clear();
+    for ( unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i ) {
+        m_core[i]->get_L1I_sub_stats(temp_css);
+        total_css += temp_css;
+    }
+    css = total_css;
+}
+void simt_core_cluster::get_L1D_sub_stats(struct cache_sub_stats &css) const{
+    struct cache_sub_stats temp_css;
+    struct cache_sub_stats total_css;
+    temp_css.clear();
+    total_css.clear();
+    for ( unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i ) {
+        m_core[i]->get_L1D_sub_stats(temp_css);
+        total_css += temp_css;
+    }
+    css = total_css;
+}
+void simt_core_cluster::get_L1C_sub_stats(struct cache_sub_stats &css) const{
+    struct cache_sub_stats temp_css;
+    struct cache_sub_stats total_css;
+    temp_css.clear();
+    total_css.clear();
+    for ( unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i ) {
+        m_core[i]->get_L1C_sub_stats(temp_css);
+        total_css += temp_css;
+    }
+    css = total_css;
+}
+void simt_core_cluster::get_L1T_sub_stats(struct cache_sub_stats &css) const{
+    struct cache_sub_stats temp_css;
+    struct cache_sub_stats total_css;
+    temp_css.clear();
+    total_css.clear();
+    for ( unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i ) {
+        m_core[i]->get_L1T_sub_stats(temp_css);
+        total_css += temp_css;
+    }
+    css = total_css;
+}
+
+void shader_core_ctx::checkExecutionStatusAndUpdate(warp_inst_t &inst, unsigned t, unsigned tid)
+{
+    if(inst.isatomic())
+           m_warp[inst.warp_id()].inc_n_atomic();
+        if (inst.space.is_local() && (inst.is_load() || inst.is_store())) {
+            new_addr_type localaddrs[MAX_ACCESSES_PER_INSN_PER_THREAD];
+            unsigned num_addrs;
+            num_addrs = translate_local_memaddr(inst.get_addr(t), tid, m_config->n_simt_clusters*m_config->n_simt_cores_per_cluster,
+                   inst.data_size, (new_addr_type*) localaddrs );
+            inst.set_addr(t, (new_addr_type*) localaddrs, num_addrs);
         }
-        if (allocated) break;  // cu has been allocated, no need to search more.
-      }
-      break;  // can only service a single input, if it failed it will fail for
-              // others.
-    }
-  }
-}
-
-void opndcoll_rfu_t::allocate_reads() {
-  // process read requests that do not have conflicts
-  std::list<op_t> allocated = m_arbiter.allocate_reads();
-  std::map<unsigned, op_t> read_ops;
-  for (std::list<op_t>::iterator r = allocated.begin(); r != allocated.end();
-       r++) {
-    const op_t &rr = *r;
-    unsigned reg = rr.get_reg();
-    unsigned wid = rr.get_wid();
-    unsigned bank =
-        register_bank(reg, wid, m_num_banks, m_bank_warp_shift, sub_core_model,
-                      m_num_banks_per_sched, rr.get_sid());
-    m_arbiter.allocate_for_read(bank, rr);
-    read_ops[bank] = rr;
-  }
-  std::map<unsigned, op_t>::iterator r;
-  for (r = read_ops.begin(); r != read_ops.end(); ++r) {
-    op_t &op = r->second;
-    unsigned cu = op.get_oc_id();
-    unsigned operand = op.get_operand();
-    m_cu[cu]->collect_operand(operand);
-    if (m_shader->get_config()->gpgpu_clock_gated_reg_file) {
-      unsigned active_count = 0;
-      for (unsigned i = 0; i < m_shader->get_config()->warp_size;
-           i = i + m_shader->get_config()->n_regfile_gating_group) {
-        for (unsigned j = 0; j < m_shader->get_config()->n_regfile_gating_group;
-             j++) {
-          if (op.get_active_mask().test(i + j)) {
-            active_count += m_shader->get_config()->n_regfile_gating_group;
-            break;
-          }
+        if ( ptx_thread_done(tid) ) {
+            m_warp[inst.warp_id()].set_completed(t);
+            m_warp[inst.warp_id()].ibuffer_flush();
         }
-      }
-      m_shader->incregfile_reads(active_count);
-    } else {
-      m_shader->incregfile_reads(
-          m_shader->get_config()->warp_size);  // op.get_active_count());
-    }
-  }
-}
 
-bool opndcoll_rfu_t::collector_unit_t::ready() const {
-  return (!m_free) && m_not_ready.none() && (*m_output_register).has_free();
-}
-
-void opndcoll_rfu_t::collector_unit_t::dump(
-    FILE *fp, const shader_core_ctx *shader) const {
-  if (m_free) {
-    fprintf(fp, "    <free>\n");
-  } else {
-    m_warp->print(fp);
-    for (unsigned i = 0; i < MAX_REG_OPERANDS * 2; i++) {
-      if (m_not_ready.test(i)) {
-        std::string r = m_src_op[i].get_reg_string();
-        fprintf(fp, "    '%s' not ready\n", r.c_str());
-      }
-    }
-  }
-}
-
-void opndcoll_rfu_t::collector_unit_t::init(unsigned n, unsigned num_banks,
-                                            unsigned log2_warp_size,
-                                            const core_config *config,
-                                            opndcoll_rfu_t *rfu,
-                                            bool sub_core_model,
-                                            unsigned banks_per_sched) {
-  m_rfu = rfu;
-  m_cuid = n;
-  m_num_banks = num_banks;
-  assert(m_warp == NULL);
-  m_warp = new warp_inst_t(config);
-  m_bank_warp_shift = log2_warp_size;
-  m_sub_core_model = sub_core_model;
-  m_num_banks_per_sched = banks_per_sched;
-}
-
-bool opndcoll_rfu_t::collector_unit_t::allocate(register_set *pipeline_reg_set,
-                                                register_set *output_reg_set) {
-  assert(m_free);
-  assert(m_not_ready.none());
-  m_free = false;
-  m_output_register = output_reg_set;
-  warp_inst_t **pipeline_reg = pipeline_reg_set->get_ready();
-  if ((pipeline_reg) and !((*pipeline_reg)->empty())) {
-    m_warp_id = (*pipeline_reg)->warp_id();
-    for (unsigned op = 0; op < MAX_REG_OPERANDS; op++) {
-      int reg_num =
-          (*pipeline_reg)->arch_reg.src[op];  // this math needs to match that
-                                              // used in
-                                              // function_info::ptx_decode_inst
-      if (reg_num >= 0) {                     // valid register
-        m_src_op[op] = op_t(this, op, reg_num, m_num_banks, m_bank_warp_shift,
-                            m_sub_core_model, m_num_banks_per_sched,
-                            (*pipeline_reg)->get_schd_id());
-        m_not_ready.set(op);
-      } else
-        m_src_op[op] = op_t();
-    }
-    // move_warp(m_warp,*pipeline_reg);
-    pipeline_reg_set->move_out_to(m_warp);
-    return true;
-  }
-  return false;
-}
-
-void opndcoll_rfu_t::collector_unit_t::dispatch() {
-  assert(m_not_ready.none());
-  // move_warp(*m_output_register,m_warp);
-  m_output_register->move_in(m_warp);
-  m_free = true;
-  m_output_register = NULL;
-  for (unsigned i = 0; i < MAX_REG_OPERANDS * 2; i++) m_src_op[i].reset();
-}
-
-simt_core_cluster::simt_core_cluster(class gpgpu_sim *gpu, unsigned cluster_id,
-                                     const shader_core_config *config,
-                                     const memory_config *mem_config,
-                                     shader_core_stats *stats,
-                                     class memory_stats_t *mstats) {
-  m_config = config;
-  m_cta_issue_next_core = m_config->n_simt_cores_per_cluster -
-                          1;  // this causes first launch to use hw cta 0
-  m_cluster_id = cluster_id;
-  m_gpu = gpu;
-  m_stats = stats;
-  m_memory_stats = mstats;
-  m_core = new shader_core_ctx *[config->n_simt_cores_per_cluster];
-  for (unsigned i = 0; i < config->n_simt_cores_per_cluster; i++) {
-    unsigned sid = m_config->cid_to_sid(i, m_cluster_id);
-    m_core[i] = new shader_core_ctx(gpu, this, sid, m_cluster_id, config,
-                                    mem_config, stats);
-    m_core_sim_order.push_back(i);
-  }
-}
-
-void simt_core_cluster::core_cycle() {
-  for (std::list<unsigned>::iterator it = m_core_sim_order.begin();
-       it != m_core_sim_order.end(); ++it) {
-    m_core[*it]->cycle();
-  }
-
-  if (m_config->simt_core_sim_order == 1) {
-    m_core_sim_order.splice(m_core_sim_order.end(), m_core_sim_order,
-                            m_core_sim_order.begin());
-  }
-}
-
-void simt_core_cluster::reinit() {
-  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++)
-    m_core[i]->reinit(0, m_config->n_thread_per_shader, true);
-}
-
-unsigned simt_core_cluster::max_cta(const kernel_info_t &kernel) {
-  return m_config->n_simt_cores_per_cluster * m_config->max_cta(kernel);
-}
-
-unsigned simt_core_cluster::get_not_completed() const {
-  unsigned not_completed = 0;
-  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++)
-    not_completed += m_core[i]->get_not_completed();
-  return not_completed;
-}
-
-void simt_core_cluster::print_not_completed(FILE *fp) const {
-  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++) {
-    unsigned not_completed = m_core[i]->get_not_completed();
-    unsigned sid = m_config->cid_to_sid(i, m_cluster_id);
-    fprintf(fp, "%u(%u) ", sid, not_completed);
-  }
-}
-
-float simt_core_cluster::get_current_occupancy(
-    unsigned long long &active, unsigned long long &total) const {
-  float aggregate = 0.f;
-  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++) {
-    aggregate += m_core[i]->get_current_occupancy(active, total);
-  }
-  return aggregate / m_config->n_simt_cores_per_cluster;
-}
-
-unsigned simt_core_cluster::get_n_active_cta() const {
-  unsigned n = 0;
-  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++)
-    n += m_core[i]->get_n_active_cta();
-  return n;
-}
-
-unsigned simt_core_cluster::get_n_active_sms() const {
-  unsigned n = 0;
-  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++)
-    n += m_core[i]->isactive();
-  return n;
-}
-
-unsigned simt_core_cluster::issue_block2core() {
-  unsigned num_blocks_issued = 0;
-  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++) {
-    unsigned core =
-        (i + m_cta_issue_next_core + 1) % m_config->n_simt_cores_per_cluster;
-
-    kernel_info_t *kernel;
-    // Jin: fetch kernel according to concurrent kernel setting
-    if (m_config->gpgpu_concurrent_kernel_sm) {  // concurrent kernel on sm
-      // always select latest issued kernel
-      kernel_info_t *k = m_gpu->select_kernel();
-      kernel = k;
-    } else {
-      // first select core kernel, if no more cta, get a new kernel
-      // only when core completes
-      kernel = m_core[core]->get_kernel();
-      if (!m_gpu->kernel_more_cta_left(kernel)) {
-        // wait till current kernel finishes
-        if (m_core[core]->get_not_completed() == 0) {
-          kernel_info_t *k = m_gpu->select_kernel();
-          if (k) m_core[core]->set_kernel(k);
-          kernel = k;
+    // PC-Histogram Update 
+    unsigned warp_id = inst.warp_id(); 
+    unsigned pc = inst.pc; 
+    for (unsigned t = 0; t < m_config->warp_size; t++) {
+        if (inst.active(t)) {
+            int tid = warp_id * m_config->warp_size + t; 
+            cflog_update_thread_pc(m_sid, tid, pc);  
         }
-      }
     }
-
-    if (m_gpu->kernel_more_cta_left(kernel) &&
-        //            (m_core[core]->get_n_active_cta() <
-        //            m_config->max_cta(*kernel)) ) {
-        m_core[core]->can_issue_1block(*kernel)) {
-      m_core[core]->issue_block2core(*kernel);
-      num_blocks_issued++;
-      m_cta_issue_next_core = core;
-      break;
-    }
-  }
-  return num_blocks_issued;
 }
 
-void simt_core_cluster::cache_flush() {
-  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++)
-    m_core[i]->cache_flush();
-}
-
-void simt_core_cluster::cache_invalidate() {
-  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++)
-    m_core[i]->cache_invalidate();
-}
-
-bool simt_core_cluster::icnt_injection_buffer_full(unsigned size, bool write) {
-  unsigned request_size = size;
-  if (!write) request_size = READ_PACKET_SIZE;
-  return !::icnt_has_buffer(m_cluster_id, request_size);
-}
-
-void simt_core_cluster::icnt_inject_request_packet(class mem_fetch *mf) {
-  // stats
-  if (mf->get_is_write())
-    m_stats->made_write_mfs++;
-  else
-    m_stats->made_read_mfs++;
-  switch (mf->get_access_type()) {
-    case CONST_ACC_R:
-      m_stats->gpgpu_n_mem_const++;
-      break;
-    case TEXTURE_ACC_R:
-      m_stats->gpgpu_n_mem_texture++;
-      break;
-    case GLOBAL_ACC_R:
-      m_stats->gpgpu_n_mem_read_global++;
-      break;
-    // case GLOBAL_ACC_R: m_stats->gpgpu_n_mem_read_global++;
-    // printf("read_global%d\n",m_stats->gpgpu_n_mem_read_global); break;
-    case GLOBAL_ACC_W:
-      m_stats->gpgpu_n_mem_write_global++;
-      break;
-    case LOCAL_ACC_R:
-      m_stats->gpgpu_n_mem_read_local++;
-      break;
-    case LOCAL_ACC_W:
-      m_stats->gpgpu_n_mem_write_local++;
-      break;
-    case INST_ACC_R:
-      m_stats->gpgpu_n_mem_read_inst++;
-      break;
-    case L1_WRBK_ACC:
-      m_stats->gpgpu_n_mem_write_global++;
-      break;
-    case L2_WRBK_ACC:
-      m_stats->gpgpu_n_mem_l2_writeback++;
-      break;
-    case L1_WR_ALLOC_R:
-      m_stats->gpgpu_n_mem_l1_write_allocate++;
-      break;
-    case L2_WR_ALLOC_R:
-      m_stats->gpgpu_n_mem_l2_write_allocate++;
-      break;
-    default:
-      assert(0);
-  }
-
-  // The packet size varies depending on the type of request:
-  // - For write request and atomic request, the packet contains the data
-  // - For read request (i.e. not write nor atomic), the packet only has control
-  // metadata
-  unsigned int packet_size = mf->size();
-  if (!mf->get_is_write() && !mf->isatomic()) {
-    packet_size = mf->get_ctrl_size();
-  }
-  m_stats->m_outgoing_traffic_stats->record_traffic(mf, packet_size);
-  unsigned destination = mf->get_sub_partition_id();
-  mf->set_status(IN_ICNT_TO_MEM,
-                 m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-  if (!mf->get_is_write() && !mf->isatomic())
-    ::icnt_push(m_cluster_id, m_config->mem2device(destination), (void *)mf,
-                mf->get_ctrl_size());
-  else
-    ::icnt_push(m_cluster_id, m_config->mem2device(destination), (void *)mf,
-                mf->size());
-}
-
-void simt_core_cluster::icnt_cycle() {
-  if (!m_response_fifo.empty()) {
-    mem_fetch *mf = m_response_fifo.front();
-    unsigned cid = m_config->sid_to_cid(mf->get_sid());
-    if (mf->get_access_type() == INST_ACC_R) {
-      // instruction fetch response
-      if (!m_core[cid]->fetch_unit_response_buffer_full()) {
-        m_response_fifo.pop_front();
-        m_core[cid]->accept_fetch_response(mf);
-      }
-    } else {
-      // data response
-      if (!m_core[cid]->ldst_unit_response_buffer_full()) {
-        m_response_fifo.pop_front();
-        m_memory_stats->memlatstat_read_done(mf);
-        m_core[cid]->accept_ldst_unit_response(mf);
-      }
-    }
-  }
-  if (m_response_fifo.size() < m_config->n_simt_ejection_buffer_size) {
-    mem_fetch *mf = (mem_fetch *)::icnt_pop(m_cluster_id);
-    if (!mf) return;
-    assert(mf->get_tpc() == m_cluster_id);
-    assert(mf->get_type() == READ_REPLY || mf->get_type() == WRITE_ACK);
-
-    // The packet size varies depending on the type of request:
-    // - For read request and atomic request, the packet contains the data
-    // - For write-ack, the packet only has control metadata
-    unsigned int packet_size =
-        (mf->get_is_write()) ? mf->get_ctrl_size() : mf->size();
-    m_stats->m_incoming_traffic_stats->record_traffic(mf, packet_size);
-    mf->set_status(IN_CLUSTER_TO_SHADER_QUEUE,
-                   m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-    // m_memory_stats->memlatstat_read_done(mf,m_shader_config->max_warps_per_shader);
-    m_response_fifo.push_back(mf);
-    m_stats->n_mem_to_simt[m_cluster_id] += mf->get_num_flits(false);
-  }
-}
-
-void simt_core_cluster::get_pdom_stack_top_info(unsigned sid, unsigned tid,
-                                                unsigned *pc,
-                                                unsigned *rpc) const {
-  unsigned cid = m_config->sid_to_cid(sid);
-  m_core[cid]->get_pdom_stack_top_info(tid, pc, rpc);
-}
-
-void simt_core_cluster::display_pipeline(unsigned sid, FILE *fout,
-                                         int print_mem, int mask) {
-  m_core[m_config->sid_to_cid(sid)]->display_pipeline(fout, print_mem, mask);
-
-  fprintf(fout, "\n");
-  fprintf(fout, "Cluster %u pipeline state\n", m_cluster_id);
-  fprintf(fout, "Response FIFO (occupancy = %zu):\n", m_response_fifo.size());
-  for (std::list<mem_fetch *>::const_iterator i = m_response_fifo.begin();
-       i != m_response_fifo.end(); i++) {
-    const mem_fetch *mf = *i;
-    mf->print(fout);
-  }
-}
-
-void simt_core_cluster::print_cache_stats(FILE *fp, unsigned &dl1_accesses,
-                                          unsigned &dl1_misses) const {
-  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i) {
-    m_core[i]->print_cache_stats(fp, dl1_accesses, dl1_misses);
-  }
-}
-
-void simt_core_cluster::get_icnt_stats(long &n_simt_to_mem,
-                                       long &n_mem_to_simt) const {
-  long simt_to_mem = 0;
-  long mem_to_simt = 0;
-  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i) {
-    m_core[i]->get_icnt_power_stats(simt_to_mem, mem_to_simt);
-  }
-  n_simt_to_mem = simt_to_mem;
-  n_mem_to_simt = mem_to_simt;
-}
-
-void simt_core_cluster::get_cache_stats(cache_stats &cs) const {
-  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i) {
-    m_core[i]->get_cache_stats(cs);
-  }
-}
-
-void simt_core_cluster::get_L1I_sub_stats(struct cache_sub_stats &css) const {
-  struct cache_sub_stats temp_css;
-  struct cache_sub_stats total_css;
-  temp_css.clear();
-  total_css.clear();
-  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i) {
-    m_core[i]->get_L1I_sub_stats(temp_css);
-    total_css += temp_css;
-  }
-  css = total_css;
-}
-void simt_core_cluster::get_L1D_sub_stats(struct cache_sub_stats &css) const {
-  struct cache_sub_stats temp_css;
-  struct cache_sub_stats total_css;
-  temp_css.clear();
-  total_css.clear();
-  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i) {
-    m_core[i]->get_L1D_sub_stats(temp_css);
-    total_css += temp_css;
-  }
-  css = total_css;
-}
-void simt_core_cluster::get_L1C_sub_stats(struct cache_sub_stats &css) const {
-  struct cache_sub_stats temp_css;
-  struct cache_sub_stats total_css;
-  temp_css.clear();
-  total_css.clear();
-  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i) {
-    m_core[i]->get_L1C_sub_stats(temp_css);
-    total_css += temp_css;
-  }
-  css = total_css;
-}
-void simt_core_cluster::get_L1T_sub_stats(struct cache_sub_stats &css) const {
-  struct cache_sub_stats temp_css;
-  struct cache_sub_stats total_css;
-  temp_css.clear();
-  total_css.clear();
-  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i) {
-    m_core[i]->get_L1T_sub_stats(temp_css);
-    total_css += temp_css;
-  }
-  css = total_css;
-}
-
-void shader_core_ctx::checkExecutionStatusAndUpdate(warp_inst_t &inst,
-                                                    unsigned t, unsigned tid) {
-  if (inst.isatomic()) m_warp[inst.warp_id()].inc_n_atomic();
-  if (inst.space.is_local() && (inst.is_load() || inst.is_store())) {
-    new_addr_type localaddrs[MAX_ACCESSES_PER_INSN_PER_THREAD];
-    unsigned num_addrs;
-    num_addrs = translate_local_memaddr(
-        inst.get_addr(t), tid,
-        m_config->n_simt_clusters * m_config->n_simt_cores_per_cluster,
-        inst.data_size, (new_addr_type *)localaddrs);
-    inst.set_addr(t, (new_addr_type *)localaddrs, num_addrs);
-  }
-  if (ptx_thread_done(tid)) {
-    m_warp[inst.warp_id()].set_completed(t);
-    m_warp[inst.warp_id()].ibuffer_flush();
-  }
-
-  // PC-Histogram Update
-  unsigned warp_id = inst.warp_id();
-  unsigned pc = inst.pc;
-  for (unsigned t = 0; t < m_config->warp_size; t++) {
-    if (inst.active(t)) {
-      int tid = warp_id * m_config->warp_size + t;
-      cflog_update_thread_pc(m_sid, tid, pc);
-    }
-  }
-}

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -3460,7 +3460,7 @@ void shader_core_ctx::warp_exit(unsigned warp_id) {
   for (unsigned i = warp_id * get_config()->warp_size;
        i < (warp_id + 1) * get_config()->warp_size; i++) {
     //		if(this->m_thread[i]->m_functional_model_thread_state &&
-    // this->m_thread[i].m_functional_model_thread_state->donecycle()==0) {
+    //this->m_thread[i].m_functional_model_thread_state->donecycle()==0) {
     //			done = false;
     //		}
 

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2011, Tor M. Aamodt, Wilson W.L. Fung, Ali Bakhoda,
-// George L. Yuan, Andrew Turner, Inderpreet Singh 
+// George L. Yuan, Andrew Turner, Inderpreet Singh
 // The University of British Columbia
 // All rights reserved.
 //
@@ -8,2060 +8,2132 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
-#include <float.h>
 #include "shader.h"
+#include <float.h>
+#include <limits.h>
+#include <string.h>
+#include "../../libcuda/gpgpu_context.h"
+#include "../cuda-sim/cuda-sim.h"
+#include "../cuda-sim/ptx-stats.h"
+#include "../cuda-sim/ptx_sim.h"
+#include "../statwrapper.h"
 #include "addrdec.h"
 #include "dram.h"
-#include "stat-tool.h"
 #include "gpu-misc.h"
-#include "../cuda-sim/ptx_sim.h"
-#include "../cuda-sim/ptx-stats.h"
-#include "../cuda-sim/cuda-sim.h"
 #include "gpu-sim.h"
+#include "icnt_wrapper.h"
 #include "mem_fetch.h"
 #include "mem_latency_stat.h"
-#include "visualizer.h"
-#include "../statwrapper.h"
-#include "icnt_wrapper.h"
-#include <string.h>
-#include <limits.h>
-#include "traffic_breakdown.h"
 #include "shader_trace.h"
-#include "../../libcuda/gpgpu_context.h"
+#include "stat-tool.h"
+#include "traffic_breakdown.h"
+#include "visualizer.h"
 
 #define PRIORITIZE_MSHR_OVER_WB 1
-#define MAX(a,b) (((a)>(b))?(a):(b))
-#define MIN(a,b) (((a)<(b))?(a):(b))
-    
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
 
-mem_fetch *shader_core_mem_fetch_allocator::alloc( new_addr_type addr, mem_access_type type, unsigned size, bool wr, unsigned long long cycle ) const
-{
-    mem_access_t access( type, addr, size, wr, m_memory_config->gpgpu_ctx);
-    mem_fetch *mf = new mem_fetch( access, 
-	    NULL,
-	    wr?WRITE_PACKET_SIZE:READ_PACKET_SIZE, 
-	    -1, 
-	    m_core_id, 
-	    m_cluster_id,
-	    m_memory_config,
-	    cycle);
-    return mf;
+mem_fetch *shader_core_mem_fetch_allocator::alloc(
+    new_addr_type addr, mem_access_type type, unsigned size, bool wr,
+    unsigned long long cycle) const {
+  mem_access_t access(type, addr, size, wr, m_memory_config->gpgpu_ctx);
+  mem_fetch *mf =
+      new mem_fetch(access, NULL, wr ? WRITE_PACKET_SIZE : READ_PACKET_SIZE, -1,
+                    m_core_id, m_cluster_id, m_memory_config, cycle);
+  return mf;
 }
 /////////////////////////////////////////////////////////////////////////////
 
-std::list<unsigned> shader_core_ctx::get_regs_written( const inst_t &fvt ) const
-{
-   std::list<unsigned> result;
-   for( unsigned op=0; op < MAX_REG_OPERANDS; op++ ) {
-      int reg_num = fvt.arch_reg.dst[op]; // this math needs to match that used in function_info::ptx_decode_inst
-      if( reg_num >= 0 ) // valid register
-         result.push_back(reg_num);
-   }
-   return result;
+std::list<unsigned> shader_core_ctx::get_regs_written(const inst_t &fvt) const {
+  std::list<unsigned> result;
+  for (unsigned op = 0; op < MAX_REG_OPERANDS; op++) {
+    int reg_num = fvt.arch_reg.dst[op];  // this math needs to match that used
+                                         // in function_info::ptx_decode_inst
+    if (reg_num >= 0)                    // valid register
+      result.push_back(reg_num);
+  }
+  return result;
 }
 
-shader_core_ctx::shader_core_ctx( class gpgpu_sim *gpu, 
-                                  class simt_core_cluster *cluster,
-                                  unsigned shader_id,
-                                  unsigned tpc_id,
-                                  const shader_core_config *config,
-                                  const memory_config *mem_config,
-                                  shader_core_stats *stats )
-   : core_t( gpu, NULL, config->warp_size, config->n_thread_per_shader ),
-     m_barriers( this, config->max_warps_per_shader, config->max_cta_per_core, config->max_barriers_per_cta, config->warp_size ),
-     m_active_warps(0), m_dynamic_warp_id(0)
-{
-    m_cluster = cluster;
-    m_config = config;
-    m_memory_config = mem_config;
-    m_stats = stats;
-    unsigned warp_size=config->warp_size;
-    Issue_Prio = 0;
-    
-    m_sid = shader_id;
-    m_tpc = tpc_id;
-    
-    m_pipeline_reg.reserve(N_PIPELINE_STAGES);
-    for (int j = 0; j<N_PIPELINE_STAGES; j++) {
-        m_pipeline_reg.push_back(register_set(m_config->pipe_widths[j],pipeline_stage_name_decode[j]));
+shader_core_ctx::shader_core_ctx(class gpgpu_sim *gpu,
+                                 class simt_core_cluster *cluster,
+                                 unsigned shader_id, unsigned tpc_id,
+                                 const shader_core_config *config,
+                                 const memory_config *mem_config,
+                                 shader_core_stats *stats)
+    : core_t(gpu, NULL, config->warp_size, config->n_thread_per_shader),
+      m_barriers(this, config->max_warps_per_shader, config->max_cta_per_core,
+                 config->max_barriers_per_cta, config->warp_size),
+      m_active_warps(0),
+      m_dynamic_warp_id(0) {
+  m_cluster = cluster;
+  m_config = config;
+  m_memory_config = mem_config;
+  m_stats = stats;
+  unsigned warp_size = config->warp_size;
+  Issue_Prio = 0;
+
+  m_sid = shader_id;
+  m_tpc = tpc_id;
+
+  m_pipeline_reg.reserve(N_PIPELINE_STAGES);
+  for (int j = 0; j < N_PIPELINE_STAGES; j++) {
+    m_pipeline_reg.push_back(
+        register_set(m_config->pipe_widths[j], pipeline_stage_name_decode[j]));
+  }
+  if (m_config->sub_core_model) {
+    // in subcore model, each scheduler should has its own issue register, so
+    // num scheduler = reg width
+    assert(m_config->gpgpu_num_sched_per_core ==
+           m_pipeline_reg[ID_OC_SP].get_size());
+    assert(m_config->gpgpu_num_sched_per_core ==
+           m_pipeline_reg[ID_OC_SFU].get_size());
+    assert(m_config->gpgpu_num_sched_per_core ==
+           m_pipeline_reg[ID_OC_MEM].get_size());
+    if (m_config->gpgpu_tensor_core_avail)
+      assert(m_config->gpgpu_num_sched_per_core ==
+             m_pipeline_reg[ID_OC_TENSOR_CORE].get_size());
+    if (m_config->gpgpu_num_dp_units > 0)
+      assert(m_config->gpgpu_num_sched_per_core ==
+             m_pipeline_reg[ID_OC_DP].get_size());
+    if (m_config->gpgpu_num_int_units > 0)
+      assert(m_config->gpgpu_num_sched_per_core ==
+             m_pipeline_reg[ID_OC_INT].get_size());
+  }
+
+  m_threadState =
+      (thread_ctx_t *)calloc(sizeof(thread_ctx_t), config->n_thread_per_shader);
+
+  m_not_completed = 0;
+  m_active_threads.reset();
+  m_n_active_cta = 0;
+  for (unsigned i = 0; i < MAX_CTA_PER_SHADER; i++) m_cta_status[i] = 0;
+  for (unsigned i = 0; i < config->n_thread_per_shader; i++) {
+    m_thread[i] = NULL;
+    m_threadState[i].m_cta_id = -1;
+    m_threadState[i].m_active = false;
+  }
+
+  // m_icnt = new shader_memory_interface(this,cluster);
+  if (m_config->gpgpu_perfect_mem) {
+    m_icnt = new perfect_memory_interface(this, cluster);
+  } else {
+    m_icnt = new shader_memory_interface(this, cluster);
+  }
+  m_mem_fetch_allocator =
+      new shader_core_mem_fetch_allocator(shader_id, tpc_id, mem_config);
+
+  // fetch
+  m_last_warp_fetched = 0;
+
+#define STRSIZE 1024
+  char name[STRSIZE];
+  snprintf(name, STRSIZE, "L1I_%03d", m_sid);
+  m_L1I = new read_only_cache(name, m_config->m_L1I_config, m_sid,
+                              get_shader_instruction_cache_id(), m_icnt,
+                              IN_L1I_MISS_QUEUE);
+
+  m_warp.resize(m_config->max_warps_per_shader, shd_warp_t(this, warp_size));
+  m_scoreboard = new Scoreboard(m_sid, m_config->max_warps_per_shader, gpu);
+
+  // scedulers
+  // must currently occur after all inputs have been initialized.
+  std::string sched_config = m_config->gpgpu_scheduler_string;
+  const concrete_scheduler scheduler =
+      sched_config.find("lrr") != std::string::npos
+          ? CONCRETE_SCHEDULER_LRR
+          : sched_config.find("two_level_active") != std::string::npos
+                ? CONCRETE_SCHEDULER_TWO_LEVEL_ACTIVE
+                : sched_config.find("gto") != std::string::npos
+                      ? CONCRETE_SCHEDULER_GTO
+                      : sched_config.find("old") != std::string::npos
+                            ? CONCRETE_SCHEDULER_OLDEST_FIRST
+                            : sched_config.find("warp_limiting") !=
+                                      std::string::npos
+                                  ? CONCRETE_SCHEDULER_WARP_LIMITING
+                                  : NUM_CONCRETE_SCHEDULERS;
+  assert(scheduler != NUM_CONCRETE_SCHEDULERS);
+
+  for (unsigned i = 0; i < m_config->gpgpu_num_sched_per_core; i++) {
+    switch (scheduler) {
+      case CONCRETE_SCHEDULER_LRR:
+        schedulers.push_back(new lrr_scheduler(
+            m_stats, this, m_scoreboard, m_simt_stack, &m_warp,
+            &m_pipeline_reg[ID_OC_SP], &m_pipeline_reg[ID_OC_DP],
+            &m_pipeline_reg[ID_OC_SFU], &m_pipeline_reg[ID_OC_INT],
+            &m_pipeline_reg[ID_OC_TENSOR_CORE], &m_pipeline_reg[ID_OC_MEM], i));
+        break;
+      case CONCRETE_SCHEDULER_TWO_LEVEL_ACTIVE:
+        schedulers.push_back(new two_level_active_scheduler(
+            m_stats, this, m_scoreboard, m_simt_stack, &m_warp,
+            &m_pipeline_reg[ID_OC_SP], &m_pipeline_reg[ID_OC_DP],
+            &m_pipeline_reg[ID_OC_SFU], &m_pipeline_reg[ID_OC_INT],
+            &m_pipeline_reg[ID_OC_TENSOR_CORE], &m_pipeline_reg[ID_OC_MEM], i,
+            config->gpgpu_scheduler_string));
+        break;
+      case CONCRETE_SCHEDULER_GTO:
+        schedulers.push_back(new gto_scheduler(
+            m_stats, this, m_scoreboard, m_simt_stack, &m_warp,
+            &m_pipeline_reg[ID_OC_SP], &m_pipeline_reg[ID_OC_DP],
+            &m_pipeline_reg[ID_OC_SFU], &m_pipeline_reg[ID_OC_INT],
+            &m_pipeline_reg[ID_OC_TENSOR_CORE], &m_pipeline_reg[ID_OC_MEM], i));
+        break;
+      case CONCRETE_SCHEDULER_OLDEST_FIRST:
+        schedulers.push_back(new oldest_scheduler(
+            m_stats, this, m_scoreboard, m_simt_stack, &m_warp,
+            &m_pipeline_reg[ID_OC_SP], &m_pipeline_reg[ID_OC_DP],
+            &m_pipeline_reg[ID_OC_SFU], &m_pipeline_reg[ID_OC_INT],
+            &m_pipeline_reg[ID_OC_TENSOR_CORE], &m_pipeline_reg[ID_OC_MEM], i));
+        break;
+      case CONCRETE_SCHEDULER_WARP_LIMITING:
+        schedulers.push_back(new swl_scheduler(
+            m_stats, this, m_scoreboard, m_simt_stack, &m_warp,
+            &m_pipeline_reg[ID_OC_SP], &m_pipeline_reg[ID_OC_DP],
+            &m_pipeline_reg[ID_OC_SFU], &m_pipeline_reg[ID_OC_INT],
+            &m_pipeline_reg[ID_OC_TENSOR_CORE], &m_pipeline_reg[ID_OC_MEM], i,
+            config->gpgpu_scheduler_string));
+        break;
+      default:
+        abort();
+    };
+  }
+
+  for (unsigned i = 0; i < m_warp.size(); i++) {
+    // distribute i's evenly though schedulers;
+    schedulers[i % m_config->gpgpu_num_sched_per_core]->add_supervised_warp_id(
+        i);
+  }
+  for (unsigned i = 0; i < m_config->gpgpu_num_sched_per_core; ++i) {
+    schedulers[i]->done_adding_supervised_warps();
+  }
+
+  // op collector configuration
+
+  enum { SP_CUS, DP_CUS, SFU_CUS, TENSOR_CORE_CUS, INT_CUS, MEM_CUS, GEN_CUS };
+
+  opndcoll_rfu_t::port_vector_t in_ports;
+  opndcoll_rfu_t::port_vector_t out_ports;
+  opndcoll_rfu_t::uint_vector_t cu_sets;
+
+  // configure generic collectors
+  m_operand_collector.add_cu_set(
+      GEN_CUS, m_config->gpgpu_operand_collector_num_units_gen,
+      m_config->gpgpu_operand_collector_num_out_ports_gen);
+
+  for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_gen;
+       i++) {
+    in_ports.push_back(&m_pipeline_reg[ID_OC_SP]);
+    in_ports.push_back(&m_pipeline_reg[ID_OC_SFU]);
+    in_ports.push_back(&m_pipeline_reg[ID_OC_MEM]);
+    out_ports.push_back(&m_pipeline_reg[OC_EX_SP]);
+    out_ports.push_back(&m_pipeline_reg[OC_EX_SFU]);
+    out_ports.push_back(&m_pipeline_reg[OC_EX_MEM]);
+    if (m_config->gpgpu_tensor_core_avail) {
+      in_ports.push_back(&m_pipeline_reg[ID_OC_TENSOR_CORE]);
+      out_ports.push_back(&m_pipeline_reg[OC_EX_TENSOR_CORE]);
     }
-    if(m_config->sub_core_model) {
-    	//in subcore model, each scheduler should has its own issue register, so num scheduler = reg width
-    	assert(m_config->gpgpu_num_sched_per_core == m_pipeline_reg[ID_OC_SP].get_size() );
-    	assert(m_config->gpgpu_num_sched_per_core == m_pipeline_reg[ID_OC_SFU].get_size() );
-    	assert(m_config->gpgpu_num_sched_per_core == m_pipeline_reg[ID_OC_MEM].get_size() );
-    	if(m_config->gpgpu_tensor_core_avail)
-    		 assert(m_config->gpgpu_num_sched_per_core == m_pipeline_reg[ID_OC_TENSOR_CORE].get_size() );
-    	if(m_config->gpgpu_num_dp_units > 0)
-    		assert(m_config->gpgpu_num_sched_per_core == m_pipeline_reg[ID_OC_DP].get_size() );
-    	if(m_config->gpgpu_num_int_units > 0)
-    	    assert(m_config->gpgpu_num_sched_per_core == m_pipeline_reg[ID_OC_INT].get_size() );
+    if (m_config->gpgpu_num_dp_units > 0) {
+      in_ports.push_back(&m_pipeline_reg[ID_OC_DP]);
+      out_ports.push_back(&m_pipeline_reg[OC_EX_DP]);
     }
-    
-    m_threadState = (thread_ctx_t*) calloc(sizeof(thread_ctx_t), config->n_thread_per_shader);
-    
+    if (m_config->gpgpu_num_int_units > 0) {
+      in_ports.push_back(&m_pipeline_reg[ID_OC_INT]);
+      out_ports.push_back(&m_pipeline_reg[OC_EX_INT]);
+    }
+    cu_sets.push_back((unsigned)GEN_CUS);
+    m_operand_collector.add_port(in_ports, out_ports, cu_sets);
+    in_ports.clear(), out_ports.clear(), cu_sets.clear();
+  }
+
+  if (m_config->enable_specialized_operand_collector) {
+    m_operand_collector.add_cu_set(
+        SP_CUS, m_config->gpgpu_operand_collector_num_units_sp,
+        m_config->gpgpu_operand_collector_num_out_ports_sp);
+    m_operand_collector.add_cu_set(
+        DP_CUS, m_config->gpgpu_operand_collector_num_units_dp,
+        m_config->gpgpu_operand_collector_num_out_ports_dp);
+    m_operand_collector.add_cu_set(
+        TENSOR_CORE_CUS, config->gpgpu_operand_collector_num_units_tensor_core,
+        config->gpgpu_operand_collector_num_out_ports_tensor_core);
+    m_operand_collector.add_cu_set(
+        SFU_CUS, m_config->gpgpu_operand_collector_num_units_sfu,
+        m_config->gpgpu_operand_collector_num_out_ports_sfu);
+    m_operand_collector.add_cu_set(
+        MEM_CUS, m_config->gpgpu_operand_collector_num_units_mem,
+        m_config->gpgpu_operand_collector_num_out_ports_mem);
+    m_operand_collector.add_cu_set(
+        INT_CUS, m_config->gpgpu_operand_collector_num_units_int,
+        m_config->gpgpu_operand_collector_num_out_ports_int);
+
+    for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_sp;
+         i++) {
+      in_ports.push_back(&m_pipeline_reg[ID_OC_SP]);
+      out_ports.push_back(&m_pipeline_reg[OC_EX_SP]);
+      cu_sets.push_back((unsigned)SP_CUS);
+      cu_sets.push_back((unsigned)GEN_CUS);
+      m_operand_collector.add_port(in_ports, out_ports, cu_sets);
+      in_ports.clear(), out_ports.clear(), cu_sets.clear();
+    }
+
+    for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_dp;
+         i++) {
+      in_ports.push_back(&m_pipeline_reg[ID_OC_DP]);
+      out_ports.push_back(&m_pipeline_reg[OC_EX_DP]);
+      cu_sets.push_back((unsigned)DP_CUS);
+      cu_sets.push_back((unsigned)GEN_CUS);
+      m_operand_collector.add_port(in_ports, out_ports, cu_sets);
+      in_ports.clear(), out_ports.clear(), cu_sets.clear();
+    }
+
+    for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_sfu;
+         i++) {
+      in_ports.push_back(&m_pipeline_reg[ID_OC_SFU]);
+      out_ports.push_back(&m_pipeline_reg[OC_EX_SFU]);
+      cu_sets.push_back((unsigned)SFU_CUS);
+      cu_sets.push_back((unsigned)GEN_CUS);
+      m_operand_collector.add_port(in_ports, out_ports, cu_sets);
+      in_ports.clear(), out_ports.clear(), cu_sets.clear();
+    }
+
+    for (unsigned i = 0;
+         i < config->gpgpu_operand_collector_num_in_ports_tensor_core; i++) {
+      in_ports.push_back(&m_pipeline_reg[ID_OC_TENSOR_CORE]);
+      out_ports.push_back(&m_pipeline_reg[OC_EX_TENSOR_CORE]);
+      cu_sets.push_back((unsigned)TENSOR_CORE_CUS);
+      cu_sets.push_back((unsigned)GEN_CUS);
+      m_operand_collector.add_port(in_ports, out_ports, cu_sets);
+      in_ports.clear(), out_ports.clear(), cu_sets.clear();
+    }
+
+    for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_mem;
+         i++) {
+      in_ports.push_back(&m_pipeline_reg[ID_OC_MEM]);
+      out_ports.push_back(&m_pipeline_reg[OC_EX_MEM]);
+      cu_sets.push_back((unsigned)MEM_CUS);
+      cu_sets.push_back((unsigned)GEN_CUS);
+      m_operand_collector.add_port(in_ports, out_ports, cu_sets);
+      in_ports.clear(), out_ports.clear(), cu_sets.clear();
+    }
+
+    for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_int;
+         i++) {
+      in_ports.push_back(&m_pipeline_reg[ID_OC_INT]);
+      out_ports.push_back(&m_pipeline_reg[OC_EX_INT]);
+      cu_sets.push_back((unsigned)INT_CUS);
+      cu_sets.push_back((unsigned)GEN_CUS);
+      m_operand_collector.add_port(in_ports, out_ports, cu_sets);
+      in_ports.clear(), out_ports.clear(), cu_sets.clear();
+    }
+  }
+
+  m_operand_collector.init(m_config->gpgpu_num_reg_banks, this);
+
+  m_num_function_units =
+      m_config->gpgpu_num_sp_units + m_config->gpgpu_num_dp_units +
+      m_config->gpgpu_num_sfu_units + m_config->gpgpu_num_tensor_core_units +
+      m_config->gpgpu_num_int_units +
+      1;  // sp_unit, sfu, dp, tensor, int, ldst_unit
+  // m_dispatch_port = new enum pipeline_stage_name_t[ m_num_function_units ];
+  // m_issue_port = new enum pipeline_stage_name_t[ m_num_function_units ];
+
+  // m_fu = new simd_function_unit*[m_num_function_units];
+
+  for (int k = 0; k < m_config->gpgpu_num_sp_units; k++) {
+    m_fu.push_back(new sp_unit(&m_pipeline_reg[EX_WB], m_config, this));
+    m_dispatch_port.push_back(ID_OC_SP);
+    m_issue_port.push_back(OC_EX_SP);
+  }
+
+  for (int k = 0; k < m_config->gpgpu_num_dp_units; k++) {
+    m_fu.push_back(new dp_unit(&m_pipeline_reg[EX_WB], m_config, this));
+    m_dispatch_port.push_back(ID_OC_DP);
+    m_issue_port.push_back(OC_EX_DP);
+  }
+  for (int k = 0; k < m_config->gpgpu_num_int_units; k++) {
+    m_fu.push_back(new int_unit(&m_pipeline_reg[EX_WB], m_config, this));
+    m_dispatch_port.push_back(ID_OC_INT);
+    m_issue_port.push_back(OC_EX_INT);
+  }
+
+  for (int k = 0; k < m_config->gpgpu_num_sfu_units; k++) {
+    m_fu.push_back(new sfu(&m_pipeline_reg[EX_WB], m_config, this));
+    m_dispatch_port.push_back(ID_OC_SFU);
+    m_issue_port.push_back(OC_EX_SFU);
+  }
+
+  for (int k = 0; k < config->gpgpu_num_tensor_core_units; k++) {
+    m_fu.push_back(new tensor_core(&m_pipeline_reg[EX_WB], m_config, this));
+    m_dispatch_port.push_back(ID_OC_TENSOR_CORE);
+    m_issue_port.push_back(OC_EX_TENSOR_CORE);
+  }
+
+  m_ldst_unit =
+      new ldst_unit(m_icnt, m_mem_fetch_allocator, this, &m_operand_collector,
+                    m_scoreboard, config, mem_config, stats, shader_id, tpc_id);
+  m_fu.push_back(m_ldst_unit);
+  m_dispatch_port.push_back(ID_OC_MEM);
+  m_issue_port.push_back(OC_EX_MEM);
+
+  assert(m_num_function_units == m_fu.size() and
+         m_fu.size() == m_dispatch_port.size() and
+         m_fu.size() == m_issue_port.size());
+
+  // there are as many result buses as the width of the EX_WB stage
+  num_result_bus = config->pipe_widths[EX_WB];
+  for (unsigned i = 0; i < num_result_bus; i++) {
+    this->m_result_bus.push_back(new std::bitset<MAX_ALU_LATENCY>());
+  }
+
+  m_last_inst_gpu_sim_cycle = 0;
+  m_last_inst_gpu_tot_sim_cycle = 0;
+
+  // Jin: for concurrent kernels on a SM
+  m_occupied_n_threads = 0;
+  m_occupied_shmem = 0;
+  m_occupied_regs = 0;
+  m_occupied_ctas = 0;
+  m_occupied_hwtid.reset();
+  m_occupied_cta_to_hwtid.clear();
+}
+
+void shader_core_ctx::reinit(unsigned start_thread, unsigned end_thread,
+                             bool reset_not_completed) {
+  if (reset_not_completed) {
     m_not_completed = 0;
     m_active_threads.reset();
-    m_n_active_cta = 0;
-    for ( unsigned i = 0; i<MAX_CTA_PER_SHADER; i++ ) 
-        m_cta_status[i]=0;
-    for (unsigned i = 0; i<config->n_thread_per_shader; i++) {
-        m_thread[i]= NULL;
-        m_threadState[i].m_cta_id = -1;
-        m_threadState[i].m_active = false;
-    }
-    
-    // m_icnt = new shader_memory_interface(this,cluster);
-    if ( m_config->gpgpu_perfect_mem ) {
-        m_icnt = new perfect_memory_interface(this,cluster);
-    } else {
-        m_icnt = new shader_memory_interface(this,cluster);
-    }
-    m_mem_fetch_allocator = new shader_core_mem_fetch_allocator(shader_id,tpc_id,mem_config);
-    
-    // fetch
-    m_last_warp_fetched = 0;
-    
-    #define STRSIZE 1024
-    char name[STRSIZE];
-    snprintf(name, STRSIZE, "L1I_%03d", m_sid);
-    m_L1I = new read_only_cache( name,m_config->m_L1I_config,m_sid,get_shader_instruction_cache_id(),m_icnt,IN_L1I_MISS_QUEUE);
-    
-    m_warp.resize(m_config->max_warps_per_shader, shd_warp_t(this, warp_size));
-    m_scoreboard = new Scoreboard(m_sid, m_config->max_warps_per_shader, gpu);
-    
-    //scedulers
-    //must currently occur after all inputs have been initialized.
-    std::string sched_config = m_config->gpgpu_scheduler_string;
-    const concrete_scheduler scheduler = sched_config.find("lrr") != std::string::npos ?
-                                         CONCRETE_SCHEDULER_LRR :
-                                         sched_config.find("two_level_active") != std::string::npos ?
-                                         CONCRETE_SCHEDULER_TWO_LEVEL_ACTIVE :
-                                         sched_config.find("gto") != std::string::npos ?
-                                         CONCRETE_SCHEDULER_GTO :
-					 sched_config.find("old") != std::string::npos ?
-					 CONCRETE_SCHEDULER_OLDEST_FIRST :
-                                         sched_config.find("warp_limiting") != std::string::npos ?
-                                         CONCRETE_SCHEDULER_WARP_LIMITING:
-                                         NUM_CONCRETE_SCHEDULERS;
-    assert ( scheduler != NUM_CONCRETE_SCHEDULERS );
-    
-    for (unsigned i = 0; i < m_config->gpgpu_num_sched_per_core; i++) {
-        switch( scheduler )
-        {
-            case CONCRETE_SCHEDULER_LRR:
-                schedulers.push_back(
-                    new lrr_scheduler( m_stats,
-                                       this,
-                                       m_scoreboard,
-                                       m_simt_stack,
-                                       &m_warp,
-                                       &m_pipeline_reg[ID_OC_SP],
-									   &m_pipeline_reg[ID_OC_DP],
-                                       &m_pipeline_reg[ID_OC_SFU],
-									   &m_pipeline_reg[ID_OC_INT],
-                                       &m_pipeline_reg[ID_OC_TENSOR_CORE],
-                                       &m_pipeline_reg[ID_OC_MEM],
-                                       i
-                                     )
-                );
-                break;
-            case CONCRETE_SCHEDULER_TWO_LEVEL_ACTIVE:
-                schedulers.push_back(
-                    new two_level_active_scheduler( m_stats,
-                                                    this,
-                                                    m_scoreboard,
-                                                    m_simt_stack,
-                                                    &m_warp,
-                                                    &m_pipeline_reg[ID_OC_SP],
-													&m_pipeline_reg[ID_OC_DP],
-                                                    &m_pipeline_reg[ID_OC_SFU],
-													&m_pipeline_reg[ID_OC_INT],
-                                                    &m_pipeline_reg[ID_OC_TENSOR_CORE],
-                                                    &m_pipeline_reg[ID_OC_MEM],
-                                                    i,
-                                                    config->gpgpu_scheduler_string
-                                                  )
-                );
-                break;
-            case CONCRETE_SCHEDULER_GTO:
-                schedulers.push_back(
-                    new gto_scheduler( m_stats,
-                                       this,
-                                       m_scoreboard,
-                                       m_simt_stack,
-                                       &m_warp,
-                                       &m_pipeline_reg[ID_OC_SP],
-									   &m_pipeline_reg[ID_OC_DP],
-                                       &m_pipeline_reg[ID_OC_SFU],
-									   &m_pipeline_reg[ID_OC_INT],
-                                       &m_pipeline_reg[ID_OC_TENSOR_CORE],
-                                       &m_pipeline_reg[ID_OC_MEM],
-                                       i
-                                     )
-                );
-                break;
-            case CONCRETE_SCHEDULER_OLDEST_FIRST:
-				schedulers.push_back(
-		    new oldest_scheduler( m_stats,
-					  this,
-					  m_scoreboard,
-					  m_simt_stack,
-					  &m_warp,
-					  &m_pipeline_reg[ID_OC_SP],
-					  &m_pipeline_reg[ID_OC_DP],
-					  &m_pipeline_reg[ID_OC_SFU],
-					  &m_pipeline_reg[ID_OC_INT],
-                      &m_pipeline_reg[ID_OC_TENSOR_CORE],
-					  &m_pipeline_reg[ID_OC_MEM],
-					  i
-					 )
-				);
-				break;
-            case CONCRETE_SCHEDULER_WARP_LIMITING:
-                schedulers.push_back(
-                    new swl_scheduler( m_stats,
-                                       this,
-                                       m_scoreboard,
-                                       m_simt_stack,
-                                       &m_warp,
-                                       &m_pipeline_reg[ID_OC_SP],
-									   &m_pipeline_reg[ID_OC_DP],
-                                       &m_pipeline_reg[ID_OC_SFU],
-									   &m_pipeline_reg[ID_OC_INT],
-                                       &m_pipeline_reg[ID_OC_TENSOR_CORE],
-                                       &m_pipeline_reg[ID_OC_MEM],
-                                       i,
-                                       config->gpgpu_scheduler_string
-                                     )
-                );
-                break;
-            default:
-                abort();
-        };
-    }
-    
-    for (unsigned i = 0; i < m_warp.size(); i++) {
-        //distribute i's evenly though schedulers;
-        schedulers[i%m_config->gpgpu_num_sched_per_core]->add_supervised_warp_id(i);
-    }
-    for ( unsigned i = 0; i < m_config->gpgpu_num_sched_per_core; ++i ) {
-        schedulers[i]->done_adding_supervised_warps();
-    }
-    
-    //op collector configuration
 
-	enum { SP_CUS, DP_CUS, SFU_CUS, TENSOR_CORE_CUS, INT_CUS, MEM_CUS,  GEN_CUS };
-
-    opndcoll_rfu_t::port_vector_t in_ports;
-    opndcoll_rfu_t::port_vector_t out_ports;
-    opndcoll_rfu_t::uint_vector_t cu_sets;
-
-    //configure generic collectors
-    m_operand_collector.add_cu_set(GEN_CUS, m_config->gpgpu_operand_collector_num_units_gen, m_config->gpgpu_operand_collector_num_out_ports_gen);
-
-    for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_gen; i++) {
-        in_ports.push_back(&m_pipeline_reg[ID_OC_SP]);
-        in_ports.push_back(&m_pipeline_reg[ID_OC_SFU]);
-        in_ports.push_back(&m_pipeline_reg[ID_OC_MEM]);
-        out_ports.push_back(&m_pipeline_reg[OC_EX_SP]);
-        out_ports.push_back(&m_pipeline_reg[OC_EX_SFU]);
-        out_ports.push_back(&m_pipeline_reg[OC_EX_MEM]);
-        if(m_config->gpgpu_tensor_core_avail) {
-        	in_ports.push_back(&m_pipeline_reg[ID_OC_TENSOR_CORE]);
-        	out_ports.push_back(&m_pipeline_reg[OC_EX_TENSOR_CORE]);
-        }
-        if(m_config->gpgpu_num_dp_units > 0) {
-			in_ports.push_back(&m_pipeline_reg[ID_OC_DP]);
-			out_ports.push_back(&m_pipeline_reg[OC_EX_DP]);
-        }
-        if(m_config->gpgpu_num_int_units > 0) {
-			in_ports.push_back(&m_pipeline_reg[ID_OC_INT]);
-			out_ports.push_back(&m_pipeline_reg[OC_EX_INT]);
-        }
-        cu_sets.push_back((unsigned)GEN_CUS);
-        m_operand_collector.add_port(in_ports,out_ports,cu_sets);
-        in_ports.clear(),out_ports.clear(),cu_sets.clear();
-    }
-
-    if(m_config->enable_specialized_operand_collector) {
-		m_operand_collector.add_cu_set(SP_CUS, m_config->gpgpu_operand_collector_num_units_sp, m_config->gpgpu_operand_collector_num_out_ports_sp);
-		m_operand_collector.add_cu_set(DP_CUS, m_config->gpgpu_operand_collector_num_units_dp, m_config->gpgpu_operand_collector_num_out_ports_dp);
-	    m_operand_collector.add_cu_set(TENSOR_CORE_CUS, config->gpgpu_operand_collector_num_units_tensor_core, config->gpgpu_operand_collector_num_out_ports_tensor_core);
-	    m_operand_collector.add_cu_set(SFU_CUS, m_config->gpgpu_operand_collector_num_units_sfu, m_config->gpgpu_operand_collector_num_out_ports_sfu);
-		m_operand_collector.add_cu_set(MEM_CUS, m_config->gpgpu_operand_collector_num_units_mem, m_config->gpgpu_operand_collector_num_out_ports_mem);
-		m_operand_collector.add_cu_set(INT_CUS, m_config->gpgpu_operand_collector_num_units_int, m_config->gpgpu_operand_collector_num_out_ports_int);
-
-		for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_sp; i++) {
-			in_ports.push_back(&m_pipeline_reg[ID_OC_SP]);
-			out_ports.push_back(&m_pipeline_reg[OC_EX_SP]);
-			cu_sets.push_back((unsigned)SP_CUS);
-			cu_sets.push_back((unsigned)GEN_CUS);
-			m_operand_collector.add_port(in_ports,out_ports,cu_sets);
-			in_ports.clear(),out_ports.clear(),cu_sets.clear();
-		}
-
-		for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_dp; i++) {
-				in_ports.push_back(&m_pipeline_reg[ID_OC_DP]);
-				out_ports.push_back(&m_pipeline_reg[OC_EX_DP]);
-				cu_sets.push_back((unsigned)DP_CUS);
-				cu_sets.push_back((unsigned)GEN_CUS);
-				m_operand_collector.add_port(in_ports,out_ports,cu_sets);
-				in_ports.clear(),out_ports.clear(),cu_sets.clear();
-			}
-
-		for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_sfu; i++) {
-			in_ports.push_back(&m_pipeline_reg[ID_OC_SFU]);
-			out_ports.push_back(&m_pipeline_reg[OC_EX_SFU]);
-			cu_sets.push_back((unsigned)SFU_CUS);
-			cu_sets.push_back((unsigned)GEN_CUS);
-			m_operand_collector.add_port(in_ports,out_ports,cu_sets);
-			in_ports.clear(),out_ports.clear(),cu_sets.clear();
-		}
-
-	    for (unsigned i = 0; i < config->gpgpu_operand_collector_num_in_ports_tensor_core; i++) {
-	        in_ports.push_back(&m_pipeline_reg[ID_OC_TENSOR_CORE]);
-	        out_ports.push_back(&m_pipeline_reg[OC_EX_TENSOR_CORE]);
-	        cu_sets.push_back((unsigned)TENSOR_CORE_CUS);
-	        cu_sets.push_back((unsigned)GEN_CUS);
-	        m_operand_collector.add_port(in_ports,out_ports,cu_sets);
-	        in_ports.clear(),out_ports.clear(),cu_sets.clear();
-	    }
-
-		for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_mem; i++) {
-			in_ports.push_back(&m_pipeline_reg[ID_OC_MEM]);
-			out_ports.push_back(&m_pipeline_reg[OC_EX_MEM]);
-			cu_sets.push_back((unsigned)MEM_CUS);
-			cu_sets.push_back((unsigned)GEN_CUS);
-			m_operand_collector.add_port(in_ports,out_ports,cu_sets);
-			in_ports.clear(),out_ports.clear(),cu_sets.clear();
-		}
-
-		for (unsigned i = 0; i < m_config->gpgpu_operand_collector_num_in_ports_int; i++) {
-			in_ports.push_back(&m_pipeline_reg[ID_OC_INT]);
-			out_ports.push_back(&m_pipeline_reg[OC_EX_INT]);
-			cu_sets.push_back((unsigned)INT_CUS);
-			cu_sets.push_back((unsigned)GEN_CUS);
-			m_operand_collector.add_port(in_ports,out_ports,cu_sets);
-			in_ports.clear(),out_ports.clear(),cu_sets.clear();
-		}
-    }
-    
-    m_operand_collector.init( m_config->gpgpu_num_reg_banks, this );
-    
-    m_num_function_units = m_config->gpgpu_num_sp_units + m_config->gpgpu_num_dp_units + m_config->gpgpu_num_sfu_units + m_config->gpgpu_num_tensor_core_units + m_config->gpgpu_num_int_units + 1; // sp_unit, sfu, dp, tensor, int, ldst_unit
-    //m_dispatch_port = new enum pipeline_stage_name_t[ m_num_function_units ];
-    //m_issue_port = new enum pipeline_stage_name_t[ m_num_function_units ];
-    
-    //m_fu = new simd_function_unit*[m_num_function_units];
-    
-    for (int k = 0; k < m_config->gpgpu_num_sp_units; k++) {
-        m_fu.push_back(new sp_unit( &m_pipeline_reg[EX_WB], m_config, this ));
-        m_dispatch_port.push_back(ID_OC_SP);
-        m_issue_port.push_back(OC_EX_SP);
-    }
-    
-    for (int k = 0; k < m_config->gpgpu_num_dp_units; k++) {
-            m_fu.push_back(new dp_unit( &m_pipeline_reg[EX_WB], m_config, this ));
-            m_dispatch_port.push_back(ID_OC_DP);
-            m_issue_port.push_back(OC_EX_DP);
-        }
-    for (int k = 0; k < m_config->gpgpu_num_int_units; k++) {
-            m_fu.push_back(new int_unit( &m_pipeline_reg[EX_WB], m_config, this ));
-            m_dispatch_port.push_back(ID_OC_INT);
-            m_issue_port.push_back(OC_EX_INT);
-        }
-
-    for (int k = 0; k < m_config->gpgpu_num_sfu_units; k++) {
-        m_fu.push_back(new sfu( &m_pipeline_reg[EX_WB], m_config, this ));
-        m_dispatch_port.push_back(ID_OC_SFU);
-        m_issue_port.push_back(OC_EX_SFU);
-    }
-       
-    for (int k = 0; k < config->gpgpu_num_tensor_core_units; k++) {
-        m_fu.push_back(new tensor_core( &m_pipeline_reg[EX_WB], m_config, this ));
-        m_dispatch_port.push_back(ID_OC_TENSOR_CORE);
-        m_issue_port.push_back(OC_EX_TENSOR_CORE);
-    }
-
-    m_ldst_unit = new ldst_unit( m_icnt, m_mem_fetch_allocator, this, &m_operand_collector, m_scoreboard, config, mem_config, stats, shader_id, tpc_id );
-    m_fu.push_back(m_ldst_unit);
-    m_dispatch_port.push_back(ID_OC_MEM);
-    m_issue_port.push_back(OC_EX_MEM);
-   
-    assert(m_num_function_units == m_fu.size() and m_fu.size() == m_dispatch_port.size() and m_fu.size() == m_issue_port.size());
-    
-    //there are as many result buses as the width of the EX_WB stage
-    num_result_bus = config->pipe_widths[EX_WB];
-    for(unsigned i=0; i<num_result_bus; i++){
-        this->m_result_bus.push_back(new std::bitset<MAX_ALU_LATENCY>());
-    }
-    
-    m_last_inst_gpu_sim_cycle = 0;
-    m_last_inst_gpu_tot_sim_cycle = 0;
-
-    //Jin: for concurrent kernels on a SM
+    // Jin: for concurrent kernels on a SM
     m_occupied_n_threads = 0;
     m_occupied_shmem = 0;
     m_occupied_regs = 0;
     m_occupied_ctas = 0;
     m_occupied_hwtid.reset();
     m_occupied_cta_to_hwtid.clear();
+    m_active_warps = 0;
+  }
+  for (unsigned i = start_thread; i < end_thread; i++) {
+    m_threadState[i].n_insn = 0;
+    m_threadState[i].m_cta_id = -1;
+  }
+  for (unsigned i = start_thread / m_config->warp_size;
+       i < end_thread / m_config->warp_size; ++i) {
+    m_warp[i].reset();
+    m_simt_stack[i]->reset();
+  }
 }
 
-void shader_core_ctx::reinit(unsigned start_thread, unsigned end_thread, bool reset_not_completed ) 
-{
-   if( reset_not_completed ) {
-       m_not_completed = 0;
-       m_active_threads.reset();
-
-       //Jin: for concurrent kernels on a SM
-       m_occupied_n_threads = 0;
-       m_occupied_shmem = 0;
-       m_occupied_regs = 0;
-       m_occupied_ctas = 0;
-       m_occupied_hwtid.reset();
-       m_occupied_cta_to_hwtid.clear();
-       m_active_warps = 0;
-
-   }
-   for (unsigned i = start_thread; i<end_thread; i++) {
-      m_threadState[i].n_insn = 0;
-      m_threadState[i].m_cta_id = -1;
-   }
-   for (unsigned i = start_thread / m_config->warp_size; i < end_thread / m_config->warp_size; ++i) {
-      m_warp[i].reset();
-      m_simt_stack[i]->reset();
-   }
-}
-
-void shader_core_ctx::init_warps( unsigned cta_id, unsigned start_thread, unsigned end_thread, unsigned ctaid, int cta_size, unsigned kernel_id )
-{
-    address_type start_pc = next_pc(start_thread);
-    if (m_config->model == POST_DOMINATOR) {
-        unsigned start_warp = start_thread / m_config->warp_size;
-        unsigned warp_per_cta =  cta_size / m_config->warp_size;
-        unsigned end_warp = end_thread / m_config->warp_size + ((end_thread % m_config->warp_size)? 1 : 0);
-        for (unsigned i = start_warp; i < end_warp; ++i) {
-            unsigned n_active=0;
-            simt_mask_t active_threads;
-            for (unsigned t = 0; t < m_config->warp_size; t++) {
-                unsigned hwtid = i * m_config->warp_size + t;
-                if ( hwtid < end_thread ) {
-                    n_active++;
-                    assert( !m_active_threads.test(hwtid) );
-                    m_active_threads.set( hwtid );
-                    active_threads.set(t);
-                }
-            }
-            m_simt_stack[i]->launch(start_pc,active_threads);
-
-              if(m_gpu->resume_option == 1 && kernel_id == m_gpu->resume_kernel && ctaid >= m_gpu->resume_CTA && ctaid < m_gpu->checkpoint_CTA_t )
-               { 
-                char fname[2048];
-                snprintf(fname,2048,"checkpoint_files/warp_%d_%d_simt.txt",i%warp_per_cta,ctaid );
-                unsigned pc,rpc;
-                m_simt_stack[i]->resume(fname);
-                m_simt_stack[i]->get_pdom_stack_top_info(&pc,&rpc);
-                for (unsigned t = 0; t < m_config->warp_size; t++) {
-                  m_thread[i * m_config->warp_size + t]->set_npc(pc);
-                  m_thread[i * m_config->warp_size + t]->update_pc();
-                }   
-                start_pc=pc;
-              }
-               
-            m_warp[i].init(start_pc,cta_id,i,active_threads, m_dynamic_warp_id);
-            ++m_dynamic_warp_id;
-            m_not_completed += n_active;
-            ++m_active_warps;
+void shader_core_ctx::init_warps(unsigned cta_id, unsigned start_thread,
+                                 unsigned end_thread, unsigned ctaid,
+                                 int cta_size, unsigned kernel_id) {
+  address_type start_pc = next_pc(start_thread);
+  if (m_config->model == POST_DOMINATOR) {
+    unsigned start_warp = start_thread / m_config->warp_size;
+    unsigned warp_per_cta = cta_size / m_config->warp_size;
+    unsigned end_warp = end_thread / m_config->warp_size +
+                        ((end_thread % m_config->warp_size) ? 1 : 0);
+    for (unsigned i = start_warp; i < end_warp; ++i) {
+      unsigned n_active = 0;
+      simt_mask_t active_threads;
+      for (unsigned t = 0; t < m_config->warp_size; t++) {
+        unsigned hwtid = i * m_config->warp_size + t;
+        if (hwtid < end_thread) {
+          n_active++;
+          assert(!m_active_threads.test(hwtid));
+          m_active_threads.set(hwtid);
+          active_threads.set(t);
+        }
       }
-   }
-}
+      m_simt_stack[i]->launch(start_pc, active_threads);
 
-// return the next pc of a thread 
-address_type shader_core_ctx::next_pc( int tid ) const
-{
-    if( tid == -1 ) 
-        return -1;
-    ptx_thread_info *the_thread = m_thread[tid];
-    if ( the_thread == NULL )
-        return -1;
-    return the_thread->get_pc(); // PC should already be updatd to next PC at this point (was set in shader_decode() last time thread ran)
-}
-
-void gpgpu_sim::get_pdom_stack_top_info( unsigned sid, unsigned tid, unsigned *pc, unsigned *rpc )
-{
-    unsigned cluster_id = m_shader_config->sid_to_cluster(sid);
-    m_cluster[cluster_id]->get_pdom_stack_top_info(sid,tid,pc,rpc);
-}
-
-void shader_core_ctx::get_pdom_stack_top_info( unsigned tid, unsigned *pc, unsigned *rpc ) const
-{
-    unsigned warp_id = tid/m_config->warp_size;
-    m_simt_stack[warp_id]->get_pdom_stack_top_info(pc,rpc);
-}
-
-float shader_core_ctx::get_current_occupancy( unsigned long long & active, unsigned long long & total ) const
-{
-    // To match the achieved_occupancy in nvprof, only SMs that are active are counted toward the occupancy.
-    if ( m_active_warps > 0 ) {
-        total += m_warp.size();
-        active += m_active_warps;
-        return float(active) / float(total);
-    } else {
-        return 0;
-    }
-}
-
-void shader_core_stats::print( FILE* fout ) const
-{
-	unsigned long long  thread_icount_uarch=0;
-	unsigned long long  warp_icount_uarch=0;
-
-    for(unsigned i=0; i < m_config->num_shader(); i++) {
-        thread_icount_uarch += m_num_sim_insn[i];
-        warp_icount_uarch += m_num_sim_winsn[i];
-    }
-    fprintf(fout,"gpgpu_n_tot_thrd_icount = %lld\n", thread_icount_uarch);
-    fprintf(fout,"gpgpu_n_tot_w_icount = %lld\n", warp_icount_uarch);
-
-    fprintf(fout,"gpgpu_n_stall_shd_mem = %d\n", gpgpu_n_stall_shd_mem );
-    fprintf(fout,"gpgpu_n_mem_read_local = %d\n", gpgpu_n_mem_read_local);
-    fprintf(fout,"gpgpu_n_mem_write_local = %d\n", gpgpu_n_mem_write_local);
-    fprintf(fout,"gpgpu_n_mem_read_global = %d\n", gpgpu_n_mem_read_global);
-    fprintf(fout,"gpgpu_n_mem_write_global = %d\n", gpgpu_n_mem_write_global);
-    fprintf(fout,"gpgpu_n_mem_texture = %d\n", gpgpu_n_mem_texture);
-    fprintf(fout,"gpgpu_n_mem_const = %d\n", gpgpu_n_mem_const);
-
-   fprintf(fout, "gpgpu_n_load_insn  = %d\n", gpgpu_n_load_insn);
-   fprintf(fout, "gpgpu_n_store_insn = %d\n", gpgpu_n_store_insn);
-   fprintf(fout, "gpgpu_n_shmem_insn = %d\n", gpgpu_n_shmem_insn);
-   fprintf(fout, "gpgpu_n_sstarr_insn = %d\n", gpgpu_n_sstarr_insn);
-   fprintf(fout, "gpgpu_n_tex_insn = %d\n", gpgpu_n_tex_insn);
-   fprintf(fout, "gpgpu_n_const_mem_insn = %d\n", gpgpu_n_const_insn);
-   fprintf(fout, "gpgpu_n_param_mem_insn = %d\n", gpgpu_n_param_insn);
-
-   fprintf(fout, "gpgpu_n_shmem_bkconflict = %d\n", gpgpu_n_shmem_bkconflict);
-   fprintf(fout, "gpgpu_n_cache_bkconflict = %d\n", gpgpu_n_cache_bkconflict);   
-
-   fprintf(fout, "gpgpu_n_intrawarp_mshr_merge = %d\n", gpgpu_n_intrawarp_mshr_merge);
-   fprintf(fout, "gpgpu_n_cmem_portconflict = %d\n", gpgpu_n_cmem_portconflict);
-
-   fprintf(fout, "gpgpu_stall_shd_mem[c_mem][resource_stall] = %d\n", gpu_stall_shd_mem_breakdown[C_MEM][BK_CONF]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[c_mem][mshr_rc] = %d\n", gpu_stall_shd_mem_breakdown[C_MEM][MSHR_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[c_mem][icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[C_MEM][ICNT_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[c_mem][data_port_stall] = %d\n", gpu_stall_shd_mem_breakdown[C_MEM][DATA_PORT_STALL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[t_mem][mshr_rc] = %d\n", gpu_stall_shd_mem_breakdown[T_MEM][MSHR_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[t_mem][icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[T_MEM][ICNT_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[t_mem][data_port_stall] = %d\n", gpu_stall_shd_mem_breakdown[T_MEM][DATA_PORT_STALL]);
-   fprintf(fout, "gpgpu_stall_shd_mem[s_mem][bk_conf] = %d\n", gpu_stall_shd_mem_breakdown[S_MEM][BK_CONF]);
-   fprintf(fout, "gpgpu_stall_shd_mem[gl_mem][resource_stall] = %d\n",
-           gpu_stall_shd_mem_breakdown[G_MEM_LD][BK_CONF] + 
-           gpu_stall_shd_mem_breakdown[G_MEM_ST][BK_CONF] + 
-           gpu_stall_shd_mem_breakdown[L_MEM_LD][BK_CONF] + 
-           gpu_stall_shd_mem_breakdown[L_MEM_ST][BK_CONF]   
-           ); // coalescing stall at data cache 
-   fprintf(fout, "gpgpu_stall_shd_mem[gl_mem][coal_stall] = %d\n", 
-           gpu_stall_shd_mem_breakdown[G_MEM_LD][COAL_STALL] + 
-           gpu_stall_shd_mem_breakdown[G_MEM_ST][COAL_STALL] + 
-           gpu_stall_shd_mem_breakdown[L_MEM_LD][COAL_STALL] + 
-           gpu_stall_shd_mem_breakdown[L_MEM_ST][COAL_STALL]    
-           ); // coalescing stall + bank conflict at data cache 
-   fprintf(fout, "gpgpu_stall_shd_mem[gl_mem][data_port_stall] = %d\n", 
-           gpu_stall_shd_mem_breakdown[G_MEM_LD][DATA_PORT_STALL] + 
-           gpu_stall_shd_mem_breakdown[G_MEM_ST][DATA_PORT_STALL] + 
-           gpu_stall_shd_mem_breakdown[L_MEM_LD][DATA_PORT_STALL] + 
-           gpu_stall_shd_mem_breakdown[L_MEM_ST][DATA_PORT_STALL]    
-           ); // data port stall at data cache 
-   //fprintf(fout, "gpgpu_stall_shd_mem[g_mem_ld][mshr_rc] = %d\n", gpu_stall_shd_mem_breakdown[G_MEM_LD][MSHR_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[g_mem_ld][icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[G_MEM_LD][ICNT_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[g_mem_ld][wb_icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[G_MEM_LD][WB_ICNT_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[g_mem_ld][wb_rsrv_fail] = %d\n", gpu_stall_shd_mem_breakdown[G_MEM_LD][WB_CACHE_RSRV_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[g_mem_st][mshr_rc] = %d\n", gpu_stall_shd_mem_breakdown[G_MEM_ST][MSHR_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[g_mem_st][icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[G_MEM_ST][ICNT_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[g_mem_st][wb_icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[G_MEM_ST][WB_ICNT_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[g_mem_st][wb_rsrv_fail] = %d\n", gpu_stall_shd_mem_breakdown[G_MEM_ST][WB_CACHE_RSRV_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][mshr_rc] = %d\n", gpu_stall_shd_mem_breakdown[L_MEM_LD][MSHR_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[L_MEM_LD][ICNT_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][wb_icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[L_MEM_LD][WB_ICNT_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][wb_rsrv_fail] = %d\n", gpu_stall_shd_mem_breakdown[L_MEM_LD][WB_CACHE_RSRV_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[l_mem_st][mshr_rc] = %d\n", gpu_stall_shd_mem_breakdown[L_MEM_ST][MSHR_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[l_mem_st][icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[L_MEM_ST][ICNT_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][wb_icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[L_MEM_ST][WB_ICNT_RC_FAIL]);
-   //fprintf(fout, "gpgpu_stall_shd_mem[l_mem_ld][wb_rsrv_fail] = %d\n", gpu_stall_shd_mem_breakdown[L_MEM_ST][WB_CACHE_RSRV_FAIL]);
-
-   fprintf(fout, "gpu_reg_bank_conflict_stalls = %d\n", gpu_reg_bank_conflict_stalls);
-
-   fprintf(fout, "Warp Occupancy Distribution:\n");
-   fprintf(fout, "Stall:%d\t", shader_cycle_distro[2]);
-   fprintf(fout, "W0_Idle:%d\t", shader_cycle_distro[0]);
-   fprintf(fout, "W0_Scoreboard:%d", shader_cycle_distro[1]);
-   for (unsigned i = 3; i < m_config->warp_size + 3; i++) 
-      fprintf(fout, "\tW%d:%d", i-2, shader_cycle_distro[i]);
-   fprintf(fout, "\n");
-   fprintf(fout, "single_issue_nums: ");
-   for (unsigned i = 0; i < m_config->gpgpu_num_sched_per_core; i++)
-        fprintf(fout, "WS%d:%d\t", i, single_issue_nums[i]);
-   fprintf(fout, "\n");
-   fprintf(fout, "dual_issue_nums: ");
-   for (unsigned i = 0; i < m_config->gpgpu_num_sched_per_core; i++)
-          fprintf(fout, "WS%d:%d\t", i, dual_issue_nums[i]);
-   fprintf(fout, "\n");
-
-   m_outgoing_traffic_stats->print(fout); 
-   m_incoming_traffic_stats->print(fout); 
-}
-
-void shader_core_stats::event_warp_issued( unsigned s_id, unsigned warp_id, unsigned num_issued, unsigned dynamic_warp_id ) {
-    assert( warp_id <= m_config->max_warps_per_shader );
-    for ( unsigned i = 0; i < num_issued; ++i ) {
-        if ( m_shader_dynamic_warp_issue_distro[ s_id ].size() <= dynamic_warp_id ) {
-            m_shader_dynamic_warp_issue_distro[ s_id ].resize(dynamic_warp_id + 1);
+      if (m_gpu->resume_option == 1 && kernel_id == m_gpu->resume_kernel &&
+          ctaid >= m_gpu->resume_CTA && ctaid < m_gpu->checkpoint_CTA_t) {
+        char fname[2048];
+        snprintf(fname, 2048, "checkpoint_files/warp_%d_%d_simt.txt",
+                 i % warp_per_cta, ctaid);
+        unsigned pc, rpc;
+        m_simt_stack[i]->resume(fname);
+        m_simt_stack[i]->get_pdom_stack_top_info(&pc, &rpc);
+        for (unsigned t = 0; t < m_config->warp_size; t++) {
+          m_thread[i * m_config->warp_size + t]->set_npc(pc);
+          m_thread[i * m_config->warp_size + t]->update_pc();
         }
-        ++m_shader_dynamic_warp_issue_distro[ s_id ][ dynamic_warp_id ];
-        if ( m_shader_warp_slot_issue_distro[ s_id ].size() <= warp_id ) {
-            m_shader_warp_slot_issue_distro[ s_id ].resize(warp_id + 1);
-        }
-        ++m_shader_warp_slot_issue_distro[ s_id ][ warp_id ];
+        start_pc = pc;
+      }
+
+      m_warp[i].init(start_pc, cta_id, i, active_threads, m_dynamic_warp_id);
+      ++m_dynamic_warp_id;
+      m_not_completed += n_active;
+      ++m_active_warps;
     }
+  }
 }
 
-void shader_core_stats::visualizer_print( gzFile visualizer_file )
-{
-    // warp divergence breakdown
-    gzprintf(visualizer_file, "WarpDivergenceBreakdown:");
-    unsigned int total=0;
-    unsigned int cf = (m_config->gpgpu_warpdistro_shader==-1)?m_config->num_shader():1;
-    gzprintf(visualizer_file, " %d", (shader_cycle_distro[0] - last_shader_cycle_distro[0]) / cf );
-    gzprintf(visualizer_file, " %d", (shader_cycle_distro[1] - last_shader_cycle_distro[1]) / cf );
-    gzprintf(visualizer_file, " %d", (shader_cycle_distro[2] - last_shader_cycle_distro[2]) / cf );
-    for (unsigned i=0; i<m_config->warp_size+3; i++) {
-       if ( i>=3 ) {
-          total += (shader_cycle_distro[i] - last_shader_cycle_distro[i]);
-          if ( ((i-3) % (m_config->warp_size/8)) == ((m_config->warp_size/8)-1) ) {
-             gzprintf(visualizer_file, " %d", total / cf );
-             total=0;
-          }
-       }
-       last_shader_cycle_distro[i] = shader_cycle_distro[i];
-    }
-    gzprintf(visualizer_file,"\n");
-
-    // warp issue breakdown
-    unsigned sid = m_config->gpgpu_warp_issue_shader;
-    unsigned count = 0;
-    unsigned warp_id_issued_sum = 0;
-    gzprintf(visualizer_file, "WarpIssueSlotBreakdown:");
-    if(m_shader_warp_slot_issue_distro[sid].size() > 0){
-        for ( std::vector<unsigned>::const_iterator iter = m_shader_warp_slot_issue_distro[ sid ].begin();
-              iter != m_shader_warp_slot_issue_distro[ sid ].end(); iter++, count++ ) {
-            unsigned diff = count < m_last_shader_warp_slot_issue_distro.size() ?
-                            *iter - m_last_shader_warp_slot_issue_distro[ count ] :
-                            *iter;
-            gzprintf( visualizer_file, " %d", diff );
-            warp_id_issued_sum += diff;
-        }
-        m_last_shader_warp_slot_issue_distro = m_shader_warp_slot_issue_distro[ sid ];
-    }else{
-        gzprintf( visualizer_file, " 0");
-    }
-    gzprintf(visualizer_file,"\n");
-
-    #define DYNAMIC_WARP_PRINT_RESOLUTION 32
-    unsigned total_issued_this_resolution = 0;
-    unsigned dynamic_id_issued_sum = 0;
-    count = 0;
-    gzprintf(visualizer_file, "WarpIssueDynamicIdBreakdown:");
-    if(m_shader_dynamic_warp_issue_distro[sid].size() > 0){
-        for ( std::vector<unsigned>::const_iterator iter = m_shader_dynamic_warp_issue_distro[ sid ].begin();
-              iter != m_shader_dynamic_warp_issue_distro[ sid ].end(); iter++, count++ ) {
-            unsigned diff = count < m_last_shader_dynamic_warp_issue_distro.size() ?
-                            *iter - m_last_shader_dynamic_warp_issue_distro[ count ] :
-                            *iter;
-            total_issued_this_resolution += diff;
-            if ( ( count + 1 ) % DYNAMIC_WARP_PRINT_RESOLUTION == 0 ) {
-                gzprintf( visualizer_file, " %d", total_issued_this_resolution );
-                dynamic_id_issued_sum += total_issued_this_resolution;
-                total_issued_this_resolution = 0;
-            }
-        }
-        if ( count % DYNAMIC_WARP_PRINT_RESOLUTION != 0 ) {
-            gzprintf( visualizer_file, " %d", total_issued_this_resolution );
-            dynamic_id_issued_sum += total_issued_this_resolution;
-        }
-        m_last_shader_dynamic_warp_issue_distro = m_shader_dynamic_warp_issue_distro[ sid ];
-        assert( warp_id_issued_sum == dynamic_id_issued_sum );
-    }else{
-        gzprintf( visualizer_file, " 0");
-    }
-    gzprintf(visualizer_file,"\n");
-
-    // overall cache miss rates
-    gzprintf(visualizer_file, "gpgpu_n_cache_bkconflict: %d\n", gpgpu_n_cache_bkconflict);
-    gzprintf(visualizer_file, "gpgpu_n_shmem_bkconflict: %d\n", gpgpu_n_shmem_bkconflict);     
-
-
-   // instruction count per shader core
-   gzprintf(visualizer_file, "shaderinsncount:  ");
-   for (unsigned i=0;i<m_config->num_shader();i++) 
-      gzprintf(visualizer_file, "%u ", m_num_sim_insn[i] );
-   gzprintf(visualizer_file, "\n");
-   // warp instruction count per shader core
-   gzprintf(visualizer_file, "shaderwarpinsncount:  ");
-   for (unsigned i=0;i<m_config->num_shader();i++)
-      gzprintf(visualizer_file, "%u ", m_num_sim_winsn[i] );
-   gzprintf(visualizer_file, "\n");
-   // warp divergence per shader core
-   gzprintf(visualizer_file, "shaderwarpdiv: ");
-   for (unsigned i=0;i<m_config->num_shader();i++) 
-      gzprintf(visualizer_file, "%u ", m_n_diverge[i] );
-   gzprintf(visualizer_file, "\n");
+// return the next pc of a thread
+address_type shader_core_ctx::next_pc(int tid) const {
+  if (tid == -1) return -1;
+  ptx_thread_info *the_thread = m_thread[tid];
+  if (the_thread == NULL) return -1;
+  return the_thread
+      ->get_pc();  // PC should already be updatd to next PC at this point (was
+                   // set in shader_decode() last time thread ran)
 }
 
-#define PROGRAM_MEM_START 0xF0000000 /* should be distinct from other memory spaces... 
-                                        check ptx_ir.h to verify this does not overlap 
-                                        other memory spaces */
-void shader_core_ctx::decode()
-{
-    if( m_inst_fetch_buffer.m_valid ) {
-        // decode 1 or 2 instructions and place them into ibuffer
-        address_type pc = m_inst_fetch_buffer.m_pc;
-        const warp_inst_t* pI1 = m_gpu->gpgpu_ctx->ptx_fetch_inst(pc);
-        m_warp[m_inst_fetch_buffer.m_warp_id].ibuffer_fill(0,pI1);
+void gpgpu_sim::get_pdom_stack_top_info(unsigned sid, unsigned tid,
+                                        unsigned *pc, unsigned *rpc) {
+  unsigned cluster_id = m_shader_config->sid_to_cluster(sid);
+  m_cluster[cluster_id]->get_pdom_stack_top_info(sid, tid, pc, rpc);
+}
+
+void shader_core_ctx::get_pdom_stack_top_info(unsigned tid, unsigned *pc,
+                                              unsigned *rpc) const {
+  unsigned warp_id = tid / m_config->warp_size;
+  m_simt_stack[warp_id]->get_pdom_stack_top_info(pc, rpc);
+}
+
+float shader_core_ctx::get_current_occupancy(unsigned long long &active,
+                                             unsigned long long &total) const {
+  // To match the achieved_occupancy in nvprof, only SMs that are active are
+  // counted toward the occupancy.
+  if (m_active_warps > 0) {
+    total += m_warp.size();
+    active += m_active_warps;
+    return float(active) / float(total);
+  } else {
+    return 0;
+  }
+}
+
+void shader_core_stats::print(FILE *fout) const {
+  unsigned long long thread_icount_uarch = 0;
+  unsigned long long warp_icount_uarch = 0;
+
+  for (unsigned i = 0; i < m_config->num_shader(); i++) {
+    thread_icount_uarch += m_num_sim_insn[i];
+    warp_icount_uarch += m_num_sim_winsn[i];
+  }
+  fprintf(fout, "gpgpu_n_tot_thrd_icount = %lld\n", thread_icount_uarch);
+  fprintf(fout, "gpgpu_n_tot_w_icount = %lld\n", warp_icount_uarch);
+
+  fprintf(fout, "gpgpu_n_stall_shd_mem = %d\n", gpgpu_n_stall_shd_mem);
+  fprintf(fout, "gpgpu_n_mem_read_local = %d\n", gpgpu_n_mem_read_local);
+  fprintf(fout, "gpgpu_n_mem_write_local = %d\n", gpgpu_n_mem_write_local);
+  fprintf(fout, "gpgpu_n_mem_read_global = %d\n", gpgpu_n_mem_read_global);
+  fprintf(fout, "gpgpu_n_mem_write_global = %d\n", gpgpu_n_mem_write_global);
+  fprintf(fout, "gpgpu_n_mem_texture = %d\n", gpgpu_n_mem_texture);
+  fprintf(fout, "gpgpu_n_mem_const = %d\n", gpgpu_n_mem_const);
+
+  fprintf(fout, "gpgpu_n_load_insn  = %d\n", gpgpu_n_load_insn);
+  fprintf(fout, "gpgpu_n_store_insn = %d\n", gpgpu_n_store_insn);
+  fprintf(fout, "gpgpu_n_shmem_insn = %d\n", gpgpu_n_shmem_insn);
+  fprintf(fout, "gpgpu_n_sstarr_insn = %d\n", gpgpu_n_sstarr_insn);
+  fprintf(fout, "gpgpu_n_tex_insn = %d\n", gpgpu_n_tex_insn);
+  fprintf(fout, "gpgpu_n_const_mem_insn = %d\n", gpgpu_n_const_insn);
+  fprintf(fout, "gpgpu_n_param_mem_insn = %d\n", gpgpu_n_param_insn);
+
+  fprintf(fout, "gpgpu_n_shmem_bkconflict = %d\n", gpgpu_n_shmem_bkconflict);
+  fprintf(fout, "gpgpu_n_cache_bkconflict = %d\n", gpgpu_n_cache_bkconflict);
+
+  fprintf(fout, "gpgpu_n_intrawarp_mshr_merge = %d\n",
+          gpgpu_n_intrawarp_mshr_merge);
+  fprintf(fout, "gpgpu_n_cmem_portconflict = %d\n", gpgpu_n_cmem_portconflict);
+
+  fprintf(fout, "gpgpu_stall_shd_mem[c_mem][resource_stall] = %d\n",
+          gpu_stall_shd_mem_breakdown[C_MEM][BK_CONF]);
+  // fprintf(fout, "gpgpu_stall_shd_mem[c_mem][mshr_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[C_MEM][MSHR_RC_FAIL]); fprintf(fout,
+  // "gpgpu_stall_shd_mem[c_mem][icnt_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[C_MEM][ICNT_RC_FAIL]); fprintf(fout,
+  // "gpgpu_stall_shd_mem[c_mem][data_port_stall] = %d\n",
+  // gpu_stall_shd_mem_breakdown[C_MEM][DATA_PORT_STALL]); fprintf(fout,
+  // "gpgpu_stall_shd_mem[t_mem][mshr_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[T_MEM][MSHR_RC_FAIL]); fprintf(fout,
+  // "gpgpu_stall_shd_mem[t_mem][icnt_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[T_MEM][ICNT_RC_FAIL]); fprintf(fout,
+  // "gpgpu_stall_shd_mem[t_mem][data_port_stall] = %d\n",
+  // gpu_stall_shd_mem_breakdown[T_MEM][DATA_PORT_STALL]);
+  fprintf(fout, "gpgpu_stall_shd_mem[s_mem][bk_conf] = %d\n",
+          gpu_stall_shd_mem_breakdown[S_MEM][BK_CONF]);
+  fprintf(
+      fout, "gpgpu_stall_shd_mem[gl_mem][resource_stall] = %d\n",
+      gpu_stall_shd_mem_breakdown[G_MEM_LD][BK_CONF] +
+          gpu_stall_shd_mem_breakdown[G_MEM_ST][BK_CONF] +
+          gpu_stall_shd_mem_breakdown[L_MEM_LD][BK_CONF] +
+          gpu_stall_shd_mem_breakdown[L_MEM_ST][BK_CONF]);  // coalescing stall
+                                                            // at data cache
+  fprintf(
+      fout, "gpgpu_stall_shd_mem[gl_mem][coal_stall] = %d\n",
+      gpu_stall_shd_mem_breakdown[G_MEM_LD][COAL_STALL] +
+          gpu_stall_shd_mem_breakdown[G_MEM_ST][COAL_STALL] +
+          gpu_stall_shd_mem_breakdown[L_MEM_LD][COAL_STALL] +
+          gpu_stall_shd_mem_breakdown[L_MEM_ST]
+                                     [COAL_STALL]);  // coalescing stall + bank
+                                                     // conflict at data cache
+  fprintf(fout, "gpgpu_stall_shd_mem[gl_mem][data_port_stall] = %d\n",
+          gpu_stall_shd_mem_breakdown[G_MEM_LD][DATA_PORT_STALL] +
+              gpu_stall_shd_mem_breakdown[G_MEM_ST][DATA_PORT_STALL] +
+              gpu_stall_shd_mem_breakdown[L_MEM_LD][DATA_PORT_STALL] +
+              gpu_stall_shd_mem_breakdown[L_MEM_ST]
+                                         [DATA_PORT_STALL]);  // data port stall
+                                                              // at data cache
+  // fprintf(fout, "gpgpu_stall_shd_mem[g_mem_ld][mshr_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[G_MEM_LD][MSHR_RC_FAIL]); fprintf(fout,
+  // "gpgpu_stall_shd_mem[g_mem_ld][icnt_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[G_MEM_LD][ICNT_RC_FAIL]); fprintf(fout,
+  // "gpgpu_stall_shd_mem[g_mem_ld][wb_icnt_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[G_MEM_LD][WB_ICNT_RC_FAIL]); fprintf(fout,
+  // "gpgpu_stall_shd_mem[g_mem_ld][wb_rsrv_fail] = %d\n",
+  // gpu_stall_shd_mem_breakdown[G_MEM_LD][WB_CACHE_RSRV_FAIL]); fprintf(fout,
+  // "gpgpu_stall_shd_mem[g_mem_st][mshr_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[G_MEM_ST][MSHR_RC_FAIL]); fprintf(fout,
+  // "gpgpu_stall_shd_mem[g_mem_st][icnt_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[G_MEM_ST][ICNT_RC_FAIL]); fprintf(fout,
+  // "gpgpu_stall_shd_mem[g_mem_st][wb_icnt_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[G_MEM_ST][WB_ICNT_RC_FAIL]); fprintf(fout,
+  // "gpgpu_stall_shd_mem[g_mem_st][wb_rsrv_fail] = %d\n",
+  // gpu_stall_shd_mem_breakdown[G_MEM_ST][WB_CACHE_RSRV_FAIL]); fprintf(fout,
+  // "gpgpu_stall_shd_mem[l_mem_ld][mshr_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[L_MEM_LD][MSHR_RC_FAIL]); fprintf(fout,
+  // "gpgpu_stall_shd_mem[l_mem_ld][icnt_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[L_MEM_LD][ICNT_RC_FAIL]); fprintf(fout,
+  // "gpgpu_stall_shd_mem[l_mem_ld][wb_icnt_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[L_MEM_LD][WB_ICNT_RC_FAIL]); fprintf(fout,
+  // "gpgpu_stall_shd_mem[l_mem_ld][wb_rsrv_fail] = %d\n",
+  // gpu_stall_shd_mem_breakdown[L_MEM_LD][WB_CACHE_RSRV_FAIL]); fprintf(fout,
+  // "gpgpu_stall_shd_mem[l_mem_st][mshr_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[L_MEM_ST][MSHR_RC_FAIL]); fprintf(fout,
+  // "gpgpu_stall_shd_mem[l_mem_st][icnt_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[L_MEM_ST][ICNT_RC_FAIL]); fprintf(fout,
+  // "gpgpu_stall_shd_mem[l_mem_ld][wb_icnt_rc] = %d\n",
+  // gpu_stall_shd_mem_breakdown[L_MEM_ST][WB_ICNT_RC_FAIL]); fprintf(fout,
+  // "gpgpu_stall_shd_mem[l_mem_ld][wb_rsrv_fail] = %d\n",
+  // gpu_stall_shd_mem_breakdown[L_MEM_ST][WB_CACHE_RSRV_FAIL]);
+
+  fprintf(fout, "gpu_reg_bank_conflict_stalls = %d\n",
+          gpu_reg_bank_conflict_stalls);
+
+  fprintf(fout, "Warp Occupancy Distribution:\n");
+  fprintf(fout, "Stall:%d\t", shader_cycle_distro[2]);
+  fprintf(fout, "W0_Idle:%d\t", shader_cycle_distro[0]);
+  fprintf(fout, "W0_Scoreboard:%d", shader_cycle_distro[1]);
+  for (unsigned i = 3; i < m_config->warp_size + 3; i++)
+    fprintf(fout, "\tW%d:%d", i - 2, shader_cycle_distro[i]);
+  fprintf(fout, "\n");
+  fprintf(fout, "single_issue_nums: ");
+  for (unsigned i = 0; i < m_config->gpgpu_num_sched_per_core; i++)
+    fprintf(fout, "WS%d:%d\t", i, single_issue_nums[i]);
+  fprintf(fout, "\n");
+  fprintf(fout, "dual_issue_nums: ");
+  for (unsigned i = 0; i < m_config->gpgpu_num_sched_per_core; i++)
+    fprintf(fout, "WS%d:%d\t", i, dual_issue_nums[i]);
+  fprintf(fout, "\n");
+
+  m_outgoing_traffic_stats->print(fout);
+  m_incoming_traffic_stats->print(fout);
+}
+
+void shader_core_stats::event_warp_issued(unsigned s_id, unsigned warp_id,
+                                          unsigned num_issued,
+                                          unsigned dynamic_warp_id) {
+  assert(warp_id <= m_config->max_warps_per_shader);
+  for (unsigned i = 0; i < num_issued; ++i) {
+    if (m_shader_dynamic_warp_issue_distro[s_id].size() <= dynamic_warp_id) {
+      m_shader_dynamic_warp_issue_distro[s_id].resize(dynamic_warp_id + 1);
+    }
+    ++m_shader_dynamic_warp_issue_distro[s_id][dynamic_warp_id];
+    if (m_shader_warp_slot_issue_distro[s_id].size() <= warp_id) {
+      m_shader_warp_slot_issue_distro[s_id].resize(warp_id + 1);
+    }
+    ++m_shader_warp_slot_issue_distro[s_id][warp_id];
+  }
+}
+
+void shader_core_stats::visualizer_print(gzFile visualizer_file) {
+  // warp divergence breakdown
+  gzprintf(visualizer_file, "WarpDivergenceBreakdown:");
+  unsigned int total = 0;
+  unsigned int cf =
+      (m_config->gpgpu_warpdistro_shader == -1) ? m_config->num_shader() : 1;
+  gzprintf(visualizer_file, " %d",
+           (shader_cycle_distro[0] - last_shader_cycle_distro[0]) / cf);
+  gzprintf(visualizer_file, " %d",
+           (shader_cycle_distro[1] - last_shader_cycle_distro[1]) / cf);
+  gzprintf(visualizer_file, " %d",
+           (shader_cycle_distro[2] - last_shader_cycle_distro[2]) / cf);
+  for (unsigned i = 0; i < m_config->warp_size + 3; i++) {
+    if (i >= 3) {
+      total += (shader_cycle_distro[i] - last_shader_cycle_distro[i]);
+      if (((i - 3) % (m_config->warp_size / 8)) ==
+          ((m_config->warp_size / 8) - 1)) {
+        gzprintf(visualizer_file, " %d", total / cf);
+        total = 0;
+      }
+    }
+    last_shader_cycle_distro[i] = shader_cycle_distro[i];
+  }
+  gzprintf(visualizer_file, "\n");
+
+  // warp issue breakdown
+  unsigned sid = m_config->gpgpu_warp_issue_shader;
+  unsigned count = 0;
+  unsigned warp_id_issued_sum = 0;
+  gzprintf(visualizer_file, "WarpIssueSlotBreakdown:");
+  if (m_shader_warp_slot_issue_distro[sid].size() > 0) {
+    for (std::vector<unsigned>::const_iterator iter =
+             m_shader_warp_slot_issue_distro[sid].begin();
+         iter != m_shader_warp_slot_issue_distro[sid].end(); iter++, count++) {
+      unsigned diff = count < m_last_shader_warp_slot_issue_distro.size()
+                          ? *iter - m_last_shader_warp_slot_issue_distro[count]
+                          : *iter;
+      gzprintf(visualizer_file, " %d", diff);
+      warp_id_issued_sum += diff;
+    }
+    m_last_shader_warp_slot_issue_distro = m_shader_warp_slot_issue_distro[sid];
+  } else {
+    gzprintf(visualizer_file, " 0");
+  }
+  gzprintf(visualizer_file, "\n");
+
+#define DYNAMIC_WARP_PRINT_RESOLUTION 32
+  unsigned total_issued_this_resolution = 0;
+  unsigned dynamic_id_issued_sum = 0;
+  count = 0;
+  gzprintf(visualizer_file, "WarpIssueDynamicIdBreakdown:");
+  if (m_shader_dynamic_warp_issue_distro[sid].size() > 0) {
+    for (std::vector<unsigned>::const_iterator iter =
+             m_shader_dynamic_warp_issue_distro[sid].begin();
+         iter != m_shader_dynamic_warp_issue_distro[sid].end();
+         iter++, count++) {
+      unsigned diff =
+          count < m_last_shader_dynamic_warp_issue_distro.size()
+              ? *iter - m_last_shader_dynamic_warp_issue_distro[count]
+              : *iter;
+      total_issued_this_resolution += diff;
+      if ((count + 1) % DYNAMIC_WARP_PRINT_RESOLUTION == 0) {
+        gzprintf(visualizer_file, " %d", total_issued_this_resolution);
+        dynamic_id_issued_sum += total_issued_this_resolution;
+        total_issued_this_resolution = 0;
+      }
+    }
+    if (count % DYNAMIC_WARP_PRINT_RESOLUTION != 0) {
+      gzprintf(visualizer_file, " %d", total_issued_this_resolution);
+      dynamic_id_issued_sum += total_issued_this_resolution;
+    }
+    m_last_shader_dynamic_warp_issue_distro =
+        m_shader_dynamic_warp_issue_distro[sid];
+    assert(warp_id_issued_sum == dynamic_id_issued_sum);
+  } else {
+    gzprintf(visualizer_file, " 0");
+  }
+  gzprintf(visualizer_file, "\n");
+
+  // overall cache miss rates
+  gzprintf(visualizer_file, "gpgpu_n_cache_bkconflict: %d\n",
+           gpgpu_n_cache_bkconflict);
+  gzprintf(visualizer_file, "gpgpu_n_shmem_bkconflict: %d\n",
+           gpgpu_n_shmem_bkconflict);
+
+  // instruction count per shader core
+  gzprintf(visualizer_file, "shaderinsncount:  ");
+  for (unsigned i = 0; i < m_config->num_shader(); i++)
+    gzprintf(visualizer_file, "%u ", m_num_sim_insn[i]);
+  gzprintf(visualizer_file, "\n");
+  // warp instruction count per shader core
+  gzprintf(visualizer_file, "shaderwarpinsncount:  ");
+  for (unsigned i = 0; i < m_config->num_shader(); i++)
+    gzprintf(visualizer_file, "%u ", m_num_sim_winsn[i]);
+  gzprintf(visualizer_file, "\n");
+  // warp divergence per shader core
+  gzprintf(visualizer_file, "shaderwarpdiv: ");
+  for (unsigned i = 0; i < m_config->num_shader(); i++)
+    gzprintf(visualizer_file, "%u ", m_n_diverge[i]);
+  gzprintf(visualizer_file, "\n");
+}
+
+#define PROGRAM_MEM_START                                      \
+  0xF0000000 /* should be distinct from other memory spaces... \
+                check ptx_ir.h to verify this does not overlap \
+                other memory spaces */
+void shader_core_ctx::decode() {
+  if (m_inst_fetch_buffer.m_valid) {
+    // decode 1 or 2 instructions and place them into ibuffer
+    address_type pc = m_inst_fetch_buffer.m_pc;
+    const warp_inst_t *pI1 = m_gpu->gpgpu_ctx->ptx_fetch_inst(pc);
+    m_warp[m_inst_fetch_buffer.m_warp_id].ibuffer_fill(0, pI1);
+    m_warp[m_inst_fetch_buffer.m_warp_id].inc_inst_in_pipeline();
+    if (pI1) {
+      m_stats->m_num_decoded_insn[m_sid]++;
+      if (pI1->oprnd_type == INT_OP) {
+        m_stats->m_num_INTdecoded_insn[m_sid]++;
+      } else if (pI1->oprnd_type == FP_OP) {
+        m_stats->m_num_FPdecoded_insn[m_sid]++;
+      }
+      const warp_inst_t *pI2 =
+          m_gpu->gpgpu_ctx->ptx_fetch_inst(pc + pI1->isize);
+      if (pI2) {
+        m_warp[m_inst_fetch_buffer.m_warp_id].ibuffer_fill(1, pI2);
         m_warp[m_inst_fetch_buffer.m_warp_id].inc_inst_in_pipeline();
-        if( pI1 ) {
-            m_stats->m_num_decoded_insn[m_sid]++;
-            if(pI1->oprnd_type==INT_OP){
-                m_stats->m_num_INTdecoded_insn[m_sid]++;
-            }else if(pI1->oprnd_type==FP_OP) {
-            	m_stats->m_num_FPdecoded_insn[m_sid]++;
-            }
-           const warp_inst_t* pI2 = m_gpu->gpgpu_ctx->ptx_fetch_inst(pc+pI1->isize);
-           if( pI2 ) {
-               m_warp[m_inst_fetch_buffer.m_warp_id].ibuffer_fill(1,pI2);
-               m_warp[m_inst_fetch_buffer.m_warp_id].inc_inst_in_pipeline();
-               m_stats->m_num_decoded_insn[m_sid]++;
-               if(pI2->oprnd_type==INT_OP){
-                   m_stats->m_num_INTdecoded_insn[m_sid]++;
-               }else if(pI2->oprnd_type==FP_OP) {
-            	   m_stats->m_num_FPdecoded_insn[m_sid]++;
-               }
-           }
+        m_stats->m_num_decoded_insn[m_sid]++;
+        if (pI2->oprnd_type == INT_OP) {
+          m_stats->m_num_INTdecoded_insn[m_sid]++;
+        } else if (pI2->oprnd_type == FP_OP) {
+          m_stats->m_num_FPdecoded_insn[m_sid]++;
         }
-        m_inst_fetch_buffer.m_valid = false;
+      }
     }
+    m_inst_fetch_buffer.m_valid = false;
+  }
 }
 
-void shader_core_ctx::fetch()
-{
+void shader_core_ctx::fetch() {
+  if (!m_inst_fetch_buffer.m_valid) {
+    if (m_L1I->access_ready()) {
+      mem_fetch *mf = m_L1I->next_access();
+      m_warp[mf->get_wid()].clear_imiss_pending();
+      m_inst_fetch_buffer = ifetch_buffer_t(
+          m_warp[mf->get_wid()].get_pc(), mf->get_access_size(), mf->get_wid());
+      assert(m_warp[mf->get_wid()].get_pc() ==
+             (mf->get_addr() -
+              PROGRAM_MEM_START));  // Verify that we got the instruction we
+                                    // were expecting.
+      m_inst_fetch_buffer.m_valid = true;
+      m_warp[mf->get_wid()].set_last_fetch(m_gpu->gpu_sim_cycle);
+      delete mf;
+    } else {
+      // find an active warp with space in instruction buffer that is not
+      // already waiting on a cache miss and get next 1-2 instructions from
+      // i-cache...
+      for (unsigned i = 0; i < m_config->max_warps_per_shader; i++) {
+        unsigned warp_id =
+            (m_last_warp_fetched + 1 + i) % m_config->max_warps_per_shader;
 
-    if( !m_inst_fetch_buffer.m_valid ) {
-        if( m_L1I->access_ready() ) {
-            mem_fetch *mf = m_L1I->next_access();
-            m_warp[mf->get_wid()].clear_imiss_pending();
-            m_inst_fetch_buffer = ifetch_buffer_t(m_warp[mf->get_wid()].get_pc(), mf->get_access_size(), mf->get_wid());
-            assert( m_warp[mf->get_wid()].get_pc() == (mf->get_addr()-PROGRAM_MEM_START)); // Verify that we got the instruction we were expecting.
-            m_inst_fetch_buffer.m_valid = true;
-            m_warp[mf->get_wid()].set_last_fetch(m_gpu->gpu_sim_cycle);
+        // this code checks if this warp has finished executing and can be
+        // reclaimed
+        if (m_warp[warp_id].hardware_done() &&
+            !m_scoreboard->pendingWrites(warp_id) &&
+            !m_warp[warp_id].done_exit()) {
+          bool did_exit = false;
+          for (unsigned t = 0; t < m_config->warp_size; t++) {
+            unsigned tid = warp_id * m_config->warp_size + t;
+            if (m_threadState[tid].m_active == true) {
+              m_threadState[tid].m_active = false;
+              unsigned cta_id = m_warp[warp_id].get_cta_id();
+              register_cta_thread_exit(cta_id, &(m_thread[tid]->get_kernel()));
+              m_not_completed -= 1;
+              m_active_threads.reset(tid);
+              assert(m_thread[tid] != NULL);
+              did_exit = true;
+            }
+          }
+          if (did_exit) m_warp[warp_id].set_done_exit();
+          --m_active_warps;
+          assert(m_active_warps >= 0);
+        }
+
+        // this code fetches instructions from the i-cache or generates memory
+        // requests
+        if (!m_warp[warp_id].functional_done() &&
+            !m_warp[warp_id].imiss_pending() &&
+            m_warp[warp_id].ibuffer_empty()) {
+          address_type pc = m_warp[warp_id].get_pc();
+          address_type ppc = pc + PROGRAM_MEM_START;
+          unsigned nbytes = 16;
+          unsigned offset_in_block =
+              pc & (m_config->m_L1I_config.get_line_sz() - 1);
+          if ((offset_in_block + nbytes) > m_config->m_L1I_config.get_line_sz())
+            nbytes = (m_config->m_L1I_config.get_line_sz() - offset_in_block);
+
+          // TODO: replace with use of allocator
+          // mem_fetch *mf = m_mem_fetch_allocator->alloc()
+          mem_access_t acc(INST_ACC_R, ppc, nbytes, false, m_gpu->gpgpu_ctx);
+          mem_fetch *mf = new mem_fetch(
+              acc, NULL /*we don't have an instruction yet*/, READ_PACKET_SIZE,
+              warp_id, m_sid, m_tpc, m_memory_config,
+              m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle);
+          std::list<cache_event> events;
+          enum cache_request_status status = m_L1I->access(
+              (new_addr_type)ppc, mf,
+              m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle, events);
+          if (status == MISS) {
+            m_last_warp_fetched = warp_id;
+            m_warp[warp_id].set_imiss_pending();
+            m_warp[warp_id].set_last_fetch(m_gpu->gpu_sim_cycle);
+          } else if (status == HIT) {
+            m_last_warp_fetched = warp_id;
+            m_inst_fetch_buffer = ifetch_buffer_t(pc, nbytes, warp_id);
+            m_warp[warp_id].set_last_fetch(m_gpu->gpu_sim_cycle);
             delete mf;
+          } else {
+            m_last_warp_fetched = warp_id;
+            assert(status == RESERVATION_FAIL);
+            delete mf;
+          }
+          break;
         }
-        else {
-            // find an active warp with space in instruction buffer that is not already waiting on a cache miss
-            // and get next 1-2 instructions from i-cache...
-            for( unsigned i=0; i < m_config->max_warps_per_shader; i++ ) {
-                unsigned warp_id = (m_last_warp_fetched+1+i) % m_config->max_warps_per_shader;
-
-                // this code checks if this warp has finished executing and can be reclaimed
-                if( m_warp[warp_id].hardware_done() && !m_scoreboard->pendingWrites(warp_id) && !m_warp[warp_id].done_exit() ) {
-                    bool did_exit=false;
-                    for( unsigned t=0; t<m_config->warp_size;t++) {
-                        unsigned tid=warp_id*m_config->warp_size+t;
-                        if( m_threadState[tid].m_active == true ) {
-                            m_threadState[tid].m_active = false; 
-                            unsigned cta_id = m_warp[warp_id].get_cta_id();
-                            register_cta_thread_exit(cta_id, &(m_thread[tid]->get_kernel()));
-                            m_not_completed -= 1;
-                            m_active_threads.reset(tid);
-                            assert( m_thread[tid]!= NULL );
-                            did_exit=true;
-                        }
-                    }
-                    if( did_exit ) 
-                        m_warp[warp_id].set_done_exit();
-                        --m_active_warps;
-                        assert(m_active_warps >= 0);
-                }
-
-                // this code fetches instructions from the i-cache or generates memory requests
-                if( !m_warp[warp_id].functional_done() && !m_warp[warp_id].imiss_pending() && m_warp[warp_id].ibuffer_empty() ) {
-                    address_type pc  = m_warp[warp_id].get_pc();
-                    address_type ppc = pc + PROGRAM_MEM_START;
-                    unsigned nbytes=16;
-                    unsigned offset_in_block = pc & (m_config->m_L1I_config.get_line_sz()-1);
-                    if( (offset_in_block+nbytes) > m_config->m_L1I_config.get_line_sz() )
-                        nbytes = (m_config->m_L1I_config.get_line_sz()-offset_in_block);
-
-                    // TODO: replace with use of allocator
-                    // mem_fetch *mf = m_mem_fetch_allocator->alloc()
-                    mem_access_t acc(INST_ACC_R,ppc,nbytes,false, m_gpu->gpgpu_ctx);
-                    mem_fetch *mf = new mem_fetch(acc,
-                            NULL/*we don't have an instruction yet*/,
-                            READ_PACKET_SIZE,
-                            warp_id,
-                            m_sid,
-                            m_tpc,
-                            m_memory_config,
-							m_gpu->gpu_tot_sim_cycle+m_gpu->gpu_sim_cycle
-							);
-                    std::list<cache_event> events;
-                    enum cache_request_status status = m_L1I->access( (new_addr_type)ppc, mf, m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle,events);
-                    if( status == MISS ) {
-                        m_last_warp_fetched=warp_id;
-                        m_warp[warp_id].set_imiss_pending();
-                        m_warp[warp_id].set_last_fetch(m_gpu->gpu_sim_cycle);
-                    } else if( status == HIT ) {
-                        m_last_warp_fetched=warp_id;
-                        m_inst_fetch_buffer = ifetch_buffer_t(pc,nbytes,warp_id);
-                        m_warp[warp_id].set_last_fetch(m_gpu->gpu_sim_cycle);
-                        delete mf;
-                    } else {
-                        m_last_warp_fetched=warp_id;
-                        assert( status == RESERVATION_FAIL );
-                        delete mf;
-                    }
-                    break;
-                }
-            }
-        }
+      }
     }
+  }
 
-    m_L1I->cycle();
+  m_L1I->cycle();
 }
 
-void shader_core_ctx::func_exec_inst( warp_inst_t &inst )
-{
-    execute_warp_inst_t(inst);
-    if( inst.is_load() || inst.is_store() )
-    {
-	inst.generate_mem_accesses();
-        //inst.print_m_accessq();	
-    }	
+void shader_core_ctx::func_exec_inst(warp_inst_t &inst) {
+  execute_warp_inst_t(inst);
+  if (inst.is_load() || inst.is_store()) {
+    inst.generate_mem_accesses();
+    // inst.print_m_accessq();
+  }
 }
 
-void shader_core_ctx::issue_warp( register_set& pipe_reg_set, const warp_inst_t* next_inst, const active_mask_t &active_mask, unsigned warp_id, unsigned sch_id )
-{
-	warp_inst_t** pipe_reg = pipe_reg_set.get_free(m_config->sub_core_model, sch_id);
-    assert(pipe_reg);
+void shader_core_ctx::issue_warp(register_set &pipe_reg_set,
+                                 const warp_inst_t *next_inst,
+                                 const active_mask_t &active_mask,
+                                 unsigned warp_id, unsigned sch_id) {
+  warp_inst_t **pipe_reg =
+      pipe_reg_set.get_free(m_config->sub_core_model, sch_id);
+  assert(pipe_reg);
 
-    m_warp[warp_id].ibuffer_free();
-    assert(next_inst->valid());
-    **pipe_reg = *next_inst; // static instruction information
-    (*pipe_reg)->issue( active_mask, warp_id, m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle, m_warp[warp_id].get_dynamic_warp_id(), sch_id ); // dynamic instruction information
-    m_stats->shader_cycle_distro[2+(*pipe_reg)->active_count()]++;
-    func_exec_inst( **pipe_reg );
-    if( next_inst->op == BARRIER_OP ){
-        m_warp[warp_id].store_info_of_last_inst_at_barrier(*pipe_reg);
-        m_barriers.warp_reaches_barrier(m_warp[warp_id].get_cta_id(),warp_id,const_cast<warp_inst_t*> (next_inst));
+  m_warp[warp_id].ibuffer_free();
+  assert(next_inst->valid());
+  **pipe_reg = *next_inst;  // static instruction information
+  (*pipe_reg)->issue(active_mask, warp_id,
+                     m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle,
+                     m_warp[warp_id].get_dynamic_warp_id(),
+                     sch_id);  // dynamic instruction information
+  m_stats->shader_cycle_distro[2 + (*pipe_reg)->active_count()]++;
+  func_exec_inst(**pipe_reg);
+  if (next_inst->op == BARRIER_OP) {
+    m_warp[warp_id].store_info_of_last_inst_at_barrier(*pipe_reg);
+    m_barriers.warp_reaches_barrier(m_warp[warp_id].get_cta_id(), warp_id,
+                                    const_cast<warp_inst_t *>(next_inst));
 
-    }else if( next_inst->op == MEMORY_BARRIER_OP ){
-        m_warp[warp_id].set_membar();
-    }
+  } else if (next_inst->op == MEMORY_BARRIER_OP) {
+    m_warp[warp_id].set_membar();
+  }
 
-    updateSIMTStack(warp_id,*pipe_reg);
-    m_scoreboard->reserveRegisters(*pipe_reg);
-    m_warp[warp_id].set_next_pc(next_inst->pc + next_inst->isize);
+  updateSIMTStack(warp_id, *pipe_reg);
+  m_scoreboard->reserveRegisters(*pipe_reg);
+  m_warp[warp_id].set_next_pc(next_inst->pc + next_inst->isize);
 }
 
-void shader_core_ctx::issue(){
+void shader_core_ctx::issue() {
+  // Ensure fair round robin issu between schedulers
+  unsigned j;
+  for (unsigned i = 0; i < schedulers.size(); i++) {
+    j = (Issue_Prio + i) % schedulers.size();
+    schedulers[j]->cycle();
+  }
+  Issue_Prio = (Issue_Prio + 1) % schedulers.size();
 
-     //Ensure fair round robin issu between schedulers 
-     unsigned j;
-     for (unsigned i = 0; i < schedulers.size(); i++) {
-	j = (Issue_Prio + i) % schedulers.size();
-	  schedulers[j]->cycle();
-     }
-     Issue_Prio = (Issue_Prio+1)% schedulers.size();
-
-    //really is issue;
-    //for (unsigned i = 0; i < schedulers.size(); i++) {
-    //    schedulers[i]->cycle();
-    //}
+  // really is issue;
+  // for (unsigned i = 0; i < schedulers.size(); i++) {
+  //    schedulers[i]->cycle();
+  //}
 }
 
-shd_warp_t& scheduler_unit::warp(int i){
-    return (*m_warp)[i];
-}
-
+shd_warp_t &scheduler_unit::warp(int i) { return (*m_warp)[i]; }
 
 /**
- * A general function to order things in a Loose Round Robin way. The simplist use of this
- * function would be to implement a loose RR scheduler between all the warps assigned to this core.
- * A more sophisticated usage would be to order a set of "fetch groups" in a RR fashion.
- * In the first case, the templated class variable would be a simple unsigned int representing the
- * warp_id.  In the 2lvl case, T could be a struct or a list representing a set of warp_ids.
- * @param result_list: The resultant list the caller wants returned.  This list is cleared and then populated
- *                     in a loose round robin way
- * @param input_list: The list of things that should be put into the result_list. For a simple scheduler
- *                    this can simply be the m_supervised_warps list.
- * @param last_issued_from_input:  An iterator pointing the last member in the input_list that issued.
- *                                 Since this function orders in a RR fashion, the object pointed
- *                                 to by this iterator will be last in the prioritization list
- * @param num_warps_to_add: The number of warps you want the scheudler to pick between this cycle.
- *                          Normally, this will be all the warps availible on the core, i.e.
- *                          m_supervised_warps.size(). However, a more sophisticated scheduler may wish to
- *                          limit this number. If the number if < m_supervised_warps.size(), then only
- *                          the warps with highest RR priority will be placed in the result_list.
+ * A general function to order things in a Loose Round Robin way. The simplist
+ * use of this function would be to implement a loose RR scheduler between all
+ * the warps assigned to this core. A more sophisticated usage would be to order
+ * a set of "fetch groups" in a RR fashion. In the first case, the templated
+ * class variable would be a simple unsigned int representing the warp_id.  In
+ * the 2lvl case, T could be a struct or a list representing a set of warp_ids.
+ * @param result_list: The resultant list the caller wants returned.  This list
+ * is cleared and then populated in a loose round robin way
+ * @param input_list: The list of things that should be put into the
+ * result_list. For a simple scheduler this can simply be the m_supervised_warps
+ * list.
+ * @param last_issued_from_input:  An iterator pointing the last member in the
+ * input_list that issued. Since this function orders in a RR fashion, the
+ * object pointed to by this iterator will be last in the prioritization list
+ * @param num_warps_to_add: The number of warps you want the scheudler to pick
+ * between this cycle. Normally, this will be all the warps availible on the
+ * core, i.e. m_supervised_warps.size(). However, a more sophisticated scheduler
+ * may wish to limit this number. If the number if < m_supervised_warps.size(),
+ * then only the warps with highest RR priority will be placed in the
+ * result_list.
  */
-    template < class T >
-void scheduler_unit::order_lrr( std::vector< T >& result_list,
-        const typename std::vector< T >& input_list,
-        const typename std::vector< T >::const_iterator& last_issued_from_input,
-        unsigned num_warps_to_add )
-{
-    assert( num_warps_to_add <= input_list.size() );
-    result_list.clear();
-    typename std::vector< T >::const_iterator iter
-        = ( last_issued_from_input ==  input_list.end() ) ? input_list.begin()
-        : last_issued_from_input + 1;
+template <class T>
+void scheduler_unit::order_lrr(
+    std::vector<T> &result_list, const typename std::vector<T> &input_list,
+    const typename std::vector<T>::const_iterator &last_issued_from_input,
+    unsigned num_warps_to_add) {
+  assert(num_warps_to_add <= input_list.size());
+  result_list.clear();
+  typename std::vector<T>::const_iterator iter =
+      (last_issued_from_input == input_list.end()) ? input_list.begin()
+                                                   : last_issued_from_input + 1;
 
-    for ( unsigned count = 0;
-            count < num_warps_to_add;
-            ++iter, ++count) {
-        if ( iter ==  input_list.end() ) {
-            iter = input_list.begin();
-        }
-        result_list.push_back( *iter );
+  for (unsigned count = 0; count < num_warps_to_add; ++iter, ++count) {
+    if (iter == input_list.end()) {
+      iter = input_list.begin();
     }
+    result_list.push_back(*iter);
+  }
 }
 
 /**
  * A general function to order things in an priority-based way.
  * The core usage of the function is similar to order_lrr.
- * The explanation of the additional parameters (beyond order_lrr) explains the further extensions.
- * @param ordering: An enum that determines how the age function will be treated in prioritization
- *                  see the definition of OrderingType.
- * @param priority_function: This function is used to sort the input_list.  It is passed to stl::sort as
- *                           the sorting fucntion. So, if you wanted to sort a list of integer warp_ids
- *                           with the oldest warps having the most priority, then the priority_function
- *                           would compare the age of the two warps.
+ * The explanation of the additional parameters (beyond order_lrr) explains the
+ * further extensions.
+ * @param ordering: An enum that determines how the age function will be treated
+ * in prioritization see the definition of OrderingType.
+ * @param priority_function: This function is used to sort the input_list.  It
+ * is passed to stl::sort as the sorting fucntion. So, if you wanted to sort a
+ * list of integer warp_ids with the oldest warps having the most priority, then
+ * the priority_function would compare the age of the two warps.
  */
-    template < class T >
-void scheduler_unit::order_by_priority( std::vector< T >& result_list,
-        const typename std::vector< T >& input_list,
-        const typename std::vector< T >::const_iterator& last_issued_from_input,
-        unsigned num_warps_to_add,
-        OrderingType ordering,
-        bool (*priority_func)(T lhs, T rhs) )
-{
-    assert( num_warps_to_add <= input_list.size() );
-    result_list.clear();
-    typename std::vector< T > temp = input_list;
+template <class T>
+void scheduler_unit::order_by_priority(
+    std::vector<T> &result_list, const typename std::vector<T> &input_list,
+    const typename std::vector<T>::const_iterator &last_issued_from_input,
+    unsigned num_warps_to_add, OrderingType ordering,
+    bool (*priority_func)(T lhs, T rhs)) {
+  assert(num_warps_to_add <= input_list.size());
+  result_list.clear();
+  typename std::vector<T> temp = input_list;
 
-    if ( ORDERING_GREEDY_THEN_PRIORITY_FUNC == ordering ) {
-        T greedy_value = *last_issued_from_input;
-        result_list.push_back( greedy_value );
+  if (ORDERING_GREEDY_THEN_PRIORITY_FUNC == ordering) {
+    T greedy_value = *last_issued_from_input;
+    result_list.push_back(greedy_value);
 
-        std::sort( temp.begin(), temp.end(), priority_func );
-        typename std::vector< T >::iterator iter = temp.begin();
-        for ( unsigned count = 0; count < num_warps_to_add; ++count, ++iter ) {
-            if ( *iter != greedy_value ) {
-                result_list.push_back( *iter );
-            }
-        }
-    } else if ( ORDERED_PRIORITY_FUNC_ONLY == ordering ) {
-        std::sort( temp.begin(), temp.end(), priority_func );
-        typename std::vector< T >::iterator iter = temp.begin();
-        for ( unsigned count = 0; count < num_warps_to_add; ++count, ++iter ) {
-            result_list.push_back( *iter );
-        }
-    } else {
-        fprintf( stderr, "Unknown ordering - %d\n", ordering );
-        abort();
-    }
-}
-
-void scheduler_unit::cycle()
-{
-    SCHED_DPRINTF( "scheduler_unit::cycle()\n" );
-    bool valid_inst = false;  // there was one warp with a valid instruction to issue (didn't require flush due to control hazard)
-    bool ready_inst = false;  // of the valid instructions, there was one not waiting for pending register writes
-    bool issued_inst = false; // of these we issued one
-
-    order_warps();
-    for ( std::vector< shd_warp_t* >::const_iterator iter = m_next_cycle_prioritized_warps.begin();
-          iter != m_next_cycle_prioritized_warps.end();
-          iter++ ) {
-        // Don't consider warps that are not yet valid
-        if ( (*iter) == NULL || (*iter)->done_exit() ) {
-            continue;
-        }
-        SCHED_DPRINTF( "Testing (warp_id %u, dynamic_warp_id %u)\n",
-                       (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id() );
-        unsigned warp_id = (*iter)->get_warp_id();
-        unsigned checked=0;
-        unsigned issued=0;
-        exec_unit_type_t previous_issued_inst_exec_type = exec_unit_type_t::NONE;
-        unsigned max_issue = m_shader->m_config->gpgpu_max_insn_issue_per_warp;
-        bool diff_exec_units = m_shader->m_config->gpgpu_dual_issue_diff_exec_units;  //In tis mode, we only allow dual issue to diff execution units (as in Maxwell and Pascal)
-
-        while( !warp(warp_id).waiting() && !warp(warp_id).ibuffer_empty() && (checked < max_issue) && (checked <= issued) && (issued < max_issue) ) {
-            const warp_inst_t *pI = warp(warp_id).ibuffer_next_inst();
-            //Jin: handle cdp latency;
-            if(pI && pI->m_is_cdp && warp(warp_id).m_cdp_latency > 0) {
-                assert(warp(warp_id).m_cdp_dummy);
-                warp(warp_id).m_cdp_latency--;
-                break;
-            }
-
-            bool valid = warp(warp_id).ibuffer_next_valid();
-            bool warp_inst_issued = false;
-            unsigned pc,rpc;
-            m_simt_stack[warp_id]->get_pdom_stack_top_info(&pc,&rpc);
-            SCHED_DPRINTF( "Warp (warp_id %u, dynamic_warp_id %u) has valid instruction (%s)\n",
-                           (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id(),
-                           m_shader->m_config->gpgpu_ctx->func_sim->ptx_get_insn_str( pc).c_str() );
-            if( pI ) {
-                assert(valid);
-                if( pc != pI->pc ) {
-                    SCHED_DPRINTF( "Warp (warp_id %u, dynamic_warp_id %u) control hazard instruction flush\n",
-                                   (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id() );
-                    // control hazard
-                    warp(warp_id).set_next_pc(pc);
-                    warp(warp_id).ibuffer_flush();
-                } else {
-                    valid_inst = true;
-                    if ( !m_scoreboard->checkCollision(warp_id, pI) ) {
-                        SCHED_DPRINTF( "Warp (warp_id %u, dynamic_warp_id %u) passes scoreboard\n",
-                                       (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id() );
-                        ready_inst = true;
-                        const active_mask_t &active_mask = m_simt_stack[warp_id]->get_active_mask();
-                        assert( warp(warp_id).inst_in_pipeline() );
-
-                        if ( (pI->op == LOAD_OP) || (pI->op == STORE_OP) || (pI->op == MEMORY_BARRIER_OP)||(pI->op==TENSOR_CORE_LOAD_OP)||(pI->op==TENSOR_CORE_STORE_OP) ) {
-                        	if( m_mem_out->has_free(m_shader->m_config->sub_core_model, m_id) && (!diff_exec_units || previous_issued_inst_exec_type != exec_unit_type_t::MEM)) {
-                                m_shader->issue_warp(*m_mem_out,pI,active_mask,warp_id,m_id);
-                                issued++;
-                                issued_inst=true;
-                                warp_inst_issued = true;
-                                previous_issued_inst_exec_type = exec_unit_type_t::MEM;
-                            }
-                        } else {
-
-                            bool sp_pipe_avail = m_sp_out->has_free(m_shader->m_config->sub_core_model, m_id);
-                            bool sfu_pipe_avail = m_sfu_out->has_free(m_shader->m_config->sub_core_model, m_id);
-                            bool tensor_core_pipe_avail = m_tensor_core_out->has_free(m_shader->m_config->sub_core_model, m_id);
-                            bool dp_pipe_avail = m_dp_out->has_free(m_shader->m_config->sub_core_model, m_id);
-                            bool int_pipe_avail = m_int_out->has_free(m_shader->m_config->sub_core_model, m_id);
-
-                            //This code need to be refactored
-                            if(pI->op != TENSOR_CORE_OP && pI->op != SFU_OP && pI->op != DP_OP) {
-                                
-									bool execute_on_SP = false;
-									bool execute_on_INT = false;
-
-									//if INT unit pipline exist, then execute ALU and INT operations on INT unit and SP-FPU on SP unit (like in Volta)
-									//if INT unit pipline does not exist, then execute all ALU, INT and SP operations on SP unit (as in Fermi, Pascal GPUs)
-									if(m_shader->m_config->gpgpu_num_int_units > 0 &&
-											int_pipe_avail &&
-											pI->op != SP_OP &&
-											!(diff_exec_units && previous_issued_inst_exec_type == exec_unit_type_t::INT))
-										execute_on_INT = true;
-									else if (sp_pipe_avail &&
-											(m_shader->m_config->gpgpu_num_int_units == 0 ||
-											(m_shader->m_config->gpgpu_num_int_units > 0 && pI->op == SP_OP)) &&
-											!(diff_exec_units && previous_issued_inst_exec_type == exec_unit_type_t::SP) )
-										execute_on_SP = true;
-
-
-									if(execute_on_INT || execute_on_SP) {
-										//Jin: special for CDP api
-										if(pI->m_is_cdp && !warp(warp_id).m_cdp_dummy) {
-											assert(warp(warp_id).m_cdp_latency == 0);
-
-											if(pI->m_is_cdp == 1)
-												warp(warp_id).m_cdp_latency = m_shader->m_config->gpgpu_ctx->func_sim->cdp_latency[pI->m_is_cdp - 1];
-											else //cudaLaunchDeviceV2 and cudaGetParameterBufferV2
-												warp(warp_id).m_cdp_latency = m_shader->m_config->gpgpu_ctx->func_sim->cdp_latency[pI->m_is_cdp - 1]
-													+ m_shader->m_config->gpgpu_ctx->func_sim->cdp_latency[pI->m_is_cdp] * active_mask.count();
-											warp(warp_id).m_cdp_dummy = true;
-											break;
-										}
-										else if(pI->m_is_cdp && warp(warp_id).m_cdp_dummy) {
-											assert(warp(warp_id).m_cdp_latency == 0);
-											warp(warp_id).m_cdp_dummy = false;
-										}
-									}
-
-									if(execute_on_SP) {
-										m_shader->issue_warp(*m_sp_out,pI,active_mask,warp_id,m_id);
-										issued++;
-										issued_inst=true;
-										warp_inst_issued = true;
-										previous_issued_inst_exec_type = exec_unit_type_t::SP;
-									} else if (execute_on_INT) {
-										m_shader->issue_warp(*m_int_out,pI,active_mask,warp_id,m_id);
-										issued++;
-										issued_inst=true;
-										warp_inst_issued = true;
-										previous_issued_inst_exec_type = exec_unit_type_t::INT;
-                                   }
-                            } else if ( (m_shader->m_config->gpgpu_num_dp_units > 0) && (pI->op == DP_OP) && !(diff_exec_units && previous_issued_inst_exec_type == exec_unit_type_t::DP)) {
-                                if( dp_pipe_avail ) {
-                                    m_shader->issue_warp(*m_dp_out,pI,active_mask,warp_id,m_id);
-                                    issued++;
-                                    issued_inst=true;
-                                    warp_inst_issued = true;
-                                    previous_issued_inst_exec_type = exec_unit_type_t::DP;
-                                }
-                            }  //If the DP units = 0 (like in Fermi archi), then execute DP inst on SFU unit
-                            else if ( ((m_shader->m_config->gpgpu_num_dp_units == 0 && pI->op == DP_OP) || (pI->op == SFU_OP) || (pI->op == ALU_SFU_OP)) && !(diff_exec_units && previous_issued_inst_exec_type == exec_unit_type_t::SFU)) {
-                                if( sfu_pipe_avail ) {
-                                    m_shader->issue_warp(*m_sfu_out,pI,active_mask,warp_id,m_id);
-                                    issued++;
-                                    issued_inst=true;
-                                    warp_inst_issued = true;
-                                    previous_issued_inst_exec_type = exec_unit_type_t::SFU;
-                                }
-                            }                         
-                             else if ( (pI->op == TENSOR_CORE_OP) && !(diff_exec_units && previous_issued_inst_exec_type == exec_unit_type_t::SP) ) {
-                                if( tensor_core_pipe_avail ) {
-                                    m_shader->issue_warp(*m_tensor_core_out,pI,active_mask,warp_id,m_id);
-                                    issued++;
-                                    issued_inst=true;
-                                    warp_inst_issued = true;
-                                    previous_issued_inst_exec_type = exec_unit_type_t::TENSOR;
-                                }
-			    }
-                         }//end of else
-                   } else {
-
-                        SCHED_DPRINTF( "Warp (warp_id %u, dynamic_warp_id %u) fails scoreboard\n",
-                                       (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id() );
-                   }
-                }
-            } else if( valid ) {
-               // this case can happen after a return instruction in diverged warp
-               SCHED_DPRINTF( "Warp (warp_id %u, dynamic_warp_id %u) return from diverged warp flush\n",
-                              (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id() );
-               warp(warp_id).set_next_pc(pc);
-               warp(warp_id).ibuffer_flush();
-            }
-            if(warp_inst_issued) {
-                SCHED_DPRINTF( "Warp (warp_id %u, dynamic_warp_id %u) issued %u instructions\n",
-                               (*iter)->get_warp_id(),
-                               (*iter)->get_dynamic_warp_id(),
-                               issued );
-                do_on_warp_issued( warp_id, issued, iter );
-            }
-            checked++;
-        }
-        if ( issued ) {
-            // This might be a bit inefficient, but we need to maintain
-            // two ordered list for proper scheduler execution.
-            // We could remove the need for this loop by associating a
-            // supervised_is index with each entry in the m_next_cycle_prioritized_warps
-            // vector. For now, just run through until you find the right warp_id
-            for ( std::vector< shd_warp_t* >::const_iterator supervised_iter = m_supervised_warps.begin();
-                  supervised_iter != m_supervised_warps.end();
-                  ++supervised_iter ) {
-                if ( *iter == *supervised_iter ) {
-                    m_last_supervised_issued = supervised_iter;
-                }
-            }
-
-            if(issued == 1)
-            	m_stats->single_issue_nums[m_id]++;
-            else if(issued > 1)
-            	m_stats->dual_issue_nums[m_id]++;
-            else
-            	abort();   //issued should be > 0
-
-            break;
-        } 
-    }
-
-    // issue stall statistics:
-    if( !valid_inst ) 
-        m_stats->shader_cycle_distro[0]++; // idle or control hazard
-    else if( !ready_inst ) 
-        m_stats->shader_cycle_distro[1]++; // waiting for RAW hazards (possibly due to memory) 
-    else if( !issued_inst ) 
-        m_stats->shader_cycle_distro[2]++; // pipeline stalled
-}
-
-void scheduler_unit::do_on_warp_issued( unsigned warp_id,
-                                        unsigned num_issued,
-                                        const std::vector< shd_warp_t* >::const_iterator& prioritized_iter )
-{
-    m_stats->event_warp_issued( m_shader->get_sid(),
-                                warp_id,
-                                num_issued,
-                                warp(warp_id).get_dynamic_warp_id() );
-    warp(warp_id).ibuffer_step();
-}
-
-bool scheduler_unit::sort_warps_by_oldest_dynamic_id(shd_warp_t* lhs, shd_warp_t* rhs)
-{
-    if (rhs && lhs) {
-        if ( lhs->done_exit() || lhs->waiting() ) {
-            return false;
-        } else if ( rhs->done_exit() || rhs->waiting() ) {
-            return true;
-        } else {
-            return lhs->get_dynamic_warp_id() < rhs->get_dynamic_warp_id();
-        }
-    } else {
-        return lhs < rhs;
-    }
-}
-
-void lrr_scheduler::order_warps()
-{
-    order_lrr( m_next_cycle_prioritized_warps,
-               m_supervised_warps,
-               m_last_supervised_issued,
-               m_supervised_warps.size() );
-}
-
-void gto_scheduler::order_warps()
-{
-    order_by_priority( m_next_cycle_prioritized_warps,
-                       m_supervised_warps,
-                       m_last_supervised_issued,
-                       m_supervised_warps.size(),
-                       ORDERING_GREEDY_THEN_PRIORITY_FUNC,
-                       scheduler_unit::sort_warps_by_oldest_dynamic_id );
-}
-
-void oldest_scheduler::order_warps()
-{
-    order_by_priority( m_next_cycle_prioritized_warps,
-                       m_supervised_warps,
-                       m_last_supervised_issued,
-                       m_supervised_warps.size(),
-		       ORDERED_PRIORITY_FUNC_ONLY,
-                       scheduler_unit::sort_warps_by_oldest_dynamic_id );
-}
-
-void
-two_level_active_scheduler::do_on_warp_issued( unsigned warp_id,
-                                               unsigned num_issued,
-                                               const std::vector< shd_warp_t* >::const_iterator& prioritized_iter )
-{
-    scheduler_unit::do_on_warp_issued( warp_id, num_issued, prioritized_iter );
-    if ( SCHEDULER_PRIORITIZATION_LRR == m_inner_level_prioritization ) {
-        std::vector< shd_warp_t* > new_active; 
-        order_lrr( new_active,
-                   m_next_cycle_prioritized_warps,
-                   prioritized_iter,
-                   m_next_cycle_prioritized_warps.size() );
-        m_next_cycle_prioritized_warps = new_active;
-    } else {
-        fprintf( stderr,
-                 "Unimplemented m_inner_level_prioritization: %d\n",
-                 m_inner_level_prioritization );
-        abort();
-    }
-}
-
-void two_level_active_scheduler::order_warps()
-{
-    //Move waiting warps to m_pending_warps
-    unsigned num_demoted = 0;
-    for (   std::vector< shd_warp_t* >::iterator iter = m_next_cycle_prioritized_warps.begin();
-            iter != m_next_cycle_prioritized_warps.end(); ) {
-        bool waiting = (*iter)->waiting();
-        for (int i=0; i<MAX_INPUT_VALUES; i++){
-            const warp_inst_t* inst = (*iter)->ibuffer_next_inst();
-            //Is the instruction waiting on a long operation?
-            if ( inst && inst->in[i] > 0 && this->m_scoreboard->islongop((*iter)->get_warp_id(), inst->in[i])){
-                waiting = true;
-            }
-        }
-
-        if( waiting ) {
-            m_pending_warps.push_back(*iter);
-            iter = m_next_cycle_prioritized_warps.erase(iter);
-            SCHED_DPRINTF( "DEMOTED warp_id=%d, dynamic_warp_id=%d\n",
-                           (*iter)->get_warp_id(),
-                           (*iter)->get_dynamic_warp_id() );
-            ++num_demoted;
-        } else {
-            ++iter;
-        }
-    }
-
-    //If there is space in m_next_cycle_prioritized_warps, promote the next m_pending_warps
-    unsigned num_promoted = 0;
-    if ( SCHEDULER_PRIORITIZATION_SRR == m_outer_level_prioritization ) {
-        while ( m_next_cycle_prioritized_warps.size() < m_max_active_warps ) {
-            m_next_cycle_prioritized_warps.push_back(m_pending_warps.front());
-            m_pending_warps.pop_front();
-            SCHED_DPRINTF( "PROMOTED warp_id=%d, dynamic_warp_id=%d\n",
-                           (m_next_cycle_prioritized_warps.back())->get_warp_id(),
-                           (m_next_cycle_prioritized_warps.back())->get_dynamic_warp_id() );
-            ++num_promoted;
-        }
-    } else {
-        fprintf( stderr,
-                 "Unimplemented m_outer_level_prioritization: %d\n",
-                 m_outer_level_prioritization );
-        abort();
-    }
-    assert( num_promoted == num_demoted );
-}
-
-swl_scheduler::swl_scheduler ( shader_core_stats* stats, shader_core_ctx* shader,
-                               Scoreboard* scoreboard, simt_stack** simt,
-                               std::vector<shd_warp_t>* warp,
-                               register_set* sp_out,
-							   register_set* dp_out,
-                               register_set* sfu_out,
-							   register_set* int_out,
-                               register_set* tensor_core_out,
-                               register_set* mem_out,
-                               int id,
-                               char* config_string )
-    : scheduler_unit ( stats, shader, scoreboard, simt, warp, sp_out, dp_out, sfu_out, int_out, tensor_core_out, mem_out, id )
-{
-    unsigned m_prioritization_readin;
-    int ret = sscanf( config_string,
-                      "warp_limiting:%d:%d",
-                      &m_prioritization_readin,
-                      &m_num_warps_to_limit
-                     );
-    assert( 2 == ret );
-    m_prioritization = (scheduler_prioritization_type)m_prioritization_readin;
-    // Currently only GTO is implemented
-    assert( m_prioritization == SCHEDULER_PRIORITIZATION_GTO );
-    assert( m_num_warps_to_limit <= shader->get_config()->max_warps_per_shader );
-}
-
-void swl_scheduler::order_warps()
-{
-    if ( SCHEDULER_PRIORITIZATION_GTO == m_prioritization ) {
-        order_by_priority( m_next_cycle_prioritized_warps,
-                           m_supervised_warps,
-                           m_last_supervised_issued,
-                           MIN( m_num_warps_to_limit, m_supervised_warps.size() ),
-                           ORDERING_GREEDY_THEN_PRIORITY_FUNC,
-                           scheduler_unit::sort_warps_by_oldest_dynamic_id );
-    } else {
-        fprintf(stderr, "swl_scheduler m_prioritization = %d\n", m_prioritization);
-        abort();
-    }
-}
-
-void shader_core_ctx::read_operands()
-{
-}
-
-address_type coalesced_segment(address_type addr, unsigned segment_size_lg2bytes)
-{
-   return  (addr >> segment_size_lg2bytes);
-}
-
-// Returns numbers of addresses in translated_addrs, each addr points to a 4B (32-bit) word
-unsigned shader_core_ctx::translate_local_memaddr( address_type localaddr, unsigned tid, unsigned num_shader, unsigned datasize, new_addr_type* translated_addrs )
-{
-   // During functional execution, each thread sees its own memory space for local memory, but these
-   // need to be mapped to a shared address space for timing simulation.  We do that mapping here.
-
-   address_type thread_base = 0;
-   unsigned max_concurrent_threads=0;
-   if (m_config->gpgpu_local_mem_map) {
-      // Dnew = D*N + T%nTpC + nTpC*C
-      // N = nTpC*nCpS*nS (max concurent threads)
-      // C = nS*K + S (hw cta number per gpu)
-      // K = T/nTpC   (hw cta number per core)
-      // D = data index
-      // T = thread
-      // nTpC = number of threads per CTA
-      // nCpS = number of CTA per shader
-      // 
-      // for a given local memory address threads in a CTA map to contiguous addresses,
-      // then distribute across memory space by CTAs from successive shader cores first, 
-      // then by successive CTA in same shader core
-      thread_base = 4*(kernel_padded_threads_per_cta * (m_sid + num_shader * (tid / kernel_padded_threads_per_cta))
-                       + tid % kernel_padded_threads_per_cta); 
-      max_concurrent_threads = kernel_padded_threads_per_cta * kernel_max_cta_per_shader * num_shader;
-   } else {
-      // legacy mapping that maps the same address in the local memory space of all threads 
-      // to a single contiguous address region 
-      thread_base = 4*(m_config->n_thread_per_shader * m_sid + tid);
-      max_concurrent_threads = num_shader * m_config->n_thread_per_shader;
-   }
-   assert( thread_base < 4/*word size*/*max_concurrent_threads );
-
-   // If requested datasize > 4B, split into multiple 4B accesses
-   // otherwise do one sub-4 byte memory access
-   unsigned num_accesses = 0;
-
-   if(datasize >= 4) {
-      // >4B access, split into 4B chunks
-      assert(datasize%4 == 0);   // Must be a multiple of 4B
-      num_accesses = datasize/4;
-      assert(num_accesses <= MAX_ACCESSES_PER_INSN_PER_THREAD); // max 32B
-      assert(localaddr%4 == 0); // Address must be 4B aligned - required if accessing 4B per request, otherwise access will overflow into next thread's space
-      for(unsigned i=0; i<num_accesses; i++) {
-          address_type local_word = localaddr/4 + i;
-          address_type linear_address = local_word*max_concurrent_threads*4 + thread_base + LOCAL_GENERIC_START;
-          translated_addrs[i] = linear_address;
+    std::sort(temp.begin(), temp.end(), priority_func);
+    typename std::vector<T>::iterator iter = temp.begin();
+    for (unsigned count = 0; count < num_warps_to_add; ++count, ++iter) {
+      if (*iter != greedy_value) {
+        result_list.push_back(*iter);
       }
-   } else {
-      // Sub-4B access, do only one access
-      assert(datasize > 0);
-      num_accesses = 1;
-      address_type local_word = localaddr/4;
-      address_type local_word_offset = localaddr%4;
-      assert( (localaddr+datasize-1)/4  == local_word ); // Make sure access doesn't overflow into next 4B chunk
-      address_type linear_address = local_word*max_concurrent_threads*4 + local_word_offset + thread_base + LOCAL_GENERIC_START;
-      translated_addrs[0] = linear_address;
-   }
-   return num_accesses;
+    }
+  } else if (ORDERED_PRIORITY_FUNC_ONLY == ordering) {
+    std::sort(temp.begin(), temp.end(), priority_func);
+    typename std::vector<T>::iterator iter = temp.begin();
+    for (unsigned count = 0; count < num_warps_to_add; ++count, ++iter) {
+      result_list.push_back(*iter);
+    }
+  } else {
+    fprintf(stderr, "Unknown ordering - %d\n", ordering);
+    abort();
+  }
+}
+
+void scheduler_unit::cycle() {
+  SCHED_DPRINTF("scheduler_unit::cycle()\n");
+  bool valid_inst =
+      false;  // there was one warp with a valid instruction to issue (didn't
+              // require flush due to control hazard)
+  bool ready_inst = false;   // of the valid instructions, there was one not
+                             // waiting for pending register writes
+  bool issued_inst = false;  // of these we issued one
+
+  order_warps();
+  for (std::vector<shd_warp_t *>::const_iterator iter =
+           m_next_cycle_prioritized_warps.begin();
+       iter != m_next_cycle_prioritized_warps.end(); iter++) {
+    // Don't consider warps that are not yet valid
+    if ((*iter) == NULL || (*iter)->done_exit()) {
+      continue;
+    }
+    SCHED_DPRINTF("Testing (warp_id %u, dynamic_warp_id %u)\n",
+                  (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id());
+    unsigned warp_id = (*iter)->get_warp_id();
+    unsigned checked = 0;
+    unsigned issued = 0;
+    exec_unit_type_t previous_issued_inst_exec_type = exec_unit_type_t::NONE;
+    unsigned max_issue = m_shader->m_config->gpgpu_max_insn_issue_per_warp;
+    bool diff_exec_units =
+        m_shader->m_config
+            ->gpgpu_dual_issue_diff_exec_units;  // In tis mode, we only allow
+                                                 // dual issue to diff execution
+                                                 // units (as in Maxwell and
+                                                 // Pascal)
+
+    while (!warp(warp_id).waiting() && !warp(warp_id).ibuffer_empty() &&
+           (checked < max_issue) && (checked <= issued) &&
+           (issued < max_issue)) {
+      const warp_inst_t *pI = warp(warp_id).ibuffer_next_inst();
+      // Jin: handle cdp latency;
+      if (pI && pI->m_is_cdp && warp(warp_id).m_cdp_latency > 0) {
+        assert(warp(warp_id).m_cdp_dummy);
+        warp(warp_id).m_cdp_latency--;
+        break;
+      }
+
+      bool valid = warp(warp_id).ibuffer_next_valid();
+      bool warp_inst_issued = false;
+      unsigned pc, rpc;
+      m_simt_stack[warp_id]->get_pdom_stack_top_info(&pc, &rpc);
+      SCHED_DPRINTF(
+          "Warp (warp_id %u, dynamic_warp_id %u) has valid instruction (%s)\n",
+          (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id(),
+          m_shader->m_config->gpgpu_ctx->func_sim->ptx_get_insn_str(pc)
+              .c_str());
+      if (pI) {
+        assert(valid);
+        if (pc != pI->pc) {
+          SCHED_DPRINTF(
+              "Warp (warp_id %u, dynamic_warp_id %u) control hazard "
+              "instruction flush\n",
+              (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id());
+          // control hazard
+          warp(warp_id).set_next_pc(pc);
+          warp(warp_id).ibuffer_flush();
+        } else {
+          valid_inst = true;
+          if (!m_scoreboard->checkCollision(warp_id, pI)) {
+            SCHED_DPRINTF(
+                "Warp (warp_id %u, dynamic_warp_id %u) passes scoreboard\n",
+                (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id());
+            ready_inst = true;
+            const active_mask_t &active_mask =
+                m_simt_stack[warp_id]->get_active_mask();
+            assert(warp(warp_id).inst_in_pipeline());
+
+            if ((pI->op == LOAD_OP) || (pI->op == STORE_OP) ||
+                (pI->op == MEMORY_BARRIER_OP) ||
+                (pI->op == TENSOR_CORE_LOAD_OP) ||
+                (pI->op == TENSOR_CORE_STORE_OP)) {
+              if (m_mem_out->has_free(m_shader->m_config->sub_core_model,
+                                      m_id) &&
+                  (!diff_exec_units ||
+                   previous_issued_inst_exec_type != exec_unit_type_t::MEM)) {
+                m_shader->issue_warp(*m_mem_out, pI, active_mask, warp_id,
+                                     m_id);
+                issued++;
+                issued_inst = true;
+                warp_inst_issued = true;
+                previous_issued_inst_exec_type = exec_unit_type_t::MEM;
+              }
+            } else {
+              bool sp_pipe_avail =
+                  m_sp_out->has_free(m_shader->m_config->sub_core_model, m_id);
+              bool sfu_pipe_avail =
+                  m_sfu_out->has_free(m_shader->m_config->sub_core_model, m_id);
+              bool tensor_core_pipe_avail = m_tensor_core_out->has_free(
+                  m_shader->m_config->sub_core_model, m_id);
+              bool dp_pipe_avail =
+                  m_dp_out->has_free(m_shader->m_config->sub_core_model, m_id);
+              bool int_pipe_avail =
+                  m_int_out->has_free(m_shader->m_config->sub_core_model, m_id);
+
+              // This code need to be refactored
+              if (pI->op != TENSOR_CORE_OP && pI->op != SFU_OP &&
+                  pI->op != DP_OP) {
+                bool execute_on_SP = false;
+                bool execute_on_INT = false;
+
+                // if INT unit pipline exist, then execute ALU and INT
+                // operations on INT unit and SP-FPU on SP unit (like in Volta)
+                // if INT unit pipline does not exist, then execute all ALU, INT
+                // and SP operations on SP unit (as in Fermi, Pascal GPUs)
+                if (m_shader->m_config->gpgpu_num_int_units > 0 &&
+                    int_pipe_avail && pI->op != SP_OP &&
+                    !(diff_exec_units &&
+                      previous_issued_inst_exec_type == exec_unit_type_t::INT))
+                  execute_on_INT = true;
+                else if (sp_pipe_avail &&
+                         (m_shader->m_config->gpgpu_num_int_units == 0 ||
+                          (m_shader->m_config->gpgpu_num_int_units > 0 &&
+                           pI->op == SP_OP)) &&
+                         !(diff_exec_units && previous_issued_inst_exec_type ==
+                                                  exec_unit_type_t::SP))
+                  execute_on_SP = true;
+
+                if (execute_on_INT || execute_on_SP) {
+                  // Jin: special for CDP api
+                  if (pI->m_is_cdp && !warp(warp_id).m_cdp_dummy) {
+                    assert(warp(warp_id).m_cdp_latency == 0);
+
+                    if (pI->m_is_cdp == 1)
+                      warp(warp_id).m_cdp_latency =
+                          m_shader->m_config->gpgpu_ctx->func_sim
+                              ->cdp_latency[pI->m_is_cdp - 1];
+                    else  // cudaLaunchDeviceV2 and cudaGetParameterBufferV2
+                      warp(warp_id).m_cdp_latency =
+                          m_shader->m_config->gpgpu_ctx->func_sim
+                              ->cdp_latency[pI->m_is_cdp - 1] +
+                          m_shader->m_config->gpgpu_ctx->func_sim
+                                  ->cdp_latency[pI->m_is_cdp] *
+                              active_mask.count();
+                    warp(warp_id).m_cdp_dummy = true;
+                    break;
+                  } else if (pI->m_is_cdp && warp(warp_id).m_cdp_dummy) {
+                    assert(warp(warp_id).m_cdp_latency == 0);
+                    warp(warp_id).m_cdp_dummy = false;
+                  }
+                }
+
+                if (execute_on_SP) {
+                  m_shader->issue_warp(*m_sp_out, pI, active_mask, warp_id,
+                                       m_id);
+                  issued++;
+                  issued_inst = true;
+                  warp_inst_issued = true;
+                  previous_issued_inst_exec_type = exec_unit_type_t::SP;
+                } else if (execute_on_INT) {
+                  m_shader->issue_warp(*m_int_out, pI, active_mask, warp_id,
+                                       m_id);
+                  issued++;
+                  issued_inst = true;
+                  warp_inst_issued = true;
+                  previous_issued_inst_exec_type = exec_unit_type_t::INT;
+                }
+              } else if ((m_shader->m_config->gpgpu_num_dp_units > 0) &&
+                         (pI->op == DP_OP) &&
+                         !(diff_exec_units && previous_issued_inst_exec_type ==
+                                                  exec_unit_type_t::DP)) {
+                if (dp_pipe_avail) {
+                  m_shader->issue_warp(*m_dp_out, pI, active_mask, warp_id,
+                                       m_id);
+                  issued++;
+                  issued_inst = true;
+                  warp_inst_issued = true;
+                  previous_issued_inst_exec_type = exec_unit_type_t::DP;
+                }
+              }  // If the DP units = 0 (like in Fermi archi), then execute DP
+                 // inst on SFU unit
+              else if (((m_shader->m_config->gpgpu_num_dp_units == 0 &&
+                         pI->op == DP_OP) ||
+                        (pI->op == SFU_OP) || (pI->op == ALU_SFU_OP)) &&
+                       !(diff_exec_units && previous_issued_inst_exec_type ==
+                                                exec_unit_type_t::SFU)) {
+                if (sfu_pipe_avail) {
+                  m_shader->issue_warp(*m_sfu_out, pI, active_mask, warp_id,
+                                       m_id);
+                  issued++;
+                  issued_inst = true;
+                  warp_inst_issued = true;
+                  previous_issued_inst_exec_type = exec_unit_type_t::SFU;
+                }
+              } else if ((pI->op == TENSOR_CORE_OP) &&
+                         !(diff_exec_units && previous_issued_inst_exec_type ==
+                                                  exec_unit_type_t::SP)) {
+                if (tensor_core_pipe_avail) {
+                  m_shader->issue_warp(*m_tensor_core_out, pI, active_mask,
+                                       warp_id, m_id);
+                  issued++;
+                  issued_inst = true;
+                  warp_inst_issued = true;
+                  previous_issued_inst_exec_type = exec_unit_type_t::TENSOR;
+                }
+              }
+            }  // end of else
+          } else {
+            SCHED_DPRINTF(
+                "Warp (warp_id %u, dynamic_warp_id %u) fails scoreboard\n",
+                (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id());
+          }
+        }
+      } else if (valid) {
+        // this case can happen after a return instruction in diverged warp
+        SCHED_DPRINTF(
+            "Warp (warp_id %u, dynamic_warp_id %u) return from diverged warp "
+            "flush\n",
+            (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id());
+        warp(warp_id).set_next_pc(pc);
+        warp(warp_id).ibuffer_flush();
+      }
+      if (warp_inst_issued) {
+        SCHED_DPRINTF(
+            "Warp (warp_id %u, dynamic_warp_id %u) issued %u instructions\n",
+            (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id(), issued);
+        do_on_warp_issued(warp_id, issued, iter);
+      }
+      checked++;
+    }
+    if (issued) {
+      // This might be a bit inefficient, but we need to maintain
+      // two ordered list for proper scheduler execution.
+      // We could remove the need for this loop by associating a
+      // supervised_is index with each entry in the
+      // m_next_cycle_prioritized_warps vector. For now, just run through until
+      // you find the right warp_id
+      for (std::vector<shd_warp_t *>::const_iterator supervised_iter =
+               m_supervised_warps.begin();
+           supervised_iter != m_supervised_warps.end(); ++supervised_iter) {
+        if (*iter == *supervised_iter) {
+          m_last_supervised_issued = supervised_iter;
+        }
+      }
+
+      if (issued == 1)
+        m_stats->single_issue_nums[m_id]++;
+      else if (issued > 1)
+        m_stats->dual_issue_nums[m_id]++;
+      else
+        abort();  // issued should be > 0
+
+      break;
+    }
+  }
+
+  // issue stall statistics:
+  if (!valid_inst)
+    m_stats->shader_cycle_distro[0]++;  // idle or control hazard
+  else if (!ready_inst)
+    m_stats->shader_cycle_distro[1]++;  // waiting for RAW hazards (possibly due
+                                        // to memory)
+  else if (!issued_inst)
+    m_stats->shader_cycle_distro[2]++;  // pipeline stalled
+}
+
+void scheduler_unit::do_on_warp_issued(
+    unsigned warp_id, unsigned num_issued,
+    const std::vector<shd_warp_t *>::const_iterator &prioritized_iter) {
+  m_stats->event_warp_issued(m_shader->get_sid(), warp_id, num_issued,
+                             warp(warp_id).get_dynamic_warp_id());
+  warp(warp_id).ibuffer_step();
+}
+
+bool scheduler_unit::sort_warps_by_oldest_dynamic_id(shd_warp_t *lhs,
+                                                     shd_warp_t *rhs) {
+  if (rhs && lhs) {
+    if (lhs->done_exit() || lhs->waiting()) {
+      return false;
+    } else if (rhs->done_exit() || rhs->waiting()) {
+      return true;
+    } else {
+      return lhs->get_dynamic_warp_id() < rhs->get_dynamic_warp_id();
+    }
+  } else {
+    return lhs < rhs;
+  }
+}
+
+void lrr_scheduler::order_warps() {
+  order_lrr(m_next_cycle_prioritized_warps, m_supervised_warps,
+            m_last_supervised_issued, m_supervised_warps.size());
+}
+
+void gto_scheduler::order_warps() {
+  order_by_priority(m_next_cycle_prioritized_warps, m_supervised_warps,
+                    m_last_supervised_issued, m_supervised_warps.size(),
+                    ORDERING_GREEDY_THEN_PRIORITY_FUNC,
+                    scheduler_unit::sort_warps_by_oldest_dynamic_id);
+}
+
+void oldest_scheduler::order_warps() {
+  order_by_priority(m_next_cycle_prioritized_warps, m_supervised_warps,
+                    m_last_supervised_issued, m_supervised_warps.size(),
+                    ORDERED_PRIORITY_FUNC_ONLY,
+                    scheduler_unit::sort_warps_by_oldest_dynamic_id);
+}
+
+void two_level_active_scheduler::do_on_warp_issued(
+    unsigned warp_id, unsigned num_issued,
+    const std::vector<shd_warp_t *>::const_iterator &prioritized_iter) {
+  scheduler_unit::do_on_warp_issued(warp_id, num_issued, prioritized_iter);
+  if (SCHEDULER_PRIORITIZATION_LRR == m_inner_level_prioritization) {
+    std::vector<shd_warp_t *> new_active;
+    order_lrr(new_active, m_next_cycle_prioritized_warps, prioritized_iter,
+              m_next_cycle_prioritized_warps.size());
+    m_next_cycle_prioritized_warps = new_active;
+  } else {
+    fprintf(stderr, "Unimplemented m_inner_level_prioritization: %d\n",
+            m_inner_level_prioritization);
+    abort();
+  }
+}
+
+void two_level_active_scheduler::order_warps() {
+  // Move waiting warps to m_pending_warps
+  unsigned num_demoted = 0;
+  for (std::vector<shd_warp_t *>::iterator iter =
+           m_next_cycle_prioritized_warps.begin();
+       iter != m_next_cycle_prioritized_warps.end();) {
+    bool waiting = (*iter)->waiting();
+    for (int i = 0; i < MAX_INPUT_VALUES; i++) {
+      const warp_inst_t *inst = (*iter)->ibuffer_next_inst();
+      // Is the instruction waiting on a long operation?
+      if (inst && inst->in[i] > 0 &&
+          this->m_scoreboard->islongop((*iter)->get_warp_id(), inst->in[i])) {
+        waiting = true;
+      }
+    }
+
+    if (waiting) {
+      m_pending_warps.push_back(*iter);
+      iter = m_next_cycle_prioritized_warps.erase(iter);
+      SCHED_DPRINTF("DEMOTED warp_id=%d, dynamic_warp_id=%d\n",
+                    (*iter)->get_warp_id(), (*iter)->get_dynamic_warp_id());
+      ++num_demoted;
+    } else {
+      ++iter;
+    }
+  }
+
+  // If there is space in m_next_cycle_prioritized_warps, promote the next
+  // m_pending_warps
+  unsigned num_promoted = 0;
+  if (SCHEDULER_PRIORITIZATION_SRR == m_outer_level_prioritization) {
+    while (m_next_cycle_prioritized_warps.size() < m_max_active_warps) {
+      m_next_cycle_prioritized_warps.push_back(m_pending_warps.front());
+      m_pending_warps.pop_front();
+      SCHED_DPRINTF(
+          "PROMOTED warp_id=%d, dynamic_warp_id=%d\n",
+          (m_next_cycle_prioritized_warps.back())->get_warp_id(),
+          (m_next_cycle_prioritized_warps.back())->get_dynamic_warp_id());
+      ++num_promoted;
+    }
+  } else {
+    fprintf(stderr, "Unimplemented m_outer_level_prioritization: %d\n",
+            m_outer_level_prioritization);
+    abort();
+  }
+  assert(num_promoted == num_demoted);
+}
+
+swl_scheduler::swl_scheduler(shader_core_stats *stats, shader_core_ctx *shader,
+                             Scoreboard *scoreboard, simt_stack **simt,
+                             std::vector<shd_warp_t> *warp,
+                             register_set *sp_out, register_set *dp_out,
+                             register_set *sfu_out, register_set *int_out,
+                             register_set *tensor_core_out,
+                             register_set *mem_out, int id, char *config_string)
+    : scheduler_unit(stats, shader, scoreboard, simt, warp, sp_out, dp_out,
+                     sfu_out, int_out, tensor_core_out, mem_out, id) {
+  unsigned m_prioritization_readin;
+  int ret = sscanf(config_string, "warp_limiting:%d:%d",
+                   &m_prioritization_readin, &m_num_warps_to_limit);
+  assert(2 == ret);
+  m_prioritization = (scheduler_prioritization_type)m_prioritization_readin;
+  // Currently only GTO is implemented
+  assert(m_prioritization == SCHEDULER_PRIORITIZATION_GTO);
+  assert(m_num_warps_to_limit <= shader->get_config()->max_warps_per_shader);
+}
+
+void swl_scheduler::order_warps() {
+  if (SCHEDULER_PRIORITIZATION_GTO == m_prioritization) {
+    order_by_priority(m_next_cycle_prioritized_warps, m_supervised_warps,
+                      m_last_supervised_issued,
+                      MIN(m_num_warps_to_limit, m_supervised_warps.size()),
+                      ORDERING_GREEDY_THEN_PRIORITY_FUNC,
+                      scheduler_unit::sort_warps_by_oldest_dynamic_id);
+  } else {
+    fprintf(stderr, "swl_scheduler m_prioritization = %d\n", m_prioritization);
+    abort();
+  }
+}
+
+void shader_core_ctx::read_operands() {}
+
+address_type coalesced_segment(address_type addr,
+                               unsigned segment_size_lg2bytes) {
+  return (addr >> segment_size_lg2bytes);
+}
+
+// Returns numbers of addresses in translated_addrs, each addr points to a 4B
+// (32-bit) word
+unsigned shader_core_ctx::translate_local_memaddr(
+    address_type localaddr, unsigned tid, unsigned num_shader,
+    unsigned datasize, new_addr_type *translated_addrs) {
+  // During functional execution, each thread sees its own memory space for
+  // local memory, but these need to be mapped to a shared address space for
+  // timing simulation.  We do that mapping here.
+
+  address_type thread_base = 0;
+  unsigned max_concurrent_threads = 0;
+  if (m_config->gpgpu_local_mem_map) {
+    // Dnew = D*N + T%nTpC + nTpC*C
+    // N = nTpC*nCpS*nS (max concurent threads)
+    // C = nS*K + S (hw cta number per gpu)
+    // K = T/nTpC   (hw cta number per core)
+    // D = data index
+    // T = thread
+    // nTpC = number of threads per CTA
+    // nCpS = number of CTA per shader
+    //
+    // for a given local memory address threads in a CTA map to contiguous
+    // addresses, then distribute across memory space by CTAs from successive
+    // shader cores first, then by successive CTA in same shader core
+    thread_base =
+        4 * (kernel_padded_threads_per_cta *
+                 (m_sid + num_shader * (tid / kernel_padded_threads_per_cta)) +
+             tid % kernel_padded_threads_per_cta);
+    max_concurrent_threads =
+        kernel_padded_threads_per_cta * kernel_max_cta_per_shader * num_shader;
+  } else {
+    // legacy mapping that maps the same address in the local memory space of
+    // all threads to a single contiguous address region
+    thread_base = 4 * (m_config->n_thread_per_shader * m_sid + tid);
+    max_concurrent_threads = num_shader * m_config->n_thread_per_shader;
+  }
+  assert(thread_base < 4 /*word size*/ * max_concurrent_threads);
+
+  // If requested datasize > 4B, split into multiple 4B accesses
+  // otherwise do one sub-4 byte memory access
+  unsigned num_accesses = 0;
+
+  if (datasize >= 4) {
+    // >4B access, split into 4B chunks
+    assert(datasize % 4 == 0);  // Must be a multiple of 4B
+    num_accesses = datasize / 4;
+    assert(num_accesses <= MAX_ACCESSES_PER_INSN_PER_THREAD);  // max 32B
+    assert(
+        localaddr % 4 ==
+        0);  // Address must be 4B aligned - required if accessing 4B per
+             // request, otherwise access will overflow into next thread's space
+    for (unsigned i = 0; i < num_accesses; i++) {
+      address_type local_word = localaddr / 4 + i;
+      address_type linear_address = local_word * max_concurrent_threads * 4 +
+                                    thread_base + LOCAL_GENERIC_START;
+      translated_addrs[i] = linear_address;
+    }
+  } else {
+    // Sub-4B access, do only one access
+    assert(datasize > 0);
+    num_accesses = 1;
+    address_type local_word = localaddr / 4;
+    address_type local_word_offset = localaddr % 4;
+    assert((localaddr + datasize - 1) / 4 ==
+           local_word);  // Make sure access doesn't overflow into next 4B chunk
+    address_type linear_address = local_word * max_concurrent_threads * 4 +
+                                  local_word_offset + thread_base +
+                                  LOCAL_GENERIC_START;
+    translated_addrs[0] = linear_address;
+  }
+  return num_accesses;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
-int shader_core_ctx::test_res_bus(int latency){
-	for(unsigned i=0; i<num_result_bus; i++){
-		if(!m_result_bus[i]->test(latency)){return i;}
-	}
-	return -1;
-}
-
-void shader_core_ctx::execute()
-{
-	for(unsigned i=0; i<num_result_bus; i++){
-		*(m_result_bus[i]) >>=1;
-	}
-    for( unsigned n=0; n < m_num_function_units; n++ ) {
-        unsigned multiplier = m_fu[n]->clock_multiplier();
-        for( unsigned c=0; c < multiplier; c++ ) 
-            m_fu[n]->cycle();
-        m_fu[n]->active_lanes_in_pipeline();
-        enum pipeline_stage_name_t issue_port = m_issue_port[n];
-        register_set& issue_inst = m_pipeline_reg[ issue_port ];
-        warp_inst_t** ready_reg = issue_inst.get_ready();
-        if( issue_inst.has_ready() && m_fu[n]->can_issue( **ready_reg ) ) {
-            bool schedule_wb_now = !m_fu[n]->stallable();
-            int resbus = -1;
-            if( schedule_wb_now && (resbus=test_res_bus( (*ready_reg)->latency ))!=-1 ) {
-                assert( (*ready_reg)->latency < MAX_ALU_LATENCY );
-                m_result_bus[resbus]->set( (*ready_reg)->latency );
-                m_fu[n]->issue( issue_inst );
-            } else if( !schedule_wb_now ) {
-                m_fu[n]->issue( issue_inst );
-            } else {
-                // stall issue (cannot reserve result bus)
-            }
-        }
+int shader_core_ctx::test_res_bus(int latency) {
+  for (unsigned i = 0; i < num_result_bus; i++) {
+    if (!m_result_bus[i]->test(latency)) {
+      return i;
     }
+  }
+  return -1;
 }
 
-void ldst_unit::print_cache_stats( FILE *fp, unsigned& dl1_accesses, unsigned& dl1_misses ) {
-   if( m_L1D ) {
-       m_L1D->print( fp, dl1_accesses, dl1_misses );
-   }
+void shader_core_ctx::execute() {
+  for (unsigned i = 0; i < num_result_bus; i++) {
+    *(m_result_bus[i]) >>= 1;
+  }
+  for (unsigned n = 0; n < m_num_function_units; n++) {
+    unsigned multiplier = m_fu[n]->clock_multiplier();
+    for (unsigned c = 0; c < multiplier; c++) m_fu[n]->cycle();
+    m_fu[n]->active_lanes_in_pipeline();
+    enum pipeline_stage_name_t issue_port = m_issue_port[n];
+    register_set &issue_inst = m_pipeline_reg[issue_port];
+    warp_inst_t **ready_reg = issue_inst.get_ready();
+    if (issue_inst.has_ready() && m_fu[n]->can_issue(**ready_reg)) {
+      bool schedule_wb_now = !m_fu[n]->stallable();
+      int resbus = -1;
+      if (schedule_wb_now &&
+          (resbus = test_res_bus((*ready_reg)->latency)) != -1) {
+        assert((*ready_reg)->latency < MAX_ALU_LATENCY);
+        m_result_bus[resbus]->set((*ready_reg)->latency);
+        m_fu[n]->issue(issue_inst);
+      } else if (!schedule_wb_now) {
+        m_fu[n]->issue(issue_inst);
+      } else {
+        // stall issue (cannot reserve result bus)
+      }
+    }
+  }
+}
+
+void ldst_unit::print_cache_stats(FILE *fp, unsigned &dl1_accesses,
+                                  unsigned &dl1_misses) {
+  if (m_L1D) {
+    m_L1D->print(fp, dl1_accesses, dl1_misses);
+  }
 }
 
 void ldst_unit::get_cache_stats(cache_stats &cs) {
-    // Adds stats to 'cs' from each cache
-    if(m_L1D)
-        cs += m_L1D->get_stats();
-    if(m_L1C)
-        cs += m_L1C->get_stats();
-    if(m_L1T)
-        cs += m_L1T->get_stats();
-
+  // Adds stats to 'cs' from each cache
+  if (m_L1D) cs += m_L1D->get_stats();
+  if (m_L1C) cs += m_L1C->get_stats();
+  if (m_L1T) cs += m_L1T->get_stats();
 }
 
-void ldst_unit::get_L1D_sub_stats(struct cache_sub_stats &css) const{
-    if(m_L1D)
-        m_L1D->get_sub_stats(css);
+void ldst_unit::get_L1D_sub_stats(struct cache_sub_stats &css) const {
+  if (m_L1D) m_L1D->get_sub_stats(css);
 }
-void ldst_unit::get_L1C_sub_stats(struct cache_sub_stats &css) const{
-    if(m_L1C)
-        m_L1C->get_sub_stats(css);
+void ldst_unit::get_L1C_sub_stats(struct cache_sub_stats &css) const {
+  if (m_L1C) m_L1C->get_sub_stats(css);
 }
-void ldst_unit::get_L1T_sub_stats(struct cache_sub_stats &css) const{
-    if(m_L1T)
-        m_L1T->get_sub_stats(css);
+void ldst_unit::get_L1T_sub_stats(struct cache_sub_stats &css) const {
+  if (m_L1T) m_L1T->get_sub_stats(css);
 }
 
-void shader_core_ctx::warp_inst_complete(const warp_inst_t &inst)
-{
-
-  #if 0
+void shader_core_ctx::warp_inst_complete(const warp_inst_t &inst) {
+#if 0
       printf("[warp_inst_complete] uid=%u core=%u warp=%u pc=%#x @ time=%llu issued@%llu\n",
              inst.get_uid(), m_sid, inst.warp_id(), inst.pc, gpu_tot_sim_cycle + gpu_sim_cycle, inst.get_issue_cycle());
-  #endif
+#endif
 
-  if(inst.op_pipe==SP__OP)
-	  m_stats->m_num_sp_committed[m_sid]++;
-  else if(inst.op_pipe==SFU__OP)
-	  m_stats->m_num_sfu_committed[m_sid]++;
-  else if(inst.op_pipe==MEM__OP)
-	  m_stats->m_num_mem_committed[m_sid]++;
+  if (inst.op_pipe == SP__OP)
+    m_stats->m_num_sp_committed[m_sid]++;
+  else if (inst.op_pipe == SFU__OP)
+    m_stats->m_num_sfu_committed[m_sid]++;
+  else if (inst.op_pipe == MEM__OP)
+    m_stats->m_num_mem_committed[m_sid]++;
 
-  if(m_config->gpgpu_clock_gated_lanes==false)
-	  m_stats->m_num_sim_insn[m_sid] += m_config->warp_size;
+  if (m_config->gpgpu_clock_gated_lanes == false)
+    m_stats->m_num_sim_insn[m_sid] += m_config->warp_size;
   else
-	  m_stats->m_num_sim_insn[m_sid] += inst.active_count();
+    m_stats->m_num_sim_insn[m_sid] += inst.active_count();
 
   m_stats->m_num_sim_winsn[m_sid]++;
   m_gpu->gpu_sim_insn += inst.active_count();
   inst.completed(m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle);
 }
 
-void shader_core_ctx::writeback()
-{
+void shader_core_ctx::writeback() {
+  unsigned max_committed_thread_instructions =
+      m_config->warp_size *
+      (m_config->pipe_widths[EX_WB]);  // from the functional units
+  m_stats->m_pipeline_duty_cycle[m_sid] =
+      ((float)(m_stats->m_num_sim_insn[m_sid] -
+               m_stats->m_last_num_sim_insn[m_sid])) /
+      max_committed_thread_instructions;
 
-	unsigned max_committed_thread_instructions=m_config->warp_size * (m_config->pipe_widths[EX_WB]); //from the functional units
-	m_stats->m_pipeline_duty_cycle[m_sid]=((float)(m_stats->m_num_sim_insn[m_sid]-m_stats->m_last_num_sim_insn[m_sid]))/max_committed_thread_instructions;
+  m_stats->m_last_num_sim_insn[m_sid] = m_stats->m_num_sim_insn[m_sid];
+  m_stats->m_last_num_sim_winsn[m_sid] = m_stats->m_num_sim_winsn[m_sid];
 
-    m_stats->m_last_num_sim_insn[m_sid]=m_stats->m_num_sim_insn[m_sid];
-    m_stats->m_last_num_sim_winsn[m_sid]=m_stats->m_num_sim_winsn[m_sid];
+  warp_inst_t **preg = m_pipeline_reg[EX_WB].get_ready();
+  warp_inst_t *pipe_reg = (preg == NULL) ? NULL : *preg;
+  while (preg and !pipe_reg->empty()) {
+    /*
+     * Right now, the writeback stage drains all waiting instructions
+     * assuming there are enough ports in the register file or the
+     * conflicts are resolved at issue.
+     */
+    /*
+     * The operand collector writeback can generally generate a stall
+     * However, here, the pipelines should be un-stallable. This is
+     * guaranteed because this is the first time the writeback function
+     * is called after the operand collector's step function, which
+     * resets the allocations. There is one case which could result in
+     * the writeback function returning false (stall), which is when
+     * an instruction tries to modify two registers (GPR and predicate)
+     * To handle this case, we ignore the return value (thus allowing
+     * no stalling).
+     */
 
-    warp_inst_t** preg = m_pipeline_reg[EX_WB].get_ready();
-    warp_inst_t* pipe_reg = (preg==NULL)? NULL:*preg;
-    while( preg and !pipe_reg->empty()) {
-    	/*
-    	 * Right now, the writeback stage drains all waiting instructions
-    	 * assuming there are enough ports in the register file or the
-    	 * conflicts are resolved at issue.
-    	 */
-    	/*
-    	 * The operand collector writeback can generally generate a stall
-    	 * However, here, the pipelines should be un-stallable. This is
-    	 * guaranteed because this is the first time the writeback function
-    	 * is called after the operand collector's step function, which
-    	 * resets the allocations. There is one case which could result in
-    	 * the writeback function returning false (stall), which is when
-    	 * an instruction tries to modify two registers (GPR and predicate)
-    	 * To handle this case, we ignore the return value (thus allowing
-    	 * no stalling).
-    	 */
-
-        m_operand_collector.writeback(*pipe_reg);
-        unsigned warp_id = pipe_reg->warp_id();
-        m_scoreboard->releaseRegisters( pipe_reg );
-        m_warp[warp_id].dec_inst_in_pipeline();
-        warp_inst_complete(*pipe_reg);
-        m_gpu->gpu_sim_insn_last_update_sid = m_sid;
-        m_gpu->gpu_sim_insn_last_update = m_gpu->gpu_sim_cycle;
-        m_last_inst_gpu_sim_cycle = m_gpu->gpu_sim_cycle;
-        m_last_inst_gpu_tot_sim_cycle = m_gpu->gpu_tot_sim_cycle;
-        pipe_reg->clear();
-        preg = m_pipeline_reg[EX_WB].get_ready();
-        pipe_reg = (preg==NULL)? NULL:*preg;
-    }
+    m_operand_collector.writeback(*pipe_reg);
+    unsigned warp_id = pipe_reg->warp_id();
+    m_scoreboard->releaseRegisters(pipe_reg);
+    m_warp[warp_id].dec_inst_in_pipeline();
+    warp_inst_complete(*pipe_reg);
+    m_gpu->gpu_sim_insn_last_update_sid = m_sid;
+    m_gpu->gpu_sim_insn_last_update = m_gpu->gpu_sim_cycle;
+    m_last_inst_gpu_sim_cycle = m_gpu->gpu_sim_cycle;
+    m_last_inst_gpu_tot_sim_cycle = m_gpu->gpu_tot_sim_cycle;
+    pipe_reg->clear();
+    preg = m_pipeline_reg[EX_WB].get_ready();
+    pipe_reg = (preg == NULL) ? NULL : *preg;
+  }
 }
 
-bool ldst_unit::shared_cycle( warp_inst_t &inst, mem_stage_stall_type &rc_fail, mem_stage_access_type &fail_type)
-{
-   if( inst.space.get_type() != shared_space )
-       return true;
+bool ldst_unit::shared_cycle(warp_inst_t &inst, mem_stage_stall_type &rc_fail,
+                             mem_stage_access_type &fail_type) {
+  if (inst.space.get_type() != shared_space) return true;
 
-   if(inst.has_dispatch_delay()){
-	   m_stats->gpgpu_n_shmem_bank_access[m_sid]++;
-   }
+  if (inst.has_dispatch_delay()) {
+    m_stats->gpgpu_n_shmem_bank_access[m_sid]++;
+  }
 
-   bool stall = inst.dispatch_delay();
-   if( stall ) {
-       fail_type = S_MEM;
-       rc_fail = BK_CONF;
-   } else 
-       rc_fail = NO_RC_FAIL;
-   return !stall; 
+  bool stall = inst.dispatch_delay();
+  if (stall) {
+    fail_type = S_MEM;
+    rc_fail = BK_CONF;
+  } else
+    rc_fail = NO_RC_FAIL;
+  return !stall;
 }
 
-mem_stage_stall_type
-ldst_unit::process_cache_access( cache_t* cache,
-                                 new_addr_type address,
-                                 warp_inst_t &inst,
-                                 std::list<cache_event>& events,
-                                 mem_fetch *mf,
-                                 enum cache_request_status status )
-{
-    mem_stage_stall_type result = NO_RC_FAIL;
-    bool write_sent = was_write_sent(events);
-    bool read_sent = was_read_sent(events);
-    if( write_sent ) {
-    	unsigned inc_ack = (m_config->m_L1D_config.get_mshr_type() == SECTOR_ASSOC)?
-    			(mf->get_data_size()/SECTOR_SIZE) : 1;
+mem_stage_stall_type ldst_unit::process_cache_access(
+    cache_t *cache, new_addr_type address, warp_inst_t &inst,
+    std::list<cache_event> &events, mem_fetch *mf,
+    enum cache_request_status status) {
+  mem_stage_stall_type result = NO_RC_FAIL;
+  bool write_sent = was_write_sent(events);
+  bool read_sent = was_read_sent(events);
+  if (write_sent) {
+    unsigned inc_ack = (m_config->m_L1D_config.get_mshr_type() == SECTOR_ASSOC)
+                           ? (mf->get_data_size() / SECTOR_SIZE)
+                           : 1;
 
-		for(unsigned i=0; i< inc_ack; ++i)
-			m_core->inc_store_req( inst.warp_id() );
-
+    for (unsigned i = 0; i < inc_ack; ++i)
+      m_core->inc_store_req(inst.warp_id());
+  }
+  if (status == HIT) {
+    assert(!read_sent);
+    inst.accessq_pop_back();
+    if (inst.is_load()) {
+      for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++)
+        if (inst.out[r] > 0) m_pending_writes[inst.warp_id()][inst.out[r]]--;
     }
-    if ( status == HIT ) {
-        assert( !read_sent );
-        inst.accessq_pop_back();
-        if ( inst.is_load() ) {
-            for ( unsigned r=0; r < MAX_OUTPUT_VALUES; r++)
-                if (inst.out[r] > 0)
-                    m_pending_writes[inst.warp_id()][inst.out[r]]--; 
+    if (!write_sent) delete mf;
+  } else if (status == RESERVATION_FAIL) {
+    result = BK_CONF;
+    assert(!read_sent);
+    assert(!write_sent);
+    delete mf;
+  } else {
+    assert(status == MISS || status == HIT_RESERVED);
+    // inst.clear_active( access.get_warp_mask() ); // threads in mf writeback
+    // when mf returns
+    inst.accessq_pop_back();
+  }
+  if (!inst.accessq_empty() && result == NO_RC_FAIL) result = COAL_STALL;
+  return result;
+}
+
+mem_stage_stall_type ldst_unit::process_memory_access_queue(cache_t *cache,
+                                                            warp_inst_t &inst) {
+  mem_stage_stall_type result = NO_RC_FAIL;
+  if (inst.accessq_empty()) return result;
+
+  if (!cache->data_port_free()) return DATA_PORT_STALL;
+
+  // const mem_access_t &access = inst.accessq_back();
+  mem_fetch *mf = m_mf_allocator->alloc(
+      inst, inst.accessq_back(),
+      m_core->get_gpu()->gpu_sim_cycle + m_core->get_gpu()->gpu_tot_sim_cycle);
+  std::list<cache_event> events;
+  enum cache_request_status status = cache->access(
+      mf->get_addr(), mf,
+      m_core->get_gpu()->gpu_sim_cycle + m_core->get_gpu()->gpu_tot_sim_cycle,
+      events);
+  return process_cache_access(cache, mf->get_addr(), inst, events, mf, status);
+}
+
+mem_stage_stall_type ldst_unit::process_memory_access_queue_l1cache(
+    l1_cache *cache, warp_inst_t &inst) {
+  mem_stage_stall_type result = NO_RC_FAIL;
+  if (inst.accessq_empty()) return result;
+
+  if (m_config->m_L1D_config.l1_latency > 0) {
+    for (int j = 0; j < m_config->m_L1D_config.l1_banks;
+         j++) {  // We can handle at max l1_banks reqs per cycle
+
+      if (inst.accessq_empty()) return result;
+
+      mem_fetch *mf =
+          m_mf_allocator->alloc(inst, inst.accessq_back(),
+                                m_core->get_gpu()->gpu_sim_cycle +
+                                    m_core->get_gpu()->gpu_tot_sim_cycle);
+      unsigned bank_id = m_config->m_L1D_config.set_bank(mf->get_addr());
+      assert(bank_id < m_config->m_L1D_config.l1_banks);
+
+      if ((l1_latency_queue[bank_id][m_config->m_L1D_config.l1_latency - 1]) ==
+          NULL) {
+        l1_latency_queue[bank_id][m_config->m_L1D_config.l1_latency - 1] = mf;
+
+        if (mf->get_inst().is_store()) {
+          unsigned inc_ack =
+              (m_config->m_L1D_config.get_mshr_type() == SECTOR_ASSOC)
+                  ? (mf->get_data_size() / SECTOR_SIZE)
+                  : 1;
+
+          for (unsigned i = 0; i < inc_ack; ++i)
+            m_core->inc_store_req(inst.warp_id());
         }
-        if( !write_sent ) 
-            delete mf;
-    } else if ( status == RESERVATION_FAIL ) {
+
+        inst.accessq_pop_back();
+      } else {
         result = BK_CONF;
-        assert( !read_sent );
-        assert( !write_sent );
         delete mf;
-    } else {
-        assert( status == MISS || status == HIT_RESERVED );
-        //inst.clear_active( access.get_warp_mask() ); // threads in mf writeback when mf returns
-        inst.accessq_pop_back();
-    }
-    if( !inst.accessq_empty() && result == NO_RC_FAIL)
-        result = COAL_STALL;
-    return result;
-}
-
-mem_stage_stall_type ldst_unit::process_memory_access_queue( cache_t *cache, warp_inst_t &inst )
-{
-    mem_stage_stall_type result = NO_RC_FAIL;
-    if( inst.accessq_empty() )
-        return result;
-
-    if( !cache->data_port_free() ) 
-        return DATA_PORT_STALL; 
-
-    //const mem_access_t &access = inst.accessq_back();
-    mem_fetch *mf = m_mf_allocator->alloc(inst,inst.accessq_back(),m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
-    std::list<cache_event> events;
-    enum cache_request_status status = cache->access(mf->get_addr(),mf,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle,events);
-    return process_cache_access( cache, mf->get_addr(), inst, events, mf, status );
-}
-
-mem_stage_stall_type ldst_unit::process_memory_access_queue_l1cache( l1_cache *cache, warp_inst_t &inst )
-{
-    mem_stage_stall_type result = NO_RC_FAIL;
-    if( inst.accessq_empty() )
-        return result;
-
-    if(m_config->m_L1D_config.l1_latency > 0)
-	{
-    	for(int j=0; j<m_config->m_L1D_config.l1_banks; j++) {  //We can handle at max l1_banks reqs per cycle
-
-    		if( inst.accessq_empty() )
-    		        return result;
-
-    	    mem_fetch *mf = m_mf_allocator->alloc(inst,inst.accessq_back(),m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
-    	    unsigned bank_id = m_config->m_L1D_config.set_bank(mf->get_addr());
-    	    assert(bank_id < m_config->m_L1D_config.l1_banks);
-
-			if((l1_latency_queue[bank_id][m_config->m_L1D_config.l1_latency-1]) == NULL)
-			{
-				l1_latency_queue[bank_id][m_config->m_L1D_config.l1_latency-1] = mf;
-
-				if( mf->get_inst().is_store() ) {
-					unsigned inc_ack = (m_config->m_L1D_config.get_mshr_type() == SECTOR_ASSOC)?
-							(mf->get_data_size()/SECTOR_SIZE) : 1;
-
-					for(unsigned i=0; i< inc_ack; ++i)
-						m_core->inc_store_req( inst.warp_id() );
-				}
-
-				inst.accessq_pop_back();
-			}
-			else
-			{
-				result = BK_CONF;
-				delete mf;
-				break;   //do not try again, just break from the loop and try the next cycle
-			}
-    	}
-		if( !inst.accessq_empty() &&  result !=BK_CONF)
-		   result = COAL_STALL;
-
-	     return result;
-	}
-    else
-    {
-	    mem_fetch *mf = m_mf_allocator->alloc(inst,inst.accessq_back(),m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
-		std::list<cache_event> events;
-		enum cache_request_status status = cache->access(mf->get_addr(),mf,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle,events);
-		return process_cache_access( cache, mf->get_addr(), inst, events, mf, status );
-    }
-}
-
-void ldst_unit::L1_latency_queue_cycle()
-{
-	for(int j=0; j<m_config->m_L1D_config.l1_banks; j++) {
-		if((l1_latency_queue[j][0]) != NULL)
-		{
-				mem_fetch* mf_next = l1_latency_queue[j][0];
-				std::list<cache_event> events;
-				enum cache_request_status status = m_L1D->access(mf_next->get_addr(),mf_next,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle,events);
-
-			   bool write_sent = was_write_sent(events);
-			   bool read_sent = was_read_sent(events);
-
-			   if ( status == HIT ) {
-				   assert( !read_sent );
-				   l1_latency_queue[j][0] = NULL;
-				   if ( mf_next->get_inst().is_load() ) {
-					   for ( unsigned r=0; r < MAX_OUTPUT_VALUES; r++)
-						   if (mf_next->get_inst().out[r] > 0)
-						   {
-							   assert(m_pending_writes[mf_next->get_inst().warp_id()][mf_next->get_inst().out[r]]>0);
-							   unsigned still_pending = --m_pending_writes[mf_next->get_inst().warp_id()][mf_next->get_inst().out[r]];
-							   if(!still_pending)
-							   {
-								m_pending_writes[mf_next->get_inst().warp_id()].erase(mf_next->get_inst().out[r]);
-								m_scoreboard->releaseRegister(mf_next->get_inst().warp_id(),mf_next->get_inst().out[r]);
-								m_core->warp_inst_complete(mf_next->get_inst());
-							   }
-						   }
-				   }
-
-				   //For write hit in WB policy
-				   if(mf_next->get_inst().is_store() && !write_sent)
-				   {
-					   unsigned dec_ack = (m_config->m_L1D_config.get_mshr_type() == SECTOR_ASSOC)?
-											(mf_next->get_data_size()/SECTOR_SIZE) : 1;
-
-					   mf_next->set_reply();
-
-					   for(unsigned i=0; i< dec_ack; ++i)
-						  m_core->store_ack(mf_next);
-				   }
-
-				   if( !write_sent )
-					   delete mf_next;
-
-			   } else if ( status == RESERVATION_FAIL ) {
-				   assert( !read_sent );
-				   assert( !write_sent );
-			   } else {
-				   assert( status == MISS || status == HIT_RESERVED );
-				   l1_latency_queue[j][0] = NULL;
-		   }
-		}
-
-		 for( unsigned stage = 0; stage<m_config->m_L1D_config.l1_latency-1; ++stage)
-		  if( l1_latency_queue[j][stage] == NULL) {
-			   l1_latency_queue[j][stage] = l1_latency_queue[j][stage+1] ;
-			   l1_latency_queue[j][stage+1] = NULL;
-		   }
-	}
-
-}
-
-
-
-bool ldst_unit::constant_cycle( warp_inst_t &inst, mem_stage_stall_type &rc_fail, mem_stage_access_type &fail_type)
-{
-   if( inst.empty() || ((inst.space.get_type() != const_space) && (inst.space.get_type() != param_space_kernel)) )
-       return true;
-   if( inst.active_count() == 0 ) 
-       return true;
-   mem_stage_stall_type fail = process_memory_access_queue(m_L1C,inst);
-   if (fail != NO_RC_FAIL){ 
-      rc_fail = fail; //keep other fails if this didn't fail.
-      fail_type = C_MEM;
-      if (rc_fail == BK_CONF or rc_fail == COAL_STALL) {
-         m_stats->gpgpu_n_cmem_portconflict++; //coal stalls aren't really a bank conflict, but this maintains previous behavior.
+        break;  // do not try again, just break from the loop and try the next
+                // cycle
       }
-   }
-   return inst.accessq_empty(); //done if empty.
-}
-
-bool ldst_unit::texture_cycle( warp_inst_t &inst, mem_stage_stall_type &rc_fail, mem_stage_access_type &fail_type)
-{
-   if( inst.empty() || inst.space.get_type() != tex_space )
-       return true;
-   if( inst.active_count() == 0 ) 
-       return true;
-   mem_stage_stall_type fail = process_memory_access_queue(m_L1T,inst);
-   if (fail != NO_RC_FAIL){ 
-      rc_fail = fail; //keep other fails if this didn't fail.
-      fail_type = T_MEM;
-   }
-   return inst.accessq_empty(); //done if empty.
-}
-
-bool ldst_unit::memory_cycle( warp_inst_t &inst, mem_stage_stall_type &stall_reason, mem_stage_access_type &access_type )
-{
-   if( inst.empty() || 
-       ((inst.space.get_type() != global_space) &&
-        (inst.space.get_type() != local_space) &&
-        (inst.space.get_type() != param_space_local)) ) 
-       return true;
-   if( inst.active_count() == 0 ) 
-       return true;
-   assert( !inst.accessq_empty() );
-   mem_stage_stall_type stall_cond = NO_RC_FAIL;
-   const mem_access_t &access = inst.accessq_back();
-
-   bool bypassL1D = false; 
-   if ( CACHE_GLOBAL == inst.cache_op || (m_L1D == NULL) ) {
-       bypassL1D = true; 
-   } else if (inst.space.is_global()) { // global memory access 
-       // skip L1 cache if the option is enabled
-       if (m_core->get_config()->gmem_skip_L1D && (CACHE_L1 != inst.cache_op))
-           bypassL1D = true; 
-   }
-   if( bypassL1D ) {
-       // bypass L1 cache
-       unsigned control_size = inst.is_store() ? WRITE_PACKET_SIZE : READ_PACKET_SIZE;
-       unsigned size = access.get_size() + control_size;
-       //printf("Interconnect:Addr: %x, size=%d\n",access.get_addr(),size);
-       if( m_icnt->full(size, inst.is_store() || inst.isatomic()) ) {
-           stall_cond = ICNT_RC_FAIL;
-       } else {
-           mem_fetch *mf = m_mf_allocator->alloc(inst,access,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
-           m_icnt->push(mf);
-           inst.accessq_pop_back();
-           //inst.clear_active( access.get_warp_mask() );
-           if( inst.is_load() ) { 
-              for( unsigned r=0; r < MAX_OUTPUT_VALUES; r++) 
-                  if(inst.out[r] > 0) 
-                      assert( m_pending_writes[inst.warp_id()][inst.out[r]] > 0 );
-           } else if( inst.is_store() ) 
-              m_core->inc_store_req( inst.warp_id() );
-       }
-   } else {
-       assert( CACHE_UNDEFINED != inst.cache_op );
-       stall_cond = process_memory_access_queue_l1cache(m_L1D,inst);
-   }
-   if( !inst.accessq_empty() && stall_cond == NO_RC_FAIL)
-       stall_cond = COAL_STALL;
-   if (stall_cond != NO_RC_FAIL) {
-      stall_reason = stall_cond;
-      bool iswrite = inst.is_store();
-      if (inst.space.is_local()) 
-         access_type = (iswrite)?L_MEM_ST:L_MEM_LD;
-      else 
-         access_type = (iswrite)?G_MEM_ST:G_MEM_LD;
-   }
-   return inst.accessq_empty(); 
-}
-
-
-bool ldst_unit::response_buffer_full() const
-{
-    return m_response_fifo.size() >= m_config->ldst_unit_response_queue_size;
-}
-
-void ldst_unit::fill( mem_fetch *mf )
-{
-    mf->set_status(IN_SHADER_LDST_RESPONSE_FIFO,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
-    m_response_fifo.push_back(mf);
-}
-
-void ldst_unit::flush(){
-	// Flush L1D cache
-	m_L1D->flush();
-}
-
-void ldst_unit::invalidate(){
-	// Flush L1D cache
-	m_L1D->invalidate();
-}
-
-simd_function_unit::simd_function_unit( const shader_core_config *config )
-{ 
-    m_config=config;
-    m_dispatch_reg = new warp_inst_t(config); 
-}
-
-
-sfu:: sfu(  register_set* result_port, const shader_core_config *config,shader_core_ctx *core  )
-    : pipelined_simd_unit(result_port,config,config->max_sfu_latency,core)
-{ 
-    m_name = "SFU"; 
-}
-
-tensor_core:: tensor_core(  register_set* result_port, const shader_core_config *config,shader_core_ctx *core  )
-    : pipelined_simd_unit(result_port,config,config->max_tensor_core_latency,core)
-{ 
-    m_name = "TENSOR_CORE"; 
-}
-
-void sfu::issue( register_set& source_reg )
-{
-    warp_inst_t** ready_reg = source_reg.get_ready();
-	//m_core->incexecstat((*ready_reg));
-
-	(*ready_reg)->op_pipe=SFU__OP;
-	m_core->incsfu_stat(m_core->get_config()->warp_size,(*ready_reg)->latency);
-	pipelined_simd_unit::issue(source_reg);
-}
-
-void tensor_core::issue( register_set& source_reg )
-{
-    warp_inst_t** ready_reg = source_reg.get_ready();
-	//m_core->incexecstat((*ready_reg));
-
-	(*ready_reg)->op_pipe= TENSOR_CORE__OP;
-	m_core->incsfu_stat(m_core->get_config()->warp_size,(*ready_reg)->latency);
-	pipelined_simd_unit::issue(source_reg);
-}
-
-unsigned pipelined_simd_unit::get_active_lanes_in_pipeline(){
-	active_mask_t active_lanes;
-	active_lanes.reset();
-	 if(m_core->get_gpu()->get_config().g_power_simulation_enabled){
-		for( unsigned stage=0; (stage+1)<m_pipeline_depth; stage++ ){
-			if( !m_pipeline_reg[stage]->empty() )
-				active_lanes|=m_pipeline_reg[stage]->get_active_mask();
-		}
-	 }
-	return active_lanes.count();
-}
-
-void ldst_unit::active_lanes_in_pipeline(){
-	unsigned active_count=pipelined_simd_unit::get_active_lanes_in_pipeline();
-	assert(active_count<=m_core->get_config()->warp_size);
-	m_core->incfumemactivelanes_stat(active_count);
-}
-
-void sp_unit::active_lanes_in_pipeline(){
-	unsigned active_count=pipelined_simd_unit::get_active_lanes_in_pipeline();
-	assert(active_count<=m_core->get_config()->warp_size);
-	m_core->incspactivelanes_stat(active_count);
-	m_core->incfuactivelanes_stat(active_count);
-	m_core->incfumemactivelanes_stat(active_count);
-}
-void dp_unit::active_lanes_in_pipeline(){
-	unsigned active_count=pipelined_simd_unit::get_active_lanes_in_pipeline();
-	assert(active_count<=m_core->get_config()->warp_size);
-	m_core->incspactivelanes_stat(active_count);
-	m_core->incfuactivelanes_stat(active_count);
-	m_core->incfumemactivelanes_stat(active_count);
-}
-
-void int_unit::active_lanes_in_pipeline(){
-	unsigned active_count=pipelined_simd_unit::get_active_lanes_in_pipeline();
-	assert(active_count<=m_core->get_config()->warp_size);
-	m_core->incspactivelanes_stat(active_count);
-	m_core->incfuactivelanes_stat(active_count);
-	m_core->incfumemactivelanes_stat(active_count);
-}
-void sfu::active_lanes_in_pipeline(){
-	unsigned active_count=pipelined_simd_unit::get_active_lanes_in_pipeline();
-	assert(active_count<=m_core->get_config()->warp_size);
-	m_core->incsfuactivelanes_stat(active_count);
-	m_core->incfuactivelanes_stat(active_count);
-	m_core->incfumemactivelanes_stat(active_count);
-}
-
-void tensor_core::active_lanes_in_pipeline(){
-	unsigned active_count=pipelined_simd_unit::get_active_lanes_in_pipeline();
-	assert(active_count<=m_core->get_config()->warp_size);
-	m_core->incsfuactivelanes_stat(active_count);
-	m_core->incfuactivelanes_stat(active_count);
-	m_core->incfumemactivelanes_stat(active_count);
-}
-
-
-sp_unit::sp_unit( register_set* result_port, const shader_core_config *config,shader_core_ctx *core)
-    : pipelined_simd_unit(result_port,config,config->max_sp_latency,core)
-{ 
-    m_name = "SP "; 
-}
-
-dp_unit::dp_unit( register_set* result_port, const shader_core_config *config,shader_core_ctx *core)
-    : pipelined_simd_unit(result_port,config,config->max_dp_latency,core)
-{
-    m_name = "DP ";
-}
-
-int_unit::int_unit( register_set* result_port, const shader_core_config *config,shader_core_ctx *core)
-    : pipelined_simd_unit(result_port,config,config->max_int_latency,core)
-{
-    m_name = "INT ";
-}
-
-void sp_unit :: issue(register_set& source_reg)
-{
-    warp_inst_t** ready_reg = source_reg.get_ready();
-	//m_core->incexecstat((*ready_reg));
-	(*ready_reg)->op_pipe=SP__OP;
-	m_core->incsp_stat(m_core->get_config()->warp_size,(*ready_reg)->latency);
-	pipelined_simd_unit::issue(source_reg);
-}
-
-void dp_unit :: issue(register_set& source_reg)
-{
-    warp_inst_t** ready_reg = source_reg.get_ready();
-	//m_core->incexecstat((*ready_reg));
-	(*ready_reg)->op_pipe=DP__OP;
-	m_core->incsp_stat(m_core->get_config()->warp_size,(*ready_reg)->latency);
-	pipelined_simd_unit::issue(source_reg);
-}
-
-void int_unit :: issue(register_set& source_reg)
-{
-    warp_inst_t** ready_reg = source_reg.get_ready();
-	//m_core->incexecstat((*ready_reg));
-	(*ready_reg)->op_pipe=INTP__OP;
-	m_core->incsp_stat(m_core->get_config()->warp_size,(*ready_reg)->latency);
-	pipelined_simd_unit::issue(source_reg);
-}
-
-pipelined_simd_unit::pipelined_simd_unit( register_set* result_port, const shader_core_config *config, unsigned max_latency,shader_core_ctx *core )
-    : simd_function_unit(config) 
-{
-    m_result_port = result_port;
-    m_pipeline_depth = max_latency;
-    m_pipeline_reg = new warp_inst_t*[m_pipeline_depth];
-    for( unsigned i=0; i < m_pipeline_depth; i++ ) 
-	m_pipeline_reg[i] = new warp_inst_t( config );
-    m_core=core;
-    active_insts_in_pipeline=0;
-}
-
-void pipelined_simd_unit::cycle()
-{
-    if( !m_pipeline_reg[0]->empty() ){
-        m_result_port->move_in(m_pipeline_reg[0]);
-        assert(active_insts_in_pipeline > 0);
-        active_insts_in_pipeline--;
     }
-    if(active_insts_in_pipeline){
-		for( unsigned stage=0; (stage+1)<m_pipeline_depth; stage++ )
-			move_warp(m_pipeline_reg[stage], m_pipeline_reg[stage+1]);
-    }
-    if( !m_dispatch_reg->empty() ) {
-        if( !m_dispatch_reg->dispatch_delay()){
-            int start_stage = m_dispatch_reg->latency - m_dispatch_reg->initiation_interval;
-            move_warp(m_pipeline_reg[start_stage],m_dispatch_reg);
-            active_insts_in_pipeline++;
+    if (!inst.accessq_empty() && result != BK_CONF) result = COAL_STALL;
+
+    return result;
+  } else {
+    mem_fetch *mf =
+        m_mf_allocator->alloc(inst, inst.accessq_back(),
+                              m_core->get_gpu()->gpu_sim_cycle +
+                                  m_core->get_gpu()->gpu_tot_sim_cycle);
+    std::list<cache_event> events;
+    enum cache_request_status status = cache->access(
+        mf->get_addr(), mf,
+        m_core->get_gpu()->gpu_sim_cycle + m_core->get_gpu()->gpu_tot_sim_cycle,
+        events);
+    return process_cache_access(cache, mf->get_addr(), inst, events, mf,
+                                status);
+  }
+}
+
+void ldst_unit::L1_latency_queue_cycle() {
+  for (int j = 0; j < m_config->m_L1D_config.l1_banks; j++) {
+    if ((l1_latency_queue[j][0]) != NULL) {
+      mem_fetch *mf_next = l1_latency_queue[j][0];
+      std::list<cache_event> events;
+      enum cache_request_status status =
+          m_L1D->access(mf_next->get_addr(), mf_next,
+                        m_core->get_gpu()->gpu_sim_cycle +
+                            m_core->get_gpu()->gpu_tot_sim_cycle,
+                        events);
+
+      bool write_sent = was_write_sent(events);
+      bool read_sent = was_read_sent(events);
+
+      if (status == HIT) {
+        assert(!read_sent);
+        l1_latency_queue[j][0] = NULL;
+        if (mf_next->get_inst().is_load()) {
+          for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++)
+            if (mf_next->get_inst().out[r] > 0) {
+              assert(m_pending_writes[mf_next->get_inst().warp_id()]
+                                     [mf_next->get_inst().out[r]] > 0);
+              unsigned still_pending =
+                  --m_pending_writes[mf_next->get_inst().warp_id()]
+                                    [mf_next->get_inst().out[r]];
+              if (!still_pending) {
+                m_pending_writes[mf_next->get_inst().warp_id()].erase(
+                    mf_next->get_inst().out[r]);
+                m_scoreboard->releaseRegister(mf_next->get_inst().warp_id(),
+                                              mf_next->get_inst().out[r]);
+                m_core->warp_inst_complete(mf_next->get_inst());
+              }
+            }
         }
+
+        // For write hit in WB policy
+        if (mf_next->get_inst().is_store() && !write_sent) {
+          unsigned dec_ack =
+              (m_config->m_L1D_config.get_mshr_type() == SECTOR_ASSOC)
+                  ? (mf_next->get_data_size() / SECTOR_SIZE)
+                  : 1;
+
+          mf_next->set_reply();
+
+          for (unsigned i = 0; i < dec_ack; ++i) m_core->store_ack(mf_next);
+        }
+
+        if (!write_sent) delete mf_next;
+
+      } else if (status == RESERVATION_FAIL) {
+        assert(!read_sent);
+        assert(!write_sent);
+      } else {
+        assert(status == MISS || status == HIT_RESERVED);
+        l1_latency_queue[j][0] = NULL;
+      }
     }
-    occupied >>=1;
+
+    for (unsigned stage = 0; stage < m_config->m_L1D_config.l1_latency - 1;
+         ++stage)
+      if (l1_latency_queue[j][stage] == NULL) {
+        l1_latency_queue[j][stage] = l1_latency_queue[j][stage + 1];
+        l1_latency_queue[j][stage + 1] = NULL;
+      }
+  }
 }
 
+bool ldst_unit::constant_cycle(warp_inst_t &inst, mem_stage_stall_type &rc_fail,
+                               mem_stage_access_type &fail_type) {
+  if (inst.empty() || ((inst.space.get_type() != const_space) &&
+                       (inst.space.get_type() != param_space_kernel)))
+    return true;
+  if (inst.active_count() == 0) return true;
+  mem_stage_stall_type fail = process_memory_access_queue(m_L1C, inst);
+  if (fail != NO_RC_FAIL) {
+    rc_fail = fail;  // keep other fails if this didn't fail.
+    fail_type = C_MEM;
+    if (rc_fail == BK_CONF or rc_fail == COAL_STALL) {
+      m_stats->gpgpu_n_cmem_portconflict++;  // coal stalls aren't really a bank
+                                             // conflict, but this maintains
+                                             // previous behavior.
+    }
+  }
+  return inst.accessq_empty();  // done if empty.
+}
 
-void pipelined_simd_unit::issue( register_set& source_reg )
-{
-    //move_warp(m_dispatch_reg,source_reg);
-    warp_inst_t** ready_reg = source_reg.get_ready();
-	m_core->incexecstat((*ready_reg));
-	//source_reg.move_out_to(m_dispatch_reg);
-	simd_function_unit::issue(source_reg);
+bool ldst_unit::texture_cycle(warp_inst_t &inst, mem_stage_stall_type &rc_fail,
+                              mem_stage_access_type &fail_type) {
+  if (inst.empty() || inst.space.get_type() != tex_space) return true;
+  if (inst.active_count() == 0) return true;
+  mem_stage_stall_type fail = process_memory_access_queue(m_L1T, inst);
+  if (fail != NO_RC_FAIL) {
+    rc_fail = fail;  // keep other fails if this didn't fail.
+    fail_type = T_MEM;
+  }
+  return inst.accessq_empty();  // done if empty.
+}
+
+bool ldst_unit::memory_cycle(warp_inst_t &inst,
+                             mem_stage_stall_type &stall_reason,
+                             mem_stage_access_type &access_type) {
+  if (inst.empty() || ((inst.space.get_type() != global_space) &&
+                       (inst.space.get_type() != local_space) &&
+                       (inst.space.get_type() != param_space_local)))
+    return true;
+  if (inst.active_count() == 0) return true;
+  assert(!inst.accessq_empty());
+  mem_stage_stall_type stall_cond = NO_RC_FAIL;
+  const mem_access_t &access = inst.accessq_back();
+
+  bool bypassL1D = false;
+  if (CACHE_GLOBAL == inst.cache_op || (m_L1D == NULL)) {
+    bypassL1D = true;
+  } else if (inst.space.is_global()) {  // global memory access
+    // skip L1 cache if the option is enabled
+    if (m_core->get_config()->gmem_skip_L1D && (CACHE_L1 != inst.cache_op))
+      bypassL1D = true;
+  }
+  if (bypassL1D) {
+    // bypass L1 cache
+    unsigned control_size =
+        inst.is_store() ? WRITE_PACKET_SIZE : READ_PACKET_SIZE;
+    unsigned size = access.get_size() + control_size;
+    // printf("Interconnect:Addr: %x, size=%d\n",access.get_addr(),size);
+    if (m_icnt->full(size, inst.is_store() || inst.isatomic())) {
+      stall_cond = ICNT_RC_FAIL;
+    } else {
+      mem_fetch *mf =
+          m_mf_allocator->alloc(inst, access,
+                                m_core->get_gpu()->gpu_sim_cycle +
+                                    m_core->get_gpu()->gpu_tot_sim_cycle);
+      m_icnt->push(mf);
+      inst.accessq_pop_back();
+      // inst.clear_active( access.get_warp_mask() );
+      if (inst.is_load()) {
+        for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++)
+          if (inst.out[r] > 0)
+            assert(m_pending_writes[inst.warp_id()][inst.out[r]] > 0);
+      } else if (inst.is_store())
+        m_core->inc_store_req(inst.warp_id());
+    }
+  } else {
+    assert(CACHE_UNDEFINED != inst.cache_op);
+    stall_cond = process_memory_access_queue_l1cache(m_L1D, inst);
+  }
+  if (!inst.accessq_empty() && stall_cond == NO_RC_FAIL)
+    stall_cond = COAL_STALL;
+  if (stall_cond != NO_RC_FAIL) {
+    stall_reason = stall_cond;
+    bool iswrite = inst.is_store();
+    if (inst.space.is_local())
+      access_type = (iswrite) ? L_MEM_ST : L_MEM_LD;
+    else
+      access_type = (iswrite) ? G_MEM_ST : G_MEM_LD;
+  }
+  return inst.accessq_empty();
+}
+
+bool ldst_unit::response_buffer_full() const {
+  return m_response_fifo.size() >= m_config->ldst_unit_response_queue_size;
+}
+
+void ldst_unit::fill(mem_fetch *mf) {
+  mf->set_status(
+      IN_SHADER_LDST_RESPONSE_FIFO,
+      m_core->get_gpu()->gpu_sim_cycle + m_core->get_gpu()->gpu_tot_sim_cycle);
+  m_response_fifo.push_back(mf);
+}
+
+void ldst_unit::flush() {
+  // Flush L1D cache
+  m_L1D->flush();
+}
+
+void ldst_unit::invalidate() {
+  // Flush L1D cache
+  m_L1D->invalidate();
+}
+
+simd_function_unit::simd_function_unit(const shader_core_config *config) {
+  m_config = config;
+  m_dispatch_reg = new warp_inst_t(config);
+}
+
+sfu::sfu(register_set *result_port, const shader_core_config *config,
+         shader_core_ctx *core)
+    : pipelined_simd_unit(result_port, config, config->max_sfu_latency, core) {
+  m_name = "SFU";
+}
+
+tensor_core::tensor_core(register_set *result_port,
+                         const shader_core_config *config,
+                         shader_core_ctx *core)
+    : pipelined_simd_unit(result_port, config, config->max_tensor_core_latency,
+                          core) {
+  m_name = "TENSOR_CORE";
+}
+
+void sfu::issue(register_set &source_reg) {
+  warp_inst_t **ready_reg = source_reg.get_ready();
+  // m_core->incexecstat((*ready_reg));
+
+  (*ready_reg)->op_pipe = SFU__OP;
+  m_core->incsfu_stat(m_core->get_config()->warp_size, (*ready_reg)->latency);
+  pipelined_simd_unit::issue(source_reg);
+}
+
+void tensor_core::issue(register_set &source_reg) {
+  warp_inst_t **ready_reg = source_reg.get_ready();
+  // m_core->incexecstat((*ready_reg));
+
+  (*ready_reg)->op_pipe = TENSOR_CORE__OP;
+  m_core->incsfu_stat(m_core->get_config()->warp_size, (*ready_reg)->latency);
+  pipelined_simd_unit::issue(source_reg);
+}
+
+unsigned pipelined_simd_unit::get_active_lanes_in_pipeline() {
+  active_mask_t active_lanes;
+  active_lanes.reset();
+  if (m_core->get_gpu()->get_config().g_power_simulation_enabled) {
+    for (unsigned stage = 0; (stage + 1) < m_pipeline_depth; stage++) {
+      if (!m_pipeline_reg[stage]->empty())
+        active_lanes |= m_pipeline_reg[stage]->get_active_mask();
+    }
+  }
+  return active_lanes.count();
+}
+
+void ldst_unit::active_lanes_in_pipeline() {
+  unsigned active_count = pipelined_simd_unit::get_active_lanes_in_pipeline();
+  assert(active_count <= m_core->get_config()->warp_size);
+  m_core->incfumemactivelanes_stat(active_count);
+}
+
+void sp_unit::active_lanes_in_pipeline() {
+  unsigned active_count = pipelined_simd_unit::get_active_lanes_in_pipeline();
+  assert(active_count <= m_core->get_config()->warp_size);
+  m_core->incspactivelanes_stat(active_count);
+  m_core->incfuactivelanes_stat(active_count);
+  m_core->incfumemactivelanes_stat(active_count);
+}
+void dp_unit::active_lanes_in_pipeline() {
+  unsigned active_count = pipelined_simd_unit::get_active_lanes_in_pipeline();
+  assert(active_count <= m_core->get_config()->warp_size);
+  m_core->incspactivelanes_stat(active_count);
+  m_core->incfuactivelanes_stat(active_count);
+  m_core->incfumemactivelanes_stat(active_count);
+}
+
+void int_unit::active_lanes_in_pipeline() {
+  unsigned active_count = pipelined_simd_unit::get_active_lanes_in_pipeline();
+  assert(active_count <= m_core->get_config()->warp_size);
+  m_core->incspactivelanes_stat(active_count);
+  m_core->incfuactivelanes_stat(active_count);
+  m_core->incfumemactivelanes_stat(active_count);
+}
+void sfu::active_lanes_in_pipeline() {
+  unsigned active_count = pipelined_simd_unit::get_active_lanes_in_pipeline();
+  assert(active_count <= m_core->get_config()->warp_size);
+  m_core->incsfuactivelanes_stat(active_count);
+  m_core->incfuactivelanes_stat(active_count);
+  m_core->incfumemactivelanes_stat(active_count);
+}
+
+void tensor_core::active_lanes_in_pipeline() {
+  unsigned active_count = pipelined_simd_unit::get_active_lanes_in_pipeline();
+  assert(active_count <= m_core->get_config()->warp_size);
+  m_core->incsfuactivelanes_stat(active_count);
+  m_core->incfuactivelanes_stat(active_count);
+  m_core->incfumemactivelanes_stat(active_count);
+}
+
+sp_unit::sp_unit(register_set *result_port, const shader_core_config *config,
+                 shader_core_ctx *core)
+    : pipelined_simd_unit(result_port, config, config->max_sp_latency, core) {
+  m_name = "SP ";
+}
+
+dp_unit::dp_unit(register_set *result_port, const shader_core_config *config,
+                 shader_core_ctx *core)
+    : pipelined_simd_unit(result_port, config, config->max_dp_latency, core) {
+  m_name = "DP ";
+}
+
+int_unit::int_unit(register_set *result_port, const shader_core_config *config,
+                   shader_core_ctx *core)
+    : pipelined_simd_unit(result_port, config, config->max_int_latency, core) {
+  m_name = "INT ";
+}
+
+void sp_unit ::issue(register_set &source_reg) {
+  warp_inst_t **ready_reg = source_reg.get_ready();
+  // m_core->incexecstat((*ready_reg));
+  (*ready_reg)->op_pipe = SP__OP;
+  m_core->incsp_stat(m_core->get_config()->warp_size, (*ready_reg)->latency);
+  pipelined_simd_unit::issue(source_reg);
+}
+
+void dp_unit ::issue(register_set &source_reg) {
+  warp_inst_t **ready_reg = source_reg.get_ready();
+  // m_core->incexecstat((*ready_reg));
+  (*ready_reg)->op_pipe = DP__OP;
+  m_core->incsp_stat(m_core->get_config()->warp_size, (*ready_reg)->latency);
+  pipelined_simd_unit::issue(source_reg);
+}
+
+void int_unit ::issue(register_set &source_reg) {
+  warp_inst_t **ready_reg = source_reg.get_ready();
+  // m_core->incexecstat((*ready_reg));
+  (*ready_reg)->op_pipe = INTP__OP;
+  m_core->incsp_stat(m_core->get_config()->warp_size, (*ready_reg)->latency);
+  pipelined_simd_unit::issue(source_reg);
+}
+
+pipelined_simd_unit::pipelined_simd_unit(register_set *result_port,
+                                         const shader_core_config *config,
+                                         unsigned max_latency,
+                                         shader_core_ctx *core)
+    : simd_function_unit(config) {
+  m_result_port = result_port;
+  m_pipeline_depth = max_latency;
+  m_pipeline_reg = new warp_inst_t *[m_pipeline_depth];
+  for (unsigned i = 0; i < m_pipeline_depth; i++)
+    m_pipeline_reg[i] = new warp_inst_t(config);
+  m_core = core;
+  active_insts_in_pipeline = 0;
+}
+
+void pipelined_simd_unit::cycle() {
+  if (!m_pipeline_reg[0]->empty()) {
+    m_result_port->move_in(m_pipeline_reg[0]);
+    assert(active_insts_in_pipeline > 0);
+    active_insts_in_pipeline--;
+  }
+  if (active_insts_in_pipeline) {
+    for (unsigned stage = 0; (stage + 1) < m_pipeline_depth; stage++)
+      move_warp(m_pipeline_reg[stage], m_pipeline_reg[stage + 1]);
+  }
+  if (!m_dispatch_reg->empty()) {
+    if (!m_dispatch_reg->dispatch_delay()) {
+      int start_stage =
+          m_dispatch_reg->latency - m_dispatch_reg->initiation_interval;
+      move_warp(m_pipeline_reg[start_stage], m_dispatch_reg);
+      active_insts_in_pipeline++;
+    }
+  }
+  occupied >>= 1;
+}
+
+void pipelined_simd_unit::issue(register_set &source_reg) {
+  // move_warp(m_dispatch_reg,source_reg);
+  warp_inst_t **ready_reg = source_reg.get_ready();
+  m_core->incexecstat((*ready_reg));
+  // source_reg.move_out_to(m_dispatch_reg);
+  simd_function_unit::issue(source_reg);
 }
 
 /*
@@ -2073,120 +2145,223 @@ void pipelined_simd_unit::issue( register_set& source_reg )
     }
 */
 
-void ldst_unit::init( mem_fetch_interface *icnt,
-                      shader_core_mem_fetch_allocator *mf_allocator,
-                      shader_core_ctx *core, 
-                      opndcoll_rfu_t *operand_collector,
-                      Scoreboard *scoreboard,
-                      const shader_core_config *config,
-                      const memory_config *mem_config,  
-                      shader_core_stats *stats,
-                      unsigned sid,
-                      unsigned tpc )
-{
-    m_memory_config = mem_config;
-    m_icnt = icnt;
-    m_mf_allocator=mf_allocator;
-    m_core = core;
-    m_operand_collector = operand_collector;
-    m_scoreboard = scoreboard;
-    m_stats = stats;
-    m_sid = sid;
-    m_tpc = tpc;
-    #define STRSIZE 1024
-    char L1T_name[STRSIZE];
-    char L1C_name[STRSIZE];
-    snprintf(L1T_name, STRSIZE, "L1T_%03d", m_sid);
-    snprintf(L1C_name, STRSIZE, "L1C_%03d", m_sid);
-    m_L1T = new tex_cache(L1T_name,m_config->m_L1T_config,m_sid,get_shader_texture_cache_id(),icnt,IN_L1T_MISS_QUEUE,IN_SHADER_L1T_ROB);
-    m_L1C = new read_only_cache(L1C_name,m_config->m_L1C_config,m_sid,get_shader_constant_cache_id(),icnt,IN_L1C_MISS_QUEUE);
-    m_L1D = NULL;
-    m_mem_rc = NO_RC_FAIL;
-    m_num_writeback_clients=5; // = shared memory, global/local (uncached), L1D, L1T, L1C
-    m_writeback_arb = 0;
-    m_next_global=NULL;
-    m_last_inst_gpu_sim_cycle=0;
-    m_last_inst_gpu_tot_sim_cycle=0;
+void ldst_unit::init(mem_fetch_interface *icnt,
+                     shader_core_mem_fetch_allocator *mf_allocator,
+                     shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
+                     Scoreboard *scoreboard, const shader_core_config *config,
+                     const memory_config *mem_config, shader_core_stats *stats,
+                     unsigned sid, unsigned tpc) {
+  m_memory_config = mem_config;
+  m_icnt = icnt;
+  m_mf_allocator = mf_allocator;
+  m_core = core;
+  m_operand_collector = operand_collector;
+  m_scoreboard = scoreboard;
+  m_stats = stats;
+  m_sid = sid;
+  m_tpc = tpc;
+#define STRSIZE 1024
+  char L1T_name[STRSIZE];
+  char L1C_name[STRSIZE];
+  snprintf(L1T_name, STRSIZE, "L1T_%03d", m_sid);
+  snprintf(L1C_name, STRSIZE, "L1C_%03d", m_sid);
+  m_L1T = new tex_cache(L1T_name, m_config->m_L1T_config, m_sid,
+                        get_shader_texture_cache_id(), icnt, IN_L1T_MISS_QUEUE,
+                        IN_SHADER_L1T_ROB);
+  m_L1C = new read_only_cache(L1C_name, m_config->m_L1C_config, m_sid,
+                              get_shader_constant_cache_id(), icnt,
+                              IN_L1C_MISS_QUEUE);
+  m_L1D = NULL;
+  m_mem_rc = NO_RC_FAIL;
+  m_num_writeback_clients =
+      5;  // = shared memory, global/local (uncached), L1D, L1T, L1C
+  m_writeback_arb = 0;
+  m_next_global = NULL;
+  m_last_inst_gpu_sim_cycle = 0;
+  m_last_inst_gpu_tot_sim_cycle = 0;
 }
 
+ldst_unit::ldst_unit(mem_fetch_interface *icnt,
+                     shader_core_mem_fetch_allocator *mf_allocator,
+                     shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
+                     Scoreboard *scoreboard, const shader_core_config *config,
+                     const memory_config *mem_config, shader_core_stats *stats,
+                     unsigned sid, unsigned tpc)
+    : pipelined_simd_unit(NULL, config, config->smem_latency, core),
+      m_next_wb(config) {
+  assert(config->smem_latency > 1);
+  init(icnt, mf_allocator, core, operand_collector, scoreboard, config,
+       mem_config, stats, sid, tpc);
+  if (!m_config->m_L1D_config.disabled()) {
+    char L1D_name[STRSIZE];
+    snprintf(L1D_name, STRSIZE, "L1D_%03d", m_sid);
+    m_L1D = new l1_cache(L1D_name, m_config->m_L1D_config, m_sid,
+                         get_shader_normal_cache_id(), m_icnt, m_mf_allocator,
+                         IN_L1D_MISS_QUEUE, core->get_gpu());
 
-ldst_unit::ldst_unit( mem_fetch_interface *icnt,
-                      shader_core_mem_fetch_allocator *mf_allocator,
-                      shader_core_ctx *core, 
-                      opndcoll_rfu_t *operand_collector,
-                      Scoreboard *scoreboard,
-                      const shader_core_config *config,
-                      const memory_config *mem_config,  
-                      shader_core_stats *stats,
-                      unsigned sid,
-                      unsigned tpc ) : pipelined_simd_unit(NULL,config,config->smem_latency,core), m_next_wb(config)
-{
-	assert(config->smem_latency > 1);
-    init( icnt,
-          mf_allocator,
-          core, 
-          operand_collector,
-          scoreboard,
-          config, 
-          mem_config,  
-          stats, 
-          sid,
-          tpc );
-    if( !m_config->m_L1D_config.disabled() ) {
-        char L1D_name[STRSIZE];
-        snprintf(L1D_name, STRSIZE, "L1D_%03d", m_sid);
-        m_L1D = new l1_cache( L1D_name,
-                              m_config->m_L1D_config,
-                              m_sid,
-                              get_shader_normal_cache_id(),
-                              m_icnt,
-                              m_mf_allocator,
-                              IN_L1D_MISS_QUEUE,
-							  core->get_gpu());
+    l1_latency_queue.resize(m_config->m_L1D_config.l1_banks);
+    assert(m_config->m_L1D_config.l1_latency > 0);
 
-        l1_latency_queue.resize(m_config->m_L1D_config.l1_banks);
-        assert(m_config->m_L1D_config.l1_latency > 0);
+    for (unsigned j = 0; j < m_config->m_L1D_config.l1_banks; j++)
+      l1_latency_queue[j].resize(m_config->m_L1D_config.l1_latency,
+                                 (mem_fetch *)NULL);
+  }
+  m_name = "MEM ";
+}
 
-		for(unsigned j = 0; j < m_config->m_L1D_config.l1_banks; j++ )
-			l1_latency_queue[j].resize(m_config->m_L1D_config.l1_latency,(mem_fetch*)NULL);
+ldst_unit::ldst_unit(mem_fetch_interface *icnt,
+                     shader_core_mem_fetch_allocator *mf_allocator,
+                     shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
+                     Scoreboard *scoreboard, const shader_core_config *config,
+                     const memory_config *mem_config, shader_core_stats *stats,
+                     unsigned sid, unsigned tpc, l1_cache *new_l1d_cache)
+    : pipelined_simd_unit(NULL, config, 3, core),
+      m_L1D(new_l1d_cache),
+      m_next_wb(config) {
+  init(icnt, mf_allocator, core, operand_collector, scoreboard, config,
+       mem_config, stats, sid, tpc);
+}
 
+void ldst_unit::issue(register_set &reg_set) {
+  warp_inst_t *inst = *(reg_set.get_ready());
+
+  // record how many pending register writes/memory accesses there are for this
+  // instruction
+  assert(inst->empty() == false);
+  if (inst->is_load() and inst->space.get_type() != shared_space) {
+    unsigned warp_id = inst->warp_id();
+    unsigned n_accesses = inst->accessq_count();
+    for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++) {
+      unsigned reg_id = inst->out[r];
+      if (reg_id > 0) {
+        m_pending_writes[warp_id][reg_id] += n_accesses;
+      }
     }
-    m_name = "MEM ";
+  }
+
+  inst->op_pipe = MEM__OP;
+  // stat collection
+  m_core->mem_instruction_stats(*inst);
+  m_core->incmem_stat(m_core->get_config()->warp_size, 1);
+  pipelined_simd_unit::issue(reg_set);
 }
 
-ldst_unit::ldst_unit( mem_fetch_interface *icnt,
-                      shader_core_mem_fetch_allocator *mf_allocator,
-                      shader_core_ctx *core, 
-                      opndcoll_rfu_t *operand_collector,
-                      Scoreboard *scoreboard,
-                      const shader_core_config *config,
-                      const memory_config *mem_config,  
-                      shader_core_stats *stats,
-                      unsigned sid,
-                      unsigned tpc,
-                      l1_cache* new_l1d_cache )
-    : pipelined_simd_unit(NULL,config,3,core), m_L1D(new_l1d_cache), m_next_wb(config)
-{
-    init( icnt,
-          mf_allocator,
-          core, 
-          operand_collector,
-          scoreboard,
-          config, 
-          mem_config,  
-          stats, 
-          sid,
-          tpc );
+void ldst_unit::writeback() {
+  // process next instruction that is going to writeback
+  if (!m_next_wb.empty()) {
+    if (m_operand_collector->writeback(m_next_wb)) {
+      bool insn_completed = false;
+      for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++) {
+        if (m_next_wb.out[r] > 0) {
+          if (m_next_wb.space.get_type() != shared_space) {
+            assert(m_pending_writes[m_next_wb.warp_id()][m_next_wb.out[r]] > 0);
+            unsigned still_pending =
+                --m_pending_writes[m_next_wb.warp_id()][m_next_wb.out[r]];
+            if (!still_pending) {
+              m_pending_writes[m_next_wb.warp_id()].erase(m_next_wb.out[r]);
+              m_scoreboard->releaseRegister(m_next_wb.warp_id(),
+                                            m_next_wb.out[r]);
+              insn_completed = true;
+            }
+          } else {  // shared
+            m_scoreboard->releaseRegister(m_next_wb.warp_id(),
+                                          m_next_wb.out[r]);
+            insn_completed = true;
+          }
+        }
+      }
+      if (insn_completed) {
+        m_core->warp_inst_complete(m_next_wb);
+      }
+      m_next_wb.clear();
+      m_last_inst_gpu_sim_cycle = m_core->get_gpu()->gpu_sim_cycle;
+      m_last_inst_gpu_tot_sim_cycle = m_core->get_gpu()->gpu_tot_sim_cycle;
+    }
+  }
+
+  unsigned serviced_client = -1;
+  for (unsigned c = 0; m_next_wb.empty() && (c < m_num_writeback_clients);
+       c++) {
+    unsigned next_client = (c + m_writeback_arb) % m_num_writeback_clients;
+    switch (next_client) {
+      case 0:  // shared memory
+        if (!m_pipeline_reg[0]->empty()) {
+          m_next_wb = *m_pipeline_reg[0];
+          if (m_next_wb.isatomic()) {
+            m_next_wb.do_atomic();
+            m_core->decrement_atomic_count(m_next_wb.warp_id(),
+                                           m_next_wb.active_count());
+          }
+          m_core->dec_inst_in_pipeline(m_pipeline_reg[0]->warp_id());
+          m_pipeline_reg[0]->clear();
+          serviced_client = next_client;
+        }
+        break;
+      case 1:  // texture response
+        if (m_L1T->access_ready()) {
+          mem_fetch *mf = m_L1T->next_access();
+          m_next_wb = mf->get_inst();
+          delete mf;
+          serviced_client = next_client;
+        }
+        break;
+      case 2:  // const cache response
+        if (m_L1C->access_ready()) {
+          mem_fetch *mf = m_L1C->next_access();
+          m_next_wb = mf->get_inst();
+          delete mf;
+          serviced_client = next_client;
+        }
+        break;
+      case 3:  // global/local
+        if (m_next_global) {
+          m_next_wb = m_next_global->get_inst();
+          if (m_next_global->isatomic())
+            m_core->decrement_atomic_count(
+                m_next_global->get_wid(),
+                m_next_global->get_access_warp_mask().count());
+          delete m_next_global;
+          m_next_global = NULL;
+          serviced_client = next_client;
+        }
+        break;
+      case 4:
+        if (m_L1D && m_L1D->access_ready()) {
+          mem_fetch *mf = m_L1D->next_access();
+          m_next_wb = mf->get_inst();
+          delete mf;
+          serviced_client = next_client;
+        }
+        break;
+      default:
+        abort();
+    }
+  }
+  // update arbitration priority only if:
+  // 1. the writeback buffer was available
+  // 2. a client was serviced
+  if (serviced_client != (unsigned)-1) {
+    m_writeback_arb = (serviced_client + 1) % m_num_writeback_clients;
+  }
 }
 
-void ldst_unit:: issue( register_set &reg_set )
+unsigned ldst_unit::clock_multiplier() const {
+  // to model multiple read port, we give multiple cycles for the memory units
+  if (m_config->mem_unit_ports)
+    return m_config->mem_unit_ports;
+  else
+    return m_config->mem_warp_parts;
+}
+/*
+void ldst_unit::issue( register_set &reg_set )
 {
-	warp_inst_t* inst = *(reg_set.get_ready());
+        warp_inst_t* inst = *(reg_set.get_ready());
+   // stat collection
+   m_core->mem_instruction_stats(*inst);
 
-   // record how many pending register writes/memory accesses there are for this instruction
-   assert(inst->empty() == false);
-   if (inst->is_load() and inst->space.get_type() != shared_space) {
-      unsigned warp_id = inst->warp_id();
+   // record how many pending register writes/memory accesses there are for this
+instruction assert(inst->empty() == false); if (inst->is_load() and
+inst->space.get_type() != shared_space) { unsigned warp_id = inst->warp_id();
       unsigned n_accesses = inst->accessq_count();
       for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++) {
          unsigned reg_id = inst->out[r];
@@ -2196,1951 +2371,1877 @@ void ldst_unit:: issue( register_set &reg_set )
       }
    }
 
-
-	inst->op_pipe=MEM__OP;
-	// stat collection
-	m_core->mem_instruction_stats(*inst);
-	m_core->incmem_stat(m_core->get_config()->warp_size,1);
-	pipelined_simd_unit::issue(reg_set);
-}
-
-void ldst_unit::writeback()
-{
-    // process next instruction that is going to writeback
-    if( !m_next_wb.empty() ) {
-        if( m_operand_collector->writeback(m_next_wb) ) {
-            bool insn_completed = false; 
-            for( unsigned r=0; r < MAX_OUTPUT_VALUES; r++ ) {
-                if( m_next_wb.out[r] > 0 ) {
-                    if( m_next_wb.space.get_type() != shared_space ) {
-                        assert( m_pending_writes[m_next_wb.warp_id()][m_next_wb.out[r]] > 0 );
-                        unsigned still_pending = --m_pending_writes[m_next_wb.warp_id()][m_next_wb.out[r]];
-                        if( !still_pending ) {
-                            m_pending_writes[m_next_wb.warp_id()].erase(m_next_wb.out[r]);
-                            m_scoreboard->releaseRegister( m_next_wb.warp_id(), m_next_wb.out[r] );
-                            insn_completed = true; 
-                        }
-                    } else { // shared 
-                        m_scoreboard->releaseRegister( m_next_wb.warp_id(), m_next_wb.out[r] );
-                        insn_completed = true; 
-                    }
-                }
-            }
-            if( insn_completed ) {
-                m_core->warp_inst_complete(m_next_wb);
-            }
-            m_next_wb.clear();
-            m_last_inst_gpu_sim_cycle = m_core->get_gpu()->gpu_sim_cycle;
-            m_last_inst_gpu_tot_sim_cycle = m_core->get_gpu()->gpu_tot_sim_cycle;
-        }
-    }
-
-    unsigned serviced_client = -1; 
-    for( unsigned c = 0; m_next_wb.empty() && (c < m_num_writeback_clients); c++ ) {
-        unsigned next_client = (c+m_writeback_arb)%m_num_writeback_clients;
-        switch( next_client ) {
-        case 0: // shared memory 
-            if( !m_pipeline_reg[0]->empty() ) {
-                m_next_wb = *m_pipeline_reg[0];
-                if(m_next_wb.isatomic()) {
-                    m_next_wb.do_atomic();
-                    m_core->decrement_atomic_count(m_next_wb.warp_id(), m_next_wb.active_count());
-                }
-                m_core->dec_inst_in_pipeline(m_pipeline_reg[0]->warp_id());
-                m_pipeline_reg[0]->clear();
-                serviced_client = next_client; 
-            }
-            break;
-        case 1: // texture response
-            if( m_L1T->access_ready() ) {
-                mem_fetch *mf = m_L1T->next_access();
-                m_next_wb = mf->get_inst();
-                delete mf;
-                serviced_client = next_client; 
-            }
-            break;
-        case 2: // const cache response
-            if( m_L1C->access_ready() ) {
-                mem_fetch *mf = m_L1C->next_access();
-                m_next_wb = mf->get_inst();
-                delete mf;
-                serviced_client = next_client; 
-            }
-            break;
-        case 3: // global/local
-            if( m_next_global ) {
-                m_next_wb = m_next_global->get_inst();
-                if( m_next_global->isatomic() ) 
-                    m_core->decrement_atomic_count(m_next_global->get_wid(),m_next_global->get_access_warp_mask().count());
-                delete m_next_global;
-                m_next_global = NULL;
-                serviced_client = next_client; 
-            }
-            break;
-        case 4: 
-            if( m_L1D && m_L1D->access_ready() ) {
-                mem_fetch *mf = m_L1D->next_access();
-                m_next_wb = mf->get_inst();
-                delete mf;
-                serviced_client = next_client; 
-            }
-            break;
-        default: abort();
-        }
-    }
-    // update arbitration priority only if: 
-    // 1. the writeback buffer was available 
-    // 2. a client was serviced 
-    if (serviced_client != (unsigned)-1) {
-        m_writeback_arb = (serviced_client + 1) % m_num_writeback_clients; 
-    }
-}
-
-unsigned ldst_unit::clock_multiplier() const
-{ 
-	//to model multiple read port, we give multiple cycles for the memory units
-	if(m_config->mem_unit_ports)
-		return m_config->mem_unit_ports;
-	else
-		return m_config->mem_warp_parts;
-}
-/*
-void ldst_unit::issue( register_set &reg_set )
-{
-	warp_inst_t* inst = *(reg_set.get_ready());
-   // stat collection
-   m_core->mem_instruction_stats(*inst); 
-
-   // record how many pending register writes/memory accesses there are for this instruction 
-   assert(inst->empty() == false); 
-   if (inst->is_load() and inst->space.get_type() != shared_space) {
-      unsigned warp_id = inst->warp_id(); 
-      unsigned n_accesses = inst->accessq_count(); 
-      for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++) {
-         unsigned reg_id = inst->out[r]; 
-         if (reg_id > 0) {
-            m_pending_writes[warp_id][reg_id] += n_accesses; 
-         }
-      }
-   }
-
    pipelined_simd_unit::issue(reg_set);
 }
 */
-void ldst_unit::cycle()
-{
-   writeback();
-   m_operand_collector->step();
-   for( unsigned stage=0; (stage+1)<m_pipeline_depth; stage++ ) 
-       if( m_pipeline_reg[stage]->empty() && !m_pipeline_reg[stage+1]->empty() )
-            move_warp(m_pipeline_reg[stage], m_pipeline_reg[stage+1]);
+void ldst_unit::cycle() {
+  writeback();
+  m_operand_collector->step();
+  for (unsigned stage = 0; (stage + 1) < m_pipeline_depth; stage++)
+    if (m_pipeline_reg[stage]->empty() && !m_pipeline_reg[stage + 1]->empty())
+      move_warp(m_pipeline_reg[stage], m_pipeline_reg[stage + 1]);
 
-   if( !m_response_fifo.empty() ) {
-       mem_fetch *mf = m_response_fifo.front();
-       if (mf->get_access_type() == TEXTURE_ACC_R) {
-           if (m_L1T->fill_port_free()) {
-               m_L1T->fill(mf,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
-               m_response_fifo.pop_front(); 
-           }
-       } else if (mf->get_access_type() == CONST_ACC_R)  {
-           if (m_L1C->fill_port_free()) {
-               mf->set_status(IN_SHADER_FETCHED,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
-               m_L1C->fill(mf,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
-               m_response_fifo.pop_front(); 
-           }
-       } else {
-    	   if( mf->get_type() == WRITE_ACK || ( m_config->gpgpu_perfect_mem && mf->get_is_write() )) {
-               m_core->store_ack(mf);
-               m_response_fifo.pop_front();
-               delete mf;
-           } else {
-               assert( !mf->get_is_write() ); // L1 cache is write evict, allocate line on load miss only
-
-               bool bypassL1D = false; 
-               if ( CACHE_GLOBAL == mf->get_inst().cache_op || (m_L1D == NULL) ) {
-                   bypassL1D = true; 
-               } else if (mf->get_access_type() == GLOBAL_ACC_R || mf->get_access_type() == GLOBAL_ACC_W) { // global memory access 
-                   if (m_core->get_config()->gmem_skip_L1D)
-                       bypassL1D = true; 
-               }
-               if( bypassL1D ) {
-                   if ( m_next_global == NULL ) {
-                       mf->set_status(IN_SHADER_FETCHED,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
-                       m_response_fifo.pop_front();
-                       m_next_global = mf;
-                   }
-               } else {
-                   if (m_L1D->fill_port_free()) {
-                       m_L1D->fill(mf,m_core->get_gpu()->gpu_sim_cycle+m_core->get_gpu()->gpu_tot_sim_cycle);
-                       m_response_fifo.pop_front();
-                   }
-               }
-           }
-       }
-   }
-
-   m_L1T->cycle();
-   m_L1C->cycle();
-   if( m_L1D ) {
-	   m_L1D->cycle();
-	   if(m_config->m_L1D_config.l1_latency > 0)
-	   		L1_latency_queue_cycle();
-   }
-
-   warp_inst_t &pipe_reg = *m_dispatch_reg;
-   enum mem_stage_stall_type rc_fail = NO_RC_FAIL;
-   mem_stage_access_type type;
-   bool done = true;
-   done &= shared_cycle(pipe_reg, rc_fail, type);
-   done &= constant_cycle(pipe_reg, rc_fail, type);
-   done &= texture_cycle(pipe_reg, rc_fail, type);
-   done &= memory_cycle(pipe_reg, rc_fail, type);
-   m_mem_rc = rc_fail;
-
-   if (!done) { // log stall types and return
-      assert(rc_fail != NO_RC_FAIL);
-      m_stats->gpgpu_n_stall_shd_mem++;
-      m_stats->gpu_stall_shd_mem_breakdown[type][rc_fail]++;
-      return;
-   }
-
-   if( !pipe_reg.empty() ) {
-       unsigned warp_id = pipe_reg.warp_id();
-       if( pipe_reg.is_load() ) {
-           if( pipe_reg.space.get_type() == shared_space ) {
-               if( m_pipeline_reg[m_config->smem_latency-1]->empty() ) {
-                   // new shared memory request
-                   move_warp(m_pipeline_reg[m_config->smem_latency-1],m_dispatch_reg);
-                   m_dispatch_reg->clear();
-               }
-           } else {
-               //if( pipe_reg.active_count() > 0 ) {
-               //    if( !m_operand_collector->writeback(pipe_reg) ) 
-               //        return;
-               //} 
-
-               bool pending_requests=false;
-               for( unsigned r=0; r<MAX_OUTPUT_VALUES; r++ ) {
-                   unsigned reg_id = pipe_reg.out[r];
-                   if( reg_id > 0 ) {
-                       if( m_pending_writes[warp_id].find(reg_id) != m_pending_writes[warp_id].end() ) {
-                           if ( m_pending_writes[warp_id][reg_id] > 0 ) {
-                               pending_requests=true;
-                               break;
-                           } else {
-                               // this instruction is done already
-                               m_pending_writes[warp_id].erase(reg_id); 
-                           }
-                       }
-                   }
-               }
-               if( !pending_requests ) {
-                   m_core->warp_inst_complete(*m_dispatch_reg);
-                   m_scoreboard->releaseRegisters(m_dispatch_reg);
-               }
-               m_core->dec_inst_in_pipeline(warp_id);
-               m_dispatch_reg->clear();
-           }
-       } else {
-           // stores exit pipeline here
-           m_core->dec_inst_in_pipeline(warp_id);
-           m_core->warp_inst_complete(*m_dispatch_reg);
-           m_dispatch_reg->clear();
-       }
-   }
-}
-
-void shader_core_ctx::register_cta_thread_exit( unsigned cta_num, kernel_info_t * kernel)
-{
-   assert( m_cta_status[cta_num] > 0 );
-   m_cta_status[cta_num]--;
-   if (!m_cta_status[cta_num]) {
-      m_n_active_cta--;
-      m_barriers.deallocate_barrier(cta_num);
-      shader_CTA_count_unlog(m_sid, 1);
-
-     SHADER_DPRINTF(LIVENESS, "GPGPU-Sim uArch: Finished CTA #%u (%lld,%lld), %u CTAs running\n",
-        cta_num, m_gpu->gpu_sim_cycle, m_gpu->gpu_tot_sim_cycle, m_n_active_cta);
-
-      if( m_n_active_cta == 0 ) {
-        SHADER_DPRINTF(LIVENESS, "GPGPU-Sim uArch: Empty (last released kernel %u \'%s\').\n",
-            kernel->get_uid(), kernel->name().c_str());
-          fflush(stdout);
-
-          //Shader can only be empty when no more cta are dispatched
-          if(kernel != m_kernel) {
-              assert(m_kernel == NULL || !m_gpu->kernel_more_cta_left(m_kernel));
-          }
-          m_kernel = NULL;
+  if (!m_response_fifo.empty()) {
+    mem_fetch *mf = m_response_fifo.front();
+    if (mf->get_access_type() == TEXTURE_ACC_R) {
+      if (m_L1T->fill_port_free()) {
+        m_L1T->fill(mf, m_core->get_gpu()->gpu_sim_cycle +
+                            m_core->get_gpu()->gpu_tot_sim_cycle);
+        m_response_fifo.pop_front();
       }
-
-      //Jin: for concurrent kernels on sm
-      release_shader_resource_1block(cta_num, *kernel);
-      kernel->dec_running();
-      if( !m_gpu->kernel_more_cta_left(kernel) ) {
-          if( !kernel->running() ) {
-              SHADER_DPRINTF(LIVENESS,
-                "GPGPU-Sim uArch: GPU detected kernel %u \'%s\' finished on shader %u.\n", kernel->get_uid(),
-                kernel->name().c_str(), m_sid);
-
-              if(m_kernel == kernel)
-                m_kernel = NULL;
-              m_gpu->set_kernel_done( kernel );
-          }
+    } else if (mf->get_access_type() == CONST_ACC_R) {
+      if (m_L1C->fill_port_free()) {
+        mf->set_status(IN_SHADER_FETCHED,
+                       m_core->get_gpu()->gpu_sim_cycle +
+                           m_core->get_gpu()->gpu_tot_sim_cycle);
+        m_L1C->fill(mf, m_core->get_gpu()->gpu_sim_cycle +
+                            m_core->get_gpu()->gpu_tot_sim_cycle);
+        m_response_fifo.pop_front();
       }
-
-   }
-}
-
-void gpgpu_sim::shader_print_runtime_stat( FILE *fout ) 
-{
-    /*
-   fprintf(fout, "SHD_INSN: ");
-   for (unsigned i=0;i<m_n_shader;i++) 
-      fprintf(fout, "%u ",m_sc[i]->get_num_sim_insn());
-   fprintf(fout, "\n");
-   fprintf(fout, "SHD_THDS: ");
-   for (unsigned i=0;i<m_n_shader;i++) 
-      fprintf(fout, "%u ",m_sc[i]->get_not_completed());
-   fprintf(fout, "\n");
-   fprintf(fout, "SHD_DIVG: ");
-   for (unsigned i=0;i<m_n_shader;i++) 
-      fprintf(fout, "%u ",m_sc[i]->get_n_diverge());
-   fprintf(fout, "\n");
-
-   fprintf(fout, "THD_INSN: ");
-   for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) 
-      fprintf(fout, "%d ", m_sc[0]->get_thread_n_insn(i) );
-   fprintf(fout, "\n");
-   */
-}
-
-
-void gpgpu_sim::shader_print_scheduler_stat( FILE* fout, bool print_dynamic_info ) const
-{
-    // Print out the stats from the sampling shader core
-    const unsigned scheduler_sampling_core = m_shader_config->gpgpu_warp_issue_shader;
-    #define STR_SIZE 55
-    char name_buff[ STR_SIZE ];
-    name_buff[ STR_SIZE - 1 ] = '\0';
-    const std::vector< unsigned >& distro
-        = print_dynamic_info ?
-          m_shader_stats->get_dynamic_warp_issue()[ scheduler_sampling_core ] :
-          m_shader_stats->get_warp_slot_issue()[ scheduler_sampling_core ];
-    if ( print_dynamic_info ) {
-        snprintf( name_buff, STR_SIZE - 1, "dynamic_warp_id" );
     } else {
-        snprintf( name_buff, STR_SIZE - 1, "warp_id" );
-    }
-    fprintf( fout,
-             "Shader %d %s issue ditsribution:\n",
-             scheduler_sampling_core,
-             name_buff );
-    const unsigned num_warp_ids = distro.size();
-    // First print out the warp ids
-    fprintf( fout, "%s:\n", name_buff );
-    for ( unsigned warp_id = 0;
-          warp_id < num_warp_ids;
-          ++warp_id  ) {
-        fprintf( fout, "%d, ", warp_id );
-    }
+      if (mf->get_type() == WRITE_ACK ||
+          (m_config->gpgpu_perfect_mem && mf->get_is_write())) {
+        m_core->store_ack(mf);
+        m_response_fifo.pop_front();
+        delete mf;
+      } else {
+        assert(!mf->get_is_write());  // L1 cache is write evict, allocate line
+                                      // on load miss only
 
-    fprintf( fout, "\ndistro:\n" );
-    // Then print out the distribution of instuctions issued
-    for ( std::vector< unsigned >::const_iterator iter = distro.begin();
-          iter != distro.end();
-          iter++ ) {
-        fprintf( fout, "%d, ", *iter );
+        bool bypassL1D = false;
+        if (CACHE_GLOBAL == mf->get_inst().cache_op || (m_L1D == NULL)) {
+          bypassL1D = true;
+        } else if (mf->get_access_type() == GLOBAL_ACC_R ||
+                   mf->get_access_type() ==
+                       GLOBAL_ACC_W) {  // global memory access
+          if (m_core->get_config()->gmem_skip_L1D) bypassL1D = true;
+        }
+        if (bypassL1D) {
+          if (m_next_global == NULL) {
+            mf->set_status(IN_SHADER_FETCHED,
+                           m_core->get_gpu()->gpu_sim_cycle +
+                               m_core->get_gpu()->gpu_tot_sim_cycle);
+            m_response_fifo.pop_front();
+            m_next_global = mf;
+          }
+        } else {
+          if (m_L1D->fill_port_free()) {
+            m_L1D->fill(mf, m_core->get_gpu()->gpu_sim_cycle +
+                                m_core->get_gpu()->gpu_tot_sim_cycle);
+            m_response_fifo.pop_front();
+          }
+        }
+      }
     }
-    fprintf( fout, "\n" );
+  }
+
+  m_L1T->cycle();
+  m_L1C->cycle();
+  if (m_L1D) {
+    m_L1D->cycle();
+    if (m_config->m_L1D_config.l1_latency > 0) L1_latency_queue_cycle();
+  }
+
+  warp_inst_t &pipe_reg = *m_dispatch_reg;
+  enum mem_stage_stall_type rc_fail = NO_RC_FAIL;
+  mem_stage_access_type type;
+  bool done = true;
+  done &= shared_cycle(pipe_reg, rc_fail, type);
+  done &= constant_cycle(pipe_reg, rc_fail, type);
+  done &= texture_cycle(pipe_reg, rc_fail, type);
+  done &= memory_cycle(pipe_reg, rc_fail, type);
+  m_mem_rc = rc_fail;
+
+  if (!done) {  // log stall types and return
+    assert(rc_fail != NO_RC_FAIL);
+    m_stats->gpgpu_n_stall_shd_mem++;
+    m_stats->gpu_stall_shd_mem_breakdown[type][rc_fail]++;
+    return;
+  }
+
+  if (!pipe_reg.empty()) {
+    unsigned warp_id = pipe_reg.warp_id();
+    if (pipe_reg.is_load()) {
+      if (pipe_reg.space.get_type() == shared_space) {
+        if (m_pipeline_reg[m_config->smem_latency - 1]->empty()) {
+          // new shared memory request
+          move_warp(m_pipeline_reg[m_config->smem_latency - 1], m_dispatch_reg);
+          m_dispatch_reg->clear();
+        }
+      } else {
+        // if( pipe_reg.active_count() > 0 ) {
+        //    if( !m_operand_collector->writeback(pipe_reg) )
+        //        return;
+        //}
+
+        bool pending_requests = false;
+        for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++) {
+          unsigned reg_id = pipe_reg.out[r];
+          if (reg_id > 0) {
+            if (m_pending_writes[warp_id].find(reg_id) !=
+                m_pending_writes[warp_id].end()) {
+              if (m_pending_writes[warp_id][reg_id] > 0) {
+                pending_requests = true;
+                break;
+              } else {
+                // this instruction is done already
+                m_pending_writes[warp_id].erase(reg_id);
+              }
+            }
+          }
+        }
+        if (!pending_requests) {
+          m_core->warp_inst_complete(*m_dispatch_reg);
+          m_scoreboard->releaseRegisters(m_dispatch_reg);
+        }
+        m_core->dec_inst_in_pipeline(warp_id);
+        m_dispatch_reg->clear();
+      }
+    } else {
+      // stores exit pipeline here
+      m_core->dec_inst_in_pipeline(warp_id);
+      m_core->warp_inst_complete(*m_dispatch_reg);
+      m_dispatch_reg->clear();
+    }
+  }
 }
 
-void gpgpu_sim::shader_print_cache_stats( FILE *fout ) const{
+void shader_core_ctx::register_cta_thread_exit(unsigned cta_num,
+                                               kernel_info_t *kernel) {
+  assert(m_cta_status[cta_num] > 0);
+  m_cta_status[cta_num]--;
+  if (!m_cta_status[cta_num]) {
+    m_n_active_cta--;
+    m_barriers.deallocate_barrier(cta_num);
+    shader_CTA_count_unlog(m_sid, 1);
 
-    // L1I
-    struct cache_sub_stats total_css;
-    struct cache_sub_stats css;
+    SHADER_DPRINTF(
+        LIVENESS,
+        "GPGPU-Sim uArch: Finished CTA #%u (%lld,%lld), %u CTAs running\n",
+        cta_num, m_gpu->gpu_sim_cycle, m_gpu->gpu_tot_sim_cycle,
+        m_n_active_cta);
 
-    if(!m_shader_config->m_L1I_config.disabled()){
-        total_css.clear();
-        css.clear();
-        fprintf(fout, "\n========= Core cache stats =========\n");
-        fprintf(fout, "L1I_cache:\n");
-        for ( unsigned i = 0; i < m_shader_config->n_simt_clusters; ++i ) {
-            m_cluster[i]->get_L1I_sub_stats(css);
-            total_css += css;
-        }
-        fprintf(fout, "\tL1I_total_cache_accesses = %llu\n", total_css.accesses);
-        fprintf(fout, "\tL1I_total_cache_misses = %llu\n", total_css.misses);
-        if(total_css.accesses > 0){
-            fprintf(fout, "\tL1I_total_cache_miss_rate = %.4lf\n", (double)total_css.misses / (double)total_css.accesses);
-        }
-        fprintf(fout, "\tL1I_total_cache_pending_hits = %llu\n", total_css.pending_hits);
-        fprintf(fout, "\tL1I_total_cache_reservation_fails = %llu\n", total_css.res_fails);
+    if (m_n_active_cta == 0) {
+      SHADER_DPRINTF(
+          LIVENESS,
+          "GPGPU-Sim uArch: Empty (last released kernel %u \'%s\').\n",
+          kernel->get_uid(), kernel->name().c_str());
+      fflush(stdout);
+
+      // Shader can only be empty when no more cta are dispatched
+      if (kernel != m_kernel) {
+        assert(m_kernel == NULL || !m_gpu->kernel_more_cta_left(m_kernel));
+      }
+      m_kernel = NULL;
     }
 
-    // L1D
-    if(!m_shader_config->m_L1D_config.disabled()){
-        total_css.clear();
-        css.clear();
-        fprintf(fout, "L1D_cache:\n");
-        for (unsigned i=0;i<m_shader_config->n_simt_clusters;i++){
-            m_cluster[i]->get_L1D_sub_stats(css);
+    // Jin: for concurrent kernels on sm
+    release_shader_resource_1block(cta_num, *kernel);
+    kernel->dec_running();
+    if (!m_gpu->kernel_more_cta_left(kernel)) {
+      if (!kernel->running()) {
+        SHADER_DPRINTF(LIVENESS,
+                       "GPGPU-Sim uArch: GPU detected kernel %u \'%s\' "
+                       "finished on shader %u.\n",
+                       kernel->get_uid(), kernel->name().c_str(), m_sid);
 
-            fprintf( stdout, "\tL1D_cache_core[%d]: Access = %llu, Miss = %llu, Miss_rate = %.3lf, Pending_hits = %llu, Reservation_fails = %llu\n",
-                     i, css.accesses, css.misses, (double)css.misses / (double)css.accesses, css.pending_hits, css.res_fails);
-
-            total_css += css;
-        }
-        fprintf(fout, "\tL1D_total_cache_accesses = %llu\n", total_css.accesses);
-        fprintf(fout, "\tL1D_total_cache_misses = %llu\n", total_css.misses);
-        if(total_css.accesses > 0){
-            fprintf(fout, "\tL1D_total_cache_miss_rate = %.4lf\n", (double)total_css.misses / (double)total_css.accesses);
-        }
-        fprintf(fout, "\tL1D_total_cache_pending_hits = %llu\n", total_css.pending_hits);
-        fprintf(fout, "\tL1D_total_cache_reservation_fails = %llu\n", total_css.res_fails);
-        total_css.print_port_stats(fout, "\tL1D_cache"); 
+        if (m_kernel == kernel) m_kernel = NULL;
+        m_gpu->set_kernel_done(kernel);
+      }
     }
-
-    // L1C
-    if(!m_shader_config->m_L1C_config.disabled()){
-        total_css.clear();
-        css.clear();
-        fprintf(fout, "L1C_cache:\n");
-        for ( unsigned i = 0; i < m_shader_config->n_simt_clusters; ++i ) {
-            m_cluster[i]->get_L1C_sub_stats(css);
-            total_css += css;
-        }
-        fprintf(fout, "\tL1C_total_cache_accesses = %llu\n", total_css.accesses);
-        fprintf(fout, "\tL1C_total_cache_misses = %llu\n", total_css.misses);
-        if(total_css.accesses > 0){
-            fprintf(fout, "\tL1C_total_cache_miss_rate = %.4lf\n", (double)total_css.misses / (double)total_css.accesses);
-        }
-        fprintf(fout, "\tL1C_total_cache_pending_hits = %llu\n", total_css.pending_hits);
-        fprintf(fout, "\tL1C_total_cache_reservation_fails = %llu\n", total_css.res_fails);
-    }
-
-    // L1T
-    if(!m_shader_config->m_L1T_config.disabled()){
-        total_css.clear();
-        css.clear();
-        fprintf(fout, "L1T_cache:\n");
-        for ( unsigned i = 0; i < m_shader_config->n_simt_clusters; ++i ) {
-            m_cluster[i]->get_L1T_sub_stats(css);
-            total_css += css;
-        }
-        fprintf(fout, "\tL1T_total_cache_accesses = %llu\n", total_css.accesses);
-        fprintf(fout, "\tL1T_total_cache_misses = %llu\n", total_css.misses);
-        if(total_css.accesses > 0){
-            fprintf(fout, "\tL1T_total_cache_miss_rate = %.4lf\n", (double)total_css.misses / (double)total_css.accesses);
-        }
-        fprintf(fout, "\tL1T_total_cache_pending_hits = %llu\n", total_css.pending_hits);
-        fprintf(fout, "\tL1T_total_cache_reservation_fails = %llu\n", total_css.res_fails);
-    }
+  }
 }
 
-void gpgpu_sim::shader_print_l1_miss_stat( FILE *fout ) const
-{
-   unsigned total_d1_misses = 0, total_d1_accesses = 0;
-   for ( unsigned i = 0; i < m_shader_config->n_simt_clusters; ++i ) {
-         unsigned custer_d1_misses = 0, cluster_d1_accesses = 0;
-         m_cluster[ i ]->print_cache_stats( fout, cluster_d1_accesses, custer_d1_misses );
-         total_d1_misses += custer_d1_misses;
-         total_d1_accesses += cluster_d1_accesses;
-   }
-   fprintf( fout, "total_dl1_misses=%d\n", total_d1_misses );
-   fprintf( fout, "total_dl1_accesses=%d\n", total_d1_accesses );
-   fprintf( fout, "total_dl1_miss_rate= %f\n", (float)total_d1_misses / (float)total_d1_accesses );
-   /*
-   fprintf(fout, "THD_INSN_AC: ");
-   for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) 
-      fprintf(fout, "%d ", m_sc[0]->get_thread_n_insn_ac(i));
-   fprintf(fout, "\n");
-   fprintf(fout, "T_L1_Mss: "); //l1 miss rate per thread
-   for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) 
-      fprintf(fout, "%d ", m_sc[0]->get_thread_n_l1_mis_ac(i));
-   fprintf(fout, "\n");
-   fprintf(fout, "T_L1_Mgs: "); //l1 merged miss rate per thread
-   for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) 
-      fprintf(fout, "%d ", m_sc[0]->get_thread_n_l1_mis_ac(i) - m_sc[0]->get_thread_n_l1_mrghit_ac(i));
-   fprintf(fout, "\n");
-   fprintf(fout, "T_L1_Acc: "); //l1 access per thread
-   for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) 
-      fprintf(fout, "%d ", m_sc[0]->get_thread_n_l1_access_ac(i));
-   fprintf(fout, "\n");
+void gpgpu_sim::shader_print_runtime_stat(FILE *fout) {
+  /*
+ fprintf(fout, "SHD_INSN: ");
+ for (unsigned i=0;i<m_n_shader;i++)
+    fprintf(fout, "%u ",m_sc[i]->get_num_sim_insn());
+ fprintf(fout, "\n");
+ fprintf(fout, "SHD_THDS: ");
+ for (unsigned i=0;i<m_n_shader;i++)
+    fprintf(fout, "%u ",m_sc[i]->get_not_completed());
+ fprintf(fout, "\n");
+ fprintf(fout, "SHD_DIVG: ");
+ for (unsigned i=0;i<m_n_shader;i++)
+    fprintf(fout, "%u ",m_sc[i]->get_n_diverge());
+ fprintf(fout, "\n");
 
-   //per warp
-   int temp =0; 
-   fprintf(fout, "W_L1_Mss: "); //l1 miss rate per warp
-   for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) {
-      temp += m_sc[0]->get_thread_n_l1_mis_ac(i);
-      if (i%m_shader_config->warp_size == (unsigned)(m_shader_config->warp_size-1)) {
-         fprintf(fout, "%d ", temp);
-         temp = 0;
-      }
-   }
-   fprintf(fout, "\n");
-   temp=0;
-   fprintf(fout, "W_L1_Mgs: "); //l1 merged miss rate per warp
-   for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) {
-      temp += (m_sc[0]->get_thread_n_l1_mis_ac(i) - m_sc[0]->get_thread_n_l1_mrghit_ac(i) );
-      if (i%m_shader_config->warp_size == (unsigned)(m_shader_config->warp_size-1)) {
-         fprintf(fout, "%d ", temp);
-         temp = 0;
-      }
-   }
-   fprintf(fout, "\n");
-   temp =0;
-   fprintf(fout, "W_L1_Acc: "); //l1 access per warp
-   for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) {
-      temp += m_sc[0]->get_thread_n_l1_access_ac(i);
-      if (i%m_shader_config->warp_size == (unsigned)(m_shader_config->warp_size-1)) {
-         fprintf(fout, "%d ", temp);
-         temp = 0;
-      }
-   }
-   fprintf(fout, "\n");
-   */
+ fprintf(fout, "THD_INSN: ");
+ for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++)
+    fprintf(fout, "%d ", m_sc[0]->get_thread_n_insn(i) );
+ fprintf(fout, "\n");
+ */
 }
 
-void warp_inst_t::print( FILE *fout ) const
-{
-    if (empty() ) {
-        fprintf(fout,"bubble\n" );
-        return;
-    } else 
-        fprintf(fout,"0x%04x ", pc );
-    fprintf(fout, "w%02d[", m_warp_id);
-    for (unsigned j=0; j<m_config->warp_size; j++)
-        fprintf(fout, "%c", (active(j)?'1':'0') );
-    fprintf(fout, "]: ");
-    m_config->gpgpu_ctx->func_sim->ptx_print_insn( pc, fout );
+void gpgpu_sim::shader_print_scheduler_stat(FILE *fout,
+                                            bool print_dynamic_info) const {
+  // Print out the stats from the sampling shader core
+  const unsigned scheduler_sampling_core =
+      m_shader_config->gpgpu_warp_issue_shader;
+#define STR_SIZE 55
+  char name_buff[STR_SIZE];
+  name_buff[STR_SIZE - 1] = '\0';
+  const std::vector<unsigned> &distro =
+      print_dynamic_info
+          ? m_shader_stats->get_dynamic_warp_issue()[scheduler_sampling_core]
+          : m_shader_stats->get_warp_slot_issue()[scheduler_sampling_core];
+  if (print_dynamic_info) {
+    snprintf(name_buff, STR_SIZE - 1, "dynamic_warp_id");
+  } else {
+    snprintf(name_buff, STR_SIZE - 1, "warp_id");
+  }
+  fprintf(fout, "Shader %d %s issue ditsribution:\n", scheduler_sampling_core,
+          name_buff);
+  const unsigned num_warp_ids = distro.size();
+  // First print out the warp ids
+  fprintf(fout, "%s:\n", name_buff);
+  for (unsigned warp_id = 0; warp_id < num_warp_ids; ++warp_id) {
+    fprintf(fout, "%d, ", warp_id);
+  }
+
+  fprintf(fout, "\ndistro:\n");
+  // Then print out the distribution of instuctions issued
+  for (std::vector<unsigned>::const_iterator iter = distro.begin();
+       iter != distro.end(); iter++) {
+    fprintf(fout, "%d, ", *iter);
+  }
+  fprintf(fout, "\n");
+}
+
+void gpgpu_sim::shader_print_cache_stats(FILE *fout) const {
+  // L1I
+  struct cache_sub_stats total_css;
+  struct cache_sub_stats css;
+
+  if (!m_shader_config->m_L1I_config.disabled()) {
+    total_css.clear();
+    css.clear();
+    fprintf(fout, "\n========= Core cache stats =========\n");
+    fprintf(fout, "L1I_cache:\n");
+    for (unsigned i = 0; i < m_shader_config->n_simt_clusters; ++i) {
+      m_cluster[i]->get_L1I_sub_stats(css);
+      total_css += css;
+    }
+    fprintf(fout, "\tL1I_total_cache_accesses = %llu\n", total_css.accesses);
+    fprintf(fout, "\tL1I_total_cache_misses = %llu\n", total_css.misses);
+    if (total_css.accesses > 0) {
+      fprintf(fout, "\tL1I_total_cache_miss_rate = %.4lf\n",
+              (double)total_css.misses / (double)total_css.accesses);
+    }
+    fprintf(fout, "\tL1I_total_cache_pending_hits = %llu\n",
+            total_css.pending_hits);
+    fprintf(fout, "\tL1I_total_cache_reservation_fails = %llu\n",
+            total_css.res_fails);
+  }
+
+  // L1D
+  if (!m_shader_config->m_L1D_config.disabled()) {
+    total_css.clear();
+    css.clear();
+    fprintf(fout, "L1D_cache:\n");
+    for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++) {
+      m_cluster[i]->get_L1D_sub_stats(css);
+
+      fprintf(stdout,
+              "\tL1D_cache_core[%d]: Access = %llu, Miss = %llu, Miss_rate = "
+              "%.3lf, Pending_hits = %llu, Reservation_fails = %llu\n",
+              i, css.accesses, css.misses,
+              (double)css.misses / (double)css.accesses, css.pending_hits,
+              css.res_fails);
+
+      total_css += css;
+    }
+    fprintf(fout, "\tL1D_total_cache_accesses = %llu\n", total_css.accesses);
+    fprintf(fout, "\tL1D_total_cache_misses = %llu\n", total_css.misses);
+    if (total_css.accesses > 0) {
+      fprintf(fout, "\tL1D_total_cache_miss_rate = %.4lf\n",
+              (double)total_css.misses / (double)total_css.accesses);
+    }
+    fprintf(fout, "\tL1D_total_cache_pending_hits = %llu\n",
+            total_css.pending_hits);
+    fprintf(fout, "\tL1D_total_cache_reservation_fails = %llu\n",
+            total_css.res_fails);
+    total_css.print_port_stats(fout, "\tL1D_cache");
+  }
+
+  // L1C
+  if (!m_shader_config->m_L1C_config.disabled()) {
+    total_css.clear();
+    css.clear();
+    fprintf(fout, "L1C_cache:\n");
+    for (unsigned i = 0; i < m_shader_config->n_simt_clusters; ++i) {
+      m_cluster[i]->get_L1C_sub_stats(css);
+      total_css += css;
+    }
+    fprintf(fout, "\tL1C_total_cache_accesses = %llu\n", total_css.accesses);
+    fprintf(fout, "\tL1C_total_cache_misses = %llu\n", total_css.misses);
+    if (total_css.accesses > 0) {
+      fprintf(fout, "\tL1C_total_cache_miss_rate = %.4lf\n",
+              (double)total_css.misses / (double)total_css.accesses);
+    }
+    fprintf(fout, "\tL1C_total_cache_pending_hits = %llu\n",
+            total_css.pending_hits);
+    fprintf(fout, "\tL1C_total_cache_reservation_fails = %llu\n",
+            total_css.res_fails);
+  }
+
+  // L1T
+  if (!m_shader_config->m_L1T_config.disabled()) {
+    total_css.clear();
+    css.clear();
+    fprintf(fout, "L1T_cache:\n");
+    for (unsigned i = 0; i < m_shader_config->n_simt_clusters; ++i) {
+      m_cluster[i]->get_L1T_sub_stats(css);
+      total_css += css;
+    }
+    fprintf(fout, "\tL1T_total_cache_accesses = %llu\n", total_css.accesses);
+    fprintf(fout, "\tL1T_total_cache_misses = %llu\n", total_css.misses);
+    if (total_css.accesses > 0) {
+      fprintf(fout, "\tL1T_total_cache_miss_rate = %.4lf\n",
+              (double)total_css.misses / (double)total_css.accesses);
+    }
+    fprintf(fout, "\tL1T_total_cache_pending_hits = %llu\n",
+            total_css.pending_hits);
+    fprintf(fout, "\tL1T_total_cache_reservation_fails = %llu\n",
+            total_css.res_fails);
+  }
+}
+
+void gpgpu_sim::shader_print_l1_miss_stat(FILE *fout) const {
+  unsigned total_d1_misses = 0, total_d1_accesses = 0;
+  for (unsigned i = 0; i < m_shader_config->n_simt_clusters; ++i) {
+    unsigned custer_d1_misses = 0, cluster_d1_accesses = 0;
+    m_cluster[i]->print_cache_stats(fout, cluster_d1_accesses,
+                                    custer_d1_misses);
+    total_d1_misses += custer_d1_misses;
+    total_d1_accesses += cluster_d1_accesses;
+  }
+  fprintf(fout, "total_dl1_misses=%d\n", total_d1_misses);
+  fprintf(fout, "total_dl1_accesses=%d\n", total_d1_accesses);
+  fprintf(fout, "total_dl1_miss_rate= %f\n",
+          (float)total_d1_misses / (float)total_d1_accesses);
+  /*
+  fprintf(fout, "THD_INSN_AC: ");
+  for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++)
+     fprintf(fout, "%d ", m_sc[0]->get_thread_n_insn_ac(i));
+  fprintf(fout, "\n");
+  fprintf(fout, "T_L1_Mss: "); //l1 miss rate per thread
+  for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++)
+     fprintf(fout, "%d ", m_sc[0]->get_thread_n_l1_mis_ac(i));
+  fprintf(fout, "\n");
+  fprintf(fout, "T_L1_Mgs: "); //l1 merged miss rate per thread
+  for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++)
+     fprintf(fout, "%d ", m_sc[0]->get_thread_n_l1_mis_ac(i) -
+  m_sc[0]->get_thread_n_l1_mrghit_ac(i)); fprintf(fout, "\n"); fprintf(fout,
+  "T_L1_Acc: "); //l1 access per thread for (unsigned i=0;
+  i<m_shader_config->n_thread_per_shader; i++) fprintf(fout, "%d ",
+  m_sc[0]->get_thread_n_l1_access_ac(i)); fprintf(fout, "\n");
+
+  //per warp
+  int temp =0;
+  fprintf(fout, "W_L1_Mss: "); //l1 miss rate per warp
+  for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) {
+     temp += m_sc[0]->get_thread_n_l1_mis_ac(i);
+     if (i%m_shader_config->warp_size ==
+  (unsigned)(m_shader_config->warp_size-1)) { fprintf(fout, "%d ", temp); temp =
+  0;
+     }
+  }
+  fprintf(fout, "\n");
+  temp=0;
+  fprintf(fout, "W_L1_Mgs: "); //l1 merged miss rate per warp
+  for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) {
+     temp += (m_sc[0]->get_thread_n_l1_mis_ac(i) -
+  m_sc[0]->get_thread_n_l1_mrghit_ac(i) ); if (i%m_shader_config->warp_size ==
+  (unsigned)(m_shader_config->warp_size-1)) { fprintf(fout, "%d ", temp); temp =
+  0;
+     }
+  }
+  fprintf(fout, "\n");
+  temp =0;
+  fprintf(fout, "W_L1_Acc: "); //l1 access per warp
+  for (unsigned i=0; i<m_shader_config->n_thread_per_shader; i++) {
+     temp += m_sc[0]->get_thread_n_l1_access_ac(i);
+     if (i%m_shader_config->warp_size ==
+  (unsigned)(m_shader_config->warp_size-1)) { fprintf(fout, "%d ", temp); temp =
+  0;
+     }
+  }
+  fprintf(fout, "\n");
+  */
+}
+
+void warp_inst_t::print(FILE *fout) const {
+  if (empty()) {
+    fprintf(fout, "bubble\n");
+    return;
+  } else
+    fprintf(fout, "0x%04x ", pc);
+  fprintf(fout, "w%02d[", m_warp_id);
+  for (unsigned j = 0; j < m_config->warp_size; j++)
+    fprintf(fout, "%c", (active(j) ? '1' : '0'));
+  fprintf(fout, "]: ");
+  m_config->gpgpu_ctx->func_sim->ptx_print_insn(pc, fout);
+  fprintf(fout, "\n");
+}
+void shader_core_ctx::incexecstat(warp_inst_t *&inst) {
+  if (inst->mem_op == TEX) inctex_stat(inst->active_count(), 1);
+
+  // Latency numbers for next operations are used to scale the power values
+  // for special operations, according observations from microbenchmarking
+  // TODO: put these numbers in the xml configuration
+
+  switch (inst->sp_op) {
+    case INT__OP:
+      incialu_stat(inst->active_count(), 32);
+      break;
+    case INT_MUL_OP:
+      incimul_stat(inst->active_count(), 7.2);
+      break;
+    case INT_MUL24_OP:
+      incimul24_stat(inst->active_count(), 4.2);
+      break;
+    case INT_MUL32_OP:
+      incimul32_stat(inst->active_count(), 4);
+      break;
+    case INT_DIV_OP:
+      incidiv_stat(inst->active_count(), 40);
+      break;
+    case FP__OP:
+      incfpalu_stat(inst->active_count(), 1);
+      break;
+    case FP_MUL_OP:
+      incfpmul_stat(inst->active_count(), 1.8);
+      break;
+    case FP_DIV_OP:
+      incfpdiv_stat(inst->active_count(), 48);
+      break;
+    case FP_SQRT_OP:
+      inctrans_stat(inst->active_count(), 25);
+      break;
+    case FP_LG_OP:
+      inctrans_stat(inst->active_count(), 35);
+      break;
+    case FP_SIN_OP:
+      inctrans_stat(inst->active_count(), 12);
+      break;
+    case FP_EXP_OP:
+      inctrans_stat(inst->active_count(), 35);
+      break;
+    default:
+      break;
+  }
+}
+void shader_core_ctx::print_stage(unsigned int stage, FILE *fout) const {
+  m_pipeline_reg[stage].print(fout);
+  // m_pipeline_reg[stage].print(fout);
+}
+
+void shader_core_ctx::display_simt_state(FILE *fout, int mask) const {
+  if ((mask & 4) && m_config->model == POST_DOMINATOR) {
+    fprintf(fout, "per warp SIMT control-flow state:\n");
+    unsigned n = m_config->n_thread_per_shader / m_config->warp_size;
+    for (unsigned i = 0; i < n; i++) {
+      unsigned nactive = 0;
+      for (unsigned j = 0; j < m_config->warp_size; j++) {
+        unsigned tid = i * m_config->warp_size + j;
+        int done = ptx_thread_done(tid);
+        nactive += (ptx_thread_done(tid) ? 0 : 1);
+        if (done && (mask & 8)) {
+          unsigned done_cycle = m_thread[tid]->donecycle();
+          if (done_cycle) {
+            printf("\n w%02u:t%03u: done @ cycle %u", i, tid, done_cycle);
+          }
+        }
+      }
+      if (nactive == 0) {
+        continue;
+      }
+      m_simt_stack[i]->print(fout);
+    }
     fprintf(fout, "\n");
-}
-void shader_core_ctx::incexecstat(warp_inst_t *&inst)
-{
-	if(inst->mem_op==TEX)
-		inctex_stat(inst->active_count(),1);
-
-    // Latency numbers for next operations are used to scale the power values
-    // for special operations, according observations from microbenchmarking
-    // TODO: put these numbers in the xml configuration
-
-	switch(inst->sp_op){
-	case INT__OP:
-		incialu_stat(inst->active_count(),32);
-		break;
-	case INT_MUL_OP:
-		incimul_stat(inst->active_count(),7.2);
-		break;
-	case INT_MUL24_OP:
-		incimul24_stat(inst->active_count(),4.2);
-		break;
-	case INT_MUL32_OP:
-		incimul32_stat(inst->active_count(),4);
-		break;
-	case INT_DIV_OP:
-		incidiv_stat(inst->active_count(),40);
-		break;
-	case FP__OP:
-		incfpalu_stat(inst->active_count(),1);
-		break;
-	case FP_MUL_OP:
-		incfpmul_stat(inst->active_count(),1.8);
-		break;
-	case FP_DIV_OP:
-		incfpdiv_stat(inst->active_count(),48);
-		break;
-	case FP_SQRT_OP:
-		inctrans_stat(inst->active_count(),25);
-		break;
-	case FP_LG_OP:
-		inctrans_stat(inst->active_count(),35);
-		break;
-	case FP_SIN_OP:
-		inctrans_stat(inst->active_count(),12);
-		break;
-	case FP_EXP_OP:
-		inctrans_stat(inst->active_count(),35);
-		break;
-	default:
-		break;
-	}
-}
-void shader_core_ctx::print_stage(unsigned int stage, FILE *fout ) const
-{
-   m_pipeline_reg[stage].print(fout);
-   //m_pipeline_reg[stage].print(fout);
+  }
 }
 
-void shader_core_ctx::display_simt_state(FILE *fout, int mask ) const
-{
-    if ( (mask & 4) && m_config->model == POST_DOMINATOR ) {
-       fprintf(fout,"per warp SIMT control-flow state:\n");
-       unsigned n = m_config->n_thread_per_shader / m_config->warp_size;
-       for (unsigned i=0; i < n; i++) {
-          unsigned nactive = 0;
-          for (unsigned j=0; j<m_config->warp_size; j++ ) {
-             unsigned tid = i*m_config->warp_size + j;
-             int done = ptx_thread_done(tid);
-             nactive += (ptx_thread_done(tid)?0:1);
-             if ( done && (mask & 8) ) {
-                unsigned done_cycle = m_thread[tid]->donecycle();
-                if ( done_cycle ) {
-                   printf("\n w%02u:t%03u: done @ cycle %u", i, tid, done_cycle );
-                }
-             }
-          }
-          if ( nactive == 0 ) {
-             continue;
-          }
-          m_simt_stack[i]->print(fout);
-       }
-       fprintf(fout,"\n");
+void ldst_unit::print(FILE *fout) const {
+  fprintf(fout, "LD/ST unit  = ");
+  m_dispatch_reg->print(fout);
+  if (m_mem_rc != NO_RC_FAIL) {
+    fprintf(fout, "              LD/ST stall condition: ");
+    switch (m_mem_rc) {
+      case BK_CONF:
+        fprintf(fout, "BK_CONF");
+        break;
+      case MSHR_RC_FAIL:
+        fprintf(fout, "MSHR_RC_FAIL");
+        break;
+      case ICNT_RC_FAIL:
+        fprintf(fout, "ICNT_RC_FAIL");
+        break;
+      case COAL_STALL:
+        fprintf(fout, "COAL_STALL");
+        break;
+      case WB_ICNT_RC_FAIL:
+        fprintf(fout, "WB_ICNT_RC_FAIL");
+        break;
+      case WB_CACHE_RSRV_FAIL:
+        fprintf(fout, "WB_CACHE_RSRV_FAIL");
+        break;
+      case N_MEM_STAGE_STALL_TYPE:
+        fprintf(fout, "N_MEM_STAGE_STALL_TYPE");
+        break;
+      default:
+        abort();
     }
+    fprintf(fout, "\n");
+  }
+  fprintf(fout, "LD/ST wb    = ");
+  m_next_wb.print(fout);
+  fprintf(
+      fout,
+      "Last LD/ST writeback @ %llu + %llu (gpu_sim_cycle+gpu_tot_sim_cycle)\n",
+      m_last_inst_gpu_sim_cycle, m_last_inst_gpu_tot_sim_cycle);
+  fprintf(fout, "Pending register writes:\n");
+  std::map<unsigned /*warp_id*/,
+           std::map<unsigned /*regnum*/, unsigned /*count*/> >::const_iterator
+      w;
+  for (w = m_pending_writes.begin(); w != m_pending_writes.end(); w++) {
+    unsigned warp_id = w->first;
+    const std::map<unsigned /*regnum*/, unsigned /*count*/> &warp_info =
+        w->second;
+    if (warp_info.empty()) continue;
+    fprintf(fout, "  w%2u : ", warp_id);
+    std::map<unsigned /*regnum*/, unsigned /*count*/>::const_iterator r;
+    for (r = warp_info.begin(); r != warp_info.end(); ++r) {
+      fprintf(fout, "  %u(%u)", r->first, r->second);
+    }
+    fprintf(fout, "\n");
+  }
+  m_L1C->display_state(fout);
+  m_L1T->display_state(fout);
+  if (!m_config->m_L1D_config.disabled()) m_L1D->display_state(fout);
+  fprintf(fout, "LD/ST response FIFO (occupancy = %zu):\n",
+          m_response_fifo.size());
+  for (std::list<mem_fetch *>::const_iterator i = m_response_fifo.begin();
+       i != m_response_fifo.end(); i++) {
+    const mem_fetch *mf = *i;
+    mf->print(fout);
+  }
 }
 
-void ldst_unit::print(FILE *fout) const
-{
-    fprintf(fout,"LD/ST unit  = ");
-    m_dispatch_reg->print(fout);
-    if ( m_mem_rc != NO_RC_FAIL ) {
-        fprintf(fout,"              LD/ST stall condition: ");
-        switch ( m_mem_rc ) {
-        case BK_CONF:        fprintf(fout,"BK_CONF"); break;
-        case MSHR_RC_FAIL:   fprintf(fout,"MSHR_RC_FAIL"); break;
-        case ICNT_RC_FAIL:   fprintf(fout,"ICNT_RC_FAIL"); break;
-        case COAL_STALL:     fprintf(fout,"COAL_STALL"); break;
-        case WB_ICNT_RC_FAIL: fprintf(fout,"WB_ICNT_RC_FAIL"); break;
-        case WB_CACHE_RSRV_FAIL: fprintf(fout,"WB_CACHE_RSRV_FAIL"); break;
-        case N_MEM_STAGE_STALL_TYPE: fprintf(fout,"N_MEM_STAGE_STALL_TYPE"); break;
-        default: abort();
+void shader_core_ctx::display_pipeline(FILE *fout, int print_mem,
+                                       int mask) const {
+  fprintf(fout, "=================================================\n");
+  fprintf(fout, "shader %u at cycle %Lu+%Lu (%u threads running)\n", m_sid,
+          m_gpu->gpu_tot_sim_cycle, m_gpu->gpu_sim_cycle, m_not_completed);
+  fprintf(fout, "=================================================\n");
+
+  dump_warp_state(fout);
+  fprintf(fout, "\n");
+
+  m_L1I->display_state(fout);
+
+  fprintf(fout, "IF/ID       = ");
+  if (!m_inst_fetch_buffer.m_valid)
+    fprintf(fout, "bubble\n");
+  else {
+    fprintf(fout, "w%2u : pc = 0x%x, nbytes = %u\n",
+            m_inst_fetch_buffer.m_warp_id, m_inst_fetch_buffer.m_pc,
+            m_inst_fetch_buffer.m_nbytes);
+  }
+  fprintf(fout, "\nibuffer status:\n");
+  for (unsigned i = 0; i < m_config->max_warps_per_shader; i++) {
+    if (!m_warp[i].ibuffer_empty()) m_warp[i].print_ibuffer(fout);
+  }
+  fprintf(fout, "\n");
+  display_simt_state(fout, mask);
+  fprintf(fout, "-------------------------- Scoreboard\n");
+  m_scoreboard->printContents();
+  /*
+     fprintf(fout,"ID/OC (SP)  = ");
+     print_stage(ID_OC_SP, fout);
+     fprintf(fout,"ID/OC (SFU) = ");
+     print_stage(ID_OC_SFU, fout);
+     fprintf(fout,"ID/OC (MEM) = ");
+     print_stage(ID_OC_MEM, fout);
+  */
+  fprintf(fout, "-------------------------- OP COL\n");
+  m_operand_collector.dump(fout);
+  /* fprintf(fout, "OC/EX (SP)  = ");
+     print_stage(OC_EX_SP, fout);
+     fprintf(fout, "OC/EX (SFU) = ");
+     print_stage(OC_EX_SFU, fout);
+     fprintf(fout, "OC/EX (MEM) = ");
+     print_stage(OC_EX_MEM, fout);
+  */
+  fprintf(fout, "-------------------------- Pipe Regs\n");
+
+  for (unsigned i = 0; i < N_PIPELINE_STAGES; i++) {
+    fprintf(fout, "--- %s ---\n", pipeline_stage_name_decode[i]);
+    print_stage(i, fout);
+    fprintf(fout, "\n");
+  }
+
+  fprintf(fout, "-------------------------- Fu\n");
+  for (unsigned n = 0; n < m_num_function_units; n++) {
+    m_fu[n]->print(fout);
+    fprintf(fout, "---------------\n");
+  }
+  fprintf(fout, "-------------------------- other:\n");
+
+  for (unsigned i = 0; i < num_result_bus; i++) {
+    std::string bits = m_result_bus[i]->to_string();
+    fprintf(fout, "EX/WB sched[%d]= %s\n", i, bits.c_str());
+  }
+  fprintf(fout, "EX/WB      = ");
+  print_stage(EX_WB, fout);
+  fprintf(fout, "\n");
+  fprintf(
+      fout,
+      "Last EX/WB writeback @ %llu + %llu (gpu_sim_cycle+gpu_tot_sim_cycle)\n",
+      m_last_inst_gpu_sim_cycle, m_last_inst_gpu_tot_sim_cycle);
+
+  if (m_active_threads.count() <= 2 * m_config->warp_size) {
+    fprintf(fout, "Active Threads : ");
+    unsigned last_warp_id = -1;
+    for (unsigned tid = 0; tid < m_active_threads.size(); tid++) {
+      unsigned warp_id = tid / m_config->warp_size;
+      if (m_active_threads.test(tid)) {
+        if (warp_id != last_warp_id) {
+          fprintf(fout, "\n  warp %u : ", warp_id);
+          last_warp_id = warp_id;
         }
-        fprintf(fout,"\n");
+        fprintf(fout, "%u ", tid);
+      }
     }
-    fprintf(fout,"LD/ST wb    = ");
-    m_next_wb.print(fout);
-    fprintf(fout, "Last LD/ST writeback @ %llu + %llu (gpu_sim_cycle+gpu_tot_sim_cycle)\n",
-                  m_last_inst_gpu_sim_cycle, m_last_inst_gpu_tot_sim_cycle );
-    fprintf(fout,"Pending register writes:\n");
-    std::map<unsigned/*warp_id*/, std::map<unsigned/*regnum*/,unsigned/*count*/> >::const_iterator w;
-    for( w=m_pending_writes.begin(); w!=m_pending_writes.end(); w++ ) {
-        unsigned warp_id = w->first;
-        const std::map<unsigned/*regnum*/,unsigned/*count*/> &warp_info = w->second;
-        if( warp_info.empty() ) 
-            continue;
-        fprintf(fout,"  w%2u : ", warp_id );
-        std::map<unsigned/*regnum*/,unsigned/*count*/>::const_iterator r;
-        for( r=warp_info.begin(); r!=warp_info.end(); ++r ) {
-            fprintf(fout,"  %u(%u)", r->first, r->second );
-        }
-        fprintf(fout,"\n");
-    }
-    m_L1C->display_state(fout);
-    m_L1T->display_state(fout);
-    if( !m_config->m_L1D_config.disabled() )
-    	m_L1D->display_state(fout);
-    fprintf(fout,"LD/ST response FIFO (occupancy = %zu):\n", m_response_fifo.size() );
-    for( std::list<mem_fetch*>::const_iterator i=m_response_fifo.begin(); i != m_response_fifo.end(); i++ ) {
-        const mem_fetch *mf = *i;
-        mf->print(fout);
-    }
+  }
 }
 
-void shader_core_ctx::display_pipeline(FILE *fout, int print_mem, int mask ) const
-{
-   fprintf(fout, "=================================================\n");
-   fprintf(fout, "shader %u at cycle %Lu+%Lu (%u threads running)\n", m_sid, 
-           m_gpu->gpu_tot_sim_cycle, m_gpu->gpu_sim_cycle, m_not_completed);
-   fprintf(fout, "=================================================\n");
+unsigned int shader_core_config::max_cta(const kernel_info_t &k) const {
+  unsigned threads_per_cta = k.threads_per_cta();
+  const class function_info *kernel = k.entry();
+  unsigned int padded_cta_size = threads_per_cta;
+  if (padded_cta_size % warp_size)
+    padded_cta_size = ((padded_cta_size / warp_size) + 1) * (warp_size);
 
-   dump_warp_state(fout);
-   fprintf(fout,"\n");
+  // Limit by n_threads/shader
+  unsigned int result_thread = n_thread_per_shader / padded_cta_size;
 
-   m_L1I->display_state(fout);
+  const struct gpgpu_ptx_sim_info *kernel_info = ptx_sim_kernel_info(kernel);
 
-   fprintf(fout, "IF/ID       = ");
-   if( !m_inst_fetch_buffer.m_valid )
-       fprintf(fout,"bubble\n");
-   else {
-       fprintf(fout,"w%2u : pc = 0x%x, nbytes = %u\n", 
-               m_inst_fetch_buffer.m_warp_id,
-               m_inst_fetch_buffer.m_pc, 
-               m_inst_fetch_buffer.m_nbytes );
-   }
-   fprintf(fout,"\nibuffer status:\n");
-   for( unsigned i=0; i<m_config->max_warps_per_shader; i++) {
-       if( !m_warp[i].ibuffer_empty() ) 
-           m_warp[i].print_ibuffer(fout);
-   }
-   fprintf(fout,"\n");
-   display_simt_state(fout,mask);
-   fprintf(fout, "-------------------------- Scoreboard\n");
-   m_scoreboard->printContents();
-/*
-   fprintf(fout,"ID/OC (SP)  = ");
-   print_stage(ID_OC_SP, fout);
-   fprintf(fout,"ID/OC (SFU) = ");
-   print_stage(ID_OC_SFU, fout);
-   fprintf(fout,"ID/OC (MEM) = ");
-   print_stage(ID_OC_MEM, fout);
-*/
-   fprintf(fout, "-------------------------- OP COL\n");
-   m_operand_collector.dump(fout);
-/* fprintf(fout, "OC/EX (SP)  = ");
-   print_stage(OC_EX_SP, fout);
-   fprintf(fout, "OC/EX (SFU) = ");
-   print_stage(OC_EX_SFU, fout);
-   fprintf(fout, "OC/EX (MEM) = ");
-   print_stage(OC_EX_MEM, fout);
-*/
-   fprintf(fout, "-------------------------- Pipe Regs\n");
+  // Limit by shmem/shader
+  unsigned int result_shmem = (unsigned)-1;
+  if (kernel_info->smem > 0)
+    result_shmem = gpgpu_shmem_size / kernel_info->smem;
 
-   for (unsigned i = 0; i < N_PIPELINE_STAGES; i++) {
-       fprintf(fout,"--- %s ---\n",pipeline_stage_name_decode[i]);
-       print_stage(i,fout);fprintf(fout,"\n");
-   }
+  // Limit by register count, rounded up to multiple of 4.
+  unsigned int result_regs = (unsigned)-1;
+  if (kernel_info->regs > 0)
+    result_regs = gpgpu_shader_registers /
+                  (padded_cta_size * ((kernel_info->regs + 3) & ~3));
 
-   fprintf(fout, "-------------------------- Fu\n");
-   for( unsigned n=0; n < m_num_function_units; n++ ){
-       m_fu[n]->print(fout);
-       fprintf(fout, "---------------\n");
-   }
-   fprintf(fout, "-------------------------- other:\n");
+  // Limit by CTA
+  unsigned int result_cta = max_cta_per_core;
 
-   for(unsigned i=0; i<num_result_bus; i++){
-	   std::string bits = m_result_bus[i]->to_string();
-	   fprintf(fout, "EX/WB sched[%d]= %s\n", i, bits.c_str() );
-   }
-   fprintf(fout, "EX/WB      = ");
-   print_stage(EX_WB, fout);
-   fprintf(fout, "\n");
-   fprintf(fout, "Last EX/WB writeback @ %llu + %llu (gpu_sim_cycle+gpu_tot_sim_cycle)\n",
-                 m_last_inst_gpu_sim_cycle, m_last_inst_gpu_tot_sim_cycle );
+  unsigned result = result_thread;
+  result = gs_min2(result, result_shmem);
+  result = gs_min2(result, result_regs);
+  result = gs_min2(result, result_cta);
 
-   if( m_active_threads.count() <= 2*m_config->warp_size ) {
-       fprintf(fout,"Active Threads : ");
-       unsigned last_warp_id = -1;
-       for(unsigned tid=0; tid < m_active_threads.size(); tid++ ) {
-           unsigned warp_id = tid/m_config->warp_size;
-           if( m_active_threads.test(tid) ) {
-               if( warp_id != last_warp_id ) {
-                   fprintf(fout,"\n  warp %u : ", warp_id );
-                   last_warp_id=warp_id;
-               }
-               fprintf(fout,"%u ", tid );
-           }
-       }
-   }
+  static const struct gpgpu_ptx_sim_info *last_kinfo = NULL;
+  if (last_kinfo !=
+      kernel_info) {  // Only print out stats if kernel_info struct changes
+    last_kinfo = kernel_info;
+    printf("GPGPU-Sim uArch: CTA/core = %u, limited by:", result);
+    if (result == result_thread) printf(" threads");
+    if (result == result_shmem) printf(" shmem");
+    if (result == result_regs) printf(" regs");
+    if (result == result_cta) printf(" cta_limit");
+    printf("\n");
+  }
 
-}
+  // gpu_max_cta_per_shader is limited by number of CTAs if not enough to keep
+  // all cores busy
+  if (k.num_blocks() < result * num_shader()) {
+    result = k.num_blocks() / num_shader();
+    if (k.num_blocks() % num_shader()) result++;
+  }
 
-unsigned int shader_core_config::max_cta( const kernel_info_t &k ) const
-{
-   unsigned threads_per_cta  = k.threads_per_cta();
-   const class function_info *kernel = k.entry();
-   unsigned int padded_cta_size = threads_per_cta;
-   if (padded_cta_size%warp_size) 
-      padded_cta_size = ((padded_cta_size/warp_size)+1)*(warp_size);
+  assert(result <= MAX_CTA_PER_SHADER);
+  if (result < 1) {
+    printf(
+        "GPGPU-Sim uArch: ERROR ** Kernel requires more resources than shader "
+        "has.\n");
+    if (gpgpu_ignore_resources_limitation) {
+      printf(
+          "GPGPU-Sim uArch: gpgpu_ignore_resources_limitation is set, ignore "
+          "the ERROR!\n");
+      return 1;
+    }
+    abort();
+  }
 
-   //Limit by n_threads/shader
-   unsigned int result_thread = n_thread_per_shader / padded_cta_size;
+  if (adaptive_volta_cache_config && !k.volta_cache_config_set) {
+    // For Volta, we assign the remaining shared memory to L1 cache
+    // For more info, see
+    // https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#shared-memory-7-x
+    unsigned total_shmed = kernel_info->smem * result;
+    assert(total_shmed >= 0 && total_shmed <= gpgpu_shmem_size);
+    assert(gpgpu_shmem_size == 98304);     // Volta has 96 KB shared
+    assert(m_L1D_config.get_nset() == 4);  // Volta L1 has four sets
+    if (total_shmed < gpgpu_shmem_size) {
+      if (total_shmed == 0)
+        m_L1D_config.set_assoc(256);  // L1 is 128KB ans shd=0
+      else if (total_shmed > 0 && total_shmed <= 8192)
+        m_L1D_config.set_assoc(240);  // L1 is 120KB ans shd=8KB
+      else if (total_shmed > 8192 && total_shmed <= 16384)
+        m_L1D_config.set_assoc(224);  // L1 is 112KB ans shd=16KB
+      else if (total_shmed > 16384 && total_shmed <= 32768)
+        m_L1D_config.set_assoc(192);  // L1 is 96KB ans shd=32KB
+      else if (total_shmed > 32768 && total_shmed <= 65536)
+        m_L1D_config.set_assoc(128);  // L1 is 64KB ans shd=64KB
+      else if (total_shmed > 65536 && total_shmed <= gpgpu_shmem_size)
+        m_L1D_config.set_assoc(64);  // L1 is 32KB and shd=96KB
+      else
+        assert(0);
 
-   const struct gpgpu_ptx_sim_info *kernel_info = ptx_sim_kernel_info(kernel);
-
-   //Limit by shmem/shader
-   unsigned int result_shmem = (unsigned)-1;
-   if (kernel_info->smem > 0)
-      result_shmem = gpgpu_shmem_size / kernel_info->smem;
-
-   //Limit by register count, rounded up to multiple of 4.
-   unsigned int result_regs = (unsigned)-1;
-   if (kernel_info->regs > 0)
-      result_regs = gpgpu_shader_registers / (padded_cta_size * ((kernel_info->regs+3)&~3));
-
-   //Limit by CTA
-   unsigned int result_cta = max_cta_per_core;
-
-   unsigned result = result_thread;
-   result = gs_min2(result, result_shmem);
-   result = gs_min2(result, result_regs);
-   result = gs_min2(result, result_cta);
-
-   static const struct gpgpu_ptx_sim_info* last_kinfo = NULL;
-   if (last_kinfo != kernel_info) {   //Only print out stats if kernel_info struct changes
-      last_kinfo = kernel_info;
-      printf ("GPGPU-Sim uArch: CTA/core = %u, limited by:", result);
-      if (result == result_thread) printf (" threads");
-      if (result == result_shmem) printf (" shmem");
-      if (result == result_regs) printf (" regs");
-      if (result == result_cta) printf (" cta_limit");
-      printf ("\n");
-   }
-
-    //gpu_max_cta_per_shader is limited by number of CTAs if not enough to keep all cores busy    
-    if( k.num_blocks() < result*num_shader() ) { 
-       result = k.num_blocks() / num_shader();
-       if (k.num_blocks() % num_shader())
-          result++;
+      printf("GPGPU-Sim: Reconfigure L1 cache in Volta Archi to %uKB\n",
+             m_L1D_config.get_total_size_inKB());
     }
 
-    assert( result <= MAX_CTA_PER_SHADER );
-    if (result < 1) {
-       printf ("GPGPU-Sim uArch: ERROR ** Kernel requires more resources than shader has.\n");
-       if(gpgpu_ignore_resources_limitation) {
-    	   printf ("GPGPU-Sim uArch: gpgpu_ignore_resources_limitation is set, ignore the ERROR!\n");
-    	   return 1;
-       }
-       abort();
-    }
+    k.volta_cache_config_set = true;
+  }
 
-    if(adaptive_volta_cache_config && !k.volta_cache_config_set) {
-    	//For Volta, we assign the remaining shared memory to L1 cache
-    	//For more info, see https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#shared-memory-7-x
-    	unsigned total_shmed = kernel_info->smem * result;
-    	assert(total_shmed >=0 && total_shmed <= gpgpu_shmem_size);
-    	assert(gpgpu_shmem_size == 98304); //Volta has 96 KB shared
-    	assert(m_L1D_config.get_nset() == 4);  //Volta L1 has four sets
-    	if(total_shmed < gpgpu_shmem_size){
-    		if(total_shmed == 0)
-    			m_L1D_config.set_assoc(256);  //L1 is 128KB ans shd=0
-    		else if(total_shmed > 0 && total_shmed <= 8192)
-    			m_L1D_config.set_assoc(240);  //L1 is 120KB ans shd=8KB
-    		else if(total_shmed > 8192 && total_shmed <= 16384)
-    		    m_L1D_config.set_assoc(224);  //L1 is 112KB ans shd=16KB
-    		else if(total_shmed > 16384 && total_shmed <= 32768)
-    		    m_L1D_config.set_assoc(192);  //L1 is 96KB ans shd=32KB
-    		else if(total_shmed > 32768 && total_shmed <= 65536)
-    		    m_L1D_config.set_assoc(128);	//L1 is 64KB ans shd=64KB
-    		else if(total_shmed > 65536 && total_shmed <= gpgpu_shmem_size)
-    		     m_L1D_config.set_assoc(64); //L1 is 32KB and shd=96KB
-    		else
-    			assert(0);
-
-    		 printf ("GPGPU-Sim: Reconfigure L1 cache in Volta Archi to %uKB\n", m_L1D_config.get_total_size_inKB());
-    	}
-
-    	k.volta_cache_config_set = true;
-    }
-
-    return result;
+  return result;
 }
 
 void shader_core_config::set_pipeline_latency() {
+  // calculate the max latency  based on the input
 
-		//calculate the max latency  based on the input
+  unsigned int_latency[5];
+  unsigned fp_latency[5];
+  unsigned dp_latency[5];
+  unsigned sfu_latency;
+  unsigned tensor_latency;
 
-		unsigned int_latency[5];
-		unsigned fp_latency[5];
-		unsigned dp_latency[5];
-		unsigned sfu_latency;
-		unsigned tensor_latency;
+  /*
+   * [0] ADD,SUB
+   * [1] MAX,Min
+   * [2] MUL
+   * [3] MAD
+   * [4] DIV
+   */
+  sscanf(gpgpu_ctx->func_sim->opcode_latency_int, "%u,%u,%u,%u,%u",
+         &int_latency[0], &int_latency[1], &int_latency[2], &int_latency[3],
+         &int_latency[4]);
+  sscanf(gpgpu_ctx->func_sim->opcode_latency_fp, "%u,%u,%u,%u,%u",
+         &fp_latency[0], &fp_latency[1], &fp_latency[2], &fp_latency[3],
+         &fp_latency[4]);
+  sscanf(gpgpu_ctx->func_sim->opcode_latency_dp, "%u,%u,%u,%u,%u",
+         &dp_latency[0], &dp_latency[1], &dp_latency[2], &dp_latency[3],
+         &dp_latency[4]);
+  sscanf(gpgpu_ctx->func_sim->opcode_latency_sfu, "%u", &sfu_latency);
+  sscanf(gpgpu_ctx->func_sim->opcode_latency_tensor, "%u", &tensor_latency);
 
-			/*
-			 * [0] ADD,SUB
-			 * [1] MAX,Min
-			 * [2] MUL
-			 * [3] MAD
-			 * [4] DIV
-			 */
-			sscanf(gpgpu_ctx->func_sim->opcode_latency_int, "%u,%u,%u,%u,%u",
-					&int_latency[0],&int_latency[1],&int_latency[2],
-					&int_latency[3],&int_latency[4]);
-			sscanf(gpgpu_ctx->func_sim->opcode_latency_fp, "%u,%u,%u,%u,%u",
-					&fp_latency[0],&fp_latency[1],&fp_latency[2],
-					&fp_latency[3],&fp_latency[4]);
-			sscanf(gpgpu_ctx->func_sim->opcode_latency_dp, "%u,%u,%u,%u,%u",
-					&dp_latency[0],&dp_latency[1],&dp_latency[2],
-					&dp_latency[3],&dp_latency[4]);
-			sscanf(gpgpu_ctx->func_sim->opcode_latency_sfu, "%u",
-					&sfu_latency);
-			sscanf(gpgpu_ctx->func_sim->opcode_latency_tensor, "%u",
-					&tensor_latency);
-
-		//all div operation are executed on sfu
-		//assume that the max latency are dp div or normal sfu_latency
-		max_sfu_latency = std::max(dp_latency[4],sfu_latency);
-		//assume that the max operation has the max latency
-		max_sp_latency = fp_latency[1];
-		max_int_latency = int_latency[1];
-		max_dp_latency = dp_latency[1];
-		max_tensor_core_latency = tensor_latency;
-
+  // all div operation are executed on sfu
+  // assume that the max latency are dp div or normal sfu_latency
+  max_sfu_latency = std::max(dp_latency[4], sfu_latency);
+  // assume that the max operation has the max latency
+  max_sp_latency = fp_latency[1];
+  max_int_latency = int_latency[1];
+  max_dp_latency = dp_latency[1];
+  max_tensor_core_latency = tensor_latency;
 }
 
-void shader_core_ctx::cycle()
-{
-	if(!isactive() && get_not_completed() == 0)
-		return;
+void shader_core_ctx::cycle() {
+  if (!isactive() && get_not_completed() == 0) return;
 
-	m_stats->shader_cycles[m_sid]++;
-    writeback();
-    execute();
-    read_operands();
-    issue();
-    decode();
-    fetch();
+  m_stats->shader_cycles[m_sid]++;
+  writeback();
+  execute();
+  read_operands();
+  issue();
+  decode();
+  fetch();
 }
 
 // Flushes all content of the cache to memory
 
-void shader_core_ctx::cache_flush()
-{
-   m_ldst_unit->flush();
-}
+void shader_core_ctx::cache_flush() { m_ldst_unit->flush(); }
 
-void shader_core_ctx::cache_invalidate()
-{
-   m_ldst_unit->invalidate();
-}
+void shader_core_ctx::cache_invalidate() { m_ldst_unit->invalidate(); }
 
 // modifiers
-std::list<opndcoll_rfu_t::op_t> opndcoll_rfu_t::arbiter_t::allocate_reads() 
-{
-   std::list<op_t> result;  // a list of registers that (a) are in different register banks, (b) do not go to the same operand collector
+std::list<opndcoll_rfu_t::op_t> opndcoll_rfu_t::arbiter_t::allocate_reads() {
+  std::list<op_t>
+      result;  // a list of registers that (a) are in different register banks,
+               // (b) do not go to the same operand collector
 
-   int input;
-   int output;
-   int _inputs = m_num_banks;
-   int _outputs = m_num_collectors;
-   int _square = ( _inputs > _outputs ) ? _inputs : _outputs;
-   assert(_square > 0);
-   int _pri = (int)m_last_cu;
+  int input;
+  int output;
+  int _inputs = m_num_banks;
+  int _outputs = m_num_collectors;
+  int _square = (_inputs > _outputs) ? _inputs : _outputs;
+  assert(_square > 0);
+  int _pri = (int)m_last_cu;
 
-   // Clear matching
-   for ( int i = 0; i < _inputs; ++i ) 
-      _inmatch[i] = -1;
-   for ( int j = 0; j < _outputs; ++j ) 
-      _outmatch[j] = -1;
+  // Clear matching
+  for (int i = 0; i < _inputs; ++i) _inmatch[i] = -1;
+  for (int j = 0; j < _outputs; ++j) _outmatch[j] = -1;
 
-   for( unsigned i=0; i<m_num_banks; i++) {
-      for( unsigned j=0; j<m_num_collectors; j++) {
-         assert( i < (unsigned)_inputs );
-         assert( j < (unsigned)_outputs );
-         _request[i][j] = 0;
+  for (unsigned i = 0; i < m_num_banks; i++) {
+    for (unsigned j = 0; j < m_num_collectors; j++) {
+      assert(i < (unsigned)_inputs);
+      assert(j < (unsigned)_outputs);
+      _request[i][j] = 0;
+    }
+    if (!m_queue[i].empty()) {
+      const op_t &op = m_queue[i].front();
+      int oc_id = op.get_oc_id();
+      assert(i < (unsigned)_inputs);
+      assert(oc_id < _outputs);
+      _request[i][oc_id] = 1;
+    }
+    if (m_allocated_bank[i].is_write()) {
+      assert(i < (unsigned)_inputs);
+      _inmatch[i] = 0;  // write gets priority
+    }
+  }
+
+  ///// wavefront allocator from booksim... --->
+
+  // Loop through diagonals of request matrix
+
+  for (int p = 0; p < _square; ++p) {
+    output = (_pri + p) % _square;
+
+    // Step through the current diagonal
+    for (input = 0; input < _inputs; ++input) {
+      assert(input < _inputs);
+      assert(output < _outputs);
+      if ((output < _outputs) && (_inmatch[input] == -1) &&
+          (_outmatch[output] == -1) &&
+          (_request[input][output] /*.label != -1*/)) {
+        // Grant!
+        _inmatch[input] = output;
+        _outmatch[output] = input;
       }
-      if( !m_queue[i].empty() ) {
-         const op_t &op = m_queue[i].front();
-         int oc_id = op.get_oc_id();
-         assert( i < (unsigned)_inputs );
-         assert( oc_id < _outputs );
-         _request[i][oc_id] = 1;
+
+      output = (output + 1) % _square;
+    }
+  }
+
+  // Round-robin the priority diagonal
+  _pri = (_pri + 1) % _square;
+
+  /// <--- end code from booksim
+
+  m_last_cu = _pri;
+  for (unsigned i = 0; i < m_num_banks; i++) {
+    if (_inmatch[i] != -1) {
+      if (!m_allocated_bank[i].is_write()) {
+        unsigned bank = (unsigned)i;
+        op_t &op = m_queue[bank].front();
+        result.push_back(op);
+        m_queue[bank].pop_front();
       }
-      if( m_allocated_bank[i].is_write() ) {
-         assert( i < (unsigned)_inputs );
-         _inmatch[i] = 0; // write gets priority
-      }
-   }
+    }
+  }
 
-   ///// wavefront allocator from booksim... --->
-   
-   // Loop through diagonals of request matrix
-
-   for ( int p = 0; p < _square; ++p ) {
-      output = ( _pri + p ) % _square;
-
-      // Step through the current diagonal
-      for ( input = 0; input < _inputs; ++input ) {
-          assert( input < _inputs );
-          assert( output < _outputs );
-         if ( ( output < _outputs ) && 
-              ( _inmatch[input] == -1 ) && 
-              ( _outmatch[output] == -1 ) &&
-              ( _request[input][output]/*.label != -1*/ ) ) {
-            // Grant!
-            _inmatch[input] = output;
-            _outmatch[output] = input;
-         }
-
-         output = ( output + 1 ) % _square;
-      }
-   }
-
-   // Round-robin the priority diagonal
-   _pri = ( _pri + 1 ) % _square;
-
-   /// <--- end code from booksim
-
-   m_last_cu = _pri;
-   for( unsigned i=0; i < m_num_banks; i++ ) {
-      if( _inmatch[i] != -1 ) {
-         if( !m_allocated_bank[i].is_write() ) {
-            unsigned bank = (unsigned)i;
-            op_t &op = m_queue[bank].front();
-            result.push_back(op);
-            m_queue[bank].pop_front();
-         }
-      }
-   }
-
-   return result;
+  return result;
 }
 
-barrier_set_t::barrier_set_t(shader_core_ctx *shader,unsigned max_warps_per_core, unsigned max_cta_per_core, unsigned max_barriers_per_cta, unsigned warp_size)
-{
-   m_max_warps_per_core = max_warps_per_core;
-   m_max_cta_per_core = max_cta_per_core;
-   m_max_barriers_per_cta = max_barriers_per_cta;
-   m_warp_size = warp_size;
-   m_shader = shader;
-   if( max_warps_per_core > WARP_PER_CTA_MAX ) {
-      printf("ERROR ** increase WARP_PER_CTA_MAX in shader.h from %u to >= %u or warps per cta in gpgpusim.config\n",
-             WARP_PER_CTA_MAX, max_warps_per_core );
-      exit(1);
-   }
-   if(max_barriers_per_cta > MAX_BARRIERS_PER_CTA){
-	   printf("ERROR ** increase MAX_BARRIERS_PER_CTA in abstract_hardware_model.h from %u to >= %u or barriers per cta in gpgpusim.config\n",
-			   MAX_BARRIERS_PER_CTA, max_barriers_per_cta );
-	   exit(1);
-   }
-   m_warp_active.reset();
-   m_warp_at_barrier.reset();
-   for(unsigned i=0; i<max_barriers_per_cta; i++){
-	   m_bar_id_to_warps[i].reset();
-   }
+barrier_set_t::barrier_set_t(shader_core_ctx *shader,
+                             unsigned max_warps_per_core,
+                             unsigned max_cta_per_core,
+                             unsigned max_barriers_per_cta,
+                             unsigned warp_size) {
+  m_max_warps_per_core = max_warps_per_core;
+  m_max_cta_per_core = max_cta_per_core;
+  m_max_barriers_per_cta = max_barriers_per_cta;
+  m_warp_size = warp_size;
+  m_shader = shader;
+  if (max_warps_per_core > WARP_PER_CTA_MAX) {
+    printf(
+        "ERROR ** increase WARP_PER_CTA_MAX in shader.h from %u to >= %u or "
+        "warps per cta in gpgpusim.config\n",
+        WARP_PER_CTA_MAX, max_warps_per_core);
+    exit(1);
+  }
+  if (max_barriers_per_cta > MAX_BARRIERS_PER_CTA) {
+    printf(
+        "ERROR ** increase MAX_BARRIERS_PER_CTA in abstract_hardware_model.h "
+        "from %u to >= %u or barriers per cta in gpgpusim.config\n",
+        MAX_BARRIERS_PER_CTA, max_barriers_per_cta);
+    exit(1);
+  }
+  m_warp_active.reset();
+  m_warp_at_barrier.reset();
+  for (unsigned i = 0; i < max_barriers_per_cta; i++) {
+    m_bar_id_to_warps[i].reset();
+  }
 }
 
 // during cta allocation
-void barrier_set_t::allocate_barrier( unsigned cta_id, warp_set_t warps )
-{
-   assert( cta_id < m_max_cta_per_core );
-   cta_to_warp_t::iterator w=m_cta_to_warps.find(cta_id);
-   assert( w == m_cta_to_warps.end() ); // cta should not already be active or allocated barrier resources
-   m_cta_to_warps[cta_id] = warps;
-   assert( m_cta_to_warps.size() <= m_max_cta_per_core ); // catch cta's that were not properly deallocated
-  
-   m_warp_active |= warps;
-   m_warp_at_barrier &= ~warps;
-   for(unsigned i=0; i<m_max_barriers_per_cta; i++){
-	   m_bar_id_to_warps[i] &=~warps;
-   }
+void barrier_set_t::allocate_barrier(unsigned cta_id, warp_set_t warps) {
+  assert(cta_id < m_max_cta_per_core);
+  cta_to_warp_t::iterator w = m_cta_to_warps.find(cta_id);
+  assert(w == m_cta_to_warps.end());  // cta should not already be active or
+                                      // allocated barrier resources
+  m_cta_to_warps[cta_id] = warps;
+  assert(m_cta_to_warps.size() <=
+         m_max_cta_per_core);  // catch cta's that were not properly deallocated
 
+  m_warp_active |= warps;
+  m_warp_at_barrier &= ~warps;
+  for (unsigned i = 0; i < m_max_barriers_per_cta; i++) {
+    m_bar_id_to_warps[i] &= ~warps;
+  }
 }
 
 // during cta deallocation
-void barrier_set_t::deallocate_barrier( unsigned cta_id )
-{
-   cta_to_warp_t::iterator w=m_cta_to_warps.find(cta_id);
-   if( w == m_cta_to_warps.end() )
-      return;
-   warp_set_t warps = w->second;
-   warp_set_t at_barrier = warps & m_warp_at_barrier;
-   assert( at_barrier.any() == false ); // no warps stuck at barrier
-   warp_set_t active = warps & m_warp_active;
-   assert( active.any() == false ); // no warps in CTA still running
-   m_warp_active &= ~warps;
-   m_warp_at_barrier &= ~warps;
+void barrier_set_t::deallocate_barrier(unsigned cta_id) {
+  cta_to_warp_t::iterator w = m_cta_to_warps.find(cta_id);
+  if (w == m_cta_to_warps.end()) return;
+  warp_set_t warps = w->second;
+  warp_set_t at_barrier = warps & m_warp_at_barrier;
+  assert(at_barrier.any() == false);  // no warps stuck at barrier
+  warp_set_t active = warps & m_warp_active;
+  assert(active.any() == false);  // no warps in CTA still running
+  m_warp_active &= ~warps;
+  m_warp_at_barrier &= ~warps;
 
-   for(unsigned i=0; i<m_max_barriers_per_cta; i++){
-	   warp_set_t at_a_specific_barrier = warps & m_bar_id_to_warps[i];
-	   assert( at_a_specific_barrier.any() == false ); // no warps stuck at barrier
-	   m_bar_id_to_warps[i] &=~warps;
-   }
-   m_cta_to_warps.erase(w);
+  for (unsigned i = 0; i < m_max_barriers_per_cta; i++) {
+    warp_set_t at_a_specific_barrier = warps & m_bar_id_to_warps[i];
+    assert(at_a_specific_barrier.any() == false);  // no warps stuck at barrier
+    m_bar_id_to_warps[i] &= ~warps;
+  }
+  m_cta_to_warps.erase(w);
 }
 
 // individual warp hits barrier
-void barrier_set_t::warp_reaches_barrier(unsigned cta_id,unsigned warp_id,warp_inst_t* inst)
-{
-	barrier_type bar_type = inst->bar_type;
-	unsigned bar_id = inst->bar_id;
-	unsigned bar_count = inst->bar_count;
-	assert(bar_id!=(unsigned)-1);
-   cta_to_warp_t::iterator w=m_cta_to_warps.find(cta_id);
+void barrier_set_t::warp_reaches_barrier(unsigned cta_id, unsigned warp_id,
+                                         warp_inst_t *inst) {
+  barrier_type bar_type = inst->bar_type;
+  unsigned bar_id = inst->bar_id;
+  unsigned bar_count = inst->bar_count;
+  assert(bar_id != (unsigned)-1);
+  cta_to_warp_t::iterator w = m_cta_to_warps.find(cta_id);
 
-   if( w == m_cta_to_warps.end() ) { // cta is active
-      printf("ERROR ** cta_id %u not found in barrier set on cycle %llu+%llu...\n", cta_id, m_shader->get_gpu()->gpu_tot_sim_cycle, m_shader->get_gpu()->gpu_sim_cycle );
-      dump();
-      abort();
-   }
-   assert( w->second.test(warp_id) == true ); // warp is in cta
-
-   m_bar_id_to_warps[bar_id].set(warp_id);
-   if(bar_type==SYNC || bar_type==RED){
-	   m_warp_at_barrier.set(warp_id);
-   }
-   warp_set_t warps_in_cta = w->second;
-   warp_set_t at_barrier = warps_in_cta & m_bar_id_to_warps[bar_id];
-   warp_set_t active = warps_in_cta & m_warp_active;
-   if(bar_count==(unsigned)-1){
-	   if( at_barrier == active ) {
-		   // all warps have reached barrier, so release waiting warps...
-		   m_bar_id_to_warps[bar_id] &= ~at_barrier;
-		   m_warp_at_barrier &= ~at_barrier;
-		   if(bar_type==RED){
-			   m_shader->broadcast_barrier_reduction(cta_id, bar_id,at_barrier);
-		   }
-	   }
-  }else{
-	  // TODO: check on the hardware if the count should include warp that exited
-	  if ((at_barrier.count() * m_warp_size) == bar_count){
-		   // required number of warps have reached barrier, so release waiting warps...
-		   m_bar_id_to_warps[bar_id] &= ~at_barrier;
-		   m_warp_at_barrier &= ~at_barrier;
-		   if(bar_type==RED){
-			   m_shader->broadcast_barrier_reduction(cta_id, bar_id,at_barrier);
-		   }
-	  }
+  if (w == m_cta_to_warps.end()) {  // cta is active
+    printf(
+        "ERROR ** cta_id %u not found in barrier set on cycle %llu+%llu...\n",
+        cta_id, m_shader->get_gpu()->gpu_tot_sim_cycle,
+        m_shader->get_gpu()->gpu_sim_cycle);
+    dump();
+    abort();
   }
+  assert(w->second.test(warp_id) == true);  // warp is in cta
 
-
+  m_bar_id_to_warps[bar_id].set(warp_id);
+  if (bar_type == SYNC || bar_type == RED) {
+    m_warp_at_barrier.set(warp_id);
+  }
+  warp_set_t warps_in_cta = w->second;
+  warp_set_t at_barrier = warps_in_cta & m_bar_id_to_warps[bar_id];
+  warp_set_t active = warps_in_cta & m_warp_active;
+  if (bar_count == (unsigned)-1) {
+    if (at_barrier == active) {
+      // all warps have reached barrier, so release waiting warps...
+      m_bar_id_to_warps[bar_id] &= ~at_barrier;
+      m_warp_at_barrier &= ~at_barrier;
+      if (bar_type == RED) {
+        m_shader->broadcast_barrier_reduction(cta_id, bar_id, at_barrier);
+      }
+    }
+  } else {
+    // TODO: check on the hardware if the count should include warp that exited
+    if ((at_barrier.count() * m_warp_size) == bar_count) {
+      // required number of warps have reached barrier, so release waiting
+      // warps...
+      m_bar_id_to_warps[bar_id] &= ~at_barrier;
+      m_warp_at_barrier &= ~at_barrier;
+      if (bar_type == RED) {
+        m_shader->broadcast_barrier_reduction(cta_id, bar_id, at_barrier);
+      }
+    }
+  }
 }
 
+// warp reaches exit
+void barrier_set_t::warp_exit(unsigned warp_id) {
+  // caller needs to verify all threads in warp are done, e.g., by checking PDOM
+  // stack to see it has only one entry during exit_impl()
+  m_warp_active.reset(warp_id);
 
-// warp reaches exit 
-void barrier_set_t::warp_exit( unsigned warp_id )
-{
-   // caller needs to verify all threads in warp are done, e.g., by checking PDOM stack to 
-   // see it has only one entry during exit_impl()
-   m_warp_active.reset(warp_id);
+  // test for barrier release
+  cta_to_warp_t::iterator w = m_cta_to_warps.begin();
+  for (; w != m_cta_to_warps.end(); ++w) {
+    if (w->second.test(warp_id) == true) break;
+  }
+  warp_set_t warps_in_cta = w->second;
+  warp_set_t active = warps_in_cta & m_warp_active;
 
-   // test for barrier release 
-   cta_to_warp_t::iterator w=m_cta_to_warps.begin(); 
-   for (; w != m_cta_to_warps.end(); ++w) {
-      if (w->second.test(warp_id) == true) break; 
-   }
-   warp_set_t warps_in_cta = w->second;
-   warp_set_t active = warps_in_cta & m_warp_active;
-
-   for(unsigned i=0; i<m_max_barriers_per_cta; i++){
-	   warp_set_t at_a_specific_barrier = warps_in_cta & m_bar_id_to_warps[i];
-	   if( at_a_specific_barrier == active ) {
-	      // all warps have reached barrier, so release waiting warps...
-		   m_bar_id_to_warps[i] &= ~at_a_specific_barrier;
-		   m_warp_at_barrier &= ~at_a_specific_barrier;
-	   }
-   }
+  for (unsigned i = 0; i < m_max_barriers_per_cta; i++) {
+    warp_set_t at_a_specific_barrier = warps_in_cta & m_bar_id_to_warps[i];
+    if (at_a_specific_barrier == active) {
+      // all warps have reached barrier, so release waiting warps...
+      m_bar_id_to_warps[i] &= ~at_a_specific_barrier;
+      m_warp_at_barrier &= ~at_a_specific_barrier;
+    }
+  }
 }
 
 // assertions
-bool barrier_set_t::warp_waiting_at_barrier( unsigned warp_id ) const
-{ 
-   return m_warp_at_barrier.test(warp_id);
+bool barrier_set_t::warp_waiting_at_barrier(unsigned warp_id) const {
+  return m_warp_at_barrier.test(warp_id);
 }
 
-void barrier_set_t::dump()
-{
-   printf( "barrier set information\n");
-   printf( "  m_max_cta_per_core = %u\n",  m_max_cta_per_core );
-   printf( "  m_max_warps_per_core = %u\n", m_max_warps_per_core );
-   printf( " m_max_barriers_per_cta =%u\n", m_max_barriers_per_cta);
-   printf( "  cta_to_warps:\n");
-   
-   cta_to_warp_t::const_iterator i;
-   for( i=m_cta_to_warps.begin(); i!=m_cta_to_warps.end(); i++ ) {
-      unsigned cta_id = i->first;
-      warp_set_t warps = i->second;
-      printf("    cta_id %u : %s\n", cta_id, warps.to_string().c_str() );
-   }
-   printf("  warp_active: %s\n", m_warp_active.to_string().c_str() );
-   printf("  warp_at_barrier: %s\n", m_warp_at_barrier.to_string().c_str() );
-   for( unsigned i=0; i<m_max_barriers_per_cta; i++){
-	   warp_set_t warps_reached_barrier = m_bar_id_to_warps[i];
-	   printf("  warp_at_barrier %u: %s\n", i, warps_reached_barrier.to_string().c_str() );
-   }
-   fflush(stdout); 
-}
+void barrier_set_t::dump() {
+  printf("barrier set information\n");
+  printf("  m_max_cta_per_core = %u\n", m_max_cta_per_core);
+  printf("  m_max_warps_per_core = %u\n", m_max_warps_per_core);
+  printf(" m_max_barriers_per_cta =%u\n", m_max_barriers_per_cta);
+  printf("  cta_to_warps:\n");
 
-void shader_core_ctx::warp_exit( unsigned warp_id )
-{
-	bool done = true;
-	for (	unsigned i = warp_id*get_config()->warp_size;
-			i < (warp_id+1)*get_config()->warp_size;
-			i++ ) {
-
-//		if(this->m_thread[i]->m_functional_model_thread_state && this->m_thread[i].m_functional_model_thread_state->donecycle()==0) {
-//			done = false;
-//		}
-
-
-		if (m_thread[i] && !m_thread[i]->is_done()) done = false;
-	}
-	//if (m_warp[warp_id].get_n_completed() == get_config()->warp_size)
-	//if (this->m_simt_stack[warp_id]->get_num_entries() == 0)
-	if (done)
-		m_barriers.warp_exit( warp_id );
-}
-
-bool shader_core_ctx::check_if_non_released_reduction_barrier(warp_inst_t &inst)
-{
-	unsigned warp_id = inst.warp_id();
-	bool bar_red_op = (inst.op == BARRIER_OP) && (inst.bar_type == RED);
-    bool non_released_barrier_reduction = false;
-    bool warp_stucked_at_barrier = warp_waiting_at_barrier(warp_id);
-    bool single_inst_in_pipeline = (m_warp[warp_id].num_issued_inst_in_pipeline()==1);
-    non_released_barrier_reduction = single_inst_in_pipeline and warp_stucked_at_barrier and bar_red_op;
-    printf("non_released_barrier_reduction=%u\n",non_released_barrier_reduction);
-    return non_released_barrier_reduction;
-}
-
-bool shader_core_ctx::warp_waiting_at_barrier( unsigned warp_id ) const
-{
-   return m_barriers.warp_waiting_at_barrier(warp_id);
-}
-
-bool shader_core_ctx::warp_waiting_at_mem_barrier( unsigned warp_id ) 
-{
-   if( !m_warp[warp_id].get_membar() ) 
-      return false;
-   if( !m_scoreboard->pendingWrites(warp_id) ) {
-      m_warp[warp_id].clear_membar();
-      return false;
-   }
-   return true;
-}
-
-void shader_core_ctx::set_max_cta( const kernel_info_t &kernel ) 
-{
-    // calculate the max cta count and cta size for local memory address mapping
-    kernel_max_cta_per_shader = m_config->max_cta(kernel);
-    unsigned int gpu_cta_size = kernel.threads_per_cta();
-    kernel_padded_threads_per_cta = (gpu_cta_size%m_config->warp_size) ? 
-        m_config->warp_size*((gpu_cta_size/m_config->warp_size)+1) : 
-        gpu_cta_size;
-}
-
-void shader_core_ctx::decrement_atomic_count( unsigned wid, unsigned n )
-{
-   assert( m_warp[wid].get_n_atomic() >= n );
-   m_warp[wid].dec_n_atomic(n);
-}
-
-void shader_core_ctx::broadcast_barrier_reduction(unsigned cta_id,unsigned bar_id,warp_set_t warps)
-{
-	for(unsigned i=0; i<m_config->max_warps_per_shader;i++){
-		if(warps.test(i)){
-			const warp_inst_t * inst = m_warp[i].restore_info_of_last_inst_at_barrier();
-			const_cast<warp_inst_t *> (inst)->broadcast_barrier_reduction(inst->get_active_mask());
-		}
-	}
-}
-
-bool shader_core_ctx::fetch_unit_response_buffer_full() const
-{
-    return false;
-}
-
-void shader_core_ctx::accept_fetch_response( mem_fetch *mf )
-{
-    mf->set_status(IN_SHADER_FETCHED,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-    m_L1I->fill(mf,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-}
-
-bool shader_core_ctx::ldst_unit_response_buffer_full() const
-{
-    return m_ldst_unit->response_buffer_full();
-}
-
-void shader_core_ctx::accept_ldst_unit_response(mem_fetch * mf) 
-{
-   m_ldst_unit->fill(mf);
-}
-
-void shader_core_ctx::store_ack( class mem_fetch *mf )
-{
-	assert( mf->get_type() == WRITE_ACK  || ( m_config->gpgpu_perfect_mem && mf->get_is_write() ) );
-    unsigned warp_id = mf->get_wid();
-    m_warp[warp_id].dec_store_req();
-}
-
-void shader_core_ctx::print_cache_stats( FILE *fp, unsigned& dl1_accesses, unsigned& dl1_misses ) {
-   m_ldst_unit->print_cache_stats( fp, dl1_accesses, dl1_misses );
-}
-
-void shader_core_ctx::get_cache_stats(cache_stats &cs){
-    // Adds stats from each cache to 'cs'
-    cs += m_L1I->get_stats(); // Get L1I stats
-    m_ldst_unit->get_cache_stats(cs); // Get L1D, L1C, L1T stats
-}
-
-void shader_core_ctx::get_L1I_sub_stats(struct cache_sub_stats &css) const{
-    if(m_L1I)
-        m_L1I->get_sub_stats(css);
-}
-void shader_core_ctx::get_L1D_sub_stats(struct cache_sub_stats &css) const{
-    m_ldst_unit->get_L1D_sub_stats(css);
-}
-void shader_core_ctx::get_L1C_sub_stats(struct cache_sub_stats &css) const{
-    m_ldst_unit->get_L1C_sub_stats(css);
-}
-void shader_core_ctx::get_L1T_sub_stats(struct cache_sub_stats &css) const{
-    m_ldst_unit->get_L1T_sub_stats(css);
-}
-
-void shader_core_ctx::get_icnt_power_stats(long &n_simt_to_mem, long &n_mem_to_simt) const{
-	n_simt_to_mem += m_stats->n_simt_to_mem[m_sid];
-	n_mem_to_simt += m_stats->n_mem_to_simt[m_sid];
-}
-
-bool shd_warp_t::functional_done() const
-{
-    return get_n_completed() == m_warp_size;
-}
-
-bool shd_warp_t::hardware_done() const
-{
-    return functional_done() && stores_done() && !inst_in_pipeline(); 
-}
-
-bool shd_warp_t::waiting() 
-{
-    if ( functional_done() ) {
-        // waiting to be initialized with a kernel
-        return true;
-    } else if ( m_shader->warp_waiting_at_barrier(m_warp_id) ) {
-        // waiting for other warps in CTA to reach barrier
-        return true;
-    } else if ( m_shader->warp_waiting_at_mem_barrier(m_warp_id) ) {
-        // waiting for memory barrier
-        return true;
-    } else if ( m_n_atomic >0 ) {
-        // waiting for atomic operation to complete at memory:
-        // this stall is not required for accurate timing model, but rather we
-        // stall here since if a call/return instruction occurs in the meantime
-        // the functional execution of the atomic when it hits DRAM can cause
-        // the wrong register to be read.
-        return true;
-    }
-    return false;
-}
-
-void shd_warp_t::print( FILE *fout ) const
-{
-    if( !done_exit() ) {
-        fprintf( fout, "w%02u npc: 0x%04x, done:%c%c%c%c:%2u i:%u s:%u a:%u (done: ", 
-                m_warp_id,
-                m_next_pc,
-                (functional_done()?'f':' '),
-                (stores_done()?'s':' '),
-                (inst_in_pipeline()?' ':'i'),
-                (done_exit()?'e':' '),
-                n_completed,
-                m_inst_in_pipeline, 
-                m_stores_outstanding,
-                m_n_atomic );
-        for (unsigned i = m_warp_id*m_warp_size; i < (m_warp_id+1)*m_warp_size; i++ ) {
-          if ( m_shader->ptx_thread_done(i) ) fprintf(fout,"1");
-          else fprintf(fout,"0");
-          if ( (((i+1)%4) == 0) && (i+1) < (m_warp_id+1)*m_warp_size ) 
-             fprintf(fout,",");
-        }
-        fprintf(fout,") ");
-        fprintf(fout," active=%s", m_active_threads.to_string().c_str() );
-        fprintf(fout," last fetched @ %5llu", m_last_fetch);
-        if( m_imiss_pending ) 
-            fprintf(fout," i-miss pending");
-        fprintf(fout,"\n");
-    }
-}
-
-void shd_warp_t::print_ibuffer( FILE *fout ) const
-{
-    fprintf(fout,"  ibuffer[%2u] : ", m_warp_id );
-    for( unsigned i=0; i < IBUFFER_SIZE; i++) {
-        const inst_t *inst = m_ibuffer[i].m_inst;
-        if( inst ) inst->print_insn(fout);
-        else if( m_ibuffer[i].m_valid ) 
-           fprintf(fout," <invalid instruction> ");
-        else fprintf(fout," <empty> ");
-    }
-    fprintf(fout,"\n");
-}
-
-void opndcoll_rfu_t::add_cu_set(unsigned set_id, unsigned num_cu, unsigned num_dispatch){
-    m_cus[set_id].reserve(num_cu); //this is necessary to stop pointers in m_cu from being invalid do to a resize;
-    for (unsigned i = 0; i < num_cu; i++) {
-        m_cus[set_id].push_back(collector_unit_t());
-        m_cu.push_back(&m_cus[set_id].back());
-    }
-    // for now each collector set gets dedicated dispatch units.
-    for (unsigned i = 0; i < num_dispatch; i++) {
-        m_dispatch_units.push_back(dispatch_unit_t(&m_cus[set_id]));
-    }
-}
-
-
-void opndcoll_rfu_t::add_port(port_vector_t & input, port_vector_t & output, uint_vector_t cu_sets)
-{
-    //m_num_ports++;
-    //m_num_collectors += num_collector_units;
-    //m_input.resize(m_num_ports);
-    //m_output.resize(m_num_ports);
-    //m_num_collector_units.resize(m_num_ports);
-    //m_input[m_num_ports-1]=input_port;
-    //m_output[m_num_ports-1]=output_port;
-    //m_num_collector_units[m_num_ports-1]=num_collector_units;
-    m_in_ports.push_back(input_port_t(input,output,cu_sets));
-}
-
-void opndcoll_rfu_t::init( unsigned num_banks, shader_core_ctx *shader )
-{
-   m_shader=shader;
-   m_arbiter.init(m_cu.size(),num_banks);
-   //for( unsigned n=0; n<m_num_ports;n++ ) 
-   //    m_dispatch_units[m_output[n]].init( m_num_collector_units[n] );
-   m_num_banks = num_banks;
-   m_bank_warp_shift = 0; 
-   m_warp_size = shader->get_config()->warp_size;
-   m_bank_warp_shift = (unsigned)(int) (log(m_warp_size+0.5) / log(2.0));
-   assert( (m_bank_warp_shift == 5) || (m_warp_size != 32) );
-
-   sub_core_model = shader->get_config()->sub_core_model;
-   m_num_warp_sceds = shader->get_config()->gpgpu_num_sched_per_core;
-   if(sub_core_model)
-	   assert(num_banks % shader->get_config()->gpgpu_num_sched_per_core == 0);
-   m_num_banks_per_sched = num_banks / shader->get_config()->gpgpu_num_sched_per_core;
-
-   for( unsigned j=0; j<m_cu.size(); j++) {
-       m_cu[j]->init(j,num_banks,m_bank_warp_shift,shader->get_config(),this, sub_core_model, m_num_banks_per_sched );
-   }
-   m_initialized=true;
-
-
-
-
-}
-
-int register_bank(int regnum, int wid, unsigned num_banks, unsigned bank_warp_shift, bool sub_core_model, unsigned banks_per_sched, unsigned sched_id)
-{
-   int bank = regnum;
-   if (bank_warp_shift)
-      bank += wid;
-   if(sub_core_model) {
-	   unsigned bank_num  = (bank % banks_per_sched) + (sched_id * banks_per_sched);
-	   assert(bank_num < num_banks);
-	   return bank_num;
-   }
-   else
-	   return bank % num_banks;
-}
-
-bool opndcoll_rfu_t::writeback( warp_inst_t &inst )
-{
-   assert( !inst.empty() );
-   std::list<unsigned> regs = m_shader->get_regs_written(inst);
-   for( unsigned op=0; op < MAX_REG_OPERANDS; op++ ) {
-      int reg_num = inst.arch_reg.dst[op]; // this math needs to match that used in function_info::ptx_decode_inst
-      if( reg_num >= 0 ){ // valid register
-         unsigned bank = register_bank(reg_num,inst.warp_id(),m_num_banks,m_bank_warp_shift, sub_core_model, m_num_banks_per_sched, inst.get_schd_id());
-         if( m_arbiter.bank_idle(bank) ) {
-             m_arbiter.allocate_bank_for_write(bank,op_t(&inst,reg_num,m_num_banks,m_bank_warp_shift, sub_core_model, m_num_banks_per_sched, inst.get_schd_id()));
-             inst.arch_reg.dst[op] = -1;
-         } else {
-             return false;
-         }
-      }
-   }
-   for(unsigned i=0;i<(unsigned)regs.size();i++){
-	      if(m_shader->get_config()->gpgpu_clock_gated_reg_file){
-	    	  unsigned active_count=0;
-	    	  for(unsigned i=0;i<m_shader->get_config()->warp_size;i=i+m_shader->get_config()->n_regfile_gating_group){
-	    		  for(unsigned j=0;j<m_shader->get_config()->n_regfile_gating_group;j++){
-	    			  if(inst.get_active_mask().test(i+j)){
-	    				  active_count+=m_shader->get_config()->n_regfile_gating_group;
-	    				  break;
-	    			  }
-	    		  }
-	    	  }
-	    	  m_shader->incregfile_writes(active_count);
-	      }else{
-	    	  m_shader->incregfile_writes(m_shader->get_config()->warp_size);//inst.active_count());
-	      }
-   }
-   return true;
-}
-
-void opndcoll_rfu_t::dispatch_ready_cu()
-{
-   for( unsigned p=0; p < m_dispatch_units.size(); ++p ) {
-      dispatch_unit_t &du = m_dispatch_units[p];
-      collector_unit_t *cu = du.find_ready();
-      if( cu ) {
-    	 for(unsigned i=0;i<(cu->get_num_operands()-cu->get_num_regs());i++){
-   	      if(m_shader->get_config()->gpgpu_clock_gated_reg_file){
-   	    	  unsigned active_count=0;
-   	    	  for(unsigned i=0;i<m_shader->get_config()->warp_size;i=i+m_shader->get_config()->n_regfile_gating_group){
-   	    		  for(unsigned j=0;j<m_shader->get_config()->n_regfile_gating_group;j++){
-   	    			  if(cu->get_active_mask().test(i+j)){
-   	    				  active_count+=m_shader->get_config()->n_regfile_gating_group;
-   	    				  break;
-   	    			  }
-   	    		  }
-   	    	  }
-   	    	  m_shader->incnon_rf_operands(active_count);
-   	      }else{
-    		 m_shader->incnon_rf_operands(m_shader->get_config()->warp_size);//cu->get_active_count());
-   	      }
-    	}
-         cu->dispatch();
-      }
-   }
-}
-
-void opndcoll_rfu_t::allocate_cu( unsigned port_num )
-{
-   input_port_t& inp = m_in_ports[port_num];
-   for (unsigned i = 0; i < inp.m_in.size(); i++) {
-       if( (*inp.m_in[i]).has_ready() ) {
-          //find a free cu 
-          for (unsigned j = 0; j < inp.m_cu_sets.size(); j++) {
-              std::vector<collector_unit_t> & cu_set = m_cus[inp.m_cu_sets[j]];
-	      bool allocated = false;
-              for (unsigned k = 0; k < cu_set.size(); k++) {
-                  if(cu_set[k].is_free()) {
-                     collector_unit_t *cu = &cu_set[k];
-                     allocated = cu->allocate(inp.m_in[i],inp.m_out[i]);
-                     m_arbiter.add_read_requests(cu);
-                     break;
-                  }
-              }
-              if (allocated) break; //cu has been allocated, no need to search more.
-          }
-          break; // can only service a single input, if it failed it will fail for others.
-       }
-   }
-}
-
-void opndcoll_rfu_t::allocate_reads()
-{
-   // process read requests that do not have conflicts
-   std::list<op_t> allocated = m_arbiter.allocate_reads();
-   std::map<unsigned,op_t> read_ops;
-   for( std::list<op_t>::iterator r=allocated.begin(); r!=allocated.end(); r++ ) {
-      const op_t &rr = *r;
-      unsigned reg = rr.get_reg();
-      unsigned wid = rr.get_wid();
-      unsigned bank = register_bank(reg,wid,m_num_banks,m_bank_warp_shift,sub_core_model, m_num_banks_per_sched, rr.get_sid());
-      m_arbiter.allocate_for_read(bank,rr);
-      read_ops[bank] = rr;
-   }
-   std::map<unsigned,op_t>::iterator r;
-   for(r=read_ops.begin();r!=read_ops.end();++r ) {
-      op_t &op = r->second;
-      unsigned cu = op.get_oc_id();
-      unsigned operand = op.get_operand();
-      m_cu[cu]->collect_operand(operand);
-      if(m_shader->get_config()->gpgpu_clock_gated_reg_file){
-    	  unsigned active_count=0;
-    	  for(unsigned i=0;i<m_shader->get_config()->warp_size;i=i+m_shader->get_config()->n_regfile_gating_group){
-    		  for(unsigned j=0;j<m_shader->get_config()->n_regfile_gating_group;j++){
-    			  if(op.get_active_mask().test(i+j)){
-    				  active_count+=m_shader->get_config()->n_regfile_gating_group;
-    				  break;
-    			  }
-    		  }
-    	  }
-    	  m_shader->incregfile_reads(active_count);
-      }else{
-    	  m_shader->incregfile_reads(m_shader->get_config()->warp_size);//op.get_active_count());
-      }
+  cta_to_warp_t::const_iterator i;
+  for (i = m_cta_to_warps.begin(); i != m_cta_to_warps.end(); i++) {
+    unsigned cta_id = i->first;
+    warp_set_t warps = i->second;
+    printf("    cta_id %u : %s\n", cta_id, warps.to_string().c_str());
   }
-} 
-
-bool opndcoll_rfu_t::collector_unit_t::ready() const 
-{ 
-   return (!m_free) && m_not_ready.none() && (*m_output_register).has_free(); 
+  printf("  warp_active: %s\n", m_warp_active.to_string().c_str());
+  printf("  warp_at_barrier: %s\n", m_warp_at_barrier.to_string().c_str());
+  for (unsigned i = 0; i < m_max_barriers_per_cta; i++) {
+    warp_set_t warps_reached_barrier = m_bar_id_to_warps[i];
+    printf("  warp_at_barrier %u: %s\n", i,
+           warps_reached_barrier.to_string().c_str());
+  }
+  fflush(stdout);
 }
 
-void opndcoll_rfu_t::collector_unit_t::dump(FILE *fp, const shader_core_ctx *shader ) const
-{
-   if( m_free ) {
-      fprintf(fp,"    <free>\n");
-   } else {
-      m_warp->print(fp);
-      for( unsigned i=0; i < MAX_REG_OPERANDS*2; i++ ) {
-         if( m_not_ready.test(i) ) {
-            std::string r = m_src_op[i].get_reg_string();
-            fprintf(fp,"    '%s' not ready\n", r.c_str() );
-         }
+void shader_core_ctx::warp_exit(unsigned warp_id) {
+  bool done = true;
+  for (unsigned i = warp_id * get_config()->warp_size;
+       i < (warp_id + 1) * get_config()->warp_size; i++) {
+    //		if(this->m_thread[i]->m_functional_model_thread_state &&
+    //this->m_thread[i].m_functional_model_thread_state->donecycle()==0) { 			done
+    //= false;
+    //		}
+
+    if (m_thread[i] && !m_thread[i]->is_done()) done = false;
+  }
+  // if (m_warp[warp_id].get_n_completed() == get_config()->warp_size)
+  // if (this->m_simt_stack[warp_id]->get_num_entries() == 0)
+  if (done) m_barriers.warp_exit(warp_id);
+}
+
+bool shader_core_ctx::check_if_non_released_reduction_barrier(
+    warp_inst_t &inst) {
+  unsigned warp_id = inst.warp_id();
+  bool bar_red_op = (inst.op == BARRIER_OP) && (inst.bar_type == RED);
+  bool non_released_barrier_reduction = false;
+  bool warp_stucked_at_barrier = warp_waiting_at_barrier(warp_id);
+  bool single_inst_in_pipeline =
+      (m_warp[warp_id].num_issued_inst_in_pipeline() == 1);
+  non_released_barrier_reduction =
+      single_inst_in_pipeline and warp_stucked_at_barrier and bar_red_op;
+  printf("non_released_barrier_reduction=%u\n", non_released_barrier_reduction);
+  return non_released_barrier_reduction;
+}
+
+bool shader_core_ctx::warp_waiting_at_barrier(unsigned warp_id) const {
+  return m_barriers.warp_waiting_at_barrier(warp_id);
+}
+
+bool shader_core_ctx::warp_waiting_at_mem_barrier(unsigned warp_id) {
+  if (!m_warp[warp_id].get_membar()) return false;
+  if (!m_scoreboard->pendingWrites(warp_id)) {
+    m_warp[warp_id].clear_membar();
+    return false;
+  }
+  return true;
+}
+
+void shader_core_ctx::set_max_cta(const kernel_info_t &kernel) {
+  // calculate the max cta count and cta size for local memory address mapping
+  kernel_max_cta_per_shader = m_config->max_cta(kernel);
+  unsigned int gpu_cta_size = kernel.threads_per_cta();
+  kernel_padded_threads_per_cta =
+      (gpu_cta_size % m_config->warp_size)
+          ? m_config->warp_size * ((gpu_cta_size / m_config->warp_size) + 1)
+          : gpu_cta_size;
+}
+
+void shader_core_ctx::decrement_atomic_count(unsigned wid, unsigned n) {
+  assert(m_warp[wid].get_n_atomic() >= n);
+  m_warp[wid].dec_n_atomic(n);
+}
+
+void shader_core_ctx::broadcast_barrier_reduction(unsigned cta_id,
+                                                  unsigned bar_id,
+                                                  warp_set_t warps) {
+  for (unsigned i = 0; i < m_config->max_warps_per_shader; i++) {
+    if (warps.test(i)) {
+      const warp_inst_t *inst =
+          m_warp[i].restore_info_of_last_inst_at_barrier();
+      const_cast<warp_inst_t *>(inst)->broadcast_barrier_reduction(
+          inst->get_active_mask());
+    }
+  }
+}
+
+bool shader_core_ctx::fetch_unit_response_buffer_full() const { return false; }
+
+void shader_core_ctx::accept_fetch_response(mem_fetch *mf) {
+  mf->set_status(IN_SHADER_FETCHED,
+                 m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+  m_L1I->fill(mf, m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+}
+
+bool shader_core_ctx::ldst_unit_response_buffer_full() const {
+  return m_ldst_unit->response_buffer_full();
+}
+
+void shader_core_ctx::accept_ldst_unit_response(mem_fetch *mf) {
+  m_ldst_unit->fill(mf);
+}
+
+void shader_core_ctx::store_ack(class mem_fetch *mf) {
+  assert(mf->get_type() == WRITE_ACK ||
+         (m_config->gpgpu_perfect_mem && mf->get_is_write()));
+  unsigned warp_id = mf->get_wid();
+  m_warp[warp_id].dec_store_req();
+}
+
+void shader_core_ctx::print_cache_stats(FILE *fp, unsigned &dl1_accesses,
+                                        unsigned &dl1_misses) {
+  m_ldst_unit->print_cache_stats(fp, dl1_accesses, dl1_misses);
+}
+
+void shader_core_ctx::get_cache_stats(cache_stats &cs) {
+  // Adds stats from each cache to 'cs'
+  cs += m_L1I->get_stats();          // Get L1I stats
+  m_ldst_unit->get_cache_stats(cs);  // Get L1D, L1C, L1T stats
+}
+
+void shader_core_ctx::get_L1I_sub_stats(struct cache_sub_stats &css) const {
+  if (m_L1I) m_L1I->get_sub_stats(css);
+}
+void shader_core_ctx::get_L1D_sub_stats(struct cache_sub_stats &css) const {
+  m_ldst_unit->get_L1D_sub_stats(css);
+}
+void shader_core_ctx::get_L1C_sub_stats(struct cache_sub_stats &css) const {
+  m_ldst_unit->get_L1C_sub_stats(css);
+}
+void shader_core_ctx::get_L1T_sub_stats(struct cache_sub_stats &css) const {
+  m_ldst_unit->get_L1T_sub_stats(css);
+}
+
+void shader_core_ctx::get_icnt_power_stats(long &n_simt_to_mem,
+                                           long &n_mem_to_simt) const {
+  n_simt_to_mem += m_stats->n_simt_to_mem[m_sid];
+  n_mem_to_simt += m_stats->n_mem_to_simt[m_sid];
+}
+
+bool shd_warp_t::functional_done() const {
+  return get_n_completed() == m_warp_size;
+}
+
+bool shd_warp_t::hardware_done() const {
+  return functional_done() && stores_done() && !inst_in_pipeline();
+}
+
+bool shd_warp_t::waiting() {
+  if (functional_done()) {
+    // waiting to be initialized with a kernel
+    return true;
+  } else if (m_shader->warp_waiting_at_barrier(m_warp_id)) {
+    // waiting for other warps in CTA to reach barrier
+    return true;
+  } else if (m_shader->warp_waiting_at_mem_barrier(m_warp_id)) {
+    // waiting for memory barrier
+    return true;
+  } else if (m_n_atomic > 0) {
+    // waiting for atomic operation to complete at memory:
+    // this stall is not required for accurate timing model, but rather we
+    // stall here since if a call/return instruction occurs in the meantime
+    // the functional execution of the atomic when it hits DRAM can cause
+    // the wrong register to be read.
+    return true;
+  }
+  return false;
+}
+
+void shd_warp_t::print(FILE *fout) const {
+  if (!done_exit()) {
+    fprintf(fout, "w%02u npc: 0x%04x, done:%c%c%c%c:%2u i:%u s:%u a:%u (done: ",
+            m_warp_id, m_next_pc, (functional_done() ? 'f' : ' '),
+            (stores_done() ? 's' : ' '), (inst_in_pipeline() ? ' ' : 'i'),
+            (done_exit() ? 'e' : ' '), n_completed, m_inst_in_pipeline,
+            m_stores_outstanding, m_n_atomic);
+    for (unsigned i = m_warp_id * m_warp_size;
+         i < (m_warp_id + 1) * m_warp_size; i++) {
+      if (m_shader->ptx_thread_done(i))
+        fprintf(fout, "1");
+      else
+        fprintf(fout, "0");
+      if ((((i + 1) % 4) == 0) && (i + 1) < (m_warp_id + 1) * m_warp_size)
+        fprintf(fout, ",");
+    }
+    fprintf(fout, ") ");
+    fprintf(fout, " active=%s", m_active_threads.to_string().c_str());
+    fprintf(fout, " last fetched @ %5llu", m_last_fetch);
+    if (m_imiss_pending) fprintf(fout, " i-miss pending");
+    fprintf(fout, "\n");
+  }
+}
+
+void shd_warp_t::print_ibuffer(FILE *fout) const {
+  fprintf(fout, "  ibuffer[%2u] : ", m_warp_id);
+  for (unsigned i = 0; i < IBUFFER_SIZE; i++) {
+    const inst_t *inst = m_ibuffer[i].m_inst;
+    if (inst)
+      inst->print_insn(fout);
+    else if (m_ibuffer[i].m_valid)
+      fprintf(fout, " <invalid instruction> ");
+    else
+      fprintf(fout, " <empty> ");
+  }
+  fprintf(fout, "\n");
+}
+
+void opndcoll_rfu_t::add_cu_set(unsigned set_id, unsigned num_cu,
+                                unsigned num_dispatch) {
+  m_cus[set_id].reserve(num_cu);  // this is necessary to stop pointers in m_cu
+                                  // from being invalid do to a resize;
+  for (unsigned i = 0; i < num_cu; i++) {
+    m_cus[set_id].push_back(collector_unit_t());
+    m_cu.push_back(&m_cus[set_id].back());
+  }
+  // for now each collector set gets dedicated dispatch units.
+  for (unsigned i = 0; i < num_dispatch; i++) {
+    m_dispatch_units.push_back(dispatch_unit_t(&m_cus[set_id]));
+  }
+}
+
+void opndcoll_rfu_t::add_port(port_vector_t &input, port_vector_t &output,
+                              uint_vector_t cu_sets) {
+  // m_num_ports++;
+  // m_num_collectors += num_collector_units;
+  // m_input.resize(m_num_ports);
+  // m_output.resize(m_num_ports);
+  // m_num_collector_units.resize(m_num_ports);
+  // m_input[m_num_ports-1]=input_port;
+  // m_output[m_num_ports-1]=output_port;
+  // m_num_collector_units[m_num_ports-1]=num_collector_units;
+  m_in_ports.push_back(input_port_t(input, output, cu_sets));
+}
+
+void opndcoll_rfu_t::init(unsigned num_banks, shader_core_ctx *shader) {
+  m_shader = shader;
+  m_arbiter.init(m_cu.size(), num_banks);
+  // for( unsigned n=0; n<m_num_ports;n++ )
+  //    m_dispatch_units[m_output[n]].init( m_num_collector_units[n] );
+  m_num_banks = num_banks;
+  m_bank_warp_shift = 0;
+  m_warp_size = shader->get_config()->warp_size;
+  m_bank_warp_shift = (unsigned)(int)(log(m_warp_size + 0.5) / log(2.0));
+  assert((m_bank_warp_shift == 5) || (m_warp_size != 32));
+
+  sub_core_model = shader->get_config()->sub_core_model;
+  m_num_warp_sceds = shader->get_config()->gpgpu_num_sched_per_core;
+  if (sub_core_model)
+    assert(num_banks % shader->get_config()->gpgpu_num_sched_per_core == 0);
+  m_num_banks_per_sched =
+      num_banks / shader->get_config()->gpgpu_num_sched_per_core;
+
+  for (unsigned j = 0; j < m_cu.size(); j++) {
+    m_cu[j]->init(j, num_banks, m_bank_warp_shift, shader->get_config(), this,
+                  sub_core_model, m_num_banks_per_sched);
+  }
+  m_initialized = true;
+}
+
+int register_bank(int regnum, int wid, unsigned num_banks,
+                  unsigned bank_warp_shift, bool sub_core_model,
+                  unsigned banks_per_sched, unsigned sched_id) {
+  int bank = regnum;
+  if (bank_warp_shift) bank += wid;
+  if (sub_core_model) {
+    unsigned bank_num = (bank % banks_per_sched) + (sched_id * banks_per_sched);
+    assert(bank_num < num_banks);
+    return bank_num;
+  } else
+    return bank % num_banks;
+}
+
+bool opndcoll_rfu_t::writeback(warp_inst_t &inst) {
+  assert(!inst.empty());
+  std::list<unsigned> regs = m_shader->get_regs_written(inst);
+  for (unsigned op = 0; op < MAX_REG_OPERANDS; op++) {
+    int reg_num = inst.arch_reg.dst[op];  // this math needs to match that used
+                                          // in function_info::ptx_decode_inst
+    if (reg_num >= 0) {                   // valid register
+      unsigned bank = register_bank(reg_num, inst.warp_id(), m_num_banks,
+                                    m_bank_warp_shift, sub_core_model,
+                                    m_num_banks_per_sched, inst.get_schd_id());
+      if (m_arbiter.bank_idle(bank)) {
+        m_arbiter.allocate_bank_for_write(
+            bank,
+            op_t(&inst, reg_num, m_num_banks, m_bank_warp_shift, sub_core_model,
+                 m_num_banks_per_sched, inst.get_schd_id()));
+        inst.arch_reg.dst[op] = -1;
+      } else {
+        return false;
       }
-   }
-}
-
-void opndcoll_rfu_t::collector_unit_t::init( unsigned n, 
-                                             unsigned num_banks, 
-                                             unsigned log2_warp_size,
-                                             const core_config *config,
-                                             opndcoll_rfu_t *rfu,
-											 bool sub_core_model,
-											 unsigned banks_per_sched)
-{ 
-   m_rfu=rfu;
-   m_cuid=n; 
-   m_num_banks=num_banks;
-   assert(m_warp==NULL); 
-   m_warp = new warp_inst_t(config);
-   m_bank_warp_shift=log2_warp_size;
-   m_sub_core_model = sub_core_model;
-   m_num_banks_per_sched = banks_per_sched;
-}
-
-bool opndcoll_rfu_t::collector_unit_t::allocate( register_set* pipeline_reg_set, register_set* output_reg_set ) 
-{
-   assert(m_free);
-   assert(m_not_ready.none());
-   m_free = false;
-   m_output_register = output_reg_set;
-   warp_inst_t **pipeline_reg = pipeline_reg_set->get_ready();
-   if( (pipeline_reg) and !((*pipeline_reg)->empty()) ) {
-      m_warp_id = (*pipeline_reg)->warp_id();
-      for( unsigned op=0; op < MAX_REG_OPERANDS; op++ ) {
-         int reg_num = (*pipeline_reg)->arch_reg.src[op]; // this math needs to match that used in function_info::ptx_decode_inst
-         if( reg_num >= 0 ) { // valid register
-            m_src_op[op] = op_t( this, op, reg_num, m_num_banks, m_bank_warp_shift, m_sub_core_model, m_num_banks_per_sched, (*pipeline_reg)->get_schd_id() );
-            m_not_ready.set(op);
-         } else 
-            m_src_op[op] = op_t();
-      }
-      //move_warp(m_warp,*pipeline_reg);
-      pipeline_reg_set->move_out_to(m_warp);
-      return true;
-   }
-   return false;
-}
-
-void opndcoll_rfu_t::collector_unit_t::dispatch()
-{
-   assert( m_not_ready.none() );
-   //move_warp(*m_output_register,m_warp);
-   m_output_register->move_in(m_warp);
-   m_free=true;
-   m_output_register = NULL;
-   for( unsigned i=0; i<MAX_REG_OPERANDS*2;i++)
-      m_src_op[i].reset();
-}
-
-simt_core_cluster::simt_core_cluster( class gpgpu_sim *gpu, 
-                                      unsigned cluster_id, 
-                                      const shader_core_config *config, 
-                                      const memory_config *mem_config,
-                                      shader_core_stats *stats, 
-                                      class memory_stats_t *mstats )
-{
-    m_config = config;
-    m_cta_issue_next_core=m_config->n_simt_cores_per_cluster-1; // this causes first launch to use hw cta 0
-    m_cluster_id=cluster_id;
-    m_gpu = gpu;
-    m_stats = stats;
-    m_memory_stats = mstats;
-    m_core = new shader_core_ctx*[ config->n_simt_cores_per_cluster ];
-    for( unsigned i=0; i < config->n_simt_cores_per_cluster; i++ ) {
-        unsigned sid = m_config->cid_to_sid(i,m_cluster_id);
-        m_core[i] = new shader_core_ctx(gpu,this,sid,m_cluster_id,config,mem_config,stats);
-        m_core_sim_order.push_back(i); 
     }
-}
-
-void simt_core_cluster::core_cycle()
-{
-    for( std::list<unsigned>::iterator it = m_core_sim_order.begin(); it != m_core_sim_order.end(); ++it ) {
-        m_core[*it]->cycle();
-    }
-
-    if (m_config->simt_core_sim_order == 1) {
-        m_core_sim_order.splice(m_core_sim_order.end(), m_core_sim_order, m_core_sim_order.begin()); 
-    }
-}
-
-void simt_core_cluster::reinit()
-{
-    for( unsigned i=0; i < m_config->n_simt_cores_per_cluster; i++ ) 
-        m_core[i]->reinit(0,m_config->n_thread_per_shader,true);
-}
-
-unsigned simt_core_cluster::max_cta( const kernel_info_t &kernel )
-{
-    return m_config->n_simt_cores_per_cluster * m_config->max_cta(kernel);
-}
-
-unsigned simt_core_cluster::get_not_completed() const
-{
-    unsigned not_completed=0;
-    for( unsigned i=0; i < m_config->n_simt_cores_per_cluster; i++ ) 
-        not_completed += m_core[i]->get_not_completed();
-    return not_completed;
-}
-
-void simt_core_cluster::print_not_completed( FILE *fp ) const
-{
-    for( unsigned i=0; i < m_config->n_simt_cores_per_cluster; i++ ) {
-        unsigned not_completed=m_core[i]->get_not_completed();
-        unsigned sid=m_config->cid_to_sid(i,m_cluster_id);
-        fprintf(fp,"%u(%u) ", sid, not_completed );
-    }
-}
-
-
-float simt_core_cluster::get_current_occupancy( unsigned long long& active, unsigned long long& total ) const {
-    float aggregate = 0.f;
-    for( unsigned i=0; i < m_config->n_simt_cores_per_cluster; i++ ) {
-        aggregate+=m_core[i]->get_current_occupancy( active, total );
-    }
-    return aggregate / m_config->n_simt_cores_per_cluster;
-}
-
-unsigned simt_core_cluster::get_n_active_cta() const
-{
-    unsigned n=0;
-    for( unsigned i=0; i < m_config->n_simt_cores_per_cluster; i++ ) 
-        n += m_core[i]->get_n_active_cta();
-    return n;
-}
-
-unsigned simt_core_cluster::get_n_active_sms() const
-{
-    unsigned n=0;
-    for( unsigned i=0; i < m_config->n_simt_cores_per_cluster; i++ )
-        n += m_core[i]->isactive();
-    return n;
-}
-
-unsigned simt_core_cluster::issue_block2core()
-{
-    unsigned num_blocks_issued=0;
-    for( unsigned i=0; i < m_config->n_simt_cores_per_cluster; i++ ) {
-        unsigned core = (i+m_cta_issue_next_core+1)%m_config->n_simt_cores_per_cluster;
-
-        kernel_info_t * kernel;
-         //Jin: fetch kernel according to concurrent kernel setting
-        if(m_config->gpgpu_concurrent_kernel_sm) {//concurrent kernel on sm 
-            //always select latest issued kernel
-            kernel_info_t *k = m_gpu->select_kernel();
-            kernel = k;
+  }
+  for (unsigned i = 0; i < (unsigned)regs.size(); i++) {
+    if (m_shader->get_config()->gpgpu_clock_gated_reg_file) {
+      unsigned active_count = 0;
+      for (unsigned i = 0; i < m_shader->get_config()->warp_size;
+           i = i + m_shader->get_config()->n_regfile_gating_group) {
+        for (unsigned j = 0; j < m_shader->get_config()->n_regfile_gating_group;
+             j++) {
+          if (inst.get_active_mask().test(i + j)) {
+            active_count += m_shader->get_config()->n_regfile_gating_group;
+            break;
+          }
         }
-        else {
-            //first select core kernel, if no more cta, get a new kernel
-            //only when core completes
-            kernel = m_core[core]->get_kernel();
-            if( !m_gpu->kernel_more_cta_left(kernel) ) {
-              //wait till current kernel finishes
-              if(m_core[core]->get_not_completed() == 0)
-              {
-                  kernel_info_t *k = m_gpu->select_kernel();
-                  if( k ) 
-                      m_core[core]->set_kernel(k);
-                  kernel = k;
+      }
+      m_shader->incregfile_writes(active_count);
+    } else {
+      m_shader->incregfile_writes(
+          m_shader->get_config()->warp_size);  // inst.active_count());
+    }
+  }
+  return true;
+}
+
+void opndcoll_rfu_t::dispatch_ready_cu() {
+  for (unsigned p = 0; p < m_dispatch_units.size(); ++p) {
+    dispatch_unit_t &du = m_dispatch_units[p];
+    collector_unit_t *cu = du.find_ready();
+    if (cu) {
+      for (unsigned i = 0; i < (cu->get_num_operands() - cu->get_num_regs());
+           i++) {
+        if (m_shader->get_config()->gpgpu_clock_gated_reg_file) {
+          unsigned active_count = 0;
+          for (unsigned i = 0; i < m_shader->get_config()->warp_size;
+               i = i + m_shader->get_config()->n_regfile_gating_group) {
+            for (unsigned j = 0;
+                 j < m_shader->get_config()->n_regfile_gating_group; j++) {
+              if (cu->get_active_mask().test(i + j)) {
+                active_count += m_shader->get_config()->n_regfile_gating_group;
+                break;
               }
             }
-        }
-
-        if( m_gpu->kernel_more_cta_left(kernel) && 
-//            (m_core[core]->get_n_active_cta() < m_config->max_cta(*kernel)) ) {
-            m_core[core]->can_issue_1block(*kernel)) {
-            m_core[core]->issue_block2core(*kernel);
-            num_blocks_issued++;
-            m_cta_issue_next_core=core; 
-            break;
-        }
-    }
-    return num_blocks_issued;
-}
-
-void simt_core_cluster::cache_flush()
-{
-    for( unsigned i=0; i < m_config->n_simt_cores_per_cluster; i++ ) 
-        m_core[i]->cache_flush();
-}
-
-void simt_core_cluster::cache_invalidate()
-{
-    for( unsigned i=0; i < m_config->n_simt_cores_per_cluster; i++ )
-        m_core[i]->cache_invalidate();
-}
-
-bool simt_core_cluster::icnt_injection_buffer_full(unsigned size, bool write)
-{
-    unsigned request_size = size;
-    if (!write) 
-        request_size = READ_PACKET_SIZE;
-    return ! ::icnt_has_buffer(m_cluster_id, request_size);
-}
-
-void simt_core_cluster::icnt_inject_request_packet(class mem_fetch *mf)
-{
-    // stats
-    if (mf->get_is_write()) m_stats->made_write_mfs++;
-    else m_stats->made_read_mfs++;
-    switch (mf->get_access_type()) {
-    case CONST_ACC_R: m_stats->gpgpu_n_mem_const++; break;
-    case TEXTURE_ACC_R: m_stats->gpgpu_n_mem_texture++; break;
-    case GLOBAL_ACC_R: m_stats->gpgpu_n_mem_read_global++; break;
-    //case GLOBAL_ACC_R: m_stats->gpgpu_n_mem_read_global++; printf("read_global%d\n",m_stats->gpgpu_n_mem_read_global); break;
-    case GLOBAL_ACC_W: m_stats->gpgpu_n_mem_write_global++; break;
-    case LOCAL_ACC_R: m_stats->gpgpu_n_mem_read_local++; break;
-    case LOCAL_ACC_W: m_stats->gpgpu_n_mem_write_local++; break;
-    case INST_ACC_R: m_stats->gpgpu_n_mem_read_inst++; break;
-    case L1_WRBK_ACC: m_stats->gpgpu_n_mem_write_global++; break;
-    case L2_WRBK_ACC: m_stats->gpgpu_n_mem_l2_writeback++; break;
-    case L1_WR_ALLOC_R: m_stats->gpgpu_n_mem_l1_write_allocate++; break;
-    case L2_WR_ALLOC_R: m_stats->gpgpu_n_mem_l2_write_allocate++; break;
-    default: assert(0);
-    }
-
-   // The packet size varies depending on the type of request: 
-   // - For write request and atomic request, the packet contains the data 
-   // - For read request (i.e. not write nor atomic), the packet only has control metadata
-   unsigned int packet_size = mf->size(); 
-   if (!mf->get_is_write() && !mf->isatomic()) {
-      packet_size = mf->get_ctrl_size(); 
-   }
-   m_stats->m_outgoing_traffic_stats->record_traffic(mf, packet_size); 
-   unsigned destination = mf->get_sub_partition_id();
-   mf->set_status(IN_ICNT_TO_MEM,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-   if (!mf->get_is_write() && !mf->isatomic())
-      ::icnt_push(m_cluster_id, m_config->mem2device(destination), (void*)mf, mf->get_ctrl_size() );
-   else 
-      ::icnt_push(m_cluster_id, m_config->mem2device(destination), (void*)mf, mf->size());
-}
-
-void simt_core_cluster::icnt_cycle()
-{
-    if( !m_response_fifo.empty() ) {
-        mem_fetch *mf = m_response_fifo.front();
-        unsigned cid = m_config->sid_to_cid(mf->get_sid());
-        if( mf->get_access_type() == INST_ACC_R ) {
-            // instruction fetch response
-            if( !m_core[cid]->fetch_unit_response_buffer_full() ) {
-                m_response_fifo.pop_front();
-                m_core[cid]->accept_fetch_response(mf);
-            }
+          }
+          m_shader->incnon_rf_operands(active_count);
         } else {
-            // data response
-            if( !m_core[cid]->ldst_unit_response_buffer_full() ) {
-                m_response_fifo.pop_front();
-                m_memory_stats->memlatstat_read_done(mf);
-                m_core[cid]->accept_ldst_unit_response(mf);
-            }
+          m_shader->incnon_rf_operands(
+              m_shader->get_config()->warp_size);  // cu->get_active_count());
         }
+      }
+      cu->dispatch();
     }
-    if( m_response_fifo.size() < m_config->n_simt_ejection_buffer_size ) {
-        mem_fetch *mf = (mem_fetch*) ::icnt_pop(m_cluster_id);
-        if (!mf) 
-            return;
-        assert(mf->get_tpc() == m_cluster_id);
-        assert(mf->get_type() == READ_REPLY || mf->get_type() == WRITE_ACK );
-
-        // The packet size varies depending on the type of request: 
-        // - For read request and atomic request, the packet contains the data 
-        // - For write-ack, the packet only has control metadata
-        unsigned int packet_size = (mf->get_is_write())? mf->get_ctrl_size() : mf->size(); 
-        m_stats->m_incoming_traffic_stats->record_traffic(mf, packet_size); 
-        mf->set_status(IN_CLUSTER_TO_SHADER_QUEUE,m_gpu->gpu_sim_cycle+m_gpu->gpu_tot_sim_cycle);
-        //m_memory_stats->memlatstat_read_done(mf,m_shader_config->max_warps_per_shader);
-        m_response_fifo.push_back(mf);
-        m_stats->n_mem_to_simt[m_cluster_id] += mf->get_num_flits(false);
-    }
+  }
 }
 
-void simt_core_cluster::get_pdom_stack_top_info( unsigned sid, unsigned tid, unsigned *pc, unsigned *rpc ) const
-{
-    unsigned cid = m_config->sid_to_cid(sid);
-    m_core[cid]->get_pdom_stack_top_info(tid,pc,rpc);
-}
-
-void simt_core_cluster::display_pipeline( unsigned sid, FILE *fout, int print_mem, int mask )
-{
-    m_core[m_config->sid_to_cid(sid)]->display_pipeline(fout,print_mem,mask);
-
-    fprintf(fout,"\n");
-    fprintf(fout,"Cluster %u pipeline state\n", m_cluster_id );
-    fprintf(fout,"Response FIFO (occupancy = %zu):\n", m_response_fifo.size() );
-    for( std::list<mem_fetch*>::const_iterator i=m_response_fifo.begin(); i != m_response_fifo.end(); i++ ) {
-        const mem_fetch *mf = *i;
-        mf->print(fout);
-    }
-}
-
-void simt_core_cluster::print_cache_stats( FILE *fp, unsigned& dl1_accesses, unsigned& dl1_misses ) const {
-   for ( unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i ) {
-      m_core[ i ]->print_cache_stats( fp, dl1_accesses, dl1_misses );
-   }
-}
-
-void simt_core_cluster::get_icnt_stats(long &n_simt_to_mem, long &n_mem_to_simt) const {
-	long simt_to_mem=0;
-	long mem_to_simt=0;
-	for ( unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i ) {
-		m_core[i]->get_icnt_power_stats(simt_to_mem, mem_to_simt);
-	}
-	n_simt_to_mem = simt_to_mem;
-	n_mem_to_simt = mem_to_simt;
-}
-
-void simt_core_cluster::get_cache_stats(cache_stats &cs) const{
-    for ( unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i ) {
-        m_core[i]->get_cache_stats(cs);
-    }
-}
-
-void simt_core_cluster::get_L1I_sub_stats(struct cache_sub_stats &css) const{
-    struct cache_sub_stats temp_css;
-    struct cache_sub_stats total_css;
-    temp_css.clear();
-    total_css.clear();
-    for ( unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i ) {
-        m_core[i]->get_L1I_sub_stats(temp_css);
-        total_css += temp_css;
-    }
-    css = total_css;
-}
-void simt_core_cluster::get_L1D_sub_stats(struct cache_sub_stats &css) const{
-    struct cache_sub_stats temp_css;
-    struct cache_sub_stats total_css;
-    temp_css.clear();
-    total_css.clear();
-    for ( unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i ) {
-        m_core[i]->get_L1D_sub_stats(temp_css);
-        total_css += temp_css;
-    }
-    css = total_css;
-}
-void simt_core_cluster::get_L1C_sub_stats(struct cache_sub_stats &css) const{
-    struct cache_sub_stats temp_css;
-    struct cache_sub_stats total_css;
-    temp_css.clear();
-    total_css.clear();
-    for ( unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i ) {
-        m_core[i]->get_L1C_sub_stats(temp_css);
-        total_css += temp_css;
-    }
-    css = total_css;
-}
-void simt_core_cluster::get_L1T_sub_stats(struct cache_sub_stats &css) const{
-    struct cache_sub_stats temp_css;
-    struct cache_sub_stats total_css;
-    temp_css.clear();
-    total_css.clear();
-    for ( unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i ) {
-        m_core[i]->get_L1T_sub_stats(temp_css);
-        total_css += temp_css;
-    }
-    css = total_css;
-}
-
-void shader_core_ctx::checkExecutionStatusAndUpdate(warp_inst_t &inst, unsigned t, unsigned tid)
-{
-    if(inst.isatomic())
-           m_warp[inst.warp_id()].inc_n_atomic();
-        if (inst.space.is_local() && (inst.is_load() || inst.is_store())) {
-            new_addr_type localaddrs[MAX_ACCESSES_PER_INSN_PER_THREAD];
-            unsigned num_addrs;
-            num_addrs = translate_local_memaddr(inst.get_addr(t), tid, m_config->n_simt_clusters*m_config->n_simt_cores_per_cluster,
-                   inst.data_size, (new_addr_type*) localaddrs );
-            inst.set_addr(t, (new_addr_type*) localaddrs, num_addrs);
+void opndcoll_rfu_t::allocate_cu(unsigned port_num) {
+  input_port_t &inp = m_in_ports[port_num];
+  for (unsigned i = 0; i < inp.m_in.size(); i++) {
+    if ((*inp.m_in[i]).has_ready()) {
+      // find a free cu
+      for (unsigned j = 0; j < inp.m_cu_sets.size(); j++) {
+        std::vector<collector_unit_t> &cu_set = m_cus[inp.m_cu_sets[j]];
+        bool allocated = false;
+        for (unsigned k = 0; k < cu_set.size(); k++) {
+          if (cu_set[k].is_free()) {
+            collector_unit_t *cu = &cu_set[k];
+            allocated = cu->allocate(inp.m_in[i], inp.m_out[i]);
+            m_arbiter.add_read_requests(cu);
+            break;
+          }
         }
-        if ( ptx_thread_done(tid) ) {
-            m_warp[inst.warp_id()].set_completed(t);
-            m_warp[inst.warp_id()].ibuffer_flush();
-        }
-
-    // PC-Histogram Update 
-    unsigned warp_id = inst.warp_id(); 
-    unsigned pc = inst.pc; 
-    for (unsigned t = 0; t < m_config->warp_size; t++) {
-        if (inst.active(t)) {
-            int tid = warp_id * m_config->warp_size + t; 
-            cflog_update_thread_pc(m_sid, tid, pc);  
-        }
+        if (allocated) break;  // cu has been allocated, no need to search more.
+      }
+      break;  // can only service a single input, if it failed it will fail for
+              // others.
     }
+  }
 }
 
+void opndcoll_rfu_t::allocate_reads() {
+  // process read requests that do not have conflicts
+  std::list<op_t> allocated = m_arbiter.allocate_reads();
+  std::map<unsigned, op_t> read_ops;
+  for (std::list<op_t>::iterator r = allocated.begin(); r != allocated.end();
+       r++) {
+    const op_t &rr = *r;
+    unsigned reg = rr.get_reg();
+    unsigned wid = rr.get_wid();
+    unsigned bank =
+        register_bank(reg, wid, m_num_banks, m_bank_warp_shift, sub_core_model,
+                      m_num_banks_per_sched, rr.get_sid());
+    m_arbiter.allocate_for_read(bank, rr);
+    read_ops[bank] = rr;
+  }
+  std::map<unsigned, op_t>::iterator r;
+  for (r = read_ops.begin(); r != read_ops.end(); ++r) {
+    op_t &op = r->second;
+    unsigned cu = op.get_oc_id();
+    unsigned operand = op.get_operand();
+    m_cu[cu]->collect_operand(operand);
+    if (m_shader->get_config()->gpgpu_clock_gated_reg_file) {
+      unsigned active_count = 0;
+      for (unsigned i = 0; i < m_shader->get_config()->warp_size;
+           i = i + m_shader->get_config()->n_regfile_gating_group) {
+        for (unsigned j = 0; j < m_shader->get_config()->n_regfile_gating_group;
+             j++) {
+          if (op.get_active_mask().test(i + j)) {
+            active_count += m_shader->get_config()->n_regfile_gating_group;
+            break;
+          }
+        }
+      }
+      m_shader->incregfile_reads(active_count);
+    } else {
+      m_shader->incregfile_reads(
+          m_shader->get_config()->warp_size);  // op.get_active_count());
+    }
+  }
+}
+
+bool opndcoll_rfu_t::collector_unit_t::ready() const {
+  return (!m_free) && m_not_ready.none() && (*m_output_register).has_free();
+}
+
+void opndcoll_rfu_t::collector_unit_t::dump(
+    FILE *fp, const shader_core_ctx *shader) const {
+  if (m_free) {
+    fprintf(fp, "    <free>\n");
+  } else {
+    m_warp->print(fp);
+    for (unsigned i = 0; i < MAX_REG_OPERANDS * 2; i++) {
+      if (m_not_ready.test(i)) {
+        std::string r = m_src_op[i].get_reg_string();
+        fprintf(fp, "    '%s' not ready\n", r.c_str());
+      }
+    }
+  }
+}
+
+void opndcoll_rfu_t::collector_unit_t::init(unsigned n, unsigned num_banks,
+                                            unsigned log2_warp_size,
+                                            const core_config *config,
+                                            opndcoll_rfu_t *rfu,
+                                            bool sub_core_model,
+                                            unsigned banks_per_sched) {
+  m_rfu = rfu;
+  m_cuid = n;
+  m_num_banks = num_banks;
+  assert(m_warp == NULL);
+  m_warp = new warp_inst_t(config);
+  m_bank_warp_shift = log2_warp_size;
+  m_sub_core_model = sub_core_model;
+  m_num_banks_per_sched = banks_per_sched;
+}
+
+bool opndcoll_rfu_t::collector_unit_t::allocate(register_set *pipeline_reg_set,
+                                                register_set *output_reg_set) {
+  assert(m_free);
+  assert(m_not_ready.none());
+  m_free = false;
+  m_output_register = output_reg_set;
+  warp_inst_t **pipeline_reg = pipeline_reg_set->get_ready();
+  if ((pipeline_reg) and !((*pipeline_reg)->empty())) {
+    m_warp_id = (*pipeline_reg)->warp_id();
+    for (unsigned op = 0; op < MAX_REG_OPERANDS; op++) {
+      int reg_num =
+          (*pipeline_reg)
+              ->arch_reg.src[op];  // this math needs to match that used in
+                                   // function_info::ptx_decode_inst
+      if (reg_num >= 0) {          // valid register
+        m_src_op[op] = op_t(this, op, reg_num, m_num_banks, m_bank_warp_shift,
+                            m_sub_core_model, m_num_banks_per_sched,
+                            (*pipeline_reg)->get_schd_id());
+        m_not_ready.set(op);
+      } else
+        m_src_op[op] = op_t();
+    }
+    // move_warp(m_warp,*pipeline_reg);
+    pipeline_reg_set->move_out_to(m_warp);
+    return true;
+  }
+  return false;
+}
+
+void opndcoll_rfu_t::collector_unit_t::dispatch() {
+  assert(m_not_ready.none());
+  // move_warp(*m_output_register,m_warp);
+  m_output_register->move_in(m_warp);
+  m_free = true;
+  m_output_register = NULL;
+  for (unsigned i = 0; i < MAX_REG_OPERANDS * 2; i++) m_src_op[i].reset();
+}
+
+simt_core_cluster::simt_core_cluster(class gpgpu_sim *gpu, unsigned cluster_id,
+                                     const shader_core_config *config,
+                                     const memory_config *mem_config,
+                                     shader_core_stats *stats,
+                                     class memory_stats_t *mstats) {
+  m_config = config;
+  m_cta_issue_next_core = m_config->n_simt_cores_per_cluster -
+                          1;  // this causes first launch to use hw cta 0
+  m_cluster_id = cluster_id;
+  m_gpu = gpu;
+  m_stats = stats;
+  m_memory_stats = mstats;
+  m_core = new shader_core_ctx *[config->n_simt_cores_per_cluster];
+  for (unsigned i = 0; i < config->n_simt_cores_per_cluster; i++) {
+    unsigned sid = m_config->cid_to_sid(i, m_cluster_id);
+    m_core[i] = new shader_core_ctx(gpu, this, sid, m_cluster_id, config,
+                                    mem_config, stats);
+    m_core_sim_order.push_back(i);
+  }
+}
+
+void simt_core_cluster::core_cycle() {
+  for (std::list<unsigned>::iterator it = m_core_sim_order.begin();
+       it != m_core_sim_order.end(); ++it) {
+    m_core[*it]->cycle();
+  }
+
+  if (m_config->simt_core_sim_order == 1) {
+    m_core_sim_order.splice(m_core_sim_order.end(), m_core_sim_order,
+                            m_core_sim_order.begin());
+  }
+}
+
+void simt_core_cluster::reinit() {
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++)
+    m_core[i]->reinit(0, m_config->n_thread_per_shader, true);
+}
+
+unsigned simt_core_cluster::max_cta(const kernel_info_t &kernel) {
+  return m_config->n_simt_cores_per_cluster * m_config->max_cta(kernel);
+}
+
+unsigned simt_core_cluster::get_not_completed() const {
+  unsigned not_completed = 0;
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++)
+    not_completed += m_core[i]->get_not_completed();
+  return not_completed;
+}
+
+void simt_core_cluster::print_not_completed(FILE *fp) const {
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++) {
+    unsigned not_completed = m_core[i]->get_not_completed();
+    unsigned sid = m_config->cid_to_sid(i, m_cluster_id);
+    fprintf(fp, "%u(%u) ", sid, not_completed);
+  }
+}
+
+float simt_core_cluster::get_current_occupancy(
+    unsigned long long &active, unsigned long long &total) const {
+  float aggregate = 0.f;
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++) {
+    aggregate += m_core[i]->get_current_occupancy(active, total);
+  }
+  return aggregate / m_config->n_simt_cores_per_cluster;
+}
+
+unsigned simt_core_cluster::get_n_active_cta() const {
+  unsigned n = 0;
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++)
+    n += m_core[i]->get_n_active_cta();
+  return n;
+}
+
+unsigned simt_core_cluster::get_n_active_sms() const {
+  unsigned n = 0;
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++)
+    n += m_core[i]->isactive();
+  return n;
+}
+
+unsigned simt_core_cluster::issue_block2core() {
+  unsigned num_blocks_issued = 0;
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++) {
+    unsigned core =
+        (i + m_cta_issue_next_core + 1) % m_config->n_simt_cores_per_cluster;
+
+    kernel_info_t *kernel;
+    // Jin: fetch kernel according to concurrent kernel setting
+    if (m_config->gpgpu_concurrent_kernel_sm) {  // concurrent kernel on sm
+      // always select latest issued kernel
+      kernel_info_t *k = m_gpu->select_kernel();
+      kernel = k;
+    } else {
+      // first select core kernel, if no more cta, get a new kernel
+      // only when core completes
+      kernel = m_core[core]->get_kernel();
+      if (!m_gpu->kernel_more_cta_left(kernel)) {
+        // wait till current kernel finishes
+        if (m_core[core]->get_not_completed() == 0) {
+          kernel_info_t *k = m_gpu->select_kernel();
+          if (k) m_core[core]->set_kernel(k);
+          kernel = k;
+        }
+      }
+    }
+
+    if (m_gpu->kernel_more_cta_left(kernel) &&
+        //            (m_core[core]->get_n_active_cta() <
+        //            m_config->max_cta(*kernel)) ) {
+        m_core[core]->can_issue_1block(*kernel)) {
+      m_core[core]->issue_block2core(*kernel);
+      num_blocks_issued++;
+      m_cta_issue_next_core = core;
+      break;
+    }
+  }
+  return num_blocks_issued;
+}
+
+void simt_core_cluster::cache_flush() {
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++)
+    m_core[i]->cache_flush();
+}
+
+void simt_core_cluster::cache_invalidate() {
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++)
+    m_core[i]->cache_invalidate();
+}
+
+bool simt_core_cluster::icnt_injection_buffer_full(unsigned size, bool write) {
+  unsigned request_size = size;
+  if (!write) request_size = READ_PACKET_SIZE;
+  return !::icnt_has_buffer(m_cluster_id, request_size);
+}
+
+void simt_core_cluster::icnt_inject_request_packet(class mem_fetch *mf) {
+  // stats
+  if (mf->get_is_write())
+    m_stats->made_write_mfs++;
+  else
+    m_stats->made_read_mfs++;
+  switch (mf->get_access_type()) {
+    case CONST_ACC_R:
+      m_stats->gpgpu_n_mem_const++;
+      break;
+    case TEXTURE_ACC_R:
+      m_stats->gpgpu_n_mem_texture++;
+      break;
+    case GLOBAL_ACC_R:
+      m_stats->gpgpu_n_mem_read_global++;
+      break;
+    // case GLOBAL_ACC_R: m_stats->gpgpu_n_mem_read_global++;
+    // printf("read_global%d\n",m_stats->gpgpu_n_mem_read_global); break;
+    case GLOBAL_ACC_W:
+      m_stats->gpgpu_n_mem_write_global++;
+      break;
+    case LOCAL_ACC_R:
+      m_stats->gpgpu_n_mem_read_local++;
+      break;
+    case LOCAL_ACC_W:
+      m_stats->gpgpu_n_mem_write_local++;
+      break;
+    case INST_ACC_R:
+      m_stats->gpgpu_n_mem_read_inst++;
+      break;
+    case L1_WRBK_ACC:
+      m_stats->gpgpu_n_mem_write_global++;
+      break;
+    case L2_WRBK_ACC:
+      m_stats->gpgpu_n_mem_l2_writeback++;
+      break;
+    case L1_WR_ALLOC_R:
+      m_stats->gpgpu_n_mem_l1_write_allocate++;
+      break;
+    case L2_WR_ALLOC_R:
+      m_stats->gpgpu_n_mem_l2_write_allocate++;
+      break;
+    default:
+      assert(0);
+  }
+
+  // The packet size varies depending on the type of request:
+  // - For write request and atomic request, the packet contains the data
+  // - For read request (i.e. not write nor atomic), the packet only has control
+  // metadata
+  unsigned int packet_size = mf->size();
+  if (!mf->get_is_write() && !mf->isatomic()) {
+    packet_size = mf->get_ctrl_size();
+  }
+  m_stats->m_outgoing_traffic_stats->record_traffic(mf, packet_size);
+  unsigned destination = mf->get_sub_partition_id();
+  mf->set_status(IN_ICNT_TO_MEM,
+                 m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+  if (!mf->get_is_write() && !mf->isatomic())
+    ::icnt_push(m_cluster_id, m_config->mem2device(destination), (void *)mf,
+                mf->get_ctrl_size());
+  else
+    ::icnt_push(m_cluster_id, m_config->mem2device(destination), (void *)mf,
+                mf->size());
+}
+
+void simt_core_cluster::icnt_cycle() {
+  if (!m_response_fifo.empty()) {
+    mem_fetch *mf = m_response_fifo.front();
+    unsigned cid = m_config->sid_to_cid(mf->get_sid());
+    if (mf->get_access_type() == INST_ACC_R) {
+      // instruction fetch response
+      if (!m_core[cid]->fetch_unit_response_buffer_full()) {
+        m_response_fifo.pop_front();
+        m_core[cid]->accept_fetch_response(mf);
+      }
+    } else {
+      // data response
+      if (!m_core[cid]->ldst_unit_response_buffer_full()) {
+        m_response_fifo.pop_front();
+        m_memory_stats->memlatstat_read_done(mf);
+        m_core[cid]->accept_ldst_unit_response(mf);
+      }
+    }
+  }
+  if (m_response_fifo.size() < m_config->n_simt_ejection_buffer_size) {
+    mem_fetch *mf = (mem_fetch *)::icnt_pop(m_cluster_id);
+    if (!mf) return;
+    assert(mf->get_tpc() == m_cluster_id);
+    assert(mf->get_type() == READ_REPLY || mf->get_type() == WRITE_ACK);
+
+    // The packet size varies depending on the type of request:
+    // - For read request and atomic request, the packet contains the data
+    // - For write-ack, the packet only has control metadata
+    unsigned int packet_size =
+        (mf->get_is_write()) ? mf->get_ctrl_size() : mf->size();
+    m_stats->m_incoming_traffic_stats->record_traffic(mf, packet_size);
+    mf->set_status(IN_CLUSTER_TO_SHADER_QUEUE,
+                   m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+    // m_memory_stats->memlatstat_read_done(mf,m_shader_config->max_warps_per_shader);
+    m_response_fifo.push_back(mf);
+    m_stats->n_mem_to_simt[m_cluster_id] += mf->get_num_flits(false);
+  }
+}
+
+void simt_core_cluster::get_pdom_stack_top_info(unsigned sid, unsigned tid,
+                                                unsigned *pc,
+                                                unsigned *rpc) const {
+  unsigned cid = m_config->sid_to_cid(sid);
+  m_core[cid]->get_pdom_stack_top_info(tid, pc, rpc);
+}
+
+void simt_core_cluster::display_pipeline(unsigned sid, FILE *fout,
+                                         int print_mem, int mask) {
+  m_core[m_config->sid_to_cid(sid)]->display_pipeline(fout, print_mem, mask);
+
+  fprintf(fout, "\n");
+  fprintf(fout, "Cluster %u pipeline state\n", m_cluster_id);
+  fprintf(fout, "Response FIFO (occupancy = %zu):\n", m_response_fifo.size());
+  for (std::list<mem_fetch *>::const_iterator i = m_response_fifo.begin();
+       i != m_response_fifo.end(); i++) {
+    const mem_fetch *mf = *i;
+    mf->print(fout);
+  }
+}
+
+void simt_core_cluster::print_cache_stats(FILE *fp, unsigned &dl1_accesses,
+                                          unsigned &dl1_misses) const {
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i) {
+    m_core[i]->print_cache_stats(fp, dl1_accesses, dl1_misses);
+  }
+}
+
+void simt_core_cluster::get_icnt_stats(long &n_simt_to_mem,
+                                       long &n_mem_to_simt) const {
+  long simt_to_mem = 0;
+  long mem_to_simt = 0;
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i) {
+    m_core[i]->get_icnt_power_stats(simt_to_mem, mem_to_simt);
+  }
+  n_simt_to_mem = simt_to_mem;
+  n_mem_to_simt = mem_to_simt;
+}
+
+void simt_core_cluster::get_cache_stats(cache_stats &cs) const {
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i) {
+    m_core[i]->get_cache_stats(cs);
+  }
+}
+
+void simt_core_cluster::get_L1I_sub_stats(struct cache_sub_stats &css) const {
+  struct cache_sub_stats temp_css;
+  struct cache_sub_stats total_css;
+  temp_css.clear();
+  total_css.clear();
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i) {
+    m_core[i]->get_L1I_sub_stats(temp_css);
+    total_css += temp_css;
+  }
+  css = total_css;
+}
+void simt_core_cluster::get_L1D_sub_stats(struct cache_sub_stats &css) const {
+  struct cache_sub_stats temp_css;
+  struct cache_sub_stats total_css;
+  temp_css.clear();
+  total_css.clear();
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i) {
+    m_core[i]->get_L1D_sub_stats(temp_css);
+    total_css += temp_css;
+  }
+  css = total_css;
+}
+void simt_core_cluster::get_L1C_sub_stats(struct cache_sub_stats &css) const {
+  struct cache_sub_stats temp_css;
+  struct cache_sub_stats total_css;
+  temp_css.clear();
+  total_css.clear();
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i) {
+    m_core[i]->get_L1C_sub_stats(temp_css);
+    total_css += temp_css;
+  }
+  css = total_css;
+}
+void simt_core_cluster::get_L1T_sub_stats(struct cache_sub_stats &css) const {
+  struct cache_sub_stats temp_css;
+  struct cache_sub_stats total_css;
+  temp_css.clear();
+  total_css.clear();
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; ++i) {
+    m_core[i]->get_L1T_sub_stats(temp_css);
+    total_css += temp_css;
+  }
+  css = total_css;
+}
+
+void shader_core_ctx::checkExecutionStatusAndUpdate(warp_inst_t &inst,
+                                                    unsigned t, unsigned tid) {
+  if (inst.isatomic()) m_warp[inst.warp_id()].inc_n_atomic();
+  if (inst.space.is_local() && (inst.is_load() || inst.is_store())) {
+    new_addr_type localaddrs[MAX_ACCESSES_PER_INSN_PER_THREAD];
+    unsigned num_addrs;
+    num_addrs = translate_local_memaddr(
+        inst.get_addr(t), tid,
+        m_config->n_simt_clusters * m_config->n_simt_cores_per_cluster,
+        inst.data_size, (new_addr_type *)localaddrs);
+    inst.set_addr(t, (new_addr_type *)localaddrs, num_addrs);
+  }
+  if (ptx_thread_done(tid)) {
+    m_warp[inst.warp_id()].set_completed(t);
+    m_warp[inst.warp_id()].ibuffer_flush();
+  }
+
+  // PC-Histogram Update
+  unsigned warp_id = inst.warp_id();
+  unsigned pc = inst.pc;
+  for (unsigned t = 0; t < m_config->warp_size; t++) {
+    if (inst.active(t)) {
+      int tid = warp_id * m_config->warp_size + t;
+      cflog_update_thread_pc(m_sid, tid, pc);
+    }
+  }
+}

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -3426,8 +3426,8 @@ void shader_core_ctx::warp_exit(unsigned warp_id) {
   for (unsigned i = warp_id * get_config()->warp_size;
        i < (warp_id + 1) * get_config()->warp_size; i++) {
     //		if(this->m_thread[i]->m_functional_model_thread_state &&
-    //this->m_thread[i].m_functional_model_thread_state->donecycle()==0) { 			done
-    //= false;
+    // this->m_thread[i].m_functional_model_thread_state->donecycle()==0) {
+    // done = false;
     //		}
 
     if (m_thread[i] && !m_thread[i]->is_done()) done = false;

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -3460,7 +3460,7 @@ void shader_core_ctx::warp_exit(unsigned warp_id) {
   for (unsigned i = warp_id * get_config()->warp_size;
        i < (warp_id + 1) * get_config()->warp_size; i++) {
     //		if(this->m_thread[i]->m_functional_model_thread_state &&
-    //this->m_thread[i].m_functional_model_thread_state->donecycle()==0) {
+    // this->m_thread[i].m_functional_model_thread_state->donecycle()==0) {
     //			done = false;
     //		}
 

--- a/src/gpgpu-sim/shader.h
+++ b/src/gpgpu-sim/shader.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2011, Tor M. Aamodt, Wilson W.L. Fung, Andrew Turner,
-// Ali Bakhoda 
+// Ali Bakhoda
 // The University of British Columbia
 // All rights reserved.
 //
@@ -8,14 +8,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -29,50 +31,50 @@
 #ifndef SHADER_H
 #define SHADER_H
 
+#include <assert.h>
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
-#include <assert.h>
+#include <algorithm>
+#include <bitset>
+#include <deque>
+#include <list>
 #include <map>
 #include <set>
-#include <vector>
-#include <list>
-#include <bitset>
 #include <utility>
-#include <algorithm>
-#include <deque>
+#include <vector>
 
 //#include "../cuda-sim/ptx.tab.h"
 
-#include "delayqueue.h"
-#include "stack.h"
-#include "dram.h"
 #include "../abstract_hardware_model.h"
-#include "scoreboard.h"
-#include "mem_fetch.h"
-#include "stats.h"
+#include "delayqueue.h"
+#include "dram.h"
 #include "gpu-cache.h"
+#include "mem_fetch.h"
+#include "scoreboard.h"
+#include "stack.h"
+#include "stats.h"
 #include "traffic_breakdown.h"
 
-
-#define NO_OP_FLAG            0xFF
+#define NO_OP_FLAG 0xFF
 
 /* READ_PACKET_SIZE:
-   bytes: 6 address (flit can specify chanel so this gives up to ~2GB/channel, so good for now),
-          2 bytes   [shaderid + mshrid](14 bits) + req_size(0-2 bits if req_size variable) - so up to 2^14 = 16384 mshr total 
+   bytes: 6 address (flit can specify chanel so this gives up to ~2GB/channel,
+   so good for now),
+          2 bytes   [shaderid + mshrid](14 bits) + req_size(0-2 bits if req_size
+   variable) - so up to 2^14 = 16384 mshr total
  */
 
 #define READ_PACKET_SIZE 8
 
-//WRITE_PACKET_SIZE: bytes: 6 address, 2 miscelaneous. 
+// WRITE_PACKET_SIZE: bytes: 6 address, 2 miscelaneous.
 #define WRITE_PACKET_SIZE 8
 
 #define WRITE_MASK_SIZE 8
 
 class gpgpu_context;
 
-enum exec_unit_type_t
-{
+enum exec_unit_type_t {
   NONE = 0,
   SP = 1,
   SFU = 2,
@@ -83,1127 +85,1134 @@ enum exec_unit_type_t
 };
 
 class thread_ctx_t {
-public:
-   unsigned m_cta_id; // hardware CTA this thread belongs
+ public:
+  unsigned m_cta_id;  // hardware CTA this thread belongs
 
-   // per thread stats (ac stands for accumulative).
-   unsigned n_insn;
-   unsigned n_insn_ac;
-   unsigned n_l1_mis_ac;
-   unsigned n_l1_mrghit_ac;
-   unsigned n_l1_access_ac; 
+  // per thread stats (ac stands for accumulative).
+  unsigned n_insn;
+  unsigned n_insn_ac;
+  unsigned n_l1_mis_ac;
+  unsigned n_l1_mrghit_ac;
+  unsigned n_l1_access_ac;
 
-   bool m_active; 
+  bool m_active;
 };
 
 class shd_warp_t {
-public:
-    shd_warp_t( class shader_core_ctx *shader, unsigned warp_size) 
-        : m_shader(shader), m_warp_size(warp_size)
-    {
-        m_stores_outstanding=0;
-        m_inst_in_pipeline=0;
-        reset(); 
+ public:
+  shd_warp_t(class shader_core_ctx *shader, unsigned warp_size)
+      : m_shader(shader), m_warp_size(warp_size) {
+    m_stores_outstanding = 0;
+    m_inst_in_pipeline = 0;
+    reset();
+  }
+  void reset() {
+    assert(m_stores_outstanding == 0);
+    assert(m_inst_in_pipeline == 0);
+    m_imiss_pending = false;
+    m_warp_id = (unsigned)-1;
+    m_dynamic_warp_id = (unsigned)-1;
+    n_completed = m_warp_size;
+    m_n_atomic = 0;
+    m_membar = false;
+    m_done_exit = true;
+    m_last_fetch = 0;
+    m_next = 0;
+
+    // Jin: cdp support
+    m_cdp_latency = 0;
+    m_cdp_dummy = false;
+  }
+  void init(address_type start_pc, unsigned cta_id, unsigned wid,
+            const std::bitset<MAX_WARP_SIZE> &active,
+            unsigned dynamic_warp_id) {
+    m_cta_id = cta_id;
+    m_warp_id = wid;
+    m_dynamic_warp_id = dynamic_warp_id;
+    m_next_pc = start_pc;
+    assert(n_completed >= active.count());
+    assert(n_completed <= m_warp_size);
+    n_completed -= active.count();  // active threads are not yet completed
+    m_active_threads = active;
+    m_done_exit = false;
+
+    // Jin: cdp support
+    m_cdp_latency = 0;
+    m_cdp_dummy = false;
+  }
+
+  bool functional_done() const;
+  bool waiting();  // not const due to membar
+  bool hardware_done() const;
+
+  bool done_exit() const { return m_done_exit; }
+  void set_done_exit() { m_done_exit = true; }
+
+  void print(FILE *fout) const;
+  void print_ibuffer(FILE *fout) const;
+
+  unsigned get_n_completed() const { return n_completed; }
+  void set_completed(unsigned lane) {
+    assert(m_active_threads.test(lane));
+    m_active_threads.reset(lane);
+    n_completed++;
+  }
+
+  void set_last_fetch(unsigned long long sim_cycle) {
+    m_last_fetch = sim_cycle;
+  }
+
+  unsigned get_n_atomic() const { return m_n_atomic; }
+  void inc_n_atomic() { m_n_atomic++; }
+  void dec_n_atomic(unsigned n) { m_n_atomic -= n; }
+
+  void set_membar() { m_membar = true; }
+  void clear_membar() { m_membar = false; }
+  bool get_membar() const { return m_membar; }
+  address_type get_pc() const { return m_next_pc; }
+  void set_next_pc(address_type pc) { m_next_pc = pc; }
+
+  void store_info_of_last_inst_at_barrier(const warp_inst_t *pI) {
+    m_inst_at_barrier = *pI;
+  }
+  warp_inst_t *restore_info_of_last_inst_at_barrier() {
+    return &m_inst_at_barrier;
+  }
+
+  void ibuffer_fill(unsigned slot, const warp_inst_t *pI) {
+    assert(slot < IBUFFER_SIZE);
+    m_ibuffer[slot].m_inst = pI;
+    m_ibuffer[slot].m_valid = true;
+    m_next = 0;
+  }
+  bool ibuffer_empty() const {
+    for (unsigned i = 0; i < IBUFFER_SIZE; i++)
+      if (m_ibuffer[i].m_valid) return false;
+    return true;
+  }
+  void ibuffer_flush() {
+    for (unsigned i = 0; i < IBUFFER_SIZE; i++) {
+      if (m_ibuffer[i].m_valid) dec_inst_in_pipeline();
+      m_ibuffer[i].m_inst = NULL;
+      m_ibuffer[i].m_valid = false;
     }
-    void reset()
-    {
-        assert( m_stores_outstanding==0);
-        assert( m_inst_in_pipeline==0);
-        m_imiss_pending=false;
-        m_warp_id=(unsigned)-1;
-        m_dynamic_warp_id = (unsigned)-1;
-        n_completed = m_warp_size; 
-        m_n_atomic=0;
-        m_membar=false;
-        m_done_exit=true;
-        m_last_fetch=0;
-        m_next=0;
+  }
+  const warp_inst_t *ibuffer_next_inst() { return m_ibuffer[m_next].m_inst; }
+  bool ibuffer_next_valid() { return m_ibuffer[m_next].m_valid; }
+  void ibuffer_free() {
+    m_ibuffer[m_next].m_inst = NULL;
+    m_ibuffer[m_next].m_valid = false;
+  }
+  void ibuffer_step() { m_next = (m_next + 1) % IBUFFER_SIZE; }
 
-        //Jin: cdp support
-        m_cdp_latency = 0;
-        m_cdp_dummy = false;
+  bool imiss_pending() const { return m_imiss_pending; }
+  void set_imiss_pending() { m_imiss_pending = true; }
+  void clear_imiss_pending() { m_imiss_pending = false; }
+
+  bool stores_done() const { return m_stores_outstanding == 0; }
+  void inc_store_req() { m_stores_outstanding++; }
+  void dec_store_req() {
+    assert(m_stores_outstanding > 0);
+    m_stores_outstanding--;
+  }
+
+  unsigned num_inst_in_buffer() const {
+    unsigned count = 0;
+    for (unsigned i = 0; i < IBUFFER_SIZE; i++) {
+      if (m_ibuffer[i].m_valid) count++;
     }
-    void init( address_type start_pc,
-               unsigned cta_id,
-               unsigned wid,
-               const std::bitset<MAX_WARP_SIZE> &active,
-               unsigned dynamic_warp_id )
-    {
-        m_cta_id=cta_id;
-        m_warp_id=wid;
-        m_dynamic_warp_id=dynamic_warp_id;
-        m_next_pc=start_pc;
-        assert( n_completed >= active.count() );
-        assert( n_completed <= m_warp_size);
-        n_completed   -= active.count(); // active threads are not yet completed
-        m_active_threads = active;
-        m_done_exit=false;
+    return count;
+  }
+  unsigned num_inst_in_pipeline() const { return m_inst_in_pipeline; }
+  unsigned num_issued_inst_in_pipeline() const {
+    return (num_inst_in_pipeline() - num_inst_in_buffer());
+  }
+  bool inst_in_pipeline() const { return m_inst_in_pipeline > 0; }
+  void inc_inst_in_pipeline() { m_inst_in_pipeline++; }
+  void dec_inst_in_pipeline() {
+    assert(m_inst_in_pipeline > 0);
+    m_inst_in_pipeline--;
+  }
 
-        //Jin: cdp support
-        m_cdp_latency = 0;
-        m_cdp_dummy = false;
+  unsigned get_cta_id() const { return m_cta_id; }
+
+  unsigned get_dynamic_warp_id() const { return m_dynamic_warp_id; }
+  unsigned get_warp_id() const { return m_warp_id; }
+
+ private:
+  static const unsigned IBUFFER_SIZE = 2;
+  class shader_core_ctx *m_shader;
+  unsigned m_cta_id;
+  unsigned m_warp_id;
+  unsigned m_warp_size;
+  unsigned m_dynamic_warp_id;
+
+  address_type m_next_pc;
+  unsigned n_completed;  // number of threads in warp completed
+  std::bitset<MAX_WARP_SIZE> m_active_threads;
+
+  bool m_imiss_pending;
+
+  struct ibuffer_entry {
+    ibuffer_entry() {
+      m_valid = false;
+      m_inst = NULL;
     }
+    const warp_inst_t *m_inst;
+    bool m_valid;
+  };
 
-    bool functional_done() const;
-    bool waiting(); // not const due to membar
-    bool hardware_done() const;
+  warp_inst_t m_inst_at_barrier;
+  ibuffer_entry m_ibuffer[IBUFFER_SIZE];
+  unsigned m_next;
 
-    bool done_exit() const { return m_done_exit; }
-    void set_done_exit() { m_done_exit=true; }
+  unsigned m_n_atomic;  // number of outstanding atomic operations
+  bool m_membar;        // if true, warp is waiting at memory barrier
 
-    void print( FILE *fout ) const;
-    void print_ibuffer( FILE *fout ) const;
+  bool m_done_exit;  // true once thread exit has been registered for threads in
+                     // this warp
 
-    unsigned get_n_completed() const { return n_completed; }
-    void set_completed( unsigned lane ) 
-    { 
-        assert( m_active_threads.test(lane) );
-        m_active_threads.reset(lane);
-        n_completed++; 
-    }
+  unsigned long long m_last_fetch;
 
-    void set_last_fetch( unsigned long long sim_cycle ) { m_last_fetch=sim_cycle; }
+  unsigned m_stores_outstanding;  // number of store requests sent but not yet
+                                  // acknowledged
+  unsigned m_inst_in_pipeline;
 
-    unsigned get_n_atomic() const { return m_n_atomic; }
-    void inc_n_atomic() { m_n_atomic++; }
-    void dec_n_atomic(unsigned n) { m_n_atomic-=n; }
-
-    void set_membar() { m_membar=true; }
-    void clear_membar() { m_membar=false; }
-    bool get_membar() const { return m_membar; }
-    address_type get_pc() const { return m_next_pc; }
-    void set_next_pc( address_type pc ) { m_next_pc = pc; }
-
-    void store_info_of_last_inst_at_barrier(const warp_inst_t *pI){ m_inst_at_barrier = *pI;}
-    warp_inst_t * restore_info_of_last_inst_at_barrier(){ return &m_inst_at_barrier;}
-
-    void ibuffer_fill( unsigned slot, const warp_inst_t *pI )
-    {
-       assert(slot < IBUFFER_SIZE );
-       m_ibuffer[slot].m_inst=pI;
-       m_ibuffer[slot].m_valid=true;
-       m_next=0; 
-    }
-    bool ibuffer_empty() const
-    {
-        for( unsigned i=0; i < IBUFFER_SIZE; i++) 
-            if(m_ibuffer[i].m_valid) 
-                return false;
-        return true;
-    }
-    void ibuffer_flush()
-    {
-        for(unsigned i=0;i<IBUFFER_SIZE;i++) {
-            if( m_ibuffer[i].m_valid )
-                dec_inst_in_pipeline();
-            m_ibuffer[i].m_inst=NULL; 
-            m_ibuffer[i].m_valid=false; 
-        }
-    }
-    const warp_inst_t *ibuffer_next_inst() { return m_ibuffer[m_next].m_inst; }
-    bool ibuffer_next_valid() { return m_ibuffer[m_next].m_valid; }
-    void ibuffer_free()
-    {
-        m_ibuffer[m_next].m_inst = NULL;
-        m_ibuffer[m_next].m_valid = false;
-    }
-    void ibuffer_step() { m_next = (m_next+1)%IBUFFER_SIZE; }
-
-    bool imiss_pending() const { return m_imiss_pending; }
-    void set_imiss_pending() { m_imiss_pending=true; }
-    void clear_imiss_pending() { m_imiss_pending=false; }
-
-    bool stores_done() const { return m_stores_outstanding == 0; }
-    void inc_store_req() { m_stores_outstanding++; }
-    void dec_store_req() 
-    {
-        assert( m_stores_outstanding > 0 );
-        m_stores_outstanding--;
-    }
-
-    unsigned num_inst_in_buffer() const
-    {
-    	unsigned count=0;
-        for(unsigned i=0;i<IBUFFER_SIZE;i++) {
-            if( m_ibuffer[i].m_valid )
-            	count++;
-        }
-    	return count;
-    }
-    unsigned num_inst_in_pipeline() const { return m_inst_in_pipeline;}
-    unsigned num_issued_inst_in_pipeline() const {return (num_inst_in_pipeline()-num_inst_in_buffer());}
-    bool inst_in_pipeline() const { return m_inst_in_pipeline > 0; }
-    void inc_inst_in_pipeline() { m_inst_in_pipeline++; }
-    void dec_inst_in_pipeline() 
-    {
-        assert( m_inst_in_pipeline > 0 );
-        m_inst_in_pipeline--;
-    }
-
-    unsigned get_cta_id() const { return m_cta_id; }
-
-    unsigned get_dynamic_warp_id() const { return m_dynamic_warp_id; }
-    unsigned get_warp_id() const { return m_warp_id; }
-
-private:
-    static const unsigned IBUFFER_SIZE=2;
-    class shader_core_ctx *m_shader;
-    unsigned m_cta_id;
-    unsigned m_warp_id;
-    unsigned m_warp_size;
-    unsigned m_dynamic_warp_id;
-
-    address_type m_next_pc;
-    unsigned n_completed;          // number of threads in warp completed
-    std::bitset<MAX_WARP_SIZE> m_active_threads;
-
-    bool m_imiss_pending;
-    
-    struct ibuffer_entry {
-       ibuffer_entry() { m_valid = false; m_inst = NULL; }
-       const warp_inst_t *m_inst;
-       bool m_valid;
-    };
-
-    warp_inst_t m_inst_at_barrier;
-    ibuffer_entry m_ibuffer[IBUFFER_SIZE]; 
-    unsigned m_next;
-                                   
-    unsigned m_n_atomic;           // number of outstanding atomic operations 
-    bool     m_membar;             // if true, warp is waiting at memory barrier
-
-    bool m_done_exit; // true once thread exit has been registered for threads in this warp
-
-    unsigned long long m_last_fetch;
-
-    unsigned m_stores_outstanding; // number of store requests sent but not yet acknowledged
-    unsigned m_inst_in_pipeline;
-
-    //Jin: cdp support
-public:
-    unsigned int m_cdp_latency;
-    bool m_cdp_dummy;
+  // Jin: cdp support
+ public:
+  unsigned int m_cdp_latency;
+  bool m_cdp_dummy;
 };
 
-
-
-inline unsigned hw_tid_from_wid(unsigned wid, unsigned warp_size, unsigned i){return wid * warp_size + i;};
-inline unsigned wid_from_hw_tid(unsigned tid, unsigned warp_size){return tid/warp_size;};
+inline unsigned hw_tid_from_wid(unsigned wid, unsigned warp_size, unsigned i) {
+  return wid * warp_size + i;
+};
+inline unsigned wid_from_hw_tid(unsigned tid, unsigned warp_size) {
+  return tid / warp_size;
+};
 
 const unsigned WARP_PER_CTA_MAX = 64;
 typedef std::bitset<WARP_PER_CTA_MAX> warp_set_t;
 
-int register_bank(int regnum, int wid, unsigned num_banks, unsigned bank_warp_shift, bool sub_core_model, unsigned banks_per_sched, unsigned sched_id );
+int register_bank(int regnum, int wid, unsigned num_banks,
+                  unsigned bank_warp_shift, bool sub_core_model,
+                  unsigned banks_per_sched, unsigned sched_id);
 
 class shader_core_ctx;
 class shader_core_config;
 class shader_core_stats;
 
-enum scheduler_prioritization_type
-{
-    SCHEDULER_PRIORITIZATION_LRR = 0, // Loose Round Robin
-    SCHEDULER_PRIORITIZATION_SRR, // Strict Round Robin
-    SCHEDULER_PRIORITIZATION_GTO, // Greedy Then Oldest
-    SCHEDULER_PRIORITIZATION_GTLRR, // Greedy Then Loose Round Robin
-    SCHEDULER_PRIORITIZATION_GTY, // Greedy Then Youngest
-    SCHEDULER_PRIORITIZATION_OLDEST, // Oldest First
-    SCHEDULER_PRIORITIZATION_YOUNGEST, // Youngest First
+enum scheduler_prioritization_type {
+  SCHEDULER_PRIORITIZATION_LRR = 0,   // Loose Round Robin
+  SCHEDULER_PRIORITIZATION_SRR,       // Strict Round Robin
+  SCHEDULER_PRIORITIZATION_GTO,       // Greedy Then Oldest
+  SCHEDULER_PRIORITIZATION_GTLRR,     // Greedy Then Loose Round Robin
+  SCHEDULER_PRIORITIZATION_GTY,       // Greedy Then Youngest
+  SCHEDULER_PRIORITIZATION_OLDEST,    // Oldest First
+  SCHEDULER_PRIORITIZATION_YOUNGEST,  // Youngest First
 };
 
 // Each of these corresponds to a string value in the gpgpsim.config file
 // For example - to specify the LRR scheudler the config must contain lrr
-enum concrete_scheduler
-{
-    CONCRETE_SCHEDULER_LRR = 0,
-    CONCRETE_SCHEDULER_GTO,
-    CONCRETE_SCHEDULER_TWO_LEVEL_ACTIVE,
-    CONCRETE_SCHEDULER_WARP_LIMITING,
-    CONCRETE_SCHEDULER_OLDEST_FIRST,
-    NUM_CONCRETE_SCHEDULERS
+enum concrete_scheduler {
+  CONCRETE_SCHEDULER_LRR = 0,
+  CONCRETE_SCHEDULER_GTO,
+  CONCRETE_SCHEDULER_TWO_LEVEL_ACTIVE,
+  CONCRETE_SCHEDULER_WARP_LIMITING,
+  CONCRETE_SCHEDULER_OLDEST_FIRST,
+  NUM_CONCRETE_SCHEDULERS
 };
 
-class scheduler_unit { //this can be copied freely, so can be used in std containers.
-public:
-    scheduler_unit(shader_core_stats* stats, shader_core_ctx* shader, 
-                   Scoreboard* scoreboard, simt_stack** simt, 
-                   std::vector<shd_warp_t>* warp, 
-                   register_set* sp_out,
-				   register_set* dp_out,
-                   register_set* sfu_out,
-				   register_set* int_out,
-                   register_set* tensor_core_out,
-                   register_set* mem_out,
-                   int id) 
-        : m_supervised_warps(), m_stats(stats), m_shader(shader),
-        m_scoreboard(scoreboard), m_simt_stack(simt), /*m_pipeline_reg(pipe_regs),*/ m_warp(warp),
-        m_sp_out(sp_out),m_dp_out(dp_out),m_sfu_out(sfu_out),m_int_out(int_out),m_tensor_core_out(tensor_core_out),m_mem_out(mem_out), m_id(id){}
-    virtual ~scheduler_unit(){}
-    virtual void add_supervised_warp_id(int i) {
-        m_supervised_warps.push_back(&warp(i));
-    }
-    virtual void done_adding_supervised_warps() {
-        m_last_supervised_issued = m_supervised_warps.end();
-    }
+class scheduler_unit {  // this can be copied freely, so can be used in std
+                        // containers.
+ public:
+  scheduler_unit(shader_core_stats *stats, shader_core_ctx *shader,
+                 Scoreboard *scoreboard, simt_stack **simt,
+                 std::vector<shd_warp_t> *warp, register_set *sp_out,
+                 register_set *dp_out, register_set *sfu_out,
+                 register_set *int_out, register_set *tensor_core_out,
+                 register_set *mem_out, int id)
+      : m_supervised_warps(),
+        m_stats(stats),
+        m_shader(shader),
+        m_scoreboard(scoreboard),
+        m_simt_stack(simt),
+        /*m_pipeline_reg(pipe_regs),*/ m_warp(warp),
+        m_sp_out(sp_out),
+        m_dp_out(dp_out),
+        m_sfu_out(sfu_out),
+        m_int_out(int_out),
+        m_tensor_core_out(tensor_core_out),
+        m_mem_out(mem_out),
+        m_id(id) {}
+  virtual ~scheduler_unit() {}
+  virtual void add_supervised_warp_id(int i) {
+    m_supervised_warps.push_back(&warp(i));
+  }
+  virtual void done_adding_supervised_warps() {
+    m_last_supervised_issued = m_supervised_warps.end();
+  }
 
+  // The core scheduler cycle method is meant to be common between
+  // all the derived schedulers.  The scheduler's behaviour can be
+  // modified by changing the contents of the m_next_cycle_prioritized_warps
+  // list.
+  void cycle();
 
-    // The core scheduler cycle method is meant to be common between
-    // all the derived schedulers.  The scheduler's behaviour can be
-    // modified by changing the contents of the m_next_cycle_prioritized_warps list.
-    void cycle();
+  // These are some common ordering fucntions that the
+  // higher order schedulers can take advantage of
+  template <typename T>
+  void order_lrr(
+      typename std::vector<T> &result_list,
+      const typename std::vector<T> &input_list,
+      const typename std::vector<T>::const_iterator &last_issued_from_input,
+      unsigned num_warps_to_add);
 
-    // These are some common ordering fucntions that the
-    // higher order schedulers can take advantage of
-    template < typename T >
-    void order_lrr( typename std::vector< T >& result_list,
-                    const typename std::vector< T >& input_list,
-                    const typename std::vector< T >::const_iterator& last_issued_from_input,
-                    unsigned num_warps_to_add );
-    
-    enum OrderingType 
-    {
-        // The item that issued last is prioritized first then the sorted result
-        // of the priority_function
-        ORDERING_GREEDY_THEN_PRIORITY_FUNC = 0,
-        // No greedy scheduling based on last to issue. Only the priority function determines
-        // priority
-        ORDERED_PRIORITY_FUNC_ONLY,
-        NUM_ORDERING,
-    };
-    template < typename U >
-    void order_by_priority( std::vector< U >& result_list,
-                            const typename std::vector< U >& input_list,
-                            const typename std::vector< U >::const_iterator& last_issued_from_input,
-                            unsigned num_warps_to_add,
-                            OrderingType age_ordering,
-                            bool (*priority_func)(U lhs, U rhs) );
-    static bool sort_warps_by_oldest_dynamic_id(shd_warp_t* lhs, shd_warp_t* rhs);
+  enum OrderingType {
+    // The item that issued last is prioritized first then the sorted result
+    // of the priority_function
+    ORDERING_GREEDY_THEN_PRIORITY_FUNC = 0,
+    // No greedy scheduling based on last to issue. Only the priority function
+    // determines
+    // priority
+    ORDERED_PRIORITY_FUNC_ONLY,
+    NUM_ORDERING,
+  };
+  template <typename U>
+  void order_by_priority(
+      std::vector<U> &result_list, const typename std::vector<U> &input_list,
+      const typename std::vector<U>::const_iterator &last_issued_from_input,
+      unsigned num_warps_to_add, OrderingType age_ordering,
+      bool (*priority_func)(U lhs, U rhs));
+  static bool sort_warps_by_oldest_dynamic_id(shd_warp_t *lhs, shd_warp_t *rhs);
 
-    // Derived classes can override this function to populate
-    // m_supervised_warps with their scheduling policies
-    virtual void order_warps() = 0;
+  // Derived classes can override this function to populate
+  // m_supervised_warps with their scheduling policies
+  virtual void order_warps() = 0;
 
-    int get_schd_id() const {return m_id;}
+  int get_schd_id() const { return m_id; }
 
-protected:
-    virtual void do_on_warp_issued( unsigned warp_id,
-                                    unsigned num_issued,
-                                    const std::vector< shd_warp_t* >::const_iterator& prioritized_iter );
-    inline int get_sid() const;
-protected:
-    shd_warp_t& warp(int i);
+ protected:
+  virtual void do_on_warp_issued(
+      unsigned warp_id, unsigned num_issued,
+      const std::vector<shd_warp_t *>::const_iterator &prioritized_iter);
+  inline int get_sid() const;
 
-    // This is the prioritized warp list that is looped over each cycle to determine
-    // which warp gets to issue.
-    std::vector< shd_warp_t* > m_next_cycle_prioritized_warps;
-    // The m_supervised_warps list is all the warps this scheduler is supposed to
-    // arbitrate between.  This is useful in systems where there is more than
-    // one warp scheduler. In a single scheduler system, this is simply all
-    // the warps assigned to this core.
-    std::vector< shd_warp_t* > m_supervised_warps;
-    // This is the iterator pointer to the last supervised warp you issued
-    std::vector< shd_warp_t* >::const_iterator m_last_supervised_issued;
-    shader_core_stats *m_stats;
-    shader_core_ctx* m_shader;
-    // these things should become accessors: but would need a bigger rearchitect of how shader_core_ctx interacts with its parts.
-    Scoreboard* m_scoreboard; 
-    simt_stack** m_simt_stack;
-    //warp_inst_t** m_pipeline_reg;
-    std::vector<shd_warp_t>* m_warp;
-    register_set* m_sp_out;
-    register_set* m_dp_out;
-    register_set* m_sfu_out;
-    register_set* m_int_out;
-    register_set* m_tensor_core_out;
-    register_set* m_mem_out;
+ protected:
+  shd_warp_t &warp(int i);
 
-    int m_id;
+  // This is the prioritized warp list that is looped over each cycle to
+  // determine
+  // which warp gets to issue.
+  std::vector<shd_warp_t *> m_next_cycle_prioritized_warps;
+  // The m_supervised_warps list is all the warps this scheduler is supposed to
+  // arbitrate between.  This is useful in systems where there is more than
+  // one warp scheduler. In a single scheduler system, this is simply all
+  // the warps assigned to this core.
+  std::vector<shd_warp_t *> m_supervised_warps;
+  // This is the iterator pointer to the last supervised warp you issued
+  std::vector<shd_warp_t *>::const_iterator m_last_supervised_issued;
+  shader_core_stats *m_stats;
+  shader_core_ctx *m_shader;
+  // these things should become accessors: but would need a bigger rearchitect
+  // of how shader_core_ctx interacts with its parts.
+  Scoreboard *m_scoreboard;
+  simt_stack **m_simt_stack;
+  // warp_inst_t** m_pipeline_reg;
+  std::vector<shd_warp_t> *m_warp;
+  register_set *m_sp_out;
+  register_set *m_dp_out;
+  register_set *m_sfu_out;
+  register_set *m_int_out;
+  register_set *m_tensor_core_out;
+  register_set *m_mem_out;
+
+  int m_id;
 };
 
 class lrr_scheduler : public scheduler_unit {
-public:
-	lrr_scheduler ( shader_core_stats* stats, shader_core_ctx* shader,
-                    Scoreboard* scoreboard, simt_stack** simt,
-                    std::vector<shd_warp_t>* warp,
-                    register_set* sp_out,
-					register_set* dp_out,
-                    register_set* sfu_out,
-					register_set* int_out,
-                    register_set* tensor_core_out,
-                    register_set* mem_out,
-                    int id )
-	: scheduler_unit ( stats, shader, scoreboard, simt, warp, sp_out, dp_out, sfu_out, int_out, tensor_core_out, mem_out, id ){}
-	virtual ~lrr_scheduler () {}
-	virtual void order_warps ();
-    virtual void done_adding_supervised_warps() {
-        m_last_supervised_issued = m_supervised_warps.end();
-    }
+ public:
+  lrr_scheduler(shader_core_stats *stats, shader_core_ctx *shader,
+                Scoreboard *scoreboard, simt_stack **simt,
+                std::vector<shd_warp_t> *warp, register_set *sp_out,
+                register_set *dp_out, register_set *sfu_out,
+                register_set *int_out, register_set *tensor_core_out,
+                register_set *mem_out, int id)
+      : scheduler_unit(stats, shader, scoreboard, simt, warp, sp_out, dp_out,
+                       sfu_out, int_out, tensor_core_out, mem_out, id) {}
+  virtual ~lrr_scheduler() {}
+  virtual void order_warps();
+  virtual void done_adding_supervised_warps() {
+    m_last_supervised_issued = m_supervised_warps.end();
+  }
 };
 
 class gto_scheduler : public scheduler_unit {
-public:
-	gto_scheduler ( shader_core_stats* stats, shader_core_ctx* shader,
-                    Scoreboard* scoreboard, simt_stack** simt,
-                    std::vector<shd_warp_t>* warp,
-                    register_set* sp_out,
-					register_set* dp_out,
-                    register_set* sfu_out,
-					register_set* int_out,
-                    register_set* tensor_core_out,
-                    register_set* mem_out,
-                    int id )
-	: scheduler_unit ( stats, shader, scoreboard, simt, warp, sp_out, dp_out, sfu_out, int_out, tensor_core_out, mem_out, id ){}
-	virtual ~gto_scheduler () {}
-	virtual void order_warps ();
-    virtual void done_adding_supervised_warps() {
-        m_last_supervised_issued = m_supervised_warps.begin();
-    }
-
+ public:
+  gto_scheduler(shader_core_stats *stats, shader_core_ctx *shader,
+                Scoreboard *scoreboard, simt_stack **simt,
+                std::vector<shd_warp_t> *warp, register_set *sp_out,
+                register_set *dp_out, register_set *sfu_out,
+                register_set *int_out, register_set *tensor_core_out,
+                register_set *mem_out, int id)
+      : scheduler_unit(stats, shader, scoreboard, simt, warp, sp_out, dp_out,
+                       sfu_out, int_out, tensor_core_out, mem_out, id) {}
+  virtual ~gto_scheduler() {}
+  virtual void order_warps();
+  virtual void done_adding_supervised_warps() {
+    m_last_supervised_issued = m_supervised_warps.begin();
+  }
 };
 
 class oldest_scheduler : public scheduler_unit {
-public:
-	oldest_scheduler ( shader_core_stats* stats, shader_core_ctx* shader,
-                    Scoreboard* scoreboard, simt_stack** simt,
-                    std::vector<shd_warp_t>* warp,
-                    register_set* sp_out,
-					register_set* dp_out,
-                    register_set* sfu_out,
-					register_set* int_out,
-                    register_set* tensor_core_out,
-                    register_set* mem_out,
-                    int id )
-	: scheduler_unit ( stats, shader, scoreboard, simt, warp, sp_out, dp_out, sfu_out, int_out, tensor_core_out, mem_out, id ){}
-	virtual ~oldest_scheduler () {}
-	virtual void order_warps ();
-        virtual void done_adding_supervised_warps() {
-        m_last_supervised_issued = m_supervised_warps.begin();
-    }
-
+ public:
+  oldest_scheduler(shader_core_stats *stats, shader_core_ctx *shader,
+                   Scoreboard *scoreboard, simt_stack **simt,
+                   std::vector<shd_warp_t> *warp, register_set *sp_out,
+                   register_set *dp_out, register_set *sfu_out,
+                   register_set *int_out, register_set *tensor_core_out,
+                   register_set *mem_out, int id)
+      : scheduler_unit(stats, shader, scoreboard, simt, warp, sp_out, dp_out,
+                       sfu_out, int_out, tensor_core_out, mem_out, id) {}
+  virtual ~oldest_scheduler() {}
+  virtual void order_warps();
+  virtual void done_adding_supervised_warps() {
+    m_last_supervised_issued = m_supervised_warps.begin();
+  }
 };
 
 class two_level_active_scheduler : public scheduler_unit {
-public:
-	two_level_active_scheduler ( shader_core_stats* stats, shader_core_ctx* shader,
-                          Scoreboard* scoreboard, simt_stack** simt,
-                          std::vector<shd_warp_t>* warp,
-                          register_set* sp_out,
-						  register_set* dp_out,
-                          register_set* sfu_out,
-						  register_set* int_out,
-                          register_set* tensor_core_out,
-                          register_set* mem_out,
-                          int id,
-                          char* config_str )
-	: scheduler_unit ( stats, shader, scoreboard, simt, warp, sp_out, dp_out, sfu_out, int_out, tensor_core_out, mem_out, id ),
-	  m_pending_warps() 
-    {
-        unsigned inner_level_readin;
-        unsigned outer_level_readin; 
-        int ret = sscanf( config_str,
-                          "two_level_active:%d:%d:%d",
-                          &m_max_active_warps,
-                          &inner_level_readin,
-                          &outer_level_readin);
-        assert( 3 == ret );
-        m_inner_level_prioritization=(scheduler_prioritization_type)inner_level_readin;
-        m_outer_level_prioritization=(scheduler_prioritization_type)outer_level_readin;
+ public:
+  two_level_active_scheduler(shader_core_stats *stats, shader_core_ctx *shader,
+                             Scoreboard *scoreboard, simt_stack **simt,
+                             std::vector<shd_warp_t> *warp,
+                             register_set *sp_out, register_set *dp_out,
+                             register_set *sfu_out, register_set *int_out,
+                             register_set *tensor_core_out,
+                             register_set *mem_out, int id, char *config_str)
+      : scheduler_unit(stats, shader, scoreboard, simt, warp, sp_out, dp_out,
+                       sfu_out, int_out, tensor_core_out, mem_out, id),
+        m_pending_warps() {
+    unsigned inner_level_readin;
+    unsigned outer_level_readin;
+    int ret =
+        sscanf(config_str, "two_level_active:%d:%d:%d", &m_max_active_warps,
+               &inner_level_readin, &outer_level_readin);
+    assert(3 == ret);
+    m_inner_level_prioritization =
+        (scheduler_prioritization_type)inner_level_readin;
+    m_outer_level_prioritization =
+        (scheduler_prioritization_type)outer_level_readin;
+  }
+  virtual ~two_level_active_scheduler() {}
+  virtual void order_warps();
+  void add_supervised_warp_id(int i) {
+    if (m_next_cycle_prioritized_warps.size() < m_max_active_warps) {
+      m_next_cycle_prioritized_warps.push_back(&warp(i));
+    } else {
+      m_pending_warps.push_back(&warp(i));
     }
-	virtual ~two_level_active_scheduler () {}
-    virtual void order_warps();
-	void add_supervised_warp_id(int i) {
-        if ( m_next_cycle_prioritized_warps.size() < m_max_active_warps ) {
-            m_next_cycle_prioritized_warps.push_back( &warp(i) );
-        } else {
-		    m_pending_warps.push_back(&warp(i));
-        }
-	}
-    virtual void done_adding_supervised_warps() {
-        m_last_supervised_issued = m_supervised_warps.begin();
-    }
+  }
+  virtual void done_adding_supervised_warps() {
+    m_last_supervised_issued = m_supervised_warps.begin();
+  }
 
-protected:
-    virtual void do_on_warp_issued( unsigned warp_id,
-                                    unsigned num_issued,
-                                    const std::vector< shd_warp_t* >::const_iterator& prioritized_iter );
+ protected:
+  virtual void do_on_warp_issued(
+      unsigned warp_id, unsigned num_issued,
+      const std::vector<shd_warp_t *>::const_iterator &prioritized_iter);
 
-private:
-	std::deque< shd_warp_t* > m_pending_warps;
-    scheduler_prioritization_type m_inner_level_prioritization;
-    scheduler_prioritization_type m_outer_level_prioritization;
-	unsigned m_max_active_warps;
+ private:
+  std::deque<shd_warp_t *> m_pending_warps;
+  scheduler_prioritization_type m_inner_level_prioritization;
+  scheduler_prioritization_type m_outer_level_prioritization;
+  unsigned m_max_active_warps;
 };
 
 // Static Warp Limiting Scheduler
 class swl_scheduler : public scheduler_unit {
-public:
-	swl_scheduler ( shader_core_stats* stats, shader_core_ctx* shader,
-                    Scoreboard* scoreboard, simt_stack** simt,
-                    std::vector<shd_warp_t>* warp,
-                    register_set* sp_out,
-					register_set* dp_out,
-                    register_set* sfu_out,
-					register_set* int_out,
-                    register_set* tensor_core_out,
-                    register_set* mem_out,
-                    int id,
-                    char* config_string );
-	virtual ~swl_scheduler () {}
-	virtual void order_warps ();
-    virtual void done_adding_supervised_warps() {
-        m_last_supervised_issued = m_supervised_warps.begin();
-    }
+ public:
+  swl_scheduler(shader_core_stats *stats, shader_core_ctx *shader,
+                Scoreboard *scoreboard, simt_stack **simt,
+                std::vector<shd_warp_t> *warp, register_set *sp_out,
+                register_set *dp_out, register_set *sfu_out,
+                register_set *int_out, register_set *tensor_core_out,
+                register_set *mem_out, int id, char *config_string);
+  virtual ~swl_scheduler() {}
+  virtual void order_warps();
+  virtual void done_adding_supervised_warps() {
+    m_last_supervised_issued = m_supervised_warps.begin();
+  }
 
-protected:
-    scheduler_prioritization_type m_prioritization;
-    unsigned m_num_warps_to_limit;
+ protected:
+  scheduler_prioritization_type m_prioritization;
+  unsigned m_num_warps_to_limit;
 };
 
+class opndcoll_rfu_t {  // operand collector based register file unit
+ public:
+  // constructors
+  opndcoll_rfu_t() {
+    m_num_banks = 0;
+    m_shader = NULL;
+    m_initialized = false;
+  }
+  void add_cu_set(unsigned cu_set, unsigned num_cu, unsigned num_dispatch);
+  typedef std::vector<register_set *> port_vector_t;
+  typedef std::vector<unsigned int> uint_vector_t;
+  void add_port(port_vector_t &input, port_vector_t &ouput,
+                uint_vector_t cu_sets);
+  void init(unsigned num_banks, shader_core_ctx *shader);
 
+  // modifiers
+  bool writeback(warp_inst_t &warp);
 
-class opndcoll_rfu_t { // operand collector based register file unit
-public:
-   // constructors
-   opndcoll_rfu_t()
-   {
-      m_num_banks=0;
-      m_shader=NULL;
-      m_initialized=false;
-   }
-   void add_cu_set(unsigned cu_set, unsigned num_cu, unsigned num_dispatch);
-   typedef std::vector<register_set*> port_vector_t;
-   typedef std::vector<unsigned int> uint_vector_t;
-   void add_port( port_vector_t & input, port_vector_t & ouput, uint_vector_t cu_sets);
-   void init( unsigned num_banks, shader_core_ctx *shader );
+  void step() {
+    dispatch_ready_cu();
+    allocate_reads();
+    for (unsigned p = 0; p < m_in_ports.size(); p++) allocate_cu(p);
+    process_banks();
+  }
 
-   // modifiers
-   bool writeback( warp_inst_t &warp ); 
+  void dump(FILE *fp) const {
+    fprintf(fp, "\n");
+    fprintf(fp, "Operand Collector State:\n");
+    for (unsigned n = 0; n < m_cu.size(); n++) {
+      fprintf(fp, "   CU-%2u: ", n);
+      m_cu[n]->dump(fp, m_shader);
+    }
+    m_arbiter.dump(fp);
+  }
 
-   void step()
-   {
-        dispatch_ready_cu();   
-        allocate_reads();
-        for( unsigned p = 0 ; p < m_in_ports.size(); p++ ) 
-            allocate_cu( p );
-        process_banks();
-   }
+  shader_core_ctx *shader_core() { return m_shader; }
 
-   void dump( FILE *fp ) const
-   {
-      fprintf(fp,"\n");
-      fprintf(fp,"Operand Collector State:\n");
-      for( unsigned n=0; n < m_cu.size(); n++ ) {
-         fprintf(fp,"   CU-%2u: ", n);
-         m_cu[n]->dump(fp,m_shader);
-      }
-      m_arbiter.dump(fp);
-   }
+ private:
+  void process_banks() { m_arbiter.reset_alloction(); }
 
-   shader_core_ctx *shader_core() { return m_shader; }
+  void dispatch_ready_cu();
+  void allocate_cu(unsigned port);
+  void allocate_reads();
 
-private:
+  // types
 
-   void process_banks()
-   {
-      m_arbiter.reset_alloction();
-   }
+  class collector_unit_t;
 
-   void dispatch_ready_cu();
-   void allocate_cu( unsigned port );
-   void allocate_reads();
-
-   // types
-
-   class collector_unit_t;
-
-   class op_t {
+  class op_t {
    public:
+    op_t() { m_valid = false; }
+    op_t(collector_unit_t *cu, unsigned op, unsigned reg, unsigned num_banks,
+         unsigned bank_warp_shift, bool sub_core_model,
+         unsigned banks_per_sched, unsigned sched_id) {
+      m_valid = true;
+      m_warp = NULL;
+      m_cu = cu;
+      m_operand = op;
+      m_register = reg;
+      m_shced_id = sched_id;
+      m_bank = register_bank(reg, cu->get_warp_id(), num_banks, bank_warp_shift,
+                             sub_core_model, banks_per_sched, sched_id);
+    }
+    op_t(const warp_inst_t *warp, unsigned reg, unsigned num_banks,
+         unsigned bank_warp_shift, bool sub_core_model,
+         unsigned banks_per_sched, unsigned sched_id) {
+      m_valid = true;
+      m_warp = warp;
+      m_register = reg;
+      m_cu = NULL;
+      m_operand = -1;
+      m_shced_id = sched_id;
+      m_bank = register_bank(reg, warp->warp_id(), num_banks, bank_warp_shift,
+                             sub_core_model, banks_per_sched, sched_id);
+    }
 
-      op_t() { m_valid = false; }
-      op_t( collector_unit_t *cu, unsigned op, unsigned reg, unsigned num_banks, unsigned bank_warp_shift, bool sub_core_model, unsigned banks_per_sched, unsigned sched_id )
-      {
-         m_valid = true;
-         m_warp=NULL;
-         m_cu = cu;
-         m_operand = op;
-         m_register = reg;
-         m_shced_id = sched_id;
-         m_bank = register_bank(reg,cu->get_warp_id(),num_banks,bank_warp_shift, sub_core_model, banks_per_sched, sched_id);
-      }
-      op_t( const warp_inst_t *warp, unsigned reg, unsigned num_banks, unsigned bank_warp_shift, bool sub_core_model, unsigned banks_per_sched, unsigned sched_id )
-      {
-         m_valid=true;
-         m_warp=warp;
-         m_register=reg;
-         m_cu=NULL;
-         m_operand = -1;
-         m_shced_id = sched_id;
-         m_bank = register_bank(reg,warp->warp_id(),num_banks,bank_warp_shift, sub_core_model, banks_per_sched, sched_id);
-      }
+    // accessors
+    bool valid() const { return m_valid; }
+    unsigned get_reg() const {
+      assert(m_valid);
+      return m_register;
+    }
+    unsigned get_wid() const {
+      if (m_warp)
+        return m_warp->warp_id();
+      else if (m_cu)
+        return m_cu->get_warp_id();
+      else
+        abort();
+    }
+    unsigned get_sid() const { return m_shced_id; }
+    unsigned get_active_count() const {
+      if (m_warp)
+        return m_warp->active_count();
+      else if (m_cu)
+        return m_cu->get_active_count();
+      else
+        abort();
+    }
+    const active_mask_t &get_active_mask() {
+      if (m_warp)
+        return m_warp->get_active_mask();
+      else if (m_cu)
+        return m_cu->get_active_mask();
+      else
+        abort();
+    }
+    unsigned get_sp_op() const {
+      if (m_warp)
+        return m_warp->sp_op;
+      else if (m_cu)
+        return m_cu->get_sp_op();
+      else
+        abort();
+    }
+    unsigned get_oc_id() const { return m_cu->get_id(); }
+    unsigned get_bank() const { return m_bank; }
+    unsigned get_operand() const { return m_operand; }
+    void dump(FILE *fp) const {
+      if (m_cu)
+        fprintf(fp, " <R%u, CU:%u, w:%02u> ", m_register, m_cu->get_id(),
+                m_cu->get_warp_id());
+      else if (!m_warp->empty())
+        fprintf(fp, " <R%u, wid:%02u> ", m_register, m_warp->warp_id());
+    }
+    std::string get_reg_string() const {
+      char buffer[64];
+      snprintf(buffer, 64, "R%u", m_register);
+      return std::string(buffer);
+    }
 
-      // accessors
-      bool valid() const { return m_valid; }
-      unsigned get_reg() const
-      {
-         assert( m_valid );
-         return m_register;
-      }
-      unsigned get_wid() const
-      {
-          if( m_warp ) return m_warp->warp_id();
-          else if( m_cu ) return m_cu->get_warp_id();
-          else abort();
-      }
-      unsigned get_sid() const
-	  {
-		 return m_shced_id;
-	  }
-      unsigned get_active_count() const
-      {
-          if( m_warp ) return m_warp->active_count();
-          else if( m_cu ) return m_cu->get_active_count();
-          else abort();
-      }
-      const active_mask_t & get_active_mask()
-      {
-          if( m_warp ) return m_warp->get_active_mask();
-          else if( m_cu ) return m_cu->get_active_mask();
-          else abort();
-      }
-      unsigned get_sp_op() const
-      {
-          if( m_warp ) return m_warp->sp_op;
-          else if( m_cu ) return m_cu->get_sp_op();
-          else abort();
-      }
-      unsigned get_oc_id() const { return m_cu->get_id(); }
-      unsigned get_bank() const { return m_bank; }
-      unsigned get_operand() const { return m_operand; }
-      void dump(FILE *fp) const 
-      {
-         if(m_cu) 
-            fprintf(fp," <R%u, CU:%u, w:%02u> ", m_register,m_cu->get_id(),m_cu->get_warp_id());
-         else if( !m_warp->empty() )
-            fprintf(fp," <R%u, wid:%02u> ", m_register,m_warp->warp_id() );
-      }
-      std::string get_reg_string() const
-      {
-         char buffer[64];
-         snprintf(buffer,64,"R%u", m_register);
-         return std::string(buffer);
-      }
-
-      // modifiers
-      void reset() { m_valid = false; }
-   private:
-      bool m_valid;
-      collector_unit_t  *m_cu; 
-      const warp_inst_t *m_warp;
-      unsigned  m_operand; // operand offset in instruction. e.g., add r1,r2,r3; r2 is oprd 0, r3 is 1 (r1 is dst)
-      unsigned  m_register;
-      unsigned  m_bank;
-      unsigned  m_shced_id; //scheduler id that has issued this inst
-   };
-
-   enum alloc_t {
-      NO_ALLOC,
-      READ_ALLOC,
-      WRITE_ALLOC,
-   };
-
-   class allocation_t {
-   public:
-      allocation_t() { m_allocation = NO_ALLOC; }
-      bool is_read() const { return m_allocation==READ_ALLOC; }
-      bool is_write() const {return m_allocation==WRITE_ALLOC; }
-      bool is_free() const {return m_allocation==NO_ALLOC; }
-      void dump(FILE *fp) const {
-         if( m_allocation == NO_ALLOC ) { fprintf(fp,"<free>"); }
-         else if( m_allocation == READ_ALLOC ) { fprintf(fp,"rd: "); m_op.dump(fp); }
-         else if( m_allocation == WRITE_ALLOC ) { fprintf(fp,"wr: "); m_op.dump(fp); }
-         fprintf(fp,"\n");
-      }
-      void alloc_read( const op_t &op )  { assert(is_free()); m_allocation=READ_ALLOC; m_op=op;  }
-      void alloc_write( const op_t &op ) { assert(is_free()); m_allocation=WRITE_ALLOC; m_op=op; }
-      void reset() { m_allocation = NO_ALLOC; }
-   private:
-      enum alloc_t m_allocation;
-      op_t m_op;
-   };
-
-   class arbiter_t {
-   public:
-      // constructors
-      arbiter_t()
-      {
-         m_queue=NULL;
-         m_allocated_bank=NULL;
-         m_allocator_rr_head=NULL;
-         _inmatch=NULL;
-         _outmatch=NULL;
-         _request=NULL;
-         m_last_cu=0;
-      }
-      void init( unsigned num_cu, unsigned num_banks ) 
-      { 
-         assert(num_cu > 0);
-         assert(num_banks > 0);
-         m_num_collectors = num_cu;
-         m_num_banks = num_banks;
-         _inmatch = new int[ m_num_banks ];
-         _outmatch = new int[ m_num_collectors ];
-         _request = new int*[ m_num_banks ];
-         for(unsigned i=0; i<m_num_banks;i++) 
-             _request[i] = new int[m_num_collectors];
-         m_queue = new std::list<op_t>[num_banks];
-         m_allocated_bank = new allocation_t[num_banks];
-         m_allocator_rr_head = new unsigned[num_cu];
-         for( unsigned n=0; n<num_cu;n++ ) 
-            m_allocator_rr_head[n] = n%num_banks;
-         reset_alloction();
-      }
-
-      // accessors
-      void dump(FILE *fp) const
-      {
-         fprintf(fp,"\n");
-         fprintf(fp,"  Arbiter State:\n");
-         fprintf(fp,"  requests:\n");
-         for( unsigned b=0; b<m_num_banks; b++ ) {
-            fprintf(fp,"    bank %u : ", b );
-            std::list<op_t>::const_iterator o = m_queue[b].begin();
-            for(; o != m_queue[b].end(); o++ ) {
-               o->dump(fp);
-            }
-            fprintf(fp,"\n");
-         }
-         fprintf(fp,"  grants:\n");
-         for(unsigned b=0;b<m_num_banks;b++) {
-            fprintf(fp,"    bank %u : ", b );
-            m_allocated_bank[b].dump(fp);
-         }
-         fprintf(fp,"\n");
-      }
-
-      // modifiers
-      std::list<op_t> allocate_reads(); 
-
-      void add_read_requests( collector_unit_t *cu ) 
-      {
-         const op_t *src = cu->get_operands();
-         for( unsigned i=0; i<MAX_REG_OPERANDS*2; i++) {
-            const op_t &op = src[i];
-            if( op.valid() ) {
-               unsigned bank = op.get_bank();
-               m_queue[bank].push_back(op);
-            }
-         }
-      }
-      bool bank_idle( unsigned bank ) const
-      {
-          return m_allocated_bank[bank].is_free();
-      }
-      void allocate_bank_for_write( unsigned bank, const op_t &op )
-      {
-         assert( bank < m_num_banks );
-         m_allocated_bank[bank].alloc_write(op);
-      }
-      void allocate_for_read( unsigned bank, const op_t &op )
-      {
-         assert( bank < m_num_banks );
-         m_allocated_bank[bank].alloc_read(op);
-      }
-      void reset_alloction()
-      {
-         for( unsigned b=0; b < m_num_banks; b++ ) 
-            m_allocated_bank[b].reset();
-      }
+    // modifiers
+    void reset() { m_valid = false; }
 
    private:
-      unsigned m_num_banks;
-      unsigned m_num_collectors;
+    bool m_valid;
+    collector_unit_t *m_cu;
+    const warp_inst_t *m_warp;
+    unsigned m_operand;  // operand offset in instruction. e.g., add r1,r2,r3;
+                         // r2 is oprd 0, r3 is 1 (r1 is dst)
+    unsigned m_register;
+    unsigned m_bank;
+    unsigned m_shced_id;  // scheduler id that has issued this inst
+  };
 
-      allocation_t *m_allocated_bank; // bank # -> register that wins
-      std::list<op_t> *m_queue;
+  enum alloc_t {
+    NO_ALLOC,
+    READ_ALLOC,
+    WRITE_ALLOC,
+  };
 
-      unsigned *m_allocator_rr_head; // cu # -> next bank to check for request (rr-arb)
-      unsigned  m_last_cu; // first cu to check while arb-ing banks (rr)
-
-      int *_inmatch;
-      int *_outmatch;
-      int **_request;
-   };
-
-   class input_port_t {
+  class allocation_t {
    public:
-       input_port_t(port_vector_t & input, port_vector_t & output, uint_vector_t cu_sets)
-       : m_in(input),m_out(output), m_cu_sets(cu_sets)
-       {
-           assert(input.size() == output.size());
-           assert(not m_cu_sets.empty());
-       }
-   //private:
-       port_vector_t m_in,m_out;
-       uint_vector_t m_cu_sets;
-   };
-
-   class collector_unit_t {
-   public:
-      // constructors
-      collector_unit_t()
-      { 
-         m_free = true;
-         m_warp = NULL;
-         m_output_register = NULL;
-         m_src_op = new op_t[MAX_REG_OPERANDS*2];
-         m_not_ready.reset();
-         m_warp_id = -1;
-         m_num_banks = 0;
-         m_bank_warp_shift = 0;
+    allocation_t() { m_allocation = NO_ALLOC; }
+    bool is_read() const { return m_allocation == READ_ALLOC; }
+    bool is_write() const { return m_allocation == WRITE_ALLOC; }
+    bool is_free() const { return m_allocation == NO_ALLOC; }
+    void dump(FILE *fp) const {
+      if (m_allocation == NO_ALLOC) {
+        fprintf(fp, "<free>");
+      } else if (m_allocation == READ_ALLOC) {
+        fprintf(fp, "rd: ");
+        m_op.dump(fp);
+      } else if (m_allocation == WRITE_ALLOC) {
+        fprintf(fp, "wr: ");
+        m_op.dump(fp);
       }
-      // accessors
-      bool ready() const;
-      const op_t *get_operands() const { return m_src_op; }
-      void dump(FILE *fp, const shader_core_ctx *shader ) const;
-
-      unsigned get_warp_id() const { return m_warp_id; }
-      unsigned get_active_count() const { return m_warp->active_count(); }
-      const active_mask_t & get_active_mask() const { return m_warp->get_active_mask(); }
-      unsigned get_sp_op() const { return m_warp->sp_op; }
-      unsigned get_id() const { return m_cuid; } // returns CU hw id
-
-      // modifiers
-      void init(unsigned n, 
-                unsigned num_banks, 
-                unsigned log2_warp_size,
-                const core_config *config,
-                opndcoll_rfu_t *rfu,
-				bool m_sub_core_model,
-				unsigned num_banks_per_sched);
-      bool allocate( register_set* pipeline_reg, register_set* output_reg );
-
-      void collect_operand( unsigned op )
-      {
-         m_not_ready.reset(op);
-      }
-      unsigned get_num_operands() const{
-    	  return m_warp->get_num_operands();
-      }
-      unsigned get_num_regs() const{
-    	  return m_warp->get_num_regs();
-      }
-      void dispatch();
-      bool is_free(){return m_free;}
+      fprintf(fp, "\n");
+    }
+    void alloc_read(const op_t &op) {
+      assert(is_free());
+      m_allocation = READ_ALLOC;
+      m_op = op;
+    }
+    void alloc_write(const op_t &op) {
+      assert(is_free());
+      m_allocation = WRITE_ALLOC;
+      m_op = op;
+    }
+    void reset() { m_allocation = NO_ALLOC; }
 
    private:
-      bool m_free;
-      unsigned m_cuid; // collector unit hw id
-      unsigned m_warp_id;
-      warp_inst_t  *m_warp;
-      register_set* m_output_register; // pipeline register to issue to when ready
-      op_t *m_src_op;
-      std::bitset<MAX_REG_OPERANDS*2> m_not_ready;
-      unsigned m_num_banks;
-      unsigned m_bank_warp_shift;
-      opndcoll_rfu_t *m_rfu;
+    enum alloc_t m_allocation;
+    op_t m_op;
+  };
 
-      unsigned m_num_banks_per_sched;
-      bool m_sub_core_model;
-
-   };
-
-   class dispatch_unit_t {
+  class arbiter_t {
    public:
-      dispatch_unit_t(std::vector<collector_unit_t>* cus) 
-      { 
-         m_last_cu=0;
-         m_collector_units=cus;
-         m_num_collectors = (*cus).size();
-         m_next_cu=0;
-      }
+    // constructors
+    arbiter_t() {
+      m_queue = NULL;
+      m_allocated_bank = NULL;
+      m_allocator_rr_head = NULL;
+      _inmatch = NULL;
+      _outmatch = NULL;
+      _request = NULL;
+      m_last_cu = 0;
+    }
+    void init(unsigned num_cu, unsigned num_banks) {
+      assert(num_cu > 0);
+      assert(num_banks > 0);
+      m_num_collectors = num_cu;
+      m_num_banks = num_banks;
+      _inmatch = new int[m_num_banks];
+      _outmatch = new int[m_num_collectors];
+      _request = new int *[m_num_banks];
+      for (unsigned i = 0; i < m_num_banks; i++)
+        _request[i] = new int[m_num_collectors];
+      m_queue = new std::list<op_t>[num_banks];
+      m_allocated_bank = new allocation_t[num_banks];
+      m_allocator_rr_head = new unsigned[num_cu];
+      for (unsigned n = 0; n < num_cu; n++)
+        m_allocator_rr_head[n] = n % num_banks;
+      reset_alloction();
+    }
 
-      collector_unit_t *find_ready()
-      {
-         for( unsigned n=0; n < m_num_collectors; n++ ) {
-            unsigned c=(m_last_cu+n+1)%m_num_collectors;
-            if( (*m_collector_units)[c].ready() ) {
-               m_last_cu=c;
-               return &((*m_collector_units)[c]);
-            }
-         }
-         return NULL;
+    // accessors
+    void dump(FILE *fp) const {
+      fprintf(fp, "\n");
+      fprintf(fp, "  Arbiter State:\n");
+      fprintf(fp, "  requests:\n");
+      for (unsigned b = 0; b < m_num_banks; b++) {
+        fprintf(fp, "    bank %u : ", b);
+        std::list<op_t>::const_iterator o = m_queue[b].begin();
+        for (; o != m_queue[b].end(); o++) {
+          o->dump(fp);
+        }
+        fprintf(fp, "\n");
       }
+      fprintf(fp, "  grants:\n");
+      for (unsigned b = 0; b < m_num_banks; b++) {
+        fprintf(fp, "    bank %u : ", b);
+        m_allocated_bank[b].dump(fp);
+      }
+      fprintf(fp, "\n");
+    }
+
+    // modifiers
+    std::list<op_t> allocate_reads();
+
+    void add_read_requests(collector_unit_t *cu) {
+      const op_t *src = cu->get_operands();
+      for (unsigned i = 0; i < MAX_REG_OPERANDS * 2; i++) {
+        const op_t &op = src[i];
+        if (op.valid()) {
+          unsigned bank = op.get_bank();
+          m_queue[bank].push_back(op);
+        }
+      }
+    }
+    bool bank_idle(unsigned bank) const {
+      return m_allocated_bank[bank].is_free();
+    }
+    void allocate_bank_for_write(unsigned bank, const op_t &op) {
+      assert(bank < m_num_banks);
+      m_allocated_bank[bank].alloc_write(op);
+    }
+    void allocate_for_read(unsigned bank, const op_t &op) {
+      assert(bank < m_num_banks);
+      m_allocated_bank[bank].alloc_read(op);
+    }
+    void reset_alloction() {
+      for (unsigned b = 0; b < m_num_banks; b++) m_allocated_bank[b].reset();
+    }
 
    private:
-      unsigned m_num_collectors;
-      std::vector<collector_unit_t>* m_collector_units;
-      unsigned m_last_cu; // dispatch ready cu's rr
-      unsigned m_next_cu;  // for initialization
-   };
+    unsigned m_num_banks;
+    unsigned m_num_collectors;
 
-   // opndcoll_rfu_t data members
-   bool m_initialized;
+    allocation_t *m_allocated_bank;  // bank # -> register that wins
+    std::list<op_t> *m_queue;
 
-   unsigned m_num_collector_sets;
-   //unsigned m_num_collectors;
-   unsigned m_num_banks;
-   unsigned m_bank_warp_shift;
-   unsigned m_warp_size;
-   std::vector<collector_unit_t *> m_cu;
-   arbiter_t m_arbiter;
+    unsigned *
+        m_allocator_rr_head;  // cu # -> next bank to check for request (rr-arb)
+    unsigned m_last_cu;       // first cu to check while arb-ing banks (rr)
 
-   unsigned m_num_banks_per_sched;
-   unsigned m_num_warp_sceds;
-   bool sub_core_model;
+    int *_inmatch;
+    int *_outmatch;
+    int **_request;
+  };
 
-   //unsigned m_num_ports;
-   //std::vector<warp_inst_t**> m_input;
-   //std::vector<warp_inst_t**> m_output;
-   //std::vector<unsigned> m_num_collector_units;
-   //warp_inst_t **m_alu_port;
+  class input_port_t {
+   public:
+    input_port_t(port_vector_t &input, port_vector_t &output,
+                 uint_vector_t cu_sets)
+        : m_in(input), m_out(output), m_cu_sets(cu_sets) {
+      assert(input.size() == output.size());
+      assert(not m_cu_sets.empty());
+    }
+    // private:
+    port_vector_t m_in, m_out;
+    uint_vector_t m_cu_sets;
+  };
 
-   std::vector<input_port_t> m_in_ports;
-   typedef std::map<unsigned /* collector set */, std::vector<collector_unit_t> /*collector sets*/ > cu_sets_t;
-   cu_sets_t m_cus;
-   std::vector<dispatch_unit_t> m_dispatch_units;
+  class collector_unit_t {
+   public:
+    // constructors
+    collector_unit_t() {
+      m_free = true;
+      m_warp = NULL;
+      m_output_register = NULL;
+      m_src_op = new op_t[MAX_REG_OPERANDS * 2];
+      m_not_ready.reset();
+      m_warp_id = -1;
+      m_num_banks = 0;
+      m_bank_warp_shift = 0;
+    }
+    // accessors
+    bool ready() const;
+    const op_t *get_operands() const { return m_src_op; }
+    void dump(FILE *fp, const shader_core_ctx *shader) const;
 
-   //typedef std::map<warp_inst_t**/*port*/,dispatch_unit_t> port_to_du_t;
-   //port_to_du_t                     m_dispatch_units;
-   //std::map<warp_inst_t**,std::list<collector_unit_t*> > m_free_cu;
-   shader_core_ctx                 *m_shader;
+    unsigned get_warp_id() const { return m_warp_id; }
+    unsigned get_active_count() const { return m_warp->active_count(); }
+    const active_mask_t &get_active_mask() const {
+      return m_warp->get_active_mask();
+    }
+    unsigned get_sp_op() const { return m_warp->sp_op; }
+    unsigned get_id() const { return m_cuid; }  // returns CU hw id
+
+    // modifiers
+    void init(unsigned n, unsigned num_banks, unsigned log2_warp_size,
+              const core_config *config, opndcoll_rfu_t *rfu,
+              bool m_sub_core_model, unsigned num_banks_per_sched);
+    bool allocate(register_set *pipeline_reg, register_set *output_reg);
+
+    void collect_operand(unsigned op) { m_not_ready.reset(op); }
+    unsigned get_num_operands() const { return m_warp->get_num_operands(); }
+    unsigned get_num_regs() const { return m_warp->get_num_regs(); }
+    void dispatch();
+    bool is_free() { return m_free; }
+
+   private:
+    bool m_free;
+    unsigned m_cuid;  // collector unit hw id
+    unsigned m_warp_id;
+    warp_inst_t *m_warp;
+    register_set
+        *m_output_register;  // pipeline register to issue to when ready
+    op_t *m_src_op;
+    std::bitset<MAX_REG_OPERANDS * 2> m_not_ready;
+    unsigned m_num_banks;
+    unsigned m_bank_warp_shift;
+    opndcoll_rfu_t *m_rfu;
+
+    unsigned m_num_banks_per_sched;
+    bool m_sub_core_model;
+  };
+
+  class dispatch_unit_t {
+   public:
+    dispatch_unit_t(std::vector<collector_unit_t> *cus) {
+      m_last_cu = 0;
+      m_collector_units = cus;
+      m_num_collectors = (*cus).size();
+      m_next_cu = 0;
+    }
+
+    collector_unit_t *find_ready() {
+      for (unsigned n = 0; n < m_num_collectors; n++) {
+        unsigned c = (m_last_cu + n + 1) % m_num_collectors;
+        if ((*m_collector_units)[c].ready()) {
+          m_last_cu = c;
+          return &((*m_collector_units)[c]);
+        }
+      }
+      return NULL;
+    }
+
+   private:
+    unsigned m_num_collectors;
+    std::vector<collector_unit_t> *m_collector_units;
+    unsigned m_last_cu;  // dispatch ready cu's rr
+    unsigned m_next_cu;  // for initialization
+  };
+
+  // opndcoll_rfu_t data members
+  bool m_initialized;
+
+  unsigned m_num_collector_sets;
+  // unsigned m_num_collectors;
+  unsigned m_num_banks;
+  unsigned m_bank_warp_shift;
+  unsigned m_warp_size;
+  std::vector<collector_unit_t *> m_cu;
+  arbiter_t m_arbiter;
+
+  unsigned m_num_banks_per_sched;
+  unsigned m_num_warp_sceds;
+  bool sub_core_model;
+
+  // unsigned m_num_ports;
+  // std::vector<warp_inst_t**> m_input;
+  // std::vector<warp_inst_t**> m_output;
+  // std::vector<unsigned> m_num_collector_units;
+  // warp_inst_t **m_alu_port;
+
+  std::vector<input_port_t> m_in_ports;
+  typedef std::map<unsigned /* collector set */,
+                   std::vector<collector_unit_t> /*collector sets*/>
+      cu_sets_t;
+  cu_sets_t m_cus;
+  std::vector<dispatch_unit_t> m_dispatch_units;
+
+  // typedef std::map<warp_inst_t**/*port*/,dispatch_unit_t> port_to_du_t;
+  // port_to_du_t                     m_dispatch_units;
+  // std::map<warp_inst_t**,std::list<collector_unit_t*> > m_free_cu;
+  shader_core_ctx *m_shader;
 };
 
 class barrier_set_t {
-public:
-   barrier_set_t(shader_core_ctx * shader, unsigned max_warps_per_core, unsigned max_cta_per_core, unsigned max_barriers_per_cta, unsigned warp_size);
+ public:
+  barrier_set_t(shader_core_ctx *shader, unsigned max_warps_per_core,
+                unsigned max_cta_per_core, unsigned max_barriers_per_cta,
+                unsigned warp_size);
 
-   // during cta allocation
-   void allocate_barrier( unsigned cta_id, warp_set_t warps );
+  // during cta allocation
+  void allocate_barrier(unsigned cta_id, warp_set_t warps);
 
-   // during cta deallocation
-   void deallocate_barrier( unsigned cta_id );
+  // during cta deallocation
+  void deallocate_barrier(unsigned cta_id);
 
-   typedef std::map<unsigned, warp_set_t >  cta_to_warp_t;
-   typedef std::map<unsigned, warp_set_t >  bar_id_to_warp_t; /*set of warps reached a specific barrier id*/
+  typedef std::map<unsigned, warp_set_t> cta_to_warp_t;
+  typedef std::map<unsigned, warp_set_t>
+      bar_id_to_warp_t; /*set of warps reached a specific barrier id*/
 
+  // individual warp hits barrier
+  void warp_reaches_barrier(unsigned cta_id, unsigned warp_id,
+                            warp_inst_t *inst);
 
-   // individual warp hits barrier
-   void warp_reaches_barrier( unsigned cta_id, unsigned warp_id, warp_inst_t* inst);
+  // warp reaches exit
+  void warp_exit(unsigned warp_id);
 
+  // assertions
+  bool warp_waiting_at_barrier(unsigned warp_id) const;
 
-   // warp reaches exit 
-   void warp_exit( unsigned warp_id );
+  // debug
+  void dump();
 
-   // assertions
-   bool warp_waiting_at_barrier( unsigned warp_id ) const;
-
-   // debug
-   void dump();
-
-private:
-   unsigned m_max_cta_per_core;
-   unsigned m_max_warps_per_core;
-   unsigned m_max_barriers_per_cta;
-   unsigned m_warp_size;
-   cta_to_warp_t m_cta_to_warps;
-   bar_id_to_warp_t m_bar_id_to_warps;
-   warp_set_t m_warp_active;
-   warp_set_t m_warp_at_barrier;
-   shader_core_ctx *m_shader;
-
+ private:
+  unsigned m_max_cta_per_core;
+  unsigned m_max_warps_per_core;
+  unsigned m_max_barriers_per_cta;
+  unsigned m_warp_size;
+  cta_to_warp_t m_cta_to_warps;
+  bar_id_to_warp_t m_bar_id_to_warps;
+  warp_set_t m_warp_active;
+  warp_set_t m_warp_at_barrier;
+  shader_core_ctx *m_shader;
 };
 
 struct insn_latency_info {
-   unsigned pc;
-   unsigned long latency;
+  unsigned pc;
+  unsigned long latency;
 };
 
 struct ifetch_buffer_t {
-    ifetch_buffer_t() { m_valid=false; }
+  ifetch_buffer_t() { m_valid = false; }
 
-    ifetch_buffer_t( address_type pc, unsigned nbytes, unsigned warp_id ) 
-    { 
-        m_valid=true; 
-        m_pc=pc; 
-        m_nbytes=nbytes; 
-        m_warp_id=warp_id;
-    }
+  ifetch_buffer_t(address_type pc, unsigned nbytes, unsigned warp_id) {
+    m_valid = true;
+    m_pc = pc;
+    m_nbytes = nbytes;
+    m_warp_id = warp_id;
+  }
 
-    bool m_valid;
-    address_type m_pc;
-    unsigned m_nbytes;
-    unsigned m_warp_id;
+  bool m_valid;
+  address_type m_pc;
+  unsigned m_nbytes;
+  unsigned m_warp_id;
 };
 
 class shader_core_config;
 
 class simd_function_unit {
-public:
-    simd_function_unit( const shader_core_config *config );
-    ~simd_function_unit() { delete m_dispatch_reg; }
+ public:
+  simd_function_unit(const shader_core_config *config);
+  ~simd_function_unit() { delete m_dispatch_reg; }
 
-    // modifiers
-    virtual void issue( register_set& source_reg ) { source_reg.move_out_to(m_dispatch_reg); occupied.set(m_dispatch_reg->latency);}
-    virtual void cycle() = 0;
-    virtual void active_lanes_in_pipeline() = 0;
+  // modifiers
+  virtual void issue(register_set &source_reg) {
+    source_reg.move_out_to(m_dispatch_reg);
+    occupied.set(m_dispatch_reg->latency);
+  }
+  virtual void cycle() = 0;
+  virtual void active_lanes_in_pipeline() = 0;
 
-    // accessors
-    virtual unsigned clock_multiplier() const { return 1; }
-    virtual bool can_issue( const warp_inst_t &inst ) const { return m_dispatch_reg->empty() && !occupied.test(inst.latency); }
-    virtual bool stallable() const = 0;
-    virtual void print( FILE *fp ) const
-    {
-        fprintf(fp,"%s dispatch= ", m_name.c_str() );
-        m_dispatch_reg->print(fp);
-    }
-    const char* get_name() {
-    	return m_name.c_str();
-    }
-protected:
-    std::string m_name;
-    const shader_core_config *m_config;
-    warp_inst_t *m_dispatch_reg;
-    static const unsigned MAX_ALU_LATENCY = 512;
-    std::bitset<MAX_ALU_LATENCY> occupied;
+  // accessors
+  virtual unsigned clock_multiplier() const { return 1; }
+  virtual bool can_issue(const warp_inst_t &inst) const {
+    return m_dispatch_reg->empty() && !occupied.test(inst.latency);
+  }
+  virtual bool stallable() const = 0;
+  virtual void print(FILE *fp) const {
+    fprintf(fp, "%s dispatch= ", m_name.c_str());
+    m_dispatch_reg->print(fp);
+  }
+  const char *get_name() { return m_name.c_str(); }
+
+ protected:
+  std::string m_name;
+  const shader_core_config *m_config;
+  warp_inst_t *m_dispatch_reg;
+  static const unsigned MAX_ALU_LATENCY = 512;
+  std::bitset<MAX_ALU_LATENCY> occupied;
 };
 
 class pipelined_simd_unit : public simd_function_unit {
-public:
-    pipelined_simd_unit( register_set* result_port, const shader_core_config *config, unsigned max_latency, shader_core_ctx *core );
+ public:
+  pipelined_simd_unit(register_set *result_port,
+                      const shader_core_config *config, unsigned max_latency,
+                      shader_core_ctx *core);
 
-    //modifiers
-    virtual void cycle();
-    virtual void issue( register_set& source_reg );
-    virtual unsigned get_active_lanes_in_pipeline();
+  // modifiers
+  virtual void cycle();
+  virtual void issue(register_set &source_reg);
+  virtual unsigned get_active_lanes_in_pipeline();
 
-    virtual void active_lanes_in_pipeline() = 0;
-/*
-    virtual void issue( register_set& source_reg )
-    {
-        //move_warp(m_dispatch_reg,source_reg);
-        //source_reg.move_out_to(m_dispatch_reg);
-        simd_function_unit::issue(source_reg);
+  virtual void active_lanes_in_pipeline() = 0;
+  /*
+      virtual void issue( register_set& source_reg )
+      {
+          //move_warp(m_dispatch_reg,source_reg);
+          //source_reg.move_out_to(m_dispatch_reg);
+          simd_function_unit::issue(source_reg);
+      }
+  */
+  // accessors
+  virtual bool stallable() const { return false; }
+  virtual bool can_issue(const warp_inst_t &inst) const {
+    return simd_function_unit::can_issue(inst);
+  }
+  virtual void print(FILE *fp) const {
+    simd_function_unit::print(fp);
+    for (int s = m_pipeline_depth - 1; s >= 0; s--) {
+      if (!m_pipeline_reg[s]->empty()) {
+        fprintf(fp, "      %s[%2d] ", m_name.c_str(), s);
+        m_pipeline_reg[s]->print(fp);
+      }
     }
-*/
-    // accessors
-    virtual bool stallable() const { return false; }
-    virtual bool can_issue( const warp_inst_t &inst ) const
-    {
-        return simd_function_unit::can_issue(inst);
-    }
-    virtual void print(FILE *fp) const
-    {
-        simd_function_unit::print(fp);
-        for( int s=m_pipeline_depth-1; s>=0; s-- ) {
-            if( !m_pipeline_reg[s]->empty() ) { 
-                fprintf(fp,"      %s[%2d] ", m_name.c_str(), s );
-                m_pipeline_reg[s]->print(fp);
-            }
-        }
-    }
-protected:
-    unsigned m_pipeline_depth;
-    warp_inst_t **m_pipeline_reg;
-    register_set *m_result_port;
-    class shader_core_ctx *m_core;
+  }
 
-    unsigned active_insts_in_pipeline;
+ protected:
+  unsigned m_pipeline_depth;
+  warp_inst_t **m_pipeline_reg;
+  register_set *m_result_port;
+  class shader_core_ctx *m_core;
 
+  unsigned active_insts_in_pipeline;
 };
 
-class sfu : public pipelined_simd_unit
-{
-public:
-    sfu( register_set* result_port, const shader_core_config *config, shader_core_ctx *core );
-    virtual bool can_issue( const warp_inst_t &inst ) const
-    {
-        switch(inst.op) {
-        case SFU_OP: break;
-        case ALU_SFU_OP: break;
-        case DP_OP: break;     //for compute <= 29 (i..e Fermi and GT200)
-        default: return false;
-        }
-        return pipelined_simd_unit::can_issue(inst);
+class sfu : public pipelined_simd_unit {
+ public:
+  sfu(register_set *result_port, const shader_core_config *config,
+      shader_core_ctx *core);
+  virtual bool can_issue(const warp_inst_t &inst) const {
+    switch (inst.op) {
+      case SFU_OP:
+        break;
+      case ALU_SFU_OP:
+        break;
+      case DP_OP:
+        break;  // for compute <= 29 (i..e Fermi and GT200)
+      default:
+        return false;
     }
-    virtual void active_lanes_in_pipeline();
-    virtual void issue(  register_set& source_reg );
+    return pipelined_simd_unit::can_issue(inst);
+  }
+  virtual void active_lanes_in_pipeline();
+  virtual void issue(register_set &source_reg);
 };
 
-class dp_unit : public pipelined_simd_unit
-{
-public:
-	dp_unit( register_set* result_port, const shader_core_config *config, shader_core_ctx *core );
-    virtual bool can_issue( const warp_inst_t &inst ) const
-    {
-        switch(inst.op) {
-        case DP_OP: break;
-        default: return false;
-        }
-        return pipelined_simd_unit::can_issue(inst);
+class dp_unit : public pipelined_simd_unit {
+ public:
+  dp_unit(register_set *result_port, const shader_core_config *config,
+          shader_core_ctx *core);
+  virtual bool can_issue(const warp_inst_t &inst) const {
+    switch (inst.op) {
+      case DP_OP:
+        break;
+      default:
+        return false;
     }
-    virtual void active_lanes_in_pipeline();
-    virtual void issue(  register_set& source_reg );
+    return pipelined_simd_unit::can_issue(inst);
+  }
+  virtual void active_lanes_in_pipeline();
+  virtual void issue(register_set &source_reg);
 };
 
-class tensor_core : public pipelined_simd_unit
-{
-public:
-    tensor_core( register_set* result_port, const shader_core_config *config, shader_core_ctx *core );
-    virtual bool can_issue( const warp_inst_t &inst ) const
-    {
-        switch(inst.op) {
-        case TENSOR_CORE_OP: break;
-        default: return false;
-        }
-        return pipelined_simd_unit::can_issue(inst);
+class tensor_core : public pipelined_simd_unit {
+ public:
+  tensor_core(register_set *result_port, const shader_core_config *config,
+              shader_core_ctx *core);
+  virtual bool can_issue(const warp_inst_t &inst) const {
+    switch (inst.op) {
+      case TENSOR_CORE_OP:
+        break;
+      default:
+        return false;
     }
-    virtual void active_lanes_in_pipeline();
-    virtual void issue(  register_set& source_reg );
+    return pipelined_simd_unit::can_issue(inst);
+  }
+  virtual void active_lanes_in_pipeline();
+  virtual void issue(register_set &source_reg);
 };
 
-
-class int_unit : public pipelined_simd_unit
-{
-public:
-	int_unit( register_set* result_port, const shader_core_config *config, shader_core_ctx *core );
-    virtual bool can_issue( const warp_inst_t &inst ) const
-    {
-        switch(inst.op) {
-        case SFU_OP: return false;
-	    case LOAD_OP: return false;
-	    case TENSOR_CORE_LOAD_OP: return false;
-		case STORE_OP: return false;
-		case TENSOR_CORE_STORE_OP: return false;
-		case MEMORY_BARRIER_OP: return false;
-	    case SP_OP: return false;
-	    case DP_OP: return false;
-        default: break;
-        }
-        return pipelined_simd_unit::can_issue(inst);
+class int_unit : public pipelined_simd_unit {
+ public:
+  int_unit(register_set *result_port, const shader_core_config *config,
+           shader_core_ctx *core);
+  virtual bool can_issue(const warp_inst_t &inst) const {
+    switch (inst.op) {
+      case SFU_OP:
+        return false;
+      case LOAD_OP:
+        return false;
+      case TENSOR_CORE_LOAD_OP:
+        return false;
+      case STORE_OP:
+        return false;
+      case TENSOR_CORE_STORE_OP:
+        return false;
+      case MEMORY_BARRIER_OP:
+        return false;
+      case SP_OP:
+        return false;
+      case DP_OP:
+        return false;
+      default:
+        break;
     }
-    virtual void active_lanes_in_pipeline();
-    virtual void issue(  register_set& source_reg );
+    return pipelined_simd_unit::can_issue(inst);
+  }
+  virtual void active_lanes_in_pipeline();
+  virtual void issue(register_set &source_reg);
 };
 
-class sp_unit : public pipelined_simd_unit
-{
-public:
-    sp_unit( register_set* result_port, const shader_core_config *config, shader_core_ctx *core );
-    virtual bool can_issue( const warp_inst_t &inst ) const
-    {
-        switch(inst.op) {
-        case SFU_OP: return false; 
-        case LOAD_OP: return false;
-        case TENSOR_CORE_LOAD_OP: return false;
-        case STORE_OP: return false;
-        case TENSOR_CORE_STORE_OP: return false;
-        case MEMORY_BARRIER_OP: return false;
-        case DP_OP: return false;
-        default: break;
-        }
-        return pipelined_simd_unit::can_issue(inst);
+class sp_unit : public pipelined_simd_unit {
+ public:
+  sp_unit(register_set *result_port, const shader_core_config *config,
+          shader_core_ctx *core);
+  virtual bool can_issue(const warp_inst_t &inst) const {
+    switch (inst.op) {
+      case SFU_OP:
+        return false;
+      case LOAD_OP:
+        return false;
+      case TENSOR_CORE_LOAD_OP:
+        return false;
+      case STORE_OP:
+        return false;
+      case TENSOR_CORE_STORE_OP:
+        return false;
+      case MEMORY_BARRIER_OP:
+        return false;
+      case DP_OP:
+        return false;
+      default:
+        break;
     }
-    virtual void active_lanes_in_pipeline();
-    virtual void issue( register_set& source_reg );
+    return pipelined_simd_unit::can_issue(inst);
+  }
+  virtual void active_lanes_in_pipeline();
+  virtual void issue(register_set &source_reg);
 };
 
 class simt_core_cluster;
@@ -1211,947 +1220,1061 @@ class shader_memory_interface;
 class shader_core_mem_fetch_allocator;
 class cache_t;
 
-class ldst_unit: public pipelined_simd_unit {
-public:
-    ldst_unit( mem_fetch_interface *icnt,
-               shader_core_mem_fetch_allocator *mf_allocator,
-               shader_core_ctx *core, 
-               opndcoll_rfu_t *operand_collector,
-               Scoreboard *scoreboard,
-               const shader_core_config *config, 
-               const memory_config *mem_config,  
-               class shader_core_stats *stats, 
-               unsigned sid, unsigned tpc );
+class ldst_unit : public pipelined_simd_unit {
+ public:
+  ldst_unit(mem_fetch_interface *icnt,
+            shader_core_mem_fetch_allocator *mf_allocator,
+            shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
+            Scoreboard *scoreboard, const shader_core_config *config,
+            const memory_config *mem_config, class shader_core_stats *stats,
+            unsigned sid, unsigned tpc);
 
-    // modifiers
-    virtual void issue( register_set &inst );
-    virtual void cycle();
-     
-    void fill( mem_fetch *mf );
-    void flush();
-    void invalidate();
-    void writeback();
+  // modifiers
+  virtual void issue(register_set &inst);
+  virtual void cycle();
 
-    // accessors
-    virtual unsigned clock_multiplier() const;
+  void fill(mem_fetch *mf);
+  void flush();
+  void invalidate();
+  void writeback();
 
-    virtual bool can_issue( const warp_inst_t &inst ) const
-    {
-        switch(inst.op) {
-        case LOAD_OP: break;
-        case TENSOR_CORE_LOAD_OP: break;
-        case STORE_OP: break;
-        case TENSOR_CORE_STORE_OP: break;
-        case MEMORY_BARRIER_OP: break;
-        default: return false;
-        }
-        return m_dispatch_reg->empty();
+  // accessors
+  virtual unsigned clock_multiplier() const;
+
+  virtual bool can_issue(const warp_inst_t &inst) const {
+    switch (inst.op) {
+      case LOAD_OP:
+        break;
+      case TENSOR_CORE_LOAD_OP:
+        break;
+      case STORE_OP:
+        break;
+      case TENSOR_CORE_STORE_OP:
+        break;
+      case MEMORY_BARRIER_OP:
+        break;
+      default:
+        return false;
     }
+    return m_dispatch_reg->empty();
+  }
 
-    virtual void active_lanes_in_pipeline();
-    virtual bool stallable() const { return true; }
-    bool response_buffer_full() const;
-    void print(FILE *fout) const;
-    void print_cache_stats( FILE *fp, unsigned& dl1_accesses, unsigned& dl1_misses );
-    void get_cache_stats(unsigned &read_accesses, unsigned &write_accesses, unsigned &read_misses, unsigned &write_misses, unsigned cache_type);
-    void get_cache_stats(cache_stats &cs);
+  virtual void active_lanes_in_pipeline();
+  virtual bool stallable() const { return true; }
+  bool response_buffer_full() const;
+  void print(FILE *fout) const;
+  void print_cache_stats(FILE *fp, unsigned &dl1_accesses,
+                         unsigned &dl1_misses);
+  void get_cache_stats(unsigned &read_accesses, unsigned &write_accesses,
+                       unsigned &read_misses, unsigned &write_misses,
+                       unsigned cache_type);
+  void get_cache_stats(cache_stats &cs);
 
-    void get_L1D_sub_stats(struct cache_sub_stats &css) const;
-    void get_L1C_sub_stats(struct cache_sub_stats &css) const;
-    void get_L1T_sub_stats(struct cache_sub_stats &css) const;
+  void get_L1D_sub_stats(struct cache_sub_stats &css) const;
+  void get_L1C_sub_stats(struct cache_sub_stats &css) const;
+  void get_L1T_sub_stats(struct cache_sub_stats &css) const;
 
-protected:
-    ldst_unit( mem_fetch_interface *icnt,
-               shader_core_mem_fetch_allocator *mf_allocator,
-               shader_core_ctx *core, 
-               opndcoll_rfu_t *operand_collector,
-               Scoreboard *scoreboard,
-               const shader_core_config *config,
-               const memory_config *mem_config,  
-               shader_core_stats *stats,
-               unsigned sid,
-               unsigned tpc,
-               l1_cache* new_l1d_cache );
-    void init( mem_fetch_interface *icnt,
-               shader_core_mem_fetch_allocator *mf_allocator,
-               shader_core_ctx *core, 
-               opndcoll_rfu_t *operand_collector,
-               Scoreboard *scoreboard,
-               const shader_core_config *config,
-               const memory_config *mem_config,  
-               shader_core_stats *stats,
-               unsigned sid,
-               unsigned tpc );
+ protected:
+  ldst_unit(mem_fetch_interface *icnt,
+            shader_core_mem_fetch_allocator *mf_allocator,
+            shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
+            Scoreboard *scoreboard, const shader_core_config *config,
+            const memory_config *mem_config, shader_core_stats *stats,
+            unsigned sid, unsigned tpc, l1_cache *new_l1d_cache);
+  void init(mem_fetch_interface *icnt,
+            shader_core_mem_fetch_allocator *mf_allocator,
+            shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
+            Scoreboard *scoreboard, const shader_core_config *config,
+            const memory_config *mem_config, shader_core_stats *stats,
+            unsigned sid, unsigned tpc);
 
-protected:
-   bool shared_cycle( warp_inst_t &inst, mem_stage_stall_type &rc_fail, mem_stage_access_type &fail_type);
-   bool constant_cycle( warp_inst_t &inst, mem_stage_stall_type &rc_fail, mem_stage_access_type &fail_type);
-   bool texture_cycle( warp_inst_t &inst, mem_stage_stall_type &rc_fail, mem_stage_access_type &fail_type);
-   bool memory_cycle( warp_inst_t &inst, mem_stage_stall_type &rc_fail, mem_stage_access_type &fail_type);
+ protected:
+  bool shared_cycle(warp_inst_t &inst, mem_stage_stall_type &rc_fail,
+                    mem_stage_access_type &fail_type);
+  bool constant_cycle(warp_inst_t &inst, mem_stage_stall_type &rc_fail,
+                      mem_stage_access_type &fail_type);
+  bool texture_cycle(warp_inst_t &inst, mem_stage_stall_type &rc_fail,
+                     mem_stage_access_type &fail_type);
+  bool memory_cycle(warp_inst_t &inst, mem_stage_stall_type &rc_fail,
+                    mem_stage_access_type &fail_type);
 
-   virtual mem_stage_stall_type process_cache_access( cache_t* cache,
-                                                      new_addr_type address,
-                                                      warp_inst_t &inst,
-                                                      std::list<cache_event>& events,
-                                                      mem_fetch *mf,
-                                                      enum cache_request_status status );
-   mem_stage_stall_type process_memory_access_queue( cache_t *cache, warp_inst_t &inst );
-   mem_stage_stall_type process_memory_access_queue_l1cache( l1_cache *cache, warp_inst_t &inst );
+  virtual mem_stage_stall_type process_cache_access(
+      cache_t *cache, new_addr_type address, warp_inst_t &inst,
+      std::list<cache_event> &events, mem_fetch *mf,
+      enum cache_request_status status);
+  mem_stage_stall_type process_memory_access_queue(cache_t *cache,
+                                                   warp_inst_t &inst);
+  mem_stage_stall_type process_memory_access_queue_l1cache(l1_cache *cache,
+                                                           warp_inst_t &inst);
 
-   const memory_config *m_memory_config;
-   class mem_fetch_interface *m_icnt;
-   shader_core_mem_fetch_allocator *m_mf_allocator;
-   class shader_core_ctx *m_core;
-   unsigned m_sid;
-   unsigned m_tpc;
+  const memory_config *m_memory_config;
+  class mem_fetch_interface *m_icnt;
+  shader_core_mem_fetch_allocator *m_mf_allocator;
+  class shader_core_ctx *m_core;
+  unsigned m_sid;
+  unsigned m_tpc;
 
-   tex_cache *m_L1T; // texture cache
-   read_only_cache *m_L1C; // constant cache
-   l1_cache *m_L1D; // data cache
-   std::map<unsigned/*warp_id*/, std::map<unsigned/*regnum*/,unsigned/*count*/> > m_pending_writes;
-   std::list<mem_fetch*> m_response_fifo;
-   opndcoll_rfu_t *m_operand_collector;
-   Scoreboard *m_scoreboard;
+  tex_cache *m_L1T;        // texture cache
+  read_only_cache *m_L1C;  // constant cache
+  l1_cache *m_L1D;         // data cache
+  std::map<unsigned /*warp_id*/,
+           std::map<unsigned /*regnum*/, unsigned /*count*/>>
+      m_pending_writes;
+  std::list<mem_fetch *> m_response_fifo;
+  opndcoll_rfu_t *m_operand_collector;
+  Scoreboard *m_scoreboard;
 
-   mem_fetch *m_next_global;
-   warp_inst_t m_next_wb;
-   unsigned m_writeback_arb; // round-robin arbiter for writeback contention between L1T, L1C, shared
-   unsigned m_num_writeback_clients;
+  mem_fetch *m_next_global;
+  warp_inst_t m_next_wb;
+  unsigned m_writeback_arb;  // round-robin arbiter for writeback contention
+                             // between L1T, L1C, shared
+  unsigned m_num_writeback_clients;
 
-   enum mem_stage_stall_type m_mem_rc;
+  enum mem_stage_stall_type m_mem_rc;
 
-   shader_core_stats *m_stats; 
+  shader_core_stats *m_stats;
 
-   // for debugging
-   unsigned long long m_last_inst_gpu_sim_cycle;
-   unsigned long long m_last_inst_gpu_tot_sim_cycle;
+  // for debugging
+  unsigned long long m_last_inst_gpu_sim_cycle;
+  unsigned long long m_last_inst_gpu_tot_sim_cycle;
 
-   std::vector<std::deque<mem_fetch* >> l1_latency_queue;
-   void L1_latency_queue_cycle();
+  std::vector<std::deque<mem_fetch *>> l1_latency_queue;
+  void L1_latency_queue_cycle();
 };
 
 enum pipeline_stage_name_t {
-    ID_OC_SP=0,
-	ID_OC_DP,
-	ID_OC_INT,
-    ID_OC_SFU,  
-    ID_OC_MEM,  
-    OC_EX_SP,
-	OC_EX_DP,
-	OC_EX_INT,
-    OC_EX_SFU,
-    OC_EX_MEM,
-    EX_WB,
-    ID_OC_TENSOR_CORE,  
-    OC_EX_TENSOR_CORE,
-    N_PIPELINE_STAGES 
-    };
-
-const char* const pipeline_stage_name_decode[] = {
-    "ID_OC_SP",
-	"ID_OC_DP",
-	"ID_OC_INT",
-    "ID_OC_SFU",  
-    "ID_OC_MEM",  
-    "OC_EX_SP",
-	"OC_EX_DP",
-	"OC_EX_INT",
-    "OC_EX_SFU",
-    "OC_EX_MEM",
-    "EX_WB",
-    "ID_OC_TENSOR_CORE",  
-    "OC_EX_TENSOR_CORE",
-    "N_PIPELINE_STAGES" 
+  ID_OC_SP = 0,
+  ID_OC_DP,
+  ID_OC_INT,
+  ID_OC_SFU,
+  ID_OC_MEM,
+  OC_EX_SP,
+  OC_EX_DP,
+  OC_EX_INT,
+  OC_EX_SFU,
+  OC_EX_MEM,
+  EX_WB,
+  ID_OC_TENSOR_CORE,
+  OC_EX_TENSOR_CORE,
+  N_PIPELINE_STAGES
 };
 
-class shader_core_config : public core_config
-{
-    public:
-    shader_core_config(gpgpu_context* ctx):core_config(ctx){
-	pipeline_widths_string = NULL;
-	gpgpu_ctx = ctx;
+const char *const pipeline_stage_name_decode[] = {
+    "ID_OC_SP",          "ID_OC_DP",         "ID_OC_INT", "ID_OC_SFU",
+    "ID_OC_MEM",         "OC_EX_SP",         "OC_EX_DP",  "OC_EX_INT",
+    "OC_EX_SFU",         "OC_EX_MEM",        "EX_WB",     "ID_OC_TENSOR_CORE",
+    "OC_EX_TENSOR_CORE", "N_PIPELINE_STAGES"};
+
+class shader_core_config : public core_config {
+ public:
+  shader_core_config(gpgpu_context *ctx) : core_config(ctx) {
+    pipeline_widths_string = NULL;
+    gpgpu_ctx = ctx;
+  }
+
+  void init() {
+    int ntok = sscanf(gpgpu_shader_core_pipeline_opt, "%d:%d",
+                      &n_thread_per_shader, &warp_size);
+    if (ntok != 2) {
+      printf(
+          "GPGPU-Sim uArch: error while parsing configuration string "
+          "gpgpu_shader_core_pipeline_opt\n");
+      abort();
     }
 
-    void init()
-    {
-        int ntok = sscanf(gpgpu_shader_core_pipeline_opt,"%d:%d", 
-                          &n_thread_per_shader,
-                          &warp_size);
-        if(ntok != 2) {
-           printf("GPGPU-Sim uArch: error while parsing configuration string gpgpu_shader_core_pipeline_opt\n");
-           abort();
-	}
+    char *toks = new char[100];
+    char *tokd = toks;
+    strcpy(toks, pipeline_widths_string);
 
-	char* toks = new char[100];
-	char* tokd = toks;
-	strcpy(toks,pipeline_widths_string);
-                                  
-	toks = strtok(toks,",");
+    toks = strtok(toks, ",");
 
-	/*	Removing the tensorcore pipeline while reading the config files if the tensor core is not available.
-	 	If we won't remove it, old regression will be broken.
-		So to support the legacy config files it's best to handle in this way.
-         */  
-	int num_config_to_read= N_PIPELINE_STAGES - 2 * (!gpgpu_tensor_core_avail);
+    /*	Removing the tensorcore pipeline while reading the config files if the
+       tensor core is not available.
+            If we won't remove it, old regression will be broken.
+            So to support the legacy config files it's best to handle in this
+       way.
+     */
+    int num_config_to_read = N_PIPELINE_STAGES - 2 * (!gpgpu_tensor_core_avail);
 
-        for (int i = 0; i < num_config_to_read; i++) { 
-	    assert(toks);
-	    ntok = sscanf(toks,"%d", &pipe_widths[i]);
-	    assert(ntok == 1); 
-	    toks = strtok(NULL,",");
-	}
-
-	delete[] tokd;
-	
-        if (n_thread_per_shader > MAX_THREAD_PER_SM) {
-           printf("GPGPU-Sim uArch: Error ** increase MAX_THREAD_PER_SM in abstract_hardware_model.h from %u to %u\n", 
-                  MAX_THREAD_PER_SM, n_thread_per_shader);
-           abort();
-        }
-        max_warps_per_shader =  n_thread_per_shader/warp_size;
-        assert( !(n_thread_per_shader % warp_size) );
-
-        set_pipeline_latency();
-        
-	m_L1I_config.init(m_L1I_config.m_config_string,FuncCachePreferNone);
-        m_L1T_config.init(m_L1T_config.m_config_string,FuncCachePreferNone);
-        m_L1C_config.init(m_L1C_config.m_config_string,FuncCachePreferNone);
-        m_L1D_config.init(m_L1D_config.m_config_string,FuncCachePreferNone);
-        gpgpu_cache_texl1_linesize = m_L1T_config.get_line_sz();
-        gpgpu_cache_constl1_linesize = m_L1C_config.get_line_sz();
-        m_valid = true;
+    for (int i = 0; i < num_config_to_read; i++) {
+      assert(toks);
+      ntok = sscanf(toks, "%d", &pipe_widths[i]);
+      assert(ntok == 1);
+      toks = strtok(NULL, ",");
     }
-    void reg_options(class OptionParser * opp );
-    unsigned max_cta( const kernel_info_t &k ) const;
-    unsigned num_shader() const { return n_simt_clusters*n_simt_cores_per_cluster; }
-    unsigned sid_to_cluster( unsigned sid ) const { return sid / n_simt_cores_per_cluster; }
-    unsigned sid_to_cid( unsigned sid )     const { return sid % n_simt_cores_per_cluster; }
-    unsigned cid_to_sid( unsigned cid, unsigned cluster_id ) const { return cluster_id*n_simt_cores_per_cluster + cid; }
-    void set_pipeline_latency();
 
-    // backward pointer
-    class gpgpu_context* gpgpu_ctx;
-// data
-    char *gpgpu_shader_core_pipeline_opt;
-    bool gpgpu_perfect_mem;
-    bool gpgpu_clock_gated_reg_file;
-    bool gpgpu_clock_gated_lanes;
-    enum divergence_support_t model;
-    unsigned n_thread_per_shader;
-    unsigned n_regfile_gating_group;
-    unsigned max_warps_per_shader; 
-    unsigned max_cta_per_core; //Limit on number of concurrent CTAs in shader core
-    unsigned max_barriers_per_cta;
-    char * gpgpu_scheduler_string;
-    unsigned gpgpu_shmem_per_block;
-    unsigned gpgpu_registers_per_block;
-    char* pipeline_widths_string;
-    int pipe_widths[N_PIPELINE_STAGES];
+    delete[] tokd;
 
-    mutable cache_config m_L1I_config;
-    mutable cache_config m_L1T_config;
-    mutable cache_config m_L1C_config;
-    mutable l1d_cache_config m_L1D_config;
+    if (n_thread_per_shader > MAX_THREAD_PER_SM) {
+      printf(
+          "GPGPU-Sim uArch: Error ** increase MAX_THREAD_PER_SM in "
+          "abstract_hardware_model.h from %u to %u\n",
+          MAX_THREAD_PER_SM, n_thread_per_shader);
+      abort();
+    }
+    max_warps_per_shader = n_thread_per_shader / warp_size;
+    assert(!(n_thread_per_shader % warp_size));
 
-    bool gpgpu_dwf_reg_bankconflict;
+    set_pipeline_latency();
 
-    unsigned gpgpu_num_sched_per_core;
-    int gpgpu_max_insn_issue_per_warp;
-    bool gpgpu_dual_issue_diff_exec_units;
+    m_L1I_config.init(m_L1I_config.m_config_string, FuncCachePreferNone);
+    m_L1T_config.init(m_L1T_config.m_config_string, FuncCachePreferNone);
+    m_L1C_config.init(m_L1C_config.m_config_string, FuncCachePreferNone);
+    m_L1D_config.init(m_L1D_config.m_config_string, FuncCachePreferNone);
+    gpgpu_cache_texl1_linesize = m_L1T_config.get_line_sz();
+    gpgpu_cache_constl1_linesize = m_L1C_config.get_line_sz();
+    m_valid = true;
+  }
+  void reg_options(class OptionParser *opp);
+  unsigned max_cta(const kernel_info_t &k) const;
+  unsigned num_shader() const {
+    return n_simt_clusters * n_simt_cores_per_cluster;
+  }
+  unsigned sid_to_cluster(unsigned sid) const {
+    return sid / n_simt_cores_per_cluster;
+  }
+  unsigned sid_to_cid(unsigned sid) const {
+    return sid % n_simt_cores_per_cluster;
+  }
+  unsigned cid_to_sid(unsigned cid, unsigned cluster_id) const {
+    return cluster_id * n_simt_cores_per_cluster + cid;
+  }
+  void set_pipeline_latency();
 
-    //op collector
-    bool enable_specialized_operand_collector;
-    int gpgpu_operand_collector_num_units_sp;
-    int gpgpu_operand_collector_num_units_dp;
-    int gpgpu_operand_collector_num_units_sfu;
-    int gpgpu_operand_collector_num_units_tensor_core;
-    int gpgpu_operand_collector_num_units_mem;
-    int gpgpu_operand_collector_num_units_gen;
-    int gpgpu_operand_collector_num_units_int;
+  // backward pointer
+  class gpgpu_context *gpgpu_ctx;
+  // data
+  char *gpgpu_shader_core_pipeline_opt;
+  bool gpgpu_perfect_mem;
+  bool gpgpu_clock_gated_reg_file;
+  bool gpgpu_clock_gated_lanes;
+  enum divergence_support_t model;
+  unsigned n_thread_per_shader;
+  unsigned n_regfile_gating_group;
+  unsigned max_warps_per_shader;
+  unsigned
+      max_cta_per_core;  // Limit on number of concurrent CTAs in shader core
+  unsigned max_barriers_per_cta;
+  char *gpgpu_scheduler_string;
+  unsigned gpgpu_shmem_per_block;
+  unsigned gpgpu_registers_per_block;
+  char *pipeline_widths_string;
+  int pipe_widths[N_PIPELINE_STAGES];
 
-    unsigned int gpgpu_operand_collector_num_in_ports_sp;
-    unsigned int gpgpu_operand_collector_num_in_ports_dp;
-    unsigned int gpgpu_operand_collector_num_in_ports_sfu;
-    unsigned int gpgpu_operand_collector_num_in_ports_tensor_core;
-    unsigned int gpgpu_operand_collector_num_in_ports_mem;
-    unsigned int gpgpu_operand_collector_num_in_ports_gen;
-    unsigned int gpgpu_operand_collector_num_in_ports_int;
+  mutable cache_config m_L1I_config;
+  mutable cache_config m_L1T_config;
+  mutable cache_config m_L1C_config;
+  mutable l1d_cache_config m_L1D_config;
 
-    unsigned int gpgpu_operand_collector_num_out_ports_sp;
-    unsigned int gpgpu_operand_collector_num_out_ports_dp;
-    unsigned int gpgpu_operand_collector_num_out_ports_sfu;
-    unsigned int gpgpu_operand_collector_num_out_ports_tensor_core;
-    unsigned int gpgpu_operand_collector_num_out_ports_mem;
-    unsigned int gpgpu_operand_collector_num_out_ports_gen;
-    unsigned int gpgpu_operand_collector_num_out_ports_int;
+  bool gpgpu_dwf_reg_bankconflict;
 
-    int gpgpu_num_sp_units;
-    int gpgpu_tensor_core_avail;
-    int gpgpu_num_dp_units;
-    int gpgpu_num_sfu_units;
-    int gpgpu_num_tensor_core_units;
-    int gpgpu_num_mem_units;
-    int gpgpu_num_int_units;
+  unsigned gpgpu_num_sched_per_core;
+  int gpgpu_max_insn_issue_per_warp;
+  bool gpgpu_dual_issue_diff_exec_units;
 
-    //Shader core resources
-    unsigned gpgpu_shader_registers;
-    int gpgpu_warpdistro_shader;
-    int gpgpu_warp_issue_shader;
-    unsigned gpgpu_num_reg_banks;
-    bool gpgpu_reg_bank_use_warp_id;
-    bool gpgpu_local_mem_map;
-    bool gpgpu_ignore_resources_limitation;
-    bool sub_core_model;
-    
-    unsigned max_sp_latency;
-    unsigned max_int_latency;
-    unsigned max_sfu_latency;
-    unsigned max_dp_latency;
-    unsigned max_tensor_core_latency;
-    
-    unsigned n_simt_cores_per_cluster;
-    unsigned n_simt_clusters;
-    unsigned n_simt_ejection_buffer_size;
-    unsigned ldst_unit_response_queue_size;
+  // op collector
+  bool enable_specialized_operand_collector;
+  int gpgpu_operand_collector_num_units_sp;
+  int gpgpu_operand_collector_num_units_dp;
+  int gpgpu_operand_collector_num_units_sfu;
+  int gpgpu_operand_collector_num_units_tensor_core;
+  int gpgpu_operand_collector_num_units_mem;
+  int gpgpu_operand_collector_num_units_gen;
+  int gpgpu_operand_collector_num_units_int;
 
-    int simt_core_sim_order; 
-    
-    unsigned smem_latency;
+  unsigned int gpgpu_operand_collector_num_in_ports_sp;
+  unsigned int gpgpu_operand_collector_num_in_ports_dp;
+  unsigned int gpgpu_operand_collector_num_in_ports_sfu;
+  unsigned int gpgpu_operand_collector_num_in_ports_tensor_core;
+  unsigned int gpgpu_operand_collector_num_in_ports_mem;
+  unsigned int gpgpu_operand_collector_num_in_ports_gen;
+  unsigned int gpgpu_operand_collector_num_in_ports_int;
 
-    unsigned mem2device(unsigned memid) const { return memid + n_simt_clusters; }
+  unsigned int gpgpu_operand_collector_num_out_ports_sp;
+  unsigned int gpgpu_operand_collector_num_out_ports_dp;
+  unsigned int gpgpu_operand_collector_num_out_ports_sfu;
+  unsigned int gpgpu_operand_collector_num_out_ports_tensor_core;
+  unsigned int gpgpu_operand_collector_num_out_ports_mem;
+  unsigned int gpgpu_operand_collector_num_out_ports_gen;
+  unsigned int gpgpu_operand_collector_num_out_ports_int;
 
-    //Jin: concurrent kernel on sm
-    bool gpgpu_concurrent_kernel_sm;
+  int gpgpu_num_sp_units;
+  int gpgpu_tensor_core_avail;
+  int gpgpu_num_dp_units;
+  int gpgpu_num_sfu_units;
+  int gpgpu_num_tensor_core_units;
+  int gpgpu_num_mem_units;
+  int gpgpu_num_int_units;
 
-    bool adpative_volta_cache_config;
+  // Shader core resources
+  unsigned gpgpu_shader_registers;
+  int gpgpu_warpdistro_shader;
+  int gpgpu_warp_issue_shader;
+  unsigned gpgpu_num_reg_banks;
+  bool gpgpu_reg_bank_use_warp_id;
+  bool gpgpu_local_mem_map;
+  bool gpgpu_ignore_resources_limitation;
+  bool sub_core_model;
 
+  unsigned max_sp_latency;
+  unsigned max_int_latency;
+  unsigned max_sfu_latency;
+  unsigned max_dp_latency;
+  unsigned max_tensor_core_latency;
+
+  unsigned n_simt_cores_per_cluster;
+  unsigned n_simt_clusters;
+  unsigned n_simt_ejection_buffer_size;
+  unsigned ldst_unit_response_queue_size;
+
+  int simt_core_sim_order;
+
+  unsigned smem_latency;
+
+  unsigned mem2device(unsigned memid) const { return memid + n_simt_clusters; }
+
+  // Jin: concurrent kernel on sm
+  bool gpgpu_concurrent_kernel_sm;
+
+  bool adpative_volta_cache_config;
 };
 
 struct shader_core_stats_pod {
+  void *shader_core_stats_pod_start[0];  // DO NOT MOVE FROM THE TOP - spaceless
+                                         // pointer to the start of this
+                                         // structure
+  unsigned long long *shader_cycles;
+  unsigned *m_num_sim_insn;   // number of scalar thread instructions committed
+                              // by this shader core
+  unsigned *m_num_sim_winsn;  // number of warp instructions committed by this
+                              // shader core
+  unsigned *m_last_num_sim_insn;
+  unsigned *m_last_num_sim_winsn;
+  unsigned *
+      m_num_decoded_insn;  // number of instructions decoded by this shader core
+  float *m_pipeline_duty_cycle;
+  unsigned *m_num_FPdecoded_insn;
+  unsigned *m_num_INTdecoded_insn;
+  unsigned *m_num_storequeued_insn;
+  unsigned *m_num_loadqueued_insn;
+  unsigned *m_num_ialu_acesses;
+  unsigned *m_num_fp_acesses;
+  unsigned *m_num_imul_acesses;
+  unsigned *m_num_tex_inst;
+  unsigned *m_num_fpmul_acesses;
+  unsigned *m_num_idiv_acesses;
+  unsigned *m_num_fpdiv_acesses;
+  unsigned *m_num_sp_acesses;
+  unsigned *m_num_sfu_acesses;
+  unsigned *m_num_tensor_core_acesses;
+  unsigned *m_num_trans_acesses;
+  unsigned *m_num_mem_acesses;
+  unsigned *m_num_sp_committed;
+  unsigned *m_num_tlb_hits;
+  unsigned *m_num_tlb_accesses;
+  unsigned *m_num_sfu_committed;
+  unsigned *m_num_tensor_core_committed;
+  unsigned *m_num_mem_committed;
+  unsigned *m_read_regfile_acesses;
+  unsigned *m_write_regfile_acesses;
+  unsigned *m_non_rf_operands;
+  unsigned *m_num_imul24_acesses;
+  unsigned *m_num_imul32_acesses;
+  unsigned *m_active_sp_lanes;
+  unsigned *m_active_sfu_lanes;
+  unsigned *m_active_tensor_core_lanes;
+  unsigned *m_active_fu_lanes;
+  unsigned *m_active_fu_mem_lanes;
+  unsigned *m_n_diverge;  // number of divergence occurring in this shader
+  unsigned gpgpu_n_load_insn;
+  unsigned gpgpu_n_store_insn;
+  unsigned gpgpu_n_shmem_insn;
+  unsigned gpgpu_n_sstarr_insn;
+  unsigned gpgpu_n_tex_insn;
+  unsigned gpgpu_n_const_insn;
+  unsigned gpgpu_n_param_insn;
+  unsigned gpgpu_n_shmem_bkconflict;
+  unsigned gpgpu_n_cache_bkconflict;
+  int gpgpu_n_intrawarp_mshr_merge;
+  unsigned gpgpu_n_cmem_portconflict;
+  unsigned gpu_stall_shd_mem_breakdown[N_MEM_STAGE_ACCESS_TYPE]
+                                      [N_MEM_STAGE_STALL_TYPE];
+  unsigned gpu_reg_bank_conflict_stalls;
+  unsigned *shader_cycle_distro;
+  unsigned *last_shader_cycle_distro;
+  unsigned *num_warps_issuable;
+  unsigned gpgpu_n_stall_shd_mem;
+  unsigned *single_issue_nums;
+  unsigned *dual_issue_nums;
 
-	void* shader_core_stats_pod_start[0]; // DO NOT MOVE FROM THE TOP - spaceless pointer to the start of this structure
-	unsigned long long *shader_cycles;
-    unsigned *m_num_sim_insn; // number of scalar thread instructions committed by this shader core
-    unsigned *m_num_sim_winsn; // number of warp instructions committed by this shader core
-	unsigned *m_last_num_sim_insn;
-	unsigned *m_last_num_sim_winsn;
-    unsigned *m_num_decoded_insn; // number of instructions decoded by this shader core
-    float *m_pipeline_duty_cycle;
-    unsigned *m_num_FPdecoded_insn;
-    unsigned *m_num_INTdecoded_insn;
-    unsigned *m_num_storequeued_insn;
-    unsigned *m_num_loadqueued_insn;
-    unsigned *m_num_ialu_acesses;
-    unsigned *m_num_fp_acesses;
-    unsigned *m_num_imul_acesses;
-    unsigned *m_num_tex_inst;
-    unsigned *m_num_fpmul_acesses;
-    unsigned *m_num_idiv_acesses;
-    unsigned *m_num_fpdiv_acesses;
-    unsigned *m_num_sp_acesses;
-    unsigned *m_num_sfu_acesses;
-    unsigned *m_num_tensor_core_acesses;
-    unsigned *m_num_trans_acesses;
-    unsigned *m_num_mem_acesses;
-    unsigned *m_num_sp_committed;
-    unsigned *m_num_tlb_hits;
-    unsigned *m_num_tlb_accesses;
-    unsigned *m_num_sfu_committed;
-    unsigned *m_num_tensor_core_committed;
-    unsigned *m_num_mem_committed;
-    unsigned *m_read_regfile_acesses;
-    unsigned *m_write_regfile_acesses;
-    unsigned *m_non_rf_operands;
-    unsigned *m_num_imul24_acesses;
-    unsigned *m_num_imul32_acesses;
-    unsigned *m_active_sp_lanes;
-    unsigned *m_active_sfu_lanes;
-    unsigned *m_active_tensor_core_lanes;
-    unsigned *m_active_fu_lanes;
-    unsigned *m_active_fu_mem_lanes;
-    unsigned *m_n_diverge;    // number of divergence occurring in this shader
-    unsigned gpgpu_n_load_insn;
-    unsigned gpgpu_n_store_insn;
-    unsigned gpgpu_n_shmem_insn;
-    unsigned gpgpu_n_sstarr_insn;
-    unsigned gpgpu_n_tex_insn;
-    unsigned gpgpu_n_const_insn;
-    unsigned gpgpu_n_param_insn;
-    unsigned gpgpu_n_shmem_bkconflict;
-    unsigned gpgpu_n_cache_bkconflict;
-    int      gpgpu_n_intrawarp_mshr_merge;
-    unsigned gpgpu_n_cmem_portconflict;
-    unsigned gpu_stall_shd_mem_breakdown[N_MEM_STAGE_ACCESS_TYPE][N_MEM_STAGE_STALL_TYPE];
-    unsigned gpu_reg_bank_conflict_stalls;
-    unsigned *shader_cycle_distro;
-    unsigned *last_shader_cycle_distro;
-    unsigned *num_warps_issuable;
-    unsigned gpgpu_n_stall_shd_mem;
-    unsigned* single_issue_nums;
-    unsigned* dual_issue_nums;
+  // memory access classification
+  int gpgpu_n_mem_read_local;
+  int gpgpu_n_mem_write_local;
+  int gpgpu_n_mem_texture;
+  int gpgpu_n_mem_const;
+  int gpgpu_n_mem_read_global;
+  int gpgpu_n_mem_write_global;
+  int gpgpu_n_mem_read_inst;
 
-    //memory access classification
-    int gpgpu_n_mem_read_local;
-    int gpgpu_n_mem_write_local;
-    int gpgpu_n_mem_texture;
-    int gpgpu_n_mem_const;
-    int gpgpu_n_mem_read_global;
-    int gpgpu_n_mem_write_global;
-    int gpgpu_n_mem_read_inst;
-    
-    int gpgpu_n_mem_l2_writeback;
-    int gpgpu_n_mem_l1_write_allocate; 
-    int gpgpu_n_mem_l2_write_allocate;
+  int gpgpu_n_mem_l2_writeback;
+  int gpgpu_n_mem_l1_write_allocate;
+  int gpgpu_n_mem_l2_write_allocate;
 
-    unsigned made_write_mfs;
-    unsigned made_read_mfs;
+  unsigned made_write_mfs;
+  unsigned made_read_mfs;
 
-    unsigned *gpgpu_n_shmem_bank_access;
-    long *n_simt_to_mem; // Interconnect power stats
-    long *n_mem_to_simt;
+  unsigned *gpgpu_n_shmem_bank_access;
+  long *n_simt_to_mem;  // Interconnect power stats
+  long *n_mem_to_simt;
 };
 
 class shader_core_stats : public shader_core_stats_pod {
-public:
-    shader_core_stats( const shader_core_config *config )
-    {
-        m_config = config;
-        shader_core_stats_pod *pod = reinterpret_cast< shader_core_stats_pod * > ( this->shader_core_stats_pod_start );
-        memset(pod,0,sizeof(shader_core_stats_pod));
-        shader_cycles=(unsigned long long *) calloc(config->num_shader(),sizeof(unsigned long long ));
-        m_num_sim_insn = (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_sim_winsn = (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_last_num_sim_winsn = (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_last_num_sim_insn = (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_pipeline_duty_cycle=(float*) calloc(config->num_shader(),sizeof(float));
-        m_num_decoded_insn = (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_FPdecoded_insn = (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_storequeued_insn=(unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_loadqueued_insn=(unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_INTdecoded_insn = (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_ialu_acesses = (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_fp_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_tex_inst= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_imul_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_imul24_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_imul32_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_fpmul_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_idiv_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_fpdiv_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_sp_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_sfu_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_tensor_core_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_trans_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_mem_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_sp_committed= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_tlb_hits=(unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_tlb_accesses=(unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_active_sp_lanes= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_active_sfu_lanes= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_active_tensor_core_lanes= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_active_fu_lanes= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_active_fu_mem_lanes= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_sfu_committed= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_tensor_core_committed= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_mem_committed= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_read_regfile_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_write_regfile_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_non_rf_operands=(unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_n_diverge = (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        shader_cycle_distro = (unsigned*) calloc(config->warp_size+3, sizeof(unsigned));
-        last_shader_cycle_distro = (unsigned*) calloc(m_config->warp_size+3, sizeof(unsigned));
-        single_issue_nums = (unsigned*) calloc(config->gpgpu_num_sched_per_core,sizeof(unsigned));
-        dual_issue_nums = (unsigned*) calloc(config->gpgpu_num_sched_per_core, sizeof(unsigned));
+ public:
+  shader_core_stats(const shader_core_config *config) {
+    m_config = config;
+    shader_core_stats_pod *pod = reinterpret_cast<shader_core_stats_pod *>(
+        this->shader_core_stats_pod_start);
+    memset(pod, 0, sizeof(shader_core_stats_pod));
+    shader_cycles = (unsigned long long *)calloc(config->num_shader(),
+                                                 sizeof(unsigned long long));
+    m_num_sim_insn = (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_sim_winsn =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_last_num_sim_winsn =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_last_num_sim_insn =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_pipeline_duty_cycle =
+        (float *)calloc(config->num_shader(), sizeof(float));
+    m_num_decoded_insn =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_FPdecoded_insn =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_storequeued_insn =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_loadqueued_insn =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_INTdecoded_insn =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_ialu_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_fp_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_tex_inst = (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_imul_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_imul24_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_imul32_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_fpmul_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_idiv_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_fpdiv_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_sp_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_sfu_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_tensor_core_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_trans_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_mem_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_sp_committed =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_tlb_hits = (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_tlb_accesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_active_sp_lanes =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_active_sfu_lanes =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_active_tensor_core_lanes =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_active_fu_lanes =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_active_fu_mem_lanes =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_sfu_committed =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_tensor_core_committed =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_mem_committed =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_read_regfile_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_write_regfile_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_non_rf_operands =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_n_diverge = (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    shader_cycle_distro =
+        (unsigned *)calloc(config->warp_size + 3, sizeof(unsigned));
+    last_shader_cycle_distro =
+        (unsigned *)calloc(m_config->warp_size + 3, sizeof(unsigned));
+    single_issue_nums =
+        (unsigned *)calloc(config->gpgpu_num_sched_per_core, sizeof(unsigned));
+    dual_issue_nums =
+        (unsigned *)calloc(config->gpgpu_num_sched_per_core, sizeof(unsigned));
 
-        n_simt_to_mem = (long *)calloc(config->num_shader(), sizeof(long));
-        n_mem_to_simt = (long *)calloc(config->num_shader(), sizeof(long));
+    n_simt_to_mem = (long *)calloc(config->num_shader(), sizeof(long));
+    n_mem_to_simt = (long *)calloc(config->num_shader(), sizeof(long));
 
-        m_outgoing_traffic_stats = new traffic_breakdown("coretomem"); 
-        m_incoming_traffic_stats = new traffic_breakdown("memtocore"); 
+    m_outgoing_traffic_stats = new traffic_breakdown("coretomem");
+    m_incoming_traffic_stats = new traffic_breakdown("memtocore");
 
-        gpgpu_n_shmem_bank_access = (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    gpgpu_n_shmem_bank_access =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
 
-        m_shader_dynamic_warp_issue_distro.resize( config->num_shader() );
-        m_shader_warp_slot_issue_distro.resize( config->num_shader() );
-    }
+    m_shader_dynamic_warp_issue_distro.resize(config->num_shader());
+    m_shader_warp_slot_issue_distro.resize(config->num_shader());
+  }
 
-    ~shader_core_stats()
-    {
-        delete m_outgoing_traffic_stats; 
-        delete m_incoming_traffic_stats; 
-        free(m_num_sim_insn); 
-        free(m_num_sim_winsn);
-        free(m_n_diverge); 
-        free(shader_cycle_distro);
-        free(last_shader_cycle_distro);
-    }
+  ~shader_core_stats() {
+    delete m_outgoing_traffic_stats;
+    delete m_incoming_traffic_stats;
+    free(m_num_sim_insn);
+    free(m_num_sim_winsn);
+    free(m_n_diverge);
+    free(shader_cycle_distro);
+    free(last_shader_cycle_distro);
+  }
 
-    void new_grid()
-    {
-    }
+  void new_grid() {}
 
-    void event_warp_issued( unsigned s_id, unsigned warp_id, unsigned num_issued, unsigned dynamic_warp_id );
+  void event_warp_issued(unsigned s_id, unsigned warp_id, unsigned num_issued,
+                         unsigned dynamic_warp_id);
 
-    void visualizer_print( gzFile visualizer_file );
+  void visualizer_print(gzFile visualizer_file);
 
-    void print( FILE *fout ) const;
+  void print(FILE *fout) const;
 
-    const std::vector< std::vector<unsigned> >& get_dynamic_warp_issue() const
-    {
-        return m_shader_dynamic_warp_issue_distro;
-    }
+  const std::vector<std::vector<unsigned>> &get_dynamic_warp_issue() const {
+    return m_shader_dynamic_warp_issue_distro;
+  }
 
-    const std::vector< std::vector<unsigned> >& get_warp_slot_issue() const
-    {
-        return m_shader_warp_slot_issue_distro;
-    }
+  const std::vector<std::vector<unsigned>> &get_warp_slot_issue() const {
+    return m_shader_warp_slot_issue_distro;
+  }
 
-private:
-    const shader_core_config *m_config;
+ private:
+  const shader_core_config *m_config;
 
-    traffic_breakdown *m_outgoing_traffic_stats; // core to memory partitions
-    traffic_breakdown *m_incoming_traffic_stats; // memory partition to core 
+  traffic_breakdown *m_outgoing_traffic_stats;  // core to memory partitions
+  traffic_breakdown *m_incoming_traffic_stats;  // memory partition to core
 
-    // Counts the instructions issued for each dynamic warp.
-    std::vector< std::vector<unsigned> > m_shader_dynamic_warp_issue_distro;
-    std::vector<unsigned> m_last_shader_dynamic_warp_issue_distro;
-    std::vector< std::vector<unsigned> > m_shader_warp_slot_issue_distro;
-    std::vector<unsigned> m_last_shader_warp_slot_issue_distro;
+  // Counts the instructions issued for each dynamic warp.
+  std::vector<std::vector<unsigned>> m_shader_dynamic_warp_issue_distro;
+  std::vector<unsigned> m_last_shader_dynamic_warp_issue_distro;
+  std::vector<std::vector<unsigned>> m_shader_warp_slot_issue_distro;
+  std::vector<unsigned> m_last_shader_warp_slot_issue_distro;
 
-    friend class power_stat_t;
-    friend class shader_core_ctx;
-    friend class ldst_unit;
-    friend class simt_core_cluster;
-    friend class scheduler_unit;
-    friend class TwoLevelScheduler;
-    friend class LooseRoundRobbinScheduler;
+  friend class power_stat_t;
+  friend class shader_core_ctx;
+  friend class ldst_unit;
+  friend class simt_core_cluster;
+  friend class scheduler_unit;
+  friend class TwoLevelScheduler;
+  friend class LooseRoundRobbinScheduler;
 };
 
 class memory_config;
 class shader_core_mem_fetch_allocator : public mem_fetch_allocator {
-public:
-    shader_core_mem_fetch_allocator( unsigned core_id, unsigned cluster_id, const memory_config *config )
-    {
-    	m_core_id = core_id;
-    	m_cluster_id = cluster_id;
-    	m_memory_config = config;
-    }
-    mem_fetch *alloc( new_addr_type addr, mem_access_type type, unsigned size, bool wr, unsigned long long cycle ) const; 
-    mem_fetch *alloc( const warp_inst_t &inst, const mem_access_t &access, unsigned long long cycle ) const
-    {
-        warp_inst_t inst_copy = inst;
-        mem_fetch *mf = new mem_fetch(access, 
-                                      &inst_copy, 
-                                      access.is_write()?WRITE_PACKET_SIZE:READ_PACKET_SIZE,
-                                      inst.warp_id(),
-                                      m_core_id, 
-                                      m_cluster_id, 
-                                      m_memory_config,
-									  cycle);
-        return mf;
-    }
+ public:
+  shader_core_mem_fetch_allocator(unsigned core_id, unsigned cluster_id,
+                                  const memory_config *config) {
+    m_core_id = core_id;
+    m_cluster_id = cluster_id;
+    m_memory_config = config;
+  }
+  mem_fetch *alloc(new_addr_type addr, mem_access_type type, unsigned size,
+                   bool wr, unsigned long long cycle) const;
+  mem_fetch *alloc(const warp_inst_t &inst, const mem_access_t &access,
+                   unsigned long long cycle) const {
+    warp_inst_t inst_copy = inst;
+    mem_fetch *mf = new mem_fetch(
+        access, &inst_copy,
+        access.is_write() ? WRITE_PACKET_SIZE : READ_PACKET_SIZE,
+        inst.warp_id(), m_core_id, m_cluster_id, m_memory_config, cycle);
+    return mf;
+  }
 
-private:
-    unsigned m_core_id;
-    unsigned m_cluster_id;
-    const memory_config *m_memory_config;
+ private:
+  unsigned m_core_id;
+  unsigned m_cluster_id;
+  const memory_config *m_memory_config;
 };
 
 class shader_core_ctx : public core_t {
-public:
-    // creator:
-    shader_core_ctx( class gpgpu_sim *gpu,
-                     class simt_core_cluster *cluster,
-                     unsigned shader_id,
-                     unsigned tpc_id,
-                     const shader_core_config *config,
-                     const memory_config *mem_config,
-                     shader_core_stats *stats );
+ public:
+  // creator:
+  shader_core_ctx(class gpgpu_sim *gpu, class simt_core_cluster *cluster,
+                  unsigned shader_id, unsigned tpc_id,
+                  const shader_core_config *config,
+                  const memory_config *mem_config, shader_core_stats *stats);
 
-// used by simt_core_cluster:
-    // modifiers
-    void cycle();
-    void reinit(unsigned start_thread, unsigned end_thread, bool reset_not_completed );
-    void issue_block2core( class kernel_info_t &kernel );
+  // used by simt_core_cluster:
+  // modifiers
+  void cycle();
+  void reinit(unsigned start_thread, unsigned end_thread,
+              bool reset_not_completed);
+  void issue_block2core(class kernel_info_t &kernel);
 
-    void cache_flush();
-    void cache_invalidate();
-    void accept_fetch_response( mem_fetch *mf );
-    void accept_ldst_unit_response( class mem_fetch * mf );
-    void broadcast_barrier_reduction(unsigned cta_id, unsigned bar_id,warp_set_t warps);
-    void set_kernel( kernel_info_t *k ) 
-    {
-        assert(k);
-        m_kernel=k; 
-//        k->inc_running(); 
-        printf("GPGPU-Sim uArch: Shader %d bind to kernel %u \'%s\'\n", m_sid, m_kernel->get_uid(),
-                 m_kernel->name().c_str() );
+  void cache_flush();
+  void cache_invalidate();
+  void accept_fetch_response(mem_fetch *mf);
+  void accept_ldst_unit_response(class mem_fetch *mf);
+  void broadcast_barrier_reduction(unsigned cta_id, unsigned bar_id,
+                                   warp_set_t warps);
+  void set_kernel(kernel_info_t *k) {
+    assert(k);
+    m_kernel = k;
+    //        k->inc_running();
+    printf("GPGPU-Sim uArch: Shader %d bind to kernel %u \'%s\'\n", m_sid,
+           m_kernel->get_uid(), m_kernel->name().c_str());
+  }
+
+  // accessors
+  bool fetch_unit_response_buffer_full() const;
+  bool ldst_unit_response_buffer_full() const;
+  unsigned get_not_completed() const { return m_not_completed; }
+  unsigned get_n_active_cta() const { return m_n_active_cta; }
+  unsigned isactive() const {
+    if (m_n_active_cta > 0)
+      return 1;
+    else
+      return 0;
+  }
+  kernel_info_t *get_kernel() { return m_kernel; }
+  unsigned get_sid() const { return m_sid; }
+
+  // used by functional simulation:
+  // modifiers
+  virtual void warp_exit(unsigned warp_id);
+
+  // accessors
+  virtual bool warp_waiting_at_barrier(unsigned warp_id) const;
+  void get_pdom_stack_top_info(unsigned tid, unsigned *pc, unsigned *rpc) const;
+  float get_current_occupancy(unsigned long long &active,
+                              unsigned long long &total) const;
+
+  // used by pipeline timing model components:
+  // modifiers
+  void mem_instruction_stats(const warp_inst_t &inst);
+  void decrement_atomic_count(unsigned wid, unsigned n);
+  void inc_store_req(unsigned warp_id) { m_warp[warp_id].inc_store_req(); }
+  void dec_inst_in_pipeline(unsigned warp_id) {
+    m_warp[warp_id].dec_inst_in_pipeline();
+  }  // also used in writeback()
+  void store_ack(class mem_fetch *mf);
+  bool warp_waiting_at_mem_barrier(unsigned warp_id);
+  void set_max_cta(const kernel_info_t &kernel);
+  void warp_inst_complete(const warp_inst_t &inst);
+
+  // accessors
+  std::list<unsigned> get_regs_written(const inst_t &fvt) const;
+  const shader_core_config *get_config() const { return m_config; }
+  void print_cache_stats(FILE *fp, unsigned &dl1_accesses,
+                         unsigned &dl1_misses);
+
+  void get_cache_stats(cache_stats &cs);
+  void get_L1I_sub_stats(struct cache_sub_stats &css) const;
+  void get_L1D_sub_stats(struct cache_sub_stats &css) const;
+  void get_L1C_sub_stats(struct cache_sub_stats &css) const;
+  void get_L1T_sub_stats(struct cache_sub_stats &css) const;
+
+  void get_icnt_power_stats(long &n_simt_to_mem, long &n_mem_to_simt) const;
+
+  // debug:
+  void display_simt_state(FILE *fout, int mask) const;
+  void display_pipeline(FILE *fout, int print_mem, int mask3bit) const;
+
+  void incload_stat() { m_stats->m_num_loadqueued_insn[m_sid]++; }
+  void incstore_stat() { m_stats->m_num_storequeued_insn[m_sid]++; }
+  void incialu_stat(unsigned active_count, double latency) {
+    if (m_config->gpgpu_clock_gated_lanes == false) {
+      m_stats->m_num_ialu_acesses[m_sid] =
+          m_stats->m_num_ialu_acesses[m_sid] + active_count * latency +
+          inactive_lanes_accesses_nonsfu(active_count, latency);
+    } else {
+      m_stats->m_num_ialu_acesses[m_sid] =
+          m_stats->m_num_ialu_acesses[m_sid] + active_count * latency;
     }
-   
-    // accessors
-    bool fetch_unit_response_buffer_full() const;
-    bool ldst_unit_response_buffer_full() const;
-    unsigned get_not_completed() const { return m_not_completed; }
-    unsigned get_n_active_cta() const { return m_n_active_cta; }
-    unsigned isactive() const {if(m_n_active_cta>0) return 1; else return 0;}
-    kernel_info_t *get_kernel() { return m_kernel; }
-    unsigned get_sid() const {return m_sid;}
-
-// used by functional simulation:
-    // modifiers
-    virtual void warp_exit( unsigned warp_id );
-    
-    // accessors
-    virtual bool warp_waiting_at_barrier( unsigned warp_id ) const;
-    void get_pdom_stack_top_info( unsigned tid, unsigned *pc, unsigned *rpc ) const;
-    float get_current_occupancy( unsigned long long & active, unsigned long long & total ) const;
-
-// used by pipeline timing model components:
-    // modifiers
-    void mem_instruction_stats(const warp_inst_t &inst);
-    void decrement_atomic_count( unsigned wid, unsigned n );
-    void inc_store_req( unsigned warp_id) { m_warp[warp_id].inc_store_req(); }
-    void dec_inst_in_pipeline( unsigned warp_id ) { m_warp[warp_id].dec_inst_in_pipeline(); } // also used in writeback()
-    void store_ack( class mem_fetch *mf );
-    bool warp_waiting_at_mem_barrier( unsigned warp_id );
-    void set_max_cta( const kernel_info_t &kernel );
-    void warp_inst_complete(const warp_inst_t &inst);
-    
-    // accessors
-    std::list<unsigned> get_regs_written( const inst_t &fvt ) const;
-    const shader_core_config *get_config() const { return m_config; }
-    void print_cache_stats( FILE *fp, unsigned& dl1_accesses, unsigned& dl1_misses );
-
-    void get_cache_stats(cache_stats &cs);
-    void get_L1I_sub_stats(struct cache_sub_stats &css) const;
-    void get_L1D_sub_stats(struct cache_sub_stats &css) const;
-    void get_L1C_sub_stats(struct cache_sub_stats &css) const;
-    void get_L1T_sub_stats(struct cache_sub_stats &css) const;
-
-    void get_icnt_power_stats(long &n_simt_to_mem, long &n_mem_to_simt) const;
-
-// debug:
-    void display_simt_state(FILE *fout, int mask ) const;
-    void display_pipeline( FILE *fout, int print_mem, int mask3bit ) const;
-
-    void incload_stat() {m_stats->m_num_loadqueued_insn[m_sid]++;}
-    void incstore_stat() {m_stats->m_num_storequeued_insn[m_sid]++;}
-    void incialu_stat(unsigned active_count,double latency) {
-		if(m_config->gpgpu_clock_gated_lanes==false){
-		  m_stats->m_num_ialu_acesses[m_sid]=m_stats->m_num_ialu_acesses[m_sid]+active_count*latency
-		    + inactive_lanes_accesses_nonsfu(active_count, latency);
-		}else {
-        m_stats->m_num_ialu_acesses[m_sid]=m_stats->m_num_ialu_acesses[m_sid]+active_count*latency;
-		}
-	 }
-    void inctex_stat(unsigned active_count,double latency){
-    	m_stats->m_num_tex_inst[m_sid]=m_stats->m_num_tex_inst[m_sid]+active_count*latency;
+  }
+  void inctex_stat(unsigned active_count, double latency) {
+    m_stats->m_num_tex_inst[m_sid] =
+        m_stats->m_num_tex_inst[m_sid] + active_count * latency;
+  }
+  void incimul_stat(unsigned active_count, double latency) {
+    if (m_config->gpgpu_clock_gated_lanes == false) {
+      m_stats->m_num_imul_acesses[m_sid] =
+          m_stats->m_num_imul_acesses[m_sid] + active_count * latency +
+          inactive_lanes_accesses_nonsfu(active_count, latency);
+    } else {
+      m_stats->m_num_imul_acesses[m_sid] =
+          m_stats->m_num_imul_acesses[m_sid] + active_count * latency;
     }
-    void incimul_stat(unsigned active_count,double latency) {
-		if(m_config->gpgpu_clock_gated_lanes==false){
-		  m_stats->m_num_imul_acesses[m_sid]=m_stats->m_num_imul_acesses[m_sid]+active_count*latency
-		    + inactive_lanes_accesses_nonsfu(active_count, latency);
-		}else {
-        m_stats->m_num_imul_acesses[m_sid]=m_stats->m_num_imul_acesses[m_sid]+active_count*latency;
-		}
-	 }
-    void incimul24_stat(unsigned active_count,double latency) {
-      if(m_config->gpgpu_clock_gated_lanes==false){
-   		m_stats->m_num_imul24_acesses[m_sid]=m_stats->m_num_imul24_acesses[m_sid]+active_count*latency
-		    + inactive_lanes_accesses_nonsfu(active_count, latency);
-		}else {
-		  m_stats->m_num_imul24_acesses[m_sid]=m_stats->m_num_imul24_acesses[m_sid]+active_count*latency;
-		}
-	 }
-	 void incimul32_stat(unsigned active_count,double latency) {
-		if(m_config->gpgpu_clock_gated_lanes==false){
-		  m_stats->m_num_imul32_acesses[m_sid]=m_stats->m_num_imul32_acesses[m_sid]+active_count*latency
-			 + inactive_lanes_accesses_sfu(active_count, latency);			
-		}else{
-		  m_stats->m_num_imul32_acesses[m_sid]=m_stats->m_num_imul32_acesses[m_sid]+active_count*latency;
-		}
-		//printf("Int_Mul -- Active_count: %d\n",active_count);
-	 }
-	 void incidiv_stat(unsigned active_count,double latency) {
-		if(m_config->gpgpu_clock_gated_lanes==false){
-		  m_stats->m_num_idiv_acesses[m_sid]=m_stats->m_num_idiv_acesses[m_sid]+active_count*latency
-			 + inactive_lanes_accesses_sfu(active_count, latency); 
-		}else {
-		  m_stats->m_num_idiv_acesses[m_sid]=m_stats->m_num_idiv_acesses[m_sid]+active_count*latency;
-		}
-	 }
-	 void incfpalu_stat(unsigned active_count,double latency) {
-		if(m_config->gpgpu_clock_gated_lanes==false){
-		  m_stats->m_num_fp_acesses[m_sid]=m_stats->m_num_fp_acesses[m_sid]+active_count*latency
-			 + inactive_lanes_accesses_nonsfu(active_count, latency);
-		}else {
-        m_stats->m_num_fp_acesses[m_sid]=m_stats->m_num_fp_acesses[m_sid]+active_count*latency;
-		} 
-	 }
-	 void incfpmul_stat(unsigned active_count,double latency) {
-		 		// printf("FP MUL stat increament\n");
-      if(m_config->gpgpu_clock_gated_lanes==false){
-		  m_stats->m_num_fpmul_acesses[m_sid]=m_stats->m_num_fpmul_acesses[m_sid]+active_count*latency
-		    + inactive_lanes_accesses_nonsfu(active_count, latency);
-		}else {
-        m_stats->m_num_fpmul_acesses[m_sid]=m_stats->m_num_fpmul_acesses[m_sid]+active_count*latency;
-		}
-	 }
-	 void incfpdiv_stat(unsigned active_count,double latency) {
-		if(m_config->gpgpu_clock_gated_lanes==false){
-		  m_stats->m_num_fpdiv_acesses[m_sid]=m_stats->m_num_fpdiv_acesses[m_sid]+active_count*latency
-			+ inactive_lanes_accesses_sfu(active_count, latency); 
-		}else {
-		  m_stats->m_num_fpdiv_acesses[m_sid]=m_stats->m_num_fpdiv_acesses[m_sid]+active_count*latency;
-		}
-	 }
-	 void inctrans_stat(unsigned active_count,double latency) {
-		if(m_config->gpgpu_clock_gated_lanes==false){
-		  m_stats->m_num_trans_acesses[m_sid]=m_stats->m_num_trans_acesses[m_sid]+active_count*latency
-			+ inactive_lanes_accesses_sfu(active_count, latency); 
-		}else{
-		  m_stats->m_num_trans_acesses[m_sid]=m_stats->m_num_trans_acesses[m_sid]+active_count*latency;
-		}
-	 }
+  }
+  void incimul24_stat(unsigned active_count, double latency) {
+    if (m_config->gpgpu_clock_gated_lanes == false) {
+      m_stats->m_num_imul24_acesses[m_sid] =
+          m_stats->m_num_imul24_acesses[m_sid] + active_count * latency +
+          inactive_lanes_accesses_nonsfu(active_count, latency);
+    } else {
+      m_stats->m_num_imul24_acesses[m_sid] =
+          m_stats->m_num_imul24_acesses[m_sid] + active_count * latency;
+    }
+  }
+  void incimul32_stat(unsigned active_count, double latency) {
+    if (m_config->gpgpu_clock_gated_lanes == false) {
+      m_stats->m_num_imul32_acesses[m_sid] =
+          m_stats->m_num_imul32_acesses[m_sid] + active_count * latency +
+          inactive_lanes_accesses_sfu(active_count, latency);
+    } else {
+      m_stats->m_num_imul32_acesses[m_sid] =
+          m_stats->m_num_imul32_acesses[m_sid] + active_count * latency;
+    }
+    // printf("Int_Mul -- Active_count: %d\n",active_count);
+  }
+  void incidiv_stat(unsigned active_count, double latency) {
+    if (m_config->gpgpu_clock_gated_lanes == false) {
+      m_stats->m_num_idiv_acesses[m_sid] =
+          m_stats->m_num_idiv_acesses[m_sid] + active_count * latency +
+          inactive_lanes_accesses_sfu(active_count, latency);
+    } else {
+      m_stats->m_num_idiv_acesses[m_sid] =
+          m_stats->m_num_idiv_acesses[m_sid] + active_count * latency;
+    }
+  }
+  void incfpalu_stat(unsigned active_count, double latency) {
+    if (m_config->gpgpu_clock_gated_lanes == false) {
+      m_stats->m_num_fp_acesses[m_sid] =
+          m_stats->m_num_fp_acesses[m_sid] + active_count * latency +
+          inactive_lanes_accesses_nonsfu(active_count, latency);
+    } else {
+      m_stats->m_num_fp_acesses[m_sid] =
+          m_stats->m_num_fp_acesses[m_sid] + active_count * latency;
+    }
+  }
+  void incfpmul_stat(unsigned active_count, double latency) {
+    // printf("FP MUL stat increament\n");
+    if (m_config->gpgpu_clock_gated_lanes == false) {
+      m_stats->m_num_fpmul_acesses[m_sid] =
+          m_stats->m_num_fpmul_acesses[m_sid] + active_count * latency +
+          inactive_lanes_accesses_nonsfu(active_count, latency);
+    } else {
+      m_stats->m_num_fpmul_acesses[m_sid] =
+          m_stats->m_num_fpmul_acesses[m_sid] + active_count * latency;
+    }
+  }
+  void incfpdiv_stat(unsigned active_count, double latency) {
+    if (m_config->gpgpu_clock_gated_lanes == false) {
+      m_stats->m_num_fpdiv_acesses[m_sid] =
+          m_stats->m_num_fpdiv_acesses[m_sid] + active_count * latency +
+          inactive_lanes_accesses_sfu(active_count, latency);
+    } else {
+      m_stats->m_num_fpdiv_acesses[m_sid] =
+          m_stats->m_num_fpdiv_acesses[m_sid] + active_count * latency;
+    }
+  }
+  void inctrans_stat(unsigned active_count, double latency) {
+    if (m_config->gpgpu_clock_gated_lanes == false) {
+      m_stats->m_num_trans_acesses[m_sid] =
+          m_stats->m_num_trans_acesses[m_sid] + active_count * latency +
+          inactive_lanes_accesses_sfu(active_count, latency);
+    } else {
+      m_stats->m_num_trans_acesses[m_sid] =
+          m_stats->m_num_trans_acesses[m_sid] + active_count * latency;
+    }
+  }
 
-	 void incsfu_stat(unsigned active_count,double latency) {m_stats->m_num_sfu_acesses[m_sid]=m_stats->m_num_sfu_acesses[m_sid]+active_count*latency;}
-	 void incsp_stat(unsigned active_count,double latency) {m_stats->m_num_sp_acesses[m_sid]=m_stats->m_num_sp_acesses[m_sid]+active_count*latency;}
-	 void incmem_stat(unsigned active_count,double latency) {
-		if(m_config->gpgpu_clock_gated_lanes==false){
-		  m_stats->m_num_mem_acesses[m_sid]=m_stats->m_num_mem_acesses[m_sid]+active_count*latency
-		    + inactive_lanes_accesses_nonsfu(active_count, latency);
-		}else {
-		  m_stats->m_num_mem_acesses[m_sid]=m_stats->m_num_mem_acesses[m_sid]+active_count*latency;
-		}
-	 }
-	 void incexecstat(warp_inst_t *&inst);
+  void incsfu_stat(unsigned active_count, double latency) {
+    m_stats->m_num_sfu_acesses[m_sid] =
+        m_stats->m_num_sfu_acesses[m_sid] + active_count * latency;
+  }
+  void incsp_stat(unsigned active_count, double latency) {
+    m_stats->m_num_sp_acesses[m_sid] =
+        m_stats->m_num_sp_acesses[m_sid] + active_count * latency;
+  }
+  void incmem_stat(unsigned active_count, double latency) {
+    if (m_config->gpgpu_clock_gated_lanes == false) {
+      m_stats->m_num_mem_acesses[m_sid] =
+          m_stats->m_num_mem_acesses[m_sid] + active_count * latency +
+          inactive_lanes_accesses_nonsfu(active_count, latency);
+    } else {
+      m_stats->m_num_mem_acesses[m_sid] =
+          m_stats->m_num_mem_acesses[m_sid] + active_count * latency;
+    }
+  }
+  void incexecstat(warp_inst_t *&inst);
 
-	 void incregfile_reads(unsigned active_count) {m_stats->m_read_regfile_acesses[m_sid]=m_stats->m_read_regfile_acesses[m_sid]+active_count;}
-	 void incregfile_writes(unsigned active_count){m_stats->m_write_regfile_acesses[m_sid]=m_stats->m_write_regfile_acesses[m_sid]+active_count;}
-	 void incnon_rf_operands(unsigned active_count){m_stats->m_non_rf_operands[m_sid]=m_stats->m_non_rf_operands[m_sid]+active_count;}
+  void incregfile_reads(unsigned active_count) {
+    m_stats->m_read_regfile_acesses[m_sid] =
+        m_stats->m_read_regfile_acesses[m_sid] + active_count;
+  }
+  void incregfile_writes(unsigned active_count) {
+    m_stats->m_write_regfile_acesses[m_sid] =
+        m_stats->m_write_regfile_acesses[m_sid] + active_count;
+  }
+  void incnon_rf_operands(unsigned active_count) {
+    m_stats->m_non_rf_operands[m_sid] =
+        m_stats->m_non_rf_operands[m_sid] + active_count;
+  }
 
-	 void incspactivelanes_stat(unsigned active_count) {m_stats->m_active_sp_lanes[m_sid]=m_stats->m_active_sp_lanes[m_sid]+active_count;}
-	 void incsfuactivelanes_stat(unsigned active_count) {m_stats->m_active_sfu_lanes[m_sid]=m_stats->m_active_sfu_lanes[m_sid]+active_count;}
-	 void incfuactivelanes_stat(unsigned active_count) {m_stats->m_active_fu_lanes[m_sid]=m_stats->m_active_fu_lanes[m_sid]+active_count;}
-	 void incfumemactivelanes_stat(unsigned active_count) {m_stats->m_active_fu_mem_lanes[m_sid]=m_stats->m_active_fu_mem_lanes[m_sid]+active_count;}
+  void incspactivelanes_stat(unsigned active_count) {
+    m_stats->m_active_sp_lanes[m_sid] =
+        m_stats->m_active_sp_lanes[m_sid] + active_count;
+  }
+  void incsfuactivelanes_stat(unsigned active_count) {
+    m_stats->m_active_sfu_lanes[m_sid] =
+        m_stats->m_active_sfu_lanes[m_sid] + active_count;
+  }
+  void incfuactivelanes_stat(unsigned active_count) {
+    m_stats->m_active_fu_lanes[m_sid] =
+        m_stats->m_active_fu_lanes[m_sid] + active_count;
+  }
+  void incfumemactivelanes_stat(unsigned active_count) {
+    m_stats->m_active_fu_mem_lanes[m_sid] =
+        m_stats->m_active_fu_mem_lanes[m_sid] + active_count;
+  }
 
-	 void inc_simt_to_mem(unsigned n_flits){ m_stats->n_simt_to_mem[m_sid] += n_flits; }
-	 bool check_if_non_released_reduction_barrier(warp_inst_t &inst);
+  void inc_simt_to_mem(unsigned n_flits) {
+    m_stats->n_simt_to_mem[m_sid] += n_flits;
+  }
+  bool check_if_non_released_reduction_barrier(warp_inst_t &inst);
 
-	private:
-	 unsigned inactive_lanes_accesses_sfu(unsigned active_count,double latency){
-      return  ( ((32-active_count)>>1)*latency) + ( ((32-active_count)>>3)*latency) + ( ((32-active_count)>>3)*latency);
-	 }
-	 unsigned inactive_lanes_accesses_nonsfu(unsigned active_count,double latency){
-      return  ( ((32-active_count)>>1)*latency);
-	 }
+ private:
+  unsigned inactive_lanes_accesses_sfu(unsigned active_count, double latency) {
+    return (((32 - active_count) >> 1) * latency) +
+           (((32 - active_count) >> 3) * latency) +
+           (((32 - active_count) >> 3) * latency);
+  }
+  unsigned inactive_lanes_accesses_nonsfu(unsigned active_count,
+                                          double latency) {
+    return (((32 - active_count) >> 1) * latency);
+  }
 
-    int test_res_bus(int latency);
-    void init_warps(unsigned cta_id, unsigned start_thread, unsigned end_thread,unsigned ctaid, int cta_size, unsigned kernel_id);
-    virtual void checkExecutionStatusAndUpdate(warp_inst_t &inst, unsigned t, unsigned tid);
-    address_type next_pc( int tid ) const;
-    void fetch();
-    void register_cta_thread_exit(unsigned cta_num, kernel_info_t * kernel );
+  int test_res_bus(int latency);
+  void init_warps(unsigned cta_id, unsigned start_thread, unsigned end_thread,
+                  unsigned ctaid, int cta_size, unsigned kernel_id);
+  virtual void checkExecutionStatusAndUpdate(warp_inst_t &inst, unsigned t,
+                                             unsigned tid);
+  address_type next_pc(int tid) const;
+  void fetch();
+  void register_cta_thread_exit(unsigned cta_num, kernel_info_t *kernel);
 
-    void decode();
-    
-    void issue();
-    friend class scheduler_unit; //this is needed to use private issue warp.
-    friend class TwoLevelScheduler;
-    friend class LooseRoundRobbinScheduler;
-    void issue_warp( register_set& warp, const warp_inst_t *pI, const active_mask_t &active_mask, unsigned warp_id, unsigned sch_id );
-    void func_exec_inst( warp_inst_t &inst );
+  void decode();
 
-     // Returns numbers of addresses in translated_addrs
-    unsigned translate_local_memaddr( address_type localaddr, unsigned tid, unsigned num_shader, unsigned datasize, new_addr_type* translated_addrs );
+  void issue();
+  friend class scheduler_unit;  // this is needed to use private issue warp.
+  friend class TwoLevelScheduler;
+  friend class LooseRoundRobbinScheduler;
+  void issue_warp(register_set &warp, const warp_inst_t *pI,
+                  const active_mask_t &active_mask, unsigned warp_id,
+                  unsigned sch_id);
+  void func_exec_inst(warp_inst_t &inst);
 
-    void read_operands();
-    
-    void execute();
-    
-    void writeback();
-    
-    // used in display_pipeline():
-    void dump_warp_state( FILE *fout ) const;
-    void print_stage(unsigned int stage, FILE *fout) const;
-    unsigned long long m_last_inst_gpu_sim_cycle;
-    unsigned long long m_last_inst_gpu_tot_sim_cycle;
+  // Returns numbers of addresses in translated_addrs
+  unsigned translate_local_memaddr(address_type localaddr, unsigned tid,
+                                   unsigned num_shader, unsigned datasize,
+                                   new_addr_type *translated_addrs);
 
-    // general information
-    unsigned m_sid; // shader id
-    unsigned m_tpc; // texture processor cluster id (aka, node id when using interconnect concentration)
-    const shader_core_config *m_config;
-    const memory_config *m_memory_config;
-    class simt_core_cluster *m_cluster;
+  void read_operands();
 
-    // statistics 
-    shader_core_stats *m_stats;
+  void execute();
 
-    // CTA scheduling / hardware thread allocation
-    unsigned m_n_active_cta; // number of Cooperative Thread Arrays (blocks) currently running on this shader.
-    unsigned m_cta_status[MAX_CTA_PER_SHADER]; // CTAs status 
-    unsigned m_not_completed; // number of threads to be completed (==0 when all thread on this core completed) 
-    std::bitset<MAX_THREAD_PER_SM> m_active_threads;
-    
-    // thread contexts 
-    thread_ctx_t             *m_threadState;
-    
-    // interconnect interface
-    mem_fetch_interface *m_icnt;
-    shader_core_mem_fetch_allocator *m_mem_fetch_allocator;
-    
-    // fetch
-    read_only_cache *m_L1I; // instruction cache
-    int  m_last_warp_fetched;
+  void writeback();
 
-    // decode/dispatch
-    std::vector<shd_warp_t>   m_warp;   // per warp information array
-    barrier_set_t             m_barriers;
-    ifetch_buffer_t           m_inst_fetch_buffer;
-    std::vector<register_set> m_pipeline_reg;
-    Scoreboard               *m_scoreboard;
-    opndcoll_rfu_t            m_operand_collector;
-    int m_active_warps;
+  // used in display_pipeline():
+  void dump_warp_state(FILE *fout) const;
+  void print_stage(unsigned int stage, FILE *fout) const;
+  unsigned long long m_last_inst_gpu_sim_cycle;
+  unsigned long long m_last_inst_gpu_tot_sim_cycle;
 
-    //schedule
-    std::vector<scheduler_unit*>  schedulers;
+  // general information
+  unsigned m_sid;  // shader id
+  unsigned m_tpc;  // texture processor cluster id (aka, node id when using
+                   // interconnect concentration)
+  const shader_core_config *m_config;
+  const memory_config *m_memory_config;
+  class simt_core_cluster *m_cluster;
 
-    //issue
-    unsigned int Issue_Prio;
+  // statistics
+  shader_core_stats *m_stats;
 
-    // execute
-    unsigned m_num_function_units;
-    std::vector<pipeline_stage_name_t> m_dispatch_port;
-    std::vector<pipeline_stage_name_t> m_issue_port;
-    std::vector<simd_function_unit*> m_fu; // stallable pipelines should be last in this array
-    ldst_unit *m_ldst_unit;
-    static const unsigned MAX_ALU_LATENCY = 512;
-    unsigned num_result_bus;
-    std::vector< std::bitset<MAX_ALU_LATENCY>* > m_result_bus;
+  // CTA scheduling / hardware thread allocation
+  unsigned m_n_active_cta;  // number of Cooperative Thread Arrays (blocks)
+                            // currently running on this shader.
+  unsigned m_cta_status[MAX_CTA_PER_SHADER];  // CTAs status
+  unsigned m_not_completed;  // number of threads to be completed (==0 when all
+                             // thread on this core completed)
+  std::bitset<MAX_THREAD_PER_SM> m_active_threads;
 
-    // used for local address mapping with single kernel launch
-    unsigned kernel_max_cta_per_shader;
-    unsigned kernel_padded_threads_per_cta;
-    // Used for handing out dynamic warp_ids to new warps.
-    // the differnece between a warp_id and a dynamic_warp_id
-    // is that the dynamic_warp_id is a running number unique to every warp
-    // run on this shader, where the warp_id is the static warp slot.
-    unsigned m_dynamic_warp_id;
+  // thread contexts
+  thread_ctx_t *m_threadState;
 
-    //Jin: concurrent kernels on a sm
-public:
-    bool can_issue_1block(kernel_info_t & kernel);
-    bool occupy_shader_resource_1block(kernel_info_t & kernel, bool occupy);
-    void release_shader_resource_1block(unsigned hw_ctaid, kernel_info_t & kernel);
-    int find_available_hwtid(unsigned int cta_size, bool occupy);
-private:
-    unsigned int m_occupied_n_threads; 
-    unsigned int m_occupied_shmem; 
-    unsigned int m_occupied_regs;
-    unsigned int m_occupied_ctas;
-    std::bitset<MAX_THREAD_PER_SM> m_occupied_hwtid;
-    std::map<unsigned int, unsigned int> m_occupied_cta_to_hwtid; 
+  // interconnect interface
+  mem_fetch_interface *m_icnt;
+  shader_core_mem_fetch_allocator *m_mem_fetch_allocator;
 
+  // fetch
+  read_only_cache *m_L1I;  // instruction cache
+  int m_last_warp_fetched;
 
+  // decode/dispatch
+  std::vector<shd_warp_t> m_warp;  // per warp information array
+  barrier_set_t m_barriers;
+  ifetch_buffer_t m_inst_fetch_buffer;
+  std::vector<register_set> m_pipeline_reg;
+  Scoreboard *m_scoreboard;
+  opndcoll_rfu_t m_operand_collector;
+  int m_active_warps;
+
+  // schedule
+  std::vector<scheduler_unit *> schedulers;
+
+  // issue
+  unsigned int Issue_Prio;
+
+  // execute
+  unsigned m_num_function_units;
+  std::vector<pipeline_stage_name_t> m_dispatch_port;
+  std::vector<pipeline_stage_name_t> m_issue_port;
+  std::vector<simd_function_unit *>
+      m_fu;  // stallable pipelines should be last in this array
+  ldst_unit *m_ldst_unit;
+  static const unsigned MAX_ALU_LATENCY = 512;
+  unsigned num_result_bus;
+  std::vector<std::bitset<MAX_ALU_LATENCY> *> m_result_bus;
+
+  // used for local address mapping with single kernel launch
+  unsigned kernel_max_cta_per_shader;
+  unsigned kernel_padded_threads_per_cta;
+  // Used for handing out dynamic warp_ids to new warps.
+  // the differnece between a warp_id and a dynamic_warp_id
+  // is that the dynamic_warp_id is a running number unique to every warp
+  // run on this shader, where the warp_id is the static warp slot.
+  unsigned m_dynamic_warp_id;
+
+  // Jin: concurrent kernels on a sm
+ public:
+  bool can_issue_1block(kernel_info_t &kernel);
+  bool occupy_shader_resource_1block(kernel_info_t &kernel, bool occupy);
+  void release_shader_resource_1block(unsigned hw_ctaid, kernel_info_t &kernel);
+  int find_available_hwtid(unsigned int cta_size, bool occupy);
+
+ private:
+  unsigned int m_occupied_n_threads;
+  unsigned int m_occupied_shmem;
+  unsigned int m_occupied_regs;
+  unsigned int m_occupied_ctas;
+  std::bitset<MAX_THREAD_PER_SM> m_occupied_hwtid;
+  std::map<unsigned int, unsigned int> m_occupied_cta_to_hwtid;
 };
 
 class simt_core_cluster {
-public:
-    simt_core_cluster( class gpgpu_sim *gpu, 
-                       unsigned cluster_id, 
-                       const shader_core_config *config, 
-                       const memory_config *mem_config,
-                       shader_core_stats *stats,
-                       memory_stats_t *mstats );
+ public:
+  simt_core_cluster(class gpgpu_sim *gpu, unsigned cluster_id,
+                    const shader_core_config *config,
+                    const memory_config *mem_config, shader_core_stats *stats,
+                    memory_stats_t *mstats);
 
-    void core_cycle();
-    void icnt_cycle();
+  void core_cycle();
+  void icnt_cycle();
 
-    void reinit();
-    unsigned issue_block2core();
-    void cache_flush();
-    void cache_invalidate();
-    bool icnt_injection_buffer_full(unsigned size, bool write);
-    void icnt_inject_request_packet(class mem_fetch *mf);
+  void reinit();
+  unsigned issue_block2core();
+  void cache_flush();
+  void cache_invalidate();
+  bool icnt_injection_buffer_full(unsigned size, bool write);
+  void icnt_inject_request_packet(class mem_fetch *mf);
 
+  // for perfect memory interface
+  bool response_queue_full() {
+    return (m_response_fifo.size() >= m_config->n_simt_ejection_buffer_size);
+  }
+  void push_response_fifo(class mem_fetch *mf) {
+    m_response_fifo.push_back(mf);
+  }
 
-    // for perfect memory interface
-    bool response_queue_full() {
-        return ( m_response_fifo.size() >= m_config->n_simt_ejection_buffer_size );
-    }
-    void push_response_fifo(class mem_fetch *mf) {
-        m_response_fifo.push_back(mf);
-    }
+  void get_pdom_stack_top_info(unsigned sid, unsigned tid, unsigned *pc,
+                               unsigned *rpc) const;
+  unsigned max_cta(const kernel_info_t &kernel);
+  unsigned get_not_completed() const;
+  void print_not_completed(FILE *fp) const;
+  unsigned get_n_active_cta() const;
+  unsigned get_n_active_sms() const;
+  gpgpu_sim *get_gpu() { return m_gpu; }
 
-    void get_pdom_stack_top_info( unsigned sid, unsigned tid, unsigned *pc, unsigned *rpc ) const;
-    unsigned max_cta( const kernel_info_t &kernel );
-    unsigned get_not_completed() const;
-    void print_not_completed( FILE *fp ) const;
-    unsigned get_n_active_cta() const;
-    unsigned get_n_active_sms() const;
-    gpgpu_sim *get_gpu() { return m_gpu; }
+  void display_pipeline(unsigned sid, FILE *fout, int print_mem, int mask);
+  void print_cache_stats(FILE *fp, unsigned &dl1_accesses,
+                         unsigned &dl1_misses) const;
 
-    void display_pipeline( unsigned sid, FILE *fout, int print_mem, int mask );
-    void print_cache_stats( FILE *fp, unsigned& dl1_accesses, unsigned& dl1_misses ) const;
+  void get_cache_stats(cache_stats &cs) const;
+  void get_L1I_sub_stats(struct cache_sub_stats &css) const;
+  void get_L1D_sub_stats(struct cache_sub_stats &css) const;
+  void get_L1C_sub_stats(struct cache_sub_stats &css) const;
+  void get_L1T_sub_stats(struct cache_sub_stats &css) const;
 
-    void get_cache_stats(cache_stats &cs) const;
-    void get_L1I_sub_stats(struct cache_sub_stats &css) const;
-    void get_L1D_sub_stats(struct cache_sub_stats &css) const;
-    void get_L1C_sub_stats(struct cache_sub_stats &css) const;
-    void get_L1T_sub_stats(struct cache_sub_stats &css) const;
+  void get_icnt_stats(long &n_simt_to_mem, long &n_mem_to_simt) const;
+  float get_current_occupancy(unsigned long long &active,
+                              unsigned long long &total) const;
 
-    void get_icnt_stats(long &n_simt_to_mem, long &n_mem_to_simt) const;
-    float get_current_occupancy( unsigned long long& active, unsigned long long & total ) const;
+ private:
+  unsigned m_cluster_id;
+  gpgpu_sim *m_gpu;
+  const shader_core_config *m_config;
+  shader_core_stats *m_stats;
+  memory_stats_t *m_memory_stats;
+  shader_core_ctx **m_core;
 
-private:
-    unsigned m_cluster_id;
-    gpgpu_sim *m_gpu;
-    const shader_core_config *m_config;
-    shader_core_stats *m_stats;
-    memory_stats_t *m_memory_stats;
-    shader_core_ctx **m_core;
-
-    unsigned m_cta_issue_next_core;
-    std::list<unsigned> m_core_sim_order;
-    std::list<mem_fetch*> m_response_fifo;
+  unsigned m_cta_issue_next_core;
+  std::list<unsigned> m_core_sim_order;
+  std::list<mem_fetch *> m_response_fifo;
 };
 
 class shader_memory_interface : public mem_fetch_interface {
-public:
-    shader_memory_interface( shader_core_ctx *core, simt_core_cluster *cluster ) { m_core=core; m_cluster=cluster; }
-    virtual bool full( unsigned size, bool write ) const 
-    {
-        return m_cluster->icnt_injection_buffer_full(size,write);
-    }
-    virtual void push(mem_fetch *mf) 
-    {
-    	m_core->inc_simt_to_mem(mf->get_num_flits(true));
-        m_cluster->icnt_inject_request_packet(mf);        
-    }
-private:
-    shader_core_ctx *m_core;
-    simt_core_cluster *m_cluster;
+ public:
+  shader_memory_interface(shader_core_ctx *core, simt_core_cluster *cluster) {
+    m_core = core;
+    m_cluster = cluster;
+  }
+  virtual bool full(unsigned size, bool write) const {
+    return m_cluster->icnt_injection_buffer_full(size, write);
+  }
+  virtual void push(mem_fetch *mf) {
+    m_core->inc_simt_to_mem(mf->get_num_flits(true));
+    m_cluster->icnt_inject_request_packet(mf);
+  }
+
+ private:
+  shader_core_ctx *m_core;
+  simt_core_cluster *m_cluster;
 };
 
 class perfect_memory_interface : public mem_fetch_interface {
-public:
-    perfect_memory_interface( shader_core_ctx *core, simt_core_cluster *cluster ) { m_core=core; m_cluster=cluster; }
-    virtual bool full( unsigned size, bool write) const
-    {
-        return m_cluster->response_queue_full();
-    }
-    virtual void push(mem_fetch *mf)
-    {
-        if ( mf && mf->isatomic() )
-            mf->do_atomic(); // execute atomic inside the "memory subsystem"
-        m_core->inc_simt_to_mem(mf->get_num_flits(true));
-        m_cluster->push_response_fifo(mf);        
-    }
-private:
-    shader_core_ctx *m_core;
-    simt_core_cluster *m_cluster;
-};
+ public:
+  perfect_memory_interface(shader_core_ctx *core, simt_core_cluster *cluster) {
+    m_core = core;
+    m_cluster = cluster;
+  }
+  virtual bool full(unsigned size, bool write) const {
+    return m_cluster->response_queue_full();
+  }
+  virtual void push(mem_fetch *mf) {
+    if (mf && mf->isatomic())
+      mf->do_atomic();  // execute atomic inside the "memory subsystem"
+    m_core->inc_simt_to_mem(mf->get_num_flits(true));
+    m_cluster->push_response_fifo(mf);
+  }
 
+ private:
+  shader_core_ctx *m_core;
+  simt_core_cluster *m_cluster;
+};
 
 inline int scheduler_unit::get_sid() const { return m_shader->get_sid(); }
 

--- a/src/gpgpu-sim/shader.h
+++ b/src/gpgpu-sim/shader.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2011, Tor M. Aamodt, Wilson W.L. Fung, Andrew Turner,
-// Ali Bakhoda
+// Ali Bakhoda 
 // The University of British Columbia
 // All rights reserved.
 //
@@ -8,16 +8,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -31,50 +29,50 @@
 #ifndef SHADER_H
 #define SHADER_H
 
-#include <assert.h>
-#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <algorithm>
-#include <bitset>
-#include <deque>
-#include <list>
+#include <math.h>
+#include <assert.h>
 #include <map>
 #include <set>
-#include <utility>
 #include <vector>
+#include <list>
+#include <bitset>
+#include <utility>
+#include <algorithm>
+#include <deque>
 
 //#include "../cuda-sim/ptx.tab.h"
 
-#include "../abstract_hardware_model.h"
 #include "delayqueue.h"
-#include "dram.h"
-#include "gpu-cache.h"
-#include "mem_fetch.h"
-#include "scoreboard.h"
 #include "stack.h"
+#include "dram.h"
+#include "../abstract_hardware_model.h"
+#include "scoreboard.h"
+#include "mem_fetch.h"
 #include "stats.h"
+#include "gpu-cache.h"
 #include "traffic_breakdown.h"
 
-#define NO_OP_FLAG 0xFF
+
+#define NO_OP_FLAG            0xFF
 
 /* READ_PACKET_SIZE:
-   bytes: 6 address (flit can specify chanel so this gives up to ~2GB/channel,
-   so good for now),
-          2 bytes   [shaderid + mshrid](14 bits) + req_size(0-2 bits if req_size
-   variable) - so up to 2^14 = 16384 mshr total
+   bytes: 6 address (flit can specify chanel so this gives up to ~2GB/channel, so good for now),
+          2 bytes   [shaderid + mshrid](14 bits) + req_size(0-2 bits if req_size variable) - so up to 2^14 = 16384 mshr total 
  */
 
 #define READ_PACKET_SIZE 8
 
-// WRITE_PACKET_SIZE: bytes: 6 address, 2 miscelaneous.
+//WRITE_PACKET_SIZE: bytes: 6 address, 2 miscelaneous. 
 #define WRITE_PACKET_SIZE 8
 
 #define WRITE_MASK_SIZE 8
 
 class gpgpu_context;
 
-enum exec_unit_type_t {
+enum exec_unit_type_t
+{
   NONE = 0,
   SP = 1,
   SFU = 2,
@@ -85,1134 +83,1127 @@ enum exec_unit_type_t {
 };
 
 class thread_ctx_t {
- public:
-  unsigned m_cta_id;  // hardware CTA this thread belongs
+public:
+   unsigned m_cta_id; // hardware CTA this thread belongs
 
-  // per thread stats (ac stands for accumulative).
-  unsigned n_insn;
-  unsigned n_insn_ac;
-  unsigned n_l1_mis_ac;
-  unsigned n_l1_mrghit_ac;
-  unsigned n_l1_access_ac;
+   // per thread stats (ac stands for accumulative).
+   unsigned n_insn;
+   unsigned n_insn_ac;
+   unsigned n_l1_mis_ac;
+   unsigned n_l1_mrghit_ac;
+   unsigned n_l1_access_ac; 
 
-  bool m_active;
+   bool m_active; 
 };
 
 class shd_warp_t {
- public:
-  shd_warp_t(class shader_core_ctx *shader, unsigned warp_size)
-      : m_shader(shader), m_warp_size(warp_size) {
-    m_stores_outstanding = 0;
-    m_inst_in_pipeline = 0;
-    reset();
-  }
-  void reset() {
-    assert(m_stores_outstanding == 0);
-    assert(m_inst_in_pipeline == 0);
-    m_imiss_pending = false;
-    m_warp_id = (unsigned)-1;
-    m_dynamic_warp_id = (unsigned)-1;
-    n_completed = m_warp_size;
-    m_n_atomic = 0;
-    m_membar = false;
-    m_done_exit = true;
-    m_last_fetch = 0;
-    m_next = 0;
-
-    // Jin: cdp support
-    m_cdp_latency = 0;
-    m_cdp_dummy = false;
-  }
-  void init(address_type start_pc, unsigned cta_id, unsigned wid,
-            const std::bitset<MAX_WARP_SIZE> &active,
-            unsigned dynamic_warp_id) {
-    m_cta_id = cta_id;
-    m_warp_id = wid;
-    m_dynamic_warp_id = dynamic_warp_id;
-    m_next_pc = start_pc;
-    assert(n_completed >= active.count());
-    assert(n_completed <= m_warp_size);
-    n_completed -= active.count();  // active threads are not yet completed
-    m_active_threads = active;
-    m_done_exit = false;
-
-    // Jin: cdp support
-    m_cdp_latency = 0;
-    m_cdp_dummy = false;
-  }
-
-  bool functional_done() const;
-  bool waiting();  // not const due to membar
-  bool hardware_done() const;
-
-  bool done_exit() const { return m_done_exit; }
-  void set_done_exit() { m_done_exit = true; }
-
-  void print(FILE *fout) const;
-  void print_ibuffer(FILE *fout) const;
-
-  unsigned get_n_completed() const { return n_completed; }
-  void set_completed(unsigned lane) {
-    assert(m_active_threads.test(lane));
-    m_active_threads.reset(lane);
-    n_completed++;
-  }
-
-  void set_last_fetch(unsigned long long sim_cycle) {
-    m_last_fetch = sim_cycle;
-  }
-
-  unsigned get_n_atomic() const { return m_n_atomic; }
-  void inc_n_atomic() { m_n_atomic++; }
-  void dec_n_atomic(unsigned n) { m_n_atomic -= n; }
-
-  void set_membar() { m_membar = true; }
-  void clear_membar() { m_membar = false; }
-  bool get_membar() const { return m_membar; }
-  address_type get_pc() const { return m_next_pc; }
-  void set_next_pc(address_type pc) { m_next_pc = pc; }
-
-  void store_info_of_last_inst_at_barrier(const warp_inst_t *pI) {
-    m_inst_at_barrier = *pI;
-  }
-  warp_inst_t *restore_info_of_last_inst_at_barrier() {
-    return &m_inst_at_barrier;
-  }
-
-  void ibuffer_fill(unsigned slot, const warp_inst_t *pI) {
-    assert(slot < IBUFFER_SIZE);
-    m_ibuffer[slot].m_inst = pI;
-    m_ibuffer[slot].m_valid = true;
-    m_next = 0;
-  }
-  bool ibuffer_empty() const {
-    for (unsigned i = 0; i < IBUFFER_SIZE; i++)
-      if (m_ibuffer[i].m_valid) return false;
-    return true;
-  }
-  void ibuffer_flush() {
-    for (unsigned i = 0; i < IBUFFER_SIZE; i++) {
-      if (m_ibuffer[i].m_valid) dec_inst_in_pipeline();
-      m_ibuffer[i].m_inst = NULL;
-      m_ibuffer[i].m_valid = false;
+public:
+    shd_warp_t( class shader_core_ctx *shader, unsigned warp_size) 
+        : m_shader(shader), m_warp_size(warp_size)
+    {
+        m_stores_outstanding=0;
+        m_inst_in_pipeline=0;
+        reset(); 
     }
-  }
-  const warp_inst_t *ibuffer_next_inst() { return m_ibuffer[m_next].m_inst; }
-  bool ibuffer_next_valid() { return m_ibuffer[m_next].m_valid; }
-  void ibuffer_free() {
-    m_ibuffer[m_next].m_inst = NULL;
-    m_ibuffer[m_next].m_valid = false;
-  }
-  void ibuffer_step() { m_next = (m_next + 1) % IBUFFER_SIZE; }
+    void reset()
+    {
+        assert( m_stores_outstanding==0);
+        assert( m_inst_in_pipeline==0);
+        m_imiss_pending=false;
+        m_warp_id=(unsigned)-1;
+        m_dynamic_warp_id = (unsigned)-1;
+        n_completed = m_warp_size; 
+        m_n_atomic=0;
+        m_membar=false;
+        m_done_exit=true;
+        m_last_fetch=0;
+        m_next=0;
 
-  bool imiss_pending() const { return m_imiss_pending; }
-  void set_imiss_pending() { m_imiss_pending = true; }
-  void clear_imiss_pending() { m_imiss_pending = false; }
-
-  bool stores_done() const { return m_stores_outstanding == 0; }
-  void inc_store_req() { m_stores_outstanding++; }
-  void dec_store_req() {
-    assert(m_stores_outstanding > 0);
-    m_stores_outstanding--;
-  }
-
-  unsigned num_inst_in_buffer() const {
-    unsigned count = 0;
-    for (unsigned i = 0; i < IBUFFER_SIZE; i++) {
-      if (m_ibuffer[i].m_valid) count++;
+        //Jin: cdp support
+        m_cdp_latency = 0;
+        m_cdp_dummy = false;
     }
-    return count;
-  }
-  unsigned num_inst_in_pipeline() const { return m_inst_in_pipeline; }
-  unsigned num_issued_inst_in_pipeline() const {
-    return (num_inst_in_pipeline() - num_inst_in_buffer());
-  }
-  bool inst_in_pipeline() const { return m_inst_in_pipeline > 0; }
-  void inc_inst_in_pipeline() { m_inst_in_pipeline++; }
-  void dec_inst_in_pipeline() {
-    assert(m_inst_in_pipeline > 0);
-    m_inst_in_pipeline--;
-  }
+    void init( address_type start_pc,
+               unsigned cta_id,
+               unsigned wid,
+               const std::bitset<MAX_WARP_SIZE> &active,
+               unsigned dynamic_warp_id )
+    {
+        m_cta_id=cta_id;
+        m_warp_id=wid;
+        m_dynamic_warp_id=dynamic_warp_id;
+        m_next_pc=start_pc;
+        assert( n_completed >= active.count() );
+        assert( n_completed <= m_warp_size);
+        n_completed   -= active.count(); // active threads are not yet completed
+        m_active_threads = active;
+        m_done_exit=false;
 
-  unsigned get_cta_id() const { return m_cta_id; }
-
-  unsigned get_dynamic_warp_id() const { return m_dynamic_warp_id; }
-  unsigned get_warp_id() const { return m_warp_id; }
-
- private:
-  static const unsigned IBUFFER_SIZE = 2;
-  class shader_core_ctx *m_shader;
-  unsigned m_cta_id;
-  unsigned m_warp_id;
-  unsigned m_warp_size;
-  unsigned m_dynamic_warp_id;
-
-  address_type m_next_pc;
-  unsigned n_completed;  // number of threads in warp completed
-  std::bitset<MAX_WARP_SIZE> m_active_threads;
-
-  bool m_imiss_pending;
-
-  struct ibuffer_entry {
-    ibuffer_entry() {
-      m_valid = false;
-      m_inst = NULL;
+        //Jin: cdp support
+        m_cdp_latency = 0;
+        m_cdp_dummy = false;
     }
-    const warp_inst_t *m_inst;
-    bool m_valid;
-  };
 
-  warp_inst_t m_inst_at_barrier;
-  ibuffer_entry m_ibuffer[IBUFFER_SIZE];
-  unsigned m_next;
+    bool functional_done() const;
+    bool waiting(); // not const due to membar
+    bool hardware_done() const;
 
-  unsigned m_n_atomic;  // number of outstanding atomic operations
-  bool m_membar;        // if true, warp is waiting at memory barrier
+    bool done_exit() const { return m_done_exit; }
+    void set_done_exit() { m_done_exit=true; }
 
-  bool m_done_exit;  // true once thread exit has been registered for threads in
-                     // this warp
+    void print( FILE *fout ) const;
+    void print_ibuffer( FILE *fout ) const;
 
-  unsigned long long m_last_fetch;
+    unsigned get_n_completed() const { return n_completed; }
+    void set_completed( unsigned lane ) 
+    { 
+        assert( m_active_threads.test(lane) );
+        m_active_threads.reset(lane);
+        n_completed++; 
+    }
 
-  unsigned m_stores_outstanding;  // number of store requests sent but not yet
-                                  // acknowledged
-  unsigned m_inst_in_pipeline;
+    void set_last_fetch( unsigned long long sim_cycle ) { m_last_fetch=sim_cycle; }
 
-  // Jin: cdp support
- public:
-  unsigned int m_cdp_latency;
-  bool m_cdp_dummy;
+    unsigned get_n_atomic() const { return m_n_atomic; }
+    void inc_n_atomic() { m_n_atomic++; }
+    void dec_n_atomic(unsigned n) { m_n_atomic-=n; }
+
+    void set_membar() { m_membar=true; }
+    void clear_membar() { m_membar=false; }
+    bool get_membar() const { return m_membar; }
+    address_type get_pc() const { return m_next_pc; }
+    void set_next_pc( address_type pc ) { m_next_pc = pc; }
+
+    void store_info_of_last_inst_at_barrier(const warp_inst_t *pI){ m_inst_at_barrier = *pI;}
+    warp_inst_t * restore_info_of_last_inst_at_barrier(){ return &m_inst_at_barrier;}
+
+    void ibuffer_fill( unsigned slot, const warp_inst_t *pI )
+    {
+       assert(slot < IBUFFER_SIZE );
+       m_ibuffer[slot].m_inst=pI;
+       m_ibuffer[slot].m_valid=true;
+       m_next=0; 
+    }
+    bool ibuffer_empty() const
+    {
+        for( unsigned i=0; i < IBUFFER_SIZE; i++) 
+            if(m_ibuffer[i].m_valid) 
+                return false;
+        return true;
+    }
+    void ibuffer_flush()
+    {
+        for(unsigned i=0;i<IBUFFER_SIZE;i++) {
+            if( m_ibuffer[i].m_valid )
+                dec_inst_in_pipeline();
+            m_ibuffer[i].m_inst=NULL; 
+            m_ibuffer[i].m_valid=false; 
+        }
+    }
+    const warp_inst_t *ibuffer_next_inst() { return m_ibuffer[m_next].m_inst; }
+    bool ibuffer_next_valid() { return m_ibuffer[m_next].m_valid; }
+    void ibuffer_free()
+    {
+        m_ibuffer[m_next].m_inst = NULL;
+        m_ibuffer[m_next].m_valid = false;
+    }
+    void ibuffer_step() { m_next = (m_next+1)%IBUFFER_SIZE; }
+
+    bool imiss_pending() const { return m_imiss_pending; }
+    void set_imiss_pending() { m_imiss_pending=true; }
+    void clear_imiss_pending() { m_imiss_pending=false; }
+
+    bool stores_done() const { return m_stores_outstanding == 0; }
+    void inc_store_req() { m_stores_outstanding++; }
+    void dec_store_req() 
+    {
+        assert( m_stores_outstanding > 0 );
+        m_stores_outstanding--;
+    }
+
+    unsigned num_inst_in_buffer() const
+    {
+    	unsigned count=0;
+        for(unsigned i=0;i<IBUFFER_SIZE;i++) {
+            if( m_ibuffer[i].m_valid )
+            	count++;
+        }
+    	return count;
+    }
+    unsigned num_inst_in_pipeline() const { return m_inst_in_pipeline;}
+    unsigned num_issued_inst_in_pipeline() const {return (num_inst_in_pipeline()-num_inst_in_buffer());}
+    bool inst_in_pipeline() const { return m_inst_in_pipeline > 0; }
+    void inc_inst_in_pipeline() { m_inst_in_pipeline++; }
+    void dec_inst_in_pipeline() 
+    {
+        assert( m_inst_in_pipeline > 0 );
+        m_inst_in_pipeline--;
+    }
+
+    unsigned get_cta_id() const { return m_cta_id; }
+
+    unsigned get_dynamic_warp_id() const { return m_dynamic_warp_id; }
+    unsigned get_warp_id() const { return m_warp_id; }
+
+private:
+    static const unsigned IBUFFER_SIZE=2;
+    class shader_core_ctx *m_shader;
+    unsigned m_cta_id;
+    unsigned m_warp_id;
+    unsigned m_warp_size;
+    unsigned m_dynamic_warp_id;
+
+    address_type m_next_pc;
+    unsigned n_completed;          // number of threads in warp completed
+    std::bitset<MAX_WARP_SIZE> m_active_threads;
+
+    bool m_imiss_pending;
+    
+    struct ibuffer_entry {
+       ibuffer_entry() { m_valid = false; m_inst = NULL; }
+       const warp_inst_t *m_inst;
+       bool m_valid;
+    };
+
+    warp_inst_t m_inst_at_barrier;
+    ibuffer_entry m_ibuffer[IBUFFER_SIZE]; 
+    unsigned m_next;
+                                   
+    unsigned m_n_atomic;           // number of outstanding atomic operations 
+    bool     m_membar;             // if true, warp is waiting at memory barrier
+
+    bool m_done_exit; // true once thread exit has been registered for threads in this warp
+
+    unsigned long long m_last_fetch;
+
+    unsigned m_stores_outstanding; // number of store requests sent but not yet acknowledged
+    unsigned m_inst_in_pipeline;
+
+    //Jin: cdp support
+public:
+    unsigned int m_cdp_latency;
+    bool m_cdp_dummy;
 };
 
-inline unsigned hw_tid_from_wid(unsigned wid, unsigned warp_size, unsigned i) {
-  return wid * warp_size + i;
-};
-inline unsigned wid_from_hw_tid(unsigned tid, unsigned warp_size) {
-  return tid / warp_size;
-};
+
+
+inline unsigned hw_tid_from_wid(unsigned wid, unsigned warp_size, unsigned i){return wid * warp_size + i;};
+inline unsigned wid_from_hw_tid(unsigned tid, unsigned warp_size){return tid/warp_size;};
 
 const unsigned WARP_PER_CTA_MAX = 64;
 typedef std::bitset<WARP_PER_CTA_MAX> warp_set_t;
 
-int register_bank(int regnum, int wid, unsigned num_banks,
-                  unsigned bank_warp_shift, bool sub_core_model,
-                  unsigned banks_per_sched, unsigned sched_id);
+int register_bank(int regnum, int wid, unsigned num_banks, unsigned bank_warp_shift, bool sub_core_model, unsigned banks_per_sched, unsigned sched_id );
 
 class shader_core_ctx;
 class shader_core_config;
 class shader_core_stats;
 
-enum scheduler_prioritization_type {
-  SCHEDULER_PRIORITIZATION_LRR = 0,   // Loose Round Robin
-  SCHEDULER_PRIORITIZATION_SRR,       // Strict Round Robin
-  SCHEDULER_PRIORITIZATION_GTO,       // Greedy Then Oldest
-  SCHEDULER_PRIORITIZATION_GTLRR,     // Greedy Then Loose Round Robin
-  SCHEDULER_PRIORITIZATION_GTY,       // Greedy Then Youngest
-  SCHEDULER_PRIORITIZATION_OLDEST,    // Oldest First
-  SCHEDULER_PRIORITIZATION_YOUNGEST,  // Youngest First
+enum scheduler_prioritization_type
+{
+    SCHEDULER_PRIORITIZATION_LRR = 0, // Loose Round Robin
+    SCHEDULER_PRIORITIZATION_SRR, // Strict Round Robin
+    SCHEDULER_PRIORITIZATION_GTO, // Greedy Then Oldest
+    SCHEDULER_PRIORITIZATION_GTLRR, // Greedy Then Loose Round Robin
+    SCHEDULER_PRIORITIZATION_GTY, // Greedy Then Youngest
+    SCHEDULER_PRIORITIZATION_OLDEST, // Oldest First
+    SCHEDULER_PRIORITIZATION_YOUNGEST, // Youngest First
 };
 
 // Each of these corresponds to a string value in the gpgpsim.config file
 // For example - to specify the LRR scheudler the config must contain lrr
-enum concrete_scheduler {
-  CONCRETE_SCHEDULER_LRR = 0,
-  CONCRETE_SCHEDULER_GTO,
-  CONCRETE_SCHEDULER_TWO_LEVEL_ACTIVE,
-  CONCRETE_SCHEDULER_WARP_LIMITING,
-  CONCRETE_SCHEDULER_OLDEST_FIRST,
-  NUM_CONCRETE_SCHEDULERS
+enum concrete_scheduler
+{
+    CONCRETE_SCHEDULER_LRR = 0,
+    CONCRETE_SCHEDULER_GTO,
+    CONCRETE_SCHEDULER_TWO_LEVEL_ACTIVE,
+    CONCRETE_SCHEDULER_WARP_LIMITING,
+    CONCRETE_SCHEDULER_OLDEST_FIRST,
+    NUM_CONCRETE_SCHEDULERS
 };
 
-class scheduler_unit {  // this can be copied freely, so can be used in std
-                        // containers.
- public:
-  scheduler_unit(shader_core_stats *stats, shader_core_ctx *shader,
-                 Scoreboard *scoreboard, simt_stack **simt,
-                 std::vector<shd_warp_t> *warp, register_set *sp_out,
-                 register_set *dp_out, register_set *sfu_out,
-                 register_set *int_out, register_set *tensor_core_out,
-                 register_set *mem_out, int id)
-      : m_supervised_warps(),
-        m_stats(stats),
-        m_shader(shader),
-        m_scoreboard(scoreboard),
-        m_simt_stack(simt),
-        /*m_pipeline_reg(pipe_regs),*/ m_warp(warp),
-        m_sp_out(sp_out),
-        m_dp_out(dp_out),
-        m_sfu_out(sfu_out),
-        m_int_out(int_out),
-        m_tensor_core_out(tensor_core_out),
-        m_mem_out(mem_out),
-        m_id(id) {}
-  virtual ~scheduler_unit() {}
-  virtual void add_supervised_warp_id(int i) {
-    m_supervised_warps.push_back(&warp(i));
-  }
-  virtual void done_adding_supervised_warps() {
-    m_last_supervised_issued = m_supervised_warps.end();
-  }
+class scheduler_unit { //this can be copied freely, so can be used in std containers.
+public:
+    scheduler_unit(shader_core_stats* stats, shader_core_ctx* shader, 
+                   Scoreboard* scoreboard, simt_stack** simt, 
+                   std::vector<shd_warp_t>* warp, 
+                   register_set* sp_out,
+				   register_set* dp_out,
+                   register_set* sfu_out,
+				   register_set* int_out,
+                   register_set* tensor_core_out,
+                   register_set* mem_out,
+                   int id) 
+        : m_supervised_warps(), m_stats(stats), m_shader(shader),
+        m_scoreboard(scoreboard), m_simt_stack(simt), /*m_pipeline_reg(pipe_regs),*/ m_warp(warp),
+        m_sp_out(sp_out),m_dp_out(dp_out),m_sfu_out(sfu_out),m_int_out(int_out),m_tensor_core_out(tensor_core_out),m_mem_out(mem_out), m_id(id){}
+    virtual ~scheduler_unit(){}
+    virtual void add_supervised_warp_id(int i) {
+        m_supervised_warps.push_back(&warp(i));
+    }
+    virtual void done_adding_supervised_warps() {
+        m_last_supervised_issued = m_supervised_warps.end();
+    }
 
-  // The core scheduler cycle method is meant to be common between
-  // all the derived schedulers.  The scheduler's behaviour can be
-  // modified by changing the contents of the m_next_cycle_prioritized_warps
-  // list.
-  void cycle();
 
-  // These are some common ordering fucntions that the
-  // higher order schedulers can take advantage of
-  template <typename T>
-  void order_lrr(
-      typename std::vector<T> &result_list,
-      const typename std::vector<T> &input_list,
-      const typename std::vector<T>::const_iterator &last_issued_from_input,
-      unsigned num_warps_to_add);
+    // The core scheduler cycle method is meant to be common between
+    // all the derived schedulers.  The scheduler's behaviour can be
+    // modified by changing the contents of the m_next_cycle_prioritized_warps list.
+    void cycle();
 
-  enum OrderingType {
-    // The item that issued last is prioritized first then the sorted result
-    // of the priority_function
-    ORDERING_GREEDY_THEN_PRIORITY_FUNC = 0,
-    // No greedy scheduling based on last to issue. Only the priority function
-    // determines
-    // priority
-    ORDERED_PRIORITY_FUNC_ONLY,
-    NUM_ORDERING,
-  };
-  template <typename U>
-  void order_by_priority(
-      std::vector<U> &result_list, const typename std::vector<U> &input_list,
-      const typename std::vector<U>::const_iterator &last_issued_from_input,
-      unsigned num_warps_to_add, OrderingType age_ordering,
-      bool (*priority_func)(U lhs, U rhs));
-  static bool sort_warps_by_oldest_dynamic_id(shd_warp_t *lhs, shd_warp_t *rhs);
+    // These are some common ordering fucntions that the
+    // higher order schedulers can take advantage of
+    template < typename T >
+    void order_lrr( typename std::vector< T >& result_list,
+                    const typename std::vector< T >& input_list,
+                    const typename std::vector< T >::const_iterator& last_issued_from_input,
+                    unsigned num_warps_to_add );
+    
+    enum OrderingType 
+    {
+        // The item that issued last is prioritized first then the sorted result
+        // of the priority_function
+        ORDERING_GREEDY_THEN_PRIORITY_FUNC = 0,
+        // No greedy scheduling based on last to issue. Only the priority function determines
+        // priority
+        ORDERED_PRIORITY_FUNC_ONLY,
+        NUM_ORDERING,
+    };
+    template < typename U >
+    void order_by_priority( std::vector< U >& result_list,
+                            const typename std::vector< U >& input_list,
+                            const typename std::vector< U >::const_iterator& last_issued_from_input,
+                            unsigned num_warps_to_add,
+                            OrderingType age_ordering,
+                            bool (*priority_func)(U lhs, U rhs) );
+    static bool sort_warps_by_oldest_dynamic_id(shd_warp_t* lhs, shd_warp_t* rhs);
 
-  // Derived classes can override this function to populate
-  // m_supervised_warps with their scheduling policies
-  virtual void order_warps() = 0;
+    // Derived classes can override this function to populate
+    // m_supervised_warps with their scheduling policies
+    virtual void order_warps() = 0;
 
-  int get_schd_id() const { return m_id; }
+    int get_schd_id() const {return m_id;}
 
- protected:
-  virtual void do_on_warp_issued(
-      unsigned warp_id, unsigned num_issued,
-      const std::vector<shd_warp_t *>::const_iterator &prioritized_iter);
-  inline int get_sid() const;
+protected:
+    virtual void do_on_warp_issued( unsigned warp_id,
+                                    unsigned num_issued,
+                                    const std::vector< shd_warp_t* >::const_iterator& prioritized_iter );
+    inline int get_sid() const;
+protected:
+    shd_warp_t& warp(int i);
 
- protected:
-  shd_warp_t &warp(int i);
+    // This is the prioritized warp list that is looped over each cycle to determine
+    // which warp gets to issue.
+    std::vector< shd_warp_t* > m_next_cycle_prioritized_warps;
+    // The m_supervised_warps list is all the warps this scheduler is supposed to
+    // arbitrate between.  This is useful in systems where there is more than
+    // one warp scheduler. In a single scheduler system, this is simply all
+    // the warps assigned to this core.
+    std::vector< shd_warp_t* > m_supervised_warps;
+    // This is the iterator pointer to the last supervised warp you issued
+    std::vector< shd_warp_t* >::const_iterator m_last_supervised_issued;
+    shader_core_stats *m_stats;
+    shader_core_ctx* m_shader;
+    // these things should become accessors: but would need a bigger rearchitect of how shader_core_ctx interacts with its parts.
+    Scoreboard* m_scoreboard; 
+    simt_stack** m_simt_stack;
+    //warp_inst_t** m_pipeline_reg;
+    std::vector<shd_warp_t>* m_warp;
+    register_set* m_sp_out;
+    register_set* m_dp_out;
+    register_set* m_sfu_out;
+    register_set* m_int_out;
+    register_set* m_tensor_core_out;
+    register_set* m_mem_out;
 
-  // This is the prioritized warp list that is looped over each cycle to
-  // determine
-  // which warp gets to issue.
-  std::vector<shd_warp_t *> m_next_cycle_prioritized_warps;
-  // The m_supervised_warps list is all the warps this scheduler is supposed to
-  // arbitrate between.  This is useful in systems where there is more than
-  // one warp scheduler. In a single scheduler system, this is simply all
-  // the warps assigned to this core.
-  std::vector<shd_warp_t *> m_supervised_warps;
-  // This is the iterator pointer to the last supervised warp you issued
-  std::vector<shd_warp_t *>::const_iterator m_last_supervised_issued;
-  shader_core_stats *m_stats;
-  shader_core_ctx *m_shader;
-  // these things should become accessors: but would need a bigger rearchitect
-  // of how shader_core_ctx interacts with its parts.
-  Scoreboard *m_scoreboard;
-  simt_stack **m_simt_stack;
-  // warp_inst_t** m_pipeline_reg;
-  std::vector<shd_warp_t> *m_warp;
-  register_set *m_sp_out;
-  register_set *m_dp_out;
-  register_set *m_sfu_out;
-  register_set *m_int_out;
-  register_set *m_tensor_core_out;
-  register_set *m_mem_out;
-
-  int m_id;
+    int m_id;
 };
 
 class lrr_scheduler : public scheduler_unit {
- public:
-  lrr_scheduler(shader_core_stats *stats, shader_core_ctx *shader,
-                Scoreboard *scoreboard, simt_stack **simt,
-                std::vector<shd_warp_t> *warp, register_set *sp_out,
-                register_set *dp_out, register_set *sfu_out,
-                register_set *int_out, register_set *tensor_core_out,
-                register_set *mem_out, int id)
-      : scheduler_unit(stats, shader, scoreboard, simt, warp, sp_out, dp_out,
-                       sfu_out, int_out, tensor_core_out, mem_out, id) {}
-  virtual ~lrr_scheduler() {}
-  virtual void order_warps();
-  virtual void done_adding_supervised_warps() {
-    m_last_supervised_issued = m_supervised_warps.end();
-  }
+public:
+	lrr_scheduler ( shader_core_stats* stats, shader_core_ctx* shader,
+                    Scoreboard* scoreboard, simt_stack** simt,
+                    std::vector<shd_warp_t>* warp,
+                    register_set* sp_out,
+					register_set* dp_out,
+                    register_set* sfu_out,
+					register_set* int_out,
+                    register_set* tensor_core_out,
+                    register_set* mem_out,
+                    int id )
+	: scheduler_unit ( stats, shader, scoreboard, simt, warp, sp_out, dp_out, sfu_out, int_out, tensor_core_out, mem_out, id ){}
+	virtual ~lrr_scheduler () {}
+	virtual void order_warps ();
+    virtual void done_adding_supervised_warps() {
+        m_last_supervised_issued = m_supervised_warps.end();
+    }
 };
 
 class gto_scheduler : public scheduler_unit {
- public:
-  gto_scheduler(shader_core_stats *stats, shader_core_ctx *shader,
-                Scoreboard *scoreboard, simt_stack **simt,
-                std::vector<shd_warp_t> *warp, register_set *sp_out,
-                register_set *dp_out, register_set *sfu_out,
-                register_set *int_out, register_set *tensor_core_out,
-                register_set *mem_out, int id)
-      : scheduler_unit(stats, shader, scoreboard, simt, warp, sp_out, dp_out,
-                       sfu_out, int_out, tensor_core_out, mem_out, id) {}
-  virtual ~gto_scheduler() {}
-  virtual void order_warps();
-  virtual void done_adding_supervised_warps() {
-    m_last_supervised_issued = m_supervised_warps.begin();
-  }
+public:
+	gto_scheduler ( shader_core_stats* stats, shader_core_ctx* shader,
+                    Scoreboard* scoreboard, simt_stack** simt,
+                    std::vector<shd_warp_t>* warp,
+                    register_set* sp_out,
+					register_set* dp_out,
+                    register_set* sfu_out,
+					register_set* int_out,
+                    register_set* tensor_core_out,
+                    register_set* mem_out,
+                    int id )
+	: scheduler_unit ( stats, shader, scoreboard, simt, warp, sp_out, dp_out, sfu_out, int_out, tensor_core_out, mem_out, id ){}
+	virtual ~gto_scheduler () {}
+	virtual void order_warps ();
+    virtual void done_adding_supervised_warps() {
+        m_last_supervised_issued = m_supervised_warps.begin();
+    }
+
 };
 
 class oldest_scheduler : public scheduler_unit {
- public:
-  oldest_scheduler(shader_core_stats *stats, shader_core_ctx *shader,
-                   Scoreboard *scoreboard, simt_stack **simt,
-                   std::vector<shd_warp_t> *warp, register_set *sp_out,
-                   register_set *dp_out, register_set *sfu_out,
-                   register_set *int_out, register_set *tensor_core_out,
-                   register_set *mem_out, int id)
-      : scheduler_unit(stats, shader, scoreboard, simt, warp, sp_out, dp_out,
-                       sfu_out, int_out, tensor_core_out, mem_out, id) {}
-  virtual ~oldest_scheduler() {}
-  virtual void order_warps();
-  virtual void done_adding_supervised_warps() {
-    m_last_supervised_issued = m_supervised_warps.begin();
-  }
+public:
+	oldest_scheduler ( shader_core_stats* stats, shader_core_ctx* shader,
+                    Scoreboard* scoreboard, simt_stack** simt,
+                    std::vector<shd_warp_t>* warp,
+                    register_set* sp_out,
+					register_set* dp_out,
+                    register_set* sfu_out,
+					register_set* int_out,
+                    register_set* tensor_core_out,
+                    register_set* mem_out,
+                    int id )
+	: scheduler_unit ( stats, shader, scoreboard, simt, warp, sp_out, dp_out, sfu_out, int_out, tensor_core_out, mem_out, id ){}
+	virtual ~oldest_scheduler () {}
+	virtual void order_warps ();
+        virtual void done_adding_supervised_warps() {
+        m_last_supervised_issued = m_supervised_warps.begin();
+    }
+
 };
 
 class two_level_active_scheduler : public scheduler_unit {
- public:
-  two_level_active_scheduler(shader_core_stats *stats, shader_core_ctx *shader,
-                             Scoreboard *scoreboard, simt_stack **simt,
-                             std::vector<shd_warp_t> *warp,
-                             register_set *sp_out, register_set *dp_out,
-                             register_set *sfu_out, register_set *int_out,
-                             register_set *tensor_core_out,
-                             register_set *mem_out, int id, char *config_str)
-      : scheduler_unit(stats, shader, scoreboard, simt, warp, sp_out, dp_out,
-                       sfu_out, int_out, tensor_core_out, mem_out, id),
-        m_pending_warps() {
-    unsigned inner_level_readin;
-    unsigned outer_level_readin;
-    int ret =
-        sscanf(config_str, "two_level_active:%d:%d:%d", &m_max_active_warps,
-               &inner_level_readin, &outer_level_readin);
-    assert(3 == ret);
-    m_inner_level_prioritization =
-        (scheduler_prioritization_type)inner_level_readin;
-    m_outer_level_prioritization =
-        (scheduler_prioritization_type)outer_level_readin;
-  }
-  virtual ~two_level_active_scheduler() {}
-  virtual void order_warps();
-  void add_supervised_warp_id(int i) {
-    if (m_next_cycle_prioritized_warps.size() < m_max_active_warps) {
-      m_next_cycle_prioritized_warps.push_back(&warp(i));
-    } else {
-      m_pending_warps.push_back(&warp(i));
+public:
+	two_level_active_scheduler ( shader_core_stats* stats, shader_core_ctx* shader,
+                          Scoreboard* scoreboard, simt_stack** simt,
+                          std::vector<shd_warp_t>* warp,
+                          register_set* sp_out,
+						  register_set* dp_out,
+                          register_set* sfu_out,
+						  register_set* int_out,
+                          register_set* tensor_core_out,
+                          register_set* mem_out,
+                          int id,
+                          char* config_str )
+	: scheduler_unit ( stats, shader, scoreboard, simt, warp, sp_out, dp_out, sfu_out, int_out, tensor_core_out, mem_out, id ),
+	  m_pending_warps() 
+    {
+        unsigned inner_level_readin;
+        unsigned outer_level_readin; 
+        int ret = sscanf( config_str,
+                          "two_level_active:%d:%d:%d",
+                          &m_max_active_warps,
+                          &inner_level_readin,
+                          &outer_level_readin);
+        assert( 3 == ret );
+        m_inner_level_prioritization=(scheduler_prioritization_type)inner_level_readin;
+        m_outer_level_prioritization=(scheduler_prioritization_type)outer_level_readin;
     }
-  }
-  virtual void done_adding_supervised_warps() {
-    m_last_supervised_issued = m_supervised_warps.begin();
-  }
+	virtual ~two_level_active_scheduler () {}
+    virtual void order_warps();
+	void add_supervised_warp_id(int i) {
+        if ( m_next_cycle_prioritized_warps.size() < m_max_active_warps ) {
+            m_next_cycle_prioritized_warps.push_back( &warp(i) );
+        } else {
+		    m_pending_warps.push_back(&warp(i));
+        }
+	}
+    virtual void done_adding_supervised_warps() {
+        m_last_supervised_issued = m_supervised_warps.begin();
+    }
 
- protected:
-  virtual void do_on_warp_issued(
-      unsigned warp_id, unsigned num_issued,
-      const std::vector<shd_warp_t *>::const_iterator &prioritized_iter);
+protected:
+    virtual void do_on_warp_issued( unsigned warp_id,
+                                    unsigned num_issued,
+                                    const std::vector< shd_warp_t* >::const_iterator& prioritized_iter );
 
- private:
-  std::deque<shd_warp_t *> m_pending_warps;
-  scheduler_prioritization_type m_inner_level_prioritization;
-  scheduler_prioritization_type m_outer_level_prioritization;
-  unsigned m_max_active_warps;
+private:
+	std::deque< shd_warp_t* > m_pending_warps;
+    scheduler_prioritization_type m_inner_level_prioritization;
+    scheduler_prioritization_type m_outer_level_prioritization;
+	unsigned m_max_active_warps;
 };
 
 // Static Warp Limiting Scheduler
 class swl_scheduler : public scheduler_unit {
- public:
-  swl_scheduler(shader_core_stats *stats, shader_core_ctx *shader,
-                Scoreboard *scoreboard, simt_stack **simt,
-                std::vector<shd_warp_t> *warp, register_set *sp_out,
-                register_set *dp_out, register_set *sfu_out,
-                register_set *int_out, register_set *tensor_core_out,
-                register_set *mem_out, int id, char *config_string);
-  virtual ~swl_scheduler() {}
-  virtual void order_warps();
-  virtual void done_adding_supervised_warps() {
-    m_last_supervised_issued = m_supervised_warps.begin();
-  }
+public:
+	swl_scheduler ( shader_core_stats* stats, shader_core_ctx* shader,
+                    Scoreboard* scoreboard, simt_stack** simt,
+                    std::vector<shd_warp_t>* warp,
+                    register_set* sp_out,
+					register_set* dp_out,
+                    register_set* sfu_out,
+					register_set* int_out,
+                    register_set* tensor_core_out,
+                    register_set* mem_out,
+                    int id,
+                    char* config_string );
+	virtual ~swl_scheduler () {}
+	virtual void order_warps ();
+    virtual void done_adding_supervised_warps() {
+        m_last_supervised_issued = m_supervised_warps.begin();
+    }
 
- protected:
-  scheduler_prioritization_type m_prioritization;
-  unsigned m_num_warps_to_limit;
+protected:
+    scheduler_prioritization_type m_prioritization;
+    unsigned m_num_warps_to_limit;
 };
 
-class opndcoll_rfu_t {  // operand collector based register file unit
- public:
-  // constructors
-  opndcoll_rfu_t() {
-    m_num_banks = 0;
-    m_shader = NULL;
-    m_initialized = false;
-  }
-  void add_cu_set(unsigned cu_set, unsigned num_cu, unsigned num_dispatch);
-  typedef std::vector<register_set *> port_vector_t;
-  typedef std::vector<unsigned int> uint_vector_t;
-  void add_port(port_vector_t &input, port_vector_t &ouput,
-                uint_vector_t cu_sets);
-  void init(unsigned num_banks, shader_core_ctx *shader);
 
-  // modifiers
-  bool writeback(warp_inst_t &warp);
 
-  void step() {
-    dispatch_ready_cu();
-    allocate_reads();
-    for (unsigned p = 0; p < m_in_ports.size(); p++) allocate_cu(p);
-    process_banks();
-  }
+class opndcoll_rfu_t { // operand collector based register file unit
+public:
+   // constructors
+   opndcoll_rfu_t()
+   {
+      m_num_banks=0;
+      m_shader=NULL;
+      m_initialized=false;
+   }
+   void add_cu_set(unsigned cu_set, unsigned num_cu, unsigned num_dispatch);
+   typedef std::vector<register_set*> port_vector_t;
+   typedef std::vector<unsigned int> uint_vector_t;
+   void add_port( port_vector_t & input, port_vector_t & ouput, uint_vector_t cu_sets);
+   void init( unsigned num_banks, shader_core_ctx *shader );
 
-  void dump(FILE *fp) const {
-    fprintf(fp, "\n");
-    fprintf(fp, "Operand Collector State:\n");
-    for (unsigned n = 0; n < m_cu.size(); n++) {
-      fprintf(fp, "   CU-%2u: ", n);
-      m_cu[n]->dump(fp, m_shader);
-    }
-    m_arbiter.dump(fp);
-  }
+   // modifiers
+   bool writeback( warp_inst_t &warp ); 
 
-  shader_core_ctx *shader_core() { return m_shader; }
+   void step()
+   {
+        dispatch_ready_cu();   
+        allocate_reads();
+        for( unsigned p = 0 ; p < m_in_ports.size(); p++ ) 
+            allocate_cu( p );
+        process_banks();
+   }
 
- private:
-  void process_banks() { m_arbiter.reset_alloction(); }
+   void dump( FILE *fp ) const
+   {
+      fprintf(fp,"\n");
+      fprintf(fp,"Operand Collector State:\n");
+      for( unsigned n=0; n < m_cu.size(); n++ ) {
+         fprintf(fp,"   CU-%2u: ", n);
+         m_cu[n]->dump(fp,m_shader);
+      }
+      m_arbiter.dump(fp);
+   }
 
-  void dispatch_ready_cu();
-  void allocate_cu(unsigned port);
-  void allocate_reads();
+   shader_core_ctx *shader_core() { return m_shader; }
 
-  // types
+private:
 
-  class collector_unit_t;
+   void process_banks()
+   {
+      m_arbiter.reset_alloction();
+   }
 
-  class op_t {
+   void dispatch_ready_cu();
+   void allocate_cu( unsigned port );
+   void allocate_reads();
+
+   // types
+
+   class collector_unit_t;
+
+   class op_t {
    public:
-    op_t() { m_valid = false; }
-    op_t(collector_unit_t *cu, unsigned op, unsigned reg, unsigned num_banks,
-         unsigned bank_warp_shift, bool sub_core_model,
-         unsigned banks_per_sched, unsigned sched_id) {
-      m_valid = true;
-      m_warp = NULL;
-      m_cu = cu;
-      m_operand = op;
-      m_register = reg;
-      m_shced_id = sched_id;
-      m_bank = register_bank(reg, cu->get_warp_id(), num_banks, bank_warp_shift,
-                             sub_core_model, banks_per_sched, sched_id);
-    }
-    op_t(const warp_inst_t *warp, unsigned reg, unsigned num_banks,
-         unsigned bank_warp_shift, bool sub_core_model,
-         unsigned banks_per_sched, unsigned sched_id) {
-      m_valid = true;
-      m_warp = warp;
-      m_register = reg;
-      m_cu = NULL;
-      m_operand = -1;
-      m_shced_id = sched_id;
-      m_bank = register_bank(reg, warp->warp_id(), num_banks, bank_warp_shift,
-                             sub_core_model, banks_per_sched, sched_id);
-    }
 
-    // accessors
-    bool valid() const { return m_valid; }
-    unsigned get_reg() const {
-      assert(m_valid);
-      return m_register;
-    }
-    unsigned get_wid() const {
-      if (m_warp)
-        return m_warp->warp_id();
-      else if (m_cu)
-        return m_cu->get_warp_id();
-      else
-        abort();
-    }
-    unsigned get_sid() const { return m_shced_id; }
-    unsigned get_active_count() const {
-      if (m_warp)
-        return m_warp->active_count();
-      else if (m_cu)
-        return m_cu->get_active_count();
-      else
-        abort();
-    }
-    const active_mask_t &get_active_mask() {
-      if (m_warp)
-        return m_warp->get_active_mask();
-      else if (m_cu)
-        return m_cu->get_active_mask();
-      else
-        abort();
-    }
-    unsigned get_sp_op() const {
-      if (m_warp)
-        return m_warp->sp_op;
-      else if (m_cu)
-        return m_cu->get_sp_op();
-      else
-        abort();
-    }
-    unsigned get_oc_id() const { return m_cu->get_id(); }
-    unsigned get_bank() const { return m_bank; }
-    unsigned get_operand() const { return m_operand; }
-    void dump(FILE *fp) const {
-      if (m_cu)
-        fprintf(fp, " <R%u, CU:%u, w:%02u> ", m_register, m_cu->get_id(),
-                m_cu->get_warp_id());
-      else if (!m_warp->empty())
-        fprintf(fp, " <R%u, wid:%02u> ", m_register, m_warp->warp_id());
-    }
-    std::string get_reg_string() const {
-      char buffer[64];
-      snprintf(buffer, 64, "R%u", m_register);
-      return std::string(buffer);
-    }
+      op_t() { m_valid = false; }
+      op_t( collector_unit_t *cu, unsigned op, unsigned reg, unsigned num_banks, unsigned bank_warp_shift, bool sub_core_model, unsigned banks_per_sched, unsigned sched_id )
+      {
+         m_valid = true;
+         m_warp=NULL;
+         m_cu = cu;
+         m_operand = op;
+         m_register = reg;
+         m_shced_id = sched_id;
+         m_bank = register_bank(reg,cu->get_warp_id(),num_banks,bank_warp_shift, sub_core_model, banks_per_sched, sched_id);
+      }
+      op_t( const warp_inst_t *warp, unsigned reg, unsigned num_banks, unsigned bank_warp_shift, bool sub_core_model, unsigned banks_per_sched, unsigned sched_id )
+      {
+         m_valid=true;
+         m_warp=warp;
+         m_register=reg;
+         m_cu=NULL;
+         m_operand = -1;
+         m_shced_id = sched_id;
+         m_bank = register_bank(reg,warp->warp_id(),num_banks,bank_warp_shift, sub_core_model, banks_per_sched, sched_id);
+      }
 
-    // modifiers
-    void reset() { m_valid = false; }
+      // accessors
+      bool valid() const { return m_valid; }
+      unsigned get_reg() const
+      {
+         assert( m_valid );
+         return m_register;
+      }
+      unsigned get_wid() const
+      {
+          if( m_warp ) return m_warp->warp_id();
+          else if( m_cu ) return m_cu->get_warp_id();
+          else abort();
+      }
+      unsigned get_sid() const
+	  {
+		 return m_shced_id;
+	  }
+      unsigned get_active_count() const
+      {
+          if( m_warp ) return m_warp->active_count();
+          else if( m_cu ) return m_cu->get_active_count();
+          else abort();
+      }
+      const active_mask_t & get_active_mask()
+      {
+          if( m_warp ) return m_warp->get_active_mask();
+          else if( m_cu ) return m_cu->get_active_mask();
+          else abort();
+      }
+      unsigned get_sp_op() const
+      {
+          if( m_warp ) return m_warp->sp_op;
+          else if( m_cu ) return m_cu->get_sp_op();
+          else abort();
+      }
+      unsigned get_oc_id() const { return m_cu->get_id(); }
+      unsigned get_bank() const { return m_bank; }
+      unsigned get_operand() const { return m_operand; }
+      void dump(FILE *fp) const 
+      {
+         if(m_cu) 
+            fprintf(fp," <R%u, CU:%u, w:%02u> ", m_register,m_cu->get_id(),m_cu->get_warp_id());
+         else if( !m_warp->empty() )
+            fprintf(fp," <R%u, wid:%02u> ", m_register,m_warp->warp_id() );
+      }
+      std::string get_reg_string() const
+      {
+         char buffer[64];
+         snprintf(buffer,64,"R%u", m_register);
+         return std::string(buffer);
+      }
+
+      // modifiers
+      void reset() { m_valid = false; }
+   private:
+      bool m_valid;
+      collector_unit_t  *m_cu; 
+      const warp_inst_t *m_warp;
+      unsigned  m_operand; // operand offset in instruction. e.g., add r1,r2,r3; r2 is oprd 0, r3 is 1 (r1 is dst)
+      unsigned  m_register;
+      unsigned  m_bank;
+      unsigned  m_shced_id; //scheduler id that has issued this inst
+   };
+
+   enum alloc_t {
+      NO_ALLOC,
+      READ_ALLOC,
+      WRITE_ALLOC,
+   };
+
+   class allocation_t {
+   public:
+      allocation_t() { m_allocation = NO_ALLOC; }
+      bool is_read() const { return m_allocation==READ_ALLOC; }
+      bool is_write() const {return m_allocation==WRITE_ALLOC; }
+      bool is_free() const {return m_allocation==NO_ALLOC; }
+      void dump(FILE *fp) const {
+         if( m_allocation == NO_ALLOC ) { fprintf(fp,"<free>"); }
+         else if( m_allocation == READ_ALLOC ) { fprintf(fp,"rd: "); m_op.dump(fp); }
+         else if( m_allocation == WRITE_ALLOC ) { fprintf(fp,"wr: "); m_op.dump(fp); }
+         fprintf(fp,"\n");
+      }
+      void alloc_read( const op_t &op )  { assert(is_free()); m_allocation=READ_ALLOC; m_op=op;  }
+      void alloc_write( const op_t &op ) { assert(is_free()); m_allocation=WRITE_ALLOC; m_op=op; }
+      void reset() { m_allocation = NO_ALLOC; }
+   private:
+      enum alloc_t m_allocation;
+      op_t m_op;
+   };
+
+   class arbiter_t {
+   public:
+      // constructors
+      arbiter_t()
+      {
+         m_queue=NULL;
+         m_allocated_bank=NULL;
+         m_allocator_rr_head=NULL;
+         _inmatch=NULL;
+         _outmatch=NULL;
+         _request=NULL;
+         m_last_cu=0;
+      }
+      void init( unsigned num_cu, unsigned num_banks ) 
+      { 
+         assert(num_cu > 0);
+         assert(num_banks > 0);
+         m_num_collectors = num_cu;
+         m_num_banks = num_banks;
+         _inmatch = new int[ m_num_banks ];
+         _outmatch = new int[ m_num_collectors ];
+         _request = new int*[ m_num_banks ];
+         for(unsigned i=0; i<m_num_banks;i++) 
+             _request[i] = new int[m_num_collectors];
+         m_queue = new std::list<op_t>[num_banks];
+         m_allocated_bank = new allocation_t[num_banks];
+         m_allocator_rr_head = new unsigned[num_cu];
+         for( unsigned n=0; n<num_cu;n++ ) 
+            m_allocator_rr_head[n] = n%num_banks;
+         reset_alloction();
+      }
+
+      // accessors
+      void dump(FILE *fp) const
+      {
+         fprintf(fp,"\n");
+         fprintf(fp,"  Arbiter State:\n");
+         fprintf(fp,"  requests:\n");
+         for( unsigned b=0; b<m_num_banks; b++ ) {
+            fprintf(fp,"    bank %u : ", b );
+            std::list<op_t>::const_iterator o = m_queue[b].begin();
+            for(; o != m_queue[b].end(); o++ ) {
+               o->dump(fp);
+            }
+            fprintf(fp,"\n");
+         }
+         fprintf(fp,"  grants:\n");
+         for(unsigned b=0;b<m_num_banks;b++) {
+            fprintf(fp,"    bank %u : ", b );
+            m_allocated_bank[b].dump(fp);
+         }
+         fprintf(fp,"\n");
+      }
+
+      // modifiers
+      std::list<op_t> allocate_reads(); 
+
+      void add_read_requests( collector_unit_t *cu ) 
+      {
+         const op_t *src = cu->get_operands();
+         for( unsigned i=0; i<MAX_REG_OPERANDS*2; i++) {
+            const op_t &op = src[i];
+            if( op.valid() ) {
+               unsigned bank = op.get_bank();
+               m_queue[bank].push_back(op);
+            }
+         }
+      }
+      bool bank_idle( unsigned bank ) const
+      {
+          return m_allocated_bank[bank].is_free();
+      }
+      void allocate_bank_for_write( unsigned bank, const op_t &op )
+      {
+         assert( bank < m_num_banks );
+         m_allocated_bank[bank].alloc_write(op);
+      }
+      void allocate_for_read( unsigned bank, const op_t &op )
+      {
+         assert( bank < m_num_banks );
+         m_allocated_bank[bank].alloc_read(op);
+      }
+      void reset_alloction()
+      {
+         for( unsigned b=0; b < m_num_banks; b++ ) 
+            m_allocated_bank[b].reset();
+      }
 
    private:
-    bool m_valid;
-    collector_unit_t *m_cu;
-    const warp_inst_t *m_warp;
-    unsigned m_operand;  // operand offset in instruction. e.g., add r1,r2,r3;
-                         // r2 is oprd 0, r3 is 1 (r1 is dst)
-    unsigned m_register;
-    unsigned m_bank;
-    unsigned m_shced_id;  // scheduler id that has issued this inst
-  };
+      unsigned m_num_banks;
+      unsigned m_num_collectors;
 
-  enum alloc_t {
-    NO_ALLOC,
-    READ_ALLOC,
-    WRITE_ALLOC,
-  };
+      allocation_t *m_allocated_bank; // bank # -> register that wins
+      std::list<op_t> *m_queue;
 
-  class allocation_t {
+      unsigned *m_allocator_rr_head; // cu # -> next bank to check for request (rr-arb)
+      unsigned  m_last_cu; // first cu to check while arb-ing banks (rr)
+
+      int *_inmatch;
+      int *_outmatch;
+      int **_request;
+   };
+
+   class input_port_t {
    public:
-    allocation_t() { m_allocation = NO_ALLOC; }
-    bool is_read() const { return m_allocation == READ_ALLOC; }
-    bool is_write() const { return m_allocation == WRITE_ALLOC; }
-    bool is_free() const { return m_allocation == NO_ALLOC; }
-    void dump(FILE *fp) const {
-      if (m_allocation == NO_ALLOC) {
-        fprintf(fp, "<free>");
-      } else if (m_allocation == READ_ALLOC) {
-        fprintf(fp, "rd: ");
-        m_op.dump(fp);
-      } else if (m_allocation == WRITE_ALLOC) {
-        fprintf(fp, "wr: ");
-        m_op.dump(fp);
+       input_port_t(port_vector_t & input, port_vector_t & output, uint_vector_t cu_sets)
+       : m_in(input),m_out(output), m_cu_sets(cu_sets)
+       {
+           assert(input.size() == output.size());
+           assert(not m_cu_sets.empty());
+       }
+   //private:
+       port_vector_t m_in,m_out;
+       uint_vector_t m_cu_sets;
+   };
+
+   class collector_unit_t {
+   public:
+      // constructors
+      collector_unit_t()
+      { 
+         m_free = true;
+         m_warp = NULL;
+         m_output_register = NULL;
+         m_src_op = new op_t[MAX_REG_OPERANDS*2];
+         m_not_ready.reset();
+         m_warp_id = -1;
+         m_num_banks = 0;
+         m_bank_warp_shift = 0;
       }
-      fprintf(fp, "\n");
-    }
-    void alloc_read(const op_t &op) {
-      assert(is_free());
-      m_allocation = READ_ALLOC;
-      m_op = op;
-    }
-    void alloc_write(const op_t &op) {
-      assert(is_free());
-      m_allocation = WRITE_ALLOC;
-      m_op = op;
-    }
-    void reset() { m_allocation = NO_ALLOC; }
+      // accessors
+      bool ready() const;
+      const op_t *get_operands() const { return m_src_op; }
+      void dump(FILE *fp, const shader_core_ctx *shader ) const;
+
+      unsigned get_warp_id() const { return m_warp_id; }
+      unsigned get_active_count() const { return m_warp->active_count(); }
+      const active_mask_t & get_active_mask() const { return m_warp->get_active_mask(); }
+      unsigned get_sp_op() const { return m_warp->sp_op; }
+      unsigned get_id() const { return m_cuid; } // returns CU hw id
+
+      // modifiers
+      void init(unsigned n, 
+                unsigned num_banks, 
+                unsigned log2_warp_size,
+                const core_config *config,
+                opndcoll_rfu_t *rfu,
+				bool m_sub_core_model,
+				unsigned num_banks_per_sched);
+      bool allocate( register_set* pipeline_reg, register_set* output_reg );
+
+      void collect_operand( unsigned op )
+      {
+         m_not_ready.reset(op);
+      }
+      unsigned get_num_operands() const{
+    	  return m_warp->get_num_operands();
+      }
+      unsigned get_num_regs() const{
+    	  return m_warp->get_num_regs();
+      }
+      void dispatch();
+      bool is_free(){return m_free;}
 
    private:
-    enum alloc_t m_allocation;
-    op_t m_op;
-  };
+      bool m_free;
+      unsigned m_cuid; // collector unit hw id
+      unsigned m_warp_id;
+      warp_inst_t  *m_warp;
+      register_set* m_output_register; // pipeline register to issue to when ready
+      op_t *m_src_op;
+      std::bitset<MAX_REG_OPERANDS*2> m_not_ready;
+      unsigned m_num_banks;
+      unsigned m_bank_warp_shift;
+      opndcoll_rfu_t *m_rfu;
 
-  class arbiter_t {
+      unsigned m_num_banks_per_sched;
+      bool m_sub_core_model;
+
+   };
+
+   class dispatch_unit_t {
    public:
-    // constructors
-    arbiter_t() {
-      m_queue = NULL;
-      m_allocated_bank = NULL;
-      m_allocator_rr_head = NULL;
-      _inmatch = NULL;
-      _outmatch = NULL;
-      _request = NULL;
-      m_last_cu = 0;
-    }
-    void init(unsigned num_cu, unsigned num_banks) {
-      assert(num_cu > 0);
-      assert(num_banks > 0);
-      m_num_collectors = num_cu;
-      m_num_banks = num_banks;
-      _inmatch = new int[m_num_banks];
-      _outmatch = new int[m_num_collectors];
-      _request = new int *[m_num_banks];
-      for (unsigned i = 0; i < m_num_banks; i++)
-        _request[i] = new int[m_num_collectors];
-      m_queue = new std::list<op_t>[num_banks];
-      m_allocated_bank = new allocation_t[num_banks];
-      m_allocator_rr_head = new unsigned[num_cu];
-      for (unsigned n = 0; n < num_cu; n++)
-        m_allocator_rr_head[n] = n % num_banks;
-      reset_alloction();
-    }
-
-    // accessors
-    void dump(FILE *fp) const {
-      fprintf(fp, "\n");
-      fprintf(fp, "  Arbiter State:\n");
-      fprintf(fp, "  requests:\n");
-      for (unsigned b = 0; b < m_num_banks; b++) {
-        fprintf(fp, "    bank %u : ", b);
-        std::list<op_t>::const_iterator o = m_queue[b].begin();
-        for (; o != m_queue[b].end(); o++) {
-          o->dump(fp);
-        }
-        fprintf(fp, "\n");
+      dispatch_unit_t(std::vector<collector_unit_t>* cus) 
+      { 
+         m_last_cu=0;
+         m_collector_units=cus;
+         m_num_collectors = (*cus).size();
+         m_next_cu=0;
       }
-      fprintf(fp, "  grants:\n");
-      for (unsigned b = 0; b < m_num_banks; b++) {
-        fprintf(fp, "    bank %u : ", b);
-        m_allocated_bank[b].dump(fp);
-      }
-      fprintf(fp, "\n");
-    }
 
-    // modifiers
-    std::list<op_t> allocate_reads();
-
-    void add_read_requests(collector_unit_t *cu) {
-      const op_t *src = cu->get_operands();
-      for (unsigned i = 0; i < MAX_REG_OPERANDS * 2; i++) {
-        const op_t &op = src[i];
-        if (op.valid()) {
-          unsigned bank = op.get_bank();
-          m_queue[bank].push_back(op);
-        }
+      collector_unit_t *find_ready()
+      {
+         for( unsigned n=0; n < m_num_collectors; n++ ) {
+            unsigned c=(m_last_cu+n+1)%m_num_collectors;
+            if( (*m_collector_units)[c].ready() ) {
+               m_last_cu=c;
+               return &((*m_collector_units)[c]);
+            }
+         }
+         return NULL;
       }
-    }
-    bool bank_idle(unsigned bank) const {
-      return m_allocated_bank[bank].is_free();
-    }
-    void allocate_bank_for_write(unsigned bank, const op_t &op) {
-      assert(bank < m_num_banks);
-      m_allocated_bank[bank].alloc_write(op);
-    }
-    void allocate_for_read(unsigned bank, const op_t &op) {
-      assert(bank < m_num_banks);
-      m_allocated_bank[bank].alloc_read(op);
-    }
-    void reset_alloction() {
-      for (unsigned b = 0; b < m_num_banks; b++) m_allocated_bank[b].reset();
-    }
 
    private:
-    unsigned m_num_banks;
-    unsigned m_num_collectors;
+      unsigned m_num_collectors;
+      std::vector<collector_unit_t>* m_collector_units;
+      unsigned m_last_cu; // dispatch ready cu's rr
+      unsigned m_next_cu;  // for initialization
+   };
 
-    allocation_t *m_allocated_bank;  // bank # -> register that wins
-    std::list<op_t> *m_queue;
+   // opndcoll_rfu_t data members
+   bool m_initialized;
 
-    unsigned *
-        m_allocator_rr_head;  // cu # -> next bank to check for request (rr-arb)
-    unsigned m_last_cu;       // first cu to check while arb-ing banks (rr)
+   unsigned m_num_collector_sets;
+   //unsigned m_num_collectors;
+   unsigned m_num_banks;
+   unsigned m_bank_warp_shift;
+   unsigned m_warp_size;
+   std::vector<collector_unit_t *> m_cu;
+   arbiter_t m_arbiter;
 
-    int *_inmatch;
-    int *_outmatch;
-    int **_request;
-  };
+   unsigned m_num_banks_per_sched;
+   unsigned m_num_warp_sceds;
+   bool sub_core_model;
 
-  class input_port_t {
-   public:
-    input_port_t(port_vector_t &input, port_vector_t &output,
-                 uint_vector_t cu_sets)
-        : m_in(input), m_out(output), m_cu_sets(cu_sets) {
-      assert(input.size() == output.size());
-      assert(not m_cu_sets.empty());
-    }
-    // private:
-    port_vector_t m_in, m_out;
-    uint_vector_t m_cu_sets;
-  };
+   //unsigned m_num_ports;
+   //std::vector<warp_inst_t**> m_input;
+   //std::vector<warp_inst_t**> m_output;
+   //std::vector<unsigned> m_num_collector_units;
+   //warp_inst_t **m_alu_port;
 
-  class collector_unit_t {
-   public:
-    // constructors
-    collector_unit_t() {
-      m_free = true;
-      m_warp = NULL;
-      m_output_register = NULL;
-      m_src_op = new op_t[MAX_REG_OPERANDS * 2];
-      m_not_ready.reset();
-      m_warp_id = -1;
-      m_num_banks = 0;
-      m_bank_warp_shift = 0;
-    }
-    // accessors
-    bool ready() const;
-    const op_t *get_operands() const { return m_src_op; }
-    void dump(FILE *fp, const shader_core_ctx *shader) const;
+   std::vector<input_port_t> m_in_ports;
+   typedef std::map<unsigned /* collector set */, std::vector<collector_unit_t> /*collector sets*/ > cu_sets_t;
+   cu_sets_t m_cus;
+   std::vector<dispatch_unit_t> m_dispatch_units;
 
-    unsigned get_warp_id() const { return m_warp_id; }
-    unsigned get_active_count() const { return m_warp->active_count(); }
-    const active_mask_t &get_active_mask() const {
-      return m_warp->get_active_mask();
-    }
-    unsigned get_sp_op() const { return m_warp->sp_op; }
-    unsigned get_id() const { return m_cuid; }  // returns CU hw id
-
-    // modifiers
-    void init(unsigned n, unsigned num_banks, unsigned log2_warp_size,
-              const core_config *config, opndcoll_rfu_t *rfu,
-              bool m_sub_core_model, unsigned num_banks_per_sched);
-    bool allocate(register_set *pipeline_reg, register_set *output_reg);
-
-    void collect_operand(unsigned op) { m_not_ready.reset(op); }
-    unsigned get_num_operands() const { return m_warp->get_num_operands(); }
-    unsigned get_num_regs() const { return m_warp->get_num_regs(); }
-    void dispatch();
-    bool is_free() { return m_free; }
-
-   private:
-    bool m_free;
-    unsigned m_cuid;  // collector unit hw id
-    unsigned m_warp_id;
-    warp_inst_t *m_warp;
-    register_set
-        *m_output_register;  // pipeline register to issue to when ready
-    op_t *m_src_op;
-    std::bitset<MAX_REG_OPERANDS * 2> m_not_ready;
-    unsigned m_num_banks;
-    unsigned m_bank_warp_shift;
-    opndcoll_rfu_t *m_rfu;
-
-    unsigned m_num_banks_per_sched;
-    bool m_sub_core_model;
-  };
-
-  class dispatch_unit_t {
-   public:
-    dispatch_unit_t(std::vector<collector_unit_t> *cus) {
-      m_last_cu = 0;
-      m_collector_units = cus;
-      m_num_collectors = (*cus).size();
-      m_next_cu = 0;
-    }
-
-    collector_unit_t *find_ready() {
-      for (unsigned n = 0; n < m_num_collectors; n++) {
-        unsigned c = (m_last_cu + n + 1) % m_num_collectors;
-        if ((*m_collector_units)[c].ready()) {
-          m_last_cu = c;
-          return &((*m_collector_units)[c]);
-        }
-      }
-      return NULL;
-    }
-
-   private:
-    unsigned m_num_collectors;
-    std::vector<collector_unit_t> *m_collector_units;
-    unsigned m_last_cu;  // dispatch ready cu's rr
-    unsigned m_next_cu;  // for initialization
-  };
-
-  // opndcoll_rfu_t data members
-  bool m_initialized;
-
-  unsigned m_num_collector_sets;
-  // unsigned m_num_collectors;
-  unsigned m_num_banks;
-  unsigned m_bank_warp_shift;
-  unsigned m_warp_size;
-  std::vector<collector_unit_t *> m_cu;
-  arbiter_t m_arbiter;
-
-  unsigned m_num_banks_per_sched;
-  unsigned m_num_warp_sceds;
-  bool sub_core_model;
-
-  // unsigned m_num_ports;
-  // std::vector<warp_inst_t**> m_input;
-  // std::vector<warp_inst_t**> m_output;
-  // std::vector<unsigned> m_num_collector_units;
-  // warp_inst_t **m_alu_port;
-
-  std::vector<input_port_t> m_in_ports;
-  typedef std::map<unsigned /* collector set */,
-                   std::vector<collector_unit_t> /*collector sets*/>
-      cu_sets_t;
-  cu_sets_t m_cus;
-  std::vector<dispatch_unit_t> m_dispatch_units;
-
-  // typedef std::map<warp_inst_t**/*port*/,dispatch_unit_t> port_to_du_t;
-  // port_to_du_t                     m_dispatch_units;
-  // std::map<warp_inst_t**,std::list<collector_unit_t*> > m_free_cu;
-  shader_core_ctx *m_shader;
+   //typedef std::map<warp_inst_t**/*port*/,dispatch_unit_t> port_to_du_t;
+   //port_to_du_t                     m_dispatch_units;
+   //std::map<warp_inst_t**,std::list<collector_unit_t*> > m_free_cu;
+   shader_core_ctx                 *m_shader;
 };
 
 class barrier_set_t {
- public:
-  barrier_set_t(shader_core_ctx *shader, unsigned max_warps_per_core,
-                unsigned max_cta_per_core, unsigned max_barriers_per_cta,
-                unsigned warp_size);
+public:
+   barrier_set_t(shader_core_ctx * shader, unsigned max_warps_per_core, unsigned max_cta_per_core, unsigned max_barriers_per_cta, unsigned warp_size);
 
-  // during cta allocation
-  void allocate_barrier(unsigned cta_id, warp_set_t warps);
+   // during cta allocation
+   void allocate_barrier( unsigned cta_id, warp_set_t warps );
 
-  // during cta deallocation
-  void deallocate_barrier(unsigned cta_id);
+   // during cta deallocation
+   void deallocate_barrier( unsigned cta_id );
 
-  typedef std::map<unsigned, warp_set_t> cta_to_warp_t;
-  typedef std::map<unsigned, warp_set_t>
-      bar_id_to_warp_t; /*set of warps reached a specific barrier id*/
+   typedef std::map<unsigned, warp_set_t >  cta_to_warp_t;
+   typedef std::map<unsigned, warp_set_t >  bar_id_to_warp_t; /*set of warps reached a specific barrier id*/
 
-  // individual warp hits barrier
-  void warp_reaches_barrier(unsigned cta_id, unsigned warp_id,
-                            warp_inst_t *inst);
 
-  // warp reaches exit
-  void warp_exit(unsigned warp_id);
+   // individual warp hits barrier
+   void warp_reaches_barrier( unsigned cta_id, unsigned warp_id, warp_inst_t* inst);
 
-  // assertions
-  bool warp_waiting_at_barrier(unsigned warp_id) const;
 
-  // debug
-  void dump();
+   // warp reaches exit 
+   void warp_exit( unsigned warp_id );
 
- private:
-  unsigned m_max_cta_per_core;
-  unsigned m_max_warps_per_core;
-  unsigned m_max_barriers_per_cta;
-  unsigned m_warp_size;
-  cta_to_warp_t m_cta_to_warps;
-  bar_id_to_warp_t m_bar_id_to_warps;
-  warp_set_t m_warp_active;
-  warp_set_t m_warp_at_barrier;
-  shader_core_ctx *m_shader;
+   // assertions
+   bool warp_waiting_at_barrier( unsigned warp_id ) const;
+
+   // debug
+   void dump();
+
+private:
+   unsigned m_max_cta_per_core;
+   unsigned m_max_warps_per_core;
+   unsigned m_max_barriers_per_cta;
+   unsigned m_warp_size;
+   cta_to_warp_t m_cta_to_warps;
+   bar_id_to_warp_t m_bar_id_to_warps;
+   warp_set_t m_warp_active;
+   warp_set_t m_warp_at_barrier;
+   shader_core_ctx *m_shader;
+
 };
 
 struct insn_latency_info {
-  unsigned pc;
-  unsigned long latency;
+   unsigned pc;
+   unsigned long latency;
 };
 
 struct ifetch_buffer_t {
-  ifetch_buffer_t() { m_valid = false; }
+    ifetch_buffer_t() { m_valid=false; }
 
-  ifetch_buffer_t(address_type pc, unsigned nbytes, unsigned warp_id) {
-    m_valid = true;
-    m_pc = pc;
-    m_nbytes = nbytes;
-    m_warp_id = warp_id;
-  }
+    ifetch_buffer_t( address_type pc, unsigned nbytes, unsigned warp_id ) 
+    { 
+        m_valid=true; 
+        m_pc=pc; 
+        m_nbytes=nbytes; 
+        m_warp_id=warp_id;
+    }
 
-  bool m_valid;
-  address_type m_pc;
-  unsigned m_nbytes;
-  unsigned m_warp_id;
+    bool m_valid;
+    address_type m_pc;
+    unsigned m_nbytes;
+    unsigned m_warp_id;
 };
 
 class shader_core_config;
 
 class simd_function_unit {
- public:
-  simd_function_unit(const shader_core_config *config);
-  ~simd_function_unit() { delete m_dispatch_reg; }
+public:
+    simd_function_unit( const shader_core_config *config );
+    ~simd_function_unit() { delete m_dispatch_reg; }
 
-  // modifiers
-  virtual void issue(register_set &source_reg) {
-    source_reg.move_out_to(m_dispatch_reg);
-    occupied.set(m_dispatch_reg->latency);
-  }
-  virtual void cycle() = 0;
-  virtual void active_lanes_in_pipeline() = 0;
+    // modifiers
+    virtual void issue( register_set& source_reg ) { source_reg.move_out_to(m_dispatch_reg); occupied.set(m_dispatch_reg->latency);}
+    virtual void cycle() = 0;
+    virtual void active_lanes_in_pipeline() = 0;
 
-  // accessors
-  virtual unsigned clock_multiplier() const { return 1; }
-  virtual bool can_issue(const warp_inst_t &inst) const {
-    return m_dispatch_reg->empty() && !occupied.test(inst.latency);
-  }
-  virtual bool stallable() const = 0;
-  virtual void print(FILE *fp) const {
-    fprintf(fp, "%s dispatch= ", m_name.c_str());
-    m_dispatch_reg->print(fp);
-  }
-  const char *get_name() { return m_name.c_str(); }
-
- protected:
-  std::string m_name;
-  const shader_core_config *m_config;
-  warp_inst_t *m_dispatch_reg;
-  static const unsigned MAX_ALU_LATENCY = 512;
-  std::bitset<MAX_ALU_LATENCY> occupied;
+    // accessors
+    virtual unsigned clock_multiplier() const { return 1; }
+    virtual bool can_issue( const warp_inst_t &inst ) const { return m_dispatch_reg->empty() && !occupied.test(inst.latency); }
+    virtual bool stallable() const = 0;
+    virtual void print( FILE *fp ) const
+    {
+        fprintf(fp,"%s dispatch= ", m_name.c_str() );
+        m_dispatch_reg->print(fp);
+    }
+    const char* get_name() {
+    	return m_name.c_str();
+    }
+protected:
+    std::string m_name;
+    const shader_core_config *m_config;
+    warp_inst_t *m_dispatch_reg;
+    static const unsigned MAX_ALU_LATENCY = 512;
+    std::bitset<MAX_ALU_LATENCY> occupied;
 };
 
 class pipelined_simd_unit : public simd_function_unit {
- public:
-  pipelined_simd_unit(register_set *result_port,
-                      const shader_core_config *config, unsigned max_latency,
-                      shader_core_ctx *core);
+public:
+    pipelined_simd_unit( register_set* result_port, const shader_core_config *config, unsigned max_latency, shader_core_ctx *core );
 
-  // modifiers
-  virtual void cycle();
-  virtual void issue(register_set &source_reg);
-  virtual unsigned get_active_lanes_in_pipeline();
+    //modifiers
+    virtual void cycle();
+    virtual void issue( register_set& source_reg );
+    virtual unsigned get_active_lanes_in_pipeline();
 
-  virtual void active_lanes_in_pipeline() = 0;
-  /*
-      virtual void issue( register_set& source_reg )
-      {
-          //move_warp(m_dispatch_reg,source_reg);
-          //source_reg.move_out_to(m_dispatch_reg);
-          simd_function_unit::issue(source_reg);
-      }
-  */
-  // accessors
-  virtual bool stallable() const { return false; }
-  virtual bool can_issue(const warp_inst_t &inst) const {
-    return simd_function_unit::can_issue(inst);
-  }
-  virtual void print(FILE *fp) const {
-    simd_function_unit::print(fp);
-    for (int s = m_pipeline_depth - 1; s >= 0; s--) {
-      if (!m_pipeline_reg[s]->empty()) {
-        fprintf(fp, "      %s[%2d] ", m_name.c_str(), s);
-        m_pipeline_reg[s]->print(fp);
-      }
+    virtual void active_lanes_in_pipeline() = 0;
+/*
+    virtual void issue( register_set& source_reg )
+    {
+        //move_warp(m_dispatch_reg,source_reg);
+        //source_reg.move_out_to(m_dispatch_reg);
+        simd_function_unit::issue(source_reg);
     }
-  }
+*/
+    // accessors
+    virtual bool stallable() const { return false; }
+    virtual bool can_issue( const warp_inst_t &inst ) const
+    {
+        return simd_function_unit::can_issue(inst);
+    }
+    virtual void print(FILE *fp) const
+    {
+        simd_function_unit::print(fp);
+        for( int s=m_pipeline_depth-1; s>=0; s-- ) {
+            if( !m_pipeline_reg[s]->empty() ) { 
+                fprintf(fp,"      %s[%2d] ", m_name.c_str(), s );
+                m_pipeline_reg[s]->print(fp);
+            }
+        }
+    }
+protected:
+    unsigned m_pipeline_depth;
+    warp_inst_t **m_pipeline_reg;
+    register_set *m_result_port;
+    class shader_core_ctx *m_core;
 
- protected:
-  unsigned m_pipeline_depth;
-  warp_inst_t **m_pipeline_reg;
-  register_set *m_result_port;
-  class shader_core_ctx *m_core;
+    unsigned active_insts_in_pipeline;
 
-  unsigned active_insts_in_pipeline;
 };
 
-class sfu : public pipelined_simd_unit {
- public:
-  sfu(register_set *result_port, const shader_core_config *config,
-      shader_core_ctx *core);
-  virtual bool can_issue(const warp_inst_t &inst) const {
-    switch (inst.op) {
-      case SFU_OP:
-        break;
-      case ALU_SFU_OP:
-        break;
-      case DP_OP:
-        break;  // for compute <= 29 (i..e Fermi and GT200)
-      default:
-        return false;
+class sfu : public pipelined_simd_unit
+{
+public:
+    sfu( register_set* result_port, const shader_core_config *config, shader_core_ctx *core );
+    virtual bool can_issue( const warp_inst_t &inst ) const
+    {
+        switch(inst.op) {
+        case SFU_OP: break;
+        case ALU_SFU_OP: break;
+        case DP_OP: break;     //for compute <= 29 (i..e Fermi and GT200)
+        default: return false;
+        }
+        return pipelined_simd_unit::can_issue(inst);
     }
-    return pipelined_simd_unit::can_issue(inst);
-  }
-  virtual void active_lanes_in_pipeline();
-  virtual void issue(register_set &source_reg);
+    virtual void active_lanes_in_pipeline();
+    virtual void issue(  register_set& source_reg );
 };
 
-class dp_unit : public pipelined_simd_unit {
- public:
-  dp_unit(register_set *result_port, const shader_core_config *config,
-          shader_core_ctx *core);
-  virtual bool can_issue(const warp_inst_t &inst) const {
-    switch (inst.op) {
-      case DP_OP:
-        break;
-      default:
-        return false;
+class dp_unit : public pipelined_simd_unit
+{
+public:
+	dp_unit( register_set* result_port, const shader_core_config *config, shader_core_ctx *core );
+    virtual bool can_issue( const warp_inst_t &inst ) const
+    {
+        switch(inst.op) {
+        case DP_OP: break;
+        default: return false;
+        }
+        return pipelined_simd_unit::can_issue(inst);
     }
-    return pipelined_simd_unit::can_issue(inst);
-  }
-  virtual void active_lanes_in_pipeline();
-  virtual void issue(register_set &source_reg);
+    virtual void active_lanes_in_pipeline();
+    virtual void issue(  register_set& source_reg );
 };
 
-class tensor_core : public pipelined_simd_unit {
- public:
-  tensor_core(register_set *result_port, const shader_core_config *config,
-              shader_core_ctx *core);
-  virtual bool can_issue(const warp_inst_t &inst) const {
-    switch (inst.op) {
-      case TENSOR_CORE_OP:
-        break;
-      default:
-        return false;
+class tensor_core : public pipelined_simd_unit
+{
+public:
+    tensor_core( register_set* result_port, const shader_core_config *config, shader_core_ctx *core );
+    virtual bool can_issue( const warp_inst_t &inst ) const
+    {
+        switch(inst.op) {
+        case TENSOR_CORE_OP: break;
+        default: return false;
+        }
+        return pipelined_simd_unit::can_issue(inst);
     }
-    return pipelined_simd_unit::can_issue(inst);
-  }
-  virtual void active_lanes_in_pipeline();
-  virtual void issue(register_set &source_reg);
+    virtual void active_lanes_in_pipeline();
+    virtual void issue(  register_set& source_reg );
 };
 
-class int_unit : public pipelined_simd_unit {
- public:
-  int_unit(register_set *result_port, const shader_core_config *config,
-           shader_core_ctx *core);
-  virtual bool can_issue(const warp_inst_t &inst) const {
-    switch (inst.op) {
-      case SFU_OP:
-        return false;
-      case LOAD_OP:
-        return false;
-      case TENSOR_CORE_LOAD_OP:
-        return false;
-      case STORE_OP:
-        return false;
-      case TENSOR_CORE_STORE_OP:
-        return false;
-      case MEMORY_BARRIER_OP:
-        return false;
-      case SP_OP:
-        return false;
-      case DP_OP:
-        return false;
-      default:
-        break;
+
+class int_unit : public pipelined_simd_unit
+{
+public:
+	int_unit( register_set* result_port, const shader_core_config *config, shader_core_ctx *core );
+    virtual bool can_issue( const warp_inst_t &inst ) const
+    {
+        switch(inst.op) {
+        case SFU_OP: return false;
+	    case LOAD_OP: return false;
+	    case TENSOR_CORE_LOAD_OP: return false;
+		case STORE_OP: return false;
+		case TENSOR_CORE_STORE_OP: return false;
+		case MEMORY_BARRIER_OP: return false;
+	    case SP_OP: return false;
+	    case DP_OP: return false;
+        default: break;
+        }
+        return pipelined_simd_unit::can_issue(inst);
     }
-    return pipelined_simd_unit::can_issue(inst);
-  }
-  virtual void active_lanes_in_pipeline();
-  virtual void issue(register_set &source_reg);
+    virtual void active_lanes_in_pipeline();
+    virtual void issue(  register_set& source_reg );
 };
 
-class sp_unit : public pipelined_simd_unit {
- public:
-  sp_unit(register_set *result_port, const shader_core_config *config,
-          shader_core_ctx *core);
-  virtual bool can_issue(const warp_inst_t &inst) const {
-    switch (inst.op) {
-      case SFU_OP:
-        return false;
-      case LOAD_OP:
-        return false;
-      case TENSOR_CORE_LOAD_OP:
-        return false;
-      case STORE_OP:
-        return false;
-      case TENSOR_CORE_STORE_OP:
-        return false;
-      case MEMORY_BARRIER_OP:
-        return false;
-      case DP_OP:
-        return false;
-      default:
-        break;
+class sp_unit : public pipelined_simd_unit
+{
+public:
+    sp_unit( register_set* result_port, const shader_core_config *config, shader_core_ctx *core );
+    virtual bool can_issue( const warp_inst_t &inst ) const
+    {
+        switch(inst.op) {
+        case SFU_OP: return false; 
+        case LOAD_OP: return false;
+        case TENSOR_CORE_LOAD_OP: return false;
+        case STORE_OP: return false;
+        case TENSOR_CORE_STORE_OP: return false;
+        case MEMORY_BARRIER_OP: return false;
+        case DP_OP: return false;
+        default: break;
+        }
+        return pipelined_simd_unit::can_issue(inst);
     }
-    return pipelined_simd_unit::can_issue(inst);
-  }
-  virtual void active_lanes_in_pipeline();
-  virtual void issue(register_set &source_reg);
+    virtual void active_lanes_in_pipeline();
+    virtual void issue( register_set& source_reg );
 };
 
 class simt_core_cluster;
@@ -1220,1061 +1211,947 @@ class shader_memory_interface;
 class shader_core_mem_fetch_allocator;
 class cache_t;
 
-class ldst_unit : public pipelined_simd_unit {
- public:
-  ldst_unit(mem_fetch_interface *icnt,
-            shader_core_mem_fetch_allocator *mf_allocator,
-            shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
-            Scoreboard *scoreboard, const shader_core_config *config,
-            const memory_config *mem_config, class shader_core_stats *stats,
-            unsigned sid, unsigned tpc);
+class ldst_unit: public pipelined_simd_unit {
+public:
+    ldst_unit( mem_fetch_interface *icnt,
+               shader_core_mem_fetch_allocator *mf_allocator,
+               shader_core_ctx *core, 
+               opndcoll_rfu_t *operand_collector,
+               Scoreboard *scoreboard,
+               const shader_core_config *config, 
+               const memory_config *mem_config,  
+               class shader_core_stats *stats, 
+               unsigned sid, unsigned tpc );
 
-  // modifiers
-  virtual void issue(register_set &inst);
-  virtual void cycle();
+    // modifiers
+    virtual void issue( register_set &inst );
+    virtual void cycle();
+     
+    void fill( mem_fetch *mf );
+    void flush();
+    void invalidate();
+    void writeback();
 
-  void fill(mem_fetch *mf);
-  void flush();
-  void invalidate();
-  void writeback();
+    // accessors
+    virtual unsigned clock_multiplier() const;
 
-  // accessors
-  virtual unsigned clock_multiplier() const;
-
-  virtual bool can_issue(const warp_inst_t &inst) const {
-    switch (inst.op) {
-      case LOAD_OP:
-        break;
-      case TENSOR_CORE_LOAD_OP:
-        break;
-      case STORE_OP:
-        break;
-      case TENSOR_CORE_STORE_OP:
-        break;
-      case MEMORY_BARRIER_OP:
-        break;
-      default:
-        return false;
+    virtual bool can_issue( const warp_inst_t &inst ) const
+    {
+        switch(inst.op) {
+        case LOAD_OP: break;
+        case TENSOR_CORE_LOAD_OP: break;
+        case STORE_OP: break;
+        case TENSOR_CORE_STORE_OP: break;
+        case MEMORY_BARRIER_OP: break;
+        default: return false;
+        }
+        return m_dispatch_reg->empty();
     }
-    return m_dispatch_reg->empty();
-  }
 
-  virtual void active_lanes_in_pipeline();
-  virtual bool stallable() const { return true; }
-  bool response_buffer_full() const;
-  void print(FILE *fout) const;
-  void print_cache_stats(FILE *fp, unsigned &dl1_accesses,
-                         unsigned &dl1_misses);
-  void get_cache_stats(unsigned &read_accesses, unsigned &write_accesses,
-                       unsigned &read_misses, unsigned &write_misses,
-                       unsigned cache_type);
-  void get_cache_stats(cache_stats &cs);
+    virtual void active_lanes_in_pipeline();
+    virtual bool stallable() const { return true; }
+    bool response_buffer_full() const;
+    void print(FILE *fout) const;
+    void print_cache_stats( FILE *fp, unsigned& dl1_accesses, unsigned& dl1_misses );
+    void get_cache_stats(unsigned &read_accesses, unsigned &write_accesses, unsigned &read_misses, unsigned &write_misses, unsigned cache_type);
+    void get_cache_stats(cache_stats &cs);
 
-  void get_L1D_sub_stats(struct cache_sub_stats &css) const;
-  void get_L1C_sub_stats(struct cache_sub_stats &css) const;
-  void get_L1T_sub_stats(struct cache_sub_stats &css) const;
+    void get_L1D_sub_stats(struct cache_sub_stats &css) const;
+    void get_L1C_sub_stats(struct cache_sub_stats &css) const;
+    void get_L1T_sub_stats(struct cache_sub_stats &css) const;
 
- protected:
-  ldst_unit(mem_fetch_interface *icnt,
-            shader_core_mem_fetch_allocator *mf_allocator,
-            shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
-            Scoreboard *scoreboard, const shader_core_config *config,
-            const memory_config *mem_config, shader_core_stats *stats,
-            unsigned sid, unsigned tpc, l1_cache *new_l1d_cache);
-  void init(mem_fetch_interface *icnt,
-            shader_core_mem_fetch_allocator *mf_allocator,
-            shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
-            Scoreboard *scoreboard, const shader_core_config *config,
-            const memory_config *mem_config, shader_core_stats *stats,
-            unsigned sid, unsigned tpc);
+protected:
+    ldst_unit( mem_fetch_interface *icnt,
+               shader_core_mem_fetch_allocator *mf_allocator,
+               shader_core_ctx *core, 
+               opndcoll_rfu_t *operand_collector,
+               Scoreboard *scoreboard,
+               const shader_core_config *config,
+               const memory_config *mem_config,  
+               shader_core_stats *stats,
+               unsigned sid,
+               unsigned tpc,
+               l1_cache* new_l1d_cache );
+    void init( mem_fetch_interface *icnt,
+               shader_core_mem_fetch_allocator *mf_allocator,
+               shader_core_ctx *core, 
+               opndcoll_rfu_t *operand_collector,
+               Scoreboard *scoreboard,
+               const shader_core_config *config,
+               const memory_config *mem_config,  
+               shader_core_stats *stats,
+               unsigned sid,
+               unsigned tpc );
 
- protected:
-  bool shared_cycle(warp_inst_t &inst, mem_stage_stall_type &rc_fail,
-                    mem_stage_access_type &fail_type);
-  bool constant_cycle(warp_inst_t &inst, mem_stage_stall_type &rc_fail,
-                      mem_stage_access_type &fail_type);
-  bool texture_cycle(warp_inst_t &inst, mem_stage_stall_type &rc_fail,
-                     mem_stage_access_type &fail_type);
-  bool memory_cycle(warp_inst_t &inst, mem_stage_stall_type &rc_fail,
-                    mem_stage_access_type &fail_type);
+protected:
+   bool shared_cycle( warp_inst_t &inst, mem_stage_stall_type &rc_fail, mem_stage_access_type &fail_type);
+   bool constant_cycle( warp_inst_t &inst, mem_stage_stall_type &rc_fail, mem_stage_access_type &fail_type);
+   bool texture_cycle( warp_inst_t &inst, mem_stage_stall_type &rc_fail, mem_stage_access_type &fail_type);
+   bool memory_cycle( warp_inst_t &inst, mem_stage_stall_type &rc_fail, mem_stage_access_type &fail_type);
 
-  virtual mem_stage_stall_type process_cache_access(
-      cache_t *cache, new_addr_type address, warp_inst_t &inst,
-      std::list<cache_event> &events, mem_fetch *mf,
-      enum cache_request_status status);
-  mem_stage_stall_type process_memory_access_queue(cache_t *cache,
-                                                   warp_inst_t &inst);
-  mem_stage_stall_type process_memory_access_queue_l1cache(l1_cache *cache,
-                                                           warp_inst_t &inst);
+   virtual mem_stage_stall_type process_cache_access( cache_t* cache,
+                                                      new_addr_type address,
+                                                      warp_inst_t &inst,
+                                                      std::list<cache_event>& events,
+                                                      mem_fetch *mf,
+                                                      enum cache_request_status status );
+   mem_stage_stall_type process_memory_access_queue( cache_t *cache, warp_inst_t &inst );
+   mem_stage_stall_type process_memory_access_queue_l1cache( l1_cache *cache, warp_inst_t &inst );
 
-  const memory_config *m_memory_config;
-  class mem_fetch_interface *m_icnt;
-  shader_core_mem_fetch_allocator *m_mf_allocator;
-  class shader_core_ctx *m_core;
-  unsigned m_sid;
-  unsigned m_tpc;
+   const memory_config *m_memory_config;
+   class mem_fetch_interface *m_icnt;
+   shader_core_mem_fetch_allocator *m_mf_allocator;
+   class shader_core_ctx *m_core;
+   unsigned m_sid;
+   unsigned m_tpc;
 
-  tex_cache *m_L1T;        // texture cache
-  read_only_cache *m_L1C;  // constant cache
-  l1_cache *m_L1D;         // data cache
-  std::map<unsigned /*warp_id*/,
-           std::map<unsigned /*regnum*/, unsigned /*count*/>>
-      m_pending_writes;
-  std::list<mem_fetch *> m_response_fifo;
-  opndcoll_rfu_t *m_operand_collector;
-  Scoreboard *m_scoreboard;
+   tex_cache *m_L1T; // texture cache
+   read_only_cache *m_L1C; // constant cache
+   l1_cache *m_L1D; // data cache
+   std::map<unsigned/*warp_id*/, std::map<unsigned/*regnum*/,unsigned/*count*/> > m_pending_writes;
+   std::list<mem_fetch*> m_response_fifo;
+   opndcoll_rfu_t *m_operand_collector;
+   Scoreboard *m_scoreboard;
 
-  mem_fetch *m_next_global;
-  warp_inst_t m_next_wb;
-  unsigned m_writeback_arb;  // round-robin arbiter for writeback contention
-                             // between L1T, L1C, shared
-  unsigned m_num_writeback_clients;
+   mem_fetch *m_next_global;
+   warp_inst_t m_next_wb;
+   unsigned m_writeback_arb; // round-robin arbiter for writeback contention between L1T, L1C, shared
+   unsigned m_num_writeback_clients;
 
-  enum mem_stage_stall_type m_mem_rc;
+   enum mem_stage_stall_type m_mem_rc;
 
-  shader_core_stats *m_stats;
+   shader_core_stats *m_stats; 
 
-  // for debugging
-  unsigned long long m_last_inst_gpu_sim_cycle;
-  unsigned long long m_last_inst_gpu_tot_sim_cycle;
+   // for debugging
+   unsigned long long m_last_inst_gpu_sim_cycle;
+   unsigned long long m_last_inst_gpu_tot_sim_cycle;
 
-  std::vector<std::deque<mem_fetch *>> l1_latency_queue;
-  void L1_latency_queue_cycle();
+   std::vector<std::deque<mem_fetch* >> l1_latency_queue;
+   void L1_latency_queue_cycle();
 };
 
 enum pipeline_stage_name_t {
-  ID_OC_SP = 0,
-  ID_OC_DP,
-  ID_OC_INT,
-  ID_OC_SFU,
-  ID_OC_MEM,
-  OC_EX_SP,
-  OC_EX_DP,
-  OC_EX_INT,
-  OC_EX_SFU,
-  OC_EX_MEM,
-  EX_WB,
-  ID_OC_TENSOR_CORE,
-  OC_EX_TENSOR_CORE,
-  N_PIPELINE_STAGES
+    ID_OC_SP=0,
+	ID_OC_DP,
+	ID_OC_INT,
+    ID_OC_SFU,  
+    ID_OC_MEM,  
+    OC_EX_SP,
+	OC_EX_DP,
+	OC_EX_INT,
+    OC_EX_SFU,
+    OC_EX_MEM,
+    EX_WB,
+    ID_OC_TENSOR_CORE,  
+    OC_EX_TENSOR_CORE,
+    N_PIPELINE_STAGES 
+    };
+
+const char* const pipeline_stage_name_decode[] = {
+    "ID_OC_SP",
+	"ID_OC_DP",
+	"ID_OC_INT",
+    "ID_OC_SFU",  
+    "ID_OC_MEM",  
+    "OC_EX_SP",
+	"OC_EX_DP",
+	"OC_EX_INT",
+    "OC_EX_SFU",
+    "OC_EX_MEM",
+    "EX_WB",
+    "ID_OC_TENSOR_CORE",  
+    "OC_EX_TENSOR_CORE",
+    "N_PIPELINE_STAGES" 
 };
 
-const char *const pipeline_stage_name_decode[] = {
-    "ID_OC_SP",          "ID_OC_DP",         "ID_OC_INT", "ID_OC_SFU",
-    "ID_OC_MEM",         "OC_EX_SP",         "OC_EX_DP",  "OC_EX_INT",
-    "OC_EX_SFU",         "OC_EX_MEM",        "EX_WB",     "ID_OC_TENSOR_CORE",
-    "OC_EX_TENSOR_CORE", "N_PIPELINE_STAGES"};
-
-class shader_core_config : public core_config {
- public:
-  shader_core_config(gpgpu_context *ctx) : core_config(ctx) {
-    pipeline_widths_string = NULL;
-    gpgpu_ctx = ctx;
-  }
-
-  void init() {
-    int ntok = sscanf(gpgpu_shader_core_pipeline_opt, "%d:%d",
-                      &n_thread_per_shader, &warp_size);
-    if (ntok != 2) {
-      printf(
-          "GPGPU-Sim uArch: error while parsing configuration string "
-          "gpgpu_shader_core_pipeline_opt\n");
-      abort();
+class shader_core_config : public core_config
+{
+    public:
+    shader_core_config(gpgpu_context* ctx):core_config(ctx){
+	pipeline_widths_string = NULL;
+	gpgpu_ctx = ctx;
     }
 
-    char *toks = new char[100];
-    char *tokd = toks;
-    strcpy(toks, pipeline_widths_string);
+    void init()
+    {
+        int ntok = sscanf(gpgpu_shader_core_pipeline_opt,"%d:%d", 
+                          &n_thread_per_shader,
+                          &warp_size);
+        if(ntok != 2) {
+           printf("GPGPU-Sim uArch: error while parsing configuration string gpgpu_shader_core_pipeline_opt\n");
+           abort();
+	}
 
-    toks = strtok(toks, ",");
+	char* toks = new char[100];
+	char* tokd = toks;
+	strcpy(toks,pipeline_widths_string);
+                                  
+	toks = strtok(toks,",");
 
-    /*	Removing the tensorcore pipeline while reading the config files if the
-       tensor core is not available.
-            If we won't remove it, old regression will be broken.
-            So to support the legacy config files it's best to handle in this
-       way.
-     */
-    int num_config_to_read = N_PIPELINE_STAGES - 2 * (!gpgpu_tensor_core_avail);
+	/*	Removing the tensorcore pipeline while reading the config files if the tensor core is not available.
+	 	If we won't remove it, old regression will be broken.
+		So to support the legacy config files it's best to handle in this way.
+         */  
+	int num_config_to_read= N_PIPELINE_STAGES - 2 * (!gpgpu_tensor_core_avail);
 
-    for (int i = 0; i < num_config_to_read; i++) {
-      assert(toks);
-      ntok = sscanf(toks, "%d", &pipe_widths[i]);
-      assert(ntok == 1);
-      toks = strtok(NULL, ",");
+        for (int i = 0; i < num_config_to_read; i++) { 
+	    assert(toks);
+	    ntok = sscanf(toks,"%d", &pipe_widths[i]);
+	    assert(ntok == 1); 
+	    toks = strtok(NULL,",");
+	}
+
+	delete[] tokd;
+	
+        if (n_thread_per_shader > MAX_THREAD_PER_SM) {
+           printf("GPGPU-Sim uArch: Error ** increase MAX_THREAD_PER_SM in abstract_hardware_model.h from %u to %u\n", 
+                  MAX_THREAD_PER_SM, n_thread_per_shader);
+           abort();
+        }
+        max_warps_per_shader =  n_thread_per_shader/warp_size;
+        assert( !(n_thread_per_shader % warp_size) );
+
+        set_pipeline_latency();
+        
+	m_L1I_config.init(m_L1I_config.m_config_string,FuncCachePreferNone);
+        m_L1T_config.init(m_L1T_config.m_config_string,FuncCachePreferNone);
+        m_L1C_config.init(m_L1C_config.m_config_string,FuncCachePreferNone);
+        m_L1D_config.init(m_L1D_config.m_config_string,FuncCachePreferNone);
+        gpgpu_cache_texl1_linesize = m_L1T_config.get_line_sz();
+        gpgpu_cache_constl1_linesize = m_L1C_config.get_line_sz();
+        m_valid = true;
     }
+    void reg_options(class OptionParser * opp );
+    unsigned max_cta( const kernel_info_t &k ) const;
+    unsigned num_shader() const { return n_simt_clusters*n_simt_cores_per_cluster; }
+    unsigned sid_to_cluster( unsigned sid ) const { return sid / n_simt_cores_per_cluster; }
+    unsigned sid_to_cid( unsigned sid )     const { return sid % n_simt_cores_per_cluster; }
+    unsigned cid_to_sid( unsigned cid, unsigned cluster_id ) const { return cluster_id*n_simt_cores_per_cluster + cid; }
+    void set_pipeline_latency();
 
-    delete[] tokd;
+    // backward pointer
+    class gpgpu_context* gpgpu_ctx;
+// data
+    char *gpgpu_shader_core_pipeline_opt;
+    bool gpgpu_perfect_mem;
+    bool gpgpu_clock_gated_reg_file;
+    bool gpgpu_clock_gated_lanes;
+    enum divergence_support_t model;
+    unsigned n_thread_per_shader;
+    unsigned n_regfile_gating_group;
+    unsigned max_warps_per_shader; 
+    unsigned max_cta_per_core; //Limit on number of concurrent CTAs in shader core
+    unsigned max_barriers_per_cta;
+    char * gpgpu_scheduler_string;
+    unsigned gpgpu_shmem_per_block;
+    unsigned gpgpu_registers_per_block;
+    char* pipeline_widths_string;
+    int pipe_widths[N_PIPELINE_STAGES];
 
-    if (n_thread_per_shader > MAX_THREAD_PER_SM) {
-      printf(
-          "GPGPU-Sim uArch: Error ** increase MAX_THREAD_PER_SM in "
-          "abstract_hardware_model.h from %u to %u\n",
-          MAX_THREAD_PER_SM, n_thread_per_shader);
-      abort();
-    }
-    max_warps_per_shader = n_thread_per_shader / warp_size;
-    assert(!(n_thread_per_shader % warp_size));
+    mutable cache_config m_L1I_config;
+    mutable cache_config m_L1T_config;
+    mutable cache_config m_L1C_config;
+    mutable l1d_cache_config m_L1D_config;
 
-    set_pipeline_latency();
+    bool gpgpu_dwf_reg_bankconflict;
 
-    m_L1I_config.init(m_L1I_config.m_config_string, FuncCachePreferNone);
-    m_L1T_config.init(m_L1T_config.m_config_string, FuncCachePreferNone);
-    m_L1C_config.init(m_L1C_config.m_config_string, FuncCachePreferNone);
-    m_L1D_config.init(m_L1D_config.m_config_string, FuncCachePreferNone);
-    gpgpu_cache_texl1_linesize = m_L1T_config.get_line_sz();
-    gpgpu_cache_constl1_linesize = m_L1C_config.get_line_sz();
-    m_valid = true;
-  }
-  void reg_options(class OptionParser *opp);
-  unsigned max_cta(const kernel_info_t &k) const;
-  unsigned num_shader() const {
-    return n_simt_clusters * n_simt_cores_per_cluster;
-  }
-  unsigned sid_to_cluster(unsigned sid) const {
-    return sid / n_simt_cores_per_cluster;
-  }
-  unsigned sid_to_cid(unsigned sid) const {
-    return sid % n_simt_cores_per_cluster;
-  }
-  unsigned cid_to_sid(unsigned cid, unsigned cluster_id) const {
-    return cluster_id * n_simt_cores_per_cluster + cid;
-  }
-  void set_pipeline_latency();
+    unsigned gpgpu_num_sched_per_core;
+    int gpgpu_max_insn_issue_per_warp;
+    bool gpgpu_dual_issue_diff_exec_units;
 
-  // backward pointer
-  class gpgpu_context *gpgpu_ctx;
-  // data
-  char *gpgpu_shader_core_pipeline_opt;
-  bool gpgpu_perfect_mem;
-  bool gpgpu_clock_gated_reg_file;
-  bool gpgpu_clock_gated_lanes;
-  enum divergence_support_t model;
-  unsigned n_thread_per_shader;
-  unsigned n_regfile_gating_group;
-  unsigned max_warps_per_shader;
-  unsigned
-      max_cta_per_core;  // Limit on number of concurrent CTAs in shader core
-  unsigned max_barriers_per_cta;
-  char *gpgpu_scheduler_string;
-  unsigned gpgpu_shmem_per_block;
-  unsigned gpgpu_registers_per_block;
-  char *pipeline_widths_string;
-  int pipe_widths[N_PIPELINE_STAGES];
+    //op collector
+    bool enable_specialized_operand_collector;
+    int gpgpu_operand_collector_num_units_sp;
+    int gpgpu_operand_collector_num_units_dp;
+    int gpgpu_operand_collector_num_units_sfu;
+    int gpgpu_operand_collector_num_units_tensor_core;
+    int gpgpu_operand_collector_num_units_mem;
+    int gpgpu_operand_collector_num_units_gen;
+    int gpgpu_operand_collector_num_units_int;
 
-  mutable cache_config m_L1I_config;
-  mutable cache_config m_L1T_config;
-  mutable cache_config m_L1C_config;
-  mutable l1d_cache_config m_L1D_config;
+    unsigned int gpgpu_operand_collector_num_in_ports_sp;
+    unsigned int gpgpu_operand_collector_num_in_ports_dp;
+    unsigned int gpgpu_operand_collector_num_in_ports_sfu;
+    unsigned int gpgpu_operand_collector_num_in_ports_tensor_core;
+    unsigned int gpgpu_operand_collector_num_in_ports_mem;
+    unsigned int gpgpu_operand_collector_num_in_ports_gen;
+    unsigned int gpgpu_operand_collector_num_in_ports_int;
 
-  bool gpgpu_dwf_reg_bankconflict;
+    unsigned int gpgpu_operand_collector_num_out_ports_sp;
+    unsigned int gpgpu_operand_collector_num_out_ports_dp;
+    unsigned int gpgpu_operand_collector_num_out_ports_sfu;
+    unsigned int gpgpu_operand_collector_num_out_ports_tensor_core;
+    unsigned int gpgpu_operand_collector_num_out_ports_mem;
+    unsigned int gpgpu_operand_collector_num_out_ports_gen;
+    unsigned int gpgpu_operand_collector_num_out_ports_int;
 
-  unsigned gpgpu_num_sched_per_core;
-  int gpgpu_max_insn_issue_per_warp;
-  bool gpgpu_dual_issue_diff_exec_units;
+    int gpgpu_num_sp_units;
+    int gpgpu_tensor_core_avail;
+    int gpgpu_num_dp_units;
+    int gpgpu_num_sfu_units;
+    int gpgpu_num_tensor_core_units;
+    int gpgpu_num_mem_units;
+    int gpgpu_num_int_units;
 
-  // op collector
-  bool enable_specialized_operand_collector;
-  int gpgpu_operand_collector_num_units_sp;
-  int gpgpu_operand_collector_num_units_dp;
-  int gpgpu_operand_collector_num_units_sfu;
-  int gpgpu_operand_collector_num_units_tensor_core;
-  int gpgpu_operand_collector_num_units_mem;
-  int gpgpu_operand_collector_num_units_gen;
-  int gpgpu_operand_collector_num_units_int;
+    //Shader core resources
+    unsigned gpgpu_shader_registers;
+    int gpgpu_warpdistro_shader;
+    int gpgpu_warp_issue_shader;
+    unsigned gpgpu_num_reg_banks;
+    bool gpgpu_reg_bank_use_warp_id;
+    bool gpgpu_local_mem_map;
+    bool gpgpu_ignore_resources_limitation;
+    bool sub_core_model;
+    
+    unsigned max_sp_latency;
+    unsigned max_int_latency;
+    unsigned max_sfu_latency;
+    unsigned max_dp_latency;
+    unsigned max_tensor_core_latency;
+    
+    unsigned n_simt_cores_per_cluster;
+    unsigned n_simt_clusters;
+    unsigned n_simt_ejection_buffer_size;
+    unsigned ldst_unit_response_queue_size;
 
-  unsigned int gpgpu_operand_collector_num_in_ports_sp;
-  unsigned int gpgpu_operand_collector_num_in_ports_dp;
-  unsigned int gpgpu_operand_collector_num_in_ports_sfu;
-  unsigned int gpgpu_operand_collector_num_in_ports_tensor_core;
-  unsigned int gpgpu_operand_collector_num_in_ports_mem;
-  unsigned int gpgpu_operand_collector_num_in_ports_gen;
-  unsigned int gpgpu_operand_collector_num_in_ports_int;
+    int simt_core_sim_order; 
+    
+    unsigned smem_latency;
 
-  unsigned int gpgpu_operand_collector_num_out_ports_sp;
-  unsigned int gpgpu_operand_collector_num_out_ports_dp;
-  unsigned int gpgpu_operand_collector_num_out_ports_sfu;
-  unsigned int gpgpu_operand_collector_num_out_ports_tensor_core;
-  unsigned int gpgpu_operand_collector_num_out_ports_mem;
-  unsigned int gpgpu_operand_collector_num_out_ports_gen;
-  unsigned int gpgpu_operand_collector_num_out_ports_int;
+    unsigned mem2device(unsigned memid) const { return memid + n_simt_clusters; }
 
-  int gpgpu_num_sp_units;
-  int gpgpu_tensor_core_avail;
-  int gpgpu_num_dp_units;
-  int gpgpu_num_sfu_units;
-  int gpgpu_num_tensor_core_units;
-  int gpgpu_num_mem_units;
-  int gpgpu_num_int_units;
+    //Jin: concurrent kernel on sm
+    bool gpgpu_concurrent_kernel_sm;
 
-  // Shader core resources
-  unsigned gpgpu_shader_registers;
-  int gpgpu_warpdistro_shader;
-  int gpgpu_warp_issue_shader;
-  unsigned gpgpu_num_reg_banks;
-  bool gpgpu_reg_bank_use_warp_id;
-  bool gpgpu_local_mem_map;
-  bool gpgpu_ignore_resources_limitation;
-  bool sub_core_model;
+    bool adpative_volta_cache_config;
 
-  unsigned max_sp_latency;
-  unsigned max_int_latency;
-  unsigned max_sfu_latency;
-  unsigned max_dp_latency;
-  unsigned max_tensor_core_latency;
-
-  unsigned n_simt_cores_per_cluster;
-  unsigned n_simt_clusters;
-  unsigned n_simt_ejection_buffer_size;
-  unsigned ldst_unit_response_queue_size;
-
-  int simt_core_sim_order;
-
-  unsigned smem_latency;
-
-  unsigned mem2device(unsigned memid) const { return memid + n_simt_clusters; }
-
-  // Jin: concurrent kernel on sm
-  bool gpgpu_concurrent_kernel_sm;
-
-  bool adpative_volta_cache_config;
 };
 
 struct shader_core_stats_pod {
-  void *shader_core_stats_pod_start[0];  // DO NOT MOVE FROM THE TOP - spaceless
-                                         // pointer to the start of this
-                                         // structure
-  unsigned long long *shader_cycles;
-  unsigned *m_num_sim_insn;   // number of scalar thread instructions committed
-                              // by this shader core
-  unsigned *m_num_sim_winsn;  // number of warp instructions committed by this
-                              // shader core
-  unsigned *m_last_num_sim_insn;
-  unsigned *m_last_num_sim_winsn;
-  unsigned *
-      m_num_decoded_insn;  // number of instructions decoded by this shader core
-  float *m_pipeline_duty_cycle;
-  unsigned *m_num_FPdecoded_insn;
-  unsigned *m_num_INTdecoded_insn;
-  unsigned *m_num_storequeued_insn;
-  unsigned *m_num_loadqueued_insn;
-  unsigned *m_num_ialu_acesses;
-  unsigned *m_num_fp_acesses;
-  unsigned *m_num_imul_acesses;
-  unsigned *m_num_tex_inst;
-  unsigned *m_num_fpmul_acesses;
-  unsigned *m_num_idiv_acesses;
-  unsigned *m_num_fpdiv_acesses;
-  unsigned *m_num_sp_acesses;
-  unsigned *m_num_sfu_acesses;
-  unsigned *m_num_tensor_core_acesses;
-  unsigned *m_num_trans_acesses;
-  unsigned *m_num_mem_acesses;
-  unsigned *m_num_sp_committed;
-  unsigned *m_num_tlb_hits;
-  unsigned *m_num_tlb_accesses;
-  unsigned *m_num_sfu_committed;
-  unsigned *m_num_tensor_core_committed;
-  unsigned *m_num_mem_committed;
-  unsigned *m_read_regfile_acesses;
-  unsigned *m_write_regfile_acesses;
-  unsigned *m_non_rf_operands;
-  unsigned *m_num_imul24_acesses;
-  unsigned *m_num_imul32_acesses;
-  unsigned *m_active_sp_lanes;
-  unsigned *m_active_sfu_lanes;
-  unsigned *m_active_tensor_core_lanes;
-  unsigned *m_active_fu_lanes;
-  unsigned *m_active_fu_mem_lanes;
-  unsigned *m_n_diverge;  // number of divergence occurring in this shader
-  unsigned gpgpu_n_load_insn;
-  unsigned gpgpu_n_store_insn;
-  unsigned gpgpu_n_shmem_insn;
-  unsigned gpgpu_n_sstarr_insn;
-  unsigned gpgpu_n_tex_insn;
-  unsigned gpgpu_n_const_insn;
-  unsigned gpgpu_n_param_insn;
-  unsigned gpgpu_n_shmem_bkconflict;
-  unsigned gpgpu_n_cache_bkconflict;
-  int gpgpu_n_intrawarp_mshr_merge;
-  unsigned gpgpu_n_cmem_portconflict;
-  unsigned gpu_stall_shd_mem_breakdown[N_MEM_STAGE_ACCESS_TYPE]
-                                      [N_MEM_STAGE_STALL_TYPE];
-  unsigned gpu_reg_bank_conflict_stalls;
-  unsigned *shader_cycle_distro;
-  unsigned *last_shader_cycle_distro;
-  unsigned *num_warps_issuable;
-  unsigned gpgpu_n_stall_shd_mem;
-  unsigned *single_issue_nums;
-  unsigned *dual_issue_nums;
 
-  // memory access classification
-  int gpgpu_n_mem_read_local;
-  int gpgpu_n_mem_write_local;
-  int gpgpu_n_mem_texture;
-  int gpgpu_n_mem_const;
-  int gpgpu_n_mem_read_global;
-  int gpgpu_n_mem_write_global;
-  int gpgpu_n_mem_read_inst;
+	void* shader_core_stats_pod_start[0]; // DO NOT MOVE FROM THE TOP - spaceless pointer to the start of this structure
+	unsigned long long *shader_cycles;
+    unsigned *m_num_sim_insn; // number of scalar thread instructions committed by this shader core
+    unsigned *m_num_sim_winsn; // number of warp instructions committed by this shader core
+	unsigned *m_last_num_sim_insn;
+	unsigned *m_last_num_sim_winsn;
+    unsigned *m_num_decoded_insn; // number of instructions decoded by this shader core
+    float *m_pipeline_duty_cycle;
+    unsigned *m_num_FPdecoded_insn;
+    unsigned *m_num_INTdecoded_insn;
+    unsigned *m_num_storequeued_insn;
+    unsigned *m_num_loadqueued_insn;
+    unsigned *m_num_ialu_acesses;
+    unsigned *m_num_fp_acesses;
+    unsigned *m_num_imul_acesses;
+    unsigned *m_num_tex_inst;
+    unsigned *m_num_fpmul_acesses;
+    unsigned *m_num_idiv_acesses;
+    unsigned *m_num_fpdiv_acesses;
+    unsigned *m_num_sp_acesses;
+    unsigned *m_num_sfu_acesses;
+    unsigned *m_num_tensor_core_acesses;
+    unsigned *m_num_trans_acesses;
+    unsigned *m_num_mem_acesses;
+    unsigned *m_num_sp_committed;
+    unsigned *m_num_tlb_hits;
+    unsigned *m_num_tlb_accesses;
+    unsigned *m_num_sfu_committed;
+    unsigned *m_num_tensor_core_committed;
+    unsigned *m_num_mem_committed;
+    unsigned *m_read_regfile_acesses;
+    unsigned *m_write_regfile_acesses;
+    unsigned *m_non_rf_operands;
+    unsigned *m_num_imul24_acesses;
+    unsigned *m_num_imul32_acesses;
+    unsigned *m_active_sp_lanes;
+    unsigned *m_active_sfu_lanes;
+    unsigned *m_active_tensor_core_lanes;
+    unsigned *m_active_fu_lanes;
+    unsigned *m_active_fu_mem_lanes;
+    unsigned *m_n_diverge;    // number of divergence occurring in this shader
+    unsigned gpgpu_n_load_insn;
+    unsigned gpgpu_n_store_insn;
+    unsigned gpgpu_n_shmem_insn;
+    unsigned gpgpu_n_sstarr_insn;
+    unsigned gpgpu_n_tex_insn;
+    unsigned gpgpu_n_const_insn;
+    unsigned gpgpu_n_param_insn;
+    unsigned gpgpu_n_shmem_bkconflict;
+    unsigned gpgpu_n_cache_bkconflict;
+    int      gpgpu_n_intrawarp_mshr_merge;
+    unsigned gpgpu_n_cmem_portconflict;
+    unsigned gpu_stall_shd_mem_breakdown[N_MEM_STAGE_ACCESS_TYPE][N_MEM_STAGE_STALL_TYPE];
+    unsigned gpu_reg_bank_conflict_stalls;
+    unsigned *shader_cycle_distro;
+    unsigned *last_shader_cycle_distro;
+    unsigned *num_warps_issuable;
+    unsigned gpgpu_n_stall_shd_mem;
+    unsigned* single_issue_nums;
+    unsigned* dual_issue_nums;
 
-  int gpgpu_n_mem_l2_writeback;
-  int gpgpu_n_mem_l1_write_allocate;
-  int gpgpu_n_mem_l2_write_allocate;
+    //memory access classification
+    int gpgpu_n_mem_read_local;
+    int gpgpu_n_mem_write_local;
+    int gpgpu_n_mem_texture;
+    int gpgpu_n_mem_const;
+    int gpgpu_n_mem_read_global;
+    int gpgpu_n_mem_write_global;
+    int gpgpu_n_mem_read_inst;
+    
+    int gpgpu_n_mem_l2_writeback;
+    int gpgpu_n_mem_l1_write_allocate; 
+    int gpgpu_n_mem_l2_write_allocate;
 
-  unsigned made_write_mfs;
-  unsigned made_read_mfs;
+    unsigned made_write_mfs;
+    unsigned made_read_mfs;
 
-  unsigned *gpgpu_n_shmem_bank_access;
-  long *n_simt_to_mem;  // Interconnect power stats
-  long *n_mem_to_simt;
+    unsigned *gpgpu_n_shmem_bank_access;
+    long *n_simt_to_mem; // Interconnect power stats
+    long *n_mem_to_simt;
 };
 
 class shader_core_stats : public shader_core_stats_pod {
- public:
-  shader_core_stats(const shader_core_config *config) {
-    m_config = config;
-    shader_core_stats_pod *pod = reinterpret_cast<shader_core_stats_pod *>(
-        this->shader_core_stats_pod_start);
-    memset(pod, 0, sizeof(shader_core_stats_pod));
-    shader_cycles = (unsigned long long *)calloc(config->num_shader(),
-                                                 sizeof(unsigned long long));
-    m_num_sim_insn = (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_num_sim_winsn =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_last_num_sim_winsn =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_last_num_sim_insn =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_pipeline_duty_cycle =
-        (float *)calloc(config->num_shader(), sizeof(float));
-    m_num_decoded_insn =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_num_FPdecoded_insn =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_num_storequeued_insn =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_num_loadqueued_insn =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_num_INTdecoded_insn =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_num_ialu_acesses =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_num_fp_acesses =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_num_tex_inst = (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_num_imul_acesses =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_num_imul24_acesses =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_num_imul32_acesses =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_num_fpmul_acesses =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_num_idiv_acesses =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_num_fpdiv_acesses =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_num_sp_acesses =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_num_sfu_acesses =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_num_tensor_core_acesses =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_num_trans_acesses =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_num_mem_acesses =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_num_sp_committed =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_num_tlb_hits = (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_num_tlb_accesses =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_active_sp_lanes =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_active_sfu_lanes =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_active_tensor_core_lanes =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_active_fu_lanes =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_active_fu_mem_lanes =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_num_sfu_committed =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_num_tensor_core_committed =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_num_mem_committed =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_read_regfile_acesses =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_write_regfile_acesses =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_non_rf_operands =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    m_n_diverge = (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
-    shader_cycle_distro =
-        (unsigned *)calloc(config->warp_size + 3, sizeof(unsigned));
-    last_shader_cycle_distro =
-        (unsigned *)calloc(m_config->warp_size + 3, sizeof(unsigned));
-    single_issue_nums =
-        (unsigned *)calloc(config->gpgpu_num_sched_per_core, sizeof(unsigned));
-    dual_issue_nums =
-        (unsigned *)calloc(config->gpgpu_num_sched_per_core, sizeof(unsigned));
+public:
+    shader_core_stats( const shader_core_config *config )
+    {
+        m_config = config;
+        shader_core_stats_pod *pod = reinterpret_cast< shader_core_stats_pod * > ( this->shader_core_stats_pod_start );
+        memset(pod,0,sizeof(shader_core_stats_pod));
+        shader_cycles=(unsigned long long *) calloc(config->num_shader(),sizeof(unsigned long long ));
+        m_num_sim_insn = (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_num_sim_winsn = (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_last_num_sim_winsn = (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_last_num_sim_insn = (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_pipeline_duty_cycle=(float*) calloc(config->num_shader(),sizeof(float));
+        m_num_decoded_insn = (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_num_FPdecoded_insn = (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_num_storequeued_insn=(unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_num_loadqueued_insn=(unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_num_INTdecoded_insn = (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_num_ialu_acesses = (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_num_fp_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_num_tex_inst= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_num_imul_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_num_imul24_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_num_imul32_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_num_fpmul_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_num_idiv_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_num_fpdiv_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_num_sp_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_num_sfu_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_num_tensor_core_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_num_trans_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_num_mem_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_num_sp_committed= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_num_tlb_hits=(unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_num_tlb_accesses=(unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_active_sp_lanes= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_active_sfu_lanes= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_active_tensor_core_lanes= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_active_fu_lanes= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_active_fu_mem_lanes= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_num_sfu_committed= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_num_tensor_core_committed= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_num_mem_committed= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_read_regfile_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_write_regfile_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_non_rf_operands=(unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        m_n_diverge = (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
+        shader_cycle_distro = (unsigned*) calloc(config->warp_size+3, sizeof(unsigned));
+        last_shader_cycle_distro = (unsigned*) calloc(m_config->warp_size+3, sizeof(unsigned));
+        single_issue_nums = (unsigned*) calloc(config->gpgpu_num_sched_per_core,sizeof(unsigned));
+        dual_issue_nums = (unsigned*) calloc(config->gpgpu_num_sched_per_core, sizeof(unsigned));
 
-    n_simt_to_mem = (long *)calloc(config->num_shader(), sizeof(long));
-    n_mem_to_simt = (long *)calloc(config->num_shader(), sizeof(long));
+        n_simt_to_mem = (long *)calloc(config->num_shader(), sizeof(long));
+        n_mem_to_simt = (long *)calloc(config->num_shader(), sizeof(long));
 
-    m_outgoing_traffic_stats = new traffic_breakdown("coretomem");
-    m_incoming_traffic_stats = new traffic_breakdown("memtocore");
+        m_outgoing_traffic_stats = new traffic_breakdown("coretomem"); 
+        m_incoming_traffic_stats = new traffic_breakdown("memtocore"); 
 
-    gpgpu_n_shmem_bank_access =
-        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+        gpgpu_n_shmem_bank_access = (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
 
-    m_shader_dynamic_warp_issue_distro.resize(config->num_shader());
-    m_shader_warp_slot_issue_distro.resize(config->num_shader());
-  }
+        m_shader_dynamic_warp_issue_distro.resize( config->num_shader() );
+        m_shader_warp_slot_issue_distro.resize( config->num_shader() );
+    }
 
-  ~shader_core_stats() {
-    delete m_outgoing_traffic_stats;
-    delete m_incoming_traffic_stats;
-    free(m_num_sim_insn);
-    free(m_num_sim_winsn);
-    free(m_n_diverge);
-    free(shader_cycle_distro);
-    free(last_shader_cycle_distro);
-  }
+    ~shader_core_stats()
+    {
+        delete m_outgoing_traffic_stats; 
+        delete m_incoming_traffic_stats; 
+        free(m_num_sim_insn); 
+        free(m_num_sim_winsn);
+        free(m_n_diverge); 
+        free(shader_cycle_distro);
+        free(last_shader_cycle_distro);
+    }
 
-  void new_grid() {}
+    void new_grid()
+    {
+    }
 
-  void event_warp_issued(unsigned s_id, unsigned warp_id, unsigned num_issued,
-                         unsigned dynamic_warp_id);
+    void event_warp_issued( unsigned s_id, unsigned warp_id, unsigned num_issued, unsigned dynamic_warp_id );
 
-  void visualizer_print(gzFile visualizer_file);
+    void visualizer_print( gzFile visualizer_file );
 
-  void print(FILE *fout) const;
+    void print( FILE *fout ) const;
 
-  const std::vector<std::vector<unsigned>> &get_dynamic_warp_issue() const {
-    return m_shader_dynamic_warp_issue_distro;
-  }
+    const std::vector< std::vector<unsigned> >& get_dynamic_warp_issue() const
+    {
+        return m_shader_dynamic_warp_issue_distro;
+    }
 
-  const std::vector<std::vector<unsigned>> &get_warp_slot_issue() const {
-    return m_shader_warp_slot_issue_distro;
-  }
+    const std::vector< std::vector<unsigned> >& get_warp_slot_issue() const
+    {
+        return m_shader_warp_slot_issue_distro;
+    }
 
- private:
-  const shader_core_config *m_config;
+private:
+    const shader_core_config *m_config;
 
-  traffic_breakdown *m_outgoing_traffic_stats;  // core to memory partitions
-  traffic_breakdown *m_incoming_traffic_stats;  // memory partition to core
+    traffic_breakdown *m_outgoing_traffic_stats; // core to memory partitions
+    traffic_breakdown *m_incoming_traffic_stats; // memory partition to core 
 
-  // Counts the instructions issued for each dynamic warp.
-  std::vector<std::vector<unsigned>> m_shader_dynamic_warp_issue_distro;
-  std::vector<unsigned> m_last_shader_dynamic_warp_issue_distro;
-  std::vector<std::vector<unsigned>> m_shader_warp_slot_issue_distro;
-  std::vector<unsigned> m_last_shader_warp_slot_issue_distro;
+    // Counts the instructions issued for each dynamic warp.
+    std::vector< std::vector<unsigned> > m_shader_dynamic_warp_issue_distro;
+    std::vector<unsigned> m_last_shader_dynamic_warp_issue_distro;
+    std::vector< std::vector<unsigned> > m_shader_warp_slot_issue_distro;
+    std::vector<unsigned> m_last_shader_warp_slot_issue_distro;
 
-  friend class power_stat_t;
-  friend class shader_core_ctx;
-  friend class ldst_unit;
-  friend class simt_core_cluster;
-  friend class scheduler_unit;
-  friend class TwoLevelScheduler;
-  friend class LooseRoundRobbinScheduler;
+    friend class power_stat_t;
+    friend class shader_core_ctx;
+    friend class ldst_unit;
+    friend class simt_core_cluster;
+    friend class scheduler_unit;
+    friend class TwoLevelScheduler;
+    friend class LooseRoundRobbinScheduler;
 };
 
 class memory_config;
 class shader_core_mem_fetch_allocator : public mem_fetch_allocator {
- public:
-  shader_core_mem_fetch_allocator(unsigned core_id, unsigned cluster_id,
-                                  const memory_config *config) {
-    m_core_id = core_id;
-    m_cluster_id = cluster_id;
-    m_memory_config = config;
-  }
-  mem_fetch *alloc(new_addr_type addr, mem_access_type type, unsigned size,
-                   bool wr, unsigned long long cycle) const;
-  mem_fetch *alloc(const warp_inst_t &inst, const mem_access_t &access,
-                   unsigned long long cycle) const {
-    warp_inst_t inst_copy = inst;
-    mem_fetch *mf = new mem_fetch(
-        access, &inst_copy,
-        access.is_write() ? WRITE_PACKET_SIZE : READ_PACKET_SIZE,
-        inst.warp_id(), m_core_id, m_cluster_id, m_memory_config, cycle);
-    return mf;
-  }
+public:
+    shader_core_mem_fetch_allocator( unsigned core_id, unsigned cluster_id, const memory_config *config )
+    {
+    	m_core_id = core_id;
+    	m_cluster_id = cluster_id;
+    	m_memory_config = config;
+    }
+    mem_fetch *alloc( new_addr_type addr, mem_access_type type, unsigned size, bool wr, unsigned long long cycle ) const; 
+    mem_fetch *alloc( const warp_inst_t &inst, const mem_access_t &access, unsigned long long cycle ) const
+    {
+        warp_inst_t inst_copy = inst;
+        mem_fetch *mf = new mem_fetch(access, 
+                                      &inst_copy, 
+                                      access.is_write()?WRITE_PACKET_SIZE:READ_PACKET_SIZE,
+                                      inst.warp_id(),
+                                      m_core_id, 
+                                      m_cluster_id, 
+                                      m_memory_config,
+									  cycle);
+        return mf;
+    }
 
- private:
-  unsigned m_core_id;
-  unsigned m_cluster_id;
-  const memory_config *m_memory_config;
+private:
+    unsigned m_core_id;
+    unsigned m_cluster_id;
+    const memory_config *m_memory_config;
 };
 
 class shader_core_ctx : public core_t {
- public:
-  // creator:
-  shader_core_ctx(class gpgpu_sim *gpu, class simt_core_cluster *cluster,
-                  unsigned shader_id, unsigned tpc_id,
-                  const shader_core_config *config,
-                  const memory_config *mem_config, shader_core_stats *stats);
+public:
+    // creator:
+    shader_core_ctx( class gpgpu_sim *gpu,
+                     class simt_core_cluster *cluster,
+                     unsigned shader_id,
+                     unsigned tpc_id,
+                     const shader_core_config *config,
+                     const memory_config *mem_config,
+                     shader_core_stats *stats );
 
-  // used by simt_core_cluster:
-  // modifiers
-  void cycle();
-  void reinit(unsigned start_thread, unsigned end_thread,
-              bool reset_not_completed);
-  void issue_block2core(class kernel_info_t &kernel);
+// used by simt_core_cluster:
+    // modifiers
+    void cycle();
+    void reinit(unsigned start_thread, unsigned end_thread, bool reset_not_completed );
+    void issue_block2core( class kernel_info_t &kernel );
 
-  void cache_flush();
-  void cache_invalidate();
-  void accept_fetch_response(mem_fetch *mf);
-  void accept_ldst_unit_response(class mem_fetch *mf);
-  void broadcast_barrier_reduction(unsigned cta_id, unsigned bar_id,
-                                   warp_set_t warps);
-  void set_kernel(kernel_info_t *k) {
-    assert(k);
-    m_kernel = k;
-    //        k->inc_running();
-    printf("GPGPU-Sim uArch: Shader %d bind to kernel %u \'%s\'\n", m_sid,
-           m_kernel->get_uid(), m_kernel->name().c_str());
-  }
-
-  // accessors
-  bool fetch_unit_response_buffer_full() const;
-  bool ldst_unit_response_buffer_full() const;
-  unsigned get_not_completed() const { return m_not_completed; }
-  unsigned get_n_active_cta() const { return m_n_active_cta; }
-  unsigned isactive() const {
-    if (m_n_active_cta > 0)
-      return 1;
-    else
-      return 0;
-  }
-  kernel_info_t *get_kernel() { return m_kernel; }
-  unsigned get_sid() const { return m_sid; }
-
-  // used by functional simulation:
-  // modifiers
-  virtual void warp_exit(unsigned warp_id);
-
-  // accessors
-  virtual bool warp_waiting_at_barrier(unsigned warp_id) const;
-  void get_pdom_stack_top_info(unsigned tid, unsigned *pc, unsigned *rpc) const;
-  float get_current_occupancy(unsigned long long &active,
-                              unsigned long long &total) const;
-
-  // used by pipeline timing model components:
-  // modifiers
-  void mem_instruction_stats(const warp_inst_t &inst);
-  void decrement_atomic_count(unsigned wid, unsigned n);
-  void inc_store_req(unsigned warp_id) { m_warp[warp_id].inc_store_req(); }
-  void dec_inst_in_pipeline(unsigned warp_id) {
-    m_warp[warp_id].dec_inst_in_pipeline();
-  }  // also used in writeback()
-  void store_ack(class mem_fetch *mf);
-  bool warp_waiting_at_mem_barrier(unsigned warp_id);
-  void set_max_cta(const kernel_info_t &kernel);
-  void warp_inst_complete(const warp_inst_t &inst);
-
-  // accessors
-  std::list<unsigned> get_regs_written(const inst_t &fvt) const;
-  const shader_core_config *get_config() const { return m_config; }
-  void print_cache_stats(FILE *fp, unsigned &dl1_accesses,
-                         unsigned &dl1_misses);
-
-  void get_cache_stats(cache_stats &cs);
-  void get_L1I_sub_stats(struct cache_sub_stats &css) const;
-  void get_L1D_sub_stats(struct cache_sub_stats &css) const;
-  void get_L1C_sub_stats(struct cache_sub_stats &css) const;
-  void get_L1T_sub_stats(struct cache_sub_stats &css) const;
-
-  void get_icnt_power_stats(long &n_simt_to_mem, long &n_mem_to_simt) const;
-
-  // debug:
-  void display_simt_state(FILE *fout, int mask) const;
-  void display_pipeline(FILE *fout, int print_mem, int mask3bit) const;
-
-  void incload_stat() { m_stats->m_num_loadqueued_insn[m_sid]++; }
-  void incstore_stat() { m_stats->m_num_storequeued_insn[m_sid]++; }
-  void incialu_stat(unsigned active_count, double latency) {
-    if (m_config->gpgpu_clock_gated_lanes == false) {
-      m_stats->m_num_ialu_acesses[m_sid] =
-          m_stats->m_num_ialu_acesses[m_sid] + active_count * latency +
-          inactive_lanes_accesses_nonsfu(active_count, latency);
-    } else {
-      m_stats->m_num_ialu_acesses[m_sid] =
-          m_stats->m_num_ialu_acesses[m_sid] + active_count * latency;
+    void cache_flush();
+    void cache_invalidate();
+    void accept_fetch_response( mem_fetch *mf );
+    void accept_ldst_unit_response( class mem_fetch * mf );
+    void broadcast_barrier_reduction(unsigned cta_id, unsigned bar_id,warp_set_t warps);
+    void set_kernel( kernel_info_t *k ) 
+    {
+        assert(k);
+        m_kernel=k; 
+//        k->inc_running(); 
+        printf("GPGPU-Sim uArch: Shader %d bind to kernel %u \'%s\'\n", m_sid, m_kernel->get_uid(),
+                 m_kernel->name().c_str() );
     }
-  }
-  void inctex_stat(unsigned active_count, double latency) {
-    m_stats->m_num_tex_inst[m_sid] =
-        m_stats->m_num_tex_inst[m_sid] + active_count * latency;
-  }
-  void incimul_stat(unsigned active_count, double latency) {
-    if (m_config->gpgpu_clock_gated_lanes == false) {
-      m_stats->m_num_imul_acesses[m_sid] =
-          m_stats->m_num_imul_acesses[m_sid] + active_count * latency +
-          inactive_lanes_accesses_nonsfu(active_count, latency);
-    } else {
-      m_stats->m_num_imul_acesses[m_sid] =
-          m_stats->m_num_imul_acesses[m_sid] + active_count * latency;
+   
+    // accessors
+    bool fetch_unit_response_buffer_full() const;
+    bool ldst_unit_response_buffer_full() const;
+    unsigned get_not_completed() const { return m_not_completed; }
+    unsigned get_n_active_cta() const { return m_n_active_cta; }
+    unsigned isactive() const {if(m_n_active_cta>0) return 1; else return 0;}
+    kernel_info_t *get_kernel() { return m_kernel; }
+    unsigned get_sid() const {return m_sid;}
+
+// used by functional simulation:
+    // modifiers
+    virtual void warp_exit( unsigned warp_id );
+    
+    // accessors
+    virtual bool warp_waiting_at_barrier( unsigned warp_id ) const;
+    void get_pdom_stack_top_info( unsigned tid, unsigned *pc, unsigned *rpc ) const;
+    float get_current_occupancy( unsigned long long & active, unsigned long long & total ) const;
+
+// used by pipeline timing model components:
+    // modifiers
+    void mem_instruction_stats(const warp_inst_t &inst);
+    void decrement_atomic_count( unsigned wid, unsigned n );
+    void inc_store_req( unsigned warp_id) { m_warp[warp_id].inc_store_req(); }
+    void dec_inst_in_pipeline( unsigned warp_id ) { m_warp[warp_id].dec_inst_in_pipeline(); } // also used in writeback()
+    void store_ack( class mem_fetch *mf );
+    bool warp_waiting_at_mem_barrier( unsigned warp_id );
+    void set_max_cta( const kernel_info_t &kernel );
+    void warp_inst_complete(const warp_inst_t &inst);
+    
+    // accessors
+    std::list<unsigned> get_regs_written( const inst_t &fvt ) const;
+    const shader_core_config *get_config() const { return m_config; }
+    void print_cache_stats( FILE *fp, unsigned& dl1_accesses, unsigned& dl1_misses );
+
+    void get_cache_stats(cache_stats &cs);
+    void get_L1I_sub_stats(struct cache_sub_stats &css) const;
+    void get_L1D_sub_stats(struct cache_sub_stats &css) const;
+    void get_L1C_sub_stats(struct cache_sub_stats &css) const;
+    void get_L1T_sub_stats(struct cache_sub_stats &css) const;
+
+    void get_icnt_power_stats(long &n_simt_to_mem, long &n_mem_to_simt) const;
+
+// debug:
+    void display_simt_state(FILE *fout, int mask ) const;
+    void display_pipeline( FILE *fout, int print_mem, int mask3bit ) const;
+
+    void incload_stat() {m_stats->m_num_loadqueued_insn[m_sid]++;}
+    void incstore_stat() {m_stats->m_num_storequeued_insn[m_sid]++;}
+    void incialu_stat(unsigned active_count,double latency) {
+		if(m_config->gpgpu_clock_gated_lanes==false){
+		  m_stats->m_num_ialu_acesses[m_sid]=m_stats->m_num_ialu_acesses[m_sid]+active_count*latency
+		    + inactive_lanes_accesses_nonsfu(active_count, latency);
+		}else {
+        m_stats->m_num_ialu_acesses[m_sid]=m_stats->m_num_ialu_acesses[m_sid]+active_count*latency;
+		}
+	 }
+    void inctex_stat(unsigned active_count,double latency){
+    	m_stats->m_num_tex_inst[m_sid]=m_stats->m_num_tex_inst[m_sid]+active_count*latency;
     }
-  }
-  void incimul24_stat(unsigned active_count, double latency) {
-    if (m_config->gpgpu_clock_gated_lanes == false) {
-      m_stats->m_num_imul24_acesses[m_sid] =
-          m_stats->m_num_imul24_acesses[m_sid] + active_count * latency +
-          inactive_lanes_accesses_nonsfu(active_count, latency);
-    } else {
-      m_stats->m_num_imul24_acesses[m_sid] =
-          m_stats->m_num_imul24_acesses[m_sid] + active_count * latency;
-    }
-  }
-  void incimul32_stat(unsigned active_count, double latency) {
-    if (m_config->gpgpu_clock_gated_lanes == false) {
-      m_stats->m_num_imul32_acesses[m_sid] =
-          m_stats->m_num_imul32_acesses[m_sid] + active_count * latency +
-          inactive_lanes_accesses_sfu(active_count, latency);
-    } else {
-      m_stats->m_num_imul32_acesses[m_sid] =
-          m_stats->m_num_imul32_acesses[m_sid] + active_count * latency;
-    }
-    // printf("Int_Mul -- Active_count: %d\n",active_count);
-  }
-  void incidiv_stat(unsigned active_count, double latency) {
-    if (m_config->gpgpu_clock_gated_lanes == false) {
-      m_stats->m_num_idiv_acesses[m_sid] =
-          m_stats->m_num_idiv_acesses[m_sid] + active_count * latency +
-          inactive_lanes_accesses_sfu(active_count, latency);
-    } else {
-      m_stats->m_num_idiv_acesses[m_sid] =
-          m_stats->m_num_idiv_acesses[m_sid] + active_count * latency;
-    }
-  }
-  void incfpalu_stat(unsigned active_count, double latency) {
-    if (m_config->gpgpu_clock_gated_lanes == false) {
-      m_stats->m_num_fp_acesses[m_sid] =
-          m_stats->m_num_fp_acesses[m_sid] + active_count * latency +
-          inactive_lanes_accesses_nonsfu(active_count, latency);
-    } else {
-      m_stats->m_num_fp_acesses[m_sid] =
-          m_stats->m_num_fp_acesses[m_sid] + active_count * latency;
-    }
-  }
-  void incfpmul_stat(unsigned active_count, double latency) {
-    // printf("FP MUL stat increament\n");
-    if (m_config->gpgpu_clock_gated_lanes == false) {
-      m_stats->m_num_fpmul_acesses[m_sid] =
-          m_stats->m_num_fpmul_acesses[m_sid] + active_count * latency +
-          inactive_lanes_accesses_nonsfu(active_count, latency);
-    } else {
-      m_stats->m_num_fpmul_acesses[m_sid] =
-          m_stats->m_num_fpmul_acesses[m_sid] + active_count * latency;
-    }
-  }
-  void incfpdiv_stat(unsigned active_count, double latency) {
-    if (m_config->gpgpu_clock_gated_lanes == false) {
-      m_stats->m_num_fpdiv_acesses[m_sid] =
-          m_stats->m_num_fpdiv_acesses[m_sid] + active_count * latency +
-          inactive_lanes_accesses_sfu(active_count, latency);
-    } else {
-      m_stats->m_num_fpdiv_acesses[m_sid] =
-          m_stats->m_num_fpdiv_acesses[m_sid] + active_count * latency;
-    }
-  }
-  void inctrans_stat(unsigned active_count, double latency) {
-    if (m_config->gpgpu_clock_gated_lanes == false) {
-      m_stats->m_num_trans_acesses[m_sid] =
-          m_stats->m_num_trans_acesses[m_sid] + active_count * latency +
-          inactive_lanes_accesses_sfu(active_count, latency);
-    } else {
-      m_stats->m_num_trans_acesses[m_sid] =
-          m_stats->m_num_trans_acesses[m_sid] + active_count * latency;
-    }
-  }
+    void incimul_stat(unsigned active_count,double latency) {
+		if(m_config->gpgpu_clock_gated_lanes==false){
+		  m_stats->m_num_imul_acesses[m_sid]=m_stats->m_num_imul_acesses[m_sid]+active_count*latency
+		    + inactive_lanes_accesses_nonsfu(active_count, latency);
+		}else {
+        m_stats->m_num_imul_acesses[m_sid]=m_stats->m_num_imul_acesses[m_sid]+active_count*latency;
+		}
+	 }
+    void incimul24_stat(unsigned active_count,double latency) {
+      if(m_config->gpgpu_clock_gated_lanes==false){
+   		m_stats->m_num_imul24_acesses[m_sid]=m_stats->m_num_imul24_acesses[m_sid]+active_count*latency
+		    + inactive_lanes_accesses_nonsfu(active_count, latency);
+		}else {
+		  m_stats->m_num_imul24_acesses[m_sid]=m_stats->m_num_imul24_acesses[m_sid]+active_count*latency;
+		}
+	 }
+	 void incimul32_stat(unsigned active_count,double latency) {
+		if(m_config->gpgpu_clock_gated_lanes==false){
+		  m_stats->m_num_imul32_acesses[m_sid]=m_stats->m_num_imul32_acesses[m_sid]+active_count*latency
+			 + inactive_lanes_accesses_sfu(active_count, latency);			
+		}else{
+		  m_stats->m_num_imul32_acesses[m_sid]=m_stats->m_num_imul32_acesses[m_sid]+active_count*latency;
+		}
+		//printf("Int_Mul -- Active_count: %d\n",active_count);
+	 }
+	 void incidiv_stat(unsigned active_count,double latency) {
+		if(m_config->gpgpu_clock_gated_lanes==false){
+		  m_stats->m_num_idiv_acesses[m_sid]=m_stats->m_num_idiv_acesses[m_sid]+active_count*latency
+			 + inactive_lanes_accesses_sfu(active_count, latency); 
+		}else {
+		  m_stats->m_num_idiv_acesses[m_sid]=m_stats->m_num_idiv_acesses[m_sid]+active_count*latency;
+		}
+	 }
+	 void incfpalu_stat(unsigned active_count,double latency) {
+		if(m_config->gpgpu_clock_gated_lanes==false){
+		  m_stats->m_num_fp_acesses[m_sid]=m_stats->m_num_fp_acesses[m_sid]+active_count*latency
+			 + inactive_lanes_accesses_nonsfu(active_count, latency);
+		}else {
+        m_stats->m_num_fp_acesses[m_sid]=m_stats->m_num_fp_acesses[m_sid]+active_count*latency;
+		} 
+	 }
+	 void incfpmul_stat(unsigned active_count,double latency) {
+		 		// printf("FP MUL stat increament\n");
+      if(m_config->gpgpu_clock_gated_lanes==false){
+		  m_stats->m_num_fpmul_acesses[m_sid]=m_stats->m_num_fpmul_acesses[m_sid]+active_count*latency
+		    + inactive_lanes_accesses_nonsfu(active_count, latency);
+		}else {
+        m_stats->m_num_fpmul_acesses[m_sid]=m_stats->m_num_fpmul_acesses[m_sid]+active_count*latency;
+		}
+	 }
+	 void incfpdiv_stat(unsigned active_count,double latency) {
+		if(m_config->gpgpu_clock_gated_lanes==false){
+		  m_stats->m_num_fpdiv_acesses[m_sid]=m_stats->m_num_fpdiv_acesses[m_sid]+active_count*latency
+			+ inactive_lanes_accesses_sfu(active_count, latency); 
+		}else {
+		  m_stats->m_num_fpdiv_acesses[m_sid]=m_stats->m_num_fpdiv_acesses[m_sid]+active_count*latency;
+		}
+	 }
+	 void inctrans_stat(unsigned active_count,double latency) {
+		if(m_config->gpgpu_clock_gated_lanes==false){
+		  m_stats->m_num_trans_acesses[m_sid]=m_stats->m_num_trans_acesses[m_sid]+active_count*latency
+			+ inactive_lanes_accesses_sfu(active_count, latency); 
+		}else{
+		  m_stats->m_num_trans_acesses[m_sid]=m_stats->m_num_trans_acesses[m_sid]+active_count*latency;
+		}
+	 }
 
-  void incsfu_stat(unsigned active_count, double latency) {
-    m_stats->m_num_sfu_acesses[m_sid] =
-        m_stats->m_num_sfu_acesses[m_sid] + active_count * latency;
-  }
-  void incsp_stat(unsigned active_count, double latency) {
-    m_stats->m_num_sp_acesses[m_sid] =
-        m_stats->m_num_sp_acesses[m_sid] + active_count * latency;
-  }
-  void incmem_stat(unsigned active_count, double latency) {
-    if (m_config->gpgpu_clock_gated_lanes == false) {
-      m_stats->m_num_mem_acesses[m_sid] =
-          m_stats->m_num_mem_acesses[m_sid] + active_count * latency +
-          inactive_lanes_accesses_nonsfu(active_count, latency);
-    } else {
-      m_stats->m_num_mem_acesses[m_sid] =
-          m_stats->m_num_mem_acesses[m_sid] + active_count * latency;
-    }
-  }
-  void incexecstat(warp_inst_t *&inst);
+	 void incsfu_stat(unsigned active_count,double latency) {m_stats->m_num_sfu_acesses[m_sid]=m_stats->m_num_sfu_acesses[m_sid]+active_count*latency;}
+	 void incsp_stat(unsigned active_count,double latency) {m_stats->m_num_sp_acesses[m_sid]=m_stats->m_num_sp_acesses[m_sid]+active_count*latency;}
+	 void incmem_stat(unsigned active_count,double latency) {
+		if(m_config->gpgpu_clock_gated_lanes==false){
+		  m_stats->m_num_mem_acesses[m_sid]=m_stats->m_num_mem_acesses[m_sid]+active_count*latency
+		    + inactive_lanes_accesses_nonsfu(active_count, latency);
+		}else {
+		  m_stats->m_num_mem_acesses[m_sid]=m_stats->m_num_mem_acesses[m_sid]+active_count*latency;
+		}
+	 }
+	 void incexecstat(warp_inst_t *&inst);
 
-  void incregfile_reads(unsigned active_count) {
-    m_stats->m_read_regfile_acesses[m_sid] =
-        m_stats->m_read_regfile_acesses[m_sid] + active_count;
-  }
-  void incregfile_writes(unsigned active_count) {
-    m_stats->m_write_regfile_acesses[m_sid] =
-        m_stats->m_write_regfile_acesses[m_sid] + active_count;
-  }
-  void incnon_rf_operands(unsigned active_count) {
-    m_stats->m_non_rf_operands[m_sid] =
-        m_stats->m_non_rf_operands[m_sid] + active_count;
-  }
+	 void incregfile_reads(unsigned active_count) {m_stats->m_read_regfile_acesses[m_sid]=m_stats->m_read_regfile_acesses[m_sid]+active_count;}
+	 void incregfile_writes(unsigned active_count){m_stats->m_write_regfile_acesses[m_sid]=m_stats->m_write_regfile_acesses[m_sid]+active_count;}
+	 void incnon_rf_operands(unsigned active_count){m_stats->m_non_rf_operands[m_sid]=m_stats->m_non_rf_operands[m_sid]+active_count;}
 
-  void incspactivelanes_stat(unsigned active_count) {
-    m_stats->m_active_sp_lanes[m_sid] =
-        m_stats->m_active_sp_lanes[m_sid] + active_count;
-  }
-  void incsfuactivelanes_stat(unsigned active_count) {
-    m_stats->m_active_sfu_lanes[m_sid] =
-        m_stats->m_active_sfu_lanes[m_sid] + active_count;
-  }
-  void incfuactivelanes_stat(unsigned active_count) {
-    m_stats->m_active_fu_lanes[m_sid] =
-        m_stats->m_active_fu_lanes[m_sid] + active_count;
-  }
-  void incfumemactivelanes_stat(unsigned active_count) {
-    m_stats->m_active_fu_mem_lanes[m_sid] =
-        m_stats->m_active_fu_mem_lanes[m_sid] + active_count;
-  }
+	 void incspactivelanes_stat(unsigned active_count) {m_stats->m_active_sp_lanes[m_sid]=m_stats->m_active_sp_lanes[m_sid]+active_count;}
+	 void incsfuactivelanes_stat(unsigned active_count) {m_stats->m_active_sfu_lanes[m_sid]=m_stats->m_active_sfu_lanes[m_sid]+active_count;}
+	 void incfuactivelanes_stat(unsigned active_count) {m_stats->m_active_fu_lanes[m_sid]=m_stats->m_active_fu_lanes[m_sid]+active_count;}
+	 void incfumemactivelanes_stat(unsigned active_count) {m_stats->m_active_fu_mem_lanes[m_sid]=m_stats->m_active_fu_mem_lanes[m_sid]+active_count;}
 
-  void inc_simt_to_mem(unsigned n_flits) {
-    m_stats->n_simt_to_mem[m_sid] += n_flits;
-  }
-  bool check_if_non_released_reduction_barrier(warp_inst_t &inst);
+	 void inc_simt_to_mem(unsigned n_flits){ m_stats->n_simt_to_mem[m_sid] += n_flits; }
+	 bool check_if_non_released_reduction_barrier(warp_inst_t &inst);
 
- private:
-  unsigned inactive_lanes_accesses_sfu(unsigned active_count, double latency) {
-    return (((32 - active_count) >> 1) * latency) +
-           (((32 - active_count) >> 3) * latency) +
-           (((32 - active_count) >> 3) * latency);
-  }
-  unsigned inactive_lanes_accesses_nonsfu(unsigned active_count,
-                                          double latency) {
-    return (((32 - active_count) >> 1) * latency);
-  }
+	private:
+	 unsigned inactive_lanes_accesses_sfu(unsigned active_count,double latency){
+      return  ( ((32-active_count)>>1)*latency) + ( ((32-active_count)>>3)*latency) + ( ((32-active_count)>>3)*latency);
+	 }
+	 unsigned inactive_lanes_accesses_nonsfu(unsigned active_count,double latency){
+      return  ( ((32-active_count)>>1)*latency);
+	 }
 
-  int test_res_bus(int latency);
-  void init_warps(unsigned cta_id, unsigned start_thread, unsigned end_thread,
-                  unsigned ctaid, int cta_size, unsigned kernel_id);
-  virtual void checkExecutionStatusAndUpdate(warp_inst_t &inst, unsigned t,
-                                             unsigned tid);
-  address_type next_pc(int tid) const;
-  void fetch();
-  void register_cta_thread_exit(unsigned cta_num, kernel_info_t *kernel);
+    int test_res_bus(int latency);
+    void init_warps(unsigned cta_id, unsigned start_thread, unsigned end_thread,unsigned ctaid, int cta_size, unsigned kernel_id);
+    virtual void checkExecutionStatusAndUpdate(warp_inst_t &inst, unsigned t, unsigned tid);
+    address_type next_pc( int tid ) const;
+    void fetch();
+    void register_cta_thread_exit(unsigned cta_num, kernel_info_t * kernel );
 
-  void decode();
+    void decode();
+    
+    void issue();
+    friend class scheduler_unit; //this is needed to use private issue warp.
+    friend class TwoLevelScheduler;
+    friend class LooseRoundRobbinScheduler;
+    void issue_warp( register_set& warp, const warp_inst_t *pI, const active_mask_t &active_mask, unsigned warp_id, unsigned sch_id );
+    void func_exec_inst( warp_inst_t &inst );
 
-  void issue();
-  friend class scheduler_unit;  // this is needed to use private issue warp.
-  friend class TwoLevelScheduler;
-  friend class LooseRoundRobbinScheduler;
-  void issue_warp(register_set &warp, const warp_inst_t *pI,
-                  const active_mask_t &active_mask, unsigned warp_id,
-                  unsigned sch_id);
-  void func_exec_inst(warp_inst_t &inst);
+     // Returns numbers of addresses in translated_addrs
+    unsigned translate_local_memaddr( address_type localaddr, unsigned tid, unsigned num_shader, unsigned datasize, new_addr_type* translated_addrs );
 
-  // Returns numbers of addresses in translated_addrs
-  unsigned translate_local_memaddr(address_type localaddr, unsigned tid,
-                                   unsigned num_shader, unsigned datasize,
-                                   new_addr_type *translated_addrs);
+    void read_operands();
+    
+    void execute();
+    
+    void writeback();
+    
+    // used in display_pipeline():
+    void dump_warp_state( FILE *fout ) const;
+    void print_stage(unsigned int stage, FILE *fout) const;
+    unsigned long long m_last_inst_gpu_sim_cycle;
+    unsigned long long m_last_inst_gpu_tot_sim_cycle;
 
-  void read_operands();
+    // general information
+    unsigned m_sid; // shader id
+    unsigned m_tpc; // texture processor cluster id (aka, node id when using interconnect concentration)
+    const shader_core_config *m_config;
+    const memory_config *m_memory_config;
+    class simt_core_cluster *m_cluster;
 
-  void execute();
+    // statistics 
+    shader_core_stats *m_stats;
 
-  void writeback();
+    // CTA scheduling / hardware thread allocation
+    unsigned m_n_active_cta; // number of Cooperative Thread Arrays (blocks) currently running on this shader.
+    unsigned m_cta_status[MAX_CTA_PER_SHADER]; // CTAs status 
+    unsigned m_not_completed; // number of threads to be completed (==0 when all thread on this core completed) 
+    std::bitset<MAX_THREAD_PER_SM> m_active_threads;
+    
+    // thread contexts 
+    thread_ctx_t             *m_threadState;
+    
+    // interconnect interface
+    mem_fetch_interface *m_icnt;
+    shader_core_mem_fetch_allocator *m_mem_fetch_allocator;
+    
+    // fetch
+    read_only_cache *m_L1I; // instruction cache
+    int  m_last_warp_fetched;
 
-  // used in display_pipeline():
-  void dump_warp_state(FILE *fout) const;
-  void print_stage(unsigned int stage, FILE *fout) const;
-  unsigned long long m_last_inst_gpu_sim_cycle;
-  unsigned long long m_last_inst_gpu_tot_sim_cycle;
+    // decode/dispatch
+    std::vector<shd_warp_t>   m_warp;   // per warp information array
+    barrier_set_t             m_barriers;
+    ifetch_buffer_t           m_inst_fetch_buffer;
+    std::vector<register_set> m_pipeline_reg;
+    Scoreboard               *m_scoreboard;
+    opndcoll_rfu_t            m_operand_collector;
+    int m_active_warps;
 
-  // general information
-  unsigned m_sid;  // shader id
-  unsigned m_tpc;  // texture processor cluster id (aka, node id when using
-                   // interconnect concentration)
-  const shader_core_config *m_config;
-  const memory_config *m_memory_config;
-  class simt_core_cluster *m_cluster;
+    //schedule
+    std::vector<scheduler_unit*>  schedulers;
 
-  // statistics
-  shader_core_stats *m_stats;
+    //issue
+    unsigned int Issue_Prio;
 
-  // CTA scheduling / hardware thread allocation
-  unsigned m_n_active_cta;  // number of Cooperative Thread Arrays (blocks)
-                            // currently running on this shader.
-  unsigned m_cta_status[MAX_CTA_PER_SHADER];  // CTAs status
-  unsigned m_not_completed;  // number of threads to be completed (==0 when all
-                             // thread on this core completed)
-  std::bitset<MAX_THREAD_PER_SM> m_active_threads;
+    // execute
+    unsigned m_num_function_units;
+    std::vector<pipeline_stage_name_t> m_dispatch_port;
+    std::vector<pipeline_stage_name_t> m_issue_port;
+    std::vector<simd_function_unit*> m_fu; // stallable pipelines should be last in this array
+    ldst_unit *m_ldst_unit;
+    static const unsigned MAX_ALU_LATENCY = 512;
+    unsigned num_result_bus;
+    std::vector< std::bitset<MAX_ALU_LATENCY>* > m_result_bus;
 
-  // thread contexts
-  thread_ctx_t *m_threadState;
+    // used for local address mapping with single kernel launch
+    unsigned kernel_max_cta_per_shader;
+    unsigned kernel_padded_threads_per_cta;
+    // Used for handing out dynamic warp_ids to new warps.
+    // the differnece between a warp_id and a dynamic_warp_id
+    // is that the dynamic_warp_id is a running number unique to every warp
+    // run on this shader, where the warp_id is the static warp slot.
+    unsigned m_dynamic_warp_id;
 
-  // interconnect interface
-  mem_fetch_interface *m_icnt;
-  shader_core_mem_fetch_allocator *m_mem_fetch_allocator;
+    //Jin: concurrent kernels on a sm
+public:
+    bool can_issue_1block(kernel_info_t & kernel);
+    bool occupy_shader_resource_1block(kernel_info_t & kernel, bool occupy);
+    void release_shader_resource_1block(unsigned hw_ctaid, kernel_info_t & kernel);
+    int find_available_hwtid(unsigned int cta_size, bool occupy);
+private:
+    unsigned int m_occupied_n_threads; 
+    unsigned int m_occupied_shmem; 
+    unsigned int m_occupied_regs;
+    unsigned int m_occupied_ctas;
+    std::bitset<MAX_THREAD_PER_SM> m_occupied_hwtid;
+    std::map<unsigned int, unsigned int> m_occupied_cta_to_hwtid; 
 
-  // fetch
-  read_only_cache *m_L1I;  // instruction cache
-  int m_last_warp_fetched;
 
-  // decode/dispatch
-  std::vector<shd_warp_t> m_warp;  // per warp information array
-  barrier_set_t m_barriers;
-  ifetch_buffer_t m_inst_fetch_buffer;
-  std::vector<register_set> m_pipeline_reg;
-  Scoreboard *m_scoreboard;
-  opndcoll_rfu_t m_operand_collector;
-  int m_active_warps;
-
-  // schedule
-  std::vector<scheduler_unit *> schedulers;
-
-  // issue
-  unsigned int Issue_Prio;
-
-  // execute
-  unsigned m_num_function_units;
-  std::vector<pipeline_stage_name_t> m_dispatch_port;
-  std::vector<pipeline_stage_name_t> m_issue_port;
-  std::vector<simd_function_unit *>
-      m_fu;  // stallable pipelines should be last in this array
-  ldst_unit *m_ldst_unit;
-  static const unsigned MAX_ALU_LATENCY = 512;
-  unsigned num_result_bus;
-  std::vector<std::bitset<MAX_ALU_LATENCY> *> m_result_bus;
-
-  // used for local address mapping with single kernel launch
-  unsigned kernel_max_cta_per_shader;
-  unsigned kernel_padded_threads_per_cta;
-  // Used for handing out dynamic warp_ids to new warps.
-  // the differnece between a warp_id and a dynamic_warp_id
-  // is that the dynamic_warp_id is a running number unique to every warp
-  // run on this shader, where the warp_id is the static warp slot.
-  unsigned m_dynamic_warp_id;
-
-  // Jin: concurrent kernels on a sm
- public:
-  bool can_issue_1block(kernel_info_t &kernel);
-  bool occupy_shader_resource_1block(kernel_info_t &kernel, bool occupy);
-  void release_shader_resource_1block(unsigned hw_ctaid, kernel_info_t &kernel);
-  int find_available_hwtid(unsigned int cta_size, bool occupy);
-
- private:
-  unsigned int m_occupied_n_threads;
-  unsigned int m_occupied_shmem;
-  unsigned int m_occupied_regs;
-  unsigned int m_occupied_ctas;
-  std::bitset<MAX_THREAD_PER_SM> m_occupied_hwtid;
-  std::map<unsigned int, unsigned int> m_occupied_cta_to_hwtid;
 };
 
 class simt_core_cluster {
- public:
-  simt_core_cluster(class gpgpu_sim *gpu, unsigned cluster_id,
-                    const shader_core_config *config,
-                    const memory_config *mem_config, shader_core_stats *stats,
-                    memory_stats_t *mstats);
+public:
+    simt_core_cluster( class gpgpu_sim *gpu, 
+                       unsigned cluster_id, 
+                       const shader_core_config *config, 
+                       const memory_config *mem_config,
+                       shader_core_stats *stats,
+                       memory_stats_t *mstats );
 
-  void core_cycle();
-  void icnt_cycle();
+    void core_cycle();
+    void icnt_cycle();
 
-  void reinit();
-  unsigned issue_block2core();
-  void cache_flush();
-  void cache_invalidate();
-  bool icnt_injection_buffer_full(unsigned size, bool write);
-  void icnt_inject_request_packet(class mem_fetch *mf);
+    void reinit();
+    unsigned issue_block2core();
+    void cache_flush();
+    void cache_invalidate();
+    bool icnt_injection_buffer_full(unsigned size, bool write);
+    void icnt_inject_request_packet(class mem_fetch *mf);
 
-  // for perfect memory interface
-  bool response_queue_full() {
-    return (m_response_fifo.size() >= m_config->n_simt_ejection_buffer_size);
-  }
-  void push_response_fifo(class mem_fetch *mf) {
-    m_response_fifo.push_back(mf);
-  }
 
-  void get_pdom_stack_top_info(unsigned sid, unsigned tid, unsigned *pc,
-                               unsigned *rpc) const;
-  unsigned max_cta(const kernel_info_t &kernel);
-  unsigned get_not_completed() const;
-  void print_not_completed(FILE *fp) const;
-  unsigned get_n_active_cta() const;
-  unsigned get_n_active_sms() const;
-  gpgpu_sim *get_gpu() { return m_gpu; }
+    // for perfect memory interface
+    bool response_queue_full() {
+        return ( m_response_fifo.size() >= m_config->n_simt_ejection_buffer_size );
+    }
+    void push_response_fifo(class mem_fetch *mf) {
+        m_response_fifo.push_back(mf);
+    }
 
-  void display_pipeline(unsigned sid, FILE *fout, int print_mem, int mask);
-  void print_cache_stats(FILE *fp, unsigned &dl1_accesses,
-                         unsigned &dl1_misses) const;
+    void get_pdom_stack_top_info( unsigned sid, unsigned tid, unsigned *pc, unsigned *rpc ) const;
+    unsigned max_cta( const kernel_info_t &kernel );
+    unsigned get_not_completed() const;
+    void print_not_completed( FILE *fp ) const;
+    unsigned get_n_active_cta() const;
+    unsigned get_n_active_sms() const;
+    gpgpu_sim *get_gpu() { return m_gpu; }
 
-  void get_cache_stats(cache_stats &cs) const;
-  void get_L1I_sub_stats(struct cache_sub_stats &css) const;
-  void get_L1D_sub_stats(struct cache_sub_stats &css) const;
-  void get_L1C_sub_stats(struct cache_sub_stats &css) const;
-  void get_L1T_sub_stats(struct cache_sub_stats &css) const;
+    void display_pipeline( unsigned sid, FILE *fout, int print_mem, int mask );
+    void print_cache_stats( FILE *fp, unsigned& dl1_accesses, unsigned& dl1_misses ) const;
 
-  void get_icnt_stats(long &n_simt_to_mem, long &n_mem_to_simt) const;
-  float get_current_occupancy(unsigned long long &active,
-                              unsigned long long &total) const;
+    void get_cache_stats(cache_stats &cs) const;
+    void get_L1I_sub_stats(struct cache_sub_stats &css) const;
+    void get_L1D_sub_stats(struct cache_sub_stats &css) const;
+    void get_L1C_sub_stats(struct cache_sub_stats &css) const;
+    void get_L1T_sub_stats(struct cache_sub_stats &css) const;
 
- private:
-  unsigned m_cluster_id;
-  gpgpu_sim *m_gpu;
-  const shader_core_config *m_config;
-  shader_core_stats *m_stats;
-  memory_stats_t *m_memory_stats;
-  shader_core_ctx **m_core;
+    void get_icnt_stats(long &n_simt_to_mem, long &n_mem_to_simt) const;
+    float get_current_occupancy( unsigned long long& active, unsigned long long & total ) const;
 
-  unsigned m_cta_issue_next_core;
-  std::list<unsigned> m_core_sim_order;
-  std::list<mem_fetch *> m_response_fifo;
+private:
+    unsigned m_cluster_id;
+    gpgpu_sim *m_gpu;
+    const shader_core_config *m_config;
+    shader_core_stats *m_stats;
+    memory_stats_t *m_memory_stats;
+    shader_core_ctx **m_core;
+
+    unsigned m_cta_issue_next_core;
+    std::list<unsigned> m_core_sim_order;
+    std::list<mem_fetch*> m_response_fifo;
 };
 
 class shader_memory_interface : public mem_fetch_interface {
- public:
-  shader_memory_interface(shader_core_ctx *core, simt_core_cluster *cluster) {
-    m_core = core;
-    m_cluster = cluster;
-  }
-  virtual bool full(unsigned size, bool write) const {
-    return m_cluster->icnt_injection_buffer_full(size, write);
-  }
-  virtual void push(mem_fetch *mf) {
-    m_core->inc_simt_to_mem(mf->get_num_flits(true));
-    m_cluster->icnt_inject_request_packet(mf);
-  }
-
- private:
-  shader_core_ctx *m_core;
-  simt_core_cluster *m_cluster;
+public:
+    shader_memory_interface( shader_core_ctx *core, simt_core_cluster *cluster ) { m_core=core; m_cluster=cluster; }
+    virtual bool full( unsigned size, bool write ) const 
+    {
+        return m_cluster->icnt_injection_buffer_full(size,write);
+    }
+    virtual void push(mem_fetch *mf) 
+    {
+    	m_core->inc_simt_to_mem(mf->get_num_flits(true));
+        m_cluster->icnt_inject_request_packet(mf);        
+    }
+private:
+    shader_core_ctx *m_core;
+    simt_core_cluster *m_cluster;
 };
 
 class perfect_memory_interface : public mem_fetch_interface {
- public:
-  perfect_memory_interface(shader_core_ctx *core, simt_core_cluster *cluster) {
-    m_core = core;
-    m_cluster = cluster;
-  }
-  virtual bool full(unsigned size, bool write) const {
-    return m_cluster->response_queue_full();
-  }
-  virtual void push(mem_fetch *mf) {
-    if (mf && mf->isatomic())
-      mf->do_atomic();  // execute atomic inside the "memory subsystem"
-    m_core->inc_simt_to_mem(mf->get_num_flits(true));
-    m_cluster->push_response_fifo(mf);
-  }
-
- private:
-  shader_core_ctx *m_core;
-  simt_core_cluster *m_cluster;
+public:
+    perfect_memory_interface( shader_core_ctx *core, simt_core_cluster *cluster ) { m_core=core; m_cluster=cluster; }
+    virtual bool full( unsigned size, bool write) const
+    {
+        return m_cluster->response_queue_full();
+    }
+    virtual void push(mem_fetch *mf)
+    {
+        if ( mf && mf->isatomic() )
+            mf->do_atomic(); // execute atomic inside the "memory subsystem"
+        m_core->inc_simt_to_mem(mf->get_num_flits(true));
+        m_cluster->push_response_fifo(mf);        
+    }
+private:
+    shader_core_ctx *m_core;
+    simt_core_cluster *m_cluster;
 };
+
 
 inline int scheduler_unit::get_sid() const { return m_shader->get_sid(); }
 

--- a/src/gpgpu-sim/shader.h
+++ b/src/gpgpu-sim/shader.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2011, Tor M. Aamodt, Wilson W.L. Fung, Andrew Turner,
-// Ali Bakhoda 
+// Ali Bakhoda
 // The University of British Columbia
 // All rights reserved.
 //
@@ -8,71 +8,71 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef SHADER_H
 #define SHADER_H
 
+#include <assert.h>
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
-#include <assert.h>
+#include <algorithm>
+#include <bitset>
+#include <deque>
+#include <list>
 #include <map>
 #include <set>
-#include <vector>
-#include <list>
-#include <bitset>
 #include <utility>
-#include <algorithm>
-#include <deque>
+#include <vector>
 
 //#include "../cuda-sim/ptx.tab.h"
 
-#include "delayqueue.h"
-#include "stack.h"
-#include "dram.h"
 #include "../abstract_hardware_model.h"
-#include "scoreboard.h"
-#include "mem_fetch.h"
-#include "stats.h"
+#include "delayqueue.h"
+#include "dram.h"
 #include "gpu-cache.h"
+#include "mem_fetch.h"
+#include "scoreboard.h"
+#include "stack.h"
+#include "stats.h"
 #include "traffic_breakdown.h"
 
-
-#define NO_OP_FLAG            0xFF
+#define NO_OP_FLAG 0xFF
 
 /* READ_PACKET_SIZE:
-   bytes: 6 address (flit can specify chanel so this gives up to ~2GB/channel, so good for now),
-          2 bytes   [shaderid + mshrid](14 bits) + req_size(0-2 bits if req_size variable) - so up to 2^14 = 16384 mshr total 
+   bytes: 6 address (flit can specify chanel so this gives up to ~2GB/channel,
+   so good for now), 2 bytes   [shaderid + mshrid](14 bits) + req_size(0-2 bits
+   if req_size variable) - so up to 2^14 = 16384 mshr total
  */
 
 #define READ_PACKET_SIZE 8
 
-//WRITE_PACKET_SIZE: bytes: 6 address, 2 miscelaneous. 
+// WRITE_PACKET_SIZE: bytes: 6 address, 2 miscelaneous.
 #define WRITE_PACKET_SIZE 8
 
 #define WRITE_MASK_SIZE 8
 
 class gpgpu_context;
 
-enum exec_unit_type_t
-{
+enum exec_unit_type_t {
   NONE = 0,
   SP = 1,
   SFU = 2,
@@ -83,1127 +83,1132 @@ enum exec_unit_type_t
 };
 
 class thread_ctx_t {
-public:
-   unsigned m_cta_id; // hardware CTA this thread belongs
+ public:
+  unsigned m_cta_id;  // hardware CTA this thread belongs
 
-   // per thread stats (ac stands for accumulative).
-   unsigned n_insn;
-   unsigned n_insn_ac;
-   unsigned n_l1_mis_ac;
-   unsigned n_l1_mrghit_ac;
-   unsigned n_l1_access_ac; 
+  // per thread stats (ac stands for accumulative).
+  unsigned n_insn;
+  unsigned n_insn_ac;
+  unsigned n_l1_mis_ac;
+  unsigned n_l1_mrghit_ac;
+  unsigned n_l1_access_ac;
 
-   bool m_active; 
+  bool m_active;
 };
 
 class shd_warp_t {
-public:
-    shd_warp_t( class shader_core_ctx *shader, unsigned warp_size) 
-        : m_shader(shader), m_warp_size(warp_size)
-    {
-        m_stores_outstanding=0;
-        m_inst_in_pipeline=0;
-        reset(); 
+ public:
+  shd_warp_t(class shader_core_ctx *shader, unsigned warp_size)
+      : m_shader(shader), m_warp_size(warp_size) {
+    m_stores_outstanding = 0;
+    m_inst_in_pipeline = 0;
+    reset();
+  }
+  void reset() {
+    assert(m_stores_outstanding == 0);
+    assert(m_inst_in_pipeline == 0);
+    m_imiss_pending = false;
+    m_warp_id = (unsigned)-1;
+    m_dynamic_warp_id = (unsigned)-1;
+    n_completed = m_warp_size;
+    m_n_atomic = 0;
+    m_membar = false;
+    m_done_exit = true;
+    m_last_fetch = 0;
+    m_next = 0;
+
+    // Jin: cdp support
+    m_cdp_latency = 0;
+    m_cdp_dummy = false;
+  }
+  void init(address_type start_pc, unsigned cta_id, unsigned wid,
+            const std::bitset<MAX_WARP_SIZE> &active,
+            unsigned dynamic_warp_id) {
+    m_cta_id = cta_id;
+    m_warp_id = wid;
+    m_dynamic_warp_id = dynamic_warp_id;
+    m_next_pc = start_pc;
+    assert(n_completed >= active.count());
+    assert(n_completed <= m_warp_size);
+    n_completed -= active.count();  // active threads are not yet completed
+    m_active_threads = active;
+    m_done_exit = false;
+
+    // Jin: cdp support
+    m_cdp_latency = 0;
+    m_cdp_dummy = false;
+  }
+
+  bool functional_done() const;
+  bool waiting();  // not const due to membar
+  bool hardware_done() const;
+
+  bool done_exit() const { return m_done_exit; }
+  void set_done_exit() { m_done_exit = true; }
+
+  void print(FILE *fout) const;
+  void print_ibuffer(FILE *fout) const;
+
+  unsigned get_n_completed() const { return n_completed; }
+  void set_completed(unsigned lane) {
+    assert(m_active_threads.test(lane));
+    m_active_threads.reset(lane);
+    n_completed++;
+  }
+
+  void set_last_fetch(unsigned long long sim_cycle) {
+    m_last_fetch = sim_cycle;
+  }
+
+  unsigned get_n_atomic() const { return m_n_atomic; }
+  void inc_n_atomic() { m_n_atomic++; }
+  void dec_n_atomic(unsigned n) { m_n_atomic -= n; }
+
+  void set_membar() { m_membar = true; }
+  void clear_membar() { m_membar = false; }
+  bool get_membar() const { return m_membar; }
+  address_type get_pc() const { return m_next_pc; }
+  void set_next_pc(address_type pc) { m_next_pc = pc; }
+
+  void store_info_of_last_inst_at_barrier(const warp_inst_t *pI) {
+    m_inst_at_barrier = *pI;
+  }
+  warp_inst_t *restore_info_of_last_inst_at_barrier() {
+    return &m_inst_at_barrier;
+  }
+
+  void ibuffer_fill(unsigned slot, const warp_inst_t *pI) {
+    assert(slot < IBUFFER_SIZE);
+    m_ibuffer[slot].m_inst = pI;
+    m_ibuffer[slot].m_valid = true;
+    m_next = 0;
+  }
+  bool ibuffer_empty() const {
+    for (unsigned i = 0; i < IBUFFER_SIZE; i++)
+      if (m_ibuffer[i].m_valid) return false;
+    return true;
+  }
+  void ibuffer_flush() {
+    for (unsigned i = 0; i < IBUFFER_SIZE; i++) {
+      if (m_ibuffer[i].m_valid) dec_inst_in_pipeline();
+      m_ibuffer[i].m_inst = NULL;
+      m_ibuffer[i].m_valid = false;
     }
-    void reset()
-    {
-        assert( m_stores_outstanding==0);
-        assert( m_inst_in_pipeline==0);
-        m_imiss_pending=false;
-        m_warp_id=(unsigned)-1;
-        m_dynamic_warp_id = (unsigned)-1;
-        n_completed = m_warp_size; 
-        m_n_atomic=0;
-        m_membar=false;
-        m_done_exit=true;
-        m_last_fetch=0;
-        m_next=0;
+  }
+  const warp_inst_t *ibuffer_next_inst() { return m_ibuffer[m_next].m_inst; }
+  bool ibuffer_next_valid() { return m_ibuffer[m_next].m_valid; }
+  void ibuffer_free() {
+    m_ibuffer[m_next].m_inst = NULL;
+    m_ibuffer[m_next].m_valid = false;
+  }
+  void ibuffer_step() { m_next = (m_next + 1) % IBUFFER_SIZE; }
 
-        //Jin: cdp support
-        m_cdp_latency = 0;
-        m_cdp_dummy = false;
+  bool imiss_pending() const { return m_imiss_pending; }
+  void set_imiss_pending() { m_imiss_pending = true; }
+  void clear_imiss_pending() { m_imiss_pending = false; }
+
+  bool stores_done() const { return m_stores_outstanding == 0; }
+  void inc_store_req() { m_stores_outstanding++; }
+  void dec_store_req() {
+    assert(m_stores_outstanding > 0);
+    m_stores_outstanding--;
+  }
+
+  unsigned num_inst_in_buffer() const {
+    unsigned count = 0;
+    for (unsigned i = 0; i < IBUFFER_SIZE; i++) {
+      if (m_ibuffer[i].m_valid) count++;
     }
-    void init( address_type start_pc,
-               unsigned cta_id,
-               unsigned wid,
-               const std::bitset<MAX_WARP_SIZE> &active,
-               unsigned dynamic_warp_id )
-    {
-        m_cta_id=cta_id;
-        m_warp_id=wid;
-        m_dynamic_warp_id=dynamic_warp_id;
-        m_next_pc=start_pc;
-        assert( n_completed >= active.count() );
-        assert( n_completed <= m_warp_size);
-        n_completed   -= active.count(); // active threads are not yet completed
-        m_active_threads = active;
-        m_done_exit=false;
+    return count;
+  }
+  unsigned num_inst_in_pipeline() const { return m_inst_in_pipeline; }
+  unsigned num_issued_inst_in_pipeline() const {
+    return (num_inst_in_pipeline() - num_inst_in_buffer());
+  }
+  bool inst_in_pipeline() const { return m_inst_in_pipeline > 0; }
+  void inc_inst_in_pipeline() { m_inst_in_pipeline++; }
+  void dec_inst_in_pipeline() {
+    assert(m_inst_in_pipeline > 0);
+    m_inst_in_pipeline--;
+  }
 
-        //Jin: cdp support
-        m_cdp_latency = 0;
-        m_cdp_dummy = false;
+  unsigned get_cta_id() const { return m_cta_id; }
+
+  unsigned get_dynamic_warp_id() const { return m_dynamic_warp_id; }
+  unsigned get_warp_id() const { return m_warp_id; }
+
+ private:
+  static const unsigned IBUFFER_SIZE = 2;
+  class shader_core_ctx *m_shader;
+  unsigned m_cta_id;
+  unsigned m_warp_id;
+  unsigned m_warp_size;
+  unsigned m_dynamic_warp_id;
+
+  address_type m_next_pc;
+  unsigned n_completed;  // number of threads in warp completed
+  std::bitset<MAX_WARP_SIZE> m_active_threads;
+
+  bool m_imiss_pending;
+
+  struct ibuffer_entry {
+    ibuffer_entry() {
+      m_valid = false;
+      m_inst = NULL;
     }
+    const warp_inst_t *m_inst;
+    bool m_valid;
+  };
 
-    bool functional_done() const;
-    bool waiting(); // not const due to membar
-    bool hardware_done() const;
+  warp_inst_t m_inst_at_barrier;
+  ibuffer_entry m_ibuffer[IBUFFER_SIZE];
+  unsigned m_next;
 
-    bool done_exit() const { return m_done_exit; }
-    void set_done_exit() { m_done_exit=true; }
+  unsigned m_n_atomic;  // number of outstanding atomic operations
+  bool m_membar;        // if true, warp is waiting at memory barrier
 
-    void print( FILE *fout ) const;
-    void print_ibuffer( FILE *fout ) const;
+  bool m_done_exit;  // true once thread exit has been registered for threads in
+                     // this warp
 
-    unsigned get_n_completed() const { return n_completed; }
-    void set_completed( unsigned lane ) 
-    { 
-        assert( m_active_threads.test(lane) );
-        m_active_threads.reset(lane);
-        n_completed++; 
-    }
+  unsigned long long m_last_fetch;
 
-    void set_last_fetch( unsigned long long sim_cycle ) { m_last_fetch=sim_cycle; }
+  unsigned m_stores_outstanding;  // number of store requests sent but not yet
+                                  // acknowledged
+  unsigned m_inst_in_pipeline;
 
-    unsigned get_n_atomic() const { return m_n_atomic; }
-    void inc_n_atomic() { m_n_atomic++; }
-    void dec_n_atomic(unsigned n) { m_n_atomic-=n; }
-
-    void set_membar() { m_membar=true; }
-    void clear_membar() { m_membar=false; }
-    bool get_membar() const { return m_membar; }
-    address_type get_pc() const { return m_next_pc; }
-    void set_next_pc( address_type pc ) { m_next_pc = pc; }
-
-    void store_info_of_last_inst_at_barrier(const warp_inst_t *pI){ m_inst_at_barrier = *pI;}
-    warp_inst_t * restore_info_of_last_inst_at_barrier(){ return &m_inst_at_barrier;}
-
-    void ibuffer_fill( unsigned slot, const warp_inst_t *pI )
-    {
-       assert(slot < IBUFFER_SIZE );
-       m_ibuffer[slot].m_inst=pI;
-       m_ibuffer[slot].m_valid=true;
-       m_next=0; 
-    }
-    bool ibuffer_empty() const
-    {
-        for( unsigned i=0; i < IBUFFER_SIZE; i++) 
-            if(m_ibuffer[i].m_valid) 
-                return false;
-        return true;
-    }
-    void ibuffer_flush()
-    {
-        for(unsigned i=0;i<IBUFFER_SIZE;i++) {
-            if( m_ibuffer[i].m_valid )
-                dec_inst_in_pipeline();
-            m_ibuffer[i].m_inst=NULL; 
-            m_ibuffer[i].m_valid=false; 
-        }
-    }
-    const warp_inst_t *ibuffer_next_inst() { return m_ibuffer[m_next].m_inst; }
-    bool ibuffer_next_valid() { return m_ibuffer[m_next].m_valid; }
-    void ibuffer_free()
-    {
-        m_ibuffer[m_next].m_inst = NULL;
-        m_ibuffer[m_next].m_valid = false;
-    }
-    void ibuffer_step() { m_next = (m_next+1)%IBUFFER_SIZE; }
-
-    bool imiss_pending() const { return m_imiss_pending; }
-    void set_imiss_pending() { m_imiss_pending=true; }
-    void clear_imiss_pending() { m_imiss_pending=false; }
-
-    bool stores_done() const { return m_stores_outstanding == 0; }
-    void inc_store_req() { m_stores_outstanding++; }
-    void dec_store_req() 
-    {
-        assert( m_stores_outstanding > 0 );
-        m_stores_outstanding--;
-    }
-
-    unsigned num_inst_in_buffer() const
-    {
-    	unsigned count=0;
-        for(unsigned i=0;i<IBUFFER_SIZE;i++) {
-            if( m_ibuffer[i].m_valid )
-            	count++;
-        }
-    	return count;
-    }
-    unsigned num_inst_in_pipeline() const { return m_inst_in_pipeline;}
-    unsigned num_issued_inst_in_pipeline() const {return (num_inst_in_pipeline()-num_inst_in_buffer());}
-    bool inst_in_pipeline() const { return m_inst_in_pipeline > 0; }
-    void inc_inst_in_pipeline() { m_inst_in_pipeline++; }
-    void dec_inst_in_pipeline() 
-    {
-        assert( m_inst_in_pipeline > 0 );
-        m_inst_in_pipeline--;
-    }
-
-    unsigned get_cta_id() const { return m_cta_id; }
-
-    unsigned get_dynamic_warp_id() const { return m_dynamic_warp_id; }
-    unsigned get_warp_id() const { return m_warp_id; }
-
-private:
-    static const unsigned IBUFFER_SIZE=2;
-    class shader_core_ctx *m_shader;
-    unsigned m_cta_id;
-    unsigned m_warp_id;
-    unsigned m_warp_size;
-    unsigned m_dynamic_warp_id;
-
-    address_type m_next_pc;
-    unsigned n_completed;          // number of threads in warp completed
-    std::bitset<MAX_WARP_SIZE> m_active_threads;
-
-    bool m_imiss_pending;
-    
-    struct ibuffer_entry {
-       ibuffer_entry() { m_valid = false; m_inst = NULL; }
-       const warp_inst_t *m_inst;
-       bool m_valid;
-    };
-
-    warp_inst_t m_inst_at_barrier;
-    ibuffer_entry m_ibuffer[IBUFFER_SIZE]; 
-    unsigned m_next;
-                                   
-    unsigned m_n_atomic;           // number of outstanding atomic operations 
-    bool     m_membar;             // if true, warp is waiting at memory barrier
-
-    bool m_done_exit; // true once thread exit has been registered for threads in this warp
-
-    unsigned long long m_last_fetch;
-
-    unsigned m_stores_outstanding; // number of store requests sent but not yet acknowledged
-    unsigned m_inst_in_pipeline;
-
-    //Jin: cdp support
-public:
-    unsigned int m_cdp_latency;
-    bool m_cdp_dummy;
+  // Jin: cdp support
+ public:
+  unsigned int m_cdp_latency;
+  bool m_cdp_dummy;
 };
 
-
-
-inline unsigned hw_tid_from_wid(unsigned wid, unsigned warp_size, unsigned i){return wid * warp_size + i;};
-inline unsigned wid_from_hw_tid(unsigned tid, unsigned warp_size){return tid/warp_size;};
+inline unsigned hw_tid_from_wid(unsigned wid, unsigned warp_size, unsigned i) {
+  return wid * warp_size + i;
+};
+inline unsigned wid_from_hw_tid(unsigned tid, unsigned warp_size) {
+  return tid / warp_size;
+};
 
 const unsigned WARP_PER_CTA_MAX = 64;
 typedef std::bitset<WARP_PER_CTA_MAX> warp_set_t;
 
-int register_bank(int regnum, int wid, unsigned num_banks, unsigned bank_warp_shift, bool sub_core_model, unsigned banks_per_sched, unsigned sched_id );
+int register_bank(int regnum, int wid, unsigned num_banks,
+                  unsigned bank_warp_shift, bool sub_core_model,
+                  unsigned banks_per_sched, unsigned sched_id);
 
 class shader_core_ctx;
 class shader_core_config;
 class shader_core_stats;
 
-enum scheduler_prioritization_type
-{
-    SCHEDULER_PRIORITIZATION_LRR = 0, // Loose Round Robin
-    SCHEDULER_PRIORITIZATION_SRR, // Strict Round Robin
-    SCHEDULER_PRIORITIZATION_GTO, // Greedy Then Oldest
-    SCHEDULER_PRIORITIZATION_GTLRR, // Greedy Then Loose Round Robin
-    SCHEDULER_PRIORITIZATION_GTY, // Greedy Then Youngest
-    SCHEDULER_PRIORITIZATION_OLDEST, // Oldest First
-    SCHEDULER_PRIORITIZATION_YOUNGEST, // Youngest First
+enum scheduler_prioritization_type {
+  SCHEDULER_PRIORITIZATION_LRR = 0,   // Loose Round Robin
+  SCHEDULER_PRIORITIZATION_SRR,       // Strict Round Robin
+  SCHEDULER_PRIORITIZATION_GTO,       // Greedy Then Oldest
+  SCHEDULER_PRIORITIZATION_GTLRR,     // Greedy Then Loose Round Robin
+  SCHEDULER_PRIORITIZATION_GTY,       // Greedy Then Youngest
+  SCHEDULER_PRIORITIZATION_OLDEST,    // Oldest First
+  SCHEDULER_PRIORITIZATION_YOUNGEST,  // Youngest First
 };
 
 // Each of these corresponds to a string value in the gpgpsim.config file
 // For example - to specify the LRR scheudler the config must contain lrr
-enum concrete_scheduler
-{
-    CONCRETE_SCHEDULER_LRR = 0,
-    CONCRETE_SCHEDULER_GTO,
-    CONCRETE_SCHEDULER_TWO_LEVEL_ACTIVE,
-    CONCRETE_SCHEDULER_WARP_LIMITING,
-    CONCRETE_SCHEDULER_OLDEST_FIRST,
-    NUM_CONCRETE_SCHEDULERS
+enum concrete_scheduler {
+  CONCRETE_SCHEDULER_LRR = 0,
+  CONCRETE_SCHEDULER_GTO,
+  CONCRETE_SCHEDULER_TWO_LEVEL_ACTIVE,
+  CONCRETE_SCHEDULER_WARP_LIMITING,
+  CONCRETE_SCHEDULER_OLDEST_FIRST,
+  NUM_CONCRETE_SCHEDULERS
 };
 
-class scheduler_unit { //this can be copied freely, so can be used in std containers.
-public:
-    scheduler_unit(shader_core_stats* stats, shader_core_ctx* shader, 
-                   Scoreboard* scoreboard, simt_stack** simt, 
-                   std::vector<shd_warp_t>* warp, 
-                   register_set* sp_out,
-				   register_set* dp_out,
-                   register_set* sfu_out,
-				   register_set* int_out,
-                   register_set* tensor_core_out,
-                   register_set* mem_out,
-                   int id) 
-        : m_supervised_warps(), m_stats(stats), m_shader(shader),
-        m_scoreboard(scoreboard), m_simt_stack(simt), /*m_pipeline_reg(pipe_regs),*/ m_warp(warp),
-        m_sp_out(sp_out),m_dp_out(dp_out),m_sfu_out(sfu_out),m_int_out(int_out),m_tensor_core_out(tensor_core_out),m_mem_out(mem_out), m_id(id){}
-    virtual ~scheduler_unit(){}
-    virtual void add_supervised_warp_id(int i) {
-        m_supervised_warps.push_back(&warp(i));
-    }
-    virtual void done_adding_supervised_warps() {
-        m_last_supervised_issued = m_supervised_warps.end();
-    }
+class scheduler_unit {  // this can be copied freely, so can be used in std
+                        // containers.
+ public:
+  scheduler_unit(shader_core_stats *stats, shader_core_ctx *shader,
+                 Scoreboard *scoreboard, simt_stack **simt,
+                 std::vector<shd_warp_t> *warp, register_set *sp_out,
+                 register_set *dp_out, register_set *sfu_out,
+                 register_set *int_out, register_set *tensor_core_out,
+                 register_set *mem_out, int id)
+      : m_supervised_warps(),
+        m_stats(stats),
+        m_shader(shader),
+        m_scoreboard(scoreboard),
+        m_simt_stack(simt),
+        /*m_pipeline_reg(pipe_regs),*/ m_warp(warp),
+        m_sp_out(sp_out),
+        m_dp_out(dp_out),
+        m_sfu_out(sfu_out),
+        m_int_out(int_out),
+        m_tensor_core_out(tensor_core_out),
+        m_mem_out(mem_out),
+        m_id(id) {}
+  virtual ~scheduler_unit() {}
+  virtual void add_supervised_warp_id(int i) {
+    m_supervised_warps.push_back(&warp(i));
+  }
+  virtual void done_adding_supervised_warps() {
+    m_last_supervised_issued = m_supervised_warps.end();
+  }
 
+  // The core scheduler cycle method is meant to be common between
+  // all the derived schedulers.  The scheduler's behaviour can be
+  // modified by changing the contents of the m_next_cycle_prioritized_warps
+  // list.
+  void cycle();
 
-    // The core scheduler cycle method is meant to be common between
-    // all the derived schedulers.  The scheduler's behaviour can be
-    // modified by changing the contents of the m_next_cycle_prioritized_warps list.
-    void cycle();
+  // These are some common ordering fucntions that the
+  // higher order schedulers can take advantage of
+  template <typename T>
+  void order_lrr(
+      typename std::vector<T> &result_list,
+      const typename std::vector<T> &input_list,
+      const typename std::vector<T>::const_iterator &last_issued_from_input,
+      unsigned num_warps_to_add);
 
-    // These are some common ordering fucntions that the
-    // higher order schedulers can take advantage of
-    template < typename T >
-    void order_lrr( typename std::vector< T >& result_list,
-                    const typename std::vector< T >& input_list,
-                    const typename std::vector< T >::const_iterator& last_issued_from_input,
-                    unsigned num_warps_to_add );
-    
-    enum OrderingType 
-    {
-        // The item that issued last is prioritized first then the sorted result
-        // of the priority_function
-        ORDERING_GREEDY_THEN_PRIORITY_FUNC = 0,
-        // No greedy scheduling based on last to issue. Only the priority function determines
-        // priority
-        ORDERED_PRIORITY_FUNC_ONLY,
-        NUM_ORDERING,
-    };
-    template < typename U >
-    void order_by_priority( std::vector< U >& result_list,
-                            const typename std::vector< U >& input_list,
-                            const typename std::vector< U >::const_iterator& last_issued_from_input,
-                            unsigned num_warps_to_add,
-                            OrderingType age_ordering,
-                            bool (*priority_func)(U lhs, U rhs) );
-    static bool sort_warps_by_oldest_dynamic_id(shd_warp_t* lhs, shd_warp_t* rhs);
+  enum OrderingType {
+    // The item that issued last is prioritized first then the sorted result
+    // of the priority_function
+    ORDERING_GREEDY_THEN_PRIORITY_FUNC = 0,
+    // No greedy scheduling based on last to issue. Only the priority function
+    // determines priority
+    ORDERED_PRIORITY_FUNC_ONLY,
+    NUM_ORDERING,
+  };
+  template <typename U>
+  void order_by_priority(
+      std::vector<U> &result_list, const typename std::vector<U> &input_list,
+      const typename std::vector<U>::const_iterator &last_issued_from_input,
+      unsigned num_warps_to_add, OrderingType age_ordering,
+      bool (*priority_func)(U lhs, U rhs));
+  static bool sort_warps_by_oldest_dynamic_id(shd_warp_t *lhs, shd_warp_t *rhs);
 
-    // Derived classes can override this function to populate
-    // m_supervised_warps with their scheduling policies
-    virtual void order_warps() = 0;
+  // Derived classes can override this function to populate
+  // m_supervised_warps with their scheduling policies
+  virtual void order_warps() = 0;
 
-    int get_schd_id() const {return m_id;}
+  int get_schd_id() const { return m_id; }
 
-protected:
-    virtual void do_on_warp_issued( unsigned warp_id,
-                                    unsigned num_issued,
-                                    const std::vector< shd_warp_t* >::const_iterator& prioritized_iter );
-    inline int get_sid() const;
-protected:
-    shd_warp_t& warp(int i);
+ protected:
+  virtual void do_on_warp_issued(
+      unsigned warp_id, unsigned num_issued,
+      const std::vector<shd_warp_t *>::const_iterator &prioritized_iter);
+  inline int get_sid() const;
 
-    // This is the prioritized warp list that is looped over each cycle to determine
-    // which warp gets to issue.
-    std::vector< shd_warp_t* > m_next_cycle_prioritized_warps;
-    // The m_supervised_warps list is all the warps this scheduler is supposed to
-    // arbitrate between.  This is useful in systems where there is more than
-    // one warp scheduler. In a single scheduler system, this is simply all
-    // the warps assigned to this core.
-    std::vector< shd_warp_t* > m_supervised_warps;
-    // This is the iterator pointer to the last supervised warp you issued
-    std::vector< shd_warp_t* >::const_iterator m_last_supervised_issued;
-    shader_core_stats *m_stats;
-    shader_core_ctx* m_shader;
-    // these things should become accessors: but would need a bigger rearchitect of how shader_core_ctx interacts with its parts.
-    Scoreboard* m_scoreboard; 
-    simt_stack** m_simt_stack;
-    //warp_inst_t** m_pipeline_reg;
-    std::vector<shd_warp_t>* m_warp;
-    register_set* m_sp_out;
-    register_set* m_dp_out;
-    register_set* m_sfu_out;
-    register_set* m_int_out;
-    register_set* m_tensor_core_out;
-    register_set* m_mem_out;
+ protected:
+  shd_warp_t &warp(int i);
 
-    int m_id;
+  // This is the prioritized warp list that is looped over each cycle to
+  // determine which warp gets to issue.
+  std::vector<shd_warp_t *> m_next_cycle_prioritized_warps;
+  // The m_supervised_warps list is all the warps this scheduler is supposed to
+  // arbitrate between.  This is useful in systems where there is more than
+  // one warp scheduler. In a single scheduler system, this is simply all
+  // the warps assigned to this core.
+  std::vector<shd_warp_t *> m_supervised_warps;
+  // This is the iterator pointer to the last supervised warp you issued
+  std::vector<shd_warp_t *>::const_iterator m_last_supervised_issued;
+  shader_core_stats *m_stats;
+  shader_core_ctx *m_shader;
+  // these things should become accessors: but would need a bigger rearchitect
+  // of how shader_core_ctx interacts with its parts.
+  Scoreboard *m_scoreboard;
+  simt_stack **m_simt_stack;
+  // warp_inst_t** m_pipeline_reg;
+  std::vector<shd_warp_t> *m_warp;
+  register_set *m_sp_out;
+  register_set *m_dp_out;
+  register_set *m_sfu_out;
+  register_set *m_int_out;
+  register_set *m_tensor_core_out;
+  register_set *m_mem_out;
+
+  int m_id;
 };
 
 class lrr_scheduler : public scheduler_unit {
-public:
-	lrr_scheduler ( shader_core_stats* stats, shader_core_ctx* shader,
-                    Scoreboard* scoreboard, simt_stack** simt,
-                    std::vector<shd_warp_t>* warp,
-                    register_set* sp_out,
-					register_set* dp_out,
-                    register_set* sfu_out,
-					register_set* int_out,
-                    register_set* tensor_core_out,
-                    register_set* mem_out,
-                    int id )
-	: scheduler_unit ( stats, shader, scoreboard, simt, warp, sp_out, dp_out, sfu_out, int_out, tensor_core_out, mem_out, id ){}
-	virtual ~lrr_scheduler () {}
-	virtual void order_warps ();
-    virtual void done_adding_supervised_warps() {
-        m_last_supervised_issued = m_supervised_warps.end();
-    }
+ public:
+  lrr_scheduler(shader_core_stats *stats, shader_core_ctx *shader,
+                Scoreboard *scoreboard, simt_stack **simt,
+                std::vector<shd_warp_t> *warp, register_set *sp_out,
+                register_set *dp_out, register_set *sfu_out,
+                register_set *int_out, register_set *tensor_core_out,
+                register_set *mem_out, int id)
+      : scheduler_unit(stats, shader, scoreboard, simt, warp, sp_out, dp_out,
+                       sfu_out, int_out, tensor_core_out, mem_out, id) {}
+  virtual ~lrr_scheduler() {}
+  virtual void order_warps();
+  virtual void done_adding_supervised_warps() {
+    m_last_supervised_issued = m_supervised_warps.end();
+  }
 };
 
 class gto_scheduler : public scheduler_unit {
-public:
-	gto_scheduler ( shader_core_stats* stats, shader_core_ctx* shader,
-                    Scoreboard* scoreboard, simt_stack** simt,
-                    std::vector<shd_warp_t>* warp,
-                    register_set* sp_out,
-					register_set* dp_out,
-                    register_set* sfu_out,
-					register_set* int_out,
-                    register_set* tensor_core_out,
-                    register_set* mem_out,
-                    int id )
-	: scheduler_unit ( stats, shader, scoreboard, simt, warp, sp_out, dp_out, sfu_out, int_out, tensor_core_out, mem_out, id ){}
-	virtual ~gto_scheduler () {}
-	virtual void order_warps ();
-    virtual void done_adding_supervised_warps() {
-        m_last_supervised_issued = m_supervised_warps.begin();
-    }
-
+ public:
+  gto_scheduler(shader_core_stats *stats, shader_core_ctx *shader,
+                Scoreboard *scoreboard, simt_stack **simt,
+                std::vector<shd_warp_t> *warp, register_set *sp_out,
+                register_set *dp_out, register_set *sfu_out,
+                register_set *int_out, register_set *tensor_core_out,
+                register_set *mem_out, int id)
+      : scheduler_unit(stats, shader, scoreboard, simt, warp, sp_out, dp_out,
+                       sfu_out, int_out, tensor_core_out, mem_out, id) {}
+  virtual ~gto_scheduler() {}
+  virtual void order_warps();
+  virtual void done_adding_supervised_warps() {
+    m_last_supervised_issued = m_supervised_warps.begin();
+  }
 };
 
 class oldest_scheduler : public scheduler_unit {
-public:
-	oldest_scheduler ( shader_core_stats* stats, shader_core_ctx* shader,
-                    Scoreboard* scoreboard, simt_stack** simt,
-                    std::vector<shd_warp_t>* warp,
-                    register_set* sp_out,
-					register_set* dp_out,
-                    register_set* sfu_out,
-					register_set* int_out,
-                    register_set* tensor_core_out,
-                    register_set* mem_out,
-                    int id )
-	: scheduler_unit ( stats, shader, scoreboard, simt, warp, sp_out, dp_out, sfu_out, int_out, tensor_core_out, mem_out, id ){}
-	virtual ~oldest_scheduler () {}
-	virtual void order_warps ();
-        virtual void done_adding_supervised_warps() {
-        m_last_supervised_issued = m_supervised_warps.begin();
-    }
-
+ public:
+  oldest_scheduler(shader_core_stats *stats, shader_core_ctx *shader,
+                   Scoreboard *scoreboard, simt_stack **simt,
+                   std::vector<shd_warp_t> *warp, register_set *sp_out,
+                   register_set *dp_out, register_set *sfu_out,
+                   register_set *int_out, register_set *tensor_core_out,
+                   register_set *mem_out, int id)
+      : scheduler_unit(stats, shader, scoreboard, simt, warp, sp_out, dp_out,
+                       sfu_out, int_out, tensor_core_out, mem_out, id) {}
+  virtual ~oldest_scheduler() {}
+  virtual void order_warps();
+  virtual void done_adding_supervised_warps() {
+    m_last_supervised_issued = m_supervised_warps.begin();
+  }
 };
 
 class two_level_active_scheduler : public scheduler_unit {
-public:
-	two_level_active_scheduler ( shader_core_stats* stats, shader_core_ctx* shader,
-                          Scoreboard* scoreboard, simt_stack** simt,
-                          std::vector<shd_warp_t>* warp,
-                          register_set* sp_out,
-						  register_set* dp_out,
-                          register_set* sfu_out,
-						  register_set* int_out,
-                          register_set* tensor_core_out,
-                          register_set* mem_out,
-                          int id,
-                          char* config_str )
-	: scheduler_unit ( stats, shader, scoreboard, simt, warp, sp_out, dp_out, sfu_out, int_out, tensor_core_out, mem_out, id ),
-	  m_pending_warps() 
-    {
-        unsigned inner_level_readin;
-        unsigned outer_level_readin; 
-        int ret = sscanf( config_str,
-                          "two_level_active:%d:%d:%d",
-                          &m_max_active_warps,
-                          &inner_level_readin,
-                          &outer_level_readin);
-        assert( 3 == ret );
-        m_inner_level_prioritization=(scheduler_prioritization_type)inner_level_readin;
-        m_outer_level_prioritization=(scheduler_prioritization_type)outer_level_readin;
+ public:
+  two_level_active_scheduler(shader_core_stats *stats, shader_core_ctx *shader,
+                             Scoreboard *scoreboard, simt_stack **simt,
+                             std::vector<shd_warp_t> *warp,
+                             register_set *sp_out, register_set *dp_out,
+                             register_set *sfu_out, register_set *int_out,
+                             register_set *tensor_core_out,
+                             register_set *mem_out, int id, char *config_str)
+      : scheduler_unit(stats, shader, scoreboard, simt, warp, sp_out, dp_out,
+                       sfu_out, int_out, tensor_core_out, mem_out, id),
+        m_pending_warps() {
+    unsigned inner_level_readin;
+    unsigned outer_level_readin;
+    int ret =
+        sscanf(config_str, "two_level_active:%d:%d:%d", &m_max_active_warps,
+               &inner_level_readin, &outer_level_readin);
+    assert(3 == ret);
+    m_inner_level_prioritization =
+        (scheduler_prioritization_type)inner_level_readin;
+    m_outer_level_prioritization =
+        (scheduler_prioritization_type)outer_level_readin;
+  }
+  virtual ~two_level_active_scheduler() {}
+  virtual void order_warps();
+  void add_supervised_warp_id(int i) {
+    if (m_next_cycle_prioritized_warps.size() < m_max_active_warps) {
+      m_next_cycle_prioritized_warps.push_back(&warp(i));
+    } else {
+      m_pending_warps.push_back(&warp(i));
     }
-	virtual ~two_level_active_scheduler () {}
-    virtual void order_warps();
-	void add_supervised_warp_id(int i) {
-        if ( m_next_cycle_prioritized_warps.size() < m_max_active_warps ) {
-            m_next_cycle_prioritized_warps.push_back( &warp(i) );
-        } else {
-		    m_pending_warps.push_back(&warp(i));
-        }
-	}
-    virtual void done_adding_supervised_warps() {
-        m_last_supervised_issued = m_supervised_warps.begin();
-    }
+  }
+  virtual void done_adding_supervised_warps() {
+    m_last_supervised_issued = m_supervised_warps.begin();
+  }
 
-protected:
-    virtual void do_on_warp_issued( unsigned warp_id,
-                                    unsigned num_issued,
-                                    const std::vector< shd_warp_t* >::const_iterator& prioritized_iter );
+ protected:
+  virtual void do_on_warp_issued(
+      unsigned warp_id, unsigned num_issued,
+      const std::vector<shd_warp_t *>::const_iterator &prioritized_iter);
 
-private:
-	std::deque< shd_warp_t* > m_pending_warps;
-    scheduler_prioritization_type m_inner_level_prioritization;
-    scheduler_prioritization_type m_outer_level_prioritization;
-	unsigned m_max_active_warps;
+ private:
+  std::deque<shd_warp_t *> m_pending_warps;
+  scheduler_prioritization_type m_inner_level_prioritization;
+  scheduler_prioritization_type m_outer_level_prioritization;
+  unsigned m_max_active_warps;
 };
 
 // Static Warp Limiting Scheduler
 class swl_scheduler : public scheduler_unit {
-public:
-	swl_scheduler ( shader_core_stats* stats, shader_core_ctx* shader,
-                    Scoreboard* scoreboard, simt_stack** simt,
-                    std::vector<shd_warp_t>* warp,
-                    register_set* sp_out,
-					register_set* dp_out,
-                    register_set* sfu_out,
-					register_set* int_out,
-                    register_set* tensor_core_out,
-                    register_set* mem_out,
-                    int id,
-                    char* config_string );
-	virtual ~swl_scheduler () {}
-	virtual void order_warps ();
-    virtual void done_adding_supervised_warps() {
-        m_last_supervised_issued = m_supervised_warps.begin();
-    }
+ public:
+  swl_scheduler(shader_core_stats *stats, shader_core_ctx *shader,
+                Scoreboard *scoreboard, simt_stack **simt,
+                std::vector<shd_warp_t> *warp, register_set *sp_out,
+                register_set *dp_out, register_set *sfu_out,
+                register_set *int_out, register_set *tensor_core_out,
+                register_set *mem_out, int id, char *config_string);
+  virtual ~swl_scheduler() {}
+  virtual void order_warps();
+  virtual void done_adding_supervised_warps() {
+    m_last_supervised_issued = m_supervised_warps.begin();
+  }
 
-protected:
-    scheduler_prioritization_type m_prioritization;
-    unsigned m_num_warps_to_limit;
+ protected:
+  scheduler_prioritization_type m_prioritization;
+  unsigned m_num_warps_to_limit;
 };
 
+class opndcoll_rfu_t {  // operand collector based register file unit
+ public:
+  // constructors
+  opndcoll_rfu_t() {
+    m_num_banks = 0;
+    m_shader = NULL;
+    m_initialized = false;
+  }
+  void add_cu_set(unsigned cu_set, unsigned num_cu, unsigned num_dispatch);
+  typedef std::vector<register_set *> port_vector_t;
+  typedef std::vector<unsigned int> uint_vector_t;
+  void add_port(port_vector_t &input, port_vector_t &ouput,
+                uint_vector_t cu_sets);
+  void init(unsigned num_banks, shader_core_ctx *shader);
 
+  // modifiers
+  bool writeback(warp_inst_t &warp);
 
-class opndcoll_rfu_t { // operand collector based register file unit
-public:
-   // constructors
-   opndcoll_rfu_t()
-   {
-      m_num_banks=0;
-      m_shader=NULL;
-      m_initialized=false;
-   }
-   void add_cu_set(unsigned cu_set, unsigned num_cu, unsigned num_dispatch);
-   typedef std::vector<register_set*> port_vector_t;
-   typedef std::vector<unsigned int> uint_vector_t;
-   void add_port( port_vector_t & input, port_vector_t & ouput, uint_vector_t cu_sets);
-   void init( unsigned num_banks, shader_core_ctx *shader );
+  void step() {
+    dispatch_ready_cu();
+    allocate_reads();
+    for (unsigned p = 0; p < m_in_ports.size(); p++) allocate_cu(p);
+    process_banks();
+  }
 
-   // modifiers
-   bool writeback( warp_inst_t &warp ); 
+  void dump(FILE *fp) const {
+    fprintf(fp, "\n");
+    fprintf(fp, "Operand Collector State:\n");
+    for (unsigned n = 0; n < m_cu.size(); n++) {
+      fprintf(fp, "   CU-%2u: ", n);
+      m_cu[n]->dump(fp, m_shader);
+    }
+    m_arbiter.dump(fp);
+  }
 
-   void step()
-   {
-        dispatch_ready_cu();   
-        allocate_reads();
-        for( unsigned p = 0 ; p < m_in_ports.size(); p++ ) 
-            allocate_cu( p );
-        process_banks();
-   }
+  shader_core_ctx *shader_core() { return m_shader; }
 
-   void dump( FILE *fp ) const
-   {
-      fprintf(fp,"\n");
-      fprintf(fp,"Operand Collector State:\n");
-      for( unsigned n=0; n < m_cu.size(); n++ ) {
-         fprintf(fp,"   CU-%2u: ", n);
-         m_cu[n]->dump(fp,m_shader);
-      }
-      m_arbiter.dump(fp);
-   }
+ private:
+  void process_banks() { m_arbiter.reset_alloction(); }
 
-   shader_core_ctx *shader_core() { return m_shader; }
+  void dispatch_ready_cu();
+  void allocate_cu(unsigned port);
+  void allocate_reads();
 
-private:
+  // types
 
-   void process_banks()
-   {
-      m_arbiter.reset_alloction();
-   }
+  class collector_unit_t;
 
-   void dispatch_ready_cu();
-   void allocate_cu( unsigned port );
-   void allocate_reads();
-
-   // types
-
-   class collector_unit_t;
-
-   class op_t {
+  class op_t {
    public:
+    op_t() { m_valid = false; }
+    op_t(collector_unit_t *cu, unsigned op, unsigned reg, unsigned num_banks,
+         unsigned bank_warp_shift, bool sub_core_model,
+         unsigned banks_per_sched, unsigned sched_id) {
+      m_valid = true;
+      m_warp = NULL;
+      m_cu = cu;
+      m_operand = op;
+      m_register = reg;
+      m_shced_id = sched_id;
+      m_bank = register_bank(reg, cu->get_warp_id(), num_banks, bank_warp_shift,
+                             sub_core_model, banks_per_sched, sched_id);
+    }
+    op_t(const warp_inst_t *warp, unsigned reg, unsigned num_banks,
+         unsigned bank_warp_shift, bool sub_core_model,
+         unsigned banks_per_sched, unsigned sched_id) {
+      m_valid = true;
+      m_warp = warp;
+      m_register = reg;
+      m_cu = NULL;
+      m_operand = -1;
+      m_shced_id = sched_id;
+      m_bank = register_bank(reg, warp->warp_id(), num_banks, bank_warp_shift,
+                             sub_core_model, banks_per_sched, sched_id);
+    }
 
-      op_t() { m_valid = false; }
-      op_t( collector_unit_t *cu, unsigned op, unsigned reg, unsigned num_banks, unsigned bank_warp_shift, bool sub_core_model, unsigned banks_per_sched, unsigned sched_id )
-      {
-         m_valid = true;
-         m_warp=NULL;
-         m_cu = cu;
-         m_operand = op;
-         m_register = reg;
-         m_shced_id = sched_id;
-         m_bank = register_bank(reg,cu->get_warp_id(),num_banks,bank_warp_shift, sub_core_model, banks_per_sched, sched_id);
-      }
-      op_t( const warp_inst_t *warp, unsigned reg, unsigned num_banks, unsigned bank_warp_shift, bool sub_core_model, unsigned banks_per_sched, unsigned sched_id )
-      {
-         m_valid=true;
-         m_warp=warp;
-         m_register=reg;
-         m_cu=NULL;
-         m_operand = -1;
-         m_shced_id = sched_id;
-         m_bank = register_bank(reg,warp->warp_id(),num_banks,bank_warp_shift, sub_core_model, banks_per_sched, sched_id);
-      }
+    // accessors
+    bool valid() const { return m_valid; }
+    unsigned get_reg() const {
+      assert(m_valid);
+      return m_register;
+    }
+    unsigned get_wid() const {
+      if (m_warp)
+        return m_warp->warp_id();
+      else if (m_cu)
+        return m_cu->get_warp_id();
+      else
+        abort();
+    }
+    unsigned get_sid() const { return m_shced_id; }
+    unsigned get_active_count() const {
+      if (m_warp)
+        return m_warp->active_count();
+      else if (m_cu)
+        return m_cu->get_active_count();
+      else
+        abort();
+    }
+    const active_mask_t &get_active_mask() {
+      if (m_warp)
+        return m_warp->get_active_mask();
+      else if (m_cu)
+        return m_cu->get_active_mask();
+      else
+        abort();
+    }
+    unsigned get_sp_op() const {
+      if (m_warp)
+        return m_warp->sp_op;
+      else if (m_cu)
+        return m_cu->get_sp_op();
+      else
+        abort();
+    }
+    unsigned get_oc_id() const { return m_cu->get_id(); }
+    unsigned get_bank() const { return m_bank; }
+    unsigned get_operand() const { return m_operand; }
+    void dump(FILE *fp) const {
+      if (m_cu)
+        fprintf(fp, " <R%u, CU:%u, w:%02u> ", m_register, m_cu->get_id(),
+                m_cu->get_warp_id());
+      else if (!m_warp->empty())
+        fprintf(fp, " <R%u, wid:%02u> ", m_register, m_warp->warp_id());
+    }
+    std::string get_reg_string() const {
+      char buffer[64];
+      snprintf(buffer, 64, "R%u", m_register);
+      return std::string(buffer);
+    }
 
-      // accessors
-      bool valid() const { return m_valid; }
-      unsigned get_reg() const
-      {
-         assert( m_valid );
-         return m_register;
-      }
-      unsigned get_wid() const
-      {
-          if( m_warp ) return m_warp->warp_id();
-          else if( m_cu ) return m_cu->get_warp_id();
-          else abort();
-      }
-      unsigned get_sid() const
-	  {
-		 return m_shced_id;
-	  }
-      unsigned get_active_count() const
-      {
-          if( m_warp ) return m_warp->active_count();
-          else if( m_cu ) return m_cu->get_active_count();
-          else abort();
-      }
-      const active_mask_t & get_active_mask()
-      {
-          if( m_warp ) return m_warp->get_active_mask();
-          else if( m_cu ) return m_cu->get_active_mask();
-          else abort();
-      }
-      unsigned get_sp_op() const
-      {
-          if( m_warp ) return m_warp->sp_op;
-          else if( m_cu ) return m_cu->get_sp_op();
-          else abort();
-      }
-      unsigned get_oc_id() const { return m_cu->get_id(); }
-      unsigned get_bank() const { return m_bank; }
-      unsigned get_operand() const { return m_operand; }
-      void dump(FILE *fp) const 
-      {
-         if(m_cu) 
-            fprintf(fp," <R%u, CU:%u, w:%02u> ", m_register,m_cu->get_id(),m_cu->get_warp_id());
-         else if( !m_warp->empty() )
-            fprintf(fp," <R%u, wid:%02u> ", m_register,m_warp->warp_id() );
-      }
-      std::string get_reg_string() const
-      {
-         char buffer[64];
-         snprintf(buffer,64,"R%u", m_register);
-         return std::string(buffer);
-      }
-
-      // modifiers
-      void reset() { m_valid = false; }
-   private:
-      bool m_valid;
-      collector_unit_t  *m_cu; 
-      const warp_inst_t *m_warp;
-      unsigned  m_operand; // operand offset in instruction. e.g., add r1,r2,r3; r2 is oprd 0, r3 is 1 (r1 is dst)
-      unsigned  m_register;
-      unsigned  m_bank;
-      unsigned  m_shced_id; //scheduler id that has issued this inst
-   };
-
-   enum alloc_t {
-      NO_ALLOC,
-      READ_ALLOC,
-      WRITE_ALLOC,
-   };
-
-   class allocation_t {
-   public:
-      allocation_t() { m_allocation = NO_ALLOC; }
-      bool is_read() const { return m_allocation==READ_ALLOC; }
-      bool is_write() const {return m_allocation==WRITE_ALLOC; }
-      bool is_free() const {return m_allocation==NO_ALLOC; }
-      void dump(FILE *fp) const {
-         if( m_allocation == NO_ALLOC ) { fprintf(fp,"<free>"); }
-         else if( m_allocation == READ_ALLOC ) { fprintf(fp,"rd: "); m_op.dump(fp); }
-         else if( m_allocation == WRITE_ALLOC ) { fprintf(fp,"wr: "); m_op.dump(fp); }
-         fprintf(fp,"\n");
-      }
-      void alloc_read( const op_t &op )  { assert(is_free()); m_allocation=READ_ALLOC; m_op=op;  }
-      void alloc_write( const op_t &op ) { assert(is_free()); m_allocation=WRITE_ALLOC; m_op=op; }
-      void reset() { m_allocation = NO_ALLOC; }
-   private:
-      enum alloc_t m_allocation;
-      op_t m_op;
-   };
-
-   class arbiter_t {
-   public:
-      // constructors
-      arbiter_t()
-      {
-         m_queue=NULL;
-         m_allocated_bank=NULL;
-         m_allocator_rr_head=NULL;
-         _inmatch=NULL;
-         _outmatch=NULL;
-         _request=NULL;
-         m_last_cu=0;
-      }
-      void init( unsigned num_cu, unsigned num_banks ) 
-      { 
-         assert(num_cu > 0);
-         assert(num_banks > 0);
-         m_num_collectors = num_cu;
-         m_num_banks = num_banks;
-         _inmatch = new int[ m_num_banks ];
-         _outmatch = new int[ m_num_collectors ];
-         _request = new int*[ m_num_banks ];
-         for(unsigned i=0; i<m_num_banks;i++) 
-             _request[i] = new int[m_num_collectors];
-         m_queue = new std::list<op_t>[num_banks];
-         m_allocated_bank = new allocation_t[num_banks];
-         m_allocator_rr_head = new unsigned[num_cu];
-         for( unsigned n=0; n<num_cu;n++ ) 
-            m_allocator_rr_head[n] = n%num_banks;
-         reset_alloction();
-      }
-
-      // accessors
-      void dump(FILE *fp) const
-      {
-         fprintf(fp,"\n");
-         fprintf(fp,"  Arbiter State:\n");
-         fprintf(fp,"  requests:\n");
-         for( unsigned b=0; b<m_num_banks; b++ ) {
-            fprintf(fp,"    bank %u : ", b );
-            std::list<op_t>::const_iterator o = m_queue[b].begin();
-            for(; o != m_queue[b].end(); o++ ) {
-               o->dump(fp);
-            }
-            fprintf(fp,"\n");
-         }
-         fprintf(fp,"  grants:\n");
-         for(unsigned b=0;b<m_num_banks;b++) {
-            fprintf(fp,"    bank %u : ", b );
-            m_allocated_bank[b].dump(fp);
-         }
-         fprintf(fp,"\n");
-      }
-
-      // modifiers
-      std::list<op_t> allocate_reads(); 
-
-      void add_read_requests( collector_unit_t *cu ) 
-      {
-         const op_t *src = cu->get_operands();
-         for( unsigned i=0; i<MAX_REG_OPERANDS*2; i++) {
-            const op_t &op = src[i];
-            if( op.valid() ) {
-               unsigned bank = op.get_bank();
-               m_queue[bank].push_back(op);
-            }
-         }
-      }
-      bool bank_idle( unsigned bank ) const
-      {
-          return m_allocated_bank[bank].is_free();
-      }
-      void allocate_bank_for_write( unsigned bank, const op_t &op )
-      {
-         assert( bank < m_num_banks );
-         m_allocated_bank[bank].alloc_write(op);
-      }
-      void allocate_for_read( unsigned bank, const op_t &op )
-      {
-         assert( bank < m_num_banks );
-         m_allocated_bank[bank].alloc_read(op);
-      }
-      void reset_alloction()
-      {
-         for( unsigned b=0; b < m_num_banks; b++ ) 
-            m_allocated_bank[b].reset();
-      }
+    // modifiers
+    void reset() { m_valid = false; }
 
    private:
-      unsigned m_num_banks;
-      unsigned m_num_collectors;
+    bool m_valid;
+    collector_unit_t *m_cu;
+    const warp_inst_t *m_warp;
+    unsigned m_operand;  // operand offset in instruction. e.g., add r1,r2,r3;
+                         // r2 is oprd 0, r3 is 1 (r1 is dst)
+    unsigned m_register;
+    unsigned m_bank;
+    unsigned m_shced_id;  // scheduler id that has issued this inst
+  };
 
-      allocation_t *m_allocated_bank; // bank # -> register that wins
-      std::list<op_t> *m_queue;
+  enum alloc_t {
+    NO_ALLOC,
+    READ_ALLOC,
+    WRITE_ALLOC,
+  };
 
-      unsigned *m_allocator_rr_head; // cu # -> next bank to check for request (rr-arb)
-      unsigned  m_last_cu; // first cu to check while arb-ing banks (rr)
-
-      int *_inmatch;
-      int *_outmatch;
-      int **_request;
-   };
-
-   class input_port_t {
+  class allocation_t {
    public:
-       input_port_t(port_vector_t & input, port_vector_t & output, uint_vector_t cu_sets)
-       : m_in(input),m_out(output), m_cu_sets(cu_sets)
-       {
-           assert(input.size() == output.size());
-           assert(not m_cu_sets.empty());
-       }
-   //private:
-       port_vector_t m_in,m_out;
-       uint_vector_t m_cu_sets;
-   };
-
-   class collector_unit_t {
-   public:
-      // constructors
-      collector_unit_t()
-      { 
-         m_free = true;
-         m_warp = NULL;
-         m_output_register = NULL;
-         m_src_op = new op_t[MAX_REG_OPERANDS*2];
-         m_not_ready.reset();
-         m_warp_id = -1;
-         m_num_banks = 0;
-         m_bank_warp_shift = 0;
+    allocation_t() { m_allocation = NO_ALLOC; }
+    bool is_read() const { return m_allocation == READ_ALLOC; }
+    bool is_write() const { return m_allocation == WRITE_ALLOC; }
+    bool is_free() const { return m_allocation == NO_ALLOC; }
+    void dump(FILE *fp) const {
+      if (m_allocation == NO_ALLOC) {
+        fprintf(fp, "<free>");
+      } else if (m_allocation == READ_ALLOC) {
+        fprintf(fp, "rd: ");
+        m_op.dump(fp);
+      } else if (m_allocation == WRITE_ALLOC) {
+        fprintf(fp, "wr: ");
+        m_op.dump(fp);
       }
-      // accessors
-      bool ready() const;
-      const op_t *get_operands() const { return m_src_op; }
-      void dump(FILE *fp, const shader_core_ctx *shader ) const;
-
-      unsigned get_warp_id() const { return m_warp_id; }
-      unsigned get_active_count() const { return m_warp->active_count(); }
-      const active_mask_t & get_active_mask() const { return m_warp->get_active_mask(); }
-      unsigned get_sp_op() const { return m_warp->sp_op; }
-      unsigned get_id() const { return m_cuid; } // returns CU hw id
-
-      // modifiers
-      void init(unsigned n, 
-                unsigned num_banks, 
-                unsigned log2_warp_size,
-                const core_config *config,
-                opndcoll_rfu_t *rfu,
-				bool m_sub_core_model,
-				unsigned num_banks_per_sched);
-      bool allocate( register_set* pipeline_reg, register_set* output_reg );
-
-      void collect_operand( unsigned op )
-      {
-         m_not_ready.reset(op);
-      }
-      unsigned get_num_operands() const{
-    	  return m_warp->get_num_operands();
-      }
-      unsigned get_num_regs() const{
-    	  return m_warp->get_num_regs();
-      }
-      void dispatch();
-      bool is_free(){return m_free;}
+      fprintf(fp, "\n");
+    }
+    void alloc_read(const op_t &op) {
+      assert(is_free());
+      m_allocation = READ_ALLOC;
+      m_op = op;
+    }
+    void alloc_write(const op_t &op) {
+      assert(is_free());
+      m_allocation = WRITE_ALLOC;
+      m_op = op;
+    }
+    void reset() { m_allocation = NO_ALLOC; }
 
    private:
-      bool m_free;
-      unsigned m_cuid; // collector unit hw id
-      unsigned m_warp_id;
-      warp_inst_t  *m_warp;
-      register_set* m_output_register; // pipeline register to issue to when ready
-      op_t *m_src_op;
-      std::bitset<MAX_REG_OPERANDS*2> m_not_ready;
-      unsigned m_num_banks;
-      unsigned m_bank_warp_shift;
-      opndcoll_rfu_t *m_rfu;
+    enum alloc_t m_allocation;
+    op_t m_op;
+  };
 
-      unsigned m_num_banks_per_sched;
-      bool m_sub_core_model;
-
-   };
-
-   class dispatch_unit_t {
+  class arbiter_t {
    public:
-      dispatch_unit_t(std::vector<collector_unit_t>* cus) 
-      { 
-         m_last_cu=0;
-         m_collector_units=cus;
-         m_num_collectors = (*cus).size();
-         m_next_cu=0;
-      }
+    // constructors
+    arbiter_t() {
+      m_queue = NULL;
+      m_allocated_bank = NULL;
+      m_allocator_rr_head = NULL;
+      _inmatch = NULL;
+      _outmatch = NULL;
+      _request = NULL;
+      m_last_cu = 0;
+    }
+    void init(unsigned num_cu, unsigned num_banks) {
+      assert(num_cu > 0);
+      assert(num_banks > 0);
+      m_num_collectors = num_cu;
+      m_num_banks = num_banks;
+      _inmatch = new int[m_num_banks];
+      _outmatch = new int[m_num_collectors];
+      _request = new int *[m_num_banks];
+      for (unsigned i = 0; i < m_num_banks; i++)
+        _request[i] = new int[m_num_collectors];
+      m_queue = new std::list<op_t>[num_banks];
+      m_allocated_bank = new allocation_t[num_banks];
+      m_allocator_rr_head = new unsigned[num_cu];
+      for (unsigned n = 0; n < num_cu; n++)
+        m_allocator_rr_head[n] = n % num_banks;
+      reset_alloction();
+    }
 
-      collector_unit_t *find_ready()
-      {
-         for( unsigned n=0; n < m_num_collectors; n++ ) {
-            unsigned c=(m_last_cu+n+1)%m_num_collectors;
-            if( (*m_collector_units)[c].ready() ) {
-               m_last_cu=c;
-               return &((*m_collector_units)[c]);
-            }
-         }
-         return NULL;
+    // accessors
+    void dump(FILE *fp) const {
+      fprintf(fp, "\n");
+      fprintf(fp, "  Arbiter State:\n");
+      fprintf(fp, "  requests:\n");
+      for (unsigned b = 0; b < m_num_banks; b++) {
+        fprintf(fp, "    bank %u : ", b);
+        std::list<op_t>::const_iterator o = m_queue[b].begin();
+        for (; o != m_queue[b].end(); o++) {
+          o->dump(fp);
+        }
+        fprintf(fp, "\n");
       }
+      fprintf(fp, "  grants:\n");
+      for (unsigned b = 0; b < m_num_banks; b++) {
+        fprintf(fp, "    bank %u : ", b);
+        m_allocated_bank[b].dump(fp);
+      }
+      fprintf(fp, "\n");
+    }
+
+    // modifiers
+    std::list<op_t> allocate_reads();
+
+    void add_read_requests(collector_unit_t *cu) {
+      const op_t *src = cu->get_operands();
+      for (unsigned i = 0; i < MAX_REG_OPERANDS * 2; i++) {
+        const op_t &op = src[i];
+        if (op.valid()) {
+          unsigned bank = op.get_bank();
+          m_queue[bank].push_back(op);
+        }
+      }
+    }
+    bool bank_idle(unsigned bank) const {
+      return m_allocated_bank[bank].is_free();
+    }
+    void allocate_bank_for_write(unsigned bank, const op_t &op) {
+      assert(bank < m_num_banks);
+      m_allocated_bank[bank].alloc_write(op);
+    }
+    void allocate_for_read(unsigned bank, const op_t &op) {
+      assert(bank < m_num_banks);
+      m_allocated_bank[bank].alloc_read(op);
+    }
+    void reset_alloction() {
+      for (unsigned b = 0; b < m_num_banks; b++) m_allocated_bank[b].reset();
+    }
 
    private:
-      unsigned m_num_collectors;
-      std::vector<collector_unit_t>* m_collector_units;
-      unsigned m_last_cu; // dispatch ready cu's rr
-      unsigned m_next_cu;  // for initialization
-   };
+    unsigned m_num_banks;
+    unsigned m_num_collectors;
 
-   // opndcoll_rfu_t data members
-   bool m_initialized;
+    allocation_t *m_allocated_bank;  // bank # -> register that wins
+    std::list<op_t> *m_queue;
 
-   unsigned m_num_collector_sets;
-   //unsigned m_num_collectors;
-   unsigned m_num_banks;
-   unsigned m_bank_warp_shift;
-   unsigned m_warp_size;
-   std::vector<collector_unit_t *> m_cu;
-   arbiter_t m_arbiter;
+    unsigned *
+        m_allocator_rr_head;  // cu # -> next bank to check for request (rr-arb)
+    unsigned m_last_cu;       // first cu to check while arb-ing banks (rr)
 
-   unsigned m_num_banks_per_sched;
-   unsigned m_num_warp_sceds;
-   bool sub_core_model;
+    int *_inmatch;
+    int *_outmatch;
+    int **_request;
+  };
 
-   //unsigned m_num_ports;
-   //std::vector<warp_inst_t**> m_input;
-   //std::vector<warp_inst_t**> m_output;
-   //std::vector<unsigned> m_num_collector_units;
-   //warp_inst_t **m_alu_port;
+  class input_port_t {
+   public:
+    input_port_t(port_vector_t &input, port_vector_t &output,
+                 uint_vector_t cu_sets)
+        : m_in(input), m_out(output), m_cu_sets(cu_sets) {
+      assert(input.size() == output.size());
+      assert(not m_cu_sets.empty());
+    }
+    // private:
+    port_vector_t m_in, m_out;
+    uint_vector_t m_cu_sets;
+  };
 
-   std::vector<input_port_t> m_in_ports;
-   typedef std::map<unsigned /* collector set */, std::vector<collector_unit_t> /*collector sets*/ > cu_sets_t;
-   cu_sets_t m_cus;
-   std::vector<dispatch_unit_t> m_dispatch_units;
+  class collector_unit_t {
+   public:
+    // constructors
+    collector_unit_t() {
+      m_free = true;
+      m_warp = NULL;
+      m_output_register = NULL;
+      m_src_op = new op_t[MAX_REG_OPERANDS * 2];
+      m_not_ready.reset();
+      m_warp_id = -1;
+      m_num_banks = 0;
+      m_bank_warp_shift = 0;
+    }
+    // accessors
+    bool ready() const;
+    const op_t *get_operands() const { return m_src_op; }
+    void dump(FILE *fp, const shader_core_ctx *shader) const;
 
-   //typedef std::map<warp_inst_t**/*port*/,dispatch_unit_t> port_to_du_t;
-   //port_to_du_t                     m_dispatch_units;
-   //std::map<warp_inst_t**,std::list<collector_unit_t*> > m_free_cu;
-   shader_core_ctx                 *m_shader;
+    unsigned get_warp_id() const { return m_warp_id; }
+    unsigned get_active_count() const { return m_warp->active_count(); }
+    const active_mask_t &get_active_mask() const {
+      return m_warp->get_active_mask();
+    }
+    unsigned get_sp_op() const { return m_warp->sp_op; }
+    unsigned get_id() const { return m_cuid; }  // returns CU hw id
+
+    // modifiers
+    void init(unsigned n, unsigned num_banks, unsigned log2_warp_size,
+              const core_config *config, opndcoll_rfu_t *rfu,
+              bool m_sub_core_model, unsigned num_banks_per_sched);
+    bool allocate(register_set *pipeline_reg, register_set *output_reg);
+
+    void collect_operand(unsigned op) { m_not_ready.reset(op); }
+    unsigned get_num_operands() const { return m_warp->get_num_operands(); }
+    unsigned get_num_regs() const { return m_warp->get_num_regs(); }
+    void dispatch();
+    bool is_free() { return m_free; }
+
+   private:
+    bool m_free;
+    unsigned m_cuid;  // collector unit hw id
+    unsigned m_warp_id;
+    warp_inst_t *m_warp;
+    register_set
+        *m_output_register;  // pipeline register to issue to when ready
+    op_t *m_src_op;
+    std::bitset<MAX_REG_OPERANDS * 2> m_not_ready;
+    unsigned m_num_banks;
+    unsigned m_bank_warp_shift;
+    opndcoll_rfu_t *m_rfu;
+
+    unsigned m_num_banks_per_sched;
+    bool m_sub_core_model;
+  };
+
+  class dispatch_unit_t {
+   public:
+    dispatch_unit_t(std::vector<collector_unit_t> *cus) {
+      m_last_cu = 0;
+      m_collector_units = cus;
+      m_num_collectors = (*cus).size();
+      m_next_cu = 0;
+    }
+
+    collector_unit_t *find_ready() {
+      for (unsigned n = 0; n < m_num_collectors; n++) {
+        unsigned c = (m_last_cu + n + 1) % m_num_collectors;
+        if ((*m_collector_units)[c].ready()) {
+          m_last_cu = c;
+          return &((*m_collector_units)[c]);
+        }
+      }
+      return NULL;
+    }
+
+   private:
+    unsigned m_num_collectors;
+    std::vector<collector_unit_t> *m_collector_units;
+    unsigned m_last_cu;  // dispatch ready cu's rr
+    unsigned m_next_cu;  // for initialization
+  };
+
+  // opndcoll_rfu_t data members
+  bool m_initialized;
+
+  unsigned m_num_collector_sets;
+  // unsigned m_num_collectors;
+  unsigned m_num_banks;
+  unsigned m_bank_warp_shift;
+  unsigned m_warp_size;
+  std::vector<collector_unit_t *> m_cu;
+  arbiter_t m_arbiter;
+
+  unsigned m_num_banks_per_sched;
+  unsigned m_num_warp_sceds;
+  bool sub_core_model;
+
+  // unsigned m_num_ports;
+  // std::vector<warp_inst_t**> m_input;
+  // std::vector<warp_inst_t**> m_output;
+  // std::vector<unsigned> m_num_collector_units;
+  // warp_inst_t **m_alu_port;
+
+  std::vector<input_port_t> m_in_ports;
+  typedef std::map<unsigned /* collector set */,
+                   std::vector<collector_unit_t> /*collector sets*/>
+      cu_sets_t;
+  cu_sets_t m_cus;
+  std::vector<dispatch_unit_t> m_dispatch_units;
+
+  // typedef std::map<warp_inst_t**/*port*/,dispatch_unit_t> port_to_du_t;
+  // port_to_du_t                     m_dispatch_units;
+  // std::map<warp_inst_t**,std::list<collector_unit_t*> > m_free_cu;
+  shader_core_ctx *m_shader;
 };
 
 class barrier_set_t {
-public:
-   barrier_set_t(shader_core_ctx * shader, unsigned max_warps_per_core, unsigned max_cta_per_core, unsigned max_barriers_per_cta, unsigned warp_size);
+ public:
+  barrier_set_t(shader_core_ctx *shader, unsigned max_warps_per_core,
+                unsigned max_cta_per_core, unsigned max_barriers_per_cta,
+                unsigned warp_size);
 
-   // during cta allocation
-   void allocate_barrier( unsigned cta_id, warp_set_t warps );
+  // during cta allocation
+  void allocate_barrier(unsigned cta_id, warp_set_t warps);
 
-   // during cta deallocation
-   void deallocate_barrier( unsigned cta_id );
+  // during cta deallocation
+  void deallocate_barrier(unsigned cta_id);
 
-   typedef std::map<unsigned, warp_set_t >  cta_to_warp_t;
-   typedef std::map<unsigned, warp_set_t >  bar_id_to_warp_t; /*set of warps reached a specific barrier id*/
+  typedef std::map<unsigned, warp_set_t> cta_to_warp_t;
+  typedef std::map<unsigned, warp_set_t>
+      bar_id_to_warp_t; /*set of warps reached a specific barrier id*/
 
+  // individual warp hits barrier
+  void warp_reaches_barrier(unsigned cta_id, unsigned warp_id,
+                            warp_inst_t *inst);
 
-   // individual warp hits barrier
-   void warp_reaches_barrier( unsigned cta_id, unsigned warp_id, warp_inst_t* inst);
+  // warp reaches exit
+  void warp_exit(unsigned warp_id);
 
+  // assertions
+  bool warp_waiting_at_barrier(unsigned warp_id) const;
 
-   // warp reaches exit 
-   void warp_exit( unsigned warp_id );
+  // debug
+  void dump();
 
-   // assertions
-   bool warp_waiting_at_barrier( unsigned warp_id ) const;
-
-   // debug
-   void dump();
-
-private:
-   unsigned m_max_cta_per_core;
-   unsigned m_max_warps_per_core;
-   unsigned m_max_barriers_per_cta;
-   unsigned m_warp_size;
-   cta_to_warp_t m_cta_to_warps;
-   bar_id_to_warp_t m_bar_id_to_warps;
-   warp_set_t m_warp_active;
-   warp_set_t m_warp_at_barrier;
-   shader_core_ctx *m_shader;
-
+ private:
+  unsigned m_max_cta_per_core;
+  unsigned m_max_warps_per_core;
+  unsigned m_max_barriers_per_cta;
+  unsigned m_warp_size;
+  cta_to_warp_t m_cta_to_warps;
+  bar_id_to_warp_t m_bar_id_to_warps;
+  warp_set_t m_warp_active;
+  warp_set_t m_warp_at_barrier;
+  shader_core_ctx *m_shader;
 };
 
 struct insn_latency_info {
-   unsigned pc;
-   unsigned long latency;
+  unsigned pc;
+  unsigned long latency;
 };
 
 struct ifetch_buffer_t {
-    ifetch_buffer_t() { m_valid=false; }
+  ifetch_buffer_t() { m_valid = false; }
 
-    ifetch_buffer_t( address_type pc, unsigned nbytes, unsigned warp_id ) 
-    { 
-        m_valid=true; 
-        m_pc=pc; 
-        m_nbytes=nbytes; 
-        m_warp_id=warp_id;
-    }
+  ifetch_buffer_t(address_type pc, unsigned nbytes, unsigned warp_id) {
+    m_valid = true;
+    m_pc = pc;
+    m_nbytes = nbytes;
+    m_warp_id = warp_id;
+  }
 
-    bool m_valid;
-    address_type m_pc;
-    unsigned m_nbytes;
-    unsigned m_warp_id;
+  bool m_valid;
+  address_type m_pc;
+  unsigned m_nbytes;
+  unsigned m_warp_id;
 };
 
 class shader_core_config;
 
 class simd_function_unit {
-public:
-    simd_function_unit( const shader_core_config *config );
-    ~simd_function_unit() { delete m_dispatch_reg; }
+ public:
+  simd_function_unit(const shader_core_config *config);
+  ~simd_function_unit() { delete m_dispatch_reg; }
 
-    // modifiers
-    virtual void issue( register_set& source_reg ) { source_reg.move_out_to(m_dispatch_reg); occupied.set(m_dispatch_reg->latency);}
-    virtual void cycle() = 0;
-    virtual void active_lanes_in_pipeline() = 0;
+  // modifiers
+  virtual void issue(register_set &source_reg) {
+    source_reg.move_out_to(m_dispatch_reg);
+    occupied.set(m_dispatch_reg->latency);
+  }
+  virtual void cycle() = 0;
+  virtual void active_lanes_in_pipeline() = 0;
 
-    // accessors
-    virtual unsigned clock_multiplier() const { return 1; }
-    virtual bool can_issue( const warp_inst_t &inst ) const { return m_dispatch_reg->empty() && !occupied.test(inst.latency); }
-    virtual bool stallable() const = 0;
-    virtual void print( FILE *fp ) const
-    {
-        fprintf(fp,"%s dispatch= ", m_name.c_str() );
-        m_dispatch_reg->print(fp);
-    }
-    const char* get_name() {
-    	return m_name.c_str();
-    }
-protected:
-    std::string m_name;
-    const shader_core_config *m_config;
-    warp_inst_t *m_dispatch_reg;
-    static const unsigned MAX_ALU_LATENCY = 512;
-    std::bitset<MAX_ALU_LATENCY> occupied;
+  // accessors
+  virtual unsigned clock_multiplier() const { return 1; }
+  virtual bool can_issue(const warp_inst_t &inst) const {
+    return m_dispatch_reg->empty() && !occupied.test(inst.latency);
+  }
+  virtual bool stallable() const = 0;
+  virtual void print(FILE *fp) const {
+    fprintf(fp, "%s dispatch= ", m_name.c_str());
+    m_dispatch_reg->print(fp);
+  }
+  const char *get_name() { return m_name.c_str(); }
+
+ protected:
+  std::string m_name;
+  const shader_core_config *m_config;
+  warp_inst_t *m_dispatch_reg;
+  static const unsigned MAX_ALU_LATENCY = 512;
+  std::bitset<MAX_ALU_LATENCY> occupied;
 };
 
 class pipelined_simd_unit : public simd_function_unit {
-public:
-    pipelined_simd_unit( register_set* result_port, const shader_core_config *config, unsigned max_latency, shader_core_ctx *core );
+ public:
+  pipelined_simd_unit(register_set *result_port,
+                      const shader_core_config *config, unsigned max_latency,
+                      shader_core_ctx *core);
 
-    //modifiers
-    virtual void cycle();
-    virtual void issue( register_set& source_reg );
-    virtual unsigned get_active_lanes_in_pipeline();
+  // modifiers
+  virtual void cycle();
+  virtual void issue(register_set &source_reg);
+  virtual unsigned get_active_lanes_in_pipeline();
 
-    virtual void active_lanes_in_pipeline() = 0;
-/*
-    virtual void issue( register_set& source_reg )
-    {
-        //move_warp(m_dispatch_reg,source_reg);
-        //source_reg.move_out_to(m_dispatch_reg);
-        simd_function_unit::issue(source_reg);
+  virtual void active_lanes_in_pipeline() = 0;
+  /*
+      virtual void issue( register_set& source_reg )
+      {
+          //move_warp(m_dispatch_reg,source_reg);
+          //source_reg.move_out_to(m_dispatch_reg);
+          simd_function_unit::issue(source_reg);
+      }
+  */
+  // accessors
+  virtual bool stallable() const { return false; }
+  virtual bool can_issue(const warp_inst_t &inst) const {
+    return simd_function_unit::can_issue(inst);
+  }
+  virtual void print(FILE *fp) const {
+    simd_function_unit::print(fp);
+    for (int s = m_pipeline_depth - 1; s >= 0; s--) {
+      if (!m_pipeline_reg[s]->empty()) {
+        fprintf(fp, "      %s[%2d] ", m_name.c_str(), s);
+        m_pipeline_reg[s]->print(fp);
+      }
     }
-*/
-    // accessors
-    virtual bool stallable() const { return false; }
-    virtual bool can_issue( const warp_inst_t &inst ) const
-    {
-        return simd_function_unit::can_issue(inst);
-    }
-    virtual void print(FILE *fp) const
-    {
-        simd_function_unit::print(fp);
-        for( int s=m_pipeline_depth-1; s>=0; s-- ) {
-            if( !m_pipeline_reg[s]->empty() ) { 
-                fprintf(fp,"      %s[%2d] ", m_name.c_str(), s );
-                m_pipeline_reg[s]->print(fp);
-            }
-        }
-    }
-protected:
-    unsigned m_pipeline_depth;
-    warp_inst_t **m_pipeline_reg;
-    register_set *m_result_port;
-    class shader_core_ctx *m_core;
+  }
 
-    unsigned active_insts_in_pipeline;
+ protected:
+  unsigned m_pipeline_depth;
+  warp_inst_t **m_pipeline_reg;
+  register_set *m_result_port;
+  class shader_core_ctx *m_core;
 
+  unsigned active_insts_in_pipeline;
 };
 
-class sfu : public pipelined_simd_unit
-{
-public:
-    sfu( register_set* result_port, const shader_core_config *config, shader_core_ctx *core );
-    virtual bool can_issue( const warp_inst_t &inst ) const
-    {
-        switch(inst.op) {
-        case SFU_OP: break;
-        case ALU_SFU_OP: break;
-        case DP_OP: break;     //for compute <= 29 (i..e Fermi and GT200)
-        default: return false;
-        }
-        return pipelined_simd_unit::can_issue(inst);
+class sfu : public pipelined_simd_unit {
+ public:
+  sfu(register_set *result_port, const shader_core_config *config,
+      shader_core_ctx *core);
+  virtual bool can_issue(const warp_inst_t &inst) const {
+    switch (inst.op) {
+      case SFU_OP:
+        break;
+      case ALU_SFU_OP:
+        break;
+      case DP_OP:
+        break;  // for compute <= 29 (i..e Fermi and GT200)
+      default:
+        return false;
     }
-    virtual void active_lanes_in_pipeline();
-    virtual void issue(  register_set& source_reg );
+    return pipelined_simd_unit::can_issue(inst);
+  }
+  virtual void active_lanes_in_pipeline();
+  virtual void issue(register_set &source_reg);
 };
 
-class dp_unit : public pipelined_simd_unit
-{
-public:
-	dp_unit( register_set* result_port, const shader_core_config *config, shader_core_ctx *core );
-    virtual bool can_issue( const warp_inst_t &inst ) const
-    {
-        switch(inst.op) {
-        case DP_OP: break;
-        default: return false;
-        }
-        return pipelined_simd_unit::can_issue(inst);
+class dp_unit : public pipelined_simd_unit {
+ public:
+  dp_unit(register_set *result_port, const shader_core_config *config,
+          shader_core_ctx *core);
+  virtual bool can_issue(const warp_inst_t &inst) const {
+    switch (inst.op) {
+      case DP_OP:
+        break;
+      default:
+        return false;
     }
-    virtual void active_lanes_in_pipeline();
-    virtual void issue(  register_set& source_reg );
+    return pipelined_simd_unit::can_issue(inst);
+  }
+  virtual void active_lanes_in_pipeline();
+  virtual void issue(register_set &source_reg);
 };
 
-class tensor_core : public pipelined_simd_unit
-{
-public:
-    tensor_core( register_set* result_port, const shader_core_config *config, shader_core_ctx *core );
-    virtual bool can_issue( const warp_inst_t &inst ) const
-    {
-        switch(inst.op) {
-        case TENSOR_CORE_OP: break;
-        default: return false;
-        }
-        return pipelined_simd_unit::can_issue(inst);
+class tensor_core : public pipelined_simd_unit {
+ public:
+  tensor_core(register_set *result_port, const shader_core_config *config,
+              shader_core_ctx *core);
+  virtual bool can_issue(const warp_inst_t &inst) const {
+    switch (inst.op) {
+      case TENSOR_CORE_OP:
+        break;
+      default:
+        return false;
     }
-    virtual void active_lanes_in_pipeline();
-    virtual void issue(  register_set& source_reg );
+    return pipelined_simd_unit::can_issue(inst);
+  }
+  virtual void active_lanes_in_pipeline();
+  virtual void issue(register_set &source_reg);
 };
 
-
-class int_unit : public pipelined_simd_unit
-{
-public:
-	int_unit( register_set* result_port, const shader_core_config *config, shader_core_ctx *core );
-    virtual bool can_issue( const warp_inst_t &inst ) const
-    {
-        switch(inst.op) {
-        case SFU_OP: return false;
-	    case LOAD_OP: return false;
-	    case TENSOR_CORE_LOAD_OP: return false;
-		case STORE_OP: return false;
-		case TENSOR_CORE_STORE_OP: return false;
-		case MEMORY_BARRIER_OP: return false;
-	    case SP_OP: return false;
-	    case DP_OP: return false;
-        default: break;
-        }
-        return pipelined_simd_unit::can_issue(inst);
+class int_unit : public pipelined_simd_unit {
+ public:
+  int_unit(register_set *result_port, const shader_core_config *config,
+           shader_core_ctx *core);
+  virtual bool can_issue(const warp_inst_t &inst) const {
+    switch (inst.op) {
+      case SFU_OP:
+        return false;
+      case LOAD_OP:
+        return false;
+      case TENSOR_CORE_LOAD_OP:
+        return false;
+      case STORE_OP:
+        return false;
+      case TENSOR_CORE_STORE_OP:
+        return false;
+      case MEMORY_BARRIER_OP:
+        return false;
+      case SP_OP:
+        return false;
+      case DP_OP:
+        return false;
+      default:
+        break;
     }
-    virtual void active_lanes_in_pipeline();
-    virtual void issue(  register_set& source_reg );
+    return pipelined_simd_unit::can_issue(inst);
+  }
+  virtual void active_lanes_in_pipeline();
+  virtual void issue(register_set &source_reg);
 };
 
-class sp_unit : public pipelined_simd_unit
-{
-public:
-    sp_unit( register_set* result_port, const shader_core_config *config, shader_core_ctx *core );
-    virtual bool can_issue( const warp_inst_t &inst ) const
-    {
-        switch(inst.op) {
-        case SFU_OP: return false; 
-        case LOAD_OP: return false;
-        case TENSOR_CORE_LOAD_OP: return false;
-        case STORE_OP: return false;
-        case TENSOR_CORE_STORE_OP: return false;
-        case MEMORY_BARRIER_OP: return false;
-        case DP_OP: return false;
-        default: break;
-        }
-        return pipelined_simd_unit::can_issue(inst);
+class sp_unit : public pipelined_simd_unit {
+ public:
+  sp_unit(register_set *result_port, const shader_core_config *config,
+          shader_core_ctx *core);
+  virtual bool can_issue(const warp_inst_t &inst) const {
+    switch (inst.op) {
+      case SFU_OP:
+        return false;
+      case LOAD_OP:
+        return false;
+      case TENSOR_CORE_LOAD_OP:
+        return false;
+      case STORE_OP:
+        return false;
+      case TENSOR_CORE_STORE_OP:
+        return false;
+      case MEMORY_BARRIER_OP:
+        return false;
+      case DP_OP:
+        return false;
+      default:
+        break;
     }
-    virtual void active_lanes_in_pipeline();
-    virtual void issue( register_set& source_reg );
+    return pipelined_simd_unit::can_issue(inst);
+  }
+  virtual void active_lanes_in_pipeline();
+  virtual void issue(register_set &source_reg);
 };
 
 class simt_core_cluster;
@@ -1211,947 +1216,1060 @@ class shader_memory_interface;
 class shader_core_mem_fetch_allocator;
 class cache_t;
 
-class ldst_unit: public pipelined_simd_unit {
-public:
-    ldst_unit( mem_fetch_interface *icnt,
-               shader_core_mem_fetch_allocator *mf_allocator,
-               shader_core_ctx *core, 
-               opndcoll_rfu_t *operand_collector,
-               Scoreboard *scoreboard,
-               const shader_core_config *config, 
-               const memory_config *mem_config,  
-               class shader_core_stats *stats, 
-               unsigned sid, unsigned tpc );
+class ldst_unit : public pipelined_simd_unit {
+ public:
+  ldst_unit(mem_fetch_interface *icnt,
+            shader_core_mem_fetch_allocator *mf_allocator,
+            shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
+            Scoreboard *scoreboard, const shader_core_config *config,
+            const memory_config *mem_config, class shader_core_stats *stats,
+            unsigned sid, unsigned tpc);
 
-    // modifiers
-    virtual void issue( register_set &inst );
-    virtual void cycle();
-     
-    void fill( mem_fetch *mf );
-    void flush();
-    void invalidate();
-    void writeback();
+  // modifiers
+  virtual void issue(register_set &inst);
+  virtual void cycle();
 
-    // accessors
-    virtual unsigned clock_multiplier() const;
+  void fill(mem_fetch *mf);
+  void flush();
+  void invalidate();
+  void writeback();
 
-    virtual bool can_issue( const warp_inst_t &inst ) const
-    {
-        switch(inst.op) {
-        case LOAD_OP: break;
-        case TENSOR_CORE_LOAD_OP: break;
-        case STORE_OP: break;
-        case TENSOR_CORE_STORE_OP: break;
-        case MEMORY_BARRIER_OP: break;
-        default: return false;
-        }
-        return m_dispatch_reg->empty();
+  // accessors
+  virtual unsigned clock_multiplier() const;
+
+  virtual bool can_issue(const warp_inst_t &inst) const {
+    switch (inst.op) {
+      case LOAD_OP:
+        break;
+      case TENSOR_CORE_LOAD_OP:
+        break;
+      case STORE_OP:
+        break;
+      case TENSOR_CORE_STORE_OP:
+        break;
+      case MEMORY_BARRIER_OP:
+        break;
+      default:
+        return false;
     }
+    return m_dispatch_reg->empty();
+  }
 
-    virtual void active_lanes_in_pipeline();
-    virtual bool stallable() const { return true; }
-    bool response_buffer_full() const;
-    void print(FILE *fout) const;
-    void print_cache_stats( FILE *fp, unsigned& dl1_accesses, unsigned& dl1_misses );
-    void get_cache_stats(unsigned &read_accesses, unsigned &write_accesses, unsigned &read_misses, unsigned &write_misses, unsigned cache_type);
-    void get_cache_stats(cache_stats &cs);
+  virtual void active_lanes_in_pipeline();
+  virtual bool stallable() const { return true; }
+  bool response_buffer_full() const;
+  void print(FILE *fout) const;
+  void print_cache_stats(FILE *fp, unsigned &dl1_accesses,
+                         unsigned &dl1_misses);
+  void get_cache_stats(unsigned &read_accesses, unsigned &write_accesses,
+                       unsigned &read_misses, unsigned &write_misses,
+                       unsigned cache_type);
+  void get_cache_stats(cache_stats &cs);
 
-    void get_L1D_sub_stats(struct cache_sub_stats &css) const;
-    void get_L1C_sub_stats(struct cache_sub_stats &css) const;
-    void get_L1T_sub_stats(struct cache_sub_stats &css) const;
+  void get_L1D_sub_stats(struct cache_sub_stats &css) const;
+  void get_L1C_sub_stats(struct cache_sub_stats &css) const;
+  void get_L1T_sub_stats(struct cache_sub_stats &css) const;
 
-protected:
-    ldst_unit( mem_fetch_interface *icnt,
-               shader_core_mem_fetch_allocator *mf_allocator,
-               shader_core_ctx *core, 
-               opndcoll_rfu_t *operand_collector,
-               Scoreboard *scoreboard,
-               const shader_core_config *config,
-               const memory_config *mem_config,  
-               shader_core_stats *stats,
-               unsigned sid,
-               unsigned tpc,
-               l1_cache* new_l1d_cache );
-    void init( mem_fetch_interface *icnt,
-               shader_core_mem_fetch_allocator *mf_allocator,
-               shader_core_ctx *core, 
-               opndcoll_rfu_t *operand_collector,
-               Scoreboard *scoreboard,
-               const shader_core_config *config,
-               const memory_config *mem_config,  
-               shader_core_stats *stats,
-               unsigned sid,
-               unsigned tpc );
+ protected:
+  ldst_unit(mem_fetch_interface *icnt,
+            shader_core_mem_fetch_allocator *mf_allocator,
+            shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
+            Scoreboard *scoreboard, const shader_core_config *config,
+            const memory_config *mem_config, shader_core_stats *stats,
+            unsigned sid, unsigned tpc, l1_cache *new_l1d_cache);
+  void init(mem_fetch_interface *icnt,
+            shader_core_mem_fetch_allocator *mf_allocator,
+            shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
+            Scoreboard *scoreboard, const shader_core_config *config,
+            const memory_config *mem_config, shader_core_stats *stats,
+            unsigned sid, unsigned tpc);
 
-protected:
-   bool shared_cycle( warp_inst_t &inst, mem_stage_stall_type &rc_fail, mem_stage_access_type &fail_type);
-   bool constant_cycle( warp_inst_t &inst, mem_stage_stall_type &rc_fail, mem_stage_access_type &fail_type);
-   bool texture_cycle( warp_inst_t &inst, mem_stage_stall_type &rc_fail, mem_stage_access_type &fail_type);
-   bool memory_cycle( warp_inst_t &inst, mem_stage_stall_type &rc_fail, mem_stage_access_type &fail_type);
+ protected:
+  bool shared_cycle(warp_inst_t &inst, mem_stage_stall_type &rc_fail,
+                    mem_stage_access_type &fail_type);
+  bool constant_cycle(warp_inst_t &inst, mem_stage_stall_type &rc_fail,
+                      mem_stage_access_type &fail_type);
+  bool texture_cycle(warp_inst_t &inst, mem_stage_stall_type &rc_fail,
+                     mem_stage_access_type &fail_type);
+  bool memory_cycle(warp_inst_t &inst, mem_stage_stall_type &rc_fail,
+                    mem_stage_access_type &fail_type);
 
-   virtual mem_stage_stall_type process_cache_access( cache_t* cache,
-                                                      new_addr_type address,
-                                                      warp_inst_t &inst,
-                                                      std::list<cache_event>& events,
-                                                      mem_fetch *mf,
-                                                      enum cache_request_status status );
-   mem_stage_stall_type process_memory_access_queue( cache_t *cache, warp_inst_t &inst );
-   mem_stage_stall_type process_memory_access_queue_l1cache( l1_cache *cache, warp_inst_t &inst );
+  virtual mem_stage_stall_type process_cache_access(
+      cache_t *cache, new_addr_type address, warp_inst_t &inst,
+      std::list<cache_event> &events, mem_fetch *mf,
+      enum cache_request_status status);
+  mem_stage_stall_type process_memory_access_queue(cache_t *cache,
+                                                   warp_inst_t &inst);
+  mem_stage_stall_type process_memory_access_queue_l1cache(l1_cache *cache,
+                                                           warp_inst_t &inst);
 
-   const memory_config *m_memory_config;
-   class mem_fetch_interface *m_icnt;
-   shader_core_mem_fetch_allocator *m_mf_allocator;
-   class shader_core_ctx *m_core;
-   unsigned m_sid;
-   unsigned m_tpc;
+  const memory_config *m_memory_config;
+  class mem_fetch_interface *m_icnt;
+  shader_core_mem_fetch_allocator *m_mf_allocator;
+  class shader_core_ctx *m_core;
+  unsigned m_sid;
+  unsigned m_tpc;
 
-   tex_cache *m_L1T; // texture cache
-   read_only_cache *m_L1C; // constant cache
-   l1_cache *m_L1D; // data cache
-   std::map<unsigned/*warp_id*/, std::map<unsigned/*regnum*/,unsigned/*count*/> > m_pending_writes;
-   std::list<mem_fetch*> m_response_fifo;
-   opndcoll_rfu_t *m_operand_collector;
-   Scoreboard *m_scoreboard;
+  tex_cache *m_L1T;        // texture cache
+  read_only_cache *m_L1C;  // constant cache
+  l1_cache *m_L1D;         // data cache
+  std::map<unsigned /*warp_id*/,
+           std::map<unsigned /*regnum*/, unsigned /*count*/>>
+      m_pending_writes;
+  std::list<mem_fetch *> m_response_fifo;
+  opndcoll_rfu_t *m_operand_collector;
+  Scoreboard *m_scoreboard;
 
-   mem_fetch *m_next_global;
-   warp_inst_t m_next_wb;
-   unsigned m_writeback_arb; // round-robin arbiter for writeback contention between L1T, L1C, shared
-   unsigned m_num_writeback_clients;
+  mem_fetch *m_next_global;
+  warp_inst_t m_next_wb;
+  unsigned m_writeback_arb;  // round-robin arbiter for writeback contention
+                             // between L1T, L1C, shared
+  unsigned m_num_writeback_clients;
 
-   enum mem_stage_stall_type m_mem_rc;
+  enum mem_stage_stall_type m_mem_rc;
 
-   shader_core_stats *m_stats; 
+  shader_core_stats *m_stats;
 
-   // for debugging
-   unsigned long long m_last_inst_gpu_sim_cycle;
-   unsigned long long m_last_inst_gpu_tot_sim_cycle;
+  // for debugging
+  unsigned long long m_last_inst_gpu_sim_cycle;
+  unsigned long long m_last_inst_gpu_tot_sim_cycle;
 
-   std::vector<std::deque<mem_fetch* >> l1_latency_queue;
-   void L1_latency_queue_cycle();
+  std::vector<std::deque<mem_fetch *>> l1_latency_queue;
+  void L1_latency_queue_cycle();
 };
 
 enum pipeline_stage_name_t {
-    ID_OC_SP=0,
-	ID_OC_DP,
-	ID_OC_INT,
-    ID_OC_SFU,  
-    ID_OC_MEM,  
-    OC_EX_SP,
-	OC_EX_DP,
-	OC_EX_INT,
-    OC_EX_SFU,
-    OC_EX_MEM,
-    EX_WB,
-    ID_OC_TENSOR_CORE,  
-    OC_EX_TENSOR_CORE,
-    N_PIPELINE_STAGES 
-    };
-
-const char* const pipeline_stage_name_decode[] = {
-    "ID_OC_SP",
-	"ID_OC_DP",
-	"ID_OC_INT",
-    "ID_OC_SFU",  
-    "ID_OC_MEM",  
-    "OC_EX_SP",
-	"OC_EX_DP",
-	"OC_EX_INT",
-    "OC_EX_SFU",
-    "OC_EX_MEM",
-    "EX_WB",
-    "ID_OC_TENSOR_CORE",  
-    "OC_EX_TENSOR_CORE",
-    "N_PIPELINE_STAGES" 
+  ID_OC_SP = 0,
+  ID_OC_DP,
+  ID_OC_INT,
+  ID_OC_SFU,
+  ID_OC_MEM,
+  OC_EX_SP,
+  OC_EX_DP,
+  OC_EX_INT,
+  OC_EX_SFU,
+  OC_EX_MEM,
+  EX_WB,
+  ID_OC_TENSOR_CORE,
+  OC_EX_TENSOR_CORE,
+  N_PIPELINE_STAGES
 };
 
-class shader_core_config : public core_config
-{
-    public:
-    shader_core_config(gpgpu_context* ctx):core_config(ctx){
-	pipeline_widths_string = NULL;
-	gpgpu_ctx = ctx;
+const char *const pipeline_stage_name_decode[] = {
+    "ID_OC_SP",          "ID_OC_DP",         "ID_OC_INT", "ID_OC_SFU",
+    "ID_OC_MEM",         "OC_EX_SP",         "OC_EX_DP",  "OC_EX_INT",
+    "OC_EX_SFU",         "OC_EX_MEM",        "EX_WB",     "ID_OC_TENSOR_CORE",
+    "OC_EX_TENSOR_CORE", "N_PIPELINE_STAGES"};
+
+class shader_core_config : public core_config {
+ public:
+  shader_core_config(gpgpu_context *ctx) : core_config(ctx) {
+    pipeline_widths_string = NULL;
+    gpgpu_ctx = ctx;
+  }
+
+  void init() {
+    int ntok = sscanf(gpgpu_shader_core_pipeline_opt, "%d:%d",
+                      &n_thread_per_shader, &warp_size);
+    if (ntok != 2) {
+      printf(
+          "GPGPU-Sim uArch: error while parsing configuration string "
+          "gpgpu_shader_core_pipeline_opt\n");
+      abort();
     }
 
-    void init()
-    {
-        int ntok = sscanf(gpgpu_shader_core_pipeline_opt,"%d:%d", 
-                          &n_thread_per_shader,
-                          &warp_size);
-        if(ntok != 2) {
-           printf("GPGPU-Sim uArch: error while parsing configuration string gpgpu_shader_core_pipeline_opt\n");
-           abort();
-	}
+    char *toks = new char[100];
+    char *tokd = toks;
+    strcpy(toks, pipeline_widths_string);
 
-	char* toks = new char[100];
-	char* tokd = toks;
-	strcpy(toks,pipeline_widths_string);
-                                  
-	toks = strtok(toks,",");
+    toks = strtok(toks, ",");
 
-	/*	Removing the tensorcore pipeline while reading the config files if the tensor core is not available.
-	 	If we won't remove it, old regression will be broken.
-		So to support the legacy config files it's best to handle in this way.
-         */  
-	int num_config_to_read= N_PIPELINE_STAGES - 2 * (!gpgpu_tensor_core_avail);
+    /*	Removing the tensorcore pipeline while reading the config files if the
+       tensor core is not available. If we won't remove it, old regression will
+       be broken. So to support the legacy config files it's best to handle in
+       this way.
+     */
+    int num_config_to_read = N_PIPELINE_STAGES - 2 * (!gpgpu_tensor_core_avail);
 
-        for (int i = 0; i < num_config_to_read; i++) { 
-	    assert(toks);
-	    ntok = sscanf(toks,"%d", &pipe_widths[i]);
-	    assert(ntok == 1); 
-	    toks = strtok(NULL,",");
-	}
-
-	delete[] tokd;
-	
-        if (n_thread_per_shader > MAX_THREAD_PER_SM) {
-           printf("GPGPU-Sim uArch: Error ** increase MAX_THREAD_PER_SM in abstract_hardware_model.h from %u to %u\n", 
-                  MAX_THREAD_PER_SM, n_thread_per_shader);
-           abort();
-        }
-        max_warps_per_shader =  n_thread_per_shader/warp_size;
-        assert( !(n_thread_per_shader % warp_size) );
-
-        set_pipeline_latency();
-        
-	m_L1I_config.init(m_L1I_config.m_config_string,FuncCachePreferNone);
-        m_L1T_config.init(m_L1T_config.m_config_string,FuncCachePreferNone);
-        m_L1C_config.init(m_L1C_config.m_config_string,FuncCachePreferNone);
-        m_L1D_config.init(m_L1D_config.m_config_string,FuncCachePreferNone);
-        gpgpu_cache_texl1_linesize = m_L1T_config.get_line_sz();
-        gpgpu_cache_constl1_linesize = m_L1C_config.get_line_sz();
-        m_valid = true;
+    for (int i = 0; i < num_config_to_read; i++) {
+      assert(toks);
+      ntok = sscanf(toks, "%d", &pipe_widths[i]);
+      assert(ntok == 1);
+      toks = strtok(NULL, ",");
     }
-    void reg_options(class OptionParser * opp );
-    unsigned max_cta( const kernel_info_t &k ) const;
-    unsigned num_shader() const { return n_simt_clusters*n_simt_cores_per_cluster; }
-    unsigned sid_to_cluster( unsigned sid ) const { return sid / n_simt_cores_per_cluster; }
-    unsigned sid_to_cid( unsigned sid )     const { return sid % n_simt_cores_per_cluster; }
-    unsigned cid_to_sid( unsigned cid, unsigned cluster_id ) const { return cluster_id*n_simt_cores_per_cluster + cid; }
-    void set_pipeline_latency();
 
-    // backward pointer
-    class gpgpu_context* gpgpu_ctx;
-// data
-    char *gpgpu_shader_core_pipeline_opt;
-    bool gpgpu_perfect_mem;
-    bool gpgpu_clock_gated_reg_file;
-    bool gpgpu_clock_gated_lanes;
-    enum divergence_support_t model;
-    unsigned n_thread_per_shader;
-    unsigned n_regfile_gating_group;
-    unsigned max_warps_per_shader; 
-    unsigned max_cta_per_core; //Limit on number of concurrent CTAs in shader core
-    unsigned max_barriers_per_cta;
-    char * gpgpu_scheduler_string;
-    unsigned gpgpu_shmem_per_block;
-    unsigned gpgpu_registers_per_block;
-    char* pipeline_widths_string;
-    int pipe_widths[N_PIPELINE_STAGES];
+    delete[] tokd;
 
-    mutable cache_config m_L1I_config;
-    mutable cache_config m_L1T_config;
-    mutable cache_config m_L1C_config;
-    mutable l1d_cache_config m_L1D_config;
+    if (n_thread_per_shader > MAX_THREAD_PER_SM) {
+      printf(
+          "GPGPU-Sim uArch: Error ** increase MAX_THREAD_PER_SM in "
+          "abstract_hardware_model.h from %u to %u\n",
+          MAX_THREAD_PER_SM, n_thread_per_shader);
+      abort();
+    }
+    max_warps_per_shader = n_thread_per_shader / warp_size;
+    assert(!(n_thread_per_shader % warp_size));
 
-    bool gpgpu_dwf_reg_bankconflict;
+    set_pipeline_latency();
 
-    unsigned gpgpu_num_sched_per_core;
-    int gpgpu_max_insn_issue_per_warp;
-    bool gpgpu_dual_issue_diff_exec_units;
+    m_L1I_config.init(m_L1I_config.m_config_string, FuncCachePreferNone);
+    m_L1T_config.init(m_L1T_config.m_config_string, FuncCachePreferNone);
+    m_L1C_config.init(m_L1C_config.m_config_string, FuncCachePreferNone);
+    m_L1D_config.init(m_L1D_config.m_config_string, FuncCachePreferNone);
+    gpgpu_cache_texl1_linesize = m_L1T_config.get_line_sz();
+    gpgpu_cache_constl1_linesize = m_L1C_config.get_line_sz();
+    m_valid = true;
+  }
+  void reg_options(class OptionParser *opp);
+  unsigned max_cta(const kernel_info_t &k) const;
+  unsigned num_shader() const {
+    return n_simt_clusters * n_simt_cores_per_cluster;
+  }
+  unsigned sid_to_cluster(unsigned sid) const {
+    return sid / n_simt_cores_per_cluster;
+  }
+  unsigned sid_to_cid(unsigned sid) const {
+    return sid % n_simt_cores_per_cluster;
+  }
+  unsigned cid_to_sid(unsigned cid, unsigned cluster_id) const {
+    return cluster_id * n_simt_cores_per_cluster + cid;
+  }
+  void set_pipeline_latency();
 
-    //op collector
-    bool enable_specialized_operand_collector;
-    int gpgpu_operand_collector_num_units_sp;
-    int gpgpu_operand_collector_num_units_dp;
-    int gpgpu_operand_collector_num_units_sfu;
-    int gpgpu_operand_collector_num_units_tensor_core;
-    int gpgpu_operand_collector_num_units_mem;
-    int gpgpu_operand_collector_num_units_gen;
-    int gpgpu_operand_collector_num_units_int;
+  // backward pointer
+  class gpgpu_context *gpgpu_ctx;
+  // data
+  char *gpgpu_shader_core_pipeline_opt;
+  bool gpgpu_perfect_mem;
+  bool gpgpu_clock_gated_reg_file;
+  bool gpgpu_clock_gated_lanes;
+  enum divergence_support_t model;
+  unsigned n_thread_per_shader;
+  unsigned n_regfile_gating_group;
+  unsigned max_warps_per_shader;
+  unsigned
+      max_cta_per_core;  // Limit on number of concurrent CTAs in shader core
+  unsigned max_barriers_per_cta;
+  char *gpgpu_scheduler_string;
+  unsigned gpgpu_shmem_per_block;
+  unsigned gpgpu_registers_per_block;
+  char *pipeline_widths_string;
+  int pipe_widths[N_PIPELINE_STAGES];
 
-    unsigned int gpgpu_operand_collector_num_in_ports_sp;
-    unsigned int gpgpu_operand_collector_num_in_ports_dp;
-    unsigned int gpgpu_operand_collector_num_in_ports_sfu;
-    unsigned int gpgpu_operand_collector_num_in_ports_tensor_core;
-    unsigned int gpgpu_operand_collector_num_in_ports_mem;
-    unsigned int gpgpu_operand_collector_num_in_ports_gen;
-    unsigned int gpgpu_operand_collector_num_in_ports_int;
+  mutable cache_config m_L1I_config;
+  mutable cache_config m_L1T_config;
+  mutable cache_config m_L1C_config;
+  mutable l1d_cache_config m_L1D_config;
 
-    unsigned int gpgpu_operand_collector_num_out_ports_sp;
-    unsigned int gpgpu_operand_collector_num_out_ports_dp;
-    unsigned int gpgpu_operand_collector_num_out_ports_sfu;
-    unsigned int gpgpu_operand_collector_num_out_ports_tensor_core;
-    unsigned int gpgpu_operand_collector_num_out_ports_mem;
-    unsigned int gpgpu_operand_collector_num_out_ports_gen;
-    unsigned int gpgpu_operand_collector_num_out_ports_int;
+  bool gpgpu_dwf_reg_bankconflict;
 
-    int gpgpu_num_sp_units;
-    int gpgpu_tensor_core_avail;
-    int gpgpu_num_dp_units;
-    int gpgpu_num_sfu_units;
-    int gpgpu_num_tensor_core_units;
-    int gpgpu_num_mem_units;
-    int gpgpu_num_int_units;
+  unsigned gpgpu_num_sched_per_core;
+  int gpgpu_max_insn_issue_per_warp;
+  bool gpgpu_dual_issue_diff_exec_units;
 
-    //Shader core resources
-    unsigned gpgpu_shader_registers;
-    int gpgpu_warpdistro_shader;
-    int gpgpu_warp_issue_shader;
-    unsigned gpgpu_num_reg_banks;
-    bool gpgpu_reg_bank_use_warp_id;
-    bool gpgpu_local_mem_map;
-    bool gpgpu_ignore_resources_limitation;
-    bool sub_core_model;
-    
-    unsigned max_sp_latency;
-    unsigned max_int_latency;
-    unsigned max_sfu_latency;
-    unsigned max_dp_latency;
-    unsigned max_tensor_core_latency;
-    
-    unsigned n_simt_cores_per_cluster;
-    unsigned n_simt_clusters;
-    unsigned n_simt_ejection_buffer_size;
-    unsigned ldst_unit_response_queue_size;
+  // op collector
+  bool enable_specialized_operand_collector;
+  int gpgpu_operand_collector_num_units_sp;
+  int gpgpu_operand_collector_num_units_dp;
+  int gpgpu_operand_collector_num_units_sfu;
+  int gpgpu_operand_collector_num_units_tensor_core;
+  int gpgpu_operand_collector_num_units_mem;
+  int gpgpu_operand_collector_num_units_gen;
+  int gpgpu_operand_collector_num_units_int;
 
-    int simt_core_sim_order; 
-    
-    unsigned smem_latency;
+  unsigned int gpgpu_operand_collector_num_in_ports_sp;
+  unsigned int gpgpu_operand_collector_num_in_ports_dp;
+  unsigned int gpgpu_operand_collector_num_in_ports_sfu;
+  unsigned int gpgpu_operand_collector_num_in_ports_tensor_core;
+  unsigned int gpgpu_operand_collector_num_in_ports_mem;
+  unsigned int gpgpu_operand_collector_num_in_ports_gen;
+  unsigned int gpgpu_operand_collector_num_in_ports_int;
 
-    unsigned mem2device(unsigned memid) const { return memid + n_simt_clusters; }
+  unsigned int gpgpu_operand_collector_num_out_ports_sp;
+  unsigned int gpgpu_operand_collector_num_out_ports_dp;
+  unsigned int gpgpu_operand_collector_num_out_ports_sfu;
+  unsigned int gpgpu_operand_collector_num_out_ports_tensor_core;
+  unsigned int gpgpu_operand_collector_num_out_ports_mem;
+  unsigned int gpgpu_operand_collector_num_out_ports_gen;
+  unsigned int gpgpu_operand_collector_num_out_ports_int;
 
-    //Jin: concurrent kernel on sm
-    bool gpgpu_concurrent_kernel_sm;
+  int gpgpu_num_sp_units;
+  int gpgpu_tensor_core_avail;
+  int gpgpu_num_dp_units;
+  int gpgpu_num_sfu_units;
+  int gpgpu_num_tensor_core_units;
+  int gpgpu_num_mem_units;
+  int gpgpu_num_int_units;
 
-    bool adpative_volta_cache_config;
+  // Shader core resources
+  unsigned gpgpu_shader_registers;
+  int gpgpu_warpdistro_shader;
+  int gpgpu_warp_issue_shader;
+  unsigned gpgpu_num_reg_banks;
+  bool gpgpu_reg_bank_use_warp_id;
+  bool gpgpu_local_mem_map;
+  bool gpgpu_ignore_resources_limitation;
+  bool sub_core_model;
 
+  unsigned max_sp_latency;
+  unsigned max_int_latency;
+  unsigned max_sfu_latency;
+  unsigned max_dp_latency;
+  unsigned max_tensor_core_latency;
+
+  unsigned n_simt_cores_per_cluster;
+  unsigned n_simt_clusters;
+  unsigned n_simt_ejection_buffer_size;
+  unsigned ldst_unit_response_queue_size;
+
+  int simt_core_sim_order;
+
+  unsigned smem_latency;
+
+  unsigned mem2device(unsigned memid) const { return memid + n_simt_clusters; }
+
+  // Jin: concurrent kernel on sm
+  bool gpgpu_concurrent_kernel_sm;
+
+  bool adpative_volta_cache_config;
 };
 
 struct shader_core_stats_pod {
+  void *
+      shader_core_stats_pod_start[0];  // DO NOT MOVE FROM THE TOP - spaceless
+                                       // pointer to the start of this structure
+  unsigned long long *shader_cycles;
+  unsigned *m_num_sim_insn;   // number of scalar thread instructions committed
+                              // by this shader core
+  unsigned *m_num_sim_winsn;  // number of warp instructions committed by this
+                              // shader core
+  unsigned *m_last_num_sim_insn;
+  unsigned *m_last_num_sim_winsn;
+  unsigned *
+      m_num_decoded_insn;  // number of instructions decoded by this shader core
+  float *m_pipeline_duty_cycle;
+  unsigned *m_num_FPdecoded_insn;
+  unsigned *m_num_INTdecoded_insn;
+  unsigned *m_num_storequeued_insn;
+  unsigned *m_num_loadqueued_insn;
+  unsigned *m_num_ialu_acesses;
+  unsigned *m_num_fp_acesses;
+  unsigned *m_num_imul_acesses;
+  unsigned *m_num_tex_inst;
+  unsigned *m_num_fpmul_acesses;
+  unsigned *m_num_idiv_acesses;
+  unsigned *m_num_fpdiv_acesses;
+  unsigned *m_num_sp_acesses;
+  unsigned *m_num_sfu_acesses;
+  unsigned *m_num_tensor_core_acesses;
+  unsigned *m_num_trans_acesses;
+  unsigned *m_num_mem_acesses;
+  unsigned *m_num_sp_committed;
+  unsigned *m_num_tlb_hits;
+  unsigned *m_num_tlb_accesses;
+  unsigned *m_num_sfu_committed;
+  unsigned *m_num_tensor_core_committed;
+  unsigned *m_num_mem_committed;
+  unsigned *m_read_regfile_acesses;
+  unsigned *m_write_regfile_acesses;
+  unsigned *m_non_rf_operands;
+  unsigned *m_num_imul24_acesses;
+  unsigned *m_num_imul32_acesses;
+  unsigned *m_active_sp_lanes;
+  unsigned *m_active_sfu_lanes;
+  unsigned *m_active_tensor_core_lanes;
+  unsigned *m_active_fu_lanes;
+  unsigned *m_active_fu_mem_lanes;
+  unsigned *m_n_diverge;  // number of divergence occurring in this shader
+  unsigned gpgpu_n_load_insn;
+  unsigned gpgpu_n_store_insn;
+  unsigned gpgpu_n_shmem_insn;
+  unsigned gpgpu_n_sstarr_insn;
+  unsigned gpgpu_n_tex_insn;
+  unsigned gpgpu_n_const_insn;
+  unsigned gpgpu_n_param_insn;
+  unsigned gpgpu_n_shmem_bkconflict;
+  unsigned gpgpu_n_cache_bkconflict;
+  int gpgpu_n_intrawarp_mshr_merge;
+  unsigned gpgpu_n_cmem_portconflict;
+  unsigned gpu_stall_shd_mem_breakdown[N_MEM_STAGE_ACCESS_TYPE]
+                                      [N_MEM_STAGE_STALL_TYPE];
+  unsigned gpu_reg_bank_conflict_stalls;
+  unsigned *shader_cycle_distro;
+  unsigned *last_shader_cycle_distro;
+  unsigned *num_warps_issuable;
+  unsigned gpgpu_n_stall_shd_mem;
+  unsigned *single_issue_nums;
+  unsigned *dual_issue_nums;
 
-	void* shader_core_stats_pod_start[0]; // DO NOT MOVE FROM THE TOP - spaceless pointer to the start of this structure
-	unsigned long long *shader_cycles;
-    unsigned *m_num_sim_insn; // number of scalar thread instructions committed by this shader core
-    unsigned *m_num_sim_winsn; // number of warp instructions committed by this shader core
-	unsigned *m_last_num_sim_insn;
-	unsigned *m_last_num_sim_winsn;
-    unsigned *m_num_decoded_insn; // number of instructions decoded by this shader core
-    float *m_pipeline_duty_cycle;
-    unsigned *m_num_FPdecoded_insn;
-    unsigned *m_num_INTdecoded_insn;
-    unsigned *m_num_storequeued_insn;
-    unsigned *m_num_loadqueued_insn;
-    unsigned *m_num_ialu_acesses;
-    unsigned *m_num_fp_acesses;
-    unsigned *m_num_imul_acesses;
-    unsigned *m_num_tex_inst;
-    unsigned *m_num_fpmul_acesses;
-    unsigned *m_num_idiv_acesses;
-    unsigned *m_num_fpdiv_acesses;
-    unsigned *m_num_sp_acesses;
-    unsigned *m_num_sfu_acesses;
-    unsigned *m_num_tensor_core_acesses;
-    unsigned *m_num_trans_acesses;
-    unsigned *m_num_mem_acesses;
-    unsigned *m_num_sp_committed;
-    unsigned *m_num_tlb_hits;
-    unsigned *m_num_tlb_accesses;
-    unsigned *m_num_sfu_committed;
-    unsigned *m_num_tensor_core_committed;
-    unsigned *m_num_mem_committed;
-    unsigned *m_read_regfile_acesses;
-    unsigned *m_write_regfile_acesses;
-    unsigned *m_non_rf_operands;
-    unsigned *m_num_imul24_acesses;
-    unsigned *m_num_imul32_acesses;
-    unsigned *m_active_sp_lanes;
-    unsigned *m_active_sfu_lanes;
-    unsigned *m_active_tensor_core_lanes;
-    unsigned *m_active_fu_lanes;
-    unsigned *m_active_fu_mem_lanes;
-    unsigned *m_n_diverge;    // number of divergence occurring in this shader
-    unsigned gpgpu_n_load_insn;
-    unsigned gpgpu_n_store_insn;
-    unsigned gpgpu_n_shmem_insn;
-    unsigned gpgpu_n_sstarr_insn;
-    unsigned gpgpu_n_tex_insn;
-    unsigned gpgpu_n_const_insn;
-    unsigned gpgpu_n_param_insn;
-    unsigned gpgpu_n_shmem_bkconflict;
-    unsigned gpgpu_n_cache_bkconflict;
-    int      gpgpu_n_intrawarp_mshr_merge;
-    unsigned gpgpu_n_cmem_portconflict;
-    unsigned gpu_stall_shd_mem_breakdown[N_MEM_STAGE_ACCESS_TYPE][N_MEM_STAGE_STALL_TYPE];
-    unsigned gpu_reg_bank_conflict_stalls;
-    unsigned *shader_cycle_distro;
-    unsigned *last_shader_cycle_distro;
-    unsigned *num_warps_issuable;
-    unsigned gpgpu_n_stall_shd_mem;
-    unsigned* single_issue_nums;
-    unsigned* dual_issue_nums;
+  // memory access classification
+  int gpgpu_n_mem_read_local;
+  int gpgpu_n_mem_write_local;
+  int gpgpu_n_mem_texture;
+  int gpgpu_n_mem_const;
+  int gpgpu_n_mem_read_global;
+  int gpgpu_n_mem_write_global;
+  int gpgpu_n_mem_read_inst;
 
-    //memory access classification
-    int gpgpu_n_mem_read_local;
-    int gpgpu_n_mem_write_local;
-    int gpgpu_n_mem_texture;
-    int gpgpu_n_mem_const;
-    int gpgpu_n_mem_read_global;
-    int gpgpu_n_mem_write_global;
-    int gpgpu_n_mem_read_inst;
-    
-    int gpgpu_n_mem_l2_writeback;
-    int gpgpu_n_mem_l1_write_allocate; 
-    int gpgpu_n_mem_l2_write_allocate;
+  int gpgpu_n_mem_l2_writeback;
+  int gpgpu_n_mem_l1_write_allocate;
+  int gpgpu_n_mem_l2_write_allocate;
 
-    unsigned made_write_mfs;
-    unsigned made_read_mfs;
+  unsigned made_write_mfs;
+  unsigned made_read_mfs;
 
-    unsigned *gpgpu_n_shmem_bank_access;
-    long *n_simt_to_mem; // Interconnect power stats
-    long *n_mem_to_simt;
+  unsigned *gpgpu_n_shmem_bank_access;
+  long *n_simt_to_mem;  // Interconnect power stats
+  long *n_mem_to_simt;
 };
 
 class shader_core_stats : public shader_core_stats_pod {
-public:
-    shader_core_stats( const shader_core_config *config )
-    {
-        m_config = config;
-        shader_core_stats_pod *pod = reinterpret_cast< shader_core_stats_pod * > ( this->shader_core_stats_pod_start );
-        memset(pod,0,sizeof(shader_core_stats_pod));
-        shader_cycles=(unsigned long long *) calloc(config->num_shader(),sizeof(unsigned long long ));
-        m_num_sim_insn = (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_sim_winsn = (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_last_num_sim_winsn = (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_last_num_sim_insn = (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_pipeline_duty_cycle=(float*) calloc(config->num_shader(),sizeof(float));
-        m_num_decoded_insn = (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_FPdecoded_insn = (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_storequeued_insn=(unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_loadqueued_insn=(unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_INTdecoded_insn = (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_ialu_acesses = (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_fp_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_tex_inst= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_imul_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_imul24_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_imul32_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_fpmul_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_idiv_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_fpdiv_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_sp_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_sfu_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_tensor_core_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_trans_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_mem_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_sp_committed= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_tlb_hits=(unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_tlb_accesses=(unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_active_sp_lanes= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_active_sfu_lanes= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_active_tensor_core_lanes= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_active_fu_lanes= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_active_fu_mem_lanes= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_sfu_committed= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_tensor_core_committed= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_num_mem_committed= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_read_regfile_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_write_regfile_acesses= (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_non_rf_operands=(unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        m_n_diverge = (unsigned*) calloc(config->num_shader(),sizeof(unsigned));
-        shader_cycle_distro = (unsigned*) calloc(config->warp_size+3, sizeof(unsigned));
-        last_shader_cycle_distro = (unsigned*) calloc(m_config->warp_size+3, sizeof(unsigned));
-        single_issue_nums = (unsigned*) calloc(config->gpgpu_num_sched_per_core,sizeof(unsigned));
-        dual_issue_nums = (unsigned*) calloc(config->gpgpu_num_sched_per_core, sizeof(unsigned));
+ public:
+  shader_core_stats(const shader_core_config *config) {
+    m_config = config;
+    shader_core_stats_pod *pod = reinterpret_cast<shader_core_stats_pod *>(
+        this->shader_core_stats_pod_start);
+    memset(pod, 0, sizeof(shader_core_stats_pod));
+    shader_cycles = (unsigned long long *)calloc(config->num_shader(),
+                                                 sizeof(unsigned long long));
+    m_num_sim_insn = (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_sim_winsn =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_last_num_sim_winsn =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_last_num_sim_insn =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_pipeline_duty_cycle =
+        (float *)calloc(config->num_shader(), sizeof(float));
+    m_num_decoded_insn =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_FPdecoded_insn =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_storequeued_insn =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_loadqueued_insn =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_INTdecoded_insn =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_ialu_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_fp_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_tex_inst = (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_imul_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_imul24_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_imul32_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_fpmul_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_idiv_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_fpdiv_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_sp_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_sfu_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_tensor_core_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_trans_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_mem_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_sp_committed =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_tlb_hits = (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_tlb_accesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_active_sp_lanes =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_active_sfu_lanes =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_active_tensor_core_lanes =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_active_fu_lanes =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_active_fu_mem_lanes =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_sfu_committed =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_tensor_core_committed =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_num_mem_committed =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_read_regfile_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_write_regfile_acesses =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_non_rf_operands =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    m_n_diverge = (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    shader_cycle_distro =
+        (unsigned *)calloc(config->warp_size + 3, sizeof(unsigned));
+    last_shader_cycle_distro =
+        (unsigned *)calloc(m_config->warp_size + 3, sizeof(unsigned));
+    single_issue_nums =
+        (unsigned *)calloc(config->gpgpu_num_sched_per_core, sizeof(unsigned));
+    dual_issue_nums =
+        (unsigned *)calloc(config->gpgpu_num_sched_per_core, sizeof(unsigned));
 
-        n_simt_to_mem = (long *)calloc(config->num_shader(), sizeof(long));
-        n_mem_to_simt = (long *)calloc(config->num_shader(), sizeof(long));
+    n_simt_to_mem = (long *)calloc(config->num_shader(), sizeof(long));
+    n_mem_to_simt = (long *)calloc(config->num_shader(), sizeof(long));
 
-        m_outgoing_traffic_stats = new traffic_breakdown("coretomem"); 
-        m_incoming_traffic_stats = new traffic_breakdown("memtocore"); 
+    m_outgoing_traffic_stats = new traffic_breakdown("coretomem");
+    m_incoming_traffic_stats = new traffic_breakdown("memtocore");
 
-        gpgpu_n_shmem_bank_access = (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
+    gpgpu_n_shmem_bank_access =
+        (unsigned *)calloc(config->num_shader(), sizeof(unsigned));
 
-        m_shader_dynamic_warp_issue_distro.resize( config->num_shader() );
-        m_shader_warp_slot_issue_distro.resize( config->num_shader() );
-    }
+    m_shader_dynamic_warp_issue_distro.resize(config->num_shader());
+    m_shader_warp_slot_issue_distro.resize(config->num_shader());
+  }
 
-    ~shader_core_stats()
-    {
-        delete m_outgoing_traffic_stats; 
-        delete m_incoming_traffic_stats; 
-        free(m_num_sim_insn); 
-        free(m_num_sim_winsn);
-        free(m_n_diverge); 
-        free(shader_cycle_distro);
-        free(last_shader_cycle_distro);
-    }
+  ~shader_core_stats() {
+    delete m_outgoing_traffic_stats;
+    delete m_incoming_traffic_stats;
+    free(m_num_sim_insn);
+    free(m_num_sim_winsn);
+    free(m_n_diverge);
+    free(shader_cycle_distro);
+    free(last_shader_cycle_distro);
+  }
 
-    void new_grid()
-    {
-    }
+  void new_grid() {}
 
-    void event_warp_issued( unsigned s_id, unsigned warp_id, unsigned num_issued, unsigned dynamic_warp_id );
+  void event_warp_issued(unsigned s_id, unsigned warp_id, unsigned num_issued,
+                         unsigned dynamic_warp_id);
 
-    void visualizer_print( gzFile visualizer_file );
+  void visualizer_print(gzFile visualizer_file);
 
-    void print( FILE *fout ) const;
+  void print(FILE *fout) const;
 
-    const std::vector< std::vector<unsigned> >& get_dynamic_warp_issue() const
-    {
-        return m_shader_dynamic_warp_issue_distro;
-    }
+  const std::vector<std::vector<unsigned>> &get_dynamic_warp_issue() const {
+    return m_shader_dynamic_warp_issue_distro;
+  }
 
-    const std::vector< std::vector<unsigned> >& get_warp_slot_issue() const
-    {
-        return m_shader_warp_slot_issue_distro;
-    }
+  const std::vector<std::vector<unsigned>> &get_warp_slot_issue() const {
+    return m_shader_warp_slot_issue_distro;
+  }
 
-private:
-    const shader_core_config *m_config;
+ private:
+  const shader_core_config *m_config;
 
-    traffic_breakdown *m_outgoing_traffic_stats; // core to memory partitions
-    traffic_breakdown *m_incoming_traffic_stats; // memory partition to core 
+  traffic_breakdown *m_outgoing_traffic_stats;  // core to memory partitions
+  traffic_breakdown *m_incoming_traffic_stats;  // memory partition to core
 
-    // Counts the instructions issued for each dynamic warp.
-    std::vector< std::vector<unsigned> > m_shader_dynamic_warp_issue_distro;
-    std::vector<unsigned> m_last_shader_dynamic_warp_issue_distro;
-    std::vector< std::vector<unsigned> > m_shader_warp_slot_issue_distro;
-    std::vector<unsigned> m_last_shader_warp_slot_issue_distro;
+  // Counts the instructions issued for each dynamic warp.
+  std::vector<std::vector<unsigned>> m_shader_dynamic_warp_issue_distro;
+  std::vector<unsigned> m_last_shader_dynamic_warp_issue_distro;
+  std::vector<std::vector<unsigned>> m_shader_warp_slot_issue_distro;
+  std::vector<unsigned> m_last_shader_warp_slot_issue_distro;
 
-    friend class power_stat_t;
-    friend class shader_core_ctx;
-    friend class ldst_unit;
-    friend class simt_core_cluster;
-    friend class scheduler_unit;
-    friend class TwoLevelScheduler;
-    friend class LooseRoundRobbinScheduler;
+  friend class power_stat_t;
+  friend class shader_core_ctx;
+  friend class ldst_unit;
+  friend class simt_core_cluster;
+  friend class scheduler_unit;
+  friend class TwoLevelScheduler;
+  friend class LooseRoundRobbinScheduler;
 };
 
 class memory_config;
 class shader_core_mem_fetch_allocator : public mem_fetch_allocator {
-public:
-    shader_core_mem_fetch_allocator( unsigned core_id, unsigned cluster_id, const memory_config *config )
-    {
-    	m_core_id = core_id;
-    	m_cluster_id = cluster_id;
-    	m_memory_config = config;
-    }
-    mem_fetch *alloc( new_addr_type addr, mem_access_type type, unsigned size, bool wr, unsigned long long cycle ) const; 
-    mem_fetch *alloc( const warp_inst_t &inst, const mem_access_t &access, unsigned long long cycle ) const
-    {
-        warp_inst_t inst_copy = inst;
-        mem_fetch *mf = new mem_fetch(access, 
-                                      &inst_copy, 
-                                      access.is_write()?WRITE_PACKET_SIZE:READ_PACKET_SIZE,
-                                      inst.warp_id(),
-                                      m_core_id, 
-                                      m_cluster_id, 
-                                      m_memory_config,
-									  cycle);
-        return mf;
-    }
+ public:
+  shader_core_mem_fetch_allocator(unsigned core_id, unsigned cluster_id,
+                                  const memory_config *config) {
+    m_core_id = core_id;
+    m_cluster_id = cluster_id;
+    m_memory_config = config;
+  }
+  mem_fetch *alloc(new_addr_type addr, mem_access_type type, unsigned size,
+                   bool wr, unsigned long long cycle) const;
+  mem_fetch *alloc(const warp_inst_t &inst, const mem_access_t &access,
+                   unsigned long long cycle) const {
+    warp_inst_t inst_copy = inst;
+    mem_fetch *mf = new mem_fetch(
+        access, &inst_copy,
+        access.is_write() ? WRITE_PACKET_SIZE : READ_PACKET_SIZE,
+        inst.warp_id(), m_core_id, m_cluster_id, m_memory_config, cycle);
+    return mf;
+  }
 
-private:
-    unsigned m_core_id;
-    unsigned m_cluster_id;
-    const memory_config *m_memory_config;
+ private:
+  unsigned m_core_id;
+  unsigned m_cluster_id;
+  const memory_config *m_memory_config;
 };
 
 class shader_core_ctx : public core_t {
-public:
-    // creator:
-    shader_core_ctx( class gpgpu_sim *gpu,
-                     class simt_core_cluster *cluster,
-                     unsigned shader_id,
-                     unsigned tpc_id,
-                     const shader_core_config *config,
-                     const memory_config *mem_config,
-                     shader_core_stats *stats );
+ public:
+  // creator:
+  shader_core_ctx(class gpgpu_sim *gpu, class simt_core_cluster *cluster,
+                  unsigned shader_id, unsigned tpc_id,
+                  const shader_core_config *config,
+                  const memory_config *mem_config, shader_core_stats *stats);
 
-// used by simt_core_cluster:
-    // modifiers
-    void cycle();
-    void reinit(unsigned start_thread, unsigned end_thread, bool reset_not_completed );
-    void issue_block2core( class kernel_info_t &kernel );
+  // used by simt_core_cluster:
+  // modifiers
+  void cycle();
+  void reinit(unsigned start_thread, unsigned end_thread,
+              bool reset_not_completed);
+  void issue_block2core(class kernel_info_t &kernel);
 
-    void cache_flush();
-    void cache_invalidate();
-    void accept_fetch_response( mem_fetch *mf );
-    void accept_ldst_unit_response( class mem_fetch * mf );
-    void broadcast_barrier_reduction(unsigned cta_id, unsigned bar_id,warp_set_t warps);
-    void set_kernel( kernel_info_t *k ) 
-    {
-        assert(k);
-        m_kernel=k; 
-//        k->inc_running(); 
-        printf("GPGPU-Sim uArch: Shader %d bind to kernel %u \'%s\'\n", m_sid, m_kernel->get_uid(),
-                 m_kernel->name().c_str() );
+  void cache_flush();
+  void cache_invalidate();
+  void accept_fetch_response(mem_fetch *mf);
+  void accept_ldst_unit_response(class mem_fetch *mf);
+  void broadcast_barrier_reduction(unsigned cta_id, unsigned bar_id,
+                                   warp_set_t warps);
+  void set_kernel(kernel_info_t *k) {
+    assert(k);
+    m_kernel = k;
+    //        k->inc_running();
+    printf("GPGPU-Sim uArch: Shader %d bind to kernel %u \'%s\'\n", m_sid,
+           m_kernel->get_uid(), m_kernel->name().c_str());
+  }
+
+  // accessors
+  bool fetch_unit_response_buffer_full() const;
+  bool ldst_unit_response_buffer_full() const;
+  unsigned get_not_completed() const { return m_not_completed; }
+  unsigned get_n_active_cta() const { return m_n_active_cta; }
+  unsigned isactive() const {
+    if (m_n_active_cta > 0)
+      return 1;
+    else
+      return 0;
+  }
+  kernel_info_t *get_kernel() { return m_kernel; }
+  unsigned get_sid() const { return m_sid; }
+
+  // used by functional simulation:
+  // modifiers
+  virtual void warp_exit(unsigned warp_id);
+
+  // accessors
+  virtual bool warp_waiting_at_barrier(unsigned warp_id) const;
+  void get_pdom_stack_top_info(unsigned tid, unsigned *pc, unsigned *rpc) const;
+  float get_current_occupancy(unsigned long long &active,
+                              unsigned long long &total) const;
+
+  // used by pipeline timing model components:
+  // modifiers
+  void mem_instruction_stats(const warp_inst_t &inst);
+  void decrement_atomic_count(unsigned wid, unsigned n);
+  void inc_store_req(unsigned warp_id) { m_warp[warp_id].inc_store_req(); }
+  void dec_inst_in_pipeline(unsigned warp_id) {
+    m_warp[warp_id].dec_inst_in_pipeline();
+  }  // also used in writeback()
+  void store_ack(class mem_fetch *mf);
+  bool warp_waiting_at_mem_barrier(unsigned warp_id);
+  void set_max_cta(const kernel_info_t &kernel);
+  void warp_inst_complete(const warp_inst_t &inst);
+
+  // accessors
+  std::list<unsigned> get_regs_written(const inst_t &fvt) const;
+  const shader_core_config *get_config() const { return m_config; }
+  void print_cache_stats(FILE *fp, unsigned &dl1_accesses,
+                         unsigned &dl1_misses);
+
+  void get_cache_stats(cache_stats &cs);
+  void get_L1I_sub_stats(struct cache_sub_stats &css) const;
+  void get_L1D_sub_stats(struct cache_sub_stats &css) const;
+  void get_L1C_sub_stats(struct cache_sub_stats &css) const;
+  void get_L1T_sub_stats(struct cache_sub_stats &css) const;
+
+  void get_icnt_power_stats(long &n_simt_to_mem, long &n_mem_to_simt) const;
+
+  // debug:
+  void display_simt_state(FILE *fout, int mask) const;
+  void display_pipeline(FILE *fout, int print_mem, int mask3bit) const;
+
+  void incload_stat() { m_stats->m_num_loadqueued_insn[m_sid]++; }
+  void incstore_stat() { m_stats->m_num_storequeued_insn[m_sid]++; }
+  void incialu_stat(unsigned active_count, double latency) {
+    if (m_config->gpgpu_clock_gated_lanes == false) {
+      m_stats->m_num_ialu_acesses[m_sid] =
+          m_stats->m_num_ialu_acesses[m_sid] + active_count * latency +
+          inactive_lanes_accesses_nonsfu(active_count, latency);
+    } else {
+      m_stats->m_num_ialu_acesses[m_sid] =
+          m_stats->m_num_ialu_acesses[m_sid] + active_count * latency;
     }
-   
-    // accessors
-    bool fetch_unit_response_buffer_full() const;
-    bool ldst_unit_response_buffer_full() const;
-    unsigned get_not_completed() const { return m_not_completed; }
-    unsigned get_n_active_cta() const { return m_n_active_cta; }
-    unsigned isactive() const {if(m_n_active_cta>0) return 1; else return 0;}
-    kernel_info_t *get_kernel() { return m_kernel; }
-    unsigned get_sid() const {return m_sid;}
-
-// used by functional simulation:
-    // modifiers
-    virtual void warp_exit( unsigned warp_id );
-    
-    // accessors
-    virtual bool warp_waiting_at_barrier( unsigned warp_id ) const;
-    void get_pdom_stack_top_info( unsigned tid, unsigned *pc, unsigned *rpc ) const;
-    float get_current_occupancy( unsigned long long & active, unsigned long long & total ) const;
-
-// used by pipeline timing model components:
-    // modifiers
-    void mem_instruction_stats(const warp_inst_t &inst);
-    void decrement_atomic_count( unsigned wid, unsigned n );
-    void inc_store_req( unsigned warp_id) { m_warp[warp_id].inc_store_req(); }
-    void dec_inst_in_pipeline( unsigned warp_id ) { m_warp[warp_id].dec_inst_in_pipeline(); } // also used in writeback()
-    void store_ack( class mem_fetch *mf );
-    bool warp_waiting_at_mem_barrier( unsigned warp_id );
-    void set_max_cta( const kernel_info_t &kernel );
-    void warp_inst_complete(const warp_inst_t &inst);
-    
-    // accessors
-    std::list<unsigned> get_regs_written( const inst_t &fvt ) const;
-    const shader_core_config *get_config() const { return m_config; }
-    void print_cache_stats( FILE *fp, unsigned& dl1_accesses, unsigned& dl1_misses );
-
-    void get_cache_stats(cache_stats &cs);
-    void get_L1I_sub_stats(struct cache_sub_stats &css) const;
-    void get_L1D_sub_stats(struct cache_sub_stats &css) const;
-    void get_L1C_sub_stats(struct cache_sub_stats &css) const;
-    void get_L1T_sub_stats(struct cache_sub_stats &css) const;
-
-    void get_icnt_power_stats(long &n_simt_to_mem, long &n_mem_to_simt) const;
-
-// debug:
-    void display_simt_state(FILE *fout, int mask ) const;
-    void display_pipeline( FILE *fout, int print_mem, int mask3bit ) const;
-
-    void incload_stat() {m_stats->m_num_loadqueued_insn[m_sid]++;}
-    void incstore_stat() {m_stats->m_num_storequeued_insn[m_sid]++;}
-    void incialu_stat(unsigned active_count,double latency) {
-		if(m_config->gpgpu_clock_gated_lanes==false){
-		  m_stats->m_num_ialu_acesses[m_sid]=m_stats->m_num_ialu_acesses[m_sid]+active_count*latency
-		    + inactive_lanes_accesses_nonsfu(active_count, latency);
-		}else {
-        m_stats->m_num_ialu_acesses[m_sid]=m_stats->m_num_ialu_acesses[m_sid]+active_count*latency;
-		}
-	 }
-    void inctex_stat(unsigned active_count,double latency){
-    	m_stats->m_num_tex_inst[m_sid]=m_stats->m_num_tex_inst[m_sid]+active_count*latency;
+  }
+  void inctex_stat(unsigned active_count, double latency) {
+    m_stats->m_num_tex_inst[m_sid] =
+        m_stats->m_num_tex_inst[m_sid] + active_count * latency;
+  }
+  void incimul_stat(unsigned active_count, double latency) {
+    if (m_config->gpgpu_clock_gated_lanes == false) {
+      m_stats->m_num_imul_acesses[m_sid] =
+          m_stats->m_num_imul_acesses[m_sid] + active_count * latency +
+          inactive_lanes_accesses_nonsfu(active_count, latency);
+    } else {
+      m_stats->m_num_imul_acesses[m_sid] =
+          m_stats->m_num_imul_acesses[m_sid] + active_count * latency;
     }
-    void incimul_stat(unsigned active_count,double latency) {
-		if(m_config->gpgpu_clock_gated_lanes==false){
-		  m_stats->m_num_imul_acesses[m_sid]=m_stats->m_num_imul_acesses[m_sid]+active_count*latency
-		    + inactive_lanes_accesses_nonsfu(active_count, latency);
-		}else {
-        m_stats->m_num_imul_acesses[m_sid]=m_stats->m_num_imul_acesses[m_sid]+active_count*latency;
-		}
-	 }
-    void incimul24_stat(unsigned active_count,double latency) {
-      if(m_config->gpgpu_clock_gated_lanes==false){
-   		m_stats->m_num_imul24_acesses[m_sid]=m_stats->m_num_imul24_acesses[m_sid]+active_count*latency
-		    + inactive_lanes_accesses_nonsfu(active_count, latency);
-		}else {
-		  m_stats->m_num_imul24_acesses[m_sid]=m_stats->m_num_imul24_acesses[m_sid]+active_count*latency;
-		}
-	 }
-	 void incimul32_stat(unsigned active_count,double latency) {
-		if(m_config->gpgpu_clock_gated_lanes==false){
-		  m_stats->m_num_imul32_acesses[m_sid]=m_stats->m_num_imul32_acesses[m_sid]+active_count*latency
-			 + inactive_lanes_accesses_sfu(active_count, latency);			
-		}else{
-		  m_stats->m_num_imul32_acesses[m_sid]=m_stats->m_num_imul32_acesses[m_sid]+active_count*latency;
-		}
-		//printf("Int_Mul -- Active_count: %d\n",active_count);
-	 }
-	 void incidiv_stat(unsigned active_count,double latency) {
-		if(m_config->gpgpu_clock_gated_lanes==false){
-		  m_stats->m_num_idiv_acesses[m_sid]=m_stats->m_num_idiv_acesses[m_sid]+active_count*latency
-			 + inactive_lanes_accesses_sfu(active_count, latency); 
-		}else {
-		  m_stats->m_num_idiv_acesses[m_sid]=m_stats->m_num_idiv_acesses[m_sid]+active_count*latency;
-		}
-	 }
-	 void incfpalu_stat(unsigned active_count,double latency) {
-		if(m_config->gpgpu_clock_gated_lanes==false){
-		  m_stats->m_num_fp_acesses[m_sid]=m_stats->m_num_fp_acesses[m_sid]+active_count*latency
-			 + inactive_lanes_accesses_nonsfu(active_count, latency);
-		}else {
-        m_stats->m_num_fp_acesses[m_sid]=m_stats->m_num_fp_acesses[m_sid]+active_count*latency;
-		} 
-	 }
-	 void incfpmul_stat(unsigned active_count,double latency) {
-		 		// printf("FP MUL stat increament\n");
-      if(m_config->gpgpu_clock_gated_lanes==false){
-		  m_stats->m_num_fpmul_acesses[m_sid]=m_stats->m_num_fpmul_acesses[m_sid]+active_count*latency
-		    + inactive_lanes_accesses_nonsfu(active_count, latency);
-		}else {
-        m_stats->m_num_fpmul_acesses[m_sid]=m_stats->m_num_fpmul_acesses[m_sid]+active_count*latency;
-		}
-	 }
-	 void incfpdiv_stat(unsigned active_count,double latency) {
-		if(m_config->gpgpu_clock_gated_lanes==false){
-		  m_stats->m_num_fpdiv_acesses[m_sid]=m_stats->m_num_fpdiv_acesses[m_sid]+active_count*latency
-			+ inactive_lanes_accesses_sfu(active_count, latency); 
-		}else {
-		  m_stats->m_num_fpdiv_acesses[m_sid]=m_stats->m_num_fpdiv_acesses[m_sid]+active_count*latency;
-		}
-	 }
-	 void inctrans_stat(unsigned active_count,double latency) {
-		if(m_config->gpgpu_clock_gated_lanes==false){
-		  m_stats->m_num_trans_acesses[m_sid]=m_stats->m_num_trans_acesses[m_sid]+active_count*latency
-			+ inactive_lanes_accesses_sfu(active_count, latency); 
-		}else{
-		  m_stats->m_num_trans_acesses[m_sid]=m_stats->m_num_trans_acesses[m_sid]+active_count*latency;
-		}
-	 }
+  }
+  void incimul24_stat(unsigned active_count, double latency) {
+    if (m_config->gpgpu_clock_gated_lanes == false) {
+      m_stats->m_num_imul24_acesses[m_sid] =
+          m_stats->m_num_imul24_acesses[m_sid] + active_count * latency +
+          inactive_lanes_accesses_nonsfu(active_count, latency);
+    } else {
+      m_stats->m_num_imul24_acesses[m_sid] =
+          m_stats->m_num_imul24_acesses[m_sid] + active_count * latency;
+    }
+  }
+  void incimul32_stat(unsigned active_count, double latency) {
+    if (m_config->gpgpu_clock_gated_lanes == false) {
+      m_stats->m_num_imul32_acesses[m_sid] =
+          m_stats->m_num_imul32_acesses[m_sid] + active_count * latency +
+          inactive_lanes_accesses_sfu(active_count, latency);
+    } else {
+      m_stats->m_num_imul32_acesses[m_sid] =
+          m_stats->m_num_imul32_acesses[m_sid] + active_count * latency;
+    }
+    // printf("Int_Mul -- Active_count: %d\n",active_count);
+  }
+  void incidiv_stat(unsigned active_count, double latency) {
+    if (m_config->gpgpu_clock_gated_lanes == false) {
+      m_stats->m_num_idiv_acesses[m_sid] =
+          m_stats->m_num_idiv_acesses[m_sid] + active_count * latency +
+          inactive_lanes_accesses_sfu(active_count, latency);
+    } else {
+      m_stats->m_num_idiv_acesses[m_sid] =
+          m_stats->m_num_idiv_acesses[m_sid] + active_count * latency;
+    }
+  }
+  void incfpalu_stat(unsigned active_count, double latency) {
+    if (m_config->gpgpu_clock_gated_lanes == false) {
+      m_stats->m_num_fp_acesses[m_sid] =
+          m_stats->m_num_fp_acesses[m_sid] + active_count * latency +
+          inactive_lanes_accesses_nonsfu(active_count, latency);
+    } else {
+      m_stats->m_num_fp_acesses[m_sid] =
+          m_stats->m_num_fp_acesses[m_sid] + active_count * latency;
+    }
+  }
+  void incfpmul_stat(unsigned active_count, double latency) {
+    // printf("FP MUL stat increament\n");
+    if (m_config->gpgpu_clock_gated_lanes == false) {
+      m_stats->m_num_fpmul_acesses[m_sid] =
+          m_stats->m_num_fpmul_acesses[m_sid] + active_count * latency +
+          inactive_lanes_accesses_nonsfu(active_count, latency);
+    } else {
+      m_stats->m_num_fpmul_acesses[m_sid] =
+          m_stats->m_num_fpmul_acesses[m_sid] + active_count * latency;
+    }
+  }
+  void incfpdiv_stat(unsigned active_count, double latency) {
+    if (m_config->gpgpu_clock_gated_lanes == false) {
+      m_stats->m_num_fpdiv_acesses[m_sid] =
+          m_stats->m_num_fpdiv_acesses[m_sid] + active_count * latency +
+          inactive_lanes_accesses_sfu(active_count, latency);
+    } else {
+      m_stats->m_num_fpdiv_acesses[m_sid] =
+          m_stats->m_num_fpdiv_acesses[m_sid] + active_count * latency;
+    }
+  }
+  void inctrans_stat(unsigned active_count, double latency) {
+    if (m_config->gpgpu_clock_gated_lanes == false) {
+      m_stats->m_num_trans_acesses[m_sid] =
+          m_stats->m_num_trans_acesses[m_sid] + active_count * latency +
+          inactive_lanes_accesses_sfu(active_count, latency);
+    } else {
+      m_stats->m_num_trans_acesses[m_sid] =
+          m_stats->m_num_trans_acesses[m_sid] + active_count * latency;
+    }
+  }
 
-	 void incsfu_stat(unsigned active_count,double latency) {m_stats->m_num_sfu_acesses[m_sid]=m_stats->m_num_sfu_acesses[m_sid]+active_count*latency;}
-	 void incsp_stat(unsigned active_count,double latency) {m_stats->m_num_sp_acesses[m_sid]=m_stats->m_num_sp_acesses[m_sid]+active_count*latency;}
-	 void incmem_stat(unsigned active_count,double latency) {
-		if(m_config->gpgpu_clock_gated_lanes==false){
-		  m_stats->m_num_mem_acesses[m_sid]=m_stats->m_num_mem_acesses[m_sid]+active_count*latency
-		    + inactive_lanes_accesses_nonsfu(active_count, latency);
-		}else {
-		  m_stats->m_num_mem_acesses[m_sid]=m_stats->m_num_mem_acesses[m_sid]+active_count*latency;
-		}
-	 }
-	 void incexecstat(warp_inst_t *&inst);
+  void incsfu_stat(unsigned active_count, double latency) {
+    m_stats->m_num_sfu_acesses[m_sid] =
+        m_stats->m_num_sfu_acesses[m_sid] + active_count * latency;
+  }
+  void incsp_stat(unsigned active_count, double latency) {
+    m_stats->m_num_sp_acesses[m_sid] =
+        m_stats->m_num_sp_acesses[m_sid] + active_count * latency;
+  }
+  void incmem_stat(unsigned active_count, double latency) {
+    if (m_config->gpgpu_clock_gated_lanes == false) {
+      m_stats->m_num_mem_acesses[m_sid] =
+          m_stats->m_num_mem_acesses[m_sid] + active_count * latency +
+          inactive_lanes_accesses_nonsfu(active_count, latency);
+    } else {
+      m_stats->m_num_mem_acesses[m_sid] =
+          m_stats->m_num_mem_acesses[m_sid] + active_count * latency;
+    }
+  }
+  void incexecstat(warp_inst_t *&inst);
 
-	 void incregfile_reads(unsigned active_count) {m_stats->m_read_regfile_acesses[m_sid]=m_stats->m_read_regfile_acesses[m_sid]+active_count;}
-	 void incregfile_writes(unsigned active_count){m_stats->m_write_regfile_acesses[m_sid]=m_stats->m_write_regfile_acesses[m_sid]+active_count;}
-	 void incnon_rf_operands(unsigned active_count){m_stats->m_non_rf_operands[m_sid]=m_stats->m_non_rf_operands[m_sid]+active_count;}
+  void incregfile_reads(unsigned active_count) {
+    m_stats->m_read_regfile_acesses[m_sid] =
+        m_stats->m_read_regfile_acesses[m_sid] + active_count;
+  }
+  void incregfile_writes(unsigned active_count) {
+    m_stats->m_write_regfile_acesses[m_sid] =
+        m_stats->m_write_regfile_acesses[m_sid] + active_count;
+  }
+  void incnon_rf_operands(unsigned active_count) {
+    m_stats->m_non_rf_operands[m_sid] =
+        m_stats->m_non_rf_operands[m_sid] + active_count;
+  }
 
-	 void incspactivelanes_stat(unsigned active_count) {m_stats->m_active_sp_lanes[m_sid]=m_stats->m_active_sp_lanes[m_sid]+active_count;}
-	 void incsfuactivelanes_stat(unsigned active_count) {m_stats->m_active_sfu_lanes[m_sid]=m_stats->m_active_sfu_lanes[m_sid]+active_count;}
-	 void incfuactivelanes_stat(unsigned active_count) {m_stats->m_active_fu_lanes[m_sid]=m_stats->m_active_fu_lanes[m_sid]+active_count;}
-	 void incfumemactivelanes_stat(unsigned active_count) {m_stats->m_active_fu_mem_lanes[m_sid]=m_stats->m_active_fu_mem_lanes[m_sid]+active_count;}
+  void incspactivelanes_stat(unsigned active_count) {
+    m_stats->m_active_sp_lanes[m_sid] =
+        m_stats->m_active_sp_lanes[m_sid] + active_count;
+  }
+  void incsfuactivelanes_stat(unsigned active_count) {
+    m_stats->m_active_sfu_lanes[m_sid] =
+        m_stats->m_active_sfu_lanes[m_sid] + active_count;
+  }
+  void incfuactivelanes_stat(unsigned active_count) {
+    m_stats->m_active_fu_lanes[m_sid] =
+        m_stats->m_active_fu_lanes[m_sid] + active_count;
+  }
+  void incfumemactivelanes_stat(unsigned active_count) {
+    m_stats->m_active_fu_mem_lanes[m_sid] =
+        m_stats->m_active_fu_mem_lanes[m_sid] + active_count;
+  }
 
-	 void inc_simt_to_mem(unsigned n_flits){ m_stats->n_simt_to_mem[m_sid] += n_flits; }
-	 bool check_if_non_released_reduction_barrier(warp_inst_t &inst);
+  void inc_simt_to_mem(unsigned n_flits) {
+    m_stats->n_simt_to_mem[m_sid] += n_flits;
+  }
+  bool check_if_non_released_reduction_barrier(warp_inst_t &inst);
 
-	private:
-	 unsigned inactive_lanes_accesses_sfu(unsigned active_count,double latency){
-      return  ( ((32-active_count)>>1)*latency) + ( ((32-active_count)>>3)*latency) + ( ((32-active_count)>>3)*latency);
-	 }
-	 unsigned inactive_lanes_accesses_nonsfu(unsigned active_count,double latency){
-      return  ( ((32-active_count)>>1)*latency);
-	 }
+ private:
+  unsigned inactive_lanes_accesses_sfu(unsigned active_count, double latency) {
+    return (((32 - active_count) >> 1) * latency) +
+           (((32 - active_count) >> 3) * latency) +
+           (((32 - active_count) >> 3) * latency);
+  }
+  unsigned inactive_lanes_accesses_nonsfu(unsigned active_count,
+                                          double latency) {
+    return (((32 - active_count) >> 1) * latency);
+  }
 
-    int test_res_bus(int latency);
-    void init_warps(unsigned cta_id, unsigned start_thread, unsigned end_thread,unsigned ctaid, int cta_size, unsigned kernel_id);
-    virtual void checkExecutionStatusAndUpdate(warp_inst_t &inst, unsigned t, unsigned tid);
-    address_type next_pc( int tid ) const;
-    void fetch();
-    void register_cta_thread_exit(unsigned cta_num, kernel_info_t * kernel );
+  int test_res_bus(int latency);
+  void init_warps(unsigned cta_id, unsigned start_thread, unsigned end_thread,
+                  unsigned ctaid, int cta_size, unsigned kernel_id);
+  virtual void checkExecutionStatusAndUpdate(warp_inst_t &inst, unsigned t,
+                                             unsigned tid);
+  address_type next_pc(int tid) const;
+  void fetch();
+  void register_cta_thread_exit(unsigned cta_num, kernel_info_t *kernel);
 
-    void decode();
-    
-    void issue();
-    friend class scheduler_unit; //this is needed to use private issue warp.
-    friend class TwoLevelScheduler;
-    friend class LooseRoundRobbinScheduler;
-    void issue_warp( register_set& warp, const warp_inst_t *pI, const active_mask_t &active_mask, unsigned warp_id, unsigned sch_id );
-    void func_exec_inst( warp_inst_t &inst );
+  void decode();
 
-     // Returns numbers of addresses in translated_addrs
-    unsigned translate_local_memaddr( address_type localaddr, unsigned tid, unsigned num_shader, unsigned datasize, new_addr_type* translated_addrs );
+  void issue();
+  friend class scheduler_unit;  // this is needed to use private issue warp.
+  friend class TwoLevelScheduler;
+  friend class LooseRoundRobbinScheduler;
+  void issue_warp(register_set &warp, const warp_inst_t *pI,
+                  const active_mask_t &active_mask, unsigned warp_id,
+                  unsigned sch_id);
+  void func_exec_inst(warp_inst_t &inst);
 
-    void read_operands();
-    
-    void execute();
-    
-    void writeback();
-    
-    // used in display_pipeline():
-    void dump_warp_state( FILE *fout ) const;
-    void print_stage(unsigned int stage, FILE *fout) const;
-    unsigned long long m_last_inst_gpu_sim_cycle;
-    unsigned long long m_last_inst_gpu_tot_sim_cycle;
+  // Returns numbers of addresses in translated_addrs
+  unsigned translate_local_memaddr(address_type localaddr, unsigned tid,
+                                   unsigned num_shader, unsigned datasize,
+                                   new_addr_type *translated_addrs);
 
-    // general information
-    unsigned m_sid; // shader id
-    unsigned m_tpc; // texture processor cluster id (aka, node id when using interconnect concentration)
-    const shader_core_config *m_config;
-    const memory_config *m_memory_config;
-    class simt_core_cluster *m_cluster;
+  void read_operands();
 
-    // statistics 
-    shader_core_stats *m_stats;
+  void execute();
 
-    // CTA scheduling / hardware thread allocation
-    unsigned m_n_active_cta; // number of Cooperative Thread Arrays (blocks) currently running on this shader.
-    unsigned m_cta_status[MAX_CTA_PER_SHADER]; // CTAs status 
-    unsigned m_not_completed; // number of threads to be completed (==0 when all thread on this core completed) 
-    std::bitset<MAX_THREAD_PER_SM> m_active_threads;
-    
-    // thread contexts 
-    thread_ctx_t             *m_threadState;
-    
-    // interconnect interface
-    mem_fetch_interface *m_icnt;
-    shader_core_mem_fetch_allocator *m_mem_fetch_allocator;
-    
-    // fetch
-    read_only_cache *m_L1I; // instruction cache
-    int  m_last_warp_fetched;
+  void writeback();
 
-    // decode/dispatch
-    std::vector<shd_warp_t>   m_warp;   // per warp information array
-    barrier_set_t             m_barriers;
-    ifetch_buffer_t           m_inst_fetch_buffer;
-    std::vector<register_set> m_pipeline_reg;
-    Scoreboard               *m_scoreboard;
-    opndcoll_rfu_t            m_operand_collector;
-    int m_active_warps;
+  // used in display_pipeline():
+  void dump_warp_state(FILE *fout) const;
+  void print_stage(unsigned int stage, FILE *fout) const;
+  unsigned long long m_last_inst_gpu_sim_cycle;
+  unsigned long long m_last_inst_gpu_tot_sim_cycle;
 
-    //schedule
-    std::vector<scheduler_unit*>  schedulers;
+  // general information
+  unsigned m_sid;  // shader id
+  unsigned m_tpc;  // texture processor cluster id (aka, node id when using
+                   // interconnect concentration)
+  const shader_core_config *m_config;
+  const memory_config *m_memory_config;
+  class simt_core_cluster *m_cluster;
 
-    //issue
-    unsigned int Issue_Prio;
+  // statistics
+  shader_core_stats *m_stats;
 
-    // execute
-    unsigned m_num_function_units;
-    std::vector<pipeline_stage_name_t> m_dispatch_port;
-    std::vector<pipeline_stage_name_t> m_issue_port;
-    std::vector<simd_function_unit*> m_fu; // stallable pipelines should be last in this array
-    ldst_unit *m_ldst_unit;
-    static const unsigned MAX_ALU_LATENCY = 512;
-    unsigned num_result_bus;
-    std::vector< std::bitset<MAX_ALU_LATENCY>* > m_result_bus;
+  // CTA scheduling / hardware thread allocation
+  unsigned m_n_active_cta;  // number of Cooperative Thread Arrays (blocks)
+                            // currently running on this shader.
+  unsigned m_cta_status[MAX_CTA_PER_SHADER];  // CTAs status
+  unsigned m_not_completed;  // number of threads to be completed (==0 when all
+                             // thread on this core completed)
+  std::bitset<MAX_THREAD_PER_SM> m_active_threads;
 
-    // used for local address mapping with single kernel launch
-    unsigned kernel_max_cta_per_shader;
-    unsigned kernel_padded_threads_per_cta;
-    // Used for handing out dynamic warp_ids to new warps.
-    // the differnece between a warp_id and a dynamic_warp_id
-    // is that the dynamic_warp_id is a running number unique to every warp
-    // run on this shader, where the warp_id is the static warp slot.
-    unsigned m_dynamic_warp_id;
+  // thread contexts
+  thread_ctx_t *m_threadState;
 
-    //Jin: concurrent kernels on a sm
-public:
-    bool can_issue_1block(kernel_info_t & kernel);
-    bool occupy_shader_resource_1block(kernel_info_t & kernel, bool occupy);
-    void release_shader_resource_1block(unsigned hw_ctaid, kernel_info_t & kernel);
-    int find_available_hwtid(unsigned int cta_size, bool occupy);
-private:
-    unsigned int m_occupied_n_threads; 
-    unsigned int m_occupied_shmem; 
-    unsigned int m_occupied_regs;
-    unsigned int m_occupied_ctas;
-    std::bitset<MAX_THREAD_PER_SM> m_occupied_hwtid;
-    std::map<unsigned int, unsigned int> m_occupied_cta_to_hwtid; 
+  // interconnect interface
+  mem_fetch_interface *m_icnt;
+  shader_core_mem_fetch_allocator *m_mem_fetch_allocator;
 
+  // fetch
+  read_only_cache *m_L1I;  // instruction cache
+  int m_last_warp_fetched;
 
+  // decode/dispatch
+  std::vector<shd_warp_t> m_warp;  // per warp information array
+  barrier_set_t m_barriers;
+  ifetch_buffer_t m_inst_fetch_buffer;
+  std::vector<register_set> m_pipeline_reg;
+  Scoreboard *m_scoreboard;
+  opndcoll_rfu_t m_operand_collector;
+  int m_active_warps;
+
+  // schedule
+  std::vector<scheduler_unit *> schedulers;
+
+  // issue
+  unsigned int Issue_Prio;
+
+  // execute
+  unsigned m_num_function_units;
+  std::vector<pipeline_stage_name_t> m_dispatch_port;
+  std::vector<pipeline_stage_name_t> m_issue_port;
+  std::vector<simd_function_unit *>
+      m_fu;  // stallable pipelines should be last in this array
+  ldst_unit *m_ldst_unit;
+  static const unsigned MAX_ALU_LATENCY = 512;
+  unsigned num_result_bus;
+  std::vector<std::bitset<MAX_ALU_LATENCY> *> m_result_bus;
+
+  // used for local address mapping with single kernel launch
+  unsigned kernel_max_cta_per_shader;
+  unsigned kernel_padded_threads_per_cta;
+  // Used for handing out dynamic warp_ids to new warps.
+  // the differnece between a warp_id and a dynamic_warp_id
+  // is that the dynamic_warp_id is a running number unique to every warp
+  // run on this shader, where the warp_id is the static warp slot.
+  unsigned m_dynamic_warp_id;
+
+  // Jin: concurrent kernels on a sm
+ public:
+  bool can_issue_1block(kernel_info_t &kernel);
+  bool occupy_shader_resource_1block(kernel_info_t &kernel, bool occupy);
+  void release_shader_resource_1block(unsigned hw_ctaid, kernel_info_t &kernel);
+  int find_available_hwtid(unsigned int cta_size, bool occupy);
+
+ private:
+  unsigned int m_occupied_n_threads;
+  unsigned int m_occupied_shmem;
+  unsigned int m_occupied_regs;
+  unsigned int m_occupied_ctas;
+  std::bitset<MAX_THREAD_PER_SM> m_occupied_hwtid;
+  std::map<unsigned int, unsigned int> m_occupied_cta_to_hwtid;
 };
 
 class simt_core_cluster {
-public:
-    simt_core_cluster( class gpgpu_sim *gpu, 
-                       unsigned cluster_id, 
-                       const shader_core_config *config, 
-                       const memory_config *mem_config,
-                       shader_core_stats *stats,
-                       memory_stats_t *mstats );
+ public:
+  simt_core_cluster(class gpgpu_sim *gpu, unsigned cluster_id,
+                    const shader_core_config *config,
+                    const memory_config *mem_config, shader_core_stats *stats,
+                    memory_stats_t *mstats);
 
-    void core_cycle();
-    void icnt_cycle();
+  void core_cycle();
+  void icnt_cycle();
 
-    void reinit();
-    unsigned issue_block2core();
-    void cache_flush();
-    void cache_invalidate();
-    bool icnt_injection_buffer_full(unsigned size, bool write);
-    void icnt_inject_request_packet(class mem_fetch *mf);
+  void reinit();
+  unsigned issue_block2core();
+  void cache_flush();
+  void cache_invalidate();
+  bool icnt_injection_buffer_full(unsigned size, bool write);
+  void icnt_inject_request_packet(class mem_fetch *mf);
 
+  // for perfect memory interface
+  bool response_queue_full() {
+    return (m_response_fifo.size() >= m_config->n_simt_ejection_buffer_size);
+  }
+  void push_response_fifo(class mem_fetch *mf) {
+    m_response_fifo.push_back(mf);
+  }
 
-    // for perfect memory interface
-    bool response_queue_full() {
-        return ( m_response_fifo.size() >= m_config->n_simt_ejection_buffer_size );
-    }
-    void push_response_fifo(class mem_fetch *mf) {
-        m_response_fifo.push_back(mf);
-    }
+  void get_pdom_stack_top_info(unsigned sid, unsigned tid, unsigned *pc,
+                               unsigned *rpc) const;
+  unsigned max_cta(const kernel_info_t &kernel);
+  unsigned get_not_completed() const;
+  void print_not_completed(FILE *fp) const;
+  unsigned get_n_active_cta() const;
+  unsigned get_n_active_sms() const;
+  gpgpu_sim *get_gpu() { return m_gpu; }
 
-    void get_pdom_stack_top_info( unsigned sid, unsigned tid, unsigned *pc, unsigned *rpc ) const;
-    unsigned max_cta( const kernel_info_t &kernel );
-    unsigned get_not_completed() const;
-    void print_not_completed( FILE *fp ) const;
-    unsigned get_n_active_cta() const;
-    unsigned get_n_active_sms() const;
-    gpgpu_sim *get_gpu() { return m_gpu; }
+  void display_pipeline(unsigned sid, FILE *fout, int print_mem, int mask);
+  void print_cache_stats(FILE *fp, unsigned &dl1_accesses,
+                         unsigned &dl1_misses) const;
 
-    void display_pipeline( unsigned sid, FILE *fout, int print_mem, int mask );
-    void print_cache_stats( FILE *fp, unsigned& dl1_accesses, unsigned& dl1_misses ) const;
+  void get_cache_stats(cache_stats &cs) const;
+  void get_L1I_sub_stats(struct cache_sub_stats &css) const;
+  void get_L1D_sub_stats(struct cache_sub_stats &css) const;
+  void get_L1C_sub_stats(struct cache_sub_stats &css) const;
+  void get_L1T_sub_stats(struct cache_sub_stats &css) const;
 
-    void get_cache_stats(cache_stats &cs) const;
-    void get_L1I_sub_stats(struct cache_sub_stats &css) const;
-    void get_L1D_sub_stats(struct cache_sub_stats &css) const;
-    void get_L1C_sub_stats(struct cache_sub_stats &css) const;
-    void get_L1T_sub_stats(struct cache_sub_stats &css) const;
+  void get_icnt_stats(long &n_simt_to_mem, long &n_mem_to_simt) const;
+  float get_current_occupancy(unsigned long long &active,
+                              unsigned long long &total) const;
 
-    void get_icnt_stats(long &n_simt_to_mem, long &n_mem_to_simt) const;
-    float get_current_occupancy( unsigned long long& active, unsigned long long & total ) const;
+ private:
+  unsigned m_cluster_id;
+  gpgpu_sim *m_gpu;
+  const shader_core_config *m_config;
+  shader_core_stats *m_stats;
+  memory_stats_t *m_memory_stats;
+  shader_core_ctx **m_core;
 
-private:
-    unsigned m_cluster_id;
-    gpgpu_sim *m_gpu;
-    const shader_core_config *m_config;
-    shader_core_stats *m_stats;
-    memory_stats_t *m_memory_stats;
-    shader_core_ctx **m_core;
-
-    unsigned m_cta_issue_next_core;
-    std::list<unsigned> m_core_sim_order;
-    std::list<mem_fetch*> m_response_fifo;
+  unsigned m_cta_issue_next_core;
+  std::list<unsigned> m_core_sim_order;
+  std::list<mem_fetch *> m_response_fifo;
 };
 
 class shader_memory_interface : public mem_fetch_interface {
-public:
-    shader_memory_interface( shader_core_ctx *core, simt_core_cluster *cluster ) { m_core=core; m_cluster=cluster; }
-    virtual bool full( unsigned size, bool write ) const 
-    {
-        return m_cluster->icnt_injection_buffer_full(size,write);
-    }
-    virtual void push(mem_fetch *mf) 
-    {
-    	m_core->inc_simt_to_mem(mf->get_num_flits(true));
-        m_cluster->icnt_inject_request_packet(mf);        
-    }
-private:
-    shader_core_ctx *m_core;
-    simt_core_cluster *m_cluster;
+ public:
+  shader_memory_interface(shader_core_ctx *core, simt_core_cluster *cluster) {
+    m_core = core;
+    m_cluster = cluster;
+  }
+  virtual bool full(unsigned size, bool write) const {
+    return m_cluster->icnt_injection_buffer_full(size, write);
+  }
+  virtual void push(mem_fetch *mf) {
+    m_core->inc_simt_to_mem(mf->get_num_flits(true));
+    m_cluster->icnt_inject_request_packet(mf);
+  }
+
+ private:
+  shader_core_ctx *m_core;
+  simt_core_cluster *m_cluster;
 };
 
 class perfect_memory_interface : public mem_fetch_interface {
-public:
-    perfect_memory_interface( shader_core_ctx *core, simt_core_cluster *cluster ) { m_core=core; m_cluster=cluster; }
-    virtual bool full( unsigned size, bool write) const
-    {
-        return m_cluster->response_queue_full();
-    }
-    virtual void push(mem_fetch *mf)
-    {
-        if ( mf && mf->isatomic() )
-            mf->do_atomic(); // execute atomic inside the "memory subsystem"
-        m_core->inc_simt_to_mem(mf->get_num_flits(true));
-        m_cluster->push_response_fifo(mf);        
-    }
-private:
-    shader_core_ctx *m_core;
-    simt_core_cluster *m_cluster;
-};
+ public:
+  perfect_memory_interface(shader_core_ctx *core, simt_core_cluster *cluster) {
+    m_core = core;
+    m_cluster = cluster;
+  }
+  virtual bool full(unsigned size, bool write) const {
+    return m_cluster->response_queue_full();
+  }
+  virtual void push(mem_fetch *mf) {
+    if (mf && mf->isatomic())
+      mf->do_atomic();  // execute atomic inside the "memory subsystem"
+    m_core->inc_simt_to_mem(mf->get_num_flits(true));
+    m_cluster->push_response_fifo(mf);
+  }
 
+ private:
+  shader_core_ctx *m_core;
+  simt_core_cluster *m_cluster;
+};
 
 inline int scheduler_unit::get_sid() const { return m_shader->get_sid(); }
 

--- a/src/gpgpu-sim/shader_trace.h
+++ b/src/gpgpu-sim/shader_trace.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2011, Tor M. Aamodt, Tim Rogers
-// George L. Yuan, Andrew Turner, Inderpreet Singh 
+// George L. Yuan, Andrew Turner, Inderpreet Singh
 // The University of British Columbia
 // All rights reserved.
 //
@@ -8,67 +8,73 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef __SHADER_TRACE_H__
 #define __SHADER_TRACE_H__
 
 #include "../trace.h"
 
-
 #if TRACING_ON
 
 #define SHADER_PRINT_STR SIM_PRINT_STR "Core %d - "
 #define SCHED_PRINT_STR SHADER_PRINT_STR "Scheduler %d - "
-#define SHADER_DTRACE(x)  (DTRACE(x) && (Trace::sampling_core == get_sid()\
-                                         || Trace::sampling_core == -1))
+#define SHADER_DTRACE(x) \
+  (DTRACE(x) &&          \
+   (Trace::sampling_core == get_sid() || Trace::sampling_core == -1))
 
 // Intended to be called from inside components of a shader core.
 // Depends on a get_sid() function
-#define SHADER_DPRINTF(x, ...) do {\
-    if (SHADER_DTRACE(x)) {\
-        printf( SHADER_PRINT_STR,\
-                m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle,\
-                Trace::trace_streams_str[Trace::x],\
-                get_sid() );\
-        printf(__VA_ARGS__);\
-    }\
-} while (0)
+#define SHADER_DPRINTF(x, ...)                                \
+  do {                                                        \
+    if (SHADER_DTRACE(x)) {                                   \
+      printf(SHADER_PRINT_STR,                                \
+             m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle, \
+             Trace::trace_streams_str[Trace::x], get_sid());  \
+      printf(__VA_ARGS__);                                    \
+    }                                                         \
+  } while (0)
 
 // Intended to be called from inside a scheduler_unit.
 // Depends on a m_id member
-#define SCHED_DPRINTF(...) do {\
-    if (SHADER_DTRACE(WARP_SCHEDULER)) {\
-        printf( SCHED_PRINT_STR,\
-                m_shader->get_gpu()->gpu_sim_cycle + m_shader->get_gpu()->gpu_tot_sim_cycle,\
-                Trace::trace_streams_str[Trace::WARP_SCHEDULER],\
-                get_sid(),\
-                m_id );\
-        printf(__VA_ARGS__);\
-    }\
-} while (0)
+#define SCHED_DPRINTF(...)                                               \
+  do {                                                                   \
+    if (SHADER_DTRACE(WARP_SCHEDULER)) {                                 \
+      printf(SCHED_PRINT_STR,                                            \
+             m_shader->get_gpu()->gpu_sim_cycle +                        \
+                 m_shader->get_gpu()->gpu_tot_sim_cycle,                 \
+             Trace::trace_streams_str[Trace::WARP_SCHEDULER], get_sid(), \
+             m_id);                                                      \
+      printf(__VA_ARGS__);                                               \
+    }                                                                    \
+  } while (0)
 
 #else
 
-#define SHADER_DTRACE(x)  (false)
-#define SHADER_DPRINTF(x, ...) do {} while (0)
-#define SCHED_DPRINTF(x, ...) do {} while (0)
+#define SHADER_DTRACE(x) (false)
+#define SHADER_DPRINTF(x, ...) \
+  do {                         \
+  } while (0)
+#define SCHED_DPRINTF(x, ...) \
+  do {                        \
+  } while (0)
 
 #endif
 

--- a/src/gpgpu-sim/shader_trace.h
+++ b/src/gpgpu-sim/shader_trace.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2011, Tor M. Aamodt, Tim Rogers
-// George L. Yuan, Andrew Turner, Inderpreet Singh
+// George L. Yuan, Andrew Turner, Inderpreet Singh 
 // The University of British Columbia
 // All rights reserved.
 //
@@ -8,16 +8,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -33,48 +31,44 @@
 
 #include "../trace.h"
 
+
 #if TRACING_ON
 
 #define SHADER_PRINT_STR SIM_PRINT_STR "Core %d - "
 #define SCHED_PRINT_STR SHADER_PRINT_STR "Scheduler %d - "
-#define SHADER_DTRACE(x) \
-  (DTRACE(x) &&          \
-   (Trace::sampling_core == get_sid() || Trace::sampling_core == -1))
+#define SHADER_DTRACE(x)  (DTRACE(x) && (Trace::sampling_core == get_sid()\
+                                         || Trace::sampling_core == -1))
 
 // Intended to be called from inside components of a shader core.
 // Depends on a get_sid() function
-#define SHADER_DPRINTF(x, ...)                                \
-  do {                                                        \
-    if (SHADER_DTRACE(x)) {                                   \
-      printf(SHADER_PRINT_STR,                                \
-             m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle, \
-             Trace::trace_streams_str[Trace::x], get_sid());  \
-      printf(__VA_ARGS__);                                    \
-    }                                                         \
-  } while (0)
+#define SHADER_DPRINTF(x, ...) do {\
+    if (SHADER_DTRACE(x)) {\
+        printf( SHADER_PRINT_STR,\
+                m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle,\
+                Trace::trace_streams_str[Trace::x],\
+                get_sid() );\
+        printf(__VA_ARGS__);\
+    }\
+} while (0)
 
 // Intended to be called from inside a scheduler_unit.
 // Depends on a m_id member
-#define SCHED_DPRINTF(...)                                                \
-  do {                                                                    \
-    if (SHADER_DTRACE(WARP_SCHEDULER)) {                                  \
-      printf(SCHED_PRINT_STR, m_shader->get_gpu()->gpu_sim_cycle +        \
-                                  m_shader->get_gpu()->gpu_tot_sim_cycle, \
-             Trace::trace_streams_str[Trace::WARP_SCHEDULER], get_sid(),  \
-             m_id);                                                       \
-      printf(__VA_ARGS__);                                                \
-    }                                                                     \
-  } while (0)
+#define SCHED_DPRINTF(...) do {\
+    if (SHADER_DTRACE(WARP_SCHEDULER)) {\
+        printf( SCHED_PRINT_STR,\
+                m_shader->get_gpu()->gpu_sim_cycle + m_shader->get_gpu()->gpu_tot_sim_cycle,\
+                Trace::trace_streams_str[Trace::WARP_SCHEDULER],\
+                get_sid(),\
+                m_id );\
+        printf(__VA_ARGS__);\
+    }\
+} while (0)
 
 #else
 
-#define SHADER_DTRACE(x) (false)
-#define SHADER_DPRINTF(x, ...) \
-  do {                         \
-  } while (0)
-#define SCHED_DPRINTF(x, ...) \
-  do {                        \
-  } while (0)
+#define SHADER_DTRACE(x)  (false)
+#define SHADER_DPRINTF(x, ...) do {} while (0)
+#define SCHED_DPRINTF(x, ...) do {} while (0)
 
 #endif
 

--- a/src/gpgpu-sim/shader_trace.h
+++ b/src/gpgpu-sim/shader_trace.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2011, Tor M. Aamodt, Tim Rogers
-// George L. Yuan, Andrew Turner, Inderpreet Singh 
+// George L. Yuan, Andrew Turner, Inderpreet Singh
 // The University of British Columbia
 // All rights reserved.
 //
@@ -8,14 +8,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -31,44 +33,48 @@
 
 #include "../trace.h"
 
-
 #if TRACING_ON
 
 #define SHADER_PRINT_STR SIM_PRINT_STR "Core %d - "
 #define SCHED_PRINT_STR SHADER_PRINT_STR "Scheduler %d - "
-#define SHADER_DTRACE(x)  (DTRACE(x) && (Trace::sampling_core == get_sid()\
-                                         || Trace::sampling_core == -1))
+#define SHADER_DTRACE(x) \
+  (DTRACE(x) &&          \
+   (Trace::sampling_core == get_sid() || Trace::sampling_core == -1))
 
 // Intended to be called from inside components of a shader core.
 // Depends on a get_sid() function
-#define SHADER_DPRINTF(x, ...) do {\
-    if (SHADER_DTRACE(x)) {\
-        printf( SHADER_PRINT_STR,\
-                m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle,\
-                Trace::trace_streams_str[Trace::x],\
-                get_sid() );\
-        printf(__VA_ARGS__);\
-    }\
-} while (0)
+#define SHADER_DPRINTF(x, ...)                                \
+  do {                                                        \
+    if (SHADER_DTRACE(x)) {                                   \
+      printf(SHADER_PRINT_STR,                                \
+             m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle, \
+             Trace::trace_streams_str[Trace::x], get_sid());  \
+      printf(__VA_ARGS__);                                    \
+    }                                                         \
+  } while (0)
 
 // Intended to be called from inside a scheduler_unit.
 // Depends on a m_id member
-#define SCHED_DPRINTF(...) do {\
-    if (SHADER_DTRACE(WARP_SCHEDULER)) {\
-        printf( SCHED_PRINT_STR,\
-                m_shader->get_gpu()->gpu_sim_cycle + m_shader->get_gpu()->gpu_tot_sim_cycle,\
-                Trace::trace_streams_str[Trace::WARP_SCHEDULER],\
-                get_sid(),\
-                m_id );\
-        printf(__VA_ARGS__);\
-    }\
-} while (0)
+#define SCHED_DPRINTF(...)                                                \
+  do {                                                                    \
+    if (SHADER_DTRACE(WARP_SCHEDULER)) {                                  \
+      printf(SCHED_PRINT_STR, m_shader->get_gpu()->gpu_sim_cycle +        \
+                                  m_shader->get_gpu()->gpu_tot_sim_cycle, \
+             Trace::trace_streams_str[Trace::WARP_SCHEDULER], get_sid(),  \
+             m_id);                                                       \
+      printf(__VA_ARGS__);                                                \
+    }                                                                     \
+  } while (0)
 
 #else
 
-#define SHADER_DTRACE(x)  (false)
-#define SHADER_DPRINTF(x, ...) do {} while (0)
-#define SCHED_DPRINTF(x, ...) do {} while (0)
+#define SHADER_DTRACE(x) (false)
+#define SHADER_DPRINTF(x, ...) \
+  do {                         \
+  } while (0)
+#define SCHED_DPRINTF(x, ...) \
+  do {                        \
+  } while (0)
 
 #endif
 

--- a/src/gpgpu-sim/stack.cc
+++ b/src/gpgpu-sim/stack.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2011, Tor M. Aamodt,  Ali Bakhoda, Ivan Sham, 
+// Copyright (c) 2009-2011, Tor M. Aamodt,  Ali Bakhoda, Ivan Sham,
 // Wilson W.L. Fung
 // All rights reserved.
 //
@@ -7,82 +7,74 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #include "stack.h"
 
-#include <stdlib.h>
 #include <assert.h>
+#include <stdlib.h>
 
 void push_stack(Stack *S, address_type val) {
-   assert(S->top < S->max_size);
-   S->v[S->top] = val;
-   (S->top)++;
-
+  assert(S->top < S->max_size);
+  S->v[S->top] = val;
+  (S->top)++;
 }
 
 address_type pop_stack(Stack *S) {
-   (S->top)--;
-   return(S->v[S->top]);
+  (S->top)--;
+  return (S->v[S->top]);
 }
 
 address_type top_stack(Stack *S) {
-   assert(S->top >= 1);
-   return(S->v[S->top - 1]);
+  assert(S->top >= 1);
+  return (S->v[S->top - 1]);
 }
 
-Stack* new_stack(int size) {
-   Stack* S;
-   S = (Stack*)malloc(sizeof(Stack));
-   S->max_size = size;
-   S->top = 0;
-   S->v = (address_type*)calloc(size, sizeof(address_type));
-   return S;
+Stack *new_stack(int size) {
+  Stack *S;
+  S = (Stack *)malloc(sizeof(Stack));
+  S->max_size = size;
+  S->top = 0;
+  S->v = (address_type *)calloc(size, sizeof(address_type));
+  return S;
 }
 
 void free_stack(Stack *S) {
-   free(S->v);
-   free(S);
+  free(S->v);
+  free(S);
 }
 
-int size_stack(Stack *S) {
-   return S->top;
-}
+int size_stack(Stack *S) { return S->top; }
 
-int full_stack(Stack *S) {
-   return S->top >= S->max_size;
-}
+int full_stack(Stack *S) { return S->top >= S->max_size; }
 
-int empty_stack(Stack *S) {
-   return S->top == 0;
-}
+int empty_stack(Stack *S) { return S->top == 0; }
 
 int element_exist_stack(Stack *S, address_type value) {
-   int i;
-   for (i = 0; i < S->top; ++i) {
-      if (value == S->v[i]) {
-         return 1;
-      }
-   }
-   return 0;
+  int i;
+  for (i = 0; i < S->top; ++i) {
+    if (value == S->v[i]) {
+      return 1;
+    }
+  }
+  return 0;
 }
 
-void reset_stack(Stack *S) {
-   S->top = 0;
-}
+void reset_stack(Stack *S) { S->top = 0; }

--- a/src/gpgpu-sim/stack.cc
+++ b/src/gpgpu-sim/stack.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2011, Tor M. Aamodt,  Ali Bakhoda, Ivan Sham,
+// Copyright (c) 2009-2011, Tor M. Aamodt,  Ali Bakhoda, Ivan Sham, 
 // Wilson W.L. Fung
 // All rights reserved.
 //
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -29,53 +27,62 @@
 
 #include "stack.h"
 
-#include <assert.h>
 #include <stdlib.h>
+#include <assert.h>
 
 void push_stack(Stack *S, address_type val) {
-  assert(S->top < S->max_size);
-  S->v[S->top] = val;
-  (S->top)++;
+   assert(S->top < S->max_size);
+   S->v[S->top] = val;
+   (S->top)++;
+
 }
 
 address_type pop_stack(Stack *S) {
-  (S->top)--;
-  return (S->v[S->top]);
+   (S->top)--;
+   return(S->v[S->top]);
 }
 
 address_type top_stack(Stack *S) {
-  assert(S->top >= 1);
-  return (S->v[S->top - 1]);
+   assert(S->top >= 1);
+   return(S->v[S->top - 1]);
 }
 
-Stack *new_stack(int size) {
-  Stack *S;
-  S = (Stack *)malloc(sizeof(Stack));
-  S->max_size = size;
-  S->top = 0;
-  S->v = (address_type *)calloc(size, sizeof(address_type));
-  return S;
+Stack* new_stack(int size) {
+   Stack* S;
+   S = (Stack*)malloc(sizeof(Stack));
+   S->max_size = size;
+   S->top = 0;
+   S->v = (address_type*)calloc(size, sizeof(address_type));
+   return S;
 }
 
 void free_stack(Stack *S) {
-  free(S->v);
-  free(S);
+   free(S->v);
+   free(S);
 }
 
-int size_stack(Stack *S) { return S->top; }
+int size_stack(Stack *S) {
+   return S->top;
+}
 
-int full_stack(Stack *S) { return S->top >= S->max_size; }
+int full_stack(Stack *S) {
+   return S->top >= S->max_size;
+}
 
-int empty_stack(Stack *S) { return S->top == 0; }
+int empty_stack(Stack *S) {
+   return S->top == 0;
+}
 
 int element_exist_stack(Stack *S, address_type value) {
-  int i;
-  for (i = 0; i < S->top; ++i) {
-    if (value == S->v[i]) {
-      return 1;
-    }
-  }
-  return 0;
+   int i;
+   for (i = 0; i < S->top; ++i) {
+      if (value == S->v[i]) {
+         return 1;
+      }
+   }
+   return 0;
 }
 
-void reset_stack(Stack *S) { S->top = 0; }
+void reset_stack(Stack *S) {
+   S->top = 0;
+}

--- a/src/gpgpu-sim/stack.cc
+++ b/src/gpgpu-sim/stack.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2011, Tor M. Aamodt,  Ali Bakhoda, Ivan Sham, 
+// Copyright (c) 2009-2011, Tor M. Aamodt,  Ali Bakhoda, Ivan Sham,
 // Wilson W.L. Fung
 // All rights reserved.
 //
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -27,62 +29,53 @@
 
 #include "stack.h"
 
-#include <stdlib.h>
 #include <assert.h>
+#include <stdlib.h>
 
 void push_stack(Stack *S, address_type val) {
-   assert(S->top < S->max_size);
-   S->v[S->top] = val;
-   (S->top)++;
-
+  assert(S->top < S->max_size);
+  S->v[S->top] = val;
+  (S->top)++;
 }
 
 address_type pop_stack(Stack *S) {
-   (S->top)--;
-   return(S->v[S->top]);
+  (S->top)--;
+  return (S->v[S->top]);
 }
 
 address_type top_stack(Stack *S) {
-   assert(S->top >= 1);
-   return(S->v[S->top - 1]);
+  assert(S->top >= 1);
+  return (S->v[S->top - 1]);
 }
 
-Stack* new_stack(int size) {
-   Stack* S;
-   S = (Stack*)malloc(sizeof(Stack));
-   S->max_size = size;
-   S->top = 0;
-   S->v = (address_type*)calloc(size, sizeof(address_type));
-   return S;
+Stack *new_stack(int size) {
+  Stack *S;
+  S = (Stack *)malloc(sizeof(Stack));
+  S->max_size = size;
+  S->top = 0;
+  S->v = (address_type *)calloc(size, sizeof(address_type));
+  return S;
 }
 
 void free_stack(Stack *S) {
-   free(S->v);
-   free(S);
+  free(S->v);
+  free(S);
 }
 
-int size_stack(Stack *S) {
-   return S->top;
-}
+int size_stack(Stack *S) { return S->top; }
 
-int full_stack(Stack *S) {
-   return S->top >= S->max_size;
-}
+int full_stack(Stack *S) { return S->top >= S->max_size; }
 
-int empty_stack(Stack *S) {
-   return S->top == 0;
-}
+int empty_stack(Stack *S) { return S->top == 0; }
 
 int element_exist_stack(Stack *S, address_type value) {
-   int i;
-   for (i = 0; i < S->top; ++i) {
-      if (value == S->v[i]) {
-         return 1;
-      }
-   }
-   return 0;
+  int i;
+  for (i = 0; i < S->top; ++i) {
+    if (value == S->v[i]) {
+      return 1;
+    }
+  }
+  return 0;
 }
 
-void reset_stack(Stack *S) {
-   S->top = 0;
-}
+void reset_stack(Stack *S) { S->top = 0; }

--- a/src/gpgpu-sim/stack.h
+++ b/src/gpgpu-sim/stack.h
@@ -7,23 +7,24 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef _MY_STACK_
 #define _MY_STACK_
@@ -31,19 +32,19 @@
 #include "../abstract_hardware_model.h"
 
 typedef struct {
-   address_type *v;
-   int max_size;
-   int top;
+  address_type *v;
+  int max_size;
+  int top;
 } Stack;
 
 void push_stack(Stack *S, address_type val);
 address_type pop_stack(Stack *S);
 address_type top_stack(Stack *S);
-Stack* new_stack(int size);
+Stack *new_stack(int size);
 void free_stack(Stack *S);
 int size_stack(Stack *S);
 int full_stack(Stack *S);
 int empty_stack(Stack *S);
 int element_exist_stack(Stack *S, address_type value);
 void reset_stack(Stack *S);
-#endif // _MY_STACK_
+#endif  // _MY_STACK_

--- a/src/gpgpu-sim/stack.h
+++ b/src/gpgpu-sim/stack.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -33,19 +31,19 @@
 #include "../abstract_hardware_model.h"
 
 typedef struct {
-  address_type *v;
-  int max_size;
-  int top;
+   address_type *v;
+   int max_size;
+   int top;
 } Stack;
 
 void push_stack(Stack *S, address_type val);
 address_type pop_stack(Stack *S);
 address_type top_stack(Stack *S);
-Stack *new_stack(int size);
+Stack* new_stack(int size);
 void free_stack(Stack *S);
 int size_stack(Stack *S);
 int full_stack(Stack *S);
 int empty_stack(Stack *S);
 int element_exist_stack(Stack *S, address_type value);
 void reset_stack(Stack *S);
-#endif  // _MY_STACK_
+#endif // _MY_STACK_

--- a/src/gpgpu-sim/stack.h
+++ b/src/gpgpu-sim/stack.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -31,19 +33,19 @@
 #include "../abstract_hardware_model.h"
 
 typedef struct {
-   address_type *v;
-   int max_size;
-   int top;
+  address_type *v;
+  int max_size;
+  int top;
 } Stack;
 
 void push_stack(Stack *S, address_type val);
 address_type pop_stack(Stack *S);
 address_type top_stack(Stack *S);
-Stack* new_stack(int size);
+Stack *new_stack(int size);
 void free_stack(Stack *S);
 int size_stack(Stack *S);
 int full_stack(Stack *S);
 int empty_stack(Stack *S);
 int element_exist_stack(Stack *S, address_type value);
 void reset_stack(Stack *S);
-#endif // _MY_STACK_
+#endif  // _MY_STACK_

--- a/src/gpgpu-sim/stat-tool.cc
+++ b/src/gpgpu-sim/stat-tool.cc
@@ -7,180 +7,179 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #include "stat-tool.h"
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <assert.h>
 #include <zlib.h>
-#include <string>
-#include <list>
-#include <vector>
-#include <map>
 #include <algorithm>
+#include <list>
+#include <map>
 #include <string>
+#include <vector>
 #include "../../libcuda/gpgpu_context.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 
-static unsigned long long  min_snap_shot_interval = 0;
-static unsigned long long  next_snap_shot_cycle = 0;
-static std::list<snap_shot_trigger*> list_ss_trigger;
+static unsigned long long min_snap_shot_interval = 0;
+static unsigned long long next_snap_shot_cycle = 0;
+static std::list<snap_shot_trigger *> list_ss_trigger;
 
-void add_snap_shot_trigger (snap_shot_trigger* ss_trigger)
-{
-   // quick optimization assuming that all snap shot intervals are perfect multiples of each other
-   if (min_snap_shot_interval == 0 || min_snap_shot_interval > ss_trigger->get_interval()) {
-      min_snap_shot_interval = ss_trigger->get_interval();
-      next_snap_shot_cycle = min_snap_shot_interval; // assume that snap shots haven't started yet
-   }
-   list_ss_trigger.push_back(ss_trigger);
+void add_snap_shot_trigger(snap_shot_trigger *ss_trigger) {
+  // quick optimization assuming that all snap shot intervals are perfect
+  // multiples of each other
+  if (min_snap_shot_interval == 0 ||
+      min_snap_shot_interval > ss_trigger->get_interval()) {
+    min_snap_shot_interval = ss_trigger->get_interval();
+    next_snap_shot_cycle =
+        min_snap_shot_interval;  // assume that snap shots haven't started yet
+  }
+  list_ss_trigger.push_back(ss_trigger);
 }
 
-void remove_snap_shot_trigger (snap_shot_trigger* ss_trigger)
-{
-   list_ss_trigger.remove(ss_trigger);
+void remove_snap_shot_trigger(snap_shot_trigger *ss_trigger) {
+  list_ss_trigger.remove(ss_trigger);
 }
 
-void try_snap_shot (unsigned long long  current_cycle)
-{
-   if (min_snap_shot_interval == 0) return;
-   if (current_cycle != next_snap_shot_cycle) return;
-   
-   std::list<snap_shot_trigger*>::iterator ss_trigger_iter = list_ss_trigger.begin();
-   for(; ss_trigger_iter != list_ss_trigger.end(); ++ss_trigger_iter) {
-      (*ss_trigger_iter)->snap_shot(current_cycle); // WF: should be try_snap_shot
-   }
-   next_snap_shot_cycle = current_cycle + min_snap_shot_interval; // WF: stateful testing, maybe bad
+void try_snap_shot(unsigned long long current_cycle) {
+  if (min_snap_shot_interval == 0) return;
+  if (current_cycle != next_snap_shot_cycle) return;
+
+  std::list<snap_shot_trigger *>::iterator ss_trigger_iter =
+      list_ss_trigger.begin();
+  for (; ss_trigger_iter != list_ss_trigger.end(); ++ss_trigger_iter) {
+    (*ss_trigger_iter)
+        ->snap_shot(current_cycle);  // WF: should be try_snap_shot
+  }
+  next_snap_shot_cycle =
+      current_cycle +
+      min_snap_shot_interval;  // WF: stateful testing, maybe bad
 }
 
 ////////////////////////////////////////////////////////////////////////////////
- 
-static unsigned long long  spill_interval = 0;
-static unsigned long long  next_spill_cycle = 0;
-static std::list<spill_log_interface*> list_spill_log;
 
-void add_spill_log (spill_log_interface* spill_log)
-{
-   list_spill_log.push_back(spill_log);
+static unsigned long long spill_interval = 0;
+static unsigned long long next_spill_cycle = 0;
+static std::list<spill_log_interface *> list_spill_log;
+
+void add_spill_log(spill_log_interface *spill_log) {
+  list_spill_log.push_back(spill_log);
 }
 
-void remove_spill_log (spill_log_interface* spill_log)
-{
-   list_spill_log.remove(spill_log);
+void remove_spill_log(spill_log_interface *spill_log) {
+  list_spill_log.remove(spill_log);
 }
 
-void set_spill_interval (unsigned long long  interval)
-{
-   spill_interval = interval;
-   next_spill_cycle = spill_interval;
+void set_spill_interval(unsigned long long interval) {
+  spill_interval = interval;
+  next_spill_cycle = spill_interval;
 }
 
-void spill_log_to_file (FILE *fout, int final, unsigned long long  current_cycle)
-{
-   if (!final && spill_interval == 0) return;
-   if (!final && current_cycle <= next_spill_cycle) return;
+void spill_log_to_file(FILE *fout, int final,
+                       unsigned long long current_cycle) {
+  if (!final && spill_interval == 0) return;
+  if (!final && current_cycle <= next_spill_cycle) return;
 
-   fprintf(fout, "\n"); // ensure that the spill occurs at a new line
-   std::list<spill_log_interface*>::iterator i_spill_log = list_spill_log.begin();
-   for(; i_spill_log != list_spill_log.end(); ++i_spill_log) {
-      (*i_spill_log)->spill(fout, final); 
-   }
-   fflush(fout);
+  fprintf(fout, "\n");  // ensure that the spill occurs at a new line
+  std::list<spill_log_interface *>::iterator i_spill_log =
+      list_spill_log.begin();
+  for (; i_spill_log != list_spill_log.end(); ++i_spill_log) {
+    (*i_spill_log)->spill(fout, final);
+  }
+  fflush(fout);
 
-   next_spill_cycle = current_cycle + spill_interval; // WF: stateful testing, maybe bad
+  next_spill_cycle =
+      current_cycle + spill_interval;  // WF: stateful testing, maybe bad
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 static int n_thread_CFloggers = 0;
-static thread_CFlocality** thread_CFlogger = NULL;
+static thread_CFlocality **thread_CFlogger = NULL;
 
-void create_thread_CFlogger(gpgpu_context* ctx, int n_loggers, int n_threads, address_type start_pc, unsigned long long  logging_interval) 
-{
-   destroy_thread_CFlogger();
-   
-   n_thread_CFloggers = n_loggers;
-   thread_CFlogger = new thread_CFlocality*[n_loggers];
+void create_thread_CFlogger(gpgpu_context *ctx, int n_loggers, int n_threads,
+                            address_type start_pc,
+                            unsigned long long logging_interval) {
+  destroy_thread_CFlogger();
 
-   std::string name_tpl("CFLog");
-   char buffer[32];
-   for (int i = 0; i < n_thread_CFloggers; i++) {
-      snprintf(buffer, 32, "%02d", i);
-      thread_CFlogger[i] = new thread_CFlocality( ctx, name_tpl + buffer, logging_interval, n_threads, start_pc);
-      if (logging_interval != 0) {
-         add_snap_shot_trigger(thread_CFlogger[i]);
-         add_spill_log(thread_CFlogger[i]);
-      }
-   }
+  n_thread_CFloggers = n_loggers;
+  thread_CFlogger = new thread_CFlocality *[n_loggers];
+
+  std::string name_tpl("CFLog");
+  char buffer[32];
+  for (int i = 0; i < n_thread_CFloggers; i++) {
+    snprintf(buffer, 32, "%02d", i);
+    thread_CFlogger[i] = new thread_CFlocality(
+        ctx, name_tpl + buffer, logging_interval, n_threads, start_pc);
+    if (logging_interval != 0) {
+      add_snap_shot_trigger(thread_CFlogger[i]);
+      add_spill_log(thread_CFlogger[i]);
+    }
+  }
 }
 
-void destroy_thread_CFlogger( ) 
-{
-   if (thread_CFlogger != NULL) {
-      for (int i = 0; i < n_thread_CFloggers; i++) {
-         remove_snap_shot_trigger(thread_CFlogger[i]);
-         remove_spill_log(thread_CFlogger[i]);
-         delete thread_CFlogger[i];
-      }
-      delete [] thread_CFlogger;
-      thread_CFlogger = NULL;
-   }
+void destroy_thread_CFlogger() {
+  if (thread_CFlogger != NULL) {
+    for (int i = 0; i < n_thread_CFloggers; i++) {
+      remove_snap_shot_trigger(thread_CFlogger[i]);
+      remove_spill_log(thread_CFlogger[i]);
+      delete thread_CFlogger[i];
+    }
+    delete[] thread_CFlogger;
+    thread_CFlogger = NULL;
+  }
 }
 
-void cflog_update_thread_pc( int logger_id, int thread_id, address_type pc ) 
-{
-   if (thread_CFlogger == NULL) return;  // this means no visualizer output 
-   if (thread_id < 0) return;
-   thread_CFlogger[logger_id]->update_thread_pc(thread_id, pc);
+void cflog_update_thread_pc(int logger_id, int thread_id, address_type pc) {
+  if (thread_CFlogger == NULL) return;  // this means no visualizer output
+  if (thread_id < 0) return;
+  thread_CFlogger[logger_id]->update_thread_pc(thread_id, pc);
 }
 
-// deprecated 
-void cflog_snapshot( int logger_id, unsigned long long  cycle ) 
-{
-   thread_CFlogger[logger_id]->snap_shot(cycle);
+// deprecated
+void cflog_snapshot(int logger_id, unsigned long long cycle) {
+  thread_CFlogger[logger_id]->snap_shot(cycle);
 }
 
-void cflog_print(FILE *fout) 
-{
-   if (thread_CFlogger == NULL) return;  // this means no visualizer output 
-   for (int i = 0; i < n_thread_CFloggers; i++) {
-      thread_CFlogger[i]->print_histo(fout);
-   }
+void cflog_print(FILE *fout) {
+  if (thread_CFlogger == NULL) return;  // this means no visualizer output
+  for (int i = 0; i < n_thread_CFloggers; i++) {
+    thread_CFlogger[i]->print_histo(fout);
+  }
 }
 
-void cflog_visualizer_print(FILE *fout) 
-{
-   if (thread_CFlogger == NULL) return;  // this means no visualizer output 
-   for (int i = 0; i < n_thread_CFloggers; i++) {
-      thread_CFlogger[i]->print_visualizer(fout);
-   }
+void cflog_visualizer_print(FILE *fout) {
+  if (thread_CFlogger == NULL) return;  // this means no visualizer output
+  for (int i = 0; i < n_thread_CFloggers; i++) {
+    thread_CFlogger[i]->print_visualizer(fout);
+  }
 }
 
-void cflog_visualizer_gzprint(gzFile fout) 
-{
-   if (thread_CFlogger == NULL) return;  // this means no visualizer output 
-   for (int i = 0; i < n_thread_CFloggers; i++) {
-      thread_CFlogger[i]->print_visualizer(fout);
-   }
+void cflog_visualizer_gzprint(gzFile fout) {
+  if (thread_CFlogger == NULL) return;  // this means no visualizer output
+  for (int i = 0; i < n_thread_CFloggers; i++) {
+    thread_CFlogger[i]->print_visualizer(fout);
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -189,26 +188,23 @@ int insn_warp_occ_logger::s_ids = 0;
 
 static std::vector<insn_warp_occ_logger> iwo_logger;
 
-void insn_warp_occ_create( int n_loggers, int simd_width )
-{
-   iwo_logger.clear();
-   iwo_logger.assign(n_loggers, insn_warp_occ_logger(simd_width));
-   for (unsigned i = 0; i < iwo_logger.size(); i++) {
-      iwo_logger[i].set_id(i);
-   }
+void insn_warp_occ_create(int n_loggers, int simd_width) {
+  iwo_logger.clear();
+  iwo_logger.assign(n_loggers, insn_warp_occ_logger(simd_width));
+  for (unsigned i = 0; i < iwo_logger.size(); i++) {
+    iwo_logger[i].set_id(i);
+  }
 }
 
-void insn_warp_occ_log( int logger_id, address_type pc, int warp_occ)
-{
-   if (warp_occ <= 0) return;
-   iwo_logger[logger_id].log(pc, warp_occ);
+void insn_warp_occ_log(int logger_id, address_type pc, int warp_occ) {
+  if (warp_occ <= 0) return;
+  iwo_logger[logger_id].log(pc, warp_occ);
 }
 
-void insn_warp_occ_print( FILE *fout )
-{
-   for (unsigned i = 0; i < iwo_logger.size(); i++) {
-      iwo_logger[i].print(fout);
-   }
+void insn_warp_occ_print(FILE *fout) {
+  for (unsigned i = 0; i < iwo_logger.size(); i++) {
+    iwo_logger[i].print(fout);
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -221,35 +217,32 @@ int linear_histogram_logger::s_ids = 0;
 
 static std::vector<linear_histogram_logger> s_warp_occ_logger;
 
-void shader_warp_occ_create( int n_loggers, int simd_width, unsigned long long  logging_interval)
-{
-   // simd_width + 1 to include the case with full warp
-   s_warp_occ_logger.assign(n_loggers, 
-                            linear_histogram_logger(simd_width + 1, logging_interval, "ShdrWarpOcc"));
-   for (unsigned i = 0; i < s_warp_occ_logger.size(); i++) {
-      s_warp_occ_logger[i].set_id(i);
-      add_snap_shot_trigger(&(s_warp_occ_logger[i]));
-      add_spill_log(&(s_warp_occ_logger[i]));
-   }
+void shader_warp_occ_create(int n_loggers, int simd_width,
+                            unsigned long long logging_interval) {
+  // simd_width + 1 to include the case with full warp
+  s_warp_occ_logger.assign(
+      n_loggers,
+      linear_histogram_logger(simd_width + 1, logging_interval, "ShdrWarpOcc"));
+  for (unsigned i = 0; i < s_warp_occ_logger.size(); i++) {
+    s_warp_occ_logger[i].set_id(i);
+    add_snap_shot_trigger(&(s_warp_occ_logger[i]));
+    add_spill_log(&(s_warp_occ_logger[i]));
+  }
 }
 
-void shader_warp_occ_log( int logger_id, int warp_occ)
-{
-   s_warp_occ_logger[logger_id].log(warp_occ);
+void shader_warp_occ_log(int logger_id, int warp_occ) {
+  s_warp_occ_logger[logger_id].log(warp_occ);
 }
 
-void shader_warp_occ_snapshot( int logger_id, unsigned long long  current_cycle)
-{
-   s_warp_occ_logger[logger_id].snap_shot(current_cycle);
+void shader_warp_occ_snapshot(int logger_id, unsigned long long current_cycle) {
+  s_warp_occ_logger[logger_id].snap_shot(current_cycle);
 }
 
-void shader_warp_occ_print( FILE *fout )
-{
-   for (unsigned i = 0; i < s_warp_occ_logger.size(); i++) {
-      s_warp_occ_logger[i].print(fout);
-   }
+void shader_warp_occ_print(FILE *fout) {
+  for (unsigned i = 0; i < s_warp_occ_logger.size(); i++) {
+    s_warp_occ_logger[i].print(fout);
+  }
 }
-
 
 /////////////////////////////////////////////////////////////////////////////////////
 // per-shadercore memory-access logger
@@ -259,105 +252,115 @@ static int s_mem_acc_logger_n_dram = 0;
 static int s_mem_acc_logger_n_bank = 0;
 static std::vector<linear_histogram_logger> s_mem_acc_logger;
 
-void shader_mem_acc_create( int n_loggers, int n_dram, int n_bank, unsigned long long  logging_interval)
-{
-   // (n_bank + 1) to space data out; 2x to separate read and write
-   s_mem_acc_logger.assign(n_loggers, 
-                           linear_histogram_logger(2 * n_dram * (n_bank + 1), logging_interval, "ShdrMemAcc"));
+void shader_mem_acc_create(int n_loggers, int n_dram, int n_bank,
+                           unsigned long long logging_interval) {
+  // (n_bank + 1) to space data out; 2x to separate read and write
+  s_mem_acc_logger.assign(
+      n_loggers, linear_histogram_logger(2 * n_dram * (n_bank + 1),
+                                         logging_interval, "ShdrMemAcc"));
 
-   s_mem_acc_logger_n_dram = n_dram;
-   s_mem_acc_logger_n_bank = n_bank;
-   for (unsigned i = 0; i < s_mem_acc_logger.size(); i++) {
-      s_mem_acc_logger[i].set_id(i);
-      add_snap_shot_trigger(&(s_mem_acc_logger[i]));
-      add_spill_log(&(s_mem_acc_logger[i]));
-   }
+  s_mem_acc_logger_n_dram = n_dram;
+  s_mem_acc_logger_n_bank = n_bank;
+  for (unsigned i = 0; i < s_mem_acc_logger.size(); i++) {
+    s_mem_acc_logger[i].set_id(i);
+    add_snap_shot_trigger(&(s_mem_acc_logger[i]));
+    add_spill_log(&(s_mem_acc_logger[i]));
+  }
 }
 
-void shader_mem_acc_log( int logger_id, int dram_id, int bank, char rw)
-{
-   if (s_mem_acc_logger_n_dram == 0) return;
-   int write_offset = 0;
-   switch(rw) {
-   case 'r': write_offset = 0; break;
-   case 'w': write_offset = (s_mem_acc_logger_n_bank + 1) * s_mem_acc_logger_n_dram; break;
-   default: assert(0); break;
-   }
-   s_mem_acc_logger[logger_id].log(dram_id * s_mem_acc_logger_n_bank + bank + write_offset);
+void shader_mem_acc_log(int logger_id, int dram_id, int bank, char rw) {
+  if (s_mem_acc_logger_n_dram == 0) return;
+  int write_offset = 0;
+  switch (rw) {
+    case 'r':
+      write_offset = 0;
+      break;
+    case 'w':
+      write_offset = (s_mem_acc_logger_n_bank + 1) * s_mem_acc_logger_n_dram;
+      break;
+    default:
+      assert(0);
+      break;
+  }
+  s_mem_acc_logger[logger_id].log(dram_id * s_mem_acc_logger_n_bank + bank +
+                                  write_offset);
 }
 
-void shader_mem_acc_snapshot( int logger_id, unsigned long long  current_cycle)
-{
-   s_mem_acc_logger[logger_id].snap_shot(current_cycle);
+void shader_mem_acc_snapshot(int logger_id, unsigned long long current_cycle) {
+  s_mem_acc_logger[logger_id].snap_shot(current_cycle);
 }
 
-void shader_mem_acc_print( FILE *fout )
-{
-   for (unsigned i = 0; i < s_mem_acc_logger.size(); i++) {
-      s_mem_acc_logger[i].print(fout);
-   }
+void shader_mem_acc_print(FILE *fout) {
+  for (unsigned i = 0; i < s_mem_acc_logger.size(); i++) {
+    s_mem_acc_logger[i].print(fout);
+  }
 }
-
 
 /////////////////////////////////////////////////////////////////////////////////////
 // per-shadercore memory-latency logger
 /////////////////////////////////////////////////////////////////////////////////////
 
 static bool s_mem_lat_logger_used = false;
-static int s_mem_lat_logger_nbins = 48;     // up to 2^24 = 16M
+static int s_mem_lat_logger_nbins = 48;  // up to 2^24 = 16M
 static std::vector<linear_histogram_logger> s_mem_lat_logger;
 
-void shader_mem_lat_create( int n_loggers, unsigned long long  logging_interval)
-{
-   s_mem_lat_logger.assign(n_loggers, 
-                           linear_histogram_logger(s_mem_lat_logger_nbins, logging_interval, "ShdrMemLat"));
+void shader_mem_lat_create(int n_loggers, unsigned long long logging_interval) {
+  s_mem_lat_logger.assign(
+      n_loggers, linear_histogram_logger(s_mem_lat_logger_nbins,
+                                         logging_interval, "ShdrMemLat"));
 
-   for (unsigned i = 0; i < s_mem_lat_logger.size(); i++) {
-      s_mem_lat_logger[i].set_id(i);
-      add_snap_shot_trigger(&(s_mem_lat_logger[i]));
-      add_spill_log(&(s_mem_lat_logger[i]));
-   }
-   
-   s_mem_lat_logger_used = true;
+  for (unsigned i = 0; i < s_mem_lat_logger.size(); i++) {
+    s_mem_lat_logger[i].set_id(i);
+    add_snap_shot_trigger(&(s_mem_lat_logger[i]));
+    add_spill_log(&(s_mem_lat_logger[i]));
+  }
+
+  s_mem_lat_logger_used = true;
 }
 
-void shader_mem_lat_log( int logger_id, int latency)
-{
-   if (s_mem_lat_logger_used == false) return;
-   if (latency > (1<<(s_mem_lat_logger_nbins/2))) assert(0); // guard for out of bound bin
-   assert(latency > 0);
-   
-   int latency_bin;
-   
-   int bin; // LOG_2(latency)
-   int v = latency;
-   register unsigned int shift;
+void shader_mem_lat_log(int logger_id, int latency) {
+  if (s_mem_lat_logger_used == false) return;
+  if (latency > (1 << (s_mem_lat_logger_nbins / 2)))
+    assert(0);  // guard for out of bound bin
+  assert(latency > 0);
 
-   bin =   (v > 0xFFFF) << 4; v >>= bin;
-   shift = (v > 0xFF  ) << 3; v >>= shift; bin |= shift;
-   shift = (v > 0xF   ) << 2; v >>= shift; bin |= shift;
-   shift = (v > 0x3   ) << 1; v >>= shift; bin |= shift;
-                                           bin |= (v >> 1);
-   latency_bin = 2 * bin;
-   if (bin > 0) {
-      latency_bin += ((latency & (1 << (bin - 1))) != 0)? 1 : 0; // approx. for LOG_sqrt2(latency)
-   }
+  int latency_bin;
 
-   s_mem_lat_logger[logger_id].log(latency_bin);
+  int bin;  // LOG_2(latency)
+  int v = latency;
+  register unsigned int shift;
+
+  bin = (v > 0xFFFF) << 4;
+  v >>= bin;
+  shift = (v > 0xFF) << 3;
+  v >>= shift;
+  bin |= shift;
+  shift = (v > 0xF) << 2;
+  v >>= shift;
+  bin |= shift;
+  shift = (v > 0x3) << 1;
+  v >>= shift;
+  bin |= shift;
+  bin |= (v >> 1);
+  latency_bin = 2 * bin;
+  if (bin > 0) {
+    latency_bin += ((latency & (1 << (bin - 1))) != 0)
+                       ? 1
+                       : 0;  // approx. for LOG_sqrt2(latency)
+  }
+
+  s_mem_lat_logger[logger_id].log(latency_bin);
 }
 
-void shader_mem_lat_snapshot( int logger_id, unsigned long long  current_cycle)
-{
-   s_mem_lat_logger[logger_id].snap_shot(current_cycle);
+void shader_mem_lat_snapshot(int logger_id, unsigned long long current_cycle) {
+  s_mem_lat_logger[logger_id].snap_shot(current_cycle);
 }
 
-void shader_mem_lat_print( FILE *fout )
-{
-   for (unsigned i = 0; i < s_mem_lat_logger.size(); i++) {
-      s_mem_lat_logger[i].print(fout);
-   }
+void shader_mem_lat_print(FILE *fout) {
+  for (unsigned i = 0; i < s_mem_lat_logger.size(); i++) {
+    s_mem_lat_logger[i].print(fout);
+  }
 }
-
 
 /////////////////////////////////////////////////////////////////////////////////////
 // per-shadercore cache-miss logger
@@ -366,425 +369,393 @@ void shader_mem_lat_print( FILE *fout )
 static int s_cache_access_logger_n_types = 0;
 static std::vector<linear_histogram_logger> s_cache_access_logger;
 
-enum cache_access_logger_types {
-   NORMALS, TEXTURE, CONSTANT, INSTRUCTION
-};
+enum cache_access_logger_types { NORMALS, TEXTURE, CONSTANT, INSTRUCTION };
 
 int get_shader_normal_cache_id() { return NORMALS; }
 int get_shader_texture_cache_id() { return TEXTURE; }
 int get_shader_constant_cache_id() { return CONSTANT; }
 int get_shader_instruction_cache_id() { return INSTRUCTION; }
 
-void shader_cache_access_create( int n_loggers, int n_types, unsigned long long  logging_interval)
-{
-   // There are different type of cache (x2 for recording accesses and misses)
-   s_cache_access_logger.assign(n_loggers, 
-                                linear_histogram_logger(n_types * 2, logging_interval, "ShdrCacheMiss"));
+void shader_cache_access_create(int n_loggers, int n_types,
+                                unsigned long long logging_interval) {
+  // There are different type of cache (x2 for recording accesses and misses)
+  s_cache_access_logger.assign(
+      n_loggers,
+      linear_histogram_logger(n_types * 2, logging_interval, "ShdrCacheMiss"));
 
-   s_cache_access_logger_n_types = n_types;
-   for (unsigned i = 0; i < s_cache_access_logger.size(); i++) {
-      s_cache_access_logger[i].set_id(i);
-      add_snap_shot_trigger(&(s_cache_access_logger[i]));
-      add_spill_log(&(s_cache_access_logger[i]));
-   }
+  s_cache_access_logger_n_types = n_types;
+  for (unsigned i = 0; i < s_cache_access_logger.size(); i++) {
+    s_cache_access_logger[i].set_id(i);
+    add_snap_shot_trigger(&(s_cache_access_logger[i]));
+    add_spill_log(&(s_cache_access_logger[i]));
+  }
 }
 
-void shader_cache_access_log( int logger_id, int type, int miss)
-{
-   if (s_cache_access_logger_n_types == 0) return;
-   if (logger_id < 0) return;
-   assert(type == NORMALS || type == TEXTURE || type == CONSTANT || type == INSTRUCTION);
-   assert(miss == 0 || miss == 1);
-   
-   s_cache_access_logger[logger_id].log(2 * type + miss);
+void shader_cache_access_log(int logger_id, int type, int miss) {
+  if (s_cache_access_logger_n_types == 0) return;
+  if (logger_id < 0) return;
+  assert(type == NORMALS || type == TEXTURE || type == CONSTANT ||
+         type == INSTRUCTION);
+  assert(miss == 0 || miss == 1);
+
+  s_cache_access_logger[logger_id].log(2 * type + miss);
 }
 
-void shader_cache_access_unlog( int logger_id, int type, int miss)
-{
-   if (s_cache_access_logger_n_types == 0) return;
-   if (logger_id < 0) return;
-   assert(type == NORMALS || type == TEXTURE || type == CONSTANT || type == INSTRUCTION);
-   assert(miss == 0 || miss == 1);
-   
-   s_cache_access_logger[logger_id].unlog(2 * type + miss);
+void shader_cache_access_unlog(int logger_id, int type, int miss) {
+  if (s_cache_access_logger_n_types == 0) return;
+  if (logger_id < 0) return;
+  assert(type == NORMALS || type == TEXTURE || type == CONSTANT ||
+         type == INSTRUCTION);
+  assert(miss == 0 || miss == 1);
+
+  s_cache_access_logger[logger_id].unlog(2 * type + miss);
 }
 
-void shader_cache_access_print( FILE *fout )
-{
-   for (unsigned i = 0; i < s_cache_access_logger.size(); i++) {
-      s_cache_access_logger[i].print(fout);
-   }
+void shader_cache_access_print(FILE *fout) {
+  for (unsigned i = 0; i < s_cache_access_logger.size(); i++) {
+    s_cache_access_logger[i].print(fout);
+  }
 }
-
 
 /////////////////////////////////////////////////////////////////////////////////////
-// per-shadercore CTA count logger (only make sense with gpgpu_spread_blocks_across_cores)
+// per-shadercore CTA count logger (only make sense with
+// gpgpu_spread_blocks_across_cores)
 /////////////////////////////////////////////////////////////////////////////////////
 
 static linear_histogram_logger *s_CTA_count_logger = NULL;
 
-void shader_CTA_count_create( int n_shaders, unsigned long long  logging_interval)
-{
-   // only need one logger to track all the shaders
-   if (s_CTA_count_logger != NULL) delete s_CTA_count_logger;
-   s_CTA_count_logger = new linear_histogram_logger(n_shaders, logging_interval, "ShdrCTACount", false);
+void shader_CTA_count_create(int n_shaders,
+                             unsigned long long logging_interval) {
+  // only need one logger to track all the shaders
+  if (s_CTA_count_logger != NULL) delete s_CTA_count_logger;
+  s_CTA_count_logger = new linear_histogram_logger(n_shaders, logging_interval,
+                                                   "ShdrCTACount", false);
 
-   s_CTA_count_logger->set_id(-1);
-   if (logging_interval != 0) {
-      add_snap_shot_trigger(s_CTA_count_logger);
-      add_spill_log(s_CTA_count_logger);
-   }
+  s_CTA_count_logger->set_id(-1);
+  if (logging_interval != 0) {
+    add_snap_shot_trigger(s_CTA_count_logger);
+    add_spill_log(s_CTA_count_logger);
+  }
 }
 
-void shader_CTA_count_log( int shader_id, int nCTAadded )
-{
-   if (s_CTA_count_logger == NULL) return;
-   
-   for (int i = 0; i < nCTAadded; i++) {
-      s_CTA_count_logger->log(shader_id);
-   }
+void shader_CTA_count_log(int shader_id, int nCTAadded) {
+  if (s_CTA_count_logger == NULL) return;
+
+  for (int i = 0; i < nCTAadded; i++) {
+    s_CTA_count_logger->log(shader_id);
+  }
 }
 
-void shader_CTA_count_unlog( int shader_id, int nCTAdone )
-{
-   if (s_CTA_count_logger == NULL) return;
-   
-   for (int i = 0; i < nCTAdone; i++) {
-      s_CTA_count_logger->unlog(shader_id);
-   }
+void shader_CTA_count_unlog(int shader_id, int nCTAdone) {
+  if (s_CTA_count_logger == NULL) return;
+
+  for (int i = 0; i < nCTAdone; i++) {
+    s_CTA_count_logger->unlog(shader_id);
+  }
 }
 
-void shader_CTA_count_print( FILE *fout )
-{
-   if (s_CTA_count_logger == NULL) return;
-   s_CTA_count_logger->print(fout);
+void shader_CTA_count_print(FILE *fout) {
+  if (s_CTA_count_logger == NULL) return;
+  s_CTA_count_logger->print(fout);
 }
 
-void shader_CTA_count_visualizer_print( FILE *fout )
-{
-   if (s_CTA_count_logger == NULL) return;
-   s_CTA_count_logger->print_visualizer(fout);
+void shader_CTA_count_visualizer_print(FILE *fout) {
+  if (s_CTA_count_logger == NULL) return;
+  s_CTA_count_logger->print_visualizer(fout);
 }
 
-void shader_CTA_count_visualizer_gzprint( gzFile fout )
-{
-   if (s_CTA_count_logger == NULL) return;
-   s_CTA_count_logger->print_visualizer(fout);
+void shader_CTA_count_visualizer_gzprint(gzFile fout) {
+  if (s_CTA_count_logger == NULL) return;
+  s_CTA_count_logger->print_visualizer(fout);
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-thread_insn_span::thread_insn_span(unsigned long long  cycle, gpgpu_context* ctx)
-  : m_cycle(cycle),
+thread_insn_span::thread_insn_span(unsigned long long cycle, gpgpu_context *ctx)
+    : m_cycle(cycle),
 #if (tr1_hash_map_ismap == 1)
-     m_insn_span_count() 
-#else 
-     m_insn_span_count(32*1024) 
+      m_insn_span_count()
+#else
+      m_insn_span_count(32 * 1024)
 #endif
 {
-    gpgpu_ctx = ctx;
+  gpgpu_ctx = ctx;
 }
 
-thread_insn_span::~thread_insn_span() { }
-   
-thread_insn_span::thread_insn_span(const thread_insn_span& other, gpgpu_context* ctx)
-      : m_cycle(other.m_cycle),
-        m_insn_span_count(other.m_insn_span_count)
-{ 
-    gpgpu_ctx = ctx;
-}
-      
-thread_insn_span& thread_insn_span::operator=(const thread_insn_span& other)
-{
-   printf("thread_insn_span& operator=\n");
-   if (this != &other) {
-      m_insn_span_count = other.m_insn_span_count;
-      m_cycle = other.m_cycle;
-   }
-   return *this;
-}
-   
-thread_insn_span& thread_insn_span::operator+=(const thread_insn_span& other)
-{
-   span_count_map::const_iterator i_sc = other.m_insn_span_count.begin();
-   for (; i_sc != other.m_insn_span_count.end(); ++i_sc) {
-      m_insn_span_count[i_sc->first] += i_sc->second;
-   }
-   return *this;
-}
-   
-void thread_insn_span::set_span( address_type pc ) 
-{
-   if( ((int)pc) >= 0 )
-      m_insn_span_count[pc] += 1;
-}
-   
-void thread_insn_span::reset(unsigned long long  cycle) 
-{
-   m_cycle = cycle;
-   m_insn_span_count.clear(); 
-}
-   
-void thread_insn_span::print_span(FILE *fout) const
-{
-   fprintf(fout, "%d: ", (int)m_cycle);
-   span_count_map::const_iterator i_sc = m_insn_span_count.begin();
-   for (; i_sc != m_insn_span_count.end(); ++i_sc) {
-      fprintf(fout, "%d ", i_sc->first);
-   }
-   fprintf(fout, "\n");
+thread_insn_span::~thread_insn_span() {}
+
+thread_insn_span::thread_insn_span(const thread_insn_span &other,
+                                   gpgpu_context *ctx)
+    : m_cycle(other.m_cycle), m_insn_span_count(other.m_insn_span_count) {
+  gpgpu_ctx = ctx;
 }
 
-void thread_insn_span::print_histo(FILE *fout) const
-{
-   fprintf(fout, "%d:", (int)m_cycle);
-   span_count_map::const_iterator i_sc = m_insn_span_count.begin();
-   for (; i_sc != m_insn_span_count.end(); ++i_sc) {
-      fprintf(fout, "%d ", i_sc->second);
-   }
-   fprintf(fout, "\n");
+thread_insn_span &thread_insn_span::operator=(const thread_insn_span &other) {
+  printf("thread_insn_span& operator=\n");
+  if (this != &other) {
+    m_insn_span_count = other.m_insn_span_count;
+    m_cycle = other.m_cycle;
+  }
+  return *this;
 }
 
-void thread_insn_span::print_sparse_histo(FILE *fout) const
-{
-   int n_printed_entries = 0;
-   span_count_map::const_iterator i_sc = m_insn_span_count.begin();
-   for (; i_sc != m_insn_span_count.end(); ++i_sc) {
-      unsigned ptx_lineno = gpgpu_ctx->translate_pc_to_ptxlineno(i_sc->first);
-      fprintf(fout, "%u %d ", ptx_lineno, i_sc->second);
-      n_printed_entries++;
-   }
-   if (n_printed_entries == 0) {
-      fprintf(fout, "0 0 ");
-   }
-   fprintf(fout, "\n");
+thread_insn_span &thread_insn_span::operator+=(const thread_insn_span &other) {
+  span_count_map::const_iterator i_sc = other.m_insn_span_count.begin();
+  for (; i_sc != other.m_insn_span_count.end(); ++i_sc) {
+    m_insn_span_count[i_sc->first] += i_sc->second;
+  }
+  return *this;
 }
 
-void thread_insn_span::print_sparse_histo(gzFile fout) const
-{
-   int n_printed_entries = 0;
-   span_count_map::const_iterator i_sc = m_insn_span_count.begin();
-   for (; i_sc != m_insn_span_count.end(); ++i_sc) {
-      unsigned ptx_lineno = gpgpu_ctx->translate_pc_to_ptxlineno(i_sc->first);
-      gzprintf(fout, "%u %d ", ptx_lineno, i_sc->second);
-      n_printed_entries++;
-   }
-   if (n_printed_entries == 0) {
-      gzprintf(fout, "0 0 ");
-   }
-   gzprintf(fout, "\n");
+void thread_insn_span::set_span(address_type pc) {
+  if (((int)pc) >= 0) m_insn_span_count[pc] += 1;
+}
+
+void thread_insn_span::reset(unsigned long long cycle) {
+  m_cycle = cycle;
+  m_insn_span_count.clear();
+}
+
+void thread_insn_span::print_span(FILE *fout) const {
+  fprintf(fout, "%d: ", (int)m_cycle);
+  span_count_map::const_iterator i_sc = m_insn_span_count.begin();
+  for (; i_sc != m_insn_span_count.end(); ++i_sc) {
+    fprintf(fout, "%d ", i_sc->first);
+  }
+  fprintf(fout, "\n");
+}
+
+void thread_insn_span::print_histo(FILE *fout) const {
+  fprintf(fout, "%d:", (int)m_cycle);
+  span_count_map::const_iterator i_sc = m_insn_span_count.begin();
+  for (; i_sc != m_insn_span_count.end(); ++i_sc) {
+    fprintf(fout, "%d ", i_sc->second);
+  }
+  fprintf(fout, "\n");
+}
+
+void thread_insn_span::print_sparse_histo(FILE *fout) const {
+  int n_printed_entries = 0;
+  span_count_map::const_iterator i_sc = m_insn_span_count.begin();
+  for (; i_sc != m_insn_span_count.end(); ++i_sc) {
+    unsigned ptx_lineno = gpgpu_ctx->translate_pc_to_ptxlineno(i_sc->first);
+    fprintf(fout, "%u %d ", ptx_lineno, i_sc->second);
+    n_printed_entries++;
+  }
+  if (n_printed_entries == 0) {
+    fprintf(fout, "0 0 ");
+  }
+  fprintf(fout, "\n");
+}
+
+void thread_insn_span::print_sparse_histo(gzFile fout) const {
+  int n_printed_entries = 0;
+  span_count_map::const_iterator i_sc = m_insn_span_count.begin();
+  for (; i_sc != m_insn_span_count.end(); ++i_sc) {
+    unsigned ptx_lineno = gpgpu_ctx->translate_pc_to_ptxlineno(i_sc->first);
+    gzprintf(fout, "%u %d ", ptx_lineno, i_sc->second);
+    n_printed_entries++;
+  }
+  if (n_printed_entries == 0) {
+    gzprintf(fout, "0 0 ");
+  }
+  gzprintf(fout, "\n");
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-thread_CFlocality::thread_CFlocality( gpgpu_context* ctx, std::string name, 
-                                     unsigned long long  snap_shot_interval, 
-                                     int nthreads, 
-                                     address_type start_pc, 
-                                     unsigned long long  start_cycle)
-      : snap_shot_trigger(snap_shot_interval), m_name(name),
-        m_nthreads(nthreads), m_thread_pc(nthreads, start_pc), m_cycle(start_cycle),
-        m_thd_span(start_cycle, ctx)
-{
-   std::fill(m_thread_pc.begin(), m_thread_pc.end(), -1); // so that hw thread with no work assigned will not clobber results
+thread_CFlocality::thread_CFlocality(gpgpu_context *ctx, std::string name,
+                                     unsigned long long snap_shot_interval,
+                                     int nthreads, address_type start_pc,
+                                     unsigned long long start_cycle)
+    : snap_shot_trigger(snap_shot_interval),
+      m_name(name),
+      m_nthreads(nthreads),
+      m_thread_pc(nthreads, start_pc),
+      m_cycle(start_cycle),
+      m_thd_span(start_cycle, ctx) {
+  std::fill(
+      m_thread_pc.begin(), m_thread_pc.end(),
+      -1);  // so that hw thread with no work assigned will not clobber results
 }
-   
-thread_CFlocality::~thread_CFlocality() 
-{
-} 
-   
-void thread_CFlocality::update_thread_pc( int thread_id, address_type pc ) 
-{
-   m_thread_pc[thread_id] = pc;
-   m_thd_span.set_span(pc);
+
+thread_CFlocality::~thread_CFlocality() {}
+
+void thread_CFlocality::update_thread_pc(int thread_id, address_type pc) {
+  m_thread_pc[thread_id] = pc;
+  m_thd_span.set_span(pc);
 }
-   
-void thread_CFlocality::snap_shot(unsigned long long  current_cycle) 
-{
-   m_thd_span_archive.push_back(m_thd_span);
-   m_thd_span.reset(current_cycle);
-   for (int i = 0; i < (int)m_thread_pc.size(); i++) {
+
+void thread_CFlocality::snap_shot(unsigned long long current_cycle) {
+  m_thd_span_archive.push_back(m_thd_span);
+  m_thd_span.reset(current_cycle);
+  for (int i = 0; i < (int)m_thread_pc.size(); i++) {
+    m_thd_span.set_span(m_thread_pc[i]);
+  }
+}
+
+void thread_CFlocality::spill(FILE *fout, bool final) {
+  std::list<thread_insn_span>::iterator lit = m_thd_span_archive.begin();
+  for (; lit != m_thd_span_archive.end(); lit = m_thd_span_archive.erase(lit)) {
+    fprintf(fout, "%s-", m_name.c_str());
+    lit->print_histo(fout);
+  }
+  assert(m_thd_span_archive.empty());
+  if (final) {
+    fprintf(fout, "%s-", m_name.c_str());
+    m_thd_span.print_histo(fout);
+  }
+}
+
+void thread_CFlocality::print_visualizer(FILE *fout) {
+  fprintf(fout, "%s: ", m_name.c_str());
+  if (m_thd_span_archive.empty()) {
+    // visualizer do no require snap_shots
+    m_thd_span.print_sparse_histo(fout);
+
+    // clean the thread span
+    m_thd_span.reset(0);
+    for (int i = 0; i < (int)m_thread_pc.size(); i++)
       m_thd_span.set_span(m_thread_pc[i]);
-   }
-}
-   
-void thread_CFlocality::spill(FILE *fout, bool final) 
-{
-   std::list<thread_insn_span>::iterator lit = m_thd_span_archive.begin();
-   for (; lit != m_thd_span_archive.end(); lit = m_thd_span_archive.erase(lit) ) {
-      fprintf(fout, "%s-", m_name.c_str());
-      lit->print_histo(fout);
-   }
-   assert( m_thd_span_archive.empty() );
-   if (final) {
-      fprintf(fout, "%s-", m_name.c_str());
-      m_thd_span.print_histo(fout);
-   }
-}
-   
-      
-void thread_CFlocality::print_visualizer(FILE *fout)  
-{
-   fprintf(fout, "%s: ", m_name.c_str());
-   if (m_thd_span_archive.empty()) {
-   
-      // visualizer do no require snap_shots
-      m_thd_span.print_sparse_histo(fout);
-      
-      // clean the thread span
-      m_thd_span.reset(0);
-      for (int i = 0; i < (int)m_thread_pc.size(); i++) 
-         m_thd_span.set_span(m_thread_pc[i]);
-   } else { 
-      assert(0); // TODO: implement fall back so that visualizer can work with snap shots
-   }
-}
-   
-void thread_CFlocality::print_visualizer(gzFile fout)
-{
-   gzprintf(fout, "%s: ", m_name.c_str());
-   if (m_thd_span_archive.empty()) {
-   
-      // visualizer do no require snap_shots
-      m_thd_span.print_sparse_histo(fout);
-      
-      // clean the thread span
-      m_thd_span.reset(0);
-      for (int i = 0; i < (int)m_thread_pc.size(); i++) {
-         m_thd_span.set_span(m_thread_pc[i]);
-      }
-   } else { 
-      assert(0); // TODO: implement fall back so that visualizer can work with snap shots
-   }
-}
-   
-void thread_CFlocality::print_span(FILE *fout) const
-{
-   std::list<thread_insn_span>::const_iterator lit = m_thd_span_archive.begin();
-   for (; lit != m_thd_span_archive.end(); ++lit) {
-      fprintf(fout, "%s-", m_name.c_str());
-      lit->print_span(fout);
-   }
-   fprintf(fout, "%s-", m_name.c_str());
-   m_thd_span.print_span(fout);
+  } else {
+    assert(0);  // TODO: implement fall back so that visualizer can work with
+                // snap shots
+  }
 }
 
-void thread_CFlocality::print_histo(FILE *fout) const
-{
-   std::list<thread_insn_span>::const_iterator lit = m_thd_span_archive.begin();
-   for (; lit != m_thd_span_archive.end(); ++lit) {
-      fprintf(fout, "%s-", m_name.c_str());
-      lit->print_histo(fout);
-   }
-   fprintf(fout, "%s-", m_name.c_str());
-   m_thd_span.print_histo(fout);
+void thread_CFlocality::print_visualizer(gzFile fout) {
+  gzprintf(fout, "%s: ", m_name.c_str());
+  if (m_thd_span_archive.empty()) {
+    // visualizer do no require snap_shots
+    m_thd_span.print_sparse_histo(fout);
+
+    // clean the thread span
+    m_thd_span.reset(0);
+    for (int i = 0; i < (int)m_thread_pc.size(); i++) {
+      m_thd_span.set_span(m_thread_pc[i]);
+    }
+  } else {
+    assert(0);  // TODO: implement fall back so that visualizer can work with
+                // snap shots
+  }
+}
+
+void thread_CFlocality::print_span(FILE *fout) const {
+  std::list<thread_insn_span>::const_iterator lit = m_thd_span_archive.begin();
+  for (; lit != m_thd_span_archive.end(); ++lit) {
+    fprintf(fout, "%s-", m_name.c_str());
+    lit->print_span(fout);
+  }
+  fprintf(fout, "%s-", m_name.c_str());
+  m_thd_span.print_span(fout);
+}
+
+void thread_CFlocality::print_histo(FILE *fout) const {
+  std::list<thread_insn_span>::const_iterator lit = m_thd_span_archive.begin();
+  for (; lit != m_thd_span_archive.end(); ++lit) {
+    fprintf(fout, "%s-", m_name.c_str());
+    lit->print_histo(fout);
+  }
+  fprintf(fout, "%s-", m_name.c_str());
+  m_thd_span.print_histo(fout);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-linear_histogram_logger::linear_histogram_logger(int n_bins, 
-                           unsigned long long  snap_shot_interval, 
-                           const char *name, 
-                           bool reset_at_snap_shot, 
-                           unsigned long long  start_cycle )
-      : snap_shot_trigger(snap_shot_interval), 
-        m_n_bins(n_bins), 
-        m_curr_lin_hist(m_n_bins, start_cycle),
-        m_lin_hist_archive(),
-        m_cycle(start_cycle),
-        m_reset_at_snap_shot(reset_at_snap_shot), 
-        m_name(name),
-        m_id(s_ids++) 
-{
+linear_histogram_logger::linear_histogram_logger(
+    int n_bins, unsigned long long snap_shot_interval, const char *name,
+    bool reset_at_snap_shot, unsigned long long start_cycle)
+    : snap_shot_trigger(snap_shot_interval),
+      m_n_bins(n_bins),
+      m_curr_lin_hist(m_n_bins, start_cycle),
+      m_lin_hist_archive(),
+      m_cycle(start_cycle),
+      m_reset_at_snap_shot(reset_at_snap_shot),
+      m_name(name),
+      m_id(s_ids++) {}
+
+linear_histogram_logger::linear_histogram_logger(
+    const linear_histogram_logger &other)
+    : snap_shot_trigger(other.get_interval()),
+      m_n_bins(other.m_n_bins),
+      m_curr_lin_hist(m_n_bins, other.m_cycle),
+      m_lin_hist_archive(),
+      m_cycle(other.m_cycle),
+      m_reset_at_snap_shot(other.m_reset_at_snap_shot),
+      m_name(other.m_name),
+      m_id(s_ids++) {}
+
+linear_histogram_logger::~linear_histogram_logger() {
+  remove_snap_shot_trigger(this);
+  remove_spill_log(this);
 }
 
-linear_histogram_logger::linear_histogram_logger(const linear_histogram_logger& other) 
-      : snap_shot_trigger(other.get_interval()), 
-        m_n_bins(other.m_n_bins), 
-        m_curr_lin_hist(m_n_bins, other.m_cycle),
-        m_lin_hist_archive(),
-        m_cycle(other.m_cycle),
-        m_reset_at_snap_shot(other.m_reset_at_snap_shot), 
-        m_name(other.m_name),
-        m_id(s_ids++) 
-{
+void linear_histogram_logger::snap_shot(unsigned long long current_cycle) {
+  m_lin_hist_archive.push_back(m_curr_lin_hist);
+  if (m_reset_at_snap_shot) {
+    m_curr_lin_hist.reset(current_cycle);
+  } else {
+    m_curr_lin_hist.set_cycle(current_cycle);
+  }
 }
 
-linear_histogram_logger::~linear_histogram_logger() 
-{
-      remove_snap_shot_trigger(this);
-      remove_spill_log(this);
-}
-   
-void linear_histogram_logger::snap_shot(unsigned long long  current_cycle) {
-   m_lin_hist_archive.push_back(m_curr_lin_hist);
-   if (m_reset_at_snap_shot) {
-      m_curr_lin_hist.reset(current_cycle);
-   } else {
-      m_curr_lin_hist.set_cycle(current_cycle);
-   }
-}
-   
-void linear_histogram_logger::spill(FILE *fout, bool final) 
-{
-   std::list<linear_histogram_snapshot>::iterator iter = m_lin_hist_archive.begin();
-   for (; iter != m_lin_hist_archive.end(); iter = m_lin_hist_archive.erase(iter) ) {
-      fprintf(fout, "%s%02d-", m_name.c_str(), (m_id >= 0)? m_id : 0);
-      iter->print(fout);
-      fprintf(fout, "\n");
-   }
-   assert( m_lin_hist_archive.empty() );
-   if (final) {
-      fprintf(fout, "%s%02d-", m_name.c_str(), (m_id >= 0)? m_id : 0);
-      m_curr_lin_hist.print(fout);
-      fprintf(fout, "\n");
-   }
-}
-   
-void linear_histogram_logger::print(FILE *fout) const
-{
-   std::list<linear_histogram_snapshot>::const_iterator iter = m_lin_hist_archive.begin();
-   for (; iter != m_lin_hist_archive.end(); ++iter) {
-      fprintf(fout, "%s%02d-", m_name.c_str(), m_id);
-      iter->print(fout);
-      fprintf(fout, "\n");
-   }
-   fprintf(fout, "%s%02d-", m_name.c_str(), m_id);
-   m_curr_lin_hist.print(fout);
-   fprintf(fout, "\n");
+void linear_histogram_logger::spill(FILE *fout, bool final) {
+  std::list<linear_histogram_snapshot>::iterator iter =
+      m_lin_hist_archive.begin();
+  for (; iter != m_lin_hist_archive.end();
+       iter = m_lin_hist_archive.erase(iter)) {
+    fprintf(fout, "%s%02d-", m_name.c_str(), (m_id >= 0) ? m_id : 0);
+    iter->print(fout);
+    fprintf(fout, "\n");
+  }
+  assert(m_lin_hist_archive.empty());
+  if (final) {
+    fprintf(fout, "%s%02d-", m_name.c_str(), (m_id >= 0) ? m_id : 0);
+    m_curr_lin_hist.print(fout);
+    fprintf(fout, "\n");
+  }
 }
 
-void linear_histogram_logger::print_visualizer(FILE *fout)
-{
-   assert(m_lin_hist_archive.empty()); // don't support snapshot for now
-   fprintf(fout, "%s", m_name.c_str());
-   if (m_id >= 0) {
-      fprintf(fout, "%02d: ", m_id);
-   } else {
-      fprintf(fout, ": ");
-   }
-   m_curr_lin_hist.print_visualizer(fout);
-   fprintf(fout, "\n");
-   if (m_reset_at_snap_shot) {
-      m_curr_lin_hist.reset(0);
-   } 
+void linear_histogram_logger::print(FILE *fout) const {
+  std::list<linear_histogram_snapshot>::const_iterator iter =
+      m_lin_hist_archive.begin();
+  for (; iter != m_lin_hist_archive.end(); ++iter) {
+    fprintf(fout, "%s%02d-", m_name.c_str(), m_id);
+    iter->print(fout);
+    fprintf(fout, "\n");
+  }
+  fprintf(fout, "%s%02d-", m_name.c_str(), m_id);
+  m_curr_lin_hist.print(fout);
+  fprintf(fout, "\n");
 }
 
-void linear_histogram_logger::print_visualizer(gzFile fout)
-{
-   assert(m_lin_hist_archive.empty()); // don't support snapshot for now
-   gzprintf(fout, "%s", m_name.c_str());
-   if (m_id >= 0) {
-      gzprintf(fout, "%02d: ", m_id);
-   } else {
-      gzprintf(fout, ": ");
-   }
-   m_curr_lin_hist.print_visualizer(fout);
-   gzprintf(fout, "\n");
-   if (m_reset_at_snap_shot) {
-      m_curr_lin_hist.reset(0);
-   } 
+void linear_histogram_logger::print_visualizer(FILE *fout) {
+  assert(m_lin_hist_archive.empty());  // don't support snapshot for now
+  fprintf(fout, "%s", m_name.c_str());
+  if (m_id >= 0) {
+    fprintf(fout, "%02d: ", m_id);
+  } else {
+    fprintf(fout, ": ");
+  }
+  m_curr_lin_hist.print_visualizer(fout);
+  fprintf(fout, "\n");
+  if (m_reset_at_snap_shot) {
+    m_curr_lin_hist.reset(0);
+  }
 }
 
+void linear_histogram_logger::print_visualizer(gzFile fout) {
+  assert(m_lin_hist_archive.empty());  // don't support snapshot for now
+  gzprintf(fout, "%s", m_name.c_str());
+  if (m_id >= 0) {
+    gzprintf(fout, "%02d: ", m_id);
+  } else {
+    gzprintf(fout, ": ");
+  }
+  m_curr_lin_hist.print_visualizer(fout);
+  gzprintf(fout, "\n");
+  if (m_reset_at_snap_shot) {
+    m_curr_lin_hist.reset(0);
+  }
+}

--- a/src/gpgpu-sim/stat-tool.cc
+++ b/src/gpgpu-sim/stat-tool.cc
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -27,160 +29,159 @@
 
 #include "stat-tool.h"
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <assert.h>
 #include <zlib.h>
-#include <string>
-#include <list>
-#include <vector>
-#include <map>
 #include <algorithm>
+#include <list>
+#include <map>
 #include <string>
+#include <string>
+#include <vector>
 #include "../../libcuda/gpgpu_context.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 
-static unsigned long long  min_snap_shot_interval = 0;
-static unsigned long long  next_snap_shot_cycle = 0;
-static std::list<snap_shot_trigger*> list_ss_trigger;
+static unsigned long long min_snap_shot_interval = 0;
+static unsigned long long next_snap_shot_cycle = 0;
+static std::list<snap_shot_trigger *> list_ss_trigger;
 
-void add_snap_shot_trigger (snap_shot_trigger* ss_trigger)
-{
-   // quick optimization assuming that all snap shot intervals are perfect multiples of each other
-   if (min_snap_shot_interval == 0 || min_snap_shot_interval > ss_trigger->get_interval()) {
-      min_snap_shot_interval = ss_trigger->get_interval();
-      next_snap_shot_cycle = min_snap_shot_interval; // assume that snap shots haven't started yet
-   }
-   list_ss_trigger.push_back(ss_trigger);
+void add_snap_shot_trigger(snap_shot_trigger *ss_trigger) {
+  // quick optimization assuming that all snap shot intervals are perfect
+  // multiples of each other
+  if (min_snap_shot_interval == 0 ||
+      min_snap_shot_interval > ss_trigger->get_interval()) {
+    min_snap_shot_interval = ss_trigger->get_interval();
+    next_snap_shot_cycle =
+        min_snap_shot_interval;  // assume that snap shots haven't started yet
+  }
+  list_ss_trigger.push_back(ss_trigger);
 }
 
-void remove_snap_shot_trigger (snap_shot_trigger* ss_trigger)
-{
-   list_ss_trigger.remove(ss_trigger);
+void remove_snap_shot_trigger(snap_shot_trigger *ss_trigger) {
+  list_ss_trigger.remove(ss_trigger);
 }
 
-void try_snap_shot (unsigned long long  current_cycle)
-{
-   if (min_snap_shot_interval == 0) return;
-   if (current_cycle != next_snap_shot_cycle) return;
-   
-   std::list<snap_shot_trigger*>::iterator ss_trigger_iter = list_ss_trigger.begin();
-   for(; ss_trigger_iter != list_ss_trigger.end(); ++ss_trigger_iter) {
-      (*ss_trigger_iter)->snap_shot(current_cycle); // WF: should be try_snap_shot
-   }
-   next_snap_shot_cycle = current_cycle + min_snap_shot_interval; // WF: stateful testing, maybe bad
+void try_snap_shot(unsigned long long current_cycle) {
+  if (min_snap_shot_interval == 0) return;
+  if (current_cycle != next_snap_shot_cycle) return;
+
+  std::list<snap_shot_trigger *>::iterator ss_trigger_iter =
+      list_ss_trigger.begin();
+  for (; ss_trigger_iter != list_ss_trigger.end(); ++ss_trigger_iter) {
+    (*ss_trigger_iter)
+        ->snap_shot(current_cycle);  // WF: should be try_snap_shot
+  }
+  next_snap_shot_cycle =
+      current_cycle +
+      min_snap_shot_interval;  // WF: stateful testing, maybe bad
 }
 
 ////////////////////////////////////////////////////////////////////////////////
- 
-static unsigned long long  spill_interval = 0;
-static unsigned long long  next_spill_cycle = 0;
-static std::list<spill_log_interface*> list_spill_log;
 
-void add_spill_log (spill_log_interface* spill_log)
-{
-   list_spill_log.push_back(spill_log);
+static unsigned long long spill_interval = 0;
+static unsigned long long next_spill_cycle = 0;
+static std::list<spill_log_interface *> list_spill_log;
+
+void add_spill_log(spill_log_interface *spill_log) {
+  list_spill_log.push_back(spill_log);
 }
 
-void remove_spill_log (spill_log_interface* spill_log)
-{
-   list_spill_log.remove(spill_log);
+void remove_spill_log(spill_log_interface *spill_log) {
+  list_spill_log.remove(spill_log);
 }
 
-void set_spill_interval (unsigned long long  interval)
-{
-   spill_interval = interval;
-   next_spill_cycle = spill_interval;
+void set_spill_interval(unsigned long long interval) {
+  spill_interval = interval;
+  next_spill_cycle = spill_interval;
 }
 
-void spill_log_to_file (FILE *fout, int final, unsigned long long  current_cycle)
-{
-   if (!final && spill_interval == 0) return;
-   if (!final && current_cycle <= next_spill_cycle) return;
+void spill_log_to_file(FILE *fout, int final,
+                       unsigned long long current_cycle) {
+  if (!final && spill_interval == 0) return;
+  if (!final && current_cycle <= next_spill_cycle) return;
 
-   fprintf(fout, "\n"); // ensure that the spill occurs at a new line
-   std::list<spill_log_interface*>::iterator i_spill_log = list_spill_log.begin();
-   for(; i_spill_log != list_spill_log.end(); ++i_spill_log) {
-      (*i_spill_log)->spill(fout, final); 
-   }
-   fflush(fout);
+  fprintf(fout, "\n");  // ensure that the spill occurs at a new line
+  std::list<spill_log_interface *>::iterator i_spill_log =
+      list_spill_log.begin();
+  for (; i_spill_log != list_spill_log.end(); ++i_spill_log) {
+    (*i_spill_log)->spill(fout, final);
+  }
+  fflush(fout);
 
-   next_spill_cycle = current_cycle + spill_interval; // WF: stateful testing, maybe bad
+  next_spill_cycle =
+      current_cycle + spill_interval;  // WF: stateful testing, maybe bad
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 static int n_thread_CFloggers = 0;
-static thread_CFlocality** thread_CFlogger = NULL;
+static thread_CFlocality **thread_CFlogger = NULL;
 
-void create_thread_CFlogger(gpgpu_context* ctx, int n_loggers, int n_threads, address_type start_pc, unsigned long long  logging_interval) 
-{
-   destroy_thread_CFlogger();
-   
-   n_thread_CFloggers = n_loggers;
-   thread_CFlogger = new thread_CFlocality*[n_loggers];
+void create_thread_CFlogger(gpgpu_context *ctx, int n_loggers, int n_threads,
+                            address_type start_pc,
+                            unsigned long long logging_interval) {
+  destroy_thread_CFlogger();
 
-   std::string name_tpl("CFLog");
-   char buffer[32];
-   for (int i = 0; i < n_thread_CFloggers; i++) {
-      snprintf(buffer, 32, "%02d", i);
-      thread_CFlogger[i] = new thread_CFlocality( ctx, name_tpl + buffer, logging_interval, n_threads, start_pc);
-      if (logging_interval != 0) {
-         add_snap_shot_trigger(thread_CFlogger[i]);
-         add_spill_log(thread_CFlogger[i]);
-      }
-   }
+  n_thread_CFloggers = n_loggers;
+  thread_CFlogger = new thread_CFlocality *[n_loggers];
+
+  std::string name_tpl("CFLog");
+  char buffer[32];
+  for (int i = 0; i < n_thread_CFloggers; i++) {
+    snprintf(buffer, 32, "%02d", i);
+    thread_CFlogger[i] = new thread_CFlocality(
+        ctx, name_tpl + buffer, logging_interval, n_threads, start_pc);
+    if (logging_interval != 0) {
+      add_snap_shot_trigger(thread_CFlogger[i]);
+      add_spill_log(thread_CFlogger[i]);
+    }
+  }
 }
 
-void destroy_thread_CFlogger( ) 
-{
-   if (thread_CFlogger != NULL) {
-      for (int i = 0; i < n_thread_CFloggers; i++) {
-         remove_snap_shot_trigger(thread_CFlogger[i]);
-         remove_spill_log(thread_CFlogger[i]);
-         delete thread_CFlogger[i];
-      }
-      delete [] thread_CFlogger;
-      thread_CFlogger = NULL;
-   }
+void destroy_thread_CFlogger() {
+  if (thread_CFlogger != NULL) {
+    for (int i = 0; i < n_thread_CFloggers; i++) {
+      remove_snap_shot_trigger(thread_CFlogger[i]);
+      remove_spill_log(thread_CFlogger[i]);
+      delete thread_CFlogger[i];
+    }
+    delete[] thread_CFlogger;
+    thread_CFlogger = NULL;
+  }
 }
 
-void cflog_update_thread_pc( int logger_id, int thread_id, address_type pc ) 
-{
-   if (thread_CFlogger == NULL) return;  // this means no visualizer output 
-   if (thread_id < 0) return;
-   thread_CFlogger[logger_id]->update_thread_pc(thread_id, pc);
+void cflog_update_thread_pc(int logger_id, int thread_id, address_type pc) {
+  if (thread_CFlogger == NULL) return;  // this means no visualizer output
+  if (thread_id < 0) return;
+  thread_CFlogger[logger_id]->update_thread_pc(thread_id, pc);
 }
 
-// deprecated 
-void cflog_snapshot( int logger_id, unsigned long long  cycle ) 
-{
-   thread_CFlogger[logger_id]->snap_shot(cycle);
+// deprecated
+void cflog_snapshot(int logger_id, unsigned long long cycle) {
+  thread_CFlogger[logger_id]->snap_shot(cycle);
 }
 
-void cflog_print(FILE *fout) 
-{
-   if (thread_CFlogger == NULL) return;  // this means no visualizer output 
-   for (int i = 0; i < n_thread_CFloggers; i++) {
-      thread_CFlogger[i]->print_histo(fout);
-   }
+void cflog_print(FILE *fout) {
+  if (thread_CFlogger == NULL) return;  // this means no visualizer output
+  for (int i = 0; i < n_thread_CFloggers; i++) {
+    thread_CFlogger[i]->print_histo(fout);
+  }
 }
 
-void cflog_visualizer_print(FILE *fout) 
-{
-   if (thread_CFlogger == NULL) return;  // this means no visualizer output 
-   for (int i = 0; i < n_thread_CFloggers; i++) {
-      thread_CFlogger[i]->print_visualizer(fout);
-   }
+void cflog_visualizer_print(FILE *fout) {
+  if (thread_CFlogger == NULL) return;  // this means no visualizer output
+  for (int i = 0; i < n_thread_CFloggers; i++) {
+    thread_CFlogger[i]->print_visualizer(fout);
+  }
 }
 
-void cflog_visualizer_gzprint(gzFile fout) 
-{
-   if (thread_CFlogger == NULL) return;  // this means no visualizer output 
-   for (int i = 0; i < n_thread_CFloggers; i++) {
-      thread_CFlogger[i]->print_visualizer(fout);
-   }
+void cflog_visualizer_gzprint(gzFile fout) {
+  if (thread_CFlogger == NULL) return;  // this means no visualizer output
+  for (int i = 0; i < n_thread_CFloggers; i++) {
+    thread_CFlogger[i]->print_visualizer(fout);
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -189,26 +190,23 @@ int insn_warp_occ_logger::s_ids = 0;
 
 static std::vector<insn_warp_occ_logger> iwo_logger;
 
-void insn_warp_occ_create( int n_loggers, int simd_width )
-{
-   iwo_logger.clear();
-   iwo_logger.assign(n_loggers, insn_warp_occ_logger(simd_width));
-   for (unsigned i = 0; i < iwo_logger.size(); i++) {
-      iwo_logger[i].set_id(i);
-   }
+void insn_warp_occ_create(int n_loggers, int simd_width) {
+  iwo_logger.clear();
+  iwo_logger.assign(n_loggers, insn_warp_occ_logger(simd_width));
+  for (unsigned i = 0; i < iwo_logger.size(); i++) {
+    iwo_logger[i].set_id(i);
+  }
 }
 
-void insn_warp_occ_log( int logger_id, address_type pc, int warp_occ)
-{
-   if (warp_occ <= 0) return;
-   iwo_logger[logger_id].log(pc, warp_occ);
+void insn_warp_occ_log(int logger_id, address_type pc, int warp_occ) {
+  if (warp_occ <= 0) return;
+  iwo_logger[logger_id].log(pc, warp_occ);
 }
 
-void insn_warp_occ_print( FILE *fout )
-{
-   for (unsigned i = 0; i < iwo_logger.size(); i++) {
-      iwo_logger[i].print(fout);
-   }
+void insn_warp_occ_print(FILE *fout) {
+  for (unsigned i = 0; i < iwo_logger.size(); i++) {
+    iwo_logger[i].print(fout);
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -221,35 +219,32 @@ int linear_histogram_logger::s_ids = 0;
 
 static std::vector<linear_histogram_logger> s_warp_occ_logger;
 
-void shader_warp_occ_create( int n_loggers, int simd_width, unsigned long long  logging_interval)
-{
-   // simd_width + 1 to include the case with full warp
-   s_warp_occ_logger.assign(n_loggers, 
-                            linear_histogram_logger(simd_width + 1, logging_interval, "ShdrWarpOcc"));
-   for (unsigned i = 0; i < s_warp_occ_logger.size(); i++) {
-      s_warp_occ_logger[i].set_id(i);
-      add_snap_shot_trigger(&(s_warp_occ_logger[i]));
-      add_spill_log(&(s_warp_occ_logger[i]));
-   }
+void shader_warp_occ_create(int n_loggers, int simd_width,
+                            unsigned long long logging_interval) {
+  // simd_width + 1 to include the case with full warp
+  s_warp_occ_logger.assign(
+      n_loggers,
+      linear_histogram_logger(simd_width + 1, logging_interval, "ShdrWarpOcc"));
+  for (unsigned i = 0; i < s_warp_occ_logger.size(); i++) {
+    s_warp_occ_logger[i].set_id(i);
+    add_snap_shot_trigger(&(s_warp_occ_logger[i]));
+    add_spill_log(&(s_warp_occ_logger[i]));
+  }
 }
 
-void shader_warp_occ_log( int logger_id, int warp_occ)
-{
-   s_warp_occ_logger[logger_id].log(warp_occ);
+void shader_warp_occ_log(int logger_id, int warp_occ) {
+  s_warp_occ_logger[logger_id].log(warp_occ);
 }
 
-void shader_warp_occ_snapshot( int logger_id, unsigned long long  current_cycle)
-{
-   s_warp_occ_logger[logger_id].snap_shot(current_cycle);
+void shader_warp_occ_snapshot(int logger_id, unsigned long long current_cycle) {
+  s_warp_occ_logger[logger_id].snap_shot(current_cycle);
 }
 
-void shader_warp_occ_print( FILE *fout )
-{
-   for (unsigned i = 0; i < s_warp_occ_logger.size(); i++) {
-      s_warp_occ_logger[i].print(fout);
-   }
+void shader_warp_occ_print(FILE *fout) {
+  for (unsigned i = 0; i < s_warp_occ_logger.size(); i++) {
+    s_warp_occ_logger[i].print(fout);
+  }
 }
-
 
 /////////////////////////////////////////////////////////////////////////////////////
 // per-shadercore memory-access logger
@@ -259,105 +254,115 @@ static int s_mem_acc_logger_n_dram = 0;
 static int s_mem_acc_logger_n_bank = 0;
 static std::vector<linear_histogram_logger> s_mem_acc_logger;
 
-void shader_mem_acc_create( int n_loggers, int n_dram, int n_bank, unsigned long long  logging_interval)
-{
-   // (n_bank + 1) to space data out; 2x to separate read and write
-   s_mem_acc_logger.assign(n_loggers, 
-                           linear_histogram_logger(2 * n_dram * (n_bank + 1), logging_interval, "ShdrMemAcc"));
+void shader_mem_acc_create(int n_loggers, int n_dram, int n_bank,
+                           unsigned long long logging_interval) {
+  // (n_bank + 1) to space data out; 2x to separate read and write
+  s_mem_acc_logger.assign(
+      n_loggers, linear_histogram_logger(2 * n_dram * (n_bank + 1),
+                                         logging_interval, "ShdrMemAcc"));
 
-   s_mem_acc_logger_n_dram = n_dram;
-   s_mem_acc_logger_n_bank = n_bank;
-   for (unsigned i = 0; i < s_mem_acc_logger.size(); i++) {
-      s_mem_acc_logger[i].set_id(i);
-      add_snap_shot_trigger(&(s_mem_acc_logger[i]));
-      add_spill_log(&(s_mem_acc_logger[i]));
-   }
+  s_mem_acc_logger_n_dram = n_dram;
+  s_mem_acc_logger_n_bank = n_bank;
+  for (unsigned i = 0; i < s_mem_acc_logger.size(); i++) {
+    s_mem_acc_logger[i].set_id(i);
+    add_snap_shot_trigger(&(s_mem_acc_logger[i]));
+    add_spill_log(&(s_mem_acc_logger[i]));
+  }
 }
 
-void shader_mem_acc_log( int logger_id, int dram_id, int bank, char rw)
-{
-   if (s_mem_acc_logger_n_dram == 0) return;
-   int write_offset = 0;
-   switch(rw) {
-   case 'r': write_offset = 0; break;
-   case 'w': write_offset = (s_mem_acc_logger_n_bank + 1) * s_mem_acc_logger_n_dram; break;
-   default: assert(0); break;
-   }
-   s_mem_acc_logger[logger_id].log(dram_id * s_mem_acc_logger_n_bank + bank + write_offset);
+void shader_mem_acc_log(int logger_id, int dram_id, int bank, char rw) {
+  if (s_mem_acc_logger_n_dram == 0) return;
+  int write_offset = 0;
+  switch (rw) {
+    case 'r':
+      write_offset = 0;
+      break;
+    case 'w':
+      write_offset = (s_mem_acc_logger_n_bank + 1) * s_mem_acc_logger_n_dram;
+      break;
+    default:
+      assert(0);
+      break;
+  }
+  s_mem_acc_logger[logger_id].log(dram_id * s_mem_acc_logger_n_bank + bank +
+                                  write_offset);
 }
 
-void shader_mem_acc_snapshot( int logger_id, unsigned long long  current_cycle)
-{
-   s_mem_acc_logger[logger_id].snap_shot(current_cycle);
+void shader_mem_acc_snapshot(int logger_id, unsigned long long current_cycle) {
+  s_mem_acc_logger[logger_id].snap_shot(current_cycle);
 }
 
-void shader_mem_acc_print( FILE *fout )
-{
-   for (unsigned i = 0; i < s_mem_acc_logger.size(); i++) {
-      s_mem_acc_logger[i].print(fout);
-   }
+void shader_mem_acc_print(FILE *fout) {
+  for (unsigned i = 0; i < s_mem_acc_logger.size(); i++) {
+    s_mem_acc_logger[i].print(fout);
+  }
 }
-
 
 /////////////////////////////////////////////////////////////////////////////////////
 // per-shadercore memory-latency logger
 /////////////////////////////////////////////////////////////////////////////////////
 
 static bool s_mem_lat_logger_used = false;
-static int s_mem_lat_logger_nbins = 48;     // up to 2^24 = 16M
+static int s_mem_lat_logger_nbins = 48;  // up to 2^24 = 16M
 static std::vector<linear_histogram_logger> s_mem_lat_logger;
 
-void shader_mem_lat_create( int n_loggers, unsigned long long  logging_interval)
-{
-   s_mem_lat_logger.assign(n_loggers, 
-                           linear_histogram_logger(s_mem_lat_logger_nbins, logging_interval, "ShdrMemLat"));
+void shader_mem_lat_create(int n_loggers, unsigned long long logging_interval) {
+  s_mem_lat_logger.assign(
+      n_loggers, linear_histogram_logger(s_mem_lat_logger_nbins,
+                                         logging_interval, "ShdrMemLat"));
 
-   for (unsigned i = 0; i < s_mem_lat_logger.size(); i++) {
-      s_mem_lat_logger[i].set_id(i);
-      add_snap_shot_trigger(&(s_mem_lat_logger[i]));
-      add_spill_log(&(s_mem_lat_logger[i]));
-   }
-   
-   s_mem_lat_logger_used = true;
+  for (unsigned i = 0; i < s_mem_lat_logger.size(); i++) {
+    s_mem_lat_logger[i].set_id(i);
+    add_snap_shot_trigger(&(s_mem_lat_logger[i]));
+    add_spill_log(&(s_mem_lat_logger[i]));
+  }
+
+  s_mem_lat_logger_used = true;
 }
 
-void shader_mem_lat_log( int logger_id, int latency)
-{
-   if (s_mem_lat_logger_used == false) return;
-   if (latency > (1<<(s_mem_lat_logger_nbins/2))) assert(0); // guard for out of bound bin
-   assert(latency > 0);
-   
-   int latency_bin;
-   
-   int bin; // LOG_2(latency)
-   int v = latency;
-   register unsigned int shift;
+void shader_mem_lat_log(int logger_id, int latency) {
+  if (s_mem_lat_logger_used == false) return;
+  if (latency > (1 << (s_mem_lat_logger_nbins / 2)))
+    assert(0);  // guard for out of bound bin
+  assert(latency > 0);
 
-   bin =   (v > 0xFFFF) << 4; v >>= bin;
-   shift = (v > 0xFF  ) << 3; v >>= shift; bin |= shift;
-   shift = (v > 0xF   ) << 2; v >>= shift; bin |= shift;
-   shift = (v > 0x3   ) << 1; v >>= shift; bin |= shift;
-                                           bin |= (v >> 1);
-   latency_bin = 2 * bin;
-   if (bin > 0) {
-      latency_bin += ((latency & (1 << (bin - 1))) != 0)? 1 : 0; // approx. for LOG_sqrt2(latency)
-   }
+  int latency_bin;
 
-   s_mem_lat_logger[logger_id].log(latency_bin);
+  int bin;  // LOG_2(latency)
+  int v = latency;
+  register unsigned int shift;
+
+  bin = (v > 0xFFFF) << 4;
+  v >>= bin;
+  shift = (v > 0xFF) << 3;
+  v >>= shift;
+  bin |= shift;
+  shift = (v > 0xF) << 2;
+  v >>= shift;
+  bin |= shift;
+  shift = (v > 0x3) << 1;
+  v >>= shift;
+  bin |= shift;
+  bin |= (v >> 1);
+  latency_bin = 2 * bin;
+  if (bin > 0) {
+    latency_bin += ((latency & (1 << (bin - 1))) != 0)
+                       ? 1
+                       : 0;  // approx. for LOG_sqrt2(latency)
+  }
+
+  s_mem_lat_logger[logger_id].log(latency_bin);
 }
 
-void shader_mem_lat_snapshot( int logger_id, unsigned long long  current_cycle)
-{
-   s_mem_lat_logger[logger_id].snap_shot(current_cycle);
+void shader_mem_lat_snapshot(int logger_id, unsigned long long current_cycle) {
+  s_mem_lat_logger[logger_id].snap_shot(current_cycle);
 }
 
-void shader_mem_lat_print( FILE *fout )
-{
-   for (unsigned i = 0; i < s_mem_lat_logger.size(); i++) {
-      s_mem_lat_logger[i].print(fout);
-   }
+void shader_mem_lat_print(FILE *fout) {
+  for (unsigned i = 0; i < s_mem_lat_logger.size(); i++) {
+    s_mem_lat_logger[i].print(fout);
+  }
 }
-
 
 /////////////////////////////////////////////////////////////////////////////////////
 // per-shadercore cache-miss logger
@@ -366,425 +371,393 @@ void shader_mem_lat_print( FILE *fout )
 static int s_cache_access_logger_n_types = 0;
 static std::vector<linear_histogram_logger> s_cache_access_logger;
 
-enum cache_access_logger_types {
-   NORMALS, TEXTURE, CONSTANT, INSTRUCTION
-};
+enum cache_access_logger_types { NORMALS, TEXTURE, CONSTANT, INSTRUCTION };
 
 int get_shader_normal_cache_id() { return NORMALS; }
 int get_shader_texture_cache_id() { return TEXTURE; }
 int get_shader_constant_cache_id() { return CONSTANT; }
 int get_shader_instruction_cache_id() { return INSTRUCTION; }
 
-void shader_cache_access_create( int n_loggers, int n_types, unsigned long long  logging_interval)
-{
-   // There are different type of cache (x2 for recording accesses and misses)
-   s_cache_access_logger.assign(n_loggers, 
-                                linear_histogram_logger(n_types * 2, logging_interval, "ShdrCacheMiss"));
+void shader_cache_access_create(int n_loggers, int n_types,
+                                unsigned long long logging_interval) {
+  // There are different type of cache (x2 for recording accesses and misses)
+  s_cache_access_logger.assign(
+      n_loggers,
+      linear_histogram_logger(n_types * 2, logging_interval, "ShdrCacheMiss"));
 
-   s_cache_access_logger_n_types = n_types;
-   for (unsigned i = 0; i < s_cache_access_logger.size(); i++) {
-      s_cache_access_logger[i].set_id(i);
-      add_snap_shot_trigger(&(s_cache_access_logger[i]));
-      add_spill_log(&(s_cache_access_logger[i]));
-   }
+  s_cache_access_logger_n_types = n_types;
+  for (unsigned i = 0; i < s_cache_access_logger.size(); i++) {
+    s_cache_access_logger[i].set_id(i);
+    add_snap_shot_trigger(&(s_cache_access_logger[i]));
+    add_spill_log(&(s_cache_access_logger[i]));
+  }
 }
 
-void shader_cache_access_log( int logger_id, int type, int miss)
-{
-   if (s_cache_access_logger_n_types == 0) return;
-   if (logger_id < 0) return;
-   assert(type == NORMALS || type == TEXTURE || type == CONSTANT || type == INSTRUCTION);
-   assert(miss == 0 || miss == 1);
-   
-   s_cache_access_logger[logger_id].log(2 * type + miss);
+void shader_cache_access_log(int logger_id, int type, int miss) {
+  if (s_cache_access_logger_n_types == 0) return;
+  if (logger_id < 0) return;
+  assert(type == NORMALS || type == TEXTURE || type == CONSTANT ||
+         type == INSTRUCTION);
+  assert(miss == 0 || miss == 1);
+
+  s_cache_access_logger[logger_id].log(2 * type + miss);
 }
 
-void shader_cache_access_unlog( int logger_id, int type, int miss)
-{
-   if (s_cache_access_logger_n_types == 0) return;
-   if (logger_id < 0) return;
-   assert(type == NORMALS || type == TEXTURE || type == CONSTANT || type == INSTRUCTION);
-   assert(miss == 0 || miss == 1);
-   
-   s_cache_access_logger[logger_id].unlog(2 * type + miss);
+void shader_cache_access_unlog(int logger_id, int type, int miss) {
+  if (s_cache_access_logger_n_types == 0) return;
+  if (logger_id < 0) return;
+  assert(type == NORMALS || type == TEXTURE || type == CONSTANT ||
+         type == INSTRUCTION);
+  assert(miss == 0 || miss == 1);
+
+  s_cache_access_logger[logger_id].unlog(2 * type + miss);
 }
 
-void shader_cache_access_print( FILE *fout )
-{
-   for (unsigned i = 0; i < s_cache_access_logger.size(); i++) {
-      s_cache_access_logger[i].print(fout);
-   }
+void shader_cache_access_print(FILE *fout) {
+  for (unsigned i = 0; i < s_cache_access_logger.size(); i++) {
+    s_cache_access_logger[i].print(fout);
+  }
 }
-
 
 /////////////////////////////////////////////////////////////////////////////////////
-// per-shadercore CTA count logger (only make sense with gpgpu_spread_blocks_across_cores)
+// per-shadercore CTA count logger (only make sense with
+// gpgpu_spread_blocks_across_cores)
 /////////////////////////////////////////////////////////////////////////////////////
 
 static linear_histogram_logger *s_CTA_count_logger = NULL;
 
-void shader_CTA_count_create( int n_shaders, unsigned long long  logging_interval)
-{
-   // only need one logger to track all the shaders
-   if (s_CTA_count_logger != NULL) delete s_CTA_count_logger;
-   s_CTA_count_logger = new linear_histogram_logger(n_shaders, logging_interval, "ShdrCTACount", false);
+void shader_CTA_count_create(int n_shaders,
+                             unsigned long long logging_interval) {
+  // only need one logger to track all the shaders
+  if (s_CTA_count_logger != NULL) delete s_CTA_count_logger;
+  s_CTA_count_logger = new linear_histogram_logger(n_shaders, logging_interval,
+                                                   "ShdrCTACount", false);
 
-   s_CTA_count_logger->set_id(-1);
-   if (logging_interval != 0) {
-      add_snap_shot_trigger(s_CTA_count_logger);
-      add_spill_log(s_CTA_count_logger);
-   }
+  s_CTA_count_logger->set_id(-1);
+  if (logging_interval != 0) {
+    add_snap_shot_trigger(s_CTA_count_logger);
+    add_spill_log(s_CTA_count_logger);
+  }
 }
 
-void shader_CTA_count_log( int shader_id, int nCTAadded )
-{
-   if (s_CTA_count_logger == NULL) return;
-   
-   for (int i = 0; i < nCTAadded; i++) {
-      s_CTA_count_logger->log(shader_id);
-   }
+void shader_CTA_count_log(int shader_id, int nCTAadded) {
+  if (s_CTA_count_logger == NULL) return;
+
+  for (int i = 0; i < nCTAadded; i++) {
+    s_CTA_count_logger->log(shader_id);
+  }
 }
 
-void shader_CTA_count_unlog( int shader_id, int nCTAdone )
-{
-   if (s_CTA_count_logger == NULL) return;
-   
-   for (int i = 0; i < nCTAdone; i++) {
-      s_CTA_count_logger->unlog(shader_id);
-   }
+void shader_CTA_count_unlog(int shader_id, int nCTAdone) {
+  if (s_CTA_count_logger == NULL) return;
+
+  for (int i = 0; i < nCTAdone; i++) {
+    s_CTA_count_logger->unlog(shader_id);
+  }
 }
 
-void shader_CTA_count_print( FILE *fout )
-{
-   if (s_CTA_count_logger == NULL) return;
-   s_CTA_count_logger->print(fout);
+void shader_CTA_count_print(FILE *fout) {
+  if (s_CTA_count_logger == NULL) return;
+  s_CTA_count_logger->print(fout);
 }
 
-void shader_CTA_count_visualizer_print( FILE *fout )
-{
-   if (s_CTA_count_logger == NULL) return;
-   s_CTA_count_logger->print_visualizer(fout);
+void shader_CTA_count_visualizer_print(FILE *fout) {
+  if (s_CTA_count_logger == NULL) return;
+  s_CTA_count_logger->print_visualizer(fout);
 }
 
-void shader_CTA_count_visualizer_gzprint( gzFile fout )
-{
-   if (s_CTA_count_logger == NULL) return;
-   s_CTA_count_logger->print_visualizer(fout);
+void shader_CTA_count_visualizer_gzprint(gzFile fout) {
+  if (s_CTA_count_logger == NULL) return;
+  s_CTA_count_logger->print_visualizer(fout);
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-thread_insn_span::thread_insn_span(unsigned long long  cycle, gpgpu_context* ctx)
-  : m_cycle(cycle),
+thread_insn_span::thread_insn_span(unsigned long long cycle, gpgpu_context *ctx)
+    : m_cycle(cycle),
 #if (tr1_hash_map_ismap == 1)
-     m_insn_span_count() 
-#else 
-     m_insn_span_count(32*1024) 
+      m_insn_span_count()
+#else
+      m_insn_span_count(32 * 1024)
 #endif
 {
-    gpgpu_ctx = ctx;
+  gpgpu_ctx = ctx;
 }
 
-thread_insn_span::~thread_insn_span() { }
-   
-thread_insn_span::thread_insn_span(const thread_insn_span& other, gpgpu_context* ctx)
-      : m_cycle(other.m_cycle),
-        m_insn_span_count(other.m_insn_span_count)
-{ 
-    gpgpu_ctx = ctx;
-}
-      
-thread_insn_span& thread_insn_span::operator=(const thread_insn_span& other)
-{
-   printf("thread_insn_span& operator=\n");
-   if (this != &other) {
-      m_insn_span_count = other.m_insn_span_count;
-      m_cycle = other.m_cycle;
-   }
-   return *this;
-}
-   
-thread_insn_span& thread_insn_span::operator+=(const thread_insn_span& other)
-{
-   span_count_map::const_iterator i_sc = other.m_insn_span_count.begin();
-   for (; i_sc != other.m_insn_span_count.end(); ++i_sc) {
-      m_insn_span_count[i_sc->first] += i_sc->second;
-   }
-   return *this;
-}
-   
-void thread_insn_span::set_span( address_type pc ) 
-{
-   if( ((int)pc) >= 0 )
-      m_insn_span_count[pc] += 1;
-}
-   
-void thread_insn_span::reset(unsigned long long  cycle) 
-{
-   m_cycle = cycle;
-   m_insn_span_count.clear(); 
-}
-   
-void thread_insn_span::print_span(FILE *fout) const
-{
-   fprintf(fout, "%d: ", (int)m_cycle);
-   span_count_map::const_iterator i_sc = m_insn_span_count.begin();
-   for (; i_sc != m_insn_span_count.end(); ++i_sc) {
-      fprintf(fout, "%d ", i_sc->first);
-   }
-   fprintf(fout, "\n");
+thread_insn_span::~thread_insn_span() {}
+
+thread_insn_span::thread_insn_span(const thread_insn_span &other,
+                                   gpgpu_context *ctx)
+    : m_cycle(other.m_cycle), m_insn_span_count(other.m_insn_span_count) {
+  gpgpu_ctx = ctx;
 }
 
-void thread_insn_span::print_histo(FILE *fout) const
-{
-   fprintf(fout, "%d:", (int)m_cycle);
-   span_count_map::const_iterator i_sc = m_insn_span_count.begin();
-   for (; i_sc != m_insn_span_count.end(); ++i_sc) {
-      fprintf(fout, "%d ", i_sc->second);
-   }
-   fprintf(fout, "\n");
+thread_insn_span &thread_insn_span::operator=(const thread_insn_span &other) {
+  printf("thread_insn_span& operator=\n");
+  if (this != &other) {
+    m_insn_span_count = other.m_insn_span_count;
+    m_cycle = other.m_cycle;
+  }
+  return *this;
 }
 
-void thread_insn_span::print_sparse_histo(FILE *fout) const
-{
-   int n_printed_entries = 0;
-   span_count_map::const_iterator i_sc = m_insn_span_count.begin();
-   for (; i_sc != m_insn_span_count.end(); ++i_sc) {
-      unsigned ptx_lineno = gpgpu_ctx->translate_pc_to_ptxlineno(i_sc->first);
-      fprintf(fout, "%u %d ", ptx_lineno, i_sc->second);
-      n_printed_entries++;
-   }
-   if (n_printed_entries == 0) {
-      fprintf(fout, "0 0 ");
-   }
-   fprintf(fout, "\n");
+thread_insn_span &thread_insn_span::operator+=(const thread_insn_span &other) {
+  span_count_map::const_iterator i_sc = other.m_insn_span_count.begin();
+  for (; i_sc != other.m_insn_span_count.end(); ++i_sc) {
+    m_insn_span_count[i_sc->first] += i_sc->second;
+  }
+  return *this;
 }
 
-void thread_insn_span::print_sparse_histo(gzFile fout) const
-{
-   int n_printed_entries = 0;
-   span_count_map::const_iterator i_sc = m_insn_span_count.begin();
-   for (; i_sc != m_insn_span_count.end(); ++i_sc) {
-      unsigned ptx_lineno = gpgpu_ctx->translate_pc_to_ptxlineno(i_sc->first);
-      gzprintf(fout, "%u %d ", ptx_lineno, i_sc->second);
-      n_printed_entries++;
-   }
-   if (n_printed_entries == 0) {
-      gzprintf(fout, "0 0 ");
-   }
-   gzprintf(fout, "\n");
+void thread_insn_span::set_span(address_type pc) {
+  if (((int)pc) >= 0) m_insn_span_count[pc] += 1;
+}
+
+void thread_insn_span::reset(unsigned long long cycle) {
+  m_cycle = cycle;
+  m_insn_span_count.clear();
+}
+
+void thread_insn_span::print_span(FILE *fout) const {
+  fprintf(fout, "%d: ", (int)m_cycle);
+  span_count_map::const_iterator i_sc = m_insn_span_count.begin();
+  for (; i_sc != m_insn_span_count.end(); ++i_sc) {
+    fprintf(fout, "%d ", i_sc->first);
+  }
+  fprintf(fout, "\n");
+}
+
+void thread_insn_span::print_histo(FILE *fout) const {
+  fprintf(fout, "%d:", (int)m_cycle);
+  span_count_map::const_iterator i_sc = m_insn_span_count.begin();
+  for (; i_sc != m_insn_span_count.end(); ++i_sc) {
+    fprintf(fout, "%d ", i_sc->second);
+  }
+  fprintf(fout, "\n");
+}
+
+void thread_insn_span::print_sparse_histo(FILE *fout) const {
+  int n_printed_entries = 0;
+  span_count_map::const_iterator i_sc = m_insn_span_count.begin();
+  for (; i_sc != m_insn_span_count.end(); ++i_sc) {
+    unsigned ptx_lineno = gpgpu_ctx->translate_pc_to_ptxlineno(i_sc->first);
+    fprintf(fout, "%u %d ", ptx_lineno, i_sc->second);
+    n_printed_entries++;
+  }
+  if (n_printed_entries == 0) {
+    fprintf(fout, "0 0 ");
+  }
+  fprintf(fout, "\n");
+}
+
+void thread_insn_span::print_sparse_histo(gzFile fout) const {
+  int n_printed_entries = 0;
+  span_count_map::const_iterator i_sc = m_insn_span_count.begin();
+  for (; i_sc != m_insn_span_count.end(); ++i_sc) {
+    unsigned ptx_lineno = gpgpu_ctx->translate_pc_to_ptxlineno(i_sc->first);
+    gzprintf(fout, "%u %d ", ptx_lineno, i_sc->second);
+    n_printed_entries++;
+  }
+  if (n_printed_entries == 0) {
+    gzprintf(fout, "0 0 ");
+  }
+  gzprintf(fout, "\n");
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-thread_CFlocality::thread_CFlocality( gpgpu_context* ctx, std::string name, 
-                                     unsigned long long  snap_shot_interval, 
-                                     int nthreads, 
-                                     address_type start_pc, 
-                                     unsigned long long  start_cycle)
-      : snap_shot_trigger(snap_shot_interval), m_name(name),
-        m_nthreads(nthreads), m_thread_pc(nthreads, start_pc), m_cycle(start_cycle),
-        m_thd_span(start_cycle, ctx)
-{
-   std::fill(m_thread_pc.begin(), m_thread_pc.end(), -1); // so that hw thread with no work assigned will not clobber results
+thread_CFlocality::thread_CFlocality(gpgpu_context *ctx, std::string name,
+                                     unsigned long long snap_shot_interval,
+                                     int nthreads, address_type start_pc,
+                                     unsigned long long start_cycle)
+    : snap_shot_trigger(snap_shot_interval),
+      m_name(name),
+      m_nthreads(nthreads),
+      m_thread_pc(nthreads, start_pc),
+      m_cycle(start_cycle),
+      m_thd_span(start_cycle, ctx) {
+  std::fill(
+      m_thread_pc.begin(), m_thread_pc.end(),
+      -1);  // so that hw thread with no work assigned will not clobber results
 }
-   
-thread_CFlocality::~thread_CFlocality() 
-{
-} 
-   
-void thread_CFlocality::update_thread_pc( int thread_id, address_type pc ) 
-{
-   m_thread_pc[thread_id] = pc;
-   m_thd_span.set_span(pc);
+
+thread_CFlocality::~thread_CFlocality() {}
+
+void thread_CFlocality::update_thread_pc(int thread_id, address_type pc) {
+  m_thread_pc[thread_id] = pc;
+  m_thd_span.set_span(pc);
 }
-   
-void thread_CFlocality::snap_shot(unsigned long long  current_cycle) 
-{
-   m_thd_span_archive.push_back(m_thd_span);
-   m_thd_span.reset(current_cycle);
-   for (int i = 0; i < (int)m_thread_pc.size(); i++) {
+
+void thread_CFlocality::snap_shot(unsigned long long current_cycle) {
+  m_thd_span_archive.push_back(m_thd_span);
+  m_thd_span.reset(current_cycle);
+  for (int i = 0; i < (int)m_thread_pc.size(); i++) {
+    m_thd_span.set_span(m_thread_pc[i]);
+  }
+}
+
+void thread_CFlocality::spill(FILE *fout, bool final) {
+  std::list<thread_insn_span>::iterator lit = m_thd_span_archive.begin();
+  for (; lit != m_thd_span_archive.end(); lit = m_thd_span_archive.erase(lit)) {
+    fprintf(fout, "%s-", m_name.c_str());
+    lit->print_histo(fout);
+  }
+  assert(m_thd_span_archive.empty());
+  if (final) {
+    fprintf(fout, "%s-", m_name.c_str());
+    m_thd_span.print_histo(fout);
+  }
+}
+
+void thread_CFlocality::print_visualizer(FILE *fout) {
+  fprintf(fout, "%s: ", m_name.c_str());
+  if (m_thd_span_archive.empty()) {
+    // visualizer do no require snap_shots
+    m_thd_span.print_sparse_histo(fout);
+
+    // clean the thread span
+    m_thd_span.reset(0);
+    for (int i = 0; i < (int)m_thread_pc.size(); i++)
       m_thd_span.set_span(m_thread_pc[i]);
-   }
-}
-   
-void thread_CFlocality::spill(FILE *fout, bool final) 
-{
-   std::list<thread_insn_span>::iterator lit = m_thd_span_archive.begin();
-   for (; lit != m_thd_span_archive.end(); lit = m_thd_span_archive.erase(lit) ) {
-      fprintf(fout, "%s-", m_name.c_str());
-      lit->print_histo(fout);
-   }
-   assert( m_thd_span_archive.empty() );
-   if (final) {
-      fprintf(fout, "%s-", m_name.c_str());
-      m_thd_span.print_histo(fout);
-   }
-}
-   
-      
-void thread_CFlocality::print_visualizer(FILE *fout)  
-{
-   fprintf(fout, "%s: ", m_name.c_str());
-   if (m_thd_span_archive.empty()) {
-   
-      // visualizer do no require snap_shots
-      m_thd_span.print_sparse_histo(fout);
-      
-      // clean the thread span
-      m_thd_span.reset(0);
-      for (int i = 0; i < (int)m_thread_pc.size(); i++) 
-         m_thd_span.set_span(m_thread_pc[i]);
-   } else { 
-      assert(0); // TODO: implement fall back so that visualizer can work with snap shots
-   }
-}
-   
-void thread_CFlocality::print_visualizer(gzFile fout)
-{
-   gzprintf(fout, "%s: ", m_name.c_str());
-   if (m_thd_span_archive.empty()) {
-   
-      // visualizer do no require snap_shots
-      m_thd_span.print_sparse_histo(fout);
-      
-      // clean the thread span
-      m_thd_span.reset(0);
-      for (int i = 0; i < (int)m_thread_pc.size(); i++) {
-         m_thd_span.set_span(m_thread_pc[i]);
-      }
-   } else { 
-      assert(0); // TODO: implement fall back so that visualizer can work with snap shots
-   }
-}
-   
-void thread_CFlocality::print_span(FILE *fout) const
-{
-   std::list<thread_insn_span>::const_iterator lit = m_thd_span_archive.begin();
-   for (; lit != m_thd_span_archive.end(); ++lit) {
-      fprintf(fout, "%s-", m_name.c_str());
-      lit->print_span(fout);
-   }
-   fprintf(fout, "%s-", m_name.c_str());
-   m_thd_span.print_span(fout);
+  } else {
+    assert(0);  // TODO: implement fall back so that visualizer can work with
+                // snap shots
+  }
 }
 
-void thread_CFlocality::print_histo(FILE *fout) const
-{
-   std::list<thread_insn_span>::const_iterator lit = m_thd_span_archive.begin();
-   for (; lit != m_thd_span_archive.end(); ++lit) {
-      fprintf(fout, "%s-", m_name.c_str());
-      lit->print_histo(fout);
-   }
-   fprintf(fout, "%s-", m_name.c_str());
-   m_thd_span.print_histo(fout);
+void thread_CFlocality::print_visualizer(gzFile fout) {
+  gzprintf(fout, "%s: ", m_name.c_str());
+  if (m_thd_span_archive.empty()) {
+    // visualizer do no require snap_shots
+    m_thd_span.print_sparse_histo(fout);
+
+    // clean the thread span
+    m_thd_span.reset(0);
+    for (int i = 0; i < (int)m_thread_pc.size(); i++) {
+      m_thd_span.set_span(m_thread_pc[i]);
+    }
+  } else {
+    assert(0);  // TODO: implement fall back so that visualizer can work with
+                // snap shots
+  }
+}
+
+void thread_CFlocality::print_span(FILE *fout) const {
+  std::list<thread_insn_span>::const_iterator lit = m_thd_span_archive.begin();
+  for (; lit != m_thd_span_archive.end(); ++lit) {
+    fprintf(fout, "%s-", m_name.c_str());
+    lit->print_span(fout);
+  }
+  fprintf(fout, "%s-", m_name.c_str());
+  m_thd_span.print_span(fout);
+}
+
+void thread_CFlocality::print_histo(FILE *fout) const {
+  std::list<thread_insn_span>::const_iterator lit = m_thd_span_archive.begin();
+  for (; lit != m_thd_span_archive.end(); ++lit) {
+    fprintf(fout, "%s-", m_name.c_str());
+    lit->print_histo(fout);
+  }
+  fprintf(fout, "%s-", m_name.c_str());
+  m_thd_span.print_histo(fout);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-linear_histogram_logger::linear_histogram_logger(int n_bins, 
-                           unsigned long long  snap_shot_interval, 
-                           const char *name, 
-                           bool reset_at_snap_shot, 
-                           unsigned long long  start_cycle )
-      : snap_shot_trigger(snap_shot_interval), 
-        m_n_bins(n_bins), 
-        m_curr_lin_hist(m_n_bins, start_cycle),
-        m_lin_hist_archive(),
-        m_cycle(start_cycle),
-        m_reset_at_snap_shot(reset_at_snap_shot), 
-        m_name(name),
-        m_id(s_ids++) 
-{
+linear_histogram_logger::linear_histogram_logger(
+    int n_bins, unsigned long long snap_shot_interval, const char *name,
+    bool reset_at_snap_shot, unsigned long long start_cycle)
+    : snap_shot_trigger(snap_shot_interval),
+      m_n_bins(n_bins),
+      m_curr_lin_hist(m_n_bins, start_cycle),
+      m_lin_hist_archive(),
+      m_cycle(start_cycle),
+      m_reset_at_snap_shot(reset_at_snap_shot),
+      m_name(name),
+      m_id(s_ids++) {}
+
+linear_histogram_logger::linear_histogram_logger(
+    const linear_histogram_logger &other)
+    : snap_shot_trigger(other.get_interval()),
+      m_n_bins(other.m_n_bins),
+      m_curr_lin_hist(m_n_bins, other.m_cycle),
+      m_lin_hist_archive(),
+      m_cycle(other.m_cycle),
+      m_reset_at_snap_shot(other.m_reset_at_snap_shot),
+      m_name(other.m_name),
+      m_id(s_ids++) {}
+
+linear_histogram_logger::~linear_histogram_logger() {
+  remove_snap_shot_trigger(this);
+  remove_spill_log(this);
 }
 
-linear_histogram_logger::linear_histogram_logger(const linear_histogram_logger& other) 
-      : snap_shot_trigger(other.get_interval()), 
-        m_n_bins(other.m_n_bins), 
-        m_curr_lin_hist(m_n_bins, other.m_cycle),
-        m_lin_hist_archive(),
-        m_cycle(other.m_cycle),
-        m_reset_at_snap_shot(other.m_reset_at_snap_shot), 
-        m_name(other.m_name),
-        m_id(s_ids++) 
-{
+void linear_histogram_logger::snap_shot(unsigned long long current_cycle) {
+  m_lin_hist_archive.push_back(m_curr_lin_hist);
+  if (m_reset_at_snap_shot) {
+    m_curr_lin_hist.reset(current_cycle);
+  } else {
+    m_curr_lin_hist.set_cycle(current_cycle);
+  }
 }
 
-linear_histogram_logger::~linear_histogram_logger() 
-{
-      remove_snap_shot_trigger(this);
-      remove_spill_log(this);
-}
-   
-void linear_histogram_logger::snap_shot(unsigned long long  current_cycle) {
-   m_lin_hist_archive.push_back(m_curr_lin_hist);
-   if (m_reset_at_snap_shot) {
-      m_curr_lin_hist.reset(current_cycle);
-   } else {
-      m_curr_lin_hist.set_cycle(current_cycle);
-   }
-}
-   
-void linear_histogram_logger::spill(FILE *fout, bool final) 
-{
-   std::list<linear_histogram_snapshot>::iterator iter = m_lin_hist_archive.begin();
-   for (; iter != m_lin_hist_archive.end(); iter = m_lin_hist_archive.erase(iter) ) {
-      fprintf(fout, "%s%02d-", m_name.c_str(), (m_id >= 0)? m_id : 0);
-      iter->print(fout);
-      fprintf(fout, "\n");
-   }
-   assert( m_lin_hist_archive.empty() );
-   if (final) {
-      fprintf(fout, "%s%02d-", m_name.c_str(), (m_id >= 0)? m_id : 0);
-      m_curr_lin_hist.print(fout);
-      fprintf(fout, "\n");
-   }
-}
-   
-void linear_histogram_logger::print(FILE *fout) const
-{
-   std::list<linear_histogram_snapshot>::const_iterator iter = m_lin_hist_archive.begin();
-   for (; iter != m_lin_hist_archive.end(); ++iter) {
-      fprintf(fout, "%s%02d-", m_name.c_str(), m_id);
-      iter->print(fout);
-      fprintf(fout, "\n");
-   }
-   fprintf(fout, "%s%02d-", m_name.c_str(), m_id);
-   m_curr_lin_hist.print(fout);
-   fprintf(fout, "\n");
+void linear_histogram_logger::spill(FILE *fout, bool final) {
+  std::list<linear_histogram_snapshot>::iterator iter =
+      m_lin_hist_archive.begin();
+  for (; iter != m_lin_hist_archive.end();
+       iter = m_lin_hist_archive.erase(iter)) {
+    fprintf(fout, "%s%02d-", m_name.c_str(), (m_id >= 0) ? m_id : 0);
+    iter->print(fout);
+    fprintf(fout, "\n");
+  }
+  assert(m_lin_hist_archive.empty());
+  if (final) {
+    fprintf(fout, "%s%02d-", m_name.c_str(), (m_id >= 0) ? m_id : 0);
+    m_curr_lin_hist.print(fout);
+    fprintf(fout, "\n");
+  }
 }
 
-void linear_histogram_logger::print_visualizer(FILE *fout)
-{
-   assert(m_lin_hist_archive.empty()); // don't support snapshot for now
-   fprintf(fout, "%s", m_name.c_str());
-   if (m_id >= 0) {
-      fprintf(fout, "%02d: ", m_id);
-   } else {
-      fprintf(fout, ": ");
-   }
-   m_curr_lin_hist.print_visualizer(fout);
-   fprintf(fout, "\n");
-   if (m_reset_at_snap_shot) {
-      m_curr_lin_hist.reset(0);
-   } 
+void linear_histogram_logger::print(FILE *fout) const {
+  std::list<linear_histogram_snapshot>::const_iterator iter =
+      m_lin_hist_archive.begin();
+  for (; iter != m_lin_hist_archive.end(); ++iter) {
+    fprintf(fout, "%s%02d-", m_name.c_str(), m_id);
+    iter->print(fout);
+    fprintf(fout, "\n");
+  }
+  fprintf(fout, "%s%02d-", m_name.c_str(), m_id);
+  m_curr_lin_hist.print(fout);
+  fprintf(fout, "\n");
 }
 
-void linear_histogram_logger::print_visualizer(gzFile fout)
-{
-   assert(m_lin_hist_archive.empty()); // don't support snapshot for now
-   gzprintf(fout, "%s", m_name.c_str());
-   if (m_id >= 0) {
-      gzprintf(fout, "%02d: ", m_id);
-   } else {
-      gzprintf(fout, ": ");
-   }
-   m_curr_lin_hist.print_visualizer(fout);
-   gzprintf(fout, "\n");
-   if (m_reset_at_snap_shot) {
-      m_curr_lin_hist.reset(0);
-   } 
+void linear_histogram_logger::print_visualizer(FILE *fout) {
+  assert(m_lin_hist_archive.empty());  // don't support snapshot for now
+  fprintf(fout, "%s", m_name.c_str());
+  if (m_id >= 0) {
+    fprintf(fout, "%02d: ", m_id);
+  } else {
+    fprintf(fout, ": ");
+  }
+  m_curr_lin_hist.print_visualizer(fout);
+  fprintf(fout, "\n");
+  if (m_reset_at_snap_shot) {
+    m_curr_lin_hist.reset(0);
+  }
 }
 
+void linear_histogram_logger::print_visualizer(gzFile fout) {
+  assert(m_lin_hist_archive.empty());  // don't support snapshot for now
+  gzprintf(fout, "%s", m_name.c_str());
+  if (m_id >= 0) {
+    gzprintf(fout, "%02d: ", m_id);
+  } else {
+    gzprintf(fout, ": ");
+  }
+  m_curr_lin_hist.print_visualizer(fout);
+  gzprintf(fout, "\n");
+  if (m_reset_at_snap_shot) {
+    m_curr_lin_hist.reset(0);
+  }
+}

--- a/src/gpgpu-sim/stat-tool.cc
+++ b/src/gpgpu-sim/stat-tool.cc
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -29,159 +27,160 @@
 
 #include "stat-tool.h"
 
-#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <assert.h>
 #include <zlib.h>
-#include <algorithm>
+#include <string>
 #include <list>
-#include <map>
-#include <string>
-#include <string>
 #include <vector>
+#include <map>
+#include <algorithm>
+#include <string>
 #include "../../libcuda/gpgpu_context.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 
-static unsigned long long min_snap_shot_interval = 0;
-static unsigned long long next_snap_shot_cycle = 0;
-static std::list<snap_shot_trigger *> list_ss_trigger;
+static unsigned long long  min_snap_shot_interval = 0;
+static unsigned long long  next_snap_shot_cycle = 0;
+static std::list<snap_shot_trigger*> list_ss_trigger;
 
-void add_snap_shot_trigger(snap_shot_trigger *ss_trigger) {
-  // quick optimization assuming that all snap shot intervals are perfect
-  // multiples of each other
-  if (min_snap_shot_interval == 0 ||
-      min_snap_shot_interval > ss_trigger->get_interval()) {
-    min_snap_shot_interval = ss_trigger->get_interval();
-    next_snap_shot_cycle =
-        min_snap_shot_interval;  // assume that snap shots haven't started yet
-  }
-  list_ss_trigger.push_back(ss_trigger);
+void add_snap_shot_trigger (snap_shot_trigger* ss_trigger)
+{
+   // quick optimization assuming that all snap shot intervals are perfect multiples of each other
+   if (min_snap_shot_interval == 0 || min_snap_shot_interval > ss_trigger->get_interval()) {
+      min_snap_shot_interval = ss_trigger->get_interval();
+      next_snap_shot_cycle = min_snap_shot_interval; // assume that snap shots haven't started yet
+   }
+   list_ss_trigger.push_back(ss_trigger);
 }
 
-void remove_snap_shot_trigger(snap_shot_trigger *ss_trigger) {
-  list_ss_trigger.remove(ss_trigger);
+void remove_snap_shot_trigger (snap_shot_trigger* ss_trigger)
+{
+   list_ss_trigger.remove(ss_trigger);
 }
 
-void try_snap_shot(unsigned long long current_cycle) {
-  if (min_snap_shot_interval == 0) return;
-  if (current_cycle != next_snap_shot_cycle) return;
-
-  std::list<snap_shot_trigger *>::iterator ss_trigger_iter =
-      list_ss_trigger.begin();
-  for (; ss_trigger_iter != list_ss_trigger.end(); ++ss_trigger_iter) {
-    (*ss_trigger_iter)
-        ->snap_shot(current_cycle);  // WF: should be try_snap_shot
-  }
-  next_snap_shot_cycle =
-      current_cycle +
-      min_snap_shot_interval;  // WF: stateful testing, maybe bad
+void try_snap_shot (unsigned long long  current_cycle)
+{
+   if (min_snap_shot_interval == 0) return;
+   if (current_cycle != next_snap_shot_cycle) return;
+   
+   std::list<snap_shot_trigger*>::iterator ss_trigger_iter = list_ss_trigger.begin();
+   for(; ss_trigger_iter != list_ss_trigger.end(); ++ss_trigger_iter) {
+      (*ss_trigger_iter)->snap_shot(current_cycle); // WF: should be try_snap_shot
+   }
+   next_snap_shot_cycle = current_cycle + min_snap_shot_interval; // WF: stateful testing, maybe bad
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+ 
+static unsigned long long  spill_interval = 0;
+static unsigned long long  next_spill_cycle = 0;
+static std::list<spill_log_interface*> list_spill_log;
 
-static unsigned long long spill_interval = 0;
-static unsigned long long next_spill_cycle = 0;
-static std::list<spill_log_interface *> list_spill_log;
-
-void add_spill_log(spill_log_interface *spill_log) {
-  list_spill_log.push_back(spill_log);
+void add_spill_log (spill_log_interface* spill_log)
+{
+   list_spill_log.push_back(spill_log);
 }
 
-void remove_spill_log(spill_log_interface *spill_log) {
-  list_spill_log.remove(spill_log);
+void remove_spill_log (spill_log_interface* spill_log)
+{
+   list_spill_log.remove(spill_log);
 }
 
-void set_spill_interval(unsigned long long interval) {
-  spill_interval = interval;
-  next_spill_cycle = spill_interval;
+void set_spill_interval (unsigned long long  interval)
+{
+   spill_interval = interval;
+   next_spill_cycle = spill_interval;
 }
 
-void spill_log_to_file(FILE *fout, int final,
-                       unsigned long long current_cycle) {
-  if (!final && spill_interval == 0) return;
-  if (!final && current_cycle <= next_spill_cycle) return;
+void spill_log_to_file (FILE *fout, int final, unsigned long long  current_cycle)
+{
+   if (!final && spill_interval == 0) return;
+   if (!final && current_cycle <= next_spill_cycle) return;
 
-  fprintf(fout, "\n");  // ensure that the spill occurs at a new line
-  std::list<spill_log_interface *>::iterator i_spill_log =
-      list_spill_log.begin();
-  for (; i_spill_log != list_spill_log.end(); ++i_spill_log) {
-    (*i_spill_log)->spill(fout, final);
-  }
-  fflush(fout);
+   fprintf(fout, "\n"); // ensure that the spill occurs at a new line
+   std::list<spill_log_interface*>::iterator i_spill_log = list_spill_log.begin();
+   for(; i_spill_log != list_spill_log.end(); ++i_spill_log) {
+      (*i_spill_log)->spill(fout, final); 
+   }
+   fflush(fout);
 
-  next_spill_cycle =
-      current_cycle + spill_interval;  // WF: stateful testing, maybe bad
+   next_spill_cycle = current_cycle + spill_interval; // WF: stateful testing, maybe bad
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 static int n_thread_CFloggers = 0;
-static thread_CFlocality **thread_CFlogger = NULL;
+static thread_CFlocality** thread_CFlogger = NULL;
 
-void create_thread_CFlogger(gpgpu_context *ctx, int n_loggers, int n_threads,
-                            address_type start_pc,
-                            unsigned long long logging_interval) {
-  destroy_thread_CFlogger();
+void create_thread_CFlogger(gpgpu_context* ctx, int n_loggers, int n_threads, address_type start_pc, unsigned long long  logging_interval) 
+{
+   destroy_thread_CFlogger();
+   
+   n_thread_CFloggers = n_loggers;
+   thread_CFlogger = new thread_CFlocality*[n_loggers];
 
-  n_thread_CFloggers = n_loggers;
-  thread_CFlogger = new thread_CFlocality *[n_loggers];
-
-  std::string name_tpl("CFLog");
-  char buffer[32];
-  for (int i = 0; i < n_thread_CFloggers; i++) {
-    snprintf(buffer, 32, "%02d", i);
-    thread_CFlogger[i] = new thread_CFlocality(
-        ctx, name_tpl + buffer, logging_interval, n_threads, start_pc);
-    if (logging_interval != 0) {
-      add_snap_shot_trigger(thread_CFlogger[i]);
-      add_spill_log(thread_CFlogger[i]);
-    }
-  }
+   std::string name_tpl("CFLog");
+   char buffer[32];
+   for (int i = 0; i < n_thread_CFloggers; i++) {
+      snprintf(buffer, 32, "%02d", i);
+      thread_CFlogger[i] = new thread_CFlocality( ctx, name_tpl + buffer, logging_interval, n_threads, start_pc);
+      if (logging_interval != 0) {
+         add_snap_shot_trigger(thread_CFlogger[i]);
+         add_spill_log(thread_CFlogger[i]);
+      }
+   }
 }
 
-void destroy_thread_CFlogger() {
-  if (thread_CFlogger != NULL) {
-    for (int i = 0; i < n_thread_CFloggers; i++) {
-      remove_snap_shot_trigger(thread_CFlogger[i]);
-      remove_spill_log(thread_CFlogger[i]);
-      delete thread_CFlogger[i];
-    }
-    delete[] thread_CFlogger;
-    thread_CFlogger = NULL;
-  }
+void destroy_thread_CFlogger( ) 
+{
+   if (thread_CFlogger != NULL) {
+      for (int i = 0; i < n_thread_CFloggers; i++) {
+         remove_snap_shot_trigger(thread_CFlogger[i]);
+         remove_spill_log(thread_CFlogger[i]);
+         delete thread_CFlogger[i];
+      }
+      delete [] thread_CFlogger;
+      thread_CFlogger = NULL;
+   }
 }
 
-void cflog_update_thread_pc(int logger_id, int thread_id, address_type pc) {
-  if (thread_CFlogger == NULL) return;  // this means no visualizer output
-  if (thread_id < 0) return;
-  thread_CFlogger[logger_id]->update_thread_pc(thread_id, pc);
+void cflog_update_thread_pc( int logger_id, int thread_id, address_type pc ) 
+{
+   if (thread_CFlogger == NULL) return;  // this means no visualizer output 
+   if (thread_id < 0) return;
+   thread_CFlogger[logger_id]->update_thread_pc(thread_id, pc);
 }
 
-// deprecated
-void cflog_snapshot(int logger_id, unsigned long long cycle) {
-  thread_CFlogger[logger_id]->snap_shot(cycle);
+// deprecated 
+void cflog_snapshot( int logger_id, unsigned long long  cycle ) 
+{
+   thread_CFlogger[logger_id]->snap_shot(cycle);
 }
 
-void cflog_print(FILE *fout) {
-  if (thread_CFlogger == NULL) return;  // this means no visualizer output
-  for (int i = 0; i < n_thread_CFloggers; i++) {
-    thread_CFlogger[i]->print_histo(fout);
-  }
+void cflog_print(FILE *fout) 
+{
+   if (thread_CFlogger == NULL) return;  // this means no visualizer output 
+   for (int i = 0; i < n_thread_CFloggers; i++) {
+      thread_CFlogger[i]->print_histo(fout);
+   }
 }
 
-void cflog_visualizer_print(FILE *fout) {
-  if (thread_CFlogger == NULL) return;  // this means no visualizer output
-  for (int i = 0; i < n_thread_CFloggers; i++) {
-    thread_CFlogger[i]->print_visualizer(fout);
-  }
+void cflog_visualizer_print(FILE *fout) 
+{
+   if (thread_CFlogger == NULL) return;  // this means no visualizer output 
+   for (int i = 0; i < n_thread_CFloggers; i++) {
+      thread_CFlogger[i]->print_visualizer(fout);
+   }
 }
 
-void cflog_visualizer_gzprint(gzFile fout) {
-  if (thread_CFlogger == NULL) return;  // this means no visualizer output
-  for (int i = 0; i < n_thread_CFloggers; i++) {
-    thread_CFlogger[i]->print_visualizer(fout);
-  }
+void cflog_visualizer_gzprint(gzFile fout) 
+{
+   if (thread_CFlogger == NULL) return;  // this means no visualizer output 
+   for (int i = 0; i < n_thread_CFloggers; i++) {
+      thread_CFlogger[i]->print_visualizer(fout);
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -190,23 +189,26 @@ int insn_warp_occ_logger::s_ids = 0;
 
 static std::vector<insn_warp_occ_logger> iwo_logger;
 
-void insn_warp_occ_create(int n_loggers, int simd_width) {
-  iwo_logger.clear();
-  iwo_logger.assign(n_loggers, insn_warp_occ_logger(simd_width));
-  for (unsigned i = 0; i < iwo_logger.size(); i++) {
-    iwo_logger[i].set_id(i);
-  }
+void insn_warp_occ_create( int n_loggers, int simd_width )
+{
+   iwo_logger.clear();
+   iwo_logger.assign(n_loggers, insn_warp_occ_logger(simd_width));
+   for (unsigned i = 0; i < iwo_logger.size(); i++) {
+      iwo_logger[i].set_id(i);
+   }
 }
 
-void insn_warp_occ_log(int logger_id, address_type pc, int warp_occ) {
-  if (warp_occ <= 0) return;
-  iwo_logger[logger_id].log(pc, warp_occ);
+void insn_warp_occ_log( int logger_id, address_type pc, int warp_occ)
+{
+   if (warp_occ <= 0) return;
+   iwo_logger[logger_id].log(pc, warp_occ);
 }
 
-void insn_warp_occ_print(FILE *fout) {
-  for (unsigned i = 0; i < iwo_logger.size(); i++) {
-    iwo_logger[i].print(fout);
-  }
+void insn_warp_occ_print( FILE *fout )
+{
+   for (unsigned i = 0; i < iwo_logger.size(); i++) {
+      iwo_logger[i].print(fout);
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -219,32 +221,35 @@ int linear_histogram_logger::s_ids = 0;
 
 static std::vector<linear_histogram_logger> s_warp_occ_logger;
 
-void shader_warp_occ_create(int n_loggers, int simd_width,
-                            unsigned long long logging_interval) {
-  // simd_width + 1 to include the case with full warp
-  s_warp_occ_logger.assign(
-      n_loggers,
-      linear_histogram_logger(simd_width + 1, logging_interval, "ShdrWarpOcc"));
-  for (unsigned i = 0; i < s_warp_occ_logger.size(); i++) {
-    s_warp_occ_logger[i].set_id(i);
-    add_snap_shot_trigger(&(s_warp_occ_logger[i]));
-    add_spill_log(&(s_warp_occ_logger[i]));
-  }
+void shader_warp_occ_create( int n_loggers, int simd_width, unsigned long long  logging_interval)
+{
+   // simd_width + 1 to include the case with full warp
+   s_warp_occ_logger.assign(n_loggers, 
+                            linear_histogram_logger(simd_width + 1, logging_interval, "ShdrWarpOcc"));
+   for (unsigned i = 0; i < s_warp_occ_logger.size(); i++) {
+      s_warp_occ_logger[i].set_id(i);
+      add_snap_shot_trigger(&(s_warp_occ_logger[i]));
+      add_spill_log(&(s_warp_occ_logger[i]));
+   }
 }
 
-void shader_warp_occ_log(int logger_id, int warp_occ) {
-  s_warp_occ_logger[logger_id].log(warp_occ);
+void shader_warp_occ_log( int logger_id, int warp_occ)
+{
+   s_warp_occ_logger[logger_id].log(warp_occ);
 }
 
-void shader_warp_occ_snapshot(int logger_id, unsigned long long current_cycle) {
-  s_warp_occ_logger[logger_id].snap_shot(current_cycle);
+void shader_warp_occ_snapshot( int logger_id, unsigned long long  current_cycle)
+{
+   s_warp_occ_logger[logger_id].snap_shot(current_cycle);
 }
 
-void shader_warp_occ_print(FILE *fout) {
-  for (unsigned i = 0; i < s_warp_occ_logger.size(); i++) {
-    s_warp_occ_logger[i].print(fout);
-  }
+void shader_warp_occ_print( FILE *fout )
+{
+   for (unsigned i = 0; i < s_warp_occ_logger.size(); i++) {
+      s_warp_occ_logger[i].print(fout);
+   }
 }
+
 
 /////////////////////////////////////////////////////////////////////////////////////
 // per-shadercore memory-access logger
@@ -254,115 +259,105 @@ static int s_mem_acc_logger_n_dram = 0;
 static int s_mem_acc_logger_n_bank = 0;
 static std::vector<linear_histogram_logger> s_mem_acc_logger;
 
-void shader_mem_acc_create(int n_loggers, int n_dram, int n_bank,
-                           unsigned long long logging_interval) {
-  // (n_bank + 1) to space data out; 2x to separate read and write
-  s_mem_acc_logger.assign(
-      n_loggers, linear_histogram_logger(2 * n_dram * (n_bank + 1),
-                                         logging_interval, "ShdrMemAcc"));
+void shader_mem_acc_create( int n_loggers, int n_dram, int n_bank, unsigned long long  logging_interval)
+{
+   // (n_bank + 1) to space data out; 2x to separate read and write
+   s_mem_acc_logger.assign(n_loggers, 
+                           linear_histogram_logger(2 * n_dram * (n_bank + 1), logging_interval, "ShdrMemAcc"));
 
-  s_mem_acc_logger_n_dram = n_dram;
-  s_mem_acc_logger_n_bank = n_bank;
-  for (unsigned i = 0; i < s_mem_acc_logger.size(); i++) {
-    s_mem_acc_logger[i].set_id(i);
-    add_snap_shot_trigger(&(s_mem_acc_logger[i]));
-    add_spill_log(&(s_mem_acc_logger[i]));
-  }
+   s_mem_acc_logger_n_dram = n_dram;
+   s_mem_acc_logger_n_bank = n_bank;
+   for (unsigned i = 0; i < s_mem_acc_logger.size(); i++) {
+      s_mem_acc_logger[i].set_id(i);
+      add_snap_shot_trigger(&(s_mem_acc_logger[i]));
+      add_spill_log(&(s_mem_acc_logger[i]));
+   }
 }
 
-void shader_mem_acc_log(int logger_id, int dram_id, int bank, char rw) {
-  if (s_mem_acc_logger_n_dram == 0) return;
-  int write_offset = 0;
-  switch (rw) {
-    case 'r':
-      write_offset = 0;
-      break;
-    case 'w':
-      write_offset = (s_mem_acc_logger_n_bank + 1) * s_mem_acc_logger_n_dram;
-      break;
-    default:
-      assert(0);
-      break;
-  }
-  s_mem_acc_logger[logger_id].log(dram_id * s_mem_acc_logger_n_bank + bank +
-                                  write_offset);
+void shader_mem_acc_log( int logger_id, int dram_id, int bank, char rw)
+{
+   if (s_mem_acc_logger_n_dram == 0) return;
+   int write_offset = 0;
+   switch(rw) {
+   case 'r': write_offset = 0; break;
+   case 'w': write_offset = (s_mem_acc_logger_n_bank + 1) * s_mem_acc_logger_n_dram; break;
+   default: assert(0); break;
+   }
+   s_mem_acc_logger[logger_id].log(dram_id * s_mem_acc_logger_n_bank + bank + write_offset);
 }
 
-void shader_mem_acc_snapshot(int logger_id, unsigned long long current_cycle) {
-  s_mem_acc_logger[logger_id].snap_shot(current_cycle);
+void shader_mem_acc_snapshot( int logger_id, unsigned long long  current_cycle)
+{
+   s_mem_acc_logger[logger_id].snap_shot(current_cycle);
 }
 
-void shader_mem_acc_print(FILE *fout) {
-  for (unsigned i = 0; i < s_mem_acc_logger.size(); i++) {
-    s_mem_acc_logger[i].print(fout);
-  }
+void shader_mem_acc_print( FILE *fout )
+{
+   for (unsigned i = 0; i < s_mem_acc_logger.size(); i++) {
+      s_mem_acc_logger[i].print(fout);
+   }
 }
+
 
 /////////////////////////////////////////////////////////////////////////////////////
 // per-shadercore memory-latency logger
 /////////////////////////////////////////////////////////////////////////////////////
 
 static bool s_mem_lat_logger_used = false;
-static int s_mem_lat_logger_nbins = 48;  // up to 2^24 = 16M
+static int s_mem_lat_logger_nbins = 48;     // up to 2^24 = 16M
 static std::vector<linear_histogram_logger> s_mem_lat_logger;
 
-void shader_mem_lat_create(int n_loggers, unsigned long long logging_interval) {
-  s_mem_lat_logger.assign(
-      n_loggers, linear_histogram_logger(s_mem_lat_logger_nbins,
-                                         logging_interval, "ShdrMemLat"));
+void shader_mem_lat_create( int n_loggers, unsigned long long  logging_interval)
+{
+   s_mem_lat_logger.assign(n_loggers, 
+                           linear_histogram_logger(s_mem_lat_logger_nbins, logging_interval, "ShdrMemLat"));
 
-  for (unsigned i = 0; i < s_mem_lat_logger.size(); i++) {
-    s_mem_lat_logger[i].set_id(i);
-    add_snap_shot_trigger(&(s_mem_lat_logger[i]));
-    add_spill_log(&(s_mem_lat_logger[i]));
-  }
-
-  s_mem_lat_logger_used = true;
+   for (unsigned i = 0; i < s_mem_lat_logger.size(); i++) {
+      s_mem_lat_logger[i].set_id(i);
+      add_snap_shot_trigger(&(s_mem_lat_logger[i]));
+      add_spill_log(&(s_mem_lat_logger[i]));
+   }
+   
+   s_mem_lat_logger_used = true;
 }
 
-void shader_mem_lat_log(int logger_id, int latency) {
-  if (s_mem_lat_logger_used == false) return;
-  if (latency > (1 << (s_mem_lat_logger_nbins / 2)))
-    assert(0);  // guard for out of bound bin
-  assert(latency > 0);
+void shader_mem_lat_log( int logger_id, int latency)
+{
+   if (s_mem_lat_logger_used == false) return;
+   if (latency > (1<<(s_mem_lat_logger_nbins/2))) assert(0); // guard for out of bound bin
+   assert(latency > 0);
+   
+   int latency_bin;
+   
+   int bin; // LOG_2(latency)
+   int v = latency;
+   register unsigned int shift;
 
-  int latency_bin;
+   bin =   (v > 0xFFFF) << 4; v >>= bin;
+   shift = (v > 0xFF  ) << 3; v >>= shift; bin |= shift;
+   shift = (v > 0xF   ) << 2; v >>= shift; bin |= shift;
+   shift = (v > 0x3   ) << 1; v >>= shift; bin |= shift;
+                                           bin |= (v >> 1);
+   latency_bin = 2 * bin;
+   if (bin > 0) {
+      latency_bin += ((latency & (1 << (bin - 1))) != 0)? 1 : 0; // approx. for LOG_sqrt2(latency)
+   }
 
-  int bin;  // LOG_2(latency)
-  int v = latency;
-  register unsigned int shift;
-
-  bin = (v > 0xFFFF) << 4;
-  v >>= bin;
-  shift = (v > 0xFF) << 3;
-  v >>= shift;
-  bin |= shift;
-  shift = (v > 0xF) << 2;
-  v >>= shift;
-  bin |= shift;
-  shift = (v > 0x3) << 1;
-  v >>= shift;
-  bin |= shift;
-  bin |= (v >> 1);
-  latency_bin = 2 * bin;
-  if (bin > 0) {
-    latency_bin += ((latency & (1 << (bin - 1))) != 0)
-                       ? 1
-                       : 0;  // approx. for LOG_sqrt2(latency)
-  }
-
-  s_mem_lat_logger[logger_id].log(latency_bin);
+   s_mem_lat_logger[logger_id].log(latency_bin);
 }
 
-void shader_mem_lat_snapshot(int logger_id, unsigned long long current_cycle) {
-  s_mem_lat_logger[logger_id].snap_shot(current_cycle);
+void shader_mem_lat_snapshot( int logger_id, unsigned long long  current_cycle)
+{
+   s_mem_lat_logger[logger_id].snap_shot(current_cycle);
 }
 
-void shader_mem_lat_print(FILE *fout) {
-  for (unsigned i = 0; i < s_mem_lat_logger.size(); i++) {
-    s_mem_lat_logger[i].print(fout);
-  }
+void shader_mem_lat_print( FILE *fout )
+{
+   for (unsigned i = 0; i < s_mem_lat_logger.size(); i++) {
+      s_mem_lat_logger[i].print(fout);
+   }
 }
+
 
 /////////////////////////////////////////////////////////////////////////////////////
 // per-shadercore cache-miss logger
@@ -371,393 +366,425 @@ void shader_mem_lat_print(FILE *fout) {
 static int s_cache_access_logger_n_types = 0;
 static std::vector<linear_histogram_logger> s_cache_access_logger;
 
-enum cache_access_logger_types { NORMALS, TEXTURE, CONSTANT, INSTRUCTION };
+enum cache_access_logger_types {
+   NORMALS, TEXTURE, CONSTANT, INSTRUCTION
+};
 
 int get_shader_normal_cache_id() { return NORMALS; }
 int get_shader_texture_cache_id() { return TEXTURE; }
 int get_shader_constant_cache_id() { return CONSTANT; }
 int get_shader_instruction_cache_id() { return INSTRUCTION; }
 
-void shader_cache_access_create(int n_loggers, int n_types,
-                                unsigned long long logging_interval) {
-  // There are different type of cache (x2 for recording accesses and misses)
-  s_cache_access_logger.assign(
-      n_loggers,
-      linear_histogram_logger(n_types * 2, logging_interval, "ShdrCacheMiss"));
+void shader_cache_access_create( int n_loggers, int n_types, unsigned long long  logging_interval)
+{
+   // There are different type of cache (x2 for recording accesses and misses)
+   s_cache_access_logger.assign(n_loggers, 
+                                linear_histogram_logger(n_types * 2, logging_interval, "ShdrCacheMiss"));
 
-  s_cache_access_logger_n_types = n_types;
-  for (unsigned i = 0; i < s_cache_access_logger.size(); i++) {
-    s_cache_access_logger[i].set_id(i);
-    add_snap_shot_trigger(&(s_cache_access_logger[i]));
-    add_spill_log(&(s_cache_access_logger[i]));
-  }
+   s_cache_access_logger_n_types = n_types;
+   for (unsigned i = 0; i < s_cache_access_logger.size(); i++) {
+      s_cache_access_logger[i].set_id(i);
+      add_snap_shot_trigger(&(s_cache_access_logger[i]));
+      add_spill_log(&(s_cache_access_logger[i]));
+   }
 }
 
-void shader_cache_access_log(int logger_id, int type, int miss) {
-  if (s_cache_access_logger_n_types == 0) return;
-  if (logger_id < 0) return;
-  assert(type == NORMALS || type == TEXTURE || type == CONSTANT ||
-         type == INSTRUCTION);
-  assert(miss == 0 || miss == 1);
-
-  s_cache_access_logger[logger_id].log(2 * type + miss);
+void shader_cache_access_log( int logger_id, int type, int miss)
+{
+   if (s_cache_access_logger_n_types == 0) return;
+   if (logger_id < 0) return;
+   assert(type == NORMALS || type == TEXTURE || type == CONSTANT || type == INSTRUCTION);
+   assert(miss == 0 || miss == 1);
+   
+   s_cache_access_logger[logger_id].log(2 * type + miss);
 }
 
-void shader_cache_access_unlog(int logger_id, int type, int miss) {
-  if (s_cache_access_logger_n_types == 0) return;
-  if (logger_id < 0) return;
-  assert(type == NORMALS || type == TEXTURE || type == CONSTANT ||
-         type == INSTRUCTION);
-  assert(miss == 0 || miss == 1);
-
-  s_cache_access_logger[logger_id].unlog(2 * type + miss);
+void shader_cache_access_unlog( int logger_id, int type, int miss)
+{
+   if (s_cache_access_logger_n_types == 0) return;
+   if (logger_id < 0) return;
+   assert(type == NORMALS || type == TEXTURE || type == CONSTANT || type == INSTRUCTION);
+   assert(miss == 0 || miss == 1);
+   
+   s_cache_access_logger[logger_id].unlog(2 * type + miss);
 }
 
-void shader_cache_access_print(FILE *fout) {
-  for (unsigned i = 0; i < s_cache_access_logger.size(); i++) {
-    s_cache_access_logger[i].print(fout);
-  }
+void shader_cache_access_print( FILE *fout )
+{
+   for (unsigned i = 0; i < s_cache_access_logger.size(); i++) {
+      s_cache_access_logger[i].print(fout);
+   }
 }
+
 
 /////////////////////////////////////////////////////////////////////////////////////
-// per-shadercore CTA count logger (only make sense with
-// gpgpu_spread_blocks_across_cores)
+// per-shadercore CTA count logger (only make sense with gpgpu_spread_blocks_across_cores)
 /////////////////////////////////////////////////////////////////////////////////////
 
 static linear_histogram_logger *s_CTA_count_logger = NULL;
 
-void shader_CTA_count_create(int n_shaders,
-                             unsigned long long logging_interval) {
-  // only need one logger to track all the shaders
-  if (s_CTA_count_logger != NULL) delete s_CTA_count_logger;
-  s_CTA_count_logger = new linear_histogram_logger(n_shaders, logging_interval,
-                                                   "ShdrCTACount", false);
+void shader_CTA_count_create( int n_shaders, unsigned long long  logging_interval)
+{
+   // only need one logger to track all the shaders
+   if (s_CTA_count_logger != NULL) delete s_CTA_count_logger;
+   s_CTA_count_logger = new linear_histogram_logger(n_shaders, logging_interval, "ShdrCTACount", false);
 
-  s_CTA_count_logger->set_id(-1);
-  if (logging_interval != 0) {
-    add_snap_shot_trigger(s_CTA_count_logger);
-    add_spill_log(s_CTA_count_logger);
-  }
+   s_CTA_count_logger->set_id(-1);
+   if (logging_interval != 0) {
+      add_snap_shot_trigger(s_CTA_count_logger);
+      add_spill_log(s_CTA_count_logger);
+   }
 }
 
-void shader_CTA_count_log(int shader_id, int nCTAadded) {
-  if (s_CTA_count_logger == NULL) return;
-
-  for (int i = 0; i < nCTAadded; i++) {
-    s_CTA_count_logger->log(shader_id);
-  }
+void shader_CTA_count_log( int shader_id, int nCTAadded )
+{
+   if (s_CTA_count_logger == NULL) return;
+   
+   for (int i = 0; i < nCTAadded; i++) {
+      s_CTA_count_logger->log(shader_id);
+   }
 }
 
-void shader_CTA_count_unlog(int shader_id, int nCTAdone) {
-  if (s_CTA_count_logger == NULL) return;
-
-  for (int i = 0; i < nCTAdone; i++) {
-    s_CTA_count_logger->unlog(shader_id);
-  }
+void shader_CTA_count_unlog( int shader_id, int nCTAdone )
+{
+   if (s_CTA_count_logger == NULL) return;
+   
+   for (int i = 0; i < nCTAdone; i++) {
+      s_CTA_count_logger->unlog(shader_id);
+   }
 }
 
-void shader_CTA_count_print(FILE *fout) {
-  if (s_CTA_count_logger == NULL) return;
-  s_CTA_count_logger->print(fout);
+void shader_CTA_count_print( FILE *fout )
+{
+   if (s_CTA_count_logger == NULL) return;
+   s_CTA_count_logger->print(fout);
 }
 
-void shader_CTA_count_visualizer_print(FILE *fout) {
-  if (s_CTA_count_logger == NULL) return;
-  s_CTA_count_logger->print_visualizer(fout);
+void shader_CTA_count_visualizer_print( FILE *fout )
+{
+   if (s_CTA_count_logger == NULL) return;
+   s_CTA_count_logger->print_visualizer(fout);
 }
 
-void shader_CTA_count_visualizer_gzprint(gzFile fout) {
-  if (s_CTA_count_logger == NULL) return;
-  s_CTA_count_logger->print_visualizer(fout);
+void shader_CTA_count_visualizer_gzprint( gzFile fout )
+{
+   if (s_CTA_count_logger == NULL) return;
+   s_CTA_count_logger->print_visualizer(fout);
 }
+
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-thread_insn_span::thread_insn_span(unsigned long long cycle, gpgpu_context *ctx)
-    : m_cycle(cycle),
+thread_insn_span::thread_insn_span(unsigned long long  cycle, gpgpu_context* ctx)
+  : m_cycle(cycle),
 #if (tr1_hash_map_ismap == 1)
-      m_insn_span_count()
-#else
-      m_insn_span_count(32 * 1024)
+     m_insn_span_count() 
+#else 
+     m_insn_span_count(32*1024) 
 #endif
 {
-  gpgpu_ctx = ctx;
+    gpgpu_ctx = ctx;
 }
 
-thread_insn_span::~thread_insn_span() {}
-
-thread_insn_span::thread_insn_span(const thread_insn_span &other,
-                                   gpgpu_context *ctx)
-    : m_cycle(other.m_cycle), m_insn_span_count(other.m_insn_span_count) {
-  gpgpu_ctx = ctx;
+thread_insn_span::~thread_insn_span() { }
+   
+thread_insn_span::thread_insn_span(const thread_insn_span& other, gpgpu_context* ctx)
+      : m_cycle(other.m_cycle),
+        m_insn_span_count(other.m_insn_span_count)
+{ 
+    gpgpu_ctx = ctx;
+}
+      
+thread_insn_span& thread_insn_span::operator=(const thread_insn_span& other)
+{
+   printf("thread_insn_span& operator=\n");
+   if (this != &other) {
+      m_insn_span_count = other.m_insn_span_count;
+      m_cycle = other.m_cycle;
+   }
+   return *this;
+}
+   
+thread_insn_span& thread_insn_span::operator+=(const thread_insn_span& other)
+{
+   span_count_map::const_iterator i_sc = other.m_insn_span_count.begin();
+   for (; i_sc != other.m_insn_span_count.end(); ++i_sc) {
+      m_insn_span_count[i_sc->first] += i_sc->second;
+   }
+   return *this;
+}
+   
+void thread_insn_span::set_span( address_type pc ) 
+{
+   if( ((int)pc) >= 0 )
+      m_insn_span_count[pc] += 1;
+}
+   
+void thread_insn_span::reset(unsigned long long  cycle) 
+{
+   m_cycle = cycle;
+   m_insn_span_count.clear(); 
+}
+   
+void thread_insn_span::print_span(FILE *fout) const
+{
+   fprintf(fout, "%d: ", (int)m_cycle);
+   span_count_map::const_iterator i_sc = m_insn_span_count.begin();
+   for (; i_sc != m_insn_span_count.end(); ++i_sc) {
+      fprintf(fout, "%d ", i_sc->first);
+   }
+   fprintf(fout, "\n");
 }
 
-thread_insn_span &thread_insn_span::operator=(const thread_insn_span &other) {
-  printf("thread_insn_span& operator=\n");
-  if (this != &other) {
-    m_insn_span_count = other.m_insn_span_count;
-    m_cycle = other.m_cycle;
-  }
-  return *this;
+void thread_insn_span::print_histo(FILE *fout) const
+{
+   fprintf(fout, "%d:", (int)m_cycle);
+   span_count_map::const_iterator i_sc = m_insn_span_count.begin();
+   for (; i_sc != m_insn_span_count.end(); ++i_sc) {
+      fprintf(fout, "%d ", i_sc->second);
+   }
+   fprintf(fout, "\n");
 }
 
-thread_insn_span &thread_insn_span::operator+=(const thread_insn_span &other) {
-  span_count_map::const_iterator i_sc = other.m_insn_span_count.begin();
-  for (; i_sc != other.m_insn_span_count.end(); ++i_sc) {
-    m_insn_span_count[i_sc->first] += i_sc->second;
-  }
-  return *this;
+void thread_insn_span::print_sparse_histo(FILE *fout) const
+{
+   int n_printed_entries = 0;
+   span_count_map::const_iterator i_sc = m_insn_span_count.begin();
+   for (; i_sc != m_insn_span_count.end(); ++i_sc) {
+      unsigned ptx_lineno = gpgpu_ctx->translate_pc_to_ptxlineno(i_sc->first);
+      fprintf(fout, "%u %d ", ptx_lineno, i_sc->second);
+      n_printed_entries++;
+   }
+   if (n_printed_entries == 0) {
+      fprintf(fout, "0 0 ");
+   }
+   fprintf(fout, "\n");
 }
 
-void thread_insn_span::set_span(address_type pc) {
-  if (((int)pc) >= 0) m_insn_span_count[pc] += 1;
-}
-
-void thread_insn_span::reset(unsigned long long cycle) {
-  m_cycle = cycle;
-  m_insn_span_count.clear();
-}
-
-void thread_insn_span::print_span(FILE *fout) const {
-  fprintf(fout, "%d: ", (int)m_cycle);
-  span_count_map::const_iterator i_sc = m_insn_span_count.begin();
-  for (; i_sc != m_insn_span_count.end(); ++i_sc) {
-    fprintf(fout, "%d ", i_sc->first);
-  }
-  fprintf(fout, "\n");
-}
-
-void thread_insn_span::print_histo(FILE *fout) const {
-  fprintf(fout, "%d:", (int)m_cycle);
-  span_count_map::const_iterator i_sc = m_insn_span_count.begin();
-  for (; i_sc != m_insn_span_count.end(); ++i_sc) {
-    fprintf(fout, "%d ", i_sc->second);
-  }
-  fprintf(fout, "\n");
-}
-
-void thread_insn_span::print_sparse_histo(FILE *fout) const {
-  int n_printed_entries = 0;
-  span_count_map::const_iterator i_sc = m_insn_span_count.begin();
-  for (; i_sc != m_insn_span_count.end(); ++i_sc) {
-    unsigned ptx_lineno = gpgpu_ctx->translate_pc_to_ptxlineno(i_sc->first);
-    fprintf(fout, "%u %d ", ptx_lineno, i_sc->second);
-    n_printed_entries++;
-  }
-  if (n_printed_entries == 0) {
-    fprintf(fout, "0 0 ");
-  }
-  fprintf(fout, "\n");
-}
-
-void thread_insn_span::print_sparse_histo(gzFile fout) const {
-  int n_printed_entries = 0;
-  span_count_map::const_iterator i_sc = m_insn_span_count.begin();
-  for (; i_sc != m_insn_span_count.end(); ++i_sc) {
-    unsigned ptx_lineno = gpgpu_ctx->translate_pc_to_ptxlineno(i_sc->first);
-    gzprintf(fout, "%u %d ", ptx_lineno, i_sc->second);
-    n_printed_entries++;
-  }
-  if (n_printed_entries == 0) {
-    gzprintf(fout, "0 0 ");
-  }
-  gzprintf(fout, "\n");
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-thread_CFlocality::thread_CFlocality(gpgpu_context *ctx, std::string name,
-                                     unsigned long long snap_shot_interval,
-                                     int nthreads, address_type start_pc,
-                                     unsigned long long start_cycle)
-    : snap_shot_trigger(snap_shot_interval),
-      m_name(name),
-      m_nthreads(nthreads),
-      m_thread_pc(nthreads, start_pc),
-      m_cycle(start_cycle),
-      m_thd_span(start_cycle, ctx) {
-  std::fill(
-      m_thread_pc.begin(), m_thread_pc.end(),
-      -1);  // so that hw thread with no work assigned will not clobber results
-}
-
-thread_CFlocality::~thread_CFlocality() {}
-
-void thread_CFlocality::update_thread_pc(int thread_id, address_type pc) {
-  m_thread_pc[thread_id] = pc;
-  m_thd_span.set_span(pc);
-}
-
-void thread_CFlocality::snap_shot(unsigned long long current_cycle) {
-  m_thd_span_archive.push_back(m_thd_span);
-  m_thd_span.reset(current_cycle);
-  for (int i = 0; i < (int)m_thread_pc.size(); i++) {
-    m_thd_span.set_span(m_thread_pc[i]);
-  }
-}
-
-void thread_CFlocality::spill(FILE *fout, bool final) {
-  std::list<thread_insn_span>::iterator lit = m_thd_span_archive.begin();
-  for (; lit != m_thd_span_archive.end(); lit = m_thd_span_archive.erase(lit)) {
-    fprintf(fout, "%s-", m_name.c_str());
-    lit->print_histo(fout);
-  }
-  assert(m_thd_span_archive.empty());
-  if (final) {
-    fprintf(fout, "%s-", m_name.c_str());
-    m_thd_span.print_histo(fout);
-  }
-}
-
-void thread_CFlocality::print_visualizer(FILE *fout) {
-  fprintf(fout, "%s: ", m_name.c_str());
-  if (m_thd_span_archive.empty()) {
-    // visualizer do no require snap_shots
-    m_thd_span.print_sparse_histo(fout);
-
-    // clean the thread span
-    m_thd_span.reset(0);
-    for (int i = 0; i < (int)m_thread_pc.size(); i++)
-      m_thd_span.set_span(m_thread_pc[i]);
-  } else {
-    assert(0);  // TODO: implement fall back so that visualizer can work with
-                // snap shots
-  }
-}
-
-void thread_CFlocality::print_visualizer(gzFile fout) {
-  gzprintf(fout, "%s: ", m_name.c_str());
-  if (m_thd_span_archive.empty()) {
-    // visualizer do no require snap_shots
-    m_thd_span.print_sparse_histo(fout);
-
-    // clean the thread span
-    m_thd_span.reset(0);
-    for (int i = 0; i < (int)m_thread_pc.size(); i++) {
-      m_thd_span.set_span(m_thread_pc[i]);
-    }
-  } else {
-    assert(0);  // TODO: implement fall back so that visualizer can work with
-                // snap shots
-  }
-}
-
-void thread_CFlocality::print_span(FILE *fout) const {
-  std::list<thread_insn_span>::const_iterator lit = m_thd_span_archive.begin();
-  for (; lit != m_thd_span_archive.end(); ++lit) {
-    fprintf(fout, "%s-", m_name.c_str());
-    lit->print_span(fout);
-  }
-  fprintf(fout, "%s-", m_name.c_str());
-  m_thd_span.print_span(fout);
-}
-
-void thread_CFlocality::print_histo(FILE *fout) const {
-  std::list<thread_insn_span>::const_iterator lit = m_thd_span_archive.begin();
-  for (; lit != m_thd_span_archive.end(); ++lit) {
-    fprintf(fout, "%s-", m_name.c_str());
-    lit->print_histo(fout);
-  }
-  fprintf(fout, "%s-", m_name.c_str());
-  m_thd_span.print_histo(fout);
+void thread_insn_span::print_sparse_histo(gzFile fout) const
+{
+   int n_printed_entries = 0;
+   span_count_map::const_iterator i_sc = m_insn_span_count.begin();
+   for (; i_sc != m_insn_span_count.end(); ++i_sc) {
+      unsigned ptx_lineno = gpgpu_ctx->translate_pc_to_ptxlineno(i_sc->first);
+      gzprintf(fout, "%u %d ", ptx_lineno, i_sc->second);
+      n_printed_entries++;
+   }
+   if (n_printed_entries == 0) {
+      gzprintf(fout, "0 0 ");
+   }
+   gzprintf(fout, "\n");
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-linear_histogram_logger::linear_histogram_logger(
-    int n_bins, unsigned long long snap_shot_interval, const char *name,
-    bool reset_at_snap_shot, unsigned long long start_cycle)
-    : snap_shot_trigger(snap_shot_interval),
-      m_n_bins(n_bins),
-      m_curr_lin_hist(m_n_bins, start_cycle),
-      m_lin_hist_archive(),
-      m_cycle(start_cycle),
-      m_reset_at_snap_shot(reset_at_snap_shot),
-      m_name(name),
-      m_id(s_ids++) {}
-
-linear_histogram_logger::linear_histogram_logger(
-    const linear_histogram_logger &other)
-    : snap_shot_trigger(other.get_interval()),
-      m_n_bins(other.m_n_bins),
-      m_curr_lin_hist(m_n_bins, other.m_cycle),
-      m_lin_hist_archive(),
-      m_cycle(other.m_cycle),
-      m_reset_at_snap_shot(other.m_reset_at_snap_shot),
-      m_name(other.m_name),
-      m_id(s_ids++) {}
-
-linear_histogram_logger::~linear_histogram_logger() {
-  remove_snap_shot_trigger(this);
-  remove_spill_log(this);
+thread_CFlocality::thread_CFlocality( gpgpu_context* ctx, std::string name, 
+                                     unsigned long long  snap_shot_interval, 
+                                     int nthreads, 
+                                     address_type start_pc, 
+                                     unsigned long long  start_cycle)
+      : snap_shot_trigger(snap_shot_interval), m_name(name),
+        m_nthreads(nthreads), m_thread_pc(nthreads, start_pc), m_cycle(start_cycle),
+        m_thd_span(start_cycle, ctx)
+{
+   std::fill(m_thread_pc.begin(), m_thread_pc.end(), -1); // so that hw thread with no work assigned will not clobber results
+}
+   
+thread_CFlocality::~thread_CFlocality() 
+{
+} 
+   
+void thread_CFlocality::update_thread_pc( int thread_id, address_type pc ) 
+{
+   m_thread_pc[thread_id] = pc;
+   m_thd_span.set_span(pc);
+}
+   
+void thread_CFlocality::snap_shot(unsigned long long  current_cycle) 
+{
+   m_thd_span_archive.push_back(m_thd_span);
+   m_thd_span.reset(current_cycle);
+   for (int i = 0; i < (int)m_thread_pc.size(); i++) {
+      m_thd_span.set_span(m_thread_pc[i]);
+   }
+}
+   
+void thread_CFlocality::spill(FILE *fout, bool final) 
+{
+   std::list<thread_insn_span>::iterator lit = m_thd_span_archive.begin();
+   for (; lit != m_thd_span_archive.end(); lit = m_thd_span_archive.erase(lit) ) {
+      fprintf(fout, "%s-", m_name.c_str());
+      lit->print_histo(fout);
+   }
+   assert( m_thd_span_archive.empty() );
+   if (final) {
+      fprintf(fout, "%s-", m_name.c_str());
+      m_thd_span.print_histo(fout);
+   }
+}
+   
+      
+void thread_CFlocality::print_visualizer(FILE *fout)  
+{
+   fprintf(fout, "%s: ", m_name.c_str());
+   if (m_thd_span_archive.empty()) {
+   
+      // visualizer do no require snap_shots
+      m_thd_span.print_sparse_histo(fout);
+      
+      // clean the thread span
+      m_thd_span.reset(0);
+      for (int i = 0; i < (int)m_thread_pc.size(); i++) 
+         m_thd_span.set_span(m_thread_pc[i]);
+   } else { 
+      assert(0); // TODO: implement fall back so that visualizer can work with snap shots
+   }
+}
+   
+void thread_CFlocality::print_visualizer(gzFile fout)
+{
+   gzprintf(fout, "%s: ", m_name.c_str());
+   if (m_thd_span_archive.empty()) {
+   
+      // visualizer do no require snap_shots
+      m_thd_span.print_sparse_histo(fout);
+      
+      // clean the thread span
+      m_thd_span.reset(0);
+      for (int i = 0; i < (int)m_thread_pc.size(); i++) {
+         m_thd_span.set_span(m_thread_pc[i]);
+      }
+   } else { 
+      assert(0); // TODO: implement fall back so that visualizer can work with snap shots
+   }
+}
+   
+void thread_CFlocality::print_span(FILE *fout) const
+{
+   std::list<thread_insn_span>::const_iterator lit = m_thd_span_archive.begin();
+   for (; lit != m_thd_span_archive.end(); ++lit) {
+      fprintf(fout, "%s-", m_name.c_str());
+      lit->print_span(fout);
+   }
+   fprintf(fout, "%s-", m_name.c_str());
+   m_thd_span.print_span(fout);
 }
 
-void linear_histogram_logger::snap_shot(unsigned long long current_cycle) {
-  m_lin_hist_archive.push_back(m_curr_lin_hist);
-  if (m_reset_at_snap_shot) {
-    m_curr_lin_hist.reset(current_cycle);
-  } else {
-    m_curr_lin_hist.set_cycle(current_cycle);
-  }
+void thread_CFlocality::print_histo(FILE *fout) const
+{
+   std::list<thread_insn_span>::const_iterator lit = m_thd_span_archive.begin();
+   for (; lit != m_thd_span_archive.end(); ++lit) {
+      fprintf(fout, "%s-", m_name.c_str());
+      lit->print_histo(fout);
+   }
+   fprintf(fout, "%s-", m_name.c_str());
+   m_thd_span.print_histo(fout);
 }
 
-void linear_histogram_logger::spill(FILE *fout, bool final) {
-  std::list<linear_histogram_snapshot>::iterator iter =
-      m_lin_hist_archive.begin();
-  for (; iter != m_lin_hist_archive.end();
-       iter = m_lin_hist_archive.erase(iter)) {
-    fprintf(fout, "%s%02d-", m_name.c_str(), (m_id >= 0) ? m_id : 0);
-    iter->print(fout);
-    fprintf(fout, "\n");
-  }
-  assert(m_lin_hist_archive.empty());
-  if (final) {
-    fprintf(fout, "%s%02d-", m_name.c_str(), (m_id >= 0) ? m_id : 0);
-    m_curr_lin_hist.print(fout);
-    fprintf(fout, "\n");
-  }
+////////////////////////////////////////////////////////////////////////////////
+
+linear_histogram_logger::linear_histogram_logger(int n_bins, 
+                           unsigned long long  snap_shot_interval, 
+                           const char *name, 
+                           bool reset_at_snap_shot, 
+                           unsigned long long  start_cycle )
+      : snap_shot_trigger(snap_shot_interval), 
+        m_n_bins(n_bins), 
+        m_curr_lin_hist(m_n_bins, start_cycle),
+        m_lin_hist_archive(),
+        m_cycle(start_cycle),
+        m_reset_at_snap_shot(reset_at_snap_shot), 
+        m_name(name),
+        m_id(s_ids++) 
+{
 }
 
-void linear_histogram_logger::print(FILE *fout) const {
-  std::list<linear_histogram_snapshot>::const_iterator iter =
-      m_lin_hist_archive.begin();
-  for (; iter != m_lin_hist_archive.end(); ++iter) {
-    fprintf(fout, "%s%02d-", m_name.c_str(), m_id);
-    iter->print(fout);
-    fprintf(fout, "\n");
-  }
-  fprintf(fout, "%s%02d-", m_name.c_str(), m_id);
-  m_curr_lin_hist.print(fout);
-  fprintf(fout, "\n");
+linear_histogram_logger::linear_histogram_logger(const linear_histogram_logger& other) 
+      : snap_shot_trigger(other.get_interval()), 
+        m_n_bins(other.m_n_bins), 
+        m_curr_lin_hist(m_n_bins, other.m_cycle),
+        m_lin_hist_archive(),
+        m_cycle(other.m_cycle),
+        m_reset_at_snap_shot(other.m_reset_at_snap_shot), 
+        m_name(other.m_name),
+        m_id(s_ids++) 
+{
 }
 
-void linear_histogram_logger::print_visualizer(FILE *fout) {
-  assert(m_lin_hist_archive.empty());  // don't support snapshot for now
-  fprintf(fout, "%s", m_name.c_str());
-  if (m_id >= 0) {
-    fprintf(fout, "%02d: ", m_id);
-  } else {
-    fprintf(fout, ": ");
-  }
-  m_curr_lin_hist.print_visualizer(fout);
-  fprintf(fout, "\n");
-  if (m_reset_at_snap_shot) {
-    m_curr_lin_hist.reset(0);
-  }
+linear_histogram_logger::~linear_histogram_logger() 
+{
+      remove_snap_shot_trigger(this);
+      remove_spill_log(this);
+}
+   
+void linear_histogram_logger::snap_shot(unsigned long long  current_cycle) {
+   m_lin_hist_archive.push_back(m_curr_lin_hist);
+   if (m_reset_at_snap_shot) {
+      m_curr_lin_hist.reset(current_cycle);
+   } else {
+      m_curr_lin_hist.set_cycle(current_cycle);
+   }
+}
+   
+void linear_histogram_logger::spill(FILE *fout, bool final) 
+{
+   std::list<linear_histogram_snapshot>::iterator iter = m_lin_hist_archive.begin();
+   for (; iter != m_lin_hist_archive.end(); iter = m_lin_hist_archive.erase(iter) ) {
+      fprintf(fout, "%s%02d-", m_name.c_str(), (m_id >= 0)? m_id : 0);
+      iter->print(fout);
+      fprintf(fout, "\n");
+   }
+   assert( m_lin_hist_archive.empty() );
+   if (final) {
+      fprintf(fout, "%s%02d-", m_name.c_str(), (m_id >= 0)? m_id : 0);
+      m_curr_lin_hist.print(fout);
+      fprintf(fout, "\n");
+   }
+}
+   
+void linear_histogram_logger::print(FILE *fout) const
+{
+   std::list<linear_histogram_snapshot>::const_iterator iter = m_lin_hist_archive.begin();
+   for (; iter != m_lin_hist_archive.end(); ++iter) {
+      fprintf(fout, "%s%02d-", m_name.c_str(), m_id);
+      iter->print(fout);
+      fprintf(fout, "\n");
+   }
+   fprintf(fout, "%s%02d-", m_name.c_str(), m_id);
+   m_curr_lin_hist.print(fout);
+   fprintf(fout, "\n");
 }
 
-void linear_histogram_logger::print_visualizer(gzFile fout) {
-  assert(m_lin_hist_archive.empty());  // don't support snapshot for now
-  gzprintf(fout, "%s", m_name.c_str());
-  if (m_id >= 0) {
-    gzprintf(fout, "%02d: ", m_id);
-  } else {
-    gzprintf(fout, ": ");
-  }
-  m_curr_lin_hist.print_visualizer(fout);
-  gzprintf(fout, "\n");
-  if (m_reset_at_snap_shot) {
-    m_curr_lin_hist.reset(0);
-  }
+void linear_histogram_logger::print_visualizer(FILE *fout)
+{
+   assert(m_lin_hist_archive.empty()); // don't support snapshot for now
+   fprintf(fout, "%s", m_name.c_str());
+   if (m_id >= 0) {
+      fprintf(fout, "%02d: ", m_id);
+   } else {
+      fprintf(fout, ": ");
+   }
+   m_curr_lin_hist.print_visualizer(fout);
+   fprintf(fout, "\n");
+   if (m_reset_at_snap_shot) {
+      m_curr_lin_hist.reset(0);
+   } 
 }
+
+void linear_histogram_logger::print_visualizer(gzFile fout)
+{
+   assert(m_lin_hist_archive.empty()); // don't support snapshot for now
+   gzprintf(fout, "%s", m_name.c_str());
+   if (m_id >= 0) {
+      gzprintf(fout, "%02d: ", m_id);
+   } else {
+      gzprintf(fout, ": ");
+   }
+   m_curr_lin_hist.print_visualizer(fout);
+   gzprintf(fout, "\n");
+   if (m_reset_at_snap_shot) {
+      m_curr_lin_hist.reset(0);
+   } 
+}
+

--- a/src/gpgpu-sim/stat-tool.h
+++ b/src/gpgpu-sim/stat-tool.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -31,54 +29,50 @@
 #define STAT_TOOL_H
 
 #include "../abstract_hardware_model.h"
-#include "../tr1_hash_map.h"
 #include "histogram.h"
+#include "../tr1_hash_map.h"
 
 #include <stdio.h>
 #include <zlib.h>
 
 class gpgpu_context;
 /////////////////////////////////////////////////////////////////////////////////////
-// logger snapshot trigger:
-// - automate the snap_shot part of loggers to avoid modifying simulation loop
-// everytime
+// logger snapshot trigger: 
+// - automate the snap_shot part of loggers to avoid modifying simulation loop everytime 
 //   a new time-dependent stat is added
 /////////////////////////////////////////////////////////////////////////////////////
 
 class snap_shot_trigger {
- public:
-  snap_shot_trigger(unsigned long long interval)
-      : m_snap_shot_interval(interval) {}
-  virtual ~snap_shot_trigger() {}
+public:
+   snap_shot_trigger(unsigned long long  interval) : m_snap_shot_interval(interval) {}
+   virtual ~snap_shot_trigger() {}
+   
+   void try_snap_shot(unsigned long long  current_cycle) {
+      if ((current_cycle % m_snap_shot_interval == 0) && current_cycle != 0) {
+         snap_shot(current_cycle);
+      }
+   }
+   
+   virtual void snap_shot(unsigned long long  current_cycle) = 0;
 
-  void try_snap_shot(unsigned long long current_cycle) {
-    if ((current_cycle % m_snap_shot_interval == 0) && current_cycle != 0) {
-      snap_shot(current_cycle);
-    }
-  }
+   const unsigned long long & get_interval() const { return m_snap_shot_interval;}
 
-  virtual void snap_shot(unsigned long long current_cycle) = 0;
-
-  const unsigned long long &get_interval() const {
-    return m_snap_shot_interval;
-  }
-
- protected:
-  unsigned long long m_snap_shot_interval;
+protected:
+   unsigned long long  m_snap_shot_interval;
 };
 
+
 /////////////////////////////////////////////////////////////////////////////////////
-// spill log interface:
-// - unified interface to spill log to file to avoid infinite memory usage for
-// logging
+// spill log interface: 
+// - unified interface to spill log to file to avoid infinite memory usage for logging
 /////////////////////////////////////////////////////////////////////////////////////
 
 class spill_log_interface {
- public:
-  spill_log_interface() {}
-  virtual ~spill_log_interface() {}
-
-  virtual void spill(FILE *fout, bool final) = 0;
+public:
+   spill_log_interface() {}
+   virtual ~spill_log_interface() {}
+   
+   virtual void spill(FILE *fout, bool final) = 0;
 };
 
 /////////////////////////////////////////////////////////////////////////////////////
@@ -86,53 +80,51 @@ class spill_log_interface {
 /////////////////////////////////////////////////////////////////////////////////////
 
 class thread_insn_span {
- public:
-  thread_insn_span(unsigned long long cycle, gpgpu_context *ctx);
-  thread_insn_span(const thread_insn_span &other, gpgpu_context *ctx);
-  ~thread_insn_span();
+public:
+   thread_insn_span(unsigned long long  cycle, gpgpu_context* ctx);
+   thread_insn_span(const thread_insn_span& other, gpgpu_context* ctx);
+   ~thread_insn_span();
+   
+   thread_insn_span& operator=(const thread_insn_span& other);
+   thread_insn_span& operator+=(const thread_insn_span& other);
+   void set_span( address_type pc );
+   void reset(unsigned long long  cycle);
+   
+   void print_span(FILE *fout) const;
+   void print_histo(FILE *fout) const;
+   void print_sparse_histo(FILE *fout) const;
+   void print_sparse_histo(gzFile fout) const;
 
-  thread_insn_span &operator=(const thread_insn_span &other);
-  thread_insn_span &operator+=(const thread_insn_span &other);
-  void set_span(address_type pc);
-  void reset(unsigned long long cycle);
-
-  void print_span(FILE *fout) const;
-  void print_histo(FILE *fout) const;
-  void print_sparse_histo(FILE *fout) const;
-  void print_sparse_histo(gzFile fout) const;
-
- private:
-  gpgpu_context *gpgpu_ctx;
-  typedef tr1_hash_map<address_type, int> span_count_map;
-  unsigned long long m_cycle;
-  span_count_map m_insn_span_count;
+private:
+   gpgpu_context* gpgpu_ctx;
+   typedef tr1_hash_map<address_type, int> span_count_map;
+   unsigned long long  m_cycle;
+   span_count_map m_insn_span_count;
 };
 
 class thread_CFlocality : public snap_shot_trigger, public spill_log_interface {
- public:
-  thread_CFlocality(gpgpu_context *ctx, std::string name,
-                    unsigned long long snap_shot_interval, int nthreads,
-                    address_type start_pc, unsigned long long start_cycle = 0);
-  ~thread_CFlocality();
+public:
+   thread_CFlocality(gpgpu_context* ctx, std::string name, unsigned long long  snap_shot_interval, 
+                     int nthreads, address_type start_pc, unsigned long long  start_cycle = 0);
+   ~thread_CFlocality();
+   
+   void update_thread_pc( int thread_id, address_type pc );
+   void snap_shot(unsigned long long  current_cycle);
+   void spill(FILE *fout, bool final);
+   
+   void print_visualizer(FILE *fout);
+   void print_visualizer(gzFile fout);
+   void print_span(FILE *fout) const;
+   void print_histo(FILE *fout) const;
+private:
+   std::string m_name;
 
-  void update_thread_pc(int thread_id, address_type pc);
-  void snap_shot(unsigned long long current_cycle);
-  void spill(FILE *fout, bool final);
-
-  void print_visualizer(FILE *fout);
-  void print_visualizer(gzFile fout);
-  void print_span(FILE *fout) const;
-  void print_histo(FILE *fout) const;
-
- private:
-  std::string m_name;
-
-  int m_nthreads;
-  std::vector<address_type> m_thread_pc;
-
-  unsigned long long m_cycle;
-  thread_insn_span m_thd_span;
-  std::list<thread_insn_span> m_thd_span_archive;
+   int m_nthreads;
+   std::vector<address_type> m_thread_pc;
+   
+   unsigned long long  m_cycle;
+   thread_insn_span m_thd_span;
+   std::list<thread_insn_span> m_thd_span_archive;
 };
 
 /////////////////////////////////////////////////////////////////////////////////////
@@ -140,188 +132,194 @@ class thread_CFlocality : public snap_shot_trigger, public spill_log_interface {
 /////////////////////////////////////////////////////////////////////////////////////
 
 class insn_warp_occ_logger {
- public:
-  insn_warp_occ_logger(int simd_width)
-      : m_simd_width(simd_width),
-        m_insn_warp_occ(1, linear_histogram(1, "", m_simd_width)),
+public:
+   insn_warp_occ_logger(int simd_width)
+      : m_simd_width(simd_width), 
+        m_insn_warp_occ(1,linear_histogram(1, "", m_simd_width)),
         m_id(s_ids++) {}
-
-  insn_warp_occ_logger(const insn_warp_occ_logger &other)
-      : m_simd_width(other.m_simd_width),
-        m_insn_warp_occ(other.m_insn_warp_occ.size(),
-                        linear_histogram(1, "", m_simd_width)),
+   
+   insn_warp_occ_logger(const insn_warp_occ_logger& other)
+      : m_simd_width(other.m_simd_width), 
+        m_insn_warp_occ(other.m_insn_warp_occ.size(), linear_histogram(1, "", m_simd_width)),
         m_id(s_ids++) {}
+   
+   ~insn_warp_occ_logger() {}
 
-  ~insn_warp_occ_logger() {}
+   insn_warp_occ_logger& operator=(const insn_warp_occ_logger& p) {
+      printf("insn_warp_occ_logger Operator= called: %02d \n", m_id);
+      assert(0);
+      return *this;
+   }   
+   
+   void set_id(int id) { m_id = id; }
+   
+   void log(address_type pc, int warp_occ) {
+       if( pc >= m_insn_warp_occ.size() ) 
+           m_insn_warp_occ.resize(2*pc, linear_histogram(1, "", m_simd_width));
+       m_insn_warp_occ[pc].add2bin(warp_occ - 1);
+   }
+   
+   void print(FILE *fout) const 
+   {
+      for (unsigned i = 0; i < m_insn_warp_occ.size(); i++) {
+         fprintf(fout, "InsnWarpOcc%02d-%d", m_id, i);
+         m_insn_warp_occ[i].fprint(fout);
+         fprintf(fout, "\n");
+      }
+   }
 
-  insn_warp_occ_logger &operator=(const insn_warp_occ_logger &p) {
-    printf("insn_warp_occ_logger Operator= called: %02d \n", m_id);
-    assert(0);
-    return *this;
-  }
+private:
 
-  void set_id(int id) { m_id = id; }
-
-  void log(address_type pc, int warp_occ) {
-    if (pc >= m_insn_warp_occ.size())
-      m_insn_warp_occ.resize(2 * pc, linear_histogram(1, "", m_simd_width));
-    m_insn_warp_occ[pc].add2bin(warp_occ - 1);
-  }
-
-  void print(FILE *fout) const {
-    for (unsigned i = 0; i < m_insn_warp_occ.size(); i++) {
-      fprintf(fout, "InsnWarpOcc%02d-%d", m_id, i);
-      m_insn_warp_occ[i].fprint(fout);
-      fprintf(fout, "\n");
-    }
-  }
-
- private:
-  int m_simd_width;
-  std::vector<linear_histogram> m_insn_warp_occ;
-  int m_id;
-  static int s_ids;
+   int m_simd_width;
+   std::vector<linear_histogram> m_insn_warp_occ;
+   int m_id;
+   static int s_ids;
 };
+
 
 /////////////////////////////////////////////////////////////////////////////////////
 // generic linear histogram logger
 /////////////////////////////////////////////////////////////////////////////////////
 
 class linear_histogram_snapshot {
- public:
-  linear_histogram_snapshot(int n_bins, unsigned long long cycle)
-      : m_cycle(cycle), m_linear_histogram(n_bins, 0) {}
+public:
+   linear_histogram_snapshot(int n_bins, unsigned long long  cycle) 
+      : m_cycle(cycle), 
+        m_linear_histogram(n_bins,0) 
+   { }
+   
+   linear_histogram_snapshot(const linear_histogram_snapshot& other) 
+      : m_cycle(other.m_cycle), 
+        m_linear_histogram(other.m_linear_histogram)
+   { }
+   
+   ~linear_histogram_snapshot() { }
+   
+   void addsample(int pos) {
+      assert((size_t)pos < m_linear_histogram.size());
+      m_linear_histogram[pos] += 1;
+   }
+   
+   void subsample(int pos) {
+      assert((size_t)pos < m_linear_histogram.size());
+      m_linear_histogram[pos] -= 1;
+   }
+   
+   void reset(unsigned long long  cycle) {
+      m_cycle = cycle;
+      m_linear_histogram.assign(m_linear_histogram.size(), 0);
+   }
+   
+   void set_cycle(unsigned long long  cycle) { m_cycle = cycle; }
+   
+   void print(FILE *fout) const {
+      fprintf(fout, "%d = ", (int)m_cycle);
+      for (unsigned int i = 0; i < m_linear_histogram.size(); i++) {
+         fprintf(fout, "%d ", m_linear_histogram[i]);
+      }
+   }
 
-  linear_histogram_snapshot(const linear_histogram_snapshot &other)
-      : m_cycle(other.m_cycle), m_linear_histogram(other.m_linear_histogram) {}
+   void print_visualizer(FILE *fout) const {
+      for (unsigned int i = 0; i < m_linear_histogram.size(); i++) {
+         fprintf(fout, "%d ", m_linear_histogram[i]);
+      }
+   }
 
-  ~linear_histogram_snapshot() {}
+   void print_visualizer(gzFile fout) const {
+      for (unsigned int i = 0; i < m_linear_histogram.size(); i++) {
+         gzprintf(fout, "%d ", m_linear_histogram[i]);
+      }
+   }
 
-  void addsample(int pos) {
-    assert((size_t)pos < m_linear_histogram.size());
-    m_linear_histogram[pos] += 1;
-  }
-
-  void subsample(int pos) {
-    assert((size_t)pos < m_linear_histogram.size());
-    m_linear_histogram[pos] -= 1;
-  }
-
-  void reset(unsigned long long cycle) {
-    m_cycle = cycle;
-    m_linear_histogram.assign(m_linear_histogram.size(), 0);
-  }
-
-  void set_cycle(unsigned long long cycle) { m_cycle = cycle; }
-
-  void print(FILE *fout) const {
-    fprintf(fout, "%d = ", (int)m_cycle);
-    for (unsigned int i = 0; i < m_linear_histogram.size(); i++) {
-      fprintf(fout, "%d ", m_linear_histogram[i]);
-    }
-  }
-
-  void print_visualizer(FILE *fout) const {
-    for (unsigned int i = 0; i < m_linear_histogram.size(); i++) {
-      fprintf(fout, "%d ", m_linear_histogram[i]);
-    }
-  }
-
-  void print_visualizer(gzFile fout) const {
-    for (unsigned int i = 0; i < m_linear_histogram.size(); i++) {
-      gzprintf(fout, "%d ", m_linear_histogram[i]);
-    }
-  }
-
- private:
-  unsigned long long m_cycle;
-  std::vector<int> m_linear_histogram;
+private:
+   unsigned long long  m_cycle;
+   std::vector<int> m_linear_histogram;
 };
 
-class linear_histogram_logger : public snap_shot_trigger,
-                                public spill_log_interface {
- public:
-  linear_histogram_logger(int n_bins, unsigned long long snap_shot_interval,
-                          const char *name, bool reset_at_snap_shot = true,
-                          unsigned long long start_cycle = 0);
-  linear_histogram_logger(const linear_histogram_logger &other);
+class linear_histogram_logger : public snap_shot_trigger, public spill_log_interface {
+public:
+   linear_histogram_logger(int n_bins, 
+                           unsigned long long  snap_shot_interval, 
+                           const char *name, 
+                           bool reset_at_snap_shot = true, 
+                           unsigned long long  start_cycle = 0);
+   linear_histogram_logger(const linear_histogram_logger& other);
+   
+   ~linear_histogram_logger();
+   
+   void set_id(int id) { m_id = id; }
+   void log(int pos) { m_curr_lin_hist.addsample(pos); }
+   void unlog(int pos) { m_curr_lin_hist.subsample(pos); }
+   void snap_shot(unsigned long long  current_cycle);
+   void spill(FILE *fout, bool final); 
 
-  ~linear_histogram_logger();
+   void print(FILE *fout) const;
+   void print_visualizer(FILE *fout);
+   void print_visualizer(gzFile fout);
 
-  void set_id(int id) { m_id = id; }
-  void log(int pos) { m_curr_lin_hist.addsample(pos); }
-  void unlog(int pos) { m_curr_lin_hist.subsample(pos); }
-  void snap_shot(unsigned long long current_cycle);
-  void spill(FILE *fout, bool final);
-
-  void print(FILE *fout) const;
-  void print_visualizer(FILE *fout);
-  void print_visualizer(gzFile fout);
-
- private:
-  int m_n_bins;
-  linear_histogram_snapshot m_curr_lin_hist;
-  std::list<linear_histogram_snapshot> m_lin_hist_archive;
-  unsigned long long m_cycle;
-  bool m_reset_at_snap_shot;
-  std::string m_name;
-  int m_id;
-  static int s_ids;
+private:
+   int m_n_bins;
+   linear_histogram_snapshot m_curr_lin_hist;
+   std::list<linear_histogram_snapshot> m_lin_hist_archive;
+   unsigned long long  m_cycle;
+   bool m_reset_at_snap_shot;
+   std::string m_name;
+   int m_id;
+   static int s_ids;
 };
 
-void try_snap_shot(unsigned long long current_cycle);
-void set_spill_interval(unsigned long long interval);
-void spill_log_to_file(FILE *fout, int final, unsigned long long current_cycle);
+void try_snap_shot (unsigned long long  current_cycle);
+void set_spill_interval (unsigned long long  interval);
+void spill_log_to_file (FILE *fout, int final, unsigned long long  current_cycle);
 
-void create_thread_CFlogger(gpgpu_context *ctx, int n_loggers, int n_threads,
-                            address_type start_pc,
-                            unsigned long long logging_interval);
-void destroy_thread_CFlogger();
-void cflog_update_thread_pc(int logger_id, int thread_id, address_type pc);
-void cflog_snapshot(int logger_id, unsigned long long cycle);
+void create_thread_CFlogger(gpgpu_context* ctx,  int n_loggers, int n_threads, address_type start_pc, unsigned long long  logging_interval);
+void destroy_thread_CFlogger( );
+void cflog_update_thread_pc( int logger_id, int thread_id, address_type pc );
+void cflog_snapshot( int logger_id, unsigned long long  cycle );
 void cflog_print(FILE *fout);
 void cflog_print_path_expression(FILE *fout);
 void cflog_visualizer_print(FILE *fout);
 void cflog_visualizer_gzprint(gzFile fout);
 
-void insn_warp_occ_create(int n_loggers, int simd_width);
-void insn_warp_occ_log(int logger_id, address_type pc, int warp_occ);
-void insn_warp_occ_print(FILE *fout);
+void insn_warp_occ_create( int n_loggers, int simd_width );
+void insn_warp_occ_log( int logger_id, address_type pc, int warp_occ );
+void insn_warp_occ_print( FILE *fout );
 
-void shader_warp_occ_create(int n_loggers, int simd_width,
-                            unsigned long long logging_interval);
-void shader_warp_occ_log(int logger_id, int warp_occ);
-void shader_warp_occ_snapshot(int logger_id, unsigned long long current_cycle);
-void shader_warp_occ_print(FILE *fout);
 
-void shader_mem_acc_create(int n_loggers, int n_dram, int n_bank,
-                           unsigned long long logging_interval);
-void shader_mem_acc_log(int logger_id, int dram_id, int bank, char rw);
-void shader_mem_acc_snapshot(int logger_id, unsigned long long current_cycle);
-void shader_mem_acc_print(FILE *fout);
+void shader_warp_occ_create( int n_loggers, int simd_width, unsigned long long  logging_interval );
+void shader_warp_occ_log( int logger_id, int warp_occ );
+void shader_warp_occ_snapshot( int logger_id, unsigned long long  current_cycle );
+void shader_warp_occ_print( FILE *fout );
 
-void shader_mem_lat_create(int n_loggers, unsigned long long logging_interval);
-void shader_mem_lat_log(int logger_id, int latency);
-void shader_mem_lat_snapshot(int logger_id, unsigned long long current_cycle);
-void shader_mem_lat_print(FILE *fout);
+
+void shader_mem_acc_create( int n_loggers, int n_dram, int n_bank, unsigned long long  logging_interval );
+void shader_mem_acc_log( int logger_id, int dram_id, int bank, char rw );
+void shader_mem_acc_snapshot( int logger_id, unsigned long long  current_cycle );
+void shader_mem_acc_print( FILE *fout );
+
+
+void shader_mem_lat_create( int n_loggers, unsigned long long  logging_interval );
+void shader_mem_lat_log( int logger_id, int latency );
+void shader_mem_lat_snapshot( int logger_id, unsigned long long  current_cycle );
+void shader_mem_lat_print( FILE *fout );
+
 
 int get_shader_normal_cache_id();
 int get_shader_texture_cache_id();
 int get_shader_constant_cache_id();
 int get_shader_instruction_cache_id();
-void shader_cache_access_create(int n_loggers, int n_types,
-                                unsigned long long logging_interval);
-void shader_cache_access_log(int logger_id, int type, int miss);
-void shader_cache_access_unlog(int logger_id, int type, int miss);
-void shader_cache_access_print(FILE *fout);
+void shader_cache_access_create( int n_loggers, int n_types, unsigned long long  logging_interval );
+void shader_cache_access_log( int logger_id, int type, int miss);
+void shader_cache_access_unlog( int logger_id, int type, int miss);
+void shader_cache_access_print( FILE *fout );
 
-void shader_CTA_count_create(int n_shaders,
-                             unsigned long long logging_interval);
-void shader_CTA_count_log(int shader_id, int nCTAadded);
-void shader_CTA_count_unlog(int shader_id, int nCTAdone);
-void shader_CTA_count_resetnow();
-void shader_CTA_count_print(FILE *fout);
-void shader_CTA_count_visualizer_print(FILE *fout);
+
+void shader_CTA_count_create( int n_shaders, unsigned long long  logging_interval);
+void shader_CTA_count_log( int shader_id, int nCTAadded );
+void shader_CTA_count_unlog( int shader_id, int nCTAdone );
+void shader_CTA_count_resetnow( );
+void shader_CTA_count_print( FILE *fout );
+void shader_CTA_count_visualizer_print( FILE *fout );
 void shader_CTA_count_visualizer_gzprint(gzFile fout);
 
 #endif /* CFLOGGER_H */

--- a/src/gpgpu-sim/stat-tool.h
+++ b/src/gpgpu-sim/stat-tool.h
@@ -7,72 +7,77 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef STAT_TOOL_H
 #define STAT_TOOL_H
 
 #include "../abstract_hardware_model.h"
-#include "histogram.h"
 #include "../tr1_hash_map.h"
+#include "histogram.h"
 
 #include <stdio.h>
 #include <zlib.h>
 
 class gpgpu_context;
 /////////////////////////////////////////////////////////////////////////////////////
-// logger snapshot trigger: 
-// - automate the snap_shot part of loggers to avoid modifying simulation loop everytime 
+// logger snapshot trigger:
+// - automate the snap_shot part of loggers to avoid modifying simulation loop
+// everytime
 //   a new time-dependent stat is added
 /////////////////////////////////////////////////////////////////////////////////////
 
 class snap_shot_trigger {
-public:
-   snap_shot_trigger(unsigned long long  interval) : m_snap_shot_interval(interval) {}
-   virtual ~snap_shot_trigger() {}
-   
-   void try_snap_shot(unsigned long long  current_cycle) {
-      if ((current_cycle % m_snap_shot_interval == 0) && current_cycle != 0) {
-         snap_shot(current_cycle);
-      }
-   }
-   
-   virtual void snap_shot(unsigned long long  current_cycle) = 0;
+ public:
+  snap_shot_trigger(unsigned long long interval)
+      : m_snap_shot_interval(interval) {}
+  virtual ~snap_shot_trigger() {}
 
-   const unsigned long long & get_interval() const { return m_snap_shot_interval;}
+  void try_snap_shot(unsigned long long current_cycle) {
+    if ((current_cycle % m_snap_shot_interval == 0) && current_cycle != 0) {
+      snap_shot(current_cycle);
+    }
+  }
 
-protected:
-   unsigned long long  m_snap_shot_interval;
+  virtual void snap_shot(unsigned long long current_cycle) = 0;
+
+  const unsigned long long &get_interval() const {
+    return m_snap_shot_interval;
+  }
+
+ protected:
+  unsigned long long m_snap_shot_interval;
 };
 
-
 /////////////////////////////////////////////////////////////////////////////////////
-// spill log interface: 
-// - unified interface to spill log to file to avoid infinite memory usage for logging
+// spill log interface:
+// - unified interface to spill log to file to avoid infinite memory usage for
+// logging
 /////////////////////////////////////////////////////////////////////////////////////
 
 class spill_log_interface {
-public:
-   spill_log_interface() {}
-   virtual ~spill_log_interface() {}
-   
-   virtual void spill(FILE *fout, bool final) = 0;
+ public:
+  spill_log_interface() {}
+  virtual ~spill_log_interface() {}
+
+  virtual void spill(FILE *fout, bool final) = 0;
 };
 
 /////////////////////////////////////////////////////////////////////////////////////
@@ -80,51 +85,53 @@ public:
 /////////////////////////////////////////////////////////////////////////////////////
 
 class thread_insn_span {
-public:
-   thread_insn_span(unsigned long long  cycle, gpgpu_context* ctx);
-   thread_insn_span(const thread_insn_span& other, gpgpu_context* ctx);
-   ~thread_insn_span();
-   
-   thread_insn_span& operator=(const thread_insn_span& other);
-   thread_insn_span& operator+=(const thread_insn_span& other);
-   void set_span( address_type pc );
-   void reset(unsigned long long  cycle);
-   
-   void print_span(FILE *fout) const;
-   void print_histo(FILE *fout) const;
-   void print_sparse_histo(FILE *fout) const;
-   void print_sparse_histo(gzFile fout) const;
+ public:
+  thread_insn_span(unsigned long long cycle, gpgpu_context *ctx);
+  thread_insn_span(const thread_insn_span &other, gpgpu_context *ctx);
+  ~thread_insn_span();
 
-private:
-   gpgpu_context* gpgpu_ctx;
-   typedef tr1_hash_map<address_type, int> span_count_map;
-   unsigned long long  m_cycle;
-   span_count_map m_insn_span_count;
+  thread_insn_span &operator=(const thread_insn_span &other);
+  thread_insn_span &operator+=(const thread_insn_span &other);
+  void set_span(address_type pc);
+  void reset(unsigned long long cycle);
+
+  void print_span(FILE *fout) const;
+  void print_histo(FILE *fout) const;
+  void print_sparse_histo(FILE *fout) const;
+  void print_sparse_histo(gzFile fout) const;
+
+ private:
+  gpgpu_context *gpgpu_ctx;
+  typedef tr1_hash_map<address_type, int> span_count_map;
+  unsigned long long m_cycle;
+  span_count_map m_insn_span_count;
 };
 
 class thread_CFlocality : public snap_shot_trigger, public spill_log_interface {
-public:
-   thread_CFlocality(gpgpu_context* ctx, std::string name, unsigned long long  snap_shot_interval, 
-                     int nthreads, address_type start_pc, unsigned long long  start_cycle = 0);
-   ~thread_CFlocality();
-   
-   void update_thread_pc( int thread_id, address_type pc );
-   void snap_shot(unsigned long long  current_cycle);
-   void spill(FILE *fout, bool final);
-   
-   void print_visualizer(FILE *fout);
-   void print_visualizer(gzFile fout);
-   void print_span(FILE *fout) const;
-   void print_histo(FILE *fout) const;
-private:
-   std::string m_name;
+ public:
+  thread_CFlocality(gpgpu_context *ctx, std::string name,
+                    unsigned long long snap_shot_interval, int nthreads,
+                    address_type start_pc, unsigned long long start_cycle = 0);
+  ~thread_CFlocality();
 
-   int m_nthreads;
-   std::vector<address_type> m_thread_pc;
-   
-   unsigned long long  m_cycle;
-   thread_insn_span m_thd_span;
-   std::list<thread_insn_span> m_thd_span_archive;
+  void update_thread_pc(int thread_id, address_type pc);
+  void snap_shot(unsigned long long current_cycle);
+  void spill(FILE *fout, bool final);
+
+  void print_visualizer(FILE *fout);
+  void print_visualizer(gzFile fout);
+  void print_span(FILE *fout) const;
+  void print_histo(FILE *fout) const;
+
+ private:
+  std::string m_name;
+
+  int m_nthreads;
+  std::vector<address_type> m_thread_pc;
+
+  unsigned long long m_cycle;
+  thread_insn_span m_thd_span;
+  std::list<thread_insn_span> m_thd_span_archive;
 };
 
 /////////////////////////////////////////////////////////////////////////////////////
@@ -132,194 +139,188 @@ private:
 /////////////////////////////////////////////////////////////////////////////////////
 
 class insn_warp_occ_logger {
-public:
-   insn_warp_occ_logger(int simd_width)
-      : m_simd_width(simd_width), 
-        m_insn_warp_occ(1,linear_histogram(1, "", m_simd_width)),
+ public:
+  insn_warp_occ_logger(int simd_width)
+      : m_simd_width(simd_width),
+        m_insn_warp_occ(1, linear_histogram(1, "", m_simd_width)),
         m_id(s_ids++) {}
-   
-   insn_warp_occ_logger(const insn_warp_occ_logger& other)
-      : m_simd_width(other.m_simd_width), 
-        m_insn_warp_occ(other.m_insn_warp_occ.size(), linear_histogram(1, "", m_simd_width)),
+
+  insn_warp_occ_logger(const insn_warp_occ_logger &other)
+      : m_simd_width(other.m_simd_width),
+        m_insn_warp_occ(other.m_insn_warp_occ.size(),
+                        linear_histogram(1, "", m_simd_width)),
         m_id(s_ids++) {}
-   
-   ~insn_warp_occ_logger() {}
 
-   insn_warp_occ_logger& operator=(const insn_warp_occ_logger& p) {
-      printf("insn_warp_occ_logger Operator= called: %02d \n", m_id);
-      assert(0);
-      return *this;
-   }   
-   
-   void set_id(int id) { m_id = id; }
-   
-   void log(address_type pc, int warp_occ) {
-       if( pc >= m_insn_warp_occ.size() ) 
-           m_insn_warp_occ.resize(2*pc, linear_histogram(1, "", m_simd_width));
-       m_insn_warp_occ[pc].add2bin(warp_occ - 1);
-   }
-   
-   void print(FILE *fout) const 
-   {
-      for (unsigned i = 0; i < m_insn_warp_occ.size(); i++) {
-         fprintf(fout, "InsnWarpOcc%02d-%d", m_id, i);
-         m_insn_warp_occ[i].fprint(fout);
-         fprintf(fout, "\n");
-      }
-   }
+  ~insn_warp_occ_logger() {}
 
-private:
+  insn_warp_occ_logger &operator=(const insn_warp_occ_logger &p) {
+    printf("insn_warp_occ_logger Operator= called: %02d \n", m_id);
+    assert(0);
+    return *this;
+  }
 
-   int m_simd_width;
-   std::vector<linear_histogram> m_insn_warp_occ;
-   int m_id;
-   static int s_ids;
+  void set_id(int id) { m_id = id; }
+
+  void log(address_type pc, int warp_occ) {
+    if (pc >= m_insn_warp_occ.size())
+      m_insn_warp_occ.resize(2 * pc, linear_histogram(1, "", m_simd_width));
+    m_insn_warp_occ[pc].add2bin(warp_occ - 1);
+  }
+
+  void print(FILE *fout) const {
+    for (unsigned i = 0; i < m_insn_warp_occ.size(); i++) {
+      fprintf(fout, "InsnWarpOcc%02d-%d", m_id, i);
+      m_insn_warp_occ[i].fprint(fout);
+      fprintf(fout, "\n");
+    }
+  }
+
+ private:
+  int m_simd_width;
+  std::vector<linear_histogram> m_insn_warp_occ;
+  int m_id;
+  static int s_ids;
 };
-
 
 /////////////////////////////////////////////////////////////////////////////////////
 // generic linear histogram logger
 /////////////////////////////////////////////////////////////////////////////////////
 
 class linear_histogram_snapshot {
-public:
-   linear_histogram_snapshot(int n_bins, unsigned long long  cycle) 
-      : m_cycle(cycle), 
-        m_linear_histogram(n_bins,0) 
-   { }
-   
-   linear_histogram_snapshot(const linear_histogram_snapshot& other) 
-      : m_cycle(other.m_cycle), 
-        m_linear_histogram(other.m_linear_histogram)
-   { }
-   
-   ~linear_histogram_snapshot() { }
-   
-   void addsample(int pos) {
-      assert((size_t)pos < m_linear_histogram.size());
-      m_linear_histogram[pos] += 1;
-   }
-   
-   void subsample(int pos) {
-      assert((size_t)pos < m_linear_histogram.size());
-      m_linear_histogram[pos] -= 1;
-   }
-   
-   void reset(unsigned long long  cycle) {
-      m_cycle = cycle;
-      m_linear_histogram.assign(m_linear_histogram.size(), 0);
-   }
-   
-   void set_cycle(unsigned long long  cycle) { m_cycle = cycle; }
-   
-   void print(FILE *fout) const {
-      fprintf(fout, "%d = ", (int)m_cycle);
-      for (unsigned int i = 0; i < m_linear_histogram.size(); i++) {
-         fprintf(fout, "%d ", m_linear_histogram[i]);
-      }
-   }
+ public:
+  linear_histogram_snapshot(int n_bins, unsigned long long cycle)
+      : m_cycle(cycle), m_linear_histogram(n_bins, 0) {}
 
-   void print_visualizer(FILE *fout) const {
-      for (unsigned int i = 0; i < m_linear_histogram.size(); i++) {
-         fprintf(fout, "%d ", m_linear_histogram[i]);
-      }
-   }
+  linear_histogram_snapshot(const linear_histogram_snapshot &other)
+      : m_cycle(other.m_cycle), m_linear_histogram(other.m_linear_histogram) {}
 
-   void print_visualizer(gzFile fout) const {
-      for (unsigned int i = 0; i < m_linear_histogram.size(); i++) {
-         gzprintf(fout, "%d ", m_linear_histogram[i]);
-      }
-   }
+  ~linear_histogram_snapshot() {}
 
-private:
-   unsigned long long  m_cycle;
-   std::vector<int> m_linear_histogram;
+  void addsample(int pos) {
+    assert((size_t)pos < m_linear_histogram.size());
+    m_linear_histogram[pos] += 1;
+  }
+
+  void subsample(int pos) {
+    assert((size_t)pos < m_linear_histogram.size());
+    m_linear_histogram[pos] -= 1;
+  }
+
+  void reset(unsigned long long cycle) {
+    m_cycle = cycle;
+    m_linear_histogram.assign(m_linear_histogram.size(), 0);
+  }
+
+  void set_cycle(unsigned long long cycle) { m_cycle = cycle; }
+
+  void print(FILE *fout) const {
+    fprintf(fout, "%d = ", (int)m_cycle);
+    for (unsigned int i = 0; i < m_linear_histogram.size(); i++) {
+      fprintf(fout, "%d ", m_linear_histogram[i]);
+    }
+  }
+
+  void print_visualizer(FILE *fout) const {
+    for (unsigned int i = 0; i < m_linear_histogram.size(); i++) {
+      fprintf(fout, "%d ", m_linear_histogram[i]);
+    }
+  }
+
+  void print_visualizer(gzFile fout) const {
+    for (unsigned int i = 0; i < m_linear_histogram.size(); i++) {
+      gzprintf(fout, "%d ", m_linear_histogram[i]);
+    }
+  }
+
+ private:
+  unsigned long long m_cycle;
+  std::vector<int> m_linear_histogram;
 };
 
-class linear_histogram_logger : public snap_shot_trigger, public spill_log_interface {
-public:
-   linear_histogram_logger(int n_bins, 
-                           unsigned long long  snap_shot_interval, 
-                           const char *name, 
-                           bool reset_at_snap_shot = true, 
-                           unsigned long long  start_cycle = 0);
-   linear_histogram_logger(const linear_histogram_logger& other);
-   
-   ~linear_histogram_logger();
-   
-   void set_id(int id) { m_id = id; }
-   void log(int pos) { m_curr_lin_hist.addsample(pos); }
-   void unlog(int pos) { m_curr_lin_hist.subsample(pos); }
-   void snap_shot(unsigned long long  current_cycle);
-   void spill(FILE *fout, bool final); 
+class linear_histogram_logger : public snap_shot_trigger,
+                                public spill_log_interface {
+ public:
+  linear_histogram_logger(int n_bins, unsigned long long snap_shot_interval,
+                          const char *name, bool reset_at_snap_shot = true,
+                          unsigned long long start_cycle = 0);
+  linear_histogram_logger(const linear_histogram_logger &other);
 
-   void print(FILE *fout) const;
-   void print_visualizer(FILE *fout);
-   void print_visualizer(gzFile fout);
+  ~linear_histogram_logger();
 
-private:
-   int m_n_bins;
-   linear_histogram_snapshot m_curr_lin_hist;
-   std::list<linear_histogram_snapshot> m_lin_hist_archive;
-   unsigned long long  m_cycle;
-   bool m_reset_at_snap_shot;
-   std::string m_name;
-   int m_id;
-   static int s_ids;
+  void set_id(int id) { m_id = id; }
+  void log(int pos) { m_curr_lin_hist.addsample(pos); }
+  void unlog(int pos) { m_curr_lin_hist.subsample(pos); }
+  void snap_shot(unsigned long long current_cycle);
+  void spill(FILE *fout, bool final);
+
+  void print(FILE *fout) const;
+  void print_visualizer(FILE *fout);
+  void print_visualizer(gzFile fout);
+
+ private:
+  int m_n_bins;
+  linear_histogram_snapshot m_curr_lin_hist;
+  std::list<linear_histogram_snapshot> m_lin_hist_archive;
+  unsigned long long m_cycle;
+  bool m_reset_at_snap_shot;
+  std::string m_name;
+  int m_id;
+  static int s_ids;
 };
 
-void try_snap_shot (unsigned long long  current_cycle);
-void set_spill_interval (unsigned long long  interval);
-void spill_log_to_file (FILE *fout, int final, unsigned long long  current_cycle);
+void try_snap_shot(unsigned long long current_cycle);
+void set_spill_interval(unsigned long long interval);
+void spill_log_to_file(FILE *fout, int final, unsigned long long current_cycle);
 
-void create_thread_CFlogger(gpgpu_context* ctx,  int n_loggers, int n_threads, address_type start_pc, unsigned long long  logging_interval);
-void destroy_thread_CFlogger( );
-void cflog_update_thread_pc( int logger_id, int thread_id, address_type pc );
-void cflog_snapshot( int logger_id, unsigned long long  cycle );
+void create_thread_CFlogger(gpgpu_context *ctx, int n_loggers, int n_threads,
+                            address_type start_pc,
+                            unsigned long long logging_interval);
+void destroy_thread_CFlogger();
+void cflog_update_thread_pc(int logger_id, int thread_id, address_type pc);
+void cflog_snapshot(int logger_id, unsigned long long cycle);
 void cflog_print(FILE *fout);
 void cflog_print_path_expression(FILE *fout);
 void cflog_visualizer_print(FILE *fout);
 void cflog_visualizer_gzprint(gzFile fout);
 
-void insn_warp_occ_create( int n_loggers, int simd_width );
-void insn_warp_occ_log( int logger_id, address_type pc, int warp_occ );
-void insn_warp_occ_print( FILE *fout );
+void insn_warp_occ_create(int n_loggers, int simd_width);
+void insn_warp_occ_log(int logger_id, address_type pc, int warp_occ);
+void insn_warp_occ_print(FILE *fout);
 
+void shader_warp_occ_create(int n_loggers, int simd_width,
+                            unsigned long long logging_interval);
+void shader_warp_occ_log(int logger_id, int warp_occ);
+void shader_warp_occ_snapshot(int logger_id, unsigned long long current_cycle);
+void shader_warp_occ_print(FILE *fout);
 
-void shader_warp_occ_create( int n_loggers, int simd_width, unsigned long long  logging_interval );
-void shader_warp_occ_log( int logger_id, int warp_occ );
-void shader_warp_occ_snapshot( int logger_id, unsigned long long  current_cycle );
-void shader_warp_occ_print( FILE *fout );
+void shader_mem_acc_create(int n_loggers, int n_dram, int n_bank,
+                           unsigned long long logging_interval);
+void shader_mem_acc_log(int logger_id, int dram_id, int bank, char rw);
+void shader_mem_acc_snapshot(int logger_id, unsigned long long current_cycle);
+void shader_mem_acc_print(FILE *fout);
 
-
-void shader_mem_acc_create( int n_loggers, int n_dram, int n_bank, unsigned long long  logging_interval );
-void shader_mem_acc_log( int logger_id, int dram_id, int bank, char rw );
-void shader_mem_acc_snapshot( int logger_id, unsigned long long  current_cycle );
-void shader_mem_acc_print( FILE *fout );
-
-
-void shader_mem_lat_create( int n_loggers, unsigned long long  logging_interval );
-void shader_mem_lat_log( int logger_id, int latency );
-void shader_mem_lat_snapshot( int logger_id, unsigned long long  current_cycle );
-void shader_mem_lat_print( FILE *fout );
-
+void shader_mem_lat_create(int n_loggers, unsigned long long logging_interval);
+void shader_mem_lat_log(int logger_id, int latency);
+void shader_mem_lat_snapshot(int logger_id, unsigned long long current_cycle);
+void shader_mem_lat_print(FILE *fout);
 
 int get_shader_normal_cache_id();
 int get_shader_texture_cache_id();
 int get_shader_constant_cache_id();
 int get_shader_instruction_cache_id();
-void shader_cache_access_create( int n_loggers, int n_types, unsigned long long  logging_interval );
-void shader_cache_access_log( int logger_id, int type, int miss);
-void shader_cache_access_unlog( int logger_id, int type, int miss);
-void shader_cache_access_print( FILE *fout );
+void shader_cache_access_create(int n_loggers, int n_types,
+                                unsigned long long logging_interval);
+void shader_cache_access_log(int logger_id, int type, int miss);
+void shader_cache_access_unlog(int logger_id, int type, int miss);
+void shader_cache_access_print(FILE *fout);
 
-
-void shader_CTA_count_create( int n_shaders, unsigned long long  logging_interval);
-void shader_CTA_count_log( int shader_id, int nCTAadded );
-void shader_CTA_count_unlog( int shader_id, int nCTAdone );
-void shader_CTA_count_resetnow( );
-void shader_CTA_count_print( FILE *fout );
-void shader_CTA_count_visualizer_print( FILE *fout );
+void shader_CTA_count_create(int n_shaders,
+                             unsigned long long logging_interval);
+void shader_CTA_count_log(int shader_id, int nCTAadded);
+void shader_CTA_count_unlog(int shader_id, int nCTAdone);
+void shader_CTA_count_resetnow();
+void shader_CTA_count_print(FILE *fout);
+void shader_CTA_count_visualizer_print(FILE *fout);
 void shader_CTA_count_visualizer_gzprint(gzFile fout);
 
 #endif /* CFLOGGER_H */

--- a/src/gpgpu-sim/stat-tool.h
+++ b/src/gpgpu-sim/stat-tool.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -29,50 +31,54 @@
 #define STAT_TOOL_H
 
 #include "../abstract_hardware_model.h"
-#include "histogram.h"
 #include "../tr1_hash_map.h"
+#include "histogram.h"
 
 #include <stdio.h>
 #include <zlib.h>
 
 class gpgpu_context;
 /////////////////////////////////////////////////////////////////////////////////////
-// logger snapshot trigger: 
-// - automate the snap_shot part of loggers to avoid modifying simulation loop everytime 
+// logger snapshot trigger:
+// - automate the snap_shot part of loggers to avoid modifying simulation loop
+// everytime
 //   a new time-dependent stat is added
 /////////////////////////////////////////////////////////////////////////////////////
 
 class snap_shot_trigger {
-public:
-   snap_shot_trigger(unsigned long long  interval) : m_snap_shot_interval(interval) {}
-   virtual ~snap_shot_trigger() {}
-   
-   void try_snap_shot(unsigned long long  current_cycle) {
-      if ((current_cycle % m_snap_shot_interval == 0) && current_cycle != 0) {
-         snap_shot(current_cycle);
-      }
-   }
-   
-   virtual void snap_shot(unsigned long long  current_cycle) = 0;
+ public:
+  snap_shot_trigger(unsigned long long interval)
+      : m_snap_shot_interval(interval) {}
+  virtual ~snap_shot_trigger() {}
 
-   const unsigned long long & get_interval() const { return m_snap_shot_interval;}
+  void try_snap_shot(unsigned long long current_cycle) {
+    if ((current_cycle % m_snap_shot_interval == 0) && current_cycle != 0) {
+      snap_shot(current_cycle);
+    }
+  }
 
-protected:
-   unsigned long long  m_snap_shot_interval;
+  virtual void snap_shot(unsigned long long current_cycle) = 0;
+
+  const unsigned long long &get_interval() const {
+    return m_snap_shot_interval;
+  }
+
+ protected:
+  unsigned long long m_snap_shot_interval;
 };
 
-
 /////////////////////////////////////////////////////////////////////////////////////
-// spill log interface: 
-// - unified interface to spill log to file to avoid infinite memory usage for logging
+// spill log interface:
+// - unified interface to spill log to file to avoid infinite memory usage for
+// logging
 /////////////////////////////////////////////////////////////////////////////////////
 
 class spill_log_interface {
-public:
-   spill_log_interface() {}
-   virtual ~spill_log_interface() {}
-   
-   virtual void spill(FILE *fout, bool final) = 0;
+ public:
+  spill_log_interface() {}
+  virtual ~spill_log_interface() {}
+
+  virtual void spill(FILE *fout, bool final) = 0;
 };
 
 /////////////////////////////////////////////////////////////////////////////////////
@@ -80,51 +86,53 @@ public:
 /////////////////////////////////////////////////////////////////////////////////////
 
 class thread_insn_span {
-public:
-   thread_insn_span(unsigned long long  cycle, gpgpu_context* ctx);
-   thread_insn_span(const thread_insn_span& other, gpgpu_context* ctx);
-   ~thread_insn_span();
-   
-   thread_insn_span& operator=(const thread_insn_span& other);
-   thread_insn_span& operator+=(const thread_insn_span& other);
-   void set_span( address_type pc );
-   void reset(unsigned long long  cycle);
-   
-   void print_span(FILE *fout) const;
-   void print_histo(FILE *fout) const;
-   void print_sparse_histo(FILE *fout) const;
-   void print_sparse_histo(gzFile fout) const;
+ public:
+  thread_insn_span(unsigned long long cycle, gpgpu_context *ctx);
+  thread_insn_span(const thread_insn_span &other, gpgpu_context *ctx);
+  ~thread_insn_span();
 
-private:
-   gpgpu_context* gpgpu_ctx;
-   typedef tr1_hash_map<address_type, int> span_count_map;
-   unsigned long long  m_cycle;
-   span_count_map m_insn_span_count;
+  thread_insn_span &operator=(const thread_insn_span &other);
+  thread_insn_span &operator+=(const thread_insn_span &other);
+  void set_span(address_type pc);
+  void reset(unsigned long long cycle);
+
+  void print_span(FILE *fout) const;
+  void print_histo(FILE *fout) const;
+  void print_sparse_histo(FILE *fout) const;
+  void print_sparse_histo(gzFile fout) const;
+
+ private:
+  gpgpu_context *gpgpu_ctx;
+  typedef tr1_hash_map<address_type, int> span_count_map;
+  unsigned long long m_cycle;
+  span_count_map m_insn_span_count;
 };
 
 class thread_CFlocality : public snap_shot_trigger, public spill_log_interface {
-public:
-   thread_CFlocality(gpgpu_context* ctx, std::string name, unsigned long long  snap_shot_interval, 
-                     int nthreads, address_type start_pc, unsigned long long  start_cycle = 0);
-   ~thread_CFlocality();
-   
-   void update_thread_pc( int thread_id, address_type pc );
-   void snap_shot(unsigned long long  current_cycle);
-   void spill(FILE *fout, bool final);
-   
-   void print_visualizer(FILE *fout);
-   void print_visualizer(gzFile fout);
-   void print_span(FILE *fout) const;
-   void print_histo(FILE *fout) const;
-private:
-   std::string m_name;
+ public:
+  thread_CFlocality(gpgpu_context *ctx, std::string name,
+                    unsigned long long snap_shot_interval, int nthreads,
+                    address_type start_pc, unsigned long long start_cycle = 0);
+  ~thread_CFlocality();
 
-   int m_nthreads;
-   std::vector<address_type> m_thread_pc;
-   
-   unsigned long long  m_cycle;
-   thread_insn_span m_thd_span;
-   std::list<thread_insn_span> m_thd_span_archive;
+  void update_thread_pc(int thread_id, address_type pc);
+  void snap_shot(unsigned long long current_cycle);
+  void spill(FILE *fout, bool final);
+
+  void print_visualizer(FILE *fout);
+  void print_visualizer(gzFile fout);
+  void print_span(FILE *fout) const;
+  void print_histo(FILE *fout) const;
+
+ private:
+  std::string m_name;
+
+  int m_nthreads;
+  std::vector<address_type> m_thread_pc;
+
+  unsigned long long m_cycle;
+  thread_insn_span m_thd_span;
+  std::list<thread_insn_span> m_thd_span_archive;
 };
 
 /////////////////////////////////////////////////////////////////////////////////////
@@ -132,194 +140,188 @@ private:
 /////////////////////////////////////////////////////////////////////////////////////
 
 class insn_warp_occ_logger {
-public:
-   insn_warp_occ_logger(int simd_width)
-      : m_simd_width(simd_width), 
-        m_insn_warp_occ(1,linear_histogram(1, "", m_simd_width)),
+ public:
+  insn_warp_occ_logger(int simd_width)
+      : m_simd_width(simd_width),
+        m_insn_warp_occ(1, linear_histogram(1, "", m_simd_width)),
         m_id(s_ids++) {}
-   
-   insn_warp_occ_logger(const insn_warp_occ_logger& other)
-      : m_simd_width(other.m_simd_width), 
-        m_insn_warp_occ(other.m_insn_warp_occ.size(), linear_histogram(1, "", m_simd_width)),
+
+  insn_warp_occ_logger(const insn_warp_occ_logger &other)
+      : m_simd_width(other.m_simd_width),
+        m_insn_warp_occ(other.m_insn_warp_occ.size(),
+                        linear_histogram(1, "", m_simd_width)),
         m_id(s_ids++) {}
-   
-   ~insn_warp_occ_logger() {}
 
-   insn_warp_occ_logger& operator=(const insn_warp_occ_logger& p) {
-      printf("insn_warp_occ_logger Operator= called: %02d \n", m_id);
-      assert(0);
-      return *this;
-   }   
-   
-   void set_id(int id) { m_id = id; }
-   
-   void log(address_type pc, int warp_occ) {
-       if( pc >= m_insn_warp_occ.size() ) 
-           m_insn_warp_occ.resize(2*pc, linear_histogram(1, "", m_simd_width));
-       m_insn_warp_occ[pc].add2bin(warp_occ - 1);
-   }
-   
-   void print(FILE *fout) const 
-   {
-      for (unsigned i = 0; i < m_insn_warp_occ.size(); i++) {
-         fprintf(fout, "InsnWarpOcc%02d-%d", m_id, i);
-         m_insn_warp_occ[i].fprint(fout);
-         fprintf(fout, "\n");
-      }
-   }
+  ~insn_warp_occ_logger() {}
 
-private:
+  insn_warp_occ_logger &operator=(const insn_warp_occ_logger &p) {
+    printf("insn_warp_occ_logger Operator= called: %02d \n", m_id);
+    assert(0);
+    return *this;
+  }
 
-   int m_simd_width;
-   std::vector<linear_histogram> m_insn_warp_occ;
-   int m_id;
-   static int s_ids;
+  void set_id(int id) { m_id = id; }
+
+  void log(address_type pc, int warp_occ) {
+    if (pc >= m_insn_warp_occ.size())
+      m_insn_warp_occ.resize(2 * pc, linear_histogram(1, "", m_simd_width));
+    m_insn_warp_occ[pc].add2bin(warp_occ - 1);
+  }
+
+  void print(FILE *fout) const {
+    for (unsigned i = 0; i < m_insn_warp_occ.size(); i++) {
+      fprintf(fout, "InsnWarpOcc%02d-%d", m_id, i);
+      m_insn_warp_occ[i].fprint(fout);
+      fprintf(fout, "\n");
+    }
+  }
+
+ private:
+  int m_simd_width;
+  std::vector<linear_histogram> m_insn_warp_occ;
+  int m_id;
+  static int s_ids;
 };
-
 
 /////////////////////////////////////////////////////////////////////////////////////
 // generic linear histogram logger
 /////////////////////////////////////////////////////////////////////////////////////
 
 class linear_histogram_snapshot {
-public:
-   linear_histogram_snapshot(int n_bins, unsigned long long  cycle) 
-      : m_cycle(cycle), 
-        m_linear_histogram(n_bins,0) 
-   { }
-   
-   linear_histogram_snapshot(const linear_histogram_snapshot& other) 
-      : m_cycle(other.m_cycle), 
-        m_linear_histogram(other.m_linear_histogram)
-   { }
-   
-   ~linear_histogram_snapshot() { }
-   
-   void addsample(int pos) {
-      assert((size_t)pos < m_linear_histogram.size());
-      m_linear_histogram[pos] += 1;
-   }
-   
-   void subsample(int pos) {
-      assert((size_t)pos < m_linear_histogram.size());
-      m_linear_histogram[pos] -= 1;
-   }
-   
-   void reset(unsigned long long  cycle) {
-      m_cycle = cycle;
-      m_linear_histogram.assign(m_linear_histogram.size(), 0);
-   }
-   
-   void set_cycle(unsigned long long  cycle) { m_cycle = cycle; }
-   
-   void print(FILE *fout) const {
-      fprintf(fout, "%d = ", (int)m_cycle);
-      for (unsigned int i = 0; i < m_linear_histogram.size(); i++) {
-         fprintf(fout, "%d ", m_linear_histogram[i]);
-      }
-   }
+ public:
+  linear_histogram_snapshot(int n_bins, unsigned long long cycle)
+      : m_cycle(cycle), m_linear_histogram(n_bins, 0) {}
 
-   void print_visualizer(FILE *fout) const {
-      for (unsigned int i = 0; i < m_linear_histogram.size(); i++) {
-         fprintf(fout, "%d ", m_linear_histogram[i]);
-      }
-   }
+  linear_histogram_snapshot(const linear_histogram_snapshot &other)
+      : m_cycle(other.m_cycle), m_linear_histogram(other.m_linear_histogram) {}
 
-   void print_visualizer(gzFile fout) const {
-      for (unsigned int i = 0; i < m_linear_histogram.size(); i++) {
-         gzprintf(fout, "%d ", m_linear_histogram[i]);
-      }
-   }
+  ~linear_histogram_snapshot() {}
 
-private:
-   unsigned long long  m_cycle;
-   std::vector<int> m_linear_histogram;
+  void addsample(int pos) {
+    assert((size_t)pos < m_linear_histogram.size());
+    m_linear_histogram[pos] += 1;
+  }
+
+  void subsample(int pos) {
+    assert((size_t)pos < m_linear_histogram.size());
+    m_linear_histogram[pos] -= 1;
+  }
+
+  void reset(unsigned long long cycle) {
+    m_cycle = cycle;
+    m_linear_histogram.assign(m_linear_histogram.size(), 0);
+  }
+
+  void set_cycle(unsigned long long cycle) { m_cycle = cycle; }
+
+  void print(FILE *fout) const {
+    fprintf(fout, "%d = ", (int)m_cycle);
+    for (unsigned int i = 0; i < m_linear_histogram.size(); i++) {
+      fprintf(fout, "%d ", m_linear_histogram[i]);
+    }
+  }
+
+  void print_visualizer(FILE *fout) const {
+    for (unsigned int i = 0; i < m_linear_histogram.size(); i++) {
+      fprintf(fout, "%d ", m_linear_histogram[i]);
+    }
+  }
+
+  void print_visualizer(gzFile fout) const {
+    for (unsigned int i = 0; i < m_linear_histogram.size(); i++) {
+      gzprintf(fout, "%d ", m_linear_histogram[i]);
+    }
+  }
+
+ private:
+  unsigned long long m_cycle;
+  std::vector<int> m_linear_histogram;
 };
 
-class linear_histogram_logger : public snap_shot_trigger, public spill_log_interface {
-public:
-   linear_histogram_logger(int n_bins, 
-                           unsigned long long  snap_shot_interval, 
-                           const char *name, 
-                           bool reset_at_snap_shot = true, 
-                           unsigned long long  start_cycle = 0);
-   linear_histogram_logger(const linear_histogram_logger& other);
-   
-   ~linear_histogram_logger();
-   
-   void set_id(int id) { m_id = id; }
-   void log(int pos) { m_curr_lin_hist.addsample(pos); }
-   void unlog(int pos) { m_curr_lin_hist.subsample(pos); }
-   void snap_shot(unsigned long long  current_cycle);
-   void spill(FILE *fout, bool final); 
+class linear_histogram_logger : public snap_shot_trigger,
+                                public spill_log_interface {
+ public:
+  linear_histogram_logger(int n_bins, unsigned long long snap_shot_interval,
+                          const char *name, bool reset_at_snap_shot = true,
+                          unsigned long long start_cycle = 0);
+  linear_histogram_logger(const linear_histogram_logger &other);
 
-   void print(FILE *fout) const;
-   void print_visualizer(FILE *fout);
-   void print_visualizer(gzFile fout);
+  ~linear_histogram_logger();
 
-private:
-   int m_n_bins;
-   linear_histogram_snapshot m_curr_lin_hist;
-   std::list<linear_histogram_snapshot> m_lin_hist_archive;
-   unsigned long long  m_cycle;
-   bool m_reset_at_snap_shot;
-   std::string m_name;
-   int m_id;
-   static int s_ids;
+  void set_id(int id) { m_id = id; }
+  void log(int pos) { m_curr_lin_hist.addsample(pos); }
+  void unlog(int pos) { m_curr_lin_hist.subsample(pos); }
+  void snap_shot(unsigned long long current_cycle);
+  void spill(FILE *fout, bool final);
+
+  void print(FILE *fout) const;
+  void print_visualizer(FILE *fout);
+  void print_visualizer(gzFile fout);
+
+ private:
+  int m_n_bins;
+  linear_histogram_snapshot m_curr_lin_hist;
+  std::list<linear_histogram_snapshot> m_lin_hist_archive;
+  unsigned long long m_cycle;
+  bool m_reset_at_snap_shot;
+  std::string m_name;
+  int m_id;
+  static int s_ids;
 };
 
-void try_snap_shot (unsigned long long  current_cycle);
-void set_spill_interval (unsigned long long  interval);
-void spill_log_to_file (FILE *fout, int final, unsigned long long  current_cycle);
+void try_snap_shot(unsigned long long current_cycle);
+void set_spill_interval(unsigned long long interval);
+void spill_log_to_file(FILE *fout, int final, unsigned long long current_cycle);
 
-void create_thread_CFlogger(gpgpu_context* ctx,  int n_loggers, int n_threads, address_type start_pc, unsigned long long  logging_interval);
-void destroy_thread_CFlogger( );
-void cflog_update_thread_pc( int logger_id, int thread_id, address_type pc );
-void cflog_snapshot( int logger_id, unsigned long long  cycle );
+void create_thread_CFlogger(gpgpu_context *ctx, int n_loggers, int n_threads,
+                            address_type start_pc,
+                            unsigned long long logging_interval);
+void destroy_thread_CFlogger();
+void cflog_update_thread_pc(int logger_id, int thread_id, address_type pc);
+void cflog_snapshot(int logger_id, unsigned long long cycle);
 void cflog_print(FILE *fout);
 void cflog_print_path_expression(FILE *fout);
 void cflog_visualizer_print(FILE *fout);
 void cflog_visualizer_gzprint(gzFile fout);
 
-void insn_warp_occ_create( int n_loggers, int simd_width );
-void insn_warp_occ_log( int logger_id, address_type pc, int warp_occ );
-void insn_warp_occ_print( FILE *fout );
+void insn_warp_occ_create(int n_loggers, int simd_width);
+void insn_warp_occ_log(int logger_id, address_type pc, int warp_occ);
+void insn_warp_occ_print(FILE *fout);
 
+void shader_warp_occ_create(int n_loggers, int simd_width,
+                            unsigned long long logging_interval);
+void shader_warp_occ_log(int logger_id, int warp_occ);
+void shader_warp_occ_snapshot(int logger_id, unsigned long long current_cycle);
+void shader_warp_occ_print(FILE *fout);
 
-void shader_warp_occ_create( int n_loggers, int simd_width, unsigned long long  logging_interval );
-void shader_warp_occ_log( int logger_id, int warp_occ );
-void shader_warp_occ_snapshot( int logger_id, unsigned long long  current_cycle );
-void shader_warp_occ_print( FILE *fout );
+void shader_mem_acc_create(int n_loggers, int n_dram, int n_bank,
+                           unsigned long long logging_interval);
+void shader_mem_acc_log(int logger_id, int dram_id, int bank, char rw);
+void shader_mem_acc_snapshot(int logger_id, unsigned long long current_cycle);
+void shader_mem_acc_print(FILE *fout);
 
-
-void shader_mem_acc_create( int n_loggers, int n_dram, int n_bank, unsigned long long  logging_interval );
-void shader_mem_acc_log( int logger_id, int dram_id, int bank, char rw );
-void shader_mem_acc_snapshot( int logger_id, unsigned long long  current_cycle );
-void shader_mem_acc_print( FILE *fout );
-
-
-void shader_mem_lat_create( int n_loggers, unsigned long long  logging_interval );
-void shader_mem_lat_log( int logger_id, int latency );
-void shader_mem_lat_snapshot( int logger_id, unsigned long long  current_cycle );
-void shader_mem_lat_print( FILE *fout );
-
+void shader_mem_lat_create(int n_loggers, unsigned long long logging_interval);
+void shader_mem_lat_log(int logger_id, int latency);
+void shader_mem_lat_snapshot(int logger_id, unsigned long long current_cycle);
+void shader_mem_lat_print(FILE *fout);
 
 int get_shader_normal_cache_id();
 int get_shader_texture_cache_id();
 int get_shader_constant_cache_id();
 int get_shader_instruction_cache_id();
-void shader_cache_access_create( int n_loggers, int n_types, unsigned long long  logging_interval );
-void shader_cache_access_log( int logger_id, int type, int miss);
-void shader_cache_access_unlog( int logger_id, int type, int miss);
-void shader_cache_access_print( FILE *fout );
+void shader_cache_access_create(int n_loggers, int n_types,
+                                unsigned long long logging_interval);
+void shader_cache_access_log(int logger_id, int type, int miss);
+void shader_cache_access_unlog(int logger_id, int type, int miss);
+void shader_cache_access_print(FILE *fout);
 
-
-void shader_CTA_count_create( int n_shaders, unsigned long long  logging_interval);
-void shader_CTA_count_log( int shader_id, int nCTAadded );
-void shader_CTA_count_unlog( int shader_id, int nCTAdone );
-void shader_CTA_count_resetnow( );
-void shader_CTA_count_print( FILE *fout );
-void shader_CTA_count_visualizer_print( FILE *fout );
+void shader_CTA_count_create(int n_shaders,
+                             unsigned long long logging_interval);
+void shader_CTA_count_log(int shader_id, int nCTAadded);
+void shader_CTA_count_unlog(int shader_id, int nCTAdone);
+void shader_CTA_count_resetnow();
+void shader_CTA_count_print(FILE *fout);
+void shader_CTA_count_visualizer_print(FILE *fout);
 void shader_CTA_count_visualizer_gzprint(gzFile fout);
 
 #endif /* CFLOGGER_H */

--- a/src/gpgpu-sim/stats.h
+++ b/src/gpgpu-sim/stats.h
@@ -7,54 +7,50 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef STATS_INCLUDED
 #define STATS_INCLUDED
 
 enum mem_stage_access_type {
-   C_MEM,
-   T_MEM,
-   S_MEM,
-   G_MEM_LD,
-   L_MEM_LD,
-   G_MEM_ST,
-   L_MEM_ST,
-   N_MEM_STAGE_ACCESS_TYPE
+  C_MEM,
+  T_MEM,
+  S_MEM,
+  G_MEM_LD,
+  L_MEM_LD,
+  G_MEM_ST,
+  L_MEM_ST,
+  N_MEM_STAGE_ACCESS_TYPE
 };
-enum tlb_request_status {
-	TLB_HIT = 0,
-	TLB_READY,
-	TLB_PENDING
-};
+enum tlb_request_status { TLB_HIT = 0, TLB_READY, TLB_PENDING };
 enum mem_stage_stall_type {
-   NO_RC_FAIL = 0, 
-   BK_CONF,
-   MSHR_RC_FAIL,
-   ICNT_RC_FAIL,
-   COAL_STALL,
-   TLB_STALL,
-   DATA_PORT_STALL,
-   WB_ICNT_RC_FAIL,
-   WB_CACHE_RSRV_FAIL,
-   N_MEM_STAGE_STALL_TYPE
+  NO_RC_FAIL = 0,
+  BK_CONF,
+  MSHR_RC_FAIL,
+  ICNT_RC_FAIL,
+  COAL_STALL,
+  TLB_STALL,
+  DATA_PORT_STALL,
+  WB_ICNT_RC_FAIL,
+  WB_CACHE_RSRV_FAIL,
+  N_MEM_STAGE_STALL_TYPE
 };
-
 
 #endif

--- a/src/gpgpu-sim/stats.h
+++ b/src/gpgpu-sim/stats.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -29,32 +31,27 @@
 #define STATS_INCLUDED
 
 enum mem_stage_access_type {
-   C_MEM,
-   T_MEM,
-   S_MEM,
-   G_MEM_LD,
-   L_MEM_LD,
-   G_MEM_ST,
-   L_MEM_ST,
-   N_MEM_STAGE_ACCESS_TYPE
+  C_MEM,
+  T_MEM,
+  S_MEM,
+  G_MEM_LD,
+  L_MEM_LD,
+  G_MEM_ST,
+  L_MEM_ST,
+  N_MEM_STAGE_ACCESS_TYPE
 };
-enum tlb_request_status {
-	TLB_HIT = 0,
-	TLB_READY,
-	TLB_PENDING
-};
+enum tlb_request_status { TLB_HIT = 0, TLB_READY, TLB_PENDING };
 enum mem_stage_stall_type {
-   NO_RC_FAIL = 0, 
-   BK_CONF,
-   MSHR_RC_FAIL,
-   ICNT_RC_FAIL,
-   COAL_STALL,
-   TLB_STALL,
-   DATA_PORT_STALL,
-   WB_ICNT_RC_FAIL,
-   WB_CACHE_RSRV_FAIL,
-   N_MEM_STAGE_STALL_TYPE
+  NO_RC_FAIL = 0,
+  BK_CONF,
+  MSHR_RC_FAIL,
+  ICNT_RC_FAIL,
+  COAL_STALL,
+  TLB_STALL,
+  DATA_PORT_STALL,
+  WB_ICNT_RC_FAIL,
+  WB_CACHE_RSRV_FAIL,
+  N_MEM_STAGE_STALL_TYPE
 };
-
 
 #endif

--- a/src/gpgpu-sim/stats.h
+++ b/src/gpgpu-sim/stats.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -31,27 +29,32 @@
 #define STATS_INCLUDED
 
 enum mem_stage_access_type {
-  C_MEM,
-  T_MEM,
-  S_MEM,
-  G_MEM_LD,
-  L_MEM_LD,
-  G_MEM_ST,
-  L_MEM_ST,
-  N_MEM_STAGE_ACCESS_TYPE
+   C_MEM,
+   T_MEM,
+   S_MEM,
+   G_MEM_LD,
+   L_MEM_LD,
+   G_MEM_ST,
+   L_MEM_ST,
+   N_MEM_STAGE_ACCESS_TYPE
 };
-enum tlb_request_status { TLB_HIT = 0, TLB_READY, TLB_PENDING };
+enum tlb_request_status {
+	TLB_HIT = 0,
+	TLB_READY,
+	TLB_PENDING
+};
 enum mem_stage_stall_type {
-  NO_RC_FAIL = 0,
-  BK_CONF,
-  MSHR_RC_FAIL,
-  ICNT_RC_FAIL,
-  COAL_STALL,
-  TLB_STALL,
-  DATA_PORT_STALL,
-  WB_ICNT_RC_FAIL,
-  WB_CACHE_RSRV_FAIL,
-  N_MEM_STAGE_STALL_TYPE
+   NO_RC_FAIL = 0, 
+   BK_CONF,
+   MSHR_RC_FAIL,
+   ICNT_RC_FAIL,
+   COAL_STALL,
+   TLB_STALL,
+   DATA_PORT_STALL,
+   WB_ICNT_RC_FAIL,
+   WB_CACHE_RSRV_FAIL,
+   N_MEM_STAGE_STALL_TYPE
 };
+
 
 #endif

--- a/src/gpgpu-sim/traffic_breakdown.cc
+++ b/src/gpgpu-sim/traffic_breakdown.cc
@@ -1,51 +1,54 @@
-#include "traffic_breakdown.h" 
-#include "mem_fetch.h" 
+#include "traffic_breakdown.h"
+#include "mem_fetch.h"
 
-void traffic_breakdown::print(FILE* fout)
-{
-   for (traffic_stat_t::const_iterator i_stat = m_stats.begin(); i_stat != m_stats.end(); i_stat++) {
-      unsigned int byte_transferred = 0; 
-      for (traffic_class_t::const_iterator i_class = i_stat->second.begin(); i_class != i_stat->second.end(); i_class++) {
-         byte_transferred += i_class->first * i_class->second;  // byte/packet x #packets
-      }
-      fprintf(fout, "traffic_breakdown_%s[%s] = %u {", m_network_name.c_str(), i_stat->first.c_str(), byte_transferred);  
-      for (traffic_class_t::const_iterator i_class = i_stat->second.begin(); i_class != i_stat->second.end(); i_class++) {
-         fprintf(fout, "%u:%u,", i_class->first, i_class->second); 
-      }
-      fprintf(fout, "}\n"); 
-   }
+void traffic_breakdown::print(FILE* fout) {
+  for (traffic_stat_t::const_iterator i_stat = m_stats.begin();
+       i_stat != m_stats.end(); i_stat++) {
+    unsigned int byte_transferred = 0;
+    for (traffic_class_t::const_iterator i_class = i_stat->second.begin();
+         i_class != i_stat->second.end(); i_class++) {
+      byte_transferred +=
+          i_class->first * i_class->second;  // byte/packet x #packets
+    }
+    fprintf(fout, "traffic_breakdown_%s[%s] = %u {", m_network_name.c_str(),
+            i_stat->first.c_str(), byte_transferred);
+    for (traffic_class_t::const_iterator i_class = i_stat->second.begin();
+         i_class != i_stat->second.end(); i_class++) {
+      fprintf(fout, "%u:%u,", i_class->first, i_class->second);
+    }
+    fprintf(fout, "}\n");
+  }
 }
 
-void traffic_breakdown::record_traffic(class mem_fetch * mf, unsigned int size) 
-{
-   m_stats[classify_memfetch(mf)][size] += 1; 
+void traffic_breakdown::record_traffic(class mem_fetch* mf, unsigned int size) {
+  m_stats[classify_memfetch(mf)][size] += 1;
 }
 
-std::string traffic_breakdown::classify_memfetch(class mem_fetch * mf)
-{
-   std::string traffic_name; 
+std::string traffic_breakdown::classify_memfetch(class mem_fetch* mf) {
+  std::string traffic_name;
 
-   enum mem_access_type access_type = mf->get_access_type(); 
+  enum mem_access_type access_type = mf->get_access_type();
 
-   switch (access_type) {
-   case CONST_ACC_R:    
-   case TEXTURE_ACC_R:   
-   case GLOBAL_ACC_W:   
-   case LOCAL_ACC_R:    
-   case LOCAL_ACC_W:    
-   case INST_ACC_R:     
-   case L1_WRBK_ACC:    
-   case L2_WRBK_ACC:    
-   case L1_WR_ALLOC_R:  
-   case L2_WR_ALLOC_R:  
-      traffic_name = mem_access_type_str(access_type); 
-      break; 
-   case GLOBAL_ACC_R:   
-      // check for global atomic operation 
-      traffic_name = (mf->isatomic())? "GLOBAL_ATOMIC" : mem_access_type_str(GLOBAL_ACC_R); 
-      break; 
-   default: assert(0 && "Unknown traffic type"); 
-   }
-   return traffic_name; 
+  switch (access_type) {
+    case CONST_ACC_R:
+    case TEXTURE_ACC_R:
+    case GLOBAL_ACC_W:
+    case LOCAL_ACC_R:
+    case LOCAL_ACC_W:
+    case INST_ACC_R:
+    case L1_WRBK_ACC:
+    case L2_WRBK_ACC:
+    case L1_WR_ALLOC_R:
+    case L2_WR_ALLOC_R:
+      traffic_name = mem_access_type_str(access_type);
+      break;
+    case GLOBAL_ACC_R:
+      // check for global atomic operation
+      traffic_name = (mf->isatomic()) ? "GLOBAL_ATOMIC"
+                                      : mem_access_type_str(GLOBAL_ACC_R);
+      break;
+    default:
+      assert(0 && "Unknown traffic type");
+  }
+  return traffic_name;
 }
-

--- a/src/gpgpu-sim/traffic_breakdown.cc
+++ b/src/gpgpu-sim/traffic_breakdown.cc
@@ -1,54 +1,51 @@
-#include "traffic_breakdown.h"
-#include "mem_fetch.h"
+#include "traffic_breakdown.h" 
+#include "mem_fetch.h" 
 
-void traffic_breakdown::print(FILE* fout) {
-  for (traffic_stat_t::const_iterator i_stat = m_stats.begin();
-       i_stat != m_stats.end(); i_stat++) {
-    unsigned int byte_transferred = 0;
-    for (traffic_class_t::const_iterator i_class = i_stat->second.begin();
-         i_class != i_stat->second.end(); i_class++) {
-      byte_transferred +=
-          i_class->first * i_class->second;  // byte/packet x #packets
-    }
-    fprintf(fout, "traffic_breakdown_%s[%s] = %u {", m_network_name.c_str(),
-            i_stat->first.c_str(), byte_transferred);
-    for (traffic_class_t::const_iterator i_class = i_stat->second.begin();
-         i_class != i_stat->second.end(); i_class++) {
-      fprintf(fout, "%u:%u,", i_class->first, i_class->second);
-    }
-    fprintf(fout, "}\n");
-  }
+void traffic_breakdown::print(FILE* fout)
+{
+   for (traffic_stat_t::const_iterator i_stat = m_stats.begin(); i_stat != m_stats.end(); i_stat++) {
+      unsigned int byte_transferred = 0; 
+      for (traffic_class_t::const_iterator i_class = i_stat->second.begin(); i_class != i_stat->second.end(); i_class++) {
+         byte_transferred += i_class->first * i_class->second;  // byte/packet x #packets
+      }
+      fprintf(fout, "traffic_breakdown_%s[%s] = %u {", m_network_name.c_str(), i_stat->first.c_str(), byte_transferred);  
+      for (traffic_class_t::const_iterator i_class = i_stat->second.begin(); i_class != i_stat->second.end(); i_class++) {
+         fprintf(fout, "%u:%u,", i_class->first, i_class->second); 
+      }
+      fprintf(fout, "}\n"); 
+   }
 }
 
-void traffic_breakdown::record_traffic(class mem_fetch* mf, unsigned int size) {
-  m_stats[classify_memfetch(mf)][size] += 1;
+void traffic_breakdown::record_traffic(class mem_fetch * mf, unsigned int size) 
+{
+   m_stats[classify_memfetch(mf)][size] += 1; 
 }
 
-std::string traffic_breakdown::classify_memfetch(class mem_fetch* mf) {
-  std::string traffic_name;
+std::string traffic_breakdown::classify_memfetch(class mem_fetch * mf)
+{
+   std::string traffic_name; 
 
-  enum mem_access_type access_type = mf->get_access_type();
+   enum mem_access_type access_type = mf->get_access_type(); 
 
-  switch (access_type) {
-    case CONST_ACC_R:
-    case TEXTURE_ACC_R:
-    case GLOBAL_ACC_W:
-    case LOCAL_ACC_R:
-    case LOCAL_ACC_W:
-    case INST_ACC_R:
-    case L1_WRBK_ACC:
-    case L2_WRBK_ACC:
-    case L1_WR_ALLOC_R:
-    case L2_WR_ALLOC_R:
-      traffic_name = mem_access_type_str(access_type);
-      break;
-    case GLOBAL_ACC_R:
-      // check for global atomic operation
-      traffic_name = (mf->isatomic()) ? "GLOBAL_ATOMIC"
-                                      : mem_access_type_str(GLOBAL_ACC_R);
-      break;
-    default:
-      assert(0 && "Unknown traffic type");
-  }
-  return traffic_name;
+   switch (access_type) {
+   case CONST_ACC_R:    
+   case TEXTURE_ACC_R:   
+   case GLOBAL_ACC_W:   
+   case LOCAL_ACC_R:    
+   case LOCAL_ACC_W:    
+   case INST_ACC_R:     
+   case L1_WRBK_ACC:    
+   case L2_WRBK_ACC:    
+   case L1_WR_ALLOC_R:  
+   case L2_WR_ALLOC_R:  
+      traffic_name = mem_access_type_str(access_type); 
+      break; 
+   case GLOBAL_ACC_R:   
+      // check for global atomic operation 
+      traffic_name = (mf->isatomic())? "GLOBAL_ATOMIC" : mem_access_type_str(GLOBAL_ACC_R); 
+      break; 
+   default: assert(0 && "Unknown traffic type"); 
+   }
+   return traffic_name; 
 }
+

--- a/src/gpgpu-sim/traffic_breakdown.h
+++ b/src/gpgpu-sim/traffic_breakdown.h
@@ -1,37 +1,35 @@
-#pragma once 
+#pragma once
 
 #include <stdio.h>
 #include <map>
-#include <string> 
+#include <string>
 
 // Breakdown traffic through the network according to category
-class traffic_breakdown
-{
-public: 
-   traffic_breakdown(const std::string &network_name) 
-   : m_network_name(network_name) 
-   { }
+class traffic_breakdown {
+ public:
+  traffic_breakdown(const std::string& network_name)
+      : m_network_name(network_name) {}
 
-   // print the stats 
-   void print(FILE* fout); 
+  // print the stats
+  void print(FILE* fout);
 
-   // record the amount and type of traffic introduced by this mem_fetch object 
-   void record_traffic(class mem_fetch * mf, unsigned int size); 
+  // record the amount and type of traffic introduced by this mem_fetch object
+  void record_traffic(class mem_fetch* mf, unsigned int size);
 
-protected:
+ protected:
+  std::string m_network_name;
 
-   std::string m_network_name; 
+  /// helper functions to identify the type of traffic sent
+  std::string classify_memfetch(class mem_fetch* mf);
 
-   /// helper functions to identify the type of traffic sent 
-   std::string classify_memfetch(class mem_fetch * mf); 
+  /// helper functions to identify the size of traffic sent
+  unsigned int packet_size(class mem_fetch* mf);
 
-   /// helper functions to identify the size of traffic sent 
-   unsigned int packet_size(class mem_fetch * mf); 
+  typedef std::string
+      mf_packet_type;  // use string so that it remains extensible
+  typedef unsigned int mf_packet_size;
+  typedef std::map<mf_packet_size, unsigned int> traffic_class_t;
+  typedef std::map<mf_packet_type, traffic_class_t> traffic_stat_t;
 
-   typedef std::string mf_packet_type;  // use string so that it remains extensible 
-   typedef unsigned int mf_packet_size; 
-   typedef std::map < mf_packet_size, unsigned int > traffic_class_t; 
-   typedef std::map < mf_packet_type, traffic_class_t > traffic_stat_t; 
-
-   traffic_stat_t m_stats; 
-}; 
+  traffic_stat_t m_stats;
+};

--- a/src/gpgpu-sim/traffic_breakdown.h
+++ b/src/gpgpu-sim/traffic_breakdown.h
@@ -1,35 +1,37 @@
-#pragma once
+#pragma once 
 
 #include <stdio.h>
 #include <map>
-#include <string>
+#include <string> 
 
 // Breakdown traffic through the network according to category
-class traffic_breakdown {
- public:
-  traffic_breakdown(const std::string& network_name)
-      : m_network_name(network_name) {}
+class traffic_breakdown
+{
+public: 
+   traffic_breakdown(const std::string &network_name) 
+   : m_network_name(network_name) 
+   { }
 
-  // print the stats
-  void print(FILE* fout);
+   // print the stats 
+   void print(FILE* fout); 
 
-  // record the amount and type of traffic introduced by this mem_fetch object
-  void record_traffic(class mem_fetch* mf, unsigned int size);
+   // record the amount and type of traffic introduced by this mem_fetch object 
+   void record_traffic(class mem_fetch * mf, unsigned int size); 
 
- protected:
-  std::string m_network_name;
+protected:
 
-  /// helper functions to identify the type of traffic sent
-  std::string classify_memfetch(class mem_fetch* mf);
+   std::string m_network_name; 
 
-  /// helper functions to identify the size of traffic sent
-  unsigned int packet_size(class mem_fetch* mf);
+   /// helper functions to identify the type of traffic sent 
+   std::string classify_memfetch(class mem_fetch * mf); 
 
-  typedef std::string
-      mf_packet_type;  // use string so that it remains extensible
-  typedef unsigned int mf_packet_size;
-  typedef std::map<mf_packet_size, unsigned int> traffic_class_t;
-  typedef std::map<mf_packet_type, traffic_class_t> traffic_stat_t;
+   /// helper functions to identify the size of traffic sent 
+   unsigned int packet_size(class mem_fetch * mf); 
 
-  traffic_stat_t m_stats;
-};
+   typedef std::string mf_packet_type;  // use string so that it remains extensible 
+   typedef unsigned int mf_packet_size; 
+   typedef std::map < mf_packet_size, unsigned int > traffic_class_t; 
+   typedef std::map < mf_packet_type, traffic_class_t > traffic_stat_t; 
+
+   traffic_stat_t m_stats; 
+}; 

--- a/src/gpgpu-sim/visualizer.cc
+++ b/src/gpgpu-sim/visualizer.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2011, Tor M. Aamodt, Wilson W.L. Fung, 
+// Copyright (c) 2009-2011, Tor M. Aamodt, Wilson W.L. Fung,
 // The University of British Columbia
 // All rights reserved.
 //
@@ -7,378 +7,384 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #include "visualizer.h"
 
+#include "../option_parser.h"
 #include "gpu-sim.h"
 #include "l2cache.h"
-#include "shader.h"
-#include "../option_parser.h"
 #include "mem_latency_stat.h"
 #include "power_stat.h"
+#include "shader.h"
 //#include "../../../mcpat/processor.h"
-#include "stat-tool.h"
 #include "gpu-cache.h"
+#include "stat-tool.h"
 
-#include <time.h>
 #include <string.h>
+#include <time.h>
 #include <zlib.h>
 
 static void time_vector_print_interval2gzfile(gzFile outfile);
 
-void gpgpu_sim::visualizer_printstat()
-{
-   gzFile visualizer_file = NULL; // gzFile is basically a pointer to a struct, so it is fine to initialize it as NULL
-   if ( !m_config.g_visualizer_enabled )
-      return;
+void gpgpu_sim::visualizer_printstat() {
+  gzFile visualizer_file = NULL;  // gzFile is basically a pointer to a struct,
+                                  // so it is fine to initialize it as NULL
+  if (!m_config.g_visualizer_enabled) return;
 
-   // clean the content of the visualizer log if it is the first time, otherwise attach at the end
-   static bool visualizer_first_printstat = true;
+  // clean the content of the visualizer log if it is the first time, otherwise
+  // attach at the end
+  static bool visualizer_first_printstat = true;
 
-   visualizer_file = gzopen(m_config.g_visualizer_filename, (visualizer_first_printstat)? "w" : "a");
-   if (visualizer_file == NULL) {
-      printf("error - could not open visualizer trace file.\n");
-      exit(1);
-   }
-   gzsetparams(visualizer_file, m_config.g_visualizer_zlevel, Z_DEFAULT_STRATEGY);
-   visualizer_first_printstat = false;
-   
-   cflog_visualizer_gzprint(visualizer_file);
-   shader_CTA_count_visualizer_gzprint(visualizer_file);
+  visualizer_file = gzopen(m_config.g_visualizer_filename,
+                           (visualizer_first_printstat) ? "w" : "a");
+  if (visualizer_file == NULL) {
+    printf("error - could not open visualizer trace file.\n");
+    exit(1);
+  }
+  gzsetparams(visualizer_file, m_config.g_visualizer_zlevel,
+              Z_DEFAULT_STRATEGY);
+  visualizer_first_printstat = false;
 
-   for (unsigned i=0;i<m_memory_config->m_n_mem;i++) 
-      m_memory_partition_unit[i]->visualizer_print(visualizer_file);
-   m_shader_stats->visualizer_print(visualizer_file);
-   m_memory_stats->visualizer_print(visualizer_file);
-   m_power_stats->visualizer_print(visualizer_file);
-   //proc->visualizer_print(visualizer_file);
-   // other parameters for graphing
-   gzprintf(visualizer_file, "globalcyclecount: %lld\n", gpu_sim_cycle);
-   gzprintf(visualizer_file, "globalinsncount: %lld\n", gpu_sim_insn);
-   gzprintf(visualizer_file, "globaltotinsncount: %lld\n", gpu_tot_sim_insn);
+  cflog_visualizer_gzprint(visualizer_file);
+  shader_CTA_count_visualizer_gzprint(visualizer_file);
 
-   time_vector_print_interval2gzfile(visualizer_file);
+  for (unsigned i = 0; i < m_memory_config->m_n_mem; i++)
+    m_memory_partition_unit[i]->visualizer_print(visualizer_file);
+  m_shader_stats->visualizer_print(visualizer_file);
+  m_memory_stats->visualizer_print(visualizer_file);
+  m_power_stats->visualizer_print(visualizer_file);
+  // proc->visualizer_print(visualizer_file);
+  // other parameters for graphing
+  gzprintf(visualizer_file, "globalcyclecount: %lld\n", gpu_sim_cycle);
+  gzprintf(visualizer_file, "globalinsncount: %lld\n", gpu_sim_insn);
+  gzprintf(visualizer_file, "globaltotinsncount: %lld\n", gpu_tot_sim_insn);
 
-   gzclose(visualizer_file);
-/*
-   gzprintf(visualizer_file, "CacheMissRate_GlobalLocalL1_All: ");
-   for (unsigned i=0;i<m_n_shader;i++) 
-      gzprintf(visualizer_file, "%0.4f ", m_sc[i]->L1_windowed_cache_miss_rate(0));
-   gzprintf(visualizer_file, "\n");
-   gzprintf(visualizer_file, "CacheMissRate_TextureL1_All: ");
-   for (unsigned i=0;i<m_n_shader;i++) 
-      gzprintf(visualizer_file, "%0.4f ", m_sc[i]->L1tex_windowed_cache_miss_rate(0));
-   gzprintf(visualizer_file, "\n");
-   gzprintf(visualizer_file, "CacheMissRate_ConstL1_All: ");
-   for (unsigned i=0;i<m_n_shader;i++) 
-      gzprintf(visualizer_file, "%0.4f ", m_sc[i]->L1const_windowed_cache_miss_rate(0));
-   gzprintf(visualizer_file, "\n");
-   gzprintf(visualizer_file, "CacheMissRate_GlobalLocalL1_noMgHt: ");
-   for (unsigned i=0;i<m_n_shader;i++) 
-      gzprintf(visualizer_file, "%0.4f ", m_sc[i]->L1_windowed_cache_miss_rate(1));
-   gzprintf(visualizer_file, "\n");
-   gzprintf(visualizer_file, "CacheMissRate_TextureL1_noMgHt: ");
-   for (unsigned i=0;i<m_n_shader;i++) 
-      gzprintf(visualizer_file, "%0.4f ", m_sc[i]->L1tex_windowed_cache_miss_rate(1));
-   gzprintf(visualizer_file, "\n");
-   gzprintf(visualizer_file, "CacheMissRate_ConstL1_noMgHt: ");
-   for (unsigned i=0;i<m_n_shader;i++) 
-      gzprintf(visualizer_file, "%0.4f ", m_sc[i]->L1const_windowed_cache_miss_rate(1));
-   gzprintf(visualizer_file, "\n");
-   // reset for next interval
-   for (unsigned i=0;i<m_n_shader;i++) 
-      m_sc[i]->new_cache_window();
-*/
+  time_vector_print_interval2gzfile(visualizer_file);
+
+  gzclose(visualizer_file);
+  /*
+     gzprintf(visualizer_file, "CacheMissRate_GlobalLocalL1_All: ");
+     for (unsigned i=0;i<m_n_shader;i++)
+        gzprintf(visualizer_file, "%0.4f ",
+     m_sc[i]->L1_windowed_cache_miss_rate(0)); gzprintf(visualizer_file, "\n");
+     gzprintf(visualizer_file, "CacheMissRate_TextureL1_All: ");
+     for (unsigned i=0;i<m_n_shader;i++)
+        gzprintf(visualizer_file, "%0.4f ",
+     m_sc[i]->L1tex_windowed_cache_miss_rate(0)); gzprintf(visualizer_file,
+     "\n"); gzprintf(visualizer_file, "CacheMissRate_ConstL1_All: "); for
+     (unsigned i=0;i<m_n_shader;i++) gzprintf(visualizer_file, "%0.4f ",
+     m_sc[i]->L1const_windowed_cache_miss_rate(0)); gzprintf(visualizer_file,
+     "\n"); gzprintf(visualizer_file, "CacheMissRate_GlobalLocalL1_noMgHt: ");
+     for (unsigned i=0;i<m_n_shader;i++)
+        gzprintf(visualizer_file, "%0.4f ",
+     m_sc[i]->L1_windowed_cache_miss_rate(1)); gzprintf(visualizer_file, "\n");
+     gzprintf(visualizer_file, "CacheMissRate_TextureL1_noMgHt: ");
+     for (unsigned i=0;i<m_n_shader;i++)
+        gzprintf(visualizer_file, "%0.4f ",
+     m_sc[i]->L1tex_windowed_cache_miss_rate(1)); gzprintf(visualizer_file,
+     "\n"); gzprintf(visualizer_file, "CacheMissRate_ConstL1_noMgHt: "); for
+     (unsigned i=0;i<m_n_shader;i++) gzprintf(visualizer_file, "%0.4f ",
+     m_sc[i]->L1const_windowed_cache_miss_rate(1)); gzprintf(visualizer_file,
+     "\n");
+     // reset for next interval
+     for (unsigned i=0;i<m_n_shader;i++)
+        m_sc[i]->new_cache_window();
+  */
 }
 
-#include <list>
-#include <vector>
 #include <iostream>
+#include <list>
 #include <map>
-#include"../gpgpu-sim/shader.h"
+#include <vector>
+#include "../gpgpu-sim/shader.h"
 class my_time_vector {
-private:
-   std::map< unsigned int, std::vector<long int> > ld_time_map;
-   std::map< unsigned int, std::vector<long int> > st_time_map;
-   unsigned ld_vector_size;
-   unsigned st_vector_size;
-   std::vector<double>  ld_time_dist;
-   std::vector<double>  st_time_dist;
+ private:
+  std::map<unsigned int, std::vector<long int> > ld_time_map;
+  std::map<unsigned int, std::vector<long int> > st_time_map;
+  unsigned ld_vector_size;
+  unsigned st_vector_size;
+  std::vector<double> ld_time_dist;
+  std::vector<double> st_time_dist;
 
-   std::vector<double>  overal_ld_time_dist;
-   std::vector<double>  overal_st_time_dist;
-   int overal_ld_count;
-   int overal_st_count;
+  std::vector<double> overal_ld_time_dist;
+  std::vector<double> overal_st_time_dist;
+  int overal_ld_count;
+  int overal_st_count;
 
-public:
-   my_time_vector(int ld_size,int st_size){
-      ld_vector_size = ld_size;
-      st_vector_size = st_size;
-      ld_time_dist.resize(ld_size);
-      st_time_dist.resize(st_size);
-      overal_ld_time_dist.resize(ld_size);
-      overal_st_time_dist.resize(st_size);
-      overal_ld_count = 0;
-      overal_st_count= 0;
-   }
-   void update_ld(unsigned int uid,unsigned int slot, long int time) { 
-      if ( ld_time_map.find( uid )!=ld_time_map.end() ) {
-         ld_time_map[uid][slot]=time;
-      } else if (slot < NUM_MEM_REQ_STAT ) {
-         std::vector<long int> time_vec;
-         time_vec.resize(ld_vector_size);
-         time_vec[slot] = time;
-         ld_time_map[uid] = time_vec;  
-      } else {
-         //It's a merged mshr! forget it
+ public:
+  my_time_vector(int ld_size, int st_size) {
+    ld_vector_size = ld_size;
+    st_vector_size = st_size;
+    ld_time_dist.resize(ld_size);
+    st_time_dist.resize(st_size);
+    overal_ld_time_dist.resize(ld_size);
+    overal_st_time_dist.resize(st_size);
+    overal_ld_count = 0;
+    overal_st_count = 0;
+  }
+  void update_ld(unsigned int uid, unsigned int slot, long int time) {
+    if (ld_time_map.find(uid) != ld_time_map.end()) {
+      ld_time_map[uid][slot] = time;
+    } else if (slot < NUM_MEM_REQ_STAT) {
+      std::vector<long int> time_vec;
+      time_vec.resize(ld_vector_size);
+      time_vec[slot] = time;
+      ld_time_map[uid] = time_vec;
+    } else {
+      // It's a merged mshr! forget it
+    }
+  }
+  void update_st(unsigned int uid, unsigned int slot, long int time) {
+    if (st_time_map.find(uid) != st_time_map.end()) {
+      st_time_map[uid][slot] = time;
+    } else {
+      std::vector<long int> time_vec;
+      time_vec.resize(st_vector_size);
+      time_vec[slot] = time;
+      st_time_map[uid] = time_vec;
+    }
+  }
+  void check_ld_update(unsigned int uid, unsigned int slot, long int latency) {
+    if (ld_time_map.find(uid) != ld_time_map.end()) {
+      int our_latency =
+          ld_time_map[uid][slot] - ld_time_map[uid][IN_ICNT_TO_MEM];
+      assert(our_latency == latency);
+    } else if (slot < NUM_MEM_REQ_STAT) {
+      abort();
+    }
+  }
+  void check_st_update(unsigned int uid, unsigned int slot, long int latency) {
+    if (st_time_map.find(uid) != st_time_map.end()) {
+      int our_latency =
+          st_time_map[uid][slot] - st_time_map[uid][IN_ICNT_TO_MEM];
+      assert(our_latency == latency);
+    } else {
+      abort();
+    }
+  }
+
+ private:
+  void calculate_ld_dist(void) {
+    unsigned i, first;
+    long int last_update, diff;
+    int finished_count = 0;
+    ld_time_dist.clear();
+    ld_time_dist.resize(ld_vector_size);
+    std::map<unsigned int, std::vector<long int> >::iterator iter, iter_temp;
+    iter = ld_time_map.begin();
+    while (iter != ld_time_map.end()) {
+      last_update = 0;
+      first = -1;
+      if (!iter->second[IN_SHADER_FETCHED]) {
+        // this request is not done yet skip it!
+        ++iter;
+        continue;
       }
-   }
-   void update_st(unsigned int uid,unsigned int slot, long int time) { 
-      if ( st_time_map.find( uid )!=st_time_map.end() ) {
-         st_time_map[uid][slot]=time;
-      } else {
-         std::vector<long int> time_vec;
-         time_vec.resize(st_vector_size);
-         time_vec[slot] = time;
-         st_time_map[uid] = time_vec;  
-      } 
-   }
-   void check_ld_update(unsigned int uid,unsigned int slot, long int latency) { 
-      if ( ld_time_map.find( uid )!=ld_time_map.end() ) {
-         int our_latency = ld_time_map[uid][slot] - ld_time_map[uid][IN_ICNT_TO_MEM];
-         assert( our_latency == latency);
-      } else if (slot < NUM_MEM_REQ_STAT ) {
-         abort();
+      while (!last_update) {
+        first++;
+        assert(first < iter->second.size());
+        last_update = iter->second[first];
       }
-   }
-   void check_st_update(unsigned int uid,unsigned int slot, long int latency) { 
-      if ( st_time_map.find( uid )!=st_time_map.end() ) {
-         int our_latency = st_time_map[uid][slot] - st_time_map[uid][IN_ICNT_TO_MEM];
-         assert( our_latency == latency);
-      } else {
-         abort();
-      } 
-   }
-private:
-   void calculate_ld_dist(void) {
-      unsigned i,first;
-      long int last_update,diff;
-      int finished_count=0;
-      ld_time_dist.clear();
-      ld_time_dist.resize(ld_vector_size);
-      std::map< unsigned int, std::vector<long int> >::iterator iter, iter_temp;
-      iter =ld_time_map.begin() ;
-      while (iter != ld_time_map.end()) {
-         last_update=0;
-         first=-1;
-         if (!iter->second[IN_SHADER_FETCHED]) {
-            //this request is not done yet skip it!
-            ++iter; 
-            continue;
-         }
-         while ( !last_update ) {
-            first++;
-            assert( first < iter->second.size() );
-            last_update = iter->second[first];
-         }
 
-         for ( i=first;i<ld_vector_size;i++ ) {
-            diff = iter->second[i] - last_update;
-            if ( diff>0 ) {
-               ld_time_dist[i]+=diff;
-               last_update = iter->second[i];               
-            }
-         }
-         iter_temp = iter;
-         iter++;
-         ld_time_map.erase(iter_temp);
-         finished_count++;
+      for (i = first; i < ld_vector_size; i++) {
+        diff = iter->second[i] - last_update;
+        if (diff > 0) {
+          ld_time_dist[i] += diff;
+          last_update = iter->second[i];
+        }
       }
-      if ( finished_count ) {
-         for ( i=0;i<ld_vector_size;i++ ) {
-            overal_ld_time_dist[i] = (overal_ld_time_dist[i]*overal_ld_count + ld_time_dist[i]) /  (overal_ld_count + finished_count); 
-         }
-         overal_ld_count += finished_count;        
-         for ( i=0;i<ld_vector_size;i++ ) {
-            ld_time_dist[i]/=finished_count;
-         }
+      iter_temp = iter;
+      iter++;
+      ld_time_map.erase(iter_temp);
+      finished_count++;
+    }
+    if (finished_count) {
+      for (i = 0; i < ld_vector_size; i++) {
+        overal_ld_time_dist[i] =
+            (overal_ld_time_dist[i] * overal_ld_count + ld_time_dist[i]) /
+            (overal_ld_count + finished_count);
       }
-   }
-
-   void calculate_st_dist(void) {
-      unsigned i,first;
-      long int last_update,diff;
-      int finished_count=0;
-      st_time_dist.clear();
-      st_time_dist.resize(st_vector_size);
-      std::map< unsigned int, std::vector<long int> >::iterator iter,iter_temp;
-      iter =st_time_map.begin() ;
-      while (  iter != st_time_map.end() ) {
-         last_update=0;
-         first=-1;
-         if (!iter->second[IN_SHADER_FETCHED]) {
-            //this request is not done yet skip it!
-            ++iter;
-            continue;
-         }
-         while ( !last_update ) {
-            first++;
-            assert( first < iter->second.size() );
-            last_update = iter->second[first];
-         }
-
-         for ( i=first;i<st_vector_size;i++ ) {
-            diff = iter->second[i] - last_update;
-            if ( diff>0 ) {
-               st_time_dist[i]+=diff;
-               last_update = iter->second[i];               
-            }
-         }
-         iter_temp = iter;
-         iter++;
-         st_time_map.erase(iter_temp);
-         finished_count++;       
+      overal_ld_count += finished_count;
+      for (i = 0; i < ld_vector_size; i++) {
+        ld_time_dist[i] /= finished_count;
       }
-      if ( finished_count ) {
-         for ( i=0;i<st_vector_size;i++ ) {
-            overal_st_time_dist[i] = (overal_st_time_dist[i]*overal_st_count + st_time_dist[i]) /  (overal_st_count + finished_count); 
-         }
-         overal_st_count += finished_count;        
-         for ( i=0;i<st_vector_size;i++ ) {
-            st_time_dist[i]/=finished_count;
-         }
+    }
+  }
+
+  void calculate_st_dist(void) {
+    unsigned i, first;
+    long int last_update, diff;
+    int finished_count = 0;
+    st_time_dist.clear();
+    st_time_dist.resize(st_vector_size);
+    std::map<unsigned int, std::vector<long int> >::iterator iter, iter_temp;
+    iter = st_time_map.begin();
+    while (iter != st_time_map.end()) {
+      last_update = 0;
+      first = -1;
+      if (!iter->second[IN_SHADER_FETCHED]) {
+        // this request is not done yet skip it!
+        ++iter;
+        continue;
       }
-   }
-
-public:
-   void clear_time_map_vectors(void) {   
-      ld_time_map.clear();
-      st_time_map.clear();
-   }
-   void print_all_ld(void) {
-      unsigned i;
-      std::map< unsigned int, std::vector<long int> >::iterator iter;
-      for ( iter =ld_time_map.begin() ; iter != ld_time_map.end(); ++iter ) {
-         std::cout<<"ld_uid"<<iter->first;
-         for ( i=0;i<ld_vector_size;i++ ) {
-            std::cout<<" "<<iter->second[i];
-         }
-         std::cout<< std::endl;
+      while (!last_update) {
+        first++;
+        assert(first < iter->second.size());
+        last_update = iter->second[first];
       }
-   }
 
-   void print_all_st(void) {
-      unsigned i;
-      std::map< unsigned int, std::vector<long int> >::iterator iter;
-
-      for ( iter =st_time_map.begin() ; iter != st_time_map.end(); ++iter ) {
-         std::cout<<"st_uid"<<iter->first;
-         for ( i=0;i<st_vector_size;i++ ) {
-            std::cout<<" "<<iter->second[i];
-         }
-         std::cout<<std::endl;
+      for (i = first; i < st_vector_size; i++) {
+        diff = iter->second[i] - last_update;
+        if (diff > 0) {
+          st_time_dist[i] += diff;
+          last_update = iter->second[i];
+        }
       }
-   }
+      iter_temp = iter;
+      iter++;
+      st_time_map.erase(iter_temp);
+      finished_count++;
+    }
+    if (finished_count) {
+      for (i = 0; i < st_vector_size; i++) {
+        overal_st_time_dist[i] =
+            (overal_st_time_dist[i] * overal_st_count + st_time_dist[i]) /
+            (overal_st_count + finished_count);
+      }
+      overal_st_count += finished_count;
+      for (i = 0; i < st_vector_size; i++) {
+        st_time_dist[i] /= finished_count;
+      }
+    }
+  }
 
-   void calculate_dist() {
-      calculate_ld_dist();
-      calculate_st_dist();
-   }
-   void print_dist(void) {
-      unsigned i; 
-      calculate_dist();
-      std::cout << "LD_mem_lat_dist " ;
-      for ( i=0;i<ld_vector_size;i++ ) {
-         std::cout <<" "<<(int)overal_ld_time_dist[i]; 
+ public:
+  void clear_time_map_vectors(void) {
+    ld_time_map.clear();
+    st_time_map.clear();
+  }
+  void print_all_ld(void) {
+    unsigned i;
+    std::map<unsigned int, std::vector<long int> >::iterator iter;
+    for (iter = ld_time_map.begin(); iter != ld_time_map.end(); ++iter) {
+      std::cout << "ld_uid" << iter->first;
+      for (i = 0; i < ld_vector_size; i++) {
+        std::cout << " " << iter->second[i];
       }
       std::cout << std::endl;
-      std::cout << "ST_mem_lat_dist " ;
-      for ( i=0;i<st_vector_size;i++ ) {
-         std::cout <<" "<<(int)overal_st_time_dist[i];
+    }
+  }
+
+  void print_all_st(void) {
+    unsigned i;
+    std::map<unsigned int, std::vector<long int> >::iterator iter;
+
+    for (iter = st_time_map.begin(); iter != st_time_map.end(); ++iter) {
+      std::cout << "st_uid" << iter->first;
+      for (i = 0; i < st_vector_size; i++) {
+        std::cout << " " << iter->second[i];
       }
       std::cout << std::endl;
-   }
-   void print_to_file(FILE *outfile) {
-      unsigned i; 
-      calculate_dist();
-      fprintf (outfile,"LDmemlatdist:") ;
-      for ( i=0;i<ld_vector_size;i++ ) {
-         fprintf (outfile," %d", (int)ld_time_dist[i]); 
-      }
-      fprintf (outfile,"\n") ;
-      fprintf (outfile,"STmemlatdist:") ;
-      for ( i=0;i<st_vector_size;i++ ) {
-         fprintf (outfile," %d", (int)st_time_dist[i]); 
-      }
-      fprintf (outfile,"\n") ;
-   }   
-   void print_to_gzfile(gzFile outfile) {
-      unsigned i; 
-      calculate_dist();
-      gzprintf (outfile,"LDmemlatdist:") ;
-      for ( i=0;i<ld_vector_size;i++ ) {
-         gzprintf (outfile," %d", (int)ld_time_dist[i]); 
-      }
-      gzprintf (outfile,"\n") ;
-      gzprintf (outfile,"STmemlatdist:") ;
-      for ( i=0;i<st_vector_size;i++ ) {
-         gzprintf (outfile," %d", (int)st_time_dist[i]); 
-      }
-      gzprintf (outfile,"\n") ;
-   }   
+    }
+  }
+
+  void calculate_dist() {
+    calculate_ld_dist();
+    calculate_st_dist();
+  }
+  void print_dist(void) {
+    unsigned i;
+    calculate_dist();
+    std::cout << "LD_mem_lat_dist ";
+    for (i = 0; i < ld_vector_size; i++) {
+      std::cout << " " << (int)overal_ld_time_dist[i];
+    }
+    std::cout << std::endl;
+    std::cout << "ST_mem_lat_dist ";
+    for (i = 0; i < st_vector_size; i++) {
+      std::cout << " " << (int)overal_st_time_dist[i];
+    }
+    std::cout << std::endl;
+  }
+  void print_to_file(FILE* outfile) {
+    unsigned i;
+    calculate_dist();
+    fprintf(outfile, "LDmemlatdist:");
+    for (i = 0; i < ld_vector_size; i++) {
+      fprintf(outfile, " %d", (int)ld_time_dist[i]);
+    }
+    fprintf(outfile, "\n");
+    fprintf(outfile, "STmemlatdist:");
+    for (i = 0; i < st_vector_size; i++) {
+      fprintf(outfile, " %d", (int)st_time_dist[i]);
+    }
+    fprintf(outfile, "\n");
+  }
+  void print_to_gzfile(gzFile outfile) {
+    unsigned i;
+    calculate_dist();
+    gzprintf(outfile, "LDmemlatdist:");
+    for (i = 0; i < ld_vector_size; i++) {
+      gzprintf(outfile, " %d", (int)ld_time_dist[i]);
+    }
+    gzprintf(outfile, "\n");
+    gzprintf(outfile, "STmemlatdist:");
+    for (i = 0; i < st_vector_size; i++) {
+      gzprintf(outfile, " %d", (int)st_time_dist[i]);
+    }
+    gzprintf(outfile, "\n");
+  }
 };
 
-my_time_vector* g_my_time_vector; 
+my_time_vector* g_my_time_vector;
 
 void time_vector_create(int size) {
-   g_my_time_vector = new my_time_vector(size,size); 
-}                               
-
-
-void time_vector_print(void) {
-   g_my_time_vector->print_dist();
+  g_my_time_vector = new my_time_vector(size, size);
 }
 
+void time_vector_print(void) { g_my_time_vector->print_dist(); }
+
 void time_vector_print_interval2gzfile(gzFile outfile) {
-   g_my_time_vector->print_to_gzfile(outfile);
+  g_my_time_vector->print_to_gzfile(outfile);
 }
 
 #include "../gpgpu-sim/mem_fetch.h"
 
-void time_vector_update(unsigned int uid,int slot ,long int cycle,int type) {
-   if ( (type == READ_REQUEST) || (type == READ_REPLY) ) {
-      g_my_time_vector->update_ld( uid, slot,cycle);
-   } else if ( (type == WRITE_REQUEST) || (type == WRITE_ACK) ) {
-      g_my_time_vector->update_st( uid, slot,cycle);
-   } else {
-      abort(); 
-   }
+void time_vector_update(unsigned int uid, int slot, long int cycle, int type) {
+  if ((type == READ_REQUEST) || (type == READ_REPLY)) {
+    g_my_time_vector->update_ld(uid, slot, cycle);
+  } else if ((type == WRITE_REQUEST) || (type == WRITE_ACK)) {
+    g_my_time_vector->update_st(uid, slot, cycle);
+  } else {
+    abort();
+  }
 }
 
-void check_time_vector_update(unsigned int uid,int slot ,long int latency,int type) 
-{
-   if ( (type == READ_REQUEST) || (type == READ_REPLY) ) {
-      g_my_time_vector->check_ld_update( uid, slot, latency );
-   } else if ( (type == WRITE_REQUEST) || (type == WRITE_ACK) ) {
-      g_my_time_vector->check_st_update( uid, slot, latency );
-   } else {
-      abort(); 
-   }
+void check_time_vector_update(unsigned int uid, int slot, long int latency,
+                              int type) {
+  if ((type == READ_REQUEST) || (type == READ_REPLY)) {
+    g_my_time_vector->check_ld_update(uid, slot, latency);
+  } else if ((type == WRITE_REQUEST) || (type == WRITE_ACK)) {
+    g_my_time_vector->check_st_update(uid, slot, latency);
+  } else {
+    abort();
+  }
 }

--- a/src/gpgpu-sim/visualizer.cc
+++ b/src/gpgpu-sim/visualizer.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2011, Tor M. Aamodt, Wilson W.L. Fung,
+// Copyright (c) 2009-2011, Tor M. Aamodt, Wilson W.L. Fung, 
 // The University of British Columbia
 // All rights reserved.
 //
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -29,370 +27,358 @@
 
 #include "visualizer.h"
 
-#include "../option_parser.h"
 #include "gpu-sim.h"
 #include "l2cache.h"
+#include "shader.h"
+#include "../option_parser.h"
 #include "mem_latency_stat.h"
 #include "power_stat.h"
-#include "shader.h"
 //#include "../../../mcpat/processor.h"
-#include "gpu-cache.h"
 #include "stat-tool.h"
+#include "gpu-cache.h"
 
-#include <string.h>
 #include <time.h>
+#include <string.h>
 #include <zlib.h>
 
 static void time_vector_print_interval2gzfile(gzFile outfile);
 
-void gpgpu_sim::visualizer_printstat() {
-  gzFile visualizer_file = NULL;  // gzFile is basically a pointer to a struct,
-                                  // so it is fine to initialize it as NULL
-  if (!m_config.g_visualizer_enabled) return;
+void gpgpu_sim::visualizer_printstat()
+{
+   gzFile visualizer_file = NULL; // gzFile is basically a pointer to a struct, so it is fine to initialize it as NULL
+   if ( !m_config.g_visualizer_enabled )
+      return;
 
-  // clean the content of the visualizer log if it is the first time, otherwise
-  // attach at the end
-  static bool visualizer_first_printstat = true;
+   // clean the content of the visualizer log if it is the first time, otherwise attach at the end
+   static bool visualizer_first_printstat = true;
 
-  visualizer_file = gzopen(m_config.g_visualizer_filename,
-                           (visualizer_first_printstat) ? "w" : "a");
-  if (visualizer_file == NULL) {
-    printf("error - could not open visualizer trace file.\n");
-    exit(1);
-  }
-  gzsetparams(visualizer_file, m_config.g_visualizer_zlevel,
-              Z_DEFAULT_STRATEGY);
-  visualizer_first_printstat = false;
+   visualizer_file = gzopen(m_config.g_visualizer_filename, (visualizer_first_printstat)? "w" : "a");
+   if (visualizer_file == NULL) {
+      printf("error - could not open visualizer trace file.\n");
+      exit(1);
+   }
+   gzsetparams(visualizer_file, m_config.g_visualizer_zlevel, Z_DEFAULT_STRATEGY);
+   visualizer_first_printstat = false;
+   
+   cflog_visualizer_gzprint(visualizer_file);
+   shader_CTA_count_visualizer_gzprint(visualizer_file);
 
-  cflog_visualizer_gzprint(visualizer_file);
-  shader_CTA_count_visualizer_gzprint(visualizer_file);
+   for (unsigned i=0;i<m_memory_config->m_n_mem;i++) 
+      m_memory_partition_unit[i]->visualizer_print(visualizer_file);
+   m_shader_stats->visualizer_print(visualizer_file);
+   m_memory_stats->visualizer_print(visualizer_file);
+   m_power_stats->visualizer_print(visualizer_file);
+   //proc->visualizer_print(visualizer_file);
+   // other parameters for graphing
+   gzprintf(visualizer_file, "globalcyclecount: %lld\n", gpu_sim_cycle);
+   gzprintf(visualizer_file, "globalinsncount: %lld\n", gpu_sim_insn);
+   gzprintf(visualizer_file, "globaltotinsncount: %lld\n", gpu_tot_sim_insn);
 
-  for (unsigned i = 0; i < m_memory_config->m_n_mem; i++)
-    m_memory_partition_unit[i]->visualizer_print(visualizer_file);
-  m_shader_stats->visualizer_print(visualizer_file);
-  m_memory_stats->visualizer_print(visualizer_file);
-  m_power_stats->visualizer_print(visualizer_file);
-  // proc->visualizer_print(visualizer_file);
-  // other parameters for graphing
-  gzprintf(visualizer_file, "globalcyclecount: %lld\n", gpu_sim_cycle);
-  gzprintf(visualizer_file, "globalinsncount: %lld\n", gpu_sim_insn);
-  gzprintf(visualizer_file, "globaltotinsncount: %lld\n", gpu_tot_sim_insn);
+   time_vector_print_interval2gzfile(visualizer_file);
 
-  time_vector_print_interval2gzfile(visualizer_file);
-
-  gzclose(visualizer_file);
-  /*
-     gzprintf(visualizer_file, "CacheMissRate_GlobalLocalL1_All: ");
-     for (unsigned i=0;i<m_n_shader;i++)
-        gzprintf(visualizer_file, "%0.4f ",
-     m_sc[i]->L1_windowed_cache_miss_rate(0));
-     gzprintf(visualizer_file, "\n");
-     gzprintf(visualizer_file, "CacheMissRate_TextureL1_All: ");
-     for (unsigned i=0;i<m_n_shader;i++)
-        gzprintf(visualizer_file, "%0.4f ",
-     m_sc[i]->L1tex_windowed_cache_miss_rate(0));
-     gzprintf(visualizer_file, "\n");
-     gzprintf(visualizer_file, "CacheMissRate_ConstL1_All: ");
-     for (unsigned i=0;i<m_n_shader;i++)
-        gzprintf(visualizer_file, "%0.4f ",
-     m_sc[i]->L1const_windowed_cache_miss_rate(0));
-     gzprintf(visualizer_file, "\n");
-     gzprintf(visualizer_file, "CacheMissRate_GlobalLocalL1_noMgHt: ");
-     for (unsigned i=0;i<m_n_shader;i++)
-        gzprintf(visualizer_file, "%0.4f ",
-     m_sc[i]->L1_windowed_cache_miss_rate(1));
-     gzprintf(visualizer_file, "\n");
-     gzprintf(visualizer_file, "CacheMissRate_TextureL1_noMgHt: ");
-     for (unsigned i=0;i<m_n_shader;i++)
-        gzprintf(visualizer_file, "%0.4f ",
-     m_sc[i]->L1tex_windowed_cache_miss_rate(1));
-     gzprintf(visualizer_file, "\n");
-     gzprintf(visualizer_file, "CacheMissRate_ConstL1_noMgHt: ");
-     for (unsigned i=0;i<m_n_shader;i++)
-        gzprintf(visualizer_file, "%0.4f ",
-     m_sc[i]->L1const_windowed_cache_miss_rate(1));
-     gzprintf(visualizer_file, "\n");
-     // reset for next interval
-     for (unsigned i=0;i<m_n_shader;i++)
-        m_sc[i]->new_cache_window();
-  */
+   gzclose(visualizer_file);
+/*
+   gzprintf(visualizer_file, "CacheMissRate_GlobalLocalL1_All: ");
+   for (unsigned i=0;i<m_n_shader;i++) 
+      gzprintf(visualizer_file, "%0.4f ", m_sc[i]->L1_windowed_cache_miss_rate(0));
+   gzprintf(visualizer_file, "\n");
+   gzprintf(visualizer_file, "CacheMissRate_TextureL1_All: ");
+   for (unsigned i=0;i<m_n_shader;i++) 
+      gzprintf(visualizer_file, "%0.4f ", m_sc[i]->L1tex_windowed_cache_miss_rate(0));
+   gzprintf(visualizer_file, "\n");
+   gzprintf(visualizer_file, "CacheMissRate_ConstL1_All: ");
+   for (unsigned i=0;i<m_n_shader;i++) 
+      gzprintf(visualizer_file, "%0.4f ", m_sc[i]->L1const_windowed_cache_miss_rate(0));
+   gzprintf(visualizer_file, "\n");
+   gzprintf(visualizer_file, "CacheMissRate_GlobalLocalL1_noMgHt: ");
+   for (unsigned i=0;i<m_n_shader;i++) 
+      gzprintf(visualizer_file, "%0.4f ", m_sc[i]->L1_windowed_cache_miss_rate(1));
+   gzprintf(visualizer_file, "\n");
+   gzprintf(visualizer_file, "CacheMissRate_TextureL1_noMgHt: ");
+   for (unsigned i=0;i<m_n_shader;i++) 
+      gzprintf(visualizer_file, "%0.4f ", m_sc[i]->L1tex_windowed_cache_miss_rate(1));
+   gzprintf(visualizer_file, "\n");
+   gzprintf(visualizer_file, "CacheMissRate_ConstL1_noMgHt: ");
+   for (unsigned i=0;i<m_n_shader;i++) 
+      gzprintf(visualizer_file, "%0.4f ", m_sc[i]->L1const_windowed_cache_miss_rate(1));
+   gzprintf(visualizer_file, "\n");
+   // reset for next interval
+   for (unsigned i=0;i<m_n_shader;i++) 
+      m_sc[i]->new_cache_window();
+*/
 }
 
-#include <iostream>
 #include <list>
-#include <map>
 #include <vector>
-#include "../gpgpu-sim/shader.h"
+#include <iostream>
+#include <map>
+#include"../gpgpu-sim/shader.h"
 class my_time_vector {
- private:
-  std::map<unsigned int, std::vector<long int> > ld_time_map;
-  std::map<unsigned int, std::vector<long int> > st_time_map;
-  unsigned ld_vector_size;
-  unsigned st_vector_size;
-  std::vector<double> ld_time_dist;
-  std::vector<double> st_time_dist;
+private:
+   std::map< unsigned int, std::vector<long int> > ld_time_map;
+   std::map< unsigned int, std::vector<long int> > st_time_map;
+   unsigned ld_vector_size;
+   unsigned st_vector_size;
+   std::vector<double>  ld_time_dist;
+   std::vector<double>  st_time_dist;
 
-  std::vector<double> overal_ld_time_dist;
-  std::vector<double> overal_st_time_dist;
-  int overal_ld_count;
-  int overal_st_count;
+   std::vector<double>  overal_ld_time_dist;
+   std::vector<double>  overal_st_time_dist;
+   int overal_ld_count;
+   int overal_st_count;
 
- public:
-  my_time_vector(int ld_size, int st_size) {
-    ld_vector_size = ld_size;
-    st_vector_size = st_size;
-    ld_time_dist.resize(ld_size);
-    st_time_dist.resize(st_size);
-    overal_ld_time_dist.resize(ld_size);
-    overal_st_time_dist.resize(st_size);
-    overal_ld_count = 0;
-    overal_st_count = 0;
-  }
-  void update_ld(unsigned int uid, unsigned int slot, long int time) {
-    if (ld_time_map.find(uid) != ld_time_map.end()) {
-      ld_time_map[uid][slot] = time;
-    } else if (slot < NUM_MEM_REQ_STAT) {
-      std::vector<long int> time_vec;
-      time_vec.resize(ld_vector_size);
-      time_vec[slot] = time;
-      ld_time_map[uid] = time_vec;
-    } else {
-      // It's a merged mshr! forget it
-    }
-  }
-  void update_st(unsigned int uid, unsigned int slot, long int time) {
-    if (st_time_map.find(uid) != st_time_map.end()) {
-      st_time_map[uid][slot] = time;
-    } else {
-      std::vector<long int> time_vec;
-      time_vec.resize(st_vector_size);
-      time_vec[slot] = time;
-      st_time_map[uid] = time_vec;
-    }
-  }
-  void check_ld_update(unsigned int uid, unsigned int slot, long int latency) {
-    if (ld_time_map.find(uid) != ld_time_map.end()) {
-      int our_latency =
-          ld_time_map[uid][slot] - ld_time_map[uid][IN_ICNT_TO_MEM];
-      assert(our_latency == latency);
-    } else if (slot < NUM_MEM_REQ_STAT) {
-      abort();
-    }
-  }
-  void check_st_update(unsigned int uid, unsigned int slot, long int latency) {
-    if (st_time_map.find(uid) != st_time_map.end()) {
-      int our_latency =
-          st_time_map[uid][slot] - st_time_map[uid][IN_ICNT_TO_MEM];
-      assert(our_latency == latency);
-    } else {
-      abort();
-    }
-  }
+public:
+   my_time_vector(int ld_size,int st_size){
+      ld_vector_size = ld_size;
+      st_vector_size = st_size;
+      ld_time_dist.resize(ld_size);
+      st_time_dist.resize(st_size);
+      overal_ld_time_dist.resize(ld_size);
+      overal_st_time_dist.resize(st_size);
+      overal_ld_count = 0;
+      overal_st_count= 0;
+   }
+   void update_ld(unsigned int uid,unsigned int slot, long int time) { 
+      if ( ld_time_map.find( uid )!=ld_time_map.end() ) {
+         ld_time_map[uid][slot]=time;
+      } else if (slot < NUM_MEM_REQ_STAT ) {
+         std::vector<long int> time_vec;
+         time_vec.resize(ld_vector_size);
+         time_vec[slot] = time;
+         ld_time_map[uid] = time_vec;  
+      } else {
+         //It's a merged mshr! forget it
+      }
+   }
+   void update_st(unsigned int uid,unsigned int slot, long int time) { 
+      if ( st_time_map.find( uid )!=st_time_map.end() ) {
+         st_time_map[uid][slot]=time;
+      } else {
+         std::vector<long int> time_vec;
+         time_vec.resize(st_vector_size);
+         time_vec[slot] = time;
+         st_time_map[uid] = time_vec;  
+      } 
+   }
+   void check_ld_update(unsigned int uid,unsigned int slot, long int latency) { 
+      if ( ld_time_map.find( uid )!=ld_time_map.end() ) {
+         int our_latency = ld_time_map[uid][slot] - ld_time_map[uid][IN_ICNT_TO_MEM];
+         assert( our_latency == latency);
+      } else if (slot < NUM_MEM_REQ_STAT ) {
+         abort();
+      }
+   }
+   void check_st_update(unsigned int uid,unsigned int slot, long int latency) { 
+      if ( st_time_map.find( uid )!=st_time_map.end() ) {
+         int our_latency = st_time_map[uid][slot] - st_time_map[uid][IN_ICNT_TO_MEM];
+         assert( our_latency == latency);
+      } else {
+         abort();
+      } 
+   }
+private:
+   void calculate_ld_dist(void) {
+      unsigned i,first;
+      long int last_update,diff;
+      int finished_count=0;
+      ld_time_dist.clear();
+      ld_time_dist.resize(ld_vector_size);
+      std::map< unsigned int, std::vector<long int> >::iterator iter, iter_temp;
+      iter =ld_time_map.begin() ;
+      while (iter != ld_time_map.end()) {
+         last_update=0;
+         first=-1;
+         if (!iter->second[IN_SHADER_FETCHED]) {
+            //this request is not done yet skip it!
+            ++iter; 
+            continue;
+         }
+         while ( !last_update ) {
+            first++;
+            assert( first < iter->second.size() );
+            last_update = iter->second[first];
+         }
 
- private:
-  void calculate_ld_dist(void) {
-    unsigned i, first;
-    long int last_update, diff;
-    int finished_count = 0;
-    ld_time_dist.clear();
-    ld_time_dist.resize(ld_vector_size);
-    std::map<unsigned int, std::vector<long int> >::iterator iter, iter_temp;
-    iter = ld_time_map.begin();
-    while (iter != ld_time_map.end()) {
-      last_update = 0;
-      first = -1;
-      if (!iter->second[IN_SHADER_FETCHED]) {
-        // this request is not done yet skip it!
-        ++iter;
-        continue;
+         for ( i=first;i<ld_vector_size;i++ ) {
+            diff = iter->second[i] - last_update;
+            if ( diff>0 ) {
+               ld_time_dist[i]+=diff;
+               last_update = iter->second[i];               
+            }
+         }
+         iter_temp = iter;
+         iter++;
+         ld_time_map.erase(iter_temp);
+         finished_count++;
       }
-      while (!last_update) {
-        first++;
-        assert(first < iter->second.size());
-        last_update = iter->second[first];
+      if ( finished_count ) {
+         for ( i=0;i<ld_vector_size;i++ ) {
+            overal_ld_time_dist[i] = (overal_ld_time_dist[i]*overal_ld_count + ld_time_dist[i]) /  (overal_ld_count + finished_count); 
+         }
+         overal_ld_count += finished_count;        
+         for ( i=0;i<ld_vector_size;i++ ) {
+            ld_time_dist[i]/=finished_count;
+         }
       }
+   }
 
-      for (i = first; i < ld_vector_size; i++) {
-        diff = iter->second[i] - last_update;
-        if (diff > 0) {
-          ld_time_dist[i] += diff;
-          last_update = iter->second[i];
-        }
-      }
-      iter_temp = iter;
-      iter++;
-      ld_time_map.erase(iter_temp);
-      finished_count++;
-    }
-    if (finished_count) {
-      for (i = 0; i < ld_vector_size; i++) {
-        overal_ld_time_dist[i] =
-            (overal_ld_time_dist[i] * overal_ld_count + ld_time_dist[i]) /
-            (overal_ld_count + finished_count);
-      }
-      overal_ld_count += finished_count;
-      for (i = 0; i < ld_vector_size; i++) {
-        ld_time_dist[i] /= finished_count;
-      }
-    }
-  }
+   void calculate_st_dist(void) {
+      unsigned i,first;
+      long int last_update,diff;
+      int finished_count=0;
+      st_time_dist.clear();
+      st_time_dist.resize(st_vector_size);
+      std::map< unsigned int, std::vector<long int> >::iterator iter,iter_temp;
+      iter =st_time_map.begin() ;
+      while (  iter != st_time_map.end() ) {
+         last_update=0;
+         first=-1;
+         if (!iter->second[IN_SHADER_FETCHED]) {
+            //this request is not done yet skip it!
+            ++iter;
+            continue;
+         }
+         while ( !last_update ) {
+            first++;
+            assert( first < iter->second.size() );
+            last_update = iter->second[first];
+         }
 
-  void calculate_st_dist(void) {
-    unsigned i, first;
-    long int last_update, diff;
-    int finished_count = 0;
-    st_time_dist.clear();
-    st_time_dist.resize(st_vector_size);
-    std::map<unsigned int, std::vector<long int> >::iterator iter, iter_temp;
-    iter = st_time_map.begin();
-    while (iter != st_time_map.end()) {
-      last_update = 0;
-      first = -1;
-      if (!iter->second[IN_SHADER_FETCHED]) {
-        // this request is not done yet skip it!
-        ++iter;
-        continue;
+         for ( i=first;i<st_vector_size;i++ ) {
+            diff = iter->second[i] - last_update;
+            if ( diff>0 ) {
+               st_time_dist[i]+=diff;
+               last_update = iter->second[i];               
+            }
+         }
+         iter_temp = iter;
+         iter++;
+         st_time_map.erase(iter_temp);
+         finished_count++;       
       }
-      while (!last_update) {
-        first++;
-        assert(first < iter->second.size());
-        last_update = iter->second[first];
+      if ( finished_count ) {
+         for ( i=0;i<st_vector_size;i++ ) {
+            overal_st_time_dist[i] = (overal_st_time_dist[i]*overal_st_count + st_time_dist[i]) /  (overal_st_count + finished_count); 
+         }
+         overal_st_count += finished_count;        
+         for ( i=0;i<st_vector_size;i++ ) {
+            st_time_dist[i]/=finished_count;
+         }
       }
+   }
 
-      for (i = first; i < st_vector_size; i++) {
-        diff = iter->second[i] - last_update;
-        if (diff > 0) {
-          st_time_dist[i] += diff;
-          last_update = iter->second[i];
-        }
+public:
+   void clear_time_map_vectors(void) {   
+      ld_time_map.clear();
+      st_time_map.clear();
+   }
+   void print_all_ld(void) {
+      unsigned i;
+      std::map< unsigned int, std::vector<long int> >::iterator iter;
+      for ( iter =ld_time_map.begin() ; iter != ld_time_map.end(); ++iter ) {
+         std::cout<<"ld_uid"<<iter->first;
+         for ( i=0;i<ld_vector_size;i++ ) {
+            std::cout<<" "<<iter->second[i];
+         }
+         std::cout<< std::endl;
       }
-      iter_temp = iter;
-      iter++;
-      st_time_map.erase(iter_temp);
-      finished_count++;
-    }
-    if (finished_count) {
-      for (i = 0; i < st_vector_size; i++) {
-        overal_st_time_dist[i] =
-            (overal_st_time_dist[i] * overal_st_count + st_time_dist[i]) /
-            (overal_st_count + finished_count);
-      }
-      overal_st_count += finished_count;
-      for (i = 0; i < st_vector_size; i++) {
-        st_time_dist[i] /= finished_count;
-      }
-    }
-  }
+   }
 
- public:
-  void clear_time_map_vectors(void) {
-    ld_time_map.clear();
-    st_time_map.clear();
-  }
-  void print_all_ld(void) {
-    unsigned i;
-    std::map<unsigned int, std::vector<long int> >::iterator iter;
-    for (iter = ld_time_map.begin(); iter != ld_time_map.end(); ++iter) {
-      std::cout << "ld_uid" << iter->first;
-      for (i = 0; i < ld_vector_size; i++) {
-        std::cout << " " << iter->second[i];
+   void print_all_st(void) {
+      unsigned i;
+      std::map< unsigned int, std::vector<long int> >::iterator iter;
+
+      for ( iter =st_time_map.begin() ; iter != st_time_map.end(); ++iter ) {
+         std::cout<<"st_uid"<<iter->first;
+         for ( i=0;i<st_vector_size;i++ ) {
+            std::cout<<" "<<iter->second[i];
+         }
+         std::cout<<std::endl;
+      }
+   }
+
+   void calculate_dist() {
+      calculate_ld_dist();
+      calculate_st_dist();
+   }
+   void print_dist(void) {
+      unsigned i; 
+      calculate_dist();
+      std::cout << "LD_mem_lat_dist " ;
+      for ( i=0;i<ld_vector_size;i++ ) {
+         std::cout <<" "<<(int)overal_ld_time_dist[i]; 
       }
       std::cout << std::endl;
-    }
-  }
-
-  void print_all_st(void) {
-    unsigned i;
-    std::map<unsigned int, std::vector<long int> >::iterator iter;
-
-    for (iter = st_time_map.begin(); iter != st_time_map.end(); ++iter) {
-      std::cout << "st_uid" << iter->first;
-      for (i = 0; i < st_vector_size; i++) {
-        std::cout << " " << iter->second[i];
+      std::cout << "ST_mem_lat_dist " ;
+      for ( i=0;i<st_vector_size;i++ ) {
+         std::cout <<" "<<(int)overal_st_time_dist[i];
       }
       std::cout << std::endl;
-    }
-  }
-
-  void calculate_dist() {
-    calculate_ld_dist();
-    calculate_st_dist();
-  }
-  void print_dist(void) {
-    unsigned i;
-    calculate_dist();
-    std::cout << "LD_mem_lat_dist ";
-    for (i = 0; i < ld_vector_size; i++) {
-      std::cout << " " << (int)overal_ld_time_dist[i];
-    }
-    std::cout << std::endl;
-    std::cout << "ST_mem_lat_dist ";
-    for (i = 0; i < st_vector_size; i++) {
-      std::cout << " " << (int)overal_st_time_dist[i];
-    }
-    std::cout << std::endl;
-  }
-  void print_to_file(FILE* outfile) {
-    unsigned i;
-    calculate_dist();
-    fprintf(outfile, "LDmemlatdist:");
-    for (i = 0; i < ld_vector_size; i++) {
-      fprintf(outfile, " %d", (int)ld_time_dist[i]);
-    }
-    fprintf(outfile, "\n");
-    fprintf(outfile, "STmemlatdist:");
-    for (i = 0; i < st_vector_size; i++) {
-      fprintf(outfile, " %d", (int)st_time_dist[i]);
-    }
-    fprintf(outfile, "\n");
-  }
-  void print_to_gzfile(gzFile outfile) {
-    unsigned i;
-    calculate_dist();
-    gzprintf(outfile, "LDmemlatdist:");
-    for (i = 0; i < ld_vector_size; i++) {
-      gzprintf(outfile, " %d", (int)ld_time_dist[i]);
-    }
-    gzprintf(outfile, "\n");
-    gzprintf(outfile, "STmemlatdist:");
-    for (i = 0; i < st_vector_size; i++) {
-      gzprintf(outfile, " %d", (int)st_time_dist[i]);
-    }
-    gzprintf(outfile, "\n");
-  }
+   }
+   void print_to_file(FILE *outfile) {
+      unsigned i; 
+      calculate_dist();
+      fprintf (outfile,"LDmemlatdist:") ;
+      for ( i=0;i<ld_vector_size;i++ ) {
+         fprintf (outfile," %d", (int)ld_time_dist[i]); 
+      }
+      fprintf (outfile,"\n") ;
+      fprintf (outfile,"STmemlatdist:") ;
+      for ( i=0;i<st_vector_size;i++ ) {
+         fprintf (outfile," %d", (int)st_time_dist[i]); 
+      }
+      fprintf (outfile,"\n") ;
+   }   
+   void print_to_gzfile(gzFile outfile) {
+      unsigned i; 
+      calculate_dist();
+      gzprintf (outfile,"LDmemlatdist:") ;
+      for ( i=0;i<ld_vector_size;i++ ) {
+         gzprintf (outfile," %d", (int)ld_time_dist[i]); 
+      }
+      gzprintf (outfile,"\n") ;
+      gzprintf (outfile,"STmemlatdist:") ;
+      for ( i=0;i<st_vector_size;i++ ) {
+         gzprintf (outfile," %d", (int)st_time_dist[i]); 
+      }
+      gzprintf (outfile,"\n") ;
+   }   
 };
 
-my_time_vector* g_my_time_vector;
+my_time_vector* g_my_time_vector; 
 
 void time_vector_create(int size) {
-  g_my_time_vector = new my_time_vector(size, size);
+   g_my_time_vector = new my_time_vector(size,size); 
+}                               
+
+
+void time_vector_print(void) {
+   g_my_time_vector->print_dist();
 }
 
-void time_vector_print(void) { g_my_time_vector->print_dist(); }
-
 void time_vector_print_interval2gzfile(gzFile outfile) {
-  g_my_time_vector->print_to_gzfile(outfile);
+   g_my_time_vector->print_to_gzfile(outfile);
 }
 
 #include "../gpgpu-sim/mem_fetch.h"
 
-void time_vector_update(unsigned int uid, int slot, long int cycle, int type) {
-  if ((type == READ_REQUEST) || (type == READ_REPLY)) {
-    g_my_time_vector->update_ld(uid, slot, cycle);
-  } else if ((type == WRITE_REQUEST) || (type == WRITE_ACK)) {
-    g_my_time_vector->update_st(uid, slot, cycle);
-  } else {
-    abort();
-  }
+void time_vector_update(unsigned int uid,int slot ,long int cycle,int type) {
+   if ( (type == READ_REQUEST) || (type == READ_REPLY) ) {
+      g_my_time_vector->update_ld( uid, slot,cycle);
+   } else if ( (type == WRITE_REQUEST) || (type == WRITE_ACK) ) {
+      g_my_time_vector->update_st( uid, slot,cycle);
+   } else {
+      abort(); 
+   }
 }
 
-void check_time_vector_update(unsigned int uid, int slot, long int latency,
-                              int type) {
-  if ((type == READ_REQUEST) || (type == READ_REPLY)) {
-    g_my_time_vector->check_ld_update(uid, slot, latency);
-  } else if ((type == WRITE_REQUEST) || (type == WRITE_ACK)) {
-    g_my_time_vector->check_st_update(uid, slot, latency);
-  } else {
-    abort();
-  }
+void check_time_vector_update(unsigned int uid,int slot ,long int latency,int type) 
+{
+   if ( (type == READ_REQUEST) || (type == READ_REPLY) ) {
+      g_my_time_vector->check_ld_update( uid, slot, latency );
+   } else if ( (type == WRITE_REQUEST) || (type == WRITE_ACK) ) {
+      g_my_time_vector->check_st_update( uid, slot, latency );
+   } else {
+      abort(); 
+   }
 }

--- a/src/gpgpu-sim/visualizer.cc
+++ b/src/gpgpu-sim/visualizer.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2011, Tor M. Aamodt, Wilson W.L. Fung, 
+// Copyright (c) 2009-2011, Tor M. Aamodt, Wilson W.L. Fung,
 // The University of British Columbia
 // All rights reserved.
 //
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -27,358 +29,370 @@
 
 #include "visualizer.h"
 
+#include "../option_parser.h"
 #include "gpu-sim.h"
 #include "l2cache.h"
-#include "shader.h"
-#include "../option_parser.h"
 #include "mem_latency_stat.h"
 #include "power_stat.h"
+#include "shader.h"
 //#include "../../../mcpat/processor.h"
-#include "stat-tool.h"
 #include "gpu-cache.h"
+#include "stat-tool.h"
 
-#include <time.h>
 #include <string.h>
+#include <time.h>
 #include <zlib.h>
 
 static void time_vector_print_interval2gzfile(gzFile outfile);
 
-void gpgpu_sim::visualizer_printstat()
-{
-   gzFile visualizer_file = NULL; // gzFile is basically a pointer to a struct, so it is fine to initialize it as NULL
-   if ( !m_config.g_visualizer_enabled )
-      return;
+void gpgpu_sim::visualizer_printstat() {
+  gzFile visualizer_file = NULL;  // gzFile is basically a pointer to a struct,
+                                  // so it is fine to initialize it as NULL
+  if (!m_config.g_visualizer_enabled) return;
 
-   // clean the content of the visualizer log if it is the first time, otherwise attach at the end
-   static bool visualizer_first_printstat = true;
+  // clean the content of the visualizer log if it is the first time, otherwise
+  // attach at the end
+  static bool visualizer_first_printstat = true;
 
-   visualizer_file = gzopen(m_config.g_visualizer_filename, (visualizer_first_printstat)? "w" : "a");
-   if (visualizer_file == NULL) {
-      printf("error - could not open visualizer trace file.\n");
-      exit(1);
-   }
-   gzsetparams(visualizer_file, m_config.g_visualizer_zlevel, Z_DEFAULT_STRATEGY);
-   visualizer_first_printstat = false;
-   
-   cflog_visualizer_gzprint(visualizer_file);
-   shader_CTA_count_visualizer_gzprint(visualizer_file);
+  visualizer_file = gzopen(m_config.g_visualizer_filename,
+                           (visualizer_first_printstat) ? "w" : "a");
+  if (visualizer_file == NULL) {
+    printf("error - could not open visualizer trace file.\n");
+    exit(1);
+  }
+  gzsetparams(visualizer_file, m_config.g_visualizer_zlevel,
+              Z_DEFAULT_STRATEGY);
+  visualizer_first_printstat = false;
 
-   for (unsigned i=0;i<m_memory_config->m_n_mem;i++) 
-      m_memory_partition_unit[i]->visualizer_print(visualizer_file);
-   m_shader_stats->visualizer_print(visualizer_file);
-   m_memory_stats->visualizer_print(visualizer_file);
-   m_power_stats->visualizer_print(visualizer_file);
-   //proc->visualizer_print(visualizer_file);
-   // other parameters for graphing
-   gzprintf(visualizer_file, "globalcyclecount: %lld\n", gpu_sim_cycle);
-   gzprintf(visualizer_file, "globalinsncount: %lld\n", gpu_sim_insn);
-   gzprintf(visualizer_file, "globaltotinsncount: %lld\n", gpu_tot_sim_insn);
+  cflog_visualizer_gzprint(visualizer_file);
+  shader_CTA_count_visualizer_gzprint(visualizer_file);
 
-   time_vector_print_interval2gzfile(visualizer_file);
+  for (unsigned i = 0; i < m_memory_config->m_n_mem; i++)
+    m_memory_partition_unit[i]->visualizer_print(visualizer_file);
+  m_shader_stats->visualizer_print(visualizer_file);
+  m_memory_stats->visualizer_print(visualizer_file);
+  m_power_stats->visualizer_print(visualizer_file);
+  // proc->visualizer_print(visualizer_file);
+  // other parameters for graphing
+  gzprintf(visualizer_file, "globalcyclecount: %lld\n", gpu_sim_cycle);
+  gzprintf(visualizer_file, "globalinsncount: %lld\n", gpu_sim_insn);
+  gzprintf(visualizer_file, "globaltotinsncount: %lld\n", gpu_tot_sim_insn);
 
-   gzclose(visualizer_file);
-/*
-   gzprintf(visualizer_file, "CacheMissRate_GlobalLocalL1_All: ");
-   for (unsigned i=0;i<m_n_shader;i++) 
-      gzprintf(visualizer_file, "%0.4f ", m_sc[i]->L1_windowed_cache_miss_rate(0));
-   gzprintf(visualizer_file, "\n");
-   gzprintf(visualizer_file, "CacheMissRate_TextureL1_All: ");
-   for (unsigned i=0;i<m_n_shader;i++) 
-      gzprintf(visualizer_file, "%0.4f ", m_sc[i]->L1tex_windowed_cache_miss_rate(0));
-   gzprintf(visualizer_file, "\n");
-   gzprintf(visualizer_file, "CacheMissRate_ConstL1_All: ");
-   for (unsigned i=0;i<m_n_shader;i++) 
-      gzprintf(visualizer_file, "%0.4f ", m_sc[i]->L1const_windowed_cache_miss_rate(0));
-   gzprintf(visualizer_file, "\n");
-   gzprintf(visualizer_file, "CacheMissRate_GlobalLocalL1_noMgHt: ");
-   for (unsigned i=0;i<m_n_shader;i++) 
-      gzprintf(visualizer_file, "%0.4f ", m_sc[i]->L1_windowed_cache_miss_rate(1));
-   gzprintf(visualizer_file, "\n");
-   gzprintf(visualizer_file, "CacheMissRate_TextureL1_noMgHt: ");
-   for (unsigned i=0;i<m_n_shader;i++) 
-      gzprintf(visualizer_file, "%0.4f ", m_sc[i]->L1tex_windowed_cache_miss_rate(1));
-   gzprintf(visualizer_file, "\n");
-   gzprintf(visualizer_file, "CacheMissRate_ConstL1_noMgHt: ");
-   for (unsigned i=0;i<m_n_shader;i++) 
-      gzprintf(visualizer_file, "%0.4f ", m_sc[i]->L1const_windowed_cache_miss_rate(1));
-   gzprintf(visualizer_file, "\n");
-   // reset for next interval
-   for (unsigned i=0;i<m_n_shader;i++) 
-      m_sc[i]->new_cache_window();
-*/
+  time_vector_print_interval2gzfile(visualizer_file);
+
+  gzclose(visualizer_file);
+  /*
+     gzprintf(visualizer_file, "CacheMissRate_GlobalLocalL1_All: ");
+     for (unsigned i=0;i<m_n_shader;i++)
+        gzprintf(visualizer_file, "%0.4f ",
+     m_sc[i]->L1_windowed_cache_miss_rate(0));
+     gzprintf(visualizer_file, "\n");
+     gzprintf(visualizer_file, "CacheMissRate_TextureL1_All: ");
+     for (unsigned i=0;i<m_n_shader;i++)
+        gzprintf(visualizer_file, "%0.4f ",
+     m_sc[i]->L1tex_windowed_cache_miss_rate(0));
+     gzprintf(visualizer_file, "\n");
+     gzprintf(visualizer_file, "CacheMissRate_ConstL1_All: ");
+     for (unsigned i=0;i<m_n_shader;i++)
+        gzprintf(visualizer_file, "%0.4f ",
+     m_sc[i]->L1const_windowed_cache_miss_rate(0));
+     gzprintf(visualizer_file, "\n");
+     gzprintf(visualizer_file, "CacheMissRate_GlobalLocalL1_noMgHt: ");
+     for (unsigned i=0;i<m_n_shader;i++)
+        gzprintf(visualizer_file, "%0.4f ",
+     m_sc[i]->L1_windowed_cache_miss_rate(1));
+     gzprintf(visualizer_file, "\n");
+     gzprintf(visualizer_file, "CacheMissRate_TextureL1_noMgHt: ");
+     for (unsigned i=0;i<m_n_shader;i++)
+        gzprintf(visualizer_file, "%0.4f ",
+     m_sc[i]->L1tex_windowed_cache_miss_rate(1));
+     gzprintf(visualizer_file, "\n");
+     gzprintf(visualizer_file, "CacheMissRate_ConstL1_noMgHt: ");
+     for (unsigned i=0;i<m_n_shader;i++)
+        gzprintf(visualizer_file, "%0.4f ",
+     m_sc[i]->L1const_windowed_cache_miss_rate(1));
+     gzprintf(visualizer_file, "\n");
+     // reset for next interval
+     for (unsigned i=0;i<m_n_shader;i++)
+        m_sc[i]->new_cache_window();
+  */
 }
 
-#include <list>
-#include <vector>
 #include <iostream>
+#include <list>
 #include <map>
-#include"../gpgpu-sim/shader.h"
+#include <vector>
+#include "../gpgpu-sim/shader.h"
 class my_time_vector {
-private:
-   std::map< unsigned int, std::vector<long int> > ld_time_map;
-   std::map< unsigned int, std::vector<long int> > st_time_map;
-   unsigned ld_vector_size;
-   unsigned st_vector_size;
-   std::vector<double>  ld_time_dist;
-   std::vector<double>  st_time_dist;
+ private:
+  std::map<unsigned int, std::vector<long int> > ld_time_map;
+  std::map<unsigned int, std::vector<long int> > st_time_map;
+  unsigned ld_vector_size;
+  unsigned st_vector_size;
+  std::vector<double> ld_time_dist;
+  std::vector<double> st_time_dist;
 
-   std::vector<double>  overal_ld_time_dist;
-   std::vector<double>  overal_st_time_dist;
-   int overal_ld_count;
-   int overal_st_count;
+  std::vector<double> overal_ld_time_dist;
+  std::vector<double> overal_st_time_dist;
+  int overal_ld_count;
+  int overal_st_count;
 
-public:
-   my_time_vector(int ld_size,int st_size){
-      ld_vector_size = ld_size;
-      st_vector_size = st_size;
-      ld_time_dist.resize(ld_size);
-      st_time_dist.resize(st_size);
-      overal_ld_time_dist.resize(ld_size);
-      overal_st_time_dist.resize(st_size);
-      overal_ld_count = 0;
-      overal_st_count= 0;
-   }
-   void update_ld(unsigned int uid,unsigned int slot, long int time) { 
-      if ( ld_time_map.find( uid )!=ld_time_map.end() ) {
-         ld_time_map[uid][slot]=time;
-      } else if (slot < NUM_MEM_REQ_STAT ) {
-         std::vector<long int> time_vec;
-         time_vec.resize(ld_vector_size);
-         time_vec[slot] = time;
-         ld_time_map[uid] = time_vec;  
-      } else {
-         //It's a merged mshr! forget it
+ public:
+  my_time_vector(int ld_size, int st_size) {
+    ld_vector_size = ld_size;
+    st_vector_size = st_size;
+    ld_time_dist.resize(ld_size);
+    st_time_dist.resize(st_size);
+    overal_ld_time_dist.resize(ld_size);
+    overal_st_time_dist.resize(st_size);
+    overal_ld_count = 0;
+    overal_st_count = 0;
+  }
+  void update_ld(unsigned int uid, unsigned int slot, long int time) {
+    if (ld_time_map.find(uid) != ld_time_map.end()) {
+      ld_time_map[uid][slot] = time;
+    } else if (slot < NUM_MEM_REQ_STAT) {
+      std::vector<long int> time_vec;
+      time_vec.resize(ld_vector_size);
+      time_vec[slot] = time;
+      ld_time_map[uid] = time_vec;
+    } else {
+      // It's a merged mshr! forget it
+    }
+  }
+  void update_st(unsigned int uid, unsigned int slot, long int time) {
+    if (st_time_map.find(uid) != st_time_map.end()) {
+      st_time_map[uid][slot] = time;
+    } else {
+      std::vector<long int> time_vec;
+      time_vec.resize(st_vector_size);
+      time_vec[slot] = time;
+      st_time_map[uid] = time_vec;
+    }
+  }
+  void check_ld_update(unsigned int uid, unsigned int slot, long int latency) {
+    if (ld_time_map.find(uid) != ld_time_map.end()) {
+      int our_latency =
+          ld_time_map[uid][slot] - ld_time_map[uid][IN_ICNT_TO_MEM];
+      assert(our_latency == latency);
+    } else if (slot < NUM_MEM_REQ_STAT) {
+      abort();
+    }
+  }
+  void check_st_update(unsigned int uid, unsigned int slot, long int latency) {
+    if (st_time_map.find(uid) != st_time_map.end()) {
+      int our_latency =
+          st_time_map[uid][slot] - st_time_map[uid][IN_ICNT_TO_MEM];
+      assert(our_latency == latency);
+    } else {
+      abort();
+    }
+  }
+
+ private:
+  void calculate_ld_dist(void) {
+    unsigned i, first;
+    long int last_update, diff;
+    int finished_count = 0;
+    ld_time_dist.clear();
+    ld_time_dist.resize(ld_vector_size);
+    std::map<unsigned int, std::vector<long int> >::iterator iter, iter_temp;
+    iter = ld_time_map.begin();
+    while (iter != ld_time_map.end()) {
+      last_update = 0;
+      first = -1;
+      if (!iter->second[IN_SHADER_FETCHED]) {
+        // this request is not done yet skip it!
+        ++iter;
+        continue;
       }
-   }
-   void update_st(unsigned int uid,unsigned int slot, long int time) { 
-      if ( st_time_map.find( uid )!=st_time_map.end() ) {
-         st_time_map[uid][slot]=time;
-      } else {
-         std::vector<long int> time_vec;
-         time_vec.resize(st_vector_size);
-         time_vec[slot] = time;
-         st_time_map[uid] = time_vec;  
-      } 
-   }
-   void check_ld_update(unsigned int uid,unsigned int slot, long int latency) { 
-      if ( ld_time_map.find( uid )!=ld_time_map.end() ) {
-         int our_latency = ld_time_map[uid][slot] - ld_time_map[uid][IN_ICNT_TO_MEM];
-         assert( our_latency == latency);
-      } else if (slot < NUM_MEM_REQ_STAT ) {
-         abort();
+      while (!last_update) {
+        first++;
+        assert(first < iter->second.size());
+        last_update = iter->second[first];
       }
-   }
-   void check_st_update(unsigned int uid,unsigned int slot, long int latency) { 
-      if ( st_time_map.find( uid )!=st_time_map.end() ) {
-         int our_latency = st_time_map[uid][slot] - st_time_map[uid][IN_ICNT_TO_MEM];
-         assert( our_latency == latency);
-      } else {
-         abort();
-      } 
-   }
-private:
-   void calculate_ld_dist(void) {
-      unsigned i,first;
-      long int last_update,diff;
-      int finished_count=0;
-      ld_time_dist.clear();
-      ld_time_dist.resize(ld_vector_size);
-      std::map< unsigned int, std::vector<long int> >::iterator iter, iter_temp;
-      iter =ld_time_map.begin() ;
-      while (iter != ld_time_map.end()) {
-         last_update=0;
-         first=-1;
-         if (!iter->second[IN_SHADER_FETCHED]) {
-            //this request is not done yet skip it!
-            ++iter; 
-            continue;
-         }
-         while ( !last_update ) {
-            first++;
-            assert( first < iter->second.size() );
-            last_update = iter->second[first];
-         }
 
-         for ( i=first;i<ld_vector_size;i++ ) {
-            diff = iter->second[i] - last_update;
-            if ( diff>0 ) {
-               ld_time_dist[i]+=diff;
-               last_update = iter->second[i];               
-            }
-         }
-         iter_temp = iter;
-         iter++;
-         ld_time_map.erase(iter_temp);
-         finished_count++;
+      for (i = first; i < ld_vector_size; i++) {
+        diff = iter->second[i] - last_update;
+        if (diff > 0) {
+          ld_time_dist[i] += diff;
+          last_update = iter->second[i];
+        }
       }
-      if ( finished_count ) {
-         for ( i=0;i<ld_vector_size;i++ ) {
-            overal_ld_time_dist[i] = (overal_ld_time_dist[i]*overal_ld_count + ld_time_dist[i]) /  (overal_ld_count + finished_count); 
-         }
-         overal_ld_count += finished_count;        
-         for ( i=0;i<ld_vector_size;i++ ) {
-            ld_time_dist[i]/=finished_count;
-         }
+      iter_temp = iter;
+      iter++;
+      ld_time_map.erase(iter_temp);
+      finished_count++;
+    }
+    if (finished_count) {
+      for (i = 0; i < ld_vector_size; i++) {
+        overal_ld_time_dist[i] =
+            (overal_ld_time_dist[i] * overal_ld_count + ld_time_dist[i]) /
+            (overal_ld_count + finished_count);
       }
-   }
-
-   void calculate_st_dist(void) {
-      unsigned i,first;
-      long int last_update,diff;
-      int finished_count=0;
-      st_time_dist.clear();
-      st_time_dist.resize(st_vector_size);
-      std::map< unsigned int, std::vector<long int> >::iterator iter,iter_temp;
-      iter =st_time_map.begin() ;
-      while (  iter != st_time_map.end() ) {
-         last_update=0;
-         first=-1;
-         if (!iter->second[IN_SHADER_FETCHED]) {
-            //this request is not done yet skip it!
-            ++iter;
-            continue;
-         }
-         while ( !last_update ) {
-            first++;
-            assert( first < iter->second.size() );
-            last_update = iter->second[first];
-         }
-
-         for ( i=first;i<st_vector_size;i++ ) {
-            diff = iter->second[i] - last_update;
-            if ( diff>0 ) {
-               st_time_dist[i]+=diff;
-               last_update = iter->second[i];               
-            }
-         }
-         iter_temp = iter;
-         iter++;
-         st_time_map.erase(iter_temp);
-         finished_count++;       
+      overal_ld_count += finished_count;
+      for (i = 0; i < ld_vector_size; i++) {
+        ld_time_dist[i] /= finished_count;
       }
-      if ( finished_count ) {
-         for ( i=0;i<st_vector_size;i++ ) {
-            overal_st_time_dist[i] = (overal_st_time_dist[i]*overal_st_count + st_time_dist[i]) /  (overal_st_count + finished_count); 
-         }
-         overal_st_count += finished_count;        
-         for ( i=0;i<st_vector_size;i++ ) {
-            st_time_dist[i]/=finished_count;
-         }
+    }
+  }
+
+  void calculate_st_dist(void) {
+    unsigned i, first;
+    long int last_update, diff;
+    int finished_count = 0;
+    st_time_dist.clear();
+    st_time_dist.resize(st_vector_size);
+    std::map<unsigned int, std::vector<long int> >::iterator iter, iter_temp;
+    iter = st_time_map.begin();
+    while (iter != st_time_map.end()) {
+      last_update = 0;
+      first = -1;
+      if (!iter->second[IN_SHADER_FETCHED]) {
+        // this request is not done yet skip it!
+        ++iter;
+        continue;
       }
-   }
-
-public:
-   void clear_time_map_vectors(void) {   
-      ld_time_map.clear();
-      st_time_map.clear();
-   }
-   void print_all_ld(void) {
-      unsigned i;
-      std::map< unsigned int, std::vector<long int> >::iterator iter;
-      for ( iter =ld_time_map.begin() ; iter != ld_time_map.end(); ++iter ) {
-         std::cout<<"ld_uid"<<iter->first;
-         for ( i=0;i<ld_vector_size;i++ ) {
-            std::cout<<" "<<iter->second[i];
-         }
-         std::cout<< std::endl;
+      while (!last_update) {
+        first++;
+        assert(first < iter->second.size());
+        last_update = iter->second[first];
       }
-   }
 
-   void print_all_st(void) {
-      unsigned i;
-      std::map< unsigned int, std::vector<long int> >::iterator iter;
-
-      for ( iter =st_time_map.begin() ; iter != st_time_map.end(); ++iter ) {
-         std::cout<<"st_uid"<<iter->first;
-         for ( i=0;i<st_vector_size;i++ ) {
-            std::cout<<" "<<iter->second[i];
-         }
-         std::cout<<std::endl;
+      for (i = first; i < st_vector_size; i++) {
+        diff = iter->second[i] - last_update;
+        if (diff > 0) {
+          st_time_dist[i] += diff;
+          last_update = iter->second[i];
+        }
       }
-   }
+      iter_temp = iter;
+      iter++;
+      st_time_map.erase(iter_temp);
+      finished_count++;
+    }
+    if (finished_count) {
+      for (i = 0; i < st_vector_size; i++) {
+        overal_st_time_dist[i] =
+            (overal_st_time_dist[i] * overal_st_count + st_time_dist[i]) /
+            (overal_st_count + finished_count);
+      }
+      overal_st_count += finished_count;
+      for (i = 0; i < st_vector_size; i++) {
+        st_time_dist[i] /= finished_count;
+      }
+    }
+  }
 
-   void calculate_dist() {
-      calculate_ld_dist();
-      calculate_st_dist();
-   }
-   void print_dist(void) {
-      unsigned i; 
-      calculate_dist();
-      std::cout << "LD_mem_lat_dist " ;
-      for ( i=0;i<ld_vector_size;i++ ) {
-         std::cout <<" "<<(int)overal_ld_time_dist[i]; 
+ public:
+  void clear_time_map_vectors(void) {
+    ld_time_map.clear();
+    st_time_map.clear();
+  }
+  void print_all_ld(void) {
+    unsigned i;
+    std::map<unsigned int, std::vector<long int> >::iterator iter;
+    for (iter = ld_time_map.begin(); iter != ld_time_map.end(); ++iter) {
+      std::cout << "ld_uid" << iter->first;
+      for (i = 0; i < ld_vector_size; i++) {
+        std::cout << " " << iter->second[i];
       }
       std::cout << std::endl;
-      std::cout << "ST_mem_lat_dist " ;
-      for ( i=0;i<st_vector_size;i++ ) {
-         std::cout <<" "<<(int)overal_st_time_dist[i];
+    }
+  }
+
+  void print_all_st(void) {
+    unsigned i;
+    std::map<unsigned int, std::vector<long int> >::iterator iter;
+
+    for (iter = st_time_map.begin(); iter != st_time_map.end(); ++iter) {
+      std::cout << "st_uid" << iter->first;
+      for (i = 0; i < st_vector_size; i++) {
+        std::cout << " " << iter->second[i];
       }
       std::cout << std::endl;
-   }
-   void print_to_file(FILE *outfile) {
-      unsigned i; 
-      calculate_dist();
-      fprintf (outfile,"LDmemlatdist:") ;
-      for ( i=0;i<ld_vector_size;i++ ) {
-         fprintf (outfile," %d", (int)ld_time_dist[i]); 
-      }
-      fprintf (outfile,"\n") ;
-      fprintf (outfile,"STmemlatdist:") ;
-      for ( i=0;i<st_vector_size;i++ ) {
-         fprintf (outfile," %d", (int)st_time_dist[i]); 
-      }
-      fprintf (outfile,"\n") ;
-   }   
-   void print_to_gzfile(gzFile outfile) {
-      unsigned i; 
-      calculate_dist();
-      gzprintf (outfile,"LDmemlatdist:") ;
-      for ( i=0;i<ld_vector_size;i++ ) {
-         gzprintf (outfile," %d", (int)ld_time_dist[i]); 
-      }
-      gzprintf (outfile,"\n") ;
-      gzprintf (outfile,"STmemlatdist:") ;
-      for ( i=0;i<st_vector_size;i++ ) {
-         gzprintf (outfile," %d", (int)st_time_dist[i]); 
-      }
-      gzprintf (outfile,"\n") ;
-   }   
+    }
+  }
+
+  void calculate_dist() {
+    calculate_ld_dist();
+    calculate_st_dist();
+  }
+  void print_dist(void) {
+    unsigned i;
+    calculate_dist();
+    std::cout << "LD_mem_lat_dist ";
+    for (i = 0; i < ld_vector_size; i++) {
+      std::cout << " " << (int)overal_ld_time_dist[i];
+    }
+    std::cout << std::endl;
+    std::cout << "ST_mem_lat_dist ";
+    for (i = 0; i < st_vector_size; i++) {
+      std::cout << " " << (int)overal_st_time_dist[i];
+    }
+    std::cout << std::endl;
+  }
+  void print_to_file(FILE* outfile) {
+    unsigned i;
+    calculate_dist();
+    fprintf(outfile, "LDmemlatdist:");
+    for (i = 0; i < ld_vector_size; i++) {
+      fprintf(outfile, " %d", (int)ld_time_dist[i]);
+    }
+    fprintf(outfile, "\n");
+    fprintf(outfile, "STmemlatdist:");
+    for (i = 0; i < st_vector_size; i++) {
+      fprintf(outfile, " %d", (int)st_time_dist[i]);
+    }
+    fprintf(outfile, "\n");
+  }
+  void print_to_gzfile(gzFile outfile) {
+    unsigned i;
+    calculate_dist();
+    gzprintf(outfile, "LDmemlatdist:");
+    for (i = 0; i < ld_vector_size; i++) {
+      gzprintf(outfile, " %d", (int)ld_time_dist[i]);
+    }
+    gzprintf(outfile, "\n");
+    gzprintf(outfile, "STmemlatdist:");
+    for (i = 0; i < st_vector_size; i++) {
+      gzprintf(outfile, " %d", (int)st_time_dist[i]);
+    }
+    gzprintf(outfile, "\n");
+  }
 };
 
-my_time_vector* g_my_time_vector; 
+my_time_vector* g_my_time_vector;
 
 void time_vector_create(int size) {
-   g_my_time_vector = new my_time_vector(size,size); 
-}                               
-
-
-void time_vector_print(void) {
-   g_my_time_vector->print_dist();
+  g_my_time_vector = new my_time_vector(size, size);
 }
 
+void time_vector_print(void) { g_my_time_vector->print_dist(); }
+
 void time_vector_print_interval2gzfile(gzFile outfile) {
-   g_my_time_vector->print_to_gzfile(outfile);
+  g_my_time_vector->print_to_gzfile(outfile);
 }
 
 #include "../gpgpu-sim/mem_fetch.h"
 
-void time_vector_update(unsigned int uid,int slot ,long int cycle,int type) {
-   if ( (type == READ_REQUEST) || (type == READ_REPLY) ) {
-      g_my_time_vector->update_ld( uid, slot,cycle);
-   } else if ( (type == WRITE_REQUEST) || (type == WRITE_ACK) ) {
-      g_my_time_vector->update_st( uid, slot,cycle);
-   } else {
-      abort(); 
-   }
+void time_vector_update(unsigned int uid, int slot, long int cycle, int type) {
+  if ((type == READ_REQUEST) || (type == READ_REPLY)) {
+    g_my_time_vector->update_ld(uid, slot, cycle);
+  } else if ((type == WRITE_REQUEST) || (type == WRITE_ACK)) {
+    g_my_time_vector->update_st(uid, slot, cycle);
+  } else {
+    abort();
+  }
 }
 
-void check_time_vector_update(unsigned int uid,int slot ,long int latency,int type) 
-{
-   if ( (type == READ_REQUEST) || (type == READ_REPLY) ) {
-      g_my_time_vector->check_ld_update( uid, slot, latency );
-   } else if ( (type == WRITE_REQUEST) || (type == WRITE_ACK) ) {
-      g_my_time_vector->check_st_update( uid, slot, latency );
-   } else {
-      abort(); 
-   }
+void check_time_vector_update(unsigned int uid, int slot, long int latency,
+                              int type) {
+  if ((type == READ_REQUEST) || (type == READ_REPLY)) {
+    g_my_time_vector->check_ld_update(uid, slot, latency);
+  } else if ((type == WRITE_REQUEST) || (type == WRITE_ACK)) {
+    g_my_time_vector->check_st_update(uid, slot, latency);
+  } else {
+    abort();
+  }
 }

--- a/src/gpgpu-sim/visualizer.h
+++ b/src/gpgpu-sim/visualizer.h
@@ -7,23 +7,24 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef VISUALIZER_H_INCLUDED
 #define VISUALIZER_H_INCLUDED
@@ -33,7 +34,8 @@
 
 void time_vector_create(int size);
 void time_vector_print(void);
-void time_vector_update(unsigned int uid,int slot ,long int cycle,int type);
-void check_time_vector_update(unsigned int uid,int slot ,long int latency,int type); 
+void time_vector_update(unsigned int uid, int slot, long int cycle, int type);
+void check_time_vector_update(unsigned int uid, int slot, long int latency,
+                              int type);
 
 #endif

--- a/src/gpgpu-sim/visualizer.h
+++ b/src/gpgpu-sim/visualizer.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -33,7 +35,8 @@
 
 void time_vector_create(int size);
 void time_vector_print(void);
-void time_vector_update(unsigned int uid,int slot ,long int cycle,int type);
-void check_time_vector_update(unsigned int uid,int slot ,long int latency,int type); 
+void time_vector_update(unsigned int uid, int slot, long int cycle, int type);
+void check_time_vector_update(unsigned int uid, int slot, long int latency,
+                              int type);
 
 #endif

--- a/src/gpgpu-sim/visualizer.h
+++ b/src/gpgpu-sim/visualizer.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -35,8 +33,7 @@
 
 void time_vector_create(int size);
 void time_vector_print(void);
-void time_vector_update(unsigned int uid, int slot, long int cycle, int type);
-void check_time_vector_update(unsigned int uid, int slot, long int latency,
-                              int type);
+void time_vector_update(unsigned int uid,int slot ,long int cycle,int type);
+void check_time_vector_update(unsigned int uid,int slot ,long int latency,int type); 
 
 #endif

--- a/src/gpgpusim_entrypoint.cc
+++ b/src/gpgpusim_entrypoint.cc
@@ -7,274 +7,285 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #include "gpgpusim_entrypoint.h"
 #include <stdio.h>
 
-#include "option_parser.h"
+#include "../libcuda/gpgpu_context.h"
 #include "cuda-sim/cuda-sim.h"
 #include "cuda-sim/ptx_ir.h"
 #include "cuda-sim/ptx_parser.h"
 #include "gpgpu-sim/gpu-sim.h"
 #include "gpgpu-sim/icnt_wrapper.h"
+#include "option_parser.h"
 #include "stream_manager.h"
-#include "../libcuda/gpgpu_context.h"
 
-#define MAX(a,b) (((a)>(b))?(a):(b))
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
 
 static int sg_argc = 3;
-static const char *sg_argv[] = {"", "-config","gpgpusim.config"};
+static const char *sg_argv[] = {"", "-config", "gpgpusim.config"};
 
-
-void * gpgpu_sim_thread_sequential(void * ctx_ptr)
-{
-    gpgpu_context * ctx = (gpgpu_context *)ctx_ptr;
-   // at most one kernel running at a time
-   bool done;
-   do {
-      sem_wait(&(ctx->the_gpgpusim->g_sim_signal_start));
-      done = true;
-      if( ctx->the_gpgpusim->g_the_gpu->get_more_cta_left() ) {
-          done = false;
-          ctx->the_gpgpusim->g_the_gpu->init();
-          while( ctx->the_gpgpusim->g_the_gpu->active() ) {
-        	  ctx->the_gpgpusim->g_the_gpu->cycle();
-        	  ctx->the_gpgpusim->g_the_gpu->deadlock_check();
-          }
-          ctx->the_gpgpusim->g_the_gpu->print_stats();
-          ctx->the_gpgpusim->g_the_gpu->update_stats();
-          ctx->print_simulation_time();
+void *gpgpu_sim_thread_sequential(void *ctx_ptr) {
+  gpgpu_context *ctx = (gpgpu_context *)ctx_ptr;
+  // at most one kernel running at a time
+  bool done;
+  do {
+    sem_wait(&(ctx->the_gpgpusim->g_sim_signal_start));
+    done = true;
+    if (ctx->the_gpgpusim->g_the_gpu->get_more_cta_left()) {
+      done = false;
+      ctx->the_gpgpusim->g_the_gpu->init();
+      while (ctx->the_gpgpusim->g_the_gpu->active()) {
+        ctx->the_gpgpusim->g_the_gpu->cycle();
+        ctx->the_gpgpusim->g_the_gpu->deadlock_check();
       }
-      sem_post(&(ctx->the_gpgpusim->g_sim_signal_finish));
-   } while(!done);
-   sem_post(&(ctx->the_gpgpusim->g_sim_signal_exit));
-   return NULL;
-}
-
-
-
-static void termination_callback()
-{
-    printf("GPGPU-Sim: *** exit detected ***\n");
-    fflush(stdout);
-}
-
-void *gpgpu_sim_thread_concurrent(void * ctx_ptr)
-{
-    gpgpu_context * ctx = (gpgpu_context *)ctx_ptr;
-    atexit(termination_callback);
-    // concurrent kernel execution simulation thread
-    do {
-        if(g_debug_execution >= 3) {
-           printf("GPGPU-Sim: *** simulation thread starting and spinning waiting for work ***\n");
-           fflush(stdout);
-        }
-        while( ctx->the_gpgpusim->g_stream_manager->empty_protected() && !ctx->the_gpgpusim->g_sim_done )
-            ;
-        if(g_debug_execution >= 3) {
-           printf("GPGPU-Sim: ** START simulation thread (detected work) **\n");
-           ctx->the_gpgpusim->g_stream_manager->print(stdout);
-           fflush(stdout);
-        }
-        pthread_mutex_lock(&(ctx->the_gpgpusim->g_sim_lock));
-        ctx->the_gpgpusim->g_sim_active = true;
-        pthread_mutex_unlock(&(ctx->the_gpgpusim->g_sim_lock));
-        bool active = false;
-        bool sim_cycles = false;
-        ctx->the_gpgpusim->g_the_gpu->init();
-        do {
-            // check if a kernel has completed
-            // launch operation on device if one is pending and can be run
-
-            // Need to break this loop when a kernel completes. This was a
-            // source of non-deterministic behaviour in GPGPU-Sim (bug 147).
-            // If another stream operation is available, g_the_gpu remains active,
-            // causing this loop to not break. If the next operation happens to be
-            // another kernel, the gpu is not re-initialized and the inter-kernel
-            // behaviour may be incorrect. Check that a kernel has finished and
-            // no other kernel is currently running.
-            if(ctx->the_gpgpusim->g_stream_manager->operation(&sim_cycles) && !ctx->the_gpgpusim->g_the_gpu->active())
-                break;
-
-            //functional simulation
-            if( ctx->the_gpgpusim->g_the_gpu->is_functional_sim()) {
-                kernel_info_t * kernel = ctx->the_gpgpusim->g_the_gpu->get_functional_kernel();
-                assert(kernel);
-                ctx->the_gpgpusim->gpgpu_ctx->func_sim->gpgpu_cuda_ptx_sim_main_func(*kernel);
-                ctx->the_gpgpusim->g_the_gpu->finish_functional_sim(kernel);
-            }
-
-            //performance simulation
-            if( ctx->the_gpgpusim->g_the_gpu->active() ) {
-            	ctx->the_gpgpusim->g_the_gpu->cycle();
-            	sim_cycles = true;
-            	ctx->the_gpgpusim->g_the_gpu->deadlock_check();
-            }else {
-                if(ctx->the_gpgpusim->g_the_gpu->cycle_insn_cta_max_hit()){
-                	ctx->the_gpgpusim->g_stream_manager->stop_all_running_kernels();
-                	ctx->the_gpgpusim->g_sim_done = true;
-                	ctx->the_gpgpusim->break_limit = true;
-                }
-            }
-
-            active=ctx->the_gpgpusim->g_the_gpu->active() || !(ctx->the_gpgpusim->g_stream_manager->empty_protected());
-
-        } while( active && !ctx->the_gpgpusim->g_sim_done);
-        if(g_debug_execution >= 3) {
-           printf("GPGPU-Sim: ** STOP simulation thread (no work) **\n");
-           fflush(stdout);
-        }
-        if(sim_cycles) {
-        	ctx->the_gpgpusim->g_the_gpu->print_stats();
-        	ctx->the_gpgpusim->g_the_gpu->update_stats();
-            ctx->print_simulation_time();
-        }
-        pthread_mutex_lock(&(ctx->the_gpgpusim->g_sim_lock));
-        ctx->the_gpgpusim->g_sim_active = false;
-        pthread_mutex_unlock(&(ctx->the_gpgpusim->g_sim_lock));
-    } while( !ctx->the_gpgpusim->g_sim_done );
-
-    printf("GPGPU-Sim: *** simulation thread exiting ***\n");
-    fflush(stdout);
-
-    if(ctx->the_gpgpusim->break_limit) {
-    	printf("GPGPU-Sim: ** break due to reaching the maximum cycles (or instructions) **\n");
-    	exit(1);
+      ctx->the_gpgpusim->g_the_gpu->print_stats();
+      ctx->the_gpgpusim->g_the_gpu->update_stats();
+      ctx->print_simulation_time();
     }
-
-    sem_post(&(ctx->the_gpgpusim->g_sim_signal_exit));
-    return NULL;
+    sem_post(&(ctx->the_gpgpusim->g_sim_signal_finish));
+  } while (!done);
+  sem_post(&(ctx->the_gpgpusim->g_sim_signal_exit));
+  return NULL;
 }
 
-void gpgpu_context::synchronize()
-{
-    printf("GPGPU-Sim: synchronize waiting for inactive GPU simulation\n");
-    the_gpgpusim->g_stream_manager->print(stdout);
-    fflush(stdout);
-//    sem_wait(&g_sim_signal_finish);
-    bool done = false;
-    do {
-        pthread_mutex_lock(&(the_gpgpusim->g_sim_lock));
-        done = ( the_gpgpusim->g_stream_manager->empty() && !the_gpgpusim->g_sim_active ) || the_gpgpusim->g_sim_done;
-        pthread_mutex_unlock(&(the_gpgpusim->g_sim_lock));
-    } while (!done);
-    printf("GPGPU-Sim: detected inactive GPU simulation thread\n");
-    fflush(stdout);
-//    sem_post(&g_sim_signal_start);
+static void termination_callback() {
+  printf("GPGPU-Sim: *** exit detected ***\n");
+  fflush(stdout);
 }
 
-void gpgpu_context::exit_simulation()
-{
-	the_gpgpusim->g_sim_done=true;
-    printf("GPGPU-Sim: exit_simulation called\n");
-    fflush(stdout);
-    sem_wait(&(the_gpgpusim->g_sim_signal_exit));
-    printf("GPGPU-Sim: simulation thread signaled exit\n");
-    fflush(stdout);
-}
-
-gpgpu_sim *gpgpu_context::gpgpu_ptx_sim_init_perf()
-{
-   srand(1);
-   print_splash();
-   func_sim->read_sim_environment_variables();
-   ptx_parser->read_parser_environment_variables();
-   option_parser_t opp = option_parser_create();
-
-   ptx_reg_options(opp);
-   func_sim->ptx_opcocde_latency_options(opp);
-
-   icnt_reg_options(opp);
-   the_gpgpusim->g_the_gpu_config = new gpgpu_sim_config(this);
-   the_gpgpusim->g_the_gpu_config->reg_options(opp); // register GPU microrachitecture options
-
-   option_parser_cmdline(opp, sg_argc, sg_argv); // parse configuration options
-   fprintf(stdout, "GPGPU-Sim: Configuration options:\n\n");
-   option_parser_print(opp, stdout);
-   // Set the Numeric locale to a standard locale where a decimal point is a "dot" not a "comma"
-   // so it does the parsing correctly independent of the system environment variables
-   assert(setlocale(LC_NUMERIC,"C"));
-   the_gpgpusim->g_the_gpu_config->init();
-
-   the_gpgpusim->g_the_gpu = new gpgpu_sim(*(the_gpgpusim->g_the_gpu_config), this);
-   the_gpgpusim->g_stream_manager = new stream_manager((the_gpgpusim->g_the_gpu), func_sim->g_cuda_launch_blocking);
-
-   the_gpgpusim->g_simulation_starttime = time((time_t *)NULL);
-
-   sem_init(&(the_gpgpusim->g_sim_signal_start),0,0);
-   sem_init(&(the_gpgpusim->g_sim_signal_finish),0,0);
-   sem_init(&(the_gpgpusim->g_sim_signal_exit),0,0);
-
-   return the_gpgpusim->g_the_gpu;
-}
-
-void gpgpu_context::start_sim_thread(int api)
-{
-    if( the_gpgpusim->g_sim_done ) {
-    	the_gpgpusim->g_sim_done = false;
-        if( api == 1 ) {
-           pthread_create(&(the_gpgpusim->g_simulation_thread),NULL,gpgpu_sim_thread_concurrent,(void *)this);
-        } else {
-           pthread_create(&(the_gpgpusim->g_simulation_thread),NULL,gpgpu_sim_thread_sequential,(void *)this);
-        }
+void *gpgpu_sim_thread_concurrent(void *ctx_ptr) {
+  gpgpu_context *ctx = (gpgpu_context *)ctx_ptr;
+  atexit(termination_callback);
+  // concurrent kernel execution simulation thread
+  do {
+    if (g_debug_execution >= 3) {
+      printf(
+          "GPGPU-Sim: *** simulation thread starting and spinning waiting for "
+          "work ***\n");
+      fflush(stdout);
     }
+    while (ctx->the_gpgpusim->g_stream_manager->empty_protected() &&
+           !ctx->the_gpgpusim->g_sim_done)
+      ;
+    if (g_debug_execution >= 3) {
+      printf("GPGPU-Sim: ** START simulation thread (detected work) **\n");
+      ctx->the_gpgpusim->g_stream_manager->print(stdout);
+      fflush(stdout);
+    }
+    pthread_mutex_lock(&(ctx->the_gpgpusim->g_sim_lock));
+    ctx->the_gpgpusim->g_sim_active = true;
+    pthread_mutex_unlock(&(ctx->the_gpgpusim->g_sim_lock));
+    bool active = false;
+    bool sim_cycles = false;
+    ctx->the_gpgpusim->g_the_gpu->init();
+    do {
+      // check if a kernel has completed
+      // launch operation on device if one is pending and can be run
+
+      // Need to break this loop when a kernel completes. This was a
+      // source of non-deterministic behaviour in GPGPU-Sim (bug 147).
+      // If another stream operation is available, g_the_gpu remains active,
+      // causing this loop to not break. If the next operation happens to be
+      // another kernel, the gpu is not re-initialized and the inter-kernel
+      // behaviour may be incorrect. Check that a kernel has finished and
+      // no other kernel is currently running.
+      if (ctx->the_gpgpusim->g_stream_manager->operation(&sim_cycles) &&
+          !ctx->the_gpgpusim->g_the_gpu->active())
+        break;
+
+      // functional simulation
+      if (ctx->the_gpgpusim->g_the_gpu->is_functional_sim()) {
+        kernel_info_t *kernel =
+            ctx->the_gpgpusim->g_the_gpu->get_functional_kernel();
+        assert(kernel);
+        ctx->the_gpgpusim->gpgpu_ctx->func_sim->gpgpu_cuda_ptx_sim_main_func(
+            *kernel);
+        ctx->the_gpgpusim->g_the_gpu->finish_functional_sim(kernel);
+      }
+
+      // performance simulation
+      if (ctx->the_gpgpusim->g_the_gpu->active()) {
+        ctx->the_gpgpusim->g_the_gpu->cycle();
+        sim_cycles = true;
+        ctx->the_gpgpusim->g_the_gpu->deadlock_check();
+      } else {
+        if (ctx->the_gpgpusim->g_the_gpu->cycle_insn_cta_max_hit()) {
+          ctx->the_gpgpusim->g_stream_manager->stop_all_running_kernels();
+          ctx->the_gpgpusim->g_sim_done = true;
+          ctx->the_gpgpusim->break_limit = true;
+        }
+      }
+
+      active = ctx->the_gpgpusim->g_the_gpu->active() ||
+               !(ctx->the_gpgpusim->g_stream_manager->empty_protected());
+
+    } while (active && !ctx->the_gpgpusim->g_sim_done);
+    if (g_debug_execution >= 3) {
+      printf("GPGPU-Sim: ** STOP simulation thread (no work) **\n");
+      fflush(stdout);
+    }
+    if (sim_cycles) {
+      ctx->the_gpgpusim->g_the_gpu->print_stats();
+      ctx->the_gpgpusim->g_the_gpu->update_stats();
+      ctx->print_simulation_time();
+    }
+    pthread_mutex_lock(&(ctx->the_gpgpusim->g_sim_lock));
+    ctx->the_gpgpusim->g_sim_active = false;
+    pthread_mutex_unlock(&(ctx->the_gpgpusim->g_sim_lock));
+  } while (!ctx->the_gpgpusim->g_sim_done);
+
+  printf("GPGPU-Sim: *** simulation thread exiting ***\n");
+  fflush(stdout);
+
+  if (ctx->the_gpgpusim->break_limit) {
+    printf(
+        "GPGPU-Sim: ** break due to reaching the maximum cycles (or "
+        "instructions) **\n");
+    exit(1);
+  }
+
+  sem_post(&(ctx->the_gpgpusim->g_sim_signal_exit));
+  return NULL;
 }
 
-void gpgpu_context::print_simulation_time()
-{
-   time_t current_time, difference, d, h, m, s;
-   current_time = time((time_t *)NULL);
-   difference = MAX(current_time - the_gpgpusim->g_simulation_starttime, 1);
-
-   d = difference/(3600*24);
-   h = difference/3600 - 24*d;
-   m = difference/60 - 60*(h + 24*d);
-   s = difference - 60*(m + 60*(h + 24*d));
-
-   fflush(stderr);
-   printf("\n\ngpgpu_simulation_time = %u days, %u hrs, %u min, %u sec (%u sec)\n",
-          (unsigned)d, (unsigned)h, (unsigned)m, (unsigned)s, (unsigned)difference );
-   printf("gpgpu_simulation_rate = %u (inst/sec)\n", (unsigned)(the_gpgpusim->g_the_gpu->gpu_tot_sim_insn / difference) );
-   const unsigned cycles_per_sec = (unsigned)(the_gpgpusim->g_the_gpu->gpu_tot_sim_cycle / difference);
-   printf("gpgpu_simulation_rate = %u (cycle/sec)\n", cycles_per_sec );
-   printf("gpgpu_silicon_slowdown = %ux\n", the_gpgpusim->g_the_gpu->shader_clock() * 1000 / cycles_per_sec);
-   fflush(stdout);
+void gpgpu_context::synchronize() {
+  printf("GPGPU-Sim: synchronize waiting for inactive GPU simulation\n");
+  the_gpgpusim->g_stream_manager->print(stdout);
+  fflush(stdout);
+  //    sem_wait(&g_sim_signal_finish);
+  bool done = false;
+  do {
+    pthread_mutex_lock(&(the_gpgpusim->g_sim_lock));
+    done = (the_gpgpusim->g_stream_manager->empty() &&
+            !the_gpgpusim->g_sim_active) ||
+           the_gpgpusim->g_sim_done;
+    pthread_mutex_unlock(&(the_gpgpusim->g_sim_lock));
+  } while (!done);
+  printf("GPGPU-Sim: detected inactive GPU simulation thread\n");
+  fflush(stdout);
+  //    sem_post(&g_sim_signal_start);
 }
 
-int gpgpu_context::gpgpu_opencl_ptx_sim_main_perf( kernel_info_t *grid )
-{
-   the_gpgpusim->g_the_gpu->launch(grid);
-   sem_post(&(the_gpgpusim->g_sim_signal_start));
-   sem_wait(&(the_gpgpusim->g_sim_signal_finish));
-   return 0;
+void gpgpu_context::exit_simulation() {
+  the_gpgpusim->g_sim_done = true;
+  printf("GPGPU-Sim: exit_simulation called\n");
+  fflush(stdout);
+  sem_wait(&(the_gpgpusim->g_sim_signal_exit));
+  printf("GPGPU-Sim: simulation thread signaled exit\n");
+  fflush(stdout);
+}
+
+gpgpu_sim *gpgpu_context::gpgpu_ptx_sim_init_perf() {
+  srand(1);
+  print_splash();
+  func_sim->read_sim_environment_variables();
+  ptx_parser->read_parser_environment_variables();
+  option_parser_t opp = option_parser_create();
+
+  ptx_reg_options(opp);
+  func_sim->ptx_opcocde_latency_options(opp);
+
+  icnt_reg_options(opp);
+  the_gpgpusim->g_the_gpu_config = new gpgpu_sim_config(this);
+  the_gpgpusim->g_the_gpu_config->reg_options(
+      opp);  // register GPU microrachitecture options
+
+  option_parser_cmdline(opp, sg_argc, sg_argv);  // parse configuration options
+  fprintf(stdout, "GPGPU-Sim: Configuration options:\n\n");
+  option_parser_print(opp, stdout);
+  // Set the Numeric locale to a standard locale where a decimal point is a
+  // "dot" not a "comma" so it does the parsing correctly independent of the
+  // system environment variables
+  assert(setlocale(LC_NUMERIC, "C"));
+  the_gpgpusim->g_the_gpu_config->init();
+
+  the_gpgpusim->g_the_gpu =
+      new gpgpu_sim(*(the_gpgpusim->g_the_gpu_config), this);
+  the_gpgpusim->g_stream_manager = new stream_manager(
+      (the_gpgpusim->g_the_gpu), func_sim->g_cuda_launch_blocking);
+
+  the_gpgpusim->g_simulation_starttime = time((time_t *)NULL);
+
+  sem_init(&(the_gpgpusim->g_sim_signal_start), 0, 0);
+  sem_init(&(the_gpgpusim->g_sim_signal_finish), 0, 0);
+  sem_init(&(the_gpgpusim->g_sim_signal_exit), 0, 0);
+
+  return the_gpgpusim->g_the_gpu;
+}
+
+void gpgpu_context::start_sim_thread(int api) {
+  if (the_gpgpusim->g_sim_done) {
+    the_gpgpusim->g_sim_done = false;
+    if (api == 1) {
+      pthread_create(&(the_gpgpusim->g_simulation_thread), NULL,
+                     gpgpu_sim_thread_concurrent, (void *)this);
+    } else {
+      pthread_create(&(the_gpgpusim->g_simulation_thread), NULL,
+                     gpgpu_sim_thread_sequential, (void *)this);
+    }
+  }
+}
+
+void gpgpu_context::print_simulation_time() {
+  time_t current_time, difference, d, h, m, s;
+  current_time = time((time_t *)NULL);
+  difference = MAX(current_time - the_gpgpusim->g_simulation_starttime, 1);
+
+  d = difference / (3600 * 24);
+  h = difference / 3600 - 24 * d;
+  m = difference / 60 - 60 * (h + 24 * d);
+  s = difference - 60 * (m + 60 * (h + 24 * d));
+
+  fflush(stderr);
+  printf(
+      "\n\ngpgpu_simulation_time = %u days, %u hrs, %u min, %u sec (%u sec)\n",
+      (unsigned)d, (unsigned)h, (unsigned)m, (unsigned)s, (unsigned)difference);
+  printf("gpgpu_simulation_rate = %u (inst/sec)\n",
+         (unsigned)(the_gpgpusim->g_the_gpu->gpu_tot_sim_insn / difference));
+  const unsigned cycles_per_sec =
+      (unsigned)(the_gpgpusim->g_the_gpu->gpu_tot_sim_cycle / difference);
+  printf("gpgpu_simulation_rate = %u (cycle/sec)\n", cycles_per_sec);
+  printf("gpgpu_silicon_slowdown = %ux\n",
+         the_gpgpusim->g_the_gpu->shader_clock() * 1000 / cycles_per_sec);
+  fflush(stdout);
+}
+
+int gpgpu_context::gpgpu_opencl_ptx_sim_main_perf(kernel_info_t *grid) {
+  the_gpgpusim->g_the_gpu->launch(grid);
+  sem_post(&(the_gpgpusim->g_sim_signal_start));
+  sem_wait(&(the_gpgpusim->g_sim_signal_finish));
+  return 0;
 }
 
 //! Functional simulation of OpenCL
 /*!
  * This function call the CUDA PTX functional simulator
  */
-int cuda_sim::gpgpu_opencl_ptx_sim_main_func( kernel_info_t *grid )
-{
-    //calling the CUDA PTX simulator, sending the kernel by reference and a flag set to true,
-    //the flag used by the function to distinguish OpenCL calls from the CUDA simulation calls which
-    //it is needed by the called function to not register the exit the exit of OpenCL kernel as it doesn't register entering in the first place as the CUDA kernels does
-   gpgpu_cuda_ptx_sim_main_func( *grid, true );
-   return 0;
+int cuda_sim::gpgpu_opencl_ptx_sim_main_func(kernel_info_t *grid) {
+  // calling the CUDA PTX simulator, sending the kernel by reference and a flag
+  // set to true, the flag used by the function to distinguish OpenCL calls from
+  // the CUDA simulation calls which it is needed by the called function to not
+  // register the exit the exit of OpenCL kernel as it doesn't register entering
+  // in the first place as the CUDA kernels does
+  gpgpu_cuda_ptx_sim_main_func(*grid, true);
+  return 0;
 }

--- a/src/gpgpusim_entrypoint.cc
+++ b/src/gpgpusim_entrypoint.cc
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -28,253 +30,266 @@
 #include "gpgpusim_entrypoint.h"
 #include <stdio.h>
 
-#include "option_parser.h"
+#include "../libcuda/gpgpu_context.h"
 #include "cuda-sim/cuda-sim.h"
 #include "cuda-sim/ptx_ir.h"
 #include "cuda-sim/ptx_parser.h"
 #include "gpgpu-sim/gpu-sim.h"
 #include "gpgpu-sim/icnt_wrapper.h"
+#include "option_parser.h"
 #include "stream_manager.h"
-#include "../libcuda/gpgpu_context.h"
 
-#define MAX(a,b) (((a)>(b))?(a):(b))
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
 
 static int sg_argc = 3;
-static const char *sg_argv[] = {"", "-config","gpgpusim.config"};
+static const char *sg_argv[] = {"", "-config", "gpgpusim.config"};
 
-
-void * gpgpu_sim_thread_sequential(void * ctx_ptr)
-{
-    gpgpu_context * ctx = (gpgpu_context *)ctx_ptr;
-   // at most one kernel running at a time
-   bool done;
-   do {
-      sem_wait(&(ctx->the_gpgpusim->g_sim_signal_start));
-      done = true;
-      if( ctx->the_gpgpusim->g_the_gpu->get_more_cta_left() ) {
-          done = false;
-          ctx->the_gpgpusim->g_the_gpu->init();
-          while( ctx->the_gpgpusim->g_the_gpu->active() ) {
-        	  ctx->the_gpgpusim->g_the_gpu->cycle();
-        	  ctx->the_gpgpusim->g_the_gpu->deadlock_check();
-          }
-          ctx->the_gpgpusim->g_the_gpu->print_stats();
-          ctx->the_gpgpusim->g_the_gpu->update_stats();
-          ctx->print_simulation_time();
+void *gpgpu_sim_thread_sequential(void *ctx_ptr) {
+  gpgpu_context *ctx = (gpgpu_context *)ctx_ptr;
+  // at most one kernel running at a time
+  bool done;
+  do {
+    sem_wait(&(ctx->the_gpgpusim->g_sim_signal_start));
+    done = true;
+    if (ctx->the_gpgpusim->g_the_gpu->get_more_cta_left()) {
+      done = false;
+      ctx->the_gpgpusim->g_the_gpu->init();
+      while (ctx->the_gpgpusim->g_the_gpu->active()) {
+        ctx->the_gpgpusim->g_the_gpu->cycle();
+        ctx->the_gpgpusim->g_the_gpu->deadlock_check();
       }
-      sem_post(&(ctx->the_gpgpusim->g_sim_signal_finish));
-   } while(!done);
-   sem_post(&(ctx->the_gpgpusim->g_sim_signal_exit));
-   return NULL;
-}
-
-
-
-static void termination_callback()
-{
-    printf("GPGPU-Sim: *** exit detected ***\n");
-    fflush(stdout);
-}
-
-void *gpgpu_sim_thread_concurrent(void * ctx_ptr)
-{
-    gpgpu_context * ctx = (gpgpu_context *)ctx_ptr;
-    atexit(termination_callback);
-    // concurrent kernel execution simulation thread
-    do {
-        if(g_debug_execution >= 3) {
-           printf("GPGPU-Sim: *** simulation thread starting and spinning waiting for work ***\n");
-           fflush(stdout);
-        }
-        while( ctx->the_gpgpusim->g_stream_manager->empty_protected() && !ctx->the_gpgpusim->g_sim_done )
-            ;
-        if(g_debug_execution >= 3) {
-           printf("GPGPU-Sim: ** START simulation thread (detected work) **\n");
-           ctx->the_gpgpusim->g_stream_manager->print(stdout);
-           fflush(stdout);
-        }
-        pthread_mutex_lock(&(ctx->the_gpgpusim->g_sim_lock));
-        ctx->the_gpgpusim->g_sim_active = true;
-        pthread_mutex_unlock(&(ctx->the_gpgpusim->g_sim_lock));
-        bool active = false;
-        bool sim_cycles = false;
-        ctx->the_gpgpusim->g_the_gpu->init();
-        do {
-            // check if a kernel has completed
-            // launch operation on device if one is pending and can be run
-
-            // Need to break this loop when a kernel completes. This was a
-            // source of non-deterministic behaviour in GPGPU-Sim (bug 147).
-            // If another stream operation is available, g_the_gpu remains active,
-            // causing this loop to not break. If the next operation happens to be
-            // another kernel, the gpu is not re-initialized and the inter-kernel
-            // behaviour may be incorrect. Check that a kernel has finished and
-            // no other kernel is currently running.
-            if(ctx->the_gpgpusim->g_stream_manager->operation(&sim_cycles) && !ctx->the_gpgpusim->g_the_gpu->active())
-                break;
-
-            //functional simulation
-            if( ctx->the_gpgpusim->g_the_gpu->is_functional_sim()) {
-                kernel_info_t * kernel = ctx->the_gpgpusim->g_the_gpu->get_functional_kernel();
-                assert(kernel);
-                ctx->the_gpgpusim->gpgpu_ctx->func_sim->gpgpu_cuda_ptx_sim_main_func(*kernel);
-                ctx->the_gpgpusim->g_the_gpu->finish_functional_sim(kernel);
-            }
-
-            //performance simulation
-            if( ctx->the_gpgpusim->g_the_gpu->active() ) {
-            	ctx->the_gpgpusim->g_the_gpu->cycle();
-            	sim_cycles = true;
-            	ctx->the_gpgpusim->g_the_gpu->deadlock_check();
-            }else {
-                if(ctx->the_gpgpusim->g_the_gpu->cycle_insn_cta_max_hit()){
-                	ctx->the_gpgpusim->g_stream_manager->stop_all_running_kernels();
-                	ctx->the_gpgpusim->g_sim_done = true;
-                	ctx->the_gpgpusim->break_limit = true;
-                }
-            }
-
-            active=ctx->the_gpgpusim->g_the_gpu->active() || !(ctx->the_gpgpusim->g_stream_manager->empty_protected());
-
-        } while( active && !ctx->the_gpgpusim->g_sim_done);
-        if(g_debug_execution >= 3) {
-           printf("GPGPU-Sim: ** STOP simulation thread (no work) **\n");
-           fflush(stdout);
-        }
-        if(sim_cycles) {
-        	ctx->the_gpgpusim->g_the_gpu->print_stats();
-        	ctx->the_gpgpusim->g_the_gpu->update_stats();
-            ctx->print_simulation_time();
-        }
-        pthread_mutex_lock(&(ctx->the_gpgpusim->g_sim_lock));
-        ctx->the_gpgpusim->g_sim_active = false;
-        pthread_mutex_unlock(&(ctx->the_gpgpusim->g_sim_lock));
-    } while( !ctx->the_gpgpusim->g_sim_done );
-
-    printf("GPGPU-Sim: *** simulation thread exiting ***\n");
-    fflush(stdout);
-
-    if(ctx->the_gpgpusim->break_limit) {
-    	printf("GPGPU-Sim: ** break due to reaching the maximum cycles (or instructions) **\n");
-    	exit(1);
+      ctx->the_gpgpusim->g_the_gpu->print_stats();
+      ctx->the_gpgpusim->g_the_gpu->update_stats();
+      ctx->print_simulation_time();
     }
-
-    sem_post(&(ctx->the_gpgpusim->g_sim_signal_exit));
-    return NULL;
+    sem_post(&(ctx->the_gpgpusim->g_sim_signal_finish));
+  } while (!done);
+  sem_post(&(ctx->the_gpgpusim->g_sim_signal_exit));
+  return NULL;
 }
 
-void gpgpu_context::synchronize()
-{
-    printf("GPGPU-Sim: synchronize waiting for inactive GPU simulation\n");
-    the_gpgpusim->g_stream_manager->print(stdout);
-    fflush(stdout);
-//    sem_wait(&g_sim_signal_finish);
-    bool done = false;
-    do {
-        pthread_mutex_lock(&(the_gpgpusim->g_sim_lock));
-        done = ( the_gpgpusim->g_stream_manager->empty() && !the_gpgpusim->g_sim_active ) || the_gpgpusim->g_sim_done;
-        pthread_mutex_unlock(&(the_gpgpusim->g_sim_lock));
-    } while (!done);
-    printf("GPGPU-Sim: detected inactive GPU simulation thread\n");
-    fflush(stdout);
-//    sem_post(&g_sim_signal_start);
+static void termination_callback() {
+  printf("GPGPU-Sim: *** exit detected ***\n");
+  fflush(stdout);
 }
 
-void gpgpu_context::exit_simulation()
-{
-	the_gpgpusim->g_sim_done=true;
-    printf("GPGPU-Sim: exit_simulation called\n");
-    fflush(stdout);
-    sem_wait(&(the_gpgpusim->g_sim_signal_exit));
-    printf("GPGPU-Sim: simulation thread signaled exit\n");
-    fflush(stdout);
-}
-
-gpgpu_sim *gpgpu_context::gpgpu_ptx_sim_init_perf()
-{
-   srand(1);
-   print_splash();
-   func_sim->read_sim_environment_variables();
-   ptx_parser->read_parser_environment_variables();
-   option_parser_t opp = option_parser_create();
-
-   ptx_reg_options(opp);
-   func_sim->ptx_opcocde_latency_options(opp);
-
-   icnt_reg_options(opp);
-   the_gpgpusim->g_the_gpu_config = new gpgpu_sim_config(this);
-   the_gpgpusim->g_the_gpu_config->reg_options(opp); // register GPU microrachitecture options
-
-   option_parser_cmdline(opp, sg_argc, sg_argv); // parse configuration options
-   fprintf(stdout, "GPGPU-Sim: Configuration options:\n\n");
-   option_parser_print(opp, stdout);
-   // Set the Numeric locale to a standard locale where a decimal point is a "dot" not a "comma"
-   // so it does the parsing correctly independent of the system environment variables
-   assert(setlocale(LC_NUMERIC,"C"));
-   the_gpgpusim->g_the_gpu_config->init();
-
-   the_gpgpusim->g_the_gpu = new gpgpu_sim(*(the_gpgpusim->g_the_gpu_config), this);
-   the_gpgpusim->g_stream_manager = new stream_manager((the_gpgpusim->g_the_gpu), func_sim->g_cuda_launch_blocking);
-
-   the_gpgpusim->g_simulation_starttime = time((time_t *)NULL);
-
-   sem_init(&(the_gpgpusim->g_sim_signal_start),0,0);
-   sem_init(&(the_gpgpusim->g_sim_signal_finish),0,0);
-   sem_init(&(the_gpgpusim->g_sim_signal_exit),0,0);
-
-   return the_gpgpusim->g_the_gpu;
-}
-
-void gpgpu_context::start_sim_thread(int api)
-{
-    if( the_gpgpusim->g_sim_done ) {
-    	the_gpgpusim->g_sim_done = false;
-        if( api == 1 ) {
-           pthread_create(&(the_gpgpusim->g_simulation_thread),NULL,gpgpu_sim_thread_concurrent,(void *)this);
-        } else {
-           pthread_create(&(the_gpgpusim->g_simulation_thread),NULL,gpgpu_sim_thread_sequential,(void *)this);
-        }
+void *gpgpu_sim_thread_concurrent(void *ctx_ptr) {
+  gpgpu_context *ctx = (gpgpu_context *)ctx_ptr;
+  atexit(termination_callback);
+  // concurrent kernel execution simulation thread
+  do {
+    if (g_debug_execution >= 3) {
+      printf(
+          "GPGPU-Sim: *** simulation thread starting and spinning waiting for "
+          "work ***\n");
+      fflush(stdout);
     }
+    while (ctx->the_gpgpusim->g_stream_manager->empty_protected() &&
+           !ctx->the_gpgpusim->g_sim_done)
+      ;
+    if (g_debug_execution >= 3) {
+      printf("GPGPU-Sim: ** START simulation thread (detected work) **\n");
+      ctx->the_gpgpusim->g_stream_manager->print(stdout);
+      fflush(stdout);
+    }
+    pthread_mutex_lock(&(ctx->the_gpgpusim->g_sim_lock));
+    ctx->the_gpgpusim->g_sim_active = true;
+    pthread_mutex_unlock(&(ctx->the_gpgpusim->g_sim_lock));
+    bool active = false;
+    bool sim_cycles = false;
+    ctx->the_gpgpusim->g_the_gpu->init();
+    do {
+      // check if a kernel has completed
+      // launch operation on device if one is pending and can be run
+
+      // Need to break this loop when a kernel completes. This was a
+      // source of non-deterministic behaviour in GPGPU-Sim (bug 147).
+      // If another stream operation is available, g_the_gpu remains active,
+      // causing this loop to not break. If the next operation happens to be
+      // another kernel, the gpu is not re-initialized and the inter-kernel
+      // behaviour may be incorrect. Check that a kernel has finished and
+      // no other kernel is currently running.
+      if (ctx->the_gpgpusim->g_stream_manager->operation(&sim_cycles) &&
+          !ctx->the_gpgpusim->g_the_gpu->active())
+        break;
+
+      // functional simulation
+      if (ctx->the_gpgpusim->g_the_gpu->is_functional_sim()) {
+        kernel_info_t *kernel =
+            ctx->the_gpgpusim->g_the_gpu->get_functional_kernel();
+        assert(kernel);
+        ctx->the_gpgpusim->gpgpu_ctx->func_sim->gpgpu_cuda_ptx_sim_main_func(
+            *kernel);
+        ctx->the_gpgpusim->g_the_gpu->finish_functional_sim(kernel);
+      }
+
+      // performance simulation
+      if (ctx->the_gpgpusim->g_the_gpu->active()) {
+        ctx->the_gpgpusim->g_the_gpu->cycle();
+        sim_cycles = true;
+        ctx->the_gpgpusim->g_the_gpu->deadlock_check();
+      } else {
+        if (ctx->the_gpgpusim->g_the_gpu->cycle_insn_cta_max_hit()) {
+          ctx->the_gpgpusim->g_stream_manager->stop_all_running_kernels();
+          ctx->the_gpgpusim->g_sim_done = true;
+          ctx->the_gpgpusim->break_limit = true;
+        }
+      }
+
+      active = ctx->the_gpgpusim->g_the_gpu->active() ||
+               !(ctx->the_gpgpusim->g_stream_manager->empty_protected());
+
+    } while (active && !ctx->the_gpgpusim->g_sim_done);
+    if (g_debug_execution >= 3) {
+      printf("GPGPU-Sim: ** STOP simulation thread (no work) **\n");
+      fflush(stdout);
+    }
+    if (sim_cycles) {
+      ctx->the_gpgpusim->g_the_gpu->print_stats();
+      ctx->the_gpgpusim->g_the_gpu->update_stats();
+      ctx->print_simulation_time();
+    }
+    pthread_mutex_lock(&(ctx->the_gpgpusim->g_sim_lock));
+    ctx->the_gpgpusim->g_sim_active = false;
+    pthread_mutex_unlock(&(ctx->the_gpgpusim->g_sim_lock));
+  } while (!ctx->the_gpgpusim->g_sim_done);
+
+  printf("GPGPU-Sim: *** simulation thread exiting ***\n");
+  fflush(stdout);
+
+  if (ctx->the_gpgpusim->break_limit) {
+    printf(
+        "GPGPU-Sim: ** break due to reaching the maximum cycles (or "
+        "instructions) **\n");
+    exit(1);
+  }
+
+  sem_post(&(ctx->the_gpgpusim->g_sim_signal_exit));
+  return NULL;
 }
 
-void gpgpu_context::print_simulation_time()
-{
-   time_t current_time, difference, d, h, m, s;
-   current_time = time((time_t *)NULL);
-   difference = MAX(current_time - the_gpgpusim->g_simulation_starttime, 1);
-
-   d = difference/(3600*24);
-   h = difference/3600 - 24*d;
-   m = difference/60 - 60*(h + 24*d);
-   s = difference - 60*(m + 60*(h + 24*d));
-
-   fflush(stderr);
-   printf("\n\ngpgpu_simulation_time = %u days, %u hrs, %u min, %u sec (%u sec)\n",
-          (unsigned)d, (unsigned)h, (unsigned)m, (unsigned)s, (unsigned)difference );
-   printf("gpgpu_simulation_rate = %u (inst/sec)\n", (unsigned)(the_gpgpusim->g_the_gpu->gpu_tot_sim_insn / difference) );
-   const unsigned cycles_per_sec = (unsigned)(the_gpgpusim->g_the_gpu->gpu_tot_sim_cycle / difference);
-   printf("gpgpu_simulation_rate = %u (cycle/sec)\n", cycles_per_sec );
-   printf("gpgpu_silicon_slowdown = %ux\n", the_gpgpusim->g_the_gpu->shader_clock() * 1000 / cycles_per_sec);
-   fflush(stdout);
+void gpgpu_context::synchronize() {
+  printf("GPGPU-Sim: synchronize waiting for inactive GPU simulation\n");
+  the_gpgpusim->g_stream_manager->print(stdout);
+  fflush(stdout);
+  //    sem_wait(&g_sim_signal_finish);
+  bool done = false;
+  do {
+    pthread_mutex_lock(&(the_gpgpusim->g_sim_lock));
+    done = (the_gpgpusim->g_stream_manager->empty() &&
+            !the_gpgpusim->g_sim_active) ||
+           the_gpgpusim->g_sim_done;
+    pthread_mutex_unlock(&(the_gpgpusim->g_sim_lock));
+  } while (!done);
+  printf("GPGPU-Sim: detected inactive GPU simulation thread\n");
+  fflush(stdout);
+  //    sem_post(&g_sim_signal_start);
 }
 
-int gpgpu_context::gpgpu_opencl_ptx_sim_main_perf( kernel_info_t *grid )
-{
-   the_gpgpusim->g_the_gpu->launch(grid);
-   sem_post(&(the_gpgpusim->g_sim_signal_start));
-   sem_wait(&(the_gpgpusim->g_sim_signal_finish));
-   return 0;
+void gpgpu_context::exit_simulation() {
+  the_gpgpusim->g_sim_done = true;
+  printf("GPGPU-Sim: exit_simulation called\n");
+  fflush(stdout);
+  sem_wait(&(the_gpgpusim->g_sim_signal_exit));
+  printf("GPGPU-Sim: simulation thread signaled exit\n");
+  fflush(stdout);
+}
+
+gpgpu_sim *gpgpu_context::gpgpu_ptx_sim_init_perf() {
+  srand(1);
+  print_splash();
+  func_sim->read_sim_environment_variables();
+  ptx_parser->read_parser_environment_variables();
+  option_parser_t opp = option_parser_create();
+
+  ptx_reg_options(opp);
+  func_sim->ptx_opcocde_latency_options(opp);
+
+  icnt_reg_options(opp);
+  the_gpgpusim->g_the_gpu_config = new gpgpu_sim_config(this);
+  the_gpgpusim->g_the_gpu_config->reg_options(
+      opp);  // register GPU microrachitecture options
+
+  option_parser_cmdline(opp, sg_argc, sg_argv);  // parse configuration options
+  fprintf(stdout, "GPGPU-Sim: Configuration options:\n\n");
+  option_parser_print(opp, stdout);
+  // Set the Numeric locale to a standard locale where a decimal point is a
+  // "dot" not a "comma"
+  // so it does the parsing correctly independent of the system environment
+  // variables
+  assert(setlocale(LC_NUMERIC, "C"));
+  the_gpgpusim->g_the_gpu_config->init();
+
+  the_gpgpusim->g_the_gpu =
+      new gpgpu_sim(*(the_gpgpusim->g_the_gpu_config), this);
+  the_gpgpusim->g_stream_manager = new stream_manager(
+      (the_gpgpusim->g_the_gpu), func_sim->g_cuda_launch_blocking);
+
+  the_gpgpusim->g_simulation_starttime = time((time_t *)NULL);
+
+  sem_init(&(the_gpgpusim->g_sim_signal_start), 0, 0);
+  sem_init(&(the_gpgpusim->g_sim_signal_finish), 0, 0);
+  sem_init(&(the_gpgpusim->g_sim_signal_exit), 0, 0);
+
+  return the_gpgpusim->g_the_gpu;
+}
+
+void gpgpu_context::start_sim_thread(int api) {
+  if (the_gpgpusim->g_sim_done) {
+    the_gpgpusim->g_sim_done = false;
+    if (api == 1) {
+      pthread_create(&(the_gpgpusim->g_simulation_thread), NULL,
+                     gpgpu_sim_thread_concurrent, (void *)this);
+    } else {
+      pthread_create(&(the_gpgpusim->g_simulation_thread), NULL,
+                     gpgpu_sim_thread_sequential, (void *)this);
+    }
+  }
+}
+
+void gpgpu_context::print_simulation_time() {
+  time_t current_time, difference, d, h, m, s;
+  current_time = time((time_t *)NULL);
+  difference = MAX(current_time - the_gpgpusim->g_simulation_starttime, 1);
+
+  d = difference / (3600 * 24);
+  h = difference / 3600 - 24 * d;
+  m = difference / 60 - 60 * (h + 24 * d);
+  s = difference - 60 * (m + 60 * (h + 24 * d));
+
+  fflush(stderr);
+  printf(
+      "\n\ngpgpu_simulation_time = %u days, %u hrs, %u min, %u sec (%u sec)\n",
+      (unsigned)d, (unsigned)h, (unsigned)m, (unsigned)s, (unsigned)difference);
+  printf("gpgpu_simulation_rate = %u (inst/sec)\n",
+         (unsigned)(the_gpgpusim->g_the_gpu->gpu_tot_sim_insn / difference));
+  const unsigned cycles_per_sec =
+      (unsigned)(the_gpgpusim->g_the_gpu->gpu_tot_sim_cycle / difference);
+  printf("gpgpu_simulation_rate = %u (cycle/sec)\n", cycles_per_sec);
+  printf("gpgpu_silicon_slowdown = %ux\n",
+         the_gpgpusim->g_the_gpu->shader_clock() * 1000 / cycles_per_sec);
+  fflush(stdout);
+}
+
+int gpgpu_context::gpgpu_opencl_ptx_sim_main_perf(kernel_info_t *grid) {
+  the_gpgpusim->g_the_gpu->launch(grid);
+  sem_post(&(the_gpgpusim->g_sim_signal_start));
+  sem_wait(&(the_gpgpusim->g_sim_signal_finish));
+  return 0;
 }
 
 //! Functional simulation of OpenCL
 /*!
  * This function call the CUDA PTX functional simulator
  */
-int cuda_sim::gpgpu_opencl_ptx_sim_main_func( kernel_info_t *grid )
-{
-    //calling the CUDA PTX simulator, sending the kernel by reference and a flag set to true,
-    //the flag used by the function to distinguish OpenCL calls from the CUDA simulation calls which
-    //it is needed by the called function to not register the exit the exit of OpenCL kernel as it doesn't register entering in the first place as the CUDA kernels does
-   gpgpu_cuda_ptx_sim_main_func( *grid, true );
-   return 0;
+int cuda_sim::gpgpu_opencl_ptx_sim_main_func(kernel_info_t *grid) {
+  // calling the CUDA PTX simulator, sending the kernel by reference and a flag
+  // set to true,
+  // the flag used by the function to distinguish OpenCL calls from the CUDA
+  // simulation calls which
+  // it is needed by the called function to not register the exit the exit of
+  // OpenCL kernel as it doesn't register entering in the first place as the
+  // CUDA kernels does
+  gpgpu_cuda_ptx_sim_main_func(*grid, true);
+  return 0;
 }

--- a/src/gpgpusim_entrypoint.cc
+++ b/src/gpgpusim_entrypoint.cc
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -30,266 +28,253 @@
 #include "gpgpusim_entrypoint.h"
 #include <stdio.h>
 
-#include "../libcuda/gpgpu_context.h"
+#include "option_parser.h"
 #include "cuda-sim/cuda-sim.h"
 #include "cuda-sim/ptx_ir.h"
 #include "cuda-sim/ptx_parser.h"
 #include "gpgpu-sim/gpu-sim.h"
 #include "gpgpu-sim/icnt_wrapper.h"
-#include "option_parser.h"
 #include "stream_manager.h"
+#include "../libcuda/gpgpu_context.h"
 
-#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#define MAX(a,b) (((a)>(b))?(a):(b))
 
 static int sg_argc = 3;
-static const char *sg_argv[] = {"", "-config", "gpgpusim.config"};
+static const char *sg_argv[] = {"", "-config","gpgpusim.config"};
 
-void *gpgpu_sim_thread_sequential(void *ctx_ptr) {
-  gpgpu_context *ctx = (gpgpu_context *)ctx_ptr;
-  // at most one kernel running at a time
-  bool done;
-  do {
-    sem_wait(&(ctx->the_gpgpusim->g_sim_signal_start));
-    done = true;
-    if (ctx->the_gpgpusim->g_the_gpu->get_more_cta_left()) {
-      done = false;
-      ctx->the_gpgpusim->g_the_gpu->init();
-      while (ctx->the_gpgpusim->g_the_gpu->active()) {
-        ctx->the_gpgpusim->g_the_gpu->cycle();
-        ctx->the_gpgpusim->g_the_gpu->deadlock_check();
+
+void * gpgpu_sim_thread_sequential(void * ctx_ptr)
+{
+    gpgpu_context * ctx = (gpgpu_context *)ctx_ptr;
+   // at most one kernel running at a time
+   bool done;
+   do {
+      sem_wait(&(ctx->the_gpgpusim->g_sim_signal_start));
+      done = true;
+      if( ctx->the_gpgpusim->g_the_gpu->get_more_cta_left() ) {
+          done = false;
+          ctx->the_gpgpusim->g_the_gpu->init();
+          while( ctx->the_gpgpusim->g_the_gpu->active() ) {
+        	  ctx->the_gpgpusim->g_the_gpu->cycle();
+        	  ctx->the_gpgpusim->g_the_gpu->deadlock_check();
+          }
+          ctx->the_gpgpusim->g_the_gpu->print_stats();
+          ctx->the_gpgpusim->g_the_gpu->update_stats();
+          ctx->print_simulation_time();
       }
-      ctx->the_gpgpusim->g_the_gpu->print_stats();
-      ctx->the_gpgpusim->g_the_gpu->update_stats();
-      ctx->print_simulation_time();
-    }
-    sem_post(&(ctx->the_gpgpusim->g_sim_signal_finish));
-  } while (!done);
-  sem_post(&(ctx->the_gpgpusim->g_sim_signal_exit));
-  return NULL;
+      sem_post(&(ctx->the_gpgpusim->g_sim_signal_finish));
+   } while(!done);
+   sem_post(&(ctx->the_gpgpusim->g_sim_signal_exit));
+   return NULL;
 }
 
-static void termination_callback() {
-  printf("GPGPU-Sim: *** exit detected ***\n");
-  fflush(stdout);
+
+
+static void termination_callback()
+{
+    printf("GPGPU-Sim: *** exit detected ***\n");
+    fflush(stdout);
 }
 
-void *gpgpu_sim_thread_concurrent(void *ctx_ptr) {
-  gpgpu_context *ctx = (gpgpu_context *)ctx_ptr;
-  atexit(termination_callback);
-  // concurrent kernel execution simulation thread
-  do {
-    if (g_debug_execution >= 3) {
-      printf(
-          "GPGPU-Sim: *** simulation thread starting and spinning waiting for "
-          "work ***\n");
-      fflush(stdout);
-    }
-    while (ctx->the_gpgpusim->g_stream_manager->empty_protected() &&
-           !ctx->the_gpgpusim->g_sim_done)
-      ;
-    if (g_debug_execution >= 3) {
-      printf("GPGPU-Sim: ** START simulation thread (detected work) **\n");
-      ctx->the_gpgpusim->g_stream_manager->print(stdout);
-      fflush(stdout);
-    }
-    pthread_mutex_lock(&(ctx->the_gpgpusim->g_sim_lock));
-    ctx->the_gpgpusim->g_sim_active = true;
-    pthread_mutex_unlock(&(ctx->the_gpgpusim->g_sim_lock));
-    bool active = false;
-    bool sim_cycles = false;
-    ctx->the_gpgpusim->g_the_gpu->init();
+void *gpgpu_sim_thread_concurrent(void * ctx_ptr)
+{
+    gpgpu_context * ctx = (gpgpu_context *)ctx_ptr;
+    atexit(termination_callback);
+    // concurrent kernel execution simulation thread
     do {
-      // check if a kernel has completed
-      // launch operation on device if one is pending and can be run
-
-      // Need to break this loop when a kernel completes. This was a
-      // source of non-deterministic behaviour in GPGPU-Sim (bug 147).
-      // If another stream operation is available, g_the_gpu remains active,
-      // causing this loop to not break. If the next operation happens to be
-      // another kernel, the gpu is not re-initialized and the inter-kernel
-      // behaviour may be incorrect. Check that a kernel has finished and
-      // no other kernel is currently running.
-      if (ctx->the_gpgpusim->g_stream_manager->operation(&sim_cycles) &&
-          !ctx->the_gpgpusim->g_the_gpu->active())
-        break;
-
-      // functional simulation
-      if (ctx->the_gpgpusim->g_the_gpu->is_functional_sim()) {
-        kernel_info_t *kernel =
-            ctx->the_gpgpusim->g_the_gpu->get_functional_kernel();
-        assert(kernel);
-        ctx->the_gpgpusim->gpgpu_ctx->func_sim->gpgpu_cuda_ptx_sim_main_func(
-            *kernel);
-        ctx->the_gpgpusim->g_the_gpu->finish_functional_sim(kernel);
-      }
-
-      // performance simulation
-      if (ctx->the_gpgpusim->g_the_gpu->active()) {
-        ctx->the_gpgpusim->g_the_gpu->cycle();
-        sim_cycles = true;
-        ctx->the_gpgpusim->g_the_gpu->deadlock_check();
-      } else {
-        if (ctx->the_gpgpusim->g_the_gpu->cycle_insn_cta_max_hit()) {
-          ctx->the_gpgpusim->g_stream_manager->stop_all_running_kernels();
-          ctx->the_gpgpusim->g_sim_done = true;
-          ctx->the_gpgpusim->break_limit = true;
+        if(g_debug_execution >= 3) {
+           printf("GPGPU-Sim: *** simulation thread starting and spinning waiting for work ***\n");
+           fflush(stdout);
         }
-      }
+        while( ctx->the_gpgpusim->g_stream_manager->empty_protected() && !ctx->the_gpgpusim->g_sim_done )
+            ;
+        if(g_debug_execution >= 3) {
+           printf("GPGPU-Sim: ** START simulation thread (detected work) **\n");
+           ctx->the_gpgpusim->g_stream_manager->print(stdout);
+           fflush(stdout);
+        }
+        pthread_mutex_lock(&(ctx->the_gpgpusim->g_sim_lock));
+        ctx->the_gpgpusim->g_sim_active = true;
+        pthread_mutex_unlock(&(ctx->the_gpgpusim->g_sim_lock));
+        bool active = false;
+        bool sim_cycles = false;
+        ctx->the_gpgpusim->g_the_gpu->init();
+        do {
+            // check if a kernel has completed
+            // launch operation on device if one is pending and can be run
 
-      active = ctx->the_gpgpusim->g_the_gpu->active() ||
-               !(ctx->the_gpgpusim->g_stream_manager->empty_protected());
+            // Need to break this loop when a kernel completes. This was a
+            // source of non-deterministic behaviour in GPGPU-Sim (bug 147).
+            // If another stream operation is available, g_the_gpu remains active,
+            // causing this loop to not break. If the next operation happens to be
+            // another kernel, the gpu is not re-initialized and the inter-kernel
+            // behaviour may be incorrect. Check that a kernel has finished and
+            // no other kernel is currently running.
+            if(ctx->the_gpgpusim->g_stream_manager->operation(&sim_cycles) && !ctx->the_gpgpusim->g_the_gpu->active())
+                break;
 
-    } while (active && !ctx->the_gpgpusim->g_sim_done);
-    if (g_debug_execution >= 3) {
-      printf("GPGPU-Sim: ** STOP simulation thread (no work) **\n");
-      fflush(stdout);
+            //functional simulation
+            if( ctx->the_gpgpusim->g_the_gpu->is_functional_sim()) {
+                kernel_info_t * kernel = ctx->the_gpgpusim->g_the_gpu->get_functional_kernel();
+                assert(kernel);
+                ctx->the_gpgpusim->gpgpu_ctx->func_sim->gpgpu_cuda_ptx_sim_main_func(*kernel);
+                ctx->the_gpgpusim->g_the_gpu->finish_functional_sim(kernel);
+            }
+
+            //performance simulation
+            if( ctx->the_gpgpusim->g_the_gpu->active() ) {
+            	ctx->the_gpgpusim->g_the_gpu->cycle();
+            	sim_cycles = true;
+            	ctx->the_gpgpusim->g_the_gpu->deadlock_check();
+            }else {
+                if(ctx->the_gpgpusim->g_the_gpu->cycle_insn_cta_max_hit()){
+                	ctx->the_gpgpusim->g_stream_manager->stop_all_running_kernels();
+                	ctx->the_gpgpusim->g_sim_done = true;
+                	ctx->the_gpgpusim->break_limit = true;
+                }
+            }
+
+            active=ctx->the_gpgpusim->g_the_gpu->active() || !(ctx->the_gpgpusim->g_stream_manager->empty_protected());
+
+        } while( active && !ctx->the_gpgpusim->g_sim_done);
+        if(g_debug_execution >= 3) {
+           printf("GPGPU-Sim: ** STOP simulation thread (no work) **\n");
+           fflush(stdout);
+        }
+        if(sim_cycles) {
+        	ctx->the_gpgpusim->g_the_gpu->print_stats();
+        	ctx->the_gpgpusim->g_the_gpu->update_stats();
+            ctx->print_simulation_time();
+        }
+        pthread_mutex_lock(&(ctx->the_gpgpusim->g_sim_lock));
+        ctx->the_gpgpusim->g_sim_active = false;
+        pthread_mutex_unlock(&(ctx->the_gpgpusim->g_sim_lock));
+    } while( !ctx->the_gpgpusim->g_sim_done );
+
+    printf("GPGPU-Sim: *** simulation thread exiting ***\n");
+    fflush(stdout);
+
+    if(ctx->the_gpgpusim->break_limit) {
+    	printf("GPGPU-Sim: ** break due to reaching the maximum cycles (or instructions) **\n");
+    	exit(1);
     }
-    if (sim_cycles) {
-      ctx->the_gpgpusim->g_the_gpu->print_stats();
-      ctx->the_gpgpusim->g_the_gpu->update_stats();
-      ctx->print_simulation_time();
+
+    sem_post(&(ctx->the_gpgpusim->g_sim_signal_exit));
+    return NULL;
+}
+
+void gpgpu_context::synchronize()
+{
+    printf("GPGPU-Sim: synchronize waiting for inactive GPU simulation\n");
+    the_gpgpusim->g_stream_manager->print(stdout);
+    fflush(stdout);
+//    sem_wait(&g_sim_signal_finish);
+    bool done = false;
+    do {
+        pthread_mutex_lock(&(the_gpgpusim->g_sim_lock));
+        done = ( the_gpgpusim->g_stream_manager->empty() && !the_gpgpusim->g_sim_active ) || the_gpgpusim->g_sim_done;
+        pthread_mutex_unlock(&(the_gpgpusim->g_sim_lock));
+    } while (!done);
+    printf("GPGPU-Sim: detected inactive GPU simulation thread\n");
+    fflush(stdout);
+//    sem_post(&g_sim_signal_start);
+}
+
+void gpgpu_context::exit_simulation()
+{
+	the_gpgpusim->g_sim_done=true;
+    printf("GPGPU-Sim: exit_simulation called\n");
+    fflush(stdout);
+    sem_wait(&(the_gpgpusim->g_sim_signal_exit));
+    printf("GPGPU-Sim: simulation thread signaled exit\n");
+    fflush(stdout);
+}
+
+gpgpu_sim *gpgpu_context::gpgpu_ptx_sim_init_perf()
+{
+   srand(1);
+   print_splash();
+   func_sim->read_sim_environment_variables();
+   ptx_parser->read_parser_environment_variables();
+   option_parser_t opp = option_parser_create();
+
+   ptx_reg_options(opp);
+   func_sim->ptx_opcocde_latency_options(opp);
+
+   icnt_reg_options(opp);
+   the_gpgpusim->g_the_gpu_config = new gpgpu_sim_config(this);
+   the_gpgpusim->g_the_gpu_config->reg_options(opp); // register GPU microrachitecture options
+
+   option_parser_cmdline(opp, sg_argc, sg_argv); // parse configuration options
+   fprintf(stdout, "GPGPU-Sim: Configuration options:\n\n");
+   option_parser_print(opp, stdout);
+   // Set the Numeric locale to a standard locale where a decimal point is a "dot" not a "comma"
+   // so it does the parsing correctly independent of the system environment variables
+   assert(setlocale(LC_NUMERIC,"C"));
+   the_gpgpusim->g_the_gpu_config->init();
+
+   the_gpgpusim->g_the_gpu = new gpgpu_sim(*(the_gpgpusim->g_the_gpu_config), this);
+   the_gpgpusim->g_stream_manager = new stream_manager((the_gpgpusim->g_the_gpu), func_sim->g_cuda_launch_blocking);
+
+   the_gpgpusim->g_simulation_starttime = time((time_t *)NULL);
+
+   sem_init(&(the_gpgpusim->g_sim_signal_start),0,0);
+   sem_init(&(the_gpgpusim->g_sim_signal_finish),0,0);
+   sem_init(&(the_gpgpusim->g_sim_signal_exit),0,0);
+
+   return the_gpgpusim->g_the_gpu;
+}
+
+void gpgpu_context::start_sim_thread(int api)
+{
+    if( the_gpgpusim->g_sim_done ) {
+    	the_gpgpusim->g_sim_done = false;
+        if( api == 1 ) {
+           pthread_create(&(the_gpgpusim->g_simulation_thread),NULL,gpgpu_sim_thread_concurrent,(void *)this);
+        } else {
+           pthread_create(&(the_gpgpusim->g_simulation_thread),NULL,gpgpu_sim_thread_sequential,(void *)this);
+        }
     }
-    pthread_mutex_lock(&(ctx->the_gpgpusim->g_sim_lock));
-    ctx->the_gpgpusim->g_sim_active = false;
-    pthread_mutex_unlock(&(ctx->the_gpgpusim->g_sim_lock));
-  } while (!ctx->the_gpgpusim->g_sim_done);
-
-  printf("GPGPU-Sim: *** simulation thread exiting ***\n");
-  fflush(stdout);
-
-  if (ctx->the_gpgpusim->break_limit) {
-    printf(
-        "GPGPU-Sim: ** break due to reaching the maximum cycles (or "
-        "instructions) **\n");
-    exit(1);
-  }
-
-  sem_post(&(ctx->the_gpgpusim->g_sim_signal_exit));
-  return NULL;
 }
 
-void gpgpu_context::synchronize() {
-  printf("GPGPU-Sim: synchronize waiting for inactive GPU simulation\n");
-  the_gpgpusim->g_stream_manager->print(stdout);
-  fflush(stdout);
-  //    sem_wait(&g_sim_signal_finish);
-  bool done = false;
-  do {
-    pthread_mutex_lock(&(the_gpgpusim->g_sim_lock));
-    done = (the_gpgpusim->g_stream_manager->empty() &&
-            !the_gpgpusim->g_sim_active) ||
-           the_gpgpusim->g_sim_done;
-    pthread_mutex_unlock(&(the_gpgpusim->g_sim_lock));
-  } while (!done);
-  printf("GPGPU-Sim: detected inactive GPU simulation thread\n");
-  fflush(stdout);
-  //    sem_post(&g_sim_signal_start);
+void gpgpu_context::print_simulation_time()
+{
+   time_t current_time, difference, d, h, m, s;
+   current_time = time((time_t *)NULL);
+   difference = MAX(current_time - the_gpgpusim->g_simulation_starttime, 1);
+
+   d = difference/(3600*24);
+   h = difference/3600 - 24*d;
+   m = difference/60 - 60*(h + 24*d);
+   s = difference - 60*(m + 60*(h + 24*d));
+
+   fflush(stderr);
+   printf("\n\ngpgpu_simulation_time = %u days, %u hrs, %u min, %u sec (%u sec)\n",
+          (unsigned)d, (unsigned)h, (unsigned)m, (unsigned)s, (unsigned)difference );
+   printf("gpgpu_simulation_rate = %u (inst/sec)\n", (unsigned)(the_gpgpusim->g_the_gpu->gpu_tot_sim_insn / difference) );
+   const unsigned cycles_per_sec = (unsigned)(the_gpgpusim->g_the_gpu->gpu_tot_sim_cycle / difference);
+   printf("gpgpu_simulation_rate = %u (cycle/sec)\n", cycles_per_sec );
+   printf("gpgpu_silicon_slowdown = %ux\n", the_gpgpusim->g_the_gpu->shader_clock() * 1000 / cycles_per_sec);
+   fflush(stdout);
 }
 
-void gpgpu_context::exit_simulation() {
-  the_gpgpusim->g_sim_done = true;
-  printf("GPGPU-Sim: exit_simulation called\n");
-  fflush(stdout);
-  sem_wait(&(the_gpgpusim->g_sim_signal_exit));
-  printf("GPGPU-Sim: simulation thread signaled exit\n");
-  fflush(stdout);
-}
-
-gpgpu_sim *gpgpu_context::gpgpu_ptx_sim_init_perf() {
-  srand(1);
-  print_splash();
-  func_sim->read_sim_environment_variables();
-  ptx_parser->read_parser_environment_variables();
-  option_parser_t opp = option_parser_create();
-
-  ptx_reg_options(opp);
-  func_sim->ptx_opcocde_latency_options(opp);
-
-  icnt_reg_options(opp);
-  the_gpgpusim->g_the_gpu_config = new gpgpu_sim_config(this);
-  the_gpgpusim->g_the_gpu_config->reg_options(
-      opp);  // register GPU microrachitecture options
-
-  option_parser_cmdline(opp, sg_argc, sg_argv);  // parse configuration options
-  fprintf(stdout, "GPGPU-Sim: Configuration options:\n\n");
-  option_parser_print(opp, stdout);
-  // Set the Numeric locale to a standard locale where a decimal point is a
-  // "dot" not a "comma"
-  // so it does the parsing correctly independent of the system environment
-  // variables
-  assert(setlocale(LC_NUMERIC, "C"));
-  the_gpgpusim->g_the_gpu_config->init();
-
-  the_gpgpusim->g_the_gpu =
-      new gpgpu_sim(*(the_gpgpusim->g_the_gpu_config), this);
-  the_gpgpusim->g_stream_manager = new stream_manager(
-      (the_gpgpusim->g_the_gpu), func_sim->g_cuda_launch_blocking);
-
-  the_gpgpusim->g_simulation_starttime = time((time_t *)NULL);
-
-  sem_init(&(the_gpgpusim->g_sim_signal_start), 0, 0);
-  sem_init(&(the_gpgpusim->g_sim_signal_finish), 0, 0);
-  sem_init(&(the_gpgpusim->g_sim_signal_exit), 0, 0);
-
-  return the_gpgpusim->g_the_gpu;
-}
-
-void gpgpu_context::start_sim_thread(int api) {
-  if (the_gpgpusim->g_sim_done) {
-    the_gpgpusim->g_sim_done = false;
-    if (api == 1) {
-      pthread_create(&(the_gpgpusim->g_simulation_thread), NULL,
-                     gpgpu_sim_thread_concurrent, (void *)this);
-    } else {
-      pthread_create(&(the_gpgpusim->g_simulation_thread), NULL,
-                     gpgpu_sim_thread_sequential, (void *)this);
-    }
-  }
-}
-
-void gpgpu_context::print_simulation_time() {
-  time_t current_time, difference, d, h, m, s;
-  current_time = time((time_t *)NULL);
-  difference = MAX(current_time - the_gpgpusim->g_simulation_starttime, 1);
-
-  d = difference / (3600 * 24);
-  h = difference / 3600 - 24 * d;
-  m = difference / 60 - 60 * (h + 24 * d);
-  s = difference - 60 * (m + 60 * (h + 24 * d));
-
-  fflush(stderr);
-  printf(
-      "\n\ngpgpu_simulation_time = %u days, %u hrs, %u min, %u sec (%u sec)\n",
-      (unsigned)d, (unsigned)h, (unsigned)m, (unsigned)s, (unsigned)difference);
-  printf("gpgpu_simulation_rate = %u (inst/sec)\n",
-         (unsigned)(the_gpgpusim->g_the_gpu->gpu_tot_sim_insn / difference));
-  const unsigned cycles_per_sec =
-      (unsigned)(the_gpgpusim->g_the_gpu->gpu_tot_sim_cycle / difference);
-  printf("gpgpu_simulation_rate = %u (cycle/sec)\n", cycles_per_sec);
-  printf("gpgpu_silicon_slowdown = %ux\n",
-         the_gpgpusim->g_the_gpu->shader_clock() * 1000 / cycles_per_sec);
-  fflush(stdout);
-}
-
-int gpgpu_context::gpgpu_opencl_ptx_sim_main_perf(kernel_info_t *grid) {
-  the_gpgpusim->g_the_gpu->launch(grid);
-  sem_post(&(the_gpgpusim->g_sim_signal_start));
-  sem_wait(&(the_gpgpusim->g_sim_signal_finish));
-  return 0;
+int gpgpu_context::gpgpu_opencl_ptx_sim_main_perf( kernel_info_t *grid )
+{
+   the_gpgpusim->g_the_gpu->launch(grid);
+   sem_post(&(the_gpgpusim->g_sim_signal_start));
+   sem_wait(&(the_gpgpusim->g_sim_signal_finish));
+   return 0;
 }
 
 //! Functional simulation of OpenCL
 /*!
  * This function call the CUDA PTX functional simulator
  */
-int cuda_sim::gpgpu_opencl_ptx_sim_main_func(kernel_info_t *grid) {
-  // calling the CUDA PTX simulator, sending the kernel by reference and a flag
-  // set to true,
-  // the flag used by the function to distinguish OpenCL calls from the CUDA
-  // simulation calls which
-  // it is needed by the called function to not register the exit the exit of
-  // OpenCL kernel as it doesn't register entering in the first place as the
-  // CUDA kernels does
-  gpgpu_cuda_ptx_sim_main_func(*grid, true);
-  return 0;
+int cuda_sim::gpgpu_opencl_ptx_sim_main_func( kernel_info_t *grid )
+{
+    //calling the CUDA PTX simulator, sending the kernel by reference and a flag set to true,
+    //the flag used by the function to distinguish OpenCL calls from the CUDA simulation calls which
+    //it is needed by the called function to not register the exit the exit of OpenCL kernel as it doesn't register entering in the first place as the CUDA kernels does
+   gpgpu_cuda_ptx_sim_main_func( *grid, true );
+   return 0;
 }

--- a/src/gpgpusim_entrypoint.h
+++ b/src/gpgpusim_entrypoint.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -28,52 +30,50 @@
 #ifndef GPGPUSIM_ENTRYPOINT_H_INCLUDED
 #define GPGPUSIM_ENTRYPOINT_H_INCLUDED
 
-#include "abstract_hardware_model.h"
 #include <pthread.h>
 #include <semaphore.h>
 #include <time.h>
+#include "abstract_hardware_model.h"
 
-//extern time_t g_simulation_starttime;
+// extern time_t g_simulation_starttime;
 class gpgpu_context;
 
 class GPGPUsim_ctx {
-    public:
-	GPGPUsim_ctx(gpgpu_context* ctx) {
-		g_sim_active = false;
-		g_sim_done = true;
-		break_limit = false;
-		g_sim_lock = PTHREAD_MUTEX_INITIALIZER;
+ public:
+  GPGPUsim_ctx(gpgpu_context *ctx) {
+    g_sim_active = false;
+    g_sim_done = true;
+    break_limit = false;
+    g_sim_lock = PTHREAD_MUTEX_INITIALIZER;
 
-		g_the_gpu_config=NULL;
-		g_the_gpu=NULL;
-		g_stream_manager=NULL;
-		the_cude_device=NULL;
-		the_context=NULL;
-		gpgpu_ctx = ctx;
-	}
+    g_the_gpu_config = NULL;
+    g_the_gpu = NULL;
+    g_stream_manager = NULL;
+    the_cude_device = NULL;
+    the_context = NULL;
+    gpgpu_ctx = ctx;
+  }
 
-	//struct gpgpu_ptx_sim_arg *grid_params;
+  // struct gpgpu_ptx_sim_arg *grid_params;
 
-	sem_t g_sim_signal_start;
-	sem_t g_sim_signal_finish;
-	sem_t g_sim_signal_exit;
-	time_t g_simulation_starttime;
-	pthread_t g_simulation_thread;
+  sem_t g_sim_signal_start;
+  sem_t g_sim_signal_finish;
+  sem_t g_sim_signal_exit;
+  time_t g_simulation_starttime;
+  pthread_t g_simulation_thread;
 
-	class gpgpu_sim_config *g_the_gpu_config;
-	class gpgpu_sim *g_the_gpu;
-	class stream_manager *g_stream_manager;
+  class gpgpu_sim_config *g_the_gpu_config;
+  class gpgpu_sim *g_the_gpu;
+  class stream_manager *g_stream_manager;
 
-	struct _cuda_device_id *the_cude_device;
-	struct CUctx_st* the_context;
-	gpgpu_context* gpgpu_ctx;
+  struct _cuda_device_id *the_cude_device;
+  struct CUctx_st *the_context;
+  gpgpu_context *gpgpu_ctx;
 
-
-	 pthread_mutex_t g_sim_lock;
-	 bool g_sim_active;
-	 bool g_sim_done;
-	 bool break_limit;
-
+  pthread_mutex_t g_sim_lock;
+  bool g_sim_active;
+  bool g_sim_done;
+  bool break_limit;
 };
 
 #endif

--- a/src/gpgpusim_entrypoint.h
+++ b/src/gpgpusim_entrypoint.h
@@ -7,73 +7,72 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef GPGPUSIM_ENTRYPOINT_H_INCLUDED
 #define GPGPUSIM_ENTRYPOINT_H_INCLUDED
 
-#include "abstract_hardware_model.h"
 #include <pthread.h>
 #include <semaphore.h>
 #include <time.h>
+#include "abstract_hardware_model.h"
 
-//extern time_t g_simulation_starttime;
+// extern time_t g_simulation_starttime;
 class gpgpu_context;
 
 class GPGPUsim_ctx {
-    public:
-	GPGPUsim_ctx(gpgpu_context* ctx) {
-		g_sim_active = false;
-		g_sim_done = true;
-		break_limit = false;
-		g_sim_lock = PTHREAD_MUTEX_INITIALIZER;
+ public:
+  GPGPUsim_ctx(gpgpu_context *ctx) {
+    g_sim_active = false;
+    g_sim_done = true;
+    break_limit = false;
+    g_sim_lock = PTHREAD_MUTEX_INITIALIZER;
 
-		g_the_gpu_config=NULL;
-		g_the_gpu=NULL;
-		g_stream_manager=NULL;
-		the_cude_device=NULL;
-		the_context=NULL;
-		gpgpu_ctx = ctx;
-	}
+    g_the_gpu_config = NULL;
+    g_the_gpu = NULL;
+    g_stream_manager = NULL;
+    the_cude_device = NULL;
+    the_context = NULL;
+    gpgpu_ctx = ctx;
+  }
 
-	//struct gpgpu_ptx_sim_arg *grid_params;
+  // struct gpgpu_ptx_sim_arg *grid_params;
 
-	sem_t g_sim_signal_start;
-	sem_t g_sim_signal_finish;
-	sem_t g_sim_signal_exit;
-	time_t g_simulation_starttime;
-	pthread_t g_simulation_thread;
+  sem_t g_sim_signal_start;
+  sem_t g_sim_signal_finish;
+  sem_t g_sim_signal_exit;
+  time_t g_simulation_starttime;
+  pthread_t g_simulation_thread;
 
-	class gpgpu_sim_config *g_the_gpu_config;
-	class gpgpu_sim *g_the_gpu;
-	class stream_manager *g_stream_manager;
+  class gpgpu_sim_config *g_the_gpu_config;
+  class gpgpu_sim *g_the_gpu;
+  class stream_manager *g_stream_manager;
 
-	struct _cuda_device_id *the_cude_device;
-	struct CUctx_st* the_context;
-	gpgpu_context* gpgpu_ctx;
+  struct _cuda_device_id *the_cude_device;
+  struct CUctx_st *the_context;
+  gpgpu_context *gpgpu_ctx;
 
-
-	 pthread_mutex_t g_sim_lock;
-	 bool g_sim_active;
-	 bool g_sim_done;
-	 bool break_limit;
-
+  pthread_mutex_t g_sim_lock;
+  bool g_sim_active;
+  bool g_sim_done;
+  bool break_limit;
 };
 
 #endif

--- a/src/gpgpusim_entrypoint.h
+++ b/src/gpgpusim_entrypoint.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -30,50 +28,52 @@
 #ifndef GPGPUSIM_ENTRYPOINT_H_INCLUDED
 #define GPGPUSIM_ENTRYPOINT_H_INCLUDED
 
+#include "abstract_hardware_model.h"
 #include <pthread.h>
 #include <semaphore.h>
 #include <time.h>
-#include "abstract_hardware_model.h"
 
-// extern time_t g_simulation_starttime;
+//extern time_t g_simulation_starttime;
 class gpgpu_context;
 
 class GPGPUsim_ctx {
- public:
-  GPGPUsim_ctx(gpgpu_context *ctx) {
-    g_sim_active = false;
-    g_sim_done = true;
-    break_limit = false;
-    g_sim_lock = PTHREAD_MUTEX_INITIALIZER;
+    public:
+	GPGPUsim_ctx(gpgpu_context* ctx) {
+		g_sim_active = false;
+		g_sim_done = true;
+		break_limit = false;
+		g_sim_lock = PTHREAD_MUTEX_INITIALIZER;
 
-    g_the_gpu_config = NULL;
-    g_the_gpu = NULL;
-    g_stream_manager = NULL;
-    the_cude_device = NULL;
-    the_context = NULL;
-    gpgpu_ctx = ctx;
-  }
+		g_the_gpu_config=NULL;
+		g_the_gpu=NULL;
+		g_stream_manager=NULL;
+		the_cude_device=NULL;
+		the_context=NULL;
+		gpgpu_ctx = ctx;
+	}
 
-  // struct gpgpu_ptx_sim_arg *grid_params;
+	//struct gpgpu_ptx_sim_arg *grid_params;
 
-  sem_t g_sim_signal_start;
-  sem_t g_sim_signal_finish;
-  sem_t g_sim_signal_exit;
-  time_t g_simulation_starttime;
-  pthread_t g_simulation_thread;
+	sem_t g_sim_signal_start;
+	sem_t g_sim_signal_finish;
+	sem_t g_sim_signal_exit;
+	time_t g_simulation_starttime;
+	pthread_t g_simulation_thread;
 
-  class gpgpu_sim_config *g_the_gpu_config;
-  class gpgpu_sim *g_the_gpu;
-  class stream_manager *g_stream_manager;
+	class gpgpu_sim_config *g_the_gpu_config;
+	class gpgpu_sim *g_the_gpu;
+	class stream_manager *g_stream_manager;
 
-  struct _cuda_device_id *the_cude_device;
-  struct CUctx_st *the_context;
-  gpgpu_context *gpgpu_ctx;
+	struct _cuda_device_id *the_cude_device;
+	struct CUctx_st* the_context;
+	gpgpu_context* gpgpu_ctx;
 
-  pthread_mutex_t g_sim_lock;
-  bool g_sim_active;
-  bool g_sim_done;
-  bool break_limit;
+
+	 pthread_mutex_t g_sim_lock;
+	 bool g_sim_active;
+	 bool g_sim_done;
+	 bool break_limit;
+
 };
 
 #endif

--- a/src/gpuwattch/XML_Parse.cc
+++ b/src/gpuwattch/XML_Parse.cc
@@ -29,2102 +29,4556 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:												   *
-*      Jingwen Leng, Univeristy of Texas, Austin                   *
-*      Syed Gilani, University of Wisconsin–Madison                *
-*      Tayler Hetherington, University of British Columbia         *
-*      Ahmed ElTantawy, University of British Columbia             *
-********************************************************************/
+ *      Modified by:
+ ** Jingwen Leng, Univeristy of Texas, Austin                   * Syed Gilani,
+ *University of Wisconsin–Madison                * Tayler Hetherington,
+ *University of British Columbia         * Ahmed ElTantawy, University of
+ *British Columbia             *
+ ********************************************************************/
 
-#include <stdio.h>
-#include "xmlParser.h"
-#include <string>
 #include "XML_Parse.h"
+#include <stdio.h>
+#include <string>
+#include "xmlParser.h"
 
 using namespace std;
 
-const char * perf_count_label[] = {"TOT_INST,", "FP_INT,", "IC_H,", "IC_M,", "DC_RH,", "DC_RM,", "DC_WH,", "DC_WM,",
-                                "TC_H,", "TC_M,", "CC_H,", "CC_M,", "SHRD_ACC,", "REG_RD,", "REG_WR,", "NON_REG_OPs,",
-                                "SP_ACC,", "SFU_ACC,", "FPU_ACC,", "MEM_RD,","MEM_WR,", "MEM_PRE,", "L2_RH,", "L2_RM,", "L2_WH,",
-                                "L2_WM,", "NOC_A,", "PIPE_A,", "IDLE_CORE_N,", "CONST_DYNAMICN"};
+const char* perf_count_label[] = {
+    "TOT_INST,",    "FP_INT,",  "IC_H,",     "IC_M,",        "DC_RH,",
+    "DC_RM,",       "DC_WH,",   "DC_WM,",    "TC_H,",        "TC_M,",
+    "CC_H,",        "CC_M,",    "SHRD_ACC,", "REG_RD,",      "REG_WR,",
+    "NON_REG_OPs,", "SP_ACC,",  "SFU_ACC,",  "FPU_ACC,",     "MEM_RD,",
+    "MEM_WR,",      "MEM_PRE,", "L2_RH,",    "L2_RM,",       "L2_WH,",
+    "L2_WM,",       "NOC_A,",   "PIPE_A,",   "IDLE_CORE_N,", "CONST_DYNAMICN"};
 
-void ParseXML::parse(char* filepath)
-{
-	unsigned int i,j,k,m,n;
-	unsigned int NumofCom_4;
-	unsigned int itmp;
-	//Initialize all structures
-	ParseXML::initialize();
-	string strtmp;
-	char chtmp[60];
-	char chtmp1[60];
-	chtmp1[0]='\0';
-	// this open and parse the XML file:
-	XMLNode xMainNode=XMLNode::openFileHelper(filepath,"component"); //the 'component' in the first layer
+void ParseXML::parse(char* filepath) {
+  unsigned int i, j, k, m, n;
+  unsigned int NumofCom_4;
+  unsigned int itmp;
+  // Initialize all structures
+  ParseXML::initialize();
+  string strtmp;
+  char chtmp[60];
+  char chtmp1[60];
+  chtmp1[0] = '\0';
+  // this open and parse the XML file:
+  XMLNode xMainNode = XMLNode::openFileHelper(
+      filepath, "component");  // the 'component' in the first layer
 
-	XMLNode xNode2=xMainNode.getChildNode("component"); // the 'component' in the second layer
-	//get all params in the second layer
-	itmp=xNode2.nChildNode("param");
-	for(i=0; i<itmp; i++)
-	{
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"GPU_Architecture")==0) {sys.GPU_Architecture=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"number_of_cores")==0) {sys.number_of_cores=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"architecture")==0) {sys.architecture=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"number_of_L1Directories")==0) {sys.number_of_L1Directories=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"number_of_L2Directories")==0) {sys.number_of_L2Directories=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"number_of_L2s")==0) {sys.number_of_L2s=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"Private_L2")==0) {sys.Private_L2=(bool)atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"number_of_L3s")==0) {sys.number_of_L3s=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"number_of_NoCs")==0) {sys.number_of_NoCs=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"number_of_dir_levels")==0) {sys.number_of_dir_levels=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"domain_size")==0) {sys.domain_size=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"first_level_dir")==0) {sys.first_level_dir=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"homogeneous_cores")==0) {sys.homogeneous_cores=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"core_tech_node")==0) {sys.core_tech_node=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"target_core_clockrate")==0) {sys.target_core_clockrate=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"target_chip_area")==0) {sys.target_chip_area=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"temperature")==0) {sys.temperature=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"number_cache_levels")==0) {sys.number_cache_levels=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"L1_property")==0) {sys.L1_property =atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"L2_property")==0) {sys.L2_property =atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"homogeneous_L2s")==0) {sys.homogeneous_L2s=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"homogeneous_L1Directories")==0) {sys.homogeneous_L1Directories=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"homogeneous_L2Directories")==0) {sys.homogeneous_L2Directories=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"L3_property")==0) {sys.L3_property =atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"homogeneous_L3s")==0) {sys.homogeneous_L3s=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"homogeneous_ccs")==0) {sys.homogeneous_ccs=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"homogeneous_NoCs")==0) {sys.homogeneous_NoCs=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"Max_area_deviation")==0) {sys.Max_area_deviation=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"Max_power_deviation")==0) {sys.Max_power_deviation=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"device_type")==0) {sys.device_type=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"longer_channel_device")==0) {sys.longer_channel_device=(bool)atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"opt_dynamic_power")==0) {sys.opt_dynamic_power=(bool)atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"opt_lakage_power")==0) {sys.opt_lakage_power=(bool)atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"opt_clockrate")==0) {sys.opt_clockrate=(bool)atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"opt_area")==0) {sys.opt_area=(bool)atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"Embedded")==0) {sys.Embedded=(bool)atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"interconnect_projection_type")==0) {sys.interconnect_projection_type=atoi(xNode2.getChildNode("param",i).getAttribute("value"))==0?0:1;continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"machine_bits")==0) {sys.machine_bits=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"virtual_address_width")==0) {sys.virtual_address_width=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"physical_address_width")==0) {sys.physical_address_width=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"virtual_memory_page_size")==0) {sys.virtual_memory_page_size=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"idle_core_power")==0) {sys.idle_core_power=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"TOT_INST")==0) {sys.scaling_coefficients[TOT_INST]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"FP_INT")==0) {sys.scaling_coefficients[FP_INT]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"IC_H")==0) {sys.scaling_coefficients[IC_H]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"IC_M")==0) {sys.scaling_coefficients[IC_M]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"DC_RH")==0) {sys.scaling_coefficients[DC_RH]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"DC_RM")==0) {sys.scaling_coefficients[DC_RM]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"DC_WH")==0) {sys.scaling_coefficients[DC_WH]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"DC_WM")==0) {sys.scaling_coefficients[DC_WM]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"TC_H")==0) {sys.scaling_coefficients[TC_H]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"TC_M")==0) {sys.scaling_coefficients[TC_M]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"CC_H")==0) {sys.scaling_coefficients[CC_H]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"CC_M")==0) {sys.scaling_coefficients[CC_M]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"SHRD_ACC")==0) {sys.scaling_coefficients[SHRD_ACC]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"REG_RD")==0) {sys.scaling_coefficients[REG_RD]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"REG_WR")==0) {sys.scaling_coefficients[REG_WR]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"NON_REG_OPs")==0) {sys.scaling_coefficients[NON_REG_OPs]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"SP_ACC")==0) {sys.scaling_coefficients[SP_ACC]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"SFU_ACC")==0) {sys.scaling_coefficients[SFU_ACC]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"FPU_ACC")==0) {sys.scaling_coefficients[FPU_ACC]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"MEM_RD")==0) {sys.scaling_coefficients[MEM_RD]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"MEM_WR")==0) {sys.scaling_coefficients[MEM_WR]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"MEM_PRE")==0) {sys.scaling_coefficients[MEM_PRE]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"L2_RH")==0) {sys.scaling_coefficients[L2_RH]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"L2_RM")==0) {sys.scaling_coefficients[L2_RM]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"L2_WH")==0) {sys.scaling_coefficients[L2_WH]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"L2_WM")==0) {sys.scaling_coefficients[L2_WM]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"NOC_A")==0) {sys.scaling_coefficients[NOC_A]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"PIPE_A")==0) {sys.scaling_coefficients[PIPE_A]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"IDLE_CORE_N")==0) {sys.scaling_coefficients[IDLE_CORE_N]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"CONST_DYNAMICN")==0) {sys.scaling_coefficients[CONST_DYNAMICN]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+  XMLNode xNode2 = xMainNode.getChildNode(
+      "component");  // the 'component' in the second layer
+  // get all params in the second layer
+  itmp = xNode2.nChildNode("param");
+  for (i = 0; i < itmp; i++) {
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "GPU_Architecture") == 0) {
+      sys.GPU_Architecture =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "number_of_cores") == 0) {
+      sys.number_of_cores =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "architecture") == 0) {
+      sys.architecture =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "number_of_L1Directories") == 0) {
+      sys.number_of_L1Directories =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "number_of_L2Directories") == 0) {
+      sys.number_of_L2Directories =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "number_of_L2s") == 0) {
+      sys.number_of_L2s =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "Private_L2") == 0) {
+      sys.Private_L2 =
+          (bool)atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "number_of_L3s") == 0) {
+      sys.number_of_L3s =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "number_of_NoCs") == 0) {
+      sys.number_of_NoCs =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "number_of_dir_levels") == 0) {
+      sys.number_of_dir_levels =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "domain_size") == 0) {
+      sys.domain_size =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "first_level_dir") == 0) {
+      sys.first_level_dir =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "homogeneous_cores") == 0) {
+      sys.homogeneous_cores =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "core_tech_node") == 0) {
+      sys.core_tech_node =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "target_core_clockrate") == 0) {
+      sys.target_core_clockrate =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "target_chip_area") == 0) {
+      sys.target_chip_area =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "temperature") == 0) {
+      sys.temperature =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "number_cache_levels") == 0) {
+      sys.number_cache_levels =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "L1_property") == 0) {
+      sys.L1_property =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "L2_property") == 0) {
+      sys.L2_property =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "homogeneous_L2s") == 0) {
+      sys.homogeneous_L2s =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "homogeneous_L1Directories") == 0) {
+      sys.homogeneous_L1Directories =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "homogeneous_L2Directories") == 0) {
+      sys.homogeneous_L2Directories =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "L3_property") == 0) {
+      sys.L3_property =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "homogeneous_L3s") == 0) {
+      sys.homogeneous_L3s =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "homogeneous_ccs") == 0) {
+      sys.homogeneous_ccs =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "homogeneous_NoCs") == 0) {
+      sys.homogeneous_NoCs =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "Max_area_deviation") == 0) {
+      sys.Max_area_deviation =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "Max_power_deviation") == 0) {
+      sys.Max_power_deviation =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "device_type") == 0) {
+      sys.device_type =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "longer_channel_device") == 0) {
+      sys.longer_channel_device =
+          (bool)atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "opt_dynamic_power") == 0) {
+      sys.opt_dynamic_power =
+          (bool)atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "opt_lakage_power") == 0) {
+      sys.opt_lakage_power =
+          (bool)atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "opt_clockrate") == 0) {
+      sys.opt_clockrate =
+          (bool)atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "opt_area") == 0) {
+      sys.opt_area =
+          (bool)atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "Embedded") == 0) {
+      sys.Embedded =
+          (bool)atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "interconnect_projection_type") == 0) {
+      sys.interconnect_projection_type =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value")) == 0 ? 0
+                                                                           : 1;
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "machine_bits") == 0) {
+      sys.machine_bits =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "virtual_address_width") == 0) {
+      sys.virtual_address_width =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "physical_address_width") == 0) {
+      sys.physical_address_width =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "virtual_memory_page_size") == 0) {
+      sys.virtual_memory_page_size =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "idle_core_power") == 0) {
+      sys.idle_core_power =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "TOT_INST") == 0) {
+      sys.scaling_coefficients[TOT_INST] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "FP_INT") == 0) {
+      sys.scaling_coefficients[FP_INT] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "IC_H") ==
+        0) {
+      sys.scaling_coefficients[IC_H] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "IC_M") ==
+        0) {
+      sys.scaling_coefficients[IC_M] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "DC_RH") ==
+        0) {
+      sys.scaling_coefficients[DC_RH] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "DC_RM") ==
+        0) {
+      sys.scaling_coefficients[DC_RM] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "DC_WH") ==
+        0) {
+      sys.scaling_coefficients[DC_WH] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "DC_WM") ==
+        0) {
+      sys.scaling_coefficients[DC_WM] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "TC_H") ==
+        0) {
+      sys.scaling_coefficients[TC_H] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "TC_M") ==
+        0) {
+      sys.scaling_coefficients[TC_M] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "CC_H") ==
+        0) {
+      sys.scaling_coefficients[CC_H] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "CC_M") ==
+        0) {
+      sys.scaling_coefficients[CC_M] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "SHRD_ACC") == 0) {
+      sys.scaling_coefficients[SHRD_ACC] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "REG_RD") == 0) {
+      sys.scaling_coefficients[REG_RD] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "REG_WR") == 0) {
+      sys.scaling_coefficients[REG_WR] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "NON_REG_OPs") == 0) {
+      sys.scaling_coefficients[NON_REG_OPs] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "SP_ACC") == 0) {
+      sys.scaling_coefficients[SP_ACC] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "SFU_ACC") == 0) {
+      sys.scaling_coefficients[SFU_ACC] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "FPU_ACC") == 0) {
+      sys.scaling_coefficients[FPU_ACC] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "MEM_RD") == 0) {
+      sys.scaling_coefficients[MEM_RD] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "MEM_WR") == 0) {
+      sys.scaling_coefficients[MEM_WR] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "MEM_PRE") == 0) {
+      sys.scaling_coefficients[MEM_PRE] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "L2_RH") ==
+        0) {
+      sys.scaling_coefficients[L2_RH] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "L2_RM") ==
+        0) {
+      sys.scaling_coefficients[L2_RM] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "L2_WH") ==
+        0) {
+      sys.scaling_coefficients[L2_WH] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "L2_WM") ==
+        0) {
+      sys.scaling_coefficients[L2_WM] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "NOC_A") ==
+        0) {
+      sys.scaling_coefficients[NOC_A] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "PIPE_A") == 0) {
+      sys.scaling_coefficients[PIPE_A] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "IDLE_CORE_N") == 0) {
+      sys.scaling_coefficients[IDLE_CORE_N] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "CONST_DYNAMICN") == 0) {
+      sys.scaling_coefficients[CONST_DYNAMICN] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
 
-/*
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"scaling_coefficients")==0)
-		{
-			strtmp.assign(xNode2.getChildNode("param",i).getAttribute("value"));
-			m=0;
-			for(n=0; n<strtmp.length(); n++)
-			{
-				if (strtmp[n]!=',')
-				{
-					sprintf(chtmp,"%c",strtmp[n]);
-					strcat(chtmp1,chtmp);
-				}
-				else{
-					sys.scaling_coefficients[m]=atof(chtmp1);
-					m++;
-					chtmp1[0]='\0';
-				}
-			}
-			sys.scaling_coefficients[m]=atof(chtmp1);
-			m++;
-			chtmp1[0]='\0';
-			continue;
-		}
-*/
-	}
+    /*
+                    if
+       (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"scaling_coefficients")==0)
+                    {
+                            strtmp.assign(xNode2.getChildNode("param",i).getAttribute("value"));
+                            m=0;
+                            for(n=0; n<strtmp.length(); n++)
+                            {
+                                    if (strtmp[n]!=',')
+                                    {
+                                            sprintf(chtmp,"%c",strtmp[n]);
+                                            strcat(chtmp1,chtmp);
+                                    }
+                                    else{
+                                            sys.scaling_coefficients[m]=atof(chtmp1);
+                                            m++;
+                                            chtmp1[0]='\0';
+                                    }
+                            }
+                            sys.scaling_coefficients[m]=atof(chtmp1);
+                            m++;
+                            chtmp1[0]='\0';
+                            continue;
+                    }
+    */
+  }
 
-//	if (sys.Private_L2 && sys.number_of_cores!=sys.number_of_L2s)
-//	{
-//		cout<<"Private L2: Number of L2s must equal to Number of Cores"<<endl;
-//		exit(0);
-//	}
+  //	if (sys.Private_L2 && sys.number_of_cores!=sys.number_of_L2s)
+  //	{
+  //		cout<<"Private L2: Number of L2s must equal to Number of
+  // Cores"<<endl; 		exit(0);
+  //	}
 
-	itmp=xNode2.nChildNode("stat");
-	for(i=0; i<itmp; i++)
-	{
-		if (strcmp(xNode2.getChildNode("stat",i).getAttribute("name"),"total_cycles")==0) {sys.total_cycles=atof(xNode2.getChildNode("stat",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("stat",i).getAttribute("name"),"num_idle_cores")==0) {sys.num_idle_cores=atoi(xNode2.getChildNode("stat",i).getAttribute("value"));continue;}
+  itmp = xNode2.nChildNode("stat");
+  for (i = 0; i < itmp; i++) {
+    if (strcmp(xNode2.getChildNode("stat", i).getAttribute("name"),
+               "total_cycles") == 0) {
+      sys.total_cycles =
+          atof(xNode2.getChildNode("stat", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("stat", i).getAttribute("name"),
+               "num_idle_cores") == 0) {
+      sys.num_idle_cores =
+          atoi(xNode2.getChildNode("stat", i).getAttribute("value"));
+      continue;
+    }
+  }
 
-	}
+  // get the number of components within the second layer
+  unsigned int NumofCom_3 = xNode2.nChildNode("component");
+  XMLNode xNode3, xNode4;  // define the third-layer(system.core0) and
+                           // fourth-layer(system.core0.predictor) xnodes
 
+  unsigned int OrderofComponents_3layer = 0;
+  if (NumofCom_3 > OrderofComponents_3layer) {
+    //___________________________get all
+    // system.core0-n________________________________________________
+    if (sys.homogeneous_cores == 1)
+      OrderofComponents_3layer = 0;
+    else
+      OrderofComponents_3layer = sys.number_of_cores - 1;
+    for (i = 0; i <= OrderofComponents_3layer; i++) {
+      xNode3 = xNode2.getChildNode("component", i);
+      if (xNode3.isEmpty() == 1) {
+        printf(
+            "The value of homogeneous_cores or number_of_cores is not "
+            "correct!");
+        exit(0);
+      } else {
+        if (strstr(xNode3.getAttribute("name"), "core") != NULL) {
+          {  // For cpu0-cpui
+            // Get all params with system.core?
+            itmp = xNode3.nChildNode("param");
+            for (k = 0; k < itmp; k++) {
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "clock_rate") == 0) {
+                sys.core[i].clock_rate =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "opt_local") == 0) {
+                sys.core[i].opt_local = (bool)atoi(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "x86") == 0) {
+                sys.core[i].x86 = (bool)atoi(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "machine_bits") == 0) {
+                sys.core[i].machine_bits =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "virtual_address_width") == 0) {
+                sys.core[i].virtual_address_width =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "physical_address_width") == 0) {
+                sys.core[i].physical_address_width =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "instruction_length") == 0) {
+                sys.core[i].instruction_length =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "opcode_width") == 0) {
+                sys.core[i].opcode_width =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "micro_opcode_width") == 0) {
+                sys.core[i].micro_opcode_width =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "machine_type") == 0) {
+                sys.core[i].machine_type =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "internal_datapath_width") == 0) {
+                sys.core[i].internal_datapath_width =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "number_hardware_threads") == 0) {
+                sys.core[i].number_hardware_threads =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "fetch_width") == 0) {
+                sys.core[i].fetch_width =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "number_instruction_fetch_ports") == 0) {
+                sys.core[i].number_instruction_fetch_ports =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "decode_width") == 0) {
+                sys.core[i].decode_width =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "issue_width") == 0) {
+                sys.core[i].issue_width =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "peak_issue_width") == 0) {
+                sys.core[i].peak_issue_width =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "commit_width") == 0) {
+                sys.core[i].commit_width =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "fp_issue_width") == 0) {
+                sys.core[i].fp_issue_width =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "prediction_width") == 0) {
+                sys.core[i].prediction_width =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
 
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "pipelines_per_core") == 0) {
+                strtmp.assign(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                m = 0;
+                for (n = 0; n < strtmp.length(); n++) {
+                  if (strtmp[n] != ',') {
+                    sprintf(chtmp, "%c", strtmp[n]);
+                    strcat(chtmp1, chtmp);
+                  } else {
+                    sys.core[i].pipelines_per_core[m] = atoi(chtmp1);
+                    m++;
+                    chtmp1[0] = '\0';
+                  }
+                }
+                sys.core[i].pipelines_per_core[m] = atoi(chtmp1);
+                m++;
+                chtmp1[0] = '\0';
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "pipeline_depth") == 0) {
+                strtmp.assign(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                m = 0;
+                for (n = 0; n < strtmp.length(); n++) {
+                  if (strtmp[n] != ',') {
+                    sprintf(chtmp, "%c", strtmp[n]);
+                    strcat(chtmp1, chtmp);
+                  } else {
+                    sys.core[i].pipeline_depth[m] = atoi(chtmp1);
+                    m++;
+                    chtmp1[0] = '\0';
+                  }
+                }
+                sys.core[i].pipeline_depth[m] = atoi(chtmp1);
+                m++;
+                chtmp1[0] = '\0';
+                continue;
+              }
 
-	//get the number of components within the second layer
-	unsigned int NumofCom_3=xNode2.nChildNode("component");
-	XMLNode xNode3,xNode4; //define the third-layer(system.core0) and fourth-layer(system.core0.predictor) xnodes
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "FPU") == 0) {
+                strcpy(sys.core[i].FPU,
+                       xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "divider_multiplier") == 0) {
+                strcpy(sys.core[i].divider_multiplier,
+                       xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "ALU_per_core") == 0) {
+                sys.core[i].ALU_per_core =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "FPU_per_core") == 0) {
+                sys.core[i].FPU_per_core =
+                    atof(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "MUL_per_core") == 0) {
+                sys.core[i].MUL_per_core =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "instruction_buffer_size") == 0) {
+                sys.core[i].instruction_buffer_size =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "decoded_stream_buffer_size") == 0) {
+                sys.core[i].decoded_stream_buffer_size =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "instruction_window_scheme") == 0) {
+                sys.core[i].instruction_window_scheme =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "instruction_window_size") == 0) {
+                sys.core[i].instruction_window_size =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "fp_instruction_window_size") == 0) {
+                sys.core[i].fp_instruction_window_size =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "ROB_size") == 0) {
+                sys.core[i].ROB_size =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "rf_banks") == 0) {
+                sys.core[i].rf_banks =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "simd_width") == 0) {
+                sys.core[i].simd_width =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "collector_units") == 0) {
+                sys.core[i].collector_units =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "core_clock_ratio") == 0) {
+                sys.core[i].core_clock_ratio =
+                    atof(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "warp_size") == 0) {
+                sys.core[i].warp_size =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
 
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "archi_Regs_IRF_size") == 0) {
+                sys.core[i].archi_Regs_IRF_size =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "archi_Regs_FRF_size") == 0) {
+                sys.core[i].archi_Regs_FRF_size =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "phy_Regs_IRF_size") == 0) {
+                sys.core[i].phy_Regs_IRF_size =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "phy_Regs_FRF_size") == 0) {
+                sys.core[i].phy_Regs_FRF_size =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "rename_scheme") == 0) {
+                sys.core[i].rename_scheme =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "register_windows_size") == 0) {
+                sys.core[i].register_windows_size =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "LSU_order") == 0) {
+                strcpy(sys.core[i].LSU_order,
+                       xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "store_buffer_size") == 0) {
+                sys.core[i].store_buffer_size =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "load_buffer_size") == 0) {
+                sys.core[i].load_buffer_size =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "memory_ports") == 0) {
+                sys.core[i].memory_ports =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "Dcache_dual_pump") == 0) {
+                strcpy(sys.core[i].Dcache_dual_pump,
+                       xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "RAS_size") == 0) {
+                sys.core[i].RAS_size =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+            }
+            // Get all stats with system.core?
+            itmp = xNode3.nChildNode("stat");
+            for (k = 0; k < itmp; k++) {
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "total_instructions") == 0) {
+                sys.core[i].total_instructions =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "int_instructions") == 0) {
+                sys.core[i].int_instructions =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "fp_instructions") == 0) {
+                sys.core[i].fp_instructions =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "branch_instructions") == 0) {
+                sys.core[i].branch_instructions =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "branch_mispredictions") == 0) {
+                sys.core[i].branch_mispredictions =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "committed_instructions") == 0) {
+                sys.core[i].committed_instructions =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "committed_int_instructions") == 0) {
+                sys.core[i].committed_int_instructions =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "committed_fp_instructions") == 0) {
+                sys.core[i].committed_fp_instructions =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "load_instructions") == 0) {
+                sys.core[i].load_instructions =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "store_instructions") == 0) {
+                sys.core[i].store_instructions =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "total_cycles") == 0) {
+                sys.core[i].total_cycles =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "idle_cycles") == 0) {
+                sys.core[i].idle_cycles =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "busy_cycles") == 0) {
+                sys.core[i].busy_cycles =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "instruction_buffer_reads") == 0) {
+                sys.core[i].instruction_buffer_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "instruction_buffer_write") == 0) {
+                sys.core[i].instruction_buffer_write =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "ROB_reads") == 0) {
+                sys.core[i].ROB_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "ROB_writes") == 0) {
+                sys.core[i].ROB_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "rename_reads") == 0) {
+                sys.core[i].rename_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "rename_writes") == 0) {
+                sys.core[i].rename_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "fp_rename_reads") == 0) {
+                sys.core[i].fp_rename_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "fp_rename_writes") == 0) {
+                sys.core[i].fp_rename_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "inst_window_reads") == 0) {
+                sys.core[i].inst_window_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "inst_window_writes") == 0) {
+                sys.core[i].inst_window_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "inst_window_wakeup_accesses") == 0) {
+                sys.core[i].inst_window_wakeup_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "inst_window_selections") == 0) {
+                sys.core[i].inst_window_selections =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "fp_inst_window_reads") == 0) {
+                sys.core[i].fp_inst_window_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "fp_inst_window_writes") == 0) {
+                sys.core[i].fp_inst_window_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "fp_inst_window_wakeup_accesses") == 0) {
+                sys.core[i].fp_inst_window_wakeup_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "archi_int_regfile_reads") == 0) {
+                sys.core[i].archi_int_regfile_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "archi_float_regfile_reads") == 0) {
+                sys.core[i].archi_float_regfile_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "phy_int_regfile_reads") == 0) {
+                sys.core[i].phy_int_regfile_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "phy_float_regfile_reads") == 0) {
+                sys.core[i].phy_float_regfile_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "phy_int_regfile_writes") == 0) {
+                sys.core[i].archi_int_regfile_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "phy_float_regfile_writes") == 0) {
+                sys.core[i].archi_float_regfile_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "archi_int_regfile_writes") == 0) {
+                sys.core[i].phy_int_regfile_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "archi_float_regfile_writes") == 0) {
+                sys.core[i].phy_float_regfile_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "int_regfile_reads") == 0) {
+                sys.core[i].int_regfile_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "float_regfile_reads") == 0) {
+                sys.core[i].float_regfile_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "int_regfile_writes") == 0) {
+                sys.core[i].int_regfile_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "float_regfile_writes") == 0) {
+                sys.core[i].float_regfile_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "non_rf_operands") == 0) {
+                sys.core[i].non_rf_operands =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
 
-	unsigned int OrderofComponents_3layer=0;
-	if (NumofCom_3>OrderofComponents_3layer)
-	{
-		//___________________________get all system.core0-n________________________________________________
-		if (sys.homogeneous_cores==1) OrderofComponents_3layer=0;
-		else OrderofComponents_3layer=sys.number_of_cores-1;
-		for (i=0; i<=OrderofComponents_3layer; i++)
-		{
-			xNode3=xNode2.getChildNode("component",i);
-			if (xNode3.isEmpty()==1) {
-				printf("The value of homogeneous_cores or number_of_cores is not correct!");
-				exit(0);
-			}
-			else{
-				if (strstr(xNode3.getAttribute("name"),"core")!=NULL)
-				{
-					{ //For cpu0-cpui
-						//Get all params with system.core?
-						itmp=xNode3.nChildNode("param");
-						for(k=0; k<itmp; k++)
-						{
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"clock_rate")==0) {sys.core[i].clock_rate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"opt_local")==0) {sys.core[i].opt_local=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"x86")==0) {sys.core[i].x86=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"machine_bits")==0) {sys.core[i].machine_bits=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"virtual_address_width")==0) {sys.core[i].virtual_address_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"physical_address_width")==0) {sys.core[i].physical_address_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"instruction_length")==0) {sys.core[i].instruction_length=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"opcode_width")==0) {sys.core[i].opcode_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"micro_opcode_width")==0) {sys.core[i].micro_opcode_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"machine_type")==0) {sys.core[i].machine_type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"internal_datapath_width")==0) {sys.core[i].internal_datapath_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_hardware_threads")==0) {sys.core[i].number_hardware_threads=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"fetch_width")==0) {sys.core[i].fetch_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_instruction_fetch_ports")==0) {sys.core[i].number_instruction_fetch_ports=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"decode_width")==0) {sys.core[i].decode_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"issue_width")==0) {sys.core[i].issue_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"peak_issue_width")==0) {sys.core[i].peak_issue_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"commit_width")==0) {sys.core[i].commit_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"fp_issue_width")==0) {sys.core[i].fp_issue_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"prediction_width")==0) {sys.core[i].prediction_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "windowed_reg_accesses") == 0) {
+                sys.core[i].windowed_reg_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "windowed_reg_transports") == 0) {
+                sys.core[i].windowed_reg_transports =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "function_calls") == 0) {
+                sys.core[i].function_calls =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "context_switches") == 0) {
+                sys.core[i].context_switches =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "ialu_accesses") == 0) {
+                sys.core[i].ialu_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "fpu_accesses") == 0) {
+                sys.core[i].fpu_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "mul_accesses") == 0) {
+                sys.core[i].mul_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "cdb_alu_accesses") == 0) {
+                sys.core[i].cdb_alu_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "cdb_mul_accesses") == 0) {
+                sys.core[i].cdb_mul_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "cdb_fpu_accesses") == 0) {
+                sys.core[i].cdb_fpu_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "load_buffer_reads") == 0) {
+                sys.core[i].load_buffer_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "load_buffer_writes") == 0) {
+                sys.core[i].load_buffer_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "load_buffer_cams") == 0) {
+                sys.core[i].load_buffer_cams =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "store_buffer_reads") == 0) {
+                sys.core[i].store_buffer_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "store_buffer_writes") == 0) {
+                sys.core[i].store_buffer_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "store_buffer_cams") == 0) {
+                sys.core[i].store_buffer_cams =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "store_buffer_forwards") == 0) {
+                sys.core[i].store_buffer_forwards =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "main_memory_access") == 0) {
+                sys.core[i].main_memory_access =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "main_memory_read") == 0) {
+                sys.core[i].main_memory_read =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "main_memory_write") == 0) {
+                sys.core[i].main_memory_write =
+                    atoi(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "pipeline_duty_cycle") == 0) {
+                sys.core[i].pipeline_duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
 
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"pipelines_per_core")==0)
-							{
-								strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-								m=0;
-								for(n=0; n<strtmp.length(); n++)
-								{
-									if (strtmp[n]!=',')
-									{
-										sprintf(chtmp,"%c",strtmp[n]);
-										strcat(chtmp1,chtmp);
-									}
-									else{
-										sys.core[i].pipelines_per_core[m]=atoi(chtmp1);
-										m++;
-										chtmp1[0]='\0';
-									}
-								}
-								sys.core[i].pipelines_per_core[m]=atoi(chtmp1);
-								m++;
-								chtmp1[0]='\0';
-								continue;
-							}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"pipeline_depth")==0)
-							{
-								strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-								m=0;
-								for(n=0; n<strtmp.length(); n++)
-								{
-									if (strtmp[n]!=',')
-									{
-										sprintf(chtmp,"%c",strtmp[n]);
-										strcat(chtmp1,chtmp);
-									}
-									else{
-										sys.core[i].pipeline_depth[m]=atoi(chtmp1);
-										m++;
-										chtmp1[0]='\0';
-									}
-								}
-								sys.core[i].pipeline_depth[m]=atoi(chtmp1);
-								m++;
-								chtmp1[0]='\0';
-								continue;
-							}
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "IFU_duty_cycle") == 0) {
+                sys.core[i].IFU_duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "BR_duty_cycle") == 0) {
+                sys.core[i].BR_duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "LSU_duty_cycle") == 0) {
+                sys.core[i].LSU_duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "MemManU_I_duty_cycle") == 0) {
+                sys.core[i].MemManU_I_duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "MemManU_D_duty_cycle") == 0) {
+                sys.core[i].MemManU_D_duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "ALU_duty_cycle") == 0) {
+                sys.core[i].ALU_duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "MUL_duty_cycle") == 0) {
+                sys.core[i].MUL_duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "FPU_duty_cycle") == 0) {
+                sys.core[i].FPU_duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "ALU_cdb_duty_cycle") == 0) {
+                sys.core[i].ALU_cdb_duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "MUL_cdb_duty_cycle") == 0) {
+                sys.core[i].MUL_cdb_duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "FPU_cdb_duty_cycle") == 0) {
+                sys.core[i].FPU_cdb_duty_cycle =
+                    atoi(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+            }
+          }
 
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"FPU")==0) {strcpy(sys.core[i].FPU,xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"divider_multiplier")==0) {strcpy(sys.core[i].divider_multiplier,xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"ALU_per_core")==0) {sys.core[i].ALU_per_core=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"FPU_per_core")==0) {sys.core[i].FPU_per_core=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"MUL_per_core")==0) {sys.core[i].MUL_per_core=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"instruction_buffer_size")==0) {sys.core[i].instruction_buffer_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"decoded_stream_buffer_size")==0) {sys.core[i].decoded_stream_buffer_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"instruction_window_scheme")==0) {sys.core[i].instruction_window_scheme  =atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"instruction_window_size")==0) {sys.core[i].instruction_window_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"fp_instruction_window_size")==0) {sys.core[i].fp_instruction_window_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"ROB_size")==0) {sys.core[i].ROB_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"rf_banks")==0) {sys.core[i].rf_banks=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"simd_width")==0) {sys.core[i].simd_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"collector_units")==0) {sys.core[i].collector_units=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"core_clock_ratio")==0) {sys.core[i].core_clock_ratio=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"warp_size")==0) {sys.core[i].warp_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+          NumofCom_4 =
+              xNode3.nChildNode("component");  // get the number of components
+                                               // within the third layer
+          for (j = 0; j < NumofCom_4; j++) {
+            xNode4 = xNode3.getChildNode("component", j);
+            if (strcmp(xNode4.getAttribute("name"), "PBT") == 0) {  // find PBT
+              itmp = xNode4.nChildNode("param");
+              for (k = 0; k < itmp; k++) {  // get all items of param in
+                                            // system.core0.predictor--PBT
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "prediction_width") == 0) {
+                  sys.core[i].predictor.prediction_width = atoi(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "prediction_scheme") == 0) {
+                  strcpy(sys.core[i].predictor.prediction_scheme,
+                         xNode4.getChildNode("param", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "predictor_size") == 0) {
+                  sys.core[i].predictor.predictor_size = atoi(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "predictor_entries") == 0) {
+                  sys.core[i].predictor.predictor_entries = atoi(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "local_predictor_size") == 0) {
+                  strtmp.assign(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  m = 0;
+                  for (n = 0; n < strtmp.length(); n++) {
+                    if (strtmp[n] != ',') {
+                      sprintf(chtmp, "%c", strtmp[n]);
+                      strcat(chtmp1, chtmp);
+                    } else {
+                      sys.core[i].predictor.local_predictor_size[m] =
+                          atoi(chtmp1);
+                      m++;
+                      chtmp1[0] = '\0';
+                    }
+                  }
+                  sys.core[i].predictor.local_predictor_size[m] = atoi(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "local_predictor_entries") == 0) {
+                  sys.core[i].predictor.local_predictor_entries = atoi(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "global_predictor_entries") == 0) {
+                  sys.core[i].predictor.global_predictor_entries = atoi(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "global_predictor_bits") == 0) {
+                  sys.core[i].predictor.global_predictor_bits = atoi(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "chooser_predictor_entries") == 0) {
+                  sys.core[i].predictor.chooser_predictor_entries = atoi(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "chooser_predictor_bits") == 0) {
+                  sys.core[i].predictor.chooser_predictor_bits = atoi(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  continue;
+                }
+              }
+              itmp = xNode4.nChildNode("stat");
+              for (k = 0; k < itmp; k++) {  // get all items of stat in
+                                            // system.core0.predictor--PBT
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "predictor_accesses") == 0)
+                  sys.core[i].predictor.predictor_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+              }
+            }
+            if (strcmp(xNode4.getAttribute("name"), "itlb") ==
+                0) {  // find system.core0.itlb
+              itmp = xNode4.nChildNode("param");
+              for (k = 0; k < itmp;
+                   k++) {  // get all items of param in system.core0.itlb--itlb
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "number_entries") == 0)
+                  sys.core[i].itlb.number_entries = atoi(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+              }
+              itmp = xNode4.nChildNode("stat");
+              for (k = 0; k < itmp; k++) {  // get all items of stat in itlb
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_hits") == 0) {
+                  sys.core[i].itlb.total_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_accesses") == 0) {
+                  sys.core[i].itlb.total_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_misses") == 0) {
+                  sys.core[i].itlb.total_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "conflicts") == 0) {
+                  sys.core[i].itlb.conflicts = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+              }
+            }
+            if (strcmp(xNode4.getAttribute("name"), "icache") ==
+                0) {  // find system.core0.icache
+              itmp = xNode4.nChildNode("param");
+              for (k = 0; k < itmp; k++) {  // get all items of param in
+                                            // system.core0.icache--icache
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "icache_config") == 0) {
+                  strtmp.assign(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  m = 0;
+                  for (n = 0; n < strtmp.length(); n++) {
+                    if (strtmp[n] != ',') {
+                      sprintf(chtmp, "%c", strtmp[n]);
+                      strcat(chtmp1, chtmp);
+                    } else {
+                      sys.core[i].icache.icache_config[m] = atof(chtmp1);
+                      m++;
+                      chtmp1[0] = '\0';
+                    }
+                  }
+                  sys.core[i].icache.icache_config[m] = atof(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "buffer_sizes") == 0) {
+                  strtmp.assign(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  m = 0;
+                  for (n = 0; n < strtmp.length(); n++) {
+                    if (strtmp[n] != ',') {
+                      sprintf(chtmp, "%c", strtmp[n]);
+                      strcat(chtmp1, chtmp);
+                    } else {
+                      sys.core[i].icache.buffer_sizes[m] = atoi(chtmp1);
+                      m++;
+                      chtmp1[0] = '\0';
+                    }
+                  }
+                  sys.core[i].icache.buffer_sizes[m] = atoi(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                }
+              }
+              itmp = xNode4.nChildNode("stat");
+              for (k = 0; k < itmp; k++) {
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_accesses") == 0) {
+                  sys.core[i].icache.total_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_accesses") == 0) {
+                  sys.core[i].icache.read_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_misses") == 0) {
+                  sys.core[i].icache.read_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "replacements") == 0) {
+                  sys.core[i].icache.replacements = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_hits") == 0) {
+                  sys.core[i].icache.read_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_hits") == 0) {
+                  sys.core[i].icache.total_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_misses") == 0) {
+                  sys.core[i].icache.total_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "miss_buffer_access") == 0) {
+                  sys.core[i].icache.miss_buffer_access = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "fill_buffer_accesses") == 0) {
+                  sys.core[i].icache.fill_buffer_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_accesses") == 0) {
+                  sys.core[i].icache.prefetch_buffer_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_writes") == 0) {
+                  sys.core[i].icache.prefetch_buffer_writes = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_reads") == 0) {
+                  sys.core[i].icache.prefetch_buffer_reads = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_hits") == 0) {
+                  sys.core[i].icache.prefetch_buffer_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "conflicts") == 0) {
+                  sys.core[i].icache.conflicts = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+              }
+            }
+            if (strcmp(xNode4.getAttribute("name"), "dtlb") ==
+                0) {  // find system.core0.dtlb
+              itmp = xNode4.nChildNode("param");
+              for (k = 0; k < itmp;
+                   k++) {  // get all items of param in system.core0.dtlb--dtlb
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "number_entries") == 0)
+                  sys.core[i].dtlb.number_entries = atoi(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+              }
+              itmp = xNode4.nChildNode("stat");
+              for (k = 0; k < itmp; k++) {  // get all items of stat in dtlb
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_accesses") == 0) {
+                  sys.core[i].dtlb.total_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_accesses") == 0) {
+                  sys.core[i].dtlb.read_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_accesses") == 0) {
+                  sys.core[i].dtlb.write_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_hits") == 0) {
+                  sys.core[i].dtlb.read_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_hits") == 0) {
+                  sys.core[i].dtlb.write_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_misses") == 0) {
+                  sys.core[i].dtlb.read_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_misses") == 0) {
+                  sys.core[i].dtlb.write_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_hits") == 0) {
+                  sys.core[i].dtlb.total_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_misses") == 0) {
+                  sys.core[i].dtlb.total_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "conflicts") == 0) {
+                  sys.core[i].dtlb.conflicts = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+              }
+            }
 
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"archi_Regs_IRF_size")==0) {sys.core[i].archi_Regs_IRF_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"archi_Regs_FRF_size")==0) {sys.core[i].archi_Regs_FRF_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"phy_Regs_IRF_size")==0) {sys.core[i].phy_Regs_IRF_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"phy_Regs_FRF_size")==0) {sys.core[i].phy_Regs_FRF_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"rename_scheme")==0) {sys.core[i].rename_scheme=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"register_windows_size")==0) {sys.core[i].register_windows_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"LSU_order")==0) {strcpy(sys.core[i].LSU_order,xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"store_buffer_size")==0) {sys.core[i].store_buffer_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"load_buffer_size")==0) {sys.core[i].load_buffer_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"memory_ports")==0) {sys.core[i].memory_ports=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"Dcache_dual_pump")==0) {strcpy(sys.core[i].Dcache_dual_pump,xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"RAS_size")==0) {sys.core[i].RAS_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-						}
-						//Get all stats with system.core?
-						itmp=xNode3.nChildNode("stat");
-						for(k=0; k<itmp; k++)
-						{
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_instructions")==0) {sys.core[i].total_instructions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"int_instructions")==0) {sys.core[i].int_instructions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"fp_instructions")==0) {sys.core[i].fp_instructions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"branch_instructions")==0) {sys.core[i].branch_instructions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"branch_mispredictions")==0) {sys.core[i].branch_mispredictions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"committed_instructions")==0) {sys.core[i].committed_instructions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"committed_int_instructions")==0) {sys.core[i].committed_int_instructions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"committed_fp_instructions")==0) {sys.core[i].committed_fp_instructions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"load_instructions")==0) {sys.core[i].load_instructions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"store_instructions")==0) {sys.core[i].store_instructions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_cycles")==0) {sys.core[i].total_cycles=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"idle_cycles")==0) {sys.core[i].idle_cycles=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"busy_cycles")==0) {sys.core[i].busy_cycles=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"instruction_buffer_reads")==0) {sys.core[i].instruction_buffer_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"instruction_buffer_write")==0) {sys.core[i].instruction_buffer_write=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"ROB_reads")==0) {sys.core[i].ROB_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"ROB_writes")==0) {sys.core[i].ROB_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"rename_reads")==0) {sys.core[i].rename_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"rename_writes")==0) {sys.core[i].rename_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"fp_rename_reads")==0) {sys.core[i].fp_rename_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"fp_rename_writes")==0) {sys.core[i].fp_rename_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"inst_window_reads")==0) {sys.core[i].inst_window_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"inst_window_writes")==0) {sys.core[i].inst_window_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"inst_window_wakeup_accesses")==0) {sys.core[i].inst_window_wakeup_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"inst_window_selections")==0) {sys.core[i].inst_window_selections=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"fp_inst_window_reads")==0) {sys.core[i].fp_inst_window_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"fp_inst_window_writes")==0) {sys.core[i].fp_inst_window_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"fp_inst_window_wakeup_accesses")==0) {sys.core[i].fp_inst_window_wakeup_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"archi_int_regfile_reads")==0) {sys.core[i].archi_int_regfile_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"archi_float_regfile_reads")==0) {sys.core[i].archi_float_regfile_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"phy_int_regfile_reads")==0) {sys.core[i].phy_int_regfile_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"phy_float_regfile_reads")==0) {sys.core[i].phy_float_regfile_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"phy_int_regfile_writes")==0) {sys.core[i].archi_int_regfile_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"phy_float_regfile_writes")==0) {sys.core[i].archi_float_regfile_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"archi_int_regfile_writes")==0) {sys.core[i].phy_int_regfile_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"archi_float_regfile_writes")==0) {sys.core[i].phy_float_regfile_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"int_regfile_reads")==0) {sys.core[i].int_regfile_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"float_regfile_reads")==0) {sys.core[i].float_regfile_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"int_regfile_writes")==0) {sys.core[i].int_regfile_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"float_regfile_writes")==0) {sys.core[i].float_regfile_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"non_rf_operands")==0) {sys.core[i].non_rf_operands=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+            // Added by Jingwen
+            if (strcmp(xNode4.getAttribute("name"), "ccache") ==
+                0) {  // find system.core0.ccache
+              itmp = xNode4.nChildNode("param");
+              for (k = 0; k < itmp; k++) {  // get all items of param in
+                                            // system.core0.ccache--ccache
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "ccache_config") == 0) {
+                  strtmp.assign(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  m = 0;
+                  for (n = 0; n < strtmp.length(); n++) {
+                    if (strtmp[n] != ',') {
+                      sprintf(chtmp, "%c", strtmp[n]);
+                      strcat(chtmp1, chtmp);
+                    } else {
+                      sys.core[i].ccache.dcache_config[m] = atof(chtmp1);
+                      m++;
+                      chtmp1[0] = '\0';
+                    }
+                  }
+                  sys.core[i].ccache.dcache_config[m] = atof(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "buffer_sizes") == 0) {
+                  strtmp.assign(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  m = 0;
+                  for (n = 0; n < strtmp.length(); n++) {
+                    if (strtmp[n] != ',') {
+                      sprintf(chtmp, "%c", strtmp[n]);
+                      strcat(chtmp1, chtmp);
+                    } else {
+                      sys.core[i].ccache.buffer_sizes[m] = atoi(chtmp1);
+                      m++;
+                      chtmp1[0] = '\0';
+                    }
+                  }
+                  sys.core[i].ccache.buffer_sizes[m] = atoi(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                }
+              }
+              itmp = xNode4.nChildNode("stat");
+              for (k = 0; k < itmp; k++) {  // get all items of stat in ccache
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_accesses") == 0) {
+                  sys.core[i].ccache.total_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_accesses") == 0) {
+                  sys.core[i].ccache.read_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_accesses") == 0) {
+                  sys.core[i].ccache.write_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_hits") == 0) {
+                  sys.core[i].ccache.total_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_misses") == 0) {
+                  sys.core[i].ccache.total_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_hits") == 0) {
+                  sys.core[i].ccache.read_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_hits") == 0) {
+                  sys.core[i].ccache.write_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_misses") == 0) {
+                  sys.core[i].ccache.read_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_misses") == 0) {
+                  sys.core[i].ccache.write_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "replacements") == 0) {
+                  sys.core[i].ccache.replacements = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_backs") == 0) {
+                  sys.core[i].ccache.write_backs = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "miss_buffer_access") == 0) {
+                  sys.core[i].ccache.miss_buffer_access = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "fill_buffer_accesses") == 0) {
+                  sys.core[i].ccache.fill_buffer_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_accesses") == 0) {
+                  sys.core[i].ccache.prefetch_buffer_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_writes") == 0) {
+                  sys.core[i].ccache.prefetch_buffer_writes = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_reads") == 0) {
+                  sys.core[i].ccache.prefetch_buffer_reads = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_hits") == 0) {
+                  sys.core[i].ccache.prefetch_buffer_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "wbb_writes") == 0) {
+                  sys.core[i].ccache.wbb_writes = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "wbb_reads") == 0) {
+                  sys.core[i].ccache.wbb_reads = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "conflicts") == 0) {
+                  sys.core[i].ccache.conflicts = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+              }
+            }
 
+            // tcache
+            if (strcmp(xNode4.getAttribute("name"), "tcache") ==
+                0) {  // find system.core0.tcache
+              itmp = xNode4.nChildNode("param");
+              for (k = 0; k < itmp; k++) {  // get all items of param in
+                                            // system.core0.tcache--tcache
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "tcache_config") == 0) {
+                  strtmp.assign(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  m = 0;
+                  for (n = 0; n < strtmp.length(); n++) {
+                    if (strtmp[n] != ',') {
+                      sprintf(chtmp, "%c", strtmp[n]);
+                      strcat(chtmp1, chtmp);
+                    } else {
+                      sys.core[i].tcache.dcache_config[m] = atof(chtmp1);
+                      m++;
+                      chtmp1[0] = '\0';
+                    }
+                  }
+                  sys.core[i].tcache.dcache_config[m] = atof(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "buffer_sizes") == 0) {
+                  strtmp.assign(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  m = 0;
+                  for (n = 0; n < strtmp.length(); n++) {
+                    if (strtmp[n] != ',') {
+                      sprintf(chtmp, "%c", strtmp[n]);
+                      strcat(chtmp1, chtmp);
+                    } else {
+                      sys.core[i].tcache.buffer_sizes[m] = atoi(chtmp1);
+                      m++;
+                      chtmp1[0] = '\0';
+                    }
+                  }
+                  sys.core[i].tcache.buffer_sizes[m] = atoi(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                }
+              }
+              itmp = xNode4.nChildNode("stat");
+              for (k = 0; k < itmp; k++) {  // get all items of stat in tcache
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_accesses") == 0) {
+                  sys.core[i].tcache.total_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_accesses") == 0) {
+                  sys.core[i].tcache.read_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_accesses") == 0) {
+                  sys.core[i].tcache.write_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_hits") == 0) {
+                  sys.core[i].tcache.total_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_misses") == 0) {
+                  sys.core[i].tcache.total_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_hits") == 0) {
+                  sys.core[i].tcache.read_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_hits") == 0) {
+                  sys.core[i].tcache.write_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_misses") == 0) {
+                  sys.core[i].tcache.read_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_misses") == 0) {
+                  sys.core[i].tcache.write_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "replacements") == 0) {
+                  sys.core[i].tcache.replacements = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_backs") == 0) {
+                  sys.core[i].tcache.write_backs = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "miss_buffer_access") == 0) {
+                  sys.core[i].tcache.miss_buffer_access = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "fill_buffer_accesses") == 0) {
+                  sys.core[i].tcache.fill_buffer_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_accesses") == 0) {
+                  sys.core[i].tcache.prefetch_buffer_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_writes") == 0) {
+                  sys.core[i].tcache.prefetch_buffer_writes = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_reads") == 0) {
+                  sys.core[i].tcache.prefetch_buffer_reads = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_hits") == 0) {
+                  sys.core[i].tcache.prefetch_buffer_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "wbb_writes") == 0) {
+                  sys.core[i].tcache.wbb_writes = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "wbb_reads") == 0) {
+                  sys.core[i].tcache.wbb_reads = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "conflicts") == 0) {
+                  sys.core[i].tcache.conflicts = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+              }
+            }
 
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"windowed_reg_accesses")==0) {sys.core[i].windowed_reg_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"windowed_reg_transports")==0) {sys.core[i].windowed_reg_transports=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"function_calls")==0) {sys.core[i].function_calls=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"context_switches")==0) {sys.core[i].context_switches=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"ialu_accesses")==0) {sys.core[i].ialu_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"fpu_accesses")==0) {sys.core[i].fpu_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"mul_accesses")==0) {sys.core[i].mul_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"cdb_alu_accesses")==0) {sys.core[i].cdb_alu_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"cdb_mul_accesses")==0) {sys.core[i].cdb_mul_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"cdb_fpu_accesses")==0) {sys.core[i].cdb_fpu_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"load_buffer_reads")==0) {sys.core[i].load_buffer_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"load_buffer_writes")==0) {sys.core[i].load_buffer_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"load_buffer_cams")==0) {sys.core[i].load_buffer_cams=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"store_buffer_reads")==0) {sys.core[i].store_buffer_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"store_buffer_writes")==0) {sys.core[i].store_buffer_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"store_buffer_cams")==0) {sys.core[i].store_buffer_cams=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"store_buffer_forwards")==0) {sys.core[i].store_buffer_forwards=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"main_memory_access")==0) {sys.core[i].main_memory_access=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"main_memory_read")==0) {sys.core[i].main_memory_read=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"main_memory_write")==0) {sys.core[i].main_memory_write=atoi(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"pipeline_duty_cycle")==0) {sys.core[i].pipeline_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+            if (strcmp(xNode4.getAttribute("name"), "sharedmemory") ==
+                0) {  // find system.core0.sharedmemory
+              itmp = xNode4.nChildNode("param");
+              for (k = 0; k < itmp;
+                   k++) {  // get all items of param in
+                           // system.core0.sharedmemory--sharedmemory
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "sharedmemory_config") == 0) {
+                  strtmp.assign(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  m = 0;
+                  for (n = 0; n < strtmp.length(); n++) {
+                    if (strtmp[n] != ',') {
+                      sprintf(chtmp, "%c", strtmp[n]);
+                      strcat(chtmp1, chtmp);
+                    } else {
+                      sys.core[i].sharedmemory.dcache_config[m] = atof(chtmp1);
+                      m++;
+                      chtmp1[0] = '\0';
+                    }
+                  }
+                  sys.core[i].sharedmemory.dcache_config[m] = atof(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "buffer_sizes") == 0) {
+                  strtmp.assign(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  m = 0;
+                  for (n = 0; n < strtmp.length(); n++) {
+                    if (strtmp[n] != ',') {
+                      sprintf(chtmp, "%c", strtmp[n]);
+                      strcat(chtmp1, chtmp);
+                    } else {
+                      sys.core[i].sharedmemory.buffer_sizes[m] = atoi(chtmp1);
+                      m++;
+                      chtmp1[0] = '\0';
+                    }
+                  }
+                  sys.core[i].sharedmemory.buffer_sizes[m] = atoi(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                }
+              }
+              itmp = xNode4.nChildNode("stat");
+              for (k = 0; k < itmp;
+                   k++) {  // get all items of stat in sharedmemory
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_accesses") == 0) {
+                  sys.core[i].sharedmemory.total_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_accesses") == 0) {
+                  sys.core[i].sharedmemory.read_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_accesses") == 0) {
+                  sys.core[i].sharedmemory.write_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_hits") == 0) {
+                  sys.core[i].sharedmemory.total_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_misses") == 0) {
+                  sys.core[i].sharedmemory.total_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_hits") == 0) {
+                  sys.core[i].sharedmemory.read_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_hits") == 0) {
+                  sys.core[i].sharedmemory.write_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_misses") == 0) {
+                  sys.core[i].sharedmemory.read_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_misses") == 0) {
+                  sys.core[i].sharedmemory.write_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "replacements") == 0) {
+                  sys.core[i].sharedmemory.replacements = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_backs") == 0) {
+                  sys.core[i].sharedmemory.write_backs = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "miss_buffer_access") == 0) {
+                  sys.core[i].sharedmemory.miss_buffer_access = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "fill_buffer_accesses") == 0) {
+                  sys.core[i].sharedmemory.fill_buffer_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_accesses") == 0) {
+                  sys.core[i].sharedmemory.prefetch_buffer_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_writes") == 0) {
+                  sys.core[i].sharedmemory.prefetch_buffer_writes = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_reads") == 0) {
+                  sys.core[i].sharedmemory.prefetch_buffer_reads = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_hits") == 0) {
+                  sys.core[i].sharedmemory.prefetch_buffer_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "wbb_writes") == 0) {
+                  sys.core[i].sharedmemory.wbb_writes = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "wbb_reads") == 0) {
+                  sys.core[i].sharedmemory.wbb_reads = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "conflicts") == 0) {
+                  sys.core[i].sharedmemory.conflicts = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+              }
+            }
 
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"IFU_duty_cycle")==0) {sys.core[i].IFU_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"BR_duty_cycle")==0) {sys.core[i].BR_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"LSU_duty_cycle")==0) {sys.core[i].LSU_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"MemManU_I_duty_cycle")==0) {sys.core[i].MemManU_I_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"MemManU_D_duty_cycle")==0) {sys.core[i].MemManU_D_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"ALU_duty_cycle")==0) {sys.core[i].ALU_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"MUL_duty_cycle")==0) {sys.core[i].MUL_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"FPU_duty_cycle")==0) {sys.core[i].FPU_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"ALU_cdb_duty_cycle")==0) {sys.core[i].ALU_cdb_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"MUL_cdb_duty_cycle")==0) {sys.core[i].MUL_cdb_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"FPU_cdb_duty_cycle")==0) {sys.core[i].FPU_cdb_duty_cycle=atoi(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-						}
-					}
+            if (strcmp(xNode4.getAttribute("name"), "dcache") ==
+                0) {  // find system.core0.dcache
+              itmp = xNode4.nChildNode("param");
+              for (k = 0; k < itmp; k++) {  // get all items of param in
+                                            // system.core0.dcache--dcache
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "dcache_config") == 0) {
+                  strtmp.assign(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  m = 0;
+                  for (n = 0; n < strtmp.length(); n++) {
+                    if (strtmp[n] != ',') {
+                      sprintf(chtmp, "%c", strtmp[n]);
+                      strcat(chtmp1, chtmp);
+                    } else {
+                      sys.core[i].dcache.dcache_config[m] = atof(chtmp1);
+                      m++;
+                      chtmp1[0] = '\0';
+                    }
+                  }
+                  sys.core[i].dcache.dcache_config[m] = atof(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "buffer_sizes") == 0) {
+                  strtmp.assign(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  m = 0;
+                  for (n = 0; n < strtmp.length(); n++) {
+                    if (strtmp[n] != ',') {
+                      sprintf(chtmp, "%c", strtmp[n]);
+                      strcat(chtmp1, chtmp);
+                    } else {
+                      sys.core[i].dcache.buffer_sizes[m] = atoi(chtmp1);
+                      m++;
+                      chtmp1[0] = '\0';
+                    }
+                  }
+                  sys.core[i].dcache.buffer_sizes[m] = atoi(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                }
+              }
+              itmp = xNode4.nChildNode("stat");
+              for (k = 0; k < itmp; k++) {  // get all items of stat in dcache
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_accesses") == 0) {
+                  sys.core[i].dcache.total_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_accesses") == 0) {
+                  sys.core[i].dcache.read_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_accesses") == 0) {
+                  sys.core[i].dcache.write_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_hits") == 0) {
+                  sys.core[i].dcache.total_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_misses") == 0) {
+                  sys.core[i].dcache.total_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_hits") == 0) {
+                  sys.core[i].dcache.read_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_hits") == 0) {
+                  sys.core[i].dcache.write_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_misses") == 0) {
+                  sys.core[i].dcache.read_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_misses") == 0) {
+                  sys.core[i].dcache.write_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "replacements") == 0) {
+                  sys.core[i].dcache.replacements = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_backs") == 0) {
+                  sys.core[i].dcache.write_backs = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "miss_buffer_access") == 0) {
+                  sys.core[i].dcache.miss_buffer_access = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "fill_buffer_accesses") == 0) {
+                  sys.core[i].dcache.fill_buffer_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_accesses") == 0) {
+                  sys.core[i].dcache.prefetch_buffer_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_writes") == 0) {
+                  sys.core[i].dcache.prefetch_buffer_writes = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_reads") == 0) {
+                  sys.core[i].dcache.prefetch_buffer_reads = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_hits") == 0) {
+                  sys.core[i].dcache.prefetch_buffer_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "wbb_writes") == 0) {
+                  sys.core[i].dcache.wbb_writes = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "wbb_reads") == 0) {
+                  sys.core[i].dcache.wbb_reads = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "conflicts") == 0) {
+                  sys.core[i].dcache.conflicts = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+              }
+            }
 
-					NumofCom_4=xNode3.nChildNode("component"); //get the number of components within the third layer
-					for(j=0; j<NumofCom_4; j++)
-					{
-						xNode4=xNode3.getChildNode("component",j);
-						if (strcmp(xNode4.getAttribute("name"),"PBT")==0)
-						{ //find PBT
-							itmp=xNode4.nChildNode("param");
-							for(k=0; k<itmp; k++)
-							{ //get all items of param in system.core0.predictor--PBT
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"prediction_width")==0) {sys.core[i].predictor.prediction_width=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"prediction_scheme")==0) {strcpy(sys.core[i].predictor.prediction_scheme,xNode4.getChildNode("param",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"predictor_size")==0) {sys.core[i].predictor.predictor_size=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"predictor_entries")==0) {sys.core[i].predictor.predictor_entries=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"local_predictor_size")==0)
-								{
-									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
-									m=0;
-									for(n=0; n<strtmp.length(); n++)
-									{
-										if (strtmp[n]!=',')
-										{
-											sprintf(chtmp,"%c",strtmp[n]);
-											strcat(chtmp1,chtmp);
-										}
-										else{
-											sys.core[i].predictor.local_predictor_size[m]=atoi(chtmp1);
-											m++;
-											chtmp1[0]='\0';
-										}
-									}
-									sys.core[i].predictor.local_predictor_size[m]=atoi(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-									continue;
-								}
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"local_predictor_entries")==0) {sys.core[i].predictor.local_predictor_entries=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"global_predictor_entries")==0) {sys.core[i].predictor.global_predictor_entries=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"global_predictor_bits")==0) {sys.core[i].predictor.global_predictor_bits=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"chooser_predictor_entries")==0) {sys.core[i].predictor.chooser_predictor_entries=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"chooser_predictor_bits")==0) {sys.core[i].predictor.chooser_predictor_bits=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
-							}
-							itmp=xNode4.nChildNode("stat");
-							for(k=0; k<itmp; k++)
-							{ //get all items of stat in system.core0.predictor--PBT
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"predictor_accesses")==0) sys.core[i].predictor.predictor_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));
-							}
-						}
-						if (strcmp(xNode4.getAttribute("name"),"itlb")==0)
-						{//find system.core0.itlb
-							itmp=xNode4.nChildNode("param");
-							for(k=0; k<itmp; k++)
-							{ //get all items of param in system.core0.itlb--itlb
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"number_entries")==0) sys.core[i].itlb.number_entries=atoi(xNode4.getChildNode("param",k).getAttribute("value"));
-							}
-							itmp=xNode4.nChildNode("stat");
-							for(k=0; k<itmp; k++)
-							{ //get all items of stat in itlb
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.core[i].itlb.total_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.core[i].itlb.total_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.core[i].itlb.total_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.core[i].itlb.conflicts=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-							}
-						}
-						if (strcmp(xNode4.getAttribute("name"),"icache")==0)
-						{//find system.core0.icache
-							itmp=xNode4.nChildNode("param");
-							for(k=0; k<itmp; k++)
-							{ //get all items of param in system.core0.icache--icache
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"icache_config")==0)
-								{
-									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
-									m=0;
-									for(n=0; n<strtmp.length(); n++)
-									{
-										if (strtmp[n]!=',')
-										{
-											sprintf(chtmp,"%c",strtmp[n]);
-											strcat(chtmp1,chtmp);
-										}
-										else{
-											sys.core[i].icache.icache_config[m]=atof(chtmp1);
-											m++;
-											chtmp1[0]='\0';
-										}
-									}
-									sys.core[i].icache.icache_config[m]=atof(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-									continue;
-								}
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"buffer_sizes")==0)
-								{
-									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
-									m=0;
-									for(n=0; n<strtmp.length(); n++)
-									{
-										if (strtmp[n]!=',')
-										{
-											sprintf(chtmp,"%c",strtmp[n]);
-											strcat(chtmp1,chtmp);
-										}
-										else{
-											sys.core[i].icache.buffer_sizes[m]=atoi(chtmp1);
-											m++;
-											chtmp1[0]='\0';
-										}
-									}
-									sys.core[i].icache.buffer_sizes[m]=atoi(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-								}
-							}
-							itmp=xNode4.nChildNode("stat");
-							for(k=0; k<itmp; k++)
-							{
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.core[i].icache.total_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.core[i].icache.read_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.core[i].icache.read_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"replacements")==0) {sys.core[i].icache.replacements=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_hits")==0) {sys.core[i].icache.read_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.core[i].icache.total_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.core[i].icache.total_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"miss_buffer_access")==0) {sys.core[i].icache.miss_buffer_access=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"fill_buffer_accesses")==0) {sys.core[i].icache.fill_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_accesses")==0) {sys.core[i].icache.prefetch_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_writes")==0) {sys.core[i].icache.prefetch_buffer_writes=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_reads")==0) {sys.core[i].icache.prefetch_buffer_reads=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_hits")==0) {sys.core[i].icache.prefetch_buffer_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.core[i].icache.conflicts=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-							}
-						}
-						if (strcmp(xNode4.getAttribute("name"),"dtlb")==0)
-						{//find system.core0.dtlb
-							itmp=xNode4.nChildNode("param");
-							for(k=0; k<itmp; k++)
-							{ //get all items of param in system.core0.dtlb--dtlb
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"number_entries")==0) sys.core[i].dtlb.number_entries=atoi(xNode4.getChildNode("param",k).getAttribute("value"));
-							}
-							itmp=xNode4.nChildNode("stat");
-							for(k=0; k<itmp; k++)
-							{ //get all items of stat in dtlb
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.core[i].dtlb.total_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.core[i].dtlb.read_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.core[i].dtlb.write_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_hits")==0) {sys.core[i].dtlb.read_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_hits")==0) {sys.core[i].dtlb.write_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.core[i].dtlb.read_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.core[i].dtlb.write_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.core[i].dtlb.total_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.core[i].dtlb.total_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.core[i].dtlb.conflicts=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+            if (strcmp(xNode4.getAttribute("name"), "BTB") ==
+                0) {  // find system.core0.BTB
+              itmp = xNode4.nChildNode("param");
+              for (k = 0; k < itmp;
+                   k++) {  // get all items of param in system.core0.BTB--BTB
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "BTB_config") == 0) {
+                  strtmp.assign(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  m = 0;
+                  for (n = 0; n < strtmp.length(); n++) {
+                    if (strtmp[n] != ',') {
+                      sprintf(chtmp, "%c", strtmp[n]);
+                      strcat(chtmp1, chtmp);
+                    } else {
+                      sys.core[i].BTB.BTB_config[m] = atoi(chtmp1);
+                      m++;
+                      chtmp1[0] = '\0';
+                    }
+                  }
+                  sys.core[i].BTB.BTB_config[m] = atoi(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                }
+              }
+              itmp = xNode4.nChildNode("stat");
+              for (k = 0; k < itmp; k++) {  // get all items of stat in BTB
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_accesses") == 0) {
+                  sys.core[i].BTB.total_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_accesses") == 0) {
+                  sys.core[i].BTB.read_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_accesses") == 0) {
+                  sys.core[i].BTB.write_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_hits") == 0) {
+                  sys.core[i].BTB.total_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_misses") == 0) {
+                  sys.core[i].BTB.total_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_hits") == 0) {
+                  sys.core[i].BTB.read_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_hits") == 0) {
+                  sys.core[i].BTB.write_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_misses") == 0) {
+                  sys.core[i].BTB.read_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_misses") == 0) {
+                  sys.core[i].BTB.write_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "replacements") == 0) {
+                  sys.core[i].BTB.replacements = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+              }
+            }
+          }
+        } else {
+          printf(
+              "The value of homogeneous_cores or number_of_cores is not "
+              "correct!");
+          exit(0);
+        }
+      }
+    }
 
-							}
-						}
+    //__________________________________________Get
+    // system.L1Directory0-n____________________________________________
+    int w, tmpOrderofComponents_3layer;
+    w = OrderofComponents_3layer + 1;
+    tmpOrderofComponents_3layer = OrderofComponents_3layer;
+    if (sys.homogeneous_L1Directories == 1)
+      OrderofComponents_3layer = OrderofComponents_3layer + 1;
+    else
+      OrderofComponents_3layer =
+          OrderofComponents_3layer + sys.number_of_L1Directories;
 
-// Added by Jingwen
-						if (strcmp(xNode4.getAttribute("name"),"ccache")==0)
-						{//find system.core0.ccache
-							itmp=xNode4.nChildNode("param");
-							for(k=0; k<itmp; k++)
-							{ //get all items of param in system.core0.ccache--ccache
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"ccache_config")==0)
-								{
-									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
-									m=0;
-									for(n=0; n<strtmp.length(); n++)
-									{
-										if (strtmp[n]!=',')
-										{
-											sprintf(chtmp,"%c",strtmp[n]);
-											strcat(chtmp1,chtmp);
-										}
-										else{
-											sys.core[i].ccache.dcache_config[m]=atof(chtmp1);
-											m++;
-											chtmp1[0]='\0';
-										}
-									}
-									sys.core[i].ccache.dcache_config[m]=atof(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-									continue;
-								}
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"buffer_sizes")==0)
-								{
-									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
-									m=0;
-									for(n=0; n<strtmp.length(); n++)
-									{
-										if (strtmp[n]!=',')
-										{
-											sprintf(chtmp,"%c",strtmp[n]);
-											strcat(chtmp1,chtmp);
-										}
-										else{
-											sys.core[i].ccache.buffer_sizes[m]=atoi(chtmp1);
-											m++;
-											chtmp1[0]='\0';
-										}
-									}
-									sys.core[i].ccache.buffer_sizes[m]=atoi(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-								}
-							}
-							itmp=xNode4.nChildNode("stat");
-							for(k=0; k<itmp; k++)
-							{ //get all items of stat in ccache
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.core[i].ccache.total_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.core[i].ccache.read_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.core[i].ccache.write_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.core[i].ccache.total_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.core[i].ccache.total_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_hits")==0) {sys.core[i].ccache.read_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_hits")==0) {sys.core[i].ccache.write_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.core[i].ccache.read_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.core[i].ccache.write_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"replacements")==0) {sys.core[i].ccache.replacements=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_backs")==0) {sys.core[i].ccache.write_backs=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"miss_buffer_access")==0) {sys.core[i].ccache.miss_buffer_access=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"fill_buffer_accesses")==0) {sys.core[i].ccache.fill_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_accesses")==0) {sys.core[i].ccache.prefetch_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_writes")==0) {sys.core[i].ccache.prefetch_buffer_writes=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_reads")==0) {sys.core[i].ccache.prefetch_buffer_reads=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_hits")==0) {sys.core[i].ccache.prefetch_buffer_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"wbb_writes")==0) {sys.core[i].ccache.wbb_writes=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"wbb_reads")==0) {sys.core[i].ccache.wbb_reads=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.core[i].ccache.conflicts=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+    for (i = 0; i < (OrderofComponents_3layer - tmpOrderofComponents_3layer);
+         i++) {
+      xNode3 = xNode2.getChildNode("component", w);
+      if (xNode3.isEmpty() == 1) {
+        printf(
+            "The value of homogeneous_L1Directories or number_of_L1Directories "
+            "is not correct!");
+        exit(0);
+      } else {
+        if (strstr(xNode3.getAttribute("id"), "L1Directory") != NULL) {
+          itmp = xNode3.nChildNode("param");
+          for (k = 0; k < itmp;
+               k++) {  // get all items of param in system.L1Directory
+            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                       "Dir_config") == 0) {
+              strtmp.assign(
+                  xNode3.getChildNode("param", k).getAttribute("value"));
+              m = 0;
+              for (n = 0; n < strtmp.length(); n++) {
+                if (strtmp[n] != ',') {
+                  sprintf(chtmp, "%c", strtmp[n]);
+                  strcat(chtmp1, chtmp);
+                } else {
+                  sys.L1Directory[i].Dir_config[m] = atof(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                }
+              }
+              sys.L1Directory[i].Dir_config[m] = atof(chtmp1);
+              m++;
+              chtmp1[0] = '\0';
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                       "buffer_sizes") == 0) {
+              strtmp.assign(
+                  xNode3.getChildNode("param", k).getAttribute("value"));
+              m = 0;
+              for (n = 0; n < strtmp.length(); n++) {
+                if (strtmp[n] != ',') {
+                  sprintf(chtmp, "%c", strtmp[n]);
+                  strcat(chtmp1, chtmp);
+                } else {
+                  sys.L1Directory[i].buffer_sizes[m] = atoi(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                }
+              }
+              sys.L1Directory[i].buffer_sizes[m] = atoi(chtmp1);
+              m++;
+              chtmp1[0] = '\0';
+              continue;
+            }
 
-							}
-						}
+            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                       "clockrate") == 0) {
+              sys.L1Directory[i].clockrate =
+                  atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                       "ports") == 0) {
+              strtmp.assign(
+                  xNode3.getChildNode("param", k).getAttribute("value"));
+              m = 0;
+              for (n = 0; n < strtmp.length(); n++) {
+                if (strtmp[n] != ',') {
+                  sprintf(chtmp, "%c", strtmp[n]);
+                  strcat(chtmp1, chtmp);
+                } else {
+                  sys.L1Directory[i].ports[m] = atoi(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                }
+              }
+              sys.L1Directory[i].ports[m] = atoi(chtmp1);
+              m++;
+              chtmp1[0] = '\0';
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                       "device_type") == 0) {
+              sys.L1Directory[i].device_type =
+                  atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                       "Directory_type") == 0) {
+              sys.L1Directory[i].Directory_type =
+                  atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                       "3D_stack") == 0) {
+              strcpy(sys.L1Directory[i].threeD_stack,
+                     xNode3.getChildNode("param", k).getAttribute("value"));
+              continue;
+            }
+          }
+          itmp = xNode3.nChildNode("stat");
+          for (k = 0; k < itmp;
+               k++) {  // get all items of stat in system.L2directorydirectory
+            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                       "total_accesses") == 0) {
+              sys.L1Directory[i].total_accesses =
+                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                       "read_accesses") == 0) {
+              sys.L1Directory[i].read_accesses =
+                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                       "write_accesses") == 0) {
+              sys.L1Directory[i].write_accesses =
+                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                       "read_misses") == 0) {
+              sys.L1Directory[i].read_misses =
+                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                       "write_misses") == 0) {
+              sys.L1Directory[i].write_misses =
+                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                       "conflicts") == 0) {
+              sys.L1Directory[i].conflicts =
+                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                       "duty_cycle") == 0) {
+              sys.L1Directory[i].duty_cycle =
+                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              continue;
+            }
+          }
+          w = w + 1;
+        } else {
+          printf(
+              "The value of homogeneous_L1Directories or "
+              "number_of_L1Directories is not correct!");
+          exit(0);
+        }
+      }
+    }
 
-            //tcache
-						if (strcmp(xNode4.getAttribute("name"),"tcache")==0)
-						{//find system.core0.tcache
-							itmp=xNode4.nChildNode("param");
-							for(k=0; k<itmp; k++)
-							{ //get all items of param in system.core0.tcache--tcache
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"tcache_config")==0)
-								{
-									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
-									m=0;
-									for(n=0; n<strtmp.length(); n++)
-									{
-										if (strtmp[n]!=',')
-										{
-											sprintf(chtmp,"%c",strtmp[n]);
-											strcat(chtmp1,chtmp);
-										}
-										else{
-											sys.core[i].tcache.dcache_config[m]=atof(chtmp1);
-											m++;
-											chtmp1[0]='\0';
-										}
-									}
-									sys.core[i].tcache.dcache_config[m]=atof(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-									continue;
-								}
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"buffer_sizes")==0)
-								{
-									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
-									m=0;
-									for(n=0; n<strtmp.length(); n++)
-									{
-										if (strtmp[n]!=',')
-										{
-											sprintf(chtmp,"%c",strtmp[n]);
-											strcat(chtmp1,chtmp);
-										}
-										else{
-											sys.core[i].tcache.buffer_sizes[m]=atoi(chtmp1);
-											m++;
-											chtmp1[0]='\0';
-										}
-									}
-									sys.core[i].tcache.buffer_sizes[m]=atoi(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-								}
-							}
-							itmp=xNode4.nChildNode("stat");
-							for(k=0; k<itmp; k++)
-							{ //get all items of stat in tcache
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.core[i].tcache.total_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.core[i].tcache.read_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.core[i].tcache.write_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.core[i].tcache.total_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.core[i].tcache.total_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_hits")==0) {sys.core[i].tcache.read_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_hits")==0) {sys.core[i].tcache.write_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.core[i].tcache.read_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.core[i].tcache.write_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"replacements")==0) {sys.core[i].tcache.replacements=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_backs")==0) {sys.core[i].tcache.write_backs=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"miss_buffer_access")==0) {sys.core[i].tcache.miss_buffer_access=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"fill_buffer_accesses")==0) {sys.core[i].tcache.fill_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_accesses")==0) {sys.core[i].tcache.prefetch_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_writes")==0) {sys.core[i].tcache.prefetch_buffer_writes=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_reads")==0) {sys.core[i].tcache.prefetch_buffer_reads=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_hits")==0) {sys.core[i].tcache.prefetch_buffer_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"wbb_writes")==0) {sys.core[i].tcache.wbb_writes=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"wbb_reads")==0) {sys.core[i].tcache.wbb_reads=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.core[i].tcache.conflicts=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+    //__________________________________________Get
+    // system.L2Directory0-n____________________________________________
+    w = OrderofComponents_3layer + 1;
+    tmpOrderofComponents_3layer = OrderofComponents_3layer;
+    if (sys.homogeneous_L2Directories == 1)
+      OrderofComponents_3layer = OrderofComponents_3layer + 1;
+    else
+      OrderofComponents_3layer =
+          OrderofComponents_3layer + sys.number_of_L2Directories;
 
-							}
-						}
+    for (i = 0; i < (OrderofComponents_3layer - tmpOrderofComponents_3layer);
+         i++) {
+      xNode3 = xNode2.getChildNode("component", w);
+      if (xNode3.isEmpty() == 1) {
+        printf(
+            "The value of homogeneous_L2Directories or number_of_L2Directories "
+            "is not correct!");
+        exit(0);
+      } else {
+        if (strstr(xNode3.getAttribute("id"), "L2Directory") != NULL) {
+          itmp = xNode3.nChildNode("param");
+          for (k = 0; k < itmp;
+               k++) {  // get all items of param in system.L2Directory
+            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                       "Dir_config") == 0) {
+              strtmp.assign(
+                  xNode3.getChildNode("param", k).getAttribute("value"));
+              m = 0;
+              for (n = 0; n < strtmp.length(); n++) {
+                if (strtmp[n] != ',') {
+                  sprintf(chtmp, "%c", strtmp[n]);
+                  strcat(chtmp1, chtmp);
+                } else {
+                  sys.L2Directory[i].Dir_config[m] = atof(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                }
+              }
+              sys.L2Directory[i].Dir_config[m] = atof(chtmp1);
+              m++;
+              chtmp1[0] = '\0';
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                       "buffer_sizes") == 0) {
+              strtmp.assign(
+                  xNode3.getChildNode("param", k).getAttribute("value"));
+              m = 0;
+              for (n = 0; n < strtmp.length(); n++) {
+                if (strtmp[n] != ',') {
+                  sprintf(chtmp, "%c", strtmp[n]);
+                  strcat(chtmp1, chtmp);
+                } else {
+                  sys.L2Directory[i].buffer_sizes[m] = atoi(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                }
+              }
+              sys.L2Directory[i].buffer_sizes[m] = atoi(chtmp1);
+              m++;
+              chtmp1[0] = '\0';
+              continue;
+            }
 
+            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                       "clockrate") == 0) {
+              sys.L2Directory[i].clockrate =
+                  atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                       "Directory_type") == 0) {
+              sys.L2Directory[i].Directory_type =
+                  atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                       "ports") == 0) {
+              strtmp.assign(
+                  xNode3.getChildNode("param", k).getAttribute("value"));
+              m = 0;
+              for (n = 0; n < strtmp.length(); n++) {
+                if (strtmp[n] != ',') {
+                  sprintf(chtmp, "%c", strtmp[n]);
+                  strcat(chtmp1, chtmp);
+                } else {
+                  sys.L2Directory[i].ports[m] = atoi(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                }
+              }
+              sys.L2Directory[i].ports[m] = atoi(chtmp1);
+              m++;
+              chtmp1[0] = '\0';
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                       "device_type") == 0) {
+              sys.L2Directory[i].device_type =
+                  atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                       "3D_stack") == 0) {
+              strcpy(sys.L2Directory[i].threeD_stack,
+                     xNode3.getChildNode("param", k).getAttribute("value"));
+              continue;
+            }
+          }
+          itmp = xNode3.nChildNode("stat");
+          for (k = 0; k < itmp;
+               k++) {  // get all items of stat in system.L2directorydirectory
+            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                       "total_accesses") == 0) {
+              sys.L2Directory[i].total_accesses =
+                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                       "read_accesses") == 0) {
+              sys.L2Directory[i].read_accesses =
+                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                       "write_accesses") == 0) {
+              sys.L2Directory[i].write_accesses =
+                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                       "read_misses") == 0) {
+              sys.L2Directory[i].read_misses =
+                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                       "write_misses") == 0) {
+              sys.L2Directory[i].write_misses =
+                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                       "conflicts") == 0) {
+              sys.L2Directory[i].conflicts =
+                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                       "duty_cycle") == 0) {
+              sys.L2Directory[i].duty_cycle =
+                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              continue;
+            }
+          }
+          w = w + 1;
+        } else {
+          printf(
+              "The value of homogeneous_L2Directories or "
+              "number_of_L2Directories is not correct!");
+          exit(0);
+        }
+      }
+    }
 
-						if (strcmp(xNode4.getAttribute("name"),"sharedmemory")==0)
-						{//find system.core0.sharedmemory
-							itmp=xNode4.nChildNode("param");
-							for(k=0; k<itmp; k++)
-							{ //get all items of param in system.core0.sharedmemory--sharedmemory
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"sharedmemory_config")==0)
-								{
-									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
-									m=0;
-									for(n=0; n<strtmp.length(); n++)
-									{
-										if (strtmp[n]!=',')
-										{
-											sprintf(chtmp,"%c",strtmp[n]);
-											strcat(chtmp1,chtmp);
-										}
-										else{
-											sys.core[i].sharedmemory.dcache_config[m]=atof(chtmp1);
-											m++;
-											chtmp1[0]='\0';
-										}
-									}
-									sys.core[i].sharedmemory.dcache_config[m]=atof(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-									continue;
-								}
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"buffer_sizes")==0)
-								{
-									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
-									m=0;
-									for(n=0; n<strtmp.length(); n++)
-									{
-										if (strtmp[n]!=',')
-										{
-											sprintf(chtmp,"%c",strtmp[n]);
-											strcat(chtmp1,chtmp);
-										}
-										else{
-											sys.core[i].sharedmemory.buffer_sizes[m]=atoi(chtmp1);
-											m++;
-											chtmp1[0]='\0';
-										}
-									}
-									sys.core[i].sharedmemory.buffer_sizes[m]=atoi(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-								}
-							}
-							itmp=xNode4.nChildNode("stat");
-							for(k=0; k<itmp; k++)
-							{ //get all items of stat in sharedmemory
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.core[i].sharedmemory.total_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.core[i].sharedmemory.read_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.core[i].sharedmemory.write_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.core[i].sharedmemory.total_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.core[i].sharedmemory.total_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_hits")==0) {sys.core[i].sharedmemory.read_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_hits")==0) {sys.core[i].sharedmemory.write_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.core[i].sharedmemory.read_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.core[i].sharedmemory.write_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"replacements")==0) {sys.core[i].sharedmemory.replacements=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_backs")==0) {sys.core[i].sharedmemory.write_backs=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"miss_buffer_access")==0) {sys.core[i].sharedmemory.miss_buffer_access=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"fill_buffer_accesses")==0) {sys.core[i].sharedmemory.fill_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_accesses")==0) {sys.core[i].sharedmemory.prefetch_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_writes")==0) {sys.core[i].sharedmemory.prefetch_buffer_writes=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_reads")==0) {sys.core[i].sharedmemory.prefetch_buffer_reads=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_hits")==0) {sys.core[i].sharedmemory.prefetch_buffer_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"wbb_writes")==0) {sys.core[i].sharedmemory.wbb_writes=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"wbb_reads")==0) {sys.core[i].sharedmemory.wbb_reads=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.core[i].sharedmemory.conflicts=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+    //__________________________________________Get
+    // system.L2[0..n]____________________________________________
+    w = OrderofComponents_3layer + 1;
+    tmpOrderofComponents_3layer = OrderofComponents_3layer;
+    if (sys.homogeneous_L2s == 1)
+      OrderofComponents_3layer = OrderofComponents_3layer + 1;
+    else
+      OrderofComponents_3layer = OrderofComponents_3layer + sys.number_of_L2s;
 
-							}
-						}
+    for (i = 0; i < (OrderofComponents_3layer - tmpOrderofComponents_3layer);
+         i++) {
+      xNode3 = xNode2.getChildNode("component", w);
+      if (xNode3.isEmpty() == 1) {
+        printf("The value of homogeneous_L2s or number_of_L2s is not correct!");
+        exit(0);
+      } else {
+        if (strstr(xNode3.getAttribute("name"), "L2") != NULL) {
+          {  // For L20-L2i
+            // Get all params with system.L2?
+            itmp = xNode3.nChildNode("param");
+            for (k = 0; k < itmp; k++) {
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "L2_config") == 0) {
+                strtmp.assign(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                m = 0;
+                for (n = 0; n < strtmp.length(); n++) {
+                  if (strtmp[n] != ',') {
+                    sprintf(chtmp, "%c", strtmp[n]);
+                    strcat(chtmp1, chtmp);
+                  } else {
+                    sys.L2[i].L2_config[m] = atof(chtmp1);
+                    m++;
+                    chtmp1[0] = '\0';
+                  }
+                }
+                sys.L2[i].L2_config[m] = atof(chtmp1);
+                m++;
+                chtmp1[0] = '\0';
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "clockrate") == 0) {
+                sys.L2[i].clockrate =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "merged_dir") == 0) {
+                sys.L2[i].merged_dir = (bool)atoi(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "ports") == 0) {
+                strtmp.assign(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                m = 0;
+                for (n = 0; n < strtmp.length(); n++) {
+                  if (strtmp[n] != ',') {
+                    sprintf(chtmp, "%c", strtmp[n]);
+                    strcat(chtmp1, chtmp);
+                  } else {
+                    sys.L2[i].ports[m] = atoi(chtmp1);
+                    m++;
+                    chtmp1[0] = '\0';
+                  }
+                }
+                sys.L2[i].ports[m] = atoi(chtmp1);
+                m++;
+                chtmp1[0] = '\0';
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "device_type") == 0) {
+                sys.L2[i].device_type =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "threeD_stack") == 0) {
+                strcpy(sys.L2[i].threeD_stack,
+                       (xNode3.getChildNode("param", k).getAttribute("value")));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "buffer_sizes") == 0) {
+                strtmp.assign(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                m = 0;
+                for (n = 0; n < strtmp.length(); n++) {
+                  if (strtmp[n] != ',') {
+                    sprintf(chtmp, "%c", strtmp[n]);
+                    strcat(chtmp1, chtmp);
+                  } else {
+                    sys.L2[i].buffer_sizes[m] = atoi(chtmp1);
+                    m++;
+                    chtmp1[0] = '\0';
+                  }
+                }
+                sys.L2[i].buffer_sizes[m] = atoi(chtmp1);
+                m++;
+                chtmp1[0] = '\0';
+                continue;
+              }
+            }
+            // Get all stats with system.L2?
+            itmp = xNode3.nChildNode("stat");
+            for (k = 0; k < itmp; k++) {
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "total_accesses") == 0) {
+                sys.L2[i].total_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "read_accesses") == 0) {
+                sys.L2[i].read_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "write_accesses") == 0) {
+                sys.L2[i].write_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "total_hits") == 0) {
+                sys.L2[i].total_hits =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "total_misses") == 0) {
+                sys.L2[i].total_misses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "read_hits") == 0) {
+                sys.L2[i].read_hits =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "write_hits") == 0) {
+                sys.L2[i].write_hits =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "read_misses") == 0) {
+                sys.L2[i].read_misses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "write_misses") == 0) {
+                sys.L2[i].write_misses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "replacements") == 0) {
+                sys.L2[i].replacements =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "write_backs") == 0) {
+                sys.L2[i].write_backs =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "miss_buffer_accesses") == 0) {
+                sys.L2[i].miss_buffer_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "fill_buffer_accesses") == 0) {
+                sys.L2[i].fill_buffer_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "prefetch_buffer_accesses") == 0) {
+                sys.L2[i].prefetch_buffer_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "prefetch_buffer_writes") == 0) {
+                sys.L2[i].prefetch_buffer_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "prefetch_buffer_reads") == 0) {
+                sys.L2[i].prefetch_buffer_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "prefetch_buffer_hits") == 0) {
+                sys.L2[i].prefetch_buffer_hits =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "wbb_writes") == 0) {
+                sys.L2[i].wbb_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "wbb_reads") == 0) {
+                sys.L2[i].wbb_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "conflicts") == 0) {
+                sys.L2[i].conflicts =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "duty_cycle") == 0) {
+                sys.L2[i].duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
 
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "homenode_read_accesses") == 0) {
+                sys.L2[i].homenode_read_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "homenode_read_accesses") == 0) {
+                sys.L2[i].homenode_read_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "homenode_read_hits") == 0) {
+                sys.L2[i].homenode_read_hits =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "homenode_write_hits") == 0) {
+                sys.L2[i].homenode_write_hits =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "homenode_read_misses") == 0) {
+                sys.L2[i].homenode_read_misses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "homenode_write_misses") == 0) {
+                sys.L2[i].homenode_write_misses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "dir_duty_cycle") == 0) {
+                sys.L2[i].dir_duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+            }
+          }
+          w = w + 1;
+        } else {
+          printf(
+              "The value of homogeneous_L2s or number_of_L2s is not correct!");
+          exit(0);
+        }
+      }
+    }
+    //__________________________________________Get
+    // system.L3[0..n]____________________________________________
+    w = OrderofComponents_3layer + 1;
+    tmpOrderofComponents_3layer = OrderofComponents_3layer;
+    if (sys.homogeneous_L3s == 1)
+      OrderofComponents_3layer = OrderofComponents_3layer + 1;
+    else
+      OrderofComponents_3layer = OrderofComponents_3layer + sys.number_of_L3s;
 
-						if (strcmp(xNode4.getAttribute("name"),"dcache")==0)
-						{//find system.core0.dcache
-							itmp=xNode4.nChildNode("param");
-							for(k=0; k<itmp; k++)
-							{ //get all items of param in system.core0.dcache--dcache
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"dcache_config")==0)
-								{
-									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
-									m=0;
-									for(n=0; n<strtmp.length(); n++)
-									{
-										if (strtmp[n]!=',')
-										{
-											sprintf(chtmp,"%c",strtmp[n]);
-											strcat(chtmp1,chtmp);
-										}
-										else{
-											sys.core[i].dcache.dcache_config[m]=atof(chtmp1);
-											m++;
-											chtmp1[0]='\0';
-										}
-									}
-									sys.core[i].dcache.dcache_config[m]=atof(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-									continue;
-								}
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"buffer_sizes")==0)
-								{
-									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
-									m=0;
-									for(n=0; n<strtmp.length(); n++)
-									{
-										if (strtmp[n]!=',')
-										{
-											sprintf(chtmp,"%c",strtmp[n]);
-											strcat(chtmp1,chtmp);
-										}
-										else{
-											sys.core[i].dcache.buffer_sizes[m]=atoi(chtmp1);
-											m++;
-											chtmp1[0]='\0';
-										}
-									}
-									sys.core[i].dcache.buffer_sizes[m]=atoi(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-								}
-							}
-							itmp=xNode4.nChildNode("stat");
-							for(k=0; k<itmp; k++)
-							{ //get all items of stat in dcache
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.core[i].dcache.total_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.core[i].dcache.read_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.core[i].dcache.write_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.core[i].dcache.total_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.core[i].dcache.total_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_hits")==0) {sys.core[i].dcache.read_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_hits")==0) {sys.core[i].dcache.write_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.core[i].dcache.read_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.core[i].dcache.write_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"replacements")==0) {sys.core[i].dcache.replacements=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_backs")==0) {sys.core[i].dcache.write_backs=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"miss_buffer_access")==0) {sys.core[i].dcache.miss_buffer_access=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"fill_buffer_accesses")==0) {sys.core[i].dcache.fill_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_accesses")==0) {sys.core[i].dcache.prefetch_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_writes")==0) {sys.core[i].dcache.prefetch_buffer_writes=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_reads")==0) {sys.core[i].dcache.prefetch_buffer_reads=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_hits")==0) {sys.core[i].dcache.prefetch_buffer_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"wbb_writes")==0) {sys.core[i].dcache.wbb_writes=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"wbb_reads")==0) {sys.core[i].dcache.wbb_reads=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.core[i].dcache.conflicts=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+    for (i = 0; i < (OrderofComponents_3layer - tmpOrderofComponents_3layer);
+         i++) {
+      xNode3 = xNode2.getChildNode("component", w);
+      if (xNode3.isEmpty() == 1) {
+        printf("The value of homogeneous_L3s or number_of_L3s is not correct!");
+        exit(0);
+      } else {
+        if (strstr(xNode3.getAttribute("name"), "L3") != NULL) {
+          {  // For L30-L3i
+            // Get all params with system.L3?
+            itmp = xNode3.nChildNode("param");
+            for (k = 0; k < itmp; k++) {
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "L3_config") == 0) {
+                strtmp.assign(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                m = 0;
+                for (n = 0; n < strtmp.length(); n++) {
+                  if (strtmp[n] != ',') {
+                    sprintf(chtmp, "%c", strtmp[n]);
+                    strcat(chtmp1, chtmp);
+                  } else {
+                    sys.L3[i].L3_config[m] = atof(chtmp1);
+                    m++;
+                    chtmp1[0] = '\0';
+                  }
+                }
+                sys.L3[i].L3_config[m] = atof(chtmp1);
+                m++;
+                chtmp1[0] = '\0';
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "clockrate") == 0) {
+                sys.L3[i].clockrate =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "merged_dir") == 0) {
+                sys.L3[i].merged_dir = (bool)atoi(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "ports") == 0) {
+                strtmp.assign(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                m = 0;
+                for (n = 0; n < strtmp.length(); n++) {
+                  if (strtmp[n] != ',') {
+                    sprintf(chtmp, "%c", strtmp[n]);
+                    strcat(chtmp1, chtmp);
+                  } else {
+                    sys.L3[i].ports[m] = atoi(chtmp1);
+                    m++;
+                    chtmp1[0] = '\0';
+                  }
+                }
+                sys.L3[i].ports[m] = atoi(chtmp1);
+                m++;
+                chtmp1[0] = '\0';
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "device_type") == 0) {
+                sys.L3[i].device_type =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "threeD_stack") == 0) {
+                strcpy(sys.L3[i].threeD_stack,
+                       (xNode3.getChildNode("param", k).getAttribute("value")));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "buffer_sizes") == 0) {
+                strtmp.assign(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                m = 0;
+                for (n = 0; n < strtmp.length(); n++) {
+                  if (strtmp[n] != ',') {
+                    sprintf(chtmp, "%c", strtmp[n]);
+                    strcat(chtmp1, chtmp);
+                  } else {
+                    sys.L3[i].buffer_sizes[m] = atoi(chtmp1);
+                    m++;
+                    chtmp1[0] = '\0';
+                  }
+                }
+                sys.L3[i].buffer_sizes[m] = atoi(chtmp1);
+                m++;
+                chtmp1[0] = '\0';
+                continue;
+              }
+            }
+            // Get all stats with system.L3?
+            itmp = xNode3.nChildNode("stat");
+            for (k = 0; k < itmp; k++) {
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "total_accesses") == 0) {
+                sys.L3[i].total_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "read_accesses") == 0) {
+                sys.L3[i].read_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "write_accesses") == 0) {
+                sys.L3[i].write_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "total_hits") == 0) {
+                sys.L3[i].total_hits =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "total_misses") == 0) {
+                sys.L3[i].total_misses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "read_hits") == 0) {
+                sys.L3[i].read_hits =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "write_hits") == 0) {
+                sys.L3[i].write_hits =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "read_misses") == 0) {
+                sys.L3[i].read_misses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "write_misses") == 0) {
+                sys.L3[i].write_misses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "replacements") == 0) {
+                sys.L3[i].replacements =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "write_backs") == 0) {
+                sys.L3[i].write_backs =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "miss_buffer_accesses") == 0) {
+                sys.L3[i].miss_buffer_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "fill_buffer_accesses") == 0) {
+                sys.L3[i].fill_buffer_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "prefetch_buffer_accesses") == 0) {
+                sys.L3[i].prefetch_buffer_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "prefetch_buffer_writes") == 0) {
+                sys.L3[i].prefetch_buffer_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "prefetch_buffer_reads") == 0) {
+                sys.L3[i].prefetch_buffer_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "prefetch_buffer_hits") == 0) {
+                sys.L3[i].prefetch_buffer_hits =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "wbb_writes") == 0) {
+                sys.L3[i].wbb_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "wbb_reads") == 0) {
+                sys.L3[i].wbb_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "conflicts") == 0) {
+                sys.L3[i].conflicts =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "duty_cycle") == 0) {
+                sys.L3[i].duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
 
-							}
-						}
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "homenode_read_accesses") == 0) {
+                sys.L3[i].homenode_read_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "homenode_read_accesses") == 0) {
+                sys.L3[i].homenode_read_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "homenode_read_hits") == 0) {
+                sys.L3[i].homenode_read_hits =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "homenode_write_hits") == 0) {
+                sys.L3[i].homenode_write_hits =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "homenode_read_misses") == 0) {
+                sys.L3[i].homenode_read_misses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "homenode_write_misses") == 0) {
+                sys.L3[i].homenode_write_misses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "dir_duty_cycle") == 0) {
+                sys.L3[i].dir_duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+            }
+          }
+          w = w + 1;
+        } else {
+          printf(
+              "The value of homogeneous_L3s or number_of_L3s is not correct!");
+          exit(0);
+        }
+      }
+    }
+    //__________________________________________Get
+    // system.NoC[0..n]____________________________________________
+    w = OrderofComponents_3layer + 1;
+    tmpOrderofComponents_3layer = OrderofComponents_3layer;
+    if (sys.homogeneous_NoCs == 1)
+      OrderofComponents_3layer = OrderofComponents_3layer + 1;
+    else
+      OrderofComponents_3layer = OrderofComponents_3layer + sys.number_of_NoCs;
 
+    for (i = 0; i < (OrderofComponents_3layer - tmpOrderofComponents_3layer);
+         i++) {
+      xNode3 = xNode2.getChildNode("component", w);
+      if (xNode3.isEmpty() == 1) {
+        printf(
+            "The value of homogeneous_NoCs or number_of_NoCs is not correct!");
+        exit(0);
+      } else {
+        if (strstr(xNode3.getAttribute("name"), "noc") != NULL) {
+          {  // For NoC0-NoCi
+            // Get all params with system.NoC?
+            itmp = xNode3.nChildNode("param");
+            for (k = 0; k < itmp; k++) {
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "clockrate") == 0) {
+                sys.NoC[i].clockrate =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "type") == 0) {
+                sys.NoC[i].type = (bool)atoi(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "topology") == 0) {
+                strcpy(sys.NoC[i].topology,
+                       (xNode3.getChildNode("param", k).getAttribute("value")));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "horizontal_nodes") == 0) {
+                sys.NoC[i].horizontal_nodes =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "vertical_nodes") == 0) {
+                sys.NoC[i].vertical_nodes =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "has_global_link") == 0) {
+                sys.NoC[i].has_global_link = (bool)atoi(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "link_throughput") == 0) {
+                sys.NoC[i].link_throughput =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "link_latency") == 0) {
+                sys.NoC[i].link_latency =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "input_ports") == 0) {
+                sys.NoC[i].input_ports =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "output_ports") == 0) {
+                sys.NoC[i].output_ports =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "virtual_channel_per_port") == 0) {
+                sys.NoC[i].virtual_channel_per_port =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "flit_bits") == 0) {
+                sys.NoC[i].flit_bits =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "input_buffer_entries_per_vc") == 0) {
+                sys.NoC[i].input_buffer_entries_per_vc =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "dual_pump") == 0) {
+                sys.NoC[i].dual_pump =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "chip_coverage") == 0) {
+                sys.NoC[i].chip_coverage =
+                    atof(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "link_routing_over_percentage") == 0) {
+                sys.NoC[i].route_over_perc =
+                    atof(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "ports_of_input_buffer") == 0) {
+                strtmp.assign(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                m = 0;
+                for (n = 0; n < strtmp.length(); n++) {
+                  if (strtmp[n] != ',') {
+                    sprintf(chtmp, "%c", strtmp[n]);
+                    strcat(chtmp1, chtmp);
+                  } else {
+                    sys.NoC[i].ports_of_input_buffer[m] = atoi(chtmp1);
+                    m++;
+                    chtmp1[0] = '\0';
+                  }
+                }
+                sys.NoC[i].ports_of_input_buffer[m] = atoi(chtmp1);
+                m++;
+                chtmp1[0] = '\0';
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "number_of_crossbars") == 0) {
+                sys.NoC[i].number_of_crossbars =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "crossbar_type") == 0) {
+                strcpy(sys.NoC[i].crossbar_type,
+                       (xNode3.getChildNode("param", k).getAttribute("value")));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "crosspoint_type") == 0) {
+                strcpy(sys.NoC[i].crosspoint_type,
+                       (xNode3.getChildNode("param", k).getAttribute("value")));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "arbiter_type") == 0) {
+                sys.NoC[i].arbiter_type =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+            }
+            NumofCom_4 =
+                xNode3.nChildNode("component");  // get the number of components
+                                                 // within the third layer
+            for (j = 0; j < NumofCom_4; j++) {
+              xNode4 = xNode3.getChildNode("component", j);
+              if (strcmp(xNode4.getAttribute("name"), "xbar0") ==
+                  0) {  // find PBT
+                itmp = xNode4.nChildNode("param");
+                for (k = 0; k < itmp; k++) {  // get all items of param in
+                                              // system.XoC0.xbar0--xbar0
+                  if (strcmp(
+                          xNode4.getChildNode("param", k).getAttribute("name"),
+                          "number_of_inputs_of_crossbars") == 0) {
+                    sys.NoC[i].xbar0.number_of_inputs_of_crossbars = atoi(
+                        xNode4.getChildNode("param", k).getAttribute("value"));
+                    continue;
+                  }
+                  if (strcmp(
+                          xNode4.getChildNode("param", k).getAttribute("name"),
+                          "number_of_outputs_of_crossbars") == 0) {
+                    sys.NoC[i].xbar0.number_of_outputs_of_crossbars = atoi(
+                        xNode4.getChildNode("param", k).getAttribute("value"));
+                    continue;
+                  }
+                  if (strcmp(
+                          xNode4.getChildNode("param", k).getAttribute("name"),
+                          "flit_bits") == 0) {
+                    sys.NoC[i].xbar0.flit_bits = atoi(
+                        xNode4.getChildNode("param", k).getAttribute("value"));
+                    continue;
+                  }
+                  if (strcmp(
+                          xNode4.getChildNode("param", k).getAttribute("name"),
+                          "input_buffer_entries_per_port") == 0) {
+                    sys.NoC[i].xbar0.input_buffer_entries_per_port = atoi(
+                        xNode4.getChildNode("param", k).getAttribute("value"));
+                    continue;
+                  }
+                  if (strcmp(
+                          xNode4.getChildNode("param", k).getAttribute("name"),
+                          "ports_of_input_buffer") == 0) {
+                    strtmp.assign(
+                        xNode4.getChildNode("param", k).getAttribute("value"));
+                    m = 0;
+                    for (n = 0; n < strtmp.length(); n++) {
+                      if (strtmp[n] != ',') {
+                        sprintf(chtmp, "%c", strtmp[n]);
+                        strcat(chtmp1, chtmp);
+                      } else {
+                        sys.NoC[i].xbar0.ports_of_input_buffer[m] =
+                            atoi(chtmp1);
+                        m++;
+                        chtmp1[0] = '\0';
+                      }
+                    }
+                    sys.NoC[i].xbar0.ports_of_input_buffer[m] = atoi(chtmp1);
+                    m++;
+                    chtmp1[0] = '\0';
+                  }
+                }
+                itmp = xNode4.nChildNode("stat");
+                for (k = 0; k < itmp; k++) {  // get all items of stat in
+                                              // system.core0.predictor--PBT
+                  if (strcmp(
+                          xNode4.getChildNode("stat", k).getAttribute("name"),
+                          "predictor_accesses") == 0)
+                    sys.core[i].predictor.predictor_accesses = atof(
+                        xNode4.getChildNode("stat", k).getAttribute("value"));
+                }
+              }
+            }
+            // Get all stats with system.NoC?
+            itmp = xNode3.nChildNode("stat");
+            for (k = 0; k < itmp; k++) {
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "total_accesses") == 0)
+                sys.NoC[i].total_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "duty_cycle") == 0)
+                sys.NoC[i].duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+            }
+          }
+          w = w + 1;
+        }
+      }
+    }
+    //__________________________________________Get
+    // system.mem____________________________________________
+    if (OrderofComponents_3layer > 0)
+      OrderofComponents_3layer = OrderofComponents_3layer + 1;
+    xNode3 = xNode2.getChildNode("component", OrderofComponents_3layer);
+    if (xNode3.isEmpty() == 1) {
+      printf(
+          "some value(s) of "
+          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
+          "not correct!");
+      exit(0);
+    }
+    if (strstr(xNode3.getAttribute("id"), "system.mem") != NULL) {
+      itmp = xNode3.nChildNode("param");
+      for (k = 0; k < itmp; k++) {  // get all items of param in system.mem
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "mem_tech_node") == 0) {
+          sys.mem.mem_tech_node =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "device_clock") == 0) {
+          sys.mem.device_clock =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "peak_transfer_rate") == 0) {
+          sys.mem.peak_transfer_rate =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "capacity_per_channel") == 0) {
+          sys.mem.capacity_per_channel =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "number_ranks") == 0) {
+          sys.mem.number_ranks =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "num_banks_of_DRAM_chip") == 0) {
+          sys.mem.num_banks_of_DRAM_chip =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "Block_width_of_DRAM_chip") == 0) {
+          sys.mem.Block_width_of_DRAM_chip =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "output_width_of_DRAM_chip") == 0) {
+          sys.mem.output_width_of_DRAM_chip =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "page_size_of_DRAM_chip") == 0) {
+          sys.mem.page_size_of_DRAM_chip =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "burstlength_of_DRAM_chip") == 0) {
+          sys.mem.burstlength_of_DRAM_chip =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "internal_prefetch_of_DRAM_chip") == 0) {
+          sys.mem.internal_prefetch_of_DRAM_chip =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+      }
+      itmp = xNode3.nChildNode("stat");
+      for (k = 0; k < itmp; k++) {  // get all items of stat in system.mem
+        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                   "memory_accesses") == 0) {
+          sys.mem.memory_accesses =
+              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                   "memory_reads") == 0) {
+          sys.mem.memory_reads =
+              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                   "memory_writes") == 0) {
+          sys.mem.memory_writes =
+              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                   "dram_pre") == 0) {
+          sys.mem.dram_pre =
+              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+          continue;
+        }
+      }
+    } else {
+      printf(
+          "some value(s) of "
+          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
+          "not correct!");
+      exit(0);
+    }
+    //__________________________________________Get
+    // system.mc____________________________________________
+    if (OrderofComponents_3layer > 0)
+      OrderofComponents_3layer = OrderofComponents_3layer + 1;
+    xNode3 = xNode2.getChildNode("component", OrderofComponents_3layer);
+    if (xNode3.isEmpty() == 1) {
+      printf(
+          "some value(s) of "
+          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
+          "not correct!");
+      exit(0);
+    }
+    if (strstr(xNode3.getAttribute("id"), "system.mc") != NULL) {
+      itmp = xNode3.nChildNode("param");
+      for (k = 0; k < itmp; k++) {  // get all items of param in system.mem
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "mc_clock") == 0) {
+          sys.mc.mc_clock =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "block_size") == 0) {
+          sys.mc.llc_line_length =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "number_mcs") == 0) {
+          sys.mc.number_mcs =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "memory_channels_per_mc") == 0) {
+          sys.mc.memory_channels_per_mc =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "req_window_size_per_channel") == 0) {
+          sys.mc.req_window_size_per_channel =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "IO_buffer_size_per_channel") == 0) {
+          sys.mc.IO_buffer_size_per_channel =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "databus_width") == 0) {
+          sys.mc.databus_width =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "addressbus_width") == 0) {
+          sys.mc.addressbus_width =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "PRT_entries") == 0) {
+          sys.mc.PRT_entries =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "peak_transfer_rate") == 0) {
+          sys.mc.peak_transfer_rate =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "number_ranks") == 0) {
+          sys.mc.number_ranks =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "LVDS") == 0) {
+          sys.mc.LVDS =
+              (bool)atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "type") == 0) {
+          sys.mc.type =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "withPHY") == 0) {
+          sys.mc.withPHY =
+              (bool)atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
 
-						if (strcmp(xNode4.getAttribute("name"),"BTB")==0)
-						{//find system.core0.BTB
-							itmp=xNode4.nChildNode("param");
-							for(k=0; k<itmp; k++)
-							{ //get all items of param in system.core0.BTB--BTB
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"BTB_config")==0)
-								{
-									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
-									m=0;
-									for(n=0; n<strtmp.length(); n++)
-									{
-										if (strtmp[n]!=',')
-										{
-											sprintf(chtmp,"%c",strtmp[n]);
-											strcat(chtmp1,chtmp);
-										}
-										else{
-											sys.core[i].BTB.BTB_config[m]=atoi(chtmp1);
-											m++;
-											chtmp1[0]='\0';
-										}
-									}
-									sys.core[i].BTB.BTB_config[m]=atoi(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-								}
-							}
-							itmp=xNode4.nChildNode("stat");
-							for(k=0; k<itmp; k++)
-							{ //get all items of stat in BTB
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.core[i].BTB.total_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.core[i].BTB.read_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.core[i].BTB.write_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.core[i].BTB.total_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.core[i].BTB.total_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_hits")==0) {sys.core[i].BTB.read_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_hits")==0) {sys.core[i].BTB.write_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.core[i].BTB.read_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.core[i].BTB.write_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"replacements")==0) {sys.core[i].BTB.replacements=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-							}
-						}
-					}
-				}
-				else {
-					printf("The value of homogeneous_cores or number_of_cores is not correct!");
-					exit(0);
-				}
-			}
-		}
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "dram_cmd_coeff") == 0) {
+          sys.mc.dram_cmd_coeff =
+              atof(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "dram_act_coeff") == 0) {
+          sys.mc.dram_act_coeff =
+              atof(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "dram_nop_coeff") == 0) {
+          sys.mc.dram_nop_coeff =
+              atof(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "dram_activity_coeff") == 0) {
+          sys.mc.dram_activity_coeff =
+              atof(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "dram_pre_coeff") == 0) {
+          sys.mc.dram_pre_coeff =
+              atof(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "dram_rd_coeff") == 0) {
+          sys.mc.dram_rd_coeff =
+              atof(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "dram_wr_coeff") == 0) {
+          sys.mc.dram_wr_coeff =
+              atof(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "dram_req_coeff") == 0) {
+          sys.mc.dram_req_coeff =
+              atof(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "dram_const_coeff") == 0) {
+          sys.mc.dram_const_coeff =
+              atof(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+      }
+      itmp = xNode3.nChildNode("stat");
+      for (k = 0; k < itmp;
+           k++) {  // get all items of stat in system.mendirectory
+        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                   "memory_accesses") == 0) {
+          sys.mc.memory_accesses =
+              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                   "memory_reads") == 0) {
+          sys.mc.memory_reads =
+              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                   "memory_writes") == 0) {
+          sys.mc.memory_writes =
+              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                   "dram_pre") == 0) {
+          sys.mc.dram_pre =
+              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+          continue;
+        }
+      }
+    } else {
+      printf(
+          "some value(s) of "
+          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
+          "not correct!");
+      exit(0);
+    }
+    //__________________________________________Get
+    // system.niu____________________________________________
+    if (OrderofComponents_3layer > 0)
+      OrderofComponents_3layer = OrderofComponents_3layer + 1;
+    xNode3 = xNode2.getChildNode("component", OrderofComponents_3layer);
+    if (xNode3.isEmpty() == 1) {
+      printf(
+          "some value(s) of "
+          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
+          "not correct!");
+      exit(0);
+    }
+    if (strstr(xNode3.getAttribute("id"), "system.niu") != NULL) {
+      itmp = xNode3.nChildNode("param");
+      for (k = 0; k < itmp; k++) {  // get all items of param in system.mem
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "clockrate") == 0) {
+          sys.niu.clockrate =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "number_units") == 0) {
+          sys.niu.number_units =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "type") == 0) {
+          sys.niu.type =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+      }
+      itmp = xNode3.nChildNode("stat");
+      for (k = 0; k < itmp;
+           k++) {  // get all items of stat in system.mendirectory
+        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                   "duty_cycle") == 0) {
+          sys.niu.duty_cycle =
+              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                   "total_load_perc") == 0) {
+          sys.niu.total_load_perc =
+              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+          continue;
+        }
+      }
+    } else {
+      printf(
+          "some value(s) of "
+          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
+          "not correct!");
+      exit(0);
+    }
 
-		//__________________________________________Get system.L1Directory0-n____________________________________________
-		int w,tmpOrderofComponents_3layer;
-		w=OrderofComponents_3layer+1;
-		tmpOrderofComponents_3layer=OrderofComponents_3layer;
-		if (sys.homogeneous_L1Directories==1) OrderofComponents_3layer=OrderofComponents_3layer+1;
-		else OrderofComponents_3layer=OrderofComponents_3layer+sys.number_of_L1Directories;
-
-		for (i=0; i<(OrderofComponents_3layer-tmpOrderofComponents_3layer); i++)
-		{
-			xNode3=xNode2.getChildNode("component",w);
-			if (xNode3.isEmpty()==1) {
-				printf("The value of homogeneous_L1Directories or number_of_L1Directories is not correct!");
-				exit(0);
-			}
-			else
-			{
-				if (strstr(xNode3.getAttribute("id"),"L1Directory")!=NULL)
-				{
-					itmp=xNode3.nChildNode("param");
-					for(k=0; k<itmp; k++)
-					{ //get all items of param in system.L1Directory
-						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"Dir_config")==0)
-						{
-							strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-							m=0;
-							for(n=0; n<strtmp.length(); n++)
-							{
-								if (strtmp[n]!=',')
-								{
-									sprintf(chtmp,"%c",strtmp[n]);
-									strcat(chtmp1,chtmp);
-								}
-								else{
-									sys.L1Directory[i].Dir_config[m]=atof(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-								}
-							}
-							sys.L1Directory[i].Dir_config[m]=atof(chtmp1);
-							m++;
-							chtmp1[0]='\0';
-							continue;
-						}
-						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"buffer_sizes")==0)
-						{
-							strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-							m=0;
-							for(n=0; n<strtmp.length(); n++)
-							{
-								if (strtmp[n]!=',')
-								{
-									sprintf(chtmp,"%c",strtmp[n]);
-									strcat(chtmp1,chtmp);
-								}
-								else{
-									sys.L1Directory[i].buffer_sizes[m]=atoi(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-								}
-							}
-							sys.L1Directory[i].buffer_sizes[m]=atoi(chtmp1);
-							m++;
-							chtmp1[0]='\0';
-							continue;
-						}
-
-						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"clockrate")==0) {sys.L1Directory[i].clockrate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"ports")==0)
-						{
-							strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-							m=0;
-							for(n=0; n<strtmp.length(); n++)
-							{
-								if (strtmp[n]!=',')
-								{
-									sprintf(chtmp,"%c",strtmp[n]);
-									strcat(chtmp1,chtmp);
-								}
-								else{
-									sys.L1Directory[i].ports[m]=atoi(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-								}
-							}
-							sys.L1Directory[i].ports[m]=atoi(chtmp1);
-							m++;
-							chtmp1[0]='\0';
-							continue;
-						}
-						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"device_type")==0) {sys.L1Directory[i].device_type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"Directory_type")==0) {sys.L1Directory[i].Directory_type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"3D_stack")==0) {strcpy(sys.L1Directory[i].threeD_stack,xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-					}
-					itmp=xNode3.nChildNode("stat");
-					for(k=0; k<itmp; k++)
-					{ //get all items of stat in system.L2directorydirectory
-						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.L1Directory[i].total_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.L1Directory[i].read_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.L1Directory[i].write_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.L1Directory[i].read_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.L1Directory[i].write_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.L1Directory[i].conflicts=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"duty_cycle")==0) {sys.L1Directory[i].duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-					}
-					w=w+1;
-				}
-				else {
-					printf("The value of homogeneous_L1Directories or number_of_L1Directories is not correct!");
-					exit(0);
-				}
-			}
-		}
-
-		//__________________________________________Get system.L2Directory0-n____________________________________________
-		w=OrderofComponents_3layer+1;
-		tmpOrderofComponents_3layer=OrderofComponents_3layer;
-		if (sys.homogeneous_L2Directories==1) OrderofComponents_3layer=OrderofComponents_3layer+1;
-		else OrderofComponents_3layer=OrderofComponents_3layer+sys.number_of_L2Directories;
-
-		for (i=0; i<(OrderofComponents_3layer-tmpOrderofComponents_3layer); i++)
-		{
-			xNode3=xNode2.getChildNode("component",w);
-			if (xNode3.isEmpty()==1) {
-				printf("The value of homogeneous_L2Directories or number_of_L2Directories is not correct!");
-				exit(0);
-			}
-			else
-			{
-				if (strstr(xNode3.getAttribute("id"),"L2Directory")!=NULL)
-				{
-					itmp=xNode3.nChildNode("param");
-					for(k=0; k<itmp; k++)
-					{ //get all items of param in system.L2Directory
-						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"Dir_config")==0)
-						{
-							strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-							m=0;
-							for(n=0; n<strtmp.length(); n++)
-							{
-								if (strtmp[n]!=',')
-								{
-									sprintf(chtmp,"%c",strtmp[n]);
-									strcat(chtmp1,chtmp);
-								}
-								else{
-									sys.L2Directory[i].Dir_config[m]=atof(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-								}
-							}
-							sys.L2Directory[i].Dir_config[m]=atof(chtmp1);
-							m++;
-							chtmp1[0]='\0';
-							continue;
-						}
-						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"buffer_sizes")==0)
-						{
-							strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-							m=0;
-							for(n=0; n<strtmp.length(); n++)
-							{
-								if (strtmp[n]!=',')
-								{
-									sprintf(chtmp,"%c",strtmp[n]);
-									strcat(chtmp1,chtmp);
-								}
-								else{
-									sys.L2Directory[i].buffer_sizes[m]=atoi(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-								}
-							}
-							sys.L2Directory[i].buffer_sizes[m]=atoi(chtmp1);
-							m++;
-							chtmp1[0]='\0';
-							continue;
-						}
-
-						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"clockrate")==0) {sys.L2Directory[i].clockrate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"Directory_type")==0) {sys.L2Directory[i].Directory_type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"ports")==0)
-						{
-							strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-							m=0;
-							for(n=0; n<strtmp.length(); n++)
-							{
-								if (strtmp[n]!=',')
-								{
-									sprintf(chtmp,"%c",strtmp[n]);
-									strcat(chtmp1,chtmp);
-								}
-								else{
-									sys.L2Directory[i].ports[m]=atoi(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-								}
-							}
-							sys.L2Directory[i].ports[m]=atoi(chtmp1);
-							m++;
-							chtmp1[0]='\0';
-							continue;
-						}
-						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"device_type")==0) {sys.L2Directory[i].device_type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"3D_stack")==0) {strcpy(sys.L2Directory[i].threeD_stack,xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-					}
-					itmp=xNode3.nChildNode("stat");
-					for(k=0; k<itmp; k++)
-					{ //get all items of stat in system.L2directorydirectory
-						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.L2Directory[i].total_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.L2Directory[i].read_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.L2Directory[i].write_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.L2Directory[i].read_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-     					if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.L2Directory[i].write_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.L2Directory[i].conflicts=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"duty_cycle")==0) {sys.L2Directory[i].duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-
-					}
-					w=w+1;
-				}
-				else {
-					printf("The value of homogeneous_L2Directories or number_of_L2Directories is not correct!");
-					exit(0);
-				}
-			}
-		}
-
-		//__________________________________________Get system.L2[0..n]____________________________________________
-		w=OrderofComponents_3layer+1;
-		tmpOrderofComponents_3layer=OrderofComponents_3layer;
-		if (sys.homogeneous_L2s==1) OrderofComponents_3layer=OrderofComponents_3layer+1;
-		else OrderofComponents_3layer=OrderofComponents_3layer+sys.number_of_L2s;
-
-		for (i=0; i<(OrderofComponents_3layer-tmpOrderofComponents_3layer); i++)
-		{
-			xNode3=xNode2.getChildNode("component",w);
-			if (xNode3.isEmpty()==1) {
-				printf("The value of homogeneous_L2s or number_of_L2s is not correct!");
-				exit(0);
-			}
-			else
-			{
-				if (strstr(xNode3.getAttribute("name"),"L2")!=NULL)
-				{
-					{ //For L20-L2i
-						//Get all params with system.L2?
-						itmp=xNode3.nChildNode("param");
-						for(k=0; k<itmp; k++)
-						{
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"L2_config")==0)
-							{
-								strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-								m=0;
-								for(n=0; n<strtmp.length(); n++)
-								{
-									if (strtmp[n]!=',')
-									{
-										sprintf(chtmp,"%c",strtmp[n]);
-										strcat(chtmp1,chtmp);
-									}
-									else{
-										sys.L2[i].L2_config[m]=atof(chtmp1);
-										m++;
-										chtmp1[0]='\0';
-									}
-								}
-								sys.L2[i].L2_config[m]=atof(chtmp1);
-								m++;
-								chtmp1[0]='\0';
-								continue;
-							}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"clockrate")==0) {sys.L2[i].clockrate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"merged_dir")==0) {sys.L2[i].merged_dir=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"ports")==0)
-							{
-								strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-								m=0;
-								for(n=0; n<strtmp.length(); n++)
-								{
-									if (strtmp[n]!=',')
-									{
-										sprintf(chtmp,"%c",strtmp[n]);
-										strcat(chtmp1,chtmp);
-									}
-									else{
-										sys.L2[i].ports[m]=atoi(chtmp1);
-										m++;
-										chtmp1[0]='\0';
-									}
-								}
-								sys.L2[i].ports[m]=atoi(chtmp1);
-								m++;
-								chtmp1[0]='\0';
-								continue;
-							}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"device_type")==0) {sys.L2[i].device_type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"threeD_stack")==0) {strcpy(sys.L2[i].threeD_stack,(xNode3.getChildNode("param",k).getAttribute("value")));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"buffer_sizes")==0)
-							{
-								strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-								m=0;
-								for(n=0; n<strtmp.length(); n++)
-								{
-									if (strtmp[n]!=',')
-									{
-										sprintf(chtmp,"%c",strtmp[n]);
-										strcat(chtmp1,chtmp);
-									}
-									else{
-										sys.L2[i].buffer_sizes[m]=atoi(chtmp1);
-										m++;
-										chtmp1[0]='\0';
-									}
-								}
-								sys.L2[i].buffer_sizes[m]=atoi(chtmp1);
-								m++;
-								chtmp1[0]='\0';
-								continue;
-							}
-						}
-						//Get all stats with system.L2?
-						itmp=xNode3.nChildNode("stat");
-						for(k=0; k<itmp; k++)
-						{
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.L2[i].total_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.L2[i].read_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.L2[i].write_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.L2[i].total_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.L2[i].total_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_hits")==0) {sys.L2[i].read_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_hits")==0) {sys.L2[i].write_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.L2[i].read_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.L2[i].write_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"replacements")==0) {sys.L2[i].replacements=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_backs")==0) {sys.L2[i].write_backs=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"miss_buffer_accesses")==0) {sys.L2[i].miss_buffer_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"fill_buffer_accesses")==0) {sys.L2[i].fill_buffer_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_accesses")==0) {sys.L2[i].prefetch_buffer_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_writes")==0) {sys.L2[i].prefetch_buffer_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_reads")==0) {sys.L2[i].prefetch_buffer_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_hits")==0) {sys.L2[i].prefetch_buffer_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"wbb_writes")==0) {sys.L2[i].wbb_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"wbb_reads")==0) {sys.L2[i].wbb_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.L2[i].conflicts=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"duty_cycle")==0) {sys.L2[i].duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_read_accesses")==0) {sys.L2[i].homenode_read_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_read_accesses")==0) {sys.L2[i].homenode_read_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_read_hits")==0) {sys.L2[i].homenode_read_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_write_hits")==0) {sys.L2[i].homenode_write_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_read_misses")==0) {sys.L2[i].homenode_read_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_write_misses")==0) {sys.L2[i].homenode_write_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"dir_duty_cycle")==0) {sys.L2[i].dir_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-
-						}
-					}
-					w=w+1;
-				}
-				else {
-					printf("The value of homogeneous_L2s or number_of_L2s is not correct!");
-					exit(0);
-				}
-			}
-		}
-		//__________________________________________Get system.L3[0..n]____________________________________________
-		w=OrderofComponents_3layer+1;
-		tmpOrderofComponents_3layer=OrderofComponents_3layer;
-		if (sys.homogeneous_L3s==1) OrderofComponents_3layer=OrderofComponents_3layer+1;
-		else OrderofComponents_3layer=OrderofComponents_3layer+sys.number_of_L3s;
-
-		for (i=0; i<(OrderofComponents_3layer-tmpOrderofComponents_3layer); i++)
-		{
-			xNode3=xNode2.getChildNode("component",w);
-			if (xNode3.isEmpty()==1) {
-				printf("The value of homogeneous_L3s or number_of_L3s is not correct!");
-				exit(0);
-			}
-			else
-			{
-				if (strstr(xNode3.getAttribute("name"),"L3")!=NULL)
-				{
-					{ //For L30-L3i
-						//Get all params with system.L3?
-						itmp=xNode3.nChildNode("param");
-						for(k=0; k<itmp; k++)
-						{
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"L3_config")==0)
-							{
-								strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-								m=0;
-								for(n=0; n<strtmp.length(); n++)
-								{
-									if (strtmp[n]!=',')
-									{
-										sprintf(chtmp,"%c",strtmp[n]);
-										strcat(chtmp1,chtmp);
-									}
-									else{
-										sys.L3[i].L3_config[m]=atof(chtmp1);
-										m++;
-										chtmp1[0]='\0';
-									}
-								}
-								sys.L3[i].L3_config[m]=atof(chtmp1);
-								m++;
-								chtmp1[0]='\0';
-								continue;
-							}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"clockrate")==0) {sys.L3[i].clockrate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"merged_dir")==0) {sys.L3[i].merged_dir=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"ports")==0)
-							{
-								strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-								m=0;
-								for(n=0; n<strtmp.length(); n++)
-								{
-									if (strtmp[n]!=',')
-									{
-										sprintf(chtmp,"%c",strtmp[n]);
-										strcat(chtmp1,chtmp);
-									}
-									else{
-										sys.L3[i].ports[m]=atoi(chtmp1);
-										m++;
-										chtmp1[0]='\0';
-									}
-								}
-								sys.L3[i].ports[m]=atoi(chtmp1);
-								m++;
-								chtmp1[0]='\0';
-								continue;
-							}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"device_type")==0) {sys.L3[i].device_type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"threeD_stack")==0) {strcpy(sys.L3[i].threeD_stack,(xNode3.getChildNode("param",k).getAttribute("value")));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"buffer_sizes")==0)
-							{
-								strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-								m=0;
-								for(n=0; n<strtmp.length(); n++)
-								{
-									if (strtmp[n]!=',')
-									{
-										sprintf(chtmp,"%c",strtmp[n]);
-										strcat(chtmp1,chtmp);
-									}
-									else{
-										sys.L3[i].buffer_sizes[m]=atoi(chtmp1);
-										m++;
-										chtmp1[0]='\0';
-									}
-								}
-								sys.L3[i].buffer_sizes[m]=atoi(chtmp1);
-								m++;
-								chtmp1[0]='\0';
-								continue;
-							}
-						}
-						//Get all stats with system.L3?
-						itmp=xNode3.nChildNode("stat");
-						for(k=0; k<itmp; k++)
-						{
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.L3[i].total_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.L3[i].read_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.L3[i].write_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.L3[i].total_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.L3[i].total_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_hits")==0) {sys.L3[i].read_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_hits")==0) {sys.L3[i].write_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.L3[i].read_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.L3[i].write_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"replacements")==0) {sys.L3[i].replacements=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_backs")==0) {sys.L3[i].write_backs=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"miss_buffer_accesses")==0) {sys.L3[i].miss_buffer_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"fill_buffer_accesses")==0) {sys.L3[i].fill_buffer_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_accesses")==0) {sys.L3[i].prefetch_buffer_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_writes")==0) {sys.L3[i].prefetch_buffer_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_reads")==0) {sys.L3[i].prefetch_buffer_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_hits")==0) {sys.L3[i].prefetch_buffer_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"wbb_writes")==0) {sys.L3[i].wbb_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"wbb_reads")==0) {sys.L3[i].wbb_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.L3[i].conflicts=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"duty_cycle")==0) {sys.L3[i].duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_read_accesses")==0) {sys.L3[i].homenode_read_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_read_accesses")==0) {sys.L3[i].homenode_read_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_read_hits")==0) {sys.L3[i].homenode_read_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_write_hits")==0) {sys.L3[i].homenode_write_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_read_misses")==0) {sys.L3[i].homenode_read_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_write_misses")==0) {sys.L3[i].homenode_write_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"dir_duty_cycle")==0) {sys.L3[i].dir_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-
-						}
-					}
-					w=w+1;
-				}
-				else {
-					printf("The value of homogeneous_L3s or number_of_L3s is not correct!");
-					exit(0);
-				}
-			}
-		}
-		//__________________________________________Get system.NoC[0..n]____________________________________________
-		w=OrderofComponents_3layer+1;
-		tmpOrderofComponents_3layer=OrderofComponents_3layer;
-		if (sys.homogeneous_NoCs==1) OrderofComponents_3layer=OrderofComponents_3layer+1;
-		else OrderofComponents_3layer=OrderofComponents_3layer+sys.number_of_NoCs;
-
-		for (i=0; i<(OrderofComponents_3layer-tmpOrderofComponents_3layer); i++)
-		{
-			xNode3=xNode2.getChildNode("component",w);
-			if (xNode3.isEmpty()==1) {
-				printf("The value of homogeneous_NoCs or number_of_NoCs is not correct!");
-				exit(0);
-			}
-			else
-			{
-				if (strstr(xNode3.getAttribute("name"),"noc")!=NULL)
-				{
-					{ //For NoC0-NoCi
-						//Get all params with system.NoC?
-						itmp=xNode3.nChildNode("param");
-						for(k=0; k<itmp; k++)
-						{
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"clockrate")==0) {sys.NoC[i].clockrate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"type")==0) {sys.NoC[i].type=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"topology")==0) {strcpy(sys.NoC[i].topology,(xNode3.getChildNode("param",k).getAttribute("value")));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"horizontal_nodes")==0) {sys.NoC[i].horizontal_nodes=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"vertical_nodes")==0) {sys.NoC[i].vertical_nodes=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"has_global_link")==0) {sys.NoC[i].has_global_link=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"link_throughput")==0) {sys.NoC[i].link_throughput=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"link_latency")==0) {sys.NoC[i].link_latency=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"input_ports")==0) {sys.NoC[i].input_ports=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"output_ports")==0) {sys.NoC[i].output_ports=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"virtual_channel_per_port")==0) {sys.NoC[i].virtual_channel_per_port=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"flit_bits")==0) {sys.NoC[i].flit_bits=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"input_buffer_entries_per_vc")==0) {sys.NoC[i].input_buffer_entries_per_vc=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dual_pump")==0) {sys.NoC[i].dual_pump=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"chip_coverage")==0) {sys.NoC[i].chip_coverage=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"link_routing_over_percentage")==0) {sys.NoC[i].route_over_perc=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"ports_of_input_buffer")==0)
-							{
-								strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-								m=0;
-								for(n=0; n<strtmp.length(); n++)
-								{
-									if (strtmp[n]!=',')
-									{
-										sprintf(chtmp,"%c",strtmp[n]);
-										strcat(chtmp1,chtmp);
-									}
-									else{
-										sys.NoC[i].ports_of_input_buffer[m]=atoi(chtmp1);
-										m++;
-										chtmp1[0]='\0';
-									}
-								}
-								sys.NoC[i].ports_of_input_buffer[m]=atoi(chtmp1);
-								m++;
-								chtmp1[0]='\0';
-								continue;
-							}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_of_crossbars")==0) {sys.NoC[i].number_of_crossbars=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"crossbar_type")==0) {strcpy(sys.NoC[i].crossbar_type,(xNode3.getChildNode("param",k).getAttribute("value")));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"crosspoint_type")==0) {strcpy(sys.NoC[i].crosspoint_type,(xNode3.getChildNode("param",k).getAttribute("value")));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"arbiter_type")==0) {sys.NoC[i].arbiter_type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-						}
-						NumofCom_4=xNode3.nChildNode("component"); //get the number of components within the third layer
-						for(j=0; j<NumofCom_4; j++)
-						{
-							xNode4=xNode3.getChildNode("component",j);
-							if (strcmp(xNode4.getAttribute("name"),"xbar0")==0)
-							{ //find PBT
-								itmp=xNode4.nChildNode("param");
-								for(k=0; k<itmp; k++)
-								{ //get all items of param in system.XoC0.xbar0--xbar0
-									if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"number_of_inputs_of_crossbars")==0) {sys.NoC[i].xbar0.number_of_inputs_of_crossbars=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
-									if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"number_of_outputs_of_crossbars")==0) {sys.NoC[i].xbar0.number_of_outputs_of_crossbars=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
-									if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"flit_bits")==0) {sys.NoC[i].xbar0.flit_bits=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
-									if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"input_buffer_entries_per_port")==0) {sys.NoC[i].xbar0.input_buffer_entries_per_port=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
-									if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"ports_of_input_buffer")==0)
-									{
-										strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
-										m=0;
-										for(n=0; n<strtmp.length(); n++)
-										{
-											if (strtmp[n]!=',')
-											{
-												sprintf(chtmp,"%c",strtmp[n]);
-												strcat(chtmp1,chtmp);
-											}
-											else{
-												sys.NoC[i].xbar0.ports_of_input_buffer[m]=atoi(chtmp1);
-												m++;
-												chtmp1[0]='\0';
-											}
-										}
-										sys.NoC[i].xbar0.ports_of_input_buffer[m]=atoi(chtmp1);
-										m++;
-										chtmp1[0]='\0';
-									}
-								}
-								itmp=xNode4.nChildNode("stat");
-								for(k=0; k<itmp; k++)
-								{ //get all items of stat in system.core0.predictor--PBT
-									if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"predictor_accesses")==0) sys.core[i].predictor.predictor_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));
-								}
-							}
-						}
-						//Get all stats with system.NoC?
-						itmp=xNode3.nChildNode("stat");
-						for(k=0; k<itmp; k++)
-						{
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) sys.NoC[i].total_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"duty_cycle")==0) sys.NoC[i].duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));
-						}
-					}
-					w=w+1;
-				}
-			}
-		}
-		//__________________________________________Get system.mem____________________________________________
-		if (OrderofComponents_3layer>0) OrderofComponents_3layer=OrderofComponents_3layer+1;
-		xNode3=xNode2.getChildNode("component",OrderofComponents_3layer);
-		if (xNode3.isEmpty()==1) {
-			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
-			exit(0);
-		}
-		if (strstr(xNode3.getAttribute("id"),"system.mem")!=NULL)
-		{
-
-			itmp=xNode3.nChildNode("param");
-			for(k=0; k<itmp; k++)
-			{ //get all items of param in system.mem
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"mem_tech_node")==0) {sys.mem.mem_tech_node=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"device_clock")==0) {sys.mem.device_clock=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"peak_transfer_rate")==0) {sys.mem.peak_transfer_rate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"capacity_per_channel")==0) {sys.mem.capacity_per_channel=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_ranks")==0) {sys.mem.number_ranks=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"num_banks_of_DRAM_chip")==0) {sys.mem.num_banks_of_DRAM_chip=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"Block_width_of_DRAM_chip")==0) {sys.mem.Block_width_of_DRAM_chip=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"output_width_of_DRAM_chip")==0) {sys.mem.output_width_of_DRAM_chip=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"page_size_of_DRAM_chip")==0) {sys.mem.page_size_of_DRAM_chip=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"burstlength_of_DRAM_chip")==0) {sys.mem.burstlength_of_DRAM_chip=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"internal_prefetch_of_DRAM_chip")==0) {sys.mem.internal_prefetch_of_DRAM_chip=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-			}
-			itmp=xNode3.nChildNode("stat");
-			for(k=0; k<itmp; k++)
-			{ //get all items of stat in system.mem
-				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_accesses")==0) {sys.mem.memory_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_reads")==0) {sys.mem.memory_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_writes")==0) {sys.mem.memory_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"dram_pre")==0) {sys.mem.dram_pre=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-			}
-		}
-		else{
-			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
-			exit(0);
-		}
-		//__________________________________________Get system.mc____________________________________________
-		if (OrderofComponents_3layer>0) OrderofComponents_3layer=OrderofComponents_3layer+1;
-		xNode3=xNode2.getChildNode("component",OrderofComponents_3layer);
-		if (xNode3.isEmpty()==1) {
-			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
-			exit(0);
-		}
-		if (strstr(xNode3.getAttribute("id"),"system.mc")!=NULL)
-		{
-			itmp=xNode3.nChildNode("param");
-			for(k=0; k<itmp; k++)
-			{ //get all items of param in system.mem
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"mc_clock")==0) {sys.mc.mc_clock=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"block_size")==0) {sys.mc.llc_line_length=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_mcs")==0) {sys.mc.number_mcs=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"memory_channels_per_mc")==0) {sys.mc.memory_channels_per_mc=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"req_window_size_per_channel")==0) {sys.mc.req_window_size_per_channel=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"IO_buffer_size_per_channel")==0) {sys.mc.IO_buffer_size_per_channel=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"databus_width")==0) {sys.mc.databus_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"addressbus_width")==0) {sys.mc.addressbus_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"PRT_entries")==0) {sys.mc.PRT_entries=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"peak_transfer_rate")==0) {sys.mc.peak_transfer_rate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_ranks")==0) {sys.mc.number_ranks=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"LVDS")==0) {sys.mc.LVDS=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"type")==0) {sys.mc.type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"withPHY")==0) {sys.mc.withPHY=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-
-        		if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dram_cmd_coeff")==0) {sys.mc.dram_cmd_coeff=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-        		if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dram_act_coeff")==0) {sys.mc.dram_act_coeff=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-        		if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dram_nop_coeff")==0) {sys.mc.dram_nop_coeff=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-        		if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dram_activity_coeff")==0) {sys.mc.dram_activity_coeff=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-        		if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dram_pre_coeff")==0) {sys.mc.dram_pre_coeff=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-        		if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dram_rd_coeff")==0) {sys.mc.dram_rd_coeff=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-        		if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dram_wr_coeff")==0) {sys.mc.dram_wr_coeff=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-        		if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dram_req_coeff")==0) {sys.mc.dram_req_coeff=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-        		if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dram_const_coeff")==0) {sys.mc.dram_const_coeff=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-			}
-			itmp=xNode3.nChildNode("stat");
-			for(k=0; k<itmp; k++)
-			{ //get all items of stat in system.mendirectory
-				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_accesses")==0) {sys.mc.memory_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_reads")==0) {sys.mc.memory_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_writes")==0) {sys.mc.memory_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"dram_pre")==0) {sys.mc.dram_pre=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-			}
-		}
-		else{
-			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
-			exit(0);
-		}
-		//__________________________________________Get system.niu____________________________________________
-		if (OrderofComponents_3layer>0) OrderofComponents_3layer=OrderofComponents_3layer+1;
-		xNode3=xNode2.getChildNode("component",OrderofComponents_3layer);
-		if (xNode3.isEmpty()==1) {
-			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
-			exit(0);
-		}
-		if (strstr(xNode3.getAttribute("id"),"system.niu")!=NULL)
-		{
-			itmp=xNode3.nChildNode("param");
-			for(k=0; k<itmp; k++)
-			{ //get all items of param in system.mem
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"clockrate")==0) {sys.niu.clockrate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_units")==0) {sys.niu.number_units=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"type")==0) {sys.niu.type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-			}
-			itmp=xNode3.nChildNode("stat");
-			for(k=0; k<itmp; k++)
-			{ //get all items of stat in system.mendirectory
-				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"duty_cycle")==0) {sys.niu.duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_load_perc")==0) {sys.niu.total_load_perc=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-			}
-		}
-		else{
-			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
-			exit(0);
-		}
-
-		//__________________________________________Get system.pcie____________________________________________
-		if (OrderofComponents_3layer>0) OrderofComponents_3layer=OrderofComponents_3layer+1;
-		xNode3=xNode2.getChildNode("component",OrderofComponents_3layer);
-		if (xNode3.isEmpty()==1) {
-			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
-			exit(0);
-		}
-		if (strstr(xNode3.getAttribute("id"),"system.pcie")!=NULL)
-		{
-			itmp=xNode3.nChildNode("param");
-			for(k=0; k<itmp; k++)
-			{ //get all items of param in system.mem
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"clockrate")==0) {sys.pcie.clockrate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_units")==0) {sys.pcie.number_units=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"num_channels")==0) {sys.pcie.num_channels=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"type")==0) {sys.pcie.type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"withPHY")==0) {sys.pcie.withPHY=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-
-			}
-			itmp=xNode3.nChildNode("stat");
-			for(k=0; k<itmp; k++)
-			{ //get all items of stat in system.mendirectory
-				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"duty_cycle")==0) {sys.pcie.duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_load_perc")==0) {sys.pcie.total_load_perc=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-			}
-		}
-		else{
-			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
-			exit(0);
-		}
-		//__________________________________________Get system.flashcontroller____________________________________________
-		if (OrderofComponents_3layer>0) OrderofComponents_3layer=OrderofComponents_3layer+1;
-		xNode3=xNode2.getChildNode("component",OrderofComponents_3layer);
-		if (xNode3.isEmpty()==1) {
-			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
-			exit(0);
-		}
-		if (strstr(xNode3.getAttribute("id"),"system.flashc")!=NULL)
-		{
-			itmp=xNode3.nChildNode("param");
-			for(k=0; k<itmp; k++)
-			{ //get all items of param in system.mem
-//				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"flashc_clock")==0) {sys.flashc.mc_clock=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-//				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"block_size")==0) {sys.flashc.llc_line_length=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_flashcs")==0) {sys.flashc.number_mcs=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-//				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"memory_channels_per_flashc")==0) {sys.flashc.memory_channels_per_mc=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-//				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"req_window_size_per_channel")==0) {sys.flashc.req_window_size_per_channel=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-//				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"IO_buffer_size_per_channel")==0) {sys.flashc.IO_buffer_size_per_channel=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-//				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"databus_width")==0) {sys.flashc.databus_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-//				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"addressbus_width")==0) {sys.flashc.addressbus_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"peak_transfer_rate")==0) {sys.flashc.peak_transfer_rate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-//				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_ranks")==0) {sys.flashc.number_ranks=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-//				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"LVDS")==0) {sys.flashc.LVDS=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"type")==0) {sys.flashc.type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"withPHY")==0) {sys.flashc.withPHY=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-
-			}
-			itmp=xNode3.nChildNode("stat");
-			for(k=0; k<itmp; k++)
-			{ //get all items of stat in system.mendirectory
-//				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_accesses")==0) {sys.flashc.memory_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-//				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_reads")==0) {sys.flashc.memory_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-//				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_writes")==0) {sys.flashc.memory_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"duty_cycle")==0) {sys.flashc.duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_load_perc")==0) {sys.flashc.total_load_perc=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-
-			}
-		}
-		else{
-			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
-			exit(0);
-		}
-
-	}
+    //__________________________________________Get
+    // system.pcie____________________________________________
+    if (OrderofComponents_3layer > 0)
+      OrderofComponents_3layer = OrderofComponents_3layer + 1;
+    xNode3 = xNode2.getChildNode("component", OrderofComponents_3layer);
+    if (xNode3.isEmpty() == 1) {
+      printf(
+          "some value(s) of "
+          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
+          "not correct!");
+      exit(0);
+    }
+    if (strstr(xNode3.getAttribute("id"), "system.pcie") != NULL) {
+      itmp = xNode3.nChildNode("param");
+      for (k = 0; k < itmp; k++) {  // get all items of param in system.mem
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "clockrate") == 0) {
+          sys.pcie.clockrate =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "number_units") == 0) {
+          sys.pcie.number_units =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "num_channels") == 0) {
+          sys.pcie.num_channels =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "type") == 0) {
+          sys.pcie.type =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "withPHY") == 0) {
+          sys.pcie.withPHY =
+              (bool)atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+      }
+      itmp = xNode3.nChildNode("stat");
+      for (k = 0; k < itmp;
+           k++) {  // get all items of stat in system.mendirectory
+        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                   "duty_cycle") == 0) {
+          sys.pcie.duty_cycle =
+              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                   "total_load_perc") == 0) {
+          sys.pcie.total_load_perc =
+              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+          continue;
+        }
+      }
+    } else {
+      printf(
+          "some value(s) of "
+          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
+          "not correct!");
+      exit(0);
+    }
+    //__________________________________________Get
+    // system.flashcontroller____________________________________________
+    if (OrderofComponents_3layer > 0)
+      OrderofComponents_3layer = OrderofComponents_3layer + 1;
+    xNode3 = xNode2.getChildNode("component", OrderofComponents_3layer);
+    if (xNode3.isEmpty() == 1) {
+      printf(
+          "some value(s) of "
+          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
+          "not correct!");
+      exit(0);
+    }
+    if (strstr(xNode3.getAttribute("id"), "system.flashc") != NULL) {
+      itmp = xNode3.nChildNode("param");
+      for (k = 0; k < itmp; k++) {  // get all items of param in system.mem
+        //				if
+        //(strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"flashc_clock")==0)
+        //{sys.flashc.mc_clock=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+        //				if
+        //(strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"block_size")==0)
+        //{sys.flashc.llc_line_length=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "number_flashcs") == 0) {
+          sys.flashc.number_mcs =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        //				if
+        //(strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"memory_channels_per_flashc")==0)
+        //{sys.flashc.memory_channels_per_mc=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+        //				if
+        //(strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"req_window_size_per_channel")==0)
+        //{sys.flashc.req_window_size_per_channel=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+        //				if
+        //(strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"IO_buffer_size_per_channel")==0)
+        //{sys.flashc.IO_buffer_size_per_channel=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+        //				if
+        //(strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"databus_width")==0)
+        //{sys.flashc.databus_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+        //				if
+        //(strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"addressbus_width")==0)
+        //{sys.flashc.addressbus_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "peak_transfer_rate") == 0) {
+          sys.flashc.peak_transfer_rate =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        //				if
+        //(strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_ranks")==0)
+        //{sys.flashc.number_ranks=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+        //				if
+        //(strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"LVDS")==0)
+        //{sys.flashc.LVDS=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "type") == 0) {
+          sys.flashc.type =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "withPHY") == 0) {
+          sys.flashc.withPHY =
+              (bool)atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+      }
+      itmp = xNode3.nChildNode("stat");
+      for (k = 0; k < itmp;
+           k++) {  // get all items of stat in system.mendirectory
+        //				if
+        //(strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_accesses")==0)
+        //{sys.flashc.memory_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+        //				if
+        //(strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_reads")==0)
+        //{sys.flashc.memory_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+        //				if
+        //(strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_writes")==0)
+        //{sys.flashc.memory_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                   "duty_cycle") == 0) {
+          sys.flashc.duty_cycle =
+              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                   "total_load_perc") == 0) {
+          sys.flashc.total_load_perc =
+              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+          continue;
+        }
+      }
+    } else {
+      printf(
+          "some value(s) of "
+          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
+          "not correct!");
+      exit(0);
+    }
+  }
 }
-void ParseXML::initialize() //Initialize all
+void ParseXML::initialize()  // Initialize all
 {
-	//All number_of_* at the level of 'system' 03/21/2009
-	sys.number_of_cores=1;
-	sys.architecture=1; //1 - fermi
-	sys.number_of_L1Directories=1;
-	sys.number_of_L2Directories=1;
-	sys.number_of_L2s=1;
-	sys.Private_L2 = false;
-	sys.number_of_L3s=1;
-	sys.number_of_NoCs=1;
-	// All params at the level of 'system'
-	//strcpy(sys.homogeneous_cores,"default");
-	sys.core_tech_node=1;
-	sys.target_core_clockrate=1;
-	sys.target_chip_area=1;
-	sys.temperature=1;
-	sys.number_cache_levels=1;
-	sys.homogeneous_cores=1;
-	sys.homogeneous_L1Directories=1;
-	sys.homogeneous_L2Directories=1;
-	sys.homogeneous_L2s=1;
-	sys.homogeneous_L3s=1;
-	sys.homogeneous_NoCs=1;
-	sys.homogeneous_ccs=1;
+  // All number_of_* at the level of 'system' 03/21/2009
+  sys.number_of_cores = 1;
+  sys.architecture = 1;  // 1 - fermi
+  sys.number_of_L1Directories = 1;
+  sys.number_of_L2Directories = 1;
+  sys.number_of_L2s = 1;
+  sys.Private_L2 = false;
+  sys.number_of_L3s = 1;
+  sys.number_of_NoCs = 1;
+  // All params at the level of 'system'
+  // strcpy(sys.homogeneous_cores,"default");
+  sys.core_tech_node = 1;
+  sys.target_core_clockrate = 1;
+  sys.target_chip_area = 1;
+  sys.temperature = 1;
+  sys.number_cache_levels = 1;
+  sys.homogeneous_cores = 1;
+  sys.homogeneous_L1Directories = 1;
+  sys.homogeneous_L2Directories = 1;
+  sys.homogeneous_L2s = 1;
+  sys.homogeneous_L3s = 1;
+  sys.homogeneous_NoCs = 1;
+  sys.homogeneous_ccs = 1;
 
-	sys.Max_area_deviation=1;
-	sys.Max_power_deviation=1;
-	sys.device_type=1;
-	sys.longer_channel_device =true;
-	sys.Embedded =false;
-	sys.opt_dynamic_power=false;
-	sys.opt_lakage_power=false;
-	sys.opt_clockrate=true;
-	sys.opt_area=false;
-	sys.interconnect_projection_type=1;
-	sys.idle_core_power=0;
-	int i,j;
-	for (i=0; i<=63; i++)
-	{
-		sys.scaling_coefficients[i]=1;
-		sys.core[i].clock_rate=1;
-		sys.core[i].opt_local = true;
-		sys.core[i].x86 = false;
-		sys.core[i].machine_bits=1;
-		sys.core[i].virtual_address_width=1;
-		sys.core[i].physical_address_width=1;
-		sys.core[i].opcode_width=1;
-		sys.core[i].micro_opcode_width=1;
-		//strcpy(sys.core[i].machine_type,"default");
-		sys.core[i].internal_datapath_width=1;
-		sys.core[i].number_hardware_threads=1;
-		sys.core[i].fetch_width=1;
-		sys.core[i].number_instruction_fetch_ports=1;
-		sys.core[i].decode_width=1;
-		sys.core[i].issue_width=1;
-		sys.core[i].peak_issue_width=1;
-		sys.core[i].commit_width=1;
-		for (j=0; j<20; j++) sys.core[i].pipelines_per_core[j]=1;
-		for (j=0; j<20; j++) sys.core[i].pipeline_depth[j]=1;
-		strcpy(sys.core[i].FPU,"default");
-		strcpy(sys.core[i]. divider_multiplier,"default");
-		sys.core[i].ALU_per_core=1;
-		sys.core[i].FPU_per_core=1.0;
-		sys.core[i].MUL_per_core=1;
-		sys.core[i].instruction_buffer_size=1;
-		sys.core[i].decoded_stream_buffer_size=1;
-		//strcpy(sys.core[i].instruction_window_scheme,"default");
-		sys.core[i].instruction_window_size=1;
-		sys.core[i].ROB_size=1;
-		sys.core[i].archi_Regs_IRF_size=1;
-		sys.core[i].archi_Regs_FRF_size=1;
-		sys.core[i].phy_Regs_IRF_size=1;
-		sys.core[i].phy_Regs_FRF_size=1;
-		//strcpy(sys.core[i].rename_scheme,"default");
-		sys.core[i].register_windows_size=1;
-		strcpy(sys.core[i].LSU_order,"default");
-		sys.core[i].store_buffer_size=1;
-		sys.core[i].load_buffer_size=1;
-		sys.core[i].memory_ports=1;
-		strcpy(sys.core[i].Dcache_dual_pump,"default");
-		sys.core[i].RAS_size=1;
-		//all stats at the level of system.core(0-n)
-		sys.core[i].total_instructions=1;
-		sys.core[i].int_instructions=1;
-		sys.core[i].fp_instructions=1;
-		sys.core[i].branch_instructions=1;
-		sys.core[i].branch_mispredictions=1;
-		sys.core[i].committed_instructions=1;
-		sys.core[i].load_instructions=1;
-		sys.core[i].store_instructions=1;
-		sys.core[i].total_cycles=1;
-		sys.core[i].idle_cycles=1;
-		sys.core[i].busy_cycles=1;
-		sys.core[i].instruction_buffer_reads=1;
-		sys.core[i].instruction_buffer_write=1;
-		sys.core[i].ROB_reads=1;
-		sys.core[i].ROB_writes=1;
-		sys.core[i].rename_accesses=1;
-		sys.core[i].inst_window_reads=1;
-		sys.core[i].inst_window_writes=1;
-		sys.core[i].inst_window_wakeup_accesses=1;
-		sys.core[i].inst_window_selections=1;
-		sys.core[i].archi_int_regfile_reads=1;
-		sys.core[i].archi_float_regfile_reads=1;
-		sys.core[i].phy_int_regfile_reads=1;
-		sys.core[i].phy_float_regfile_reads=1;
-		sys.core[i].windowed_reg_accesses=1;
-		sys.core[i].windowed_reg_transports=1;
-		sys.core[i].function_calls=1;
-		sys.core[i].ialu_accesses=1;
-		sys.core[i].fpu_accesses=1;
-		sys.core[i].mul_accesses=1;
-		sys.core[i].cdb_alu_accesses=1;
-		sys.core[i].cdb_mul_accesses=1;
-		sys.core[i].cdb_fpu_accesses=1;
-		sys.core[i].load_buffer_reads=1;
-		sys.core[i].load_buffer_writes=1;
-		sys.core[i].load_buffer_cams=1;
-		sys.core[i].store_buffer_reads=1;
-		sys.core[i].store_buffer_writes=1;
-		sys.core[i].store_buffer_cams=1;
-		sys.core[i].store_buffer_forwards=1;
-		sys.core[i].main_memory_access=1;
-		sys.core[i].main_memory_read=1;
-		sys.core[i].main_memory_write=1;
-		sys.core[i].IFU_duty_cycle = 1;
-		sys.core[i].BR_duty_cycle = 1;
-		sys.core[i].LSU_duty_cycle = 1;
-		sys.core[i].MemManU_I_duty_cycle =1;
-		sys.core[i].MemManU_D_duty_cycle =1;
-		sys.core[i].ALU_duty_cycle =1;
-		sys.core[i].MUL_duty_cycle =1;
-		sys.core[i].FPU_duty_cycle =1;
-		sys.core[i].ALU_cdb_duty_cycle =1;
-		sys.core[i].MUL_cdb_duty_cycle =1;
-		sys.core[i].FPU_cdb_duty_cycle =1;
-		//system.core?.predictor
-		sys.core[i].predictor.prediction_width=1;
-		strcpy(sys.core[i].predictor.prediction_scheme,"default");
-		sys.core[i].predictor.predictor_size=1;
-		sys.core[i].predictor.predictor_entries=1;
-		sys.core[i].predictor.local_predictor_entries=1;
-		for (j=0; j<20; j++) sys.core[i].predictor.local_predictor_size[j]=1;
-		sys.core[i].predictor.global_predictor_entries=1;
-		sys.core[i].predictor.global_predictor_bits=1;
-		sys.core[i].predictor.chooser_predictor_entries=1;
-		sys.core[i].predictor.chooser_predictor_bits=1;
-		sys.core[i].predictor.predictor_accesses=1;
-		//system.core?.itlb
-		sys.core[i].itlb.number_entries=1;
-		sys.core[i].itlb.total_hits=1;
-		sys.core[i].itlb.total_accesses=1;
-		sys.core[i].itlb.total_misses=1;
-		//system.core?.icache
-		for (j=0; j<20; j++) sys.core[i].icache.icache_config[j]=1;
-		//strcpy(sys.core[i].icache.buffer_sizes,"default");
-		sys.core[i].icache.total_accesses=1;
-		sys.core[i].icache.read_accesses=1;
-		sys.core[i].icache.read_misses=1;
-		sys.core[i].icache.replacements=1;
-		sys.core[i].icache.read_hits=1;
-		sys.core[i].icache.total_hits=1;
-		sys.core[i].icache.total_misses=1;
-		sys.core[i].icache.miss_buffer_access=1;
-		sys.core[i].icache.fill_buffer_accesses=1;
-		sys.core[i].icache.prefetch_buffer_accesses=1;
-		sys.core[i].icache.prefetch_buffer_writes=1;
-		sys.core[i].icache.prefetch_buffer_reads=1;
-		sys.core[i].icache.prefetch_buffer_hits=1;
-		//system.core?.dtlb
-		sys.core[i].dtlb.number_entries=1;
-		sys.core[i].dtlb.total_accesses=1;
-		sys.core[i].dtlb.read_accesses=1;
-		sys.core[i].dtlb.write_accesses=1;
-		sys.core[i].dtlb.write_hits=1;
-		sys.core[i].dtlb.read_hits=1;
-		sys.core[i].dtlb.read_misses=1;
-		sys.core[i].dtlb.write_misses=1;
-		sys.core[i].dtlb.total_hits=1;
-		sys.core[i].dtlb.total_misses=1;
-		//system.core?.dcache
-		for (j=0; j<20; j++) sys.core[i].dcache.dcache_config[j]=1;
-		//strcpy(sys.core[i].dcache.buffer_sizes,"default");
-		sys.core[i].dcache.total_accesses=1;
-		sys.core[i].dcache.read_accesses=1;
-		sys.core[i].dcache.write_accesses=1;
-		sys.core[i].dcache.total_hits=1;
-		sys.core[i].dcache.total_misses=1;
-		sys.core[i].dcache.read_hits=1;
-		sys.core[i].dcache.write_hits=1;
-		sys.core[i].dcache.read_misses=1;
-		sys.core[i].dcache.write_misses=1;
-		sys.core[i].dcache.replacements=1;
-		sys.core[i].dcache.write_backs=1;
-		sys.core[i].dcache.miss_buffer_access=1;
-		sys.core[i].dcache.fill_buffer_accesses=1;
-		sys.core[i].dcache.prefetch_buffer_accesses=1;
-		sys.core[i].dcache.prefetch_buffer_writes=1;
-		sys.core[i].dcache.prefetch_buffer_reads=1;
-		sys.core[i].dcache.prefetch_buffer_hits=1;
-		sys.core[i].dcache.wbb_writes=1;
-		sys.core[i].dcache.wbb_reads=1;
-		//system.core?.BTB
-		for (j=0; j<20; j++) sys.core[i].BTB.BTB_config[j]=1;
-		sys.core[i].BTB.total_accesses=1;
-		sys.core[i].BTB.read_accesses=1;
-		sys.core[i].BTB.write_accesses=1;
-		sys.core[i].BTB.total_hits=1;
-		sys.core[i].BTB.total_misses=1;
-		sys.core[i].BTB.read_hits=1;
-		sys.core[i].BTB.write_hits=1;
-		sys.core[i].BTB.read_misses=1;
-		sys.core[i].BTB.write_misses=1;
-		sys.core[i].BTB.replacements=1;
-	}
+  sys.Max_area_deviation = 1;
+  sys.Max_power_deviation = 1;
+  sys.device_type = 1;
+  sys.longer_channel_device = true;
+  sys.Embedded = false;
+  sys.opt_dynamic_power = false;
+  sys.opt_lakage_power = false;
+  sys.opt_clockrate = true;
+  sys.opt_area = false;
+  sys.interconnect_projection_type = 1;
+  sys.idle_core_power = 0;
+  int i, j;
+  for (i = 0; i <= 63; i++) {
+    sys.scaling_coefficients[i] = 1;
+    sys.core[i].clock_rate = 1;
+    sys.core[i].opt_local = true;
+    sys.core[i].x86 = false;
+    sys.core[i].machine_bits = 1;
+    sys.core[i].virtual_address_width = 1;
+    sys.core[i].physical_address_width = 1;
+    sys.core[i].opcode_width = 1;
+    sys.core[i].micro_opcode_width = 1;
+    // strcpy(sys.core[i].machine_type,"default");
+    sys.core[i].internal_datapath_width = 1;
+    sys.core[i].number_hardware_threads = 1;
+    sys.core[i].fetch_width = 1;
+    sys.core[i].number_instruction_fetch_ports = 1;
+    sys.core[i].decode_width = 1;
+    sys.core[i].issue_width = 1;
+    sys.core[i].peak_issue_width = 1;
+    sys.core[i].commit_width = 1;
+    for (j = 0; j < 20; j++) sys.core[i].pipelines_per_core[j] = 1;
+    for (j = 0; j < 20; j++) sys.core[i].pipeline_depth[j] = 1;
+    strcpy(sys.core[i].FPU, "default");
+    strcpy(sys.core[i].divider_multiplier, "default");
+    sys.core[i].ALU_per_core = 1;
+    sys.core[i].FPU_per_core = 1.0;
+    sys.core[i].MUL_per_core = 1;
+    sys.core[i].instruction_buffer_size = 1;
+    sys.core[i].decoded_stream_buffer_size = 1;
+    // strcpy(sys.core[i].instruction_window_scheme,"default");
+    sys.core[i].instruction_window_size = 1;
+    sys.core[i].ROB_size = 1;
+    sys.core[i].archi_Regs_IRF_size = 1;
+    sys.core[i].archi_Regs_FRF_size = 1;
+    sys.core[i].phy_Regs_IRF_size = 1;
+    sys.core[i].phy_Regs_FRF_size = 1;
+    // strcpy(sys.core[i].rename_scheme,"default");
+    sys.core[i].register_windows_size = 1;
+    strcpy(sys.core[i].LSU_order, "default");
+    sys.core[i].store_buffer_size = 1;
+    sys.core[i].load_buffer_size = 1;
+    sys.core[i].memory_ports = 1;
+    strcpy(sys.core[i].Dcache_dual_pump, "default");
+    sys.core[i].RAS_size = 1;
+    // all stats at the level of system.core(0-n)
+    sys.core[i].total_instructions = 1;
+    sys.core[i].int_instructions = 1;
+    sys.core[i].fp_instructions = 1;
+    sys.core[i].branch_instructions = 1;
+    sys.core[i].branch_mispredictions = 1;
+    sys.core[i].committed_instructions = 1;
+    sys.core[i].load_instructions = 1;
+    sys.core[i].store_instructions = 1;
+    sys.core[i].total_cycles = 1;
+    sys.core[i].idle_cycles = 1;
+    sys.core[i].busy_cycles = 1;
+    sys.core[i].instruction_buffer_reads = 1;
+    sys.core[i].instruction_buffer_write = 1;
+    sys.core[i].ROB_reads = 1;
+    sys.core[i].ROB_writes = 1;
+    sys.core[i].rename_accesses = 1;
+    sys.core[i].inst_window_reads = 1;
+    sys.core[i].inst_window_writes = 1;
+    sys.core[i].inst_window_wakeup_accesses = 1;
+    sys.core[i].inst_window_selections = 1;
+    sys.core[i].archi_int_regfile_reads = 1;
+    sys.core[i].archi_float_regfile_reads = 1;
+    sys.core[i].phy_int_regfile_reads = 1;
+    sys.core[i].phy_float_regfile_reads = 1;
+    sys.core[i].windowed_reg_accesses = 1;
+    sys.core[i].windowed_reg_transports = 1;
+    sys.core[i].function_calls = 1;
+    sys.core[i].ialu_accesses = 1;
+    sys.core[i].fpu_accesses = 1;
+    sys.core[i].mul_accesses = 1;
+    sys.core[i].cdb_alu_accesses = 1;
+    sys.core[i].cdb_mul_accesses = 1;
+    sys.core[i].cdb_fpu_accesses = 1;
+    sys.core[i].load_buffer_reads = 1;
+    sys.core[i].load_buffer_writes = 1;
+    sys.core[i].load_buffer_cams = 1;
+    sys.core[i].store_buffer_reads = 1;
+    sys.core[i].store_buffer_writes = 1;
+    sys.core[i].store_buffer_cams = 1;
+    sys.core[i].store_buffer_forwards = 1;
+    sys.core[i].main_memory_access = 1;
+    sys.core[i].main_memory_read = 1;
+    sys.core[i].main_memory_write = 1;
+    sys.core[i].IFU_duty_cycle = 1;
+    sys.core[i].BR_duty_cycle = 1;
+    sys.core[i].LSU_duty_cycle = 1;
+    sys.core[i].MemManU_I_duty_cycle = 1;
+    sys.core[i].MemManU_D_duty_cycle = 1;
+    sys.core[i].ALU_duty_cycle = 1;
+    sys.core[i].MUL_duty_cycle = 1;
+    sys.core[i].FPU_duty_cycle = 1;
+    sys.core[i].ALU_cdb_duty_cycle = 1;
+    sys.core[i].MUL_cdb_duty_cycle = 1;
+    sys.core[i].FPU_cdb_duty_cycle = 1;
+    // system.core?.predictor
+    sys.core[i].predictor.prediction_width = 1;
+    strcpy(sys.core[i].predictor.prediction_scheme, "default");
+    sys.core[i].predictor.predictor_size = 1;
+    sys.core[i].predictor.predictor_entries = 1;
+    sys.core[i].predictor.local_predictor_entries = 1;
+    for (j = 0; j < 20; j++) sys.core[i].predictor.local_predictor_size[j] = 1;
+    sys.core[i].predictor.global_predictor_entries = 1;
+    sys.core[i].predictor.global_predictor_bits = 1;
+    sys.core[i].predictor.chooser_predictor_entries = 1;
+    sys.core[i].predictor.chooser_predictor_bits = 1;
+    sys.core[i].predictor.predictor_accesses = 1;
+    // system.core?.itlb
+    sys.core[i].itlb.number_entries = 1;
+    sys.core[i].itlb.total_hits = 1;
+    sys.core[i].itlb.total_accesses = 1;
+    sys.core[i].itlb.total_misses = 1;
+    // system.core?.icache
+    for (j = 0; j < 20; j++) sys.core[i].icache.icache_config[j] = 1;
+    // strcpy(sys.core[i].icache.buffer_sizes,"default");
+    sys.core[i].icache.total_accesses = 1;
+    sys.core[i].icache.read_accesses = 1;
+    sys.core[i].icache.read_misses = 1;
+    sys.core[i].icache.replacements = 1;
+    sys.core[i].icache.read_hits = 1;
+    sys.core[i].icache.total_hits = 1;
+    sys.core[i].icache.total_misses = 1;
+    sys.core[i].icache.miss_buffer_access = 1;
+    sys.core[i].icache.fill_buffer_accesses = 1;
+    sys.core[i].icache.prefetch_buffer_accesses = 1;
+    sys.core[i].icache.prefetch_buffer_writes = 1;
+    sys.core[i].icache.prefetch_buffer_reads = 1;
+    sys.core[i].icache.prefetch_buffer_hits = 1;
+    // system.core?.dtlb
+    sys.core[i].dtlb.number_entries = 1;
+    sys.core[i].dtlb.total_accesses = 1;
+    sys.core[i].dtlb.read_accesses = 1;
+    sys.core[i].dtlb.write_accesses = 1;
+    sys.core[i].dtlb.write_hits = 1;
+    sys.core[i].dtlb.read_hits = 1;
+    sys.core[i].dtlb.read_misses = 1;
+    sys.core[i].dtlb.write_misses = 1;
+    sys.core[i].dtlb.total_hits = 1;
+    sys.core[i].dtlb.total_misses = 1;
+    // system.core?.dcache
+    for (j = 0; j < 20; j++) sys.core[i].dcache.dcache_config[j] = 1;
+    // strcpy(sys.core[i].dcache.buffer_sizes,"default");
+    sys.core[i].dcache.total_accesses = 1;
+    sys.core[i].dcache.read_accesses = 1;
+    sys.core[i].dcache.write_accesses = 1;
+    sys.core[i].dcache.total_hits = 1;
+    sys.core[i].dcache.total_misses = 1;
+    sys.core[i].dcache.read_hits = 1;
+    sys.core[i].dcache.write_hits = 1;
+    sys.core[i].dcache.read_misses = 1;
+    sys.core[i].dcache.write_misses = 1;
+    sys.core[i].dcache.replacements = 1;
+    sys.core[i].dcache.write_backs = 1;
+    sys.core[i].dcache.miss_buffer_access = 1;
+    sys.core[i].dcache.fill_buffer_accesses = 1;
+    sys.core[i].dcache.prefetch_buffer_accesses = 1;
+    sys.core[i].dcache.prefetch_buffer_writes = 1;
+    sys.core[i].dcache.prefetch_buffer_reads = 1;
+    sys.core[i].dcache.prefetch_buffer_hits = 1;
+    sys.core[i].dcache.wbb_writes = 1;
+    sys.core[i].dcache.wbb_reads = 1;
+    // system.core?.BTB
+    for (j = 0; j < 20; j++) sys.core[i].BTB.BTB_config[j] = 1;
+    sys.core[i].BTB.total_accesses = 1;
+    sys.core[i].BTB.read_accesses = 1;
+    sys.core[i].BTB.write_accesses = 1;
+    sys.core[i].BTB.total_hits = 1;
+    sys.core[i].BTB.total_misses = 1;
+    sys.core[i].BTB.read_hits = 1;
+    sys.core[i].BTB.write_hits = 1;
+    sys.core[i].BTB.read_misses = 1;
+    sys.core[i].BTB.write_misses = 1;
+    sys.core[i].BTB.replacements = 1;
+  }
 
-	//system_L1directory
-	for (i=0; i<=63; i++)
-	{
-		for (j=0; j<20; j++) sys.L1Directory[i].Dir_config[j]=1;
-		for (j=0; j<20; j++) sys.L1Directory[i].buffer_sizes[j]=1;
-		sys.L1Directory[i].clockrate=1;
-		sys.L1Directory[i].ports[20]=1;
-		sys.L1Directory[i].device_type=1;
-		strcpy(sys.L1Directory[i].threeD_stack,"default");
-		sys.L1Directory[i].total_accesses=1;
-		sys.L1Directory[i].read_accesses=1;
-		sys.L1Directory[i].write_accesses=1;
-		sys.L1Directory[i].duty_cycle =1;
-	}
-	//system_L2directory
-	for (i=0; i<=63; i++)
-	{
-		for (j=0; j<20; j++) sys.L2Directory[i].Dir_config[j]=1;
-		for (j=0; j<20; j++) sys.L2Directory[i].buffer_sizes[j]=1;
-		sys.L2Directory[i].clockrate=1;
-		sys.L2Directory[i].ports[20]=1;
-		sys.L2Directory[i].device_type=1;
-		strcpy(sys.L2Directory[i].threeD_stack,"default");
-		sys.L2Directory[i].total_accesses=1;
-		sys.L2Directory[i].read_accesses=1;
-		sys.L2Directory[i].write_accesses=1;
-		sys.L2Directory[i].duty_cycle =1;
-	}
-	for (i=0; i<=63; i++)
-	{
-		//system_L2
-		for (j=0; j<20; j++) sys.L2[i].L2_config[j]=1;
-		sys.L2[i].clockrate=1;
-		for (j=0; j<20; j++) sys.L2[i].ports[j]=1;
-		sys.L2[i].device_type=1;
-		strcpy(sys.L2[i].threeD_stack,"default");
-		for (j=0; j<20; j++) sys.L2[i].buffer_sizes[j]=1;
-		sys.L2[i].total_accesses=1;
-		sys.L2[i].read_accesses=1;
-		sys.L2[i].write_accesses=1;
-		sys.L2[i].total_hits=1;
-		sys.L2[i].total_misses=1;
-		sys.L2[i].read_hits=1;
-		sys.L2[i].write_hits=1;
-		sys.L2[i].read_misses=1;
-		sys.L2[i].write_misses=1;
-		sys.L2[i].replacements=1;
-		sys.L2[i].write_backs=1;
-		sys.L2[i].miss_buffer_accesses=1;
-		sys.L2[i].fill_buffer_accesses=1;
-		sys.L2[i].prefetch_buffer_accesses=1;
-		sys.L2[i].prefetch_buffer_writes=1;
-		sys.L2[i].prefetch_buffer_reads=1;
-		sys.L2[i].prefetch_buffer_hits=1;
-		sys.L2[i].wbb_writes=1;
-		sys.L2[i].wbb_reads=1;
-		sys.L2[i].duty_cycle =1;
-		sys.L2[i].merged_dir=false;
-		sys.L2[i].homenode_read_accesses =1;
-		sys.L2[i].homenode_write_accesses=1;
-		sys.L2[i].homenode_read_hits=1;
-		sys.L2[i].homenode_write_hits=1;
-		sys.L2[i].homenode_read_misses=1;
-		sys.L2[i].homenode_write_misses=1;
-		sys.L2[i].dir_duty_cycle=1;
-	}
-	for (i=0; i<=63; i++)
-	{
-		//system_L3
-		for (j=0; j<20; j++) sys.L3[i].L3_config[j]=1;
-		sys.L3[i].clockrate=1;
-		for (j=0; j<20; j++) sys.L3[i].ports[j]=1;
-		sys.L3[i].device_type=1;
-		strcpy(sys.L3[i].threeD_stack,"default");
-		for (j=0; j<20; j++) sys.L3[i].buffer_sizes[j]=1;
-		sys.L3[i].total_accesses=1;
-		sys.L3[i].read_accesses=1;
-		sys.L3[i].write_accesses=1;
-		sys.L3[i].total_hits=1;
-		sys.L3[i].total_misses=1;
-		sys.L3[i].read_hits=1;
-		sys.L3[i].write_hits=1;
-		sys.L3[i].read_misses=1;
-		sys.L3[i].write_misses=1;
-		sys.L3[i].replacements=1;
-		sys.L3[i].write_backs=1;
-		sys.L3[i].miss_buffer_accesses=1;
-		sys.L3[i].fill_buffer_accesses=1;
-		sys.L3[i].prefetch_buffer_accesses=1;
-		sys.L3[i].prefetch_buffer_writes=1;
-		sys.L3[i].prefetch_buffer_reads=1;
-		sys.L3[i].prefetch_buffer_hits=1;
-		sys.L3[i].wbb_writes=1;
-		sys.L3[i].wbb_reads=1;
-		sys.L3[i].duty_cycle =1;
-		sys.L3[i].merged_dir=false;
-		sys.L3[i].homenode_read_accesses =1;
-		sys.L3[i].homenode_write_accesses=1;
-		sys.L3[i].homenode_read_hits=1;
-		sys.L3[i].homenode_write_hits=1;
-		sys.L3[i].homenode_read_misses=1;
-		sys.L3[i].homenode_write_misses=1;
-		sys.L3[i].dir_duty_cycle=1;
-	}
-	//system_NoC
-	for (i=0; i<=63; i++)
-	{
-		sys.NoC[i].clockrate=1;
-		sys.NoC[i].type=true;
-		sys.NoC[i].chip_coverage=1;
-		sys.NoC[i].has_global_link = true;
-		strcpy(sys.NoC[i].topology,"default");
-		sys.NoC[i].horizontal_nodes=1;
-		sys.NoC[i].vertical_nodes=1;
-		sys.NoC[i].input_ports=1;
-		sys.NoC[i].output_ports=1;
-		sys.NoC[i].virtual_channel_per_port=1;
-		sys.NoC[i].flit_bits=1;
-		sys.NoC[i].input_buffer_entries_per_vc=1;
-		sys.NoC[i].total_accesses=1;
-		sys.NoC[i].duty_cycle=1;
-		sys.NoC[i].route_over_perc = 0.5;
-		for (j=0; j<20; j++) sys.NoC[i].ports_of_input_buffer[j]=1;
-		sys.NoC[i].number_of_crossbars=1;
-		strcpy(sys.NoC[i].crossbar_type,"default");
-		strcpy(sys.NoC[i].crosspoint_type,"default");
-		//system.NoC?.xbar0;
-		sys.NoC[i].xbar0.number_of_inputs_of_crossbars=1;
-		sys.NoC[i].xbar0.number_of_outputs_of_crossbars=1;
-		sys.NoC[i].xbar0.flit_bits=1;
-		sys.NoC[i].xbar0.input_buffer_entries_per_port=1;
-		sys.NoC[i].xbar0.ports_of_input_buffer[20]=1;
-		sys.NoC[i].xbar0.crossbar_accesses=1;
-	}
-	//system_mem
-	sys.mem.mem_tech_node=1;
-	sys.mem.device_clock=1;
-	sys.mem.capacity_per_channel=1;
-	sys.mem.number_ranks=1;
-	sys.mem.peak_transfer_rate =1;
-	sys.mem.num_banks_of_DRAM_chip=1;
-	sys.mem.Block_width_of_DRAM_chip=1;
-	sys.mem.output_width_of_DRAM_chip=1;
-	sys.mem.page_size_of_DRAM_chip=1;
-	sys.mem.burstlength_of_DRAM_chip=1;
-	sys.mem.internal_prefetch_of_DRAM_chip=1;
-	sys.mem.memory_accesses=1;
-	sys.mem.memory_reads=1;
-	sys.mem.memory_writes=1;
+  // system_L1directory
+  for (i = 0; i <= 63; i++) {
+    for (j = 0; j < 20; j++) sys.L1Directory[i].Dir_config[j] = 1;
+    for (j = 0; j < 20; j++) sys.L1Directory[i].buffer_sizes[j] = 1;
+    sys.L1Directory[i].clockrate = 1;
+    sys.L1Directory[i].ports[20] = 1;
+    sys.L1Directory[i].device_type = 1;
+    strcpy(sys.L1Directory[i].threeD_stack, "default");
+    sys.L1Directory[i].total_accesses = 1;
+    sys.L1Directory[i].read_accesses = 1;
+    sys.L1Directory[i].write_accesses = 1;
+    sys.L1Directory[i].duty_cycle = 1;
+  }
+  // system_L2directory
+  for (i = 0; i <= 63; i++) {
+    for (j = 0; j < 20; j++) sys.L2Directory[i].Dir_config[j] = 1;
+    for (j = 0; j < 20; j++) sys.L2Directory[i].buffer_sizes[j] = 1;
+    sys.L2Directory[i].clockrate = 1;
+    sys.L2Directory[i].ports[20] = 1;
+    sys.L2Directory[i].device_type = 1;
+    strcpy(sys.L2Directory[i].threeD_stack, "default");
+    sys.L2Directory[i].total_accesses = 1;
+    sys.L2Directory[i].read_accesses = 1;
+    sys.L2Directory[i].write_accesses = 1;
+    sys.L2Directory[i].duty_cycle = 1;
+  }
+  for (i = 0; i <= 63; i++) {
+    // system_L2
+    for (j = 0; j < 20; j++) sys.L2[i].L2_config[j] = 1;
+    sys.L2[i].clockrate = 1;
+    for (j = 0; j < 20; j++) sys.L2[i].ports[j] = 1;
+    sys.L2[i].device_type = 1;
+    strcpy(sys.L2[i].threeD_stack, "default");
+    for (j = 0; j < 20; j++) sys.L2[i].buffer_sizes[j] = 1;
+    sys.L2[i].total_accesses = 1;
+    sys.L2[i].read_accesses = 1;
+    sys.L2[i].write_accesses = 1;
+    sys.L2[i].total_hits = 1;
+    sys.L2[i].total_misses = 1;
+    sys.L2[i].read_hits = 1;
+    sys.L2[i].write_hits = 1;
+    sys.L2[i].read_misses = 1;
+    sys.L2[i].write_misses = 1;
+    sys.L2[i].replacements = 1;
+    sys.L2[i].write_backs = 1;
+    sys.L2[i].miss_buffer_accesses = 1;
+    sys.L2[i].fill_buffer_accesses = 1;
+    sys.L2[i].prefetch_buffer_accesses = 1;
+    sys.L2[i].prefetch_buffer_writes = 1;
+    sys.L2[i].prefetch_buffer_reads = 1;
+    sys.L2[i].prefetch_buffer_hits = 1;
+    sys.L2[i].wbb_writes = 1;
+    sys.L2[i].wbb_reads = 1;
+    sys.L2[i].duty_cycle = 1;
+    sys.L2[i].merged_dir = false;
+    sys.L2[i].homenode_read_accesses = 1;
+    sys.L2[i].homenode_write_accesses = 1;
+    sys.L2[i].homenode_read_hits = 1;
+    sys.L2[i].homenode_write_hits = 1;
+    sys.L2[i].homenode_read_misses = 1;
+    sys.L2[i].homenode_write_misses = 1;
+    sys.L2[i].dir_duty_cycle = 1;
+  }
+  for (i = 0; i <= 63; i++) {
+    // system_L3
+    for (j = 0; j < 20; j++) sys.L3[i].L3_config[j] = 1;
+    sys.L3[i].clockrate = 1;
+    for (j = 0; j < 20; j++) sys.L3[i].ports[j] = 1;
+    sys.L3[i].device_type = 1;
+    strcpy(sys.L3[i].threeD_stack, "default");
+    for (j = 0; j < 20; j++) sys.L3[i].buffer_sizes[j] = 1;
+    sys.L3[i].total_accesses = 1;
+    sys.L3[i].read_accesses = 1;
+    sys.L3[i].write_accesses = 1;
+    sys.L3[i].total_hits = 1;
+    sys.L3[i].total_misses = 1;
+    sys.L3[i].read_hits = 1;
+    sys.L3[i].write_hits = 1;
+    sys.L3[i].read_misses = 1;
+    sys.L3[i].write_misses = 1;
+    sys.L3[i].replacements = 1;
+    sys.L3[i].write_backs = 1;
+    sys.L3[i].miss_buffer_accesses = 1;
+    sys.L3[i].fill_buffer_accesses = 1;
+    sys.L3[i].prefetch_buffer_accesses = 1;
+    sys.L3[i].prefetch_buffer_writes = 1;
+    sys.L3[i].prefetch_buffer_reads = 1;
+    sys.L3[i].prefetch_buffer_hits = 1;
+    sys.L3[i].wbb_writes = 1;
+    sys.L3[i].wbb_reads = 1;
+    sys.L3[i].duty_cycle = 1;
+    sys.L3[i].merged_dir = false;
+    sys.L3[i].homenode_read_accesses = 1;
+    sys.L3[i].homenode_write_accesses = 1;
+    sys.L3[i].homenode_read_hits = 1;
+    sys.L3[i].homenode_write_hits = 1;
+    sys.L3[i].homenode_read_misses = 1;
+    sys.L3[i].homenode_write_misses = 1;
+    sys.L3[i].dir_duty_cycle = 1;
+  }
+  // system_NoC
+  for (i = 0; i <= 63; i++) {
+    sys.NoC[i].clockrate = 1;
+    sys.NoC[i].type = true;
+    sys.NoC[i].chip_coverage = 1;
+    sys.NoC[i].has_global_link = true;
+    strcpy(sys.NoC[i].topology, "default");
+    sys.NoC[i].horizontal_nodes = 1;
+    sys.NoC[i].vertical_nodes = 1;
+    sys.NoC[i].input_ports = 1;
+    sys.NoC[i].output_ports = 1;
+    sys.NoC[i].virtual_channel_per_port = 1;
+    sys.NoC[i].flit_bits = 1;
+    sys.NoC[i].input_buffer_entries_per_vc = 1;
+    sys.NoC[i].total_accesses = 1;
+    sys.NoC[i].duty_cycle = 1;
+    sys.NoC[i].route_over_perc = 0.5;
+    for (j = 0; j < 20; j++) sys.NoC[i].ports_of_input_buffer[j] = 1;
+    sys.NoC[i].number_of_crossbars = 1;
+    strcpy(sys.NoC[i].crossbar_type, "default");
+    strcpy(sys.NoC[i].crosspoint_type, "default");
+    // system.NoC?.xbar0;
+    sys.NoC[i].xbar0.number_of_inputs_of_crossbars = 1;
+    sys.NoC[i].xbar0.number_of_outputs_of_crossbars = 1;
+    sys.NoC[i].xbar0.flit_bits = 1;
+    sys.NoC[i].xbar0.input_buffer_entries_per_port = 1;
+    sys.NoC[i].xbar0.ports_of_input_buffer[20] = 1;
+    sys.NoC[i].xbar0.crossbar_accesses = 1;
+  }
+  // system_mem
+  sys.mem.mem_tech_node = 1;
+  sys.mem.device_clock = 1;
+  sys.mem.capacity_per_channel = 1;
+  sys.mem.number_ranks = 1;
+  sys.mem.peak_transfer_rate = 1;
+  sys.mem.num_banks_of_DRAM_chip = 1;
+  sys.mem.Block_width_of_DRAM_chip = 1;
+  sys.mem.output_width_of_DRAM_chip = 1;
+  sys.mem.page_size_of_DRAM_chip = 1;
+  sys.mem.burstlength_of_DRAM_chip = 1;
+  sys.mem.internal_prefetch_of_DRAM_chip = 1;
+  sys.mem.memory_accesses = 1;
+  sys.mem.memory_reads = 1;
+  sys.mem.memory_writes = 1;
 
-	//system_mc
-	sys.mc.mc_clock =1;
-	sys.mc.number_mcs=1;
-	sys.mc.peak_transfer_rate =1;
-	sys.mc.memory_channels_per_mc=1;
-	sys.mc.number_ranks=1;
-	sys.mc.req_window_size_per_channel=1;
-	sys.mc.IO_buffer_size_per_channel=1;
-	sys.mc.databus_width=1;
-	sys.mc.addressbus_width=1;
-	sys.mc.memory_accesses=1;
-	sys.mc.memory_reads=1;
-	sys.mc.memory_writes=1;
-	sys.mc.LVDS=true;
-	sys.mc.type=1;
+  // system_mc
+  sys.mc.mc_clock = 1;
+  sys.mc.number_mcs = 1;
+  sys.mc.peak_transfer_rate = 1;
+  sys.mc.memory_channels_per_mc = 1;
+  sys.mc.number_ranks = 1;
+  sys.mc.req_window_size_per_channel = 1;
+  sys.mc.IO_buffer_size_per_channel = 1;
+  sys.mc.databus_width = 1;
+  sys.mc.addressbus_width = 1;
+  sys.mc.memory_accesses = 1;
+  sys.mc.memory_reads = 1;
+  sys.mc.memory_writes = 1;
+  sys.mc.LVDS = true;
+  sys.mc.type = 1;
 
-	//system_niu
-	sys.niu.clockrate =1;
-	sys.niu.number_units=1;
-	sys.niu.type = 1;
-	sys.niu.duty_cycle =1;
-	sys.niu.total_load_perc=1;
-	//system_pcie
-	sys.pcie.clockrate =1;
-	sys.pcie.number_units=1;
-	sys.pcie.num_channels=1;
-	sys.pcie.type = 1;
-	sys.pcie.withPHY = false;
-	sys.pcie.duty_cycle =1;
-	sys.pcie.total_load_perc=1;
-	//system_flash_controller
-	sys.flashc.mc_clock =1;
-	sys.flashc.number_mcs=1;
-	sys.flashc.peak_transfer_rate =1;
-	sys.flashc.memory_channels_per_mc=1;
-	sys.flashc.number_ranks=1;
-	sys.flashc.req_window_size_per_channel=1;
-	sys.flashc.IO_buffer_size_per_channel=1;
-	sys.flashc.databus_width=1;
-	sys.flashc.addressbus_width=1;
-	sys.flashc.memory_accesses=1;
-	sys.flashc.memory_reads=1;
-	sys.flashc.memory_writes=1;
-	sys.flashc.LVDS=true;
-	sys.flashc.withPHY = false;
-	sys.flashc.type =1;
-	sys.flashc.duty_cycle =1;
-	sys.flashc.total_load_perc=1;
+  // system_niu
+  sys.niu.clockrate = 1;
+  sys.niu.number_units = 1;
+  sys.niu.type = 1;
+  sys.niu.duty_cycle = 1;
+  sys.niu.total_load_perc = 1;
+  // system_pcie
+  sys.pcie.clockrate = 1;
+  sys.pcie.number_units = 1;
+  sys.pcie.num_channels = 1;
+  sys.pcie.type = 1;
+  sys.pcie.withPHY = false;
+  sys.pcie.duty_cycle = 1;
+  sys.pcie.total_load_perc = 1;
+  // system_flash_controller
+  sys.flashc.mc_clock = 1;
+  sys.flashc.number_mcs = 1;
+  sys.flashc.peak_transfer_rate = 1;
+  sys.flashc.memory_channels_per_mc = 1;
+  sys.flashc.number_ranks = 1;
+  sys.flashc.req_window_size_per_channel = 1;
+  sys.flashc.IO_buffer_size_per_channel = 1;
+  sys.flashc.databus_width = 1;
+  sys.flashc.addressbus_width = 1;
+  sys.flashc.memory_accesses = 1;
+  sys.flashc.memory_reads = 1;
+  sys.flashc.memory_writes = 1;
+  sys.flashc.LVDS = true;
+  sys.flashc.withPHY = false;
+  sys.flashc.type = 1;
+  sys.flashc.duty_cycle = 1;
+  sys.flashc.total_load_perc = 1;
 }

--- a/src/gpuwattch/XML_Parse.cc
+++ b/src/gpuwattch/XML_Parse.cc
@@ -535,7 +535,7 @@ void ParseXML::parse(char* filepath) {
   //	if (sys.Private_L2 && sys.number_of_cores!=sys.number_of_L2s)
   //	{
   //		cout<<"Private L2: Number of L2s must equal to Number of
-  //Cores"<<endl;
+  // Cores"<<endl;
   //		exit(0);
   //	}
 
@@ -563,7 +563,7 @@ void ParseXML::parse(char* filepath) {
   unsigned int OrderofComponents_3layer = 0;
   if (NumofCom_3 > OrderofComponents_3layer) {
     //___________________________get all
-    //system.core0-n________________________________________________
+    // system.core0-n________________________________________________
     if (sys.homogeneous_cores == 1)
       OrderofComponents_3layer = 0;
     else
@@ -2044,9 +2044,8 @@ void ParseXML::parse(char* filepath) {
             if (strcmp(xNode4.getAttribute("name"), "sharedmemory") ==
                 0) {  // find system.core0.sharedmemory
               itmp = xNode4.nChildNode("param");
-              for (k = 0; k < itmp;
-                   k++) {  // get all items of param in
-                           // system.core0.sharedmemory--sharedmemory
+              for (k = 0; k < itmp; k++) {  // get all items of param in
+                // system.core0.sharedmemory--sharedmemory
                 if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
                            "sharedmemory_config") == 0) {
                   strtmp.assign(
@@ -2483,7 +2482,7 @@ void ParseXML::parse(char* filepath) {
     }
 
     //__________________________________________Get
-    //system.L1Directory0-n____________________________________________
+    // system.L1Directory0-n____________________________________________
     int w, tmpOrderofComponents_3layer;
     w = OrderofComponents_3layer + 1;
     tmpOrderofComponents_3layer = OrderofComponents_3layer;
@@ -2649,7 +2648,7 @@ void ParseXML::parse(char* filepath) {
     }
 
     //__________________________________________Get
-    //system.L2Directory0-n____________________________________________
+    // system.L2Directory0-n____________________________________________
     w = OrderofComponents_3layer + 1;
     tmpOrderofComponents_3layer = OrderofComponents_3layer;
     if (sys.homogeneous_L2Directories == 1)
@@ -2814,7 +2813,7 @@ void ParseXML::parse(char* filepath) {
     }
 
     //__________________________________________Get
-    //system.L2[0..n]____________________________________________
+    // system.L2[0..n]____________________________________________
     w = OrderofComponents_3layer + 1;
     tmpOrderofComponents_3layer = OrderofComponents_3layer;
     if (sys.homogeneous_L2s == 1)
@@ -3102,7 +3101,7 @@ void ParseXML::parse(char* filepath) {
       }
     }
     //__________________________________________Get
-    //system.L3[0..n]____________________________________________
+    // system.L3[0..n]____________________________________________
     w = OrderofComponents_3layer + 1;
     tmpOrderofComponents_3layer = OrderofComponents_3layer;
     if (sys.homogeneous_L3s == 1)
@@ -3390,7 +3389,7 @@ void ParseXML::parse(char* filepath) {
       }
     }
     //__________________________________________Get
-    //system.NoC[0..n]____________________________________________
+    // system.NoC[0..n]____________________________________________
     w = OrderofComponents_3layer + 1;
     tmpOrderofComponents_3layer = OrderofComponents_3layer;
     if (sys.homogeneous_NoCs == 1)
@@ -3641,7 +3640,7 @@ void ParseXML::parse(char* filepath) {
       }
     }
     //__________________________________________Get
-    //system.mem____________________________________________
+    // system.mem____________________________________________
     if (OrderofComponents_3layer > 0)
       OrderofComponents_3layer = OrderofComponents_3layer + 1;
     xNode3 = xNode2.getChildNode("component", OrderofComponents_3layer);
@@ -3757,7 +3756,7 @@ void ParseXML::parse(char* filepath) {
       exit(0);
     }
     //__________________________________________Get
-    //system.mc____________________________________________
+    // system.mc____________________________________________
     if (OrderofComponents_3layer > 0)
       OrderofComponents_3layer = OrderofComponents_3layer + 1;
     xNode3 = xNode2.getChildNode("component", OrderofComponents_3layer);
@@ -3947,7 +3946,7 @@ void ParseXML::parse(char* filepath) {
       exit(0);
     }
     //__________________________________________Get
-    //system.niu____________________________________________
+    // system.niu____________________________________________
     if (OrderofComponents_3layer > 0)
       OrderofComponents_3layer = OrderofComponents_3layer + 1;
     xNode3 = xNode2.getChildNode("component", OrderofComponents_3layer);
@@ -4005,7 +4004,7 @@ void ParseXML::parse(char* filepath) {
     }
 
     //__________________________________________Get
-    //system.pcie____________________________________________
+    // system.pcie____________________________________________
     if (OrderofComponents_3layer > 0)
       OrderofComponents_3layer = OrderofComponents_3layer + 1;
     xNode3 = xNode2.getChildNode("component", OrderofComponents_3layer);
@@ -4074,7 +4073,7 @@ void ParseXML::parse(char* filepath) {
       exit(0);
     }
     //__________________________________________Get
-    //system.flashcontroller____________________________________________
+    // system.flashcontroller____________________________________________
     if (OrderofComponents_3layer > 0)
       OrderofComponents_3layer = OrderofComponents_3layer + 1;
     xNode3 = xNode2.getChildNode("component", OrderofComponents_3layer);

--- a/src/gpuwattch/XML_Parse.cc
+++ b/src/gpuwattch/XML_Parse.cc
@@ -29,4558 +29,2102 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:
-**
+*      Modified by:												   *
 *      Jingwen Leng, Univeristy of Texas, Austin                   *
 *      Syed Gilani, University of Wisconsin–Madison                *
 *      Tayler Hetherington, University of British Columbia         *
 *      Ahmed ElTantawy, University of British Columbia             *
 ********************************************************************/
 
-#include "XML_Parse.h"
 #include <stdio.h>
-#include <string>
 #include "xmlParser.h"
+#include <string>
+#include "XML_Parse.h"
 
 using namespace std;
 
-const char* perf_count_label[] = {
-    "TOT_INST,",    "FP_INT,",  "IC_H,",     "IC_M,",        "DC_RH,",
-    "DC_RM,",       "DC_WH,",   "DC_WM,",    "TC_H,",        "TC_M,",
-    "CC_H,",        "CC_M,",    "SHRD_ACC,", "REG_RD,",      "REG_WR,",
-    "NON_REG_OPs,", "SP_ACC,",  "SFU_ACC,",  "FPU_ACC,",     "MEM_RD,",
-    "MEM_WR,",      "MEM_PRE,", "L2_RH,",    "L2_RM,",       "L2_WH,",
-    "L2_WM,",       "NOC_A,",   "PIPE_A,",   "IDLE_CORE_N,", "CONST_DYNAMICN"};
+const char * perf_count_label[] = {"TOT_INST,", "FP_INT,", "IC_H,", "IC_M,", "DC_RH,", "DC_RM,", "DC_WH,", "DC_WM,",
+                                "TC_H,", "TC_M,", "CC_H,", "CC_M,", "SHRD_ACC,", "REG_RD,", "REG_WR,", "NON_REG_OPs,",
+                                "SP_ACC,", "SFU_ACC,", "FPU_ACC,", "MEM_RD,","MEM_WR,", "MEM_PRE,", "L2_RH,", "L2_RM,", "L2_WH,",
+                                "L2_WM,", "NOC_A,", "PIPE_A,", "IDLE_CORE_N,", "CONST_DYNAMICN"};
 
-void ParseXML::parse(char* filepath) {
-  unsigned int i, j, k, m, n;
-  unsigned int NumofCom_4;
-  unsigned int itmp;
-  // Initialize all structures
-  ParseXML::initialize();
-  string strtmp;
-  char chtmp[60];
-  char chtmp1[60];
-  chtmp1[0] = '\0';
-  // this open and parse the XML file:
-  XMLNode xMainNode = XMLNode::openFileHelper(
-      filepath, "component");  // the 'component' in the first layer
-
-  XMLNode xNode2 = xMainNode.getChildNode(
-      "component");  // the 'component' in the second layer
-  // get all params in the second layer
-  itmp = xNode2.nChildNode("param");
-  for (i = 0; i < itmp; i++) {
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "GPU_Architecture") == 0) {
-      sys.GPU_Architecture =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "number_of_cores") == 0) {
-      sys.number_of_cores =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "architecture") == 0) {
-      sys.architecture =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "number_of_L1Directories") == 0) {
-      sys.number_of_L1Directories =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "number_of_L2Directories") == 0) {
-      sys.number_of_L2Directories =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "number_of_L2s") == 0) {
-      sys.number_of_L2s =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "Private_L2") == 0) {
-      sys.Private_L2 =
-          (bool)atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "number_of_L3s") == 0) {
-      sys.number_of_L3s =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "number_of_NoCs") == 0) {
-      sys.number_of_NoCs =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "number_of_dir_levels") == 0) {
-      sys.number_of_dir_levels =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "domain_size") == 0) {
-      sys.domain_size =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "first_level_dir") == 0) {
-      sys.first_level_dir =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "homogeneous_cores") == 0) {
-      sys.homogeneous_cores =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "core_tech_node") == 0) {
-      sys.core_tech_node =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "target_core_clockrate") == 0) {
-      sys.target_core_clockrate =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "target_chip_area") == 0) {
-      sys.target_chip_area =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "temperature") == 0) {
-      sys.temperature =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "number_cache_levels") == 0) {
-      sys.number_cache_levels =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "L1_property") == 0) {
-      sys.L1_property =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "L2_property") == 0) {
-      sys.L2_property =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "homogeneous_L2s") == 0) {
-      sys.homogeneous_L2s =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "homogeneous_L1Directories") == 0) {
-      sys.homogeneous_L1Directories =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "homogeneous_L2Directories") == 0) {
-      sys.homogeneous_L2Directories =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "L3_property") == 0) {
-      sys.L3_property =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "homogeneous_L3s") == 0) {
-      sys.homogeneous_L3s =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "homogeneous_ccs") == 0) {
-      sys.homogeneous_ccs =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "homogeneous_NoCs") == 0) {
-      sys.homogeneous_NoCs =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "Max_area_deviation") == 0) {
-      sys.Max_area_deviation =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "Max_power_deviation") == 0) {
-      sys.Max_power_deviation =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "device_type") == 0) {
-      sys.device_type =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "longer_channel_device") == 0) {
-      sys.longer_channel_device =
-          (bool)atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "opt_dynamic_power") == 0) {
-      sys.opt_dynamic_power =
-          (bool)atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "opt_lakage_power") == 0) {
-      sys.opt_lakage_power =
-          (bool)atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "opt_clockrate") == 0) {
-      sys.opt_clockrate =
-          (bool)atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "opt_area") == 0) {
-      sys.opt_area =
-          (bool)atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "Embedded") == 0) {
-      sys.Embedded =
-          (bool)atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "interconnect_projection_type") == 0) {
-      sys.interconnect_projection_type =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value")) == 0 ? 0
-                                                                           : 1;
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "machine_bits") == 0) {
-      sys.machine_bits =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "virtual_address_width") == 0) {
-      sys.virtual_address_width =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "physical_address_width") == 0) {
-      sys.physical_address_width =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "virtual_memory_page_size") == 0) {
-      sys.virtual_memory_page_size =
-          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "idle_core_power") == 0) {
-      sys.idle_core_power =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "TOT_INST") == 0) {
-      sys.scaling_coefficients[TOT_INST] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "FP_INT") == 0) {
-      sys.scaling_coefficients[FP_INT] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "IC_H") ==
-        0) {
-      sys.scaling_coefficients[IC_H] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "IC_M") ==
-        0) {
-      sys.scaling_coefficients[IC_M] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "DC_RH") ==
-        0) {
-      sys.scaling_coefficients[DC_RH] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "DC_RM") ==
-        0) {
-      sys.scaling_coefficients[DC_RM] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "DC_WH") ==
-        0) {
-      sys.scaling_coefficients[DC_WH] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "DC_WM") ==
-        0) {
-      sys.scaling_coefficients[DC_WM] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "TC_H") ==
-        0) {
-      sys.scaling_coefficients[TC_H] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "TC_M") ==
-        0) {
-      sys.scaling_coefficients[TC_M] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "CC_H") ==
-        0) {
-      sys.scaling_coefficients[CC_H] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "CC_M") ==
-        0) {
-      sys.scaling_coefficients[CC_M] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "SHRD_ACC") == 0) {
-      sys.scaling_coefficients[SHRD_ACC] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "REG_RD") == 0) {
-      sys.scaling_coefficients[REG_RD] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "REG_WR") == 0) {
-      sys.scaling_coefficients[REG_WR] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "NON_REG_OPs") == 0) {
-      sys.scaling_coefficients[NON_REG_OPs] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "SP_ACC") == 0) {
-      sys.scaling_coefficients[SP_ACC] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "SFU_ACC") == 0) {
-      sys.scaling_coefficients[SFU_ACC] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "FPU_ACC") == 0) {
-      sys.scaling_coefficients[FPU_ACC] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "MEM_RD") == 0) {
-      sys.scaling_coefficients[MEM_RD] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "MEM_WR") == 0) {
-      sys.scaling_coefficients[MEM_WR] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "MEM_PRE") == 0) {
-      sys.scaling_coefficients[MEM_PRE] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "L2_RH") ==
-        0) {
-      sys.scaling_coefficients[L2_RH] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "L2_RM") ==
-        0) {
-      sys.scaling_coefficients[L2_RM] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "L2_WH") ==
-        0) {
-      sys.scaling_coefficients[L2_WH] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "L2_WM") ==
-        0) {
-      sys.scaling_coefficients[L2_WM] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "NOC_A") ==
-        0) {
-      sys.scaling_coefficients[NOC_A] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "PIPE_A") == 0) {
-      sys.scaling_coefficients[PIPE_A] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "IDLE_CORE_N") == 0) {
-      sys.scaling_coefficients[IDLE_CORE_N] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
-               "CONST_DYNAMICN") == 0) {
-      sys.scaling_coefficients[CONST_DYNAMICN] =
-          atof(xNode2.getChildNode("param", i).getAttribute("value"));
-      continue;
-    }
-
-    /*
-                    if
-       (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"scaling_coefficients")==0)
-                    {
-                            strtmp.assign(xNode2.getChildNode("param",i).getAttribute("value"));
-                            m=0;
-                            for(n=0; n<strtmp.length(); n++)
-                            {
-                                    if (strtmp[n]!=',')
-                                    {
-                                            sprintf(chtmp,"%c",strtmp[n]);
-                                            strcat(chtmp1,chtmp);
-                                    }
-                                    else{
-                                            sys.scaling_coefficients[m]=atof(chtmp1);
-                                            m++;
-                                            chtmp1[0]='\0';
-                                    }
-                            }
-                            sys.scaling_coefficients[m]=atof(chtmp1);
-                            m++;
-                            chtmp1[0]='\0';
-                            continue;
-                    }
-    */
-  }
-
-  //	if (sys.Private_L2 && sys.number_of_cores!=sys.number_of_L2s)
-  //	{
-  //		cout<<"Private L2: Number of L2s must equal to Number of
-  //Cores"<<endl;
-  //		exit(0);
-  //	}
-
-  itmp = xNode2.nChildNode("stat");
-  for (i = 0; i < itmp; i++) {
-    if (strcmp(xNode2.getChildNode("stat", i).getAttribute("name"),
-               "total_cycles") == 0) {
-      sys.total_cycles =
-          atof(xNode2.getChildNode("stat", i).getAttribute("value"));
-      continue;
-    }
-    if (strcmp(xNode2.getChildNode("stat", i).getAttribute("name"),
-               "num_idle_cores") == 0) {
-      sys.num_idle_cores =
-          atoi(xNode2.getChildNode("stat", i).getAttribute("value"));
-      continue;
-    }
-  }
-
-  // get the number of components within the second layer
-  unsigned int NumofCom_3 = xNode2.nChildNode("component");
-  XMLNode xNode3, xNode4;  // define the third-layer(system.core0) and
-                           // fourth-layer(system.core0.predictor) xnodes
-
-  unsigned int OrderofComponents_3layer = 0;
-  if (NumofCom_3 > OrderofComponents_3layer) {
-    //___________________________get all
-    //system.core0-n________________________________________________
-    if (sys.homogeneous_cores == 1)
-      OrderofComponents_3layer = 0;
-    else
-      OrderofComponents_3layer = sys.number_of_cores - 1;
-    for (i = 0; i <= OrderofComponents_3layer; i++) {
-      xNode3 = xNode2.getChildNode("component", i);
-      if (xNode3.isEmpty() == 1) {
-        printf(
-            "The value of homogeneous_cores or number_of_cores is not "
-            "correct!");
-        exit(0);
-      } else {
-        if (strstr(xNode3.getAttribute("name"), "core") != NULL) {
-          {  // For cpu0-cpui
-            // Get all params with system.core?
-            itmp = xNode3.nChildNode("param");
-            for (k = 0; k < itmp; k++) {
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "clock_rate") == 0) {
-                sys.core[i].clock_rate =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "opt_local") == 0) {
-                sys.core[i].opt_local = (bool)atoi(
-                    xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "x86") == 0) {
-                sys.core[i].x86 = (bool)atoi(
-                    xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "machine_bits") == 0) {
-                sys.core[i].machine_bits =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "virtual_address_width") == 0) {
-                sys.core[i].virtual_address_width =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "physical_address_width") == 0) {
-                sys.core[i].physical_address_width =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "instruction_length") == 0) {
-                sys.core[i].instruction_length =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "opcode_width") == 0) {
-                sys.core[i].opcode_width =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "micro_opcode_width") == 0) {
-                sys.core[i].micro_opcode_width =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "machine_type") == 0) {
-                sys.core[i].machine_type =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "internal_datapath_width") == 0) {
-                sys.core[i].internal_datapath_width =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "number_hardware_threads") == 0) {
-                sys.core[i].number_hardware_threads =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "fetch_width") == 0) {
-                sys.core[i].fetch_width =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "number_instruction_fetch_ports") == 0) {
-                sys.core[i].number_instruction_fetch_ports =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "decode_width") == 0) {
-                sys.core[i].decode_width =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "issue_width") == 0) {
-                sys.core[i].issue_width =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "peak_issue_width") == 0) {
-                sys.core[i].peak_issue_width =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "commit_width") == 0) {
-                sys.core[i].commit_width =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "fp_issue_width") == 0) {
-                sys.core[i].fp_issue_width =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "prediction_width") == 0) {
-                sys.core[i].prediction_width =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "pipelines_per_core") == 0) {
-                strtmp.assign(
-                    xNode3.getChildNode("param", k).getAttribute("value"));
-                m = 0;
-                for (n = 0; n < strtmp.length(); n++) {
-                  if (strtmp[n] != ',') {
-                    sprintf(chtmp, "%c", strtmp[n]);
-                    strcat(chtmp1, chtmp);
-                  } else {
-                    sys.core[i].pipelines_per_core[m] = atoi(chtmp1);
-                    m++;
-                    chtmp1[0] = '\0';
-                  }
-                }
-                sys.core[i].pipelines_per_core[m] = atoi(chtmp1);
-                m++;
-                chtmp1[0] = '\0';
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "pipeline_depth") == 0) {
-                strtmp.assign(
-                    xNode3.getChildNode("param", k).getAttribute("value"));
-                m = 0;
-                for (n = 0; n < strtmp.length(); n++) {
-                  if (strtmp[n] != ',') {
-                    sprintf(chtmp, "%c", strtmp[n]);
-                    strcat(chtmp1, chtmp);
-                  } else {
-                    sys.core[i].pipeline_depth[m] = atoi(chtmp1);
-                    m++;
-                    chtmp1[0] = '\0';
-                  }
-                }
-                sys.core[i].pipeline_depth[m] = atoi(chtmp1);
-                m++;
-                chtmp1[0] = '\0';
-                continue;
-              }
-
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "FPU") == 0) {
-                strcpy(sys.core[i].FPU,
-                       xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "divider_multiplier") == 0) {
-                strcpy(sys.core[i].divider_multiplier,
-                       xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "ALU_per_core") == 0) {
-                sys.core[i].ALU_per_core =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "FPU_per_core") == 0) {
-                sys.core[i].FPU_per_core =
-                    atof(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "MUL_per_core") == 0) {
-                sys.core[i].MUL_per_core =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "instruction_buffer_size") == 0) {
-                sys.core[i].instruction_buffer_size =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "decoded_stream_buffer_size") == 0) {
-                sys.core[i].decoded_stream_buffer_size =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "instruction_window_scheme") == 0) {
-                sys.core[i].instruction_window_scheme =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "instruction_window_size") == 0) {
-                sys.core[i].instruction_window_size =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "fp_instruction_window_size") == 0) {
-                sys.core[i].fp_instruction_window_size =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "ROB_size") == 0) {
-                sys.core[i].ROB_size =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "rf_banks") == 0) {
-                sys.core[i].rf_banks =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "simd_width") == 0) {
-                sys.core[i].simd_width =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "collector_units") == 0) {
-                sys.core[i].collector_units =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "core_clock_ratio") == 0) {
-                sys.core[i].core_clock_ratio =
-                    atof(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "warp_size") == 0) {
-                sys.core[i].warp_size =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "archi_Regs_IRF_size") == 0) {
-                sys.core[i].archi_Regs_IRF_size =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "archi_Regs_FRF_size") == 0) {
-                sys.core[i].archi_Regs_FRF_size =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "phy_Regs_IRF_size") == 0) {
-                sys.core[i].phy_Regs_IRF_size =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "phy_Regs_FRF_size") == 0) {
-                sys.core[i].phy_Regs_FRF_size =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "rename_scheme") == 0) {
-                sys.core[i].rename_scheme =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "register_windows_size") == 0) {
-                sys.core[i].register_windows_size =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "LSU_order") == 0) {
-                strcpy(sys.core[i].LSU_order,
-                       xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "store_buffer_size") == 0) {
-                sys.core[i].store_buffer_size =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "load_buffer_size") == 0) {
-                sys.core[i].load_buffer_size =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "memory_ports") == 0) {
-                sys.core[i].memory_ports =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "Dcache_dual_pump") == 0) {
-                strcpy(sys.core[i].Dcache_dual_pump,
-                       xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "RAS_size") == 0) {
-                sys.core[i].RAS_size =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-            }
-            // Get all stats with system.core?
-            itmp = xNode3.nChildNode("stat");
-            for (k = 0; k < itmp; k++) {
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "total_instructions") == 0) {
-                sys.core[i].total_instructions =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "int_instructions") == 0) {
-                sys.core[i].int_instructions =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "fp_instructions") == 0) {
-                sys.core[i].fp_instructions =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "branch_instructions") == 0) {
-                sys.core[i].branch_instructions =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "branch_mispredictions") == 0) {
-                sys.core[i].branch_mispredictions =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "committed_instructions") == 0) {
-                sys.core[i].committed_instructions =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "committed_int_instructions") == 0) {
-                sys.core[i].committed_int_instructions =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "committed_fp_instructions") == 0) {
-                sys.core[i].committed_fp_instructions =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "load_instructions") == 0) {
-                sys.core[i].load_instructions =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "store_instructions") == 0) {
-                sys.core[i].store_instructions =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "total_cycles") == 0) {
-                sys.core[i].total_cycles =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "idle_cycles") == 0) {
-                sys.core[i].idle_cycles =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "busy_cycles") == 0) {
-                sys.core[i].busy_cycles =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "instruction_buffer_reads") == 0) {
-                sys.core[i].instruction_buffer_reads =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "instruction_buffer_write") == 0) {
-                sys.core[i].instruction_buffer_write =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "ROB_reads") == 0) {
-                sys.core[i].ROB_reads =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "ROB_writes") == 0) {
-                sys.core[i].ROB_writes =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "rename_reads") == 0) {
-                sys.core[i].rename_reads =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "rename_writes") == 0) {
-                sys.core[i].rename_writes =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "fp_rename_reads") == 0) {
-                sys.core[i].fp_rename_reads =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "fp_rename_writes") == 0) {
-                sys.core[i].fp_rename_writes =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "inst_window_reads") == 0) {
-                sys.core[i].inst_window_reads =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "inst_window_writes") == 0) {
-                sys.core[i].inst_window_writes =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "inst_window_wakeup_accesses") == 0) {
-                sys.core[i].inst_window_wakeup_accesses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "inst_window_selections") == 0) {
-                sys.core[i].inst_window_selections =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "fp_inst_window_reads") == 0) {
-                sys.core[i].fp_inst_window_reads =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "fp_inst_window_writes") == 0) {
-                sys.core[i].fp_inst_window_writes =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "fp_inst_window_wakeup_accesses") == 0) {
-                sys.core[i].fp_inst_window_wakeup_accesses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "archi_int_regfile_reads") == 0) {
-                sys.core[i].archi_int_regfile_reads =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "archi_float_regfile_reads") == 0) {
-                sys.core[i].archi_float_regfile_reads =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "phy_int_regfile_reads") == 0) {
-                sys.core[i].phy_int_regfile_reads =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "phy_float_regfile_reads") == 0) {
-                sys.core[i].phy_float_regfile_reads =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "phy_int_regfile_writes") == 0) {
-                sys.core[i].archi_int_regfile_writes =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "phy_float_regfile_writes") == 0) {
-                sys.core[i].archi_float_regfile_writes =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "archi_int_regfile_writes") == 0) {
-                sys.core[i].phy_int_regfile_writes =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "archi_float_regfile_writes") == 0) {
-                sys.core[i].phy_float_regfile_writes =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "int_regfile_reads") == 0) {
-                sys.core[i].int_regfile_reads =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "float_regfile_reads") == 0) {
-                sys.core[i].float_regfile_reads =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "int_regfile_writes") == 0) {
-                sys.core[i].int_regfile_writes =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "float_regfile_writes") == 0) {
-                sys.core[i].float_regfile_writes =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "non_rf_operands") == 0) {
-                sys.core[i].non_rf_operands =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "windowed_reg_accesses") == 0) {
-                sys.core[i].windowed_reg_accesses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "windowed_reg_transports") == 0) {
-                sys.core[i].windowed_reg_transports =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "function_calls") == 0) {
-                sys.core[i].function_calls =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "context_switches") == 0) {
-                sys.core[i].context_switches =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "ialu_accesses") == 0) {
-                sys.core[i].ialu_accesses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "fpu_accesses") == 0) {
-                sys.core[i].fpu_accesses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "mul_accesses") == 0) {
-                sys.core[i].mul_accesses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "cdb_alu_accesses") == 0) {
-                sys.core[i].cdb_alu_accesses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "cdb_mul_accesses") == 0) {
-                sys.core[i].cdb_mul_accesses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "cdb_fpu_accesses") == 0) {
-                sys.core[i].cdb_fpu_accesses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "load_buffer_reads") == 0) {
-                sys.core[i].load_buffer_reads =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "load_buffer_writes") == 0) {
-                sys.core[i].load_buffer_writes =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "load_buffer_cams") == 0) {
-                sys.core[i].load_buffer_cams =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "store_buffer_reads") == 0) {
-                sys.core[i].store_buffer_reads =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "store_buffer_writes") == 0) {
-                sys.core[i].store_buffer_writes =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "store_buffer_cams") == 0) {
-                sys.core[i].store_buffer_cams =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "store_buffer_forwards") == 0) {
-                sys.core[i].store_buffer_forwards =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "main_memory_access") == 0) {
-                sys.core[i].main_memory_access =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "main_memory_read") == 0) {
-                sys.core[i].main_memory_read =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "main_memory_write") == 0) {
-                sys.core[i].main_memory_write =
-                    atoi(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "pipeline_duty_cycle") == 0) {
-                sys.core[i].pipeline_duty_cycle =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "IFU_duty_cycle") == 0) {
-                sys.core[i].IFU_duty_cycle =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "BR_duty_cycle") == 0) {
-                sys.core[i].BR_duty_cycle =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "LSU_duty_cycle") == 0) {
-                sys.core[i].LSU_duty_cycle =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "MemManU_I_duty_cycle") == 0) {
-                sys.core[i].MemManU_I_duty_cycle =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "MemManU_D_duty_cycle") == 0) {
-                sys.core[i].MemManU_D_duty_cycle =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "ALU_duty_cycle") == 0) {
-                sys.core[i].ALU_duty_cycle =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "MUL_duty_cycle") == 0) {
-                sys.core[i].MUL_duty_cycle =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "FPU_duty_cycle") == 0) {
-                sys.core[i].FPU_duty_cycle =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "ALU_cdb_duty_cycle") == 0) {
-                sys.core[i].ALU_cdb_duty_cycle =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "MUL_cdb_duty_cycle") == 0) {
-                sys.core[i].MUL_cdb_duty_cycle =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "FPU_cdb_duty_cycle") == 0) {
-                sys.core[i].FPU_cdb_duty_cycle =
-                    atoi(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-            }
-          }
-
-          NumofCom_4 = xNode3.nChildNode("component");  // get the number of
-                                                        // components within the
-                                                        // third layer
-          for (j = 0; j < NumofCom_4; j++) {
-            xNode4 = xNode3.getChildNode("component", j);
-            if (strcmp(xNode4.getAttribute("name"), "PBT") == 0) {  // find PBT
-              itmp = xNode4.nChildNode("param");
-              for (k = 0; k < itmp; k++) {  // get all items of param in
-                                            // system.core0.predictor--PBT
-                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
-                           "prediction_width") == 0) {
-                  sys.core[i].predictor.prediction_width = atoi(
-                      xNode4.getChildNode("param", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
-                           "prediction_scheme") == 0) {
-                  strcpy(sys.core[i].predictor.prediction_scheme,
-                         xNode4.getChildNode("param", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
-                           "predictor_size") == 0) {
-                  sys.core[i].predictor.predictor_size = atoi(
-                      xNode4.getChildNode("param", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
-                           "predictor_entries") == 0) {
-                  sys.core[i].predictor.predictor_entries = atoi(
-                      xNode4.getChildNode("param", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
-                           "local_predictor_size") == 0) {
-                  strtmp.assign(
-                      xNode4.getChildNode("param", k).getAttribute("value"));
-                  m = 0;
-                  for (n = 0; n < strtmp.length(); n++) {
-                    if (strtmp[n] != ',') {
-                      sprintf(chtmp, "%c", strtmp[n]);
-                      strcat(chtmp1, chtmp);
-                    } else {
-                      sys.core[i].predictor.local_predictor_size[m] =
-                          atoi(chtmp1);
-                      m++;
-                      chtmp1[0] = '\0';
-                    }
-                  }
-                  sys.core[i].predictor.local_predictor_size[m] = atoi(chtmp1);
-                  m++;
-                  chtmp1[0] = '\0';
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
-                           "local_predictor_entries") == 0) {
-                  sys.core[i].predictor.local_predictor_entries = atoi(
-                      xNode4.getChildNode("param", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
-                           "global_predictor_entries") == 0) {
-                  sys.core[i].predictor.global_predictor_entries = atoi(
-                      xNode4.getChildNode("param", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
-                           "global_predictor_bits") == 0) {
-                  sys.core[i].predictor.global_predictor_bits = atoi(
-                      xNode4.getChildNode("param", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
-                           "chooser_predictor_entries") == 0) {
-                  sys.core[i].predictor.chooser_predictor_entries = atoi(
-                      xNode4.getChildNode("param", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
-                           "chooser_predictor_bits") == 0) {
-                  sys.core[i].predictor.chooser_predictor_bits = atoi(
-                      xNode4.getChildNode("param", k).getAttribute("value"));
-                  continue;
-                }
-              }
-              itmp = xNode4.nChildNode("stat");
-              for (k = 0; k < itmp; k++) {  // get all items of stat in
-                                            // system.core0.predictor--PBT
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "predictor_accesses") == 0)
-                  sys.core[i].predictor.predictor_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-              }
-            }
-            if (strcmp(xNode4.getAttribute("name"), "itlb") ==
-                0) {  // find system.core0.itlb
-              itmp = xNode4.nChildNode("param");
-              for (k = 0; k < itmp;
-                   k++) {  // get all items of param in system.core0.itlb--itlb
-                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
-                           "number_entries") == 0)
-                  sys.core[i].itlb.number_entries = atoi(
-                      xNode4.getChildNode("param", k).getAttribute("value"));
-              }
-              itmp = xNode4.nChildNode("stat");
-              for (k = 0; k < itmp; k++) {  // get all items of stat in itlb
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "total_hits") == 0) {
-                  sys.core[i].itlb.total_hits = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "total_accesses") == 0) {
-                  sys.core[i].itlb.total_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "total_misses") == 0) {
-                  sys.core[i].itlb.total_misses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "conflicts") == 0) {
-                  sys.core[i].itlb.conflicts = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-              }
-            }
-            if (strcmp(xNode4.getAttribute("name"), "icache") ==
-                0) {  // find system.core0.icache
-              itmp = xNode4.nChildNode("param");
-              for (k = 0; k < itmp; k++) {  // get all items of param in
-                                            // system.core0.icache--icache
-                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
-                           "icache_config") == 0) {
-                  strtmp.assign(
-                      xNode4.getChildNode("param", k).getAttribute("value"));
-                  m = 0;
-                  for (n = 0; n < strtmp.length(); n++) {
-                    if (strtmp[n] != ',') {
-                      sprintf(chtmp, "%c", strtmp[n]);
-                      strcat(chtmp1, chtmp);
-                    } else {
-                      sys.core[i].icache.icache_config[m] = atof(chtmp1);
-                      m++;
-                      chtmp1[0] = '\0';
-                    }
-                  }
-                  sys.core[i].icache.icache_config[m] = atof(chtmp1);
-                  m++;
-                  chtmp1[0] = '\0';
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
-                           "buffer_sizes") == 0) {
-                  strtmp.assign(
-                      xNode4.getChildNode("param", k).getAttribute("value"));
-                  m = 0;
-                  for (n = 0; n < strtmp.length(); n++) {
-                    if (strtmp[n] != ',') {
-                      sprintf(chtmp, "%c", strtmp[n]);
-                      strcat(chtmp1, chtmp);
-                    } else {
-                      sys.core[i].icache.buffer_sizes[m] = atoi(chtmp1);
-                      m++;
-                      chtmp1[0] = '\0';
-                    }
-                  }
-                  sys.core[i].icache.buffer_sizes[m] = atoi(chtmp1);
-                  m++;
-                  chtmp1[0] = '\0';
-                }
-              }
-              itmp = xNode4.nChildNode("stat");
-              for (k = 0; k < itmp; k++) {
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "total_accesses") == 0) {
-                  sys.core[i].icache.total_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "read_accesses") == 0) {
-                  sys.core[i].icache.read_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "read_misses") == 0) {
-                  sys.core[i].icache.read_misses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "replacements") == 0) {
-                  sys.core[i].icache.replacements = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "read_hits") == 0) {
-                  sys.core[i].icache.read_hits = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "total_hits") == 0) {
-                  sys.core[i].icache.total_hits = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "total_misses") == 0) {
-                  sys.core[i].icache.total_misses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "miss_buffer_access") == 0) {
-                  sys.core[i].icache.miss_buffer_access = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "fill_buffer_accesses") == 0) {
-                  sys.core[i].icache.fill_buffer_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "prefetch_buffer_accesses") == 0) {
-                  sys.core[i].icache.prefetch_buffer_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "prefetch_buffer_writes") == 0) {
-                  sys.core[i].icache.prefetch_buffer_writes = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "prefetch_buffer_reads") == 0) {
-                  sys.core[i].icache.prefetch_buffer_reads = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "prefetch_buffer_hits") == 0) {
-                  sys.core[i].icache.prefetch_buffer_hits = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "conflicts") == 0) {
-                  sys.core[i].icache.conflicts = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-              }
-            }
-            if (strcmp(xNode4.getAttribute("name"), "dtlb") ==
-                0) {  // find system.core0.dtlb
-              itmp = xNode4.nChildNode("param");
-              for (k = 0; k < itmp;
-                   k++) {  // get all items of param in system.core0.dtlb--dtlb
-                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
-                           "number_entries") == 0)
-                  sys.core[i].dtlb.number_entries = atoi(
-                      xNode4.getChildNode("param", k).getAttribute("value"));
-              }
-              itmp = xNode4.nChildNode("stat");
-              for (k = 0; k < itmp; k++) {  // get all items of stat in dtlb
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "total_accesses") == 0) {
-                  sys.core[i].dtlb.total_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "read_accesses") == 0) {
-                  sys.core[i].dtlb.read_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "write_accesses") == 0) {
-                  sys.core[i].dtlb.write_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "read_hits") == 0) {
-                  sys.core[i].dtlb.read_hits = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "write_hits") == 0) {
-                  sys.core[i].dtlb.write_hits = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "read_misses") == 0) {
-                  sys.core[i].dtlb.read_misses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "write_misses") == 0) {
-                  sys.core[i].dtlb.write_misses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "total_hits") == 0) {
-                  sys.core[i].dtlb.total_hits = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "total_misses") == 0) {
-                  sys.core[i].dtlb.total_misses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "conflicts") == 0) {
-                  sys.core[i].dtlb.conflicts = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-              }
-            }
-
-            // Added by Jingwen
-            if (strcmp(xNode4.getAttribute("name"), "ccache") ==
-                0) {  // find system.core0.ccache
-              itmp = xNode4.nChildNode("param");
-              for (k = 0; k < itmp; k++) {  // get all items of param in
-                                            // system.core0.ccache--ccache
-                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
-                           "ccache_config") == 0) {
-                  strtmp.assign(
-                      xNode4.getChildNode("param", k).getAttribute("value"));
-                  m = 0;
-                  for (n = 0; n < strtmp.length(); n++) {
-                    if (strtmp[n] != ',') {
-                      sprintf(chtmp, "%c", strtmp[n]);
-                      strcat(chtmp1, chtmp);
-                    } else {
-                      sys.core[i].ccache.dcache_config[m] = atof(chtmp1);
-                      m++;
-                      chtmp1[0] = '\0';
-                    }
-                  }
-                  sys.core[i].ccache.dcache_config[m] = atof(chtmp1);
-                  m++;
-                  chtmp1[0] = '\0';
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
-                           "buffer_sizes") == 0) {
-                  strtmp.assign(
-                      xNode4.getChildNode("param", k).getAttribute("value"));
-                  m = 0;
-                  for (n = 0; n < strtmp.length(); n++) {
-                    if (strtmp[n] != ',') {
-                      sprintf(chtmp, "%c", strtmp[n]);
-                      strcat(chtmp1, chtmp);
-                    } else {
-                      sys.core[i].ccache.buffer_sizes[m] = atoi(chtmp1);
-                      m++;
-                      chtmp1[0] = '\0';
-                    }
-                  }
-                  sys.core[i].ccache.buffer_sizes[m] = atoi(chtmp1);
-                  m++;
-                  chtmp1[0] = '\0';
-                }
-              }
-              itmp = xNode4.nChildNode("stat");
-              for (k = 0; k < itmp; k++) {  // get all items of stat in ccache
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "total_accesses") == 0) {
-                  sys.core[i].ccache.total_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "read_accesses") == 0) {
-                  sys.core[i].ccache.read_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "write_accesses") == 0) {
-                  sys.core[i].ccache.write_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "total_hits") == 0) {
-                  sys.core[i].ccache.total_hits = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "total_misses") == 0) {
-                  sys.core[i].ccache.total_misses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "read_hits") == 0) {
-                  sys.core[i].ccache.read_hits = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "write_hits") == 0) {
-                  sys.core[i].ccache.write_hits = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "read_misses") == 0) {
-                  sys.core[i].ccache.read_misses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "write_misses") == 0) {
-                  sys.core[i].ccache.write_misses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "replacements") == 0) {
-                  sys.core[i].ccache.replacements = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "write_backs") == 0) {
-                  sys.core[i].ccache.write_backs = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "miss_buffer_access") == 0) {
-                  sys.core[i].ccache.miss_buffer_access = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "fill_buffer_accesses") == 0) {
-                  sys.core[i].ccache.fill_buffer_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "prefetch_buffer_accesses") == 0) {
-                  sys.core[i].ccache.prefetch_buffer_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "prefetch_buffer_writes") == 0) {
-                  sys.core[i].ccache.prefetch_buffer_writes = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "prefetch_buffer_reads") == 0) {
-                  sys.core[i].ccache.prefetch_buffer_reads = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "prefetch_buffer_hits") == 0) {
-                  sys.core[i].ccache.prefetch_buffer_hits = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "wbb_writes") == 0) {
-                  sys.core[i].ccache.wbb_writes = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "wbb_reads") == 0) {
-                  sys.core[i].ccache.wbb_reads = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "conflicts") == 0) {
-                  sys.core[i].ccache.conflicts = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-              }
-            }
-
-            // tcache
-            if (strcmp(xNode4.getAttribute("name"), "tcache") ==
-                0) {  // find system.core0.tcache
-              itmp = xNode4.nChildNode("param");
-              for (k = 0; k < itmp; k++) {  // get all items of param in
-                                            // system.core0.tcache--tcache
-                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
-                           "tcache_config") == 0) {
-                  strtmp.assign(
-                      xNode4.getChildNode("param", k).getAttribute("value"));
-                  m = 0;
-                  for (n = 0; n < strtmp.length(); n++) {
-                    if (strtmp[n] != ',') {
-                      sprintf(chtmp, "%c", strtmp[n]);
-                      strcat(chtmp1, chtmp);
-                    } else {
-                      sys.core[i].tcache.dcache_config[m] = atof(chtmp1);
-                      m++;
-                      chtmp1[0] = '\0';
-                    }
-                  }
-                  sys.core[i].tcache.dcache_config[m] = atof(chtmp1);
-                  m++;
-                  chtmp1[0] = '\0';
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
-                           "buffer_sizes") == 0) {
-                  strtmp.assign(
-                      xNode4.getChildNode("param", k).getAttribute("value"));
-                  m = 0;
-                  for (n = 0; n < strtmp.length(); n++) {
-                    if (strtmp[n] != ',') {
-                      sprintf(chtmp, "%c", strtmp[n]);
-                      strcat(chtmp1, chtmp);
-                    } else {
-                      sys.core[i].tcache.buffer_sizes[m] = atoi(chtmp1);
-                      m++;
-                      chtmp1[0] = '\0';
-                    }
-                  }
-                  sys.core[i].tcache.buffer_sizes[m] = atoi(chtmp1);
-                  m++;
-                  chtmp1[0] = '\0';
-                }
-              }
-              itmp = xNode4.nChildNode("stat");
-              for (k = 0; k < itmp; k++) {  // get all items of stat in tcache
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "total_accesses") == 0) {
-                  sys.core[i].tcache.total_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "read_accesses") == 0) {
-                  sys.core[i].tcache.read_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "write_accesses") == 0) {
-                  sys.core[i].tcache.write_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "total_hits") == 0) {
-                  sys.core[i].tcache.total_hits = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "total_misses") == 0) {
-                  sys.core[i].tcache.total_misses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "read_hits") == 0) {
-                  sys.core[i].tcache.read_hits = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "write_hits") == 0) {
-                  sys.core[i].tcache.write_hits = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "read_misses") == 0) {
-                  sys.core[i].tcache.read_misses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "write_misses") == 0) {
-                  sys.core[i].tcache.write_misses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "replacements") == 0) {
-                  sys.core[i].tcache.replacements = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "write_backs") == 0) {
-                  sys.core[i].tcache.write_backs = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "miss_buffer_access") == 0) {
-                  sys.core[i].tcache.miss_buffer_access = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "fill_buffer_accesses") == 0) {
-                  sys.core[i].tcache.fill_buffer_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "prefetch_buffer_accesses") == 0) {
-                  sys.core[i].tcache.prefetch_buffer_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "prefetch_buffer_writes") == 0) {
-                  sys.core[i].tcache.prefetch_buffer_writes = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "prefetch_buffer_reads") == 0) {
-                  sys.core[i].tcache.prefetch_buffer_reads = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "prefetch_buffer_hits") == 0) {
-                  sys.core[i].tcache.prefetch_buffer_hits = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "wbb_writes") == 0) {
-                  sys.core[i].tcache.wbb_writes = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "wbb_reads") == 0) {
-                  sys.core[i].tcache.wbb_reads = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "conflicts") == 0) {
-                  sys.core[i].tcache.conflicts = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-              }
-            }
-
-            if (strcmp(xNode4.getAttribute("name"), "sharedmemory") ==
-                0) {  // find system.core0.sharedmemory
-              itmp = xNode4.nChildNode("param");
-              for (k = 0; k < itmp;
-                   k++) {  // get all items of param in
-                           // system.core0.sharedmemory--sharedmemory
-                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
-                           "sharedmemory_config") == 0) {
-                  strtmp.assign(
-                      xNode4.getChildNode("param", k).getAttribute("value"));
-                  m = 0;
-                  for (n = 0; n < strtmp.length(); n++) {
-                    if (strtmp[n] != ',') {
-                      sprintf(chtmp, "%c", strtmp[n]);
-                      strcat(chtmp1, chtmp);
-                    } else {
-                      sys.core[i].sharedmemory.dcache_config[m] = atof(chtmp1);
-                      m++;
-                      chtmp1[0] = '\0';
-                    }
-                  }
-                  sys.core[i].sharedmemory.dcache_config[m] = atof(chtmp1);
-                  m++;
-                  chtmp1[0] = '\0';
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
-                           "buffer_sizes") == 0) {
-                  strtmp.assign(
-                      xNode4.getChildNode("param", k).getAttribute("value"));
-                  m = 0;
-                  for (n = 0; n < strtmp.length(); n++) {
-                    if (strtmp[n] != ',') {
-                      sprintf(chtmp, "%c", strtmp[n]);
-                      strcat(chtmp1, chtmp);
-                    } else {
-                      sys.core[i].sharedmemory.buffer_sizes[m] = atoi(chtmp1);
-                      m++;
-                      chtmp1[0] = '\0';
-                    }
-                  }
-                  sys.core[i].sharedmemory.buffer_sizes[m] = atoi(chtmp1);
-                  m++;
-                  chtmp1[0] = '\0';
-                }
-              }
-              itmp = xNode4.nChildNode("stat");
-              for (k = 0; k < itmp;
-                   k++) {  // get all items of stat in sharedmemory
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "total_accesses") == 0) {
-                  sys.core[i].sharedmemory.total_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "read_accesses") == 0) {
-                  sys.core[i].sharedmemory.read_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "write_accesses") == 0) {
-                  sys.core[i].sharedmemory.write_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "total_hits") == 0) {
-                  sys.core[i].sharedmemory.total_hits = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "total_misses") == 0) {
-                  sys.core[i].sharedmemory.total_misses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "read_hits") == 0) {
-                  sys.core[i].sharedmemory.read_hits = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "write_hits") == 0) {
-                  sys.core[i].sharedmemory.write_hits = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "read_misses") == 0) {
-                  sys.core[i].sharedmemory.read_misses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "write_misses") == 0) {
-                  sys.core[i].sharedmemory.write_misses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "replacements") == 0) {
-                  sys.core[i].sharedmemory.replacements = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "write_backs") == 0) {
-                  sys.core[i].sharedmemory.write_backs = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "miss_buffer_access") == 0) {
-                  sys.core[i].sharedmemory.miss_buffer_access = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "fill_buffer_accesses") == 0) {
-                  sys.core[i].sharedmemory.fill_buffer_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "prefetch_buffer_accesses") == 0) {
-                  sys.core[i].sharedmemory.prefetch_buffer_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "prefetch_buffer_writes") == 0) {
-                  sys.core[i].sharedmemory.prefetch_buffer_writes = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "prefetch_buffer_reads") == 0) {
-                  sys.core[i].sharedmemory.prefetch_buffer_reads = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "prefetch_buffer_hits") == 0) {
-                  sys.core[i].sharedmemory.prefetch_buffer_hits = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "wbb_writes") == 0) {
-                  sys.core[i].sharedmemory.wbb_writes = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "wbb_reads") == 0) {
-                  sys.core[i].sharedmemory.wbb_reads = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "conflicts") == 0) {
-                  sys.core[i].sharedmemory.conflicts = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-              }
-            }
-
-            if (strcmp(xNode4.getAttribute("name"), "dcache") ==
-                0) {  // find system.core0.dcache
-              itmp = xNode4.nChildNode("param");
-              for (k = 0; k < itmp; k++) {  // get all items of param in
-                                            // system.core0.dcache--dcache
-                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
-                           "dcache_config") == 0) {
-                  strtmp.assign(
-                      xNode4.getChildNode("param", k).getAttribute("value"));
-                  m = 0;
-                  for (n = 0; n < strtmp.length(); n++) {
-                    if (strtmp[n] != ',') {
-                      sprintf(chtmp, "%c", strtmp[n]);
-                      strcat(chtmp1, chtmp);
-                    } else {
-                      sys.core[i].dcache.dcache_config[m] = atof(chtmp1);
-                      m++;
-                      chtmp1[0] = '\0';
-                    }
-                  }
-                  sys.core[i].dcache.dcache_config[m] = atof(chtmp1);
-                  m++;
-                  chtmp1[0] = '\0';
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
-                           "buffer_sizes") == 0) {
-                  strtmp.assign(
-                      xNode4.getChildNode("param", k).getAttribute("value"));
-                  m = 0;
-                  for (n = 0; n < strtmp.length(); n++) {
-                    if (strtmp[n] != ',') {
-                      sprintf(chtmp, "%c", strtmp[n]);
-                      strcat(chtmp1, chtmp);
-                    } else {
-                      sys.core[i].dcache.buffer_sizes[m] = atoi(chtmp1);
-                      m++;
-                      chtmp1[0] = '\0';
-                    }
-                  }
-                  sys.core[i].dcache.buffer_sizes[m] = atoi(chtmp1);
-                  m++;
-                  chtmp1[0] = '\0';
-                }
-              }
-              itmp = xNode4.nChildNode("stat");
-              for (k = 0; k < itmp; k++) {  // get all items of stat in dcache
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "total_accesses") == 0) {
-                  sys.core[i].dcache.total_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "read_accesses") == 0) {
-                  sys.core[i].dcache.read_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "write_accesses") == 0) {
-                  sys.core[i].dcache.write_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "total_hits") == 0) {
-                  sys.core[i].dcache.total_hits = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "total_misses") == 0) {
-                  sys.core[i].dcache.total_misses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "read_hits") == 0) {
-                  sys.core[i].dcache.read_hits = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "write_hits") == 0) {
-                  sys.core[i].dcache.write_hits = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "read_misses") == 0) {
-                  sys.core[i].dcache.read_misses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "write_misses") == 0) {
-                  sys.core[i].dcache.write_misses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "replacements") == 0) {
-                  sys.core[i].dcache.replacements = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "write_backs") == 0) {
-                  sys.core[i].dcache.write_backs = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "miss_buffer_access") == 0) {
-                  sys.core[i].dcache.miss_buffer_access = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "fill_buffer_accesses") == 0) {
-                  sys.core[i].dcache.fill_buffer_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "prefetch_buffer_accesses") == 0) {
-                  sys.core[i].dcache.prefetch_buffer_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "prefetch_buffer_writes") == 0) {
-                  sys.core[i].dcache.prefetch_buffer_writes = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "prefetch_buffer_reads") == 0) {
-                  sys.core[i].dcache.prefetch_buffer_reads = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "prefetch_buffer_hits") == 0) {
-                  sys.core[i].dcache.prefetch_buffer_hits = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "wbb_writes") == 0) {
-                  sys.core[i].dcache.wbb_writes = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "wbb_reads") == 0) {
-                  sys.core[i].dcache.wbb_reads = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "conflicts") == 0) {
-                  sys.core[i].dcache.conflicts = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-              }
-            }
-
-            if (strcmp(xNode4.getAttribute("name"), "BTB") ==
-                0) {  // find system.core0.BTB
-              itmp = xNode4.nChildNode("param");
-              for (k = 0; k < itmp;
-                   k++) {  // get all items of param in system.core0.BTB--BTB
-                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
-                           "BTB_config") == 0) {
-                  strtmp.assign(
-                      xNode4.getChildNode("param", k).getAttribute("value"));
-                  m = 0;
-                  for (n = 0; n < strtmp.length(); n++) {
-                    if (strtmp[n] != ',') {
-                      sprintf(chtmp, "%c", strtmp[n]);
-                      strcat(chtmp1, chtmp);
-                    } else {
-                      sys.core[i].BTB.BTB_config[m] = atoi(chtmp1);
-                      m++;
-                      chtmp1[0] = '\0';
-                    }
-                  }
-                  sys.core[i].BTB.BTB_config[m] = atoi(chtmp1);
-                  m++;
-                  chtmp1[0] = '\0';
-                }
-              }
-              itmp = xNode4.nChildNode("stat");
-              for (k = 0; k < itmp; k++) {  // get all items of stat in BTB
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "total_accesses") == 0) {
-                  sys.core[i].BTB.total_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "read_accesses") == 0) {
-                  sys.core[i].BTB.read_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "write_accesses") == 0) {
-                  sys.core[i].BTB.write_accesses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "total_hits") == 0) {
-                  sys.core[i].BTB.total_hits = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "total_misses") == 0) {
-                  sys.core[i].BTB.total_misses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "read_hits") == 0) {
-                  sys.core[i].BTB.read_hits = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "write_hits") == 0) {
-                  sys.core[i].BTB.write_hits = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "read_misses") == 0) {
-                  sys.core[i].BTB.read_misses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "write_misses") == 0) {
-                  sys.core[i].BTB.write_misses = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
-                           "replacements") == 0) {
-                  sys.core[i].BTB.replacements = atof(
-                      xNode4.getChildNode("stat", k).getAttribute("value"));
-                  continue;
-                }
-              }
-            }
-          }
-        } else {
-          printf(
-              "The value of homogeneous_cores or number_of_cores is not "
-              "correct!");
-          exit(0);
-        }
-      }
-    }
-
-    //__________________________________________Get
-    //system.L1Directory0-n____________________________________________
-    int w, tmpOrderofComponents_3layer;
-    w = OrderofComponents_3layer + 1;
-    tmpOrderofComponents_3layer = OrderofComponents_3layer;
-    if (sys.homogeneous_L1Directories == 1)
-      OrderofComponents_3layer = OrderofComponents_3layer + 1;
-    else
-      OrderofComponents_3layer =
-          OrderofComponents_3layer + sys.number_of_L1Directories;
-
-    for (i = 0; i < (OrderofComponents_3layer - tmpOrderofComponents_3layer);
-         i++) {
-      xNode3 = xNode2.getChildNode("component", w);
-      if (xNode3.isEmpty() == 1) {
-        printf(
-            "The value of homogeneous_L1Directories or number_of_L1Directories "
-            "is not correct!");
-        exit(0);
-      } else {
-        if (strstr(xNode3.getAttribute("id"), "L1Directory") != NULL) {
-          itmp = xNode3.nChildNode("param");
-          for (k = 0; k < itmp;
-               k++) {  // get all items of param in system.L1Directory
-            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                       "Dir_config") == 0) {
-              strtmp.assign(
-                  xNode3.getChildNode("param", k).getAttribute("value"));
-              m = 0;
-              for (n = 0; n < strtmp.length(); n++) {
-                if (strtmp[n] != ',') {
-                  sprintf(chtmp, "%c", strtmp[n]);
-                  strcat(chtmp1, chtmp);
-                } else {
-                  sys.L1Directory[i].Dir_config[m] = atof(chtmp1);
-                  m++;
-                  chtmp1[0] = '\0';
-                }
-              }
-              sys.L1Directory[i].Dir_config[m] = atof(chtmp1);
-              m++;
-              chtmp1[0] = '\0';
-              continue;
-            }
-            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                       "buffer_sizes") == 0) {
-              strtmp.assign(
-                  xNode3.getChildNode("param", k).getAttribute("value"));
-              m = 0;
-              for (n = 0; n < strtmp.length(); n++) {
-                if (strtmp[n] != ',') {
-                  sprintf(chtmp, "%c", strtmp[n]);
-                  strcat(chtmp1, chtmp);
-                } else {
-                  sys.L1Directory[i].buffer_sizes[m] = atoi(chtmp1);
-                  m++;
-                  chtmp1[0] = '\0';
-                }
-              }
-              sys.L1Directory[i].buffer_sizes[m] = atoi(chtmp1);
-              m++;
-              chtmp1[0] = '\0';
-              continue;
-            }
-
-            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                       "clockrate") == 0) {
-              sys.L1Directory[i].clockrate =
-                  atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-              continue;
-            }
-            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                       "ports") == 0) {
-              strtmp.assign(
-                  xNode3.getChildNode("param", k).getAttribute("value"));
-              m = 0;
-              for (n = 0; n < strtmp.length(); n++) {
-                if (strtmp[n] != ',') {
-                  sprintf(chtmp, "%c", strtmp[n]);
-                  strcat(chtmp1, chtmp);
-                } else {
-                  sys.L1Directory[i].ports[m] = atoi(chtmp1);
-                  m++;
-                  chtmp1[0] = '\0';
-                }
-              }
-              sys.L1Directory[i].ports[m] = atoi(chtmp1);
-              m++;
-              chtmp1[0] = '\0';
-              continue;
-            }
-            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                       "device_type") == 0) {
-              sys.L1Directory[i].device_type =
-                  atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-              continue;
-            }
-            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                       "Directory_type") == 0) {
-              sys.L1Directory[i].Directory_type =
-                  atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-              continue;
-            }
-            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                       "3D_stack") == 0) {
-              strcpy(sys.L1Directory[i].threeD_stack,
-                     xNode3.getChildNode("param", k).getAttribute("value"));
-              continue;
-            }
-          }
-          itmp = xNode3.nChildNode("stat");
-          for (k = 0; k < itmp;
-               k++) {  // get all items of stat in system.L2directorydirectory
-            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                       "total_accesses") == 0) {
-              sys.L1Directory[i].total_accesses =
-                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-              continue;
-            }
-            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                       "read_accesses") == 0) {
-              sys.L1Directory[i].read_accesses =
-                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-              continue;
-            }
-            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                       "write_accesses") == 0) {
-              sys.L1Directory[i].write_accesses =
-                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-              continue;
-            }
-            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                       "read_misses") == 0) {
-              sys.L1Directory[i].read_misses =
-                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-              continue;
-            }
-            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                       "write_misses") == 0) {
-              sys.L1Directory[i].write_misses =
-                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-              continue;
-            }
-            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                       "conflicts") == 0) {
-              sys.L1Directory[i].conflicts =
-                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-              continue;
-            }
-            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                       "duty_cycle") == 0) {
-              sys.L1Directory[i].duty_cycle =
-                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-              continue;
-            }
-          }
-          w = w + 1;
-        } else {
-          printf(
-              "The value of homogeneous_L1Directories or "
-              "number_of_L1Directories is not correct!");
-          exit(0);
-        }
-      }
-    }
-
-    //__________________________________________Get
-    //system.L2Directory0-n____________________________________________
-    w = OrderofComponents_3layer + 1;
-    tmpOrderofComponents_3layer = OrderofComponents_3layer;
-    if (sys.homogeneous_L2Directories == 1)
-      OrderofComponents_3layer = OrderofComponents_3layer + 1;
-    else
-      OrderofComponents_3layer =
-          OrderofComponents_3layer + sys.number_of_L2Directories;
-
-    for (i = 0; i < (OrderofComponents_3layer - tmpOrderofComponents_3layer);
-         i++) {
-      xNode3 = xNode2.getChildNode("component", w);
-      if (xNode3.isEmpty() == 1) {
-        printf(
-            "The value of homogeneous_L2Directories or number_of_L2Directories "
-            "is not correct!");
-        exit(0);
-      } else {
-        if (strstr(xNode3.getAttribute("id"), "L2Directory") != NULL) {
-          itmp = xNode3.nChildNode("param");
-          for (k = 0; k < itmp;
-               k++) {  // get all items of param in system.L2Directory
-            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                       "Dir_config") == 0) {
-              strtmp.assign(
-                  xNode3.getChildNode("param", k).getAttribute("value"));
-              m = 0;
-              for (n = 0; n < strtmp.length(); n++) {
-                if (strtmp[n] != ',') {
-                  sprintf(chtmp, "%c", strtmp[n]);
-                  strcat(chtmp1, chtmp);
-                } else {
-                  sys.L2Directory[i].Dir_config[m] = atof(chtmp1);
-                  m++;
-                  chtmp1[0] = '\0';
-                }
-              }
-              sys.L2Directory[i].Dir_config[m] = atof(chtmp1);
-              m++;
-              chtmp1[0] = '\0';
-              continue;
-            }
-            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                       "buffer_sizes") == 0) {
-              strtmp.assign(
-                  xNode3.getChildNode("param", k).getAttribute("value"));
-              m = 0;
-              for (n = 0; n < strtmp.length(); n++) {
-                if (strtmp[n] != ',') {
-                  sprintf(chtmp, "%c", strtmp[n]);
-                  strcat(chtmp1, chtmp);
-                } else {
-                  sys.L2Directory[i].buffer_sizes[m] = atoi(chtmp1);
-                  m++;
-                  chtmp1[0] = '\0';
-                }
-              }
-              sys.L2Directory[i].buffer_sizes[m] = atoi(chtmp1);
-              m++;
-              chtmp1[0] = '\0';
-              continue;
-            }
-
-            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                       "clockrate") == 0) {
-              sys.L2Directory[i].clockrate =
-                  atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-              continue;
-            }
-            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                       "Directory_type") == 0) {
-              sys.L2Directory[i].Directory_type =
-                  atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-              continue;
-            }
-            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                       "ports") == 0) {
-              strtmp.assign(
-                  xNode3.getChildNode("param", k).getAttribute("value"));
-              m = 0;
-              for (n = 0; n < strtmp.length(); n++) {
-                if (strtmp[n] != ',') {
-                  sprintf(chtmp, "%c", strtmp[n]);
-                  strcat(chtmp1, chtmp);
-                } else {
-                  sys.L2Directory[i].ports[m] = atoi(chtmp1);
-                  m++;
-                  chtmp1[0] = '\0';
-                }
-              }
-              sys.L2Directory[i].ports[m] = atoi(chtmp1);
-              m++;
-              chtmp1[0] = '\0';
-              continue;
-            }
-            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                       "device_type") == 0) {
-              sys.L2Directory[i].device_type =
-                  atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-              continue;
-            }
-            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                       "3D_stack") == 0) {
-              strcpy(sys.L2Directory[i].threeD_stack,
-                     xNode3.getChildNode("param", k).getAttribute("value"));
-              continue;
-            }
-          }
-          itmp = xNode3.nChildNode("stat");
-          for (k = 0; k < itmp;
-               k++) {  // get all items of stat in system.L2directorydirectory
-            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                       "total_accesses") == 0) {
-              sys.L2Directory[i].total_accesses =
-                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-              continue;
-            }
-            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                       "read_accesses") == 0) {
-              sys.L2Directory[i].read_accesses =
-                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-              continue;
-            }
-            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                       "write_accesses") == 0) {
-              sys.L2Directory[i].write_accesses =
-                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-              continue;
-            }
-            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                       "read_misses") == 0) {
-              sys.L2Directory[i].read_misses =
-                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-              continue;
-            }
-            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                       "write_misses") == 0) {
-              sys.L2Directory[i].write_misses =
-                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-              continue;
-            }
-            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                       "conflicts") == 0) {
-              sys.L2Directory[i].conflicts =
-                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-              continue;
-            }
-            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                       "duty_cycle") == 0) {
-              sys.L2Directory[i].duty_cycle =
-                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-              continue;
-            }
-          }
-          w = w + 1;
-        } else {
-          printf(
-              "The value of homogeneous_L2Directories or "
-              "number_of_L2Directories is not correct!");
-          exit(0);
-        }
-      }
-    }
-
-    //__________________________________________Get
-    //system.L2[0..n]____________________________________________
-    w = OrderofComponents_3layer + 1;
-    tmpOrderofComponents_3layer = OrderofComponents_3layer;
-    if (sys.homogeneous_L2s == 1)
-      OrderofComponents_3layer = OrderofComponents_3layer + 1;
-    else
-      OrderofComponents_3layer = OrderofComponents_3layer + sys.number_of_L2s;
-
-    for (i = 0; i < (OrderofComponents_3layer - tmpOrderofComponents_3layer);
-         i++) {
-      xNode3 = xNode2.getChildNode("component", w);
-      if (xNode3.isEmpty() == 1) {
-        printf("The value of homogeneous_L2s or number_of_L2s is not correct!");
-        exit(0);
-      } else {
-        if (strstr(xNode3.getAttribute("name"), "L2") != NULL) {
-          {  // For L20-L2i
-            // Get all params with system.L2?
-            itmp = xNode3.nChildNode("param");
-            for (k = 0; k < itmp; k++) {
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "L2_config") == 0) {
-                strtmp.assign(
-                    xNode3.getChildNode("param", k).getAttribute("value"));
-                m = 0;
-                for (n = 0; n < strtmp.length(); n++) {
-                  if (strtmp[n] != ',') {
-                    sprintf(chtmp, "%c", strtmp[n]);
-                    strcat(chtmp1, chtmp);
-                  } else {
-                    sys.L2[i].L2_config[m] = atof(chtmp1);
-                    m++;
-                    chtmp1[0] = '\0';
-                  }
-                }
-                sys.L2[i].L2_config[m] = atof(chtmp1);
-                m++;
-                chtmp1[0] = '\0';
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "clockrate") == 0) {
-                sys.L2[i].clockrate =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "merged_dir") == 0) {
-                sys.L2[i].merged_dir = (bool)atoi(
-                    xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "ports") == 0) {
-                strtmp.assign(
-                    xNode3.getChildNode("param", k).getAttribute("value"));
-                m = 0;
-                for (n = 0; n < strtmp.length(); n++) {
-                  if (strtmp[n] != ',') {
-                    sprintf(chtmp, "%c", strtmp[n]);
-                    strcat(chtmp1, chtmp);
-                  } else {
-                    sys.L2[i].ports[m] = atoi(chtmp1);
-                    m++;
-                    chtmp1[0] = '\0';
-                  }
-                }
-                sys.L2[i].ports[m] = atoi(chtmp1);
-                m++;
-                chtmp1[0] = '\0';
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "device_type") == 0) {
-                sys.L2[i].device_type =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "threeD_stack") == 0) {
-                strcpy(sys.L2[i].threeD_stack,
-                       (xNode3.getChildNode("param", k).getAttribute("value")));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "buffer_sizes") == 0) {
-                strtmp.assign(
-                    xNode3.getChildNode("param", k).getAttribute("value"));
-                m = 0;
-                for (n = 0; n < strtmp.length(); n++) {
-                  if (strtmp[n] != ',') {
-                    sprintf(chtmp, "%c", strtmp[n]);
-                    strcat(chtmp1, chtmp);
-                  } else {
-                    sys.L2[i].buffer_sizes[m] = atoi(chtmp1);
-                    m++;
-                    chtmp1[0] = '\0';
-                  }
-                }
-                sys.L2[i].buffer_sizes[m] = atoi(chtmp1);
-                m++;
-                chtmp1[0] = '\0';
-                continue;
-              }
-            }
-            // Get all stats with system.L2?
-            itmp = xNode3.nChildNode("stat");
-            for (k = 0; k < itmp; k++) {
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "total_accesses") == 0) {
-                sys.L2[i].total_accesses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "read_accesses") == 0) {
-                sys.L2[i].read_accesses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "write_accesses") == 0) {
-                sys.L2[i].write_accesses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "total_hits") == 0) {
-                sys.L2[i].total_hits =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "total_misses") == 0) {
-                sys.L2[i].total_misses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "read_hits") == 0) {
-                sys.L2[i].read_hits =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "write_hits") == 0) {
-                sys.L2[i].write_hits =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "read_misses") == 0) {
-                sys.L2[i].read_misses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "write_misses") == 0) {
-                sys.L2[i].write_misses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "replacements") == 0) {
-                sys.L2[i].replacements =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "write_backs") == 0) {
-                sys.L2[i].write_backs =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "miss_buffer_accesses") == 0) {
-                sys.L2[i].miss_buffer_accesses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "fill_buffer_accesses") == 0) {
-                sys.L2[i].fill_buffer_accesses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "prefetch_buffer_accesses") == 0) {
-                sys.L2[i].prefetch_buffer_accesses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "prefetch_buffer_writes") == 0) {
-                sys.L2[i].prefetch_buffer_writes =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "prefetch_buffer_reads") == 0) {
-                sys.L2[i].prefetch_buffer_reads =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "prefetch_buffer_hits") == 0) {
-                sys.L2[i].prefetch_buffer_hits =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "wbb_writes") == 0) {
-                sys.L2[i].wbb_writes =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "wbb_reads") == 0) {
-                sys.L2[i].wbb_reads =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "conflicts") == 0) {
-                sys.L2[i].conflicts =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "duty_cycle") == 0) {
-                sys.L2[i].duty_cycle =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "homenode_read_accesses") == 0) {
-                sys.L2[i].homenode_read_accesses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "homenode_read_accesses") == 0) {
-                sys.L2[i].homenode_read_accesses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "homenode_read_hits") == 0) {
-                sys.L2[i].homenode_read_hits =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "homenode_write_hits") == 0) {
-                sys.L2[i].homenode_write_hits =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "homenode_read_misses") == 0) {
-                sys.L2[i].homenode_read_misses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "homenode_write_misses") == 0) {
-                sys.L2[i].homenode_write_misses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "dir_duty_cycle") == 0) {
-                sys.L2[i].dir_duty_cycle =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-            }
-          }
-          w = w + 1;
-        } else {
-          printf(
-              "The value of homogeneous_L2s or number_of_L2s is not correct!");
-          exit(0);
-        }
-      }
-    }
-    //__________________________________________Get
-    //system.L3[0..n]____________________________________________
-    w = OrderofComponents_3layer + 1;
-    tmpOrderofComponents_3layer = OrderofComponents_3layer;
-    if (sys.homogeneous_L3s == 1)
-      OrderofComponents_3layer = OrderofComponents_3layer + 1;
-    else
-      OrderofComponents_3layer = OrderofComponents_3layer + sys.number_of_L3s;
-
-    for (i = 0; i < (OrderofComponents_3layer - tmpOrderofComponents_3layer);
-         i++) {
-      xNode3 = xNode2.getChildNode("component", w);
-      if (xNode3.isEmpty() == 1) {
-        printf("The value of homogeneous_L3s or number_of_L3s is not correct!");
-        exit(0);
-      } else {
-        if (strstr(xNode3.getAttribute("name"), "L3") != NULL) {
-          {  // For L30-L3i
-            // Get all params with system.L3?
-            itmp = xNode3.nChildNode("param");
-            for (k = 0; k < itmp; k++) {
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "L3_config") == 0) {
-                strtmp.assign(
-                    xNode3.getChildNode("param", k).getAttribute("value"));
-                m = 0;
-                for (n = 0; n < strtmp.length(); n++) {
-                  if (strtmp[n] != ',') {
-                    sprintf(chtmp, "%c", strtmp[n]);
-                    strcat(chtmp1, chtmp);
-                  } else {
-                    sys.L3[i].L3_config[m] = atof(chtmp1);
-                    m++;
-                    chtmp1[0] = '\0';
-                  }
-                }
-                sys.L3[i].L3_config[m] = atof(chtmp1);
-                m++;
-                chtmp1[0] = '\0';
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "clockrate") == 0) {
-                sys.L3[i].clockrate =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "merged_dir") == 0) {
-                sys.L3[i].merged_dir = (bool)atoi(
-                    xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "ports") == 0) {
-                strtmp.assign(
-                    xNode3.getChildNode("param", k).getAttribute("value"));
-                m = 0;
-                for (n = 0; n < strtmp.length(); n++) {
-                  if (strtmp[n] != ',') {
-                    sprintf(chtmp, "%c", strtmp[n]);
-                    strcat(chtmp1, chtmp);
-                  } else {
-                    sys.L3[i].ports[m] = atoi(chtmp1);
-                    m++;
-                    chtmp1[0] = '\0';
-                  }
-                }
-                sys.L3[i].ports[m] = atoi(chtmp1);
-                m++;
-                chtmp1[0] = '\0';
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "device_type") == 0) {
-                sys.L3[i].device_type =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "threeD_stack") == 0) {
-                strcpy(sys.L3[i].threeD_stack,
-                       (xNode3.getChildNode("param", k).getAttribute("value")));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "buffer_sizes") == 0) {
-                strtmp.assign(
-                    xNode3.getChildNode("param", k).getAttribute("value"));
-                m = 0;
-                for (n = 0; n < strtmp.length(); n++) {
-                  if (strtmp[n] != ',') {
-                    sprintf(chtmp, "%c", strtmp[n]);
-                    strcat(chtmp1, chtmp);
-                  } else {
-                    sys.L3[i].buffer_sizes[m] = atoi(chtmp1);
-                    m++;
-                    chtmp1[0] = '\0';
-                  }
-                }
-                sys.L3[i].buffer_sizes[m] = atoi(chtmp1);
-                m++;
-                chtmp1[0] = '\0';
-                continue;
-              }
-            }
-            // Get all stats with system.L3?
-            itmp = xNode3.nChildNode("stat");
-            for (k = 0; k < itmp; k++) {
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "total_accesses") == 0) {
-                sys.L3[i].total_accesses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "read_accesses") == 0) {
-                sys.L3[i].read_accesses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "write_accesses") == 0) {
-                sys.L3[i].write_accesses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "total_hits") == 0) {
-                sys.L3[i].total_hits =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "total_misses") == 0) {
-                sys.L3[i].total_misses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "read_hits") == 0) {
-                sys.L3[i].read_hits =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "write_hits") == 0) {
-                sys.L3[i].write_hits =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "read_misses") == 0) {
-                sys.L3[i].read_misses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "write_misses") == 0) {
-                sys.L3[i].write_misses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "replacements") == 0) {
-                sys.L3[i].replacements =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "write_backs") == 0) {
-                sys.L3[i].write_backs =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "miss_buffer_accesses") == 0) {
-                sys.L3[i].miss_buffer_accesses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "fill_buffer_accesses") == 0) {
-                sys.L3[i].fill_buffer_accesses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "prefetch_buffer_accesses") == 0) {
-                sys.L3[i].prefetch_buffer_accesses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "prefetch_buffer_writes") == 0) {
-                sys.L3[i].prefetch_buffer_writes =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "prefetch_buffer_reads") == 0) {
-                sys.L3[i].prefetch_buffer_reads =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "prefetch_buffer_hits") == 0) {
-                sys.L3[i].prefetch_buffer_hits =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "wbb_writes") == 0) {
-                sys.L3[i].wbb_writes =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "wbb_reads") == 0) {
-                sys.L3[i].wbb_reads =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "conflicts") == 0) {
-                sys.L3[i].conflicts =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "duty_cycle") == 0) {
-                sys.L3[i].duty_cycle =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "homenode_read_accesses") == 0) {
-                sys.L3[i].homenode_read_accesses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "homenode_read_accesses") == 0) {
-                sys.L3[i].homenode_read_accesses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "homenode_read_hits") == 0) {
-                sys.L3[i].homenode_read_hits =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "homenode_write_hits") == 0) {
-                sys.L3[i].homenode_write_hits =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "homenode_read_misses") == 0) {
-                sys.L3[i].homenode_read_misses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "homenode_write_misses") == 0) {
-                sys.L3[i].homenode_write_misses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "dir_duty_cycle") == 0) {
-                sys.L3[i].dir_duty_cycle =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-                continue;
-              }
-            }
-          }
-          w = w + 1;
-        } else {
-          printf(
-              "The value of homogeneous_L3s or number_of_L3s is not correct!");
-          exit(0);
-        }
-      }
-    }
-    //__________________________________________Get
-    //system.NoC[0..n]____________________________________________
-    w = OrderofComponents_3layer + 1;
-    tmpOrderofComponents_3layer = OrderofComponents_3layer;
-    if (sys.homogeneous_NoCs == 1)
-      OrderofComponents_3layer = OrderofComponents_3layer + 1;
-    else
-      OrderofComponents_3layer = OrderofComponents_3layer + sys.number_of_NoCs;
-
-    for (i = 0; i < (OrderofComponents_3layer - tmpOrderofComponents_3layer);
-         i++) {
-      xNode3 = xNode2.getChildNode("component", w);
-      if (xNode3.isEmpty() == 1) {
-        printf(
-            "The value of homogeneous_NoCs or number_of_NoCs is not correct!");
-        exit(0);
-      } else {
-        if (strstr(xNode3.getAttribute("name"), "noc") != NULL) {
-          {  // For NoC0-NoCi
-            // Get all params with system.NoC?
-            itmp = xNode3.nChildNode("param");
-            for (k = 0; k < itmp; k++) {
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "clockrate") == 0) {
-                sys.NoC[i].clockrate =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "type") == 0) {
-                sys.NoC[i].type = (bool)atoi(
-                    xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "topology") == 0) {
-                strcpy(sys.NoC[i].topology,
-                       (xNode3.getChildNode("param", k).getAttribute("value")));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "horizontal_nodes") == 0) {
-                sys.NoC[i].horizontal_nodes =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "vertical_nodes") == 0) {
-                sys.NoC[i].vertical_nodes =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "has_global_link") == 0) {
-                sys.NoC[i].has_global_link = (bool)atoi(
-                    xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "link_throughput") == 0) {
-                sys.NoC[i].link_throughput =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "link_latency") == 0) {
-                sys.NoC[i].link_latency =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "input_ports") == 0) {
-                sys.NoC[i].input_ports =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "output_ports") == 0) {
-                sys.NoC[i].output_ports =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "virtual_channel_per_port") == 0) {
-                sys.NoC[i].virtual_channel_per_port =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "flit_bits") == 0) {
-                sys.NoC[i].flit_bits =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "input_buffer_entries_per_vc") == 0) {
-                sys.NoC[i].input_buffer_entries_per_vc =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "dual_pump") == 0) {
-                sys.NoC[i].dual_pump =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "chip_coverage") == 0) {
-                sys.NoC[i].chip_coverage =
-                    atof(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "link_routing_over_percentage") == 0) {
-                sys.NoC[i].route_over_perc =
-                    atof(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "ports_of_input_buffer") == 0) {
-                strtmp.assign(
-                    xNode3.getChildNode("param", k).getAttribute("value"));
-                m = 0;
-                for (n = 0; n < strtmp.length(); n++) {
-                  if (strtmp[n] != ',') {
-                    sprintf(chtmp, "%c", strtmp[n]);
-                    strcat(chtmp1, chtmp);
-                  } else {
-                    sys.NoC[i].ports_of_input_buffer[m] = atoi(chtmp1);
-                    m++;
-                    chtmp1[0] = '\0';
-                  }
-                }
-                sys.NoC[i].ports_of_input_buffer[m] = atoi(chtmp1);
-                m++;
-                chtmp1[0] = '\0';
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "number_of_crossbars") == 0) {
-                sys.NoC[i].number_of_crossbars =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "crossbar_type") == 0) {
-                strcpy(sys.NoC[i].crossbar_type,
-                       (xNode3.getChildNode("param", k).getAttribute("value")));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "crosspoint_type") == 0) {
-                strcpy(sys.NoC[i].crosspoint_type,
-                       (xNode3.getChildNode("param", k).getAttribute("value")));
-                continue;
-              }
-              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                         "arbiter_type") == 0) {
-                sys.NoC[i].arbiter_type =
-                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-                continue;
-              }
-            }
-            NumofCom_4 = xNode3.nChildNode("component");  // get the number of
-                                                          // components within
-                                                          // the third layer
-            for (j = 0; j < NumofCom_4; j++) {
-              xNode4 = xNode3.getChildNode("component", j);
-              if (strcmp(xNode4.getAttribute("name"), "xbar0") ==
-                  0) {  // find PBT
-                itmp = xNode4.nChildNode("param");
-                for (k = 0; k < itmp; k++) {  // get all items of param in
-                                              // system.XoC0.xbar0--xbar0
-                  if (strcmp(
-                          xNode4.getChildNode("param", k).getAttribute("name"),
-                          "number_of_inputs_of_crossbars") == 0) {
-                    sys.NoC[i].xbar0.number_of_inputs_of_crossbars = atoi(
-                        xNode4.getChildNode("param", k).getAttribute("value"));
-                    continue;
-                  }
-                  if (strcmp(
-                          xNode4.getChildNode("param", k).getAttribute("name"),
-                          "number_of_outputs_of_crossbars") == 0) {
-                    sys.NoC[i].xbar0.number_of_outputs_of_crossbars = atoi(
-                        xNode4.getChildNode("param", k).getAttribute("value"));
-                    continue;
-                  }
-                  if (strcmp(
-                          xNode4.getChildNode("param", k).getAttribute("name"),
-                          "flit_bits") == 0) {
-                    sys.NoC[i].xbar0.flit_bits = atoi(
-                        xNode4.getChildNode("param", k).getAttribute("value"));
-                    continue;
-                  }
-                  if (strcmp(
-                          xNode4.getChildNode("param", k).getAttribute("name"),
-                          "input_buffer_entries_per_port") == 0) {
-                    sys.NoC[i].xbar0.input_buffer_entries_per_port = atoi(
-                        xNode4.getChildNode("param", k).getAttribute("value"));
-                    continue;
-                  }
-                  if (strcmp(
-                          xNode4.getChildNode("param", k).getAttribute("name"),
-                          "ports_of_input_buffer") == 0) {
-                    strtmp.assign(
-                        xNode4.getChildNode("param", k).getAttribute("value"));
-                    m = 0;
-                    for (n = 0; n < strtmp.length(); n++) {
-                      if (strtmp[n] != ',') {
-                        sprintf(chtmp, "%c", strtmp[n]);
-                        strcat(chtmp1, chtmp);
-                      } else {
-                        sys.NoC[i].xbar0.ports_of_input_buffer[m] =
-                            atoi(chtmp1);
-                        m++;
-                        chtmp1[0] = '\0';
-                      }
-                    }
-                    sys.NoC[i].xbar0.ports_of_input_buffer[m] = atoi(chtmp1);
-                    m++;
-                    chtmp1[0] = '\0';
-                  }
-                }
-                itmp = xNode4.nChildNode("stat");
-                for (k = 0; k < itmp; k++) {  // get all items of stat in
-                                              // system.core0.predictor--PBT
-                  if (strcmp(
-                          xNode4.getChildNode("stat", k).getAttribute("name"),
-                          "predictor_accesses") == 0)
-                    sys.core[i].predictor.predictor_accesses = atof(
-                        xNode4.getChildNode("stat", k).getAttribute("value"));
-                }
-              }
-            }
-            // Get all stats with system.NoC?
-            itmp = xNode3.nChildNode("stat");
-            for (k = 0; k < itmp; k++) {
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "total_accesses") == 0)
-                sys.NoC[i].total_accesses =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                         "duty_cycle") == 0)
-                sys.NoC[i].duty_cycle =
-                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-            }
-          }
-          w = w + 1;
-        }
-      }
-    }
-    //__________________________________________Get
-    //system.mem____________________________________________
-    if (OrderofComponents_3layer > 0)
-      OrderofComponents_3layer = OrderofComponents_3layer + 1;
-    xNode3 = xNode2.getChildNode("component", OrderofComponents_3layer);
-    if (xNode3.isEmpty() == 1) {
-      printf(
-          "some value(s) of "
-          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
-          "not correct!");
-      exit(0);
-    }
-    if (strstr(xNode3.getAttribute("id"), "system.mem") != NULL) {
-      itmp = xNode3.nChildNode("param");
-      for (k = 0; k < itmp; k++) {  // get all items of param in system.mem
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "mem_tech_node") == 0) {
-          sys.mem.mem_tech_node =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "device_clock") == 0) {
-          sys.mem.device_clock =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "peak_transfer_rate") == 0) {
-          sys.mem.peak_transfer_rate =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "capacity_per_channel") == 0) {
-          sys.mem.capacity_per_channel =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "number_ranks") == 0) {
-          sys.mem.number_ranks =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "num_banks_of_DRAM_chip") == 0) {
-          sys.mem.num_banks_of_DRAM_chip =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "Block_width_of_DRAM_chip") == 0) {
-          sys.mem.Block_width_of_DRAM_chip =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "output_width_of_DRAM_chip") == 0) {
-          sys.mem.output_width_of_DRAM_chip =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "page_size_of_DRAM_chip") == 0) {
-          sys.mem.page_size_of_DRAM_chip =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "burstlength_of_DRAM_chip") == 0) {
-          sys.mem.burstlength_of_DRAM_chip =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "internal_prefetch_of_DRAM_chip") == 0) {
-          sys.mem.internal_prefetch_of_DRAM_chip =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-      }
-      itmp = xNode3.nChildNode("stat");
-      for (k = 0; k < itmp; k++) {  // get all items of stat in system.mem
-        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                   "memory_accesses") == 0) {
-          sys.mem.memory_accesses =
-              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                   "memory_reads") == 0) {
-          sys.mem.memory_reads =
-              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                   "memory_writes") == 0) {
-          sys.mem.memory_writes =
-              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                   "dram_pre") == 0) {
-          sys.mem.dram_pre =
-              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-          continue;
-        }
-      }
-    } else {
-      printf(
-          "some value(s) of "
-          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
-          "not correct!");
-      exit(0);
-    }
-    //__________________________________________Get
-    //system.mc____________________________________________
-    if (OrderofComponents_3layer > 0)
-      OrderofComponents_3layer = OrderofComponents_3layer + 1;
-    xNode3 = xNode2.getChildNode("component", OrderofComponents_3layer);
-    if (xNode3.isEmpty() == 1) {
-      printf(
-          "some value(s) of "
-          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
-          "not correct!");
-      exit(0);
-    }
-    if (strstr(xNode3.getAttribute("id"), "system.mc") != NULL) {
-      itmp = xNode3.nChildNode("param");
-      for (k = 0; k < itmp; k++) {  // get all items of param in system.mem
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "mc_clock") == 0) {
-          sys.mc.mc_clock =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "block_size") == 0) {
-          sys.mc.llc_line_length =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "number_mcs") == 0) {
-          sys.mc.number_mcs =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "memory_channels_per_mc") == 0) {
-          sys.mc.memory_channels_per_mc =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "req_window_size_per_channel") == 0) {
-          sys.mc.req_window_size_per_channel =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "IO_buffer_size_per_channel") == 0) {
-          sys.mc.IO_buffer_size_per_channel =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "databus_width") == 0) {
-          sys.mc.databus_width =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "addressbus_width") == 0) {
-          sys.mc.addressbus_width =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "PRT_entries") == 0) {
-          sys.mc.PRT_entries =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "peak_transfer_rate") == 0) {
-          sys.mc.peak_transfer_rate =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "number_ranks") == 0) {
-          sys.mc.number_ranks =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "LVDS") == 0) {
-          sys.mc.LVDS =
-              (bool)atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "type") == 0) {
-          sys.mc.type =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "withPHY") == 0) {
-          sys.mc.withPHY =
-              (bool)atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "dram_cmd_coeff") == 0) {
-          sys.mc.dram_cmd_coeff =
-              atof(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "dram_act_coeff") == 0) {
-          sys.mc.dram_act_coeff =
-              atof(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "dram_nop_coeff") == 0) {
-          sys.mc.dram_nop_coeff =
-              atof(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "dram_activity_coeff") == 0) {
-          sys.mc.dram_activity_coeff =
-              atof(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "dram_pre_coeff") == 0) {
-          sys.mc.dram_pre_coeff =
-              atof(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "dram_rd_coeff") == 0) {
-          sys.mc.dram_rd_coeff =
-              atof(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "dram_wr_coeff") == 0) {
-          sys.mc.dram_wr_coeff =
-              atof(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "dram_req_coeff") == 0) {
-          sys.mc.dram_req_coeff =
-              atof(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "dram_const_coeff") == 0) {
-          sys.mc.dram_const_coeff =
-              atof(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-      }
-      itmp = xNode3.nChildNode("stat");
-      for (k = 0; k < itmp;
-           k++) {  // get all items of stat in system.mendirectory
-        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                   "memory_accesses") == 0) {
-          sys.mc.memory_accesses =
-              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                   "memory_reads") == 0) {
-          sys.mc.memory_reads =
-              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                   "memory_writes") == 0) {
-          sys.mc.memory_writes =
-              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                   "dram_pre") == 0) {
-          sys.mc.dram_pre =
-              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-          continue;
-        }
-      }
-    } else {
-      printf(
-          "some value(s) of "
-          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
-          "not correct!");
-      exit(0);
-    }
-    //__________________________________________Get
-    //system.niu____________________________________________
-    if (OrderofComponents_3layer > 0)
-      OrderofComponents_3layer = OrderofComponents_3layer + 1;
-    xNode3 = xNode2.getChildNode("component", OrderofComponents_3layer);
-    if (xNode3.isEmpty() == 1) {
-      printf(
-          "some value(s) of "
-          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
-          "not correct!");
-      exit(0);
-    }
-    if (strstr(xNode3.getAttribute("id"), "system.niu") != NULL) {
-      itmp = xNode3.nChildNode("param");
-      for (k = 0; k < itmp; k++) {  // get all items of param in system.mem
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "clockrate") == 0) {
-          sys.niu.clockrate =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "number_units") == 0) {
-          sys.niu.number_units =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "type") == 0) {
-          sys.niu.type =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-      }
-      itmp = xNode3.nChildNode("stat");
-      for (k = 0; k < itmp;
-           k++) {  // get all items of stat in system.mendirectory
-        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                   "duty_cycle") == 0) {
-          sys.niu.duty_cycle =
-              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                   "total_load_perc") == 0) {
-          sys.niu.total_load_perc =
-              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-          continue;
-        }
-      }
-    } else {
-      printf(
-          "some value(s) of "
-          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
-          "not correct!");
-      exit(0);
-    }
-
-    //__________________________________________Get
-    //system.pcie____________________________________________
-    if (OrderofComponents_3layer > 0)
-      OrderofComponents_3layer = OrderofComponents_3layer + 1;
-    xNode3 = xNode2.getChildNode("component", OrderofComponents_3layer);
-    if (xNode3.isEmpty() == 1) {
-      printf(
-          "some value(s) of "
-          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
-          "not correct!");
-      exit(0);
-    }
-    if (strstr(xNode3.getAttribute("id"), "system.pcie") != NULL) {
-      itmp = xNode3.nChildNode("param");
-      for (k = 0; k < itmp; k++) {  // get all items of param in system.mem
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "clockrate") == 0) {
-          sys.pcie.clockrate =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "number_units") == 0) {
-          sys.pcie.number_units =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "num_channels") == 0) {
-          sys.pcie.num_channels =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "type") == 0) {
-          sys.pcie.type =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "withPHY") == 0) {
-          sys.pcie.withPHY =
-              (bool)atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-      }
-      itmp = xNode3.nChildNode("stat");
-      for (k = 0; k < itmp;
-           k++) {  // get all items of stat in system.mendirectory
-        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                   "duty_cycle") == 0) {
-          sys.pcie.duty_cycle =
-              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                   "total_load_perc") == 0) {
-          sys.pcie.total_load_perc =
-              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-          continue;
-        }
-      }
-    } else {
-      printf(
-          "some value(s) of "
-          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
-          "not correct!");
-      exit(0);
-    }
-    //__________________________________________Get
-    //system.flashcontroller____________________________________________
-    if (OrderofComponents_3layer > 0)
-      OrderofComponents_3layer = OrderofComponents_3layer + 1;
-    xNode3 = xNode2.getChildNode("component", OrderofComponents_3layer);
-    if (xNode3.isEmpty() == 1) {
-      printf(
-          "some value(s) of "
-          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
-          "not correct!");
-      exit(0);
-    }
-    if (strstr(xNode3.getAttribute("id"), "system.flashc") != NULL) {
-      itmp = xNode3.nChildNode("param");
-      for (k = 0; k < itmp; k++) {  // get all items of param in system.mem
-        //				if
-        //(strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"flashc_clock")==0)
-        //{sys.flashc.mc_clock=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-        //				if
-        //(strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"block_size")==0)
-        //{sys.flashc.llc_line_length=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "number_flashcs") == 0) {
-          sys.flashc.number_mcs =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        //				if
-        //(strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"memory_channels_per_flashc")==0)
-        //{sys.flashc.memory_channels_per_mc=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-        //				if
-        //(strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"req_window_size_per_channel")==0)
-        //{sys.flashc.req_window_size_per_channel=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-        //				if
-        //(strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"IO_buffer_size_per_channel")==0)
-        //{sys.flashc.IO_buffer_size_per_channel=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-        //				if
-        //(strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"databus_width")==0)
-        //{sys.flashc.databus_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-        //				if
-        //(strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"addressbus_width")==0)
-        //{sys.flashc.addressbus_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "peak_transfer_rate") == 0) {
-          sys.flashc.peak_transfer_rate =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        //				if
-        //(strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_ranks")==0)
-        //{sys.flashc.number_ranks=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-        //				if
-        //(strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"LVDS")==0)
-        //{sys.flashc.LVDS=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "type") == 0) {
-          sys.flashc.type =
-              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
-                   "withPHY") == 0) {
-          sys.flashc.withPHY =
-              (bool)atoi(xNode3.getChildNode("param", k).getAttribute("value"));
-          continue;
-        }
-      }
-      itmp = xNode3.nChildNode("stat");
-      for (k = 0; k < itmp;
-           k++) {  // get all items of stat in system.mendirectory
-        //				if
-        //(strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_accesses")==0)
-        //{sys.flashc.memory_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-        //				if
-        //(strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_reads")==0)
-        //{sys.flashc.memory_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-        //				if
-        //(strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_writes")==0)
-        //{sys.flashc.memory_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                   "duty_cycle") == 0) {
-          sys.flashc.duty_cycle =
-              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-          continue;
-        }
-        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
-                   "total_load_perc") == 0) {
-          sys.flashc.total_load_perc =
-              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
-          continue;
-        }
-      }
-    } else {
-      printf(
-          "some value(s) of "
-          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
-          "not correct!");
-      exit(0);
-    }
-  }
-}
-void ParseXML::initialize()  // Initialize all
+void ParseXML::parse(char* filepath)
 {
-  // All number_of_* at the level of 'system' 03/21/2009
-  sys.number_of_cores = 1;
-  sys.architecture = 1;  // 1 - fermi
-  sys.number_of_L1Directories = 1;
-  sys.number_of_L2Directories = 1;
-  sys.number_of_L2s = 1;
-  sys.Private_L2 = false;
-  sys.number_of_L3s = 1;
-  sys.number_of_NoCs = 1;
-  // All params at the level of 'system'
-  // strcpy(sys.homogeneous_cores,"default");
-  sys.core_tech_node = 1;
-  sys.target_core_clockrate = 1;
-  sys.target_chip_area = 1;
-  sys.temperature = 1;
-  sys.number_cache_levels = 1;
-  sys.homogeneous_cores = 1;
-  sys.homogeneous_L1Directories = 1;
-  sys.homogeneous_L2Directories = 1;
-  sys.homogeneous_L2s = 1;
-  sys.homogeneous_L3s = 1;
-  sys.homogeneous_NoCs = 1;
-  sys.homogeneous_ccs = 1;
+	unsigned int i,j,k,m,n;
+	unsigned int NumofCom_4;
+	unsigned int itmp;
+	//Initialize all structures
+	ParseXML::initialize();
+	string strtmp;
+	char chtmp[60];
+	char chtmp1[60];
+	chtmp1[0]='\0';
+	// this open and parse the XML file:
+	XMLNode xMainNode=XMLNode::openFileHelper(filepath,"component"); //the 'component' in the first layer
 
-  sys.Max_area_deviation = 1;
-  sys.Max_power_deviation = 1;
-  sys.device_type = 1;
-  sys.longer_channel_device = true;
-  sys.Embedded = false;
-  sys.opt_dynamic_power = false;
-  sys.opt_lakage_power = false;
-  sys.opt_clockrate = true;
-  sys.opt_area = false;
-  sys.interconnect_projection_type = 1;
-  sys.idle_core_power = 0;
-  int i, j;
-  for (i = 0; i <= 63; i++) {
-    sys.scaling_coefficients[i] = 1;
-    sys.core[i].clock_rate = 1;
-    sys.core[i].opt_local = true;
-    sys.core[i].x86 = false;
-    sys.core[i].machine_bits = 1;
-    sys.core[i].virtual_address_width = 1;
-    sys.core[i].physical_address_width = 1;
-    sys.core[i].opcode_width = 1;
-    sys.core[i].micro_opcode_width = 1;
-    // strcpy(sys.core[i].machine_type,"default");
-    sys.core[i].internal_datapath_width = 1;
-    sys.core[i].number_hardware_threads = 1;
-    sys.core[i].fetch_width = 1;
-    sys.core[i].number_instruction_fetch_ports = 1;
-    sys.core[i].decode_width = 1;
-    sys.core[i].issue_width = 1;
-    sys.core[i].peak_issue_width = 1;
-    sys.core[i].commit_width = 1;
-    for (j = 0; j < 20; j++) sys.core[i].pipelines_per_core[j] = 1;
-    for (j = 0; j < 20; j++) sys.core[i].pipeline_depth[j] = 1;
-    strcpy(sys.core[i].FPU, "default");
-    strcpy(sys.core[i].divider_multiplier, "default");
-    sys.core[i].ALU_per_core = 1;
-    sys.core[i].FPU_per_core = 1.0;
-    sys.core[i].MUL_per_core = 1;
-    sys.core[i].instruction_buffer_size = 1;
-    sys.core[i].decoded_stream_buffer_size = 1;
-    // strcpy(sys.core[i].instruction_window_scheme,"default");
-    sys.core[i].instruction_window_size = 1;
-    sys.core[i].ROB_size = 1;
-    sys.core[i].archi_Regs_IRF_size = 1;
-    sys.core[i].archi_Regs_FRF_size = 1;
-    sys.core[i].phy_Regs_IRF_size = 1;
-    sys.core[i].phy_Regs_FRF_size = 1;
-    // strcpy(sys.core[i].rename_scheme,"default");
-    sys.core[i].register_windows_size = 1;
-    strcpy(sys.core[i].LSU_order, "default");
-    sys.core[i].store_buffer_size = 1;
-    sys.core[i].load_buffer_size = 1;
-    sys.core[i].memory_ports = 1;
-    strcpy(sys.core[i].Dcache_dual_pump, "default");
-    sys.core[i].RAS_size = 1;
-    // all stats at the level of system.core(0-n)
-    sys.core[i].total_instructions = 1;
-    sys.core[i].int_instructions = 1;
-    sys.core[i].fp_instructions = 1;
-    sys.core[i].branch_instructions = 1;
-    sys.core[i].branch_mispredictions = 1;
-    sys.core[i].committed_instructions = 1;
-    sys.core[i].load_instructions = 1;
-    sys.core[i].store_instructions = 1;
-    sys.core[i].total_cycles = 1;
-    sys.core[i].idle_cycles = 1;
-    sys.core[i].busy_cycles = 1;
-    sys.core[i].instruction_buffer_reads = 1;
-    sys.core[i].instruction_buffer_write = 1;
-    sys.core[i].ROB_reads = 1;
-    sys.core[i].ROB_writes = 1;
-    sys.core[i].rename_accesses = 1;
-    sys.core[i].inst_window_reads = 1;
-    sys.core[i].inst_window_writes = 1;
-    sys.core[i].inst_window_wakeup_accesses = 1;
-    sys.core[i].inst_window_selections = 1;
-    sys.core[i].archi_int_regfile_reads = 1;
-    sys.core[i].archi_float_regfile_reads = 1;
-    sys.core[i].phy_int_regfile_reads = 1;
-    sys.core[i].phy_float_regfile_reads = 1;
-    sys.core[i].windowed_reg_accesses = 1;
-    sys.core[i].windowed_reg_transports = 1;
-    sys.core[i].function_calls = 1;
-    sys.core[i].ialu_accesses = 1;
-    sys.core[i].fpu_accesses = 1;
-    sys.core[i].mul_accesses = 1;
-    sys.core[i].cdb_alu_accesses = 1;
-    sys.core[i].cdb_mul_accesses = 1;
-    sys.core[i].cdb_fpu_accesses = 1;
-    sys.core[i].load_buffer_reads = 1;
-    sys.core[i].load_buffer_writes = 1;
-    sys.core[i].load_buffer_cams = 1;
-    sys.core[i].store_buffer_reads = 1;
-    sys.core[i].store_buffer_writes = 1;
-    sys.core[i].store_buffer_cams = 1;
-    sys.core[i].store_buffer_forwards = 1;
-    sys.core[i].main_memory_access = 1;
-    sys.core[i].main_memory_read = 1;
-    sys.core[i].main_memory_write = 1;
-    sys.core[i].IFU_duty_cycle = 1;
-    sys.core[i].BR_duty_cycle = 1;
-    sys.core[i].LSU_duty_cycle = 1;
-    sys.core[i].MemManU_I_duty_cycle = 1;
-    sys.core[i].MemManU_D_duty_cycle = 1;
-    sys.core[i].ALU_duty_cycle = 1;
-    sys.core[i].MUL_duty_cycle = 1;
-    sys.core[i].FPU_duty_cycle = 1;
-    sys.core[i].ALU_cdb_duty_cycle = 1;
-    sys.core[i].MUL_cdb_duty_cycle = 1;
-    sys.core[i].FPU_cdb_duty_cycle = 1;
-    // system.core?.predictor
-    sys.core[i].predictor.prediction_width = 1;
-    strcpy(sys.core[i].predictor.prediction_scheme, "default");
-    sys.core[i].predictor.predictor_size = 1;
-    sys.core[i].predictor.predictor_entries = 1;
-    sys.core[i].predictor.local_predictor_entries = 1;
-    for (j = 0; j < 20; j++) sys.core[i].predictor.local_predictor_size[j] = 1;
-    sys.core[i].predictor.global_predictor_entries = 1;
-    sys.core[i].predictor.global_predictor_bits = 1;
-    sys.core[i].predictor.chooser_predictor_entries = 1;
-    sys.core[i].predictor.chooser_predictor_bits = 1;
-    sys.core[i].predictor.predictor_accesses = 1;
-    // system.core?.itlb
-    sys.core[i].itlb.number_entries = 1;
-    sys.core[i].itlb.total_hits = 1;
-    sys.core[i].itlb.total_accesses = 1;
-    sys.core[i].itlb.total_misses = 1;
-    // system.core?.icache
-    for (j = 0; j < 20; j++) sys.core[i].icache.icache_config[j] = 1;
-    // strcpy(sys.core[i].icache.buffer_sizes,"default");
-    sys.core[i].icache.total_accesses = 1;
-    sys.core[i].icache.read_accesses = 1;
-    sys.core[i].icache.read_misses = 1;
-    sys.core[i].icache.replacements = 1;
-    sys.core[i].icache.read_hits = 1;
-    sys.core[i].icache.total_hits = 1;
-    sys.core[i].icache.total_misses = 1;
-    sys.core[i].icache.miss_buffer_access = 1;
-    sys.core[i].icache.fill_buffer_accesses = 1;
-    sys.core[i].icache.prefetch_buffer_accesses = 1;
-    sys.core[i].icache.prefetch_buffer_writes = 1;
-    sys.core[i].icache.prefetch_buffer_reads = 1;
-    sys.core[i].icache.prefetch_buffer_hits = 1;
-    // system.core?.dtlb
-    sys.core[i].dtlb.number_entries = 1;
-    sys.core[i].dtlb.total_accesses = 1;
-    sys.core[i].dtlb.read_accesses = 1;
-    sys.core[i].dtlb.write_accesses = 1;
-    sys.core[i].dtlb.write_hits = 1;
-    sys.core[i].dtlb.read_hits = 1;
-    sys.core[i].dtlb.read_misses = 1;
-    sys.core[i].dtlb.write_misses = 1;
-    sys.core[i].dtlb.total_hits = 1;
-    sys.core[i].dtlb.total_misses = 1;
-    // system.core?.dcache
-    for (j = 0; j < 20; j++) sys.core[i].dcache.dcache_config[j] = 1;
-    // strcpy(sys.core[i].dcache.buffer_sizes,"default");
-    sys.core[i].dcache.total_accesses = 1;
-    sys.core[i].dcache.read_accesses = 1;
-    sys.core[i].dcache.write_accesses = 1;
-    sys.core[i].dcache.total_hits = 1;
-    sys.core[i].dcache.total_misses = 1;
-    sys.core[i].dcache.read_hits = 1;
-    sys.core[i].dcache.write_hits = 1;
-    sys.core[i].dcache.read_misses = 1;
-    sys.core[i].dcache.write_misses = 1;
-    sys.core[i].dcache.replacements = 1;
-    sys.core[i].dcache.write_backs = 1;
-    sys.core[i].dcache.miss_buffer_access = 1;
-    sys.core[i].dcache.fill_buffer_accesses = 1;
-    sys.core[i].dcache.prefetch_buffer_accesses = 1;
-    sys.core[i].dcache.prefetch_buffer_writes = 1;
-    sys.core[i].dcache.prefetch_buffer_reads = 1;
-    sys.core[i].dcache.prefetch_buffer_hits = 1;
-    sys.core[i].dcache.wbb_writes = 1;
-    sys.core[i].dcache.wbb_reads = 1;
-    // system.core?.BTB
-    for (j = 0; j < 20; j++) sys.core[i].BTB.BTB_config[j] = 1;
-    sys.core[i].BTB.total_accesses = 1;
-    sys.core[i].BTB.read_accesses = 1;
-    sys.core[i].BTB.write_accesses = 1;
-    sys.core[i].BTB.total_hits = 1;
-    sys.core[i].BTB.total_misses = 1;
-    sys.core[i].BTB.read_hits = 1;
-    sys.core[i].BTB.write_hits = 1;
-    sys.core[i].BTB.read_misses = 1;
-    sys.core[i].BTB.write_misses = 1;
-    sys.core[i].BTB.replacements = 1;
-  }
+	XMLNode xNode2=xMainNode.getChildNode("component"); // the 'component' in the second layer
+	//get all params in the second layer
+	itmp=xNode2.nChildNode("param");
+	for(i=0; i<itmp; i++)
+	{
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"GPU_Architecture")==0) {sys.GPU_Architecture=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"number_of_cores")==0) {sys.number_of_cores=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"architecture")==0) {sys.architecture=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"number_of_L1Directories")==0) {sys.number_of_L1Directories=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"number_of_L2Directories")==0) {sys.number_of_L2Directories=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"number_of_L2s")==0) {sys.number_of_L2s=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"Private_L2")==0) {sys.Private_L2=(bool)atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"number_of_L3s")==0) {sys.number_of_L3s=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"number_of_NoCs")==0) {sys.number_of_NoCs=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"number_of_dir_levels")==0) {sys.number_of_dir_levels=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"domain_size")==0) {sys.domain_size=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"first_level_dir")==0) {sys.first_level_dir=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"homogeneous_cores")==0) {sys.homogeneous_cores=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"core_tech_node")==0) {sys.core_tech_node=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"target_core_clockrate")==0) {sys.target_core_clockrate=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"target_chip_area")==0) {sys.target_chip_area=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"temperature")==0) {sys.temperature=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"number_cache_levels")==0) {sys.number_cache_levels=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"L1_property")==0) {sys.L1_property =atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"L2_property")==0) {sys.L2_property =atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"homogeneous_L2s")==0) {sys.homogeneous_L2s=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"homogeneous_L1Directories")==0) {sys.homogeneous_L1Directories=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"homogeneous_L2Directories")==0) {sys.homogeneous_L2Directories=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"L3_property")==0) {sys.L3_property =atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"homogeneous_L3s")==0) {sys.homogeneous_L3s=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"homogeneous_ccs")==0) {sys.homogeneous_ccs=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"homogeneous_NoCs")==0) {sys.homogeneous_NoCs=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"Max_area_deviation")==0) {sys.Max_area_deviation=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"Max_power_deviation")==0) {sys.Max_power_deviation=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"device_type")==0) {sys.device_type=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"longer_channel_device")==0) {sys.longer_channel_device=(bool)atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"opt_dynamic_power")==0) {sys.opt_dynamic_power=(bool)atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"opt_lakage_power")==0) {sys.opt_lakage_power=(bool)atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"opt_clockrate")==0) {sys.opt_clockrate=(bool)atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"opt_area")==0) {sys.opt_area=(bool)atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"Embedded")==0) {sys.Embedded=(bool)atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"interconnect_projection_type")==0) {sys.interconnect_projection_type=atoi(xNode2.getChildNode("param",i).getAttribute("value"))==0?0:1;continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"machine_bits")==0) {sys.machine_bits=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"virtual_address_width")==0) {sys.virtual_address_width=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"physical_address_width")==0) {sys.physical_address_width=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"virtual_memory_page_size")==0) {sys.virtual_memory_page_size=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"idle_core_power")==0) {sys.idle_core_power=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"TOT_INST")==0) {sys.scaling_coefficients[TOT_INST]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"FP_INT")==0) {sys.scaling_coefficients[FP_INT]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"IC_H")==0) {sys.scaling_coefficients[IC_H]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"IC_M")==0) {sys.scaling_coefficients[IC_M]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"DC_RH")==0) {sys.scaling_coefficients[DC_RH]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"DC_RM")==0) {sys.scaling_coefficients[DC_RM]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"DC_WH")==0) {sys.scaling_coefficients[DC_WH]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"DC_WM")==0) {sys.scaling_coefficients[DC_WM]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"TC_H")==0) {sys.scaling_coefficients[TC_H]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"TC_M")==0) {sys.scaling_coefficients[TC_M]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"CC_H")==0) {sys.scaling_coefficients[CC_H]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"CC_M")==0) {sys.scaling_coefficients[CC_M]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"SHRD_ACC")==0) {sys.scaling_coefficients[SHRD_ACC]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"REG_RD")==0) {sys.scaling_coefficients[REG_RD]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"REG_WR")==0) {sys.scaling_coefficients[REG_WR]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"NON_REG_OPs")==0) {sys.scaling_coefficients[NON_REG_OPs]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"SP_ACC")==0) {sys.scaling_coefficients[SP_ACC]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"SFU_ACC")==0) {sys.scaling_coefficients[SFU_ACC]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"FPU_ACC")==0) {sys.scaling_coefficients[FPU_ACC]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"MEM_RD")==0) {sys.scaling_coefficients[MEM_RD]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"MEM_WR")==0) {sys.scaling_coefficients[MEM_WR]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"MEM_PRE")==0) {sys.scaling_coefficients[MEM_PRE]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"L2_RH")==0) {sys.scaling_coefficients[L2_RH]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"L2_RM")==0) {sys.scaling_coefficients[L2_RM]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"L2_WH")==0) {sys.scaling_coefficients[L2_WH]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"L2_WM")==0) {sys.scaling_coefficients[L2_WM]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"NOC_A")==0) {sys.scaling_coefficients[NOC_A]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"PIPE_A")==0) {sys.scaling_coefficients[PIPE_A]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"IDLE_CORE_N")==0) {sys.scaling_coefficients[IDLE_CORE_N]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"CONST_DYNAMICN")==0) {sys.scaling_coefficients[CONST_DYNAMICN]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
 
-  // system_L1directory
-  for (i = 0; i <= 63; i++) {
-    for (j = 0; j < 20; j++) sys.L1Directory[i].Dir_config[j] = 1;
-    for (j = 0; j < 20; j++) sys.L1Directory[i].buffer_sizes[j] = 1;
-    sys.L1Directory[i].clockrate = 1;
-    sys.L1Directory[i].ports[20] = 1;
-    sys.L1Directory[i].device_type = 1;
-    strcpy(sys.L1Directory[i].threeD_stack, "default");
-    sys.L1Directory[i].total_accesses = 1;
-    sys.L1Directory[i].read_accesses = 1;
-    sys.L1Directory[i].write_accesses = 1;
-    sys.L1Directory[i].duty_cycle = 1;
-  }
-  // system_L2directory
-  for (i = 0; i <= 63; i++) {
-    for (j = 0; j < 20; j++) sys.L2Directory[i].Dir_config[j] = 1;
-    for (j = 0; j < 20; j++) sys.L2Directory[i].buffer_sizes[j] = 1;
-    sys.L2Directory[i].clockrate = 1;
-    sys.L2Directory[i].ports[20] = 1;
-    sys.L2Directory[i].device_type = 1;
-    strcpy(sys.L2Directory[i].threeD_stack, "default");
-    sys.L2Directory[i].total_accesses = 1;
-    sys.L2Directory[i].read_accesses = 1;
-    sys.L2Directory[i].write_accesses = 1;
-    sys.L2Directory[i].duty_cycle = 1;
-  }
-  for (i = 0; i <= 63; i++) {
-    // system_L2
-    for (j = 0; j < 20; j++) sys.L2[i].L2_config[j] = 1;
-    sys.L2[i].clockrate = 1;
-    for (j = 0; j < 20; j++) sys.L2[i].ports[j] = 1;
-    sys.L2[i].device_type = 1;
-    strcpy(sys.L2[i].threeD_stack, "default");
-    for (j = 0; j < 20; j++) sys.L2[i].buffer_sizes[j] = 1;
-    sys.L2[i].total_accesses = 1;
-    sys.L2[i].read_accesses = 1;
-    sys.L2[i].write_accesses = 1;
-    sys.L2[i].total_hits = 1;
-    sys.L2[i].total_misses = 1;
-    sys.L2[i].read_hits = 1;
-    sys.L2[i].write_hits = 1;
-    sys.L2[i].read_misses = 1;
-    sys.L2[i].write_misses = 1;
-    sys.L2[i].replacements = 1;
-    sys.L2[i].write_backs = 1;
-    sys.L2[i].miss_buffer_accesses = 1;
-    sys.L2[i].fill_buffer_accesses = 1;
-    sys.L2[i].prefetch_buffer_accesses = 1;
-    sys.L2[i].prefetch_buffer_writes = 1;
-    sys.L2[i].prefetch_buffer_reads = 1;
-    sys.L2[i].prefetch_buffer_hits = 1;
-    sys.L2[i].wbb_writes = 1;
-    sys.L2[i].wbb_reads = 1;
-    sys.L2[i].duty_cycle = 1;
-    sys.L2[i].merged_dir = false;
-    sys.L2[i].homenode_read_accesses = 1;
-    sys.L2[i].homenode_write_accesses = 1;
-    sys.L2[i].homenode_read_hits = 1;
-    sys.L2[i].homenode_write_hits = 1;
-    sys.L2[i].homenode_read_misses = 1;
-    sys.L2[i].homenode_write_misses = 1;
-    sys.L2[i].dir_duty_cycle = 1;
-  }
-  for (i = 0; i <= 63; i++) {
-    // system_L3
-    for (j = 0; j < 20; j++) sys.L3[i].L3_config[j] = 1;
-    sys.L3[i].clockrate = 1;
-    for (j = 0; j < 20; j++) sys.L3[i].ports[j] = 1;
-    sys.L3[i].device_type = 1;
-    strcpy(sys.L3[i].threeD_stack, "default");
-    for (j = 0; j < 20; j++) sys.L3[i].buffer_sizes[j] = 1;
-    sys.L3[i].total_accesses = 1;
-    sys.L3[i].read_accesses = 1;
-    sys.L3[i].write_accesses = 1;
-    sys.L3[i].total_hits = 1;
-    sys.L3[i].total_misses = 1;
-    sys.L3[i].read_hits = 1;
-    sys.L3[i].write_hits = 1;
-    sys.L3[i].read_misses = 1;
-    sys.L3[i].write_misses = 1;
-    sys.L3[i].replacements = 1;
-    sys.L3[i].write_backs = 1;
-    sys.L3[i].miss_buffer_accesses = 1;
-    sys.L3[i].fill_buffer_accesses = 1;
-    sys.L3[i].prefetch_buffer_accesses = 1;
-    sys.L3[i].prefetch_buffer_writes = 1;
-    sys.L3[i].prefetch_buffer_reads = 1;
-    sys.L3[i].prefetch_buffer_hits = 1;
-    sys.L3[i].wbb_writes = 1;
-    sys.L3[i].wbb_reads = 1;
-    sys.L3[i].duty_cycle = 1;
-    sys.L3[i].merged_dir = false;
-    sys.L3[i].homenode_read_accesses = 1;
-    sys.L3[i].homenode_write_accesses = 1;
-    sys.L3[i].homenode_read_hits = 1;
-    sys.L3[i].homenode_write_hits = 1;
-    sys.L3[i].homenode_read_misses = 1;
-    sys.L3[i].homenode_write_misses = 1;
-    sys.L3[i].dir_duty_cycle = 1;
-  }
-  // system_NoC
-  for (i = 0; i <= 63; i++) {
-    sys.NoC[i].clockrate = 1;
-    sys.NoC[i].type = true;
-    sys.NoC[i].chip_coverage = 1;
-    sys.NoC[i].has_global_link = true;
-    strcpy(sys.NoC[i].topology, "default");
-    sys.NoC[i].horizontal_nodes = 1;
-    sys.NoC[i].vertical_nodes = 1;
-    sys.NoC[i].input_ports = 1;
-    sys.NoC[i].output_ports = 1;
-    sys.NoC[i].virtual_channel_per_port = 1;
-    sys.NoC[i].flit_bits = 1;
-    sys.NoC[i].input_buffer_entries_per_vc = 1;
-    sys.NoC[i].total_accesses = 1;
-    sys.NoC[i].duty_cycle = 1;
-    sys.NoC[i].route_over_perc = 0.5;
-    for (j = 0; j < 20; j++) sys.NoC[i].ports_of_input_buffer[j] = 1;
-    sys.NoC[i].number_of_crossbars = 1;
-    strcpy(sys.NoC[i].crossbar_type, "default");
-    strcpy(sys.NoC[i].crosspoint_type, "default");
-    // system.NoC?.xbar0;
-    sys.NoC[i].xbar0.number_of_inputs_of_crossbars = 1;
-    sys.NoC[i].xbar0.number_of_outputs_of_crossbars = 1;
-    sys.NoC[i].xbar0.flit_bits = 1;
-    sys.NoC[i].xbar0.input_buffer_entries_per_port = 1;
-    sys.NoC[i].xbar0.ports_of_input_buffer[20] = 1;
-    sys.NoC[i].xbar0.crossbar_accesses = 1;
-  }
-  // system_mem
-  sys.mem.mem_tech_node = 1;
-  sys.mem.device_clock = 1;
-  sys.mem.capacity_per_channel = 1;
-  sys.mem.number_ranks = 1;
-  sys.mem.peak_transfer_rate = 1;
-  sys.mem.num_banks_of_DRAM_chip = 1;
-  sys.mem.Block_width_of_DRAM_chip = 1;
-  sys.mem.output_width_of_DRAM_chip = 1;
-  sys.mem.page_size_of_DRAM_chip = 1;
-  sys.mem.burstlength_of_DRAM_chip = 1;
-  sys.mem.internal_prefetch_of_DRAM_chip = 1;
-  sys.mem.memory_accesses = 1;
-  sys.mem.memory_reads = 1;
-  sys.mem.memory_writes = 1;
+/*
+		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"scaling_coefficients")==0)
+		{
+			strtmp.assign(xNode2.getChildNode("param",i).getAttribute("value"));
+			m=0;
+			for(n=0; n<strtmp.length(); n++)
+			{
+				if (strtmp[n]!=',')
+				{
+					sprintf(chtmp,"%c",strtmp[n]);
+					strcat(chtmp1,chtmp);
+				}
+				else{
+					sys.scaling_coefficients[m]=atof(chtmp1);
+					m++;
+					chtmp1[0]='\0';
+				}
+			}
+			sys.scaling_coefficients[m]=atof(chtmp1);
+			m++;
+			chtmp1[0]='\0';
+			continue;
+		}
+*/
+	}
 
-  // system_mc
-  sys.mc.mc_clock = 1;
-  sys.mc.number_mcs = 1;
-  sys.mc.peak_transfer_rate = 1;
-  sys.mc.memory_channels_per_mc = 1;
-  sys.mc.number_ranks = 1;
-  sys.mc.req_window_size_per_channel = 1;
-  sys.mc.IO_buffer_size_per_channel = 1;
-  sys.mc.databus_width = 1;
-  sys.mc.addressbus_width = 1;
-  sys.mc.memory_accesses = 1;
-  sys.mc.memory_reads = 1;
-  sys.mc.memory_writes = 1;
-  sys.mc.LVDS = true;
-  sys.mc.type = 1;
+//	if (sys.Private_L2 && sys.number_of_cores!=sys.number_of_L2s)
+//	{
+//		cout<<"Private L2: Number of L2s must equal to Number of Cores"<<endl;
+//		exit(0);
+//	}
 
-  // system_niu
-  sys.niu.clockrate = 1;
-  sys.niu.number_units = 1;
-  sys.niu.type = 1;
-  sys.niu.duty_cycle = 1;
-  sys.niu.total_load_perc = 1;
-  // system_pcie
-  sys.pcie.clockrate = 1;
-  sys.pcie.number_units = 1;
-  sys.pcie.num_channels = 1;
-  sys.pcie.type = 1;
-  sys.pcie.withPHY = false;
-  sys.pcie.duty_cycle = 1;
-  sys.pcie.total_load_perc = 1;
-  // system_flash_controller
-  sys.flashc.mc_clock = 1;
-  sys.flashc.number_mcs = 1;
-  sys.flashc.peak_transfer_rate = 1;
-  sys.flashc.memory_channels_per_mc = 1;
-  sys.flashc.number_ranks = 1;
-  sys.flashc.req_window_size_per_channel = 1;
-  sys.flashc.IO_buffer_size_per_channel = 1;
-  sys.flashc.databus_width = 1;
-  sys.flashc.addressbus_width = 1;
-  sys.flashc.memory_accesses = 1;
-  sys.flashc.memory_reads = 1;
-  sys.flashc.memory_writes = 1;
-  sys.flashc.LVDS = true;
-  sys.flashc.withPHY = false;
-  sys.flashc.type = 1;
-  sys.flashc.duty_cycle = 1;
-  sys.flashc.total_load_perc = 1;
+	itmp=xNode2.nChildNode("stat");
+	for(i=0; i<itmp; i++)
+	{
+		if (strcmp(xNode2.getChildNode("stat",i).getAttribute("name"),"total_cycles")==0) {sys.total_cycles=atof(xNode2.getChildNode("stat",i).getAttribute("value"));continue;}
+		if (strcmp(xNode2.getChildNode("stat",i).getAttribute("name"),"num_idle_cores")==0) {sys.num_idle_cores=atoi(xNode2.getChildNode("stat",i).getAttribute("value"));continue;}
+
+	}
+
+
+
+	//get the number of components within the second layer
+	unsigned int NumofCom_3=xNode2.nChildNode("component");
+	XMLNode xNode3,xNode4; //define the third-layer(system.core0) and fourth-layer(system.core0.predictor) xnodes
+
+
+	unsigned int OrderofComponents_3layer=0;
+	if (NumofCom_3>OrderofComponents_3layer)
+	{
+		//___________________________get all system.core0-n________________________________________________
+		if (sys.homogeneous_cores==1) OrderofComponents_3layer=0;
+		else OrderofComponents_3layer=sys.number_of_cores-1;
+		for (i=0; i<=OrderofComponents_3layer; i++)
+		{
+			xNode3=xNode2.getChildNode("component",i);
+			if (xNode3.isEmpty()==1) {
+				printf("The value of homogeneous_cores or number_of_cores is not correct!");
+				exit(0);
+			}
+			else{
+				if (strstr(xNode3.getAttribute("name"),"core")!=NULL)
+				{
+					{ //For cpu0-cpui
+						//Get all params with system.core?
+						itmp=xNode3.nChildNode("param");
+						for(k=0; k<itmp; k++)
+						{
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"clock_rate")==0) {sys.core[i].clock_rate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"opt_local")==0) {sys.core[i].opt_local=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"x86")==0) {sys.core[i].x86=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"machine_bits")==0) {sys.core[i].machine_bits=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"virtual_address_width")==0) {sys.core[i].virtual_address_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"physical_address_width")==0) {sys.core[i].physical_address_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"instruction_length")==0) {sys.core[i].instruction_length=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"opcode_width")==0) {sys.core[i].opcode_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"micro_opcode_width")==0) {sys.core[i].micro_opcode_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"machine_type")==0) {sys.core[i].machine_type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"internal_datapath_width")==0) {sys.core[i].internal_datapath_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_hardware_threads")==0) {sys.core[i].number_hardware_threads=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"fetch_width")==0) {sys.core[i].fetch_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_instruction_fetch_ports")==0) {sys.core[i].number_instruction_fetch_ports=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"decode_width")==0) {sys.core[i].decode_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"issue_width")==0) {sys.core[i].issue_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"peak_issue_width")==0) {sys.core[i].peak_issue_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"commit_width")==0) {sys.core[i].commit_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"fp_issue_width")==0) {sys.core[i].fp_issue_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"prediction_width")==0) {sys.core[i].prediction_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"pipelines_per_core")==0)
+							{
+								strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
+								m=0;
+								for(n=0; n<strtmp.length(); n++)
+								{
+									if (strtmp[n]!=',')
+									{
+										sprintf(chtmp,"%c",strtmp[n]);
+										strcat(chtmp1,chtmp);
+									}
+									else{
+										sys.core[i].pipelines_per_core[m]=atoi(chtmp1);
+										m++;
+										chtmp1[0]='\0';
+									}
+								}
+								sys.core[i].pipelines_per_core[m]=atoi(chtmp1);
+								m++;
+								chtmp1[0]='\0';
+								continue;
+							}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"pipeline_depth")==0)
+							{
+								strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
+								m=0;
+								for(n=0; n<strtmp.length(); n++)
+								{
+									if (strtmp[n]!=',')
+									{
+										sprintf(chtmp,"%c",strtmp[n]);
+										strcat(chtmp1,chtmp);
+									}
+									else{
+										sys.core[i].pipeline_depth[m]=atoi(chtmp1);
+										m++;
+										chtmp1[0]='\0';
+									}
+								}
+								sys.core[i].pipeline_depth[m]=atoi(chtmp1);
+								m++;
+								chtmp1[0]='\0';
+								continue;
+							}
+
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"FPU")==0) {strcpy(sys.core[i].FPU,xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"divider_multiplier")==0) {strcpy(sys.core[i].divider_multiplier,xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"ALU_per_core")==0) {sys.core[i].ALU_per_core=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"FPU_per_core")==0) {sys.core[i].FPU_per_core=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"MUL_per_core")==0) {sys.core[i].MUL_per_core=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"instruction_buffer_size")==0) {sys.core[i].instruction_buffer_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"decoded_stream_buffer_size")==0) {sys.core[i].decoded_stream_buffer_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"instruction_window_scheme")==0) {sys.core[i].instruction_window_scheme  =atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"instruction_window_size")==0) {sys.core[i].instruction_window_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"fp_instruction_window_size")==0) {sys.core[i].fp_instruction_window_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"ROB_size")==0) {sys.core[i].ROB_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"rf_banks")==0) {sys.core[i].rf_banks=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"simd_width")==0) {sys.core[i].simd_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"collector_units")==0) {sys.core[i].collector_units=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"core_clock_ratio")==0) {sys.core[i].core_clock_ratio=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"warp_size")==0) {sys.core[i].warp_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"archi_Regs_IRF_size")==0) {sys.core[i].archi_Regs_IRF_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"archi_Regs_FRF_size")==0) {sys.core[i].archi_Regs_FRF_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"phy_Regs_IRF_size")==0) {sys.core[i].phy_Regs_IRF_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"phy_Regs_FRF_size")==0) {sys.core[i].phy_Regs_FRF_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"rename_scheme")==0) {sys.core[i].rename_scheme=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"register_windows_size")==0) {sys.core[i].register_windows_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"LSU_order")==0) {strcpy(sys.core[i].LSU_order,xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"store_buffer_size")==0) {sys.core[i].store_buffer_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"load_buffer_size")==0) {sys.core[i].load_buffer_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"memory_ports")==0) {sys.core[i].memory_ports=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"Dcache_dual_pump")==0) {strcpy(sys.core[i].Dcache_dual_pump,xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"RAS_size")==0) {sys.core[i].RAS_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+						}
+						//Get all stats with system.core?
+						itmp=xNode3.nChildNode("stat");
+						for(k=0; k<itmp; k++)
+						{
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_instructions")==0) {sys.core[i].total_instructions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"int_instructions")==0) {sys.core[i].int_instructions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"fp_instructions")==0) {sys.core[i].fp_instructions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"branch_instructions")==0) {sys.core[i].branch_instructions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"branch_mispredictions")==0) {sys.core[i].branch_mispredictions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"committed_instructions")==0) {sys.core[i].committed_instructions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"committed_int_instructions")==0) {sys.core[i].committed_int_instructions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"committed_fp_instructions")==0) {sys.core[i].committed_fp_instructions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"load_instructions")==0) {sys.core[i].load_instructions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"store_instructions")==0) {sys.core[i].store_instructions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_cycles")==0) {sys.core[i].total_cycles=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"idle_cycles")==0) {sys.core[i].idle_cycles=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"busy_cycles")==0) {sys.core[i].busy_cycles=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"instruction_buffer_reads")==0) {sys.core[i].instruction_buffer_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"instruction_buffer_write")==0) {sys.core[i].instruction_buffer_write=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"ROB_reads")==0) {sys.core[i].ROB_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"ROB_writes")==0) {sys.core[i].ROB_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"rename_reads")==0) {sys.core[i].rename_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"rename_writes")==0) {sys.core[i].rename_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"fp_rename_reads")==0) {sys.core[i].fp_rename_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"fp_rename_writes")==0) {sys.core[i].fp_rename_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"inst_window_reads")==0) {sys.core[i].inst_window_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"inst_window_writes")==0) {sys.core[i].inst_window_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"inst_window_wakeup_accesses")==0) {sys.core[i].inst_window_wakeup_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"inst_window_selections")==0) {sys.core[i].inst_window_selections=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"fp_inst_window_reads")==0) {sys.core[i].fp_inst_window_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"fp_inst_window_writes")==0) {sys.core[i].fp_inst_window_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"fp_inst_window_wakeup_accesses")==0) {sys.core[i].fp_inst_window_wakeup_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"archi_int_regfile_reads")==0) {sys.core[i].archi_int_regfile_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"archi_float_regfile_reads")==0) {sys.core[i].archi_float_regfile_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"phy_int_regfile_reads")==0) {sys.core[i].phy_int_regfile_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"phy_float_regfile_reads")==0) {sys.core[i].phy_float_regfile_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"phy_int_regfile_writes")==0) {sys.core[i].archi_int_regfile_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"phy_float_regfile_writes")==0) {sys.core[i].archi_float_regfile_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"archi_int_regfile_writes")==0) {sys.core[i].phy_int_regfile_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"archi_float_regfile_writes")==0) {sys.core[i].phy_float_regfile_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"int_regfile_reads")==0) {sys.core[i].int_regfile_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"float_regfile_reads")==0) {sys.core[i].float_regfile_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"int_regfile_writes")==0) {sys.core[i].int_regfile_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"float_regfile_writes")==0) {sys.core[i].float_regfile_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"non_rf_operands")==0) {sys.core[i].non_rf_operands=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+
+
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"windowed_reg_accesses")==0) {sys.core[i].windowed_reg_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"windowed_reg_transports")==0) {sys.core[i].windowed_reg_transports=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"function_calls")==0) {sys.core[i].function_calls=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"context_switches")==0) {sys.core[i].context_switches=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"ialu_accesses")==0) {sys.core[i].ialu_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"fpu_accesses")==0) {sys.core[i].fpu_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"mul_accesses")==0) {sys.core[i].mul_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"cdb_alu_accesses")==0) {sys.core[i].cdb_alu_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"cdb_mul_accesses")==0) {sys.core[i].cdb_mul_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"cdb_fpu_accesses")==0) {sys.core[i].cdb_fpu_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"load_buffer_reads")==0) {sys.core[i].load_buffer_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"load_buffer_writes")==0) {sys.core[i].load_buffer_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"load_buffer_cams")==0) {sys.core[i].load_buffer_cams=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"store_buffer_reads")==0) {sys.core[i].store_buffer_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"store_buffer_writes")==0) {sys.core[i].store_buffer_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"store_buffer_cams")==0) {sys.core[i].store_buffer_cams=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"store_buffer_forwards")==0) {sys.core[i].store_buffer_forwards=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"main_memory_access")==0) {sys.core[i].main_memory_access=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"main_memory_read")==0) {sys.core[i].main_memory_read=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"main_memory_write")==0) {sys.core[i].main_memory_write=atoi(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"pipeline_duty_cycle")==0) {sys.core[i].pipeline_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"IFU_duty_cycle")==0) {sys.core[i].IFU_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"BR_duty_cycle")==0) {sys.core[i].BR_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"LSU_duty_cycle")==0) {sys.core[i].LSU_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"MemManU_I_duty_cycle")==0) {sys.core[i].MemManU_I_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"MemManU_D_duty_cycle")==0) {sys.core[i].MemManU_D_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"ALU_duty_cycle")==0) {sys.core[i].ALU_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"MUL_duty_cycle")==0) {sys.core[i].MUL_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"FPU_duty_cycle")==0) {sys.core[i].FPU_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"ALU_cdb_duty_cycle")==0) {sys.core[i].ALU_cdb_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"MUL_cdb_duty_cycle")==0) {sys.core[i].MUL_cdb_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"FPU_cdb_duty_cycle")==0) {sys.core[i].FPU_cdb_duty_cycle=atoi(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+						}
+					}
+
+					NumofCom_4=xNode3.nChildNode("component"); //get the number of components within the third layer
+					for(j=0; j<NumofCom_4; j++)
+					{
+						xNode4=xNode3.getChildNode("component",j);
+						if (strcmp(xNode4.getAttribute("name"),"PBT")==0)
+						{ //find PBT
+							itmp=xNode4.nChildNode("param");
+							for(k=0; k<itmp; k++)
+							{ //get all items of param in system.core0.predictor--PBT
+								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"prediction_width")==0) {sys.core[i].predictor.prediction_width=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"prediction_scheme")==0) {strcpy(sys.core[i].predictor.prediction_scheme,xNode4.getChildNode("param",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"predictor_size")==0) {sys.core[i].predictor.predictor_size=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"predictor_entries")==0) {sys.core[i].predictor.predictor_entries=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"local_predictor_size")==0)
+								{
+									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
+									m=0;
+									for(n=0; n<strtmp.length(); n++)
+									{
+										if (strtmp[n]!=',')
+										{
+											sprintf(chtmp,"%c",strtmp[n]);
+											strcat(chtmp1,chtmp);
+										}
+										else{
+											sys.core[i].predictor.local_predictor_size[m]=atoi(chtmp1);
+											m++;
+											chtmp1[0]='\0';
+										}
+									}
+									sys.core[i].predictor.local_predictor_size[m]=atoi(chtmp1);
+									m++;
+									chtmp1[0]='\0';
+									continue;
+								}
+								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"local_predictor_entries")==0) {sys.core[i].predictor.local_predictor_entries=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"global_predictor_entries")==0) {sys.core[i].predictor.global_predictor_entries=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"global_predictor_bits")==0) {sys.core[i].predictor.global_predictor_bits=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"chooser_predictor_entries")==0) {sys.core[i].predictor.chooser_predictor_entries=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"chooser_predictor_bits")==0) {sys.core[i].predictor.chooser_predictor_bits=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
+							}
+							itmp=xNode4.nChildNode("stat");
+							for(k=0; k<itmp; k++)
+							{ //get all items of stat in system.core0.predictor--PBT
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"predictor_accesses")==0) sys.core[i].predictor.predictor_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));
+							}
+						}
+						if (strcmp(xNode4.getAttribute("name"),"itlb")==0)
+						{//find system.core0.itlb
+							itmp=xNode4.nChildNode("param");
+							for(k=0; k<itmp; k++)
+							{ //get all items of param in system.core0.itlb--itlb
+								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"number_entries")==0) sys.core[i].itlb.number_entries=atoi(xNode4.getChildNode("param",k).getAttribute("value"));
+							}
+							itmp=xNode4.nChildNode("stat");
+							for(k=0; k<itmp; k++)
+							{ //get all items of stat in itlb
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.core[i].itlb.total_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.core[i].itlb.total_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.core[i].itlb.total_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.core[i].itlb.conflicts=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+							}
+						}
+						if (strcmp(xNode4.getAttribute("name"),"icache")==0)
+						{//find system.core0.icache
+							itmp=xNode4.nChildNode("param");
+							for(k=0; k<itmp; k++)
+							{ //get all items of param in system.core0.icache--icache
+								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"icache_config")==0)
+								{
+									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
+									m=0;
+									for(n=0; n<strtmp.length(); n++)
+									{
+										if (strtmp[n]!=',')
+										{
+											sprintf(chtmp,"%c",strtmp[n]);
+											strcat(chtmp1,chtmp);
+										}
+										else{
+											sys.core[i].icache.icache_config[m]=atof(chtmp1);
+											m++;
+											chtmp1[0]='\0';
+										}
+									}
+									sys.core[i].icache.icache_config[m]=atof(chtmp1);
+									m++;
+									chtmp1[0]='\0';
+									continue;
+								}
+								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"buffer_sizes")==0)
+								{
+									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
+									m=0;
+									for(n=0; n<strtmp.length(); n++)
+									{
+										if (strtmp[n]!=',')
+										{
+											sprintf(chtmp,"%c",strtmp[n]);
+											strcat(chtmp1,chtmp);
+										}
+										else{
+											sys.core[i].icache.buffer_sizes[m]=atoi(chtmp1);
+											m++;
+											chtmp1[0]='\0';
+										}
+									}
+									sys.core[i].icache.buffer_sizes[m]=atoi(chtmp1);
+									m++;
+									chtmp1[0]='\0';
+								}
+							}
+							itmp=xNode4.nChildNode("stat");
+							for(k=0; k<itmp; k++)
+							{
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.core[i].icache.total_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.core[i].icache.read_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.core[i].icache.read_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"replacements")==0) {sys.core[i].icache.replacements=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_hits")==0) {sys.core[i].icache.read_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.core[i].icache.total_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.core[i].icache.total_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"miss_buffer_access")==0) {sys.core[i].icache.miss_buffer_access=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"fill_buffer_accesses")==0) {sys.core[i].icache.fill_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_accesses")==0) {sys.core[i].icache.prefetch_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_writes")==0) {sys.core[i].icache.prefetch_buffer_writes=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_reads")==0) {sys.core[i].icache.prefetch_buffer_reads=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_hits")==0) {sys.core[i].icache.prefetch_buffer_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.core[i].icache.conflicts=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+							}
+						}
+						if (strcmp(xNode4.getAttribute("name"),"dtlb")==0)
+						{//find system.core0.dtlb
+							itmp=xNode4.nChildNode("param");
+							for(k=0; k<itmp; k++)
+							{ //get all items of param in system.core0.dtlb--dtlb
+								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"number_entries")==0) sys.core[i].dtlb.number_entries=atoi(xNode4.getChildNode("param",k).getAttribute("value"));
+							}
+							itmp=xNode4.nChildNode("stat");
+							for(k=0; k<itmp; k++)
+							{ //get all items of stat in dtlb
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.core[i].dtlb.total_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.core[i].dtlb.read_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.core[i].dtlb.write_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_hits")==0) {sys.core[i].dtlb.read_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_hits")==0) {sys.core[i].dtlb.write_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.core[i].dtlb.read_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.core[i].dtlb.write_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.core[i].dtlb.total_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.core[i].dtlb.total_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.core[i].dtlb.conflicts=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+
+							}
+						}
+
+// Added by Jingwen
+						if (strcmp(xNode4.getAttribute("name"),"ccache")==0)
+						{//find system.core0.ccache
+							itmp=xNode4.nChildNode("param");
+							for(k=0; k<itmp; k++)
+							{ //get all items of param in system.core0.ccache--ccache
+								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"ccache_config")==0)
+								{
+									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
+									m=0;
+									for(n=0; n<strtmp.length(); n++)
+									{
+										if (strtmp[n]!=',')
+										{
+											sprintf(chtmp,"%c",strtmp[n]);
+											strcat(chtmp1,chtmp);
+										}
+										else{
+											sys.core[i].ccache.dcache_config[m]=atof(chtmp1);
+											m++;
+											chtmp1[0]='\0';
+										}
+									}
+									sys.core[i].ccache.dcache_config[m]=atof(chtmp1);
+									m++;
+									chtmp1[0]='\0';
+									continue;
+								}
+								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"buffer_sizes")==0)
+								{
+									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
+									m=0;
+									for(n=0; n<strtmp.length(); n++)
+									{
+										if (strtmp[n]!=',')
+										{
+											sprintf(chtmp,"%c",strtmp[n]);
+											strcat(chtmp1,chtmp);
+										}
+										else{
+											sys.core[i].ccache.buffer_sizes[m]=atoi(chtmp1);
+											m++;
+											chtmp1[0]='\0';
+										}
+									}
+									sys.core[i].ccache.buffer_sizes[m]=atoi(chtmp1);
+									m++;
+									chtmp1[0]='\0';
+								}
+							}
+							itmp=xNode4.nChildNode("stat");
+							for(k=0; k<itmp; k++)
+							{ //get all items of stat in ccache
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.core[i].ccache.total_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.core[i].ccache.read_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.core[i].ccache.write_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.core[i].ccache.total_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.core[i].ccache.total_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_hits")==0) {sys.core[i].ccache.read_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_hits")==0) {sys.core[i].ccache.write_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.core[i].ccache.read_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.core[i].ccache.write_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"replacements")==0) {sys.core[i].ccache.replacements=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_backs")==0) {sys.core[i].ccache.write_backs=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"miss_buffer_access")==0) {sys.core[i].ccache.miss_buffer_access=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"fill_buffer_accesses")==0) {sys.core[i].ccache.fill_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_accesses")==0) {sys.core[i].ccache.prefetch_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_writes")==0) {sys.core[i].ccache.prefetch_buffer_writes=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_reads")==0) {sys.core[i].ccache.prefetch_buffer_reads=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_hits")==0) {sys.core[i].ccache.prefetch_buffer_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"wbb_writes")==0) {sys.core[i].ccache.wbb_writes=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"wbb_reads")==0) {sys.core[i].ccache.wbb_reads=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.core[i].ccache.conflicts=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+
+							}
+						}
+
+            //tcache
+						if (strcmp(xNode4.getAttribute("name"),"tcache")==0)
+						{//find system.core0.tcache
+							itmp=xNode4.nChildNode("param");
+							for(k=0; k<itmp; k++)
+							{ //get all items of param in system.core0.tcache--tcache
+								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"tcache_config")==0)
+								{
+									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
+									m=0;
+									for(n=0; n<strtmp.length(); n++)
+									{
+										if (strtmp[n]!=',')
+										{
+											sprintf(chtmp,"%c",strtmp[n]);
+											strcat(chtmp1,chtmp);
+										}
+										else{
+											sys.core[i].tcache.dcache_config[m]=atof(chtmp1);
+											m++;
+											chtmp1[0]='\0';
+										}
+									}
+									sys.core[i].tcache.dcache_config[m]=atof(chtmp1);
+									m++;
+									chtmp1[0]='\0';
+									continue;
+								}
+								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"buffer_sizes")==0)
+								{
+									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
+									m=0;
+									for(n=0; n<strtmp.length(); n++)
+									{
+										if (strtmp[n]!=',')
+										{
+											sprintf(chtmp,"%c",strtmp[n]);
+											strcat(chtmp1,chtmp);
+										}
+										else{
+											sys.core[i].tcache.buffer_sizes[m]=atoi(chtmp1);
+											m++;
+											chtmp1[0]='\0';
+										}
+									}
+									sys.core[i].tcache.buffer_sizes[m]=atoi(chtmp1);
+									m++;
+									chtmp1[0]='\0';
+								}
+							}
+							itmp=xNode4.nChildNode("stat");
+							for(k=0; k<itmp; k++)
+							{ //get all items of stat in tcache
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.core[i].tcache.total_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.core[i].tcache.read_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.core[i].tcache.write_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.core[i].tcache.total_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.core[i].tcache.total_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_hits")==0) {sys.core[i].tcache.read_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_hits")==0) {sys.core[i].tcache.write_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.core[i].tcache.read_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.core[i].tcache.write_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"replacements")==0) {sys.core[i].tcache.replacements=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_backs")==0) {sys.core[i].tcache.write_backs=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"miss_buffer_access")==0) {sys.core[i].tcache.miss_buffer_access=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"fill_buffer_accesses")==0) {sys.core[i].tcache.fill_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_accesses")==0) {sys.core[i].tcache.prefetch_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_writes")==0) {sys.core[i].tcache.prefetch_buffer_writes=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_reads")==0) {sys.core[i].tcache.prefetch_buffer_reads=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_hits")==0) {sys.core[i].tcache.prefetch_buffer_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"wbb_writes")==0) {sys.core[i].tcache.wbb_writes=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"wbb_reads")==0) {sys.core[i].tcache.wbb_reads=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.core[i].tcache.conflicts=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+
+							}
+						}
+
+
+						if (strcmp(xNode4.getAttribute("name"),"sharedmemory")==0)
+						{//find system.core0.sharedmemory
+							itmp=xNode4.nChildNode("param");
+							for(k=0; k<itmp; k++)
+							{ //get all items of param in system.core0.sharedmemory--sharedmemory
+								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"sharedmemory_config")==0)
+								{
+									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
+									m=0;
+									for(n=0; n<strtmp.length(); n++)
+									{
+										if (strtmp[n]!=',')
+										{
+											sprintf(chtmp,"%c",strtmp[n]);
+											strcat(chtmp1,chtmp);
+										}
+										else{
+											sys.core[i].sharedmemory.dcache_config[m]=atof(chtmp1);
+											m++;
+											chtmp1[0]='\0';
+										}
+									}
+									sys.core[i].sharedmemory.dcache_config[m]=atof(chtmp1);
+									m++;
+									chtmp1[0]='\0';
+									continue;
+								}
+								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"buffer_sizes")==0)
+								{
+									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
+									m=0;
+									for(n=0; n<strtmp.length(); n++)
+									{
+										if (strtmp[n]!=',')
+										{
+											sprintf(chtmp,"%c",strtmp[n]);
+											strcat(chtmp1,chtmp);
+										}
+										else{
+											sys.core[i].sharedmemory.buffer_sizes[m]=atoi(chtmp1);
+											m++;
+											chtmp1[0]='\0';
+										}
+									}
+									sys.core[i].sharedmemory.buffer_sizes[m]=atoi(chtmp1);
+									m++;
+									chtmp1[0]='\0';
+								}
+							}
+							itmp=xNode4.nChildNode("stat");
+							for(k=0; k<itmp; k++)
+							{ //get all items of stat in sharedmemory
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.core[i].sharedmemory.total_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.core[i].sharedmemory.read_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.core[i].sharedmemory.write_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.core[i].sharedmemory.total_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.core[i].sharedmemory.total_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_hits")==0) {sys.core[i].sharedmemory.read_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_hits")==0) {sys.core[i].sharedmemory.write_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.core[i].sharedmemory.read_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.core[i].sharedmemory.write_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"replacements")==0) {sys.core[i].sharedmemory.replacements=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_backs")==0) {sys.core[i].sharedmemory.write_backs=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"miss_buffer_access")==0) {sys.core[i].sharedmemory.miss_buffer_access=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"fill_buffer_accesses")==0) {sys.core[i].sharedmemory.fill_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_accesses")==0) {sys.core[i].sharedmemory.prefetch_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_writes")==0) {sys.core[i].sharedmemory.prefetch_buffer_writes=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_reads")==0) {sys.core[i].sharedmemory.prefetch_buffer_reads=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_hits")==0) {sys.core[i].sharedmemory.prefetch_buffer_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"wbb_writes")==0) {sys.core[i].sharedmemory.wbb_writes=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"wbb_reads")==0) {sys.core[i].sharedmemory.wbb_reads=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.core[i].sharedmemory.conflicts=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+
+							}
+						}
+
+
+						if (strcmp(xNode4.getAttribute("name"),"dcache")==0)
+						{//find system.core0.dcache
+							itmp=xNode4.nChildNode("param");
+							for(k=0; k<itmp; k++)
+							{ //get all items of param in system.core0.dcache--dcache
+								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"dcache_config")==0)
+								{
+									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
+									m=0;
+									for(n=0; n<strtmp.length(); n++)
+									{
+										if (strtmp[n]!=',')
+										{
+											sprintf(chtmp,"%c",strtmp[n]);
+											strcat(chtmp1,chtmp);
+										}
+										else{
+											sys.core[i].dcache.dcache_config[m]=atof(chtmp1);
+											m++;
+											chtmp1[0]='\0';
+										}
+									}
+									sys.core[i].dcache.dcache_config[m]=atof(chtmp1);
+									m++;
+									chtmp1[0]='\0';
+									continue;
+								}
+								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"buffer_sizes")==0)
+								{
+									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
+									m=0;
+									for(n=0; n<strtmp.length(); n++)
+									{
+										if (strtmp[n]!=',')
+										{
+											sprintf(chtmp,"%c",strtmp[n]);
+											strcat(chtmp1,chtmp);
+										}
+										else{
+											sys.core[i].dcache.buffer_sizes[m]=atoi(chtmp1);
+											m++;
+											chtmp1[0]='\0';
+										}
+									}
+									sys.core[i].dcache.buffer_sizes[m]=atoi(chtmp1);
+									m++;
+									chtmp1[0]='\0';
+								}
+							}
+							itmp=xNode4.nChildNode("stat");
+							for(k=0; k<itmp; k++)
+							{ //get all items of stat in dcache
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.core[i].dcache.total_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.core[i].dcache.read_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.core[i].dcache.write_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.core[i].dcache.total_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.core[i].dcache.total_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_hits")==0) {sys.core[i].dcache.read_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_hits")==0) {sys.core[i].dcache.write_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.core[i].dcache.read_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.core[i].dcache.write_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"replacements")==0) {sys.core[i].dcache.replacements=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_backs")==0) {sys.core[i].dcache.write_backs=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"miss_buffer_access")==0) {sys.core[i].dcache.miss_buffer_access=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"fill_buffer_accesses")==0) {sys.core[i].dcache.fill_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_accesses")==0) {sys.core[i].dcache.prefetch_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_writes")==0) {sys.core[i].dcache.prefetch_buffer_writes=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_reads")==0) {sys.core[i].dcache.prefetch_buffer_reads=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_hits")==0) {sys.core[i].dcache.prefetch_buffer_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"wbb_writes")==0) {sys.core[i].dcache.wbb_writes=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"wbb_reads")==0) {sys.core[i].dcache.wbb_reads=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.core[i].dcache.conflicts=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+
+							}
+						}
+
+
+						if (strcmp(xNode4.getAttribute("name"),"BTB")==0)
+						{//find system.core0.BTB
+							itmp=xNode4.nChildNode("param");
+							for(k=0; k<itmp; k++)
+							{ //get all items of param in system.core0.BTB--BTB
+								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"BTB_config")==0)
+								{
+									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
+									m=0;
+									for(n=0; n<strtmp.length(); n++)
+									{
+										if (strtmp[n]!=',')
+										{
+											sprintf(chtmp,"%c",strtmp[n]);
+											strcat(chtmp1,chtmp);
+										}
+										else{
+											sys.core[i].BTB.BTB_config[m]=atoi(chtmp1);
+											m++;
+											chtmp1[0]='\0';
+										}
+									}
+									sys.core[i].BTB.BTB_config[m]=atoi(chtmp1);
+									m++;
+									chtmp1[0]='\0';
+								}
+							}
+							itmp=xNode4.nChildNode("stat");
+							for(k=0; k<itmp; k++)
+							{ //get all items of stat in BTB
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.core[i].BTB.total_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.core[i].BTB.read_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.core[i].BTB.write_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.core[i].BTB.total_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.core[i].BTB.total_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_hits")==0) {sys.core[i].BTB.read_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_hits")==0) {sys.core[i].BTB.write_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.core[i].BTB.read_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.core[i].BTB.write_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"replacements")==0) {sys.core[i].BTB.replacements=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+							}
+						}
+					}
+				}
+				else {
+					printf("The value of homogeneous_cores or number_of_cores is not correct!");
+					exit(0);
+				}
+			}
+		}
+
+		//__________________________________________Get system.L1Directory0-n____________________________________________
+		int w,tmpOrderofComponents_3layer;
+		w=OrderofComponents_3layer+1;
+		tmpOrderofComponents_3layer=OrderofComponents_3layer;
+		if (sys.homogeneous_L1Directories==1) OrderofComponents_3layer=OrderofComponents_3layer+1;
+		else OrderofComponents_3layer=OrderofComponents_3layer+sys.number_of_L1Directories;
+
+		for (i=0; i<(OrderofComponents_3layer-tmpOrderofComponents_3layer); i++)
+		{
+			xNode3=xNode2.getChildNode("component",w);
+			if (xNode3.isEmpty()==1) {
+				printf("The value of homogeneous_L1Directories or number_of_L1Directories is not correct!");
+				exit(0);
+			}
+			else
+			{
+				if (strstr(xNode3.getAttribute("id"),"L1Directory")!=NULL)
+				{
+					itmp=xNode3.nChildNode("param");
+					for(k=0; k<itmp; k++)
+					{ //get all items of param in system.L1Directory
+						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"Dir_config")==0)
+						{
+							strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
+							m=0;
+							for(n=0; n<strtmp.length(); n++)
+							{
+								if (strtmp[n]!=',')
+								{
+									sprintf(chtmp,"%c",strtmp[n]);
+									strcat(chtmp1,chtmp);
+								}
+								else{
+									sys.L1Directory[i].Dir_config[m]=atof(chtmp1);
+									m++;
+									chtmp1[0]='\0';
+								}
+							}
+							sys.L1Directory[i].Dir_config[m]=atof(chtmp1);
+							m++;
+							chtmp1[0]='\0';
+							continue;
+						}
+						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"buffer_sizes")==0)
+						{
+							strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
+							m=0;
+							for(n=0; n<strtmp.length(); n++)
+							{
+								if (strtmp[n]!=',')
+								{
+									sprintf(chtmp,"%c",strtmp[n]);
+									strcat(chtmp1,chtmp);
+								}
+								else{
+									sys.L1Directory[i].buffer_sizes[m]=atoi(chtmp1);
+									m++;
+									chtmp1[0]='\0';
+								}
+							}
+							sys.L1Directory[i].buffer_sizes[m]=atoi(chtmp1);
+							m++;
+							chtmp1[0]='\0';
+							continue;
+						}
+
+						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"clockrate")==0) {sys.L1Directory[i].clockrate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"ports")==0)
+						{
+							strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
+							m=0;
+							for(n=0; n<strtmp.length(); n++)
+							{
+								if (strtmp[n]!=',')
+								{
+									sprintf(chtmp,"%c",strtmp[n]);
+									strcat(chtmp1,chtmp);
+								}
+								else{
+									sys.L1Directory[i].ports[m]=atoi(chtmp1);
+									m++;
+									chtmp1[0]='\0';
+								}
+							}
+							sys.L1Directory[i].ports[m]=atoi(chtmp1);
+							m++;
+							chtmp1[0]='\0';
+							continue;
+						}
+						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"device_type")==0) {sys.L1Directory[i].device_type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"Directory_type")==0) {sys.L1Directory[i].Directory_type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"3D_stack")==0) {strcpy(sys.L1Directory[i].threeD_stack,xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+					}
+					itmp=xNode3.nChildNode("stat");
+					for(k=0; k<itmp; k++)
+					{ //get all items of stat in system.L2directorydirectory
+						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.L1Directory[i].total_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.L1Directory[i].read_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.L1Directory[i].write_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.L1Directory[i].read_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.L1Directory[i].write_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.L1Directory[i].conflicts=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"duty_cycle")==0) {sys.L1Directory[i].duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+					}
+					w=w+1;
+				}
+				else {
+					printf("The value of homogeneous_L1Directories or number_of_L1Directories is not correct!");
+					exit(0);
+				}
+			}
+		}
+
+		//__________________________________________Get system.L2Directory0-n____________________________________________
+		w=OrderofComponents_3layer+1;
+		tmpOrderofComponents_3layer=OrderofComponents_3layer;
+		if (sys.homogeneous_L2Directories==1) OrderofComponents_3layer=OrderofComponents_3layer+1;
+		else OrderofComponents_3layer=OrderofComponents_3layer+sys.number_of_L2Directories;
+
+		for (i=0; i<(OrderofComponents_3layer-tmpOrderofComponents_3layer); i++)
+		{
+			xNode3=xNode2.getChildNode("component",w);
+			if (xNode3.isEmpty()==1) {
+				printf("The value of homogeneous_L2Directories or number_of_L2Directories is not correct!");
+				exit(0);
+			}
+			else
+			{
+				if (strstr(xNode3.getAttribute("id"),"L2Directory")!=NULL)
+				{
+					itmp=xNode3.nChildNode("param");
+					for(k=0; k<itmp; k++)
+					{ //get all items of param in system.L2Directory
+						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"Dir_config")==0)
+						{
+							strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
+							m=0;
+							for(n=0; n<strtmp.length(); n++)
+							{
+								if (strtmp[n]!=',')
+								{
+									sprintf(chtmp,"%c",strtmp[n]);
+									strcat(chtmp1,chtmp);
+								}
+								else{
+									sys.L2Directory[i].Dir_config[m]=atof(chtmp1);
+									m++;
+									chtmp1[0]='\0';
+								}
+							}
+							sys.L2Directory[i].Dir_config[m]=atof(chtmp1);
+							m++;
+							chtmp1[0]='\0';
+							continue;
+						}
+						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"buffer_sizes")==0)
+						{
+							strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
+							m=0;
+							for(n=0; n<strtmp.length(); n++)
+							{
+								if (strtmp[n]!=',')
+								{
+									sprintf(chtmp,"%c",strtmp[n]);
+									strcat(chtmp1,chtmp);
+								}
+								else{
+									sys.L2Directory[i].buffer_sizes[m]=atoi(chtmp1);
+									m++;
+									chtmp1[0]='\0';
+								}
+							}
+							sys.L2Directory[i].buffer_sizes[m]=atoi(chtmp1);
+							m++;
+							chtmp1[0]='\0';
+							continue;
+						}
+
+						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"clockrate")==0) {sys.L2Directory[i].clockrate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"Directory_type")==0) {sys.L2Directory[i].Directory_type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"ports")==0)
+						{
+							strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
+							m=0;
+							for(n=0; n<strtmp.length(); n++)
+							{
+								if (strtmp[n]!=',')
+								{
+									sprintf(chtmp,"%c",strtmp[n]);
+									strcat(chtmp1,chtmp);
+								}
+								else{
+									sys.L2Directory[i].ports[m]=atoi(chtmp1);
+									m++;
+									chtmp1[0]='\0';
+								}
+							}
+							sys.L2Directory[i].ports[m]=atoi(chtmp1);
+							m++;
+							chtmp1[0]='\0';
+							continue;
+						}
+						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"device_type")==0) {sys.L2Directory[i].device_type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"3D_stack")==0) {strcpy(sys.L2Directory[i].threeD_stack,xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+					}
+					itmp=xNode3.nChildNode("stat");
+					for(k=0; k<itmp; k++)
+					{ //get all items of stat in system.L2directorydirectory
+						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.L2Directory[i].total_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.L2Directory[i].read_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.L2Directory[i].write_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.L2Directory[i].read_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+     					if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.L2Directory[i].write_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.L2Directory[i].conflicts=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"duty_cycle")==0) {sys.L2Directory[i].duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+
+					}
+					w=w+1;
+				}
+				else {
+					printf("The value of homogeneous_L2Directories or number_of_L2Directories is not correct!");
+					exit(0);
+				}
+			}
+		}
+
+		//__________________________________________Get system.L2[0..n]____________________________________________
+		w=OrderofComponents_3layer+1;
+		tmpOrderofComponents_3layer=OrderofComponents_3layer;
+		if (sys.homogeneous_L2s==1) OrderofComponents_3layer=OrderofComponents_3layer+1;
+		else OrderofComponents_3layer=OrderofComponents_3layer+sys.number_of_L2s;
+
+		for (i=0; i<(OrderofComponents_3layer-tmpOrderofComponents_3layer); i++)
+		{
+			xNode3=xNode2.getChildNode("component",w);
+			if (xNode3.isEmpty()==1) {
+				printf("The value of homogeneous_L2s or number_of_L2s is not correct!");
+				exit(0);
+			}
+			else
+			{
+				if (strstr(xNode3.getAttribute("name"),"L2")!=NULL)
+				{
+					{ //For L20-L2i
+						//Get all params with system.L2?
+						itmp=xNode3.nChildNode("param");
+						for(k=0; k<itmp; k++)
+						{
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"L2_config")==0)
+							{
+								strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
+								m=0;
+								for(n=0; n<strtmp.length(); n++)
+								{
+									if (strtmp[n]!=',')
+									{
+										sprintf(chtmp,"%c",strtmp[n]);
+										strcat(chtmp1,chtmp);
+									}
+									else{
+										sys.L2[i].L2_config[m]=atof(chtmp1);
+										m++;
+										chtmp1[0]='\0';
+									}
+								}
+								sys.L2[i].L2_config[m]=atof(chtmp1);
+								m++;
+								chtmp1[0]='\0';
+								continue;
+							}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"clockrate")==0) {sys.L2[i].clockrate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"merged_dir")==0) {sys.L2[i].merged_dir=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"ports")==0)
+							{
+								strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
+								m=0;
+								for(n=0; n<strtmp.length(); n++)
+								{
+									if (strtmp[n]!=',')
+									{
+										sprintf(chtmp,"%c",strtmp[n]);
+										strcat(chtmp1,chtmp);
+									}
+									else{
+										sys.L2[i].ports[m]=atoi(chtmp1);
+										m++;
+										chtmp1[0]='\0';
+									}
+								}
+								sys.L2[i].ports[m]=atoi(chtmp1);
+								m++;
+								chtmp1[0]='\0';
+								continue;
+							}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"device_type")==0) {sys.L2[i].device_type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"threeD_stack")==0) {strcpy(sys.L2[i].threeD_stack,(xNode3.getChildNode("param",k).getAttribute("value")));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"buffer_sizes")==0)
+							{
+								strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
+								m=0;
+								for(n=0; n<strtmp.length(); n++)
+								{
+									if (strtmp[n]!=',')
+									{
+										sprintf(chtmp,"%c",strtmp[n]);
+										strcat(chtmp1,chtmp);
+									}
+									else{
+										sys.L2[i].buffer_sizes[m]=atoi(chtmp1);
+										m++;
+										chtmp1[0]='\0';
+									}
+								}
+								sys.L2[i].buffer_sizes[m]=atoi(chtmp1);
+								m++;
+								chtmp1[0]='\0';
+								continue;
+							}
+						}
+						//Get all stats with system.L2?
+						itmp=xNode3.nChildNode("stat");
+						for(k=0; k<itmp; k++)
+						{
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.L2[i].total_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.L2[i].read_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.L2[i].write_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.L2[i].total_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.L2[i].total_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_hits")==0) {sys.L2[i].read_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_hits")==0) {sys.L2[i].write_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.L2[i].read_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.L2[i].write_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"replacements")==0) {sys.L2[i].replacements=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_backs")==0) {sys.L2[i].write_backs=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"miss_buffer_accesses")==0) {sys.L2[i].miss_buffer_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"fill_buffer_accesses")==0) {sys.L2[i].fill_buffer_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_accesses")==0) {sys.L2[i].prefetch_buffer_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_writes")==0) {sys.L2[i].prefetch_buffer_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_reads")==0) {sys.L2[i].prefetch_buffer_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_hits")==0) {sys.L2[i].prefetch_buffer_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"wbb_writes")==0) {sys.L2[i].wbb_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"wbb_reads")==0) {sys.L2[i].wbb_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.L2[i].conflicts=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"duty_cycle")==0) {sys.L2[i].duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_read_accesses")==0) {sys.L2[i].homenode_read_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_read_accesses")==0) {sys.L2[i].homenode_read_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_read_hits")==0) {sys.L2[i].homenode_read_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_write_hits")==0) {sys.L2[i].homenode_write_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_read_misses")==0) {sys.L2[i].homenode_read_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_write_misses")==0) {sys.L2[i].homenode_write_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"dir_duty_cycle")==0) {sys.L2[i].dir_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+
+						}
+					}
+					w=w+1;
+				}
+				else {
+					printf("The value of homogeneous_L2s or number_of_L2s is not correct!");
+					exit(0);
+				}
+			}
+		}
+		//__________________________________________Get system.L3[0..n]____________________________________________
+		w=OrderofComponents_3layer+1;
+		tmpOrderofComponents_3layer=OrderofComponents_3layer;
+		if (sys.homogeneous_L3s==1) OrderofComponents_3layer=OrderofComponents_3layer+1;
+		else OrderofComponents_3layer=OrderofComponents_3layer+sys.number_of_L3s;
+
+		for (i=0; i<(OrderofComponents_3layer-tmpOrderofComponents_3layer); i++)
+		{
+			xNode3=xNode2.getChildNode("component",w);
+			if (xNode3.isEmpty()==1) {
+				printf("The value of homogeneous_L3s or number_of_L3s is not correct!");
+				exit(0);
+			}
+			else
+			{
+				if (strstr(xNode3.getAttribute("name"),"L3")!=NULL)
+				{
+					{ //For L30-L3i
+						//Get all params with system.L3?
+						itmp=xNode3.nChildNode("param");
+						for(k=0; k<itmp; k++)
+						{
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"L3_config")==0)
+							{
+								strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
+								m=0;
+								for(n=0; n<strtmp.length(); n++)
+								{
+									if (strtmp[n]!=',')
+									{
+										sprintf(chtmp,"%c",strtmp[n]);
+										strcat(chtmp1,chtmp);
+									}
+									else{
+										sys.L3[i].L3_config[m]=atof(chtmp1);
+										m++;
+										chtmp1[0]='\0';
+									}
+								}
+								sys.L3[i].L3_config[m]=atof(chtmp1);
+								m++;
+								chtmp1[0]='\0';
+								continue;
+							}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"clockrate")==0) {sys.L3[i].clockrate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"merged_dir")==0) {sys.L3[i].merged_dir=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"ports")==0)
+							{
+								strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
+								m=0;
+								for(n=0; n<strtmp.length(); n++)
+								{
+									if (strtmp[n]!=',')
+									{
+										sprintf(chtmp,"%c",strtmp[n]);
+										strcat(chtmp1,chtmp);
+									}
+									else{
+										sys.L3[i].ports[m]=atoi(chtmp1);
+										m++;
+										chtmp1[0]='\0';
+									}
+								}
+								sys.L3[i].ports[m]=atoi(chtmp1);
+								m++;
+								chtmp1[0]='\0';
+								continue;
+							}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"device_type")==0) {sys.L3[i].device_type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"threeD_stack")==0) {strcpy(sys.L3[i].threeD_stack,(xNode3.getChildNode("param",k).getAttribute("value")));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"buffer_sizes")==0)
+							{
+								strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
+								m=0;
+								for(n=0; n<strtmp.length(); n++)
+								{
+									if (strtmp[n]!=',')
+									{
+										sprintf(chtmp,"%c",strtmp[n]);
+										strcat(chtmp1,chtmp);
+									}
+									else{
+										sys.L3[i].buffer_sizes[m]=atoi(chtmp1);
+										m++;
+										chtmp1[0]='\0';
+									}
+								}
+								sys.L3[i].buffer_sizes[m]=atoi(chtmp1);
+								m++;
+								chtmp1[0]='\0';
+								continue;
+							}
+						}
+						//Get all stats with system.L3?
+						itmp=xNode3.nChildNode("stat");
+						for(k=0; k<itmp; k++)
+						{
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.L3[i].total_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.L3[i].read_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.L3[i].write_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.L3[i].total_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.L3[i].total_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_hits")==0) {sys.L3[i].read_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_hits")==0) {sys.L3[i].write_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.L3[i].read_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.L3[i].write_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"replacements")==0) {sys.L3[i].replacements=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_backs")==0) {sys.L3[i].write_backs=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"miss_buffer_accesses")==0) {sys.L3[i].miss_buffer_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"fill_buffer_accesses")==0) {sys.L3[i].fill_buffer_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_accesses")==0) {sys.L3[i].prefetch_buffer_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_writes")==0) {sys.L3[i].prefetch_buffer_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_reads")==0) {sys.L3[i].prefetch_buffer_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_hits")==0) {sys.L3[i].prefetch_buffer_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"wbb_writes")==0) {sys.L3[i].wbb_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"wbb_reads")==0) {sys.L3[i].wbb_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.L3[i].conflicts=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"duty_cycle")==0) {sys.L3[i].duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_read_accesses")==0) {sys.L3[i].homenode_read_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_read_accesses")==0) {sys.L3[i].homenode_read_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_read_hits")==0) {sys.L3[i].homenode_read_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_write_hits")==0) {sys.L3[i].homenode_write_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_read_misses")==0) {sys.L3[i].homenode_read_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_write_misses")==0) {sys.L3[i].homenode_write_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"dir_duty_cycle")==0) {sys.L3[i].dir_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+
+						}
+					}
+					w=w+1;
+				}
+				else {
+					printf("The value of homogeneous_L3s or number_of_L3s is not correct!");
+					exit(0);
+				}
+			}
+		}
+		//__________________________________________Get system.NoC[0..n]____________________________________________
+		w=OrderofComponents_3layer+1;
+		tmpOrderofComponents_3layer=OrderofComponents_3layer;
+		if (sys.homogeneous_NoCs==1) OrderofComponents_3layer=OrderofComponents_3layer+1;
+		else OrderofComponents_3layer=OrderofComponents_3layer+sys.number_of_NoCs;
+
+		for (i=0; i<(OrderofComponents_3layer-tmpOrderofComponents_3layer); i++)
+		{
+			xNode3=xNode2.getChildNode("component",w);
+			if (xNode3.isEmpty()==1) {
+				printf("The value of homogeneous_NoCs or number_of_NoCs is not correct!");
+				exit(0);
+			}
+			else
+			{
+				if (strstr(xNode3.getAttribute("name"),"noc")!=NULL)
+				{
+					{ //For NoC0-NoCi
+						//Get all params with system.NoC?
+						itmp=xNode3.nChildNode("param");
+						for(k=0; k<itmp; k++)
+						{
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"clockrate")==0) {sys.NoC[i].clockrate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"type")==0) {sys.NoC[i].type=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"topology")==0) {strcpy(sys.NoC[i].topology,(xNode3.getChildNode("param",k).getAttribute("value")));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"horizontal_nodes")==0) {sys.NoC[i].horizontal_nodes=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"vertical_nodes")==0) {sys.NoC[i].vertical_nodes=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"has_global_link")==0) {sys.NoC[i].has_global_link=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"link_throughput")==0) {sys.NoC[i].link_throughput=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"link_latency")==0) {sys.NoC[i].link_latency=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"input_ports")==0) {sys.NoC[i].input_ports=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"output_ports")==0) {sys.NoC[i].output_ports=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"virtual_channel_per_port")==0) {sys.NoC[i].virtual_channel_per_port=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"flit_bits")==0) {sys.NoC[i].flit_bits=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"input_buffer_entries_per_vc")==0) {sys.NoC[i].input_buffer_entries_per_vc=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dual_pump")==0) {sys.NoC[i].dual_pump=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"chip_coverage")==0) {sys.NoC[i].chip_coverage=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"link_routing_over_percentage")==0) {sys.NoC[i].route_over_perc=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"ports_of_input_buffer")==0)
+							{
+								strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
+								m=0;
+								for(n=0; n<strtmp.length(); n++)
+								{
+									if (strtmp[n]!=',')
+									{
+										sprintf(chtmp,"%c",strtmp[n]);
+										strcat(chtmp1,chtmp);
+									}
+									else{
+										sys.NoC[i].ports_of_input_buffer[m]=atoi(chtmp1);
+										m++;
+										chtmp1[0]='\0';
+									}
+								}
+								sys.NoC[i].ports_of_input_buffer[m]=atoi(chtmp1);
+								m++;
+								chtmp1[0]='\0';
+								continue;
+							}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_of_crossbars")==0) {sys.NoC[i].number_of_crossbars=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"crossbar_type")==0) {strcpy(sys.NoC[i].crossbar_type,(xNode3.getChildNode("param",k).getAttribute("value")));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"crosspoint_type")==0) {strcpy(sys.NoC[i].crosspoint_type,(xNode3.getChildNode("param",k).getAttribute("value")));continue;}
+							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"arbiter_type")==0) {sys.NoC[i].arbiter_type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+						}
+						NumofCom_4=xNode3.nChildNode("component"); //get the number of components within the third layer
+						for(j=0; j<NumofCom_4; j++)
+						{
+							xNode4=xNode3.getChildNode("component",j);
+							if (strcmp(xNode4.getAttribute("name"),"xbar0")==0)
+							{ //find PBT
+								itmp=xNode4.nChildNode("param");
+								for(k=0; k<itmp; k++)
+								{ //get all items of param in system.XoC0.xbar0--xbar0
+									if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"number_of_inputs_of_crossbars")==0) {sys.NoC[i].xbar0.number_of_inputs_of_crossbars=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
+									if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"number_of_outputs_of_crossbars")==0) {sys.NoC[i].xbar0.number_of_outputs_of_crossbars=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
+									if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"flit_bits")==0) {sys.NoC[i].xbar0.flit_bits=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
+									if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"input_buffer_entries_per_port")==0) {sys.NoC[i].xbar0.input_buffer_entries_per_port=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
+									if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"ports_of_input_buffer")==0)
+									{
+										strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
+										m=0;
+										for(n=0; n<strtmp.length(); n++)
+										{
+											if (strtmp[n]!=',')
+											{
+												sprintf(chtmp,"%c",strtmp[n]);
+												strcat(chtmp1,chtmp);
+											}
+											else{
+												sys.NoC[i].xbar0.ports_of_input_buffer[m]=atoi(chtmp1);
+												m++;
+												chtmp1[0]='\0';
+											}
+										}
+										sys.NoC[i].xbar0.ports_of_input_buffer[m]=atoi(chtmp1);
+										m++;
+										chtmp1[0]='\0';
+									}
+								}
+								itmp=xNode4.nChildNode("stat");
+								for(k=0; k<itmp; k++)
+								{ //get all items of stat in system.core0.predictor--PBT
+									if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"predictor_accesses")==0) sys.core[i].predictor.predictor_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));
+								}
+							}
+						}
+						//Get all stats with system.NoC?
+						itmp=xNode3.nChildNode("stat");
+						for(k=0; k<itmp; k++)
+						{
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) sys.NoC[i].total_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));
+							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"duty_cycle")==0) sys.NoC[i].duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));
+						}
+					}
+					w=w+1;
+				}
+			}
+		}
+		//__________________________________________Get system.mem____________________________________________
+		if (OrderofComponents_3layer>0) OrderofComponents_3layer=OrderofComponents_3layer+1;
+		xNode3=xNode2.getChildNode("component",OrderofComponents_3layer);
+		if (xNode3.isEmpty()==1) {
+			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
+			exit(0);
+		}
+		if (strstr(xNode3.getAttribute("id"),"system.mem")!=NULL)
+		{
+
+			itmp=xNode3.nChildNode("param");
+			for(k=0; k<itmp; k++)
+			{ //get all items of param in system.mem
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"mem_tech_node")==0) {sys.mem.mem_tech_node=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"device_clock")==0) {sys.mem.device_clock=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"peak_transfer_rate")==0) {sys.mem.peak_transfer_rate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"capacity_per_channel")==0) {sys.mem.capacity_per_channel=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_ranks")==0) {sys.mem.number_ranks=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"num_banks_of_DRAM_chip")==0) {sys.mem.num_banks_of_DRAM_chip=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"Block_width_of_DRAM_chip")==0) {sys.mem.Block_width_of_DRAM_chip=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"output_width_of_DRAM_chip")==0) {sys.mem.output_width_of_DRAM_chip=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"page_size_of_DRAM_chip")==0) {sys.mem.page_size_of_DRAM_chip=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"burstlength_of_DRAM_chip")==0) {sys.mem.burstlength_of_DRAM_chip=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"internal_prefetch_of_DRAM_chip")==0) {sys.mem.internal_prefetch_of_DRAM_chip=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+			}
+			itmp=xNode3.nChildNode("stat");
+			for(k=0; k<itmp; k++)
+			{ //get all items of stat in system.mem
+				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_accesses")==0) {sys.mem.memory_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_reads")==0) {sys.mem.memory_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_writes")==0) {sys.mem.memory_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"dram_pre")==0) {sys.mem.dram_pre=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+			}
+		}
+		else{
+			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
+			exit(0);
+		}
+		//__________________________________________Get system.mc____________________________________________
+		if (OrderofComponents_3layer>0) OrderofComponents_3layer=OrderofComponents_3layer+1;
+		xNode3=xNode2.getChildNode("component",OrderofComponents_3layer);
+		if (xNode3.isEmpty()==1) {
+			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
+			exit(0);
+		}
+		if (strstr(xNode3.getAttribute("id"),"system.mc")!=NULL)
+		{
+			itmp=xNode3.nChildNode("param");
+			for(k=0; k<itmp; k++)
+			{ //get all items of param in system.mem
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"mc_clock")==0) {sys.mc.mc_clock=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"block_size")==0) {sys.mc.llc_line_length=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_mcs")==0) {sys.mc.number_mcs=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"memory_channels_per_mc")==0) {sys.mc.memory_channels_per_mc=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"req_window_size_per_channel")==0) {sys.mc.req_window_size_per_channel=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"IO_buffer_size_per_channel")==0) {sys.mc.IO_buffer_size_per_channel=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"databus_width")==0) {sys.mc.databus_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"addressbus_width")==0) {sys.mc.addressbus_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"PRT_entries")==0) {sys.mc.PRT_entries=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"peak_transfer_rate")==0) {sys.mc.peak_transfer_rate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_ranks")==0) {sys.mc.number_ranks=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"LVDS")==0) {sys.mc.LVDS=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"type")==0) {sys.mc.type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"withPHY")==0) {sys.mc.withPHY=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+
+        		if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dram_cmd_coeff")==0) {sys.mc.dram_cmd_coeff=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+        		if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dram_act_coeff")==0) {sys.mc.dram_act_coeff=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+        		if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dram_nop_coeff")==0) {sys.mc.dram_nop_coeff=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+        		if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dram_activity_coeff")==0) {sys.mc.dram_activity_coeff=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+        		if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dram_pre_coeff")==0) {sys.mc.dram_pre_coeff=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+        		if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dram_rd_coeff")==0) {sys.mc.dram_rd_coeff=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+        		if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dram_wr_coeff")==0) {sys.mc.dram_wr_coeff=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+        		if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dram_req_coeff")==0) {sys.mc.dram_req_coeff=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+        		if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dram_const_coeff")==0) {sys.mc.dram_const_coeff=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+			}
+			itmp=xNode3.nChildNode("stat");
+			for(k=0; k<itmp; k++)
+			{ //get all items of stat in system.mendirectory
+				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_accesses")==0) {sys.mc.memory_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_reads")==0) {sys.mc.memory_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_writes")==0) {sys.mc.memory_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"dram_pre")==0) {sys.mc.dram_pre=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+			}
+		}
+		else{
+			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
+			exit(0);
+		}
+		//__________________________________________Get system.niu____________________________________________
+		if (OrderofComponents_3layer>0) OrderofComponents_3layer=OrderofComponents_3layer+1;
+		xNode3=xNode2.getChildNode("component",OrderofComponents_3layer);
+		if (xNode3.isEmpty()==1) {
+			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
+			exit(0);
+		}
+		if (strstr(xNode3.getAttribute("id"),"system.niu")!=NULL)
+		{
+			itmp=xNode3.nChildNode("param");
+			for(k=0; k<itmp; k++)
+			{ //get all items of param in system.mem
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"clockrate")==0) {sys.niu.clockrate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_units")==0) {sys.niu.number_units=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"type")==0) {sys.niu.type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+			}
+			itmp=xNode3.nChildNode("stat");
+			for(k=0; k<itmp; k++)
+			{ //get all items of stat in system.mendirectory
+				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"duty_cycle")==0) {sys.niu.duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_load_perc")==0) {sys.niu.total_load_perc=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+			}
+		}
+		else{
+			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
+			exit(0);
+		}
+
+		//__________________________________________Get system.pcie____________________________________________
+		if (OrderofComponents_3layer>0) OrderofComponents_3layer=OrderofComponents_3layer+1;
+		xNode3=xNode2.getChildNode("component",OrderofComponents_3layer);
+		if (xNode3.isEmpty()==1) {
+			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
+			exit(0);
+		}
+		if (strstr(xNode3.getAttribute("id"),"system.pcie")!=NULL)
+		{
+			itmp=xNode3.nChildNode("param");
+			for(k=0; k<itmp; k++)
+			{ //get all items of param in system.mem
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"clockrate")==0) {sys.pcie.clockrate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_units")==0) {sys.pcie.number_units=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"num_channels")==0) {sys.pcie.num_channels=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"type")==0) {sys.pcie.type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"withPHY")==0) {sys.pcie.withPHY=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+
+			}
+			itmp=xNode3.nChildNode("stat");
+			for(k=0; k<itmp; k++)
+			{ //get all items of stat in system.mendirectory
+				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"duty_cycle")==0) {sys.pcie.duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_load_perc")==0) {sys.pcie.total_load_perc=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+			}
+		}
+		else{
+			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
+			exit(0);
+		}
+		//__________________________________________Get system.flashcontroller____________________________________________
+		if (OrderofComponents_3layer>0) OrderofComponents_3layer=OrderofComponents_3layer+1;
+		xNode3=xNode2.getChildNode("component",OrderofComponents_3layer);
+		if (xNode3.isEmpty()==1) {
+			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
+			exit(0);
+		}
+		if (strstr(xNode3.getAttribute("id"),"system.flashc")!=NULL)
+		{
+			itmp=xNode3.nChildNode("param");
+			for(k=0; k<itmp; k++)
+			{ //get all items of param in system.mem
+//				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"flashc_clock")==0) {sys.flashc.mc_clock=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+//				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"block_size")==0) {sys.flashc.llc_line_length=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_flashcs")==0) {sys.flashc.number_mcs=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+//				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"memory_channels_per_flashc")==0) {sys.flashc.memory_channels_per_mc=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+//				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"req_window_size_per_channel")==0) {sys.flashc.req_window_size_per_channel=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+//				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"IO_buffer_size_per_channel")==0) {sys.flashc.IO_buffer_size_per_channel=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+//				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"databus_width")==0) {sys.flashc.databus_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+//				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"addressbus_width")==0) {sys.flashc.addressbus_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"peak_transfer_rate")==0) {sys.flashc.peak_transfer_rate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+//				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_ranks")==0) {sys.flashc.number_ranks=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+//				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"LVDS")==0) {sys.flashc.LVDS=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"type")==0) {sys.flashc.type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"withPHY")==0) {sys.flashc.withPHY=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+
+			}
+			itmp=xNode3.nChildNode("stat");
+			for(k=0; k<itmp; k++)
+			{ //get all items of stat in system.mendirectory
+//				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_accesses")==0) {sys.flashc.memory_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+//				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_reads")==0) {sys.flashc.memory_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+//				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_writes")==0) {sys.flashc.memory_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"duty_cycle")==0) {sys.flashc.duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_load_perc")==0) {sys.flashc.total_load_perc=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+
+			}
+		}
+		else{
+			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
+			exit(0);
+		}
+
+	}
+}
+void ParseXML::initialize() //Initialize all
+{
+	//All number_of_* at the level of 'system' 03/21/2009
+	sys.number_of_cores=1;
+	sys.architecture=1; //1 - fermi
+	sys.number_of_L1Directories=1;
+	sys.number_of_L2Directories=1;
+	sys.number_of_L2s=1;
+	sys.Private_L2 = false;
+	sys.number_of_L3s=1;
+	sys.number_of_NoCs=1;
+	// All params at the level of 'system'
+	//strcpy(sys.homogeneous_cores,"default");
+	sys.core_tech_node=1;
+	sys.target_core_clockrate=1;
+	sys.target_chip_area=1;
+	sys.temperature=1;
+	sys.number_cache_levels=1;
+	sys.homogeneous_cores=1;
+	sys.homogeneous_L1Directories=1;
+	sys.homogeneous_L2Directories=1;
+	sys.homogeneous_L2s=1;
+	sys.homogeneous_L3s=1;
+	sys.homogeneous_NoCs=1;
+	sys.homogeneous_ccs=1;
+
+	sys.Max_area_deviation=1;
+	sys.Max_power_deviation=1;
+	sys.device_type=1;
+	sys.longer_channel_device =true;
+	sys.Embedded =false;
+	sys.opt_dynamic_power=false;
+	sys.opt_lakage_power=false;
+	sys.opt_clockrate=true;
+	sys.opt_area=false;
+	sys.interconnect_projection_type=1;
+	sys.idle_core_power=0;
+	int i,j;
+	for (i=0; i<=63; i++)
+	{
+		sys.scaling_coefficients[i]=1;
+		sys.core[i].clock_rate=1;
+		sys.core[i].opt_local = true;
+		sys.core[i].x86 = false;
+		sys.core[i].machine_bits=1;
+		sys.core[i].virtual_address_width=1;
+		sys.core[i].physical_address_width=1;
+		sys.core[i].opcode_width=1;
+		sys.core[i].micro_opcode_width=1;
+		//strcpy(sys.core[i].machine_type,"default");
+		sys.core[i].internal_datapath_width=1;
+		sys.core[i].number_hardware_threads=1;
+		sys.core[i].fetch_width=1;
+		sys.core[i].number_instruction_fetch_ports=1;
+		sys.core[i].decode_width=1;
+		sys.core[i].issue_width=1;
+		sys.core[i].peak_issue_width=1;
+		sys.core[i].commit_width=1;
+		for (j=0; j<20; j++) sys.core[i].pipelines_per_core[j]=1;
+		for (j=0; j<20; j++) sys.core[i].pipeline_depth[j]=1;
+		strcpy(sys.core[i].FPU,"default");
+		strcpy(sys.core[i]. divider_multiplier,"default");
+		sys.core[i].ALU_per_core=1;
+		sys.core[i].FPU_per_core=1.0;
+		sys.core[i].MUL_per_core=1;
+		sys.core[i].instruction_buffer_size=1;
+		sys.core[i].decoded_stream_buffer_size=1;
+		//strcpy(sys.core[i].instruction_window_scheme,"default");
+		sys.core[i].instruction_window_size=1;
+		sys.core[i].ROB_size=1;
+		sys.core[i].archi_Regs_IRF_size=1;
+		sys.core[i].archi_Regs_FRF_size=1;
+		sys.core[i].phy_Regs_IRF_size=1;
+		sys.core[i].phy_Regs_FRF_size=1;
+		//strcpy(sys.core[i].rename_scheme,"default");
+		sys.core[i].register_windows_size=1;
+		strcpy(sys.core[i].LSU_order,"default");
+		sys.core[i].store_buffer_size=1;
+		sys.core[i].load_buffer_size=1;
+		sys.core[i].memory_ports=1;
+		strcpy(sys.core[i].Dcache_dual_pump,"default");
+		sys.core[i].RAS_size=1;
+		//all stats at the level of system.core(0-n)
+		sys.core[i].total_instructions=1;
+		sys.core[i].int_instructions=1;
+		sys.core[i].fp_instructions=1;
+		sys.core[i].branch_instructions=1;
+		sys.core[i].branch_mispredictions=1;
+		sys.core[i].committed_instructions=1;
+		sys.core[i].load_instructions=1;
+		sys.core[i].store_instructions=1;
+		sys.core[i].total_cycles=1;
+		sys.core[i].idle_cycles=1;
+		sys.core[i].busy_cycles=1;
+		sys.core[i].instruction_buffer_reads=1;
+		sys.core[i].instruction_buffer_write=1;
+		sys.core[i].ROB_reads=1;
+		sys.core[i].ROB_writes=1;
+		sys.core[i].rename_accesses=1;
+		sys.core[i].inst_window_reads=1;
+		sys.core[i].inst_window_writes=1;
+		sys.core[i].inst_window_wakeup_accesses=1;
+		sys.core[i].inst_window_selections=1;
+		sys.core[i].archi_int_regfile_reads=1;
+		sys.core[i].archi_float_regfile_reads=1;
+		sys.core[i].phy_int_regfile_reads=1;
+		sys.core[i].phy_float_regfile_reads=1;
+		sys.core[i].windowed_reg_accesses=1;
+		sys.core[i].windowed_reg_transports=1;
+		sys.core[i].function_calls=1;
+		sys.core[i].ialu_accesses=1;
+		sys.core[i].fpu_accesses=1;
+		sys.core[i].mul_accesses=1;
+		sys.core[i].cdb_alu_accesses=1;
+		sys.core[i].cdb_mul_accesses=1;
+		sys.core[i].cdb_fpu_accesses=1;
+		sys.core[i].load_buffer_reads=1;
+		sys.core[i].load_buffer_writes=1;
+		sys.core[i].load_buffer_cams=1;
+		sys.core[i].store_buffer_reads=1;
+		sys.core[i].store_buffer_writes=1;
+		sys.core[i].store_buffer_cams=1;
+		sys.core[i].store_buffer_forwards=1;
+		sys.core[i].main_memory_access=1;
+		sys.core[i].main_memory_read=1;
+		sys.core[i].main_memory_write=1;
+		sys.core[i].IFU_duty_cycle = 1;
+		sys.core[i].BR_duty_cycle = 1;
+		sys.core[i].LSU_duty_cycle = 1;
+		sys.core[i].MemManU_I_duty_cycle =1;
+		sys.core[i].MemManU_D_duty_cycle =1;
+		sys.core[i].ALU_duty_cycle =1;
+		sys.core[i].MUL_duty_cycle =1;
+		sys.core[i].FPU_duty_cycle =1;
+		sys.core[i].ALU_cdb_duty_cycle =1;
+		sys.core[i].MUL_cdb_duty_cycle =1;
+		sys.core[i].FPU_cdb_duty_cycle =1;
+		//system.core?.predictor
+		sys.core[i].predictor.prediction_width=1;
+		strcpy(sys.core[i].predictor.prediction_scheme,"default");
+		sys.core[i].predictor.predictor_size=1;
+		sys.core[i].predictor.predictor_entries=1;
+		sys.core[i].predictor.local_predictor_entries=1;
+		for (j=0; j<20; j++) sys.core[i].predictor.local_predictor_size[j]=1;
+		sys.core[i].predictor.global_predictor_entries=1;
+		sys.core[i].predictor.global_predictor_bits=1;
+		sys.core[i].predictor.chooser_predictor_entries=1;
+		sys.core[i].predictor.chooser_predictor_bits=1;
+		sys.core[i].predictor.predictor_accesses=1;
+		//system.core?.itlb
+		sys.core[i].itlb.number_entries=1;
+		sys.core[i].itlb.total_hits=1;
+		sys.core[i].itlb.total_accesses=1;
+		sys.core[i].itlb.total_misses=1;
+		//system.core?.icache
+		for (j=0; j<20; j++) sys.core[i].icache.icache_config[j]=1;
+		//strcpy(sys.core[i].icache.buffer_sizes,"default");
+		sys.core[i].icache.total_accesses=1;
+		sys.core[i].icache.read_accesses=1;
+		sys.core[i].icache.read_misses=1;
+		sys.core[i].icache.replacements=1;
+		sys.core[i].icache.read_hits=1;
+		sys.core[i].icache.total_hits=1;
+		sys.core[i].icache.total_misses=1;
+		sys.core[i].icache.miss_buffer_access=1;
+		sys.core[i].icache.fill_buffer_accesses=1;
+		sys.core[i].icache.prefetch_buffer_accesses=1;
+		sys.core[i].icache.prefetch_buffer_writes=1;
+		sys.core[i].icache.prefetch_buffer_reads=1;
+		sys.core[i].icache.prefetch_buffer_hits=1;
+		//system.core?.dtlb
+		sys.core[i].dtlb.number_entries=1;
+		sys.core[i].dtlb.total_accesses=1;
+		sys.core[i].dtlb.read_accesses=1;
+		sys.core[i].dtlb.write_accesses=1;
+		sys.core[i].dtlb.write_hits=1;
+		sys.core[i].dtlb.read_hits=1;
+		sys.core[i].dtlb.read_misses=1;
+		sys.core[i].dtlb.write_misses=1;
+		sys.core[i].dtlb.total_hits=1;
+		sys.core[i].dtlb.total_misses=1;
+		//system.core?.dcache
+		for (j=0; j<20; j++) sys.core[i].dcache.dcache_config[j]=1;
+		//strcpy(sys.core[i].dcache.buffer_sizes,"default");
+		sys.core[i].dcache.total_accesses=1;
+		sys.core[i].dcache.read_accesses=1;
+		sys.core[i].dcache.write_accesses=1;
+		sys.core[i].dcache.total_hits=1;
+		sys.core[i].dcache.total_misses=1;
+		sys.core[i].dcache.read_hits=1;
+		sys.core[i].dcache.write_hits=1;
+		sys.core[i].dcache.read_misses=1;
+		sys.core[i].dcache.write_misses=1;
+		sys.core[i].dcache.replacements=1;
+		sys.core[i].dcache.write_backs=1;
+		sys.core[i].dcache.miss_buffer_access=1;
+		sys.core[i].dcache.fill_buffer_accesses=1;
+		sys.core[i].dcache.prefetch_buffer_accesses=1;
+		sys.core[i].dcache.prefetch_buffer_writes=1;
+		sys.core[i].dcache.prefetch_buffer_reads=1;
+		sys.core[i].dcache.prefetch_buffer_hits=1;
+		sys.core[i].dcache.wbb_writes=1;
+		sys.core[i].dcache.wbb_reads=1;
+		//system.core?.BTB
+		for (j=0; j<20; j++) sys.core[i].BTB.BTB_config[j]=1;
+		sys.core[i].BTB.total_accesses=1;
+		sys.core[i].BTB.read_accesses=1;
+		sys.core[i].BTB.write_accesses=1;
+		sys.core[i].BTB.total_hits=1;
+		sys.core[i].BTB.total_misses=1;
+		sys.core[i].BTB.read_hits=1;
+		sys.core[i].BTB.write_hits=1;
+		sys.core[i].BTB.read_misses=1;
+		sys.core[i].BTB.write_misses=1;
+		sys.core[i].BTB.replacements=1;
+	}
+
+	//system_L1directory
+	for (i=0; i<=63; i++)
+	{
+		for (j=0; j<20; j++) sys.L1Directory[i].Dir_config[j]=1;
+		for (j=0; j<20; j++) sys.L1Directory[i].buffer_sizes[j]=1;
+		sys.L1Directory[i].clockrate=1;
+		sys.L1Directory[i].ports[20]=1;
+		sys.L1Directory[i].device_type=1;
+		strcpy(sys.L1Directory[i].threeD_stack,"default");
+		sys.L1Directory[i].total_accesses=1;
+		sys.L1Directory[i].read_accesses=1;
+		sys.L1Directory[i].write_accesses=1;
+		sys.L1Directory[i].duty_cycle =1;
+	}
+	//system_L2directory
+	for (i=0; i<=63; i++)
+	{
+		for (j=0; j<20; j++) sys.L2Directory[i].Dir_config[j]=1;
+		for (j=0; j<20; j++) sys.L2Directory[i].buffer_sizes[j]=1;
+		sys.L2Directory[i].clockrate=1;
+		sys.L2Directory[i].ports[20]=1;
+		sys.L2Directory[i].device_type=1;
+		strcpy(sys.L2Directory[i].threeD_stack,"default");
+		sys.L2Directory[i].total_accesses=1;
+		sys.L2Directory[i].read_accesses=1;
+		sys.L2Directory[i].write_accesses=1;
+		sys.L2Directory[i].duty_cycle =1;
+	}
+	for (i=0; i<=63; i++)
+	{
+		//system_L2
+		for (j=0; j<20; j++) sys.L2[i].L2_config[j]=1;
+		sys.L2[i].clockrate=1;
+		for (j=0; j<20; j++) sys.L2[i].ports[j]=1;
+		sys.L2[i].device_type=1;
+		strcpy(sys.L2[i].threeD_stack,"default");
+		for (j=0; j<20; j++) sys.L2[i].buffer_sizes[j]=1;
+		sys.L2[i].total_accesses=1;
+		sys.L2[i].read_accesses=1;
+		sys.L2[i].write_accesses=1;
+		sys.L2[i].total_hits=1;
+		sys.L2[i].total_misses=1;
+		sys.L2[i].read_hits=1;
+		sys.L2[i].write_hits=1;
+		sys.L2[i].read_misses=1;
+		sys.L2[i].write_misses=1;
+		sys.L2[i].replacements=1;
+		sys.L2[i].write_backs=1;
+		sys.L2[i].miss_buffer_accesses=1;
+		sys.L2[i].fill_buffer_accesses=1;
+		sys.L2[i].prefetch_buffer_accesses=1;
+		sys.L2[i].prefetch_buffer_writes=1;
+		sys.L2[i].prefetch_buffer_reads=1;
+		sys.L2[i].prefetch_buffer_hits=1;
+		sys.L2[i].wbb_writes=1;
+		sys.L2[i].wbb_reads=1;
+		sys.L2[i].duty_cycle =1;
+		sys.L2[i].merged_dir=false;
+		sys.L2[i].homenode_read_accesses =1;
+		sys.L2[i].homenode_write_accesses=1;
+		sys.L2[i].homenode_read_hits=1;
+		sys.L2[i].homenode_write_hits=1;
+		sys.L2[i].homenode_read_misses=1;
+		sys.L2[i].homenode_write_misses=1;
+		sys.L2[i].dir_duty_cycle=1;
+	}
+	for (i=0; i<=63; i++)
+	{
+		//system_L3
+		for (j=0; j<20; j++) sys.L3[i].L3_config[j]=1;
+		sys.L3[i].clockrate=1;
+		for (j=0; j<20; j++) sys.L3[i].ports[j]=1;
+		sys.L3[i].device_type=1;
+		strcpy(sys.L3[i].threeD_stack,"default");
+		for (j=0; j<20; j++) sys.L3[i].buffer_sizes[j]=1;
+		sys.L3[i].total_accesses=1;
+		sys.L3[i].read_accesses=1;
+		sys.L3[i].write_accesses=1;
+		sys.L3[i].total_hits=1;
+		sys.L3[i].total_misses=1;
+		sys.L3[i].read_hits=1;
+		sys.L3[i].write_hits=1;
+		sys.L3[i].read_misses=1;
+		sys.L3[i].write_misses=1;
+		sys.L3[i].replacements=1;
+		sys.L3[i].write_backs=1;
+		sys.L3[i].miss_buffer_accesses=1;
+		sys.L3[i].fill_buffer_accesses=1;
+		sys.L3[i].prefetch_buffer_accesses=1;
+		sys.L3[i].prefetch_buffer_writes=1;
+		sys.L3[i].prefetch_buffer_reads=1;
+		sys.L3[i].prefetch_buffer_hits=1;
+		sys.L3[i].wbb_writes=1;
+		sys.L3[i].wbb_reads=1;
+		sys.L3[i].duty_cycle =1;
+		sys.L3[i].merged_dir=false;
+		sys.L3[i].homenode_read_accesses =1;
+		sys.L3[i].homenode_write_accesses=1;
+		sys.L3[i].homenode_read_hits=1;
+		sys.L3[i].homenode_write_hits=1;
+		sys.L3[i].homenode_read_misses=1;
+		sys.L3[i].homenode_write_misses=1;
+		sys.L3[i].dir_duty_cycle=1;
+	}
+	//system_NoC
+	for (i=0; i<=63; i++)
+	{
+		sys.NoC[i].clockrate=1;
+		sys.NoC[i].type=true;
+		sys.NoC[i].chip_coverage=1;
+		sys.NoC[i].has_global_link = true;
+		strcpy(sys.NoC[i].topology,"default");
+		sys.NoC[i].horizontal_nodes=1;
+		sys.NoC[i].vertical_nodes=1;
+		sys.NoC[i].input_ports=1;
+		sys.NoC[i].output_ports=1;
+		sys.NoC[i].virtual_channel_per_port=1;
+		sys.NoC[i].flit_bits=1;
+		sys.NoC[i].input_buffer_entries_per_vc=1;
+		sys.NoC[i].total_accesses=1;
+		sys.NoC[i].duty_cycle=1;
+		sys.NoC[i].route_over_perc = 0.5;
+		for (j=0; j<20; j++) sys.NoC[i].ports_of_input_buffer[j]=1;
+		sys.NoC[i].number_of_crossbars=1;
+		strcpy(sys.NoC[i].crossbar_type,"default");
+		strcpy(sys.NoC[i].crosspoint_type,"default");
+		//system.NoC?.xbar0;
+		sys.NoC[i].xbar0.number_of_inputs_of_crossbars=1;
+		sys.NoC[i].xbar0.number_of_outputs_of_crossbars=1;
+		sys.NoC[i].xbar0.flit_bits=1;
+		sys.NoC[i].xbar0.input_buffer_entries_per_port=1;
+		sys.NoC[i].xbar0.ports_of_input_buffer[20]=1;
+		sys.NoC[i].xbar0.crossbar_accesses=1;
+	}
+	//system_mem
+	sys.mem.mem_tech_node=1;
+	sys.mem.device_clock=1;
+	sys.mem.capacity_per_channel=1;
+	sys.mem.number_ranks=1;
+	sys.mem.peak_transfer_rate =1;
+	sys.mem.num_banks_of_DRAM_chip=1;
+	sys.mem.Block_width_of_DRAM_chip=1;
+	sys.mem.output_width_of_DRAM_chip=1;
+	sys.mem.page_size_of_DRAM_chip=1;
+	sys.mem.burstlength_of_DRAM_chip=1;
+	sys.mem.internal_prefetch_of_DRAM_chip=1;
+	sys.mem.memory_accesses=1;
+	sys.mem.memory_reads=1;
+	sys.mem.memory_writes=1;
+
+	//system_mc
+	sys.mc.mc_clock =1;
+	sys.mc.number_mcs=1;
+	sys.mc.peak_transfer_rate =1;
+	sys.mc.memory_channels_per_mc=1;
+	sys.mc.number_ranks=1;
+	sys.mc.req_window_size_per_channel=1;
+	sys.mc.IO_buffer_size_per_channel=1;
+	sys.mc.databus_width=1;
+	sys.mc.addressbus_width=1;
+	sys.mc.memory_accesses=1;
+	sys.mc.memory_reads=1;
+	sys.mc.memory_writes=1;
+	sys.mc.LVDS=true;
+	sys.mc.type=1;
+
+	//system_niu
+	sys.niu.clockrate =1;
+	sys.niu.number_units=1;
+	sys.niu.type = 1;
+	sys.niu.duty_cycle =1;
+	sys.niu.total_load_perc=1;
+	//system_pcie
+	sys.pcie.clockrate =1;
+	sys.pcie.number_units=1;
+	sys.pcie.num_channels=1;
+	sys.pcie.type = 1;
+	sys.pcie.withPHY = false;
+	sys.pcie.duty_cycle =1;
+	sys.pcie.total_load_perc=1;
+	//system_flash_controller
+	sys.flashc.mc_clock =1;
+	sys.flashc.number_mcs=1;
+	sys.flashc.peak_transfer_rate =1;
+	sys.flashc.memory_channels_per_mc=1;
+	sys.flashc.number_ranks=1;
+	sys.flashc.req_window_size_per_channel=1;
+	sys.flashc.IO_buffer_size_per_channel=1;
+	sys.flashc.databus_width=1;
+	sys.flashc.addressbus_width=1;
+	sys.flashc.memory_accesses=1;
+	sys.flashc.memory_reads=1;
+	sys.flashc.memory_writes=1;
+	sys.flashc.LVDS=true;
+	sys.flashc.withPHY = false;
+	sys.flashc.type =1;
+	sys.flashc.duty_cycle =1;
+	sys.flashc.total_load_perc=1;
 }

--- a/src/gpuwattch/XML_Parse.cc
+++ b/src/gpuwattch/XML_Parse.cc
@@ -29,2102 +29,4558 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:												   *
+*      Modified by:
+**
 *      Jingwen Leng, Univeristy of Texas, Austin                   *
 *      Syed Gilani, University of Wisconsin–Madison                *
 *      Tayler Hetherington, University of British Columbia         *
 *      Ahmed ElTantawy, University of British Columbia             *
 ********************************************************************/
 
-#include <stdio.h>
-#include "xmlParser.h"
-#include <string>
 #include "XML_Parse.h"
+#include <stdio.h>
+#include <string>
+#include "xmlParser.h"
 
 using namespace std;
 
-const char * perf_count_label[] = {"TOT_INST,", "FP_INT,", "IC_H,", "IC_M,", "DC_RH,", "DC_RM,", "DC_WH,", "DC_WM,",
-                                "TC_H,", "TC_M,", "CC_H,", "CC_M,", "SHRD_ACC,", "REG_RD,", "REG_WR,", "NON_REG_OPs,",
-                                "SP_ACC,", "SFU_ACC,", "FPU_ACC,", "MEM_RD,","MEM_WR,", "MEM_PRE,", "L2_RH,", "L2_RM,", "L2_WH,",
-                                "L2_WM,", "NOC_A,", "PIPE_A,", "IDLE_CORE_N,", "CONST_DYNAMICN"};
+const char* perf_count_label[] = {
+    "TOT_INST,",    "FP_INT,",  "IC_H,",     "IC_M,",        "DC_RH,",
+    "DC_RM,",       "DC_WH,",   "DC_WM,",    "TC_H,",        "TC_M,",
+    "CC_H,",        "CC_M,",    "SHRD_ACC,", "REG_RD,",      "REG_WR,",
+    "NON_REG_OPs,", "SP_ACC,",  "SFU_ACC,",  "FPU_ACC,",     "MEM_RD,",
+    "MEM_WR,",      "MEM_PRE,", "L2_RH,",    "L2_RM,",       "L2_WH,",
+    "L2_WM,",       "NOC_A,",   "PIPE_A,",   "IDLE_CORE_N,", "CONST_DYNAMICN"};
 
-void ParseXML::parse(char* filepath)
-{
-	unsigned int i,j,k,m,n;
-	unsigned int NumofCom_4;
-	unsigned int itmp;
-	//Initialize all structures
-	ParseXML::initialize();
-	string strtmp;
-	char chtmp[60];
-	char chtmp1[60];
-	chtmp1[0]='\0';
-	// this open and parse the XML file:
-	XMLNode xMainNode=XMLNode::openFileHelper(filepath,"component"); //the 'component' in the first layer
+void ParseXML::parse(char* filepath) {
+  unsigned int i, j, k, m, n;
+  unsigned int NumofCom_4;
+  unsigned int itmp;
+  // Initialize all structures
+  ParseXML::initialize();
+  string strtmp;
+  char chtmp[60];
+  char chtmp1[60];
+  chtmp1[0] = '\0';
+  // this open and parse the XML file:
+  XMLNode xMainNode = XMLNode::openFileHelper(
+      filepath, "component");  // the 'component' in the first layer
 
-	XMLNode xNode2=xMainNode.getChildNode("component"); // the 'component' in the second layer
-	//get all params in the second layer
-	itmp=xNode2.nChildNode("param");
-	for(i=0; i<itmp; i++)
-	{
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"GPU_Architecture")==0) {sys.GPU_Architecture=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"number_of_cores")==0) {sys.number_of_cores=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"architecture")==0) {sys.architecture=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"number_of_L1Directories")==0) {sys.number_of_L1Directories=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"number_of_L2Directories")==0) {sys.number_of_L2Directories=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"number_of_L2s")==0) {sys.number_of_L2s=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"Private_L2")==0) {sys.Private_L2=(bool)atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"number_of_L3s")==0) {sys.number_of_L3s=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"number_of_NoCs")==0) {sys.number_of_NoCs=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"number_of_dir_levels")==0) {sys.number_of_dir_levels=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"domain_size")==0) {sys.domain_size=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"first_level_dir")==0) {sys.first_level_dir=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"homogeneous_cores")==0) {sys.homogeneous_cores=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"core_tech_node")==0) {sys.core_tech_node=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"target_core_clockrate")==0) {sys.target_core_clockrate=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"target_chip_area")==0) {sys.target_chip_area=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"temperature")==0) {sys.temperature=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"number_cache_levels")==0) {sys.number_cache_levels=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"L1_property")==0) {sys.L1_property =atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"L2_property")==0) {sys.L2_property =atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"homogeneous_L2s")==0) {sys.homogeneous_L2s=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"homogeneous_L1Directories")==0) {sys.homogeneous_L1Directories=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"homogeneous_L2Directories")==0) {sys.homogeneous_L2Directories=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"L3_property")==0) {sys.L3_property =atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"homogeneous_L3s")==0) {sys.homogeneous_L3s=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"homogeneous_ccs")==0) {sys.homogeneous_ccs=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"homogeneous_NoCs")==0) {sys.homogeneous_NoCs=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"Max_area_deviation")==0) {sys.Max_area_deviation=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"Max_power_deviation")==0) {sys.Max_power_deviation=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"device_type")==0) {sys.device_type=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"longer_channel_device")==0) {sys.longer_channel_device=(bool)atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"opt_dynamic_power")==0) {sys.opt_dynamic_power=(bool)atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"opt_lakage_power")==0) {sys.opt_lakage_power=(bool)atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"opt_clockrate")==0) {sys.opt_clockrate=(bool)atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"opt_area")==0) {sys.opt_area=(bool)atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"Embedded")==0) {sys.Embedded=(bool)atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"interconnect_projection_type")==0) {sys.interconnect_projection_type=atoi(xNode2.getChildNode("param",i).getAttribute("value"))==0?0:1;continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"machine_bits")==0) {sys.machine_bits=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"virtual_address_width")==0) {sys.virtual_address_width=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"physical_address_width")==0) {sys.physical_address_width=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"virtual_memory_page_size")==0) {sys.virtual_memory_page_size=atoi(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"idle_core_power")==0) {sys.idle_core_power=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"TOT_INST")==0) {sys.scaling_coefficients[TOT_INST]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"FP_INT")==0) {sys.scaling_coefficients[FP_INT]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"IC_H")==0) {sys.scaling_coefficients[IC_H]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"IC_M")==0) {sys.scaling_coefficients[IC_M]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"DC_RH")==0) {sys.scaling_coefficients[DC_RH]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"DC_RM")==0) {sys.scaling_coefficients[DC_RM]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"DC_WH")==0) {sys.scaling_coefficients[DC_WH]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"DC_WM")==0) {sys.scaling_coefficients[DC_WM]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"TC_H")==0) {sys.scaling_coefficients[TC_H]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"TC_M")==0) {sys.scaling_coefficients[TC_M]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"CC_H")==0) {sys.scaling_coefficients[CC_H]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"CC_M")==0) {sys.scaling_coefficients[CC_M]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"SHRD_ACC")==0) {sys.scaling_coefficients[SHRD_ACC]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"REG_RD")==0) {sys.scaling_coefficients[REG_RD]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"REG_WR")==0) {sys.scaling_coefficients[REG_WR]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"NON_REG_OPs")==0) {sys.scaling_coefficients[NON_REG_OPs]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"SP_ACC")==0) {sys.scaling_coefficients[SP_ACC]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"SFU_ACC")==0) {sys.scaling_coefficients[SFU_ACC]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"FPU_ACC")==0) {sys.scaling_coefficients[FPU_ACC]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"MEM_RD")==0) {sys.scaling_coefficients[MEM_RD]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"MEM_WR")==0) {sys.scaling_coefficients[MEM_WR]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"MEM_PRE")==0) {sys.scaling_coefficients[MEM_PRE]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"L2_RH")==0) {sys.scaling_coefficients[L2_RH]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"L2_RM")==0) {sys.scaling_coefficients[L2_RM]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"L2_WH")==0) {sys.scaling_coefficients[L2_WH]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"L2_WM")==0) {sys.scaling_coefficients[L2_WM]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"NOC_A")==0) {sys.scaling_coefficients[NOC_A]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"PIPE_A")==0) {sys.scaling_coefficients[PIPE_A]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"IDLE_CORE_N")==0) {sys.scaling_coefficients[IDLE_CORE_N]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
-        if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"CONST_DYNAMICN")==0) {sys.scaling_coefficients[CONST_DYNAMICN]=atof(xNode2.getChildNode("param",i).getAttribute("value"));continue;}
+  XMLNode xNode2 = xMainNode.getChildNode(
+      "component");  // the 'component' in the second layer
+  // get all params in the second layer
+  itmp = xNode2.nChildNode("param");
+  for (i = 0; i < itmp; i++) {
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "GPU_Architecture") == 0) {
+      sys.GPU_Architecture =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "number_of_cores") == 0) {
+      sys.number_of_cores =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "architecture") == 0) {
+      sys.architecture =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "number_of_L1Directories") == 0) {
+      sys.number_of_L1Directories =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "number_of_L2Directories") == 0) {
+      sys.number_of_L2Directories =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "number_of_L2s") == 0) {
+      sys.number_of_L2s =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "Private_L2") == 0) {
+      sys.Private_L2 =
+          (bool)atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "number_of_L3s") == 0) {
+      sys.number_of_L3s =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "number_of_NoCs") == 0) {
+      sys.number_of_NoCs =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "number_of_dir_levels") == 0) {
+      sys.number_of_dir_levels =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "domain_size") == 0) {
+      sys.domain_size =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "first_level_dir") == 0) {
+      sys.first_level_dir =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "homogeneous_cores") == 0) {
+      sys.homogeneous_cores =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "core_tech_node") == 0) {
+      sys.core_tech_node =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "target_core_clockrate") == 0) {
+      sys.target_core_clockrate =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "target_chip_area") == 0) {
+      sys.target_chip_area =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "temperature") == 0) {
+      sys.temperature =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "number_cache_levels") == 0) {
+      sys.number_cache_levels =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "L1_property") == 0) {
+      sys.L1_property =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "L2_property") == 0) {
+      sys.L2_property =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "homogeneous_L2s") == 0) {
+      sys.homogeneous_L2s =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "homogeneous_L1Directories") == 0) {
+      sys.homogeneous_L1Directories =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "homogeneous_L2Directories") == 0) {
+      sys.homogeneous_L2Directories =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "L3_property") == 0) {
+      sys.L3_property =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "homogeneous_L3s") == 0) {
+      sys.homogeneous_L3s =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "homogeneous_ccs") == 0) {
+      sys.homogeneous_ccs =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "homogeneous_NoCs") == 0) {
+      sys.homogeneous_NoCs =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "Max_area_deviation") == 0) {
+      sys.Max_area_deviation =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "Max_power_deviation") == 0) {
+      sys.Max_power_deviation =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "device_type") == 0) {
+      sys.device_type =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "longer_channel_device") == 0) {
+      sys.longer_channel_device =
+          (bool)atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "opt_dynamic_power") == 0) {
+      sys.opt_dynamic_power =
+          (bool)atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "opt_lakage_power") == 0) {
+      sys.opt_lakage_power =
+          (bool)atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "opt_clockrate") == 0) {
+      sys.opt_clockrate =
+          (bool)atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "opt_area") == 0) {
+      sys.opt_area =
+          (bool)atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "Embedded") == 0) {
+      sys.Embedded =
+          (bool)atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "interconnect_projection_type") == 0) {
+      sys.interconnect_projection_type =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value")) == 0 ? 0
+                                                                           : 1;
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "machine_bits") == 0) {
+      sys.machine_bits =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "virtual_address_width") == 0) {
+      sys.virtual_address_width =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "physical_address_width") == 0) {
+      sys.physical_address_width =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "virtual_memory_page_size") == 0) {
+      sys.virtual_memory_page_size =
+          atoi(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "idle_core_power") == 0) {
+      sys.idle_core_power =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "TOT_INST") == 0) {
+      sys.scaling_coefficients[TOT_INST] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "FP_INT") == 0) {
+      sys.scaling_coefficients[FP_INT] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "IC_H") ==
+        0) {
+      sys.scaling_coefficients[IC_H] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "IC_M") ==
+        0) {
+      sys.scaling_coefficients[IC_M] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "DC_RH") ==
+        0) {
+      sys.scaling_coefficients[DC_RH] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "DC_RM") ==
+        0) {
+      sys.scaling_coefficients[DC_RM] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "DC_WH") ==
+        0) {
+      sys.scaling_coefficients[DC_WH] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "DC_WM") ==
+        0) {
+      sys.scaling_coefficients[DC_WM] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "TC_H") ==
+        0) {
+      sys.scaling_coefficients[TC_H] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "TC_M") ==
+        0) {
+      sys.scaling_coefficients[TC_M] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "CC_H") ==
+        0) {
+      sys.scaling_coefficients[CC_H] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "CC_M") ==
+        0) {
+      sys.scaling_coefficients[CC_M] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "SHRD_ACC") == 0) {
+      sys.scaling_coefficients[SHRD_ACC] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "REG_RD") == 0) {
+      sys.scaling_coefficients[REG_RD] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "REG_WR") == 0) {
+      sys.scaling_coefficients[REG_WR] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "NON_REG_OPs") == 0) {
+      sys.scaling_coefficients[NON_REG_OPs] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "SP_ACC") == 0) {
+      sys.scaling_coefficients[SP_ACC] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "SFU_ACC") == 0) {
+      sys.scaling_coefficients[SFU_ACC] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "FPU_ACC") == 0) {
+      sys.scaling_coefficients[FPU_ACC] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "MEM_RD") == 0) {
+      sys.scaling_coefficients[MEM_RD] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "MEM_WR") == 0) {
+      sys.scaling_coefficients[MEM_WR] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "MEM_PRE") == 0) {
+      sys.scaling_coefficients[MEM_PRE] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "L2_RH") ==
+        0) {
+      sys.scaling_coefficients[L2_RH] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "L2_RM") ==
+        0) {
+      sys.scaling_coefficients[L2_RM] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "L2_WH") ==
+        0) {
+      sys.scaling_coefficients[L2_WH] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "L2_WM") ==
+        0) {
+      sys.scaling_coefficients[L2_WM] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"), "NOC_A") ==
+        0) {
+      sys.scaling_coefficients[NOC_A] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "PIPE_A") == 0) {
+      sys.scaling_coefficients[PIPE_A] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "IDLE_CORE_N") == 0) {
+      sys.scaling_coefficients[IDLE_CORE_N] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("param", i).getAttribute("name"),
+               "CONST_DYNAMICN") == 0) {
+      sys.scaling_coefficients[CONST_DYNAMICN] =
+          atof(xNode2.getChildNode("param", i).getAttribute("value"));
+      continue;
+    }
 
-/*
-		if (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"scaling_coefficients")==0)
-		{
-			strtmp.assign(xNode2.getChildNode("param",i).getAttribute("value"));
-			m=0;
-			for(n=0; n<strtmp.length(); n++)
-			{
-				if (strtmp[n]!=',')
-				{
-					sprintf(chtmp,"%c",strtmp[n]);
-					strcat(chtmp1,chtmp);
-				}
-				else{
-					sys.scaling_coefficients[m]=atof(chtmp1);
-					m++;
-					chtmp1[0]='\0';
-				}
-			}
-			sys.scaling_coefficients[m]=atof(chtmp1);
-			m++;
-			chtmp1[0]='\0';
-			continue;
-		}
-*/
-	}
+    /*
+                    if
+       (strcmp(xNode2.getChildNode("param",i).getAttribute("name"),"scaling_coefficients")==0)
+                    {
+                            strtmp.assign(xNode2.getChildNode("param",i).getAttribute("value"));
+                            m=0;
+                            for(n=0; n<strtmp.length(); n++)
+                            {
+                                    if (strtmp[n]!=',')
+                                    {
+                                            sprintf(chtmp,"%c",strtmp[n]);
+                                            strcat(chtmp1,chtmp);
+                                    }
+                                    else{
+                                            sys.scaling_coefficients[m]=atof(chtmp1);
+                                            m++;
+                                            chtmp1[0]='\0';
+                                    }
+                            }
+                            sys.scaling_coefficients[m]=atof(chtmp1);
+                            m++;
+                            chtmp1[0]='\0';
+                            continue;
+                    }
+    */
+  }
 
-//	if (sys.Private_L2 && sys.number_of_cores!=sys.number_of_L2s)
-//	{
-//		cout<<"Private L2: Number of L2s must equal to Number of Cores"<<endl;
-//		exit(0);
-//	}
+  //	if (sys.Private_L2 && sys.number_of_cores!=sys.number_of_L2s)
+  //	{
+  //		cout<<"Private L2: Number of L2s must equal to Number of
+  //Cores"<<endl;
+  //		exit(0);
+  //	}
 
-	itmp=xNode2.nChildNode("stat");
-	for(i=0; i<itmp; i++)
-	{
-		if (strcmp(xNode2.getChildNode("stat",i).getAttribute("name"),"total_cycles")==0) {sys.total_cycles=atof(xNode2.getChildNode("stat",i).getAttribute("value"));continue;}
-		if (strcmp(xNode2.getChildNode("stat",i).getAttribute("name"),"num_idle_cores")==0) {sys.num_idle_cores=atoi(xNode2.getChildNode("stat",i).getAttribute("value"));continue;}
+  itmp = xNode2.nChildNode("stat");
+  for (i = 0; i < itmp; i++) {
+    if (strcmp(xNode2.getChildNode("stat", i).getAttribute("name"),
+               "total_cycles") == 0) {
+      sys.total_cycles =
+          atof(xNode2.getChildNode("stat", i).getAttribute("value"));
+      continue;
+    }
+    if (strcmp(xNode2.getChildNode("stat", i).getAttribute("name"),
+               "num_idle_cores") == 0) {
+      sys.num_idle_cores =
+          atoi(xNode2.getChildNode("stat", i).getAttribute("value"));
+      continue;
+    }
+  }
 
-	}
+  // get the number of components within the second layer
+  unsigned int NumofCom_3 = xNode2.nChildNode("component");
+  XMLNode xNode3, xNode4;  // define the third-layer(system.core0) and
+                           // fourth-layer(system.core0.predictor) xnodes
 
+  unsigned int OrderofComponents_3layer = 0;
+  if (NumofCom_3 > OrderofComponents_3layer) {
+    //___________________________get all
+    //system.core0-n________________________________________________
+    if (sys.homogeneous_cores == 1)
+      OrderofComponents_3layer = 0;
+    else
+      OrderofComponents_3layer = sys.number_of_cores - 1;
+    for (i = 0; i <= OrderofComponents_3layer; i++) {
+      xNode3 = xNode2.getChildNode("component", i);
+      if (xNode3.isEmpty() == 1) {
+        printf(
+            "The value of homogeneous_cores or number_of_cores is not "
+            "correct!");
+        exit(0);
+      } else {
+        if (strstr(xNode3.getAttribute("name"), "core") != NULL) {
+          {  // For cpu0-cpui
+            // Get all params with system.core?
+            itmp = xNode3.nChildNode("param");
+            for (k = 0; k < itmp; k++) {
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "clock_rate") == 0) {
+                sys.core[i].clock_rate =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "opt_local") == 0) {
+                sys.core[i].opt_local = (bool)atoi(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "x86") == 0) {
+                sys.core[i].x86 = (bool)atoi(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "machine_bits") == 0) {
+                sys.core[i].machine_bits =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "virtual_address_width") == 0) {
+                sys.core[i].virtual_address_width =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "physical_address_width") == 0) {
+                sys.core[i].physical_address_width =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "instruction_length") == 0) {
+                sys.core[i].instruction_length =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "opcode_width") == 0) {
+                sys.core[i].opcode_width =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "micro_opcode_width") == 0) {
+                sys.core[i].micro_opcode_width =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "machine_type") == 0) {
+                sys.core[i].machine_type =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "internal_datapath_width") == 0) {
+                sys.core[i].internal_datapath_width =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "number_hardware_threads") == 0) {
+                sys.core[i].number_hardware_threads =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "fetch_width") == 0) {
+                sys.core[i].fetch_width =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "number_instruction_fetch_ports") == 0) {
+                sys.core[i].number_instruction_fetch_ports =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "decode_width") == 0) {
+                sys.core[i].decode_width =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "issue_width") == 0) {
+                sys.core[i].issue_width =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "peak_issue_width") == 0) {
+                sys.core[i].peak_issue_width =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "commit_width") == 0) {
+                sys.core[i].commit_width =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "fp_issue_width") == 0) {
+                sys.core[i].fp_issue_width =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "prediction_width") == 0) {
+                sys.core[i].prediction_width =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
 
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "pipelines_per_core") == 0) {
+                strtmp.assign(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                m = 0;
+                for (n = 0; n < strtmp.length(); n++) {
+                  if (strtmp[n] != ',') {
+                    sprintf(chtmp, "%c", strtmp[n]);
+                    strcat(chtmp1, chtmp);
+                  } else {
+                    sys.core[i].pipelines_per_core[m] = atoi(chtmp1);
+                    m++;
+                    chtmp1[0] = '\0';
+                  }
+                }
+                sys.core[i].pipelines_per_core[m] = atoi(chtmp1);
+                m++;
+                chtmp1[0] = '\0';
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "pipeline_depth") == 0) {
+                strtmp.assign(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                m = 0;
+                for (n = 0; n < strtmp.length(); n++) {
+                  if (strtmp[n] != ',') {
+                    sprintf(chtmp, "%c", strtmp[n]);
+                    strcat(chtmp1, chtmp);
+                  } else {
+                    sys.core[i].pipeline_depth[m] = atoi(chtmp1);
+                    m++;
+                    chtmp1[0] = '\0';
+                  }
+                }
+                sys.core[i].pipeline_depth[m] = atoi(chtmp1);
+                m++;
+                chtmp1[0] = '\0';
+                continue;
+              }
 
-	//get the number of components within the second layer
-	unsigned int NumofCom_3=xNode2.nChildNode("component");
-	XMLNode xNode3,xNode4; //define the third-layer(system.core0) and fourth-layer(system.core0.predictor) xnodes
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "FPU") == 0) {
+                strcpy(sys.core[i].FPU,
+                       xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "divider_multiplier") == 0) {
+                strcpy(sys.core[i].divider_multiplier,
+                       xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "ALU_per_core") == 0) {
+                sys.core[i].ALU_per_core =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "FPU_per_core") == 0) {
+                sys.core[i].FPU_per_core =
+                    atof(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "MUL_per_core") == 0) {
+                sys.core[i].MUL_per_core =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "instruction_buffer_size") == 0) {
+                sys.core[i].instruction_buffer_size =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "decoded_stream_buffer_size") == 0) {
+                sys.core[i].decoded_stream_buffer_size =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "instruction_window_scheme") == 0) {
+                sys.core[i].instruction_window_scheme =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "instruction_window_size") == 0) {
+                sys.core[i].instruction_window_size =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "fp_instruction_window_size") == 0) {
+                sys.core[i].fp_instruction_window_size =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "ROB_size") == 0) {
+                sys.core[i].ROB_size =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "rf_banks") == 0) {
+                sys.core[i].rf_banks =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "simd_width") == 0) {
+                sys.core[i].simd_width =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "collector_units") == 0) {
+                sys.core[i].collector_units =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "core_clock_ratio") == 0) {
+                sys.core[i].core_clock_ratio =
+                    atof(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "warp_size") == 0) {
+                sys.core[i].warp_size =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
 
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "archi_Regs_IRF_size") == 0) {
+                sys.core[i].archi_Regs_IRF_size =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "archi_Regs_FRF_size") == 0) {
+                sys.core[i].archi_Regs_FRF_size =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "phy_Regs_IRF_size") == 0) {
+                sys.core[i].phy_Regs_IRF_size =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "phy_Regs_FRF_size") == 0) {
+                sys.core[i].phy_Regs_FRF_size =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "rename_scheme") == 0) {
+                sys.core[i].rename_scheme =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "register_windows_size") == 0) {
+                sys.core[i].register_windows_size =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "LSU_order") == 0) {
+                strcpy(sys.core[i].LSU_order,
+                       xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "store_buffer_size") == 0) {
+                sys.core[i].store_buffer_size =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "load_buffer_size") == 0) {
+                sys.core[i].load_buffer_size =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "memory_ports") == 0) {
+                sys.core[i].memory_ports =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "Dcache_dual_pump") == 0) {
+                strcpy(sys.core[i].Dcache_dual_pump,
+                       xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "RAS_size") == 0) {
+                sys.core[i].RAS_size =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+            }
+            // Get all stats with system.core?
+            itmp = xNode3.nChildNode("stat");
+            for (k = 0; k < itmp; k++) {
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "total_instructions") == 0) {
+                sys.core[i].total_instructions =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "int_instructions") == 0) {
+                sys.core[i].int_instructions =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "fp_instructions") == 0) {
+                sys.core[i].fp_instructions =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "branch_instructions") == 0) {
+                sys.core[i].branch_instructions =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "branch_mispredictions") == 0) {
+                sys.core[i].branch_mispredictions =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "committed_instructions") == 0) {
+                sys.core[i].committed_instructions =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "committed_int_instructions") == 0) {
+                sys.core[i].committed_int_instructions =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "committed_fp_instructions") == 0) {
+                sys.core[i].committed_fp_instructions =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "load_instructions") == 0) {
+                sys.core[i].load_instructions =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "store_instructions") == 0) {
+                sys.core[i].store_instructions =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "total_cycles") == 0) {
+                sys.core[i].total_cycles =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "idle_cycles") == 0) {
+                sys.core[i].idle_cycles =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "busy_cycles") == 0) {
+                sys.core[i].busy_cycles =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "instruction_buffer_reads") == 0) {
+                sys.core[i].instruction_buffer_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "instruction_buffer_write") == 0) {
+                sys.core[i].instruction_buffer_write =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "ROB_reads") == 0) {
+                sys.core[i].ROB_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "ROB_writes") == 0) {
+                sys.core[i].ROB_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "rename_reads") == 0) {
+                sys.core[i].rename_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "rename_writes") == 0) {
+                sys.core[i].rename_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "fp_rename_reads") == 0) {
+                sys.core[i].fp_rename_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "fp_rename_writes") == 0) {
+                sys.core[i].fp_rename_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "inst_window_reads") == 0) {
+                sys.core[i].inst_window_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "inst_window_writes") == 0) {
+                sys.core[i].inst_window_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "inst_window_wakeup_accesses") == 0) {
+                sys.core[i].inst_window_wakeup_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "inst_window_selections") == 0) {
+                sys.core[i].inst_window_selections =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "fp_inst_window_reads") == 0) {
+                sys.core[i].fp_inst_window_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "fp_inst_window_writes") == 0) {
+                sys.core[i].fp_inst_window_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "fp_inst_window_wakeup_accesses") == 0) {
+                sys.core[i].fp_inst_window_wakeup_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "archi_int_regfile_reads") == 0) {
+                sys.core[i].archi_int_regfile_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "archi_float_regfile_reads") == 0) {
+                sys.core[i].archi_float_regfile_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "phy_int_regfile_reads") == 0) {
+                sys.core[i].phy_int_regfile_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "phy_float_regfile_reads") == 0) {
+                sys.core[i].phy_float_regfile_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "phy_int_regfile_writes") == 0) {
+                sys.core[i].archi_int_regfile_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "phy_float_regfile_writes") == 0) {
+                sys.core[i].archi_float_regfile_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "archi_int_regfile_writes") == 0) {
+                sys.core[i].phy_int_regfile_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "archi_float_regfile_writes") == 0) {
+                sys.core[i].phy_float_regfile_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "int_regfile_reads") == 0) {
+                sys.core[i].int_regfile_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "float_regfile_reads") == 0) {
+                sys.core[i].float_regfile_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "int_regfile_writes") == 0) {
+                sys.core[i].int_regfile_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "float_regfile_writes") == 0) {
+                sys.core[i].float_regfile_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "non_rf_operands") == 0) {
+                sys.core[i].non_rf_operands =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
 
-	unsigned int OrderofComponents_3layer=0;
-	if (NumofCom_3>OrderofComponents_3layer)
-	{
-		//___________________________get all system.core0-n________________________________________________
-		if (sys.homogeneous_cores==1) OrderofComponents_3layer=0;
-		else OrderofComponents_3layer=sys.number_of_cores-1;
-		for (i=0; i<=OrderofComponents_3layer; i++)
-		{
-			xNode3=xNode2.getChildNode("component",i);
-			if (xNode3.isEmpty()==1) {
-				printf("The value of homogeneous_cores or number_of_cores is not correct!");
-				exit(0);
-			}
-			else{
-				if (strstr(xNode3.getAttribute("name"),"core")!=NULL)
-				{
-					{ //For cpu0-cpui
-						//Get all params with system.core?
-						itmp=xNode3.nChildNode("param");
-						for(k=0; k<itmp; k++)
-						{
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"clock_rate")==0) {sys.core[i].clock_rate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"opt_local")==0) {sys.core[i].opt_local=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"x86")==0) {sys.core[i].x86=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"machine_bits")==0) {sys.core[i].machine_bits=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"virtual_address_width")==0) {sys.core[i].virtual_address_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"physical_address_width")==0) {sys.core[i].physical_address_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"instruction_length")==0) {sys.core[i].instruction_length=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"opcode_width")==0) {sys.core[i].opcode_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"micro_opcode_width")==0) {sys.core[i].micro_opcode_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"machine_type")==0) {sys.core[i].machine_type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"internal_datapath_width")==0) {sys.core[i].internal_datapath_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_hardware_threads")==0) {sys.core[i].number_hardware_threads=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"fetch_width")==0) {sys.core[i].fetch_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_instruction_fetch_ports")==0) {sys.core[i].number_instruction_fetch_ports=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"decode_width")==0) {sys.core[i].decode_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"issue_width")==0) {sys.core[i].issue_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"peak_issue_width")==0) {sys.core[i].peak_issue_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"commit_width")==0) {sys.core[i].commit_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"fp_issue_width")==0) {sys.core[i].fp_issue_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"prediction_width")==0) {sys.core[i].prediction_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "windowed_reg_accesses") == 0) {
+                sys.core[i].windowed_reg_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "windowed_reg_transports") == 0) {
+                sys.core[i].windowed_reg_transports =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "function_calls") == 0) {
+                sys.core[i].function_calls =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "context_switches") == 0) {
+                sys.core[i].context_switches =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "ialu_accesses") == 0) {
+                sys.core[i].ialu_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "fpu_accesses") == 0) {
+                sys.core[i].fpu_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "mul_accesses") == 0) {
+                sys.core[i].mul_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "cdb_alu_accesses") == 0) {
+                sys.core[i].cdb_alu_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "cdb_mul_accesses") == 0) {
+                sys.core[i].cdb_mul_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "cdb_fpu_accesses") == 0) {
+                sys.core[i].cdb_fpu_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "load_buffer_reads") == 0) {
+                sys.core[i].load_buffer_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "load_buffer_writes") == 0) {
+                sys.core[i].load_buffer_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "load_buffer_cams") == 0) {
+                sys.core[i].load_buffer_cams =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "store_buffer_reads") == 0) {
+                sys.core[i].store_buffer_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "store_buffer_writes") == 0) {
+                sys.core[i].store_buffer_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "store_buffer_cams") == 0) {
+                sys.core[i].store_buffer_cams =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "store_buffer_forwards") == 0) {
+                sys.core[i].store_buffer_forwards =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "main_memory_access") == 0) {
+                sys.core[i].main_memory_access =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "main_memory_read") == 0) {
+                sys.core[i].main_memory_read =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "main_memory_write") == 0) {
+                sys.core[i].main_memory_write =
+                    atoi(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "pipeline_duty_cycle") == 0) {
+                sys.core[i].pipeline_duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
 
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"pipelines_per_core")==0)
-							{
-								strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-								m=0;
-								for(n=0; n<strtmp.length(); n++)
-								{
-									if (strtmp[n]!=',')
-									{
-										sprintf(chtmp,"%c",strtmp[n]);
-										strcat(chtmp1,chtmp);
-									}
-									else{
-										sys.core[i].pipelines_per_core[m]=atoi(chtmp1);
-										m++;
-										chtmp1[0]='\0';
-									}
-								}
-								sys.core[i].pipelines_per_core[m]=atoi(chtmp1);
-								m++;
-								chtmp1[0]='\0';
-								continue;
-							}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"pipeline_depth")==0)
-							{
-								strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-								m=0;
-								for(n=0; n<strtmp.length(); n++)
-								{
-									if (strtmp[n]!=',')
-									{
-										sprintf(chtmp,"%c",strtmp[n]);
-										strcat(chtmp1,chtmp);
-									}
-									else{
-										sys.core[i].pipeline_depth[m]=atoi(chtmp1);
-										m++;
-										chtmp1[0]='\0';
-									}
-								}
-								sys.core[i].pipeline_depth[m]=atoi(chtmp1);
-								m++;
-								chtmp1[0]='\0';
-								continue;
-							}
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "IFU_duty_cycle") == 0) {
+                sys.core[i].IFU_duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "BR_duty_cycle") == 0) {
+                sys.core[i].BR_duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "LSU_duty_cycle") == 0) {
+                sys.core[i].LSU_duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "MemManU_I_duty_cycle") == 0) {
+                sys.core[i].MemManU_I_duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "MemManU_D_duty_cycle") == 0) {
+                sys.core[i].MemManU_D_duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "ALU_duty_cycle") == 0) {
+                sys.core[i].ALU_duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "MUL_duty_cycle") == 0) {
+                sys.core[i].MUL_duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "FPU_duty_cycle") == 0) {
+                sys.core[i].FPU_duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "ALU_cdb_duty_cycle") == 0) {
+                sys.core[i].ALU_cdb_duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "MUL_cdb_duty_cycle") == 0) {
+                sys.core[i].MUL_cdb_duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "FPU_cdb_duty_cycle") == 0) {
+                sys.core[i].FPU_cdb_duty_cycle =
+                    atoi(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+            }
+          }
 
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"FPU")==0) {strcpy(sys.core[i].FPU,xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"divider_multiplier")==0) {strcpy(sys.core[i].divider_multiplier,xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"ALU_per_core")==0) {sys.core[i].ALU_per_core=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"FPU_per_core")==0) {sys.core[i].FPU_per_core=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"MUL_per_core")==0) {sys.core[i].MUL_per_core=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"instruction_buffer_size")==0) {sys.core[i].instruction_buffer_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"decoded_stream_buffer_size")==0) {sys.core[i].decoded_stream_buffer_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"instruction_window_scheme")==0) {sys.core[i].instruction_window_scheme  =atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"instruction_window_size")==0) {sys.core[i].instruction_window_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"fp_instruction_window_size")==0) {sys.core[i].fp_instruction_window_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"ROB_size")==0) {sys.core[i].ROB_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"rf_banks")==0) {sys.core[i].rf_banks=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"simd_width")==0) {sys.core[i].simd_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"collector_units")==0) {sys.core[i].collector_units=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"core_clock_ratio")==0) {sys.core[i].core_clock_ratio=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"warp_size")==0) {sys.core[i].warp_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+          NumofCom_4 = xNode3.nChildNode("component");  // get the number of
+                                                        // components within the
+                                                        // third layer
+          for (j = 0; j < NumofCom_4; j++) {
+            xNode4 = xNode3.getChildNode("component", j);
+            if (strcmp(xNode4.getAttribute("name"), "PBT") == 0) {  // find PBT
+              itmp = xNode4.nChildNode("param");
+              for (k = 0; k < itmp; k++) {  // get all items of param in
+                                            // system.core0.predictor--PBT
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "prediction_width") == 0) {
+                  sys.core[i].predictor.prediction_width = atoi(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "prediction_scheme") == 0) {
+                  strcpy(sys.core[i].predictor.prediction_scheme,
+                         xNode4.getChildNode("param", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "predictor_size") == 0) {
+                  sys.core[i].predictor.predictor_size = atoi(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "predictor_entries") == 0) {
+                  sys.core[i].predictor.predictor_entries = atoi(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "local_predictor_size") == 0) {
+                  strtmp.assign(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  m = 0;
+                  for (n = 0; n < strtmp.length(); n++) {
+                    if (strtmp[n] != ',') {
+                      sprintf(chtmp, "%c", strtmp[n]);
+                      strcat(chtmp1, chtmp);
+                    } else {
+                      sys.core[i].predictor.local_predictor_size[m] =
+                          atoi(chtmp1);
+                      m++;
+                      chtmp1[0] = '\0';
+                    }
+                  }
+                  sys.core[i].predictor.local_predictor_size[m] = atoi(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "local_predictor_entries") == 0) {
+                  sys.core[i].predictor.local_predictor_entries = atoi(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "global_predictor_entries") == 0) {
+                  sys.core[i].predictor.global_predictor_entries = atoi(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "global_predictor_bits") == 0) {
+                  sys.core[i].predictor.global_predictor_bits = atoi(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "chooser_predictor_entries") == 0) {
+                  sys.core[i].predictor.chooser_predictor_entries = atoi(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "chooser_predictor_bits") == 0) {
+                  sys.core[i].predictor.chooser_predictor_bits = atoi(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  continue;
+                }
+              }
+              itmp = xNode4.nChildNode("stat");
+              for (k = 0; k < itmp; k++) {  // get all items of stat in
+                                            // system.core0.predictor--PBT
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "predictor_accesses") == 0)
+                  sys.core[i].predictor.predictor_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+              }
+            }
+            if (strcmp(xNode4.getAttribute("name"), "itlb") ==
+                0) {  // find system.core0.itlb
+              itmp = xNode4.nChildNode("param");
+              for (k = 0; k < itmp;
+                   k++) {  // get all items of param in system.core0.itlb--itlb
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "number_entries") == 0)
+                  sys.core[i].itlb.number_entries = atoi(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+              }
+              itmp = xNode4.nChildNode("stat");
+              for (k = 0; k < itmp; k++) {  // get all items of stat in itlb
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_hits") == 0) {
+                  sys.core[i].itlb.total_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_accesses") == 0) {
+                  sys.core[i].itlb.total_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_misses") == 0) {
+                  sys.core[i].itlb.total_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "conflicts") == 0) {
+                  sys.core[i].itlb.conflicts = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+              }
+            }
+            if (strcmp(xNode4.getAttribute("name"), "icache") ==
+                0) {  // find system.core0.icache
+              itmp = xNode4.nChildNode("param");
+              for (k = 0; k < itmp; k++) {  // get all items of param in
+                                            // system.core0.icache--icache
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "icache_config") == 0) {
+                  strtmp.assign(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  m = 0;
+                  for (n = 0; n < strtmp.length(); n++) {
+                    if (strtmp[n] != ',') {
+                      sprintf(chtmp, "%c", strtmp[n]);
+                      strcat(chtmp1, chtmp);
+                    } else {
+                      sys.core[i].icache.icache_config[m] = atof(chtmp1);
+                      m++;
+                      chtmp1[0] = '\0';
+                    }
+                  }
+                  sys.core[i].icache.icache_config[m] = atof(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "buffer_sizes") == 0) {
+                  strtmp.assign(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  m = 0;
+                  for (n = 0; n < strtmp.length(); n++) {
+                    if (strtmp[n] != ',') {
+                      sprintf(chtmp, "%c", strtmp[n]);
+                      strcat(chtmp1, chtmp);
+                    } else {
+                      sys.core[i].icache.buffer_sizes[m] = atoi(chtmp1);
+                      m++;
+                      chtmp1[0] = '\0';
+                    }
+                  }
+                  sys.core[i].icache.buffer_sizes[m] = atoi(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                }
+              }
+              itmp = xNode4.nChildNode("stat");
+              for (k = 0; k < itmp; k++) {
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_accesses") == 0) {
+                  sys.core[i].icache.total_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_accesses") == 0) {
+                  sys.core[i].icache.read_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_misses") == 0) {
+                  sys.core[i].icache.read_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "replacements") == 0) {
+                  sys.core[i].icache.replacements = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_hits") == 0) {
+                  sys.core[i].icache.read_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_hits") == 0) {
+                  sys.core[i].icache.total_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_misses") == 0) {
+                  sys.core[i].icache.total_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "miss_buffer_access") == 0) {
+                  sys.core[i].icache.miss_buffer_access = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "fill_buffer_accesses") == 0) {
+                  sys.core[i].icache.fill_buffer_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_accesses") == 0) {
+                  sys.core[i].icache.prefetch_buffer_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_writes") == 0) {
+                  sys.core[i].icache.prefetch_buffer_writes = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_reads") == 0) {
+                  sys.core[i].icache.prefetch_buffer_reads = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_hits") == 0) {
+                  sys.core[i].icache.prefetch_buffer_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "conflicts") == 0) {
+                  sys.core[i].icache.conflicts = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+              }
+            }
+            if (strcmp(xNode4.getAttribute("name"), "dtlb") ==
+                0) {  // find system.core0.dtlb
+              itmp = xNode4.nChildNode("param");
+              for (k = 0; k < itmp;
+                   k++) {  // get all items of param in system.core0.dtlb--dtlb
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "number_entries") == 0)
+                  sys.core[i].dtlb.number_entries = atoi(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+              }
+              itmp = xNode4.nChildNode("stat");
+              for (k = 0; k < itmp; k++) {  // get all items of stat in dtlb
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_accesses") == 0) {
+                  sys.core[i].dtlb.total_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_accesses") == 0) {
+                  sys.core[i].dtlb.read_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_accesses") == 0) {
+                  sys.core[i].dtlb.write_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_hits") == 0) {
+                  sys.core[i].dtlb.read_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_hits") == 0) {
+                  sys.core[i].dtlb.write_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_misses") == 0) {
+                  sys.core[i].dtlb.read_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_misses") == 0) {
+                  sys.core[i].dtlb.write_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_hits") == 0) {
+                  sys.core[i].dtlb.total_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_misses") == 0) {
+                  sys.core[i].dtlb.total_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "conflicts") == 0) {
+                  sys.core[i].dtlb.conflicts = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+              }
+            }
 
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"archi_Regs_IRF_size")==0) {sys.core[i].archi_Regs_IRF_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"archi_Regs_FRF_size")==0) {sys.core[i].archi_Regs_FRF_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"phy_Regs_IRF_size")==0) {sys.core[i].phy_Regs_IRF_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"phy_Regs_FRF_size")==0) {sys.core[i].phy_Regs_FRF_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"rename_scheme")==0) {sys.core[i].rename_scheme=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"register_windows_size")==0) {sys.core[i].register_windows_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"LSU_order")==0) {strcpy(sys.core[i].LSU_order,xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"store_buffer_size")==0) {sys.core[i].store_buffer_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"load_buffer_size")==0) {sys.core[i].load_buffer_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"memory_ports")==0) {sys.core[i].memory_ports=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"Dcache_dual_pump")==0) {strcpy(sys.core[i].Dcache_dual_pump,xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"RAS_size")==0) {sys.core[i].RAS_size=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-						}
-						//Get all stats with system.core?
-						itmp=xNode3.nChildNode("stat");
-						for(k=0; k<itmp; k++)
-						{
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_instructions")==0) {sys.core[i].total_instructions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"int_instructions")==0) {sys.core[i].int_instructions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"fp_instructions")==0) {sys.core[i].fp_instructions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"branch_instructions")==0) {sys.core[i].branch_instructions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"branch_mispredictions")==0) {sys.core[i].branch_mispredictions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"committed_instructions")==0) {sys.core[i].committed_instructions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"committed_int_instructions")==0) {sys.core[i].committed_int_instructions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"committed_fp_instructions")==0) {sys.core[i].committed_fp_instructions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"load_instructions")==0) {sys.core[i].load_instructions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"store_instructions")==0) {sys.core[i].store_instructions=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_cycles")==0) {sys.core[i].total_cycles=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"idle_cycles")==0) {sys.core[i].idle_cycles=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"busy_cycles")==0) {sys.core[i].busy_cycles=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"instruction_buffer_reads")==0) {sys.core[i].instruction_buffer_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"instruction_buffer_write")==0) {sys.core[i].instruction_buffer_write=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"ROB_reads")==0) {sys.core[i].ROB_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"ROB_writes")==0) {sys.core[i].ROB_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"rename_reads")==0) {sys.core[i].rename_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"rename_writes")==0) {sys.core[i].rename_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"fp_rename_reads")==0) {sys.core[i].fp_rename_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"fp_rename_writes")==0) {sys.core[i].fp_rename_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"inst_window_reads")==0) {sys.core[i].inst_window_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"inst_window_writes")==0) {sys.core[i].inst_window_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"inst_window_wakeup_accesses")==0) {sys.core[i].inst_window_wakeup_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"inst_window_selections")==0) {sys.core[i].inst_window_selections=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"fp_inst_window_reads")==0) {sys.core[i].fp_inst_window_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"fp_inst_window_writes")==0) {sys.core[i].fp_inst_window_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"fp_inst_window_wakeup_accesses")==0) {sys.core[i].fp_inst_window_wakeup_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"archi_int_regfile_reads")==0) {sys.core[i].archi_int_regfile_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"archi_float_regfile_reads")==0) {sys.core[i].archi_float_regfile_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"phy_int_regfile_reads")==0) {sys.core[i].phy_int_regfile_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"phy_float_regfile_reads")==0) {sys.core[i].phy_float_regfile_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"phy_int_regfile_writes")==0) {sys.core[i].archi_int_regfile_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"phy_float_regfile_writes")==0) {sys.core[i].archi_float_regfile_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"archi_int_regfile_writes")==0) {sys.core[i].phy_int_regfile_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"archi_float_regfile_writes")==0) {sys.core[i].phy_float_regfile_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"int_regfile_reads")==0) {sys.core[i].int_regfile_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"float_regfile_reads")==0) {sys.core[i].float_regfile_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"int_regfile_writes")==0) {sys.core[i].int_regfile_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"float_regfile_writes")==0) {sys.core[i].float_regfile_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"non_rf_operands")==0) {sys.core[i].non_rf_operands=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+            // Added by Jingwen
+            if (strcmp(xNode4.getAttribute("name"), "ccache") ==
+                0) {  // find system.core0.ccache
+              itmp = xNode4.nChildNode("param");
+              for (k = 0; k < itmp; k++) {  // get all items of param in
+                                            // system.core0.ccache--ccache
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "ccache_config") == 0) {
+                  strtmp.assign(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  m = 0;
+                  for (n = 0; n < strtmp.length(); n++) {
+                    if (strtmp[n] != ',') {
+                      sprintf(chtmp, "%c", strtmp[n]);
+                      strcat(chtmp1, chtmp);
+                    } else {
+                      sys.core[i].ccache.dcache_config[m] = atof(chtmp1);
+                      m++;
+                      chtmp1[0] = '\0';
+                    }
+                  }
+                  sys.core[i].ccache.dcache_config[m] = atof(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "buffer_sizes") == 0) {
+                  strtmp.assign(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  m = 0;
+                  for (n = 0; n < strtmp.length(); n++) {
+                    if (strtmp[n] != ',') {
+                      sprintf(chtmp, "%c", strtmp[n]);
+                      strcat(chtmp1, chtmp);
+                    } else {
+                      sys.core[i].ccache.buffer_sizes[m] = atoi(chtmp1);
+                      m++;
+                      chtmp1[0] = '\0';
+                    }
+                  }
+                  sys.core[i].ccache.buffer_sizes[m] = atoi(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                }
+              }
+              itmp = xNode4.nChildNode("stat");
+              for (k = 0; k < itmp; k++) {  // get all items of stat in ccache
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_accesses") == 0) {
+                  sys.core[i].ccache.total_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_accesses") == 0) {
+                  sys.core[i].ccache.read_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_accesses") == 0) {
+                  sys.core[i].ccache.write_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_hits") == 0) {
+                  sys.core[i].ccache.total_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_misses") == 0) {
+                  sys.core[i].ccache.total_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_hits") == 0) {
+                  sys.core[i].ccache.read_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_hits") == 0) {
+                  sys.core[i].ccache.write_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_misses") == 0) {
+                  sys.core[i].ccache.read_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_misses") == 0) {
+                  sys.core[i].ccache.write_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "replacements") == 0) {
+                  sys.core[i].ccache.replacements = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_backs") == 0) {
+                  sys.core[i].ccache.write_backs = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "miss_buffer_access") == 0) {
+                  sys.core[i].ccache.miss_buffer_access = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "fill_buffer_accesses") == 0) {
+                  sys.core[i].ccache.fill_buffer_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_accesses") == 0) {
+                  sys.core[i].ccache.prefetch_buffer_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_writes") == 0) {
+                  sys.core[i].ccache.prefetch_buffer_writes = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_reads") == 0) {
+                  sys.core[i].ccache.prefetch_buffer_reads = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_hits") == 0) {
+                  sys.core[i].ccache.prefetch_buffer_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "wbb_writes") == 0) {
+                  sys.core[i].ccache.wbb_writes = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "wbb_reads") == 0) {
+                  sys.core[i].ccache.wbb_reads = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "conflicts") == 0) {
+                  sys.core[i].ccache.conflicts = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+              }
+            }
 
+            // tcache
+            if (strcmp(xNode4.getAttribute("name"), "tcache") ==
+                0) {  // find system.core0.tcache
+              itmp = xNode4.nChildNode("param");
+              for (k = 0; k < itmp; k++) {  // get all items of param in
+                                            // system.core0.tcache--tcache
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "tcache_config") == 0) {
+                  strtmp.assign(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  m = 0;
+                  for (n = 0; n < strtmp.length(); n++) {
+                    if (strtmp[n] != ',') {
+                      sprintf(chtmp, "%c", strtmp[n]);
+                      strcat(chtmp1, chtmp);
+                    } else {
+                      sys.core[i].tcache.dcache_config[m] = atof(chtmp1);
+                      m++;
+                      chtmp1[0] = '\0';
+                    }
+                  }
+                  sys.core[i].tcache.dcache_config[m] = atof(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "buffer_sizes") == 0) {
+                  strtmp.assign(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  m = 0;
+                  for (n = 0; n < strtmp.length(); n++) {
+                    if (strtmp[n] != ',') {
+                      sprintf(chtmp, "%c", strtmp[n]);
+                      strcat(chtmp1, chtmp);
+                    } else {
+                      sys.core[i].tcache.buffer_sizes[m] = atoi(chtmp1);
+                      m++;
+                      chtmp1[0] = '\0';
+                    }
+                  }
+                  sys.core[i].tcache.buffer_sizes[m] = atoi(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                }
+              }
+              itmp = xNode4.nChildNode("stat");
+              for (k = 0; k < itmp; k++) {  // get all items of stat in tcache
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_accesses") == 0) {
+                  sys.core[i].tcache.total_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_accesses") == 0) {
+                  sys.core[i].tcache.read_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_accesses") == 0) {
+                  sys.core[i].tcache.write_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_hits") == 0) {
+                  sys.core[i].tcache.total_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_misses") == 0) {
+                  sys.core[i].tcache.total_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_hits") == 0) {
+                  sys.core[i].tcache.read_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_hits") == 0) {
+                  sys.core[i].tcache.write_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_misses") == 0) {
+                  sys.core[i].tcache.read_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_misses") == 0) {
+                  sys.core[i].tcache.write_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "replacements") == 0) {
+                  sys.core[i].tcache.replacements = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_backs") == 0) {
+                  sys.core[i].tcache.write_backs = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "miss_buffer_access") == 0) {
+                  sys.core[i].tcache.miss_buffer_access = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "fill_buffer_accesses") == 0) {
+                  sys.core[i].tcache.fill_buffer_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_accesses") == 0) {
+                  sys.core[i].tcache.prefetch_buffer_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_writes") == 0) {
+                  sys.core[i].tcache.prefetch_buffer_writes = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_reads") == 0) {
+                  sys.core[i].tcache.prefetch_buffer_reads = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_hits") == 0) {
+                  sys.core[i].tcache.prefetch_buffer_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "wbb_writes") == 0) {
+                  sys.core[i].tcache.wbb_writes = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "wbb_reads") == 0) {
+                  sys.core[i].tcache.wbb_reads = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "conflicts") == 0) {
+                  sys.core[i].tcache.conflicts = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+              }
+            }
 
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"windowed_reg_accesses")==0) {sys.core[i].windowed_reg_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"windowed_reg_transports")==0) {sys.core[i].windowed_reg_transports=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"function_calls")==0) {sys.core[i].function_calls=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"context_switches")==0) {sys.core[i].context_switches=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"ialu_accesses")==0) {sys.core[i].ialu_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"fpu_accesses")==0) {sys.core[i].fpu_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"mul_accesses")==0) {sys.core[i].mul_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"cdb_alu_accesses")==0) {sys.core[i].cdb_alu_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"cdb_mul_accesses")==0) {sys.core[i].cdb_mul_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"cdb_fpu_accesses")==0) {sys.core[i].cdb_fpu_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"load_buffer_reads")==0) {sys.core[i].load_buffer_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"load_buffer_writes")==0) {sys.core[i].load_buffer_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"load_buffer_cams")==0) {sys.core[i].load_buffer_cams=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"store_buffer_reads")==0) {sys.core[i].store_buffer_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"store_buffer_writes")==0) {sys.core[i].store_buffer_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"store_buffer_cams")==0) {sys.core[i].store_buffer_cams=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"store_buffer_forwards")==0) {sys.core[i].store_buffer_forwards=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"main_memory_access")==0) {sys.core[i].main_memory_access=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"main_memory_read")==0) {sys.core[i].main_memory_read=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"main_memory_write")==0) {sys.core[i].main_memory_write=atoi(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"pipeline_duty_cycle")==0) {sys.core[i].pipeline_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+            if (strcmp(xNode4.getAttribute("name"), "sharedmemory") ==
+                0) {  // find system.core0.sharedmemory
+              itmp = xNode4.nChildNode("param");
+              for (k = 0; k < itmp;
+                   k++) {  // get all items of param in
+                           // system.core0.sharedmemory--sharedmemory
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "sharedmemory_config") == 0) {
+                  strtmp.assign(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  m = 0;
+                  for (n = 0; n < strtmp.length(); n++) {
+                    if (strtmp[n] != ',') {
+                      sprintf(chtmp, "%c", strtmp[n]);
+                      strcat(chtmp1, chtmp);
+                    } else {
+                      sys.core[i].sharedmemory.dcache_config[m] = atof(chtmp1);
+                      m++;
+                      chtmp1[0] = '\0';
+                    }
+                  }
+                  sys.core[i].sharedmemory.dcache_config[m] = atof(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "buffer_sizes") == 0) {
+                  strtmp.assign(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  m = 0;
+                  for (n = 0; n < strtmp.length(); n++) {
+                    if (strtmp[n] != ',') {
+                      sprintf(chtmp, "%c", strtmp[n]);
+                      strcat(chtmp1, chtmp);
+                    } else {
+                      sys.core[i].sharedmemory.buffer_sizes[m] = atoi(chtmp1);
+                      m++;
+                      chtmp1[0] = '\0';
+                    }
+                  }
+                  sys.core[i].sharedmemory.buffer_sizes[m] = atoi(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                }
+              }
+              itmp = xNode4.nChildNode("stat");
+              for (k = 0; k < itmp;
+                   k++) {  // get all items of stat in sharedmemory
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_accesses") == 0) {
+                  sys.core[i].sharedmemory.total_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_accesses") == 0) {
+                  sys.core[i].sharedmemory.read_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_accesses") == 0) {
+                  sys.core[i].sharedmemory.write_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_hits") == 0) {
+                  sys.core[i].sharedmemory.total_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_misses") == 0) {
+                  sys.core[i].sharedmemory.total_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_hits") == 0) {
+                  sys.core[i].sharedmemory.read_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_hits") == 0) {
+                  sys.core[i].sharedmemory.write_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_misses") == 0) {
+                  sys.core[i].sharedmemory.read_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_misses") == 0) {
+                  sys.core[i].sharedmemory.write_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "replacements") == 0) {
+                  sys.core[i].sharedmemory.replacements = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_backs") == 0) {
+                  sys.core[i].sharedmemory.write_backs = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "miss_buffer_access") == 0) {
+                  sys.core[i].sharedmemory.miss_buffer_access = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "fill_buffer_accesses") == 0) {
+                  sys.core[i].sharedmemory.fill_buffer_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_accesses") == 0) {
+                  sys.core[i].sharedmemory.prefetch_buffer_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_writes") == 0) {
+                  sys.core[i].sharedmemory.prefetch_buffer_writes = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_reads") == 0) {
+                  sys.core[i].sharedmemory.prefetch_buffer_reads = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_hits") == 0) {
+                  sys.core[i].sharedmemory.prefetch_buffer_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "wbb_writes") == 0) {
+                  sys.core[i].sharedmemory.wbb_writes = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "wbb_reads") == 0) {
+                  sys.core[i].sharedmemory.wbb_reads = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "conflicts") == 0) {
+                  sys.core[i].sharedmemory.conflicts = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+              }
+            }
 
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"IFU_duty_cycle")==0) {sys.core[i].IFU_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"BR_duty_cycle")==0) {sys.core[i].BR_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"LSU_duty_cycle")==0) {sys.core[i].LSU_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"MemManU_I_duty_cycle")==0) {sys.core[i].MemManU_I_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"MemManU_D_duty_cycle")==0) {sys.core[i].MemManU_D_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"ALU_duty_cycle")==0) {sys.core[i].ALU_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"MUL_duty_cycle")==0) {sys.core[i].MUL_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"FPU_duty_cycle")==0) {sys.core[i].FPU_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"ALU_cdb_duty_cycle")==0) {sys.core[i].ALU_cdb_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"MUL_cdb_duty_cycle")==0) {sys.core[i].MUL_cdb_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"FPU_cdb_duty_cycle")==0) {sys.core[i].FPU_cdb_duty_cycle=atoi(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-						}
-					}
+            if (strcmp(xNode4.getAttribute("name"), "dcache") ==
+                0) {  // find system.core0.dcache
+              itmp = xNode4.nChildNode("param");
+              for (k = 0; k < itmp; k++) {  // get all items of param in
+                                            // system.core0.dcache--dcache
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "dcache_config") == 0) {
+                  strtmp.assign(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  m = 0;
+                  for (n = 0; n < strtmp.length(); n++) {
+                    if (strtmp[n] != ',') {
+                      sprintf(chtmp, "%c", strtmp[n]);
+                      strcat(chtmp1, chtmp);
+                    } else {
+                      sys.core[i].dcache.dcache_config[m] = atof(chtmp1);
+                      m++;
+                      chtmp1[0] = '\0';
+                    }
+                  }
+                  sys.core[i].dcache.dcache_config[m] = atof(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "buffer_sizes") == 0) {
+                  strtmp.assign(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  m = 0;
+                  for (n = 0; n < strtmp.length(); n++) {
+                    if (strtmp[n] != ',') {
+                      sprintf(chtmp, "%c", strtmp[n]);
+                      strcat(chtmp1, chtmp);
+                    } else {
+                      sys.core[i].dcache.buffer_sizes[m] = atoi(chtmp1);
+                      m++;
+                      chtmp1[0] = '\0';
+                    }
+                  }
+                  sys.core[i].dcache.buffer_sizes[m] = atoi(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                }
+              }
+              itmp = xNode4.nChildNode("stat");
+              for (k = 0; k < itmp; k++) {  // get all items of stat in dcache
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_accesses") == 0) {
+                  sys.core[i].dcache.total_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_accesses") == 0) {
+                  sys.core[i].dcache.read_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_accesses") == 0) {
+                  sys.core[i].dcache.write_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_hits") == 0) {
+                  sys.core[i].dcache.total_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_misses") == 0) {
+                  sys.core[i].dcache.total_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_hits") == 0) {
+                  sys.core[i].dcache.read_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_hits") == 0) {
+                  sys.core[i].dcache.write_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_misses") == 0) {
+                  sys.core[i].dcache.read_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_misses") == 0) {
+                  sys.core[i].dcache.write_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "replacements") == 0) {
+                  sys.core[i].dcache.replacements = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_backs") == 0) {
+                  sys.core[i].dcache.write_backs = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "miss_buffer_access") == 0) {
+                  sys.core[i].dcache.miss_buffer_access = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "fill_buffer_accesses") == 0) {
+                  sys.core[i].dcache.fill_buffer_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_accesses") == 0) {
+                  sys.core[i].dcache.prefetch_buffer_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_writes") == 0) {
+                  sys.core[i].dcache.prefetch_buffer_writes = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_reads") == 0) {
+                  sys.core[i].dcache.prefetch_buffer_reads = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "prefetch_buffer_hits") == 0) {
+                  sys.core[i].dcache.prefetch_buffer_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "wbb_writes") == 0) {
+                  sys.core[i].dcache.wbb_writes = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "wbb_reads") == 0) {
+                  sys.core[i].dcache.wbb_reads = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "conflicts") == 0) {
+                  sys.core[i].dcache.conflicts = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+              }
+            }
 
-					NumofCom_4=xNode3.nChildNode("component"); //get the number of components within the third layer
-					for(j=0; j<NumofCom_4; j++)
-					{
-						xNode4=xNode3.getChildNode("component",j);
-						if (strcmp(xNode4.getAttribute("name"),"PBT")==0)
-						{ //find PBT
-							itmp=xNode4.nChildNode("param");
-							for(k=0; k<itmp; k++)
-							{ //get all items of param in system.core0.predictor--PBT
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"prediction_width")==0) {sys.core[i].predictor.prediction_width=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"prediction_scheme")==0) {strcpy(sys.core[i].predictor.prediction_scheme,xNode4.getChildNode("param",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"predictor_size")==0) {sys.core[i].predictor.predictor_size=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"predictor_entries")==0) {sys.core[i].predictor.predictor_entries=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"local_predictor_size")==0)
-								{
-									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
-									m=0;
-									for(n=0; n<strtmp.length(); n++)
-									{
-										if (strtmp[n]!=',')
-										{
-											sprintf(chtmp,"%c",strtmp[n]);
-											strcat(chtmp1,chtmp);
-										}
-										else{
-											sys.core[i].predictor.local_predictor_size[m]=atoi(chtmp1);
-											m++;
-											chtmp1[0]='\0';
-										}
-									}
-									sys.core[i].predictor.local_predictor_size[m]=atoi(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-									continue;
-								}
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"local_predictor_entries")==0) {sys.core[i].predictor.local_predictor_entries=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"global_predictor_entries")==0) {sys.core[i].predictor.global_predictor_entries=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"global_predictor_bits")==0) {sys.core[i].predictor.global_predictor_bits=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"chooser_predictor_entries")==0) {sys.core[i].predictor.chooser_predictor_entries=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"chooser_predictor_bits")==0) {sys.core[i].predictor.chooser_predictor_bits=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
-							}
-							itmp=xNode4.nChildNode("stat");
-							for(k=0; k<itmp; k++)
-							{ //get all items of stat in system.core0.predictor--PBT
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"predictor_accesses")==0) sys.core[i].predictor.predictor_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));
-							}
-						}
-						if (strcmp(xNode4.getAttribute("name"),"itlb")==0)
-						{//find system.core0.itlb
-							itmp=xNode4.nChildNode("param");
-							for(k=0; k<itmp; k++)
-							{ //get all items of param in system.core0.itlb--itlb
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"number_entries")==0) sys.core[i].itlb.number_entries=atoi(xNode4.getChildNode("param",k).getAttribute("value"));
-							}
-							itmp=xNode4.nChildNode("stat");
-							for(k=0; k<itmp; k++)
-							{ //get all items of stat in itlb
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.core[i].itlb.total_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.core[i].itlb.total_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.core[i].itlb.total_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.core[i].itlb.conflicts=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-							}
-						}
-						if (strcmp(xNode4.getAttribute("name"),"icache")==0)
-						{//find system.core0.icache
-							itmp=xNode4.nChildNode("param");
-							for(k=0; k<itmp; k++)
-							{ //get all items of param in system.core0.icache--icache
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"icache_config")==0)
-								{
-									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
-									m=0;
-									for(n=0; n<strtmp.length(); n++)
-									{
-										if (strtmp[n]!=',')
-										{
-											sprintf(chtmp,"%c",strtmp[n]);
-											strcat(chtmp1,chtmp);
-										}
-										else{
-											sys.core[i].icache.icache_config[m]=atof(chtmp1);
-											m++;
-											chtmp1[0]='\0';
-										}
-									}
-									sys.core[i].icache.icache_config[m]=atof(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-									continue;
-								}
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"buffer_sizes")==0)
-								{
-									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
-									m=0;
-									for(n=0; n<strtmp.length(); n++)
-									{
-										if (strtmp[n]!=',')
-										{
-											sprintf(chtmp,"%c",strtmp[n]);
-											strcat(chtmp1,chtmp);
-										}
-										else{
-											sys.core[i].icache.buffer_sizes[m]=atoi(chtmp1);
-											m++;
-											chtmp1[0]='\0';
-										}
-									}
-									sys.core[i].icache.buffer_sizes[m]=atoi(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-								}
-							}
-							itmp=xNode4.nChildNode("stat");
-							for(k=0; k<itmp; k++)
-							{
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.core[i].icache.total_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.core[i].icache.read_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.core[i].icache.read_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"replacements")==0) {sys.core[i].icache.replacements=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_hits")==0) {sys.core[i].icache.read_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.core[i].icache.total_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.core[i].icache.total_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"miss_buffer_access")==0) {sys.core[i].icache.miss_buffer_access=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"fill_buffer_accesses")==0) {sys.core[i].icache.fill_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_accesses")==0) {sys.core[i].icache.prefetch_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_writes")==0) {sys.core[i].icache.prefetch_buffer_writes=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_reads")==0) {sys.core[i].icache.prefetch_buffer_reads=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_hits")==0) {sys.core[i].icache.prefetch_buffer_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.core[i].icache.conflicts=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-							}
-						}
-						if (strcmp(xNode4.getAttribute("name"),"dtlb")==0)
-						{//find system.core0.dtlb
-							itmp=xNode4.nChildNode("param");
-							for(k=0; k<itmp; k++)
-							{ //get all items of param in system.core0.dtlb--dtlb
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"number_entries")==0) sys.core[i].dtlb.number_entries=atoi(xNode4.getChildNode("param",k).getAttribute("value"));
-							}
-							itmp=xNode4.nChildNode("stat");
-							for(k=0; k<itmp; k++)
-							{ //get all items of stat in dtlb
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.core[i].dtlb.total_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.core[i].dtlb.read_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.core[i].dtlb.write_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_hits")==0) {sys.core[i].dtlb.read_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_hits")==0) {sys.core[i].dtlb.write_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.core[i].dtlb.read_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.core[i].dtlb.write_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.core[i].dtlb.total_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.core[i].dtlb.total_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.core[i].dtlb.conflicts=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+            if (strcmp(xNode4.getAttribute("name"), "BTB") ==
+                0) {  // find system.core0.BTB
+              itmp = xNode4.nChildNode("param");
+              for (k = 0; k < itmp;
+                   k++) {  // get all items of param in system.core0.BTB--BTB
+                if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
+                           "BTB_config") == 0) {
+                  strtmp.assign(
+                      xNode4.getChildNode("param", k).getAttribute("value"));
+                  m = 0;
+                  for (n = 0; n < strtmp.length(); n++) {
+                    if (strtmp[n] != ',') {
+                      sprintf(chtmp, "%c", strtmp[n]);
+                      strcat(chtmp1, chtmp);
+                    } else {
+                      sys.core[i].BTB.BTB_config[m] = atoi(chtmp1);
+                      m++;
+                      chtmp1[0] = '\0';
+                    }
+                  }
+                  sys.core[i].BTB.BTB_config[m] = atoi(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                }
+              }
+              itmp = xNode4.nChildNode("stat");
+              for (k = 0; k < itmp; k++) {  // get all items of stat in BTB
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_accesses") == 0) {
+                  sys.core[i].BTB.total_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_accesses") == 0) {
+                  sys.core[i].BTB.read_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_accesses") == 0) {
+                  sys.core[i].BTB.write_accesses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_hits") == 0) {
+                  sys.core[i].BTB.total_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "total_misses") == 0) {
+                  sys.core[i].BTB.total_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_hits") == 0) {
+                  sys.core[i].BTB.read_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_hits") == 0) {
+                  sys.core[i].BTB.write_hits = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "read_misses") == 0) {
+                  sys.core[i].BTB.read_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "write_misses") == 0) {
+                  sys.core[i].BTB.write_misses = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+                if (strcmp(xNode4.getChildNode("stat", k).getAttribute("name"),
+                           "replacements") == 0) {
+                  sys.core[i].BTB.replacements = atof(
+                      xNode4.getChildNode("stat", k).getAttribute("value"));
+                  continue;
+                }
+              }
+            }
+          }
+        } else {
+          printf(
+              "The value of homogeneous_cores or number_of_cores is not "
+              "correct!");
+          exit(0);
+        }
+      }
+    }
 
-							}
-						}
+    //__________________________________________Get
+    //system.L1Directory0-n____________________________________________
+    int w, tmpOrderofComponents_3layer;
+    w = OrderofComponents_3layer + 1;
+    tmpOrderofComponents_3layer = OrderofComponents_3layer;
+    if (sys.homogeneous_L1Directories == 1)
+      OrderofComponents_3layer = OrderofComponents_3layer + 1;
+    else
+      OrderofComponents_3layer =
+          OrderofComponents_3layer + sys.number_of_L1Directories;
 
-// Added by Jingwen
-						if (strcmp(xNode4.getAttribute("name"),"ccache")==0)
-						{//find system.core0.ccache
-							itmp=xNode4.nChildNode("param");
-							for(k=0; k<itmp; k++)
-							{ //get all items of param in system.core0.ccache--ccache
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"ccache_config")==0)
-								{
-									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
-									m=0;
-									for(n=0; n<strtmp.length(); n++)
-									{
-										if (strtmp[n]!=',')
-										{
-											sprintf(chtmp,"%c",strtmp[n]);
-											strcat(chtmp1,chtmp);
-										}
-										else{
-											sys.core[i].ccache.dcache_config[m]=atof(chtmp1);
-											m++;
-											chtmp1[0]='\0';
-										}
-									}
-									sys.core[i].ccache.dcache_config[m]=atof(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-									continue;
-								}
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"buffer_sizes")==0)
-								{
-									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
-									m=0;
-									for(n=0; n<strtmp.length(); n++)
-									{
-										if (strtmp[n]!=',')
-										{
-											sprintf(chtmp,"%c",strtmp[n]);
-											strcat(chtmp1,chtmp);
-										}
-										else{
-											sys.core[i].ccache.buffer_sizes[m]=atoi(chtmp1);
-											m++;
-											chtmp1[0]='\0';
-										}
-									}
-									sys.core[i].ccache.buffer_sizes[m]=atoi(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-								}
-							}
-							itmp=xNode4.nChildNode("stat");
-							for(k=0; k<itmp; k++)
-							{ //get all items of stat in ccache
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.core[i].ccache.total_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.core[i].ccache.read_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.core[i].ccache.write_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.core[i].ccache.total_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.core[i].ccache.total_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_hits")==0) {sys.core[i].ccache.read_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_hits")==0) {sys.core[i].ccache.write_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.core[i].ccache.read_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.core[i].ccache.write_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"replacements")==0) {sys.core[i].ccache.replacements=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_backs")==0) {sys.core[i].ccache.write_backs=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"miss_buffer_access")==0) {sys.core[i].ccache.miss_buffer_access=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"fill_buffer_accesses")==0) {sys.core[i].ccache.fill_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_accesses")==0) {sys.core[i].ccache.prefetch_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_writes")==0) {sys.core[i].ccache.prefetch_buffer_writes=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_reads")==0) {sys.core[i].ccache.prefetch_buffer_reads=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_hits")==0) {sys.core[i].ccache.prefetch_buffer_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"wbb_writes")==0) {sys.core[i].ccache.wbb_writes=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"wbb_reads")==0) {sys.core[i].ccache.wbb_reads=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.core[i].ccache.conflicts=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+    for (i = 0; i < (OrderofComponents_3layer - tmpOrderofComponents_3layer);
+         i++) {
+      xNode3 = xNode2.getChildNode("component", w);
+      if (xNode3.isEmpty() == 1) {
+        printf(
+            "The value of homogeneous_L1Directories or number_of_L1Directories "
+            "is not correct!");
+        exit(0);
+      } else {
+        if (strstr(xNode3.getAttribute("id"), "L1Directory") != NULL) {
+          itmp = xNode3.nChildNode("param");
+          for (k = 0; k < itmp;
+               k++) {  // get all items of param in system.L1Directory
+            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                       "Dir_config") == 0) {
+              strtmp.assign(
+                  xNode3.getChildNode("param", k).getAttribute("value"));
+              m = 0;
+              for (n = 0; n < strtmp.length(); n++) {
+                if (strtmp[n] != ',') {
+                  sprintf(chtmp, "%c", strtmp[n]);
+                  strcat(chtmp1, chtmp);
+                } else {
+                  sys.L1Directory[i].Dir_config[m] = atof(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                }
+              }
+              sys.L1Directory[i].Dir_config[m] = atof(chtmp1);
+              m++;
+              chtmp1[0] = '\0';
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                       "buffer_sizes") == 0) {
+              strtmp.assign(
+                  xNode3.getChildNode("param", k).getAttribute("value"));
+              m = 0;
+              for (n = 0; n < strtmp.length(); n++) {
+                if (strtmp[n] != ',') {
+                  sprintf(chtmp, "%c", strtmp[n]);
+                  strcat(chtmp1, chtmp);
+                } else {
+                  sys.L1Directory[i].buffer_sizes[m] = atoi(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                }
+              }
+              sys.L1Directory[i].buffer_sizes[m] = atoi(chtmp1);
+              m++;
+              chtmp1[0] = '\0';
+              continue;
+            }
 
-							}
-						}
+            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                       "clockrate") == 0) {
+              sys.L1Directory[i].clockrate =
+                  atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                       "ports") == 0) {
+              strtmp.assign(
+                  xNode3.getChildNode("param", k).getAttribute("value"));
+              m = 0;
+              for (n = 0; n < strtmp.length(); n++) {
+                if (strtmp[n] != ',') {
+                  sprintf(chtmp, "%c", strtmp[n]);
+                  strcat(chtmp1, chtmp);
+                } else {
+                  sys.L1Directory[i].ports[m] = atoi(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                }
+              }
+              sys.L1Directory[i].ports[m] = atoi(chtmp1);
+              m++;
+              chtmp1[0] = '\0';
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                       "device_type") == 0) {
+              sys.L1Directory[i].device_type =
+                  atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                       "Directory_type") == 0) {
+              sys.L1Directory[i].Directory_type =
+                  atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                       "3D_stack") == 0) {
+              strcpy(sys.L1Directory[i].threeD_stack,
+                     xNode3.getChildNode("param", k).getAttribute("value"));
+              continue;
+            }
+          }
+          itmp = xNode3.nChildNode("stat");
+          for (k = 0; k < itmp;
+               k++) {  // get all items of stat in system.L2directorydirectory
+            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                       "total_accesses") == 0) {
+              sys.L1Directory[i].total_accesses =
+                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                       "read_accesses") == 0) {
+              sys.L1Directory[i].read_accesses =
+                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                       "write_accesses") == 0) {
+              sys.L1Directory[i].write_accesses =
+                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                       "read_misses") == 0) {
+              sys.L1Directory[i].read_misses =
+                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                       "write_misses") == 0) {
+              sys.L1Directory[i].write_misses =
+                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                       "conflicts") == 0) {
+              sys.L1Directory[i].conflicts =
+                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                       "duty_cycle") == 0) {
+              sys.L1Directory[i].duty_cycle =
+                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              continue;
+            }
+          }
+          w = w + 1;
+        } else {
+          printf(
+              "The value of homogeneous_L1Directories or "
+              "number_of_L1Directories is not correct!");
+          exit(0);
+        }
+      }
+    }
 
-            //tcache
-						if (strcmp(xNode4.getAttribute("name"),"tcache")==0)
-						{//find system.core0.tcache
-							itmp=xNode4.nChildNode("param");
-							for(k=0; k<itmp; k++)
-							{ //get all items of param in system.core0.tcache--tcache
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"tcache_config")==0)
-								{
-									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
-									m=0;
-									for(n=0; n<strtmp.length(); n++)
-									{
-										if (strtmp[n]!=',')
-										{
-											sprintf(chtmp,"%c",strtmp[n]);
-											strcat(chtmp1,chtmp);
-										}
-										else{
-											sys.core[i].tcache.dcache_config[m]=atof(chtmp1);
-											m++;
-											chtmp1[0]='\0';
-										}
-									}
-									sys.core[i].tcache.dcache_config[m]=atof(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-									continue;
-								}
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"buffer_sizes")==0)
-								{
-									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
-									m=0;
-									for(n=0; n<strtmp.length(); n++)
-									{
-										if (strtmp[n]!=',')
-										{
-											sprintf(chtmp,"%c",strtmp[n]);
-											strcat(chtmp1,chtmp);
-										}
-										else{
-											sys.core[i].tcache.buffer_sizes[m]=atoi(chtmp1);
-											m++;
-											chtmp1[0]='\0';
-										}
-									}
-									sys.core[i].tcache.buffer_sizes[m]=atoi(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-								}
-							}
-							itmp=xNode4.nChildNode("stat");
-							for(k=0; k<itmp; k++)
-							{ //get all items of stat in tcache
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.core[i].tcache.total_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.core[i].tcache.read_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.core[i].tcache.write_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.core[i].tcache.total_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.core[i].tcache.total_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_hits")==0) {sys.core[i].tcache.read_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_hits")==0) {sys.core[i].tcache.write_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.core[i].tcache.read_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.core[i].tcache.write_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"replacements")==0) {sys.core[i].tcache.replacements=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_backs")==0) {sys.core[i].tcache.write_backs=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"miss_buffer_access")==0) {sys.core[i].tcache.miss_buffer_access=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"fill_buffer_accesses")==0) {sys.core[i].tcache.fill_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_accesses")==0) {sys.core[i].tcache.prefetch_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_writes")==0) {sys.core[i].tcache.prefetch_buffer_writes=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_reads")==0) {sys.core[i].tcache.prefetch_buffer_reads=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_hits")==0) {sys.core[i].tcache.prefetch_buffer_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"wbb_writes")==0) {sys.core[i].tcache.wbb_writes=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"wbb_reads")==0) {sys.core[i].tcache.wbb_reads=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.core[i].tcache.conflicts=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+    //__________________________________________Get
+    //system.L2Directory0-n____________________________________________
+    w = OrderofComponents_3layer + 1;
+    tmpOrderofComponents_3layer = OrderofComponents_3layer;
+    if (sys.homogeneous_L2Directories == 1)
+      OrderofComponents_3layer = OrderofComponents_3layer + 1;
+    else
+      OrderofComponents_3layer =
+          OrderofComponents_3layer + sys.number_of_L2Directories;
 
-							}
-						}
+    for (i = 0; i < (OrderofComponents_3layer - tmpOrderofComponents_3layer);
+         i++) {
+      xNode3 = xNode2.getChildNode("component", w);
+      if (xNode3.isEmpty() == 1) {
+        printf(
+            "The value of homogeneous_L2Directories or number_of_L2Directories "
+            "is not correct!");
+        exit(0);
+      } else {
+        if (strstr(xNode3.getAttribute("id"), "L2Directory") != NULL) {
+          itmp = xNode3.nChildNode("param");
+          for (k = 0; k < itmp;
+               k++) {  // get all items of param in system.L2Directory
+            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                       "Dir_config") == 0) {
+              strtmp.assign(
+                  xNode3.getChildNode("param", k).getAttribute("value"));
+              m = 0;
+              for (n = 0; n < strtmp.length(); n++) {
+                if (strtmp[n] != ',') {
+                  sprintf(chtmp, "%c", strtmp[n]);
+                  strcat(chtmp1, chtmp);
+                } else {
+                  sys.L2Directory[i].Dir_config[m] = atof(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                }
+              }
+              sys.L2Directory[i].Dir_config[m] = atof(chtmp1);
+              m++;
+              chtmp1[0] = '\0';
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                       "buffer_sizes") == 0) {
+              strtmp.assign(
+                  xNode3.getChildNode("param", k).getAttribute("value"));
+              m = 0;
+              for (n = 0; n < strtmp.length(); n++) {
+                if (strtmp[n] != ',') {
+                  sprintf(chtmp, "%c", strtmp[n]);
+                  strcat(chtmp1, chtmp);
+                } else {
+                  sys.L2Directory[i].buffer_sizes[m] = atoi(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                }
+              }
+              sys.L2Directory[i].buffer_sizes[m] = atoi(chtmp1);
+              m++;
+              chtmp1[0] = '\0';
+              continue;
+            }
 
+            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                       "clockrate") == 0) {
+              sys.L2Directory[i].clockrate =
+                  atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                       "Directory_type") == 0) {
+              sys.L2Directory[i].Directory_type =
+                  atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                       "ports") == 0) {
+              strtmp.assign(
+                  xNode3.getChildNode("param", k).getAttribute("value"));
+              m = 0;
+              for (n = 0; n < strtmp.length(); n++) {
+                if (strtmp[n] != ',') {
+                  sprintf(chtmp, "%c", strtmp[n]);
+                  strcat(chtmp1, chtmp);
+                } else {
+                  sys.L2Directory[i].ports[m] = atoi(chtmp1);
+                  m++;
+                  chtmp1[0] = '\0';
+                }
+              }
+              sys.L2Directory[i].ports[m] = atoi(chtmp1);
+              m++;
+              chtmp1[0] = '\0';
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                       "device_type") == 0) {
+              sys.L2Directory[i].device_type =
+                  atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                       "3D_stack") == 0) {
+              strcpy(sys.L2Directory[i].threeD_stack,
+                     xNode3.getChildNode("param", k).getAttribute("value"));
+              continue;
+            }
+          }
+          itmp = xNode3.nChildNode("stat");
+          for (k = 0; k < itmp;
+               k++) {  // get all items of stat in system.L2directorydirectory
+            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                       "total_accesses") == 0) {
+              sys.L2Directory[i].total_accesses =
+                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                       "read_accesses") == 0) {
+              sys.L2Directory[i].read_accesses =
+                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                       "write_accesses") == 0) {
+              sys.L2Directory[i].write_accesses =
+                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                       "read_misses") == 0) {
+              sys.L2Directory[i].read_misses =
+                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                       "write_misses") == 0) {
+              sys.L2Directory[i].write_misses =
+                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                       "conflicts") == 0) {
+              sys.L2Directory[i].conflicts =
+                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              continue;
+            }
+            if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                       "duty_cycle") == 0) {
+              sys.L2Directory[i].duty_cycle =
+                  atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              continue;
+            }
+          }
+          w = w + 1;
+        } else {
+          printf(
+              "The value of homogeneous_L2Directories or "
+              "number_of_L2Directories is not correct!");
+          exit(0);
+        }
+      }
+    }
 
-						if (strcmp(xNode4.getAttribute("name"),"sharedmemory")==0)
-						{//find system.core0.sharedmemory
-							itmp=xNode4.nChildNode("param");
-							for(k=0; k<itmp; k++)
-							{ //get all items of param in system.core0.sharedmemory--sharedmemory
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"sharedmemory_config")==0)
-								{
-									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
-									m=0;
-									for(n=0; n<strtmp.length(); n++)
-									{
-										if (strtmp[n]!=',')
-										{
-											sprintf(chtmp,"%c",strtmp[n]);
-											strcat(chtmp1,chtmp);
-										}
-										else{
-											sys.core[i].sharedmemory.dcache_config[m]=atof(chtmp1);
-											m++;
-											chtmp1[0]='\0';
-										}
-									}
-									sys.core[i].sharedmemory.dcache_config[m]=atof(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-									continue;
-								}
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"buffer_sizes")==0)
-								{
-									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
-									m=0;
-									for(n=0; n<strtmp.length(); n++)
-									{
-										if (strtmp[n]!=',')
-										{
-											sprintf(chtmp,"%c",strtmp[n]);
-											strcat(chtmp1,chtmp);
-										}
-										else{
-											sys.core[i].sharedmemory.buffer_sizes[m]=atoi(chtmp1);
-											m++;
-											chtmp1[0]='\0';
-										}
-									}
-									sys.core[i].sharedmemory.buffer_sizes[m]=atoi(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-								}
-							}
-							itmp=xNode4.nChildNode("stat");
-							for(k=0; k<itmp; k++)
-							{ //get all items of stat in sharedmemory
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.core[i].sharedmemory.total_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.core[i].sharedmemory.read_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.core[i].sharedmemory.write_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.core[i].sharedmemory.total_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.core[i].sharedmemory.total_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_hits")==0) {sys.core[i].sharedmemory.read_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_hits")==0) {sys.core[i].sharedmemory.write_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.core[i].sharedmemory.read_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.core[i].sharedmemory.write_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"replacements")==0) {sys.core[i].sharedmemory.replacements=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_backs")==0) {sys.core[i].sharedmemory.write_backs=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"miss_buffer_access")==0) {sys.core[i].sharedmemory.miss_buffer_access=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"fill_buffer_accesses")==0) {sys.core[i].sharedmemory.fill_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_accesses")==0) {sys.core[i].sharedmemory.prefetch_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_writes")==0) {sys.core[i].sharedmemory.prefetch_buffer_writes=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_reads")==0) {sys.core[i].sharedmemory.prefetch_buffer_reads=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_hits")==0) {sys.core[i].sharedmemory.prefetch_buffer_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"wbb_writes")==0) {sys.core[i].sharedmemory.wbb_writes=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"wbb_reads")==0) {sys.core[i].sharedmemory.wbb_reads=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.core[i].sharedmemory.conflicts=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+    //__________________________________________Get
+    //system.L2[0..n]____________________________________________
+    w = OrderofComponents_3layer + 1;
+    tmpOrderofComponents_3layer = OrderofComponents_3layer;
+    if (sys.homogeneous_L2s == 1)
+      OrderofComponents_3layer = OrderofComponents_3layer + 1;
+    else
+      OrderofComponents_3layer = OrderofComponents_3layer + sys.number_of_L2s;
 
-							}
-						}
+    for (i = 0; i < (OrderofComponents_3layer - tmpOrderofComponents_3layer);
+         i++) {
+      xNode3 = xNode2.getChildNode("component", w);
+      if (xNode3.isEmpty() == 1) {
+        printf("The value of homogeneous_L2s or number_of_L2s is not correct!");
+        exit(0);
+      } else {
+        if (strstr(xNode3.getAttribute("name"), "L2") != NULL) {
+          {  // For L20-L2i
+            // Get all params with system.L2?
+            itmp = xNode3.nChildNode("param");
+            for (k = 0; k < itmp; k++) {
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "L2_config") == 0) {
+                strtmp.assign(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                m = 0;
+                for (n = 0; n < strtmp.length(); n++) {
+                  if (strtmp[n] != ',') {
+                    sprintf(chtmp, "%c", strtmp[n]);
+                    strcat(chtmp1, chtmp);
+                  } else {
+                    sys.L2[i].L2_config[m] = atof(chtmp1);
+                    m++;
+                    chtmp1[0] = '\0';
+                  }
+                }
+                sys.L2[i].L2_config[m] = atof(chtmp1);
+                m++;
+                chtmp1[0] = '\0';
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "clockrate") == 0) {
+                sys.L2[i].clockrate =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "merged_dir") == 0) {
+                sys.L2[i].merged_dir = (bool)atoi(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "ports") == 0) {
+                strtmp.assign(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                m = 0;
+                for (n = 0; n < strtmp.length(); n++) {
+                  if (strtmp[n] != ',') {
+                    sprintf(chtmp, "%c", strtmp[n]);
+                    strcat(chtmp1, chtmp);
+                  } else {
+                    sys.L2[i].ports[m] = atoi(chtmp1);
+                    m++;
+                    chtmp1[0] = '\0';
+                  }
+                }
+                sys.L2[i].ports[m] = atoi(chtmp1);
+                m++;
+                chtmp1[0] = '\0';
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "device_type") == 0) {
+                sys.L2[i].device_type =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "threeD_stack") == 0) {
+                strcpy(sys.L2[i].threeD_stack,
+                       (xNode3.getChildNode("param", k).getAttribute("value")));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "buffer_sizes") == 0) {
+                strtmp.assign(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                m = 0;
+                for (n = 0; n < strtmp.length(); n++) {
+                  if (strtmp[n] != ',') {
+                    sprintf(chtmp, "%c", strtmp[n]);
+                    strcat(chtmp1, chtmp);
+                  } else {
+                    sys.L2[i].buffer_sizes[m] = atoi(chtmp1);
+                    m++;
+                    chtmp1[0] = '\0';
+                  }
+                }
+                sys.L2[i].buffer_sizes[m] = atoi(chtmp1);
+                m++;
+                chtmp1[0] = '\0';
+                continue;
+              }
+            }
+            // Get all stats with system.L2?
+            itmp = xNode3.nChildNode("stat");
+            for (k = 0; k < itmp; k++) {
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "total_accesses") == 0) {
+                sys.L2[i].total_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "read_accesses") == 0) {
+                sys.L2[i].read_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "write_accesses") == 0) {
+                sys.L2[i].write_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "total_hits") == 0) {
+                sys.L2[i].total_hits =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "total_misses") == 0) {
+                sys.L2[i].total_misses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "read_hits") == 0) {
+                sys.L2[i].read_hits =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "write_hits") == 0) {
+                sys.L2[i].write_hits =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "read_misses") == 0) {
+                sys.L2[i].read_misses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "write_misses") == 0) {
+                sys.L2[i].write_misses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "replacements") == 0) {
+                sys.L2[i].replacements =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "write_backs") == 0) {
+                sys.L2[i].write_backs =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "miss_buffer_accesses") == 0) {
+                sys.L2[i].miss_buffer_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "fill_buffer_accesses") == 0) {
+                sys.L2[i].fill_buffer_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "prefetch_buffer_accesses") == 0) {
+                sys.L2[i].prefetch_buffer_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "prefetch_buffer_writes") == 0) {
+                sys.L2[i].prefetch_buffer_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "prefetch_buffer_reads") == 0) {
+                sys.L2[i].prefetch_buffer_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "prefetch_buffer_hits") == 0) {
+                sys.L2[i].prefetch_buffer_hits =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "wbb_writes") == 0) {
+                sys.L2[i].wbb_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "wbb_reads") == 0) {
+                sys.L2[i].wbb_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "conflicts") == 0) {
+                sys.L2[i].conflicts =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "duty_cycle") == 0) {
+                sys.L2[i].duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
 
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "homenode_read_accesses") == 0) {
+                sys.L2[i].homenode_read_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "homenode_read_accesses") == 0) {
+                sys.L2[i].homenode_read_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "homenode_read_hits") == 0) {
+                sys.L2[i].homenode_read_hits =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "homenode_write_hits") == 0) {
+                sys.L2[i].homenode_write_hits =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "homenode_read_misses") == 0) {
+                sys.L2[i].homenode_read_misses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "homenode_write_misses") == 0) {
+                sys.L2[i].homenode_write_misses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "dir_duty_cycle") == 0) {
+                sys.L2[i].dir_duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+            }
+          }
+          w = w + 1;
+        } else {
+          printf(
+              "The value of homogeneous_L2s or number_of_L2s is not correct!");
+          exit(0);
+        }
+      }
+    }
+    //__________________________________________Get
+    //system.L3[0..n]____________________________________________
+    w = OrderofComponents_3layer + 1;
+    tmpOrderofComponents_3layer = OrderofComponents_3layer;
+    if (sys.homogeneous_L3s == 1)
+      OrderofComponents_3layer = OrderofComponents_3layer + 1;
+    else
+      OrderofComponents_3layer = OrderofComponents_3layer + sys.number_of_L3s;
 
-						if (strcmp(xNode4.getAttribute("name"),"dcache")==0)
-						{//find system.core0.dcache
-							itmp=xNode4.nChildNode("param");
-							for(k=0; k<itmp; k++)
-							{ //get all items of param in system.core0.dcache--dcache
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"dcache_config")==0)
-								{
-									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
-									m=0;
-									for(n=0; n<strtmp.length(); n++)
-									{
-										if (strtmp[n]!=',')
-										{
-											sprintf(chtmp,"%c",strtmp[n]);
-											strcat(chtmp1,chtmp);
-										}
-										else{
-											sys.core[i].dcache.dcache_config[m]=atof(chtmp1);
-											m++;
-											chtmp1[0]='\0';
-										}
-									}
-									sys.core[i].dcache.dcache_config[m]=atof(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-									continue;
-								}
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"buffer_sizes")==0)
-								{
-									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
-									m=0;
-									for(n=0; n<strtmp.length(); n++)
-									{
-										if (strtmp[n]!=',')
-										{
-											sprintf(chtmp,"%c",strtmp[n]);
-											strcat(chtmp1,chtmp);
-										}
-										else{
-											sys.core[i].dcache.buffer_sizes[m]=atoi(chtmp1);
-											m++;
-											chtmp1[0]='\0';
-										}
-									}
-									sys.core[i].dcache.buffer_sizes[m]=atoi(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-								}
-							}
-							itmp=xNode4.nChildNode("stat");
-							for(k=0; k<itmp; k++)
-							{ //get all items of stat in dcache
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.core[i].dcache.total_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.core[i].dcache.read_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.core[i].dcache.write_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.core[i].dcache.total_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.core[i].dcache.total_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_hits")==0) {sys.core[i].dcache.read_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_hits")==0) {sys.core[i].dcache.write_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.core[i].dcache.read_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.core[i].dcache.write_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"replacements")==0) {sys.core[i].dcache.replacements=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_backs")==0) {sys.core[i].dcache.write_backs=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"miss_buffer_access")==0) {sys.core[i].dcache.miss_buffer_access=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"fill_buffer_accesses")==0) {sys.core[i].dcache.fill_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_accesses")==0) {sys.core[i].dcache.prefetch_buffer_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_writes")==0) {sys.core[i].dcache.prefetch_buffer_writes=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_reads")==0) {sys.core[i].dcache.prefetch_buffer_reads=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_hits")==0) {sys.core[i].dcache.prefetch_buffer_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"wbb_writes")==0) {sys.core[i].dcache.wbb_writes=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"wbb_reads")==0) {sys.core[i].dcache.wbb_reads=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.core[i].dcache.conflicts=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
+    for (i = 0; i < (OrderofComponents_3layer - tmpOrderofComponents_3layer);
+         i++) {
+      xNode3 = xNode2.getChildNode("component", w);
+      if (xNode3.isEmpty() == 1) {
+        printf("The value of homogeneous_L3s or number_of_L3s is not correct!");
+        exit(0);
+      } else {
+        if (strstr(xNode3.getAttribute("name"), "L3") != NULL) {
+          {  // For L30-L3i
+            // Get all params with system.L3?
+            itmp = xNode3.nChildNode("param");
+            for (k = 0; k < itmp; k++) {
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "L3_config") == 0) {
+                strtmp.assign(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                m = 0;
+                for (n = 0; n < strtmp.length(); n++) {
+                  if (strtmp[n] != ',') {
+                    sprintf(chtmp, "%c", strtmp[n]);
+                    strcat(chtmp1, chtmp);
+                  } else {
+                    sys.L3[i].L3_config[m] = atof(chtmp1);
+                    m++;
+                    chtmp1[0] = '\0';
+                  }
+                }
+                sys.L3[i].L3_config[m] = atof(chtmp1);
+                m++;
+                chtmp1[0] = '\0';
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "clockrate") == 0) {
+                sys.L3[i].clockrate =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "merged_dir") == 0) {
+                sys.L3[i].merged_dir = (bool)atoi(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "ports") == 0) {
+                strtmp.assign(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                m = 0;
+                for (n = 0; n < strtmp.length(); n++) {
+                  if (strtmp[n] != ',') {
+                    sprintf(chtmp, "%c", strtmp[n]);
+                    strcat(chtmp1, chtmp);
+                  } else {
+                    sys.L3[i].ports[m] = atoi(chtmp1);
+                    m++;
+                    chtmp1[0] = '\0';
+                  }
+                }
+                sys.L3[i].ports[m] = atoi(chtmp1);
+                m++;
+                chtmp1[0] = '\0';
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "device_type") == 0) {
+                sys.L3[i].device_type =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "threeD_stack") == 0) {
+                strcpy(sys.L3[i].threeD_stack,
+                       (xNode3.getChildNode("param", k).getAttribute("value")));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "buffer_sizes") == 0) {
+                strtmp.assign(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                m = 0;
+                for (n = 0; n < strtmp.length(); n++) {
+                  if (strtmp[n] != ',') {
+                    sprintf(chtmp, "%c", strtmp[n]);
+                    strcat(chtmp1, chtmp);
+                  } else {
+                    sys.L3[i].buffer_sizes[m] = atoi(chtmp1);
+                    m++;
+                    chtmp1[0] = '\0';
+                  }
+                }
+                sys.L3[i].buffer_sizes[m] = atoi(chtmp1);
+                m++;
+                chtmp1[0] = '\0';
+                continue;
+              }
+            }
+            // Get all stats with system.L3?
+            itmp = xNode3.nChildNode("stat");
+            for (k = 0; k < itmp; k++) {
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "total_accesses") == 0) {
+                sys.L3[i].total_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "read_accesses") == 0) {
+                sys.L3[i].read_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "write_accesses") == 0) {
+                sys.L3[i].write_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "total_hits") == 0) {
+                sys.L3[i].total_hits =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "total_misses") == 0) {
+                sys.L3[i].total_misses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "read_hits") == 0) {
+                sys.L3[i].read_hits =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "write_hits") == 0) {
+                sys.L3[i].write_hits =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "read_misses") == 0) {
+                sys.L3[i].read_misses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "write_misses") == 0) {
+                sys.L3[i].write_misses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "replacements") == 0) {
+                sys.L3[i].replacements =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "write_backs") == 0) {
+                sys.L3[i].write_backs =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "miss_buffer_accesses") == 0) {
+                sys.L3[i].miss_buffer_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "fill_buffer_accesses") == 0) {
+                sys.L3[i].fill_buffer_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "prefetch_buffer_accesses") == 0) {
+                sys.L3[i].prefetch_buffer_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "prefetch_buffer_writes") == 0) {
+                sys.L3[i].prefetch_buffer_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "prefetch_buffer_reads") == 0) {
+                sys.L3[i].prefetch_buffer_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "prefetch_buffer_hits") == 0) {
+                sys.L3[i].prefetch_buffer_hits =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "wbb_writes") == 0) {
+                sys.L3[i].wbb_writes =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "wbb_reads") == 0) {
+                sys.L3[i].wbb_reads =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "conflicts") == 0) {
+                sys.L3[i].conflicts =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "duty_cycle") == 0) {
+                sys.L3[i].duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
 
-							}
-						}
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "homenode_read_accesses") == 0) {
+                sys.L3[i].homenode_read_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "homenode_read_accesses") == 0) {
+                sys.L3[i].homenode_read_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "homenode_read_hits") == 0) {
+                sys.L3[i].homenode_read_hits =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "homenode_write_hits") == 0) {
+                sys.L3[i].homenode_write_hits =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "homenode_read_misses") == 0) {
+                sys.L3[i].homenode_read_misses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "homenode_write_misses") == 0) {
+                sys.L3[i].homenode_write_misses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "dir_duty_cycle") == 0) {
+                sys.L3[i].dir_duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+                continue;
+              }
+            }
+          }
+          w = w + 1;
+        } else {
+          printf(
+              "The value of homogeneous_L3s or number_of_L3s is not correct!");
+          exit(0);
+        }
+      }
+    }
+    //__________________________________________Get
+    //system.NoC[0..n]____________________________________________
+    w = OrderofComponents_3layer + 1;
+    tmpOrderofComponents_3layer = OrderofComponents_3layer;
+    if (sys.homogeneous_NoCs == 1)
+      OrderofComponents_3layer = OrderofComponents_3layer + 1;
+    else
+      OrderofComponents_3layer = OrderofComponents_3layer + sys.number_of_NoCs;
 
+    for (i = 0; i < (OrderofComponents_3layer - tmpOrderofComponents_3layer);
+         i++) {
+      xNode3 = xNode2.getChildNode("component", w);
+      if (xNode3.isEmpty() == 1) {
+        printf(
+            "The value of homogeneous_NoCs or number_of_NoCs is not correct!");
+        exit(0);
+      } else {
+        if (strstr(xNode3.getAttribute("name"), "noc") != NULL) {
+          {  // For NoC0-NoCi
+            // Get all params with system.NoC?
+            itmp = xNode3.nChildNode("param");
+            for (k = 0; k < itmp; k++) {
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "clockrate") == 0) {
+                sys.NoC[i].clockrate =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "type") == 0) {
+                sys.NoC[i].type = (bool)atoi(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "topology") == 0) {
+                strcpy(sys.NoC[i].topology,
+                       (xNode3.getChildNode("param", k).getAttribute("value")));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "horizontal_nodes") == 0) {
+                sys.NoC[i].horizontal_nodes =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "vertical_nodes") == 0) {
+                sys.NoC[i].vertical_nodes =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "has_global_link") == 0) {
+                sys.NoC[i].has_global_link = (bool)atoi(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "link_throughput") == 0) {
+                sys.NoC[i].link_throughput =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "link_latency") == 0) {
+                sys.NoC[i].link_latency =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "input_ports") == 0) {
+                sys.NoC[i].input_ports =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "output_ports") == 0) {
+                sys.NoC[i].output_ports =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "virtual_channel_per_port") == 0) {
+                sys.NoC[i].virtual_channel_per_port =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "flit_bits") == 0) {
+                sys.NoC[i].flit_bits =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "input_buffer_entries_per_vc") == 0) {
+                sys.NoC[i].input_buffer_entries_per_vc =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "dual_pump") == 0) {
+                sys.NoC[i].dual_pump =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "chip_coverage") == 0) {
+                sys.NoC[i].chip_coverage =
+                    atof(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "link_routing_over_percentage") == 0) {
+                sys.NoC[i].route_over_perc =
+                    atof(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "ports_of_input_buffer") == 0) {
+                strtmp.assign(
+                    xNode3.getChildNode("param", k).getAttribute("value"));
+                m = 0;
+                for (n = 0; n < strtmp.length(); n++) {
+                  if (strtmp[n] != ',') {
+                    sprintf(chtmp, "%c", strtmp[n]);
+                    strcat(chtmp1, chtmp);
+                  } else {
+                    sys.NoC[i].ports_of_input_buffer[m] = atoi(chtmp1);
+                    m++;
+                    chtmp1[0] = '\0';
+                  }
+                }
+                sys.NoC[i].ports_of_input_buffer[m] = atoi(chtmp1);
+                m++;
+                chtmp1[0] = '\0';
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "number_of_crossbars") == 0) {
+                sys.NoC[i].number_of_crossbars =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "crossbar_type") == 0) {
+                strcpy(sys.NoC[i].crossbar_type,
+                       (xNode3.getChildNode("param", k).getAttribute("value")));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "crosspoint_type") == 0) {
+                strcpy(sys.NoC[i].crosspoint_type,
+                       (xNode3.getChildNode("param", k).getAttribute("value")));
+                continue;
+              }
+              if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                         "arbiter_type") == 0) {
+                sys.NoC[i].arbiter_type =
+                    atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+                continue;
+              }
+            }
+            NumofCom_4 = xNode3.nChildNode("component");  // get the number of
+                                                          // components within
+                                                          // the third layer
+            for (j = 0; j < NumofCom_4; j++) {
+              xNode4 = xNode3.getChildNode("component", j);
+              if (strcmp(xNode4.getAttribute("name"), "xbar0") ==
+                  0) {  // find PBT
+                itmp = xNode4.nChildNode("param");
+                for (k = 0; k < itmp; k++) {  // get all items of param in
+                                              // system.XoC0.xbar0--xbar0
+                  if (strcmp(
+                          xNode4.getChildNode("param", k).getAttribute("name"),
+                          "number_of_inputs_of_crossbars") == 0) {
+                    sys.NoC[i].xbar0.number_of_inputs_of_crossbars = atoi(
+                        xNode4.getChildNode("param", k).getAttribute("value"));
+                    continue;
+                  }
+                  if (strcmp(
+                          xNode4.getChildNode("param", k).getAttribute("name"),
+                          "number_of_outputs_of_crossbars") == 0) {
+                    sys.NoC[i].xbar0.number_of_outputs_of_crossbars = atoi(
+                        xNode4.getChildNode("param", k).getAttribute("value"));
+                    continue;
+                  }
+                  if (strcmp(
+                          xNode4.getChildNode("param", k).getAttribute("name"),
+                          "flit_bits") == 0) {
+                    sys.NoC[i].xbar0.flit_bits = atoi(
+                        xNode4.getChildNode("param", k).getAttribute("value"));
+                    continue;
+                  }
+                  if (strcmp(
+                          xNode4.getChildNode("param", k).getAttribute("name"),
+                          "input_buffer_entries_per_port") == 0) {
+                    sys.NoC[i].xbar0.input_buffer_entries_per_port = atoi(
+                        xNode4.getChildNode("param", k).getAttribute("value"));
+                    continue;
+                  }
+                  if (strcmp(
+                          xNode4.getChildNode("param", k).getAttribute("name"),
+                          "ports_of_input_buffer") == 0) {
+                    strtmp.assign(
+                        xNode4.getChildNode("param", k).getAttribute("value"));
+                    m = 0;
+                    for (n = 0; n < strtmp.length(); n++) {
+                      if (strtmp[n] != ',') {
+                        sprintf(chtmp, "%c", strtmp[n]);
+                        strcat(chtmp1, chtmp);
+                      } else {
+                        sys.NoC[i].xbar0.ports_of_input_buffer[m] =
+                            atoi(chtmp1);
+                        m++;
+                        chtmp1[0] = '\0';
+                      }
+                    }
+                    sys.NoC[i].xbar0.ports_of_input_buffer[m] = atoi(chtmp1);
+                    m++;
+                    chtmp1[0] = '\0';
+                  }
+                }
+                itmp = xNode4.nChildNode("stat");
+                for (k = 0; k < itmp; k++) {  // get all items of stat in
+                                              // system.core0.predictor--PBT
+                  if (strcmp(
+                          xNode4.getChildNode("stat", k).getAttribute("name"),
+                          "predictor_accesses") == 0)
+                    sys.core[i].predictor.predictor_accesses = atof(
+                        xNode4.getChildNode("stat", k).getAttribute("value"));
+                }
+              }
+            }
+            // Get all stats with system.NoC?
+            itmp = xNode3.nChildNode("stat");
+            for (k = 0; k < itmp; k++) {
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "total_accesses") == 0)
+                sys.NoC[i].total_accesses =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+              if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                         "duty_cycle") == 0)
+                sys.NoC[i].duty_cycle =
+                    atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+            }
+          }
+          w = w + 1;
+        }
+      }
+    }
+    //__________________________________________Get
+    //system.mem____________________________________________
+    if (OrderofComponents_3layer > 0)
+      OrderofComponents_3layer = OrderofComponents_3layer + 1;
+    xNode3 = xNode2.getChildNode("component", OrderofComponents_3layer);
+    if (xNode3.isEmpty() == 1) {
+      printf(
+          "some value(s) of "
+          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
+          "not correct!");
+      exit(0);
+    }
+    if (strstr(xNode3.getAttribute("id"), "system.mem") != NULL) {
+      itmp = xNode3.nChildNode("param");
+      for (k = 0; k < itmp; k++) {  // get all items of param in system.mem
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "mem_tech_node") == 0) {
+          sys.mem.mem_tech_node =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "device_clock") == 0) {
+          sys.mem.device_clock =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "peak_transfer_rate") == 0) {
+          sys.mem.peak_transfer_rate =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "capacity_per_channel") == 0) {
+          sys.mem.capacity_per_channel =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "number_ranks") == 0) {
+          sys.mem.number_ranks =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "num_banks_of_DRAM_chip") == 0) {
+          sys.mem.num_banks_of_DRAM_chip =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "Block_width_of_DRAM_chip") == 0) {
+          sys.mem.Block_width_of_DRAM_chip =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "output_width_of_DRAM_chip") == 0) {
+          sys.mem.output_width_of_DRAM_chip =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "page_size_of_DRAM_chip") == 0) {
+          sys.mem.page_size_of_DRAM_chip =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "burstlength_of_DRAM_chip") == 0) {
+          sys.mem.burstlength_of_DRAM_chip =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "internal_prefetch_of_DRAM_chip") == 0) {
+          sys.mem.internal_prefetch_of_DRAM_chip =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+      }
+      itmp = xNode3.nChildNode("stat");
+      for (k = 0; k < itmp; k++) {  // get all items of stat in system.mem
+        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                   "memory_accesses") == 0) {
+          sys.mem.memory_accesses =
+              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                   "memory_reads") == 0) {
+          sys.mem.memory_reads =
+              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                   "memory_writes") == 0) {
+          sys.mem.memory_writes =
+              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                   "dram_pre") == 0) {
+          sys.mem.dram_pre =
+              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+          continue;
+        }
+      }
+    } else {
+      printf(
+          "some value(s) of "
+          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
+          "not correct!");
+      exit(0);
+    }
+    //__________________________________________Get
+    //system.mc____________________________________________
+    if (OrderofComponents_3layer > 0)
+      OrderofComponents_3layer = OrderofComponents_3layer + 1;
+    xNode3 = xNode2.getChildNode("component", OrderofComponents_3layer);
+    if (xNode3.isEmpty() == 1) {
+      printf(
+          "some value(s) of "
+          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
+          "not correct!");
+      exit(0);
+    }
+    if (strstr(xNode3.getAttribute("id"), "system.mc") != NULL) {
+      itmp = xNode3.nChildNode("param");
+      for (k = 0; k < itmp; k++) {  // get all items of param in system.mem
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "mc_clock") == 0) {
+          sys.mc.mc_clock =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "block_size") == 0) {
+          sys.mc.llc_line_length =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "number_mcs") == 0) {
+          sys.mc.number_mcs =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "memory_channels_per_mc") == 0) {
+          sys.mc.memory_channels_per_mc =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "req_window_size_per_channel") == 0) {
+          sys.mc.req_window_size_per_channel =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "IO_buffer_size_per_channel") == 0) {
+          sys.mc.IO_buffer_size_per_channel =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "databus_width") == 0) {
+          sys.mc.databus_width =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "addressbus_width") == 0) {
+          sys.mc.addressbus_width =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "PRT_entries") == 0) {
+          sys.mc.PRT_entries =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "peak_transfer_rate") == 0) {
+          sys.mc.peak_transfer_rate =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "number_ranks") == 0) {
+          sys.mc.number_ranks =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "LVDS") == 0) {
+          sys.mc.LVDS =
+              (bool)atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "type") == 0) {
+          sys.mc.type =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "withPHY") == 0) {
+          sys.mc.withPHY =
+              (bool)atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
 
-						if (strcmp(xNode4.getAttribute("name"),"BTB")==0)
-						{//find system.core0.BTB
-							itmp=xNode4.nChildNode("param");
-							for(k=0; k<itmp; k++)
-							{ //get all items of param in system.core0.BTB--BTB
-								if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"BTB_config")==0)
-								{
-									strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
-									m=0;
-									for(n=0; n<strtmp.length(); n++)
-									{
-										if (strtmp[n]!=',')
-										{
-											sprintf(chtmp,"%c",strtmp[n]);
-											strcat(chtmp1,chtmp);
-										}
-										else{
-											sys.core[i].BTB.BTB_config[m]=atoi(chtmp1);
-											m++;
-											chtmp1[0]='\0';
-										}
-									}
-									sys.core[i].BTB.BTB_config[m]=atoi(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-								}
-							}
-							itmp=xNode4.nChildNode("stat");
-							for(k=0; k<itmp; k++)
-							{ //get all items of stat in BTB
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.core[i].BTB.total_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.core[i].BTB.read_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.core[i].BTB.write_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.core[i].BTB.total_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.core[i].BTB.total_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_hits")==0) {sys.core[i].BTB.read_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_hits")==0) {sys.core[i].BTB.write_hits=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.core[i].BTB.read_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.core[i].BTB.write_misses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-								if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"replacements")==0) {sys.core[i].BTB.replacements=atof(xNode4.getChildNode("stat",k).getAttribute("value"));continue;}
-							}
-						}
-					}
-				}
-				else {
-					printf("The value of homogeneous_cores or number_of_cores is not correct!");
-					exit(0);
-				}
-			}
-		}
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "dram_cmd_coeff") == 0) {
+          sys.mc.dram_cmd_coeff =
+              atof(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "dram_act_coeff") == 0) {
+          sys.mc.dram_act_coeff =
+              atof(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "dram_nop_coeff") == 0) {
+          sys.mc.dram_nop_coeff =
+              atof(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "dram_activity_coeff") == 0) {
+          sys.mc.dram_activity_coeff =
+              atof(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "dram_pre_coeff") == 0) {
+          sys.mc.dram_pre_coeff =
+              atof(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "dram_rd_coeff") == 0) {
+          sys.mc.dram_rd_coeff =
+              atof(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "dram_wr_coeff") == 0) {
+          sys.mc.dram_wr_coeff =
+              atof(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "dram_req_coeff") == 0) {
+          sys.mc.dram_req_coeff =
+              atof(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "dram_const_coeff") == 0) {
+          sys.mc.dram_const_coeff =
+              atof(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+      }
+      itmp = xNode3.nChildNode("stat");
+      for (k = 0; k < itmp;
+           k++) {  // get all items of stat in system.mendirectory
+        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                   "memory_accesses") == 0) {
+          sys.mc.memory_accesses =
+              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                   "memory_reads") == 0) {
+          sys.mc.memory_reads =
+              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                   "memory_writes") == 0) {
+          sys.mc.memory_writes =
+              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                   "dram_pre") == 0) {
+          sys.mc.dram_pre =
+              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+          continue;
+        }
+      }
+    } else {
+      printf(
+          "some value(s) of "
+          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
+          "not correct!");
+      exit(0);
+    }
+    //__________________________________________Get
+    //system.niu____________________________________________
+    if (OrderofComponents_3layer > 0)
+      OrderofComponents_3layer = OrderofComponents_3layer + 1;
+    xNode3 = xNode2.getChildNode("component", OrderofComponents_3layer);
+    if (xNode3.isEmpty() == 1) {
+      printf(
+          "some value(s) of "
+          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
+          "not correct!");
+      exit(0);
+    }
+    if (strstr(xNode3.getAttribute("id"), "system.niu") != NULL) {
+      itmp = xNode3.nChildNode("param");
+      for (k = 0; k < itmp; k++) {  // get all items of param in system.mem
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "clockrate") == 0) {
+          sys.niu.clockrate =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "number_units") == 0) {
+          sys.niu.number_units =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "type") == 0) {
+          sys.niu.type =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+      }
+      itmp = xNode3.nChildNode("stat");
+      for (k = 0; k < itmp;
+           k++) {  // get all items of stat in system.mendirectory
+        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                   "duty_cycle") == 0) {
+          sys.niu.duty_cycle =
+              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                   "total_load_perc") == 0) {
+          sys.niu.total_load_perc =
+              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+          continue;
+        }
+      }
+    } else {
+      printf(
+          "some value(s) of "
+          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
+          "not correct!");
+      exit(0);
+    }
 
-		//__________________________________________Get system.L1Directory0-n____________________________________________
-		int w,tmpOrderofComponents_3layer;
-		w=OrderofComponents_3layer+1;
-		tmpOrderofComponents_3layer=OrderofComponents_3layer;
-		if (sys.homogeneous_L1Directories==1) OrderofComponents_3layer=OrderofComponents_3layer+1;
-		else OrderofComponents_3layer=OrderofComponents_3layer+sys.number_of_L1Directories;
-
-		for (i=0; i<(OrderofComponents_3layer-tmpOrderofComponents_3layer); i++)
-		{
-			xNode3=xNode2.getChildNode("component",w);
-			if (xNode3.isEmpty()==1) {
-				printf("The value of homogeneous_L1Directories or number_of_L1Directories is not correct!");
-				exit(0);
-			}
-			else
-			{
-				if (strstr(xNode3.getAttribute("id"),"L1Directory")!=NULL)
-				{
-					itmp=xNode3.nChildNode("param");
-					for(k=0; k<itmp; k++)
-					{ //get all items of param in system.L1Directory
-						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"Dir_config")==0)
-						{
-							strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-							m=0;
-							for(n=0; n<strtmp.length(); n++)
-							{
-								if (strtmp[n]!=',')
-								{
-									sprintf(chtmp,"%c",strtmp[n]);
-									strcat(chtmp1,chtmp);
-								}
-								else{
-									sys.L1Directory[i].Dir_config[m]=atof(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-								}
-							}
-							sys.L1Directory[i].Dir_config[m]=atof(chtmp1);
-							m++;
-							chtmp1[0]='\0';
-							continue;
-						}
-						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"buffer_sizes")==0)
-						{
-							strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-							m=0;
-							for(n=0; n<strtmp.length(); n++)
-							{
-								if (strtmp[n]!=',')
-								{
-									sprintf(chtmp,"%c",strtmp[n]);
-									strcat(chtmp1,chtmp);
-								}
-								else{
-									sys.L1Directory[i].buffer_sizes[m]=atoi(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-								}
-							}
-							sys.L1Directory[i].buffer_sizes[m]=atoi(chtmp1);
-							m++;
-							chtmp1[0]='\0';
-							continue;
-						}
-
-						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"clockrate")==0) {sys.L1Directory[i].clockrate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"ports")==0)
-						{
-							strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-							m=0;
-							for(n=0; n<strtmp.length(); n++)
-							{
-								if (strtmp[n]!=',')
-								{
-									sprintf(chtmp,"%c",strtmp[n]);
-									strcat(chtmp1,chtmp);
-								}
-								else{
-									sys.L1Directory[i].ports[m]=atoi(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-								}
-							}
-							sys.L1Directory[i].ports[m]=atoi(chtmp1);
-							m++;
-							chtmp1[0]='\0';
-							continue;
-						}
-						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"device_type")==0) {sys.L1Directory[i].device_type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"Directory_type")==0) {sys.L1Directory[i].Directory_type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"3D_stack")==0) {strcpy(sys.L1Directory[i].threeD_stack,xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-					}
-					itmp=xNode3.nChildNode("stat");
-					for(k=0; k<itmp; k++)
-					{ //get all items of stat in system.L2directorydirectory
-						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.L1Directory[i].total_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.L1Directory[i].read_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.L1Directory[i].write_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.L1Directory[i].read_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.L1Directory[i].write_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.L1Directory[i].conflicts=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"duty_cycle")==0) {sys.L1Directory[i].duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-					}
-					w=w+1;
-				}
-				else {
-					printf("The value of homogeneous_L1Directories or number_of_L1Directories is not correct!");
-					exit(0);
-				}
-			}
-		}
-
-		//__________________________________________Get system.L2Directory0-n____________________________________________
-		w=OrderofComponents_3layer+1;
-		tmpOrderofComponents_3layer=OrderofComponents_3layer;
-		if (sys.homogeneous_L2Directories==1) OrderofComponents_3layer=OrderofComponents_3layer+1;
-		else OrderofComponents_3layer=OrderofComponents_3layer+sys.number_of_L2Directories;
-
-		for (i=0; i<(OrderofComponents_3layer-tmpOrderofComponents_3layer); i++)
-		{
-			xNode3=xNode2.getChildNode("component",w);
-			if (xNode3.isEmpty()==1) {
-				printf("The value of homogeneous_L2Directories or number_of_L2Directories is not correct!");
-				exit(0);
-			}
-			else
-			{
-				if (strstr(xNode3.getAttribute("id"),"L2Directory")!=NULL)
-				{
-					itmp=xNode3.nChildNode("param");
-					for(k=0; k<itmp; k++)
-					{ //get all items of param in system.L2Directory
-						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"Dir_config")==0)
-						{
-							strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-							m=0;
-							for(n=0; n<strtmp.length(); n++)
-							{
-								if (strtmp[n]!=',')
-								{
-									sprintf(chtmp,"%c",strtmp[n]);
-									strcat(chtmp1,chtmp);
-								}
-								else{
-									sys.L2Directory[i].Dir_config[m]=atof(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-								}
-							}
-							sys.L2Directory[i].Dir_config[m]=atof(chtmp1);
-							m++;
-							chtmp1[0]='\0';
-							continue;
-						}
-						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"buffer_sizes")==0)
-						{
-							strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-							m=0;
-							for(n=0; n<strtmp.length(); n++)
-							{
-								if (strtmp[n]!=',')
-								{
-									sprintf(chtmp,"%c",strtmp[n]);
-									strcat(chtmp1,chtmp);
-								}
-								else{
-									sys.L2Directory[i].buffer_sizes[m]=atoi(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-								}
-							}
-							sys.L2Directory[i].buffer_sizes[m]=atoi(chtmp1);
-							m++;
-							chtmp1[0]='\0';
-							continue;
-						}
-
-						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"clockrate")==0) {sys.L2Directory[i].clockrate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"Directory_type")==0) {sys.L2Directory[i].Directory_type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"ports")==0)
-						{
-							strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-							m=0;
-							for(n=0; n<strtmp.length(); n++)
-							{
-								if (strtmp[n]!=',')
-								{
-									sprintf(chtmp,"%c",strtmp[n]);
-									strcat(chtmp1,chtmp);
-								}
-								else{
-									sys.L2Directory[i].ports[m]=atoi(chtmp1);
-									m++;
-									chtmp1[0]='\0';
-								}
-							}
-							sys.L2Directory[i].ports[m]=atoi(chtmp1);
-							m++;
-							chtmp1[0]='\0';
-							continue;
-						}
-						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"device_type")==0) {sys.L2Directory[i].device_type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"3D_stack")==0) {strcpy(sys.L2Directory[i].threeD_stack,xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-					}
-					itmp=xNode3.nChildNode("stat");
-					for(k=0; k<itmp; k++)
-					{ //get all items of stat in system.L2directorydirectory
-						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.L2Directory[i].total_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.L2Directory[i].read_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.L2Directory[i].write_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.L2Directory[i].read_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-     					if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.L2Directory[i].write_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.L2Directory[i].conflicts=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-						if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"duty_cycle")==0) {sys.L2Directory[i].duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-
-					}
-					w=w+1;
-				}
-				else {
-					printf("The value of homogeneous_L2Directories or number_of_L2Directories is not correct!");
-					exit(0);
-				}
-			}
-		}
-
-		//__________________________________________Get system.L2[0..n]____________________________________________
-		w=OrderofComponents_3layer+1;
-		tmpOrderofComponents_3layer=OrderofComponents_3layer;
-		if (sys.homogeneous_L2s==1) OrderofComponents_3layer=OrderofComponents_3layer+1;
-		else OrderofComponents_3layer=OrderofComponents_3layer+sys.number_of_L2s;
-
-		for (i=0; i<(OrderofComponents_3layer-tmpOrderofComponents_3layer); i++)
-		{
-			xNode3=xNode2.getChildNode("component",w);
-			if (xNode3.isEmpty()==1) {
-				printf("The value of homogeneous_L2s or number_of_L2s is not correct!");
-				exit(0);
-			}
-			else
-			{
-				if (strstr(xNode3.getAttribute("name"),"L2")!=NULL)
-				{
-					{ //For L20-L2i
-						//Get all params with system.L2?
-						itmp=xNode3.nChildNode("param");
-						for(k=0; k<itmp; k++)
-						{
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"L2_config")==0)
-							{
-								strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-								m=0;
-								for(n=0; n<strtmp.length(); n++)
-								{
-									if (strtmp[n]!=',')
-									{
-										sprintf(chtmp,"%c",strtmp[n]);
-										strcat(chtmp1,chtmp);
-									}
-									else{
-										sys.L2[i].L2_config[m]=atof(chtmp1);
-										m++;
-										chtmp1[0]='\0';
-									}
-								}
-								sys.L2[i].L2_config[m]=atof(chtmp1);
-								m++;
-								chtmp1[0]='\0';
-								continue;
-							}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"clockrate")==0) {sys.L2[i].clockrate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"merged_dir")==0) {sys.L2[i].merged_dir=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"ports")==0)
-							{
-								strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-								m=0;
-								for(n=0; n<strtmp.length(); n++)
-								{
-									if (strtmp[n]!=',')
-									{
-										sprintf(chtmp,"%c",strtmp[n]);
-										strcat(chtmp1,chtmp);
-									}
-									else{
-										sys.L2[i].ports[m]=atoi(chtmp1);
-										m++;
-										chtmp1[0]='\0';
-									}
-								}
-								sys.L2[i].ports[m]=atoi(chtmp1);
-								m++;
-								chtmp1[0]='\0';
-								continue;
-							}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"device_type")==0) {sys.L2[i].device_type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"threeD_stack")==0) {strcpy(sys.L2[i].threeD_stack,(xNode3.getChildNode("param",k).getAttribute("value")));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"buffer_sizes")==0)
-							{
-								strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-								m=0;
-								for(n=0; n<strtmp.length(); n++)
-								{
-									if (strtmp[n]!=',')
-									{
-										sprintf(chtmp,"%c",strtmp[n]);
-										strcat(chtmp1,chtmp);
-									}
-									else{
-										sys.L2[i].buffer_sizes[m]=atoi(chtmp1);
-										m++;
-										chtmp1[0]='\0';
-									}
-								}
-								sys.L2[i].buffer_sizes[m]=atoi(chtmp1);
-								m++;
-								chtmp1[0]='\0';
-								continue;
-							}
-						}
-						//Get all stats with system.L2?
-						itmp=xNode3.nChildNode("stat");
-						for(k=0; k<itmp; k++)
-						{
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.L2[i].total_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.L2[i].read_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.L2[i].write_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.L2[i].total_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.L2[i].total_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_hits")==0) {sys.L2[i].read_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_hits")==0) {sys.L2[i].write_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.L2[i].read_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.L2[i].write_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"replacements")==0) {sys.L2[i].replacements=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_backs")==0) {sys.L2[i].write_backs=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"miss_buffer_accesses")==0) {sys.L2[i].miss_buffer_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"fill_buffer_accesses")==0) {sys.L2[i].fill_buffer_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_accesses")==0) {sys.L2[i].prefetch_buffer_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_writes")==0) {sys.L2[i].prefetch_buffer_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_reads")==0) {sys.L2[i].prefetch_buffer_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_hits")==0) {sys.L2[i].prefetch_buffer_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"wbb_writes")==0) {sys.L2[i].wbb_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"wbb_reads")==0) {sys.L2[i].wbb_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.L2[i].conflicts=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"duty_cycle")==0) {sys.L2[i].duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_read_accesses")==0) {sys.L2[i].homenode_read_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_read_accesses")==0) {sys.L2[i].homenode_read_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_read_hits")==0) {sys.L2[i].homenode_read_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_write_hits")==0) {sys.L2[i].homenode_write_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_read_misses")==0) {sys.L2[i].homenode_read_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_write_misses")==0) {sys.L2[i].homenode_write_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"dir_duty_cycle")==0) {sys.L2[i].dir_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-
-						}
-					}
-					w=w+1;
-				}
-				else {
-					printf("The value of homogeneous_L2s or number_of_L2s is not correct!");
-					exit(0);
-				}
-			}
-		}
-		//__________________________________________Get system.L3[0..n]____________________________________________
-		w=OrderofComponents_3layer+1;
-		tmpOrderofComponents_3layer=OrderofComponents_3layer;
-		if (sys.homogeneous_L3s==1) OrderofComponents_3layer=OrderofComponents_3layer+1;
-		else OrderofComponents_3layer=OrderofComponents_3layer+sys.number_of_L3s;
-
-		for (i=0; i<(OrderofComponents_3layer-tmpOrderofComponents_3layer); i++)
-		{
-			xNode3=xNode2.getChildNode("component",w);
-			if (xNode3.isEmpty()==1) {
-				printf("The value of homogeneous_L3s or number_of_L3s is not correct!");
-				exit(0);
-			}
-			else
-			{
-				if (strstr(xNode3.getAttribute("name"),"L3")!=NULL)
-				{
-					{ //For L30-L3i
-						//Get all params with system.L3?
-						itmp=xNode3.nChildNode("param");
-						for(k=0; k<itmp; k++)
-						{
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"L3_config")==0)
-							{
-								strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-								m=0;
-								for(n=0; n<strtmp.length(); n++)
-								{
-									if (strtmp[n]!=',')
-									{
-										sprintf(chtmp,"%c",strtmp[n]);
-										strcat(chtmp1,chtmp);
-									}
-									else{
-										sys.L3[i].L3_config[m]=atof(chtmp1);
-										m++;
-										chtmp1[0]='\0';
-									}
-								}
-								sys.L3[i].L3_config[m]=atof(chtmp1);
-								m++;
-								chtmp1[0]='\0';
-								continue;
-							}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"clockrate")==0) {sys.L3[i].clockrate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"merged_dir")==0) {sys.L3[i].merged_dir=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"ports")==0)
-							{
-								strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-								m=0;
-								for(n=0; n<strtmp.length(); n++)
-								{
-									if (strtmp[n]!=',')
-									{
-										sprintf(chtmp,"%c",strtmp[n]);
-										strcat(chtmp1,chtmp);
-									}
-									else{
-										sys.L3[i].ports[m]=atoi(chtmp1);
-										m++;
-										chtmp1[0]='\0';
-									}
-								}
-								sys.L3[i].ports[m]=atoi(chtmp1);
-								m++;
-								chtmp1[0]='\0';
-								continue;
-							}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"device_type")==0) {sys.L3[i].device_type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"threeD_stack")==0) {strcpy(sys.L3[i].threeD_stack,(xNode3.getChildNode("param",k).getAttribute("value")));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"buffer_sizes")==0)
-							{
-								strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-								m=0;
-								for(n=0; n<strtmp.length(); n++)
-								{
-									if (strtmp[n]!=',')
-									{
-										sprintf(chtmp,"%c",strtmp[n]);
-										strcat(chtmp1,chtmp);
-									}
-									else{
-										sys.L3[i].buffer_sizes[m]=atoi(chtmp1);
-										m++;
-										chtmp1[0]='\0';
-									}
-								}
-								sys.L3[i].buffer_sizes[m]=atoi(chtmp1);
-								m++;
-								chtmp1[0]='\0';
-								continue;
-							}
-						}
-						//Get all stats with system.L3?
-						itmp=xNode3.nChildNode("stat");
-						for(k=0; k<itmp; k++)
-						{
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) {sys.L3[i].total_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_accesses")==0) {sys.L3[i].read_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_accesses")==0) {sys.L3[i].write_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_hits")==0) {sys.L3[i].total_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_misses")==0) {sys.L3[i].total_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_hits")==0) {sys.L3[i].read_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_hits")==0) {sys.L3[i].write_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"read_misses")==0) {sys.L3[i].read_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_misses")==0) {sys.L3[i].write_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"replacements")==0) {sys.L3[i].replacements=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"write_backs")==0) {sys.L3[i].write_backs=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"miss_buffer_accesses")==0) {sys.L3[i].miss_buffer_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"fill_buffer_accesses")==0) {sys.L3[i].fill_buffer_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_accesses")==0) {sys.L3[i].prefetch_buffer_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_writes")==0) {sys.L3[i].prefetch_buffer_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_reads")==0) {sys.L3[i].prefetch_buffer_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"prefetch_buffer_hits")==0) {sys.L3[i].prefetch_buffer_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"wbb_writes")==0) {sys.L3[i].wbb_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"wbb_reads")==0) {sys.L3[i].wbb_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"conflicts")==0) {sys.L3[i].conflicts=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"duty_cycle")==0) {sys.L3[i].duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_read_accesses")==0) {sys.L3[i].homenode_read_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_read_accesses")==0) {sys.L3[i].homenode_read_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_read_hits")==0) {sys.L3[i].homenode_read_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_write_hits")==0) {sys.L3[i].homenode_write_hits=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_read_misses")==0) {sys.L3[i].homenode_read_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"homenode_write_misses")==0) {sys.L3[i].homenode_write_misses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"dir_duty_cycle")==0) {sys.L3[i].dir_duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-
-						}
-					}
-					w=w+1;
-				}
-				else {
-					printf("The value of homogeneous_L3s or number_of_L3s is not correct!");
-					exit(0);
-				}
-			}
-		}
-		//__________________________________________Get system.NoC[0..n]____________________________________________
-		w=OrderofComponents_3layer+1;
-		tmpOrderofComponents_3layer=OrderofComponents_3layer;
-		if (sys.homogeneous_NoCs==1) OrderofComponents_3layer=OrderofComponents_3layer+1;
-		else OrderofComponents_3layer=OrderofComponents_3layer+sys.number_of_NoCs;
-
-		for (i=0; i<(OrderofComponents_3layer-tmpOrderofComponents_3layer); i++)
-		{
-			xNode3=xNode2.getChildNode("component",w);
-			if (xNode3.isEmpty()==1) {
-				printf("The value of homogeneous_NoCs or number_of_NoCs is not correct!");
-				exit(0);
-			}
-			else
-			{
-				if (strstr(xNode3.getAttribute("name"),"noc")!=NULL)
-				{
-					{ //For NoC0-NoCi
-						//Get all params with system.NoC?
-						itmp=xNode3.nChildNode("param");
-						for(k=0; k<itmp; k++)
-						{
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"clockrate")==0) {sys.NoC[i].clockrate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"type")==0) {sys.NoC[i].type=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"topology")==0) {strcpy(sys.NoC[i].topology,(xNode3.getChildNode("param",k).getAttribute("value")));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"horizontal_nodes")==0) {sys.NoC[i].horizontal_nodes=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"vertical_nodes")==0) {sys.NoC[i].vertical_nodes=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"has_global_link")==0) {sys.NoC[i].has_global_link=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"link_throughput")==0) {sys.NoC[i].link_throughput=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"link_latency")==0) {sys.NoC[i].link_latency=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"input_ports")==0) {sys.NoC[i].input_ports=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"output_ports")==0) {sys.NoC[i].output_ports=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"virtual_channel_per_port")==0) {sys.NoC[i].virtual_channel_per_port=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"flit_bits")==0) {sys.NoC[i].flit_bits=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"input_buffer_entries_per_vc")==0) {sys.NoC[i].input_buffer_entries_per_vc=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dual_pump")==0) {sys.NoC[i].dual_pump=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"chip_coverage")==0) {sys.NoC[i].chip_coverage=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"link_routing_over_percentage")==0) {sys.NoC[i].route_over_perc=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"ports_of_input_buffer")==0)
-							{
-								strtmp.assign(xNode3.getChildNode("param",k).getAttribute("value"));
-								m=0;
-								for(n=0; n<strtmp.length(); n++)
-								{
-									if (strtmp[n]!=',')
-									{
-										sprintf(chtmp,"%c",strtmp[n]);
-										strcat(chtmp1,chtmp);
-									}
-									else{
-										sys.NoC[i].ports_of_input_buffer[m]=atoi(chtmp1);
-										m++;
-										chtmp1[0]='\0';
-									}
-								}
-								sys.NoC[i].ports_of_input_buffer[m]=atoi(chtmp1);
-								m++;
-								chtmp1[0]='\0';
-								continue;
-							}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_of_crossbars")==0) {sys.NoC[i].number_of_crossbars=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"crossbar_type")==0) {strcpy(sys.NoC[i].crossbar_type,(xNode3.getChildNode("param",k).getAttribute("value")));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"crosspoint_type")==0) {strcpy(sys.NoC[i].crosspoint_type,(xNode3.getChildNode("param",k).getAttribute("value")));continue;}
-							if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"arbiter_type")==0) {sys.NoC[i].arbiter_type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-						}
-						NumofCom_4=xNode3.nChildNode("component"); //get the number of components within the third layer
-						for(j=0; j<NumofCom_4; j++)
-						{
-							xNode4=xNode3.getChildNode("component",j);
-							if (strcmp(xNode4.getAttribute("name"),"xbar0")==0)
-							{ //find PBT
-								itmp=xNode4.nChildNode("param");
-								for(k=0; k<itmp; k++)
-								{ //get all items of param in system.XoC0.xbar0--xbar0
-									if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"number_of_inputs_of_crossbars")==0) {sys.NoC[i].xbar0.number_of_inputs_of_crossbars=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
-									if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"number_of_outputs_of_crossbars")==0) {sys.NoC[i].xbar0.number_of_outputs_of_crossbars=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
-									if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"flit_bits")==0) {sys.NoC[i].xbar0.flit_bits=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
-									if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"input_buffer_entries_per_port")==0) {sys.NoC[i].xbar0.input_buffer_entries_per_port=atoi(xNode4.getChildNode("param",k).getAttribute("value"));continue;}
-									if (strcmp(xNode4.getChildNode("param",k).getAttribute("name"),"ports_of_input_buffer")==0)
-									{
-										strtmp.assign(xNode4.getChildNode("param",k).getAttribute("value"));
-										m=0;
-										for(n=0; n<strtmp.length(); n++)
-										{
-											if (strtmp[n]!=',')
-											{
-												sprintf(chtmp,"%c",strtmp[n]);
-												strcat(chtmp1,chtmp);
-											}
-											else{
-												sys.NoC[i].xbar0.ports_of_input_buffer[m]=atoi(chtmp1);
-												m++;
-												chtmp1[0]='\0';
-											}
-										}
-										sys.NoC[i].xbar0.ports_of_input_buffer[m]=atoi(chtmp1);
-										m++;
-										chtmp1[0]='\0';
-									}
-								}
-								itmp=xNode4.nChildNode("stat");
-								for(k=0; k<itmp; k++)
-								{ //get all items of stat in system.core0.predictor--PBT
-									if (strcmp(xNode4.getChildNode("stat",k).getAttribute("name"),"predictor_accesses")==0) sys.core[i].predictor.predictor_accesses=atof(xNode4.getChildNode("stat",k).getAttribute("value"));
-								}
-							}
-						}
-						//Get all stats with system.NoC?
-						itmp=xNode3.nChildNode("stat");
-						for(k=0; k<itmp; k++)
-						{
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_accesses")==0) sys.NoC[i].total_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));
-							if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"duty_cycle")==0) sys.NoC[i].duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));
-						}
-					}
-					w=w+1;
-				}
-			}
-		}
-		//__________________________________________Get system.mem____________________________________________
-		if (OrderofComponents_3layer>0) OrderofComponents_3layer=OrderofComponents_3layer+1;
-		xNode3=xNode2.getChildNode("component",OrderofComponents_3layer);
-		if (xNode3.isEmpty()==1) {
-			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
-			exit(0);
-		}
-		if (strstr(xNode3.getAttribute("id"),"system.mem")!=NULL)
-		{
-
-			itmp=xNode3.nChildNode("param");
-			for(k=0; k<itmp; k++)
-			{ //get all items of param in system.mem
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"mem_tech_node")==0) {sys.mem.mem_tech_node=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"device_clock")==0) {sys.mem.device_clock=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"peak_transfer_rate")==0) {sys.mem.peak_transfer_rate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"capacity_per_channel")==0) {sys.mem.capacity_per_channel=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_ranks")==0) {sys.mem.number_ranks=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"num_banks_of_DRAM_chip")==0) {sys.mem.num_banks_of_DRAM_chip=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"Block_width_of_DRAM_chip")==0) {sys.mem.Block_width_of_DRAM_chip=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"output_width_of_DRAM_chip")==0) {sys.mem.output_width_of_DRAM_chip=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"page_size_of_DRAM_chip")==0) {sys.mem.page_size_of_DRAM_chip=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"burstlength_of_DRAM_chip")==0) {sys.mem.burstlength_of_DRAM_chip=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"internal_prefetch_of_DRAM_chip")==0) {sys.mem.internal_prefetch_of_DRAM_chip=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-			}
-			itmp=xNode3.nChildNode("stat");
-			for(k=0; k<itmp; k++)
-			{ //get all items of stat in system.mem
-				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_accesses")==0) {sys.mem.memory_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_reads")==0) {sys.mem.memory_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_writes")==0) {sys.mem.memory_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"dram_pre")==0) {sys.mem.dram_pre=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-			}
-		}
-		else{
-			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
-			exit(0);
-		}
-		//__________________________________________Get system.mc____________________________________________
-		if (OrderofComponents_3layer>0) OrderofComponents_3layer=OrderofComponents_3layer+1;
-		xNode3=xNode2.getChildNode("component",OrderofComponents_3layer);
-		if (xNode3.isEmpty()==1) {
-			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
-			exit(0);
-		}
-		if (strstr(xNode3.getAttribute("id"),"system.mc")!=NULL)
-		{
-			itmp=xNode3.nChildNode("param");
-			for(k=0; k<itmp; k++)
-			{ //get all items of param in system.mem
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"mc_clock")==0) {sys.mc.mc_clock=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"block_size")==0) {sys.mc.llc_line_length=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_mcs")==0) {sys.mc.number_mcs=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"memory_channels_per_mc")==0) {sys.mc.memory_channels_per_mc=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"req_window_size_per_channel")==0) {sys.mc.req_window_size_per_channel=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"IO_buffer_size_per_channel")==0) {sys.mc.IO_buffer_size_per_channel=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"databus_width")==0) {sys.mc.databus_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"addressbus_width")==0) {sys.mc.addressbus_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"PRT_entries")==0) {sys.mc.PRT_entries=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"peak_transfer_rate")==0) {sys.mc.peak_transfer_rate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_ranks")==0) {sys.mc.number_ranks=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"LVDS")==0) {sys.mc.LVDS=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"type")==0) {sys.mc.type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"withPHY")==0) {sys.mc.withPHY=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-
-        		if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dram_cmd_coeff")==0) {sys.mc.dram_cmd_coeff=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-        		if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dram_act_coeff")==0) {sys.mc.dram_act_coeff=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-        		if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dram_nop_coeff")==0) {sys.mc.dram_nop_coeff=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-        		if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dram_activity_coeff")==0) {sys.mc.dram_activity_coeff=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-        		if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dram_pre_coeff")==0) {sys.mc.dram_pre_coeff=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-        		if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dram_rd_coeff")==0) {sys.mc.dram_rd_coeff=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-        		if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dram_wr_coeff")==0) {sys.mc.dram_wr_coeff=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-        		if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dram_req_coeff")==0) {sys.mc.dram_req_coeff=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-        		if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"dram_const_coeff")==0) {sys.mc.dram_const_coeff=atof(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-			}
-			itmp=xNode3.nChildNode("stat");
-			for(k=0; k<itmp; k++)
-			{ //get all items of stat in system.mendirectory
-				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_accesses")==0) {sys.mc.memory_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_reads")==0) {sys.mc.memory_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_writes")==0) {sys.mc.memory_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"dram_pre")==0) {sys.mc.dram_pre=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-			}
-		}
-		else{
-			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
-			exit(0);
-		}
-		//__________________________________________Get system.niu____________________________________________
-		if (OrderofComponents_3layer>0) OrderofComponents_3layer=OrderofComponents_3layer+1;
-		xNode3=xNode2.getChildNode("component",OrderofComponents_3layer);
-		if (xNode3.isEmpty()==1) {
-			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
-			exit(0);
-		}
-		if (strstr(xNode3.getAttribute("id"),"system.niu")!=NULL)
-		{
-			itmp=xNode3.nChildNode("param");
-			for(k=0; k<itmp; k++)
-			{ //get all items of param in system.mem
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"clockrate")==0) {sys.niu.clockrate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_units")==0) {sys.niu.number_units=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"type")==0) {sys.niu.type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-			}
-			itmp=xNode3.nChildNode("stat");
-			for(k=0; k<itmp; k++)
-			{ //get all items of stat in system.mendirectory
-				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"duty_cycle")==0) {sys.niu.duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_load_perc")==0) {sys.niu.total_load_perc=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-			}
-		}
-		else{
-			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
-			exit(0);
-		}
-
-		//__________________________________________Get system.pcie____________________________________________
-		if (OrderofComponents_3layer>0) OrderofComponents_3layer=OrderofComponents_3layer+1;
-		xNode3=xNode2.getChildNode("component",OrderofComponents_3layer);
-		if (xNode3.isEmpty()==1) {
-			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
-			exit(0);
-		}
-		if (strstr(xNode3.getAttribute("id"),"system.pcie")!=NULL)
-		{
-			itmp=xNode3.nChildNode("param");
-			for(k=0; k<itmp; k++)
-			{ //get all items of param in system.mem
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"clockrate")==0) {sys.pcie.clockrate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_units")==0) {sys.pcie.number_units=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"num_channels")==0) {sys.pcie.num_channels=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"type")==0) {sys.pcie.type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"withPHY")==0) {sys.pcie.withPHY=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-
-			}
-			itmp=xNode3.nChildNode("stat");
-			for(k=0; k<itmp; k++)
-			{ //get all items of stat in system.mendirectory
-				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"duty_cycle")==0) {sys.pcie.duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_load_perc")==0) {sys.pcie.total_load_perc=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-			}
-		}
-		else{
-			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
-			exit(0);
-		}
-		//__________________________________________Get system.flashcontroller____________________________________________
-		if (OrderofComponents_3layer>0) OrderofComponents_3layer=OrderofComponents_3layer+1;
-		xNode3=xNode2.getChildNode("component",OrderofComponents_3layer);
-		if (xNode3.isEmpty()==1) {
-			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
-			exit(0);
-		}
-		if (strstr(xNode3.getAttribute("id"),"system.flashc")!=NULL)
-		{
-			itmp=xNode3.nChildNode("param");
-			for(k=0; k<itmp; k++)
-			{ //get all items of param in system.mem
-//				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"flashc_clock")==0) {sys.flashc.mc_clock=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-//				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"block_size")==0) {sys.flashc.llc_line_length=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_flashcs")==0) {sys.flashc.number_mcs=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-//				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"memory_channels_per_flashc")==0) {sys.flashc.memory_channels_per_mc=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-//				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"req_window_size_per_channel")==0) {sys.flashc.req_window_size_per_channel=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-//				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"IO_buffer_size_per_channel")==0) {sys.flashc.IO_buffer_size_per_channel=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-//				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"databus_width")==0) {sys.flashc.databus_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-//				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"addressbus_width")==0) {sys.flashc.addressbus_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"peak_transfer_rate")==0) {sys.flashc.peak_transfer_rate=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-//				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_ranks")==0) {sys.flashc.number_ranks=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-//				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"LVDS")==0) {sys.flashc.LVDS=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"type")==0) {sys.flashc.type=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"withPHY")==0) {sys.flashc.withPHY=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
-
-			}
-			itmp=xNode3.nChildNode("stat");
-			for(k=0; k<itmp; k++)
-			{ //get all items of stat in system.mendirectory
-//				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_accesses")==0) {sys.flashc.memory_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-//				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_reads")==0) {sys.flashc.memory_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-//				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_writes")==0) {sys.flashc.memory_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"duty_cycle")==0) {sys.flashc.duty_cycle=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-				if (strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"total_load_perc")==0) {sys.flashc.total_load_perc=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
-
-			}
-		}
-		else{
-			printf("some value(s) of number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are not correct!");
-			exit(0);
-		}
-
-	}
+    //__________________________________________Get
+    //system.pcie____________________________________________
+    if (OrderofComponents_3layer > 0)
+      OrderofComponents_3layer = OrderofComponents_3layer + 1;
+    xNode3 = xNode2.getChildNode("component", OrderofComponents_3layer);
+    if (xNode3.isEmpty() == 1) {
+      printf(
+          "some value(s) of "
+          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
+          "not correct!");
+      exit(0);
+    }
+    if (strstr(xNode3.getAttribute("id"), "system.pcie") != NULL) {
+      itmp = xNode3.nChildNode("param");
+      for (k = 0; k < itmp; k++) {  // get all items of param in system.mem
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "clockrate") == 0) {
+          sys.pcie.clockrate =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "number_units") == 0) {
+          sys.pcie.number_units =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "num_channels") == 0) {
+          sys.pcie.num_channels =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "type") == 0) {
+          sys.pcie.type =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "withPHY") == 0) {
+          sys.pcie.withPHY =
+              (bool)atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+      }
+      itmp = xNode3.nChildNode("stat");
+      for (k = 0; k < itmp;
+           k++) {  // get all items of stat in system.mendirectory
+        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                   "duty_cycle") == 0) {
+          sys.pcie.duty_cycle =
+              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                   "total_load_perc") == 0) {
+          sys.pcie.total_load_perc =
+              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+          continue;
+        }
+      }
+    } else {
+      printf(
+          "some value(s) of "
+          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
+          "not correct!");
+      exit(0);
+    }
+    //__________________________________________Get
+    //system.flashcontroller____________________________________________
+    if (OrderofComponents_3layer > 0)
+      OrderofComponents_3layer = OrderofComponents_3layer + 1;
+    xNode3 = xNode2.getChildNode("component", OrderofComponents_3layer);
+    if (xNode3.isEmpty() == 1) {
+      printf(
+          "some value(s) of "
+          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
+          "not correct!");
+      exit(0);
+    }
+    if (strstr(xNode3.getAttribute("id"), "system.flashc") != NULL) {
+      itmp = xNode3.nChildNode("param");
+      for (k = 0; k < itmp; k++) {  // get all items of param in system.mem
+        //				if
+        //(strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"flashc_clock")==0)
+        //{sys.flashc.mc_clock=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+        //				if
+        //(strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"block_size")==0)
+        //{sys.flashc.llc_line_length=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "number_flashcs") == 0) {
+          sys.flashc.number_mcs =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        //				if
+        //(strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"memory_channels_per_flashc")==0)
+        //{sys.flashc.memory_channels_per_mc=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+        //				if
+        //(strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"req_window_size_per_channel")==0)
+        //{sys.flashc.req_window_size_per_channel=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+        //				if
+        //(strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"IO_buffer_size_per_channel")==0)
+        //{sys.flashc.IO_buffer_size_per_channel=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+        //				if
+        //(strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"databus_width")==0)
+        //{sys.flashc.databus_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+        //				if
+        //(strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"addressbus_width")==0)
+        //{sys.flashc.addressbus_width=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "peak_transfer_rate") == 0) {
+          sys.flashc.peak_transfer_rate =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        //				if
+        //(strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"number_ranks")==0)
+        //{sys.flashc.number_ranks=atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+        //				if
+        //(strcmp(xNode3.getChildNode("param",k).getAttribute("name"),"LVDS")==0)
+        //{sys.flashc.LVDS=(bool)atoi(xNode3.getChildNode("param",k).getAttribute("value"));continue;}
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "type") == 0) {
+          sys.flashc.type =
+              atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("param", k).getAttribute("name"),
+                   "withPHY") == 0) {
+          sys.flashc.withPHY =
+              (bool)atoi(xNode3.getChildNode("param", k).getAttribute("value"));
+          continue;
+        }
+      }
+      itmp = xNode3.nChildNode("stat");
+      for (k = 0; k < itmp;
+           k++) {  // get all items of stat in system.mendirectory
+        //				if
+        //(strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_accesses")==0)
+        //{sys.flashc.memory_accesses=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+        //				if
+        //(strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_reads")==0)
+        //{sys.flashc.memory_reads=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+        //				if
+        //(strcmp(xNode3.getChildNode("stat",k).getAttribute("name"),"memory_writes")==0)
+        //{sys.flashc.memory_writes=atof(xNode3.getChildNode("stat",k).getAttribute("value"));continue;}
+        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                   "duty_cycle") == 0) {
+          sys.flashc.duty_cycle =
+              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+          continue;
+        }
+        if (strcmp(xNode3.getChildNode("stat", k).getAttribute("name"),
+                   "total_load_perc") == 0) {
+          sys.flashc.total_load_perc =
+              atof(xNode3.getChildNode("stat", k).getAttribute("value"));
+          continue;
+        }
+      }
+    } else {
+      printf(
+          "some value(s) of "
+          "number_of_cores/number_of_L2s/number_of_L3s/number_of_NoCs is/are "
+          "not correct!");
+      exit(0);
+    }
+  }
 }
-void ParseXML::initialize() //Initialize all
+void ParseXML::initialize()  // Initialize all
 {
-	//All number_of_* at the level of 'system' 03/21/2009
-	sys.number_of_cores=1;
-	sys.architecture=1; //1 - fermi
-	sys.number_of_L1Directories=1;
-	sys.number_of_L2Directories=1;
-	sys.number_of_L2s=1;
-	sys.Private_L2 = false;
-	sys.number_of_L3s=1;
-	sys.number_of_NoCs=1;
-	// All params at the level of 'system'
-	//strcpy(sys.homogeneous_cores,"default");
-	sys.core_tech_node=1;
-	sys.target_core_clockrate=1;
-	sys.target_chip_area=1;
-	sys.temperature=1;
-	sys.number_cache_levels=1;
-	sys.homogeneous_cores=1;
-	sys.homogeneous_L1Directories=1;
-	sys.homogeneous_L2Directories=1;
-	sys.homogeneous_L2s=1;
-	sys.homogeneous_L3s=1;
-	sys.homogeneous_NoCs=1;
-	sys.homogeneous_ccs=1;
+  // All number_of_* at the level of 'system' 03/21/2009
+  sys.number_of_cores = 1;
+  sys.architecture = 1;  // 1 - fermi
+  sys.number_of_L1Directories = 1;
+  sys.number_of_L2Directories = 1;
+  sys.number_of_L2s = 1;
+  sys.Private_L2 = false;
+  sys.number_of_L3s = 1;
+  sys.number_of_NoCs = 1;
+  // All params at the level of 'system'
+  // strcpy(sys.homogeneous_cores,"default");
+  sys.core_tech_node = 1;
+  sys.target_core_clockrate = 1;
+  sys.target_chip_area = 1;
+  sys.temperature = 1;
+  sys.number_cache_levels = 1;
+  sys.homogeneous_cores = 1;
+  sys.homogeneous_L1Directories = 1;
+  sys.homogeneous_L2Directories = 1;
+  sys.homogeneous_L2s = 1;
+  sys.homogeneous_L3s = 1;
+  sys.homogeneous_NoCs = 1;
+  sys.homogeneous_ccs = 1;
 
-	sys.Max_area_deviation=1;
-	sys.Max_power_deviation=1;
-	sys.device_type=1;
-	sys.longer_channel_device =true;
-	sys.Embedded =false;
-	sys.opt_dynamic_power=false;
-	sys.opt_lakage_power=false;
-	sys.opt_clockrate=true;
-	sys.opt_area=false;
-	sys.interconnect_projection_type=1;
-	sys.idle_core_power=0;
-	int i,j;
-	for (i=0; i<=63; i++)
-	{
-		sys.scaling_coefficients[i]=1;
-		sys.core[i].clock_rate=1;
-		sys.core[i].opt_local = true;
-		sys.core[i].x86 = false;
-		sys.core[i].machine_bits=1;
-		sys.core[i].virtual_address_width=1;
-		sys.core[i].physical_address_width=1;
-		sys.core[i].opcode_width=1;
-		sys.core[i].micro_opcode_width=1;
-		//strcpy(sys.core[i].machine_type,"default");
-		sys.core[i].internal_datapath_width=1;
-		sys.core[i].number_hardware_threads=1;
-		sys.core[i].fetch_width=1;
-		sys.core[i].number_instruction_fetch_ports=1;
-		sys.core[i].decode_width=1;
-		sys.core[i].issue_width=1;
-		sys.core[i].peak_issue_width=1;
-		sys.core[i].commit_width=1;
-		for (j=0; j<20; j++) sys.core[i].pipelines_per_core[j]=1;
-		for (j=0; j<20; j++) sys.core[i].pipeline_depth[j]=1;
-		strcpy(sys.core[i].FPU,"default");
-		strcpy(sys.core[i]. divider_multiplier,"default");
-		sys.core[i].ALU_per_core=1;
-		sys.core[i].FPU_per_core=1.0;
-		sys.core[i].MUL_per_core=1;
-		sys.core[i].instruction_buffer_size=1;
-		sys.core[i].decoded_stream_buffer_size=1;
-		//strcpy(sys.core[i].instruction_window_scheme,"default");
-		sys.core[i].instruction_window_size=1;
-		sys.core[i].ROB_size=1;
-		sys.core[i].archi_Regs_IRF_size=1;
-		sys.core[i].archi_Regs_FRF_size=1;
-		sys.core[i].phy_Regs_IRF_size=1;
-		sys.core[i].phy_Regs_FRF_size=1;
-		//strcpy(sys.core[i].rename_scheme,"default");
-		sys.core[i].register_windows_size=1;
-		strcpy(sys.core[i].LSU_order,"default");
-		sys.core[i].store_buffer_size=1;
-		sys.core[i].load_buffer_size=1;
-		sys.core[i].memory_ports=1;
-		strcpy(sys.core[i].Dcache_dual_pump,"default");
-		sys.core[i].RAS_size=1;
-		//all stats at the level of system.core(0-n)
-		sys.core[i].total_instructions=1;
-		sys.core[i].int_instructions=1;
-		sys.core[i].fp_instructions=1;
-		sys.core[i].branch_instructions=1;
-		sys.core[i].branch_mispredictions=1;
-		sys.core[i].committed_instructions=1;
-		sys.core[i].load_instructions=1;
-		sys.core[i].store_instructions=1;
-		sys.core[i].total_cycles=1;
-		sys.core[i].idle_cycles=1;
-		sys.core[i].busy_cycles=1;
-		sys.core[i].instruction_buffer_reads=1;
-		sys.core[i].instruction_buffer_write=1;
-		sys.core[i].ROB_reads=1;
-		sys.core[i].ROB_writes=1;
-		sys.core[i].rename_accesses=1;
-		sys.core[i].inst_window_reads=1;
-		sys.core[i].inst_window_writes=1;
-		sys.core[i].inst_window_wakeup_accesses=1;
-		sys.core[i].inst_window_selections=1;
-		sys.core[i].archi_int_regfile_reads=1;
-		sys.core[i].archi_float_regfile_reads=1;
-		sys.core[i].phy_int_regfile_reads=1;
-		sys.core[i].phy_float_regfile_reads=1;
-		sys.core[i].windowed_reg_accesses=1;
-		sys.core[i].windowed_reg_transports=1;
-		sys.core[i].function_calls=1;
-		sys.core[i].ialu_accesses=1;
-		sys.core[i].fpu_accesses=1;
-		sys.core[i].mul_accesses=1;
-		sys.core[i].cdb_alu_accesses=1;
-		sys.core[i].cdb_mul_accesses=1;
-		sys.core[i].cdb_fpu_accesses=1;
-		sys.core[i].load_buffer_reads=1;
-		sys.core[i].load_buffer_writes=1;
-		sys.core[i].load_buffer_cams=1;
-		sys.core[i].store_buffer_reads=1;
-		sys.core[i].store_buffer_writes=1;
-		sys.core[i].store_buffer_cams=1;
-		sys.core[i].store_buffer_forwards=1;
-		sys.core[i].main_memory_access=1;
-		sys.core[i].main_memory_read=1;
-		sys.core[i].main_memory_write=1;
-		sys.core[i].IFU_duty_cycle = 1;
-		sys.core[i].BR_duty_cycle = 1;
-		sys.core[i].LSU_duty_cycle = 1;
-		sys.core[i].MemManU_I_duty_cycle =1;
-		sys.core[i].MemManU_D_duty_cycle =1;
-		sys.core[i].ALU_duty_cycle =1;
-		sys.core[i].MUL_duty_cycle =1;
-		sys.core[i].FPU_duty_cycle =1;
-		sys.core[i].ALU_cdb_duty_cycle =1;
-		sys.core[i].MUL_cdb_duty_cycle =1;
-		sys.core[i].FPU_cdb_duty_cycle =1;
-		//system.core?.predictor
-		sys.core[i].predictor.prediction_width=1;
-		strcpy(sys.core[i].predictor.prediction_scheme,"default");
-		sys.core[i].predictor.predictor_size=1;
-		sys.core[i].predictor.predictor_entries=1;
-		sys.core[i].predictor.local_predictor_entries=1;
-		for (j=0; j<20; j++) sys.core[i].predictor.local_predictor_size[j]=1;
-		sys.core[i].predictor.global_predictor_entries=1;
-		sys.core[i].predictor.global_predictor_bits=1;
-		sys.core[i].predictor.chooser_predictor_entries=1;
-		sys.core[i].predictor.chooser_predictor_bits=1;
-		sys.core[i].predictor.predictor_accesses=1;
-		//system.core?.itlb
-		sys.core[i].itlb.number_entries=1;
-		sys.core[i].itlb.total_hits=1;
-		sys.core[i].itlb.total_accesses=1;
-		sys.core[i].itlb.total_misses=1;
-		//system.core?.icache
-		for (j=0; j<20; j++) sys.core[i].icache.icache_config[j]=1;
-		//strcpy(sys.core[i].icache.buffer_sizes,"default");
-		sys.core[i].icache.total_accesses=1;
-		sys.core[i].icache.read_accesses=1;
-		sys.core[i].icache.read_misses=1;
-		sys.core[i].icache.replacements=1;
-		sys.core[i].icache.read_hits=1;
-		sys.core[i].icache.total_hits=1;
-		sys.core[i].icache.total_misses=1;
-		sys.core[i].icache.miss_buffer_access=1;
-		sys.core[i].icache.fill_buffer_accesses=1;
-		sys.core[i].icache.prefetch_buffer_accesses=1;
-		sys.core[i].icache.prefetch_buffer_writes=1;
-		sys.core[i].icache.prefetch_buffer_reads=1;
-		sys.core[i].icache.prefetch_buffer_hits=1;
-		//system.core?.dtlb
-		sys.core[i].dtlb.number_entries=1;
-		sys.core[i].dtlb.total_accesses=1;
-		sys.core[i].dtlb.read_accesses=1;
-		sys.core[i].dtlb.write_accesses=1;
-		sys.core[i].dtlb.write_hits=1;
-		sys.core[i].dtlb.read_hits=1;
-		sys.core[i].dtlb.read_misses=1;
-		sys.core[i].dtlb.write_misses=1;
-		sys.core[i].dtlb.total_hits=1;
-		sys.core[i].dtlb.total_misses=1;
-		//system.core?.dcache
-		for (j=0; j<20; j++) sys.core[i].dcache.dcache_config[j]=1;
-		//strcpy(sys.core[i].dcache.buffer_sizes,"default");
-		sys.core[i].dcache.total_accesses=1;
-		sys.core[i].dcache.read_accesses=1;
-		sys.core[i].dcache.write_accesses=1;
-		sys.core[i].dcache.total_hits=1;
-		sys.core[i].dcache.total_misses=1;
-		sys.core[i].dcache.read_hits=1;
-		sys.core[i].dcache.write_hits=1;
-		sys.core[i].dcache.read_misses=1;
-		sys.core[i].dcache.write_misses=1;
-		sys.core[i].dcache.replacements=1;
-		sys.core[i].dcache.write_backs=1;
-		sys.core[i].dcache.miss_buffer_access=1;
-		sys.core[i].dcache.fill_buffer_accesses=1;
-		sys.core[i].dcache.prefetch_buffer_accesses=1;
-		sys.core[i].dcache.prefetch_buffer_writes=1;
-		sys.core[i].dcache.prefetch_buffer_reads=1;
-		sys.core[i].dcache.prefetch_buffer_hits=1;
-		sys.core[i].dcache.wbb_writes=1;
-		sys.core[i].dcache.wbb_reads=1;
-		//system.core?.BTB
-		for (j=0; j<20; j++) sys.core[i].BTB.BTB_config[j]=1;
-		sys.core[i].BTB.total_accesses=1;
-		sys.core[i].BTB.read_accesses=1;
-		sys.core[i].BTB.write_accesses=1;
-		sys.core[i].BTB.total_hits=1;
-		sys.core[i].BTB.total_misses=1;
-		sys.core[i].BTB.read_hits=1;
-		sys.core[i].BTB.write_hits=1;
-		sys.core[i].BTB.read_misses=1;
-		sys.core[i].BTB.write_misses=1;
-		sys.core[i].BTB.replacements=1;
-	}
+  sys.Max_area_deviation = 1;
+  sys.Max_power_deviation = 1;
+  sys.device_type = 1;
+  sys.longer_channel_device = true;
+  sys.Embedded = false;
+  sys.opt_dynamic_power = false;
+  sys.opt_lakage_power = false;
+  sys.opt_clockrate = true;
+  sys.opt_area = false;
+  sys.interconnect_projection_type = 1;
+  sys.idle_core_power = 0;
+  int i, j;
+  for (i = 0; i <= 63; i++) {
+    sys.scaling_coefficients[i] = 1;
+    sys.core[i].clock_rate = 1;
+    sys.core[i].opt_local = true;
+    sys.core[i].x86 = false;
+    sys.core[i].machine_bits = 1;
+    sys.core[i].virtual_address_width = 1;
+    sys.core[i].physical_address_width = 1;
+    sys.core[i].opcode_width = 1;
+    sys.core[i].micro_opcode_width = 1;
+    // strcpy(sys.core[i].machine_type,"default");
+    sys.core[i].internal_datapath_width = 1;
+    sys.core[i].number_hardware_threads = 1;
+    sys.core[i].fetch_width = 1;
+    sys.core[i].number_instruction_fetch_ports = 1;
+    sys.core[i].decode_width = 1;
+    sys.core[i].issue_width = 1;
+    sys.core[i].peak_issue_width = 1;
+    sys.core[i].commit_width = 1;
+    for (j = 0; j < 20; j++) sys.core[i].pipelines_per_core[j] = 1;
+    for (j = 0; j < 20; j++) sys.core[i].pipeline_depth[j] = 1;
+    strcpy(sys.core[i].FPU, "default");
+    strcpy(sys.core[i].divider_multiplier, "default");
+    sys.core[i].ALU_per_core = 1;
+    sys.core[i].FPU_per_core = 1.0;
+    sys.core[i].MUL_per_core = 1;
+    sys.core[i].instruction_buffer_size = 1;
+    sys.core[i].decoded_stream_buffer_size = 1;
+    // strcpy(sys.core[i].instruction_window_scheme,"default");
+    sys.core[i].instruction_window_size = 1;
+    sys.core[i].ROB_size = 1;
+    sys.core[i].archi_Regs_IRF_size = 1;
+    sys.core[i].archi_Regs_FRF_size = 1;
+    sys.core[i].phy_Regs_IRF_size = 1;
+    sys.core[i].phy_Regs_FRF_size = 1;
+    // strcpy(sys.core[i].rename_scheme,"default");
+    sys.core[i].register_windows_size = 1;
+    strcpy(sys.core[i].LSU_order, "default");
+    sys.core[i].store_buffer_size = 1;
+    sys.core[i].load_buffer_size = 1;
+    sys.core[i].memory_ports = 1;
+    strcpy(sys.core[i].Dcache_dual_pump, "default");
+    sys.core[i].RAS_size = 1;
+    // all stats at the level of system.core(0-n)
+    sys.core[i].total_instructions = 1;
+    sys.core[i].int_instructions = 1;
+    sys.core[i].fp_instructions = 1;
+    sys.core[i].branch_instructions = 1;
+    sys.core[i].branch_mispredictions = 1;
+    sys.core[i].committed_instructions = 1;
+    sys.core[i].load_instructions = 1;
+    sys.core[i].store_instructions = 1;
+    sys.core[i].total_cycles = 1;
+    sys.core[i].idle_cycles = 1;
+    sys.core[i].busy_cycles = 1;
+    sys.core[i].instruction_buffer_reads = 1;
+    sys.core[i].instruction_buffer_write = 1;
+    sys.core[i].ROB_reads = 1;
+    sys.core[i].ROB_writes = 1;
+    sys.core[i].rename_accesses = 1;
+    sys.core[i].inst_window_reads = 1;
+    sys.core[i].inst_window_writes = 1;
+    sys.core[i].inst_window_wakeup_accesses = 1;
+    sys.core[i].inst_window_selections = 1;
+    sys.core[i].archi_int_regfile_reads = 1;
+    sys.core[i].archi_float_regfile_reads = 1;
+    sys.core[i].phy_int_regfile_reads = 1;
+    sys.core[i].phy_float_regfile_reads = 1;
+    sys.core[i].windowed_reg_accesses = 1;
+    sys.core[i].windowed_reg_transports = 1;
+    sys.core[i].function_calls = 1;
+    sys.core[i].ialu_accesses = 1;
+    sys.core[i].fpu_accesses = 1;
+    sys.core[i].mul_accesses = 1;
+    sys.core[i].cdb_alu_accesses = 1;
+    sys.core[i].cdb_mul_accesses = 1;
+    sys.core[i].cdb_fpu_accesses = 1;
+    sys.core[i].load_buffer_reads = 1;
+    sys.core[i].load_buffer_writes = 1;
+    sys.core[i].load_buffer_cams = 1;
+    sys.core[i].store_buffer_reads = 1;
+    sys.core[i].store_buffer_writes = 1;
+    sys.core[i].store_buffer_cams = 1;
+    sys.core[i].store_buffer_forwards = 1;
+    sys.core[i].main_memory_access = 1;
+    sys.core[i].main_memory_read = 1;
+    sys.core[i].main_memory_write = 1;
+    sys.core[i].IFU_duty_cycle = 1;
+    sys.core[i].BR_duty_cycle = 1;
+    sys.core[i].LSU_duty_cycle = 1;
+    sys.core[i].MemManU_I_duty_cycle = 1;
+    sys.core[i].MemManU_D_duty_cycle = 1;
+    sys.core[i].ALU_duty_cycle = 1;
+    sys.core[i].MUL_duty_cycle = 1;
+    sys.core[i].FPU_duty_cycle = 1;
+    sys.core[i].ALU_cdb_duty_cycle = 1;
+    sys.core[i].MUL_cdb_duty_cycle = 1;
+    sys.core[i].FPU_cdb_duty_cycle = 1;
+    // system.core?.predictor
+    sys.core[i].predictor.prediction_width = 1;
+    strcpy(sys.core[i].predictor.prediction_scheme, "default");
+    sys.core[i].predictor.predictor_size = 1;
+    sys.core[i].predictor.predictor_entries = 1;
+    sys.core[i].predictor.local_predictor_entries = 1;
+    for (j = 0; j < 20; j++) sys.core[i].predictor.local_predictor_size[j] = 1;
+    sys.core[i].predictor.global_predictor_entries = 1;
+    sys.core[i].predictor.global_predictor_bits = 1;
+    sys.core[i].predictor.chooser_predictor_entries = 1;
+    sys.core[i].predictor.chooser_predictor_bits = 1;
+    sys.core[i].predictor.predictor_accesses = 1;
+    // system.core?.itlb
+    sys.core[i].itlb.number_entries = 1;
+    sys.core[i].itlb.total_hits = 1;
+    sys.core[i].itlb.total_accesses = 1;
+    sys.core[i].itlb.total_misses = 1;
+    // system.core?.icache
+    for (j = 0; j < 20; j++) sys.core[i].icache.icache_config[j] = 1;
+    // strcpy(sys.core[i].icache.buffer_sizes,"default");
+    sys.core[i].icache.total_accesses = 1;
+    sys.core[i].icache.read_accesses = 1;
+    sys.core[i].icache.read_misses = 1;
+    sys.core[i].icache.replacements = 1;
+    sys.core[i].icache.read_hits = 1;
+    sys.core[i].icache.total_hits = 1;
+    sys.core[i].icache.total_misses = 1;
+    sys.core[i].icache.miss_buffer_access = 1;
+    sys.core[i].icache.fill_buffer_accesses = 1;
+    sys.core[i].icache.prefetch_buffer_accesses = 1;
+    sys.core[i].icache.prefetch_buffer_writes = 1;
+    sys.core[i].icache.prefetch_buffer_reads = 1;
+    sys.core[i].icache.prefetch_buffer_hits = 1;
+    // system.core?.dtlb
+    sys.core[i].dtlb.number_entries = 1;
+    sys.core[i].dtlb.total_accesses = 1;
+    sys.core[i].dtlb.read_accesses = 1;
+    sys.core[i].dtlb.write_accesses = 1;
+    sys.core[i].dtlb.write_hits = 1;
+    sys.core[i].dtlb.read_hits = 1;
+    sys.core[i].dtlb.read_misses = 1;
+    sys.core[i].dtlb.write_misses = 1;
+    sys.core[i].dtlb.total_hits = 1;
+    sys.core[i].dtlb.total_misses = 1;
+    // system.core?.dcache
+    for (j = 0; j < 20; j++) sys.core[i].dcache.dcache_config[j] = 1;
+    // strcpy(sys.core[i].dcache.buffer_sizes,"default");
+    sys.core[i].dcache.total_accesses = 1;
+    sys.core[i].dcache.read_accesses = 1;
+    sys.core[i].dcache.write_accesses = 1;
+    sys.core[i].dcache.total_hits = 1;
+    sys.core[i].dcache.total_misses = 1;
+    sys.core[i].dcache.read_hits = 1;
+    sys.core[i].dcache.write_hits = 1;
+    sys.core[i].dcache.read_misses = 1;
+    sys.core[i].dcache.write_misses = 1;
+    sys.core[i].dcache.replacements = 1;
+    sys.core[i].dcache.write_backs = 1;
+    sys.core[i].dcache.miss_buffer_access = 1;
+    sys.core[i].dcache.fill_buffer_accesses = 1;
+    sys.core[i].dcache.prefetch_buffer_accesses = 1;
+    sys.core[i].dcache.prefetch_buffer_writes = 1;
+    sys.core[i].dcache.prefetch_buffer_reads = 1;
+    sys.core[i].dcache.prefetch_buffer_hits = 1;
+    sys.core[i].dcache.wbb_writes = 1;
+    sys.core[i].dcache.wbb_reads = 1;
+    // system.core?.BTB
+    for (j = 0; j < 20; j++) sys.core[i].BTB.BTB_config[j] = 1;
+    sys.core[i].BTB.total_accesses = 1;
+    sys.core[i].BTB.read_accesses = 1;
+    sys.core[i].BTB.write_accesses = 1;
+    sys.core[i].BTB.total_hits = 1;
+    sys.core[i].BTB.total_misses = 1;
+    sys.core[i].BTB.read_hits = 1;
+    sys.core[i].BTB.write_hits = 1;
+    sys.core[i].BTB.read_misses = 1;
+    sys.core[i].BTB.write_misses = 1;
+    sys.core[i].BTB.replacements = 1;
+  }
 
-	//system_L1directory
-	for (i=0; i<=63; i++)
-	{
-		for (j=0; j<20; j++) sys.L1Directory[i].Dir_config[j]=1;
-		for (j=0; j<20; j++) sys.L1Directory[i].buffer_sizes[j]=1;
-		sys.L1Directory[i].clockrate=1;
-		sys.L1Directory[i].ports[20]=1;
-		sys.L1Directory[i].device_type=1;
-		strcpy(sys.L1Directory[i].threeD_stack,"default");
-		sys.L1Directory[i].total_accesses=1;
-		sys.L1Directory[i].read_accesses=1;
-		sys.L1Directory[i].write_accesses=1;
-		sys.L1Directory[i].duty_cycle =1;
-	}
-	//system_L2directory
-	for (i=0; i<=63; i++)
-	{
-		for (j=0; j<20; j++) sys.L2Directory[i].Dir_config[j]=1;
-		for (j=0; j<20; j++) sys.L2Directory[i].buffer_sizes[j]=1;
-		sys.L2Directory[i].clockrate=1;
-		sys.L2Directory[i].ports[20]=1;
-		sys.L2Directory[i].device_type=1;
-		strcpy(sys.L2Directory[i].threeD_stack,"default");
-		sys.L2Directory[i].total_accesses=1;
-		sys.L2Directory[i].read_accesses=1;
-		sys.L2Directory[i].write_accesses=1;
-		sys.L2Directory[i].duty_cycle =1;
-	}
-	for (i=0; i<=63; i++)
-	{
-		//system_L2
-		for (j=0; j<20; j++) sys.L2[i].L2_config[j]=1;
-		sys.L2[i].clockrate=1;
-		for (j=0; j<20; j++) sys.L2[i].ports[j]=1;
-		sys.L2[i].device_type=1;
-		strcpy(sys.L2[i].threeD_stack,"default");
-		for (j=0; j<20; j++) sys.L2[i].buffer_sizes[j]=1;
-		sys.L2[i].total_accesses=1;
-		sys.L2[i].read_accesses=1;
-		sys.L2[i].write_accesses=1;
-		sys.L2[i].total_hits=1;
-		sys.L2[i].total_misses=1;
-		sys.L2[i].read_hits=1;
-		sys.L2[i].write_hits=1;
-		sys.L2[i].read_misses=1;
-		sys.L2[i].write_misses=1;
-		sys.L2[i].replacements=1;
-		sys.L2[i].write_backs=1;
-		sys.L2[i].miss_buffer_accesses=1;
-		sys.L2[i].fill_buffer_accesses=1;
-		sys.L2[i].prefetch_buffer_accesses=1;
-		sys.L2[i].prefetch_buffer_writes=1;
-		sys.L2[i].prefetch_buffer_reads=1;
-		sys.L2[i].prefetch_buffer_hits=1;
-		sys.L2[i].wbb_writes=1;
-		sys.L2[i].wbb_reads=1;
-		sys.L2[i].duty_cycle =1;
-		sys.L2[i].merged_dir=false;
-		sys.L2[i].homenode_read_accesses =1;
-		sys.L2[i].homenode_write_accesses=1;
-		sys.L2[i].homenode_read_hits=1;
-		sys.L2[i].homenode_write_hits=1;
-		sys.L2[i].homenode_read_misses=1;
-		sys.L2[i].homenode_write_misses=1;
-		sys.L2[i].dir_duty_cycle=1;
-	}
-	for (i=0; i<=63; i++)
-	{
-		//system_L3
-		for (j=0; j<20; j++) sys.L3[i].L3_config[j]=1;
-		sys.L3[i].clockrate=1;
-		for (j=0; j<20; j++) sys.L3[i].ports[j]=1;
-		sys.L3[i].device_type=1;
-		strcpy(sys.L3[i].threeD_stack,"default");
-		for (j=0; j<20; j++) sys.L3[i].buffer_sizes[j]=1;
-		sys.L3[i].total_accesses=1;
-		sys.L3[i].read_accesses=1;
-		sys.L3[i].write_accesses=1;
-		sys.L3[i].total_hits=1;
-		sys.L3[i].total_misses=1;
-		sys.L3[i].read_hits=1;
-		sys.L3[i].write_hits=1;
-		sys.L3[i].read_misses=1;
-		sys.L3[i].write_misses=1;
-		sys.L3[i].replacements=1;
-		sys.L3[i].write_backs=1;
-		sys.L3[i].miss_buffer_accesses=1;
-		sys.L3[i].fill_buffer_accesses=1;
-		sys.L3[i].prefetch_buffer_accesses=1;
-		sys.L3[i].prefetch_buffer_writes=1;
-		sys.L3[i].prefetch_buffer_reads=1;
-		sys.L3[i].prefetch_buffer_hits=1;
-		sys.L3[i].wbb_writes=1;
-		sys.L3[i].wbb_reads=1;
-		sys.L3[i].duty_cycle =1;
-		sys.L3[i].merged_dir=false;
-		sys.L3[i].homenode_read_accesses =1;
-		sys.L3[i].homenode_write_accesses=1;
-		sys.L3[i].homenode_read_hits=1;
-		sys.L3[i].homenode_write_hits=1;
-		sys.L3[i].homenode_read_misses=1;
-		sys.L3[i].homenode_write_misses=1;
-		sys.L3[i].dir_duty_cycle=1;
-	}
-	//system_NoC
-	for (i=0; i<=63; i++)
-	{
-		sys.NoC[i].clockrate=1;
-		sys.NoC[i].type=true;
-		sys.NoC[i].chip_coverage=1;
-		sys.NoC[i].has_global_link = true;
-		strcpy(sys.NoC[i].topology,"default");
-		sys.NoC[i].horizontal_nodes=1;
-		sys.NoC[i].vertical_nodes=1;
-		sys.NoC[i].input_ports=1;
-		sys.NoC[i].output_ports=1;
-		sys.NoC[i].virtual_channel_per_port=1;
-		sys.NoC[i].flit_bits=1;
-		sys.NoC[i].input_buffer_entries_per_vc=1;
-		sys.NoC[i].total_accesses=1;
-		sys.NoC[i].duty_cycle=1;
-		sys.NoC[i].route_over_perc = 0.5;
-		for (j=0; j<20; j++) sys.NoC[i].ports_of_input_buffer[j]=1;
-		sys.NoC[i].number_of_crossbars=1;
-		strcpy(sys.NoC[i].crossbar_type,"default");
-		strcpy(sys.NoC[i].crosspoint_type,"default");
-		//system.NoC?.xbar0;
-		sys.NoC[i].xbar0.number_of_inputs_of_crossbars=1;
-		sys.NoC[i].xbar0.number_of_outputs_of_crossbars=1;
-		sys.NoC[i].xbar0.flit_bits=1;
-		sys.NoC[i].xbar0.input_buffer_entries_per_port=1;
-		sys.NoC[i].xbar0.ports_of_input_buffer[20]=1;
-		sys.NoC[i].xbar0.crossbar_accesses=1;
-	}
-	//system_mem
-	sys.mem.mem_tech_node=1;
-	sys.mem.device_clock=1;
-	sys.mem.capacity_per_channel=1;
-	sys.mem.number_ranks=1;
-	sys.mem.peak_transfer_rate =1;
-	sys.mem.num_banks_of_DRAM_chip=1;
-	sys.mem.Block_width_of_DRAM_chip=1;
-	sys.mem.output_width_of_DRAM_chip=1;
-	sys.mem.page_size_of_DRAM_chip=1;
-	sys.mem.burstlength_of_DRAM_chip=1;
-	sys.mem.internal_prefetch_of_DRAM_chip=1;
-	sys.mem.memory_accesses=1;
-	sys.mem.memory_reads=1;
-	sys.mem.memory_writes=1;
+  // system_L1directory
+  for (i = 0; i <= 63; i++) {
+    for (j = 0; j < 20; j++) sys.L1Directory[i].Dir_config[j] = 1;
+    for (j = 0; j < 20; j++) sys.L1Directory[i].buffer_sizes[j] = 1;
+    sys.L1Directory[i].clockrate = 1;
+    sys.L1Directory[i].ports[20] = 1;
+    sys.L1Directory[i].device_type = 1;
+    strcpy(sys.L1Directory[i].threeD_stack, "default");
+    sys.L1Directory[i].total_accesses = 1;
+    sys.L1Directory[i].read_accesses = 1;
+    sys.L1Directory[i].write_accesses = 1;
+    sys.L1Directory[i].duty_cycle = 1;
+  }
+  // system_L2directory
+  for (i = 0; i <= 63; i++) {
+    for (j = 0; j < 20; j++) sys.L2Directory[i].Dir_config[j] = 1;
+    for (j = 0; j < 20; j++) sys.L2Directory[i].buffer_sizes[j] = 1;
+    sys.L2Directory[i].clockrate = 1;
+    sys.L2Directory[i].ports[20] = 1;
+    sys.L2Directory[i].device_type = 1;
+    strcpy(sys.L2Directory[i].threeD_stack, "default");
+    sys.L2Directory[i].total_accesses = 1;
+    sys.L2Directory[i].read_accesses = 1;
+    sys.L2Directory[i].write_accesses = 1;
+    sys.L2Directory[i].duty_cycle = 1;
+  }
+  for (i = 0; i <= 63; i++) {
+    // system_L2
+    for (j = 0; j < 20; j++) sys.L2[i].L2_config[j] = 1;
+    sys.L2[i].clockrate = 1;
+    for (j = 0; j < 20; j++) sys.L2[i].ports[j] = 1;
+    sys.L2[i].device_type = 1;
+    strcpy(sys.L2[i].threeD_stack, "default");
+    for (j = 0; j < 20; j++) sys.L2[i].buffer_sizes[j] = 1;
+    sys.L2[i].total_accesses = 1;
+    sys.L2[i].read_accesses = 1;
+    sys.L2[i].write_accesses = 1;
+    sys.L2[i].total_hits = 1;
+    sys.L2[i].total_misses = 1;
+    sys.L2[i].read_hits = 1;
+    sys.L2[i].write_hits = 1;
+    sys.L2[i].read_misses = 1;
+    sys.L2[i].write_misses = 1;
+    sys.L2[i].replacements = 1;
+    sys.L2[i].write_backs = 1;
+    sys.L2[i].miss_buffer_accesses = 1;
+    sys.L2[i].fill_buffer_accesses = 1;
+    sys.L2[i].prefetch_buffer_accesses = 1;
+    sys.L2[i].prefetch_buffer_writes = 1;
+    sys.L2[i].prefetch_buffer_reads = 1;
+    sys.L2[i].prefetch_buffer_hits = 1;
+    sys.L2[i].wbb_writes = 1;
+    sys.L2[i].wbb_reads = 1;
+    sys.L2[i].duty_cycle = 1;
+    sys.L2[i].merged_dir = false;
+    sys.L2[i].homenode_read_accesses = 1;
+    sys.L2[i].homenode_write_accesses = 1;
+    sys.L2[i].homenode_read_hits = 1;
+    sys.L2[i].homenode_write_hits = 1;
+    sys.L2[i].homenode_read_misses = 1;
+    sys.L2[i].homenode_write_misses = 1;
+    sys.L2[i].dir_duty_cycle = 1;
+  }
+  for (i = 0; i <= 63; i++) {
+    // system_L3
+    for (j = 0; j < 20; j++) sys.L3[i].L3_config[j] = 1;
+    sys.L3[i].clockrate = 1;
+    for (j = 0; j < 20; j++) sys.L3[i].ports[j] = 1;
+    sys.L3[i].device_type = 1;
+    strcpy(sys.L3[i].threeD_stack, "default");
+    for (j = 0; j < 20; j++) sys.L3[i].buffer_sizes[j] = 1;
+    sys.L3[i].total_accesses = 1;
+    sys.L3[i].read_accesses = 1;
+    sys.L3[i].write_accesses = 1;
+    sys.L3[i].total_hits = 1;
+    sys.L3[i].total_misses = 1;
+    sys.L3[i].read_hits = 1;
+    sys.L3[i].write_hits = 1;
+    sys.L3[i].read_misses = 1;
+    sys.L3[i].write_misses = 1;
+    sys.L3[i].replacements = 1;
+    sys.L3[i].write_backs = 1;
+    sys.L3[i].miss_buffer_accesses = 1;
+    sys.L3[i].fill_buffer_accesses = 1;
+    sys.L3[i].prefetch_buffer_accesses = 1;
+    sys.L3[i].prefetch_buffer_writes = 1;
+    sys.L3[i].prefetch_buffer_reads = 1;
+    sys.L3[i].prefetch_buffer_hits = 1;
+    sys.L3[i].wbb_writes = 1;
+    sys.L3[i].wbb_reads = 1;
+    sys.L3[i].duty_cycle = 1;
+    sys.L3[i].merged_dir = false;
+    sys.L3[i].homenode_read_accesses = 1;
+    sys.L3[i].homenode_write_accesses = 1;
+    sys.L3[i].homenode_read_hits = 1;
+    sys.L3[i].homenode_write_hits = 1;
+    sys.L3[i].homenode_read_misses = 1;
+    sys.L3[i].homenode_write_misses = 1;
+    sys.L3[i].dir_duty_cycle = 1;
+  }
+  // system_NoC
+  for (i = 0; i <= 63; i++) {
+    sys.NoC[i].clockrate = 1;
+    sys.NoC[i].type = true;
+    sys.NoC[i].chip_coverage = 1;
+    sys.NoC[i].has_global_link = true;
+    strcpy(sys.NoC[i].topology, "default");
+    sys.NoC[i].horizontal_nodes = 1;
+    sys.NoC[i].vertical_nodes = 1;
+    sys.NoC[i].input_ports = 1;
+    sys.NoC[i].output_ports = 1;
+    sys.NoC[i].virtual_channel_per_port = 1;
+    sys.NoC[i].flit_bits = 1;
+    sys.NoC[i].input_buffer_entries_per_vc = 1;
+    sys.NoC[i].total_accesses = 1;
+    sys.NoC[i].duty_cycle = 1;
+    sys.NoC[i].route_over_perc = 0.5;
+    for (j = 0; j < 20; j++) sys.NoC[i].ports_of_input_buffer[j] = 1;
+    sys.NoC[i].number_of_crossbars = 1;
+    strcpy(sys.NoC[i].crossbar_type, "default");
+    strcpy(sys.NoC[i].crosspoint_type, "default");
+    // system.NoC?.xbar0;
+    sys.NoC[i].xbar0.number_of_inputs_of_crossbars = 1;
+    sys.NoC[i].xbar0.number_of_outputs_of_crossbars = 1;
+    sys.NoC[i].xbar0.flit_bits = 1;
+    sys.NoC[i].xbar0.input_buffer_entries_per_port = 1;
+    sys.NoC[i].xbar0.ports_of_input_buffer[20] = 1;
+    sys.NoC[i].xbar0.crossbar_accesses = 1;
+  }
+  // system_mem
+  sys.mem.mem_tech_node = 1;
+  sys.mem.device_clock = 1;
+  sys.mem.capacity_per_channel = 1;
+  sys.mem.number_ranks = 1;
+  sys.mem.peak_transfer_rate = 1;
+  sys.mem.num_banks_of_DRAM_chip = 1;
+  sys.mem.Block_width_of_DRAM_chip = 1;
+  sys.mem.output_width_of_DRAM_chip = 1;
+  sys.mem.page_size_of_DRAM_chip = 1;
+  sys.mem.burstlength_of_DRAM_chip = 1;
+  sys.mem.internal_prefetch_of_DRAM_chip = 1;
+  sys.mem.memory_accesses = 1;
+  sys.mem.memory_reads = 1;
+  sys.mem.memory_writes = 1;
 
-	//system_mc
-	sys.mc.mc_clock =1;
-	sys.mc.number_mcs=1;
-	sys.mc.peak_transfer_rate =1;
-	sys.mc.memory_channels_per_mc=1;
-	sys.mc.number_ranks=1;
-	sys.mc.req_window_size_per_channel=1;
-	sys.mc.IO_buffer_size_per_channel=1;
-	sys.mc.databus_width=1;
-	sys.mc.addressbus_width=1;
-	sys.mc.memory_accesses=1;
-	sys.mc.memory_reads=1;
-	sys.mc.memory_writes=1;
-	sys.mc.LVDS=true;
-	sys.mc.type=1;
+  // system_mc
+  sys.mc.mc_clock = 1;
+  sys.mc.number_mcs = 1;
+  sys.mc.peak_transfer_rate = 1;
+  sys.mc.memory_channels_per_mc = 1;
+  sys.mc.number_ranks = 1;
+  sys.mc.req_window_size_per_channel = 1;
+  sys.mc.IO_buffer_size_per_channel = 1;
+  sys.mc.databus_width = 1;
+  sys.mc.addressbus_width = 1;
+  sys.mc.memory_accesses = 1;
+  sys.mc.memory_reads = 1;
+  sys.mc.memory_writes = 1;
+  sys.mc.LVDS = true;
+  sys.mc.type = 1;
 
-	//system_niu
-	sys.niu.clockrate =1;
-	sys.niu.number_units=1;
-	sys.niu.type = 1;
-	sys.niu.duty_cycle =1;
-	sys.niu.total_load_perc=1;
-	//system_pcie
-	sys.pcie.clockrate =1;
-	sys.pcie.number_units=1;
-	sys.pcie.num_channels=1;
-	sys.pcie.type = 1;
-	sys.pcie.withPHY = false;
-	sys.pcie.duty_cycle =1;
-	sys.pcie.total_load_perc=1;
-	//system_flash_controller
-	sys.flashc.mc_clock =1;
-	sys.flashc.number_mcs=1;
-	sys.flashc.peak_transfer_rate =1;
-	sys.flashc.memory_channels_per_mc=1;
-	sys.flashc.number_ranks=1;
-	sys.flashc.req_window_size_per_channel=1;
-	sys.flashc.IO_buffer_size_per_channel=1;
-	sys.flashc.databus_width=1;
-	sys.flashc.addressbus_width=1;
-	sys.flashc.memory_accesses=1;
-	sys.flashc.memory_reads=1;
-	sys.flashc.memory_writes=1;
-	sys.flashc.LVDS=true;
-	sys.flashc.withPHY = false;
-	sys.flashc.type =1;
-	sys.flashc.duty_cycle =1;
-	sys.flashc.total_load_perc=1;
+  // system_niu
+  sys.niu.clockrate = 1;
+  sys.niu.number_units = 1;
+  sys.niu.type = 1;
+  sys.niu.duty_cycle = 1;
+  sys.niu.total_load_perc = 1;
+  // system_pcie
+  sys.pcie.clockrate = 1;
+  sys.pcie.number_units = 1;
+  sys.pcie.num_channels = 1;
+  sys.pcie.type = 1;
+  sys.pcie.withPHY = false;
+  sys.pcie.duty_cycle = 1;
+  sys.pcie.total_load_perc = 1;
+  // system_flash_controller
+  sys.flashc.mc_clock = 1;
+  sys.flashc.number_mcs = 1;
+  sys.flashc.peak_transfer_rate = 1;
+  sys.flashc.memory_channels_per_mc = 1;
+  sys.flashc.number_ranks = 1;
+  sys.flashc.req_window_size_per_channel = 1;
+  sys.flashc.IO_buffer_size_per_channel = 1;
+  sys.flashc.databus_width = 1;
+  sys.flashc.addressbus_width = 1;
+  sys.flashc.memory_accesses = 1;
+  sys.flashc.memory_reads = 1;
+  sys.flashc.memory_writes = 1;
+  sys.flashc.LVDS = true;
+  sys.flashc.withPHY = false;
+  sys.flashc.type = 1;
+  sys.flashc.duty_cycle = 1;
+  sys.flashc.total_load_perc = 1;
 }

--- a/src/gpuwattch/XML_Parse.cc
+++ b/src/gpuwattch/XML_Parse.cc
@@ -535,7 +535,7 @@ void ParseXML::parse(char* filepath) {
   //	if (sys.Private_L2 && sys.number_of_cores!=sys.number_of_L2s)
   //	{
   //		cout<<"Private L2: Number of L2s must equal to Number of
-  // Cores"<<endl;
+  //Cores"<<endl;
   //		exit(0);
   //	}
 
@@ -563,7 +563,7 @@ void ParseXML::parse(char* filepath) {
   unsigned int OrderofComponents_3layer = 0;
   if (NumofCom_3 > OrderofComponents_3layer) {
     //___________________________get all
-    // system.core0-n________________________________________________
+    //system.core0-n________________________________________________
     if (sys.homogeneous_cores == 1)
       OrderofComponents_3layer = 0;
     else
@@ -2044,8 +2044,9 @@ void ParseXML::parse(char* filepath) {
             if (strcmp(xNode4.getAttribute("name"), "sharedmemory") ==
                 0) {  // find system.core0.sharedmemory
               itmp = xNode4.nChildNode("param");
-              for (k = 0; k < itmp; k++) {  // get all items of param in
-                // system.core0.sharedmemory--sharedmemory
+              for (k = 0; k < itmp;
+                   k++) {  // get all items of param in
+                           // system.core0.sharedmemory--sharedmemory
                 if (strcmp(xNode4.getChildNode("param", k).getAttribute("name"),
                            "sharedmemory_config") == 0) {
                   strtmp.assign(
@@ -2482,7 +2483,7 @@ void ParseXML::parse(char* filepath) {
     }
 
     //__________________________________________Get
-    // system.L1Directory0-n____________________________________________
+    //system.L1Directory0-n____________________________________________
     int w, tmpOrderofComponents_3layer;
     w = OrderofComponents_3layer + 1;
     tmpOrderofComponents_3layer = OrderofComponents_3layer;
@@ -2648,7 +2649,7 @@ void ParseXML::parse(char* filepath) {
     }
 
     //__________________________________________Get
-    // system.L2Directory0-n____________________________________________
+    //system.L2Directory0-n____________________________________________
     w = OrderofComponents_3layer + 1;
     tmpOrderofComponents_3layer = OrderofComponents_3layer;
     if (sys.homogeneous_L2Directories == 1)
@@ -2813,7 +2814,7 @@ void ParseXML::parse(char* filepath) {
     }
 
     //__________________________________________Get
-    // system.L2[0..n]____________________________________________
+    //system.L2[0..n]____________________________________________
     w = OrderofComponents_3layer + 1;
     tmpOrderofComponents_3layer = OrderofComponents_3layer;
     if (sys.homogeneous_L2s == 1)
@@ -3101,7 +3102,7 @@ void ParseXML::parse(char* filepath) {
       }
     }
     //__________________________________________Get
-    // system.L3[0..n]____________________________________________
+    //system.L3[0..n]____________________________________________
     w = OrderofComponents_3layer + 1;
     tmpOrderofComponents_3layer = OrderofComponents_3layer;
     if (sys.homogeneous_L3s == 1)
@@ -3389,7 +3390,7 @@ void ParseXML::parse(char* filepath) {
       }
     }
     //__________________________________________Get
-    // system.NoC[0..n]____________________________________________
+    //system.NoC[0..n]____________________________________________
     w = OrderofComponents_3layer + 1;
     tmpOrderofComponents_3layer = OrderofComponents_3layer;
     if (sys.homogeneous_NoCs == 1)
@@ -3640,7 +3641,7 @@ void ParseXML::parse(char* filepath) {
       }
     }
     //__________________________________________Get
-    // system.mem____________________________________________
+    //system.mem____________________________________________
     if (OrderofComponents_3layer > 0)
       OrderofComponents_3layer = OrderofComponents_3layer + 1;
     xNode3 = xNode2.getChildNode("component", OrderofComponents_3layer);
@@ -3756,7 +3757,7 @@ void ParseXML::parse(char* filepath) {
       exit(0);
     }
     //__________________________________________Get
-    // system.mc____________________________________________
+    //system.mc____________________________________________
     if (OrderofComponents_3layer > 0)
       OrderofComponents_3layer = OrderofComponents_3layer + 1;
     xNode3 = xNode2.getChildNode("component", OrderofComponents_3layer);
@@ -3946,7 +3947,7 @@ void ParseXML::parse(char* filepath) {
       exit(0);
     }
     //__________________________________________Get
-    // system.niu____________________________________________
+    //system.niu____________________________________________
     if (OrderofComponents_3layer > 0)
       OrderofComponents_3layer = OrderofComponents_3layer + 1;
     xNode3 = xNode2.getChildNode("component", OrderofComponents_3layer);
@@ -4004,7 +4005,7 @@ void ParseXML::parse(char* filepath) {
     }
 
     //__________________________________________Get
-    // system.pcie____________________________________________
+    //system.pcie____________________________________________
     if (OrderofComponents_3layer > 0)
       OrderofComponents_3layer = OrderofComponents_3layer + 1;
     xNode3 = xNode2.getChildNode("component", OrderofComponents_3layer);
@@ -4073,7 +4074,7 @@ void ParseXML::parse(char* filepath) {
       exit(0);
     }
     //__________________________________________Get
-    // system.flashcontroller____________________________________________
+    //system.flashcontroller____________________________________________
     if (OrderofComponents_3layer > 0)
       OrderofComponents_3layer = OrderofComponents_3layer + 1;
     xNode3 = xNode2.getChildNode("component", OrderofComponents_3layer);

--- a/src/gpuwattch/XML_Parse.h
+++ b/src/gpuwattch/XML_Parse.h
@@ -29,660 +29,663 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:												   *
-*      Jingwen Leng, Univeristy of Texas, Austin                   *
-*      Syed Gilani, University of Wisconsin–Madison                *
-*      Tayler Hetherington, University of British Columbia         *
-*      Ahmed ElTantawy, University of British Columbia             *
-********************************************************************/
+ *      Modified by:
+ ** Jingwen Leng, Univeristy of Texas, Austin                   * Syed Gilani,
+ *University of Wisconsin–Madison                * Tayler Hetherington,
+ *University of British Columbia         * Ahmed ElTantawy, University of
+ *British Columbia             *
+ ********************************************************************/
 
 #ifndef XML_PARSE_H_
 #define XML_PARSE_H_
-
 
 //#ifdef WIN32
 //#define _CRT_SECURE_NO_DEPRECATE
 //#endif
 
 #include <stdio.h>
-#include "xmlParser.h"
 #include <string.h>
 #include <iostream>
+#include "xmlParser.h"
 using namespace std;
 
 /*
 void myfree(char *t); // {free(t);}
 ToXMLStringTool tx,tx2;
 */
-//all subnodes at the level of system.core(0-n)
-//cache_policy is added into cache property arrays;//0 no write or write-though with non-write allocate;1 write-back with write-allocate
+// all subnodes at the level of system.core(0-n)
+// cache_policy is added into cache property arrays;//0 no write or write-though
+// with non-write allocate;1 write-back with write-allocate
 //
-//tgrogers - This was a static array declared in the header...
-//           Not too sure why the authors did this, maybe they didn't understand the context
-//           of the "static" keyword outside a class declaration.  As it was written, each object file
-//           had it's own copy of the string list - which is okay, since the string is constant but
-//           wastes space and causes the compiler to complain about unused vars in files where this header
-//           is included but they don't use the variable.  Now this is extern'd here and the storage/definition
-//           is in the XML_Parse.cc file
-extern const char * perf_count_label[];
+// tgrogers - This was a static array declared in the header...
+//           Not too sure why the authors did this, maybe they didn't understand
+//           the context of the "static" keyword outside a class declaration. As
+//           it was written, each object file had it's own copy of the string
+//           list - which is okay, since the string is constant but wastes space
+//           and causes the compiler to complain about unused vars in files
+//           where this header is included but they don't use the variable.  Now
+//           this is extern'd here and the storage/definition is in the
+//           XML_Parse.cc file
+extern const char* perf_count_label[];
 
 enum perf_count_t {
-   TOT_INST=0,
-   FP_INT,
-   IC_H,
-   IC_M,
-   DC_RH,
-   DC_RM,
-   DC_WH,
-   DC_WM,
-   TC_H,
-   TC_M,
-   CC_H,
-   CC_M,
-   SHRD_ACC,
-   REG_RD,
-   REG_WR,
-   NON_REG_OPs,
-   SP_ACC,
-   SFU_ACC,
-   FPU_ACC,
-   MEM_RD,
-   MEM_WR,
-   MEM_PRE,
-   L2_RH,
-   L2_RM,
-   L2_WH,
-   L2_WM,
-   NOC_A,
-   PIPE_A,
-   IDLE_CORE_N,
-   CONST_DYNAMICN,
-   NUM_PERFORMANCE_COUNTERS
+  TOT_INST = 0,
+  FP_INT,
+  IC_H,
+  IC_M,
+  DC_RH,
+  DC_RM,
+  DC_WH,
+  DC_WM,
+  TC_H,
+  TC_M,
+  CC_H,
+  CC_M,
+  SHRD_ACC,
+  REG_RD,
+  REG_WR,
+  NON_REG_OPs,
+  SP_ACC,
+  SFU_ACC,
+  FPU_ACC,
+  MEM_RD,
+  MEM_WR,
+  MEM_PRE,
+  L2_RH,
+  L2_RM,
+  L2_WH,
+  L2_WM,
+  NOC_A,
+  PIPE_A,
+  IDLE_CORE_N,
+  CONST_DYNAMICN,
+  NUM_PERFORMANCE_COUNTERS
 };
 
-typedef struct{
-	int prediction_width;
-	char prediction_scheme[20];
-	int predictor_size;
-	int predictor_entries;
-	int local_predictor_size[20];
-	int local_predictor_entries;
-	int global_predictor_entries;
-	int global_predictor_bits;
-	int chooser_predictor_entries;
-	int chooser_predictor_bits;
-	double predictor_accesses;
+typedef struct {
+  int prediction_width;
+  char prediction_scheme[20];
+  int predictor_size;
+  int predictor_entries;
+  int local_predictor_size[20];
+  int local_predictor_entries;
+  int global_predictor_entries;
+  int global_predictor_bits;
+  int chooser_predictor_entries;
+  int chooser_predictor_bits;
+  double predictor_accesses;
 } predictor_systemcore;
-typedef struct{
-	int number_entries;
-	int cache_policy;//0 no write or write-though with non-write allocate;1 write-back with write-allocate
-	double total_hits;
-	double total_accesses;
-	double total_misses;
-	double conflicts;
+typedef struct {
+  int number_entries;
+  int cache_policy;  // 0 no write or write-though with non-write allocate;1
+                     // write-back with write-allocate
+  double total_hits;
+  double total_accesses;
+  double total_misses;
+  double conflicts;
 } itlb_systemcore;
-typedef struct{
-	//params
-	double icache_config[20];
-	int buffer_sizes[20];
-	int cache_policy;//0 no write or write-though with non-write allocate;1 write-back with write-allocate
-	//stats
-	double total_accesses;
-	double read_accesses;
-	double read_misses;
-	double replacements;
-	double read_hits;
-	double total_hits;
-	double total_misses;
-	double miss_buffer_access;
-	double fill_buffer_accesses;
-	double prefetch_buffer_accesses;
-	double prefetch_buffer_writes;
-	double prefetch_buffer_reads;
-	double prefetch_buffer_hits;
-	double conflicts;
+typedef struct {
+  // params
+  double icache_config[20];
+  int buffer_sizes[20];
+  int cache_policy;  // 0 no write or write-though with non-write allocate;1
+                     // write-back with write-allocate
+  // stats
+  double total_accesses;
+  double read_accesses;
+  double read_misses;
+  double replacements;
+  double read_hits;
+  double total_hits;
+  double total_misses;
+  double miss_buffer_access;
+  double fill_buffer_accesses;
+  double prefetch_buffer_accesses;
+  double prefetch_buffer_writes;
+  double prefetch_buffer_reads;
+  double prefetch_buffer_hits;
+  double conflicts;
 } icache_systemcore;
-typedef struct{
-	//params
-	int number_entries;
-	int cache_policy;//0 no write or write-though with non-write allocate;1 write-back with write-allocate
-	//stats
-	double total_accesses;
-	double read_accesses;
-	double write_accesses;
-	double write_hits;
-	double read_hits;
-	double read_misses;
-	double write_misses;
-	double total_hits;
-	double total_misses;
-	double conflicts;
+typedef struct {
+  // params
+  int number_entries;
+  int cache_policy;  // 0 no write or write-though with non-write allocate;1
+                     // write-back with write-allocate
+  // stats
+  double total_accesses;
+  double read_accesses;
+  double write_accesses;
+  double write_hits;
+  double read_hits;
+  double read_misses;
+  double write_misses;
+  double total_hits;
+  double total_misses;
+  double conflicts;
 } dtlb_systemcore;
-typedef struct{
-	//params
-	double dcache_config[20];
-	int buffer_sizes[20];
-	int cache_policy;//0 no write or write-though with non-write allocate;1 write-back with write-allocate
-	//stats
-	double total_accesses;
-	double read_accesses;
-	double write_accesses;
-	double total_hits;
-	double total_misses;
-	double read_hits;
-	double write_hits;
-	double read_misses;
-	double write_misses;
-	double replacements;
-	double write_backs;
-	double miss_buffer_access;
-	double fill_buffer_accesses;
-	double prefetch_buffer_accesses;
-	double prefetch_buffer_writes;
-	double prefetch_buffer_reads;
-	double prefetch_buffer_hits;
-	double wbb_writes;
-	double wbb_reads;
-	double conflicts;
+typedef struct {
+  // params
+  double dcache_config[20];
+  int buffer_sizes[20];
+  int cache_policy;  // 0 no write or write-though with non-write allocate;1
+                     // write-back with write-allocate
+  // stats
+  double total_accesses;
+  double read_accesses;
+  double write_accesses;
+  double total_hits;
+  double total_misses;
+  double read_hits;
+  double write_hits;
+  double read_misses;
+  double write_misses;
+  double replacements;
+  double write_backs;
+  double miss_buffer_access;
+  double fill_buffer_accesses;
+  double prefetch_buffer_accesses;
+  double prefetch_buffer_writes;
+  double prefetch_buffer_reads;
+  double prefetch_buffer_hits;
+  double wbb_writes;
+  double wbb_reads;
+  double conflicts;
 } dcache_systemcore;
-typedef struct{
-	//params
-	int BTB_config[20];
-	//stats
-	double total_accesses;
-	double read_accesses;
-	double write_accesses;
-	double total_hits;
-	double total_misses;
-	double read_hits;
-	double write_hits;
-	double read_misses;
-	double write_misses;
-	double replacements;
+typedef struct {
+  // params
+  int BTB_config[20];
+  // stats
+  double total_accesses;
+  double read_accesses;
+  double write_accesses;
+  double total_hits;
+  double total_misses;
+  double read_hits;
+  double write_hits;
+  double read_misses;
+  double write_misses;
+  double replacements;
 } BTB_systemcore;
-typedef struct{
-	//all params at the level of system.core(0-n)
-	int clock_rate;
-	bool opt_local;
-	bool x86;
-	int machine_bits;
-	int virtual_address_width;
-	int physical_address_width;
-	int opcode_width;
-	int micro_opcode_width;
-	int instruction_length;
-	int machine_type;
-	int internal_datapath_width;
-	int number_hardware_threads;
-	int fetch_width;
-	int number_instruction_fetch_ports;
-	int decode_width;
-	int issue_width;
-	int peak_issue_width;
-	int commit_width;
-	int pipelines_per_core[20];
-	int pipeline_depth[20];
-	char FPU[20];
-	char divider_multiplier[20];
-	int ALU_per_core;
-	double FPU_per_core;
-	int MUL_per_core;
-	int instruction_buffer_size;
-	int decoded_stream_buffer_size;
-	int instruction_window_scheme;
-	int instruction_window_size;
-	int fp_instruction_window_size;
-	int ROB_size;
-	int archi_Regs_IRF_size;
-	int archi_Regs_FRF_size;
-	int phy_Regs_IRF_size;
-	int phy_Regs_FRF_size;
-	int rename_scheme;
-	int register_windows_size;
-	char LSU_order[20];
-	int store_buffer_size;
-	int load_buffer_size;
-	int memory_ports;
-	char Dcache_dual_pump[20];
-	int RAS_size;
-	int fp_issue_width;
-	int prediction_width;
-	int number_of_BTB;
-	int number_of_BPT;
-	bool gpgpu_clock_gated_lanes;
+typedef struct {
+  // all params at the level of system.core(0-n)
+  int clock_rate;
+  bool opt_local;
+  bool x86;
+  int machine_bits;
+  int virtual_address_width;
+  int physical_address_width;
+  int opcode_width;
+  int micro_opcode_width;
+  int instruction_length;
+  int machine_type;
+  int internal_datapath_width;
+  int number_hardware_threads;
+  int fetch_width;
+  int number_instruction_fetch_ports;
+  int decode_width;
+  int issue_width;
+  int peak_issue_width;
+  int commit_width;
+  int pipelines_per_core[20];
+  int pipeline_depth[20];
+  char FPU[20];
+  char divider_multiplier[20];
+  int ALU_per_core;
+  double FPU_per_core;
+  int MUL_per_core;
+  int instruction_buffer_size;
+  int decoded_stream_buffer_size;
+  int instruction_window_scheme;
+  int instruction_window_size;
+  int fp_instruction_window_size;
+  int ROB_size;
+  int archi_Regs_IRF_size;
+  int archi_Regs_FRF_size;
+  int phy_Regs_IRF_size;
+  int phy_Regs_FRF_size;
+  int rename_scheme;
+  int register_windows_size;
+  char LSU_order[20];
+  int store_buffer_size;
+  int load_buffer_size;
+  int memory_ports;
+  char Dcache_dual_pump[20];
+  int RAS_size;
+  int fp_issue_width;
+  int prediction_width;
+  int number_of_BTB;
+  int number_of_BPT;
+  bool gpgpu_clock_gated_lanes;
 
-	//all stats at the level of system.core(0-n)
-	double total_instructions;
-	double int_instructions;
-	double fp_instructions;
-	double branch_instructions;
-	double branch_mispredictions;
-	double committed_instructions;
-	double committed_int_instructions;
-	double committed_fp_instructions;
-	double load_instructions;
-	double store_instructions;
-	double total_cycles;
-	double idle_cycles;
-	double busy_cycles;
-	double instruction_buffer_reads;
-	double instruction_buffer_write;
-	double ROB_reads;
-	double ROB_writes;
-	double rename_accesses;
-	double fp_rename_accesses;
-	double rename_reads;
-	double rename_writes;
-	double fp_rename_reads;
-	double fp_rename_writes;
-	double inst_window_reads;
-	double inst_window_writes;
-	double inst_window_wakeup_accesses;
-	double inst_window_selections;
-	double fp_inst_window_reads;
-	double fp_inst_window_writes;
-	double fp_inst_window_wakeup_accesses;
-	double fp_inst_window_selections;
-	double archi_int_regfile_reads;
-	double archi_float_regfile_reads;
-	double phy_int_regfile_reads;
-	double phy_float_regfile_reads;
-	double phy_int_regfile_writes;
-	double phy_float_regfile_writes;
-	double archi_int_regfile_writes;
-	double archi_float_regfile_writes;
-	double int_regfile_reads;
-	double float_regfile_reads;
-	double int_regfile_writes;
-	double float_regfile_writes;
-	double non_rf_operands;
-	double windowed_reg_accesses;
-	double windowed_reg_transports;
-	double function_calls;
-	double context_switches;
-	double ialu_accesses;
-	double fpu_accesses;
-	double mul_accesses;
-	double sp_average_active_lanes;
-	double sfu_average_active_lanes;
-	double cdb_alu_accesses;
-	double cdb_mul_accesses;
-	double cdb_fpu_accesses;
-	double load_buffer_reads;
-	double load_buffer_writes;
-	double load_buffer_cams;
-	double store_buffer_reads;
-	double store_buffer_writes;
-	double store_buffer_cams;
-	double store_buffer_forwards;
-	double main_memory_access;
-	double main_memory_read;
-	double main_memory_write;
-	double pipeline_duty_cycle;
+  // all stats at the level of system.core(0-n)
+  double total_instructions;
+  double int_instructions;
+  double fp_instructions;
+  double branch_instructions;
+  double branch_mispredictions;
+  double committed_instructions;
+  double committed_int_instructions;
+  double committed_fp_instructions;
+  double load_instructions;
+  double store_instructions;
+  double total_cycles;
+  double idle_cycles;
+  double busy_cycles;
+  double instruction_buffer_reads;
+  double instruction_buffer_write;
+  double ROB_reads;
+  double ROB_writes;
+  double rename_accesses;
+  double fp_rename_accesses;
+  double rename_reads;
+  double rename_writes;
+  double fp_rename_reads;
+  double fp_rename_writes;
+  double inst_window_reads;
+  double inst_window_writes;
+  double inst_window_wakeup_accesses;
+  double inst_window_selections;
+  double fp_inst_window_reads;
+  double fp_inst_window_writes;
+  double fp_inst_window_wakeup_accesses;
+  double fp_inst_window_selections;
+  double archi_int_regfile_reads;
+  double archi_float_regfile_reads;
+  double phy_int_regfile_reads;
+  double phy_float_regfile_reads;
+  double phy_int_regfile_writes;
+  double phy_float_regfile_writes;
+  double archi_int_regfile_writes;
+  double archi_float_regfile_writes;
+  double int_regfile_reads;
+  double float_regfile_reads;
+  double int_regfile_writes;
+  double float_regfile_writes;
+  double non_rf_operands;
+  double windowed_reg_accesses;
+  double windowed_reg_transports;
+  double function_calls;
+  double context_switches;
+  double ialu_accesses;
+  double fpu_accesses;
+  double mul_accesses;
+  double sp_average_active_lanes;
+  double sfu_average_active_lanes;
+  double cdb_alu_accesses;
+  double cdb_mul_accesses;
+  double cdb_fpu_accesses;
+  double load_buffer_reads;
+  double load_buffer_writes;
+  double load_buffer_cams;
+  double store_buffer_reads;
+  double store_buffer_writes;
+  double store_buffer_cams;
+  double store_buffer_forwards;
+  double main_memory_access;
+  double main_memory_read;
+  double main_memory_write;
+  double pipeline_duty_cycle;
 
-	double IFU_duty_cycle ;
-	double BR_duty_cycle ;
-	double LSU_duty_cycle ;
-	double MemManU_I_duty_cycle;
-	double MemManU_D_duty_cycle ;
-	double ALU_duty_cycle ;
-	double MUL_duty_cycle ;
-	double FPU_duty_cycle ;
-	double ALU_cdb_duty_cycle ;
-	double MUL_cdb_duty_cycle ;
-	double FPU_cdb_duty_cycle ;
+  double IFU_duty_cycle;
+  double BR_duty_cycle;
+  double LSU_duty_cycle;
+  double MemManU_I_duty_cycle;
+  double MemManU_D_duty_cycle;
+  double ALU_duty_cycle;
+  double MUL_duty_cycle;
+  double FPU_duty_cycle;
+  double ALU_cdb_duty_cycle;
+  double MUL_cdb_duty_cycle;
+  double FPU_cdb_duty_cycle;
 
-	double num_idle_cores;
+  double num_idle_cores;
 
+  int rf_banks;             // (4)
+  int simd_width;           // (8)
+  int collector_units;      // (4)
+  double core_clock_ratio;  // (2.0)
+  int warp_size;            // (32)
 
-	int rf_banks;// (4)
-   int simd_width;// (8)
-   int collector_units;// (4)
-   double core_clock_ratio;// (2.0)
-   int warp_size;// (32) 
-	
-	//all subnodes at the level of system.core(0-n)
-	predictor_systemcore predictor;
-	itlb_systemcore itlb;
-	icache_systemcore icache;
-	dtlb_systemcore dtlb;
-	dcache_systemcore dcache;
-	dcache_systemcore ccache;
-	dcache_systemcore tcache;
-	dcache_systemcore sharedmemory; // added by Jingwen
-	BTB_systemcore BTB;
+  // all subnodes at the level of system.core(0-n)
+  predictor_systemcore predictor;
+  itlb_systemcore itlb;
+  icache_systemcore icache;
+  dtlb_systemcore dtlb;
+  dcache_systemcore dcache;
+  dcache_systemcore ccache;
+  dcache_systemcore tcache;
+  dcache_systemcore sharedmemory;  // added by Jingwen
+  BTB_systemcore BTB;
 
 } system_core;
-typedef struct{
-	//params
-	int Directory_type;
-	double Dir_config[20];
-	int buffer_sizes[20];
-	int clockrate;
-	int ports[20];
-	int device_type;
-	int cache_policy;//0 no write or write-though with non-write allocate;1 write-back with write-allocate
-	char threeD_stack[20];
-	//stats
-	double total_accesses;
-	double read_accesses;
-	double write_accesses;
-	double read_misses;
-	double write_misses;
-	double conflicts;
-	double duty_cycle;
+typedef struct {
+  // params
+  int Directory_type;
+  double Dir_config[20];
+  int buffer_sizes[20];
+  int clockrate;
+  int ports[20];
+  int device_type;
+  int cache_policy;  // 0 no write or write-though with non-write allocate;1
+                     // write-back with write-allocate
+  char threeD_stack[20];
+  // stats
+  double total_accesses;
+  double read_accesses;
+  double write_accesses;
+  double read_misses;
+  double write_misses;
+  double conflicts;
+  double duty_cycle;
 } system_L1Directory;
-typedef struct{
-	//params
-	int Directory_type;
-	double Dir_config[20];
-	int buffer_sizes[20];
-	int clockrate;
-	int ports[20];
-	int device_type;
-	int cache_policy;//0 no write or write-though with non-write allocate;1 write-back with write-allocate
-	char threeD_stack[20];
-	//stats
-	double total_accesses;
-	double read_accesses;
-	double write_accesses;
-	double read_misses;
-	double write_misses;
-	double conflicts;
-	double duty_cycle;
+typedef struct {
+  // params
+  int Directory_type;
+  double Dir_config[20];
+  int buffer_sizes[20];
+  int clockrate;
+  int ports[20];
+  int device_type;
+  int cache_policy;  // 0 no write or write-though with non-write allocate;1
+                     // write-back with write-allocate
+  char threeD_stack[20];
+  // stats
+  double total_accesses;
+  double read_accesses;
+  double write_accesses;
+  double read_misses;
+  double write_misses;
+  double conflicts;
+  double duty_cycle;
 } system_L2Directory;
-typedef struct{
-	//params
-	double L2_config[20];
-	int clockrate;
-	int ports[20];
-	int device_type;
-	int cache_policy;//0 no write or write-though with non-write allocate;1 write-back with write-allocate
-	char threeD_stack[20];
-	int buffer_sizes[20];
-	//stats
-	double total_accesses;
-	double read_accesses;
-	double write_accesses;
-	double total_hits;
-	double total_misses;
-	double read_hits;
-	double write_hits;
-	double read_misses;
-	double write_misses;
-	double replacements;
-	double write_backs;
-	double miss_buffer_accesses;
-	double fill_buffer_accesses;
-	double prefetch_buffer_accesses;
-	double prefetch_buffer_writes;
-	double prefetch_buffer_reads;
-	double prefetch_buffer_hits;
-	double wbb_writes;
-	double wbb_reads;
-	double conflicts;
-	double duty_cycle;
+typedef struct {
+  // params
+  double L2_config[20];
+  int clockrate;
+  int ports[20];
+  int device_type;
+  int cache_policy;  // 0 no write or write-though with non-write allocate;1
+                     // write-back with write-allocate
+  char threeD_stack[20];
+  int buffer_sizes[20];
+  // stats
+  double total_accesses;
+  double read_accesses;
+  double write_accesses;
+  double total_hits;
+  double total_misses;
+  double read_hits;
+  double write_hits;
+  double read_misses;
+  double write_misses;
+  double replacements;
+  double write_backs;
+  double miss_buffer_accesses;
+  double fill_buffer_accesses;
+  double prefetch_buffer_accesses;
+  double prefetch_buffer_writes;
+  double prefetch_buffer_reads;
+  double prefetch_buffer_hits;
+  double wbb_writes;
+  double wbb_reads;
+  double conflicts;
+  double duty_cycle;
 
-	bool   merged_dir;
-	double homenode_read_accesses;
-	double homenode_write_accesses;
-	double homenode_read_hits;
-	double homenode_write_hits;
-	double homenode_read_misses;
-	double homenode_write_misses;
-	double dir_duty_cycle;
+  bool merged_dir;
+  double homenode_read_accesses;
+  double homenode_write_accesses;
+  double homenode_read_hits;
+  double homenode_write_hits;
+  double homenode_read_misses;
+  double homenode_write_misses;
+  double dir_duty_cycle;
 } system_L2;
-typedef struct{
-	//params
-	double L3_config[20];
-	int clockrate;
-	int ports[20];
-	int device_type;
-	int cache_policy;//0 no write or write-though with non-write allocate;1 write-back with write-allocate
-	char threeD_stack[20];
-	int buffer_sizes[20];
-	//stats
-	double total_accesses;
-	double read_accesses;
-	double write_accesses;
-	double total_hits;
-	double total_misses;
-	double read_hits;
-	double write_hits;
-	double read_misses;
-	double write_misses;
-	double replacements;
-	double write_backs;
-	double miss_buffer_accesses;
-	double fill_buffer_accesses;
-	double prefetch_buffer_accesses;
-	double prefetch_buffer_writes;
-	double prefetch_buffer_reads;
-	double prefetch_buffer_hits;
-	double wbb_writes;
-	double wbb_reads;
-	double conflicts;
-	double duty_cycle;
+typedef struct {
+  // params
+  double L3_config[20];
+  int clockrate;
+  int ports[20];
+  int device_type;
+  int cache_policy;  // 0 no write or write-though with non-write allocate;1
+                     // write-back with write-allocate
+  char threeD_stack[20];
+  int buffer_sizes[20];
+  // stats
+  double total_accesses;
+  double read_accesses;
+  double write_accesses;
+  double total_hits;
+  double total_misses;
+  double read_hits;
+  double write_hits;
+  double read_misses;
+  double write_misses;
+  double replacements;
+  double write_backs;
+  double miss_buffer_accesses;
+  double fill_buffer_accesses;
+  double prefetch_buffer_accesses;
+  double prefetch_buffer_writes;
+  double prefetch_buffer_reads;
+  double prefetch_buffer_hits;
+  double wbb_writes;
+  double wbb_reads;
+  double conflicts;
+  double duty_cycle;
 
-	bool   merged_dir;
-	double homenode_read_accesses;
-	double homenode_write_accesses;
-	double homenode_read_hits;
-	double homenode_write_hits;
-	double homenode_read_misses;
-	double homenode_write_misses;
-	double dir_duty_cycle;
+  bool merged_dir;
+  double homenode_read_accesses;
+  double homenode_write_accesses;
+  double homenode_read_hits;
+  double homenode_write_hits;
+  double homenode_read_misses;
+  double homenode_write_misses;
+  double dir_duty_cycle;
 } system_L3;
-typedef struct{
-	//params
-	int number_of_inputs_of_crossbars;
-	int number_of_outputs_of_crossbars;
-	int flit_bits;
-	int input_buffer_entries_per_port;
-	int ports_of_input_buffer[20];
-	//stats
-	double crossbar_accesses;
+typedef struct {
+  // params
+  int number_of_inputs_of_crossbars;
+  int number_of_outputs_of_crossbars;
+  int flit_bits;
+  int input_buffer_entries_per_port;
+  int ports_of_input_buffer[20];
+  // stats
+  double crossbar_accesses;
 } xbar0_systemNoC;
-typedef struct{
-	//params
-	int clockrate;
-	bool type;
-	bool has_global_link;
-	char topology[20];
-	int horizontal_nodes;
-	int vertical_nodes;
-	int link_throughput;
-	int link_latency;
-	int input_ports;
-	int output_ports;
-	int virtual_channel_per_port;
-	int flit_bits;
-	int input_buffer_entries_per_vc;
-	int ports_of_input_buffer[20];
-	int dual_pump;
-	int number_of_crossbars;
-	char crossbar_type[20];
-	char crosspoint_type[20];
-	xbar0_systemNoC xbar0;
-	int arbiter_type;
-	double chip_coverage;
-	//stats
-	double total_accesses;
-	double duty_cycle;
-	double route_over_perc;
+typedef struct {
+  // params
+  int clockrate;
+  bool type;
+  bool has_global_link;
+  char topology[20];
+  int horizontal_nodes;
+  int vertical_nodes;
+  int link_throughput;
+  int link_latency;
+  int input_ports;
+  int output_ports;
+  int virtual_channel_per_port;
+  int flit_bits;
+  int input_buffer_entries_per_vc;
+  int ports_of_input_buffer[20];
+  int dual_pump;
+  int number_of_crossbars;
+  char crossbar_type[20];
+  char crosspoint_type[20];
+  xbar0_systemNoC xbar0;
+  int arbiter_type;
+  double chip_coverage;
+  // stats
+  double total_accesses;
+  double duty_cycle;
+  double route_over_perc;
 } system_NoC;
-typedef struct{
-	//params
-	int mem_tech_node;
-	int device_clock;
-	int peak_transfer_rate;
-	int internal_prefetch_of_DRAM_chip;
-	int capacity_per_channel;
-	int number_ranks;
-	int num_banks_of_DRAM_chip;
-	int Block_width_of_DRAM_chip;
-	int output_width_of_DRAM_chip;
-	int page_size_of_DRAM_chip;
-	int burstlength_of_DRAM_chip;
+typedef struct {
+  // params
+  int mem_tech_node;
+  int device_clock;
+  int peak_transfer_rate;
+  int internal_prefetch_of_DRAM_chip;
+  int capacity_per_channel;
+  int number_ranks;
+  int num_banks_of_DRAM_chip;
+  int Block_width_of_DRAM_chip;
+  int output_width_of_DRAM_chip;
+  int page_size_of_DRAM_chip;
+  int burstlength_of_DRAM_chip;
 
-	//stats
-	double memory_accesses;
-	double memory_reads;
-	double memory_writes;
-	double dram_pre;
+  // stats
+  double memory_accesses;
+  double memory_reads;
+  double memory_writes;
+  double dram_pre;
 } system_mem;
-typedef struct{
-	//params
-    //Common Param for mc and fc
-	double peak_transfer_rate;
-	int number_mcs;
-	bool withPHY;
-	int type;
+typedef struct {
+  // params
+  // Common Param for mc and fc
+  double peak_transfer_rate;
+  int number_mcs;
+  bool withPHY;
+  int type;
 
-	//FCParam
-	//stats
-	double duty_cycle;
-	double total_load_perc;
+  // FCParam
+  // stats
+  double duty_cycle;
+  double total_load_perc;
 
-	//McParam
-	int mc_clock;
-    int llc_line_length;
-	int memory_channels_per_mc;
-	int number_ranks;
-	int req_window_size_per_channel;
-	int IO_buffer_size_per_channel;
-	int databus_width;
-	int addressbus_width;
-	int PRT_entries;
-	bool LVDS;
+  // McParam
+  int mc_clock;
+  int llc_line_length;
+  int memory_channels_per_mc;
+  int number_ranks;
+  int req_window_size_per_channel;
+  int IO_buffer_size_per_channel;
+  int databus_width;
+  int addressbus_width;
+  int PRT_entries;
+  bool LVDS;
 
-	// emprical DRAM coeff
-	double dram_cmd_coeff;
-	double dram_act_coeff;
-	double dram_nop_coeff;
-	double dram_activity_coeff;
-	double dram_pre_coeff;
-	double dram_rd_coeff;
-	double dram_wr_coeff;
-	double dram_req_coeff;
-	double dram_const_coeff;
+  // emprical DRAM coeff
+  double dram_cmd_coeff;
+  double dram_act_coeff;
+  double dram_nop_coeff;
+  double dram_activity_coeff;
+  double dram_pre_coeff;
+  double dram_rd_coeff;
+  double dram_wr_coeff;
+  double dram_req_coeff;
+  double dram_const_coeff;
 
-	//stats
-	double memory_accesses;
-	double memory_reads;
-	double memory_writes;
+  // stats
+  double memory_accesses;
+  double memory_reads;
+  double memory_writes;
 
-	//dram stats
-	double dram_cmd;
-	double dram_activity;
-	double dram_nop;
-	double dram_act;
-	double dram_pre;
-	double dram_rd;
-	double dram_wr;
-	double dram_req;
-
+  // dram stats
+  double dram_cmd;
+  double dram_activity;
+  double dram_nop;
+  double dram_act;
+  double dram_pre;
+  double dram_rd;
+  double dram_wr;
+  double dram_req;
 
 } system_mc;
 
-typedef struct{
-	//params
-    int clockrate;
-	int number_units;
-	int type;
-	//stats
-	double duty_cycle;
-	double total_load_perc;
+typedef struct {
+  // params
+  int clockrate;
+  int number_units;
+  int type;
+  // stats
+  double duty_cycle;
+  double total_load_perc;
 } system_niu;
 
-typedef struct{
-	//params
-    int clockrate;
-	int number_units;
-	int num_channels;
-	int type;
-	bool withPHY;
-	//stats
-	double duty_cycle;
-	double total_load_perc;
+typedef struct {
+  // params
+  int clockrate;
+  int number_units;
+  int num_channels;
+  int type;
+  bool withPHY;
+  // stats
+  double duty_cycle;
+  double total_load_perc;
 } system_pcie;
 
-typedef struct{
-	//All number_of_* at the level of 'system' Ying 03/21/2009
-	int GPU_Architecture;
-	int number_of_cores;
-	int architecture;
-	int number_of_L1Directories;
-	int number_of_L2Directories;
-	int number_of_L2s;
-	bool Private_L2;
-	int number_of_L3s;
-	int number_of_NoCs;
-	int number_of_dir_levels;
-    int domain_size;
-    int first_level_dir;
-	// All params at the level of 'system'
-	int homogeneous_cores;
-	int homogeneous_L1Directories;
-	int homogeneous_L2Directories;
-	double core_tech_node;
-	int target_core_clockrate;
-	int target_chip_area;
-	int temperature;
-	int number_cache_levels;
-	int L1_property;
-	int L2_property;
-	int homogeneous_L2s;
-	int L3_property;
-	int homogeneous_L3s;
-	int homogeneous_NoCs;
-	int homogeneous_ccs;
-	int Max_area_deviation;
-	int Max_power_deviation;
-	int device_type;
-	bool longer_channel_device;
-	bool Embedded;
-	bool opt_dynamic_power;
-	bool opt_lakage_power;
-	bool opt_clockrate;
-	bool opt_area;
-	int interconnect_projection_type;
-	int machine_bits;
-	int virtual_address_width;
-	int physical_address_width;
-	int virtual_memory_page_size;
-	double idle_core_power;
-	double num_idle_cores;
-	int arch;
-    double total_cycles;
-	//system.core(0-n):3rd level
-    double scaling_coefficients[64];
-	system_core core[64];
-	system_L1Directory L1Directory[64];
-	system_L2Directory L2Directory[64];
-	system_L2 L2[64];
-    system_L2 l2;
-	system_L3 L3[64];
-    system_NoC NoC[64];
-    system_mem mem;
-	system_mc mc;
-	system_mc flashc;
-	system_niu niu;
-	system_pcie pcie;
+typedef struct {
+  // All number_of_* at the level of 'system' Ying 03/21/2009
+  int GPU_Architecture;
+  int number_of_cores;
+  int architecture;
+  int number_of_L1Directories;
+  int number_of_L2Directories;
+  int number_of_L2s;
+  bool Private_L2;
+  int number_of_L3s;
+  int number_of_NoCs;
+  int number_of_dir_levels;
+  int domain_size;
+  int first_level_dir;
+  // All params at the level of 'system'
+  int homogeneous_cores;
+  int homogeneous_L1Directories;
+  int homogeneous_L2Directories;
+  double core_tech_node;
+  int target_core_clockrate;
+  int target_chip_area;
+  int temperature;
+  int number_cache_levels;
+  int L1_property;
+  int L2_property;
+  int homogeneous_L2s;
+  int L3_property;
+  int homogeneous_L3s;
+  int homogeneous_NoCs;
+  int homogeneous_ccs;
+  int Max_area_deviation;
+  int Max_power_deviation;
+  int device_type;
+  bool longer_channel_device;
+  bool Embedded;
+  bool opt_dynamic_power;
+  bool opt_lakage_power;
+  bool opt_clockrate;
+  bool opt_area;
+  int interconnect_projection_type;
+  int machine_bits;
+  int virtual_address_width;
+  int physical_address_width;
+  int virtual_memory_page_size;
+  double idle_core_power;
+  double num_idle_cores;
+  int arch;
+  double total_cycles;
+  // system.core(0-n):3rd level
+  double scaling_coefficients[64];
+  system_core core[64];
+  system_L1Directory L1Directory[64];
+  system_L2Directory L2Directory[64];
+  system_L2 L2[64];
+  system_L2 l2;
+  system_L3 L3[64];
+  system_NoC NoC[64];
+  system_mem mem;
+  system_mc mc;
+  system_mc flashc;
+  system_niu niu;
+  system_pcie pcie;
 } root_system;
 
-class ParseXML
-{
-public:
-	void parse(char* filepath);
-    void initialize();
-public:
-	root_system sys;
+class ParseXML {
+ public:
+  void parse(char* filepath);
+  void initialize();
+
+ public:
+  root_system sys;
 };
 
-
 #endif /* XML_PARSE_H_ */
-
-
-
-

--- a/src/gpuwattch/XML_Parse.h
+++ b/src/gpuwattch/XML_Parse.h
@@ -29,8 +29,7 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:
-**
+*      Modified by:												   *
 *      Jingwen Leng, Univeristy of Texas, Austin                   *
 *      Syed Gilani, University of Wisconsin–Madison                *
 *      Tayler Hetherington, University of British Columbia         *
@@ -40,656 +39,650 @@
 #ifndef XML_PARSE_H_
 #define XML_PARSE_H_
 
+
 //#ifdef WIN32
 //#define _CRT_SECURE_NO_DEPRECATE
 //#endif
 
 #include <stdio.h>
+#include "xmlParser.h"
 #include <string.h>
 #include <iostream>
-#include "xmlParser.h"
 using namespace std;
 
 /*
 void myfree(char *t); // {free(t);}
 ToXMLStringTool tx,tx2;
 */
-// all subnodes at the level of system.core(0-n)
-// cache_policy is added into cache property arrays;//0 no write or write-though
-// with non-write allocate;1 write-back with write-allocate
+//all subnodes at the level of system.core(0-n)
+//cache_policy is added into cache property arrays;//0 no write or write-though with non-write allocate;1 write-back with write-allocate
 //
-// tgrogers - This was a static array declared in the header...
-//           Not too sure why the authors did this, maybe they didn't understand
-//           the context
-//           of the "static" keyword outside a class declaration.  As it was
-//           written, each object file
-//           had it's own copy of the string list - which is okay, since the
-//           string is constant but
-//           wastes space and causes the compiler to complain about unused vars
-//           in files where this header
-//           is included but they don't use the variable.  Now this is extern'd
-//           here and the storage/definition
+//tgrogers - This was a static array declared in the header...
+//           Not too sure why the authors did this, maybe they didn't understand the context
+//           of the "static" keyword outside a class declaration.  As it was written, each object file
+//           had it's own copy of the string list - which is okay, since the string is constant but
+//           wastes space and causes the compiler to complain about unused vars in files where this header
+//           is included but they don't use the variable.  Now this is extern'd here and the storage/definition
 //           is in the XML_Parse.cc file
-extern const char* perf_count_label[];
+extern const char * perf_count_label[];
 
 enum perf_count_t {
-  TOT_INST = 0,
-  FP_INT,
-  IC_H,
-  IC_M,
-  DC_RH,
-  DC_RM,
-  DC_WH,
-  DC_WM,
-  TC_H,
-  TC_M,
-  CC_H,
-  CC_M,
-  SHRD_ACC,
-  REG_RD,
-  REG_WR,
-  NON_REG_OPs,
-  SP_ACC,
-  SFU_ACC,
-  FPU_ACC,
-  MEM_RD,
-  MEM_WR,
-  MEM_PRE,
-  L2_RH,
-  L2_RM,
-  L2_WH,
-  L2_WM,
-  NOC_A,
-  PIPE_A,
-  IDLE_CORE_N,
-  CONST_DYNAMICN,
-  NUM_PERFORMANCE_COUNTERS
+   TOT_INST=0,
+   FP_INT,
+   IC_H,
+   IC_M,
+   DC_RH,
+   DC_RM,
+   DC_WH,
+   DC_WM,
+   TC_H,
+   TC_M,
+   CC_H,
+   CC_M,
+   SHRD_ACC,
+   REG_RD,
+   REG_WR,
+   NON_REG_OPs,
+   SP_ACC,
+   SFU_ACC,
+   FPU_ACC,
+   MEM_RD,
+   MEM_WR,
+   MEM_PRE,
+   L2_RH,
+   L2_RM,
+   L2_WH,
+   L2_WM,
+   NOC_A,
+   PIPE_A,
+   IDLE_CORE_N,
+   CONST_DYNAMICN,
+   NUM_PERFORMANCE_COUNTERS
 };
 
-typedef struct {
-  int prediction_width;
-  char prediction_scheme[20];
-  int predictor_size;
-  int predictor_entries;
-  int local_predictor_size[20];
-  int local_predictor_entries;
-  int global_predictor_entries;
-  int global_predictor_bits;
-  int chooser_predictor_entries;
-  int chooser_predictor_bits;
-  double predictor_accesses;
+typedef struct{
+	int prediction_width;
+	char prediction_scheme[20];
+	int predictor_size;
+	int predictor_entries;
+	int local_predictor_size[20];
+	int local_predictor_entries;
+	int global_predictor_entries;
+	int global_predictor_bits;
+	int chooser_predictor_entries;
+	int chooser_predictor_bits;
+	double predictor_accesses;
 } predictor_systemcore;
-typedef struct {
-  int number_entries;
-  int cache_policy;  // 0 no write or write-though with non-write allocate;1
-                     // write-back with write-allocate
-  double total_hits;
-  double total_accesses;
-  double total_misses;
-  double conflicts;
+typedef struct{
+	int number_entries;
+	int cache_policy;//0 no write or write-though with non-write allocate;1 write-back with write-allocate
+	double total_hits;
+	double total_accesses;
+	double total_misses;
+	double conflicts;
 } itlb_systemcore;
-typedef struct {
-  // params
-  double icache_config[20];
-  int buffer_sizes[20];
-  int cache_policy;  // 0 no write or write-though with non-write allocate;1
-                     // write-back with write-allocate
-  // stats
-  double total_accesses;
-  double read_accesses;
-  double read_misses;
-  double replacements;
-  double read_hits;
-  double total_hits;
-  double total_misses;
-  double miss_buffer_access;
-  double fill_buffer_accesses;
-  double prefetch_buffer_accesses;
-  double prefetch_buffer_writes;
-  double prefetch_buffer_reads;
-  double prefetch_buffer_hits;
-  double conflicts;
+typedef struct{
+	//params
+	double icache_config[20];
+	int buffer_sizes[20];
+	int cache_policy;//0 no write or write-though with non-write allocate;1 write-back with write-allocate
+	//stats
+	double total_accesses;
+	double read_accesses;
+	double read_misses;
+	double replacements;
+	double read_hits;
+	double total_hits;
+	double total_misses;
+	double miss_buffer_access;
+	double fill_buffer_accesses;
+	double prefetch_buffer_accesses;
+	double prefetch_buffer_writes;
+	double prefetch_buffer_reads;
+	double prefetch_buffer_hits;
+	double conflicts;
 } icache_systemcore;
-typedef struct {
-  // params
-  int number_entries;
-  int cache_policy;  // 0 no write or write-though with non-write allocate;1
-                     // write-back with write-allocate
-  // stats
-  double total_accesses;
-  double read_accesses;
-  double write_accesses;
-  double write_hits;
-  double read_hits;
-  double read_misses;
-  double write_misses;
-  double total_hits;
-  double total_misses;
-  double conflicts;
+typedef struct{
+	//params
+	int number_entries;
+	int cache_policy;//0 no write or write-though with non-write allocate;1 write-back with write-allocate
+	//stats
+	double total_accesses;
+	double read_accesses;
+	double write_accesses;
+	double write_hits;
+	double read_hits;
+	double read_misses;
+	double write_misses;
+	double total_hits;
+	double total_misses;
+	double conflicts;
 } dtlb_systemcore;
-typedef struct {
-  // params
-  double dcache_config[20];
-  int buffer_sizes[20];
-  int cache_policy;  // 0 no write or write-though with non-write allocate;1
-                     // write-back with write-allocate
-  // stats
-  double total_accesses;
-  double read_accesses;
-  double write_accesses;
-  double total_hits;
-  double total_misses;
-  double read_hits;
-  double write_hits;
-  double read_misses;
-  double write_misses;
-  double replacements;
-  double write_backs;
-  double miss_buffer_access;
-  double fill_buffer_accesses;
-  double prefetch_buffer_accesses;
-  double prefetch_buffer_writes;
-  double prefetch_buffer_reads;
-  double prefetch_buffer_hits;
-  double wbb_writes;
-  double wbb_reads;
-  double conflicts;
+typedef struct{
+	//params
+	double dcache_config[20];
+	int buffer_sizes[20];
+	int cache_policy;//0 no write or write-though with non-write allocate;1 write-back with write-allocate
+	//stats
+	double total_accesses;
+	double read_accesses;
+	double write_accesses;
+	double total_hits;
+	double total_misses;
+	double read_hits;
+	double write_hits;
+	double read_misses;
+	double write_misses;
+	double replacements;
+	double write_backs;
+	double miss_buffer_access;
+	double fill_buffer_accesses;
+	double prefetch_buffer_accesses;
+	double prefetch_buffer_writes;
+	double prefetch_buffer_reads;
+	double prefetch_buffer_hits;
+	double wbb_writes;
+	double wbb_reads;
+	double conflicts;
 } dcache_systemcore;
-typedef struct {
-  // params
-  int BTB_config[20];
-  // stats
-  double total_accesses;
-  double read_accesses;
-  double write_accesses;
-  double total_hits;
-  double total_misses;
-  double read_hits;
-  double write_hits;
-  double read_misses;
-  double write_misses;
-  double replacements;
+typedef struct{
+	//params
+	int BTB_config[20];
+	//stats
+	double total_accesses;
+	double read_accesses;
+	double write_accesses;
+	double total_hits;
+	double total_misses;
+	double read_hits;
+	double write_hits;
+	double read_misses;
+	double write_misses;
+	double replacements;
 } BTB_systemcore;
-typedef struct {
-  // all params at the level of system.core(0-n)
-  int clock_rate;
-  bool opt_local;
-  bool x86;
-  int machine_bits;
-  int virtual_address_width;
-  int physical_address_width;
-  int opcode_width;
-  int micro_opcode_width;
-  int instruction_length;
-  int machine_type;
-  int internal_datapath_width;
-  int number_hardware_threads;
-  int fetch_width;
-  int number_instruction_fetch_ports;
-  int decode_width;
-  int issue_width;
-  int peak_issue_width;
-  int commit_width;
-  int pipelines_per_core[20];
-  int pipeline_depth[20];
-  char FPU[20];
-  char divider_multiplier[20];
-  int ALU_per_core;
-  double FPU_per_core;
-  int MUL_per_core;
-  int instruction_buffer_size;
-  int decoded_stream_buffer_size;
-  int instruction_window_scheme;
-  int instruction_window_size;
-  int fp_instruction_window_size;
-  int ROB_size;
-  int archi_Regs_IRF_size;
-  int archi_Regs_FRF_size;
-  int phy_Regs_IRF_size;
-  int phy_Regs_FRF_size;
-  int rename_scheme;
-  int register_windows_size;
-  char LSU_order[20];
-  int store_buffer_size;
-  int load_buffer_size;
-  int memory_ports;
-  char Dcache_dual_pump[20];
-  int RAS_size;
-  int fp_issue_width;
-  int prediction_width;
-  int number_of_BTB;
-  int number_of_BPT;
-  bool gpgpu_clock_gated_lanes;
+typedef struct{
+	//all params at the level of system.core(0-n)
+	int clock_rate;
+	bool opt_local;
+	bool x86;
+	int machine_bits;
+	int virtual_address_width;
+	int physical_address_width;
+	int opcode_width;
+	int micro_opcode_width;
+	int instruction_length;
+	int machine_type;
+	int internal_datapath_width;
+	int number_hardware_threads;
+	int fetch_width;
+	int number_instruction_fetch_ports;
+	int decode_width;
+	int issue_width;
+	int peak_issue_width;
+	int commit_width;
+	int pipelines_per_core[20];
+	int pipeline_depth[20];
+	char FPU[20];
+	char divider_multiplier[20];
+	int ALU_per_core;
+	double FPU_per_core;
+	int MUL_per_core;
+	int instruction_buffer_size;
+	int decoded_stream_buffer_size;
+	int instruction_window_scheme;
+	int instruction_window_size;
+	int fp_instruction_window_size;
+	int ROB_size;
+	int archi_Regs_IRF_size;
+	int archi_Regs_FRF_size;
+	int phy_Regs_IRF_size;
+	int phy_Regs_FRF_size;
+	int rename_scheme;
+	int register_windows_size;
+	char LSU_order[20];
+	int store_buffer_size;
+	int load_buffer_size;
+	int memory_ports;
+	char Dcache_dual_pump[20];
+	int RAS_size;
+	int fp_issue_width;
+	int prediction_width;
+	int number_of_BTB;
+	int number_of_BPT;
+	bool gpgpu_clock_gated_lanes;
 
-  // all stats at the level of system.core(0-n)
-  double total_instructions;
-  double int_instructions;
-  double fp_instructions;
-  double branch_instructions;
-  double branch_mispredictions;
-  double committed_instructions;
-  double committed_int_instructions;
-  double committed_fp_instructions;
-  double load_instructions;
-  double store_instructions;
-  double total_cycles;
-  double idle_cycles;
-  double busy_cycles;
-  double instruction_buffer_reads;
-  double instruction_buffer_write;
-  double ROB_reads;
-  double ROB_writes;
-  double rename_accesses;
-  double fp_rename_accesses;
-  double rename_reads;
-  double rename_writes;
-  double fp_rename_reads;
-  double fp_rename_writes;
-  double inst_window_reads;
-  double inst_window_writes;
-  double inst_window_wakeup_accesses;
-  double inst_window_selections;
-  double fp_inst_window_reads;
-  double fp_inst_window_writes;
-  double fp_inst_window_wakeup_accesses;
-  double fp_inst_window_selections;
-  double archi_int_regfile_reads;
-  double archi_float_regfile_reads;
-  double phy_int_regfile_reads;
-  double phy_float_regfile_reads;
-  double phy_int_regfile_writes;
-  double phy_float_regfile_writes;
-  double archi_int_regfile_writes;
-  double archi_float_regfile_writes;
-  double int_regfile_reads;
-  double float_regfile_reads;
-  double int_regfile_writes;
-  double float_regfile_writes;
-  double non_rf_operands;
-  double windowed_reg_accesses;
-  double windowed_reg_transports;
-  double function_calls;
-  double context_switches;
-  double ialu_accesses;
-  double fpu_accesses;
-  double mul_accesses;
-  double sp_average_active_lanes;
-  double sfu_average_active_lanes;
-  double cdb_alu_accesses;
-  double cdb_mul_accesses;
-  double cdb_fpu_accesses;
-  double load_buffer_reads;
-  double load_buffer_writes;
-  double load_buffer_cams;
-  double store_buffer_reads;
-  double store_buffer_writes;
-  double store_buffer_cams;
-  double store_buffer_forwards;
-  double main_memory_access;
-  double main_memory_read;
-  double main_memory_write;
-  double pipeline_duty_cycle;
+	//all stats at the level of system.core(0-n)
+	double total_instructions;
+	double int_instructions;
+	double fp_instructions;
+	double branch_instructions;
+	double branch_mispredictions;
+	double committed_instructions;
+	double committed_int_instructions;
+	double committed_fp_instructions;
+	double load_instructions;
+	double store_instructions;
+	double total_cycles;
+	double idle_cycles;
+	double busy_cycles;
+	double instruction_buffer_reads;
+	double instruction_buffer_write;
+	double ROB_reads;
+	double ROB_writes;
+	double rename_accesses;
+	double fp_rename_accesses;
+	double rename_reads;
+	double rename_writes;
+	double fp_rename_reads;
+	double fp_rename_writes;
+	double inst_window_reads;
+	double inst_window_writes;
+	double inst_window_wakeup_accesses;
+	double inst_window_selections;
+	double fp_inst_window_reads;
+	double fp_inst_window_writes;
+	double fp_inst_window_wakeup_accesses;
+	double fp_inst_window_selections;
+	double archi_int_regfile_reads;
+	double archi_float_regfile_reads;
+	double phy_int_regfile_reads;
+	double phy_float_regfile_reads;
+	double phy_int_regfile_writes;
+	double phy_float_regfile_writes;
+	double archi_int_regfile_writes;
+	double archi_float_regfile_writes;
+	double int_regfile_reads;
+	double float_regfile_reads;
+	double int_regfile_writes;
+	double float_regfile_writes;
+	double non_rf_operands;
+	double windowed_reg_accesses;
+	double windowed_reg_transports;
+	double function_calls;
+	double context_switches;
+	double ialu_accesses;
+	double fpu_accesses;
+	double mul_accesses;
+	double sp_average_active_lanes;
+	double sfu_average_active_lanes;
+	double cdb_alu_accesses;
+	double cdb_mul_accesses;
+	double cdb_fpu_accesses;
+	double load_buffer_reads;
+	double load_buffer_writes;
+	double load_buffer_cams;
+	double store_buffer_reads;
+	double store_buffer_writes;
+	double store_buffer_cams;
+	double store_buffer_forwards;
+	double main_memory_access;
+	double main_memory_read;
+	double main_memory_write;
+	double pipeline_duty_cycle;
 
-  double IFU_duty_cycle;
-  double BR_duty_cycle;
-  double LSU_duty_cycle;
-  double MemManU_I_duty_cycle;
-  double MemManU_D_duty_cycle;
-  double ALU_duty_cycle;
-  double MUL_duty_cycle;
-  double FPU_duty_cycle;
-  double ALU_cdb_duty_cycle;
-  double MUL_cdb_duty_cycle;
-  double FPU_cdb_duty_cycle;
+	double IFU_duty_cycle ;
+	double BR_duty_cycle ;
+	double LSU_duty_cycle ;
+	double MemManU_I_duty_cycle;
+	double MemManU_D_duty_cycle ;
+	double ALU_duty_cycle ;
+	double MUL_duty_cycle ;
+	double FPU_duty_cycle ;
+	double ALU_cdb_duty_cycle ;
+	double MUL_cdb_duty_cycle ;
+	double FPU_cdb_duty_cycle ;
 
-  double num_idle_cores;
+	double num_idle_cores;
 
-  int rf_banks;             // (4)
-  int simd_width;           // (8)
-  int collector_units;      // (4)
-  double core_clock_ratio;  // (2.0)
-  int warp_size;            // (32)
 
-  // all subnodes at the level of system.core(0-n)
-  predictor_systemcore predictor;
-  itlb_systemcore itlb;
-  icache_systemcore icache;
-  dtlb_systemcore dtlb;
-  dcache_systemcore dcache;
-  dcache_systemcore ccache;
-  dcache_systemcore tcache;
-  dcache_systemcore sharedmemory;  // added by Jingwen
-  BTB_systemcore BTB;
+	int rf_banks;// (4)
+   int simd_width;// (8)
+   int collector_units;// (4)
+   double core_clock_ratio;// (2.0)
+   int warp_size;// (32) 
+	
+	//all subnodes at the level of system.core(0-n)
+	predictor_systemcore predictor;
+	itlb_systemcore itlb;
+	icache_systemcore icache;
+	dtlb_systemcore dtlb;
+	dcache_systemcore dcache;
+	dcache_systemcore ccache;
+	dcache_systemcore tcache;
+	dcache_systemcore sharedmemory; // added by Jingwen
+	BTB_systemcore BTB;
 
 } system_core;
-typedef struct {
-  // params
-  int Directory_type;
-  double Dir_config[20];
-  int buffer_sizes[20];
-  int clockrate;
-  int ports[20];
-  int device_type;
-  int cache_policy;  // 0 no write or write-though with non-write allocate;1
-                     // write-back with write-allocate
-  char threeD_stack[20];
-  // stats
-  double total_accesses;
-  double read_accesses;
-  double write_accesses;
-  double read_misses;
-  double write_misses;
-  double conflicts;
-  double duty_cycle;
+typedef struct{
+	//params
+	int Directory_type;
+	double Dir_config[20];
+	int buffer_sizes[20];
+	int clockrate;
+	int ports[20];
+	int device_type;
+	int cache_policy;//0 no write or write-though with non-write allocate;1 write-back with write-allocate
+	char threeD_stack[20];
+	//stats
+	double total_accesses;
+	double read_accesses;
+	double write_accesses;
+	double read_misses;
+	double write_misses;
+	double conflicts;
+	double duty_cycle;
 } system_L1Directory;
-typedef struct {
-  // params
-  int Directory_type;
-  double Dir_config[20];
-  int buffer_sizes[20];
-  int clockrate;
-  int ports[20];
-  int device_type;
-  int cache_policy;  // 0 no write or write-though with non-write allocate;1
-                     // write-back with write-allocate
-  char threeD_stack[20];
-  // stats
-  double total_accesses;
-  double read_accesses;
-  double write_accesses;
-  double read_misses;
-  double write_misses;
-  double conflicts;
-  double duty_cycle;
+typedef struct{
+	//params
+	int Directory_type;
+	double Dir_config[20];
+	int buffer_sizes[20];
+	int clockrate;
+	int ports[20];
+	int device_type;
+	int cache_policy;//0 no write or write-though with non-write allocate;1 write-back with write-allocate
+	char threeD_stack[20];
+	//stats
+	double total_accesses;
+	double read_accesses;
+	double write_accesses;
+	double read_misses;
+	double write_misses;
+	double conflicts;
+	double duty_cycle;
 } system_L2Directory;
-typedef struct {
-  // params
-  double L2_config[20];
-  int clockrate;
-  int ports[20];
-  int device_type;
-  int cache_policy;  // 0 no write or write-though with non-write allocate;1
-                     // write-back with write-allocate
-  char threeD_stack[20];
-  int buffer_sizes[20];
-  // stats
-  double total_accesses;
-  double read_accesses;
-  double write_accesses;
-  double total_hits;
-  double total_misses;
-  double read_hits;
-  double write_hits;
-  double read_misses;
-  double write_misses;
-  double replacements;
-  double write_backs;
-  double miss_buffer_accesses;
-  double fill_buffer_accesses;
-  double prefetch_buffer_accesses;
-  double prefetch_buffer_writes;
-  double prefetch_buffer_reads;
-  double prefetch_buffer_hits;
-  double wbb_writes;
-  double wbb_reads;
-  double conflicts;
-  double duty_cycle;
+typedef struct{
+	//params
+	double L2_config[20];
+	int clockrate;
+	int ports[20];
+	int device_type;
+	int cache_policy;//0 no write or write-though with non-write allocate;1 write-back with write-allocate
+	char threeD_stack[20];
+	int buffer_sizes[20];
+	//stats
+	double total_accesses;
+	double read_accesses;
+	double write_accesses;
+	double total_hits;
+	double total_misses;
+	double read_hits;
+	double write_hits;
+	double read_misses;
+	double write_misses;
+	double replacements;
+	double write_backs;
+	double miss_buffer_accesses;
+	double fill_buffer_accesses;
+	double prefetch_buffer_accesses;
+	double prefetch_buffer_writes;
+	double prefetch_buffer_reads;
+	double prefetch_buffer_hits;
+	double wbb_writes;
+	double wbb_reads;
+	double conflicts;
+	double duty_cycle;
 
-  bool merged_dir;
-  double homenode_read_accesses;
-  double homenode_write_accesses;
-  double homenode_read_hits;
-  double homenode_write_hits;
-  double homenode_read_misses;
-  double homenode_write_misses;
-  double dir_duty_cycle;
+	bool   merged_dir;
+	double homenode_read_accesses;
+	double homenode_write_accesses;
+	double homenode_read_hits;
+	double homenode_write_hits;
+	double homenode_read_misses;
+	double homenode_write_misses;
+	double dir_duty_cycle;
 } system_L2;
-typedef struct {
-  // params
-  double L3_config[20];
-  int clockrate;
-  int ports[20];
-  int device_type;
-  int cache_policy;  // 0 no write or write-though with non-write allocate;1
-                     // write-back with write-allocate
-  char threeD_stack[20];
-  int buffer_sizes[20];
-  // stats
-  double total_accesses;
-  double read_accesses;
-  double write_accesses;
-  double total_hits;
-  double total_misses;
-  double read_hits;
-  double write_hits;
-  double read_misses;
-  double write_misses;
-  double replacements;
-  double write_backs;
-  double miss_buffer_accesses;
-  double fill_buffer_accesses;
-  double prefetch_buffer_accesses;
-  double prefetch_buffer_writes;
-  double prefetch_buffer_reads;
-  double prefetch_buffer_hits;
-  double wbb_writes;
-  double wbb_reads;
-  double conflicts;
-  double duty_cycle;
+typedef struct{
+	//params
+	double L3_config[20];
+	int clockrate;
+	int ports[20];
+	int device_type;
+	int cache_policy;//0 no write or write-though with non-write allocate;1 write-back with write-allocate
+	char threeD_stack[20];
+	int buffer_sizes[20];
+	//stats
+	double total_accesses;
+	double read_accesses;
+	double write_accesses;
+	double total_hits;
+	double total_misses;
+	double read_hits;
+	double write_hits;
+	double read_misses;
+	double write_misses;
+	double replacements;
+	double write_backs;
+	double miss_buffer_accesses;
+	double fill_buffer_accesses;
+	double prefetch_buffer_accesses;
+	double prefetch_buffer_writes;
+	double prefetch_buffer_reads;
+	double prefetch_buffer_hits;
+	double wbb_writes;
+	double wbb_reads;
+	double conflicts;
+	double duty_cycle;
 
-  bool merged_dir;
-  double homenode_read_accesses;
-  double homenode_write_accesses;
-  double homenode_read_hits;
-  double homenode_write_hits;
-  double homenode_read_misses;
-  double homenode_write_misses;
-  double dir_duty_cycle;
+	bool   merged_dir;
+	double homenode_read_accesses;
+	double homenode_write_accesses;
+	double homenode_read_hits;
+	double homenode_write_hits;
+	double homenode_read_misses;
+	double homenode_write_misses;
+	double dir_duty_cycle;
 } system_L3;
-typedef struct {
-  // params
-  int number_of_inputs_of_crossbars;
-  int number_of_outputs_of_crossbars;
-  int flit_bits;
-  int input_buffer_entries_per_port;
-  int ports_of_input_buffer[20];
-  // stats
-  double crossbar_accesses;
+typedef struct{
+	//params
+	int number_of_inputs_of_crossbars;
+	int number_of_outputs_of_crossbars;
+	int flit_bits;
+	int input_buffer_entries_per_port;
+	int ports_of_input_buffer[20];
+	//stats
+	double crossbar_accesses;
 } xbar0_systemNoC;
-typedef struct {
-  // params
-  int clockrate;
-  bool type;
-  bool has_global_link;
-  char topology[20];
-  int horizontal_nodes;
-  int vertical_nodes;
-  int link_throughput;
-  int link_latency;
-  int input_ports;
-  int output_ports;
-  int virtual_channel_per_port;
-  int flit_bits;
-  int input_buffer_entries_per_vc;
-  int ports_of_input_buffer[20];
-  int dual_pump;
-  int number_of_crossbars;
-  char crossbar_type[20];
-  char crosspoint_type[20];
-  xbar0_systemNoC xbar0;
-  int arbiter_type;
-  double chip_coverage;
-  // stats
-  double total_accesses;
-  double duty_cycle;
-  double route_over_perc;
+typedef struct{
+	//params
+	int clockrate;
+	bool type;
+	bool has_global_link;
+	char topology[20];
+	int horizontal_nodes;
+	int vertical_nodes;
+	int link_throughput;
+	int link_latency;
+	int input_ports;
+	int output_ports;
+	int virtual_channel_per_port;
+	int flit_bits;
+	int input_buffer_entries_per_vc;
+	int ports_of_input_buffer[20];
+	int dual_pump;
+	int number_of_crossbars;
+	char crossbar_type[20];
+	char crosspoint_type[20];
+	xbar0_systemNoC xbar0;
+	int arbiter_type;
+	double chip_coverage;
+	//stats
+	double total_accesses;
+	double duty_cycle;
+	double route_over_perc;
 } system_NoC;
-typedef struct {
-  // params
-  int mem_tech_node;
-  int device_clock;
-  int peak_transfer_rate;
-  int internal_prefetch_of_DRAM_chip;
-  int capacity_per_channel;
-  int number_ranks;
-  int num_banks_of_DRAM_chip;
-  int Block_width_of_DRAM_chip;
-  int output_width_of_DRAM_chip;
-  int page_size_of_DRAM_chip;
-  int burstlength_of_DRAM_chip;
+typedef struct{
+	//params
+	int mem_tech_node;
+	int device_clock;
+	int peak_transfer_rate;
+	int internal_prefetch_of_DRAM_chip;
+	int capacity_per_channel;
+	int number_ranks;
+	int num_banks_of_DRAM_chip;
+	int Block_width_of_DRAM_chip;
+	int output_width_of_DRAM_chip;
+	int page_size_of_DRAM_chip;
+	int burstlength_of_DRAM_chip;
 
-  // stats
-  double memory_accesses;
-  double memory_reads;
-  double memory_writes;
-  double dram_pre;
+	//stats
+	double memory_accesses;
+	double memory_reads;
+	double memory_writes;
+	double dram_pre;
 } system_mem;
-typedef struct {
-  // params
-  // Common Param for mc and fc
-  double peak_transfer_rate;
-  int number_mcs;
-  bool withPHY;
-  int type;
+typedef struct{
+	//params
+    //Common Param for mc and fc
+	double peak_transfer_rate;
+	int number_mcs;
+	bool withPHY;
+	int type;
 
-  // FCParam
-  // stats
-  double duty_cycle;
-  double total_load_perc;
+	//FCParam
+	//stats
+	double duty_cycle;
+	double total_load_perc;
 
-  // McParam
-  int mc_clock;
-  int llc_line_length;
-  int memory_channels_per_mc;
-  int number_ranks;
-  int req_window_size_per_channel;
-  int IO_buffer_size_per_channel;
-  int databus_width;
-  int addressbus_width;
-  int PRT_entries;
-  bool LVDS;
+	//McParam
+	int mc_clock;
+    int llc_line_length;
+	int memory_channels_per_mc;
+	int number_ranks;
+	int req_window_size_per_channel;
+	int IO_buffer_size_per_channel;
+	int databus_width;
+	int addressbus_width;
+	int PRT_entries;
+	bool LVDS;
 
-  // emprical DRAM coeff
-  double dram_cmd_coeff;
-  double dram_act_coeff;
-  double dram_nop_coeff;
-  double dram_activity_coeff;
-  double dram_pre_coeff;
-  double dram_rd_coeff;
-  double dram_wr_coeff;
-  double dram_req_coeff;
-  double dram_const_coeff;
+	// emprical DRAM coeff
+	double dram_cmd_coeff;
+	double dram_act_coeff;
+	double dram_nop_coeff;
+	double dram_activity_coeff;
+	double dram_pre_coeff;
+	double dram_rd_coeff;
+	double dram_wr_coeff;
+	double dram_req_coeff;
+	double dram_const_coeff;
 
-  // stats
-  double memory_accesses;
-  double memory_reads;
-  double memory_writes;
+	//stats
+	double memory_accesses;
+	double memory_reads;
+	double memory_writes;
 
-  // dram stats
-  double dram_cmd;
-  double dram_activity;
-  double dram_nop;
-  double dram_act;
-  double dram_pre;
-  double dram_rd;
-  double dram_wr;
-  double dram_req;
+	//dram stats
+	double dram_cmd;
+	double dram_activity;
+	double dram_nop;
+	double dram_act;
+	double dram_pre;
+	double dram_rd;
+	double dram_wr;
+	double dram_req;
+
 
 } system_mc;
 
-typedef struct {
-  // params
-  int clockrate;
-  int number_units;
-  int type;
-  // stats
-  double duty_cycle;
-  double total_load_perc;
+typedef struct{
+	//params
+    int clockrate;
+	int number_units;
+	int type;
+	//stats
+	double duty_cycle;
+	double total_load_perc;
 } system_niu;
 
-typedef struct {
-  // params
-  int clockrate;
-  int number_units;
-  int num_channels;
-  int type;
-  bool withPHY;
-  // stats
-  double duty_cycle;
-  double total_load_perc;
+typedef struct{
+	//params
+    int clockrate;
+	int number_units;
+	int num_channels;
+	int type;
+	bool withPHY;
+	//stats
+	double duty_cycle;
+	double total_load_perc;
 } system_pcie;
 
-typedef struct {
-  // All number_of_* at the level of 'system' Ying 03/21/2009
-  int GPU_Architecture;
-  int number_of_cores;
-  int architecture;
-  int number_of_L1Directories;
-  int number_of_L2Directories;
-  int number_of_L2s;
-  bool Private_L2;
-  int number_of_L3s;
-  int number_of_NoCs;
-  int number_of_dir_levels;
-  int domain_size;
-  int first_level_dir;
-  // All params at the level of 'system'
-  int homogeneous_cores;
-  int homogeneous_L1Directories;
-  int homogeneous_L2Directories;
-  double core_tech_node;
-  int target_core_clockrate;
-  int target_chip_area;
-  int temperature;
-  int number_cache_levels;
-  int L1_property;
-  int L2_property;
-  int homogeneous_L2s;
-  int L3_property;
-  int homogeneous_L3s;
-  int homogeneous_NoCs;
-  int homogeneous_ccs;
-  int Max_area_deviation;
-  int Max_power_deviation;
-  int device_type;
-  bool longer_channel_device;
-  bool Embedded;
-  bool opt_dynamic_power;
-  bool opt_lakage_power;
-  bool opt_clockrate;
-  bool opt_area;
-  int interconnect_projection_type;
-  int machine_bits;
-  int virtual_address_width;
-  int physical_address_width;
-  int virtual_memory_page_size;
-  double idle_core_power;
-  double num_idle_cores;
-  int arch;
-  double total_cycles;
-  // system.core(0-n):3rd level
-  double scaling_coefficients[64];
-  system_core core[64];
-  system_L1Directory L1Directory[64];
-  system_L2Directory L2Directory[64];
-  system_L2 L2[64];
-  system_L2 l2;
-  system_L3 L3[64];
-  system_NoC NoC[64];
-  system_mem mem;
-  system_mc mc;
-  system_mc flashc;
-  system_niu niu;
-  system_pcie pcie;
+typedef struct{
+	//All number_of_* at the level of 'system' Ying 03/21/2009
+	int GPU_Architecture;
+	int number_of_cores;
+	int architecture;
+	int number_of_L1Directories;
+	int number_of_L2Directories;
+	int number_of_L2s;
+	bool Private_L2;
+	int number_of_L3s;
+	int number_of_NoCs;
+	int number_of_dir_levels;
+    int domain_size;
+    int first_level_dir;
+	// All params at the level of 'system'
+	int homogeneous_cores;
+	int homogeneous_L1Directories;
+	int homogeneous_L2Directories;
+	double core_tech_node;
+	int target_core_clockrate;
+	int target_chip_area;
+	int temperature;
+	int number_cache_levels;
+	int L1_property;
+	int L2_property;
+	int homogeneous_L2s;
+	int L3_property;
+	int homogeneous_L3s;
+	int homogeneous_NoCs;
+	int homogeneous_ccs;
+	int Max_area_deviation;
+	int Max_power_deviation;
+	int device_type;
+	bool longer_channel_device;
+	bool Embedded;
+	bool opt_dynamic_power;
+	bool opt_lakage_power;
+	bool opt_clockrate;
+	bool opt_area;
+	int interconnect_projection_type;
+	int machine_bits;
+	int virtual_address_width;
+	int physical_address_width;
+	int virtual_memory_page_size;
+	double idle_core_power;
+	double num_idle_cores;
+	int arch;
+    double total_cycles;
+	//system.core(0-n):3rd level
+    double scaling_coefficients[64];
+	system_core core[64];
+	system_L1Directory L1Directory[64];
+	system_L2Directory L2Directory[64];
+	system_L2 L2[64];
+    system_L2 l2;
+	system_L3 L3[64];
+    system_NoC NoC[64];
+    system_mem mem;
+	system_mc mc;
+	system_mc flashc;
+	system_niu niu;
+	system_pcie pcie;
 } root_system;
 
-class ParseXML {
- public:
-  void parse(char* filepath);
-  void initialize();
-
- public:
-  root_system sys;
+class ParseXML
+{
+public:
+	void parse(char* filepath);
+    void initialize();
+public:
+	root_system sys;
 };
 
+
 #endif /* XML_PARSE_H_ */
+
+
+
+

--- a/src/gpuwattch/XML_Parse.h
+++ b/src/gpuwattch/XML_Parse.h
@@ -29,7 +29,8 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:												   *
+*      Modified by:
+**
 *      Jingwen Leng, Univeristy of Texas, Austin                   *
 *      Syed Gilani, University of Wisconsin–Madison                *
 *      Tayler Hetherington, University of British Columbia         *
@@ -39,650 +40,656 @@
 #ifndef XML_PARSE_H_
 #define XML_PARSE_H_
 
-
 //#ifdef WIN32
 //#define _CRT_SECURE_NO_DEPRECATE
 //#endif
 
 #include <stdio.h>
-#include "xmlParser.h"
 #include <string.h>
 #include <iostream>
+#include "xmlParser.h"
 using namespace std;
 
 /*
 void myfree(char *t); // {free(t);}
 ToXMLStringTool tx,tx2;
 */
-//all subnodes at the level of system.core(0-n)
-//cache_policy is added into cache property arrays;//0 no write or write-though with non-write allocate;1 write-back with write-allocate
+// all subnodes at the level of system.core(0-n)
+// cache_policy is added into cache property arrays;//0 no write or write-though
+// with non-write allocate;1 write-back with write-allocate
 //
-//tgrogers - This was a static array declared in the header...
-//           Not too sure why the authors did this, maybe they didn't understand the context
-//           of the "static" keyword outside a class declaration.  As it was written, each object file
-//           had it's own copy of the string list - which is okay, since the string is constant but
-//           wastes space and causes the compiler to complain about unused vars in files where this header
-//           is included but they don't use the variable.  Now this is extern'd here and the storage/definition
+// tgrogers - This was a static array declared in the header...
+//           Not too sure why the authors did this, maybe they didn't understand
+//           the context
+//           of the "static" keyword outside a class declaration.  As it was
+//           written, each object file
+//           had it's own copy of the string list - which is okay, since the
+//           string is constant but
+//           wastes space and causes the compiler to complain about unused vars
+//           in files where this header
+//           is included but they don't use the variable.  Now this is extern'd
+//           here and the storage/definition
 //           is in the XML_Parse.cc file
-extern const char * perf_count_label[];
+extern const char* perf_count_label[];
 
 enum perf_count_t {
-   TOT_INST=0,
-   FP_INT,
-   IC_H,
-   IC_M,
-   DC_RH,
-   DC_RM,
-   DC_WH,
-   DC_WM,
-   TC_H,
-   TC_M,
-   CC_H,
-   CC_M,
-   SHRD_ACC,
-   REG_RD,
-   REG_WR,
-   NON_REG_OPs,
-   SP_ACC,
-   SFU_ACC,
-   FPU_ACC,
-   MEM_RD,
-   MEM_WR,
-   MEM_PRE,
-   L2_RH,
-   L2_RM,
-   L2_WH,
-   L2_WM,
-   NOC_A,
-   PIPE_A,
-   IDLE_CORE_N,
-   CONST_DYNAMICN,
-   NUM_PERFORMANCE_COUNTERS
+  TOT_INST = 0,
+  FP_INT,
+  IC_H,
+  IC_M,
+  DC_RH,
+  DC_RM,
+  DC_WH,
+  DC_WM,
+  TC_H,
+  TC_M,
+  CC_H,
+  CC_M,
+  SHRD_ACC,
+  REG_RD,
+  REG_WR,
+  NON_REG_OPs,
+  SP_ACC,
+  SFU_ACC,
+  FPU_ACC,
+  MEM_RD,
+  MEM_WR,
+  MEM_PRE,
+  L2_RH,
+  L2_RM,
+  L2_WH,
+  L2_WM,
+  NOC_A,
+  PIPE_A,
+  IDLE_CORE_N,
+  CONST_DYNAMICN,
+  NUM_PERFORMANCE_COUNTERS
 };
 
-typedef struct{
-	int prediction_width;
-	char prediction_scheme[20];
-	int predictor_size;
-	int predictor_entries;
-	int local_predictor_size[20];
-	int local_predictor_entries;
-	int global_predictor_entries;
-	int global_predictor_bits;
-	int chooser_predictor_entries;
-	int chooser_predictor_bits;
-	double predictor_accesses;
+typedef struct {
+  int prediction_width;
+  char prediction_scheme[20];
+  int predictor_size;
+  int predictor_entries;
+  int local_predictor_size[20];
+  int local_predictor_entries;
+  int global_predictor_entries;
+  int global_predictor_bits;
+  int chooser_predictor_entries;
+  int chooser_predictor_bits;
+  double predictor_accesses;
 } predictor_systemcore;
-typedef struct{
-	int number_entries;
-	int cache_policy;//0 no write or write-though with non-write allocate;1 write-back with write-allocate
-	double total_hits;
-	double total_accesses;
-	double total_misses;
-	double conflicts;
+typedef struct {
+  int number_entries;
+  int cache_policy;  // 0 no write or write-though with non-write allocate;1
+                     // write-back with write-allocate
+  double total_hits;
+  double total_accesses;
+  double total_misses;
+  double conflicts;
 } itlb_systemcore;
-typedef struct{
-	//params
-	double icache_config[20];
-	int buffer_sizes[20];
-	int cache_policy;//0 no write or write-though with non-write allocate;1 write-back with write-allocate
-	//stats
-	double total_accesses;
-	double read_accesses;
-	double read_misses;
-	double replacements;
-	double read_hits;
-	double total_hits;
-	double total_misses;
-	double miss_buffer_access;
-	double fill_buffer_accesses;
-	double prefetch_buffer_accesses;
-	double prefetch_buffer_writes;
-	double prefetch_buffer_reads;
-	double prefetch_buffer_hits;
-	double conflicts;
+typedef struct {
+  // params
+  double icache_config[20];
+  int buffer_sizes[20];
+  int cache_policy;  // 0 no write or write-though with non-write allocate;1
+                     // write-back with write-allocate
+  // stats
+  double total_accesses;
+  double read_accesses;
+  double read_misses;
+  double replacements;
+  double read_hits;
+  double total_hits;
+  double total_misses;
+  double miss_buffer_access;
+  double fill_buffer_accesses;
+  double prefetch_buffer_accesses;
+  double prefetch_buffer_writes;
+  double prefetch_buffer_reads;
+  double prefetch_buffer_hits;
+  double conflicts;
 } icache_systemcore;
-typedef struct{
-	//params
-	int number_entries;
-	int cache_policy;//0 no write or write-though with non-write allocate;1 write-back with write-allocate
-	//stats
-	double total_accesses;
-	double read_accesses;
-	double write_accesses;
-	double write_hits;
-	double read_hits;
-	double read_misses;
-	double write_misses;
-	double total_hits;
-	double total_misses;
-	double conflicts;
+typedef struct {
+  // params
+  int number_entries;
+  int cache_policy;  // 0 no write or write-though with non-write allocate;1
+                     // write-back with write-allocate
+  // stats
+  double total_accesses;
+  double read_accesses;
+  double write_accesses;
+  double write_hits;
+  double read_hits;
+  double read_misses;
+  double write_misses;
+  double total_hits;
+  double total_misses;
+  double conflicts;
 } dtlb_systemcore;
-typedef struct{
-	//params
-	double dcache_config[20];
-	int buffer_sizes[20];
-	int cache_policy;//0 no write or write-though with non-write allocate;1 write-back with write-allocate
-	//stats
-	double total_accesses;
-	double read_accesses;
-	double write_accesses;
-	double total_hits;
-	double total_misses;
-	double read_hits;
-	double write_hits;
-	double read_misses;
-	double write_misses;
-	double replacements;
-	double write_backs;
-	double miss_buffer_access;
-	double fill_buffer_accesses;
-	double prefetch_buffer_accesses;
-	double prefetch_buffer_writes;
-	double prefetch_buffer_reads;
-	double prefetch_buffer_hits;
-	double wbb_writes;
-	double wbb_reads;
-	double conflicts;
+typedef struct {
+  // params
+  double dcache_config[20];
+  int buffer_sizes[20];
+  int cache_policy;  // 0 no write or write-though with non-write allocate;1
+                     // write-back with write-allocate
+  // stats
+  double total_accesses;
+  double read_accesses;
+  double write_accesses;
+  double total_hits;
+  double total_misses;
+  double read_hits;
+  double write_hits;
+  double read_misses;
+  double write_misses;
+  double replacements;
+  double write_backs;
+  double miss_buffer_access;
+  double fill_buffer_accesses;
+  double prefetch_buffer_accesses;
+  double prefetch_buffer_writes;
+  double prefetch_buffer_reads;
+  double prefetch_buffer_hits;
+  double wbb_writes;
+  double wbb_reads;
+  double conflicts;
 } dcache_systemcore;
-typedef struct{
-	//params
-	int BTB_config[20];
-	//stats
-	double total_accesses;
-	double read_accesses;
-	double write_accesses;
-	double total_hits;
-	double total_misses;
-	double read_hits;
-	double write_hits;
-	double read_misses;
-	double write_misses;
-	double replacements;
+typedef struct {
+  // params
+  int BTB_config[20];
+  // stats
+  double total_accesses;
+  double read_accesses;
+  double write_accesses;
+  double total_hits;
+  double total_misses;
+  double read_hits;
+  double write_hits;
+  double read_misses;
+  double write_misses;
+  double replacements;
 } BTB_systemcore;
-typedef struct{
-	//all params at the level of system.core(0-n)
-	int clock_rate;
-	bool opt_local;
-	bool x86;
-	int machine_bits;
-	int virtual_address_width;
-	int physical_address_width;
-	int opcode_width;
-	int micro_opcode_width;
-	int instruction_length;
-	int machine_type;
-	int internal_datapath_width;
-	int number_hardware_threads;
-	int fetch_width;
-	int number_instruction_fetch_ports;
-	int decode_width;
-	int issue_width;
-	int peak_issue_width;
-	int commit_width;
-	int pipelines_per_core[20];
-	int pipeline_depth[20];
-	char FPU[20];
-	char divider_multiplier[20];
-	int ALU_per_core;
-	double FPU_per_core;
-	int MUL_per_core;
-	int instruction_buffer_size;
-	int decoded_stream_buffer_size;
-	int instruction_window_scheme;
-	int instruction_window_size;
-	int fp_instruction_window_size;
-	int ROB_size;
-	int archi_Regs_IRF_size;
-	int archi_Regs_FRF_size;
-	int phy_Regs_IRF_size;
-	int phy_Regs_FRF_size;
-	int rename_scheme;
-	int register_windows_size;
-	char LSU_order[20];
-	int store_buffer_size;
-	int load_buffer_size;
-	int memory_ports;
-	char Dcache_dual_pump[20];
-	int RAS_size;
-	int fp_issue_width;
-	int prediction_width;
-	int number_of_BTB;
-	int number_of_BPT;
-	bool gpgpu_clock_gated_lanes;
+typedef struct {
+  // all params at the level of system.core(0-n)
+  int clock_rate;
+  bool opt_local;
+  bool x86;
+  int machine_bits;
+  int virtual_address_width;
+  int physical_address_width;
+  int opcode_width;
+  int micro_opcode_width;
+  int instruction_length;
+  int machine_type;
+  int internal_datapath_width;
+  int number_hardware_threads;
+  int fetch_width;
+  int number_instruction_fetch_ports;
+  int decode_width;
+  int issue_width;
+  int peak_issue_width;
+  int commit_width;
+  int pipelines_per_core[20];
+  int pipeline_depth[20];
+  char FPU[20];
+  char divider_multiplier[20];
+  int ALU_per_core;
+  double FPU_per_core;
+  int MUL_per_core;
+  int instruction_buffer_size;
+  int decoded_stream_buffer_size;
+  int instruction_window_scheme;
+  int instruction_window_size;
+  int fp_instruction_window_size;
+  int ROB_size;
+  int archi_Regs_IRF_size;
+  int archi_Regs_FRF_size;
+  int phy_Regs_IRF_size;
+  int phy_Regs_FRF_size;
+  int rename_scheme;
+  int register_windows_size;
+  char LSU_order[20];
+  int store_buffer_size;
+  int load_buffer_size;
+  int memory_ports;
+  char Dcache_dual_pump[20];
+  int RAS_size;
+  int fp_issue_width;
+  int prediction_width;
+  int number_of_BTB;
+  int number_of_BPT;
+  bool gpgpu_clock_gated_lanes;
 
-	//all stats at the level of system.core(0-n)
-	double total_instructions;
-	double int_instructions;
-	double fp_instructions;
-	double branch_instructions;
-	double branch_mispredictions;
-	double committed_instructions;
-	double committed_int_instructions;
-	double committed_fp_instructions;
-	double load_instructions;
-	double store_instructions;
-	double total_cycles;
-	double idle_cycles;
-	double busy_cycles;
-	double instruction_buffer_reads;
-	double instruction_buffer_write;
-	double ROB_reads;
-	double ROB_writes;
-	double rename_accesses;
-	double fp_rename_accesses;
-	double rename_reads;
-	double rename_writes;
-	double fp_rename_reads;
-	double fp_rename_writes;
-	double inst_window_reads;
-	double inst_window_writes;
-	double inst_window_wakeup_accesses;
-	double inst_window_selections;
-	double fp_inst_window_reads;
-	double fp_inst_window_writes;
-	double fp_inst_window_wakeup_accesses;
-	double fp_inst_window_selections;
-	double archi_int_regfile_reads;
-	double archi_float_regfile_reads;
-	double phy_int_regfile_reads;
-	double phy_float_regfile_reads;
-	double phy_int_regfile_writes;
-	double phy_float_regfile_writes;
-	double archi_int_regfile_writes;
-	double archi_float_regfile_writes;
-	double int_regfile_reads;
-	double float_regfile_reads;
-	double int_regfile_writes;
-	double float_regfile_writes;
-	double non_rf_operands;
-	double windowed_reg_accesses;
-	double windowed_reg_transports;
-	double function_calls;
-	double context_switches;
-	double ialu_accesses;
-	double fpu_accesses;
-	double mul_accesses;
-	double sp_average_active_lanes;
-	double sfu_average_active_lanes;
-	double cdb_alu_accesses;
-	double cdb_mul_accesses;
-	double cdb_fpu_accesses;
-	double load_buffer_reads;
-	double load_buffer_writes;
-	double load_buffer_cams;
-	double store_buffer_reads;
-	double store_buffer_writes;
-	double store_buffer_cams;
-	double store_buffer_forwards;
-	double main_memory_access;
-	double main_memory_read;
-	double main_memory_write;
-	double pipeline_duty_cycle;
+  // all stats at the level of system.core(0-n)
+  double total_instructions;
+  double int_instructions;
+  double fp_instructions;
+  double branch_instructions;
+  double branch_mispredictions;
+  double committed_instructions;
+  double committed_int_instructions;
+  double committed_fp_instructions;
+  double load_instructions;
+  double store_instructions;
+  double total_cycles;
+  double idle_cycles;
+  double busy_cycles;
+  double instruction_buffer_reads;
+  double instruction_buffer_write;
+  double ROB_reads;
+  double ROB_writes;
+  double rename_accesses;
+  double fp_rename_accesses;
+  double rename_reads;
+  double rename_writes;
+  double fp_rename_reads;
+  double fp_rename_writes;
+  double inst_window_reads;
+  double inst_window_writes;
+  double inst_window_wakeup_accesses;
+  double inst_window_selections;
+  double fp_inst_window_reads;
+  double fp_inst_window_writes;
+  double fp_inst_window_wakeup_accesses;
+  double fp_inst_window_selections;
+  double archi_int_regfile_reads;
+  double archi_float_regfile_reads;
+  double phy_int_regfile_reads;
+  double phy_float_regfile_reads;
+  double phy_int_regfile_writes;
+  double phy_float_regfile_writes;
+  double archi_int_regfile_writes;
+  double archi_float_regfile_writes;
+  double int_regfile_reads;
+  double float_regfile_reads;
+  double int_regfile_writes;
+  double float_regfile_writes;
+  double non_rf_operands;
+  double windowed_reg_accesses;
+  double windowed_reg_transports;
+  double function_calls;
+  double context_switches;
+  double ialu_accesses;
+  double fpu_accesses;
+  double mul_accesses;
+  double sp_average_active_lanes;
+  double sfu_average_active_lanes;
+  double cdb_alu_accesses;
+  double cdb_mul_accesses;
+  double cdb_fpu_accesses;
+  double load_buffer_reads;
+  double load_buffer_writes;
+  double load_buffer_cams;
+  double store_buffer_reads;
+  double store_buffer_writes;
+  double store_buffer_cams;
+  double store_buffer_forwards;
+  double main_memory_access;
+  double main_memory_read;
+  double main_memory_write;
+  double pipeline_duty_cycle;
 
-	double IFU_duty_cycle ;
-	double BR_duty_cycle ;
-	double LSU_duty_cycle ;
-	double MemManU_I_duty_cycle;
-	double MemManU_D_duty_cycle ;
-	double ALU_duty_cycle ;
-	double MUL_duty_cycle ;
-	double FPU_duty_cycle ;
-	double ALU_cdb_duty_cycle ;
-	double MUL_cdb_duty_cycle ;
-	double FPU_cdb_duty_cycle ;
+  double IFU_duty_cycle;
+  double BR_duty_cycle;
+  double LSU_duty_cycle;
+  double MemManU_I_duty_cycle;
+  double MemManU_D_duty_cycle;
+  double ALU_duty_cycle;
+  double MUL_duty_cycle;
+  double FPU_duty_cycle;
+  double ALU_cdb_duty_cycle;
+  double MUL_cdb_duty_cycle;
+  double FPU_cdb_duty_cycle;
 
-	double num_idle_cores;
+  double num_idle_cores;
 
+  int rf_banks;             // (4)
+  int simd_width;           // (8)
+  int collector_units;      // (4)
+  double core_clock_ratio;  // (2.0)
+  int warp_size;            // (32)
 
-	int rf_banks;// (4)
-   int simd_width;// (8)
-   int collector_units;// (4)
-   double core_clock_ratio;// (2.0)
-   int warp_size;// (32) 
-	
-	//all subnodes at the level of system.core(0-n)
-	predictor_systemcore predictor;
-	itlb_systemcore itlb;
-	icache_systemcore icache;
-	dtlb_systemcore dtlb;
-	dcache_systemcore dcache;
-	dcache_systemcore ccache;
-	dcache_systemcore tcache;
-	dcache_systemcore sharedmemory; // added by Jingwen
-	BTB_systemcore BTB;
+  // all subnodes at the level of system.core(0-n)
+  predictor_systemcore predictor;
+  itlb_systemcore itlb;
+  icache_systemcore icache;
+  dtlb_systemcore dtlb;
+  dcache_systemcore dcache;
+  dcache_systemcore ccache;
+  dcache_systemcore tcache;
+  dcache_systemcore sharedmemory;  // added by Jingwen
+  BTB_systemcore BTB;
 
 } system_core;
-typedef struct{
-	//params
-	int Directory_type;
-	double Dir_config[20];
-	int buffer_sizes[20];
-	int clockrate;
-	int ports[20];
-	int device_type;
-	int cache_policy;//0 no write or write-though with non-write allocate;1 write-back with write-allocate
-	char threeD_stack[20];
-	//stats
-	double total_accesses;
-	double read_accesses;
-	double write_accesses;
-	double read_misses;
-	double write_misses;
-	double conflicts;
-	double duty_cycle;
+typedef struct {
+  // params
+  int Directory_type;
+  double Dir_config[20];
+  int buffer_sizes[20];
+  int clockrate;
+  int ports[20];
+  int device_type;
+  int cache_policy;  // 0 no write or write-though with non-write allocate;1
+                     // write-back with write-allocate
+  char threeD_stack[20];
+  // stats
+  double total_accesses;
+  double read_accesses;
+  double write_accesses;
+  double read_misses;
+  double write_misses;
+  double conflicts;
+  double duty_cycle;
 } system_L1Directory;
-typedef struct{
-	//params
-	int Directory_type;
-	double Dir_config[20];
-	int buffer_sizes[20];
-	int clockrate;
-	int ports[20];
-	int device_type;
-	int cache_policy;//0 no write or write-though with non-write allocate;1 write-back with write-allocate
-	char threeD_stack[20];
-	//stats
-	double total_accesses;
-	double read_accesses;
-	double write_accesses;
-	double read_misses;
-	double write_misses;
-	double conflicts;
-	double duty_cycle;
+typedef struct {
+  // params
+  int Directory_type;
+  double Dir_config[20];
+  int buffer_sizes[20];
+  int clockrate;
+  int ports[20];
+  int device_type;
+  int cache_policy;  // 0 no write or write-though with non-write allocate;1
+                     // write-back with write-allocate
+  char threeD_stack[20];
+  // stats
+  double total_accesses;
+  double read_accesses;
+  double write_accesses;
+  double read_misses;
+  double write_misses;
+  double conflicts;
+  double duty_cycle;
 } system_L2Directory;
-typedef struct{
-	//params
-	double L2_config[20];
-	int clockrate;
-	int ports[20];
-	int device_type;
-	int cache_policy;//0 no write or write-though with non-write allocate;1 write-back with write-allocate
-	char threeD_stack[20];
-	int buffer_sizes[20];
-	//stats
-	double total_accesses;
-	double read_accesses;
-	double write_accesses;
-	double total_hits;
-	double total_misses;
-	double read_hits;
-	double write_hits;
-	double read_misses;
-	double write_misses;
-	double replacements;
-	double write_backs;
-	double miss_buffer_accesses;
-	double fill_buffer_accesses;
-	double prefetch_buffer_accesses;
-	double prefetch_buffer_writes;
-	double prefetch_buffer_reads;
-	double prefetch_buffer_hits;
-	double wbb_writes;
-	double wbb_reads;
-	double conflicts;
-	double duty_cycle;
+typedef struct {
+  // params
+  double L2_config[20];
+  int clockrate;
+  int ports[20];
+  int device_type;
+  int cache_policy;  // 0 no write or write-though with non-write allocate;1
+                     // write-back with write-allocate
+  char threeD_stack[20];
+  int buffer_sizes[20];
+  // stats
+  double total_accesses;
+  double read_accesses;
+  double write_accesses;
+  double total_hits;
+  double total_misses;
+  double read_hits;
+  double write_hits;
+  double read_misses;
+  double write_misses;
+  double replacements;
+  double write_backs;
+  double miss_buffer_accesses;
+  double fill_buffer_accesses;
+  double prefetch_buffer_accesses;
+  double prefetch_buffer_writes;
+  double prefetch_buffer_reads;
+  double prefetch_buffer_hits;
+  double wbb_writes;
+  double wbb_reads;
+  double conflicts;
+  double duty_cycle;
 
-	bool   merged_dir;
-	double homenode_read_accesses;
-	double homenode_write_accesses;
-	double homenode_read_hits;
-	double homenode_write_hits;
-	double homenode_read_misses;
-	double homenode_write_misses;
-	double dir_duty_cycle;
+  bool merged_dir;
+  double homenode_read_accesses;
+  double homenode_write_accesses;
+  double homenode_read_hits;
+  double homenode_write_hits;
+  double homenode_read_misses;
+  double homenode_write_misses;
+  double dir_duty_cycle;
 } system_L2;
-typedef struct{
-	//params
-	double L3_config[20];
-	int clockrate;
-	int ports[20];
-	int device_type;
-	int cache_policy;//0 no write or write-though with non-write allocate;1 write-back with write-allocate
-	char threeD_stack[20];
-	int buffer_sizes[20];
-	//stats
-	double total_accesses;
-	double read_accesses;
-	double write_accesses;
-	double total_hits;
-	double total_misses;
-	double read_hits;
-	double write_hits;
-	double read_misses;
-	double write_misses;
-	double replacements;
-	double write_backs;
-	double miss_buffer_accesses;
-	double fill_buffer_accesses;
-	double prefetch_buffer_accesses;
-	double prefetch_buffer_writes;
-	double prefetch_buffer_reads;
-	double prefetch_buffer_hits;
-	double wbb_writes;
-	double wbb_reads;
-	double conflicts;
-	double duty_cycle;
+typedef struct {
+  // params
+  double L3_config[20];
+  int clockrate;
+  int ports[20];
+  int device_type;
+  int cache_policy;  // 0 no write or write-though with non-write allocate;1
+                     // write-back with write-allocate
+  char threeD_stack[20];
+  int buffer_sizes[20];
+  // stats
+  double total_accesses;
+  double read_accesses;
+  double write_accesses;
+  double total_hits;
+  double total_misses;
+  double read_hits;
+  double write_hits;
+  double read_misses;
+  double write_misses;
+  double replacements;
+  double write_backs;
+  double miss_buffer_accesses;
+  double fill_buffer_accesses;
+  double prefetch_buffer_accesses;
+  double prefetch_buffer_writes;
+  double prefetch_buffer_reads;
+  double prefetch_buffer_hits;
+  double wbb_writes;
+  double wbb_reads;
+  double conflicts;
+  double duty_cycle;
 
-	bool   merged_dir;
-	double homenode_read_accesses;
-	double homenode_write_accesses;
-	double homenode_read_hits;
-	double homenode_write_hits;
-	double homenode_read_misses;
-	double homenode_write_misses;
-	double dir_duty_cycle;
+  bool merged_dir;
+  double homenode_read_accesses;
+  double homenode_write_accesses;
+  double homenode_read_hits;
+  double homenode_write_hits;
+  double homenode_read_misses;
+  double homenode_write_misses;
+  double dir_duty_cycle;
 } system_L3;
-typedef struct{
-	//params
-	int number_of_inputs_of_crossbars;
-	int number_of_outputs_of_crossbars;
-	int flit_bits;
-	int input_buffer_entries_per_port;
-	int ports_of_input_buffer[20];
-	//stats
-	double crossbar_accesses;
+typedef struct {
+  // params
+  int number_of_inputs_of_crossbars;
+  int number_of_outputs_of_crossbars;
+  int flit_bits;
+  int input_buffer_entries_per_port;
+  int ports_of_input_buffer[20];
+  // stats
+  double crossbar_accesses;
 } xbar0_systemNoC;
-typedef struct{
-	//params
-	int clockrate;
-	bool type;
-	bool has_global_link;
-	char topology[20];
-	int horizontal_nodes;
-	int vertical_nodes;
-	int link_throughput;
-	int link_latency;
-	int input_ports;
-	int output_ports;
-	int virtual_channel_per_port;
-	int flit_bits;
-	int input_buffer_entries_per_vc;
-	int ports_of_input_buffer[20];
-	int dual_pump;
-	int number_of_crossbars;
-	char crossbar_type[20];
-	char crosspoint_type[20];
-	xbar0_systemNoC xbar0;
-	int arbiter_type;
-	double chip_coverage;
-	//stats
-	double total_accesses;
-	double duty_cycle;
-	double route_over_perc;
+typedef struct {
+  // params
+  int clockrate;
+  bool type;
+  bool has_global_link;
+  char topology[20];
+  int horizontal_nodes;
+  int vertical_nodes;
+  int link_throughput;
+  int link_latency;
+  int input_ports;
+  int output_ports;
+  int virtual_channel_per_port;
+  int flit_bits;
+  int input_buffer_entries_per_vc;
+  int ports_of_input_buffer[20];
+  int dual_pump;
+  int number_of_crossbars;
+  char crossbar_type[20];
+  char crosspoint_type[20];
+  xbar0_systemNoC xbar0;
+  int arbiter_type;
+  double chip_coverage;
+  // stats
+  double total_accesses;
+  double duty_cycle;
+  double route_over_perc;
 } system_NoC;
-typedef struct{
-	//params
-	int mem_tech_node;
-	int device_clock;
-	int peak_transfer_rate;
-	int internal_prefetch_of_DRAM_chip;
-	int capacity_per_channel;
-	int number_ranks;
-	int num_banks_of_DRAM_chip;
-	int Block_width_of_DRAM_chip;
-	int output_width_of_DRAM_chip;
-	int page_size_of_DRAM_chip;
-	int burstlength_of_DRAM_chip;
+typedef struct {
+  // params
+  int mem_tech_node;
+  int device_clock;
+  int peak_transfer_rate;
+  int internal_prefetch_of_DRAM_chip;
+  int capacity_per_channel;
+  int number_ranks;
+  int num_banks_of_DRAM_chip;
+  int Block_width_of_DRAM_chip;
+  int output_width_of_DRAM_chip;
+  int page_size_of_DRAM_chip;
+  int burstlength_of_DRAM_chip;
 
-	//stats
-	double memory_accesses;
-	double memory_reads;
-	double memory_writes;
-	double dram_pre;
+  // stats
+  double memory_accesses;
+  double memory_reads;
+  double memory_writes;
+  double dram_pre;
 } system_mem;
-typedef struct{
-	//params
-    //Common Param for mc and fc
-	double peak_transfer_rate;
-	int number_mcs;
-	bool withPHY;
-	int type;
+typedef struct {
+  // params
+  // Common Param for mc and fc
+  double peak_transfer_rate;
+  int number_mcs;
+  bool withPHY;
+  int type;
 
-	//FCParam
-	//stats
-	double duty_cycle;
-	double total_load_perc;
+  // FCParam
+  // stats
+  double duty_cycle;
+  double total_load_perc;
 
-	//McParam
-	int mc_clock;
-    int llc_line_length;
-	int memory_channels_per_mc;
-	int number_ranks;
-	int req_window_size_per_channel;
-	int IO_buffer_size_per_channel;
-	int databus_width;
-	int addressbus_width;
-	int PRT_entries;
-	bool LVDS;
+  // McParam
+  int mc_clock;
+  int llc_line_length;
+  int memory_channels_per_mc;
+  int number_ranks;
+  int req_window_size_per_channel;
+  int IO_buffer_size_per_channel;
+  int databus_width;
+  int addressbus_width;
+  int PRT_entries;
+  bool LVDS;
 
-	// emprical DRAM coeff
-	double dram_cmd_coeff;
-	double dram_act_coeff;
-	double dram_nop_coeff;
-	double dram_activity_coeff;
-	double dram_pre_coeff;
-	double dram_rd_coeff;
-	double dram_wr_coeff;
-	double dram_req_coeff;
-	double dram_const_coeff;
+  // emprical DRAM coeff
+  double dram_cmd_coeff;
+  double dram_act_coeff;
+  double dram_nop_coeff;
+  double dram_activity_coeff;
+  double dram_pre_coeff;
+  double dram_rd_coeff;
+  double dram_wr_coeff;
+  double dram_req_coeff;
+  double dram_const_coeff;
 
-	//stats
-	double memory_accesses;
-	double memory_reads;
-	double memory_writes;
+  // stats
+  double memory_accesses;
+  double memory_reads;
+  double memory_writes;
 
-	//dram stats
-	double dram_cmd;
-	double dram_activity;
-	double dram_nop;
-	double dram_act;
-	double dram_pre;
-	double dram_rd;
-	double dram_wr;
-	double dram_req;
-
+  // dram stats
+  double dram_cmd;
+  double dram_activity;
+  double dram_nop;
+  double dram_act;
+  double dram_pre;
+  double dram_rd;
+  double dram_wr;
+  double dram_req;
 
 } system_mc;
 
-typedef struct{
-	//params
-    int clockrate;
-	int number_units;
-	int type;
-	//stats
-	double duty_cycle;
-	double total_load_perc;
+typedef struct {
+  // params
+  int clockrate;
+  int number_units;
+  int type;
+  // stats
+  double duty_cycle;
+  double total_load_perc;
 } system_niu;
 
-typedef struct{
-	//params
-    int clockrate;
-	int number_units;
-	int num_channels;
-	int type;
-	bool withPHY;
-	//stats
-	double duty_cycle;
-	double total_load_perc;
+typedef struct {
+  // params
+  int clockrate;
+  int number_units;
+  int num_channels;
+  int type;
+  bool withPHY;
+  // stats
+  double duty_cycle;
+  double total_load_perc;
 } system_pcie;
 
-typedef struct{
-	//All number_of_* at the level of 'system' Ying 03/21/2009
-	int GPU_Architecture;
-	int number_of_cores;
-	int architecture;
-	int number_of_L1Directories;
-	int number_of_L2Directories;
-	int number_of_L2s;
-	bool Private_L2;
-	int number_of_L3s;
-	int number_of_NoCs;
-	int number_of_dir_levels;
-    int domain_size;
-    int first_level_dir;
-	// All params at the level of 'system'
-	int homogeneous_cores;
-	int homogeneous_L1Directories;
-	int homogeneous_L2Directories;
-	double core_tech_node;
-	int target_core_clockrate;
-	int target_chip_area;
-	int temperature;
-	int number_cache_levels;
-	int L1_property;
-	int L2_property;
-	int homogeneous_L2s;
-	int L3_property;
-	int homogeneous_L3s;
-	int homogeneous_NoCs;
-	int homogeneous_ccs;
-	int Max_area_deviation;
-	int Max_power_deviation;
-	int device_type;
-	bool longer_channel_device;
-	bool Embedded;
-	bool opt_dynamic_power;
-	bool opt_lakage_power;
-	bool opt_clockrate;
-	bool opt_area;
-	int interconnect_projection_type;
-	int machine_bits;
-	int virtual_address_width;
-	int physical_address_width;
-	int virtual_memory_page_size;
-	double idle_core_power;
-	double num_idle_cores;
-	int arch;
-    double total_cycles;
-	//system.core(0-n):3rd level
-    double scaling_coefficients[64];
-	system_core core[64];
-	system_L1Directory L1Directory[64];
-	system_L2Directory L2Directory[64];
-	system_L2 L2[64];
-    system_L2 l2;
-	system_L3 L3[64];
-    system_NoC NoC[64];
-    system_mem mem;
-	system_mc mc;
-	system_mc flashc;
-	system_niu niu;
-	system_pcie pcie;
+typedef struct {
+  // All number_of_* at the level of 'system' Ying 03/21/2009
+  int GPU_Architecture;
+  int number_of_cores;
+  int architecture;
+  int number_of_L1Directories;
+  int number_of_L2Directories;
+  int number_of_L2s;
+  bool Private_L2;
+  int number_of_L3s;
+  int number_of_NoCs;
+  int number_of_dir_levels;
+  int domain_size;
+  int first_level_dir;
+  // All params at the level of 'system'
+  int homogeneous_cores;
+  int homogeneous_L1Directories;
+  int homogeneous_L2Directories;
+  double core_tech_node;
+  int target_core_clockrate;
+  int target_chip_area;
+  int temperature;
+  int number_cache_levels;
+  int L1_property;
+  int L2_property;
+  int homogeneous_L2s;
+  int L3_property;
+  int homogeneous_L3s;
+  int homogeneous_NoCs;
+  int homogeneous_ccs;
+  int Max_area_deviation;
+  int Max_power_deviation;
+  int device_type;
+  bool longer_channel_device;
+  bool Embedded;
+  bool opt_dynamic_power;
+  bool opt_lakage_power;
+  bool opt_clockrate;
+  bool opt_area;
+  int interconnect_projection_type;
+  int machine_bits;
+  int virtual_address_width;
+  int physical_address_width;
+  int virtual_memory_page_size;
+  double idle_core_power;
+  double num_idle_cores;
+  int arch;
+  double total_cycles;
+  // system.core(0-n):3rd level
+  double scaling_coefficients[64];
+  system_core core[64];
+  system_L1Directory L1Directory[64];
+  system_L2Directory L2Directory[64];
+  system_L2 L2[64];
+  system_L2 l2;
+  system_L3 L3[64];
+  system_NoC NoC[64];
+  system_mem mem;
+  system_mc mc;
+  system_mc flashc;
+  system_niu niu;
+  system_pcie pcie;
 } root_system;
 
-class ParseXML
-{
-public:
-	void parse(char* filepath);
-    void initialize();
-public:
-	root_system sys;
+class ParseXML {
+ public:
+  void parse(char* filepath);
+  void initialize();
+
+ public:
+  root_system sys;
 };
 
-
 #endif /* XML_PARSE_H_ */
-
-
-
-

--- a/src/gpuwattch/arch_const.h
+++ b/src/gpuwattch/arch_const.h
@@ -32,202 +32,189 @@
 #ifndef ARCH_CONST_H_
 #define ARCH_CONST_H_
 
-typedef struct{
-	unsigned int capacity;
-	unsigned int assoc;//fully
-	unsigned int blocksize;
+typedef struct {
+  unsigned int capacity;
+  unsigned int assoc;  // fully
+  unsigned int blocksize;
 } array_inputs;
 
-//Do Not change, unless you want to bypass the XML interface and do not care about the default values.
-//Global parameters
-const int  			number_of_cores =	8;
-const int  			number_of_L2s 	=	1;
-const int 			number_of_L3s	=	1;
-const int 			number_of_NoCs	=	1;
+// Do Not change, unless you want to bypass the XML interface and do not care
+// about the default values. Global parameters
+const int number_of_cores = 8;
+const int number_of_L2s = 1;
+const int number_of_L3s = 1;
+const int number_of_NoCs = 1;
 
-const double 		archi_F_sz_nm	=	90.0;
-const unsigned int 	dev_type		=	0;
-const double 		CLOCKRATE 		= 	1.2*1e9;
-const double 		AF 				= 	0.5;
-//const bool 			inorder			=	true;
-const bool			embedded		=	false; //NEW
+const double archi_F_sz_nm = 90.0;
+const unsigned int dev_type = 0;
+const double CLOCKRATE = 1.2 * 1e9;
+const double AF = 0.5;
+// const bool 			inorder			=	true;
+const bool embedded = false;  // NEW
 
-const bool 			homogeneous_cores	= 	true;
-const bool 			temperature		=	360;
-const int			number_cache_levels	=	3;
-const int			L1_property		=	0; //private 0; coherent 1, shared 2.
-const int		 	L2_property		=	2;
-const bool	    	homogeneous_L2s	=	true;
-const bool		    L3_property		= 	2;
-const bool 			homogeneous_L3s	=	true;
-const double 		Max_area_deviation	=	50;
-const double	    Max_dynamic_deviation	=50; //New
-const int 			opt_dynamic_power	=	1;
-const int 			opt_lakage_power	=	0;
-const int		 	opt_area			=	0;
-const int			interconnect_projection_type	=	0;
+const bool homogeneous_cores = true;
+const bool temperature = 360;
+const int number_cache_levels = 3;
+const int L1_property = 0;  // private 0; coherent 1, shared 2.
+const int L2_property = 2;
+const bool homogeneous_L2s = true;
+const bool L3_property = 2;
+const bool homogeneous_L3s = true;
+const double Max_area_deviation = 50;
+const double Max_dynamic_deviation = 50;  // New
+const int opt_dynamic_power = 1;
+const int opt_lakage_power = 0;
+const int opt_area = 0;
+const int interconnect_projection_type = 0;
 
 //******************************Core Parameters
 #if (inorder)
-const int opcode_length			= 	8;//Niagara
-const int reg_length			=	5;//Niagara
-const int instruction_length	=	32;//Niagara
-const int data_width			=	64;
+const int opcode_length = 8;        // Niagara
+const int reg_length = 5;           // Niagara
+const int instruction_length = 32;  // Niagara
+const int data_width = 64;
 #else
-const int opcode_length			= 	8;//16;//Niagara
-const int reg_length			=	7;//Niagara
-const int instruction_length	=	32;//Niagara
-const int data_width			=	64;
+const int opcode_length = 8;        // 16;//Niagara
+const int reg_length = 7;           // Niagara
+const int instruction_length = 32;  // Niagara
+const int data_width = 64;
 #endif
 
+// Caches
+// itlb
+const int itlbsize = 512;
+const int itlbassoc = 0;  // fully
+const int itlbblocksize = 8;
+// icache
+const int icachesize = 32768;
+const int icacheassoc = 4;
+const int icacheblocksize = 32;
+// dtlb
+const int dtlbsize = 512;
+const int dtlbassoc = 0;  // fully
+const int dtlbblocksize = 8;
+// dcache
+const int dcachesize = 32768;
+const int dcacheassoc = 4;
+const int dcacheblocksize = 32;
+const int dcache_write_buffers = 8;
 
-//Caches
-//itlb
-const int itlbsize=512;
-const int itlbassoc=0;//fully
-const int itlbblocksize=8;
-//icache
-const int icachesize=32768;
-const int icacheassoc=4;
-const int icacheblocksize=32;
-//dtlb
-const int dtlbsize=512;
-const int dtlbassoc=0;//fully
-const int dtlbblocksize=8;
-//dcache
-const int dcachesize=32768;
-const int dcacheassoc=4;
-const int dcacheblocksize=32;
-const int dcache_write_buffers=8;
+// cache controllers
+// IB,
+const int numIBEntries = 64;
+const int IBsize = 64;  // 2*4*instruction_length/8*2;
+const int IBassoc = 0;  // In Niagara it is still fully associ
+const int IBblocksize = 4;
 
-//cache controllers
-//IB,
-const int numIBEntries			=	64;
-const int IBsize				=	64;//2*4*instruction_length/8*2;
-const int IBassoc				=	0;//In Niagara it is still fully associ
-const int IBblocksize			=	4;
+// IFB and MIL should have the same parameters CAM
+const int IFBsize = 128;  //
+const int IFBassoc = 0;   // In Niagara it is still fully associ
+const int IFBblocksize = 4;
 
-//IFB and MIL should have the same parameters CAM
-const int IFBsize=128;//
-const int IFBassoc=0;//In Niagara it is still fully associ
-const int IFBblocksize=4;
+const int icache_write_buffers = 8;
 
+// register file RAM
+const int regfilesize = 5760;
+const int regfileassoc = 1;
+const int regfileblocksize = 18;
+// regwin  RAM
+const int regwinsize = 256;
+const int regwinassoc = 1;
+const int regwinblocksize = 8;
 
+// store buffer, lsq
+const int lsqsize = 512;
+const int lsqassoc = 0;
+const int lsqblocksize = 8;
 
+// data fill queue RAM
+const int dfqsize = 1024;
+const int dfqassoc = 1;
+const int dfqblocksize = 16;
 
-const int icache_write_buffers=8;
+// outside the cores
+// L2 cache bank
+const int l2cachesize = 262144;
+const int l2cacheassoc = 16;
+const int l2cacheblocksize = 64;
 
-//register file RAM
-const int regfilesize=5760;
-const int regfileassoc=1;
-const int regfileblocksize=18;
-//regwin  RAM
-const int regwinsize=256;
-const int regwinassoc=1;
-const int regwinblocksize=8;
+// L2 directory
+const int l2dirsize = 1024;
+const int l2dirassoc = 0;
+const int l2dirblocksize = 2;
 
-
-
-//store buffer, lsq
-const int lsqsize=512;
-const int lsqassoc=0;
-const int lsqblocksize=8;
-
-//data fill queue RAM
-const int dfqsize=1024;
-const int dfqassoc=1;
-const int dfqblocksize=16;
-
-//outside the cores
-//L2 cache bank
-const int l2cachesize=262144;
-const int l2cacheassoc=16;
-const int l2cacheblocksize=64;
-
-//L2 directory
-const int l2dirsize=1024;
-const int l2dirassoc=0;
-const int l2dirblocksize=2;
-
-//crossbar
-//PCX
+// crossbar
+// PCX
 const int PCX_NUMBER_INPUT_PORTS_CROSSBAR = 8;
 const int PCX_NUMBER_OUTPUT_PORTS_CROSSBAR = 9;
-const int PCX_NUMBER_SIGNALS_PER_PORT_CROSSBAR =144;
-//PCX buffer RAM
-const int pcx_buffersize=1024;
-const int pcx_bufferassoc=1;
-const int pcx_bufferblocksize=32;
-const int pcx_numbuffer=5;
-//pcx arbiter
-const int pcx_arbsize=128;
-const int pcx_arbassoc=1;
-const int pcx_arbblocksize=2;
-const int pcx_numarb=5;
+const int PCX_NUMBER_SIGNALS_PER_PORT_CROSSBAR = 144;
+// PCX buffer RAM
+const int pcx_buffersize = 1024;
+const int pcx_bufferassoc = 1;
+const int pcx_bufferblocksize = 32;
+const int pcx_numbuffer = 5;
+// pcx arbiter
+const int pcx_arbsize = 128;
+const int pcx_arbassoc = 1;
+const int pcx_arbblocksize = 2;
+const int pcx_numarb = 5;
 
-//CPX
+// CPX
 const int CPX_NUMBER_INPUT_PORTS_CROSSBAR = 5;
 const int CPX_NUMBER_OUTPUT_PORTS_CROSSBAR = 8;
-const int CPX_NUMBER_SIGNALS_PER_PORT_CROSSBAR =150;
-//CPX buffer RAM
-const int cpx_buffersize=1024;
-const int cpx_bufferassoc=1;
-const int cpx_bufferblocksize=32;
-const int cpx_numbuffer=8;
-//cpx arbiter
-const int cpx_arbsize=128;
-const int cpx_arbassoc=1;
-const int cpx_arbblocksize=2;
-const int cpx_numarb=8;
+const int CPX_NUMBER_SIGNALS_PER_PORT_CROSSBAR = 150;
+// CPX buffer RAM
+const int cpx_buffersize = 1024;
+const int cpx_bufferassoc = 1;
+const int cpx_bufferblocksize = 32;
+const int cpx_numbuffer = 8;
+// cpx arbiter
+const int cpx_arbsize = 128;
+const int cpx_arbassoc = 1;
+const int cpx_arbblocksize = 2;
+const int cpx_numarb = 8;
 
+const int numPhysFloatRegs = 256;
+const int numPhysIntRegs = 32;
+const int numROBEntries = 192;
+const int umRobs = 1;
 
+const int BTBEntries = 4096;
+const int BTBTagSize = 16;
+const int LFSTSize = 1024;
+const int LQEntries = 32;
+const int RASSize = 16;
+const int SQEntries = 32;
+const int SSITSize = 1024;
+const int activity = 0;
+const int backComSize = 5;
+const int cachePorts = 200;
+const int choiceCtrBits = 2;
+const int choicePredictorSize = 8192;
 
+const int commitWidth = 8;
+const int decodeWidth = 8;
+const int dispatchWidth = 8;
+const int fetchWidth = 8;
+const int issueWidth = 1;
+const int renameWidth = 8;
+// what is this forwardComSize=5??
 
+const int globalCtrBits = 2;
+const int globalHistoryBits = 13;
+const int globalPredictorSize = 8192;
 
-const int numPhysFloatRegs=256;
-const int numPhysIntRegs=32;
-const int numROBEntries=192;
-const int umRobs=1;
+const int localCtrBits = 2;
+const int localHistoryBits = 11;
+const int localHistoryTableSize = 2048;
+const int localPredictorSize = 2048;
 
-const int BTBEntries=4096;
-const int BTBTagSize=16;
-const int LFSTSize=1024;
-const int LQEntries=32;
-const int RASSize=16;
-const int SQEntries=32;
-const int SSITSize=1024;
-const int activity=0;
-const int backComSize=5;
-const int cachePorts=200;
-const int choiceCtrBits=2;
-const int choicePredictorSize=8192;
-
-
-const int commitWidth=8;
-const int decodeWidth=8;
-const int dispatchWidth=8;
-const int fetchWidth=8;
-const int issueWidth=1;
-const int renameWidth=8;
-//what is this forwardComSize=5??
-
-const int globalCtrBits=2;
-const int globalHistoryBits=13;
-const int globalPredictorSize=8192;
-
-
-
-const int localCtrBits=2;
-const int localHistoryBits=11;
-const int localHistoryTableSize=2048;
-const int localPredictorSize=2048;
-
-const double Woutdrvnandn	=30 *0.09;//(24.0 * LSCALE)
-const double Woutdrvnandp	=12.5 *0.09;//(10.0 * LSCALE)
-const double Woutdrvnorn	=7.5*0.09;//(6.0 * LSCALE)
-const double Woutdrvnorp  =50 * 0.09;//	(40.0 * LSCALE)
-const double Woutdrivern	=60*0.09;//(48.0 * LSCALE)
-const double Woutdriverp	=100 * 0.09;//(80.0 * LSCALE)
+const double Woutdrvnandn = 30 * 0.09;    //(24.0 * LSCALE)
+const double Woutdrvnandp = 12.5 * 0.09;  //(10.0 * LSCALE)
+const double Woutdrvnorn = 7.5 * 0.09;    //(6.0 * LSCALE)
+const double Woutdrvnorp = 50 * 0.09;     //	(40.0 * LSCALE)
+const double Woutdrivern = 60 * 0.09;     //(48.0 * LSCALE)
+const double Woutdriverp = 100 * 0.09;    //(80.0 * LSCALE)
 
 /*
 smtCommitPolicy=RoundRobin
@@ -270,7 +257,6 @@ mem_side=system.tol2bus.port[2]
 */
 
 //[system.cpu0.dtb]
-//type=AlphaDT
-
+// type=AlphaDT
 
 #endif /* ARCH_CONST_H_ */

--- a/src/gpuwattch/arch_const.h
+++ b/src/gpuwattch/arch_const.h
@@ -32,202 +32,190 @@
 #ifndef ARCH_CONST_H_
 #define ARCH_CONST_H_
 
-typedef struct{
-	unsigned int capacity;
-	unsigned int assoc;//fully
-	unsigned int blocksize;
+typedef struct {
+  unsigned int capacity;
+  unsigned int assoc;  // fully
+  unsigned int blocksize;
 } array_inputs;
 
-//Do Not change, unless you want to bypass the XML interface and do not care about the default values.
-//Global parameters
-const int  			number_of_cores =	8;
-const int  			number_of_L2s 	=	1;
-const int 			number_of_L3s	=	1;
-const int 			number_of_NoCs	=	1;
+// Do Not change, unless you want to bypass the XML interface and do not care
+// about the default values.
+// Global parameters
+const int number_of_cores = 8;
+const int number_of_L2s = 1;
+const int number_of_L3s = 1;
+const int number_of_NoCs = 1;
 
-const double 		archi_F_sz_nm	=	90.0;
-const unsigned int 	dev_type		=	0;
-const double 		CLOCKRATE 		= 	1.2*1e9;
-const double 		AF 				= 	0.5;
-//const bool 			inorder			=	true;
-const bool			embedded		=	false; //NEW
+const double archi_F_sz_nm = 90.0;
+const unsigned int dev_type = 0;
+const double CLOCKRATE = 1.2 * 1e9;
+const double AF = 0.5;
+// const bool 			inorder			=	true;
+const bool embedded = false;  // NEW
 
-const bool 			homogeneous_cores	= 	true;
-const bool 			temperature		=	360;
-const int			number_cache_levels	=	3;
-const int			L1_property		=	0; //private 0; coherent 1, shared 2.
-const int		 	L2_property		=	2;
-const bool	    	homogeneous_L2s	=	true;
-const bool		    L3_property		= 	2;
-const bool 			homogeneous_L3s	=	true;
-const double 		Max_area_deviation	=	50;
-const double	    Max_dynamic_deviation	=50; //New
-const int 			opt_dynamic_power	=	1;
-const int 			opt_lakage_power	=	0;
-const int		 	opt_area			=	0;
-const int			interconnect_projection_type	=	0;
+const bool homogeneous_cores = true;
+const bool temperature = 360;
+const int number_cache_levels = 3;
+const int L1_property = 0;  // private 0; coherent 1, shared 2.
+const int L2_property = 2;
+const bool homogeneous_L2s = true;
+const bool L3_property = 2;
+const bool homogeneous_L3s = true;
+const double Max_area_deviation = 50;
+const double Max_dynamic_deviation = 50;  // New
+const int opt_dynamic_power = 1;
+const int opt_lakage_power = 0;
+const int opt_area = 0;
+const int interconnect_projection_type = 0;
 
 //******************************Core Parameters
 #if (inorder)
-const int opcode_length			= 	8;//Niagara
-const int reg_length			=	5;//Niagara
-const int instruction_length	=	32;//Niagara
-const int data_width			=	64;
+const int opcode_length = 8;        // Niagara
+const int reg_length = 5;           // Niagara
+const int instruction_length = 32;  // Niagara
+const int data_width = 64;
 #else
-const int opcode_length			= 	8;//16;//Niagara
-const int reg_length			=	7;//Niagara
-const int instruction_length	=	32;//Niagara
-const int data_width			=	64;
+const int opcode_length = 8;        // 16;//Niagara
+const int reg_length = 7;           // Niagara
+const int instruction_length = 32;  // Niagara
+const int data_width = 64;
 #endif
 
+// Caches
+// itlb
+const int itlbsize = 512;
+const int itlbassoc = 0;  // fully
+const int itlbblocksize = 8;
+// icache
+const int icachesize = 32768;
+const int icacheassoc = 4;
+const int icacheblocksize = 32;
+// dtlb
+const int dtlbsize = 512;
+const int dtlbassoc = 0;  // fully
+const int dtlbblocksize = 8;
+// dcache
+const int dcachesize = 32768;
+const int dcacheassoc = 4;
+const int dcacheblocksize = 32;
+const int dcache_write_buffers = 8;
 
-//Caches
-//itlb
-const int itlbsize=512;
-const int itlbassoc=0;//fully
-const int itlbblocksize=8;
-//icache
-const int icachesize=32768;
-const int icacheassoc=4;
-const int icacheblocksize=32;
-//dtlb
-const int dtlbsize=512;
-const int dtlbassoc=0;//fully
-const int dtlbblocksize=8;
-//dcache
-const int dcachesize=32768;
-const int dcacheassoc=4;
-const int dcacheblocksize=32;
-const int dcache_write_buffers=8;
+// cache controllers
+// IB,
+const int numIBEntries = 64;
+const int IBsize = 64;  // 2*4*instruction_length/8*2;
+const int IBassoc = 0;  // In Niagara it is still fully associ
+const int IBblocksize = 4;
 
-//cache controllers
-//IB,
-const int numIBEntries			=	64;
-const int IBsize				=	64;//2*4*instruction_length/8*2;
-const int IBassoc				=	0;//In Niagara it is still fully associ
-const int IBblocksize			=	4;
+// IFB and MIL should have the same parameters CAM
+const int IFBsize = 128;  //
+const int IFBassoc = 0;   // In Niagara it is still fully associ
+const int IFBblocksize = 4;
 
-//IFB and MIL should have the same parameters CAM
-const int IFBsize=128;//
-const int IFBassoc=0;//In Niagara it is still fully associ
-const int IFBblocksize=4;
+const int icache_write_buffers = 8;
 
+// register file RAM
+const int regfilesize = 5760;
+const int regfileassoc = 1;
+const int regfileblocksize = 18;
+// regwin  RAM
+const int regwinsize = 256;
+const int regwinassoc = 1;
+const int regwinblocksize = 8;
 
+// store buffer, lsq
+const int lsqsize = 512;
+const int lsqassoc = 0;
+const int lsqblocksize = 8;
 
+// data fill queue RAM
+const int dfqsize = 1024;
+const int dfqassoc = 1;
+const int dfqblocksize = 16;
 
-const int icache_write_buffers=8;
+// outside the cores
+// L2 cache bank
+const int l2cachesize = 262144;
+const int l2cacheassoc = 16;
+const int l2cacheblocksize = 64;
 
-//register file RAM
-const int regfilesize=5760;
-const int regfileassoc=1;
-const int regfileblocksize=18;
-//regwin  RAM
-const int regwinsize=256;
-const int regwinassoc=1;
-const int regwinblocksize=8;
+// L2 directory
+const int l2dirsize = 1024;
+const int l2dirassoc = 0;
+const int l2dirblocksize = 2;
 
-
-
-//store buffer, lsq
-const int lsqsize=512;
-const int lsqassoc=0;
-const int lsqblocksize=8;
-
-//data fill queue RAM
-const int dfqsize=1024;
-const int dfqassoc=1;
-const int dfqblocksize=16;
-
-//outside the cores
-//L2 cache bank
-const int l2cachesize=262144;
-const int l2cacheassoc=16;
-const int l2cacheblocksize=64;
-
-//L2 directory
-const int l2dirsize=1024;
-const int l2dirassoc=0;
-const int l2dirblocksize=2;
-
-//crossbar
-//PCX
+// crossbar
+// PCX
 const int PCX_NUMBER_INPUT_PORTS_CROSSBAR = 8;
 const int PCX_NUMBER_OUTPUT_PORTS_CROSSBAR = 9;
-const int PCX_NUMBER_SIGNALS_PER_PORT_CROSSBAR =144;
-//PCX buffer RAM
-const int pcx_buffersize=1024;
-const int pcx_bufferassoc=1;
-const int pcx_bufferblocksize=32;
-const int pcx_numbuffer=5;
-//pcx arbiter
-const int pcx_arbsize=128;
-const int pcx_arbassoc=1;
-const int pcx_arbblocksize=2;
-const int pcx_numarb=5;
+const int PCX_NUMBER_SIGNALS_PER_PORT_CROSSBAR = 144;
+// PCX buffer RAM
+const int pcx_buffersize = 1024;
+const int pcx_bufferassoc = 1;
+const int pcx_bufferblocksize = 32;
+const int pcx_numbuffer = 5;
+// pcx arbiter
+const int pcx_arbsize = 128;
+const int pcx_arbassoc = 1;
+const int pcx_arbblocksize = 2;
+const int pcx_numarb = 5;
 
-//CPX
+// CPX
 const int CPX_NUMBER_INPUT_PORTS_CROSSBAR = 5;
 const int CPX_NUMBER_OUTPUT_PORTS_CROSSBAR = 8;
-const int CPX_NUMBER_SIGNALS_PER_PORT_CROSSBAR =150;
-//CPX buffer RAM
-const int cpx_buffersize=1024;
-const int cpx_bufferassoc=1;
-const int cpx_bufferblocksize=32;
-const int cpx_numbuffer=8;
-//cpx arbiter
-const int cpx_arbsize=128;
-const int cpx_arbassoc=1;
-const int cpx_arbblocksize=2;
-const int cpx_numarb=8;
+const int CPX_NUMBER_SIGNALS_PER_PORT_CROSSBAR = 150;
+// CPX buffer RAM
+const int cpx_buffersize = 1024;
+const int cpx_bufferassoc = 1;
+const int cpx_bufferblocksize = 32;
+const int cpx_numbuffer = 8;
+// cpx arbiter
+const int cpx_arbsize = 128;
+const int cpx_arbassoc = 1;
+const int cpx_arbblocksize = 2;
+const int cpx_numarb = 8;
 
+const int numPhysFloatRegs = 256;
+const int numPhysIntRegs = 32;
+const int numROBEntries = 192;
+const int umRobs = 1;
 
+const int BTBEntries = 4096;
+const int BTBTagSize = 16;
+const int LFSTSize = 1024;
+const int LQEntries = 32;
+const int RASSize = 16;
+const int SQEntries = 32;
+const int SSITSize = 1024;
+const int activity = 0;
+const int backComSize = 5;
+const int cachePorts = 200;
+const int choiceCtrBits = 2;
+const int choicePredictorSize = 8192;
 
+const int commitWidth = 8;
+const int decodeWidth = 8;
+const int dispatchWidth = 8;
+const int fetchWidth = 8;
+const int issueWidth = 1;
+const int renameWidth = 8;
+// what is this forwardComSize=5??
 
+const int globalCtrBits = 2;
+const int globalHistoryBits = 13;
+const int globalPredictorSize = 8192;
 
-const int numPhysFloatRegs=256;
-const int numPhysIntRegs=32;
-const int numROBEntries=192;
-const int umRobs=1;
+const int localCtrBits = 2;
+const int localHistoryBits = 11;
+const int localHistoryTableSize = 2048;
+const int localPredictorSize = 2048;
 
-const int BTBEntries=4096;
-const int BTBTagSize=16;
-const int LFSTSize=1024;
-const int LQEntries=32;
-const int RASSize=16;
-const int SQEntries=32;
-const int SSITSize=1024;
-const int activity=0;
-const int backComSize=5;
-const int cachePorts=200;
-const int choiceCtrBits=2;
-const int choicePredictorSize=8192;
-
-
-const int commitWidth=8;
-const int decodeWidth=8;
-const int dispatchWidth=8;
-const int fetchWidth=8;
-const int issueWidth=1;
-const int renameWidth=8;
-//what is this forwardComSize=5??
-
-const int globalCtrBits=2;
-const int globalHistoryBits=13;
-const int globalPredictorSize=8192;
-
-
-
-const int localCtrBits=2;
-const int localHistoryBits=11;
-const int localHistoryTableSize=2048;
-const int localPredictorSize=2048;
-
-const double Woutdrvnandn	=30 *0.09;//(24.0 * LSCALE)
-const double Woutdrvnandp	=12.5 *0.09;//(10.0 * LSCALE)
-const double Woutdrvnorn	=7.5*0.09;//(6.0 * LSCALE)
-const double Woutdrvnorp  =50 * 0.09;//	(40.0 * LSCALE)
-const double Woutdrivern	=60*0.09;//(48.0 * LSCALE)
-const double Woutdriverp	=100 * 0.09;//(80.0 * LSCALE)
+const double Woutdrvnandn = 30 * 0.09;    //(24.0 * LSCALE)
+const double Woutdrvnandp = 12.5 * 0.09;  //(10.0 * LSCALE)
+const double Woutdrvnorn = 7.5 * 0.09;    //(6.0 * LSCALE)
+const double Woutdrvnorp = 50 * 0.09;     //	(40.0 * LSCALE)
+const double Woutdrivern = 60 * 0.09;     //(48.0 * LSCALE)
+const double Woutdriverp = 100 * 0.09;    //(80.0 * LSCALE)
 
 /*
 smtCommitPolicy=RoundRobin
@@ -270,7 +258,6 @@ mem_side=system.tol2bus.port[2]
 */
 
 //[system.cpu0.dtb]
-//type=AlphaDT
-
+// type=AlphaDT
 
 #endif /* ARCH_CONST_H_ */

--- a/src/gpuwattch/arch_const.h
+++ b/src/gpuwattch/arch_const.h
@@ -32,190 +32,202 @@
 #ifndef ARCH_CONST_H_
 #define ARCH_CONST_H_
 
-typedef struct {
-  unsigned int capacity;
-  unsigned int assoc;  // fully
-  unsigned int blocksize;
+typedef struct{
+	unsigned int capacity;
+	unsigned int assoc;//fully
+	unsigned int blocksize;
 } array_inputs;
 
-// Do Not change, unless you want to bypass the XML interface and do not care
-// about the default values.
-// Global parameters
-const int number_of_cores = 8;
-const int number_of_L2s = 1;
-const int number_of_L3s = 1;
-const int number_of_NoCs = 1;
+//Do Not change, unless you want to bypass the XML interface and do not care about the default values.
+//Global parameters
+const int  			number_of_cores =	8;
+const int  			number_of_L2s 	=	1;
+const int 			number_of_L3s	=	1;
+const int 			number_of_NoCs	=	1;
 
-const double archi_F_sz_nm = 90.0;
-const unsigned int dev_type = 0;
-const double CLOCKRATE = 1.2 * 1e9;
-const double AF = 0.5;
-// const bool 			inorder			=	true;
-const bool embedded = false;  // NEW
+const double 		archi_F_sz_nm	=	90.0;
+const unsigned int 	dev_type		=	0;
+const double 		CLOCKRATE 		= 	1.2*1e9;
+const double 		AF 				= 	0.5;
+//const bool 			inorder			=	true;
+const bool			embedded		=	false; //NEW
 
-const bool homogeneous_cores = true;
-const bool temperature = 360;
-const int number_cache_levels = 3;
-const int L1_property = 0;  // private 0; coherent 1, shared 2.
-const int L2_property = 2;
-const bool homogeneous_L2s = true;
-const bool L3_property = 2;
-const bool homogeneous_L3s = true;
-const double Max_area_deviation = 50;
-const double Max_dynamic_deviation = 50;  // New
-const int opt_dynamic_power = 1;
-const int opt_lakage_power = 0;
-const int opt_area = 0;
-const int interconnect_projection_type = 0;
+const bool 			homogeneous_cores	= 	true;
+const bool 			temperature		=	360;
+const int			number_cache_levels	=	3;
+const int			L1_property		=	0; //private 0; coherent 1, shared 2.
+const int		 	L2_property		=	2;
+const bool	    	homogeneous_L2s	=	true;
+const bool		    L3_property		= 	2;
+const bool 			homogeneous_L3s	=	true;
+const double 		Max_area_deviation	=	50;
+const double	    Max_dynamic_deviation	=50; //New
+const int 			opt_dynamic_power	=	1;
+const int 			opt_lakage_power	=	0;
+const int		 	opt_area			=	0;
+const int			interconnect_projection_type	=	0;
 
 //******************************Core Parameters
 #if (inorder)
-const int opcode_length = 8;        // Niagara
-const int reg_length = 5;           // Niagara
-const int instruction_length = 32;  // Niagara
-const int data_width = 64;
+const int opcode_length			= 	8;//Niagara
+const int reg_length			=	5;//Niagara
+const int instruction_length	=	32;//Niagara
+const int data_width			=	64;
 #else
-const int opcode_length = 8;        // 16;//Niagara
-const int reg_length = 7;           // Niagara
-const int instruction_length = 32;  // Niagara
-const int data_width = 64;
+const int opcode_length			= 	8;//16;//Niagara
+const int reg_length			=	7;//Niagara
+const int instruction_length	=	32;//Niagara
+const int data_width			=	64;
 #endif
 
-// Caches
-// itlb
-const int itlbsize = 512;
-const int itlbassoc = 0;  // fully
-const int itlbblocksize = 8;
-// icache
-const int icachesize = 32768;
-const int icacheassoc = 4;
-const int icacheblocksize = 32;
-// dtlb
-const int dtlbsize = 512;
-const int dtlbassoc = 0;  // fully
-const int dtlbblocksize = 8;
-// dcache
-const int dcachesize = 32768;
-const int dcacheassoc = 4;
-const int dcacheblocksize = 32;
-const int dcache_write_buffers = 8;
 
-// cache controllers
-// IB,
-const int numIBEntries = 64;
-const int IBsize = 64;  // 2*4*instruction_length/8*2;
-const int IBassoc = 0;  // In Niagara it is still fully associ
-const int IBblocksize = 4;
+//Caches
+//itlb
+const int itlbsize=512;
+const int itlbassoc=0;//fully
+const int itlbblocksize=8;
+//icache
+const int icachesize=32768;
+const int icacheassoc=4;
+const int icacheblocksize=32;
+//dtlb
+const int dtlbsize=512;
+const int dtlbassoc=0;//fully
+const int dtlbblocksize=8;
+//dcache
+const int dcachesize=32768;
+const int dcacheassoc=4;
+const int dcacheblocksize=32;
+const int dcache_write_buffers=8;
 
-// IFB and MIL should have the same parameters CAM
-const int IFBsize = 128;  //
-const int IFBassoc = 0;   // In Niagara it is still fully associ
-const int IFBblocksize = 4;
+//cache controllers
+//IB,
+const int numIBEntries			=	64;
+const int IBsize				=	64;//2*4*instruction_length/8*2;
+const int IBassoc				=	0;//In Niagara it is still fully associ
+const int IBblocksize			=	4;
 
-const int icache_write_buffers = 8;
+//IFB and MIL should have the same parameters CAM
+const int IFBsize=128;//
+const int IFBassoc=0;//In Niagara it is still fully associ
+const int IFBblocksize=4;
 
-// register file RAM
-const int regfilesize = 5760;
-const int regfileassoc = 1;
-const int regfileblocksize = 18;
-// regwin  RAM
-const int regwinsize = 256;
-const int regwinassoc = 1;
-const int regwinblocksize = 8;
 
-// store buffer, lsq
-const int lsqsize = 512;
-const int lsqassoc = 0;
-const int lsqblocksize = 8;
 
-// data fill queue RAM
-const int dfqsize = 1024;
-const int dfqassoc = 1;
-const int dfqblocksize = 16;
 
-// outside the cores
-// L2 cache bank
-const int l2cachesize = 262144;
-const int l2cacheassoc = 16;
-const int l2cacheblocksize = 64;
+const int icache_write_buffers=8;
 
-// L2 directory
-const int l2dirsize = 1024;
-const int l2dirassoc = 0;
-const int l2dirblocksize = 2;
+//register file RAM
+const int regfilesize=5760;
+const int regfileassoc=1;
+const int regfileblocksize=18;
+//regwin  RAM
+const int regwinsize=256;
+const int regwinassoc=1;
+const int regwinblocksize=8;
 
-// crossbar
-// PCX
+
+
+//store buffer, lsq
+const int lsqsize=512;
+const int lsqassoc=0;
+const int lsqblocksize=8;
+
+//data fill queue RAM
+const int dfqsize=1024;
+const int dfqassoc=1;
+const int dfqblocksize=16;
+
+//outside the cores
+//L2 cache bank
+const int l2cachesize=262144;
+const int l2cacheassoc=16;
+const int l2cacheblocksize=64;
+
+//L2 directory
+const int l2dirsize=1024;
+const int l2dirassoc=0;
+const int l2dirblocksize=2;
+
+//crossbar
+//PCX
 const int PCX_NUMBER_INPUT_PORTS_CROSSBAR = 8;
 const int PCX_NUMBER_OUTPUT_PORTS_CROSSBAR = 9;
-const int PCX_NUMBER_SIGNALS_PER_PORT_CROSSBAR = 144;
-// PCX buffer RAM
-const int pcx_buffersize = 1024;
-const int pcx_bufferassoc = 1;
-const int pcx_bufferblocksize = 32;
-const int pcx_numbuffer = 5;
-// pcx arbiter
-const int pcx_arbsize = 128;
-const int pcx_arbassoc = 1;
-const int pcx_arbblocksize = 2;
-const int pcx_numarb = 5;
+const int PCX_NUMBER_SIGNALS_PER_PORT_CROSSBAR =144;
+//PCX buffer RAM
+const int pcx_buffersize=1024;
+const int pcx_bufferassoc=1;
+const int pcx_bufferblocksize=32;
+const int pcx_numbuffer=5;
+//pcx arbiter
+const int pcx_arbsize=128;
+const int pcx_arbassoc=1;
+const int pcx_arbblocksize=2;
+const int pcx_numarb=5;
 
-// CPX
+//CPX
 const int CPX_NUMBER_INPUT_PORTS_CROSSBAR = 5;
 const int CPX_NUMBER_OUTPUT_PORTS_CROSSBAR = 8;
-const int CPX_NUMBER_SIGNALS_PER_PORT_CROSSBAR = 150;
-// CPX buffer RAM
-const int cpx_buffersize = 1024;
-const int cpx_bufferassoc = 1;
-const int cpx_bufferblocksize = 32;
-const int cpx_numbuffer = 8;
-// cpx arbiter
-const int cpx_arbsize = 128;
-const int cpx_arbassoc = 1;
-const int cpx_arbblocksize = 2;
-const int cpx_numarb = 8;
+const int CPX_NUMBER_SIGNALS_PER_PORT_CROSSBAR =150;
+//CPX buffer RAM
+const int cpx_buffersize=1024;
+const int cpx_bufferassoc=1;
+const int cpx_bufferblocksize=32;
+const int cpx_numbuffer=8;
+//cpx arbiter
+const int cpx_arbsize=128;
+const int cpx_arbassoc=1;
+const int cpx_arbblocksize=2;
+const int cpx_numarb=8;
 
-const int numPhysFloatRegs = 256;
-const int numPhysIntRegs = 32;
-const int numROBEntries = 192;
-const int umRobs = 1;
 
-const int BTBEntries = 4096;
-const int BTBTagSize = 16;
-const int LFSTSize = 1024;
-const int LQEntries = 32;
-const int RASSize = 16;
-const int SQEntries = 32;
-const int SSITSize = 1024;
-const int activity = 0;
-const int backComSize = 5;
-const int cachePorts = 200;
-const int choiceCtrBits = 2;
-const int choicePredictorSize = 8192;
 
-const int commitWidth = 8;
-const int decodeWidth = 8;
-const int dispatchWidth = 8;
-const int fetchWidth = 8;
-const int issueWidth = 1;
-const int renameWidth = 8;
-// what is this forwardComSize=5??
 
-const int globalCtrBits = 2;
-const int globalHistoryBits = 13;
-const int globalPredictorSize = 8192;
 
-const int localCtrBits = 2;
-const int localHistoryBits = 11;
-const int localHistoryTableSize = 2048;
-const int localPredictorSize = 2048;
+const int numPhysFloatRegs=256;
+const int numPhysIntRegs=32;
+const int numROBEntries=192;
+const int umRobs=1;
 
-const double Woutdrvnandn = 30 * 0.09;    //(24.0 * LSCALE)
-const double Woutdrvnandp = 12.5 * 0.09;  //(10.0 * LSCALE)
-const double Woutdrvnorn = 7.5 * 0.09;    //(6.0 * LSCALE)
-const double Woutdrvnorp = 50 * 0.09;     //	(40.0 * LSCALE)
-const double Woutdrivern = 60 * 0.09;     //(48.0 * LSCALE)
-const double Woutdriverp = 100 * 0.09;    //(80.0 * LSCALE)
+const int BTBEntries=4096;
+const int BTBTagSize=16;
+const int LFSTSize=1024;
+const int LQEntries=32;
+const int RASSize=16;
+const int SQEntries=32;
+const int SSITSize=1024;
+const int activity=0;
+const int backComSize=5;
+const int cachePorts=200;
+const int choiceCtrBits=2;
+const int choicePredictorSize=8192;
+
+
+const int commitWidth=8;
+const int decodeWidth=8;
+const int dispatchWidth=8;
+const int fetchWidth=8;
+const int issueWidth=1;
+const int renameWidth=8;
+//what is this forwardComSize=5??
+
+const int globalCtrBits=2;
+const int globalHistoryBits=13;
+const int globalPredictorSize=8192;
+
+
+
+const int localCtrBits=2;
+const int localHistoryBits=11;
+const int localHistoryTableSize=2048;
+const int localPredictorSize=2048;
+
+const double Woutdrvnandn	=30 *0.09;//(24.0 * LSCALE)
+const double Woutdrvnandp	=12.5 *0.09;//(10.0 * LSCALE)
+const double Woutdrvnorn	=7.5*0.09;//(6.0 * LSCALE)
+const double Woutdrvnorp  =50 * 0.09;//	(40.0 * LSCALE)
+const double Woutdrivern	=60*0.09;//(48.0 * LSCALE)
+const double Woutdriverp	=100 * 0.09;//(80.0 * LSCALE)
 
 /*
 smtCommitPolicy=RoundRobin
@@ -258,6 +270,7 @@ mem_side=system.tol2bus.port[2]
 */
 
 //[system.cpu0.dtb]
-// type=AlphaDT
+//type=AlphaDT
+
 
 #endif /* ARCH_CONST_H_ */

--- a/src/gpuwattch/array.cc
+++ b/src/gpuwattch/array.cc
@@ -118,7 +118,7 @@ void ArrayST::optimize_array() {
           10;  // This is the time_dev to be used for next iteration
 
       //		from best area to worst area -->worst timing to best
-      // timing
+      //timing
       if ((((local_result.cycle_time - throughput) <= 1e-10) &&
            (local_result.access_time - latency) <= 1e-10) ||
           (local_result.data_array2->area_efficiency <
@@ -145,8 +145,8 @@ void ArrayST::optimize_array() {
 
         if (l_ip.cycle_time_dev > 10) {  // if not >10 local_result is the last
                                          // result, it cannot be cleaned up
-          temp_res = &local_result;      // Only solutions not saved in the list
-                                         // need to be cleaned up
+          temp_res = &local_result;  // Only solutions not saved in the list
+                                     // need to be cleaned up
           temp_res->cleanup();
         }
       }
@@ -171,36 +171,23 @@ void ArrayST::optimize_array() {
     //		/*According to "Content-Addressable Memory (CAM) Circuits and
     //				Architectures": A Tutorial and Survey
     //				by Kostas Pagiamtzis et al.
-    //				CAM structures can be heavily pipelined and use
-    // look-ahead
-    // techniques,
-    //				therefore timing can be relaxed. But McPAT does not
-    //model
-    // the
-    // advanced
-    //				techniques. If continue optimizing, the area efficiency
-    //will
-    // be
-    // too low
+    //				CAM structures can be heavily pipelined and use look-ahead
+    //techniques,
+    //				therefore timing can be relaxed. But McPAT does not model the
+    //advanced
+    //				techniques. If continue optimizing, the area efficiency will be
+    //too low
     //		*/
     //		//For CAM and FA, stop opt if area efficiency is too low
     //		if (throughput_overflow==true)
-    //			cout<< "Warning: " <<" McPAT stopped optimization on
-    //throughput
-    // for
+    //			cout<< "Warning: " <<" McPAT stopped optimization on throughput for
     //"<< name
-    //				<<" array structure because its area efficiency
-    //is
-    // below
+    //				<<" array structure because its area efficiency is below
     //"<<area_efficiency_threshold<<"% " << endl;
     //		if (latency_overflow==true)
-    //			cout<< "Warning: " <<" McPAT stopped optimization on latency
-    //for
-    //"<<
-    // name
-    //				<<" array structure because its area efficiency
-    //is
-    // below
+    //			cout<< "Warning: " <<" McPAT stopped optimization on latency for "<<
+    //name
+    //				<<" array structure because its area efficiency is below
     //"<<area_efficiency_threshold<<"% " << endl;
     //	}
 

--- a/src/gpuwattch/array.cc
+++ b/src/gpuwattch/array.cc
@@ -174,21 +174,21 @@ void ArrayST::optimize_array() {
     //				CAM structures can be heavily pipelined and use
     // look-ahead techniques, 				therefore timing can be
     // relaxed. But McPAT does not model the
-    // advanced 				techniques. If continue optimizing, the area efficiency
-    // will be too low
+    // advanced 				techniques. If continue optimizing, the
+    // area efficiency will be too low
     //		*/
     //		//For CAM and FA, stop opt if area efficiency is too low
     //		if (throughput_overflow==true)
     //			cout<< "Warning: " <<" McPAT stopped optimization on
-    //throughput for
+    // throughput for
     //"<< name
     //				<<" array structure because its area efficiency
-    //is below
+    // is below
     //"<<area_efficiency_threshold<<"% " << endl; 		if
-    //(latency_overflow==true) 			cout<< "Warning: " <<" McPAT stopped
-    //optimization on latency for "<< name
+    //(latency_overflow==true) 			cout<< "Warning: " <<" McPAT
+    // stopped optimization on latency for "<< name
     //				<<" array structure because its area efficiency
-    //is below
+    // is below
     //"<<area_efficiency_threshold<<"% " << endl;
     //	}
 

--- a/src/gpuwattch/array.cc
+++ b/src/gpuwattch/array.cc
@@ -118,7 +118,7 @@ void ArrayST::optimize_array() {
           10;  // This is the time_dev to be used for next iteration
 
       //		from best area to worst area -->worst timing to best
-      //timing
+      // timing
       if ((((local_result.cycle_time - throughput) <= 1e-10) &&
            (local_result.access_time - latency) <= 1e-10) ||
           (local_result.data_array2->area_efficiency <
@@ -145,8 +145,8 @@ void ArrayST::optimize_array() {
 
         if (l_ip.cycle_time_dev > 10) {  // if not >10 local_result is the last
                                          // result, it cannot be cleaned up
-          temp_res = &local_result;  // Only solutions not saved in the list
-                                     // need to be cleaned up
+          temp_res = &local_result;      // Only solutions not saved in the list
+                                         // need to be cleaned up
           temp_res->cleanup();
         }
       }
@@ -171,23 +171,36 @@ void ArrayST::optimize_array() {
     //		/*According to "Content-Addressable Memory (CAM) Circuits and
     //				Architectures": A Tutorial and Survey
     //				by Kostas Pagiamtzis et al.
-    //				CAM structures can be heavily pipelined and use look-ahead
-    //techniques,
-    //				therefore timing can be relaxed. But McPAT does not model the
-    //advanced
-    //				techniques. If continue optimizing, the area efficiency will be
-    //too low
+    //				CAM structures can be heavily pipelined and use
+    // look-ahead
+    // techniques,
+    //				therefore timing can be relaxed. But McPAT does not
+    //model
+    // the
+    // advanced
+    //				techniques. If continue optimizing, the area efficiency
+    //will
+    // be
+    // too low
     //		*/
     //		//For CAM and FA, stop opt if area efficiency is too low
     //		if (throughput_overflow==true)
-    //			cout<< "Warning: " <<" McPAT stopped optimization on throughput for
+    //			cout<< "Warning: " <<" McPAT stopped optimization on
+    //throughput
+    // for
     //"<< name
-    //				<<" array structure because its area efficiency is below
+    //				<<" array structure because its area efficiency
+    //is
+    // below
     //"<<area_efficiency_threshold<<"% " << endl;
     //		if (latency_overflow==true)
-    //			cout<< "Warning: " <<" McPAT stopped optimization on latency for "<<
-    //name
-    //				<<" array structure because its area efficiency is below
+    //			cout<< "Warning: " <<" McPAT stopped optimization on latency
+    //for
+    //"<<
+    // name
+    //				<<" array structure because its area efficiency
+    //is
+    // below
     //"<<area_efficiency_threshold<<"% " << endl;
     //	}
 

--- a/src/gpuwattch/array.cc
+++ b/src/gpuwattch/array.cc
@@ -29,280 +29,273 @@
  *
  ***************************************************************************/
 
-#define GLOBALVAR
-#include "array.h"
-#include <assert.h>
-#include <math.h>
-#include <iostream>
+#define  GLOBALVAR
 #include "cacti/area.h"
 #include "decoder.h"
-#include "globalvar.h"
 #include "parameter.h"
+#include "array.h"
+#include <iostream>
+#include <math.h>
+#include <assert.h>
+#include "globalvar.h"
 
 using namespace std;
 
-ArrayST::ArrayST(const InputParameter *configure_interface, string _name,
-                 enum Device_ty device_ty_, bool opt_local_,
-                 enum Core_type core_ty_, bool _is_default)
-    : l_ip(*configure_interface),
-      name(_name),
-      device_ty(device_ty_),
-      opt_local(opt_local_),
-      core_ty(core_ty_),
-      is_default(_is_default) {
-  if (l_ip.cache_sz < 64) l_ip.cache_sz = 64;
-  l_ip.error_checking();  // not only do the error checking but also fill some
-                          // missing parameters
-  optimize_array();
-}
-
-void ArrayST::compute_base_power() {
-  // l_ip.out_w               =l_ip.line_sz*8;
-  local_result = cacti_interface(&l_ip);
-}
-
-void ArrayST::optimize_array() {
-  list<uca_org_t> candidate_solutions(0);
-  list<uca_org_t>::iterator candidate_iter, min_dynamic_energy_iter;
-
-  uca_org_t *temp_res = 0;
-  local_result.valid = false;
-
-  double throughput = l_ip.throughput, latency = l_ip.latency;
-  double area_efficiency_threshold = 20.0;
-  bool throughput_overflow = true, latency_overflow = true;
-  compute_base_power();
-
-  if ((local_result.cycle_time - throughput) <= 1e-10)
-    throughput_overflow = false;
-  if ((local_result.access_time - latency) <= 1e-10) latency_overflow = false;
-
-  if (opt_for_clk && opt_local) {
-    if (throughput_overflow || latency_overflow) {
-      l_ip.ed = 0;
-
-      l_ip.delay_wt = 100;  // Fixed number, make sure timing can be satisfied.
-      l_ip.cycle_time_wt = 1000;
-
-      l_ip.area_wt = 10;  // Fixed number, This is used to exhaustive search for
-                          // individual components.
-      l_ip.dynamic_power_wt = 10;  // Fixed number, This is used to exhaustive
-                                   // search for individual components.
-      l_ip.leakage_power_wt = 10;
-
-      l_ip.delay_dev =
-          1000000;  // Fixed number, make sure timing can be satisfied.
-      l_ip.cycle_time_dev = 100;
-
-      l_ip.area_dev = 1000000;  // Fixed number, This is used to exhaustive
-                                // search for individual components.
-      l_ip.dynamic_power_dev = 1000000;  // Fixed number, This is used to
-                                         // exhaustive search for individual
-                                         // components.
-      l_ip.leakage_power_dev = 1000000;
-
-      throughput_overflow =
-          true;  // Reset overflow flag before start optimization iterations
-      latency_overflow = true;
-
-      temp_res = &local_result;  // Clean up the result for optimized for ED^2P
-      temp_res->cleanup();
-    }
-
-    while ((throughput_overflow || latency_overflow) &&
-           l_ip.cycle_time_dev > 10)  // && l_ip.delay_dev > 10
+ArrayST::ArrayST(const InputParameter *configure_interface,
+		               string _name,
+		               enum Device_ty device_ty_,
+		               bool opt_local_,
+		               enum Core_type core_ty_,
+		               bool _is_default)
+:l_ip(*configure_interface),
+ name(_name),
+ device_ty(device_ty_),
+ opt_local(opt_local_),
+ core_ty(core_ty_),
+ is_default(_is_default)
     {
-      compute_base_power();
 
-      l_ip.cycle_time_dev -=
-          10;  // This is the time_dev to be used for next iteration
+	if (l_ip.cache_sz<64) l_ip.cache_sz=64;
+	l_ip.error_checking();//not only do the error checking but also fill some missing parameters
+	optimize_array();
 
-      //		from best area to worst area -->worst timing to best
-      //timing
-      if ((((local_result.cycle_time - throughput) <= 1e-10) &&
-           (local_result.access_time - latency) <= 1e-10) ||
-          (local_result.data_array2->area_efficiency <
-               area_efficiency_threshold &&
-           l_ip.assoc == 0)) {  // if no satisfiable solution is found,the most
-                                // aggressive one is left
-        candidate_solutions.push_back(local_result);
-        // output_data_csv(candidate_solutions.back());
-        if (((local_result.cycle_time - throughput) <= 1e-10) &&
-            ((local_result.access_time - latency) <= 1e-10))
-        // ensure stop opt not because of cam
-        {
-          throughput_overflow = false;
-          latency_overflow = false;
-        }
-
-      } else {
-        // TODO: whether checking the partial satisfied results too, or just
-        // change the mark???
-        if ((local_result.cycle_time - throughput) <= 1e-10)
-          throughput_overflow = false;
-        if ((local_result.access_time - latency) <= 1e-10)
-          latency_overflow = false;
-
-        if (l_ip.cycle_time_dev > 10) {  // if not >10 local_result is the last
-                                         // result, it cannot be cleaned up
-          temp_res = &local_result;  // Only solutions not saved in the list
-                                     // need to be cleaned up
-          temp_res->cleanup();
-        }
-      }
-      //			l_ip.cycle_time_dev-=10;
-      //			l_ip.delay_dev-=10;
-    }
-
-    if (l_ip.assoc > 0) {
-      // For array structures except CAM and FA, Give warning but still provide
-      // a result with best timing found
-      if (throughput_overflow == true)
-        cout << "Warning: " << name
-             << " array structure cannot satisfy throughput constraint."
-             << endl;
-      if (latency_overflow == true)
-        cout << "Warning: " << name
-             << " array structure cannot satisfy latency constraint." << endl;
-    }
-
-    //	else
-    //	{
-    //		/*According to "Content-Addressable Memory (CAM) Circuits and
-    //				Architectures": A Tutorial and Survey
-    //				by Kostas Pagiamtzis et al.
-    //				CAM structures can be heavily pipelined and use look-ahead
-    //techniques,
-    //				therefore timing can be relaxed. But McPAT does not model the
-    //advanced
-    //				techniques. If continue optimizing, the area efficiency will be
-    //too low
-    //		*/
-    //		//For CAM and FA, stop opt if area efficiency is too low
-    //		if (throughput_overflow==true)
-    //			cout<< "Warning: " <<" McPAT stopped optimization on throughput for
-    //"<< name
-    //				<<" array structure because its area efficiency is below
-    //"<<area_efficiency_threshold<<"% " << endl;
-    //		if (latency_overflow==true)
-    //			cout<< "Warning: " <<" McPAT stopped optimization on latency for "<<
-    //name
-    //				<<" array structure because its area efficiency is below
-    //"<<area_efficiency_threshold<<"% " << endl;
-    //	}
-
-    // double min_dynamic_energy, min_dynamic_power, min_leakage_power,
-    // min_cycle_time;
-    double min_dynamic_energy = BIGNUM;
-    if (candidate_solutions.empty() == false) {
-      local_result.valid = true;
-      for (candidate_iter = candidate_solutions.begin();
-           candidate_iter != candidate_solutions.end(); ++candidate_iter)
-
-      {
-        if (min_dynamic_energy > (candidate_iter)->power.readOp.dynamic) {
-          min_dynamic_energy = (candidate_iter)->power.readOp.dynamic;
-          min_dynamic_energy_iter = candidate_iter;
-          local_result = *(min_dynamic_energy_iter);
-          // TODO: since results are reordered results and l_ip may miss match.
-          // Therefore, the final output spread sheets may show the miss match.
-
-        } else {
-          candidate_iter->cleanup();
-        }
-      }
-    }
-    candidate_solutions.clear();
-  }
-
-  double long_channel_device_reduction =
-      longer_channel_device_reduction(device_ty, core_ty);
-
-  double macro_layout_overhead = g_tp.macro_layout_overhead;
-  double chip_PR_overhead = g_tp.chip_layout_overhead;
-  double total_overhead = macro_layout_overhead * chip_PR_overhead;
-  local_result.area *= total_overhead;
-
-  // maintain constant power density
-  double pppm_t[4] = {total_overhead, 1, 1, total_overhead};
-
-  double sckRation = g_tp.sckt_co_eff;
-  local_result.power.readOp.dynamic *= sckRation;
-  local_result.power.writeOp.dynamic *= sckRation;
-  local_result.power.searchOp.dynamic *= sckRation;
-  local_result.power.readOp.leakage *= l_ip.nbanks;
-  local_result.power.readOp.longer_channel_leakage =
-      local_result.power.readOp.leakage * long_channel_device_reduction;
-  local_result.power = local_result.power * pppm_t;
-
-  local_result.data_array2->power.readOp.dynamic *= sckRation;
-  local_result.data_array2->power.writeOp.dynamic *= sckRation;
-  local_result.data_array2->power.searchOp.dynamic *= sckRation;
-  local_result.data_array2->power.readOp.leakage *= l_ip.nbanks;
-  local_result.data_array2->power.readOp.longer_channel_leakage =
-      local_result.data_array2->power.readOp.leakage *
-      long_channel_device_reduction;
-  local_result.data_array2->power = local_result.data_array2->power * pppm_t;
-
-  if (!(l_ip.pure_cam || l_ip.pure_ram || l_ip.fully_assoc) && l_ip.is_cache) {
-    local_result.tag_array2->power.readOp.dynamic *= sckRation;
-    local_result.tag_array2->power.writeOp.dynamic *= sckRation;
-    local_result.tag_array2->power.searchOp.dynamic *= sckRation;
-    local_result.tag_array2->power.readOp.leakage *= l_ip.nbanks;
-    local_result.tag_array2->power.readOp.longer_channel_leakage =
-        local_result.tag_array2->power.readOp.leakage *
-        long_channel_device_reduction;
-    local_result.tag_array2->power = local_result.tag_array2->power * pppm_t;
-  }
 }
 
-void ArrayST::leakage_feedback(double temperature) {
-  // Update the temperature. l_ip is already set and error-checked in the
-  // creator function.
-  l_ip.temp = (unsigned int)round(temperature / 10.0) * 10;
 
-  // This corresponds to cacti_interface() in the initialization process.
-  // Leakage power is updated here.
-  reconfigure(&l_ip, &local_result);
+void ArrayST::compute_base_power()
+    {
+	//l_ip.out_w               =l_ip.line_sz*8;
+    local_result=cacti_interface(&l_ip);
+
+    }
+
+void ArrayST::optimize_array()
+{
+	list<uca_org_t > candidate_solutions(0);
+	list<uca_org_t >::iterator candidate_iter, min_dynamic_energy_iter;
+
+	uca_org_t * temp_res = 0;
+	local_result.valid=false;
+
+	double 	throughput=l_ip.throughput, latency=l_ip.latency;
+	double  area_efficiency_threshold = 20.0;
+	bool 	throughput_overflow=true, latency_overflow=true;
+	compute_base_power();
+
+	if ((local_result.cycle_time - throughput) <= 1e-10 )
+		throughput_overflow=false;
+	if ((local_result.access_time - latency)<= 1e-10)
+		latency_overflow=false;
+
+	if (opt_for_clk && opt_local)
+	{
+		if (throughput_overflow || latency_overflow)
+		{
+			l_ip.ed=0;
+
+			l_ip.delay_wt                = 100;//Fixed number, make sure timing can be satisfied.
+			l_ip.cycle_time_wt           = 1000;
+
+			l_ip.area_wt                 = 10;//Fixed number, This is used to exhaustive search for individual components.
+			l_ip.dynamic_power_wt        = 10;//Fixed number, This is used to exhaustive search for individual components.
+			l_ip.leakage_power_wt        = 10;
+
+			l_ip.delay_dev               = 1000000;//Fixed number, make sure timing can be satisfied.
+			l_ip.cycle_time_dev          = 100;
+
+			l_ip.area_dev                = 1000000;//Fixed number, This is used to exhaustive search for individual components.
+			l_ip.dynamic_power_dev       = 1000000;//Fixed number, This is used to exhaustive search for individual components.
+			l_ip.leakage_power_dev       = 1000000;
+
+			throughput_overflow=true; //Reset overflow flag before start optimization iterations
+			latency_overflow=true;
+
+			temp_res = &local_result; //Clean up the result for optimized for ED^2P
+			temp_res->cleanup();
+		}
+
+
+		while ((throughput_overflow || latency_overflow)&&l_ip.cycle_time_dev > 10)// && l_ip.delay_dev > 10
+		{
+			compute_base_power();
+
+			l_ip.cycle_time_dev-=10;//This is the time_dev to be used for next iteration
+
+			//		from best area to worst area -->worst timing to best timing
+			if ((((local_result.cycle_time - throughput) <= 1e-10 ) && (local_result.access_time - latency)<= 1e-10)||
+					(local_result.data_array2->area_efficiency < area_efficiency_threshold && l_ip.assoc == 0))
+			{  //if no satisfiable solution is found,the most aggressive one is left
+				candidate_solutions.push_back(local_result);
+				//output_data_csv(candidate_solutions.back());
+				if (((local_result.cycle_time - throughput) <= 1e-10) && ((local_result.access_time - latency)<= 1e-10))
+					//ensure stop opt not because of cam
+				{
+					throughput_overflow=false;
+					latency_overflow=false;
+				}
+
+			}
+			else
+			{
+				//TODO: whether checking the partial satisfied results too, or just change the mark???
+				if ((local_result.cycle_time - throughput) <= 1e-10)
+										throughput_overflow=false;
+				if ((local_result.access_time - latency)<= 1e-10)
+										latency_overflow=false;
+
+				if (l_ip.cycle_time_dev > 10)
+				{   //if not >10 local_result is the last result, it cannot be cleaned up
+					temp_res = &local_result; //Only solutions not saved in the list need to be cleaned up
+					temp_res->cleanup();
+				}
+			}
+//			l_ip.cycle_time_dev-=10;
+//			l_ip.delay_dev-=10;
+
+		}
+
+
+	if (l_ip.assoc > 0)
+	{
+		//For array structures except CAM and FA, Give warning but still provide a result with best timing found
+		if (throughput_overflow==true)
+			cout<< "Warning: " << name<<" array structure cannot satisfy throughput constraint." << endl;
+		if (latency_overflow==true)
+			cout<< "Warning: " << name<<" array structure cannot satisfy latency constraint." << endl;
+	}
+
+//	else
+//	{
+//		/*According to "Content-Addressable Memory (CAM) Circuits and
+//				Architectures": A Tutorial and Survey
+//				by Kostas Pagiamtzis et al.
+//				CAM structures can be heavily pipelined and use look-ahead techniques,
+//				therefore timing can be relaxed. But McPAT does not model the advanced
+//				techniques. If continue optimizing, the area efficiency will be too low
+//		*/
+//		//For CAM and FA, stop opt if area efficiency is too low
+//		if (throughput_overflow==true)
+//			cout<< "Warning: " <<" McPAT stopped optimization on throughput for "<< name
+//				<<" array structure because its area efficiency is below "<<area_efficiency_threshold<<"% " << endl;
+//		if (latency_overflow==true)
+//			cout<< "Warning: " <<" McPAT stopped optimization on latency for "<< name
+//				<<" array structure because its area efficiency is below "<<area_efficiency_threshold<<"% " << endl;
+//	}
+
+		//double min_dynamic_energy, min_dynamic_power, min_leakage_power, min_cycle_time;
+		double min_dynamic_energy=BIGNUM;
+		if (candidate_solutions.empty()==false)
+		{
+			local_result.valid=true;
+			for (candidate_iter = candidate_solutions.begin(); candidate_iter != candidate_solutions.end(); ++candidate_iter)
+
+			{
+				if (min_dynamic_energy > (candidate_iter)->power.readOp.dynamic)
+				{
+					min_dynamic_energy = (candidate_iter)->power.readOp.dynamic;
+					min_dynamic_energy_iter = candidate_iter;
+					local_result = *(min_dynamic_energy_iter);
+					//TODO: since results are reordered results and l_ip may miss match. Therefore, the final output spread sheets may show the miss match.
+
+				}
+				else
+				{
+					candidate_iter->cleanup() ;
+				}
+
+			}
+
+
+		}
+	candidate_solutions.clear();
+	}
+
+	double long_channel_device_reduction = longer_channel_device_reduction(device_ty,core_ty);
+
+	double macro_layout_overhead   = g_tp.macro_layout_overhead;
+	double chip_PR_overhead        = g_tp.chip_layout_overhead;
+	double total_overhead          = macro_layout_overhead*chip_PR_overhead;
+	local_result.area *= total_overhead;
+
+	//maintain constant power density
+	double pppm_t[4]    = {total_overhead,1,1,total_overhead};
+
+	double sckRation = g_tp.sckt_co_eff;
+	local_result.power.readOp.dynamic *= sckRation;
+	local_result.power.writeOp.dynamic *= sckRation;
+	local_result.power.searchOp.dynamic *= sckRation;
+	local_result.power.readOp.leakage *= l_ip.nbanks;
+	local_result.power.readOp.longer_channel_leakage =
+		local_result.power.readOp.leakage*long_channel_device_reduction;
+	local_result.power = local_result.power* pppm_t;
+
+	local_result.data_array2->power.readOp.dynamic *= sckRation;
+	local_result.data_array2->power.writeOp.dynamic *= sckRation;
+	local_result.data_array2->power.searchOp.dynamic *= sckRation;
+	local_result.data_array2->power.readOp.leakage *= l_ip.nbanks;
+	local_result.data_array2->power.readOp.longer_channel_leakage =
+		local_result.data_array2->power.readOp.leakage*long_channel_device_reduction;
+	local_result.data_array2->power = local_result.data_array2->power* pppm_t;
+
+
+	if (!(l_ip.pure_cam || l_ip.pure_ram || l_ip.fully_assoc) && l_ip.is_cache)
+	{
+		local_result.tag_array2->power.readOp.dynamic *= sckRation;
+		local_result.tag_array2->power.writeOp.dynamic *= sckRation;
+		local_result.tag_array2->power.searchOp.dynamic *= sckRation;
+		local_result.tag_array2->power.readOp.leakage *= l_ip.nbanks;
+		local_result.tag_array2->power.readOp.longer_channel_leakage =
+			local_result.tag_array2->power.readOp.leakage*long_channel_device_reduction;
+		local_result.tag_array2->power = local_result.tag_array2->power* pppm_t;
+	}
+
+
+}
+
+void ArrayST::leakage_feedback(double temperature)
+{
+  // Update the temperature. l_ip is already set and error-checked in the creator function.
+  l_ip.temp = (unsigned int)round(temperature/10.0)*10;
+
+  // This corresponds to cacti_interface() in the initialization process. Leakage power is updated here.
+  reconfigure(&l_ip,&local_result);
 
   // Scale the power values. This is part of ArrayST::optimize_array().
-  double long_channel_device_reduction =
-      longer_channel_device_reduction(device_ty, core_ty);
+  double long_channel_device_reduction = longer_channel_device_reduction(device_ty,core_ty);
 
-  double macro_layout_overhead = g_tp.macro_layout_overhead;
-  double chip_PR_overhead = g_tp.chip_layout_overhead;
-  double total_overhead = macro_layout_overhead * chip_PR_overhead;
+  double macro_layout_overhead   = g_tp.macro_layout_overhead;
+  double chip_PR_overhead        = g_tp.chip_layout_overhead;
+  double total_overhead          = macro_layout_overhead*chip_PR_overhead;
 
-  double pppm_t[4] = {total_overhead, 1, 1, total_overhead};
+  double pppm_t[4]    = {total_overhead,1,1,total_overhead};
 
   double sckRation = g_tp.sckt_co_eff;
   local_result.power.readOp.dynamic *= sckRation;
   local_result.power.writeOp.dynamic *= sckRation;
   local_result.power.searchOp.dynamic *= sckRation;
   local_result.power.readOp.leakage *= l_ip.nbanks;
-  local_result.power.readOp.longer_channel_leakage =
-      local_result.power.readOp.leakage * long_channel_device_reduction;
-  local_result.power = local_result.power * pppm_t;
+  local_result.power.readOp.longer_channel_leakage = local_result.power.readOp.leakage*long_channel_device_reduction;
+  local_result.power = local_result.power* pppm_t;
 
   local_result.data_array2->power.readOp.dynamic *= sckRation;
   local_result.data_array2->power.writeOp.dynamic *= sckRation;
   local_result.data_array2->power.searchOp.dynamic *= sckRation;
   local_result.data_array2->power.readOp.leakage *= l_ip.nbanks;
-  local_result.data_array2->power.readOp.longer_channel_leakage =
-      local_result.data_array2->power.readOp.leakage *
-      long_channel_device_reduction;
-  local_result.data_array2->power = local_result.data_array2->power * pppm_t;
+  local_result.data_array2->power.readOp.longer_channel_leakage = local_result.data_array2->power.readOp.leakage*long_channel_device_reduction;
+  local_result.data_array2->power = local_result.data_array2->power* pppm_t;
 
-  if (!(l_ip.pure_cam || l_ip.pure_ram || l_ip.fully_assoc) && l_ip.is_cache) {
+  if (!(l_ip.pure_cam || l_ip.pure_ram || l_ip.fully_assoc) && l_ip.is_cache)
+  {
     local_result.tag_array2->power.readOp.dynamic *= sckRation;
     local_result.tag_array2->power.writeOp.dynamic *= sckRation;
     local_result.tag_array2->power.searchOp.dynamic *= sckRation;
     local_result.tag_array2->power.readOp.leakage *= l_ip.nbanks;
-    local_result.tag_array2->power.readOp.longer_channel_leakage =
-        local_result.tag_array2->power.readOp.leakage *
-        long_channel_device_reduction;
-    local_result.tag_array2->power = local_result.tag_array2->power * pppm_t;
+    local_result.tag_array2->power.readOp.longer_channel_leakage = local_result.tag_array2->power.readOp.leakage*long_channel_device_reduction;
+    local_result.tag_array2->power = local_result.tag_array2->power* pppm_t;
   }
 }
 
-ArrayST::~ArrayST() { local_result.cleanup(); }
+ArrayST:: ~ArrayST()
+{
+	local_result.cleanup();
+}

--- a/src/gpuwattch/array.cc
+++ b/src/gpuwattch/array.cc
@@ -29,273 +29,280 @@
  *
  ***************************************************************************/
 
-#define  GLOBALVAR
+#define GLOBALVAR
+#include "array.h"
+#include <assert.h>
+#include <math.h>
+#include <iostream>
 #include "cacti/area.h"
 #include "decoder.h"
-#include "parameter.h"
-#include "array.h"
-#include <iostream>
-#include <math.h>
-#include <assert.h>
 #include "globalvar.h"
+#include "parameter.h"
 
 using namespace std;
 
-ArrayST::ArrayST(const InputParameter *configure_interface,
-		               string _name,
-		               enum Device_ty device_ty_,
-		               bool opt_local_,
-		               enum Core_type core_ty_,
-		               bool _is_default)
-:l_ip(*configure_interface),
- name(_name),
- device_ty(device_ty_),
- opt_local(opt_local_),
- core_ty(core_ty_),
- is_default(_is_default)
-    {
-
-	if (l_ip.cache_sz<64) l_ip.cache_sz=64;
-	l_ip.error_checking();//not only do the error checking but also fill some missing parameters
-	optimize_array();
-
+ArrayST::ArrayST(const InputParameter *configure_interface, string _name,
+                 enum Device_ty device_ty_, bool opt_local_,
+                 enum Core_type core_ty_, bool _is_default)
+    : l_ip(*configure_interface),
+      name(_name),
+      device_ty(device_ty_),
+      opt_local(opt_local_),
+      core_ty(core_ty_),
+      is_default(_is_default) {
+  if (l_ip.cache_sz < 64) l_ip.cache_sz = 64;
+  l_ip.error_checking();  // not only do the error checking but also fill some
+                          // missing parameters
+  optimize_array();
 }
 
+void ArrayST::compute_base_power() {
+  // l_ip.out_w               =l_ip.line_sz*8;
+  local_result = cacti_interface(&l_ip);
+}
 
-void ArrayST::compute_base_power()
-    {
-	//l_ip.out_w               =l_ip.line_sz*8;
-    local_result=cacti_interface(&l_ip);
+void ArrayST::optimize_array() {
+  list<uca_org_t> candidate_solutions(0);
+  list<uca_org_t>::iterator candidate_iter, min_dynamic_energy_iter;
 
+  uca_org_t *temp_res = 0;
+  local_result.valid = false;
+
+  double throughput = l_ip.throughput, latency = l_ip.latency;
+  double area_efficiency_threshold = 20.0;
+  bool throughput_overflow = true, latency_overflow = true;
+  compute_base_power();
+
+  if ((local_result.cycle_time - throughput) <= 1e-10)
+    throughput_overflow = false;
+  if ((local_result.access_time - latency) <= 1e-10) latency_overflow = false;
+
+  if (opt_for_clk && opt_local) {
+    if (throughput_overflow || latency_overflow) {
+      l_ip.ed = 0;
+
+      l_ip.delay_wt = 100;  // Fixed number, make sure timing can be satisfied.
+      l_ip.cycle_time_wt = 1000;
+
+      l_ip.area_wt = 10;  // Fixed number, This is used to exhaustive search for
+                          // individual components.
+      l_ip.dynamic_power_wt = 10;  // Fixed number, This is used to exhaustive
+                                   // search for individual components.
+      l_ip.leakage_power_wt = 10;
+
+      l_ip.delay_dev =
+          1000000;  // Fixed number, make sure timing can be satisfied.
+      l_ip.cycle_time_dev = 100;
+
+      l_ip.area_dev = 1000000;  // Fixed number, This is used to exhaustive
+                                // search for individual components.
+      l_ip.dynamic_power_dev = 1000000;  // Fixed number, This is used to
+                                         // exhaustive search for individual
+                                         // components.
+      l_ip.leakage_power_dev = 1000000;
+
+      throughput_overflow =
+          true;  // Reset overflow flag before start optimization iterations
+      latency_overflow = true;
+
+      temp_res = &local_result;  // Clean up the result for optimized for ED^2P
+      temp_res->cleanup();
     }
 
-void ArrayST::optimize_array()
-{
-	list<uca_org_t > candidate_solutions(0);
-	list<uca_org_t >::iterator candidate_iter, min_dynamic_energy_iter;
+    while ((throughput_overflow || latency_overflow) &&
+           l_ip.cycle_time_dev > 10)  // && l_ip.delay_dev > 10
+    {
+      compute_base_power();
 
-	uca_org_t * temp_res = 0;
-	local_result.valid=false;
+      l_ip.cycle_time_dev -=
+          10;  // This is the time_dev to be used for next iteration
 
-	double 	throughput=l_ip.throughput, latency=l_ip.latency;
-	double  area_efficiency_threshold = 20.0;
-	bool 	throughput_overflow=true, latency_overflow=true;
-	compute_base_power();
+      //		from best area to worst area -->worst timing to best
+      //timing
+      if ((((local_result.cycle_time - throughput) <= 1e-10) &&
+           (local_result.access_time - latency) <= 1e-10) ||
+          (local_result.data_array2->area_efficiency <
+               area_efficiency_threshold &&
+           l_ip.assoc == 0)) {  // if no satisfiable solution is found,the most
+                                // aggressive one is left
+        candidate_solutions.push_back(local_result);
+        // output_data_csv(candidate_solutions.back());
+        if (((local_result.cycle_time - throughput) <= 1e-10) &&
+            ((local_result.access_time - latency) <= 1e-10))
+        // ensure stop opt not because of cam
+        {
+          throughput_overflow = false;
+          latency_overflow = false;
+        }
 
-	if ((local_result.cycle_time - throughput) <= 1e-10 )
-		throughput_overflow=false;
-	if ((local_result.access_time - latency)<= 1e-10)
-		latency_overflow=false;
+      } else {
+        // TODO: whether checking the partial satisfied results too, or just
+        // change the mark???
+        if ((local_result.cycle_time - throughput) <= 1e-10)
+          throughput_overflow = false;
+        if ((local_result.access_time - latency) <= 1e-10)
+          latency_overflow = false;
 
-	if (opt_for_clk && opt_local)
-	{
-		if (throughput_overflow || latency_overflow)
-		{
-			l_ip.ed=0;
+        if (l_ip.cycle_time_dev > 10) {  // if not >10 local_result is the last
+                                         // result, it cannot be cleaned up
+          temp_res = &local_result;  // Only solutions not saved in the list
+                                     // need to be cleaned up
+          temp_res->cleanup();
+        }
+      }
+      //			l_ip.cycle_time_dev-=10;
+      //			l_ip.delay_dev-=10;
+    }
 
-			l_ip.delay_wt                = 100;//Fixed number, make sure timing can be satisfied.
-			l_ip.cycle_time_wt           = 1000;
+    if (l_ip.assoc > 0) {
+      // For array structures except CAM and FA, Give warning but still provide
+      // a result with best timing found
+      if (throughput_overflow == true)
+        cout << "Warning: " << name
+             << " array structure cannot satisfy throughput constraint."
+             << endl;
+      if (latency_overflow == true)
+        cout << "Warning: " << name
+             << " array structure cannot satisfy latency constraint." << endl;
+    }
 
-			l_ip.area_wt                 = 10;//Fixed number, This is used to exhaustive search for individual components.
-			l_ip.dynamic_power_wt        = 10;//Fixed number, This is used to exhaustive search for individual components.
-			l_ip.leakage_power_wt        = 10;
+    //	else
+    //	{
+    //		/*According to "Content-Addressable Memory (CAM) Circuits and
+    //				Architectures": A Tutorial and Survey
+    //				by Kostas Pagiamtzis et al.
+    //				CAM structures can be heavily pipelined and use look-ahead
+    //techniques,
+    //				therefore timing can be relaxed. But McPAT does not model the
+    //advanced
+    //				techniques. If continue optimizing, the area efficiency will be
+    //too low
+    //		*/
+    //		//For CAM and FA, stop opt if area efficiency is too low
+    //		if (throughput_overflow==true)
+    //			cout<< "Warning: " <<" McPAT stopped optimization on throughput for
+    //"<< name
+    //				<<" array structure because its area efficiency is below
+    //"<<area_efficiency_threshold<<"% " << endl;
+    //		if (latency_overflow==true)
+    //			cout<< "Warning: " <<" McPAT stopped optimization on latency for "<<
+    //name
+    //				<<" array structure because its area efficiency is below
+    //"<<area_efficiency_threshold<<"% " << endl;
+    //	}
 
-			l_ip.delay_dev               = 1000000;//Fixed number, make sure timing can be satisfied.
-			l_ip.cycle_time_dev          = 100;
+    // double min_dynamic_energy, min_dynamic_power, min_leakage_power,
+    // min_cycle_time;
+    double min_dynamic_energy = BIGNUM;
+    if (candidate_solutions.empty() == false) {
+      local_result.valid = true;
+      for (candidate_iter = candidate_solutions.begin();
+           candidate_iter != candidate_solutions.end(); ++candidate_iter)
 
-			l_ip.area_dev                = 1000000;//Fixed number, This is used to exhaustive search for individual components.
-			l_ip.dynamic_power_dev       = 1000000;//Fixed number, This is used to exhaustive search for individual components.
-			l_ip.leakage_power_dev       = 1000000;
+      {
+        if (min_dynamic_energy > (candidate_iter)->power.readOp.dynamic) {
+          min_dynamic_energy = (candidate_iter)->power.readOp.dynamic;
+          min_dynamic_energy_iter = candidate_iter;
+          local_result = *(min_dynamic_energy_iter);
+          // TODO: since results are reordered results and l_ip may miss match.
+          // Therefore, the final output spread sheets may show the miss match.
 
-			throughput_overflow=true; //Reset overflow flag before start optimization iterations
-			latency_overflow=true;
+        } else {
+          candidate_iter->cleanup();
+        }
+      }
+    }
+    candidate_solutions.clear();
+  }
 
-			temp_res = &local_result; //Clean up the result for optimized for ED^2P
-			temp_res->cleanup();
-		}
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(device_ty, core_ty);
 
+  double macro_layout_overhead = g_tp.macro_layout_overhead;
+  double chip_PR_overhead = g_tp.chip_layout_overhead;
+  double total_overhead = macro_layout_overhead * chip_PR_overhead;
+  local_result.area *= total_overhead;
 
-		while ((throughput_overflow || latency_overflow)&&l_ip.cycle_time_dev > 10)// && l_ip.delay_dev > 10
-		{
-			compute_base_power();
-
-			l_ip.cycle_time_dev-=10;//This is the time_dev to be used for next iteration
-
-			//		from best area to worst area -->worst timing to best timing
-			if ((((local_result.cycle_time - throughput) <= 1e-10 ) && (local_result.access_time - latency)<= 1e-10)||
-					(local_result.data_array2->area_efficiency < area_efficiency_threshold && l_ip.assoc == 0))
-			{  //if no satisfiable solution is found,the most aggressive one is left
-				candidate_solutions.push_back(local_result);
-				//output_data_csv(candidate_solutions.back());
-				if (((local_result.cycle_time - throughput) <= 1e-10) && ((local_result.access_time - latency)<= 1e-10))
-					//ensure stop opt not because of cam
-				{
-					throughput_overflow=false;
-					latency_overflow=false;
-				}
-
-			}
-			else
-			{
-				//TODO: whether checking the partial satisfied results too, or just change the mark???
-				if ((local_result.cycle_time - throughput) <= 1e-10)
-										throughput_overflow=false;
-				if ((local_result.access_time - latency)<= 1e-10)
-										latency_overflow=false;
-
-				if (l_ip.cycle_time_dev > 10)
-				{   //if not >10 local_result is the last result, it cannot be cleaned up
-					temp_res = &local_result; //Only solutions not saved in the list need to be cleaned up
-					temp_res->cleanup();
-				}
-			}
-//			l_ip.cycle_time_dev-=10;
-//			l_ip.delay_dev-=10;
-
-		}
-
-
-	if (l_ip.assoc > 0)
-	{
-		//For array structures except CAM and FA, Give warning but still provide a result with best timing found
-		if (throughput_overflow==true)
-			cout<< "Warning: " << name<<" array structure cannot satisfy throughput constraint." << endl;
-		if (latency_overflow==true)
-			cout<< "Warning: " << name<<" array structure cannot satisfy latency constraint." << endl;
-	}
-
-//	else
-//	{
-//		/*According to "Content-Addressable Memory (CAM) Circuits and
-//				Architectures": A Tutorial and Survey
-//				by Kostas Pagiamtzis et al.
-//				CAM structures can be heavily pipelined and use look-ahead techniques,
-//				therefore timing can be relaxed. But McPAT does not model the advanced
-//				techniques. If continue optimizing, the area efficiency will be too low
-//		*/
-//		//For CAM and FA, stop opt if area efficiency is too low
-//		if (throughput_overflow==true)
-//			cout<< "Warning: " <<" McPAT stopped optimization on throughput for "<< name
-//				<<" array structure because its area efficiency is below "<<area_efficiency_threshold<<"% " << endl;
-//		if (latency_overflow==true)
-//			cout<< "Warning: " <<" McPAT stopped optimization on latency for "<< name
-//				<<" array structure because its area efficiency is below "<<area_efficiency_threshold<<"% " << endl;
-//	}
-
-		//double min_dynamic_energy, min_dynamic_power, min_leakage_power, min_cycle_time;
-		double min_dynamic_energy=BIGNUM;
-		if (candidate_solutions.empty()==false)
-		{
-			local_result.valid=true;
-			for (candidate_iter = candidate_solutions.begin(); candidate_iter != candidate_solutions.end(); ++candidate_iter)
-
-			{
-				if (min_dynamic_energy > (candidate_iter)->power.readOp.dynamic)
-				{
-					min_dynamic_energy = (candidate_iter)->power.readOp.dynamic;
-					min_dynamic_energy_iter = candidate_iter;
-					local_result = *(min_dynamic_energy_iter);
-					//TODO: since results are reordered results and l_ip may miss match. Therefore, the final output spread sheets may show the miss match.
-
-				}
-				else
-				{
-					candidate_iter->cleanup() ;
-				}
-
-			}
-
-
-		}
-	candidate_solutions.clear();
-	}
-
-	double long_channel_device_reduction = longer_channel_device_reduction(device_ty,core_ty);
-
-	double macro_layout_overhead   = g_tp.macro_layout_overhead;
-	double chip_PR_overhead        = g_tp.chip_layout_overhead;
-	double total_overhead          = macro_layout_overhead*chip_PR_overhead;
-	local_result.area *= total_overhead;
-
-	//maintain constant power density
-	double pppm_t[4]    = {total_overhead,1,1,total_overhead};
-
-	double sckRation = g_tp.sckt_co_eff;
-	local_result.power.readOp.dynamic *= sckRation;
-	local_result.power.writeOp.dynamic *= sckRation;
-	local_result.power.searchOp.dynamic *= sckRation;
-	local_result.power.readOp.leakage *= l_ip.nbanks;
-	local_result.power.readOp.longer_channel_leakage =
-		local_result.power.readOp.leakage*long_channel_device_reduction;
-	local_result.power = local_result.power* pppm_t;
-
-	local_result.data_array2->power.readOp.dynamic *= sckRation;
-	local_result.data_array2->power.writeOp.dynamic *= sckRation;
-	local_result.data_array2->power.searchOp.dynamic *= sckRation;
-	local_result.data_array2->power.readOp.leakage *= l_ip.nbanks;
-	local_result.data_array2->power.readOp.longer_channel_leakage =
-		local_result.data_array2->power.readOp.leakage*long_channel_device_reduction;
-	local_result.data_array2->power = local_result.data_array2->power* pppm_t;
-
-
-	if (!(l_ip.pure_cam || l_ip.pure_ram || l_ip.fully_assoc) && l_ip.is_cache)
-	{
-		local_result.tag_array2->power.readOp.dynamic *= sckRation;
-		local_result.tag_array2->power.writeOp.dynamic *= sckRation;
-		local_result.tag_array2->power.searchOp.dynamic *= sckRation;
-		local_result.tag_array2->power.readOp.leakage *= l_ip.nbanks;
-		local_result.tag_array2->power.readOp.longer_channel_leakage =
-			local_result.tag_array2->power.readOp.leakage*long_channel_device_reduction;
-		local_result.tag_array2->power = local_result.tag_array2->power* pppm_t;
-	}
-
-
-}
-
-void ArrayST::leakage_feedback(double temperature)
-{
-  // Update the temperature. l_ip is already set and error-checked in the creator function.
-  l_ip.temp = (unsigned int)round(temperature/10.0)*10;
-
-  // This corresponds to cacti_interface() in the initialization process. Leakage power is updated here.
-  reconfigure(&l_ip,&local_result);
-
-  // Scale the power values. This is part of ArrayST::optimize_array().
-  double long_channel_device_reduction = longer_channel_device_reduction(device_ty,core_ty);
-
-  double macro_layout_overhead   = g_tp.macro_layout_overhead;
-  double chip_PR_overhead        = g_tp.chip_layout_overhead;
-  double total_overhead          = macro_layout_overhead*chip_PR_overhead;
-
-  double pppm_t[4]    = {total_overhead,1,1,total_overhead};
+  // maintain constant power density
+  double pppm_t[4] = {total_overhead, 1, 1, total_overhead};
 
   double sckRation = g_tp.sckt_co_eff;
   local_result.power.readOp.dynamic *= sckRation;
   local_result.power.writeOp.dynamic *= sckRation;
   local_result.power.searchOp.dynamic *= sckRation;
   local_result.power.readOp.leakage *= l_ip.nbanks;
-  local_result.power.readOp.longer_channel_leakage = local_result.power.readOp.leakage*long_channel_device_reduction;
-  local_result.power = local_result.power* pppm_t;
+  local_result.power.readOp.longer_channel_leakage =
+      local_result.power.readOp.leakage * long_channel_device_reduction;
+  local_result.power = local_result.power * pppm_t;
 
   local_result.data_array2->power.readOp.dynamic *= sckRation;
   local_result.data_array2->power.writeOp.dynamic *= sckRation;
   local_result.data_array2->power.searchOp.dynamic *= sckRation;
   local_result.data_array2->power.readOp.leakage *= l_ip.nbanks;
-  local_result.data_array2->power.readOp.longer_channel_leakage = local_result.data_array2->power.readOp.leakage*long_channel_device_reduction;
-  local_result.data_array2->power = local_result.data_array2->power* pppm_t;
+  local_result.data_array2->power.readOp.longer_channel_leakage =
+      local_result.data_array2->power.readOp.leakage *
+      long_channel_device_reduction;
+  local_result.data_array2->power = local_result.data_array2->power * pppm_t;
 
-  if (!(l_ip.pure_cam || l_ip.pure_ram || l_ip.fully_assoc) && l_ip.is_cache)
-  {
+  if (!(l_ip.pure_cam || l_ip.pure_ram || l_ip.fully_assoc) && l_ip.is_cache) {
     local_result.tag_array2->power.readOp.dynamic *= sckRation;
     local_result.tag_array2->power.writeOp.dynamic *= sckRation;
     local_result.tag_array2->power.searchOp.dynamic *= sckRation;
     local_result.tag_array2->power.readOp.leakage *= l_ip.nbanks;
-    local_result.tag_array2->power.readOp.longer_channel_leakage = local_result.tag_array2->power.readOp.leakage*long_channel_device_reduction;
-    local_result.tag_array2->power = local_result.tag_array2->power* pppm_t;
+    local_result.tag_array2->power.readOp.longer_channel_leakage =
+        local_result.tag_array2->power.readOp.leakage *
+        long_channel_device_reduction;
+    local_result.tag_array2->power = local_result.tag_array2->power * pppm_t;
   }
 }
 
-ArrayST:: ~ArrayST()
-{
-	local_result.cleanup();
+void ArrayST::leakage_feedback(double temperature) {
+  // Update the temperature. l_ip is already set and error-checked in the
+  // creator function.
+  l_ip.temp = (unsigned int)round(temperature / 10.0) * 10;
+
+  // This corresponds to cacti_interface() in the initialization process.
+  // Leakage power is updated here.
+  reconfigure(&l_ip, &local_result);
+
+  // Scale the power values. This is part of ArrayST::optimize_array().
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(device_ty, core_ty);
+
+  double macro_layout_overhead = g_tp.macro_layout_overhead;
+  double chip_PR_overhead = g_tp.chip_layout_overhead;
+  double total_overhead = macro_layout_overhead * chip_PR_overhead;
+
+  double pppm_t[4] = {total_overhead, 1, 1, total_overhead};
+
+  double sckRation = g_tp.sckt_co_eff;
+  local_result.power.readOp.dynamic *= sckRation;
+  local_result.power.writeOp.dynamic *= sckRation;
+  local_result.power.searchOp.dynamic *= sckRation;
+  local_result.power.readOp.leakage *= l_ip.nbanks;
+  local_result.power.readOp.longer_channel_leakage =
+      local_result.power.readOp.leakage * long_channel_device_reduction;
+  local_result.power = local_result.power * pppm_t;
+
+  local_result.data_array2->power.readOp.dynamic *= sckRation;
+  local_result.data_array2->power.writeOp.dynamic *= sckRation;
+  local_result.data_array2->power.searchOp.dynamic *= sckRation;
+  local_result.data_array2->power.readOp.leakage *= l_ip.nbanks;
+  local_result.data_array2->power.readOp.longer_channel_leakage =
+      local_result.data_array2->power.readOp.leakage *
+      long_channel_device_reduction;
+  local_result.data_array2->power = local_result.data_array2->power * pppm_t;
+
+  if (!(l_ip.pure_cam || l_ip.pure_ram || l_ip.fully_assoc) && l_ip.is_cache) {
+    local_result.tag_array2->power.readOp.dynamic *= sckRation;
+    local_result.tag_array2->power.writeOp.dynamic *= sckRation;
+    local_result.tag_array2->power.searchOp.dynamic *= sckRation;
+    local_result.tag_array2->power.readOp.leakage *= l_ip.nbanks;
+    local_result.tag_array2->power.readOp.longer_channel_leakage =
+        local_result.tag_array2->power.readOp.leakage *
+        long_channel_device_reduction;
+    local_result.tag_array2->power = local_result.tag_array2->power * pppm_t;
+  }
 }
+
+ArrayST::~ArrayST() { local_result.cleanup(); }

--- a/src/gpuwattch/array.cc
+++ b/src/gpuwattch/array.cc
@@ -29,273 +29,281 @@
  *
  ***************************************************************************/
 
-#define  GLOBALVAR
+#define GLOBALVAR
+#include "array.h"
+#include <assert.h>
+#include <math.h>
+#include <iostream>
 #include "cacti/area.h"
 #include "decoder.h"
-#include "parameter.h"
-#include "array.h"
-#include <iostream>
-#include <math.h>
-#include <assert.h>
 #include "globalvar.h"
+#include "parameter.h"
 
 using namespace std;
 
-ArrayST::ArrayST(const InputParameter *configure_interface,
-		               string _name,
-		               enum Device_ty device_ty_,
-		               bool opt_local_,
-		               enum Core_type core_ty_,
-		               bool _is_default)
-:l_ip(*configure_interface),
- name(_name),
- device_ty(device_ty_),
- opt_local(opt_local_),
- core_ty(core_ty_),
- is_default(_is_default)
-    {
-
-	if (l_ip.cache_sz<64) l_ip.cache_sz=64;
-	l_ip.error_checking();//not only do the error checking but also fill some missing parameters
-	optimize_array();
-
+ArrayST::ArrayST(const InputParameter *configure_interface, string _name,
+                 enum Device_ty device_ty_, bool opt_local_,
+                 enum Core_type core_ty_, bool _is_default)
+    : l_ip(*configure_interface),
+      name(_name),
+      device_ty(device_ty_),
+      opt_local(opt_local_),
+      core_ty(core_ty_),
+      is_default(_is_default) {
+  if (l_ip.cache_sz < 64) l_ip.cache_sz = 64;
+  l_ip.error_checking();  // not only do the error checking but also fill some
+                          // missing parameters
+  optimize_array();
 }
 
+void ArrayST::compute_base_power() {
+  // l_ip.out_w               =l_ip.line_sz*8;
+  local_result = cacti_interface(&l_ip);
+}
 
-void ArrayST::compute_base_power()
-    {
-	//l_ip.out_w               =l_ip.line_sz*8;
-    local_result=cacti_interface(&l_ip);
+void ArrayST::optimize_array() {
+  list<uca_org_t> candidate_solutions(0);
+  list<uca_org_t>::iterator candidate_iter, min_dynamic_energy_iter;
 
+  uca_org_t *temp_res = 0;
+  local_result.valid = false;
+
+  double throughput = l_ip.throughput, latency = l_ip.latency;
+  double area_efficiency_threshold = 20.0;
+  bool throughput_overflow = true, latency_overflow = true;
+  compute_base_power();
+
+  if ((local_result.cycle_time - throughput) <= 1e-10)
+    throughput_overflow = false;
+  if ((local_result.access_time - latency) <= 1e-10) latency_overflow = false;
+
+  if (opt_for_clk && opt_local) {
+    if (throughput_overflow || latency_overflow) {
+      l_ip.ed = 0;
+
+      l_ip.delay_wt = 100;  // Fixed number, make sure timing can be satisfied.
+      l_ip.cycle_time_wt = 1000;
+
+      l_ip.area_wt = 10;  // Fixed number, This is used to exhaustive search for
+                          // individual components.
+      l_ip.dynamic_power_wt = 10;  // Fixed number, This is used to exhaustive
+                                   // search for individual components.
+      l_ip.leakage_power_wt = 10;
+
+      l_ip.delay_dev =
+          1000000;  // Fixed number, make sure timing can be satisfied.
+      l_ip.cycle_time_dev = 100;
+
+      l_ip.area_dev = 1000000;  // Fixed number, This is used to exhaustive
+                                // search for individual components.
+      l_ip.dynamic_power_dev =
+          1000000;  // Fixed number, This is used to exhaustive search for
+                    // individual components.
+      l_ip.leakage_power_dev = 1000000;
+
+      throughput_overflow =
+          true;  // Reset overflow flag before start optimization iterations
+      latency_overflow = true;
+
+      temp_res = &local_result;  // Clean up the result for optimized for ED^2P
+      temp_res->cleanup();
     }
 
-void ArrayST::optimize_array()
-{
-	list<uca_org_t > candidate_solutions(0);
-	list<uca_org_t >::iterator candidate_iter, min_dynamic_energy_iter;
+    while ((throughput_overflow || latency_overflow) &&
+           l_ip.cycle_time_dev > 10)  // && l_ip.delay_dev > 10
+    {
+      compute_base_power();
 
-	uca_org_t * temp_res = 0;
-	local_result.valid=false;
+      l_ip.cycle_time_dev -=
+          10;  // This is the time_dev to be used for next iteration
 
-	double 	throughput=l_ip.throughput, latency=l_ip.latency;
-	double  area_efficiency_threshold = 20.0;
-	bool 	throughput_overflow=true, latency_overflow=true;
-	compute_base_power();
+      //		from best area to worst area -->worst timing to best
+      // timing
+      if ((((local_result.cycle_time - throughput) <= 1e-10) &&
+           (local_result.access_time - latency) <= 1e-10) ||
+          (local_result.data_array2->area_efficiency <
+               area_efficiency_threshold &&
+           l_ip.assoc == 0)) {  // if no satisfiable solution is found,the most
+                                // aggressive one is left
+        candidate_solutions.push_back(local_result);
+        // output_data_csv(candidate_solutions.back());
+        if (((local_result.cycle_time - throughput) <= 1e-10) &&
+            ((local_result.access_time - latency) <= 1e-10))
+        // ensure stop opt not because of cam
+        {
+          throughput_overflow = false;
+          latency_overflow = false;
+        }
 
-	if ((local_result.cycle_time - throughput) <= 1e-10 )
-		throughput_overflow=false;
-	if ((local_result.access_time - latency)<= 1e-10)
-		latency_overflow=false;
+      } else {
+        // TODO: whether checking the partial satisfied results too, or just
+        // change the mark???
+        if ((local_result.cycle_time - throughput) <= 1e-10)
+          throughput_overflow = false;
+        if ((local_result.access_time - latency) <= 1e-10)
+          latency_overflow = false;
 
-	if (opt_for_clk && opt_local)
-	{
-		if (throughput_overflow || latency_overflow)
-		{
-			l_ip.ed=0;
+        if (l_ip.cycle_time_dev > 10) {  // if not >10 local_result is the last
+                                         // result, it cannot be cleaned up
+          temp_res = &local_result;      // Only solutions not saved in the list
+                                         // need to be cleaned up
+          temp_res->cleanup();
+        }
+      }
+      //			l_ip.cycle_time_dev-=10;
+      //			l_ip.delay_dev-=10;
+    }
 
-			l_ip.delay_wt                = 100;//Fixed number, make sure timing can be satisfied.
-			l_ip.cycle_time_wt           = 1000;
+    if (l_ip.assoc > 0) {
+      // For array structures except CAM and FA, Give warning but still provide
+      // a result with best timing found
+      if (throughput_overflow == true)
+        cout << "Warning: " << name
+             << " array structure cannot satisfy throughput constraint."
+             << endl;
+      if (latency_overflow == true)
+        cout << "Warning: " << name
+             << " array structure cannot satisfy latency constraint." << endl;
+    }
 
-			l_ip.area_wt                 = 10;//Fixed number, This is used to exhaustive search for individual components.
-			l_ip.dynamic_power_wt        = 10;//Fixed number, This is used to exhaustive search for individual components.
-			l_ip.leakage_power_wt        = 10;
+    //	else
+    //	{
+    //		/*According to "Content-Addressable Memory (CAM) Circuits and
+    //				Architectures": A Tutorial and Survey
+    //				by Kostas Pagiamtzis et al.
+    //				CAM structures can be heavily pipelined and use
+    // look-ahead techniques, 				therefore timing can be
+    // relaxed. But McPAT does not model the
+    // advanced 				techniques. If continue optimizing, the area efficiency
+    // will be too low
+    //		*/
+    //		//For CAM and FA, stop opt if area efficiency is too low
+    //		if (throughput_overflow==true)
+    //			cout<< "Warning: " <<" McPAT stopped optimization on
+    //throughput for
+    //"<< name
+    //				<<" array structure because its area efficiency
+    //is below
+    //"<<area_efficiency_threshold<<"% " << endl; 		if
+    //(latency_overflow==true) 			cout<< "Warning: " <<" McPAT stopped
+    //optimization on latency for "<< name
+    //				<<" array structure because its area efficiency
+    //is below
+    //"<<area_efficiency_threshold<<"% " << endl;
+    //	}
 
-			l_ip.delay_dev               = 1000000;//Fixed number, make sure timing can be satisfied.
-			l_ip.cycle_time_dev          = 100;
+    // double min_dynamic_energy, min_dynamic_power, min_leakage_power,
+    // min_cycle_time;
+    double min_dynamic_energy = BIGNUM;
+    if (candidate_solutions.empty() == false) {
+      local_result.valid = true;
+      for (candidate_iter = candidate_solutions.begin();
+           candidate_iter != candidate_solutions.end(); ++candidate_iter)
 
-			l_ip.area_dev                = 1000000;//Fixed number, This is used to exhaustive search for individual components.
-			l_ip.dynamic_power_dev       = 1000000;//Fixed number, This is used to exhaustive search for individual components.
-			l_ip.leakage_power_dev       = 1000000;
+      {
+        if (min_dynamic_energy > (candidate_iter)->power.readOp.dynamic) {
+          min_dynamic_energy = (candidate_iter)->power.readOp.dynamic;
+          min_dynamic_energy_iter = candidate_iter;
+          local_result = *(min_dynamic_energy_iter);
+          // TODO: since results are reordered results and l_ip may miss match.
+          // Therefore, the final output spread sheets may show the miss match.
 
-			throughput_overflow=true; //Reset overflow flag before start optimization iterations
-			latency_overflow=true;
+        } else {
+          candidate_iter->cleanup();
+        }
+      }
+    }
+    candidate_solutions.clear();
+  }
 
-			temp_res = &local_result; //Clean up the result for optimized for ED^2P
-			temp_res->cleanup();
-		}
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(device_ty, core_ty);
 
+  double macro_layout_overhead = g_tp.macro_layout_overhead;
+  double chip_PR_overhead = g_tp.chip_layout_overhead;
+  double total_overhead = macro_layout_overhead * chip_PR_overhead;
+  local_result.area *= total_overhead;
 
-		while ((throughput_overflow || latency_overflow)&&l_ip.cycle_time_dev > 10)// && l_ip.delay_dev > 10
-		{
-			compute_base_power();
-
-			l_ip.cycle_time_dev-=10;//This is the time_dev to be used for next iteration
-
-			//		from best area to worst area -->worst timing to best timing
-			if ((((local_result.cycle_time - throughput) <= 1e-10 ) && (local_result.access_time - latency)<= 1e-10)||
-					(local_result.data_array2->area_efficiency < area_efficiency_threshold && l_ip.assoc == 0))
-			{  //if no satisfiable solution is found,the most aggressive one is left
-				candidate_solutions.push_back(local_result);
-				//output_data_csv(candidate_solutions.back());
-				if (((local_result.cycle_time - throughput) <= 1e-10) && ((local_result.access_time - latency)<= 1e-10))
-					//ensure stop opt not because of cam
-				{
-					throughput_overflow=false;
-					latency_overflow=false;
-				}
-
-			}
-			else
-			{
-				//TODO: whether checking the partial satisfied results too, or just change the mark???
-				if ((local_result.cycle_time - throughput) <= 1e-10)
-										throughput_overflow=false;
-				if ((local_result.access_time - latency)<= 1e-10)
-										latency_overflow=false;
-
-				if (l_ip.cycle_time_dev > 10)
-				{   //if not >10 local_result is the last result, it cannot be cleaned up
-					temp_res = &local_result; //Only solutions not saved in the list need to be cleaned up
-					temp_res->cleanup();
-				}
-			}
-//			l_ip.cycle_time_dev-=10;
-//			l_ip.delay_dev-=10;
-
-		}
-
-
-	if (l_ip.assoc > 0)
-	{
-		//For array structures except CAM and FA, Give warning but still provide a result with best timing found
-		if (throughput_overflow==true)
-			cout<< "Warning: " << name<<" array structure cannot satisfy throughput constraint." << endl;
-		if (latency_overflow==true)
-			cout<< "Warning: " << name<<" array structure cannot satisfy latency constraint." << endl;
-	}
-
-//	else
-//	{
-//		/*According to "Content-Addressable Memory (CAM) Circuits and
-//				Architectures": A Tutorial and Survey
-//				by Kostas Pagiamtzis et al.
-//				CAM structures can be heavily pipelined and use look-ahead techniques,
-//				therefore timing can be relaxed. But McPAT does not model the advanced
-//				techniques. If continue optimizing, the area efficiency will be too low
-//		*/
-//		//For CAM and FA, stop opt if area efficiency is too low
-//		if (throughput_overflow==true)
-//			cout<< "Warning: " <<" McPAT stopped optimization on throughput for "<< name
-//				<<" array structure because its area efficiency is below "<<area_efficiency_threshold<<"% " << endl;
-//		if (latency_overflow==true)
-//			cout<< "Warning: " <<" McPAT stopped optimization on latency for "<< name
-//				<<" array structure because its area efficiency is below "<<area_efficiency_threshold<<"% " << endl;
-//	}
-
-		//double min_dynamic_energy, min_dynamic_power, min_leakage_power, min_cycle_time;
-		double min_dynamic_energy=BIGNUM;
-		if (candidate_solutions.empty()==false)
-		{
-			local_result.valid=true;
-			for (candidate_iter = candidate_solutions.begin(); candidate_iter != candidate_solutions.end(); ++candidate_iter)
-
-			{
-				if (min_dynamic_energy > (candidate_iter)->power.readOp.dynamic)
-				{
-					min_dynamic_energy = (candidate_iter)->power.readOp.dynamic;
-					min_dynamic_energy_iter = candidate_iter;
-					local_result = *(min_dynamic_energy_iter);
-					//TODO: since results are reordered results and l_ip may miss match. Therefore, the final output spread sheets may show the miss match.
-
-				}
-				else
-				{
-					candidate_iter->cleanup() ;
-				}
-
-			}
-
-
-		}
-	candidate_solutions.clear();
-	}
-
-	double long_channel_device_reduction = longer_channel_device_reduction(device_ty,core_ty);
-
-	double macro_layout_overhead   = g_tp.macro_layout_overhead;
-	double chip_PR_overhead        = g_tp.chip_layout_overhead;
-	double total_overhead          = macro_layout_overhead*chip_PR_overhead;
-	local_result.area *= total_overhead;
-
-	//maintain constant power density
-	double pppm_t[4]    = {total_overhead,1,1,total_overhead};
-
-	double sckRation = g_tp.sckt_co_eff;
-	local_result.power.readOp.dynamic *= sckRation;
-	local_result.power.writeOp.dynamic *= sckRation;
-	local_result.power.searchOp.dynamic *= sckRation;
-	local_result.power.readOp.leakage *= l_ip.nbanks;
-	local_result.power.readOp.longer_channel_leakage =
-		local_result.power.readOp.leakage*long_channel_device_reduction;
-	local_result.power = local_result.power* pppm_t;
-
-	local_result.data_array2->power.readOp.dynamic *= sckRation;
-	local_result.data_array2->power.writeOp.dynamic *= sckRation;
-	local_result.data_array2->power.searchOp.dynamic *= sckRation;
-	local_result.data_array2->power.readOp.leakage *= l_ip.nbanks;
-	local_result.data_array2->power.readOp.longer_channel_leakage =
-		local_result.data_array2->power.readOp.leakage*long_channel_device_reduction;
-	local_result.data_array2->power = local_result.data_array2->power* pppm_t;
-
-
-	if (!(l_ip.pure_cam || l_ip.pure_ram || l_ip.fully_assoc) && l_ip.is_cache)
-	{
-		local_result.tag_array2->power.readOp.dynamic *= sckRation;
-		local_result.tag_array2->power.writeOp.dynamic *= sckRation;
-		local_result.tag_array2->power.searchOp.dynamic *= sckRation;
-		local_result.tag_array2->power.readOp.leakage *= l_ip.nbanks;
-		local_result.tag_array2->power.readOp.longer_channel_leakage =
-			local_result.tag_array2->power.readOp.leakage*long_channel_device_reduction;
-		local_result.tag_array2->power = local_result.tag_array2->power* pppm_t;
-	}
-
-
-}
-
-void ArrayST::leakage_feedback(double temperature)
-{
-  // Update the temperature. l_ip is already set and error-checked in the creator function.
-  l_ip.temp = (unsigned int)round(temperature/10.0)*10;
-
-  // This corresponds to cacti_interface() in the initialization process. Leakage power is updated here.
-  reconfigure(&l_ip,&local_result);
-
-  // Scale the power values. This is part of ArrayST::optimize_array().
-  double long_channel_device_reduction = longer_channel_device_reduction(device_ty,core_ty);
-
-  double macro_layout_overhead   = g_tp.macro_layout_overhead;
-  double chip_PR_overhead        = g_tp.chip_layout_overhead;
-  double total_overhead          = macro_layout_overhead*chip_PR_overhead;
-
-  double pppm_t[4]    = {total_overhead,1,1,total_overhead};
+  // maintain constant power density
+  double pppm_t[4] = {total_overhead, 1, 1, total_overhead};
 
   double sckRation = g_tp.sckt_co_eff;
   local_result.power.readOp.dynamic *= sckRation;
   local_result.power.writeOp.dynamic *= sckRation;
   local_result.power.searchOp.dynamic *= sckRation;
   local_result.power.readOp.leakage *= l_ip.nbanks;
-  local_result.power.readOp.longer_channel_leakage = local_result.power.readOp.leakage*long_channel_device_reduction;
-  local_result.power = local_result.power* pppm_t;
+  local_result.power.readOp.longer_channel_leakage =
+      local_result.power.readOp.leakage * long_channel_device_reduction;
+  local_result.power = local_result.power * pppm_t;
 
   local_result.data_array2->power.readOp.dynamic *= sckRation;
   local_result.data_array2->power.writeOp.dynamic *= sckRation;
   local_result.data_array2->power.searchOp.dynamic *= sckRation;
   local_result.data_array2->power.readOp.leakage *= l_ip.nbanks;
-  local_result.data_array2->power.readOp.longer_channel_leakage = local_result.data_array2->power.readOp.leakage*long_channel_device_reduction;
-  local_result.data_array2->power = local_result.data_array2->power* pppm_t;
+  local_result.data_array2->power.readOp.longer_channel_leakage =
+      local_result.data_array2->power.readOp.leakage *
+      long_channel_device_reduction;
+  local_result.data_array2->power = local_result.data_array2->power * pppm_t;
 
-  if (!(l_ip.pure_cam || l_ip.pure_ram || l_ip.fully_assoc) && l_ip.is_cache)
-  {
+  if (!(l_ip.pure_cam || l_ip.pure_ram || l_ip.fully_assoc) && l_ip.is_cache) {
     local_result.tag_array2->power.readOp.dynamic *= sckRation;
     local_result.tag_array2->power.writeOp.dynamic *= sckRation;
     local_result.tag_array2->power.searchOp.dynamic *= sckRation;
     local_result.tag_array2->power.readOp.leakage *= l_ip.nbanks;
-    local_result.tag_array2->power.readOp.longer_channel_leakage = local_result.tag_array2->power.readOp.leakage*long_channel_device_reduction;
-    local_result.tag_array2->power = local_result.tag_array2->power* pppm_t;
+    local_result.tag_array2->power.readOp.longer_channel_leakage =
+        local_result.tag_array2->power.readOp.leakage *
+        long_channel_device_reduction;
+    local_result.tag_array2->power = local_result.tag_array2->power * pppm_t;
   }
 }
 
-ArrayST:: ~ArrayST()
-{
-	local_result.cleanup();
+void ArrayST::leakage_feedback(double temperature) {
+  // Update the temperature. l_ip is already set and error-checked in the
+  // creator function.
+  l_ip.temp = (unsigned int)round(temperature / 10.0) * 10;
+
+  // This corresponds to cacti_interface() in the initialization process.
+  // Leakage power is updated here.
+  reconfigure(&l_ip, &local_result);
+
+  // Scale the power values. This is part of ArrayST::optimize_array().
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(device_ty, core_ty);
+
+  double macro_layout_overhead = g_tp.macro_layout_overhead;
+  double chip_PR_overhead = g_tp.chip_layout_overhead;
+  double total_overhead = macro_layout_overhead * chip_PR_overhead;
+
+  double pppm_t[4] = {total_overhead, 1, 1, total_overhead};
+
+  double sckRation = g_tp.sckt_co_eff;
+  local_result.power.readOp.dynamic *= sckRation;
+  local_result.power.writeOp.dynamic *= sckRation;
+  local_result.power.searchOp.dynamic *= sckRation;
+  local_result.power.readOp.leakage *= l_ip.nbanks;
+  local_result.power.readOp.longer_channel_leakage =
+      local_result.power.readOp.leakage * long_channel_device_reduction;
+  local_result.power = local_result.power * pppm_t;
+
+  local_result.data_array2->power.readOp.dynamic *= sckRation;
+  local_result.data_array2->power.writeOp.dynamic *= sckRation;
+  local_result.data_array2->power.searchOp.dynamic *= sckRation;
+  local_result.data_array2->power.readOp.leakage *= l_ip.nbanks;
+  local_result.data_array2->power.readOp.longer_channel_leakage =
+      local_result.data_array2->power.readOp.leakage *
+      long_channel_device_reduction;
+  local_result.data_array2->power = local_result.data_array2->power * pppm_t;
+
+  if (!(l_ip.pure_cam || l_ip.pure_ram || l_ip.fully_assoc) && l_ip.is_cache) {
+    local_result.tag_array2->power.readOp.dynamic *= sckRation;
+    local_result.tag_array2->power.writeOp.dynamic *= sckRation;
+    local_result.tag_array2->power.searchOp.dynamic *= sckRation;
+    local_result.tag_array2->power.readOp.leakage *= l_ip.nbanks;
+    local_result.tag_array2->power.readOp.longer_channel_leakage =
+        local_result.tag_array2->power.readOp.leakage *
+        long_channel_device_reduction;
+    local_result.tag_array2->power = local_result.tag_array2->power * pppm_t;
+  }
 }
+
+ArrayST::~ArrayST() { local_result.cleanup(); }

--- a/src/gpuwattch/array.cc
+++ b/src/gpuwattch/array.cc
@@ -174,8 +174,8 @@ void ArrayST::optimize_array() {
     //				CAM structures can be heavily pipelined and use
     // look-ahead techniques, 				therefore timing can be
     // relaxed. But McPAT does not model the
-    // advanced 				techniques. If continue optimizing, the
-    // area efficiency will be too low
+    // advanced 				techniques. If continue
+    // optimizing, the area efficiency will be too low
     //		*/
     //		//For CAM and FA, stop opt if area efficiency is too low
     //		if (throughput_overflow==true)

--- a/src/gpuwattch/array.h
+++ b/src/gpuwattch/array.h
@@ -32,69 +32,86 @@
 #ifndef ARRAY_H_
 #define ARRAY_H_
 
-#include "basic_components.h"
-#include "cacti/const.h"
-#include "cacti/cacti_interface.h"
-#include "cacti/parameter.h"
-#include "cacti/component.h"
 #include <iostream>
 #include <string>
+#include "basic_components.h"
+#include "cacti/cacti_interface.h"
+#include "cacti/component.h"
+#include "cacti/const.h"
+#include "cacti/parameter.h"
 
 using namespace std;
 
-class ArrayST :public Component{
+class ArrayST : public Component {
  public:
   ArrayST(){};
-  ArrayST(const InputParameter *configure_interface, string _name, enum Device_ty device_ty_, bool opt_local_=true, enum Core_type core_ty_=Inorder,  bool _is_default=true);
+  ArrayST(const InputParameter* configure_interface, string _name,
+          enum Device_ty device_ty_, bool opt_local_ = true,
+          enum Core_type core_ty_ = Inorder, bool _is_default = true);
 
   InputParameter l_ip;
-  string         name;
+  string name;
   enum Device_ty device_ty;
   bool opt_local;
   enum Core_type core_ty;
-  bool           is_default;
-  uca_org_t      local_result;
+  bool is_default;
+  uca_org_t local_result;
 
-  statsDef       tdp_stats;
-  statsDef       rtp_stats;
-  statsDef       stats_t;
-  powerDef       power_t;
+  statsDef tdp_stats;
+  statsDef rtp_stats;
+  statsDef stats_t;
+  powerDef power_t;
 
   virtual void optimize_array();
   virtual void compute_base_power();
   virtual ~ArrayST();
-  
+
   void leakage_feedback(double temperature);
 };
 
-class InstCache :public Component{
-public:
+class InstCache : public Component {
+ public:
   ArrayST* caches;
   ArrayST* missb;
   ArrayST* ifb;
   ArrayST* prefetchb;
-  powerDef power_t;//temp value holder for both (max) power and runtime power
-  InstCache(){caches=0;missb=0;ifb=0;prefetchb=0;};
-  ~InstCache(){
-	  if (caches)    {//caches->local_result.cleanup();
-					  delete caches; caches=0;}
-	  if (missb)     {//missb->local_result.cleanup();
-					  delete missb; missb=0;}
-	  if (ifb)       {//ifb->local_result.cleanup();
-					  delete ifb; ifb=0;}
-	  if (prefetchb) {//prefetchb->local_result.cleanup();
-					  delete prefetchb; prefetchb=0;}
-   };
+  powerDef power_t;  // temp value holder for both (max) power and runtime power
+  InstCache() {
+    caches = 0;
+    missb = 0;
+    ifb = 0;
+    prefetchb = 0;
+  };
+  ~InstCache() {
+    if (caches) {  // caches->local_result.cleanup();
+      delete caches;
+      caches = 0;
+    }
+    if (missb) {  // missb->local_result.cleanup();
+      delete missb;
+      missb = 0;
+    }
+    if (ifb) {  // ifb->local_result.cleanup();
+      delete ifb;
+      ifb = 0;
+    }
+    if (prefetchb) {  // prefetchb->local_result.cleanup();
+      delete prefetchb;
+      prefetchb = 0;
+    }
+  };
 };
 
-class DataCache :public InstCache{
-public:
+class DataCache : public InstCache {
+ public:
   ArrayST* wbb;
-  DataCache(){wbb=0;};
-  ~DataCache(){
-	  if (wbb) {//wbb->local_result.cleanup();
-				delete wbb; wbb=0;}
-   };
+  DataCache() { wbb = 0; };
+  ~DataCache() {
+    if (wbb) {  // wbb->local_result.cleanup();
+      delete wbb;
+      wbb = 0;
+    }
+  };
 };
 
 #endif /* TLB_H_ */

--- a/src/gpuwattch/array.h
+++ b/src/gpuwattch/array.h
@@ -32,86 +32,69 @@
 #ifndef ARRAY_H_
 #define ARRAY_H_
 
+#include "basic_components.h"
+#include "cacti/const.h"
+#include "cacti/cacti_interface.h"
+#include "cacti/parameter.h"
+#include "cacti/component.h"
 #include <iostream>
 #include <string>
-#include "basic_components.h"
-#include "cacti/cacti_interface.h"
-#include "cacti/component.h"
-#include "cacti/const.h"
-#include "cacti/parameter.h"
 
 using namespace std;
 
-class ArrayST : public Component {
+class ArrayST :public Component{
  public:
   ArrayST(){};
-  ArrayST(const InputParameter* configure_interface, string _name,
-          enum Device_ty device_ty_, bool opt_local_ = true,
-          enum Core_type core_ty_ = Inorder, bool _is_default = true);
+  ArrayST(const InputParameter *configure_interface, string _name, enum Device_ty device_ty_, bool opt_local_=true, enum Core_type core_ty_=Inorder,  bool _is_default=true);
 
   InputParameter l_ip;
-  string name;
+  string         name;
   enum Device_ty device_ty;
   bool opt_local;
   enum Core_type core_ty;
-  bool is_default;
-  uca_org_t local_result;
+  bool           is_default;
+  uca_org_t      local_result;
 
-  statsDef tdp_stats;
-  statsDef rtp_stats;
-  statsDef stats_t;
-  powerDef power_t;
+  statsDef       tdp_stats;
+  statsDef       rtp_stats;
+  statsDef       stats_t;
+  powerDef       power_t;
 
   virtual void optimize_array();
   virtual void compute_base_power();
   virtual ~ArrayST();
-
+  
   void leakage_feedback(double temperature);
 };
 
-class InstCache : public Component {
- public:
+class InstCache :public Component{
+public:
   ArrayST* caches;
   ArrayST* missb;
   ArrayST* ifb;
   ArrayST* prefetchb;
-  powerDef power_t;  // temp value holder for both (max) power and runtime power
-  InstCache() {
-    caches = 0;
-    missb = 0;
-    ifb = 0;
-    prefetchb = 0;
-  };
-  ~InstCache() {
-    if (caches) {  // caches->local_result.cleanup();
-      delete caches;
-      caches = 0;
-    }
-    if (missb) {  // missb->local_result.cleanup();
-      delete missb;
-      missb = 0;
-    }
-    if (ifb) {  // ifb->local_result.cleanup();
-      delete ifb;
-      ifb = 0;
-    }
-    if (prefetchb) {  // prefetchb->local_result.cleanup();
-      delete prefetchb;
-      prefetchb = 0;
-    }
-  };
+  powerDef power_t;//temp value holder for both (max) power and runtime power
+  InstCache(){caches=0;missb=0;ifb=0;prefetchb=0;};
+  ~InstCache(){
+	  if (caches)    {//caches->local_result.cleanup();
+					  delete caches; caches=0;}
+	  if (missb)     {//missb->local_result.cleanup();
+					  delete missb; missb=0;}
+	  if (ifb)       {//ifb->local_result.cleanup();
+					  delete ifb; ifb=0;}
+	  if (prefetchb) {//prefetchb->local_result.cleanup();
+					  delete prefetchb; prefetchb=0;}
+   };
 };
 
-class DataCache : public InstCache {
- public:
+class DataCache :public InstCache{
+public:
   ArrayST* wbb;
-  DataCache() { wbb = 0; };
-  ~DataCache() {
-    if (wbb) {  // wbb->local_result.cleanup();
-      delete wbb;
-      wbb = 0;
-    }
-  };
+  DataCache(){wbb=0;};
+  ~DataCache(){
+	  if (wbb) {//wbb->local_result.cleanup();
+				delete wbb; wbb=0;}
+   };
 };
 
 #endif /* TLB_H_ */

--- a/src/gpuwattch/basic_components.cc
+++ b/src/gpuwattch/basic_components.cc
@@ -30,97 +30,87 @@
  ***************************************************************************/
 
 #include "basic_components.h"
-#include <iostream>
 #include <assert.h>
 #include <cmath>
+#include <iostream>
 
-double longer_channel_device_reduction(
-		enum Device_ty device_ty,
-		enum Core_type core_ty)
-{
+double longer_channel_device_reduction(enum Device_ty device_ty,
+                                       enum Core_type core_ty) {
+  double longer_channel_device_percentage_core;
+  double longer_channel_device_percentage_uncore;
+  double longer_channel_device_percentage_llc;
 
-	double longer_channel_device_percentage_core;
-	double longer_channel_device_percentage_uncore;
-	double longer_channel_device_percentage_llc;
+  double long_channel_device_reduction;
 
-	double long_channel_device_reduction;
+  longer_channel_device_percentage_llc = 1.0;
+  longer_channel_device_percentage_uncore = 0.82;
+  if (core_ty == OOO) {
+    longer_channel_device_percentage_core =
+        0.56;  // 0.54 Xeon Tulsa //0.58 Nehelam
+    // longer_channel_device_percentage_uncore = 0.76;//0.85 Nehelam
 
-	longer_channel_device_percentage_llc    = 1.0;
-	longer_channel_device_percentage_uncore = 0.82;
-	if (core_ty==OOO)
-	{
-		longer_channel_device_percentage_core   = 0.56;//0.54 Xeon Tulsa //0.58 Nehelam
-		//longer_channel_device_percentage_uncore = 0.76;//0.85 Nehelam
+  } else {
+    longer_channel_device_percentage_core = 0.8;  // 0.8;//Niagara
+    // longer_channel_device_percentage_uncore = 0.9;//Niagara
+  }
 
-	}
-	else
-	{
-		longer_channel_device_percentage_core   = 0.8;//0.8;//Niagara
-		//longer_channel_device_percentage_uncore = 0.9;//Niagara
-	}
+  if (device_ty == Core_device) {
+    long_channel_device_reduction =
+        (1 - longer_channel_device_percentage_core) +
+        longer_channel_device_percentage_core *
+            g_tp.peri_global.long_channel_leakage_reduction;
+  } else if (device_ty == Uncore_device) {
+    long_channel_device_reduction =
+        (1 - longer_channel_device_percentage_uncore) +
+        longer_channel_device_percentage_uncore *
+            g_tp.peri_global.long_channel_leakage_reduction;
+  } else if (device_ty == LLC_device) {
+    long_channel_device_reduction =
+        (1 - longer_channel_device_percentage_llc) +
+        longer_channel_device_percentage_llc *
+            g_tp.peri_global.long_channel_leakage_reduction;
+  } else {
+    cout << "unknown device category" << endl;
+    exit(0);
+  }
 
-	if (device_ty==Core_device)
-	{
-		long_channel_device_reduction = (1- longer_channel_device_percentage_core)
-		+ longer_channel_device_percentage_core * g_tp.peri_global.long_channel_leakage_reduction;
-	}
-	else if (device_ty==Uncore_device)
-	{
-		long_channel_device_reduction = (1- longer_channel_device_percentage_uncore)
-		+ longer_channel_device_percentage_uncore * g_tp.peri_global.long_channel_leakage_reduction;
-	}
-	else if (device_ty==LLC_device)
-	{
-		long_channel_device_reduction = (1- longer_channel_device_percentage_llc)
-		+ longer_channel_device_percentage_llc * g_tp.peri_global.long_channel_leakage_reduction;
-	}
-	else
-	{
-		cout<<"unknown device category"<<endl;
-		exit(0);
-	}
-
-	return long_channel_device_reduction;
+  return long_channel_device_reduction;
 }
 
-statsComponents operator+(const statsComponents & x, const statsComponents & y)
-{
-	statsComponents z;
+statsComponents operator+(const statsComponents& x, const statsComponents& y) {
+  statsComponents z;
 
-	z.access = x.access + y.access;
-	z.hit    = x.hit + y.hit;
-	z.miss   = x.miss  + y.miss;
+  z.access = x.access + y.access;
+  z.hit = x.hit + y.hit;
+  z.miss = x.miss + y.miss;
 
-	return z;
+  return z;
 }
 
-statsComponents operator*(const statsComponents & x, double const * const y)
-{
-	statsComponents z;
+statsComponents operator*(const statsComponents& x, double const* const y) {
+  statsComponents z;
 
-	z.access = x.access*y[0];
-	z.hit    = x.hit*y[1];
-	z.miss   = x.miss*y[2];
+  z.access = x.access * y[0];
+  z.hit = x.hit * y[1];
+  z.miss = x.miss * y[2];
 
-	return z;
+  return z;
 }
 
-statsDef operator+(const statsDef & x, const statsDef & y)
-{
-	statsDef z;
+statsDef operator+(const statsDef& x, const statsDef& y) {
+  statsDef z;
 
-	z.readAc   = x.readAc  + y.readAc;
-	z.writeAc  = x.writeAc + y.writeAc;
-	z.searchAc  = x.searchAc + y.searchAc;
-	return z;
+  z.readAc = x.readAc + y.readAc;
+  z.writeAc = x.writeAc + y.writeAc;
+  z.searchAc = x.searchAc + y.searchAc;
+  return z;
 }
 
-statsDef operator*(const statsDef & x, double const * const y)
-{
-	statsDef z;
+statsDef operator*(const statsDef& x, double const* const y) {
+  statsDef z;
 
-	z.readAc   = x.readAc*y;
-	z.writeAc  = x.writeAc*y;
-	z.searchAc  = x.searchAc*y;
-	return z;
+  z.readAc = x.readAc * y;
+  z.writeAc = x.writeAc * y;
+  z.searchAc = x.searchAc * y;
+  return z;
 }

--- a/src/gpuwattch/basic_components.cc
+++ b/src/gpuwattch/basic_components.cc
@@ -30,87 +30,97 @@
  ***************************************************************************/
 
 #include "basic_components.h"
+#include <iostream>
 #include <assert.h>
 #include <cmath>
-#include <iostream>
 
-double longer_channel_device_reduction(enum Device_ty device_ty,
-                                       enum Core_type core_ty) {
-  double longer_channel_device_percentage_core;
-  double longer_channel_device_percentage_uncore;
-  double longer_channel_device_percentage_llc;
+double longer_channel_device_reduction(
+		enum Device_ty device_ty,
+		enum Core_type core_ty)
+{
 
-  double long_channel_device_reduction;
+	double longer_channel_device_percentage_core;
+	double longer_channel_device_percentage_uncore;
+	double longer_channel_device_percentage_llc;
 
-  longer_channel_device_percentage_llc = 1.0;
-  longer_channel_device_percentage_uncore = 0.82;
-  if (core_ty == OOO) {
-    longer_channel_device_percentage_core =
-        0.56;  // 0.54 Xeon Tulsa //0.58 Nehelam
-    // longer_channel_device_percentage_uncore = 0.76;//0.85 Nehelam
+	double long_channel_device_reduction;
 
-  } else {
-    longer_channel_device_percentage_core = 0.8;  // 0.8;//Niagara
-    // longer_channel_device_percentage_uncore = 0.9;//Niagara
-  }
+	longer_channel_device_percentage_llc    = 1.0;
+	longer_channel_device_percentage_uncore = 0.82;
+	if (core_ty==OOO)
+	{
+		longer_channel_device_percentage_core   = 0.56;//0.54 Xeon Tulsa //0.58 Nehelam
+		//longer_channel_device_percentage_uncore = 0.76;//0.85 Nehelam
 
-  if (device_ty == Core_device) {
-    long_channel_device_reduction =
-        (1 - longer_channel_device_percentage_core) +
-        longer_channel_device_percentage_core *
-            g_tp.peri_global.long_channel_leakage_reduction;
-  } else if (device_ty == Uncore_device) {
-    long_channel_device_reduction =
-        (1 - longer_channel_device_percentage_uncore) +
-        longer_channel_device_percentage_uncore *
-            g_tp.peri_global.long_channel_leakage_reduction;
-  } else if (device_ty == LLC_device) {
-    long_channel_device_reduction =
-        (1 - longer_channel_device_percentage_llc) +
-        longer_channel_device_percentage_llc *
-            g_tp.peri_global.long_channel_leakage_reduction;
-  } else {
-    cout << "unknown device category" << endl;
-    exit(0);
-  }
+	}
+	else
+	{
+		longer_channel_device_percentage_core   = 0.8;//0.8;//Niagara
+		//longer_channel_device_percentage_uncore = 0.9;//Niagara
+	}
 
-  return long_channel_device_reduction;
+	if (device_ty==Core_device)
+	{
+		long_channel_device_reduction = (1- longer_channel_device_percentage_core)
+		+ longer_channel_device_percentage_core * g_tp.peri_global.long_channel_leakage_reduction;
+	}
+	else if (device_ty==Uncore_device)
+	{
+		long_channel_device_reduction = (1- longer_channel_device_percentage_uncore)
+		+ longer_channel_device_percentage_uncore * g_tp.peri_global.long_channel_leakage_reduction;
+	}
+	else if (device_ty==LLC_device)
+	{
+		long_channel_device_reduction = (1- longer_channel_device_percentage_llc)
+		+ longer_channel_device_percentage_llc * g_tp.peri_global.long_channel_leakage_reduction;
+	}
+	else
+	{
+		cout<<"unknown device category"<<endl;
+		exit(0);
+	}
+
+	return long_channel_device_reduction;
 }
 
-statsComponents operator+(const statsComponents& x, const statsComponents& y) {
-  statsComponents z;
+statsComponents operator+(const statsComponents & x, const statsComponents & y)
+{
+	statsComponents z;
 
-  z.access = x.access + y.access;
-  z.hit = x.hit + y.hit;
-  z.miss = x.miss + y.miss;
+	z.access = x.access + y.access;
+	z.hit    = x.hit + y.hit;
+	z.miss   = x.miss  + y.miss;
 
-  return z;
+	return z;
 }
 
-statsComponents operator*(const statsComponents& x, double const* const y) {
-  statsComponents z;
+statsComponents operator*(const statsComponents & x, double const * const y)
+{
+	statsComponents z;
 
-  z.access = x.access * y[0];
-  z.hit = x.hit * y[1];
-  z.miss = x.miss * y[2];
+	z.access = x.access*y[0];
+	z.hit    = x.hit*y[1];
+	z.miss   = x.miss*y[2];
 
-  return z;
+	return z;
 }
 
-statsDef operator+(const statsDef& x, const statsDef& y) {
-  statsDef z;
+statsDef operator+(const statsDef & x, const statsDef & y)
+{
+	statsDef z;
 
-  z.readAc = x.readAc + y.readAc;
-  z.writeAc = x.writeAc + y.writeAc;
-  z.searchAc = x.searchAc + y.searchAc;
-  return z;
+	z.readAc   = x.readAc  + y.readAc;
+	z.writeAc  = x.writeAc + y.writeAc;
+	z.searchAc  = x.searchAc + y.searchAc;
+	return z;
 }
 
-statsDef operator*(const statsDef& x, double const* const y) {
-  statsDef z;
+statsDef operator*(const statsDef & x, double const * const y)
+{
+	statsDef z;
 
-  z.readAc = x.readAc * y;
-  z.writeAc = x.writeAc * y;
-  z.searchAc = x.searchAc * y;
-  return z;
+	z.readAc   = x.readAc*y;
+	z.writeAc  = x.writeAc*y;
+	z.searchAc  = x.searchAc*y;
+	return z;
 }

--- a/src/gpuwattch/basic_components.h
+++ b/src/gpuwattch/basic_components.h
@@ -32,302 +32,284 @@
 #ifndef BASIC_COMPONENTS_H_
 #define BASIC_COMPONENTS_H_
 
+#include <vector>
 #include "XML_Parse.h"
 #include "cacti/parameter.h"
-#include <vector>
 
 const double cdb_overhead = 1.1;
 
-enum FU_type {
-    FPU,
-    ALU,
-    MUL
-};
+enum FU_type { FPU, ALU, MUL };
 
-enum Core_type {
-	OOO,
-	Inorder
-};
+enum Core_type { OOO, Inorder };
 
-enum Renaming_type {
-    RAMbased,
-	CAMbased
-};
+enum Renaming_type { RAMbased, CAMbased };
 
-enum Scheduler_type {
-    PhysicalRegFile,
-	ReservationStation
-};
+enum Scheduler_type { PhysicalRegFile, ReservationStation };
 
-enum cache_level {
-    L2,
-    L3,
-    L1Directory,
-    L2Directory
-};
+enum cache_level { L2, L3, L1Directory, L2Directory };
 
 enum MemoryCtrl_type {
-	MC,    //memory controller
-	FLASHC //flash controller
+  MC,     // memory controller
+  FLASHC  // flash controller
 };
 
-enum Dram_type {
-	GDDR5,
-	GDDR3
-};
-
+enum Dram_type { GDDR5, GDDR3 };
 
 enum Dir_type {
-	ST,//shadowed tag
-	DC,//directory cache
-	SBT,//static bank tag
-	NonDir
+  ST,   // shadowed tag
+  DC,   // directory cache
+  SBT,  // static bank tag
+  NonDir
 
 };
 
-enum Cache_policy {
-	Write_through,
-	Write_back
+enum Cache_policy { Write_through, Write_back };
+
+enum Device_ty { Core_device, Uncore_device, LLC_device };
+
+class statsComponents {
+ public:
+  double access;
+  double hit;
+  double miss;
+
+  statsComponents() : access(0), hit(0), miss(0) {}
+  statsComponents(const statsComponents &obj) { *this = obj; }
+  statsComponents &operator=(const statsComponents &rhs) {
+    access = rhs.access;
+    hit = rhs.hit;
+    miss = rhs.miss;
+    return *this;
+  }
+  void reset() {
+    access = 0;
+    hit = 0;
+    miss = 0;
+  }
+
+  friend statsComponents operator+(const statsComponents &x,
+                                   const statsComponents &y);
+  friend statsComponents operator*(const statsComponents &x,
+                                   double const *const y);
 };
 
-enum Device_ty {
-	Core_device,
-	Uncore_device,
-	LLC_device
+class statsDef {
+ public:
+  statsComponents readAc;
+  statsComponents writeAc;
+  statsComponents searchAc;
+
+  statsDef() : readAc(), writeAc(), searchAc() {}
+  void reset() {
+    readAc.reset();
+    writeAc.reset();
+    searchAc.reset();
+  }
+
+  friend statsDef operator+(const statsDef &x, const statsDef &y);
+  friend statsDef operator*(const statsDef &x, double const *const y);
 };
 
-class statsComponents
-{
-  public:
-    double access;
-    double hit;
-    double miss;
-
-    statsComponents() : access(0), hit(0), miss(0)  {}
-    statsComponents(const statsComponents & obj) { *this = obj; }
-    statsComponents & operator=(const statsComponents & rhs)
-    {
-      access = rhs.access;
-      hit = rhs.hit;
-      miss  = rhs.miss;
-      return *this;
-    }
-    void reset() { access = 0; hit = 0; miss = 0;}
-
-    friend statsComponents operator+(const statsComponents & x, const statsComponents & y);
-    friend statsComponents operator*(const statsComponents & x, double const * const y);
-};
-
-class statsDef
-{
-  public:
-    statsComponents readAc;
-    statsComponents writeAc;
-    statsComponents searchAc;
-
-    statsDef() : readAc(), writeAc(),searchAc() { }
-    void reset() { readAc.reset(); writeAc.reset();searchAc.reset();}
-
-    friend statsDef operator+(const statsDef & x, const statsDef & y);
-    friend statsDef operator*(const statsDef & x, double const * const y);
-};
-
-double longer_channel_device_reduction(
-		enum Device_ty device_ty=Core_device,
-		enum Core_type core_ty=Inorder);
+double longer_channel_device_reduction(enum Device_ty device_ty = Core_device,
+                                       enum Core_type core_ty = Inorder);
 
 class CoreDynParam {
-public:
-	CoreDynParam(){};
-	CoreDynParam(ParseXML *XML_interface, int ithCore_);
-	//    :XML(XML_interface),
-	//     ithCore(ithCore_)
-	//     core_ty(inorder),
-	//     rm_ty(CAMbased),
-	//     scheu_ty(PhysicalRegFile),
-	//     clockRate(1e9),//1GHz
-	//     arch_ireg_width(32),
-	//     arch_freg_width(32),
-	//     phy_ireg_width(128),
-	//     phy_freg_width(128),
-	//     perThreadState(8),
-	//     globalCheckpoint(32),
-	//     instructionLength(32){};
-	//ParseXML * XML;
-	bool opt_local;
-	bool x86;
-	bool Embedded;
-    enum Core_type  core_ty;
-	enum Renaming_type rm_ty;
-    enum Scheduler_type scheu_ty;
-    double clockRate,executionTime;
-    int  arch_ireg_width, arch_freg_width, phy_ireg_width, phy_freg_width;
-    int  num_IRF_entry, num_FRF_entry, num_ifreelist_entries, num_ffreelist_entries;
-    int  fetchW, decodeW,issueW,peak_issueW, commitW,peak_commitW, predictionW, fp_issueW, fp_decodeW;
-    int  perThreadState, globalCheckpoint, instruction_length, pc_width, opcode_length, micro_opcode_length;
-    int  num_hthreads, pipeline_stages, fp_pipeline_stages, num_pipelines, num_fp_pipelines;
-    int  num_alus, num_muls;
-    double num_fpus;
-    int  int_data_width, fp_data_width,v_address_width, p_address_width;
-    double pipeline_duty_cycle, total_cycles, busy_cycles, idle_cycles;
-    bool regWindowing,multithreaded;
-    double pppm_lkg_multhread[4];
-	double IFU_duty_cycle,BR_duty_cycle,LSU_duty_cycle,MemManU_I_duty_cycle,
-	       MemManU_D_duty_cycle, ALU_duty_cycle,MUL_duty_cycle,
-	       FPU_duty_cycle, ALU_cdb_duty_cycle,MUL_cdb_duty_cycle,
-	       FPU_cdb_duty_cycle;
-    ~CoreDynParam(){};
+ public:
+  CoreDynParam(){};
+  CoreDynParam(ParseXML *XML_interface, int ithCore_);
+  //    :XML(XML_interface),
+  //     ithCore(ithCore_)
+  //     core_ty(inorder),
+  //     rm_ty(CAMbased),
+  //     scheu_ty(PhysicalRegFile),
+  //     clockRate(1e9),//1GHz
+  //     arch_ireg_width(32),
+  //     arch_freg_width(32),
+  //     phy_ireg_width(128),
+  //     phy_freg_width(128),
+  //     perThreadState(8),
+  //     globalCheckpoint(32),
+  //     instructionLength(32){};
+  // ParseXML * XML;
+  bool opt_local;
+  bool x86;
+  bool Embedded;
+  enum Core_type core_ty;
+  enum Renaming_type rm_ty;
+  enum Scheduler_type scheu_ty;
+  double clockRate, executionTime;
+  int arch_ireg_width, arch_freg_width, phy_ireg_width, phy_freg_width;
+  int num_IRF_entry, num_FRF_entry, num_ifreelist_entries,
+      num_ffreelist_entries;
+  int fetchW, decodeW, issueW, peak_issueW, commitW, peak_commitW, predictionW,
+      fp_issueW, fp_decodeW;
+  int perThreadState, globalCheckpoint, instruction_length, pc_width,
+      opcode_length, micro_opcode_length;
+  int num_hthreads, pipeline_stages, fp_pipeline_stages, num_pipelines,
+      num_fp_pipelines;
+  int num_alus, num_muls;
+  double num_fpus;
+  int int_data_width, fp_data_width, v_address_width, p_address_width;
+  double pipeline_duty_cycle, total_cycles, busy_cycles, idle_cycles;
+  bool regWindowing, multithreaded;
+  double pppm_lkg_multhread[4];
+  double IFU_duty_cycle, BR_duty_cycle, LSU_duty_cycle, MemManU_I_duty_cycle,
+      MemManU_D_duty_cycle, ALU_duty_cycle, MUL_duty_cycle, FPU_duty_cycle,
+      ALU_cdb_duty_cycle, MUL_cdb_duty_cycle, FPU_cdb_duty_cycle;
+  ~CoreDynParam(){};
 };
 
 class CacheDynParam {
-public:
-	CacheDynParam(){};
-	CacheDynParam(ParseXML *XML_interface, int ithCache_);
-    string name;
-	enum Dir_type    dir_ty;
-	double clockRate,executionTime;
-    double    capacity, blockW, assoc, nbanks;
-    double throughput, latency;
-    double duty_cycle, dir_duty_cycle;
-    //double duty_cycle;
-    int missb_size, fu_size, prefetchb_size, wbb_size;
-    ~CacheDynParam(){};
+ public:
+  CacheDynParam(){};
+  CacheDynParam(ParseXML *XML_interface, int ithCache_);
+  string name;
+  enum Dir_type dir_ty;
+  double clockRate, executionTime;
+  double capacity, blockW, assoc, nbanks;
+  double throughput, latency;
+  double duty_cycle, dir_duty_cycle;
+  // double duty_cycle;
+  int missb_size, fu_size, prefetchb_size, wbb_size;
+  ~CacheDynParam(){};
 };
 
 class DRAMParam {
-public:
-	DRAMParam(){};
-	DRAMParam(ParseXML *XML_interface, int ithCache_);
-    string name;
-    double  clockRate;
-    double executionTime;
-    double cmd_coeff;
-    double activity_coeff;
-    double nop_coeff;
-    double act_coeff;
-    double pre_coeff;
-    double rd_coeff;
-    double wr_coeff;
-    double req_coeff;
-    double const_coeff;
+ public:
+  DRAMParam(){};
+  DRAMParam(ParseXML *XML_interface, int ithCache_);
+  string name;
+  double clockRate;
+  double executionTime;
+  double cmd_coeff;
+  double activity_coeff;
+  double nop_coeff;
+  double act_coeff;
+  double pre_coeff;
+  double rd_coeff;
+  double wr_coeff;
+  double req_coeff;
+  double const_coeff;
 
-	int detailed_dram_model; // 1 - to use newly added DRAM model (GDDR5 only), 0 - use empirical model
-	// the following are the current specified by DATA SHEET
-	// unit: mA
-	int idd0;
-	int idd1;
-	int idd2p;
-	int idd2n;
-	int idd3p;
-	int idd3n;
-	int idd4r;
-	int idd4w;
-	int idd5;
-	int idd6;
-	int idd7;
+  int detailed_dram_model;  // 1 - to use newly added DRAM model (GDDR5 only), 0
+                            // - use empirical model
+  // the following are the current specified by DATA SHEET
+  // unit: mA
+  int idd0;
+  int idd1;
+  int idd2p;
+  int idd2n;
+  int idd3p;
+  int idd3n;
+  int idd4r;
+  int idd4w;
+  int idd5;
+  int idd6;
+  int idd7;
 
-	// the following are the vdd specified by DATA SHEET; NOT the actual VDD
-	double datasheet_vdd;
-	double actual_vdd;
+  // the following are the vdd specified by DATA SHEET; NOT the actual VDD
+  double datasheet_vdd;
+  double actual_vdd;
 
-	// the following are the timing parameters specified by DATA SHEET
-	// unit: ns
-	int t_ccd;
-	int t_rrd;
-	int t_rcd;
-	int t_ras;
-	int t_rp;
-	int t_rc;
-	int t_cl;
-	int t_cdlr;
-	int t_wr;
+  // the following are the timing parameters specified by DATA SHEET
+  // unit: ns
+  int t_ccd;
+  int t_rrd;
+  int t_rcd;
+  int t_ras;
+  int t_rp;
+  int t_rc;
+  int t_cl;
+  int t_cdlr;
+  int t_wr;
 
-	// the following are the DRAM clocks
-	// unit: MHz
-	int datasheet_operating_clock; // this is specified by DATA SHEET. This is NOT the actual DRAM clock
-	int actual_operating_clock;
+  // the following are the DRAM clocks
+  // unit: MHz
+  int datasheet_operating_clock;  // this is specified by DATA SHEET. This is
+                                  // NOT the actual DRAM clock
+  int actual_operating_clock;
 
-	// the following are each DRAM bank's IO info
-	int bank_width; // in bits
-	int dqs_signal_width; // in bits
-	int extra_dq_write_signal_width; //in bits
-	int per_dq_read_power; // in mW
-	int per_dq_write_power; // in mW
+  // the following are each DRAM bank's IO info
+  int bank_width;                   // in bits
+  int dqs_signal_width;             // in bits
+  int extra_dq_write_signal_width;  // in bits
+  int per_dq_read_power;            // in mW
+  int per_dq_write_power;           // in mW
 
-    ~DRAMParam(){};
+  ~DRAMParam(){};
 };
 
 class MCParam {
-public:
-	MCParam(){};
-	MCParam(ParseXML *XML_interface, int ithCache_);
-    string name;
-    double  clockRate,num_mcs, peakDataTransferRate, num_channels;
-    //  double mcTEPowerperGhz;
-    //	double mcPHYperGbit;
-    //	double area;
-    int	   llcBlockSize, dataBusWidth, addressBusWidth;
-    int    opcodeW;
-    int    memAccesses;
-    int    memRank;
-    int    type;
-    double frontend_duty_cycle, duty_cycle, perc_load;
-    double executionTime, reads, writes;
-    bool   LVDS, withPHY;
+ public:
+  MCParam(){};
+  MCParam(ParseXML *XML_interface, int ithCache_);
+  string name;
+  double clockRate, num_mcs, peakDataTransferRate, num_channels;
+  //  double mcTEPowerperGhz;
+  //	double mcPHYperGbit;
+  //	double area;
+  int llcBlockSize, dataBusWidth, addressBusWidth;
+  int opcodeW;
+  int memAccesses;
+  int memRank;
+  int type;
+  double frontend_duty_cycle, duty_cycle, perc_load;
+  double executionTime, reads, writes;
+  bool LVDS, withPHY;
 
-    ~MCParam(){};
+  ~MCParam(){};
 };
 
 class NoCParam {
-public:
-	NoCParam(){};
-	NoCParam(ParseXML *XML_interface, int ithCache_);
-    string name;
-    double  clockRate;
-    int	   flit_size;
-    int    input_ports, output_ports, min_ports, global_linked_ports;
-    int    virtual_channel_per_port,input_buffer_entries_per_vc;
-    int    horizontal_nodes,vertical_nodes, total_nodes;
-    double executionTime, total_access, link_throughput,link_latency,
-		   duty_cycle, chip_coverage, route_over_perc;
-    bool   has_global_link, type;
+ public:
+  NoCParam(){};
+  NoCParam(ParseXML *XML_interface, int ithCache_);
+  string name;
+  double clockRate;
+  int flit_size;
+  int input_ports, output_ports, min_ports, global_linked_ports;
+  int virtual_channel_per_port, input_buffer_entries_per_vc;
+  int horizontal_nodes, vertical_nodes, total_nodes;
+  double executionTime, total_access, link_throughput, link_latency, duty_cycle,
+      chip_coverage, route_over_perc;
+  bool has_global_link, type;
 
-    ~NoCParam(){};
+  ~NoCParam(){};
 };
 
 class ProcParam {
-public:
-	ProcParam(){};
-	ProcParam(ParseXML *XML_interface, int ithCache_);
-    string name;
-    int  numCore, numL2, numL3, numNOC, numL1Dir, numL2Dir,numMC, numMCChannel;
-    bool homoCore, homoL2, homoL3, homoNOC, homoL1Dir, homoL2Dir;
+ public:
+  ProcParam(){};
+  ProcParam(ParseXML *XML_interface, int ithCache_);
+  string name;
+  int numCore, numL2, numL3, numNOC, numL1Dir, numL2Dir, numMC, numMCChannel;
+  bool homoCore, homoL2, homoL3, homoNOC, homoL1Dir, homoL2Dir;
 
-    ~ProcParam(){};
+  ~ProcParam(){};
 };
 
 class NIUParam {
-public:
-	NIUParam(){};
-	NIUParam(ParseXML *XML_interface, int ithCache_);
-    string name;
-    double  clockRate;
-    int    num_units;
-    int    type;
-    double duty_cycle, perc_load;
-    ~NIUParam(){};
+ public:
+  NIUParam(){};
+  NIUParam(ParseXML *XML_interface, int ithCache_);
+  string name;
+  double clockRate;
+  int num_units;
+  int type;
+  double duty_cycle, perc_load;
+  ~NIUParam(){};
 };
 
 class PCIeParam {
-public:
-	PCIeParam(){};
-	PCIeParam(ParseXML *XML_interface, int ithCache_);
-    string name;
-    double  clockRate;
-    int    num_channels, num_units;
-    bool   withPHY;
-    int    type;
-    double duty_cycle, perc_load;
-    ~PCIeParam(){};
+ public:
+  PCIeParam(){};
+  PCIeParam(ParseXML *XML_interface, int ithCache_);
+  string name;
+  double clockRate;
+  int num_channels, num_units;
+  bool withPHY;
+  int type;
+  double duty_cycle, perc_load;
+  ~PCIeParam(){};
 };
 #endif /* BASIC_COMPONENTS_H_ */

--- a/src/gpuwattch/basic_components.h
+++ b/src/gpuwattch/basic_components.h
@@ -32,284 +32,302 @@
 #ifndef BASIC_COMPONENTS_H_
 #define BASIC_COMPONENTS_H_
 
-#include <vector>
 #include "XML_Parse.h"
 #include "cacti/parameter.h"
+#include <vector>
 
 const double cdb_overhead = 1.1;
 
-enum FU_type { FPU, ALU, MUL };
+enum FU_type {
+    FPU,
+    ALU,
+    MUL
+};
 
-enum Core_type { OOO, Inorder };
+enum Core_type {
+	OOO,
+	Inorder
+};
 
-enum Renaming_type { RAMbased, CAMbased };
+enum Renaming_type {
+    RAMbased,
+	CAMbased
+};
 
-enum Scheduler_type { PhysicalRegFile, ReservationStation };
+enum Scheduler_type {
+    PhysicalRegFile,
+	ReservationStation
+};
 
-enum cache_level { L2, L3, L1Directory, L2Directory };
+enum cache_level {
+    L2,
+    L3,
+    L1Directory,
+    L2Directory
+};
 
 enum MemoryCtrl_type {
-  MC,     // memory controller
-  FLASHC  // flash controller
+	MC,    //memory controller
+	FLASHC //flash controller
 };
 
-enum Dram_type { GDDR5, GDDR3 };
+enum Dram_type {
+	GDDR5,
+	GDDR3
+};
+
 
 enum Dir_type {
-  ST,   // shadowed tag
-  DC,   // directory cache
-  SBT,  // static bank tag
-  NonDir
+	ST,//shadowed tag
+	DC,//directory cache
+	SBT,//static bank tag
+	NonDir
 
 };
 
-enum Cache_policy { Write_through, Write_back };
-
-enum Device_ty { Core_device, Uncore_device, LLC_device };
-
-class statsComponents {
- public:
-  double access;
-  double hit;
-  double miss;
-
-  statsComponents() : access(0), hit(0), miss(0) {}
-  statsComponents(const statsComponents &obj) { *this = obj; }
-  statsComponents &operator=(const statsComponents &rhs) {
-    access = rhs.access;
-    hit = rhs.hit;
-    miss = rhs.miss;
-    return *this;
-  }
-  void reset() {
-    access = 0;
-    hit = 0;
-    miss = 0;
-  }
-
-  friend statsComponents operator+(const statsComponents &x,
-                                   const statsComponents &y);
-  friend statsComponents operator*(const statsComponents &x,
-                                   double const *const y);
+enum Cache_policy {
+	Write_through,
+	Write_back
 };
 
-class statsDef {
- public:
-  statsComponents readAc;
-  statsComponents writeAc;
-  statsComponents searchAc;
-
-  statsDef() : readAc(), writeAc(), searchAc() {}
-  void reset() {
-    readAc.reset();
-    writeAc.reset();
-    searchAc.reset();
-  }
-
-  friend statsDef operator+(const statsDef &x, const statsDef &y);
-  friend statsDef operator*(const statsDef &x, double const *const y);
+enum Device_ty {
+	Core_device,
+	Uncore_device,
+	LLC_device
 };
 
-double longer_channel_device_reduction(enum Device_ty device_ty = Core_device,
-                                       enum Core_type core_ty = Inorder);
+class statsComponents
+{
+  public:
+    double access;
+    double hit;
+    double miss;
+
+    statsComponents() : access(0), hit(0), miss(0)  {}
+    statsComponents(const statsComponents & obj) { *this = obj; }
+    statsComponents & operator=(const statsComponents & rhs)
+    {
+      access = rhs.access;
+      hit = rhs.hit;
+      miss  = rhs.miss;
+      return *this;
+    }
+    void reset() { access = 0; hit = 0; miss = 0;}
+
+    friend statsComponents operator+(const statsComponents & x, const statsComponents & y);
+    friend statsComponents operator*(const statsComponents & x, double const * const y);
+};
+
+class statsDef
+{
+  public:
+    statsComponents readAc;
+    statsComponents writeAc;
+    statsComponents searchAc;
+
+    statsDef() : readAc(), writeAc(),searchAc() { }
+    void reset() { readAc.reset(); writeAc.reset();searchAc.reset();}
+
+    friend statsDef operator+(const statsDef & x, const statsDef & y);
+    friend statsDef operator*(const statsDef & x, double const * const y);
+};
+
+double longer_channel_device_reduction(
+		enum Device_ty device_ty=Core_device,
+		enum Core_type core_ty=Inorder);
 
 class CoreDynParam {
- public:
-  CoreDynParam(){};
-  CoreDynParam(ParseXML *XML_interface, int ithCore_);
-  //    :XML(XML_interface),
-  //     ithCore(ithCore_)
-  //     core_ty(inorder),
-  //     rm_ty(CAMbased),
-  //     scheu_ty(PhysicalRegFile),
-  //     clockRate(1e9),//1GHz
-  //     arch_ireg_width(32),
-  //     arch_freg_width(32),
-  //     phy_ireg_width(128),
-  //     phy_freg_width(128),
-  //     perThreadState(8),
-  //     globalCheckpoint(32),
-  //     instructionLength(32){};
-  // ParseXML * XML;
-  bool opt_local;
-  bool x86;
-  bool Embedded;
-  enum Core_type core_ty;
-  enum Renaming_type rm_ty;
-  enum Scheduler_type scheu_ty;
-  double clockRate, executionTime;
-  int arch_ireg_width, arch_freg_width, phy_ireg_width, phy_freg_width;
-  int num_IRF_entry, num_FRF_entry, num_ifreelist_entries,
-      num_ffreelist_entries;
-  int fetchW, decodeW, issueW, peak_issueW, commitW, peak_commitW, predictionW,
-      fp_issueW, fp_decodeW;
-  int perThreadState, globalCheckpoint, instruction_length, pc_width,
-      opcode_length, micro_opcode_length;
-  int num_hthreads, pipeline_stages, fp_pipeline_stages, num_pipelines,
-      num_fp_pipelines;
-  int num_alus, num_muls;
-  double num_fpus;
-  int int_data_width, fp_data_width, v_address_width, p_address_width;
-  double pipeline_duty_cycle, total_cycles, busy_cycles, idle_cycles;
-  bool regWindowing, multithreaded;
-  double pppm_lkg_multhread[4];
-  double IFU_duty_cycle, BR_duty_cycle, LSU_duty_cycle, MemManU_I_duty_cycle,
-      MemManU_D_duty_cycle, ALU_duty_cycle, MUL_duty_cycle, FPU_duty_cycle,
-      ALU_cdb_duty_cycle, MUL_cdb_duty_cycle, FPU_cdb_duty_cycle;
-  ~CoreDynParam(){};
+public:
+	CoreDynParam(){};
+	CoreDynParam(ParseXML *XML_interface, int ithCore_);
+	//    :XML(XML_interface),
+	//     ithCore(ithCore_)
+	//     core_ty(inorder),
+	//     rm_ty(CAMbased),
+	//     scheu_ty(PhysicalRegFile),
+	//     clockRate(1e9),//1GHz
+	//     arch_ireg_width(32),
+	//     arch_freg_width(32),
+	//     phy_ireg_width(128),
+	//     phy_freg_width(128),
+	//     perThreadState(8),
+	//     globalCheckpoint(32),
+	//     instructionLength(32){};
+	//ParseXML * XML;
+	bool opt_local;
+	bool x86;
+	bool Embedded;
+    enum Core_type  core_ty;
+	enum Renaming_type rm_ty;
+    enum Scheduler_type scheu_ty;
+    double clockRate,executionTime;
+    int  arch_ireg_width, arch_freg_width, phy_ireg_width, phy_freg_width;
+    int  num_IRF_entry, num_FRF_entry, num_ifreelist_entries, num_ffreelist_entries;
+    int  fetchW, decodeW,issueW,peak_issueW, commitW,peak_commitW, predictionW, fp_issueW, fp_decodeW;
+    int  perThreadState, globalCheckpoint, instruction_length, pc_width, opcode_length, micro_opcode_length;
+    int  num_hthreads, pipeline_stages, fp_pipeline_stages, num_pipelines, num_fp_pipelines;
+    int  num_alus, num_muls;
+    double num_fpus;
+    int  int_data_width, fp_data_width,v_address_width, p_address_width;
+    double pipeline_duty_cycle, total_cycles, busy_cycles, idle_cycles;
+    bool regWindowing,multithreaded;
+    double pppm_lkg_multhread[4];
+	double IFU_duty_cycle,BR_duty_cycle,LSU_duty_cycle,MemManU_I_duty_cycle,
+	       MemManU_D_duty_cycle, ALU_duty_cycle,MUL_duty_cycle,
+	       FPU_duty_cycle, ALU_cdb_duty_cycle,MUL_cdb_duty_cycle,
+	       FPU_cdb_duty_cycle;
+    ~CoreDynParam(){};
 };
 
 class CacheDynParam {
- public:
-  CacheDynParam(){};
-  CacheDynParam(ParseXML *XML_interface, int ithCache_);
-  string name;
-  enum Dir_type dir_ty;
-  double clockRate, executionTime;
-  double capacity, blockW, assoc, nbanks;
-  double throughput, latency;
-  double duty_cycle, dir_duty_cycle;
-  // double duty_cycle;
-  int missb_size, fu_size, prefetchb_size, wbb_size;
-  ~CacheDynParam(){};
+public:
+	CacheDynParam(){};
+	CacheDynParam(ParseXML *XML_interface, int ithCache_);
+    string name;
+	enum Dir_type    dir_ty;
+	double clockRate,executionTime;
+    double    capacity, blockW, assoc, nbanks;
+    double throughput, latency;
+    double duty_cycle, dir_duty_cycle;
+    //double duty_cycle;
+    int missb_size, fu_size, prefetchb_size, wbb_size;
+    ~CacheDynParam(){};
 };
 
 class DRAMParam {
- public:
-  DRAMParam(){};
-  DRAMParam(ParseXML *XML_interface, int ithCache_);
-  string name;
-  double clockRate;
-  double executionTime;
-  double cmd_coeff;
-  double activity_coeff;
-  double nop_coeff;
-  double act_coeff;
-  double pre_coeff;
-  double rd_coeff;
-  double wr_coeff;
-  double req_coeff;
-  double const_coeff;
+public:
+	DRAMParam(){};
+	DRAMParam(ParseXML *XML_interface, int ithCache_);
+    string name;
+    double  clockRate;
+    double executionTime;
+    double cmd_coeff;
+    double activity_coeff;
+    double nop_coeff;
+    double act_coeff;
+    double pre_coeff;
+    double rd_coeff;
+    double wr_coeff;
+    double req_coeff;
+    double const_coeff;
 
-  int detailed_dram_model;  // 1 - to use newly added DRAM model (GDDR5 only), 0
-                            // - use empirical model
-  // the following are the current specified by DATA SHEET
-  // unit: mA
-  int idd0;
-  int idd1;
-  int idd2p;
-  int idd2n;
-  int idd3p;
-  int idd3n;
-  int idd4r;
-  int idd4w;
-  int idd5;
-  int idd6;
-  int idd7;
+	int detailed_dram_model; // 1 - to use newly added DRAM model (GDDR5 only), 0 - use empirical model
+	// the following are the current specified by DATA SHEET
+	// unit: mA
+	int idd0;
+	int idd1;
+	int idd2p;
+	int idd2n;
+	int idd3p;
+	int idd3n;
+	int idd4r;
+	int idd4w;
+	int idd5;
+	int idd6;
+	int idd7;
 
-  // the following are the vdd specified by DATA SHEET; NOT the actual VDD
-  double datasheet_vdd;
-  double actual_vdd;
+	// the following are the vdd specified by DATA SHEET; NOT the actual VDD
+	double datasheet_vdd;
+	double actual_vdd;
 
-  // the following are the timing parameters specified by DATA SHEET
-  // unit: ns
-  int t_ccd;
-  int t_rrd;
-  int t_rcd;
-  int t_ras;
-  int t_rp;
-  int t_rc;
-  int t_cl;
-  int t_cdlr;
-  int t_wr;
+	// the following are the timing parameters specified by DATA SHEET
+	// unit: ns
+	int t_ccd;
+	int t_rrd;
+	int t_rcd;
+	int t_ras;
+	int t_rp;
+	int t_rc;
+	int t_cl;
+	int t_cdlr;
+	int t_wr;
 
-  // the following are the DRAM clocks
-  // unit: MHz
-  int datasheet_operating_clock;  // this is specified by DATA SHEET. This is
-                                  // NOT the actual DRAM clock
-  int actual_operating_clock;
+	// the following are the DRAM clocks
+	// unit: MHz
+	int datasheet_operating_clock; // this is specified by DATA SHEET. This is NOT the actual DRAM clock
+	int actual_operating_clock;
 
-  // the following are each DRAM bank's IO info
-  int bank_width;                   // in bits
-  int dqs_signal_width;             // in bits
-  int extra_dq_write_signal_width;  // in bits
-  int per_dq_read_power;            // in mW
-  int per_dq_write_power;           // in mW
+	// the following are each DRAM bank's IO info
+	int bank_width; // in bits
+	int dqs_signal_width; // in bits
+	int extra_dq_write_signal_width; //in bits
+	int per_dq_read_power; // in mW
+	int per_dq_write_power; // in mW
 
-  ~DRAMParam(){};
+    ~DRAMParam(){};
 };
 
 class MCParam {
- public:
-  MCParam(){};
-  MCParam(ParseXML *XML_interface, int ithCache_);
-  string name;
-  double clockRate, num_mcs, peakDataTransferRate, num_channels;
-  //  double mcTEPowerperGhz;
-  //	double mcPHYperGbit;
-  //	double area;
-  int llcBlockSize, dataBusWidth, addressBusWidth;
-  int opcodeW;
-  int memAccesses;
-  int memRank;
-  int type;
-  double frontend_duty_cycle, duty_cycle, perc_load;
-  double executionTime, reads, writes;
-  bool LVDS, withPHY;
+public:
+	MCParam(){};
+	MCParam(ParseXML *XML_interface, int ithCache_);
+    string name;
+    double  clockRate,num_mcs, peakDataTransferRate, num_channels;
+    //  double mcTEPowerperGhz;
+    //	double mcPHYperGbit;
+    //	double area;
+    int	   llcBlockSize, dataBusWidth, addressBusWidth;
+    int    opcodeW;
+    int    memAccesses;
+    int    memRank;
+    int    type;
+    double frontend_duty_cycle, duty_cycle, perc_load;
+    double executionTime, reads, writes;
+    bool   LVDS, withPHY;
 
-  ~MCParam(){};
+    ~MCParam(){};
 };
 
 class NoCParam {
- public:
-  NoCParam(){};
-  NoCParam(ParseXML *XML_interface, int ithCache_);
-  string name;
-  double clockRate;
-  int flit_size;
-  int input_ports, output_ports, min_ports, global_linked_ports;
-  int virtual_channel_per_port, input_buffer_entries_per_vc;
-  int horizontal_nodes, vertical_nodes, total_nodes;
-  double executionTime, total_access, link_throughput, link_latency, duty_cycle,
-      chip_coverage, route_over_perc;
-  bool has_global_link, type;
+public:
+	NoCParam(){};
+	NoCParam(ParseXML *XML_interface, int ithCache_);
+    string name;
+    double  clockRate;
+    int	   flit_size;
+    int    input_ports, output_ports, min_ports, global_linked_ports;
+    int    virtual_channel_per_port,input_buffer_entries_per_vc;
+    int    horizontal_nodes,vertical_nodes, total_nodes;
+    double executionTime, total_access, link_throughput,link_latency,
+		   duty_cycle, chip_coverage, route_over_perc;
+    bool   has_global_link, type;
 
-  ~NoCParam(){};
+    ~NoCParam(){};
 };
 
 class ProcParam {
- public:
-  ProcParam(){};
-  ProcParam(ParseXML *XML_interface, int ithCache_);
-  string name;
-  int numCore, numL2, numL3, numNOC, numL1Dir, numL2Dir, numMC, numMCChannel;
-  bool homoCore, homoL2, homoL3, homoNOC, homoL1Dir, homoL2Dir;
+public:
+	ProcParam(){};
+	ProcParam(ParseXML *XML_interface, int ithCache_);
+    string name;
+    int  numCore, numL2, numL3, numNOC, numL1Dir, numL2Dir,numMC, numMCChannel;
+    bool homoCore, homoL2, homoL3, homoNOC, homoL1Dir, homoL2Dir;
 
-  ~ProcParam(){};
+    ~ProcParam(){};
 };
 
 class NIUParam {
- public:
-  NIUParam(){};
-  NIUParam(ParseXML *XML_interface, int ithCache_);
-  string name;
-  double clockRate;
-  int num_units;
-  int type;
-  double duty_cycle, perc_load;
-  ~NIUParam(){};
+public:
+	NIUParam(){};
+	NIUParam(ParseXML *XML_interface, int ithCache_);
+    string name;
+    double  clockRate;
+    int    num_units;
+    int    type;
+    double duty_cycle, perc_load;
+    ~NIUParam(){};
 };
 
 class PCIeParam {
- public:
-  PCIeParam(){};
-  PCIeParam(ParseXML *XML_interface, int ithCache_);
-  string name;
-  double clockRate;
-  int num_channels, num_units;
-  bool withPHY;
-  int type;
-  double duty_cycle, perc_load;
-  ~PCIeParam(){};
+public:
+	PCIeParam(){};
+	PCIeParam(ParseXML *XML_interface, int ithCache_);
+    string name;
+    double  clockRate;
+    int    num_channels, num_units;
+    bool   withPHY;
+    int    type;
+    double duty_cycle, perc_load;
+    ~PCIeParam(){};
 };
 #endif /* BASIC_COMPONENTS_H_ */

--- a/src/gpuwattch/core.cc
+++ b/src/gpuwattch/core.cc
@@ -29,6835 +29,5309 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:
-**
+*      Modified by:												   *
 *      Jingwen Leng, Univeristy of Texas, Austin                   *
 *      Syed Gilani, University of Wisconsin–Madison                *
 *      Tayler Hetherington, University of British Columbia         *
 *      Ahmed ElTantawy, University of British Columbia             *
 ********************************************************************/
 
-#include "core.h"
-#include <assert.h>
-#include <algorithm>
-#include <cmath>
-#include <iostream>
-#include <string>
-#include "XML_Parse.h"
-#include "cacti/basic_circuit.h"
-#include "const.h"
 #include "io.h"
 #include "parameter.h"
+#include "const.h"
+#include "cacti/basic_circuit.h"
+#include <iostream>
+#include <algorithm>
+#include "XML_Parse.h"
+#include <string>
+#include <cmath>
+#include <assert.h>
+#include "core.h"
 //#include "globalvar.h"
-// double exClockRate;
+//double exClockRate;
 //*********************
-// Operand collector (OC) modelling (Syed Gilani)
+//Operand collector (OC) modelling (Syed Gilani)
 //*********************
-// The OCs are modelled similar to the GPGPU-Sim v3.x documentation and
-// nVIDIA patents.
-// the OC need the following GPGPU-Sim config options:
-//-gpgpu_num_reg_banks                    8 # Number of register banks (default
-//= 8)
-//-gpgpu_reg_bank_use_warp_id                    0 # Use warp ID in mapping
-//registers to banks (default = off)
-//-gpgpu_operand_collector_num_units_sp                    6 # number of
-//collector units (default = 4)
-//-gpgpu_operand_collector_num_units_sfu                    8 # number of
-//collector units (default = 4)
-//-gpgpu_operand_collector_num_units_mem                    2 # number of
-//collector units (default = 2)
-//-gpgpu_operand_collector_num_units_gen                    0 # number of
-//collector units (default = 0)
-//-gpgpu_operand_collector_num_in_ports_sp                    1 # number of
-//collector unit in ports (default = 1)
-//-gpgpu_operand_collector_num_in_ports_sfu                    1 # number of
-//collector unit in ports (default = 1)
-//-gpgpu_operand_collector_num_in_ports_mem                    1 # number of
-//collector unit in ports (default = 1)
-//-gpgpu_operand_collector_num_in_ports_gen                    0 # number of
-//collector unit in ports (default = 0)
-//-gpgpu_operand_collector_num_out_ports_sp                    1 # number of
-//collector unit in ports (default = 1)
-//-gpgpu_operand_collector_num_out_ports_sfu                    1 # number of
-//collector unit in ports (default = 1)
-//-gpgpu_operand_collector_num_out_ports_mem                    1 # number of
-//collector unit in ports (default = 1)
-//-gpgpu_operand_collector_num_out_ports_gen                    0 # number of
-//collector unit in ports (default = 0)
+//The OCs are modelled similar to the GPGPU-Sim v3.x documentation and
+//nVIDIA patents.
+//the OC need the following GPGPU-Sim config options:
+//-gpgpu_num_reg_banks                    8 # Number of register banks (default = 8)
+//-gpgpu_reg_bank_use_warp_id                    0 # Use warp ID in mapping registers to banks (default = off)
+//-gpgpu_operand_collector_num_units_sp                    6 # number of collector units (default = 4)
+//-gpgpu_operand_collector_num_units_sfu                    8 # number of collector units (default = 4)
+//-gpgpu_operand_collector_num_units_mem                    2 # number of collector units (default = 2)
+//-gpgpu_operand_collector_num_units_gen                    0 # number of collector units (default = 0)
+//-gpgpu_operand_collector_num_in_ports_sp                    1 # number of collector unit in ports (default = 1)
+//-gpgpu_operand_collector_num_in_ports_sfu                    1 # number of collector unit in ports (default = 1)
+//-gpgpu_operand_collector_num_in_ports_mem                    1 # number of collector unit in ports (default = 1)
+//-gpgpu_operand_collector_num_in_ports_gen                    0 # number of collector unit in ports (default = 0)
+//-gpgpu_operand_collector_num_out_ports_sp                    1 # number of collector unit in ports (default = 1)
+//-gpgpu_operand_collector_num_out_ports_sfu                    1 # number of collector unit in ports (default = 1)
+//-gpgpu_operand_collector_num_out_ports_mem                    1 # number of collector unit in ports (default = 1)
+//-gpgpu_operand_collector_num_out_ports_gen                    0 # number of collector unit in ports (default = 0)
 
-// The total number of collector units and their input ports, and the number of
-// register file banks
-// determine the crossbar size.
+//The total number of collector units and their input ports, and the number of register file banks
+//determine the crossbar size. 
 
-InstFetchU::InstFetchU(ParseXML* XML_interface, int ithCore_,
-                       InputParameter* interface_ip_,
-                       const CoreDynParam& dyn_p_, bool exist_)
-    : XML(XML_interface),
-      ithCore(ithCore_),
-      interface_ip(*interface_ip_),
-      coredynp(dyn_p_),
-      IB(0),
-      BTB(0),
-      ID_inst(0),
-      ID_operand(0),
-      ID_misc(0),
-      exist(exist_) {
-  if (!exist) return;
-  int idx, tag, data, size, line, assoc, banks;
-  bool debug = false, is_default = true;
+InstFetchU::InstFetchU(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_, bool exist_)
+:XML(XML_interface),
+ ithCore(ithCore_),
+ interface_ip(*interface_ip_),
+ coredynp(dyn_p_),
+ IB  (0),
+ BTB (0),
+ ID_inst  (0),
+ ID_operand  (0),
+ ID_misc  (0),
+ exist(exist_)
+{
+	  if (!exist) return;
+	  int  idx, tag, data, size, line, assoc, banks;
+	  bool debug= false, is_default = true;
 
-  clockRate = coredynp.clockRate;
-  executionTime = coredynp.executionTime;
+	  clockRate = coredynp.clockRate;
+	  executionTime = coredynp.executionTime;
 
-  cache_p = (Cache_policy)XML->sys.core[ithCore].icache.icache_config[7];
-  // Assuming all L1 caches are virtually idxed physically tagged.
-  // cache
+	  cache_p = (Cache_policy)XML->sys.core[ithCore].icache.icache_config[7];
+	  //Assuming all L1 caches are virtually idxed physically tagged.
+	  //cache
 
-  size = (int)XML->sys.core[ithCore].icache.icache_config[0];
-  line = (int)XML->sys.core[ithCore].icache.icache_config[1];
-  assoc = (int)XML->sys.core[ithCore].icache.icache_config[2];
-  banks = (int)XML->sys.core[ithCore].icache.icache_config[3];
-  idx = debug ? 9 : int(ceil(log2(size / line / assoc)));
-  tag = debug ? 51 : (int)XML->sys.physical_address_width - idx -
-                         int(ceil(log2(line))) + EXTRA_TAG_BITS;
-  interface_ip.specific_tag = 1;
-  interface_ip.tag_w = tag;
-  interface_ip.cache_sz =
-      debug ? 32768 : (int)XML->sys.core[ithCore].icache.icache_config[0];
-  interface_ip.line_sz =
-      debug ? 64 : (int)XML->sys.core[ithCore].icache.icache_config[1];
-  interface_ip.assoc =
-      debug ? 8 : (int)XML->sys.core[ithCore].icache.icache_config[2];
-  interface_ip.nbanks =
-      debug ? 1 : (int)XML->sys.core[ithCore].icache.icache_config[3];
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode =
-      0;  // debug?0:XML->sys.core[ithCore].icache.icache_config[5];
-  interface_ip.throughput =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].icache.icache_config[4] / clockRate;
-  interface_ip.latency =
-      debug ? 3.0 / clockRate
-            : XML->sys.core[ithCore].icache.icache_config[5] / clockRate;
-  interface_ip.is_cache = true;
-  interface_ip.pure_cam = false;
-  interface_ip.pure_ram = false;
-  //  interface_ip.obj_func_dyn_energy = 0;
-  //  interface_ip.obj_func_dyn_power  = 0;
-  //  interface_ip.obj_func_leak_power = 0;
-  //  interface_ip.obj_func_cycle_t    = 1;
-  interface_ip.num_rw_ports =
-      debug ? 1 : XML->sys.core[ithCore].number_instruction_fetch_ports;
-  interface_ip.num_rd_ports = 0;
-  interface_ip.num_wr_ports = 0;
-  interface_ip.num_se_rd_ports = 0;
-  icache.caches = new ArrayST(&interface_ip, "icache", Core_device,
-                              coredynp.opt_local, coredynp.core_ty);
-  scktRatio = g_tp.sckt_co_eff;
-  chip_PR_overhead = g_tp.chip_layout_overhead;
-  macro_PR_overhead = g_tp.macro_layout_overhead;
-  icache.area.set_area(icache.area.get_area() +
-                       icache.caches->local_result.area);
-  area.set_area(area.get_area() + icache.caches->local_result.area);
-  // output_data_csv(icache.caches.local_result);
+	  size                             = (int)XML->sys.core[ithCore].icache.icache_config[0];
+	  line                             = (int)XML->sys.core[ithCore].icache.icache_config[1];
+	  assoc                            = (int)XML->sys.core[ithCore].icache.icache_config[2];
+	  banks                            = (int)XML->sys.core[ithCore].icache.icache_config[3];
+	  idx    					 	   = debug?9:int(ceil(log2(size/line/assoc)));
+	  tag							   = debug?51:(int)XML->sys.physical_address_width-idx-int(ceil(log2(line))) + EXTRA_TAG_BITS;
+	  interface_ip.specific_tag        = 1;
+	  interface_ip.tag_w               = tag;
+	  interface_ip.cache_sz            = debug?32768:(int)XML->sys.core[ithCore].icache.icache_config[0];
+	  interface_ip.line_sz             = debug?64:(int)XML->sys.core[ithCore].icache.icache_config[1];
+	  interface_ip.assoc               = debug?8:(int)XML->sys.core[ithCore].icache.icache_config[2];
+	  interface_ip.nbanks              = debug?1:(int)XML->sys.core[ithCore].icache.icache_config[3];
+	  interface_ip.out_w               = interface_ip.line_sz*8;
+	  interface_ip.access_mode         = 0;//debug?0:XML->sys.core[ithCore].icache.icache_config[5];
+	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].icache.icache_config[4]/clockRate;
+	  interface_ip.latency             = debug?3.0/clockRate:XML->sys.core[ithCore].icache.icache_config[5]/clockRate;
+	  interface_ip.is_cache			 = true;
+	  interface_ip.pure_cam			 = false;
+	  interface_ip.pure_ram			 = false;
+	//  interface_ip.obj_func_dyn_energy = 0;
+	//  interface_ip.obj_func_dyn_power  = 0;
+	//  interface_ip.obj_func_leak_power = 0;
+	//  interface_ip.obj_func_cycle_t    = 1;
+	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].number_instruction_fetch_ports;
+	  interface_ip.num_rd_ports    = 0;
+	  interface_ip.num_wr_ports    = 0;
+	  interface_ip.num_se_rd_ports = 0;
+	  icache.caches = new ArrayST(&interface_ip, "icache", Core_device, coredynp.opt_local, coredynp.core_ty);
+	  scktRatio = g_tp.sckt_co_eff;
+	  chip_PR_overhead = g_tp.chip_layout_overhead;
+	  macro_PR_overhead = g_tp.macro_layout_overhead;
+	  icache.area.set_area(icache.area.get_area()+ icache.caches->local_result.area);
+	  area.set_area(area.get_area()+ icache.caches->local_result.area);
+	  //output_data_csv(icache.caches.local_result);
 
-  /*
-   *iCache controllers
-   *miss buffer Each MSHR contains enough state
-   *to handle one or more accesses of any type to a single memory line.
-   *Due to the generality of the MSHR mechanism,
-   *the amount of state involved is non-trivial:
-   *including the address, pointers to the cache entry and destination register,
-   *written data, and various other pieces of state.
-   */
-  interface_ip.num_search_ports =
-      debug ? 1 : XML->sys.core[ithCore].number_instruction_fetch_ports;
-  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-  data = (XML->sys.physical_address_width) + int(ceil(log2(size / line))) +
-         icache.caches->l_ip.line_sz * 8;
-  interface_ip.specific_tag = 1;
-  interface_ip.tag_w = tag;
-  interface_ip.line_sz =
-      int(ceil(data / 8.0));  // int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-  interface_ip.cache_sz =
-      XML->sys.core[ithCore].icache.buffer_sizes[0] * interface_ip.line_sz;
-  interface_ip.assoc = 0;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 0;
-  interface_ip.throughput =
-      debug ? 1.0 / clockRate : XML->sys.core[ithCore].icache.icache_config[4] /
-                                    clockRate;  // means cycle time
-  interface_ip.latency =
-      debug ? 1.0 / clockRate : XML->sys.core[ithCore].icache.icache_config[5] /
-                                    clockRate;  // means access time
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports =
-      debug ? 1 : XML->sys.core[ithCore].number_instruction_fetch_ports;
-  interface_ip.num_rd_ports = 0;
-  interface_ip.num_wr_ports = 0;
-  interface_ip.num_se_rd_ports = 0;
-  interface_ip.num_search_ports =
-      XML->sys.core[ithCore].number_instruction_fetch_ports;
-  icache.missb = new ArrayST(&interface_ip, "icacheMissBuffer", Core_device,
-                             coredynp.opt_local, coredynp.core_ty);
-  icache.area.set_area(icache.area.get_area() +
-                       icache.missb->local_result.area);
-  area.set_area(area.get_area() + icache.missb->local_result.area);
-  // output_data_csv(icache.missb.local_result);
 
-  // fill buffer
-  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-  data = icache.caches->l_ip.line_sz;
-  interface_ip.specific_tag = 1;
-  interface_ip.tag_w = tag;
-  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
-  interface_ip.cache_sz = data * XML->sys.core[ithCore].icache.buffer_sizes[1];
-  interface_ip.assoc = 0;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 0;
-  interface_ip.throughput =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].icache.icache_config[4] / clockRate;
-  interface_ip.latency =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].icache.icache_config[5] / clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports =
-      debug ? 1 : XML->sys.core[ithCore].number_instruction_fetch_ports;
-  interface_ip.num_rd_ports = 0;
-  interface_ip.num_wr_ports = 0;
-  interface_ip.num_se_rd_ports = 0;
-  interface_ip.num_search_ports =
-      XML->sys.core[ithCore].number_instruction_fetch_ports;
-  icache.ifb = new ArrayST(&interface_ip, "icacheFillBuffer", Core_device,
-                           coredynp.opt_local, coredynp.core_ty);
-  icache.area.set_area(icache.area.get_area() + icache.ifb->local_result.area);
-  area.set_area(area.get_area() + icache.ifb->local_result.area);
-  // output_data_csv(icache.ifb.local_result);
+	  /*
+	   *iCache controllers
+	   *miss buffer Each MSHR contains enough state
+	   *to handle one or more accesses of any type to a single memory line.
+	   *Due to the generality of the MSHR mechanism,
+	   *the amount of state involved is non-trivial:
+	   *including the address, pointers to the cache entry and destination register,
+	   *written data, and various other pieces of state.
+	   */
+	  interface_ip.num_search_ports    = debug?1:XML->sys.core[ithCore].number_instruction_fetch_ports;
+	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+	  data							   = (XML->sys.physical_address_width) + int(ceil(log2(size/line))) + icache.caches->l_ip.line_sz*8;
+	  interface_ip.specific_tag        = 1;
+	  interface_ip.tag_w               = tag;
+	  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+	  interface_ip.cache_sz            = XML->sys.core[ithCore].icache.buffer_sizes[0]*interface_ip.line_sz;
+	  interface_ip.assoc               = 0;
+	  interface_ip.nbanks              = 1;
+	  interface_ip.out_w               = interface_ip.line_sz*8;
+	  interface_ip.access_mode         = 0;
+	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].icache.icache_config[4]/clockRate;//means cycle time
+	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].icache.icache_config[5]/clockRate;//means access time
+	  interface_ip.obj_func_dyn_energy = 0;
+	  interface_ip.obj_func_dyn_power  = 0;
+	  interface_ip.obj_func_leak_power = 0;
+	  interface_ip.obj_func_cycle_t    = 1;
+	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].number_instruction_fetch_ports;
+	  interface_ip.num_rd_ports    = 0;
+	  interface_ip.num_wr_ports    = 0;
+	  interface_ip.num_se_rd_ports = 0;
+	  interface_ip.num_search_ports = XML->sys.core[ithCore].number_instruction_fetch_ports;
+	  icache.missb = new ArrayST(&interface_ip, "icacheMissBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
+	  icache.area.set_area(icache.area.get_area()+ icache.missb->local_result.area);
+	  area.set_area(area.get_area()+ icache.missb->local_result.area);
+	  //output_data_csv(icache.missb.local_result);
 
-  // prefetch buffer
-  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;  // check with
-                                                           // previous entries
-                                                           // to decide wthether
-                                                           // to merge.
-  data = icache.caches->l_ip
-             .line_sz;  // separate queue to prevent from cache polution.
-  interface_ip.specific_tag = 1;
-  interface_ip.tag_w = tag;
-  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
-  interface_ip.cache_sz =
-      XML->sys.core[ithCore].icache.buffer_sizes[2] * interface_ip.line_sz;
-  interface_ip.assoc = 0;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 0;
-  interface_ip.throughput =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].icache.icache_config[4] / clockRate;
-  interface_ip.latency =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].icache.icache_config[5] / clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports =
-      debug ? 1 : XML->sys.core[ithCore].number_instruction_fetch_ports;
-  interface_ip.num_rd_ports = 0;
-  interface_ip.num_wr_ports = 0;
-  interface_ip.num_se_rd_ports = 0;
-  interface_ip.num_search_ports =
-      XML->sys.core[ithCore].number_instruction_fetch_ports;
-  icache.prefetchb =
-      new ArrayST(&interface_ip, "icacheprefetchBuffer", Core_device,
-                  coredynp.opt_local, coredynp.core_ty);
-  icache.area.set_area(icache.area.get_area() +
-                       icache.prefetchb->local_result.area);
-  area.set_area(area.get_area() + icache.prefetchb->local_result.area);
-  // output_data_csv(icache.prefetchb.local_result);
+	  //fill buffer
+	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+	  data							   = icache.caches->l_ip.line_sz;
+	  interface_ip.specific_tag        = 1;
+	  interface_ip.tag_w               = tag;
+	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
+	  interface_ip.cache_sz            = data*XML->sys.core[ithCore].icache.buffer_sizes[1];
+	  interface_ip.assoc               = 0;
+	  interface_ip.nbanks              = 1;
+	  interface_ip.out_w               = interface_ip.line_sz*8;
+	  interface_ip.access_mode         = 0;
+	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].icache.icache_config[4]/clockRate;
+	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].icache.icache_config[5]/clockRate;
+	  interface_ip.obj_func_dyn_energy = 0;
+	  interface_ip.obj_func_dyn_power  = 0;
+	  interface_ip.obj_func_leak_power = 0;
+	  interface_ip.obj_func_cycle_t    = 1;
+	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].number_instruction_fetch_ports;
+	  interface_ip.num_rd_ports    = 0;
+	  interface_ip.num_wr_ports    = 0;
+	  interface_ip.num_se_rd_ports = 0;
+	  interface_ip.num_search_ports = XML->sys.core[ithCore].number_instruction_fetch_ports;
+	  icache.ifb = new ArrayST(&interface_ip, "icacheFillBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
+	  icache.area.set_area(icache.area.get_area()+ icache.ifb->local_result.area);
+	  area.set_area(area.get_area()+ icache.ifb->local_result.area);
+	  //output_data_csv(icache.ifb.local_result);
 
-  // Instruction buffer
-  data =
-      XML->sys.core[ithCore].instruction_length *
-      XML->sys.core[ithCore].peak_issue_width;  // icache.caches.l_ip.line_sz;
-                                                // //multiple threads timing
-                                                // sharing the instruction
-                                                // buffer.
-  interface_ip.is_cache = false;
-  interface_ip.pure_ram = true;
-  interface_ip.pure_cam = false;
-  interface_ip.line_sz = int(ceil(data / 8.0));
-  interface_ip.cache_sz =
-      XML->sys.core[ithCore].number_hardware_threads *
-                  XML->sys.core[ithCore].instruction_buffer_size *
-                  interface_ip.line_sz >
-              64
-          ? XML->sys.core[ithCore].number_hardware_threads *
-                XML->sys.core[ithCore].instruction_buffer_size *
-                interface_ip.line_sz
-          : 64;
-  interface_ip.assoc = 1;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 0;
-  interface_ip.throughput = 1.0 / clockRate;
-  interface_ip.latency = 1.0 / clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  // NOTE: Assuming IB is time slice shared among threads, every fetch op will
-  // at least fetch "fetch width" instructions.
-  interface_ip.num_rw_ports =
-      debug
-          ? 1
-          : XML->sys.core[ithCore]
-                .number_instruction_fetch_ports;  // XML->sys.core[ithCore].fetch_width;
-  interface_ip.num_rd_ports = 0;
-  interface_ip.num_wr_ports = 0;
-  interface_ip.num_se_rd_ports = 0;
-  IB = new ArrayST(&interface_ip, "InstBuffer", Core_device, coredynp.opt_local,
-                   coredynp.core_ty);
-  IB->area.set_area(IB->area.get_area() + IB->local_result.area);
-  area.set_area(area.get_area() + IB->local_result.area);
-  // output_data_csv(IB.IB.local_result);
+	  //prefetch buffer
+	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries to decide wthether to merge.
+	  data							   = icache.caches->l_ip.line_sz;//separate queue to prevent from cache polution.
+	  interface_ip.specific_tag        = 1;
+	  interface_ip.tag_w               = tag;
+	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
+	  interface_ip.cache_sz            = XML->sys.core[ithCore].icache.buffer_sizes[2]*interface_ip.line_sz;
+	  interface_ip.assoc               = 0;
+	  interface_ip.nbanks              = 1;
+	  interface_ip.out_w               = interface_ip.line_sz*8;
+	  interface_ip.access_mode         = 0;
+	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].icache.icache_config[4]/clockRate;
+	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].icache.icache_config[5]/clockRate;
+	  interface_ip.obj_func_dyn_energy = 0;
+	  interface_ip.obj_func_dyn_power  = 0;
+	  interface_ip.obj_func_leak_power = 0;
+	  interface_ip.obj_func_cycle_t    = 1;
+	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].number_instruction_fetch_ports;
+	  interface_ip.num_rd_ports    = 0;
+	  interface_ip.num_wr_ports    = 0;
+	  interface_ip.num_se_rd_ports = 0;
+	  interface_ip.num_search_ports = XML->sys.core[ithCore].number_instruction_fetch_ports;
+	  icache.prefetchb = new ArrayST(&interface_ip, "icacheprefetchBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
+	  icache.area.set_area(icache.area.get_area()+ icache.prefetchb->local_result.area);
+	  area.set_area(area.get_area()+ icache.prefetchb->local_result.area);
+	  //output_data_csv(icache.prefetchb.local_result);
 
-  //	  inst_decoder.opcode_length = XML->sys.core[ithCore].opcode_width;
-  //	  inst_decoder.init_decoder(is_default, &interface_ip);
-  //	  inst_decoder.full_decoder_power();
+	  //Instruction buffer
+	  data							   = XML->sys.core[ithCore].instruction_length*XML->sys.core[ithCore].peak_issue_width;//icache.caches.l_ip.line_sz; //multiple threads timing sharing the instruction buffer.
+	  interface_ip.is_cache			   = false;
+	  interface_ip.pure_ram            = true;
+	  interface_ip.pure_cam            = false;
+	  interface_ip.line_sz             = int(ceil(data/8.0));
+	  interface_ip.cache_sz            = XML->sys.core[ithCore].number_hardware_threads*XML->sys.core[ithCore].instruction_buffer_size*interface_ip.line_sz>64?
+			                             XML->sys.core[ithCore].number_hardware_threads*XML->sys.core[ithCore].instruction_buffer_size*interface_ip.line_sz:64;
+	  interface_ip.assoc               = 1;
+	  interface_ip.nbanks              = 1;
+	  interface_ip.out_w               = interface_ip.line_sz*8;
+	  interface_ip.access_mode         = 0;
+	  interface_ip.throughput          = 1.0/clockRate;
+	  interface_ip.latency             = 1.0/clockRate;
+	  interface_ip.obj_func_dyn_energy = 0;
+	  interface_ip.obj_func_dyn_power  = 0;
+	  interface_ip.obj_func_leak_power = 0;
+	  interface_ip.obj_func_cycle_t    = 1;
+	  //NOTE: Assuming IB is time slice shared among threads, every fetch op will at least fetch "fetch width" instructions.
+	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].number_instruction_fetch_ports;//XML->sys.core[ithCore].fetch_width;
+	  interface_ip.num_rd_ports    = 0;
+	  interface_ip.num_wr_ports    = 0;
+	  interface_ip.num_se_rd_ports = 0;
+	  IB = new ArrayST(&interface_ip, "InstBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
+	  IB->area.set_area(IB->area.get_area()+ IB->local_result.area);
+	  area.set_area(area.get_area()+ IB->local_result.area);
+	  //output_data_csv(IB.IB.local_result);
 
-  if (coredynp.predictionW > 0) {
-    /*
-     * BTB branch target buffer, accessed during IF stage. Virtually indexed and
-     * virtually tagged
-     * It is only a cache without all the buffers in the cache controller since
-     * it is more like a
-     * look up table than a cache with cache controller. When access miss, no
-     * load from other places
-     * such as main memory (not actively fill the misses), it is passively
-     * updated under two circumstances:
-     * 1)  when BPT@ID stage finds out current is a taken branch while BTB
-     * missed
-     * 2)  When BPT@ID stage predicts differently than BTB
-     * 3)  When ID stage finds out current instruction is not a branch while BTB
-     * had a hit.(mark as invalid)
-     * 4)  when EXEU find out wrong target has been provided from BTB.
-     *
-     */
-    size = XML->sys.core[ithCore].BTB.BTB_config[0];
-    line = XML->sys.core[ithCore].BTB.BTB_config[1];
-    assoc = XML->sys.core[ithCore].BTB.BTB_config[2];
-    banks = XML->sys.core[ithCore].BTB.BTB_config[3];
-    idx = debug ? 9 : int(ceil(log2(size / line / assoc)));
-    //    	  tag							   =
-    //    debug?51:XML->sys.virtual_address_width-idx-int(ceil(log2(line))) +
-    //    int(ceil(log2(XML->sys.core[ithCore].number_hardware_threads)))
-    //    +EXTRA_TAG_BITS;
-    tag =
-        debug ? 51 : XML->sys.virtual_address_width +
-                         int(ceil(log2(
-                             XML->sys.core[ithCore].number_hardware_threads))) +
-                         EXTRA_TAG_BITS;
-    interface_ip.is_cache = true;
-    interface_ip.pure_ram = false;
-    interface_ip.pure_cam = false;
-    interface_ip.specific_tag = 1;
-    interface_ip.tag_w = tag;
-    interface_ip.cache_sz = debug ? 32768 : size;
-    interface_ip.line_sz = debug ? 64 : line;
-    interface_ip.assoc = debug ? 8 : assoc;
-    interface_ip.nbanks = debug ? 1 : banks;
-    interface_ip.out_w = interface_ip.line_sz * 8;
-    interface_ip.access_mode =
-        0;  // debug?0:XML->sys.core[ithCore].dcache.dcache_config[5];
-    interface_ip.throughput =
-        debug ? 1.0 / clockRate
-              : XML->sys.core[ithCore].BTB.BTB_config[4] / clockRate;
-    interface_ip.latency =
-        debug ? 3.0 / clockRate
-              : XML->sys.core[ithCore].BTB.BTB_config[5] / clockRate;
-    interface_ip.obj_func_dyn_energy = 0;
-    interface_ip.obj_func_dyn_power = 0;
-    interface_ip.obj_func_leak_power = 0;
-    interface_ip.obj_func_cycle_t = 1;
-    interface_ip.num_rw_ports = 1;
-    interface_ip.num_rd_ports = coredynp.predictionW;
-    interface_ip.num_wr_ports = coredynp.predictionW;
-    interface_ip.num_se_rd_ports = 0;
-    BTB = new ArrayST(&interface_ip, "Branch Target Buffer", Core_device,
-                      coredynp.opt_local, coredynp.core_ty);
-    BTB->area.set_area(BTB->area.get_area() + BTB->local_result.area);
-    area.set_area(area.get_area() + BTB->local_result.area);
-    /// cout<<"area="<<area<<endl;
+	  //	  inst_decoder.opcode_length = XML->sys.core[ithCore].opcode_width;
+	  //	  inst_decoder.init_decoder(is_default, &interface_ip);
+	  //	  inst_decoder.full_decoder_power();
 
-    BPT = new BranchPredictor(XML, ithCore, &interface_ip, coredynp);
-    area.set_area(area.get_area() + BPT->area.get_area());
-  }
+      if (coredynp.predictionW>0)
+      {
+    	  /*
+    	   * BTB branch target buffer, accessed during IF stage. Virtually indexed and virtually tagged
+    	   * It is only a cache without all the buffers in the cache controller since it is more like a
+    	   * look up table than a cache with cache controller. When access miss, no load from other places
+    	   * such as main memory (not actively fill the misses), it is passively updated under two circumstances:
+    	   * 1)  when BPT@ID stage finds out current is a taken branch while BTB missed
+    	   * 2)  When BPT@ID stage predicts differently than BTB
+    	   * 3)  When ID stage finds out current instruction is not a branch while BTB had a hit.(mark as invalid)
+    	   * 4)  when EXEU find out wrong target has been provided from BTB.
+    	   *
+    	   */
+    	  size                             = XML->sys.core[ithCore].BTB.BTB_config[0];
+    	  line                             = XML->sys.core[ithCore].BTB.BTB_config[1];
+    	  assoc                            = XML->sys.core[ithCore].BTB.BTB_config[2];
+    	  banks                            = XML->sys.core[ithCore].BTB.BTB_config[3];
+    	  idx    					 	   = debug?9:int(ceil(log2(size/line/assoc)));
+//    	  tag							   = debug?51:XML->sys.virtual_address_width-idx-int(ceil(log2(line))) + int(ceil(log2(XML->sys.core[ithCore].number_hardware_threads))) +EXTRA_TAG_BITS;
+    	  tag							   = debug?51:XML->sys.virtual_address_width + int(ceil(log2(XML->sys.core[ithCore].number_hardware_threads))) +EXTRA_TAG_BITS;
+    	  interface_ip.is_cache			   = true;
+    	  interface_ip.pure_ram            = false;
+    	  interface_ip.pure_cam            = false;
+    	  interface_ip.specific_tag        = 1;
+    	  interface_ip.tag_w               = tag;
+    	  interface_ip.cache_sz            = debug?32768:size;
+    	  interface_ip.line_sz             = debug?64:line;
+    	  interface_ip.assoc               = debug?8:assoc;
+    	  interface_ip.nbanks              = debug?1:banks;
+    	  interface_ip.out_w               = interface_ip.line_sz*8;
+    	  interface_ip.access_mode         = 0;//debug?0:XML->sys.core[ithCore].dcache.dcache_config[5];
+    	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].BTB.BTB_config[4]/clockRate;
+    	  interface_ip.latency             = debug?3.0/clockRate:XML->sys.core[ithCore].BTB.BTB_config[5]/clockRate;
+    	  interface_ip.obj_func_dyn_energy = 0;
+    	  interface_ip.obj_func_dyn_power  = 0;
+    	  interface_ip.obj_func_leak_power = 0;
+    	  interface_ip.obj_func_cycle_t    = 1;
+    	  interface_ip.num_rw_ports    = 1;
+    	  interface_ip.num_rd_ports    = coredynp.predictionW;
+    	  interface_ip.num_wr_ports    = coredynp.predictionW;
+    	  interface_ip.num_se_rd_ports = 0;
+    	  BTB = new ArrayST(&interface_ip, "Branch Target Buffer", Core_device, coredynp.opt_local, coredynp.core_ty);
+    	  BTB->area.set_area(BTB->area.get_area()+ BTB->local_result.area);
+    	  area.set_area(area.get_area()+ BTB->local_result.area);
+    	  ///cout<<"area="<<area<<endl;
 
-  ID_inst = new inst_decoder(is_default, &interface_ip, coredynp.opcode_length,
-                             1 /*Decoder should not know how many by itself*/,
-                             coredynp.x86, Core_device, coredynp.core_ty);
-
-  ID_operand =
-      new inst_decoder(is_default, &interface_ip, coredynp.arch_ireg_width, 1,
-                       coredynp.x86, Core_device, coredynp.core_ty);
-
-  ID_misc = new inst_decoder(is_default, &interface_ip,
-                             8 /* Prefix field etc upto 14B*/, 1, coredynp.x86,
-                             Core_device, coredynp.core_ty);
-  // TODO: X86 decoder should decode the inst in cyclic mode under the control
-  // of squencer.
-  // So the dynamic power should be multiplied by a few times.
-  area.set_area(area.get_area() +
-                (ID_inst->area.get_area() + ID_operand->area.get_area() +
-                 ID_misc->area.get_area()) *
-                    coredynp.decodeW);
-}
-
-BranchPredictor::BranchPredictor(ParseXML* XML_interface, int ithCore_,
-                                 InputParameter* interface_ip_,
-                                 const CoreDynParam& dyn_p_, bool exist_)
-    : XML(XML_interface),
-      ithCore(ithCore_),
-      interface_ip(*interface_ip_),
-      coredynp(dyn_p_),
-      globalBPT(0),
-      localBPT(0),
-      L1_localBPT(0),
-      L2_localBPT(0),
-      chooser(0),
-      RAS(0),
-      exist(exist_) {
-  /*
-   * Branch Predictor, accessed during ID stage.
-   * McPAT's branch predictor model is the tournament branch predictor used in
-   * Alpha 21264,
-   * including global predictor, local two level predictor, and Chooser.
-   * The Branch predictor also includes a RAS (return address stack) for
-   * function calls
-   * Branch predictors are tagged by thread ID and modeled as 1-way associative
-   * $
-   * However RAS return address stacks are duplicated for each thread.
-   * TODO:Data Width need to be computed more precisely	 *
-   */
-  if (!exist) return;
-  int tag, data;
-
-  clockRate = coredynp.clockRate;
-  executionTime = coredynp.executionTime;
-  interface_ip.assoc = 1;
-  interface_ip.pure_cam = false;
-  if (coredynp.multithreaded) {
-    tag = int(log2(coredynp.num_hthreads) + EXTRA_TAG_BITS);
-    interface_ip.specific_tag = 1;
-    interface_ip.tag_w = tag;
-
-    interface_ip.is_cache = true;
-    interface_ip.pure_ram = false;
-  } else {
-    interface_ip.is_cache = false;
-    interface_ip.pure_ram = true;
-  }
-  // Global predictor
-  data =
-      int(ceil(XML->sys.core[ithCore].predictor.global_predictor_bits / 8.0));
-  interface_ip.line_sz = data;
-  interface_ip.cache_sz =
-      data * XML->sys.core[ithCore].predictor.global_predictor_entries;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 2;
-  interface_ip.throughput = 1.0 / clockRate;
-  interface_ip.latency = 1.0 / clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports = 0;
-  interface_ip.num_rd_ports = coredynp.predictionW;
-  interface_ip.num_wr_ports = coredynp.predictionW;
-  interface_ip.num_se_rd_ports = 0;
-  globalBPT = new ArrayST(&interface_ip, "Global Predictor", Core_device,
-                          coredynp.opt_local, coredynp.core_ty);
-  globalBPT->area.set_area(globalBPT->area.get_area() +
-                           globalBPT->local_result.area);
-  area.set_area(area.get_area() + globalBPT->local_result.area);
-
-  // Local BPT (Level 1)
-  data =
-      int(ceil(XML->sys.core[ithCore].predictor.local_predictor_size[0] / 8.0));
-  interface_ip.line_sz = data;
-  interface_ip.cache_sz =
-      data * XML->sys.core[ithCore].predictor.local_predictor_entries;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 2;
-  interface_ip.throughput = 1.0 / clockRate;
-  interface_ip.latency = 1.0 / clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports = 0;
-  interface_ip.num_rd_ports = coredynp.predictionW;
-  interface_ip.num_wr_ports = coredynp.predictionW;
-  interface_ip.num_se_rd_ports = 0;
-  L1_localBPT = new ArrayST(&interface_ip, "L1 local Predictor", Core_device,
-                            coredynp.opt_local, coredynp.core_ty);
-  L1_localBPT->area.set_area(L1_localBPT->area.get_area() +
-                             L1_localBPT->local_result.area);
-  area.set_area(area.get_area() + L1_localBPT->local_result.area);
-
-  // Local BPT (Level 2)
-  data =
-      int(ceil(XML->sys.core[ithCore].predictor.local_predictor_size[1] / 8.0));
-  interface_ip.line_sz = data;
-  interface_ip.cache_sz =
-      data * XML->sys.core[ithCore].predictor.local_predictor_entries;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 2;
-  interface_ip.throughput = 1.0 / clockRate;
-  interface_ip.latency = 1.0 / clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports = 0;
-  interface_ip.num_rd_ports = coredynp.predictionW;
-  interface_ip.num_wr_ports = coredynp.predictionW;
-  interface_ip.num_se_rd_ports = 0;
-  L2_localBPT = new ArrayST(&interface_ip, "L2 local Predictor", Core_device,
-                            coredynp.opt_local, coredynp.core_ty);
-  L2_localBPT->area.set_area(L2_localBPT->area.get_area() +
-                             L2_localBPT->local_result.area);
-  area.set_area(area.get_area() + L2_localBPT->local_result.area);
-
-  // Chooser
-  data =
-      int(ceil(XML->sys.core[ithCore].predictor.chooser_predictor_bits / 8.0));
-  interface_ip.line_sz = data;
-  interface_ip.cache_sz =
-      data * XML->sys.core[ithCore].predictor.chooser_predictor_entries;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 2;
-  interface_ip.throughput = 1.0 / clockRate;
-  interface_ip.latency = 1.0 / clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports = 0;
-  interface_ip.num_rd_ports = coredynp.predictionW;
-  interface_ip.num_wr_ports = coredynp.predictionW;
-  interface_ip.num_se_rd_ports = 0;
-  chooser = new ArrayST(&interface_ip, "Predictor Chooser", Core_device,
-                        coredynp.opt_local, coredynp.core_ty);
-  chooser->area.set_area(chooser->area.get_area() + chooser->local_result.area);
-  area.set_area(area.get_area() + chooser->local_result.area);
-
-  // RAS return address stacks are Duplicated for each thread.
-  interface_ip.is_cache = false;
-  interface_ip.pure_ram = true;
-  data = int(ceil(coredynp.pc_width / 8.0));
-  interface_ip.line_sz = data;
-  interface_ip.cache_sz = data * XML->sys.core[ithCore].RAS_size;
-  interface_ip.assoc = 1;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 2;
-  interface_ip.throughput = 1.0 / clockRate;
-  interface_ip.latency = 1.0 / clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports = 0;
-  interface_ip.num_rd_ports = coredynp.predictionW;
-  interface_ip.num_wr_ports = coredynp.predictionW;
-  interface_ip.num_se_rd_ports = 0;
-  RAS = new ArrayST(&interface_ip, "RAS", Core_device, coredynp.opt_local,
-                    coredynp.core_ty);
-  RAS->area.set_area(RAS->area.get_area() +
-                     RAS->local_result.area * coredynp.num_hthreads);
-  area.set_area(area.get_area() +
-                RAS->local_result.area * coredynp.num_hthreads);
-}
-
-SchedulerU::SchedulerU(ParseXML* XML_interface, int ithCore_,
-                       InputParameter* interface_ip_,
-                       const CoreDynParam& dyn_p_, bool exist_)
-    : XML(XML_interface),
-      ithCore(ithCore_),
-      interface_ip(*interface_ip_),
-      coredynp(dyn_p_),
-      int_inst_window(0),
-      fp_inst_window(0),
-      ROB(0),
-      instruction_selection(0),
-      exist(exist_) {
-  if (!exist) return;
-  int tag, data;
-  bool is_default = true;
-  string tmp_name;
-
-  clockRate = coredynp.clockRate;
-  executionTime = coredynp.executionTime;
-  if ((coredynp.core_ty == Inorder && coredynp.multithreaded)) {
-    // Instruction issue queue, in-order multi-issue or multithreaded processor
-    // also has this structure. Unified window for Inorder processors
-    tag = int(log2(XML->sys.core[ithCore].number_hardware_threads) *
-              coredynp.perThreadState);  // This is the normal thread state bits
-                                         // based on Niagara Design
-    data = XML->sys.core[ithCore].instruction_length;
-    // NOTE: x86 inst can be very lengthy, up to 15B. Source: Intel® 64 and
-    // IA-32 Architectures
-    // Software Developer’s Manual
-    interface_ip.is_cache = true;
-    interface_ip.pure_cam = false;
-    interface_ip.pure_ram = false;
-    interface_ip.line_sz = int(ceil(data / 8.0));
-    interface_ip.specific_tag = 1;
-    interface_ip.tag_w = tag;
-    interface_ip.cache_sz =
-        XML->sys.core[ithCore].instruction_window_size * interface_ip.line_sz >
-                64
-            ? XML->sys.core[ithCore].instruction_window_size *
-                  interface_ip.line_sz
-            : 64;
-    interface_ip.assoc = 0;
-    interface_ip.nbanks = 1;
-    interface_ip.out_w = interface_ip.line_sz * 8;
-    interface_ip.access_mode = 1;
-    interface_ip.throughput = 1.0 / clockRate;
-    interface_ip.latency = 1.0 / clockRate;
-    interface_ip.obj_func_dyn_energy = 0;
-    interface_ip.obj_func_dyn_power = 0;
-    interface_ip.obj_func_leak_power = 0;
-    interface_ip.obj_func_cycle_t = 1;
-    interface_ip.num_rw_ports = 0;
-    interface_ip.num_rd_ports = coredynp.peak_issueW;
-    interface_ip.num_wr_ports = coredynp.peak_issueW;
-    interface_ip.num_se_rd_ports = 0;
-    interface_ip.num_search_ports = coredynp.peak_issueW;
-    int_inst_window = new ArrayST(&interface_ip, "InstFetchQueue", Core_device,
-                                  coredynp.opt_local, coredynp.core_ty);
-    int_inst_window->area.set_area(int_inst_window->area.get_area() +
-                                   int_inst_window->local_result.area *
-                                       coredynp.num_pipelines);
-    area.set_area(area.get_area() +
-                  int_inst_window->local_result.area * coredynp.num_pipelines);
-    // output_data_csv(iRS.RS.local_result);
-    Iw_height = int_inst_window->local_result.cache_ht;
-
-    /*
-     * selection logic
-     * In a single-issue Inorder multithreaded processor like Niagara, issue
-     * width=1*number_of_threads since the processor does need to pick up
-     * instructions from multiple ready ones(although these ready ones are from
-     * different threads).While SMT processors do not distinguish which thread
-     * belongs to who
-     * at the issue stage.
-     */
-
-    instruction_selection = new selection_logic(
-        is_default, XML->sys.core[ithCore].instruction_window_size,
-        coredynp.peak_issueW * XML->sys.core[ithCore].number_hardware_threads,
-        &interface_ip, Core_device, coredynp.core_ty);
-  }
-
-  if (coredynp.core_ty == OOO) {
-    /*
-     * CAM based instruction window
-     * For physicalRegFilebased OOO it is the instruction issue queue, where
-     * only tags of phy regs are stored
-     * For RS based OOO it is the Reservation station, where both tags and
-     * values of phy regs are stored
-     * It is written once and read twice(two operands) before an instruction can
-     * be issued.
-     * X86 instruction can be very long up to 15B. add instruction length in XML
-     */
-    if (coredynp.scheu_ty == PhysicalRegFile) {
-      tag = coredynp.phy_ireg_width;
-      // Each time only half of the tag is compared, but two tag should be
-      // stored.
-      // This underestimate the search power
-      data =
-          int((ceil((coredynp.instruction_length +
-                     2 * (coredynp.phy_ireg_width - coredynp.arch_ireg_width)) /
-                    2.0) /
-               8.0));
-      // Data width being divided by 2 means only after both operands available
-      // the whole data will be read out.
-      // This is modeled using two equivalent readouts with half of the data
-      // width
-      tmp_name = "InstIssueQueue";
-    } else {
-      tag = coredynp.phy_ireg_width;
-      // Each time only half of the tag is compared, but two tag should be
-      // stored.
-      // This underestimate the search power
-      data =
-          int(ceil(((coredynp.instruction_length +
-                     2 * (coredynp.phy_ireg_width - coredynp.arch_ireg_width) +
-                     2 * coredynp.int_data_width) /
-                    2.0) /
-                   8.0));
-      // Data width being divided by 2 means only after both operands available
-      // the whole data will be read out.
-      // This is modeled using two equivalent readouts with half of the data
-      // width
-
-      tmp_name = "IntReservationStation";
-    }
-    interface_ip.is_cache = true;
-    interface_ip.pure_cam = false;
-    interface_ip.pure_ram = false;
-    interface_ip.line_sz = data;
-    interface_ip.cache_sz =
-        data * XML->sys.core[ithCore].instruction_window_size;
-    interface_ip.assoc = 0;
-    interface_ip.nbanks = 1;
-    interface_ip.out_w = interface_ip.line_sz * 8;
-    interface_ip.specific_tag = 1;
-    interface_ip.tag_w = tag;
-    interface_ip.access_mode = 0;
-    interface_ip.throughput = 2 * 1.0 / clockRate;
-    interface_ip.latency = 2 * 1.0 / clockRate;
-    interface_ip.obj_func_dyn_energy = 0;
-    interface_ip.obj_func_dyn_power = 0;
-    interface_ip.obj_func_leak_power = 0;
-    interface_ip.obj_func_cycle_t = 1;
-    interface_ip.num_rw_ports = 0;
-    interface_ip.num_rd_ports = coredynp.peak_issueW;
-    interface_ip.num_wr_ports = coredynp.peak_issueW;
-    interface_ip.num_se_rd_ports = 0;
-    interface_ip.num_search_ports = coredynp.peak_issueW;
-    int_inst_window = new ArrayST(&interface_ip, tmp_name, Core_device,
-                                  coredynp.opt_local, coredynp.core_ty);
-    int_inst_window->area.set_area(int_inst_window->area.get_area() +
-                                   int_inst_window->local_result.area *
-                                       coredynp.num_pipelines);
-    area.set_area(area.get_area() +
-                  int_inst_window->local_result.area * coredynp.num_pipelines);
-    Iw_height = int_inst_window->local_result.cache_ht;
-    // FU inst window
-    if (coredynp.scheu_ty == PhysicalRegFile) {
-      tag = 2 * coredynp.phy_freg_width;  // TODO: each time only half of the
-                                          // tag is compared
-      data =
-          int(ceil((coredynp.instruction_length +
-                    2 * (coredynp.phy_freg_width - coredynp.arch_freg_width)) /
-                   8.0));
-      tmp_name = "FPIssueQueue";
-    } else {
-      tag = 2 * coredynp.phy_ireg_width;
-      data =
-          int(ceil((coredynp.instruction_length +
-                    2 * (coredynp.phy_freg_width - coredynp.arch_freg_width) +
-                    2 * coredynp.fp_data_width) /
-                   8.0));
-      tmp_name = "FPReservationStation";
-    }
-    interface_ip.is_cache = true;
-    interface_ip.pure_cam = false;
-    interface_ip.pure_ram = false;
-    interface_ip.line_sz = data;
-    interface_ip.cache_sz =
-        data * XML->sys.core[ithCore].fp_instruction_window_size;
-    interface_ip.assoc = 0;
-    interface_ip.nbanks = 1;
-    interface_ip.out_w = interface_ip.line_sz * 8;
-    interface_ip.specific_tag = 1;
-    interface_ip.tag_w = tag;
-    interface_ip.access_mode = 0;
-    interface_ip.throughput = 1.0 / clockRate;
-    interface_ip.latency = 1.0 / clockRate;
-    interface_ip.obj_func_dyn_energy = 0;
-    interface_ip.obj_func_dyn_power = 0;
-    interface_ip.obj_func_leak_power = 0;
-    interface_ip.obj_func_cycle_t = 1;
-    interface_ip.num_rw_ports = 0;
-    interface_ip.num_rd_ports = coredynp.fp_issueW;
-    interface_ip.num_wr_ports = coredynp.fp_issueW;
-    interface_ip.num_se_rd_ports = 0;
-    interface_ip.num_search_ports = coredynp.fp_issueW;
-    fp_inst_window = new ArrayST(&interface_ip, tmp_name, Core_device,
-                                 coredynp.opt_local, coredynp.core_ty);
-    fp_inst_window->area.set_area(fp_inst_window->area.get_area() +
-                                  fp_inst_window->local_result.area *
-                                      coredynp.num_fp_pipelines);
-    area.set_area(area.get_area() +
-                  fp_inst_window->local_result.area *
-                      coredynp.num_fp_pipelines);
-    fp_Iw_height = fp_inst_window->local_result.cache_ht;
-
-    if (XML->sys.core[ithCore].ROB_size > 0) {
-      /*
-       *  if ROB_size = 0, then the target processor does not support
-       *hardware-based
-       *  speculation, i.e. , the processor allow OOO issue as well as OOO
-       *completion, which
-       *  means branch must be resolved before instruction issued into
-       *instruction window, since
-       *  there is no change to flush miss-predict branch path after
-       *instructions are issued in this situation.
-       *
-       *  ROB.ROB size = inflight inst. ROB is unified for int and fp inst.
-       *  One old approach is to combine the RAT and ROB as a huge CAM structure
-       *as in AMD K7.
-       *  However, this approach is abandoned due to its high power and poor
-       *scalablility.
-       *	McPAT uses current implementation of ROB as circular buffer.
-       *	ROB is written once when instruction is issued and read once
-       *when the instruction is committed.         *
-       */
-      int robExtra = int(ceil(5 + log2(coredynp.num_hthreads)));
-      // 5 bits are: busy, Issued, Finished, speculative, valid
-      if (coredynp.scheu_ty == PhysicalRegFile) {
-        // PC is to id the instruction for recover exception.
-        // inst is used to map the renamed dest. registers.so that commit stage
-        // can know which reg/RRAT to update
-        //				data = int(ceil((robExtra+coredynp.pc_width
-        //+
-        //						coredynp.instruction_length +
-        //2*coredynp.phy_ireg_width)/8.0));
-        data = int(ceil(
-            (robExtra + coredynp.pc_width + coredynp.phy_ireg_width) / 8.0));
-      } else {
-        // in RS based OOO, ROB also contains value of destination reg
-        //				data  = int(ceil((robExtra+coredynp.pc_width
-        //+
-        //						coredynp.instruction_length +
-        //2*coredynp.phy_ireg_width + coredynp.fp_data_width)/8.0));
-        data = int(ceil((robExtra + coredynp.pc_width +
-                         coredynp.phy_ireg_width + coredynp.fp_data_width) /
-                        8.0));
+    	  BPT = new BranchPredictor(XML, ithCore, &interface_ip,coredynp);
+    	  area.set_area(area.get_area()+ BPT->area.get_area());
       }
-      interface_ip.is_cache = false;
-      interface_ip.pure_cam = false;
-      interface_ip.pure_ram = true;
-      interface_ip.line_sz = data;
-      interface_ip.cache_sz =
-          data *
-          XML->sys.core[ithCore]
-              .ROB_size;  // The XML ROB size is for all threads
-      interface_ip.assoc = 1;
-      interface_ip.nbanks = 1;
-      interface_ip.out_w = interface_ip.line_sz * 8;
-      interface_ip.access_mode = 1;
-      interface_ip.throughput = 1.0 / clockRate;
-      interface_ip.latency = 1.0 / clockRate;
-      interface_ip.obj_func_dyn_energy = 0;
-      interface_ip.obj_func_dyn_power = 0;
-      interface_ip.obj_func_leak_power = 0;
-      interface_ip.obj_func_cycle_t = 1;
-      interface_ip.num_rw_ports = 0;
-      interface_ip.num_rd_ports = coredynp.peak_commitW;
-      interface_ip.num_wr_ports = coredynp.peak_issueW;
-      interface_ip.num_se_rd_ports = 0;
-      interface_ip.num_search_ports = 0;
-      ROB = new ArrayST(&interface_ip, "ReorderBuffer", Core_device,
-                        coredynp.opt_local, coredynp.core_ty);
-      ROB->area.set_area(ROB->area.get_area() +
-                         ROB->local_result.area * coredynp.num_pipelines);
-      area.set_area(area.get_area() +
-                    ROB->local_result.area * coredynp.num_pipelines);
-      ROB_height = ROB->local_result.cache_ht;
+
+      ID_inst = new inst_decoder(is_default, &interface_ip,
+    		  coredynp.opcode_length, 1/*Decoder should not know how many by itself*/,
+    		  coredynp.x86,
+    		  Core_device, coredynp.core_ty);
+
+      ID_operand = new inst_decoder(is_default, &interface_ip,
+    		  coredynp.arch_ireg_width, 1,
+    		  coredynp.x86,
+    		  Core_device, coredynp.core_ty);
+
+      ID_misc = new inst_decoder(is_default, &interface_ip,
+    		  8/* Prefix field etc upto 14B*/, 1,
+    		  coredynp.x86,
+    		  Core_device, coredynp.core_ty);
+      //TODO: X86 decoder should decode the inst in cyclic mode under the control of squencer.
+      //So the dynamic power should be multiplied by a few times.
+      area.set_area(area.get_area()+ (ID_inst->area.get_area()
+    		  +ID_operand->area.get_area()
+    		  +ID_misc->area.get_area())*coredynp.decodeW);
+
+}
+
+
+BranchPredictor::BranchPredictor(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_, bool exist_)
+:XML(XML_interface),
+ ithCore(ithCore_),
+ interface_ip(*interface_ip_),
+ coredynp(dyn_p_),
+ globalBPT(0),
+ localBPT(0),
+ L1_localBPT(0),
+ L2_localBPT(0),
+ chooser(0),
+ RAS(0),
+ exist(exist_)
+{
+	/*
+	 * Branch Predictor, accessed during ID stage.
+	 * McPAT's branch predictor model is the tournament branch predictor used in Alpha 21264,
+	 * including global predictor, local two level predictor, and Chooser.
+	 * The Branch predictor also includes a RAS (return address stack) for function calls
+	 * Branch predictors are tagged by thread ID and modeled as 1-way associative $
+	 * However RAS return address stacks are duplicated for each thread.
+	 * TODO:Data Width need to be computed more precisely	 *
+	 */
+	if (!exist) return;
+	int  tag, data;
+
+	clockRate = coredynp.clockRate;
+	executionTime = coredynp.executionTime;
+	interface_ip.assoc               = 1;
+	interface_ip.pure_cam            = false;
+	if (coredynp.multithreaded)
+	{
+
+		tag							     = int(log2(coredynp.num_hthreads)+ EXTRA_TAG_BITS);
+		interface_ip.specific_tag        = 1;
+		interface_ip.tag_w               = tag;
+
+		interface_ip.is_cache			 = true;
+		interface_ip.pure_ram            = false;
+		}
+	else
+	{
+		interface_ip.is_cache			 = false;
+		interface_ip.pure_ram            = true;
+
+	}
+	//Global predictor
+	data							 = int(ceil(XML->sys.core[ithCore].predictor.global_predictor_bits/8.0));
+	interface_ip.line_sz             = data;
+	interface_ip.cache_sz            = data*XML->sys.core[ithCore].predictor.global_predictor_entries;
+	interface_ip.nbanks              = 1;
+	interface_ip.out_w               = interface_ip.line_sz*8;
+	interface_ip.access_mode         = 2;
+	interface_ip.throughput          = 1.0/clockRate;
+	interface_ip.latency             = 1.0/clockRate;
+	interface_ip.obj_func_dyn_energy = 0;
+	interface_ip.obj_func_dyn_power  = 0;
+	interface_ip.obj_func_leak_power = 0;
+	interface_ip.obj_func_cycle_t    = 1;
+	interface_ip.num_rw_ports    = 0;
+	interface_ip.num_rd_ports    = coredynp.predictionW;
+	interface_ip.num_wr_ports    = coredynp.predictionW;
+	interface_ip.num_se_rd_ports = 0;
+	globalBPT = new ArrayST(&interface_ip, "Global Predictor", Core_device, coredynp.opt_local, coredynp.core_ty);
+	globalBPT->area.set_area(globalBPT->area.get_area()+ globalBPT->local_result.area);
+	area.set_area(area.get_area()+ globalBPT->local_result.area);
+
+	//Local BPT (Level 1)
+	data							 = int(ceil(XML->sys.core[ithCore].predictor.local_predictor_size[0]/8.0));
+	interface_ip.line_sz             = data;
+	interface_ip.cache_sz            = data*XML->sys.core[ithCore].predictor.local_predictor_entries;
+	interface_ip.nbanks              = 1;
+	interface_ip.out_w               = interface_ip.line_sz*8;
+	interface_ip.access_mode         = 2;
+	interface_ip.throughput          = 1.0/clockRate;
+	interface_ip.latency             = 1.0/clockRate;
+	interface_ip.obj_func_dyn_energy = 0;
+	interface_ip.obj_func_dyn_power  = 0;
+	interface_ip.obj_func_leak_power = 0;
+	interface_ip.obj_func_cycle_t    = 1;
+	interface_ip.num_rw_ports    = 0;
+	interface_ip.num_rd_ports    = coredynp.predictionW;
+	interface_ip.num_wr_ports    = coredynp.predictionW;
+	interface_ip.num_se_rd_ports = 0;
+	L1_localBPT = new ArrayST(&interface_ip, "L1 local Predictor", Core_device, coredynp.opt_local, coredynp.core_ty);
+	L1_localBPT->area.set_area(L1_localBPT->area.get_area()+ L1_localBPT->local_result.area);
+	area.set_area(area.get_area()+ L1_localBPT->local_result.area);
+
+	//Local BPT (Level 2)
+	data							 = int(ceil(XML->sys.core[ithCore].predictor.local_predictor_size[1]/8.0));
+	interface_ip.line_sz             = data;
+	interface_ip.cache_sz            = data*XML->sys.core[ithCore].predictor.local_predictor_entries;
+	interface_ip.nbanks              = 1;
+	interface_ip.out_w               = interface_ip.line_sz*8;
+	interface_ip.access_mode         = 2;
+	interface_ip.throughput          = 1.0/clockRate;
+	interface_ip.latency             = 1.0/clockRate;
+	interface_ip.obj_func_dyn_energy = 0;
+	interface_ip.obj_func_dyn_power  = 0;
+	interface_ip.obj_func_leak_power = 0;
+	interface_ip.obj_func_cycle_t    = 1;
+	interface_ip.num_rw_ports    = 0;
+	interface_ip.num_rd_ports    = coredynp.predictionW;
+	interface_ip.num_wr_ports    = coredynp.predictionW;
+	interface_ip.num_se_rd_ports = 0;
+	L2_localBPT = new ArrayST(&interface_ip, "L2 local Predictor", Core_device, coredynp.opt_local, coredynp.core_ty);
+	L2_localBPT->area.set_area(L2_localBPT->area.get_area()+ L2_localBPT->local_result.area);
+	area.set_area(area.get_area()+ L2_localBPT->local_result.area);
+
+	//Chooser
+	data							 = int(ceil(XML->sys.core[ithCore].predictor.chooser_predictor_bits/8.0));
+	interface_ip.line_sz             = data;
+	interface_ip.cache_sz            = data*XML->sys.core[ithCore].predictor.chooser_predictor_entries;
+	interface_ip.nbanks              = 1;
+	interface_ip.out_w               = interface_ip.line_sz*8;
+	interface_ip.access_mode         = 2;
+	interface_ip.throughput          = 1.0/clockRate;
+	interface_ip.latency             = 1.0/clockRate;
+	interface_ip.obj_func_dyn_energy = 0;
+	interface_ip.obj_func_dyn_power  = 0;
+	interface_ip.obj_func_leak_power = 0;
+	interface_ip.obj_func_cycle_t    = 1;
+	interface_ip.num_rw_ports    = 0;
+	interface_ip.num_rd_ports    = coredynp.predictionW;
+	interface_ip.num_wr_ports    = coredynp.predictionW;
+	interface_ip.num_se_rd_ports = 0;
+	chooser = new ArrayST(&interface_ip, "Predictor Chooser", Core_device, coredynp.opt_local, coredynp.core_ty);
+	chooser->area.set_area(chooser->area.get_area()+ chooser->local_result.area);
+	area.set_area(area.get_area()+ chooser->local_result.area);
+
+	//RAS return address stacks are Duplicated for each thread.
+	interface_ip.is_cache			 = false;
+	interface_ip.pure_ram            = true;
+	data							 = int(ceil(coredynp.pc_width/8.0));
+	interface_ip.line_sz             = data;
+	interface_ip.cache_sz            = data*XML->sys.core[ithCore].RAS_size;
+	interface_ip.assoc               = 1;
+	interface_ip.nbanks              = 1;
+	interface_ip.out_w               = interface_ip.line_sz*8;
+	interface_ip.access_mode         = 2;
+	interface_ip.throughput          = 1.0/clockRate;
+	interface_ip.latency             = 1.0/clockRate;
+	interface_ip.obj_func_dyn_energy = 0;
+	interface_ip.obj_func_dyn_power  = 0;
+	interface_ip.obj_func_leak_power = 0;
+	interface_ip.obj_func_cycle_t    = 1;
+	interface_ip.num_rw_ports    = 0;
+	interface_ip.num_rd_ports    = coredynp.predictionW;
+	interface_ip.num_wr_ports    = coredynp.predictionW;
+	interface_ip.num_se_rd_ports = 0;
+	RAS = new ArrayST(&interface_ip, "RAS", Core_device, coredynp.opt_local, coredynp.core_ty);
+	RAS->area.set_area(RAS->area.get_area()+ RAS->local_result.area*coredynp.num_hthreads);
+	area.set_area(area.get_area()+ RAS->local_result.area*coredynp.num_hthreads);
+
+}
+
+SchedulerU::SchedulerU(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_, bool exist_)
+:XML(XML_interface),
+ ithCore(ithCore_),
+ interface_ip(*interface_ip_),
+ coredynp(dyn_p_),
+ int_inst_window(0),
+ fp_inst_window(0),
+ ROB(0),
+ instruction_selection(0),
+ exist(exist_)
+ {
+	if (!exist) return;
+	int   tag, data;
+	bool  is_default=true;
+	string tmp_name;
+
+	clockRate = coredynp.clockRate;
+	executionTime = coredynp.executionTime;
+	if ((coredynp.core_ty==Inorder && coredynp.multithreaded))
+	{
+		//Instruction issue queue, in-order multi-issue or multithreaded processor also has this structure. Unified window for Inorder processors
+		tag							     = int(log2(XML->sys.core[ithCore].number_hardware_threads)*coredynp.perThreadState);//This is the normal thread state bits based on Niagara Design
+		data							 = XML->sys.core[ithCore].instruction_length;
+		//NOTE: x86 inst can be very lengthy, up to 15B. Source: Intel® 64 and IA-32 Architectures
+		//Software Developer’s Manual
+		interface_ip.is_cache			 = true;
+		interface_ip.pure_cam            = false;
+		interface_ip.pure_ram            = false;
+		interface_ip.line_sz             = int(ceil(data/8.0));
+		interface_ip.specific_tag        = 1;
+		interface_ip.tag_w               = tag;
+		interface_ip.cache_sz            = XML->sys.core[ithCore].instruction_window_size*interface_ip.line_sz>64?XML->sys.core[ithCore].instruction_window_size*interface_ip.line_sz:64;
+		interface_ip.assoc               = 0;
+		interface_ip.nbanks              = 1;
+		interface_ip.out_w               = interface_ip.line_sz*8;
+		interface_ip.access_mode         = 1;
+		interface_ip.throughput          = 1.0/clockRate;
+		interface_ip.latency             = 1.0/clockRate;
+		interface_ip.obj_func_dyn_energy = 0;
+		interface_ip.obj_func_dyn_power  = 0;
+		interface_ip.obj_func_leak_power = 0;
+		interface_ip.obj_func_cycle_t    = 1;
+		interface_ip.num_rw_ports        = 0;
+		interface_ip.num_rd_ports        = coredynp.peak_issueW;
+		interface_ip.num_wr_ports        = coredynp.peak_issueW;
+		interface_ip.num_se_rd_ports     = 0;
+		interface_ip.num_search_ports    = coredynp.peak_issueW;
+		int_inst_window = new ArrayST(&interface_ip, "InstFetchQueue", Core_device, coredynp.opt_local, coredynp.core_ty);
+		int_inst_window->area.set_area(int_inst_window->area.get_area()+ int_inst_window->local_result.area*coredynp.num_pipelines);
+		area.set_area(area.get_area()+ int_inst_window->local_result.area*coredynp.num_pipelines);
+		//output_data_csv(iRS.RS.local_result);
+		Iw_height      =int_inst_window->local_result.cache_ht;
+
+		/*
+		 * selection logic
+		 * In a single-issue Inorder multithreaded processor like Niagara, issue width=1*number_of_threads since the processor does need to pick up
+		 * instructions from multiple ready ones(although these ready ones are from different threads).While SMT processors do not distinguish which thread belongs to who
+		 * at the issue stage.
+		 */
+
+		instruction_selection = new selection_logic(is_default, XML->sys.core[ithCore].instruction_window_size,
+				coredynp.peak_issueW*XML->sys.core[ithCore].number_hardware_threads,
+				&interface_ip, Core_device, coredynp.core_ty);
+	}
+
+    if (coredynp.core_ty==OOO)
+    {
+    	/*
+    	 * CAM based instruction window
+    	 * For physicalRegFilebased OOO it is the instruction issue queue, where only tags of phy regs are stored
+    	 * For RS based OOO it is the Reservation station, where both tags and values of phy regs are stored
+    	 * It is written once and read twice(two operands) before an instruction can be issued.
+    	 * X86 instruction can be very long up to 15B. add instruction length in XML
+    	 */
+    	if(coredynp.scheu_ty==PhysicalRegFile)
+    	{
+    		tag	 = coredynp.phy_ireg_width;
+    		// Each time only half of the tag is compared, but two tag should be stored.
+    		// This underestimate the search power
+    		data = int((ceil((coredynp.instruction_length+2*(coredynp.phy_ireg_width - coredynp.arch_ireg_width))/2.0)/8.0));
+	        //Data width being divided by 2 means only after both operands available the whole data will be read out.
+	        //This is modeled using two equivalent readouts with half of the data width
+    		tmp_name = "InstIssueQueue";
+    	}
+    	else
+    	{
+	        tag	  = coredynp.phy_ireg_width;
+    		// Each time only half of the tag is compared, but two tag should be stored.
+    		// This underestimate the search power
+	        data  = int(ceil(((coredynp.instruction_length+2*(coredynp.phy_ireg_width - coredynp.arch_ireg_width)+
+	        		2*coredynp.int_data_width)/2.0)/8.0));
+	        //Data width being divided by 2 means only after both operands available the whole data will be read out.
+	        //This is modeled using two equivalent readouts with half of the data width
+
+	        tmp_name = "IntReservationStation";
+    	}
+    	interface_ip.is_cache			 = true;
+    	interface_ip.pure_cam            = false;
+    	interface_ip.pure_ram            = false;
+    	interface_ip.line_sz             = data;
+    	interface_ip.cache_sz            = data*XML->sys.core[ithCore].instruction_window_size;
+    	interface_ip.assoc               = 0;
+    	interface_ip.nbanks              = 1;
+    	interface_ip.out_w               = interface_ip.line_sz*8;
+    	interface_ip.specific_tag        = 1;
+    	interface_ip.tag_w               = tag;
+    	interface_ip.access_mode         = 0;
+    	interface_ip.throughput          = 2*1.0/clockRate;
+    	interface_ip.latency             = 2*1.0/clockRate;
+    	interface_ip.obj_func_dyn_energy = 0;
+    	interface_ip.obj_func_dyn_power  = 0;
+    	interface_ip.obj_func_leak_power = 0;
+    	interface_ip.obj_func_cycle_t    = 1;
+    	interface_ip.num_rw_ports       = 0;
+    	interface_ip.num_rd_ports       = coredynp.peak_issueW;
+    	interface_ip.num_wr_ports       = coredynp.peak_issueW;
+    	interface_ip.num_se_rd_ports    = 0;
+		interface_ip.num_search_ports   = coredynp.peak_issueW;
+		int_inst_window = new ArrayST(&interface_ip, tmp_name, Core_device, coredynp.opt_local, coredynp.core_ty);
+		int_inst_window->area.set_area(int_inst_window->area.get_area()+ int_inst_window->local_result.area*coredynp.num_pipelines);
+		area.set_area(area.get_area()+ int_inst_window->local_result.area*coredynp.num_pipelines);
+		Iw_height      =int_inst_window->local_result.cache_ht;
+		//FU inst window
+    	if(coredynp.scheu_ty==PhysicalRegFile)
+    	{
+    		tag	 = 2*coredynp.phy_freg_width;// TODO: each time only half of the tag is compared
+    		data = int(ceil((coredynp.instruction_length+2*(coredynp.phy_freg_width - coredynp.arch_freg_width))/8.0));
+    		tmp_name = "FPIssueQueue";
+    	}
+    	else
+    	{
+	        tag	  = 2*coredynp.phy_ireg_width;
+	        data  = int(ceil((coredynp.instruction_length+2*(coredynp.phy_freg_width - coredynp.arch_freg_width)+
+	        		2*coredynp.fp_data_width)/8.0));
+	        tmp_name = "FPReservationStation";
+    	}
+    	interface_ip.is_cache			 = true;
+    	interface_ip.pure_cam            = false;
+    	interface_ip.pure_ram            = false;
+    	interface_ip.line_sz             = data;
+    	interface_ip.cache_sz            = data*XML->sys.core[ithCore].fp_instruction_window_size;
+    	interface_ip.assoc               = 0;
+    	interface_ip.nbanks              = 1;
+    	interface_ip.out_w               = interface_ip.line_sz*8;
+    	interface_ip.specific_tag        = 1;
+    	interface_ip.tag_w               = tag;
+    	interface_ip.access_mode         = 0;
+    	interface_ip.throughput          = 1.0/clockRate;
+    	interface_ip.latency             = 1.0/clockRate;
+    	interface_ip.obj_func_dyn_energy = 0;
+    	interface_ip.obj_func_dyn_power  = 0;
+    	interface_ip.obj_func_leak_power = 0;
+    	interface_ip.obj_func_cycle_t    = 1;
+    	interface_ip.num_rw_ports       = 0;
+    	interface_ip.num_rd_ports       = coredynp.fp_issueW;
+    	interface_ip.num_wr_ports       = coredynp.fp_issueW;
+    	interface_ip.num_se_rd_ports    = 0;
+		interface_ip.num_search_ports   = coredynp.fp_issueW;
+		fp_inst_window = new ArrayST(&interface_ip, tmp_name, Core_device, coredynp.opt_local, coredynp.core_ty);
+		fp_inst_window->area.set_area(fp_inst_window->area.get_area()+ fp_inst_window->local_result.area*coredynp.num_fp_pipelines);
+		area.set_area(area.get_area()+ fp_inst_window->local_result.area*coredynp.num_fp_pipelines);
+		fp_Iw_height      =fp_inst_window->local_result.cache_ht;
+
+		if (XML->sys.core[ithCore].ROB_size >0)
+		{
+			/*
+			 *  if ROB_size = 0, then the target processor does not support hardware-based
+			 *  speculation, i.e. , the processor allow OOO issue as well as OOO completion, which
+			 *  means branch must be resolved before instruction issued into instruction window, since
+			 *  there is no change to flush miss-predict branch path after instructions are issued in this situation.
+			 *
+			 *  ROB.ROB size = inflight inst. ROB is unified for int and fp inst.
+			 *  One old approach is to combine the RAT and ROB as a huge CAM structure as in AMD K7.
+			 *  However, this approach is abandoned due to its high power and poor scalablility.
+			 *	McPAT uses current implementation of ROB as circular buffer.
+			 *	ROB is written once when instruction is issued and read once when the instruction is committed.         *
+			 */
+			int robExtra = int(ceil(5 + log2(coredynp.num_hthreads)));
+			//5 bits are: busy, Issued, Finished, speculative, valid
+			if(coredynp.scheu_ty==PhysicalRegFile)
+			{
+				//PC is to id the instruction for recover exception.
+				//inst is used to map the renamed dest. registers.so that commit stage can know which reg/RRAT to update
+//				data = int(ceil((robExtra+coredynp.pc_width +
+//						coredynp.instruction_length + 2*coredynp.phy_ireg_width)/8.0));
+				data = int(ceil((robExtra+coredynp.pc_width +
+							coredynp.phy_ireg_width)/8.0));
+			}
+			else
+			{
+				//in RS based OOO, ROB also contains value of destination reg
+//				data  = int(ceil((robExtra+coredynp.pc_width +
+//						coredynp.instruction_length + 2*coredynp.phy_ireg_width + coredynp.fp_data_width)/8.0));
+				data  = int(ceil((robExtra + coredynp.pc_width +
+						coredynp.phy_ireg_width + coredynp.fp_data_width)/8.0));
+			}
+			interface_ip.is_cache			 = false;
+			interface_ip.pure_cam            = false;
+			interface_ip.pure_ram            = true;
+			interface_ip.line_sz             = data;
+			interface_ip.cache_sz            = data*XML->sys.core[ithCore].ROB_size;//The XML ROB size is for all threads
+			interface_ip.assoc               = 1;
+			interface_ip.nbanks              = 1;
+			interface_ip.out_w               = interface_ip.line_sz*8;
+			interface_ip.access_mode         = 1;
+			interface_ip.throughput          = 1.0/clockRate;
+			interface_ip.latency             = 1.0/clockRate;
+			interface_ip.obj_func_dyn_energy = 0;
+			interface_ip.obj_func_dyn_power  = 0;
+			interface_ip.obj_func_leak_power = 0;
+			interface_ip.obj_func_cycle_t    = 1;
+			interface_ip.num_rw_ports       = 0;
+			interface_ip.num_rd_ports       = coredynp.peak_commitW;
+			interface_ip.num_wr_ports       = coredynp.peak_issueW;
+			interface_ip.num_se_rd_ports    = 0;
+			interface_ip.num_search_ports   = 0;
+			ROB = new ArrayST(&interface_ip, "ReorderBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
+			ROB->area.set_area(ROB->area.get_area()+ ROB->local_result.area*coredynp.num_pipelines);
+			area.set_area(area.get_area()+ ROB->local_result.area*coredynp.num_pipelines);
+			ROB_height      =ROB->local_result.cache_ht;
+		}
+
+		instruction_selection = new selection_logic(is_default, XML->sys.core[ithCore].instruction_window_size,
+				coredynp.peak_issueW, &interface_ip, Core_device, coredynp.core_ty);
     }
-
-    instruction_selection = new selection_logic(
-        is_default, XML->sys.core[ithCore].instruction_window_size,
-        coredynp.peak_issueW, &interface_ip, Core_device, coredynp.core_ty);
-  }
 }
 
-LoadStoreU::LoadStoreU(ParseXML* XML_interface, int ithCore_,
-                       InputParameter* interface_ip_,
-                       const CoreDynParam& dyn_p_, bool exist_)
-    : XML(XML_interface),
-      ithCore(ithCore_),
-      interface_ip(*interface_ip_),
-      coredynp(dyn_p_),
-      LSQ(0),
-      exist(exist_) {
-  if (!exist) return;
-  int idx, tag, data, size, line, assoc;
-  bool debug = false;
-  int ldst_opcode = XML->sys.core[ithCore].opcode_width;  // 16;
+LoadStoreU::LoadStoreU(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_,bool exist_)
+:XML(XML_interface),
+ ithCore(ithCore_),
+ interface_ip(*interface_ip_),
+ coredynp(dyn_p_),
+ LSQ(0),
+ exist(exist_)
+{
+	  if (!exist) return;
+	  int  idx, tag, data, size, line, assoc;
+	  bool debug= false;
+	  int ldst_opcode = XML->sys.core[ithCore].opcode_width;//16;
 
-  clockRate = coredynp.clockRate;
-  executionTime = coredynp.executionTime;
-  cache_p = (Cache_policy)XML->sys.core[ithCore].dcache.dcache_config[7];
+	  clockRate = coredynp.clockRate;
+	  executionTime = coredynp.executionTime;
+	  cache_p = (Cache_policy)XML->sys.core[ithCore].dcache.dcache_config[7];
 
-  interface_ip.num_search_ports = XML->sys.core[ithCore].memory_ports;
-  interface_ip.is_cache = true;
-  interface_ip.pure_cam = false;
-  interface_ip.pure_ram = false;
+	  interface_ip.num_search_ports    = XML->sys.core[ithCore].memory_ports;
+	  interface_ip.is_cache			   = true;
+	  interface_ip.pure_cam            = false;
+	  interface_ip.pure_ram            = false;
+	 
 
-  // Crossbar based interconnect for shared memory accesses, added by Syed
-  // Crossbar
+	  //Crossbar based interconnect for shared memory accesses, added by Syed
+	  //Crossbar
 
-  if (XML->sys.architecture == 1) {
-    xbar_shared = new Crossbar(
-        coredynp.num_fpus, coredynp.num_fpus, 32,
-        &(g_tp.peri_global));  // Syed: coredynp.num_fpus is used as simd_width
-  } else {
-    xbar_shared = new Crossbar(
-        coredynp.num_fpus, coredynp.num_fpus, 32,
-        &(g_tp.peri_global));  // Syed: coredynp.num_fpus is used as simd_width
-  }
+	  if(XML->sys.architecture==1){
+    xbar_shared     = new Crossbar(coredynp.num_fpus,coredynp.num_fpus,32,&(g_tp.peri_global));//Syed: coredynp.num_fpus is used as simd_width  
+	  }
+	  else{
+	  xbar_shared     = new Crossbar(coredynp.num_fpus,coredynp.num_fpus,32,&(g_tp.peri_global));//Syed: coredynp.num_fpus is used as simd_width
+	  }
 
-  // TODO: Check if this line should be changed to
-  // new
-  // Crossbar(simd_width,shared_memory_banks,word_length*simd_width,&(g_tp.peri_global));
 
-  // shared memory added by Jingwen
-  size = (int)XML->sys.core[ithCore].sharedmemory.dcache_config[0];
-  line = (int)XML->sys.core[ithCore].sharedmemory.dcache_config[1];
-  assoc = (int)XML->sys.core[ithCore].sharedmemory.dcache_config[2];
-  idx = debug ? 9 : int(ceil(log2(size / line / assoc)));
-  tag = debug ? 51 : XML->sys.physical_address_width - idx -
-                         int(ceil(log2(line))) + EXTRA_TAG_BITS;
-  interface_ip.specific_tag = 1;
-  interface_ip.tag_w = 1;
-  interface_ip.cache_sz =
-      debug ? 32768 : (int)XML->sys.core[ithCore].sharedmemory.dcache_config[0];
-  interface_ip.line_sz =
-      debug ? 64 : (int)XML->sys.core[ithCore].sharedmemory.dcache_config[1];
-  interface_ip.assoc =
-      debug ? 8 : (int)XML->sys.core[ithCore].sharedmemory.dcache_config[2];
-  interface_ip.nbanks =
-      debug ? 1 : (int)XML->sys.core[ithCore].sharedmemory.dcache_config[3];
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode =
-      0;  // debug?0:XML->sys.core[ithCore].sharedmemory.dcache_config[5];
-  interface_ip.throughput =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].sharedmemory.dcache_config[4] / clockRate;
-  interface_ip.latency =
-      debug ? 3.0 / clockRate
-            : XML->sys.core[ithCore].sharedmemory.dcache_config[5] / clockRate;
-  interface_ip.is_cache = true;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports =
-      debug ? 1 : XML->sys.core[ithCore].memory_ports;  // usually In-order has
-                                                        // 1 and OOO has 2 at
-                                                        // least.
-  interface_ip.num_rd_ports = 0;
-  interface_ip.num_wr_ports = 0;
-  interface_ip.num_se_rd_ports = 0;
-  sharedmemory.caches = new ArrayST(&interface_ip, "sharedmemory", Core_device,
-                                    coredynp.opt_local, coredynp.core_ty);
-  sharedmemory.area.set_area(sharedmemory.area.get_area() +
-                             sharedmemory.caches->local_result.area);
-  area.set_area(area.get_area() + sharedmemory.caches->local_result.area +
-                xbar_shared->area.get_area());
+     //TODO: Check if this line should be changed to
+     //new Crossbar(simd_width,shared_memory_banks,word_length*simd_width,&(g_tp.peri_global));
 
-  // shared memory buffer
-  // miss buffer
-  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-  data = (XML->sys.physical_address_width) + int(ceil(log2(size / line))) +
-         sharedmemory.caches->l_ip.line_sz * 8;
-  interface_ip.specific_tag = 1;
-  interface_ip.tag_w = 1;
-  interface_ip.line_sz =
-      int(ceil(data / 8.0));  // int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-  interface_ip.cache_sz = XML->sys.core[ithCore].sharedmemory.buffer_sizes[0] *
-                          interface_ip.line_sz;
-  interface_ip.assoc = 0;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 2;
-  interface_ip.throughput =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].sharedmemory.dcache_config[4] / clockRate;
-  interface_ip.latency =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].sharedmemory.dcache_config[5] / clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
-  ;
-  interface_ip.num_rd_ports = 0;
-  interface_ip.num_wr_ports = 0;
-  interface_ip.num_se_rd_ports = 0;
-  sharedmemory.missb =
-      new ArrayST(&interface_ip, "SharedmemoryMissBuffer", Core_device,
-                  coredynp.opt_local, coredynp.core_ty);
-  sharedmemory.area.set_area(sharedmemory.area.get_area() +
-                             sharedmemory.missb->local_result.area);
-  area.set_area(area.get_area() + sharedmemory.missb->local_result.area);
+    //shared memory added by Jingwen
+	  size                             = (int)XML->sys.core[ithCore].sharedmemory.dcache_config[0];
+	  line                             = (int)XML->sys.core[ithCore].sharedmemory.dcache_config[1];
+	  assoc                            = (int)XML->sys.core[ithCore].sharedmemory.dcache_config[2];
+	  idx    					 	   = debug?9:int(ceil(log2(size/line/assoc)));
+	  tag							   = debug?51:XML->sys.physical_address_width-idx-int(ceil(log2(line))) + EXTRA_TAG_BITS;
+	  interface_ip.specific_tag        = 1;
+	  interface_ip.tag_w               = 1;
+	  interface_ip.cache_sz            = debug?32768:(int)XML->sys.core[ithCore].sharedmemory.dcache_config[0];
+	  interface_ip.line_sz             = debug?64:(int)XML->sys.core[ithCore].sharedmemory.dcache_config[1];
+	  interface_ip.assoc               = debug?8:(int)XML->sys.core[ithCore].sharedmemory.dcache_config[2];
+	  interface_ip.nbanks              = debug?1:(int)XML->sys.core[ithCore].sharedmemory.dcache_config[3];
+	  interface_ip.out_w               = interface_ip.line_sz*8;
+	  interface_ip.access_mode         = 0;//debug?0:XML->sys.core[ithCore].sharedmemory.dcache_config[5];
+	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[4]/clockRate;
+	  interface_ip.latency             = debug?3.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[5]/clockRate;
+	  interface_ip.is_cache			 = true;
+	  interface_ip.obj_func_dyn_energy = 0;
+	  interface_ip.obj_func_dyn_power  = 0;
+	  interface_ip.obj_func_leak_power = 0;
+	  interface_ip.obj_func_cycle_t    = 1;
+	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;//usually In-order has 1 and OOO has 2 at least.
+	  interface_ip.num_rd_ports    = 0;
+	  interface_ip.num_wr_ports    = 0;
+	  interface_ip.num_se_rd_ports = 0;
+	  sharedmemory.caches = new ArrayST(&interface_ip, "sharedmemory", Core_device, coredynp.opt_local, coredynp.core_ty);
+	  sharedmemory.area.set_area(sharedmemory.area.get_area()+ sharedmemory.caches->local_result.area);
+	  area.set_area(area.get_area()+ sharedmemory.caches->local_result.area + xbar_shared->area.get_area());
 
-  // sharedmemory fill buffer
-  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-  data = sharedmemory.caches->l_ip.line_sz;
-  interface_ip.specific_tag = 1;
-  interface_ip.tag_w = 1;
-  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
-  interface_ip.cache_sz =
-      data * XML->sys.core[ithCore].sharedmemory.buffer_sizes[1];
-  interface_ip.assoc = 0;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 2;
-  interface_ip.throughput =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].sharedmemory.dcache_config[4] / clockRate;
-  interface_ip.latency =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].sharedmemory.dcache_config[5] / clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
-  ;
-  interface_ip.num_rd_ports = 0;
-  interface_ip.num_wr_ports = 0;
-  interface_ip.num_se_rd_ports = 0;
-  sharedmemory.ifb =
-      new ArrayST(&interface_ip, "SharedMemoryFillBuffer", Core_device,
-                  coredynp.opt_local, coredynp.core_ty);
-  sharedmemory.area.set_area(sharedmemory.area.get_area() +
-                             sharedmemory.ifb->local_result.area);
-  area.set_area(area.get_area() + sharedmemory.ifb->local_result.area);
 
-  // sharedmemory prefetch buffer
-  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;  // check with
-                                                           // previous entries
-                                                           // to decide wthether
-                                                           // to merge.
-  data = sharedmemory.caches->l_ip
-             .line_sz;  // separate queue to prevent from cache polution.
-  interface_ip.specific_tag = 1;
-  interface_ip.tag_w = 1;
-  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
-  interface_ip.cache_sz = XML->sys.core[ithCore].sharedmemory.buffer_sizes[2] *
-                          interface_ip.line_sz;
-  interface_ip.assoc = 0;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 2;
-  interface_ip.throughput =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].sharedmemory.dcache_config[4] / clockRate;
-  interface_ip.latency =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].sharedmemory.dcache_config[5] / clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
-  ;
-  interface_ip.num_rd_ports = 0;
-  interface_ip.num_wr_ports = 0;
-  interface_ip.num_se_rd_ports = 0;
-  sharedmemory.prefetchb =
-      new ArrayST(&interface_ip, "dcacheprefetchBuffer", Core_device,
-                  coredynp.opt_local, coredynp.core_ty);
-  sharedmemory.area.set_area(sharedmemory.area.get_area() +
-                             sharedmemory.prefetchb->local_result.area);
-  area.set_area(area.get_area() + sharedmemory.prefetchb->local_result.area);
+    //shared memory buffer
+	  //miss buffer
+	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+	  data							   = (XML->sys.physical_address_width) + int(ceil(log2(size/line))) + sharedmemory.caches->l_ip.line_sz*8;
+	  interface_ip.specific_tag        = 1;
+	  interface_ip.tag_w               = 1;
+	  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+	  interface_ip.cache_sz            = XML->sys.core[ithCore].sharedmemory.buffer_sizes[0]*interface_ip.line_sz;
+	  interface_ip.assoc               = 0;
+	  interface_ip.nbanks              = 1;
+	  interface_ip.out_w               = interface_ip.line_sz*8;
+	  interface_ip.access_mode         = 2;
+	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[4]/clockRate;
+	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[5]/clockRate;
+	  interface_ip.obj_func_dyn_energy = 0;
+	  interface_ip.obj_func_dyn_power  = 0;
+	  interface_ip.obj_func_leak_power = 0;
+	  interface_ip.obj_func_cycle_t    = 1;
+	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
+	  interface_ip.num_rd_ports    = 0;
+	  interface_ip.num_wr_ports    = 0;
+	  interface_ip.num_se_rd_ports = 0;
+	  sharedmemory.missb = new ArrayST(&interface_ip, "SharedmemoryMissBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
+	  sharedmemory.area.set_area(sharedmemory.area.get_area()+ sharedmemory.missb->local_result.area);
+	  area.set_area(area.get_area()+ sharedmemory.missb->local_result.area);
 
-  // shared memory WBB
-  if (cache_p == Write_back) {
-    tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-    data = sharedmemory.caches->l_ip.line_sz;
-    interface_ip.specific_tag = 1;
-    interface_ip.tag_w = 1;
-    interface_ip.line_sz = data;
-    interface_ip.cache_sz =
-        XML->sys.core[ithCore].sharedmemory.buffer_sizes[3] *
-        interface_ip.line_sz;
-    interface_ip.assoc = 0;
-    interface_ip.nbanks = 1;
-    interface_ip.out_w = interface_ip.line_sz * 8;
-    interface_ip.access_mode = 2;
-    interface_ip.throughput =
-        debug
-            ? 1.0 / clockRate
-            : XML->sys.core[ithCore].sharedmemory.dcache_config[4] / clockRate;
-    interface_ip.latency =
-        debug
-            ? 1.0 / clockRate
-            : XML->sys.core[ithCore].sharedmemory.dcache_config[5] / clockRate;
-    interface_ip.obj_func_dyn_energy = 0;
-    interface_ip.obj_func_dyn_power = 0;
-    interface_ip.obj_func_leak_power = 0;
-    interface_ip.obj_func_cycle_t = 1;
-    interface_ip.num_rw_ports = XML->sys.core[ithCore].memory_ports;
-    interface_ip.num_rd_ports = 0;
-    interface_ip.num_wr_ports = 0;
-    interface_ip.num_se_rd_ports = 0;
-    sharedmemory.wbb = new ArrayST(&interface_ip, "dcacheWBB", Core_device,
-                                   coredynp.opt_local, coredynp.core_ty);
-    sharedmemory.area.set_area(sharedmemory.area.get_area() +
-                               sharedmemory.wbb->local_result.area);
-    area.set_area(area.get_area() + sharedmemory.wbb->local_result.area);
-    // output_data_csv(sharedmemory.wbb.local_result);
-  }
 
-  /*
-   * ccache starts here
-   */
-  // Constant cache
-  size = (int)XML->sys.core[ithCore].ccache.dcache_config[0];
-  line = (int)XML->sys.core[ithCore].ccache.dcache_config[1];
-  assoc = (int)XML->sys.core[ithCore].ccache.dcache_config[2];
-  idx = debug ? 9 : int(ceil(log2(size / line / assoc)));
-  tag = debug ? 51 : XML->sys.physical_address_width - idx -
-                         int(ceil(log2(line))) + EXTRA_TAG_BITS;
-  interface_ip.specific_tag = 1;
-  interface_ip.tag_w = tag;
-  interface_ip.cache_sz =
-      debug ? 32768 : (int)XML->sys.core[ithCore].ccache.dcache_config[0];
-  interface_ip.line_sz =
-      debug ? 64 : (int)XML->sys.core[ithCore].ccache.dcache_config[1];
-  interface_ip.assoc =
-      debug ? 8 : (int)XML->sys.core[ithCore].ccache.dcache_config[2];
-  interface_ip.nbanks =
-      debug ? 1 : (int)XML->sys.core[ithCore].ccache.dcache_config[3];
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode =
-      0;  // debug?0:XML->sys.core[ithCore].ccache.dcache_config[5];
-  interface_ip.throughput =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].ccache.dcache_config[4] / clockRate;
-  interface_ip.latency =
-      debug ? 3.0 / clockRate
-            : XML->sys.core[ithCore].ccache.dcache_config[5] / clockRate;
-  interface_ip.is_cache = true;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports =
-      debug ? 1 : XML->sys.core[ithCore].memory_ports;  // usually In-order has
-                                                        // 1 and OOO has 2 at
-                                                        // least.
-  interface_ip.num_rd_ports = 0;
-  interface_ip.num_wr_ports = 0;
-  interface_ip.num_se_rd_ports = 0;
-  ccache.caches = new ArrayST(&interface_ip, "ccache", Core_device,
-                              coredynp.opt_local, coredynp.core_ty);
-  ccache.area.set_area(ccache.area.get_area() +
-                       ccache.caches->local_result.area);
-  area.set_area(area.get_area() + ccache.caches->local_result.area);
-  // output_data_csv(ccache.caches.local_result);
+    //sharedmemory fill buffer
+	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+	  data							   = sharedmemory.caches->l_ip.line_sz;
+	  interface_ip.specific_tag        = 1;
+	  interface_ip.tag_w               = 1;
+	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
+	  interface_ip.cache_sz            = data*XML->sys.core[ithCore].sharedmemory.buffer_sizes[1];
+	  interface_ip.assoc               = 0;
+	  interface_ip.nbanks              = 1;
+	  interface_ip.out_w               = interface_ip.line_sz*8;
+	  interface_ip.access_mode         = 2;
+	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[4]/clockRate;
+	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[5]/clockRate;
+	  interface_ip.obj_func_dyn_energy = 0;
+	  interface_ip.obj_func_dyn_power  = 0;
+	  interface_ip.obj_func_leak_power = 0;
+	  interface_ip.obj_func_cycle_t    = 1;
+	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
+	  interface_ip.num_rd_ports    = 0;
+	  interface_ip.num_wr_ports    = 0;
+	  interface_ip.num_se_rd_ports = 0;
+	  sharedmemory.ifb = new ArrayST(&interface_ip, "SharedMemoryFillBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
+	  sharedmemory.area.set_area(sharedmemory.area.get_area()+ sharedmemory.ifb->local_result.area);
+	  area.set_area(area.get_area()+ sharedmemory.ifb->local_result.area);
 
-  // cCache controllers
-  // miss buffer
-  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-  data = (XML->sys.physical_address_width) + int(ceil(log2(size / line))) +
-         ccache.caches->l_ip.line_sz * 8;
-  interface_ip.specific_tag = 1;
-  interface_ip.tag_w = tag;
-  interface_ip.line_sz =
-      int(ceil(data / 8.0));  // int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-  interface_ip.cache_sz =
-      XML->sys.core[ithCore].ccache.buffer_sizes[0] * interface_ip.line_sz;
-  interface_ip.assoc = 0;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 2;
-  interface_ip.throughput =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].ccache.dcache_config[4] / clockRate;
-  interface_ip.latency =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].ccache.dcache_config[5] / clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
-  ;
-  interface_ip.num_rd_ports = 0;
-  interface_ip.num_wr_ports = 0;
-  interface_ip.num_se_rd_ports = 0;
-  ccache.missb = new ArrayST(&interface_ip, "ccacheMissBuffer", Core_device,
-                             coredynp.opt_local, coredynp.core_ty);
-  ccache.area.set_area(ccache.area.get_area() +
-                       ccache.missb->local_result.area);
-  area.set_area(area.get_area() + ccache.missb->local_result.area);
-  // output_data_csv(ccache.missb.local_result);
+    //sharedmemory prefetch buffer
+	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries to decide wthether to merge.
+	  data							   = sharedmemory.caches->l_ip.line_sz;//separate queue to prevent from cache polution.
+	  interface_ip.specific_tag        = 1;
+	  interface_ip.tag_w               = 1;
+	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
+	  interface_ip.cache_sz            = XML->sys.core[ithCore].sharedmemory.buffer_sizes[2]*interface_ip.line_sz;
+	  interface_ip.assoc               = 0;
+	  interface_ip.nbanks              = 1;
+	  interface_ip.out_w               = interface_ip.line_sz*8;
+	  interface_ip.access_mode         = 2;
+	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[4]/clockRate;
+	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[5]/clockRate;
+	  interface_ip.obj_func_dyn_energy = 0;
+	  interface_ip.obj_func_dyn_power  = 0;
+	  interface_ip.obj_func_leak_power = 0;
+	  interface_ip.obj_func_cycle_t    = 1;
+	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
+	  interface_ip.num_rd_ports    = 0;
+	  interface_ip.num_wr_ports    = 0;
+	  interface_ip.num_se_rd_ports = 0;
+	  sharedmemory.prefetchb = new ArrayST(&interface_ip, "dcacheprefetchBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
+	  sharedmemory.area.set_area(sharedmemory.area.get_area()+ sharedmemory.prefetchb->local_result.area);
+	  area.set_area(area.get_area()+ sharedmemory.prefetchb->local_result.area);
 
-  // fill buffer
-  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-  data = ccache.caches->l_ip.line_sz;
-  interface_ip.specific_tag = 1;
-  interface_ip.tag_w = tag;
-  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
-  interface_ip.cache_sz = data * XML->sys.core[ithCore].ccache.buffer_sizes[1];
-  interface_ip.assoc = 0;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 2;
-  interface_ip.throughput =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].ccache.dcache_config[4] / clockRate;
-  interface_ip.latency =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].ccache.dcache_config[5] / clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
-  ;
-  interface_ip.num_rd_ports = 0;
-  interface_ip.num_wr_ports = 0;
-  interface_ip.num_se_rd_ports = 0;
-  ccache.ifb = new ArrayST(&interface_ip, "ccacheFillBuffer", Core_device,
-                           coredynp.opt_local, coredynp.core_ty);
-  ccache.area.set_area(ccache.area.get_area() + ccache.ifb->local_result.area);
-  area.set_area(area.get_area() + ccache.ifb->local_result.area);
-  // output_data_csv(ccache.ifb.local_result);
+    //shared memory WBB
+	  if (cache_p==Write_back)
+	  {
+		  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+		  data							   = sharedmemory.caches->l_ip.line_sz;
+		  interface_ip.specific_tag        = 1;
+		  interface_ip.tag_w               = 1;
+		  interface_ip.line_sz             = data;
+		  interface_ip.cache_sz            = XML->sys.core[ithCore].sharedmemory.buffer_sizes[3]*interface_ip.line_sz;
+		  interface_ip.assoc               = 0;
+		  interface_ip.nbanks              = 1;
+		  interface_ip.out_w               = interface_ip.line_sz*8;
+		  interface_ip.access_mode         = 2;
+		  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[4]/clockRate;
+		  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[5]/clockRate;
+		  interface_ip.obj_func_dyn_energy = 0;
+		  interface_ip.obj_func_dyn_power  = 0;
+		  interface_ip.obj_func_leak_power = 0;
+		  interface_ip.obj_func_cycle_t    = 1;
+		  interface_ip.num_rw_ports    = XML->sys.core[ithCore].memory_ports;
+		  interface_ip.num_rd_ports    = 0;
+		  interface_ip.num_wr_ports    = 0;
+		  interface_ip.num_se_rd_ports = 0;
+		  sharedmemory.wbb = new ArrayST(&interface_ip, "dcacheWBB", Core_device, coredynp.opt_local, coredynp.core_ty);
+		  sharedmemory.area.set_area(sharedmemory.area.get_area()+ sharedmemory.wbb->local_result.area);
+		  area.set_area(area.get_area()+ sharedmemory.wbb->local_result.area);
+		  //output_data_csv(sharedmemory.wbb.local_result);
+	  }
 
-  // prefetch buffer
-  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;  // check with
-                                                           // previous entries
-                                                           // to decide wthether
-                                                           // to merge.
-  data = ccache.caches->l_ip
-             .line_sz;  // separate queue to prevent from cache polution.
-  interface_ip.specific_tag = 1;
-  interface_ip.tag_w = tag;
-  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
-  interface_ip.cache_sz =
-      XML->sys.core[ithCore].ccache.buffer_sizes[2] * interface_ip.line_sz;
-  interface_ip.assoc = 0;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 2;
-  interface_ip.throughput =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].ccache.dcache_config[4] / clockRate;
-  interface_ip.latency =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].ccache.dcache_config[5] / clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
-  ;
-  interface_ip.num_rd_ports = 0;
-  interface_ip.num_wr_ports = 0;
-  interface_ip.num_se_rd_ports = 0;
-  ccache.prefetchb =
-      new ArrayST(&interface_ip, "ccacheprefetchBuffer", Core_device,
-                  coredynp.opt_local, coredynp.core_ty);
-  ccache.area.set_area(ccache.area.get_area() +
-                       ccache.prefetchb->local_result.area);
-  area.set_area(area.get_area() + ccache.prefetchb->local_result.area);
-  // output_data_csv(ccache.prefetchb.local_result);
 
-  // WBB
-  if (cache_p == Write_back) {
-    tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-    data = ccache.caches->l_ip.line_sz;
-    interface_ip.specific_tag = 1;
-    interface_ip.tag_w = tag;
-    interface_ip.line_sz = data;
-    interface_ip.cache_sz =
-        XML->sys.core[ithCore].ccache.buffer_sizes[3] * interface_ip.line_sz;
-    interface_ip.assoc = 0;
-    interface_ip.nbanks = 1;
-    interface_ip.out_w = interface_ip.line_sz * 8;
-    interface_ip.access_mode = 2;
-    interface_ip.throughput =
-        debug ? 1.0 / clockRate
-              : XML->sys.core[ithCore].ccache.dcache_config[4] / clockRate;
-    interface_ip.latency =
-        debug ? 1.0 / clockRate
-              : XML->sys.core[ithCore].ccache.dcache_config[5] / clockRate;
-    interface_ip.obj_func_dyn_energy = 0;
-    interface_ip.obj_func_dyn_power = 0;
-    interface_ip.obj_func_leak_power = 0;
-    interface_ip.obj_func_cycle_t = 1;
-    interface_ip.num_rw_ports = XML->sys.core[ithCore].memory_ports;
-    interface_ip.num_rd_ports = 0;
-    interface_ip.num_wr_ports = 0;
-    interface_ip.num_se_rd_ports = 0;
-    ccache.wbb = new ArrayST(&interface_ip, "ccacheWBB", Core_device,
-                             coredynp.opt_local, coredynp.core_ty);
-    ccache.area.set_area(ccache.area.get_area() +
-                         ccache.wbb->local_result.area);
-    area.set_area(area.get_area() + ccache.wbb->local_result.area);
-    // output_data_csv(ccache.wbb.local_result);
-  }
+   /*
+    * ccache starts here
+    */   
+    //Constant cache
+	  size                             = (int)XML->sys.core[ithCore].ccache.dcache_config[0];
+	  line                             = (int)XML->sys.core[ithCore].ccache.dcache_config[1];
+	  assoc                            = (int)XML->sys.core[ithCore].ccache.dcache_config[2];
+	  idx    					 	   = debug?9:int(ceil(log2(size/line/assoc)));
+	  tag							   = debug?51:XML->sys.physical_address_width-idx-int(ceil(log2(line))) + EXTRA_TAG_BITS;
+	  interface_ip.specific_tag        = 1;
+	  interface_ip.tag_w               = tag;
+	  interface_ip.cache_sz            = debug?32768:(int)XML->sys.core[ithCore].ccache.dcache_config[0];
+	  interface_ip.line_sz             = debug?64:(int)XML->sys.core[ithCore].ccache.dcache_config[1];
+	  interface_ip.assoc               = debug?8:(int)XML->sys.core[ithCore].ccache.dcache_config[2];
+	  interface_ip.nbanks              = debug?1:(int)XML->sys.core[ithCore].ccache.dcache_config[3];
+	  interface_ip.out_w               = interface_ip.line_sz*8;
+	  interface_ip.access_mode         = 0;//debug?0:XML->sys.core[ithCore].ccache.dcache_config[5];
+	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[4]/clockRate;
+	  interface_ip.latency             = debug?3.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[5]/clockRate;
+	  interface_ip.is_cache			 = true;
+	  interface_ip.obj_func_dyn_energy = 0;
+	  interface_ip.obj_func_dyn_power  = 0;
+	  interface_ip.obj_func_leak_power = 0;
+	  interface_ip.obj_func_cycle_t    = 1;
+	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;//usually In-order has 1 and OOO has 2 at least.
+	  interface_ip.num_rd_ports    = 0;
+	  interface_ip.num_wr_ports    = 0;
+	  interface_ip.num_se_rd_ports = 0;
+	  ccache.caches = new ArrayST(&interface_ip, "ccache", Core_device, coredynp.opt_local, coredynp.core_ty);
+	  ccache.area.set_area(ccache.area.get_area()+ ccache.caches->local_result.area);
+	  area.set_area(area.get_area()+ ccache.caches->local_result.area);
+	  //output_data_csv(ccache.caches.local_result);
 
-  /*
-   * tcache starts here
-   */
-  // Texture cache
-  size = (int)XML->sys.core[ithCore].tcache.dcache_config[0];
-  line = (int)XML->sys.core[ithCore].tcache.dcache_config[1];
-  assoc = (int)XML->sys.core[ithCore].tcache.dcache_config[2];
-  idx = debug ? 9 : int(ceil(log2(size / line / assoc)));
-  tag = debug ? 51 : XML->sys.physical_address_width - idx -
-                         int(ceil(log2(line))) + EXTRA_TAG_BITS;
-  interface_ip.specific_tag = 1;
-  interface_ip.tag_w = tag;
-  interface_ip.cache_sz =
-      debug ? 32768 : (int)XML->sys.core[ithCore].tcache.dcache_config[0];
-  interface_ip.line_sz =
-      debug ? 64 : (int)XML->sys.core[ithCore].tcache.dcache_config[1];
-  interface_ip.assoc =
-      debug ? 8 : (int)XML->sys.core[ithCore].tcache.dcache_config[2];
-  interface_ip.nbanks =
-      debug ? 1 : (int)XML->sys.core[ithCore].tcache.dcache_config[3];
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode =
-      0;  // debug?0:XML->sys.core[ithCore].tcache.dcache_config[5];
-  interface_ip.throughput =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].tcache.dcache_config[4] / clockRate;
-  interface_ip.latency =
-      debug ? 3.0 / clockRate
-            : XML->sys.core[ithCore].tcache.dcache_config[5] / clockRate;
-  interface_ip.is_cache = true;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports =
-      debug ? 1 : XML->sys.core[ithCore].memory_ports;  // usually In-order has
-                                                        // 1 and OOO has 2 at
-                                                        // least.
-  interface_ip.num_rd_ports = 0;
-  interface_ip.num_wr_ports = 0;
-  interface_ip.num_se_rd_ports = 0;
-  tcache.caches = new ArrayST(&interface_ip, "tcache", Core_device,
-                              coredynp.opt_local, coredynp.core_ty);
-  tcache.area.set_area(tcache.area.get_area() +
-                       tcache.caches->local_result.area);
-  area.set_area(area.get_area() + tcache.caches->local_result.area);
-  // output_data_csv(tcache.caches.local_result);
 
-  // tCache controllers
-  // miss buffer
-  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-  data = (XML->sys.physical_address_width) + int(ceil(log2(size / line))) +
-         tcache.caches->l_ip.line_sz * 8;
-  interface_ip.specific_tag = 1;
-  interface_ip.tag_w = tag;
-  interface_ip.line_sz =
-      int(ceil(data / 8.0));  // int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-  interface_ip.cache_sz =
-      XML->sys.core[ithCore].tcache.buffer_sizes[0] * interface_ip.line_sz;
-  interface_ip.assoc = 0;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 2;
-  interface_ip.throughput =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].tcache.dcache_config[4] / clockRate;
-  interface_ip.latency =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].tcache.dcache_config[5] / clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
-  ;
-  interface_ip.num_rd_ports = 0;
-  interface_ip.num_wr_ports = 0;
-  interface_ip.num_se_rd_ports = 0;
-  tcache.missb = new ArrayST(&interface_ip, "tcacheMissBuffer", Core_device,
-                             coredynp.opt_local, coredynp.core_ty);
-  tcache.area.set_area(tcache.area.get_area() +
-                       tcache.missb->local_result.area);
-  area.set_area(area.get_area() + tcache.missb->local_result.area);
-  // output_data_csv(tcache.missb.local_result);
 
-  // fill buffer
-  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-  data = tcache.caches->l_ip.line_sz;
-  interface_ip.specific_tag = 1;
-  interface_ip.tag_w = tag;
-  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
-  interface_ip.cache_sz = data * XML->sys.core[ithCore].tcache.buffer_sizes[1];
-  interface_ip.assoc = 0;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 2;
-  interface_ip.throughput =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].tcache.dcache_config[4] / clockRate;
-  interface_ip.latency =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].tcache.dcache_config[5] / clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
-  ;
-  interface_ip.num_rd_ports = 0;
-  interface_ip.num_wr_ports = 0;
-  interface_ip.num_se_rd_ports = 0;
-  tcache.ifb = new ArrayST(&interface_ip, "tcacheFillBuffer", Core_device,
-                           coredynp.opt_local, coredynp.core_ty);
-  tcache.area.set_area(tcache.area.get_area() + tcache.ifb->local_result.area);
-  area.set_area(area.get_area() + tcache.ifb->local_result.area);
-  // output_data_csv(tcache.ifb.local_result);
+      //cCache controllers
+	  //miss buffer
+	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+	  data							   = (XML->sys.physical_address_width) + int(ceil(log2(size/line))) + ccache.caches->l_ip.line_sz*8;
+	  interface_ip.specific_tag        = 1;
+	  interface_ip.tag_w               = tag;
+	  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+	  interface_ip.cache_sz            = XML->sys.core[ithCore].ccache.buffer_sizes[0]*interface_ip.line_sz;
+	  interface_ip.assoc               = 0;
+	  interface_ip.nbanks              = 1;
+	  interface_ip.out_w               = interface_ip.line_sz*8;
+	  interface_ip.access_mode         = 2;
+	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[4]/clockRate;
+	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[5]/clockRate;
+	  interface_ip.obj_func_dyn_energy = 0;
+	  interface_ip.obj_func_dyn_power  = 0;
+	  interface_ip.obj_func_leak_power = 0;
+	  interface_ip.obj_func_cycle_t    = 1;
+	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
+	  interface_ip.num_rd_ports    = 0;
+	  interface_ip.num_wr_ports    = 0;
+	  interface_ip.num_se_rd_ports = 0;
+	  ccache.missb = new ArrayST(&interface_ip, "ccacheMissBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
+	  ccache.area.set_area(ccache.area.get_area()+ ccache.missb->local_result.area);
+	  area.set_area(area.get_area()+ ccache.missb->local_result.area);
+	  //output_data_csv(ccache.missb.local_result);
 
-  // prefetch buffer
-  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;  // check with
-                                                           // previous entries
-                                                           // to decide wthether
-                                                           // to merge.
-  data = tcache.caches->l_ip
-             .line_sz;  // separate queue to prevent from cache polution.
-  interface_ip.specific_tag = 1;
-  interface_ip.tag_w = tag;
-  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
-  interface_ip.cache_sz =
-      XML->sys.core[ithCore].tcache.buffer_sizes[2] * interface_ip.line_sz;
-  interface_ip.assoc = 0;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 2;
-  interface_ip.throughput =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].tcache.dcache_config[4] / clockRate;
-  interface_ip.latency =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].tcache.dcache_config[5] / clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
-  ;
-  interface_ip.num_rd_ports = 0;
-  interface_ip.num_wr_ports = 0;
-  interface_ip.num_se_rd_ports = 0;
-  tcache.prefetchb =
-      new ArrayST(&interface_ip, "tcacheprefetchBuffer", Core_device,
-                  coredynp.opt_local, coredynp.core_ty);
-  tcache.area.set_area(tcache.area.get_area() +
-                       tcache.prefetchb->local_result.area);
-  area.set_area(area.get_area() + tcache.prefetchb->local_result.area);
-  // output_data_csv(tcache.prefetchb.local_result);
+	  //fill buffer
+	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+	  data							   = ccache.caches->l_ip.line_sz;
+	  interface_ip.specific_tag        = 1;
+	  interface_ip.tag_w               = tag;
+	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
+	  interface_ip.cache_sz            = data*XML->sys.core[ithCore].ccache.buffer_sizes[1];
+	  interface_ip.assoc               = 0;
+	  interface_ip.nbanks              = 1;
+	  interface_ip.out_w               = interface_ip.line_sz*8;
+	  interface_ip.access_mode         = 2;
+	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[4]/clockRate;
+	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[5]/clockRate;
+	  interface_ip.obj_func_dyn_energy = 0;
+	  interface_ip.obj_func_dyn_power  = 0;
+	  interface_ip.obj_func_leak_power = 0;
+	  interface_ip.obj_func_cycle_t    = 1;
+	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
+	  interface_ip.num_rd_ports    = 0;
+	  interface_ip.num_wr_ports    = 0;
+	  interface_ip.num_se_rd_ports = 0;
+	  ccache.ifb = new ArrayST(&interface_ip, "ccacheFillBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
+	  ccache.area.set_area(ccache.area.get_area()+ ccache.ifb->local_result.area);
+	  area.set_area(area.get_area()+ ccache.ifb->local_result.area);
+	  //output_data_csv(ccache.ifb.local_result);
 
-  // WBB
-  if (cache_p == Write_back) {
-    tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-    data = tcache.caches->l_ip.line_sz;
-    interface_ip.specific_tag = 1;
-    interface_ip.tag_w = tag;
-    interface_ip.line_sz = data;
-    interface_ip.cache_sz =
-        XML->sys.core[ithCore].tcache.buffer_sizes[3] * interface_ip.line_sz;
-    interface_ip.assoc = 0;
-    interface_ip.nbanks = 1;
-    interface_ip.out_w = interface_ip.line_sz * 8;
-    interface_ip.access_mode = 2;
-    interface_ip.throughput =
-        debug ? 1.0 / clockRate
-              : XML->sys.core[ithCore].tcache.dcache_config[4] / clockRate;
-    interface_ip.latency =
-        debug ? 1.0 / clockRate
-              : XML->sys.core[ithCore].tcache.dcache_config[5] / clockRate;
-    interface_ip.obj_func_dyn_energy = 0;
-    interface_ip.obj_func_dyn_power = 0;
-    interface_ip.obj_func_leak_power = 0;
-    interface_ip.obj_func_cycle_t = 1;
-    interface_ip.num_rw_ports = XML->sys.core[ithCore].memory_ports;
-    interface_ip.num_rd_ports = 0;
-    interface_ip.num_wr_ports = 0;
-    interface_ip.num_se_rd_ports = 0;
-    tcache.wbb = new ArrayST(&interface_ip, "tcacheWBB", Core_device,
-                             coredynp.opt_local, coredynp.core_ty);
-    tcache.area.set_area(tcache.area.get_area() +
-                         tcache.wbb->local_result.area);
-    area.set_area(area.get_area() + tcache.wbb->local_result.area);
-    // output_data_csv(tcache.wbb.local_result);
-  }
+	  //prefetch buffer
+	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries to decide wthether to merge.
+	  data							   = ccache.caches->l_ip.line_sz;//separate queue to prevent from cache polution.
+	  interface_ip.specific_tag        = 1;
+	  interface_ip.tag_w               = tag;
+	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
+	  interface_ip.cache_sz            = XML->sys.core[ithCore].ccache.buffer_sizes[2]*interface_ip.line_sz;
+	  interface_ip.assoc               = 0;
+	  interface_ip.nbanks              = 1;
+	  interface_ip.out_w               = interface_ip.line_sz*8;
+	  interface_ip.access_mode         = 2;
+	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[4]/clockRate;
+	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[5]/clockRate;
+	  interface_ip.obj_func_dyn_energy = 0;
+	  interface_ip.obj_func_dyn_power  = 0;
+	  interface_ip.obj_func_leak_power = 0;
+	  interface_ip.obj_func_cycle_t    = 1;
+	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
+	  interface_ip.num_rd_ports    = 0;
+	  interface_ip.num_wr_ports    = 0;
+	  interface_ip.num_se_rd_ports = 0;
+	  ccache.prefetchb = new ArrayST(&interface_ip, "ccacheprefetchBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
+	  ccache.area.set_area(ccache.area.get_area()+ ccache.prefetchb->local_result.area);
+	  area.set_area(area.get_area()+ ccache.prefetchb->local_result.area);
+	  //output_data_csv(ccache.prefetchb.local_result);
 
-  /*
-   * dcache starts here
-   */
-  // Dcache
-  size = (int)XML->sys.core[ithCore].dcache.dcache_config[0];
-  line = (int)XML->sys.core[ithCore].dcache.dcache_config[1];
-  assoc = (int)XML->sys.core[ithCore].dcache.dcache_config[2];
-  idx = debug ? 9 : int(ceil(log2(size / line / assoc)));
-  tag = debug ? 51 : XML->sys.physical_address_width - idx -
-                         int(ceil(log2(line))) + EXTRA_TAG_BITS;
-  interface_ip.specific_tag = 1;
-  interface_ip.tag_w = tag;
-  interface_ip.cache_sz =
-      debug ? 32768 : (int)XML->sys.core[ithCore].dcache.dcache_config[0];
-  interface_ip.line_sz =
-      debug ? 64 : (int)XML->sys.core[ithCore].dcache.dcache_config[1];
-  interface_ip.assoc =
-      debug ? 8 : (int)XML->sys.core[ithCore].dcache.dcache_config[2];
-  interface_ip.nbanks =
-      debug ? 1 : (int)XML->sys.core[ithCore].dcache.dcache_config[3];
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode =
-      0;  // debug?0:XML->sys.core[ithCore].dcache.dcache_config[5];
-  interface_ip.throughput =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].dcache.dcache_config[4] / clockRate;
-  interface_ip.latency =
-      debug ? 3.0 / clockRate
-            : XML->sys.core[ithCore].dcache.dcache_config[5] / clockRate;
-  interface_ip.is_cache = true;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports =
-      debug ? 1 : XML->sys.core[ithCore].memory_ports;  // usually In-order has
-                                                        // 1 and OOO has 2 at
-                                                        // least.
-  interface_ip.num_rd_ports = 0;
-  interface_ip.num_wr_ports = 0;
-  interface_ip.num_se_rd_ports = 0;
-  dcache.caches = new ArrayST(&interface_ip, "dcache", Core_device,
-                              coredynp.opt_local, coredynp.core_ty);
-  dcache.area.set_area(dcache.area.get_area() +
-                       dcache.caches->local_result.area);
-  area.set_area(area.get_area() + dcache.caches->local_result.area);
-  // output_data_csv(dcache.caches.local_result);
+	  //WBB
+	  if (cache_p==Write_back)
+	  {
+		  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+		  data							   = ccache.caches->l_ip.line_sz;
+		  interface_ip.specific_tag        = 1;
+		  interface_ip.tag_w               = tag;
+		  interface_ip.line_sz             = data;
+		  interface_ip.cache_sz            = XML->sys.core[ithCore].ccache.buffer_sizes[3]*interface_ip.line_sz;
+		  interface_ip.assoc               = 0;
+		  interface_ip.nbanks              = 1;
+		  interface_ip.out_w               = interface_ip.line_sz*8;
+		  interface_ip.access_mode         = 2;
+		  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[4]/clockRate;
+		  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[5]/clockRate;
+		  interface_ip.obj_func_dyn_energy = 0;
+		  interface_ip.obj_func_dyn_power  = 0;
+		  interface_ip.obj_func_leak_power = 0;
+		  interface_ip.obj_func_cycle_t    = 1;
+		  interface_ip.num_rw_ports    = XML->sys.core[ithCore].memory_ports;
+		  interface_ip.num_rd_ports    = 0;
+		  interface_ip.num_wr_ports    = 0;
+		  interface_ip.num_se_rd_ports = 0;
+		  ccache.wbb = new ArrayST(&interface_ip, "ccacheWBB", Core_device, coredynp.opt_local, coredynp.core_ty);
+		  ccache.area.set_area(ccache.area.get_area()+ ccache.wbb->local_result.area);
+		  area.set_area(area.get_area()+ ccache.wbb->local_result.area);
+		  //output_data_csv(ccache.wbb.local_result);
+	  }
 
-  // dCache controllers
-  // miss buffer
-  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-  data = (XML->sys.physical_address_width) + int(ceil(log2(size / line))) +
-         dcache.caches->l_ip.line_sz * 8;
-  interface_ip.specific_tag = 1;
-  interface_ip.tag_w = tag;
-  interface_ip.line_sz =
-      int(ceil(data / 8.0));  // int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-  interface_ip.cache_sz =
-      XML->sys.core[ithCore].dcache.buffer_sizes[0] * interface_ip.line_sz;
-  interface_ip.assoc = 0;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 2;
-  interface_ip.throughput =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].dcache.dcache_config[4] / clockRate;
-  interface_ip.latency =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].dcache.dcache_config[5] / clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
-  ;
-  interface_ip.num_rd_ports = 0;
-  interface_ip.num_wr_ports = 0;
-  interface_ip.num_se_rd_ports = 0;
-  dcache.missb = new ArrayST(&interface_ip, "dcacheMissBuffer", Core_device,
-                             coredynp.opt_local, coredynp.core_ty);
-  dcache.area.set_area(dcache.area.get_area() +
-                       dcache.missb->local_result.area);
-  area.set_area(area.get_area() + dcache.missb->local_result.area);
-  // output_data_csv(dcache.missb.local_result);
+   /*
+    * tcache starts here
+    */   
+    //Texture cache
+	  size                             = (int)XML->sys.core[ithCore].tcache.dcache_config[0];
+	  line                             = (int)XML->sys.core[ithCore].tcache.dcache_config[1];
+	  assoc                            = (int)XML->sys.core[ithCore].tcache.dcache_config[2];
+	  idx    					 	   = debug?9:int(ceil(log2(size/line/assoc)));
+	  tag							   = debug?51:XML->sys.physical_address_width-idx-int(ceil(log2(line))) + EXTRA_TAG_BITS;
+	  interface_ip.specific_tag        = 1;
+	  interface_ip.tag_w               = tag;
+	  interface_ip.cache_sz            = debug?32768:(int)XML->sys.core[ithCore].tcache.dcache_config[0];
+	  interface_ip.line_sz             = debug?64:(int)XML->sys.core[ithCore].tcache.dcache_config[1];
+	  interface_ip.assoc               = debug?8:(int)XML->sys.core[ithCore].tcache.dcache_config[2];
+	  interface_ip.nbanks              = debug?1:(int)XML->sys.core[ithCore].tcache.dcache_config[3];
+	  interface_ip.out_w               = interface_ip.line_sz*8;
+	  interface_ip.access_mode         = 0;//debug?0:XML->sys.core[ithCore].tcache.dcache_config[5];
+	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[4]/clockRate;
+	  interface_ip.latency             = debug?3.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[5]/clockRate;
+	  interface_ip.is_cache			 = true;
+	  interface_ip.obj_func_dyn_energy = 0;
+	  interface_ip.obj_func_dyn_power  = 0;
+	  interface_ip.obj_func_leak_power = 0;
+	  interface_ip.obj_func_cycle_t    = 1;
+	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;//usually In-order has 1 and OOO has 2 at least.
+	  interface_ip.num_rd_ports    = 0;
+	  interface_ip.num_wr_ports    = 0;
+	  interface_ip.num_se_rd_ports = 0;
+	  tcache.caches = new ArrayST(&interface_ip, "tcache", Core_device, coredynp.opt_local, coredynp.core_ty);
+	  tcache.area.set_area(tcache.area.get_area()+ tcache.caches->local_result.area);
+	  area.set_area(area.get_area()+ tcache.caches->local_result.area);
+	  //output_data_csv(tcache.caches.local_result);
 
-  // fill buffer
-  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-  data = dcache.caches->l_ip.line_sz;
-  interface_ip.specific_tag = 1;
-  interface_ip.tag_w = tag;
-  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
-  interface_ip.cache_sz = data * XML->sys.core[ithCore].dcache.buffer_sizes[1];
-  interface_ip.assoc = 0;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 2;
-  interface_ip.throughput =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].dcache.dcache_config[4] / clockRate;
-  interface_ip.latency =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].dcache.dcache_config[5] / clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
-  ;
-  interface_ip.num_rd_ports = 0;
-  interface_ip.num_wr_ports = 0;
-  interface_ip.num_se_rd_ports = 0;
-  dcache.ifb = new ArrayST(&interface_ip, "dcacheFillBuffer", Core_device,
-                           coredynp.opt_local, coredynp.core_ty);
-  dcache.area.set_area(dcache.area.get_area() + dcache.ifb->local_result.area);
-  area.set_area(area.get_area() + dcache.ifb->local_result.area);
-  // output_data_csv(dcache.ifb.local_result);
 
-  // prefetch buffer
-  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;  // check with
-                                                           // previous entries
-                                                           // to decide wthether
-                                                           // to merge.
-  data = dcache.caches->l_ip
-             .line_sz;  // separate queue to prevent from cache polution.
-  interface_ip.specific_tag = 1;
-  interface_ip.tag_w = tag;
-  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
-  interface_ip.cache_sz =
-      XML->sys.core[ithCore].dcache.buffer_sizes[2] * interface_ip.line_sz;
-  interface_ip.assoc = 0;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 2;
-  interface_ip.throughput =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].dcache.dcache_config[4] / clockRate;
-  interface_ip.latency =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].dcache.dcache_config[5] / clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
-  ;
-  interface_ip.num_rd_ports = 0;
-  interface_ip.num_wr_ports = 0;
-  interface_ip.num_se_rd_ports = 0;
-  dcache.prefetchb =
-      new ArrayST(&interface_ip, "dcacheprefetchBuffer", Core_device,
-                  coredynp.opt_local, coredynp.core_ty);
-  dcache.area.set_area(dcache.area.get_area() +
-                       dcache.prefetchb->local_result.area);
-  area.set_area(area.get_area() + dcache.prefetchb->local_result.area);
-  // output_data_csv(dcache.prefetchb.local_result);
+	  //tCache controllers
+	  //miss buffer
+	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+	  data							   = (XML->sys.physical_address_width) + int(ceil(log2(size/line))) + tcache.caches->l_ip.line_sz*8;
+	  interface_ip.specific_tag        = 1;
+	  interface_ip.tag_w               = tag;
+	  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+	  interface_ip.cache_sz            = XML->sys.core[ithCore].tcache.buffer_sizes[0]*interface_ip.line_sz;
+	  interface_ip.assoc               = 0;
+	  interface_ip.nbanks              = 1;
+	  interface_ip.out_w               = interface_ip.line_sz*8;
+	  interface_ip.access_mode         = 2;
+	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[4]/clockRate;
+	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[5]/clockRate;
+	  interface_ip.obj_func_dyn_energy = 0;
+	  interface_ip.obj_func_dyn_power  = 0;
+	  interface_ip.obj_func_leak_power = 0;
+	  interface_ip.obj_func_cycle_t    = 1;
+	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
+	  interface_ip.num_rd_ports    = 0;
+	  interface_ip.num_wr_ports    = 0;
+	  interface_ip.num_se_rd_ports = 0;
+	  tcache.missb = new ArrayST(&interface_ip, "tcacheMissBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
+	  tcache.area.set_area(tcache.area.get_area()+ tcache.missb->local_result.area);
+	  area.set_area(area.get_area()+ tcache.missb->local_result.area);
+	  //output_data_csv(tcache.missb.local_result);
 
-  // WBB
-  if (cache_p == Write_back) {
-    tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-    data = dcache.caches->l_ip.line_sz;
-    interface_ip.specific_tag = 1;
-    interface_ip.tag_w = tag;
-    interface_ip.line_sz = data;
-    interface_ip.cache_sz =
-        XML->sys.core[ithCore].dcache.buffer_sizes[3] * interface_ip.line_sz;
-    interface_ip.assoc = 0;
-    interface_ip.nbanks = 1;
-    interface_ip.out_w = interface_ip.line_sz * 8;
-    interface_ip.access_mode = 2;
-    interface_ip.throughput =
-        debug ? 1.0 / clockRate
-              : XML->sys.core[ithCore].dcache.dcache_config[4] / clockRate;
-    interface_ip.latency =
-        debug ? 1.0 / clockRate
-              : XML->sys.core[ithCore].dcache.dcache_config[5] / clockRate;
-    interface_ip.obj_func_dyn_energy = 0;
-    interface_ip.obj_func_dyn_power = 0;
-    interface_ip.obj_func_leak_power = 0;
-    interface_ip.obj_func_cycle_t = 1;
-    interface_ip.num_rw_ports = XML->sys.core[ithCore].memory_ports;
-    interface_ip.num_rd_ports = 0;
-    interface_ip.num_wr_ports = 0;
-    interface_ip.num_se_rd_ports = 0;
-    dcache.wbb = new ArrayST(&interface_ip, "dcacheWBB", Core_device,
-                             coredynp.opt_local, coredynp.core_ty);
-    dcache.area.set_area(dcache.area.get_area() +
-                         dcache.wbb->local_result.area);
-    area.set_area(area.get_area() + dcache.wbb->local_result.area);
-    // output_data_csv(dcache.wbb.local_result);
-  }
+	  //fill buffer
+	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+	  data							   = tcache.caches->l_ip.line_sz;
+	  interface_ip.specific_tag        = 1;
+	  interface_ip.tag_w               = tag;
+	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
+	  interface_ip.cache_sz            = data*XML->sys.core[ithCore].tcache.buffer_sizes[1];
+	  interface_ip.assoc               = 0;
+	  interface_ip.nbanks              = 1;
+	  interface_ip.out_w               = interface_ip.line_sz*8;
+	  interface_ip.access_mode         = 2;
+	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[4]/clockRate;
+	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[5]/clockRate;
+	  interface_ip.obj_func_dyn_energy = 0;
+	  interface_ip.obj_func_dyn_power  = 0;
+	  interface_ip.obj_func_leak_power = 0;
+	  interface_ip.obj_func_cycle_t    = 1;
+	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
+	  interface_ip.num_rd_ports    = 0;
+	  interface_ip.num_wr_ports    = 0;
+	  interface_ip.num_se_rd_ports = 0;
+	  tcache.ifb = new ArrayST(&interface_ip, "tcacheFillBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
+	  tcache.area.set_area(tcache.area.get_area()+ tcache.ifb->local_result.area);
+	  area.set_area(area.get_area()+ tcache.ifb->local_result.area);
+	  //output_data_csv(tcache.ifb.local_result);
 
-  /*
-   * LSU--in-order processors do not have separate load queue: unified lsq
-   * partitioned among threads
-   * it is actually the store queue but for inorder processors it serves as both
-   * loadQ and StoreQ
-   */
-  tag = ldst_opcode + XML->sys.virtual_address_width +
-        int(ceil(log2(XML->sys.core[ithCore].number_hardware_threads))) +
-        EXTRA_TAG_BITS;
-  data = XML->sys.machine_bits;
-  interface_ip.is_cache = true;
-  interface_ip.line_sz = int(ceil(data / 32.0)) * 4;
-  interface_ip.specific_tag = 1;
-  interface_ip.tag_w = tag;
-  interface_ip.cache_sz = XML->sys.core[ithCore].store_buffer_size *
-                          interface_ip.line_sz *
-                          XML->sys.core[ithCore].number_hardware_threads;
-  interface_ip.assoc = 0;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 1;
-  interface_ip.throughput = 1.0 / clockRate;
-  interface_ip.latency = 1.0 / clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports = 0;
-  interface_ip.num_rd_ports = XML->sys.core[ithCore].memory_ports;
-  interface_ip.num_wr_ports = XML->sys.core[ithCore].memory_ports;
-  interface_ip.num_se_rd_ports = 0;
-  interface_ip.num_search_ports = XML->sys.core[ithCore].memory_ports;
-  LSQ = new ArrayST(&interface_ip, "Load(Store)Queue", Core_device,
-                    coredynp.opt_local, coredynp.core_ty);
-  LSQ->area.set_area(LSQ->area.get_area() + LSQ->local_result.area);
-  area.set_area(area.get_area() + LSQ->local_result.area);
-  area.set_area(area.get_area() * cdb_overhead);
-  // output_data_csv(LSQ.LSQ.local_result);
-  lsq_height =
-      LSQ->local_result.cache_ht *
-      sqrt(cdb_overhead); /*XML->sys.core[ithCore].number_hardware_threads*/
+	  //prefetch buffer
+	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries to decide wthether to merge.
+	  data							   = tcache.caches->l_ip.line_sz;//separate queue to prevent from cache polution.
+	  interface_ip.specific_tag        = 1;
+	  interface_ip.tag_w               = tag;
+	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
+	  interface_ip.cache_sz            = XML->sys.core[ithCore].tcache.buffer_sizes[2]*interface_ip.line_sz;
+	  interface_ip.assoc               = 0;
+	  interface_ip.nbanks              = 1;
+	  interface_ip.out_w               = interface_ip.line_sz*8;
+	  interface_ip.access_mode         = 2;
+	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[4]/clockRate;
+	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[5]/clockRate;
+	  interface_ip.obj_func_dyn_energy = 0;
+	  interface_ip.obj_func_dyn_power  = 0;
+	  interface_ip.obj_func_leak_power = 0;
+	  interface_ip.obj_func_cycle_t    = 1;
+	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
+	  interface_ip.num_rd_ports    = 0;
+	  interface_ip.num_wr_ports    = 0;
+	  interface_ip.num_se_rd_ports = 0;
+	  tcache.prefetchb = new ArrayST(&interface_ip, "tcacheprefetchBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
+	  tcache.area.set_area(tcache.area.get_area()+ tcache.prefetchb->local_result.area);
+	  area.set_area(area.get_area()+ tcache.prefetchb->local_result.area);
+	  //output_data_csv(tcache.prefetchb.local_result);
 
-  if ((coredynp.core_ty == OOO) &&
-      (XML->sys.core[ithCore].load_buffer_size > 0)) {
-    interface_ip.line_sz = int(ceil(data / 32.0)) * 4;
-    interface_ip.specific_tag = 1;
-    interface_ip.tag_w = tag;
-    interface_ip.cache_sz = XML->sys.core[ithCore].load_buffer_size *
-                            interface_ip.line_sz *
-                            XML->sys.core[ithCore].number_hardware_threads;
-    interface_ip.assoc = 0;
-    interface_ip.nbanks = 1;
-    interface_ip.out_w = interface_ip.line_sz * 8;
-    interface_ip.access_mode = 1;
-    interface_ip.throughput = 1.0 / clockRate;
-    interface_ip.latency = 1.0 / clockRate;
-    interface_ip.obj_func_dyn_energy = 0;
-    interface_ip.obj_func_dyn_power = 0;
-    interface_ip.obj_func_leak_power = 0;
-    interface_ip.obj_func_cycle_t = 1;
-    interface_ip.num_rw_ports = 0;
-    interface_ip.num_rd_ports = XML->sys.core[ithCore].memory_ports;
-    interface_ip.num_wr_ports = XML->sys.core[ithCore].memory_ports;
-    interface_ip.num_se_rd_ports = 0;
-    interface_ip.num_search_ports = XML->sys.core[ithCore].memory_ports;
-    LoadQ = new ArrayST(&interface_ip, "LoadQueue", Core_device,
-                        coredynp.opt_local, coredynp.core_ty);
-    LoadQ->area.set_area(LoadQ->area.get_area() + LoadQ->local_result.area);
-    area.set_area(area.get_area() + LoadQ->local_result.area);
-    area.set_area(area.get_area() * cdb_overhead);
-    // output_data_csv(LoadQ.LoadQ.local_result);
-    lsq_height =
-        (LSQ->local_result.cache_ht + LoadQ->local_result.cache_ht) *
-        sqrt(cdb_overhead); /*XML->sys.core[ithCore].number_hardware_threads*/
-  }
+	  //WBB
+	  if (cache_p==Write_back)
+	  {
+		  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+		  data							   = tcache.caches->l_ip.line_sz;
+		  interface_ip.specific_tag        = 1;
+		  interface_ip.tag_w               = tag;
+		  interface_ip.line_sz             = data;
+		  interface_ip.cache_sz            = XML->sys.core[ithCore].tcache.buffer_sizes[3]*interface_ip.line_sz;
+		  interface_ip.assoc               = 0;
+		  interface_ip.nbanks              = 1;
+		  interface_ip.out_w               = interface_ip.line_sz*8;
+		  interface_ip.access_mode         = 2;
+		  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[4]/clockRate;
+		  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[5]/clockRate;
+		  interface_ip.obj_func_dyn_energy = 0;
+		  interface_ip.obj_func_dyn_power  = 0;
+		  interface_ip.obj_func_leak_power = 0;
+		  interface_ip.obj_func_cycle_t    = 1;
+		  interface_ip.num_rw_ports    = XML->sys.core[ithCore].memory_ports;
+		  interface_ip.num_rd_ports    = 0;
+		  interface_ip.num_wr_ports    = 0;
+		  interface_ip.num_se_rd_ports = 0;
+		  tcache.wbb = new ArrayST(&interface_ip, "tcacheWBB", Core_device, coredynp.opt_local, coredynp.core_ty);
+		  tcache.area.set_area(tcache.area.get_area()+ tcache.wbb->local_result.area);
+		  area.set_area(area.get_area()+ tcache.wbb->local_result.area);
+		  //output_data_csv(tcache.wbb.local_result);
+	  }
+
+
+
+
+   /*
+    * dcache starts here
+    */   
+    //Dcache
+	  size                             = (int)XML->sys.core[ithCore].dcache.dcache_config[0];
+	  line                             = (int)XML->sys.core[ithCore].dcache.dcache_config[1];
+	  assoc                            = (int)XML->sys.core[ithCore].dcache.dcache_config[2];
+	  idx    					 	   = debug?9:int(ceil(log2(size/line/assoc)));
+	  tag							   = debug?51:XML->sys.physical_address_width-idx-int(ceil(log2(line))) + EXTRA_TAG_BITS;
+	  interface_ip.specific_tag        = 1;
+	  interface_ip.tag_w               = tag;
+	  interface_ip.cache_sz            = debug?32768:(int)XML->sys.core[ithCore].dcache.dcache_config[0];
+	  interface_ip.line_sz             = debug?64:(int)XML->sys.core[ithCore].dcache.dcache_config[1];
+	  interface_ip.assoc               = debug?8:(int)XML->sys.core[ithCore].dcache.dcache_config[2];
+	  interface_ip.nbanks              = debug?1:(int)XML->sys.core[ithCore].dcache.dcache_config[3];
+	  interface_ip.out_w               = interface_ip.line_sz*8;
+	  interface_ip.access_mode         = 0;//debug?0:XML->sys.core[ithCore].dcache.dcache_config[5];
+	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[4]/clockRate;
+	  interface_ip.latency             = debug?3.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[5]/clockRate;
+	  interface_ip.is_cache			 = true;
+	  interface_ip.obj_func_dyn_energy = 0;
+	  interface_ip.obj_func_dyn_power  = 0;
+	  interface_ip.obj_func_leak_power = 0;
+	  interface_ip.obj_func_cycle_t    = 1;
+	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;//usually In-order has 1 and OOO has 2 at least.
+	  interface_ip.num_rd_ports    = 0;
+	  interface_ip.num_wr_ports    = 0;
+	  interface_ip.num_se_rd_ports = 0;
+	  dcache.caches = new ArrayST(&interface_ip, "dcache", Core_device, coredynp.opt_local, coredynp.core_ty);
+	  dcache.area.set_area(dcache.area.get_area()+ dcache.caches->local_result.area);
+	  area.set_area(area.get_area()+ dcache.caches->local_result.area);
+	  //output_data_csv(dcache.caches.local_result);
+
+
+	  //dCache controllers
+	  //miss buffer
+	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+	  data							   = (XML->sys.physical_address_width) + int(ceil(log2(size/line))) + dcache.caches->l_ip.line_sz*8;
+	  interface_ip.specific_tag        = 1;
+	  interface_ip.tag_w               = tag;
+	  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+	  interface_ip.cache_sz            = XML->sys.core[ithCore].dcache.buffer_sizes[0]*interface_ip.line_sz;
+	  interface_ip.assoc               = 0;
+	  interface_ip.nbanks              = 1;
+	  interface_ip.out_w               = interface_ip.line_sz*8;
+	  interface_ip.access_mode         = 2;
+	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[4]/clockRate;
+	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[5]/clockRate;
+	  interface_ip.obj_func_dyn_energy = 0;
+	  interface_ip.obj_func_dyn_power  = 0;
+	  interface_ip.obj_func_leak_power = 0;
+	  interface_ip.obj_func_cycle_t    = 1;
+	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
+	  interface_ip.num_rd_ports    = 0;
+	  interface_ip.num_wr_ports    = 0;
+	  interface_ip.num_se_rd_ports = 0;
+	  dcache.missb = new ArrayST(&interface_ip, "dcacheMissBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
+	  dcache.area.set_area(dcache.area.get_area()+ dcache.missb->local_result.area);
+	  area.set_area(area.get_area()+ dcache.missb->local_result.area);
+	  //output_data_csv(dcache.missb.local_result);
+
+	  //fill buffer
+	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+	  data							   = dcache.caches->l_ip.line_sz;
+	  interface_ip.specific_tag        = 1;
+	  interface_ip.tag_w               = tag;
+	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
+	  interface_ip.cache_sz            = data*XML->sys.core[ithCore].dcache.buffer_sizes[1];
+	  interface_ip.assoc               = 0;
+	  interface_ip.nbanks              = 1;
+	  interface_ip.out_w               = interface_ip.line_sz*8;
+	  interface_ip.access_mode         = 2;
+	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[4]/clockRate;
+	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[5]/clockRate;
+	  interface_ip.obj_func_dyn_energy = 0;
+	  interface_ip.obj_func_dyn_power  = 0;
+	  interface_ip.obj_func_leak_power = 0;
+	  interface_ip.obj_func_cycle_t    = 1;
+	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
+	  interface_ip.num_rd_ports    = 0;
+	  interface_ip.num_wr_ports    = 0;
+	  interface_ip.num_se_rd_ports = 0;
+	  dcache.ifb = new ArrayST(&interface_ip, "dcacheFillBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
+	  dcache.area.set_area(dcache.area.get_area()+ dcache.ifb->local_result.area);
+	  area.set_area(area.get_area()+ dcache.ifb->local_result.area);
+	  //output_data_csv(dcache.ifb.local_result);
+
+	  //prefetch buffer
+	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries to decide wthether to merge.
+	  data							   = dcache.caches->l_ip.line_sz;//separate queue to prevent from cache polution.
+	  interface_ip.specific_tag        = 1;
+	  interface_ip.tag_w               = tag;
+	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
+	  interface_ip.cache_sz            = XML->sys.core[ithCore].dcache.buffer_sizes[2]*interface_ip.line_sz;
+	  interface_ip.assoc               = 0;
+	  interface_ip.nbanks              = 1;
+	  interface_ip.out_w               = interface_ip.line_sz*8;
+	  interface_ip.access_mode         = 2;
+	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[4]/clockRate;
+	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[5]/clockRate;
+	  interface_ip.obj_func_dyn_energy = 0;
+	  interface_ip.obj_func_dyn_power  = 0;
+	  interface_ip.obj_func_leak_power = 0;
+	  interface_ip.obj_func_cycle_t    = 1;
+	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
+	  interface_ip.num_rd_ports    = 0;
+	  interface_ip.num_wr_ports    = 0;
+	  interface_ip.num_se_rd_ports = 0;
+	  dcache.prefetchb = new ArrayST(&interface_ip, "dcacheprefetchBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
+	  dcache.area.set_area(dcache.area.get_area()+ dcache.prefetchb->local_result.area);
+	  area.set_area(area.get_area()+ dcache.prefetchb->local_result.area);
+	  //output_data_csv(dcache.prefetchb.local_result);
+
+	  //WBB
+	  if (cache_p==Write_back)
+	  {
+		  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+		  data							   = dcache.caches->l_ip.line_sz;
+		  interface_ip.specific_tag        = 1;
+		  interface_ip.tag_w               = tag;
+		  interface_ip.line_sz             = data;
+		  interface_ip.cache_sz            = XML->sys.core[ithCore].dcache.buffer_sizes[3]*interface_ip.line_sz;
+		  interface_ip.assoc               = 0;
+		  interface_ip.nbanks              = 1;
+		  interface_ip.out_w               = interface_ip.line_sz*8;
+		  interface_ip.access_mode         = 2;
+		  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[4]/clockRate;
+		  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[5]/clockRate;
+		  interface_ip.obj_func_dyn_energy = 0;
+		  interface_ip.obj_func_dyn_power  = 0;
+		  interface_ip.obj_func_leak_power = 0;
+		  interface_ip.obj_func_cycle_t    = 1;
+		  interface_ip.num_rw_ports    = XML->sys.core[ithCore].memory_ports;
+		  interface_ip.num_rd_ports    = 0;
+		  interface_ip.num_wr_ports    = 0;
+		  interface_ip.num_se_rd_ports = 0;
+		  dcache.wbb = new ArrayST(&interface_ip, "dcacheWBB", Core_device, coredynp.opt_local, coredynp.core_ty);
+		  dcache.area.set_area(dcache.area.get_area()+ dcache.wbb->local_result.area);
+		  area.set_area(area.get_area()+ dcache.wbb->local_result.area);
+		  //output_data_csv(dcache.wbb.local_result);
+	  }
+
+	  /*
+	   * LSU--in-order processors do not have separate load queue: unified lsq
+	   * partitioned among threads
+	   * it is actually the store queue but for inorder processors it serves as both loadQ and StoreQ
+	   */
+	  tag							   = ldst_opcode+XML->sys.virtual_address_width +int(ceil(log2(XML->sys.core[ithCore].number_hardware_threads))) + EXTRA_TAG_BITS;
+	  data							   = XML->sys.machine_bits;
+	  interface_ip.is_cache			   = true;
+	  interface_ip.line_sz             = int(ceil(data/32.0))*4;
+	  interface_ip.specific_tag        = 1;
+	  interface_ip.tag_w               = tag;
+	  interface_ip.cache_sz            = XML->sys.core[ithCore].store_buffer_size*interface_ip.line_sz*XML->sys.core[ithCore].number_hardware_threads;
+	  interface_ip.assoc               = 0;
+	  interface_ip.nbanks              = 1;
+	  interface_ip.out_w               = interface_ip.line_sz*8;
+	  interface_ip.access_mode         = 1;
+	  interface_ip.throughput          = 1.0/clockRate;
+	  interface_ip.latency             = 1.0/clockRate;
+	  interface_ip.obj_func_dyn_energy = 0;
+	  interface_ip.obj_func_dyn_power  = 0;
+	  interface_ip.obj_func_leak_power = 0;
+	  interface_ip.obj_func_cycle_t    = 1;
+	  interface_ip.num_rw_ports        = 0;
+	  interface_ip.num_rd_ports        = XML->sys.core[ithCore].memory_ports;
+	  interface_ip.num_wr_ports        = XML->sys.core[ithCore].memory_ports;
+	  interface_ip.num_se_rd_ports     = 0;
+	  interface_ip.num_search_ports    =XML->sys.core[ithCore].memory_ports;
+	  LSQ = new ArrayST(&interface_ip, "Load(Store)Queue", Core_device, coredynp.opt_local, coredynp.core_ty);
+	  LSQ->area.set_area(LSQ->area.get_area()+ LSQ->local_result.area);
+	  area.set_area(area.get_area()+ LSQ->local_result.area);
+	  area.set_area(area.get_area()*cdb_overhead);
+	  //output_data_csv(LSQ.LSQ.local_result);
+	  lsq_height=LSQ->local_result.cache_ht*sqrt(cdb_overhead);/*XML->sys.core[ithCore].number_hardware_threads*/
+
+	  if ((coredynp.core_ty==OOO) && (XML->sys.core[ithCore].load_buffer_size >0))
+	  {
+		  interface_ip.line_sz             = int(ceil(data/32.0))*4;
+		  interface_ip.specific_tag        = 1;
+		  interface_ip.tag_w               = tag;
+		  interface_ip.cache_sz            = XML->sys.core[ithCore].load_buffer_size*interface_ip.line_sz*XML->sys.core[ithCore].number_hardware_threads;
+		  interface_ip.assoc               = 0;
+		  interface_ip.nbanks              = 1;
+		  interface_ip.out_w               = interface_ip.line_sz*8;
+		  interface_ip.access_mode         = 1;
+		  interface_ip.throughput          = 1.0/clockRate;
+		  interface_ip.latency             = 1.0/clockRate;
+		  interface_ip.obj_func_dyn_energy = 0;
+		  interface_ip.obj_func_dyn_power  = 0;
+		  interface_ip.obj_func_leak_power = 0;
+		  interface_ip.obj_func_cycle_t    = 1;
+		  interface_ip.num_rw_ports        = 0;
+		  interface_ip.num_rd_ports        = XML->sys.core[ithCore].memory_ports;
+		  interface_ip.num_wr_ports        = XML->sys.core[ithCore].memory_ports;
+		  interface_ip.num_se_rd_ports     = 0;
+		  interface_ip.num_search_ports    =XML->sys.core[ithCore].memory_ports;
+		  LoadQ = new ArrayST(&interface_ip, "LoadQueue", Core_device, coredynp.opt_local, coredynp.core_ty);
+		  LoadQ->area.set_area(LoadQ->area.get_area()+ LoadQ->local_result.area);
+		  area.set_area(area.get_area()+ LoadQ->local_result.area);
+		  area.set_area(area.get_area()*cdb_overhead);
+		  //output_data_csv(LoadQ.LoadQ.local_result);
+		  lsq_height=(LSQ->local_result.cache_ht + LoadQ->local_result.cache_ht)*sqrt(cdb_overhead);/*XML->sys.core[ithCore].number_hardware_threads*/
+	  }
+
 }
 
-MemManU::MemManU(ParseXML* XML_interface, int ithCore_,
-                 InputParameter* interface_ip_, const CoreDynParam& dyn_p_,
-                 bool exist_)
-    : XML(XML_interface),
-      ithCore(ithCore_),
-      interface_ip(*interface_ip_),
-      coredynp(dyn_p_),
-      itlb(0),
-      dtlb(0),
-      exist(exist_) {
-  if (!exist) return;
-  int tag, data;
-  bool debug = false;
+MemManU::MemManU(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_,bool exist_)
+:XML(XML_interface),
+ ithCore(ithCore_),
+ interface_ip(*interface_ip_),
+ coredynp(dyn_p_),
+ itlb(0),
+ dtlb(0),
+ exist(exist_)
+{
+	  if (!exist) return;
+	  int  tag, data;
+	  bool debug= false;
 
-  clockRate = coredynp.clockRate;
-  executionTime = coredynp.executionTime;
+	  clockRate = coredynp.clockRate;
+	  executionTime = coredynp.executionTime;
 
-  interface_ip.is_cache = true;
-  interface_ip.pure_cam = false;
-  interface_ip.pure_ram = false;
-  interface_ip.specific_tag = 1;
-  // Itlb TLBs are partioned among threads according to Nigara and Nehalem
-  tag = XML->sys.virtual_address_width -
-        int(floor(log2(XML->sys.virtual_memory_page_size))) +
-        int(ceil(log2(XML->sys.core[ithCore].number_hardware_threads))) +
-        EXTRA_TAG_BITS;
-  data = XML->sys.physical_address_width -
-         int(floor(log2(XML->sys.virtual_memory_page_size)));
-  interface_ip.tag_w = tag;
-  interface_ip.line_sz =
-      int(ceil(data / 8.0));  // int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-  interface_ip.cache_sz =
-      XML->sys.core[ithCore].itlb.number_entries *
-      interface_ip.line_sz;  //*XML->sys.core[ithCore].number_hardware_threads;
-  interface_ip.assoc = 0;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 0;
-  interface_ip.throughput =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].icache.icache_config[4] / clockRate;
-  interface_ip.latency =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].icache.icache_config[5] / clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports = 0;
-  interface_ip.num_rd_ports = 0;
-  interface_ip.num_wr_ports =
-      debug ? 1 : XML->sys.core[ithCore].number_instruction_fetch_ports;
-  interface_ip.num_se_rd_ports = 0;
-  interface_ip.num_search_ports =
-      debug ? 1 : XML->sys.core[ithCore].number_instruction_fetch_ports;
-  itlb = new ArrayST(&interface_ip, "ITLB", Core_device, coredynp.opt_local,
-                     coredynp.core_ty);
-  itlb->area.set_area(itlb->area.get_area() + itlb->local_result.area);
-  area.set_area(area.get_area() + itlb->local_result.area);
-  // output_data_csv(itlb.tlb.local_result);
+	  interface_ip.is_cache			   = true;
+	  interface_ip.pure_cam            = false;
+	  interface_ip.pure_ram            = false;
+	  interface_ip.specific_tag        = 1;
+	  //Itlb TLBs are partioned among threads according to Nigara and Nehalem
+	  tag							   = XML->sys.virtual_address_width- int(floor(log2(XML->sys.virtual_memory_page_size))) + int(ceil(log2(XML->sys.core[ithCore].number_hardware_threads)))+ EXTRA_TAG_BITS;
+	  data							   = XML->sys.physical_address_width- int(floor(log2(XML->sys.virtual_memory_page_size)));
+	  interface_ip.tag_w               = tag;
+	  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+	  interface_ip.cache_sz            = XML->sys.core[ithCore].itlb.number_entries*interface_ip.line_sz;//*XML->sys.core[ithCore].number_hardware_threads;
+	  interface_ip.assoc               = 0;
+	  interface_ip.nbanks              = 1;
+	  interface_ip.out_w               = interface_ip.line_sz*8;
+	  interface_ip.access_mode         = 0;
+	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].icache.icache_config[4]/clockRate;
+	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].icache.icache_config[5]/clockRate;
+	  interface_ip.obj_func_dyn_energy = 0;
+	  interface_ip.obj_func_dyn_power  = 0;
+	  interface_ip.obj_func_leak_power = 0;
+	  interface_ip.obj_func_cycle_t    = 1;
+	  interface_ip.num_rw_ports    = 0;
+	  interface_ip.num_rd_ports    = 0;
+	  interface_ip.num_wr_ports    = debug?1:XML->sys.core[ithCore].number_instruction_fetch_ports;
+	  interface_ip.num_se_rd_ports = 0;
+	  interface_ip.num_search_ports    = debug?1:XML->sys.core[ithCore].number_instruction_fetch_ports;
+	  itlb = new ArrayST(&interface_ip, "ITLB", Core_device, coredynp.opt_local, coredynp.core_ty);
+	  itlb->area.set_area(itlb->area.get_area()+ itlb->local_result.area);
+	  area.set_area(area.get_area()+ itlb->local_result.area);
+	  //output_data_csv(itlb.tlb.local_result);
 
-  // dtlb
-  tag = XML->sys.virtual_address_width -
-        int(floor(log2(XML->sys.virtual_memory_page_size))) +
-        int(ceil(log2(XML->sys.core[ithCore].number_hardware_threads))) +
-        EXTRA_TAG_BITS;
-  data = XML->sys.physical_address_width -
-         int(floor(log2(XML->sys.virtual_memory_page_size)));
-  interface_ip.specific_tag = 1;
-  interface_ip.tag_w = tag;
-  interface_ip.line_sz =
-      int(ceil(data / 8.0));  // int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-  interface_ip.cache_sz =
-      XML->sys.core[ithCore].dtlb.number_entries *
-      interface_ip.line_sz;  //*XML->sys.core[ithCore].number_hardware_threads;
-  interface_ip.assoc = 0;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 0;
-  interface_ip.throughput =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].dcache.dcache_config[4] / clockRate;
-  interface_ip.latency =
-      debug ? 1.0 / clockRate
-            : XML->sys.core[ithCore].dcache.dcache_config[5] / clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports = 0;
-  interface_ip.num_rd_ports = 0;
-  interface_ip.num_wr_ports = XML->sys.core[ithCore].memory_ports;
-  interface_ip.num_se_rd_ports = 0;
-  interface_ip.num_search_ports = XML->sys.core[ithCore].memory_ports;
-  dtlb = new ArrayST(&interface_ip, "DTLB", Core_device, coredynp.opt_local,
-                     coredynp.core_ty);
-  dtlb->area.set_area(dtlb->area.get_area() + dtlb->local_result.area);
-  area.set_area(area.get_area() + dtlb->local_result.area);
-  // output_data_csv(dtlb.tlb.local_result);
+	  //dtlb
+	  tag							   = XML->sys.virtual_address_width- int(floor(log2(XML->sys.virtual_memory_page_size))) +int(ceil(log2(XML->sys.core[ithCore].number_hardware_threads)))+ EXTRA_TAG_BITS;
+	  data							   = XML->sys.physical_address_width- int(floor(log2(XML->sys.virtual_memory_page_size)));
+	  interface_ip.specific_tag        = 1;
+	  interface_ip.tag_w               = tag;
+	  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+	  interface_ip.cache_sz            = XML->sys.core[ithCore].dtlb.number_entries*interface_ip.line_sz;//*XML->sys.core[ithCore].number_hardware_threads;
+	  interface_ip.assoc               = 0;
+	  interface_ip.nbanks              = 1;
+	  interface_ip.out_w               = interface_ip.line_sz*8;
+	  interface_ip.access_mode         = 0;
+	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[4]/clockRate;
+	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[5]/clockRate;
+	  interface_ip.obj_func_dyn_energy = 0;
+	  interface_ip.obj_func_dyn_power  = 0;
+	  interface_ip.obj_func_leak_power = 0;
+	  interface_ip.obj_func_cycle_t    = 1;
+	  interface_ip.num_rw_ports    = 0;
+	  interface_ip.num_rd_ports    = 0;
+	  interface_ip.num_wr_ports    = XML->sys.core[ithCore].memory_ports;
+	  interface_ip.num_se_rd_ports = 0;
+	  interface_ip.num_search_ports = XML->sys.core[ithCore].memory_ports;
+	  dtlb = new ArrayST(&interface_ip, "DTLB", Core_device, coredynp.opt_local, coredynp.core_ty);
+	  dtlb->area.set_area(dtlb->area.get_area()+ dtlb->local_result.area);
+	  area.set_area(area.get_area()+ dtlb->local_result.area);
+	  //output_data_csv(dtlb.tlb.local_result);
+
 }
 //#define FERMI
 
-RegFU::RegFU(ParseXML* XML_interface, int ithCore_,
-             InputParameter* interface_ip_, const CoreDynParam& dyn_p_,
-             double exClockRate, bool exist_)
-    : XML(XML_interface),
-      ithCore(ithCore_),
-      interface_ip(*interface_ip_),
-      coredynp(dyn_p_),
-      IRF(0),
-      FRF(0),
-      RFWIN(0),
-      exist(exist_) {
-  /*
-   * processors have separate architectural register files for each thread.
-   * therefore, the bypass buses need to travel across all the register files.
-   */
-  if (!exist) return;
-  int data;
-  clockRate = exClockRate;  // coredynp.clockRate;
-  executionTime = coredynp.executionTime;
+RegFU::RegFU(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_,double exClockRate,bool exist_)
+:XML(XML_interface),
+ ithCore(ithCore_),
+ interface_ip(*interface_ip_),
+ coredynp(dyn_p_),
+ IRF (0),
+ FRF (0),
+ RFWIN (0),
+ exist(exist_)
+ {
+	/*
+	 * processors have separate architectural register files for each thread.
+	 * therefore, the bypass buses need to travel across all the register files.
+	 */
+	if (!exist) return;
+	int  data;
+	clockRate = exClockRate;//coredynp.clockRate;
+	executionTime = coredynp.executionTime;
   /*********************************************************************************
-        * OC stage modelling (Syed Gilani)
-        *********************************************************************************/
+	* OC stage modelling (Syed Gilani)
+	*********************************************************************************/
+  
+  //Crossbar
+ 
+	if(XML->sys.architecture==1){
+  xbar_rfu     = new Crossbar(XML->sys.core[ithCore].rf_banks/2,XML->sys.core[ithCore].collector_units/2
+		                 ,(128),&(g_tp.peri_global));
+	}else{
+  xbar_rfu     = new Crossbar(XML->sys.core[ithCore].rf_banks,XML->sys.core[ithCore].collector_units
+		                 ,(128),&(g_tp.peri_global));
+	}
 
-  // Crossbar
+  //new Crossbar(simd_width,shared_memory_banks,word_length*simd_width,&(g_tp.peri_global));
 
-  if (XML->sys.architecture == 1) {
-    xbar_rfu = new Crossbar(XML->sys.core[ithCore].rf_banks / 2,
-                            XML->sys.core[ithCore].collector_units / 2, (128),
-                            &(g_tp.peri_global));
-  } else {
-    xbar_rfu = new Crossbar(XML->sys.core[ithCore].rf_banks,
-                            XML->sys.core[ithCore].collector_units, (128),
-                            &(g_tp.peri_global));
-  }
+  //Arbiter
+  arbiter_rfu = new MCPAT_Arbiter(XML->sys.core[ithCore].rf_banks,XML->sys.core[ithCore].collector_units , 1,&(g_tp.peri_global));
 
-  // new
-  // Crossbar(simd_width,shared_memory_banks,word_length*simd_width,&(g_tp.peri_global));
 
-  // Arbiter
-  arbiter_rfu = new MCPAT_Arbiter(XML->sys.core[ithCore].rf_banks,
-                                  XML->sys.core[ithCore].collector_units, 1,
-                                  &(g_tp.peri_global));
 
-  // RF banks modelled here for GPGPU-Sim (Syed Gilani)
-  //
-  //**********************************IRF***************************************
-  data = coredynp.int_data_width;
-  // data               *= 8;
-  interface_ip.is_cache = false;
-  interface_ip.pure_cam = false;
-  interface_ip.pure_ram = true;
+	// RF banks modelled here for GPGPU-Sim (Syed Gilani)
+	//
+	//**********************************IRF***************************************
+	data							 = coredynp.int_data_width;
+  //data               *= 8;
+	interface_ip.is_cache			 = false;
+	interface_ip.pure_cam            = false;
+	interface_ip.pure_ram            = true;
 
-  interface_ip.line_sz = 16;  // int(ceil(data/32.0))*4 *
-                              // XML->sys.core[ithCore].simd_width/4 ;//2 for
-                              // Tesla as RF width half of SIMD width
+	interface_ip.line_sz             = 16;//int(ceil(data/32.0))*4 * XML->sys.core[ithCore].simd_width/4 ;//2 for Tesla as RF width half of SIMD width
 
-  interface_ip.line_sz = 16;  // int(ceil(data/32.0))*4 *
-                              // XML->sys.core[ithCore].simd_width/2 ;//2 for
-                              // Tesla as RF width half of SIMD width
+	interface_ip.line_sz             = 16;//int(ceil(data/32.0))*4 * XML->sys.core[ithCore].simd_width/2 ;//2 for Tesla as RF width half of SIMD width
 
-  interface_ip.cache_sz = coredynp.num_IRF_entry * 4;
-  interface_ip.assoc = 1;
-  interface_ip.nbanks = XML->sys.core[ithCore].rf_banks;
+	interface_ip.cache_sz            = coredynp.num_IRF_entry*4;
+	interface_ip.assoc               = 1;
+	interface_ip.nbanks              = XML->sys.core[ithCore].rf_banks;
 
-  interface_ip.out_w =
-      interface_ip.line_sz *
-      8;  // interface_ip.line_sz*XML->sys.core[ithCore].simd_width/4; //2 for
-          // Tesla and 4 for Fermi
+	interface_ip.out_w               = interface_ip.line_sz*8;//interface_ip.line_sz*XML->sys.core[ithCore].simd_width/4; //2 for Tesla and 4 for Fermi
 
-  interface_ip.out_w =
-      interface_ip.line_sz *
-      8;  // interface_ip.line_sz*XML->sys.core[ithCore].simd_width/2; //2 for
-          // Tesla and 4 for Fermi
+	interface_ip.out_w               = interface_ip.line_sz*8;//interface_ip.line_sz*XML->sys.core[ithCore].simd_width/2; //2 for Tesla and 4 for Fermi
 
-  interface_ip.access_mode = 1;
-  interface_ip.throughput = 1 / (clockRate);
-  interface_ip.latency = 8.0 / (clockRate);
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 1;
-  interface_ip.obj_func_cycle_t = 0;
-  interface_ip.num_rw_ports = 0;  // this is the transfer port for
-                                  // saving/restoring states when exceptions
-                                  // happen.
-  interface_ip.num_rd_ports = 1;  // 2*coredynp.peak_issueW;
-  interface_ip.num_wr_ports = 1;  // coredynp.peak_issueW;
-  interface_ip.num_se_rd_ports = 0;
-  IRF = new ArrayST(&interface_ip, "Integer Register File", Core_device,
-                    coredynp.opt_local, coredynp.core_ty);
 
-  IRF->area.set_area(IRF->area.get_area() +
-                     IRF->local_result.area * coredynp.num_pipelines *
-                         cdb_overhead);
+	interface_ip.access_mode         = 1;
+	interface_ip.throughput          = 1/(clockRate);
+	interface_ip.latency             = 8.0/(clockRate);
+	interface_ip.obj_func_dyn_energy = 0;
+	interface_ip.obj_func_dyn_power  = 0;
+	interface_ip.obj_func_leak_power = 1;
+	interface_ip.obj_func_cycle_t    = 0;
+	interface_ip.num_rw_ports    = 0;//this is the transfer port for saving/restoring states when exceptions happen.
+	interface_ip.num_rd_ports    = 1;//2*coredynp.peak_issueW;
+	interface_ip.num_wr_ports    = 1;//coredynp.peak_issueW;
+	interface_ip.num_se_rd_ports = 0;
+	IRF = new ArrayST(&interface_ip, "Integer Register File", Core_device, coredynp.opt_local, coredynp.core_ty);
 
-  area.set_area(area.get_area() + IRF->local_result.area +
-                xbar_rfu->area.get_area() + arbiter_rfu->area.get_area());
-  if (XML->sys.architecture == 1) {
-    IRF->local_result.power.readOp.dynamic *= .33;
-    IRF->local_result.power.writeOp.dynamic *= .33;
-  } else {
-    IRF->local_result.power.readOp.dynamic *= .55;
-    IRF->local_result.power.writeOp.dynamic *= .55;
-  }
+	IRF->area.set_area(IRF->area.get_area()+ IRF->local_result.area*coredynp.num_pipelines*cdb_overhead);
 
-  /**
-   * Operand collectors (32-bit wide, 8 entry banks )
-   */
-  data = 32;
-  // data               *= 8;
-  interface_ip.is_cache = false;
-  interface_ip.pure_cam = false;
-  interface_ip.pure_ram = true;
 
-  interface_ip.line_sz = 4;  // int(ceil(data/32.0))*4 *
-                             // XML->sys.core[ithCore].simd_width/4 ;//2 for
-                             // Tesla as RF width half of SIMD width
+	area.set_area(area.get_area()+ IRF->local_result.area
+		 + xbar_rfu->area.get_area() + arbiter_rfu->area.get_area());
+	if(XML->sys.architecture==1){
+	IRF->local_result.power.readOp.dynamic *= .33;
+	IRF->local_result.power.writeOp.dynamic *= .33;
+	}
+	else {
+	IRF->local_result.power.readOp.dynamic *= .55;
+	IRF->local_result.power.writeOp.dynamic *= .55;
+	}
 
-  interface_ip.line_sz = 4;  // int(ceil(data/32.0))*4 *
-                             // XML->sys.core[ithCore].simd_width/2 ;//2 for
-                             // Tesla as RF width half of SIMD width
 
-  interface_ip.cache_sz = 8 * 4;
-  interface_ip.assoc = 1;
-  interface_ip.nbanks = 1;
 
-  interface_ip.out_w =
-      interface_ip
-          .line_sz;  // interface_ip.line_sz*XML->sys.core[ithCore].simd_width/4;
-                     // //2 for Tesla and 4 for Fermi
 
-  interface_ip.out_w =
-      interface_ip
-          .line_sz;  // interface_ip.line_sz*XML->sys.core[ithCore].simd_width/2;
-                     // //2 for Tesla and 4 for Fermi
+	/**
+	 * Operand collectors (32-bit wide, 8 entry banks )
+	 */
+	data							 = 32;
+  //data               *= 8;
+	interface_ip.is_cache			 = false;
+	interface_ip.pure_cam            = false;
+	interface_ip.pure_ram            = true;
 
-  interface_ip.access_mode = 1;
-  interface_ip.throughput = 1.0 / (clockRate);
-  interface_ip.latency = 1.0 / (clockRate);
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 1;
-  interface_ip.obj_func_cycle_t = 0;
-  interface_ip.num_rw_ports = 0;  // this is the transfer port for
-                                  // saving/restoring states when exceptions
-                                  // happen.
-  interface_ip.num_rd_ports = 1;  // 2*coredynp.peak_issueW;
-  interface_ip.num_wr_ports = 1;  // coredynp.peak_issueW;
-  interface_ip.num_se_rd_ports = 0;
-  OPC = new ArrayST(&interface_ip, "Operand collectors", Core_device,
-                    coredynp.opt_local, coredynp.core_ty);
+	interface_ip.line_sz             = 4;//int(ceil(data/32.0))*4 * XML->sys.core[ithCore].simd_width/4 ;//2 for Tesla as RF width half of SIMD width
 
-  OPC->area.set_area(OPC->area.get_area() +
-                     OPC->local_result.area * coredynp.num_pipelines *
-                         cdb_overhead);
+	interface_ip.line_sz             = 4;//int(ceil(data/32.0))*4 * XML->sys.core[ithCore].simd_width/2 ;//2 for Tesla as RF width half of SIMD width
 
-  area.set_area(area.get_area() + OPC->local_result.area);
+	interface_ip.cache_sz            = 8*4;
+	interface_ip.assoc               = 1;
+	interface_ip.nbanks              = 1;
 
-  /********
-   * For GPGPUSim (Syed Gilani)
-   * Do not include FRF in final results for GPU. Only model the IRF
-   ********/
+	interface_ip.out_w               = interface_ip.line_sz;//interface_ip.line_sz*XML->sys.core[ithCore].simd_width/4; //2 for Tesla and 4 for Fermi
 
-  //**********************************FRF***************************************
-  data = coredynp.fp_data_width;
-  // data               *= 8;
-  interface_ip.is_cache = false;
-  interface_ip.pure_cam = false;
-  interface_ip.pure_ram = true;
-  interface_ip.line_sz = int(ceil(data / 32.0)) * 4;
-  interface_ip.cache_sz = coredynp.num_FRF_entry * interface_ip.line_sz;
-  interface_ip.assoc = 1;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 1;
-  interface_ip.throughput = 1.0 / clockRate;
-  interface_ip.latency = 1.0 / clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports = 1;  // this is the transfer port for
-                                  // saving/restoring states when exceptions
-                                  // happen.
-  interface_ip.num_rd_ports = 2 * XML->sys.core[ithCore].issue_width;
-  // interface_ip.num_rd_ports    = 1;
-  interface_ip.num_wr_ports = XML->sys.core[ithCore].issue_width;
-  // interface_ip.num_wr_ports    = 1;
-  interface_ip.num_se_rd_ports = 0;
-  FRF = new ArrayST(&interface_ip, "Floating point Register File", Core_device,
-                    coredynp.opt_local, coredynp.core_ty);
-  // FRF->area.set_area(FRF->area.get_area()+
-  // FRF->local_result.area*XML->sys.core[ithCore].number_hardware_threads*coredynp.num_fp_pipelines*cdb_overhead);
-  // area.set_area(area.get_area()+
-  // FRF->local_result.area*XML->sys.core[ithCore].number_hardware_threads*coredynp.num_fp_pipelines*cdb_overhead);
-  // area.set_area(area.get_area()*cdb_overhead);
-  // output_data_csv(FRF.RF.local_result);
-  int_regfile_height = IRF->local_result.cache_ht *
-                       XML->sys.core[ithCore].number_hardware_threads *
-                       sqrt(cdb_overhead);
-  fp_regfile_height = 0;
-  // fp_regfile_height =
-  // FRF->local_result.cache_ht*XML->sys.core[ithCore].number_hardware_threads*sqrt(cdb_overhead);
-  // since a EXU is associated with each pipeline, the cdb should not have
-  // longer length.
-  if (coredynp.regWindowing) {
-    //*********************************REG_WIN************************************
-    data = coredynp.int_data_width;  // ECC, and usually 2 regs are transfered
-                                     // together during window shifting.Niagara
-                                     // Mega cell
-    interface_ip.is_cache = false;
-    interface_ip.pure_cam = false;
-    interface_ip.pure_ram = true;
-    interface_ip.line_sz = int(ceil(data / 8.0));
-    interface_ip.cache_sz = XML->sys.core[ithCore].register_windows_size *
-                            IRF->l_ip.cache_sz *
-                            XML->sys.core[ithCore].number_hardware_threads;
-    interface_ip.assoc = 1;
-    interface_ip.nbanks = 1;
-    interface_ip.out_w = interface_ip.line_sz * 8;
-    interface_ip.access_mode = 1;
-    interface_ip.throughput = 4.0 / clockRate;
-    interface_ip.latency = 4.0 / clockRate;
-    interface_ip.obj_func_dyn_energy = 0;
-    interface_ip.obj_func_dyn_power = 0;
-    interface_ip.obj_func_leak_power = 0;
-    interface_ip.obj_func_cycle_t = 1;
-    interface_ip.num_rw_ports = 1;  // this is the transfer port for
-                                    // saving/restoring states when exceptions
-                                    // happen.
-    interface_ip.num_rd_ports = 0;
-    interface_ip.num_wr_ports = 0;
-    interface_ip.num_se_rd_ports = 0;
-    RFWIN = new ArrayST(&interface_ip, "RegWindow", Core_device,
-                        coredynp.opt_local, coredynp.core_ty);
-    RFWIN->area.set_area(RFWIN->area.get_area() +
-                         RFWIN->local_result.area * coredynp.num_pipelines);
-    area.set_area(area.get_area() +
-                  RFWIN->local_result.area * coredynp.num_pipelines);
-    // output_data_csv(RFWIN.RF.local_result);
-  }
+	interface_ip.out_w               = interface_ip.line_sz;//interface_ip.line_sz*XML->sys.core[ithCore].simd_width/2; //2 for Tesla and 4 for Fermi
+
+
+	interface_ip.access_mode         = 1;
+	interface_ip.throughput          = 1.0/(clockRate);
+	interface_ip.latency             = 1.0/(clockRate);
+	interface_ip.obj_func_dyn_energy = 0;
+	interface_ip.obj_func_dyn_power  = 0;
+	interface_ip.obj_func_leak_power = 1;
+	interface_ip.obj_func_cycle_t    = 0;
+	interface_ip.num_rw_ports    = 0;//this is the transfer port for saving/restoring states when exceptions happen.
+	interface_ip.num_rd_ports    = 1;//2*coredynp.peak_issueW;
+	interface_ip.num_wr_ports    = 1;//coredynp.peak_issueW;
+	interface_ip.num_se_rd_ports = 0;
+	OPC = new ArrayST(&interface_ip, "Operand collectors", Core_device, coredynp.opt_local, coredynp.core_ty);
+
+	OPC->area.set_area(OPC->area.get_area()+ OPC->local_result.area*coredynp.num_pipelines*cdb_overhead);
+
+
+	area.set_area(area.get_area()+ OPC->local_result.area);
+
+
+
+
+	/********
+	 * For GPGPUSim (Syed Gilani)
+	 * Do not include FRF in final results for GPU. Only model the IRF
+	 ********/
+
+	//**********************************FRF***************************************
+	data							 = coredynp.fp_data_width;
+  //data               *= 8;
+	interface_ip.is_cache			 = false;
+	interface_ip.pure_cam            = false;
+	interface_ip.pure_ram            = true;
+	interface_ip.line_sz             = int(ceil(data/32.0))*4;
+	interface_ip.cache_sz            = coredynp.num_FRF_entry*interface_ip.line_sz;
+	interface_ip.assoc               = 1;
+	interface_ip.nbanks              = 1;
+	interface_ip.out_w               = interface_ip.line_sz*8;
+	interface_ip.access_mode         = 1;
+	interface_ip.throughput          = 1.0/clockRate;
+	interface_ip.latency             = 1.0/clockRate;
+	interface_ip.obj_func_dyn_energy = 0;
+	interface_ip.obj_func_dyn_power  = 0;
+	interface_ip.obj_func_leak_power = 0;
+	interface_ip.obj_func_cycle_t    = 1;
+	interface_ip.num_rw_ports    = 1;//this is the transfer port for saving/restoring states when exceptions happen.
+	interface_ip.num_rd_ports    = 2*XML->sys.core[ithCore].issue_width;
+	//interface_ip.num_rd_ports    = 1;
+	interface_ip.num_wr_ports    = XML->sys.core[ithCore].issue_width;
+	//interface_ip.num_wr_ports    = 1;
+	interface_ip.num_se_rd_ports = 0;
+	FRF = new ArrayST(&interface_ip, "Floating point Register File", Core_device, coredynp.opt_local, coredynp.core_ty);
+	//FRF->area.set_area(FRF->area.get_area()+ FRF->local_result.area*XML->sys.core[ithCore].number_hardware_threads*coredynp.num_fp_pipelines*cdb_overhead);
+	//area.set_area(area.get_area()+ FRF->local_result.area*XML->sys.core[ithCore].number_hardware_threads*coredynp.num_fp_pipelines*cdb_overhead);
+	//area.set_area(area.get_area()*cdb_overhead);
+	//output_data_csv(FRF.RF.local_result);
+	int_regfile_height= IRF->local_result.cache_ht*XML->sys.core[ithCore].number_hardware_threads*sqrt(cdb_overhead);
+	fp_regfile_height=0;
+	//fp_regfile_height = FRF->local_result.cache_ht*XML->sys.core[ithCore].number_hardware_threads*sqrt(cdb_overhead);
+    //since a EXU is associated with each pipeline, the cdb should not have longer length.
+	if (coredynp.regWindowing)
+	{
+		//*********************************REG_WIN************************************
+		data							 = coredynp.int_data_width; //ECC, and usually 2 regs are transfered together during window shifting.Niagara Mega cell
+		interface_ip.is_cache			 = false;
+		interface_ip.pure_cam            = false;
+		interface_ip.pure_ram            = true;
+		interface_ip.line_sz             = int(ceil(data/8.0));
+		interface_ip.cache_sz            = XML->sys.core[ithCore].register_windows_size*IRF->l_ip.cache_sz*XML->sys.core[ithCore].number_hardware_threads;
+		interface_ip.assoc               = 1;
+		interface_ip.nbanks              = 1;
+		interface_ip.out_w               = interface_ip.line_sz*8;
+		interface_ip.access_mode         = 1;
+		interface_ip.throughput          = 4.0/clockRate;
+		interface_ip.latency             = 4.0/clockRate;
+		interface_ip.obj_func_dyn_energy = 0;
+		interface_ip.obj_func_dyn_power  = 0;
+		interface_ip.obj_func_leak_power = 0;
+		interface_ip.obj_func_cycle_t    = 1;
+		interface_ip.num_rw_ports    = 1;//this is the transfer port for saving/restoring states when exceptions happen.
+		interface_ip.num_rd_ports    = 0;
+		interface_ip.num_wr_ports    = 0;
+		interface_ip.num_se_rd_ports = 0;
+		RFWIN = new ArrayST(&interface_ip, "RegWindow", Core_device, coredynp.opt_local, coredynp.core_ty);
+		RFWIN->area.set_area(RFWIN->area.get_area()+ RFWIN->local_result.area*coredynp.num_pipelines);
+		area.set_area(area.get_area()+ RFWIN->local_result.area*coredynp.num_pipelines);
+		//output_data_csv(RFWIN.RF.local_result);
+	}
+
+
+ }
+
+EXECU::EXECU(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, double lsq_height_, const CoreDynParam & dyn_p_,  double exClockRate, bool exist_)
+:XML(XML_interface),
+ ithCore(ithCore_),
+ interface_ip(*interface_ip_),
+ lsq_height(lsq_height_),
+ coredynp(dyn_p_),
+ rfu(0),
+ scheu(0),
+ fp_u(0),
+ exeu(0),
+ mul(0),
+ int_bypass(0),
+ intTagBypass(0),
+ int_mul_bypass(0),
+ intTag_mul_Bypass(0),
+ fp_bypass(0),
+ fpTagBypass(0),
+ exist(exist_),
+ rf_fu_clockRate(exClockRate)
+{
+	  if (!exist) return;
+	  double fu_height = 0.0;
+      clockRate = coredynp.clockRate;
+		//cout <<"EXECU exClockRate: "<<exClockRate<<endl;
+      executionTime = coredynp.executionTime;
+	  rfu   = new RegFU(XML, ithCore, &interface_ip,coredynp,exClockRate);
+	  scheu = new SchedulerU(XML, ithCore, &interface_ip,coredynp);
+	  exeu  = new FunctionalUnit(XML, ithCore,&interface_ip, coredynp, ALU,exClockRate);
+	  area.set_area(area.get_area()+ exeu->area.get_area() + rfu->area.get_area() +scheu->area.get_area() );
+	  fu_height = exeu->FU_height;
+	  if (coredynp.num_fpus >0)
+	  {
+		  fp_u  = new FunctionalUnit(XML, ithCore,&interface_ip, coredynp, FPU, exClockRate);
+		  area.set_area(area.get_area()+ fp_u->area.get_area());
+	  }
+	  if (coredynp.num_muls >0)
+	  {
+		  mul   = new FunctionalUnit(XML, ithCore,&interface_ip, coredynp, MUL, exClockRate);
+		  area.set_area(area.get_area()+ mul->area.get_area());
+		  fu_height +=  mul->FU_height;
+	  }
+	  /*
+	   * broadcast logic, including int-broadcast; int_tag-broadcast; fp-broadcast; fp_tag-broadcast
+	   * integer by pass has two paths and fp has 3 paths.
+	   * on the same bus there are multiple tri-state drivers and muxes that go to different components on the same bus
+	   */
+	  if (XML->sys.Embedded)
+	  		{
+	  		interface_ip.wt                  =Global_30;
+	  		interface_ip.wire_is_mat_type = 0;
+	  		interface_ip.wire_os_mat_type = 0;
+	  	    interface_ip.throughput       = 1.0/clockRate;
+	  	    interface_ip.latency          = 1.0/clockRate;
+	  		}
+	  	else
+	  		{
+	  		interface_ip.wt                  =Global;
+	  		interface_ip.wire_is_mat_type = 2;//start from semi-global since local wires are already used
+	  		interface_ip.wire_os_mat_type = 2;
+	  	    interface_ip.throughput       = 10.0/clockRate; //Do not care
+	  	    interface_ip.latency          = 10.0/clockRate;
+	  		}
+
+	  if (coredynp.core_ty==Inorder)
+	  {//
+		  int_bypass   = new interconnect("Int Bypass Data", Core_device, 1, 1, int(ceil(XML->sys.machine_bits/32.0)*32),
+				  rfu->int_regfile_height + exeu->FU_height + lsq_height, &interface_ip, 3,
+				  false, 1.0, coredynp.opt_local, coredynp.core_ty);
+		  bypass.area.set_area(bypass.area.get_area() + int_bypass->area.get_area());
+		  intTagBypass = new interconnect("Int Bypass tag" , Core_device, 1, 1, coredynp.perThreadState,
+				  rfu->int_regfile_height + exeu->FU_height + lsq_height + scheu->Iw_height, &interface_ip, 3,
+				  false, 1.0, coredynp.opt_local, coredynp.core_ty);
+		  bypass.area.set_area(bypass.area.get_area()  +intTagBypass->area.get_area());
+
+		  if (coredynp.num_muls>0)
+		  {
+			  int_mul_bypass     = new interconnect("Mul Bypass Data" , Core_device, 1, 1, int(ceil(XML->sys.machine_bits/32.0)*32*1.5),
+					  rfu->fp_regfile_height + exeu->FU_height + mul->FU_height + lsq_height, &interface_ip, 3,
+					  false, 1.0, coredynp.opt_local, coredynp.core_ty);
+			  bypass.area.set_area(bypass.area.get_area()  +int_mul_bypass->area.get_area());
+			  intTag_mul_Bypass  = new interconnect("Mul Bypass tag"  , Core_device, 1, 1, coredynp.perThreadState,
+					  rfu->fp_regfile_height + exeu->FU_height + mul->FU_height + lsq_height + scheu->Iw_height, &interface_ip, 3,
+					  false, 1.0, coredynp.opt_local, coredynp.core_ty);
+			  bypass.area.set_area(bypass.area.get_area()  +intTag_mul_Bypass->area.get_area());
+		  }
+
+		  /*
+		  if (coredynp.num_fpus>0)
+		  {
+			  fp_bypass    = new interconnect("FP Bypass Data" , Core_device, 1, 1, int(ceil(XML->sys.machine_bits/32.0)*32*1.5),
+					  rfu->fp_regfile_height + fp_u->FU_height, &interface_ip, 3,
+					  false, 1.0, coredynp.opt_local, coredynp.core_ty);
+			  bypass.area.set_area(bypass.area.get_area()  +fp_bypass->area.get_area());
+			  fpTagBypass  = new interconnect("FP Bypass tag"  , Core_device, 1, 1, coredynp.perThreadState,
+					  rfu->fp_regfile_height + fp_u->FU_height + lsq_height + scheu->Iw_height, &interface_ip, 3,
+					  false, 1.0, coredynp.opt_local, coredynp.core_ty);
+			  bypass.area.set_area(bypass.area.get_area()  +fpTagBypass->area.get_area());
+		  }*/
+	  } /* if (coredynp.core_ty==Inorder) */ 
+	  else
+	  {//OOO
+		  if (coredynp.scheu_ty==PhysicalRegFile)
+		  {
+			  /* For physical register based OOO,
+			   * data broadcast interconnects cover across functional units, lsq, inst windows and register files,
+			   * while tag broadcast interconnects also cover across ROB
+			   */
+			  int_bypass   = new interconnect("Int Bypass Data", Core_device, 1, 1, int(ceil(coredynp.int_data_width)),
+					            rfu->int_regfile_height + exeu->FU_height + lsq_height, &interface_ip, 3,
+								false, 1.0, coredynp.opt_local, coredynp.core_ty);
+			  bypass.area.set_area(bypass.area.get_area()  +int_bypass->area.get_area());
+			  intTagBypass = new interconnect("Int Bypass tag" , Core_device, 1, 1, coredynp.phy_ireg_width,
+					            rfu->int_regfile_height + exeu->FU_height + lsq_height + scheu->Iw_height + scheu->ROB_height , &interface_ip, 3,
+								false, 1.0, coredynp.opt_local, coredynp.core_ty);
+
+			  if (coredynp.num_muls>0)
+			  {
+				  int_mul_bypass   = new interconnect("Mul Bypass Data", Core_device, 1, 1, int(ceil(coredynp.int_data_width)),
+										rfu->int_regfile_height + exeu->FU_height + mul->FU_height + lsq_height, &interface_ip, 3,
+										false, 1.0, coredynp.opt_local, coredynp.core_ty);
+				  intTag_mul_Bypass = new interconnect("Mul Bypass tag" , Core_device, 1, 1, coredynp.phy_ireg_width,
+										rfu->int_regfile_height + exeu->FU_height + mul->FU_height + lsq_height + scheu->Iw_height + scheu->ROB_height , &interface_ip, 3,
+										false, 1.0, coredynp.opt_local, coredynp.core_ty);
+				  bypass.area.set_area(bypass.area.get_area()  +int_mul_bypass->area.get_area());
+				  bypass.area.set_area(bypass.area.get_area()  +intTag_mul_Bypass->area.get_area());
+			  }
+
+			  if (coredynp.num_fpus>0)
+			  {
+				  fp_bypass    = new interconnect("FP Bypass Data" , Core_device, 1, 1, int(ceil(coredynp.fp_data_width)),
+								  rfu->fp_regfile_height + fp_u->FU_height, &interface_ip, 3,
+								  false, 1.0, coredynp.opt_local, coredynp.core_ty);
+				  fpTagBypass  = new interconnect("FP Bypass tag"  , Core_device, 1, 1, coredynp.phy_freg_width,
+								  rfu->fp_regfile_height + fp_u->FU_height + lsq_height + scheu->fp_Iw_height + scheu->ROB_height, &interface_ip, 3,
+								  false, 1.0, coredynp.opt_local, coredynp.core_ty);
+				  bypass.area.set_area(bypass.area.get_area()  +fp_bypass->area.get_area());
+				  bypass.area.set_area(bypass.area.get_area()  +fpTagBypass->area.get_area());
+			  }
+		  }
+		  else
+		  {
+             /*
+              * In RS based processor both data and tag are broadcast together,
+              * covering functional units, lsq, nst windows, register files, and ROBs
+              */
+			  int_bypass   = new interconnect("Int Bypass Data", Core_device, 1, 1, int(ceil(coredynp.int_data_width)),
+					            rfu->int_regfile_height + exeu->FU_height + lsq_height + scheu->Iw_height + scheu->ROB_height, &interface_ip, 3,
+								  false, 1.0, coredynp.opt_local, coredynp.core_ty);
+			  intTagBypass = new interconnect("Int Bypass tag" , Core_device, 1, 1, coredynp.phy_ireg_width,
+					            rfu->int_regfile_height + exeu->FU_height + lsq_height + scheu->Iw_height + scheu->ROB_height , &interface_ip, 3,
+								  false, 1.0, coredynp.opt_local, coredynp.core_ty);
+			  bypass.area.set_area(bypass.area.get_area() +int_bypass->area.get_area());
+			  bypass.area.set_area(bypass.area.get_area() +intTagBypass->area.get_area());
+			  if (coredynp.num_muls>0)
+			  {
+				  int_mul_bypass   = new interconnect("Mul Bypass Data", Core_device, 1, 1, int(ceil(coredynp.int_data_width)),
+						            rfu->int_regfile_height + exeu->FU_height + mul->FU_height + lsq_height + scheu->Iw_height + scheu->ROB_height, &interface_ip, 3,
+									  false, 1.0, coredynp.opt_local, coredynp.core_ty);
+				  intTag_mul_Bypass = new interconnect("Mul Bypass tag" , Core_device, 1, 1, coredynp.phy_ireg_width,
+						            rfu->int_regfile_height + exeu->FU_height + mul->FU_height + lsq_height + scheu->Iw_height + scheu->ROB_height , &interface_ip, 3,
+									  false, 1.0, coredynp.opt_local, coredynp.core_ty);
+				  bypass.area.set_area(bypass.area.get_area() +int_mul_bypass->area.get_area());
+				  bypass.area.set_area(bypass.area.get_area() +intTag_mul_Bypass->area.get_area());
+			  }
+
+			  if (coredynp.num_fpus>0)
+			  {
+				  fp_bypass    = new interconnect("FP Bypass Data" , Core_device, 1, 1, int(ceil(coredynp.fp_data_width)),
+						  rfu->fp_regfile_height + fp_u->FU_height + lsq_height + scheu->fp_Iw_height + scheu->ROB_height, &interface_ip, 3,
+						  false, 1.0, coredynp.opt_local, coredynp.core_ty);
+				  fpTagBypass  = new interconnect("FP Bypass tag"  , Core_device, 1, 1, coredynp.phy_freg_width,
+						  rfu->fp_regfile_height + fp_u->FU_height + lsq_height + scheu->fp_Iw_height + scheu->ROB_height, &interface_ip, 3,
+						  false, 1.0, coredynp.opt_local, coredynp.core_ty);
+				  bypass.area.set_area(bypass.area.get_area() +fp_bypass->area.get_area());
+				  bypass.area.set_area(bypass.area.get_area() +fpTagBypass->area.get_area());
+			  }
+		  } /* else */ 
+
+
+	  } /* else */ 
+	  area.set_area(area.get_area()/*+ bypass.area.get_area()*/);
 }
 
-EXECU::EXECU(ParseXML* XML_interface, int ithCore_,
-             InputParameter* interface_ip_, double lsq_height_,
-             const CoreDynParam& dyn_p_, double exClockRate, bool exist_)
-    : XML(XML_interface),
-      ithCore(ithCore_),
-      interface_ip(*interface_ip_),
-      lsq_height(lsq_height_),
-      coredynp(dyn_p_),
-      rfu(0),
-      scheu(0),
-      fp_u(0),
-      exeu(0),
-      mul(0),
-      int_bypass(0),
-      intTagBypass(0),
-      int_mul_bypass(0),
-      intTag_mul_Bypass(0),
-      fp_bypass(0),
-      fpTagBypass(0),
-      exist(exist_),
-      rf_fu_clockRate(exClockRate) {
-  if (!exist) return;
-  double fu_height = 0.0;
-  clockRate = coredynp.clockRate;
-  // cout <<"EXECU exClockRate: "<<exClockRate<<endl;
-  executionTime = coredynp.executionTime;
-  rfu = new RegFU(XML, ithCore, &interface_ip, coredynp, exClockRate);
-  scheu = new SchedulerU(XML, ithCore, &interface_ip, coredynp);
-  exeu = new FunctionalUnit(XML, ithCore, &interface_ip, coredynp, ALU,
-                            exClockRate);
-  area.set_area(area.get_area() + exeu->area.get_area() + rfu->area.get_area() +
-                scheu->area.get_area());
-  fu_height = exeu->FU_height;
-  if (coredynp.num_fpus > 0) {
-    fp_u = new FunctionalUnit(XML, ithCore, &interface_ip, coredynp, FPU,
-                              exClockRate);
-    area.set_area(area.get_area() + fp_u->area.get_area());
-  }
-  if (coredynp.num_muls > 0) {
-    mul = new FunctionalUnit(XML, ithCore, &interface_ip, coredynp, MUL,
-                             exClockRate);
-    area.set_area(area.get_area() + mul->area.get_area());
-    fu_height += mul->FU_height;
-  }
-  /*
-   * broadcast logic, including int-broadcast; int_tag-broadcast; fp-broadcast;
-   * fp_tag-broadcast
-   * integer by pass has two paths and fp has 3 paths.
-   * on the same bus there are multiple tri-state drivers and muxes that go to
-   * different components on the same bus
-   */
-  if (XML->sys.Embedded) {
-    interface_ip.wt = Global_30;
-    interface_ip.wire_is_mat_type = 0;
-    interface_ip.wire_os_mat_type = 0;
-    interface_ip.throughput = 1.0 / clockRate;
-    interface_ip.latency = 1.0 / clockRate;
-  } else {
-    interface_ip.wt = Global;
-    interface_ip.wire_is_mat_type =
-        2;  // start from semi-global since local wires are already used
-    interface_ip.wire_os_mat_type = 2;
-    interface_ip.throughput = 10.0 / clockRate;  // Do not care
-    interface_ip.latency = 10.0 / clockRate;
-  }
-
-  if (coredynp.core_ty == Inorder) {  //
-    int_bypass = new interconnect(
-        "Int Bypass Data", Core_device, 1, 1,
-        int(ceil(XML->sys.machine_bits / 32.0) * 32),
-        rfu->int_regfile_height + exeu->FU_height + lsq_height, &interface_ip,
-        3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
-    bypass.area.set_area(bypass.area.get_area() + int_bypass->area.get_area());
-    intTagBypass = new interconnect(
-        "Int Bypass tag", Core_device, 1, 1, coredynp.perThreadState,
-        rfu->int_regfile_height + exeu->FU_height + lsq_height +
-            scheu->Iw_height,
-        &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
-    bypass.area.set_area(bypass.area.get_area() +
-                         intTagBypass->area.get_area());
-
-    if (coredynp.num_muls > 0) {
-      int_mul_bypass = new interconnect(
-          "Mul Bypass Data", Core_device, 1, 1,
-          int(ceil(XML->sys.machine_bits / 32.0) * 32 * 1.5),
-          rfu->fp_regfile_height + exeu->FU_height + mul->FU_height +
-              lsq_height,
-          &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
-      bypass.area.set_area(bypass.area.get_area() +
-                           int_mul_bypass->area.get_area());
-      intTag_mul_Bypass = new interconnect(
-          "Mul Bypass tag", Core_device, 1, 1, coredynp.perThreadState,
-          rfu->fp_regfile_height + exeu->FU_height + mul->FU_height +
-              lsq_height + scheu->Iw_height,
-          &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
-      bypass.area.set_area(bypass.area.get_area() +
-                           intTag_mul_Bypass->area.get_area());
-    }
-
-    /*
-    if (coredynp.num_fpus>0)
+RENAMINGU::RENAMINGU(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_,bool exist_)
+:XML(XML_interface),
+ ithCore(ithCore_),
+ interface_ip(*interface_ip_),
+ coredynp(dyn_p_),
+ iFRAT(0),
+ fFRAT(0),
+ iRRAT(0),
+ fRRAT(0),
+ ifreeL(0),
+ ffreeL(0),
+ idcl(0),
+ fdcl(0),
+ RAHT(0),
+ exist(exist_)
+ {
+	/*
+	 * Although renaming logic maybe be used in in-order processors,
+     * McPAT assumes no renaming logic is used since the performance gain is very limited and
+     * the only major inorder processor with renaming logic is Itainium
+     * that is a VLIW processor and different from current McPAT's model.
+	 * physical register base OOO must have Dual-RAT architecture or equivalent structure.FRAT:FrontRAT, RRAT:RetireRAT;
+	 * i,f prefix mean int and fp
+	 * RAT for all Renaming logic, random accessible checkpointing is used, but only update when instruction retires.
+	 * FRAT will be read twice and written once per instruction;
+	 * RRAT will be write once per instruction when committing and reads out all when context switch
+	 * checkpointing is implicit
+	 * Renaming logic is duplicated for each different hardware threads
+	 *
+	 * No Dual-RAT is needed in RS-based OOO processors,
+	 * however, RAT needs to do associative search in RAT, when instruction commits and ROB release the entry,
+	 * to make sure all the renamings associated with the ROB to be released are updated at the same time.
+	 * RAM scheme has # ARchi Reg entry with each entry hold phy reg tag,
+	 * CAM scheme has # Phy Reg entry with each entry hold ARchi reg tag,
+	 *
+	 * Both RAM and CAM have same DCL
+	 */
+	if (!exist) return;
+	int  tag, data, out_w;
+//	interface_ip.wire_is_mat_type = 0;
+//	interface_ip.wire_os_mat_type = 0;
+//	interface_ip.wt               = Global_30;
+	clockRate = coredynp.clockRate;
+	executionTime = coredynp.executionTime;
+    if (coredynp.core_ty==OOO)
     {
-            fp_bypass    = new interconnect("FP Bypass Data" , Core_device, 1,
-    1, int(ceil(XML->sys.machine_bits/32.0)*32*1.5),
-                            rfu->fp_regfile_height + fp_u->FU_height,
-    &interface_ip, 3,
-                            false, 1.0, coredynp.opt_local, coredynp.core_ty);
-            bypass.area.set_area(bypass.area.get_area()
-    +fp_bypass->area.get_area());
-            fpTagBypass  = new interconnect("FP Bypass tag"  , Core_device, 1,
-    1, coredynp.perThreadState,
-                            rfu->fp_regfile_height + fp_u->FU_height +
-    lsq_height + scheu->Iw_height, &interface_ip, 3,
-                            false, 1.0, coredynp.opt_local, coredynp.core_ty);
-            bypass.area.set_area(bypass.area.get_area()
-    +fpTagBypass->area.get_area());
-    }*/
-  }       /* if (coredynp.core_ty==Inorder) */
-  else {  // OOO
-    if (coredynp.scheu_ty == PhysicalRegFile) {
-      /* For physical register based OOO,
-       * data broadcast interconnects cover across functional units, lsq, inst
-       * windows and register files,
-       * while tag broadcast interconnects also cover across ROB
-       */
-      int_bypass = new interconnect(
-          "Int Bypass Data", Core_device, 1, 1,
-          int(ceil(coredynp.int_data_width)),
-          rfu->int_regfile_height + exeu->FU_height + lsq_height, &interface_ip,
-          3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
-      bypass.area.set_area(bypass.area.get_area() +
-                           int_bypass->area.get_area());
-      intTagBypass = new interconnect(
-          "Int Bypass tag", Core_device, 1, 1, coredynp.phy_ireg_width,
-          rfu->int_regfile_height + exeu->FU_height + lsq_height +
-              scheu->Iw_height + scheu->ROB_height,
-          &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+	//integer pipeline
+	if (coredynp.scheu_ty==PhysicalRegFile)
+	{
+		if (coredynp.rm_ty ==RAMbased)
+		{	  //FRAT with global checkpointing (GCs) please see paper tech report for detailed explaintions
+			data							 = 33;//int(ceil(coredynp.phy_ireg_width*(1+coredynp.globalCheckpoint)/8.0));
+//			data							 = int(ceil(coredynp.phy_ireg_width/8.0));
+			out_w                            = 1;//int(ceil(coredynp.phy_ireg_width/8.0));
+			interface_ip.is_cache			 = false;
+			interface_ip.pure_cam            = false;
+			interface_ip.pure_ram            = true;
+			interface_ip.line_sz             = data;
+			interface_ip.cache_sz            = data*XML->sys.core[ithCore].archi_Regs_IRF_size;
+			interface_ip.assoc               = 1;
+			interface_ip.nbanks              = 1;
+			interface_ip.out_w               = out_w*8;
+			interface_ip.access_mode         = 2;
+			interface_ip.throughput          = 1.0/clockRate;
+			interface_ip.latency             = 1.0/clockRate;
+			interface_ip.obj_func_dyn_energy = 0;
+			interface_ip.obj_func_dyn_power  = 0;
+			interface_ip.obj_func_leak_power = 0;
+			interface_ip.obj_func_cycle_t    = 1;
+			interface_ip.num_rw_ports    = 1;//the extra one port is for GCs
+			interface_ip.num_rd_ports    = 2*coredynp.decodeW;
+			interface_ip.num_wr_ports    = coredynp.decodeW;
+			interface_ip.num_se_rd_ports = 0;
+			iFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
+			iFRAT->area.set_area(iFRAT->area.get_area()+ iFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
+			area.set_area(area.get_area()+ iFRAT->area.get_area());
 
-      if (coredynp.num_muls > 0) {
-        int_mul_bypass = new interconnect(
-            "Mul Bypass Data", Core_device, 1, 1,
-            int(ceil(coredynp.int_data_width)),
-            rfu->int_regfile_height + exeu->FU_height + mul->FU_height +
-                lsq_height,
-            &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
-        intTag_mul_Bypass = new interconnect(
-            "Mul Bypass tag", Core_device, 1, 1, coredynp.phy_ireg_width,
-            rfu->int_regfile_height + exeu->FU_height + mul->FU_height +
-                lsq_height + scheu->Iw_height + scheu->ROB_height,
-            &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
-        bypass.area.set_area(bypass.area.get_area() +
-                             int_mul_bypass->area.get_area());
-        bypass.area.set_area(bypass.area.get_area() +
-                             intTag_mul_Bypass->area.get_area());
-      }
+//			//RAHT According to Intel, combine GC with FRAT is very costly.
+//			data							 = int(ceil(coredynp.phy_ireg_width/8.0)*coredynp.num_IRF_entry);
+//			out_w                            = data;
+//			interface_ip.is_cache			 = false;
+//			interface_ip.pure_cam            = false;
+//			interface_ip.pure_ram            = true;
+//			interface_ip.line_sz             = data;
+//			interface_ip.cache_sz            = data*coredynp.globalCheckpoint;
+//			interface_ip.assoc               = 1;
+//			interface_ip.nbanks              = 1;
+//			interface_ip.out_w               = out_w*8;
+//			interface_ip.access_mode         = 0;
+//			interface_ip.throughput          = 1.0/clockRate;
+//			interface_ip.latency             = 1.0/clockRate;
+//			interface_ip.obj_func_dyn_energy = 0;
+//			interface_ip.obj_func_dyn_power  = 0;
+//			interface_ip.obj_func_leak_power = 0;
+//			interface_ip.obj_func_cycle_t    = 1;
+//			interface_ip.num_rw_ports    = 1;//the extra one port is for GCs
+//			interface_ip.num_rd_ports    = 2*coredynp.decodeW;
+//			interface_ip.num_wr_ports    = coredynp.decodeW;
+//			interface_ip.num_se_rd_ports = 0;
+//			iFRAT = new ArrayST(&interface_ip, "Int FrontRAT");
+//			iFRAT->area.set_area(iFRAT->area.get_area()+ iFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
+//			area.set_area(area.get_area()+ iFRAT->area.get_area());
 
-      if (coredynp.num_fpus > 0) {
-        fp_bypass = new interconnect("FP Bypass Data", Core_device, 1, 1,
-                                     int(ceil(coredynp.fp_data_width)),
-                                     rfu->fp_regfile_height + fp_u->FU_height,
-                                     &interface_ip, 3, false, 1.0,
-                                     coredynp.opt_local, coredynp.core_ty);
-        fpTagBypass = new interconnect(
-            "FP Bypass tag", Core_device, 1, 1, coredynp.phy_freg_width,
-            rfu->fp_regfile_height + fp_u->FU_height + lsq_height +
-                scheu->fp_Iw_height + scheu->ROB_height,
-            &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
-        bypass.area.set_area(bypass.area.get_area() +
-                             fp_bypass->area.get_area());
-        bypass.area.set_area(bypass.area.get_area() +
-                             fpTagBypass->area.get_area());
-      }
-    } else {
-      /*
-       * In RS based processor both data and tag are broadcast together,
-       * covering functional units, lsq, nst windows, register files, and ROBs
-       */
-      int_bypass = new interconnect(
-          "Int Bypass Data", Core_device, 1, 1,
-          int(ceil(coredynp.int_data_width)),
-          rfu->int_regfile_height + exeu->FU_height + lsq_height +
-              scheu->Iw_height + scheu->ROB_height,
-          &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
-      intTagBypass = new interconnect(
-          "Int Bypass tag", Core_device, 1, 1, coredynp.phy_ireg_width,
-          rfu->int_regfile_height + exeu->FU_height + lsq_height +
-              scheu->Iw_height + scheu->ROB_height,
-          &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
-      bypass.area.set_area(bypass.area.get_area() +
-                           int_bypass->area.get_area());
-      bypass.area.set_area(bypass.area.get_area() +
-                           intTagBypass->area.get_area());
-      if (coredynp.num_muls > 0) {
-        int_mul_bypass = new interconnect(
-            "Mul Bypass Data", Core_device, 1, 1,
-            int(ceil(coredynp.int_data_width)),
-            rfu->int_regfile_height + exeu->FU_height + mul->FU_height +
-                lsq_height + scheu->Iw_height + scheu->ROB_height,
-            &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
-        intTag_mul_Bypass = new interconnect(
-            "Mul Bypass tag", Core_device, 1, 1, coredynp.phy_ireg_width,
-            rfu->int_regfile_height + exeu->FU_height + mul->FU_height +
-                lsq_height + scheu->Iw_height + scheu->ROB_height,
-            &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
-        bypass.area.set_area(bypass.area.get_area() +
-                             int_mul_bypass->area.get_area());
-        bypass.area.set_area(bypass.area.get_area() +
-                             intTag_mul_Bypass->area.get_area());
-      }
+			//FRAT floating point
+			data							 = int(ceil(coredynp.phy_freg_width*(1+coredynp.globalCheckpoint)/8.0));
+			out_w                            = int(ceil(coredynp.phy_freg_width/8.0));
+			interface_ip.is_cache			 = false;
+			interface_ip.pure_cam            = false;
+			interface_ip.pure_ram            = true;
+			interface_ip.line_sz             = data;
+			interface_ip.cache_sz            = data*XML->sys.core[ithCore].archi_Regs_FRF_size;
+			interface_ip.assoc               = 1;
+			interface_ip.nbanks              = 1;
+			interface_ip.out_w               = out_w*8;
+			interface_ip.access_mode         = 2;
+			interface_ip.throughput          = 1.0/clockRate;
+			interface_ip.latency             = 1.0/clockRate;
+			interface_ip.obj_func_dyn_energy = 0;
+			interface_ip.obj_func_dyn_power  = 0;
+			interface_ip.obj_func_leak_power = 0;
+			interface_ip.obj_func_cycle_t    = 1;
+			interface_ip.num_rw_ports    = 1;//the extra one port is for GCs
+			interface_ip.num_rd_ports    = 2*coredynp.fp_decodeW;
+			interface_ip.num_wr_ports    = coredynp.fp_decodeW;
+			interface_ip.num_se_rd_ports = 0;
+			fFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
+			fFRAT->area.set_area(fFRAT->area.get_area()+ fFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
+			area.set_area(area.get_area()+ fFRAT->area.get_area());
 
-      if (coredynp.num_fpus > 0) {
-        fp_bypass = new interconnect(
-            "FP Bypass Data", Core_device, 1, 1,
-            int(ceil(coredynp.fp_data_width)),
-            rfu->fp_regfile_height + fp_u->FU_height + lsq_height +
-                scheu->fp_Iw_height + scheu->ROB_height,
-            &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
-        fpTagBypass = new interconnect(
-            "FP Bypass tag", Core_device, 1, 1, coredynp.phy_freg_width,
-            rfu->fp_regfile_height + fp_u->FU_height + lsq_height +
-                scheu->fp_Iw_height + scheu->ROB_height,
-            &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
-        bypass.area.set_area(bypass.area.get_area() +
-                             fp_bypass->area.get_area());
-        bypass.area.set_area(bypass.area.get_area() +
-                             fpTagBypass->area.get_area());
-      }
-    } /* else */
+		}
+		else if ((coredynp.rm_ty ==CAMbased))
+		{
+			//FRAT
+			tag							     = coredynp.arch_ireg_width;
+			data							 = int(ceil ((coredynp.arch_ireg_width+1*coredynp.globalCheckpoint)/8.0));//the address of CAM needed to be sent out
+			out_w                            = int(ceil (coredynp.arch_ireg_width/8.0));
+			interface_ip.is_cache			 = true;
+			interface_ip.pure_cam            = false;
+			interface_ip.pure_ram            = false;
+			interface_ip.line_sz             = data;
+			interface_ip.cache_sz            = data*XML->sys.core[ithCore].phy_Regs_IRF_size;
+			interface_ip.assoc               = 0;
+			interface_ip.nbanks              = 1;
+			interface_ip.out_w               = out_w*8;
+			interface_ip.specific_tag        = 1;
+			interface_ip.tag_w               = tag;
+			interface_ip.access_mode         = 2;
+			interface_ip.throughput          = 1.0/clockRate;
+			interface_ip.latency             = 1.0/clockRate;
+			interface_ip.obj_func_dyn_energy = 0;
+			interface_ip.obj_func_dyn_power  = 0;
+			interface_ip.obj_func_leak_power = 0;
+			interface_ip.obj_func_cycle_t    = 1;
+			interface_ip.num_rw_ports    = 1;//for GCs
+			interface_ip.num_rd_ports    = coredynp.decodeW;
+			interface_ip.num_wr_ports    = coredynp.decodeW;
+			interface_ip.num_se_rd_ports = 0;
+			interface_ip.num_search_ports= 2*coredynp.decodeW;
+			iFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
+			iFRAT->area.set_area(iFRAT->area.get_area()+ iFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
+			area.set_area(area.get_area()+ iFRAT->area.get_area());
 
-  } /* else */
-  area.set_area(area.get_area() /*+ bypass.area.get_area()*/);
+			//FRAT for FP
+			tag							     = coredynp.arch_freg_width;
+			data							 = int(ceil ((coredynp.arch_freg_width+1*coredynp.globalCheckpoint)/8.0));//the address of CAM needed to be sent out
+			out_w                            = int(ceil (coredynp.arch_freg_width/8.0));
+			interface_ip.is_cache			 = true;
+			interface_ip.pure_cam            = false;
+			interface_ip.pure_ram            = false;
+			interface_ip.line_sz             = data;
+			interface_ip.cache_sz            = data*XML->sys.core[ithCore].phy_Regs_FRF_size;
+			interface_ip.assoc               = 0;
+			interface_ip.nbanks              = 1;
+			interface_ip.out_w               = out_w*8;
+			interface_ip.specific_tag        = 1;
+			interface_ip.tag_w               = tag;
+			interface_ip.access_mode         = 2;
+			interface_ip.throughput          = 1.0/clockRate;
+			interface_ip.latency             = 1.0/clockRate;
+			interface_ip.obj_func_dyn_energy = 0;
+			interface_ip.obj_func_dyn_power  = 0;
+			interface_ip.obj_func_leak_power = 0;
+			interface_ip.obj_func_cycle_t    = 1;
+			interface_ip.num_rw_ports    = 1;//for GCs
+			interface_ip.num_rd_ports    = coredynp.fp_decodeW;
+			interface_ip.num_wr_ports    = coredynp.fp_decodeW;
+			interface_ip.num_se_rd_ports = 0;
+			interface_ip.num_search_ports= 2*coredynp.fp_decodeW;
+			fFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
+			fFRAT->area.set_area(fFRAT->area.get_area()+ fFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
+			area.set_area(area.get_area()+ fFRAT->area.get_area());
+
+		}
+
+		//RRAT is always RAM based, does not have GCs, and is used only for record latest non-speculative mapping
+		data							 = int(ceil(coredynp.phy_ireg_width/8.0));
+		interface_ip.is_cache			 = false;
+		interface_ip.pure_cam            = false;
+		interface_ip.pure_ram            = true;
+		interface_ip.line_sz             = data;
+		interface_ip.cache_sz            = data*XML->sys.core[ithCore].archi_Regs_IRF_size*2;//HACK to make it as least 64B
+		interface_ip.assoc               = 1;
+		interface_ip.nbanks              = 1;
+		interface_ip.out_w               = interface_ip.line_sz*8;
+		interface_ip.access_mode         = 1;
+		interface_ip.throughput          = 1.0/clockRate;
+		interface_ip.latency             = 1.0/clockRate;
+		interface_ip.obj_func_dyn_energy = 0;
+		interface_ip.obj_func_dyn_power  = 0;
+		interface_ip.obj_func_leak_power = 0;
+		interface_ip.obj_func_cycle_t    = 1;
+		interface_ip.num_rw_ports    = 0;
+		interface_ip.num_rd_ports    = XML->sys.core[ithCore].commit_width;
+		interface_ip.num_wr_ports    = XML->sys.core[ithCore].commit_width;
+		interface_ip.num_se_rd_ports = 0;
+		iRRAT = new ArrayST(&interface_ip, "Int RetireRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
+		iRRAT->area.set_area(iRRAT->area.get_area()+ iRRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
+		area.set_area(area.get_area()+ iRRAT->area.get_area());
+
+		//RRAT for FP
+		data							 = int(ceil(coredynp.phy_freg_width/8.0));
+		interface_ip.is_cache			 = false;
+		interface_ip.pure_cam            = false;
+		interface_ip.pure_ram            = true;
+		interface_ip.line_sz             = data;
+		interface_ip.cache_sz            = data*XML->sys.core[ithCore].archi_Regs_FRF_size*2;//HACK to make it as least 64B
+		interface_ip.assoc               = 1;
+		interface_ip.nbanks              = 1;
+		interface_ip.out_w               = interface_ip.line_sz*8;
+		interface_ip.access_mode         = 1;
+		interface_ip.throughput          = 1.0/clockRate;
+		interface_ip.latency             = 1.0/clockRate;
+		interface_ip.obj_func_dyn_energy = 0;
+		interface_ip.obj_func_dyn_power  = 0;
+		interface_ip.obj_func_leak_power = 0;
+		interface_ip.obj_func_cycle_t    = 1;
+		interface_ip.num_rw_ports    = 0;
+		interface_ip.num_rd_ports    = coredynp.fp_decodeW;
+		interface_ip.num_wr_ports    = coredynp.fp_decodeW;
+		interface_ip.num_se_rd_ports = 0;
+		fRRAT = new ArrayST(&interface_ip, "Int RetireRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
+		fRRAT->area.set_area(fRRAT->area.get_area()+ fRRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
+		area.set_area(area.get_area()+ fRRAT->area.get_area());
+
+		//Freelist of renaming unit always RAM based
+		//Recycle happens at two places: 1)when DCL check there are WAW, the Phyregisters/ROB directly recycles into freelist
+		// 2)When instruction commits the Phyregisters/ROB needed to be recycled.
+		//therefore num_wr port = decode-1(-1 means at least one phy reg will be used for the current renaming group) + commit width
+		data							 = int(ceil(coredynp.phy_ireg_width/8.0));
+		interface_ip.is_cache			 = false;
+		interface_ip.pure_cam            = false;
+		interface_ip.pure_ram            = true;
+		interface_ip.line_sz             = data;
+		interface_ip.cache_sz            = data*coredynp.num_ifreelist_entries;
+		interface_ip.assoc               = 1;
+		interface_ip.nbanks              = 1;
+		interface_ip.out_w               = interface_ip.line_sz*8;
+		interface_ip.access_mode         = 1;
+		interface_ip.throughput          = 1.0/clockRate;
+		interface_ip.latency             = 1.0/clockRate;
+		interface_ip.obj_func_dyn_energy = 0;
+		interface_ip.obj_func_dyn_power  = 0;
+		interface_ip.obj_func_leak_power = 0;
+		interface_ip.obj_func_cycle_t    = 1;
+		interface_ip.num_rw_ports    = 1;//TODO
+		interface_ip.num_rd_ports    = coredynp.decodeW;
+		interface_ip.num_wr_ports    = coredynp.decodeW -1 + XML->sys.core[ithCore].commit_width;
+		//every cycle, (coredynp.decodeW -1) inst may need to send back it dest tags, committW insts needs to update freelist buffers
+		interface_ip.num_se_rd_ports = 0;
+		ifreeL = new ArrayST(&interface_ip, "Int Free List", Core_device, coredynp.opt_local, coredynp.core_ty);
+		ifreeL->area.set_area(ifreeL->area.get_area()+ ifreeL->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
+		area.set_area(area.get_area()+ ifreeL->area.get_area());
+
+		//freelist for FP
+		data							 = int(ceil(coredynp.phy_freg_width/8.0));
+		interface_ip.is_cache			 = false;
+		interface_ip.pure_cam            = false;
+		interface_ip.pure_ram            = true;
+		interface_ip.line_sz             = data;
+		interface_ip.cache_sz            = data*coredynp.num_ffreelist_entries;
+		interface_ip.assoc               = 1;
+		interface_ip.nbanks              = 1;
+		interface_ip.out_w               = interface_ip.line_sz*8;
+		interface_ip.access_mode         = 1;
+		interface_ip.throughput          = 1.0/clockRate;
+		interface_ip.latency             = 1.0/clockRate;
+		interface_ip.obj_func_dyn_energy = 0;
+		interface_ip.obj_func_dyn_power  = 0;
+		interface_ip.obj_func_leak_power = 0;
+		interface_ip.obj_func_cycle_t    = 1;
+		interface_ip.num_rw_ports    = 1;
+		interface_ip.num_rd_ports    = coredynp.fp_decodeW;
+		interface_ip.num_wr_ports    = coredynp.fp_decodeW -1 + XML->sys.core[ithCore].commit_width;
+		interface_ip.num_se_rd_ports = 0;
+		ffreeL = new ArrayST(&interface_ip, "Int Free List", Core_device, coredynp.opt_local, coredynp.core_ty);
+		ffreeL->area.set_area(ffreeL->area.get_area()+ ffreeL->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
+		area.set_area(area.get_area()+ ffreeL->area.get_area());
+
+		idcl  = new dep_resource_conflict_check(&interface_ip,coredynp,coredynp.phy_ireg_width);//TODO:Separate 2 sections See TR
+		fdcl  = new dep_resource_conflict_check(&interface_ip,coredynp,coredynp.phy_freg_width);
+
+	}
+	else if (coredynp.scheu_ty==ReservationStation){
+		if (coredynp.rm_ty ==RAMbased){
+			/*
+			 * however, RAT needs to do associative search in RAT, when instruction commits and ROB release the entry,
+			 * to make sure all the renamings associated with the ROB to be released are updated to ARF at the same time.
+			 * RAM based RAT for RS base OOO does not save the search operations. Its advantage is to have less entries than
+			 * CAM based RAT so that it is more scalable as number of ROB/physical regs increases.
+			 */
+			tag							     = coredynp.phy_ireg_width;
+			data							 = int(ceil(coredynp.phy_ireg_width*(1+coredynp.globalCheckpoint)/8.0));
+			out_w                            = int(ceil(coredynp.phy_ireg_width/8.0));
+			interface_ip.is_cache			 = true;
+			interface_ip.pure_cam            = false;
+			interface_ip.pure_ram            = false;
+			interface_ip.line_sz             = data;
+			interface_ip.cache_sz            = data*XML->sys.core[ithCore].archi_Regs_IRF_size;
+			interface_ip.assoc               = 0;
+			interface_ip.nbanks              = 1;
+			interface_ip.out_w               = out_w*8;
+			interface_ip.access_mode         = 2;
+			interface_ip.throughput          = 1.0/clockRate;
+			interface_ip.latency             = 1.0/clockRate;
+			interface_ip.obj_func_dyn_energy = 0;
+			interface_ip.obj_func_dyn_power  = 0;
+			interface_ip.obj_func_leak_power = 0;
+			interface_ip.obj_func_cycle_t    = 1;
+			interface_ip.num_rw_ports    = 1;//the extra one port is for GCs
+			interface_ip.num_rd_ports    = 2*coredynp.decodeW;
+			interface_ip.num_wr_ports    = coredynp.decodeW;
+			interface_ip.num_se_rd_ports = 0;
+			interface_ip.num_search_ports= coredynp.commitW;//TODO
+			iFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
+			iFRAT->local_result.adjust_area();
+			iFRAT->area.set_area(iFRAT->area.get_area()+ iFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
+			area.set_area(area.get_area()+ iFRAT->area.get_area());
+
+			//FP
+			tag							     = coredynp.phy_freg_width;
+			data							 = int(ceil(coredynp.phy_freg_width*(1+coredynp.globalCheckpoint)/8.0));
+			out_w                            = int(ceil(coredynp.phy_freg_width/8.0));
+			interface_ip.is_cache			 = true;
+			interface_ip.pure_cam            = false;
+			interface_ip.pure_ram            = false;
+			interface_ip.line_sz             = data;
+			interface_ip.cache_sz            = data*XML->sys.core[ithCore].archi_Regs_FRF_size;
+			interface_ip.assoc               = 0;
+			interface_ip.nbanks              = 1;
+			interface_ip.out_w               = out_w*8;
+			interface_ip.access_mode         = 2;
+			interface_ip.throughput          = 1.0/clockRate;
+			interface_ip.latency             = 1.0/clockRate;
+			interface_ip.obj_func_dyn_energy = 0;
+			interface_ip.obj_func_dyn_power  = 0;
+			interface_ip.obj_func_leak_power = 0;
+			interface_ip.obj_func_cycle_t    = 1;
+			interface_ip.num_rw_ports    = 1;//the extra one port is for GCs
+			interface_ip.num_rd_ports    = 2*coredynp.fp_decodeW;
+			interface_ip.num_wr_ports    = coredynp.fp_decodeW;
+			interface_ip.num_se_rd_ports = 0;
+			interface_ip.num_search_ports= coredynp.fp_decodeW;//actually is fp commit width
+			fFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
+			fFRAT->local_result.adjust_area();
+			fFRAT->area.set_area(fFRAT->area.get_area()+ fFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
+			area.set_area(area.get_area()+ fFRAT->area.get_area());
+
+		}
+		else if ((coredynp.rm_ty ==CAMbased))
+		{
+			//FRAT
+			tag							     = coredynp.arch_ireg_width;
+			data							 = int(ceil (coredynp.arch_ireg_width+1*coredynp.globalCheckpoint/8.0));//the address of CAM needed to be sent out
+			out_w                            = int(ceil (coredynp.arch_ireg_width/8.0));
+			interface_ip.is_cache			 = true;
+			interface_ip.pure_cam            = false;
+			interface_ip.pure_ram            = false;
+			interface_ip.line_sz             = data;
+			interface_ip.cache_sz            = data*XML->sys.core[ithCore].phy_Regs_IRF_size;
+			interface_ip.assoc               = 0;
+			interface_ip.nbanks              = 1;
+			interface_ip.out_w               = out_w*8;
+			interface_ip.specific_tag        = 1;
+			interface_ip.tag_w               = tag;
+			interface_ip.access_mode         = 2;
+			interface_ip.throughput          = 1.0/clockRate;
+			interface_ip.latency             = 1.0/clockRate;
+			interface_ip.obj_func_dyn_energy = 0;
+			interface_ip.obj_func_dyn_power  = 0;
+			interface_ip.obj_func_leak_power = 0;
+			interface_ip.obj_func_cycle_t    = 1;
+			interface_ip.num_rw_ports    = 1;//for GCs
+			interface_ip.num_rd_ports    = XML->sys.core[ithCore].decode_width;//0;TODO
+			interface_ip.num_wr_ports    = XML->sys.core[ithCore].decode_width;
+			interface_ip.num_se_rd_ports = 0;
+			interface_ip.num_search_ports= 2*XML->sys.core[ithCore].decode_width;
+			iFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
+			iFRAT->area.set_area(iFRAT->area.get_area()+ iFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
+			area.set_area(area.get_area()+ iFRAT->area.get_area());
+
+			//FRAT
+			tag							     = coredynp.arch_freg_width;
+			data							 = int(ceil (coredynp.arch_freg_width+1*coredynp.globalCheckpoint/8.0));//the address of CAM needed to be sent out
+			out_w                            = int(ceil (coredynp.arch_freg_width/8.0));
+			interface_ip.is_cache			 = true;
+			interface_ip.pure_cam            = false;
+			interface_ip.pure_ram            = false;
+			interface_ip.line_sz             = data;
+			interface_ip.cache_sz            = data*XML->sys.core[ithCore].phy_Regs_FRF_size;
+			interface_ip.assoc               = 0;
+			interface_ip.nbanks              = 1;
+			interface_ip.out_w               = out_w*8;
+			interface_ip.specific_tag        = 1;
+			interface_ip.tag_w               = tag;
+			interface_ip.access_mode         = 2;
+			interface_ip.throughput          = 1.0/clockRate;
+			interface_ip.latency             = 1.0/clockRate;
+			interface_ip.obj_func_dyn_energy = 0;
+			interface_ip.obj_func_dyn_power  = 0;
+			interface_ip.obj_func_leak_power = 0;
+			interface_ip.obj_func_cycle_t    = 1;
+			interface_ip.num_rw_ports    = 1;//for GCs
+			interface_ip.num_rd_ports    = XML->sys.core[ithCore].decode_width;//0;TODO;
+			interface_ip.num_wr_ports    = coredynp.fp_decodeW;
+			interface_ip.num_se_rd_ports = 0;
+			interface_ip.num_search_ports= 2*coredynp.fp_decodeW;
+			fFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
+			fFRAT->area.set_area(fFRAT->area.get_area()+ fFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
+			area.set_area(area.get_area()+ fFRAT->area.get_area());
+
+		}
+		//No RRAT for RS based OOO
+		//Freelist of renaming unit of RS based OOO is unifed for both int and fp renaming unit since the ROB is unified
+		data							 = int(ceil(coredynp.phy_ireg_width/8.0));
+		interface_ip.is_cache			 = false;
+		interface_ip.pure_cam            = false;
+		interface_ip.pure_ram            = true;
+		interface_ip.line_sz             = data;
+		interface_ip.cache_sz            = data*coredynp.num_ifreelist_entries;
+		interface_ip.assoc               = 1;
+		interface_ip.nbanks              = 1;
+		interface_ip.out_w               = interface_ip.line_sz*8;
+		interface_ip.access_mode         = 1;
+		interface_ip.throughput          = 1.0/clockRate;
+		interface_ip.latency             = 1.0/clockRate;
+		interface_ip.obj_func_dyn_energy = 0;
+		interface_ip.obj_func_dyn_power  = 0;
+		interface_ip.obj_func_leak_power = 0;
+		interface_ip.obj_func_cycle_t    = 1;
+		interface_ip.num_rw_ports    = 1;//TODO
+		interface_ip.num_rd_ports    = XML->sys.core[ithCore].decode_width;
+		interface_ip.num_wr_ports    = XML->sys.core[ithCore].decode_width -1 + XML->sys.core[ithCore].commit_width;
+		interface_ip.num_se_rd_ports = 0;
+		ifreeL = new ArrayST(&interface_ip, "Unified Free List", Core_device, coredynp.opt_local, coredynp.core_ty);
+		ifreeL->area.set_area(ifreeL->area.get_area()+ ifreeL->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
+		area.set_area(area.get_area()+ ifreeL->area.get_area());
+
+		idcl  = new dep_resource_conflict_check(&interface_ip,coredynp,coredynp.phy_ireg_width);//TODO:Separate 2 sections See TR
+		fdcl  = new dep_resource_conflict_check(&interface_ip,coredynp,coredynp.phy_freg_width);
+	}
+
 }
-
-RENAMINGU::RENAMINGU(ParseXML* XML_interface, int ithCore_,
-                     InputParameter* interface_ip_, const CoreDynParam& dyn_p_,
-                     bool exist_)
-    : XML(XML_interface),
-      ithCore(ithCore_),
-      interface_ip(*interface_ip_),
-      coredynp(dyn_p_),
-      iFRAT(0),
-      fFRAT(0),
-      iRRAT(0),
-      fRRAT(0),
-      ifreeL(0),
-      ffreeL(0),
-      idcl(0),
-      fdcl(0),
-      RAHT(0),
-      exist(exist_) {
-  /*
-   * Although renaming logic maybe be used in in-order processors,
-*McPAT assumes no renaming logic is used since the performance gain is very
-* limited and
-*the only major inorder processor with renaming logic is Itainium
-*that is a VLIW processor and different from current McPAT's model.
-   * physical register base OOO must have Dual-RAT architecture or equivalent
-* structure.FRAT:FrontRAT, RRAT:RetireRAT;
-   * i,f prefix mean int and fp
-   * RAT for all Renaming logic, random accessible checkpointing is used, but
-* only update when instruction retires.
-   * FRAT will be read twice and written once per instruction;
-   * RRAT will be write once per instruction when committing and reads out all
-* when context switch
-   * checkpointing is implicit
-   * Renaming logic is duplicated for each different hardware threads
-   *
-   * No Dual-RAT is needed in RS-based OOO processors,
-   * however, RAT needs to do associative search in RAT, when instruction
-* commits and ROB release the entry,
-   * to make sure all the renamings associated with the ROB to be released are
-* updated at the same time.
-   * RAM scheme has # ARchi Reg entry with each entry hold phy reg tag,
-   * CAM scheme has # Phy Reg entry with each entry hold ARchi reg tag,
-   *
-   * Both RAM and CAM have same DCL
-   */
-  if (!exist) return;
-  int tag, data, out_w;
-  //	interface_ip.wire_is_mat_type = 0;
-  //	interface_ip.wire_os_mat_type = 0;
-  //	interface_ip.wt               = Global_30;
-  clockRate = coredynp.clockRate;
-  executionTime = coredynp.executionTime;
-  if (coredynp.core_ty == OOO) {
-    // integer pipeline
-    if (coredynp.scheu_ty == PhysicalRegFile) {
-      if (coredynp.rm_ty == RAMbased) {  // FRAT with global checkpointing (GCs)
-                                         // please see paper tech report for
-                                         // detailed explaintions
-        data =
-            33;  // int(ceil(coredynp.phy_ireg_width*(1+coredynp.globalCheckpoint)/8.0));
-        //			data							 =
-        //int(ceil(coredynp.phy_ireg_width/8.0));
-        out_w = 1;  // int(ceil(coredynp.phy_ireg_width/8.0));
-        interface_ip.is_cache = false;
-        interface_ip.pure_cam = false;
-        interface_ip.pure_ram = true;
-        interface_ip.line_sz = data;
-        interface_ip.cache_sz =
-            data * XML->sys.core[ithCore].archi_Regs_IRF_size;
-        interface_ip.assoc = 1;
-        interface_ip.nbanks = 1;
-        interface_ip.out_w = out_w * 8;
-        interface_ip.access_mode = 2;
-        interface_ip.throughput = 1.0 / clockRate;
-        interface_ip.latency = 1.0 / clockRate;
-        interface_ip.obj_func_dyn_energy = 0;
-        interface_ip.obj_func_dyn_power = 0;
-        interface_ip.obj_func_leak_power = 0;
-        interface_ip.obj_func_cycle_t = 1;
-        interface_ip.num_rw_ports = 1;  // the extra one port is for GCs
-        interface_ip.num_rd_ports = 2 * coredynp.decodeW;
-        interface_ip.num_wr_ports = coredynp.decodeW;
-        interface_ip.num_se_rd_ports = 0;
-        iFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device,
-                            coredynp.opt_local, coredynp.core_ty);
-        iFRAT->area.set_area(
-            iFRAT->area.get_area() +
-            iFRAT->local_result.area *
-                XML->sys.core[ithCore].number_hardware_threads);
-        area.set_area(area.get_area() + iFRAT->area.get_area());
-
-        //			//RAHT According to Intel, combine GC with FRAT is
-        //very costly.
-        //			data							 =
-        //int(ceil(coredynp.phy_ireg_width/8.0)*coredynp.num_IRF_entry);
-        //			out_w                            = data;
-        //			interface_ip.is_cache			 =
-        //false;
-        //			interface_ip.pure_cam            = false;
-        //			interface_ip.pure_ram            = true;
-        //			interface_ip.line_sz             = data;
-        //			interface_ip.cache_sz            =
-        //data*coredynp.globalCheckpoint;
-        //			interface_ip.assoc               = 1;
-        //			interface_ip.nbanks              = 1;
-        //			interface_ip.out_w               = out_w*8;
-        //			interface_ip.access_mode         = 0;
-        //			interface_ip.throughput          =
-        //1.0/clockRate;
-        //			interface_ip.latency             =
-        //1.0/clockRate;
-        //			interface_ip.obj_func_dyn_energy = 0;
-        //			interface_ip.obj_func_dyn_power  = 0;
-        //			interface_ip.obj_func_leak_power = 0;
-        //			interface_ip.obj_func_cycle_t    = 1;
-        //			interface_ip.num_rw_ports    = 1;//the extra one
-        //port is for GCs
-        //			interface_ip.num_rd_ports    =
-        //2*coredynp.decodeW;
-        //			interface_ip.num_wr_ports    = coredynp.decodeW;
-        //			interface_ip.num_se_rd_ports = 0;
-        //			iFRAT = new ArrayST(&interface_ip, "Int
-        //FrontRAT");
-        //			iFRAT->area.set_area(iFRAT->area.get_area()+
-        //iFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
-        //			area.set_area(area.get_area()+
-        //iFRAT->area.get_area());
-
-        // FRAT floating point
-        data = int(ceil(coredynp.phy_freg_width *
-                        (1 + coredynp.globalCheckpoint) / 8.0));
-        out_w = int(ceil(coredynp.phy_freg_width / 8.0));
-        interface_ip.is_cache = false;
-        interface_ip.pure_cam = false;
-        interface_ip.pure_ram = true;
-        interface_ip.line_sz = data;
-        interface_ip.cache_sz =
-            data * XML->sys.core[ithCore].archi_Regs_FRF_size;
-        interface_ip.assoc = 1;
-        interface_ip.nbanks = 1;
-        interface_ip.out_w = out_w * 8;
-        interface_ip.access_mode = 2;
-        interface_ip.throughput = 1.0 / clockRate;
-        interface_ip.latency = 1.0 / clockRate;
-        interface_ip.obj_func_dyn_energy = 0;
-        interface_ip.obj_func_dyn_power = 0;
-        interface_ip.obj_func_leak_power = 0;
-        interface_ip.obj_func_cycle_t = 1;
-        interface_ip.num_rw_ports = 1;  // the extra one port is for GCs
-        interface_ip.num_rd_ports = 2 * coredynp.fp_decodeW;
-        interface_ip.num_wr_ports = coredynp.fp_decodeW;
-        interface_ip.num_se_rd_ports = 0;
-        fFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device,
-                            coredynp.opt_local, coredynp.core_ty);
-        fFRAT->area.set_area(
-            fFRAT->area.get_area() +
-            fFRAT->local_result.area *
-                XML->sys.core[ithCore].number_hardware_threads);
-        area.set_area(area.get_area() + fFRAT->area.get_area());
-
-      } else if ((coredynp.rm_ty == CAMbased)) {
-        // FRAT
-        tag = coredynp.arch_ireg_width;
-        data = int(
-            ceil((coredynp.arch_ireg_width + 1 * coredynp.globalCheckpoint) /
-                 8.0));  // the address of CAM needed to be sent out
-        out_w = int(ceil(coredynp.arch_ireg_width / 8.0));
-        interface_ip.is_cache = true;
-        interface_ip.pure_cam = false;
-        interface_ip.pure_ram = false;
-        interface_ip.line_sz = data;
-        interface_ip.cache_sz = data * XML->sys.core[ithCore].phy_Regs_IRF_size;
-        interface_ip.assoc = 0;
-        interface_ip.nbanks = 1;
-        interface_ip.out_w = out_w * 8;
-        interface_ip.specific_tag = 1;
-        interface_ip.tag_w = tag;
-        interface_ip.access_mode = 2;
-        interface_ip.throughput = 1.0 / clockRate;
-        interface_ip.latency = 1.0 / clockRate;
-        interface_ip.obj_func_dyn_energy = 0;
-        interface_ip.obj_func_dyn_power = 0;
-        interface_ip.obj_func_leak_power = 0;
-        interface_ip.obj_func_cycle_t = 1;
-        interface_ip.num_rw_ports = 1;  // for GCs
-        interface_ip.num_rd_ports = coredynp.decodeW;
-        interface_ip.num_wr_ports = coredynp.decodeW;
-        interface_ip.num_se_rd_ports = 0;
-        interface_ip.num_search_ports = 2 * coredynp.decodeW;
-        iFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device,
-                            coredynp.opt_local, coredynp.core_ty);
-        iFRAT->area.set_area(
-            iFRAT->area.get_area() +
-            iFRAT->local_result.area *
-                XML->sys.core[ithCore].number_hardware_threads);
-        area.set_area(area.get_area() + iFRAT->area.get_area());
-
-        // FRAT for FP
-        tag = coredynp.arch_freg_width;
-        data = int(
-            ceil((coredynp.arch_freg_width + 1 * coredynp.globalCheckpoint) /
-                 8.0));  // the address of CAM needed to be sent out
-        out_w = int(ceil(coredynp.arch_freg_width / 8.0));
-        interface_ip.is_cache = true;
-        interface_ip.pure_cam = false;
-        interface_ip.pure_ram = false;
-        interface_ip.line_sz = data;
-        interface_ip.cache_sz = data * XML->sys.core[ithCore].phy_Regs_FRF_size;
-        interface_ip.assoc = 0;
-        interface_ip.nbanks = 1;
-        interface_ip.out_w = out_w * 8;
-        interface_ip.specific_tag = 1;
-        interface_ip.tag_w = tag;
-        interface_ip.access_mode = 2;
-        interface_ip.throughput = 1.0 / clockRate;
-        interface_ip.latency = 1.0 / clockRate;
-        interface_ip.obj_func_dyn_energy = 0;
-        interface_ip.obj_func_dyn_power = 0;
-        interface_ip.obj_func_leak_power = 0;
-        interface_ip.obj_func_cycle_t = 1;
-        interface_ip.num_rw_ports = 1;  // for GCs
-        interface_ip.num_rd_ports = coredynp.fp_decodeW;
-        interface_ip.num_wr_ports = coredynp.fp_decodeW;
-        interface_ip.num_se_rd_ports = 0;
-        interface_ip.num_search_ports = 2 * coredynp.fp_decodeW;
-        fFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device,
-                            coredynp.opt_local, coredynp.core_ty);
-        fFRAT->area.set_area(
-            fFRAT->area.get_area() +
-            fFRAT->local_result.area *
-                XML->sys.core[ithCore].number_hardware_threads);
-        area.set_area(area.get_area() + fFRAT->area.get_area());
-      }
-
-      // RRAT is always RAM based, does not have GCs, and is used only for
-      // record latest non-speculative mapping
-      data = int(ceil(coredynp.phy_ireg_width / 8.0));
-      interface_ip.is_cache = false;
-      interface_ip.pure_cam = false;
-      interface_ip.pure_ram = true;
-      interface_ip.line_sz = data;
-      interface_ip.cache_sz = data *
-                              XML->sys.core[ithCore].archi_Regs_IRF_size *
-                              2;  // HACK to make it as least 64B
-      interface_ip.assoc = 1;
-      interface_ip.nbanks = 1;
-      interface_ip.out_w = interface_ip.line_sz * 8;
-      interface_ip.access_mode = 1;
-      interface_ip.throughput = 1.0 / clockRate;
-      interface_ip.latency = 1.0 / clockRate;
-      interface_ip.obj_func_dyn_energy = 0;
-      interface_ip.obj_func_dyn_power = 0;
-      interface_ip.obj_func_leak_power = 0;
-      interface_ip.obj_func_cycle_t = 1;
-      interface_ip.num_rw_ports = 0;
-      interface_ip.num_rd_ports = XML->sys.core[ithCore].commit_width;
-      interface_ip.num_wr_ports = XML->sys.core[ithCore].commit_width;
-      interface_ip.num_se_rd_ports = 0;
-      iRRAT = new ArrayST(&interface_ip, "Int RetireRAT", Core_device,
-                          coredynp.opt_local, coredynp.core_ty);
-      iRRAT->area.set_area(iRRAT->area.get_area() +
-                           iRRAT->local_result.area *
-                               XML->sys.core[ithCore].number_hardware_threads);
-      area.set_area(area.get_area() + iRRAT->area.get_area());
-
-      // RRAT for FP
-      data = int(ceil(coredynp.phy_freg_width / 8.0));
-      interface_ip.is_cache = false;
-      interface_ip.pure_cam = false;
-      interface_ip.pure_ram = true;
-      interface_ip.line_sz = data;
-      interface_ip.cache_sz = data *
-                              XML->sys.core[ithCore].archi_Regs_FRF_size *
-                              2;  // HACK to make it as least 64B
-      interface_ip.assoc = 1;
-      interface_ip.nbanks = 1;
-      interface_ip.out_w = interface_ip.line_sz * 8;
-      interface_ip.access_mode = 1;
-      interface_ip.throughput = 1.0 / clockRate;
-      interface_ip.latency = 1.0 / clockRate;
-      interface_ip.obj_func_dyn_energy = 0;
-      interface_ip.obj_func_dyn_power = 0;
-      interface_ip.obj_func_leak_power = 0;
-      interface_ip.obj_func_cycle_t = 1;
-      interface_ip.num_rw_ports = 0;
-      interface_ip.num_rd_ports = coredynp.fp_decodeW;
-      interface_ip.num_wr_ports = coredynp.fp_decodeW;
-      interface_ip.num_se_rd_ports = 0;
-      fRRAT = new ArrayST(&interface_ip, "Int RetireRAT", Core_device,
-                          coredynp.opt_local, coredynp.core_ty);
-      fRRAT->area.set_area(fRRAT->area.get_area() +
-                           fRRAT->local_result.area *
-                               XML->sys.core[ithCore].number_hardware_threads);
-      area.set_area(area.get_area() + fRRAT->area.get_area());
-
-      // Freelist of renaming unit always RAM based
-      // Recycle happens at two places: 1)when DCL check there are WAW, the
-      // Phyregisters/ROB directly recycles into freelist
-      // 2)When instruction commits the Phyregisters/ROB needed to be recycled.
-      // therefore num_wr port = decode-1(-1 means at least one phy reg will be
-      // used for the current renaming group) + commit width
-      data = int(ceil(coredynp.phy_ireg_width / 8.0));
-      interface_ip.is_cache = false;
-      interface_ip.pure_cam = false;
-      interface_ip.pure_ram = true;
-      interface_ip.line_sz = data;
-      interface_ip.cache_sz = data * coredynp.num_ifreelist_entries;
-      interface_ip.assoc = 1;
-      interface_ip.nbanks = 1;
-      interface_ip.out_w = interface_ip.line_sz * 8;
-      interface_ip.access_mode = 1;
-      interface_ip.throughput = 1.0 / clockRate;
-      interface_ip.latency = 1.0 / clockRate;
-      interface_ip.obj_func_dyn_energy = 0;
-      interface_ip.obj_func_dyn_power = 0;
-      interface_ip.obj_func_leak_power = 0;
-      interface_ip.obj_func_cycle_t = 1;
-      interface_ip.num_rw_ports = 1;  // TODO
-      interface_ip.num_rd_ports = coredynp.decodeW;
-      interface_ip.num_wr_ports =
-          coredynp.decodeW - 1 + XML->sys.core[ithCore].commit_width;
-      // every cycle, (coredynp.decodeW -1) inst may need to send back it dest
-      // tags, committW insts needs to update freelist buffers
-      interface_ip.num_se_rd_ports = 0;
-      ifreeL = new ArrayST(&interface_ip, "Int Free List", Core_device,
-                           coredynp.opt_local, coredynp.core_ty);
-      ifreeL->area.set_area(ifreeL->area.get_area() +
-                            ifreeL->local_result.area *
-                                XML->sys.core[ithCore].number_hardware_threads);
-      area.set_area(area.get_area() + ifreeL->area.get_area());
-
-      // freelist for FP
-      data = int(ceil(coredynp.phy_freg_width / 8.0));
-      interface_ip.is_cache = false;
-      interface_ip.pure_cam = false;
-      interface_ip.pure_ram = true;
-      interface_ip.line_sz = data;
-      interface_ip.cache_sz = data * coredynp.num_ffreelist_entries;
-      interface_ip.assoc = 1;
-      interface_ip.nbanks = 1;
-      interface_ip.out_w = interface_ip.line_sz * 8;
-      interface_ip.access_mode = 1;
-      interface_ip.throughput = 1.0 / clockRate;
-      interface_ip.latency = 1.0 / clockRate;
-      interface_ip.obj_func_dyn_energy = 0;
-      interface_ip.obj_func_dyn_power = 0;
-      interface_ip.obj_func_leak_power = 0;
-      interface_ip.obj_func_cycle_t = 1;
-      interface_ip.num_rw_ports = 1;
-      interface_ip.num_rd_ports = coredynp.fp_decodeW;
-      interface_ip.num_wr_ports =
-          coredynp.fp_decodeW - 1 + XML->sys.core[ithCore].commit_width;
-      interface_ip.num_se_rd_ports = 0;
-      ffreeL = new ArrayST(&interface_ip, "Int Free List", Core_device,
-                           coredynp.opt_local, coredynp.core_ty);
-      ffreeL->area.set_area(ffreeL->area.get_area() +
-                            ffreeL->local_result.area *
-                                XML->sys.core[ithCore].number_hardware_threads);
-      area.set_area(area.get_area() + ffreeL->area.get_area());
-
-      idcl = new dep_resource_conflict_check(
-          &interface_ip, coredynp,
-          coredynp.phy_ireg_width);  // TODO:Separate 2 sections See TR
-      fdcl = new dep_resource_conflict_check(&interface_ip, coredynp,
-                                             coredynp.phy_freg_width);
-
-    } else if (coredynp.scheu_ty == ReservationStation) {
-      if (coredynp.rm_ty == RAMbased) {
-        /*
-         * however, RAT needs to do associative search in RAT, when instruction
-         * commits and ROB release the entry,
-         * to make sure all the renamings associated with the ROB to be released
-         * are updated to ARF at the same time.
-         * RAM based RAT for RS base OOO does not save the search operations.
-         * Its advantage is to have less entries than
-         * CAM based RAT so that it is more scalable as number of ROB/physical
-         * regs increases.
-         */
-        tag = coredynp.phy_ireg_width;
-        data = int(ceil(coredynp.phy_ireg_width *
-                        (1 + coredynp.globalCheckpoint) / 8.0));
-        out_w = int(ceil(coredynp.phy_ireg_width / 8.0));
-        interface_ip.is_cache = true;
-        interface_ip.pure_cam = false;
-        interface_ip.pure_ram = false;
-        interface_ip.line_sz = data;
-        interface_ip.cache_sz =
-            data * XML->sys.core[ithCore].archi_Regs_IRF_size;
-        interface_ip.assoc = 0;
-        interface_ip.nbanks = 1;
-        interface_ip.out_w = out_w * 8;
-        interface_ip.access_mode = 2;
-        interface_ip.throughput = 1.0 / clockRate;
-        interface_ip.latency = 1.0 / clockRate;
-        interface_ip.obj_func_dyn_energy = 0;
-        interface_ip.obj_func_dyn_power = 0;
-        interface_ip.obj_func_leak_power = 0;
-        interface_ip.obj_func_cycle_t = 1;
-        interface_ip.num_rw_ports = 1;  // the extra one port is for GCs
-        interface_ip.num_rd_ports = 2 * coredynp.decodeW;
-        interface_ip.num_wr_ports = coredynp.decodeW;
-        interface_ip.num_se_rd_ports = 0;
-        interface_ip.num_search_ports = coredynp.commitW;  // TODO
-        iFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device,
-                            coredynp.opt_local, coredynp.core_ty);
-        iFRAT->local_result.adjust_area();
-        iFRAT->area.set_area(
-            iFRAT->area.get_area() +
-            iFRAT->local_result.area *
-                XML->sys.core[ithCore].number_hardware_threads);
-        area.set_area(area.get_area() + iFRAT->area.get_area());
-
-        // FP
-        tag = coredynp.phy_freg_width;
-        data = int(ceil(coredynp.phy_freg_width *
-                        (1 + coredynp.globalCheckpoint) / 8.0));
-        out_w = int(ceil(coredynp.phy_freg_width / 8.0));
-        interface_ip.is_cache = true;
-        interface_ip.pure_cam = false;
-        interface_ip.pure_ram = false;
-        interface_ip.line_sz = data;
-        interface_ip.cache_sz =
-            data * XML->sys.core[ithCore].archi_Regs_FRF_size;
-        interface_ip.assoc = 0;
-        interface_ip.nbanks = 1;
-        interface_ip.out_w = out_w * 8;
-        interface_ip.access_mode = 2;
-        interface_ip.throughput = 1.0 / clockRate;
-        interface_ip.latency = 1.0 / clockRate;
-        interface_ip.obj_func_dyn_energy = 0;
-        interface_ip.obj_func_dyn_power = 0;
-        interface_ip.obj_func_leak_power = 0;
-        interface_ip.obj_func_cycle_t = 1;
-        interface_ip.num_rw_ports = 1;  // the extra one port is for GCs
-        interface_ip.num_rd_ports = 2 * coredynp.fp_decodeW;
-        interface_ip.num_wr_ports = coredynp.fp_decodeW;
-        interface_ip.num_se_rd_ports = 0;
-        interface_ip.num_search_ports =
-            coredynp.fp_decodeW;  // actually is fp commit width
-        fFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device,
-                            coredynp.opt_local, coredynp.core_ty);
-        fFRAT->local_result.adjust_area();
-        fFRAT->area.set_area(
-            fFRAT->area.get_area() +
-            fFRAT->local_result.area *
-                XML->sys.core[ithCore].number_hardware_threads);
-        area.set_area(area.get_area() + fFRAT->area.get_area());
-
-      } else if ((coredynp.rm_ty == CAMbased)) {
-        // FRAT
-        tag = coredynp.arch_ireg_width;
-        data = int(ceil(coredynp.arch_ireg_width +
-                        1 * coredynp.globalCheckpoint /
-                            8.0));  // the address of CAM needed to be sent out
-        out_w = int(ceil(coredynp.arch_ireg_width / 8.0));
-        interface_ip.is_cache = true;
-        interface_ip.pure_cam = false;
-        interface_ip.pure_ram = false;
-        interface_ip.line_sz = data;
-        interface_ip.cache_sz = data * XML->sys.core[ithCore].phy_Regs_IRF_size;
-        interface_ip.assoc = 0;
-        interface_ip.nbanks = 1;
-        interface_ip.out_w = out_w * 8;
-        interface_ip.specific_tag = 1;
-        interface_ip.tag_w = tag;
-        interface_ip.access_mode = 2;
-        interface_ip.throughput = 1.0 / clockRate;
-        interface_ip.latency = 1.0 / clockRate;
-        interface_ip.obj_func_dyn_energy = 0;
-        interface_ip.obj_func_dyn_power = 0;
-        interface_ip.obj_func_leak_power = 0;
-        interface_ip.obj_func_cycle_t = 1;
-        interface_ip.num_rw_ports = 1;  // for GCs
-        interface_ip.num_rd_ports =
-            XML->sys.core[ithCore].decode_width;  // 0;TODO
-        interface_ip.num_wr_ports = XML->sys.core[ithCore].decode_width;
-        interface_ip.num_se_rd_ports = 0;
-        interface_ip.num_search_ports = 2 * XML->sys.core[ithCore].decode_width;
-        iFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device,
-                            coredynp.opt_local, coredynp.core_ty);
-        iFRAT->area.set_area(
-            iFRAT->area.get_area() +
-            iFRAT->local_result.area *
-                XML->sys.core[ithCore].number_hardware_threads);
-        area.set_area(area.get_area() + iFRAT->area.get_area());
-
-        // FRAT
-        tag = coredynp.arch_freg_width;
-        data = int(ceil(coredynp.arch_freg_width +
-                        1 * coredynp.globalCheckpoint /
-                            8.0));  // the address of CAM needed to be sent out
-        out_w = int(ceil(coredynp.arch_freg_width / 8.0));
-        interface_ip.is_cache = true;
-        interface_ip.pure_cam = false;
-        interface_ip.pure_ram = false;
-        interface_ip.line_sz = data;
-        interface_ip.cache_sz = data * XML->sys.core[ithCore].phy_Regs_FRF_size;
-        interface_ip.assoc = 0;
-        interface_ip.nbanks = 1;
-        interface_ip.out_w = out_w * 8;
-        interface_ip.specific_tag = 1;
-        interface_ip.tag_w = tag;
-        interface_ip.access_mode = 2;
-        interface_ip.throughput = 1.0 / clockRate;
-        interface_ip.latency = 1.0 / clockRate;
-        interface_ip.obj_func_dyn_energy = 0;
-        interface_ip.obj_func_dyn_power = 0;
-        interface_ip.obj_func_leak_power = 0;
-        interface_ip.obj_func_cycle_t = 1;
-        interface_ip.num_rw_ports = 1;  // for GCs
-        interface_ip.num_rd_ports =
-            XML->sys.core[ithCore].decode_width;  // 0;TODO;
-        interface_ip.num_wr_ports = coredynp.fp_decodeW;
-        interface_ip.num_se_rd_ports = 0;
-        interface_ip.num_search_ports = 2 * coredynp.fp_decodeW;
-        fFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device,
-                            coredynp.opt_local, coredynp.core_ty);
-        fFRAT->area.set_area(
-            fFRAT->area.get_area() +
-            fFRAT->local_result.area *
-                XML->sys.core[ithCore].number_hardware_threads);
-        area.set_area(area.get_area() + fFRAT->area.get_area());
-      }
-      // No RRAT for RS based OOO
-      // Freelist of renaming unit of RS based OOO is unifed for both int and fp
-      // renaming unit since the ROB is unified
-      data = int(ceil(coredynp.phy_ireg_width / 8.0));
-      interface_ip.is_cache = false;
-      interface_ip.pure_cam = false;
-      interface_ip.pure_ram = true;
-      interface_ip.line_sz = data;
-      interface_ip.cache_sz = data * coredynp.num_ifreelist_entries;
-      interface_ip.assoc = 1;
-      interface_ip.nbanks = 1;
-      interface_ip.out_w = interface_ip.line_sz * 8;
-      interface_ip.access_mode = 1;
-      interface_ip.throughput = 1.0 / clockRate;
-      interface_ip.latency = 1.0 / clockRate;
-      interface_ip.obj_func_dyn_energy = 0;
-      interface_ip.obj_func_dyn_power = 0;
-      interface_ip.obj_func_leak_power = 0;
-      interface_ip.obj_func_cycle_t = 1;
-      interface_ip.num_rw_ports = 1;  // TODO
-      interface_ip.num_rd_ports = XML->sys.core[ithCore].decode_width;
-      interface_ip.num_wr_ports = XML->sys.core[ithCore].decode_width - 1 +
-                                  XML->sys.core[ithCore].commit_width;
-      interface_ip.num_se_rd_ports = 0;
-      ifreeL = new ArrayST(&interface_ip, "Unified Free List", Core_device,
-                           coredynp.opt_local, coredynp.core_ty);
-      ifreeL->area.set_area(ifreeL->area.get_area() +
-                            ifreeL->local_result.area *
-                                XML->sys.core[ithCore].number_hardware_threads);
-      area.set_area(area.get_area() + ifreeL->area.get_area());
-
-      idcl = new dep_resource_conflict_check(
-          &interface_ip, coredynp,
-          coredynp.phy_ireg_width);  // TODO:Separate 2 sections See TR
-      fdcl = new dep_resource_conflict_check(&interface_ip, coredynp,
-                                             coredynp.phy_freg_width);
+    if (coredynp.core_ty==Inorder&& coredynp.issueW>1)
+    {
+	  /* Dependency check logic will only present when decode(issue) width>1.
+	  *  Multiple issue in order processor can do without renaming, but dcl is a must.
+	  */
+	idcl  = new dep_resource_conflict_check(&interface_ip,coredynp,coredynp.phy_ireg_width);//TODO:Separate 2 sections See TR
+	fdcl  = new dep_resource_conflict_check(&interface_ip,coredynp,coredynp.phy_freg_width);
     }
-  }
-  if (coredynp.core_ty == Inorder && coredynp.issueW > 1) {
-    /* Dependency check logic will only present when decode(issue) width>1.
-    *  Multiple issue in order processor can do without renaming, but dcl is a
-    * must.
-    */
-    idcl = new dep_resource_conflict_check(
-        &interface_ip, coredynp,
-        coredynp.phy_ireg_width);  // TODO:Separate 2 sections See TR
-    fdcl = new dep_resource_conflict_check(&interface_ip, coredynp,
-                                           coredynp.phy_freg_width);
-  }
 }
 
 Core::Core(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_)
-    : XML(XML_interface),
-      ithCore(ithCore_),
-      interface_ip(*interface_ip_),
-      ifu(0),
-      lsu(0),
-      mmu(0),
-      exu(0),
-      rnu(0),
-      corepipe(0),
-      undiffCore(0),
-      l2cache(0) {
-  /**
-   * Testing: (to be removed) added by syed
-   */
-  // XML->sys.core[ithCore].simd_width=8;// (8)
-  // XML->sys.core[ithCore].collector_units=4;// (4)
-  // XML->sys.core[ithCore].core_clock_ratio=2.0;// (2.0)
-  // XML->sys.core[ithCore].warp_size=32;// (32)
-
+:XML(XML_interface),
+ ithCore(ithCore_),
+ interface_ip(*interface_ip_),
+ ifu  (0),
+ lsu  (0),
+ mmu  (0),
+ exu  (0),
+ rnu  (0),
+ corepipe (0),
+ undiffCore (0),
+ l2cache (0)
+{
+ /**
+  * Testing: (to be removed) added by syed
+  */
+  //XML->sys.core[ithCore].simd_width=8;// (8)
+  //XML->sys.core[ithCore].collector_units=4;// (4)
+  //XML->sys.core[ithCore].core_clock_ratio=2.0;// (2.0)
+  //XML->sys.core[ithCore].warp_size=32;// (32) 
+  
   /*
   * initialize, compute and optimize individual components.
   */
 
-  IdleCoreEnergy = 0;
-  IdlePower_PerCore = 0;
+	IdleCoreEnergy=0;
+	IdlePower_PerCore = 0;
   double pipeline_area_per_unit;
-  if (XML->sys.Private_L2) {
-    l2cache = new SharedCache(XML, ithCore, &interface_ip);
+  if (XML->sys.Private_L2)
+  {
+	  l2cache = new SharedCache(XML,ithCore, &interface_ip);
+
   }
-  //  interface_ip.wire_is_mat_type = 2;
-  //  interface_ip.wire_os_mat_type = 2;
-  //  interface_ip.wt               =Global_30;
+//  interface_ip.wire_is_mat_type = 2;
+//  interface_ip.wire_os_mat_type = 2;
+//  interface_ip.wt               =Global_30;
   set_core_param();
   clockRate = coredynp.clockRate;
-  exClockRate = clockRate * XML->sys.core[ithCore].core_clock_ratio;
+  exClockRate = clockRate*XML->sys.core[ithCore].core_clock_ratio;
 
   executionTime = coredynp.executionTime;
-  ifu = new InstFetchU(XML, ithCore, &interface_ip, coredynp);
-  lsu = new LoadStoreU(XML, ithCore, &interface_ip, coredynp);
-  mmu = new MemManU(XML, ithCore, &interface_ip, coredynp);
-  exu = new EXECU(XML, ithCore, &interface_ip, lsu->lsq_height, coredynp,
-                  exClockRate, true);
+  ifu          = new InstFetchU(XML, ithCore, &interface_ip,coredynp);
+  lsu          = new LoadStoreU(XML, ithCore, &interface_ip,coredynp);
+  mmu          = new MemManU   (XML, ithCore, &interface_ip,coredynp);
+  exu          = new EXECU     (XML, ithCore, &interface_ip,lsu->lsq_height, coredynp, exClockRate,true);
+  
 
-  undiffCore = new UndiffCore(XML, ithCore, &interface_ip, coredynp);
-  if (coredynp.core_ty == OOO) {
-    rnu = new RENAMINGU(XML, ithCore, &interface_ip, coredynp);
+
+
+
+  undiffCore   = new UndiffCore(XML, ithCore, &interface_ip,coredynp);
+  if (coredynp.core_ty==OOO)
+  {
+	  rnu = new RENAMINGU(XML, ithCore, &interface_ip,coredynp);
   }
-  corepipe = new Pipeline(&interface_ip, coredynp);
+  corepipe = new Pipeline(&interface_ip,coredynp);
 
-  if (coredynp.core_ty == OOO) {
-    pipeline_area_per_unit =
-        (corepipe->area.get_area() * coredynp.num_pipelines) / 5.0;
-    if (rnu->exist) {
-      rnu->area.set_area(rnu->area.get_area() + pipeline_area_per_unit);
-    }
-  } else {
-    pipeline_area_per_unit =
-        (corepipe->area.get_area() * coredynp.num_pipelines) / 4.0;
+  if (coredynp.core_ty==OOO)
+  {
+	  pipeline_area_per_unit    = (corepipe->area.get_area()*coredynp.num_pipelines)/5.0;
+	  if (rnu->exist)
+	  {
+		  rnu->area.set_area(rnu->area.get_area() + pipeline_area_per_unit);
+	  }
   }
-
-  // area.set_area(area.get_area()+ corepipe->area.get_area());
-  if (ifu->exist) {
-    ifu->area.set_area(ifu->area.get_area() + pipeline_area_per_unit);
-    area.set_area(area.get_area() + ifu->area.get_area());
-  }
-  if (lsu->exist) {
-    lsu->area.set_area(lsu->area.get_area() + pipeline_area_per_unit);
-    area.set_area(area.get_area() + lsu->area.get_area());
-  }
-  if (exu->exist) {
-    exu->area.set_area(exu->area.get_area() + pipeline_area_per_unit);
-    area.set_area(area.get_area() + exu->area.get_area());
-  }
-  if (mmu->exist) {
-    mmu->area.set_area(mmu->area.get_area() + pipeline_area_per_unit);
-    area.set_area(area.get_area() + mmu->area.get_area());
-  }
-
-  if (coredynp.core_ty == OOO) {
-    if (rnu->exist) {
-      area.set_area(area.get_area() + rnu->area.get_area());
-    }
-  }
-
-  if (undiffCore->exist) {
-    area.set_area(area.get_area() + undiffCore->area.get_area());
-  }
-
-  if (XML->sys.Private_L2) {
-    area.set_area(area.get_area() + l2cache->area.get_area());
-  }
-  //  //clock power
-  //  clockNetwork.init_wire_external(is_default, &interface_ip);
-  //  clockNetwork.clk_area           =area*1.1;//10% of placement overhead.
-  //  rule of thumb
-  //  clockNetwork.end_wiring_level   =5;//toplevel metal
-  //  clockNetwork.start_wiring_level =5;//toplevel metal
-  //  clockNetwork.num_regs           = corepipe.tot_stage_vector;
-  //  clockNetwork.optimize_wire();
-}
-
-void BranchPredictor::computeEnergy(bool is_tdp) {
-  if (!exist) return;
-  double r_access;
-  double w_access;
-  if (is_tdp) {
-    r_access = coredynp.predictionW * coredynp.BR_duty_cycle;
-    w_access = 0 * coredynp.BR_duty_cycle;
-    globalBPT->stats_t.readAc.access = r_access;
-    globalBPT->stats_t.writeAc.access = w_access;
-    globalBPT->tdp_stats = globalBPT->stats_t;
-
-    L1_localBPT->stats_t.readAc.access = r_access;
-    L1_localBPT->stats_t.writeAc.access = w_access;
-    L1_localBPT->tdp_stats = L1_localBPT->stats_t;
-
-    L2_localBPT->stats_t.readAc.access = r_access;
-    L2_localBPT->stats_t.writeAc.access = w_access;
-    L2_localBPT->tdp_stats = L2_localBPT->stats_t;
-
-    chooser->stats_t.readAc.access = r_access;
-    chooser->stats_t.writeAc.access = w_access;
-    chooser->tdp_stats = chooser->stats_t;
-
-    RAS->stats_t.readAc.access = r_access;
-    RAS->stats_t.writeAc.access = w_access;
-    RAS->tdp_stats = RAS->stats_t;
-  } else {
-    // The resolution of BPT accesses is coarse, but this is
-    // because most simulators cannot track finer grained details
-    r_access = XML->sys.core[ithCore].branch_instructions;
-    w_access =
-        XML->sys.core[ithCore].branch_mispredictions +
-        0.1 *
-            XML->sys.core[ithCore]
-                .branch_instructions;  // 10% of BR will flip internal bits//0
-    globalBPT->stats_t.readAc.access = r_access;
-    globalBPT->stats_t.writeAc.access = w_access;
-    globalBPT->rtp_stats = globalBPT->stats_t;
-
-    L1_localBPT->stats_t.readAc.access = r_access;
-    L1_localBPT->stats_t.writeAc.access = w_access;
-    L1_localBPT->rtp_stats = L1_localBPT->stats_t;
-
-    L2_localBPT->stats_t.readAc.access = r_access;
-    L2_localBPT->stats_t.writeAc.access = w_access;
-    L2_localBPT->rtp_stats = L2_localBPT->stats_t;
-
-    chooser->stats_t.readAc.access = r_access;
-    chooser->stats_t.writeAc.access = w_access;
-    chooser->rtp_stats = chooser->stats_t;
-
-    RAS->stats_t.readAc.access = XML->sys.core[ithCore].function_calls;
-    RAS->stats_t.writeAc.access = XML->sys.core[ithCore].function_calls;
-    RAS->rtp_stats = RAS->stats_t;
-  }
-
-  globalBPT->power_t.reset();
-  L1_localBPT->power_t.reset();
-  L2_localBPT->power_t.reset();
-  chooser->power_t.reset();
-  RAS->power_t.reset();
-
-  globalBPT->power_t.readOp.dynamic +=
-      globalBPT->local_result.power.readOp.dynamic *
-          globalBPT->stats_t.readAc.access +
-      globalBPT->stats_t.writeAc.access *
-          globalBPT->local_result.power.writeOp.dynamic;
-  L1_localBPT->power_t.readOp.dynamic +=
-      L1_localBPT->local_result.power.readOp.dynamic *
-          L1_localBPT->stats_t.readAc.access +
-      L1_localBPT->stats_t.writeAc.access *
-          L1_localBPT->local_result.power.writeOp.dynamic;
-
-  L2_localBPT->power_t.readOp.dynamic +=
-      L2_localBPT->local_result.power.readOp.dynamic *
-          L2_localBPT->stats_t.readAc.access +
-      L2_localBPT->stats_t.writeAc.access *
-          L2_localBPT->local_result.power.writeOp.dynamic;
-
-  chooser->power_t.readOp.dynamic +=
-      chooser->local_result.power.readOp.dynamic *
-          chooser->stats_t.readAc.access +
-      chooser->stats_t.writeAc.access *
-          chooser->local_result.power.writeOp.dynamic;
-  RAS->power_t.readOp.dynamic +=
-      RAS->local_result.power.readOp.dynamic * RAS->stats_t.readAc.access +
-      RAS->stats_t.writeAc.access * RAS->local_result.power.writeOp.dynamic;
-
-  if (is_tdp) {
-    globalBPT->power =
-        globalBPT->power_t + globalBPT->local_result.power * pppm_lkg;
-    L1_localBPT->power =
-        L1_localBPT->power_t + L1_localBPT->local_result.power * pppm_lkg;
-    L2_localBPT->power =
-        L2_localBPT->power_t + L2_localBPT->local_result.power * pppm_lkg;
-    chooser->power = chooser->power_t + chooser->local_result.power * pppm_lkg;
-    RAS->power =
-        RAS->power_t + RAS->local_result.power * coredynp.pppm_lkg_multhread;
-
-    power = power + globalBPT->power + L1_localBPT->power + chooser->power +
-            RAS->power;
-  } else {
-    globalBPT->rt_power =
-        globalBPT->power_t + globalBPT->local_result.power * pppm_lkg;
-    L1_localBPT->rt_power =
-        L1_localBPT->power_t + L1_localBPT->local_result.power * pppm_lkg;
-    L2_localBPT->rt_power =
-        L2_localBPT->power_t + L2_localBPT->local_result.power * pppm_lkg;
-    chooser->rt_power =
-        chooser->power_t + chooser->local_result.power * pppm_lkg;
-    RAS->rt_power =
-        RAS->power_t + RAS->local_result.power * coredynp.pppm_lkg_multhread;
-    rt_power = rt_power + globalBPT->rt_power + L1_localBPT->rt_power +
-               chooser->rt_power + RAS->rt_power;
-  }
-}
-
-void BranchPredictor::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
-  if (!exist) return;
-  string indent_str(indent, ' ');
-  string indent_str_next(indent + 2, ' ');
-  bool long_channel = XML->sys.longer_channel_device;
-  if (is_tdp) {
-    cout << indent_str << "Global Predictor:" << endl;
-    cout << indent_str_next << "Area = " << globalBPT->area.get_area() * 1e-6
-         << " mm^2" << endl;
-    cout << indent_str_next
-         << "Peak Dynamic = " << globalBPT->power.readOp.dynamic * clockRate
-         << " W" << endl;
-    cout << indent_str_next << "Subthreshold Leakage = "
-         << (long_channel ? globalBPT->power.readOp.longer_channel_leakage
-                          : globalBPT->power.readOp.leakage)
-         << " W" << endl;
-    cout << indent_str_next
-         << "Gate Leakage = " << globalBPT->power.readOp.gate_leakage << " W"
-         << endl;
-    cout << indent_str_next << "Runtime Dynamic = "
-         << globalBPT->rt_power.readOp.dynamic / executionTime << " W" << endl;
-    cout << endl;
-    cout << indent_str << "Local Predictor:" << endl;
-    cout << indent_str << "L1_Local Predictor:" << endl;
-    cout << indent_str_next << "Area = " << L1_localBPT->area.get_area() * 1e-6
-         << " mm^2" << endl;
-    cout << indent_str_next
-         << "Peak Dynamic = " << L1_localBPT->power.readOp.dynamic * clockRate
-         << " W" << endl;
-    cout << indent_str_next << "Subthreshold Leakage = "
-         << (long_channel ? L1_localBPT->power.readOp.longer_channel_leakage
-                          : L1_localBPT->power.readOp.leakage)
-         << " W" << endl;
-    cout << indent_str_next
-         << "Gate Leakage = " << L1_localBPT->power.readOp.gate_leakage << " W"
-         << endl;
-    cout << indent_str_next << "Runtime Dynamic = "
-         << L1_localBPT->rt_power.readOp.dynamic / executionTime << " W"
-         << endl;
-    cout << endl;
-    cout << indent_str << "L2_Local Predictor:" << endl;
-    cout << indent_str_next << "Area = " << L2_localBPT->area.get_area() * 1e-6
-         << " mm^2" << endl;
-    cout << indent_str_next
-         << "Peak Dynamic = " << L2_localBPT->power.readOp.dynamic * clockRate
-         << " W" << endl;
-    cout << indent_str_next << "Subthreshold Leakage = "
-         << (long_channel ? L2_localBPT->power.readOp.longer_channel_leakage
-                          : L2_localBPT->power.readOp.leakage)
-         << " W" << endl;
-    cout << indent_str_next
-         << "Gate Leakage = " << L2_localBPT->power.readOp.gate_leakage << " W"
-         << endl;
-    cout << indent_str_next << "Runtime Dynamic = "
-         << L2_localBPT->rt_power.readOp.dynamic / executionTime << " W"
-         << endl;
-    cout << endl;
-
-    cout << indent_str << "Chooser:" << endl;
-    cout << indent_str_next << "Area = " << chooser->area.get_area() * 1e-6
-         << " mm^2" << endl;
-    cout << indent_str_next
-         << "Peak Dynamic = " << chooser->power.readOp.dynamic * clockRate
-         << " W" << endl;
-    cout << indent_str_next << "Subthreshold Leakage = "
-         << (long_channel ? chooser->power.readOp.longer_channel_leakage
-                          : chooser->power.readOp.leakage)
-         << " W" << endl;
-    cout << indent_str_next
-         << "Gate Leakage = " << chooser->power.readOp.gate_leakage << " W"
-         << endl;
-    cout << indent_str_next << "Runtime Dynamic = "
-         << chooser->rt_power.readOp.dynamic / executionTime << " W" << endl;
-    cout << endl;
-    cout << indent_str << "RAS:" << endl;
-    cout << indent_str_next << "Area = " << RAS->area.get_area() * 1e-6
-         << " mm^2" << endl;
-    cout << indent_str_next
-         << "Peak Dynamic = " << RAS->power.readOp.dynamic * clockRate << " W"
-         << endl;
-    cout << indent_str_next << "Subthreshold Leakage = "
-         << (long_channel ? RAS->power.readOp.longer_channel_leakage
-                          : RAS->power.readOp.leakage)
-         << " W" << endl;
-    cout << indent_str_next
-         << "Gate Leakage = " << RAS->power.readOp.gate_leakage << " W" << endl;
-    cout << indent_str_next
-         << "Runtime Dynamic = " << RAS->rt_power.readOp.dynamic / executionTime
-         << " W" << endl;
-    cout << endl;
-  } else {
-    //		cout << indent_str_next << "Global Predictor    Peak Dynamic = " <<
-    //globalBPT->rt_power.readOp.dynamic*clockRate << " W" << endl;
-    //		cout << indent_str_next << "Global Predictor    Subthreshold Leakage =
-    //" << globalBPT->rt_power.readOp.leakage <<" W" << endl;
-    //		cout << indent_str_next << "Global Predictor    Gate Leakage = " <<
-    //globalBPT->rt_power.readOp.gate_leakage << " W" << endl;
-    //		cout << indent_str_next << "Local Predictor   Peak Dynamic = " <<
-    //L1_localBPT->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Local Predictor   Subthreshold Leakage = "
-    //<< L1_localBPT->rt_power.readOp.leakage  << " W" << endl;
-    //		cout << indent_str_next << "Local Predictor   Gate Leakage = " <<
-    //L1_localBPT->rt_power.readOp.gate_leakage  << " W" << endl;
-    //		cout << indent_str_next << "Chooser   Peak Dynamic = " <<
-    //chooser->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Chooser   Subthreshold Leakage = " <<
-    //chooser->rt_power.readOp.leakage  << " W" << endl;
-    //		cout << indent_str_next << "Chooser   Gate Leakage = " <<
-    //chooser->rt_power.readOp.gate_leakage  << " W" << endl;
-    //		cout << indent_str_next << "RAS   Peak Dynamic = " <<
-    //RAS->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "RAS   Subthreshold Leakage = " <<
-    //RAS->rt_power.readOp.leakage  << " W" << endl;
-    //		cout << indent_str_next << "RAS   Gate Leakage = " <<
-    //RAS->rt_power.readOp.gate_leakage  << " W" << endl;
-  }
-}
-
-void InstFetchU::computeEnergy(bool is_tdp) {
-  executionTime =
-      XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);  // Syed
-  // cout <<"IFU: execution time:
-  // "<<XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6)<<endl;
-  // cout <<"IFU: total cycles"<<XML->sys.total_cycles<<endl;
-  if (!exist) return;
-  if (is_tdp) {
-    // init stats for Peak
-    icache.caches->stats_t.readAc.access =
-        icache.caches->l_ip.num_rw_ports * coredynp.IFU_duty_cycle;
-    icache.caches->stats_t.readAc.miss = 0;
-    icache.caches->stats_t.readAc.hit = icache.caches->stats_t.readAc.access -
-                                        icache.caches->stats_t.readAc.miss;
-    icache.caches->tdp_stats = icache.caches->stats_t;
-
-    icache.missb->stats_t.readAc.access = icache.missb->stats_t.readAc.hit =
-        icache.missb->l_ip.num_search_ports;
-    icache.missb->stats_t.writeAc.access = icache.missb->stats_t.writeAc.hit =
-        icache.missb->l_ip.num_search_ports;
-    icache.missb->tdp_stats = icache.missb->stats_t;
-
-    icache.ifb->stats_t.readAc.access = icache.ifb->stats_t.readAc.hit =
-        icache.ifb->l_ip.num_search_ports;
-    icache.ifb->stats_t.writeAc.access = icache.ifb->stats_t.writeAc.hit =
-        icache.ifb->l_ip.num_search_ports;
-    icache.ifb->tdp_stats = icache.ifb->stats_t;
-
-    icache.prefetchb->stats_t.readAc.access =
-        icache.prefetchb->stats_t.readAc.hit =
-            icache.prefetchb->l_ip.num_search_ports;
-    icache.prefetchb->stats_t.writeAc.access = icache.ifb->stats_t.writeAc.hit =
-        icache.ifb->l_ip.num_search_ports;
-    icache.prefetchb->tdp_stats = icache.prefetchb->stats_t;
-
-    IB->stats_t.readAc.access = IB->stats_t.writeAc.access =
-        XML->sys.core[ithCore].peak_issue_width;
-    IB->tdp_stats = IB->stats_t;
-
-    if (coredynp.predictionW > 0) {
-      BTB->stats_t.readAc.access =
-          coredynp.predictionW;  // XML->sys.core[ithCore].BTB.read_accesses;
-      BTB->stats_t.writeAc.access =
-          0;  // XML->sys.core[ithCore].BTB.write_accesses;
-    }
-
-    ID_inst->stats_t.readAc.access = coredynp.decodeW;
-    ID_operand->stats_t.readAc.access = coredynp.decodeW;
-    ID_misc->stats_t.readAc.access = coredynp.decodeW;
-    ID_inst->tdp_stats = ID_inst->stats_t;
-    ID_operand->tdp_stats = ID_operand->stats_t;
-    ID_misc->tdp_stats = ID_misc->stats_t;
-
-  } /* if (is_tdp) */
   else {
-    rt_power.reset();
-    icache.rt_power.reset();  // Jingwen
-    // init stats for Runtime Dynamic (RTP)
-    // cout<< "****>>>>Icache stats:"<<endl;
-    // cout<<"Read accesses: "<< XML->sys.core[ithCore].icache.read_accesses <<
-    // " Read misses: "<<XML->sys.core[ithCore].icache.read_misses<<endl;
-    icache.caches->stats_t.readAc.access =
-        XML->sys.core[ithCore].icache.read_accesses;
-    icache.caches->stats_t.readAc.miss =
-        XML->sys.core[ithCore].icache.read_misses;
-    // cout<<endl<<"inside mcpat read access=
-    // "<<XML->sys.core[ithCore].icache.read_accesses;
-    // cout<<endl<<"inside mcpat read miss=
-    // "<<XML->sys.core[ithCore].icache.read_misses;
-
-    icache.caches->stats_t.readAc.hit = icache.caches->stats_t.readAc.access -
-                                        icache.caches->stats_t.readAc.miss;
-    icache.caches->rtp_stats = icache.caches->stats_t;
-    // cout<<endl<<"inside mcpat read hit=
-    // "<<icache.caches->stats_t.readAc.hit<<endl;
-    icache.missb->stats_t.readAc.access = icache.caches->stats_t.readAc.miss;
-    icache.missb->stats_t.writeAc.access = icache.caches->stats_t.readAc.miss;
-    icache.missb->rtp_stats = icache.missb->stats_t;
-
-    icache.ifb->stats_t.readAc.access = icache.caches->stats_t.readAc.miss;
-    icache.ifb->stats_t.writeAc.access = icache.caches->stats_t.readAc.miss;
-    icache.ifb->rtp_stats = icache.ifb->stats_t;
-
-    icache.prefetchb->stats_t.readAc.access =
-        icache.caches->stats_t.readAc.miss;
-    icache.prefetchb->stats_t.writeAc.access =
-        icache.caches->stats_t.readAc.miss;
-    icache.prefetchb->rtp_stats = icache.prefetchb->stats_t;
-
-    IB->stats_t.readAc.access = IB->stats_t.writeAc.access =
-        XML->sys.core[ithCore].total_instructions;
-    IB->rtp_stats = IB->stats_t;
-    // cout<<"IB: total instructions: "<<IB->stats_t.readAc.access <<endl;
-    if (coredynp.predictionW > 0) {
-      BTB->stats_t.readAc.access =
-          XML->sys.core[ithCore]
-              .BTB
-              .read_accesses;  // XML->sys.core[ithCore].branch_instructions;
-      BTB->stats_t.writeAc.access =
-          XML->sys.core[ithCore]
-              .BTB
-              .write_accesses;  // XML->sys.core[ithCore].branch_mispredictions;
-      BTB->rtp_stats = BTB->stats_t;
-    }
-    // cout<<"ID: total instructions: "<<
-    // XML->sys.core[ithCore].total_instructions<<endl;
-    ID_inst->stats_t.readAc.access = XML->sys.core[ithCore].total_instructions;
-    ID_operand->stats_t.readAc.access =
-        XML->sys.core[ithCore].total_instructions;
-    ID_misc->stats_t.readAc.access = XML->sys.core[ithCore].total_instructions;
-    ID_inst->rtp_stats = ID_inst->stats_t;
-    ID_operand->rtp_stats = ID_operand->stats_t;
-    ID_misc->rtp_stats = ID_misc->stats_t;
+	  pipeline_area_per_unit    = (corepipe->area.get_area()*coredynp.num_pipelines)/4.0;
   }
 
-  icache.power_t.reset();
-  IB->power_t.reset();
-  //	ID_inst->power_t.reset();
-  //	ID_operand->power_t.reset();
-  //	ID_misc->power_t.reset();
-  if (coredynp.predictionW > 0) {
-    BTB->power_t.reset();
+  //area.set_area(area.get_area()+ corepipe->area.get_area());
+  if (ifu->exist)
+  {
+	  ifu->area.set_area(ifu->area.get_area() + pipeline_area_per_unit);
+	  area.set_area(area.get_area() + ifu->area.get_area());
+  }
+  if (lsu->exist)
+  {
+	  lsu->area.set_area(lsu->area.get_area() + pipeline_area_per_unit);
+      area.set_area(area.get_area() + lsu->area.get_area());
+  }
+  if (exu->exist)
+  {
+	  exu->area.set_area(exu->area.get_area() + pipeline_area_per_unit);
+	  area.set_area(area.get_area()+exu->area.get_area());
+  }
+  if (mmu->exist)
+  {
+	  mmu->area.set_area(mmu->area.get_area() + pipeline_area_per_unit);
+      area.set_area(area.get_area()+mmu->area.get_area());
   }
 
-  icache.power_t.readOp.dynamic +=
-      (icache.caches->stats_t.readAc.hit *
-           icache.caches->local_result.power.readOp.dynamic +
-       // icache.caches->stats_t.readAc.miss*icache.caches->local_result.tag_array2->power.readOp.dynamic+
-       icache.caches->stats_t.readAc.miss *
-           icache.caches->local_result.power.readOp
-               .dynamic +  // assume tag data accessed in parallel
-       icache.caches->stats_t.readAc.miss *
-           icache.caches->local_result.power.writeOp
-               .dynamic);  // read miss in Icache cause a write to Icache
-  icache.power_t.readOp.dynamic +=
-      icache.missb->stats_t.readAc.access *
-          icache.missb->local_result.power.searchOp.dynamic +
-      icache.missb->stats_t.writeAc.access *
-          icache.missb->local_result.power.writeOp
-              .dynamic;  // each access to missb involves a CAM and a write
-  icache.power_t.readOp.dynamic +=
-      icache.ifb->stats_t.readAc.access *
-          icache.ifb->local_result.power.searchOp.dynamic +
-      icache.ifb->stats_t.writeAc.access *
-          icache.ifb->local_result.power.writeOp.dynamic;
-  icache.power_t.readOp.dynamic +=
-      icache.prefetchb->stats_t.readAc.access *
-          icache.prefetchb->local_result.power.searchOp.dynamic +
-      icache.prefetchb->stats_t.writeAc.access *
-          icache.prefetchb->local_result.power.writeOp.dynamic;
-  // cout<<"Icache power: "<<icache.power_t.readOp.dynamic	<<endl;
-  IB->power_t.readOp.dynamic +=
-      IB->local_result.power.readOp.dynamic * IB->stats_t.readAc.access +
-      IB->stats_t.writeAc.access * IB->local_result.power.writeOp.dynamic;
-  // cout << "IB power: "<<IB->power_t.readOp.dynamic<<endl;
-  if (coredynp.predictionW > 0) {
-    BTB->power_t.readOp.dynamic +=
-        BTB->local_result.power.readOp.dynamic * BTB->stats_t.readAc.access +
-        BTB->stats_t.writeAc.access * BTB->local_result.power.writeOp.dynamic;
+  if (coredynp.core_ty==OOO)
+  {
+	  if (rnu->exist)
+	  {
 
-    BPT->computeEnergy(is_tdp);
+		  area.set_area(area.get_area() + rnu->area.get_area());
+	  }
   }
 
-  if (is_tdp) {
-    //    	icache.power = icache.power_t +
-    //    	        (icache.caches->local_result.power)*pppm_lkg +
-    //    			(icache.missb->local_result.power +
-    //    			icache.ifb->local_result.power +
-    //    			icache.prefetchb->local_result.power)*pppm_Isub;
-    icache.power =
-        icache.power_t +
-        (icache.caches->local_result.power + icache.missb->local_result.power +
-         icache.ifb->local_result.power +
-         icache.prefetchb->local_result.power) *
-            pppm_lkg;
-
-    IB->power = IB->power_t + IB->local_result.power * pppm_lkg;
-    power = power + icache.power + IB->power;
-    if (coredynp.predictionW > 0) {
-      BTB->power = BTB->power_t + BTB->local_result.power * pppm_lkg;
-      power = power + BTB->power + BPT->power;
-    }
-
-    ID_inst->power_t.readOp.dynamic = ID_inst->power.readOp.dynamic;
-    ID_operand->power_t.readOp.dynamic = ID_operand->power.readOp.dynamic;
-    ID_misc->power_t.readOp.dynamic = ID_misc->power.readOp.dynamic;
-
-    ID_inst->power.readOp.dynamic *= ID_inst->tdp_stats.readAc.access;
-    ID_operand->power.readOp.dynamic *= ID_operand->tdp_stats.readAc.access;
-    ID_misc->power.readOp.dynamic *= ID_misc->tdp_stats.readAc.access;
-
-    power = power + (ID_inst->power + ID_operand->power + ID_misc->power);
-  } /* if (is_tdp) */
-  else {
-    //    	icache.rt_power = icache.power_t +
-    //    	        (icache.caches->local_result.power)*pppm_lkg +
-    //    			(icache.missb->local_result.power +
-    //    			icache.ifb->local_result.power +
-    //    			icache.prefetchb->local_result.power)*pppm_Isub;
-
-    icache.rt_power =
-        icache.power_t +
-        (icache.caches->local_result.power + icache.missb->local_result.power +
-         icache.ifb->local_result.power +
-         icache.prefetchb->local_result.power) *
-            pppm_lkg;
-
-    // IB->rt_power = IB->power_t + IB->local_result.power*pppm_lkg;
-    IB->rt_power.readOp.dynamic =
-        IB->local_result.power.readOp.dynamic * IB->rtp_stats.readAc.access;
-    IB->rt_power.readOp.dynamic +=
-        IB->local_result.power.writeOp.dynamic * IB->rtp_stats.writeAc.access;
-    rt_power = rt_power + icache.rt_power + IB->rt_power;
-    if (coredynp.predictionW > 0) {
-      BTB->rt_power = BTB->power_t + BTB->local_result.power * pppm_lkg;
-      rt_power = rt_power + BTB->rt_power + BPT->rt_power;
-    }
-
-    ID_inst->rt_power.readOp.dynamic =
-        ID_inst->power_t.readOp.dynamic * ID_inst->rtp_stats.readAc.access;
-    ID_operand->rt_power.readOp.dynamic = ID_operand->power_t.readOp.dynamic *
-                                          ID_operand->rtp_stats.readAc.access;
-    ID_misc->rt_power.readOp.dynamic =
-        ID_misc->power_t.readOp.dynamic * ID_misc->rtp_stats.readAc.access;
-
-    rt_power = rt_power +
-               (ID_inst->rt_power + ID_operand->rt_power + ID_misc->rt_power);
-    // cout<<"ID inst: "<<ID_inst->rt_power.readOp.dynamic << " ID operand:
-    // "<<ID_operand->rt_power.readOp.dynamic<<" ID misc:
-    // "<<ID_misc->rt_power.readOp.dynamic<<endl;
+  if (undiffCore->exist)
+  {
+	  area.set_area(area.get_area() + undiffCore->area.get_area());
   }
+
+  if (XML->sys.Private_L2)
+  {
+	  area.set_area(area.get_area() + l2cache->area.get_area());
+
+  }
+//  //clock power
+//  clockNetwork.init_wire_external(is_default, &interface_ip);
+//  clockNetwork.clk_area           =area*1.1;//10% of placement overhead. rule of thumb
+//  clockNetwork.end_wiring_level   =5;//toplevel metal
+//  clockNetwork.start_wiring_level =5;//toplevel metal
+//  clockNetwork.num_regs           = corepipe.tot_stage_vector;
+//  clockNetwork.optimize_wire();
 }
 
-void InstFetchU::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
-  if (!exist) return;
-  string indent_str(indent, ' ');
-  string indent_str_next(indent + 2, ' ');
-  bool long_channel = XML->sys.longer_channel_device;
 
-  if (is_tdp) {
-    cout << indent_str << "Instruction Cache:" << endl;
-    cout << indent_str_next << "Area = " << icache.area.get_area() * 1e-6
-         << " mm^2" << endl;
-    cout << indent_str_next
-         << "Peak Dynamic = " << icache.power.readOp.dynamic * clockRate << " W"
-         << endl;
-    cout << indent_str_next << "Subthreshold Leakage = "
-         << (long_channel ? icache.power.readOp.longer_channel_leakage
-                          : icache.power.readOp.leakage)
-         << " W" << endl;
-    cout << indent_str_next
-         << "Gate Leakage = " << icache.power.readOp.gate_leakage << " W"
-         << endl;
-    cout << indent_str_next << "Runtime Dynamic = "
-         << icache.rt_power.readOp.dynamic / executionTime << " W" << endl;
-    cout << endl;
-    if (coredynp.predictionW > 0) {
-      cout << indent_str << "Branch Target Buffer:" << endl;
-      cout << indent_str_next << "Area = " << BTB->area.get_area() * 1e-6
-           << " mm^2" << endl;
-      cout << indent_str_next
-           << "Peak Dynamic = " << BTB->power.readOp.dynamic * clockRate << " W"
-           << endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel ? BTB->power.readOp.longer_channel_leakage
-                            : BTB->power.readOp.leakage)
-           << " W" << endl;
-      cout << indent_str_next
-           << "Gate Leakage = " << BTB->power.readOp.gate_leakage << " W"
-           << endl;
-      cout << indent_str_next << "Runtime Dynamic = "
-           << BTB->rt_power.readOp.dynamic / executionTime << " W" << endl;
-      cout << endl;
-      if (BPT->exist) {
-        cout << indent_str << "Branch Predictor:" << endl;
-        cout << indent_str_next << "Area = " << BPT->area.get_area() * 1e-6
-             << " mm^2" << endl;
-        cout << indent_str_next
-             << "Peak Dynamic = " << BPT->power.readOp.dynamic * clockRate
-             << " W" << endl;
-        cout << indent_str_next << "Subthreshold Leakage = "
-             << (long_channel ? BPT->power.readOp.longer_channel_leakage
-                              : BPT->power.readOp.leakage)
-             << " W" << endl;
-        cout << indent_str_next
-             << "Gate Leakage = " << BPT->power.readOp.gate_leakage << " W"
-             << endl;
-        cout << indent_str_next << "Runtime Dynamic = "
-             << BPT->rt_power.readOp.dynamic / executionTime << " W" << endl;
-        cout << endl;
-        if (plevel > 3) {
-          BPT->displayEnergy(indent + 4, plevel, is_tdp);
-        }
-      }
-    }
-    cout << indent_str << "Instruction Buffer:" << endl;
-    cout << indent_str_next << "Area = " << IB->area.get_area() * 1e-6
-         << " mm^2" << endl;
-    cout << indent_str_next
-         << "Peak Dynamic = " << IB->power.readOp.dynamic * clockRate << " W"
-         << endl;
-    cout << indent_str_next << "Subthreshold Leakage = "
-         << (long_channel ? IB->power.readOp.longer_channel_leakage
-                          : IB->power.readOp.leakage)
-         << " W" << endl;
-    cout << indent_str_next
-         << "Gate Leakage = " << IB->power.readOp.gate_leakage << " W" << endl;
-    cout << indent_str_next
-         << "Runtime Dynamic = " << IB->rt_power.readOp.dynamic / executionTime
-         << " W" << endl;
-    cout << endl;
-    cout << indent_str << "Instruction Decoder:" << endl;
-    cout << indent_str_next << "Area = "
-         << (ID_inst->area.get_area() + ID_operand->area.get_area() +
-             ID_misc->area.get_area()) *
-                coredynp.decodeW * 1e-6
-         << " mm^2" << endl;
-    cout << indent_str_next << "Peak Dynamic = "
-         << (ID_inst->power.readOp.dynamic + ID_operand->power.readOp.dynamic +
-             ID_misc->power.readOp.dynamic) *
-                clockRate
-         << " W" << endl;
-    cout << indent_str_next << "Subthreshold Leakage = "
-         << (long_channel ? (ID_inst->power.readOp.longer_channel_leakage +
-                             ID_operand->power.readOp.longer_channel_leakage +
-                             ID_misc->power.readOp.longer_channel_leakage)
-                          : (ID_inst->power.readOp.leakage +
-                             ID_operand->power.readOp.leakage +
-                             ID_misc->power.readOp.leakage))
-         << " W" << endl;
-    cout << indent_str_next
-         << "Gate Leakage = " << (ID_inst->power.readOp.gate_leakage +
-                                  ID_operand->power.readOp.gate_leakage +
-                                  ID_misc->power.readOp.gate_leakage)
-         << " W" << endl;
-    cout << indent_str_next << "Runtime Dynamic = "
-         << (ID_inst->rt_power.readOp.dynamic +
-             ID_operand->rt_power.readOp.dynamic +
-             ID_misc->rt_power.readOp.dynamic) /
-                executionTime
-         << " W" << endl;
-    cout << endl;
-  } else {
-    //		cout << indent_str_next << "Instruction Cache    Peak Dynamic = " <<
-    //icache.rt_power.readOp.dynamic*clockRate << " W" << endl;
-    //		cout << indent_str_next << "Instruction Cache    Subthreshold Leakage
-    //= " << icache.rt_power.readOp.leakage <<" W" << endl;
-    //		cout << indent_str_next << "Instruction Cache    Gate Leakage = " <<
-    //icache.rt_power.readOp.gate_leakage << " W" << endl;
-    //		cout << indent_str_next << "Instruction Buffer   Peak Dynamic = " <<
-    //IB->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Instruction Buffer   Subthreshold Leakage
-    //= " << IB->rt_power.readOp.leakage  << " W" << endl;
-    //		cout << indent_str_next << "Instruction Buffer   Gate Leakage = " <<
-    //IB->rt_power.readOp.gate_leakage  << " W" << endl;
-    //		cout << indent_str_next << "Branch Target Buffer   Peak Dynamic = " <<
-    //BTB->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Branch Target Buffer   Subthreshold
-    //Leakage = " << BTB->rt_power.readOp.leakage  << " W" << endl;
-    //		cout << indent_str_next << "Branch Target Buffer   Gate Leakage = " <<
-    //BTB->rt_power.readOp.gate_leakage  << " W" << endl;
-    //		cout << indent_str_next << "Branch Predictor   Peak Dynamic = " <<
-    //BPT->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Branch Predictor   Subthreshold Leakage =
-    //" << BPT->rt_power.readOp.leakage  << " W" << endl;
-    //		cout << indent_str_next << "Branch Predictor   Gate Leakage = " <<
-    //BPT->rt_power.readOp.gate_leakage  << " W" << endl;
-  }
-}
-
-void RENAMINGU::computeEnergy(bool is_tdp) {
-  if (!exist) return;
-  double pppm_t[4] = {1, 1, 1, 1};
-  if (is_tdp) {  // init stats for Peak
-    if (coredynp.core_ty == OOO) {
-      if (coredynp.scheu_ty == PhysicalRegFile) {
-        if (coredynp.rm_ty == RAMbased) {
-          iFRAT->stats_t.readAc.access = iFRAT->l_ip.num_rd_ports;
-          iFRAT->stats_t.writeAc.access = iFRAT->l_ip.num_wr_ports;
-          iFRAT->tdp_stats = iFRAT->stats_t;
-
-          fFRAT->stats_t.readAc.access = fFRAT->l_ip.num_rd_ports;
-          fFRAT->stats_t.writeAc.access = fFRAT->l_ip.num_wr_ports;
-          fFRAT->tdp_stats = fFRAT->stats_t;
-
-        } else if ((coredynp.rm_ty == CAMbased)) {
-          iFRAT->stats_t.readAc.access = iFRAT->l_ip.num_search_ports;
-          iFRAT->stats_t.writeAc.access = iFRAT->l_ip.num_wr_ports;
-          iFRAT->tdp_stats = iFRAT->stats_t;
-
-          fFRAT->stats_t.readAc.access = fFRAT->l_ip.num_search_ports;
-          fFRAT->stats_t.writeAc.access = fFRAT->l_ip.num_wr_ports;
-          fFRAT->tdp_stats = fFRAT->stats_t;
-        }
-
-        iRRAT->stats_t.readAc.access = iRRAT->l_ip.num_rd_ports;
-        iRRAT->stats_t.writeAc.access = iRRAT->l_ip.num_wr_ports;
-        iRRAT->tdp_stats = iRRAT->stats_t;
-
-        fRRAT->stats_t.readAc.access = fRRAT->l_ip.num_rd_ports;
-        fRRAT->stats_t.writeAc.access = fRRAT->l_ip.num_wr_ports;
-        fRRAT->tdp_stats = fRRAT->stats_t;
-
-        ifreeL->stats_t.readAc.access =
-            coredynp.decodeW;  // ifreeL->l_ip.num_rd_ports;;
-        ifreeL->stats_t.writeAc.access =
-            coredynp.decodeW;  // ifreeL->l_ip.num_wr_ports;
-        ifreeL->tdp_stats = ifreeL->stats_t;
-
-        ffreeL->stats_t.readAc.access =
-            coredynp.decodeW;  // ffreeL->l_ip.num_rd_ports;
-        ffreeL->stats_t.writeAc.access =
-            coredynp.decodeW;  // ffreeL->l_ip.num_wr_ports;
-        ffreeL->tdp_stats = ffreeL->stats_t;
-      } else if (coredynp.scheu_ty == ReservationStation) {
-        if (coredynp.rm_ty == RAMbased) {
-          iFRAT->stats_t.readAc.access = iFRAT->l_ip.num_rd_ports;
-          iFRAT->stats_t.writeAc.access = iFRAT->l_ip.num_wr_ports;
-          iFRAT->stats_t.searchAc.access = iFRAT->l_ip.num_search_ports;
-          iFRAT->tdp_stats = iFRAT->stats_t;
-
-          fFRAT->stats_t.readAc.access = fFRAT->l_ip.num_rd_ports;
-          fFRAT->stats_t.writeAc.access = fFRAT->l_ip.num_wr_ports;
-          fFRAT->stats_t.searchAc.access = fFRAT->l_ip.num_search_ports;
-          fFRAT->tdp_stats = fFRAT->stats_t;
-
-        } else if ((coredynp.rm_ty == CAMbased)) {
-          iFRAT->stats_t.readAc.access = iFRAT->l_ip.num_search_ports;
-          iFRAT->stats_t.writeAc.access = iFRAT->l_ip.num_wr_ports;
-          iFRAT->tdp_stats = iFRAT->stats_t;
-
-          fFRAT->stats_t.readAc.access = fFRAT->l_ip.num_search_ports;
-          fFRAT->stats_t.writeAc.access = fFRAT->l_ip.num_wr_ports;
-          fFRAT->tdp_stats = fFRAT->stats_t;
-        }
-        // Unified free list for both int and fp
-        ifreeL->stats_t.readAc.access =
-            coredynp.decodeW;  // ifreeL->l_ip.num_rd_ports;
-        ifreeL->stats_t.writeAc.access =
-            coredynp.decodeW;  // ifreeL->l_ip.num_wr_ports;
-        ifreeL->tdp_stats = ifreeL->stats_t;
-      }
-      idcl->stats_t.readAc.access = coredynp.decodeW;
-      fdcl->stats_t.readAc.access = coredynp.decodeW;
-      idcl->tdp_stats = idcl->stats_t;
-      fdcl->tdp_stats = fdcl->stats_t;
-    } else {
-      if (coredynp.issueW > 1) {
-        idcl->stats_t.readAc.access = coredynp.decodeW;
-        fdcl->stats_t.readAc.access = coredynp.decodeW;
-        idcl->tdp_stats = idcl->stats_t;
-        fdcl->tdp_stats = fdcl->stats_t;
-      }
-    }
-
-  } else {  // init stats for Runtime Dynamic (RTP)
-    if (coredynp.core_ty == OOO) {
-      if (coredynp.scheu_ty == PhysicalRegFile) {
-        if (coredynp.rm_ty == RAMbased) {
-          iFRAT->stats_t.readAc.access = XML->sys.core[ithCore].rename_reads;
-          iFRAT->stats_t.writeAc.access = XML->sys.core[ithCore].rename_writes;
-          iFRAT->rtp_stats = iFRAT->stats_t;
-
-          fFRAT->stats_t.readAc.access = XML->sys.core[ithCore].fp_rename_reads;
-          fFRAT->stats_t.writeAc.access =
-              XML->sys.core[ithCore].fp_rename_writes;
-          fFRAT->rtp_stats = fFRAT->stats_t;
-        } else if ((coredynp.rm_ty == CAMbased)) {
-          iFRAT->stats_t.readAc.access = XML->sys.core[ithCore].rename_reads;
-          iFRAT->stats_t.writeAc.access = XML->sys.core[ithCore].rename_writes;
-          iFRAT->rtp_stats = iFRAT->stats_t;
-
-          fFRAT->stats_t.readAc.access = XML->sys.core[ithCore].fp_rename_reads;
-          fFRAT->stats_t.writeAc.access =
-              XML->sys.core[ithCore].fp_rename_writes;
-          fFRAT->rtp_stats = fFRAT->stats_t;
-        }
-
-        iRRAT->stats_t.readAc.access =
-            XML->sys.core[ithCore].rename_writes;  // Hack, should be (context
-                                                   // switch + branch
-                                                   // mispredictions)*16
-        iRRAT->stats_t.writeAc.access = XML->sys.core[ithCore].rename_writes;
-        iRRAT->rtp_stats = iRRAT->stats_t;
-
-        fRRAT->stats_t.readAc.access =
-            XML->sys.core[ithCore].fp_rename_writes;  // Hack, should be
-                                                      // (context switch +
-                                                      // branch
-                                                      // mispredictions)*16
-        fRRAT->stats_t.writeAc.access = XML->sys.core[ithCore].fp_rename_writes;
-        fRRAT->rtp_stats = fRRAT->stats_t;
-
-        ifreeL->stats_t.readAc.access = XML->sys.core[ithCore].rename_reads;
-        ifreeL->stats_t.writeAc.access =
-            2 * XML->sys.core[ithCore].rename_writes;
-        ifreeL->rtp_stats = ifreeL->stats_t;
-
-        ffreeL->stats_t.readAc.access = XML->sys.core[ithCore].fp_rename_reads;
-        ffreeL->stats_t.writeAc.access =
-            2 * XML->sys.core[ithCore].fp_rename_writes;
-        ffreeL->rtp_stats = ffreeL->stats_t;
-      } else if (coredynp.scheu_ty == ReservationStation) {
-        if (coredynp.rm_ty == RAMbased) {
-          iFRAT->stats_t.readAc.access = XML->sys.core[ithCore].rename_reads;
-          iFRAT->stats_t.writeAc.access = XML->sys.core[ithCore].rename_writes;
-          iFRAT->stats_t.searchAc.access =
-              XML->sys.core[ithCore]
-                  .committed_int_instructions;  // hack: not all committed
-                                                // instructions use regs.
-          iFRAT->rtp_stats = iFRAT->stats_t;
-
-          fFRAT->stats_t.readAc.access = XML->sys.core[ithCore].fp_rename_reads;
-          fFRAT->stats_t.writeAc.access =
-              XML->sys.core[ithCore].fp_rename_writes;
-          fFRAT->stats_t.searchAc.access =
-              XML->sys.core[ithCore].committed_fp_instructions;
-          fFRAT->rtp_stats = fFRAT->stats_t;
-        } else if ((coredynp.rm_ty == CAMbased)) {
-          iFRAT->stats_t.readAc.access = XML->sys.core[ithCore].rename_reads;
-          iFRAT->stats_t.writeAc.access = XML->sys.core[ithCore].rename_writes;
-          iFRAT->rtp_stats = iFRAT->stats_t;
-
-          fFRAT->stats_t.readAc.access = XML->sys.core[ithCore].fp_rename_reads;
-          fFRAT->stats_t.writeAc.access =
-              XML->sys.core[ithCore].fp_rename_writes;
-          fFRAT->rtp_stats = fFRAT->stats_t;
-        }
-        // Unified free list for both int and fp since the ROB act as physcial
-        // registers
-        ifreeL->stats_t.readAc.access = XML->sys.core[ithCore].rename_reads +
-                                        XML->sys.core[ithCore].fp_rename_reads;
-        ifreeL->stats_t.writeAc.access =
-            2 * (XML->sys.core[ithCore].rename_writes +
-                 XML->sys.core[ithCore].fp_rename_writes);  // HACK: 2-> since
-                                                            // some of renaming
-                                                            // in the same group
-        // are terminated early
-        ifreeL->rtp_stats = ifreeL->stats_t;
-      }
-      idcl->stats_t.readAc.access = 3 * coredynp.decodeW * coredynp.decodeW *
-                                    XML->sys.core[ithCore].rename_reads;
-      fdcl->stats_t.readAc.access = 3 * coredynp.fp_issueW *
-                                    coredynp.fp_issueW *
-                                    XML->sys.core[ithCore].fp_rename_writes;
-      idcl->rtp_stats = idcl->stats_t;
-      fdcl->rtp_stats = fdcl->stats_t;
-    } else {
-      if (coredynp.issueW > 1) {
-        idcl->stats_t.readAc.access =
-            2 * XML->sys.core[ithCore].int_instructions;
-        fdcl->stats_t.readAc.access = XML->sys.core[ithCore].fp_instructions;
-        idcl->rtp_stats = idcl->stats_t;
-        fdcl->rtp_stats = fdcl->stats_t;
-      }
-    }
-  }
-  /* Compute engine */
-  if (coredynp.core_ty == OOO) {
-    if (coredynp.scheu_ty == PhysicalRegFile) {
-      if (coredynp.rm_ty == RAMbased) {
-        iFRAT->power_t.reset();
-        fFRAT->power_t.reset();
-
-        iFRAT->power_t.readOp.dynamic +=
-            (iFRAT->stats_t.readAc.access *
-                 (iFRAT->local_result.power.readOp.dynamic +
-                  idcl->power.readOp.dynamic) +
-             iFRAT->stats_t.writeAc.access *
-                 iFRAT->local_result.power.writeOp.dynamic);
-        fFRAT->power_t.readOp.dynamic +=
-            (fFRAT->stats_t.readAc.access *
-                 (fFRAT->local_result.power.readOp.dynamic +
-                  fdcl->power.readOp.dynamic) +
-             fFRAT->stats_t.writeAc.access *
-                 fFRAT->local_result.power.writeOp.dynamic);
-      } else if ((coredynp.rm_ty == CAMbased)) {
-        iFRAT->power_t.reset();
-        fFRAT->power_t.reset();
-        iFRAT->power_t.readOp.dynamic +=
-            (iFRAT->stats_t.readAc.access *
-                 (iFRAT->local_result.power.searchOp.dynamic +
-                  idcl->power.readOp.dynamic) +
-             iFRAT->stats_t.writeAc.access *
-                 iFRAT->local_result.power.writeOp.dynamic);
-        fFRAT->power_t.readOp.dynamic +=
-            (fFRAT->stats_t.readAc.access *
-                 (fFRAT->local_result.power.searchOp.dynamic +
-                  fdcl->power.readOp.dynamic) +
-             fFRAT->stats_t.writeAc.access *
-                 fFRAT->local_result.power.writeOp.dynamic);
-      }
-
-      iRRAT->power_t.reset();
-      fRRAT->power_t.reset();
-      ifreeL->power_t.reset();
-      ffreeL->power_t.reset();
-
-      iRRAT->power_t.readOp.dynamic +=
-          (iRRAT->stats_t.readAc.access *
-               iRRAT->local_result.power.readOp.dynamic +
-           iRRAT->stats_t.writeAc.access *
-               iRRAT->local_result.power.writeOp.dynamic);
-      fRRAT->power_t.readOp.dynamic +=
-          (fRRAT->stats_t.readAc.access *
-               fRRAT->local_result.power.readOp.dynamic +
-           fRRAT->stats_t.writeAc.access *
-               fRRAT->local_result.power.writeOp.dynamic);
-      ifreeL->power_t.readOp.dynamic +=
-          (ifreeL->stats_t.readAc.access *
-               ifreeL->local_result.power.readOp.dynamic +
-           ifreeL->stats_t.writeAc.access *
-               ifreeL->local_result.power.writeOp.dynamic);
-      ffreeL->power_t.readOp.dynamic +=
-          (ffreeL->stats_t.readAc.access *
-               ffreeL->local_result.power.readOp.dynamic +
-           ffreeL->stats_t.writeAc.access *
-               ffreeL->local_result.power.writeOp.dynamic);
-
-    } else if (coredynp.scheu_ty == ReservationStation) {
-      if (coredynp.rm_ty == RAMbased) {
-        iFRAT->power_t.reset();
-        fFRAT->power_t.reset();
-
-        iFRAT->power_t.readOp.dynamic +=
-            (iFRAT->stats_t.readAc.access *
-                 (iFRAT->local_result.power.readOp.dynamic +
-                  idcl->power.readOp.dynamic) +
-             iFRAT->stats_t.writeAc.access *
-                 iFRAT->local_result.power.writeOp.dynamic +
-             iFRAT->stats_t.searchAc.access *
-                 iFRAT->local_result.power.searchOp.dynamic);
-        fFRAT->power_t.readOp.dynamic +=
-            (fFRAT->stats_t.readAc.access *
-                 (fFRAT->local_result.power.readOp.dynamic +
-                  fdcl->power.readOp.dynamic) +
-             fFRAT->stats_t.writeAc.access *
-                 fFRAT->local_result.power.writeOp.dynamic +
-             fFRAT->stats_t.searchAc.access *
-                 fFRAT->local_result.power.searchOp.dynamic);
-      } else if ((coredynp.rm_ty == CAMbased)) {
-        iFRAT->power_t.reset();
-        fFRAT->power_t.reset();
-        iFRAT->power_t.readOp.dynamic +=
-            (iFRAT->stats_t.readAc.access *
-                 (iFRAT->local_result.power.searchOp.dynamic +
-                  idcl->power.readOp.dynamic) +
-             iFRAT->stats_t.writeAc.access *
-                 iFRAT->local_result.power.writeOp.dynamic);
-        fFRAT->power_t.readOp.dynamic +=
-            (fFRAT->stats_t.readAc.access *
-                 (fFRAT->local_result.power.searchOp.dynamic +
-                  fdcl->power.readOp.dynamic) +
-             fFRAT->stats_t.writeAc.access *
-                 fFRAT->local_result.power.writeOp.dynamic);
-      }
-      ifreeL->power_t.reset();
-      ifreeL->power_t.readOp.dynamic +=
-          (ifreeL->stats_t.readAc.access *
-               ifreeL->local_result.power.readOp.dynamic +
-           ifreeL->stats_t.writeAc.access *
-               ifreeL->local_result.power.writeOp.dynamic);
-    }
-
-  } else {
-    if (coredynp.issueW > 1) {
-      idcl->power_t.reset();
-      fdcl->power_t.reset();
-      set_pppm(pppm_t, idcl->stats_t.readAc.access, coredynp.num_hthreads,
-               coredynp.num_hthreads, idcl->stats_t.readAc.access);
-      idcl->power_t = idcl->power * pppm_t;
-      set_pppm(pppm_t, fdcl->stats_t.readAc.access, coredynp.num_hthreads,
-               coredynp.num_hthreads, idcl->stats_t.readAc.access);
-      fdcl->power_t = fdcl->power * pppm_t;
-    }
-  }
-
-  // assign value to tpd and rtp
-  if (is_tdp) {
-    if (coredynp.core_ty == OOO) {
-      if (coredynp.scheu_ty == PhysicalRegFile) {
-        iFRAT->power =
-            iFRAT->power_t +
-            (iFRAT->local_result.power) * coredynp.pppm_lkg_multhread +
-            idcl->power_t;
-        fFRAT->power =
-            fFRAT->power_t +
-            (fFRAT->local_result.power) * coredynp.pppm_lkg_multhread +
-            fdcl->power_t;
-        iRRAT->power = iRRAT->power_t +
-                       iRRAT->local_result.power * coredynp.pppm_lkg_multhread;
-        fRRAT->power = fRRAT->power_t +
-                       fRRAT->local_result.power * coredynp.pppm_lkg_multhread;
-        ifreeL->power =
-            ifreeL->power_t +
-            ifreeL->local_result.power * coredynp.pppm_lkg_multhread;
-        ffreeL->power =
-            ffreeL->power_t +
-            ffreeL->local_result.power * coredynp.pppm_lkg_multhread;
-        power = power + (iFRAT->power + fFRAT->power) +
-                (iRRAT->power + fRRAT->power) + (ifreeL->power + ffreeL->power);
-      } else if (coredynp.scheu_ty == ReservationStation) {
-        iFRAT->power =
-            iFRAT->power_t +
-            (iFRAT->local_result.power) * coredynp.pppm_lkg_multhread +
-            idcl->power_t;
-        fFRAT->power =
-            fFRAT->power_t +
-            (fFRAT->local_result.power) * coredynp.pppm_lkg_multhread +
-            fdcl->power_t;
-        ifreeL->power =
-            ifreeL->power_t +
-            ifreeL->local_result.power * coredynp.pppm_lkg_multhread;
-        power = power + (iFRAT->power + fFRAT->power) + ifreeL->power;
-      }
-    } else {
-      power = power + idcl->power_t + fdcl->power_t;
-    }
-
-  } else {
-    if (coredynp.core_ty == OOO) {
-      if (coredynp.scheu_ty == PhysicalRegFile) {
-        iFRAT->rt_power =
-            iFRAT->power_t +
-            (iFRAT->local_result.power) * coredynp.pppm_lkg_multhread +
-            idcl->power_t;
-        fFRAT->rt_power =
-            fFRAT->power_t +
-            (fFRAT->local_result.power) * coredynp.pppm_lkg_multhread +
-            fdcl->power_t;
-        iRRAT->rt_power =
-            iRRAT->power_t +
-            iRRAT->local_result.power * coredynp.pppm_lkg_multhread;
-        fRRAT->rt_power =
-            fRRAT->power_t +
-            fRRAT->local_result.power * coredynp.pppm_lkg_multhread;
-        ifreeL->rt_power =
-            ifreeL->power_t +
-            ifreeL->local_result.power * coredynp.pppm_lkg_multhread;
-        ffreeL->rt_power =
-            ffreeL->power_t +
-            ffreeL->local_result.power * coredynp.pppm_lkg_multhread;
-        rt_power = rt_power + (iFRAT->rt_power + fFRAT->rt_power) +
-                   (iRRAT->rt_power + fRRAT->rt_power) +
-                   (ifreeL->rt_power + ffreeL->rt_power);
-      } else if (coredynp.scheu_ty == ReservationStation) {
-        iFRAT->rt_power =
-            iFRAT->power_t +
-            (iFRAT->local_result.power) * coredynp.pppm_lkg_multhread +
-            idcl->power_t;
-        fFRAT->rt_power =
-            fFRAT->power_t +
-            (fFRAT->local_result.power) * coredynp.pppm_lkg_multhread +
-            fdcl->power_t;
-        ifreeL->rt_power =
-            ifreeL->power_t +
-            ifreeL->local_result.power * coredynp.pppm_lkg_multhread;
-        rt_power =
-            rt_power + (iFRAT->rt_power + fFRAT->rt_power) + ifreeL->rt_power;
-      }
-    } else {
-      rt_power = rt_power + idcl->power_t + fdcl->power_t;
-    }
-  }
-}
-
-void RENAMINGU::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
-  if (!exist) return;
-  string indent_str(indent, ' ');
-  string indent_str_next(indent + 2, ' ');
-  bool long_channel = XML->sys.longer_channel_device;
-
-  if (is_tdp) {
-    if (coredynp.core_ty == OOO) {
-      cout << indent_str << "Int Front End RAT:" << endl;
-      cout << indent_str_next << "Area = " << iFRAT->area.get_area() * 1e-6
-           << " mm^2" << endl;
-      cout << indent_str_next
-           << "Peak Dynamic = " << iFRAT->power.readOp.dynamic * clockRate
-           << " W" << endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel ? iFRAT->power.readOp.longer_channel_leakage
-                            : iFRAT->power.readOp.leakage)
-           << " W" << endl;
-      cout << indent_str_next
-           << "Gate Leakage = " << iFRAT->power.readOp.gate_leakage << " W"
-           << endl;
-      cout << indent_str_next << "Runtime Dynamic = "
-           << iFRAT->rt_power.readOp.dynamic / executionTime << " W" << endl;
-      cout << endl;
-      cout << indent_str << "FP Front End RAT:" << endl;
-      cout << indent_str_next << "Area = " << fFRAT->area.get_area() * 1e-6
-           << " mm^2" << endl;
-      cout << indent_str_next
-           << "Peak Dynamic = " << fFRAT->power.readOp.dynamic * clockRate
-           << " W" << endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel ? fFRAT->power.readOp.longer_channel_leakage
-                            : fFRAT->power.readOp.leakage)
-           << " W" << endl;
-      cout << indent_str_next
-           << "Gate Leakage = " << fFRAT->power.readOp.gate_leakage << " W"
-           << endl;
-      cout << indent_str_next << "Runtime Dynamic = "
-           << fFRAT->rt_power.readOp.dynamic / executionTime << " W" << endl;
-      cout << endl;
-      cout << indent_str << "Free List:" << endl;
-      cout << indent_str_next << "Area = " << ifreeL->area.get_area() * 1e-6
-           << " mm^2" << endl;
-      cout << indent_str_next
-           << "Peak Dynamic = " << ifreeL->power.readOp.dynamic * clockRate
-           << " W" << endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel ? ifreeL->power.readOp.longer_channel_leakage
-                            : ifreeL->power.readOp.leakage)
-           << " W" << endl;
-      cout << indent_str_next
-           << "Gate Leakage = " << ifreeL->power.readOp.gate_leakage << " W"
-           << endl;
-      cout << indent_str_next << "Runtime Dynamic = "
-           << ifreeL->rt_power.readOp.dynamic / executionTime << " W" << endl;
-      cout << endl;
-
-      if (coredynp.scheu_ty == PhysicalRegFile) {
-        cout << indent_str << "Int Retire RAT: " << endl;
-        cout << indent_str_next << "Area = " << iRRAT->area.get_area() * 1e-6
-             << " mm^2" << endl;
-        cout << indent_str_next
-             << "Peak Dynamic = " << iRRAT->power.readOp.dynamic * clockRate
-             << " W" << endl;
-        cout << indent_str_next << "Subthreshold Leakage = "
-             << (long_channel ? iRRAT->power.readOp.longer_channel_leakage
-                              : iRRAT->power.readOp.leakage)
-             << " W" << endl;
-        cout << indent_str_next
-             << "Gate Leakage = " << iRRAT->power.readOp.gate_leakage << " W"
-             << endl;
-        cout << indent_str_next << "Runtime Dynamic = "
-             << iRRAT->rt_power.readOp.dynamic / executionTime << " W" << endl;
-        cout << endl;
-        cout << indent_str << "FP Retire RAT:" << endl;
-        cout << indent_str_next << "Area = " << fRRAT->area.get_area() * 1e-6
-             << " mm^2" << endl;
-        cout << indent_str_next
-             << "Peak Dynamic = " << fRRAT->power.readOp.dynamic * clockRate
-             << " W" << endl;
-        cout << indent_str_next << "Subthreshold Leakage = "
-             << (long_channel ? fRRAT->power.readOp.longer_channel_leakage
-                              : fRRAT->power.readOp.leakage)
-             << " W" << endl;
-        cout << indent_str_next
-             << "Gate Leakage = " << fRRAT->power.readOp.gate_leakage << " W"
-             << endl;
-        cout << indent_str_next << "Runtime Dynamic = "
-             << fRRAT->rt_power.readOp.dynamic / executionTime << " W" << endl;
-        cout << endl;
-        cout << indent_str << "FP Free List:" << endl;
-        cout << indent_str_next << "Area = " << ffreeL->area.get_area() * 1e-6
-             << " mm^2" << endl;
-        cout << indent_str_next
-             << "Peak Dynamic = " << ffreeL->power.readOp.dynamic * clockRate
-             << " W" << endl;
-        cout << indent_str_next << "Subthreshold Leakage = "
-             << (long_channel ? ffreeL->power.readOp.longer_channel_leakage
-                              : ffreeL->power.readOp.leakage)
-             << " W" << endl;
-        cout << indent_str_next
-             << "Gate Leakage = " << ffreeL->power.readOp.gate_leakage << " W"
-             << endl;
-        cout << indent_str_next << "Runtime Dynamic = "
-             << ffreeL->rt_power.readOp.dynamic / executionTime << " W" << endl;
-        cout << endl;
-      }
-    } else {
-      cout << indent_str << "Int DCL:" << endl;
-      cout << indent_str_next
-           << "Peak Dynamic = " << idcl->power.readOp.dynamic * clockRate
-           << " W" << endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel ? idcl->power.readOp.longer_channel_leakage
-                            : idcl->power.readOp.leakage)
-           << " W" << endl;
-      cout << indent_str_next
-           << "Gate Leakage = " << idcl->power.readOp.gate_leakage << " W"
-           << endl;
-      cout << indent_str_next << "Runtime Dynamic = "
-           << idcl->rt_power.readOp.dynamic / executionTime << " W" << endl;
-      cout << indent_str << "FP DCL:" << endl;
-      cout << indent_str_next
-           << "Peak Dynamic = " << fdcl->power.readOp.dynamic * clockRate
-           << " W" << endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel ? fdcl->power.readOp.longer_channel_leakage
-                            : fdcl->power.readOp.leakage)
-           << " W" << endl;
-      cout << indent_str_next
-           << "Gate Leakage = " << fdcl->power.readOp.gate_leakage << " W"
-           << endl;
-      cout << indent_str_next << "Runtime Dynamic = "
-           << fdcl->rt_power.readOp.dynamic / executionTime << " W" << endl;
-    }
-  } else {
-    if (coredynp.core_ty == OOO) {
-      cout << indent_str_next << "Int Front End RAT    Peak Dynamic = "
-           << iFRAT->rt_power.readOp.dynamic * clockRate << " W" << endl;
-      cout << indent_str_next << "Int Front End RAT    Subthreshold Leakage = "
-           << iFRAT->rt_power.readOp.leakage << " W" << endl;
-      cout << indent_str_next << "Int Front End RAT    Gate Leakage = "
-           << iFRAT->rt_power.readOp.gate_leakage << " W" << endl;
-      cout << indent_str_next << "FP Front End RAT   Peak Dynamic = "
-           << fFRAT->rt_power.readOp.dynamic * clockRate << " W" << endl;
-      cout << indent_str_next << "FP Front End RAT   Subthreshold Leakage = "
-           << fFRAT->rt_power.readOp.leakage << " W" << endl;
-      cout << indent_str_next << "FP Front End RAT   Gate Leakage = "
-           << fFRAT->rt_power.readOp.gate_leakage << " W" << endl;
-      cout << indent_str_next << "Free List   Peak Dynamic = "
-           << ifreeL->rt_power.readOp.dynamic * clockRate << " W" << endl;
-      cout << indent_str_next << "Free List   Subthreshold Leakage = "
-           << ifreeL->rt_power.readOp.leakage << " W" << endl;
-      cout << indent_str_next << "Free List   Gate Leakage = "
-           << fFRAT->rt_power.readOp.gate_leakage << " W" << endl;
-      if (coredynp.scheu_ty == PhysicalRegFile) {
-        cout << indent_str_next << "Int Retire RAT   Peak Dynamic = "
-             << iRRAT->rt_power.readOp.dynamic * clockRate << " W" << endl;
-        cout << indent_str_next << "Int Retire RAT   Subthreshold Leakage = "
-             << iRRAT->rt_power.readOp.leakage << " W" << endl;
-        cout << indent_str_next << "Int Retire RAT   Gate Leakage = "
-             << iRRAT->rt_power.readOp.gate_leakage << " W" << endl;
-        cout << indent_str_next << "FP Retire RAT   Peak Dynamic = "
-             << fRRAT->rt_power.readOp.dynamic * clockRate << " W" << endl;
-        cout << indent_str_next << "FP Retire RAT   Subthreshold Leakage = "
-             << fRRAT->rt_power.readOp.leakage << " W" << endl;
-        cout << indent_str_next << "FP Retire RAT   Gate Leakage = "
-             << fRRAT->rt_power.readOp.gate_leakage << " W" << endl;
-        cout << indent_str_next << "FP Free List   Peak Dynamic = "
-             << ffreeL->rt_power.readOp.dynamic * clockRate << " W" << endl;
-        cout << indent_str_next << "FP Free List   Subthreshold Leakage = "
-             << ffreeL->rt_power.readOp.leakage << " W" << endl;
-        cout << indent_str_next << "FP Free List   Gate Leakage = "
-             << fFRAT->rt_power.readOp.gate_leakage << " W" << endl;
-      }
-    } else {
-      cout << indent_str_next << "Int DCL   Peak Dynamic = "
-           << idcl->rt_power.readOp.dynamic * clockRate << " W" << endl;
-      cout << indent_str_next << "Int DCL   Subthreshold Leakage = "
-           << idcl->rt_power.readOp.leakage << " W" << endl;
-      cout << indent_str_next
-           << "Int DCL   Gate Leakage = " << idcl->rt_power.readOp.gate_leakage
-           << " W" << endl;
-      cout << indent_str_next << "FP DCL   Peak Dynamic = "
-           << fdcl->rt_power.readOp.dynamic * clockRate << " W" << endl;
-      cout << indent_str_next << "FP DCL   Subthreshold Leakage = "
-           << fdcl->rt_power.readOp.leakage << " W" << endl;
-      cout << indent_str_next
-           << "FP DCL   Gate Leakage = " << fdcl->rt_power.readOp.gate_leakage
-           << " W" << endl;
-    }
-  }
-}
-
-void SchedulerU::computeEnergy(bool is_tdp) {
-  if (!exist) return;
-  double ROB_duty_cycle;
-  //	ROB_duty_cycle = ((coredynp.ALU_duty_cycle +
-  //coredynp.num_muls>0?coredynp.MUL_duty_cycle:0
-  //			+ coredynp.num_fpus>0?coredynp.FPU_duty_cycle:0))*1.1<1 ?
-  //(coredynp.ALU_duty_cycle + coredynp.num_muls>0?coredynp.MUL_duty_cycle:0
-  //					+
-  //coredynp.num_fpus>0?coredynp.FPU_duty_cycle:0)*1.1:1;
-  ROB_duty_cycle = 1;
-  // init stats
-  if (is_tdp) {
-    if (coredynp.core_ty == OOO) {
-      int_inst_window->stats_t.readAc.access =
-          coredynp.issueW *
-          coredynp.num_pipelines;  // int_inst_window->l_ip.num_search_ports;
-      int_inst_window->stats_t.writeAc.access =
-          coredynp.issueW *
-          coredynp.num_pipelines;  // int_inst_window->l_ip.num_wr_ports;
-      int_inst_window->stats_t.searchAc.access =
-          coredynp.issueW * coredynp.num_pipelines;
-      int_inst_window->tdp_stats = int_inst_window->stats_t;
-      fp_inst_window->stats_t.readAc.access =
-          fp_inst_window->l_ip.num_rd_ports * coredynp.num_fp_pipelines;
-      fp_inst_window->stats_t.writeAc.access =
-          fp_inst_window->l_ip.num_wr_ports * coredynp.num_fp_pipelines;
-      fp_inst_window->stats_t.searchAc.access =
-          fp_inst_window->l_ip.num_search_ports * coredynp.num_fp_pipelines;
-      fp_inst_window->tdp_stats = fp_inst_window->stats_t;
-
-      if (XML->sys.core[ithCore].ROB_size > 0) {
-        ROB->stats_t.readAc.access =
-            coredynp.commitW * coredynp.num_pipelines * ROB_duty_cycle;
-        ROB->stats_t.writeAc.access =
-            coredynp.issueW * coredynp.num_pipelines * ROB_duty_cycle;
-        ROB->tdp_stats = ROB->stats_t;
-
-        /*
-         * When inst commits, ROB must be read.
-         * Because for Physcial register based cores, physical register tag in
-         * ROB
-         * need to be read out and write into RRAT/CAM based RAT.
-         * For RS based cores, register content that stored in ROB must be
-         * read out and stored in architectural registers.
-         *
-         * if no-register is involved, the ROB read out operation when
-         * instruction commits can be ignored.
-         * assuming 20% insts. belong this type.
-         * TODO: ROB duty_cycle need to be revisited
-         */
-      }
-
-    } else if (coredynp.multithreaded) {
-      int_inst_window->stats_t.readAc.access =
-          coredynp.issueW *
-          coredynp.num_pipelines;  // int_inst_window->l_ip.num_search_ports;
-      int_inst_window->stats_t.writeAc.access =
-          coredynp.issueW *
-          coredynp.num_pipelines;  // int_inst_window->l_ip.num_wr_ports;
-      int_inst_window->stats_t.searchAc.access =
-          coredynp.issueW * coredynp.num_pipelines;
-      int_inst_window->tdp_stats = int_inst_window->stats_t;
-    }
-
-  } else {  // rtp
-    if (coredynp.core_ty == OOO) {
-      int_inst_window->stats_t.readAc.access =
-          XML->sys.core[ithCore].inst_window_reads;
-      int_inst_window->stats_t.writeAc.access =
-          XML->sys.core[ithCore].inst_window_writes;
-      int_inst_window->stats_t.searchAc.access =
-          XML->sys.core[ithCore].inst_window_wakeup_accesses;
-      int_inst_window->rtp_stats = int_inst_window->stats_t;
-      fp_inst_window->stats_t.readAc.access =
-          XML->sys.core[ithCore].fp_inst_window_reads;
-      fp_inst_window->stats_t.writeAc.access =
-          XML->sys.core[ithCore].fp_inst_window_writes;
-      fp_inst_window->stats_t.searchAc.access =
-          XML->sys.core[ithCore].fp_inst_window_wakeup_accesses;
-      fp_inst_window->rtp_stats = fp_inst_window->stats_t;
-
-      if (XML->sys.core[ithCore].ROB_size > 0) {
-        ROB->stats_t.readAc.access = XML->sys.core[ithCore].ROB_reads;
-        ROB->stats_t.writeAc.access = XML->sys.core[ithCore].ROB_writes;
-        /* ROB need to be updated in RS based OOO when new values are produced,
-         * this update may happen before the commit stage when ROB entry is
-         * released
-         * 1. ROB write at instruction inserted in
-         * 2. ROB write as results produced (for RS based OOO only)
-         * 3. ROB read  as instruction committed. For RS based OOO, data values
-         * are read out and sent to ARF
-         * For Physical reg based OOO, no data stored in ROB, but register tags
-         * need to be
-         * read out and used to set the RRAT and to recycle the register tag to
-         * free list buffer
-         */
-        ROB->rtp_stats = ROB->stats_t;
-      }
-
-    } else if (coredynp.multithreaded) {
-      int_inst_window->stats_t.readAc.access =
-          XML->sys.core[ithCore].int_instructions +
-          XML->sys.core[ithCore].fp_instructions;
-      int_inst_window->stats_t.writeAc.access =
-          XML->sys.core[ithCore].int_instructions +
-          XML->sys.core[ithCore].fp_instructions;
-      int_inst_window->stats_t.searchAc.access =
-          2 * (XML->sys.core[ithCore].int_instructions +
-               XML->sys.core[ithCore].fp_instructions);
-      int_inst_window->rtp_stats = int_inst_window->stats_t;
-    }
-  }
-
-  // computation engine
-  if (coredynp.core_ty == OOO) {
-    int_inst_window->power_t.reset();
-    fp_inst_window->power_t.reset();
-
-    /* each instruction needs to write to scheduler, read out when all resources
-     * and source operands are ready
-     * two search ops with one for each source operand
-     *
-     */
-    int_inst_window->power_t.readOp.dynamic +=
-        int_inst_window->local_result.power.readOp.dynamic *
-            int_inst_window->stats_t.readAc.access +
-        int_inst_window->local_result.power.searchOp.dynamic *
-            int_inst_window->stats_t.searchAc.access +
-        int_inst_window->local_result.power.writeOp.dynamic *
-            int_inst_window->stats_t.writeAc.access +
-        int_inst_window->stats_t.readAc.access *
-            instruction_selection->power.readOp.dynamic;
-
-    fp_inst_window->power_t.readOp.dynamic +=
-        fp_inst_window->local_result.power.readOp.dynamic *
-            fp_inst_window->stats_t.readAc.access +
-        fp_inst_window->local_result.power.searchOp.dynamic *
-            fp_inst_window->stats_t.searchAc.access +
-        fp_inst_window->local_result.power.writeOp.dynamic *
-            fp_inst_window->stats_t.writeAc.access +
-        fp_inst_window->stats_t.writeAc.access *
-            instruction_selection->power.readOp.dynamic;
-
-    if (XML->sys.core[ithCore].ROB_size > 0) {
-      ROB->power_t.reset();
-      ROB->power_t.readOp.dynamic +=
-          ROB->local_result.power.readOp.dynamic * ROB->stats_t.readAc.access +
-          ROB->stats_t.writeAc.access * ROB->local_result.power.writeOp.dynamic;
-    }
-
-  } else if (coredynp.multithreaded) {
-    int_inst_window->power_t.reset();
-    int_inst_window->power_t.readOp.dynamic +=
-        int_inst_window->local_result.power.readOp.dynamic *
-            int_inst_window->stats_t.readAc.access +
-        int_inst_window->local_result.power.searchOp.dynamic *
-            int_inst_window->stats_t.searchAc.access +
-        int_inst_window->local_result.power.writeOp.dynamic *
-            int_inst_window->stats_t.writeAc.access +
-        int_inst_window->stats_t.writeAc.access *
-            instruction_selection->power.readOp.dynamic;
-  }
-
-  // assign values
-  if (is_tdp) {
-    if (coredynp.core_ty == OOO) {
-      int_inst_window->power =
-          int_inst_window->power_t +
-          (int_inst_window->local_result.power + instruction_selection->power) *
-              pppm_lkg;
-      fp_inst_window->power =
-          fp_inst_window->power_t +
-          (fp_inst_window->local_result.power + instruction_selection->power) *
-              pppm_lkg;
-      power = power + int_inst_window->power + fp_inst_window->power;
-      if (XML->sys.core[ithCore].ROB_size > 0) {
-        ROB->power = ROB->power_t + ROB->local_result.power * pppm_lkg;
-        power = power + ROB->power;
-      }
-
-    } else if (coredynp.multithreaded) {
-      //			set_pppm(pppm_t,
-      //XML->sys.core[ithCore].issue_width,1, 1, 1);
-      int_inst_window->power =
-          int_inst_window->power_t +
-          (int_inst_window->local_result.power + instruction_selection->power) *
-              pppm_lkg;
-      power = power + int_inst_window->power;
-    }
-
-  } else {  // rtp
-    if (coredynp.core_ty == OOO) {
-      int_inst_window->rt_power =
-          int_inst_window->power_t +
-          (int_inst_window->local_result.power + instruction_selection->power) *
-              pppm_lkg;
-      fp_inst_window->rt_power =
-          fp_inst_window->power_t +
-          (fp_inst_window->local_result.power + instruction_selection->power) *
-              pppm_lkg;
-      rt_power =
-          rt_power + int_inst_window->rt_power + fp_inst_window->rt_power;
-      if (XML->sys.core[ithCore].ROB_size > 0) {
-        ROB->rt_power = ROB->power_t + ROB->local_result.power * pppm_lkg;
-        rt_power = rt_power + ROB->rt_power;
-      }
-
-    } else if (coredynp.multithreaded) {
-      //			set_pppm(pppm_t,
-      //XML->sys.core[ithCore].issue_width,1, 1, 1);
-      int_inst_window->rt_power =
-          int_inst_window->power_t +
-          (int_inst_window->local_result.power + instruction_selection->power) *
-              pppm_lkg;
-      rt_power = rt_power + int_inst_window->rt_power;
-    }
-  }
-  //	set_pppm(pppm_t, XML->sys.core[ithCore].issue_width,1, 1, 1);
-  //	cout<<"Scheduler
-  //power="<<power.readOp.dynamic<<"leakage="<<power.readOp.leakage<<endl;
-  //	cout<<"IW="<<int_inst_window->local_result.power.searchOp.dynamic *
-  //int_inst_window->stats_t.readAc.access +
-  //    + int_inst_window->local_result.power.writeOp.dynamic *
-  //    int_inst_window->stats_t.writeAc.access<<"leakage="<<int_inst_window->local_result.power.readOp.leakage<<endl;
-  //	cout<<"selection"<<instruction_selection->power.readOp.dynamic<<"leakage"<<instruction_selection->power.readOp.leakage<<endl;
-}
-
-void SchedulerU::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
-  if (!exist) return;
-  string indent_str(indent, ' ');
-  string indent_str_next(indent + 2, ' ');
-  bool long_channel = XML->sys.longer_channel_device;
-
-  if (is_tdp) {
-    if (coredynp.core_ty == OOO) {
-      cout << indent_str << "Instruction Window:" << endl;
-      cout << indent_str_next
-           << "Area = " << int_inst_window->area.get_area() * 1e-6 << " mm^2"
-           << endl;
-      cout << indent_str_next << "Peak Dynamic = "
-           << int_inst_window->power.readOp.dynamic * clockRate << " W" << endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel
-                   ? int_inst_window->power.readOp.longer_channel_leakage
-                   : int_inst_window->power.readOp.leakage)
-           << " W" << endl;
-      cout << indent_str_next
-           << "Gate Leakage = " << int_inst_window->power.readOp.gate_leakage
-           << " W" << endl;
-      cout << indent_str_next << "Runtime Dynamic = "
-           << int_inst_window->rt_power.readOp.dynamic / executionTime << " W"
-           << endl;
-      cout << endl;
-      cout << indent_str << "FP Instruction Window:" << endl;
-      cout << indent_str_next
-           << "Area = " << fp_inst_window->area.get_area() * 1e-6 << " mm^2"
-           << endl;
-      cout << indent_str_next << "Peak Dynamic = "
-           << fp_inst_window->power.readOp.dynamic * clockRate << " W" << endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel
-                   ? fp_inst_window->power.readOp.longer_channel_leakage
-                   : fp_inst_window->power.readOp.leakage)
-           << " W" << endl;
-      cout << indent_str_next
-           << "Gate Leakage = " << fp_inst_window->power.readOp.gate_leakage
-           << " W" << endl;
-      cout << indent_str_next << "Runtime Dynamic = "
-           << fp_inst_window->rt_power.readOp.dynamic / executionTime << " W"
-           << endl;
-      cout << endl;
-      if (XML->sys.core[ithCore].ROB_size > 0) {
-        cout << indent_str << "ROB:" << endl;
-        cout << indent_str_next << "Area = " << ROB->area.get_area() * 1e-6
-             << " mm^2" << endl;
-        cout << indent_str_next
-             << "Peak Dynamic = " << ROB->power.readOp.dynamic * clockRate
-             << " W" << endl;
-        cout << indent_str_next << "Subthreshold Leakage = "
-             << (long_channel ? ROB->power.readOp.longer_channel_leakage
-                              : ROB->power.readOp.leakage)
-             << " W" << endl;
-        cout << indent_str_next
-             << "Gate Leakage = " << ROB->power.readOp.gate_leakage << " W"
-             << endl;
-        cout << indent_str_next << "Runtime Dynamic = "
-             << ROB->rt_power.readOp.dynamic / executionTime << " W" << endl;
-        cout << endl;
-      }
-    } else if (coredynp.multithreaded) {
-      cout << indent_str << "Instruction Window:" << endl;
-      cout << indent_str_next
-           << "Area = " << int_inst_window->area.get_area() * 1e-6 << " mm^2"
-           << endl;
-      cout << indent_str_next << "Peak Dynamic = "
-           << int_inst_window->power.readOp.dynamic * clockRate << " W" << endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel
-                   ? int_inst_window->power.readOp.longer_channel_leakage
-                   : int_inst_window->power.readOp.leakage)
-           << " W" << endl;
-      cout << indent_str_next
-           << "Gate Leakage = " << int_inst_window->power.readOp.gate_leakage
-           << " W" << endl;
-      cout << indent_str_next << "Runtime Dynamic = "
-           << int_inst_window->rt_power.readOp.dynamic / executionTime << " W"
-           << endl;
-      cout << endl;
-    }
-  } else {
-    if (coredynp.core_ty == OOO) {
-      cout << indent_str_next << "Instruction Window    Peak Dynamic = "
-           << int_inst_window->rt_power.readOp.dynamic * clockRate << " W"
-           << endl;
-      cout << indent_str_next << "Instruction Window    Subthreshold Leakage = "
-           << int_inst_window->rt_power.readOp.leakage << " W" << endl;
-      cout << indent_str_next << "Instruction Window    Gate Leakage = "
-           << int_inst_window->rt_power.readOp.gate_leakage << " W" << endl;
-      cout << indent_str_next << "FP Instruction Window   Peak Dynamic = "
-           << fp_inst_window->rt_power.readOp.dynamic * clockRate << " W"
-           << endl;
-      cout << indent_str_next
-           << "FP Instruction Window   Subthreshold Leakage = "
-           << fp_inst_window->rt_power.readOp.leakage << " W" << endl;
-      cout << indent_str_next << "FP Instruction Window   Gate Leakage = "
-           << fp_inst_window->rt_power.readOp.gate_leakage << " W" << endl;
-      if (XML->sys.core[ithCore].ROB_size > 0) {
-        cout << indent_str_next << "ROB   Peak Dynamic = "
-             << ROB->rt_power.readOp.dynamic * clockRate << " W" << endl;
-        cout << indent_str_next
-             << "ROB   Subthreshold Leakage = " << ROB->rt_power.readOp.leakage
-             << " W" << endl;
-        cout << indent_str_next
-             << "ROB   Gate Leakage = " << ROB->rt_power.readOp.gate_leakage
-             << " W" << endl;
-      }
-    } else if (coredynp.multithreaded) {
-      cout << indent_str_next << "Instruction Window    Peak Dynamic = "
-           << int_inst_window->rt_power.readOp.dynamic * clockRate << " W"
-           << endl;
-      cout << indent_str_next << "Instruction Window    Subthreshold Leakage = "
-           << int_inst_window->rt_power.readOp.leakage << " W" << endl;
-      cout << indent_str_next << "Instruction Window    Gate Leakage = "
-           << int_inst_window->rt_power.readOp.gate_leakage << " W" << endl;
-    }
-  }
-}
-
-void LoadStoreU::computeEnergy(bool is_tdp) {
-  if (!exist) return;
-
-  executionTime =
-      XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);  // Syed
-
-  // RF crossbar power (Syed)
-  xbar_shared->compute_power();
-
-  if (is_tdp) {
-    // init stats for Peak
-    // added by Jingwen
-    sharedmemory.caches->stats_t.readAc.access =
-        0.67 * sharedmemory.caches->l_ip.num_rw_ports * coredynp.LSU_duty_cycle;
-    sharedmemory.caches->stats_t.readAc.miss = 0;
-    sharedmemory.caches->stats_t.readAc.hit =
-        sharedmemory.caches->stats_t.readAc.access -
-        sharedmemory.caches->stats_t.readAc.miss;
-    sharedmemory.caches->stats_t.writeAc.access =
-        0.33 * sharedmemory.caches->l_ip.num_rw_ports * coredynp.LSU_duty_cycle;
-    sharedmemory.caches->stats_t.writeAc.miss = 0;
-    sharedmemory.caches->stats_t.writeAc.hit =
-        sharedmemory.caches->stats_t.writeAc.access -
-        sharedmemory.caches->stats_t.writeAc.miss;
-    sharedmemory.caches->tdp_stats = sharedmemory.caches->stats_t;
-
-    sharedmemory.missb->stats_t.readAc.access =
-        sharedmemory.missb->l_ip.num_search_ports;
-    sharedmemory.missb->stats_t.writeAc.access =
-        sharedmemory.missb->l_ip.num_search_ports;
-    sharedmemory.missb->tdp_stats = sharedmemory.missb->stats_t;
-
-    sharedmemory.ifb->stats_t.readAc.access =
-        sharedmemory.ifb->l_ip.num_search_ports;
-    sharedmemory.ifb->stats_t.writeAc.access =
-        sharedmemory.ifb->l_ip.num_search_ports;
-    sharedmemory.ifb->tdp_stats = sharedmemory.ifb->stats_t;
-
-    sharedmemory.prefetchb->stats_t.readAc.access =
-        sharedmemory.prefetchb->l_ip.num_search_ports;
-    sharedmemory.prefetchb->stats_t.writeAc.access =
-        sharedmemory.ifb->l_ip.num_search_ports;
-    sharedmemory.prefetchb->tdp_stats = sharedmemory.prefetchb->stats_t;
-    if (cache_p == Write_back) {
-      sharedmemory.wbb->stats_t.readAc.access =
-          sharedmemory.wbb->l_ip.num_search_ports;
-      sharedmemory.wbb->stats_t.writeAc.access =
-          sharedmemory.wbb->l_ip.num_search_ports;
-      sharedmemory.wbb->tdp_stats = sharedmemory.wbb->stats_t;
-    }
-
-    // init stats for Peak
-    dcache.caches->stats_t.readAc.access =
-        0.67 * dcache.caches->l_ip.num_rw_ports * coredynp.LSU_duty_cycle;
-    dcache.caches->stats_t.readAc.miss = 0;
-    dcache.caches->stats_t.readAc.hit = dcache.caches->stats_t.readAc.access -
-                                        dcache.caches->stats_t.readAc.miss;
-    dcache.caches->stats_t.writeAc.access =
-        0.33 * dcache.caches->l_ip.num_rw_ports * coredynp.LSU_duty_cycle;
-    dcache.caches->stats_t.writeAc.miss = 0;
-    dcache.caches->stats_t.writeAc.hit = dcache.caches->stats_t.writeAc.access -
-                                         dcache.caches->stats_t.writeAc.miss;
-    dcache.caches->tdp_stats = dcache.caches->stats_t;
-
-    dcache.missb->stats_t.readAc.access = dcache.missb->l_ip.num_search_ports;
-    dcache.missb->stats_t.writeAc.access = dcache.missb->l_ip.num_search_ports;
-    dcache.missb->tdp_stats = dcache.missb->stats_t;
-
-    dcache.ifb->stats_t.readAc.access = dcache.ifb->l_ip.num_search_ports;
-    dcache.ifb->stats_t.writeAc.access = dcache.ifb->l_ip.num_search_ports;
-    dcache.ifb->tdp_stats = dcache.ifb->stats_t;
-
-    dcache.prefetchb->stats_t.readAc.access =
-        dcache.prefetchb->l_ip.num_search_ports;
-    dcache.prefetchb->stats_t.writeAc.access =
-        dcache.ifb->l_ip.num_search_ports;
-    dcache.prefetchb->tdp_stats = dcache.prefetchb->stats_t;
-    if (cache_p == Write_back) {
-      dcache.wbb->stats_t.readAc.access = dcache.wbb->l_ip.num_search_ports;
-      dcache.wbb->stats_t.writeAc.access = dcache.wbb->l_ip.num_search_ports;
-      dcache.wbb->tdp_stats = dcache.wbb->stats_t;
-    }
-
-    // init stats for Peak - ccache
-    ccache.caches->stats_t.readAc.access =
-        0.67 * ccache.caches->l_ip.num_rw_ports * coredynp.LSU_duty_cycle;
-    ccache.caches->stats_t.readAc.miss = 0;
-    ccache.caches->stats_t.readAc.hit = ccache.caches->stats_t.readAc.access -
-                                        ccache.caches->stats_t.readAc.miss;
-    ccache.caches->stats_t.writeAc.access =
-        0.33 * ccache.caches->l_ip.num_rw_ports * coredynp.LSU_duty_cycle;
-    ccache.caches->stats_t.writeAc.miss = 0;
-    ccache.caches->stats_t.writeAc.hit = ccache.caches->stats_t.writeAc.access -
-                                         ccache.caches->stats_t.writeAc.miss;
-    ccache.caches->tdp_stats = ccache.caches->stats_t;
-
-    ccache.missb->stats_t.readAc.access = ccache.missb->l_ip.num_search_ports;
-    ccache.missb->stats_t.writeAc.access = ccache.missb->l_ip.num_search_ports;
-    ccache.missb->tdp_stats = ccache.missb->stats_t;
-
-    ccache.ifb->stats_t.readAc.access = ccache.ifb->l_ip.num_search_ports;
-    ccache.ifb->stats_t.writeAc.access = ccache.ifb->l_ip.num_search_ports;
-    ccache.ifb->tdp_stats = ccache.ifb->stats_t;
-
-    ccache.prefetchb->stats_t.readAc.access =
-        ccache.prefetchb->l_ip.num_search_ports;
-    ccache.prefetchb->stats_t.writeAc.access =
-        ccache.ifb->l_ip.num_search_ports;
-    ccache.prefetchb->tdp_stats = ccache.prefetchb->stats_t;
-    if (cache_p == Write_back) {
-      ccache.wbb->stats_t.readAc.access = ccache.wbb->l_ip.num_search_ports;
-      ccache.wbb->stats_t.writeAc.access = ccache.wbb->l_ip.num_search_ports;
-      ccache.wbb->tdp_stats = ccache.wbb->stats_t;
-    }
-
-    // init stats for Peak - tcache
-    tcache.caches->stats_t.readAc.access =
-        0.67 * tcache.caches->l_ip.num_rw_ports * coredynp.LSU_duty_cycle;
-    tcache.caches->stats_t.readAc.miss = 0;
-    tcache.caches->stats_t.readAc.hit = tcache.caches->stats_t.readAc.access -
-                                        tcache.caches->stats_t.readAc.miss;
-    tcache.caches->stats_t.writeAc.access =
-        0.33 * tcache.caches->l_ip.num_rw_ports * coredynp.LSU_duty_cycle;
-    tcache.caches->stats_t.writeAc.miss = 0;
-    tcache.caches->stats_t.writeAc.hit = tcache.caches->stats_t.writeAc.access -
-                                         tcache.caches->stats_t.writeAc.miss;
-    tcache.caches->tdp_stats = tcache.caches->stats_t;
-
-    tcache.missb->stats_t.readAc.access = tcache.missb->l_ip.num_search_ports;
-    tcache.missb->stats_t.writeAc.access = tcache.missb->l_ip.num_search_ports;
-    tcache.missb->tdp_stats = tcache.missb->stats_t;
-
-    tcache.ifb->stats_t.readAc.access = tcache.ifb->l_ip.num_search_ports;
-    tcache.ifb->stats_t.writeAc.access = tcache.ifb->l_ip.num_search_ports;
-    tcache.ifb->tdp_stats = tcache.ifb->stats_t;
-
-    tcache.prefetchb->stats_t.readAc.access =
-        tcache.prefetchb->l_ip.num_search_ports;
-    tcache.prefetchb->stats_t.writeAc.access =
-        tcache.ifb->l_ip.num_search_ports;
-    tcache.prefetchb->tdp_stats = tcache.prefetchb->stats_t;
-    if (cache_p == Write_back) {
-      tcache.wbb->stats_t.readAc.access = tcache.wbb->l_ip.num_search_ports;
-      tcache.wbb->stats_t.writeAc.access = tcache.wbb->l_ip.num_search_ports;
-      tcache.wbb->tdp_stats = tcache.wbb->stats_t;
-    }
-
-    LSQ->stats_t.readAc.access = LSQ->stats_t.writeAc.access =
-        LSQ->l_ip.num_search_ports * coredynp.LSU_duty_cycle;
-    LSQ->tdp_stats = LSQ->stats_t;
-    if ((coredynp.core_ty == OOO) &&
-        (XML->sys.core[ithCore].load_buffer_size > 0)) {
-      LoadQ->stats_t.readAc.access = LoadQ->stats_t.writeAc.access =
-          LoadQ->l_ip.num_search_ports * coredynp.LSU_duty_cycle;
-      LoadQ->tdp_stats = LoadQ->stats_t;
-    }
-  } else {
-    // init stats for Runtime Dynamic (RTP)
-
-    sharedmemory.caches->stats_t.readAc.access =
-        XML->sys.core[ithCore].sharedmemory.read_accesses;
-    sharedmemory.caches->stats_t.readAc.miss =
-        XML->sys.core[ithCore].sharedmemory.read_misses;
-    sharedmemory.caches->stats_t.readAc.hit =
-        sharedmemory.caches->stats_t.readAc.access -
-        sharedmemory.caches->stats_t.readAc.miss;
-    sharedmemory.caches->stats_t.writeAc.access =
-        XML->sys.core[ithCore].sharedmemory.write_accesses;
-    sharedmemory.caches->stats_t.writeAc.miss =
-        XML->sys.core[ithCore].sharedmemory.write_misses;
-    sharedmemory.caches->stats_t.writeAc.hit =
-        sharedmemory.caches->stats_t.writeAc.access -
-        sharedmemory.caches->stats_t.writeAc.miss;
-    sharedmemory.caches->rtp_stats = sharedmemory.caches->stats_t;
-
-    dcache.caches->stats_t.readAc.access =
-        XML->sys.core[ithCore].dcache.read_accesses;
-    dcache.caches->stats_t.readAc.miss =
-        XML->sys.core[ithCore].dcache.read_misses;
-    dcache.caches->stats_t.readAc.hit = dcache.caches->stats_t.readAc.access -
-                                        dcache.caches->stats_t.readAc.miss;
-    dcache.caches->stats_t.writeAc.access =
-        XML->sys.core[ithCore].dcache.write_accesses;
-    dcache.caches->stats_t.writeAc.miss =
-        XML->sys.core[ithCore].dcache.write_misses;
-    dcache.caches->stats_t.writeAc.hit = dcache.caches->stats_t.writeAc.access -
-                                         dcache.caches->stats_t.writeAc.miss;
-    dcache.caches->rtp_stats = dcache.caches->stats_t;
-
-    ccache.caches->stats_t.readAc.access =
-        XML->sys.core[ithCore].ccache.read_accesses;
-    ccache.caches->stats_t.readAc.miss =
-        XML->sys.core[ithCore].ccache.read_misses;
-    ccache.caches->stats_t.readAc.hit = ccache.caches->stats_t.readAc.access -
-                                        ccache.caches->stats_t.readAc.miss;
-    ccache.caches->stats_t.writeAc.access =
-        XML->sys.core[ithCore].ccache.write_accesses;
-    ccache.caches->stats_t.writeAc.miss =
-        XML->sys.core[ithCore].ccache.write_misses;
-    ccache.caches->stats_t.writeAc.hit = ccache.caches->stats_t.writeAc.access -
-                                         ccache.caches->stats_t.writeAc.miss;
-    ccache.caches->rtp_stats = ccache.caches->stats_t;
-
-    tcache.caches->stats_t.readAc.access =
-        XML->sys.core[ithCore].tcache.read_accesses;
-    tcache.caches->stats_t.readAc.miss =
-        XML->sys.core[ithCore].tcache.read_misses;
-    tcache.caches->stats_t.readAc.hit = tcache.caches->stats_t.readAc.access -
-                                        tcache.caches->stats_t.readAc.miss;
-    tcache.caches->stats_t.writeAc.access =
-        XML->sys.core[ithCore].tcache.write_accesses;
-    tcache.caches->stats_t.writeAc.miss =
-        XML->sys.core[ithCore].tcache.write_misses;
-    tcache.caches->stats_t.writeAc.hit = tcache.caches->stats_t.writeAc.access -
-                                         tcache.caches->stats_t.writeAc.miss;
-    tcache.caches->rtp_stats = tcache.caches->stats_t;
-
-    if (cache_p == Write_back) {
-      sharedmemory.missb->stats_t.readAc.access =
-          sharedmemory.caches->stats_t.writeAc.miss;
-      sharedmemory.missb->stats_t.writeAc.access =
-          sharedmemory.caches->stats_t.writeAc.miss;
-      sharedmemory.missb->rtp_stats = sharedmemory.missb->stats_t;
-      sharedmemory.ifb->stats_t.readAc.access =
-          sharedmemory.caches->stats_t.writeAc.miss;
-      sharedmemory.ifb->stats_t.writeAc.access =
-          sharedmemory.caches->stats_t.writeAc.miss;
-      sharedmemory.ifb->rtp_stats = sharedmemory.ifb->stats_t;
-      sharedmemory.prefetchb->stats_t.readAc.access =
-          sharedmemory.caches->stats_t.writeAc.miss;
-      sharedmemory.prefetchb->stats_t.writeAc.access =
-          sharedmemory.caches->stats_t.writeAc.miss;
-      sharedmemory.prefetchb->rtp_stats = sharedmemory.prefetchb->stats_t;
-      sharedmemory.wbb->stats_t.readAc.access =
-          sharedmemory.caches->stats_t.writeAc.miss;
-      sharedmemory.wbb->stats_t.writeAc.access =
-          sharedmemory.caches->stats_t.writeAc.miss;
-      sharedmemory.wbb->rtp_stats = sharedmemory.wbb->stats_t;
-
-      dcache.missb->stats_t.readAc.access = dcache.caches->stats_t.writeAc.miss;
-      dcache.missb->stats_t.writeAc.access =
-          dcache.caches->stats_t.writeAc.miss;
-      dcache.missb->rtp_stats = dcache.missb->stats_t;
-      dcache.ifb->stats_t.readAc.access = dcache.caches->stats_t.writeAc.miss;
-      dcache.ifb->stats_t.writeAc.access = dcache.caches->stats_t.writeAc.miss;
-      dcache.ifb->rtp_stats = dcache.ifb->stats_t;
-      dcache.prefetchb->stats_t.readAc.access =
-          dcache.caches->stats_t.writeAc.miss;
-      dcache.prefetchb->stats_t.writeAc.access =
-          dcache.caches->stats_t.writeAc.miss;
-      dcache.prefetchb->rtp_stats = dcache.prefetchb->stats_t;
-      dcache.wbb->stats_t.readAc.access = dcache.caches->stats_t.writeAc.miss;
-      dcache.wbb->stats_t.writeAc.access = dcache.caches->stats_t.writeAc.miss;
-      dcache.wbb->rtp_stats = dcache.wbb->stats_t;
-
-      ccache.missb->stats_t.readAc.access = ccache.caches->stats_t.writeAc.miss;
-      ccache.missb->stats_t.writeAc.access =
-          ccache.caches->stats_t.writeAc.miss;
-      ccache.missb->rtp_stats = ccache.missb->stats_t;
-      ccache.ifb->stats_t.readAc.access = ccache.caches->stats_t.writeAc.miss;
-      ccache.ifb->stats_t.writeAc.access = ccache.caches->stats_t.writeAc.miss;
-      ccache.ifb->rtp_stats = ccache.ifb->stats_t;
-      ccache.prefetchb->stats_t.readAc.access =
-          ccache.caches->stats_t.writeAc.miss;
-      ccache.prefetchb->stats_t.writeAc.access =
-          ccache.caches->stats_t.writeAc.miss;
-      ccache.prefetchb->rtp_stats = ccache.prefetchb->stats_t;
-      ccache.wbb->stats_t.readAc.access = ccache.caches->stats_t.writeAc.miss;
-      ccache.wbb->stats_t.writeAc.access = ccache.caches->stats_t.writeAc.miss;
-      ccache.wbb->rtp_stats = ccache.wbb->stats_t;
-
-      tcache.missb->stats_t.readAc.access = tcache.caches->stats_t.writeAc.miss;
-      tcache.missb->stats_t.writeAc.access =
-          tcache.caches->stats_t.writeAc.miss;
-      tcache.missb->rtp_stats = tcache.missb->stats_t;
-      tcache.ifb->stats_t.readAc.access = tcache.caches->stats_t.writeAc.miss;
-      tcache.ifb->stats_t.writeAc.access = tcache.caches->stats_t.writeAc.miss;
-      tcache.ifb->rtp_stats = tcache.ifb->stats_t;
-      tcache.prefetchb->stats_t.readAc.access =
-          tcache.caches->stats_t.writeAc.miss;
-      tcache.prefetchb->stats_t.writeAc.access =
-          tcache.caches->stats_t.writeAc.miss;
-      tcache.prefetchb->rtp_stats = tcache.prefetchb->stats_t;
-      tcache.wbb->stats_t.readAc.access = tcache.caches->stats_t.writeAc.miss;
-      tcache.wbb->stats_t.writeAc.access = tcache.caches->stats_t.writeAc.miss;
-      tcache.wbb->rtp_stats = tcache.wbb->stats_t;
-    } else {
-      sharedmemory.missb->stats_t.readAc.access =
-          sharedmemory.caches->stats_t.readAc.miss;
-      sharedmemory.missb->stats_t.writeAc.access =
-          sharedmemory.caches->stats_t.readAc.miss;
-      sharedmemory.missb->rtp_stats = sharedmemory.missb->stats_t;
-      sharedmemory.ifb->stats_t.readAc.access =
-          sharedmemory.caches->stats_t.readAc.miss;
-      sharedmemory.ifb->stats_t.writeAc.access =
-          sharedmemory.caches->stats_t.readAc.miss;
-      sharedmemory.ifb->rtp_stats = sharedmemory.ifb->stats_t;
-      sharedmemory.prefetchb->stats_t.readAc.access =
-          sharedmemory.caches->stats_t.readAc.miss;
-      sharedmemory.prefetchb->stats_t.writeAc.access =
-          sharedmemory.caches->stats_t.readAc.miss;
-      sharedmemory.prefetchb->rtp_stats = sharedmemory.prefetchb->stats_t;
-
-      dcache.missb->stats_t.readAc.access = dcache.caches->stats_t.readAc.miss;
-      dcache.missb->stats_t.writeAc.access = dcache.caches->stats_t.readAc.miss;
-      dcache.missb->rtp_stats = dcache.missb->stats_t;
-      dcache.ifb->stats_t.readAc.access = dcache.caches->stats_t.readAc.miss;
-      dcache.ifb->stats_t.writeAc.access = dcache.caches->stats_t.readAc.miss;
-      dcache.ifb->rtp_stats = dcache.ifb->stats_t;
-      dcache.prefetchb->stats_t.readAc.access =
-          dcache.caches->stats_t.readAc.miss;
-      dcache.prefetchb->stats_t.writeAc.access =
-          dcache.caches->stats_t.readAc.miss;
-      dcache.prefetchb->rtp_stats = dcache.prefetchb->stats_t;
-
-      ccache.missb->stats_t.readAc.access = ccache.caches->stats_t.readAc.miss;
-      ccache.missb->stats_t.writeAc.access = ccache.caches->stats_t.readAc.miss;
-      ccache.missb->rtp_stats = ccache.missb->stats_t;
-      ccache.ifb->stats_t.readAc.access = ccache.caches->stats_t.readAc.miss;
-      ccache.ifb->stats_t.writeAc.access = ccache.caches->stats_t.readAc.miss;
-      ccache.ifb->rtp_stats = ccache.ifb->stats_t;
-      ccache.prefetchb->stats_t.readAc.access =
-          ccache.caches->stats_t.readAc.miss;
-      ccache.prefetchb->stats_t.writeAc.access =
-          ccache.caches->stats_t.readAc.miss;
-      ccache.prefetchb->rtp_stats = ccache.prefetchb->stats_t;
-
-      tcache.missb->stats_t.readAc.access = tcache.caches->stats_t.readAc.miss;
-      tcache.missb->stats_t.writeAc.access = tcache.caches->stats_t.readAc.miss;
-      tcache.missb->rtp_stats = tcache.missb->stats_t;
-      tcache.ifb->stats_t.readAc.access = tcache.caches->stats_t.readAc.miss;
-      tcache.ifb->stats_t.writeAc.access = tcache.caches->stats_t.readAc.miss;
-      tcache.ifb->rtp_stats = tcache.ifb->stats_t;
-      tcache.prefetchb->stats_t.readAc.access =
-          tcache.caches->stats_t.readAc.miss;
-      tcache.prefetchb->stats_t.writeAc.access =
-          tcache.caches->stats_t.readAc.miss;
-      tcache.prefetchb->rtp_stats = tcache.prefetchb->stats_t;
-    }
-
-    LSQ->stats_t.readAc.access = (XML->sys.core[ithCore].load_instructions +
-                                  XML->sys.core[ithCore].store_instructions) *
-                                 2;  // flush overhead considered
-    LSQ->stats_t.writeAc.access = (XML->sys.core[ithCore].load_instructions +
-                                   XML->sys.core[ithCore].store_instructions) *
-                                  2;
-    LSQ->rtp_stats = LSQ->stats_t;
-
-    if ((coredynp.core_ty == OOO) &&
-        (XML->sys.core[ithCore].load_buffer_size > 0)) {
-      LoadQ->stats_t.readAc.access = XML->sys.core[ithCore].load_instructions +
-                                     XML->sys.core[ithCore].store_instructions;
-      LoadQ->stats_t.writeAc.access = XML->sys.core[ithCore].load_instructions +
-                                      XML->sys.core[ithCore].store_instructions;
-      LoadQ->rtp_stats = LoadQ->stats_t;
-    }
-  }
-
-  sharedmemory.power_t.reset();
-  dcache.power_t.reset();
-  ccache.power_t.reset();
-  tcache.power_t.reset();
-  LSQ->power_t.reset();
-
-  sharedmemory.power_t.readOp.dynamic +=
-      (sharedmemory.caches->stats_t.readAc.hit *
-           sharedmemory.caches->local_result.power.readOp.dynamic +
-       sharedmemory.caches->stats_t.readAc.miss *
-           sharedmemory.caches->local_result.power.readOp.dynamic +
-       sharedmemory.caches->stats_t.writeAc.miss *
-           sharedmemory.caches->local_result.tag_array2->power.readOp.dynamic +
-       sharedmemory.caches->stats_t.writeAc.access *
-           sharedmemory.caches->local_result.power.writeOp.dynamic +
-       xbar_shared->power.readOp.dynamic *
-           (sharedmemory.caches->stats_t.readAc.hit +
-            sharedmemory.caches->stats_t.writeAc.hit));
-
-  dcache.power_t.readOp.dynamic +=
-      (dcache.caches->stats_t.readAc.hit *
-           dcache.caches->local_result.power.readOp.dynamic +
-       dcache.caches->stats_t.readAc.miss *
-           dcache.caches->local_result.power.readOp.dynamic +
-       dcache.caches->stats_t.writeAc.miss *
-           dcache.caches->local_result.tag_array2->power.readOp.dynamic +
-       dcache.caches->stats_t.writeAc.access *
-           dcache.caches->local_result.power.writeOp.dynamic +
-       xbar_shared->power.readOp.dynamic *
-           (dcache.caches->stats_t.readAc.hit +
-            dcache.caches->stats_t.writeAc.hit));
-  ccache.power_t.readOp.dynamic +=
-      (ccache.caches->stats_t.readAc.hit *
-           ccache.caches->local_result.power.readOp.dynamic +
-       ccache.caches->stats_t.readAc.miss *
-           ccache.caches->local_result.power.readOp.dynamic +
-       ccache.caches->stats_t.writeAc.miss *
-           ccache.caches->local_result.tag_array2->power.readOp.dynamic +
-       ccache.caches->stats_t.writeAc.access *
-           ccache.caches->local_result.power.writeOp.dynamic +
-       xbar_shared->power.readOp.dynamic * (ccache.caches->stats_t.readAc.hit));
-
-  tcache.power_t.readOp.dynamic +=
-      (tcache.caches->stats_t.readAc.hit *
-           tcache.caches->local_result.power.readOp.dynamic +
-       tcache.caches->stats_t.readAc.miss *
-           tcache.caches->local_result.power.readOp.dynamic +
-       tcache.caches->stats_t.writeAc.miss *
-           tcache.caches->local_result.tag_array2->power.readOp.dynamic +
-       tcache.caches->stats_t.writeAc.access *
-           tcache.caches->local_result.power.writeOp.dynamic +
-       xbar_shared->power.readOp.dynamic *
-           (tcache.caches->stats_t.readAc.hit +
-            tcache.caches->stats_t.writeAc.hit));
-
-  if (cache_p == Write_back) {  // write miss will generate a write later
-    dcache.power_t.readOp.dynamic +=
-        dcache.caches->stats_t.writeAc.miss *
-        dcache.caches->local_result.power.writeOp.dynamic;
-    ccache.power_t.readOp.dynamic +=
-        ccache.caches->stats_t.writeAc.miss *
-        ccache.caches->local_result.power.writeOp.dynamic;
-    tcache.power_t.readOp.dynamic +=
-        tcache.caches->stats_t.writeAc.miss *
-        tcache.caches->local_result.power.writeOp.dynamic;
-    sharedmemory.power_t.readOp.dynamic +=
-        sharedmemory.caches->stats_t.writeAc.miss *
-        sharedmemory.caches->local_result.power.writeOp.dynamic;
-  }
-
-  sharedmemory.power_t.readOp.dynamic +=
-      sharedmemory.missb->stats_t.readAc.access *
-          sharedmemory.missb->local_result.power.searchOp.dynamic +
-      sharedmemory.missb->stats_t.writeAc.access *
-          sharedmemory.missb->local_result.power.writeOp
-              .dynamic;  // each access to missb involves a CAM and a write
-  sharedmemory.power_t.readOp.dynamic +=
-      sharedmemory.ifb->stats_t.readAc.access *
-          sharedmemory.ifb->local_result.power.searchOp.dynamic +
-      sharedmemory.ifb->stats_t.writeAc.access *
-          sharedmemory.ifb->local_result.power.writeOp.dynamic;
-  sharedmemory.power_t.readOp.dynamic +=
-      sharedmemory.prefetchb->stats_t.readAc.access *
-          sharedmemory.prefetchb->local_result.power.searchOp.dynamic +
-      sharedmemory.prefetchb->stats_t.writeAc.access *
-          sharedmemory.prefetchb->local_result.power.writeOp.dynamic;
-  if (cache_p == Write_back) {
-    sharedmemory.power_t.readOp.dynamic +=
-        sharedmemory.wbb->stats_t.readAc.access *
-            sharedmemory.wbb->local_result.power.searchOp.dynamic +
-        sharedmemory.wbb->stats_t.writeAc.access *
-            sharedmemory.wbb->local_result.power.writeOp.dynamic;
-  }
-
-  dcache.power_t.readOp.dynamic +=
-      dcache.missb->stats_t.readAc.access *
-          dcache.missb->local_result.power.searchOp.dynamic +
-      dcache.missb->stats_t.writeAc.access *
-          dcache.missb->local_result.power.writeOp
-              .dynamic;  // each access to missb involves a CAM and a write
-  dcache.power_t.readOp.dynamic +=
-      dcache.ifb->stats_t.readAc.access *
-          dcache.ifb->local_result.power.searchOp.dynamic +
-      dcache.ifb->stats_t.writeAc.access *
-          dcache.ifb->local_result.power.writeOp.dynamic;
-  dcache.power_t.readOp.dynamic +=
-      dcache.prefetchb->stats_t.readAc.access *
-          dcache.prefetchb->local_result.power.searchOp.dynamic +
-      dcache.prefetchb->stats_t.writeAc.access *
-          dcache.prefetchb->local_result.power.writeOp.dynamic;
-  if (cache_p == Write_back) {
-    dcache.power_t.readOp.dynamic +=
-        dcache.wbb->stats_t.readAc.access *
-            dcache.wbb->local_result.power.searchOp.dynamic +
-        dcache.wbb->stats_t.writeAc.access *
-            dcache.wbb->local_result.power.writeOp.dynamic;
-  }
-
-  ccache.power_t.readOp.dynamic +=
-      ccache.missb->stats_t.readAc.access *
-          ccache.missb->local_result.power.searchOp.dynamic +
-      ccache.missb->stats_t.writeAc.access *
-          ccache.missb->local_result.power.writeOp
-              .dynamic;  // each access to missb involves a CAM and a write
-  ccache.power_t.readOp.dynamic +=
-      ccache.ifb->stats_t.readAc.access *
-          ccache.ifb->local_result.power.searchOp.dynamic +
-      ccache.ifb->stats_t.writeAc.access *
-          ccache.ifb->local_result.power.writeOp.dynamic;
-  ccache.power_t.readOp.dynamic +=
-      ccache.prefetchb->stats_t.readAc.access *
-          ccache.prefetchb->local_result.power.searchOp.dynamic +
-      ccache.prefetchb->stats_t.writeAc.access *
-          ccache.prefetchb->local_result.power.writeOp.dynamic;
-  if (cache_p == Write_back) {
-    ccache.power_t.readOp.dynamic +=
-        ccache.wbb->stats_t.readAc.access *
-            ccache.wbb->local_result.power.searchOp.dynamic +
-        ccache.wbb->stats_t.writeAc.access *
-            ccache.wbb->local_result.power.writeOp.dynamic;
-  }
-
-  tcache.power_t.readOp.dynamic +=
-      tcache.missb->stats_t.readAc.access *
-          tcache.missb->local_result.power.searchOp.dynamic +
-      tcache.missb->stats_t.writeAc.access *
-          tcache.missb->local_result.power.writeOp
-              .dynamic;  // each access to missb involves a CAM and a write
-  tcache.power_t.readOp.dynamic +=
-      tcache.ifb->stats_t.readAc.access *
-          tcache.ifb->local_result.power.searchOp.dynamic +
-      tcache.ifb->stats_t.writeAc.access *
-          tcache.ifb->local_result.power.writeOp.dynamic;
-  tcache.power_t.readOp.dynamic +=
-      tcache.prefetchb->stats_t.readAc.access *
-          tcache.prefetchb->local_result.power.searchOp.dynamic +
-      tcache.prefetchb->stats_t.writeAc.access *
-          tcache.prefetchb->local_result.power.writeOp.dynamic;
-  if (cache_p == Write_back) {
-    tcache.power_t.readOp.dynamic +=
-        tcache.wbb->stats_t.readAc.access *
-            tcache.wbb->local_result.power.searchOp.dynamic +
-        tcache.wbb->stats_t.writeAc.access *
-            tcache.wbb->local_result.power.writeOp.dynamic;
-  }
-
-  if ((coredynp.core_ty == OOO) &&
-      (XML->sys.core[ithCore].load_buffer_size > 0)) {
-    LoadQ->power_t.reset();
-    LoadQ->power_t.readOp.dynamic +=
-        LoadQ->stats_t.readAc.access *
-            (LoadQ->local_result.power.searchOp.dynamic +
-             LoadQ->local_result.power.readOp.dynamic) +
-        LoadQ->stats_t.writeAc.access *
-            LoadQ->local_result.power.writeOp.dynamic;  // every memory access
-                                                        // invloves at least two
-                                                        // operations on LoadQ
-
-    LSQ->power_t.readOp.dynamic +=
-        LSQ->stats_t.readAc.access * (LSQ->local_result.power.searchOp.dynamic +
-                                      LSQ->local_result.power.readOp.dynamic) +
-        LSQ->stats_t.writeAc.access *
-            LSQ->local_result.power.writeOp.dynamic;  // every memory access
-                                                      // invloves at least two
-                                                      // operations on LSQ
-
-  } else {
-    //	LSQ->power_t.readOp.dynamic  +=
-    //LSQ->stats_t.readAc.access*(LSQ->local_result.power.searchOp.dynamic +
-    //LSQ->local_result.power.readOp.dynamic)
-    //	        +
-    //LSQ->stats_t.writeAc.access*LSQ->local_result.power.writeOp.dynamic;//every
-    //memory access invloves at least two operations on LSQ
-    //	No LSQ in GPUs (Syed)
-  }
-
-  if (is_tdp) {
-    //    	dcache.power = dcache.power_t +
-    //    (dcache.caches->local_result.power)*pppm_lkg +
-    //    			(dcache.missb->local_result.power +
-    //    			dcache.ifb->local_result.power +
-    //    			dcache.prefetchb->local_result.power +
-    //    			dcache.wbb->local_result.power)*pppm_Isub;
-
-    sharedmemory.power =
-        sharedmemory.power_t +
-        (sharedmemory.caches->local_result.power +
-         sharedmemory.missb->local_result.power +
-         sharedmemory.ifb->local_result.power +
-         sharedmemory.prefetchb->local_result.power + xbar_shared->power) *
-            pppm_lkg;
-    if (cache_p == Write_back) {
-      sharedmemory.power =
-          sharedmemory.power + sharedmemory.wbb->local_result.power * pppm_lkg;
-    }
-
-    dcache.power =
-        dcache.power_t +
-        (dcache.caches->local_result.power + dcache.missb->local_result.power +
-         dcache.ifb->local_result.power +
-         dcache.prefetchb->local_result.power) *
-            pppm_lkg;
-    if (cache_p == Write_back) {
-      dcache.power = dcache.power + dcache.wbb->local_result.power * pppm_lkg;
-    }
-
-    ccache.power =
-        ccache.power_t +
-        (ccache.caches->local_result.power + ccache.missb->local_result.power +
-         ccache.ifb->local_result.power +
-         ccache.prefetchb->local_result.power) *
-            pppm_lkg;
-    if (cache_p == Write_back) {
-      ccache.power = ccache.power + ccache.wbb->local_result.power * pppm_lkg;
-    }
-
-    tcache.power =
-        tcache.power_t +
-        (tcache.caches->local_result.power + tcache.missb->local_result.power +
-         tcache.ifb->local_result.power +
-         tcache.prefetchb->local_result.power) *
-            pppm_lkg;
-    if (cache_p == Write_back) {
-      tcache.power = tcache.power + tcache.wbb->local_result.power * pppm_lkg;
-    }
-
-    LSQ->power = LSQ->power_t + LSQ->local_result.power * pppm_lkg;
-    // No LSQ in GPUs (Syed)
-    LSQ->power.reset();
-    power = power + dcache.power + LSQ->power + sharedmemory.power +
-            ccache.power + tcache.power;
-
-    if ((coredynp.core_ty == OOO) &&
-        (XML->sys.core[ithCore].load_buffer_size > 0)) {
-      LoadQ->power = LoadQ->power_t + LoadQ->local_result.power * pppm_lkg;
-      power = power + LoadQ->power;
-    }
-  } else {
-    //    	dcache.rt_power = dcache.power_t +
-    //    (dcache.caches->local_result.power +
-    //    			dcache.missb->local_result.power +
-    //    			dcache.ifb->local_result.power +
-    //    			dcache.prefetchb->local_result.power +
-    //    			dcache.wbb->local_result.power)*pppm_lkg;
-    rt_power.reset();
-    sharedmemory.rt_power.reset();  // Jingwen
-    tcache.rt_power.reset();
-    ccache.rt_power.reset();
-    dcache.rt_power.reset();
-    LSQ->rt_power.reset();
-
-    sharedmemory.rt_power = sharedmemory.power_t +
-                            (sharedmemory.caches->local_result.power +
-                             sharedmemory.missb->local_result.power +
-                             sharedmemory.ifb->local_result.power +
-                             sharedmemory.prefetchb->local_result.power) *
-                                pppm_lkg;
-
-    if (cache_p == Write_back) {
-      sharedmemory.rt_power = sharedmemory.rt_power +
-                              sharedmemory.wbb->local_result.power * pppm_lkg;
-    }
-
-    dcache.rt_power =
-        dcache.power_t +
-        (dcache.caches->local_result.power + dcache.missb->local_result.power +
-         dcache.ifb->local_result.power +
-         dcache.prefetchb->local_result.power) *
-            pppm_lkg;
-    if (cache_p == Write_back) {
-      dcache.rt_power =
-          dcache.rt_power + dcache.wbb->local_result.power * pppm_lkg;
-    }
-
-    ccache.rt_power =
-        ccache.power_t +
-        (ccache.caches->local_result.power + ccache.missb->local_result.power +
-         ccache.ifb->local_result.power +
-         ccache.prefetchb->local_result.power) *
-            pppm_lkg;
-    if (cache_p == Write_back) {
-      ccache.rt_power =
-          ccache.rt_power + ccache.wbb->local_result.power * pppm_lkg;
-    }
-
-    tcache.rt_power =
-        tcache.power_t +
-        (tcache.caches->local_result.power + tcache.missb->local_result.power +
-         tcache.ifb->local_result.power +
-         tcache.prefetchb->local_result.power) *
-            pppm_lkg;
-    if (cache_p == Write_back) {
-      tcache.rt_power =
-          tcache.rt_power + tcache.wbb->local_result.power * pppm_lkg;
-    }
-
-    LSQ->rt_power = LSQ->power_t + LSQ->local_result.power * pppm_lkg;
-    LSQ->rt_power.reset();
-    rt_power = rt_power + dcache.rt_power + LSQ->rt_power +
-               sharedmemory.rt_power + ccache.rt_power + tcache.rt_power;
-
-    if ((coredynp.core_ty == OOO) &&
-        (XML->sys.core[ithCore].load_buffer_size > 0)) {
-      LoadQ->rt_power = LoadQ->power_t + LoadQ->local_result.power * pppm_lkg;
-      rt_power = rt_power + LoadQ->rt_power;
-    }
-  }
-}
-
-void LoadStoreU::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
-  if (!exist) return;
-  string indent_str(indent, ' ');
-  string indent_str_next(indent + 2, ' ');
-  bool long_channel = XML->sys.longer_channel_device;
-
-  if (is_tdp) {
-    cout << indent_str << "Shared Memory:" << endl;
-    cout << indent_str_next << "Area = " << sharedmemory.area.get_area() * 1e-6
-         << " mm^2" << endl;
-    cout << indent_str_next
-         << "Peak Dynamic = " << sharedmemory.power.readOp.dynamic * clockRate
-         << " W" << endl;
-    cout << indent_str_next << "Subthreshold Leakage = "
-         << (long_channel ? sharedmemory.power.readOp.longer_channel_leakage
-                          : sharedmemory.power.readOp.leakage)
-         << " W" << endl;
-    cout << indent_str_next
-         << "Gate Leakage = " << sharedmemory.power.readOp.gate_leakage << " W"
-         << endl;
-    cout << indent_str_next << "Runtime Dynamic = "
-         << sharedmemory.rt_power.readOp.dynamic / executionTime << " W"
-         << endl;
-    cout << endl;
-
-    cout << indent_str << "Data Cache:" << endl;
-    cout << indent_str_next << "Area = " << dcache.area.get_area() * 1e-6
-         << " mm^2" << endl;
-    cout << indent_str_next
-         << "Peak Dynamic = " << dcache.power.readOp.dynamic * clockRate << " W"
-         << endl;
-    cout << indent_str_next << "Subthreshold Leakage = "
-         << (long_channel ? dcache.power.readOp.longer_channel_leakage
-                          : dcache.power.readOp.leakage)
-         << " W" << endl;
-    cout << indent_str_next
-         << "Gate Leakage = " << dcache.power.readOp.gate_leakage << " W"
-         << endl;
-    cout << indent_str_next << "Runtime Dynamic = "
-         << dcache.rt_power.readOp.dynamic / executionTime << " W" << endl;
-    cout << endl;
-
-    cout << indent_str << "Constant Cache:" << endl;
-    cout << indent_str_next << "Area = " << ccache.area.get_area() * 1e-6
-         << " mm^2" << endl;
-    cout << indent_str_next
-         << "Peak Dynamic = " << ccache.power.readOp.dynamic * clockRate << " W"
-         << endl;
-    cout << indent_str_next << "Subthreshold Leakage = "
-         << (long_channel ? dcache.power.readOp.longer_channel_leakage
-                          : dcache.power.readOp.leakage)
-         << " W" << endl;
-    cout << indent_str_next
-         << "Gate Leakage = " << ccache.power.readOp.gate_leakage << " W"
-         << endl;
-    cout << indent_str_next << "Runtime Dynamic = "
-         << ccache.rt_power.readOp.dynamic / executionTime << " W" << endl;
-    cout << indent_str_next
-         << "Runtime Dynamic Energy = " << ccache.rt_power.readOp.dynamic
-         << " J" << endl;
-    cout << indent_str_next << "Execution Time = " << executionTime << " s"
-         << endl;
-    cout << endl;
-
-    cout << indent_str << "Texture Cache:" << endl;
-    cout << indent_str_next << "Area = " << tcache.area.get_area() * 1e-6
-         << " mm^2" << endl;
-    cout << indent_str_next
-         << "Peak Dynamic = " << tcache.power.readOp.dynamic * clockRate << " W"
-         << endl;
-    cout << indent_str_next << "Subthreshold Leakage = "
-         << (long_channel ? dcache.power.readOp.longer_channel_leakage
-                          : dcache.power.readOp.leakage)
-         << " W" << endl;
-    cout << indent_str_next
-         << "Gate Leakage = " << tcache.power.readOp.gate_leakage << " W"
-         << endl;
-    cout << indent_str_next << "Runtime Dynamic = "
-         << tcache.rt_power.readOp.dynamic / executionTime << " W" << endl;
-    cout << endl;
-
-    if (coredynp.core_ty == Inorder) {
-      cout << indent_str << "Load/Store Queue:" << endl;
-      cout << indent_str_next << "Area = " << LSQ->area.get_area() * 1e-6
-           << " mm^2" << endl;
-      cout << indent_str_next
-           << "Peak Dynamic = " << LSQ->power.readOp.dynamic * clockRate << " W"
-           << endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel ? LSQ->power.readOp.longer_channel_leakage
-                            : LSQ->power.readOp.leakage)
-           << " W" << endl;
-      cout << indent_str_next
-           << "Gate Leakage = " << LSQ->power.readOp.gate_leakage << " W"
-           << endl;
-      cout << indent_str_next << "Runtime Dynamic = "
-           << LSQ->rt_power.readOp.dynamic / executionTime << " W" << endl;
-      cout << endl;
-    } else
-
+void BranchPredictor::computeEnergy(bool is_tdp)
+{
+	if (!exist) return;
+	double r_access;
+	double w_access;
+	if (is_tdp)
     {
-      if (XML->sys.core[ithCore].load_buffer_size > 0) {
-        cout << indent_str << "LoadQ:" << endl;
-        cout << indent_str_next << "Area = " << LoadQ->area.get_area() * 1e-6
-             << " mm^2" << endl;
-        cout << indent_str_next
-             << "Peak Dynamic = " << LoadQ->power.readOp.dynamic * clockRate
-             << " W" << endl;
-        cout << indent_str_next << "Subthreshold Leakage = "
-             << (long_channel ? LoadQ->power.readOp.longer_channel_leakage
-                              : LoadQ->power.readOp.leakage)
-             << " W" << endl;
-        cout << indent_str_next
-             << "Gate Leakage = " << LoadQ->power.readOp.gate_leakage << " W"
-             << endl;
-        cout << indent_str_next << "Runtime Dynamic = "
-             << LoadQ->rt_power.readOp.dynamic / executionTime << " W" << endl;
-        cout << endl;
-      }
-      cout << indent_str << "StoreQ:" << endl;
-      cout << indent_str_next << "Area = " << LSQ->area.get_area() * 1e-6
-           << " mm^2" << endl;
-      cout << indent_str_next
-           << "Peak Dynamic = " << LSQ->power.readOp.dynamic * clockRate << " W"
-           << endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel ? LSQ->power.readOp.longer_channel_leakage
-                            : LSQ->power.readOp.leakage)
-           << " W" << endl;
-      cout << indent_str_next
-           << "Gate Leakage = " << LSQ->power.readOp.gate_leakage << " W"
-           << endl;
-      cout << indent_str_next << "Runtime Dynamic = "
-           << LSQ->rt_power.readOp.dynamic / executionTime << " W" << endl;
-      cout << endl;
+    	r_access = coredynp.predictionW*coredynp.BR_duty_cycle;
+    	w_access = 0*coredynp.BR_duty_cycle;
+    	globalBPT->stats_t.readAc.access  = r_access;
+    	globalBPT->stats_t.writeAc.access = w_access;
+    	globalBPT->tdp_stats = globalBPT->stats_t;
+
+    	L1_localBPT->stats_t.readAc.access  = r_access;
+    	L1_localBPT->stats_t.writeAc.access = w_access;
+    	L1_localBPT->tdp_stats = L1_localBPT->stats_t;
+
+    	L2_localBPT->stats_t.readAc.access  = r_access;
+    	L2_localBPT->stats_t.writeAc.access = w_access;
+    	L2_localBPT->tdp_stats = L2_localBPT->stats_t;
+
+    	chooser->stats_t.readAc.access  = r_access;
+    	chooser->stats_t.writeAc.access = w_access;
+    	chooser->tdp_stats = chooser->stats_t;
+
+    	RAS->stats_t.readAc.access  = r_access;
+    	RAS->stats_t.writeAc.access = w_access;
+    	RAS->tdp_stats = RAS->stats_t;
     }
-  } else {
-    cout << indent_str_next << "Shared Memory    Peak Dynamic = "
-         << sharedmemory.rt_power.readOp.dynamic * clockRate << " W" << endl;
-    cout << indent_str_next << "Shared Memory    Subthreshold Leakage = "
-         << sharedmemory.rt_power.readOp.leakage << " W" << endl;
-    cout << indent_str_next << "Shared Memory    Gate Leakage = "
-         << sharedmemory.rt_power.readOp.gate_leakage << " W" << endl;
+    else
+    {
+    	//The resolution of BPT accesses is coarse, but this is
+    	//because most simulators cannot track finer grained details
+    	r_access = XML->sys.core[ithCore].branch_instructions;
+    	w_access = XML->sys.core[ithCore].branch_mispredictions + 0.1*XML->sys.core[ithCore].branch_instructions;//10% of BR will flip internal bits//0
+    	globalBPT->stats_t.readAc.access  = r_access;
+    	globalBPT->stats_t.writeAc.access = w_access;
+    	globalBPT->rtp_stats = globalBPT->stats_t;
 
-    cout << indent_str_next << "Data Cache    Peak Dynamic = "
-         << dcache.rt_power.readOp.dynamic * clockRate << " W" << endl;
-    cout << indent_str_next << "Data Cache    Subthreshold Leakage = "
-         << dcache.rt_power.readOp.leakage << " W" << endl;
-    cout << indent_str_next << "Data Cache    Gate Leakage = "
-         << dcache.rt_power.readOp.gate_leakage << " W" << endl;
+    	L1_localBPT->stats_t.readAc.access  = r_access;
+    	L1_localBPT->stats_t.writeAc.access = w_access;
+    	L1_localBPT->rtp_stats = L1_localBPT->stats_t;
 
-    cout << indent_str_next << "Constant Cache    Peak Dynamic = "
-         << ccache.rt_power.readOp.dynamic * clockRate << " W" << endl;
-    cout << indent_str_next << "Constant Cache    Subthreshold Leakage = "
-         << ccache.rt_power.readOp.leakage << " W" << endl;
-    cout << indent_str_next << "Constant Cache    Gate Leakage = "
-         << ccache.rt_power.readOp.gate_leakage << " W" << endl;
+    	L2_localBPT->stats_t.readAc.access  = r_access;
+    	L2_localBPT->stats_t.writeAc.access = w_access;
+    	L2_localBPT->rtp_stats = L2_localBPT->stats_t;
 
-    cout << indent_str_next << "Texture Cache    Peak Dynamic = "
-         << tcache.rt_power.readOp.dynamic * clockRate << " W" << endl;
-    cout << indent_str_next << "Texture Cache    Subthreshold Leakage = "
-         << tcache.rt_power.readOp.leakage << " W" << endl;
-    cout << indent_str_next << "Texture Cache    Gate Leakage = "
-         << tcache.rt_power.readOp.gate_leakage << " W" << endl;
+    	chooser->stats_t.readAc.access  = r_access;
+    	chooser->stats_t.writeAc.access = w_access;
+    	chooser->rtp_stats = chooser->stats_t;
 
-    if (coredynp.core_ty == Inorder) {
-      cout << indent_str_next << "Load/Store Queue   Peak Dynamic = "
-           << LSQ->rt_power.readOp.dynamic * clockRate << " W" << endl;
-      cout << indent_str_next << "Load/Store Queue   Subthreshold Leakage = "
-           << LSQ->rt_power.readOp.leakage << " W" << endl;
-      cout << indent_str_next << "Load/Store Queue   Gate Leakage = "
-           << LSQ->rt_power.readOp.gate_leakage << " W" << endl;
-    } else {
-      cout << indent_str_next << "LoadQ   Peak Dynamic = "
-           << LoadQ->rt_power.readOp.dynamic * clockRate << " W" << endl;
-      cout << indent_str_next << "LoadQ   Subthreshold Leakage = "
-           << LoadQ->rt_power.readOp.leakage << " W" << endl;
-      cout << indent_str_next
-           << "LoadQ   Gate Leakage = " << LoadQ->rt_power.readOp.gate_leakage
-           << " W" << endl;
-      cout << indent_str_next << "StoreQ   Peak Dynamic = "
-           << LSQ->rt_power.readOp.dynamic * clockRate << " W" << endl;
-      cout << indent_str_next
-           << "StoreQ   Subthreshold Leakage = " << LSQ->rt_power.readOp.leakage
-           << " W" << endl;
-      cout << indent_str_next
-           << "StoreQ   Gate Leakage = " << LSQ->rt_power.readOp.gate_leakage
-           << " W" << endl;
+    	RAS->stats_t.readAc.access  = XML->sys.core[ithCore].function_calls;
+    	RAS->stats_t.writeAc.access = XML->sys.core[ithCore].function_calls;
+    	RAS->rtp_stats = RAS->stats_t;
+   }
+
+	globalBPT->power_t.reset();
+	L1_localBPT->power_t.reset();
+	L2_localBPT->power_t.reset();
+	chooser->power_t.reset();
+	RAS->power_t.reset();
+
+    globalBPT->power_t.readOp.dynamic   +=  globalBPT->local_result.power.readOp.dynamic*globalBPT->stats_t.readAc.access +
+                globalBPT->stats_t.writeAc.access*globalBPT->local_result.power.writeOp.dynamic;
+    L1_localBPT->power_t.readOp.dynamic   +=  L1_localBPT->local_result.power.readOp.dynamic*L1_localBPT->stats_t.readAc.access +
+                L1_localBPT->stats_t.writeAc.access*L1_localBPT->local_result.power.writeOp.dynamic;
+
+    L2_localBPT->power_t.readOp.dynamic   +=  L2_localBPT->local_result.power.readOp.dynamic*L2_localBPT->stats_t.readAc.access +
+                L2_localBPT->stats_t.writeAc.access*L2_localBPT->local_result.power.writeOp.dynamic;
+
+    chooser->power_t.readOp.dynamic   +=  chooser->local_result.power.readOp.dynamic*chooser->stats_t.readAc.access +
+                chooser->stats_t.writeAc.access*chooser->local_result.power.writeOp.dynamic;
+    RAS->power_t.readOp.dynamic   +=  RAS->local_result.power.readOp.dynamic*RAS->stats_t.readAc.access +
+                RAS->stats_t.writeAc.access*RAS->local_result.power.writeOp.dynamic;
+
+    if (is_tdp)
+    {
+    	globalBPT->power = globalBPT->power_t + globalBPT->local_result.power*pppm_lkg;
+    	L1_localBPT->power = L1_localBPT->power_t + L1_localBPT->local_result.power*pppm_lkg;
+    	L2_localBPT->power = L2_localBPT->power_t + L2_localBPT->local_result.power*pppm_lkg;
+    	chooser->power = chooser->power_t + chooser->local_result.power*pppm_lkg;
+    	RAS->power = RAS->power_t + RAS->local_result.power*coredynp.pppm_lkg_multhread;
+
+    	power = power + globalBPT->power + L1_localBPT->power + chooser->power + RAS->power;
     }
-  }
+    else
+    {
+    	globalBPT->rt_power = globalBPT->power_t + globalBPT->local_result.power*pppm_lkg;
+    	L1_localBPT->rt_power = L1_localBPT->power_t + L1_localBPT->local_result.power*pppm_lkg;
+    	L2_localBPT->rt_power = L2_localBPT->power_t + L2_localBPT->local_result.power*pppm_lkg;
+    	chooser->rt_power = chooser->power_t + chooser->local_result.power*pppm_lkg;
+    	RAS->rt_power = RAS->power_t + RAS->local_result.power*coredynp.pppm_lkg_multhread;
+    	rt_power = rt_power + globalBPT->rt_power + L1_localBPT->rt_power + chooser->rt_power + RAS->rt_power;
+    }
 }
 
-void MemManU::computeEnergy(bool is_tdp) {
-  if (!exist) return;
-  if (is_tdp) {
-    // init stats for Peak
-    itlb->stats_t.readAc.access = itlb->l_ip.num_search_ports;
-    itlb->stats_t.readAc.miss = 0;
-    itlb->stats_t.readAc.hit =
-        itlb->stats_t.readAc.access - itlb->stats_t.readAc.miss;
-    itlb->tdp_stats = itlb->stats_t;
+void BranchPredictor::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
+{
+	if (!exist) return;
+	string indent_str(indent, ' ');
+	string indent_str_next(indent+2, ' ');
+	bool long_channel = XML->sys.longer_channel_device;
+	if (is_tdp)
+	{
+		cout << indent_str<< "Global Predictor:" << endl;
+		cout << indent_str_next << "Area = " << globalBPT->area.get_area()*1e-6<< " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << globalBPT->power.readOp.dynamic*clockRate << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = "
+			<< (long_channel? globalBPT->power.readOp.longer_channel_leakage:globalBPT->power.readOp.leakage) <<" W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << globalBPT->power.readOp.gate_leakage << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic = " << globalBPT->rt_power.readOp.dynamic/executionTime << " W" << endl;
+		cout <<endl;
+		cout << indent_str << "Local Predictor:" << endl;
+		cout << indent_str << "L1_Local Predictor:" << endl;
+		cout << indent_str_next << "Area = " << L1_localBPT->area.get_area() *1e-6 << " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << L1_localBPT->power.readOp.dynamic*clockRate  << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = "
+			<< (long_channel? L1_localBPT->power.readOp.longer_channel_leakage:L1_localBPT->power.readOp.leakage)  << " W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << L1_localBPT->power.readOp.gate_leakage  << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic = " << L1_localBPT->rt_power.readOp.dynamic/executionTime << " W" << endl;
+		cout <<endl;
+		cout << indent_str << "L2_Local Predictor:" << endl;
+		cout << indent_str_next << "Area = " << L2_localBPT->area.get_area() *1e-6 << " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << L2_localBPT->power.readOp.dynamic*clockRate  << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = "
+			<< (long_channel? L2_localBPT->power.readOp.longer_channel_leakage:L2_localBPT->power.readOp.leakage)  << " W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << L2_localBPT->power.readOp.gate_leakage  << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic = " << L2_localBPT->rt_power.readOp.dynamic/executionTime << " W" << endl;
+		cout <<endl;
 
-    dtlb->stats_t.readAc.access =
-        dtlb->l_ip.num_search_ports * coredynp.LSU_duty_cycle;
-    dtlb->stats_t.readAc.miss = 0;
-    dtlb->stats_t.readAc.hit =
-        dtlb->stats_t.readAc.access - dtlb->stats_t.readAc.miss;
-    dtlb->tdp_stats = dtlb->stats_t;
-  } else {
-    // init stats for Runtime Dynamic (RTP)
-    itlb->stats_t.readAc.access = XML->sys.core[ithCore].itlb.total_accesses;
-    itlb->stats_t.readAc.miss = XML->sys.core[ithCore].itlb.total_misses;
-    itlb->stats_t.readAc.hit =
-        itlb->stats_t.readAc.access - itlb->stats_t.readAc.miss;
-    itlb->rtp_stats = itlb->stats_t;
+		cout << indent_str << "Chooser:" << endl;
+		cout << indent_str_next << "Area = " << chooser->area.get_area()  *1e-6 << " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << chooser->power.readOp.dynamic*clockRate  << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = "
+			<< (long_channel? chooser->power.readOp.longer_channel_leakage:chooser->power.readOp.leakage)  << " W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << chooser->power.readOp.gate_leakage  << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic = " << chooser->rt_power.readOp.dynamic/executionTime << " W" << endl;
+		cout <<endl;
+		cout << indent_str << "RAS:" << endl;
+		cout << indent_str_next << "Area = " << RAS->area.get_area() *1e-6 << " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << RAS->power.readOp.dynamic*clockRate  << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = "
+			<< (long_channel? RAS->power.readOp.longer_channel_leakage:RAS->power.readOp.leakage)  << " W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << RAS->power.readOp.gate_leakage  << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic = " << RAS->rt_power.readOp.dynamic/executionTime << " W" << endl;
+		cout <<endl;
+	}
+	else
+	{
+//		cout << indent_str_next << "Global Predictor    Peak Dynamic = " << globalBPT->rt_power.readOp.dynamic*clockRate << " W" << endl;
+//		cout << indent_str_next << "Global Predictor    Subthreshold Leakage = " << globalBPT->rt_power.readOp.leakage <<" W" << endl;
+//		cout << indent_str_next << "Global Predictor    Gate Leakage = " << globalBPT->rt_power.readOp.gate_leakage << " W" << endl;
+//		cout << indent_str_next << "Local Predictor   Peak Dynamic = " << L1_localBPT->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+//		cout << indent_str_next << "Local Predictor   Subthreshold Leakage = " << L1_localBPT->rt_power.readOp.leakage  << " W" << endl;
+//		cout << indent_str_next << "Local Predictor   Gate Leakage = " << L1_localBPT->rt_power.readOp.gate_leakage  << " W" << endl;
+//		cout << indent_str_next << "Chooser   Peak Dynamic = " << chooser->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+//		cout << indent_str_next << "Chooser   Subthreshold Leakage = " << chooser->rt_power.readOp.leakage  << " W" << endl;
+//		cout << indent_str_next << "Chooser   Gate Leakage = " << chooser->rt_power.readOp.gate_leakage  << " W" << endl;
+//		cout << indent_str_next << "RAS   Peak Dynamic = " << RAS->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+//		cout << indent_str_next << "RAS   Subthreshold Leakage = " << RAS->rt_power.readOp.leakage  << " W" << endl;
+//		cout << indent_str_next << "RAS   Gate Leakage = " << RAS->rt_power.readOp.gate_leakage  << " W" << endl;
+	}
 
-    dtlb->stats_t.readAc.access = XML->sys.core[ithCore].dtlb.total_accesses;
-    dtlb->stats_t.readAc.miss = XML->sys.core[ithCore].dtlb.total_misses;
-    dtlb->stats_t.readAc.hit =
-        dtlb->stats_t.readAc.access - dtlb->stats_t.readAc.miss;
-    dtlb->rtp_stats = dtlb->stats_t;
-  }
-
-  itlb->power_t.reset();
-  dtlb->power_t.reset();
-  itlb->power_t.readOp.dynamic +=
-      itlb->stats_t.readAc.access *
-          itlb->local_result.power.searchOp.dynamic  // FA spent most power in
-                                                     // tag, so use total access
-                                                     // not hits
-      + itlb->stats_t.readAc.miss * itlb->local_result.power.writeOp.dynamic;
-  dtlb->power_t.readOp.dynamic +=
-      dtlb->stats_t.readAc.access *
-          dtlb->local_result.power.searchOp.dynamic  // FA spent most power in
-                                                     // tag, so use total access
-                                                     // not hits
-      + dtlb->stats_t.readAc.miss * dtlb->local_result.power.writeOp.dynamic;
-
-  if (is_tdp) {
-    itlb->power = itlb->power_t + itlb->local_result.power * pppm_lkg;
-    dtlb->power = dtlb->power_t + dtlb->local_result.power * pppm_lkg;
-    power = power + itlb->power + dtlb->power;
-  } else {
-    itlb->rt_power = itlb->power_t + itlb->local_result.power * pppm_lkg;
-    dtlb->rt_power = dtlb->power_t + dtlb->local_result.power * pppm_lkg;
-    rt_power = rt_power + itlb->rt_power + dtlb->rt_power;
-  }
 }
 
-void MemManU::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
-  if (!exist) return;
-  string indent_str(indent, ' ');
-  string indent_str_next(indent + 2, ' ');
-  bool long_channel = XML->sys.longer_channel_device;
+void InstFetchU::computeEnergy(bool is_tdp)
+{
+  executionTime=XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);//Syed
+  //cout <<"IFU: execution time: "<<XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6)<<endl;
+  //cout <<"IFU: total cycles"<<XML->sys.total_cycles<<endl;
+	if (!exist) return;
+	if (is_tdp)
+    {
+		//init stats for Peak
+    	icache.caches->stats_t.readAc.access  = icache.caches->l_ip.num_rw_ports*coredynp.IFU_duty_cycle;
+    	icache.caches->stats_t.readAc.miss    = 0;
+    	icache.caches->stats_t.readAc.hit     = icache.caches->stats_t.readAc.access - icache.caches->stats_t.readAc.miss;
+    	icache.caches->tdp_stats = icache.caches->stats_t;
 
-  if (is_tdp) {
-    cout << indent_str << "Itlb:" << endl;
-    cout << indent_str_next << "Area = " << itlb->area.get_area() * 1e-6
-         << " mm^2" << endl;
-    cout << indent_str_next
-         << "Peak Dynamic = " << itlb->power.readOp.dynamic * clockRate << " W"
-         << endl;
-    cout << indent_str_next << "Subthreshold Leakage = "
-         << (long_channel ? itlb->power.readOp.longer_channel_leakage
-                          : itlb->power.readOp.leakage)
-         << " W" << endl;
-    cout << indent_str_next
-         << "Gate Leakage = " << itlb->power.readOp.gate_leakage << " W"
-         << endl;
-    cout << indent_str_next << "Runtime Dynamic = "
-         << itlb->rt_power.readOp.dynamic / executionTime << " W" << endl;
-    cout << endl;
-    cout << indent_str << "Dtlb:" << endl;
-    cout << indent_str_next << "Area = " << dtlb->area.get_area() * 1e-6
-         << " mm^2" << endl;
-    cout << indent_str_next
-         << "Peak Dynamic = " << dtlb->power.readOp.dynamic * clockRate << " W"
-         << endl;
-    cout << indent_str_next << "Subthreshold Leakage = "
-         << (long_channel ? dtlb->power.readOp.longer_channel_leakage
-                          : dtlb->power.readOp.leakage)
-         << " W" << endl;
-    cout << indent_str_next
-         << "Gate Leakage = " << dtlb->power.readOp.gate_leakage << " W"
-         << endl;
-    cout << indent_str_next << "Runtime Dynamic = "
-         << dtlb->rt_power.readOp.dynamic / executionTime << " W" << endl;
-    cout << endl;
-  } else {
-    cout << indent_str_next << "Itlb    Peak Dynamic = "
-         << itlb->rt_power.readOp.dynamic * clockRate << " W" << endl;
-    cout << indent_str_next
-         << "Itlb    Subthreshold Leakage = " << itlb->rt_power.readOp.leakage
-         << " W" << endl;
-    cout << indent_str_next
-         << "Itlb    Gate Leakage = " << itlb->rt_power.readOp.gate_leakage
-         << " W" << endl;
-    cout << indent_str_next << "Dtlb   Peak Dynamic = "
-         << dtlb->rt_power.readOp.dynamic * clockRate << " W" << endl;
-    cout << indent_str_next
-         << "Dtlb   Subthreshold Leakage = " << dtlb->rt_power.readOp.leakage
-         << " W" << endl;
-    cout << indent_str_next
-         << "Dtlb   Gate Leakage = " << dtlb->rt_power.readOp.gate_leakage
-         << " W" << endl;
-  }
+    	icache.missb->stats_t.readAc.access  = icache.missb->stats_t.readAc.hit=  icache.missb->l_ip.num_search_ports;
+    	icache.missb->stats_t.writeAc.access = icache.missb->stats_t.writeAc.hit= icache.missb->l_ip.num_search_ports;
+    	icache.missb->tdp_stats = icache.missb->stats_t;
+
+    	icache.ifb->stats_t.readAc.access  = icache.ifb->stats_t.readAc.hit=  icache.ifb->l_ip.num_search_ports;
+    	icache.ifb->stats_t.writeAc.access = icache.ifb->stats_t.writeAc.hit= icache.ifb->l_ip.num_search_ports;
+    	icache.ifb->tdp_stats = icache.ifb->stats_t;
+
+    	icache.prefetchb->stats_t.readAc.access  = icache.prefetchb->stats_t.readAc.hit= icache.prefetchb->l_ip.num_search_ports;
+    	icache.prefetchb->stats_t.writeAc.access = icache.ifb->stats_t.writeAc.hit= icache.ifb->l_ip.num_search_ports;
+    	icache.prefetchb->tdp_stats = icache.prefetchb->stats_t;
+
+    	IB->stats_t.readAc.access = IB->stats_t.writeAc.access = XML->sys.core[ithCore].peak_issue_width;
+    	IB->tdp_stats = IB->stats_t;
+
+    	if (coredynp.predictionW>0)
+    	{
+    		BTB->stats_t.readAc.access  = coredynp.predictionW;//XML->sys.core[ithCore].BTB.read_accesses;
+    		BTB->stats_t.writeAc.access = 0;//XML->sys.core[ithCore].BTB.write_accesses;
+    	}
+
+    	ID_inst->stats_t.readAc.access     = coredynp.decodeW;
+    	ID_operand->stats_t.readAc.access  = coredynp.decodeW;
+    	ID_misc->stats_t.readAc.access     = coredynp.decodeW;
+    	ID_inst->tdp_stats = ID_inst->stats_t;
+    	ID_operand->tdp_stats = ID_operand->stats_t;
+    	ID_misc->tdp_stats = ID_misc->stats_t;
+
+
+   
+	 } /* if (is_tdp) */
+    else
+    {
+      rt_power.reset();
+      icache.rt_power.reset(); //Jingwen
+     	//init stats for Runtime Dynamic (RTP)
+		//cout<< "****>>>>Icache stats:"<<endl;
+		//cout<<"Read accesses: "<< XML->sys.core[ithCore].icache.read_accesses << " Read misses: "<<XML->sys.core[ithCore].icache.read_misses<<endl;
+    	icache.caches->stats_t.readAc.access  = XML->sys.core[ithCore].icache.read_accesses;
+    	icache.caches->stats_t.readAc.miss    = XML->sys.core[ithCore].icache.read_misses;
+    	//cout<<endl<<"inside mcpat read access= "<<XML->sys.core[ithCore].icache.read_accesses;
+    	//cout<<endl<<"inside mcpat read miss= "<<XML->sys.core[ithCore].icache.read_misses;
+
+    	icache.caches->stats_t.readAc.hit     = icache.caches->stats_t.readAc.access - icache.caches->stats_t.readAc.miss;
+    	icache.caches->rtp_stats = icache.caches->stats_t;
+    	//cout<<endl<<"inside mcpat read hit= "<<icache.caches->stats_t.readAc.hit<<endl;
+    	icache.missb->stats_t.readAc.access  = icache.caches->stats_t.readAc.miss;
+    	icache.missb->stats_t.writeAc.access = icache.caches->stats_t.readAc.miss;
+    	icache.missb->rtp_stats = icache.missb->stats_t;
+
+    	icache.ifb->stats_t.readAc.access  = icache.caches->stats_t.readAc.miss;
+    	icache.ifb->stats_t.writeAc.access = icache.caches->stats_t.readAc.miss;
+    	icache.ifb->rtp_stats = icache.ifb->stats_t;
+
+    	icache.prefetchb->stats_t.readAc.access  = icache.caches->stats_t.readAc.miss;
+    	icache.prefetchb->stats_t.writeAc.access = icache.caches->stats_t.readAc.miss;
+    	icache.prefetchb->rtp_stats = icache.prefetchb->stats_t;
+
+    	IB->stats_t.readAc.access = IB->stats_t.writeAc.access = XML->sys.core[ithCore].total_instructions;
+    	IB->rtp_stats = IB->stats_t;
+    	//cout<<"IB: total instructions: "<<IB->stats_t.readAc.access <<endl;
+    	if (coredynp.predictionW>0)
+    	{
+    		BTB->stats_t.readAc.access  = XML->sys.core[ithCore].BTB.read_accesses;//XML->sys.core[ithCore].branch_instructions;
+    		BTB->stats_t.writeAc.access = XML->sys.core[ithCore].BTB.write_accesses;//XML->sys.core[ithCore].branch_mispredictions;
+    		BTB->rtp_stats = BTB->stats_t;
+    	}
+    	//cout<<"ID: total instructions: "<< XML->sys.core[ithCore].total_instructions<<endl;
+    	ID_inst->stats_t.readAc.access     = XML->sys.core[ithCore].total_instructions;
+    	ID_operand->stats_t.readAc.access  = XML->sys.core[ithCore].total_instructions;
+    	ID_misc->stats_t.readAc.access     = XML->sys.core[ithCore].total_instructions;
+    	ID_inst->rtp_stats = ID_inst->stats_t;
+    	ID_operand->rtp_stats = ID_operand->stats_t;
+    	ID_misc->rtp_stats = ID_misc->stats_t;
+
+    }
+
+    icache.power_t.reset();
+    IB->power_t.reset();
+//	ID_inst->power_t.reset();
+//	ID_operand->power_t.reset();
+//	ID_misc->power_t.reset();
+    if (coredynp.predictionW>0)
+    {
+    	BTB->power_t.reset();
+    }
+
+    icache.power_t.readOp.dynamic	+= (icache.caches->stats_t.readAc.hit*icache.caches->local_result.power.readOp.dynamic+
+    		//icache.caches->stats_t.readAc.miss*icache.caches->local_result.tag_array2->power.readOp.dynamic+
+    		icache.caches->stats_t.readAc.miss*icache.caches->local_result.power.readOp.dynamic+ //assume tag data accessed in parallel
+    		icache.caches->stats_t.readAc.miss*icache.caches->local_result.power.writeOp.dynamic); //read miss in Icache cause a write to Icache
+    icache.power_t.readOp.dynamic	+=  icache.missb->stats_t.readAc.access*icache.missb->local_result.power.searchOp.dynamic +
+            icache.missb->stats_t.writeAc.access*icache.missb->local_result.power.writeOp.dynamic;//each access to missb involves a CAM and a write
+    icache.power_t.readOp.dynamic	+=  icache.ifb->stats_t.readAc.access*icache.ifb->local_result.power.searchOp.dynamic +
+            icache.ifb->stats_t.writeAc.access*icache.ifb->local_result.power.writeOp.dynamic;
+    icache.power_t.readOp.dynamic	+=  icache.prefetchb->stats_t.readAc.access*icache.prefetchb->local_result.power.searchOp.dynamic +
+            icache.prefetchb->stats_t.writeAc.access*icache.prefetchb->local_result.power.writeOp.dynamic;
+   //cout<<"Icache power: "<<icache.power_t.readOp.dynamic	<<endl;
+	IB->power_t.readOp.dynamic   +=  IB->local_result.power.readOp.dynamic*IB->stats_t.readAc.access +
+			IB->stats_t.writeAc.access*IB->local_result.power.writeOp.dynamic;
+  //cout << "IB power: "<<IB->power_t.readOp.dynamic<<endl;
+	if (coredynp.predictionW>0)
+	{
+		BTB->power_t.readOp.dynamic   +=  BTB->local_result.power.readOp.dynamic*BTB->stats_t.readAc.access +
+		BTB->stats_t.writeAc.access*BTB->local_result.power.writeOp.dynamic;
+
+		BPT->computeEnergy(is_tdp);
+	}
+
+    if (is_tdp)
+    {
+//    	icache.power = icache.power_t +
+//    	        (icache.caches->local_result.power)*pppm_lkg +
+//    			(icache.missb->local_result.power +
+//    			icache.ifb->local_result.power +
+//    			icache.prefetchb->local_result.power)*pppm_Isub;
+    	icache.power = icache.power_t +
+    	        (icache.caches->local_result.power +
+    			icache.missb->local_result.power +
+    			icache.ifb->local_result.power +
+    			icache.prefetchb->local_result.power)*pppm_lkg;
+
+    	IB->power = IB->power_t + IB->local_result.power*pppm_lkg;
+    	power     = power + icache.power + IB->power;
+    	if (coredynp.predictionW>0)
+    	{
+    		BTB->power = BTB->power_t + BTB->local_result.power*pppm_lkg;
+    		power     = power  + BTB->power + BPT->power;
+    	}
+
+    	ID_inst->power_t.readOp.dynamic    = ID_inst->power.readOp.dynamic;
+    	ID_operand->power_t.readOp.dynamic = ID_operand->power.readOp.dynamic;
+    	ID_misc->power_t.readOp.dynamic    = ID_misc->power.readOp.dynamic;
+
+    	ID_inst->power.readOp.dynamic    *= ID_inst->tdp_stats.readAc.access;
+    	ID_operand->power.readOp.dynamic *= ID_operand->tdp_stats.readAc.access;
+    	ID_misc->power.readOp.dynamic    *= ID_misc->tdp_stats.readAc.access;
+
+    	power = power + (ID_inst->power +
+							ID_operand->power +
+							ID_misc->power);
+	 } /* if (is_tdp) */ 
+    else
+    {
+//    	icache.rt_power = icache.power_t +
+//    	        (icache.caches->local_result.power)*pppm_lkg +
+//    			(icache.missb->local_result.power +
+//    			icache.ifb->local_result.power +
+//    			icache.prefetchb->local_result.power)*pppm_Isub;
+
+    	icache.rt_power = icache.power_t +
+    	        (icache.caches->local_result.power +
+    			icache.missb->local_result.power +
+    			icache.ifb->local_result.power +
+    			icache.prefetchb->local_result.power)*pppm_lkg;
+
+    	//IB->rt_power = IB->power_t + IB->local_result.power*pppm_lkg;
+    	IB->rt_power.readOp.dynamic = IB->local_result.power.readOp.dynamic * IB->rtp_stats.readAc.access;
+    	IB->rt_power.readOp.dynamic += IB->local_result.power.writeOp.dynamic * IB->rtp_stats.writeAc.access;
+    	rt_power     = rt_power + icache.rt_power + IB->rt_power;
+    	if (coredynp.predictionW>0)
+    	{
+    		BTB->rt_power = BTB->power_t + BTB->local_result.power*pppm_lkg;
+    		rt_power     = rt_power + BTB->rt_power + BPT->rt_power;
+    	}
+
+    	ID_inst->rt_power.readOp.dynamic    = ID_inst->power_t.readOp.dynamic*ID_inst->rtp_stats.readAc.access;
+    	ID_operand->rt_power.readOp.dynamic = ID_operand->power_t.readOp.dynamic * ID_operand->rtp_stats.readAc.access;
+    	ID_misc->rt_power.readOp.dynamic    = ID_misc->power_t.readOp.dynamic * ID_misc->rtp_stats.readAc.access;
+
+    	rt_power = rt_power + (ID_inst->rt_power +
+							ID_operand->rt_power +
+							ID_misc->rt_power);
+		//cout<<"ID inst: "<<ID_inst->rt_power.readOp.dynamic << " ID operand: "<<ID_operand->rt_power.readOp.dynamic<<" ID misc: "<<ID_misc->rt_power.readOp.dynamic<<endl;
+    }
 }
 
-void RegFU::computeEnergy(bool is_tdp) {
-  /*
-   * Architecture RF and physical RF cannot be present at the same time.
-   * Therefore, the RF stats can only refer to either ARF or PRF;
-   * And the same stats can be used for both.
-   */
-  if (!exist) return;
+void InstFetchU::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
+{
+	if (!exist) return;
+	string indent_str(indent, ' ');
+	string indent_str_next(indent+2, ' ');
+	bool long_channel = XML->sys.longer_channel_device;
 
-  executionTime =
-      XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);  // Syed
-  // RF crossbar power (Syed Gilani)
-  xbar_rfu->compute_power();
 
-  // Arbiter power
-  arbiter_rfu->compute_power();
+	if (is_tdp)
+	{
 
-  if (is_tdp) {
-    // RF power -- modified by Syed
-    // init stats for Peak
+		cout << indent_str<< "Instruction Cache:" << endl;
+		cout << indent_str_next << "Area = " << icache.area.get_area()*1e-6<< " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << icache.power.readOp.dynamic*clockRate << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = "
+			<< (long_channel? icache.power.readOp.longer_channel_leakage:icache.power.readOp.leakage) <<" W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << icache.power.readOp.gate_leakage << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic = " << icache.rt_power.readOp.dynamic/executionTime << " W" << endl;
+		cout <<endl;
+		if (coredynp.predictionW>0)
+		{
+			cout << indent_str<< "Branch Target Buffer:" << endl;
+			cout << indent_str_next << "Area = " << BTB->area.get_area() *1e-6 << " mm^2" << endl;
+			cout << indent_str_next << "Peak Dynamic = " << BTB->power.readOp.dynamic*clockRate  << " W" << endl;
+			cout << indent_str_next << "Subthreshold Leakage = "
+				<< (long_channel? BTB->power.readOp.longer_channel_leakage:BTB->power.readOp.leakage)  << " W" << endl;
+			cout << indent_str_next << "Gate Leakage = " << BTB->power.readOp.gate_leakage  << " W" << endl;
+			cout << indent_str_next << "Runtime Dynamic = " << BTB->rt_power.readOp.dynamic/executionTime << " W" << endl;
+			cout <<endl;
+			if (BPT->exist)
+			{
+				cout << indent_str<< "Branch Predictor:" << endl;
+				cout << indent_str_next << "Area = " << BPT->area.get_area()  *1e-6<< " mm^2" << endl;
+				cout << indent_str_next << "Peak Dynamic = " << BPT->power.readOp.dynamic*clockRate  << " W" << endl;
+				cout << indent_str_next << "Subthreshold Leakage = "
+					<< (long_channel? BPT->power.readOp.longer_channel_leakage:BPT->power.readOp.leakage)  << " W" << endl;
+				cout << indent_str_next << "Gate Leakage = " << BPT->power.readOp.gate_leakage  << " W" << endl;
+				cout << indent_str_next << "Runtime Dynamic = " << BPT->rt_power.readOp.dynamic/executionTime << " W" << endl;
+				cout <<endl;
+				if (plevel>3)
+				{
+					BPT->displayEnergy(indent+4, plevel, is_tdp);
+				}
+			}
+		}
+		cout << indent_str<< "Instruction Buffer:" << endl;
+		cout << indent_str_next << "Area = " << IB->area.get_area()*1e-6  << " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << IB->power.readOp.dynamic*clockRate  << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = "
+		<< (long_channel? IB->power.readOp.longer_channel_leakage:IB->power.readOp.leakage)  << " W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << IB->power.readOp.gate_leakage  << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic = " << IB->rt_power.readOp.dynamic/executionTime << " W" << endl;
+		cout <<endl;
+		cout << indent_str<< "Instruction Decoder:" << endl;
+		cout << indent_str_next << "Area = " << (ID_inst->area.get_area() +
+				ID_operand->area.get_area() +
+				ID_misc->area.get_area())*coredynp.decodeW*1e-6  << " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << (ID_inst->power.readOp.dynamic +
+				ID_operand->power.readOp.dynamic +
+				ID_misc->power.readOp.dynamic)*clockRate  << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = "
+		<< (long_channel? (ID_inst->power.readOp.longer_channel_leakage +
+				ID_operand->power.readOp.longer_channel_leakage +
+				ID_misc->power.readOp.longer_channel_leakage):
+					(ID_inst->power.readOp.leakage +
+							ID_operand->power.readOp.leakage +
+							ID_misc->power.readOp.leakage))  << " W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << (ID_inst->power.readOp.gate_leakage +
+				ID_operand->power.readOp.gate_leakage +
+				ID_misc->power.readOp.gate_leakage)  << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic = " << (ID_inst->rt_power.readOp.dynamic +
+				ID_operand->rt_power.readOp.dynamic +
+				ID_misc->rt_power.readOp.dynamic)/executionTime << " W" << endl;
+		cout <<endl;
+	}
+	else
+	{
+//		cout << indent_str_next << "Instruction Cache    Peak Dynamic = " << icache.rt_power.readOp.dynamic*clockRate << " W" << endl;
+//		cout << indent_str_next << "Instruction Cache    Subthreshold Leakage = " << icache.rt_power.readOp.leakage <<" W" << endl;
+//		cout << indent_str_next << "Instruction Cache    Gate Leakage = " << icache.rt_power.readOp.gate_leakage << " W" << endl;
+//		cout << indent_str_next << "Instruction Buffer   Peak Dynamic = " << IB->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+//		cout << indent_str_next << "Instruction Buffer   Subthreshold Leakage = " << IB->rt_power.readOp.leakage  << " W" << endl;
+//		cout << indent_str_next << "Instruction Buffer   Gate Leakage = " << IB->rt_power.readOp.gate_leakage  << " W" << endl;
+//		cout << indent_str_next << "Branch Target Buffer   Peak Dynamic = " << BTB->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+//		cout << indent_str_next << "Branch Target Buffer   Subthreshold Leakage = " << BTB->rt_power.readOp.leakage  << " W" << endl;
+//		cout << indent_str_next << "Branch Target Buffer   Gate Leakage = " << BTB->rt_power.readOp.gate_leakage  << " W" << endl;
+//		cout << indent_str_next << "Branch Predictor   Peak Dynamic = " << BPT->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+//		cout << indent_str_next << "Branch Predictor   Subthreshold Leakage = " << BPT->rt_power.readOp.leakage  << " W" << endl;
+//		cout << indent_str_next << "Branch Predictor   Gate Leakage = " << BPT->rt_power.readOp.gate_leakage  << " W" << endl;
+	}
 
-    IRF->stats_t.readAc.access = 4;
-    IRF->stats_t.writeAc.access = 4;
-    IRF->tdp_stats = IRF->stats_t;
-
-    IRF->stats_t.readAc.access = 2;
-    IRF->stats_t.writeAc.access = 1;
-    IRF->tdp_stats = IRF->stats_t;
-
-    OPC->stats_t.readAc.access = 32;
-    OPC->stats_t.writeAc.access = 32;
-    OPC->tdp_stats = OPC->stats_t;
-
-    // Commented by Syed (GPUs have a single RF which we model by IRF)
-    // FRF->stats_t.readAc.access  =
-    // FRF->l_ip.num_rd_ports*coredynp.FPU_duty_cycle*1.05*coredynp.num_fp_pipelines;
-    // FRF->stats_t.writeAc.access  =
-    // FRF->l_ip.num_wr_ports*coredynp.FPU_duty_cycle*1.05*coredynp.num_fp_pipelines;
-    // FRF->tdp_stats = FRF->stats_t;
-    if (coredynp.regWindowing) {
-      RFWIN->stats_t.readAc.access = 0;   // 0.5*RFWIN->l_ip.num_rw_ports;
-      RFWIN->stats_t.writeAc.access = 0;  // 0.5*RFWIN->l_ip.num_rw_ports;
-      RFWIN->tdp_stats = RFWIN->stats_t;
-    }
-  } /* if (is_tdp) */
-  else {
-    // init stats for Runtime Dynamic (RTP)
-    // in Tesla each RF operand accesses 2 banks, so multiply acceses by 2
-    // (read and write energies of reg_file are per bank)(Tesla) : Syed
-    // Also, for a SIMD width of 8 and warp size of 32 threads, 4 accesses
-    // (each accessing 2 banks) need to be performed per operand
-    if (XML->sys.architecture == 1) {
-      IRF->stats_t.readAc.access =
-          (XML->sys.core[ithCore].int_regfile_reads / 32) * (4 * 2);  /// 1.5;
-      IRF->stats_t.writeAc.access =
-          (XML->sys.core[ithCore].int_regfile_writes / 32) * (4 * 2);  /// 1.5;
-    } else {
-      IRF->stats_t.readAc.access =
-          (XML->sys.core[ithCore].int_regfile_reads / 32) *
-          (2 * 4);  /// 1.5;//TODO: no diff on archi and phy
-      IRF->stats_t.writeAc.access =
-          (XML->sys.core[ithCore].int_regfile_writes / 32) * (2 * 4);  /// 1.5;
-    }
-    IRF->rtp_stats = IRF->stats_t;
-
-    OPC->stats_t.readAc.access =
-        (XML->sys.core[ithCore].int_regfile_reads) /*/1.5*/ +
-        XML->sys.core[ithCore]
-            .non_rf_operands;  /// 1.5;//TODO: no diff on archi and phy
-    OPC->stats_t.writeAc.access = 0;
-    OPC->rtp_stats = OPC->stats_t;
-
-    // cout<< "IRF read energy: "<<
-    // IRF->local_result.power.readOp.dynamic<<endl;
-    // cout<< "IRF write energy: "<<
-    // IRF->local_result.power.writeOp.dynamic<<endl;
-    // FRF->stats_t.readAc.access  = XML->sys.core[ithCore].float_regfile_reads;
-    // FRF->stats_t.writeAc.access  =
-    // XML->sys.core[ithCore].float_regfile_writes;
-    // FRF->rtp_stats = FRF->stats_t;
-    if (coredynp.regWindowing) {
-      RFWIN->stats_t.readAc.access = XML->sys.core[ithCore].function_calls * 16;
-      RFWIN->stats_t.writeAc.access =
-          XML->sys.core[ithCore].function_calls * 16;
-      RFWIN->rtp_stats = RFWIN->stats_t;
-
-      IRF->stats_t.readAc.access = XML->sys.core[ithCore].int_regfile_reads +
-                                   XML->sys.core[ithCore].function_calls * 16;
-      IRF->stats_t.writeAc.access = XML->sys.core[ithCore].int_regfile_writes +
-                                    XML->sys.core[ithCore].function_calls * 16;
-      IRF->rtp_stats = IRF->stats_t;
-    }
-  }
-  IRF->power_t.reset();
-  FRF->power_t.reset();
-  OPC->power_t.reset();
-  // IRF->power_t  =  IRF->power_t + IRF->local_result.power;// +
-  // xbar_rfu->power + arbiter_rfu->power;
-
-  IRF->power_t.readOp.dynamic =
-      (IRF->stats_t.readAc.access * IRF->local_result.power.readOp.dynamic +
-       IRF->stats_t.writeAc.access * IRF->local_result.power.writeOp.dynamic);
-  OPC->power_t.readOp.dynamic =
-      (OPC->stats_t.readAc.access * OPC->local_result.power.readOp.dynamic);
-
-  if (coredynp.regWindowing) {
-    RFWIN->power_t.reset();
-    RFWIN->power_t.readOp.dynamic +=
-        (RFWIN->stats_t.readAc.access *
-             RFWIN->local_result.power.readOp.dynamic +
-         RFWIN->stats_t.writeAc.access *
-             RFWIN->local_result.power.writeOp.dynamic);
-  }
-
-  if (is_tdp) {
-    // cout<<"pre: IRF_power_t: "<<IRF->power.readOp.dynamic<<"
-    // ("<<IRF->power.readOp.dynamic*clockRate<<") "<<" IRF_localresult: "<<
-    //                   IRF->local_result.power.readOp.dynamic<<endl;
-    // Syed: removed the multiplication of power by hardware threads
-    // since the one IRF  is shared by all threads in GPUs
-
-    // FRF->power  =  FRF->power_t + FRF->local_result.power
-    // *coredynp.pppm_lkg_multhread;
-
-    double pppm_lkg_banks[4];
-    set_pppm(pppm_lkg_banks, 0, XML->sys.core[ithCore].collector_units,
-             XML->sys.core[ithCore].collector_units);
-    IRF->power = (IRF->power_t) + IRF->local_result.power * pppm_lkg;
-    IRF->power.readOp.dynamic = IRF->power_t.readOp.dynamic * 1;
-    OPC->power = (OPC->power_t) + OPC->local_result.power * pppm_lkg_banks;
-    OPC->power.readOp.dynamic = OPC->power_t.readOp.dynamic * 1;
-
-    power = power + (IRF->power + OPC->power);
-
-    if (coredynp.regWindowing) {
-      RFWIN->power = RFWIN->power_t + RFWIN->local_result.power * pppm_lkg;
-      power = power + RFWIN->power;
-    }
-  } /* if (is_tdp) */
-  else {
-    // Removed *coredynp.pppm_lkg_multhread since all hardware threads shared
-    // the same IRF
-    IRF->rt_power =
-        IRF->power_t +
-        IRF->local_result.power * pppm_lkg; /* *coredynp.pppm_lkg_multhread;*/
-    OPC->rt_power = OPC->power_t + OPC->local_result.power * pppm_lkg;
-    if (XML->sys.architecture == 1) {
-      // Each warp operand accesses the crossbar
-      xbar_rfu->rt_power.readOp.dynamic =
-          ((XML->sys.core[ithCore].int_regfile_reads / (32 /**1.5*/)) +
-           (XML->sys.core[ithCore].non_rf_operands / (32 /**1.5*/))) *
-          xbar_rfu->power.readOp.dynamic;
-    } else {
-      xbar_rfu->rt_power.readOp.dynamic =
-          ((XML->sys.core[ithCore].int_regfile_reads / (32 /**1.5*/)) +
-           (XML->sys.core[ithCore].non_rf_operands / (32 /**1.5*/))) *
-          xbar_rfu->power.readOp.dynamic;
-    }
-    arbiter_rfu->rt_power.readOp.dynamic =
-        ((XML->sys.core[ithCore].int_regfile_reads / (32 /**1.5*/)) +
-         (XML->sys.core[ithCore].non_rf_operands / (32 /**1.5*/))) *
-        arbiter_rfu->power.readOp.dynamic;
-
-    rt_power =
-        rt_power + (IRF->power_t /*+ FRF->power_t*/ + xbar_rfu->rt_power +
-                    arbiter_rfu->rt_power + OPC->power_t);
-    if (coredynp.regWindowing) {
-      RFWIN->rt_power = RFWIN->power_t + RFWIN->local_result.power * pppm_lkg;
-      rt_power = rt_power + RFWIN->rt_power;
-    }
-  }
 }
 
-void RegFU::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
-  if (!exist) return;
-  string indent_str(indent, ' ');
-  string indent_str_next(indent + 2, ' ');
-  bool long_channel = XML->sys.longer_channel_device;
+void RENAMINGU::computeEnergy(bool is_tdp)
+{
+	if (!exist) return;
+	double pppm_t[4]    = {1,1,1,1};
+	if (is_tdp)
+	{//init stats for Peak
+		if (coredynp.core_ty==OOO){
+			if (coredynp.scheu_ty==PhysicalRegFile)
+			{
+				if (coredynp.rm_ty ==RAMbased)
+				{
+					iFRAT->stats_t.readAc.access   = iFRAT->l_ip.num_rd_ports;
+					iFRAT->stats_t.writeAc.access  = iFRAT->l_ip.num_wr_ports;
+					iFRAT->tdp_stats = iFRAT->stats_t;
 
-  if (is_tdp) {
-    cout << indent_str << "Register file banks: " << endl;
-    cout << indent_str_next << "Area = " << IRF->area.get_area() * 1e-6
-         << " mm^2" << endl;
-    cout << indent_str_next
-         << "Peak Dynamic = " << IRF->power.readOp.dynamic * clockRate << " W"
-         << endl;
-    cout << indent_str_next << "Subthreshold Leakage = "
-         << (long_channel ? IRF->power.readOp.longer_channel_leakage
-                          : IRF->power.readOp.leakage)
-         << " W" << endl;
+					fFRAT->stats_t.readAc.access   = fFRAT->l_ip.num_rd_ports;
+					fFRAT->stats_t.writeAc.access  = fFRAT->l_ip.num_wr_ports;
+					fFRAT->tdp_stats = fFRAT->stats_t;
 
-    cout << indent_str_next
-         << "Gate Leakage = " << IRF->power.readOp.gate_leakage << " W" << endl;
-    cout << indent_str_next
-         << "Runtime Dynamic = " << IRF->rt_power.readOp.dynamic / executionTime
-         << " W" << endl;
-    cout << endl;
-    cout << indent_str << "Crossbar (Integer RF):" << endl;
-    cout << indent_str_next << "Area = " << xbar_rfu->area.get_area() * 1e-6
-         << " mm^2" << endl;
-    cout << indent_str_next
-         << "Peak Dynamic = " << xbar_rfu->power.readOp.dynamic * clockRate
-         << " W" << endl;
-    cout << indent_str_next << "Subthreshold Leakage = "
-         << (long_channel ? xbar_rfu->power.readOp.longer_channel_leakage
-                          : xbar_rfu->power.readOp.leakage)
-         << " W" << endl;
+				}
+				else if ((coredynp.rm_ty ==CAMbased))
+				{
+					iFRAT->stats_t.readAc.access   = iFRAT->l_ip.num_search_ports;
+					iFRAT->stats_t.writeAc.access  = iFRAT->l_ip.num_wr_ports;
+					iFRAT->tdp_stats = iFRAT->stats_t;
 
-    cout << indent_str_next
-         << "Gate Leakage = " << xbar_rfu->power.readOp.gate_leakage << " W"
-         << endl;
-    cout << indent_str_next << "Runtime Dynamic = "
-         << xbar_rfu->rt_power.readOp.dynamic / executionTime << " W" << endl;
-    cout << endl;
+					fFRAT->stats_t.readAc.access   = fFRAT->l_ip.num_search_ports;
+					fFRAT->stats_t.writeAc.access  = fFRAT->l_ip.num_wr_ports;
+					fFRAT->tdp_stats = fFRAT->stats_t;
+				}
 
-    cout << indent_str << "Arbiter (Integer RF):" << endl;
-    cout << indent_str_next << "Area = " << arbiter_rfu->area.get_area() * 1e-6
-         << " mm^2" << endl;
-    cout << indent_str_next
-         << "Peak Dynamic = " << arbiter_rfu->power.readOp.dynamic * clockRate
-         << " W" << endl;
-    cout << indent_str_next << "Subthreshold Leakage = "
-         << (long_channel ? arbiter_rfu->power.readOp.longer_channel_leakage
-                          : arbiter_rfu->power.readOp.leakage)
-         << " W" << endl;
+				iRRAT->stats_t.readAc.access   = iRRAT->l_ip.num_rd_ports;
+				iRRAT->stats_t.writeAc.access  = iRRAT->l_ip.num_wr_ports;
+				iRRAT->tdp_stats = iRRAT->stats_t;
 
-    cout << indent_str_next
-         << "Gate Leakage = " << arbiter_rfu->power.readOp.gate_leakage << " W"
-         << endl;
-    cout << indent_str_next << "Runtime Dynamic = "
-         << arbiter_rfu->rt_power.readOp.dynamic / executionTime << " W"
-         << endl;
-    cout << endl;
+				fRRAT->stats_t.readAc.access   = fRRAT->l_ip.num_rd_ports;
+				fRRAT->stats_t.writeAc.access  = fRRAT->l_ip.num_wr_ports;
+				fRRAT->tdp_stats = fRRAT->stats_t;
 
-    /*
-    cout << indent_str<< "Floating Point RF:" << endl;
-    cout << indent_str_next << "Area = " << FRF->area.get_area()*1e-6  << "
-    mm^2" << endl;
-    cout << indent_str_next << "Peak Dynamic = " <<
-    FRF->power.readOp.dynamic*clockRate  << " W" << endl;
-    cout << indent_str_next << "Subthreshold Leakage = "
-            << (long_channel?
-    FRF->power.readOp.longer_channel_leakage:FRF->power.readOp.leakage)  << " W"
-    << endl;
-    cout << indent_str_next << "Gate Leakage = " <<
-    FRF->power.readOp.gate_leakage  << " W" << endl;
-    cout << indent_str_next << "Runtime Dynamic = " <<
-    FRF->rt_power.readOp.dynamic/executionTime << " W" << endl;
-    cout <<endl;
-    */
-    if (coredynp.regWindowing) {
-      cout << indent_str << "Register Windows:" << endl;
-      cout << indent_str_next << "Area = " << RFWIN->area.get_area() * 1e-6
-           << " mm^2" << endl;
-      cout << indent_str_next
-           << "Peak Dynamic = " << RFWIN->power.readOp.dynamic * clockRate
-           << " W" << endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel ? RFWIN->power.readOp.longer_channel_leakage
-                            : RFWIN->power.readOp.leakage)
-           << " W" << endl;
-      cout << indent_str_next
-           << "Gate Leakage = " << RFWIN->power.readOp.gate_leakage << " W"
-           << endl;
-      cout << indent_str_next << "Runtime Dynamic = "
-           << RFWIN->rt_power.readOp.dynamic / executionTime << " W" << endl;
-      cout << endl;
-    }
-  } else {
-    cout << indent_str_next << "Integer RF    Peak Dynamic = "
-         << IRF->rt_power.readOp.dynamic * clockRate << " W" << endl;
-    cout << indent_str_next << "Integer RF    Subthreshold Leakage = "
-         << IRF->rt_power.readOp.leakage << " W" << endl;
-    cout << indent_str_next
-         << "Integer RF    Gate Leakage = " << IRF->rt_power.readOp.gate_leakage
-         << " W" << endl;
-    cout << indent_str_next << "Floating Point RF   Peak Dynamic = "
-         << FRF->rt_power.readOp.dynamic * clockRate << " W" << endl;
-    cout << indent_str_next << "Floating Point RF   Subthreshold Leakage = "
-         << FRF->rt_power.readOp.leakage << " W" << endl;
-    cout << indent_str_next << "Floating Point RF   Gate Leakage = "
-         << FRF->rt_power.readOp.gate_leakage << " W" << endl;
-    if (coredynp.regWindowing) {
-      cout << indent_str_next << "Register Windows   Peak Dynamic = "
-           << RFWIN->rt_power.readOp.dynamic * clockRate << " W" << endl;
-      cout << indent_str_next << "Register Windows   Subthreshold Leakage = "
-           << RFWIN->rt_power.readOp.leakage << " W" << endl;
-      cout << indent_str_next << "Register Windows   Gate Leakage = "
-           << RFWIN->rt_power.readOp.gate_leakage << " W" << endl;
-    }
-  }
+				ifreeL->stats_t.readAc.access   = coredynp.decodeW;//ifreeL->l_ip.num_rd_ports;;
+				ifreeL->stats_t.writeAc.access  = coredynp.decodeW;//ifreeL->l_ip.num_wr_ports;
+				ifreeL->tdp_stats = ifreeL->stats_t;
+
+				ffreeL->stats_t.readAc.access   = coredynp.decodeW;//ffreeL->l_ip.num_rd_ports;
+				ffreeL->stats_t.writeAc.access  = coredynp.decodeW;//ffreeL->l_ip.num_wr_ports;
+				ffreeL->tdp_stats = ffreeL->stats_t;
+			}
+			else if (coredynp.scheu_ty==ReservationStation){
+				if (coredynp.rm_ty ==RAMbased)
+				{
+					iFRAT->stats_t.readAc.access    = iFRAT->l_ip.num_rd_ports;
+					iFRAT->stats_t.writeAc.access   = iFRAT->l_ip.num_wr_ports;
+					iFRAT->stats_t.searchAc.access  = iFRAT->l_ip.num_search_ports;
+					iFRAT->tdp_stats = iFRAT->stats_t;
+
+					fFRAT->stats_t.readAc.access    = fFRAT->l_ip.num_rd_ports;
+					fFRAT->stats_t.writeAc.access   = fFRAT->l_ip.num_wr_ports;
+					fFRAT->stats_t.searchAc.access  = fFRAT->l_ip.num_search_ports;
+					fFRAT->tdp_stats = fFRAT->stats_t;
+
+				}
+				else if ((coredynp.rm_ty ==CAMbased))
+				{
+					iFRAT->stats_t.readAc.access   = iFRAT->l_ip.num_search_ports;
+					iFRAT->stats_t.writeAc.access  = iFRAT->l_ip.num_wr_ports;
+					iFRAT->tdp_stats = iFRAT->stats_t;
+
+					fFRAT->stats_t.readAc.access   = fFRAT->l_ip.num_search_ports;
+					fFRAT->stats_t.writeAc.access  = fFRAT->l_ip.num_wr_ports;
+					fFRAT->tdp_stats = fFRAT->stats_t;
+				}
+				//Unified free list for both int and fp
+				ifreeL->stats_t.readAc.access   = coredynp.decodeW;//ifreeL->l_ip.num_rd_ports;
+				ifreeL->stats_t.writeAc.access  = coredynp.decodeW;//ifreeL->l_ip.num_wr_ports;
+				ifreeL->tdp_stats = ifreeL->stats_t;
+			}
+			idcl->stats_t.readAc.access = coredynp.decodeW;
+			fdcl->stats_t.readAc.access = coredynp.decodeW;
+			idcl->tdp_stats = idcl->stats_t;
+			fdcl->tdp_stats = fdcl->stats_t;
+		}
+		else
+		{
+			if (coredynp.issueW>1)
+			{
+				idcl->stats_t.readAc.access = coredynp.decodeW;
+				fdcl->stats_t.readAc.access = coredynp.decodeW;
+				idcl->tdp_stats = idcl->stats_t;
+				fdcl->tdp_stats = fdcl->stats_t;
+			}
+		}
+
+	}
+	else
+	{//init stats for Runtime Dynamic (RTP)
+		if (coredynp.core_ty==OOO){
+			if (coredynp.scheu_ty==PhysicalRegFile)
+			{
+				if (coredynp.rm_ty ==RAMbased)
+				{
+					iFRAT->stats_t.readAc.access   = XML->sys.core[ithCore].rename_reads;
+					iFRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].rename_writes;
+					iFRAT->rtp_stats = iFRAT->stats_t;
+
+					fFRAT->stats_t.readAc.access   = XML->sys.core[ithCore].fp_rename_reads;
+					fFRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].fp_rename_writes;
+					fFRAT->rtp_stats = fFRAT->stats_t;
+				}
+				else if ((coredynp.rm_ty ==CAMbased))
+				{
+					iFRAT->stats_t.readAc.access   = XML->sys.core[ithCore].rename_reads;
+					iFRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].rename_writes;
+					iFRAT->rtp_stats = iFRAT->stats_t;
+
+					fFRAT->stats_t.readAc.access   = XML->sys.core[ithCore].fp_rename_reads;
+					fFRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].fp_rename_writes;
+					fFRAT->rtp_stats = fFRAT->stats_t;
+				}
+
+				iRRAT->stats_t.readAc.access   = XML->sys.core[ithCore].rename_writes;//Hack, should be (context switch + branch mispredictions)*16
+				iRRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].rename_writes;
+				iRRAT->rtp_stats = iRRAT->stats_t;
+
+				fRRAT->stats_t.readAc.access   = XML->sys.core[ithCore].fp_rename_writes;//Hack, should be (context switch + branch mispredictions)*16
+				fRRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].fp_rename_writes;
+				fRRAT->rtp_stats = fRRAT->stats_t;
+
+				ifreeL->stats_t.readAc.access   = XML->sys.core[ithCore].rename_reads;
+				ifreeL->stats_t.writeAc.access  = 2*XML->sys.core[ithCore].rename_writes;
+				ifreeL->rtp_stats = ifreeL->stats_t;
+
+				ffreeL->stats_t.readAc.access   = XML->sys.core[ithCore].fp_rename_reads;
+				ffreeL->stats_t.writeAc.access  = 2*XML->sys.core[ithCore].fp_rename_writes;
+				ffreeL->rtp_stats = ffreeL->stats_t;
+			}
+			else if (coredynp.scheu_ty==ReservationStation){
+				if (coredynp.rm_ty ==RAMbased)
+				{
+					iFRAT->stats_t.readAc.access   = XML->sys.core[ithCore].rename_reads;
+					iFRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].rename_writes;
+					iFRAT->stats_t.searchAc.access  = XML->sys.core[ithCore].committed_int_instructions;//hack: not all committed instructions use regs.
+					iFRAT->rtp_stats = iFRAT->stats_t;
+
+					fFRAT->stats_t.readAc.access   = XML->sys.core[ithCore].fp_rename_reads;
+					fFRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].fp_rename_writes;
+					fFRAT->stats_t.searchAc.access  = XML->sys.core[ithCore].committed_fp_instructions;
+					fFRAT->rtp_stats = fFRAT->stats_t;
+				}
+				else if ((coredynp.rm_ty ==CAMbased))
+				{
+					iFRAT->stats_t.readAc.access   = XML->sys.core[ithCore].rename_reads;
+					iFRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].rename_writes;
+					iFRAT->rtp_stats = iFRAT->stats_t;
+
+					fFRAT->stats_t.readAc.access   = XML->sys.core[ithCore].fp_rename_reads;
+					fFRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].fp_rename_writes;
+					fFRAT->rtp_stats = fFRAT->stats_t;
+				}
+				//Unified free list for both int and fp since the ROB act as physcial registers
+				ifreeL->stats_t.readAc.access   = XML->sys.core[ithCore].rename_reads +
+					XML->sys.core[ithCore].fp_rename_reads;
+				ifreeL->stats_t.writeAc.access  = 2*(XML->sys.core[ithCore].rename_writes +
+					XML->sys.core[ithCore].fp_rename_writes);//HACK: 2-> since some of renaming in the same group
+															 //are terminated early
+				ifreeL->rtp_stats = ifreeL->stats_t;
+			}
+			idcl->stats_t.readAc.access = 3*coredynp.decodeW*coredynp.decodeW*XML->sys.core[ithCore].rename_reads;
+			fdcl->stats_t.readAc.access = 3*coredynp.fp_issueW*coredynp.fp_issueW*XML->sys.core[ithCore].fp_rename_writes;
+			idcl->rtp_stats = idcl->stats_t;
+			fdcl->rtp_stats = fdcl->stats_t;
+		}
+		else
+		{
+			if (coredynp.issueW>1)
+			{
+				idcl->stats_t.readAc.access = 2*XML->sys.core[ithCore].int_instructions;
+				fdcl->stats_t.readAc.access = XML->sys.core[ithCore].fp_instructions;
+				idcl->rtp_stats = idcl->stats_t;
+				fdcl->rtp_stats = fdcl->stats_t;
+			}
+		}
+
+	}
+    /* Compute engine */
+	if (coredynp.core_ty==OOO)
+	{
+		if (coredynp.scheu_ty==PhysicalRegFile)
+		{
+			if (coredynp.rm_ty ==RAMbased)
+			{
+				iFRAT->power_t.reset();
+				fFRAT->power_t.reset();
+
+				iFRAT->power_t.readOp.dynamic  +=  (iFRAT->stats_t.readAc.access
+						*(iFRAT->local_result.power.readOp.dynamic + idcl->power.readOp.dynamic)
+						+iFRAT->stats_t.writeAc.access*iFRAT->local_result.power.writeOp.dynamic);
+				fFRAT->power_t.readOp.dynamic  +=  (fFRAT->stats_t.readAc.access
+						*(fFRAT->local_result.power.readOp.dynamic + fdcl->power.readOp.dynamic)
+						+fFRAT->stats_t.writeAc.access*fFRAT->local_result.power.writeOp.dynamic);
+			}
+			else if ((coredynp.rm_ty ==CAMbased))
+			{
+				iFRAT->power_t.reset();
+				fFRAT->power_t.reset();
+				iFRAT->power_t.readOp.dynamic  +=  (iFRAT->stats_t.readAc.access
+						*(iFRAT->local_result.power.searchOp.dynamic + idcl->power.readOp.dynamic)
+						+iFRAT->stats_t.writeAc.access*iFRAT->local_result.power.writeOp.dynamic);
+				fFRAT->power_t.readOp.dynamic  +=  (fFRAT->stats_t.readAc.access
+						*(fFRAT->local_result.power.searchOp.dynamic + fdcl->power.readOp.dynamic)
+						+fFRAT->stats_t.writeAc.access*fFRAT->local_result.power.writeOp.dynamic);
+			}
+
+			iRRAT->power_t.reset();
+			fRRAT->power_t.reset();
+			ifreeL->power_t.reset();
+			ffreeL->power_t.reset();
+
+			iRRAT->power_t.readOp.dynamic  +=  (iRRAT->stats_t.readAc.access*iRRAT->local_result.power.readOp.dynamic
+					+iRRAT->stats_t.writeAc.access*iRRAT->local_result.power.writeOp.dynamic);
+			fRRAT->power_t.readOp.dynamic  +=  (fRRAT->stats_t.readAc.access*fRRAT->local_result.power.readOp.dynamic
+					+fRRAT->stats_t.writeAc.access*fRRAT->local_result.power.writeOp.dynamic);
+			ifreeL->power_t.readOp.dynamic  +=  (ifreeL->stats_t.readAc.access*ifreeL->local_result.power.readOp.dynamic
+					+ifreeL->stats_t.writeAc.access*ifreeL->local_result.power.writeOp.dynamic);
+			ffreeL->power_t.readOp.dynamic  +=  (ffreeL->stats_t.readAc.access*ffreeL->local_result.power.readOp.dynamic
+					+ffreeL->stats_t.writeAc.access*ffreeL->local_result.power.writeOp.dynamic);
+
+		}
+		else if (coredynp.scheu_ty==ReservationStation)
+		{
+			if (coredynp.rm_ty ==RAMbased)
+			{
+				iFRAT->power_t.reset();
+				fFRAT->power_t.reset();
+
+				iFRAT->power_t.readOp.dynamic  +=  (iFRAT->stats_t.readAc.access
+						*(iFRAT->local_result.power.readOp.dynamic + idcl->power.readOp.dynamic)
+						+iFRAT->stats_t.writeAc.access*iFRAT->local_result.power.writeOp.dynamic
+						+iFRAT->stats_t.searchAc.access*iFRAT->local_result.power.searchOp.dynamic);
+				fFRAT->power_t.readOp.dynamic  +=  (fFRAT->stats_t.readAc.access
+						*(fFRAT->local_result.power.readOp.dynamic + fdcl->power.readOp.dynamic)
+						+fFRAT->stats_t.writeAc.access*fFRAT->local_result.power.writeOp.dynamic
+						+fFRAT->stats_t.searchAc.access*fFRAT->local_result.power.searchOp.dynamic);
+			}
+			else if ((coredynp.rm_ty ==CAMbased))
+			{
+				iFRAT->power_t.reset();
+				fFRAT->power_t.reset();
+				iFRAT->power_t.readOp.dynamic  +=  (iFRAT->stats_t.readAc.access
+						*(iFRAT->local_result.power.searchOp.dynamic + idcl->power.readOp.dynamic)
+						+iFRAT->stats_t.writeAc.access*iFRAT->local_result.power.writeOp.dynamic);
+				fFRAT->power_t.readOp.dynamic  +=  (fFRAT->stats_t.readAc.access
+						*(fFRAT->local_result.power.searchOp.dynamic + fdcl->power.readOp.dynamic)
+						+fFRAT->stats_t.writeAc.access*fFRAT->local_result.power.writeOp.dynamic);
+			}
+			ifreeL->power_t.reset();
+			ifreeL->power_t.readOp.dynamic  +=  (ifreeL->stats_t.readAc.access*ifreeL->local_result.power.readOp.dynamic
+					+ifreeL->stats_t.writeAc.access*ifreeL->local_result.power.writeOp.dynamic);
+		}
+
+	}
+	else
+	{
+		if (coredynp.issueW>1)
+		{
+			idcl->power_t.reset();
+			fdcl->power_t.reset();
+			set_pppm(pppm_t, idcl->stats_t.readAc.access, coredynp.num_hthreads, coredynp.num_hthreads, idcl->stats_t.readAc.access);
+			idcl->power_t = idcl->power * pppm_t;
+			set_pppm(pppm_t, fdcl->stats_t.readAc.access, coredynp.num_hthreads, coredynp.num_hthreads, idcl->stats_t.readAc.access);
+			fdcl->power_t = fdcl->power * pppm_t;
+		}
+
+	}
+
+	//assign value to tpd and rtp
+	if (is_tdp)
+	{
+		if (coredynp.core_ty==OOO)
+		{
+			if (coredynp.scheu_ty==PhysicalRegFile)
+			{
+				iFRAT->power   =  iFRAT->power_t + (iFRAT->local_result.power ) * coredynp.pppm_lkg_multhread + idcl->power_t;
+				fFRAT->power   =  fFRAT->power_t + (fFRAT->local_result.power ) * coredynp.pppm_lkg_multhread + fdcl->power_t;
+				iRRAT->power   =  iRRAT->power_t + iRRAT->local_result.power * coredynp.pppm_lkg_multhread;
+				fRRAT->power   =  fRRAT->power_t + fRRAT->local_result.power * coredynp.pppm_lkg_multhread;
+				ifreeL->power  =  ifreeL->power_t + ifreeL->local_result.power * coredynp.pppm_lkg_multhread;
+				ffreeL->power  =  ffreeL->power_t + ffreeL->local_result.power * coredynp.pppm_lkg_multhread;
+				power	       =  power + (iFRAT->power + fFRAT->power)
+				                 + (iRRAT->power + fRRAT->power)
+				                 + (ifreeL->power + ffreeL->power);
+			}
+			else if (coredynp.scheu_ty==ReservationStation)
+			{
+				iFRAT->power   =  iFRAT->power_t + (iFRAT->local_result.power ) * coredynp.pppm_lkg_multhread + idcl->power_t;
+				fFRAT->power   =  fFRAT->power_t + (fFRAT->local_result.power ) * coredynp.pppm_lkg_multhread + fdcl->power_t;
+				ifreeL->power  =  ifreeL->power_t + ifreeL->local_result.power * coredynp.pppm_lkg_multhread;
+				power	       =  power + (iFRAT->power + fFRAT->power)
+				                 + ifreeL->power;
+			}
+		}
+		else
+		{
+			power   =  power + idcl->power_t + fdcl->power_t;
+		}
+
+	}
+	else
+	{
+		if (coredynp.core_ty==OOO)
+		{
+			if (coredynp.scheu_ty==PhysicalRegFile)
+			{
+				iFRAT->rt_power   =  iFRAT->power_t + (iFRAT->local_result.power ) * coredynp.pppm_lkg_multhread + idcl->power_t;
+				fFRAT->rt_power   =  fFRAT->power_t + (fFRAT->local_result.power ) * coredynp.pppm_lkg_multhread + fdcl->power_t;
+				iRRAT->rt_power   =  iRRAT->power_t + iRRAT->local_result.power * coredynp.pppm_lkg_multhread;
+				fRRAT->rt_power   =  fRRAT->power_t + fRRAT->local_result.power * coredynp.pppm_lkg_multhread;
+				ifreeL->rt_power  =  ifreeL->power_t + ifreeL->local_result.power * coredynp.pppm_lkg_multhread;
+				ffreeL->rt_power  =  ffreeL->power_t + ffreeL->local_result.power * coredynp.pppm_lkg_multhread;
+				rt_power	      =  rt_power + (iFRAT->rt_power + fFRAT->rt_power)
+				                   + (iRRAT->rt_power + fRRAT->rt_power)
+				                   + (ifreeL->rt_power + ffreeL->rt_power);
+			}
+			else if (coredynp.scheu_ty==ReservationStation)
+			{
+				iFRAT->rt_power   =  iFRAT->power_t + (iFRAT->local_result.power ) * coredynp.pppm_lkg_multhread + idcl->power_t;
+				fFRAT->rt_power   =  fFRAT->power_t + (fFRAT->local_result.power ) * coredynp.pppm_lkg_multhread + fdcl->power_t;
+				ifreeL->rt_power  =  ifreeL->power_t + ifreeL->local_result.power * coredynp.pppm_lkg_multhread;
+				rt_power	      =  rt_power + (iFRAT->rt_power + fFRAT->rt_power)
+				                   + ifreeL->rt_power;
+			}
+		}
+		else
+		{
+			rt_power   =  rt_power + idcl->power_t + fdcl->power_t;
+		}
+
+	}
 }
 
-void EXECU::computeEnergy(bool is_tdp) {
-  if (!exist) return;
-  // Syed
-  double pppm_t[4] = {1, 1, 1, 1};
-  double pppm_freqScaling[4] = {rf_fu_clockRate / clockRate, 1, 1, 1};
-  executionTime =
-      XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);  // Syed
+void RENAMINGU::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
+{
+	if (!exist) return;
+	string indent_str(indent, ' ');
+	string indent_str_next(indent+2, ' ');
+	bool long_channel = XML->sys.longer_channel_device;
 
-  //	rfu->power.reset();
+
+	if (is_tdp)
+	{
+
+		if (coredynp.core_ty==OOO)
+		{
+			cout << indent_str<< "Int Front End RAT:" << endl;
+			cout << indent_str_next << "Area = " << iFRAT->area.get_area()*1e-6<< " mm^2" << endl;
+			cout << indent_str_next << "Peak Dynamic = " << iFRAT->power.readOp.dynamic*clockRate << " W" << endl;
+			cout << indent_str_next << "Subthreshold Leakage = "
+				<< (long_channel? iFRAT->power.readOp.longer_channel_leakage:iFRAT->power.readOp.leakage) <<" W" << endl;
+			cout << indent_str_next << "Gate Leakage = " << iFRAT->power.readOp.gate_leakage << " W" << endl;
+			cout << indent_str_next << "Runtime Dynamic = " << iFRAT->rt_power.readOp.dynamic/executionTime << " W" << endl;
+			cout <<endl;
+			cout << indent_str<< "FP Front End RAT:" << endl;
+			cout << indent_str_next << "Area = " << fFRAT->area.get_area()*1e-6  << " mm^2" << endl;
+			cout << indent_str_next << "Peak Dynamic = " << fFRAT->power.readOp.dynamic*clockRate  << " W" << endl;
+			cout << indent_str_next << "Subthreshold Leakage = "
+				<< (long_channel? fFRAT->power.readOp.longer_channel_leakage:fFRAT->power.readOp.leakage)  << " W" << endl;
+			cout << indent_str_next << "Gate Leakage = " << fFRAT->power.readOp.gate_leakage  << " W" << endl;
+			cout << indent_str_next << "Runtime Dynamic = " << fFRAT->rt_power.readOp.dynamic/executionTime << " W" << endl;
+			cout <<endl;
+			cout << indent_str<<"Free List:" << endl;
+			cout << indent_str_next << "Area = " << ifreeL->area.get_area()*1e-6  << " mm^2" << endl;
+			cout << indent_str_next << "Peak Dynamic = " << ifreeL->power.readOp.dynamic*clockRate  << " W" << endl;
+			cout << indent_str_next << "Subthreshold Leakage = "
+				<< (long_channel? ifreeL->power.readOp.longer_channel_leakage:ifreeL->power.readOp.leakage)  << " W" << endl;
+			cout << indent_str_next << "Gate Leakage = " << ifreeL->power.readOp.gate_leakage  << " W" << endl;
+			cout << indent_str_next << "Runtime Dynamic = " << ifreeL->rt_power.readOp.dynamic/executionTime << " W" << endl;
+			cout <<endl;
+
+			if (coredynp.scheu_ty==PhysicalRegFile)
+			{
+				cout << indent_str<< "Int Retire RAT: " << endl;
+				cout << indent_str_next << "Area = " << iRRAT->area.get_area() *1e-6 << " mm^2" << endl;
+				cout << indent_str_next << "Peak Dynamic = " << iRRAT->power.readOp.dynamic*clockRate  << " W" << endl;
+				cout << indent_str_next << "Subthreshold Leakage = "
+					<< (long_channel? iRRAT->power.readOp.longer_channel_leakage:iRRAT->power.readOp.leakage)  << " W" << endl;
+				cout << indent_str_next << "Gate Leakage = " << iRRAT->power.readOp.gate_leakage  << " W" << endl;
+				cout << indent_str_next << "Runtime Dynamic = " << iRRAT->rt_power.readOp.dynamic/executionTime << " W" << endl;
+				cout <<endl;
+				cout << indent_str<< "FP Retire RAT:" << endl;
+				cout << indent_str_next << "Area = " << fRRAT->area.get_area()  *1e-6<< " mm^2" << endl;
+				cout << indent_str_next << "Peak Dynamic = " << fRRAT->power.readOp.dynamic*clockRate  << " W" << endl;
+				cout << indent_str_next << "Subthreshold Leakage = "
+					<< (long_channel? fRRAT->power.readOp.longer_channel_leakage:fRRAT->power.readOp.leakage)  << " W" << endl;
+				cout << indent_str_next << "Gate Leakage = " << fRRAT->power.readOp.gate_leakage  << " W" << endl;
+				cout << indent_str_next << "Runtime Dynamic = " << fRRAT->rt_power.readOp.dynamic/executionTime << " W" << endl;
+				cout <<endl;
+				cout << indent_str<< "FP Free List:" << endl;
+				cout << indent_str_next << "Area = " << ffreeL->area.get_area()*1e-6  << " mm^2" << endl;
+				cout << indent_str_next << "Peak Dynamic = " << ffreeL->power.readOp.dynamic*clockRate  << " W" << endl;
+				cout << indent_str_next << "Subthreshold Leakage = "
+					<< (long_channel? ffreeL->power.readOp.longer_channel_leakage:ffreeL->power.readOp.leakage)  << " W" << endl;
+				cout << indent_str_next << "Gate Leakage = " << ffreeL->power.readOp.gate_leakage  << " W" << endl;
+				cout << indent_str_next << "Runtime Dynamic = " << ffreeL->rt_power.readOp.dynamic/executionTime << " W" << endl;
+				cout <<endl;
+			}
+		}
+		else
+		{
+			cout << indent_str<< "Int DCL:" << endl;
+			cout << indent_str_next << "Peak Dynamic = " << idcl->power.readOp.dynamic*clockRate  << " W" << endl;
+			cout << indent_str_next << "Subthreshold Leakage = "
+				<< (long_channel? idcl->power.readOp.longer_channel_leakage:idcl->power.readOp.leakage)  << " W" << endl;
+			cout << indent_str_next << "Gate Leakage = " << idcl->power.readOp.gate_leakage  << " W" << endl;
+			cout << indent_str_next << "Runtime Dynamic = " << idcl->rt_power.readOp.dynamic/executionTime << " W" << endl;
+			cout << indent_str<<"FP DCL:" << endl;
+			cout << indent_str_next << "Peak Dynamic = " << fdcl->power.readOp.dynamic*clockRate  << " W" << endl;
+			cout << indent_str_next << "Subthreshold Leakage = "
+				<< (long_channel? fdcl->power.readOp.longer_channel_leakage:fdcl->power.readOp.leakage)  << " W" << endl;
+			cout << indent_str_next << "Gate Leakage = " << fdcl->power.readOp.gate_leakage  << " W" << endl;
+			cout << indent_str_next << "Runtime Dynamic = " << fdcl->rt_power.readOp.dynamic/executionTime << " W" << endl;
+		}
+	}
+	else
+	{
+		if (coredynp.core_ty==OOO)
+		{
+			cout << indent_str_next << "Int Front End RAT    Peak Dynamic = " << iFRAT->rt_power.readOp.dynamic*clockRate << " W" << endl;
+			cout << indent_str_next << "Int Front End RAT    Subthreshold Leakage = " << iFRAT->rt_power.readOp.leakage <<" W" << endl;
+			cout << indent_str_next << "Int Front End RAT    Gate Leakage = " << iFRAT->rt_power.readOp.gate_leakage << " W" << endl;
+			cout << indent_str_next << "FP Front End RAT   Peak Dynamic = " << fFRAT->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+			cout << indent_str_next << "FP Front End RAT   Subthreshold Leakage = " << fFRAT->rt_power.readOp.leakage  << " W" << endl;
+			cout << indent_str_next << "FP Front End RAT   Gate Leakage = " << fFRAT->rt_power.readOp.gate_leakage  << " W" << endl;
+			cout << indent_str_next << "Free List   Peak Dynamic = " << ifreeL->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+			cout << indent_str_next << "Free List   Subthreshold Leakage = " << ifreeL->rt_power.readOp.leakage  << " W" << endl;
+			cout << indent_str_next << "Free List   Gate Leakage = " << fFRAT->rt_power.readOp.gate_leakage  << " W" << endl;
+			if (coredynp.scheu_ty==PhysicalRegFile)
+			{
+				cout << indent_str_next << "Int Retire RAT   Peak Dynamic = " << iRRAT->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+				cout << indent_str_next << "Int Retire RAT   Subthreshold Leakage = " << iRRAT->rt_power.readOp.leakage  << " W" << endl;
+				cout << indent_str_next << "Int Retire RAT   Gate Leakage = " << iRRAT->rt_power.readOp.gate_leakage  << " W" << endl;
+				cout << indent_str_next << "FP Retire RAT   Peak Dynamic = " << fRRAT->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+				cout << indent_str_next << "FP Retire RAT   Subthreshold Leakage = " << fRRAT->rt_power.readOp.leakage  << " W" << endl;
+				cout << indent_str_next << "FP Retire RAT   Gate Leakage = " << fRRAT->rt_power.readOp.gate_leakage  << " W" << endl;
+				cout << indent_str_next << "FP Free List   Peak Dynamic = " << ffreeL->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+				cout << indent_str_next << "FP Free List   Subthreshold Leakage = " << ffreeL->rt_power.readOp.leakage  << " W" << endl;
+				cout << indent_str_next << "FP Free List   Gate Leakage = " << fFRAT->rt_power.readOp.gate_leakage  << " W" << endl;
+			}
+		}
+		else
+		{
+			cout << indent_str_next << "Int DCL   Peak Dynamic = " << idcl->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+			cout << indent_str_next << "Int DCL   Subthreshold Leakage = " << idcl->rt_power.readOp.leakage  << " W" << endl;
+			cout << indent_str_next << "Int DCL   Gate Leakage = " << idcl->rt_power.readOp.gate_leakage  << " W" << endl;
+			cout << indent_str_next << "FP DCL   Peak Dynamic = " << fdcl->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+			cout << indent_str_next << "FP DCL   Subthreshold Leakage = " << fdcl->rt_power.readOp.leakage  << " W" << endl;
+			cout << indent_str_next << "FP DCL   Gate Leakage = " << fdcl->rt_power.readOp.gate_leakage  << " W" << endl;
+		}
+	}
+
+}
+
+
+void SchedulerU::computeEnergy(bool is_tdp)
+{
+	if (!exist) return;
+	double ROB_duty_cycle;
+//	ROB_duty_cycle = ((coredynp.ALU_duty_cycle + coredynp.num_muls>0?coredynp.MUL_duty_cycle:0
+//			+ coredynp.num_fpus>0?coredynp.FPU_duty_cycle:0))*1.1<1 ? (coredynp.ALU_duty_cycle + coredynp.num_muls>0?coredynp.MUL_duty_cycle:0
+//					+ coredynp.num_fpus>0?coredynp.FPU_duty_cycle:0)*1.1:1;
+	ROB_duty_cycle = 1;
+	//init stats
+	if (is_tdp)
+	{
+		if (coredynp.core_ty==OOO)
+		{
+			int_inst_window->stats_t.readAc.access    = coredynp.issueW*coredynp.num_pipelines;//int_inst_window->l_ip.num_search_ports;
+			int_inst_window->stats_t.writeAc.access   = coredynp.issueW*coredynp.num_pipelines;//int_inst_window->l_ip.num_wr_ports;
+			int_inst_window->stats_t.searchAc.access  = coredynp.issueW*coredynp.num_pipelines;
+			int_inst_window->tdp_stats                = int_inst_window->stats_t;
+			fp_inst_window->stats_t.readAc.access     = fp_inst_window->l_ip.num_rd_ports*coredynp.num_fp_pipelines;
+			fp_inst_window->stats_t.writeAc.access    = fp_inst_window->l_ip.num_wr_ports*coredynp.num_fp_pipelines;
+			fp_inst_window->stats_t.searchAc.access   = fp_inst_window->l_ip.num_search_ports*coredynp.num_fp_pipelines;
+			fp_inst_window->tdp_stats                 = fp_inst_window->stats_t;
+
+			if (XML->sys.core[ithCore].ROB_size >0)
+			{
+				ROB->stats_t.readAc.access   = coredynp.commitW*coredynp.num_pipelines*ROB_duty_cycle;
+				ROB->stats_t.writeAc.access  = coredynp.issueW*coredynp.num_pipelines*ROB_duty_cycle;
+				ROB->tdp_stats        = ROB->stats_t;
+
+				/*
+				 * When inst commits, ROB must be read.
+				 * Because for Physcial register based cores, physical register tag in ROB
+				 * need to be read out and write into RRAT/CAM based RAT.
+				 * For RS based cores, register content that stored in ROB must be
+				 * read out and stored in architectural registers.
+				 *
+				 * if no-register is involved, the ROB read out operation when instruction commits can be ignored.
+				 * assuming 20% insts. belong this type.
+				 * TODO: ROB duty_cycle need to be revisited
+				 */
+			}
+
+		}
+		else if (coredynp.multithreaded)
+		{
+			int_inst_window->stats_t.readAc.access   = coredynp.issueW*coredynp.num_pipelines;//int_inst_window->l_ip.num_search_ports;
+			int_inst_window->stats_t.writeAc.access  = coredynp.issueW*coredynp.num_pipelines;//int_inst_window->l_ip.num_wr_ports;
+			int_inst_window->stats_t.searchAc.access = coredynp.issueW*coredynp.num_pipelines;
+			int_inst_window->tdp_stats       = int_inst_window->stats_t;
+		}
+
+     }
+    else
+    {//rtp
+		if (coredynp.core_ty==OOO)
+		{
+			int_inst_window->stats_t.readAc.access   = XML->sys.core[ithCore].inst_window_reads;
+			int_inst_window->stats_t.writeAc.access  = XML->sys.core[ithCore].inst_window_writes;
+			int_inst_window->stats_t.searchAc.access = XML->sys.core[ithCore].inst_window_wakeup_accesses;
+			int_inst_window->rtp_stats               = int_inst_window->stats_t;
+			fp_inst_window->stats_t.readAc.access    = XML->sys.core[ithCore].fp_inst_window_reads;
+			fp_inst_window->stats_t.writeAc.access   = XML->sys.core[ithCore].fp_inst_window_writes;
+			fp_inst_window->stats_t.searchAc.access  = XML->sys.core[ithCore].fp_inst_window_wakeup_accesses;
+			fp_inst_window->rtp_stats                = fp_inst_window->stats_t;
+
+			if (XML->sys.core[ithCore].ROB_size >0)
+			{
+
+				ROB->stats_t.readAc.access   = XML->sys.core[ithCore].ROB_reads;
+				ROB->stats_t.writeAc.access  = XML->sys.core[ithCore].ROB_writes;
+				/* ROB need to be updated in RS based OOO when new values are produced,
+				 * this update may happen before the commit stage when ROB entry is released
+				 * 1. ROB write at instruction inserted in
+				 * 2. ROB write as results produced (for RS based OOO only)
+				 * 3. ROB read  as instruction committed. For RS based OOO, data values are read out and sent to ARF
+				 * For Physical reg based OOO, no data stored in ROB, but register tags need to be
+				 * read out and used to set the RRAT and to recycle the register tag to free list buffer
+				 */
+				ROB->rtp_stats        = ROB->stats_t;
+			}
+
+		}
+		else if (coredynp.multithreaded)
+		{
+			int_inst_window->stats_t.readAc.access    = XML->sys.core[ithCore].int_instructions + XML->sys.core[ithCore].fp_instructions;
+			int_inst_window->stats_t.writeAc.access   = XML->sys.core[ithCore].int_instructions + XML->sys.core[ithCore].fp_instructions;
+			int_inst_window->stats_t.searchAc.access  = 2*(XML->sys.core[ithCore].int_instructions + XML->sys.core[ithCore].fp_instructions);
+			int_inst_window->rtp_stats                = int_inst_window->stats_t;
+		}
+    }
+
+	//computation engine
+	if (coredynp.core_ty==OOO)
+	{
+		int_inst_window->power_t.reset();
+		fp_inst_window->power_t.reset();
+
+		/* each instruction needs to write to scheduler, read out when all resources and source operands are ready
+		 * two search ops with one for each source operand
+		 *
+		 */
+		int_inst_window->power_t.readOp.dynamic  +=  int_inst_window->local_result.power.readOp.dynamic * int_inst_window->stats_t.readAc.access
+					+ int_inst_window->local_result.power.searchOp.dynamic * int_inst_window->stats_t.searchAc.access
+					+ int_inst_window->local_result.power.writeOp.dynamic  * int_inst_window->stats_t.writeAc.access
+					+ int_inst_window->stats_t.readAc.access * instruction_selection->power.readOp.dynamic;
+
+		fp_inst_window->power_t.readOp.dynamic   +=  fp_inst_window->local_result.power.readOp.dynamic * fp_inst_window->stats_t.readAc.access
+					+ fp_inst_window->local_result.power.searchOp.dynamic * fp_inst_window->stats_t.searchAc.access
+					+ fp_inst_window->local_result.power.writeOp.dynamic * fp_inst_window->stats_t.writeAc.access
+					+ fp_inst_window->stats_t.writeAc.access * instruction_selection->power.readOp.dynamic;
+
+		if (XML->sys.core[ithCore].ROB_size >0)
+		{
+			ROB->power_t.reset();
+			ROB->power_t.readOp.dynamic   +=  ROB->local_result.power.readOp.dynamic*ROB->stats_t.readAc.access +
+						ROB->stats_t.writeAc.access*ROB->local_result.power.writeOp.dynamic;
+		}
+
+
+
+
+	}
+	else if (coredynp.multithreaded)
+	{
+		int_inst_window->power_t.reset();
+		int_inst_window->power_t.readOp.dynamic  +=  int_inst_window->local_result.power.readOp.dynamic * int_inst_window->stats_t.readAc.access
+						  + int_inst_window->local_result.power.searchOp.dynamic * int_inst_window->stats_t.searchAc.access
+				          + int_inst_window->local_result.power.writeOp.dynamic  * int_inst_window->stats_t.writeAc.access
+				          + int_inst_window->stats_t.writeAc.access * instruction_selection->power.readOp.dynamic;
+	}
+
+	//assign values
+	if (is_tdp)
+	{
+		if (coredynp.core_ty==OOO)
+		{
+			int_inst_window->power = int_inst_window->power_t + (int_inst_window->local_result.power +instruction_selection->power) *pppm_lkg;
+			fp_inst_window->power = fp_inst_window->power_t + (fp_inst_window->local_result.power +instruction_selection->power) *pppm_lkg;
+			power	   = power + int_inst_window->power + fp_inst_window->power;
+			if (XML->sys.core[ithCore].ROB_size >0)
+			{
+				ROB->power = ROB->power_t + ROB->local_result.power*pppm_lkg;
+				power	   = power + ROB->power;
+			}
+
+		}
+		else if (coredynp.multithreaded)
+		{
+			//			set_pppm(pppm_t, XML->sys.core[ithCore].issue_width,1, 1, 1);
+			int_inst_window->power = int_inst_window->power_t + (int_inst_window->local_result.power +instruction_selection->power) *pppm_lkg;
+			power	   = power + int_inst_window->power;
+      	}
+
+     }
+    else
+    {//rtp
+		if (coredynp.core_ty==OOO)
+		{
+			int_inst_window->rt_power = int_inst_window->power_t + (int_inst_window->local_result.power +instruction_selection->power) *pppm_lkg;
+			fp_inst_window->rt_power  = fp_inst_window->power_t + (fp_inst_window->local_result.power +instruction_selection->power) *pppm_lkg;
+			rt_power	              = rt_power + int_inst_window->rt_power + fp_inst_window->rt_power;
+			if (XML->sys.core[ithCore].ROB_size >0)
+			{
+				ROB->rt_power = ROB->power_t + ROB->local_result.power*pppm_lkg;
+				rt_power	              = rt_power + ROB->rt_power;
+			}
+
+		}
+		else if (coredynp.multithreaded)
+		{
+			//			set_pppm(pppm_t, XML->sys.core[ithCore].issue_width,1, 1, 1);
+			int_inst_window->rt_power = int_inst_window->power_t + (int_inst_window->local_result.power +instruction_selection->power) *pppm_lkg;
+			rt_power	              = rt_power + int_inst_window->rt_power;
+      	}
+    }
+//	set_pppm(pppm_t, XML->sys.core[ithCore].issue_width,1, 1, 1);
+//	cout<<"Scheduler power="<<power.readOp.dynamic<<"leakage="<<power.readOp.leakage<<endl;
+//	cout<<"IW="<<int_inst_window->local_result.power.searchOp.dynamic * int_inst_window->stats_t.readAc.access +
+//    + int_inst_window->local_result.power.writeOp.dynamic * int_inst_window->stats_t.writeAc.access<<"leakage="<<int_inst_window->local_result.power.readOp.leakage<<endl;
+//	cout<<"selection"<<instruction_selection->power.readOp.dynamic<<"leakage"<<instruction_selection->power.readOp.leakage<<endl;
+}
+
+void SchedulerU::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
+{
+	if (!exist) return;
+	string indent_str(indent, ' ');
+	string indent_str_next(indent+2, ' ');
+	bool long_channel = XML->sys.longer_channel_device;
+
+
+	if (is_tdp)
+	{
+		if (coredynp.core_ty==OOO)
+		{
+			cout << indent_str << "Instruction Window:" << endl;
+			cout << indent_str_next << "Area = " << int_inst_window->area.get_area()*1e-6<< " mm^2" << endl;
+			cout << indent_str_next << "Peak Dynamic = " << int_inst_window->power.readOp.dynamic*clockRate << " W" << endl;
+			cout << indent_str_next << "Subthreshold Leakage = "
+				<< (long_channel? int_inst_window->power.readOp.longer_channel_leakage:int_inst_window->power.readOp.leakage) <<" W" << endl;
+			cout << indent_str_next << "Gate Leakage = " << int_inst_window->power.readOp.gate_leakage << " W" << endl;
+			cout << indent_str_next << "Runtime Dynamic = " << int_inst_window->rt_power.readOp.dynamic/executionTime << " W" << endl;
+			cout <<endl;
+			cout << indent_str << "FP Instruction Window:" << endl;
+			cout << indent_str_next << "Area = " << fp_inst_window->area.get_area()*1e-6  << " mm^2" << endl;
+			cout << indent_str_next << "Peak Dynamic = " << fp_inst_window->power.readOp.dynamic*clockRate  << " W" << endl;
+			cout << indent_str_next << "Subthreshold Leakage = "
+				<< (long_channel? fp_inst_window->power.readOp.longer_channel_leakage:fp_inst_window->power.readOp.leakage ) << " W" << endl;
+			cout << indent_str_next << "Gate Leakage = " << fp_inst_window->power.readOp.gate_leakage  << " W" << endl;
+			cout << indent_str_next << "Runtime Dynamic = " << fp_inst_window->rt_power.readOp.dynamic/executionTime << " W" << endl;
+			cout <<endl;
+			if (XML->sys.core[ithCore].ROB_size >0)
+			{
+				cout << indent_str<<"ROB:" << endl;
+				cout << indent_str_next << "Area = " << ROB->area.get_area() *1e-6 << " mm^2" << endl;
+				cout << indent_str_next << "Peak Dynamic = " << ROB->power.readOp.dynamic*clockRate  << " W" << endl;
+				cout << indent_str_next << "Subthreshold Leakage = "
+				<< (long_channel? ROB->power.readOp.longer_channel_leakage:ROB->power.readOp.leakage)  << " W" << endl;
+				cout << indent_str_next << "Gate Leakage = " << ROB->power.readOp.gate_leakage  << " W" << endl;
+				cout << indent_str_next << "Runtime Dynamic = " << ROB->rt_power.readOp.dynamic/executionTime << " W" << endl;
+				cout <<endl;
+			}
+		}
+		else if (coredynp.multithreaded)
+		{
+			cout << indent_str << "Instruction Window:" << endl;
+			cout << indent_str_next << "Area = " << int_inst_window->area.get_area()*1e-6<< " mm^2" << endl;
+			cout << indent_str_next << "Peak Dynamic = " << int_inst_window->power.readOp.dynamic*clockRate << " W" << endl;
+			cout << indent_str_next << "Subthreshold Leakage = "
+				<< (long_channel? int_inst_window->power.readOp.longer_channel_leakage:int_inst_window->power.readOp.leakage) <<" W" << endl;
+			cout << indent_str_next << "Gate Leakage = " << int_inst_window->power.readOp.gate_leakage << " W" << endl;
+			cout << indent_str_next << "Runtime Dynamic = " << int_inst_window->rt_power.readOp.dynamic/executionTime << " W" << endl;
+			cout <<endl;
+		}
+	}
+	else
+	{
+		if (coredynp.core_ty==OOO)
+		{
+			cout << indent_str_next << "Instruction Window    Peak Dynamic = " << int_inst_window->rt_power.readOp.dynamic*clockRate << " W" << endl;
+			cout << indent_str_next << "Instruction Window    Subthreshold Leakage = " << int_inst_window->rt_power.readOp.leakage <<" W" << endl;
+			cout << indent_str_next << "Instruction Window    Gate Leakage = " << int_inst_window->rt_power.readOp.gate_leakage << " W" << endl;
+			cout << indent_str_next << "FP Instruction Window   Peak Dynamic = " << fp_inst_window->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+			cout << indent_str_next << "FP Instruction Window   Subthreshold Leakage = " << fp_inst_window->rt_power.readOp.leakage  << " W" << endl;
+			cout << indent_str_next << "FP Instruction Window   Gate Leakage = " << fp_inst_window->rt_power.readOp.gate_leakage  << " W" << endl;
+			if (XML->sys.core[ithCore].ROB_size >0)
+			{
+				cout << indent_str_next << "ROB   Peak Dynamic = " << ROB->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+				cout << indent_str_next << "ROB   Subthreshold Leakage = " << ROB->rt_power.readOp.leakage  << " W" << endl;
+				cout << indent_str_next << "ROB   Gate Leakage = " << ROB->rt_power.readOp.gate_leakage  << " W" << endl;
+			}
+		}
+		else if (coredynp.multithreaded)
+		{
+			cout << indent_str_next << "Instruction Window    Peak Dynamic = " << int_inst_window->rt_power.readOp.dynamic*clockRate << " W" << endl;
+			cout << indent_str_next << "Instruction Window    Subthreshold Leakage = " << int_inst_window->rt_power.readOp.leakage <<" W" << endl;
+			cout << indent_str_next << "Instruction Window    Gate Leakage = " << int_inst_window->rt_power.readOp.gate_leakage << " W" << endl;
+		}
+	}
+
+}
+
+void LoadStoreU::computeEnergy(bool is_tdp)
+{
+	if (!exist) return;
+
+	executionTime=XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);//Syed
+
+	//RF crossbar power (Syed)
+	xbar_shared->compute_power();
+   
+	if (is_tdp)
+	    {
+
+	    	//init stats for Peak
+        // added by Jingwen
+	    	sharedmemory.caches->stats_t.readAc.access  = 0.67*sharedmemory.caches->l_ip.num_rw_ports*coredynp.LSU_duty_cycle;
+	    	sharedmemory.caches->stats_t.readAc.miss    = 0;
+	    	sharedmemory.caches->stats_t.readAc.hit     = sharedmemory.caches->stats_t.readAc.access - sharedmemory.caches->stats_t.readAc.miss;
+	    	sharedmemory.caches->stats_t.writeAc.access = 0.33*sharedmemory.caches->l_ip.num_rw_ports*coredynp.LSU_duty_cycle;
+	    	sharedmemory.caches->stats_t.writeAc.miss   = 0;
+    		sharedmemory.caches->stats_t.writeAc.hit    = sharedmemory.caches->stats_t.writeAc.access -	sharedmemory.caches->stats_t.writeAc.miss;
+	    	sharedmemory.caches->tdp_stats = sharedmemory.caches->stats_t;
+
+	    	sharedmemory.missb->stats_t.readAc.access  = sharedmemory.missb->l_ip.num_search_ports;
+	    	sharedmemory.missb->stats_t.writeAc.access = sharedmemory.missb->l_ip.num_search_ports;
+	    	sharedmemory.missb->tdp_stats = sharedmemory.missb->stats_t;
+
+	    	sharedmemory.ifb->stats_t.readAc.access  = sharedmemory.ifb->l_ip.num_search_ports;
+	    	sharedmemory.ifb->stats_t.writeAc.access = sharedmemory.ifb->l_ip.num_search_ports;
+	    	sharedmemory.ifb->tdp_stats = sharedmemory.ifb->stats_t;
+
+	    	sharedmemory.prefetchb->stats_t.readAc.access  = sharedmemory.prefetchb->l_ip.num_search_ports;
+	    	sharedmemory.prefetchb->stats_t.writeAc.access = sharedmemory.ifb->l_ip.num_search_ports;
+	    	sharedmemory.prefetchb->tdp_stats = sharedmemory.prefetchb->stats_t;
+	    	if (cache_p==Write_back)
+	    	{
+	    		sharedmemory.wbb->stats_t.readAc.access  = sharedmemory.wbb->l_ip.num_search_ports;
+	    		sharedmemory.wbb->stats_t.writeAc.access = sharedmemory.wbb->l_ip.num_search_ports;
+	    		sharedmemory.wbb->tdp_stats = sharedmemory.wbb->stats_t;
+	    	}
+
+
+
+	    	//init stats for Peak
+	    	dcache.caches->stats_t.readAc.access  = 0.67*dcache.caches->l_ip.num_rw_ports*coredynp.LSU_duty_cycle;
+	    	dcache.caches->stats_t.readAc.miss    = 0;
+	    	dcache.caches->stats_t.readAc.hit     = dcache.caches->stats_t.readAc.access - dcache.caches->stats_t.readAc.miss;
+	    	dcache.caches->stats_t.writeAc.access = 0.33*dcache.caches->l_ip.num_rw_ports*coredynp.LSU_duty_cycle;
+	    	dcache.caches->stats_t.writeAc.miss   = 0;
+    		dcache.caches->stats_t.writeAc.hit    = dcache.caches->stats_t.writeAc.access -	dcache.caches->stats_t.writeAc.miss;
+	    	dcache.caches->tdp_stats = dcache.caches->stats_t;
+
+	    	dcache.missb->stats_t.readAc.access  = dcache.missb->l_ip.num_search_ports;
+	    	dcache.missb->stats_t.writeAc.access = dcache.missb->l_ip.num_search_ports;
+	    	dcache.missb->tdp_stats = dcache.missb->stats_t;
+
+	    	dcache.ifb->stats_t.readAc.access  = dcache.ifb->l_ip.num_search_ports;
+	    	dcache.ifb->stats_t.writeAc.access = dcache.ifb->l_ip.num_search_ports;
+	    	dcache.ifb->tdp_stats = dcache.ifb->stats_t;
+
+	    	dcache.prefetchb->stats_t.readAc.access  = dcache.prefetchb->l_ip.num_search_ports;
+	    	dcache.prefetchb->stats_t.writeAc.access = dcache.ifb->l_ip.num_search_ports;
+	    	dcache.prefetchb->tdp_stats = dcache.prefetchb->stats_t;
+	    	if (cache_p==Write_back)
+	    	{
+	    		dcache.wbb->stats_t.readAc.access  = dcache.wbb->l_ip.num_search_ports;
+	    		dcache.wbb->stats_t.writeAc.access = dcache.wbb->l_ip.num_search_ports;
+	    		dcache.wbb->tdp_stats = dcache.wbb->stats_t;
+	    	}
+
+
+	    	//init stats for Peak - ccache
+	    	ccache.caches->stats_t.readAc.access  = 0.67*ccache.caches->l_ip.num_rw_ports*coredynp.LSU_duty_cycle;
+	    	ccache.caches->stats_t.readAc.miss    = 0;
+	    	ccache.caches->stats_t.readAc.hit     = ccache.caches->stats_t.readAc.access - ccache.caches->stats_t.readAc.miss;
+	    	ccache.caches->stats_t.writeAc.access = 0.33*ccache.caches->l_ip.num_rw_ports*coredynp.LSU_duty_cycle;
+	    	ccache.caches->stats_t.writeAc.miss   = 0;
+    		ccache.caches->stats_t.writeAc.hit    = ccache.caches->stats_t.writeAc.access -	ccache.caches->stats_t.writeAc.miss;
+	    	ccache.caches->tdp_stats = ccache.caches->stats_t;
+
+	    	ccache.missb->stats_t.readAc.access  = ccache.missb->l_ip.num_search_ports;
+	    	ccache.missb->stats_t.writeAc.access = ccache.missb->l_ip.num_search_ports;
+	    	ccache.missb->tdp_stats = ccache.missb->stats_t;
+
+	    	ccache.ifb->stats_t.readAc.access  = ccache.ifb->l_ip.num_search_ports;
+	    	ccache.ifb->stats_t.writeAc.access = ccache.ifb->l_ip.num_search_ports;
+	    	ccache.ifb->tdp_stats = ccache.ifb->stats_t;
+
+	    	ccache.prefetchb->stats_t.readAc.access  = ccache.prefetchb->l_ip.num_search_ports;
+	    	ccache.prefetchb->stats_t.writeAc.access = ccache.ifb->l_ip.num_search_ports;
+	    	ccache.prefetchb->tdp_stats = ccache.prefetchb->stats_t;
+	    	if (cache_p==Write_back)
+	    	{
+	    		ccache.wbb->stats_t.readAc.access  = ccache.wbb->l_ip.num_search_ports;
+	    		ccache.wbb->stats_t.writeAc.access = ccache.wbb->l_ip.num_search_ports;
+	    		ccache.wbb->tdp_stats = ccache.wbb->stats_t;
+	    	}
+
+
+	    	//init stats for Peak - tcache
+	    	tcache.caches->stats_t.readAc.access  = 0.67*tcache.caches->l_ip.num_rw_ports*coredynp.LSU_duty_cycle;
+	    	tcache.caches->stats_t.readAc.miss    = 0;
+	    	tcache.caches->stats_t.readAc.hit     = tcache.caches->stats_t.readAc.access - tcache.caches->stats_t.readAc.miss;
+	    	tcache.caches->stats_t.writeAc.access = 0.33*tcache.caches->l_ip.num_rw_ports*coredynp.LSU_duty_cycle;
+	    	tcache.caches->stats_t.writeAc.miss   = 0;
+    		tcache.caches->stats_t.writeAc.hit    = tcache.caches->stats_t.writeAc.access -	tcache.caches->stats_t.writeAc.miss;
+	    	tcache.caches->tdp_stats = tcache.caches->stats_t;
+
+	    	tcache.missb->stats_t.readAc.access  = tcache.missb->l_ip.num_search_ports;
+	    	tcache.missb->stats_t.writeAc.access = tcache.missb->l_ip.num_search_ports;
+	    	tcache.missb->tdp_stats = tcache.missb->stats_t;
+
+	    	tcache.ifb->stats_t.readAc.access  = tcache.ifb->l_ip.num_search_ports;
+	    	tcache.ifb->stats_t.writeAc.access = tcache.ifb->l_ip.num_search_ports;
+	    	tcache.ifb->tdp_stats = tcache.ifb->stats_t;
+
+	    	tcache.prefetchb->stats_t.readAc.access  = tcache.prefetchb->l_ip.num_search_ports;
+	    	tcache.prefetchb->stats_t.writeAc.access = tcache.ifb->l_ip.num_search_ports;
+	    	tcache.prefetchb->tdp_stats = tcache.prefetchb->stats_t;
+	    	if (cache_p==Write_back)
+	    	{
+	    		tcache.wbb->stats_t.readAc.access  = tcache.wbb->l_ip.num_search_ports;
+	    		tcache.wbb->stats_t.writeAc.access = tcache.wbb->l_ip.num_search_ports;
+	    		tcache.wbb->tdp_stats = tcache.wbb->stats_t;
+	    	}
+
+
+
+	    	LSQ->stats_t.readAc.access = LSQ->stats_t.writeAc.access = LSQ->l_ip.num_search_ports*coredynp.LSU_duty_cycle;
+	    	LSQ->tdp_stats = LSQ->stats_t;
+	    	if ((coredynp.core_ty==OOO) && (XML->sys.core[ithCore].load_buffer_size >0))
+	    	{
+	    		LoadQ->stats_t.readAc.access = LoadQ->stats_t.writeAc.access = LoadQ->l_ip.num_search_ports*coredynp.LSU_duty_cycle;
+	    		LoadQ->tdp_stats = LoadQ->stats_t;
+	    	}
+	    }
+	    else
+	    {
+	    	//init stats for Runtime Dynamic (RTP)
+
+	    	sharedmemory.caches->stats_t.readAc.access  = XML->sys.core[ithCore].sharedmemory.read_accesses;
+	    	sharedmemory.caches->stats_t.readAc.miss    = XML->sys.core[ithCore].sharedmemory.read_misses;
+	    	sharedmemory.caches->stats_t.readAc.hit     = sharedmemory.caches->stats_t.readAc.access - sharedmemory.caches->stats_t.readAc.miss;
+	    	sharedmemory.caches->stats_t.writeAc.access = XML->sys.core[ithCore].sharedmemory.write_accesses;
+	    	sharedmemory.caches->stats_t.writeAc.miss   = XML->sys.core[ithCore].sharedmemory.write_misses;
+    		sharedmemory.caches->stats_t.writeAc.hit    = sharedmemory.caches->stats_t.writeAc.access -	sharedmemory.caches->stats_t.writeAc.miss;
+	    	sharedmemory.caches->rtp_stats = sharedmemory.caches->stats_t;
+
+
+
+	    	dcache.caches->stats_t.readAc.access  = XML->sys.core[ithCore].dcache.read_accesses;
+	    	dcache.caches->stats_t.readAc.miss    = XML->sys.core[ithCore].dcache.read_misses;
+	    	dcache.caches->stats_t.readAc.hit     = dcache.caches->stats_t.readAc.access - dcache.caches->stats_t.readAc.miss;
+	    	dcache.caches->stats_t.writeAc.access = XML->sys.core[ithCore].dcache.write_accesses;
+	    	dcache.caches->stats_t.writeAc.miss   = XML->sys.core[ithCore].dcache.write_misses;
+    		dcache.caches->stats_t.writeAc.hit    = dcache.caches->stats_t.writeAc.access -	dcache.caches->stats_t.writeAc.miss;
+	    	dcache.caches->rtp_stats = dcache.caches->stats_t;
+
+	    	ccache.caches->stats_t.readAc.access  = XML->sys.core[ithCore].ccache.read_accesses;
+	    	ccache.caches->stats_t.readAc.miss    = XML->sys.core[ithCore].ccache.read_misses;
+	    	ccache.caches->stats_t.readAc.hit     = ccache.caches->stats_t.readAc.access - ccache.caches->stats_t.readAc.miss;
+	    	ccache.caches->stats_t.writeAc.access = XML->sys.core[ithCore].ccache.write_accesses;
+	    	ccache.caches->stats_t.writeAc.miss   = XML->sys.core[ithCore].ccache.write_misses;
+    		ccache.caches->stats_t.writeAc.hit    = ccache.caches->stats_t.writeAc.access -	ccache.caches->stats_t.writeAc.miss;
+	    	ccache.caches->rtp_stats = ccache.caches->stats_t;
+
+	    	tcache.caches->stats_t.readAc.access  = XML->sys.core[ithCore].tcache.read_accesses;
+	    	tcache.caches->stats_t.readAc.miss    = XML->sys.core[ithCore].tcache.read_misses;
+	    	tcache.caches->stats_t.readAc.hit     = tcache.caches->stats_t.readAc.access - tcache.caches->stats_t.readAc.miss;
+	    	tcache.caches->stats_t.writeAc.access = XML->sys.core[ithCore].tcache.write_accesses;
+	    	tcache.caches->stats_t.writeAc.miss   = XML->sys.core[ithCore].tcache.write_misses;
+    		tcache.caches->stats_t.writeAc.hit    = tcache.caches->stats_t.writeAc.access -	tcache.caches->stats_t.writeAc.miss;
+	    	tcache.caches->rtp_stats = tcache.caches->stats_t;
+
+	    	if (cache_p==Write_back)
+	    	{
+
+	    		sharedmemory.missb->stats_t.readAc.access  = sharedmemory.caches->stats_t.writeAc.miss;
+	    		sharedmemory.missb->stats_t.writeAc.access = sharedmemory.caches->stats_t.writeAc.miss;
+	    		sharedmemory.missb->rtp_stats = sharedmemory.missb->stats_t;
+	    		sharedmemory.ifb->stats_t.readAc.access  = sharedmemory.caches->stats_t.writeAc.miss;
+	    		sharedmemory.ifb->stats_t.writeAc.access = sharedmemory.caches->stats_t.writeAc.miss;
+	    		sharedmemory.ifb->rtp_stats = sharedmemory.ifb->stats_t;
+	    		sharedmemory.prefetchb->stats_t.readAc.access  = sharedmemory.caches->stats_t.writeAc.miss;
+	    		sharedmemory.prefetchb->stats_t.writeAc.access = sharedmemory.caches->stats_t.writeAc.miss;
+	    		sharedmemory.prefetchb->rtp_stats = sharedmemory.prefetchb->stats_t;
+	    		sharedmemory.wbb->stats_t.readAc.access  = sharedmemory.caches->stats_t.writeAc.miss;
+	    		sharedmemory.wbb->stats_t.writeAc.access = sharedmemory.caches->stats_t.writeAc.miss;
+	    		sharedmemory.wbb->rtp_stats = sharedmemory.wbb->stats_t;
+
+
+	    		dcache.missb->stats_t.readAc.access  = dcache.caches->stats_t.writeAc.miss;
+	    		dcache.missb->stats_t.writeAc.access = dcache.caches->stats_t.writeAc.miss;
+	    		dcache.missb->rtp_stats = dcache.missb->stats_t;
+	    		dcache.ifb->stats_t.readAc.access  = dcache.caches->stats_t.writeAc.miss;
+	    		dcache.ifb->stats_t.writeAc.access = dcache.caches->stats_t.writeAc.miss;
+	    		dcache.ifb->rtp_stats = dcache.ifb->stats_t;
+	    		dcache.prefetchb->stats_t.readAc.access  = dcache.caches->stats_t.writeAc.miss;
+	    		dcache.prefetchb->stats_t.writeAc.access = dcache.caches->stats_t.writeAc.miss;
+	    		dcache.prefetchb->rtp_stats = dcache.prefetchb->stats_t;
+	    		dcache.wbb->stats_t.readAc.access  = dcache.caches->stats_t.writeAc.miss;
+	    		dcache.wbb->stats_t.writeAc.access = dcache.caches->stats_t.writeAc.miss;
+	    		dcache.wbb->rtp_stats = dcache.wbb->stats_t;
+
+	    		ccache.missb->stats_t.readAc.access  = ccache.caches->stats_t.writeAc.miss;
+	    		ccache.missb->stats_t.writeAc.access = ccache.caches->stats_t.writeAc.miss;
+	    		ccache.missb->rtp_stats = ccache.missb->stats_t;
+	    		ccache.ifb->stats_t.readAc.access  = ccache.caches->stats_t.writeAc.miss;
+	    		ccache.ifb->stats_t.writeAc.access = ccache.caches->stats_t.writeAc.miss;
+	    		ccache.ifb->rtp_stats = ccache.ifb->stats_t;
+	    		ccache.prefetchb->stats_t.readAc.access  = ccache.caches->stats_t.writeAc.miss;
+	    		ccache.prefetchb->stats_t.writeAc.access = ccache.caches->stats_t.writeAc.miss;
+	    		ccache.prefetchb->rtp_stats = ccache.prefetchb->stats_t;
+	    		ccache.wbb->stats_t.readAc.access  = ccache.caches->stats_t.writeAc.miss;
+	    		ccache.wbb->stats_t.writeAc.access = ccache.caches->stats_t.writeAc.miss;
+	    		ccache.wbb->rtp_stats = ccache.wbb->stats_t;
+
+	    		tcache.missb->stats_t.readAc.access  = tcache.caches->stats_t.writeAc.miss;
+	    		tcache.missb->stats_t.writeAc.access = tcache.caches->stats_t.writeAc.miss;
+	    		tcache.missb->rtp_stats = tcache.missb->stats_t;
+	    		tcache.ifb->stats_t.readAc.access  = tcache.caches->stats_t.writeAc.miss;
+	    		tcache.ifb->stats_t.writeAc.access = tcache.caches->stats_t.writeAc.miss;
+	    		tcache.ifb->rtp_stats = tcache.ifb->stats_t;
+	    		tcache.prefetchb->stats_t.readAc.access  = tcache.caches->stats_t.writeAc.miss;
+	    		tcache.prefetchb->stats_t.writeAc.access = tcache.caches->stats_t.writeAc.miss;
+	    		tcache.prefetchb->rtp_stats = tcache.prefetchb->stats_t;
+	    		tcache.wbb->stats_t.readAc.access  = tcache.caches->stats_t.writeAc.miss;
+	    		tcache.wbb->stats_t.writeAc.access = tcache.caches->stats_t.writeAc.miss;
+	    		tcache.wbb->rtp_stats = tcache.wbb->stats_t;
+	    	}
+	    	else
+	    	{
+	    		sharedmemory.missb->stats_t.readAc.access  = sharedmemory.caches->stats_t.readAc.miss;
+	    		sharedmemory.missb->stats_t.writeAc.access = sharedmemory.caches->stats_t.readAc.miss;
+	    		sharedmemory.missb->rtp_stats = sharedmemory.missb->stats_t;
+	    		sharedmemory.ifb->stats_t.readAc.access  = sharedmemory.caches->stats_t.readAc.miss;
+	    		sharedmemory.ifb->stats_t.writeAc.access = sharedmemory.caches->stats_t.readAc.miss;
+	    		sharedmemory.ifb->rtp_stats = sharedmemory.ifb->stats_t;
+	    		sharedmemory.prefetchb->stats_t.readAc.access  = sharedmemory.caches->stats_t.readAc.miss;
+	    		sharedmemory.prefetchb->stats_t.writeAc.access = sharedmemory.caches->stats_t.readAc.miss;
+	    		sharedmemory.prefetchb->rtp_stats = sharedmemory.prefetchb->stats_t;
+
+
+	    		dcache.missb->stats_t.readAc.access  = dcache.caches->stats_t.readAc.miss;
+	    		dcache.missb->stats_t.writeAc.access = dcache.caches->stats_t.readAc.miss;
+	    		dcache.missb->rtp_stats = dcache.missb->stats_t;
+	    		dcache.ifb->stats_t.readAc.access  = dcache.caches->stats_t.readAc.miss;
+	    		dcache.ifb->stats_t.writeAc.access = dcache.caches->stats_t.readAc.miss;
+	    		dcache.ifb->rtp_stats = dcache.ifb->stats_t;
+	    		dcache.prefetchb->stats_t.readAc.access  = dcache.caches->stats_t.readAc.miss;
+	    		dcache.prefetchb->stats_t.writeAc.access = dcache.caches->stats_t.readAc.miss;
+	    		dcache.prefetchb->rtp_stats = dcache.prefetchb->stats_t;
+
+
+	    		ccache.missb->stats_t.readAc.access  = ccache.caches->stats_t.readAc.miss;
+	    		ccache.missb->stats_t.writeAc.access = ccache.caches->stats_t.readAc.miss;
+	    		ccache.missb->rtp_stats = ccache.missb->stats_t;
+	    		ccache.ifb->stats_t.readAc.access  = ccache.caches->stats_t.readAc.miss;
+	    		ccache.ifb->stats_t.writeAc.access = ccache.caches->stats_t.readAc.miss;
+	    		ccache.ifb->rtp_stats = ccache.ifb->stats_t;
+	    		ccache.prefetchb->stats_t.readAc.access  = ccache.caches->stats_t.readAc.miss;
+	    		ccache.prefetchb->stats_t.writeAc.access = ccache.caches->stats_t.readAc.miss;
+	    		ccache.prefetchb->rtp_stats = ccache.prefetchb->stats_t;
+
+	    		tcache.missb->stats_t.readAc.access  = tcache.caches->stats_t.readAc.miss;
+	    		tcache.missb->stats_t.writeAc.access = tcache.caches->stats_t.readAc.miss;
+	    		tcache.missb->rtp_stats = tcache.missb->stats_t;
+	    		tcache.ifb->stats_t.readAc.access  = tcache.caches->stats_t.readAc.miss;
+	    		tcache.ifb->stats_t.writeAc.access = tcache.caches->stats_t.readAc.miss;
+	    		tcache.ifb->rtp_stats = tcache.ifb->stats_t;
+	    		tcache.prefetchb->stats_t.readAc.access  = tcache.caches->stats_t.readAc.miss;
+	    		tcache.prefetchb->stats_t.writeAc.access = tcache.caches->stats_t.readAc.miss;
+	    		tcache.prefetchb->rtp_stats = tcache.prefetchb->stats_t;
+
+	    	}
+
+	    	LSQ->stats_t.readAc.access  = (XML->sys.core[ithCore].load_instructions + XML->sys.core[ithCore].store_instructions)*2;//flush overhead considered
+	    	LSQ->stats_t.writeAc.access = (XML->sys.core[ithCore].load_instructions + XML->sys.core[ithCore].store_instructions)*2;
+	    	LSQ->rtp_stats = LSQ->stats_t;
+
+	    	if ((coredynp.core_ty==OOO) && (XML->sys.core[ithCore].load_buffer_size >0))
+	    	{
+		    	LoadQ->stats_t.readAc.access  = XML->sys.core[ithCore].load_instructions + XML->sys.core[ithCore].store_instructions;
+		    	LoadQ->stats_t.writeAc.access = XML->sys.core[ithCore].load_instructions + XML->sys.core[ithCore].store_instructions;
+		    	LoadQ->rtp_stats = LoadQ->stats_t;
+	    	}
+
+	    }
+
+	sharedmemory.power_t.reset();
+	dcache.power_t.reset();
+	ccache.power_t.reset();
+	tcache.power_t.reset();
+	LSQ->power_t.reset();
+
+    sharedmemory.power_t.readOp.dynamic	+= (sharedmemory.caches->stats_t.readAc.hit*sharedmemory.caches->local_result.power.readOp.dynamic+
+    		sharedmemory.caches->stats_t.readAc.miss*sharedmemory.caches->local_result.power.readOp.dynamic+
+    		sharedmemory.caches->stats_t.writeAc.miss*sharedmemory.caches->local_result.tag_array2->power.readOp.dynamic+
+    		sharedmemory.caches->stats_t.writeAc.access*sharedmemory.caches->local_result.power.writeOp.dynamic +
+			xbar_shared->power.readOp.dynamic*(sharedmemory.caches->stats_t.readAc.hit+ sharedmemory.caches->stats_t.writeAc.hit));
+
+
+    dcache.power_t.readOp.dynamic	+= (dcache.caches->stats_t.readAc.hit*dcache.caches->local_result.power.readOp.dynamic+
+    		dcache.caches->stats_t.readAc.miss*dcache.caches->local_result.power.readOp.dynamic+
+    		dcache.caches->stats_t.writeAc.miss*dcache.caches->local_result.tag_array2->power.readOp.dynamic+
+    		dcache.caches->stats_t.writeAc.access*dcache.caches->local_result.power.writeOp.dynamic +
+			xbar_shared->power.readOp.dynamic*(dcache.caches->stats_t.readAc.hit+ dcache.caches->stats_t.writeAc.hit));
+    ccache.power_t.readOp.dynamic	+= (ccache.caches->stats_t.readAc.hit*ccache.caches->local_result.power.readOp.dynamic+
+    		ccache.caches->stats_t.readAc.miss*ccache.caches->local_result.power.readOp.dynamic+
+    		ccache.caches->stats_t.writeAc.miss*ccache.caches->local_result.tag_array2->power.readOp.dynamic+
+    		ccache.caches->stats_t.writeAc.access*ccache.caches->local_result.power.writeOp.dynamic + 
+			xbar_shared->power.readOp.dynamic*(ccache.caches->stats_t.readAc.hit));
+
+    tcache.power_t.readOp.dynamic	+= (tcache.caches->stats_t.readAc.hit*tcache.caches->local_result.power.readOp.dynamic+
+    		tcache.caches->stats_t.readAc.miss*tcache.caches->local_result.power.readOp.dynamic+
+    		tcache.caches->stats_t.writeAc.miss*tcache.caches->local_result.tag_array2->power.readOp.dynamic+
+    		tcache.caches->stats_t.writeAc.access*tcache.caches->local_result.power.writeOp.dynamic+
+			xbar_shared->power.readOp.dynamic*(tcache.caches->stats_t.readAc.hit+ tcache.caches->stats_t.writeAc.hit));
+
+    if (cache_p==Write_back)
+    {//write miss will generate a write later
+    	dcache.power_t.readOp.dynamic	+= dcache.caches->stats_t.writeAc.miss*dcache.caches->local_result.power.writeOp.dynamic;
+    	ccache.power_t.readOp.dynamic	+= ccache.caches->stats_t.writeAc.miss*ccache.caches->local_result.power.writeOp.dynamic;
+    	tcache.power_t.readOp.dynamic	+= tcache.caches->stats_t.writeAc.miss*tcache.caches->local_result.power.writeOp.dynamic;
+    	sharedmemory.power_t.readOp.dynamic	+= sharedmemory.caches->stats_t.writeAc.miss*sharedmemory.caches->local_result.power.writeOp.dynamic;
+    }
+
+
+    sharedmemory.power_t.readOp.dynamic	+=  sharedmemory.missb->stats_t.readAc.access*sharedmemory.missb->local_result.power.searchOp.dynamic +
+            sharedmemory.missb->stats_t.writeAc.access*sharedmemory.missb->local_result.power.writeOp.dynamic;//each access to missb involves a CAM and a write
+    sharedmemory.power_t.readOp.dynamic	+=  sharedmemory.ifb->stats_t.readAc.access*sharedmemory.ifb->local_result.power.searchOp.dynamic +
+            sharedmemory.ifb->stats_t.writeAc.access*sharedmemory.ifb->local_result.power.writeOp.dynamic;
+    sharedmemory.power_t.readOp.dynamic	+=  sharedmemory.prefetchb->stats_t.readAc.access*sharedmemory.prefetchb->local_result.power.searchOp.dynamic +
+            sharedmemory.prefetchb->stats_t.writeAc.access*sharedmemory.prefetchb->local_result.power.writeOp.dynamic;
+    if (cache_p==Write_back)
+    {
+    	sharedmemory.power_t.readOp.dynamic	+=  sharedmemory.wbb->stats_t.readAc.access*sharedmemory.wbb->local_result.power.searchOp.dynamic
+			+ sharedmemory.wbb->stats_t.writeAc.access*sharedmemory.wbb->local_result.power.writeOp.dynamic;
+    }
+
+
+    dcache.power_t.readOp.dynamic	+=  dcache.missb->stats_t.readAc.access*dcache.missb->local_result.power.searchOp.dynamic +
+            dcache.missb->stats_t.writeAc.access*dcache.missb->local_result.power.writeOp.dynamic;//each access to missb involves a CAM and a write
+    dcache.power_t.readOp.dynamic	+=  dcache.ifb->stats_t.readAc.access*dcache.ifb->local_result.power.searchOp.dynamic +
+            dcache.ifb->stats_t.writeAc.access*dcache.ifb->local_result.power.writeOp.dynamic;
+    dcache.power_t.readOp.dynamic	+=  dcache.prefetchb->stats_t.readAc.access*dcache.prefetchb->local_result.power.searchOp.dynamic +
+            dcache.prefetchb->stats_t.writeAc.access*dcache.prefetchb->local_result.power.writeOp.dynamic;
+    if (cache_p==Write_back)
+    {
+    	dcache.power_t.readOp.dynamic	+=  dcache.wbb->stats_t.readAc.access*dcache.wbb->local_result.power.searchOp.dynamic
+			+ dcache.wbb->stats_t.writeAc.access*dcache.wbb->local_result.power.writeOp.dynamic;
+    }
+
+    ccache.power_t.readOp.dynamic	+=  ccache.missb->stats_t.readAc.access*ccache.missb->local_result.power.searchOp.dynamic +
+            ccache.missb->stats_t.writeAc.access*ccache.missb->local_result.power.writeOp.dynamic;//each access to missb involves a CAM and a write
+    ccache.power_t.readOp.dynamic	+=  ccache.ifb->stats_t.readAc.access*ccache.ifb->local_result.power.searchOp.dynamic +
+            ccache.ifb->stats_t.writeAc.access*ccache.ifb->local_result.power.writeOp.dynamic;
+    ccache.power_t.readOp.dynamic	+=  ccache.prefetchb->stats_t.readAc.access*ccache.prefetchb->local_result.power.searchOp.dynamic +
+            ccache.prefetchb->stats_t.writeAc.access*ccache.prefetchb->local_result.power.writeOp.dynamic;
+    if (cache_p==Write_back)
+    {
+    	ccache.power_t.readOp.dynamic	+=  ccache.wbb->stats_t.readAc.access*ccache.wbb->local_result.power.searchOp.dynamic
+			+ ccache.wbb->stats_t.writeAc.access*ccache.wbb->local_result.power.writeOp.dynamic;
+    }
+
+    tcache.power_t.readOp.dynamic	+=  tcache.missb->stats_t.readAc.access*tcache.missb->local_result.power.searchOp.dynamic +
+            tcache.missb->stats_t.writeAc.access*tcache.missb->local_result.power.writeOp.dynamic;//each access to missb involves a CAM and a write
+    tcache.power_t.readOp.dynamic	+=  tcache.ifb->stats_t.readAc.access*tcache.ifb->local_result.power.searchOp.dynamic +
+            tcache.ifb->stats_t.writeAc.access*tcache.ifb->local_result.power.writeOp.dynamic;
+    tcache.power_t.readOp.dynamic	+=  tcache.prefetchb->stats_t.readAc.access*tcache.prefetchb->local_result.power.searchOp.dynamic +
+            tcache.prefetchb->stats_t.writeAc.access*tcache.prefetchb->local_result.power.writeOp.dynamic;
+    if (cache_p==Write_back)
+    {
+    	tcache.power_t.readOp.dynamic	+=  tcache.wbb->stats_t.readAc.access*tcache.wbb->local_result.power.searchOp.dynamic
+			+ tcache.wbb->stats_t.writeAc.access*tcache.wbb->local_result.power.writeOp.dynamic;
+    }
+
+
+    if ((coredynp.core_ty==OOO) && (XML->sys.core[ithCore].load_buffer_size >0))
+    {
+    	LoadQ->power_t.reset();
+    	LoadQ->power_t.readOp.dynamic  +=  LoadQ->stats_t.readAc.access*(LoadQ->local_result.power.searchOp.dynamic+ LoadQ->local_result.power.readOp.dynamic)+
+    	        LoadQ->stats_t.writeAc.access*LoadQ->local_result.power.writeOp.dynamic;//every memory access invloves at least two operations on LoadQ
+
+    	LSQ->power_t.readOp.dynamic  +=  LSQ->stats_t.readAc.access*(LSQ->local_result.power.searchOp.dynamic + LSQ->local_result.power.readOp.dynamic)
+    		        + LSQ->stats_t.writeAc.access*LSQ->local_result.power.writeOp.dynamic;//every memory access invloves at least two operations on LSQ
+
+    }
+    else
+    {
+    //	LSQ->power_t.readOp.dynamic  +=  LSQ->stats_t.readAc.access*(LSQ->local_result.power.searchOp.dynamic + LSQ->local_result.power.readOp.dynamic)
+    	//	        + LSQ->stats_t.writeAc.access*LSQ->local_result.power.writeOp.dynamic;//every memory access invloves at least two operations on LSQ
+		//	No LSQ in GPUs (Syed)
+
+    }
+
+    if (is_tdp)
+    {
+//    	dcache.power = dcache.power_t + (dcache.caches->local_result.power)*pppm_lkg +
+//    			(dcache.missb->local_result.power +
+//    			dcache.ifb->local_result.power +
+//    			dcache.prefetchb->local_result.power +
+//    			dcache.wbb->local_result.power)*pppm_Isub;
+
+
+    	sharedmemory.power = sharedmemory.power_t + (sharedmemory.caches->local_result.power +
+    			sharedmemory.missb->local_result.power +
+    			sharedmemory.ifb->local_result.power +
+    			sharedmemory.prefetchb->local_result.power + xbar_shared->power) *pppm_lkg;
+    	if (cache_p==Write_back)
+    	{
+    		sharedmemory.power = sharedmemory.power + sharedmemory.wbb->local_result.power*pppm_lkg;
+    	}
+
+
+    	dcache.power = dcache.power_t + (dcache.caches->local_result.power +
+    			dcache.missb->local_result.power +
+    			dcache.ifb->local_result.power +
+    			dcache.prefetchb->local_result.power) *pppm_lkg;
+    	if (cache_p==Write_back)
+    	{
+    		dcache.power = dcache.power + dcache.wbb->local_result.power*pppm_lkg;
+    	}
+
+    	ccache.power = ccache.power_t + (ccache.caches->local_result.power +
+    			ccache.missb->local_result.power +
+    			ccache.ifb->local_result.power +
+    			ccache.prefetchb->local_result.power) *pppm_lkg;
+    	if (cache_p==Write_back)
+    	{
+    		ccache.power = ccache.power + ccache.wbb->local_result.power*pppm_lkg;
+    	}
+
+    	tcache.power = tcache.power_t + (tcache.caches->local_result.power +
+    			tcache.missb->local_result.power +
+    			tcache.ifb->local_result.power +
+    			tcache.prefetchb->local_result.power) *pppm_lkg;
+    	if (cache_p==Write_back)
+    	{
+    		tcache.power = tcache.power + tcache.wbb->local_result.power*pppm_lkg;
+    	}
+
+
+    	LSQ->power = LSQ->power_t + LSQ->local_result.power *pppm_lkg;
+		//No LSQ in GPUs (Syed)
+   	LSQ->power.reset();
+    	power     = power + dcache.power + LSQ->power +sharedmemory.power + ccache.power + tcache.power;
+
+    	if ((coredynp.core_ty==OOO) && (XML->sys.core[ithCore].load_buffer_size >0))
+    	{
+    		LoadQ->power = LoadQ->power_t + LoadQ->local_result.power *pppm_lkg;
+    		power     = power + LoadQ->power;
+    	}
+    }
+    else
+    {
+//    	dcache.rt_power = dcache.power_t + (dcache.caches->local_result.power +
+//    			dcache.missb->local_result.power +
+//    			dcache.ifb->local_result.power +
+//    			dcache.prefetchb->local_result.power +
+//    			dcache.wbb->local_result.power)*pppm_lkg;
+      rt_power.reset();
+      sharedmemory.rt_power.reset(); //Jingwen
+      tcache.rt_power.reset();
+      ccache.rt_power.reset();
+      dcache.rt_power.reset();
+      LSQ->rt_power.reset();
+
+
+    	sharedmemory.rt_power = sharedmemory.power_t + (sharedmemory.caches->local_result.power +
+    			sharedmemory.missb->local_result.power +
+    			sharedmemory.ifb->local_result.power +
+    			sharedmemory.prefetchb->local_result.power )*pppm_lkg;
+
+    	if (cache_p==Write_back)
+    	{
+    		sharedmemory.rt_power = sharedmemory.rt_power + sharedmemory.wbb->local_result.power*pppm_lkg;
+    	}
+
+    	dcache.rt_power = dcache.power_t + (dcache.caches->local_result.power +
+    			dcache.missb->local_result.power +
+    			dcache.ifb->local_result.power +
+    			dcache.prefetchb->local_result.power )*pppm_lkg;
+    	if (cache_p==Write_back)
+    	{
+    		dcache.rt_power = dcache.rt_power + dcache.wbb->local_result.power*pppm_lkg;
+    	}
+
+    	ccache.rt_power = ccache.power_t + (ccache.caches->local_result.power +
+    			ccache.missb->local_result.power +
+    			ccache.ifb->local_result.power +
+    			ccache.prefetchb->local_result.power )*pppm_lkg;
+    	if (cache_p==Write_back)
+    	{
+    		ccache.rt_power = ccache.rt_power + ccache.wbb->local_result.power*pppm_lkg;
+    	}
+
+    	tcache.rt_power = tcache.power_t + (tcache.caches->local_result.power +
+    			tcache.missb->local_result.power +
+    			tcache.ifb->local_result.power +
+    			tcache.prefetchb->local_result.power )*pppm_lkg;
+    	if (cache_p==Write_back)
+    	{
+    		tcache.rt_power = tcache.rt_power + tcache.wbb->local_result.power*pppm_lkg;
+    	}
+
+
+
+    	LSQ->rt_power = LSQ->power_t + LSQ->local_result.power *pppm_lkg;
+		LSQ->rt_power.reset();
+    	rt_power     = rt_power + dcache.rt_power + LSQ->rt_power + sharedmemory.rt_power + ccache.rt_power + tcache.rt_power;
+
+    	if ((coredynp.core_ty==OOO) && (XML->sys.core[ithCore].load_buffer_size >0))
+    	{
+    		LoadQ->rt_power = LoadQ->power_t + LoadQ->local_result.power *pppm_lkg;
+    		rt_power     = rt_power + LoadQ->rt_power;
+    	}
+    }
+}
+
+
+void LoadStoreU::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
+{
+	if (!exist) return;
+	string indent_str(indent, ' ');
+	string indent_str_next(indent+2, ' ');
+	bool long_channel = XML->sys.longer_channel_device;
+
+
+	if (is_tdp)
+	{
+
+		cout << indent_str << "Shared Memory:" << endl;
+		cout << indent_str_next << "Area = " << sharedmemory.area.get_area()*1e-6<< " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << sharedmemory.power.readOp.dynamic*clockRate << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = "
+			<< (long_channel? sharedmemory.power.readOp.longer_channel_leakage:sharedmemory.power.readOp.leakage )<<" W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << sharedmemory.power.readOp.gate_leakage << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic = " << sharedmemory.rt_power.readOp.dynamic/executionTime << " W" << endl;
+		cout <<endl;
+
+
+		cout << indent_str << "Data Cache:" << endl;
+		cout << indent_str_next << "Area = " << dcache.area.get_area()*1e-6<< " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << dcache.power.readOp.dynamic*clockRate << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = "
+			<< (long_channel? dcache.power.readOp.longer_channel_leakage:dcache.power.readOp.leakage )<<" W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << dcache.power.readOp.gate_leakage << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic = " << dcache.rt_power.readOp.dynamic/executionTime << " W" << endl;
+		cout <<endl;
+
+		cout << indent_str << "Constant Cache:" << endl;
+		cout << indent_str_next << "Area = " << ccache.area.get_area()*1e-6<< " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << ccache.power.readOp.dynamic*clockRate << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = "
+			<< (long_channel? dcache.power.readOp.longer_channel_leakage:dcache.power.readOp.leakage )<<" W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << ccache.power.readOp.gate_leakage << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic = " << ccache.rt_power.readOp.dynamic/executionTime << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic Energy = " << ccache.rt_power.readOp.dynamic<<" J"<<endl;
+      cout << indent_str_next << "Execution Time = " << executionTime<<" s"<<endl;
+		cout <<endl;
+
+
+		cout << indent_str << "Texture Cache:" << endl;
+		cout << indent_str_next << "Area = " << tcache.area.get_area()*1e-6<< " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << tcache.power.readOp.dynamic*clockRate << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = "
+			<< (long_channel? dcache.power.readOp.longer_channel_leakage:dcache.power.readOp.leakage )<<" W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << tcache.power.readOp.gate_leakage << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic = " << tcache.rt_power.readOp.dynamic/executionTime << " W" << endl;
+		cout <<endl;
+		
+    if (coredynp.core_ty==Inorder)
+		{
+			cout << indent_str << "Load/Store Queue:" << endl;
+			cout << indent_str_next << "Area = " << LSQ->area.get_area()*1e-6  << " mm^2" << endl;
+			cout << indent_str_next << "Peak Dynamic = " << LSQ->power.readOp.dynamic*clockRate  << " W" << endl;
+			cout << indent_str_next << "Subthreshold Leakage = "
+				<< (long_channel? LSQ->power.readOp.longer_channel_leakage:LSQ->power.readOp.leakage)  << " W" << endl;
+			cout << indent_str_next << "Gate Leakage = " << LSQ->power.readOp.gate_leakage  << " W" << endl;
+			cout << indent_str_next << "Runtime Dynamic = " << LSQ->rt_power.readOp.dynamic/executionTime << " W" << endl;
+			cout <<endl;
+		}
+		else
+
+		{
+			if (XML->sys.core[ithCore].load_buffer_size >0)
+			{
+				cout << indent_str << "LoadQ:" << endl;
+				cout << indent_str_next << "Area = " << LoadQ->area.get_area() *1e-6 << " mm^2" << endl;
+				cout << indent_str_next << "Peak Dynamic = " << LoadQ->power.readOp.dynamic*clockRate  << " W" << endl;
+				cout << indent_str_next << "Subthreshold Leakage = "
+				<< (long_channel? LoadQ->power.readOp.longer_channel_leakage:LoadQ->power.readOp.leakage)  << " W" << endl;
+				cout << indent_str_next << "Gate Leakage = " << LoadQ->power.readOp.gate_leakage  << " W" << endl;
+				cout << indent_str_next << "Runtime Dynamic = " << LoadQ->rt_power.readOp.dynamic/executionTime << " W" << endl;
+				cout <<endl;
+			}
+			cout << indent_str<< "StoreQ:" << endl;
+			cout << indent_str_next << "Area = " << LSQ->area.get_area()  *1e-6<< " mm^2" << endl;
+			cout << indent_str_next << "Peak Dynamic = " << LSQ->power.readOp.dynamic*clockRate  << " W" << endl;
+			cout << indent_str_next << "Subthreshold Leakage = "
+				<< (long_channel? LSQ->power.readOp.longer_channel_leakage:LSQ->power.readOp.leakage)  << " W" << endl;
+			cout << indent_str_next << "Gate Leakage = " << LSQ->power.readOp.gate_leakage  << " W" << endl;
+			cout << indent_str_next << "Runtime Dynamic = " << LSQ->rt_power.readOp.dynamic/executionTime<< " W" << endl;
+			cout <<endl;
+		}
+	}
+	else
+	{
+
+		cout << indent_str_next << "Shared Memory    Peak Dynamic = " << sharedmemory.rt_power.readOp.dynamic*clockRate << " W" << endl;
+		cout << indent_str_next << "Shared Memory    Subthreshold Leakage = " << sharedmemory.rt_power.readOp.leakage <<" W" << endl;
+		cout << indent_str_next << "Shared Memory    Gate Leakage = " << sharedmemory.rt_power.readOp.gate_leakage << " W" << endl;
+
+
+		cout << indent_str_next << "Data Cache    Peak Dynamic = " << dcache.rt_power.readOp.dynamic*clockRate << " W" << endl;
+		cout << indent_str_next << "Data Cache    Subthreshold Leakage = " << dcache.rt_power.readOp.leakage <<" W" << endl;
+		cout << indent_str_next << "Data Cache    Gate Leakage = " << dcache.rt_power.readOp.gate_leakage << " W" << endl;
+
+		cout << indent_str_next << "Constant Cache    Peak Dynamic = " << ccache.rt_power.readOp.dynamic*clockRate << " W" << endl;
+		cout << indent_str_next << "Constant Cache    Subthreshold Leakage = " << ccache.rt_power.readOp.leakage <<" W" << endl;
+		cout << indent_str_next << "Constant Cache    Gate Leakage = " << ccache.rt_power.readOp.gate_leakage << " W" << endl;
+
+		cout << indent_str_next << "Texture Cache    Peak Dynamic = " << tcache.rt_power.readOp.dynamic*clockRate << " W" << endl;
+		cout << indent_str_next << "Texture Cache    Subthreshold Leakage = " << tcache.rt_power.readOp.leakage <<" W" << endl;
+		cout << indent_str_next << "Texture Cache    Gate Leakage = " << tcache.rt_power.readOp.gate_leakage << " W" << endl;
+		
+    if (coredynp.core_ty==Inorder)
+		{
+			cout << indent_str_next << "Load/Store Queue   Peak Dynamic = " << LSQ->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+			cout << indent_str_next << "Load/Store Queue   Subthreshold Leakage = " << LSQ->rt_power.readOp.leakage  << " W" << endl;
+			cout << indent_str_next << "Load/Store Queue   Gate Leakage = " << LSQ->rt_power.readOp.gate_leakage  << " W" << endl;
+		}
+		else
+		{
+			cout << indent_str_next << "LoadQ   Peak Dynamic = " << LoadQ->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+			cout << indent_str_next << "LoadQ   Subthreshold Leakage = " << LoadQ->rt_power.readOp.leakage  << " W" << endl;
+			cout << indent_str_next << "LoadQ   Gate Leakage = " << LoadQ->rt_power.readOp.gate_leakage  << " W" << endl;
+			cout << indent_str_next << "StoreQ   Peak Dynamic = " << LSQ->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+			cout << indent_str_next << "StoreQ   Subthreshold Leakage = " << LSQ->rt_power.readOp.leakage  << " W" << endl;
+			cout << indent_str_next << "StoreQ   Gate Leakage = " << LSQ->rt_power.readOp.gate_leakage  << " W" << endl;
+		}
+	}
+
+}
+
+void MemManU::computeEnergy(bool is_tdp)
+{
+
+	if (!exist) return;
+	if (is_tdp)
+    {
+    	//init stats for Peak
+    	itlb->stats_t.readAc.access  = itlb->l_ip.num_search_ports;
+    	itlb->stats_t.readAc.miss    = 0;
+    	itlb->stats_t.readAc.hit     = itlb->stats_t.readAc.access - itlb->stats_t.readAc.miss;
+    	itlb->tdp_stats = itlb->stats_t;
+
+    	dtlb->stats_t.readAc.access  = dtlb->l_ip.num_search_ports*coredynp.LSU_duty_cycle;
+    	dtlb->stats_t.readAc.miss    = 0;
+    	dtlb->stats_t.readAc.hit     = dtlb->stats_t.readAc.access - dtlb->stats_t.readAc.miss;
+    	dtlb->tdp_stats = dtlb->stats_t;
+     }
+    else
+    {
+    	//init stats for Runtime Dynamic (RTP)
+    	itlb->stats_t.readAc.access  = XML->sys.core[ithCore].itlb.total_accesses;
+    	itlb->stats_t.readAc.miss    = XML->sys.core[ithCore].itlb.total_misses;
+    	itlb->stats_t.readAc.hit     = itlb->stats_t.readAc.access - itlb->stats_t.readAc.miss;
+    	itlb->rtp_stats = itlb->stats_t;
+
+    	dtlb->stats_t.readAc.access  = XML->sys.core[ithCore].dtlb.total_accesses;
+    	dtlb->stats_t.readAc.miss    = XML->sys.core[ithCore].dtlb.total_misses;
+    	dtlb->stats_t.readAc.hit     = dtlb->stats_t.readAc.access - dtlb->stats_t.readAc.miss;
+    	dtlb->rtp_stats = dtlb->stats_t;
+    }
+
+    itlb->power_t.reset();
+    dtlb->power_t.reset();
+	itlb->power_t.readOp.dynamic +=  itlb->stats_t.readAc.access*itlb->local_result.power.searchOp.dynamic//FA spent most power in tag, so use total access not hits
+	                      +itlb->stats_t.readAc.miss*itlb->local_result.power.writeOp.dynamic;
+	dtlb->power_t.readOp.dynamic +=  dtlb->stats_t.readAc.access*dtlb->local_result.power.searchOp.dynamic//FA spent most power in tag, so use total access not hits
+	                      +dtlb->stats_t.readAc.miss*dtlb->local_result.power.writeOp.dynamic;
+
+	if (is_tdp)
+	    {
+		itlb->power = itlb->power_t + itlb->local_result.power *pppm_lkg;
+		dtlb->power = dtlb->power_t + dtlb->local_result.power *pppm_lkg;
+		power     = power + itlb->power + dtlb->power;
+	    }
+	    else
+	    {
+			itlb->rt_power = itlb->power_t + itlb->local_result.power *pppm_lkg;
+			dtlb->rt_power = dtlb->power_t + dtlb->local_result.power *pppm_lkg;
+			rt_power     = rt_power + itlb->rt_power + dtlb->rt_power;
+	    }
+
+}
+
+void MemManU::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
+{
+	if (!exist) return;
+	string indent_str(indent, ' ');
+	string indent_str_next(indent+2, ' ');
+	bool long_channel = XML->sys.longer_channel_device;
+
+
+
+
+	if (is_tdp)
+	{
+		cout << indent_str << "Itlb:" << endl;
+		cout << indent_str_next << "Area = " << itlb->area.get_area()*1e-6<< " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << itlb->power.readOp.dynamic*clockRate << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = "
+			<< (long_channel? itlb->power.readOp.longer_channel_leakage:itlb->power.readOp.leakage) <<" W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << itlb->power.readOp.gate_leakage << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic = " << itlb->rt_power.readOp.dynamic/executionTime << " W" << endl;
+		cout <<endl;
+		cout << indent_str<< "Dtlb:" << endl;
+		cout << indent_str_next << "Area = " << dtlb->area.get_area()*1e-6  << " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << dtlb->power.readOp.dynamic*clockRate  << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = "
+			<< (long_channel? dtlb->power.readOp.longer_channel_leakage:dtlb->power.readOp.leakage)  << " W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << dtlb->power.readOp.gate_leakage  << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic = " << dtlb->rt_power.readOp.dynamic/executionTime << " W" << endl;
+		cout <<endl;
+	}
+	else
+	{
+		cout << indent_str_next << "Itlb    Peak Dynamic = " << itlb->rt_power.readOp.dynamic*clockRate << " W" << endl;
+		cout << indent_str_next << "Itlb    Subthreshold Leakage = " << itlb->rt_power.readOp.leakage <<" W" << endl;
+		cout << indent_str_next << "Itlb    Gate Leakage = " << itlb->rt_power.readOp.gate_leakage << " W" << endl;
+		cout << indent_str_next << "Dtlb   Peak Dynamic = " << dtlb->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+		cout << indent_str_next << "Dtlb   Subthreshold Leakage = " << dtlb->rt_power.readOp.leakage  << " W" << endl;
+		cout << indent_str_next << "Dtlb   Gate Leakage = " << dtlb->rt_power.readOp.gate_leakage  << " W" << endl;
+	}
+
+}
+
+void RegFU::computeEnergy(bool is_tdp)
+{
+/*
+ * Architecture RF and physical RF cannot be present at the same time.
+ * Therefore, the RF stats can only refer to either ARF or PRF;
+ * And the same stats can be used for both.
+ */
+	if (!exist) return;
+
+  executionTime=XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);//Syed
+ //RF crossbar power (Syed Gilani)
+ xbar_rfu->compute_power();
+
+
+ //Arbiter power
+ arbiter_rfu->compute_power(); 
+
+	if (is_tdp)
+    {
+        //RF power -- modified by Syed
+    	//init stats for Peak
+
+    	IRF->stats_t.readAc.access  = 4;
+    	IRF->stats_t.writeAc.access  = 4;
+    	IRF->tdp_stats = IRF->stats_t;
+
+    	IRF->stats_t.readAc.access  = 2;
+    	IRF->stats_t.writeAc.access  = 1;
+    	IRF->tdp_stats = IRF->stats_t;
+
+
+    	OPC->stats_t.readAc.access  = 32;
+    	OPC->stats_t.writeAc.access  = 32;
+    	OPC->tdp_stats = OPC->stats_t;
+
+        //Commented by Syed (GPUs have a single RF which we model by IRF)
+    	//FRF->stats_t.readAc.access  = FRF->l_ip.num_rd_ports*coredynp.FPU_duty_cycle*1.05*coredynp.num_fp_pipelines;
+    	//FRF->stats_t.writeAc.access  = FRF->l_ip.num_wr_ports*coredynp.FPU_duty_cycle*1.05*coredynp.num_fp_pipelines;
+    	//FRF->tdp_stats = FRF->stats_t;
+    	if (coredynp.regWindowing)
+    	{
+        	RFWIN->stats_t.readAc.access  = 0;//0.5*RFWIN->l_ip.num_rw_ports;
+        	RFWIN->stats_t.writeAc.access  = 0;//0.5*RFWIN->l_ip.num_rw_ports;
+        	RFWIN->tdp_stats = RFWIN->stats_t;
+    	}
+	 } /* if (is_tdp) */ 
+    else
+    {
+    	//init stats for Runtime Dynamic (RTP)
+		//in Tesla each RF operand accesses 2 banks, so multiply acceses by 2
+		// (read and write energies of reg_file are per bank)(Tesla) : Syed
+		// Also, for a SIMD width of 8 and warp size of 32 threads, 4 accesses
+		// (each accessing 2 banks) need to be performed per operand
+if (XML->sys.architecture==1){
+    	IRF->stats_t.readAc.access  = (XML->sys.core[ithCore].int_regfile_reads/32)*(4*2);///1.5; 
+    	IRF->stats_t.writeAc.access  = (XML->sys.core[ithCore].int_regfile_writes/32)*(4*2);///1.5;
+} else {
+    	IRF->stats_t.readAc.access  = (XML->sys.core[ithCore].int_regfile_reads/32)*(2*4);///1.5;//TODO: no diff on archi and phy
+    	IRF->stats_t.writeAc.access  = (XML->sys.core[ithCore].int_regfile_writes/32)*(2*4);///1.5;
+}
+    	IRF->rtp_stats = IRF->stats_t;
+
+    	OPC->stats_t.readAc.access  = (XML->sys.core[ithCore].int_regfile_reads)/*/1.5*/+XML->sys.core[ithCore].non_rf_operands;///1.5;//TODO: no diff on archi and phy
+    	OPC->stats_t.writeAc.access  = 0;
+    	OPC->rtp_stats = OPC->stats_t;
+
+      //cout<< "IRF read energy: "<<    IRF->local_result.power.readOp.dynamic<<endl;
+      //cout<< "IRF write energy: "<<    IRF->local_result.power.writeOp.dynamic<<endl;
+    	//FRF->stats_t.readAc.access  = XML->sys.core[ithCore].float_regfile_reads;
+    	//FRF->stats_t.writeAc.access  = XML->sys.core[ithCore].float_regfile_writes;
+    	//FRF->rtp_stats = FRF->stats_t;
+    	if (coredynp.regWindowing)
+    	{
+        	RFWIN->stats_t.readAc.access  = XML->sys.core[ithCore].function_calls*16;
+        	RFWIN->stats_t.writeAc.access  = XML->sys.core[ithCore].function_calls*16;
+        	RFWIN->rtp_stats = RFWIN->stats_t;
+
+        	IRF->stats_t.readAc.access  = XML->sys.core[ithCore].int_regfile_reads +
+        	     XML->sys.core[ithCore].function_calls*16;
+        	IRF->stats_t.writeAc.access  = XML->sys.core[ithCore].int_regfile_writes +
+        	     XML->sys.core[ithCore].function_calls*16;
+        	IRF->rtp_stats = IRF->stats_t;
+
+    	}
+    }
+	IRF->power_t.reset();
+	FRF->power_t.reset();
+	OPC->power_t.reset();
+	//IRF->power_t  =  IRF->power_t + IRF->local_result.power;// + xbar_rfu->power + arbiter_rfu->power;
+
+
+	
+	IRF->power_t.readOp.dynamic  =  (IRF->stats_t.readAc.access*IRF->local_result.power.readOp.dynamic
+			+IRF->stats_t.writeAc.access*IRF->local_result.power.writeOp.dynamic);
+	OPC->power_t.readOp.dynamic  =  (OPC->stats_t.readAc.access*OPC->local_result.power.readOp.dynamic);
+
+	if (coredynp.regWindowing)
+	{
+		RFWIN->power_t.reset();
+		RFWIN->power_t.readOp.dynamic   +=  (RFWIN->stats_t.readAc.access*RFWIN->local_result.power.readOp.dynamic +
+				RFWIN->stats_t.writeAc.access*RFWIN->local_result.power.writeOp.dynamic);
+	}
+
+	if (is_tdp)
+	{
+
+	  	//cout<<"pre: IRF_power_t: "<<IRF->power.readOp.dynamic<<" ("<<IRF->power.readOp.dynamic*clockRate<<") "<<" IRF_localresult: "<<
+		 //                   IRF->local_result.power.readOp.dynamic<<endl;
+		//Syed: removed the multiplication of power by hardware threads
+		//since the one IRF  is shared by all threads in GPUs
+
+		//FRF->power  =  FRF->power_t + FRF->local_result.power *coredynp.pppm_lkg_multhread;
+
+	  double pppm_lkg_banks[4];
+	  set_pppm(pppm_lkg_banks, 0,XML->sys.core[ithCore].collector_units,XML->sys.core[ithCore].collector_units );
+	  IRF->power = (IRF->power_t) + IRF->local_result.power*pppm_lkg;
+	  IRF->power.readOp.dynamic=IRF->power_t.readOp.dynamic*1;
+	  OPC->power = (OPC->power_t) + OPC->local_result.power *pppm_lkg_banks;
+	  OPC->power.readOp.dynamic=OPC->power_t.readOp.dynamic*1;
+
+	  
+	  power	    =  power + (IRF->power+OPC->power);
+
+
+		if (coredynp.regWindowing)
+		{
+			RFWIN->power = RFWIN->power_t + RFWIN->local_result.power *pppm_lkg;
+			power        = power + RFWIN->power;
+		}
+	} /* if (is_tdp) */	
+	else
+	{
+	  //Removed *coredynp.pppm_lkg_multhread since all hardware threads shared the same IRF
+		IRF->rt_power  =  IRF->power_t + IRF->local_result.power*pppm_lkg;/* *coredynp.pppm_lkg_multhread;*/
+		OPC->rt_power = OPC->power_t +  OPC->local_result.power*pppm_lkg;
+if(XML->sys.architecture==1){
+	//Each warp operand accesses the crossbar
+   xbar_rfu->rt_power.readOp.dynamic=((XML->sys.core[ithCore].int_regfile_reads/(32/**1.5*/))+(XML->sys.core[ithCore].non_rf_operands/(32/**1.5*/)))*xbar_rfu->power.readOp.dynamic;
+} else {
+	xbar_rfu->rt_power.readOp.dynamic=((XML->sys.core[ithCore].int_regfile_reads/(32/**1.5*/))+(XML->sys.core[ithCore].non_rf_operands/(32/**1.5*/)))*xbar_rfu->power.readOp.dynamic;
+}
+		arbiter_rfu->rt_power.readOp.dynamic=((XML->sys.core[ithCore].int_regfile_reads/(32/**1.5*/))+(XML->sys.core[ithCore].non_rf_operands/(32/**1.5*/)))*arbiter_rfu->power.readOp.dynamic;
+
+
+		rt_power	   =  rt_power + (IRF->power_t /*+ FRF->power_t*/+xbar_rfu->rt_power+arbiter_rfu->rt_power+OPC->power_t);
+		if (coredynp.regWindowing)
+		{
+			RFWIN->rt_power = RFWIN->power_t + RFWIN->local_result.power *pppm_lkg;
+			rt_power        = rt_power + RFWIN->rt_power;
+		}
+	}
+}
+
+
+void RegFU::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
+{
+	if (!exist) return;
+	string indent_str(indent, ' ');
+	string indent_str_next(indent+2, ' ');
+	bool long_channel = XML->sys.longer_channel_device;
+
+	if (is_tdp)
+	{	cout << indent_str << "Register file banks: " << endl;
+		cout << indent_str_next << "Area = " << IRF->area.get_area()*1e-6<< " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << IRF->power.readOp.dynamic*clockRate << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = "
+			<< (long_channel? IRF->power.readOp.longer_channel_leakage:IRF->power.readOp.leakage) <<" W" << endl;
+
+		cout << indent_str_next << "Gate Leakage = " << IRF->power.readOp.gate_leakage << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic = " << IRF->rt_power.readOp.dynamic/executionTime << " W" << endl;
+		cout <<endl;
+      cout << indent_str << "Crossbar (Integer RF):" << endl;
+		cout << indent_str_next << "Area = " << xbar_rfu->area.get_area()*1e-6<< " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << xbar_rfu->power.readOp.dynamic*clockRate << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = "
+			<< (long_channel? xbar_rfu->power.readOp.longer_channel_leakage:xbar_rfu->power.readOp.leakage) <<" W" << endl;
+
+		cout << indent_str_next << "Gate Leakage = " << xbar_rfu->power.readOp.gate_leakage << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic = " << xbar_rfu->rt_power.readOp.dynamic/executionTime << " W" << endl;
+		cout <<endl;
+      
+		cout << indent_str << "Arbiter (Integer RF):" << endl;
+		cout << indent_str_next << "Area = " << arbiter_rfu->area.get_area()*1e-6<< " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << arbiter_rfu->power.readOp.dynamic*clockRate << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = "
+			<< (long_channel? arbiter_rfu->power.readOp.longer_channel_leakage:arbiter_rfu->power.readOp.leakage) <<" W" << endl;
+
+		cout << indent_str_next << "Gate Leakage = " << arbiter_rfu->power.readOp.gate_leakage << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic = " << arbiter_rfu->rt_power.readOp.dynamic/executionTime << " W" << endl;
+		cout <<endl;
+
+		/*
+		cout << indent_str<< "Floating Point RF:" << endl;
+		cout << indent_str_next << "Area = " << FRF->area.get_area()*1e-6  << " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << FRF->power.readOp.dynamic*clockRate  << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = "
+			<< (long_channel? FRF->power.readOp.longer_channel_leakage:FRF->power.readOp.leakage)  << " W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << FRF->power.readOp.gate_leakage  << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic = " << FRF->rt_power.readOp.dynamic/executionTime << " W" << endl;
+		cout <<endl;
+		*/
+		if (coredynp.regWindowing)
+		{
+			cout << indent_str << "Register Windows:" << endl;
+			cout << indent_str_next << "Area = " << RFWIN->area.get_area() *1e-6 << " mm^2" << endl;
+			cout << indent_str_next << "Peak Dynamic = " << RFWIN->power.readOp.dynamic*clockRate  << " W" << endl;
+			cout << indent_str_next << "Subthreshold Leakage = "
+				<< (long_channel? RFWIN->power.readOp.longer_channel_leakage:RFWIN->power.readOp.leakage)  << " W" << endl;
+			cout << indent_str_next << "Gate Leakage = " << RFWIN->power.readOp.gate_leakage  << " W" << endl;
+			cout << indent_str_next << "Runtime Dynamic = " << RFWIN->rt_power.readOp.dynamic/executionTime << " W" << endl;
+			cout <<endl;
+		}
+	}
+	else
+	{
+		cout << indent_str_next << "Integer RF    Peak Dynamic = " << IRF->rt_power.readOp.dynamic*clockRate << " W" << endl;
+		cout << indent_str_next << "Integer RF    Subthreshold Leakage = " << IRF->rt_power.readOp.leakage <<" W" << endl;
+		cout << indent_str_next << "Integer RF    Gate Leakage = " << IRF->rt_power.readOp.gate_leakage << " W" << endl;
+		cout << indent_str_next << "Floating Point RF   Peak Dynamic = " << FRF->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+		cout << indent_str_next << "Floating Point RF   Subthreshold Leakage = " << FRF->rt_power.readOp.leakage  << " W" << endl;
+		cout << indent_str_next << "Floating Point RF   Gate Leakage = " << FRF->rt_power.readOp.gate_leakage  << " W" << endl;
+		if (coredynp.regWindowing)
+		{
+			cout << indent_str_next << "Register Windows   Peak Dynamic = " << RFWIN->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+			cout << indent_str_next << "Register Windows   Subthreshold Leakage = " << RFWIN->rt_power.readOp.leakage  << " W" << endl;
+			cout << indent_str_next << "Register Windows   Gate Leakage = " << RFWIN->rt_power.readOp.gate_leakage  << " W" << endl;
+		}
+	}
+}
+
+
+void EXECU::computeEnergy(bool is_tdp)
+{
+	if (!exist) return;
+	//Syed
+	double pppm_t[4]    = {1,1,1,1};
+	double pppm_freqScaling[4]    = {rf_fu_clockRate/clockRate,1,1,1};
+  executionTime=XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);//Syed
+
+
+//	rfu->power.reset();
   rfu->rt_power.reset();
-  //	scheu->power.reset();
-  scheu->rt_power.reset();
-  //	exeu->power.reset();
-  exeu->rt_power.reset();
+//	scheu->power.reset();
+	scheu->rt_power.reset();
+//	exeu->power.reset();
+	exeu->rt_power.reset();
 
-  rfu->computeEnergy(is_tdp);
-  scheu->computeEnergy(is_tdp);
-  exeu->computeEnergy(is_tdp);
-  if (coredynp.num_fpus > 0) {
+	rfu->computeEnergy(is_tdp);
+	scheu->computeEnergy(is_tdp);
+	exeu->computeEnergy(is_tdp);
+	if (coredynp.num_fpus >0)
+	{
     fp_u->rt_power.reset();
-    fp_u->computeEnergy(is_tdp);
-  }
-  if (coredynp.num_muls > 0) {
+		fp_u->computeEnergy(is_tdp);
+	}
+	if (coredynp.num_muls >0)
+	{
     mul->rt_power.reset();
-    mul->computeEnergy(is_tdp);
-  }
+		mul->computeEnergy(is_tdp);
+	}
   bypass.rt_power.reset();
 
-  if (is_tdp) {
-    set_pppm(pppm_t, 2 * coredynp.ALU_cdb_duty_cycle, 2, 2,
-             2 * coredynp.ALU_cdb_duty_cycle);  // 2 means two source operands
-                                                // needs to be passed for each
-                                                // int instruction.
-    // bypass.power = bypass.power + intTagBypass->power*pppm_t +
-    // int_bypass->power*pppm_t;
-    if (coredynp.num_muls > 0) {
-      set_pppm(pppm_t, 2 * coredynp.MUL_cdb_duty_cycle, 2, 2,
-               2 * coredynp.MUL_cdb_duty_cycle);  // 2 means two source operands
-                                                  // needs to be passed for each
-                                                  // int instruction.
-      // No conventional bypassing in GPU (Syed)
-      // bypass.power = bypass.power + intTag_mul_Bypass->power*pppm_t +
-      // int_mul_bypass->power*pppm_t;
-      power = power + mul->power * pppm_freqScaling;
-    }
+	if (is_tdp)
+	{
+		set_pppm(pppm_t, 2*coredynp.ALU_cdb_duty_cycle, 2, 2, 2*coredynp.ALU_cdb_duty_cycle);//2 means two source operands needs to be passed for each int instruction.
+		//bypass.power = bypass.power + intTagBypass->power*pppm_t + int_bypass->power*pppm_t;
+		if (coredynp.num_muls >0)
+		{
+			set_pppm(pppm_t, 2*coredynp.MUL_cdb_duty_cycle, 2, 2, 2*coredynp.MUL_cdb_duty_cycle);//2 means two source operands needs to be passed for each int instruction.
+			//No conventional bypassing in GPU (Syed)
+			//bypass.power = bypass.power + intTag_mul_Bypass->power*pppm_t + int_mul_bypass->power*pppm_t;
+			power      = power + mul->power*pppm_freqScaling;
+		}
 
-    if (coredynp.num_fpus > 0) {
-      set_pppm(pppm_t, 3 * coredynp.FPU_cdb_duty_cycle, 3, 3,
-               3 * coredynp.FPU_cdb_duty_cycle);  // 3 means three source
-                                                  // operands needs to be passed
-                                                  // for each fp instruction.
-      // No conventional bypassing in GPU (Syed)
-      // bypass.power = bypass.power + fp_bypass->power*pppm_t  +
-      // fpTagBypass->power*pppm_t ;
-      power = power + fp_u->power * pppm_freqScaling;
-    }
-    // No conventional bypassing in GPU (Syed)
+		if (coredynp.num_fpus>0)
+		{
+			set_pppm(pppm_t, 3*coredynp.FPU_cdb_duty_cycle, 3, 3, 3*coredynp.FPU_cdb_duty_cycle);//3 means three source operands needs to be passed for each fp instruction.
+			//No conventional bypassing in GPU (Syed)			
+			//bypass.power = bypass.power + fp_bypass->power*pppm_t  + fpTagBypass->power*pppm_t ;
+			power      = power + fp_u->power*pppm_freqScaling;
 
-    power = power + rfu->power * pppm_freqScaling +
-            exeu->power * pppm_freqScaling /*+ bypass.power*/ + scheu->power;
+		}
+		//No conventional bypassing in GPU (Syed)
 
-  } else {
-    set_pppm(pppm_t, XML->sys.core[ithCore].cdb_alu_accesses, 2, 2,
-             XML->sys.core[ithCore].cdb_alu_accesses);
-    // bypass.rt_power = bypass.rt_power + intTagBypass->power*pppm_t;
-    // bypass.rt_power = bypass.rt_power + int_bypass->power*pppm_t;
+		power      = power + rfu->power*pppm_freqScaling + exeu->power*pppm_freqScaling /*+ bypass.power*/ + scheu->power
+		                   ;
 
-    if (coredynp.num_muls > 0) {
-      set_pppm(pppm_t, XML->sys.core[ithCore].cdb_mul_accesses, 2, 2,
-               XML->sys.core[ithCore].cdb_mul_accesses);  // 2 means two source
-                                                          // operands needs to
-                                                          // be passed for each
-                                                          // int instruction.
-      // bypass.rt_power = bypass.rt_power + intTag_mul_Bypass->power*pppm_t +
-      // int_mul_bypass->power*pppm_t;
-      rt_power = rt_power + mul->rt_power;
-    }
 
-    if (coredynp.num_fpus > 0) {
-      set_pppm(pppm_t, XML->sys.core[ithCore].cdb_fpu_accesses, 3, 3,
-               XML->sys.core[ithCore].cdb_fpu_accesses);
-      // bypass.rt_power = bypass.rt_power + fp_bypass->power*pppm_t;
-      // bypass.rt_power = bypass.rt_power + fpTagBypass->power*pppm_t;
-      rt_power = rt_power + fp_u->rt_power;
-    }
-    // No conventional bypassing in GPU (Syed)
-    rt_power = rt_power + rfu->rt_power * pppm_freqScaling +
-               exeu->rt_power * pppm_freqScaling +
-               /*bypass.rt_power +*/ scheu->rt_power;
-  }
+	}
+	else
+	{
+		set_pppm(pppm_t, XML->sys.core[ithCore].cdb_alu_accesses, 2, 2, XML->sys.core[ithCore].cdb_alu_accesses);
+		//bypass.rt_power = bypass.rt_power + intTagBypass->power*pppm_t;
+		//bypass.rt_power = bypass.rt_power + int_bypass->power*pppm_t;
+
+		if (coredynp.num_muls >0)
+		{
+			set_pppm(pppm_t, XML->sys.core[ithCore].cdb_mul_accesses, 2, 2, XML->sys.core[ithCore].cdb_mul_accesses);//2 means two source operands needs to be passed for each int instruction.
+			//bypass.rt_power = bypass.rt_power + intTag_mul_Bypass->power*pppm_t + int_mul_bypass->power*pppm_t;
+			rt_power      = rt_power + mul->rt_power;
+		}
+
+		if (coredynp.num_fpus>0)
+		{
+			set_pppm(pppm_t, XML->sys.core[ithCore].cdb_fpu_accesses, 3, 3, XML->sys.core[ithCore].cdb_fpu_accesses);
+			//bypass.rt_power = bypass.rt_power + fp_bypass->power*pppm_t;
+			//bypass.rt_power = bypass.rt_power + fpTagBypass->power*pppm_t;
+			rt_power      = rt_power + fp_u->rt_power;
+		}
+		//No conventional bypassing in GPU (Syed)
+		rt_power      = rt_power + rfu->rt_power*pppm_freqScaling + exeu->rt_power*pppm_freqScaling + /*bypass.rt_power +*/ scheu->rt_power;
+	}
 }
 
-void EXECU::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
-  if (!exist) return;
-  string indent_str(indent, ' ');
-  string indent_str_next(indent + 2, ' ');
-  bool long_channel = XML->sys.longer_channel_device;
+void EXECU::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
+{
+	if (!exist) return;
+	string indent_str(indent, ' ');
+	string indent_str_next(indent+2, ' ');
+	bool long_channel = XML->sys.longer_channel_device;
 
-  //	cout << indent_str_next << "Results Broadcast Bus Area = " <<
-  //bypass->area.get_area() *1e-6 << " mm^2" << endl;
-  if (is_tdp) {
-    cout << indent_str << "Register Files:" << endl;
-    cout << indent_str_next << "Area = " << rfu->area.get_area() * 1e-6
-         << " mm^2" << endl;
-    cout << indent_str_next
-         << "Peak Dynamic = " << rfu->power.readOp.dynamic * rf_fu_clockRate
-         << " W" << endl;
-    // cout << "rf_fu Clock rate: "<< rf_fu_clockRate<<endl;
-    cout << indent_str_next << "Subthreshold Leakage = "
-         << (long_channel ? rfu->power.readOp.longer_channel_leakage
-                          : rfu->power.readOp.leakage)
-         << " W" << endl;
-    cout << indent_str_next
-         << "Gate Leakage = " << rfu->power.readOp.gate_leakage << " W" << endl;
-    cout << indent_str_next
-         << "Runtime Dynamic = " << rfu->rt_power.readOp.dynamic / executionTime
-         << " W" << endl;
-    cout << endl;
-    if (plevel > 3) {
-      rfu->displayEnergy(indent + 4, is_tdp);
-    }
-    cout << indent_str << "Instruction Scheduler:" << endl;
-    cout << indent_str_next << "Area = " << scheu->area.get_area() * 1e-6
-         << " mm^2" << endl;
-    cout << indent_str_next
-         << "Peak Dynamic = " << scheu->power.readOp.dynamic * clockRate << " W"
-         << endl;
-    cout << indent_str_next << "Subthreshold Leakage = "
-         << (long_channel ? scheu->power.readOp.longer_channel_leakage
-                          : scheu->power.readOp.leakage)
-         << " W" << endl;
-    cout << indent_str_next
-         << "Gate Leakage = " << scheu->power.readOp.gate_leakage << " W"
-         << endl;
-    cout << indent_str_next << "Runtime Dynamic = "
-         << scheu->rt_power.readOp.dynamic / executionTime << " W" << endl;
-    cout << endl;
-    if (plevel > 3) {
-      scheu->displayEnergy(indent + 4, is_tdp);
-    }
-    exeu->displayEnergy(indent, is_tdp);
-    if (coredynp.num_fpus > 0) {
-      fp_u->displayEnergy(indent, is_tdp);
-    }
-    if (coredynp.num_muls > 0) {
-      mul->displayEnergy(indent, is_tdp);
-    }
-    cout << indent_str << "Results Broadcast Bus:" << endl;
-    cout << indent_str_next
-         << "Area Overhead = " << bypass.area.get_area() * 1e-6 << " mm^2"
-         << endl;
-    cout << indent_str_next
-         << "Peak Dynamic = " << bypass.power.readOp.dynamic * clockRate << " W"
-         << endl;
-    cout << indent_str_next << "Subthreshold Leakage = "
-         << (long_channel ? bypass.power.readOp.longer_channel_leakage
-                          : bypass.power.readOp.leakage)
-         << " W" << endl;
-    cout << indent_str_next
-         << "Gate Leakage = " << bypass.power.readOp.gate_leakage << " W"
-         << endl;
-    cout << indent_str_next << "Runtime Dynamic = "
-         << bypass.rt_power.readOp.dynamic / executionTime << " W" << endl;
-    cout << endl;
-  } else {
-    cout << indent_str_next << "Register Files    Peak Dynamic = "
-         << rfu->rt_power.readOp.dynamic * clockRate << " W" << endl;
-    cout << indent_str_next << "Register Files    Subthreshold Leakage = "
-         << rfu->rt_power.readOp.leakage << " W" << endl;
-    cout << indent_str_next << "Register Files    Gate Leakage = "
-         << rfu->rt_power.readOp.gate_leakage << " W" << endl;
-    cout << indent_str_next << "Instruction Sheduler   Peak Dynamic = "
-         << scheu->rt_power.readOp.dynamic * clockRate << " W" << endl;
-    cout << indent_str_next << "Instruction Sheduler   Subthreshold Leakage = "
-         << scheu->rt_power.readOp.leakage << " W" << endl;
-    cout << indent_str_next << "Instruction Sheduler   Gate Leakage = "
-         << scheu->rt_power.readOp.gate_leakage << " W" << endl;
-    cout << indent_str_next << "Results Broadcast Bus   Peak Dynamic = "
-         << bypass.rt_power.readOp.dynamic * clockRate << " W" << endl;
-    cout << indent_str_next << "Results Broadcast Bus   Subthreshold Leakage = "
-         << bypass.rt_power.readOp.leakage << " W" << endl;
-    cout << indent_str_next << "Results Broadcast Bus   Gate Leakage = "
-         << bypass.rt_power.readOp.gate_leakage << " W" << endl;
-  }
+
+//	cout << indent_str_next << "Results Broadcast Bus Area = " << bypass->area.get_area() *1e-6 << " mm^2" << endl;
+	if (is_tdp)
+	{
+		cout << indent_str << "Register Files:" << endl;
+		cout << indent_str_next << "Area = " << rfu->area.get_area()*1e-6<< " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << rfu->power.readOp.dynamic*rf_fu_clockRate << " W" << endl;
+		//cout << "rf_fu Clock rate: "<< rf_fu_clockRate<<endl;
+		cout << indent_str_next << "Subthreshold Leakage = "
+			<< (long_channel? rfu->power.readOp.longer_channel_leakage:rfu->power.readOp.leakage) <<" W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << rfu->power.readOp.gate_leakage << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic = " << rfu->rt_power.readOp.dynamic/executionTime << " W" << endl;
+		cout <<endl;
+		if (plevel>3){
+			rfu->displayEnergy(indent+4,is_tdp);
+		}
+		cout << indent_str << "Instruction Scheduler:" << endl;
+		cout << indent_str_next << "Area = " << scheu->area.get_area()*1e-6  << " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << scheu->power.readOp.dynamic*clockRate  << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = "
+			<< (long_channel? scheu->power.readOp.longer_channel_leakage:scheu->power.readOp.leakage)  << " W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << scheu->power.readOp.gate_leakage  << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic = " << scheu->rt_power.readOp.dynamic/executionTime << " W" << endl;
+		cout <<endl;
+		if (plevel>3){
+			scheu->displayEnergy(indent+4,is_tdp);
+		}
+		exeu->displayEnergy(indent,is_tdp);
+		if (coredynp.num_fpus>0)
+		{
+			fp_u->displayEnergy(indent,is_tdp);
+		}
+		if (coredynp.num_muls >0)
+		{
+			mul->displayEnergy(indent,is_tdp);
+		}
+		cout << indent_str << "Results Broadcast Bus:" << endl;
+		cout << indent_str_next << "Area Overhead = " << bypass.area.get_area()*1e-6  << " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << bypass.power.readOp.dynamic*clockRate  << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = "
+			<< (long_channel? bypass.power.readOp.longer_channel_leakage:bypass.power.readOp.leakage ) << " W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << bypass.power.readOp.gate_leakage  << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic = " << bypass.rt_power.readOp.dynamic/executionTime << " W" << endl;
+		cout <<endl;
+	}
+	else
+	{
+		cout << indent_str_next << "Register Files    Peak Dynamic = " << rfu->rt_power.readOp.dynamic*clockRate << " W" << endl;
+		cout << indent_str_next << "Register Files    Subthreshold Leakage = " << rfu->rt_power.readOp.leakage <<" W" << endl;
+		cout << indent_str_next << "Register Files    Gate Leakage = " << rfu->rt_power.readOp.gate_leakage << " W" << endl;
+		cout << indent_str_next << "Instruction Sheduler   Peak Dynamic = " << scheu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+		cout << indent_str_next << "Instruction Sheduler   Subthreshold Leakage = " << scheu->rt_power.readOp.leakage  << " W" << endl;
+		cout << indent_str_next << "Instruction Sheduler   Gate Leakage = " << scheu->rt_power.readOp.gate_leakage  << " W" << endl;
+		cout << indent_str_next << "Results Broadcast Bus   Peak Dynamic = " << bypass.rt_power.readOp.dynamic*clockRate  << " W" << endl;
+		cout << indent_str_next << "Results Broadcast Bus   Subthreshold Leakage = " << bypass.rt_power.readOp.leakage  << " W" << endl;
+		cout << indent_str_next << "Results Broadcast Bus   Gate Leakage = " << bypass.rt_power.readOp.gate_leakage  << " W" << endl;
+	}
+
 }
 
-// Jingwen
-void Core::compute() {
-  // power_point_product_masks
-  double pppm_t[4] = {1, 1, 1, 1};
-  double rtp_pipeline_coe;
-  double num_units = 4.0;
-  Pipeline_energy = 0;
 
-  // Set pipeline duty cycle for this inteval
-  coredynp.pipeline_duty_cycle = XML->sys.core[ithCore].pipeline_duty_cycle;
-  rt_power.reset();
-  ifu->rt_power.reset();
-  lsu->rt_power.reset();
-  mmu->rt_power.reset();
-  exu->rt_power.reset();
 
-  ifu->computeEnergy(false);
-  lsu->computeEnergy(false);
-  mmu->computeEnergy(false);
-  exu->computeEnergy(false);
 
-  if (XML->sys.homogeneous_cores == 1) {
-    rtp_pipeline_coe = coredynp.pipeline_duty_cycle * XML->sys.total_cycles *
-                       XML->sys.number_of_cores;
-  } else {
-    rtp_pipeline_coe = coredynp.pipeline_duty_cycle * coredynp.total_cycles;
-    // Jingwen
-    if (coredynp.total_cycles != XML->sys.total_cycles) {
-      cout << "total cycle not match!" << endl;
-      exit(1);
-    }
-  }
 
-  set_pppm(pppm_t, coredynp.num_pipelines * rtp_pipeline_coe / num_units,
-           coredynp.num_pipelines / num_units,
-           coredynp.num_pipelines / num_units,
-           coredynp.num_pipelines / num_units);
 
-  if (ifu->exist) {
-    Pipeline_energy += corepipe->power.readOp.dynamic *
-                       (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
-    ifu->rt_power = ifu->rt_power + corepipe->power * pppm_t;
-    rt_power = rt_power + ifu->rt_power;
-  }
+//Jingwen
+void Core::compute()
+{
+    //power_point_product_masks
+    double pppm_t[4]    = {1,1,1,1};
+    double rtp_pipeline_coe;
+    double num_units = 4.0;
+    Pipeline_energy=0;
 
-  if (lsu->exist) {
-    Pipeline_energy += corepipe->power.readOp.dynamic *
-                       (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
-    lsu->rt_power = lsu->rt_power + corepipe->power * pppm_t;
-    rt_power = rt_power + lsu->rt_power;
-  }
-  if (exu->exist) {
-    Pipeline_energy += corepipe->power.readOp.dynamic *
-                       (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
-    exu->rt_power = exu->rt_power + corepipe->power * pppm_t;
-    rt_power = rt_power + exu->rt_power;
-  }
-  if (mmu->exist) {
-    Pipeline_energy += corepipe->power.readOp.dynamic *
-                       (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
-    mmu->rt_power = mmu->rt_power + corepipe->power * pppm_t;
-    rt_power = rt_power + mmu->rt_power;
-  }
+	 //Set pipeline duty cycle for this inteval 
+	coredynp.pipeline_duty_cycle=XML->sys.core[ithCore].pipeline_duty_cycle;
+    rt_power.reset();
+    ifu->rt_power.reset();
+    lsu->rt_power.reset();
+    mmu->rt_power.reset();
+    exu->rt_power.reset();
 
-  rt_power = rt_power + undiffCore->power;
 
-  if (XML->sys.Private_L2) {
-    l2cache->computeEnergy(false);
-    rt_power = rt_power + l2cache->rt_power;
-  }
+		ifu->computeEnergy(false);
+		lsu->computeEnergy(false);
+		mmu->computeEnergy(false);
+		exu->computeEnergy(false);
 
-  IdleCoreEnergy =
-      XML->sys.num_idle_cores * XML->sys.idle_core_power * executionTime;
 
-  rt_power.readOp.dynamic += IdleCoreEnergy;
+		if (XML->sys.homogeneous_cores==1)
+		{
+				rtp_pipeline_coe = coredynp.pipeline_duty_cycle * XML->sys.total_cycles * XML->sys.number_of_cores;
+		}
+		else
+		{
+
+			rtp_pipeline_coe = coredynp.pipeline_duty_cycle * coredynp.total_cycles;
+			//Jingwen
+			if (coredynp.total_cycles != XML->sys.total_cycles)
+			{
+				cout << "total cycle not match!" << endl;
+				exit(1);
+			}
+		}
+      
+		set_pppm(pppm_t, coredynp.num_pipelines*rtp_pipeline_coe/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units);
+
+		if (ifu->exist)
+		{
+			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
+			ifu->rt_power = ifu->rt_power + corepipe->power*pppm_t;
+			rt_power     = rt_power + ifu->rt_power ;
+		}
+    
+		if (lsu->exist)
+		{
+			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
+			lsu->rt_power = lsu->rt_power + corepipe->power*pppm_t;
+			rt_power     = rt_power  + lsu->rt_power;
+		}
+		if (exu->exist)
+		{
+			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
+			exu->rt_power = exu->rt_power + corepipe->power*pppm_t;
+			rt_power     = rt_power  + exu->rt_power;
+		}
+		if (mmu->exist)
+		{
+			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
+			mmu->rt_power = mmu->rt_power + corepipe->power*pppm_t;
+			rt_power     = rt_power +  mmu->rt_power ;
+		}
+
+		rt_power     = rt_power +  undiffCore->power;
+    
+
+		if (XML->sys.Private_L2)
+		{
+
+			l2cache->computeEnergy(false);
+			rt_power = rt_power  + l2cache->rt_power;
+		}
+		
+		IdleCoreEnergy=XML->sys.num_idle_cores * XML->sys.idle_core_power* executionTime;
+
+		rt_power.readOp.dynamic += IdleCoreEnergy;
+
 }
 
-void Core::computeEnergy(bool is_tdp) {
-  // power_point_product_masks
-  double pppm_t[4] = {1, 1, 1, 1};
-  double rtp_pipeline_coe;
-  double num_units = 4.0;
-  Pipeline_energy = 0;
 
-  if (XML->sys.homogeneous_cores == 1) {
-    rtp_pipeline_coe = coredynp.pipeline_duty_cycle * XML->sys.total_cycles *
-                       XML->sys.number_of_cores;
-  } else {
-    rtp_pipeline_coe = coredynp.pipeline_duty_cycle * coredynp.total_cycles;
-  }
 
-  if (is_tdp) {
-    ifu->computeEnergy(is_tdp);
-    lsu->computeEnergy(is_tdp);
-    mmu->computeEnergy(is_tdp);
-    exu->computeEnergy(is_tdp);
 
-    if (coredynp.core_ty == OOO) {
-      num_units = 5.0;
-      rnu->computeEnergy(is_tdp);
-      set_pppm(pppm_t, coredynp.num_pipelines / num_units,
-               coredynp.num_pipelines / num_units,
-               coredynp.num_pipelines / num_units,
-               coredynp.num_pipelines / num_units);
-      if (rnu->exist) {
-        rnu->power = rnu->power + corepipe->power * pppm_t;
-        power = power + rnu->power;
-      }
+void Core::computeEnergy(bool is_tdp)
+{
+	//power_point_product_masks
+	double pppm_t[4]    = {1,1,1,1};
+    double rtp_pipeline_coe;
+    double num_units = 4.0;
+    Pipeline_energy=0;
+
+    if (XML->sys.homogeneous_cores==1)
+    {
+       rtp_pipeline_coe = coredynp.pipeline_duty_cycle * XML->sys.total_cycles * XML->sys.number_of_cores;
     }
+    else
+    {
+       rtp_pipeline_coe = coredynp.pipeline_duty_cycle * coredynp.total_cycles;
+    }
+ 
 
-    if (ifu->exist) {
-      Pipeline_energy +=
-          corepipe->power.readOp.dynamic *
-          (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
-      set_pppm(pppm_t,
-               coredynp.num_pipelines / num_units * coredynp.IFU_duty_cycle,
-               coredynp.num_pipelines / num_units,
-               coredynp.num_pipelines / num_units,
-               coredynp.num_pipelines / num_units);
-      //			cout << "IFU = " <<
-      //ifu->power.readOp.dynamic*clockRate  << " W" << endl;
-      ifu->power = ifu->power + corepipe->power * pppm_t;
-      //			cout << "IFU = " <<
-      //ifu->power.readOp.dynamic*clockRate  << " W" << endl;
-      //			cout << "1/4 pipe = " <<
-      //corepipe->power.readOp.dynamic*clockRate/num_units  << " W" << endl;
-      power = power + ifu->power;
-      //			cout << "core = " <<
-      //power.readOp.dynamic*clockRate  << " W" << endl;
-    }
-    if (lsu->exist) {
-      Pipeline_energy +=
-          corepipe->power.readOp.dynamic *
-          (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
-      set_pppm(pppm_t,
-               coredynp.num_pipelines / num_units * coredynp.LSU_duty_cycle,
-               coredynp.num_pipelines / num_units,
-               coredynp.num_pipelines / num_units,
-               coredynp.num_pipelines / num_units);
-      lsu->power = lsu->power + corepipe->power * pppm_t;
-      //			cout << "LSU = " <<
-      //lsu->power.readOp.dynamic*clockRate  << " W" << endl;
-      power = power + lsu->power;
-      //			cout << "core = " <<
-      //power.readOp.dynamic*clockRate  << " W" << endl;
-    }
-    if (exu->exist) {
-      Pipeline_energy +=
-          corepipe->power.readOp.dynamic *
-          (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
-      set_pppm(pppm_t,
-               coredynp.num_pipelines / num_units * coredynp.ALU_duty_cycle,
-               coredynp.num_pipelines / num_units,
-               coredynp.num_pipelines / num_units,
-               coredynp.num_pipelines / num_units);
-      // cout<<"ExPowerScalingFactor:"<<coredynp.num_pipelines/num_units*coredynp.ALU_duty_cycle<<endl;
-      exu->power = exu->power + corepipe->power * pppm_t;
-      //			cout << "EXE = " <<
-      //exu->power.readOp.dynamic*clockRate  << " W" << endl;
-      power = power + exu->power;
-      //			cout << "core = " <<
-      //power.readOp.dynamic*clockRate  << " W" << endl;
-    }
-    if (mmu->exist) {
-      Pipeline_energy +=
-          corepipe->power.readOp.dynamic *
-          (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
-      set_pppm(pppm_t, coredynp.num_pipelines / num_units *
-                           (0.5 + 0.5 * coredynp.LSU_duty_cycle),
-               coredynp.num_pipelines / num_units,
-               coredynp.num_pipelines / num_units,
-               coredynp.num_pipelines / num_units);
-      mmu->power = mmu->power + corepipe->power * pppm_t;
-      //			cout << "MMU = " <<
-      //mmu->power.readOp.dynamic*clockRate  << " W" << endl;
-      power = power + mmu->power;
-      //			cout << "core = " <<
-      //power.readOp.dynamic*clockRate  << " W" << endl;
-    }
+	if (is_tdp)
+	{
+		ifu->computeEnergy(is_tdp);
+		lsu->computeEnergy(is_tdp);
+		mmu->computeEnergy(is_tdp);
+		exu->computeEnergy(is_tdp);
 
-    power = power + undiffCore->power;
+		if (coredynp.core_ty==OOO)
+		{
+			num_units = 5.0;
+			rnu->computeEnergy(is_tdp);
+			set_pppm(pppm_t, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units);
+			if (rnu->exist)
+			{
+				rnu->power = rnu->power + corepipe->power*pppm_t;
+				power     = power + rnu->power;
+			}
+		}
 
-    if (XML->sys.Private_L2) {
-      l2cache->computeEnergy(is_tdp);
-      set_pppm(pppm_t, l2cache->cachep.clockRate / clockRate, 1, 1, 1);
-      // l2cache->power = l2cache->power*pppm_t;
-      power = power + l2cache->power * pppm_t;
-    }
+		if (ifu->exist)
+		{
+			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
+			set_pppm(pppm_t, coredynp.num_pipelines/num_units*coredynp.IFU_duty_cycle, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units);
+//			cout << "IFU = " << ifu->power.readOp.dynamic*clockRate  << " W" << endl;
+			ifu->power = ifu->power + corepipe->power*pppm_t;
+//			cout << "IFU = " << ifu->power.readOp.dynamic*clockRate  << " W" << endl;
+//			cout << "1/4 pipe = " << corepipe->power.readOp.dynamic*clockRate/num_units  << " W" << endl;
+			power     = power + ifu->power;
+//			cout << "core = " << power.readOp.dynamic*clockRate  << " W" << endl;
+		}
+		if (lsu->exist)
+		{
+			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
+			set_pppm(pppm_t, coredynp.num_pipelines/num_units*coredynp.LSU_duty_cycle, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units);
+			lsu->power = lsu->power + corepipe->power*pppm_t;
+//			cout << "LSU = " << lsu->power.readOp.dynamic*clockRate  << " W" << endl;
+			power     = power + lsu->power;
+//			cout << "core = " << power.readOp.dynamic*clockRate  << " W" << endl;
+		}
+		if (exu->exist)
+		{
+			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
+			set_pppm(pppm_t, coredynp.num_pipelines/num_units*coredynp.ALU_duty_cycle, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units);
+			//cout<<"ExPowerScalingFactor:"<<coredynp.num_pipelines/num_units*coredynp.ALU_duty_cycle<<endl;
+			exu->power = exu->power + corepipe->power*pppm_t;
+//			cout << "EXE = " << exu->power.readOp.dynamic*clockRate  << " W" << endl;
+			power     = power + exu->power;
+//			cout << "core = " << power.readOp.dynamic*clockRate  << " W" << endl;
+		}
+		if (mmu->exist)
+		{
+			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
+			set_pppm(pppm_t, coredynp.num_pipelines/num_units*(0.5+0.5*coredynp.LSU_duty_cycle), coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units);
+			mmu->power = mmu->power + corepipe->power*pppm_t;
+//			cout << "MMU = " << mmu->power.readOp.dynamic*clockRate  << " W" << endl;
+			power     = power +  mmu->power;
+//			cout << "core = " << power.readOp.dynamic*clockRate  << " W" << endl;
+		}
 
-  } else {
+		power     = power +  undiffCore->power;
+
+		if (XML->sys.Private_L2)
+		{
+
+			l2cache->computeEnergy(is_tdp);
+			set_pppm(pppm_t,l2cache->cachep.clockRate/clockRate, 1,1,1);
+			//l2cache->power = l2cache->power*pppm_t;
+			power = power  + l2cache->power*pppm_t;
+		}
+
+	}
+	else
+	{
     rt_power.reset();
 
-    ifu->computeEnergy(is_tdp);
-    lsu->computeEnergy(is_tdp);
-    mmu->computeEnergy(is_tdp);
-    exu->computeEnergy(is_tdp);
-    if (coredynp.core_ty == OOO) {
-      num_units = 5.0;
-      rnu->computeEnergy(is_tdp);
-      set_pppm(pppm_t, coredynp.num_pipelines / num_units,
-               coredynp.num_pipelines / num_units,
-               coredynp.num_pipelines / num_units,
-               coredynp.num_pipelines / num_units);
-      if (rnu->exist) {
-        rnu->rt_power = rnu->rt_power + corepipe->power * pppm_t;
 
-        rt_power = rt_power + rnu->rt_power;
-      }
-    } else {
-      set_pppm(pppm_t, coredynp.num_pipelines * rtp_pipeline_coe / num_units,
-               coredynp.num_pipelines / num_units,
-               coredynp.num_pipelines / num_units,
-               coredynp.num_pipelines / num_units);
-    }
 
-    if (ifu->exist) {
-      Pipeline_energy +=
-          corepipe->power.readOp.dynamic *
-          (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
-      ifu->rt_power = ifu->rt_power + corepipe->power * pppm_t;
-      rt_power = rt_power + ifu->rt_power;
-    }
-    if (lsu->exist) {
-      Pipeline_energy +=
-          corepipe->power.readOp.dynamic *
-          (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
-      lsu->rt_power = lsu->rt_power + corepipe->power * pppm_t;
-      rt_power = rt_power + lsu->rt_power;
-    }
-    if (exu->exist) {
-      Pipeline_energy +=
-          corepipe->power.readOp.dynamic *
-          (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
-      exu->rt_power = exu->rt_power + corepipe->power * pppm_t;
-      rt_power = rt_power + exu->rt_power;
-    }
-    if (mmu->exist) {
-      Pipeline_energy +=
-          corepipe->power.readOp.dynamic *
-          (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
-      mmu->rt_power = mmu->rt_power + corepipe->power * pppm_t;
-      rt_power = rt_power + mmu->rt_power;
-    }
 
-    rt_power = rt_power + undiffCore->power;
-    //		cout << "EXE = " << exu->power.readOp.dynamic*clockRate  << " W" <<
-    //endl;
-    if (XML->sys.Private_L2) {
-      l2cache->computeEnergy(is_tdp);
-      // set_pppm(pppm_t,1/l2cache->cachep.executionTime, 1,1,1);
-      // l2cache->rt_power = l2cache->rt_power*pppm_t;
-      rt_power = rt_power + l2cache->rt_power;
-    }
-  }
+		ifu->computeEnergy(is_tdp);
+		lsu->computeEnergy(is_tdp);
+		mmu->computeEnergy(is_tdp);
+		exu->computeEnergy(is_tdp);
+		if (coredynp.core_ty==OOO)
+		{
+			num_units = 5.0;
+			rnu->computeEnergy(is_tdp);
+        	set_pppm(pppm_t, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units);
+			if (rnu->exist)
+			{
+        	rnu->rt_power = rnu->rt_power + corepipe->power*pppm_t;
+
+			rt_power      = rt_power + rnu->rt_power;
+			}
+		}
+		else
+		{
+
+		    set_pppm(pppm_t, coredynp.num_pipelines*rtp_pipeline_coe/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units);
+		}
+
+		if (ifu->exist)
+		{
+			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
+			ifu->rt_power = ifu->rt_power + corepipe->power*pppm_t;
+			rt_power     = rt_power + ifu->rt_power ;
+		}
+		if (lsu->exist)
+		{
+			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
+			lsu->rt_power = lsu->rt_power + corepipe->power*pppm_t;
+			rt_power     = rt_power  + lsu->rt_power;
+		}
+		if (exu->exist)
+		{
+			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
+			exu->rt_power = exu->rt_power + corepipe->power*pppm_t;
+			rt_power     = rt_power  + exu->rt_power;
+		}
+		if (mmu->exist)
+		{
+			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
+			mmu->rt_power = mmu->rt_power + corepipe->power*pppm_t;
+			rt_power     = rt_power +  mmu->rt_power ;
+		}
+
+		rt_power     = rt_power +  undiffCore->power;
+//		cout << "EXE = " << exu->power.readOp.dynamic*clockRate  << " W" << endl;
+		if (XML->sys.Private_L2)
+		{
+			l2cache->computeEnergy(is_tdp);
+			//set_pppm(pppm_t,1/l2cache->cachep.executionTime, 1,1,1);
+			//l2cache->rt_power = l2cache->rt_power*pppm_t;
+			rt_power = rt_power  + l2cache->rt_power;
+		}
+
+	}
+
 }
 
-void Core::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
-  string indent_str(indent, ' ');
-  string indent_str_next(indent + 2, ' ');
-  bool long_channel = XML->sys.longer_channel_device;
-  if (is_tdp) {
-    cout << "Core:" << endl;
-    cout << indent_str << "Area = " << area.get_area() * 1e-6 << " mm^2"
-         << endl;
-    cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic * clockRate
-         << " W" << endl;
-    cout << indent_str << "Subthreshold Leakage = "
-         << (long_channel ? power.readOp.longer_channel_leakage
-                          : power.readOp.leakage)
-         << " W" << endl;
-    // cout << indent_str << "Subthreshold Leakage = " <<
-    // power.readOp.longer_channel_leakage <<" W" << endl;
-    cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W"
-         << endl;
-    cout << indent_str
-         << "Runtime Dynamic = " << rt_power.readOp.dynamic / executionTime
-         << " W" << endl;
-    cout << endl;
-    if (ifu->exist) {
-      cout << indent_str << "Instruction Fetch Unit:" << endl;
-      cout << indent_str_next << "Area = " << ifu->area.get_area() * 1e-6
-           << " mm^2" << endl;
-      cout << indent_str_next
-           << "Peak Dynamic = " << ifu->power.readOp.dynamic * clockRate << " W"
-           << endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel ? ifu->power.readOp.longer_channel_leakage
-                            : ifu->power.readOp.leakage)
-           << " W" << endl;
-      // cout << indent_str_next << "Subthreshold Leakage = " <<
-      // ifu->power.readOp.longer_channel_leakage <<" W" << endl;
-      cout << indent_str_next
-           << "Gate Leakage = " << ifu->power.readOp.gate_leakage << " W"
-           << endl;
-      cout << indent_str_next << "Runtime Dynamic = "
-           << ifu->rt_power.readOp.dynamic / executionTime << " W" << endl;
-      cout << endl;
-      if (plevel > 2) {
-        ifu->displayEnergy(indent + 4, plevel, is_tdp);
-      }
-    }
-    if (coredynp.core_ty == OOO) {
-      if (rnu->exist) {
-        cout << indent_str << "Renaming Unit:" << endl;
-        cout << indent_str_next << "Area = " << rnu->area.get_area() * 1e-6
-             << " mm^2" << endl;
-        cout << indent_str_next
-             << "Peak Dynamic = " << rnu->power.readOp.dynamic * clockRate
-             << " W" << endl;
-        cout << indent_str_next << "Subthreshold Leakage = "
-             << (long_channel ? rnu->power.readOp.longer_channel_leakage
-                              : rnu->power.readOp.leakage)
-             << " W" << endl;
-        // cout << indent_str_next << "Subthreshold Leakage = " <<
-        // rnu->power.readOp.longer_channel_leakage  << " W" << endl;
-        cout << indent_str_next
-             << "Gate Leakage = " << rnu->power.readOp.gate_leakage << " W"
-             << endl;
-        cout << indent_str_next << "Runtime Dynamic = "
-             << rnu->rt_power.readOp.dynamic / executionTime << " W" << endl;
-        cout << endl;
-        if (plevel > 2) {
-          rnu->displayEnergy(indent + 4, plevel, is_tdp);
-        }
-      }
-    }
-    if (lsu->exist) {
-      cout << indent_str << "Load Store Unit:" << endl;
-      cout << indent_str_next << "Area = " << lsu->area.get_area() * 1e-6
-           << " mm^2" << endl;
-      cout << indent_str_next
-           << "Peak Dynamic = " << lsu->power.readOp.dynamic * clockRate << " W"
-           << endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel ? lsu->power.readOp.longer_channel_leakage
-                            : lsu->power.readOp.leakage)
-           << " W" << endl;
-      // cout << indent_str_next << "Subthreshold Leakage = " <<
-      // lsu->power.readOp.longer_channel_leakage  << " W" << endl;
-      cout << indent_str_next
-           << "Gate Leakage = " << lsu->power.readOp.gate_leakage << " W"
-           << endl;
-      cout << indent_str_next << "Runtime Dynamic = "
-           << lsu->rt_power.readOp.dynamic / executionTime << " W" << endl;
-      cout << endl;
-      if (plevel > 2) {
-        lsu->displayEnergy(indent + 4, plevel, is_tdp);
-      }
-    }
-    if (mmu->exist) {
-      cout << indent_str << "Memory Management Unit:" << endl;
-      cout << indent_str_next << "Area = " << mmu->area.get_area() * 1e-6
-           << " mm^2" << endl;
-      cout << indent_str_next
-           << "Peak Dynamic = " << mmu->power.readOp.dynamic * clockRate << " W"
-           << endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel ? mmu->power.readOp.longer_channel_leakage
-                            : mmu->power.readOp.leakage)
-           << " W" << endl;
-      // cout << indent_str_next << "Subthreshold Leakage = " <<
-      // mmu->power.readOp.longer_channel_leakage   << " W" << endl;
-      cout << indent_str_next
-           << "Gate Leakage = " << mmu->power.readOp.gate_leakage << " W"
-           << endl;
-      cout << indent_str_next << "Runtime Dynamic = "
-           << mmu->rt_power.readOp.dynamic / executionTime << " W" << endl;
-      cout << endl;
-      if (plevel > 2) {
-        mmu->displayEnergy(indent + 4, plevel, is_tdp);
-      }
-    }
-    if (exu->exist) {
-      cout << indent_str << "Execution Unit:" << endl;
-      cout << indent_str_next << "Area = " << exu->area.get_area() * 1e-6
-           << " mm^2" << endl;
-      cout << indent_str_next
-           << "Peak Dynamic = " << exu->power.readOp.dynamic * clockRate << " W"
-           << endl;
-      cout << indent_str_next
-           << "Peak Dynamic Energy = " << exu->power.readOp.dynamic << " W"
-           << endl;
-      cout << indent_str_next << "clock Rate = " << clockRate << " W" << endl;
+void Core::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
+{
+	string indent_str(indent, ' ');
+	string indent_str_next(indent+2, ' ');
+	bool long_channel = XML->sys.longer_channel_device;
+	if (is_tdp)
+	{
+		cout << "Core:" << endl;
+		cout << indent_str << "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
+		cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic*clockRate << " W" << endl;
+		cout << indent_str << "Subthreshold Leakage = "
+			<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
+		//cout << indent_str << "Subthreshold Leakage = " << power.readOp.longer_channel_leakage <<" W" << endl;
+		cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
+		cout << indent_str << "Runtime Dynamic = " << rt_power.readOp.dynamic/executionTime << " W" << endl;
+		cout<<endl;
+		if (ifu->exist)
+		{
+			cout << indent_str << "Instruction Fetch Unit:" << endl;
+			cout << indent_str_next << "Area = " << ifu->area.get_area()*1e-6<< " mm^2" << endl;
+			cout << indent_str_next << "Peak Dynamic = " << ifu->power.readOp.dynamic*clockRate << " W" << endl;
+			cout << indent_str_next << "Subthreshold Leakage = "
+				<< (long_channel? ifu->power.readOp.longer_channel_leakage:ifu->power.readOp.leakage) <<" W" << endl;
+			//cout << indent_str_next << "Subthreshold Leakage = " << ifu->power.readOp.longer_channel_leakage <<" W" << endl;
+			cout << indent_str_next << "Gate Leakage = " << ifu->power.readOp.gate_leakage << " W" << endl;
+			cout << indent_str_next << "Runtime Dynamic = " << ifu->rt_power.readOp.dynamic/executionTime << " W" << endl;
+			cout <<endl;
+			if (plevel >2){
+				ifu->displayEnergy(indent+4,plevel,is_tdp);
+			}
+		}
+		if (coredynp.core_ty==OOO)
+		{
+			if (rnu->exist)
+			{
+				cout << indent_str<< "Renaming Unit:" << endl;
+				cout << indent_str_next << "Area = " << rnu->area.get_area()*1e-6  << " mm^2" << endl;
+				cout << indent_str_next << "Peak Dynamic = " << rnu->power.readOp.dynamic*clockRate  << " W" << endl;
+				cout << indent_str_next << "Subthreshold Leakage = "
+					<< (long_channel? rnu->power.readOp.longer_channel_leakage:rnu->power.readOp.leakage)  << " W" << endl;
+				//cout << indent_str_next << "Subthreshold Leakage = " << rnu->power.readOp.longer_channel_leakage  << " W" << endl;
+				cout << indent_str_next << "Gate Leakage = " << rnu->power.readOp.gate_leakage  << " W" << endl;
+				cout << indent_str_next << "Runtime Dynamic = " << rnu->rt_power.readOp.dynamic/executionTime << " W" << endl;
+				cout <<endl;
+				if (plevel >2){
+					rnu->displayEnergy(indent+4,plevel,is_tdp);
+				}
+			}
 
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel ? exu->power.readOp.longer_channel_leakage
-                            : exu->power.readOp.leakage)
-           << " W" << endl;
-      // cout << indent_str_next << "Subthreshold Leakage = " <<
-      // exu->power.readOp.longer_channel_leakage << " W" << endl;
-      cout << indent_str_next
-           << "Gate Leakage = " << exu->power.readOp.gate_leakage << " W"
-           << endl;
-      cout << indent_str_next << "Runtime Dynamic = "
-           << exu->rt_power.readOp.dynamic / executionTime << " W" << endl;
-      cout << endl;
-      if (plevel > 2) {
-        exu->displayEnergy(indent + 4, plevel, is_tdp);
-      }
-    }
-    //		if (plevel >2)
-    //		{
-    //			if (undiffCore->exist)
-    //			{
-    //				cout << indent_str << "Undifferentiated Core" <<
-    //endl;
-    //				cout << indent_str_next << "Area = " <<
-    //undiffCore->area.get_area()*1e-6<< " mm^2" << endl;
-    //				cout << indent_str_next << "Peak Dynamic = " <<
-    //undiffCore->power.readOp.dynamic*clockRate << " W" << endl;
-    ////				cout << indent_str_next << "Subthreshold Leakage = " <<
-    ///undiffCore->power.readOp.leakage <<" W" << endl;
-    //				cout << indent_str_next << "Subthreshold Leakage =
-    //"
-    //								<< (long_channel?
-    //undiffCore->power.readOp.longer_channel_leakage:undiffCore->power.readOp.leakage)
-    //<< " W" << endl;
-    //				cout << indent_str_next << "Gate Leakage = " <<
-    //undiffCore->power.readOp.gate_leakage << " W" << endl;
-    //				//		cout << indent_str_next << "Runtime Dynamic = " <<
-    //undiffCore->rt_power.readOp.dynamic/executionTime << " W" << endl;
-    //				cout <<endl;
-    //			}
-    //		}
-    if (XML->sys.Private_L2) {
-      l2cache->displayEnergy(4, is_tdp);
-    }
+		}
+		if (lsu->exist)
+		{
+			cout << indent_str<< "Load Store Unit:" << endl;
+			cout << indent_str_next << "Area = " << lsu->area.get_area()*1e-6  << " mm^2" << endl;
+			cout << indent_str_next << "Peak Dynamic = " << lsu->power.readOp.dynamic*clockRate  << " W" << endl;
+			cout << indent_str_next << "Subthreshold Leakage = "
+				<< (long_channel? lsu->power.readOp.longer_channel_leakage:lsu->power.readOp.leakage ) << " W" << endl;
+			//cout << indent_str_next << "Subthreshold Leakage = " << lsu->power.readOp.longer_channel_leakage  << " W" << endl;
+			cout << indent_str_next << "Gate Leakage = " << lsu->power.readOp.gate_leakage  << " W" << endl;
+			cout << indent_str_next << "Runtime Dynamic = " << lsu->rt_power.readOp.dynamic/executionTime << " W" << endl;
+			cout <<endl;
+			if (plevel >2){
+				lsu->displayEnergy(indent+4,plevel,is_tdp);
+			}
+		}
+		if (mmu->exist)
+		{
+			cout << indent_str<< "Memory Management Unit:" << endl;
+			cout << indent_str_next << "Area = " << mmu->area.get_area() *1e-6 << " mm^2" << endl;
+			cout << indent_str_next << "Peak Dynamic = " << mmu->power.readOp.dynamic*clockRate  << " W" << endl;
+			cout << indent_str_next << "Subthreshold Leakage = "
+				<< (long_channel? mmu->power.readOp.longer_channel_leakage:mmu->power.readOp.leakage)   << " W" << endl;
+			//cout << indent_str_next << "Subthreshold Leakage = " << mmu->power.readOp.longer_channel_leakage   << " W" << endl;
+			cout << indent_str_next << "Gate Leakage = " << mmu->power.readOp.gate_leakage  << " W" << endl;
+			cout << indent_str_next << "Runtime Dynamic = " << mmu->rt_power.readOp.dynamic/executionTime << " W" << endl;
+			cout <<endl;
+			if (plevel >2){
+				mmu->displayEnergy(indent+4,plevel,is_tdp);
+			}
+		}
+		if (exu->exist)
+		{
+			cout << indent_str<< "Execution Unit:" << endl;
+			cout << indent_str_next << "Area = " << exu->area.get_area()  *1e-6<< " mm^2" << endl;
+			cout << indent_str_next << "Peak Dynamic = " << exu->power.readOp.dynamic*clockRate  << " W" << endl;
+			cout << indent_str_next << "Peak Dynamic Energy = " << exu->power.readOp.dynamic  << " W" << endl;
+			cout << indent_str_next << "clock Rate = " << clockRate  << " W" << endl;
 
-    cout << indent_str << "Idle Core: " << endl;
-    cout << indent_str_next
-         << "Runtime Dynamic = " << IdleCoreEnergy / executionTime << " W\n"
-         << endl;
+			cout << indent_str_next << "Subthreshold Leakage = "
+				<< (long_channel? exu->power.readOp.longer_channel_leakage:exu->power.readOp.leakage)   << " W" << endl;
+			//cout << indent_str_next << "Subthreshold Leakage = " << exu->power.readOp.longer_channel_leakage << " W" << endl;
+			cout << indent_str_next << "Gate Leakage = " << exu->power.readOp.gate_leakage  << " W" << endl;
+			cout << indent_str_next << "Runtime Dynamic = " << exu->rt_power.readOp.dynamic/executionTime << " W" << endl;
+			cout <<endl;
+			if (plevel >2){
+				exu->displayEnergy(indent+4,plevel,is_tdp);
+			}
+		}
+//		if (plevel >2)
+//		{
+//			if (undiffCore->exist)
+//			{
+//				cout << indent_str << "Undifferentiated Core" << endl;
+//				cout << indent_str_next << "Area = " << undiffCore->area.get_area()*1e-6<< " mm^2" << endl;
+//				cout << indent_str_next << "Peak Dynamic = " << undiffCore->power.readOp.dynamic*clockRate << " W" << endl;
+////				cout << indent_str_next << "Subthreshold Leakage = " << undiffCore->power.readOp.leakage <<" W" << endl;
+//				cout << indent_str_next << "Subthreshold Leakage = "
+//								<< (long_channel? undiffCore->power.readOp.longer_channel_leakage:undiffCore->power.readOp.leakage)   << " W" << endl;
+//				cout << indent_str_next << "Gate Leakage = " << undiffCore->power.readOp.gate_leakage << " W" << endl;
+//				//		cout << indent_str_next << "Runtime Dynamic = " << undiffCore->rt_power.readOp.dynamic/executionTime << " W" << endl;
+//				cout <<endl;
+//			}
+//		}
+		if (XML->sys.Private_L2)
+		{
 
-  } else {
-    //		cout << indent_str_next << "Instruction Fetch Unit    Peak Dynamic = "
-    //<< ifu->rt_power.readOp.dynamic*clockRate << " W" << endl;
-    //		cout << indent_str_next << "Instruction Fetch Unit    Subthreshold
-    //Leakage = " << ifu->rt_power.readOp.leakage <<" W" << endl;
-    //		cout << indent_str_next << "Instruction Fetch Unit    Gate Leakage = "
-    //<< ifu->rt_power.readOp.gate_leakage << " W" << endl;
-    //		cout << indent_str_next << "Load Store Unit   Peak Dynamic = " <<
-    //lsu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Load Store Unit   Subthreshold Leakage = "
-    //<< lsu->rt_power.readOp.leakage  << " W" << endl;
-    //		cout << indent_str_next << "Load Store Unit   Gate Leakage = " <<
-    //lsu->rt_power.readOp.gate_leakage  << " W" << endl;
-    //		cout << indent_str_next << "Memory Management Unit   Peak Dynamic = "
-    //<< mmu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Memory Management Unit   Subthreshold
-    //Leakage = " << mmu->rt_power.readOp.leakage  << " W" << endl;
-    //		cout << indent_str_next << "Memory Management Unit   Gate Leakage = "
-    //<< mmu->rt_power.readOp.gate_leakage  << " W" << endl;
-    //		cout << indent_str_next << "Execution Unit   Peak Dynamic = " <<
-    //exu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Execution Unit   Subthreshold Leakage = "
-    //<< exu->rt_power.readOp.leakage  << " W" << endl;
-    //		cout << indent_str_next << "Execution Unit   Gate Leakage = " <<
-    //exu->rt_power.readOp.gate_leakage  << " W" << endl;
-  }
+			l2cache->displayEnergy(4,is_tdp);
+		}
+
+		cout << indent_str<< "Idle Core: " << endl;
+			cout << indent_str_next << "Runtime Dynamic = " << IdleCoreEnergy/executionTime << " W\n" << endl;
+
+	}
+	else
+	{
+//		cout << indent_str_next << "Instruction Fetch Unit    Peak Dynamic = " << ifu->rt_power.readOp.dynamic*clockRate << " W" << endl;
+//		cout << indent_str_next << "Instruction Fetch Unit    Subthreshold Leakage = " << ifu->rt_power.readOp.leakage <<" W" << endl;
+//		cout << indent_str_next << "Instruction Fetch Unit    Gate Leakage = " << ifu->rt_power.readOp.gate_leakage << " W" << endl;
+//		cout << indent_str_next << "Load Store Unit   Peak Dynamic = " << lsu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+//		cout << indent_str_next << "Load Store Unit   Subthreshold Leakage = " << lsu->rt_power.readOp.leakage  << " W" << endl;
+//		cout << indent_str_next << "Load Store Unit   Gate Leakage = " << lsu->rt_power.readOp.gate_leakage  << " W" << endl;
+//		cout << indent_str_next << "Memory Management Unit   Peak Dynamic = " << mmu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+//		cout << indent_str_next << "Memory Management Unit   Subthreshold Leakage = " << mmu->rt_power.readOp.leakage  << " W" << endl;
+//		cout << indent_str_next << "Memory Management Unit   Gate Leakage = " << mmu->rt_power.readOp.gate_leakage  << " W" << endl;
+//		cout << indent_str_next << "Execution Unit   Peak Dynamic = " << exu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+//		cout << indent_str_next << "Execution Unit   Subthreshold Leakage = " << exu->rt_power.readOp.leakage  << " W" << endl;
+//		cout << indent_str_next << "Execution Unit   Gate Leakage = " << exu->rt_power.readOp.gate_leakage  << " W" << endl;
+	}
 }
-InstFetchU::~InstFetchU() {
-  if (!exist) return;
-  if (IB) {
-    delete IB;
-    IB = 0;
-  }
-  if (ID_inst) {
-    delete ID_inst;
-    ID_inst = 0;
-  }
-  if (ID_operand) {
-    delete ID_operand;
-    ID_operand = 0;
-  }
-  if (ID_misc) {
-    delete ID_misc;
-    ID_misc = 0;
-  }
-  if (coredynp.predictionW > 0) {
-    if (BTB) {
-      delete BTB;
-      BTB = 0;
-    }
-    if (BPT) {
-      delete BPT;
-      BPT = 0;
-    }
-  }
+InstFetchU ::~InstFetchU(){
+
+	if (!exist) return;
+	if(IB) 	                   {delete IB; IB = 0;}
+	if(ID_inst) 	           {delete ID_inst; ID_inst = 0;}
+	if(ID_operand) 	           {delete ID_operand; ID_operand = 0;}
+	if(ID_misc) 	           {delete ID_misc; ID_misc = 0;}
+	if (coredynp.predictionW>0)
+	{
+		if(BTB) 	               {delete BTB; BTB = 0;}
+		if(BPT) 	               {delete BPT; BPT = 0;}
+	}
 }
 
-BranchPredictor::~BranchPredictor() {
-  if (!exist) return;
-  if (globalBPT) {
-    delete globalBPT;
-    globalBPT = 0;
-  }
-  if (localBPT) {
-    delete localBPT;
-    localBPT = 0;
-  }
-  if (L1_localBPT) {
-    delete L1_localBPT;
-    L1_localBPT = 0;
-  }
-  if (L2_localBPT) {
-    delete L2_localBPT;
-    L2_localBPT = 0;
-  }
-  if (chooser) {
-    delete chooser;
-    chooser = 0;
-  }
-  if (RAS) {
-    delete RAS;
-    RAS = 0;
-  }
+BranchPredictor ::~BranchPredictor(){
+
+	if (!exist) return;
+	if(globalBPT) 	           {delete globalBPT; globalBPT = 0;}
+	if(localBPT) 	           {delete localBPT; localBPT = 0;}
+    if(L1_localBPT) 	       {delete L1_localBPT; L1_localBPT = 0;}
+    if(L2_localBPT) 	       {delete L2_localBPT; L2_localBPT = 0;}
+    if(chooser) 	           {delete chooser; chooser = 0;}
+    if(RAS) 	               {delete RAS; RAS = 0;}
+	}
+
+RENAMINGU ::~RENAMINGU(){
+
+	if (!exist) return;
+	if(iFRAT ) 	               {delete iFRAT; iFRAT = 0;}
+    if(fFRAT ) 	               {delete fFRAT; fFRAT =0;}
+    if(iRRAT)                  {delete iRRAT; iRRAT = 0;}
+    if(iFRAT)                  {delete iFRAT; iFRAT = 0;}
+    if(ifreeL)                 {delete ifreeL;ifreeL= 0;}
+    if(ffreeL)                 {delete ffreeL;ffreeL= 0;}
+    if(idcl)                   {delete idcl;  idcl = 0;}
+    if(fdcl)                   {delete fdcl;  fdcl = 0;}
+    if(RAHT)                   {delete RAHT;  RAHT = 0;}
+	}
+
+LoadStoreU ::~LoadStoreU(){
+
+	if (!exist) return;
+	if(LSQ) 	               {delete LSQ; LSQ = 0;}
+	}
+
+MemManU ::~MemManU(){
+
+	if (!exist) return;
+	if(itlb) 	               {delete itlb; itlb = 0;}
+    if(dtlb) 	               {delete dtlb; dtlb = 0;}
+	}
+
+RegFU ::~RegFU(){
+
+	if (!exist) return;
+	if(IRF) 	               {delete IRF; IRF = 0;}
+    if(FRF) 	               {delete FRF; FRF = 0;}
+    if(RFWIN) 	               {delete RFWIN; RFWIN = 0;}
+	}
+
+SchedulerU ::~SchedulerU(){
+
+	if (!exist) return;
+	if(int_inst_window) 	   {delete int_inst_window; int_inst_window = 0;}
+	if(fp_inst_window) 	       {delete int_inst_window; int_inst_window = 0;}
+	if(ROB) 	               {delete ROB; ROB = 0;}
+    if(instruction_selection)  {delete instruction_selection;instruction_selection = 0;}
+	}
+
+EXECU ::~EXECU(){
+
+	if (!exist) return;
+	if(int_bypass) 	           {delete int_bypass; int_bypass = 0;}
+    if(intTagBypass) 	       {delete intTagBypass; intTagBypass =0;}
+    if(int_mul_bypass) 	       {delete int_mul_bypass; int_mul_bypass = 0;}
+    if(intTag_mul_Bypass) 	   {delete intTag_mul_Bypass; intTag_mul_Bypass =0;}
+    if(fp_bypass) 	           {delete fp_bypass;fp_bypass = 0;}
+    if(fpTagBypass) 	       {delete fpTagBypass;fpTagBypass = 0;}
+    if(fp_u)                   {delete fp_u;fp_u = 0;}
+    if(exeu)                   {delete exeu;exeu = 0;}
+    if(mul)                    {delete mul;mul = 0;}
+    if(rfu)                    {delete rfu;rfu = 0;}
+	if(scheu) 	               {delete scheu; scheu = 0;}
+	}
+
+Core ::~Core(){
+
+	if(ifu) 	               {delete ifu; ifu = 0;}
+	if(lsu) 	               {delete lsu; lsu = 0;}
+	if(rnu) 	               {delete rnu; rnu = 0;}
+	if(mmu) 	               {delete mmu; mmu = 0;}
+	if(exu) 	               {delete exu; exu = 0;}
+    if(corepipe) 	           {delete corepipe; corepipe = 0;}
+    if(undiffCore)             {delete undiffCore;undiffCore = 0;}
+    if(l2cache)                {delete l2cache;l2cache = 0;}
+	}
+
+void Core::set_core_param()
+{
+	coredynp.opt_local = XML->sys.core[ithCore].opt_local;
+	coredynp.x86 = XML->sys.core[ithCore].x86;
+	coredynp.Embedded = XML->sys.Embedded;
+	coredynp.core_ty   = (enum Core_type)XML->sys.core[ithCore].machine_type;
+	coredynp.rm_ty     = (enum Renaming_type)XML->sys.core[ithCore].rename_scheme;
+    coredynp.fetchW    = XML->sys.core[ithCore].fetch_width;
+    coredynp.decodeW   = XML->sys.core[ithCore].decode_width;
+    coredynp.issueW    = XML->sys.core[ithCore].issue_width;
+    coredynp.peak_issueW   = XML->sys.core[ithCore].peak_issue_width;
+    coredynp.commitW       = XML->sys.core[ithCore].commit_width;
+    coredynp.peak_commitW  = XML->sys.core[ithCore].peak_issue_width;
+    coredynp.predictionW   = XML->sys.core[ithCore].prediction_width;
+    coredynp.fp_issueW     = XML->sys.core[ithCore].fp_issue_width;
+    coredynp.fp_decodeW    = XML->sys.core[ithCore].fp_issue_width;
+    coredynp.num_alus      = XML->sys.core[ithCore].ALU_per_core;
+    coredynp.num_fpus      = XML->sys.core[ithCore].FPU_per_core;
+    coredynp.num_muls      = XML->sys.core[ithCore].MUL_per_core;
+
+
+    coredynp.num_hthreads	     = XML->sys.core[ithCore].number_hardware_threads;
+    coredynp.multithreaded       = coredynp.num_hthreads>1? true:false;
+    coredynp.instruction_length  = XML->sys.core[ithCore].instruction_length;
+    coredynp.pc_width            = XML->sys.virtual_address_width;
+
+   	coredynp.opcode_length       = XML->sys.core[ithCore].opcode_width;
+    coredynp.micro_opcode_length = XML->sys.core[ithCore].micro_opcode_width;
+    coredynp.num_pipelines       = XML->sys.core[ithCore].pipelines_per_core[0];
+    coredynp.pipeline_stages     = XML->sys.core[ithCore].pipeline_depth[0];
+    coredynp.num_fp_pipelines    = XML->sys.core[ithCore].pipelines_per_core[1];
+    coredynp.fp_pipeline_stages  = XML->sys.core[ithCore].pipeline_depth[1];
+    coredynp.int_data_width      = int(ceil(XML->sys.machine_bits/32.0))*32;
+    coredynp.fp_data_width       = coredynp.int_data_width;
+    coredynp.v_address_width     = XML->sys.virtual_address_width;
+    coredynp.p_address_width     = XML->sys.physical_address_width;
+
+	coredynp.scheu_ty         = (enum Scheduler_type)XML->sys.core[ithCore].instruction_window_scheme;
+	coredynp.arch_ireg_width  =  int(ceil(log2(XML->sys.core[ithCore].archi_Regs_IRF_size)));
+	coredynp.arch_freg_width  =  int(ceil(log2(XML->sys.core[ithCore].archi_Regs_FRF_size)));
+	coredynp.num_IRF_entry    = XML->sys.core[ithCore].archi_Regs_IRF_size;
+	coredynp.num_FRF_entry    = XML->sys.core[ithCore].archi_Regs_FRF_size;
+	coredynp.pipeline_duty_cycle = XML->sys.core[ithCore].pipeline_duty_cycle;
+	coredynp.total_cycles        = XML->sys.core[ithCore].total_cycles;
+	coredynp.busy_cycles         = XML->sys.core[ithCore].busy_cycles;
+	coredynp.idle_cycles         = XML->sys.core[ithCore].idle_cycles;
+
+	//Max power duty cycle for peak power estimation
+//	if (coredynp.core_ty==OOO)
+//	{
+//		coredynp.IFU_duty_cycle = 1;
+//		coredynp.LSU_duty_cycle = 1;
+//		coredynp.MemManU_I_duty_cycle =1;
+//		coredynp.MemManU_D_duty_cycle =1;
+//		coredynp.ALU_duty_cycle =1;
+//		coredynp.MUL_duty_cycle =1;
+//		coredynp.FPU_duty_cycle =1;
+//		coredynp.ALU_cdb_duty_cycle =1;
+//		coredynp.MUL_cdb_duty_cycle =1;
+//		coredynp.FPU_cdb_duty_cycle =1;
+//	}
+//	else
+//	{
+		coredynp.IFU_duty_cycle = XML->sys.core[ithCore].IFU_duty_cycle;
+		coredynp.BR_duty_cycle = XML->sys.core[ithCore].BR_duty_cycle;
+		coredynp.LSU_duty_cycle = XML->sys.core[ithCore].LSU_duty_cycle;
+		coredynp.MemManU_I_duty_cycle = XML->sys.core[ithCore].MemManU_I_duty_cycle;
+		coredynp.MemManU_D_duty_cycle = XML->sys.core[ithCore].MemManU_D_duty_cycle;
+		coredynp.ALU_duty_cycle = XML->sys.core[ithCore].ALU_duty_cycle;
+		coredynp.MUL_duty_cycle = XML->sys.core[ithCore].MUL_duty_cycle;
+		coredynp.FPU_duty_cycle = XML->sys.core[ithCore].FPU_duty_cycle;
+		coredynp.ALU_cdb_duty_cycle = XML->sys.core[ithCore].ALU_cdb_duty_cycle;
+		coredynp.MUL_cdb_duty_cycle = XML->sys.core[ithCore].MUL_cdb_duty_cycle;
+		coredynp.FPU_cdb_duty_cycle = XML->sys.core[ithCore].FPU_cdb_duty_cycle;
+//	}
+
+
+	if (!((coredynp.core_ty==OOO)||(coredynp.core_ty==Inorder)))
+	{
+		cout<<"Invalid Core Type"<<endl;
+		exit(0);
+	}
+//	if (coredynp.core_ty==OOO)
+//	{
+//		cout<<"OOO processor models are being updated and will be available in next release"<<endl;
+//		exit(0);
+//	}
+	if (!((coredynp.scheu_ty==PhysicalRegFile)||(coredynp.scheu_ty==ReservationStation)))
+	{
+		cout<<"Invalid OOO Scheduler Type"<<endl;
+		exit(0);
+	}
+
+	if (!((coredynp.rm_ty ==RAMbased)||(coredynp.rm_ty ==CAMbased)))
+	{
+		cout<<"Invalid OOO Renaming Type"<<endl;
+		exit(0);
+	}
+
+if (coredynp.core_ty==OOO)
+{
+	if (coredynp.scheu_ty==PhysicalRegFile)
+	{
+	  coredynp.phy_ireg_width  =  int(ceil(log2(XML->sys.core[ithCore].phy_Regs_IRF_size)));
+	  coredynp.phy_freg_width  =  int(ceil(log2(XML->sys.core[ithCore].phy_Regs_FRF_size)));
+	  coredynp.num_ifreelist_entries = coredynp.num_IRF_entry  = XML->sys.core[ithCore].phy_Regs_IRF_size;
+	  coredynp.num_ffreelist_entries = coredynp.num_FRF_entry  = XML->sys.core[ithCore].phy_Regs_FRF_size;
+	}
+	else if (coredynp.scheu_ty==ReservationStation)
+	{//ROB serves as Phy RF in RS based OOO
+      coredynp.phy_ireg_width  =  int(ceil(log2(XML->sys.core[ithCore].ROB_size)));
+	  coredynp.phy_freg_width  =  int(ceil(log2(XML->sys.core[ithCore].ROB_size)));
+	  coredynp.num_ifreelist_entries = XML->sys.core[ithCore].ROB_size;
+	  coredynp.num_ffreelist_entries = XML->sys.core[ithCore].ROB_size;
+
+	}
+
 }
-
-RENAMINGU::~RENAMINGU() {
-  if (!exist) return;
-  if (iFRAT) {
-    delete iFRAT;
-    iFRAT = 0;
-  }
-  if (fFRAT) {
-    delete fFRAT;
-    fFRAT = 0;
-  }
-  if (iRRAT) {
-    delete iRRAT;
-    iRRAT = 0;
-  }
-  if (iFRAT) {
-    delete iFRAT;
-    iFRAT = 0;
-  }
-  if (ifreeL) {
-    delete ifreeL;
-    ifreeL = 0;
-  }
-  if (ffreeL) {
-    delete ffreeL;
-    ffreeL = 0;
-  }
-  if (idcl) {
-    delete idcl;
-    idcl = 0;
-  }
-  if (fdcl) {
-    delete fdcl;
-    fdcl = 0;
-  }
-  if (RAHT) {
-    delete RAHT;
-    RAHT = 0;
-  }
-}
-
-LoadStoreU::~LoadStoreU() {
-  if (!exist) return;
-  if (LSQ) {
-    delete LSQ;
-    LSQ = 0;
-  }
-}
-
-MemManU::~MemManU() {
-  if (!exist) return;
-  if (itlb) {
-    delete itlb;
-    itlb = 0;
-  }
-  if (dtlb) {
-    delete dtlb;
-    dtlb = 0;
-  }
-}
-
-RegFU::~RegFU() {
-  if (!exist) return;
-  if (IRF) {
-    delete IRF;
-    IRF = 0;
-  }
-  if (FRF) {
-    delete FRF;
-    FRF = 0;
-  }
-  if (RFWIN) {
-    delete RFWIN;
-    RFWIN = 0;
-  }
-}
-
-SchedulerU::~SchedulerU() {
-  if (!exist) return;
-  if (int_inst_window) {
-    delete int_inst_window;
-    int_inst_window = 0;
-  }
-  if (fp_inst_window) {
-    delete int_inst_window;
-    int_inst_window = 0;
-  }
-  if (ROB) {
-    delete ROB;
-    ROB = 0;
-  }
-  if (instruction_selection) {
-    delete instruction_selection;
-    instruction_selection = 0;
-  }
-}
-
-EXECU::~EXECU() {
-  if (!exist) return;
-  if (int_bypass) {
-    delete int_bypass;
-    int_bypass = 0;
-  }
-  if (intTagBypass) {
-    delete intTagBypass;
-    intTagBypass = 0;
-  }
-  if (int_mul_bypass) {
-    delete int_mul_bypass;
-    int_mul_bypass = 0;
-  }
-  if (intTag_mul_Bypass) {
-    delete intTag_mul_Bypass;
-    intTag_mul_Bypass = 0;
-  }
-  if (fp_bypass) {
-    delete fp_bypass;
-    fp_bypass = 0;
-  }
-  if (fpTagBypass) {
-    delete fpTagBypass;
-    fpTagBypass = 0;
-  }
-  if (fp_u) {
-    delete fp_u;
-    fp_u = 0;
-  }
-  if (exeu) {
-    delete exeu;
-    exeu = 0;
-  }
-  if (mul) {
-    delete mul;
-    mul = 0;
-  }
-  if (rfu) {
-    delete rfu;
-    rfu = 0;
-  }
-  if (scheu) {
-    delete scheu;
-    scheu = 0;
-  }
-}
-
-Core::~Core() {
-  if (ifu) {
-    delete ifu;
-    ifu = 0;
-  }
-  if (lsu) {
-    delete lsu;
-    lsu = 0;
-  }
-  if (rnu) {
-    delete rnu;
-    rnu = 0;
-  }
-  if (mmu) {
-    delete mmu;
-    mmu = 0;
-  }
-  if (exu) {
-    delete exu;
-    exu = 0;
-  }
-  if (corepipe) {
-    delete corepipe;
-    corepipe = 0;
-  }
-  if (undiffCore) {
-    delete undiffCore;
-    undiffCore = 0;
-  }
-  if (l2cache) {
-    delete l2cache;
-    l2cache = 0;
-  }
-}
-
-void Core::set_core_param() {
-  coredynp.opt_local = XML->sys.core[ithCore].opt_local;
-  coredynp.x86 = XML->sys.core[ithCore].x86;
-  coredynp.Embedded = XML->sys.Embedded;
-  coredynp.core_ty = (enum Core_type)XML->sys.core[ithCore].machine_type;
-  coredynp.rm_ty = (enum Renaming_type)XML->sys.core[ithCore].rename_scheme;
-  coredynp.fetchW = XML->sys.core[ithCore].fetch_width;
-  coredynp.decodeW = XML->sys.core[ithCore].decode_width;
-  coredynp.issueW = XML->sys.core[ithCore].issue_width;
-  coredynp.peak_issueW = XML->sys.core[ithCore].peak_issue_width;
-  coredynp.commitW = XML->sys.core[ithCore].commit_width;
-  coredynp.peak_commitW = XML->sys.core[ithCore].peak_issue_width;
-  coredynp.predictionW = XML->sys.core[ithCore].prediction_width;
-  coredynp.fp_issueW = XML->sys.core[ithCore].fp_issue_width;
-  coredynp.fp_decodeW = XML->sys.core[ithCore].fp_issue_width;
-  coredynp.num_alus = XML->sys.core[ithCore].ALU_per_core;
-  coredynp.num_fpus = XML->sys.core[ithCore].FPU_per_core;
-  coredynp.num_muls = XML->sys.core[ithCore].MUL_per_core;
-
-  coredynp.num_hthreads = XML->sys.core[ithCore].number_hardware_threads;
-  coredynp.multithreaded = coredynp.num_hthreads > 1 ? true : false;
-  coredynp.instruction_length = XML->sys.core[ithCore].instruction_length;
-  coredynp.pc_width = XML->sys.virtual_address_width;
-
-  coredynp.opcode_length = XML->sys.core[ithCore].opcode_width;
-  coredynp.micro_opcode_length = XML->sys.core[ithCore].micro_opcode_width;
-  coredynp.num_pipelines = XML->sys.core[ithCore].pipelines_per_core[0];
-  coredynp.pipeline_stages = XML->sys.core[ithCore].pipeline_depth[0];
-  coredynp.num_fp_pipelines = XML->sys.core[ithCore].pipelines_per_core[1];
-  coredynp.fp_pipeline_stages = XML->sys.core[ithCore].pipeline_depth[1];
-  coredynp.int_data_width = int(ceil(XML->sys.machine_bits / 32.0)) * 32;
-  coredynp.fp_data_width = coredynp.int_data_width;
-  coredynp.v_address_width = XML->sys.virtual_address_width;
-  coredynp.p_address_width = XML->sys.physical_address_width;
-
-  coredynp.scheu_ty =
-      (enum Scheduler_type)XML->sys.core[ithCore].instruction_window_scheme;
-  coredynp.arch_ireg_width =
-      int(ceil(log2(XML->sys.core[ithCore].archi_Regs_IRF_size)));
-  coredynp.arch_freg_width =
-      int(ceil(log2(XML->sys.core[ithCore].archi_Regs_FRF_size)));
-  coredynp.num_IRF_entry = XML->sys.core[ithCore].archi_Regs_IRF_size;
-  coredynp.num_FRF_entry = XML->sys.core[ithCore].archi_Regs_FRF_size;
-  coredynp.pipeline_duty_cycle = XML->sys.core[ithCore].pipeline_duty_cycle;
-  coredynp.total_cycles = XML->sys.core[ithCore].total_cycles;
-  coredynp.busy_cycles = XML->sys.core[ithCore].busy_cycles;
-  coredynp.idle_cycles = XML->sys.core[ithCore].idle_cycles;
-
-  // Max power duty cycle for peak power estimation
-  //	if (coredynp.core_ty==OOO)
-  //	{
-  //		coredynp.IFU_duty_cycle = 1;
-  //		coredynp.LSU_duty_cycle = 1;
-  //		coredynp.MemManU_I_duty_cycle =1;
-  //		coredynp.MemManU_D_duty_cycle =1;
-  //		coredynp.ALU_duty_cycle =1;
-  //		coredynp.MUL_duty_cycle =1;
-  //		coredynp.FPU_duty_cycle =1;
-  //		coredynp.ALU_cdb_duty_cycle =1;
-  //		coredynp.MUL_cdb_duty_cycle =1;
-  //		coredynp.FPU_cdb_duty_cycle =1;
-  //	}
-  //	else
-  //	{
-  coredynp.IFU_duty_cycle = XML->sys.core[ithCore].IFU_duty_cycle;
-  coredynp.BR_duty_cycle = XML->sys.core[ithCore].BR_duty_cycle;
-  coredynp.LSU_duty_cycle = XML->sys.core[ithCore].LSU_duty_cycle;
-  coredynp.MemManU_I_duty_cycle = XML->sys.core[ithCore].MemManU_I_duty_cycle;
-  coredynp.MemManU_D_duty_cycle = XML->sys.core[ithCore].MemManU_D_duty_cycle;
-  coredynp.ALU_duty_cycle = XML->sys.core[ithCore].ALU_duty_cycle;
-  coredynp.MUL_duty_cycle = XML->sys.core[ithCore].MUL_duty_cycle;
-  coredynp.FPU_duty_cycle = XML->sys.core[ithCore].FPU_duty_cycle;
-  coredynp.ALU_cdb_duty_cycle = XML->sys.core[ithCore].ALU_cdb_duty_cycle;
-  coredynp.MUL_cdb_duty_cycle = XML->sys.core[ithCore].MUL_cdb_duty_cycle;
-  coredynp.FPU_cdb_duty_cycle = XML->sys.core[ithCore].FPU_cdb_duty_cycle;
-  //	}
-
-  if (!((coredynp.core_ty == OOO) || (coredynp.core_ty == Inorder))) {
-    cout << "Invalid Core Type" << endl;
-    exit(0);
-  }
-  //	if (coredynp.core_ty==OOO)
-  //	{
-  //		cout<<"OOO processor models are being updated and will be available
-  //in next release"<<endl;
-  //		exit(0);
-  //	}
-  if (!((coredynp.scheu_ty == PhysicalRegFile) ||
-        (coredynp.scheu_ty == ReservationStation))) {
-    cout << "Invalid OOO Scheduler Type" << endl;
-    exit(0);
-  }
-
-  if (!((coredynp.rm_ty == RAMbased) || (coredynp.rm_ty == CAMbased))) {
-    cout << "Invalid OOO Renaming Type" << endl;
-    exit(0);
-  }
-
-  if (coredynp.core_ty == OOO) {
-    if (coredynp.scheu_ty == PhysicalRegFile) {
-      coredynp.phy_ireg_width =
-          int(ceil(log2(XML->sys.core[ithCore].phy_Regs_IRF_size)));
-      coredynp.phy_freg_width =
-          int(ceil(log2(XML->sys.core[ithCore].phy_Regs_FRF_size)));
-      coredynp.num_ifreelist_entries = coredynp.num_IRF_entry =
-          XML->sys.core[ithCore].phy_Regs_IRF_size;
-      coredynp.num_ffreelist_entries = coredynp.num_FRF_entry =
-          XML->sys.core[ithCore].phy_Regs_FRF_size;
-    } else if (coredynp.scheu_ty ==
-               ReservationStation) {  // ROB serves as Phy RF in RS based OOO
-      coredynp.phy_ireg_width =
-          int(ceil(log2(XML->sys.core[ithCore].ROB_size)));
-      coredynp.phy_freg_width =
-          int(ceil(log2(XML->sys.core[ithCore].ROB_size)));
-      coredynp.num_ifreelist_entries = XML->sys.core[ithCore].ROB_size;
-      coredynp.num_ffreelist_entries = XML->sys.core[ithCore].ROB_size;
-    }
-  }
-  coredynp.globalCheckpoint = 32;  // best check pointing entries for a 4~8
-                                   // issue OOO should be 16~48;See TR for
-                                   // reference.
-  coredynp.perThreadState = 8;
-  coredynp.instruction_length = 32;
-  coredynp.clockRate = XML->sys.core[ithCore].clock_rate;
-  coredynp.clockRate *= 1e6;
-  coredynp.regWindowing = (XML->sys.core[ithCore].register_windows_size > 0 &&
-                           coredynp.core_ty == Inorder)
-                              ? true
-                              : false;
-  coredynp.executionTime = XML->sys.total_cycles / coredynp.clockRate;
-  set_pppm(coredynp.pppm_lkg_multhread, 0, coredynp.num_hthreads,
-           coredynp.num_hthreads, 0);
+	coredynp.globalCheckpoint   =  32;//best check pointing entries for a 4~8 issue OOO should be 16~48;See TR for reference.
+	coredynp.perThreadState     =  8;
+	coredynp.instruction_length = 32;
+	coredynp.clockRate          =  XML->sys.core[ithCore].clock_rate;
+	coredynp.clockRate          *= 1e6;
+	coredynp.regWindowing= (XML->sys.core[ithCore].register_windows_size>0&&coredynp.core_ty==Inorder)?true:false;
+	coredynp.executionTime = XML->sys.total_cycles/coredynp.clockRate;
+	set_pppm(coredynp.pppm_lkg_multhread, 0, coredynp.num_hthreads, coredynp.num_hthreads, 0);
 }

--- a/src/gpuwattch/core.cc
+++ b/src/gpuwattch/core.cc
@@ -2401,9 +2401,9 @@ RENAMINGU::RENAMINGU(ParseXML* XML_interface, int ithCore_,
         // out_w = data; 			interface_ip.is_cache
         //= false; 			interface_ip.pure_cam            =
         // false; 			interface_ip.pure_ram            = true;
-        // interface_ip.line_sz = data; 			interface_ip.cache_sz
-        // = data*coredynp.globalCheckpoint; interface_ip.assoc = 1;
-        // interface_ip.nbanks              = 1;
+        // interface_ip.line_sz = data;
+        // interface_ip.cache_sz = data*coredynp.globalCheckpoint;
+        // interface_ip.assoc = 1; interface_ip.nbanks              = 1;
         // interface_ip.out_w =
         // out_w*8; 			interface_ip.access_mode         = 0;
         // interface_ip.throughput = 1.0/clockRate;
@@ -2411,8 +2411,8 @@ RENAMINGU::RENAMINGU(ParseXML* XML_interface, int ithCore_,
         // interface_ip.obj_func_dyn_energy = 0;
         // interface_ip.obj_func_dyn_power  = 0;
         // interface_ip.obj_func_leak_power = 0;
-        //interface_ip.obj_func_cycle_t    = 1;
-        //interface_ip.num_rw_ports = 1;//the extra one
+        // interface_ip.obj_func_cycle_t    = 1;
+        // interface_ip.num_rw_ports = 1;//the extra one
         // port is for GCs 			interface_ip.num_rd_ports    =
         // 2*coredynp.decodeW; 			interface_ip.num_wr_ports    =
         // coredynp.decodeW;
@@ -6384,7 +6384,7 @@ void Core::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
     // << indent_str_next << "Peak Dynamic = " <<
     // undiffCore->power.readOp.dynamic*clockRate << " W" << endl;
     ////				cout << indent_str_next << "Subthreshold
-    ///Leakage
+    /// Leakage
     ///=
     ///"
     ///<< undiffCore->power.readOp.leakage <<" W" << endl;
@@ -6395,12 +6395,12 @@ void Core::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
     //(long_channel?
     // undiffCore->power.readOp.longer_channel_leakage:undiffCore->power.readOp.leakage)
     //<< " W" << endl; 				cout << indent_str_next << "Gate
-    //Leakage
+    // Leakage
     //=
     //"
     //<< undiffCore->power.readOp.gate_leakage << " W" << endl;
-    //				//		cout << indent_str_next << "Runtime
-    //Dynamic
+    //				//		cout << indent_str_next <<
+    //"Runtime Dynamic
     //=
     //"
     //<< undiffCore->rt_power.readOp.dynamic/executionTime << " W" << endl;

--- a/src/gpuwattch/core.cc
+++ b/src/gpuwattch/core.cc
@@ -804,7 +804,7 @@ SchedulerU::SchedulerU(ParseXML* XML_interface, int ithCore_,
         // can know which reg/RRAT to update
         //				data =
         // int(ceil((robExtra+coredynp.pc_width
-        //+ 						coredynp.instruction_length
+        //+ coredynp.instruction_length
         //+ 2*coredynp.phy_ireg_width)/8.0));
         data = int(ceil(
             (robExtra + coredynp.pc_width + coredynp.phy_ireg_width) / 8.0));
@@ -812,7 +812,7 @@ SchedulerU::SchedulerU(ParseXML* XML_interface, int ithCore_,
         // in RS based OOO, ROB also contains value of destination reg
         //				data  =
         // int(ceil((robExtra+coredynp.pc_width
-        //+ 						coredynp.instruction_length
+        //+ coredynp.instruction_length
         //+ 2*coredynp.phy_ireg_width + coredynp.fp_data_width)/8.0));
         data = int(ceil((robExtra + coredynp.pc_width +
                          coredynp.phy_ireg_width + coredynp.fp_data_width) /
@@ -2400,18 +2400,19 @@ RENAMINGU::RENAMINGU(ParseXML* XML_interface, int ithCore_,
         // int(ceil(coredynp.phy_ireg_width/8.0)*coredynp.num_IRF_entry);
         // out_w = data; 			interface_ip.is_cache
         //= false; 			interface_ip.pure_cam            =
-        //false; 			interface_ip.pure_ram            = true; 			interface_ip.line_sz
-        //= data; 			interface_ip.cache_sz            =
-        // data*coredynp.globalCheckpoint; interface_ip.assoc = 1;
+        // false; 			interface_ip.pure_ram            = true;
+        // interface_ip.line_sz = data; 			interface_ip.cache_sz
+        // = data*coredynp.globalCheckpoint; interface_ip.assoc = 1;
         // interface_ip.nbanks              = 1;
         // interface_ip.out_w =
         // out_w*8; 			interface_ip.access_mode         = 0;
         // interface_ip.throughput = 1.0/clockRate;
-        //interface_ip.latency = 1.0/clockRate; 			interface_ip.obj_func_dyn_energy
-        //= 0; 			interface_ip.obj_func_dyn_power  = 0;
-        //			interface_ip.obj_func_leak_power = 0;
-        //			interface_ip.obj_func_cycle_t    = 1;
-        //			interface_ip.num_rw_ports    = 1;//the extra one
+        // interface_ip.latency = 1.0/clockRate;
+        // interface_ip.obj_func_dyn_energy = 0;
+        // interface_ip.obj_func_dyn_power  = 0;
+        // interface_ip.obj_func_leak_power = 0;
+        //interface_ip.obj_func_cycle_t    = 1;
+        //interface_ip.num_rw_ports = 1;//the extra one
         // port is for GCs 			interface_ip.num_rd_ports    =
         // 2*coredynp.decodeW; 			interface_ip.num_wr_ports    =
         // coredynp.decodeW;
@@ -6382,7 +6383,9 @@ void Core::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
     // cout
     // << indent_str_next << "Peak Dynamic = " <<
     // undiffCore->power.readOp.dynamic*clockRate << " W" << endl;
-    ////				cout << indent_str_next << "Subthreshold Leakage =
+    ////				cout << indent_str_next << "Subthreshold
+    ///Leakage
+    ///=
     ///"
     ///<< undiffCore->power.readOp.leakage <<" W" << endl;
     //				cout << indent_str_next << "Subthreshold Leakage
@@ -6391,10 +6394,14 @@ void Core::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
     //								<<
     //(long_channel?
     // undiffCore->power.readOp.longer_channel_leakage:undiffCore->power.readOp.leakage)
-    //<< " W" << endl; 				cout << indent_str_next << "Gate Leakage =
+    //<< " W" << endl; 				cout << indent_str_next << "Gate
+    //Leakage
+    //=
     //"
     //<< undiffCore->power.readOp.gate_leakage << " W" << endl;
-    //				//		cout << indent_str_next << "Runtime Dynamic =
+    //				//		cout << indent_str_next << "Runtime
+    //Dynamic
+    //=
     //"
     //<< undiffCore->rt_power.readOp.dynamic/executionTime << " W" << endl;
     // cout
@@ -6411,11 +6418,12 @@ void Core::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
          << endl;
 
   } else {
-    //		cout << indent_str_next << "Instruction Fetch Unit    Peak Dynamic
+    //		cout << indent_str_next << "Instruction Fetch Unit    Peak
+    // Dynamic
     //=
     //"
     //<< ifu->rt_power.readOp.dynamic*clockRate << " W" << endl;
-    //cout
+    // cout
     //<< indent_str_next << "Instruction Fetch Unit    Subthreshold Leakage = "
     // << ifu->rt_power.readOp.leakage <<" W" << endl; 		cout <<
     // indent_str_next << "Instruction Fetch Unit    Gate Leakage = " <<
@@ -6430,7 +6438,7 @@ void Core::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
     // << "Load Store Unit   Gate Leakage = " <<
     // lsu->rt_power.readOp.gate_leakage
     //<< " W" << endl; 		cout << indent_str_next << "Memory Management
-    //Unit Peak Dynamic = " << mmu->rt_power.readOp.dynamic*clockRate  << " W"
+    // Unit Peak Dynamic = " << mmu->rt_power.readOp.dynamic*clockRate  << " W"
     // <<
     // endl; 		cout << indent_str_next << "Memory Management Unit
     // Subthreshold Leakage = " << mmu->rt_power.readOp.leakage  << " W" <<

--- a/src/gpuwattch/core.cc
+++ b/src/gpuwattch/core.cc
@@ -59,31 +59,31 @@
 //-gpgpu_num_reg_banks                    8 # Number of register banks (default
 //= 8)
 //-gpgpu_reg_bank_use_warp_id                    0 # Use warp ID in mapping
-// registers to banks (default = off)
+//registers to banks (default = off)
 //-gpgpu_operand_collector_num_units_sp                    6 # number of
-// collector units (default = 4)
+//collector units (default = 4)
 //-gpgpu_operand_collector_num_units_sfu                    8 # number of
-// collector units (default = 4)
+//collector units (default = 4)
 //-gpgpu_operand_collector_num_units_mem                    2 # number of
-// collector units (default = 2)
+//collector units (default = 2)
 //-gpgpu_operand_collector_num_units_gen                    0 # number of
-// collector units (default = 0)
+//collector units (default = 0)
 //-gpgpu_operand_collector_num_in_ports_sp                    1 # number of
-// collector unit in ports (default = 1)
+//collector unit in ports (default = 1)
 //-gpgpu_operand_collector_num_in_ports_sfu                    1 # number of
-// collector unit in ports (default = 1)
+//collector unit in ports (default = 1)
 //-gpgpu_operand_collector_num_in_ports_mem                    1 # number of
-// collector unit in ports (default = 1)
+//collector unit in ports (default = 1)
 //-gpgpu_operand_collector_num_in_ports_gen                    0 # number of
-// collector unit in ports (default = 0)
+//collector unit in ports (default = 0)
 //-gpgpu_operand_collector_num_out_ports_sp                    1 # number of
-// collector unit in ports (default = 1)
+//collector unit in ports (default = 1)
 //-gpgpu_operand_collector_num_out_ports_sfu                    1 # number of
-// collector unit in ports (default = 1)
+//collector unit in ports (default = 1)
 //-gpgpu_operand_collector_num_out_ports_mem                    1 # number of
-// collector unit in ports (default = 1)
+//collector unit in ports (default = 1)
 //-gpgpu_operand_collector_num_out_ports_gen                    0 # number of
-// collector unit in ports (default = 0)
+//collector unit in ports (default = 0)
 
 // The total number of collector units and their input ports, and the number of
 // register file banks
@@ -827,22 +827,18 @@ SchedulerU::SchedulerU(ParseXML* XML_interface, int ithCore_,
         // PC is to id the instruction for recover exception.
         // inst is used to map the renamed dest. registers.so that commit stage
         // can know which reg/RRAT to update
-        //				data =
-        // int(ceil((robExtra+coredynp.pc_width
+        //				data = int(ceil((robExtra+coredynp.pc_width
         //+
-        //						coredynp.instruction_length
-        //+
-        // 2*coredynp.phy_ireg_width)/8.0));
+        //						coredynp.instruction_length +
+        //2*coredynp.phy_ireg_width)/8.0));
         data = int(ceil(
             (robExtra + coredynp.pc_width + coredynp.phy_ireg_width) / 8.0));
       } else {
         // in RS based OOO, ROB also contains value of destination reg
-        //				data  =
-        // int(ceil((robExtra+coredynp.pc_width
+        //				data  = int(ceil((robExtra+coredynp.pc_width
         //+
-        //						coredynp.instruction_length
-        //+
-        // 2*coredynp.phy_ireg_width + coredynp.fp_data_width)/8.0));
+        //						coredynp.instruction_length +
+        //2*coredynp.phy_ireg_width + coredynp.fp_data_width)/8.0));
         data = int(ceil((robExtra + coredynp.pc_width +
                          coredynp.phy_ireg_width + coredynp.fp_data_width) /
                         8.0));
@@ -2403,9 +2399,8 @@ RENAMINGU::RENAMINGU(ParseXML* XML_interface, int ithCore_,
                                          // detailed explaintions
         data =
             33;  // int(ceil(coredynp.phy_ireg_width*(1+coredynp.globalCheckpoint)/8.0));
-        //			data
-        //=
-        // int(ceil(coredynp.phy_ireg_width/8.0));
+        //			data							 =
+        //int(ceil(coredynp.phy_ireg_width/8.0));
         out_w = 1;  // int(ceil(coredynp.phy_ireg_width/8.0));
         interface_ip.is_cache = false;
         interface_ip.pure_cam = false;
@@ -2435,44 +2430,42 @@ RENAMINGU::RENAMINGU(ParseXML* XML_interface, int ithCore_,
                 XML->sys.core[ithCore].number_hardware_threads);
         area.set_area(area.get_area() + iFRAT->area.get_area());
 
-        //			//RAHT According to Intel, combine GC with FRAT
-        // is
-        // very costly.
-        //			data
-        //=
-        // int(ceil(coredynp.phy_ireg_width/8.0)*coredynp.num_IRF_entry);
+        //			//RAHT According to Intel, combine GC with FRAT is
+        //very costly.
+        //			data							 =
+        //int(ceil(coredynp.phy_ireg_width/8.0)*coredynp.num_IRF_entry);
         //			out_w                            = data;
         //			interface_ip.is_cache			 =
-        // false;
+        //false;
         //			interface_ip.pure_cam            = false;
         //			interface_ip.pure_ram            = true;
         //			interface_ip.line_sz             = data;
         //			interface_ip.cache_sz            =
-        // data*coredynp.globalCheckpoint;
+        //data*coredynp.globalCheckpoint;
         //			interface_ip.assoc               = 1;
         //			interface_ip.nbanks              = 1;
         //			interface_ip.out_w               = out_w*8;
         //			interface_ip.access_mode         = 0;
         //			interface_ip.throughput          =
-        // 1.0/clockRate;
+        //1.0/clockRate;
         //			interface_ip.latency             =
-        // 1.0/clockRate;
+        //1.0/clockRate;
         //			interface_ip.obj_func_dyn_energy = 0;
         //			interface_ip.obj_func_dyn_power  = 0;
         //			interface_ip.obj_func_leak_power = 0;
         //			interface_ip.obj_func_cycle_t    = 1;
         //			interface_ip.num_rw_ports    = 1;//the extra one
-        // port is for GCs
+        //port is for GCs
         //			interface_ip.num_rd_ports    =
-        // 2*coredynp.decodeW;
+        //2*coredynp.decodeW;
         //			interface_ip.num_wr_ports    = coredynp.decodeW;
         //			interface_ip.num_se_rd_ports = 0;
         //			iFRAT = new ArrayST(&interface_ip, "Int
-        // FrontRAT");
+        //FrontRAT");
         //			iFRAT->area.set_area(iFRAT->area.get_area()+
-        // iFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
+        //iFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
         //			area.set_area(area.get_area()+
-        // iFRAT->area.get_area());
+        //iFRAT->area.get_area());
 
         // FRAT floating point
         data = int(ceil(coredynp.phy_freg_width *
@@ -3230,39 +3223,30 @@ void BranchPredictor::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
          << " W" << endl;
     cout << endl;
   } else {
-    //		cout << indent_str_next << "Global Predictor    Peak Dynamic = "
-    //<<
-    // globalBPT->rt_power.readOp.dynamic*clockRate << " W" << endl;
-    //		cout << indent_str_next << "Global Predictor    Subthreshold
-    //Leakage
-    //=
+    //		cout << indent_str_next << "Global Predictor    Peak Dynamic = " <<
+    //globalBPT->rt_power.readOp.dynamic*clockRate << " W" << endl;
+    //		cout << indent_str_next << "Global Predictor    Subthreshold Leakage =
     //" << globalBPT->rt_power.readOp.leakage <<" W" << endl;
-    //		cout << indent_str_next << "Global Predictor    Gate Leakage = "
-    //<<
-    // globalBPT->rt_power.readOp.gate_leakage << " W" << endl;
-    //		cout << indent_str_next << "Local Predictor   Peak Dynamic = "
-    //<<
-    // L1_localBPT->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Local Predictor   Subthreshold Leakage
-    //=
-    //"
+    //		cout << indent_str_next << "Global Predictor    Gate Leakage = " <<
+    //globalBPT->rt_power.readOp.gate_leakage << " W" << endl;
+    //		cout << indent_str_next << "Local Predictor   Peak Dynamic = " <<
+    //L1_localBPT->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "Local Predictor   Subthreshold Leakage = "
     //<< L1_localBPT->rt_power.readOp.leakage  << " W" << endl;
-    //		cout << indent_str_next << "Local Predictor   Gate Leakage = "
-    //<<
-    // L1_localBPT->rt_power.readOp.gate_leakage  << " W" << endl;
+    //		cout << indent_str_next << "Local Predictor   Gate Leakage = " <<
+    //L1_localBPT->rt_power.readOp.gate_leakage  << " W" << endl;
     //		cout << indent_str_next << "Chooser   Peak Dynamic = " <<
-    // chooser->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Chooser   Subthreshold Leakage = "
-    //<<
-    // chooser->rt_power.readOp.leakage  << " W" << endl;
+    //chooser->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "Chooser   Subthreshold Leakage = " <<
+    //chooser->rt_power.readOp.leakage  << " W" << endl;
     //		cout << indent_str_next << "Chooser   Gate Leakage = " <<
-    // chooser->rt_power.readOp.gate_leakage  << " W" << endl;
+    //chooser->rt_power.readOp.gate_leakage  << " W" << endl;
     //		cout << indent_str_next << "RAS   Peak Dynamic = " <<
-    // RAS->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //RAS->rt_power.readOp.dynamic*clockRate  << " W" << endl;
     //		cout << indent_str_next << "RAS   Subthreshold Leakage = " <<
-    // RAS->rt_power.readOp.leakage  << " W" << endl;
+    //RAS->rt_power.readOp.leakage  << " W" << endl;
     //		cout << indent_str_next << "RAS   Gate Leakage = " <<
-    // RAS->rt_power.readOp.gate_leakage  << " W" << endl;
+    //RAS->rt_power.readOp.gate_leakage  << " W" << endl;
   }
 }
 
@@ -3609,48 +3593,30 @@ void InstFetchU::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
          << " W" << endl;
     cout << endl;
   } else {
-    //		cout << indent_str_next << "Instruction Cache    Peak Dynamic =
-    //"
-    //<<
-    // icache.rt_power.readOp.dynamic*clockRate << " W" << endl;
-    //		cout << indent_str_next << "Instruction Cache    Subthreshold
-    // Leakage
+    //		cout << indent_str_next << "Instruction Cache    Peak Dynamic = " <<
+    //icache.rt_power.readOp.dynamic*clockRate << " W" << endl;
+    //		cout << indent_str_next << "Instruction Cache    Subthreshold Leakage
     //= " << icache.rt_power.readOp.leakage <<" W" << endl;
-    //		cout << indent_str_next << "Instruction Cache    Gate Leakage =
-    //"
-    //<<
-    // icache.rt_power.readOp.gate_leakage << " W" << endl;
-    //		cout << indent_str_next << "Instruction Buffer   Peak Dynamic =
-    //"
-    //<<
-    // IB->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Instruction Buffer   Subthreshold
-    // Leakage
+    //		cout << indent_str_next << "Instruction Cache    Gate Leakage = " <<
+    //icache.rt_power.readOp.gate_leakage << " W" << endl;
+    //		cout << indent_str_next << "Instruction Buffer   Peak Dynamic = " <<
+    //IB->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "Instruction Buffer   Subthreshold Leakage
     //= " << IB->rt_power.readOp.leakage  << " W" << endl;
-    //		cout << indent_str_next << "Instruction Buffer   Gate Leakage =
-    //"
-    //<<
-    // IB->rt_power.readOp.gate_leakage  << " W" << endl;
-    //		cout << indent_str_next << "Branch Target Buffer   Peak Dynamic =
-    //"
-    //<<
-    // BTB->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "Instruction Buffer   Gate Leakage = " <<
+    //IB->rt_power.readOp.gate_leakage  << " W" << endl;
+    //		cout << indent_str_next << "Branch Target Buffer   Peak Dynamic = " <<
+    //BTB->rt_power.readOp.dynamic*clockRate  << " W" << endl;
     //		cout << indent_str_next << "Branch Target Buffer   Subthreshold
-    // Leakage = " << BTB->rt_power.readOp.leakage  << " W" << endl;
-    //		cout << indent_str_next << "Branch Target Buffer   Gate Leakage =
-    //"
-    //<<
-    // BTB->rt_power.readOp.gate_leakage  << " W" << endl;
-    //		cout << indent_str_next << "Branch Predictor   Peak Dynamic = "
-    //<<
-    // BPT->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Branch Predictor   Subthreshold
-    //Leakage
-    //=
+    //Leakage = " << BTB->rt_power.readOp.leakage  << " W" << endl;
+    //		cout << indent_str_next << "Branch Target Buffer   Gate Leakage = " <<
+    //BTB->rt_power.readOp.gate_leakage  << " W" << endl;
+    //		cout << indent_str_next << "Branch Predictor   Peak Dynamic = " <<
+    //BPT->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "Branch Predictor   Subthreshold Leakage =
     //" << BPT->rt_power.readOp.leakage  << " W" << endl;
-    //		cout << indent_str_next << "Branch Predictor   Gate Leakage = "
-    //<<
-    // BPT->rt_power.readOp.gate_leakage  << " W" << endl;
+    //		cout << indent_str_next << "Branch Predictor   Gate Leakage = " <<
+    //BPT->rt_power.readOp.gate_leakage  << " W" << endl;
   }
 }
 
@@ -4248,12 +4214,11 @@ void SchedulerU::computeEnergy(bool is_tdp) {
   if (!exist) return;
   double ROB_duty_cycle;
   //	ROB_duty_cycle = ((coredynp.ALU_duty_cycle +
-  // coredynp.num_muls>0?coredynp.MUL_duty_cycle:0
-  //			+ coredynp.num_fpus>0?coredynp.FPU_duty_cycle:0))*1.1<1
-  //?
+  //coredynp.num_muls>0?coredynp.MUL_duty_cycle:0
+  //			+ coredynp.num_fpus>0?coredynp.FPU_duty_cycle:0))*1.1<1 ?
   //(coredynp.ALU_duty_cycle + coredynp.num_muls>0?coredynp.MUL_duty_cycle:0
   //					+
-  // coredynp.num_fpus>0?coredynp.FPU_duty_cycle:0)*1.1:1;
+  //coredynp.num_fpus>0?coredynp.FPU_duty_cycle:0)*1.1:1;
   ROB_duty_cycle = 1;
   // init stats
   if (is_tdp) {
@@ -4427,7 +4392,7 @@ void SchedulerU::computeEnergy(bool is_tdp) {
 
     } else if (coredynp.multithreaded) {
       //			set_pppm(pppm_t,
-      // XML->sys.core[ithCore].issue_width,1, 1, 1);
+      //XML->sys.core[ithCore].issue_width,1, 1, 1);
       int_inst_window->power =
           int_inst_window->power_t +
           (int_inst_window->local_result.power + instruction_selection->power) *
@@ -4454,7 +4419,7 @@ void SchedulerU::computeEnergy(bool is_tdp) {
 
     } else if (coredynp.multithreaded) {
       //			set_pppm(pppm_t,
-      // XML->sys.core[ithCore].issue_width,1, 1, 1);
+      //XML->sys.core[ithCore].issue_width,1, 1, 1);
       int_inst_window->rt_power =
           int_inst_window->power_t +
           (int_inst_window->local_result.power + instruction_selection->power) *
@@ -4464,9 +4429,9 @@ void SchedulerU::computeEnergy(bool is_tdp) {
   }
   //	set_pppm(pppm_t, XML->sys.core[ithCore].issue_width,1, 1, 1);
   //	cout<<"Scheduler
-  // power="<<power.readOp.dynamic<<"leakage="<<power.readOp.leakage<<endl;
+  //power="<<power.readOp.dynamic<<"leakage="<<power.readOp.leakage<<endl;
   //	cout<<"IW="<<int_inst_window->local_result.power.searchOp.dynamic *
-  // int_inst_window->stats_t.readAc.access +
+  //int_inst_window->stats_t.readAc.access +
   //    + int_inst_window->local_result.power.writeOp.dynamic *
   //    int_inst_window->stats_t.writeAc.access<<"leakage="<<int_inst_window->local_result.power.readOp.leakage<<endl;
   //	cout<<"selection"<<instruction_selection->power.readOp.dynamic<<"leakage"<<instruction_selection->power.readOp.leakage<<endl;
@@ -5139,11 +5104,11 @@ void LoadStoreU::computeEnergy(bool is_tdp) {
 
   } else {
     //	LSQ->power_t.readOp.dynamic  +=
-    // LSQ->stats_t.readAc.access*(LSQ->local_result.power.searchOp.dynamic +
-    // LSQ->local_result.power.readOp.dynamic)
+    //LSQ->stats_t.readAc.access*(LSQ->local_result.power.searchOp.dynamic +
+    //LSQ->local_result.power.readOp.dynamic)
     //	        +
-    // LSQ->stats_t.writeAc.access*LSQ->local_result.power.writeOp.dynamic;//every
-    // memory access invloves at least two operations on LSQ
+    //LSQ->stats_t.writeAc.access*LSQ->local_result.power.writeOp.dynamic;//every
+    //memory access invloves at least two operations on LSQ
     //	No LSQ in GPUs (Syed)
   }
 
@@ -5979,7 +5944,7 @@ void EXECU::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
   bool long_channel = XML->sys.longer_channel_device;
 
   //	cout << indent_str_next << "Results Broadcast Bus Area = " <<
-  // bypass->area.get_area() *1e-6 << " mm^2" << endl;
+  //bypass->area.get_area() *1e-6 << " mm^2" << endl;
   if (is_tdp) {
     cout << indent_str << "Register Files:" << endl;
     cout << indent_str_next << "Area = " << rfu->area.get_area() * 1e-6
@@ -6186,15 +6151,15 @@ void Core::computeEnergy(bool is_tdp) {
                coredynp.num_pipelines / num_units,
                coredynp.num_pipelines / num_units);
       //			cout << "IFU = " <<
-      // ifu->power.readOp.dynamic*clockRate  << " W" << endl;
+      //ifu->power.readOp.dynamic*clockRate  << " W" << endl;
       ifu->power = ifu->power + corepipe->power * pppm_t;
       //			cout << "IFU = " <<
-      // ifu->power.readOp.dynamic*clockRate  << " W" << endl;
+      //ifu->power.readOp.dynamic*clockRate  << " W" << endl;
       //			cout << "1/4 pipe = " <<
-      // corepipe->power.readOp.dynamic*clockRate/num_units  << " W" << endl;
+      //corepipe->power.readOp.dynamic*clockRate/num_units  << " W" << endl;
       power = power + ifu->power;
       //			cout << "core = " <<
-      // power.readOp.dynamic*clockRate  << " W" << endl;
+      //power.readOp.dynamic*clockRate  << " W" << endl;
     }
     if (lsu->exist) {
       Pipeline_energy +=
@@ -6207,10 +6172,10 @@ void Core::computeEnergy(bool is_tdp) {
                coredynp.num_pipelines / num_units);
       lsu->power = lsu->power + corepipe->power * pppm_t;
       //			cout << "LSU = " <<
-      // lsu->power.readOp.dynamic*clockRate  << " W" << endl;
+      //lsu->power.readOp.dynamic*clockRate  << " W" << endl;
       power = power + lsu->power;
       //			cout << "core = " <<
-      // power.readOp.dynamic*clockRate  << " W" << endl;
+      //power.readOp.dynamic*clockRate  << " W" << endl;
     }
     if (exu->exist) {
       Pipeline_energy +=
@@ -6224,10 +6189,10 @@ void Core::computeEnergy(bool is_tdp) {
       // cout<<"ExPowerScalingFactor:"<<coredynp.num_pipelines/num_units*coredynp.ALU_duty_cycle<<endl;
       exu->power = exu->power + corepipe->power * pppm_t;
       //			cout << "EXE = " <<
-      // exu->power.readOp.dynamic*clockRate  << " W" << endl;
+      //exu->power.readOp.dynamic*clockRate  << " W" << endl;
       power = power + exu->power;
       //			cout << "core = " <<
-      // power.readOp.dynamic*clockRate  << " W" << endl;
+      //power.readOp.dynamic*clockRate  << " W" << endl;
     }
     if (mmu->exist) {
       Pipeline_energy +=
@@ -6240,10 +6205,10 @@ void Core::computeEnergy(bool is_tdp) {
                coredynp.num_pipelines / num_units);
       mmu->power = mmu->power + corepipe->power * pppm_t;
       //			cout << "MMU = " <<
-      // mmu->power.readOp.dynamic*clockRate  << " W" << endl;
+      //mmu->power.readOp.dynamic*clockRate  << " W" << endl;
       power = power + mmu->power;
       //			cout << "core = " <<
-      // power.readOp.dynamic*clockRate  << " W" << endl;
+      //power.readOp.dynamic*clockRate  << " W" << endl;
     }
 
     power = power + undiffCore->power;
@@ -6311,9 +6276,8 @@ void Core::computeEnergy(bool is_tdp) {
     }
 
     rt_power = rt_power + undiffCore->power;
-    //		cout << "EXE = " << exu->power.readOp.dynamic*clockRate  << " W"
-    //<<
-    // endl;
+    //		cout << "EXE = " << exu->power.readOp.dynamic*clockRate  << " W" <<
+    //endl;
     if (XML->sys.Private_L2) {
       l2cache->computeEnergy(is_tdp);
       // set_pppm(pppm_t,1/l2cache->cachep.executionTime, 1,1,1);
@@ -6472,28 +6436,22 @@ void Core::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
     //			if (undiffCore->exist)
     //			{
     //				cout << indent_str << "Undifferentiated Core" <<
-    // endl;
+    //endl;
     //				cout << indent_str_next << "Area = " <<
-    // undiffCore->area.get_area()*1e-6<< " mm^2" << endl;
+    //undiffCore->area.get_area()*1e-6<< " mm^2" << endl;
     //				cout << indent_str_next << "Peak Dynamic = " <<
-    // undiffCore->power.readOp.dynamic*clockRate << " W" << endl;
-    ////				cout << indent_str_next << "Subthreshold Leakage =
-    ///"
-    ///<<
-    /// undiffCore->power.readOp.leakage <<" W" << endl;
-    //				cout << indent_str_next << "Subthreshold Leakage
-    //=
+    //undiffCore->power.readOp.dynamic*clockRate << " W" << endl;
+    ////				cout << indent_str_next << "Subthreshold Leakage = " <<
+    ///undiffCore->power.readOp.leakage <<" W" << endl;
+    //				cout << indent_str_next << "Subthreshold Leakage =
     //"
-    //								<<
-    //(long_channel?
-    // undiffCore->power.readOp.longer_channel_leakage:undiffCore->power.readOp.leakage)
+    //								<< (long_channel?
+    //undiffCore->power.readOp.longer_channel_leakage:undiffCore->power.readOp.leakage)
     //<< " W" << endl;
     //				cout << indent_str_next << "Gate Leakage = " <<
-    // undiffCore->power.readOp.gate_leakage << " W" << endl;
-    //				//		cout << indent_str_next << "Runtime Dynamic =
-    //"
-    //<<
-    // undiffCore->rt_power.readOp.dynamic/executionTime << " W" << endl;
+    //undiffCore->power.readOp.gate_leakage << " W" << endl;
+    //				//		cout << indent_str_next << "Runtime Dynamic = " <<
+    //undiffCore->rt_power.readOp.dynamic/executionTime << " W" << endl;
     //				cout <<endl;
     //			}
     //		}
@@ -6507,44 +6465,30 @@ void Core::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
          << endl;
 
   } else {
-    //		cout << indent_str_next << "Instruction Fetch Unit    Peak Dynamic
-    //=
-    //"
+    //		cout << indent_str_next << "Instruction Fetch Unit    Peak Dynamic = "
     //<< ifu->rt_power.readOp.dynamic*clockRate << " W" << endl;
-    //		cout << indent_str_next << "Instruction Fetch Unit Subthreshold
-    // Leakage = " << ifu->rt_power.readOp.leakage <<" W" << endl;
-    //		cout << indent_str_next << "Instruction Fetch Unit    Gate Leakage
-    //=
-    //"
+    //		cout << indent_str_next << "Instruction Fetch Unit    Subthreshold
+    //Leakage = " << ifu->rt_power.readOp.leakage <<" W" << endl;
+    //		cout << indent_str_next << "Instruction Fetch Unit    Gate Leakage = "
     //<< ifu->rt_power.readOp.gate_leakage << " W" << endl;
-    //		cout << indent_str_next << "Load Store Unit   Peak Dynamic = "
-    //<<
-    // lsu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Load Store Unit   Subthreshold Leakage
-    //=
-    //"
+    //		cout << indent_str_next << "Load Store Unit   Peak Dynamic = " <<
+    //lsu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "Load Store Unit   Subthreshold Leakage = "
     //<< lsu->rt_power.readOp.leakage  << " W" << endl;
-    //		cout << indent_str_next << "Load Store Unit   Gate Leakage = "
-    //<<
-    // lsu->rt_power.readOp.gate_leakage  << " W" << endl;
-    //		cout << indent_str_next << "Memory Management Unit   Peak Dynamic
-    //=
-    //"
+    //		cout << indent_str_next << "Load Store Unit   Gate Leakage = " <<
+    //lsu->rt_power.readOp.gate_leakage  << " W" << endl;
+    //		cout << indent_str_next << "Memory Management Unit   Peak Dynamic = "
     //<< mmu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Memory Management Unit Subthreshold
-    // Leakage = " << mmu->rt_power.readOp.leakage  << " W" << endl;
-    //		cout << indent_str_next << "Memory Management Unit   Gate Leakage
-    //=
-    //"
+    //		cout << indent_str_next << "Memory Management Unit   Subthreshold
+    //Leakage = " << mmu->rt_power.readOp.leakage  << " W" << endl;
+    //		cout << indent_str_next << "Memory Management Unit   Gate Leakage = "
     //<< mmu->rt_power.readOp.gate_leakage  << " W" << endl;
     //		cout << indent_str_next << "Execution Unit   Peak Dynamic = " <<
-    // exu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Execution Unit   Subthreshold Leakage
-    //=
-    //"
+    //exu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "Execution Unit   Subthreshold Leakage = "
     //<< exu->rt_power.readOp.leakage  << " W" << endl;
     //		cout << indent_str_next << "Execution Unit   Gate Leakage = " <<
-    // exu->rt_power.readOp.gate_leakage  << " W" << endl;
+    //exu->rt_power.readOp.gate_leakage  << " W" << endl;
   }
 }
 InstFetchU::~InstFetchU() {
@@ -6867,9 +6811,8 @@ void Core::set_core_param() {
   }
   //	if (coredynp.core_ty==OOO)
   //	{
-  //		cout<<"OOO processor models are being updated and will be
-  // available
-  // in next release"<<endl;
+  //		cout<<"OOO processor models are being updated and will be available
+  //in next release"<<endl;
   //		exit(0);
   //	}
   if (!((coredynp.scheu_ty == PhysicalRegFile) ||

--- a/src/gpuwattch/core.cc
+++ b/src/gpuwattch/core.cc
@@ -29,5309 +29,6791 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:												   *
-*      Jingwen Leng, Univeristy of Texas, Austin                   *
-*      Syed Gilani, University of Wisconsin–Madison                *
-*      Tayler Hetherington, University of British Columbia         *
-*      Ahmed ElTantawy, University of British Columbia             *
-********************************************************************/
+ *      Modified by:
+ ** Jingwen Leng, Univeristy of Texas, Austin                   * Syed Gilani,
+ *University of Wisconsin–Madison                * Tayler Hetherington,
+ *University of British Columbia         * Ahmed ElTantawy, University of
+ *British Columbia             *
+ ********************************************************************/
 
+#include "core.h"
+#include <assert.h>
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <string>
+#include "XML_Parse.h"
+#include "cacti/basic_circuit.h"
+#include "const.h"
 #include "io.h"
 #include "parameter.h"
-#include "const.h"
-#include "cacti/basic_circuit.h"
-#include <iostream>
-#include <algorithm>
-#include "XML_Parse.h"
-#include <string>
-#include <cmath>
-#include <assert.h>
-#include "core.h"
 //#include "globalvar.h"
-//double exClockRate;
+// double exClockRate;
 //*********************
-//Operand collector (OC) modelling (Syed Gilani)
+// Operand collector (OC) modelling (Syed Gilani)
 //*********************
-//The OCs are modelled similar to the GPGPU-Sim v3.x documentation and
-//nVIDIA patents.
-//the OC need the following GPGPU-Sim config options:
-//-gpgpu_num_reg_banks                    8 # Number of register banks (default = 8)
-//-gpgpu_reg_bank_use_warp_id                    0 # Use warp ID in mapping registers to banks (default = off)
-//-gpgpu_operand_collector_num_units_sp                    6 # number of collector units (default = 4)
-//-gpgpu_operand_collector_num_units_sfu                    8 # number of collector units (default = 4)
-//-gpgpu_operand_collector_num_units_mem                    2 # number of collector units (default = 2)
-//-gpgpu_operand_collector_num_units_gen                    0 # number of collector units (default = 0)
-//-gpgpu_operand_collector_num_in_ports_sp                    1 # number of collector unit in ports (default = 1)
-//-gpgpu_operand_collector_num_in_ports_sfu                    1 # number of collector unit in ports (default = 1)
-//-gpgpu_operand_collector_num_in_ports_mem                    1 # number of collector unit in ports (default = 1)
-//-gpgpu_operand_collector_num_in_ports_gen                    0 # number of collector unit in ports (default = 0)
-//-gpgpu_operand_collector_num_out_ports_sp                    1 # number of collector unit in ports (default = 1)
-//-gpgpu_operand_collector_num_out_ports_sfu                    1 # number of collector unit in ports (default = 1)
-//-gpgpu_operand_collector_num_out_ports_mem                    1 # number of collector unit in ports (default = 1)
-//-gpgpu_operand_collector_num_out_ports_gen                    0 # number of collector unit in ports (default = 0)
+// The OCs are modelled similar to the GPGPU-Sim v3.x documentation and
+// nVIDIA patents.
+// the OC need the following GPGPU-Sim config options:
+//-gpgpu_num_reg_banks                    8 # Number of register banks (default
+//= 8) -gpgpu_reg_bank_use_warp_id                    0 # Use warp ID in mapping
+// registers to banks (default = off) -gpgpu_operand_collector_num_units_sp 6 #
+// number of collector units (default = 4)
+// -gpgpu_operand_collector_num_units_sfu 8 # number of collector units (default
+// = 4) -gpgpu_operand_collector_num_units_mem                    2 # number of
+// collector units (default = 2) -gpgpu_operand_collector_num_units_gen 0 #
+// number of collector units (default = 0)
+//-gpgpu_operand_collector_num_in_ports_sp                    1 # number of
+// collector unit in ports (default = 1)
+//-gpgpu_operand_collector_num_in_ports_sfu                    1 # number of
+// collector unit in ports (default = 1)
+//-gpgpu_operand_collector_num_in_ports_mem                    1 # number of
+// collector unit in ports (default = 1)
+//-gpgpu_operand_collector_num_in_ports_gen                    0 # number of
+// collector unit in ports (default = 0)
+//-gpgpu_operand_collector_num_out_ports_sp                    1 # number of
+// collector unit in ports (default = 1)
+//-gpgpu_operand_collector_num_out_ports_sfu                    1 # number of
+// collector unit in ports (default = 1)
+//-gpgpu_operand_collector_num_out_ports_mem                    1 # number of
+// collector unit in ports (default = 1)
+//-gpgpu_operand_collector_num_out_ports_gen                    0 # number of
+// collector unit in ports (default = 0)
 
-//The total number of collector units and their input ports, and the number of register file banks
-//determine the crossbar size. 
+// The total number of collector units and their input ports, and the number of
+// register file banks determine the crossbar size.
 
-InstFetchU::InstFetchU(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_, bool exist_)
-:XML(XML_interface),
- ithCore(ithCore_),
- interface_ip(*interface_ip_),
- coredynp(dyn_p_),
- IB  (0),
- BTB (0),
- ID_inst  (0),
- ID_operand  (0),
- ID_misc  (0),
- exist(exist_)
-{
-	  if (!exist) return;
-	  int  idx, tag, data, size, line, assoc, banks;
-	  bool debug= false, is_default = true;
+InstFetchU::InstFetchU(ParseXML* XML_interface, int ithCore_,
+                       InputParameter* interface_ip_,
+                       const CoreDynParam& dyn_p_, bool exist_)
+    : XML(XML_interface),
+      ithCore(ithCore_),
+      interface_ip(*interface_ip_),
+      coredynp(dyn_p_),
+      IB(0),
+      BTB(0),
+      ID_inst(0),
+      ID_operand(0),
+      ID_misc(0),
+      exist(exist_) {
+  if (!exist) return;
+  int idx, tag, data, size, line, assoc, banks;
+  bool debug = false, is_default = true;
 
-	  clockRate = coredynp.clockRate;
-	  executionTime = coredynp.executionTime;
+  clockRate = coredynp.clockRate;
+  executionTime = coredynp.executionTime;
 
-	  cache_p = (Cache_policy)XML->sys.core[ithCore].icache.icache_config[7];
-	  //Assuming all L1 caches are virtually idxed physically tagged.
-	  //cache
+  cache_p = (Cache_policy)XML->sys.core[ithCore].icache.icache_config[7];
+  // Assuming all L1 caches are virtually idxed physically tagged.
+  // cache
 
-	  size                             = (int)XML->sys.core[ithCore].icache.icache_config[0];
-	  line                             = (int)XML->sys.core[ithCore].icache.icache_config[1];
-	  assoc                            = (int)XML->sys.core[ithCore].icache.icache_config[2];
-	  banks                            = (int)XML->sys.core[ithCore].icache.icache_config[3];
-	  idx    					 	   = debug?9:int(ceil(log2(size/line/assoc)));
-	  tag							   = debug?51:(int)XML->sys.physical_address_width-idx-int(ceil(log2(line))) + EXTRA_TAG_BITS;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.cache_sz            = debug?32768:(int)XML->sys.core[ithCore].icache.icache_config[0];
-	  interface_ip.line_sz             = debug?64:(int)XML->sys.core[ithCore].icache.icache_config[1];
-	  interface_ip.assoc               = debug?8:(int)XML->sys.core[ithCore].icache.icache_config[2];
-	  interface_ip.nbanks              = debug?1:(int)XML->sys.core[ithCore].icache.icache_config[3];
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 0;//debug?0:XML->sys.core[ithCore].icache.icache_config[5];
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].icache.icache_config[4]/clockRate;
-	  interface_ip.latency             = debug?3.0/clockRate:XML->sys.core[ithCore].icache.icache_config[5]/clockRate;
-	  interface_ip.is_cache			 = true;
-	  interface_ip.pure_cam			 = false;
-	  interface_ip.pure_ram			 = false;
-	//  interface_ip.obj_func_dyn_energy = 0;
-	//  interface_ip.obj_func_dyn_power  = 0;
-	//  interface_ip.obj_func_leak_power = 0;
-	//  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].number_instruction_fetch_ports;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  icache.caches = new ArrayST(&interface_ip, "icache", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  scktRatio = g_tp.sckt_co_eff;
-	  chip_PR_overhead = g_tp.chip_layout_overhead;
-	  macro_PR_overhead = g_tp.macro_layout_overhead;
-	  icache.area.set_area(icache.area.get_area()+ icache.caches->local_result.area);
-	  area.set_area(area.get_area()+ icache.caches->local_result.area);
-	  //output_data_csv(icache.caches.local_result);
+  size = (int)XML->sys.core[ithCore].icache.icache_config[0];
+  line = (int)XML->sys.core[ithCore].icache.icache_config[1];
+  assoc = (int)XML->sys.core[ithCore].icache.icache_config[2];
+  banks = (int)XML->sys.core[ithCore].icache.icache_config[3];
+  idx = debug ? 9 : int(ceil(log2(size / line / assoc)));
+  tag = debug ? 51
+              : (int)XML->sys.physical_address_width - idx -
+                    int(ceil(log2(line))) + EXTRA_TAG_BITS;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.cache_sz =
+      debug ? 32768 : (int)XML->sys.core[ithCore].icache.icache_config[0];
+  interface_ip.line_sz =
+      debug ? 64 : (int)XML->sys.core[ithCore].icache.icache_config[1];
+  interface_ip.assoc =
+      debug ? 8 : (int)XML->sys.core[ithCore].icache.icache_config[2];
+  interface_ip.nbanks =
+      debug ? 1 : (int)XML->sys.core[ithCore].icache.icache_config[3];
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode =
+      0;  // debug?0:XML->sys.core[ithCore].icache.icache_config[5];
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].icache.icache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 3.0 / clockRate
+            : XML->sys.core[ithCore].icache.icache_config[5] / clockRate;
+  interface_ip.is_cache = true;
+  interface_ip.pure_cam = false;
+  interface_ip.pure_ram = false;
+  //  interface_ip.obj_func_dyn_energy = 0;
+  //  interface_ip.obj_func_dyn_power  = 0;
+  //  interface_ip.obj_func_leak_power = 0;
+  //  interface_ip.obj_func_cycle_t    = 1;
+  interface_ip.num_rw_ports =
+      debug ? 1 : XML->sys.core[ithCore].number_instruction_fetch_ports;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  icache.caches = new ArrayST(&interface_ip, "icache", Core_device,
+                              coredynp.opt_local, coredynp.core_ty);
+  scktRatio = g_tp.sckt_co_eff;
+  chip_PR_overhead = g_tp.chip_layout_overhead;
+  macro_PR_overhead = g_tp.macro_layout_overhead;
+  icache.area.set_area(icache.area.get_area() +
+                       icache.caches->local_result.area);
+  area.set_area(area.get_area() + icache.caches->local_result.area);
+  // output_data_csv(icache.caches.local_result);
 
+  /*
+   *iCache controllers
+   *miss buffer Each MSHR contains enough state
+   *to handle one or more accesses of any type to a single memory line.
+   *Due to the generality of the MSHR mechanism,
+   *the amount of state involved is non-trivial:
+   *including the address, pointers to the cache entry and destination register,
+   *written data, and various other pieces of state.
+   */
+  interface_ip.num_search_ports =
+      debug ? 1 : XML->sys.core[ithCore].number_instruction_fetch_ports;
+  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data = (XML->sys.physical_address_width) + int(ceil(log2(size / line))) +
+         icache.caches->l_ip.line_sz * 8;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.line_sz =
+      int(ceil(data / 8.0));  // int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+  interface_ip.cache_sz =
+      XML->sys.core[ithCore].icache.buffer_sizes[0] * interface_ip.line_sz;
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 0;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].icache.icache_config[4] /
+                  clockRate;  // means cycle time
+  interface_ip.latency = debug
+                             ? 1.0 / clockRate
+                             : XML->sys.core[ithCore].icache.icache_config[5] /
+                                   clockRate;  // means access time
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports =
+      debug ? 1 : XML->sys.core[ithCore].number_instruction_fetch_ports;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  interface_ip.num_search_ports =
+      XML->sys.core[ithCore].number_instruction_fetch_ports;
+  icache.missb = new ArrayST(&interface_ip, "icacheMissBuffer", Core_device,
+                             coredynp.opt_local, coredynp.core_ty);
+  icache.area.set_area(icache.area.get_area() +
+                       icache.missb->local_result.area);
+  area.set_area(area.get_area() + icache.missb->local_result.area);
+  // output_data_csv(icache.missb.local_result);
 
-	  /*
-	   *iCache controllers
-	   *miss buffer Each MSHR contains enough state
-	   *to handle one or more accesses of any type to a single memory line.
-	   *Due to the generality of the MSHR mechanism,
-	   *the amount of state involved is non-trivial:
-	   *including the address, pointers to the cache entry and destination register,
-	   *written data, and various other pieces of state.
-	   */
-	  interface_ip.num_search_ports    = debug?1:XML->sys.core[ithCore].number_instruction_fetch_ports;
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  data							   = (XML->sys.physical_address_width) + int(ceil(log2(size/line))) + icache.caches->l_ip.line_sz*8;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-	  interface_ip.cache_sz            = XML->sys.core[ithCore].icache.buffer_sizes[0]*interface_ip.line_sz;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 0;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].icache.icache_config[4]/clockRate;//means cycle time
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].icache.icache_config[5]/clockRate;//means access time
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].number_instruction_fetch_ports;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  interface_ip.num_search_ports = XML->sys.core[ithCore].number_instruction_fetch_ports;
-	  icache.missb = new ArrayST(&interface_ip, "icacheMissBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  icache.area.set_area(icache.area.get_area()+ icache.missb->local_result.area);
-	  area.set_area(area.get_area()+ icache.missb->local_result.area);
-	  //output_data_csv(icache.missb.local_result);
+  // fill buffer
+  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data = icache.caches->l_ip.line_sz;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
+  interface_ip.cache_sz = data * XML->sys.core[ithCore].icache.buffer_sizes[1];
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 0;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].icache.icache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].icache.icache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports =
+      debug ? 1 : XML->sys.core[ithCore].number_instruction_fetch_ports;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  interface_ip.num_search_ports =
+      XML->sys.core[ithCore].number_instruction_fetch_ports;
+  icache.ifb = new ArrayST(&interface_ip, "icacheFillBuffer", Core_device,
+                           coredynp.opt_local, coredynp.core_ty);
+  icache.area.set_area(icache.area.get_area() + icache.ifb->local_result.area);
+  area.set_area(area.get_area() + icache.ifb->local_result.area);
+  // output_data_csv(icache.ifb.local_result);
 
-	  //fill buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  data							   = icache.caches->l_ip.line_sz;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-	  interface_ip.cache_sz            = data*XML->sys.core[ithCore].icache.buffer_sizes[1];
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 0;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].icache.icache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].icache.icache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].number_instruction_fetch_ports;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  interface_ip.num_search_ports = XML->sys.core[ithCore].number_instruction_fetch_ports;
-	  icache.ifb = new ArrayST(&interface_ip, "icacheFillBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  icache.area.set_area(icache.area.get_area()+ icache.ifb->local_result.area);
-	  area.set_area(area.get_area()+ icache.ifb->local_result.area);
-	  //output_data_csv(icache.ifb.local_result);
+  // prefetch buffer
+  tag = XML->sys.physical_address_width +
+        EXTRA_TAG_BITS;  // check with previous entries to decide wthether to
+                         // merge.
+  data = icache.caches->l_ip
+             .line_sz;  // separate queue to prevent from cache polution.
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
+  interface_ip.cache_sz =
+      XML->sys.core[ithCore].icache.buffer_sizes[2] * interface_ip.line_sz;
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 0;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].icache.icache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].icache.icache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports =
+      debug ? 1 : XML->sys.core[ithCore].number_instruction_fetch_ports;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  interface_ip.num_search_ports =
+      XML->sys.core[ithCore].number_instruction_fetch_ports;
+  icache.prefetchb =
+      new ArrayST(&interface_ip, "icacheprefetchBuffer", Core_device,
+                  coredynp.opt_local, coredynp.core_ty);
+  icache.area.set_area(icache.area.get_area() +
+                       icache.prefetchb->local_result.area);
+  area.set_area(area.get_area() + icache.prefetchb->local_result.area);
+  // output_data_csv(icache.prefetchb.local_result);
 
-	  //prefetch buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries to decide wthether to merge.
-	  data							   = icache.caches->l_ip.line_sz;//separate queue to prevent from cache polution.
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-	  interface_ip.cache_sz            = XML->sys.core[ithCore].icache.buffer_sizes[2]*interface_ip.line_sz;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 0;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].icache.icache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].icache.icache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].number_instruction_fetch_ports;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  interface_ip.num_search_ports = XML->sys.core[ithCore].number_instruction_fetch_ports;
-	  icache.prefetchb = new ArrayST(&interface_ip, "icacheprefetchBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  icache.area.set_area(icache.area.get_area()+ icache.prefetchb->local_result.area);
-	  area.set_area(area.get_area()+ icache.prefetchb->local_result.area);
-	  //output_data_csv(icache.prefetchb.local_result);
+  // Instruction buffer
+  data =
+      XML->sys.core[ithCore].instruction_length *
+      XML->sys.core[ithCore]
+          .peak_issue_width;  // icache.caches.l_ip.line_sz; //multiple threads
+                              // timing sharing the instruction buffer.
+  interface_ip.is_cache = false;
+  interface_ip.pure_ram = true;
+  interface_ip.pure_cam = false;
+  interface_ip.line_sz = int(ceil(data / 8.0));
+  interface_ip.cache_sz =
+      XML->sys.core[ithCore].number_hardware_threads *
+                  XML->sys.core[ithCore].instruction_buffer_size *
+                  interface_ip.line_sz >
+              64
+          ? XML->sys.core[ithCore].number_hardware_threads *
+                XML->sys.core[ithCore].instruction_buffer_size *
+                interface_ip.line_sz
+          : 64;
+  interface_ip.assoc = 1;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 0;
+  interface_ip.throughput = 1.0 / clockRate;
+  interface_ip.latency = 1.0 / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  // NOTE: Assuming IB is time slice shared among threads, every fetch op will
+  // at least fetch "fetch width" instructions.
+  interface_ip.num_rw_ports =
+      debug
+          ? 1
+          : XML->sys.core[ithCore]
+                .number_instruction_fetch_ports;  // XML->sys.core[ithCore].fetch_width;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  IB = new ArrayST(&interface_ip, "InstBuffer", Core_device, coredynp.opt_local,
+                   coredynp.core_ty);
+  IB->area.set_area(IB->area.get_area() + IB->local_result.area);
+  area.set_area(area.get_area() + IB->local_result.area);
+  // output_data_csv(IB.IB.local_result);
 
-	  //Instruction buffer
-	  data							   = XML->sys.core[ithCore].instruction_length*XML->sys.core[ithCore].peak_issue_width;//icache.caches.l_ip.line_sz; //multiple threads timing sharing the instruction buffer.
-	  interface_ip.is_cache			   = false;
-	  interface_ip.pure_ram            = true;
-	  interface_ip.pure_cam            = false;
-	  interface_ip.line_sz             = int(ceil(data/8.0));
-	  interface_ip.cache_sz            = XML->sys.core[ithCore].number_hardware_threads*XML->sys.core[ithCore].instruction_buffer_size*interface_ip.line_sz>64?
-			                             XML->sys.core[ithCore].number_hardware_threads*XML->sys.core[ithCore].instruction_buffer_size*interface_ip.line_sz:64;
-	  interface_ip.assoc               = 1;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 0;
-	  interface_ip.throughput          = 1.0/clockRate;
-	  interface_ip.latency             = 1.0/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  //NOTE: Assuming IB is time slice shared among threads, every fetch op will at least fetch "fetch width" instructions.
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].number_instruction_fetch_ports;//XML->sys.core[ithCore].fetch_width;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  IB = new ArrayST(&interface_ip, "InstBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  IB->area.set_area(IB->area.get_area()+ IB->local_result.area);
-	  area.set_area(area.get_area()+ IB->local_result.area);
-	  //output_data_csv(IB.IB.local_result);
+  //	  inst_decoder.opcode_length = XML->sys.core[ithCore].opcode_width;
+  //	  inst_decoder.init_decoder(is_default, &interface_ip);
+  //	  inst_decoder.full_decoder_power();
 
-	  //	  inst_decoder.opcode_length = XML->sys.core[ithCore].opcode_width;
-	  //	  inst_decoder.init_decoder(is_default, &interface_ip);
-	  //	  inst_decoder.full_decoder_power();
+  if (coredynp.predictionW > 0) {
+    /*
+     * BTB branch target buffer, accessed during IF stage. Virtually indexed and
+     * virtually tagged It is only a cache without all the buffers in the cache
+     * controller since it is more like a look up table than a cache with cache
+     * controller. When access miss, no load from other places such as main
+     * memory (not actively fill the misses), it is passively updated under two
+     * circumstances: 1)  when BPT@ID stage finds out current is a taken branch
+     * while BTB missed 2)  When BPT@ID stage predicts differently than BTB 3)
+     * When ID stage finds out current instruction is not a branch while BTB had
+     * a hit.(mark as invalid) 4)  when EXEU find out wrong target has been
+     * provided from BTB.
+     *
+     */
+    size = XML->sys.core[ithCore].BTB.BTB_config[0];
+    line = XML->sys.core[ithCore].BTB.BTB_config[1];
+    assoc = XML->sys.core[ithCore].BTB.BTB_config[2];
+    banks = XML->sys.core[ithCore].BTB.BTB_config[3];
+    idx = debug ? 9 : int(ceil(log2(size / line / assoc)));
+    //    	  tag							   =
+    //    debug?51:XML->sys.virtual_address_width-idx-int(ceil(log2(line))) +
+    //    int(ceil(log2(XML->sys.core[ithCore].number_hardware_threads)))
+    //    +EXTRA_TAG_BITS;
+    tag = debug ? 51
+                : XML->sys.virtual_address_width +
+                      int(ceil(log2(
+                          XML->sys.core[ithCore].number_hardware_threads))) +
+                      EXTRA_TAG_BITS;
+    interface_ip.is_cache = true;
+    interface_ip.pure_ram = false;
+    interface_ip.pure_cam = false;
+    interface_ip.specific_tag = 1;
+    interface_ip.tag_w = tag;
+    interface_ip.cache_sz = debug ? 32768 : size;
+    interface_ip.line_sz = debug ? 64 : line;
+    interface_ip.assoc = debug ? 8 : assoc;
+    interface_ip.nbanks = debug ? 1 : banks;
+    interface_ip.out_w = interface_ip.line_sz * 8;
+    interface_ip.access_mode =
+        0;  // debug?0:XML->sys.core[ithCore].dcache.dcache_config[5];
+    interface_ip.throughput =
+        debug ? 1.0 / clockRate
+              : XML->sys.core[ithCore].BTB.BTB_config[4] / clockRate;
+    interface_ip.latency =
+        debug ? 3.0 / clockRate
+              : XML->sys.core[ithCore].BTB.BTB_config[5] / clockRate;
+    interface_ip.obj_func_dyn_energy = 0;
+    interface_ip.obj_func_dyn_power = 0;
+    interface_ip.obj_func_leak_power = 0;
+    interface_ip.obj_func_cycle_t = 1;
+    interface_ip.num_rw_ports = 1;
+    interface_ip.num_rd_ports = coredynp.predictionW;
+    interface_ip.num_wr_ports = coredynp.predictionW;
+    interface_ip.num_se_rd_ports = 0;
+    BTB = new ArrayST(&interface_ip, "Branch Target Buffer", Core_device,
+                      coredynp.opt_local, coredynp.core_ty);
+    BTB->area.set_area(BTB->area.get_area() + BTB->local_result.area);
+    area.set_area(area.get_area() + BTB->local_result.area);
+    /// cout<<"area="<<area<<endl;
 
-      if (coredynp.predictionW>0)
-      {
-    	  /*
-    	   * BTB branch target buffer, accessed during IF stage. Virtually indexed and virtually tagged
-    	   * It is only a cache without all the buffers in the cache controller since it is more like a
-    	   * look up table than a cache with cache controller. When access miss, no load from other places
-    	   * such as main memory (not actively fill the misses), it is passively updated under two circumstances:
-    	   * 1)  when BPT@ID stage finds out current is a taken branch while BTB missed
-    	   * 2)  When BPT@ID stage predicts differently than BTB
-    	   * 3)  When ID stage finds out current instruction is not a branch while BTB had a hit.(mark as invalid)
-    	   * 4)  when EXEU find out wrong target has been provided from BTB.
-    	   *
-    	   */
-    	  size                             = XML->sys.core[ithCore].BTB.BTB_config[0];
-    	  line                             = XML->sys.core[ithCore].BTB.BTB_config[1];
-    	  assoc                            = XML->sys.core[ithCore].BTB.BTB_config[2];
-    	  banks                            = XML->sys.core[ithCore].BTB.BTB_config[3];
-    	  idx    					 	   = debug?9:int(ceil(log2(size/line/assoc)));
-//    	  tag							   = debug?51:XML->sys.virtual_address_width-idx-int(ceil(log2(line))) + int(ceil(log2(XML->sys.core[ithCore].number_hardware_threads))) +EXTRA_TAG_BITS;
-    	  tag							   = debug?51:XML->sys.virtual_address_width + int(ceil(log2(XML->sys.core[ithCore].number_hardware_threads))) +EXTRA_TAG_BITS;
-    	  interface_ip.is_cache			   = true;
-    	  interface_ip.pure_ram            = false;
-    	  interface_ip.pure_cam            = false;
-    	  interface_ip.specific_tag        = 1;
-    	  interface_ip.tag_w               = tag;
-    	  interface_ip.cache_sz            = debug?32768:size;
-    	  interface_ip.line_sz             = debug?64:line;
-    	  interface_ip.assoc               = debug?8:assoc;
-    	  interface_ip.nbanks              = debug?1:banks;
-    	  interface_ip.out_w               = interface_ip.line_sz*8;
-    	  interface_ip.access_mode         = 0;//debug?0:XML->sys.core[ithCore].dcache.dcache_config[5];
-    	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].BTB.BTB_config[4]/clockRate;
-    	  interface_ip.latency             = debug?3.0/clockRate:XML->sys.core[ithCore].BTB.BTB_config[5]/clockRate;
-    	  interface_ip.obj_func_dyn_energy = 0;
-    	  interface_ip.obj_func_dyn_power  = 0;
-    	  interface_ip.obj_func_leak_power = 0;
-    	  interface_ip.obj_func_cycle_t    = 1;
-    	  interface_ip.num_rw_ports    = 1;
-    	  interface_ip.num_rd_ports    = coredynp.predictionW;
-    	  interface_ip.num_wr_ports    = coredynp.predictionW;
-    	  interface_ip.num_se_rd_ports = 0;
-    	  BTB = new ArrayST(&interface_ip, "Branch Target Buffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-    	  BTB->area.set_area(BTB->area.get_area()+ BTB->local_result.area);
-    	  area.set_area(area.get_area()+ BTB->local_result.area);
-    	  ///cout<<"area="<<area<<endl;
+    BPT = new BranchPredictor(XML, ithCore, &interface_ip, coredynp);
+    area.set_area(area.get_area() + BPT->area.get_area());
+  }
 
-    	  BPT = new BranchPredictor(XML, ithCore, &interface_ip,coredynp);
-    	  area.set_area(area.get_area()+ BPT->area.get_area());
-      }
+  ID_inst = new inst_decoder(is_default, &interface_ip, coredynp.opcode_length,
+                             1 /*Decoder should not know how many by itself*/,
+                             coredynp.x86, Core_device, coredynp.core_ty);
 
-      ID_inst = new inst_decoder(is_default, &interface_ip,
-    		  coredynp.opcode_length, 1/*Decoder should not know how many by itself*/,
-    		  coredynp.x86,
-    		  Core_device, coredynp.core_ty);
+  ID_operand =
+      new inst_decoder(is_default, &interface_ip, coredynp.arch_ireg_width, 1,
+                       coredynp.x86, Core_device, coredynp.core_ty);
 
-      ID_operand = new inst_decoder(is_default, &interface_ip,
-    		  coredynp.arch_ireg_width, 1,
-    		  coredynp.x86,
-    		  Core_device, coredynp.core_ty);
-
-      ID_misc = new inst_decoder(is_default, &interface_ip,
-    		  8/* Prefix field etc upto 14B*/, 1,
-    		  coredynp.x86,
-    		  Core_device, coredynp.core_ty);
-      //TODO: X86 decoder should decode the inst in cyclic mode under the control of squencer.
-      //So the dynamic power should be multiplied by a few times.
-      area.set_area(area.get_area()+ (ID_inst->area.get_area()
-    		  +ID_operand->area.get_area()
-    		  +ID_misc->area.get_area())*coredynp.decodeW);
-
+  ID_misc = new inst_decoder(is_default, &interface_ip,
+                             8 /* Prefix field etc upto 14B*/, 1, coredynp.x86,
+                             Core_device, coredynp.core_ty);
+  // TODO: X86 decoder should decode the inst in cyclic mode under the control
+  // of squencer. So the dynamic power should be multiplied by a few times.
+  area.set_area(area.get_area() +
+                (ID_inst->area.get_area() + ID_operand->area.get_area() +
+                 ID_misc->area.get_area()) *
+                    coredynp.decodeW);
 }
 
+BranchPredictor::BranchPredictor(ParseXML* XML_interface, int ithCore_,
+                                 InputParameter* interface_ip_,
+                                 const CoreDynParam& dyn_p_, bool exist_)
+    : XML(XML_interface),
+      ithCore(ithCore_),
+      interface_ip(*interface_ip_),
+      coredynp(dyn_p_),
+      globalBPT(0),
+      localBPT(0),
+      L1_localBPT(0),
+      L2_localBPT(0),
+      chooser(0),
+      RAS(0),
+      exist(exist_) {
+  /*
+   * Branch Predictor, accessed during ID stage.
+   * McPAT's branch predictor model is the tournament branch predictor used in
+   * Alpha 21264, including global predictor, local two level predictor, and
+   * Chooser. The Branch predictor also includes a RAS (return address stack)
+   * for function calls Branch predictors are tagged by thread ID and modeled as
+   * 1-way associative $ However RAS return address stacks are duplicated for
+   * each thread.
+   * TODO:Data Width need to be computed more precisely	 *
+   */
+  if (!exist) return;
+  int tag, data;
 
-BranchPredictor::BranchPredictor(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_, bool exist_)
-:XML(XML_interface),
- ithCore(ithCore_),
- interface_ip(*interface_ip_),
- coredynp(dyn_p_),
- globalBPT(0),
- localBPT(0),
- L1_localBPT(0),
- L2_localBPT(0),
- chooser(0),
- RAS(0),
- exist(exist_)
-{
-	/*
-	 * Branch Predictor, accessed during ID stage.
-	 * McPAT's branch predictor model is the tournament branch predictor used in Alpha 21264,
-	 * including global predictor, local two level predictor, and Chooser.
-	 * The Branch predictor also includes a RAS (return address stack) for function calls
-	 * Branch predictors are tagged by thread ID and modeled as 1-way associative $
-	 * However RAS return address stacks are duplicated for each thread.
-	 * TODO:Data Width need to be computed more precisely	 *
-	 */
-	if (!exist) return;
-	int  tag, data;
+  clockRate = coredynp.clockRate;
+  executionTime = coredynp.executionTime;
+  interface_ip.assoc = 1;
+  interface_ip.pure_cam = false;
+  if (coredynp.multithreaded) {
+    tag = int(log2(coredynp.num_hthreads) + EXTRA_TAG_BITS);
+    interface_ip.specific_tag = 1;
+    interface_ip.tag_w = tag;
 
-	clockRate = coredynp.clockRate;
-	executionTime = coredynp.executionTime;
-	interface_ip.assoc               = 1;
-	interface_ip.pure_cam            = false;
-	if (coredynp.multithreaded)
-	{
+    interface_ip.is_cache = true;
+    interface_ip.pure_ram = false;
+  } else {
+    interface_ip.is_cache = false;
+    interface_ip.pure_ram = true;
+  }
+  // Global predictor
+  data =
+      int(ceil(XML->sys.core[ithCore].predictor.global_predictor_bits / 8.0));
+  interface_ip.line_sz = data;
+  interface_ip.cache_sz =
+      data * XML->sys.core[ithCore].predictor.global_predictor_entries;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput = 1.0 / clockRate;
+  interface_ip.latency = 1.0 / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = 0;
+  interface_ip.num_rd_ports = coredynp.predictionW;
+  interface_ip.num_wr_ports = coredynp.predictionW;
+  interface_ip.num_se_rd_ports = 0;
+  globalBPT = new ArrayST(&interface_ip, "Global Predictor", Core_device,
+                          coredynp.opt_local, coredynp.core_ty);
+  globalBPT->area.set_area(globalBPT->area.get_area() +
+                           globalBPT->local_result.area);
+  area.set_area(area.get_area() + globalBPT->local_result.area);
 
-		tag							     = int(log2(coredynp.num_hthreads)+ EXTRA_TAG_BITS);
-		interface_ip.specific_tag        = 1;
-		interface_ip.tag_w               = tag;
+  // Local BPT (Level 1)
+  data =
+      int(ceil(XML->sys.core[ithCore].predictor.local_predictor_size[0] / 8.0));
+  interface_ip.line_sz = data;
+  interface_ip.cache_sz =
+      data * XML->sys.core[ithCore].predictor.local_predictor_entries;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput = 1.0 / clockRate;
+  interface_ip.latency = 1.0 / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = 0;
+  interface_ip.num_rd_ports = coredynp.predictionW;
+  interface_ip.num_wr_ports = coredynp.predictionW;
+  interface_ip.num_se_rd_ports = 0;
+  L1_localBPT = new ArrayST(&interface_ip, "L1 local Predictor", Core_device,
+                            coredynp.opt_local, coredynp.core_ty);
+  L1_localBPT->area.set_area(L1_localBPT->area.get_area() +
+                             L1_localBPT->local_result.area);
+  area.set_area(area.get_area() + L1_localBPT->local_result.area);
 
-		interface_ip.is_cache			 = true;
-		interface_ip.pure_ram            = false;
-		}
-	else
-	{
-		interface_ip.is_cache			 = false;
-		interface_ip.pure_ram            = true;
+  // Local BPT (Level 2)
+  data =
+      int(ceil(XML->sys.core[ithCore].predictor.local_predictor_size[1] / 8.0));
+  interface_ip.line_sz = data;
+  interface_ip.cache_sz =
+      data * XML->sys.core[ithCore].predictor.local_predictor_entries;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput = 1.0 / clockRate;
+  interface_ip.latency = 1.0 / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = 0;
+  interface_ip.num_rd_ports = coredynp.predictionW;
+  interface_ip.num_wr_ports = coredynp.predictionW;
+  interface_ip.num_se_rd_ports = 0;
+  L2_localBPT = new ArrayST(&interface_ip, "L2 local Predictor", Core_device,
+                            coredynp.opt_local, coredynp.core_ty);
+  L2_localBPT->area.set_area(L2_localBPT->area.get_area() +
+                             L2_localBPT->local_result.area);
+  area.set_area(area.get_area() + L2_localBPT->local_result.area);
 
-	}
-	//Global predictor
-	data							 = int(ceil(XML->sys.core[ithCore].predictor.global_predictor_bits/8.0));
-	interface_ip.line_sz             = data;
-	interface_ip.cache_sz            = data*XML->sys.core[ithCore].predictor.global_predictor_entries;
-	interface_ip.nbanks              = 1;
-	interface_ip.out_w               = interface_ip.line_sz*8;
-	interface_ip.access_mode         = 2;
-	interface_ip.throughput          = 1.0/clockRate;
-	interface_ip.latency             = 1.0/clockRate;
-	interface_ip.obj_func_dyn_energy = 0;
-	interface_ip.obj_func_dyn_power  = 0;
-	interface_ip.obj_func_leak_power = 0;
-	interface_ip.obj_func_cycle_t    = 1;
-	interface_ip.num_rw_ports    = 0;
-	interface_ip.num_rd_ports    = coredynp.predictionW;
-	interface_ip.num_wr_ports    = coredynp.predictionW;
-	interface_ip.num_se_rd_ports = 0;
-	globalBPT = new ArrayST(&interface_ip, "Global Predictor", Core_device, coredynp.opt_local, coredynp.core_ty);
-	globalBPT->area.set_area(globalBPT->area.get_area()+ globalBPT->local_result.area);
-	area.set_area(area.get_area()+ globalBPT->local_result.area);
+  // Chooser
+  data =
+      int(ceil(XML->sys.core[ithCore].predictor.chooser_predictor_bits / 8.0));
+  interface_ip.line_sz = data;
+  interface_ip.cache_sz =
+      data * XML->sys.core[ithCore].predictor.chooser_predictor_entries;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput = 1.0 / clockRate;
+  interface_ip.latency = 1.0 / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = 0;
+  interface_ip.num_rd_ports = coredynp.predictionW;
+  interface_ip.num_wr_ports = coredynp.predictionW;
+  interface_ip.num_se_rd_ports = 0;
+  chooser = new ArrayST(&interface_ip, "Predictor Chooser", Core_device,
+                        coredynp.opt_local, coredynp.core_ty);
+  chooser->area.set_area(chooser->area.get_area() + chooser->local_result.area);
+  area.set_area(area.get_area() + chooser->local_result.area);
 
-	//Local BPT (Level 1)
-	data							 = int(ceil(XML->sys.core[ithCore].predictor.local_predictor_size[0]/8.0));
-	interface_ip.line_sz             = data;
-	interface_ip.cache_sz            = data*XML->sys.core[ithCore].predictor.local_predictor_entries;
-	interface_ip.nbanks              = 1;
-	interface_ip.out_w               = interface_ip.line_sz*8;
-	interface_ip.access_mode         = 2;
-	interface_ip.throughput          = 1.0/clockRate;
-	interface_ip.latency             = 1.0/clockRate;
-	interface_ip.obj_func_dyn_energy = 0;
-	interface_ip.obj_func_dyn_power  = 0;
-	interface_ip.obj_func_leak_power = 0;
-	interface_ip.obj_func_cycle_t    = 1;
-	interface_ip.num_rw_ports    = 0;
-	interface_ip.num_rd_ports    = coredynp.predictionW;
-	interface_ip.num_wr_ports    = coredynp.predictionW;
-	interface_ip.num_se_rd_ports = 0;
-	L1_localBPT = new ArrayST(&interface_ip, "L1 local Predictor", Core_device, coredynp.opt_local, coredynp.core_ty);
-	L1_localBPT->area.set_area(L1_localBPT->area.get_area()+ L1_localBPT->local_result.area);
-	area.set_area(area.get_area()+ L1_localBPT->local_result.area);
-
-	//Local BPT (Level 2)
-	data							 = int(ceil(XML->sys.core[ithCore].predictor.local_predictor_size[1]/8.0));
-	interface_ip.line_sz             = data;
-	interface_ip.cache_sz            = data*XML->sys.core[ithCore].predictor.local_predictor_entries;
-	interface_ip.nbanks              = 1;
-	interface_ip.out_w               = interface_ip.line_sz*8;
-	interface_ip.access_mode         = 2;
-	interface_ip.throughput          = 1.0/clockRate;
-	interface_ip.latency             = 1.0/clockRate;
-	interface_ip.obj_func_dyn_energy = 0;
-	interface_ip.obj_func_dyn_power  = 0;
-	interface_ip.obj_func_leak_power = 0;
-	interface_ip.obj_func_cycle_t    = 1;
-	interface_ip.num_rw_ports    = 0;
-	interface_ip.num_rd_ports    = coredynp.predictionW;
-	interface_ip.num_wr_ports    = coredynp.predictionW;
-	interface_ip.num_se_rd_ports = 0;
-	L2_localBPT = new ArrayST(&interface_ip, "L2 local Predictor", Core_device, coredynp.opt_local, coredynp.core_ty);
-	L2_localBPT->area.set_area(L2_localBPT->area.get_area()+ L2_localBPT->local_result.area);
-	area.set_area(area.get_area()+ L2_localBPT->local_result.area);
-
-	//Chooser
-	data							 = int(ceil(XML->sys.core[ithCore].predictor.chooser_predictor_bits/8.0));
-	interface_ip.line_sz             = data;
-	interface_ip.cache_sz            = data*XML->sys.core[ithCore].predictor.chooser_predictor_entries;
-	interface_ip.nbanks              = 1;
-	interface_ip.out_w               = interface_ip.line_sz*8;
-	interface_ip.access_mode         = 2;
-	interface_ip.throughput          = 1.0/clockRate;
-	interface_ip.latency             = 1.0/clockRate;
-	interface_ip.obj_func_dyn_energy = 0;
-	interface_ip.obj_func_dyn_power  = 0;
-	interface_ip.obj_func_leak_power = 0;
-	interface_ip.obj_func_cycle_t    = 1;
-	interface_ip.num_rw_ports    = 0;
-	interface_ip.num_rd_ports    = coredynp.predictionW;
-	interface_ip.num_wr_ports    = coredynp.predictionW;
-	interface_ip.num_se_rd_ports = 0;
-	chooser = new ArrayST(&interface_ip, "Predictor Chooser", Core_device, coredynp.opt_local, coredynp.core_ty);
-	chooser->area.set_area(chooser->area.get_area()+ chooser->local_result.area);
-	area.set_area(area.get_area()+ chooser->local_result.area);
-
-	//RAS return address stacks are Duplicated for each thread.
-	interface_ip.is_cache			 = false;
-	interface_ip.pure_ram            = true;
-	data							 = int(ceil(coredynp.pc_width/8.0));
-	interface_ip.line_sz             = data;
-	interface_ip.cache_sz            = data*XML->sys.core[ithCore].RAS_size;
-	interface_ip.assoc               = 1;
-	interface_ip.nbanks              = 1;
-	interface_ip.out_w               = interface_ip.line_sz*8;
-	interface_ip.access_mode         = 2;
-	interface_ip.throughput          = 1.0/clockRate;
-	interface_ip.latency             = 1.0/clockRate;
-	interface_ip.obj_func_dyn_energy = 0;
-	interface_ip.obj_func_dyn_power  = 0;
-	interface_ip.obj_func_leak_power = 0;
-	interface_ip.obj_func_cycle_t    = 1;
-	interface_ip.num_rw_ports    = 0;
-	interface_ip.num_rd_ports    = coredynp.predictionW;
-	interface_ip.num_wr_ports    = coredynp.predictionW;
-	interface_ip.num_se_rd_ports = 0;
-	RAS = new ArrayST(&interface_ip, "RAS", Core_device, coredynp.opt_local, coredynp.core_ty);
-	RAS->area.set_area(RAS->area.get_area()+ RAS->local_result.area*coredynp.num_hthreads);
-	area.set_area(area.get_area()+ RAS->local_result.area*coredynp.num_hthreads);
-
+  // RAS return address stacks are Duplicated for each thread.
+  interface_ip.is_cache = false;
+  interface_ip.pure_ram = true;
+  data = int(ceil(coredynp.pc_width / 8.0));
+  interface_ip.line_sz = data;
+  interface_ip.cache_sz = data * XML->sys.core[ithCore].RAS_size;
+  interface_ip.assoc = 1;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput = 1.0 / clockRate;
+  interface_ip.latency = 1.0 / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = 0;
+  interface_ip.num_rd_ports = coredynp.predictionW;
+  interface_ip.num_wr_ports = coredynp.predictionW;
+  interface_ip.num_se_rd_ports = 0;
+  RAS = new ArrayST(&interface_ip, "RAS", Core_device, coredynp.opt_local,
+                    coredynp.core_ty);
+  RAS->area.set_area(RAS->area.get_area() +
+                     RAS->local_result.area * coredynp.num_hthreads);
+  area.set_area(area.get_area() +
+                RAS->local_result.area * coredynp.num_hthreads);
 }
 
-SchedulerU::SchedulerU(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_, bool exist_)
-:XML(XML_interface),
- ithCore(ithCore_),
- interface_ip(*interface_ip_),
- coredynp(dyn_p_),
- int_inst_window(0),
- fp_inst_window(0),
- ROB(0),
- instruction_selection(0),
- exist(exist_)
- {
-	if (!exist) return;
-	int   tag, data;
-	bool  is_default=true;
-	string tmp_name;
+SchedulerU::SchedulerU(ParseXML* XML_interface, int ithCore_,
+                       InputParameter* interface_ip_,
+                       const CoreDynParam& dyn_p_, bool exist_)
+    : XML(XML_interface),
+      ithCore(ithCore_),
+      interface_ip(*interface_ip_),
+      coredynp(dyn_p_),
+      int_inst_window(0),
+      fp_inst_window(0),
+      ROB(0),
+      instruction_selection(0),
+      exist(exist_) {
+  if (!exist) return;
+  int tag, data;
+  bool is_default = true;
+  string tmp_name;
 
-	clockRate = coredynp.clockRate;
-	executionTime = coredynp.executionTime;
-	if ((coredynp.core_ty==Inorder && coredynp.multithreaded))
-	{
-		//Instruction issue queue, in-order multi-issue or multithreaded processor also has this structure. Unified window for Inorder processors
-		tag							     = int(log2(XML->sys.core[ithCore].number_hardware_threads)*coredynp.perThreadState);//This is the normal thread state bits based on Niagara Design
-		data							 = XML->sys.core[ithCore].instruction_length;
-		//NOTE: x86 inst can be very lengthy, up to 15B. Source: Intel® 64 and IA-32 Architectures
-		//Software Developer’s Manual
-		interface_ip.is_cache			 = true;
-		interface_ip.pure_cam            = false;
-		interface_ip.pure_ram            = false;
-		interface_ip.line_sz             = int(ceil(data/8.0));
-		interface_ip.specific_tag        = 1;
-		interface_ip.tag_w               = tag;
-		interface_ip.cache_sz            = XML->sys.core[ithCore].instruction_window_size*interface_ip.line_sz>64?XML->sys.core[ithCore].instruction_window_size*interface_ip.line_sz:64;
-		interface_ip.assoc               = 0;
-		interface_ip.nbanks              = 1;
-		interface_ip.out_w               = interface_ip.line_sz*8;
-		interface_ip.access_mode         = 1;
-		interface_ip.throughput          = 1.0/clockRate;
-		interface_ip.latency             = 1.0/clockRate;
-		interface_ip.obj_func_dyn_energy = 0;
-		interface_ip.obj_func_dyn_power  = 0;
-		interface_ip.obj_func_leak_power = 0;
-		interface_ip.obj_func_cycle_t    = 1;
-		interface_ip.num_rw_ports        = 0;
-		interface_ip.num_rd_ports        = coredynp.peak_issueW;
-		interface_ip.num_wr_ports        = coredynp.peak_issueW;
-		interface_ip.num_se_rd_ports     = 0;
-		interface_ip.num_search_ports    = coredynp.peak_issueW;
-		int_inst_window = new ArrayST(&interface_ip, "InstFetchQueue", Core_device, coredynp.opt_local, coredynp.core_ty);
-		int_inst_window->area.set_area(int_inst_window->area.get_area()+ int_inst_window->local_result.area*coredynp.num_pipelines);
-		area.set_area(area.get_area()+ int_inst_window->local_result.area*coredynp.num_pipelines);
-		//output_data_csv(iRS.RS.local_result);
-		Iw_height      =int_inst_window->local_result.cache_ht;
+  clockRate = coredynp.clockRate;
+  executionTime = coredynp.executionTime;
+  if ((coredynp.core_ty == Inorder && coredynp.multithreaded)) {
+    // Instruction issue queue, in-order multi-issue or multithreaded processor
+    // also has this structure. Unified window for Inorder processors
+    tag = int(log2(XML->sys.core[ithCore].number_hardware_threads) *
+              coredynp.perThreadState);  // This is the normal thread state bits
+                                         // based on Niagara Design
+    data = XML->sys.core[ithCore].instruction_length;
+    // NOTE: x86 inst can be very lengthy, up to 15B. Source: Intel® 64 and
+    // IA-32 Architectures Software Developer’s Manual
+    interface_ip.is_cache = true;
+    interface_ip.pure_cam = false;
+    interface_ip.pure_ram = false;
+    interface_ip.line_sz = int(ceil(data / 8.0));
+    interface_ip.specific_tag = 1;
+    interface_ip.tag_w = tag;
+    interface_ip.cache_sz =
+        XML->sys.core[ithCore].instruction_window_size * interface_ip.line_sz >
+                64
+            ? XML->sys.core[ithCore].instruction_window_size *
+                  interface_ip.line_sz
+            : 64;
+    interface_ip.assoc = 0;
+    interface_ip.nbanks = 1;
+    interface_ip.out_w = interface_ip.line_sz * 8;
+    interface_ip.access_mode = 1;
+    interface_ip.throughput = 1.0 / clockRate;
+    interface_ip.latency = 1.0 / clockRate;
+    interface_ip.obj_func_dyn_energy = 0;
+    interface_ip.obj_func_dyn_power = 0;
+    interface_ip.obj_func_leak_power = 0;
+    interface_ip.obj_func_cycle_t = 1;
+    interface_ip.num_rw_ports = 0;
+    interface_ip.num_rd_ports = coredynp.peak_issueW;
+    interface_ip.num_wr_ports = coredynp.peak_issueW;
+    interface_ip.num_se_rd_ports = 0;
+    interface_ip.num_search_ports = coredynp.peak_issueW;
+    int_inst_window = new ArrayST(&interface_ip, "InstFetchQueue", Core_device,
+                                  coredynp.opt_local, coredynp.core_ty);
+    int_inst_window->area.set_area(int_inst_window->area.get_area() +
+                                   int_inst_window->local_result.area *
+                                       coredynp.num_pipelines);
+    area.set_area(area.get_area() +
+                  int_inst_window->local_result.area * coredynp.num_pipelines);
+    // output_data_csv(iRS.RS.local_result);
+    Iw_height = int_inst_window->local_result.cache_ht;
 
-		/*
-		 * selection logic
-		 * In a single-issue Inorder multithreaded processor like Niagara, issue width=1*number_of_threads since the processor does need to pick up
-		 * instructions from multiple ready ones(although these ready ones are from different threads).While SMT processors do not distinguish which thread belongs to who
-		 * at the issue stage.
-		 */
+    /*
+     * selection logic
+     * In a single-issue Inorder multithreaded processor like Niagara, issue
+     * width=1*number_of_threads since the processor does need to pick up
+     * instructions from multiple ready ones(although these ready ones are from
+     * different threads).While SMT processors do not distinguish which thread
+     * belongs to who at the issue stage.
+     */
 
-		instruction_selection = new selection_logic(is_default, XML->sys.core[ithCore].instruction_window_size,
-				coredynp.peak_issueW*XML->sys.core[ithCore].number_hardware_threads,
-				&interface_ip, Core_device, coredynp.core_ty);
-	}
+    instruction_selection = new selection_logic(
+        is_default, XML->sys.core[ithCore].instruction_window_size,
+        coredynp.peak_issueW * XML->sys.core[ithCore].number_hardware_threads,
+        &interface_ip, Core_device, coredynp.core_ty);
+  }
 
-    if (coredynp.core_ty==OOO)
-    {
-    	/*
-    	 * CAM based instruction window
-    	 * For physicalRegFilebased OOO it is the instruction issue queue, where only tags of phy regs are stored
-    	 * For RS based OOO it is the Reservation station, where both tags and values of phy regs are stored
-    	 * It is written once and read twice(two operands) before an instruction can be issued.
-    	 * X86 instruction can be very long up to 15B. add instruction length in XML
-    	 */
-    	if(coredynp.scheu_ty==PhysicalRegFile)
-    	{
-    		tag	 = coredynp.phy_ireg_width;
-    		// Each time only half of the tag is compared, but two tag should be stored.
-    		// This underestimate the search power
-    		data = int((ceil((coredynp.instruction_length+2*(coredynp.phy_ireg_width - coredynp.arch_ireg_width))/2.0)/8.0));
-	        //Data width being divided by 2 means only after both operands available the whole data will be read out.
-	        //This is modeled using two equivalent readouts with half of the data width
-    		tmp_name = "InstIssueQueue";
-    	}
-    	else
-    	{
-	        tag	  = coredynp.phy_ireg_width;
-    		// Each time only half of the tag is compared, but two tag should be stored.
-    		// This underestimate the search power
-	        data  = int(ceil(((coredynp.instruction_length+2*(coredynp.phy_ireg_width - coredynp.arch_ireg_width)+
-	        		2*coredynp.int_data_width)/2.0)/8.0));
-	        //Data width being divided by 2 means only after both operands available the whole data will be read out.
-	        //This is modeled using two equivalent readouts with half of the data width
+  if (coredynp.core_ty == OOO) {
+    /*
+     * CAM based instruction window
+     * For physicalRegFilebased OOO it is the instruction issue queue, where
+     * only tags of phy regs are stored For RS based OOO it is the Reservation
+     * station, where both tags and values of phy regs are stored It is written
+     * once and read twice(two operands) before an instruction can be issued.
+     * X86 instruction can be very long up to 15B. add instruction length in XML
+     */
+    if (coredynp.scheu_ty == PhysicalRegFile) {
+      tag = coredynp.phy_ireg_width;
+      // Each time only half of the tag is compared, but two tag should be
+      // stored. This underestimate the search power
+      data =
+          int((ceil((coredynp.instruction_length +
+                     2 * (coredynp.phy_ireg_width - coredynp.arch_ireg_width)) /
+                    2.0) /
+               8.0));
+      // Data width being divided by 2 means only after both operands available
+      // the whole data will be read out. This is modeled using two equivalent
+      // readouts with half of the data width
+      tmp_name = "InstIssueQueue";
+    } else {
+      tag = coredynp.phy_ireg_width;
+      // Each time only half of the tag is compared, but two tag should be
+      // stored. This underestimate the search power
+      data =
+          int(ceil(((coredynp.instruction_length +
+                     2 * (coredynp.phy_ireg_width - coredynp.arch_ireg_width) +
+                     2 * coredynp.int_data_width) /
+                    2.0) /
+                   8.0));
+      // Data width being divided by 2 means only after both operands available
+      // the whole data will be read out. This is modeled using two equivalent
+      // readouts with half of the data width
 
-	        tmp_name = "IntReservationStation";
-    	}
-    	interface_ip.is_cache			 = true;
-    	interface_ip.pure_cam            = false;
-    	interface_ip.pure_ram            = false;
-    	interface_ip.line_sz             = data;
-    	interface_ip.cache_sz            = data*XML->sys.core[ithCore].instruction_window_size;
-    	interface_ip.assoc               = 0;
-    	interface_ip.nbanks              = 1;
-    	interface_ip.out_w               = interface_ip.line_sz*8;
-    	interface_ip.specific_tag        = 1;
-    	interface_ip.tag_w               = tag;
-    	interface_ip.access_mode         = 0;
-    	interface_ip.throughput          = 2*1.0/clockRate;
-    	interface_ip.latency             = 2*1.0/clockRate;
-    	interface_ip.obj_func_dyn_energy = 0;
-    	interface_ip.obj_func_dyn_power  = 0;
-    	interface_ip.obj_func_leak_power = 0;
-    	interface_ip.obj_func_cycle_t    = 1;
-    	interface_ip.num_rw_ports       = 0;
-    	interface_ip.num_rd_ports       = coredynp.peak_issueW;
-    	interface_ip.num_wr_ports       = coredynp.peak_issueW;
-    	interface_ip.num_se_rd_ports    = 0;
-		interface_ip.num_search_ports   = coredynp.peak_issueW;
-		int_inst_window = new ArrayST(&interface_ip, tmp_name, Core_device, coredynp.opt_local, coredynp.core_ty);
-		int_inst_window->area.set_area(int_inst_window->area.get_area()+ int_inst_window->local_result.area*coredynp.num_pipelines);
-		area.set_area(area.get_area()+ int_inst_window->local_result.area*coredynp.num_pipelines);
-		Iw_height      =int_inst_window->local_result.cache_ht;
-		//FU inst window
-    	if(coredynp.scheu_ty==PhysicalRegFile)
-    	{
-    		tag	 = 2*coredynp.phy_freg_width;// TODO: each time only half of the tag is compared
-    		data = int(ceil((coredynp.instruction_length+2*(coredynp.phy_freg_width - coredynp.arch_freg_width))/8.0));
-    		tmp_name = "FPIssueQueue";
-    	}
-    	else
-    	{
-	        tag	  = 2*coredynp.phy_ireg_width;
-	        data  = int(ceil((coredynp.instruction_length+2*(coredynp.phy_freg_width - coredynp.arch_freg_width)+
-	        		2*coredynp.fp_data_width)/8.0));
-	        tmp_name = "FPReservationStation";
-    	}
-    	interface_ip.is_cache			 = true;
-    	interface_ip.pure_cam            = false;
-    	interface_ip.pure_ram            = false;
-    	interface_ip.line_sz             = data;
-    	interface_ip.cache_sz            = data*XML->sys.core[ithCore].fp_instruction_window_size;
-    	interface_ip.assoc               = 0;
-    	interface_ip.nbanks              = 1;
-    	interface_ip.out_w               = interface_ip.line_sz*8;
-    	interface_ip.specific_tag        = 1;
-    	interface_ip.tag_w               = tag;
-    	interface_ip.access_mode         = 0;
-    	interface_ip.throughput          = 1.0/clockRate;
-    	interface_ip.latency             = 1.0/clockRate;
-    	interface_ip.obj_func_dyn_energy = 0;
-    	interface_ip.obj_func_dyn_power  = 0;
-    	interface_ip.obj_func_leak_power = 0;
-    	interface_ip.obj_func_cycle_t    = 1;
-    	interface_ip.num_rw_ports       = 0;
-    	interface_ip.num_rd_ports       = coredynp.fp_issueW;
-    	interface_ip.num_wr_ports       = coredynp.fp_issueW;
-    	interface_ip.num_se_rd_ports    = 0;
-		interface_ip.num_search_ports   = coredynp.fp_issueW;
-		fp_inst_window = new ArrayST(&interface_ip, tmp_name, Core_device, coredynp.opt_local, coredynp.core_ty);
-		fp_inst_window->area.set_area(fp_inst_window->area.get_area()+ fp_inst_window->local_result.area*coredynp.num_fp_pipelines);
-		area.set_area(area.get_area()+ fp_inst_window->local_result.area*coredynp.num_fp_pipelines);
-		fp_Iw_height      =fp_inst_window->local_result.cache_ht;
-
-		if (XML->sys.core[ithCore].ROB_size >0)
-		{
-			/*
-			 *  if ROB_size = 0, then the target processor does not support hardware-based
-			 *  speculation, i.e. , the processor allow OOO issue as well as OOO completion, which
-			 *  means branch must be resolved before instruction issued into instruction window, since
-			 *  there is no change to flush miss-predict branch path after instructions are issued in this situation.
-			 *
-			 *  ROB.ROB size = inflight inst. ROB is unified for int and fp inst.
-			 *  One old approach is to combine the RAT and ROB as a huge CAM structure as in AMD K7.
-			 *  However, this approach is abandoned due to its high power and poor scalablility.
-			 *	McPAT uses current implementation of ROB as circular buffer.
-			 *	ROB is written once when instruction is issued and read once when the instruction is committed.         *
-			 */
-			int robExtra = int(ceil(5 + log2(coredynp.num_hthreads)));
-			//5 bits are: busy, Issued, Finished, speculative, valid
-			if(coredynp.scheu_ty==PhysicalRegFile)
-			{
-				//PC is to id the instruction for recover exception.
-				//inst is used to map the renamed dest. registers.so that commit stage can know which reg/RRAT to update
-//				data = int(ceil((robExtra+coredynp.pc_width +
-//						coredynp.instruction_length + 2*coredynp.phy_ireg_width)/8.0));
-				data = int(ceil((robExtra+coredynp.pc_width +
-							coredynp.phy_ireg_width)/8.0));
-			}
-			else
-			{
-				//in RS based OOO, ROB also contains value of destination reg
-//				data  = int(ceil((robExtra+coredynp.pc_width +
-//						coredynp.instruction_length + 2*coredynp.phy_ireg_width + coredynp.fp_data_width)/8.0));
-				data  = int(ceil((robExtra + coredynp.pc_width +
-						coredynp.phy_ireg_width + coredynp.fp_data_width)/8.0));
-			}
-			interface_ip.is_cache			 = false;
-			interface_ip.pure_cam            = false;
-			interface_ip.pure_ram            = true;
-			interface_ip.line_sz             = data;
-			interface_ip.cache_sz            = data*XML->sys.core[ithCore].ROB_size;//The XML ROB size is for all threads
-			interface_ip.assoc               = 1;
-			interface_ip.nbanks              = 1;
-			interface_ip.out_w               = interface_ip.line_sz*8;
-			interface_ip.access_mode         = 1;
-			interface_ip.throughput          = 1.0/clockRate;
-			interface_ip.latency             = 1.0/clockRate;
-			interface_ip.obj_func_dyn_energy = 0;
-			interface_ip.obj_func_dyn_power  = 0;
-			interface_ip.obj_func_leak_power = 0;
-			interface_ip.obj_func_cycle_t    = 1;
-			interface_ip.num_rw_ports       = 0;
-			interface_ip.num_rd_ports       = coredynp.peak_commitW;
-			interface_ip.num_wr_ports       = coredynp.peak_issueW;
-			interface_ip.num_se_rd_ports    = 0;
-			interface_ip.num_search_ports   = 0;
-			ROB = new ArrayST(&interface_ip, "ReorderBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-			ROB->area.set_area(ROB->area.get_area()+ ROB->local_result.area*coredynp.num_pipelines);
-			area.set_area(area.get_area()+ ROB->local_result.area*coredynp.num_pipelines);
-			ROB_height      =ROB->local_result.cache_ht;
-		}
-
-		instruction_selection = new selection_logic(is_default, XML->sys.core[ithCore].instruction_window_size,
-				coredynp.peak_issueW, &interface_ip, Core_device, coredynp.core_ty);
+      tmp_name = "IntReservationStation";
     }
+    interface_ip.is_cache = true;
+    interface_ip.pure_cam = false;
+    interface_ip.pure_ram = false;
+    interface_ip.line_sz = data;
+    interface_ip.cache_sz =
+        data * XML->sys.core[ithCore].instruction_window_size;
+    interface_ip.assoc = 0;
+    interface_ip.nbanks = 1;
+    interface_ip.out_w = interface_ip.line_sz * 8;
+    interface_ip.specific_tag = 1;
+    interface_ip.tag_w = tag;
+    interface_ip.access_mode = 0;
+    interface_ip.throughput = 2 * 1.0 / clockRate;
+    interface_ip.latency = 2 * 1.0 / clockRate;
+    interface_ip.obj_func_dyn_energy = 0;
+    interface_ip.obj_func_dyn_power = 0;
+    interface_ip.obj_func_leak_power = 0;
+    interface_ip.obj_func_cycle_t = 1;
+    interface_ip.num_rw_ports = 0;
+    interface_ip.num_rd_ports = coredynp.peak_issueW;
+    interface_ip.num_wr_ports = coredynp.peak_issueW;
+    interface_ip.num_se_rd_ports = 0;
+    interface_ip.num_search_ports = coredynp.peak_issueW;
+    int_inst_window = new ArrayST(&interface_ip, tmp_name, Core_device,
+                                  coredynp.opt_local, coredynp.core_ty);
+    int_inst_window->area.set_area(int_inst_window->area.get_area() +
+                                   int_inst_window->local_result.area *
+                                       coredynp.num_pipelines);
+    area.set_area(area.get_area() +
+                  int_inst_window->local_result.area * coredynp.num_pipelines);
+    Iw_height = int_inst_window->local_result.cache_ht;
+    // FU inst window
+    if (coredynp.scheu_ty == PhysicalRegFile) {
+      tag = 2 * coredynp.phy_freg_width;  // TODO: each time only half of the
+                                          // tag is compared
+      data =
+          int(ceil((coredynp.instruction_length +
+                    2 * (coredynp.phy_freg_width - coredynp.arch_freg_width)) /
+                   8.0));
+      tmp_name = "FPIssueQueue";
+    } else {
+      tag = 2 * coredynp.phy_ireg_width;
+      data =
+          int(ceil((coredynp.instruction_length +
+                    2 * (coredynp.phy_freg_width - coredynp.arch_freg_width) +
+                    2 * coredynp.fp_data_width) /
+                   8.0));
+      tmp_name = "FPReservationStation";
+    }
+    interface_ip.is_cache = true;
+    interface_ip.pure_cam = false;
+    interface_ip.pure_ram = false;
+    interface_ip.line_sz = data;
+    interface_ip.cache_sz =
+        data * XML->sys.core[ithCore].fp_instruction_window_size;
+    interface_ip.assoc = 0;
+    interface_ip.nbanks = 1;
+    interface_ip.out_w = interface_ip.line_sz * 8;
+    interface_ip.specific_tag = 1;
+    interface_ip.tag_w = tag;
+    interface_ip.access_mode = 0;
+    interface_ip.throughput = 1.0 / clockRate;
+    interface_ip.latency = 1.0 / clockRate;
+    interface_ip.obj_func_dyn_energy = 0;
+    interface_ip.obj_func_dyn_power = 0;
+    interface_ip.obj_func_leak_power = 0;
+    interface_ip.obj_func_cycle_t = 1;
+    interface_ip.num_rw_ports = 0;
+    interface_ip.num_rd_ports = coredynp.fp_issueW;
+    interface_ip.num_wr_ports = coredynp.fp_issueW;
+    interface_ip.num_se_rd_ports = 0;
+    interface_ip.num_search_ports = coredynp.fp_issueW;
+    fp_inst_window = new ArrayST(&interface_ip, tmp_name, Core_device,
+                                 coredynp.opt_local, coredynp.core_ty);
+    fp_inst_window->area.set_area(fp_inst_window->area.get_area() +
+                                  fp_inst_window->local_result.area *
+                                      coredynp.num_fp_pipelines);
+    area.set_area(area.get_area() + fp_inst_window->local_result.area *
+                                        coredynp.num_fp_pipelines);
+    fp_Iw_height = fp_inst_window->local_result.cache_ht;
+
+    if (XML->sys.core[ithCore].ROB_size > 0) {
+      /*
+       *  if ROB_size = 0, then the target processor does not support
+       *hardware-based speculation, i.e. , the processor allow OOO issue as well
+       *as OOO completion, which means branch must be resolved before
+       *instruction issued into instruction window, since there is no change to
+       *flush miss-predict branch path after instructions are issued in this
+       *situation.
+       *
+       *  ROB.ROB size = inflight inst. ROB is unified for int and fp inst.
+       *  One old approach is to combine the RAT and ROB as a huge CAM structure
+       *as in AMD K7. However, this approach is abandoned due to its high power
+       *and poor scalablility. McPAT uses current implementation of ROB as
+       *circular buffer. ROB is written once when instruction is issued and read
+       *once when the instruction is committed.         *
+       */
+      int robExtra = int(ceil(5 + log2(coredynp.num_hthreads)));
+      // 5 bits are: busy, Issued, Finished, speculative, valid
+      if (coredynp.scheu_ty == PhysicalRegFile) {
+        // PC is to id the instruction for recover exception.
+        // inst is used to map the renamed dest. registers.so that commit stage
+        // can know which reg/RRAT to update
+        //				data =
+        // int(ceil((robExtra+coredynp.pc_width
+        //+ 						coredynp.instruction_length
+        //+ 2*coredynp.phy_ireg_width)/8.0));
+        data = int(ceil(
+            (robExtra + coredynp.pc_width + coredynp.phy_ireg_width) / 8.0));
+      } else {
+        // in RS based OOO, ROB also contains value of destination reg
+        //				data  =
+        // int(ceil((robExtra+coredynp.pc_width
+        //+ 						coredynp.instruction_length
+        //+ 2*coredynp.phy_ireg_width + coredynp.fp_data_width)/8.0));
+        data = int(ceil((robExtra + coredynp.pc_width +
+                         coredynp.phy_ireg_width + coredynp.fp_data_width) /
+                        8.0));
+      }
+      interface_ip.is_cache = false;
+      interface_ip.pure_cam = false;
+      interface_ip.pure_ram = true;
+      interface_ip.line_sz = data;
+      interface_ip.cache_sz =
+          data * XML->sys.core[ithCore]
+                     .ROB_size;  // The XML ROB size is for all threads
+      interface_ip.assoc = 1;
+      interface_ip.nbanks = 1;
+      interface_ip.out_w = interface_ip.line_sz * 8;
+      interface_ip.access_mode = 1;
+      interface_ip.throughput = 1.0 / clockRate;
+      interface_ip.latency = 1.0 / clockRate;
+      interface_ip.obj_func_dyn_energy = 0;
+      interface_ip.obj_func_dyn_power = 0;
+      interface_ip.obj_func_leak_power = 0;
+      interface_ip.obj_func_cycle_t = 1;
+      interface_ip.num_rw_ports = 0;
+      interface_ip.num_rd_ports = coredynp.peak_commitW;
+      interface_ip.num_wr_ports = coredynp.peak_issueW;
+      interface_ip.num_se_rd_ports = 0;
+      interface_ip.num_search_ports = 0;
+      ROB = new ArrayST(&interface_ip, "ReorderBuffer", Core_device,
+                        coredynp.opt_local, coredynp.core_ty);
+      ROB->area.set_area(ROB->area.get_area() +
+                         ROB->local_result.area * coredynp.num_pipelines);
+      area.set_area(area.get_area() +
+                    ROB->local_result.area * coredynp.num_pipelines);
+      ROB_height = ROB->local_result.cache_ht;
+    }
+
+    instruction_selection = new selection_logic(
+        is_default, XML->sys.core[ithCore].instruction_window_size,
+        coredynp.peak_issueW, &interface_ip, Core_device, coredynp.core_ty);
+  }
 }
 
-LoadStoreU::LoadStoreU(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_,bool exist_)
-:XML(XML_interface),
- ithCore(ithCore_),
- interface_ip(*interface_ip_),
- coredynp(dyn_p_),
- LSQ(0),
- exist(exist_)
-{
-	  if (!exist) return;
-	  int  idx, tag, data, size, line, assoc;
-	  bool debug= false;
-	  int ldst_opcode = XML->sys.core[ithCore].opcode_width;//16;
+LoadStoreU::LoadStoreU(ParseXML* XML_interface, int ithCore_,
+                       InputParameter* interface_ip_,
+                       const CoreDynParam& dyn_p_, bool exist_)
+    : XML(XML_interface),
+      ithCore(ithCore_),
+      interface_ip(*interface_ip_),
+      coredynp(dyn_p_),
+      LSQ(0),
+      exist(exist_) {
+  if (!exist) return;
+  int idx, tag, data, size, line, assoc;
+  bool debug = false;
+  int ldst_opcode = XML->sys.core[ithCore].opcode_width;  // 16;
 
-	  clockRate = coredynp.clockRate;
-	  executionTime = coredynp.executionTime;
-	  cache_p = (Cache_policy)XML->sys.core[ithCore].dcache.dcache_config[7];
+  clockRate = coredynp.clockRate;
+  executionTime = coredynp.executionTime;
+  cache_p = (Cache_policy)XML->sys.core[ithCore].dcache.dcache_config[7];
 
-	  interface_ip.num_search_ports    = XML->sys.core[ithCore].memory_ports;
-	  interface_ip.is_cache			   = true;
-	  interface_ip.pure_cam            = false;
-	  interface_ip.pure_ram            = false;
-	 
+  interface_ip.num_search_ports = XML->sys.core[ithCore].memory_ports;
+  interface_ip.is_cache = true;
+  interface_ip.pure_cam = false;
+  interface_ip.pure_ram = false;
 
-	  //Crossbar based interconnect for shared memory accesses, added by Syed
-	  //Crossbar
+  // Crossbar based interconnect for shared memory accesses, added by Syed
+  // Crossbar
 
-	  if(XML->sys.architecture==1){
-    xbar_shared     = new Crossbar(coredynp.num_fpus,coredynp.num_fpus,32,&(g_tp.peri_global));//Syed: coredynp.num_fpus is used as simd_width  
-	  }
-	  else{
-	  xbar_shared     = new Crossbar(coredynp.num_fpus,coredynp.num_fpus,32,&(g_tp.peri_global));//Syed: coredynp.num_fpus is used as simd_width
-	  }
+  if (XML->sys.architecture == 1) {
+    xbar_shared = new Crossbar(
+        coredynp.num_fpus, coredynp.num_fpus, 32,
+        &(g_tp.peri_global));  // Syed: coredynp.num_fpus is used as simd_width
+  } else {
+    xbar_shared = new Crossbar(
+        coredynp.num_fpus, coredynp.num_fpus, 32,
+        &(g_tp.peri_global));  // Syed: coredynp.num_fpus is used as simd_width
+  }
 
+  // TODO: Check if this line should be changed to
+  // new
+  // Crossbar(simd_width,shared_memory_banks,word_length*simd_width,&(g_tp.peri_global));
 
-     //TODO: Check if this line should be changed to
-     //new Crossbar(simd_width,shared_memory_banks,word_length*simd_width,&(g_tp.peri_global));
+  // shared memory added by Jingwen
+  size = (int)XML->sys.core[ithCore].sharedmemory.dcache_config[0];
+  line = (int)XML->sys.core[ithCore].sharedmemory.dcache_config[1];
+  assoc = (int)XML->sys.core[ithCore].sharedmemory.dcache_config[2];
+  idx = debug ? 9 : int(ceil(log2(size / line / assoc)));
+  tag = debug ? 51
+              : XML->sys.physical_address_width - idx - int(ceil(log2(line))) +
+                    EXTRA_TAG_BITS;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = 1;
+  interface_ip.cache_sz =
+      debug ? 32768 : (int)XML->sys.core[ithCore].sharedmemory.dcache_config[0];
+  interface_ip.line_sz =
+      debug ? 64 : (int)XML->sys.core[ithCore].sharedmemory.dcache_config[1];
+  interface_ip.assoc =
+      debug ? 8 : (int)XML->sys.core[ithCore].sharedmemory.dcache_config[2];
+  interface_ip.nbanks =
+      debug ? 1 : (int)XML->sys.core[ithCore].sharedmemory.dcache_config[3];
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode =
+      0;  // debug?0:XML->sys.core[ithCore].sharedmemory.dcache_config[5];
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].sharedmemory.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 3.0 / clockRate
+            : XML->sys.core[ithCore].sharedmemory.dcache_config[5] / clockRate;
+  interface_ip.is_cache = true;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports =
+      debug ? 1
+            : XML->sys.core[ithCore].memory_ports;  // usually In-order has 1
+                                                    // and OOO has 2 at least.
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  sharedmemory.caches = new ArrayST(&interface_ip, "sharedmemory", Core_device,
+                                    coredynp.opt_local, coredynp.core_ty);
+  sharedmemory.area.set_area(sharedmemory.area.get_area() +
+                             sharedmemory.caches->local_result.area);
+  area.set_area(area.get_area() + sharedmemory.caches->local_result.area +
+                xbar_shared->area.get_area());
 
-    //shared memory added by Jingwen
-	  size                             = (int)XML->sys.core[ithCore].sharedmemory.dcache_config[0];
-	  line                             = (int)XML->sys.core[ithCore].sharedmemory.dcache_config[1];
-	  assoc                            = (int)XML->sys.core[ithCore].sharedmemory.dcache_config[2];
-	  idx    					 	   = debug?9:int(ceil(log2(size/line/assoc)));
-	  tag							   = debug?51:XML->sys.physical_address_width-idx-int(ceil(log2(line))) + EXTRA_TAG_BITS;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = 1;
-	  interface_ip.cache_sz            = debug?32768:(int)XML->sys.core[ithCore].sharedmemory.dcache_config[0];
-	  interface_ip.line_sz             = debug?64:(int)XML->sys.core[ithCore].sharedmemory.dcache_config[1];
-	  interface_ip.assoc               = debug?8:(int)XML->sys.core[ithCore].sharedmemory.dcache_config[2];
-	  interface_ip.nbanks              = debug?1:(int)XML->sys.core[ithCore].sharedmemory.dcache_config[3];
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 0;//debug?0:XML->sys.core[ithCore].sharedmemory.dcache_config[5];
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?3.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[5]/clockRate;
-	  interface_ip.is_cache			 = true;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;//usually In-order has 1 and OOO has 2 at least.
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  sharedmemory.caches = new ArrayST(&interface_ip, "sharedmemory", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  sharedmemory.area.set_area(sharedmemory.area.get_area()+ sharedmemory.caches->local_result.area);
-	  area.set_area(area.get_area()+ sharedmemory.caches->local_result.area + xbar_shared->area.get_area());
+  // shared memory buffer
+  // miss buffer
+  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data = (XML->sys.physical_address_width) + int(ceil(log2(size / line))) +
+         sharedmemory.caches->l_ip.line_sz * 8;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = 1;
+  interface_ip.line_sz =
+      int(ceil(data / 8.0));  // int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+  interface_ip.cache_sz = XML->sys.core[ithCore].sharedmemory.buffer_sizes[0] *
+                          interface_ip.line_sz;
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].sharedmemory.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].sharedmemory.dcache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
+  ;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  sharedmemory.missb =
+      new ArrayST(&interface_ip, "SharedmemoryMissBuffer", Core_device,
+                  coredynp.opt_local, coredynp.core_ty);
+  sharedmemory.area.set_area(sharedmemory.area.get_area() +
+                             sharedmemory.missb->local_result.area);
+  area.set_area(area.get_area() + sharedmemory.missb->local_result.area);
 
+  // sharedmemory fill buffer
+  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data = sharedmemory.caches->l_ip.line_sz;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = 1;
+  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
+  interface_ip.cache_sz =
+      data * XML->sys.core[ithCore].sharedmemory.buffer_sizes[1];
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].sharedmemory.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].sharedmemory.dcache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
+  ;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  sharedmemory.ifb =
+      new ArrayST(&interface_ip, "SharedMemoryFillBuffer", Core_device,
+                  coredynp.opt_local, coredynp.core_ty);
+  sharedmemory.area.set_area(sharedmemory.area.get_area() +
+                             sharedmemory.ifb->local_result.area);
+  area.set_area(area.get_area() + sharedmemory.ifb->local_result.area);
 
-    //shared memory buffer
-	  //miss buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  data							   = (XML->sys.physical_address_width) + int(ceil(log2(size/line))) + sharedmemory.caches->l_ip.line_sz*8;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = 1;
-	  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-	  interface_ip.cache_sz            = XML->sys.core[ithCore].sharedmemory.buffer_sizes[0]*interface_ip.line_sz;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 2;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  sharedmemory.missb = new ArrayST(&interface_ip, "SharedmemoryMissBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  sharedmemory.area.set_area(sharedmemory.area.get_area()+ sharedmemory.missb->local_result.area);
-	  area.set_area(area.get_area()+ sharedmemory.missb->local_result.area);
+  // sharedmemory prefetch buffer
+  tag = XML->sys.physical_address_width +
+        EXTRA_TAG_BITS;  // check with previous entries to decide wthether to
+                         // merge.
+  data = sharedmemory.caches->l_ip
+             .line_sz;  // separate queue to prevent from cache polution.
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = 1;
+  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
+  interface_ip.cache_sz = XML->sys.core[ithCore].sharedmemory.buffer_sizes[2] *
+                          interface_ip.line_sz;
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].sharedmemory.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].sharedmemory.dcache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
+  ;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  sharedmemory.prefetchb =
+      new ArrayST(&interface_ip, "dcacheprefetchBuffer", Core_device,
+                  coredynp.opt_local, coredynp.core_ty);
+  sharedmemory.area.set_area(sharedmemory.area.get_area() +
+                             sharedmemory.prefetchb->local_result.area);
+  area.set_area(area.get_area() + sharedmemory.prefetchb->local_result.area);
 
+  // shared memory WBB
+  if (cache_p == Write_back) {
+    tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+    data = sharedmemory.caches->l_ip.line_sz;
+    interface_ip.specific_tag = 1;
+    interface_ip.tag_w = 1;
+    interface_ip.line_sz = data;
+    interface_ip.cache_sz =
+        XML->sys.core[ithCore].sharedmemory.buffer_sizes[3] *
+        interface_ip.line_sz;
+    interface_ip.assoc = 0;
+    interface_ip.nbanks = 1;
+    interface_ip.out_w = interface_ip.line_sz * 8;
+    interface_ip.access_mode = 2;
+    interface_ip.throughput =
+        debug
+            ? 1.0 / clockRate
+            : XML->sys.core[ithCore].sharedmemory.dcache_config[4] / clockRate;
+    interface_ip.latency =
+        debug
+            ? 1.0 / clockRate
+            : XML->sys.core[ithCore].sharedmemory.dcache_config[5] / clockRate;
+    interface_ip.obj_func_dyn_energy = 0;
+    interface_ip.obj_func_dyn_power = 0;
+    interface_ip.obj_func_leak_power = 0;
+    interface_ip.obj_func_cycle_t = 1;
+    interface_ip.num_rw_ports = XML->sys.core[ithCore].memory_ports;
+    interface_ip.num_rd_ports = 0;
+    interface_ip.num_wr_ports = 0;
+    interface_ip.num_se_rd_ports = 0;
+    sharedmemory.wbb = new ArrayST(&interface_ip, "dcacheWBB", Core_device,
+                                   coredynp.opt_local, coredynp.core_ty);
+    sharedmemory.area.set_area(sharedmemory.area.get_area() +
+                               sharedmemory.wbb->local_result.area);
+    area.set_area(area.get_area() + sharedmemory.wbb->local_result.area);
+    // output_data_csv(sharedmemory.wbb.local_result);
+  }
 
-    //sharedmemory fill buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  data							   = sharedmemory.caches->l_ip.line_sz;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = 1;
-	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-	  interface_ip.cache_sz            = data*XML->sys.core[ithCore].sharedmemory.buffer_sizes[1];
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 2;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  sharedmemory.ifb = new ArrayST(&interface_ip, "SharedMemoryFillBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  sharedmemory.area.set_area(sharedmemory.area.get_area()+ sharedmemory.ifb->local_result.area);
-	  area.set_area(area.get_area()+ sharedmemory.ifb->local_result.area);
+  /*
+   * ccache starts here
+   */
+  // Constant cache
+  size = (int)XML->sys.core[ithCore].ccache.dcache_config[0];
+  line = (int)XML->sys.core[ithCore].ccache.dcache_config[1];
+  assoc = (int)XML->sys.core[ithCore].ccache.dcache_config[2];
+  idx = debug ? 9 : int(ceil(log2(size / line / assoc)));
+  tag = debug ? 51
+              : XML->sys.physical_address_width - idx - int(ceil(log2(line))) +
+                    EXTRA_TAG_BITS;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.cache_sz =
+      debug ? 32768 : (int)XML->sys.core[ithCore].ccache.dcache_config[0];
+  interface_ip.line_sz =
+      debug ? 64 : (int)XML->sys.core[ithCore].ccache.dcache_config[1];
+  interface_ip.assoc =
+      debug ? 8 : (int)XML->sys.core[ithCore].ccache.dcache_config[2];
+  interface_ip.nbanks =
+      debug ? 1 : (int)XML->sys.core[ithCore].ccache.dcache_config[3];
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode =
+      0;  // debug?0:XML->sys.core[ithCore].ccache.dcache_config[5];
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].ccache.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 3.0 / clockRate
+            : XML->sys.core[ithCore].ccache.dcache_config[5] / clockRate;
+  interface_ip.is_cache = true;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports =
+      debug ? 1
+            : XML->sys.core[ithCore].memory_ports;  // usually In-order has 1
+                                                    // and OOO has 2 at least.
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  ccache.caches = new ArrayST(&interface_ip, "ccache", Core_device,
+                              coredynp.opt_local, coredynp.core_ty);
+  ccache.area.set_area(ccache.area.get_area() +
+                       ccache.caches->local_result.area);
+  area.set_area(area.get_area() + ccache.caches->local_result.area);
+  // output_data_csv(ccache.caches.local_result);
 
-    //sharedmemory prefetch buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries to decide wthether to merge.
-	  data							   = sharedmemory.caches->l_ip.line_sz;//separate queue to prevent from cache polution.
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = 1;
-	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-	  interface_ip.cache_sz            = XML->sys.core[ithCore].sharedmemory.buffer_sizes[2]*interface_ip.line_sz;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 2;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  sharedmemory.prefetchb = new ArrayST(&interface_ip, "dcacheprefetchBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  sharedmemory.area.set_area(sharedmemory.area.get_area()+ sharedmemory.prefetchb->local_result.area);
-	  area.set_area(area.get_area()+ sharedmemory.prefetchb->local_result.area);
+  // cCache controllers
+  // miss buffer
+  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data = (XML->sys.physical_address_width) + int(ceil(log2(size / line))) +
+         ccache.caches->l_ip.line_sz * 8;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.line_sz =
+      int(ceil(data / 8.0));  // int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+  interface_ip.cache_sz =
+      XML->sys.core[ithCore].ccache.buffer_sizes[0] * interface_ip.line_sz;
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].ccache.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].ccache.dcache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
+  ;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  ccache.missb = new ArrayST(&interface_ip, "ccacheMissBuffer", Core_device,
+                             coredynp.opt_local, coredynp.core_ty);
+  ccache.area.set_area(ccache.area.get_area() +
+                       ccache.missb->local_result.area);
+  area.set_area(area.get_area() + ccache.missb->local_result.area);
+  // output_data_csv(ccache.missb.local_result);
 
-    //shared memory WBB
-	  if (cache_p==Write_back)
-	  {
-		  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-		  data							   = sharedmemory.caches->l_ip.line_sz;
-		  interface_ip.specific_tag        = 1;
-		  interface_ip.tag_w               = 1;
-		  interface_ip.line_sz             = data;
-		  interface_ip.cache_sz            = XML->sys.core[ithCore].sharedmemory.buffer_sizes[3]*interface_ip.line_sz;
-		  interface_ip.assoc               = 0;
-		  interface_ip.nbanks              = 1;
-		  interface_ip.out_w               = interface_ip.line_sz*8;
-		  interface_ip.access_mode         = 2;
-		  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[4]/clockRate;
-		  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[5]/clockRate;
-		  interface_ip.obj_func_dyn_energy = 0;
-		  interface_ip.obj_func_dyn_power  = 0;
-		  interface_ip.obj_func_leak_power = 0;
-		  interface_ip.obj_func_cycle_t    = 1;
-		  interface_ip.num_rw_ports    = XML->sys.core[ithCore].memory_ports;
-		  interface_ip.num_rd_ports    = 0;
-		  interface_ip.num_wr_ports    = 0;
-		  interface_ip.num_se_rd_ports = 0;
-		  sharedmemory.wbb = new ArrayST(&interface_ip, "dcacheWBB", Core_device, coredynp.opt_local, coredynp.core_ty);
-		  sharedmemory.area.set_area(sharedmemory.area.get_area()+ sharedmemory.wbb->local_result.area);
-		  area.set_area(area.get_area()+ sharedmemory.wbb->local_result.area);
-		  //output_data_csv(sharedmemory.wbb.local_result);
-	  }
+  // fill buffer
+  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data = ccache.caches->l_ip.line_sz;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
+  interface_ip.cache_sz = data * XML->sys.core[ithCore].ccache.buffer_sizes[1];
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].ccache.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].ccache.dcache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
+  ;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  ccache.ifb = new ArrayST(&interface_ip, "ccacheFillBuffer", Core_device,
+                           coredynp.opt_local, coredynp.core_ty);
+  ccache.area.set_area(ccache.area.get_area() + ccache.ifb->local_result.area);
+  area.set_area(area.get_area() + ccache.ifb->local_result.area);
+  // output_data_csv(ccache.ifb.local_result);
 
+  // prefetch buffer
+  tag = XML->sys.physical_address_width +
+        EXTRA_TAG_BITS;  // check with previous entries to decide wthether to
+                         // merge.
+  data = ccache.caches->l_ip
+             .line_sz;  // separate queue to prevent from cache polution.
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
+  interface_ip.cache_sz =
+      XML->sys.core[ithCore].ccache.buffer_sizes[2] * interface_ip.line_sz;
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].ccache.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].ccache.dcache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
+  ;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  ccache.prefetchb =
+      new ArrayST(&interface_ip, "ccacheprefetchBuffer", Core_device,
+                  coredynp.opt_local, coredynp.core_ty);
+  ccache.area.set_area(ccache.area.get_area() +
+                       ccache.prefetchb->local_result.area);
+  area.set_area(area.get_area() + ccache.prefetchb->local_result.area);
+  // output_data_csv(ccache.prefetchb.local_result);
 
-   /*
-    * ccache starts here
-    */   
-    //Constant cache
-	  size                             = (int)XML->sys.core[ithCore].ccache.dcache_config[0];
-	  line                             = (int)XML->sys.core[ithCore].ccache.dcache_config[1];
-	  assoc                            = (int)XML->sys.core[ithCore].ccache.dcache_config[2];
-	  idx    					 	   = debug?9:int(ceil(log2(size/line/assoc)));
-	  tag							   = debug?51:XML->sys.physical_address_width-idx-int(ceil(log2(line))) + EXTRA_TAG_BITS;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.cache_sz            = debug?32768:(int)XML->sys.core[ithCore].ccache.dcache_config[0];
-	  interface_ip.line_sz             = debug?64:(int)XML->sys.core[ithCore].ccache.dcache_config[1];
-	  interface_ip.assoc               = debug?8:(int)XML->sys.core[ithCore].ccache.dcache_config[2];
-	  interface_ip.nbanks              = debug?1:(int)XML->sys.core[ithCore].ccache.dcache_config[3];
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 0;//debug?0:XML->sys.core[ithCore].ccache.dcache_config[5];
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?3.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[5]/clockRate;
-	  interface_ip.is_cache			 = true;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;//usually In-order has 1 and OOO has 2 at least.
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  ccache.caches = new ArrayST(&interface_ip, "ccache", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  ccache.area.set_area(ccache.area.get_area()+ ccache.caches->local_result.area);
-	  area.set_area(area.get_area()+ ccache.caches->local_result.area);
-	  //output_data_csv(ccache.caches.local_result);
+  // WBB
+  if (cache_p == Write_back) {
+    tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+    data = ccache.caches->l_ip.line_sz;
+    interface_ip.specific_tag = 1;
+    interface_ip.tag_w = tag;
+    interface_ip.line_sz = data;
+    interface_ip.cache_sz =
+        XML->sys.core[ithCore].ccache.buffer_sizes[3] * interface_ip.line_sz;
+    interface_ip.assoc = 0;
+    interface_ip.nbanks = 1;
+    interface_ip.out_w = interface_ip.line_sz * 8;
+    interface_ip.access_mode = 2;
+    interface_ip.throughput =
+        debug ? 1.0 / clockRate
+              : XML->sys.core[ithCore].ccache.dcache_config[4] / clockRate;
+    interface_ip.latency =
+        debug ? 1.0 / clockRate
+              : XML->sys.core[ithCore].ccache.dcache_config[5] / clockRate;
+    interface_ip.obj_func_dyn_energy = 0;
+    interface_ip.obj_func_dyn_power = 0;
+    interface_ip.obj_func_leak_power = 0;
+    interface_ip.obj_func_cycle_t = 1;
+    interface_ip.num_rw_ports = XML->sys.core[ithCore].memory_ports;
+    interface_ip.num_rd_ports = 0;
+    interface_ip.num_wr_ports = 0;
+    interface_ip.num_se_rd_ports = 0;
+    ccache.wbb = new ArrayST(&interface_ip, "ccacheWBB", Core_device,
+                             coredynp.opt_local, coredynp.core_ty);
+    ccache.area.set_area(ccache.area.get_area() +
+                         ccache.wbb->local_result.area);
+    area.set_area(area.get_area() + ccache.wbb->local_result.area);
+    // output_data_csv(ccache.wbb.local_result);
+  }
 
+  /*
+   * tcache starts here
+   */
+  // Texture cache
+  size = (int)XML->sys.core[ithCore].tcache.dcache_config[0];
+  line = (int)XML->sys.core[ithCore].tcache.dcache_config[1];
+  assoc = (int)XML->sys.core[ithCore].tcache.dcache_config[2];
+  idx = debug ? 9 : int(ceil(log2(size / line / assoc)));
+  tag = debug ? 51
+              : XML->sys.physical_address_width - idx - int(ceil(log2(line))) +
+                    EXTRA_TAG_BITS;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.cache_sz =
+      debug ? 32768 : (int)XML->sys.core[ithCore].tcache.dcache_config[0];
+  interface_ip.line_sz =
+      debug ? 64 : (int)XML->sys.core[ithCore].tcache.dcache_config[1];
+  interface_ip.assoc =
+      debug ? 8 : (int)XML->sys.core[ithCore].tcache.dcache_config[2];
+  interface_ip.nbanks =
+      debug ? 1 : (int)XML->sys.core[ithCore].tcache.dcache_config[3];
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode =
+      0;  // debug?0:XML->sys.core[ithCore].tcache.dcache_config[5];
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].tcache.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 3.0 / clockRate
+            : XML->sys.core[ithCore].tcache.dcache_config[5] / clockRate;
+  interface_ip.is_cache = true;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports =
+      debug ? 1
+            : XML->sys.core[ithCore].memory_ports;  // usually In-order has 1
+                                                    // and OOO has 2 at least.
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  tcache.caches = new ArrayST(&interface_ip, "tcache", Core_device,
+                              coredynp.opt_local, coredynp.core_ty);
+  tcache.area.set_area(tcache.area.get_area() +
+                       tcache.caches->local_result.area);
+  area.set_area(area.get_area() + tcache.caches->local_result.area);
+  // output_data_csv(tcache.caches.local_result);
 
+  // tCache controllers
+  // miss buffer
+  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data = (XML->sys.physical_address_width) + int(ceil(log2(size / line))) +
+         tcache.caches->l_ip.line_sz * 8;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.line_sz =
+      int(ceil(data / 8.0));  // int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+  interface_ip.cache_sz =
+      XML->sys.core[ithCore].tcache.buffer_sizes[0] * interface_ip.line_sz;
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].tcache.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].tcache.dcache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
+  ;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  tcache.missb = new ArrayST(&interface_ip, "tcacheMissBuffer", Core_device,
+                             coredynp.opt_local, coredynp.core_ty);
+  tcache.area.set_area(tcache.area.get_area() +
+                       tcache.missb->local_result.area);
+  area.set_area(area.get_area() + tcache.missb->local_result.area);
+  // output_data_csv(tcache.missb.local_result);
 
-      //cCache controllers
-	  //miss buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  data							   = (XML->sys.physical_address_width) + int(ceil(log2(size/line))) + ccache.caches->l_ip.line_sz*8;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-	  interface_ip.cache_sz            = XML->sys.core[ithCore].ccache.buffer_sizes[0]*interface_ip.line_sz;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 2;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  ccache.missb = new ArrayST(&interface_ip, "ccacheMissBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  ccache.area.set_area(ccache.area.get_area()+ ccache.missb->local_result.area);
-	  area.set_area(area.get_area()+ ccache.missb->local_result.area);
-	  //output_data_csv(ccache.missb.local_result);
+  // fill buffer
+  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data = tcache.caches->l_ip.line_sz;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
+  interface_ip.cache_sz = data * XML->sys.core[ithCore].tcache.buffer_sizes[1];
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].tcache.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].tcache.dcache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
+  ;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  tcache.ifb = new ArrayST(&interface_ip, "tcacheFillBuffer", Core_device,
+                           coredynp.opt_local, coredynp.core_ty);
+  tcache.area.set_area(tcache.area.get_area() + tcache.ifb->local_result.area);
+  area.set_area(area.get_area() + tcache.ifb->local_result.area);
+  // output_data_csv(tcache.ifb.local_result);
 
-	  //fill buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  data							   = ccache.caches->l_ip.line_sz;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-	  interface_ip.cache_sz            = data*XML->sys.core[ithCore].ccache.buffer_sizes[1];
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 2;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  ccache.ifb = new ArrayST(&interface_ip, "ccacheFillBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  ccache.area.set_area(ccache.area.get_area()+ ccache.ifb->local_result.area);
-	  area.set_area(area.get_area()+ ccache.ifb->local_result.area);
-	  //output_data_csv(ccache.ifb.local_result);
+  // prefetch buffer
+  tag = XML->sys.physical_address_width +
+        EXTRA_TAG_BITS;  // check with previous entries to decide wthether to
+                         // merge.
+  data = tcache.caches->l_ip
+             .line_sz;  // separate queue to prevent from cache polution.
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
+  interface_ip.cache_sz =
+      XML->sys.core[ithCore].tcache.buffer_sizes[2] * interface_ip.line_sz;
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].tcache.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].tcache.dcache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
+  ;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  tcache.prefetchb =
+      new ArrayST(&interface_ip, "tcacheprefetchBuffer", Core_device,
+                  coredynp.opt_local, coredynp.core_ty);
+  tcache.area.set_area(tcache.area.get_area() +
+                       tcache.prefetchb->local_result.area);
+  area.set_area(area.get_area() + tcache.prefetchb->local_result.area);
+  // output_data_csv(tcache.prefetchb.local_result);
 
-	  //prefetch buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries to decide wthether to merge.
-	  data							   = ccache.caches->l_ip.line_sz;//separate queue to prevent from cache polution.
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-	  interface_ip.cache_sz            = XML->sys.core[ithCore].ccache.buffer_sizes[2]*interface_ip.line_sz;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 2;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  ccache.prefetchb = new ArrayST(&interface_ip, "ccacheprefetchBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  ccache.area.set_area(ccache.area.get_area()+ ccache.prefetchb->local_result.area);
-	  area.set_area(area.get_area()+ ccache.prefetchb->local_result.area);
-	  //output_data_csv(ccache.prefetchb.local_result);
+  // WBB
+  if (cache_p == Write_back) {
+    tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+    data = tcache.caches->l_ip.line_sz;
+    interface_ip.specific_tag = 1;
+    interface_ip.tag_w = tag;
+    interface_ip.line_sz = data;
+    interface_ip.cache_sz =
+        XML->sys.core[ithCore].tcache.buffer_sizes[3] * interface_ip.line_sz;
+    interface_ip.assoc = 0;
+    interface_ip.nbanks = 1;
+    interface_ip.out_w = interface_ip.line_sz * 8;
+    interface_ip.access_mode = 2;
+    interface_ip.throughput =
+        debug ? 1.0 / clockRate
+              : XML->sys.core[ithCore].tcache.dcache_config[4] / clockRate;
+    interface_ip.latency =
+        debug ? 1.0 / clockRate
+              : XML->sys.core[ithCore].tcache.dcache_config[5] / clockRate;
+    interface_ip.obj_func_dyn_energy = 0;
+    interface_ip.obj_func_dyn_power = 0;
+    interface_ip.obj_func_leak_power = 0;
+    interface_ip.obj_func_cycle_t = 1;
+    interface_ip.num_rw_ports = XML->sys.core[ithCore].memory_ports;
+    interface_ip.num_rd_ports = 0;
+    interface_ip.num_wr_ports = 0;
+    interface_ip.num_se_rd_ports = 0;
+    tcache.wbb = new ArrayST(&interface_ip, "tcacheWBB", Core_device,
+                             coredynp.opt_local, coredynp.core_ty);
+    tcache.area.set_area(tcache.area.get_area() +
+                         tcache.wbb->local_result.area);
+    area.set_area(area.get_area() + tcache.wbb->local_result.area);
+    // output_data_csv(tcache.wbb.local_result);
+  }
 
-	  //WBB
-	  if (cache_p==Write_back)
-	  {
-		  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-		  data							   = ccache.caches->l_ip.line_sz;
-		  interface_ip.specific_tag        = 1;
-		  interface_ip.tag_w               = tag;
-		  interface_ip.line_sz             = data;
-		  interface_ip.cache_sz            = XML->sys.core[ithCore].ccache.buffer_sizes[3]*interface_ip.line_sz;
-		  interface_ip.assoc               = 0;
-		  interface_ip.nbanks              = 1;
-		  interface_ip.out_w               = interface_ip.line_sz*8;
-		  interface_ip.access_mode         = 2;
-		  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[4]/clockRate;
-		  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[5]/clockRate;
-		  interface_ip.obj_func_dyn_energy = 0;
-		  interface_ip.obj_func_dyn_power  = 0;
-		  interface_ip.obj_func_leak_power = 0;
-		  interface_ip.obj_func_cycle_t    = 1;
-		  interface_ip.num_rw_ports    = XML->sys.core[ithCore].memory_ports;
-		  interface_ip.num_rd_ports    = 0;
-		  interface_ip.num_wr_ports    = 0;
-		  interface_ip.num_se_rd_ports = 0;
-		  ccache.wbb = new ArrayST(&interface_ip, "ccacheWBB", Core_device, coredynp.opt_local, coredynp.core_ty);
-		  ccache.area.set_area(ccache.area.get_area()+ ccache.wbb->local_result.area);
-		  area.set_area(area.get_area()+ ccache.wbb->local_result.area);
-		  //output_data_csv(ccache.wbb.local_result);
-	  }
+  /*
+   * dcache starts here
+   */
+  // Dcache
+  size = (int)XML->sys.core[ithCore].dcache.dcache_config[0];
+  line = (int)XML->sys.core[ithCore].dcache.dcache_config[1];
+  assoc = (int)XML->sys.core[ithCore].dcache.dcache_config[2];
+  idx = debug ? 9 : int(ceil(log2(size / line / assoc)));
+  tag = debug ? 51
+              : XML->sys.physical_address_width - idx - int(ceil(log2(line))) +
+                    EXTRA_TAG_BITS;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.cache_sz =
+      debug ? 32768 : (int)XML->sys.core[ithCore].dcache.dcache_config[0];
+  interface_ip.line_sz =
+      debug ? 64 : (int)XML->sys.core[ithCore].dcache.dcache_config[1];
+  interface_ip.assoc =
+      debug ? 8 : (int)XML->sys.core[ithCore].dcache.dcache_config[2];
+  interface_ip.nbanks =
+      debug ? 1 : (int)XML->sys.core[ithCore].dcache.dcache_config[3];
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode =
+      0;  // debug?0:XML->sys.core[ithCore].dcache.dcache_config[5];
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].dcache.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 3.0 / clockRate
+            : XML->sys.core[ithCore].dcache.dcache_config[5] / clockRate;
+  interface_ip.is_cache = true;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports =
+      debug ? 1
+            : XML->sys.core[ithCore].memory_ports;  // usually In-order has 1
+                                                    // and OOO has 2 at least.
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  dcache.caches = new ArrayST(&interface_ip, "dcache", Core_device,
+                              coredynp.opt_local, coredynp.core_ty);
+  dcache.area.set_area(dcache.area.get_area() +
+                       dcache.caches->local_result.area);
+  area.set_area(area.get_area() + dcache.caches->local_result.area);
+  // output_data_csv(dcache.caches.local_result);
 
-   /*
-    * tcache starts here
-    */   
-    //Texture cache
-	  size                             = (int)XML->sys.core[ithCore].tcache.dcache_config[0];
-	  line                             = (int)XML->sys.core[ithCore].tcache.dcache_config[1];
-	  assoc                            = (int)XML->sys.core[ithCore].tcache.dcache_config[2];
-	  idx    					 	   = debug?9:int(ceil(log2(size/line/assoc)));
-	  tag							   = debug?51:XML->sys.physical_address_width-idx-int(ceil(log2(line))) + EXTRA_TAG_BITS;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.cache_sz            = debug?32768:(int)XML->sys.core[ithCore].tcache.dcache_config[0];
-	  interface_ip.line_sz             = debug?64:(int)XML->sys.core[ithCore].tcache.dcache_config[1];
-	  interface_ip.assoc               = debug?8:(int)XML->sys.core[ithCore].tcache.dcache_config[2];
-	  interface_ip.nbanks              = debug?1:(int)XML->sys.core[ithCore].tcache.dcache_config[3];
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 0;//debug?0:XML->sys.core[ithCore].tcache.dcache_config[5];
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?3.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[5]/clockRate;
-	  interface_ip.is_cache			 = true;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;//usually In-order has 1 and OOO has 2 at least.
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  tcache.caches = new ArrayST(&interface_ip, "tcache", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  tcache.area.set_area(tcache.area.get_area()+ tcache.caches->local_result.area);
-	  area.set_area(area.get_area()+ tcache.caches->local_result.area);
-	  //output_data_csv(tcache.caches.local_result);
+  // dCache controllers
+  // miss buffer
+  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data = (XML->sys.physical_address_width) + int(ceil(log2(size / line))) +
+         dcache.caches->l_ip.line_sz * 8;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.line_sz =
+      int(ceil(data / 8.0));  // int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+  interface_ip.cache_sz =
+      XML->sys.core[ithCore].dcache.buffer_sizes[0] * interface_ip.line_sz;
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].dcache.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].dcache.dcache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
+  ;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  dcache.missb = new ArrayST(&interface_ip, "dcacheMissBuffer", Core_device,
+                             coredynp.opt_local, coredynp.core_ty);
+  dcache.area.set_area(dcache.area.get_area() +
+                       dcache.missb->local_result.area);
+  area.set_area(area.get_area() + dcache.missb->local_result.area);
+  // output_data_csv(dcache.missb.local_result);
 
+  // fill buffer
+  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data = dcache.caches->l_ip.line_sz;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
+  interface_ip.cache_sz = data * XML->sys.core[ithCore].dcache.buffer_sizes[1];
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].dcache.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].dcache.dcache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
+  ;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  dcache.ifb = new ArrayST(&interface_ip, "dcacheFillBuffer", Core_device,
+                           coredynp.opt_local, coredynp.core_ty);
+  dcache.area.set_area(dcache.area.get_area() + dcache.ifb->local_result.area);
+  area.set_area(area.get_area() + dcache.ifb->local_result.area);
+  // output_data_csv(dcache.ifb.local_result);
 
-	  //tCache controllers
-	  //miss buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  data							   = (XML->sys.physical_address_width) + int(ceil(log2(size/line))) + tcache.caches->l_ip.line_sz*8;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-	  interface_ip.cache_sz            = XML->sys.core[ithCore].tcache.buffer_sizes[0]*interface_ip.line_sz;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 2;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  tcache.missb = new ArrayST(&interface_ip, "tcacheMissBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  tcache.area.set_area(tcache.area.get_area()+ tcache.missb->local_result.area);
-	  area.set_area(area.get_area()+ tcache.missb->local_result.area);
-	  //output_data_csv(tcache.missb.local_result);
+  // prefetch buffer
+  tag = XML->sys.physical_address_width +
+        EXTRA_TAG_BITS;  // check with previous entries to decide wthether to
+                         // merge.
+  data = dcache.caches->l_ip
+             .line_sz;  // separate queue to prevent from cache polution.
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
+  interface_ip.cache_sz =
+      XML->sys.core[ithCore].dcache.buffer_sizes[2] * interface_ip.line_sz;
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].dcache.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].dcache.dcache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
+  ;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  dcache.prefetchb =
+      new ArrayST(&interface_ip, "dcacheprefetchBuffer", Core_device,
+                  coredynp.opt_local, coredynp.core_ty);
+  dcache.area.set_area(dcache.area.get_area() +
+                       dcache.prefetchb->local_result.area);
+  area.set_area(area.get_area() + dcache.prefetchb->local_result.area);
+  // output_data_csv(dcache.prefetchb.local_result);
 
-	  //fill buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  data							   = tcache.caches->l_ip.line_sz;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-	  interface_ip.cache_sz            = data*XML->sys.core[ithCore].tcache.buffer_sizes[1];
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 2;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  tcache.ifb = new ArrayST(&interface_ip, "tcacheFillBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  tcache.area.set_area(tcache.area.get_area()+ tcache.ifb->local_result.area);
-	  area.set_area(area.get_area()+ tcache.ifb->local_result.area);
-	  //output_data_csv(tcache.ifb.local_result);
+  // WBB
+  if (cache_p == Write_back) {
+    tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+    data = dcache.caches->l_ip.line_sz;
+    interface_ip.specific_tag = 1;
+    interface_ip.tag_w = tag;
+    interface_ip.line_sz = data;
+    interface_ip.cache_sz =
+        XML->sys.core[ithCore].dcache.buffer_sizes[3] * interface_ip.line_sz;
+    interface_ip.assoc = 0;
+    interface_ip.nbanks = 1;
+    interface_ip.out_w = interface_ip.line_sz * 8;
+    interface_ip.access_mode = 2;
+    interface_ip.throughput =
+        debug ? 1.0 / clockRate
+              : XML->sys.core[ithCore].dcache.dcache_config[4] / clockRate;
+    interface_ip.latency =
+        debug ? 1.0 / clockRate
+              : XML->sys.core[ithCore].dcache.dcache_config[5] / clockRate;
+    interface_ip.obj_func_dyn_energy = 0;
+    interface_ip.obj_func_dyn_power = 0;
+    interface_ip.obj_func_leak_power = 0;
+    interface_ip.obj_func_cycle_t = 1;
+    interface_ip.num_rw_ports = XML->sys.core[ithCore].memory_ports;
+    interface_ip.num_rd_ports = 0;
+    interface_ip.num_wr_ports = 0;
+    interface_ip.num_se_rd_ports = 0;
+    dcache.wbb = new ArrayST(&interface_ip, "dcacheWBB", Core_device,
+                             coredynp.opt_local, coredynp.core_ty);
+    dcache.area.set_area(dcache.area.get_area() +
+                         dcache.wbb->local_result.area);
+    area.set_area(area.get_area() + dcache.wbb->local_result.area);
+    // output_data_csv(dcache.wbb.local_result);
+  }
 
-	  //prefetch buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries to decide wthether to merge.
-	  data							   = tcache.caches->l_ip.line_sz;//separate queue to prevent from cache polution.
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-	  interface_ip.cache_sz            = XML->sys.core[ithCore].tcache.buffer_sizes[2]*interface_ip.line_sz;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 2;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  tcache.prefetchb = new ArrayST(&interface_ip, "tcacheprefetchBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  tcache.area.set_area(tcache.area.get_area()+ tcache.prefetchb->local_result.area);
-	  area.set_area(area.get_area()+ tcache.prefetchb->local_result.area);
-	  //output_data_csv(tcache.prefetchb.local_result);
+  /*
+   * LSU--in-order processors do not have separate load queue: unified lsq
+   * partitioned among threads
+   * it is actually the store queue but for inorder processors it serves as both
+   * loadQ and StoreQ
+   */
+  tag = ldst_opcode + XML->sys.virtual_address_width +
+        int(ceil(log2(XML->sys.core[ithCore].number_hardware_threads))) +
+        EXTRA_TAG_BITS;
+  data = XML->sys.machine_bits;
+  interface_ip.is_cache = true;
+  interface_ip.line_sz = int(ceil(data / 32.0)) * 4;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.cache_sz = XML->sys.core[ithCore].store_buffer_size *
+                          interface_ip.line_sz *
+                          XML->sys.core[ithCore].number_hardware_threads;
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 1;
+  interface_ip.throughput = 1.0 / clockRate;
+  interface_ip.latency = 1.0 / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = 0;
+  interface_ip.num_rd_ports = XML->sys.core[ithCore].memory_ports;
+  interface_ip.num_wr_ports = XML->sys.core[ithCore].memory_ports;
+  interface_ip.num_se_rd_ports = 0;
+  interface_ip.num_search_ports = XML->sys.core[ithCore].memory_ports;
+  LSQ = new ArrayST(&interface_ip, "Load(Store)Queue", Core_device,
+                    coredynp.opt_local, coredynp.core_ty);
+  LSQ->area.set_area(LSQ->area.get_area() + LSQ->local_result.area);
+  area.set_area(area.get_area() + LSQ->local_result.area);
+  area.set_area(area.get_area() * cdb_overhead);
+  // output_data_csv(LSQ.LSQ.local_result);
+  lsq_height =
+      LSQ->local_result.cache_ht *
+      sqrt(cdb_overhead); /*XML->sys.core[ithCore].number_hardware_threads*/
 
-	  //WBB
-	  if (cache_p==Write_back)
-	  {
-		  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-		  data							   = tcache.caches->l_ip.line_sz;
-		  interface_ip.specific_tag        = 1;
-		  interface_ip.tag_w               = tag;
-		  interface_ip.line_sz             = data;
-		  interface_ip.cache_sz            = XML->sys.core[ithCore].tcache.buffer_sizes[3]*interface_ip.line_sz;
-		  interface_ip.assoc               = 0;
-		  interface_ip.nbanks              = 1;
-		  interface_ip.out_w               = interface_ip.line_sz*8;
-		  interface_ip.access_mode         = 2;
-		  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[4]/clockRate;
-		  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[5]/clockRate;
-		  interface_ip.obj_func_dyn_energy = 0;
-		  interface_ip.obj_func_dyn_power  = 0;
-		  interface_ip.obj_func_leak_power = 0;
-		  interface_ip.obj_func_cycle_t    = 1;
-		  interface_ip.num_rw_ports    = XML->sys.core[ithCore].memory_ports;
-		  interface_ip.num_rd_ports    = 0;
-		  interface_ip.num_wr_ports    = 0;
-		  interface_ip.num_se_rd_ports = 0;
-		  tcache.wbb = new ArrayST(&interface_ip, "tcacheWBB", Core_device, coredynp.opt_local, coredynp.core_ty);
-		  tcache.area.set_area(tcache.area.get_area()+ tcache.wbb->local_result.area);
-		  area.set_area(area.get_area()+ tcache.wbb->local_result.area);
-		  //output_data_csv(tcache.wbb.local_result);
-	  }
-
-
-
-
-   /*
-    * dcache starts here
-    */   
-    //Dcache
-	  size                             = (int)XML->sys.core[ithCore].dcache.dcache_config[0];
-	  line                             = (int)XML->sys.core[ithCore].dcache.dcache_config[1];
-	  assoc                            = (int)XML->sys.core[ithCore].dcache.dcache_config[2];
-	  idx    					 	   = debug?9:int(ceil(log2(size/line/assoc)));
-	  tag							   = debug?51:XML->sys.physical_address_width-idx-int(ceil(log2(line))) + EXTRA_TAG_BITS;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.cache_sz            = debug?32768:(int)XML->sys.core[ithCore].dcache.dcache_config[0];
-	  interface_ip.line_sz             = debug?64:(int)XML->sys.core[ithCore].dcache.dcache_config[1];
-	  interface_ip.assoc               = debug?8:(int)XML->sys.core[ithCore].dcache.dcache_config[2];
-	  interface_ip.nbanks              = debug?1:(int)XML->sys.core[ithCore].dcache.dcache_config[3];
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 0;//debug?0:XML->sys.core[ithCore].dcache.dcache_config[5];
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?3.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[5]/clockRate;
-	  interface_ip.is_cache			 = true;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;//usually In-order has 1 and OOO has 2 at least.
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  dcache.caches = new ArrayST(&interface_ip, "dcache", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  dcache.area.set_area(dcache.area.get_area()+ dcache.caches->local_result.area);
-	  area.set_area(area.get_area()+ dcache.caches->local_result.area);
-	  //output_data_csv(dcache.caches.local_result);
-
-
-	  //dCache controllers
-	  //miss buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  data							   = (XML->sys.physical_address_width) + int(ceil(log2(size/line))) + dcache.caches->l_ip.line_sz*8;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-	  interface_ip.cache_sz            = XML->sys.core[ithCore].dcache.buffer_sizes[0]*interface_ip.line_sz;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 2;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  dcache.missb = new ArrayST(&interface_ip, "dcacheMissBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  dcache.area.set_area(dcache.area.get_area()+ dcache.missb->local_result.area);
-	  area.set_area(area.get_area()+ dcache.missb->local_result.area);
-	  //output_data_csv(dcache.missb.local_result);
-
-	  //fill buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  data							   = dcache.caches->l_ip.line_sz;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-	  interface_ip.cache_sz            = data*XML->sys.core[ithCore].dcache.buffer_sizes[1];
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 2;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  dcache.ifb = new ArrayST(&interface_ip, "dcacheFillBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  dcache.area.set_area(dcache.area.get_area()+ dcache.ifb->local_result.area);
-	  area.set_area(area.get_area()+ dcache.ifb->local_result.area);
-	  //output_data_csv(dcache.ifb.local_result);
-
-	  //prefetch buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries to decide wthether to merge.
-	  data							   = dcache.caches->l_ip.line_sz;//separate queue to prevent from cache polution.
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-	  interface_ip.cache_sz            = XML->sys.core[ithCore].dcache.buffer_sizes[2]*interface_ip.line_sz;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 2;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  dcache.prefetchb = new ArrayST(&interface_ip, "dcacheprefetchBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  dcache.area.set_area(dcache.area.get_area()+ dcache.prefetchb->local_result.area);
-	  area.set_area(area.get_area()+ dcache.prefetchb->local_result.area);
-	  //output_data_csv(dcache.prefetchb.local_result);
-
-	  //WBB
-	  if (cache_p==Write_back)
-	  {
-		  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-		  data							   = dcache.caches->l_ip.line_sz;
-		  interface_ip.specific_tag        = 1;
-		  interface_ip.tag_w               = tag;
-		  interface_ip.line_sz             = data;
-		  interface_ip.cache_sz            = XML->sys.core[ithCore].dcache.buffer_sizes[3]*interface_ip.line_sz;
-		  interface_ip.assoc               = 0;
-		  interface_ip.nbanks              = 1;
-		  interface_ip.out_w               = interface_ip.line_sz*8;
-		  interface_ip.access_mode         = 2;
-		  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[4]/clockRate;
-		  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[5]/clockRate;
-		  interface_ip.obj_func_dyn_energy = 0;
-		  interface_ip.obj_func_dyn_power  = 0;
-		  interface_ip.obj_func_leak_power = 0;
-		  interface_ip.obj_func_cycle_t    = 1;
-		  interface_ip.num_rw_ports    = XML->sys.core[ithCore].memory_ports;
-		  interface_ip.num_rd_ports    = 0;
-		  interface_ip.num_wr_ports    = 0;
-		  interface_ip.num_se_rd_ports = 0;
-		  dcache.wbb = new ArrayST(&interface_ip, "dcacheWBB", Core_device, coredynp.opt_local, coredynp.core_ty);
-		  dcache.area.set_area(dcache.area.get_area()+ dcache.wbb->local_result.area);
-		  area.set_area(area.get_area()+ dcache.wbb->local_result.area);
-		  //output_data_csv(dcache.wbb.local_result);
-	  }
-
-	  /*
-	   * LSU--in-order processors do not have separate load queue: unified lsq
-	   * partitioned among threads
-	   * it is actually the store queue but for inorder processors it serves as both loadQ and StoreQ
-	   */
-	  tag							   = ldst_opcode+XML->sys.virtual_address_width +int(ceil(log2(XML->sys.core[ithCore].number_hardware_threads))) + EXTRA_TAG_BITS;
-	  data							   = XML->sys.machine_bits;
-	  interface_ip.is_cache			   = true;
-	  interface_ip.line_sz             = int(ceil(data/32.0))*4;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.cache_sz            = XML->sys.core[ithCore].store_buffer_size*interface_ip.line_sz*XML->sys.core[ithCore].number_hardware_threads;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 1;
-	  interface_ip.throughput          = 1.0/clockRate;
-	  interface_ip.latency             = 1.0/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports        = 0;
-	  interface_ip.num_rd_ports        = XML->sys.core[ithCore].memory_ports;
-	  interface_ip.num_wr_ports        = XML->sys.core[ithCore].memory_ports;
-	  interface_ip.num_se_rd_ports     = 0;
-	  interface_ip.num_search_ports    =XML->sys.core[ithCore].memory_ports;
-	  LSQ = new ArrayST(&interface_ip, "Load(Store)Queue", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  LSQ->area.set_area(LSQ->area.get_area()+ LSQ->local_result.area);
-	  area.set_area(area.get_area()+ LSQ->local_result.area);
-	  area.set_area(area.get_area()*cdb_overhead);
-	  //output_data_csv(LSQ.LSQ.local_result);
-	  lsq_height=LSQ->local_result.cache_ht*sqrt(cdb_overhead);/*XML->sys.core[ithCore].number_hardware_threads*/
-
-	  if ((coredynp.core_ty==OOO) && (XML->sys.core[ithCore].load_buffer_size >0))
-	  {
-		  interface_ip.line_sz             = int(ceil(data/32.0))*4;
-		  interface_ip.specific_tag        = 1;
-		  interface_ip.tag_w               = tag;
-		  interface_ip.cache_sz            = XML->sys.core[ithCore].load_buffer_size*interface_ip.line_sz*XML->sys.core[ithCore].number_hardware_threads;
-		  interface_ip.assoc               = 0;
-		  interface_ip.nbanks              = 1;
-		  interface_ip.out_w               = interface_ip.line_sz*8;
-		  interface_ip.access_mode         = 1;
-		  interface_ip.throughput          = 1.0/clockRate;
-		  interface_ip.latency             = 1.0/clockRate;
-		  interface_ip.obj_func_dyn_energy = 0;
-		  interface_ip.obj_func_dyn_power  = 0;
-		  interface_ip.obj_func_leak_power = 0;
-		  interface_ip.obj_func_cycle_t    = 1;
-		  interface_ip.num_rw_ports        = 0;
-		  interface_ip.num_rd_ports        = XML->sys.core[ithCore].memory_ports;
-		  interface_ip.num_wr_ports        = XML->sys.core[ithCore].memory_ports;
-		  interface_ip.num_se_rd_ports     = 0;
-		  interface_ip.num_search_ports    =XML->sys.core[ithCore].memory_ports;
-		  LoadQ = new ArrayST(&interface_ip, "LoadQueue", Core_device, coredynp.opt_local, coredynp.core_ty);
-		  LoadQ->area.set_area(LoadQ->area.get_area()+ LoadQ->local_result.area);
-		  area.set_area(area.get_area()+ LoadQ->local_result.area);
-		  area.set_area(area.get_area()*cdb_overhead);
-		  //output_data_csv(LoadQ.LoadQ.local_result);
-		  lsq_height=(LSQ->local_result.cache_ht + LoadQ->local_result.cache_ht)*sqrt(cdb_overhead);/*XML->sys.core[ithCore].number_hardware_threads*/
-	  }
-
+  if ((coredynp.core_ty == OOO) &&
+      (XML->sys.core[ithCore].load_buffer_size > 0)) {
+    interface_ip.line_sz = int(ceil(data / 32.0)) * 4;
+    interface_ip.specific_tag = 1;
+    interface_ip.tag_w = tag;
+    interface_ip.cache_sz = XML->sys.core[ithCore].load_buffer_size *
+                            interface_ip.line_sz *
+                            XML->sys.core[ithCore].number_hardware_threads;
+    interface_ip.assoc = 0;
+    interface_ip.nbanks = 1;
+    interface_ip.out_w = interface_ip.line_sz * 8;
+    interface_ip.access_mode = 1;
+    interface_ip.throughput = 1.0 / clockRate;
+    interface_ip.latency = 1.0 / clockRate;
+    interface_ip.obj_func_dyn_energy = 0;
+    interface_ip.obj_func_dyn_power = 0;
+    interface_ip.obj_func_leak_power = 0;
+    interface_ip.obj_func_cycle_t = 1;
+    interface_ip.num_rw_ports = 0;
+    interface_ip.num_rd_ports = XML->sys.core[ithCore].memory_ports;
+    interface_ip.num_wr_ports = XML->sys.core[ithCore].memory_ports;
+    interface_ip.num_se_rd_ports = 0;
+    interface_ip.num_search_ports = XML->sys.core[ithCore].memory_ports;
+    LoadQ = new ArrayST(&interface_ip, "LoadQueue", Core_device,
+                        coredynp.opt_local, coredynp.core_ty);
+    LoadQ->area.set_area(LoadQ->area.get_area() + LoadQ->local_result.area);
+    area.set_area(area.get_area() + LoadQ->local_result.area);
+    area.set_area(area.get_area() * cdb_overhead);
+    // output_data_csv(LoadQ.LoadQ.local_result);
+    lsq_height =
+        (LSQ->local_result.cache_ht + LoadQ->local_result.cache_ht) *
+        sqrt(cdb_overhead); /*XML->sys.core[ithCore].number_hardware_threads*/
+  }
 }
 
-MemManU::MemManU(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_,bool exist_)
-:XML(XML_interface),
- ithCore(ithCore_),
- interface_ip(*interface_ip_),
- coredynp(dyn_p_),
- itlb(0),
- dtlb(0),
- exist(exist_)
-{
-	  if (!exist) return;
-	  int  tag, data;
-	  bool debug= false;
+MemManU::MemManU(ParseXML* XML_interface, int ithCore_,
+                 InputParameter* interface_ip_, const CoreDynParam& dyn_p_,
+                 bool exist_)
+    : XML(XML_interface),
+      ithCore(ithCore_),
+      interface_ip(*interface_ip_),
+      coredynp(dyn_p_),
+      itlb(0),
+      dtlb(0),
+      exist(exist_) {
+  if (!exist) return;
+  int tag, data;
+  bool debug = false;
 
-	  clockRate = coredynp.clockRate;
-	  executionTime = coredynp.executionTime;
+  clockRate = coredynp.clockRate;
+  executionTime = coredynp.executionTime;
 
-	  interface_ip.is_cache			   = true;
-	  interface_ip.pure_cam            = false;
-	  interface_ip.pure_ram            = false;
-	  interface_ip.specific_tag        = 1;
-	  //Itlb TLBs are partioned among threads according to Nigara and Nehalem
-	  tag							   = XML->sys.virtual_address_width- int(floor(log2(XML->sys.virtual_memory_page_size))) + int(ceil(log2(XML->sys.core[ithCore].number_hardware_threads)))+ EXTRA_TAG_BITS;
-	  data							   = XML->sys.physical_address_width- int(floor(log2(XML->sys.virtual_memory_page_size)));
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-	  interface_ip.cache_sz            = XML->sys.core[ithCore].itlb.number_entries*interface_ip.line_sz;//*XML->sys.core[ithCore].number_hardware_threads;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 0;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].icache.icache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].icache.icache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = 0;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = debug?1:XML->sys.core[ithCore].number_instruction_fetch_ports;
-	  interface_ip.num_se_rd_ports = 0;
-	  interface_ip.num_search_ports    = debug?1:XML->sys.core[ithCore].number_instruction_fetch_ports;
-	  itlb = new ArrayST(&interface_ip, "ITLB", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  itlb->area.set_area(itlb->area.get_area()+ itlb->local_result.area);
-	  area.set_area(area.get_area()+ itlb->local_result.area);
-	  //output_data_csv(itlb.tlb.local_result);
+  interface_ip.is_cache = true;
+  interface_ip.pure_cam = false;
+  interface_ip.pure_ram = false;
+  interface_ip.specific_tag = 1;
+  // Itlb TLBs are partioned among threads according to Nigara and Nehalem
+  tag = XML->sys.virtual_address_width -
+        int(floor(log2(XML->sys.virtual_memory_page_size))) +
+        int(ceil(log2(XML->sys.core[ithCore].number_hardware_threads))) +
+        EXTRA_TAG_BITS;
+  data = XML->sys.physical_address_width -
+         int(floor(log2(XML->sys.virtual_memory_page_size)));
+  interface_ip.tag_w = tag;
+  interface_ip.line_sz =
+      int(ceil(data / 8.0));  // int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+  interface_ip.cache_sz =
+      XML->sys.core[ithCore].itlb.number_entries *
+      interface_ip.line_sz;  //*XML->sys.core[ithCore].number_hardware_threads;
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 0;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].icache.icache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].icache.icache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = 0;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports =
+      debug ? 1 : XML->sys.core[ithCore].number_instruction_fetch_ports;
+  interface_ip.num_se_rd_ports = 0;
+  interface_ip.num_search_ports =
+      debug ? 1 : XML->sys.core[ithCore].number_instruction_fetch_ports;
+  itlb = new ArrayST(&interface_ip, "ITLB", Core_device, coredynp.opt_local,
+                     coredynp.core_ty);
+  itlb->area.set_area(itlb->area.get_area() + itlb->local_result.area);
+  area.set_area(area.get_area() + itlb->local_result.area);
+  // output_data_csv(itlb.tlb.local_result);
 
-	  //dtlb
-	  tag							   = XML->sys.virtual_address_width- int(floor(log2(XML->sys.virtual_memory_page_size))) +int(ceil(log2(XML->sys.core[ithCore].number_hardware_threads)))+ EXTRA_TAG_BITS;
-	  data							   = XML->sys.physical_address_width- int(floor(log2(XML->sys.virtual_memory_page_size)));
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-	  interface_ip.cache_sz            = XML->sys.core[ithCore].dtlb.number_entries*interface_ip.line_sz;//*XML->sys.core[ithCore].number_hardware_threads;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 0;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = 0;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = XML->sys.core[ithCore].memory_ports;
-	  interface_ip.num_se_rd_ports = 0;
-	  interface_ip.num_search_ports = XML->sys.core[ithCore].memory_ports;
-	  dtlb = new ArrayST(&interface_ip, "DTLB", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  dtlb->area.set_area(dtlb->area.get_area()+ dtlb->local_result.area);
-	  area.set_area(area.get_area()+ dtlb->local_result.area);
-	  //output_data_csv(dtlb.tlb.local_result);
-
+  // dtlb
+  tag = XML->sys.virtual_address_width -
+        int(floor(log2(XML->sys.virtual_memory_page_size))) +
+        int(ceil(log2(XML->sys.core[ithCore].number_hardware_threads))) +
+        EXTRA_TAG_BITS;
+  data = XML->sys.physical_address_width -
+         int(floor(log2(XML->sys.virtual_memory_page_size)));
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.line_sz =
+      int(ceil(data / 8.0));  // int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+  interface_ip.cache_sz =
+      XML->sys.core[ithCore].dtlb.number_entries *
+      interface_ip.line_sz;  //*XML->sys.core[ithCore].number_hardware_threads;
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 0;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].dcache.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].dcache.dcache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = 0;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = XML->sys.core[ithCore].memory_ports;
+  interface_ip.num_se_rd_ports = 0;
+  interface_ip.num_search_ports = XML->sys.core[ithCore].memory_ports;
+  dtlb = new ArrayST(&interface_ip, "DTLB", Core_device, coredynp.opt_local,
+                     coredynp.core_ty);
+  dtlb->area.set_area(dtlb->area.get_area() + dtlb->local_result.area);
+  area.set_area(area.get_area() + dtlb->local_result.area);
+  // output_data_csv(dtlb.tlb.local_result);
 }
 //#define FERMI
 
-RegFU::RegFU(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_,double exClockRate,bool exist_)
-:XML(XML_interface),
- ithCore(ithCore_),
- interface_ip(*interface_ip_),
- coredynp(dyn_p_),
- IRF (0),
- FRF (0),
- RFWIN (0),
- exist(exist_)
- {
-	/*
-	 * processors have separate architectural register files for each thread.
-	 * therefore, the bypass buses need to travel across all the register files.
-	 */
-	if (!exist) return;
-	int  data;
-	clockRate = exClockRate;//coredynp.clockRate;
-	executionTime = coredynp.executionTime;
+RegFU::RegFU(ParseXML* XML_interface, int ithCore_,
+             InputParameter* interface_ip_, const CoreDynParam& dyn_p_,
+             double exClockRate, bool exist_)
+    : XML(XML_interface),
+      ithCore(ithCore_),
+      interface_ip(*interface_ip_),
+      coredynp(dyn_p_),
+      IRF(0),
+      FRF(0),
+      RFWIN(0),
+      exist(exist_) {
+  /*
+   * processors have separate architectural register files for each thread.
+   * therefore, the bypass buses need to travel across all the register files.
+   */
+  if (!exist) return;
+  int data;
+  clockRate = exClockRate;  // coredynp.clockRate;
+  executionTime = coredynp.executionTime;
   /*********************************************************************************
-	* OC stage modelling (Syed Gilani)
-	*********************************************************************************/
-  
-  //Crossbar
- 
-	if(XML->sys.architecture==1){
-  xbar_rfu     = new Crossbar(XML->sys.core[ithCore].rf_banks/2,XML->sys.core[ithCore].collector_units/2
-		                 ,(128),&(g_tp.peri_global));
-	}else{
-  xbar_rfu     = new Crossbar(XML->sys.core[ithCore].rf_banks,XML->sys.core[ithCore].collector_units
-		                 ,(128),&(g_tp.peri_global));
-	}
+   * OC stage modelling (Syed Gilani)
+   *********************************************************************************/
 
-  //new Crossbar(simd_width,shared_memory_banks,word_length*simd_width,&(g_tp.peri_global));
+  // Crossbar
 
-  //Arbiter
-  arbiter_rfu = new MCPAT_Arbiter(XML->sys.core[ithCore].rf_banks,XML->sys.core[ithCore].collector_units , 1,&(g_tp.peri_global));
+  if (XML->sys.architecture == 1) {
+    xbar_rfu = new Crossbar(XML->sys.core[ithCore].rf_banks / 2,
+                            XML->sys.core[ithCore].collector_units / 2, (128),
+                            &(g_tp.peri_global));
+  } else {
+    xbar_rfu = new Crossbar(XML->sys.core[ithCore].rf_banks,
+                            XML->sys.core[ithCore].collector_units, (128),
+                            &(g_tp.peri_global));
+  }
 
+  // new
+  // Crossbar(simd_width,shared_memory_banks,word_length*simd_width,&(g_tp.peri_global));
 
+  // Arbiter
+  arbiter_rfu = new MCPAT_Arbiter(XML->sys.core[ithCore].rf_banks,
+                                  XML->sys.core[ithCore].collector_units, 1,
+                                  &(g_tp.peri_global));
 
-	// RF banks modelled here for GPGPU-Sim (Syed Gilani)
-	//
-	//**********************************IRF***************************************
-	data							 = coredynp.int_data_width;
-  //data               *= 8;
-	interface_ip.is_cache			 = false;
-	interface_ip.pure_cam            = false;
-	interface_ip.pure_ram            = true;
+  // RF banks modelled here for GPGPU-Sim (Syed Gilani)
+  //
+  //**********************************IRF***************************************
+  data = coredynp.int_data_width;
+  // data               *= 8;
+  interface_ip.is_cache = false;
+  interface_ip.pure_cam = false;
+  interface_ip.pure_ram = true;
 
-	interface_ip.line_sz             = 16;//int(ceil(data/32.0))*4 * XML->sys.core[ithCore].simd_width/4 ;//2 for Tesla as RF width half of SIMD width
+  interface_ip.line_sz =
+      16;  // int(ceil(data/32.0))*4 * XML->sys.core[ithCore].simd_width/4 ;//2
+           // for Tesla as RF width half of SIMD width
 
-	interface_ip.line_sz             = 16;//int(ceil(data/32.0))*4 * XML->sys.core[ithCore].simd_width/2 ;//2 for Tesla as RF width half of SIMD width
+  interface_ip.line_sz =
+      16;  // int(ceil(data/32.0))*4 * XML->sys.core[ithCore].simd_width/2 ;//2
+           // for Tesla as RF width half of SIMD width
 
-	interface_ip.cache_sz            = coredynp.num_IRF_entry*4;
-	interface_ip.assoc               = 1;
-	interface_ip.nbanks              = XML->sys.core[ithCore].rf_banks;
+  interface_ip.cache_sz = coredynp.num_IRF_entry * 4;
+  interface_ip.assoc = 1;
+  interface_ip.nbanks = XML->sys.core[ithCore].rf_banks;
 
-	interface_ip.out_w               = interface_ip.line_sz*8;//interface_ip.line_sz*XML->sys.core[ithCore].simd_width/4; //2 for Tesla and 4 for Fermi
+  interface_ip.out_w =
+      interface_ip.line_sz *
+      8;  // interface_ip.line_sz*XML->sys.core[ithCore].simd_width/4;
+          // //2 for Tesla and 4 for Fermi
 
-	interface_ip.out_w               = interface_ip.line_sz*8;//interface_ip.line_sz*XML->sys.core[ithCore].simd_width/2; //2 for Tesla and 4 for Fermi
+  interface_ip.out_w =
+      interface_ip.line_sz *
+      8;  // interface_ip.line_sz*XML->sys.core[ithCore].simd_width/2;
+          // //2 for Tesla and 4 for Fermi
 
+  interface_ip.access_mode = 1;
+  interface_ip.throughput = 1 / (clockRate);
+  interface_ip.latency = 8.0 / (clockRate);
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 1;
+  interface_ip.obj_func_cycle_t = 0;
+  interface_ip.num_rw_ports =
+      0;  // this is the transfer port for saving/restoring states when
+          // exceptions happen.
+  interface_ip.num_rd_ports = 1;  // 2*coredynp.peak_issueW;
+  interface_ip.num_wr_ports = 1;  // coredynp.peak_issueW;
+  interface_ip.num_se_rd_ports = 0;
+  IRF = new ArrayST(&interface_ip, "Integer Register File", Core_device,
+                    coredynp.opt_local, coredynp.core_ty);
 
-	interface_ip.access_mode         = 1;
-	interface_ip.throughput          = 1/(clockRate);
-	interface_ip.latency             = 8.0/(clockRate);
-	interface_ip.obj_func_dyn_energy = 0;
-	interface_ip.obj_func_dyn_power  = 0;
-	interface_ip.obj_func_leak_power = 1;
-	interface_ip.obj_func_cycle_t    = 0;
-	interface_ip.num_rw_ports    = 0;//this is the transfer port for saving/restoring states when exceptions happen.
-	interface_ip.num_rd_ports    = 1;//2*coredynp.peak_issueW;
-	interface_ip.num_wr_ports    = 1;//coredynp.peak_issueW;
-	interface_ip.num_se_rd_ports = 0;
-	IRF = new ArrayST(&interface_ip, "Integer Register File", Core_device, coredynp.opt_local, coredynp.core_ty);
+  IRF->area.set_area(IRF->area.get_area() + IRF->local_result.area *
+                                                coredynp.num_pipelines *
+                                                cdb_overhead);
 
-	IRF->area.set_area(IRF->area.get_area()+ IRF->local_result.area*coredynp.num_pipelines*cdb_overhead);
+  area.set_area(area.get_area() + IRF->local_result.area +
+                xbar_rfu->area.get_area() + arbiter_rfu->area.get_area());
+  if (XML->sys.architecture == 1) {
+    IRF->local_result.power.readOp.dynamic *= .33;
+    IRF->local_result.power.writeOp.dynamic *= .33;
+  } else {
+    IRF->local_result.power.readOp.dynamic *= .55;
+    IRF->local_result.power.writeOp.dynamic *= .55;
+  }
 
+  /**
+   * Operand collectors (32-bit wide, 8 entry banks )
+   */
+  data = 32;
+  // data               *= 8;
+  interface_ip.is_cache = false;
+  interface_ip.pure_cam = false;
+  interface_ip.pure_ram = true;
 
-	area.set_area(area.get_area()+ IRF->local_result.area
-		 + xbar_rfu->area.get_area() + arbiter_rfu->area.get_area());
-	if(XML->sys.architecture==1){
-	IRF->local_result.power.readOp.dynamic *= .33;
-	IRF->local_result.power.writeOp.dynamic *= .33;
-	}
-	else {
-	IRF->local_result.power.readOp.dynamic *= .55;
-	IRF->local_result.power.writeOp.dynamic *= .55;
-	}
+  interface_ip.line_sz =
+      4;  // int(ceil(data/32.0))*4 * XML->sys.core[ithCore].simd_width/4 ;//2
+          // for Tesla as RF width half of SIMD width
 
+  interface_ip.line_sz =
+      4;  // int(ceil(data/32.0))*4 * XML->sys.core[ithCore].simd_width/2 ;//2
+          // for Tesla as RF width half of SIMD width
 
+  interface_ip.cache_sz = 8 * 4;
+  interface_ip.assoc = 1;
+  interface_ip.nbanks = 1;
 
+  interface_ip.out_w =
+      interface_ip
+          .line_sz;  // interface_ip.line_sz*XML->sys.core[ithCore].simd_width/4;
+                     // //2 for Tesla and 4 for Fermi
 
-	/**
-	 * Operand collectors (32-bit wide, 8 entry banks )
-	 */
-	data							 = 32;
-  //data               *= 8;
-	interface_ip.is_cache			 = false;
-	interface_ip.pure_cam            = false;
-	interface_ip.pure_ram            = true;
+  interface_ip.out_w =
+      interface_ip
+          .line_sz;  // interface_ip.line_sz*XML->sys.core[ithCore].simd_width/2;
+                     // //2 for Tesla and 4 for Fermi
 
-	interface_ip.line_sz             = 4;//int(ceil(data/32.0))*4 * XML->sys.core[ithCore].simd_width/4 ;//2 for Tesla as RF width half of SIMD width
+  interface_ip.access_mode = 1;
+  interface_ip.throughput = 1.0 / (clockRate);
+  interface_ip.latency = 1.0 / (clockRate);
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 1;
+  interface_ip.obj_func_cycle_t = 0;
+  interface_ip.num_rw_ports =
+      0;  // this is the transfer port for saving/restoring states when
+          // exceptions happen.
+  interface_ip.num_rd_ports = 1;  // 2*coredynp.peak_issueW;
+  interface_ip.num_wr_ports = 1;  // coredynp.peak_issueW;
+  interface_ip.num_se_rd_ports = 0;
+  OPC = new ArrayST(&interface_ip, "Operand collectors", Core_device,
+                    coredynp.opt_local, coredynp.core_ty);
 
-	interface_ip.line_sz             = 4;//int(ceil(data/32.0))*4 * XML->sys.core[ithCore].simd_width/2 ;//2 for Tesla as RF width half of SIMD width
+  OPC->area.set_area(OPC->area.get_area() + OPC->local_result.area *
+                                                coredynp.num_pipelines *
+                                                cdb_overhead);
 
-	interface_ip.cache_sz            = 8*4;
-	interface_ip.assoc               = 1;
-	interface_ip.nbanks              = 1;
+  area.set_area(area.get_area() + OPC->local_result.area);
 
-	interface_ip.out_w               = interface_ip.line_sz;//interface_ip.line_sz*XML->sys.core[ithCore].simd_width/4; //2 for Tesla and 4 for Fermi
+  /********
+   * For GPGPUSim (Syed Gilani)
+   * Do not include FRF in final results for GPU. Only model the IRF
+   ********/
 
-	interface_ip.out_w               = interface_ip.line_sz;//interface_ip.line_sz*XML->sys.core[ithCore].simd_width/2; //2 for Tesla and 4 for Fermi
-
-
-	interface_ip.access_mode         = 1;
-	interface_ip.throughput          = 1.0/(clockRate);
-	interface_ip.latency             = 1.0/(clockRate);
-	interface_ip.obj_func_dyn_energy = 0;
-	interface_ip.obj_func_dyn_power  = 0;
-	interface_ip.obj_func_leak_power = 1;
-	interface_ip.obj_func_cycle_t    = 0;
-	interface_ip.num_rw_ports    = 0;//this is the transfer port for saving/restoring states when exceptions happen.
-	interface_ip.num_rd_ports    = 1;//2*coredynp.peak_issueW;
-	interface_ip.num_wr_ports    = 1;//coredynp.peak_issueW;
-	interface_ip.num_se_rd_ports = 0;
-	OPC = new ArrayST(&interface_ip, "Operand collectors", Core_device, coredynp.opt_local, coredynp.core_ty);
-
-	OPC->area.set_area(OPC->area.get_area()+ OPC->local_result.area*coredynp.num_pipelines*cdb_overhead);
-
-
-	area.set_area(area.get_area()+ OPC->local_result.area);
-
-
-
-
-	/********
-	 * For GPGPUSim (Syed Gilani)
-	 * Do not include FRF in final results for GPU. Only model the IRF
-	 ********/
-
-	//**********************************FRF***************************************
-	data							 = coredynp.fp_data_width;
-  //data               *= 8;
-	interface_ip.is_cache			 = false;
-	interface_ip.pure_cam            = false;
-	interface_ip.pure_ram            = true;
-	interface_ip.line_sz             = int(ceil(data/32.0))*4;
-	interface_ip.cache_sz            = coredynp.num_FRF_entry*interface_ip.line_sz;
-	interface_ip.assoc               = 1;
-	interface_ip.nbanks              = 1;
-	interface_ip.out_w               = interface_ip.line_sz*8;
-	interface_ip.access_mode         = 1;
-	interface_ip.throughput          = 1.0/clockRate;
-	interface_ip.latency             = 1.0/clockRate;
-	interface_ip.obj_func_dyn_energy = 0;
-	interface_ip.obj_func_dyn_power  = 0;
-	interface_ip.obj_func_leak_power = 0;
-	interface_ip.obj_func_cycle_t    = 1;
-	interface_ip.num_rw_ports    = 1;//this is the transfer port for saving/restoring states when exceptions happen.
-	interface_ip.num_rd_ports    = 2*XML->sys.core[ithCore].issue_width;
-	//interface_ip.num_rd_ports    = 1;
-	interface_ip.num_wr_ports    = XML->sys.core[ithCore].issue_width;
-	//interface_ip.num_wr_ports    = 1;
-	interface_ip.num_se_rd_ports = 0;
-	FRF = new ArrayST(&interface_ip, "Floating point Register File", Core_device, coredynp.opt_local, coredynp.core_ty);
-	//FRF->area.set_area(FRF->area.get_area()+ FRF->local_result.area*XML->sys.core[ithCore].number_hardware_threads*coredynp.num_fp_pipelines*cdb_overhead);
-	//area.set_area(area.get_area()+ FRF->local_result.area*XML->sys.core[ithCore].number_hardware_threads*coredynp.num_fp_pipelines*cdb_overhead);
-	//area.set_area(area.get_area()*cdb_overhead);
-	//output_data_csv(FRF.RF.local_result);
-	int_regfile_height= IRF->local_result.cache_ht*XML->sys.core[ithCore].number_hardware_threads*sqrt(cdb_overhead);
-	fp_regfile_height=0;
-	//fp_regfile_height = FRF->local_result.cache_ht*XML->sys.core[ithCore].number_hardware_threads*sqrt(cdb_overhead);
-    //since a EXU is associated with each pipeline, the cdb should not have longer length.
-	if (coredynp.regWindowing)
-	{
-		//*********************************REG_WIN************************************
-		data							 = coredynp.int_data_width; //ECC, and usually 2 regs are transfered together during window shifting.Niagara Mega cell
-		interface_ip.is_cache			 = false;
-		interface_ip.pure_cam            = false;
-		interface_ip.pure_ram            = true;
-		interface_ip.line_sz             = int(ceil(data/8.0));
-		interface_ip.cache_sz            = XML->sys.core[ithCore].register_windows_size*IRF->l_ip.cache_sz*XML->sys.core[ithCore].number_hardware_threads;
-		interface_ip.assoc               = 1;
-		interface_ip.nbanks              = 1;
-		interface_ip.out_w               = interface_ip.line_sz*8;
-		interface_ip.access_mode         = 1;
-		interface_ip.throughput          = 4.0/clockRate;
-		interface_ip.latency             = 4.0/clockRate;
-		interface_ip.obj_func_dyn_energy = 0;
-		interface_ip.obj_func_dyn_power  = 0;
-		interface_ip.obj_func_leak_power = 0;
-		interface_ip.obj_func_cycle_t    = 1;
-		interface_ip.num_rw_ports    = 1;//this is the transfer port for saving/restoring states when exceptions happen.
-		interface_ip.num_rd_ports    = 0;
-		interface_ip.num_wr_ports    = 0;
-		interface_ip.num_se_rd_ports = 0;
-		RFWIN = new ArrayST(&interface_ip, "RegWindow", Core_device, coredynp.opt_local, coredynp.core_ty);
-		RFWIN->area.set_area(RFWIN->area.get_area()+ RFWIN->local_result.area*coredynp.num_pipelines);
-		area.set_area(area.get_area()+ RFWIN->local_result.area*coredynp.num_pipelines);
-		//output_data_csv(RFWIN.RF.local_result);
-	}
-
-
- }
-
-EXECU::EXECU(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, double lsq_height_, const CoreDynParam & dyn_p_,  double exClockRate, bool exist_)
-:XML(XML_interface),
- ithCore(ithCore_),
- interface_ip(*interface_ip_),
- lsq_height(lsq_height_),
- coredynp(dyn_p_),
- rfu(0),
- scheu(0),
- fp_u(0),
- exeu(0),
- mul(0),
- int_bypass(0),
- intTagBypass(0),
- int_mul_bypass(0),
- intTag_mul_Bypass(0),
- fp_bypass(0),
- fpTagBypass(0),
- exist(exist_),
- rf_fu_clockRate(exClockRate)
-{
-	  if (!exist) return;
-	  double fu_height = 0.0;
-      clockRate = coredynp.clockRate;
-		//cout <<"EXECU exClockRate: "<<exClockRate<<endl;
-      executionTime = coredynp.executionTime;
-	  rfu   = new RegFU(XML, ithCore, &interface_ip,coredynp,exClockRate);
-	  scheu = new SchedulerU(XML, ithCore, &interface_ip,coredynp);
-	  exeu  = new FunctionalUnit(XML, ithCore,&interface_ip, coredynp, ALU,exClockRate);
-	  area.set_area(area.get_area()+ exeu->area.get_area() + rfu->area.get_area() +scheu->area.get_area() );
-	  fu_height = exeu->FU_height;
-	  if (coredynp.num_fpus >0)
-	  {
-		  fp_u  = new FunctionalUnit(XML, ithCore,&interface_ip, coredynp, FPU, exClockRate);
-		  area.set_area(area.get_area()+ fp_u->area.get_area());
-	  }
-	  if (coredynp.num_muls >0)
-	  {
-		  mul   = new FunctionalUnit(XML, ithCore,&interface_ip, coredynp, MUL, exClockRate);
-		  area.set_area(area.get_area()+ mul->area.get_area());
-		  fu_height +=  mul->FU_height;
-	  }
-	  /*
-	   * broadcast logic, including int-broadcast; int_tag-broadcast; fp-broadcast; fp_tag-broadcast
-	   * integer by pass has two paths and fp has 3 paths.
-	   * on the same bus there are multiple tri-state drivers and muxes that go to different components on the same bus
-	   */
-	  if (XML->sys.Embedded)
-	  		{
-	  		interface_ip.wt                  =Global_30;
-	  		interface_ip.wire_is_mat_type = 0;
-	  		interface_ip.wire_os_mat_type = 0;
-	  	    interface_ip.throughput       = 1.0/clockRate;
-	  	    interface_ip.latency          = 1.0/clockRate;
-	  		}
-	  	else
-	  		{
-	  		interface_ip.wt                  =Global;
-	  		interface_ip.wire_is_mat_type = 2;//start from semi-global since local wires are already used
-	  		interface_ip.wire_os_mat_type = 2;
-	  	    interface_ip.throughput       = 10.0/clockRate; //Do not care
-	  	    interface_ip.latency          = 10.0/clockRate;
-	  		}
-
-	  if (coredynp.core_ty==Inorder)
-	  {//
-		  int_bypass   = new interconnect("Int Bypass Data", Core_device, 1, 1, int(ceil(XML->sys.machine_bits/32.0)*32),
-				  rfu->int_regfile_height + exeu->FU_height + lsq_height, &interface_ip, 3,
-				  false, 1.0, coredynp.opt_local, coredynp.core_ty);
-		  bypass.area.set_area(bypass.area.get_area() + int_bypass->area.get_area());
-		  intTagBypass = new interconnect("Int Bypass tag" , Core_device, 1, 1, coredynp.perThreadState,
-				  rfu->int_regfile_height + exeu->FU_height + lsq_height + scheu->Iw_height, &interface_ip, 3,
-				  false, 1.0, coredynp.opt_local, coredynp.core_ty);
-		  bypass.area.set_area(bypass.area.get_area()  +intTagBypass->area.get_area());
-
-		  if (coredynp.num_muls>0)
-		  {
-			  int_mul_bypass     = new interconnect("Mul Bypass Data" , Core_device, 1, 1, int(ceil(XML->sys.machine_bits/32.0)*32*1.5),
-					  rfu->fp_regfile_height + exeu->FU_height + mul->FU_height + lsq_height, &interface_ip, 3,
-					  false, 1.0, coredynp.opt_local, coredynp.core_ty);
-			  bypass.area.set_area(bypass.area.get_area()  +int_mul_bypass->area.get_area());
-			  intTag_mul_Bypass  = new interconnect("Mul Bypass tag"  , Core_device, 1, 1, coredynp.perThreadState,
-					  rfu->fp_regfile_height + exeu->FU_height + mul->FU_height + lsq_height + scheu->Iw_height, &interface_ip, 3,
-					  false, 1.0, coredynp.opt_local, coredynp.core_ty);
-			  bypass.area.set_area(bypass.area.get_area()  +intTag_mul_Bypass->area.get_area());
-		  }
-
-		  /*
-		  if (coredynp.num_fpus>0)
-		  {
-			  fp_bypass    = new interconnect("FP Bypass Data" , Core_device, 1, 1, int(ceil(XML->sys.machine_bits/32.0)*32*1.5),
-					  rfu->fp_regfile_height + fp_u->FU_height, &interface_ip, 3,
-					  false, 1.0, coredynp.opt_local, coredynp.core_ty);
-			  bypass.area.set_area(bypass.area.get_area()  +fp_bypass->area.get_area());
-			  fpTagBypass  = new interconnect("FP Bypass tag"  , Core_device, 1, 1, coredynp.perThreadState,
-					  rfu->fp_regfile_height + fp_u->FU_height + lsq_height + scheu->Iw_height, &interface_ip, 3,
-					  false, 1.0, coredynp.opt_local, coredynp.core_ty);
-			  bypass.area.set_area(bypass.area.get_area()  +fpTagBypass->area.get_area());
-		  }*/
-	  } /* if (coredynp.core_ty==Inorder) */ 
-	  else
-	  {//OOO
-		  if (coredynp.scheu_ty==PhysicalRegFile)
-		  {
-			  /* For physical register based OOO,
-			   * data broadcast interconnects cover across functional units, lsq, inst windows and register files,
-			   * while tag broadcast interconnects also cover across ROB
-			   */
-			  int_bypass   = new interconnect("Int Bypass Data", Core_device, 1, 1, int(ceil(coredynp.int_data_width)),
-					            rfu->int_regfile_height + exeu->FU_height + lsq_height, &interface_ip, 3,
-								false, 1.0, coredynp.opt_local, coredynp.core_ty);
-			  bypass.area.set_area(bypass.area.get_area()  +int_bypass->area.get_area());
-			  intTagBypass = new interconnect("Int Bypass tag" , Core_device, 1, 1, coredynp.phy_ireg_width,
-					            rfu->int_regfile_height + exeu->FU_height + lsq_height + scheu->Iw_height + scheu->ROB_height , &interface_ip, 3,
-								false, 1.0, coredynp.opt_local, coredynp.core_ty);
-
-			  if (coredynp.num_muls>0)
-			  {
-				  int_mul_bypass   = new interconnect("Mul Bypass Data", Core_device, 1, 1, int(ceil(coredynp.int_data_width)),
-										rfu->int_regfile_height + exeu->FU_height + mul->FU_height + lsq_height, &interface_ip, 3,
-										false, 1.0, coredynp.opt_local, coredynp.core_ty);
-				  intTag_mul_Bypass = new interconnect("Mul Bypass tag" , Core_device, 1, 1, coredynp.phy_ireg_width,
-										rfu->int_regfile_height + exeu->FU_height + mul->FU_height + lsq_height + scheu->Iw_height + scheu->ROB_height , &interface_ip, 3,
-										false, 1.0, coredynp.opt_local, coredynp.core_ty);
-				  bypass.area.set_area(bypass.area.get_area()  +int_mul_bypass->area.get_area());
-				  bypass.area.set_area(bypass.area.get_area()  +intTag_mul_Bypass->area.get_area());
-			  }
-
-			  if (coredynp.num_fpus>0)
-			  {
-				  fp_bypass    = new interconnect("FP Bypass Data" , Core_device, 1, 1, int(ceil(coredynp.fp_data_width)),
-								  rfu->fp_regfile_height + fp_u->FU_height, &interface_ip, 3,
-								  false, 1.0, coredynp.opt_local, coredynp.core_ty);
-				  fpTagBypass  = new interconnect("FP Bypass tag"  , Core_device, 1, 1, coredynp.phy_freg_width,
-								  rfu->fp_regfile_height + fp_u->FU_height + lsq_height + scheu->fp_Iw_height + scheu->ROB_height, &interface_ip, 3,
-								  false, 1.0, coredynp.opt_local, coredynp.core_ty);
-				  bypass.area.set_area(bypass.area.get_area()  +fp_bypass->area.get_area());
-				  bypass.area.set_area(bypass.area.get_area()  +fpTagBypass->area.get_area());
-			  }
-		  }
-		  else
-		  {
-             /*
-              * In RS based processor both data and tag are broadcast together,
-              * covering functional units, lsq, nst windows, register files, and ROBs
-              */
-			  int_bypass   = new interconnect("Int Bypass Data", Core_device, 1, 1, int(ceil(coredynp.int_data_width)),
-					            rfu->int_regfile_height + exeu->FU_height + lsq_height + scheu->Iw_height + scheu->ROB_height, &interface_ip, 3,
-								  false, 1.0, coredynp.opt_local, coredynp.core_ty);
-			  intTagBypass = new interconnect("Int Bypass tag" , Core_device, 1, 1, coredynp.phy_ireg_width,
-					            rfu->int_regfile_height + exeu->FU_height + lsq_height + scheu->Iw_height + scheu->ROB_height , &interface_ip, 3,
-								  false, 1.0, coredynp.opt_local, coredynp.core_ty);
-			  bypass.area.set_area(bypass.area.get_area() +int_bypass->area.get_area());
-			  bypass.area.set_area(bypass.area.get_area() +intTagBypass->area.get_area());
-			  if (coredynp.num_muls>0)
-			  {
-				  int_mul_bypass   = new interconnect("Mul Bypass Data", Core_device, 1, 1, int(ceil(coredynp.int_data_width)),
-						            rfu->int_regfile_height + exeu->FU_height + mul->FU_height + lsq_height + scheu->Iw_height + scheu->ROB_height, &interface_ip, 3,
-									  false, 1.0, coredynp.opt_local, coredynp.core_ty);
-				  intTag_mul_Bypass = new interconnect("Mul Bypass tag" , Core_device, 1, 1, coredynp.phy_ireg_width,
-						            rfu->int_regfile_height + exeu->FU_height + mul->FU_height + lsq_height + scheu->Iw_height + scheu->ROB_height , &interface_ip, 3,
-									  false, 1.0, coredynp.opt_local, coredynp.core_ty);
-				  bypass.area.set_area(bypass.area.get_area() +int_mul_bypass->area.get_area());
-				  bypass.area.set_area(bypass.area.get_area() +intTag_mul_Bypass->area.get_area());
-			  }
-
-			  if (coredynp.num_fpus>0)
-			  {
-				  fp_bypass    = new interconnect("FP Bypass Data" , Core_device, 1, 1, int(ceil(coredynp.fp_data_width)),
-						  rfu->fp_regfile_height + fp_u->FU_height + lsq_height + scheu->fp_Iw_height + scheu->ROB_height, &interface_ip, 3,
-						  false, 1.0, coredynp.opt_local, coredynp.core_ty);
-				  fpTagBypass  = new interconnect("FP Bypass tag"  , Core_device, 1, 1, coredynp.phy_freg_width,
-						  rfu->fp_regfile_height + fp_u->FU_height + lsq_height + scheu->fp_Iw_height + scheu->ROB_height, &interface_ip, 3,
-						  false, 1.0, coredynp.opt_local, coredynp.core_ty);
-				  bypass.area.set_area(bypass.area.get_area() +fp_bypass->area.get_area());
-				  bypass.area.set_area(bypass.area.get_area() +fpTagBypass->area.get_area());
-			  }
-		  } /* else */ 
-
-
-	  } /* else */ 
-	  area.set_area(area.get_area()/*+ bypass.area.get_area()*/);
+  //**********************************FRF***************************************
+  data = coredynp.fp_data_width;
+  // data               *= 8;
+  interface_ip.is_cache = false;
+  interface_ip.pure_cam = false;
+  interface_ip.pure_ram = true;
+  interface_ip.line_sz = int(ceil(data / 32.0)) * 4;
+  interface_ip.cache_sz = coredynp.num_FRF_entry * interface_ip.line_sz;
+  interface_ip.assoc = 1;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 1;
+  interface_ip.throughput = 1.0 / clockRate;
+  interface_ip.latency = 1.0 / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports =
+      1;  // this is the transfer port for saving/restoring states when
+          // exceptions happen.
+  interface_ip.num_rd_ports = 2 * XML->sys.core[ithCore].issue_width;
+  // interface_ip.num_rd_ports    = 1;
+  interface_ip.num_wr_ports = XML->sys.core[ithCore].issue_width;
+  // interface_ip.num_wr_ports    = 1;
+  interface_ip.num_se_rd_ports = 0;
+  FRF = new ArrayST(&interface_ip, "Floating point Register File", Core_device,
+                    coredynp.opt_local, coredynp.core_ty);
+  // FRF->area.set_area(FRF->area.get_area()+
+  // FRF->local_result.area*XML->sys.core[ithCore].number_hardware_threads*coredynp.num_fp_pipelines*cdb_overhead);
+  // area.set_area(area.get_area()+
+  // FRF->local_result.area*XML->sys.core[ithCore].number_hardware_threads*coredynp.num_fp_pipelines*cdb_overhead);
+  // area.set_area(area.get_area()*cdb_overhead);
+  // output_data_csv(FRF.RF.local_result);
+  int_regfile_height = IRF->local_result.cache_ht *
+                       XML->sys.core[ithCore].number_hardware_threads *
+                       sqrt(cdb_overhead);
+  fp_regfile_height = 0;
+  // fp_regfile_height =
+  // FRF->local_result.cache_ht*XML->sys.core[ithCore].number_hardware_threads*sqrt(cdb_overhead);
+  // since a EXU is associated with each pipeline, the cdb should not have
+  // longer length.
+  if (coredynp.regWindowing) {
+    //*********************************REG_WIN************************************
+    data =
+        coredynp
+            .int_data_width;  // ECC, and usually 2 regs are transfered together
+                              // during window shifting.Niagara Mega cell
+    interface_ip.is_cache = false;
+    interface_ip.pure_cam = false;
+    interface_ip.pure_ram = true;
+    interface_ip.line_sz = int(ceil(data / 8.0));
+    interface_ip.cache_sz = XML->sys.core[ithCore].register_windows_size *
+                            IRF->l_ip.cache_sz *
+                            XML->sys.core[ithCore].number_hardware_threads;
+    interface_ip.assoc = 1;
+    interface_ip.nbanks = 1;
+    interface_ip.out_w = interface_ip.line_sz * 8;
+    interface_ip.access_mode = 1;
+    interface_ip.throughput = 4.0 / clockRate;
+    interface_ip.latency = 4.0 / clockRate;
+    interface_ip.obj_func_dyn_energy = 0;
+    interface_ip.obj_func_dyn_power = 0;
+    interface_ip.obj_func_leak_power = 0;
+    interface_ip.obj_func_cycle_t = 1;
+    interface_ip.num_rw_ports =
+        1;  // this is the transfer port for saving/restoring states when
+            // exceptions happen.
+    interface_ip.num_rd_ports = 0;
+    interface_ip.num_wr_ports = 0;
+    interface_ip.num_se_rd_ports = 0;
+    RFWIN = new ArrayST(&interface_ip, "RegWindow", Core_device,
+                        coredynp.opt_local, coredynp.core_ty);
+    RFWIN->area.set_area(RFWIN->area.get_area() +
+                         RFWIN->local_result.area * coredynp.num_pipelines);
+    area.set_area(area.get_area() +
+                  RFWIN->local_result.area * coredynp.num_pipelines);
+    // output_data_csv(RFWIN.RF.local_result);
+  }
 }
 
-RENAMINGU::RENAMINGU(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_,bool exist_)
-:XML(XML_interface),
- ithCore(ithCore_),
- interface_ip(*interface_ip_),
- coredynp(dyn_p_),
- iFRAT(0),
- fFRAT(0),
- iRRAT(0),
- fRRAT(0),
- ifreeL(0),
- ffreeL(0),
- idcl(0),
- fdcl(0),
- RAHT(0),
- exist(exist_)
- {
-	/*
-	 * Although renaming logic maybe be used in in-order processors,
-     * McPAT assumes no renaming logic is used since the performance gain is very limited and
-     * the only major inorder processor with renaming logic is Itainium
-     * that is a VLIW processor and different from current McPAT's model.
-	 * physical register base OOO must have Dual-RAT architecture or equivalent structure.FRAT:FrontRAT, RRAT:RetireRAT;
-	 * i,f prefix mean int and fp
-	 * RAT for all Renaming logic, random accessible checkpointing is used, but only update when instruction retires.
-	 * FRAT will be read twice and written once per instruction;
-	 * RRAT will be write once per instruction when committing and reads out all when context switch
-	 * checkpointing is implicit
-	 * Renaming logic is duplicated for each different hardware threads
-	 *
-	 * No Dual-RAT is needed in RS-based OOO processors,
-	 * however, RAT needs to do associative search in RAT, when instruction commits and ROB release the entry,
-	 * to make sure all the renamings associated with the ROB to be released are updated at the same time.
-	 * RAM scheme has # ARchi Reg entry with each entry hold phy reg tag,
-	 * CAM scheme has # Phy Reg entry with each entry hold ARchi reg tag,
-	 *
-	 * Both RAM and CAM have same DCL
-	 */
-	if (!exist) return;
-	int  tag, data, out_w;
-//	interface_ip.wire_is_mat_type = 0;
-//	interface_ip.wire_os_mat_type = 0;
-//	interface_ip.wt               = Global_30;
-	clockRate = coredynp.clockRate;
-	executionTime = coredynp.executionTime;
-    if (coredynp.core_ty==OOO)
-    {
-	//integer pipeline
-	if (coredynp.scheu_ty==PhysicalRegFile)
-	{
-		if (coredynp.rm_ty ==RAMbased)
-		{	  //FRAT with global checkpointing (GCs) please see paper tech report for detailed explaintions
-			data							 = 33;//int(ceil(coredynp.phy_ireg_width*(1+coredynp.globalCheckpoint)/8.0));
-//			data							 = int(ceil(coredynp.phy_ireg_width/8.0));
-			out_w                            = 1;//int(ceil(coredynp.phy_ireg_width/8.0));
-			interface_ip.is_cache			 = false;
-			interface_ip.pure_cam            = false;
-			interface_ip.pure_ram            = true;
-			interface_ip.line_sz             = data;
-			interface_ip.cache_sz            = data*XML->sys.core[ithCore].archi_Regs_IRF_size;
-			interface_ip.assoc               = 1;
-			interface_ip.nbanks              = 1;
-			interface_ip.out_w               = out_w*8;
-			interface_ip.access_mode         = 2;
-			interface_ip.throughput          = 1.0/clockRate;
-			interface_ip.latency             = 1.0/clockRate;
-			interface_ip.obj_func_dyn_energy = 0;
-			interface_ip.obj_func_dyn_power  = 0;
-			interface_ip.obj_func_leak_power = 0;
-			interface_ip.obj_func_cycle_t    = 1;
-			interface_ip.num_rw_ports    = 1;//the extra one port is for GCs
-			interface_ip.num_rd_ports    = 2*coredynp.decodeW;
-			interface_ip.num_wr_ports    = coredynp.decodeW;
-			interface_ip.num_se_rd_ports = 0;
-			iFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
-			iFRAT->area.set_area(iFRAT->area.get_area()+ iFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
-			area.set_area(area.get_area()+ iFRAT->area.get_area());
+EXECU::EXECU(ParseXML* XML_interface, int ithCore_,
+             InputParameter* interface_ip_, double lsq_height_,
+             const CoreDynParam& dyn_p_, double exClockRate, bool exist_)
+    : XML(XML_interface),
+      ithCore(ithCore_),
+      interface_ip(*interface_ip_),
+      lsq_height(lsq_height_),
+      coredynp(dyn_p_),
+      rfu(0),
+      scheu(0),
+      fp_u(0),
+      exeu(0),
+      mul(0),
+      int_bypass(0),
+      intTagBypass(0),
+      int_mul_bypass(0),
+      intTag_mul_Bypass(0),
+      fp_bypass(0),
+      fpTagBypass(0),
+      exist(exist_),
+      rf_fu_clockRate(exClockRate) {
+  if (!exist) return;
+  double fu_height = 0.0;
+  clockRate = coredynp.clockRate;
+  // cout <<"EXECU exClockRate: "<<exClockRate<<endl;
+  executionTime = coredynp.executionTime;
+  rfu = new RegFU(XML, ithCore, &interface_ip, coredynp, exClockRate);
+  scheu = new SchedulerU(XML, ithCore, &interface_ip, coredynp);
+  exeu = new FunctionalUnit(XML, ithCore, &interface_ip, coredynp, ALU,
+                            exClockRate);
+  area.set_area(area.get_area() + exeu->area.get_area() + rfu->area.get_area() +
+                scheu->area.get_area());
+  fu_height = exeu->FU_height;
+  if (coredynp.num_fpus > 0) {
+    fp_u = new FunctionalUnit(XML, ithCore, &interface_ip, coredynp, FPU,
+                              exClockRate);
+    area.set_area(area.get_area() + fp_u->area.get_area());
+  }
+  if (coredynp.num_muls > 0) {
+    mul = new FunctionalUnit(XML, ithCore, &interface_ip, coredynp, MUL,
+                             exClockRate);
+    area.set_area(area.get_area() + mul->area.get_area());
+    fu_height += mul->FU_height;
+  }
+  /*
+   * broadcast logic, including int-broadcast; int_tag-broadcast; fp-broadcast;
+   * fp_tag-broadcast integer by pass has two paths and fp has 3 paths. on the
+   * same bus there are multiple tri-state drivers and muxes that go to
+   * different components on the same bus
+   */
+  if (XML->sys.Embedded) {
+    interface_ip.wt = Global_30;
+    interface_ip.wire_is_mat_type = 0;
+    interface_ip.wire_os_mat_type = 0;
+    interface_ip.throughput = 1.0 / clockRate;
+    interface_ip.latency = 1.0 / clockRate;
+  } else {
+    interface_ip.wt = Global;
+    interface_ip.wire_is_mat_type =
+        2;  // start from semi-global since local wires are already used
+    interface_ip.wire_os_mat_type = 2;
+    interface_ip.throughput = 10.0 / clockRate;  // Do not care
+    interface_ip.latency = 10.0 / clockRate;
+  }
 
-//			//RAHT According to Intel, combine GC with FRAT is very costly.
-//			data							 = int(ceil(coredynp.phy_ireg_width/8.0)*coredynp.num_IRF_entry);
-//			out_w                            = data;
-//			interface_ip.is_cache			 = false;
-//			interface_ip.pure_cam            = false;
-//			interface_ip.pure_ram            = true;
-//			interface_ip.line_sz             = data;
-//			interface_ip.cache_sz            = data*coredynp.globalCheckpoint;
-//			interface_ip.assoc               = 1;
-//			interface_ip.nbanks              = 1;
-//			interface_ip.out_w               = out_w*8;
-//			interface_ip.access_mode         = 0;
-//			interface_ip.throughput          = 1.0/clockRate;
-//			interface_ip.latency             = 1.0/clockRate;
-//			interface_ip.obj_func_dyn_energy = 0;
-//			interface_ip.obj_func_dyn_power  = 0;
-//			interface_ip.obj_func_leak_power = 0;
-//			interface_ip.obj_func_cycle_t    = 1;
-//			interface_ip.num_rw_ports    = 1;//the extra one port is for GCs
-//			interface_ip.num_rd_ports    = 2*coredynp.decodeW;
-//			interface_ip.num_wr_ports    = coredynp.decodeW;
-//			interface_ip.num_se_rd_ports = 0;
-//			iFRAT = new ArrayST(&interface_ip, "Int FrontRAT");
-//			iFRAT->area.set_area(iFRAT->area.get_area()+ iFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
-//			area.set_area(area.get_area()+ iFRAT->area.get_area());
+  if (coredynp.core_ty == Inorder) {  //
+    int_bypass = new interconnect(
+        "Int Bypass Data", Core_device, 1, 1,
+        int(ceil(XML->sys.machine_bits / 32.0) * 32),
+        rfu->int_regfile_height + exeu->FU_height + lsq_height, &interface_ip,
+        3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+    bypass.area.set_area(bypass.area.get_area() + int_bypass->area.get_area());
+    intTagBypass = new interconnect(
+        "Int Bypass tag", Core_device, 1, 1, coredynp.perThreadState,
+        rfu->int_regfile_height + exeu->FU_height + lsq_height +
+            scheu->Iw_height,
+        &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+    bypass.area.set_area(bypass.area.get_area() +
+                         intTagBypass->area.get_area());
 
-			//FRAT floating point
-			data							 = int(ceil(coredynp.phy_freg_width*(1+coredynp.globalCheckpoint)/8.0));
-			out_w                            = int(ceil(coredynp.phy_freg_width/8.0));
-			interface_ip.is_cache			 = false;
-			interface_ip.pure_cam            = false;
-			interface_ip.pure_ram            = true;
-			interface_ip.line_sz             = data;
-			interface_ip.cache_sz            = data*XML->sys.core[ithCore].archi_Regs_FRF_size;
-			interface_ip.assoc               = 1;
-			interface_ip.nbanks              = 1;
-			interface_ip.out_w               = out_w*8;
-			interface_ip.access_mode         = 2;
-			interface_ip.throughput          = 1.0/clockRate;
-			interface_ip.latency             = 1.0/clockRate;
-			interface_ip.obj_func_dyn_energy = 0;
-			interface_ip.obj_func_dyn_power  = 0;
-			interface_ip.obj_func_leak_power = 0;
-			interface_ip.obj_func_cycle_t    = 1;
-			interface_ip.num_rw_ports    = 1;//the extra one port is for GCs
-			interface_ip.num_rd_ports    = 2*coredynp.fp_decodeW;
-			interface_ip.num_wr_ports    = coredynp.fp_decodeW;
-			interface_ip.num_se_rd_ports = 0;
-			fFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
-			fFRAT->area.set_area(fFRAT->area.get_area()+ fFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
-			area.set_area(area.get_area()+ fFRAT->area.get_area());
-
-		}
-		else if ((coredynp.rm_ty ==CAMbased))
-		{
-			//FRAT
-			tag							     = coredynp.arch_ireg_width;
-			data							 = int(ceil ((coredynp.arch_ireg_width+1*coredynp.globalCheckpoint)/8.0));//the address of CAM needed to be sent out
-			out_w                            = int(ceil (coredynp.arch_ireg_width/8.0));
-			interface_ip.is_cache			 = true;
-			interface_ip.pure_cam            = false;
-			interface_ip.pure_ram            = false;
-			interface_ip.line_sz             = data;
-			interface_ip.cache_sz            = data*XML->sys.core[ithCore].phy_Regs_IRF_size;
-			interface_ip.assoc               = 0;
-			interface_ip.nbanks              = 1;
-			interface_ip.out_w               = out_w*8;
-			interface_ip.specific_tag        = 1;
-			interface_ip.tag_w               = tag;
-			interface_ip.access_mode         = 2;
-			interface_ip.throughput          = 1.0/clockRate;
-			interface_ip.latency             = 1.0/clockRate;
-			interface_ip.obj_func_dyn_energy = 0;
-			interface_ip.obj_func_dyn_power  = 0;
-			interface_ip.obj_func_leak_power = 0;
-			interface_ip.obj_func_cycle_t    = 1;
-			interface_ip.num_rw_ports    = 1;//for GCs
-			interface_ip.num_rd_ports    = coredynp.decodeW;
-			interface_ip.num_wr_ports    = coredynp.decodeW;
-			interface_ip.num_se_rd_ports = 0;
-			interface_ip.num_search_ports= 2*coredynp.decodeW;
-			iFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
-			iFRAT->area.set_area(iFRAT->area.get_area()+ iFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
-			area.set_area(area.get_area()+ iFRAT->area.get_area());
-
-			//FRAT for FP
-			tag							     = coredynp.arch_freg_width;
-			data							 = int(ceil ((coredynp.arch_freg_width+1*coredynp.globalCheckpoint)/8.0));//the address of CAM needed to be sent out
-			out_w                            = int(ceil (coredynp.arch_freg_width/8.0));
-			interface_ip.is_cache			 = true;
-			interface_ip.pure_cam            = false;
-			interface_ip.pure_ram            = false;
-			interface_ip.line_sz             = data;
-			interface_ip.cache_sz            = data*XML->sys.core[ithCore].phy_Regs_FRF_size;
-			interface_ip.assoc               = 0;
-			interface_ip.nbanks              = 1;
-			interface_ip.out_w               = out_w*8;
-			interface_ip.specific_tag        = 1;
-			interface_ip.tag_w               = tag;
-			interface_ip.access_mode         = 2;
-			interface_ip.throughput          = 1.0/clockRate;
-			interface_ip.latency             = 1.0/clockRate;
-			interface_ip.obj_func_dyn_energy = 0;
-			interface_ip.obj_func_dyn_power  = 0;
-			interface_ip.obj_func_leak_power = 0;
-			interface_ip.obj_func_cycle_t    = 1;
-			interface_ip.num_rw_ports    = 1;//for GCs
-			interface_ip.num_rd_ports    = coredynp.fp_decodeW;
-			interface_ip.num_wr_ports    = coredynp.fp_decodeW;
-			interface_ip.num_se_rd_ports = 0;
-			interface_ip.num_search_ports= 2*coredynp.fp_decodeW;
-			fFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
-			fFRAT->area.set_area(fFRAT->area.get_area()+ fFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
-			area.set_area(area.get_area()+ fFRAT->area.get_area());
-
-		}
-
-		//RRAT is always RAM based, does not have GCs, and is used only for record latest non-speculative mapping
-		data							 = int(ceil(coredynp.phy_ireg_width/8.0));
-		interface_ip.is_cache			 = false;
-		interface_ip.pure_cam            = false;
-		interface_ip.pure_ram            = true;
-		interface_ip.line_sz             = data;
-		interface_ip.cache_sz            = data*XML->sys.core[ithCore].archi_Regs_IRF_size*2;//HACK to make it as least 64B
-		interface_ip.assoc               = 1;
-		interface_ip.nbanks              = 1;
-		interface_ip.out_w               = interface_ip.line_sz*8;
-		interface_ip.access_mode         = 1;
-		interface_ip.throughput          = 1.0/clockRate;
-		interface_ip.latency             = 1.0/clockRate;
-		interface_ip.obj_func_dyn_energy = 0;
-		interface_ip.obj_func_dyn_power  = 0;
-		interface_ip.obj_func_leak_power = 0;
-		interface_ip.obj_func_cycle_t    = 1;
-		interface_ip.num_rw_ports    = 0;
-		interface_ip.num_rd_ports    = XML->sys.core[ithCore].commit_width;
-		interface_ip.num_wr_ports    = XML->sys.core[ithCore].commit_width;
-		interface_ip.num_se_rd_ports = 0;
-		iRRAT = new ArrayST(&interface_ip, "Int RetireRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
-		iRRAT->area.set_area(iRRAT->area.get_area()+ iRRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
-		area.set_area(area.get_area()+ iRRAT->area.get_area());
-
-		//RRAT for FP
-		data							 = int(ceil(coredynp.phy_freg_width/8.0));
-		interface_ip.is_cache			 = false;
-		interface_ip.pure_cam            = false;
-		interface_ip.pure_ram            = true;
-		interface_ip.line_sz             = data;
-		interface_ip.cache_sz            = data*XML->sys.core[ithCore].archi_Regs_FRF_size*2;//HACK to make it as least 64B
-		interface_ip.assoc               = 1;
-		interface_ip.nbanks              = 1;
-		interface_ip.out_w               = interface_ip.line_sz*8;
-		interface_ip.access_mode         = 1;
-		interface_ip.throughput          = 1.0/clockRate;
-		interface_ip.latency             = 1.0/clockRate;
-		interface_ip.obj_func_dyn_energy = 0;
-		interface_ip.obj_func_dyn_power  = 0;
-		interface_ip.obj_func_leak_power = 0;
-		interface_ip.obj_func_cycle_t    = 1;
-		interface_ip.num_rw_ports    = 0;
-		interface_ip.num_rd_ports    = coredynp.fp_decodeW;
-		interface_ip.num_wr_ports    = coredynp.fp_decodeW;
-		interface_ip.num_se_rd_ports = 0;
-		fRRAT = new ArrayST(&interface_ip, "Int RetireRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
-		fRRAT->area.set_area(fRRAT->area.get_area()+ fRRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
-		area.set_area(area.get_area()+ fRRAT->area.get_area());
-
-		//Freelist of renaming unit always RAM based
-		//Recycle happens at two places: 1)when DCL check there are WAW, the Phyregisters/ROB directly recycles into freelist
-		// 2)When instruction commits the Phyregisters/ROB needed to be recycled.
-		//therefore num_wr port = decode-1(-1 means at least one phy reg will be used for the current renaming group) + commit width
-		data							 = int(ceil(coredynp.phy_ireg_width/8.0));
-		interface_ip.is_cache			 = false;
-		interface_ip.pure_cam            = false;
-		interface_ip.pure_ram            = true;
-		interface_ip.line_sz             = data;
-		interface_ip.cache_sz            = data*coredynp.num_ifreelist_entries;
-		interface_ip.assoc               = 1;
-		interface_ip.nbanks              = 1;
-		interface_ip.out_w               = interface_ip.line_sz*8;
-		interface_ip.access_mode         = 1;
-		interface_ip.throughput          = 1.0/clockRate;
-		interface_ip.latency             = 1.0/clockRate;
-		interface_ip.obj_func_dyn_energy = 0;
-		interface_ip.obj_func_dyn_power  = 0;
-		interface_ip.obj_func_leak_power = 0;
-		interface_ip.obj_func_cycle_t    = 1;
-		interface_ip.num_rw_ports    = 1;//TODO
-		interface_ip.num_rd_ports    = coredynp.decodeW;
-		interface_ip.num_wr_ports    = coredynp.decodeW -1 + XML->sys.core[ithCore].commit_width;
-		//every cycle, (coredynp.decodeW -1) inst may need to send back it dest tags, committW insts needs to update freelist buffers
-		interface_ip.num_se_rd_ports = 0;
-		ifreeL = new ArrayST(&interface_ip, "Int Free List", Core_device, coredynp.opt_local, coredynp.core_ty);
-		ifreeL->area.set_area(ifreeL->area.get_area()+ ifreeL->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
-		area.set_area(area.get_area()+ ifreeL->area.get_area());
-
-		//freelist for FP
-		data							 = int(ceil(coredynp.phy_freg_width/8.0));
-		interface_ip.is_cache			 = false;
-		interface_ip.pure_cam            = false;
-		interface_ip.pure_ram            = true;
-		interface_ip.line_sz             = data;
-		interface_ip.cache_sz            = data*coredynp.num_ffreelist_entries;
-		interface_ip.assoc               = 1;
-		interface_ip.nbanks              = 1;
-		interface_ip.out_w               = interface_ip.line_sz*8;
-		interface_ip.access_mode         = 1;
-		interface_ip.throughput          = 1.0/clockRate;
-		interface_ip.latency             = 1.0/clockRate;
-		interface_ip.obj_func_dyn_energy = 0;
-		interface_ip.obj_func_dyn_power  = 0;
-		interface_ip.obj_func_leak_power = 0;
-		interface_ip.obj_func_cycle_t    = 1;
-		interface_ip.num_rw_ports    = 1;
-		interface_ip.num_rd_ports    = coredynp.fp_decodeW;
-		interface_ip.num_wr_ports    = coredynp.fp_decodeW -1 + XML->sys.core[ithCore].commit_width;
-		interface_ip.num_se_rd_ports = 0;
-		ffreeL = new ArrayST(&interface_ip, "Int Free List", Core_device, coredynp.opt_local, coredynp.core_ty);
-		ffreeL->area.set_area(ffreeL->area.get_area()+ ffreeL->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
-		area.set_area(area.get_area()+ ffreeL->area.get_area());
-
-		idcl  = new dep_resource_conflict_check(&interface_ip,coredynp,coredynp.phy_ireg_width);//TODO:Separate 2 sections See TR
-		fdcl  = new dep_resource_conflict_check(&interface_ip,coredynp,coredynp.phy_freg_width);
-
-	}
-	else if (coredynp.scheu_ty==ReservationStation){
-		if (coredynp.rm_ty ==RAMbased){
-			/*
-			 * however, RAT needs to do associative search in RAT, when instruction commits and ROB release the entry,
-			 * to make sure all the renamings associated with the ROB to be released are updated to ARF at the same time.
-			 * RAM based RAT for RS base OOO does not save the search operations. Its advantage is to have less entries than
-			 * CAM based RAT so that it is more scalable as number of ROB/physical regs increases.
-			 */
-			tag							     = coredynp.phy_ireg_width;
-			data							 = int(ceil(coredynp.phy_ireg_width*(1+coredynp.globalCheckpoint)/8.0));
-			out_w                            = int(ceil(coredynp.phy_ireg_width/8.0));
-			interface_ip.is_cache			 = true;
-			interface_ip.pure_cam            = false;
-			interface_ip.pure_ram            = false;
-			interface_ip.line_sz             = data;
-			interface_ip.cache_sz            = data*XML->sys.core[ithCore].archi_Regs_IRF_size;
-			interface_ip.assoc               = 0;
-			interface_ip.nbanks              = 1;
-			interface_ip.out_w               = out_w*8;
-			interface_ip.access_mode         = 2;
-			interface_ip.throughput          = 1.0/clockRate;
-			interface_ip.latency             = 1.0/clockRate;
-			interface_ip.obj_func_dyn_energy = 0;
-			interface_ip.obj_func_dyn_power  = 0;
-			interface_ip.obj_func_leak_power = 0;
-			interface_ip.obj_func_cycle_t    = 1;
-			interface_ip.num_rw_ports    = 1;//the extra one port is for GCs
-			interface_ip.num_rd_ports    = 2*coredynp.decodeW;
-			interface_ip.num_wr_ports    = coredynp.decodeW;
-			interface_ip.num_se_rd_ports = 0;
-			interface_ip.num_search_ports= coredynp.commitW;//TODO
-			iFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
-			iFRAT->local_result.adjust_area();
-			iFRAT->area.set_area(iFRAT->area.get_area()+ iFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
-			area.set_area(area.get_area()+ iFRAT->area.get_area());
-
-			//FP
-			tag							     = coredynp.phy_freg_width;
-			data							 = int(ceil(coredynp.phy_freg_width*(1+coredynp.globalCheckpoint)/8.0));
-			out_w                            = int(ceil(coredynp.phy_freg_width/8.0));
-			interface_ip.is_cache			 = true;
-			interface_ip.pure_cam            = false;
-			interface_ip.pure_ram            = false;
-			interface_ip.line_sz             = data;
-			interface_ip.cache_sz            = data*XML->sys.core[ithCore].archi_Regs_FRF_size;
-			interface_ip.assoc               = 0;
-			interface_ip.nbanks              = 1;
-			interface_ip.out_w               = out_w*8;
-			interface_ip.access_mode         = 2;
-			interface_ip.throughput          = 1.0/clockRate;
-			interface_ip.latency             = 1.0/clockRate;
-			interface_ip.obj_func_dyn_energy = 0;
-			interface_ip.obj_func_dyn_power  = 0;
-			interface_ip.obj_func_leak_power = 0;
-			interface_ip.obj_func_cycle_t    = 1;
-			interface_ip.num_rw_ports    = 1;//the extra one port is for GCs
-			interface_ip.num_rd_ports    = 2*coredynp.fp_decodeW;
-			interface_ip.num_wr_ports    = coredynp.fp_decodeW;
-			interface_ip.num_se_rd_ports = 0;
-			interface_ip.num_search_ports= coredynp.fp_decodeW;//actually is fp commit width
-			fFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
-			fFRAT->local_result.adjust_area();
-			fFRAT->area.set_area(fFRAT->area.get_area()+ fFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
-			area.set_area(area.get_area()+ fFRAT->area.get_area());
-
-		}
-		else if ((coredynp.rm_ty ==CAMbased))
-		{
-			//FRAT
-			tag							     = coredynp.arch_ireg_width;
-			data							 = int(ceil (coredynp.arch_ireg_width+1*coredynp.globalCheckpoint/8.0));//the address of CAM needed to be sent out
-			out_w                            = int(ceil (coredynp.arch_ireg_width/8.0));
-			interface_ip.is_cache			 = true;
-			interface_ip.pure_cam            = false;
-			interface_ip.pure_ram            = false;
-			interface_ip.line_sz             = data;
-			interface_ip.cache_sz            = data*XML->sys.core[ithCore].phy_Regs_IRF_size;
-			interface_ip.assoc               = 0;
-			interface_ip.nbanks              = 1;
-			interface_ip.out_w               = out_w*8;
-			interface_ip.specific_tag        = 1;
-			interface_ip.tag_w               = tag;
-			interface_ip.access_mode         = 2;
-			interface_ip.throughput          = 1.0/clockRate;
-			interface_ip.latency             = 1.0/clockRate;
-			interface_ip.obj_func_dyn_energy = 0;
-			interface_ip.obj_func_dyn_power  = 0;
-			interface_ip.obj_func_leak_power = 0;
-			interface_ip.obj_func_cycle_t    = 1;
-			interface_ip.num_rw_ports    = 1;//for GCs
-			interface_ip.num_rd_ports    = XML->sys.core[ithCore].decode_width;//0;TODO
-			interface_ip.num_wr_ports    = XML->sys.core[ithCore].decode_width;
-			interface_ip.num_se_rd_ports = 0;
-			interface_ip.num_search_ports= 2*XML->sys.core[ithCore].decode_width;
-			iFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
-			iFRAT->area.set_area(iFRAT->area.get_area()+ iFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
-			area.set_area(area.get_area()+ iFRAT->area.get_area());
-
-			//FRAT
-			tag							     = coredynp.arch_freg_width;
-			data							 = int(ceil (coredynp.arch_freg_width+1*coredynp.globalCheckpoint/8.0));//the address of CAM needed to be sent out
-			out_w                            = int(ceil (coredynp.arch_freg_width/8.0));
-			interface_ip.is_cache			 = true;
-			interface_ip.pure_cam            = false;
-			interface_ip.pure_ram            = false;
-			interface_ip.line_sz             = data;
-			interface_ip.cache_sz            = data*XML->sys.core[ithCore].phy_Regs_FRF_size;
-			interface_ip.assoc               = 0;
-			interface_ip.nbanks              = 1;
-			interface_ip.out_w               = out_w*8;
-			interface_ip.specific_tag        = 1;
-			interface_ip.tag_w               = tag;
-			interface_ip.access_mode         = 2;
-			interface_ip.throughput          = 1.0/clockRate;
-			interface_ip.latency             = 1.0/clockRate;
-			interface_ip.obj_func_dyn_energy = 0;
-			interface_ip.obj_func_dyn_power  = 0;
-			interface_ip.obj_func_leak_power = 0;
-			interface_ip.obj_func_cycle_t    = 1;
-			interface_ip.num_rw_ports    = 1;//for GCs
-			interface_ip.num_rd_ports    = XML->sys.core[ithCore].decode_width;//0;TODO;
-			interface_ip.num_wr_ports    = coredynp.fp_decodeW;
-			interface_ip.num_se_rd_ports = 0;
-			interface_ip.num_search_ports= 2*coredynp.fp_decodeW;
-			fFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
-			fFRAT->area.set_area(fFRAT->area.get_area()+ fFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
-			area.set_area(area.get_area()+ fFRAT->area.get_area());
-
-		}
-		//No RRAT for RS based OOO
-		//Freelist of renaming unit of RS based OOO is unifed for both int and fp renaming unit since the ROB is unified
-		data							 = int(ceil(coredynp.phy_ireg_width/8.0));
-		interface_ip.is_cache			 = false;
-		interface_ip.pure_cam            = false;
-		interface_ip.pure_ram            = true;
-		interface_ip.line_sz             = data;
-		interface_ip.cache_sz            = data*coredynp.num_ifreelist_entries;
-		interface_ip.assoc               = 1;
-		interface_ip.nbanks              = 1;
-		interface_ip.out_w               = interface_ip.line_sz*8;
-		interface_ip.access_mode         = 1;
-		interface_ip.throughput          = 1.0/clockRate;
-		interface_ip.latency             = 1.0/clockRate;
-		interface_ip.obj_func_dyn_energy = 0;
-		interface_ip.obj_func_dyn_power  = 0;
-		interface_ip.obj_func_leak_power = 0;
-		interface_ip.obj_func_cycle_t    = 1;
-		interface_ip.num_rw_ports    = 1;//TODO
-		interface_ip.num_rd_ports    = XML->sys.core[ithCore].decode_width;
-		interface_ip.num_wr_ports    = XML->sys.core[ithCore].decode_width -1 + XML->sys.core[ithCore].commit_width;
-		interface_ip.num_se_rd_ports = 0;
-		ifreeL = new ArrayST(&interface_ip, "Unified Free List", Core_device, coredynp.opt_local, coredynp.core_ty);
-		ifreeL->area.set_area(ifreeL->area.get_area()+ ifreeL->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
-		area.set_area(area.get_area()+ ifreeL->area.get_area());
-
-		idcl  = new dep_resource_conflict_check(&interface_ip,coredynp,coredynp.phy_ireg_width);//TODO:Separate 2 sections See TR
-		fdcl  = new dep_resource_conflict_check(&interface_ip,coredynp,coredynp.phy_freg_width);
-	}
-
-}
-    if (coredynp.core_ty==Inorder&& coredynp.issueW>1)
-    {
-	  /* Dependency check logic will only present when decode(issue) width>1.
-	  *  Multiple issue in order processor can do without renaming, but dcl is a must.
-	  */
-	idcl  = new dep_resource_conflict_check(&interface_ip,coredynp,coredynp.phy_ireg_width);//TODO:Separate 2 sections See TR
-	fdcl  = new dep_resource_conflict_check(&interface_ip,coredynp,coredynp.phy_freg_width);
+    if (coredynp.num_muls > 0) {
+      int_mul_bypass = new interconnect(
+          "Mul Bypass Data", Core_device, 1, 1,
+          int(ceil(XML->sys.machine_bits / 32.0) * 32 * 1.5),
+          rfu->fp_regfile_height + exeu->FU_height + mul->FU_height +
+              lsq_height,
+          &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+      bypass.area.set_area(bypass.area.get_area() +
+                           int_mul_bypass->area.get_area());
+      intTag_mul_Bypass = new interconnect(
+          "Mul Bypass tag", Core_device, 1, 1, coredynp.perThreadState,
+          rfu->fp_regfile_height + exeu->FU_height + mul->FU_height +
+              lsq_height + scheu->Iw_height,
+          &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+      bypass.area.set_area(bypass.area.get_area() +
+                           intTag_mul_Bypass->area.get_area());
     }
+
+    /*
+    if (coredynp.num_fpus>0)
+    {
+            fp_bypass    = new interconnect("FP Bypass Data" , Core_device, 1,
+    1, int(ceil(XML->sys.machine_bits/32.0)*32*1.5), rfu->fp_regfile_height +
+    fp_u->FU_height, &interface_ip, 3, false, 1.0, coredynp.opt_local,
+    coredynp.core_ty); bypass.area.set_area(bypass.area.get_area()
+    +fp_bypass->area.get_area()); fpTagBypass  = new interconnect("FP Bypass
+    tag"  , Core_device, 1, 1, coredynp.perThreadState, rfu->fp_regfile_height +
+    fp_u->FU_height + lsq_height + scheu->Iw_height, &interface_ip, 3,
+                            false, 1.0, coredynp.opt_local, coredynp.core_ty);
+            bypass.area.set_area(bypass.area.get_area()
+    +fpTagBypass->area.get_area());
+    }*/
+  }       /* if (coredynp.core_ty==Inorder) */
+  else {  // OOO
+    if (coredynp.scheu_ty == PhysicalRegFile) {
+      /* For physical register based OOO,
+       * data broadcast interconnects cover across functional units, lsq, inst
+       * windows and register files, while tag broadcast interconnects also
+       * cover across ROB
+       */
+      int_bypass = new interconnect(
+          "Int Bypass Data", Core_device, 1, 1,
+          int(ceil(coredynp.int_data_width)),
+          rfu->int_regfile_height + exeu->FU_height + lsq_height, &interface_ip,
+          3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+      bypass.area.set_area(bypass.area.get_area() +
+                           int_bypass->area.get_area());
+      intTagBypass = new interconnect(
+          "Int Bypass tag", Core_device, 1, 1, coredynp.phy_ireg_width,
+          rfu->int_regfile_height + exeu->FU_height + lsq_height +
+              scheu->Iw_height + scheu->ROB_height,
+          &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+
+      if (coredynp.num_muls > 0) {
+        int_mul_bypass = new interconnect(
+            "Mul Bypass Data", Core_device, 1, 1,
+            int(ceil(coredynp.int_data_width)),
+            rfu->int_regfile_height + exeu->FU_height + mul->FU_height +
+                lsq_height,
+            &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+        intTag_mul_Bypass = new interconnect(
+            "Mul Bypass tag", Core_device, 1, 1, coredynp.phy_ireg_width,
+            rfu->int_regfile_height + exeu->FU_height + mul->FU_height +
+                lsq_height + scheu->Iw_height + scheu->ROB_height,
+            &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+        bypass.area.set_area(bypass.area.get_area() +
+                             int_mul_bypass->area.get_area());
+        bypass.area.set_area(bypass.area.get_area() +
+                             intTag_mul_Bypass->area.get_area());
+      }
+
+      if (coredynp.num_fpus > 0) {
+        fp_bypass = new interconnect("FP Bypass Data", Core_device, 1, 1,
+                                     int(ceil(coredynp.fp_data_width)),
+                                     rfu->fp_regfile_height + fp_u->FU_height,
+                                     &interface_ip, 3, false, 1.0,
+                                     coredynp.opt_local, coredynp.core_ty);
+        fpTagBypass = new interconnect(
+            "FP Bypass tag", Core_device, 1, 1, coredynp.phy_freg_width,
+            rfu->fp_regfile_height + fp_u->FU_height + lsq_height +
+                scheu->fp_Iw_height + scheu->ROB_height,
+            &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+        bypass.area.set_area(bypass.area.get_area() +
+                             fp_bypass->area.get_area());
+        bypass.area.set_area(bypass.area.get_area() +
+                             fpTagBypass->area.get_area());
+      }
+    } else {
+      /*
+       * In RS based processor both data and tag are broadcast together,
+       * covering functional units, lsq, nst windows, register files, and ROBs
+       */
+      int_bypass = new interconnect(
+          "Int Bypass Data", Core_device, 1, 1,
+          int(ceil(coredynp.int_data_width)),
+          rfu->int_regfile_height + exeu->FU_height + lsq_height +
+              scheu->Iw_height + scheu->ROB_height,
+          &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+      intTagBypass = new interconnect(
+          "Int Bypass tag", Core_device, 1, 1, coredynp.phy_ireg_width,
+          rfu->int_regfile_height + exeu->FU_height + lsq_height +
+              scheu->Iw_height + scheu->ROB_height,
+          &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+      bypass.area.set_area(bypass.area.get_area() +
+                           int_bypass->area.get_area());
+      bypass.area.set_area(bypass.area.get_area() +
+                           intTagBypass->area.get_area());
+      if (coredynp.num_muls > 0) {
+        int_mul_bypass = new interconnect(
+            "Mul Bypass Data", Core_device, 1, 1,
+            int(ceil(coredynp.int_data_width)),
+            rfu->int_regfile_height + exeu->FU_height + mul->FU_height +
+                lsq_height + scheu->Iw_height + scheu->ROB_height,
+            &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+        intTag_mul_Bypass = new interconnect(
+            "Mul Bypass tag", Core_device, 1, 1, coredynp.phy_ireg_width,
+            rfu->int_regfile_height + exeu->FU_height + mul->FU_height +
+                lsq_height + scheu->Iw_height + scheu->ROB_height,
+            &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+        bypass.area.set_area(bypass.area.get_area() +
+                             int_mul_bypass->area.get_area());
+        bypass.area.set_area(bypass.area.get_area() +
+                             intTag_mul_Bypass->area.get_area());
+      }
+
+      if (coredynp.num_fpus > 0) {
+        fp_bypass = new interconnect(
+            "FP Bypass Data", Core_device, 1, 1,
+            int(ceil(coredynp.fp_data_width)),
+            rfu->fp_regfile_height + fp_u->FU_height + lsq_height +
+                scheu->fp_Iw_height + scheu->ROB_height,
+            &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+        fpTagBypass = new interconnect(
+            "FP Bypass tag", Core_device, 1, 1, coredynp.phy_freg_width,
+            rfu->fp_regfile_height + fp_u->FU_height + lsq_height +
+                scheu->fp_Iw_height + scheu->ROB_height,
+            &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+        bypass.area.set_area(bypass.area.get_area() +
+                             fp_bypass->area.get_area());
+        bypass.area.set_area(bypass.area.get_area() +
+                             fpTagBypass->area.get_area());
+      }
+    } /* else */
+
+  } /* else */
+  area.set_area(area.get_area() /*+ bypass.area.get_area()*/);
+}
+
+RENAMINGU::RENAMINGU(ParseXML* XML_interface, int ithCore_,
+                     InputParameter* interface_ip_, const CoreDynParam& dyn_p_,
+                     bool exist_)
+    : XML(XML_interface),
+      ithCore(ithCore_),
+      interface_ip(*interface_ip_),
+      coredynp(dyn_p_),
+      iFRAT(0),
+      fFRAT(0),
+      iRRAT(0),
+      fRRAT(0),
+      ifreeL(0),
+      ffreeL(0),
+      idcl(0),
+      fdcl(0),
+      RAHT(0),
+      exist(exist_) {
+  /*
+   * Although renaming logic maybe be used in in-order processors,
+   * McPAT assumes no renaming logic is used since the performance gain is very
+   * limited and the only major inorder processor with renaming logic is
+   * Itainium that is a VLIW processor and different from current McPAT's model.
+   * physical register base OOO must have Dual-RAT architecture or equivalent
+   * structure.FRAT:FrontRAT, RRAT:RetireRAT; i,f prefix mean int and fp RAT for
+   * all Renaming logic, random accessible checkpointing is used, but only
+   * update when instruction retires. FRAT will be read twice and written once
+   * per instruction; RRAT will be write once per instruction when committing
+   * and reads out all when context switch checkpointing is implicit Renaming
+   * logic is duplicated for each different hardware threads
+   *
+   * No Dual-RAT is needed in RS-based OOO processors,
+   * however, RAT needs to do associative search in RAT, when instruction
+   * commits and ROB release the entry, to make sure all the renamings
+   * associated with the ROB to be released are updated at the same time. RAM
+   * scheme has # ARchi Reg entry with each entry hold phy reg tag, CAM scheme
+   * has # Phy Reg entry with each entry hold ARchi reg tag,
+   *
+   * Both RAM and CAM have same DCL
+   */
+  if (!exist) return;
+  int tag, data, out_w;
+  //	interface_ip.wire_is_mat_type = 0;
+  //	interface_ip.wire_os_mat_type = 0;
+  //	interface_ip.wt               = Global_30;
+  clockRate = coredynp.clockRate;
+  executionTime = coredynp.executionTime;
+  if (coredynp.core_ty == OOO) {
+    // integer pipeline
+    if (coredynp.scheu_ty == PhysicalRegFile) {
+      if (coredynp.rm_ty ==
+          RAMbased) {  // FRAT with global checkpointing (GCs) please see paper
+                       // tech report for detailed explaintions
+        data =
+            33;  // int(ceil(coredynp.phy_ireg_width*(1+coredynp.globalCheckpoint)/8.0));
+        //			data
+        //= int(ceil(coredynp.phy_ireg_width/8.0));
+        out_w = 1;  // int(ceil(coredynp.phy_ireg_width/8.0));
+        interface_ip.is_cache = false;
+        interface_ip.pure_cam = false;
+        interface_ip.pure_ram = true;
+        interface_ip.line_sz = data;
+        interface_ip.cache_sz =
+            data * XML->sys.core[ithCore].archi_Regs_IRF_size;
+        interface_ip.assoc = 1;
+        interface_ip.nbanks = 1;
+        interface_ip.out_w = out_w * 8;
+        interface_ip.access_mode = 2;
+        interface_ip.throughput = 1.0 / clockRate;
+        interface_ip.latency = 1.0 / clockRate;
+        interface_ip.obj_func_dyn_energy = 0;
+        interface_ip.obj_func_dyn_power = 0;
+        interface_ip.obj_func_leak_power = 0;
+        interface_ip.obj_func_cycle_t = 1;
+        interface_ip.num_rw_ports = 1;  // the extra one port is for GCs
+        interface_ip.num_rd_ports = 2 * coredynp.decodeW;
+        interface_ip.num_wr_ports = coredynp.decodeW;
+        interface_ip.num_se_rd_ports = 0;
+        iFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device,
+                            coredynp.opt_local, coredynp.core_ty);
+        iFRAT->area.set_area(
+            iFRAT->area.get_area() +
+            iFRAT->local_result.area *
+                XML->sys.core[ithCore].number_hardware_threads);
+        area.set_area(area.get_area() + iFRAT->area.get_area());
+
+        //			//RAHT According to Intel, combine GC with FRAT
+        // is very costly. 			data =
+        // int(ceil(coredynp.phy_ireg_width/8.0)*coredynp.num_IRF_entry);
+        // out_w = data; 			interface_ip.is_cache
+        //= false; 			interface_ip.pure_cam            =
+        //false; 			interface_ip.pure_ram            = true; 			interface_ip.line_sz
+        //= data; 			interface_ip.cache_sz            =
+        // data*coredynp.globalCheckpoint; interface_ip.assoc = 1;
+        // interface_ip.nbanks              = 1;
+        // interface_ip.out_w =
+        // out_w*8; 			interface_ip.access_mode         = 0;
+        // interface_ip.throughput = 1.0/clockRate;
+        //interface_ip.latency = 1.0/clockRate; 			interface_ip.obj_func_dyn_energy
+        //= 0; 			interface_ip.obj_func_dyn_power  = 0;
+        //			interface_ip.obj_func_leak_power = 0;
+        //			interface_ip.obj_func_cycle_t    = 1;
+        //			interface_ip.num_rw_ports    = 1;//the extra one
+        // port is for GCs 			interface_ip.num_rd_ports    =
+        // 2*coredynp.decodeW; 			interface_ip.num_wr_ports    =
+        // coredynp.decodeW;
+        //			interface_ip.num_se_rd_ports = 0;
+        //			iFRAT = new ArrayST(&interface_ip, "Int
+        // FrontRAT");
+        // iFRAT->area.set_area(iFRAT->area.get_area()+
+        // iFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
+        //			area.set_area(area.get_area()+
+        // iFRAT->area.get_area());
+
+        // FRAT floating point
+        data = int(ceil(coredynp.phy_freg_width *
+                        (1 + coredynp.globalCheckpoint) / 8.0));
+        out_w = int(ceil(coredynp.phy_freg_width / 8.0));
+        interface_ip.is_cache = false;
+        interface_ip.pure_cam = false;
+        interface_ip.pure_ram = true;
+        interface_ip.line_sz = data;
+        interface_ip.cache_sz =
+            data * XML->sys.core[ithCore].archi_Regs_FRF_size;
+        interface_ip.assoc = 1;
+        interface_ip.nbanks = 1;
+        interface_ip.out_w = out_w * 8;
+        interface_ip.access_mode = 2;
+        interface_ip.throughput = 1.0 / clockRate;
+        interface_ip.latency = 1.0 / clockRate;
+        interface_ip.obj_func_dyn_energy = 0;
+        interface_ip.obj_func_dyn_power = 0;
+        interface_ip.obj_func_leak_power = 0;
+        interface_ip.obj_func_cycle_t = 1;
+        interface_ip.num_rw_ports = 1;  // the extra one port is for GCs
+        interface_ip.num_rd_ports = 2 * coredynp.fp_decodeW;
+        interface_ip.num_wr_ports = coredynp.fp_decodeW;
+        interface_ip.num_se_rd_ports = 0;
+        fFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device,
+                            coredynp.opt_local, coredynp.core_ty);
+        fFRAT->area.set_area(
+            fFRAT->area.get_area() +
+            fFRAT->local_result.area *
+                XML->sys.core[ithCore].number_hardware_threads);
+        area.set_area(area.get_area() + fFRAT->area.get_area());
+
+      } else if ((coredynp.rm_ty == CAMbased)) {
+        // FRAT
+        tag = coredynp.arch_ireg_width;
+        data = int(
+            ceil((coredynp.arch_ireg_width + 1 * coredynp.globalCheckpoint) /
+                 8.0));  // the address of CAM needed to be sent out
+        out_w = int(ceil(coredynp.arch_ireg_width / 8.0));
+        interface_ip.is_cache = true;
+        interface_ip.pure_cam = false;
+        interface_ip.pure_ram = false;
+        interface_ip.line_sz = data;
+        interface_ip.cache_sz = data * XML->sys.core[ithCore].phy_Regs_IRF_size;
+        interface_ip.assoc = 0;
+        interface_ip.nbanks = 1;
+        interface_ip.out_w = out_w * 8;
+        interface_ip.specific_tag = 1;
+        interface_ip.tag_w = tag;
+        interface_ip.access_mode = 2;
+        interface_ip.throughput = 1.0 / clockRate;
+        interface_ip.latency = 1.0 / clockRate;
+        interface_ip.obj_func_dyn_energy = 0;
+        interface_ip.obj_func_dyn_power = 0;
+        interface_ip.obj_func_leak_power = 0;
+        interface_ip.obj_func_cycle_t = 1;
+        interface_ip.num_rw_ports = 1;  // for GCs
+        interface_ip.num_rd_ports = coredynp.decodeW;
+        interface_ip.num_wr_ports = coredynp.decodeW;
+        interface_ip.num_se_rd_ports = 0;
+        interface_ip.num_search_ports = 2 * coredynp.decodeW;
+        iFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device,
+                            coredynp.opt_local, coredynp.core_ty);
+        iFRAT->area.set_area(
+            iFRAT->area.get_area() +
+            iFRAT->local_result.area *
+                XML->sys.core[ithCore].number_hardware_threads);
+        area.set_area(area.get_area() + iFRAT->area.get_area());
+
+        // FRAT for FP
+        tag = coredynp.arch_freg_width;
+        data = int(
+            ceil((coredynp.arch_freg_width + 1 * coredynp.globalCheckpoint) /
+                 8.0));  // the address of CAM needed to be sent out
+        out_w = int(ceil(coredynp.arch_freg_width / 8.0));
+        interface_ip.is_cache = true;
+        interface_ip.pure_cam = false;
+        interface_ip.pure_ram = false;
+        interface_ip.line_sz = data;
+        interface_ip.cache_sz = data * XML->sys.core[ithCore].phy_Regs_FRF_size;
+        interface_ip.assoc = 0;
+        interface_ip.nbanks = 1;
+        interface_ip.out_w = out_w * 8;
+        interface_ip.specific_tag = 1;
+        interface_ip.tag_w = tag;
+        interface_ip.access_mode = 2;
+        interface_ip.throughput = 1.0 / clockRate;
+        interface_ip.latency = 1.0 / clockRate;
+        interface_ip.obj_func_dyn_energy = 0;
+        interface_ip.obj_func_dyn_power = 0;
+        interface_ip.obj_func_leak_power = 0;
+        interface_ip.obj_func_cycle_t = 1;
+        interface_ip.num_rw_ports = 1;  // for GCs
+        interface_ip.num_rd_ports = coredynp.fp_decodeW;
+        interface_ip.num_wr_ports = coredynp.fp_decodeW;
+        interface_ip.num_se_rd_ports = 0;
+        interface_ip.num_search_ports = 2 * coredynp.fp_decodeW;
+        fFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device,
+                            coredynp.opt_local, coredynp.core_ty);
+        fFRAT->area.set_area(
+            fFRAT->area.get_area() +
+            fFRAT->local_result.area *
+                XML->sys.core[ithCore].number_hardware_threads);
+        area.set_area(area.get_area() + fFRAT->area.get_area());
+      }
+
+      // RRAT is always RAM based, does not have GCs, and is used only for
+      // record latest non-speculative mapping
+      data = int(ceil(coredynp.phy_ireg_width / 8.0));
+      interface_ip.is_cache = false;
+      interface_ip.pure_cam = false;
+      interface_ip.pure_ram = true;
+      interface_ip.line_sz = data;
+      interface_ip.cache_sz = data *
+                              XML->sys.core[ithCore].archi_Regs_IRF_size *
+                              2;  // HACK to make it as least 64B
+      interface_ip.assoc = 1;
+      interface_ip.nbanks = 1;
+      interface_ip.out_w = interface_ip.line_sz * 8;
+      interface_ip.access_mode = 1;
+      interface_ip.throughput = 1.0 / clockRate;
+      interface_ip.latency = 1.0 / clockRate;
+      interface_ip.obj_func_dyn_energy = 0;
+      interface_ip.obj_func_dyn_power = 0;
+      interface_ip.obj_func_leak_power = 0;
+      interface_ip.obj_func_cycle_t = 1;
+      interface_ip.num_rw_ports = 0;
+      interface_ip.num_rd_ports = XML->sys.core[ithCore].commit_width;
+      interface_ip.num_wr_ports = XML->sys.core[ithCore].commit_width;
+      interface_ip.num_se_rd_ports = 0;
+      iRRAT = new ArrayST(&interface_ip, "Int RetireRAT", Core_device,
+                          coredynp.opt_local, coredynp.core_ty);
+      iRRAT->area.set_area(iRRAT->area.get_area() +
+                           iRRAT->local_result.area *
+                               XML->sys.core[ithCore].number_hardware_threads);
+      area.set_area(area.get_area() + iRRAT->area.get_area());
+
+      // RRAT for FP
+      data = int(ceil(coredynp.phy_freg_width / 8.0));
+      interface_ip.is_cache = false;
+      interface_ip.pure_cam = false;
+      interface_ip.pure_ram = true;
+      interface_ip.line_sz = data;
+      interface_ip.cache_sz = data *
+                              XML->sys.core[ithCore].archi_Regs_FRF_size *
+                              2;  // HACK to make it as least 64B
+      interface_ip.assoc = 1;
+      interface_ip.nbanks = 1;
+      interface_ip.out_w = interface_ip.line_sz * 8;
+      interface_ip.access_mode = 1;
+      interface_ip.throughput = 1.0 / clockRate;
+      interface_ip.latency = 1.0 / clockRate;
+      interface_ip.obj_func_dyn_energy = 0;
+      interface_ip.obj_func_dyn_power = 0;
+      interface_ip.obj_func_leak_power = 0;
+      interface_ip.obj_func_cycle_t = 1;
+      interface_ip.num_rw_ports = 0;
+      interface_ip.num_rd_ports = coredynp.fp_decodeW;
+      interface_ip.num_wr_ports = coredynp.fp_decodeW;
+      interface_ip.num_se_rd_ports = 0;
+      fRRAT = new ArrayST(&interface_ip, "Int RetireRAT", Core_device,
+                          coredynp.opt_local, coredynp.core_ty);
+      fRRAT->area.set_area(fRRAT->area.get_area() +
+                           fRRAT->local_result.area *
+                               XML->sys.core[ithCore].number_hardware_threads);
+      area.set_area(area.get_area() + fRRAT->area.get_area());
+
+      // Freelist of renaming unit always RAM based
+      // Recycle happens at two places: 1)when DCL check there are WAW, the
+      // Phyregisters/ROB directly recycles into freelist
+      // 2)When instruction commits the Phyregisters/ROB needed to be recycled.
+      // therefore num_wr port = decode-1(-1 means at least one phy reg will be
+      // used for the current renaming group) + commit width
+      data = int(ceil(coredynp.phy_ireg_width / 8.0));
+      interface_ip.is_cache = false;
+      interface_ip.pure_cam = false;
+      interface_ip.pure_ram = true;
+      interface_ip.line_sz = data;
+      interface_ip.cache_sz = data * coredynp.num_ifreelist_entries;
+      interface_ip.assoc = 1;
+      interface_ip.nbanks = 1;
+      interface_ip.out_w = interface_ip.line_sz * 8;
+      interface_ip.access_mode = 1;
+      interface_ip.throughput = 1.0 / clockRate;
+      interface_ip.latency = 1.0 / clockRate;
+      interface_ip.obj_func_dyn_energy = 0;
+      interface_ip.obj_func_dyn_power = 0;
+      interface_ip.obj_func_leak_power = 0;
+      interface_ip.obj_func_cycle_t = 1;
+      interface_ip.num_rw_ports = 1;  // TODO
+      interface_ip.num_rd_ports = coredynp.decodeW;
+      interface_ip.num_wr_ports =
+          coredynp.decodeW - 1 + XML->sys.core[ithCore].commit_width;
+      // every cycle, (coredynp.decodeW -1) inst may need to send back it dest
+      // tags, committW insts needs to update freelist buffers
+      interface_ip.num_se_rd_ports = 0;
+      ifreeL = new ArrayST(&interface_ip, "Int Free List", Core_device,
+                           coredynp.opt_local, coredynp.core_ty);
+      ifreeL->area.set_area(ifreeL->area.get_area() +
+                            ifreeL->local_result.area *
+                                XML->sys.core[ithCore].number_hardware_threads);
+      area.set_area(area.get_area() + ifreeL->area.get_area());
+
+      // freelist for FP
+      data = int(ceil(coredynp.phy_freg_width / 8.0));
+      interface_ip.is_cache = false;
+      interface_ip.pure_cam = false;
+      interface_ip.pure_ram = true;
+      interface_ip.line_sz = data;
+      interface_ip.cache_sz = data * coredynp.num_ffreelist_entries;
+      interface_ip.assoc = 1;
+      interface_ip.nbanks = 1;
+      interface_ip.out_w = interface_ip.line_sz * 8;
+      interface_ip.access_mode = 1;
+      interface_ip.throughput = 1.0 / clockRate;
+      interface_ip.latency = 1.0 / clockRate;
+      interface_ip.obj_func_dyn_energy = 0;
+      interface_ip.obj_func_dyn_power = 0;
+      interface_ip.obj_func_leak_power = 0;
+      interface_ip.obj_func_cycle_t = 1;
+      interface_ip.num_rw_ports = 1;
+      interface_ip.num_rd_ports = coredynp.fp_decodeW;
+      interface_ip.num_wr_ports =
+          coredynp.fp_decodeW - 1 + XML->sys.core[ithCore].commit_width;
+      interface_ip.num_se_rd_ports = 0;
+      ffreeL = new ArrayST(&interface_ip, "Int Free List", Core_device,
+                           coredynp.opt_local, coredynp.core_ty);
+      ffreeL->area.set_area(ffreeL->area.get_area() +
+                            ffreeL->local_result.area *
+                                XML->sys.core[ithCore].number_hardware_threads);
+      area.set_area(area.get_area() + ffreeL->area.get_area());
+
+      idcl = new dep_resource_conflict_check(
+          &interface_ip, coredynp,
+          coredynp.phy_ireg_width);  // TODO:Separate 2 sections See TR
+      fdcl = new dep_resource_conflict_check(&interface_ip, coredynp,
+                                             coredynp.phy_freg_width);
+
+    } else if (coredynp.scheu_ty == ReservationStation) {
+      if (coredynp.rm_ty == RAMbased) {
+        /*
+         * however, RAT needs to do associative search in RAT, when instruction
+         * commits and ROB release the entry, to make sure all the renamings
+         * associated with the ROB to be released are updated to ARF at the same
+         * time. RAM based RAT for RS base OOO does not save the search
+         * operations. Its advantage is to have less entries than CAM based RAT
+         * so that it is more scalable as number of ROB/physical regs increases.
+         */
+        tag = coredynp.phy_ireg_width;
+        data = int(ceil(coredynp.phy_ireg_width *
+                        (1 + coredynp.globalCheckpoint) / 8.0));
+        out_w = int(ceil(coredynp.phy_ireg_width / 8.0));
+        interface_ip.is_cache = true;
+        interface_ip.pure_cam = false;
+        interface_ip.pure_ram = false;
+        interface_ip.line_sz = data;
+        interface_ip.cache_sz =
+            data * XML->sys.core[ithCore].archi_Regs_IRF_size;
+        interface_ip.assoc = 0;
+        interface_ip.nbanks = 1;
+        interface_ip.out_w = out_w * 8;
+        interface_ip.access_mode = 2;
+        interface_ip.throughput = 1.0 / clockRate;
+        interface_ip.latency = 1.0 / clockRate;
+        interface_ip.obj_func_dyn_energy = 0;
+        interface_ip.obj_func_dyn_power = 0;
+        interface_ip.obj_func_leak_power = 0;
+        interface_ip.obj_func_cycle_t = 1;
+        interface_ip.num_rw_ports = 1;  // the extra one port is for GCs
+        interface_ip.num_rd_ports = 2 * coredynp.decodeW;
+        interface_ip.num_wr_ports = coredynp.decodeW;
+        interface_ip.num_se_rd_ports = 0;
+        interface_ip.num_search_ports = coredynp.commitW;  // TODO
+        iFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device,
+                            coredynp.opt_local, coredynp.core_ty);
+        iFRAT->local_result.adjust_area();
+        iFRAT->area.set_area(
+            iFRAT->area.get_area() +
+            iFRAT->local_result.area *
+                XML->sys.core[ithCore].number_hardware_threads);
+        area.set_area(area.get_area() + iFRAT->area.get_area());
+
+        // FP
+        tag = coredynp.phy_freg_width;
+        data = int(ceil(coredynp.phy_freg_width *
+                        (1 + coredynp.globalCheckpoint) / 8.0));
+        out_w = int(ceil(coredynp.phy_freg_width / 8.0));
+        interface_ip.is_cache = true;
+        interface_ip.pure_cam = false;
+        interface_ip.pure_ram = false;
+        interface_ip.line_sz = data;
+        interface_ip.cache_sz =
+            data * XML->sys.core[ithCore].archi_Regs_FRF_size;
+        interface_ip.assoc = 0;
+        interface_ip.nbanks = 1;
+        interface_ip.out_w = out_w * 8;
+        interface_ip.access_mode = 2;
+        interface_ip.throughput = 1.0 / clockRate;
+        interface_ip.latency = 1.0 / clockRate;
+        interface_ip.obj_func_dyn_energy = 0;
+        interface_ip.obj_func_dyn_power = 0;
+        interface_ip.obj_func_leak_power = 0;
+        interface_ip.obj_func_cycle_t = 1;
+        interface_ip.num_rw_ports = 1;  // the extra one port is for GCs
+        interface_ip.num_rd_ports = 2 * coredynp.fp_decodeW;
+        interface_ip.num_wr_ports = coredynp.fp_decodeW;
+        interface_ip.num_se_rd_ports = 0;
+        interface_ip.num_search_ports =
+            coredynp.fp_decodeW;  // actually is fp commit width
+        fFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device,
+                            coredynp.opt_local, coredynp.core_ty);
+        fFRAT->local_result.adjust_area();
+        fFRAT->area.set_area(
+            fFRAT->area.get_area() +
+            fFRAT->local_result.area *
+                XML->sys.core[ithCore].number_hardware_threads);
+        area.set_area(area.get_area() + fFRAT->area.get_area());
+
+      } else if ((coredynp.rm_ty == CAMbased)) {
+        // FRAT
+        tag = coredynp.arch_ireg_width;
+        data = int(ceil(coredynp.arch_ireg_width +
+                        1 * coredynp.globalCheckpoint /
+                            8.0));  // the address of CAM needed to be sent out
+        out_w = int(ceil(coredynp.arch_ireg_width / 8.0));
+        interface_ip.is_cache = true;
+        interface_ip.pure_cam = false;
+        interface_ip.pure_ram = false;
+        interface_ip.line_sz = data;
+        interface_ip.cache_sz = data * XML->sys.core[ithCore].phy_Regs_IRF_size;
+        interface_ip.assoc = 0;
+        interface_ip.nbanks = 1;
+        interface_ip.out_w = out_w * 8;
+        interface_ip.specific_tag = 1;
+        interface_ip.tag_w = tag;
+        interface_ip.access_mode = 2;
+        interface_ip.throughput = 1.0 / clockRate;
+        interface_ip.latency = 1.0 / clockRate;
+        interface_ip.obj_func_dyn_energy = 0;
+        interface_ip.obj_func_dyn_power = 0;
+        interface_ip.obj_func_leak_power = 0;
+        interface_ip.obj_func_cycle_t = 1;
+        interface_ip.num_rw_ports = 1;  // for GCs
+        interface_ip.num_rd_ports =
+            XML->sys.core[ithCore].decode_width;  // 0;TODO
+        interface_ip.num_wr_ports = XML->sys.core[ithCore].decode_width;
+        interface_ip.num_se_rd_ports = 0;
+        interface_ip.num_search_ports = 2 * XML->sys.core[ithCore].decode_width;
+        iFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device,
+                            coredynp.opt_local, coredynp.core_ty);
+        iFRAT->area.set_area(
+            iFRAT->area.get_area() +
+            iFRAT->local_result.area *
+                XML->sys.core[ithCore].number_hardware_threads);
+        area.set_area(area.get_area() + iFRAT->area.get_area());
+
+        // FRAT
+        tag = coredynp.arch_freg_width;
+        data = int(ceil(coredynp.arch_freg_width +
+                        1 * coredynp.globalCheckpoint /
+                            8.0));  // the address of CAM needed to be sent out
+        out_w = int(ceil(coredynp.arch_freg_width / 8.0));
+        interface_ip.is_cache = true;
+        interface_ip.pure_cam = false;
+        interface_ip.pure_ram = false;
+        interface_ip.line_sz = data;
+        interface_ip.cache_sz = data * XML->sys.core[ithCore].phy_Regs_FRF_size;
+        interface_ip.assoc = 0;
+        interface_ip.nbanks = 1;
+        interface_ip.out_w = out_w * 8;
+        interface_ip.specific_tag = 1;
+        interface_ip.tag_w = tag;
+        interface_ip.access_mode = 2;
+        interface_ip.throughput = 1.0 / clockRate;
+        interface_ip.latency = 1.0 / clockRate;
+        interface_ip.obj_func_dyn_energy = 0;
+        interface_ip.obj_func_dyn_power = 0;
+        interface_ip.obj_func_leak_power = 0;
+        interface_ip.obj_func_cycle_t = 1;
+        interface_ip.num_rw_ports = 1;  // for GCs
+        interface_ip.num_rd_ports =
+            XML->sys.core[ithCore].decode_width;  // 0;TODO;
+        interface_ip.num_wr_ports = coredynp.fp_decodeW;
+        interface_ip.num_se_rd_ports = 0;
+        interface_ip.num_search_ports = 2 * coredynp.fp_decodeW;
+        fFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device,
+                            coredynp.opt_local, coredynp.core_ty);
+        fFRAT->area.set_area(
+            fFRAT->area.get_area() +
+            fFRAT->local_result.area *
+                XML->sys.core[ithCore].number_hardware_threads);
+        area.set_area(area.get_area() + fFRAT->area.get_area());
+      }
+      // No RRAT for RS based OOO
+      // Freelist of renaming unit of RS based OOO is unifed for both int and fp
+      // renaming unit since the ROB is unified
+      data = int(ceil(coredynp.phy_ireg_width / 8.0));
+      interface_ip.is_cache = false;
+      interface_ip.pure_cam = false;
+      interface_ip.pure_ram = true;
+      interface_ip.line_sz = data;
+      interface_ip.cache_sz = data * coredynp.num_ifreelist_entries;
+      interface_ip.assoc = 1;
+      interface_ip.nbanks = 1;
+      interface_ip.out_w = interface_ip.line_sz * 8;
+      interface_ip.access_mode = 1;
+      interface_ip.throughput = 1.0 / clockRate;
+      interface_ip.latency = 1.0 / clockRate;
+      interface_ip.obj_func_dyn_energy = 0;
+      interface_ip.obj_func_dyn_power = 0;
+      interface_ip.obj_func_leak_power = 0;
+      interface_ip.obj_func_cycle_t = 1;
+      interface_ip.num_rw_ports = 1;  // TODO
+      interface_ip.num_rd_ports = XML->sys.core[ithCore].decode_width;
+      interface_ip.num_wr_ports = XML->sys.core[ithCore].decode_width - 1 +
+                                  XML->sys.core[ithCore].commit_width;
+      interface_ip.num_se_rd_ports = 0;
+      ifreeL = new ArrayST(&interface_ip, "Unified Free List", Core_device,
+                           coredynp.opt_local, coredynp.core_ty);
+      ifreeL->area.set_area(ifreeL->area.get_area() +
+                            ifreeL->local_result.area *
+                                XML->sys.core[ithCore].number_hardware_threads);
+      area.set_area(area.get_area() + ifreeL->area.get_area());
+
+      idcl = new dep_resource_conflict_check(
+          &interface_ip, coredynp,
+          coredynp.phy_ireg_width);  // TODO:Separate 2 sections See TR
+      fdcl = new dep_resource_conflict_check(&interface_ip, coredynp,
+                                             coredynp.phy_freg_width);
+    }
+  }
+  if (coredynp.core_ty == Inorder && coredynp.issueW > 1) {
+    /* Dependency check logic will only present when decode(issue) width>1.
+     *  Multiple issue in order processor can do without renaming, but dcl is a
+     * must.
+     */
+    idcl = new dep_resource_conflict_check(
+        &interface_ip, coredynp,
+        coredynp.phy_ireg_width);  // TODO:Separate 2 sections See TR
+    fdcl = new dep_resource_conflict_check(&interface_ip, coredynp,
+                                           coredynp.phy_freg_width);
+  }
 }
 
 Core::Core(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_)
-:XML(XML_interface),
- ithCore(ithCore_),
- interface_ip(*interface_ip_),
- ifu  (0),
- lsu  (0),
- mmu  (0),
- exu  (0),
- rnu  (0),
- corepipe (0),
- undiffCore (0),
- l2cache (0)
-{
- /**
-  * Testing: (to be removed) added by syed
-  */
-  //XML->sys.core[ithCore].simd_width=8;// (8)
-  //XML->sys.core[ithCore].collector_units=4;// (4)
-  //XML->sys.core[ithCore].core_clock_ratio=2.0;// (2.0)
-  //XML->sys.core[ithCore].warp_size=32;// (32) 
-  
+    : XML(XML_interface),
+      ithCore(ithCore_),
+      interface_ip(*interface_ip_),
+      ifu(0),
+      lsu(0),
+      mmu(0),
+      exu(0),
+      rnu(0),
+      corepipe(0),
+      undiffCore(0),
+      l2cache(0) {
+  /**
+   * Testing: (to be removed) added by syed
+   */
+  // XML->sys.core[ithCore].simd_width=8;// (8)
+  // XML->sys.core[ithCore].collector_units=4;// (4)
+  // XML->sys.core[ithCore].core_clock_ratio=2.0;// (2.0)
+  // XML->sys.core[ithCore].warp_size=32;// (32)
+
   /*
-  * initialize, compute and optimize individual components.
-  */
+   * initialize, compute and optimize individual components.
+   */
 
-	IdleCoreEnergy=0;
-	IdlePower_PerCore = 0;
+  IdleCoreEnergy = 0;
+  IdlePower_PerCore = 0;
   double pipeline_area_per_unit;
-  if (XML->sys.Private_L2)
-  {
-	  l2cache = new SharedCache(XML,ithCore, &interface_ip);
-
+  if (XML->sys.Private_L2) {
+    l2cache = new SharedCache(XML, ithCore, &interface_ip);
   }
-//  interface_ip.wire_is_mat_type = 2;
-//  interface_ip.wire_os_mat_type = 2;
-//  interface_ip.wt               =Global_30;
+  //  interface_ip.wire_is_mat_type = 2;
+  //  interface_ip.wire_os_mat_type = 2;
+  //  interface_ip.wt               =Global_30;
   set_core_param();
   clockRate = coredynp.clockRate;
-  exClockRate = clockRate*XML->sys.core[ithCore].core_clock_ratio;
+  exClockRate = clockRate * XML->sys.core[ithCore].core_clock_ratio;
 
   executionTime = coredynp.executionTime;
-  ifu          = new InstFetchU(XML, ithCore, &interface_ip,coredynp);
-  lsu          = new LoadStoreU(XML, ithCore, &interface_ip,coredynp);
-  mmu          = new MemManU   (XML, ithCore, &interface_ip,coredynp);
-  exu          = new EXECU     (XML, ithCore, &interface_ip,lsu->lsq_height, coredynp, exClockRate,true);
-  
+  ifu = new InstFetchU(XML, ithCore, &interface_ip, coredynp);
+  lsu = new LoadStoreU(XML, ithCore, &interface_ip, coredynp);
+  mmu = new MemManU(XML, ithCore, &interface_ip, coredynp);
+  exu = new EXECU(XML, ithCore, &interface_ip, lsu->lsq_height, coredynp,
+                  exClockRate, true);
 
-
-
-
-  undiffCore   = new UndiffCore(XML, ithCore, &interface_ip,coredynp);
-  if (coredynp.core_ty==OOO)
-  {
-	  rnu = new RENAMINGU(XML, ithCore, &interface_ip,coredynp);
+  undiffCore = new UndiffCore(XML, ithCore, &interface_ip, coredynp);
+  if (coredynp.core_ty == OOO) {
+    rnu = new RENAMINGU(XML, ithCore, &interface_ip, coredynp);
   }
-  corepipe = new Pipeline(&interface_ip,coredynp);
+  corepipe = new Pipeline(&interface_ip, coredynp);
 
-  if (coredynp.core_ty==OOO)
-  {
-	  pipeline_area_per_unit    = (corepipe->area.get_area()*coredynp.num_pipelines)/5.0;
-	  if (rnu->exist)
-	  {
-		  rnu->area.set_area(rnu->area.get_area() + pipeline_area_per_unit);
-	  }
+  if (coredynp.core_ty == OOO) {
+    pipeline_area_per_unit =
+        (corepipe->area.get_area() * coredynp.num_pipelines) / 5.0;
+    if (rnu->exist) {
+      rnu->area.set_area(rnu->area.get_area() + pipeline_area_per_unit);
+    }
+  } else {
+    pipeline_area_per_unit =
+        (corepipe->area.get_area() * coredynp.num_pipelines) / 4.0;
   }
+
+  // area.set_area(area.get_area()+ corepipe->area.get_area());
+  if (ifu->exist) {
+    ifu->area.set_area(ifu->area.get_area() + pipeline_area_per_unit);
+    area.set_area(area.get_area() + ifu->area.get_area());
+  }
+  if (lsu->exist) {
+    lsu->area.set_area(lsu->area.get_area() + pipeline_area_per_unit);
+    area.set_area(area.get_area() + lsu->area.get_area());
+  }
+  if (exu->exist) {
+    exu->area.set_area(exu->area.get_area() + pipeline_area_per_unit);
+    area.set_area(area.get_area() + exu->area.get_area());
+  }
+  if (mmu->exist) {
+    mmu->area.set_area(mmu->area.get_area() + pipeline_area_per_unit);
+    area.set_area(area.get_area() + mmu->area.get_area());
+  }
+
+  if (coredynp.core_ty == OOO) {
+    if (rnu->exist) {
+      area.set_area(area.get_area() + rnu->area.get_area());
+    }
+  }
+
+  if (undiffCore->exist) {
+    area.set_area(area.get_area() + undiffCore->area.get_area());
+  }
+
+  if (XML->sys.Private_L2) {
+    area.set_area(area.get_area() + l2cache->area.get_area());
+  }
+  //  //clock power
+  //  clockNetwork.init_wire_external(is_default, &interface_ip);
+  //  clockNetwork.clk_area           =area*1.1;//10% of placement overhead.
+  //  rule of thumb clockNetwork.end_wiring_level   =5;//toplevel metal
+  //  clockNetwork.start_wiring_level =5;//toplevel metal
+  //  clockNetwork.num_regs           = corepipe.tot_stage_vector;
+  //  clockNetwork.optimize_wire();
+}
+
+void BranchPredictor::computeEnergy(bool is_tdp) {
+  if (!exist) return;
+  double r_access;
+  double w_access;
+  if (is_tdp) {
+    r_access = coredynp.predictionW * coredynp.BR_duty_cycle;
+    w_access = 0 * coredynp.BR_duty_cycle;
+    globalBPT->stats_t.readAc.access = r_access;
+    globalBPT->stats_t.writeAc.access = w_access;
+    globalBPT->tdp_stats = globalBPT->stats_t;
+
+    L1_localBPT->stats_t.readAc.access = r_access;
+    L1_localBPT->stats_t.writeAc.access = w_access;
+    L1_localBPT->tdp_stats = L1_localBPT->stats_t;
+
+    L2_localBPT->stats_t.readAc.access = r_access;
+    L2_localBPT->stats_t.writeAc.access = w_access;
+    L2_localBPT->tdp_stats = L2_localBPT->stats_t;
+
+    chooser->stats_t.readAc.access = r_access;
+    chooser->stats_t.writeAc.access = w_access;
+    chooser->tdp_stats = chooser->stats_t;
+
+    RAS->stats_t.readAc.access = r_access;
+    RAS->stats_t.writeAc.access = w_access;
+    RAS->tdp_stats = RAS->stats_t;
+  } else {
+    // The resolution of BPT accesses is coarse, but this is
+    // because most simulators cannot track finer grained details
+    r_access = XML->sys.core[ithCore].branch_instructions;
+    w_access =
+        XML->sys.core[ithCore].branch_mispredictions +
+        0.1 * XML->sys.core[ithCore]
+                  .branch_instructions;  // 10% of BR will flip internal bits//0
+    globalBPT->stats_t.readAc.access = r_access;
+    globalBPT->stats_t.writeAc.access = w_access;
+    globalBPT->rtp_stats = globalBPT->stats_t;
+
+    L1_localBPT->stats_t.readAc.access = r_access;
+    L1_localBPT->stats_t.writeAc.access = w_access;
+    L1_localBPT->rtp_stats = L1_localBPT->stats_t;
+
+    L2_localBPT->stats_t.readAc.access = r_access;
+    L2_localBPT->stats_t.writeAc.access = w_access;
+    L2_localBPT->rtp_stats = L2_localBPT->stats_t;
+
+    chooser->stats_t.readAc.access = r_access;
+    chooser->stats_t.writeAc.access = w_access;
+    chooser->rtp_stats = chooser->stats_t;
+
+    RAS->stats_t.readAc.access = XML->sys.core[ithCore].function_calls;
+    RAS->stats_t.writeAc.access = XML->sys.core[ithCore].function_calls;
+    RAS->rtp_stats = RAS->stats_t;
+  }
+
+  globalBPT->power_t.reset();
+  L1_localBPT->power_t.reset();
+  L2_localBPT->power_t.reset();
+  chooser->power_t.reset();
+  RAS->power_t.reset();
+
+  globalBPT->power_t.readOp.dynamic +=
+      globalBPT->local_result.power.readOp.dynamic *
+          globalBPT->stats_t.readAc.access +
+      globalBPT->stats_t.writeAc.access *
+          globalBPT->local_result.power.writeOp.dynamic;
+  L1_localBPT->power_t.readOp.dynamic +=
+      L1_localBPT->local_result.power.readOp.dynamic *
+          L1_localBPT->stats_t.readAc.access +
+      L1_localBPT->stats_t.writeAc.access *
+          L1_localBPT->local_result.power.writeOp.dynamic;
+
+  L2_localBPT->power_t.readOp.dynamic +=
+      L2_localBPT->local_result.power.readOp.dynamic *
+          L2_localBPT->stats_t.readAc.access +
+      L2_localBPT->stats_t.writeAc.access *
+          L2_localBPT->local_result.power.writeOp.dynamic;
+
+  chooser->power_t.readOp.dynamic +=
+      chooser->local_result.power.readOp.dynamic *
+          chooser->stats_t.readAc.access +
+      chooser->stats_t.writeAc.access *
+          chooser->local_result.power.writeOp.dynamic;
+  RAS->power_t.readOp.dynamic +=
+      RAS->local_result.power.readOp.dynamic * RAS->stats_t.readAc.access +
+      RAS->stats_t.writeAc.access * RAS->local_result.power.writeOp.dynamic;
+
+  if (is_tdp) {
+    globalBPT->power =
+        globalBPT->power_t + globalBPT->local_result.power * pppm_lkg;
+    L1_localBPT->power =
+        L1_localBPT->power_t + L1_localBPT->local_result.power * pppm_lkg;
+    L2_localBPT->power =
+        L2_localBPT->power_t + L2_localBPT->local_result.power * pppm_lkg;
+    chooser->power = chooser->power_t + chooser->local_result.power * pppm_lkg;
+    RAS->power =
+        RAS->power_t + RAS->local_result.power * coredynp.pppm_lkg_multhread;
+
+    power = power + globalBPT->power + L1_localBPT->power + chooser->power +
+            RAS->power;
+  } else {
+    globalBPT->rt_power =
+        globalBPT->power_t + globalBPT->local_result.power * pppm_lkg;
+    L1_localBPT->rt_power =
+        L1_localBPT->power_t + L1_localBPT->local_result.power * pppm_lkg;
+    L2_localBPT->rt_power =
+        L2_localBPT->power_t + L2_localBPT->local_result.power * pppm_lkg;
+    chooser->rt_power =
+        chooser->power_t + chooser->local_result.power * pppm_lkg;
+    RAS->rt_power =
+        RAS->power_t + RAS->local_result.power * coredynp.pppm_lkg_multhread;
+    rt_power = rt_power + globalBPT->rt_power + L1_localBPT->rt_power +
+               chooser->rt_power + RAS->rt_power;
+  }
+}
+
+void BranchPredictor::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  if (!exist) return;
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
+  if (is_tdp) {
+    cout << indent_str << "Global Predictor:" << endl;
+    cout << indent_str_next << "Area = " << globalBPT->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << globalBPT->power.readOp.dynamic * clockRate
+         << " W" << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? globalBPT->power.readOp.longer_channel_leakage
+                          : globalBPT->power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << globalBPT->power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << globalBPT->rt_power.readOp.dynamic / executionTime << " W" << endl;
+    cout << endl;
+    cout << indent_str << "Local Predictor:" << endl;
+    cout << indent_str << "L1_Local Predictor:" << endl;
+    cout << indent_str_next << "Area = " << L1_localBPT->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << L1_localBPT->power.readOp.dynamic * clockRate
+         << " W" << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? L1_localBPT->power.readOp.longer_channel_leakage
+                          : L1_localBPT->power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << L1_localBPT->power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << L1_localBPT->rt_power.readOp.dynamic / executionTime << " W"
+         << endl;
+    cout << endl;
+    cout << indent_str << "L2_Local Predictor:" << endl;
+    cout << indent_str_next << "Area = " << L2_localBPT->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << L2_localBPT->power.readOp.dynamic * clockRate
+         << " W" << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? L2_localBPT->power.readOp.longer_channel_leakage
+                          : L2_localBPT->power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << L2_localBPT->power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << L2_localBPT->rt_power.readOp.dynamic / executionTime << " W"
+         << endl;
+    cout << endl;
+
+    cout << indent_str << "Chooser:" << endl;
+    cout << indent_str_next << "Area = " << chooser->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << chooser->power.readOp.dynamic * clockRate
+         << " W" << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? chooser->power.readOp.longer_channel_leakage
+                          : chooser->power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << chooser->power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << chooser->rt_power.readOp.dynamic / executionTime << " W" << endl;
+    cout << endl;
+    cout << indent_str << "RAS:" << endl;
+    cout << indent_str_next << "Area = " << RAS->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << RAS->power.readOp.dynamic * clockRate << " W"
+         << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? RAS->power.readOp.longer_channel_leakage
+                          : RAS->power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << RAS->power.readOp.gate_leakage << " W" << endl;
+    cout << indent_str_next
+         << "Runtime Dynamic = " << RAS->rt_power.readOp.dynamic / executionTime
+         << " W" << endl;
+    cout << endl;
+  } else {
+    //		cout << indent_str_next << "Global Predictor    Peak Dynamic = "
+    //<< globalBPT->rt_power.readOp.dynamic*clockRate << " W" << endl;
+    // cout << indent_str_next << "Global Predictor    Subthreshold Leakage = "
+    // << globalBPT->rt_power.readOp.leakage <<" W" << endl; 		cout <<
+    // indent_str_next
+    //<< "Global Predictor    Gate Leakage = " <<
+    // globalBPT->rt_power.readOp.gate_leakage << " W" << endl;
+    // cout
+    // << indent_str_next << "Local Predictor   Peak Dynamic = " <<
+    // L1_localBPT->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    // cout
+    // << indent_str_next << "Local Predictor   Subthreshold Leakage = " <<
+    // L1_localBPT->rt_power.readOp.leakage  << " W" << endl; 		cout <<
+    // indent_str_next << "Local Predictor   Gate Leakage = " <<
+    // L1_localBPT->rt_power.readOp.gate_leakage  << " W" << endl;
+    // cout
+    // << indent_str_next << "Chooser   Peak Dynamic = " <<
+    // chooser->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    // cout
+    // << indent_str_next << "Chooser   Subthreshold Leakage = " <<
+    // chooser->rt_power.readOp.leakage  << " W" << endl; 		cout <<
+    // indent_str_next
+    //<< "Chooser   Gate Leakage = " << chooser->rt_power.readOp.gate_leakage <<
+    //" W" << endl; 		cout << indent_str_next << "RAS   Peak Dynamic =
+    //"
+    //<< RAS->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    // cout << indent_str_next << "RAS   Subthreshold Leakage = " <<
+    // RAS->rt_power.readOp.leakage  << " W" << endl; 		cout <<
+    // indent_str_next
+    // << "RAS   Gate Leakage = " << RAS->rt_power.readOp.gate_leakage  << " W"
+    //<< endl;
+  }
+}
+
+void InstFetchU::computeEnergy(bool is_tdp) {
+  executionTime =
+      XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);  // Syed
+  // cout <<"IFU: execution time:
+  // "<<XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6)<<endl; cout
+  // <<"IFU: total cycles"<<XML->sys.total_cycles<<endl;
+  if (!exist) return;
+  if (is_tdp) {
+    // init stats for Peak
+    icache.caches->stats_t.readAc.access =
+        icache.caches->l_ip.num_rw_ports * coredynp.IFU_duty_cycle;
+    icache.caches->stats_t.readAc.miss = 0;
+    icache.caches->stats_t.readAc.hit = icache.caches->stats_t.readAc.access -
+                                        icache.caches->stats_t.readAc.miss;
+    icache.caches->tdp_stats = icache.caches->stats_t;
+
+    icache.missb->stats_t.readAc.access = icache.missb->stats_t.readAc.hit =
+        icache.missb->l_ip.num_search_ports;
+    icache.missb->stats_t.writeAc.access = icache.missb->stats_t.writeAc.hit =
+        icache.missb->l_ip.num_search_ports;
+    icache.missb->tdp_stats = icache.missb->stats_t;
+
+    icache.ifb->stats_t.readAc.access = icache.ifb->stats_t.readAc.hit =
+        icache.ifb->l_ip.num_search_ports;
+    icache.ifb->stats_t.writeAc.access = icache.ifb->stats_t.writeAc.hit =
+        icache.ifb->l_ip.num_search_ports;
+    icache.ifb->tdp_stats = icache.ifb->stats_t;
+
+    icache.prefetchb->stats_t.readAc.access =
+        icache.prefetchb->stats_t.readAc.hit =
+            icache.prefetchb->l_ip.num_search_ports;
+    icache.prefetchb->stats_t.writeAc.access = icache.ifb->stats_t.writeAc.hit =
+        icache.ifb->l_ip.num_search_ports;
+    icache.prefetchb->tdp_stats = icache.prefetchb->stats_t;
+
+    IB->stats_t.readAc.access = IB->stats_t.writeAc.access =
+        XML->sys.core[ithCore].peak_issue_width;
+    IB->tdp_stats = IB->stats_t;
+
+    if (coredynp.predictionW > 0) {
+      BTB->stats_t.readAc.access =
+          coredynp.predictionW;  // XML->sys.core[ithCore].BTB.read_accesses;
+      BTB->stats_t.writeAc.access =
+          0;  // XML->sys.core[ithCore].BTB.write_accesses;
+    }
+
+    ID_inst->stats_t.readAc.access = coredynp.decodeW;
+    ID_operand->stats_t.readAc.access = coredynp.decodeW;
+    ID_misc->stats_t.readAc.access = coredynp.decodeW;
+    ID_inst->tdp_stats = ID_inst->stats_t;
+    ID_operand->tdp_stats = ID_operand->stats_t;
+    ID_misc->tdp_stats = ID_misc->stats_t;
+
+  } /* if (is_tdp) */
   else {
-	  pipeline_area_per_unit    = (corepipe->area.get_area()*coredynp.num_pipelines)/4.0;
+    rt_power.reset();
+    icache.rt_power.reset();  // Jingwen
+    // init stats for Runtime Dynamic (RTP)
+    // cout<< "****>>>>Icache stats:"<<endl;
+    // cout<<"Read accesses: "<< XML->sys.core[ithCore].icache.read_accesses <<
+    // " Read misses: "<<XML->sys.core[ithCore].icache.read_misses<<endl;
+    icache.caches->stats_t.readAc.access =
+        XML->sys.core[ithCore].icache.read_accesses;
+    icache.caches->stats_t.readAc.miss =
+        XML->sys.core[ithCore].icache.read_misses;
+    // cout<<endl<<"inside mcpat read access=
+    // "<<XML->sys.core[ithCore].icache.read_accesses; cout<<endl<<"inside mcpat
+    // read miss= "<<XML->sys.core[ithCore].icache.read_misses;
+
+    icache.caches->stats_t.readAc.hit = icache.caches->stats_t.readAc.access -
+                                        icache.caches->stats_t.readAc.miss;
+    icache.caches->rtp_stats = icache.caches->stats_t;
+    // cout<<endl<<"inside mcpat read hit=
+    // "<<icache.caches->stats_t.readAc.hit<<endl;
+    icache.missb->stats_t.readAc.access = icache.caches->stats_t.readAc.miss;
+    icache.missb->stats_t.writeAc.access = icache.caches->stats_t.readAc.miss;
+    icache.missb->rtp_stats = icache.missb->stats_t;
+
+    icache.ifb->stats_t.readAc.access = icache.caches->stats_t.readAc.miss;
+    icache.ifb->stats_t.writeAc.access = icache.caches->stats_t.readAc.miss;
+    icache.ifb->rtp_stats = icache.ifb->stats_t;
+
+    icache.prefetchb->stats_t.readAc.access =
+        icache.caches->stats_t.readAc.miss;
+    icache.prefetchb->stats_t.writeAc.access =
+        icache.caches->stats_t.readAc.miss;
+    icache.prefetchb->rtp_stats = icache.prefetchb->stats_t;
+
+    IB->stats_t.readAc.access = IB->stats_t.writeAc.access =
+        XML->sys.core[ithCore].total_instructions;
+    IB->rtp_stats = IB->stats_t;
+    // cout<<"IB: total instructions: "<<IB->stats_t.readAc.access <<endl;
+    if (coredynp.predictionW > 0) {
+      BTB->stats_t.readAc.access =
+          XML->sys.core[ithCore]
+              .BTB
+              .read_accesses;  // XML->sys.core[ithCore].branch_instructions;
+      BTB->stats_t.writeAc.access =
+          XML->sys.core[ithCore]
+              .BTB
+              .write_accesses;  // XML->sys.core[ithCore].branch_mispredictions;
+      BTB->rtp_stats = BTB->stats_t;
+    }
+    // cout<<"ID: total instructions: "<<
+    // XML->sys.core[ithCore].total_instructions<<endl;
+    ID_inst->stats_t.readAc.access = XML->sys.core[ithCore].total_instructions;
+    ID_operand->stats_t.readAc.access =
+        XML->sys.core[ithCore].total_instructions;
+    ID_misc->stats_t.readAc.access = XML->sys.core[ithCore].total_instructions;
+    ID_inst->rtp_stats = ID_inst->stats_t;
+    ID_operand->rtp_stats = ID_operand->stats_t;
+    ID_misc->rtp_stats = ID_misc->stats_t;
   }
 
-  //area.set_area(area.get_area()+ corepipe->area.get_area());
-  if (ifu->exist)
-  {
-	  ifu->area.set_area(ifu->area.get_area() + pipeline_area_per_unit);
-	  area.set_area(area.get_area() + ifu->area.get_area());
-  }
-  if (lsu->exist)
-  {
-	  lsu->area.set_area(lsu->area.get_area() + pipeline_area_per_unit);
-      area.set_area(area.get_area() + lsu->area.get_area());
-  }
-  if (exu->exist)
-  {
-	  exu->area.set_area(exu->area.get_area() + pipeline_area_per_unit);
-	  area.set_area(area.get_area()+exu->area.get_area());
-  }
-  if (mmu->exist)
-  {
-	  mmu->area.set_area(mmu->area.get_area() + pipeline_area_per_unit);
-      area.set_area(area.get_area()+mmu->area.get_area());
+  icache.power_t.reset();
+  IB->power_t.reset();
+  //	ID_inst->power_t.reset();
+  //	ID_operand->power_t.reset();
+  //	ID_misc->power_t.reset();
+  if (coredynp.predictionW > 0) {
+    BTB->power_t.reset();
   }
 
-  if (coredynp.core_ty==OOO)
-  {
-	  if (rnu->exist)
-	  {
+  icache.power_t.readOp.dynamic +=
+      (icache.caches->stats_t.readAc.hit *
+           icache.caches->local_result.power.readOp.dynamic +
+       // icache.caches->stats_t.readAc.miss*icache.caches->local_result.tag_array2->power.readOp.dynamic+
+       icache.caches->stats_t.readAc.miss *
+           icache.caches->local_result.power.readOp
+               .dynamic +  // assume tag data accessed in parallel
+       icache.caches->stats_t.readAc.miss *
+           icache.caches->local_result.power.writeOp
+               .dynamic);  // read miss in Icache cause a write to Icache
+  icache.power_t.readOp.dynamic +=
+      icache.missb->stats_t.readAc.access *
+          icache.missb->local_result.power.searchOp.dynamic +
+      icache.missb->stats_t.writeAc.access *
+          icache.missb->local_result.power.writeOp
+              .dynamic;  // each access to missb involves a CAM and a write
+  icache.power_t.readOp.dynamic +=
+      icache.ifb->stats_t.readAc.access *
+          icache.ifb->local_result.power.searchOp.dynamic +
+      icache.ifb->stats_t.writeAc.access *
+          icache.ifb->local_result.power.writeOp.dynamic;
+  icache.power_t.readOp.dynamic +=
+      icache.prefetchb->stats_t.readAc.access *
+          icache.prefetchb->local_result.power.searchOp.dynamic +
+      icache.prefetchb->stats_t.writeAc.access *
+          icache.prefetchb->local_result.power.writeOp.dynamic;
+  // cout<<"Icache power: "<<icache.power_t.readOp.dynamic	<<endl;
+  IB->power_t.readOp.dynamic +=
+      IB->local_result.power.readOp.dynamic * IB->stats_t.readAc.access +
+      IB->stats_t.writeAc.access * IB->local_result.power.writeOp.dynamic;
+  // cout << "IB power: "<<IB->power_t.readOp.dynamic<<endl;
+  if (coredynp.predictionW > 0) {
+    BTB->power_t.readOp.dynamic +=
+        BTB->local_result.power.readOp.dynamic * BTB->stats_t.readAc.access +
+        BTB->stats_t.writeAc.access * BTB->local_result.power.writeOp.dynamic;
 
-		  area.set_area(area.get_area() + rnu->area.get_area());
-	  }
+    BPT->computeEnergy(is_tdp);
   }
 
-  if (undiffCore->exist)
-  {
-	  area.set_area(area.get_area() + undiffCore->area.get_area());
+  if (is_tdp) {
+    //    	icache.power = icache.power_t +
+    //    	        (icache.caches->local_result.power)*pppm_lkg +
+    //    			(icache.missb->local_result.power +
+    //    			icache.ifb->local_result.power +
+    //    			icache.prefetchb->local_result.power)*pppm_Isub;
+    icache.power = icache.power_t + (icache.caches->local_result.power +
+                                     icache.missb->local_result.power +
+                                     icache.ifb->local_result.power +
+                                     icache.prefetchb->local_result.power) *
+                                        pppm_lkg;
+
+    IB->power = IB->power_t + IB->local_result.power * pppm_lkg;
+    power = power + icache.power + IB->power;
+    if (coredynp.predictionW > 0) {
+      BTB->power = BTB->power_t + BTB->local_result.power * pppm_lkg;
+      power = power + BTB->power + BPT->power;
+    }
+
+    ID_inst->power_t.readOp.dynamic = ID_inst->power.readOp.dynamic;
+    ID_operand->power_t.readOp.dynamic = ID_operand->power.readOp.dynamic;
+    ID_misc->power_t.readOp.dynamic = ID_misc->power.readOp.dynamic;
+
+    ID_inst->power.readOp.dynamic *= ID_inst->tdp_stats.readAc.access;
+    ID_operand->power.readOp.dynamic *= ID_operand->tdp_stats.readAc.access;
+    ID_misc->power.readOp.dynamic *= ID_misc->tdp_stats.readAc.access;
+
+    power = power + (ID_inst->power + ID_operand->power + ID_misc->power);
+  } /* if (is_tdp) */
+  else {
+    //    	icache.rt_power = icache.power_t +
+    //    	        (icache.caches->local_result.power)*pppm_lkg +
+    //    			(icache.missb->local_result.power +
+    //    			icache.ifb->local_result.power +
+    //    			icache.prefetchb->local_result.power)*pppm_Isub;
+
+    icache.rt_power = icache.power_t + (icache.caches->local_result.power +
+                                        icache.missb->local_result.power +
+                                        icache.ifb->local_result.power +
+                                        icache.prefetchb->local_result.power) *
+                                           pppm_lkg;
+
+    // IB->rt_power = IB->power_t + IB->local_result.power*pppm_lkg;
+    IB->rt_power.readOp.dynamic =
+        IB->local_result.power.readOp.dynamic * IB->rtp_stats.readAc.access;
+    IB->rt_power.readOp.dynamic +=
+        IB->local_result.power.writeOp.dynamic * IB->rtp_stats.writeAc.access;
+    rt_power = rt_power + icache.rt_power + IB->rt_power;
+    if (coredynp.predictionW > 0) {
+      BTB->rt_power = BTB->power_t + BTB->local_result.power * pppm_lkg;
+      rt_power = rt_power + BTB->rt_power + BPT->rt_power;
+    }
+
+    ID_inst->rt_power.readOp.dynamic =
+        ID_inst->power_t.readOp.dynamic * ID_inst->rtp_stats.readAc.access;
+    ID_operand->rt_power.readOp.dynamic = ID_operand->power_t.readOp.dynamic *
+                                          ID_operand->rtp_stats.readAc.access;
+    ID_misc->rt_power.readOp.dynamic =
+        ID_misc->power_t.readOp.dynamic * ID_misc->rtp_stats.readAc.access;
+
+    rt_power = rt_power +
+               (ID_inst->rt_power + ID_operand->rt_power + ID_misc->rt_power);
+    // cout<<"ID inst: "<<ID_inst->rt_power.readOp.dynamic << " ID operand:
+    // "<<ID_operand->rt_power.readOp.dynamic<<" ID misc:
+    // "<<ID_misc->rt_power.readOp.dynamic<<endl;
+  }
+}
+
+void InstFetchU::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  if (!exist) return;
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
+
+  if (is_tdp) {
+    cout << indent_str << "Instruction Cache:" << endl;
+    cout << indent_str_next << "Area = " << icache.area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << icache.power.readOp.dynamic * clockRate << " W"
+         << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? icache.power.readOp.longer_channel_leakage
+                          : icache.power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << icache.power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << icache.rt_power.readOp.dynamic / executionTime << " W" << endl;
+    cout << endl;
+    if (coredynp.predictionW > 0) {
+      cout << indent_str << "Branch Target Buffer:" << endl;
+      cout << indent_str_next << "Area = " << BTB->area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << BTB->power.readOp.dynamic * clockRate << " W"
+           << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? BTB->power.readOp.longer_channel_leakage
+                            : BTB->power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << BTB->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << BTB->rt_power.readOp.dynamic / executionTime << " W" << endl;
+      cout << endl;
+      if (BPT->exist) {
+        cout << indent_str << "Branch Predictor:" << endl;
+        cout << indent_str_next << "Area = " << BPT->area.get_area() * 1e-6
+             << " mm^2" << endl;
+        cout << indent_str_next
+             << "Peak Dynamic = " << BPT->power.readOp.dynamic * clockRate
+             << " W" << endl;
+        cout << indent_str_next << "Subthreshold Leakage = "
+             << (long_channel ? BPT->power.readOp.longer_channel_leakage
+                              : BPT->power.readOp.leakage)
+             << " W" << endl;
+        cout << indent_str_next
+             << "Gate Leakage = " << BPT->power.readOp.gate_leakage << " W"
+             << endl;
+        cout << indent_str_next << "Runtime Dynamic = "
+             << BPT->rt_power.readOp.dynamic / executionTime << " W" << endl;
+        cout << endl;
+        if (plevel > 3) {
+          BPT->displayEnergy(indent + 4, plevel, is_tdp);
+        }
+      }
+    }
+    cout << indent_str << "Instruction Buffer:" << endl;
+    cout << indent_str_next << "Area = " << IB->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << IB->power.readOp.dynamic * clockRate << " W"
+         << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? IB->power.readOp.longer_channel_leakage
+                          : IB->power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << IB->power.readOp.gate_leakage << " W" << endl;
+    cout << indent_str_next
+         << "Runtime Dynamic = " << IB->rt_power.readOp.dynamic / executionTime
+         << " W" << endl;
+    cout << endl;
+    cout << indent_str << "Instruction Decoder:" << endl;
+    cout << indent_str_next << "Area = "
+         << (ID_inst->area.get_area() + ID_operand->area.get_area() +
+             ID_misc->area.get_area()) *
+                coredynp.decodeW * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next << "Peak Dynamic = "
+         << (ID_inst->power.readOp.dynamic + ID_operand->power.readOp.dynamic +
+             ID_misc->power.readOp.dynamic) *
+                clockRate
+         << " W" << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? (ID_inst->power.readOp.longer_channel_leakage +
+                             ID_operand->power.readOp.longer_channel_leakage +
+                             ID_misc->power.readOp.longer_channel_leakage)
+                          : (ID_inst->power.readOp.leakage +
+                             ID_operand->power.readOp.leakage +
+                             ID_misc->power.readOp.leakage))
+         << " W" << endl;
+    cout << indent_str_next << "Gate Leakage = "
+         << (ID_inst->power.readOp.gate_leakage +
+             ID_operand->power.readOp.gate_leakage +
+             ID_misc->power.readOp.gate_leakage)
+         << " W" << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << (ID_inst->rt_power.readOp.dynamic +
+             ID_operand->rt_power.readOp.dynamic +
+             ID_misc->rt_power.readOp.dynamic) /
+                executionTime
+         << " W" << endl;
+    cout << endl;
+  } else {
+    //		cout << indent_str_next << "Instruction Cache    Peak Dynamic =
+    //"
+    //<< icache.rt_power.readOp.dynamic*clockRate << " W" << endl;
+    // cout << indent_str_next << "Instruction Cache    Subthreshold Leakage = "
+    // << icache.rt_power.readOp.leakage <<" W" << endl; 		cout <<
+    // indent_str_next << "Instruction Cache    Gate Leakage = " <<
+    // icache.rt_power.readOp.gate_leakage << " W" << endl; 		cout <<
+    // indent_str_next << "Instruction Buffer   Peak Dynamic = " <<
+    // IB->rt_power.readOp.dynamic*clockRate  << " W" << endl; 		cout <<
+    // indent_str_next << "Instruction Buffer   Subthreshold Leakage = " <<
+    // IB->rt_power.readOp.leakage  << " W" << endl; 		cout <<
+    // indent_str_next
+    // << "Instruction Buffer   Gate Leakage = " <<
+    // IB->rt_power.readOp.gate_leakage
+    //<< " W" << endl; 		cout << indent_str_next << "Branch Target Buffer
+    // Peak Dynamic = " << BTB->rt_power.readOp.dynamic*clockRate  << " W" <<
+    // endl; 		cout << indent_str_next << "Branch Target Buffer
+    // Subthreshold Leakage = " << BTB->rt_power.readOp.leakage  << " W" <<
+    // endl; 		cout
+    // << indent_str_next << "Branch Target Buffer   Gate Leakage = " <<
+    // BTB->rt_power.readOp.gate_leakage  << " W" << endl; 		cout <<
+    // indent_str_next << "Branch Predictor   Peak Dynamic = " <<
+    // BPT->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    // cout
+    // << indent_str_next << "Branch Predictor   Subthreshold Leakage = " <<
+    // BPT->rt_power.readOp.leakage  << " W" << endl; 		cout <<
+    // indent_str_next
+    // << "Branch Predictor   Gate Leakage = " <<
+    // BPT->rt_power.readOp.gate_leakage
+    //<< " W" << endl;
+  }
+}
+
+void RENAMINGU::computeEnergy(bool is_tdp) {
+  if (!exist) return;
+  double pppm_t[4] = {1, 1, 1, 1};
+  if (is_tdp) {  // init stats for Peak
+    if (coredynp.core_ty == OOO) {
+      if (coredynp.scheu_ty == PhysicalRegFile) {
+        if (coredynp.rm_ty == RAMbased) {
+          iFRAT->stats_t.readAc.access = iFRAT->l_ip.num_rd_ports;
+          iFRAT->stats_t.writeAc.access = iFRAT->l_ip.num_wr_ports;
+          iFRAT->tdp_stats = iFRAT->stats_t;
+
+          fFRAT->stats_t.readAc.access = fFRAT->l_ip.num_rd_ports;
+          fFRAT->stats_t.writeAc.access = fFRAT->l_ip.num_wr_ports;
+          fFRAT->tdp_stats = fFRAT->stats_t;
+
+        } else if ((coredynp.rm_ty == CAMbased)) {
+          iFRAT->stats_t.readAc.access = iFRAT->l_ip.num_search_ports;
+          iFRAT->stats_t.writeAc.access = iFRAT->l_ip.num_wr_ports;
+          iFRAT->tdp_stats = iFRAT->stats_t;
+
+          fFRAT->stats_t.readAc.access = fFRAT->l_ip.num_search_ports;
+          fFRAT->stats_t.writeAc.access = fFRAT->l_ip.num_wr_ports;
+          fFRAT->tdp_stats = fFRAT->stats_t;
+        }
+
+        iRRAT->stats_t.readAc.access = iRRAT->l_ip.num_rd_ports;
+        iRRAT->stats_t.writeAc.access = iRRAT->l_ip.num_wr_ports;
+        iRRAT->tdp_stats = iRRAT->stats_t;
+
+        fRRAT->stats_t.readAc.access = fRRAT->l_ip.num_rd_ports;
+        fRRAT->stats_t.writeAc.access = fRRAT->l_ip.num_wr_ports;
+        fRRAT->tdp_stats = fRRAT->stats_t;
+
+        ifreeL->stats_t.readAc.access =
+            coredynp.decodeW;  // ifreeL->l_ip.num_rd_ports;;
+        ifreeL->stats_t.writeAc.access =
+            coredynp.decodeW;  // ifreeL->l_ip.num_wr_ports;
+        ifreeL->tdp_stats = ifreeL->stats_t;
+
+        ffreeL->stats_t.readAc.access =
+            coredynp.decodeW;  // ffreeL->l_ip.num_rd_ports;
+        ffreeL->stats_t.writeAc.access =
+            coredynp.decodeW;  // ffreeL->l_ip.num_wr_ports;
+        ffreeL->tdp_stats = ffreeL->stats_t;
+      } else if (coredynp.scheu_ty == ReservationStation) {
+        if (coredynp.rm_ty == RAMbased) {
+          iFRAT->stats_t.readAc.access = iFRAT->l_ip.num_rd_ports;
+          iFRAT->stats_t.writeAc.access = iFRAT->l_ip.num_wr_ports;
+          iFRAT->stats_t.searchAc.access = iFRAT->l_ip.num_search_ports;
+          iFRAT->tdp_stats = iFRAT->stats_t;
+
+          fFRAT->stats_t.readAc.access = fFRAT->l_ip.num_rd_ports;
+          fFRAT->stats_t.writeAc.access = fFRAT->l_ip.num_wr_ports;
+          fFRAT->stats_t.searchAc.access = fFRAT->l_ip.num_search_ports;
+          fFRAT->tdp_stats = fFRAT->stats_t;
+
+        } else if ((coredynp.rm_ty == CAMbased)) {
+          iFRAT->stats_t.readAc.access = iFRAT->l_ip.num_search_ports;
+          iFRAT->stats_t.writeAc.access = iFRAT->l_ip.num_wr_ports;
+          iFRAT->tdp_stats = iFRAT->stats_t;
+
+          fFRAT->stats_t.readAc.access = fFRAT->l_ip.num_search_ports;
+          fFRAT->stats_t.writeAc.access = fFRAT->l_ip.num_wr_ports;
+          fFRAT->tdp_stats = fFRAT->stats_t;
+        }
+        // Unified free list for both int and fp
+        ifreeL->stats_t.readAc.access =
+            coredynp.decodeW;  // ifreeL->l_ip.num_rd_ports;
+        ifreeL->stats_t.writeAc.access =
+            coredynp.decodeW;  // ifreeL->l_ip.num_wr_ports;
+        ifreeL->tdp_stats = ifreeL->stats_t;
+      }
+      idcl->stats_t.readAc.access = coredynp.decodeW;
+      fdcl->stats_t.readAc.access = coredynp.decodeW;
+      idcl->tdp_stats = idcl->stats_t;
+      fdcl->tdp_stats = fdcl->stats_t;
+    } else {
+      if (coredynp.issueW > 1) {
+        idcl->stats_t.readAc.access = coredynp.decodeW;
+        fdcl->stats_t.readAc.access = coredynp.decodeW;
+        idcl->tdp_stats = idcl->stats_t;
+        fdcl->tdp_stats = fdcl->stats_t;
+      }
+    }
+
+  } else {  // init stats for Runtime Dynamic (RTP)
+    if (coredynp.core_ty == OOO) {
+      if (coredynp.scheu_ty == PhysicalRegFile) {
+        if (coredynp.rm_ty == RAMbased) {
+          iFRAT->stats_t.readAc.access = XML->sys.core[ithCore].rename_reads;
+          iFRAT->stats_t.writeAc.access = XML->sys.core[ithCore].rename_writes;
+          iFRAT->rtp_stats = iFRAT->stats_t;
+
+          fFRAT->stats_t.readAc.access = XML->sys.core[ithCore].fp_rename_reads;
+          fFRAT->stats_t.writeAc.access =
+              XML->sys.core[ithCore].fp_rename_writes;
+          fFRAT->rtp_stats = fFRAT->stats_t;
+        } else if ((coredynp.rm_ty == CAMbased)) {
+          iFRAT->stats_t.readAc.access = XML->sys.core[ithCore].rename_reads;
+          iFRAT->stats_t.writeAc.access = XML->sys.core[ithCore].rename_writes;
+          iFRAT->rtp_stats = iFRAT->stats_t;
+
+          fFRAT->stats_t.readAc.access = XML->sys.core[ithCore].fp_rename_reads;
+          fFRAT->stats_t.writeAc.access =
+              XML->sys.core[ithCore].fp_rename_writes;
+          fFRAT->rtp_stats = fFRAT->stats_t;
+        }
+
+        iRRAT->stats_t.readAc.access =
+            XML->sys.core[ithCore]
+                .rename_writes;  // Hack, should be (context switch + branch
+                                 // mispredictions)*16
+        iRRAT->stats_t.writeAc.access = XML->sys.core[ithCore].rename_writes;
+        iRRAT->rtp_stats = iRRAT->stats_t;
+
+        fRRAT->stats_t.readAc.access =
+            XML->sys.core[ithCore]
+                .fp_rename_writes;  // Hack, should be (context switch + branch
+                                    // mispredictions)*16
+        fRRAT->stats_t.writeAc.access = XML->sys.core[ithCore].fp_rename_writes;
+        fRRAT->rtp_stats = fRRAT->stats_t;
+
+        ifreeL->stats_t.readAc.access = XML->sys.core[ithCore].rename_reads;
+        ifreeL->stats_t.writeAc.access =
+            2 * XML->sys.core[ithCore].rename_writes;
+        ifreeL->rtp_stats = ifreeL->stats_t;
+
+        ffreeL->stats_t.readAc.access = XML->sys.core[ithCore].fp_rename_reads;
+        ffreeL->stats_t.writeAc.access =
+            2 * XML->sys.core[ithCore].fp_rename_writes;
+        ffreeL->rtp_stats = ffreeL->stats_t;
+      } else if (coredynp.scheu_ty == ReservationStation) {
+        if (coredynp.rm_ty == RAMbased) {
+          iFRAT->stats_t.readAc.access = XML->sys.core[ithCore].rename_reads;
+          iFRAT->stats_t.writeAc.access = XML->sys.core[ithCore].rename_writes;
+          iFRAT->stats_t.searchAc.access =
+              XML->sys.core[ithCore]
+                  .committed_int_instructions;  // hack: not all committed
+                                                // instructions use regs.
+          iFRAT->rtp_stats = iFRAT->stats_t;
+
+          fFRAT->stats_t.readAc.access = XML->sys.core[ithCore].fp_rename_reads;
+          fFRAT->stats_t.writeAc.access =
+              XML->sys.core[ithCore].fp_rename_writes;
+          fFRAT->stats_t.searchAc.access =
+              XML->sys.core[ithCore].committed_fp_instructions;
+          fFRAT->rtp_stats = fFRAT->stats_t;
+        } else if ((coredynp.rm_ty == CAMbased)) {
+          iFRAT->stats_t.readAc.access = XML->sys.core[ithCore].rename_reads;
+          iFRAT->stats_t.writeAc.access = XML->sys.core[ithCore].rename_writes;
+          iFRAT->rtp_stats = iFRAT->stats_t;
+
+          fFRAT->stats_t.readAc.access = XML->sys.core[ithCore].fp_rename_reads;
+          fFRAT->stats_t.writeAc.access =
+              XML->sys.core[ithCore].fp_rename_writes;
+          fFRAT->rtp_stats = fFRAT->stats_t;
+        }
+        // Unified free list for both int and fp since the ROB act as physcial
+        // registers
+        ifreeL->stats_t.readAc.access = XML->sys.core[ithCore].rename_reads +
+                                        XML->sys.core[ithCore].fp_rename_reads;
+        ifreeL->stats_t.writeAc.access =
+            2 * (XML->sys.core[ithCore].rename_writes +
+                 XML->sys.core[ithCore]
+                     .fp_rename_writes);  // HACK: 2-> since some of renaming in
+                                          // the same group are terminated early
+        ifreeL->rtp_stats = ifreeL->stats_t;
+      }
+      idcl->stats_t.readAc.access = 3 * coredynp.decodeW * coredynp.decodeW *
+                                    XML->sys.core[ithCore].rename_reads;
+      fdcl->stats_t.readAc.access = 3 * coredynp.fp_issueW *
+                                    coredynp.fp_issueW *
+                                    XML->sys.core[ithCore].fp_rename_writes;
+      idcl->rtp_stats = idcl->stats_t;
+      fdcl->rtp_stats = fdcl->stats_t;
+    } else {
+      if (coredynp.issueW > 1) {
+        idcl->stats_t.readAc.access =
+            2 * XML->sys.core[ithCore].int_instructions;
+        fdcl->stats_t.readAc.access = XML->sys.core[ithCore].fp_instructions;
+        idcl->rtp_stats = idcl->stats_t;
+        fdcl->rtp_stats = fdcl->stats_t;
+      }
+    }
+  }
+  /* Compute engine */
+  if (coredynp.core_ty == OOO) {
+    if (coredynp.scheu_ty == PhysicalRegFile) {
+      if (coredynp.rm_ty == RAMbased) {
+        iFRAT->power_t.reset();
+        fFRAT->power_t.reset();
+
+        iFRAT->power_t.readOp.dynamic +=
+            (iFRAT->stats_t.readAc.access *
+                 (iFRAT->local_result.power.readOp.dynamic +
+                  idcl->power.readOp.dynamic) +
+             iFRAT->stats_t.writeAc.access *
+                 iFRAT->local_result.power.writeOp.dynamic);
+        fFRAT->power_t.readOp.dynamic +=
+            (fFRAT->stats_t.readAc.access *
+                 (fFRAT->local_result.power.readOp.dynamic +
+                  fdcl->power.readOp.dynamic) +
+             fFRAT->stats_t.writeAc.access *
+                 fFRAT->local_result.power.writeOp.dynamic);
+      } else if ((coredynp.rm_ty == CAMbased)) {
+        iFRAT->power_t.reset();
+        fFRAT->power_t.reset();
+        iFRAT->power_t.readOp.dynamic +=
+            (iFRAT->stats_t.readAc.access *
+                 (iFRAT->local_result.power.searchOp.dynamic +
+                  idcl->power.readOp.dynamic) +
+             iFRAT->stats_t.writeAc.access *
+                 iFRAT->local_result.power.writeOp.dynamic);
+        fFRAT->power_t.readOp.dynamic +=
+            (fFRAT->stats_t.readAc.access *
+                 (fFRAT->local_result.power.searchOp.dynamic +
+                  fdcl->power.readOp.dynamic) +
+             fFRAT->stats_t.writeAc.access *
+                 fFRAT->local_result.power.writeOp.dynamic);
+      }
+
+      iRRAT->power_t.reset();
+      fRRAT->power_t.reset();
+      ifreeL->power_t.reset();
+      ffreeL->power_t.reset();
+
+      iRRAT->power_t.readOp.dynamic +=
+          (iRRAT->stats_t.readAc.access *
+               iRRAT->local_result.power.readOp.dynamic +
+           iRRAT->stats_t.writeAc.access *
+               iRRAT->local_result.power.writeOp.dynamic);
+      fRRAT->power_t.readOp.dynamic +=
+          (fRRAT->stats_t.readAc.access *
+               fRRAT->local_result.power.readOp.dynamic +
+           fRRAT->stats_t.writeAc.access *
+               fRRAT->local_result.power.writeOp.dynamic);
+      ifreeL->power_t.readOp.dynamic +=
+          (ifreeL->stats_t.readAc.access *
+               ifreeL->local_result.power.readOp.dynamic +
+           ifreeL->stats_t.writeAc.access *
+               ifreeL->local_result.power.writeOp.dynamic);
+      ffreeL->power_t.readOp.dynamic +=
+          (ffreeL->stats_t.readAc.access *
+               ffreeL->local_result.power.readOp.dynamic +
+           ffreeL->stats_t.writeAc.access *
+               ffreeL->local_result.power.writeOp.dynamic);
+
+    } else if (coredynp.scheu_ty == ReservationStation) {
+      if (coredynp.rm_ty == RAMbased) {
+        iFRAT->power_t.reset();
+        fFRAT->power_t.reset();
+
+        iFRAT->power_t.readOp.dynamic +=
+            (iFRAT->stats_t.readAc.access *
+                 (iFRAT->local_result.power.readOp.dynamic +
+                  idcl->power.readOp.dynamic) +
+             iFRAT->stats_t.writeAc.access *
+                 iFRAT->local_result.power.writeOp.dynamic +
+             iFRAT->stats_t.searchAc.access *
+                 iFRAT->local_result.power.searchOp.dynamic);
+        fFRAT->power_t.readOp.dynamic +=
+            (fFRAT->stats_t.readAc.access *
+                 (fFRAT->local_result.power.readOp.dynamic +
+                  fdcl->power.readOp.dynamic) +
+             fFRAT->stats_t.writeAc.access *
+                 fFRAT->local_result.power.writeOp.dynamic +
+             fFRAT->stats_t.searchAc.access *
+                 fFRAT->local_result.power.searchOp.dynamic);
+      } else if ((coredynp.rm_ty == CAMbased)) {
+        iFRAT->power_t.reset();
+        fFRAT->power_t.reset();
+        iFRAT->power_t.readOp.dynamic +=
+            (iFRAT->stats_t.readAc.access *
+                 (iFRAT->local_result.power.searchOp.dynamic +
+                  idcl->power.readOp.dynamic) +
+             iFRAT->stats_t.writeAc.access *
+                 iFRAT->local_result.power.writeOp.dynamic);
+        fFRAT->power_t.readOp.dynamic +=
+            (fFRAT->stats_t.readAc.access *
+                 (fFRAT->local_result.power.searchOp.dynamic +
+                  fdcl->power.readOp.dynamic) +
+             fFRAT->stats_t.writeAc.access *
+                 fFRAT->local_result.power.writeOp.dynamic);
+      }
+      ifreeL->power_t.reset();
+      ifreeL->power_t.readOp.dynamic +=
+          (ifreeL->stats_t.readAc.access *
+               ifreeL->local_result.power.readOp.dynamic +
+           ifreeL->stats_t.writeAc.access *
+               ifreeL->local_result.power.writeOp.dynamic);
+    }
+
+  } else {
+    if (coredynp.issueW > 1) {
+      idcl->power_t.reset();
+      fdcl->power_t.reset();
+      set_pppm(pppm_t, idcl->stats_t.readAc.access, coredynp.num_hthreads,
+               coredynp.num_hthreads, idcl->stats_t.readAc.access);
+      idcl->power_t = idcl->power * pppm_t;
+      set_pppm(pppm_t, fdcl->stats_t.readAc.access, coredynp.num_hthreads,
+               coredynp.num_hthreads, idcl->stats_t.readAc.access);
+      fdcl->power_t = fdcl->power * pppm_t;
+    }
   }
 
-  if (XML->sys.Private_L2)
-  {
-	  area.set_area(area.get_area() + l2cache->area.get_area());
+  // assign value to tpd and rtp
+  if (is_tdp) {
+    if (coredynp.core_ty == OOO) {
+      if (coredynp.scheu_ty == PhysicalRegFile) {
+        iFRAT->power =
+            iFRAT->power_t +
+            (iFRAT->local_result.power) * coredynp.pppm_lkg_multhread +
+            idcl->power_t;
+        fFRAT->power =
+            fFRAT->power_t +
+            (fFRAT->local_result.power) * coredynp.pppm_lkg_multhread +
+            fdcl->power_t;
+        iRRAT->power = iRRAT->power_t +
+                       iRRAT->local_result.power * coredynp.pppm_lkg_multhread;
+        fRRAT->power = fRRAT->power_t +
+                       fRRAT->local_result.power * coredynp.pppm_lkg_multhread;
+        ifreeL->power = ifreeL->power_t + ifreeL->local_result.power *
+                                              coredynp.pppm_lkg_multhread;
+        ffreeL->power = ffreeL->power_t + ffreeL->local_result.power *
+                                              coredynp.pppm_lkg_multhread;
+        power = power + (iFRAT->power + fFRAT->power) +
+                (iRRAT->power + fRRAT->power) + (ifreeL->power + ffreeL->power);
+      } else if (coredynp.scheu_ty == ReservationStation) {
+        iFRAT->power =
+            iFRAT->power_t +
+            (iFRAT->local_result.power) * coredynp.pppm_lkg_multhread +
+            idcl->power_t;
+        fFRAT->power =
+            fFRAT->power_t +
+            (fFRAT->local_result.power) * coredynp.pppm_lkg_multhread +
+            fdcl->power_t;
+        ifreeL->power = ifreeL->power_t + ifreeL->local_result.power *
+                                              coredynp.pppm_lkg_multhread;
+        power = power + (iFRAT->power + fFRAT->power) + ifreeL->power;
+      }
+    } else {
+      power = power + idcl->power_t + fdcl->power_t;
+    }
 
+  } else {
+    if (coredynp.core_ty == OOO) {
+      if (coredynp.scheu_ty == PhysicalRegFile) {
+        iFRAT->rt_power =
+            iFRAT->power_t +
+            (iFRAT->local_result.power) * coredynp.pppm_lkg_multhread +
+            idcl->power_t;
+        fFRAT->rt_power =
+            fFRAT->power_t +
+            (fFRAT->local_result.power) * coredynp.pppm_lkg_multhread +
+            fdcl->power_t;
+        iRRAT->rt_power = iRRAT->power_t + iRRAT->local_result.power *
+                                               coredynp.pppm_lkg_multhread;
+        fRRAT->rt_power = fRRAT->power_t + fRRAT->local_result.power *
+                                               coredynp.pppm_lkg_multhread;
+        ifreeL->rt_power = ifreeL->power_t + ifreeL->local_result.power *
+                                                 coredynp.pppm_lkg_multhread;
+        ffreeL->rt_power = ffreeL->power_t + ffreeL->local_result.power *
+                                                 coredynp.pppm_lkg_multhread;
+        rt_power = rt_power + (iFRAT->rt_power + fFRAT->rt_power) +
+                   (iRRAT->rt_power + fRRAT->rt_power) +
+                   (ifreeL->rt_power + ffreeL->rt_power);
+      } else if (coredynp.scheu_ty == ReservationStation) {
+        iFRAT->rt_power =
+            iFRAT->power_t +
+            (iFRAT->local_result.power) * coredynp.pppm_lkg_multhread +
+            idcl->power_t;
+        fFRAT->rt_power =
+            fFRAT->power_t +
+            (fFRAT->local_result.power) * coredynp.pppm_lkg_multhread +
+            fdcl->power_t;
+        ifreeL->rt_power = ifreeL->power_t + ifreeL->local_result.power *
+                                                 coredynp.pppm_lkg_multhread;
+        rt_power =
+            rt_power + (iFRAT->rt_power + fFRAT->rt_power) + ifreeL->rt_power;
+      }
+    } else {
+      rt_power = rt_power + idcl->power_t + fdcl->power_t;
+    }
   }
-//  //clock power
-//  clockNetwork.init_wire_external(is_default, &interface_ip);
-//  clockNetwork.clk_area           =area*1.1;//10% of placement overhead. rule of thumb
-//  clockNetwork.end_wiring_level   =5;//toplevel metal
-//  clockNetwork.start_wiring_level =5;//toplevel metal
-//  clockNetwork.num_regs           = corepipe.tot_stage_vector;
-//  clockNetwork.optimize_wire();
 }
 
+void RENAMINGU::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  if (!exist) return;
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
 
-void BranchPredictor::computeEnergy(bool is_tdp)
-{
-	if (!exist) return;
-	double r_access;
-	double w_access;
-	if (is_tdp)
-    {
-    	r_access = coredynp.predictionW*coredynp.BR_duty_cycle;
-    	w_access = 0*coredynp.BR_duty_cycle;
-    	globalBPT->stats_t.readAc.access  = r_access;
-    	globalBPT->stats_t.writeAc.access = w_access;
-    	globalBPT->tdp_stats = globalBPT->stats_t;
+  if (is_tdp) {
+    if (coredynp.core_ty == OOO) {
+      cout << indent_str << "Int Front End RAT:" << endl;
+      cout << indent_str_next << "Area = " << iFRAT->area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << iFRAT->power.readOp.dynamic * clockRate
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? iFRAT->power.readOp.longer_channel_leakage
+                            : iFRAT->power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << iFRAT->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << iFRAT->rt_power.readOp.dynamic / executionTime << " W" << endl;
+      cout << endl;
+      cout << indent_str << "FP Front End RAT:" << endl;
+      cout << indent_str_next << "Area = " << fFRAT->area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << fFRAT->power.readOp.dynamic * clockRate
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? fFRAT->power.readOp.longer_channel_leakage
+                            : fFRAT->power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << fFRAT->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << fFRAT->rt_power.readOp.dynamic / executionTime << " W" << endl;
+      cout << endl;
+      cout << indent_str << "Free List:" << endl;
+      cout << indent_str_next << "Area = " << ifreeL->area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << ifreeL->power.readOp.dynamic * clockRate
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? ifreeL->power.readOp.longer_channel_leakage
+                            : ifreeL->power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << ifreeL->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << ifreeL->rt_power.readOp.dynamic / executionTime << " W" << endl;
+      cout << endl;
 
-    	L1_localBPT->stats_t.readAc.access  = r_access;
-    	L1_localBPT->stats_t.writeAc.access = w_access;
-    	L1_localBPT->tdp_stats = L1_localBPT->stats_t;
-
-    	L2_localBPT->stats_t.readAc.access  = r_access;
-    	L2_localBPT->stats_t.writeAc.access = w_access;
-    	L2_localBPT->tdp_stats = L2_localBPT->stats_t;
-
-    	chooser->stats_t.readAc.access  = r_access;
-    	chooser->stats_t.writeAc.access = w_access;
-    	chooser->tdp_stats = chooser->stats_t;
-
-    	RAS->stats_t.readAc.access  = r_access;
-    	RAS->stats_t.writeAc.access = w_access;
-    	RAS->tdp_stats = RAS->stats_t;
+      if (coredynp.scheu_ty == PhysicalRegFile) {
+        cout << indent_str << "Int Retire RAT: " << endl;
+        cout << indent_str_next << "Area = " << iRRAT->area.get_area() * 1e-6
+             << " mm^2" << endl;
+        cout << indent_str_next
+             << "Peak Dynamic = " << iRRAT->power.readOp.dynamic * clockRate
+             << " W" << endl;
+        cout << indent_str_next << "Subthreshold Leakage = "
+             << (long_channel ? iRRAT->power.readOp.longer_channel_leakage
+                              : iRRAT->power.readOp.leakage)
+             << " W" << endl;
+        cout << indent_str_next
+             << "Gate Leakage = " << iRRAT->power.readOp.gate_leakage << " W"
+             << endl;
+        cout << indent_str_next << "Runtime Dynamic = "
+             << iRRAT->rt_power.readOp.dynamic / executionTime << " W" << endl;
+        cout << endl;
+        cout << indent_str << "FP Retire RAT:" << endl;
+        cout << indent_str_next << "Area = " << fRRAT->area.get_area() * 1e-6
+             << " mm^2" << endl;
+        cout << indent_str_next
+             << "Peak Dynamic = " << fRRAT->power.readOp.dynamic * clockRate
+             << " W" << endl;
+        cout << indent_str_next << "Subthreshold Leakage = "
+             << (long_channel ? fRRAT->power.readOp.longer_channel_leakage
+                              : fRRAT->power.readOp.leakage)
+             << " W" << endl;
+        cout << indent_str_next
+             << "Gate Leakage = " << fRRAT->power.readOp.gate_leakage << " W"
+             << endl;
+        cout << indent_str_next << "Runtime Dynamic = "
+             << fRRAT->rt_power.readOp.dynamic / executionTime << " W" << endl;
+        cout << endl;
+        cout << indent_str << "FP Free List:" << endl;
+        cout << indent_str_next << "Area = " << ffreeL->area.get_area() * 1e-6
+             << " mm^2" << endl;
+        cout << indent_str_next
+             << "Peak Dynamic = " << ffreeL->power.readOp.dynamic * clockRate
+             << " W" << endl;
+        cout << indent_str_next << "Subthreshold Leakage = "
+             << (long_channel ? ffreeL->power.readOp.longer_channel_leakage
+                              : ffreeL->power.readOp.leakage)
+             << " W" << endl;
+        cout << indent_str_next
+             << "Gate Leakage = " << ffreeL->power.readOp.gate_leakage << " W"
+             << endl;
+        cout << indent_str_next << "Runtime Dynamic = "
+             << ffreeL->rt_power.readOp.dynamic / executionTime << " W" << endl;
+        cout << endl;
+      }
+    } else {
+      cout << indent_str << "Int DCL:" << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << idcl->power.readOp.dynamic * clockRate
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? idcl->power.readOp.longer_channel_leakage
+                            : idcl->power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << idcl->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << idcl->rt_power.readOp.dynamic / executionTime << " W" << endl;
+      cout << indent_str << "FP DCL:" << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << fdcl->power.readOp.dynamic * clockRate
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? fdcl->power.readOp.longer_channel_leakage
+                            : fdcl->power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << fdcl->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << fdcl->rt_power.readOp.dynamic / executionTime << " W" << endl;
     }
-    else
-    {
-    	//The resolution of BPT accesses is coarse, but this is
-    	//because most simulators cannot track finer grained details
-    	r_access = XML->sys.core[ithCore].branch_instructions;
-    	w_access = XML->sys.core[ithCore].branch_mispredictions + 0.1*XML->sys.core[ithCore].branch_instructions;//10% of BR will flip internal bits//0
-    	globalBPT->stats_t.readAc.access  = r_access;
-    	globalBPT->stats_t.writeAc.access = w_access;
-    	globalBPT->rtp_stats = globalBPT->stats_t;
-
-    	L1_localBPT->stats_t.readAc.access  = r_access;
-    	L1_localBPT->stats_t.writeAc.access = w_access;
-    	L1_localBPT->rtp_stats = L1_localBPT->stats_t;
-
-    	L2_localBPT->stats_t.readAc.access  = r_access;
-    	L2_localBPT->stats_t.writeAc.access = w_access;
-    	L2_localBPT->rtp_stats = L2_localBPT->stats_t;
-
-    	chooser->stats_t.readAc.access  = r_access;
-    	chooser->stats_t.writeAc.access = w_access;
-    	chooser->rtp_stats = chooser->stats_t;
-
-    	RAS->stats_t.readAc.access  = XML->sys.core[ithCore].function_calls;
-    	RAS->stats_t.writeAc.access = XML->sys.core[ithCore].function_calls;
-    	RAS->rtp_stats = RAS->stats_t;
-   }
-
-	globalBPT->power_t.reset();
-	L1_localBPT->power_t.reset();
-	L2_localBPT->power_t.reset();
-	chooser->power_t.reset();
-	RAS->power_t.reset();
-
-    globalBPT->power_t.readOp.dynamic   +=  globalBPT->local_result.power.readOp.dynamic*globalBPT->stats_t.readAc.access +
-                globalBPT->stats_t.writeAc.access*globalBPT->local_result.power.writeOp.dynamic;
-    L1_localBPT->power_t.readOp.dynamic   +=  L1_localBPT->local_result.power.readOp.dynamic*L1_localBPT->stats_t.readAc.access +
-                L1_localBPT->stats_t.writeAc.access*L1_localBPT->local_result.power.writeOp.dynamic;
-
-    L2_localBPT->power_t.readOp.dynamic   +=  L2_localBPT->local_result.power.readOp.dynamic*L2_localBPT->stats_t.readAc.access +
-                L2_localBPT->stats_t.writeAc.access*L2_localBPT->local_result.power.writeOp.dynamic;
-
-    chooser->power_t.readOp.dynamic   +=  chooser->local_result.power.readOp.dynamic*chooser->stats_t.readAc.access +
-                chooser->stats_t.writeAc.access*chooser->local_result.power.writeOp.dynamic;
-    RAS->power_t.readOp.dynamic   +=  RAS->local_result.power.readOp.dynamic*RAS->stats_t.readAc.access +
-                RAS->stats_t.writeAc.access*RAS->local_result.power.writeOp.dynamic;
-
-    if (is_tdp)
-    {
-    	globalBPT->power = globalBPT->power_t + globalBPT->local_result.power*pppm_lkg;
-    	L1_localBPT->power = L1_localBPT->power_t + L1_localBPT->local_result.power*pppm_lkg;
-    	L2_localBPT->power = L2_localBPT->power_t + L2_localBPT->local_result.power*pppm_lkg;
-    	chooser->power = chooser->power_t + chooser->local_result.power*pppm_lkg;
-    	RAS->power = RAS->power_t + RAS->local_result.power*coredynp.pppm_lkg_multhread;
-
-    	power = power + globalBPT->power + L1_localBPT->power + chooser->power + RAS->power;
+  } else {
+    if (coredynp.core_ty == OOO) {
+      cout << indent_str_next << "Int Front End RAT    Peak Dynamic = "
+           << iFRAT->rt_power.readOp.dynamic * clockRate << " W" << endl;
+      cout << indent_str_next << "Int Front End RAT    Subthreshold Leakage = "
+           << iFRAT->rt_power.readOp.leakage << " W" << endl;
+      cout << indent_str_next << "Int Front End RAT    Gate Leakage = "
+           << iFRAT->rt_power.readOp.gate_leakage << " W" << endl;
+      cout << indent_str_next << "FP Front End RAT   Peak Dynamic = "
+           << fFRAT->rt_power.readOp.dynamic * clockRate << " W" << endl;
+      cout << indent_str_next << "FP Front End RAT   Subthreshold Leakage = "
+           << fFRAT->rt_power.readOp.leakage << " W" << endl;
+      cout << indent_str_next << "FP Front End RAT   Gate Leakage = "
+           << fFRAT->rt_power.readOp.gate_leakage << " W" << endl;
+      cout << indent_str_next << "Free List   Peak Dynamic = "
+           << ifreeL->rt_power.readOp.dynamic * clockRate << " W" << endl;
+      cout << indent_str_next << "Free List   Subthreshold Leakage = "
+           << ifreeL->rt_power.readOp.leakage << " W" << endl;
+      cout << indent_str_next << "Free List   Gate Leakage = "
+           << fFRAT->rt_power.readOp.gate_leakage << " W" << endl;
+      if (coredynp.scheu_ty == PhysicalRegFile) {
+        cout << indent_str_next << "Int Retire RAT   Peak Dynamic = "
+             << iRRAT->rt_power.readOp.dynamic * clockRate << " W" << endl;
+        cout << indent_str_next << "Int Retire RAT   Subthreshold Leakage = "
+             << iRRAT->rt_power.readOp.leakage << " W" << endl;
+        cout << indent_str_next << "Int Retire RAT   Gate Leakage = "
+             << iRRAT->rt_power.readOp.gate_leakage << " W" << endl;
+        cout << indent_str_next << "FP Retire RAT   Peak Dynamic = "
+             << fRRAT->rt_power.readOp.dynamic * clockRate << " W" << endl;
+        cout << indent_str_next << "FP Retire RAT   Subthreshold Leakage = "
+             << fRRAT->rt_power.readOp.leakage << " W" << endl;
+        cout << indent_str_next << "FP Retire RAT   Gate Leakage = "
+             << fRRAT->rt_power.readOp.gate_leakage << " W" << endl;
+        cout << indent_str_next << "FP Free List   Peak Dynamic = "
+             << ffreeL->rt_power.readOp.dynamic * clockRate << " W" << endl;
+        cout << indent_str_next << "FP Free List   Subthreshold Leakage = "
+             << ffreeL->rt_power.readOp.leakage << " W" << endl;
+        cout << indent_str_next << "FP Free List   Gate Leakage = "
+             << fFRAT->rt_power.readOp.gate_leakage << " W" << endl;
+      }
+    } else {
+      cout << indent_str_next << "Int DCL   Peak Dynamic = "
+           << idcl->rt_power.readOp.dynamic * clockRate << " W" << endl;
+      cout << indent_str_next << "Int DCL   Subthreshold Leakage = "
+           << idcl->rt_power.readOp.leakage << " W" << endl;
+      cout << indent_str_next
+           << "Int DCL   Gate Leakage = " << idcl->rt_power.readOp.gate_leakage
+           << " W" << endl;
+      cout << indent_str_next << "FP DCL   Peak Dynamic = "
+           << fdcl->rt_power.readOp.dynamic * clockRate << " W" << endl;
+      cout << indent_str_next << "FP DCL   Subthreshold Leakage = "
+           << fdcl->rt_power.readOp.leakage << " W" << endl;
+      cout << indent_str_next
+           << "FP DCL   Gate Leakage = " << fdcl->rt_power.readOp.gate_leakage
+           << " W" << endl;
     }
-    else
-    {
-    	globalBPT->rt_power = globalBPT->power_t + globalBPT->local_result.power*pppm_lkg;
-    	L1_localBPT->rt_power = L1_localBPT->power_t + L1_localBPT->local_result.power*pppm_lkg;
-    	L2_localBPT->rt_power = L2_localBPT->power_t + L2_localBPT->local_result.power*pppm_lkg;
-    	chooser->rt_power = chooser->power_t + chooser->local_result.power*pppm_lkg;
-    	RAS->rt_power = RAS->power_t + RAS->local_result.power*coredynp.pppm_lkg_multhread;
-    	rt_power = rt_power + globalBPT->rt_power + L1_localBPT->rt_power + chooser->rt_power + RAS->rt_power;
-    }
+  }
 }
 
-void BranchPredictor::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	if (!exist) return;
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
-	if (is_tdp)
-	{
-		cout << indent_str<< "Global Predictor:" << endl;
-		cout << indent_str_next << "Area = " << globalBPT->area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << globalBPT->power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? globalBPT->power.readOp.longer_channel_leakage:globalBPT->power.readOp.leakage) <<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << globalBPT->power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << globalBPT->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-		cout << indent_str << "Local Predictor:" << endl;
-		cout << indent_str << "L1_Local Predictor:" << endl;
-		cout << indent_str_next << "Area = " << L1_localBPT->area.get_area() *1e-6 << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << L1_localBPT->power.readOp.dynamic*clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? L1_localBPT->power.readOp.longer_channel_leakage:L1_localBPT->power.readOp.leakage)  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << L1_localBPT->power.readOp.gate_leakage  << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << L1_localBPT->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-		cout << indent_str << "L2_Local Predictor:" << endl;
-		cout << indent_str_next << "Area = " << L2_localBPT->area.get_area() *1e-6 << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << L2_localBPT->power.readOp.dynamic*clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? L2_localBPT->power.readOp.longer_channel_leakage:L2_localBPT->power.readOp.leakage)  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << L2_localBPT->power.readOp.gate_leakage  << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << L2_localBPT->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
+void SchedulerU::computeEnergy(bool is_tdp) {
+  if (!exist) return;
+  double ROB_duty_cycle;
+  //	ROB_duty_cycle = ((coredynp.ALU_duty_cycle +
+  // coredynp.num_muls>0?coredynp.MUL_duty_cycle:0
+  //			+ coredynp.num_fpus>0?coredynp.FPU_duty_cycle:0))*1.1<1
+  //? (coredynp.ALU_duty_cycle + coredynp.num_muls>0?coredynp.MUL_duty_cycle:0
+  //					+
+  // coredynp.num_fpus>0?coredynp.FPU_duty_cycle:0)*1.1:1;
+  ROB_duty_cycle = 1;
+  // init stats
+  if (is_tdp) {
+    if (coredynp.core_ty == OOO) {
+      int_inst_window->stats_t.readAc.access =
+          coredynp.issueW *
+          coredynp.num_pipelines;  // int_inst_window->l_ip.num_search_ports;
+      int_inst_window->stats_t.writeAc.access =
+          coredynp.issueW *
+          coredynp.num_pipelines;  // int_inst_window->l_ip.num_wr_ports;
+      int_inst_window->stats_t.searchAc.access =
+          coredynp.issueW * coredynp.num_pipelines;
+      int_inst_window->tdp_stats = int_inst_window->stats_t;
+      fp_inst_window->stats_t.readAc.access =
+          fp_inst_window->l_ip.num_rd_ports * coredynp.num_fp_pipelines;
+      fp_inst_window->stats_t.writeAc.access =
+          fp_inst_window->l_ip.num_wr_ports * coredynp.num_fp_pipelines;
+      fp_inst_window->stats_t.searchAc.access =
+          fp_inst_window->l_ip.num_search_ports * coredynp.num_fp_pipelines;
+      fp_inst_window->tdp_stats = fp_inst_window->stats_t;
 
-		cout << indent_str << "Chooser:" << endl;
-		cout << indent_str_next << "Area = " << chooser->area.get_area()  *1e-6 << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << chooser->power.readOp.dynamic*clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? chooser->power.readOp.longer_channel_leakage:chooser->power.readOp.leakage)  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << chooser->power.readOp.gate_leakage  << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << chooser->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-		cout << indent_str << "RAS:" << endl;
-		cout << indent_str_next << "Area = " << RAS->area.get_area() *1e-6 << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << RAS->power.readOp.dynamic*clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? RAS->power.readOp.longer_channel_leakage:RAS->power.readOp.leakage)  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << RAS->power.readOp.gate_leakage  << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << RAS->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-	}
-	else
-	{
-//		cout << indent_str_next << "Global Predictor    Peak Dynamic = " << globalBPT->rt_power.readOp.dynamic*clockRate << " W" << endl;
-//		cout << indent_str_next << "Global Predictor    Subthreshold Leakage = " << globalBPT->rt_power.readOp.leakage <<" W" << endl;
-//		cout << indent_str_next << "Global Predictor    Gate Leakage = " << globalBPT->rt_power.readOp.gate_leakage << " W" << endl;
-//		cout << indent_str_next << "Local Predictor   Peak Dynamic = " << L1_localBPT->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-//		cout << indent_str_next << "Local Predictor   Subthreshold Leakage = " << L1_localBPT->rt_power.readOp.leakage  << " W" << endl;
-//		cout << indent_str_next << "Local Predictor   Gate Leakage = " << L1_localBPT->rt_power.readOp.gate_leakage  << " W" << endl;
-//		cout << indent_str_next << "Chooser   Peak Dynamic = " << chooser->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-//		cout << indent_str_next << "Chooser   Subthreshold Leakage = " << chooser->rt_power.readOp.leakage  << " W" << endl;
-//		cout << indent_str_next << "Chooser   Gate Leakage = " << chooser->rt_power.readOp.gate_leakage  << " W" << endl;
-//		cout << indent_str_next << "RAS   Peak Dynamic = " << RAS->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-//		cout << indent_str_next << "RAS   Subthreshold Leakage = " << RAS->rt_power.readOp.leakage  << " W" << endl;
-//		cout << indent_str_next << "RAS   Gate Leakage = " << RAS->rt_power.readOp.gate_leakage  << " W" << endl;
-	}
+      if (XML->sys.core[ithCore].ROB_size > 0) {
+        ROB->stats_t.readAc.access =
+            coredynp.commitW * coredynp.num_pipelines * ROB_duty_cycle;
+        ROB->stats_t.writeAc.access =
+            coredynp.issueW * coredynp.num_pipelines * ROB_duty_cycle;
+        ROB->tdp_stats = ROB->stats_t;
 
+        /*
+         * When inst commits, ROB must be read.
+         * Because for Physcial register based cores, physical register tag in
+         * ROB need to be read out and write into RRAT/CAM based RAT. For RS
+         * based cores, register content that stored in ROB must be read out and
+         * stored in architectural registers.
+         *
+         * if no-register is involved, the ROB read out operation when
+         * instruction commits can be ignored. assuming 20% insts. belong this
+         * type.
+         * TODO: ROB duty_cycle need to be revisited
+         */
+      }
+
+    } else if (coredynp.multithreaded) {
+      int_inst_window->stats_t.readAc.access =
+          coredynp.issueW *
+          coredynp.num_pipelines;  // int_inst_window->l_ip.num_search_ports;
+      int_inst_window->stats_t.writeAc.access =
+          coredynp.issueW *
+          coredynp.num_pipelines;  // int_inst_window->l_ip.num_wr_ports;
+      int_inst_window->stats_t.searchAc.access =
+          coredynp.issueW * coredynp.num_pipelines;
+      int_inst_window->tdp_stats = int_inst_window->stats_t;
+    }
+
+  } else {  // rtp
+    if (coredynp.core_ty == OOO) {
+      int_inst_window->stats_t.readAc.access =
+          XML->sys.core[ithCore].inst_window_reads;
+      int_inst_window->stats_t.writeAc.access =
+          XML->sys.core[ithCore].inst_window_writes;
+      int_inst_window->stats_t.searchAc.access =
+          XML->sys.core[ithCore].inst_window_wakeup_accesses;
+      int_inst_window->rtp_stats = int_inst_window->stats_t;
+      fp_inst_window->stats_t.readAc.access =
+          XML->sys.core[ithCore].fp_inst_window_reads;
+      fp_inst_window->stats_t.writeAc.access =
+          XML->sys.core[ithCore].fp_inst_window_writes;
+      fp_inst_window->stats_t.searchAc.access =
+          XML->sys.core[ithCore].fp_inst_window_wakeup_accesses;
+      fp_inst_window->rtp_stats = fp_inst_window->stats_t;
+
+      if (XML->sys.core[ithCore].ROB_size > 0) {
+        ROB->stats_t.readAc.access = XML->sys.core[ithCore].ROB_reads;
+        ROB->stats_t.writeAc.access = XML->sys.core[ithCore].ROB_writes;
+        /* ROB need to be updated in RS based OOO when new values are produced,
+         * this update may happen before the commit stage when ROB entry is
+         * released
+         * 1. ROB write at instruction inserted in
+         * 2. ROB write as results produced (for RS based OOO only)
+         * 3. ROB read  as instruction committed. For RS based OOO, data values
+         * are read out and sent to ARF For Physical reg based OOO, no data
+         * stored in ROB, but register tags need to be read out and used to set
+         * the RRAT and to recycle the register tag to free list buffer
+         */
+        ROB->rtp_stats = ROB->stats_t;
+      }
+
+    } else if (coredynp.multithreaded) {
+      int_inst_window->stats_t.readAc.access =
+          XML->sys.core[ithCore].int_instructions +
+          XML->sys.core[ithCore].fp_instructions;
+      int_inst_window->stats_t.writeAc.access =
+          XML->sys.core[ithCore].int_instructions +
+          XML->sys.core[ithCore].fp_instructions;
+      int_inst_window->stats_t.searchAc.access =
+          2 * (XML->sys.core[ithCore].int_instructions +
+               XML->sys.core[ithCore].fp_instructions);
+      int_inst_window->rtp_stats = int_inst_window->stats_t;
+    }
+  }
+
+  // computation engine
+  if (coredynp.core_ty == OOO) {
+    int_inst_window->power_t.reset();
+    fp_inst_window->power_t.reset();
+
+    /* each instruction needs to write to scheduler, read out when all resources
+     * and source operands are ready two search ops with one for each source
+     * operand
+     *
+     */
+    int_inst_window->power_t.readOp.dynamic +=
+        int_inst_window->local_result.power.readOp.dynamic *
+            int_inst_window->stats_t.readAc.access +
+        int_inst_window->local_result.power.searchOp.dynamic *
+            int_inst_window->stats_t.searchAc.access +
+        int_inst_window->local_result.power.writeOp.dynamic *
+            int_inst_window->stats_t.writeAc.access +
+        int_inst_window->stats_t.readAc.access *
+            instruction_selection->power.readOp.dynamic;
+
+    fp_inst_window->power_t.readOp.dynamic +=
+        fp_inst_window->local_result.power.readOp.dynamic *
+            fp_inst_window->stats_t.readAc.access +
+        fp_inst_window->local_result.power.searchOp.dynamic *
+            fp_inst_window->stats_t.searchAc.access +
+        fp_inst_window->local_result.power.writeOp.dynamic *
+            fp_inst_window->stats_t.writeAc.access +
+        fp_inst_window->stats_t.writeAc.access *
+            instruction_selection->power.readOp.dynamic;
+
+    if (XML->sys.core[ithCore].ROB_size > 0) {
+      ROB->power_t.reset();
+      ROB->power_t.readOp.dynamic +=
+          ROB->local_result.power.readOp.dynamic * ROB->stats_t.readAc.access +
+          ROB->stats_t.writeAc.access * ROB->local_result.power.writeOp.dynamic;
+    }
+
+  } else if (coredynp.multithreaded) {
+    int_inst_window->power_t.reset();
+    int_inst_window->power_t.readOp.dynamic +=
+        int_inst_window->local_result.power.readOp.dynamic *
+            int_inst_window->stats_t.readAc.access +
+        int_inst_window->local_result.power.searchOp.dynamic *
+            int_inst_window->stats_t.searchAc.access +
+        int_inst_window->local_result.power.writeOp.dynamic *
+            int_inst_window->stats_t.writeAc.access +
+        int_inst_window->stats_t.writeAc.access *
+            instruction_selection->power.readOp.dynamic;
+  }
+
+  // assign values
+  if (is_tdp) {
+    if (coredynp.core_ty == OOO) {
+      int_inst_window->power =
+          int_inst_window->power_t +
+          (int_inst_window->local_result.power + instruction_selection->power) *
+              pppm_lkg;
+      fp_inst_window->power =
+          fp_inst_window->power_t +
+          (fp_inst_window->local_result.power + instruction_selection->power) *
+              pppm_lkg;
+      power = power + int_inst_window->power + fp_inst_window->power;
+      if (XML->sys.core[ithCore].ROB_size > 0) {
+        ROB->power = ROB->power_t + ROB->local_result.power * pppm_lkg;
+        power = power + ROB->power;
+      }
+
+    } else if (coredynp.multithreaded) {
+      //			set_pppm(pppm_t,
+      // XML->sys.core[ithCore].issue_width,1, 1, 1);
+      int_inst_window->power =
+          int_inst_window->power_t +
+          (int_inst_window->local_result.power + instruction_selection->power) *
+              pppm_lkg;
+      power = power + int_inst_window->power;
+    }
+
+  } else {  // rtp
+    if (coredynp.core_ty == OOO) {
+      int_inst_window->rt_power =
+          int_inst_window->power_t +
+          (int_inst_window->local_result.power + instruction_selection->power) *
+              pppm_lkg;
+      fp_inst_window->rt_power =
+          fp_inst_window->power_t +
+          (fp_inst_window->local_result.power + instruction_selection->power) *
+              pppm_lkg;
+      rt_power =
+          rt_power + int_inst_window->rt_power + fp_inst_window->rt_power;
+      if (XML->sys.core[ithCore].ROB_size > 0) {
+        ROB->rt_power = ROB->power_t + ROB->local_result.power * pppm_lkg;
+        rt_power = rt_power + ROB->rt_power;
+      }
+
+    } else if (coredynp.multithreaded) {
+      //			set_pppm(pppm_t,
+      // XML->sys.core[ithCore].issue_width,1, 1, 1);
+      int_inst_window->rt_power =
+          int_inst_window->power_t +
+          (int_inst_window->local_result.power + instruction_selection->power) *
+              pppm_lkg;
+      rt_power = rt_power + int_inst_window->rt_power;
+    }
+  }
+  //	set_pppm(pppm_t, XML->sys.core[ithCore].issue_width,1, 1, 1);
+  //	cout<<"Scheduler
+  // power="<<power.readOp.dynamic<<"leakage="<<power.readOp.leakage<<endl;
+  //	cout<<"IW="<<int_inst_window->local_result.power.searchOp.dynamic *
+  // int_inst_window->stats_t.readAc.access +
+  //    + int_inst_window->local_result.power.writeOp.dynamic *
+  //    int_inst_window->stats_t.writeAc.access<<"leakage="<<int_inst_window->local_result.power.readOp.leakage<<endl;
+  //	cout<<"selection"<<instruction_selection->power.readOp.dynamic<<"leakage"<<instruction_selection->power.readOp.leakage<<endl;
 }
 
-void InstFetchU::computeEnergy(bool is_tdp)
-{
-  executionTime=XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);//Syed
-  //cout <<"IFU: execution time: "<<XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6)<<endl;
-  //cout <<"IFU: total cycles"<<XML->sys.total_cycles<<endl;
-	if (!exist) return;
-	if (is_tdp)
-    {
-		//init stats for Peak
-    	icache.caches->stats_t.readAc.access  = icache.caches->l_ip.num_rw_ports*coredynp.IFU_duty_cycle;
-    	icache.caches->stats_t.readAc.miss    = 0;
-    	icache.caches->stats_t.readAc.hit     = icache.caches->stats_t.readAc.access - icache.caches->stats_t.readAc.miss;
-    	icache.caches->tdp_stats = icache.caches->stats_t;
+void SchedulerU::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  if (!exist) return;
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
 
-    	icache.missb->stats_t.readAc.access  = icache.missb->stats_t.readAc.hit=  icache.missb->l_ip.num_search_ports;
-    	icache.missb->stats_t.writeAc.access = icache.missb->stats_t.writeAc.hit= icache.missb->l_ip.num_search_ports;
-    	icache.missb->tdp_stats = icache.missb->stats_t;
-
-    	icache.ifb->stats_t.readAc.access  = icache.ifb->stats_t.readAc.hit=  icache.ifb->l_ip.num_search_ports;
-    	icache.ifb->stats_t.writeAc.access = icache.ifb->stats_t.writeAc.hit= icache.ifb->l_ip.num_search_ports;
-    	icache.ifb->tdp_stats = icache.ifb->stats_t;
-
-    	icache.prefetchb->stats_t.readAc.access  = icache.prefetchb->stats_t.readAc.hit= icache.prefetchb->l_ip.num_search_ports;
-    	icache.prefetchb->stats_t.writeAc.access = icache.ifb->stats_t.writeAc.hit= icache.ifb->l_ip.num_search_ports;
-    	icache.prefetchb->tdp_stats = icache.prefetchb->stats_t;
-
-    	IB->stats_t.readAc.access = IB->stats_t.writeAc.access = XML->sys.core[ithCore].peak_issue_width;
-    	IB->tdp_stats = IB->stats_t;
-
-    	if (coredynp.predictionW>0)
-    	{
-    		BTB->stats_t.readAc.access  = coredynp.predictionW;//XML->sys.core[ithCore].BTB.read_accesses;
-    		BTB->stats_t.writeAc.access = 0;//XML->sys.core[ithCore].BTB.write_accesses;
-    	}
-
-    	ID_inst->stats_t.readAc.access     = coredynp.decodeW;
-    	ID_operand->stats_t.readAc.access  = coredynp.decodeW;
-    	ID_misc->stats_t.readAc.access     = coredynp.decodeW;
-    	ID_inst->tdp_stats = ID_inst->stats_t;
-    	ID_operand->tdp_stats = ID_operand->stats_t;
-    	ID_misc->tdp_stats = ID_misc->stats_t;
-
-
-   
-	 } /* if (is_tdp) */
-    else
-    {
-      rt_power.reset();
-      icache.rt_power.reset(); //Jingwen
-     	//init stats for Runtime Dynamic (RTP)
-		//cout<< "****>>>>Icache stats:"<<endl;
-		//cout<<"Read accesses: "<< XML->sys.core[ithCore].icache.read_accesses << " Read misses: "<<XML->sys.core[ithCore].icache.read_misses<<endl;
-    	icache.caches->stats_t.readAc.access  = XML->sys.core[ithCore].icache.read_accesses;
-    	icache.caches->stats_t.readAc.miss    = XML->sys.core[ithCore].icache.read_misses;
-    	//cout<<endl<<"inside mcpat read access= "<<XML->sys.core[ithCore].icache.read_accesses;
-    	//cout<<endl<<"inside mcpat read miss= "<<XML->sys.core[ithCore].icache.read_misses;
-
-    	icache.caches->stats_t.readAc.hit     = icache.caches->stats_t.readAc.access - icache.caches->stats_t.readAc.miss;
-    	icache.caches->rtp_stats = icache.caches->stats_t;
-    	//cout<<endl<<"inside mcpat read hit= "<<icache.caches->stats_t.readAc.hit<<endl;
-    	icache.missb->stats_t.readAc.access  = icache.caches->stats_t.readAc.miss;
-    	icache.missb->stats_t.writeAc.access = icache.caches->stats_t.readAc.miss;
-    	icache.missb->rtp_stats = icache.missb->stats_t;
-
-    	icache.ifb->stats_t.readAc.access  = icache.caches->stats_t.readAc.miss;
-    	icache.ifb->stats_t.writeAc.access = icache.caches->stats_t.readAc.miss;
-    	icache.ifb->rtp_stats = icache.ifb->stats_t;
-
-    	icache.prefetchb->stats_t.readAc.access  = icache.caches->stats_t.readAc.miss;
-    	icache.prefetchb->stats_t.writeAc.access = icache.caches->stats_t.readAc.miss;
-    	icache.prefetchb->rtp_stats = icache.prefetchb->stats_t;
-
-    	IB->stats_t.readAc.access = IB->stats_t.writeAc.access = XML->sys.core[ithCore].total_instructions;
-    	IB->rtp_stats = IB->stats_t;
-    	//cout<<"IB: total instructions: "<<IB->stats_t.readAc.access <<endl;
-    	if (coredynp.predictionW>0)
-    	{
-    		BTB->stats_t.readAc.access  = XML->sys.core[ithCore].BTB.read_accesses;//XML->sys.core[ithCore].branch_instructions;
-    		BTB->stats_t.writeAc.access = XML->sys.core[ithCore].BTB.write_accesses;//XML->sys.core[ithCore].branch_mispredictions;
-    		BTB->rtp_stats = BTB->stats_t;
-    	}
-    	//cout<<"ID: total instructions: "<< XML->sys.core[ithCore].total_instructions<<endl;
-    	ID_inst->stats_t.readAc.access     = XML->sys.core[ithCore].total_instructions;
-    	ID_operand->stats_t.readAc.access  = XML->sys.core[ithCore].total_instructions;
-    	ID_misc->stats_t.readAc.access     = XML->sys.core[ithCore].total_instructions;
-    	ID_inst->rtp_stats = ID_inst->stats_t;
-    	ID_operand->rtp_stats = ID_operand->stats_t;
-    	ID_misc->rtp_stats = ID_misc->stats_t;
-
+  if (is_tdp) {
+    if (coredynp.core_ty == OOO) {
+      cout << indent_str << "Instruction Window:" << endl;
+      cout << indent_str_next
+           << "Area = " << int_inst_window->area.get_area() * 1e-6 << " mm^2"
+           << endl;
+      cout << indent_str_next << "Peak Dynamic = "
+           << int_inst_window->power.readOp.dynamic * clockRate << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel
+                   ? int_inst_window->power.readOp.longer_channel_leakage
+                   : int_inst_window->power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << int_inst_window->power.readOp.gate_leakage
+           << " W" << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << int_inst_window->rt_power.readOp.dynamic / executionTime << " W"
+           << endl;
+      cout << endl;
+      cout << indent_str << "FP Instruction Window:" << endl;
+      cout << indent_str_next
+           << "Area = " << fp_inst_window->area.get_area() * 1e-6 << " mm^2"
+           << endl;
+      cout << indent_str_next << "Peak Dynamic = "
+           << fp_inst_window->power.readOp.dynamic * clockRate << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel
+                   ? fp_inst_window->power.readOp.longer_channel_leakage
+                   : fp_inst_window->power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << fp_inst_window->power.readOp.gate_leakage
+           << " W" << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << fp_inst_window->rt_power.readOp.dynamic / executionTime << " W"
+           << endl;
+      cout << endl;
+      if (XML->sys.core[ithCore].ROB_size > 0) {
+        cout << indent_str << "ROB:" << endl;
+        cout << indent_str_next << "Area = " << ROB->area.get_area() * 1e-6
+             << " mm^2" << endl;
+        cout << indent_str_next
+             << "Peak Dynamic = " << ROB->power.readOp.dynamic * clockRate
+             << " W" << endl;
+        cout << indent_str_next << "Subthreshold Leakage = "
+             << (long_channel ? ROB->power.readOp.longer_channel_leakage
+                              : ROB->power.readOp.leakage)
+             << " W" << endl;
+        cout << indent_str_next
+             << "Gate Leakage = " << ROB->power.readOp.gate_leakage << " W"
+             << endl;
+        cout << indent_str_next << "Runtime Dynamic = "
+             << ROB->rt_power.readOp.dynamic / executionTime << " W" << endl;
+        cout << endl;
+      }
+    } else if (coredynp.multithreaded) {
+      cout << indent_str << "Instruction Window:" << endl;
+      cout << indent_str_next
+           << "Area = " << int_inst_window->area.get_area() * 1e-6 << " mm^2"
+           << endl;
+      cout << indent_str_next << "Peak Dynamic = "
+           << int_inst_window->power.readOp.dynamic * clockRate << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel
+                   ? int_inst_window->power.readOp.longer_channel_leakage
+                   : int_inst_window->power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << int_inst_window->power.readOp.gate_leakage
+           << " W" << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << int_inst_window->rt_power.readOp.dynamic / executionTime << " W"
+           << endl;
+      cout << endl;
     }
-
-    icache.power_t.reset();
-    IB->power_t.reset();
-//	ID_inst->power_t.reset();
-//	ID_operand->power_t.reset();
-//	ID_misc->power_t.reset();
-    if (coredynp.predictionW>0)
-    {
-    	BTB->power_t.reset();
+  } else {
+    if (coredynp.core_ty == OOO) {
+      cout << indent_str_next << "Instruction Window    Peak Dynamic = "
+           << int_inst_window->rt_power.readOp.dynamic * clockRate << " W"
+           << endl;
+      cout << indent_str_next << "Instruction Window    Subthreshold Leakage = "
+           << int_inst_window->rt_power.readOp.leakage << " W" << endl;
+      cout << indent_str_next << "Instruction Window    Gate Leakage = "
+           << int_inst_window->rt_power.readOp.gate_leakage << " W" << endl;
+      cout << indent_str_next << "FP Instruction Window   Peak Dynamic = "
+           << fp_inst_window->rt_power.readOp.dynamic * clockRate << " W"
+           << endl;
+      cout << indent_str_next
+           << "FP Instruction Window   Subthreshold Leakage = "
+           << fp_inst_window->rt_power.readOp.leakage << " W" << endl;
+      cout << indent_str_next << "FP Instruction Window   Gate Leakage = "
+           << fp_inst_window->rt_power.readOp.gate_leakage << " W" << endl;
+      if (XML->sys.core[ithCore].ROB_size > 0) {
+        cout << indent_str_next << "ROB   Peak Dynamic = "
+             << ROB->rt_power.readOp.dynamic * clockRate << " W" << endl;
+        cout << indent_str_next
+             << "ROB   Subthreshold Leakage = " << ROB->rt_power.readOp.leakage
+             << " W" << endl;
+        cout << indent_str_next
+             << "ROB   Gate Leakage = " << ROB->rt_power.readOp.gate_leakage
+             << " W" << endl;
+      }
+    } else if (coredynp.multithreaded) {
+      cout << indent_str_next << "Instruction Window    Peak Dynamic = "
+           << int_inst_window->rt_power.readOp.dynamic * clockRate << " W"
+           << endl;
+      cout << indent_str_next << "Instruction Window    Subthreshold Leakage = "
+           << int_inst_window->rt_power.readOp.leakage << " W" << endl;
+      cout << indent_str_next << "Instruction Window    Gate Leakage = "
+           << int_inst_window->rt_power.readOp.gate_leakage << " W" << endl;
     }
-
-    icache.power_t.readOp.dynamic	+= (icache.caches->stats_t.readAc.hit*icache.caches->local_result.power.readOp.dynamic+
-    		//icache.caches->stats_t.readAc.miss*icache.caches->local_result.tag_array2->power.readOp.dynamic+
-    		icache.caches->stats_t.readAc.miss*icache.caches->local_result.power.readOp.dynamic+ //assume tag data accessed in parallel
-    		icache.caches->stats_t.readAc.miss*icache.caches->local_result.power.writeOp.dynamic); //read miss in Icache cause a write to Icache
-    icache.power_t.readOp.dynamic	+=  icache.missb->stats_t.readAc.access*icache.missb->local_result.power.searchOp.dynamic +
-            icache.missb->stats_t.writeAc.access*icache.missb->local_result.power.writeOp.dynamic;//each access to missb involves a CAM and a write
-    icache.power_t.readOp.dynamic	+=  icache.ifb->stats_t.readAc.access*icache.ifb->local_result.power.searchOp.dynamic +
-            icache.ifb->stats_t.writeAc.access*icache.ifb->local_result.power.writeOp.dynamic;
-    icache.power_t.readOp.dynamic	+=  icache.prefetchb->stats_t.readAc.access*icache.prefetchb->local_result.power.searchOp.dynamic +
-            icache.prefetchb->stats_t.writeAc.access*icache.prefetchb->local_result.power.writeOp.dynamic;
-   //cout<<"Icache power: "<<icache.power_t.readOp.dynamic	<<endl;
-	IB->power_t.readOp.dynamic   +=  IB->local_result.power.readOp.dynamic*IB->stats_t.readAc.access +
-			IB->stats_t.writeAc.access*IB->local_result.power.writeOp.dynamic;
-  //cout << "IB power: "<<IB->power_t.readOp.dynamic<<endl;
-	if (coredynp.predictionW>0)
-	{
-		BTB->power_t.readOp.dynamic   +=  BTB->local_result.power.readOp.dynamic*BTB->stats_t.readAc.access +
-		BTB->stats_t.writeAc.access*BTB->local_result.power.writeOp.dynamic;
-
-		BPT->computeEnergy(is_tdp);
-	}
-
-    if (is_tdp)
-    {
-//    	icache.power = icache.power_t +
-//    	        (icache.caches->local_result.power)*pppm_lkg +
-//    			(icache.missb->local_result.power +
-//    			icache.ifb->local_result.power +
-//    			icache.prefetchb->local_result.power)*pppm_Isub;
-    	icache.power = icache.power_t +
-    	        (icache.caches->local_result.power +
-    			icache.missb->local_result.power +
-    			icache.ifb->local_result.power +
-    			icache.prefetchb->local_result.power)*pppm_lkg;
-
-    	IB->power = IB->power_t + IB->local_result.power*pppm_lkg;
-    	power     = power + icache.power + IB->power;
-    	if (coredynp.predictionW>0)
-    	{
-    		BTB->power = BTB->power_t + BTB->local_result.power*pppm_lkg;
-    		power     = power  + BTB->power + BPT->power;
-    	}
-
-    	ID_inst->power_t.readOp.dynamic    = ID_inst->power.readOp.dynamic;
-    	ID_operand->power_t.readOp.dynamic = ID_operand->power.readOp.dynamic;
-    	ID_misc->power_t.readOp.dynamic    = ID_misc->power.readOp.dynamic;
-
-    	ID_inst->power.readOp.dynamic    *= ID_inst->tdp_stats.readAc.access;
-    	ID_operand->power.readOp.dynamic *= ID_operand->tdp_stats.readAc.access;
-    	ID_misc->power.readOp.dynamic    *= ID_misc->tdp_stats.readAc.access;
-
-    	power = power + (ID_inst->power +
-							ID_operand->power +
-							ID_misc->power);
-	 } /* if (is_tdp) */ 
-    else
-    {
-//    	icache.rt_power = icache.power_t +
-//    	        (icache.caches->local_result.power)*pppm_lkg +
-//    			(icache.missb->local_result.power +
-//    			icache.ifb->local_result.power +
-//    			icache.prefetchb->local_result.power)*pppm_Isub;
-
-    	icache.rt_power = icache.power_t +
-    	        (icache.caches->local_result.power +
-    			icache.missb->local_result.power +
-    			icache.ifb->local_result.power +
-    			icache.prefetchb->local_result.power)*pppm_lkg;
-
-    	//IB->rt_power = IB->power_t + IB->local_result.power*pppm_lkg;
-    	IB->rt_power.readOp.dynamic = IB->local_result.power.readOp.dynamic * IB->rtp_stats.readAc.access;
-    	IB->rt_power.readOp.dynamic += IB->local_result.power.writeOp.dynamic * IB->rtp_stats.writeAc.access;
-    	rt_power     = rt_power + icache.rt_power + IB->rt_power;
-    	if (coredynp.predictionW>0)
-    	{
-    		BTB->rt_power = BTB->power_t + BTB->local_result.power*pppm_lkg;
-    		rt_power     = rt_power + BTB->rt_power + BPT->rt_power;
-    	}
-
-    	ID_inst->rt_power.readOp.dynamic    = ID_inst->power_t.readOp.dynamic*ID_inst->rtp_stats.readAc.access;
-    	ID_operand->rt_power.readOp.dynamic = ID_operand->power_t.readOp.dynamic * ID_operand->rtp_stats.readAc.access;
-    	ID_misc->rt_power.readOp.dynamic    = ID_misc->power_t.readOp.dynamic * ID_misc->rtp_stats.readAc.access;
-
-    	rt_power = rt_power + (ID_inst->rt_power +
-							ID_operand->rt_power +
-							ID_misc->rt_power);
-		//cout<<"ID inst: "<<ID_inst->rt_power.readOp.dynamic << " ID operand: "<<ID_operand->rt_power.readOp.dynamic<<" ID misc: "<<ID_misc->rt_power.readOp.dynamic<<endl;
-    }
+  }
 }
 
-void InstFetchU::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	if (!exist) return;
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
+void LoadStoreU::computeEnergy(bool is_tdp) {
+  if (!exist) return;
 
+  executionTime =
+      XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);  // Syed
 
-	if (is_tdp)
-	{
+  // RF crossbar power (Syed)
+  xbar_shared->compute_power();
 
-		cout << indent_str<< "Instruction Cache:" << endl;
-		cout << indent_str_next << "Area = " << icache.area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << icache.power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? icache.power.readOp.longer_channel_leakage:icache.power.readOp.leakage) <<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << icache.power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << icache.rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-		if (coredynp.predictionW>0)
-		{
-			cout << indent_str<< "Branch Target Buffer:" << endl;
-			cout << indent_str_next << "Area = " << BTB->area.get_area() *1e-6 << " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << BTB->power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? BTB->power.readOp.longer_channel_leakage:BTB->power.readOp.leakage)  << " W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << BTB->power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << BTB->rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-			if (BPT->exist)
-			{
-				cout << indent_str<< "Branch Predictor:" << endl;
-				cout << indent_str_next << "Area = " << BPT->area.get_area()  *1e-6<< " mm^2" << endl;
-				cout << indent_str_next << "Peak Dynamic = " << BPT->power.readOp.dynamic*clockRate  << " W" << endl;
-				cout << indent_str_next << "Subthreshold Leakage = "
-					<< (long_channel? BPT->power.readOp.longer_channel_leakage:BPT->power.readOp.leakage)  << " W" << endl;
-				cout << indent_str_next << "Gate Leakage = " << BPT->power.readOp.gate_leakage  << " W" << endl;
-				cout << indent_str_next << "Runtime Dynamic = " << BPT->rt_power.readOp.dynamic/executionTime << " W" << endl;
-				cout <<endl;
-				if (plevel>3)
-				{
-					BPT->displayEnergy(indent+4, plevel, is_tdp);
-				}
-			}
-		}
-		cout << indent_str<< "Instruction Buffer:" << endl;
-		cout << indent_str_next << "Area = " << IB->area.get_area()*1e-6  << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << IB->power.readOp.dynamic*clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-		<< (long_channel? IB->power.readOp.longer_channel_leakage:IB->power.readOp.leakage)  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << IB->power.readOp.gate_leakage  << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << IB->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-		cout << indent_str<< "Instruction Decoder:" << endl;
-		cout << indent_str_next << "Area = " << (ID_inst->area.get_area() +
-				ID_operand->area.get_area() +
-				ID_misc->area.get_area())*coredynp.decodeW*1e-6  << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << (ID_inst->power.readOp.dynamic +
-				ID_operand->power.readOp.dynamic +
-				ID_misc->power.readOp.dynamic)*clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-		<< (long_channel? (ID_inst->power.readOp.longer_channel_leakage +
-				ID_operand->power.readOp.longer_channel_leakage +
-				ID_misc->power.readOp.longer_channel_leakage):
-					(ID_inst->power.readOp.leakage +
-							ID_operand->power.readOp.leakage +
-							ID_misc->power.readOp.leakage))  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << (ID_inst->power.readOp.gate_leakage +
-				ID_operand->power.readOp.gate_leakage +
-				ID_misc->power.readOp.gate_leakage)  << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << (ID_inst->rt_power.readOp.dynamic +
-				ID_operand->rt_power.readOp.dynamic +
-				ID_misc->rt_power.readOp.dynamic)/executionTime << " W" << endl;
-		cout <<endl;
-	}
-	else
-	{
-//		cout << indent_str_next << "Instruction Cache    Peak Dynamic = " << icache.rt_power.readOp.dynamic*clockRate << " W" << endl;
-//		cout << indent_str_next << "Instruction Cache    Subthreshold Leakage = " << icache.rt_power.readOp.leakage <<" W" << endl;
-//		cout << indent_str_next << "Instruction Cache    Gate Leakage = " << icache.rt_power.readOp.gate_leakage << " W" << endl;
-//		cout << indent_str_next << "Instruction Buffer   Peak Dynamic = " << IB->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-//		cout << indent_str_next << "Instruction Buffer   Subthreshold Leakage = " << IB->rt_power.readOp.leakage  << " W" << endl;
-//		cout << indent_str_next << "Instruction Buffer   Gate Leakage = " << IB->rt_power.readOp.gate_leakage  << " W" << endl;
-//		cout << indent_str_next << "Branch Target Buffer   Peak Dynamic = " << BTB->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-//		cout << indent_str_next << "Branch Target Buffer   Subthreshold Leakage = " << BTB->rt_power.readOp.leakage  << " W" << endl;
-//		cout << indent_str_next << "Branch Target Buffer   Gate Leakage = " << BTB->rt_power.readOp.gate_leakage  << " W" << endl;
-//		cout << indent_str_next << "Branch Predictor   Peak Dynamic = " << BPT->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-//		cout << indent_str_next << "Branch Predictor   Subthreshold Leakage = " << BPT->rt_power.readOp.leakage  << " W" << endl;
-//		cout << indent_str_next << "Branch Predictor   Gate Leakage = " << BPT->rt_power.readOp.gate_leakage  << " W" << endl;
-	}
+  if (is_tdp) {
+    // init stats for Peak
+    // added by Jingwen
+    sharedmemory.caches->stats_t.readAc.access =
+        0.67 * sharedmemory.caches->l_ip.num_rw_ports * coredynp.LSU_duty_cycle;
+    sharedmemory.caches->stats_t.readAc.miss = 0;
+    sharedmemory.caches->stats_t.readAc.hit =
+        sharedmemory.caches->stats_t.readAc.access -
+        sharedmemory.caches->stats_t.readAc.miss;
+    sharedmemory.caches->stats_t.writeAc.access =
+        0.33 * sharedmemory.caches->l_ip.num_rw_ports * coredynp.LSU_duty_cycle;
+    sharedmemory.caches->stats_t.writeAc.miss = 0;
+    sharedmemory.caches->stats_t.writeAc.hit =
+        sharedmemory.caches->stats_t.writeAc.access -
+        sharedmemory.caches->stats_t.writeAc.miss;
+    sharedmemory.caches->tdp_stats = sharedmemory.caches->stats_t;
 
-}
+    sharedmemory.missb->stats_t.readAc.access =
+        sharedmemory.missb->l_ip.num_search_ports;
+    sharedmemory.missb->stats_t.writeAc.access =
+        sharedmemory.missb->l_ip.num_search_ports;
+    sharedmemory.missb->tdp_stats = sharedmemory.missb->stats_t;
 
-void RENAMINGU::computeEnergy(bool is_tdp)
-{
-	if (!exist) return;
-	double pppm_t[4]    = {1,1,1,1};
-	if (is_tdp)
-	{//init stats for Peak
-		if (coredynp.core_ty==OOO){
-			if (coredynp.scheu_ty==PhysicalRegFile)
-			{
-				if (coredynp.rm_ty ==RAMbased)
-				{
-					iFRAT->stats_t.readAc.access   = iFRAT->l_ip.num_rd_ports;
-					iFRAT->stats_t.writeAc.access  = iFRAT->l_ip.num_wr_ports;
-					iFRAT->tdp_stats = iFRAT->stats_t;
+    sharedmemory.ifb->stats_t.readAc.access =
+        sharedmemory.ifb->l_ip.num_search_ports;
+    sharedmemory.ifb->stats_t.writeAc.access =
+        sharedmemory.ifb->l_ip.num_search_ports;
+    sharedmemory.ifb->tdp_stats = sharedmemory.ifb->stats_t;
 
-					fFRAT->stats_t.readAc.access   = fFRAT->l_ip.num_rd_ports;
-					fFRAT->stats_t.writeAc.access  = fFRAT->l_ip.num_wr_ports;
-					fFRAT->tdp_stats = fFRAT->stats_t;
-
-				}
-				else if ((coredynp.rm_ty ==CAMbased))
-				{
-					iFRAT->stats_t.readAc.access   = iFRAT->l_ip.num_search_ports;
-					iFRAT->stats_t.writeAc.access  = iFRAT->l_ip.num_wr_ports;
-					iFRAT->tdp_stats = iFRAT->stats_t;
-
-					fFRAT->stats_t.readAc.access   = fFRAT->l_ip.num_search_ports;
-					fFRAT->stats_t.writeAc.access  = fFRAT->l_ip.num_wr_ports;
-					fFRAT->tdp_stats = fFRAT->stats_t;
-				}
-
-				iRRAT->stats_t.readAc.access   = iRRAT->l_ip.num_rd_ports;
-				iRRAT->stats_t.writeAc.access  = iRRAT->l_ip.num_wr_ports;
-				iRRAT->tdp_stats = iRRAT->stats_t;
-
-				fRRAT->stats_t.readAc.access   = fRRAT->l_ip.num_rd_ports;
-				fRRAT->stats_t.writeAc.access  = fRRAT->l_ip.num_wr_ports;
-				fRRAT->tdp_stats = fRRAT->stats_t;
-
-				ifreeL->stats_t.readAc.access   = coredynp.decodeW;//ifreeL->l_ip.num_rd_ports;;
-				ifreeL->stats_t.writeAc.access  = coredynp.decodeW;//ifreeL->l_ip.num_wr_ports;
-				ifreeL->tdp_stats = ifreeL->stats_t;
-
-				ffreeL->stats_t.readAc.access   = coredynp.decodeW;//ffreeL->l_ip.num_rd_ports;
-				ffreeL->stats_t.writeAc.access  = coredynp.decodeW;//ffreeL->l_ip.num_wr_ports;
-				ffreeL->tdp_stats = ffreeL->stats_t;
-			}
-			else if (coredynp.scheu_ty==ReservationStation){
-				if (coredynp.rm_ty ==RAMbased)
-				{
-					iFRAT->stats_t.readAc.access    = iFRAT->l_ip.num_rd_ports;
-					iFRAT->stats_t.writeAc.access   = iFRAT->l_ip.num_wr_ports;
-					iFRAT->stats_t.searchAc.access  = iFRAT->l_ip.num_search_ports;
-					iFRAT->tdp_stats = iFRAT->stats_t;
-
-					fFRAT->stats_t.readAc.access    = fFRAT->l_ip.num_rd_ports;
-					fFRAT->stats_t.writeAc.access   = fFRAT->l_ip.num_wr_ports;
-					fFRAT->stats_t.searchAc.access  = fFRAT->l_ip.num_search_ports;
-					fFRAT->tdp_stats = fFRAT->stats_t;
-
-				}
-				else if ((coredynp.rm_ty ==CAMbased))
-				{
-					iFRAT->stats_t.readAc.access   = iFRAT->l_ip.num_search_ports;
-					iFRAT->stats_t.writeAc.access  = iFRAT->l_ip.num_wr_ports;
-					iFRAT->tdp_stats = iFRAT->stats_t;
-
-					fFRAT->stats_t.readAc.access   = fFRAT->l_ip.num_search_ports;
-					fFRAT->stats_t.writeAc.access  = fFRAT->l_ip.num_wr_ports;
-					fFRAT->tdp_stats = fFRAT->stats_t;
-				}
-				//Unified free list for both int and fp
-				ifreeL->stats_t.readAc.access   = coredynp.decodeW;//ifreeL->l_ip.num_rd_ports;
-				ifreeL->stats_t.writeAc.access  = coredynp.decodeW;//ifreeL->l_ip.num_wr_ports;
-				ifreeL->tdp_stats = ifreeL->stats_t;
-			}
-			idcl->stats_t.readAc.access = coredynp.decodeW;
-			fdcl->stats_t.readAc.access = coredynp.decodeW;
-			idcl->tdp_stats = idcl->stats_t;
-			fdcl->tdp_stats = fdcl->stats_t;
-		}
-		else
-		{
-			if (coredynp.issueW>1)
-			{
-				idcl->stats_t.readAc.access = coredynp.decodeW;
-				fdcl->stats_t.readAc.access = coredynp.decodeW;
-				idcl->tdp_stats = idcl->stats_t;
-				fdcl->tdp_stats = fdcl->stats_t;
-			}
-		}
-
-	}
-	else
-	{//init stats for Runtime Dynamic (RTP)
-		if (coredynp.core_ty==OOO){
-			if (coredynp.scheu_ty==PhysicalRegFile)
-			{
-				if (coredynp.rm_ty ==RAMbased)
-				{
-					iFRAT->stats_t.readAc.access   = XML->sys.core[ithCore].rename_reads;
-					iFRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].rename_writes;
-					iFRAT->rtp_stats = iFRAT->stats_t;
-
-					fFRAT->stats_t.readAc.access   = XML->sys.core[ithCore].fp_rename_reads;
-					fFRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].fp_rename_writes;
-					fFRAT->rtp_stats = fFRAT->stats_t;
-				}
-				else if ((coredynp.rm_ty ==CAMbased))
-				{
-					iFRAT->stats_t.readAc.access   = XML->sys.core[ithCore].rename_reads;
-					iFRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].rename_writes;
-					iFRAT->rtp_stats = iFRAT->stats_t;
-
-					fFRAT->stats_t.readAc.access   = XML->sys.core[ithCore].fp_rename_reads;
-					fFRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].fp_rename_writes;
-					fFRAT->rtp_stats = fFRAT->stats_t;
-				}
-
-				iRRAT->stats_t.readAc.access   = XML->sys.core[ithCore].rename_writes;//Hack, should be (context switch + branch mispredictions)*16
-				iRRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].rename_writes;
-				iRRAT->rtp_stats = iRRAT->stats_t;
-
-				fRRAT->stats_t.readAc.access   = XML->sys.core[ithCore].fp_rename_writes;//Hack, should be (context switch + branch mispredictions)*16
-				fRRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].fp_rename_writes;
-				fRRAT->rtp_stats = fRRAT->stats_t;
-
-				ifreeL->stats_t.readAc.access   = XML->sys.core[ithCore].rename_reads;
-				ifreeL->stats_t.writeAc.access  = 2*XML->sys.core[ithCore].rename_writes;
-				ifreeL->rtp_stats = ifreeL->stats_t;
-
-				ffreeL->stats_t.readAc.access   = XML->sys.core[ithCore].fp_rename_reads;
-				ffreeL->stats_t.writeAc.access  = 2*XML->sys.core[ithCore].fp_rename_writes;
-				ffreeL->rtp_stats = ffreeL->stats_t;
-			}
-			else if (coredynp.scheu_ty==ReservationStation){
-				if (coredynp.rm_ty ==RAMbased)
-				{
-					iFRAT->stats_t.readAc.access   = XML->sys.core[ithCore].rename_reads;
-					iFRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].rename_writes;
-					iFRAT->stats_t.searchAc.access  = XML->sys.core[ithCore].committed_int_instructions;//hack: not all committed instructions use regs.
-					iFRAT->rtp_stats = iFRAT->stats_t;
-
-					fFRAT->stats_t.readAc.access   = XML->sys.core[ithCore].fp_rename_reads;
-					fFRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].fp_rename_writes;
-					fFRAT->stats_t.searchAc.access  = XML->sys.core[ithCore].committed_fp_instructions;
-					fFRAT->rtp_stats = fFRAT->stats_t;
-				}
-				else if ((coredynp.rm_ty ==CAMbased))
-				{
-					iFRAT->stats_t.readAc.access   = XML->sys.core[ithCore].rename_reads;
-					iFRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].rename_writes;
-					iFRAT->rtp_stats = iFRAT->stats_t;
-
-					fFRAT->stats_t.readAc.access   = XML->sys.core[ithCore].fp_rename_reads;
-					fFRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].fp_rename_writes;
-					fFRAT->rtp_stats = fFRAT->stats_t;
-				}
-				//Unified free list for both int and fp since the ROB act as physcial registers
-				ifreeL->stats_t.readAc.access   = XML->sys.core[ithCore].rename_reads +
-					XML->sys.core[ithCore].fp_rename_reads;
-				ifreeL->stats_t.writeAc.access  = 2*(XML->sys.core[ithCore].rename_writes +
-					XML->sys.core[ithCore].fp_rename_writes);//HACK: 2-> since some of renaming in the same group
-															 //are terminated early
-				ifreeL->rtp_stats = ifreeL->stats_t;
-			}
-			idcl->stats_t.readAc.access = 3*coredynp.decodeW*coredynp.decodeW*XML->sys.core[ithCore].rename_reads;
-			fdcl->stats_t.readAc.access = 3*coredynp.fp_issueW*coredynp.fp_issueW*XML->sys.core[ithCore].fp_rename_writes;
-			idcl->rtp_stats = idcl->stats_t;
-			fdcl->rtp_stats = fdcl->stats_t;
-		}
-		else
-		{
-			if (coredynp.issueW>1)
-			{
-				idcl->stats_t.readAc.access = 2*XML->sys.core[ithCore].int_instructions;
-				fdcl->stats_t.readAc.access = XML->sys.core[ithCore].fp_instructions;
-				idcl->rtp_stats = idcl->stats_t;
-				fdcl->rtp_stats = fdcl->stats_t;
-			}
-		}
-
-	}
-    /* Compute engine */
-	if (coredynp.core_ty==OOO)
-	{
-		if (coredynp.scheu_ty==PhysicalRegFile)
-		{
-			if (coredynp.rm_ty ==RAMbased)
-			{
-				iFRAT->power_t.reset();
-				fFRAT->power_t.reset();
-
-				iFRAT->power_t.readOp.dynamic  +=  (iFRAT->stats_t.readAc.access
-						*(iFRAT->local_result.power.readOp.dynamic + idcl->power.readOp.dynamic)
-						+iFRAT->stats_t.writeAc.access*iFRAT->local_result.power.writeOp.dynamic);
-				fFRAT->power_t.readOp.dynamic  +=  (fFRAT->stats_t.readAc.access
-						*(fFRAT->local_result.power.readOp.dynamic + fdcl->power.readOp.dynamic)
-						+fFRAT->stats_t.writeAc.access*fFRAT->local_result.power.writeOp.dynamic);
-			}
-			else if ((coredynp.rm_ty ==CAMbased))
-			{
-				iFRAT->power_t.reset();
-				fFRAT->power_t.reset();
-				iFRAT->power_t.readOp.dynamic  +=  (iFRAT->stats_t.readAc.access
-						*(iFRAT->local_result.power.searchOp.dynamic + idcl->power.readOp.dynamic)
-						+iFRAT->stats_t.writeAc.access*iFRAT->local_result.power.writeOp.dynamic);
-				fFRAT->power_t.readOp.dynamic  +=  (fFRAT->stats_t.readAc.access
-						*(fFRAT->local_result.power.searchOp.dynamic + fdcl->power.readOp.dynamic)
-						+fFRAT->stats_t.writeAc.access*fFRAT->local_result.power.writeOp.dynamic);
-			}
-
-			iRRAT->power_t.reset();
-			fRRAT->power_t.reset();
-			ifreeL->power_t.reset();
-			ffreeL->power_t.reset();
-
-			iRRAT->power_t.readOp.dynamic  +=  (iRRAT->stats_t.readAc.access*iRRAT->local_result.power.readOp.dynamic
-					+iRRAT->stats_t.writeAc.access*iRRAT->local_result.power.writeOp.dynamic);
-			fRRAT->power_t.readOp.dynamic  +=  (fRRAT->stats_t.readAc.access*fRRAT->local_result.power.readOp.dynamic
-					+fRRAT->stats_t.writeAc.access*fRRAT->local_result.power.writeOp.dynamic);
-			ifreeL->power_t.readOp.dynamic  +=  (ifreeL->stats_t.readAc.access*ifreeL->local_result.power.readOp.dynamic
-					+ifreeL->stats_t.writeAc.access*ifreeL->local_result.power.writeOp.dynamic);
-			ffreeL->power_t.readOp.dynamic  +=  (ffreeL->stats_t.readAc.access*ffreeL->local_result.power.readOp.dynamic
-					+ffreeL->stats_t.writeAc.access*ffreeL->local_result.power.writeOp.dynamic);
-
-		}
-		else if (coredynp.scheu_ty==ReservationStation)
-		{
-			if (coredynp.rm_ty ==RAMbased)
-			{
-				iFRAT->power_t.reset();
-				fFRAT->power_t.reset();
-
-				iFRAT->power_t.readOp.dynamic  +=  (iFRAT->stats_t.readAc.access
-						*(iFRAT->local_result.power.readOp.dynamic + idcl->power.readOp.dynamic)
-						+iFRAT->stats_t.writeAc.access*iFRAT->local_result.power.writeOp.dynamic
-						+iFRAT->stats_t.searchAc.access*iFRAT->local_result.power.searchOp.dynamic);
-				fFRAT->power_t.readOp.dynamic  +=  (fFRAT->stats_t.readAc.access
-						*(fFRAT->local_result.power.readOp.dynamic + fdcl->power.readOp.dynamic)
-						+fFRAT->stats_t.writeAc.access*fFRAT->local_result.power.writeOp.dynamic
-						+fFRAT->stats_t.searchAc.access*fFRAT->local_result.power.searchOp.dynamic);
-			}
-			else if ((coredynp.rm_ty ==CAMbased))
-			{
-				iFRAT->power_t.reset();
-				fFRAT->power_t.reset();
-				iFRAT->power_t.readOp.dynamic  +=  (iFRAT->stats_t.readAc.access
-						*(iFRAT->local_result.power.searchOp.dynamic + idcl->power.readOp.dynamic)
-						+iFRAT->stats_t.writeAc.access*iFRAT->local_result.power.writeOp.dynamic);
-				fFRAT->power_t.readOp.dynamic  +=  (fFRAT->stats_t.readAc.access
-						*(fFRAT->local_result.power.searchOp.dynamic + fdcl->power.readOp.dynamic)
-						+fFRAT->stats_t.writeAc.access*fFRAT->local_result.power.writeOp.dynamic);
-			}
-			ifreeL->power_t.reset();
-			ifreeL->power_t.readOp.dynamic  +=  (ifreeL->stats_t.readAc.access*ifreeL->local_result.power.readOp.dynamic
-					+ifreeL->stats_t.writeAc.access*ifreeL->local_result.power.writeOp.dynamic);
-		}
-
-	}
-	else
-	{
-		if (coredynp.issueW>1)
-		{
-			idcl->power_t.reset();
-			fdcl->power_t.reset();
-			set_pppm(pppm_t, idcl->stats_t.readAc.access, coredynp.num_hthreads, coredynp.num_hthreads, idcl->stats_t.readAc.access);
-			idcl->power_t = idcl->power * pppm_t;
-			set_pppm(pppm_t, fdcl->stats_t.readAc.access, coredynp.num_hthreads, coredynp.num_hthreads, idcl->stats_t.readAc.access);
-			fdcl->power_t = fdcl->power * pppm_t;
-		}
-
-	}
-
-	//assign value to tpd and rtp
-	if (is_tdp)
-	{
-		if (coredynp.core_ty==OOO)
-		{
-			if (coredynp.scheu_ty==PhysicalRegFile)
-			{
-				iFRAT->power   =  iFRAT->power_t + (iFRAT->local_result.power ) * coredynp.pppm_lkg_multhread + idcl->power_t;
-				fFRAT->power   =  fFRAT->power_t + (fFRAT->local_result.power ) * coredynp.pppm_lkg_multhread + fdcl->power_t;
-				iRRAT->power   =  iRRAT->power_t + iRRAT->local_result.power * coredynp.pppm_lkg_multhread;
-				fRRAT->power   =  fRRAT->power_t + fRRAT->local_result.power * coredynp.pppm_lkg_multhread;
-				ifreeL->power  =  ifreeL->power_t + ifreeL->local_result.power * coredynp.pppm_lkg_multhread;
-				ffreeL->power  =  ffreeL->power_t + ffreeL->local_result.power * coredynp.pppm_lkg_multhread;
-				power	       =  power + (iFRAT->power + fFRAT->power)
-				                 + (iRRAT->power + fRRAT->power)
-				                 + (ifreeL->power + ffreeL->power);
-			}
-			else if (coredynp.scheu_ty==ReservationStation)
-			{
-				iFRAT->power   =  iFRAT->power_t + (iFRAT->local_result.power ) * coredynp.pppm_lkg_multhread + idcl->power_t;
-				fFRAT->power   =  fFRAT->power_t + (fFRAT->local_result.power ) * coredynp.pppm_lkg_multhread + fdcl->power_t;
-				ifreeL->power  =  ifreeL->power_t + ifreeL->local_result.power * coredynp.pppm_lkg_multhread;
-				power	       =  power + (iFRAT->power + fFRAT->power)
-				                 + ifreeL->power;
-			}
-		}
-		else
-		{
-			power   =  power + idcl->power_t + fdcl->power_t;
-		}
-
-	}
-	else
-	{
-		if (coredynp.core_ty==OOO)
-		{
-			if (coredynp.scheu_ty==PhysicalRegFile)
-			{
-				iFRAT->rt_power   =  iFRAT->power_t + (iFRAT->local_result.power ) * coredynp.pppm_lkg_multhread + idcl->power_t;
-				fFRAT->rt_power   =  fFRAT->power_t + (fFRAT->local_result.power ) * coredynp.pppm_lkg_multhread + fdcl->power_t;
-				iRRAT->rt_power   =  iRRAT->power_t + iRRAT->local_result.power * coredynp.pppm_lkg_multhread;
-				fRRAT->rt_power   =  fRRAT->power_t + fRRAT->local_result.power * coredynp.pppm_lkg_multhread;
-				ifreeL->rt_power  =  ifreeL->power_t + ifreeL->local_result.power * coredynp.pppm_lkg_multhread;
-				ffreeL->rt_power  =  ffreeL->power_t + ffreeL->local_result.power * coredynp.pppm_lkg_multhread;
-				rt_power	      =  rt_power + (iFRAT->rt_power + fFRAT->rt_power)
-				                   + (iRRAT->rt_power + fRRAT->rt_power)
-				                   + (ifreeL->rt_power + ffreeL->rt_power);
-			}
-			else if (coredynp.scheu_ty==ReservationStation)
-			{
-				iFRAT->rt_power   =  iFRAT->power_t + (iFRAT->local_result.power ) * coredynp.pppm_lkg_multhread + idcl->power_t;
-				fFRAT->rt_power   =  fFRAT->power_t + (fFRAT->local_result.power ) * coredynp.pppm_lkg_multhread + fdcl->power_t;
-				ifreeL->rt_power  =  ifreeL->power_t + ifreeL->local_result.power * coredynp.pppm_lkg_multhread;
-				rt_power	      =  rt_power + (iFRAT->rt_power + fFRAT->rt_power)
-				                   + ifreeL->rt_power;
-			}
-		}
-		else
-		{
-			rt_power   =  rt_power + idcl->power_t + fdcl->power_t;
-		}
-
-	}
-}
-
-void RENAMINGU::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	if (!exist) return;
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
-
-
-	if (is_tdp)
-	{
-
-		if (coredynp.core_ty==OOO)
-		{
-			cout << indent_str<< "Int Front End RAT:" << endl;
-			cout << indent_str_next << "Area = " << iFRAT->area.get_area()*1e-6<< " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << iFRAT->power.readOp.dynamic*clockRate << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? iFRAT->power.readOp.longer_channel_leakage:iFRAT->power.readOp.leakage) <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << iFRAT->power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << iFRAT->rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-			cout << indent_str<< "FP Front End RAT:" << endl;
-			cout << indent_str_next << "Area = " << fFRAT->area.get_area()*1e-6  << " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << fFRAT->power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? fFRAT->power.readOp.longer_channel_leakage:fFRAT->power.readOp.leakage)  << " W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << fFRAT->power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << fFRAT->rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-			cout << indent_str<<"Free List:" << endl;
-			cout << indent_str_next << "Area = " << ifreeL->area.get_area()*1e-6  << " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << ifreeL->power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? ifreeL->power.readOp.longer_channel_leakage:ifreeL->power.readOp.leakage)  << " W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << ifreeL->power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << ifreeL->rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-
-			if (coredynp.scheu_ty==PhysicalRegFile)
-			{
-				cout << indent_str<< "Int Retire RAT: " << endl;
-				cout << indent_str_next << "Area = " << iRRAT->area.get_area() *1e-6 << " mm^2" << endl;
-				cout << indent_str_next << "Peak Dynamic = " << iRRAT->power.readOp.dynamic*clockRate  << " W" << endl;
-				cout << indent_str_next << "Subthreshold Leakage = "
-					<< (long_channel? iRRAT->power.readOp.longer_channel_leakage:iRRAT->power.readOp.leakage)  << " W" << endl;
-				cout << indent_str_next << "Gate Leakage = " << iRRAT->power.readOp.gate_leakage  << " W" << endl;
-				cout << indent_str_next << "Runtime Dynamic = " << iRRAT->rt_power.readOp.dynamic/executionTime << " W" << endl;
-				cout <<endl;
-				cout << indent_str<< "FP Retire RAT:" << endl;
-				cout << indent_str_next << "Area = " << fRRAT->area.get_area()  *1e-6<< " mm^2" << endl;
-				cout << indent_str_next << "Peak Dynamic = " << fRRAT->power.readOp.dynamic*clockRate  << " W" << endl;
-				cout << indent_str_next << "Subthreshold Leakage = "
-					<< (long_channel? fRRAT->power.readOp.longer_channel_leakage:fRRAT->power.readOp.leakage)  << " W" << endl;
-				cout << indent_str_next << "Gate Leakage = " << fRRAT->power.readOp.gate_leakage  << " W" << endl;
-				cout << indent_str_next << "Runtime Dynamic = " << fRRAT->rt_power.readOp.dynamic/executionTime << " W" << endl;
-				cout <<endl;
-				cout << indent_str<< "FP Free List:" << endl;
-				cout << indent_str_next << "Area = " << ffreeL->area.get_area()*1e-6  << " mm^2" << endl;
-				cout << indent_str_next << "Peak Dynamic = " << ffreeL->power.readOp.dynamic*clockRate  << " W" << endl;
-				cout << indent_str_next << "Subthreshold Leakage = "
-					<< (long_channel? ffreeL->power.readOp.longer_channel_leakage:ffreeL->power.readOp.leakage)  << " W" << endl;
-				cout << indent_str_next << "Gate Leakage = " << ffreeL->power.readOp.gate_leakage  << " W" << endl;
-				cout << indent_str_next << "Runtime Dynamic = " << ffreeL->rt_power.readOp.dynamic/executionTime << " W" << endl;
-				cout <<endl;
-			}
-		}
-		else
-		{
-			cout << indent_str<< "Int DCL:" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << idcl->power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? idcl->power.readOp.longer_channel_leakage:idcl->power.readOp.leakage)  << " W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << idcl->power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << idcl->rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout << indent_str<<"FP DCL:" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << fdcl->power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? fdcl->power.readOp.longer_channel_leakage:fdcl->power.readOp.leakage)  << " W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << fdcl->power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << fdcl->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		}
-	}
-	else
-	{
-		if (coredynp.core_ty==OOO)
-		{
-			cout << indent_str_next << "Int Front End RAT    Peak Dynamic = " << iFRAT->rt_power.readOp.dynamic*clockRate << " W" << endl;
-			cout << indent_str_next << "Int Front End RAT    Subthreshold Leakage = " << iFRAT->rt_power.readOp.leakage <<" W" << endl;
-			cout << indent_str_next << "Int Front End RAT    Gate Leakage = " << iFRAT->rt_power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next << "FP Front End RAT   Peak Dynamic = " << fFRAT->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "FP Front End RAT   Subthreshold Leakage = " << fFRAT->rt_power.readOp.leakage  << " W" << endl;
-			cout << indent_str_next << "FP Front End RAT   Gate Leakage = " << fFRAT->rt_power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Free List   Peak Dynamic = " << ifreeL->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Free List   Subthreshold Leakage = " << ifreeL->rt_power.readOp.leakage  << " W" << endl;
-			cout << indent_str_next << "Free List   Gate Leakage = " << fFRAT->rt_power.readOp.gate_leakage  << " W" << endl;
-			if (coredynp.scheu_ty==PhysicalRegFile)
-			{
-				cout << indent_str_next << "Int Retire RAT   Peak Dynamic = " << iRRAT->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-				cout << indent_str_next << "Int Retire RAT   Subthreshold Leakage = " << iRRAT->rt_power.readOp.leakage  << " W" << endl;
-				cout << indent_str_next << "Int Retire RAT   Gate Leakage = " << iRRAT->rt_power.readOp.gate_leakage  << " W" << endl;
-				cout << indent_str_next << "FP Retire RAT   Peak Dynamic = " << fRRAT->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-				cout << indent_str_next << "FP Retire RAT   Subthreshold Leakage = " << fRRAT->rt_power.readOp.leakage  << " W" << endl;
-				cout << indent_str_next << "FP Retire RAT   Gate Leakage = " << fRRAT->rt_power.readOp.gate_leakage  << " W" << endl;
-				cout << indent_str_next << "FP Free List   Peak Dynamic = " << ffreeL->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-				cout << indent_str_next << "FP Free List   Subthreshold Leakage = " << ffreeL->rt_power.readOp.leakage  << " W" << endl;
-				cout << indent_str_next << "FP Free List   Gate Leakage = " << fFRAT->rt_power.readOp.gate_leakage  << " W" << endl;
-			}
-		}
-		else
-		{
-			cout << indent_str_next << "Int DCL   Peak Dynamic = " << idcl->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Int DCL   Subthreshold Leakage = " << idcl->rt_power.readOp.leakage  << " W" << endl;
-			cout << indent_str_next << "Int DCL   Gate Leakage = " << idcl->rt_power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "FP DCL   Peak Dynamic = " << fdcl->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "FP DCL   Subthreshold Leakage = " << fdcl->rt_power.readOp.leakage  << " W" << endl;
-			cout << indent_str_next << "FP DCL   Gate Leakage = " << fdcl->rt_power.readOp.gate_leakage  << " W" << endl;
-		}
-	}
-
-}
-
-
-void SchedulerU::computeEnergy(bool is_tdp)
-{
-	if (!exist) return;
-	double ROB_duty_cycle;
-//	ROB_duty_cycle = ((coredynp.ALU_duty_cycle + coredynp.num_muls>0?coredynp.MUL_duty_cycle:0
-//			+ coredynp.num_fpus>0?coredynp.FPU_duty_cycle:0))*1.1<1 ? (coredynp.ALU_duty_cycle + coredynp.num_muls>0?coredynp.MUL_duty_cycle:0
-//					+ coredynp.num_fpus>0?coredynp.FPU_duty_cycle:0)*1.1:1;
-	ROB_duty_cycle = 1;
-	//init stats
-	if (is_tdp)
-	{
-		if (coredynp.core_ty==OOO)
-		{
-			int_inst_window->stats_t.readAc.access    = coredynp.issueW*coredynp.num_pipelines;//int_inst_window->l_ip.num_search_ports;
-			int_inst_window->stats_t.writeAc.access   = coredynp.issueW*coredynp.num_pipelines;//int_inst_window->l_ip.num_wr_ports;
-			int_inst_window->stats_t.searchAc.access  = coredynp.issueW*coredynp.num_pipelines;
-			int_inst_window->tdp_stats                = int_inst_window->stats_t;
-			fp_inst_window->stats_t.readAc.access     = fp_inst_window->l_ip.num_rd_ports*coredynp.num_fp_pipelines;
-			fp_inst_window->stats_t.writeAc.access    = fp_inst_window->l_ip.num_wr_ports*coredynp.num_fp_pipelines;
-			fp_inst_window->stats_t.searchAc.access   = fp_inst_window->l_ip.num_search_ports*coredynp.num_fp_pipelines;
-			fp_inst_window->tdp_stats                 = fp_inst_window->stats_t;
-
-			if (XML->sys.core[ithCore].ROB_size >0)
-			{
-				ROB->stats_t.readAc.access   = coredynp.commitW*coredynp.num_pipelines*ROB_duty_cycle;
-				ROB->stats_t.writeAc.access  = coredynp.issueW*coredynp.num_pipelines*ROB_duty_cycle;
-				ROB->tdp_stats        = ROB->stats_t;
-
-				/*
-				 * When inst commits, ROB must be read.
-				 * Because for Physcial register based cores, physical register tag in ROB
-				 * need to be read out and write into RRAT/CAM based RAT.
-				 * For RS based cores, register content that stored in ROB must be
-				 * read out and stored in architectural registers.
-				 *
-				 * if no-register is involved, the ROB read out operation when instruction commits can be ignored.
-				 * assuming 20% insts. belong this type.
-				 * TODO: ROB duty_cycle need to be revisited
-				 */
-			}
-
-		}
-		else if (coredynp.multithreaded)
-		{
-			int_inst_window->stats_t.readAc.access   = coredynp.issueW*coredynp.num_pipelines;//int_inst_window->l_ip.num_search_ports;
-			int_inst_window->stats_t.writeAc.access  = coredynp.issueW*coredynp.num_pipelines;//int_inst_window->l_ip.num_wr_ports;
-			int_inst_window->stats_t.searchAc.access = coredynp.issueW*coredynp.num_pipelines;
-			int_inst_window->tdp_stats       = int_inst_window->stats_t;
-		}
-
-     }
-    else
-    {//rtp
-		if (coredynp.core_ty==OOO)
-		{
-			int_inst_window->stats_t.readAc.access   = XML->sys.core[ithCore].inst_window_reads;
-			int_inst_window->stats_t.writeAc.access  = XML->sys.core[ithCore].inst_window_writes;
-			int_inst_window->stats_t.searchAc.access = XML->sys.core[ithCore].inst_window_wakeup_accesses;
-			int_inst_window->rtp_stats               = int_inst_window->stats_t;
-			fp_inst_window->stats_t.readAc.access    = XML->sys.core[ithCore].fp_inst_window_reads;
-			fp_inst_window->stats_t.writeAc.access   = XML->sys.core[ithCore].fp_inst_window_writes;
-			fp_inst_window->stats_t.searchAc.access  = XML->sys.core[ithCore].fp_inst_window_wakeup_accesses;
-			fp_inst_window->rtp_stats                = fp_inst_window->stats_t;
-
-			if (XML->sys.core[ithCore].ROB_size >0)
-			{
-
-				ROB->stats_t.readAc.access   = XML->sys.core[ithCore].ROB_reads;
-				ROB->stats_t.writeAc.access  = XML->sys.core[ithCore].ROB_writes;
-				/* ROB need to be updated in RS based OOO when new values are produced,
-				 * this update may happen before the commit stage when ROB entry is released
-				 * 1. ROB write at instruction inserted in
-				 * 2. ROB write as results produced (for RS based OOO only)
-				 * 3. ROB read  as instruction committed. For RS based OOO, data values are read out and sent to ARF
-				 * For Physical reg based OOO, no data stored in ROB, but register tags need to be
-				 * read out and used to set the RRAT and to recycle the register tag to free list buffer
-				 */
-				ROB->rtp_stats        = ROB->stats_t;
-			}
-
-		}
-		else if (coredynp.multithreaded)
-		{
-			int_inst_window->stats_t.readAc.access    = XML->sys.core[ithCore].int_instructions + XML->sys.core[ithCore].fp_instructions;
-			int_inst_window->stats_t.writeAc.access   = XML->sys.core[ithCore].int_instructions + XML->sys.core[ithCore].fp_instructions;
-			int_inst_window->stats_t.searchAc.access  = 2*(XML->sys.core[ithCore].int_instructions + XML->sys.core[ithCore].fp_instructions);
-			int_inst_window->rtp_stats                = int_inst_window->stats_t;
-		}
+    sharedmemory.prefetchb->stats_t.readAc.access =
+        sharedmemory.prefetchb->l_ip.num_search_ports;
+    sharedmemory.prefetchb->stats_t.writeAc.access =
+        sharedmemory.ifb->l_ip.num_search_ports;
+    sharedmemory.prefetchb->tdp_stats = sharedmemory.prefetchb->stats_t;
+    if (cache_p == Write_back) {
+      sharedmemory.wbb->stats_t.readAc.access =
+          sharedmemory.wbb->l_ip.num_search_ports;
+      sharedmemory.wbb->stats_t.writeAc.access =
+          sharedmemory.wbb->l_ip.num_search_ports;
+      sharedmemory.wbb->tdp_stats = sharedmemory.wbb->stats_t;
     }
 
-	//computation engine
-	if (coredynp.core_ty==OOO)
-	{
-		int_inst_window->power_t.reset();
-		fp_inst_window->power_t.reset();
-
-		/* each instruction needs to write to scheduler, read out when all resources and source operands are ready
-		 * two search ops with one for each source operand
-		 *
-		 */
-		int_inst_window->power_t.readOp.dynamic  +=  int_inst_window->local_result.power.readOp.dynamic * int_inst_window->stats_t.readAc.access
-					+ int_inst_window->local_result.power.searchOp.dynamic * int_inst_window->stats_t.searchAc.access
-					+ int_inst_window->local_result.power.writeOp.dynamic  * int_inst_window->stats_t.writeAc.access
-					+ int_inst_window->stats_t.readAc.access * instruction_selection->power.readOp.dynamic;
-
-		fp_inst_window->power_t.readOp.dynamic   +=  fp_inst_window->local_result.power.readOp.dynamic * fp_inst_window->stats_t.readAc.access
-					+ fp_inst_window->local_result.power.searchOp.dynamic * fp_inst_window->stats_t.searchAc.access
-					+ fp_inst_window->local_result.power.writeOp.dynamic * fp_inst_window->stats_t.writeAc.access
-					+ fp_inst_window->stats_t.writeAc.access * instruction_selection->power.readOp.dynamic;
-
-		if (XML->sys.core[ithCore].ROB_size >0)
-		{
-			ROB->power_t.reset();
-			ROB->power_t.readOp.dynamic   +=  ROB->local_result.power.readOp.dynamic*ROB->stats_t.readAc.access +
-						ROB->stats_t.writeAc.access*ROB->local_result.power.writeOp.dynamic;
-		}
-
-
-
-
-	}
-	else if (coredynp.multithreaded)
-	{
-		int_inst_window->power_t.reset();
-		int_inst_window->power_t.readOp.dynamic  +=  int_inst_window->local_result.power.readOp.dynamic * int_inst_window->stats_t.readAc.access
-						  + int_inst_window->local_result.power.searchOp.dynamic * int_inst_window->stats_t.searchAc.access
-				          + int_inst_window->local_result.power.writeOp.dynamic  * int_inst_window->stats_t.writeAc.access
-				          + int_inst_window->stats_t.writeAc.access * instruction_selection->power.readOp.dynamic;
-	}
-
-	//assign values
-	if (is_tdp)
-	{
-		if (coredynp.core_ty==OOO)
-		{
-			int_inst_window->power = int_inst_window->power_t + (int_inst_window->local_result.power +instruction_selection->power) *pppm_lkg;
-			fp_inst_window->power = fp_inst_window->power_t + (fp_inst_window->local_result.power +instruction_selection->power) *pppm_lkg;
-			power	   = power + int_inst_window->power + fp_inst_window->power;
-			if (XML->sys.core[ithCore].ROB_size >0)
-			{
-				ROB->power = ROB->power_t + ROB->local_result.power*pppm_lkg;
-				power	   = power + ROB->power;
-			}
-
-		}
-		else if (coredynp.multithreaded)
-		{
-			//			set_pppm(pppm_t, XML->sys.core[ithCore].issue_width,1, 1, 1);
-			int_inst_window->power = int_inst_window->power_t + (int_inst_window->local_result.power +instruction_selection->power) *pppm_lkg;
-			power	   = power + int_inst_window->power;
-      	}
-
-     }
-    else
-    {//rtp
-		if (coredynp.core_ty==OOO)
-		{
-			int_inst_window->rt_power = int_inst_window->power_t + (int_inst_window->local_result.power +instruction_selection->power) *pppm_lkg;
-			fp_inst_window->rt_power  = fp_inst_window->power_t + (fp_inst_window->local_result.power +instruction_selection->power) *pppm_lkg;
-			rt_power	              = rt_power + int_inst_window->rt_power + fp_inst_window->rt_power;
-			if (XML->sys.core[ithCore].ROB_size >0)
-			{
-				ROB->rt_power = ROB->power_t + ROB->local_result.power*pppm_lkg;
-				rt_power	              = rt_power + ROB->rt_power;
-			}
-
-		}
-		else if (coredynp.multithreaded)
-		{
-			//			set_pppm(pppm_t, XML->sys.core[ithCore].issue_width,1, 1, 1);
-			int_inst_window->rt_power = int_inst_window->power_t + (int_inst_window->local_result.power +instruction_selection->power) *pppm_lkg;
-			rt_power	              = rt_power + int_inst_window->rt_power;
-      	}
-    }
-//	set_pppm(pppm_t, XML->sys.core[ithCore].issue_width,1, 1, 1);
-//	cout<<"Scheduler power="<<power.readOp.dynamic<<"leakage="<<power.readOp.leakage<<endl;
-//	cout<<"IW="<<int_inst_window->local_result.power.searchOp.dynamic * int_inst_window->stats_t.readAc.access +
-//    + int_inst_window->local_result.power.writeOp.dynamic * int_inst_window->stats_t.writeAc.access<<"leakage="<<int_inst_window->local_result.power.readOp.leakage<<endl;
-//	cout<<"selection"<<instruction_selection->power.readOp.dynamic<<"leakage"<<instruction_selection->power.readOp.leakage<<endl;
-}
-
-void SchedulerU::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	if (!exist) return;
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
-
-
-	if (is_tdp)
-	{
-		if (coredynp.core_ty==OOO)
-		{
-			cout << indent_str << "Instruction Window:" << endl;
-			cout << indent_str_next << "Area = " << int_inst_window->area.get_area()*1e-6<< " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << int_inst_window->power.readOp.dynamic*clockRate << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? int_inst_window->power.readOp.longer_channel_leakage:int_inst_window->power.readOp.leakage) <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << int_inst_window->power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << int_inst_window->rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-			cout << indent_str << "FP Instruction Window:" << endl;
-			cout << indent_str_next << "Area = " << fp_inst_window->area.get_area()*1e-6  << " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << fp_inst_window->power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? fp_inst_window->power.readOp.longer_channel_leakage:fp_inst_window->power.readOp.leakage ) << " W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << fp_inst_window->power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << fp_inst_window->rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-			if (XML->sys.core[ithCore].ROB_size >0)
-			{
-				cout << indent_str<<"ROB:" << endl;
-				cout << indent_str_next << "Area = " << ROB->area.get_area() *1e-6 << " mm^2" << endl;
-				cout << indent_str_next << "Peak Dynamic = " << ROB->power.readOp.dynamic*clockRate  << " W" << endl;
-				cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? ROB->power.readOp.longer_channel_leakage:ROB->power.readOp.leakage)  << " W" << endl;
-				cout << indent_str_next << "Gate Leakage = " << ROB->power.readOp.gate_leakage  << " W" << endl;
-				cout << indent_str_next << "Runtime Dynamic = " << ROB->rt_power.readOp.dynamic/executionTime << " W" << endl;
-				cout <<endl;
-			}
-		}
-		else if (coredynp.multithreaded)
-		{
-			cout << indent_str << "Instruction Window:" << endl;
-			cout << indent_str_next << "Area = " << int_inst_window->area.get_area()*1e-6<< " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << int_inst_window->power.readOp.dynamic*clockRate << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? int_inst_window->power.readOp.longer_channel_leakage:int_inst_window->power.readOp.leakage) <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << int_inst_window->power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << int_inst_window->rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-		}
-	}
-	else
-	{
-		if (coredynp.core_ty==OOO)
-		{
-			cout << indent_str_next << "Instruction Window    Peak Dynamic = " << int_inst_window->rt_power.readOp.dynamic*clockRate << " W" << endl;
-			cout << indent_str_next << "Instruction Window    Subthreshold Leakage = " << int_inst_window->rt_power.readOp.leakage <<" W" << endl;
-			cout << indent_str_next << "Instruction Window    Gate Leakage = " << int_inst_window->rt_power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next << "FP Instruction Window   Peak Dynamic = " << fp_inst_window->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "FP Instruction Window   Subthreshold Leakage = " << fp_inst_window->rt_power.readOp.leakage  << " W" << endl;
-			cout << indent_str_next << "FP Instruction Window   Gate Leakage = " << fp_inst_window->rt_power.readOp.gate_leakage  << " W" << endl;
-			if (XML->sys.core[ithCore].ROB_size >0)
-			{
-				cout << indent_str_next << "ROB   Peak Dynamic = " << ROB->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-				cout << indent_str_next << "ROB   Subthreshold Leakage = " << ROB->rt_power.readOp.leakage  << " W" << endl;
-				cout << indent_str_next << "ROB   Gate Leakage = " << ROB->rt_power.readOp.gate_leakage  << " W" << endl;
-			}
-		}
-		else if (coredynp.multithreaded)
-		{
-			cout << indent_str_next << "Instruction Window    Peak Dynamic = " << int_inst_window->rt_power.readOp.dynamic*clockRate << " W" << endl;
-			cout << indent_str_next << "Instruction Window    Subthreshold Leakage = " << int_inst_window->rt_power.readOp.leakage <<" W" << endl;
-			cout << indent_str_next << "Instruction Window    Gate Leakage = " << int_inst_window->rt_power.readOp.gate_leakage << " W" << endl;
-		}
-	}
-
-}
-
-void LoadStoreU::computeEnergy(bool is_tdp)
-{
-	if (!exist) return;
-
-	executionTime=XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);//Syed
-
-	//RF crossbar power (Syed)
-	xbar_shared->compute_power();
-   
-	if (is_tdp)
-	    {
-
-	    	//init stats for Peak
-        // added by Jingwen
-	    	sharedmemory.caches->stats_t.readAc.access  = 0.67*sharedmemory.caches->l_ip.num_rw_ports*coredynp.LSU_duty_cycle;
-	    	sharedmemory.caches->stats_t.readAc.miss    = 0;
-	    	sharedmemory.caches->stats_t.readAc.hit     = sharedmemory.caches->stats_t.readAc.access - sharedmemory.caches->stats_t.readAc.miss;
-	    	sharedmemory.caches->stats_t.writeAc.access = 0.33*sharedmemory.caches->l_ip.num_rw_ports*coredynp.LSU_duty_cycle;
-	    	sharedmemory.caches->stats_t.writeAc.miss   = 0;
-    		sharedmemory.caches->stats_t.writeAc.hit    = sharedmemory.caches->stats_t.writeAc.access -	sharedmemory.caches->stats_t.writeAc.miss;
-	    	sharedmemory.caches->tdp_stats = sharedmemory.caches->stats_t;
-
-	    	sharedmemory.missb->stats_t.readAc.access  = sharedmemory.missb->l_ip.num_search_ports;
-	    	sharedmemory.missb->stats_t.writeAc.access = sharedmemory.missb->l_ip.num_search_ports;
-	    	sharedmemory.missb->tdp_stats = sharedmemory.missb->stats_t;
-
-	    	sharedmemory.ifb->stats_t.readAc.access  = sharedmemory.ifb->l_ip.num_search_ports;
-	    	sharedmemory.ifb->stats_t.writeAc.access = sharedmemory.ifb->l_ip.num_search_ports;
-	    	sharedmemory.ifb->tdp_stats = sharedmemory.ifb->stats_t;
-
-	    	sharedmemory.prefetchb->stats_t.readAc.access  = sharedmemory.prefetchb->l_ip.num_search_ports;
-	    	sharedmemory.prefetchb->stats_t.writeAc.access = sharedmemory.ifb->l_ip.num_search_ports;
-	    	sharedmemory.prefetchb->tdp_stats = sharedmemory.prefetchb->stats_t;
-	    	if (cache_p==Write_back)
-	    	{
-	    		sharedmemory.wbb->stats_t.readAc.access  = sharedmemory.wbb->l_ip.num_search_ports;
-	    		sharedmemory.wbb->stats_t.writeAc.access = sharedmemory.wbb->l_ip.num_search_ports;
-	    		sharedmemory.wbb->tdp_stats = sharedmemory.wbb->stats_t;
-	    	}
-
-
-
-	    	//init stats for Peak
-	    	dcache.caches->stats_t.readAc.access  = 0.67*dcache.caches->l_ip.num_rw_ports*coredynp.LSU_duty_cycle;
-	    	dcache.caches->stats_t.readAc.miss    = 0;
-	    	dcache.caches->stats_t.readAc.hit     = dcache.caches->stats_t.readAc.access - dcache.caches->stats_t.readAc.miss;
-	    	dcache.caches->stats_t.writeAc.access = 0.33*dcache.caches->l_ip.num_rw_ports*coredynp.LSU_duty_cycle;
-	    	dcache.caches->stats_t.writeAc.miss   = 0;
-    		dcache.caches->stats_t.writeAc.hit    = dcache.caches->stats_t.writeAc.access -	dcache.caches->stats_t.writeAc.miss;
-	    	dcache.caches->tdp_stats = dcache.caches->stats_t;
-
-	    	dcache.missb->stats_t.readAc.access  = dcache.missb->l_ip.num_search_ports;
-	    	dcache.missb->stats_t.writeAc.access = dcache.missb->l_ip.num_search_ports;
-	    	dcache.missb->tdp_stats = dcache.missb->stats_t;
-
-	    	dcache.ifb->stats_t.readAc.access  = dcache.ifb->l_ip.num_search_ports;
-	    	dcache.ifb->stats_t.writeAc.access = dcache.ifb->l_ip.num_search_ports;
-	    	dcache.ifb->tdp_stats = dcache.ifb->stats_t;
-
-	    	dcache.prefetchb->stats_t.readAc.access  = dcache.prefetchb->l_ip.num_search_ports;
-	    	dcache.prefetchb->stats_t.writeAc.access = dcache.ifb->l_ip.num_search_ports;
-	    	dcache.prefetchb->tdp_stats = dcache.prefetchb->stats_t;
-	    	if (cache_p==Write_back)
-	    	{
-	    		dcache.wbb->stats_t.readAc.access  = dcache.wbb->l_ip.num_search_ports;
-	    		dcache.wbb->stats_t.writeAc.access = dcache.wbb->l_ip.num_search_ports;
-	    		dcache.wbb->tdp_stats = dcache.wbb->stats_t;
-	    	}
-
-
-	    	//init stats for Peak - ccache
-	    	ccache.caches->stats_t.readAc.access  = 0.67*ccache.caches->l_ip.num_rw_ports*coredynp.LSU_duty_cycle;
-	    	ccache.caches->stats_t.readAc.miss    = 0;
-	    	ccache.caches->stats_t.readAc.hit     = ccache.caches->stats_t.readAc.access - ccache.caches->stats_t.readAc.miss;
-	    	ccache.caches->stats_t.writeAc.access = 0.33*ccache.caches->l_ip.num_rw_ports*coredynp.LSU_duty_cycle;
-	    	ccache.caches->stats_t.writeAc.miss   = 0;
-    		ccache.caches->stats_t.writeAc.hit    = ccache.caches->stats_t.writeAc.access -	ccache.caches->stats_t.writeAc.miss;
-	    	ccache.caches->tdp_stats = ccache.caches->stats_t;
-
-	    	ccache.missb->stats_t.readAc.access  = ccache.missb->l_ip.num_search_ports;
-	    	ccache.missb->stats_t.writeAc.access = ccache.missb->l_ip.num_search_ports;
-	    	ccache.missb->tdp_stats = ccache.missb->stats_t;
-
-	    	ccache.ifb->stats_t.readAc.access  = ccache.ifb->l_ip.num_search_ports;
-	    	ccache.ifb->stats_t.writeAc.access = ccache.ifb->l_ip.num_search_ports;
-	    	ccache.ifb->tdp_stats = ccache.ifb->stats_t;
-
-	    	ccache.prefetchb->stats_t.readAc.access  = ccache.prefetchb->l_ip.num_search_ports;
-	    	ccache.prefetchb->stats_t.writeAc.access = ccache.ifb->l_ip.num_search_ports;
-	    	ccache.prefetchb->tdp_stats = ccache.prefetchb->stats_t;
-	    	if (cache_p==Write_back)
-	    	{
-	    		ccache.wbb->stats_t.readAc.access  = ccache.wbb->l_ip.num_search_ports;
-	    		ccache.wbb->stats_t.writeAc.access = ccache.wbb->l_ip.num_search_ports;
-	    		ccache.wbb->tdp_stats = ccache.wbb->stats_t;
-	    	}
-
-
-	    	//init stats for Peak - tcache
-	    	tcache.caches->stats_t.readAc.access  = 0.67*tcache.caches->l_ip.num_rw_ports*coredynp.LSU_duty_cycle;
-	    	tcache.caches->stats_t.readAc.miss    = 0;
-	    	tcache.caches->stats_t.readAc.hit     = tcache.caches->stats_t.readAc.access - tcache.caches->stats_t.readAc.miss;
-	    	tcache.caches->stats_t.writeAc.access = 0.33*tcache.caches->l_ip.num_rw_ports*coredynp.LSU_duty_cycle;
-	    	tcache.caches->stats_t.writeAc.miss   = 0;
-    		tcache.caches->stats_t.writeAc.hit    = tcache.caches->stats_t.writeAc.access -	tcache.caches->stats_t.writeAc.miss;
-	    	tcache.caches->tdp_stats = tcache.caches->stats_t;
-
-	    	tcache.missb->stats_t.readAc.access  = tcache.missb->l_ip.num_search_ports;
-	    	tcache.missb->stats_t.writeAc.access = tcache.missb->l_ip.num_search_ports;
-	    	tcache.missb->tdp_stats = tcache.missb->stats_t;
-
-	    	tcache.ifb->stats_t.readAc.access  = tcache.ifb->l_ip.num_search_ports;
-	    	tcache.ifb->stats_t.writeAc.access = tcache.ifb->l_ip.num_search_ports;
-	    	tcache.ifb->tdp_stats = tcache.ifb->stats_t;
-
-	    	tcache.prefetchb->stats_t.readAc.access  = tcache.prefetchb->l_ip.num_search_ports;
-	    	tcache.prefetchb->stats_t.writeAc.access = tcache.ifb->l_ip.num_search_ports;
-	    	tcache.prefetchb->tdp_stats = tcache.prefetchb->stats_t;
-	    	if (cache_p==Write_back)
-	    	{
-	    		tcache.wbb->stats_t.readAc.access  = tcache.wbb->l_ip.num_search_ports;
-	    		tcache.wbb->stats_t.writeAc.access = tcache.wbb->l_ip.num_search_ports;
-	    		tcache.wbb->tdp_stats = tcache.wbb->stats_t;
-	    	}
-
-
-
-	    	LSQ->stats_t.readAc.access = LSQ->stats_t.writeAc.access = LSQ->l_ip.num_search_ports*coredynp.LSU_duty_cycle;
-	    	LSQ->tdp_stats = LSQ->stats_t;
-	    	if ((coredynp.core_ty==OOO) && (XML->sys.core[ithCore].load_buffer_size >0))
-	    	{
-	    		LoadQ->stats_t.readAc.access = LoadQ->stats_t.writeAc.access = LoadQ->l_ip.num_search_ports*coredynp.LSU_duty_cycle;
-	    		LoadQ->tdp_stats = LoadQ->stats_t;
-	    	}
-	    }
-	    else
-	    {
-	    	//init stats for Runtime Dynamic (RTP)
-
-	    	sharedmemory.caches->stats_t.readAc.access  = XML->sys.core[ithCore].sharedmemory.read_accesses;
-	    	sharedmemory.caches->stats_t.readAc.miss    = XML->sys.core[ithCore].sharedmemory.read_misses;
-	    	sharedmemory.caches->stats_t.readAc.hit     = sharedmemory.caches->stats_t.readAc.access - sharedmemory.caches->stats_t.readAc.miss;
-	    	sharedmemory.caches->stats_t.writeAc.access = XML->sys.core[ithCore].sharedmemory.write_accesses;
-	    	sharedmemory.caches->stats_t.writeAc.miss   = XML->sys.core[ithCore].sharedmemory.write_misses;
-    		sharedmemory.caches->stats_t.writeAc.hit    = sharedmemory.caches->stats_t.writeAc.access -	sharedmemory.caches->stats_t.writeAc.miss;
-	    	sharedmemory.caches->rtp_stats = sharedmemory.caches->stats_t;
-
-
-
-	    	dcache.caches->stats_t.readAc.access  = XML->sys.core[ithCore].dcache.read_accesses;
-	    	dcache.caches->stats_t.readAc.miss    = XML->sys.core[ithCore].dcache.read_misses;
-	    	dcache.caches->stats_t.readAc.hit     = dcache.caches->stats_t.readAc.access - dcache.caches->stats_t.readAc.miss;
-	    	dcache.caches->stats_t.writeAc.access = XML->sys.core[ithCore].dcache.write_accesses;
-	    	dcache.caches->stats_t.writeAc.miss   = XML->sys.core[ithCore].dcache.write_misses;
-    		dcache.caches->stats_t.writeAc.hit    = dcache.caches->stats_t.writeAc.access -	dcache.caches->stats_t.writeAc.miss;
-	    	dcache.caches->rtp_stats = dcache.caches->stats_t;
-
-	    	ccache.caches->stats_t.readAc.access  = XML->sys.core[ithCore].ccache.read_accesses;
-	    	ccache.caches->stats_t.readAc.miss    = XML->sys.core[ithCore].ccache.read_misses;
-	    	ccache.caches->stats_t.readAc.hit     = ccache.caches->stats_t.readAc.access - ccache.caches->stats_t.readAc.miss;
-	    	ccache.caches->stats_t.writeAc.access = XML->sys.core[ithCore].ccache.write_accesses;
-	    	ccache.caches->stats_t.writeAc.miss   = XML->sys.core[ithCore].ccache.write_misses;
-    		ccache.caches->stats_t.writeAc.hit    = ccache.caches->stats_t.writeAc.access -	ccache.caches->stats_t.writeAc.miss;
-	    	ccache.caches->rtp_stats = ccache.caches->stats_t;
-
-	    	tcache.caches->stats_t.readAc.access  = XML->sys.core[ithCore].tcache.read_accesses;
-	    	tcache.caches->stats_t.readAc.miss    = XML->sys.core[ithCore].tcache.read_misses;
-	    	tcache.caches->stats_t.readAc.hit     = tcache.caches->stats_t.readAc.access - tcache.caches->stats_t.readAc.miss;
-	    	tcache.caches->stats_t.writeAc.access = XML->sys.core[ithCore].tcache.write_accesses;
-	    	tcache.caches->stats_t.writeAc.miss   = XML->sys.core[ithCore].tcache.write_misses;
-    		tcache.caches->stats_t.writeAc.hit    = tcache.caches->stats_t.writeAc.access -	tcache.caches->stats_t.writeAc.miss;
-	    	tcache.caches->rtp_stats = tcache.caches->stats_t;
-
-	    	if (cache_p==Write_back)
-	    	{
-
-	    		sharedmemory.missb->stats_t.readAc.access  = sharedmemory.caches->stats_t.writeAc.miss;
-	    		sharedmemory.missb->stats_t.writeAc.access = sharedmemory.caches->stats_t.writeAc.miss;
-	    		sharedmemory.missb->rtp_stats = sharedmemory.missb->stats_t;
-	    		sharedmemory.ifb->stats_t.readAc.access  = sharedmemory.caches->stats_t.writeAc.miss;
-	    		sharedmemory.ifb->stats_t.writeAc.access = sharedmemory.caches->stats_t.writeAc.miss;
-	    		sharedmemory.ifb->rtp_stats = sharedmemory.ifb->stats_t;
-	    		sharedmemory.prefetchb->stats_t.readAc.access  = sharedmemory.caches->stats_t.writeAc.miss;
-	    		sharedmemory.prefetchb->stats_t.writeAc.access = sharedmemory.caches->stats_t.writeAc.miss;
-	    		sharedmemory.prefetchb->rtp_stats = sharedmemory.prefetchb->stats_t;
-	    		sharedmemory.wbb->stats_t.readAc.access  = sharedmemory.caches->stats_t.writeAc.miss;
-	    		sharedmemory.wbb->stats_t.writeAc.access = sharedmemory.caches->stats_t.writeAc.miss;
-	    		sharedmemory.wbb->rtp_stats = sharedmemory.wbb->stats_t;
-
-
-	    		dcache.missb->stats_t.readAc.access  = dcache.caches->stats_t.writeAc.miss;
-	    		dcache.missb->stats_t.writeAc.access = dcache.caches->stats_t.writeAc.miss;
-	    		dcache.missb->rtp_stats = dcache.missb->stats_t;
-	    		dcache.ifb->stats_t.readAc.access  = dcache.caches->stats_t.writeAc.miss;
-	    		dcache.ifb->stats_t.writeAc.access = dcache.caches->stats_t.writeAc.miss;
-	    		dcache.ifb->rtp_stats = dcache.ifb->stats_t;
-	    		dcache.prefetchb->stats_t.readAc.access  = dcache.caches->stats_t.writeAc.miss;
-	    		dcache.prefetchb->stats_t.writeAc.access = dcache.caches->stats_t.writeAc.miss;
-	    		dcache.prefetchb->rtp_stats = dcache.prefetchb->stats_t;
-	    		dcache.wbb->stats_t.readAc.access  = dcache.caches->stats_t.writeAc.miss;
-	    		dcache.wbb->stats_t.writeAc.access = dcache.caches->stats_t.writeAc.miss;
-	    		dcache.wbb->rtp_stats = dcache.wbb->stats_t;
-
-	    		ccache.missb->stats_t.readAc.access  = ccache.caches->stats_t.writeAc.miss;
-	    		ccache.missb->stats_t.writeAc.access = ccache.caches->stats_t.writeAc.miss;
-	    		ccache.missb->rtp_stats = ccache.missb->stats_t;
-	    		ccache.ifb->stats_t.readAc.access  = ccache.caches->stats_t.writeAc.miss;
-	    		ccache.ifb->stats_t.writeAc.access = ccache.caches->stats_t.writeAc.miss;
-	    		ccache.ifb->rtp_stats = ccache.ifb->stats_t;
-	    		ccache.prefetchb->stats_t.readAc.access  = ccache.caches->stats_t.writeAc.miss;
-	    		ccache.prefetchb->stats_t.writeAc.access = ccache.caches->stats_t.writeAc.miss;
-	    		ccache.prefetchb->rtp_stats = ccache.prefetchb->stats_t;
-	    		ccache.wbb->stats_t.readAc.access  = ccache.caches->stats_t.writeAc.miss;
-	    		ccache.wbb->stats_t.writeAc.access = ccache.caches->stats_t.writeAc.miss;
-	    		ccache.wbb->rtp_stats = ccache.wbb->stats_t;
-
-	    		tcache.missb->stats_t.readAc.access  = tcache.caches->stats_t.writeAc.miss;
-	    		tcache.missb->stats_t.writeAc.access = tcache.caches->stats_t.writeAc.miss;
-	    		tcache.missb->rtp_stats = tcache.missb->stats_t;
-	    		tcache.ifb->stats_t.readAc.access  = tcache.caches->stats_t.writeAc.miss;
-	    		tcache.ifb->stats_t.writeAc.access = tcache.caches->stats_t.writeAc.miss;
-	    		tcache.ifb->rtp_stats = tcache.ifb->stats_t;
-	    		tcache.prefetchb->stats_t.readAc.access  = tcache.caches->stats_t.writeAc.miss;
-	    		tcache.prefetchb->stats_t.writeAc.access = tcache.caches->stats_t.writeAc.miss;
-	    		tcache.prefetchb->rtp_stats = tcache.prefetchb->stats_t;
-	    		tcache.wbb->stats_t.readAc.access  = tcache.caches->stats_t.writeAc.miss;
-	    		tcache.wbb->stats_t.writeAc.access = tcache.caches->stats_t.writeAc.miss;
-	    		tcache.wbb->rtp_stats = tcache.wbb->stats_t;
-	    	}
-	    	else
-	    	{
-	    		sharedmemory.missb->stats_t.readAc.access  = sharedmemory.caches->stats_t.readAc.miss;
-	    		sharedmemory.missb->stats_t.writeAc.access = sharedmemory.caches->stats_t.readAc.miss;
-	    		sharedmemory.missb->rtp_stats = sharedmemory.missb->stats_t;
-	    		sharedmemory.ifb->stats_t.readAc.access  = sharedmemory.caches->stats_t.readAc.miss;
-	    		sharedmemory.ifb->stats_t.writeAc.access = sharedmemory.caches->stats_t.readAc.miss;
-	    		sharedmemory.ifb->rtp_stats = sharedmemory.ifb->stats_t;
-	    		sharedmemory.prefetchb->stats_t.readAc.access  = sharedmemory.caches->stats_t.readAc.miss;
-	    		sharedmemory.prefetchb->stats_t.writeAc.access = sharedmemory.caches->stats_t.readAc.miss;
-	    		sharedmemory.prefetchb->rtp_stats = sharedmemory.prefetchb->stats_t;
-
-
-	    		dcache.missb->stats_t.readAc.access  = dcache.caches->stats_t.readAc.miss;
-	    		dcache.missb->stats_t.writeAc.access = dcache.caches->stats_t.readAc.miss;
-	    		dcache.missb->rtp_stats = dcache.missb->stats_t;
-	    		dcache.ifb->stats_t.readAc.access  = dcache.caches->stats_t.readAc.miss;
-	    		dcache.ifb->stats_t.writeAc.access = dcache.caches->stats_t.readAc.miss;
-	    		dcache.ifb->rtp_stats = dcache.ifb->stats_t;
-	    		dcache.prefetchb->stats_t.readAc.access  = dcache.caches->stats_t.readAc.miss;
-	    		dcache.prefetchb->stats_t.writeAc.access = dcache.caches->stats_t.readAc.miss;
-	    		dcache.prefetchb->rtp_stats = dcache.prefetchb->stats_t;
-
-
-	    		ccache.missb->stats_t.readAc.access  = ccache.caches->stats_t.readAc.miss;
-	    		ccache.missb->stats_t.writeAc.access = ccache.caches->stats_t.readAc.miss;
-	    		ccache.missb->rtp_stats = ccache.missb->stats_t;
-	    		ccache.ifb->stats_t.readAc.access  = ccache.caches->stats_t.readAc.miss;
-	    		ccache.ifb->stats_t.writeAc.access = ccache.caches->stats_t.readAc.miss;
-	    		ccache.ifb->rtp_stats = ccache.ifb->stats_t;
-	    		ccache.prefetchb->stats_t.readAc.access  = ccache.caches->stats_t.readAc.miss;
-	    		ccache.prefetchb->stats_t.writeAc.access = ccache.caches->stats_t.readAc.miss;
-	    		ccache.prefetchb->rtp_stats = ccache.prefetchb->stats_t;
-
-	    		tcache.missb->stats_t.readAc.access  = tcache.caches->stats_t.readAc.miss;
-	    		tcache.missb->stats_t.writeAc.access = tcache.caches->stats_t.readAc.miss;
-	    		tcache.missb->rtp_stats = tcache.missb->stats_t;
-	    		tcache.ifb->stats_t.readAc.access  = tcache.caches->stats_t.readAc.miss;
-	    		tcache.ifb->stats_t.writeAc.access = tcache.caches->stats_t.readAc.miss;
-	    		tcache.ifb->rtp_stats = tcache.ifb->stats_t;
-	    		tcache.prefetchb->stats_t.readAc.access  = tcache.caches->stats_t.readAc.miss;
-	    		tcache.prefetchb->stats_t.writeAc.access = tcache.caches->stats_t.readAc.miss;
-	    		tcache.prefetchb->rtp_stats = tcache.prefetchb->stats_t;
-
-	    	}
-
-	    	LSQ->stats_t.readAc.access  = (XML->sys.core[ithCore].load_instructions + XML->sys.core[ithCore].store_instructions)*2;//flush overhead considered
-	    	LSQ->stats_t.writeAc.access = (XML->sys.core[ithCore].load_instructions + XML->sys.core[ithCore].store_instructions)*2;
-	    	LSQ->rtp_stats = LSQ->stats_t;
-
-	    	if ((coredynp.core_ty==OOO) && (XML->sys.core[ithCore].load_buffer_size >0))
-	    	{
-		    	LoadQ->stats_t.readAc.access  = XML->sys.core[ithCore].load_instructions + XML->sys.core[ithCore].store_instructions;
-		    	LoadQ->stats_t.writeAc.access = XML->sys.core[ithCore].load_instructions + XML->sys.core[ithCore].store_instructions;
-		    	LoadQ->rtp_stats = LoadQ->stats_t;
-	    	}
-
-	    }
-
-	sharedmemory.power_t.reset();
-	dcache.power_t.reset();
-	ccache.power_t.reset();
-	tcache.power_t.reset();
-	LSQ->power_t.reset();
-
-    sharedmemory.power_t.readOp.dynamic	+= (sharedmemory.caches->stats_t.readAc.hit*sharedmemory.caches->local_result.power.readOp.dynamic+
-    		sharedmemory.caches->stats_t.readAc.miss*sharedmemory.caches->local_result.power.readOp.dynamic+
-    		sharedmemory.caches->stats_t.writeAc.miss*sharedmemory.caches->local_result.tag_array2->power.readOp.dynamic+
-    		sharedmemory.caches->stats_t.writeAc.access*sharedmemory.caches->local_result.power.writeOp.dynamic +
-			xbar_shared->power.readOp.dynamic*(sharedmemory.caches->stats_t.readAc.hit+ sharedmemory.caches->stats_t.writeAc.hit));
-
-
-    dcache.power_t.readOp.dynamic	+= (dcache.caches->stats_t.readAc.hit*dcache.caches->local_result.power.readOp.dynamic+
-    		dcache.caches->stats_t.readAc.miss*dcache.caches->local_result.power.readOp.dynamic+
-    		dcache.caches->stats_t.writeAc.miss*dcache.caches->local_result.tag_array2->power.readOp.dynamic+
-    		dcache.caches->stats_t.writeAc.access*dcache.caches->local_result.power.writeOp.dynamic +
-			xbar_shared->power.readOp.dynamic*(dcache.caches->stats_t.readAc.hit+ dcache.caches->stats_t.writeAc.hit));
-    ccache.power_t.readOp.dynamic	+= (ccache.caches->stats_t.readAc.hit*ccache.caches->local_result.power.readOp.dynamic+
-    		ccache.caches->stats_t.readAc.miss*ccache.caches->local_result.power.readOp.dynamic+
-    		ccache.caches->stats_t.writeAc.miss*ccache.caches->local_result.tag_array2->power.readOp.dynamic+
-    		ccache.caches->stats_t.writeAc.access*ccache.caches->local_result.power.writeOp.dynamic + 
-			xbar_shared->power.readOp.dynamic*(ccache.caches->stats_t.readAc.hit));
-
-    tcache.power_t.readOp.dynamic	+= (tcache.caches->stats_t.readAc.hit*tcache.caches->local_result.power.readOp.dynamic+
-    		tcache.caches->stats_t.readAc.miss*tcache.caches->local_result.power.readOp.dynamic+
-    		tcache.caches->stats_t.writeAc.miss*tcache.caches->local_result.tag_array2->power.readOp.dynamic+
-    		tcache.caches->stats_t.writeAc.access*tcache.caches->local_result.power.writeOp.dynamic+
-			xbar_shared->power.readOp.dynamic*(tcache.caches->stats_t.readAc.hit+ tcache.caches->stats_t.writeAc.hit));
-
-    if (cache_p==Write_back)
-    {//write miss will generate a write later
-    	dcache.power_t.readOp.dynamic	+= dcache.caches->stats_t.writeAc.miss*dcache.caches->local_result.power.writeOp.dynamic;
-    	ccache.power_t.readOp.dynamic	+= ccache.caches->stats_t.writeAc.miss*ccache.caches->local_result.power.writeOp.dynamic;
-    	tcache.power_t.readOp.dynamic	+= tcache.caches->stats_t.writeAc.miss*tcache.caches->local_result.power.writeOp.dynamic;
-    	sharedmemory.power_t.readOp.dynamic	+= sharedmemory.caches->stats_t.writeAc.miss*sharedmemory.caches->local_result.power.writeOp.dynamic;
+    // init stats for Peak
+    dcache.caches->stats_t.readAc.access =
+        0.67 * dcache.caches->l_ip.num_rw_ports * coredynp.LSU_duty_cycle;
+    dcache.caches->stats_t.readAc.miss = 0;
+    dcache.caches->stats_t.readAc.hit = dcache.caches->stats_t.readAc.access -
+                                        dcache.caches->stats_t.readAc.miss;
+    dcache.caches->stats_t.writeAc.access =
+        0.33 * dcache.caches->l_ip.num_rw_ports * coredynp.LSU_duty_cycle;
+    dcache.caches->stats_t.writeAc.miss = 0;
+    dcache.caches->stats_t.writeAc.hit = dcache.caches->stats_t.writeAc.access -
+                                         dcache.caches->stats_t.writeAc.miss;
+    dcache.caches->tdp_stats = dcache.caches->stats_t;
+
+    dcache.missb->stats_t.readAc.access = dcache.missb->l_ip.num_search_ports;
+    dcache.missb->stats_t.writeAc.access = dcache.missb->l_ip.num_search_ports;
+    dcache.missb->tdp_stats = dcache.missb->stats_t;
+
+    dcache.ifb->stats_t.readAc.access = dcache.ifb->l_ip.num_search_ports;
+    dcache.ifb->stats_t.writeAc.access = dcache.ifb->l_ip.num_search_ports;
+    dcache.ifb->tdp_stats = dcache.ifb->stats_t;
+
+    dcache.prefetchb->stats_t.readAc.access =
+        dcache.prefetchb->l_ip.num_search_ports;
+    dcache.prefetchb->stats_t.writeAc.access =
+        dcache.ifb->l_ip.num_search_ports;
+    dcache.prefetchb->tdp_stats = dcache.prefetchb->stats_t;
+    if (cache_p == Write_back) {
+      dcache.wbb->stats_t.readAc.access = dcache.wbb->l_ip.num_search_ports;
+      dcache.wbb->stats_t.writeAc.access = dcache.wbb->l_ip.num_search_ports;
+      dcache.wbb->tdp_stats = dcache.wbb->stats_t;
     }
 
+    // init stats for Peak - ccache
+    ccache.caches->stats_t.readAc.access =
+        0.67 * ccache.caches->l_ip.num_rw_ports * coredynp.LSU_duty_cycle;
+    ccache.caches->stats_t.readAc.miss = 0;
+    ccache.caches->stats_t.readAc.hit = ccache.caches->stats_t.readAc.access -
+                                        ccache.caches->stats_t.readAc.miss;
+    ccache.caches->stats_t.writeAc.access =
+        0.33 * ccache.caches->l_ip.num_rw_ports * coredynp.LSU_duty_cycle;
+    ccache.caches->stats_t.writeAc.miss = 0;
+    ccache.caches->stats_t.writeAc.hit = ccache.caches->stats_t.writeAc.access -
+                                         ccache.caches->stats_t.writeAc.miss;
+    ccache.caches->tdp_stats = ccache.caches->stats_t;
 
-    sharedmemory.power_t.readOp.dynamic	+=  sharedmemory.missb->stats_t.readAc.access*sharedmemory.missb->local_result.power.searchOp.dynamic +
-            sharedmemory.missb->stats_t.writeAc.access*sharedmemory.missb->local_result.power.writeOp.dynamic;//each access to missb involves a CAM and a write
-    sharedmemory.power_t.readOp.dynamic	+=  sharedmemory.ifb->stats_t.readAc.access*sharedmemory.ifb->local_result.power.searchOp.dynamic +
-            sharedmemory.ifb->stats_t.writeAc.access*sharedmemory.ifb->local_result.power.writeOp.dynamic;
-    sharedmemory.power_t.readOp.dynamic	+=  sharedmemory.prefetchb->stats_t.readAc.access*sharedmemory.prefetchb->local_result.power.searchOp.dynamic +
-            sharedmemory.prefetchb->stats_t.writeAc.access*sharedmemory.prefetchb->local_result.power.writeOp.dynamic;
-    if (cache_p==Write_back)
+    ccache.missb->stats_t.readAc.access = ccache.missb->l_ip.num_search_ports;
+    ccache.missb->stats_t.writeAc.access = ccache.missb->l_ip.num_search_ports;
+    ccache.missb->tdp_stats = ccache.missb->stats_t;
+
+    ccache.ifb->stats_t.readAc.access = ccache.ifb->l_ip.num_search_ports;
+    ccache.ifb->stats_t.writeAc.access = ccache.ifb->l_ip.num_search_ports;
+    ccache.ifb->tdp_stats = ccache.ifb->stats_t;
+
+    ccache.prefetchb->stats_t.readAc.access =
+        ccache.prefetchb->l_ip.num_search_ports;
+    ccache.prefetchb->stats_t.writeAc.access =
+        ccache.ifb->l_ip.num_search_ports;
+    ccache.prefetchb->tdp_stats = ccache.prefetchb->stats_t;
+    if (cache_p == Write_back) {
+      ccache.wbb->stats_t.readAc.access = ccache.wbb->l_ip.num_search_ports;
+      ccache.wbb->stats_t.writeAc.access = ccache.wbb->l_ip.num_search_ports;
+      ccache.wbb->tdp_stats = ccache.wbb->stats_t;
+    }
+
+    // init stats for Peak - tcache
+    tcache.caches->stats_t.readAc.access =
+        0.67 * tcache.caches->l_ip.num_rw_ports * coredynp.LSU_duty_cycle;
+    tcache.caches->stats_t.readAc.miss = 0;
+    tcache.caches->stats_t.readAc.hit = tcache.caches->stats_t.readAc.access -
+                                        tcache.caches->stats_t.readAc.miss;
+    tcache.caches->stats_t.writeAc.access =
+        0.33 * tcache.caches->l_ip.num_rw_ports * coredynp.LSU_duty_cycle;
+    tcache.caches->stats_t.writeAc.miss = 0;
+    tcache.caches->stats_t.writeAc.hit = tcache.caches->stats_t.writeAc.access -
+                                         tcache.caches->stats_t.writeAc.miss;
+    tcache.caches->tdp_stats = tcache.caches->stats_t;
+
+    tcache.missb->stats_t.readAc.access = tcache.missb->l_ip.num_search_ports;
+    tcache.missb->stats_t.writeAc.access = tcache.missb->l_ip.num_search_ports;
+    tcache.missb->tdp_stats = tcache.missb->stats_t;
+
+    tcache.ifb->stats_t.readAc.access = tcache.ifb->l_ip.num_search_ports;
+    tcache.ifb->stats_t.writeAc.access = tcache.ifb->l_ip.num_search_ports;
+    tcache.ifb->tdp_stats = tcache.ifb->stats_t;
+
+    tcache.prefetchb->stats_t.readAc.access =
+        tcache.prefetchb->l_ip.num_search_ports;
+    tcache.prefetchb->stats_t.writeAc.access =
+        tcache.ifb->l_ip.num_search_ports;
+    tcache.prefetchb->tdp_stats = tcache.prefetchb->stats_t;
+    if (cache_p == Write_back) {
+      tcache.wbb->stats_t.readAc.access = tcache.wbb->l_ip.num_search_ports;
+      tcache.wbb->stats_t.writeAc.access = tcache.wbb->l_ip.num_search_ports;
+      tcache.wbb->tdp_stats = tcache.wbb->stats_t;
+    }
+
+    LSQ->stats_t.readAc.access = LSQ->stats_t.writeAc.access =
+        LSQ->l_ip.num_search_ports * coredynp.LSU_duty_cycle;
+    LSQ->tdp_stats = LSQ->stats_t;
+    if ((coredynp.core_ty == OOO) &&
+        (XML->sys.core[ithCore].load_buffer_size > 0)) {
+      LoadQ->stats_t.readAc.access = LoadQ->stats_t.writeAc.access =
+          LoadQ->l_ip.num_search_ports * coredynp.LSU_duty_cycle;
+      LoadQ->tdp_stats = LoadQ->stats_t;
+    }
+  } else {
+    // init stats for Runtime Dynamic (RTP)
+
+    sharedmemory.caches->stats_t.readAc.access =
+        XML->sys.core[ithCore].sharedmemory.read_accesses;
+    sharedmemory.caches->stats_t.readAc.miss =
+        XML->sys.core[ithCore].sharedmemory.read_misses;
+    sharedmemory.caches->stats_t.readAc.hit =
+        sharedmemory.caches->stats_t.readAc.access -
+        sharedmemory.caches->stats_t.readAc.miss;
+    sharedmemory.caches->stats_t.writeAc.access =
+        XML->sys.core[ithCore].sharedmemory.write_accesses;
+    sharedmemory.caches->stats_t.writeAc.miss =
+        XML->sys.core[ithCore].sharedmemory.write_misses;
+    sharedmemory.caches->stats_t.writeAc.hit =
+        sharedmemory.caches->stats_t.writeAc.access -
+        sharedmemory.caches->stats_t.writeAc.miss;
+    sharedmemory.caches->rtp_stats = sharedmemory.caches->stats_t;
+
+    dcache.caches->stats_t.readAc.access =
+        XML->sys.core[ithCore].dcache.read_accesses;
+    dcache.caches->stats_t.readAc.miss =
+        XML->sys.core[ithCore].dcache.read_misses;
+    dcache.caches->stats_t.readAc.hit = dcache.caches->stats_t.readAc.access -
+                                        dcache.caches->stats_t.readAc.miss;
+    dcache.caches->stats_t.writeAc.access =
+        XML->sys.core[ithCore].dcache.write_accesses;
+    dcache.caches->stats_t.writeAc.miss =
+        XML->sys.core[ithCore].dcache.write_misses;
+    dcache.caches->stats_t.writeAc.hit = dcache.caches->stats_t.writeAc.access -
+                                         dcache.caches->stats_t.writeAc.miss;
+    dcache.caches->rtp_stats = dcache.caches->stats_t;
+
+    ccache.caches->stats_t.readAc.access =
+        XML->sys.core[ithCore].ccache.read_accesses;
+    ccache.caches->stats_t.readAc.miss =
+        XML->sys.core[ithCore].ccache.read_misses;
+    ccache.caches->stats_t.readAc.hit = ccache.caches->stats_t.readAc.access -
+                                        ccache.caches->stats_t.readAc.miss;
+    ccache.caches->stats_t.writeAc.access =
+        XML->sys.core[ithCore].ccache.write_accesses;
+    ccache.caches->stats_t.writeAc.miss =
+        XML->sys.core[ithCore].ccache.write_misses;
+    ccache.caches->stats_t.writeAc.hit = ccache.caches->stats_t.writeAc.access -
+                                         ccache.caches->stats_t.writeAc.miss;
+    ccache.caches->rtp_stats = ccache.caches->stats_t;
+
+    tcache.caches->stats_t.readAc.access =
+        XML->sys.core[ithCore].tcache.read_accesses;
+    tcache.caches->stats_t.readAc.miss =
+        XML->sys.core[ithCore].tcache.read_misses;
+    tcache.caches->stats_t.readAc.hit = tcache.caches->stats_t.readAc.access -
+                                        tcache.caches->stats_t.readAc.miss;
+    tcache.caches->stats_t.writeAc.access =
+        XML->sys.core[ithCore].tcache.write_accesses;
+    tcache.caches->stats_t.writeAc.miss =
+        XML->sys.core[ithCore].tcache.write_misses;
+    tcache.caches->stats_t.writeAc.hit = tcache.caches->stats_t.writeAc.access -
+                                         tcache.caches->stats_t.writeAc.miss;
+    tcache.caches->rtp_stats = tcache.caches->stats_t;
+
+    if (cache_p == Write_back) {
+      sharedmemory.missb->stats_t.readAc.access =
+          sharedmemory.caches->stats_t.writeAc.miss;
+      sharedmemory.missb->stats_t.writeAc.access =
+          sharedmemory.caches->stats_t.writeAc.miss;
+      sharedmemory.missb->rtp_stats = sharedmemory.missb->stats_t;
+      sharedmemory.ifb->stats_t.readAc.access =
+          sharedmemory.caches->stats_t.writeAc.miss;
+      sharedmemory.ifb->stats_t.writeAc.access =
+          sharedmemory.caches->stats_t.writeAc.miss;
+      sharedmemory.ifb->rtp_stats = sharedmemory.ifb->stats_t;
+      sharedmemory.prefetchb->stats_t.readAc.access =
+          sharedmemory.caches->stats_t.writeAc.miss;
+      sharedmemory.prefetchb->stats_t.writeAc.access =
+          sharedmemory.caches->stats_t.writeAc.miss;
+      sharedmemory.prefetchb->rtp_stats = sharedmemory.prefetchb->stats_t;
+      sharedmemory.wbb->stats_t.readAc.access =
+          sharedmemory.caches->stats_t.writeAc.miss;
+      sharedmemory.wbb->stats_t.writeAc.access =
+          sharedmemory.caches->stats_t.writeAc.miss;
+      sharedmemory.wbb->rtp_stats = sharedmemory.wbb->stats_t;
+
+      dcache.missb->stats_t.readAc.access = dcache.caches->stats_t.writeAc.miss;
+      dcache.missb->stats_t.writeAc.access =
+          dcache.caches->stats_t.writeAc.miss;
+      dcache.missb->rtp_stats = dcache.missb->stats_t;
+      dcache.ifb->stats_t.readAc.access = dcache.caches->stats_t.writeAc.miss;
+      dcache.ifb->stats_t.writeAc.access = dcache.caches->stats_t.writeAc.miss;
+      dcache.ifb->rtp_stats = dcache.ifb->stats_t;
+      dcache.prefetchb->stats_t.readAc.access =
+          dcache.caches->stats_t.writeAc.miss;
+      dcache.prefetchb->stats_t.writeAc.access =
+          dcache.caches->stats_t.writeAc.miss;
+      dcache.prefetchb->rtp_stats = dcache.prefetchb->stats_t;
+      dcache.wbb->stats_t.readAc.access = dcache.caches->stats_t.writeAc.miss;
+      dcache.wbb->stats_t.writeAc.access = dcache.caches->stats_t.writeAc.miss;
+      dcache.wbb->rtp_stats = dcache.wbb->stats_t;
+
+      ccache.missb->stats_t.readAc.access = ccache.caches->stats_t.writeAc.miss;
+      ccache.missb->stats_t.writeAc.access =
+          ccache.caches->stats_t.writeAc.miss;
+      ccache.missb->rtp_stats = ccache.missb->stats_t;
+      ccache.ifb->stats_t.readAc.access = ccache.caches->stats_t.writeAc.miss;
+      ccache.ifb->stats_t.writeAc.access = ccache.caches->stats_t.writeAc.miss;
+      ccache.ifb->rtp_stats = ccache.ifb->stats_t;
+      ccache.prefetchb->stats_t.readAc.access =
+          ccache.caches->stats_t.writeAc.miss;
+      ccache.prefetchb->stats_t.writeAc.access =
+          ccache.caches->stats_t.writeAc.miss;
+      ccache.prefetchb->rtp_stats = ccache.prefetchb->stats_t;
+      ccache.wbb->stats_t.readAc.access = ccache.caches->stats_t.writeAc.miss;
+      ccache.wbb->stats_t.writeAc.access = ccache.caches->stats_t.writeAc.miss;
+      ccache.wbb->rtp_stats = ccache.wbb->stats_t;
+
+      tcache.missb->stats_t.readAc.access = tcache.caches->stats_t.writeAc.miss;
+      tcache.missb->stats_t.writeAc.access =
+          tcache.caches->stats_t.writeAc.miss;
+      tcache.missb->rtp_stats = tcache.missb->stats_t;
+      tcache.ifb->stats_t.readAc.access = tcache.caches->stats_t.writeAc.miss;
+      tcache.ifb->stats_t.writeAc.access = tcache.caches->stats_t.writeAc.miss;
+      tcache.ifb->rtp_stats = tcache.ifb->stats_t;
+      tcache.prefetchb->stats_t.readAc.access =
+          tcache.caches->stats_t.writeAc.miss;
+      tcache.prefetchb->stats_t.writeAc.access =
+          tcache.caches->stats_t.writeAc.miss;
+      tcache.prefetchb->rtp_stats = tcache.prefetchb->stats_t;
+      tcache.wbb->stats_t.readAc.access = tcache.caches->stats_t.writeAc.miss;
+      tcache.wbb->stats_t.writeAc.access = tcache.caches->stats_t.writeAc.miss;
+      tcache.wbb->rtp_stats = tcache.wbb->stats_t;
+    } else {
+      sharedmemory.missb->stats_t.readAc.access =
+          sharedmemory.caches->stats_t.readAc.miss;
+      sharedmemory.missb->stats_t.writeAc.access =
+          sharedmemory.caches->stats_t.readAc.miss;
+      sharedmemory.missb->rtp_stats = sharedmemory.missb->stats_t;
+      sharedmemory.ifb->stats_t.readAc.access =
+          sharedmemory.caches->stats_t.readAc.miss;
+      sharedmemory.ifb->stats_t.writeAc.access =
+          sharedmemory.caches->stats_t.readAc.miss;
+      sharedmemory.ifb->rtp_stats = sharedmemory.ifb->stats_t;
+      sharedmemory.prefetchb->stats_t.readAc.access =
+          sharedmemory.caches->stats_t.readAc.miss;
+      sharedmemory.prefetchb->stats_t.writeAc.access =
+          sharedmemory.caches->stats_t.readAc.miss;
+      sharedmemory.prefetchb->rtp_stats = sharedmemory.prefetchb->stats_t;
+
+      dcache.missb->stats_t.readAc.access = dcache.caches->stats_t.readAc.miss;
+      dcache.missb->stats_t.writeAc.access = dcache.caches->stats_t.readAc.miss;
+      dcache.missb->rtp_stats = dcache.missb->stats_t;
+      dcache.ifb->stats_t.readAc.access = dcache.caches->stats_t.readAc.miss;
+      dcache.ifb->stats_t.writeAc.access = dcache.caches->stats_t.readAc.miss;
+      dcache.ifb->rtp_stats = dcache.ifb->stats_t;
+      dcache.prefetchb->stats_t.readAc.access =
+          dcache.caches->stats_t.readAc.miss;
+      dcache.prefetchb->stats_t.writeAc.access =
+          dcache.caches->stats_t.readAc.miss;
+      dcache.prefetchb->rtp_stats = dcache.prefetchb->stats_t;
+
+      ccache.missb->stats_t.readAc.access = ccache.caches->stats_t.readAc.miss;
+      ccache.missb->stats_t.writeAc.access = ccache.caches->stats_t.readAc.miss;
+      ccache.missb->rtp_stats = ccache.missb->stats_t;
+      ccache.ifb->stats_t.readAc.access = ccache.caches->stats_t.readAc.miss;
+      ccache.ifb->stats_t.writeAc.access = ccache.caches->stats_t.readAc.miss;
+      ccache.ifb->rtp_stats = ccache.ifb->stats_t;
+      ccache.prefetchb->stats_t.readAc.access =
+          ccache.caches->stats_t.readAc.miss;
+      ccache.prefetchb->stats_t.writeAc.access =
+          ccache.caches->stats_t.readAc.miss;
+      ccache.prefetchb->rtp_stats = ccache.prefetchb->stats_t;
+
+      tcache.missb->stats_t.readAc.access = tcache.caches->stats_t.readAc.miss;
+      tcache.missb->stats_t.writeAc.access = tcache.caches->stats_t.readAc.miss;
+      tcache.missb->rtp_stats = tcache.missb->stats_t;
+      tcache.ifb->stats_t.readAc.access = tcache.caches->stats_t.readAc.miss;
+      tcache.ifb->stats_t.writeAc.access = tcache.caches->stats_t.readAc.miss;
+      tcache.ifb->rtp_stats = tcache.ifb->stats_t;
+      tcache.prefetchb->stats_t.readAc.access =
+          tcache.caches->stats_t.readAc.miss;
+      tcache.prefetchb->stats_t.writeAc.access =
+          tcache.caches->stats_t.readAc.miss;
+      tcache.prefetchb->rtp_stats = tcache.prefetchb->stats_t;
+    }
+
+    LSQ->stats_t.readAc.access = (XML->sys.core[ithCore].load_instructions +
+                                  XML->sys.core[ithCore].store_instructions) *
+                                 2;  // flush overhead considered
+    LSQ->stats_t.writeAc.access = (XML->sys.core[ithCore].load_instructions +
+                                   XML->sys.core[ithCore].store_instructions) *
+                                  2;
+    LSQ->rtp_stats = LSQ->stats_t;
+
+    if ((coredynp.core_ty == OOO) &&
+        (XML->sys.core[ithCore].load_buffer_size > 0)) {
+      LoadQ->stats_t.readAc.access = XML->sys.core[ithCore].load_instructions +
+                                     XML->sys.core[ithCore].store_instructions;
+      LoadQ->stats_t.writeAc.access = XML->sys.core[ithCore].load_instructions +
+                                      XML->sys.core[ithCore].store_instructions;
+      LoadQ->rtp_stats = LoadQ->stats_t;
+    }
+  }
+
+  sharedmemory.power_t.reset();
+  dcache.power_t.reset();
+  ccache.power_t.reset();
+  tcache.power_t.reset();
+  LSQ->power_t.reset();
+
+  sharedmemory.power_t.readOp.dynamic +=
+      (sharedmemory.caches->stats_t.readAc.hit *
+           sharedmemory.caches->local_result.power.readOp.dynamic +
+       sharedmemory.caches->stats_t.readAc.miss *
+           sharedmemory.caches->local_result.power.readOp.dynamic +
+       sharedmemory.caches->stats_t.writeAc.miss *
+           sharedmemory.caches->local_result.tag_array2->power.readOp.dynamic +
+       sharedmemory.caches->stats_t.writeAc.access *
+           sharedmemory.caches->local_result.power.writeOp.dynamic +
+       xbar_shared->power.readOp.dynamic *
+           (sharedmemory.caches->stats_t.readAc.hit +
+            sharedmemory.caches->stats_t.writeAc.hit));
+
+  dcache.power_t.readOp.dynamic +=
+      (dcache.caches->stats_t.readAc.hit *
+           dcache.caches->local_result.power.readOp.dynamic +
+       dcache.caches->stats_t.readAc.miss *
+           dcache.caches->local_result.power.readOp.dynamic +
+       dcache.caches->stats_t.writeAc.miss *
+           dcache.caches->local_result.tag_array2->power.readOp.dynamic +
+       dcache.caches->stats_t.writeAc.access *
+           dcache.caches->local_result.power.writeOp.dynamic +
+       xbar_shared->power.readOp.dynamic *
+           (dcache.caches->stats_t.readAc.hit +
+            dcache.caches->stats_t.writeAc.hit));
+  ccache.power_t.readOp.dynamic +=
+      (ccache.caches->stats_t.readAc.hit *
+           ccache.caches->local_result.power.readOp.dynamic +
+       ccache.caches->stats_t.readAc.miss *
+           ccache.caches->local_result.power.readOp.dynamic +
+       ccache.caches->stats_t.writeAc.miss *
+           ccache.caches->local_result.tag_array2->power.readOp.dynamic +
+       ccache.caches->stats_t.writeAc.access *
+           ccache.caches->local_result.power.writeOp.dynamic +
+       xbar_shared->power.readOp.dynamic * (ccache.caches->stats_t.readAc.hit));
+
+  tcache.power_t.readOp.dynamic +=
+      (tcache.caches->stats_t.readAc.hit *
+           tcache.caches->local_result.power.readOp.dynamic +
+       tcache.caches->stats_t.readAc.miss *
+           tcache.caches->local_result.power.readOp.dynamic +
+       tcache.caches->stats_t.writeAc.miss *
+           tcache.caches->local_result.tag_array2->power.readOp.dynamic +
+       tcache.caches->stats_t.writeAc.access *
+           tcache.caches->local_result.power.writeOp.dynamic +
+       xbar_shared->power.readOp.dynamic *
+           (tcache.caches->stats_t.readAc.hit +
+            tcache.caches->stats_t.writeAc.hit));
+
+  if (cache_p == Write_back) {  // write miss will generate a write later
+    dcache.power_t.readOp.dynamic +=
+        dcache.caches->stats_t.writeAc.miss *
+        dcache.caches->local_result.power.writeOp.dynamic;
+    ccache.power_t.readOp.dynamic +=
+        ccache.caches->stats_t.writeAc.miss *
+        ccache.caches->local_result.power.writeOp.dynamic;
+    tcache.power_t.readOp.dynamic +=
+        tcache.caches->stats_t.writeAc.miss *
+        tcache.caches->local_result.power.writeOp.dynamic;
+    sharedmemory.power_t.readOp.dynamic +=
+        sharedmemory.caches->stats_t.writeAc.miss *
+        sharedmemory.caches->local_result.power.writeOp.dynamic;
+  }
+
+  sharedmemory.power_t.readOp.dynamic +=
+      sharedmemory.missb->stats_t.readAc.access *
+          sharedmemory.missb->local_result.power.searchOp.dynamic +
+      sharedmemory.missb->stats_t.writeAc.access *
+          sharedmemory.missb->local_result.power.writeOp
+              .dynamic;  // each access to missb involves a CAM and a write
+  sharedmemory.power_t.readOp.dynamic +=
+      sharedmemory.ifb->stats_t.readAc.access *
+          sharedmemory.ifb->local_result.power.searchOp.dynamic +
+      sharedmemory.ifb->stats_t.writeAc.access *
+          sharedmemory.ifb->local_result.power.writeOp.dynamic;
+  sharedmemory.power_t.readOp.dynamic +=
+      sharedmemory.prefetchb->stats_t.readAc.access *
+          sharedmemory.prefetchb->local_result.power.searchOp.dynamic +
+      sharedmemory.prefetchb->stats_t.writeAc.access *
+          sharedmemory.prefetchb->local_result.power.writeOp.dynamic;
+  if (cache_p == Write_back) {
+    sharedmemory.power_t.readOp.dynamic +=
+        sharedmemory.wbb->stats_t.readAc.access *
+            sharedmemory.wbb->local_result.power.searchOp.dynamic +
+        sharedmemory.wbb->stats_t.writeAc.access *
+            sharedmemory.wbb->local_result.power.writeOp.dynamic;
+  }
+
+  dcache.power_t.readOp.dynamic +=
+      dcache.missb->stats_t.readAc.access *
+          dcache.missb->local_result.power.searchOp.dynamic +
+      dcache.missb->stats_t.writeAc.access *
+          dcache.missb->local_result.power.writeOp
+              .dynamic;  // each access to missb involves a CAM and a write
+  dcache.power_t.readOp.dynamic +=
+      dcache.ifb->stats_t.readAc.access *
+          dcache.ifb->local_result.power.searchOp.dynamic +
+      dcache.ifb->stats_t.writeAc.access *
+          dcache.ifb->local_result.power.writeOp.dynamic;
+  dcache.power_t.readOp.dynamic +=
+      dcache.prefetchb->stats_t.readAc.access *
+          dcache.prefetchb->local_result.power.searchOp.dynamic +
+      dcache.prefetchb->stats_t.writeAc.access *
+          dcache.prefetchb->local_result.power.writeOp.dynamic;
+  if (cache_p == Write_back) {
+    dcache.power_t.readOp.dynamic +=
+        dcache.wbb->stats_t.readAc.access *
+            dcache.wbb->local_result.power.searchOp.dynamic +
+        dcache.wbb->stats_t.writeAc.access *
+            dcache.wbb->local_result.power.writeOp.dynamic;
+  }
+
+  ccache.power_t.readOp.dynamic +=
+      ccache.missb->stats_t.readAc.access *
+          ccache.missb->local_result.power.searchOp.dynamic +
+      ccache.missb->stats_t.writeAc.access *
+          ccache.missb->local_result.power.writeOp
+              .dynamic;  // each access to missb involves a CAM and a write
+  ccache.power_t.readOp.dynamic +=
+      ccache.ifb->stats_t.readAc.access *
+          ccache.ifb->local_result.power.searchOp.dynamic +
+      ccache.ifb->stats_t.writeAc.access *
+          ccache.ifb->local_result.power.writeOp.dynamic;
+  ccache.power_t.readOp.dynamic +=
+      ccache.prefetchb->stats_t.readAc.access *
+          ccache.prefetchb->local_result.power.searchOp.dynamic +
+      ccache.prefetchb->stats_t.writeAc.access *
+          ccache.prefetchb->local_result.power.writeOp.dynamic;
+  if (cache_p == Write_back) {
+    ccache.power_t.readOp.dynamic +=
+        ccache.wbb->stats_t.readAc.access *
+            ccache.wbb->local_result.power.searchOp.dynamic +
+        ccache.wbb->stats_t.writeAc.access *
+            ccache.wbb->local_result.power.writeOp.dynamic;
+  }
+
+  tcache.power_t.readOp.dynamic +=
+      tcache.missb->stats_t.readAc.access *
+          tcache.missb->local_result.power.searchOp.dynamic +
+      tcache.missb->stats_t.writeAc.access *
+          tcache.missb->local_result.power.writeOp
+              .dynamic;  // each access to missb involves a CAM and a write
+  tcache.power_t.readOp.dynamic +=
+      tcache.ifb->stats_t.readAc.access *
+          tcache.ifb->local_result.power.searchOp.dynamic +
+      tcache.ifb->stats_t.writeAc.access *
+          tcache.ifb->local_result.power.writeOp.dynamic;
+  tcache.power_t.readOp.dynamic +=
+      tcache.prefetchb->stats_t.readAc.access *
+          tcache.prefetchb->local_result.power.searchOp.dynamic +
+      tcache.prefetchb->stats_t.writeAc.access *
+          tcache.prefetchb->local_result.power.writeOp.dynamic;
+  if (cache_p == Write_back) {
+    tcache.power_t.readOp.dynamic +=
+        tcache.wbb->stats_t.readAc.access *
+            tcache.wbb->local_result.power.searchOp.dynamic +
+        tcache.wbb->stats_t.writeAc.access *
+            tcache.wbb->local_result.power.writeOp.dynamic;
+  }
+
+  if ((coredynp.core_ty == OOO) &&
+      (XML->sys.core[ithCore].load_buffer_size > 0)) {
+    LoadQ->power_t.reset();
+    LoadQ->power_t.readOp.dynamic +=
+        LoadQ->stats_t.readAc.access *
+            (LoadQ->local_result.power.searchOp.dynamic +
+             LoadQ->local_result.power.readOp.dynamic) +
+        LoadQ->stats_t.writeAc.access *
+            LoadQ->local_result.power.writeOp
+                .dynamic;  // every memory access invloves at least two
+                           // operations on LoadQ
+
+    LSQ->power_t.readOp.dynamic +=
+        LSQ->stats_t.readAc.access * (LSQ->local_result.power.searchOp.dynamic +
+                                      LSQ->local_result.power.readOp.dynamic) +
+        LSQ->stats_t.writeAc.access *
+            LSQ->local_result.power.writeOp
+                .dynamic;  // every memory access invloves at least two
+                           // operations on LSQ
+
+  } else {
+    //	LSQ->power_t.readOp.dynamic  +=
+    // LSQ->stats_t.readAc.access*(LSQ->local_result.power.searchOp.dynamic +
+    // LSQ->local_result.power.readOp.dynamic)
+    //	        +
+    // LSQ->stats_t.writeAc.access*LSQ->local_result.power.writeOp.dynamic;//every
+    // memory access invloves at least two operations on LSQ 	No LSQ in GPUs
+    //(Syed)
+  }
+
+  if (is_tdp) {
+    //    	dcache.power = dcache.power_t +
+    //    (dcache.caches->local_result.power)*pppm_lkg +
+    //    			(dcache.missb->local_result.power +
+    //    			dcache.ifb->local_result.power +
+    //    			dcache.prefetchb->local_result.power +
+    //    			dcache.wbb->local_result.power)*pppm_Isub;
+
+    sharedmemory.power =
+        sharedmemory.power_t +
+        (sharedmemory.caches->local_result.power +
+         sharedmemory.missb->local_result.power +
+         sharedmemory.ifb->local_result.power +
+         sharedmemory.prefetchb->local_result.power + xbar_shared->power) *
+            pppm_lkg;
+    if (cache_p == Write_back) {
+      sharedmemory.power =
+          sharedmemory.power + sharedmemory.wbb->local_result.power * pppm_lkg;
+    }
+
+    dcache.power = dcache.power_t + (dcache.caches->local_result.power +
+                                     dcache.missb->local_result.power +
+                                     dcache.ifb->local_result.power +
+                                     dcache.prefetchb->local_result.power) *
+                                        pppm_lkg;
+    if (cache_p == Write_back) {
+      dcache.power = dcache.power + dcache.wbb->local_result.power * pppm_lkg;
+    }
+
+    ccache.power = ccache.power_t + (ccache.caches->local_result.power +
+                                     ccache.missb->local_result.power +
+                                     ccache.ifb->local_result.power +
+                                     ccache.prefetchb->local_result.power) *
+                                        pppm_lkg;
+    if (cache_p == Write_back) {
+      ccache.power = ccache.power + ccache.wbb->local_result.power * pppm_lkg;
+    }
+
+    tcache.power = tcache.power_t + (tcache.caches->local_result.power +
+                                     tcache.missb->local_result.power +
+                                     tcache.ifb->local_result.power +
+                                     tcache.prefetchb->local_result.power) *
+                                        pppm_lkg;
+    if (cache_p == Write_back) {
+      tcache.power = tcache.power + tcache.wbb->local_result.power * pppm_lkg;
+    }
+
+    LSQ->power = LSQ->power_t + LSQ->local_result.power * pppm_lkg;
+    // No LSQ in GPUs (Syed)
+    LSQ->power.reset();
+    power = power + dcache.power + LSQ->power + sharedmemory.power +
+            ccache.power + tcache.power;
+
+    if ((coredynp.core_ty == OOO) &&
+        (XML->sys.core[ithCore].load_buffer_size > 0)) {
+      LoadQ->power = LoadQ->power_t + LoadQ->local_result.power * pppm_lkg;
+      power = power + LoadQ->power;
+    }
+  } else {
+    //    	dcache.rt_power = dcache.power_t +
+    //    (dcache.caches->local_result.power +
+    //    dcache.missb->local_result.power
+    //    + 			dcache.ifb->local_result.power +
+    //    			dcache.prefetchb->local_result.power +
+    //    			dcache.wbb->local_result.power)*pppm_lkg;
+    rt_power.reset();
+    sharedmemory.rt_power.reset();  // Jingwen
+    tcache.rt_power.reset();
+    ccache.rt_power.reset();
+    dcache.rt_power.reset();
+    LSQ->rt_power.reset();
+
+    sharedmemory.rt_power =
+        sharedmemory.power_t + (sharedmemory.caches->local_result.power +
+                                sharedmemory.missb->local_result.power +
+                                sharedmemory.ifb->local_result.power +
+                                sharedmemory.prefetchb->local_result.power) *
+                                   pppm_lkg;
+
+    if (cache_p == Write_back) {
+      sharedmemory.rt_power = sharedmemory.rt_power +
+                              sharedmemory.wbb->local_result.power * pppm_lkg;
+    }
+
+    dcache.rt_power = dcache.power_t + (dcache.caches->local_result.power +
+                                        dcache.missb->local_result.power +
+                                        dcache.ifb->local_result.power +
+                                        dcache.prefetchb->local_result.power) *
+                                           pppm_lkg;
+    if (cache_p == Write_back) {
+      dcache.rt_power =
+          dcache.rt_power + dcache.wbb->local_result.power * pppm_lkg;
+    }
+
+    ccache.rt_power = ccache.power_t + (ccache.caches->local_result.power +
+                                        ccache.missb->local_result.power +
+                                        ccache.ifb->local_result.power +
+                                        ccache.prefetchb->local_result.power) *
+                                           pppm_lkg;
+    if (cache_p == Write_back) {
+      ccache.rt_power =
+          ccache.rt_power + ccache.wbb->local_result.power * pppm_lkg;
+    }
+
+    tcache.rt_power = tcache.power_t + (tcache.caches->local_result.power +
+                                        tcache.missb->local_result.power +
+                                        tcache.ifb->local_result.power +
+                                        tcache.prefetchb->local_result.power) *
+                                           pppm_lkg;
+    if (cache_p == Write_back) {
+      tcache.rt_power =
+          tcache.rt_power + tcache.wbb->local_result.power * pppm_lkg;
+    }
+
+    LSQ->rt_power = LSQ->power_t + LSQ->local_result.power * pppm_lkg;
+    LSQ->rt_power.reset();
+    rt_power = rt_power + dcache.rt_power + LSQ->rt_power +
+               sharedmemory.rt_power + ccache.rt_power + tcache.rt_power;
+
+    if ((coredynp.core_ty == OOO) &&
+        (XML->sys.core[ithCore].load_buffer_size > 0)) {
+      LoadQ->rt_power = LoadQ->power_t + LoadQ->local_result.power * pppm_lkg;
+      rt_power = rt_power + LoadQ->rt_power;
+    }
+  }
+}
+
+void LoadStoreU::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  if (!exist) return;
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
+
+  if (is_tdp) {
+    cout << indent_str << "Shared Memory:" << endl;
+    cout << indent_str_next << "Area = " << sharedmemory.area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << sharedmemory.power.readOp.dynamic * clockRate
+         << " W" << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? sharedmemory.power.readOp.longer_channel_leakage
+                          : sharedmemory.power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << sharedmemory.power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << sharedmemory.rt_power.readOp.dynamic / executionTime << " W"
+         << endl;
+    cout << endl;
+
+    cout << indent_str << "Data Cache:" << endl;
+    cout << indent_str_next << "Area = " << dcache.area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << dcache.power.readOp.dynamic * clockRate << " W"
+         << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? dcache.power.readOp.longer_channel_leakage
+                          : dcache.power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << dcache.power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << dcache.rt_power.readOp.dynamic / executionTime << " W" << endl;
+    cout << endl;
+
+    cout << indent_str << "Constant Cache:" << endl;
+    cout << indent_str_next << "Area = " << ccache.area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << ccache.power.readOp.dynamic * clockRate << " W"
+         << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? dcache.power.readOp.longer_channel_leakage
+                          : dcache.power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << ccache.power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << ccache.rt_power.readOp.dynamic / executionTime << " W" << endl;
+    cout << indent_str_next
+         << "Runtime Dynamic Energy = " << ccache.rt_power.readOp.dynamic
+         << " J" << endl;
+    cout << indent_str_next << "Execution Time = " << executionTime << " s"
+         << endl;
+    cout << endl;
+
+    cout << indent_str << "Texture Cache:" << endl;
+    cout << indent_str_next << "Area = " << tcache.area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << tcache.power.readOp.dynamic * clockRate << " W"
+         << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? dcache.power.readOp.longer_channel_leakage
+                          : dcache.power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << tcache.power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << tcache.rt_power.readOp.dynamic / executionTime << " W" << endl;
+    cout << endl;
+
+    if (coredynp.core_ty == Inorder) {
+      cout << indent_str << "Load/Store Queue:" << endl;
+      cout << indent_str_next << "Area = " << LSQ->area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << LSQ->power.readOp.dynamic * clockRate << " W"
+           << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? LSQ->power.readOp.longer_channel_leakage
+                            : LSQ->power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << LSQ->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << LSQ->rt_power.readOp.dynamic / executionTime << " W" << endl;
+      cout << endl;
+    } else
+
     {
-    	sharedmemory.power_t.readOp.dynamic	+=  sharedmemory.wbb->stats_t.readAc.access*sharedmemory.wbb->local_result.power.searchOp.dynamic
-			+ sharedmemory.wbb->stats_t.writeAc.access*sharedmemory.wbb->local_result.power.writeOp.dynamic;
+      if (XML->sys.core[ithCore].load_buffer_size > 0) {
+        cout << indent_str << "LoadQ:" << endl;
+        cout << indent_str_next << "Area = " << LoadQ->area.get_area() * 1e-6
+             << " mm^2" << endl;
+        cout << indent_str_next
+             << "Peak Dynamic = " << LoadQ->power.readOp.dynamic * clockRate
+             << " W" << endl;
+        cout << indent_str_next << "Subthreshold Leakage = "
+             << (long_channel ? LoadQ->power.readOp.longer_channel_leakage
+                              : LoadQ->power.readOp.leakage)
+             << " W" << endl;
+        cout << indent_str_next
+             << "Gate Leakage = " << LoadQ->power.readOp.gate_leakage << " W"
+             << endl;
+        cout << indent_str_next << "Runtime Dynamic = "
+             << LoadQ->rt_power.readOp.dynamic / executionTime << " W" << endl;
+        cout << endl;
+      }
+      cout << indent_str << "StoreQ:" << endl;
+      cout << indent_str_next << "Area = " << LSQ->area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << LSQ->power.readOp.dynamic * clockRate << " W"
+           << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? LSQ->power.readOp.longer_channel_leakage
+                            : LSQ->power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << LSQ->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << LSQ->rt_power.readOp.dynamic / executionTime << " W" << endl;
+      cout << endl;
     }
+  } else {
+    cout << indent_str_next << "Shared Memory    Peak Dynamic = "
+         << sharedmemory.rt_power.readOp.dynamic * clockRate << " W" << endl;
+    cout << indent_str_next << "Shared Memory    Subthreshold Leakage = "
+         << sharedmemory.rt_power.readOp.leakage << " W" << endl;
+    cout << indent_str_next << "Shared Memory    Gate Leakage = "
+         << sharedmemory.rt_power.readOp.gate_leakage << " W" << endl;
 
+    cout << indent_str_next << "Data Cache    Peak Dynamic = "
+         << dcache.rt_power.readOp.dynamic * clockRate << " W" << endl;
+    cout << indent_str_next << "Data Cache    Subthreshold Leakage = "
+         << dcache.rt_power.readOp.leakage << " W" << endl;
+    cout << indent_str_next << "Data Cache    Gate Leakage = "
+         << dcache.rt_power.readOp.gate_leakage << " W" << endl;
 
-    dcache.power_t.readOp.dynamic	+=  dcache.missb->stats_t.readAc.access*dcache.missb->local_result.power.searchOp.dynamic +
-            dcache.missb->stats_t.writeAc.access*dcache.missb->local_result.power.writeOp.dynamic;//each access to missb involves a CAM and a write
-    dcache.power_t.readOp.dynamic	+=  dcache.ifb->stats_t.readAc.access*dcache.ifb->local_result.power.searchOp.dynamic +
-            dcache.ifb->stats_t.writeAc.access*dcache.ifb->local_result.power.writeOp.dynamic;
-    dcache.power_t.readOp.dynamic	+=  dcache.prefetchb->stats_t.readAc.access*dcache.prefetchb->local_result.power.searchOp.dynamic +
-            dcache.prefetchb->stats_t.writeAc.access*dcache.prefetchb->local_result.power.writeOp.dynamic;
-    if (cache_p==Write_back)
-    {
-    	dcache.power_t.readOp.dynamic	+=  dcache.wbb->stats_t.readAc.access*dcache.wbb->local_result.power.searchOp.dynamic
-			+ dcache.wbb->stats_t.writeAc.access*dcache.wbb->local_result.power.writeOp.dynamic;
+    cout << indent_str_next << "Constant Cache    Peak Dynamic = "
+         << ccache.rt_power.readOp.dynamic * clockRate << " W" << endl;
+    cout << indent_str_next << "Constant Cache    Subthreshold Leakage = "
+         << ccache.rt_power.readOp.leakage << " W" << endl;
+    cout << indent_str_next << "Constant Cache    Gate Leakage = "
+         << ccache.rt_power.readOp.gate_leakage << " W" << endl;
+
+    cout << indent_str_next << "Texture Cache    Peak Dynamic = "
+         << tcache.rt_power.readOp.dynamic * clockRate << " W" << endl;
+    cout << indent_str_next << "Texture Cache    Subthreshold Leakage = "
+         << tcache.rt_power.readOp.leakage << " W" << endl;
+    cout << indent_str_next << "Texture Cache    Gate Leakage = "
+         << tcache.rt_power.readOp.gate_leakage << " W" << endl;
+
+    if (coredynp.core_ty == Inorder) {
+      cout << indent_str_next << "Load/Store Queue   Peak Dynamic = "
+           << LSQ->rt_power.readOp.dynamic * clockRate << " W" << endl;
+      cout << indent_str_next << "Load/Store Queue   Subthreshold Leakage = "
+           << LSQ->rt_power.readOp.leakage << " W" << endl;
+      cout << indent_str_next << "Load/Store Queue   Gate Leakage = "
+           << LSQ->rt_power.readOp.gate_leakage << " W" << endl;
+    } else {
+      cout << indent_str_next << "LoadQ   Peak Dynamic = "
+           << LoadQ->rt_power.readOp.dynamic * clockRate << " W" << endl;
+      cout << indent_str_next << "LoadQ   Subthreshold Leakage = "
+           << LoadQ->rt_power.readOp.leakage << " W" << endl;
+      cout << indent_str_next
+           << "LoadQ   Gate Leakage = " << LoadQ->rt_power.readOp.gate_leakage
+           << " W" << endl;
+      cout << indent_str_next << "StoreQ   Peak Dynamic = "
+           << LSQ->rt_power.readOp.dynamic * clockRate << " W" << endl;
+      cout << indent_str_next
+           << "StoreQ   Subthreshold Leakage = " << LSQ->rt_power.readOp.leakage
+           << " W" << endl;
+      cout << indent_str_next
+           << "StoreQ   Gate Leakage = " << LSQ->rt_power.readOp.gate_leakage
+           << " W" << endl;
     }
-
-    ccache.power_t.readOp.dynamic	+=  ccache.missb->stats_t.readAc.access*ccache.missb->local_result.power.searchOp.dynamic +
-            ccache.missb->stats_t.writeAc.access*ccache.missb->local_result.power.writeOp.dynamic;//each access to missb involves a CAM and a write
-    ccache.power_t.readOp.dynamic	+=  ccache.ifb->stats_t.readAc.access*ccache.ifb->local_result.power.searchOp.dynamic +
-            ccache.ifb->stats_t.writeAc.access*ccache.ifb->local_result.power.writeOp.dynamic;
-    ccache.power_t.readOp.dynamic	+=  ccache.prefetchb->stats_t.readAc.access*ccache.prefetchb->local_result.power.searchOp.dynamic +
-            ccache.prefetchb->stats_t.writeAc.access*ccache.prefetchb->local_result.power.writeOp.dynamic;
-    if (cache_p==Write_back)
-    {
-    	ccache.power_t.readOp.dynamic	+=  ccache.wbb->stats_t.readAc.access*ccache.wbb->local_result.power.searchOp.dynamic
-			+ ccache.wbb->stats_t.writeAc.access*ccache.wbb->local_result.power.writeOp.dynamic;
-    }
-
-    tcache.power_t.readOp.dynamic	+=  tcache.missb->stats_t.readAc.access*tcache.missb->local_result.power.searchOp.dynamic +
-            tcache.missb->stats_t.writeAc.access*tcache.missb->local_result.power.writeOp.dynamic;//each access to missb involves a CAM and a write
-    tcache.power_t.readOp.dynamic	+=  tcache.ifb->stats_t.readAc.access*tcache.ifb->local_result.power.searchOp.dynamic +
-            tcache.ifb->stats_t.writeAc.access*tcache.ifb->local_result.power.writeOp.dynamic;
-    tcache.power_t.readOp.dynamic	+=  tcache.prefetchb->stats_t.readAc.access*tcache.prefetchb->local_result.power.searchOp.dynamic +
-            tcache.prefetchb->stats_t.writeAc.access*tcache.prefetchb->local_result.power.writeOp.dynamic;
-    if (cache_p==Write_back)
-    {
-    	tcache.power_t.readOp.dynamic	+=  tcache.wbb->stats_t.readAc.access*tcache.wbb->local_result.power.searchOp.dynamic
-			+ tcache.wbb->stats_t.writeAc.access*tcache.wbb->local_result.power.writeOp.dynamic;
-    }
-
-
-    if ((coredynp.core_ty==OOO) && (XML->sys.core[ithCore].load_buffer_size >0))
-    {
-    	LoadQ->power_t.reset();
-    	LoadQ->power_t.readOp.dynamic  +=  LoadQ->stats_t.readAc.access*(LoadQ->local_result.power.searchOp.dynamic+ LoadQ->local_result.power.readOp.dynamic)+
-    	        LoadQ->stats_t.writeAc.access*LoadQ->local_result.power.writeOp.dynamic;//every memory access invloves at least two operations on LoadQ
-
-    	LSQ->power_t.readOp.dynamic  +=  LSQ->stats_t.readAc.access*(LSQ->local_result.power.searchOp.dynamic + LSQ->local_result.power.readOp.dynamic)
-    		        + LSQ->stats_t.writeAc.access*LSQ->local_result.power.writeOp.dynamic;//every memory access invloves at least two operations on LSQ
-
-    }
-    else
-    {
-    //	LSQ->power_t.readOp.dynamic  +=  LSQ->stats_t.readAc.access*(LSQ->local_result.power.searchOp.dynamic + LSQ->local_result.power.readOp.dynamic)
-    	//	        + LSQ->stats_t.writeAc.access*LSQ->local_result.power.writeOp.dynamic;//every memory access invloves at least two operations on LSQ
-		//	No LSQ in GPUs (Syed)
-
-    }
-
-    if (is_tdp)
-    {
-//    	dcache.power = dcache.power_t + (dcache.caches->local_result.power)*pppm_lkg +
-//    			(dcache.missb->local_result.power +
-//    			dcache.ifb->local_result.power +
-//    			dcache.prefetchb->local_result.power +
-//    			dcache.wbb->local_result.power)*pppm_Isub;
-
-
-    	sharedmemory.power = sharedmemory.power_t + (sharedmemory.caches->local_result.power +
-    			sharedmemory.missb->local_result.power +
-    			sharedmemory.ifb->local_result.power +
-    			sharedmemory.prefetchb->local_result.power + xbar_shared->power) *pppm_lkg;
-    	if (cache_p==Write_back)
-    	{
-    		sharedmemory.power = sharedmemory.power + sharedmemory.wbb->local_result.power*pppm_lkg;
-    	}
-
-
-    	dcache.power = dcache.power_t + (dcache.caches->local_result.power +
-    			dcache.missb->local_result.power +
-    			dcache.ifb->local_result.power +
-    			dcache.prefetchb->local_result.power) *pppm_lkg;
-    	if (cache_p==Write_back)
-    	{
-    		dcache.power = dcache.power + dcache.wbb->local_result.power*pppm_lkg;
-    	}
-
-    	ccache.power = ccache.power_t + (ccache.caches->local_result.power +
-    			ccache.missb->local_result.power +
-    			ccache.ifb->local_result.power +
-    			ccache.prefetchb->local_result.power) *pppm_lkg;
-    	if (cache_p==Write_back)
-    	{
-    		ccache.power = ccache.power + ccache.wbb->local_result.power*pppm_lkg;
-    	}
-
-    	tcache.power = tcache.power_t + (tcache.caches->local_result.power +
-    			tcache.missb->local_result.power +
-    			tcache.ifb->local_result.power +
-    			tcache.prefetchb->local_result.power) *pppm_lkg;
-    	if (cache_p==Write_back)
-    	{
-    		tcache.power = tcache.power + tcache.wbb->local_result.power*pppm_lkg;
-    	}
-
-
-    	LSQ->power = LSQ->power_t + LSQ->local_result.power *pppm_lkg;
-		//No LSQ in GPUs (Syed)
-   	LSQ->power.reset();
-    	power     = power + dcache.power + LSQ->power +sharedmemory.power + ccache.power + tcache.power;
-
-    	if ((coredynp.core_ty==OOO) && (XML->sys.core[ithCore].load_buffer_size >0))
-    	{
-    		LoadQ->power = LoadQ->power_t + LoadQ->local_result.power *pppm_lkg;
-    		power     = power + LoadQ->power;
-    	}
-    }
-    else
-    {
-//    	dcache.rt_power = dcache.power_t + (dcache.caches->local_result.power +
-//    			dcache.missb->local_result.power +
-//    			dcache.ifb->local_result.power +
-//    			dcache.prefetchb->local_result.power +
-//    			dcache.wbb->local_result.power)*pppm_lkg;
-      rt_power.reset();
-      sharedmemory.rt_power.reset(); //Jingwen
-      tcache.rt_power.reset();
-      ccache.rt_power.reset();
-      dcache.rt_power.reset();
-      LSQ->rt_power.reset();
-
-
-    	sharedmemory.rt_power = sharedmemory.power_t + (sharedmemory.caches->local_result.power +
-    			sharedmemory.missb->local_result.power +
-    			sharedmemory.ifb->local_result.power +
-    			sharedmemory.prefetchb->local_result.power )*pppm_lkg;
-
-    	if (cache_p==Write_back)
-    	{
-    		sharedmemory.rt_power = sharedmemory.rt_power + sharedmemory.wbb->local_result.power*pppm_lkg;
-    	}
-
-    	dcache.rt_power = dcache.power_t + (dcache.caches->local_result.power +
-    			dcache.missb->local_result.power +
-    			dcache.ifb->local_result.power +
-    			dcache.prefetchb->local_result.power )*pppm_lkg;
-    	if (cache_p==Write_back)
-    	{
-    		dcache.rt_power = dcache.rt_power + dcache.wbb->local_result.power*pppm_lkg;
-    	}
-
-    	ccache.rt_power = ccache.power_t + (ccache.caches->local_result.power +
-    			ccache.missb->local_result.power +
-    			ccache.ifb->local_result.power +
-    			ccache.prefetchb->local_result.power )*pppm_lkg;
-    	if (cache_p==Write_back)
-    	{
-    		ccache.rt_power = ccache.rt_power + ccache.wbb->local_result.power*pppm_lkg;
-    	}
-
-    	tcache.rt_power = tcache.power_t + (tcache.caches->local_result.power +
-    			tcache.missb->local_result.power +
-    			tcache.ifb->local_result.power +
-    			tcache.prefetchb->local_result.power )*pppm_lkg;
-    	if (cache_p==Write_back)
-    	{
-    		tcache.rt_power = tcache.rt_power + tcache.wbb->local_result.power*pppm_lkg;
-    	}
-
-
-
-    	LSQ->rt_power = LSQ->power_t + LSQ->local_result.power *pppm_lkg;
-		LSQ->rt_power.reset();
-    	rt_power     = rt_power + dcache.rt_power + LSQ->rt_power + sharedmemory.rt_power + ccache.rt_power + tcache.rt_power;
-
-    	if ((coredynp.core_ty==OOO) && (XML->sys.core[ithCore].load_buffer_size >0))
-    	{
-    		LoadQ->rt_power = LoadQ->power_t + LoadQ->local_result.power *pppm_lkg;
-    		rt_power     = rt_power + LoadQ->rt_power;
-    	}
-    }
+  }
 }
 
+void MemManU::computeEnergy(bool is_tdp) {
+  if (!exist) return;
+  if (is_tdp) {
+    // init stats for Peak
+    itlb->stats_t.readAc.access = itlb->l_ip.num_search_ports;
+    itlb->stats_t.readAc.miss = 0;
+    itlb->stats_t.readAc.hit =
+        itlb->stats_t.readAc.access - itlb->stats_t.readAc.miss;
+    itlb->tdp_stats = itlb->stats_t;
 
-void LoadStoreU::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	if (!exist) return;
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
+    dtlb->stats_t.readAc.access =
+        dtlb->l_ip.num_search_ports * coredynp.LSU_duty_cycle;
+    dtlb->stats_t.readAc.miss = 0;
+    dtlb->stats_t.readAc.hit =
+        dtlb->stats_t.readAc.access - dtlb->stats_t.readAc.miss;
+    dtlb->tdp_stats = dtlb->stats_t;
+  } else {
+    // init stats for Runtime Dynamic (RTP)
+    itlb->stats_t.readAc.access = XML->sys.core[ithCore].itlb.total_accesses;
+    itlb->stats_t.readAc.miss = XML->sys.core[ithCore].itlb.total_misses;
+    itlb->stats_t.readAc.hit =
+        itlb->stats_t.readAc.access - itlb->stats_t.readAc.miss;
+    itlb->rtp_stats = itlb->stats_t;
 
+    dtlb->stats_t.readAc.access = XML->sys.core[ithCore].dtlb.total_accesses;
+    dtlb->stats_t.readAc.miss = XML->sys.core[ithCore].dtlb.total_misses;
+    dtlb->stats_t.readAc.hit =
+        dtlb->stats_t.readAc.access - dtlb->stats_t.readAc.miss;
+    dtlb->rtp_stats = dtlb->stats_t;
+  }
 
-	if (is_tdp)
-	{
+  itlb->power_t.reset();
+  dtlb->power_t.reset();
+  itlb->power_t.readOp.dynamic +=
+      itlb->stats_t.readAc.access *
+          itlb->local_result.power.searchOp
+              .dynamic  // FA spent most power in tag,
+                        // so use total access not hits
+      + itlb->stats_t.readAc.miss * itlb->local_result.power.writeOp.dynamic;
+  dtlb->power_t.readOp.dynamic +=
+      dtlb->stats_t.readAc.access *
+          dtlb->local_result.power.searchOp
+              .dynamic  // FA spent most power in tag,
+                        // so use total access not hits
+      + dtlb->stats_t.readAc.miss * dtlb->local_result.power.writeOp.dynamic;
 
-		cout << indent_str << "Shared Memory:" << endl;
-		cout << indent_str_next << "Area = " << sharedmemory.area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << sharedmemory.power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? sharedmemory.power.readOp.longer_channel_leakage:sharedmemory.power.readOp.leakage )<<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << sharedmemory.power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << sharedmemory.rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-
-
-		cout << indent_str << "Data Cache:" << endl;
-		cout << indent_str_next << "Area = " << dcache.area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << dcache.power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? dcache.power.readOp.longer_channel_leakage:dcache.power.readOp.leakage )<<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << dcache.power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << dcache.rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-
-		cout << indent_str << "Constant Cache:" << endl;
-		cout << indent_str_next << "Area = " << ccache.area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << ccache.power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? dcache.power.readOp.longer_channel_leakage:dcache.power.readOp.leakage )<<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << ccache.power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << ccache.rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic Energy = " << ccache.rt_power.readOp.dynamic<<" J"<<endl;
-      cout << indent_str_next << "Execution Time = " << executionTime<<" s"<<endl;
-		cout <<endl;
-
-
-		cout << indent_str << "Texture Cache:" << endl;
-		cout << indent_str_next << "Area = " << tcache.area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << tcache.power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? dcache.power.readOp.longer_channel_leakage:dcache.power.readOp.leakage )<<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << tcache.power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << tcache.rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-		
-    if (coredynp.core_ty==Inorder)
-		{
-			cout << indent_str << "Load/Store Queue:" << endl;
-			cout << indent_str_next << "Area = " << LSQ->area.get_area()*1e-6  << " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << LSQ->power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? LSQ->power.readOp.longer_channel_leakage:LSQ->power.readOp.leakage)  << " W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << LSQ->power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << LSQ->rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-		}
-		else
-
-		{
-			if (XML->sys.core[ithCore].load_buffer_size >0)
-			{
-				cout << indent_str << "LoadQ:" << endl;
-				cout << indent_str_next << "Area = " << LoadQ->area.get_area() *1e-6 << " mm^2" << endl;
-				cout << indent_str_next << "Peak Dynamic = " << LoadQ->power.readOp.dynamic*clockRate  << " W" << endl;
-				cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? LoadQ->power.readOp.longer_channel_leakage:LoadQ->power.readOp.leakage)  << " W" << endl;
-				cout << indent_str_next << "Gate Leakage = " << LoadQ->power.readOp.gate_leakage  << " W" << endl;
-				cout << indent_str_next << "Runtime Dynamic = " << LoadQ->rt_power.readOp.dynamic/executionTime << " W" << endl;
-				cout <<endl;
-			}
-			cout << indent_str<< "StoreQ:" << endl;
-			cout << indent_str_next << "Area = " << LSQ->area.get_area()  *1e-6<< " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << LSQ->power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? LSQ->power.readOp.longer_channel_leakage:LSQ->power.readOp.leakage)  << " W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << LSQ->power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << LSQ->rt_power.readOp.dynamic/executionTime<< " W" << endl;
-			cout <<endl;
-		}
-	}
-	else
-	{
-
-		cout << indent_str_next << "Shared Memory    Peak Dynamic = " << sharedmemory.rt_power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Shared Memory    Subthreshold Leakage = " << sharedmemory.rt_power.readOp.leakage <<" W" << endl;
-		cout << indent_str_next << "Shared Memory    Gate Leakage = " << sharedmemory.rt_power.readOp.gate_leakage << " W" << endl;
-
-
-		cout << indent_str_next << "Data Cache    Peak Dynamic = " << dcache.rt_power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Data Cache    Subthreshold Leakage = " << dcache.rt_power.readOp.leakage <<" W" << endl;
-		cout << indent_str_next << "Data Cache    Gate Leakage = " << dcache.rt_power.readOp.gate_leakage << " W" << endl;
-
-		cout << indent_str_next << "Constant Cache    Peak Dynamic = " << ccache.rt_power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Constant Cache    Subthreshold Leakage = " << ccache.rt_power.readOp.leakage <<" W" << endl;
-		cout << indent_str_next << "Constant Cache    Gate Leakage = " << ccache.rt_power.readOp.gate_leakage << " W" << endl;
-
-		cout << indent_str_next << "Texture Cache    Peak Dynamic = " << tcache.rt_power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Texture Cache    Subthreshold Leakage = " << tcache.rt_power.readOp.leakage <<" W" << endl;
-		cout << indent_str_next << "Texture Cache    Gate Leakage = " << tcache.rt_power.readOp.gate_leakage << " W" << endl;
-		
-    if (coredynp.core_ty==Inorder)
-		{
-			cout << indent_str_next << "Load/Store Queue   Peak Dynamic = " << LSQ->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Load/Store Queue   Subthreshold Leakage = " << LSQ->rt_power.readOp.leakage  << " W" << endl;
-			cout << indent_str_next << "Load/Store Queue   Gate Leakage = " << LSQ->rt_power.readOp.gate_leakage  << " W" << endl;
-		}
-		else
-		{
-			cout << indent_str_next << "LoadQ   Peak Dynamic = " << LoadQ->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "LoadQ   Subthreshold Leakage = " << LoadQ->rt_power.readOp.leakage  << " W" << endl;
-			cout << indent_str_next << "LoadQ   Gate Leakage = " << LoadQ->rt_power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "StoreQ   Peak Dynamic = " << LSQ->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "StoreQ   Subthreshold Leakage = " << LSQ->rt_power.readOp.leakage  << " W" << endl;
-			cout << indent_str_next << "StoreQ   Gate Leakage = " << LSQ->rt_power.readOp.gate_leakage  << " W" << endl;
-		}
-	}
-
+  if (is_tdp) {
+    itlb->power = itlb->power_t + itlb->local_result.power * pppm_lkg;
+    dtlb->power = dtlb->power_t + dtlb->local_result.power * pppm_lkg;
+    power = power + itlb->power + dtlb->power;
+  } else {
+    itlb->rt_power = itlb->power_t + itlb->local_result.power * pppm_lkg;
+    dtlb->rt_power = dtlb->power_t + dtlb->local_result.power * pppm_lkg;
+    rt_power = rt_power + itlb->rt_power + dtlb->rt_power;
+  }
 }
 
-void MemManU::computeEnergy(bool is_tdp)
-{
+void MemManU::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  if (!exist) return;
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
 
-	if (!exist) return;
-	if (is_tdp)
-    {
-    	//init stats for Peak
-    	itlb->stats_t.readAc.access  = itlb->l_ip.num_search_ports;
-    	itlb->stats_t.readAc.miss    = 0;
-    	itlb->stats_t.readAc.hit     = itlb->stats_t.readAc.access - itlb->stats_t.readAc.miss;
-    	itlb->tdp_stats = itlb->stats_t;
+  if (is_tdp) {
+    cout << indent_str << "Itlb:" << endl;
+    cout << indent_str_next << "Area = " << itlb->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << itlb->power.readOp.dynamic * clockRate << " W"
+         << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? itlb->power.readOp.longer_channel_leakage
+                          : itlb->power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << itlb->power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << itlb->rt_power.readOp.dynamic / executionTime << " W" << endl;
+    cout << endl;
+    cout << indent_str << "Dtlb:" << endl;
+    cout << indent_str_next << "Area = " << dtlb->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << dtlb->power.readOp.dynamic * clockRate << " W"
+         << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? dtlb->power.readOp.longer_channel_leakage
+                          : dtlb->power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << dtlb->power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << dtlb->rt_power.readOp.dynamic / executionTime << " W" << endl;
+    cout << endl;
+  } else {
+    cout << indent_str_next << "Itlb    Peak Dynamic = "
+         << itlb->rt_power.readOp.dynamic * clockRate << " W" << endl;
+    cout << indent_str_next
+         << "Itlb    Subthreshold Leakage = " << itlb->rt_power.readOp.leakage
+         << " W" << endl;
+    cout << indent_str_next
+         << "Itlb    Gate Leakage = " << itlb->rt_power.readOp.gate_leakage
+         << " W" << endl;
+    cout << indent_str_next << "Dtlb   Peak Dynamic = "
+         << dtlb->rt_power.readOp.dynamic * clockRate << " W" << endl;
+    cout << indent_str_next
+         << "Dtlb   Subthreshold Leakage = " << dtlb->rt_power.readOp.leakage
+         << " W" << endl;
+    cout << indent_str_next
+         << "Dtlb   Gate Leakage = " << dtlb->rt_power.readOp.gate_leakage
+         << " W" << endl;
+  }
+}
 
-    	dtlb->stats_t.readAc.access  = dtlb->l_ip.num_search_ports*coredynp.LSU_duty_cycle;
-    	dtlb->stats_t.readAc.miss    = 0;
-    	dtlb->stats_t.readAc.hit     = dtlb->stats_t.readAc.access - dtlb->stats_t.readAc.miss;
-    	dtlb->tdp_stats = dtlb->stats_t;
-     }
-    else
-    {
-    	//init stats for Runtime Dynamic (RTP)
-    	itlb->stats_t.readAc.access  = XML->sys.core[ithCore].itlb.total_accesses;
-    	itlb->stats_t.readAc.miss    = XML->sys.core[ithCore].itlb.total_misses;
-    	itlb->stats_t.readAc.hit     = itlb->stats_t.readAc.access - itlb->stats_t.readAc.miss;
-    	itlb->rtp_stats = itlb->stats_t;
+void RegFU::computeEnergy(bool is_tdp) {
+  /*
+   * Architecture RF and physical RF cannot be present at the same time.
+   * Therefore, the RF stats can only refer to either ARF or PRF;
+   * And the same stats can be used for both.
+   */
+  if (!exist) return;
 
-    	dtlb->stats_t.readAc.access  = XML->sys.core[ithCore].dtlb.total_accesses;
-    	dtlb->stats_t.readAc.miss    = XML->sys.core[ithCore].dtlb.total_misses;
-    	dtlb->stats_t.readAc.hit     = dtlb->stats_t.readAc.access - dtlb->stats_t.readAc.miss;
-    	dtlb->rtp_stats = dtlb->stats_t;
+  executionTime =
+      XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);  // Syed
+  // RF crossbar power (Syed Gilani)
+  xbar_rfu->compute_power();
+
+  // Arbiter power
+  arbiter_rfu->compute_power();
+
+  if (is_tdp) {
+    // RF power -- modified by Syed
+    // init stats for Peak
+
+    IRF->stats_t.readAc.access = 4;
+    IRF->stats_t.writeAc.access = 4;
+    IRF->tdp_stats = IRF->stats_t;
+
+    IRF->stats_t.readAc.access = 2;
+    IRF->stats_t.writeAc.access = 1;
+    IRF->tdp_stats = IRF->stats_t;
+
+    OPC->stats_t.readAc.access = 32;
+    OPC->stats_t.writeAc.access = 32;
+    OPC->tdp_stats = OPC->stats_t;
+
+    // Commented by Syed (GPUs have a single RF which we model by IRF)
+    // FRF->stats_t.readAc.access  =
+    // FRF->l_ip.num_rd_ports*coredynp.FPU_duty_cycle*1.05*coredynp.num_fp_pipelines;
+    // FRF->stats_t.writeAc.access  =
+    // FRF->l_ip.num_wr_ports*coredynp.FPU_duty_cycle*1.05*coredynp.num_fp_pipelines;
+    // FRF->tdp_stats = FRF->stats_t;
+    if (coredynp.regWindowing) {
+      RFWIN->stats_t.readAc.access = 0;   // 0.5*RFWIN->l_ip.num_rw_ports;
+      RFWIN->stats_t.writeAc.access = 0;  // 0.5*RFWIN->l_ip.num_rw_ports;
+      RFWIN->tdp_stats = RFWIN->stats_t;
     }
-
-    itlb->power_t.reset();
-    dtlb->power_t.reset();
-	itlb->power_t.readOp.dynamic +=  itlb->stats_t.readAc.access*itlb->local_result.power.searchOp.dynamic//FA spent most power in tag, so use total access not hits
-	                      +itlb->stats_t.readAc.miss*itlb->local_result.power.writeOp.dynamic;
-	dtlb->power_t.readOp.dynamic +=  dtlb->stats_t.readAc.access*dtlb->local_result.power.searchOp.dynamic//FA spent most power in tag, so use total access not hits
-	                      +dtlb->stats_t.readAc.miss*dtlb->local_result.power.writeOp.dynamic;
-
-	if (is_tdp)
-	    {
-		itlb->power = itlb->power_t + itlb->local_result.power *pppm_lkg;
-		dtlb->power = dtlb->power_t + dtlb->local_result.power *pppm_lkg;
-		power     = power + itlb->power + dtlb->power;
-	    }
-	    else
-	    {
-			itlb->rt_power = itlb->power_t + itlb->local_result.power *pppm_lkg;
-			dtlb->rt_power = dtlb->power_t + dtlb->local_result.power *pppm_lkg;
-			rt_power     = rt_power + itlb->rt_power + dtlb->rt_power;
-	    }
-
-}
-
-void MemManU::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	if (!exist) return;
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
-
-
-
-
-	if (is_tdp)
-	{
-		cout << indent_str << "Itlb:" << endl;
-		cout << indent_str_next << "Area = " << itlb->area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << itlb->power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? itlb->power.readOp.longer_channel_leakage:itlb->power.readOp.leakage) <<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << itlb->power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << itlb->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-		cout << indent_str<< "Dtlb:" << endl;
-		cout << indent_str_next << "Area = " << dtlb->area.get_area()*1e-6  << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << dtlb->power.readOp.dynamic*clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? dtlb->power.readOp.longer_channel_leakage:dtlb->power.readOp.leakage)  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << dtlb->power.readOp.gate_leakage  << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << dtlb->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-	}
-	else
-	{
-		cout << indent_str_next << "Itlb    Peak Dynamic = " << itlb->rt_power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Itlb    Subthreshold Leakage = " << itlb->rt_power.readOp.leakage <<" W" << endl;
-		cout << indent_str_next << "Itlb    Gate Leakage = " << itlb->rt_power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Dtlb   Peak Dynamic = " << dtlb->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-		cout << indent_str_next << "Dtlb   Subthreshold Leakage = " << dtlb->rt_power.readOp.leakage  << " W" << endl;
-		cout << indent_str_next << "Dtlb   Gate Leakage = " << dtlb->rt_power.readOp.gate_leakage  << " W" << endl;
-	}
-
-}
-
-void RegFU::computeEnergy(bool is_tdp)
-{
-/*
- * Architecture RF and physical RF cannot be present at the same time.
- * Therefore, the RF stats can only refer to either ARF or PRF;
- * And the same stats can be used for both.
- */
-	if (!exist) return;
-
-  executionTime=XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);//Syed
- //RF crossbar power (Syed Gilani)
- xbar_rfu->compute_power();
-
-
- //Arbiter power
- arbiter_rfu->compute_power(); 
-
-	if (is_tdp)
-    {
-        //RF power -- modified by Syed
-    	//init stats for Peak
-
-    	IRF->stats_t.readAc.access  = 4;
-    	IRF->stats_t.writeAc.access  = 4;
-    	IRF->tdp_stats = IRF->stats_t;
-
-    	IRF->stats_t.readAc.access  = 2;
-    	IRF->stats_t.writeAc.access  = 1;
-    	IRF->tdp_stats = IRF->stats_t;
-
-
-    	OPC->stats_t.readAc.access  = 32;
-    	OPC->stats_t.writeAc.access  = 32;
-    	OPC->tdp_stats = OPC->stats_t;
-
-        //Commented by Syed (GPUs have a single RF which we model by IRF)
-    	//FRF->stats_t.readAc.access  = FRF->l_ip.num_rd_ports*coredynp.FPU_duty_cycle*1.05*coredynp.num_fp_pipelines;
-    	//FRF->stats_t.writeAc.access  = FRF->l_ip.num_wr_ports*coredynp.FPU_duty_cycle*1.05*coredynp.num_fp_pipelines;
-    	//FRF->tdp_stats = FRF->stats_t;
-    	if (coredynp.regWindowing)
-    	{
-        	RFWIN->stats_t.readAc.access  = 0;//0.5*RFWIN->l_ip.num_rw_ports;
-        	RFWIN->stats_t.writeAc.access  = 0;//0.5*RFWIN->l_ip.num_rw_ports;
-        	RFWIN->tdp_stats = RFWIN->stats_t;
-    	}
-	 } /* if (is_tdp) */ 
-    else
-    {
-    	//init stats for Runtime Dynamic (RTP)
-		//in Tesla each RF operand accesses 2 banks, so multiply acceses by 2
-		// (read and write energies of reg_file are per bank)(Tesla) : Syed
-		// Also, for a SIMD width of 8 and warp size of 32 threads, 4 accesses
-		// (each accessing 2 banks) need to be performed per operand
-if (XML->sys.architecture==1){
-    	IRF->stats_t.readAc.access  = (XML->sys.core[ithCore].int_regfile_reads/32)*(4*2);///1.5; 
-    	IRF->stats_t.writeAc.access  = (XML->sys.core[ithCore].int_regfile_writes/32)*(4*2);///1.5;
-} else {
-    	IRF->stats_t.readAc.access  = (XML->sys.core[ithCore].int_regfile_reads/32)*(2*4);///1.5;//TODO: no diff on archi and phy
-    	IRF->stats_t.writeAc.access  = (XML->sys.core[ithCore].int_regfile_writes/32)*(2*4);///1.5;
-}
-    	IRF->rtp_stats = IRF->stats_t;
-
-    	OPC->stats_t.readAc.access  = (XML->sys.core[ithCore].int_regfile_reads)/*/1.5*/+XML->sys.core[ithCore].non_rf_operands;///1.5;//TODO: no diff on archi and phy
-    	OPC->stats_t.writeAc.access  = 0;
-    	OPC->rtp_stats = OPC->stats_t;
-
-      //cout<< "IRF read energy: "<<    IRF->local_result.power.readOp.dynamic<<endl;
-      //cout<< "IRF write energy: "<<    IRF->local_result.power.writeOp.dynamic<<endl;
-    	//FRF->stats_t.readAc.access  = XML->sys.core[ithCore].float_regfile_reads;
-    	//FRF->stats_t.writeAc.access  = XML->sys.core[ithCore].float_regfile_writes;
-    	//FRF->rtp_stats = FRF->stats_t;
-    	if (coredynp.regWindowing)
-    	{
-        	RFWIN->stats_t.readAc.access  = XML->sys.core[ithCore].function_calls*16;
-        	RFWIN->stats_t.writeAc.access  = XML->sys.core[ithCore].function_calls*16;
-        	RFWIN->rtp_stats = RFWIN->stats_t;
-
-        	IRF->stats_t.readAc.access  = XML->sys.core[ithCore].int_regfile_reads +
-        	     XML->sys.core[ithCore].function_calls*16;
-        	IRF->stats_t.writeAc.access  = XML->sys.core[ithCore].int_regfile_writes +
-        	     XML->sys.core[ithCore].function_calls*16;
-        	IRF->rtp_stats = IRF->stats_t;
-
-    	}
+  } /* if (is_tdp) */
+  else {
+    // init stats for Runtime Dynamic (RTP)
+    // in Tesla each RF operand accesses 2 banks, so multiply acceses by 2
+    // (read and write energies of reg_file are per bank)(Tesla) : Syed
+    // Also, for a SIMD width of 8 and warp size of 32 threads, 4 accesses
+    // (each accessing 2 banks) need to be performed per operand
+    if (XML->sys.architecture == 1) {
+      IRF->stats_t.readAc.access =
+          (XML->sys.core[ithCore].int_regfile_reads / 32) * (4 * 2);  /// 1.5;
+      IRF->stats_t.writeAc.access =
+          (XML->sys.core[ithCore].int_regfile_writes / 32) * (4 * 2);  /// 1.5;
+    } else {
+      IRF->stats_t.readAc.access =
+          (XML->sys.core[ithCore].int_regfile_reads / 32) *
+          (2 * 4);  /// 1.5;//TODO: no diff on archi and phy
+      IRF->stats_t.writeAc.access =
+          (XML->sys.core[ithCore].int_regfile_writes / 32) * (2 * 4);  /// 1.5;
     }
-	IRF->power_t.reset();
-	FRF->power_t.reset();
-	OPC->power_t.reset();
-	//IRF->power_t  =  IRF->power_t + IRF->local_result.power;// + xbar_rfu->power + arbiter_rfu->power;
+    IRF->rtp_stats = IRF->stats_t;
 
+    OPC->stats_t.readAc.access =
+        (XML->sys.core[ithCore].int_regfile_reads) /*/1.5*/ +
+        XML->sys.core[ithCore]
+            .non_rf_operands;  /// 1.5;//TODO: no diff on archi and phy
+    OPC->stats_t.writeAc.access = 0;
+    OPC->rtp_stats = OPC->stats_t;
 
-	
-	IRF->power_t.readOp.dynamic  =  (IRF->stats_t.readAc.access*IRF->local_result.power.readOp.dynamic
-			+IRF->stats_t.writeAc.access*IRF->local_result.power.writeOp.dynamic);
-	OPC->power_t.readOp.dynamic  =  (OPC->stats_t.readAc.access*OPC->local_result.power.readOp.dynamic);
+    // cout<< "IRF read energy: "<<
+    // IRF->local_result.power.readOp.dynamic<<endl; cout<< "IRF write energy:
+    // "<<    IRF->local_result.power.writeOp.dynamic<<endl;
+    // FRF->stats_t.readAc.access  = XML->sys.core[ithCore].float_regfile_reads;
+    // FRF->stats_t.writeAc.access  =
+    // XML->sys.core[ithCore].float_regfile_writes; FRF->rtp_stats =
+    // FRF->stats_t;
+    if (coredynp.regWindowing) {
+      RFWIN->stats_t.readAc.access = XML->sys.core[ithCore].function_calls * 16;
+      RFWIN->stats_t.writeAc.access =
+          XML->sys.core[ithCore].function_calls * 16;
+      RFWIN->rtp_stats = RFWIN->stats_t;
 
-	if (coredynp.regWindowing)
-	{
-		RFWIN->power_t.reset();
-		RFWIN->power_t.readOp.dynamic   +=  (RFWIN->stats_t.readAc.access*RFWIN->local_result.power.readOp.dynamic +
-				RFWIN->stats_t.writeAc.access*RFWIN->local_result.power.writeOp.dynamic);
-	}
+      IRF->stats_t.readAc.access = XML->sys.core[ithCore].int_regfile_reads +
+                                   XML->sys.core[ithCore].function_calls * 16;
+      IRF->stats_t.writeAc.access = XML->sys.core[ithCore].int_regfile_writes +
+                                    XML->sys.core[ithCore].function_calls * 16;
+      IRF->rtp_stats = IRF->stats_t;
+    }
+  }
+  IRF->power_t.reset();
+  FRF->power_t.reset();
+  OPC->power_t.reset();
+  // IRF->power_t  =  IRF->power_t + IRF->local_result.power;// +
+  // xbar_rfu->power + arbiter_rfu->power;
 
-	if (is_tdp)
-	{
+  IRF->power_t.readOp.dynamic =
+      (IRF->stats_t.readAc.access * IRF->local_result.power.readOp.dynamic +
+       IRF->stats_t.writeAc.access * IRF->local_result.power.writeOp.dynamic);
+  OPC->power_t.readOp.dynamic =
+      (OPC->stats_t.readAc.access * OPC->local_result.power.readOp.dynamic);
 
-	  	//cout<<"pre: IRF_power_t: "<<IRF->power.readOp.dynamic<<" ("<<IRF->power.readOp.dynamic*clockRate<<") "<<" IRF_localresult: "<<
-		 //                   IRF->local_result.power.readOp.dynamic<<endl;
-		//Syed: removed the multiplication of power by hardware threads
-		//since the one IRF  is shared by all threads in GPUs
+  if (coredynp.regWindowing) {
+    RFWIN->power_t.reset();
+    RFWIN->power_t.readOp.dynamic +=
+        (RFWIN->stats_t.readAc.access *
+             RFWIN->local_result.power.readOp.dynamic +
+         RFWIN->stats_t.writeAc.access *
+             RFWIN->local_result.power.writeOp.dynamic);
+  }
 
-		//FRF->power  =  FRF->power_t + FRF->local_result.power *coredynp.pppm_lkg_multhread;
+  if (is_tdp) {
+    // cout<<"pre: IRF_power_t: "<<IRF->power.readOp.dynamic<<"
+    // ("<<IRF->power.readOp.dynamic*clockRate<<") "<<" IRF_localresult: "<<
+    //                   IRF->local_result.power.readOp.dynamic<<endl;
+    // Syed: removed the multiplication of power by hardware threads
+    // since the one IRF  is shared by all threads in GPUs
 
-	  double pppm_lkg_banks[4];
-	  set_pppm(pppm_lkg_banks, 0,XML->sys.core[ithCore].collector_units,XML->sys.core[ithCore].collector_units );
-	  IRF->power = (IRF->power_t) + IRF->local_result.power*pppm_lkg;
-	  IRF->power.readOp.dynamic=IRF->power_t.readOp.dynamic*1;
-	  OPC->power = (OPC->power_t) + OPC->local_result.power *pppm_lkg_banks;
-	  OPC->power.readOp.dynamic=OPC->power_t.readOp.dynamic*1;
+    // FRF->power  =  FRF->power_t + FRF->local_result.power
+    // *coredynp.pppm_lkg_multhread;
 
-	  
-	  power	    =  power + (IRF->power+OPC->power);
+    double pppm_lkg_banks[4];
+    set_pppm(pppm_lkg_banks, 0, XML->sys.core[ithCore].collector_units,
+             XML->sys.core[ithCore].collector_units);
+    IRF->power = (IRF->power_t) + IRF->local_result.power * pppm_lkg;
+    IRF->power.readOp.dynamic = IRF->power_t.readOp.dynamic * 1;
+    OPC->power = (OPC->power_t) + OPC->local_result.power * pppm_lkg_banks;
+    OPC->power.readOp.dynamic = OPC->power_t.readOp.dynamic * 1;
 
+    power = power + (IRF->power + OPC->power);
 
-		if (coredynp.regWindowing)
-		{
-			RFWIN->power = RFWIN->power_t + RFWIN->local_result.power *pppm_lkg;
-			power        = power + RFWIN->power;
-		}
-	} /* if (is_tdp) */	
-	else
-	{
-	  //Removed *coredynp.pppm_lkg_multhread since all hardware threads shared the same IRF
-		IRF->rt_power  =  IRF->power_t + IRF->local_result.power*pppm_lkg;/* *coredynp.pppm_lkg_multhread;*/
-		OPC->rt_power = OPC->power_t +  OPC->local_result.power*pppm_lkg;
-if(XML->sys.architecture==1){
-	//Each warp operand accesses the crossbar
-   xbar_rfu->rt_power.readOp.dynamic=((XML->sys.core[ithCore].int_regfile_reads/(32/**1.5*/))+(XML->sys.core[ithCore].non_rf_operands/(32/**1.5*/)))*xbar_rfu->power.readOp.dynamic;
-} else {
-	xbar_rfu->rt_power.readOp.dynamic=((XML->sys.core[ithCore].int_regfile_reads/(32/**1.5*/))+(XML->sys.core[ithCore].non_rf_operands/(32/**1.5*/)))*xbar_rfu->power.readOp.dynamic;
-}
-		arbiter_rfu->rt_power.readOp.dynamic=((XML->sys.core[ithCore].int_regfile_reads/(32/**1.5*/))+(XML->sys.core[ithCore].non_rf_operands/(32/**1.5*/)))*arbiter_rfu->power.readOp.dynamic;
+    if (coredynp.regWindowing) {
+      RFWIN->power = RFWIN->power_t + RFWIN->local_result.power * pppm_lkg;
+      power = power + RFWIN->power;
+    }
+  } /* if (is_tdp) */
+  else {
+    // Removed *coredynp.pppm_lkg_multhread since all hardware threads shared
+    // the same IRF
+    IRF->rt_power =
+        IRF->power_t +
+        IRF->local_result.power * pppm_lkg; /* *coredynp.pppm_lkg_multhread;*/
+    OPC->rt_power = OPC->power_t + OPC->local_result.power * pppm_lkg;
+    if (XML->sys.architecture == 1) {
+      // Each warp operand accesses the crossbar
+      xbar_rfu->rt_power.readOp.dynamic =
+          ((XML->sys.core[ithCore].int_regfile_reads / (32 /**1.5*/)) +
+           (XML->sys.core[ithCore].non_rf_operands / (32 /**1.5*/))) *
+          xbar_rfu->power.readOp.dynamic;
+    } else {
+      xbar_rfu->rt_power.readOp.dynamic =
+          ((XML->sys.core[ithCore].int_regfile_reads / (32 /**1.5*/)) +
+           (XML->sys.core[ithCore].non_rf_operands / (32 /**1.5*/))) *
+          xbar_rfu->power.readOp.dynamic;
+    }
+    arbiter_rfu->rt_power.readOp.dynamic =
+        ((XML->sys.core[ithCore].int_regfile_reads / (32 /**1.5*/)) +
+         (XML->sys.core[ithCore].non_rf_operands / (32 /**1.5*/))) *
+        arbiter_rfu->power.readOp.dynamic;
 
-
-		rt_power	   =  rt_power + (IRF->power_t /*+ FRF->power_t*/+xbar_rfu->rt_power+arbiter_rfu->rt_power+OPC->power_t);
-		if (coredynp.regWindowing)
-		{
-			RFWIN->rt_power = RFWIN->power_t + RFWIN->local_result.power *pppm_lkg;
-			rt_power        = rt_power + RFWIN->rt_power;
-		}
-	}
-}
-
-
-void RegFU::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	if (!exist) return;
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
-
-	if (is_tdp)
-	{	cout << indent_str << "Register file banks: " << endl;
-		cout << indent_str_next << "Area = " << IRF->area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << IRF->power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? IRF->power.readOp.longer_channel_leakage:IRF->power.readOp.leakage) <<" W" << endl;
-
-		cout << indent_str_next << "Gate Leakage = " << IRF->power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << IRF->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-      cout << indent_str << "Crossbar (Integer RF):" << endl;
-		cout << indent_str_next << "Area = " << xbar_rfu->area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << xbar_rfu->power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? xbar_rfu->power.readOp.longer_channel_leakage:xbar_rfu->power.readOp.leakage) <<" W" << endl;
-
-		cout << indent_str_next << "Gate Leakage = " << xbar_rfu->power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << xbar_rfu->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-      
-		cout << indent_str << "Arbiter (Integer RF):" << endl;
-		cout << indent_str_next << "Area = " << arbiter_rfu->area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << arbiter_rfu->power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? arbiter_rfu->power.readOp.longer_channel_leakage:arbiter_rfu->power.readOp.leakage) <<" W" << endl;
-
-		cout << indent_str_next << "Gate Leakage = " << arbiter_rfu->power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << arbiter_rfu->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-
-		/*
-		cout << indent_str<< "Floating Point RF:" << endl;
-		cout << indent_str_next << "Area = " << FRF->area.get_area()*1e-6  << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << FRF->power.readOp.dynamic*clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? FRF->power.readOp.longer_channel_leakage:FRF->power.readOp.leakage)  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << FRF->power.readOp.gate_leakage  << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << FRF->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-		*/
-		if (coredynp.regWindowing)
-		{
-			cout << indent_str << "Register Windows:" << endl;
-			cout << indent_str_next << "Area = " << RFWIN->area.get_area() *1e-6 << " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << RFWIN->power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? RFWIN->power.readOp.longer_channel_leakage:RFWIN->power.readOp.leakage)  << " W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << RFWIN->power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << RFWIN->rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-		}
-	}
-	else
-	{
-		cout << indent_str_next << "Integer RF    Peak Dynamic = " << IRF->rt_power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Integer RF    Subthreshold Leakage = " << IRF->rt_power.readOp.leakage <<" W" << endl;
-		cout << indent_str_next << "Integer RF    Gate Leakage = " << IRF->rt_power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Floating Point RF   Peak Dynamic = " << FRF->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-		cout << indent_str_next << "Floating Point RF   Subthreshold Leakage = " << FRF->rt_power.readOp.leakage  << " W" << endl;
-		cout << indent_str_next << "Floating Point RF   Gate Leakage = " << FRF->rt_power.readOp.gate_leakage  << " W" << endl;
-		if (coredynp.regWindowing)
-		{
-			cout << indent_str_next << "Register Windows   Peak Dynamic = " << RFWIN->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Register Windows   Subthreshold Leakage = " << RFWIN->rt_power.readOp.leakage  << " W" << endl;
-			cout << indent_str_next << "Register Windows   Gate Leakage = " << RFWIN->rt_power.readOp.gate_leakage  << " W" << endl;
-		}
-	}
+    rt_power =
+        rt_power + (IRF->power_t /*+ FRF->power_t*/ + xbar_rfu->rt_power +
+                    arbiter_rfu->rt_power + OPC->power_t);
+    if (coredynp.regWindowing) {
+      RFWIN->rt_power = RFWIN->power_t + RFWIN->local_result.power * pppm_lkg;
+      rt_power = rt_power + RFWIN->rt_power;
+    }
+  }
 }
 
+void RegFU::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  if (!exist) return;
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
 
-void EXECU::computeEnergy(bool is_tdp)
-{
-	if (!exist) return;
-	//Syed
-	double pppm_t[4]    = {1,1,1,1};
-	double pppm_freqScaling[4]    = {rf_fu_clockRate/clockRate,1,1,1};
-  executionTime=XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);//Syed
+  if (is_tdp) {
+    cout << indent_str << "Register file banks: " << endl;
+    cout << indent_str_next << "Area = " << IRF->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << IRF->power.readOp.dynamic * clockRate << " W"
+         << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? IRF->power.readOp.longer_channel_leakage
+                          : IRF->power.readOp.leakage)
+         << " W" << endl;
 
+    cout << indent_str_next
+         << "Gate Leakage = " << IRF->power.readOp.gate_leakage << " W" << endl;
+    cout << indent_str_next
+         << "Runtime Dynamic = " << IRF->rt_power.readOp.dynamic / executionTime
+         << " W" << endl;
+    cout << endl;
+    cout << indent_str << "Crossbar (Integer RF):" << endl;
+    cout << indent_str_next << "Area = " << xbar_rfu->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << xbar_rfu->power.readOp.dynamic * clockRate
+         << " W" << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? xbar_rfu->power.readOp.longer_channel_leakage
+                          : xbar_rfu->power.readOp.leakage)
+         << " W" << endl;
 
-//	rfu->power.reset();
+    cout << indent_str_next
+         << "Gate Leakage = " << xbar_rfu->power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << xbar_rfu->rt_power.readOp.dynamic / executionTime << " W" << endl;
+    cout << endl;
+
+    cout << indent_str << "Arbiter (Integer RF):" << endl;
+    cout << indent_str_next << "Area = " << arbiter_rfu->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << arbiter_rfu->power.readOp.dynamic * clockRate
+         << " W" << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? arbiter_rfu->power.readOp.longer_channel_leakage
+                          : arbiter_rfu->power.readOp.leakage)
+         << " W" << endl;
+
+    cout << indent_str_next
+         << "Gate Leakage = " << arbiter_rfu->power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << arbiter_rfu->rt_power.readOp.dynamic / executionTime << " W"
+         << endl;
+    cout << endl;
+
+    /*
+    cout << indent_str<< "Floating Point RF:" << endl;
+    cout << indent_str_next << "Area = " << FRF->area.get_area()*1e-6  << "
+    mm^2" << endl; cout << indent_str_next << "Peak Dynamic = " <<
+    FRF->power.readOp.dynamic*clockRate  << " W" << endl; cout <<
+    indent_str_next << "Subthreshold Leakage = "
+            << (long_channel?
+    FRF->power.readOp.longer_channel_leakage:FRF->power.readOp.leakage)  << " W"
+    << endl; cout << indent_str_next << "Gate Leakage = " <<
+    FRF->power.readOp.gate_leakage  << " W" << endl; cout << indent_str_next <<
+    "Runtime Dynamic = " << FRF->rt_power.readOp.dynamic/executionTime << " W"
+    << endl; cout <<endl;
+    */
+    if (coredynp.regWindowing) {
+      cout << indent_str << "Register Windows:" << endl;
+      cout << indent_str_next << "Area = " << RFWIN->area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << RFWIN->power.readOp.dynamic * clockRate
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? RFWIN->power.readOp.longer_channel_leakage
+                            : RFWIN->power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << RFWIN->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << RFWIN->rt_power.readOp.dynamic / executionTime << " W" << endl;
+      cout << endl;
+    }
+  } else {
+    cout << indent_str_next << "Integer RF    Peak Dynamic = "
+         << IRF->rt_power.readOp.dynamic * clockRate << " W" << endl;
+    cout << indent_str_next << "Integer RF    Subthreshold Leakage = "
+         << IRF->rt_power.readOp.leakage << " W" << endl;
+    cout << indent_str_next
+         << "Integer RF    Gate Leakage = " << IRF->rt_power.readOp.gate_leakage
+         << " W" << endl;
+    cout << indent_str_next << "Floating Point RF   Peak Dynamic = "
+         << FRF->rt_power.readOp.dynamic * clockRate << " W" << endl;
+    cout << indent_str_next << "Floating Point RF   Subthreshold Leakage = "
+         << FRF->rt_power.readOp.leakage << " W" << endl;
+    cout << indent_str_next << "Floating Point RF   Gate Leakage = "
+         << FRF->rt_power.readOp.gate_leakage << " W" << endl;
+    if (coredynp.regWindowing) {
+      cout << indent_str_next << "Register Windows   Peak Dynamic = "
+           << RFWIN->rt_power.readOp.dynamic * clockRate << " W" << endl;
+      cout << indent_str_next << "Register Windows   Subthreshold Leakage = "
+           << RFWIN->rt_power.readOp.leakage << " W" << endl;
+      cout << indent_str_next << "Register Windows   Gate Leakage = "
+           << RFWIN->rt_power.readOp.gate_leakage << " W" << endl;
+    }
+  }
+}
+
+void EXECU::computeEnergy(bool is_tdp) {
+  if (!exist) return;
+  // Syed
+  double pppm_t[4] = {1, 1, 1, 1};
+  double pppm_freqScaling[4] = {rf_fu_clockRate / clockRate, 1, 1, 1};
+  executionTime =
+      XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);  // Syed
+
+  //	rfu->power.reset();
   rfu->rt_power.reset();
-//	scheu->power.reset();
-	scheu->rt_power.reset();
-//	exeu->power.reset();
-	exeu->rt_power.reset();
+  //	scheu->power.reset();
+  scheu->rt_power.reset();
+  //	exeu->power.reset();
+  exeu->rt_power.reset();
 
-	rfu->computeEnergy(is_tdp);
-	scheu->computeEnergy(is_tdp);
-	exeu->computeEnergy(is_tdp);
-	if (coredynp.num_fpus >0)
-	{
+  rfu->computeEnergy(is_tdp);
+  scheu->computeEnergy(is_tdp);
+  exeu->computeEnergy(is_tdp);
+  if (coredynp.num_fpus > 0) {
     fp_u->rt_power.reset();
-		fp_u->computeEnergy(is_tdp);
-	}
-	if (coredynp.num_muls >0)
-	{
+    fp_u->computeEnergy(is_tdp);
+  }
+  if (coredynp.num_muls > 0) {
     mul->rt_power.reset();
-		mul->computeEnergy(is_tdp);
-	}
+    mul->computeEnergy(is_tdp);
+  }
   bypass.rt_power.reset();
 
-	if (is_tdp)
-	{
-		set_pppm(pppm_t, 2*coredynp.ALU_cdb_duty_cycle, 2, 2, 2*coredynp.ALU_cdb_duty_cycle);//2 means two source operands needs to be passed for each int instruction.
-		//bypass.power = bypass.power + intTagBypass->power*pppm_t + int_bypass->power*pppm_t;
-		if (coredynp.num_muls >0)
-		{
-			set_pppm(pppm_t, 2*coredynp.MUL_cdb_duty_cycle, 2, 2, 2*coredynp.MUL_cdb_duty_cycle);//2 means two source operands needs to be passed for each int instruction.
-			//No conventional bypassing in GPU (Syed)
-			//bypass.power = bypass.power + intTag_mul_Bypass->power*pppm_t + int_mul_bypass->power*pppm_t;
-			power      = power + mul->power*pppm_freqScaling;
-		}
-
-		if (coredynp.num_fpus>0)
-		{
-			set_pppm(pppm_t, 3*coredynp.FPU_cdb_duty_cycle, 3, 3, 3*coredynp.FPU_cdb_duty_cycle);//3 means three source operands needs to be passed for each fp instruction.
-			//No conventional bypassing in GPU (Syed)			
-			//bypass.power = bypass.power + fp_bypass->power*pppm_t  + fpTagBypass->power*pppm_t ;
-			power      = power + fp_u->power*pppm_freqScaling;
-
-		}
-		//No conventional bypassing in GPU (Syed)
-
-		power      = power + rfu->power*pppm_freqScaling + exeu->power*pppm_freqScaling /*+ bypass.power*/ + scheu->power
-		                   ;
-
-
-	}
-	else
-	{
-		set_pppm(pppm_t, XML->sys.core[ithCore].cdb_alu_accesses, 2, 2, XML->sys.core[ithCore].cdb_alu_accesses);
-		//bypass.rt_power = bypass.rt_power + intTagBypass->power*pppm_t;
-		//bypass.rt_power = bypass.rt_power + int_bypass->power*pppm_t;
-
-		if (coredynp.num_muls >0)
-		{
-			set_pppm(pppm_t, XML->sys.core[ithCore].cdb_mul_accesses, 2, 2, XML->sys.core[ithCore].cdb_mul_accesses);//2 means two source operands needs to be passed for each int instruction.
-			//bypass.rt_power = bypass.rt_power + intTag_mul_Bypass->power*pppm_t + int_mul_bypass->power*pppm_t;
-			rt_power      = rt_power + mul->rt_power;
-		}
-
-		if (coredynp.num_fpus>0)
-		{
-			set_pppm(pppm_t, XML->sys.core[ithCore].cdb_fpu_accesses, 3, 3, XML->sys.core[ithCore].cdb_fpu_accesses);
-			//bypass.rt_power = bypass.rt_power + fp_bypass->power*pppm_t;
-			//bypass.rt_power = bypass.rt_power + fpTagBypass->power*pppm_t;
-			rt_power      = rt_power + fp_u->rt_power;
-		}
-		//No conventional bypassing in GPU (Syed)
-		rt_power      = rt_power + rfu->rt_power*pppm_freqScaling + exeu->rt_power*pppm_freqScaling + /*bypass.rt_power +*/ scheu->rt_power;
-	}
-}
-
-void EXECU::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	if (!exist) return;
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
-
-
-//	cout << indent_str_next << "Results Broadcast Bus Area = " << bypass->area.get_area() *1e-6 << " mm^2" << endl;
-	if (is_tdp)
-	{
-		cout << indent_str << "Register Files:" << endl;
-		cout << indent_str_next << "Area = " << rfu->area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << rfu->power.readOp.dynamic*rf_fu_clockRate << " W" << endl;
-		//cout << "rf_fu Clock rate: "<< rf_fu_clockRate<<endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? rfu->power.readOp.longer_channel_leakage:rfu->power.readOp.leakage) <<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << rfu->power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << rfu->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-		if (plevel>3){
-			rfu->displayEnergy(indent+4,is_tdp);
-		}
-		cout << indent_str << "Instruction Scheduler:" << endl;
-		cout << indent_str_next << "Area = " << scheu->area.get_area()*1e-6  << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << scheu->power.readOp.dynamic*clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? scheu->power.readOp.longer_channel_leakage:scheu->power.readOp.leakage)  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << scheu->power.readOp.gate_leakage  << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << scheu->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-		if (plevel>3){
-			scheu->displayEnergy(indent+4,is_tdp);
-		}
-		exeu->displayEnergy(indent,is_tdp);
-		if (coredynp.num_fpus>0)
-		{
-			fp_u->displayEnergy(indent,is_tdp);
-		}
-		if (coredynp.num_muls >0)
-		{
-			mul->displayEnergy(indent,is_tdp);
-		}
-		cout << indent_str << "Results Broadcast Bus:" << endl;
-		cout << indent_str_next << "Area Overhead = " << bypass.area.get_area()*1e-6  << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << bypass.power.readOp.dynamic*clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? bypass.power.readOp.longer_channel_leakage:bypass.power.readOp.leakage ) << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << bypass.power.readOp.gate_leakage  << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << bypass.rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-	}
-	else
-	{
-		cout << indent_str_next << "Register Files    Peak Dynamic = " << rfu->rt_power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Register Files    Subthreshold Leakage = " << rfu->rt_power.readOp.leakage <<" W" << endl;
-		cout << indent_str_next << "Register Files    Gate Leakage = " << rfu->rt_power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Instruction Sheduler   Peak Dynamic = " << scheu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-		cout << indent_str_next << "Instruction Sheduler   Subthreshold Leakage = " << scheu->rt_power.readOp.leakage  << " W" << endl;
-		cout << indent_str_next << "Instruction Sheduler   Gate Leakage = " << scheu->rt_power.readOp.gate_leakage  << " W" << endl;
-		cout << indent_str_next << "Results Broadcast Bus   Peak Dynamic = " << bypass.rt_power.readOp.dynamic*clockRate  << " W" << endl;
-		cout << indent_str_next << "Results Broadcast Bus   Subthreshold Leakage = " << bypass.rt_power.readOp.leakage  << " W" << endl;
-		cout << indent_str_next << "Results Broadcast Bus   Gate Leakage = " << bypass.rt_power.readOp.gate_leakage  << " W" << endl;
-	}
-
-}
-
-
-
-
-
-
-//Jingwen
-void Core::compute()
-{
-    //power_point_product_masks
-    double pppm_t[4]    = {1,1,1,1};
-    double rtp_pipeline_coe;
-    double num_units = 4.0;
-    Pipeline_energy=0;
-
-	 //Set pipeline duty cycle for this inteval 
-	coredynp.pipeline_duty_cycle=XML->sys.core[ithCore].pipeline_duty_cycle;
-    rt_power.reset();
-    ifu->rt_power.reset();
-    lsu->rt_power.reset();
-    mmu->rt_power.reset();
-    exu->rt_power.reset();
-
-
-		ifu->computeEnergy(false);
-		lsu->computeEnergy(false);
-		mmu->computeEnergy(false);
-		exu->computeEnergy(false);
-
-
-		if (XML->sys.homogeneous_cores==1)
-		{
-				rtp_pipeline_coe = coredynp.pipeline_duty_cycle * XML->sys.total_cycles * XML->sys.number_of_cores;
-		}
-		else
-		{
-
-			rtp_pipeline_coe = coredynp.pipeline_duty_cycle * coredynp.total_cycles;
-			//Jingwen
-			if (coredynp.total_cycles != XML->sys.total_cycles)
-			{
-				cout << "total cycle not match!" << endl;
-				exit(1);
-			}
-		}
-      
-		set_pppm(pppm_t, coredynp.num_pipelines*rtp_pipeline_coe/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units);
-
-		if (ifu->exist)
-		{
-			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
-			ifu->rt_power = ifu->rt_power + corepipe->power*pppm_t;
-			rt_power     = rt_power + ifu->rt_power ;
-		}
-    
-		if (lsu->exist)
-		{
-			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
-			lsu->rt_power = lsu->rt_power + corepipe->power*pppm_t;
-			rt_power     = rt_power  + lsu->rt_power;
-		}
-		if (exu->exist)
-		{
-			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
-			exu->rt_power = exu->rt_power + corepipe->power*pppm_t;
-			rt_power     = rt_power  + exu->rt_power;
-		}
-		if (mmu->exist)
-		{
-			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
-			mmu->rt_power = mmu->rt_power + corepipe->power*pppm_t;
-			rt_power     = rt_power +  mmu->rt_power ;
-		}
-
-		rt_power     = rt_power +  undiffCore->power;
-    
-
-		if (XML->sys.Private_L2)
-		{
-
-			l2cache->computeEnergy(false);
-			rt_power = rt_power  + l2cache->rt_power;
-		}
-		
-		IdleCoreEnergy=XML->sys.num_idle_cores * XML->sys.idle_core_power* executionTime;
-
-		rt_power.readOp.dynamic += IdleCoreEnergy;
-
-}
-
-
-
-
-void Core::computeEnergy(bool is_tdp)
-{
-	//power_point_product_masks
-	double pppm_t[4]    = {1,1,1,1};
-    double rtp_pipeline_coe;
-    double num_units = 4.0;
-    Pipeline_energy=0;
-
-    if (XML->sys.homogeneous_cores==1)
-    {
-       rtp_pipeline_coe = coredynp.pipeline_duty_cycle * XML->sys.total_cycles * XML->sys.number_of_cores;
+  if (is_tdp) {
+    set_pppm(
+        pppm_t, 2 * coredynp.ALU_cdb_duty_cycle, 2, 2,
+        2 * coredynp
+                .ALU_cdb_duty_cycle);  // 2 means two source operands needs to
+                                       // be passed for each int instruction.
+    // bypass.power = bypass.power + intTagBypass->power*pppm_t +
+    // int_bypass->power*pppm_t;
+    if (coredynp.num_muls > 0) {
+      set_pppm(
+          pppm_t, 2 * coredynp.MUL_cdb_duty_cycle, 2, 2,
+          2 * coredynp
+                  .MUL_cdb_duty_cycle);  // 2 means two source operands needs to
+                                         // be passed for each int instruction.
+      // No conventional bypassing in GPU (Syed)
+      // bypass.power = bypass.power + intTag_mul_Bypass->power*pppm_t +
+      // int_mul_bypass->power*pppm_t;
+      power = power + mul->power * pppm_freqScaling;
     }
-    else
-    {
-       rtp_pipeline_coe = coredynp.pipeline_duty_cycle * coredynp.total_cycles;
+
+    if (coredynp.num_fpus > 0) {
+      set_pppm(pppm_t, 3 * coredynp.FPU_cdb_duty_cycle, 3, 3,
+               3 * coredynp.FPU_cdb_duty_cycle);  // 3 means three source
+                                                  // operands needs to be passed
+                                                  // for each fp instruction.
+      // No conventional bypassing in GPU (Syed)
+      // bypass.power = bypass.power + fp_bypass->power*pppm_t  +
+      // fpTagBypass->power*pppm_t ;
+      power = power + fp_u->power * pppm_freqScaling;
     }
- 
+    // No conventional bypassing in GPU (Syed)
 
-	if (is_tdp)
-	{
-		ifu->computeEnergy(is_tdp);
-		lsu->computeEnergy(is_tdp);
-		mmu->computeEnergy(is_tdp);
-		exu->computeEnergy(is_tdp);
+    power = power + rfu->power * pppm_freqScaling +
+            exeu->power * pppm_freqScaling /*+ bypass.power*/ + scheu->power;
 
-		if (coredynp.core_ty==OOO)
-		{
-			num_units = 5.0;
-			rnu->computeEnergy(is_tdp);
-			set_pppm(pppm_t, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units);
-			if (rnu->exist)
-			{
-				rnu->power = rnu->power + corepipe->power*pppm_t;
-				power     = power + rnu->power;
-			}
-		}
+  } else {
+    set_pppm(pppm_t, XML->sys.core[ithCore].cdb_alu_accesses, 2, 2,
+             XML->sys.core[ithCore].cdb_alu_accesses);
+    // bypass.rt_power = bypass.rt_power + intTagBypass->power*pppm_t;
+    // bypass.rt_power = bypass.rt_power + int_bypass->power*pppm_t;
 
-		if (ifu->exist)
-		{
-			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
-			set_pppm(pppm_t, coredynp.num_pipelines/num_units*coredynp.IFU_duty_cycle, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units);
-//			cout << "IFU = " << ifu->power.readOp.dynamic*clockRate  << " W" << endl;
-			ifu->power = ifu->power + corepipe->power*pppm_t;
-//			cout << "IFU = " << ifu->power.readOp.dynamic*clockRate  << " W" << endl;
-//			cout << "1/4 pipe = " << corepipe->power.readOp.dynamic*clockRate/num_units  << " W" << endl;
-			power     = power + ifu->power;
-//			cout << "core = " << power.readOp.dynamic*clockRate  << " W" << endl;
-		}
-		if (lsu->exist)
-		{
-			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
-			set_pppm(pppm_t, coredynp.num_pipelines/num_units*coredynp.LSU_duty_cycle, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units);
-			lsu->power = lsu->power + corepipe->power*pppm_t;
-//			cout << "LSU = " << lsu->power.readOp.dynamic*clockRate  << " W" << endl;
-			power     = power + lsu->power;
-//			cout << "core = " << power.readOp.dynamic*clockRate  << " W" << endl;
-		}
-		if (exu->exist)
-		{
-			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
-			set_pppm(pppm_t, coredynp.num_pipelines/num_units*coredynp.ALU_duty_cycle, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units);
-			//cout<<"ExPowerScalingFactor:"<<coredynp.num_pipelines/num_units*coredynp.ALU_duty_cycle<<endl;
-			exu->power = exu->power + corepipe->power*pppm_t;
-//			cout << "EXE = " << exu->power.readOp.dynamic*clockRate  << " W" << endl;
-			power     = power + exu->power;
-//			cout << "core = " << power.readOp.dynamic*clockRate  << " W" << endl;
-		}
-		if (mmu->exist)
-		{
-			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
-			set_pppm(pppm_t, coredynp.num_pipelines/num_units*(0.5+0.5*coredynp.LSU_duty_cycle), coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units);
-			mmu->power = mmu->power + corepipe->power*pppm_t;
-//			cout << "MMU = " << mmu->power.readOp.dynamic*clockRate  << " W" << endl;
-			power     = power +  mmu->power;
-//			cout << "core = " << power.readOp.dynamic*clockRate  << " W" << endl;
-		}
+    if (coredynp.num_muls > 0) {
+      set_pppm(pppm_t, XML->sys.core[ithCore].cdb_mul_accesses, 2, 2,
+               XML->sys.core[ithCore]
+                   .cdb_mul_accesses);  // 2 means two source operands needs to
+                                        // be passed for each int instruction.
+      // bypass.rt_power = bypass.rt_power + intTag_mul_Bypass->power*pppm_t +
+      // int_mul_bypass->power*pppm_t;
+      rt_power = rt_power + mul->rt_power;
+    }
 
-		power     = power +  undiffCore->power;
+    if (coredynp.num_fpus > 0) {
+      set_pppm(pppm_t, XML->sys.core[ithCore].cdb_fpu_accesses, 3, 3,
+               XML->sys.core[ithCore].cdb_fpu_accesses);
+      // bypass.rt_power = bypass.rt_power + fp_bypass->power*pppm_t;
+      // bypass.rt_power = bypass.rt_power + fpTagBypass->power*pppm_t;
+      rt_power = rt_power + fp_u->rt_power;
+    }
+    // No conventional bypassing in GPU (Syed)
+    rt_power = rt_power + rfu->rt_power * pppm_freqScaling +
+               exeu->rt_power * pppm_freqScaling +
+               /*bypass.rt_power +*/ scheu->rt_power;
+  }
+}
 
-		if (XML->sys.Private_L2)
-		{
+void EXECU::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  if (!exist) return;
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
 
-			l2cache->computeEnergy(is_tdp);
-			set_pppm(pppm_t,l2cache->cachep.clockRate/clockRate, 1,1,1);
-			//l2cache->power = l2cache->power*pppm_t;
-			power = power  + l2cache->power*pppm_t;
-		}
+  //	cout << indent_str_next << "Results Broadcast Bus Area = " <<
+  // bypass->area.get_area() *1e-6 << " mm^2" << endl;
+  if (is_tdp) {
+    cout << indent_str << "Register Files:" << endl;
+    cout << indent_str_next << "Area = " << rfu->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << rfu->power.readOp.dynamic * rf_fu_clockRate
+         << " W" << endl;
+    // cout << "rf_fu Clock rate: "<< rf_fu_clockRate<<endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? rfu->power.readOp.longer_channel_leakage
+                          : rfu->power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << rfu->power.readOp.gate_leakage << " W" << endl;
+    cout << indent_str_next
+         << "Runtime Dynamic = " << rfu->rt_power.readOp.dynamic / executionTime
+         << " W" << endl;
+    cout << endl;
+    if (plevel > 3) {
+      rfu->displayEnergy(indent + 4, is_tdp);
+    }
+    cout << indent_str << "Instruction Scheduler:" << endl;
+    cout << indent_str_next << "Area = " << scheu->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << scheu->power.readOp.dynamic * clockRate << " W"
+         << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? scheu->power.readOp.longer_channel_leakage
+                          : scheu->power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << scheu->power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << scheu->rt_power.readOp.dynamic / executionTime << " W" << endl;
+    cout << endl;
+    if (plevel > 3) {
+      scheu->displayEnergy(indent + 4, is_tdp);
+    }
+    exeu->displayEnergy(indent, is_tdp);
+    if (coredynp.num_fpus > 0) {
+      fp_u->displayEnergy(indent, is_tdp);
+    }
+    if (coredynp.num_muls > 0) {
+      mul->displayEnergy(indent, is_tdp);
+    }
+    cout << indent_str << "Results Broadcast Bus:" << endl;
+    cout << indent_str_next
+         << "Area Overhead = " << bypass.area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << bypass.power.readOp.dynamic * clockRate << " W"
+         << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? bypass.power.readOp.longer_channel_leakage
+                          : bypass.power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << bypass.power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << bypass.rt_power.readOp.dynamic / executionTime << " W" << endl;
+    cout << endl;
+  } else {
+    cout << indent_str_next << "Register Files    Peak Dynamic = "
+         << rfu->rt_power.readOp.dynamic * clockRate << " W" << endl;
+    cout << indent_str_next << "Register Files    Subthreshold Leakage = "
+         << rfu->rt_power.readOp.leakage << " W" << endl;
+    cout << indent_str_next << "Register Files    Gate Leakage = "
+         << rfu->rt_power.readOp.gate_leakage << " W" << endl;
+    cout << indent_str_next << "Instruction Sheduler   Peak Dynamic = "
+         << scheu->rt_power.readOp.dynamic * clockRate << " W" << endl;
+    cout << indent_str_next << "Instruction Sheduler   Subthreshold Leakage = "
+         << scheu->rt_power.readOp.leakage << " W" << endl;
+    cout << indent_str_next << "Instruction Sheduler   Gate Leakage = "
+         << scheu->rt_power.readOp.gate_leakage << " W" << endl;
+    cout << indent_str_next << "Results Broadcast Bus   Peak Dynamic = "
+         << bypass.rt_power.readOp.dynamic * clockRate << " W" << endl;
+    cout << indent_str_next << "Results Broadcast Bus   Subthreshold Leakage = "
+         << bypass.rt_power.readOp.leakage << " W" << endl;
+    cout << indent_str_next << "Results Broadcast Bus   Gate Leakage = "
+         << bypass.rt_power.readOp.gate_leakage << " W" << endl;
+  }
+}
 
-	}
-	else
-	{
+// Jingwen
+void Core::compute() {
+  // power_point_product_masks
+  double pppm_t[4] = {1, 1, 1, 1};
+  double rtp_pipeline_coe;
+  double num_units = 4.0;
+  Pipeline_energy = 0;
+
+  // Set pipeline duty cycle for this inteval
+  coredynp.pipeline_duty_cycle = XML->sys.core[ithCore].pipeline_duty_cycle;
+  rt_power.reset();
+  ifu->rt_power.reset();
+  lsu->rt_power.reset();
+  mmu->rt_power.reset();
+  exu->rt_power.reset();
+
+  ifu->computeEnergy(false);
+  lsu->computeEnergy(false);
+  mmu->computeEnergy(false);
+  exu->computeEnergy(false);
+
+  if (XML->sys.homogeneous_cores == 1) {
+    rtp_pipeline_coe = coredynp.pipeline_duty_cycle * XML->sys.total_cycles *
+                       XML->sys.number_of_cores;
+  } else {
+    rtp_pipeline_coe = coredynp.pipeline_duty_cycle * coredynp.total_cycles;
+    // Jingwen
+    if (coredynp.total_cycles != XML->sys.total_cycles) {
+      cout << "total cycle not match!" << endl;
+      exit(1);
+    }
+  }
+
+  set_pppm(pppm_t, coredynp.num_pipelines * rtp_pipeline_coe / num_units,
+           coredynp.num_pipelines / num_units,
+           coredynp.num_pipelines / num_units,
+           coredynp.num_pipelines / num_units);
+
+  if (ifu->exist) {
+    Pipeline_energy += corepipe->power.readOp.dynamic *
+                       (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
+    ifu->rt_power = ifu->rt_power + corepipe->power * pppm_t;
+    rt_power = rt_power + ifu->rt_power;
+  }
+
+  if (lsu->exist) {
+    Pipeline_energy += corepipe->power.readOp.dynamic *
+                       (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
+    lsu->rt_power = lsu->rt_power + corepipe->power * pppm_t;
+    rt_power = rt_power + lsu->rt_power;
+  }
+  if (exu->exist) {
+    Pipeline_energy += corepipe->power.readOp.dynamic *
+                       (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
+    exu->rt_power = exu->rt_power + corepipe->power * pppm_t;
+    rt_power = rt_power + exu->rt_power;
+  }
+  if (mmu->exist) {
+    Pipeline_energy += corepipe->power.readOp.dynamic *
+                       (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
+    mmu->rt_power = mmu->rt_power + corepipe->power * pppm_t;
+    rt_power = rt_power + mmu->rt_power;
+  }
+
+  rt_power = rt_power + undiffCore->power;
+
+  if (XML->sys.Private_L2) {
+    l2cache->computeEnergy(false);
+    rt_power = rt_power + l2cache->rt_power;
+  }
+
+  IdleCoreEnergy =
+      XML->sys.num_idle_cores * XML->sys.idle_core_power * executionTime;
+
+  rt_power.readOp.dynamic += IdleCoreEnergy;
+}
+
+void Core::computeEnergy(bool is_tdp) {
+  // power_point_product_masks
+  double pppm_t[4] = {1, 1, 1, 1};
+  double rtp_pipeline_coe;
+  double num_units = 4.0;
+  Pipeline_energy = 0;
+
+  if (XML->sys.homogeneous_cores == 1) {
+    rtp_pipeline_coe = coredynp.pipeline_duty_cycle * XML->sys.total_cycles *
+                       XML->sys.number_of_cores;
+  } else {
+    rtp_pipeline_coe = coredynp.pipeline_duty_cycle * coredynp.total_cycles;
+  }
+
+  if (is_tdp) {
+    ifu->computeEnergy(is_tdp);
+    lsu->computeEnergy(is_tdp);
+    mmu->computeEnergy(is_tdp);
+    exu->computeEnergy(is_tdp);
+
+    if (coredynp.core_ty == OOO) {
+      num_units = 5.0;
+      rnu->computeEnergy(is_tdp);
+      set_pppm(pppm_t, coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units);
+      if (rnu->exist) {
+        rnu->power = rnu->power + corepipe->power * pppm_t;
+        power = power + rnu->power;
+      }
+    }
+
+    if (ifu->exist) {
+      Pipeline_energy +=
+          corepipe->power.readOp.dynamic *
+          (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
+      set_pppm(pppm_t,
+               coredynp.num_pipelines / num_units * coredynp.IFU_duty_cycle,
+               coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units);
+      //			cout << "IFU = " <<
+      // ifu->power.readOp.dynamic*clockRate  << " W" << endl;
+      ifu->power = ifu->power + corepipe->power * pppm_t;
+      //			cout << "IFU = " <<
+      // ifu->power.readOp.dynamic*clockRate  << " W" << endl;
+      // cout << "1/4 pipe = " <<
+      // corepipe->power.readOp.dynamic*clockRate/num_units  << " W" << endl;
+      power = power + ifu->power;
+      //			cout << "core = " <<
+      // power.readOp.dynamic*clockRate  << " W" << endl;
+    }
+    if (lsu->exist) {
+      Pipeline_energy +=
+          corepipe->power.readOp.dynamic *
+          (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
+      set_pppm(pppm_t,
+               coredynp.num_pipelines / num_units * coredynp.LSU_duty_cycle,
+               coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units);
+      lsu->power = lsu->power + corepipe->power * pppm_t;
+      //			cout << "LSU = " <<
+      // lsu->power.readOp.dynamic*clockRate  << " W" << endl;
+      power = power + lsu->power;
+      //			cout << "core = " <<
+      // power.readOp.dynamic*clockRate  << " W" << endl;
+    }
+    if (exu->exist) {
+      Pipeline_energy +=
+          corepipe->power.readOp.dynamic *
+          (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
+      set_pppm(pppm_t,
+               coredynp.num_pipelines / num_units * coredynp.ALU_duty_cycle,
+               coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units);
+      // cout<<"ExPowerScalingFactor:"<<coredynp.num_pipelines/num_units*coredynp.ALU_duty_cycle<<endl;
+      exu->power = exu->power + corepipe->power * pppm_t;
+      //			cout << "EXE = " <<
+      // exu->power.readOp.dynamic*clockRate  << " W" << endl;
+      power = power + exu->power;
+      //			cout << "core = " <<
+      // power.readOp.dynamic*clockRate  << " W" << endl;
+    }
+    if (mmu->exist) {
+      Pipeline_energy +=
+          corepipe->power.readOp.dynamic *
+          (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
+      set_pppm(pppm_t,
+               coredynp.num_pipelines / num_units *
+                   (0.5 + 0.5 * coredynp.LSU_duty_cycle),
+               coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units);
+      mmu->power = mmu->power + corepipe->power * pppm_t;
+      //			cout << "MMU = " <<
+      // mmu->power.readOp.dynamic*clockRate  << " W" << endl;
+      power = power + mmu->power;
+      //			cout << "core = " <<
+      // power.readOp.dynamic*clockRate  << " W" << endl;
+    }
+
+    power = power + undiffCore->power;
+
+    if (XML->sys.Private_L2) {
+      l2cache->computeEnergy(is_tdp);
+      set_pppm(pppm_t, l2cache->cachep.clockRate / clockRate, 1, 1, 1);
+      // l2cache->power = l2cache->power*pppm_t;
+      power = power + l2cache->power * pppm_t;
+    }
+
+  } else {
     rt_power.reset();
 
+    ifu->computeEnergy(is_tdp);
+    lsu->computeEnergy(is_tdp);
+    mmu->computeEnergy(is_tdp);
+    exu->computeEnergy(is_tdp);
+    if (coredynp.core_ty == OOO) {
+      num_units = 5.0;
+      rnu->computeEnergy(is_tdp);
+      set_pppm(pppm_t, coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units);
+      if (rnu->exist) {
+        rnu->rt_power = rnu->rt_power + corepipe->power * pppm_t;
 
+        rt_power = rt_power + rnu->rt_power;
+      }
+    } else {
+      set_pppm(pppm_t, coredynp.num_pipelines * rtp_pipeline_coe / num_units,
+               coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units);
+    }
 
+    if (ifu->exist) {
+      Pipeline_energy +=
+          corepipe->power.readOp.dynamic *
+          (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
+      ifu->rt_power = ifu->rt_power + corepipe->power * pppm_t;
+      rt_power = rt_power + ifu->rt_power;
+    }
+    if (lsu->exist) {
+      Pipeline_energy +=
+          corepipe->power.readOp.dynamic *
+          (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
+      lsu->rt_power = lsu->rt_power + corepipe->power * pppm_t;
+      rt_power = rt_power + lsu->rt_power;
+    }
+    if (exu->exist) {
+      Pipeline_energy +=
+          corepipe->power.readOp.dynamic *
+          (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
+      exu->rt_power = exu->rt_power + corepipe->power * pppm_t;
+      rt_power = rt_power + exu->rt_power;
+    }
+    if (mmu->exist) {
+      Pipeline_energy +=
+          corepipe->power.readOp.dynamic *
+          (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
+      mmu->rt_power = mmu->rt_power + corepipe->power * pppm_t;
+      rt_power = rt_power + mmu->rt_power;
+    }
 
-		ifu->computeEnergy(is_tdp);
-		lsu->computeEnergy(is_tdp);
-		mmu->computeEnergy(is_tdp);
-		exu->computeEnergy(is_tdp);
-		if (coredynp.core_ty==OOO)
-		{
-			num_units = 5.0;
-			rnu->computeEnergy(is_tdp);
-        	set_pppm(pppm_t, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units);
-			if (rnu->exist)
-			{
-        	rnu->rt_power = rnu->rt_power + corepipe->power*pppm_t;
-
-			rt_power      = rt_power + rnu->rt_power;
-			}
-		}
-		else
-		{
-
-		    set_pppm(pppm_t, coredynp.num_pipelines*rtp_pipeline_coe/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units);
-		}
-
-		if (ifu->exist)
-		{
-			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
-			ifu->rt_power = ifu->rt_power + corepipe->power*pppm_t;
-			rt_power     = rt_power + ifu->rt_power ;
-		}
-		if (lsu->exist)
-		{
-			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
-			lsu->rt_power = lsu->rt_power + corepipe->power*pppm_t;
-			rt_power     = rt_power  + lsu->rt_power;
-		}
-		if (exu->exist)
-		{
-			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
-			exu->rt_power = exu->rt_power + corepipe->power*pppm_t;
-			rt_power     = rt_power  + exu->rt_power;
-		}
-		if (mmu->exist)
-		{
-			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
-			mmu->rt_power = mmu->rt_power + corepipe->power*pppm_t;
-			rt_power     = rt_power +  mmu->rt_power ;
-		}
-
-		rt_power     = rt_power +  undiffCore->power;
-//		cout << "EXE = " << exu->power.readOp.dynamic*clockRate  << " W" << endl;
-		if (XML->sys.Private_L2)
-		{
-			l2cache->computeEnergy(is_tdp);
-			//set_pppm(pppm_t,1/l2cache->cachep.executionTime, 1,1,1);
-			//l2cache->rt_power = l2cache->rt_power*pppm_t;
-			rt_power = rt_power  + l2cache->rt_power;
-		}
-
-	}
-
+    rt_power = rt_power + undiffCore->power;
+    //		cout << "EXE = " << exu->power.readOp.dynamic*clockRate  << " W"
+    //<< endl;
+    if (XML->sys.Private_L2) {
+      l2cache->computeEnergy(is_tdp);
+      // set_pppm(pppm_t,1/l2cache->cachep.executionTime, 1,1,1);
+      // l2cache->rt_power = l2cache->rt_power*pppm_t;
+      rt_power = rt_power + l2cache->rt_power;
+    }
+  }
 }
 
-void Core::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
-	if (is_tdp)
-	{
-		cout << "Core:" << endl;
-		cout << indent_str << "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str << "Subthreshold Leakage = "
-			<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
-		//cout << indent_str << "Subthreshold Leakage = " << power.readOp.longer_channel_leakage <<" W" << endl;
-		cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str << "Runtime Dynamic = " << rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout<<endl;
-		if (ifu->exist)
-		{
-			cout << indent_str << "Instruction Fetch Unit:" << endl;
-			cout << indent_str_next << "Area = " << ifu->area.get_area()*1e-6<< " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << ifu->power.readOp.dynamic*clockRate << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? ifu->power.readOp.longer_channel_leakage:ifu->power.readOp.leakage) <<" W" << endl;
-			//cout << indent_str_next << "Subthreshold Leakage = " << ifu->power.readOp.longer_channel_leakage <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << ifu->power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << ifu->rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-			if (plevel >2){
-				ifu->displayEnergy(indent+4,plevel,is_tdp);
-			}
-		}
-		if (coredynp.core_ty==OOO)
-		{
-			if (rnu->exist)
-			{
-				cout << indent_str<< "Renaming Unit:" << endl;
-				cout << indent_str_next << "Area = " << rnu->area.get_area()*1e-6  << " mm^2" << endl;
-				cout << indent_str_next << "Peak Dynamic = " << rnu->power.readOp.dynamic*clockRate  << " W" << endl;
-				cout << indent_str_next << "Subthreshold Leakage = "
-					<< (long_channel? rnu->power.readOp.longer_channel_leakage:rnu->power.readOp.leakage)  << " W" << endl;
-				//cout << indent_str_next << "Subthreshold Leakage = " << rnu->power.readOp.longer_channel_leakage  << " W" << endl;
-				cout << indent_str_next << "Gate Leakage = " << rnu->power.readOp.gate_leakage  << " W" << endl;
-				cout << indent_str_next << "Runtime Dynamic = " << rnu->rt_power.readOp.dynamic/executionTime << " W" << endl;
-				cout <<endl;
-				if (plevel >2){
-					rnu->displayEnergy(indent+4,plevel,is_tdp);
-				}
-			}
+void Core::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
+  if (is_tdp) {
+    cout << "Core:" << endl;
+    cout << indent_str << "Area = " << area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic * clockRate
+         << " W" << endl;
+    cout << indent_str << "Subthreshold Leakage = "
+         << (long_channel ? power.readOp.longer_channel_leakage
+                          : power.readOp.leakage)
+         << " W" << endl;
+    // cout << indent_str << "Subthreshold Leakage = " <<
+    // power.readOp.longer_channel_leakage <<" W" << endl;
+    cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str
+         << "Runtime Dynamic = " << rt_power.readOp.dynamic / executionTime
+         << " W" << endl;
+    cout << endl;
+    if (ifu->exist) {
+      cout << indent_str << "Instruction Fetch Unit:" << endl;
+      cout << indent_str_next << "Area = " << ifu->area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << ifu->power.readOp.dynamic * clockRate << " W"
+           << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? ifu->power.readOp.longer_channel_leakage
+                            : ifu->power.readOp.leakage)
+           << " W" << endl;
+      // cout << indent_str_next << "Subthreshold Leakage = " <<
+      // ifu->power.readOp.longer_channel_leakage <<" W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << ifu->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << ifu->rt_power.readOp.dynamic / executionTime << " W" << endl;
+      cout << endl;
+      if (plevel > 2) {
+        ifu->displayEnergy(indent + 4, plevel, is_tdp);
+      }
+    }
+    if (coredynp.core_ty == OOO) {
+      if (rnu->exist) {
+        cout << indent_str << "Renaming Unit:" << endl;
+        cout << indent_str_next << "Area = " << rnu->area.get_area() * 1e-6
+             << " mm^2" << endl;
+        cout << indent_str_next
+             << "Peak Dynamic = " << rnu->power.readOp.dynamic * clockRate
+             << " W" << endl;
+        cout << indent_str_next << "Subthreshold Leakage = "
+             << (long_channel ? rnu->power.readOp.longer_channel_leakage
+                              : rnu->power.readOp.leakage)
+             << " W" << endl;
+        // cout << indent_str_next << "Subthreshold Leakage = " <<
+        // rnu->power.readOp.longer_channel_leakage  << " W" << endl;
+        cout << indent_str_next
+             << "Gate Leakage = " << rnu->power.readOp.gate_leakage << " W"
+             << endl;
+        cout << indent_str_next << "Runtime Dynamic = "
+             << rnu->rt_power.readOp.dynamic / executionTime << " W" << endl;
+        cout << endl;
+        if (plevel > 2) {
+          rnu->displayEnergy(indent + 4, plevel, is_tdp);
+        }
+      }
+    }
+    if (lsu->exist) {
+      cout << indent_str << "Load Store Unit:" << endl;
+      cout << indent_str_next << "Area = " << lsu->area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << lsu->power.readOp.dynamic * clockRate << " W"
+           << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? lsu->power.readOp.longer_channel_leakage
+                            : lsu->power.readOp.leakage)
+           << " W" << endl;
+      // cout << indent_str_next << "Subthreshold Leakage = " <<
+      // lsu->power.readOp.longer_channel_leakage  << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << lsu->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << lsu->rt_power.readOp.dynamic / executionTime << " W" << endl;
+      cout << endl;
+      if (plevel > 2) {
+        lsu->displayEnergy(indent + 4, plevel, is_tdp);
+      }
+    }
+    if (mmu->exist) {
+      cout << indent_str << "Memory Management Unit:" << endl;
+      cout << indent_str_next << "Area = " << mmu->area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << mmu->power.readOp.dynamic * clockRate << " W"
+           << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? mmu->power.readOp.longer_channel_leakage
+                            : mmu->power.readOp.leakage)
+           << " W" << endl;
+      // cout << indent_str_next << "Subthreshold Leakage = " <<
+      // mmu->power.readOp.longer_channel_leakage   << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << mmu->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << mmu->rt_power.readOp.dynamic / executionTime << " W" << endl;
+      cout << endl;
+      if (plevel > 2) {
+        mmu->displayEnergy(indent + 4, plevel, is_tdp);
+      }
+    }
+    if (exu->exist) {
+      cout << indent_str << "Execution Unit:" << endl;
+      cout << indent_str_next << "Area = " << exu->area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << exu->power.readOp.dynamic * clockRate << " W"
+           << endl;
+      cout << indent_str_next
+           << "Peak Dynamic Energy = " << exu->power.readOp.dynamic << " W"
+           << endl;
+      cout << indent_str_next << "clock Rate = " << clockRate << " W" << endl;
 
-		}
-		if (lsu->exist)
-		{
-			cout << indent_str<< "Load Store Unit:" << endl;
-			cout << indent_str_next << "Area = " << lsu->area.get_area()*1e-6  << " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << lsu->power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? lsu->power.readOp.longer_channel_leakage:lsu->power.readOp.leakage ) << " W" << endl;
-			//cout << indent_str_next << "Subthreshold Leakage = " << lsu->power.readOp.longer_channel_leakage  << " W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << lsu->power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << lsu->rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-			if (plevel >2){
-				lsu->displayEnergy(indent+4,plevel,is_tdp);
-			}
-		}
-		if (mmu->exist)
-		{
-			cout << indent_str<< "Memory Management Unit:" << endl;
-			cout << indent_str_next << "Area = " << mmu->area.get_area() *1e-6 << " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << mmu->power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? mmu->power.readOp.longer_channel_leakage:mmu->power.readOp.leakage)   << " W" << endl;
-			//cout << indent_str_next << "Subthreshold Leakage = " << mmu->power.readOp.longer_channel_leakage   << " W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << mmu->power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << mmu->rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-			if (plevel >2){
-				mmu->displayEnergy(indent+4,plevel,is_tdp);
-			}
-		}
-		if (exu->exist)
-		{
-			cout << indent_str<< "Execution Unit:" << endl;
-			cout << indent_str_next << "Area = " << exu->area.get_area()  *1e-6<< " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << exu->power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Peak Dynamic Energy = " << exu->power.readOp.dynamic  << " W" << endl;
-			cout << indent_str_next << "clock Rate = " << clockRate  << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? exu->power.readOp.longer_channel_leakage
+                            : exu->power.readOp.leakage)
+           << " W" << endl;
+      // cout << indent_str_next << "Subthreshold Leakage = " <<
+      // exu->power.readOp.longer_channel_leakage << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << exu->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << exu->rt_power.readOp.dynamic / executionTime << " W" << endl;
+      cout << endl;
+      if (plevel > 2) {
+        exu->displayEnergy(indent + 4, plevel, is_tdp);
+      }
+    }
+    //		if (plevel >2)
+    //		{
+    //			if (undiffCore->exist)
+    //			{
+    //				cout << indent_str << "Undifferentiated Core" <<
+    // endl; 				cout << indent_str_next << "Area = " <<
+    // undiffCore->area.get_area()*1e-6<< " mm^2" << endl;
+    // cout
+    // << indent_str_next << "Peak Dynamic = " <<
+    // undiffCore->power.readOp.dynamic*clockRate << " W" << endl;
+    ////				cout << indent_str_next << "Subthreshold Leakage =
+    ///"
+    ///<< undiffCore->power.readOp.leakage <<" W" << endl;
+    //				cout << indent_str_next << "Subthreshold Leakage
+    //=
+    //"
+    //								<<
+    //(long_channel?
+    // undiffCore->power.readOp.longer_channel_leakage:undiffCore->power.readOp.leakage)
+    //<< " W" << endl; 				cout << indent_str_next << "Gate Leakage =
+    //"
+    //<< undiffCore->power.readOp.gate_leakage << " W" << endl;
+    //				//		cout << indent_str_next << "Runtime Dynamic =
+    //"
+    //<< undiffCore->rt_power.readOp.dynamic/executionTime << " W" << endl;
+    // cout
+    //<<endl;
+    //			}
+    //		}
+    if (XML->sys.Private_L2) {
+      l2cache->displayEnergy(4, is_tdp);
+    }
 
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? exu->power.readOp.longer_channel_leakage:exu->power.readOp.leakage)   << " W" << endl;
-			//cout << indent_str_next << "Subthreshold Leakage = " << exu->power.readOp.longer_channel_leakage << " W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << exu->power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << exu->rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-			if (plevel >2){
-				exu->displayEnergy(indent+4,plevel,is_tdp);
-			}
-		}
-//		if (plevel >2)
-//		{
-//			if (undiffCore->exist)
-//			{
-//				cout << indent_str << "Undifferentiated Core" << endl;
-//				cout << indent_str_next << "Area = " << undiffCore->area.get_area()*1e-6<< " mm^2" << endl;
-//				cout << indent_str_next << "Peak Dynamic = " << undiffCore->power.readOp.dynamic*clockRate << " W" << endl;
-////				cout << indent_str_next << "Subthreshold Leakage = " << undiffCore->power.readOp.leakage <<" W" << endl;
-//				cout << indent_str_next << "Subthreshold Leakage = "
-//								<< (long_channel? undiffCore->power.readOp.longer_channel_leakage:undiffCore->power.readOp.leakage)   << " W" << endl;
-//				cout << indent_str_next << "Gate Leakage = " << undiffCore->power.readOp.gate_leakage << " W" << endl;
-//				//		cout << indent_str_next << "Runtime Dynamic = " << undiffCore->rt_power.readOp.dynamic/executionTime << " W" << endl;
-//				cout <<endl;
-//			}
-//		}
-		if (XML->sys.Private_L2)
-		{
+    cout << indent_str << "Idle Core: " << endl;
+    cout << indent_str_next
+         << "Runtime Dynamic = " << IdleCoreEnergy / executionTime << " W\n"
+         << endl;
 
-			l2cache->displayEnergy(4,is_tdp);
-		}
-
-		cout << indent_str<< "Idle Core: " << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << IdleCoreEnergy/executionTime << " W\n" << endl;
-
-	}
-	else
-	{
-//		cout << indent_str_next << "Instruction Fetch Unit    Peak Dynamic = " << ifu->rt_power.readOp.dynamic*clockRate << " W" << endl;
-//		cout << indent_str_next << "Instruction Fetch Unit    Subthreshold Leakage = " << ifu->rt_power.readOp.leakage <<" W" << endl;
-//		cout << indent_str_next << "Instruction Fetch Unit    Gate Leakage = " << ifu->rt_power.readOp.gate_leakage << " W" << endl;
-//		cout << indent_str_next << "Load Store Unit   Peak Dynamic = " << lsu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-//		cout << indent_str_next << "Load Store Unit   Subthreshold Leakage = " << lsu->rt_power.readOp.leakage  << " W" << endl;
-//		cout << indent_str_next << "Load Store Unit   Gate Leakage = " << lsu->rt_power.readOp.gate_leakage  << " W" << endl;
-//		cout << indent_str_next << "Memory Management Unit   Peak Dynamic = " << mmu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-//		cout << indent_str_next << "Memory Management Unit   Subthreshold Leakage = " << mmu->rt_power.readOp.leakage  << " W" << endl;
-//		cout << indent_str_next << "Memory Management Unit   Gate Leakage = " << mmu->rt_power.readOp.gate_leakage  << " W" << endl;
-//		cout << indent_str_next << "Execution Unit   Peak Dynamic = " << exu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-//		cout << indent_str_next << "Execution Unit   Subthreshold Leakage = " << exu->rt_power.readOp.leakage  << " W" << endl;
-//		cout << indent_str_next << "Execution Unit   Gate Leakage = " << exu->rt_power.readOp.gate_leakage  << " W" << endl;
-	}
+  } else {
+    //		cout << indent_str_next << "Instruction Fetch Unit    Peak Dynamic
+    //=
+    //"
+    //<< ifu->rt_power.readOp.dynamic*clockRate << " W" << endl;
+    //cout
+    //<< indent_str_next << "Instruction Fetch Unit    Subthreshold Leakage = "
+    // << ifu->rt_power.readOp.leakage <<" W" << endl; 		cout <<
+    // indent_str_next << "Instruction Fetch Unit    Gate Leakage = " <<
+    // ifu->rt_power.readOp.gate_leakage << " W" << endl; 		cout <<
+    // indent_str_next
+    //<< "Load Store Unit   Peak Dynamic = " <<
+    // lsu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    // cout
+    // << indent_str_next << "Load Store Unit   Subthreshold Leakage = " <<
+    // lsu->rt_power.readOp.leakage  << " W" << endl; 		cout <<
+    // indent_str_next
+    // << "Load Store Unit   Gate Leakage = " <<
+    // lsu->rt_power.readOp.gate_leakage
+    //<< " W" << endl; 		cout << indent_str_next << "Memory Management
+    //Unit Peak Dynamic = " << mmu->rt_power.readOp.dynamic*clockRate  << " W"
+    // <<
+    // endl; 		cout << indent_str_next << "Memory Management Unit
+    // Subthreshold Leakage = " << mmu->rt_power.readOp.leakage  << " W" <<
+    // endl; 		cout
+    // << indent_str_next << "Memory Management Unit   Gate Leakage = " <<
+    // mmu->rt_power.readOp.gate_leakage  << " W" << endl; 		cout <<
+    // indent_str_next << "Execution Unit   Peak Dynamic = " <<
+    // exu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    // cout
+    // << indent_str_next << "Execution Unit   Subthreshold Leakage = " <<
+    // exu->rt_power.readOp.leakage  << " W" << endl; 		cout <<
+    // indent_str_next
+    // << "Execution Unit   Gate Leakage = " <<
+    // exu->rt_power.readOp.gate_leakage
+    //<< " W" << endl;
+  }
 }
-InstFetchU ::~InstFetchU(){
-
-	if (!exist) return;
-	if(IB) 	                   {delete IB; IB = 0;}
-	if(ID_inst) 	           {delete ID_inst; ID_inst = 0;}
-	if(ID_operand) 	           {delete ID_operand; ID_operand = 0;}
-	if(ID_misc) 	           {delete ID_misc; ID_misc = 0;}
-	if (coredynp.predictionW>0)
-	{
-		if(BTB) 	               {delete BTB; BTB = 0;}
-		if(BPT) 	               {delete BPT; BPT = 0;}
-	}
+InstFetchU ::~InstFetchU() {
+  if (!exist) return;
+  if (IB) {
+    delete IB;
+    IB = 0;
+  }
+  if (ID_inst) {
+    delete ID_inst;
+    ID_inst = 0;
+  }
+  if (ID_operand) {
+    delete ID_operand;
+    ID_operand = 0;
+  }
+  if (ID_misc) {
+    delete ID_misc;
+    ID_misc = 0;
+  }
+  if (coredynp.predictionW > 0) {
+    if (BTB) {
+      delete BTB;
+      BTB = 0;
+    }
+    if (BPT) {
+      delete BPT;
+      BPT = 0;
+    }
+  }
 }
 
-BranchPredictor ::~BranchPredictor(){
-
-	if (!exist) return;
-	if(globalBPT) 	           {delete globalBPT; globalBPT = 0;}
-	if(localBPT) 	           {delete localBPT; localBPT = 0;}
-    if(L1_localBPT) 	       {delete L1_localBPT; L1_localBPT = 0;}
-    if(L2_localBPT) 	       {delete L2_localBPT; L2_localBPT = 0;}
-    if(chooser) 	           {delete chooser; chooser = 0;}
-    if(RAS) 	               {delete RAS; RAS = 0;}
-	}
-
-RENAMINGU ::~RENAMINGU(){
-
-	if (!exist) return;
-	if(iFRAT ) 	               {delete iFRAT; iFRAT = 0;}
-    if(fFRAT ) 	               {delete fFRAT; fFRAT =0;}
-    if(iRRAT)                  {delete iRRAT; iRRAT = 0;}
-    if(iFRAT)                  {delete iFRAT; iFRAT = 0;}
-    if(ifreeL)                 {delete ifreeL;ifreeL= 0;}
-    if(ffreeL)                 {delete ffreeL;ffreeL= 0;}
-    if(idcl)                   {delete idcl;  idcl = 0;}
-    if(fdcl)                   {delete fdcl;  fdcl = 0;}
-    if(RAHT)                   {delete RAHT;  RAHT = 0;}
-	}
-
-LoadStoreU ::~LoadStoreU(){
-
-	if (!exist) return;
-	if(LSQ) 	               {delete LSQ; LSQ = 0;}
-	}
-
-MemManU ::~MemManU(){
-
-	if (!exist) return;
-	if(itlb) 	               {delete itlb; itlb = 0;}
-    if(dtlb) 	               {delete dtlb; dtlb = 0;}
-	}
-
-RegFU ::~RegFU(){
-
-	if (!exist) return;
-	if(IRF) 	               {delete IRF; IRF = 0;}
-    if(FRF) 	               {delete FRF; FRF = 0;}
-    if(RFWIN) 	               {delete RFWIN; RFWIN = 0;}
-	}
-
-SchedulerU ::~SchedulerU(){
-
-	if (!exist) return;
-	if(int_inst_window) 	   {delete int_inst_window; int_inst_window = 0;}
-	if(fp_inst_window) 	       {delete int_inst_window; int_inst_window = 0;}
-	if(ROB) 	               {delete ROB; ROB = 0;}
-    if(instruction_selection)  {delete instruction_selection;instruction_selection = 0;}
-	}
-
-EXECU ::~EXECU(){
-
-	if (!exist) return;
-	if(int_bypass) 	           {delete int_bypass; int_bypass = 0;}
-    if(intTagBypass) 	       {delete intTagBypass; intTagBypass =0;}
-    if(int_mul_bypass) 	       {delete int_mul_bypass; int_mul_bypass = 0;}
-    if(intTag_mul_Bypass) 	   {delete intTag_mul_Bypass; intTag_mul_Bypass =0;}
-    if(fp_bypass) 	           {delete fp_bypass;fp_bypass = 0;}
-    if(fpTagBypass) 	       {delete fpTagBypass;fpTagBypass = 0;}
-    if(fp_u)                   {delete fp_u;fp_u = 0;}
-    if(exeu)                   {delete exeu;exeu = 0;}
-    if(mul)                    {delete mul;mul = 0;}
-    if(rfu)                    {delete rfu;rfu = 0;}
-	if(scheu) 	               {delete scheu; scheu = 0;}
-	}
-
-Core ::~Core(){
-
-	if(ifu) 	               {delete ifu; ifu = 0;}
-	if(lsu) 	               {delete lsu; lsu = 0;}
-	if(rnu) 	               {delete rnu; rnu = 0;}
-	if(mmu) 	               {delete mmu; mmu = 0;}
-	if(exu) 	               {delete exu; exu = 0;}
-    if(corepipe) 	           {delete corepipe; corepipe = 0;}
-    if(undiffCore)             {delete undiffCore;undiffCore = 0;}
-    if(l2cache)                {delete l2cache;l2cache = 0;}
-	}
-
-void Core::set_core_param()
-{
-	coredynp.opt_local = XML->sys.core[ithCore].opt_local;
-	coredynp.x86 = XML->sys.core[ithCore].x86;
-	coredynp.Embedded = XML->sys.Embedded;
-	coredynp.core_ty   = (enum Core_type)XML->sys.core[ithCore].machine_type;
-	coredynp.rm_ty     = (enum Renaming_type)XML->sys.core[ithCore].rename_scheme;
-    coredynp.fetchW    = XML->sys.core[ithCore].fetch_width;
-    coredynp.decodeW   = XML->sys.core[ithCore].decode_width;
-    coredynp.issueW    = XML->sys.core[ithCore].issue_width;
-    coredynp.peak_issueW   = XML->sys.core[ithCore].peak_issue_width;
-    coredynp.commitW       = XML->sys.core[ithCore].commit_width;
-    coredynp.peak_commitW  = XML->sys.core[ithCore].peak_issue_width;
-    coredynp.predictionW   = XML->sys.core[ithCore].prediction_width;
-    coredynp.fp_issueW     = XML->sys.core[ithCore].fp_issue_width;
-    coredynp.fp_decodeW    = XML->sys.core[ithCore].fp_issue_width;
-    coredynp.num_alus      = XML->sys.core[ithCore].ALU_per_core;
-    coredynp.num_fpus      = XML->sys.core[ithCore].FPU_per_core;
-    coredynp.num_muls      = XML->sys.core[ithCore].MUL_per_core;
-
-
-    coredynp.num_hthreads	     = XML->sys.core[ithCore].number_hardware_threads;
-    coredynp.multithreaded       = coredynp.num_hthreads>1? true:false;
-    coredynp.instruction_length  = XML->sys.core[ithCore].instruction_length;
-    coredynp.pc_width            = XML->sys.virtual_address_width;
-
-   	coredynp.opcode_length       = XML->sys.core[ithCore].opcode_width;
-    coredynp.micro_opcode_length = XML->sys.core[ithCore].micro_opcode_width;
-    coredynp.num_pipelines       = XML->sys.core[ithCore].pipelines_per_core[0];
-    coredynp.pipeline_stages     = XML->sys.core[ithCore].pipeline_depth[0];
-    coredynp.num_fp_pipelines    = XML->sys.core[ithCore].pipelines_per_core[1];
-    coredynp.fp_pipeline_stages  = XML->sys.core[ithCore].pipeline_depth[1];
-    coredynp.int_data_width      = int(ceil(XML->sys.machine_bits/32.0))*32;
-    coredynp.fp_data_width       = coredynp.int_data_width;
-    coredynp.v_address_width     = XML->sys.virtual_address_width;
-    coredynp.p_address_width     = XML->sys.physical_address_width;
-
-	coredynp.scheu_ty         = (enum Scheduler_type)XML->sys.core[ithCore].instruction_window_scheme;
-	coredynp.arch_ireg_width  =  int(ceil(log2(XML->sys.core[ithCore].archi_Regs_IRF_size)));
-	coredynp.arch_freg_width  =  int(ceil(log2(XML->sys.core[ithCore].archi_Regs_FRF_size)));
-	coredynp.num_IRF_entry    = XML->sys.core[ithCore].archi_Regs_IRF_size;
-	coredynp.num_FRF_entry    = XML->sys.core[ithCore].archi_Regs_FRF_size;
-	coredynp.pipeline_duty_cycle = XML->sys.core[ithCore].pipeline_duty_cycle;
-	coredynp.total_cycles        = XML->sys.core[ithCore].total_cycles;
-	coredynp.busy_cycles         = XML->sys.core[ithCore].busy_cycles;
-	coredynp.idle_cycles         = XML->sys.core[ithCore].idle_cycles;
-
-	//Max power duty cycle for peak power estimation
-//	if (coredynp.core_ty==OOO)
-//	{
-//		coredynp.IFU_duty_cycle = 1;
-//		coredynp.LSU_duty_cycle = 1;
-//		coredynp.MemManU_I_duty_cycle =1;
-//		coredynp.MemManU_D_duty_cycle =1;
-//		coredynp.ALU_duty_cycle =1;
-//		coredynp.MUL_duty_cycle =1;
-//		coredynp.FPU_duty_cycle =1;
-//		coredynp.ALU_cdb_duty_cycle =1;
-//		coredynp.MUL_cdb_duty_cycle =1;
-//		coredynp.FPU_cdb_duty_cycle =1;
-//	}
-//	else
-//	{
-		coredynp.IFU_duty_cycle = XML->sys.core[ithCore].IFU_duty_cycle;
-		coredynp.BR_duty_cycle = XML->sys.core[ithCore].BR_duty_cycle;
-		coredynp.LSU_duty_cycle = XML->sys.core[ithCore].LSU_duty_cycle;
-		coredynp.MemManU_I_duty_cycle = XML->sys.core[ithCore].MemManU_I_duty_cycle;
-		coredynp.MemManU_D_duty_cycle = XML->sys.core[ithCore].MemManU_D_duty_cycle;
-		coredynp.ALU_duty_cycle = XML->sys.core[ithCore].ALU_duty_cycle;
-		coredynp.MUL_duty_cycle = XML->sys.core[ithCore].MUL_duty_cycle;
-		coredynp.FPU_duty_cycle = XML->sys.core[ithCore].FPU_duty_cycle;
-		coredynp.ALU_cdb_duty_cycle = XML->sys.core[ithCore].ALU_cdb_duty_cycle;
-		coredynp.MUL_cdb_duty_cycle = XML->sys.core[ithCore].MUL_cdb_duty_cycle;
-		coredynp.FPU_cdb_duty_cycle = XML->sys.core[ithCore].FPU_cdb_duty_cycle;
-//	}
-
-
-	if (!((coredynp.core_ty==OOO)||(coredynp.core_ty==Inorder)))
-	{
-		cout<<"Invalid Core Type"<<endl;
-		exit(0);
-	}
-//	if (coredynp.core_ty==OOO)
-//	{
-//		cout<<"OOO processor models are being updated and will be available in next release"<<endl;
-//		exit(0);
-//	}
-	if (!((coredynp.scheu_ty==PhysicalRegFile)||(coredynp.scheu_ty==ReservationStation)))
-	{
-		cout<<"Invalid OOO Scheduler Type"<<endl;
-		exit(0);
-	}
-
-	if (!((coredynp.rm_ty ==RAMbased)||(coredynp.rm_ty ==CAMbased)))
-	{
-		cout<<"Invalid OOO Renaming Type"<<endl;
-		exit(0);
-	}
-
-if (coredynp.core_ty==OOO)
-{
-	if (coredynp.scheu_ty==PhysicalRegFile)
-	{
-	  coredynp.phy_ireg_width  =  int(ceil(log2(XML->sys.core[ithCore].phy_Regs_IRF_size)));
-	  coredynp.phy_freg_width  =  int(ceil(log2(XML->sys.core[ithCore].phy_Regs_FRF_size)));
-	  coredynp.num_ifreelist_entries = coredynp.num_IRF_entry  = XML->sys.core[ithCore].phy_Regs_IRF_size;
-	  coredynp.num_ffreelist_entries = coredynp.num_FRF_entry  = XML->sys.core[ithCore].phy_Regs_FRF_size;
-	}
-	else if (coredynp.scheu_ty==ReservationStation)
-	{//ROB serves as Phy RF in RS based OOO
-      coredynp.phy_ireg_width  =  int(ceil(log2(XML->sys.core[ithCore].ROB_size)));
-	  coredynp.phy_freg_width  =  int(ceil(log2(XML->sys.core[ithCore].ROB_size)));
-	  coredynp.num_ifreelist_entries = XML->sys.core[ithCore].ROB_size;
-	  coredynp.num_ffreelist_entries = XML->sys.core[ithCore].ROB_size;
-
-	}
-
+BranchPredictor ::~BranchPredictor() {
+  if (!exist) return;
+  if (globalBPT) {
+    delete globalBPT;
+    globalBPT = 0;
+  }
+  if (localBPT) {
+    delete localBPT;
+    localBPT = 0;
+  }
+  if (L1_localBPT) {
+    delete L1_localBPT;
+    L1_localBPT = 0;
+  }
+  if (L2_localBPT) {
+    delete L2_localBPT;
+    L2_localBPT = 0;
+  }
+  if (chooser) {
+    delete chooser;
+    chooser = 0;
+  }
+  if (RAS) {
+    delete RAS;
+    RAS = 0;
+  }
 }
-	coredynp.globalCheckpoint   =  32;//best check pointing entries for a 4~8 issue OOO should be 16~48;See TR for reference.
-	coredynp.perThreadState     =  8;
-	coredynp.instruction_length = 32;
-	coredynp.clockRate          =  XML->sys.core[ithCore].clock_rate;
-	coredynp.clockRate          *= 1e6;
-	coredynp.regWindowing= (XML->sys.core[ithCore].register_windows_size>0&&coredynp.core_ty==Inorder)?true:false;
-	coredynp.executionTime = XML->sys.total_cycles/coredynp.clockRate;
-	set_pppm(coredynp.pppm_lkg_multhread, 0, coredynp.num_hthreads, coredynp.num_hthreads, 0);
+
+RENAMINGU ::~RENAMINGU() {
+  if (!exist) return;
+  if (iFRAT) {
+    delete iFRAT;
+    iFRAT = 0;
+  }
+  if (fFRAT) {
+    delete fFRAT;
+    fFRAT = 0;
+  }
+  if (iRRAT) {
+    delete iRRAT;
+    iRRAT = 0;
+  }
+  if (iFRAT) {
+    delete iFRAT;
+    iFRAT = 0;
+  }
+  if (ifreeL) {
+    delete ifreeL;
+    ifreeL = 0;
+  }
+  if (ffreeL) {
+    delete ffreeL;
+    ffreeL = 0;
+  }
+  if (idcl) {
+    delete idcl;
+    idcl = 0;
+  }
+  if (fdcl) {
+    delete fdcl;
+    fdcl = 0;
+  }
+  if (RAHT) {
+    delete RAHT;
+    RAHT = 0;
+  }
+}
+
+LoadStoreU ::~LoadStoreU() {
+  if (!exist) return;
+  if (LSQ) {
+    delete LSQ;
+    LSQ = 0;
+  }
+}
+
+MemManU ::~MemManU() {
+  if (!exist) return;
+  if (itlb) {
+    delete itlb;
+    itlb = 0;
+  }
+  if (dtlb) {
+    delete dtlb;
+    dtlb = 0;
+  }
+}
+
+RegFU ::~RegFU() {
+  if (!exist) return;
+  if (IRF) {
+    delete IRF;
+    IRF = 0;
+  }
+  if (FRF) {
+    delete FRF;
+    FRF = 0;
+  }
+  if (RFWIN) {
+    delete RFWIN;
+    RFWIN = 0;
+  }
+}
+
+SchedulerU ::~SchedulerU() {
+  if (!exist) return;
+  if (int_inst_window) {
+    delete int_inst_window;
+    int_inst_window = 0;
+  }
+  if (fp_inst_window) {
+    delete int_inst_window;
+    int_inst_window = 0;
+  }
+  if (ROB) {
+    delete ROB;
+    ROB = 0;
+  }
+  if (instruction_selection) {
+    delete instruction_selection;
+    instruction_selection = 0;
+  }
+}
+
+EXECU ::~EXECU() {
+  if (!exist) return;
+  if (int_bypass) {
+    delete int_bypass;
+    int_bypass = 0;
+  }
+  if (intTagBypass) {
+    delete intTagBypass;
+    intTagBypass = 0;
+  }
+  if (int_mul_bypass) {
+    delete int_mul_bypass;
+    int_mul_bypass = 0;
+  }
+  if (intTag_mul_Bypass) {
+    delete intTag_mul_Bypass;
+    intTag_mul_Bypass = 0;
+  }
+  if (fp_bypass) {
+    delete fp_bypass;
+    fp_bypass = 0;
+  }
+  if (fpTagBypass) {
+    delete fpTagBypass;
+    fpTagBypass = 0;
+  }
+  if (fp_u) {
+    delete fp_u;
+    fp_u = 0;
+  }
+  if (exeu) {
+    delete exeu;
+    exeu = 0;
+  }
+  if (mul) {
+    delete mul;
+    mul = 0;
+  }
+  if (rfu) {
+    delete rfu;
+    rfu = 0;
+  }
+  if (scheu) {
+    delete scheu;
+    scheu = 0;
+  }
+}
+
+Core ::~Core() {
+  if (ifu) {
+    delete ifu;
+    ifu = 0;
+  }
+  if (lsu) {
+    delete lsu;
+    lsu = 0;
+  }
+  if (rnu) {
+    delete rnu;
+    rnu = 0;
+  }
+  if (mmu) {
+    delete mmu;
+    mmu = 0;
+  }
+  if (exu) {
+    delete exu;
+    exu = 0;
+  }
+  if (corepipe) {
+    delete corepipe;
+    corepipe = 0;
+  }
+  if (undiffCore) {
+    delete undiffCore;
+    undiffCore = 0;
+  }
+  if (l2cache) {
+    delete l2cache;
+    l2cache = 0;
+  }
+}
+
+void Core::set_core_param() {
+  coredynp.opt_local = XML->sys.core[ithCore].opt_local;
+  coredynp.x86 = XML->sys.core[ithCore].x86;
+  coredynp.Embedded = XML->sys.Embedded;
+  coredynp.core_ty = (enum Core_type)XML->sys.core[ithCore].machine_type;
+  coredynp.rm_ty = (enum Renaming_type)XML->sys.core[ithCore].rename_scheme;
+  coredynp.fetchW = XML->sys.core[ithCore].fetch_width;
+  coredynp.decodeW = XML->sys.core[ithCore].decode_width;
+  coredynp.issueW = XML->sys.core[ithCore].issue_width;
+  coredynp.peak_issueW = XML->sys.core[ithCore].peak_issue_width;
+  coredynp.commitW = XML->sys.core[ithCore].commit_width;
+  coredynp.peak_commitW = XML->sys.core[ithCore].peak_issue_width;
+  coredynp.predictionW = XML->sys.core[ithCore].prediction_width;
+  coredynp.fp_issueW = XML->sys.core[ithCore].fp_issue_width;
+  coredynp.fp_decodeW = XML->sys.core[ithCore].fp_issue_width;
+  coredynp.num_alus = XML->sys.core[ithCore].ALU_per_core;
+  coredynp.num_fpus = XML->sys.core[ithCore].FPU_per_core;
+  coredynp.num_muls = XML->sys.core[ithCore].MUL_per_core;
+
+  coredynp.num_hthreads = XML->sys.core[ithCore].number_hardware_threads;
+  coredynp.multithreaded = coredynp.num_hthreads > 1 ? true : false;
+  coredynp.instruction_length = XML->sys.core[ithCore].instruction_length;
+  coredynp.pc_width = XML->sys.virtual_address_width;
+
+  coredynp.opcode_length = XML->sys.core[ithCore].opcode_width;
+  coredynp.micro_opcode_length = XML->sys.core[ithCore].micro_opcode_width;
+  coredynp.num_pipelines = XML->sys.core[ithCore].pipelines_per_core[0];
+  coredynp.pipeline_stages = XML->sys.core[ithCore].pipeline_depth[0];
+  coredynp.num_fp_pipelines = XML->sys.core[ithCore].pipelines_per_core[1];
+  coredynp.fp_pipeline_stages = XML->sys.core[ithCore].pipeline_depth[1];
+  coredynp.int_data_width = int(ceil(XML->sys.machine_bits / 32.0)) * 32;
+  coredynp.fp_data_width = coredynp.int_data_width;
+  coredynp.v_address_width = XML->sys.virtual_address_width;
+  coredynp.p_address_width = XML->sys.physical_address_width;
+
+  coredynp.scheu_ty =
+      (enum Scheduler_type)XML->sys.core[ithCore].instruction_window_scheme;
+  coredynp.arch_ireg_width =
+      int(ceil(log2(XML->sys.core[ithCore].archi_Regs_IRF_size)));
+  coredynp.arch_freg_width =
+      int(ceil(log2(XML->sys.core[ithCore].archi_Regs_FRF_size)));
+  coredynp.num_IRF_entry = XML->sys.core[ithCore].archi_Regs_IRF_size;
+  coredynp.num_FRF_entry = XML->sys.core[ithCore].archi_Regs_FRF_size;
+  coredynp.pipeline_duty_cycle = XML->sys.core[ithCore].pipeline_duty_cycle;
+  coredynp.total_cycles = XML->sys.core[ithCore].total_cycles;
+  coredynp.busy_cycles = XML->sys.core[ithCore].busy_cycles;
+  coredynp.idle_cycles = XML->sys.core[ithCore].idle_cycles;
+
+  // Max power duty cycle for peak power estimation
+  //	if (coredynp.core_ty==OOO)
+  //	{
+  //		coredynp.IFU_duty_cycle = 1;
+  //		coredynp.LSU_duty_cycle = 1;
+  //		coredynp.MemManU_I_duty_cycle =1;
+  //		coredynp.MemManU_D_duty_cycle =1;
+  //		coredynp.ALU_duty_cycle =1;
+  //		coredynp.MUL_duty_cycle =1;
+  //		coredynp.FPU_duty_cycle =1;
+  //		coredynp.ALU_cdb_duty_cycle =1;
+  //		coredynp.MUL_cdb_duty_cycle =1;
+  //		coredynp.FPU_cdb_duty_cycle =1;
+  //	}
+  //	else
+  //	{
+  coredynp.IFU_duty_cycle = XML->sys.core[ithCore].IFU_duty_cycle;
+  coredynp.BR_duty_cycle = XML->sys.core[ithCore].BR_duty_cycle;
+  coredynp.LSU_duty_cycle = XML->sys.core[ithCore].LSU_duty_cycle;
+  coredynp.MemManU_I_duty_cycle = XML->sys.core[ithCore].MemManU_I_duty_cycle;
+  coredynp.MemManU_D_duty_cycle = XML->sys.core[ithCore].MemManU_D_duty_cycle;
+  coredynp.ALU_duty_cycle = XML->sys.core[ithCore].ALU_duty_cycle;
+  coredynp.MUL_duty_cycle = XML->sys.core[ithCore].MUL_duty_cycle;
+  coredynp.FPU_duty_cycle = XML->sys.core[ithCore].FPU_duty_cycle;
+  coredynp.ALU_cdb_duty_cycle = XML->sys.core[ithCore].ALU_cdb_duty_cycle;
+  coredynp.MUL_cdb_duty_cycle = XML->sys.core[ithCore].MUL_cdb_duty_cycle;
+  coredynp.FPU_cdb_duty_cycle = XML->sys.core[ithCore].FPU_cdb_duty_cycle;
+  //	}
+
+  if (!((coredynp.core_ty == OOO) || (coredynp.core_ty == Inorder))) {
+    cout << "Invalid Core Type" << endl;
+    exit(0);
+  }
+  //	if (coredynp.core_ty==OOO)
+  //	{
+  //		cout<<"OOO processor models are being updated and will be
+  // available in next release"<<endl; 		exit(0);
+  //	}
+  if (!((coredynp.scheu_ty == PhysicalRegFile) ||
+        (coredynp.scheu_ty == ReservationStation))) {
+    cout << "Invalid OOO Scheduler Type" << endl;
+    exit(0);
+  }
+
+  if (!((coredynp.rm_ty == RAMbased) || (coredynp.rm_ty == CAMbased))) {
+    cout << "Invalid OOO Renaming Type" << endl;
+    exit(0);
+  }
+
+  if (coredynp.core_ty == OOO) {
+    if (coredynp.scheu_ty == PhysicalRegFile) {
+      coredynp.phy_ireg_width =
+          int(ceil(log2(XML->sys.core[ithCore].phy_Regs_IRF_size)));
+      coredynp.phy_freg_width =
+          int(ceil(log2(XML->sys.core[ithCore].phy_Regs_FRF_size)));
+      coredynp.num_ifreelist_entries = coredynp.num_IRF_entry =
+          XML->sys.core[ithCore].phy_Regs_IRF_size;
+      coredynp.num_ffreelist_entries = coredynp.num_FRF_entry =
+          XML->sys.core[ithCore].phy_Regs_FRF_size;
+    } else if (coredynp.scheu_ty ==
+               ReservationStation) {  // ROB serves as Phy RF in RS based OOO
+      coredynp.phy_ireg_width =
+          int(ceil(log2(XML->sys.core[ithCore].ROB_size)));
+      coredynp.phy_freg_width =
+          int(ceil(log2(XML->sys.core[ithCore].ROB_size)));
+      coredynp.num_ifreelist_entries = XML->sys.core[ithCore].ROB_size;
+      coredynp.num_ffreelist_entries = XML->sys.core[ithCore].ROB_size;
+    }
+  }
+  coredynp.globalCheckpoint =
+      32;  // best check pointing entries for a 4~8 issue OOO should be
+           // 16~48;See TR for reference.
+  coredynp.perThreadState = 8;
+  coredynp.instruction_length = 32;
+  coredynp.clockRate = XML->sys.core[ithCore].clock_rate;
+  coredynp.clockRate *= 1e6;
+  coredynp.regWindowing = (XML->sys.core[ithCore].register_windows_size > 0 &&
+                           coredynp.core_ty == Inorder)
+                              ? true
+                              : false;
+  coredynp.executionTime = XML->sys.total_cycles / coredynp.clockRate;
+  set_pppm(coredynp.pppm_lkg_multhread, 0, coredynp.num_hthreads,
+           coredynp.num_hthreads, 0);
 }

--- a/src/gpuwattch/core.cc
+++ b/src/gpuwattch/core.cc
@@ -59,31 +59,31 @@
 //-gpgpu_num_reg_banks                    8 # Number of register banks (default
 //= 8)
 //-gpgpu_reg_bank_use_warp_id                    0 # Use warp ID in mapping
-//registers to banks (default = off)
+// registers to banks (default = off)
 //-gpgpu_operand_collector_num_units_sp                    6 # number of
-//collector units (default = 4)
+// collector units (default = 4)
 //-gpgpu_operand_collector_num_units_sfu                    8 # number of
-//collector units (default = 4)
+// collector units (default = 4)
 //-gpgpu_operand_collector_num_units_mem                    2 # number of
-//collector units (default = 2)
+// collector units (default = 2)
 //-gpgpu_operand_collector_num_units_gen                    0 # number of
-//collector units (default = 0)
+// collector units (default = 0)
 //-gpgpu_operand_collector_num_in_ports_sp                    1 # number of
-//collector unit in ports (default = 1)
+// collector unit in ports (default = 1)
 //-gpgpu_operand_collector_num_in_ports_sfu                    1 # number of
-//collector unit in ports (default = 1)
+// collector unit in ports (default = 1)
 //-gpgpu_operand_collector_num_in_ports_mem                    1 # number of
-//collector unit in ports (default = 1)
+// collector unit in ports (default = 1)
 //-gpgpu_operand_collector_num_in_ports_gen                    0 # number of
-//collector unit in ports (default = 0)
+// collector unit in ports (default = 0)
 //-gpgpu_operand_collector_num_out_ports_sp                    1 # number of
-//collector unit in ports (default = 1)
+// collector unit in ports (default = 1)
 //-gpgpu_operand_collector_num_out_ports_sfu                    1 # number of
-//collector unit in ports (default = 1)
+// collector unit in ports (default = 1)
 //-gpgpu_operand_collector_num_out_ports_mem                    1 # number of
-//collector unit in ports (default = 1)
+// collector unit in ports (default = 1)
 //-gpgpu_operand_collector_num_out_ports_gen                    0 # number of
-//collector unit in ports (default = 0)
+// collector unit in ports (default = 0)
 
 // The total number of collector units and their input ports, and the number of
 // register file banks
@@ -827,18 +827,22 @@ SchedulerU::SchedulerU(ParseXML* XML_interface, int ithCore_,
         // PC is to id the instruction for recover exception.
         // inst is used to map the renamed dest. registers.so that commit stage
         // can know which reg/RRAT to update
-        //				data = int(ceil((robExtra+coredynp.pc_width
+        //				data =
+        // int(ceil((robExtra+coredynp.pc_width
         //+
-        //						coredynp.instruction_length +
-        //2*coredynp.phy_ireg_width)/8.0));
+        //						coredynp.instruction_length
+        //+
+        // 2*coredynp.phy_ireg_width)/8.0));
         data = int(ceil(
             (robExtra + coredynp.pc_width + coredynp.phy_ireg_width) / 8.0));
       } else {
         // in RS based OOO, ROB also contains value of destination reg
-        //				data  = int(ceil((robExtra+coredynp.pc_width
+        //				data  =
+        // int(ceil((robExtra+coredynp.pc_width
         //+
-        //						coredynp.instruction_length +
-        //2*coredynp.phy_ireg_width + coredynp.fp_data_width)/8.0));
+        //						coredynp.instruction_length
+        //+
+        // 2*coredynp.phy_ireg_width + coredynp.fp_data_width)/8.0));
         data = int(ceil((robExtra + coredynp.pc_width +
                          coredynp.phy_ireg_width + coredynp.fp_data_width) /
                         8.0));
@@ -2399,8 +2403,9 @@ RENAMINGU::RENAMINGU(ParseXML* XML_interface, int ithCore_,
                                          // detailed explaintions
         data =
             33;  // int(ceil(coredynp.phy_ireg_width*(1+coredynp.globalCheckpoint)/8.0));
-        //			data							 =
-        //int(ceil(coredynp.phy_ireg_width/8.0));
+        //			data
+        //=
+        // int(ceil(coredynp.phy_ireg_width/8.0));
         out_w = 1;  // int(ceil(coredynp.phy_ireg_width/8.0));
         interface_ip.is_cache = false;
         interface_ip.pure_cam = false;
@@ -2430,42 +2435,44 @@ RENAMINGU::RENAMINGU(ParseXML* XML_interface, int ithCore_,
                 XML->sys.core[ithCore].number_hardware_threads);
         area.set_area(area.get_area() + iFRAT->area.get_area());
 
-        //			//RAHT According to Intel, combine GC with FRAT is
-        //very costly.
-        //			data							 =
-        //int(ceil(coredynp.phy_ireg_width/8.0)*coredynp.num_IRF_entry);
+        //			//RAHT According to Intel, combine GC with FRAT
+        // is
+        // very costly.
+        //			data
+        //=
+        // int(ceil(coredynp.phy_ireg_width/8.0)*coredynp.num_IRF_entry);
         //			out_w                            = data;
         //			interface_ip.is_cache			 =
-        //false;
+        // false;
         //			interface_ip.pure_cam            = false;
         //			interface_ip.pure_ram            = true;
         //			interface_ip.line_sz             = data;
         //			interface_ip.cache_sz            =
-        //data*coredynp.globalCheckpoint;
+        // data*coredynp.globalCheckpoint;
         //			interface_ip.assoc               = 1;
         //			interface_ip.nbanks              = 1;
         //			interface_ip.out_w               = out_w*8;
         //			interface_ip.access_mode         = 0;
         //			interface_ip.throughput          =
-        //1.0/clockRate;
+        // 1.0/clockRate;
         //			interface_ip.latency             =
-        //1.0/clockRate;
+        // 1.0/clockRate;
         //			interface_ip.obj_func_dyn_energy = 0;
         //			interface_ip.obj_func_dyn_power  = 0;
         //			interface_ip.obj_func_leak_power = 0;
         //			interface_ip.obj_func_cycle_t    = 1;
         //			interface_ip.num_rw_ports    = 1;//the extra one
-        //port is for GCs
+        // port is for GCs
         //			interface_ip.num_rd_ports    =
-        //2*coredynp.decodeW;
+        // 2*coredynp.decodeW;
         //			interface_ip.num_wr_ports    = coredynp.decodeW;
         //			interface_ip.num_se_rd_ports = 0;
         //			iFRAT = new ArrayST(&interface_ip, "Int
-        //FrontRAT");
+        // FrontRAT");
         //			iFRAT->area.set_area(iFRAT->area.get_area()+
-        //iFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
+        // iFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
         //			area.set_area(area.get_area()+
-        //iFRAT->area.get_area());
+        // iFRAT->area.get_area());
 
         // FRAT floating point
         data = int(ceil(coredynp.phy_freg_width *
@@ -3223,30 +3230,39 @@ void BranchPredictor::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
          << " W" << endl;
     cout << endl;
   } else {
-    //		cout << indent_str_next << "Global Predictor    Peak Dynamic = " <<
-    //globalBPT->rt_power.readOp.dynamic*clockRate << " W" << endl;
-    //		cout << indent_str_next << "Global Predictor    Subthreshold Leakage =
+    //		cout << indent_str_next << "Global Predictor    Peak Dynamic = "
+    //<<
+    // globalBPT->rt_power.readOp.dynamic*clockRate << " W" << endl;
+    //		cout << indent_str_next << "Global Predictor    Subthreshold
+    //Leakage
+    //=
     //" << globalBPT->rt_power.readOp.leakage <<" W" << endl;
-    //		cout << indent_str_next << "Global Predictor    Gate Leakage = " <<
-    //globalBPT->rt_power.readOp.gate_leakage << " W" << endl;
-    //		cout << indent_str_next << "Local Predictor   Peak Dynamic = " <<
-    //L1_localBPT->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Local Predictor   Subthreshold Leakage = "
+    //		cout << indent_str_next << "Global Predictor    Gate Leakage = "
+    //<<
+    // globalBPT->rt_power.readOp.gate_leakage << " W" << endl;
+    //		cout << indent_str_next << "Local Predictor   Peak Dynamic = "
+    //<<
+    // L1_localBPT->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "Local Predictor   Subthreshold Leakage
+    //=
+    //"
     //<< L1_localBPT->rt_power.readOp.leakage  << " W" << endl;
-    //		cout << indent_str_next << "Local Predictor   Gate Leakage = " <<
-    //L1_localBPT->rt_power.readOp.gate_leakage  << " W" << endl;
+    //		cout << indent_str_next << "Local Predictor   Gate Leakage = "
+    //<<
+    // L1_localBPT->rt_power.readOp.gate_leakage  << " W" << endl;
     //		cout << indent_str_next << "Chooser   Peak Dynamic = " <<
-    //chooser->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Chooser   Subthreshold Leakage = " <<
-    //chooser->rt_power.readOp.leakage  << " W" << endl;
+    // chooser->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "Chooser   Subthreshold Leakage = "
+    //<<
+    // chooser->rt_power.readOp.leakage  << " W" << endl;
     //		cout << indent_str_next << "Chooser   Gate Leakage = " <<
-    //chooser->rt_power.readOp.gate_leakage  << " W" << endl;
+    // chooser->rt_power.readOp.gate_leakage  << " W" << endl;
     //		cout << indent_str_next << "RAS   Peak Dynamic = " <<
-    //RAS->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    // RAS->rt_power.readOp.dynamic*clockRate  << " W" << endl;
     //		cout << indent_str_next << "RAS   Subthreshold Leakage = " <<
-    //RAS->rt_power.readOp.leakage  << " W" << endl;
+    // RAS->rt_power.readOp.leakage  << " W" << endl;
     //		cout << indent_str_next << "RAS   Gate Leakage = " <<
-    //RAS->rt_power.readOp.gate_leakage  << " W" << endl;
+    // RAS->rt_power.readOp.gate_leakage  << " W" << endl;
   }
 }
 
@@ -3593,30 +3609,48 @@ void InstFetchU::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
          << " W" << endl;
     cout << endl;
   } else {
-    //		cout << indent_str_next << "Instruction Cache    Peak Dynamic = " <<
-    //icache.rt_power.readOp.dynamic*clockRate << " W" << endl;
-    //		cout << indent_str_next << "Instruction Cache    Subthreshold Leakage
+    //		cout << indent_str_next << "Instruction Cache    Peak Dynamic =
+    //"
+    //<<
+    // icache.rt_power.readOp.dynamic*clockRate << " W" << endl;
+    //		cout << indent_str_next << "Instruction Cache    Subthreshold
+    // Leakage
     //= " << icache.rt_power.readOp.leakage <<" W" << endl;
-    //		cout << indent_str_next << "Instruction Cache    Gate Leakage = " <<
-    //icache.rt_power.readOp.gate_leakage << " W" << endl;
-    //		cout << indent_str_next << "Instruction Buffer   Peak Dynamic = " <<
-    //IB->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Instruction Buffer   Subthreshold Leakage
+    //		cout << indent_str_next << "Instruction Cache    Gate Leakage =
+    //"
+    //<<
+    // icache.rt_power.readOp.gate_leakage << " W" << endl;
+    //		cout << indent_str_next << "Instruction Buffer   Peak Dynamic =
+    //"
+    //<<
+    // IB->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "Instruction Buffer   Subthreshold
+    // Leakage
     //= " << IB->rt_power.readOp.leakage  << " W" << endl;
-    //		cout << indent_str_next << "Instruction Buffer   Gate Leakage = " <<
-    //IB->rt_power.readOp.gate_leakage  << " W" << endl;
-    //		cout << indent_str_next << "Branch Target Buffer   Peak Dynamic = " <<
-    //BTB->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "Instruction Buffer   Gate Leakage =
+    //"
+    //<<
+    // IB->rt_power.readOp.gate_leakage  << " W" << endl;
+    //		cout << indent_str_next << "Branch Target Buffer   Peak Dynamic =
+    //"
+    //<<
+    // BTB->rt_power.readOp.dynamic*clockRate  << " W" << endl;
     //		cout << indent_str_next << "Branch Target Buffer   Subthreshold
-    //Leakage = " << BTB->rt_power.readOp.leakage  << " W" << endl;
-    //		cout << indent_str_next << "Branch Target Buffer   Gate Leakage = " <<
-    //BTB->rt_power.readOp.gate_leakage  << " W" << endl;
-    //		cout << indent_str_next << "Branch Predictor   Peak Dynamic = " <<
-    //BPT->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Branch Predictor   Subthreshold Leakage =
+    // Leakage = " << BTB->rt_power.readOp.leakage  << " W" << endl;
+    //		cout << indent_str_next << "Branch Target Buffer   Gate Leakage =
+    //"
+    //<<
+    // BTB->rt_power.readOp.gate_leakage  << " W" << endl;
+    //		cout << indent_str_next << "Branch Predictor   Peak Dynamic = "
+    //<<
+    // BPT->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "Branch Predictor   Subthreshold
+    //Leakage
+    //=
     //" << BPT->rt_power.readOp.leakage  << " W" << endl;
-    //		cout << indent_str_next << "Branch Predictor   Gate Leakage = " <<
-    //BPT->rt_power.readOp.gate_leakage  << " W" << endl;
+    //		cout << indent_str_next << "Branch Predictor   Gate Leakage = "
+    //<<
+    // BPT->rt_power.readOp.gate_leakage  << " W" << endl;
   }
 }
 
@@ -4214,11 +4248,12 @@ void SchedulerU::computeEnergy(bool is_tdp) {
   if (!exist) return;
   double ROB_duty_cycle;
   //	ROB_duty_cycle = ((coredynp.ALU_duty_cycle +
-  //coredynp.num_muls>0?coredynp.MUL_duty_cycle:0
-  //			+ coredynp.num_fpus>0?coredynp.FPU_duty_cycle:0))*1.1<1 ?
+  // coredynp.num_muls>0?coredynp.MUL_duty_cycle:0
+  //			+ coredynp.num_fpus>0?coredynp.FPU_duty_cycle:0))*1.1<1
+  //?
   //(coredynp.ALU_duty_cycle + coredynp.num_muls>0?coredynp.MUL_duty_cycle:0
   //					+
-  //coredynp.num_fpus>0?coredynp.FPU_duty_cycle:0)*1.1:1;
+  // coredynp.num_fpus>0?coredynp.FPU_duty_cycle:0)*1.1:1;
   ROB_duty_cycle = 1;
   // init stats
   if (is_tdp) {
@@ -4392,7 +4427,7 @@ void SchedulerU::computeEnergy(bool is_tdp) {
 
     } else if (coredynp.multithreaded) {
       //			set_pppm(pppm_t,
-      //XML->sys.core[ithCore].issue_width,1, 1, 1);
+      // XML->sys.core[ithCore].issue_width,1, 1, 1);
       int_inst_window->power =
           int_inst_window->power_t +
           (int_inst_window->local_result.power + instruction_selection->power) *
@@ -4419,7 +4454,7 @@ void SchedulerU::computeEnergy(bool is_tdp) {
 
     } else if (coredynp.multithreaded) {
       //			set_pppm(pppm_t,
-      //XML->sys.core[ithCore].issue_width,1, 1, 1);
+      // XML->sys.core[ithCore].issue_width,1, 1, 1);
       int_inst_window->rt_power =
           int_inst_window->power_t +
           (int_inst_window->local_result.power + instruction_selection->power) *
@@ -4429,9 +4464,9 @@ void SchedulerU::computeEnergy(bool is_tdp) {
   }
   //	set_pppm(pppm_t, XML->sys.core[ithCore].issue_width,1, 1, 1);
   //	cout<<"Scheduler
-  //power="<<power.readOp.dynamic<<"leakage="<<power.readOp.leakage<<endl;
+  // power="<<power.readOp.dynamic<<"leakage="<<power.readOp.leakage<<endl;
   //	cout<<"IW="<<int_inst_window->local_result.power.searchOp.dynamic *
-  //int_inst_window->stats_t.readAc.access +
+  // int_inst_window->stats_t.readAc.access +
   //    + int_inst_window->local_result.power.writeOp.dynamic *
   //    int_inst_window->stats_t.writeAc.access<<"leakage="<<int_inst_window->local_result.power.readOp.leakage<<endl;
   //	cout<<"selection"<<instruction_selection->power.readOp.dynamic<<"leakage"<<instruction_selection->power.readOp.leakage<<endl;
@@ -5104,11 +5139,11 @@ void LoadStoreU::computeEnergy(bool is_tdp) {
 
   } else {
     //	LSQ->power_t.readOp.dynamic  +=
-    //LSQ->stats_t.readAc.access*(LSQ->local_result.power.searchOp.dynamic +
-    //LSQ->local_result.power.readOp.dynamic)
+    // LSQ->stats_t.readAc.access*(LSQ->local_result.power.searchOp.dynamic +
+    // LSQ->local_result.power.readOp.dynamic)
     //	        +
-    //LSQ->stats_t.writeAc.access*LSQ->local_result.power.writeOp.dynamic;//every
-    //memory access invloves at least two operations on LSQ
+    // LSQ->stats_t.writeAc.access*LSQ->local_result.power.writeOp.dynamic;//every
+    // memory access invloves at least two operations on LSQ
     //	No LSQ in GPUs (Syed)
   }
 
@@ -5944,7 +5979,7 @@ void EXECU::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
   bool long_channel = XML->sys.longer_channel_device;
 
   //	cout << indent_str_next << "Results Broadcast Bus Area = " <<
-  //bypass->area.get_area() *1e-6 << " mm^2" << endl;
+  // bypass->area.get_area() *1e-6 << " mm^2" << endl;
   if (is_tdp) {
     cout << indent_str << "Register Files:" << endl;
     cout << indent_str_next << "Area = " << rfu->area.get_area() * 1e-6
@@ -6151,15 +6186,15 @@ void Core::computeEnergy(bool is_tdp) {
                coredynp.num_pipelines / num_units,
                coredynp.num_pipelines / num_units);
       //			cout << "IFU = " <<
-      //ifu->power.readOp.dynamic*clockRate  << " W" << endl;
+      // ifu->power.readOp.dynamic*clockRate  << " W" << endl;
       ifu->power = ifu->power + corepipe->power * pppm_t;
       //			cout << "IFU = " <<
-      //ifu->power.readOp.dynamic*clockRate  << " W" << endl;
+      // ifu->power.readOp.dynamic*clockRate  << " W" << endl;
       //			cout << "1/4 pipe = " <<
-      //corepipe->power.readOp.dynamic*clockRate/num_units  << " W" << endl;
+      // corepipe->power.readOp.dynamic*clockRate/num_units  << " W" << endl;
       power = power + ifu->power;
       //			cout << "core = " <<
-      //power.readOp.dynamic*clockRate  << " W" << endl;
+      // power.readOp.dynamic*clockRate  << " W" << endl;
     }
     if (lsu->exist) {
       Pipeline_energy +=
@@ -6172,10 +6207,10 @@ void Core::computeEnergy(bool is_tdp) {
                coredynp.num_pipelines / num_units);
       lsu->power = lsu->power + corepipe->power * pppm_t;
       //			cout << "LSU = " <<
-      //lsu->power.readOp.dynamic*clockRate  << " W" << endl;
+      // lsu->power.readOp.dynamic*clockRate  << " W" << endl;
       power = power + lsu->power;
       //			cout << "core = " <<
-      //power.readOp.dynamic*clockRate  << " W" << endl;
+      // power.readOp.dynamic*clockRate  << " W" << endl;
     }
     if (exu->exist) {
       Pipeline_energy +=
@@ -6189,10 +6224,10 @@ void Core::computeEnergy(bool is_tdp) {
       // cout<<"ExPowerScalingFactor:"<<coredynp.num_pipelines/num_units*coredynp.ALU_duty_cycle<<endl;
       exu->power = exu->power + corepipe->power * pppm_t;
       //			cout << "EXE = " <<
-      //exu->power.readOp.dynamic*clockRate  << " W" << endl;
+      // exu->power.readOp.dynamic*clockRate  << " W" << endl;
       power = power + exu->power;
       //			cout << "core = " <<
-      //power.readOp.dynamic*clockRate  << " W" << endl;
+      // power.readOp.dynamic*clockRate  << " W" << endl;
     }
     if (mmu->exist) {
       Pipeline_energy +=
@@ -6205,10 +6240,10 @@ void Core::computeEnergy(bool is_tdp) {
                coredynp.num_pipelines / num_units);
       mmu->power = mmu->power + corepipe->power * pppm_t;
       //			cout << "MMU = " <<
-      //mmu->power.readOp.dynamic*clockRate  << " W" << endl;
+      // mmu->power.readOp.dynamic*clockRate  << " W" << endl;
       power = power + mmu->power;
       //			cout << "core = " <<
-      //power.readOp.dynamic*clockRate  << " W" << endl;
+      // power.readOp.dynamic*clockRate  << " W" << endl;
     }
 
     power = power + undiffCore->power;
@@ -6276,8 +6311,9 @@ void Core::computeEnergy(bool is_tdp) {
     }
 
     rt_power = rt_power + undiffCore->power;
-    //		cout << "EXE = " << exu->power.readOp.dynamic*clockRate  << " W" <<
-    //endl;
+    //		cout << "EXE = " << exu->power.readOp.dynamic*clockRate  << " W"
+    //<<
+    // endl;
     if (XML->sys.Private_L2) {
       l2cache->computeEnergy(is_tdp);
       // set_pppm(pppm_t,1/l2cache->cachep.executionTime, 1,1,1);
@@ -6436,22 +6472,28 @@ void Core::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
     //			if (undiffCore->exist)
     //			{
     //				cout << indent_str << "Undifferentiated Core" <<
-    //endl;
+    // endl;
     //				cout << indent_str_next << "Area = " <<
-    //undiffCore->area.get_area()*1e-6<< " mm^2" << endl;
+    // undiffCore->area.get_area()*1e-6<< " mm^2" << endl;
     //				cout << indent_str_next << "Peak Dynamic = " <<
-    //undiffCore->power.readOp.dynamic*clockRate << " W" << endl;
-    ////				cout << indent_str_next << "Subthreshold Leakage = " <<
-    ///undiffCore->power.readOp.leakage <<" W" << endl;
-    //				cout << indent_str_next << "Subthreshold Leakage =
+    // undiffCore->power.readOp.dynamic*clockRate << " W" << endl;
+    ////				cout << indent_str_next << "Subthreshold Leakage =
+    ///"
+    ///<<
+    /// undiffCore->power.readOp.leakage <<" W" << endl;
+    //				cout << indent_str_next << "Subthreshold Leakage
+    //=
     //"
-    //								<< (long_channel?
-    //undiffCore->power.readOp.longer_channel_leakage:undiffCore->power.readOp.leakage)
+    //								<<
+    //(long_channel?
+    // undiffCore->power.readOp.longer_channel_leakage:undiffCore->power.readOp.leakage)
     //<< " W" << endl;
     //				cout << indent_str_next << "Gate Leakage = " <<
-    //undiffCore->power.readOp.gate_leakage << " W" << endl;
-    //				//		cout << indent_str_next << "Runtime Dynamic = " <<
-    //undiffCore->rt_power.readOp.dynamic/executionTime << " W" << endl;
+    // undiffCore->power.readOp.gate_leakage << " W" << endl;
+    //				//		cout << indent_str_next << "Runtime Dynamic =
+    //"
+    //<<
+    // undiffCore->rt_power.readOp.dynamic/executionTime << " W" << endl;
     //				cout <<endl;
     //			}
     //		}
@@ -6465,30 +6507,44 @@ void Core::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
          << endl;
 
   } else {
-    //		cout << indent_str_next << "Instruction Fetch Unit    Peak Dynamic = "
+    //		cout << indent_str_next << "Instruction Fetch Unit    Peak Dynamic
+    //=
+    //"
     //<< ifu->rt_power.readOp.dynamic*clockRate << " W" << endl;
-    //		cout << indent_str_next << "Instruction Fetch Unit    Subthreshold
-    //Leakage = " << ifu->rt_power.readOp.leakage <<" W" << endl;
-    //		cout << indent_str_next << "Instruction Fetch Unit    Gate Leakage = "
+    //		cout << indent_str_next << "Instruction Fetch Unit Subthreshold
+    // Leakage = " << ifu->rt_power.readOp.leakage <<" W" << endl;
+    //		cout << indent_str_next << "Instruction Fetch Unit    Gate Leakage
+    //=
+    //"
     //<< ifu->rt_power.readOp.gate_leakage << " W" << endl;
-    //		cout << indent_str_next << "Load Store Unit   Peak Dynamic = " <<
-    //lsu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Load Store Unit   Subthreshold Leakage = "
+    //		cout << indent_str_next << "Load Store Unit   Peak Dynamic = "
+    //<<
+    // lsu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "Load Store Unit   Subthreshold Leakage
+    //=
+    //"
     //<< lsu->rt_power.readOp.leakage  << " W" << endl;
-    //		cout << indent_str_next << "Load Store Unit   Gate Leakage = " <<
-    //lsu->rt_power.readOp.gate_leakage  << " W" << endl;
-    //		cout << indent_str_next << "Memory Management Unit   Peak Dynamic = "
+    //		cout << indent_str_next << "Load Store Unit   Gate Leakage = "
+    //<<
+    // lsu->rt_power.readOp.gate_leakage  << " W" << endl;
+    //		cout << indent_str_next << "Memory Management Unit   Peak Dynamic
+    //=
+    //"
     //<< mmu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Memory Management Unit   Subthreshold
-    //Leakage = " << mmu->rt_power.readOp.leakage  << " W" << endl;
-    //		cout << indent_str_next << "Memory Management Unit   Gate Leakage = "
+    //		cout << indent_str_next << "Memory Management Unit Subthreshold
+    // Leakage = " << mmu->rt_power.readOp.leakage  << " W" << endl;
+    //		cout << indent_str_next << "Memory Management Unit   Gate Leakage
+    //=
+    //"
     //<< mmu->rt_power.readOp.gate_leakage  << " W" << endl;
     //		cout << indent_str_next << "Execution Unit   Peak Dynamic = " <<
-    //exu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Execution Unit   Subthreshold Leakage = "
+    // exu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "Execution Unit   Subthreshold Leakage
+    //=
+    //"
     //<< exu->rt_power.readOp.leakage  << " W" << endl;
     //		cout << indent_str_next << "Execution Unit   Gate Leakage = " <<
-    //exu->rt_power.readOp.gate_leakage  << " W" << endl;
+    // exu->rt_power.readOp.gate_leakage  << " W" << endl;
   }
 }
 InstFetchU::~InstFetchU() {
@@ -6811,8 +6867,9 @@ void Core::set_core_param() {
   }
   //	if (coredynp.core_ty==OOO)
   //	{
-  //		cout<<"OOO processor models are being updated and will be available
-  //in next release"<<endl;
+  //		cout<<"OOO processor models are being updated and will be
+  // available
+  // in next release"<<endl;
   //		exit(0);
   //	}
   if (!((coredynp.scheu_ty == PhysicalRegFile) ||

--- a/src/gpuwattch/core.cc
+++ b/src/gpuwattch/core.cc
@@ -29,5309 +29,6835 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:												   *
+*      Modified by:
+**
 *      Jingwen Leng, Univeristy of Texas, Austin                   *
 *      Syed Gilani, University of Wisconsin–Madison                *
 *      Tayler Hetherington, University of British Columbia         *
 *      Ahmed ElTantawy, University of British Columbia             *
 ********************************************************************/
 
+#include "core.h"
+#include <assert.h>
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <string>
+#include "XML_Parse.h"
+#include "cacti/basic_circuit.h"
+#include "const.h"
 #include "io.h"
 #include "parameter.h"
-#include "const.h"
-#include "cacti/basic_circuit.h"
-#include <iostream>
-#include <algorithm>
-#include "XML_Parse.h"
-#include <string>
-#include <cmath>
-#include <assert.h>
-#include "core.h"
 //#include "globalvar.h"
-//double exClockRate;
+// double exClockRate;
 //*********************
-//Operand collector (OC) modelling (Syed Gilani)
+// Operand collector (OC) modelling (Syed Gilani)
 //*********************
-//The OCs are modelled similar to the GPGPU-Sim v3.x documentation and
-//nVIDIA patents.
-//the OC need the following GPGPU-Sim config options:
-//-gpgpu_num_reg_banks                    8 # Number of register banks (default = 8)
-//-gpgpu_reg_bank_use_warp_id                    0 # Use warp ID in mapping registers to banks (default = off)
-//-gpgpu_operand_collector_num_units_sp                    6 # number of collector units (default = 4)
-//-gpgpu_operand_collector_num_units_sfu                    8 # number of collector units (default = 4)
-//-gpgpu_operand_collector_num_units_mem                    2 # number of collector units (default = 2)
-//-gpgpu_operand_collector_num_units_gen                    0 # number of collector units (default = 0)
-//-gpgpu_operand_collector_num_in_ports_sp                    1 # number of collector unit in ports (default = 1)
-//-gpgpu_operand_collector_num_in_ports_sfu                    1 # number of collector unit in ports (default = 1)
-//-gpgpu_operand_collector_num_in_ports_mem                    1 # number of collector unit in ports (default = 1)
-//-gpgpu_operand_collector_num_in_ports_gen                    0 # number of collector unit in ports (default = 0)
-//-gpgpu_operand_collector_num_out_ports_sp                    1 # number of collector unit in ports (default = 1)
-//-gpgpu_operand_collector_num_out_ports_sfu                    1 # number of collector unit in ports (default = 1)
-//-gpgpu_operand_collector_num_out_ports_mem                    1 # number of collector unit in ports (default = 1)
-//-gpgpu_operand_collector_num_out_ports_gen                    0 # number of collector unit in ports (default = 0)
+// The OCs are modelled similar to the GPGPU-Sim v3.x documentation and
+// nVIDIA patents.
+// the OC need the following GPGPU-Sim config options:
+//-gpgpu_num_reg_banks                    8 # Number of register banks (default
+//= 8)
+//-gpgpu_reg_bank_use_warp_id                    0 # Use warp ID in mapping
+//registers to banks (default = off)
+//-gpgpu_operand_collector_num_units_sp                    6 # number of
+//collector units (default = 4)
+//-gpgpu_operand_collector_num_units_sfu                    8 # number of
+//collector units (default = 4)
+//-gpgpu_operand_collector_num_units_mem                    2 # number of
+//collector units (default = 2)
+//-gpgpu_operand_collector_num_units_gen                    0 # number of
+//collector units (default = 0)
+//-gpgpu_operand_collector_num_in_ports_sp                    1 # number of
+//collector unit in ports (default = 1)
+//-gpgpu_operand_collector_num_in_ports_sfu                    1 # number of
+//collector unit in ports (default = 1)
+//-gpgpu_operand_collector_num_in_ports_mem                    1 # number of
+//collector unit in ports (default = 1)
+//-gpgpu_operand_collector_num_in_ports_gen                    0 # number of
+//collector unit in ports (default = 0)
+//-gpgpu_operand_collector_num_out_ports_sp                    1 # number of
+//collector unit in ports (default = 1)
+//-gpgpu_operand_collector_num_out_ports_sfu                    1 # number of
+//collector unit in ports (default = 1)
+//-gpgpu_operand_collector_num_out_ports_mem                    1 # number of
+//collector unit in ports (default = 1)
+//-gpgpu_operand_collector_num_out_ports_gen                    0 # number of
+//collector unit in ports (default = 0)
 
-//The total number of collector units and their input ports, and the number of register file banks
-//determine the crossbar size. 
+// The total number of collector units and their input ports, and the number of
+// register file banks
+// determine the crossbar size.
 
-InstFetchU::InstFetchU(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_, bool exist_)
-:XML(XML_interface),
- ithCore(ithCore_),
- interface_ip(*interface_ip_),
- coredynp(dyn_p_),
- IB  (0),
- BTB (0),
- ID_inst  (0),
- ID_operand  (0),
- ID_misc  (0),
- exist(exist_)
-{
-	  if (!exist) return;
-	  int  idx, tag, data, size, line, assoc, banks;
-	  bool debug= false, is_default = true;
+InstFetchU::InstFetchU(ParseXML* XML_interface, int ithCore_,
+                       InputParameter* interface_ip_,
+                       const CoreDynParam& dyn_p_, bool exist_)
+    : XML(XML_interface),
+      ithCore(ithCore_),
+      interface_ip(*interface_ip_),
+      coredynp(dyn_p_),
+      IB(0),
+      BTB(0),
+      ID_inst(0),
+      ID_operand(0),
+      ID_misc(0),
+      exist(exist_) {
+  if (!exist) return;
+  int idx, tag, data, size, line, assoc, banks;
+  bool debug = false, is_default = true;
 
-	  clockRate = coredynp.clockRate;
-	  executionTime = coredynp.executionTime;
+  clockRate = coredynp.clockRate;
+  executionTime = coredynp.executionTime;
 
-	  cache_p = (Cache_policy)XML->sys.core[ithCore].icache.icache_config[7];
-	  //Assuming all L1 caches are virtually idxed physically tagged.
-	  //cache
+  cache_p = (Cache_policy)XML->sys.core[ithCore].icache.icache_config[7];
+  // Assuming all L1 caches are virtually idxed physically tagged.
+  // cache
 
-	  size                             = (int)XML->sys.core[ithCore].icache.icache_config[0];
-	  line                             = (int)XML->sys.core[ithCore].icache.icache_config[1];
-	  assoc                            = (int)XML->sys.core[ithCore].icache.icache_config[2];
-	  banks                            = (int)XML->sys.core[ithCore].icache.icache_config[3];
-	  idx    					 	   = debug?9:int(ceil(log2(size/line/assoc)));
-	  tag							   = debug?51:(int)XML->sys.physical_address_width-idx-int(ceil(log2(line))) + EXTRA_TAG_BITS;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.cache_sz            = debug?32768:(int)XML->sys.core[ithCore].icache.icache_config[0];
-	  interface_ip.line_sz             = debug?64:(int)XML->sys.core[ithCore].icache.icache_config[1];
-	  interface_ip.assoc               = debug?8:(int)XML->sys.core[ithCore].icache.icache_config[2];
-	  interface_ip.nbanks              = debug?1:(int)XML->sys.core[ithCore].icache.icache_config[3];
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 0;//debug?0:XML->sys.core[ithCore].icache.icache_config[5];
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].icache.icache_config[4]/clockRate;
-	  interface_ip.latency             = debug?3.0/clockRate:XML->sys.core[ithCore].icache.icache_config[5]/clockRate;
-	  interface_ip.is_cache			 = true;
-	  interface_ip.pure_cam			 = false;
-	  interface_ip.pure_ram			 = false;
-	//  interface_ip.obj_func_dyn_energy = 0;
-	//  interface_ip.obj_func_dyn_power  = 0;
-	//  interface_ip.obj_func_leak_power = 0;
-	//  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].number_instruction_fetch_ports;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  icache.caches = new ArrayST(&interface_ip, "icache", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  scktRatio = g_tp.sckt_co_eff;
-	  chip_PR_overhead = g_tp.chip_layout_overhead;
-	  macro_PR_overhead = g_tp.macro_layout_overhead;
-	  icache.area.set_area(icache.area.get_area()+ icache.caches->local_result.area);
-	  area.set_area(area.get_area()+ icache.caches->local_result.area);
-	  //output_data_csv(icache.caches.local_result);
+  size = (int)XML->sys.core[ithCore].icache.icache_config[0];
+  line = (int)XML->sys.core[ithCore].icache.icache_config[1];
+  assoc = (int)XML->sys.core[ithCore].icache.icache_config[2];
+  banks = (int)XML->sys.core[ithCore].icache.icache_config[3];
+  idx = debug ? 9 : int(ceil(log2(size / line / assoc)));
+  tag = debug ? 51 : (int)XML->sys.physical_address_width - idx -
+                         int(ceil(log2(line))) + EXTRA_TAG_BITS;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.cache_sz =
+      debug ? 32768 : (int)XML->sys.core[ithCore].icache.icache_config[0];
+  interface_ip.line_sz =
+      debug ? 64 : (int)XML->sys.core[ithCore].icache.icache_config[1];
+  interface_ip.assoc =
+      debug ? 8 : (int)XML->sys.core[ithCore].icache.icache_config[2];
+  interface_ip.nbanks =
+      debug ? 1 : (int)XML->sys.core[ithCore].icache.icache_config[3];
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode =
+      0;  // debug?0:XML->sys.core[ithCore].icache.icache_config[5];
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].icache.icache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 3.0 / clockRate
+            : XML->sys.core[ithCore].icache.icache_config[5] / clockRate;
+  interface_ip.is_cache = true;
+  interface_ip.pure_cam = false;
+  interface_ip.pure_ram = false;
+  //  interface_ip.obj_func_dyn_energy = 0;
+  //  interface_ip.obj_func_dyn_power  = 0;
+  //  interface_ip.obj_func_leak_power = 0;
+  //  interface_ip.obj_func_cycle_t    = 1;
+  interface_ip.num_rw_ports =
+      debug ? 1 : XML->sys.core[ithCore].number_instruction_fetch_ports;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  icache.caches = new ArrayST(&interface_ip, "icache", Core_device,
+                              coredynp.opt_local, coredynp.core_ty);
+  scktRatio = g_tp.sckt_co_eff;
+  chip_PR_overhead = g_tp.chip_layout_overhead;
+  macro_PR_overhead = g_tp.macro_layout_overhead;
+  icache.area.set_area(icache.area.get_area() +
+                       icache.caches->local_result.area);
+  area.set_area(area.get_area() + icache.caches->local_result.area);
+  // output_data_csv(icache.caches.local_result);
 
+  /*
+   *iCache controllers
+   *miss buffer Each MSHR contains enough state
+   *to handle one or more accesses of any type to a single memory line.
+   *Due to the generality of the MSHR mechanism,
+   *the amount of state involved is non-trivial:
+   *including the address, pointers to the cache entry and destination register,
+   *written data, and various other pieces of state.
+   */
+  interface_ip.num_search_ports =
+      debug ? 1 : XML->sys.core[ithCore].number_instruction_fetch_ports;
+  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data = (XML->sys.physical_address_width) + int(ceil(log2(size / line))) +
+         icache.caches->l_ip.line_sz * 8;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.line_sz =
+      int(ceil(data / 8.0));  // int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+  interface_ip.cache_sz =
+      XML->sys.core[ithCore].icache.buffer_sizes[0] * interface_ip.line_sz;
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 0;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate : XML->sys.core[ithCore].icache.icache_config[4] /
+                                    clockRate;  // means cycle time
+  interface_ip.latency =
+      debug ? 1.0 / clockRate : XML->sys.core[ithCore].icache.icache_config[5] /
+                                    clockRate;  // means access time
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports =
+      debug ? 1 : XML->sys.core[ithCore].number_instruction_fetch_ports;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  interface_ip.num_search_ports =
+      XML->sys.core[ithCore].number_instruction_fetch_ports;
+  icache.missb = new ArrayST(&interface_ip, "icacheMissBuffer", Core_device,
+                             coredynp.opt_local, coredynp.core_ty);
+  icache.area.set_area(icache.area.get_area() +
+                       icache.missb->local_result.area);
+  area.set_area(area.get_area() + icache.missb->local_result.area);
+  // output_data_csv(icache.missb.local_result);
 
-	  /*
-	   *iCache controllers
-	   *miss buffer Each MSHR contains enough state
-	   *to handle one or more accesses of any type to a single memory line.
-	   *Due to the generality of the MSHR mechanism,
-	   *the amount of state involved is non-trivial:
-	   *including the address, pointers to the cache entry and destination register,
-	   *written data, and various other pieces of state.
-	   */
-	  interface_ip.num_search_ports    = debug?1:XML->sys.core[ithCore].number_instruction_fetch_ports;
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  data							   = (XML->sys.physical_address_width) + int(ceil(log2(size/line))) + icache.caches->l_ip.line_sz*8;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-	  interface_ip.cache_sz            = XML->sys.core[ithCore].icache.buffer_sizes[0]*interface_ip.line_sz;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 0;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].icache.icache_config[4]/clockRate;//means cycle time
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].icache.icache_config[5]/clockRate;//means access time
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].number_instruction_fetch_ports;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  interface_ip.num_search_ports = XML->sys.core[ithCore].number_instruction_fetch_ports;
-	  icache.missb = new ArrayST(&interface_ip, "icacheMissBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  icache.area.set_area(icache.area.get_area()+ icache.missb->local_result.area);
-	  area.set_area(area.get_area()+ icache.missb->local_result.area);
-	  //output_data_csv(icache.missb.local_result);
+  // fill buffer
+  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data = icache.caches->l_ip.line_sz;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
+  interface_ip.cache_sz = data * XML->sys.core[ithCore].icache.buffer_sizes[1];
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 0;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].icache.icache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].icache.icache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports =
+      debug ? 1 : XML->sys.core[ithCore].number_instruction_fetch_ports;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  interface_ip.num_search_ports =
+      XML->sys.core[ithCore].number_instruction_fetch_ports;
+  icache.ifb = new ArrayST(&interface_ip, "icacheFillBuffer", Core_device,
+                           coredynp.opt_local, coredynp.core_ty);
+  icache.area.set_area(icache.area.get_area() + icache.ifb->local_result.area);
+  area.set_area(area.get_area() + icache.ifb->local_result.area);
+  // output_data_csv(icache.ifb.local_result);
 
-	  //fill buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  data							   = icache.caches->l_ip.line_sz;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-	  interface_ip.cache_sz            = data*XML->sys.core[ithCore].icache.buffer_sizes[1];
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 0;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].icache.icache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].icache.icache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].number_instruction_fetch_ports;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  interface_ip.num_search_ports = XML->sys.core[ithCore].number_instruction_fetch_ports;
-	  icache.ifb = new ArrayST(&interface_ip, "icacheFillBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  icache.area.set_area(icache.area.get_area()+ icache.ifb->local_result.area);
-	  area.set_area(area.get_area()+ icache.ifb->local_result.area);
-	  //output_data_csv(icache.ifb.local_result);
+  // prefetch buffer
+  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;  // check with
+                                                           // previous entries
+                                                           // to decide wthether
+                                                           // to merge.
+  data = icache.caches->l_ip
+             .line_sz;  // separate queue to prevent from cache polution.
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
+  interface_ip.cache_sz =
+      XML->sys.core[ithCore].icache.buffer_sizes[2] * interface_ip.line_sz;
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 0;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].icache.icache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].icache.icache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports =
+      debug ? 1 : XML->sys.core[ithCore].number_instruction_fetch_ports;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  interface_ip.num_search_ports =
+      XML->sys.core[ithCore].number_instruction_fetch_ports;
+  icache.prefetchb =
+      new ArrayST(&interface_ip, "icacheprefetchBuffer", Core_device,
+                  coredynp.opt_local, coredynp.core_ty);
+  icache.area.set_area(icache.area.get_area() +
+                       icache.prefetchb->local_result.area);
+  area.set_area(area.get_area() + icache.prefetchb->local_result.area);
+  // output_data_csv(icache.prefetchb.local_result);
 
-	  //prefetch buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries to decide wthether to merge.
-	  data							   = icache.caches->l_ip.line_sz;//separate queue to prevent from cache polution.
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-	  interface_ip.cache_sz            = XML->sys.core[ithCore].icache.buffer_sizes[2]*interface_ip.line_sz;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 0;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].icache.icache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].icache.icache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].number_instruction_fetch_ports;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  interface_ip.num_search_ports = XML->sys.core[ithCore].number_instruction_fetch_ports;
-	  icache.prefetchb = new ArrayST(&interface_ip, "icacheprefetchBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  icache.area.set_area(icache.area.get_area()+ icache.prefetchb->local_result.area);
-	  area.set_area(area.get_area()+ icache.prefetchb->local_result.area);
-	  //output_data_csv(icache.prefetchb.local_result);
+  // Instruction buffer
+  data =
+      XML->sys.core[ithCore].instruction_length *
+      XML->sys.core[ithCore].peak_issue_width;  // icache.caches.l_ip.line_sz;
+                                                // //multiple threads timing
+                                                // sharing the instruction
+                                                // buffer.
+  interface_ip.is_cache = false;
+  interface_ip.pure_ram = true;
+  interface_ip.pure_cam = false;
+  interface_ip.line_sz = int(ceil(data / 8.0));
+  interface_ip.cache_sz =
+      XML->sys.core[ithCore].number_hardware_threads *
+                  XML->sys.core[ithCore].instruction_buffer_size *
+                  interface_ip.line_sz >
+              64
+          ? XML->sys.core[ithCore].number_hardware_threads *
+                XML->sys.core[ithCore].instruction_buffer_size *
+                interface_ip.line_sz
+          : 64;
+  interface_ip.assoc = 1;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 0;
+  interface_ip.throughput = 1.0 / clockRate;
+  interface_ip.latency = 1.0 / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  // NOTE: Assuming IB is time slice shared among threads, every fetch op will
+  // at least fetch "fetch width" instructions.
+  interface_ip.num_rw_ports =
+      debug
+          ? 1
+          : XML->sys.core[ithCore]
+                .number_instruction_fetch_ports;  // XML->sys.core[ithCore].fetch_width;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  IB = new ArrayST(&interface_ip, "InstBuffer", Core_device, coredynp.opt_local,
+                   coredynp.core_ty);
+  IB->area.set_area(IB->area.get_area() + IB->local_result.area);
+  area.set_area(area.get_area() + IB->local_result.area);
+  // output_data_csv(IB.IB.local_result);
 
-	  //Instruction buffer
-	  data							   = XML->sys.core[ithCore].instruction_length*XML->sys.core[ithCore].peak_issue_width;//icache.caches.l_ip.line_sz; //multiple threads timing sharing the instruction buffer.
-	  interface_ip.is_cache			   = false;
-	  interface_ip.pure_ram            = true;
-	  interface_ip.pure_cam            = false;
-	  interface_ip.line_sz             = int(ceil(data/8.0));
-	  interface_ip.cache_sz            = XML->sys.core[ithCore].number_hardware_threads*XML->sys.core[ithCore].instruction_buffer_size*interface_ip.line_sz>64?
-			                             XML->sys.core[ithCore].number_hardware_threads*XML->sys.core[ithCore].instruction_buffer_size*interface_ip.line_sz:64;
-	  interface_ip.assoc               = 1;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 0;
-	  interface_ip.throughput          = 1.0/clockRate;
-	  interface_ip.latency             = 1.0/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  //NOTE: Assuming IB is time slice shared among threads, every fetch op will at least fetch "fetch width" instructions.
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].number_instruction_fetch_ports;//XML->sys.core[ithCore].fetch_width;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  IB = new ArrayST(&interface_ip, "InstBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  IB->area.set_area(IB->area.get_area()+ IB->local_result.area);
-	  area.set_area(area.get_area()+ IB->local_result.area);
-	  //output_data_csv(IB.IB.local_result);
+  //	  inst_decoder.opcode_length = XML->sys.core[ithCore].opcode_width;
+  //	  inst_decoder.init_decoder(is_default, &interface_ip);
+  //	  inst_decoder.full_decoder_power();
 
-	  //	  inst_decoder.opcode_length = XML->sys.core[ithCore].opcode_width;
-	  //	  inst_decoder.init_decoder(is_default, &interface_ip);
-	  //	  inst_decoder.full_decoder_power();
+  if (coredynp.predictionW > 0) {
+    /*
+     * BTB branch target buffer, accessed during IF stage. Virtually indexed and
+     * virtually tagged
+     * It is only a cache without all the buffers in the cache controller since
+     * it is more like a
+     * look up table than a cache with cache controller. When access miss, no
+     * load from other places
+     * such as main memory (not actively fill the misses), it is passively
+     * updated under two circumstances:
+     * 1)  when BPT@ID stage finds out current is a taken branch while BTB
+     * missed
+     * 2)  When BPT@ID stage predicts differently than BTB
+     * 3)  When ID stage finds out current instruction is not a branch while BTB
+     * had a hit.(mark as invalid)
+     * 4)  when EXEU find out wrong target has been provided from BTB.
+     *
+     */
+    size = XML->sys.core[ithCore].BTB.BTB_config[0];
+    line = XML->sys.core[ithCore].BTB.BTB_config[1];
+    assoc = XML->sys.core[ithCore].BTB.BTB_config[2];
+    banks = XML->sys.core[ithCore].BTB.BTB_config[3];
+    idx = debug ? 9 : int(ceil(log2(size / line / assoc)));
+    //    	  tag							   =
+    //    debug?51:XML->sys.virtual_address_width-idx-int(ceil(log2(line))) +
+    //    int(ceil(log2(XML->sys.core[ithCore].number_hardware_threads)))
+    //    +EXTRA_TAG_BITS;
+    tag =
+        debug ? 51 : XML->sys.virtual_address_width +
+                         int(ceil(log2(
+                             XML->sys.core[ithCore].number_hardware_threads))) +
+                         EXTRA_TAG_BITS;
+    interface_ip.is_cache = true;
+    interface_ip.pure_ram = false;
+    interface_ip.pure_cam = false;
+    interface_ip.specific_tag = 1;
+    interface_ip.tag_w = tag;
+    interface_ip.cache_sz = debug ? 32768 : size;
+    interface_ip.line_sz = debug ? 64 : line;
+    interface_ip.assoc = debug ? 8 : assoc;
+    interface_ip.nbanks = debug ? 1 : banks;
+    interface_ip.out_w = interface_ip.line_sz * 8;
+    interface_ip.access_mode =
+        0;  // debug?0:XML->sys.core[ithCore].dcache.dcache_config[5];
+    interface_ip.throughput =
+        debug ? 1.0 / clockRate
+              : XML->sys.core[ithCore].BTB.BTB_config[4] / clockRate;
+    interface_ip.latency =
+        debug ? 3.0 / clockRate
+              : XML->sys.core[ithCore].BTB.BTB_config[5] / clockRate;
+    interface_ip.obj_func_dyn_energy = 0;
+    interface_ip.obj_func_dyn_power = 0;
+    interface_ip.obj_func_leak_power = 0;
+    interface_ip.obj_func_cycle_t = 1;
+    interface_ip.num_rw_ports = 1;
+    interface_ip.num_rd_ports = coredynp.predictionW;
+    interface_ip.num_wr_ports = coredynp.predictionW;
+    interface_ip.num_se_rd_ports = 0;
+    BTB = new ArrayST(&interface_ip, "Branch Target Buffer", Core_device,
+                      coredynp.opt_local, coredynp.core_ty);
+    BTB->area.set_area(BTB->area.get_area() + BTB->local_result.area);
+    area.set_area(area.get_area() + BTB->local_result.area);
+    /// cout<<"area="<<area<<endl;
 
-      if (coredynp.predictionW>0)
-      {
-    	  /*
-    	   * BTB branch target buffer, accessed during IF stage. Virtually indexed and virtually tagged
-    	   * It is only a cache without all the buffers in the cache controller since it is more like a
-    	   * look up table than a cache with cache controller. When access miss, no load from other places
-    	   * such as main memory (not actively fill the misses), it is passively updated under two circumstances:
-    	   * 1)  when BPT@ID stage finds out current is a taken branch while BTB missed
-    	   * 2)  When BPT@ID stage predicts differently than BTB
-    	   * 3)  When ID stage finds out current instruction is not a branch while BTB had a hit.(mark as invalid)
-    	   * 4)  when EXEU find out wrong target has been provided from BTB.
-    	   *
-    	   */
-    	  size                             = XML->sys.core[ithCore].BTB.BTB_config[0];
-    	  line                             = XML->sys.core[ithCore].BTB.BTB_config[1];
-    	  assoc                            = XML->sys.core[ithCore].BTB.BTB_config[2];
-    	  banks                            = XML->sys.core[ithCore].BTB.BTB_config[3];
-    	  idx    					 	   = debug?9:int(ceil(log2(size/line/assoc)));
-//    	  tag							   = debug?51:XML->sys.virtual_address_width-idx-int(ceil(log2(line))) + int(ceil(log2(XML->sys.core[ithCore].number_hardware_threads))) +EXTRA_TAG_BITS;
-    	  tag							   = debug?51:XML->sys.virtual_address_width + int(ceil(log2(XML->sys.core[ithCore].number_hardware_threads))) +EXTRA_TAG_BITS;
-    	  interface_ip.is_cache			   = true;
-    	  interface_ip.pure_ram            = false;
-    	  interface_ip.pure_cam            = false;
-    	  interface_ip.specific_tag        = 1;
-    	  interface_ip.tag_w               = tag;
-    	  interface_ip.cache_sz            = debug?32768:size;
-    	  interface_ip.line_sz             = debug?64:line;
-    	  interface_ip.assoc               = debug?8:assoc;
-    	  interface_ip.nbanks              = debug?1:banks;
-    	  interface_ip.out_w               = interface_ip.line_sz*8;
-    	  interface_ip.access_mode         = 0;//debug?0:XML->sys.core[ithCore].dcache.dcache_config[5];
-    	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].BTB.BTB_config[4]/clockRate;
-    	  interface_ip.latency             = debug?3.0/clockRate:XML->sys.core[ithCore].BTB.BTB_config[5]/clockRate;
-    	  interface_ip.obj_func_dyn_energy = 0;
-    	  interface_ip.obj_func_dyn_power  = 0;
-    	  interface_ip.obj_func_leak_power = 0;
-    	  interface_ip.obj_func_cycle_t    = 1;
-    	  interface_ip.num_rw_ports    = 1;
-    	  interface_ip.num_rd_ports    = coredynp.predictionW;
-    	  interface_ip.num_wr_ports    = coredynp.predictionW;
-    	  interface_ip.num_se_rd_ports = 0;
-    	  BTB = new ArrayST(&interface_ip, "Branch Target Buffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-    	  BTB->area.set_area(BTB->area.get_area()+ BTB->local_result.area);
-    	  area.set_area(area.get_area()+ BTB->local_result.area);
-    	  ///cout<<"area="<<area<<endl;
+    BPT = new BranchPredictor(XML, ithCore, &interface_ip, coredynp);
+    area.set_area(area.get_area() + BPT->area.get_area());
+  }
 
-    	  BPT = new BranchPredictor(XML, ithCore, &interface_ip,coredynp);
-    	  area.set_area(area.get_area()+ BPT->area.get_area());
-      }
+  ID_inst = new inst_decoder(is_default, &interface_ip, coredynp.opcode_length,
+                             1 /*Decoder should not know how many by itself*/,
+                             coredynp.x86, Core_device, coredynp.core_ty);
 
-      ID_inst = new inst_decoder(is_default, &interface_ip,
-    		  coredynp.opcode_length, 1/*Decoder should not know how many by itself*/,
-    		  coredynp.x86,
-    		  Core_device, coredynp.core_ty);
+  ID_operand =
+      new inst_decoder(is_default, &interface_ip, coredynp.arch_ireg_width, 1,
+                       coredynp.x86, Core_device, coredynp.core_ty);
 
-      ID_operand = new inst_decoder(is_default, &interface_ip,
-    		  coredynp.arch_ireg_width, 1,
-    		  coredynp.x86,
-    		  Core_device, coredynp.core_ty);
-
-      ID_misc = new inst_decoder(is_default, &interface_ip,
-    		  8/* Prefix field etc upto 14B*/, 1,
-    		  coredynp.x86,
-    		  Core_device, coredynp.core_ty);
-      //TODO: X86 decoder should decode the inst in cyclic mode under the control of squencer.
-      //So the dynamic power should be multiplied by a few times.
-      area.set_area(area.get_area()+ (ID_inst->area.get_area()
-    		  +ID_operand->area.get_area()
-    		  +ID_misc->area.get_area())*coredynp.decodeW);
-
+  ID_misc = new inst_decoder(is_default, &interface_ip,
+                             8 /* Prefix field etc upto 14B*/, 1, coredynp.x86,
+                             Core_device, coredynp.core_ty);
+  // TODO: X86 decoder should decode the inst in cyclic mode under the control
+  // of squencer.
+  // So the dynamic power should be multiplied by a few times.
+  area.set_area(area.get_area() +
+                (ID_inst->area.get_area() + ID_operand->area.get_area() +
+                 ID_misc->area.get_area()) *
+                    coredynp.decodeW);
 }
 
+BranchPredictor::BranchPredictor(ParseXML* XML_interface, int ithCore_,
+                                 InputParameter* interface_ip_,
+                                 const CoreDynParam& dyn_p_, bool exist_)
+    : XML(XML_interface),
+      ithCore(ithCore_),
+      interface_ip(*interface_ip_),
+      coredynp(dyn_p_),
+      globalBPT(0),
+      localBPT(0),
+      L1_localBPT(0),
+      L2_localBPT(0),
+      chooser(0),
+      RAS(0),
+      exist(exist_) {
+  /*
+   * Branch Predictor, accessed during ID stage.
+   * McPAT's branch predictor model is the tournament branch predictor used in
+   * Alpha 21264,
+   * including global predictor, local two level predictor, and Chooser.
+   * The Branch predictor also includes a RAS (return address stack) for
+   * function calls
+   * Branch predictors are tagged by thread ID and modeled as 1-way associative
+   * $
+   * However RAS return address stacks are duplicated for each thread.
+   * TODO:Data Width need to be computed more precisely	 *
+   */
+  if (!exist) return;
+  int tag, data;
 
-BranchPredictor::BranchPredictor(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_, bool exist_)
-:XML(XML_interface),
- ithCore(ithCore_),
- interface_ip(*interface_ip_),
- coredynp(dyn_p_),
- globalBPT(0),
- localBPT(0),
- L1_localBPT(0),
- L2_localBPT(0),
- chooser(0),
- RAS(0),
- exist(exist_)
-{
-	/*
-	 * Branch Predictor, accessed during ID stage.
-	 * McPAT's branch predictor model is the tournament branch predictor used in Alpha 21264,
-	 * including global predictor, local two level predictor, and Chooser.
-	 * The Branch predictor also includes a RAS (return address stack) for function calls
-	 * Branch predictors are tagged by thread ID and modeled as 1-way associative $
-	 * However RAS return address stacks are duplicated for each thread.
-	 * TODO:Data Width need to be computed more precisely	 *
-	 */
-	if (!exist) return;
-	int  tag, data;
+  clockRate = coredynp.clockRate;
+  executionTime = coredynp.executionTime;
+  interface_ip.assoc = 1;
+  interface_ip.pure_cam = false;
+  if (coredynp.multithreaded) {
+    tag = int(log2(coredynp.num_hthreads) + EXTRA_TAG_BITS);
+    interface_ip.specific_tag = 1;
+    interface_ip.tag_w = tag;
 
-	clockRate = coredynp.clockRate;
-	executionTime = coredynp.executionTime;
-	interface_ip.assoc               = 1;
-	interface_ip.pure_cam            = false;
-	if (coredynp.multithreaded)
-	{
+    interface_ip.is_cache = true;
+    interface_ip.pure_ram = false;
+  } else {
+    interface_ip.is_cache = false;
+    interface_ip.pure_ram = true;
+  }
+  // Global predictor
+  data =
+      int(ceil(XML->sys.core[ithCore].predictor.global_predictor_bits / 8.0));
+  interface_ip.line_sz = data;
+  interface_ip.cache_sz =
+      data * XML->sys.core[ithCore].predictor.global_predictor_entries;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput = 1.0 / clockRate;
+  interface_ip.latency = 1.0 / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = 0;
+  interface_ip.num_rd_ports = coredynp.predictionW;
+  interface_ip.num_wr_ports = coredynp.predictionW;
+  interface_ip.num_se_rd_ports = 0;
+  globalBPT = new ArrayST(&interface_ip, "Global Predictor", Core_device,
+                          coredynp.opt_local, coredynp.core_ty);
+  globalBPT->area.set_area(globalBPT->area.get_area() +
+                           globalBPT->local_result.area);
+  area.set_area(area.get_area() + globalBPT->local_result.area);
 
-		tag							     = int(log2(coredynp.num_hthreads)+ EXTRA_TAG_BITS);
-		interface_ip.specific_tag        = 1;
-		interface_ip.tag_w               = tag;
+  // Local BPT (Level 1)
+  data =
+      int(ceil(XML->sys.core[ithCore].predictor.local_predictor_size[0] / 8.0));
+  interface_ip.line_sz = data;
+  interface_ip.cache_sz =
+      data * XML->sys.core[ithCore].predictor.local_predictor_entries;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput = 1.0 / clockRate;
+  interface_ip.latency = 1.0 / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = 0;
+  interface_ip.num_rd_ports = coredynp.predictionW;
+  interface_ip.num_wr_ports = coredynp.predictionW;
+  interface_ip.num_se_rd_ports = 0;
+  L1_localBPT = new ArrayST(&interface_ip, "L1 local Predictor", Core_device,
+                            coredynp.opt_local, coredynp.core_ty);
+  L1_localBPT->area.set_area(L1_localBPT->area.get_area() +
+                             L1_localBPT->local_result.area);
+  area.set_area(area.get_area() + L1_localBPT->local_result.area);
 
-		interface_ip.is_cache			 = true;
-		interface_ip.pure_ram            = false;
-		}
-	else
-	{
-		interface_ip.is_cache			 = false;
-		interface_ip.pure_ram            = true;
+  // Local BPT (Level 2)
+  data =
+      int(ceil(XML->sys.core[ithCore].predictor.local_predictor_size[1] / 8.0));
+  interface_ip.line_sz = data;
+  interface_ip.cache_sz =
+      data * XML->sys.core[ithCore].predictor.local_predictor_entries;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput = 1.0 / clockRate;
+  interface_ip.latency = 1.0 / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = 0;
+  interface_ip.num_rd_ports = coredynp.predictionW;
+  interface_ip.num_wr_ports = coredynp.predictionW;
+  interface_ip.num_se_rd_ports = 0;
+  L2_localBPT = new ArrayST(&interface_ip, "L2 local Predictor", Core_device,
+                            coredynp.opt_local, coredynp.core_ty);
+  L2_localBPT->area.set_area(L2_localBPT->area.get_area() +
+                             L2_localBPT->local_result.area);
+  area.set_area(area.get_area() + L2_localBPT->local_result.area);
 
-	}
-	//Global predictor
-	data							 = int(ceil(XML->sys.core[ithCore].predictor.global_predictor_bits/8.0));
-	interface_ip.line_sz             = data;
-	interface_ip.cache_sz            = data*XML->sys.core[ithCore].predictor.global_predictor_entries;
-	interface_ip.nbanks              = 1;
-	interface_ip.out_w               = interface_ip.line_sz*8;
-	interface_ip.access_mode         = 2;
-	interface_ip.throughput          = 1.0/clockRate;
-	interface_ip.latency             = 1.0/clockRate;
-	interface_ip.obj_func_dyn_energy = 0;
-	interface_ip.obj_func_dyn_power  = 0;
-	interface_ip.obj_func_leak_power = 0;
-	interface_ip.obj_func_cycle_t    = 1;
-	interface_ip.num_rw_ports    = 0;
-	interface_ip.num_rd_ports    = coredynp.predictionW;
-	interface_ip.num_wr_ports    = coredynp.predictionW;
-	interface_ip.num_se_rd_ports = 0;
-	globalBPT = new ArrayST(&interface_ip, "Global Predictor", Core_device, coredynp.opt_local, coredynp.core_ty);
-	globalBPT->area.set_area(globalBPT->area.get_area()+ globalBPT->local_result.area);
-	area.set_area(area.get_area()+ globalBPT->local_result.area);
+  // Chooser
+  data =
+      int(ceil(XML->sys.core[ithCore].predictor.chooser_predictor_bits / 8.0));
+  interface_ip.line_sz = data;
+  interface_ip.cache_sz =
+      data * XML->sys.core[ithCore].predictor.chooser_predictor_entries;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput = 1.0 / clockRate;
+  interface_ip.latency = 1.0 / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = 0;
+  interface_ip.num_rd_ports = coredynp.predictionW;
+  interface_ip.num_wr_ports = coredynp.predictionW;
+  interface_ip.num_se_rd_ports = 0;
+  chooser = new ArrayST(&interface_ip, "Predictor Chooser", Core_device,
+                        coredynp.opt_local, coredynp.core_ty);
+  chooser->area.set_area(chooser->area.get_area() + chooser->local_result.area);
+  area.set_area(area.get_area() + chooser->local_result.area);
 
-	//Local BPT (Level 1)
-	data							 = int(ceil(XML->sys.core[ithCore].predictor.local_predictor_size[0]/8.0));
-	interface_ip.line_sz             = data;
-	interface_ip.cache_sz            = data*XML->sys.core[ithCore].predictor.local_predictor_entries;
-	interface_ip.nbanks              = 1;
-	interface_ip.out_w               = interface_ip.line_sz*8;
-	interface_ip.access_mode         = 2;
-	interface_ip.throughput          = 1.0/clockRate;
-	interface_ip.latency             = 1.0/clockRate;
-	interface_ip.obj_func_dyn_energy = 0;
-	interface_ip.obj_func_dyn_power  = 0;
-	interface_ip.obj_func_leak_power = 0;
-	interface_ip.obj_func_cycle_t    = 1;
-	interface_ip.num_rw_ports    = 0;
-	interface_ip.num_rd_ports    = coredynp.predictionW;
-	interface_ip.num_wr_ports    = coredynp.predictionW;
-	interface_ip.num_se_rd_ports = 0;
-	L1_localBPT = new ArrayST(&interface_ip, "L1 local Predictor", Core_device, coredynp.opt_local, coredynp.core_ty);
-	L1_localBPT->area.set_area(L1_localBPT->area.get_area()+ L1_localBPT->local_result.area);
-	area.set_area(area.get_area()+ L1_localBPT->local_result.area);
-
-	//Local BPT (Level 2)
-	data							 = int(ceil(XML->sys.core[ithCore].predictor.local_predictor_size[1]/8.0));
-	interface_ip.line_sz             = data;
-	interface_ip.cache_sz            = data*XML->sys.core[ithCore].predictor.local_predictor_entries;
-	interface_ip.nbanks              = 1;
-	interface_ip.out_w               = interface_ip.line_sz*8;
-	interface_ip.access_mode         = 2;
-	interface_ip.throughput          = 1.0/clockRate;
-	interface_ip.latency             = 1.0/clockRate;
-	interface_ip.obj_func_dyn_energy = 0;
-	interface_ip.obj_func_dyn_power  = 0;
-	interface_ip.obj_func_leak_power = 0;
-	interface_ip.obj_func_cycle_t    = 1;
-	interface_ip.num_rw_ports    = 0;
-	interface_ip.num_rd_ports    = coredynp.predictionW;
-	interface_ip.num_wr_ports    = coredynp.predictionW;
-	interface_ip.num_se_rd_ports = 0;
-	L2_localBPT = new ArrayST(&interface_ip, "L2 local Predictor", Core_device, coredynp.opt_local, coredynp.core_ty);
-	L2_localBPT->area.set_area(L2_localBPT->area.get_area()+ L2_localBPT->local_result.area);
-	area.set_area(area.get_area()+ L2_localBPT->local_result.area);
-
-	//Chooser
-	data							 = int(ceil(XML->sys.core[ithCore].predictor.chooser_predictor_bits/8.0));
-	interface_ip.line_sz             = data;
-	interface_ip.cache_sz            = data*XML->sys.core[ithCore].predictor.chooser_predictor_entries;
-	interface_ip.nbanks              = 1;
-	interface_ip.out_w               = interface_ip.line_sz*8;
-	interface_ip.access_mode         = 2;
-	interface_ip.throughput          = 1.0/clockRate;
-	interface_ip.latency             = 1.0/clockRate;
-	interface_ip.obj_func_dyn_energy = 0;
-	interface_ip.obj_func_dyn_power  = 0;
-	interface_ip.obj_func_leak_power = 0;
-	interface_ip.obj_func_cycle_t    = 1;
-	interface_ip.num_rw_ports    = 0;
-	interface_ip.num_rd_ports    = coredynp.predictionW;
-	interface_ip.num_wr_ports    = coredynp.predictionW;
-	interface_ip.num_se_rd_ports = 0;
-	chooser = new ArrayST(&interface_ip, "Predictor Chooser", Core_device, coredynp.opt_local, coredynp.core_ty);
-	chooser->area.set_area(chooser->area.get_area()+ chooser->local_result.area);
-	area.set_area(area.get_area()+ chooser->local_result.area);
-
-	//RAS return address stacks are Duplicated for each thread.
-	interface_ip.is_cache			 = false;
-	interface_ip.pure_ram            = true;
-	data							 = int(ceil(coredynp.pc_width/8.0));
-	interface_ip.line_sz             = data;
-	interface_ip.cache_sz            = data*XML->sys.core[ithCore].RAS_size;
-	interface_ip.assoc               = 1;
-	interface_ip.nbanks              = 1;
-	interface_ip.out_w               = interface_ip.line_sz*8;
-	interface_ip.access_mode         = 2;
-	interface_ip.throughput          = 1.0/clockRate;
-	interface_ip.latency             = 1.0/clockRate;
-	interface_ip.obj_func_dyn_energy = 0;
-	interface_ip.obj_func_dyn_power  = 0;
-	interface_ip.obj_func_leak_power = 0;
-	interface_ip.obj_func_cycle_t    = 1;
-	interface_ip.num_rw_ports    = 0;
-	interface_ip.num_rd_ports    = coredynp.predictionW;
-	interface_ip.num_wr_ports    = coredynp.predictionW;
-	interface_ip.num_se_rd_ports = 0;
-	RAS = new ArrayST(&interface_ip, "RAS", Core_device, coredynp.opt_local, coredynp.core_ty);
-	RAS->area.set_area(RAS->area.get_area()+ RAS->local_result.area*coredynp.num_hthreads);
-	area.set_area(area.get_area()+ RAS->local_result.area*coredynp.num_hthreads);
-
+  // RAS return address stacks are Duplicated for each thread.
+  interface_ip.is_cache = false;
+  interface_ip.pure_ram = true;
+  data = int(ceil(coredynp.pc_width / 8.0));
+  interface_ip.line_sz = data;
+  interface_ip.cache_sz = data * XML->sys.core[ithCore].RAS_size;
+  interface_ip.assoc = 1;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput = 1.0 / clockRate;
+  interface_ip.latency = 1.0 / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = 0;
+  interface_ip.num_rd_ports = coredynp.predictionW;
+  interface_ip.num_wr_ports = coredynp.predictionW;
+  interface_ip.num_se_rd_ports = 0;
+  RAS = new ArrayST(&interface_ip, "RAS", Core_device, coredynp.opt_local,
+                    coredynp.core_ty);
+  RAS->area.set_area(RAS->area.get_area() +
+                     RAS->local_result.area * coredynp.num_hthreads);
+  area.set_area(area.get_area() +
+                RAS->local_result.area * coredynp.num_hthreads);
 }
 
-SchedulerU::SchedulerU(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_, bool exist_)
-:XML(XML_interface),
- ithCore(ithCore_),
- interface_ip(*interface_ip_),
- coredynp(dyn_p_),
- int_inst_window(0),
- fp_inst_window(0),
- ROB(0),
- instruction_selection(0),
- exist(exist_)
- {
-	if (!exist) return;
-	int   tag, data;
-	bool  is_default=true;
-	string tmp_name;
+SchedulerU::SchedulerU(ParseXML* XML_interface, int ithCore_,
+                       InputParameter* interface_ip_,
+                       const CoreDynParam& dyn_p_, bool exist_)
+    : XML(XML_interface),
+      ithCore(ithCore_),
+      interface_ip(*interface_ip_),
+      coredynp(dyn_p_),
+      int_inst_window(0),
+      fp_inst_window(0),
+      ROB(0),
+      instruction_selection(0),
+      exist(exist_) {
+  if (!exist) return;
+  int tag, data;
+  bool is_default = true;
+  string tmp_name;
 
-	clockRate = coredynp.clockRate;
-	executionTime = coredynp.executionTime;
-	if ((coredynp.core_ty==Inorder && coredynp.multithreaded))
-	{
-		//Instruction issue queue, in-order multi-issue or multithreaded processor also has this structure. Unified window for Inorder processors
-		tag							     = int(log2(XML->sys.core[ithCore].number_hardware_threads)*coredynp.perThreadState);//This is the normal thread state bits based on Niagara Design
-		data							 = XML->sys.core[ithCore].instruction_length;
-		//NOTE: x86 inst can be very lengthy, up to 15B. Source: Intel® 64 and IA-32 Architectures
-		//Software Developer’s Manual
-		interface_ip.is_cache			 = true;
-		interface_ip.pure_cam            = false;
-		interface_ip.pure_ram            = false;
-		interface_ip.line_sz             = int(ceil(data/8.0));
-		interface_ip.specific_tag        = 1;
-		interface_ip.tag_w               = tag;
-		interface_ip.cache_sz            = XML->sys.core[ithCore].instruction_window_size*interface_ip.line_sz>64?XML->sys.core[ithCore].instruction_window_size*interface_ip.line_sz:64;
-		interface_ip.assoc               = 0;
-		interface_ip.nbanks              = 1;
-		interface_ip.out_w               = interface_ip.line_sz*8;
-		interface_ip.access_mode         = 1;
-		interface_ip.throughput          = 1.0/clockRate;
-		interface_ip.latency             = 1.0/clockRate;
-		interface_ip.obj_func_dyn_energy = 0;
-		interface_ip.obj_func_dyn_power  = 0;
-		interface_ip.obj_func_leak_power = 0;
-		interface_ip.obj_func_cycle_t    = 1;
-		interface_ip.num_rw_ports        = 0;
-		interface_ip.num_rd_ports        = coredynp.peak_issueW;
-		interface_ip.num_wr_ports        = coredynp.peak_issueW;
-		interface_ip.num_se_rd_ports     = 0;
-		interface_ip.num_search_ports    = coredynp.peak_issueW;
-		int_inst_window = new ArrayST(&interface_ip, "InstFetchQueue", Core_device, coredynp.opt_local, coredynp.core_ty);
-		int_inst_window->area.set_area(int_inst_window->area.get_area()+ int_inst_window->local_result.area*coredynp.num_pipelines);
-		area.set_area(area.get_area()+ int_inst_window->local_result.area*coredynp.num_pipelines);
-		//output_data_csv(iRS.RS.local_result);
-		Iw_height      =int_inst_window->local_result.cache_ht;
+  clockRate = coredynp.clockRate;
+  executionTime = coredynp.executionTime;
+  if ((coredynp.core_ty == Inorder && coredynp.multithreaded)) {
+    // Instruction issue queue, in-order multi-issue or multithreaded processor
+    // also has this structure. Unified window for Inorder processors
+    tag = int(log2(XML->sys.core[ithCore].number_hardware_threads) *
+              coredynp.perThreadState);  // This is the normal thread state bits
+                                         // based on Niagara Design
+    data = XML->sys.core[ithCore].instruction_length;
+    // NOTE: x86 inst can be very lengthy, up to 15B. Source: Intel® 64 and
+    // IA-32 Architectures
+    // Software Developer’s Manual
+    interface_ip.is_cache = true;
+    interface_ip.pure_cam = false;
+    interface_ip.pure_ram = false;
+    interface_ip.line_sz = int(ceil(data / 8.0));
+    interface_ip.specific_tag = 1;
+    interface_ip.tag_w = tag;
+    interface_ip.cache_sz =
+        XML->sys.core[ithCore].instruction_window_size * interface_ip.line_sz >
+                64
+            ? XML->sys.core[ithCore].instruction_window_size *
+                  interface_ip.line_sz
+            : 64;
+    interface_ip.assoc = 0;
+    interface_ip.nbanks = 1;
+    interface_ip.out_w = interface_ip.line_sz * 8;
+    interface_ip.access_mode = 1;
+    interface_ip.throughput = 1.0 / clockRate;
+    interface_ip.latency = 1.0 / clockRate;
+    interface_ip.obj_func_dyn_energy = 0;
+    interface_ip.obj_func_dyn_power = 0;
+    interface_ip.obj_func_leak_power = 0;
+    interface_ip.obj_func_cycle_t = 1;
+    interface_ip.num_rw_ports = 0;
+    interface_ip.num_rd_ports = coredynp.peak_issueW;
+    interface_ip.num_wr_ports = coredynp.peak_issueW;
+    interface_ip.num_se_rd_ports = 0;
+    interface_ip.num_search_ports = coredynp.peak_issueW;
+    int_inst_window = new ArrayST(&interface_ip, "InstFetchQueue", Core_device,
+                                  coredynp.opt_local, coredynp.core_ty);
+    int_inst_window->area.set_area(int_inst_window->area.get_area() +
+                                   int_inst_window->local_result.area *
+                                       coredynp.num_pipelines);
+    area.set_area(area.get_area() +
+                  int_inst_window->local_result.area * coredynp.num_pipelines);
+    // output_data_csv(iRS.RS.local_result);
+    Iw_height = int_inst_window->local_result.cache_ht;
 
-		/*
-		 * selection logic
-		 * In a single-issue Inorder multithreaded processor like Niagara, issue width=1*number_of_threads since the processor does need to pick up
-		 * instructions from multiple ready ones(although these ready ones are from different threads).While SMT processors do not distinguish which thread belongs to who
-		 * at the issue stage.
-		 */
+    /*
+     * selection logic
+     * In a single-issue Inorder multithreaded processor like Niagara, issue
+     * width=1*number_of_threads since the processor does need to pick up
+     * instructions from multiple ready ones(although these ready ones are from
+     * different threads).While SMT processors do not distinguish which thread
+     * belongs to who
+     * at the issue stage.
+     */
 
-		instruction_selection = new selection_logic(is_default, XML->sys.core[ithCore].instruction_window_size,
-				coredynp.peak_issueW*XML->sys.core[ithCore].number_hardware_threads,
-				&interface_ip, Core_device, coredynp.core_ty);
-	}
+    instruction_selection = new selection_logic(
+        is_default, XML->sys.core[ithCore].instruction_window_size,
+        coredynp.peak_issueW * XML->sys.core[ithCore].number_hardware_threads,
+        &interface_ip, Core_device, coredynp.core_ty);
+  }
 
-    if (coredynp.core_ty==OOO)
-    {
-    	/*
-    	 * CAM based instruction window
-    	 * For physicalRegFilebased OOO it is the instruction issue queue, where only tags of phy regs are stored
-    	 * For RS based OOO it is the Reservation station, where both tags and values of phy regs are stored
-    	 * It is written once and read twice(two operands) before an instruction can be issued.
-    	 * X86 instruction can be very long up to 15B. add instruction length in XML
-    	 */
-    	if(coredynp.scheu_ty==PhysicalRegFile)
-    	{
-    		tag	 = coredynp.phy_ireg_width;
-    		// Each time only half of the tag is compared, but two tag should be stored.
-    		// This underestimate the search power
-    		data = int((ceil((coredynp.instruction_length+2*(coredynp.phy_ireg_width - coredynp.arch_ireg_width))/2.0)/8.0));
-	        //Data width being divided by 2 means only after both operands available the whole data will be read out.
-	        //This is modeled using two equivalent readouts with half of the data width
-    		tmp_name = "InstIssueQueue";
-    	}
-    	else
-    	{
-	        tag	  = coredynp.phy_ireg_width;
-    		// Each time only half of the tag is compared, but two tag should be stored.
-    		// This underestimate the search power
-	        data  = int(ceil(((coredynp.instruction_length+2*(coredynp.phy_ireg_width - coredynp.arch_ireg_width)+
-	        		2*coredynp.int_data_width)/2.0)/8.0));
-	        //Data width being divided by 2 means only after both operands available the whole data will be read out.
-	        //This is modeled using two equivalent readouts with half of the data width
+  if (coredynp.core_ty == OOO) {
+    /*
+     * CAM based instruction window
+     * For physicalRegFilebased OOO it is the instruction issue queue, where
+     * only tags of phy regs are stored
+     * For RS based OOO it is the Reservation station, where both tags and
+     * values of phy regs are stored
+     * It is written once and read twice(two operands) before an instruction can
+     * be issued.
+     * X86 instruction can be very long up to 15B. add instruction length in XML
+     */
+    if (coredynp.scheu_ty == PhysicalRegFile) {
+      tag = coredynp.phy_ireg_width;
+      // Each time only half of the tag is compared, but two tag should be
+      // stored.
+      // This underestimate the search power
+      data =
+          int((ceil((coredynp.instruction_length +
+                     2 * (coredynp.phy_ireg_width - coredynp.arch_ireg_width)) /
+                    2.0) /
+               8.0));
+      // Data width being divided by 2 means only after both operands available
+      // the whole data will be read out.
+      // This is modeled using two equivalent readouts with half of the data
+      // width
+      tmp_name = "InstIssueQueue";
+    } else {
+      tag = coredynp.phy_ireg_width;
+      // Each time only half of the tag is compared, but two tag should be
+      // stored.
+      // This underestimate the search power
+      data =
+          int(ceil(((coredynp.instruction_length +
+                     2 * (coredynp.phy_ireg_width - coredynp.arch_ireg_width) +
+                     2 * coredynp.int_data_width) /
+                    2.0) /
+                   8.0));
+      // Data width being divided by 2 means only after both operands available
+      // the whole data will be read out.
+      // This is modeled using two equivalent readouts with half of the data
+      // width
 
-	        tmp_name = "IntReservationStation";
-    	}
-    	interface_ip.is_cache			 = true;
-    	interface_ip.pure_cam            = false;
-    	interface_ip.pure_ram            = false;
-    	interface_ip.line_sz             = data;
-    	interface_ip.cache_sz            = data*XML->sys.core[ithCore].instruction_window_size;
-    	interface_ip.assoc               = 0;
-    	interface_ip.nbanks              = 1;
-    	interface_ip.out_w               = interface_ip.line_sz*8;
-    	interface_ip.specific_tag        = 1;
-    	interface_ip.tag_w               = tag;
-    	interface_ip.access_mode         = 0;
-    	interface_ip.throughput          = 2*1.0/clockRate;
-    	interface_ip.latency             = 2*1.0/clockRate;
-    	interface_ip.obj_func_dyn_energy = 0;
-    	interface_ip.obj_func_dyn_power  = 0;
-    	interface_ip.obj_func_leak_power = 0;
-    	interface_ip.obj_func_cycle_t    = 1;
-    	interface_ip.num_rw_ports       = 0;
-    	interface_ip.num_rd_ports       = coredynp.peak_issueW;
-    	interface_ip.num_wr_ports       = coredynp.peak_issueW;
-    	interface_ip.num_se_rd_ports    = 0;
-		interface_ip.num_search_ports   = coredynp.peak_issueW;
-		int_inst_window = new ArrayST(&interface_ip, tmp_name, Core_device, coredynp.opt_local, coredynp.core_ty);
-		int_inst_window->area.set_area(int_inst_window->area.get_area()+ int_inst_window->local_result.area*coredynp.num_pipelines);
-		area.set_area(area.get_area()+ int_inst_window->local_result.area*coredynp.num_pipelines);
-		Iw_height      =int_inst_window->local_result.cache_ht;
-		//FU inst window
-    	if(coredynp.scheu_ty==PhysicalRegFile)
-    	{
-    		tag	 = 2*coredynp.phy_freg_width;// TODO: each time only half of the tag is compared
-    		data = int(ceil((coredynp.instruction_length+2*(coredynp.phy_freg_width - coredynp.arch_freg_width))/8.0));
-    		tmp_name = "FPIssueQueue";
-    	}
-    	else
-    	{
-	        tag	  = 2*coredynp.phy_ireg_width;
-	        data  = int(ceil((coredynp.instruction_length+2*(coredynp.phy_freg_width - coredynp.arch_freg_width)+
-	        		2*coredynp.fp_data_width)/8.0));
-	        tmp_name = "FPReservationStation";
-    	}
-    	interface_ip.is_cache			 = true;
-    	interface_ip.pure_cam            = false;
-    	interface_ip.pure_ram            = false;
-    	interface_ip.line_sz             = data;
-    	interface_ip.cache_sz            = data*XML->sys.core[ithCore].fp_instruction_window_size;
-    	interface_ip.assoc               = 0;
-    	interface_ip.nbanks              = 1;
-    	interface_ip.out_w               = interface_ip.line_sz*8;
-    	interface_ip.specific_tag        = 1;
-    	interface_ip.tag_w               = tag;
-    	interface_ip.access_mode         = 0;
-    	interface_ip.throughput          = 1.0/clockRate;
-    	interface_ip.latency             = 1.0/clockRate;
-    	interface_ip.obj_func_dyn_energy = 0;
-    	interface_ip.obj_func_dyn_power  = 0;
-    	interface_ip.obj_func_leak_power = 0;
-    	interface_ip.obj_func_cycle_t    = 1;
-    	interface_ip.num_rw_ports       = 0;
-    	interface_ip.num_rd_ports       = coredynp.fp_issueW;
-    	interface_ip.num_wr_ports       = coredynp.fp_issueW;
-    	interface_ip.num_se_rd_ports    = 0;
-		interface_ip.num_search_ports   = coredynp.fp_issueW;
-		fp_inst_window = new ArrayST(&interface_ip, tmp_name, Core_device, coredynp.opt_local, coredynp.core_ty);
-		fp_inst_window->area.set_area(fp_inst_window->area.get_area()+ fp_inst_window->local_result.area*coredynp.num_fp_pipelines);
-		area.set_area(area.get_area()+ fp_inst_window->local_result.area*coredynp.num_fp_pipelines);
-		fp_Iw_height      =fp_inst_window->local_result.cache_ht;
-
-		if (XML->sys.core[ithCore].ROB_size >0)
-		{
-			/*
-			 *  if ROB_size = 0, then the target processor does not support hardware-based
-			 *  speculation, i.e. , the processor allow OOO issue as well as OOO completion, which
-			 *  means branch must be resolved before instruction issued into instruction window, since
-			 *  there is no change to flush miss-predict branch path after instructions are issued in this situation.
-			 *
-			 *  ROB.ROB size = inflight inst. ROB is unified for int and fp inst.
-			 *  One old approach is to combine the RAT and ROB as a huge CAM structure as in AMD K7.
-			 *  However, this approach is abandoned due to its high power and poor scalablility.
-			 *	McPAT uses current implementation of ROB as circular buffer.
-			 *	ROB is written once when instruction is issued and read once when the instruction is committed.         *
-			 */
-			int robExtra = int(ceil(5 + log2(coredynp.num_hthreads)));
-			//5 bits are: busy, Issued, Finished, speculative, valid
-			if(coredynp.scheu_ty==PhysicalRegFile)
-			{
-				//PC is to id the instruction for recover exception.
-				//inst is used to map the renamed dest. registers.so that commit stage can know which reg/RRAT to update
-//				data = int(ceil((robExtra+coredynp.pc_width +
-//						coredynp.instruction_length + 2*coredynp.phy_ireg_width)/8.0));
-				data = int(ceil((robExtra+coredynp.pc_width +
-							coredynp.phy_ireg_width)/8.0));
-			}
-			else
-			{
-				//in RS based OOO, ROB also contains value of destination reg
-//				data  = int(ceil((robExtra+coredynp.pc_width +
-//						coredynp.instruction_length + 2*coredynp.phy_ireg_width + coredynp.fp_data_width)/8.0));
-				data  = int(ceil((robExtra + coredynp.pc_width +
-						coredynp.phy_ireg_width + coredynp.fp_data_width)/8.0));
-			}
-			interface_ip.is_cache			 = false;
-			interface_ip.pure_cam            = false;
-			interface_ip.pure_ram            = true;
-			interface_ip.line_sz             = data;
-			interface_ip.cache_sz            = data*XML->sys.core[ithCore].ROB_size;//The XML ROB size is for all threads
-			interface_ip.assoc               = 1;
-			interface_ip.nbanks              = 1;
-			interface_ip.out_w               = interface_ip.line_sz*8;
-			interface_ip.access_mode         = 1;
-			interface_ip.throughput          = 1.0/clockRate;
-			interface_ip.latency             = 1.0/clockRate;
-			interface_ip.obj_func_dyn_energy = 0;
-			interface_ip.obj_func_dyn_power  = 0;
-			interface_ip.obj_func_leak_power = 0;
-			interface_ip.obj_func_cycle_t    = 1;
-			interface_ip.num_rw_ports       = 0;
-			interface_ip.num_rd_ports       = coredynp.peak_commitW;
-			interface_ip.num_wr_ports       = coredynp.peak_issueW;
-			interface_ip.num_se_rd_ports    = 0;
-			interface_ip.num_search_ports   = 0;
-			ROB = new ArrayST(&interface_ip, "ReorderBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-			ROB->area.set_area(ROB->area.get_area()+ ROB->local_result.area*coredynp.num_pipelines);
-			area.set_area(area.get_area()+ ROB->local_result.area*coredynp.num_pipelines);
-			ROB_height      =ROB->local_result.cache_ht;
-		}
-
-		instruction_selection = new selection_logic(is_default, XML->sys.core[ithCore].instruction_window_size,
-				coredynp.peak_issueW, &interface_ip, Core_device, coredynp.core_ty);
+      tmp_name = "IntReservationStation";
     }
+    interface_ip.is_cache = true;
+    interface_ip.pure_cam = false;
+    interface_ip.pure_ram = false;
+    interface_ip.line_sz = data;
+    interface_ip.cache_sz =
+        data * XML->sys.core[ithCore].instruction_window_size;
+    interface_ip.assoc = 0;
+    interface_ip.nbanks = 1;
+    interface_ip.out_w = interface_ip.line_sz * 8;
+    interface_ip.specific_tag = 1;
+    interface_ip.tag_w = tag;
+    interface_ip.access_mode = 0;
+    interface_ip.throughput = 2 * 1.0 / clockRate;
+    interface_ip.latency = 2 * 1.0 / clockRate;
+    interface_ip.obj_func_dyn_energy = 0;
+    interface_ip.obj_func_dyn_power = 0;
+    interface_ip.obj_func_leak_power = 0;
+    interface_ip.obj_func_cycle_t = 1;
+    interface_ip.num_rw_ports = 0;
+    interface_ip.num_rd_ports = coredynp.peak_issueW;
+    interface_ip.num_wr_ports = coredynp.peak_issueW;
+    interface_ip.num_se_rd_ports = 0;
+    interface_ip.num_search_ports = coredynp.peak_issueW;
+    int_inst_window = new ArrayST(&interface_ip, tmp_name, Core_device,
+                                  coredynp.opt_local, coredynp.core_ty);
+    int_inst_window->area.set_area(int_inst_window->area.get_area() +
+                                   int_inst_window->local_result.area *
+                                       coredynp.num_pipelines);
+    area.set_area(area.get_area() +
+                  int_inst_window->local_result.area * coredynp.num_pipelines);
+    Iw_height = int_inst_window->local_result.cache_ht;
+    // FU inst window
+    if (coredynp.scheu_ty == PhysicalRegFile) {
+      tag = 2 * coredynp.phy_freg_width;  // TODO: each time only half of the
+                                          // tag is compared
+      data =
+          int(ceil((coredynp.instruction_length +
+                    2 * (coredynp.phy_freg_width - coredynp.arch_freg_width)) /
+                   8.0));
+      tmp_name = "FPIssueQueue";
+    } else {
+      tag = 2 * coredynp.phy_ireg_width;
+      data =
+          int(ceil((coredynp.instruction_length +
+                    2 * (coredynp.phy_freg_width - coredynp.arch_freg_width) +
+                    2 * coredynp.fp_data_width) /
+                   8.0));
+      tmp_name = "FPReservationStation";
+    }
+    interface_ip.is_cache = true;
+    interface_ip.pure_cam = false;
+    interface_ip.pure_ram = false;
+    interface_ip.line_sz = data;
+    interface_ip.cache_sz =
+        data * XML->sys.core[ithCore].fp_instruction_window_size;
+    interface_ip.assoc = 0;
+    interface_ip.nbanks = 1;
+    interface_ip.out_w = interface_ip.line_sz * 8;
+    interface_ip.specific_tag = 1;
+    interface_ip.tag_w = tag;
+    interface_ip.access_mode = 0;
+    interface_ip.throughput = 1.0 / clockRate;
+    interface_ip.latency = 1.0 / clockRate;
+    interface_ip.obj_func_dyn_energy = 0;
+    interface_ip.obj_func_dyn_power = 0;
+    interface_ip.obj_func_leak_power = 0;
+    interface_ip.obj_func_cycle_t = 1;
+    interface_ip.num_rw_ports = 0;
+    interface_ip.num_rd_ports = coredynp.fp_issueW;
+    interface_ip.num_wr_ports = coredynp.fp_issueW;
+    interface_ip.num_se_rd_ports = 0;
+    interface_ip.num_search_ports = coredynp.fp_issueW;
+    fp_inst_window = new ArrayST(&interface_ip, tmp_name, Core_device,
+                                 coredynp.opt_local, coredynp.core_ty);
+    fp_inst_window->area.set_area(fp_inst_window->area.get_area() +
+                                  fp_inst_window->local_result.area *
+                                      coredynp.num_fp_pipelines);
+    area.set_area(area.get_area() +
+                  fp_inst_window->local_result.area *
+                      coredynp.num_fp_pipelines);
+    fp_Iw_height = fp_inst_window->local_result.cache_ht;
+
+    if (XML->sys.core[ithCore].ROB_size > 0) {
+      /*
+       *  if ROB_size = 0, then the target processor does not support
+       *hardware-based
+       *  speculation, i.e. , the processor allow OOO issue as well as OOO
+       *completion, which
+       *  means branch must be resolved before instruction issued into
+       *instruction window, since
+       *  there is no change to flush miss-predict branch path after
+       *instructions are issued in this situation.
+       *
+       *  ROB.ROB size = inflight inst. ROB is unified for int and fp inst.
+       *  One old approach is to combine the RAT and ROB as a huge CAM structure
+       *as in AMD K7.
+       *  However, this approach is abandoned due to its high power and poor
+       *scalablility.
+       *	McPAT uses current implementation of ROB as circular buffer.
+       *	ROB is written once when instruction is issued and read once
+       *when the instruction is committed.         *
+       */
+      int robExtra = int(ceil(5 + log2(coredynp.num_hthreads)));
+      // 5 bits are: busy, Issued, Finished, speculative, valid
+      if (coredynp.scheu_ty == PhysicalRegFile) {
+        // PC is to id the instruction for recover exception.
+        // inst is used to map the renamed dest. registers.so that commit stage
+        // can know which reg/RRAT to update
+        //				data = int(ceil((robExtra+coredynp.pc_width
+        //+
+        //						coredynp.instruction_length +
+        //2*coredynp.phy_ireg_width)/8.0));
+        data = int(ceil(
+            (robExtra + coredynp.pc_width + coredynp.phy_ireg_width) / 8.0));
+      } else {
+        // in RS based OOO, ROB also contains value of destination reg
+        //				data  = int(ceil((robExtra+coredynp.pc_width
+        //+
+        //						coredynp.instruction_length +
+        //2*coredynp.phy_ireg_width + coredynp.fp_data_width)/8.0));
+        data = int(ceil((robExtra + coredynp.pc_width +
+                         coredynp.phy_ireg_width + coredynp.fp_data_width) /
+                        8.0));
+      }
+      interface_ip.is_cache = false;
+      interface_ip.pure_cam = false;
+      interface_ip.pure_ram = true;
+      interface_ip.line_sz = data;
+      interface_ip.cache_sz =
+          data *
+          XML->sys.core[ithCore]
+              .ROB_size;  // The XML ROB size is for all threads
+      interface_ip.assoc = 1;
+      interface_ip.nbanks = 1;
+      interface_ip.out_w = interface_ip.line_sz * 8;
+      interface_ip.access_mode = 1;
+      interface_ip.throughput = 1.0 / clockRate;
+      interface_ip.latency = 1.0 / clockRate;
+      interface_ip.obj_func_dyn_energy = 0;
+      interface_ip.obj_func_dyn_power = 0;
+      interface_ip.obj_func_leak_power = 0;
+      interface_ip.obj_func_cycle_t = 1;
+      interface_ip.num_rw_ports = 0;
+      interface_ip.num_rd_ports = coredynp.peak_commitW;
+      interface_ip.num_wr_ports = coredynp.peak_issueW;
+      interface_ip.num_se_rd_ports = 0;
+      interface_ip.num_search_ports = 0;
+      ROB = new ArrayST(&interface_ip, "ReorderBuffer", Core_device,
+                        coredynp.opt_local, coredynp.core_ty);
+      ROB->area.set_area(ROB->area.get_area() +
+                         ROB->local_result.area * coredynp.num_pipelines);
+      area.set_area(area.get_area() +
+                    ROB->local_result.area * coredynp.num_pipelines);
+      ROB_height = ROB->local_result.cache_ht;
+    }
+
+    instruction_selection = new selection_logic(
+        is_default, XML->sys.core[ithCore].instruction_window_size,
+        coredynp.peak_issueW, &interface_ip, Core_device, coredynp.core_ty);
+  }
 }
 
-LoadStoreU::LoadStoreU(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_,bool exist_)
-:XML(XML_interface),
- ithCore(ithCore_),
- interface_ip(*interface_ip_),
- coredynp(dyn_p_),
- LSQ(0),
- exist(exist_)
-{
-	  if (!exist) return;
-	  int  idx, tag, data, size, line, assoc;
-	  bool debug= false;
-	  int ldst_opcode = XML->sys.core[ithCore].opcode_width;//16;
+LoadStoreU::LoadStoreU(ParseXML* XML_interface, int ithCore_,
+                       InputParameter* interface_ip_,
+                       const CoreDynParam& dyn_p_, bool exist_)
+    : XML(XML_interface),
+      ithCore(ithCore_),
+      interface_ip(*interface_ip_),
+      coredynp(dyn_p_),
+      LSQ(0),
+      exist(exist_) {
+  if (!exist) return;
+  int idx, tag, data, size, line, assoc;
+  bool debug = false;
+  int ldst_opcode = XML->sys.core[ithCore].opcode_width;  // 16;
 
-	  clockRate = coredynp.clockRate;
-	  executionTime = coredynp.executionTime;
-	  cache_p = (Cache_policy)XML->sys.core[ithCore].dcache.dcache_config[7];
+  clockRate = coredynp.clockRate;
+  executionTime = coredynp.executionTime;
+  cache_p = (Cache_policy)XML->sys.core[ithCore].dcache.dcache_config[7];
 
-	  interface_ip.num_search_ports    = XML->sys.core[ithCore].memory_ports;
-	  interface_ip.is_cache			   = true;
-	  interface_ip.pure_cam            = false;
-	  interface_ip.pure_ram            = false;
-	 
+  interface_ip.num_search_ports = XML->sys.core[ithCore].memory_ports;
+  interface_ip.is_cache = true;
+  interface_ip.pure_cam = false;
+  interface_ip.pure_ram = false;
 
-	  //Crossbar based interconnect for shared memory accesses, added by Syed
-	  //Crossbar
+  // Crossbar based interconnect for shared memory accesses, added by Syed
+  // Crossbar
 
-	  if(XML->sys.architecture==1){
-    xbar_shared     = new Crossbar(coredynp.num_fpus,coredynp.num_fpus,32,&(g_tp.peri_global));//Syed: coredynp.num_fpus is used as simd_width  
-	  }
-	  else{
-	  xbar_shared     = new Crossbar(coredynp.num_fpus,coredynp.num_fpus,32,&(g_tp.peri_global));//Syed: coredynp.num_fpus is used as simd_width
-	  }
+  if (XML->sys.architecture == 1) {
+    xbar_shared = new Crossbar(
+        coredynp.num_fpus, coredynp.num_fpus, 32,
+        &(g_tp.peri_global));  // Syed: coredynp.num_fpus is used as simd_width
+  } else {
+    xbar_shared = new Crossbar(
+        coredynp.num_fpus, coredynp.num_fpus, 32,
+        &(g_tp.peri_global));  // Syed: coredynp.num_fpus is used as simd_width
+  }
 
+  // TODO: Check if this line should be changed to
+  // new
+  // Crossbar(simd_width,shared_memory_banks,word_length*simd_width,&(g_tp.peri_global));
 
-     //TODO: Check if this line should be changed to
-     //new Crossbar(simd_width,shared_memory_banks,word_length*simd_width,&(g_tp.peri_global));
+  // shared memory added by Jingwen
+  size = (int)XML->sys.core[ithCore].sharedmemory.dcache_config[0];
+  line = (int)XML->sys.core[ithCore].sharedmemory.dcache_config[1];
+  assoc = (int)XML->sys.core[ithCore].sharedmemory.dcache_config[2];
+  idx = debug ? 9 : int(ceil(log2(size / line / assoc)));
+  tag = debug ? 51 : XML->sys.physical_address_width - idx -
+                         int(ceil(log2(line))) + EXTRA_TAG_BITS;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = 1;
+  interface_ip.cache_sz =
+      debug ? 32768 : (int)XML->sys.core[ithCore].sharedmemory.dcache_config[0];
+  interface_ip.line_sz =
+      debug ? 64 : (int)XML->sys.core[ithCore].sharedmemory.dcache_config[1];
+  interface_ip.assoc =
+      debug ? 8 : (int)XML->sys.core[ithCore].sharedmemory.dcache_config[2];
+  interface_ip.nbanks =
+      debug ? 1 : (int)XML->sys.core[ithCore].sharedmemory.dcache_config[3];
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode =
+      0;  // debug?0:XML->sys.core[ithCore].sharedmemory.dcache_config[5];
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].sharedmemory.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 3.0 / clockRate
+            : XML->sys.core[ithCore].sharedmemory.dcache_config[5] / clockRate;
+  interface_ip.is_cache = true;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports =
+      debug ? 1 : XML->sys.core[ithCore].memory_ports;  // usually In-order has
+                                                        // 1 and OOO has 2 at
+                                                        // least.
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  sharedmemory.caches = new ArrayST(&interface_ip, "sharedmemory", Core_device,
+                                    coredynp.opt_local, coredynp.core_ty);
+  sharedmemory.area.set_area(sharedmemory.area.get_area() +
+                             sharedmemory.caches->local_result.area);
+  area.set_area(area.get_area() + sharedmemory.caches->local_result.area +
+                xbar_shared->area.get_area());
 
-    //shared memory added by Jingwen
-	  size                             = (int)XML->sys.core[ithCore].sharedmemory.dcache_config[0];
-	  line                             = (int)XML->sys.core[ithCore].sharedmemory.dcache_config[1];
-	  assoc                            = (int)XML->sys.core[ithCore].sharedmemory.dcache_config[2];
-	  idx    					 	   = debug?9:int(ceil(log2(size/line/assoc)));
-	  tag							   = debug?51:XML->sys.physical_address_width-idx-int(ceil(log2(line))) + EXTRA_TAG_BITS;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = 1;
-	  interface_ip.cache_sz            = debug?32768:(int)XML->sys.core[ithCore].sharedmemory.dcache_config[0];
-	  interface_ip.line_sz             = debug?64:(int)XML->sys.core[ithCore].sharedmemory.dcache_config[1];
-	  interface_ip.assoc               = debug?8:(int)XML->sys.core[ithCore].sharedmemory.dcache_config[2];
-	  interface_ip.nbanks              = debug?1:(int)XML->sys.core[ithCore].sharedmemory.dcache_config[3];
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 0;//debug?0:XML->sys.core[ithCore].sharedmemory.dcache_config[5];
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?3.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[5]/clockRate;
-	  interface_ip.is_cache			 = true;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;//usually In-order has 1 and OOO has 2 at least.
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  sharedmemory.caches = new ArrayST(&interface_ip, "sharedmemory", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  sharedmemory.area.set_area(sharedmemory.area.get_area()+ sharedmemory.caches->local_result.area);
-	  area.set_area(area.get_area()+ sharedmemory.caches->local_result.area + xbar_shared->area.get_area());
+  // shared memory buffer
+  // miss buffer
+  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data = (XML->sys.physical_address_width) + int(ceil(log2(size / line))) +
+         sharedmemory.caches->l_ip.line_sz * 8;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = 1;
+  interface_ip.line_sz =
+      int(ceil(data / 8.0));  // int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+  interface_ip.cache_sz = XML->sys.core[ithCore].sharedmemory.buffer_sizes[0] *
+                          interface_ip.line_sz;
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].sharedmemory.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].sharedmemory.dcache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
+  ;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  sharedmemory.missb =
+      new ArrayST(&interface_ip, "SharedmemoryMissBuffer", Core_device,
+                  coredynp.opt_local, coredynp.core_ty);
+  sharedmemory.area.set_area(sharedmemory.area.get_area() +
+                             sharedmemory.missb->local_result.area);
+  area.set_area(area.get_area() + sharedmemory.missb->local_result.area);
 
+  // sharedmemory fill buffer
+  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data = sharedmemory.caches->l_ip.line_sz;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = 1;
+  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
+  interface_ip.cache_sz =
+      data * XML->sys.core[ithCore].sharedmemory.buffer_sizes[1];
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].sharedmemory.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].sharedmemory.dcache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
+  ;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  sharedmemory.ifb =
+      new ArrayST(&interface_ip, "SharedMemoryFillBuffer", Core_device,
+                  coredynp.opt_local, coredynp.core_ty);
+  sharedmemory.area.set_area(sharedmemory.area.get_area() +
+                             sharedmemory.ifb->local_result.area);
+  area.set_area(area.get_area() + sharedmemory.ifb->local_result.area);
 
-    //shared memory buffer
-	  //miss buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  data							   = (XML->sys.physical_address_width) + int(ceil(log2(size/line))) + sharedmemory.caches->l_ip.line_sz*8;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = 1;
-	  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-	  interface_ip.cache_sz            = XML->sys.core[ithCore].sharedmemory.buffer_sizes[0]*interface_ip.line_sz;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 2;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  sharedmemory.missb = new ArrayST(&interface_ip, "SharedmemoryMissBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  sharedmemory.area.set_area(sharedmemory.area.get_area()+ sharedmemory.missb->local_result.area);
-	  area.set_area(area.get_area()+ sharedmemory.missb->local_result.area);
+  // sharedmemory prefetch buffer
+  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;  // check with
+                                                           // previous entries
+                                                           // to decide wthether
+                                                           // to merge.
+  data = sharedmemory.caches->l_ip
+             .line_sz;  // separate queue to prevent from cache polution.
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = 1;
+  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
+  interface_ip.cache_sz = XML->sys.core[ithCore].sharedmemory.buffer_sizes[2] *
+                          interface_ip.line_sz;
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].sharedmemory.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].sharedmemory.dcache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
+  ;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  sharedmemory.prefetchb =
+      new ArrayST(&interface_ip, "dcacheprefetchBuffer", Core_device,
+                  coredynp.opt_local, coredynp.core_ty);
+  sharedmemory.area.set_area(sharedmemory.area.get_area() +
+                             sharedmemory.prefetchb->local_result.area);
+  area.set_area(area.get_area() + sharedmemory.prefetchb->local_result.area);
 
+  // shared memory WBB
+  if (cache_p == Write_back) {
+    tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+    data = sharedmemory.caches->l_ip.line_sz;
+    interface_ip.specific_tag = 1;
+    interface_ip.tag_w = 1;
+    interface_ip.line_sz = data;
+    interface_ip.cache_sz =
+        XML->sys.core[ithCore].sharedmemory.buffer_sizes[3] *
+        interface_ip.line_sz;
+    interface_ip.assoc = 0;
+    interface_ip.nbanks = 1;
+    interface_ip.out_w = interface_ip.line_sz * 8;
+    interface_ip.access_mode = 2;
+    interface_ip.throughput =
+        debug
+            ? 1.0 / clockRate
+            : XML->sys.core[ithCore].sharedmemory.dcache_config[4] / clockRate;
+    interface_ip.latency =
+        debug
+            ? 1.0 / clockRate
+            : XML->sys.core[ithCore].sharedmemory.dcache_config[5] / clockRate;
+    interface_ip.obj_func_dyn_energy = 0;
+    interface_ip.obj_func_dyn_power = 0;
+    interface_ip.obj_func_leak_power = 0;
+    interface_ip.obj_func_cycle_t = 1;
+    interface_ip.num_rw_ports = XML->sys.core[ithCore].memory_ports;
+    interface_ip.num_rd_ports = 0;
+    interface_ip.num_wr_ports = 0;
+    interface_ip.num_se_rd_ports = 0;
+    sharedmemory.wbb = new ArrayST(&interface_ip, "dcacheWBB", Core_device,
+                                   coredynp.opt_local, coredynp.core_ty);
+    sharedmemory.area.set_area(sharedmemory.area.get_area() +
+                               sharedmemory.wbb->local_result.area);
+    area.set_area(area.get_area() + sharedmemory.wbb->local_result.area);
+    // output_data_csv(sharedmemory.wbb.local_result);
+  }
 
-    //sharedmemory fill buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  data							   = sharedmemory.caches->l_ip.line_sz;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = 1;
-	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-	  interface_ip.cache_sz            = data*XML->sys.core[ithCore].sharedmemory.buffer_sizes[1];
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 2;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  sharedmemory.ifb = new ArrayST(&interface_ip, "SharedMemoryFillBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  sharedmemory.area.set_area(sharedmemory.area.get_area()+ sharedmemory.ifb->local_result.area);
-	  area.set_area(area.get_area()+ sharedmemory.ifb->local_result.area);
+  /*
+   * ccache starts here
+   */
+  // Constant cache
+  size = (int)XML->sys.core[ithCore].ccache.dcache_config[0];
+  line = (int)XML->sys.core[ithCore].ccache.dcache_config[1];
+  assoc = (int)XML->sys.core[ithCore].ccache.dcache_config[2];
+  idx = debug ? 9 : int(ceil(log2(size / line / assoc)));
+  tag = debug ? 51 : XML->sys.physical_address_width - idx -
+                         int(ceil(log2(line))) + EXTRA_TAG_BITS;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.cache_sz =
+      debug ? 32768 : (int)XML->sys.core[ithCore].ccache.dcache_config[0];
+  interface_ip.line_sz =
+      debug ? 64 : (int)XML->sys.core[ithCore].ccache.dcache_config[1];
+  interface_ip.assoc =
+      debug ? 8 : (int)XML->sys.core[ithCore].ccache.dcache_config[2];
+  interface_ip.nbanks =
+      debug ? 1 : (int)XML->sys.core[ithCore].ccache.dcache_config[3];
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode =
+      0;  // debug?0:XML->sys.core[ithCore].ccache.dcache_config[5];
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].ccache.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 3.0 / clockRate
+            : XML->sys.core[ithCore].ccache.dcache_config[5] / clockRate;
+  interface_ip.is_cache = true;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports =
+      debug ? 1 : XML->sys.core[ithCore].memory_ports;  // usually In-order has
+                                                        // 1 and OOO has 2 at
+                                                        // least.
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  ccache.caches = new ArrayST(&interface_ip, "ccache", Core_device,
+                              coredynp.opt_local, coredynp.core_ty);
+  ccache.area.set_area(ccache.area.get_area() +
+                       ccache.caches->local_result.area);
+  area.set_area(area.get_area() + ccache.caches->local_result.area);
+  // output_data_csv(ccache.caches.local_result);
 
-    //sharedmemory prefetch buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries to decide wthether to merge.
-	  data							   = sharedmemory.caches->l_ip.line_sz;//separate queue to prevent from cache polution.
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = 1;
-	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-	  interface_ip.cache_sz            = XML->sys.core[ithCore].sharedmemory.buffer_sizes[2]*interface_ip.line_sz;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 2;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  sharedmemory.prefetchb = new ArrayST(&interface_ip, "dcacheprefetchBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  sharedmemory.area.set_area(sharedmemory.area.get_area()+ sharedmemory.prefetchb->local_result.area);
-	  area.set_area(area.get_area()+ sharedmemory.prefetchb->local_result.area);
+  // cCache controllers
+  // miss buffer
+  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data = (XML->sys.physical_address_width) + int(ceil(log2(size / line))) +
+         ccache.caches->l_ip.line_sz * 8;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.line_sz =
+      int(ceil(data / 8.0));  // int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+  interface_ip.cache_sz =
+      XML->sys.core[ithCore].ccache.buffer_sizes[0] * interface_ip.line_sz;
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].ccache.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].ccache.dcache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
+  ;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  ccache.missb = new ArrayST(&interface_ip, "ccacheMissBuffer", Core_device,
+                             coredynp.opt_local, coredynp.core_ty);
+  ccache.area.set_area(ccache.area.get_area() +
+                       ccache.missb->local_result.area);
+  area.set_area(area.get_area() + ccache.missb->local_result.area);
+  // output_data_csv(ccache.missb.local_result);
 
-    //shared memory WBB
-	  if (cache_p==Write_back)
-	  {
-		  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-		  data							   = sharedmemory.caches->l_ip.line_sz;
-		  interface_ip.specific_tag        = 1;
-		  interface_ip.tag_w               = 1;
-		  interface_ip.line_sz             = data;
-		  interface_ip.cache_sz            = XML->sys.core[ithCore].sharedmemory.buffer_sizes[3]*interface_ip.line_sz;
-		  interface_ip.assoc               = 0;
-		  interface_ip.nbanks              = 1;
-		  interface_ip.out_w               = interface_ip.line_sz*8;
-		  interface_ip.access_mode         = 2;
-		  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[4]/clockRate;
-		  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].sharedmemory.dcache_config[5]/clockRate;
-		  interface_ip.obj_func_dyn_energy = 0;
-		  interface_ip.obj_func_dyn_power  = 0;
-		  interface_ip.obj_func_leak_power = 0;
-		  interface_ip.obj_func_cycle_t    = 1;
-		  interface_ip.num_rw_ports    = XML->sys.core[ithCore].memory_ports;
-		  interface_ip.num_rd_ports    = 0;
-		  interface_ip.num_wr_ports    = 0;
-		  interface_ip.num_se_rd_ports = 0;
-		  sharedmemory.wbb = new ArrayST(&interface_ip, "dcacheWBB", Core_device, coredynp.opt_local, coredynp.core_ty);
-		  sharedmemory.area.set_area(sharedmemory.area.get_area()+ sharedmemory.wbb->local_result.area);
-		  area.set_area(area.get_area()+ sharedmemory.wbb->local_result.area);
-		  //output_data_csv(sharedmemory.wbb.local_result);
-	  }
+  // fill buffer
+  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data = ccache.caches->l_ip.line_sz;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
+  interface_ip.cache_sz = data * XML->sys.core[ithCore].ccache.buffer_sizes[1];
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].ccache.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].ccache.dcache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
+  ;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  ccache.ifb = new ArrayST(&interface_ip, "ccacheFillBuffer", Core_device,
+                           coredynp.opt_local, coredynp.core_ty);
+  ccache.area.set_area(ccache.area.get_area() + ccache.ifb->local_result.area);
+  area.set_area(area.get_area() + ccache.ifb->local_result.area);
+  // output_data_csv(ccache.ifb.local_result);
 
+  // prefetch buffer
+  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;  // check with
+                                                           // previous entries
+                                                           // to decide wthether
+                                                           // to merge.
+  data = ccache.caches->l_ip
+             .line_sz;  // separate queue to prevent from cache polution.
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
+  interface_ip.cache_sz =
+      XML->sys.core[ithCore].ccache.buffer_sizes[2] * interface_ip.line_sz;
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].ccache.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].ccache.dcache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
+  ;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  ccache.prefetchb =
+      new ArrayST(&interface_ip, "ccacheprefetchBuffer", Core_device,
+                  coredynp.opt_local, coredynp.core_ty);
+  ccache.area.set_area(ccache.area.get_area() +
+                       ccache.prefetchb->local_result.area);
+  area.set_area(area.get_area() + ccache.prefetchb->local_result.area);
+  // output_data_csv(ccache.prefetchb.local_result);
 
-   /*
-    * ccache starts here
-    */   
-    //Constant cache
-	  size                             = (int)XML->sys.core[ithCore].ccache.dcache_config[0];
-	  line                             = (int)XML->sys.core[ithCore].ccache.dcache_config[1];
-	  assoc                            = (int)XML->sys.core[ithCore].ccache.dcache_config[2];
-	  idx    					 	   = debug?9:int(ceil(log2(size/line/assoc)));
-	  tag							   = debug?51:XML->sys.physical_address_width-idx-int(ceil(log2(line))) + EXTRA_TAG_BITS;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.cache_sz            = debug?32768:(int)XML->sys.core[ithCore].ccache.dcache_config[0];
-	  interface_ip.line_sz             = debug?64:(int)XML->sys.core[ithCore].ccache.dcache_config[1];
-	  interface_ip.assoc               = debug?8:(int)XML->sys.core[ithCore].ccache.dcache_config[2];
-	  interface_ip.nbanks              = debug?1:(int)XML->sys.core[ithCore].ccache.dcache_config[3];
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 0;//debug?0:XML->sys.core[ithCore].ccache.dcache_config[5];
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?3.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[5]/clockRate;
-	  interface_ip.is_cache			 = true;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;//usually In-order has 1 and OOO has 2 at least.
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  ccache.caches = new ArrayST(&interface_ip, "ccache", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  ccache.area.set_area(ccache.area.get_area()+ ccache.caches->local_result.area);
-	  area.set_area(area.get_area()+ ccache.caches->local_result.area);
-	  //output_data_csv(ccache.caches.local_result);
+  // WBB
+  if (cache_p == Write_back) {
+    tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+    data = ccache.caches->l_ip.line_sz;
+    interface_ip.specific_tag = 1;
+    interface_ip.tag_w = tag;
+    interface_ip.line_sz = data;
+    interface_ip.cache_sz =
+        XML->sys.core[ithCore].ccache.buffer_sizes[3] * interface_ip.line_sz;
+    interface_ip.assoc = 0;
+    interface_ip.nbanks = 1;
+    interface_ip.out_w = interface_ip.line_sz * 8;
+    interface_ip.access_mode = 2;
+    interface_ip.throughput =
+        debug ? 1.0 / clockRate
+              : XML->sys.core[ithCore].ccache.dcache_config[4] / clockRate;
+    interface_ip.latency =
+        debug ? 1.0 / clockRate
+              : XML->sys.core[ithCore].ccache.dcache_config[5] / clockRate;
+    interface_ip.obj_func_dyn_energy = 0;
+    interface_ip.obj_func_dyn_power = 0;
+    interface_ip.obj_func_leak_power = 0;
+    interface_ip.obj_func_cycle_t = 1;
+    interface_ip.num_rw_ports = XML->sys.core[ithCore].memory_ports;
+    interface_ip.num_rd_ports = 0;
+    interface_ip.num_wr_ports = 0;
+    interface_ip.num_se_rd_ports = 0;
+    ccache.wbb = new ArrayST(&interface_ip, "ccacheWBB", Core_device,
+                             coredynp.opt_local, coredynp.core_ty);
+    ccache.area.set_area(ccache.area.get_area() +
+                         ccache.wbb->local_result.area);
+    area.set_area(area.get_area() + ccache.wbb->local_result.area);
+    // output_data_csv(ccache.wbb.local_result);
+  }
 
+  /*
+   * tcache starts here
+   */
+  // Texture cache
+  size = (int)XML->sys.core[ithCore].tcache.dcache_config[0];
+  line = (int)XML->sys.core[ithCore].tcache.dcache_config[1];
+  assoc = (int)XML->sys.core[ithCore].tcache.dcache_config[2];
+  idx = debug ? 9 : int(ceil(log2(size / line / assoc)));
+  tag = debug ? 51 : XML->sys.physical_address_width - idx -
+                         int(ceil(log2(line))) + EXTRA_TAG_BITS;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.cache_sz =
+      debug ? 32768 : (int)XML->sys.core[ithCore].tcache.dcache_config[0];
+  interface_ip.line_sz =
+      debug ? 64 : (int)XML->sys.core[ithCore].tcache.dcache_config[1];
+  interface_ip.assoc =
+      debug ? 8 : (int)XML->sys.core[ithCore].tcache.dcache_config[2];
+  interface_ip.nbanks =
+      debug ? 1 : (int)XML->sys.core[ithCore].tcache.dcache_config[3];
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode =
+      0;  // debug?0:XML->sys.core[ithCore].tcache.dcache_config[5];
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].tcache.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 3.0 / clockRate
+            : XML->sys.core[ithCore].tcache.dcache_config[5] / clockRate;
+  interface_ip.is_cache = true;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports =
+      debug ? 1 : XML->sys.core[ithCore].memory_ports;  // usually In-order has
+                                                        // 1 and OOO has 2 at
+                                                        // least.
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  tcache.caches = new ArrayST(&interface_ip, "tcache", Core_device,
+                              coredynp.opt_local, coredynp.core_ty);
+  tcache.area.set_area(tcache.area.get_area() +
+                       tcache.caches->local_result.area);
+  area.set_area(area.get_area() + tcache.caches->local_result.area);
+  // output_data_csv(tcache.caches.local_result);
 
+  // tCache controllers
+  // miss buffer
+  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data = (XML->sys.physical_address_width) + int(ceil(log2(size / line))) +
+         tcache.caches->l_ip.line_sz * 8;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.line_sz =
+      int(ceil(data / 8.0));  // int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+  interface_ip.cache_sz =
+      XML->sys.core[ithCore].tcache.buffer_sizes[0] * interface_ip.line_sz;
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].tcache.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].tcache.dcache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
+  ;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  tcache.missb = new ArrayST(&interface_ip, "tcacheMissBuffer", Core_device,
+                             coredynp.opt_local, coredynp.core_ty);
+  tcache.area.set_area(tcache.area.get_area() +
+                       tcache.missb->local_result.area);
+  area.set_area(area.get_area() + tcache.missb->local_result.area);
+  // output_data_csv(tcache.missb.local_result);
 
-      //cCache controllers
-	  //miss buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  data							   = (XML->sys.physical_address_width) + int(ceil(log2(size/line))) + ccache.caches->l_ip.line_sz*8;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-	  interface_ip.cache_sz            = XML->sys.core[ithCore].ccache.buffer_sizes[0]*interface_ip.line_sz;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 2;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  ccache.missb = new ArrayST(&interface_ip, "ccacheMissBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  ccache.area.set_area(ccache.area.get_area()+ ccache.missb->local_result.area);
-	  area.set_area(area.get_area()+ ccache.missb->local_result.area);
-	  //output_data_csv(ccache.missb.local_result);
+  // fill buffer
+  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data = tcache.caches->l_ip.line_sz;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
+  interface_ip.cache_sz = data * XML->sys.core[ithCore].tcache.buffer_sizes[1];
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].tcache.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].tcache.dcache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
+  ;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  tcache.ifb = new ArrayST(&interface_ip, "tcacheFillBuffer", Core_device,
+                           coredynp.opt_local, coredynp.core_ty);
+  tcache.area.set_area(tcache.area.get_area() + tcache.ifb->local_result.area);
+  area.set_area(area.get_area() + tcache.ifb->local_result.area);
+  // output_data_csv(tcache.ifb.local_result);
 
-	  //fill buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  data							   = ccache.caches->l_ip.line_sz;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-	  interface_ip.cache_sz            = data*XML->sys.core[ithCore].ccache.buffer_sizes[1];
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 2;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  ccache.ifb = new ArrayST(&interface_ip, "ccacheFillBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  ccache.area.set_area(ccache.area.get_area()+ ccache.ifb->local_result.area);
-	  area.set_area(area.get_area()+ ccache.ifb->local_result.area);
-	  //output_data_csv(ccache.ifb.local_result);
+  // prefetch buffer
+  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;  // check with
+                                                           // previous entries
+                                                           // to decide wthether
+                                                           // to merge.
+  data = tcache.caches->l_ip
+             .line_sz;  // separate queue to prevent from cache polution.
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
+  interface_ip.cache_sz =
+      XML->sys.core[ithCore].tcache.buffer_sizes[2] * interface_ip.line_sz;
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].tcache.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].tcache.dcache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
+  ;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  tcache.prefetchb =
+      new ArrayST(&interface_ip, "tcacheprefetchBuffer", Core_device,
+                  coredynp.opt_local, coredynp.core_ty);
+  tcache.area.set_area(tcache.area.get_area() +
+                       tcache.prefetchb->local_result.area);
+  area.set_area(area.get_area() + tcache.prefetchb->local_result.area);
+  // output_data_csv(tcache.prefetchb.local_result);
 
-	  //prefetch buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries to decide wthether to merge.
-	  data							   = ccache.caches->l_ip.line_sz;//separate queue to prevent from cache polution.
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-	  interface_ip.cache_sz            = XML->sys.core[ithCore].ccache.buffer_sizes[2]*interface_ip.line_sz;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 2;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  ccache.prefetchb = new ArrayST(&interface_ip, "ccacheprefetchBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  ccache.area.set_area(ccache.area.get_area()+ ccache.prefetchb->local_result.area);
-	  area.set_area(area.get_area()+ ccache.prefetchb->local_result.area);
-	  //output_data_csv(ccache.prefetchb.local_result);
+  // WBB
+  if (cache_p == Write_back) {
+    tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+    data = tcache.caches->l_ip.line_sz;
+    interface_ip.specific_tag = 1;
+    interface_ip.tag_w = tag;
+    interface_ip.line_sz = data;
+    interface_ip.cache_sz =
+        XML->sys.core[ithCore].tcache.buffer_sizes[3] * interface_ip.line_sz;
+    interface_ip.assoc = 0;
+    interface_ip.nbanks = 1;
+    interface_ip.out_w = interface_ip.line_sz * 8;
+    interface_ip.access_mode = 2;
+    interface_ip.throughput =
+        debug ? 1.0 / clockRate
+              : XML->sys.core[ithCore].tcache.dcache_config[4] / clockRate;
+    interface_ip.latency =
+        debug ? 1.0 / clockRate
+              : XML->sys.core[ithCore].tcache.dcache_config[5] / clockRate;
+    interface_ip.obj_func_dyn_energy = 0;
+    interface_ip.obj_func_dyn_power = 0;
+    interface_ip.obj_func_leak_power = 0;
+    interface_ip.obj_func_cycle_t = 1;
+    interface_ip.num_rw_ports = XML->sys.core[ithCore].memory_ports;
+    interface_ip.num_rd_ports = 0;
+    interface_ip.num_wr_ports = 0;
+    interface_ip.num_se_rd_ports = 0;
+    tcache.wbb = new ArrayST(&interface_ip, "tcacheWBB", Core_device,
+                             coredynp.opt_local, coredynp.core_ty);
+    tcache.area.set_area(tcache.area.get_area() +
+                         tcache.wbb->local_result.area);
+    area.set_area(area.get_area() + tcache.wbb->local_result.area);
+    // output_data_csv(tcache.wbb.local_result);
+  }
 
-	  //WBB
-	  if (cache_p==Write_back)
-	  {
-		  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-		  data							   = ccache.caches->l_ip.line_sz;
-		  interface_ip.specific_tag        = 1;
-		  interface_ip.tag_w               = tag;
-		  interface_ip.line_sz             = data;
-		  interface_ip.cache_sz            = XML->sys.core[ithCore].ccache.buffer_sizes[3]*interface_ip.line_sz;
-		  interface_ip.assoc               = 0;
-		  interface_ip.nbanks              = 1;
-		  interface_ip.out_w               = interface_ip.line_sz*8;
-		  interface_ip.access_mode         = 2;
-		  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[4]/clockRate;
-		  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].ccache.dcache_config[5]/clockRate;
-		  interface_ip.obj_func_dyn_energy = 0;
-		  interface_ip.obj_func_dyn_power  = 0;
-		  interface_ip.obj_func_leak_power = 0;
-		  interface_ip.obj_func_cycle_t    = 1;
-		  interface_ip.num_rw_ports    = XML->sys.core[ithCore].memory_ports;
-		  interface_ip.num_rd_ports    = 0;
-		  interface_ip.num_wr_ports    = 0;
-		  interface_ip.num_se_rd_ports = 0;
-		  ccache.wbb = new ArrayST(&interface_ip, "ccacheWBB", Core_device, coredynp.opt_local, coredynp.core_ty);
-		  ccache.area.set_area(ccache.area.get_area()+ ccache.wbb->local_result.area);
-		  area.set_area(area.get_area()+ ccache.wbb->local_result.area);
-		  //output_data_csv(ccache.wbb.local_result);
-	  }
+  /*
+   * dcache starts here
+   */
+  // Dcache
+  size = (int)XML->sys.core[ithCore].dcache.dcache_config[0];
+  line = (int)XML->sys.core[ithCore].dcache.dcache_config[1];
+  assoc = (int)XML->sys.core[ithCore].dcache.dcache_config[2];
+  idx = debug ? 9 : int(ceil(log2(size / line / assoc)));
+  tag = debug ? 51 : XML->sys.physical_address_width - idx -
+                         int(ceil(log2(line))) + EXTRA_TAG_BITS;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.cache_sz =
+      debug ? 32768 : (int)XML->sys.core[ithCore].dcache.dcache_config[0];
+  interface_ip.line_sz =
+      debug ? 64 : (int)XML->sys.core[ithCore].dcache.dcache_config[1];
+  interface_ip.assoc =
+      debug ? 8 : (int)XML->sys.core[ithCore].dcache.dcache_config[2];
+  interface_ip.nbanks =
+      debug ? 1 : (int)XML->sys.core[ithCore].dcache.dcache_config[3];
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode =
+      0;  // debug?0:XML->sys.core[ithCore].dcache.dcache_config[5];
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].dcache.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 3.0 / clockRate
+            : XML->sys.core[ithCore].dcache.dcache_config[5] / clockRate;
+  interface_ip.is_cache = true;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports =
+      debug ? 1 : XML->sys.core[ithCore].memory_ports;  // usually In-order has
+                                                        // 1 and OOO has 2 at
+                                                        // least.
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  dcache.caches = new ArrayST(&interface_ip, "dcache", Core_device,
+                              coredynp.opt_local, coredynp.core_ty);
+  dcache.area.set_area(dcache.area.get_area() +
+                       dcache.caches->local_result.area);
+  area.set_area(area.get_area() + dcache.caches->local_result.area);
+  // output_data_csv(dcache.caches.local_result);
 
-   /*
-    * tcache starts here
-    */   
-    //Texture cache
-	  size                             = (int)XML->sys.core[ithCore].tcache.dcache_config[0];
-	  line                             = (int)XML->sys.core[ithCore].tcache.dcache_config[1];
-	  assoc                            = (int)XML->sys.core[ithCore].tcache.dcache_config[2];
-	  idx    					 	   = debug?9:int(ceil(log2(size/line/assoc)));
-	  tag							   = debug?51:XML->sys.physical_address_width-idx-int(ceil(log2(line))) + EXTRA_TAG_BITS;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.cache_sz            = debug?32768:(int)XML->sys.core[ithCore].tcache.dcache_config[0];
-	  interface_ip.line_sz             = debug?64:(int)XML->sys.core[ithCore].tcache.dcache_config[1];
-	  interface_ip.assoc               = debug?8:(int)XML->sys.core[ithCore].tcache.dcache_config[2];
-	  interface_ip.nbanks              = debug?1:(int)XML->sys.core[ithCore].tcache.dcache_config[3];
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 0;//debug?0:XML->sys.core[ithCore].tcache.dcache_config[5];
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?3.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[5]/clockRate;
-	  interface_ip.is_cache			 = true;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;//usually In-order has 1 and OOO has 2 at least.
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  tcache.caches = new ArrayST(&interface_ip, "tcache", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  tcache.area.set_area(tcache.area.get_area()+ tcache.caches->local_result.area);
-	  area.set_area(area.get_area()+ tcache.caches->local_result.area);
-	  //output_data_csv(tcache.caches.local_result);
+  // dCache controllers
+  // miss buffer
+  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data = (XML->sys.physical_address_width) + int(ceil(log2(size / line))) +
+         dcache.caches->l_ip.line_sz * 8;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.line_sz =
+      int(ceil(data / 8.0));  // int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+  interface_ip.cache_sz =
+      XML->sys.core[ithCore].dcache.buffer_sizes[0] * interface_ip.line_sz;
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].dcache.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].dcache.dcache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
+  ;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  dcache.missb = new ArrayST(&interface_ip, "dcacheMissBuffer", Core_device,
+                             coredynp.opt_local, coredynp.core_ty);
+  dcache.area.set_area(dcache.area.get_area() +
+                       dcache.missb->local_result.area);
+  area.set_area(area.get_area() + dcache.missb->local_result.area);
+  // output_data_csv(dcache.missb.local_result);
 
+  // fill buffer
+  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data = dcache.caches->l_ip.line_sz;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
+  interface_ip.cache_sz = data * XML->sys.core[ithCore].dcache.buffer_sizes[1];
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].dcache.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].dcache.dcache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
+  ;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  dcache.ifb = new ArrayST(&interface_ip, "dcacheFillBuffer", Core_device,
+                           coredynp.opt_local, coredynp.core_ty);
+  dcache.area.set_area(dcache.area.get_area() + dcache.ifb->local_result.area);
+  area.set_area(area.get_area() + dcache.ifb->local_result.area);
+  // output_data_csv(dcache.ifb.local_result);
 
-	  //tCache controllers
-	  //miss buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  data							   = (XML->sys.physical_address_width) + int(ceil(log2(size/line))) + tcache.caches->l_ip.line_sz*8;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-	  interface_ip.cache_sz            = XML->sys.core[ithCore].tcache.buffer_sizes[0]*interface_ip.line_sz;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 2;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  tcache.missb = new ArrayST(&interface_ip, "tcacheMissBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  tcache.area.set_area(tcache.area.get_area()+ tcache.missb->local_result.area);
-	  area.set_area(area.get_area()+ tcache.missb->local_result.area);
-	  //output_data_csv(tcache.missb.local_result);
+  // prefetch buffer
+  tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;  // check with
+                                                           // previous entries
+                                                           // to decide wthether
+                                                           // to merge.
+  data = dcache.caches->l_ip
+             .line_sz;  // separate queue to prevent from cache polution.
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
+  interface_ip.cache_sz =
+      XML->sys.core[ithCore].dcache.buffer_sizes[2] * interface_ip.line_sz;
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 2;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].dcache.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].dcache.dcache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = debug ? 1 : XML->sys.core[ithCore].memory_ports;
+  ;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  dcache.prefetchb =
+      new ArrayST(&interface_ip, "dcacheprefetchBuffer", Core_device,
+                  coredynp.opt_local, coredynp.core_ty);
+  dcache.area.set_area(dcache.area.get_area() +
+                       dcache.prefetchb->local_result.area);
+  area.set_area(area.get_area() + dcache.prefetchb->local_result.area);
+  // output_data_csv(dcache.prefetchb.local_result);
 
-	  //fill buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  data							   = tcache.caches->l_ip.line_sz;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-	  interface_ip.cache_sz            = data*XML->sys.core[ithCore].tcache.buffer_sizes[1];
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 2;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  tcache.ifb = new ArrayST(&interface_ip, "tcacheFillBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  tcache.area.set_area(tcache.area.get_area()+ tcache.ifb->local_result.area);
-	  area.set_area(area.get_area()+ tcache.ifb->local_result.area);
-	  //output_data_csv(tcache.ifb.local_result);
+  // WBB
+  if (cache_p == Write_back) {
+    tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+    data = dcache.caches->l_ip.line_sz;
+    interface_ip.specific_tag = 1;
+    interface_ip.tag_w = tag;
+    interface_ip.line_sz = data;
+    interface_ip.cache_sz =
+        XML->sys.core[ithCore].dcache.buffer_sizes[3] * interface_ip.line_sz;
+    interface_ip.assoc = 0;
+    interface_ip.nbanks = 1;
+    interface_ip.out_w = interface_ip.line_sz * 8;
+    interface_ip.access_mode = 2;
+    interface_ip.throughput =
+        debug ? 1.0 / clockRate
+              : XML->sys.core[ithCore].dcache.dcache_config[4] / clockRate;
+    interface_ip.latency =
+        debug ? 1.0 / clockRate
+              : XML->sys.core[ithCore].dcache.dcache_config[5] / clockRate;
+    interface_ip.obj_func_dyn_energy = 0;
+    interface_ip.obj_func_dyn_power = 0;
+    interface_ip.obj_func_leak_power = 0;
+    interface_ip.obj_func_cycle_t = 1;
+    interface_ip.num_rw_ports = XML->sys.core[ithCore].memory_ports;
+    interface_ip.num_rd_ports = 0;
+    interface_ip.num_wr_ports = 0;
+    interface_ip.num_se_rd_ports = 0;
+    dcache.wbb = new ArrayST(&interface_ip, "dcacheWBB", Core_device,
+                             coredynp.opt_local, coredynp.core_ty);
+    dcache.area.set_area(dcache.area.get_area() +
+                         dcache.wbb->local_result.area);
+    area.set_area(area.get_area() + dcache.wbb->local_result.area);
+    // output_data_csv(dcache.wbb.local_result);
+  }
 
-	  //prefetch buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries to decide wthether to merge.
-	  data							   = tcache.caches->l_ip.line_sz;//separate queue to prevent from cache polution.
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-	  interface_ip.cache_sz            = XML->sys.core[ithCore].tcache.buffer_sizes[2]*interface_ip.line_sz;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 2;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  tcache.prefetchb = new ArrayST(&interface_ip, "tcacheprefetchBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  tcache.area.set_area(tcache.area.get_area()+ tcache.prefetchb->local_result.area);
-	  area.set_area(area.get_area()+ tcache.prefetchb->local_result.area);
-	  //output_data_csv(tcache.prefetchb.local_result);
+  /*
+   * LSU--in-order processors do not have separate load queue: unified lsq
+   * partitioned among threads
+   * it is actually the store queue but for inorder processors it serves as both
+   * loadQ and StoreQ
+   */
+  tag = ldst_opcode + XML->sys.virtual_address_width +
+        int(ceil(log2(XML->sys.core[ithCore].number_hardware_threads))) +
+        EXTRA_TAG_BITS;
+  data = XML->sys.machine_bits;
+  interface_ip.is_cache = true;
+  interface_ip.line_sz = int(ceil(data / 32.0)) * 4;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.cache_sz = XML->sys.core[ithCore].store_buffer_size *
+                          interface_ip.line_sz *
+                          XML->sys.core[ithCore].number_hardware_threads;
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 1;
+  interface_ip.throughput = 1.0 / clockRate;
+  interface_ip.latency = 1.0 / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = 0;
+  interface_ip.num_rd_ports = XML->sys.core[ithCore].memory_ports;
+  interface_ip.num_wr_ports = XML->sys.core[ithCore].memory_ports;
+  interface_ip.num_se_rd_ports = 0;
+  interface_ip.num_search_ports = XML->sys.core[ithCore].memory_ports;
+  LSQ = new ArrayST(&interface_ip, "Load(Store)Queue", Core_device,
+                    coredynp.opt_local, coredynp.core_ty);
+  LSQ->area.set_area(LSQ->area.get_area() + LSQ->local_result.area);
+  area.set_area(area.get_area() + LSQ->local_result.area);
+  area.set_area(area.get_area() * cdb_overhead);
+  // output_data_csv(LSQ.LSQ.local_result);
+  lsq_height =
+      LSQ->local_result.cache_ht *
+      sqrt(cdb_overhead); /*XML->sys.core[ithCore].number_hardware_threads*/
 
-	  //WBB
-	  if (cache_p==Write_back)
-	  {
-		  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-		  data							   = tcache.caches->l_ip.line_sz;
-		  interface_ip.specific_tag        = 1;
-		  interface_ip.tag_w               = tag;
-		  interface_ip.line_sz             = data;
-		  interface_ip.cache_sz            = XML->sys.core[ithCore].tcache.buffer_sizes[3]*interface_ip.line_sz;
-		  interface_ip.assoc               = 0;
-		  interface_ip.nbanks              = 1;
-		  interface_ip.out_w               = interface_ip.line_sz*8;
-		  interface_ip.access_mode         = 2;
-		  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[4]/clockRate;
-		  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].tcache.dcache_config[5]/clockRate;
-		  interface_ip.obj_func_dyn_energy = 0;
-		  interface_ip.obj_func_dyn_power  = 0;
-		  interface_ip.obj_func_leak_power = 0;
-		  interface_ip.obj_func_cycle_t    = 1;
-		  interface_ip.num_rw_ports    = XML->sys.core[ithCore].memory_ports;
-		  interface_ip.num_rd_ports    = 0;
-		  interface_ip.num_wr_ports    = 0;
-		  interface_ip.num_se_rd_ports = 0;
-		  tcache.wbb = new ArrayST(&interface_ip, "tcacheWBB", Core_device, coredynp.opt_local, coredynp.core_ty);
-		  tcache.area.set_area(tcache.area.get_area()+ tcache.wbb->local_result.area);
-		  area.set_area(area.get_area()+ tcache.wbb->local_result.area);
-		  //output_data_csv(tcache.wbb.local_result);
-	  }
-
-
-
-
-   /*
-    * dcache starts here
-    */   
-    //Dcache
-	  size                             = (int)XML->sys.core[ithCore].dcache.dcache_config[0];
-	  line                             = (int)XML->sys.core[ithCore].dcache.dcache_config[1];
-	  assoc                            = (int)XML->sys.core[ithCore].dcache.dcache_config[2];
-	  idx    					 	   = debug?9:int(ceil(log2(size/line/assoc)));
-	  tag							   = debug?51:XML->sys.physical_address_width-idx-int(ceil(log2(line))) + EXTRA_TAG_BITS;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.cache_sz            = debug?32768:(int)XML->sys.core[ithCore].dcache.dcache_config[0];
-	  interface_ip.line_sz             = debug?64:(int)XML->sys.core[ithCore].dcache.dcache_config[1];
-	  interface_ip.assoc               = debug?8:(int)XML->sys.core[ithCore].dcache.dcache_config[2];
-	  interface_ip.nbanks              = debug?1:(int)XML->sys.core[ithCore].dcache.dcache_config[3];
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 0;//debug?0:XML->sys.core[ithCore].dcache.dcache_config[5];
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?3.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[5]/clockRate;
-	  interface_ip.is_cache			 = true;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;//usually In-order has 1 and OOO has 2 at least.
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  dcache.caches = new ArrayST(&interface_ip, "dcache", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  dcache.area.set_area(dcache.area.get_area()+ dcache.caches->local_result.area);
-	  area.set_area(area.get_area()+ dcache.caches->local_result.area);
-	  //output_data_csv(dcache.caches.local_result);
-
-
-	  //dCache controllers
-	  //miss buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  data							   = (XML->sys.physical_address_width) + int(ceil(log2(size/line))) + dcache.caches->l_ip.line_sz*8;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-	  interface_ip.cache_sz            = XML->sys.core[ithCore].dcache.buffer_sizes[0]*interface_ip.line_sz;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 2;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  dcache.missb = new ArrayST(&interface_ip, "dcacheMissBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  dcache.area.set_area(dcache.area.get_area()+ dcache.missb->local_result.area);
-	  area.set_area(area.get_area()+ dcache.missb->local_result.area);
-	  //output_data_csv(dcache.missb.local_result);
-
-	  //fill buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  data							   = dcache.caches->l_ip.line_sz;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-	  interface_ip.cache_sz            = data*XML->sys.core[ithCore].dcache.buffer_sizes[1];
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 2;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  dcache.ifb = new ArrayST(&interface_ip, "dcacheFillBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  dcache.area.set_area(dcache.area.get_area()+ dcache.ifb->local_result.area);
-	  area.set_area(area.get_area()+ dcache.ifb->local_result.area);
-	  //output_data_csv(dcache.ifb.local_result);
-
-	  //prefetch buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries to decide wthether to merge.
-	  data							   = dcache.caches->l_ip.line_sz;//separate queue to prevent from cache polution.
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-	  interface_ip.cache_sz            = XML->sys.core[ithCore].dcache.buffer_sizes[2]*interface_ip.line_sz;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 2;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = debug?1:XML->sys.core[ithCore].memory_ports;;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  dcache.prefetchb = new ArrayST(&interface_ip, "dcacheprefetchBuffer", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  dcache.area.set_area(dcache.area.get_area()+ dcache.prefetchb->local_result.area);
-	  area.set_area(area.get_area()+ dcache.prefetchb->local_result.area);
-	  //output_data_csv(dcache.prefetchb.local_result);
-
-	  //WBB
-	  if (cache_p==Write_back)
-	  {
-		  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-		  data							   = dcache.caches->l_ip.line_sz;
-		  interface_ip.specific_tag        = 1;
-		  interface_ip.tag_w               = tag;
-		  interface_ip.line_sz             = data;
-		  interface_ip.cache_sz            = XML->sys.core[ithCore].dcache.buffer_sizes[3]*interface_ip.line_sz;
-		  interface_ip.assoc               = 0;
-		  interface_ip.nbanks              = 1;
-		  interface_ip.out_w               = interface_ip.line_sz*8;
-		  interface_ip.access_mode         = 2;
-		  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[4]/clockRate;
-		  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[5]/clockRate;
-		  interface_ip.obj_func_dyn_energy = 0;
-		  interface_ip.obj_func_dyn_power  = 0;
-		  interface_ip.obj_func_leak_power = 0;
-		  interface_ip.obj_func_cycle_t    = 1;
-		  interface_ip.num_rw_ports    = XML->sys.core[ithCore].memory_ports;
-		  interface_ip.num_rd_ports    = 0;
-		  interface_ip.num_wr_ports    = 0;
-		  interface_ip.num_se_rd_ports = 0;
-		  dcache.wbb = new ArrayST(&interface_ip, "dcacheWBB", Core_device, coredynp.opt_local, coredynp.core_ty);
-		  dcache.area.set_area(dcache.area.get_area()+ dcache.wbb->local_result.area);
-		  area.set_area(area.get_area()+ dcache.wbb->local_result.area);
-		  //output_data_csv(dcache.wbb.local_result);
-	  }
-
-	  /*
-	   * LSU--in-order processors do not have separate load queue: unified lsq
-	   * partitioned among threads
-	   * it is actually the store queue but for inorder processors it serves as both loadQ and StoreQ
-	   */
-	  tag							   = ldst_opcode+XML->sys.virtual_address_width +int(ceil(log2(XML->sys.core[ithCore].number_hardware_threads))) + EXTRA_TAG_BITS;
-	  data							   = XML->sys.machine_bits;
-	  interface_ip.is_cache			   = true;
-	  interface_ip.line_sz             = int(ceil(data/32.0))*4;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.cache_sz            = XML->sys.core[ithCore].store_buffer_size*interface_ip.line_sz*XML->sys.core[ithCore].number_hardware_threads;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 1;
-	  interface_ip.throughput          = 1.0/clockRate;
-	  interface_ip.latency             = 1.0/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports        = 0;
-	  interface_ip.num_rd_ports        = XML->sys.core[ithCore].memory_ports;
-	  interface_ip.num_wr_ports        = XML->sys.core[ithCore].memory_ports;
-	  interface_ip.num_se_rd_ports     = 0;
-	  interface_ip.num_search_ports    =XML->sys.core[ithCore].memory_ports;
-	  LSQ = new ArrayST(&interface_ip, "Load(Store)Queue", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  LSQ->area.set_area(LSQ->area.get_area()+ LSQ->local_result.area);
-	  area.set_area(area.get_area()+ LSQ->local_result.area);
-	  area.set_area(area.get_area()*cdb_overhead);
-	  //output_data_csv(LSQ.LSQ.local_result);
-	  lsq_height=LSQ->local_result.cache_ht*sqrt(cdb_overhead);/*XML->sys.core[ithCore].number_hardware_threads*/
-
-	  if ((coredynp.core_ty==OOO) && (XML->sys.core[ithCore].load_buffer_size >0))
-	  {
-		  interface_ip.line_sz             = int(ceil(data/32.0))*4;
-		  interface_ip.specific_tag        = 1;
-		  interface_ip.tag_w               = tag;
-		  interface_ip.cache_sz            = XML->sys.core[ithCore].load_buffer_size*interface_ip.line_sz*XML->sys.core[ithCore].number_hardware_threads;
-		  interface_ip.assoc               = 0;
-		  interface_ip.nbanks              = 1;
-		  interface_ip.out_w               = interface_ip.line_sz*8;
-		  interface_ip.access_mode         = 1;
-		  interface_ip.throughput          = 1.0/clockRate;
-		  interface_ip.latency             = 1.0/clockRate;
-		  interface_ip.obj_func_dyn_energy = 0;
-		  interface_ip.obj_func_dyn_power  = 0;
-		  interface_ip.obj_func_leak_power = 0;
-		  interface_ip.obj_func_cycle_t    = 1;
-		  interface_ip.num_rw_ports        = 0;
-		  interface_ip.num_rd_ports        = XML->sys.core[ithCore].memory_ports;
-		  interface_ip.num_wr_ports        = XML->sys.core[ithCore].memory_ports;
-		  interface_ip.num_se_rd_ports     = 0;
-		  interface_ip.num_search_ports    =XML->sys.core[ithCore].memory_ports;
-		  LoadQ = new ArrayST(&interface_ip, "LoadQueue", Core_device, coredynp.opt_local, coredynp.core_ty);
-		  LoadQ->area.set_area(LoadQ->area.get_area()+ LoadQ->local_result.area);
-		  area.set_area(area.get_area()+ LoadQ->local_result.area);
-		  area.set_area(area.get_area()*cdb_overhead);
-		  //output_data_csv(LoadQ.LoadQ.local_result);
-		  lsq_height=(LSQ->local_result.cache_ht + LoadQ->local_result.cache_ht)*sqrt(cdb_overhead);/*XML->sys.core[ithCore].number_hardware_threads*/
-	  }
-
+  if ((coredynp.core_ty == OOO) &&
+      (XML->sys.core[ithCore].load_buffer_size > 0)) {
+    interface_ip.line_sz = int(ceil(data / 32.0)) * 4;
+    interface_ip.specific_tag = 1;
+    interface_ip.tag_w = tag;
+    interface_ip.cache_sz = XML->sys.core[ithCore].load_buffer_size *
+                            interface_ip.line_sz *
+                            XML->sys.core[ithCore].number_hardware_threads;
+    interface_ip.assoc = 0;
+    interface_ip.nbanks = 1;
+    interface_ip.out_w = interface_ip.line_sz * 8;
+    interface_ip.access_mode = 1;
+    interface_ip.throughput = 1.0 / clockRate;
+    interface_ip.latency = 1.0 / clockRate;
+    interface_ip.obj_func_dyn_energy = 0;
+    interface_ip.obj_func_dyn_power = 0;
+    interface_ip.obj_func_leak_power = 0;
+    interface_ip.obj_func_cycle_t = 1;
+    interface_ip.num_rw_ports = 0;
+    interface_ip.num_rd_ports = XML->sys.core[ithCore].memory_ports;
+    interface_ip.num_wr_ports = XML->sys.core[ithCore].memory_ports;
+    interface_ip.num_se_rd_ports = 0;
+    interface_ip.num_search_ports = XML->sys.core[ithCore].memory_ports;
+    LoadQ = new ArrayST(&interface_ip, "LoadQueue", Core_device,
+                        coredynp.opt_local, coredynp.core_ty);
+    LoadQ->area.set_area(LoadQ->area.get_area() + LoadQ->local_result.area);
+    area.set_area(area.get_area() + LoadQ->local_result.area);
+    area.set_area(area.get_area() * cdb_overhead);
+    // output_data_csv(LoadQ.LoadQ.local_result);
+    lsq_height =
+        (LSQ->local_result.cache_ht + LoadQ->local_result.cache_ht) *
+        sqrt(cdb_overhead); /*XML->sys.core[ithCore].number_hardware_threads*/
+  }
 }
 
-MemManU::MemManU(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_,bool exist_)
-:XML(XML_interface),
- ithCore(ithCore_),
- interface_ip(*interface_ip_),
- coredynp(dyn_p_),
- itlb(0),
- dtlb(0),
- exist(exist_)
-{
-	  if (!exist) return;
-	  int  tag, data;
-	  bool debug= false;
+MemManU::MemManU(ParseXML* XML_interface, int ithCore_,
+                 InputParameter* interface_ip_, const CoreDynParam& dyn_p_,
+                 bool exist_)
+    : XML(XML_interface),
+      ithCore(ithCore_),
+      interface_ip(*interface_ip_),
+      coredynp(dyn_p_),
+      itlb(0),
+      dtlb(0),
+      exist(exist_) {
+  if (!exist) return;
+  int tag, data;
+  bool debug = false;
 
-	  clockRate = coredynp.clockRate;
-	  executionTime = coredynp.executionTime;
+  clockRate = coredynp.clockRate;
+  executionTime = coredynp.executionTime;
 
-	  interface_ip.is_cache			   = true;
-	  interface_ip.pure_cam            = false;
-	  interface_ip.pure_ram            = false;
-	  interface_ip.specific_tag        = 1;
-	  //Itlb TLBs are partioned among threads according to Nigara and Nehalem
-	  tag							   = XML->sys.virtual_address_width- int(floor(log2(XML->sys.virtual_memory_page_size))) + int(ceil(log2(XML->sys.core[ithCore].number_hardware_threads)))+ EXTRA_TAG_BITS;
-	  data							   = XML->sys.physical_address_width- int(floor(log2(XML->sys.virtual_memory_page_size)));
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-	  interface_ip.cache_sz            = XML->sys.core[ithCore].itlb.number_entries*interface_ip.line_sz;//*XML->sys.core[ithCore].number_hardware_threads;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 0;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].icache.icache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].icache.icache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = 0;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = debug?1:XML->sys.core[ithCore].number_instruction_fetch_ports;
-	  interface_ip.num_se_rd_ports = 0;
-	  interface_ip.num_search_ports    = debug?1:XML->sys.core[ithCore].number_instruction_fetch_ports;
-	  itlb = new ArrayST(&interface_ip, "ITLB", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  itlb->area.set_area(itlb->area.get_area()+ itlb->local_result.area);
-	  area.set_area(area.get_area()+ itlb->local_result.area);
-	  //output_data_csv(itlb.tlb.local_result);
+  interface_ip.is_cache = true;
+  interface_ip.pure_cam = false;
+  interface_ip.pure_ram = false;
+  interface_ip.specific_tag = 1;
+  // Itlb TLBs are partioned among threads according to Nigara and Nehalem
+  tag = XML->sys.virtual_address_width -
+        int(floor(log2(XML->sys.virtual_memory_page_size))) +
+        int(ceil(log2(XML->sys.core[ithCore].number_hardware_threads))) +
+        EXTRA_TAG_BITS;
+  data = XML->sys.physical_address_width -
+         int(floor(log2(XML->sys.virtual_memory_page_size)));
+  interface_ip.tag_w = tag;
+  interface_ip.line_sz =
+      int(ceil(data / 8.0));  // int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+  interface_ip.cache_sz =
+      XML->sys.core[ithCore].itlb.number_entries *
+      interface_ip.line_sz;  //*XML->sys.core[ithCore].number_hardware_threads;
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 0;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].icache.icache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].icache.icache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = 0;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports =
+      debug ? 1 : XML->sys.core[ithCore].number_instruction_fetch_ports;
+  interface_ip.num_se_rd_ports = 0;
+  interface_ip.num_search_ports =
+      debug ? 1 : XML->sys.core[ithCore].number_instruction_fetch_ports;
+  itlb = new ArrayST(&interface_ip, "ITLB", Core_device, coredynp.opt_local,
+                     coredynp.core_ty);
+  itlb->area.set_area(itlb->area.get_area() + itlb->local_result.area);
+  area.set_area(area.get_area() + itlb->local_result.area);
+  // output_data_csv(itlb.tlb.local_result);
 
-	  //dtlb
-	  tag							   = XML->sys.virtual_address_width- int(floor(log2(XML->sys.virtual_memory_page_size))) +int(ceil(log2(XML->sys.core[ithCore].number_hardware_threads)))+ EXTRA_TAG_BITS;
-	  data							   = XML->sys.physical_address_width- int(floor(log2(XML->sys.virtual_memory_page_size)));
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-	  interface_ip.cache_sz            = XML->sys.core[ithCore].dtlb.number_entries*interface_ip.line_sz;//*XML->sys.core[ithCore].number_hardware_threads;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 0;
-	  interface_ip.throughput          = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[4]/clockRate;
-	  interface_ip.latency             = debug?1.0/clockRate:XML->sys.core[ithCore].dcache.dcache_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = 0;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = XML->sys.core[ithCore].memory_ports;
-	  interface_ip.num_se_rd_ports = 0;
-	  interface_ip.num_search_ports = XML->sys.core[ithCore].memory_ports;
-	  dtlb = new ArrayST(&interface_ip, "DTLB", Core_device, coredynp.opt_local, coredynp.core_ty);
-	  dtlb->area.set_area(dtlb->area.get_area()+ dtlb->local_result.area);
-	  area.set_area(area.get_area()+ dtlb->local_result.area);
-	  //output_data_csv(dtlb.tlb.local_result);
-
+  // dtlb
+  tag = XML->sys.virtual_address_width -
+        int(floor(log2(XML->sys.virtual_memory_page_size))) +
+        int(ceil(log2(XML->sys.core[ithCore].number_hardware_threads))) +
+        EXTRA_TAG_BITS;
+  data = XML->sys.physical_address_width -
+         int(floor(log2(XML->sys.virtual_memory_page_size)));
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.line_sz =
+      int(ceil(data / 8.0));  // int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+  interface_ip.cache_sz =
+      XML->sys.core[ithCore].dtlb.number_entries *
+      interface_ip.line_sz;  //*XML->sys.core[ithCore].number_hardware_threads;
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 0;
+  interface_ip.throughput =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].dcache.dcache_config[4] / clockRate;
+  interface_ip.latency =
+      debug ? 1.0 / clockRate
+            : XML->sys.core[ithCore].dcache.dcache_config[5] / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = 0;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = XML->sys.core[ithCore].memory_ports;
+  interface_ip.num_se_rd_ports = 0;
+  interface_ip.num_search_ports = XML->sys.core[ithCore].memory_ports;
+  dtlb = new ArrayST(&interface_ip, "DTLB", Core_device, coredynp.opt_local,
+                     coredynp.core_ty);
+  dtlb->area.set_area(dtlb->area.get_area() + dtlb->local_result.area);
+  area.set_area(area.get_area() + dtlb->local_result.area);
+  // output_data_csv(dtlb.tlb.local_result);
 }
 //#define FERMI
 
-RegFU::RegFU(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_,double exClockRate,bool exist_)
-:XML(XML_interface),
- ithCore(ithCore_),
- interface_ip(*interface_ip_),
- coredynp(dyn_p_),
- IRF (0),
- FRF (0),
- RFWIN (0),
- exist(exist_)
- {
-	/*
-	 * processors have separate architectural register files for each thread.
-	 * therefore, the bypass buses need to travel across all the register files.
-	 */
-	if (!exist) return;
-	int  data;
-	clockRate = exClockRate;//coredynp.clockRate;
-	executionTime = coredynp.executionTime;
+RegFU::RegFU(ParseXML* XML_interface, int ithCore_,
+             InputParameter* interface_ip_, const CoreDynParam& dyn_p_,
+             double exClockRate, bool exist_)
+    : XML(XML_interface),
+      ithCore(ithCore_),
+      interface_ip(*interface_ip_),
+      coredynp(dyn_p_),
+      IRF(0),
+      FRF(0),
+      RFWIN(0),
+      exist(exist_) {
+  /*
+   * processors have separate architectural register files for each thread.
+   * therefore, the bypass buses need to travel across all the register files.
+   */
+  if (!exist) return;
+  int data;
+  clockRate = exClockRate;  // coredynp.clockRate;
+  executionTime = coredynp.executionTime;
   /*********************************************************************************
-	* OC stage modelling (Syed Gilani)
-	*********************************************************************************/
-  
-  //Crossbar
- 
-	if(XML->sys.architecture==1){
-  xbar_rfu     = new Crossbar(XML->sys.core[ithCore].rf_banks/2,XML->sys.core[ithCore].collector_units/2
-		                 ,(128),&(g_tp.peri_global));
-	}else{
-  xbar_rfu     = new Crossbar(XML->sys.core[ithCore].rf_banks,XML->sys.core[ithCore].collector_units
-		                 ,(128),&(g_tp.peri_global));
-	}
+        * OC stage modelling (Syed Gilani)
+        *********************************************************************************/
 
-  //new Crossbar(simd_width,shared_memory_banks,word_length*simd_width,&(g_tp.peri_global));
+  // Crossbar
 
-  //Arbiter
-  arbiter_rfu = new MCPAT_Arbiter(XML->sys.core[ithCore].rf_banks,XML->sys.core[ithCore].collector_units , 1,&(g_tp.peri_global));
+  if (XML->sys.architecture == 1) {
+    xbar_rfu = new Crossbar(XML->sys.core[ithCore].rf_banks / 2,
+                            XML->sys.core[ithCore].collector_units / 2, (128),
+                            &(g_tp.peri_global));
+  } else {
+    xbar_rfu = new Crossbar(XML->sys.core[ithCore].rf_banks,
+                            XML->sys.core[ithCore].collector_units, (128),
+                            &(g_tp.peri_global));
+  }
 
+  // new
+  // Crossbar(simd_width,shared_memory_banks,word_length*simd_width,&(g_tp.peri_global));
 
+  // Arbiter
+  arbiter_rfu = new MCPAT_Arbiter(XML->sys.core[ithCore].rf_banks,
+                                  XML->sys.core[ithCore].collector_units, 1,
+                                  &(g_tp.peri_global));
 
-	// RF banks modelled here for GPGPU-Sim (Syed Gilani)
-	//
-	//**********************************IRF***************************************
-	data							 = coredynp.int_data_width;
-  //data               *= 8;
-	interface_ip.is_cache			 = false;
-	interface_ip.pure_cam            = false;
-	interface_ip.pure_ram            = true;
+  // RF banks modelled here for GPGPU-Sim (Syed Gilani)
+  //
+  //**********************************IRF***************************************
+  data = coredynp.int_data_width;
+  // data               *= 8;
+  interface_ip.is_cache = false;
+  interface_ip.pure_cam = false;
+  interface_ip.pure_ram = true;
 
-	interface_ip.line_sz             = 16;//int(ceil(data/32.0))*4 * XML->sys.core[ithCore].simd_width/4 ;//2 for Tesla as RF width half of SIMD width
+  interface_ip.line_sz = 16;  // int(ceil(data/32.0))*4 *
+                              // XML->sys.core[ithCore].simd_width/4 ;//2 for
+                              // Tesla as RF width half of SIMD width
 
-	interface_ip.line_sz             = 16;//int(ceil(data/32.0))*4 * XML->sys.core[ithCore].simd_width/2 ;//2 for Tesla as RF width half of SIMD width
+  interface_ip.line_sz = 16;  // int(ceil(data/32.0))*4 *
+                              // XML->sys.core[ithCore].simd_width/2 ;//2 for
+                              // Tesla as RF width half of SIMD width
 
-	interface_ip.cache_sz            = coredynp.num_IRF_entry*4;
-	interface_ip.assoc               = 1;
-	interface_ip.nbanks              = XML->sys.core[ithCore].rf_banks;
+  interface_ip.cache_sz = coredynp.num_IRF_entry * 4;
+  interface_ip.assoc = 1;
+  interface_ip.nbanks = XML->sys.core[ithCore].rf_banks;
 
-	interface_ip.out_w               = interface_ip.line_sz*8;//interface_ip.line_sz*XML->sys.core[ithCore].simd_width/4; //2 for Tesla and 4 for Fermi
+  interface_ip.out_w =
+      interface_ip.line_sz *
+      8;  // interface_ip.line_sz*XML->sys.core[ithCore].simd_width/4; //2 for
+          // Tesla and 4 for Fermi
 
-	interface_ip.out_w               = interface_ip.line_sz*8;//interface_ip.line_sz*XML->sys.core[ithCore].simd_width/2; //2 for Tesla and 4 for Fermi
+  interface_ip.out_w =
+      interface_ip.line_sz *
+      8;  // interface_ip.line_sz*XML->sys.core[ithCore].simd_width/2; //2 for
+          // Tesla and 4 for Fermi
 
+  interface_ip.access_mode = 1;
+  interface_ip.throughput = 1 / (clockRate);
+  interface_ip.latency = 8.0 / (clockRate);
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 1;
+  interface_ip.obj_func_cycle_t = 0;
+  interface_ip.num_rw_ports = 0;  // this is the transfer port for
+                                  // saving/restoring states when exceptions
+                                  // happen.
+  interface_ip.num_rd_ports = 1;  // 2*coredynp.peak_issueW;
+  interface_ip.num_wr_ports = 1;  // coredynp.peak_issueW;
+  interface_ip.num_se_rd_ports = 0;
+  IRF = new ArrayST(&interface_ip, "Integer Register File", Core_device,
+                    coredynp.opt_local, coredynp.core_ty);
 
-	interface_ip.access_mode         = 1;
-	interface_ip.throughput          = 1/(clockRate);
-	interface_ip.latency             = 8.0/(clockRate);
-	interface_ip.obj_func_dyn_energy = 0;
-	interface_ip.obj_func_dyn_power  = 0;
-	interface_ip.obj_func_leak_power = 1;
-	interface_ip.obj_func_cycle_t    = 0;
-	interface_ip.num_rw_ports    = 0;//this is the transfer port for saving/restoring states when exceptions happen.
-	interface_ip.num_rd_ports    = 1;//2*coredynp.peak_issueW;
-	interface_ip.num_wr_ports    = 1;//coredynp.peak_issueW;
-	interface_ip.num_se_rd_ports = 0;
-	IRF = new ArrayST(&interface_ip, "Integer Register File", Core_device, coredynp.opt_local, coredynp.core_ty);
+  IRF->area.set_area(IRF->area.get_area() +
+                     IRF->local_result.area * coredynp.num_pipelines *
+                         cdb_overhead);
 
-	IRF->area.set_area(IRF->area.get_area()+ IRF->local_result.area*coredynp.num_pipelines*cdb_overhead);
+  area.set_area(area.get_area() + IRF->local_result.area +
+                xbar_rfu->area.get_area() + arbiter_rfu->area.get_area());
+  if (XML->sys.architecture == 1) {
+    IRF->local_result.power.readOp.dynamic *= .33;
+    IRF->local_result.power.writeOp.dynamic *= .33;
+  } else {
+    IRF->local_result.power.readOp.dynamic *= .55;
+    IRF->local_result.power.writeOp.dynamic *= .55;
+  }
 
+  /**
+   * Operand collectors (32-bit wide, 8 entry banks )
+   */
+  data = 32;
+  // data               *= 8;
+  interface_ip.is_cache = false;
+  interface_ip.pure_cam = false;
+  interface_ip.pure_ram = true;
 
-	area.set_area(area.get_area()+ IRF->local_result.area
-		 + xbar_rfu->area.get_area() + arbiter_rfu->area.get_area());
-	if(XML->sys.architecture==1){
-	IRF->local_result.power.readOp.dynamic *= .33;
-	IRF->local_result.power.writeOp.dynamic *= .33;
-	}
-	else {
-	IRF->local_result.power.readOp.dynamic *= .55;
-	IRF->local_result.power.writeOp.dynamic *= .55;
-	}
+  interface_ip.line_sz = 4;  // int(ceil(data/32.0))*4 *
+                             // XML->sys.core[ithCore].simd_width/4 ;//2 for
+                             // Tesla as RF width half of SIMD width
 
+  interface_ip.line_sz = 4;  // int(ceil(data/32.0))*4 *
+                             // XML->sys.core[ithCore].simd_width/2 ;//2 for
+                             // Tesla as RF width half of SIMD width
 
+  interface_ip.cache_sz = 8 * 4;
+  interface_ip.assoc = 1;
+  interface_ip.nbanks = 1;
 
+  interface_ip.out_w =
+      interface_ip
+          .line_sz;  // interface_ip.line_sz*XML->sys.core[ithCore].simd_width/4;
+                     // //2 for Tesla and 4 for Fermi
 
-	/**
-	 * Operand collectors (32-bit wide, 8 entry banks )
-	 */
-	data							 = 32;
-  //data               *= 8;
-	interface_ip.is_cache			 = false;
-	interface_ip.pure_cam            = false;
-	interface_ip.pure_ram            = true;
+  interface_ip.out_w =
+      interface_ip
+          .line_sz;  // interface_ip.line_sz*XML->sys.core[ithCore].simd_width/2;
+                     // //2 for Tesla and 4 for Fermi
 
-	interface_ip.line_sz             = 4;//int(ceil(data/32.0))*4 * XML->sys.core[ithCore].simd_width/4 ;//2 for Tesla as RF width half of SIMD width
+  interface_ip.access_mode = 1;
+  interface_ip.throughput = 1.0 / (clockRate);
+  interface_ip.latency = 1.0 / (clockRate);
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 1;
+  interface_ip.obj_func_cycle_t = 0;
+  interface_ip.num_rw_ports = 0;  // this is the transfer port for
+                                  // saving/restoring states when exceptions
+                                  // happen.
+  interface_ip.num_rd_ports = 1;  // 2*coredynp.peak_issueW;
+  interface_ip.num_wr_ports = 1;  // coredynp.peak_issueW;
+  interface_ip.num_se_rd_ports = 0;
+  OPC = new ArrayST(&interface_ip, "Operand collectors", Core_device,
+                    coredynp.opt_local, coredynp.core_ty);
 
-	interface_ip.line_sz             = 4;//int(ceil(data/32.0))*4 * XML->sys.core[ithCore].simd_width/2 ;//2 for Tesla as RF width half of SIMD width
+  OPC->area.set_area(OPC->area.get_area() +
+                     OPC->local_result.area * coredynp.num_pipelines *
+                         cdb_overhead);
 
-	interface_ip.cache_sz            = 8*4;
-	interface_ip.assoc               = 1;
-	interface_ip.nbanks              = 1;
+  area.set_area(area.get_area() + OPC->local_result.area);
 
-	interface_ip.out_w               = interface_ip.line_sz;//interface_ip.line_sz*XML->sys.core[ithCore].simd_width/4; //2 for Tesla and 4 for Fermi
+  /********
+   * For GPGPUSim (Syed Gilani)
+   * Do not include FRF in final results for GPU. Only model the IRF
+   ********/
 
-	interface_ip.out_w               = interface_ip.line_sz;//interface_ip.line_sz*XML->sys.core[ithCore].simd_width/2; //2 for Tesla and 4 for Fermi
-
-
-	interface_ip.access_mode         = 1;
-	interface_ip.throughput          = 1.0/(clockRate);
-	interface_ip.latency             = 1.0/(clockRate);
-	interface_ip.obj_func_dyn_energy = 0;
-	interface_ip.obj_func_dyn_power  = 0;
-	interface_ip.obj_func_leak_power = 1;
-	interface_ip.obj_func_cycle_t    = 0;
-	interface_ip.num_rw_ports    = 0;//this is the transfer port for saving/restoring states when exceptions happen.
-	interface_ip.num_rd_ports    = 1;//2*coredynp.peak_issueW;
-	interface_ip.num_wr_ports    = 1;//coredynp.peak_issueW;
-	interface_ip.num_se_rd_ports = 0;
-	OPC = new ArrayST(&interface_ip, "Operand collectors", Core_device, coredynp.opt_local, coredynp.core_ty);
-
-	OPC->area.set_area(OPC->area.get_area()+ OPC->local_result.area*coredynp.num_pipelines*cdb_overhead);
-
-
-	area.set_area(area.get_area()+ OPC->local_result.area);
-
-
-
-
-	/********
-	 * For GPGPUSim (Syed Gilani)
-	 * Do not include FRF in final results for GPU. Only model the IRF
-	 ********/
-
-	//**********************************FRF***************************************
-	data							 = coredynp.fp_data_width;
-  //data               *= 8;
-	interface_ip.is_cache			 = false;
-	interface_ip.pure_cam            = false;
-	interface_ip.pure_ram            = true;
-	interface_ip.line_sz             = int(ceil(data/32.0))*4;
-	interface_ip.cache_sz            = coredynp.num_FRF_entry*interface_ip.line_sz;
-	interface_ip.assoc               = 1;
-	interface_ip.nbanks              = 1;
-	interface_ip.out_w               = interface_ip.line_sz*8;
-	interface_ip.access_mode         = 1;
-	interface_ip.throughput          = 1.0/clockRate;
-	interface_ip.latency             = 1.0/clockRate;
-	interface_ip.obj_func_dyn_energy = 0;
-	interface_ip.obj_func_dyn_power  = 0;
-	interface_ip.obj_func_leak_power = 0;
-	interface_ip.obj_func_cycle_t    = 1;
-	interface_ip.num_rw_ports    = 1;//this is the transfer port for saving/restoring states when exceptions happen.
-	interface_ip.num_rd_ports    = 2*XML->sys.core[ithCore].issue_width;
-	//interface_ip.num_rd_ports    = 1;
-	interface_ip.num_wr_ports    = XML->sys.core[ithCore].issue_width;
-	//interface_ip.num_wr_ports    = 1;
-	interface_ip.num_se_rd_ports = 0;
-	FRF = new ArrayST(&interface_ip, "Floating point Register File", Core_device, coredynp.opt_local, coredynp.core_ty);
-	//FRF->area.set_area(FRF->area.get_area()+ FRF->local_result.area*XML->sys.core[ithCore].number_hardware_threads*coredynp.num_fp_pipelines*cdb_overhead);
-	//area.set_area(area.get_area()+ FRF->local_result.area*XML->sys.core[ithCore].number_hardware_threads*coredynp.num_fp_pipelines*cdb_overhead);
-	//area.set_area(area.get_area()*cdb_overhead);
-	//output_data_csv(FRF.RF.local_result);
-	int_regfile_height= IRF->local_result.cache_ht*XML->sys.core[ithCore].number_hardware_threads*sqrt(cdb_overhead);
-	fp_regfile_height=0;
-	//fp_regfile_height = FRF->local_result.cache_ht*XML->sys.core[ithCore].number_hardware_threads*sqrt(cdb_overhead);
-    //since a EXU is associated with each pipeline, the cdb should not have longer length.
-	if (coredynp.regWindowing)
-	{
-		//*********************************REG_WIN************************************
-		data							 = coredynp.int_data_width; //ECC, and usually 2 regs are transfered together during window shifting.Niagara Mega cell
-		interface_ip.is_cache			 = false;
-		interface_ip.pure_cam            = false;
-		interface_ip.pure_ram            = true;
-		interface_ip.line_sz             = int(ceil(data/8.0));
-		interface_ip.cache_sz            = XML->sys.core[ithCore].register_windows_size*IRF->l_ip.cache_sz*XML->sys.core[ithCore].number_hardware_threads;
-		interface_ip.assoc               = 1;
-		interface_ip.nbanks              = 1;
-		interface_ip.out_w               = interface_ip.line_sz*8;
-		interface_ip.access_mode         = 1;
-		interface_ip.throughput          = 4.0/clockRate;
-		interface_ip.latency             = 4.0/clockRate;
-		interface_ip.obj_func_dyn_energy = 0;
-		interface_ip.obj_func_dyn_power  = 0;
-		interface_ip.obj_func_leak_power = 0;
-		interface_ip.obj_func_cycle_t    = 1;
-		interface_ip.num_rw_ports    = 1;//this is the transfer port for saving/restoring states when exceptions happen.
-		interface_ip.num_rd_ports    = 0;
-		interface_ip.num_wr_ports    = 0;
-		interface_ip.num_se_rd_ports = 0;
-		RFWIN = new ArrayST(&interface_ip, "RegWindow", Core_device, coredynp.opt_local, coredynp.core_ty);
-		RFWIN->area.set_area(RFWIN->area.get_area()+ RFWIN->local_result.area*coredynp.num_pipelines);
-		area.set_area(area.get_area()+ RFWIN->local_result.area*coredynp.num_pipelines);
-		//output_data_csv(RFWIN.RF.local_result);
-	}
-
-
- }
-
-EXECU::EXECU(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, double lsq_height_, const CoreDynParam & dyn_p_,  double exClockRate, bool exist_)
-:XML(XML_interface),
- ithCore(ithCore_),
- interface_ip(*interface_ip_),
- lsq_height(lsq_height_),
- coredynp(dyn_p_),
- rfu(0),
- scheu(0),
- fp_u(0),
- exeu(0),
- mul(0),
- int_bypass(0),
- intTagBypass(0),
- int_mul_bypass(0),
- intTag_mul_Bypass(0),
- fp_bypass(0),
- fpTagBypass(0),
- exist(exist_),
- rf_fu_clockRate(exClockRate)
-{
-	  if (!exist) return;
-	  double fu_height = 0.0;
-      clockRate = coredynp.clockRate;
-		//cout <<"EXECU exClockRate: "<<exClockRate<<endl;
-      executionTime = coredynp.executionTime;
-	  rfu   = new RegFU(XML, ithCore, &interface_ip,coredynp,exClockRate);
-	  scheu = new SchedulerU(XML, ithCore, &interface_ip,coredynp);
-	  exeu  = new FunctionalUnit(XML, ithCore,&interface_ip, coredynp, ALU,exClockRate);
-	  area.set_area(area.get_area()+ exeu->area.get_area() + rfu->area.get_area() +scheu->area.get_area() );
-	  fu_height = exeu->FU_height;
-	  if (coredynp.num_fpus >0)
-	  {
-		  fp_u  = new FunctionalUnit(XML, ithCore,&interface_ip, coredynp, FPU, exClockRate);
-		  area.set_area(area.get_area()+ fp_u->area.get_area());
-	  }
-	  if (coredynp.num_muls >0)
-	  {
-		  mul   = new FunctionalUnit(XML, ithCore,&interface_ip, coredynp, MUL, exClockRate);
-		  area.set_area(area.get_area()+ mul->area.get_area());
-		  fu_height +=  mul->FU_height;
-	  }
-	  /*
-	   * broadcast logic, including int-broadcast; int_tag-broadcast; fp-broadcast; fp_tag-broadcast
-	   * integer by pass has two paths and fp has 3 paths.
-	   * on the same bus there are multiple tri-state drivers and muxes that go to different components on the same bus
-	   */
-	  if (XML->sys.Embedded)
-	  		{
-	  		interface_ip.wt                  =Global_30;
-	  		interface_ip.wire_is_mat_type = 0;
-	  		interface_ip.wire_os_mat_type = 0;
-	  	    interface_ip.throughput       = 1.0/clockRate;
-	  	    interface_ip.latency          = 1.0/clockRate;
-	  		}
-	  	else
-	  		{
-	  		interface_ip.wt                  =Global;
-	  		interface_ip.wire_is_mat_type = 2;//start from semi-global since local wires are already used
-	  		interface_ip.wire_os_mat_type = 2;
-	  	    interface_ip.throughput       = 10.0/clockRate; //Do not care
-	  	    interface_ip.latency          = 10.0/clockRate;
-	  		}
-
-	  if (coredynp.core_ty==Inorder)
-	  {//
-		  int_bypass   = new interconnect("Int Bypass Data", Core_device, 1, 1, int(ceil(XML->sys.machine_bits/32.0)*32),
-				  rfu->int_regfile_height + exeu->FU_height + lsq_height, &interface_ip, 3,
-				  false, 1.0, coredynp.opt_local, coredynp.core_ty);
-		  bypass.area.set_area(bypass.area.get_area() + int_bypass->area.get_area());
-		  intTagBypass = new interconnect("Int Bypass tag" , Core_device, 1, 1, coredynp.perThreadState,
-				  rfu->int_regfile_height + exeu->FU_height + lsq_height + scheu->Iw_height, &interface_ip, 3,
-				  false, 1.0, coredynp.opt_local, coredynp.core_ty);
-		  bypass.area.set_area(bypass.area.get_area()  +intTagBypass->area.get_area());
-
-		  if (coredynp.num_muls>0)
-		  {
-			  int_mul_bypass     = new interconnect("Mul Bypass Data" , Core_device, 1, 1, int(ceil(XML->sys.machine_bits/32.0)*32*1.5),
-					  rfu->fp_regfile_height + exeu->FU_height + mul->FU_height + lsq_height, &interface_ip, 3,
-					  false, 1.0, coredynp.opt_local, coredynp.core_ty);
-			  bypass.area.set_area(bypass.area.get_area()  +int_mul_bypass->area.get_area());
-			  intTag_mul_Bypass  = new interconnect("Mul Bypass tag"  , Core_device, 1, 1, coredynp.perThreadState,
-					  rfu->fp_regfile_height + exeu->FU_height + mul->FU_height + lsq_height + scheu->Iw_height, &interface_ip, 3,
-					  false, 1.0, coredynp.opt_local, coredynp.core_ty);
-			  bypass.area.set_area(bypass.area.get_area()  +intTag_mul_Bypass->area.get_area());
-		  }
-
-		  /*
-		  if (coredynp.num_fpus>0)
-		  {
-			  fp_bypass    = new interconnect("FP Bypass Data" , Core_device, 1, 1, int(ceil(XML->sys.machine_bits/32.0)*32*1.5),
-					  rfu->fp_regfile_height + fp_u->FU_height, &interface_ip, 3,
-					  false, 1.0, coredynp.opt_local, coredynp.core_ty);
-			  bypass.area.set_area(bypass.area.get_area()  +fp_bypass->area.get_area());
-			  fpTagBypass  = new interconnect("FP Bypass tag"  , Core_device, 1, 1, coredynp.perThreadState,
-					  rfu->fp_regfile_height + fp_u->FU_height + lsq_height + scheu->Iw_height, &interface_ip, 3,
-					  false, 1.0, coredynp.opt_local, coredynp.core_ty);
-			  bypass.area.set_area(bypass.area.get_area()  +fpTagBypass->area.get_area());
-		  }*/
-	  } /* if (coredynp.core_ty==Inorder) */ 
-	  else
-	  {//OOO
-		  if (coredynp.scheu_ty==PhysicalRegFile)
-		  {
-			  /* For physical register based OOO,
-			   * data broadcast interconnects cover across functional units, lsq, inst windows and register files,
-			   * while tag broadcast interconnects also cover across ROB
-			   */
-			  int_bypass   = new interconnect("Int Bypass Data", Core_device, 1, 1, int(ceil(coredynp.int_data_width)),
-					            rfu->int_regfile_height + exeu->FU_height + lsq_height, &interface_ip, 3,
-								false, 1.0, coredynp.opt_local, coredynp.core_ty);
-			  bypass.area.set_area(bypass.area.get_area()  +int_bypass->area.get_area());
-			  intTagBypass = new interconnect("Int Bypass tag" , Core_device, 1, 1, coredynp.phy_ireg_width,
-					            rfu->int_regfile_height + exeu->FU_height + lsq_height + scheu->Iw_height + scheu->ROB_height , &interface_ip, 3,
-								false, 1.0, coredynp.opt_local, coredynp.core_ty);
-
-			  if (coredynp.num_muls>0)
-			  {
-				  int_mul_bypass   = new interconnect("Mul Bypass Data", Core_device, 1, 1, int(ceil(coredynp.int_data_width)),
-										rfu->int_regfile_height + exeu->FU_height + mul->FU_height + lsq_height, &interface_ip, 3,
-										false, 1.0, coredynp.opt_local, coredynp.core_ty);
-				  intTag_mul_Bypass = new interconnect("Mul Bypass tag" , Core_device, 1, 1, coredynp.phy_ireg_width,
-										rfu->int_regfile_height + exeu->FU_height + mul->FU_height + lsq_height + scheu->Iw_height + scheu->ROB_height , &interface_ip, 3,
-										false, 1.0, coredynp.opt_local, coredynp.core_ty);
-				  bypass.area.set_area(bypass.area.get_area()  +int_mul_bypass->area.get_area());
-				  bypass.area.set_area(bypass.area.get_area()  +intTag_mul_Bypass->area.get_area());
-			  }
-
-			  if (coredynp.num_fpus>0)
-			  {
-				  fp_bypass    = new interconnect("FP Bypass Data" , Core_device, 1, 1, int(ceil(coredynp.fp_data_width)),
-								  rfu->fp_regfile_height + fp_u->FU_height, &interface_ip, 3,
-								  false, 1.0, coredynp.opt_local, coredynp.core_ty);
-				  fpTagBypass  = new interconnect("FP Bypass tag"  , Core_device, 1, 1, coredynp.phy_freg_width,
-								  rfu->fp_regfile_height + fp_u->FU_height + lsq_height + scheu->fp_Iw_height + scheu->ROB_height, &interface_ip, 3,
-								  false, 1.0, coredynp.opt_local, coredynp.core_ty);
-				  bypass.area.set_area(bypass.area.get_area()  +fp_bypass->area.get_area());
-				  bypass.area.set_area(bypass.area.get_area()  +fpTagBypass->area.get_area());
-			  }
-		  }
-		  else
-		  {
-             /*
-              * In RS based processor both data and tag are broadcast together,
-              * covering functional units, lsq, nst windows, register files, and ROBs
-              */
-			  int_bypass   = new interconnect("Int Bypass Data", Core_device, 1, 1, int(ceil(coredynp.int_data_width)),
-					            rfu->int_regfile_height + exeu->FU_height + lsq_height + scheu->Iw_height + scheu->ROB_height, &interface_ip, 3,
-								  false, 1.0, coredynp.opt_local, coredynp.core_ty);
-			  intTagBypass = new interconnect("Int Bypass tag" , Core_device, 1, 1, coredynp.phy_ireg_width,
-					            rfu->int_regfile_height + exeu->FU_height + lsq_height + scheu->Iw_height + scheu->ROB_height , &interface_ip, 3,
-								  false, 1.0, coredynp.opt_local, coredynp.core_ty);
-			  bypass.area.set_area(bypass.area.get_area() +int_bypass->area.get_area());
-			  bypass.area.set_area(bypass.area.get_area() +intTagBypass->area.get_area());
-			  if (coredynp.num_muls>0)
-			  {
-				  int_mul_bypass   = new interconnect("Mul Bypass Data", Core_device, 1, 1, int(ceil(coredynp.int_data_width)),
-						            rfu->int_regfile_height + exeu->FU_height + mul->FU_height + lsq_height + scheu->Iw_height + scheu->ROB_height, &interface_ip, 3,
-									  false, 1.0, coredynp.opt_local, coredynp.core_ty);
-				  intTag_mul_Bypass = new interconnect("Mul Bypass tag" , Core_device, 1, 1, coredynp.phy_ireg_width,
-						            rfu->int_regfile_height + exeu->FU_height + mul->FU_height + lsq_height + scheu->Iw_height + scheu->ROB_height , &interface_ip, 3,
-									  false, 1.0, coredynp.opt_local, coredynp.core_ty);
-				  bypass.area.set_area(bypass.area.get_area() +int_mul_bypass->area.get_area());
-				  bypass.area.set_area(bypass.area.get_area() +intTag_mul_Bypass->area.get_area());
-			  }
-
-			  if (coredynp.num_fpus>0)
-			  {
-				  fp_bypass    = new interconnect("FP Bypass Data" , Core_device, 1, 1, int(ceil(coredynp.fp_data_width)),
-						  rfu->fp_regfile_height + fp_u->FU_height + lsq_height + scheu->fp_Iw_height + scheu->ROB_height, &interface_ip, 3,
-						  false, 1.0, coredynp.opt_local, coredynp.core_ty);
-				  fpTagBypass  = new interconnect("FP Bypass tag"  , Core_device, 1, 1, coredynp.phy_freg_width,
-						  rfu->fp_regfile_height + fp_u->FU_height + lsq_height + scheu->fp_Iw_height + scheu->ROB_height, &interface_ip, 3,
-						  false, 1.0, coredynp.opt_local, coredynp.core_ty);
-				  bypass.area.set_area(bypass.area.get_area() +fp_bypass->area.get_area());
-				  bypass.area.set_area(bypass.area.get_area() +fpTagBypass->area.get_area());
-			  }
-		  } /* else */ 
-
-
-	  } /* else */ 
-	  area.set_area(area.get_area()/*+ bypass.area.get_area()*/);
+  //**********************************FRF***************************************
+  data = coredynp.fp_data_width;
+  // data               *= 8;
+  interface_ip.is_cache = false;
+  interface_ip.pure_cam = false;
+  interface_ip.pure_ram = true;
+  interface_ip.line_sz = int(ceil(data / 32.0)) * 4;
+  interface_ip.cache_sz = coredynp.num_FRF_entry * interface_ip.line_sz;
+  interface_ip.assoc = 1;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 1;
+  interface_ip.throughput = 1.0 / clockRate;
+  interface_ip.latency = 1.0 / clockRate;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = 1;  // this is the transfer port for
+                                  // saving/restoring states when exceptions
+                                  // happen.
+  interface_ip.num_rd_ports = 2 * XML->sys.core[ithCore].issue_width;
+  // interface_ip.num_rd_ports    = 1;
+  interface_ip.num_wr_ports = XML->sys.core[ithCore].issue_width;
+  // interface_ip.num_wr_ports    = 1;
+  interface_ip.num_se_rd_ports = 0;
+  FRF = new ArrayST(&interface_ip, "Floating point Register File", Core_device,
+                    coredynp.opt_local, coredynp.core_ty);
+  // FRF->area.set_area(FRF->area.get_area()+
+  // FRF->local_result.area*XML->sys.core[ithCore].number_hardware_threads*coredynp.num_fp_pipelines*cdb_overhead);
+  // area.set_area(area.get_area()+
+  // FRF->local_result.area*XML->sys.core[ithCore].number_hardware_threads*coredynp.num_fp_pipelines*cdb_overhead);
+  // area.set_area(area.get_area()*cdb_overhead);
+  // output_data_csv(FRF.RF.local_result);
+  int_regfile_height = IRF->local_result.cache_ht *
+                       XML->sys.core[ithCore].number_hardware_threads *
+                       sqrt(cdb_overhead);
+  fp_regfile_height = 0;
+  // fp_regfile_height =
+  // FRF->local_result.cache_ht*XML->sys.core[ithCore].number_hardware_threads*sqrt(cdb_overhead);
+  // since a EXU is associated with each pipeline, the cdb should not have
+  // longer length.
+  if (coredynp.regWindowing) {
+    //*********************************REG_WIN************************************
+    data = coredynp.int_data_width;  // ECC, and usually 2 regs are transfered
+                                     // together during window shifting.Niagara
+                                     // Mega cell
+    interface_ip.is_cache = false;
+    interface_ip.pure_cam = false;
+    interface_ip.pure_ram = true;
+    interface_ip.line_sz = int(ceil(data / 8.0));
+    interface_ip.cache_sz = XML->sys.core[ithCore].register_windows_size *
+                            IRF->l_ip.cache_sz *
+                            XML->sys.core[ithCore].number_hardware_threads;
+    interface_ip.assoc = 1;
+    interface_ip.nbanks = 1;
+    interface_ip.out_w = interface_ip.line_sz * 8;
+    interface_ip.access_mode = 1;
+    interface_ip.throughput = 4.0 / clockRate;
+    interface_ip.latency = 4.0 / clockRate;
+    interface_ip.obj_func_dyn_energy = 0;
+    interface_ip.obj_func_dyn_power = 0;
+    interface_ip.obj_func_leak_power = 0;
+    interface_ip.obj_func_cycle_t = 1;
+    interface_ip.num_rw_ports = 1;  // this is the transfer port for
+                                    // saving/restoring states when exceptions
+                                    // happen.
+    interface_ip.num_rd_ports = 0;
+    interface_ip.num_wr_ports = 0;
+    interface_ip.num_se_rd_ports = 0;
+    RFWIN = new ArrayST(&interface_ip, "RegWindow", Core_device,
+                        coredynp.opt_local, coredynp.core_ty);
+    RFWIN->area.set_area(RFWIN->area.get_area() +
+                         RFWIN->local_result.area * coredynp.num_pipelines);
+    area.set_area(area.get_area() +
+                  RFWIN->local_result.area * coredynp.num_pipelines);
+    // output_data_csv(RFWIN.RF.local_result);
+  }
 }
 
-RENAMINGU::RENAMINGU(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_,bool exist_)
-:XML(XML_interface),
- ithCore(ithCore_),
- interface_ip(*interface_ip_),
- coredynp(dyn_p_),
- iFRAT(0),
- fFRAT(0),
- iRRAT(0),
- fRRAT(0),
- ifreeL(0),
- ffreeL(0),
- idcl(0),
- fdcl(0),
- RAHT(0),
- exist(exist_)
- {
-	/*
-	 * Although renaming logic maybe be used in in-order processors,
-     * McPAT assumes no renaming logic is used since the performance gain is very limited and
-     * the only major inorder processor with renaming logic is Itainium
-     * that is a VLIW processor and different from current McPAT's model.
-	 * physical register base OOO must have Dual-RAT architecture or equivalent structure.FRAT:FrontRAT, RRAT:RetireRAT;
-	 * i,f prefix mean int and fp
-	 * RAT for all Renaming logic, random accessible checkpointing is used, but only update when instruction retires.
-	 * FRAT will be read twice and written once per instruction;
-	 * RRAT will be write once per instruction when committing and reads out all when context switch
-	 * checkpointing is implicit
-	 * Renaming logic is duplicated for each different hardware threads
-	 *
-	 * No Dual-RAT is needed in RS-based OOO processors,
-	 * however, RAT needs to do associative search in RAT, when instruction commits and ROB release the entry,
-	 * to make sure all the renamings associated with the ROB to be released are updated at the same time.
-	 * RAM scheme has # ARchi Reg entry with each entry hold phy reg tag,
-	 * CAM scheme has # Phy Reg entry with each entry hold ARchi reg tag,
-	 *
-	 * Both RAM and CAM have same DCL
-	 */
-	if (!exist) return;
-	int  tag, data, out_w;
-//	interface_ip.wire_is_mat_type = 0;
-//	interface_ip.wire_os_mat_type = 0;
-//	interface_ip.wt               = Global_30;
-	clockRate = coredynp.clockRate;
-	executionTime = coredynp.executionTime;
-    if (coredynp.core_ty==OOO)
-    {
-	//integer pipeline
-	if (coredynp.scheu_ty==PhysicalRegFile)
-	{
-		if (coredynp.rm_ty ==RAMbased)
-		{	  //FRAT with global checkpointing (GCs) please see paper tech report for detailed explaintions
-			data							 = 33;//int(ceil(coredynp.phy_ireg_width*(1+coredynp.globalCheckpoint)/8.0));
-//			data							 = int(ceil(coredynp.phy_ireg_width/8.0));
-			out_w                            = 1;//int(ceil(coredynp.phy_ireg_width/8.0));
-			interface_ip.is_cache			 = false;
-			interface_ip.pure_cam            = false;
-			interface_ip.pure_ram            = true;
-			interface_ip.line_sz             = data;
-			interface_ip.cache_sz            = data*XML->sys.core[ithCore].archi_Regs_IRF_size;
-			interface_ip.assoc               = 1;
-			interface_ip.nbanks              = 1;
-			interface_ip.out_w               = out_w*8;
-			interface_ip.access_mode         = 2;
-			interface_ip.throughput          = 1.0/clockRate;
-			interface_ip.latency             = 1.0/clockRate;
-			interface_ip.obj_func_dyn_energy = 0;
-			interface_ip.obj_func_dyn_power  = 0;
-			interface_ip.obj_func_leak_power = 0;
-			interface_ip.obj_func_cycle_t    = 1;
-			interface_ip.num_rw_ports    = 1;//the extra one port is for GCs
-			interface_ip.num_rd_ports    = 2*coredynp.decodeW;
-			interface_ip.num_wr_ports    = coredynp.decodeW;
-			interface_ip.num_se_rd_ports = 0;
-			iFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
-			iFRAT->area.set_area(iFRAT->area.get_area()+ iFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
-			area.set_area(area.get_area()+ iFRAT->area.get_area());
+EXECU::EXECU(ParseXML* XML_interface, int ithCore_,
+             InputParameter* interface_ip_, double lsq_height_,
+             const CoreDynParam& dyn_p_, double exClockRate, bool exist_)
+    : XML(XML_interface),
+      ithCore(ithCore_),
+      interface_ip(*interface_ip_),
+      lsq_height(lsq_height_),
+      coredynp(dyn_p_),
+      rfu(0),
+      scheu(0),
+      fp_u(0),
+      exeu(0),
+      mul(0),
+      int_bypass(0),
+      intTagBypass(0),
+      int_mul_bypass(0),
+      intTag_mul_Bypass(0),
+      fp_bypass(0),
+      fpTagBypass(0),
+      exist(exist_),
+      rf_fu_clockRate(exClockRate) {
+  if (!exist) return;
+  double fu_height = 0.0;
+  clockRate = coredynp.clockRate;
+  // cout <<"EXECU exClockRate: "<<exClockRate<<endl;
+  executionTime = coredynp.executionTime;
+  rfu = new RegFU(XML, ithCore, &interface_ip, coredynp, exClockRate);
+  scheu = new SchedulerU(XML, ithCore, &interface_ip, coredynp);
+  exeu = new FunctionalUnit(XML, ithCore, &interface_ip, coredynp, ALU,
+                            exClockRate);
+  area.set_area(area.get_area() + exeu->area.get_area() + rfu->area.get_area() +
+                scheu->area.get_area());
+  fu_height = exeu->FU_height;
+  if (coredynp.num_fpus > 0) {
+    fp_u = new FunctionalUnit(XML, ithCore, &interface_ip, coredynp, FPU,
+                              exClockRate);
+    area.set_area(area.get_area() + fp_u->area.get_area());
+  }
+  if (coredynp.num_muls > 0) {
+    mul = new FunctionalUnit(XML, ithCore, &interface_ip, coredynp, MUL,
+                             exClockRate);
+    area.set_area(area.get_area() + mul->area.get_area());
+    fu_height += mul->FU_height;
+  }
+  /*
+   * broadcast logic, including int-broadcast; int_tag-broadcast; fp-broadcast;
+   * fp_tag-broadcast
+   * integer by pass has two paths and fp has 3 paths.
+   * on the same bus there are multiple tri-state drivers and muxes that go to
+   * different components on the same bus
+   */
+  if (XML->sys.Embedded) {
+    interface_ip.wt = Global_30;
+    interface_ip.wire_is_mat_type = 0;
+    interface_ip.wire_os_mat_type = 0;
+    interface_ip.throughput = 1.0 / clockRate;
+    interface_ip.latency = 1.0 / clockRate;
+  } else {
+    interface_ip.wt = Global;
+    interface_ip.wire_is_mat_type =
+        2;  // start from semi-global since local wires are already used
+    interface_ip.wire_os_mat_type = 2;
+    interface_ip.throughput = 10.0 / clockRate;  // Do not care
+    interface_ip.latency = 10.0 / clockRate;
+  }
 
-//			//RAHT According to Intel, combine GC with FRAT is very costly.
-//			data							 = int(ceil(coredynp.phy_ireg_width/8.0)*coredynp.num_IRF_entry);
-//			out_w                            = data;
-//			interface_ip.is_cache			 = false;
-//			interface_ip.pure_cam            = false;
-//			interface_ip.pure_ram            = true;
-//			interface_ip.line_sz             = data;
-//			interface_ip.cache_sz            = data*coredynp.globalCheckpoint;
-//			interface_ip.assoc               = 1;
-//			interface_ip.nbanks              = 1;
-//			interface_ip.out_w               = out_w*8;
-//			interface_ip.access_mode         = 0;
-//			interface_ip.throughput          = 1.0/clockRate;
-//			interface_ip.latency             = 1.0/clockRate;
-//			interface_ip.obj_func_dyn_energy = 0;
-//			interface_ip.obj_func_dyn_power  = 0;
-//			interface_ip.obj_func_leak_power = 0;
-//			interface_ip.obj_func_cycle_t    = 1;
-//			interface_ip.num_rw_ports    = 1;//the extra one port is for GCs
-//			interface_ip.num_rd_ports    = 2*coredynp.decodeW;
-//			interface_ip.num_wr_ports    = coredynp.decodeW;
-//			interface_ip.num_se_rd_ports = 0;
-//			iFRAT = new ArrayST(&interface_ip, "Int FrontRAT");
-//			iFRAT->area.set_area(iFRAT->area.get_area()+ iFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
-//			area.set_area(area.get_area()+ iFRAT->area.get_area());
+  if (coredynp.core_ty == Inorder) {  //
+    int_bypass = new interconnect(
+        "Int Bypass Data", Core_device, 1, 1,
+        int(ceil(XML->sys.machine_bits / 32.0) * 32),
+        rfu->int_regfile_height + exeu->FU_height + lsq_height, &interface_ip,
+        3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+    bypass.area.set_area(bypass.area.get_area() + int_bypass->area.get_area());
+    intTagBypass = new interconnect(
+        "Int Bypass tag", Core_device, 1, 1, coredynp.perThreadState,
+        rfu->int_regfile_height + exeu->FU_height + lsq_height +
+            scheu->Iw_height,
+        &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+    bypass.area.set_area(bypass.area.get_area() +
+                         intTagBypass->area.get_area());
 
-			//FRAT floating point
-			data							 = int(ceil(coredynp.phy_freg_width*(1+coredynp.globalCheckpoint)/8.0));
-			out_w                            = int(ceil(coredynp.phy_freg_width/8.0));
-			interface_ip.is_cache			 = false;
-			interface_ip.pure_cam            = false;
-			interface_ip.pure_ram            = true;
-			interface_ip.line_sz             = data;
-			interface_ip.cache_sz            = data*XML->sys.core[ithCore].archi_Regs_FRF_size;
-			interface_ip.assoc               = 1;
-			interface_ip.nbanks              = 1;
-			interface_ip.out_w               = out_w*8;
-			interface_ip.access_mode         = 2;
-			interface_ip.throughput          = 1.0/clockRate;
-			interface_ip.latency             = 1.0/clockRate;
-			interface_ip.obj_func_dyn_energy = 0;
-			interface_ip.obj_func_dyn_power  = 0;
-			interface_ip.obj_func_leak_power = 0;
-			interface_ip.obj_func_cycle_t    = 1;
-			interface_ip.num_rw_ports    = 1;//the extra one port is for GCs
-			interface_ip.num_rd_ports    = 2*coredynp.fp_decodeW;
-			interface_ip.num_wr_ports    = coredynp.fp_decodeW;
-			interface_ip.num_se_rd_ports = 0;
-			fFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
-			fFRAT->area.set_area(fFRAT->area.get_area()+ fFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
-			area.set_area(area.get_area()+ fFRAT->area.get_area());
-
-		}
-		else if ((coredynp.rm_ty ==CAMbased))
-		{
-			//FRAT
-			tag							     = coredynp.arch_ireg_width;
-			data							 = int(ceil ((coredynp.arch_ireg_width+1*coredynp.globalCheckpoint)/8.0));//the address of CAM needed to be sent out
-			out_w                            = int(ceil (coredynp.arch_ireg_width/8.0));
-			interface_ip.is_cache			 = true;
-			interface_ip.pure_cam            = false;
-			interface_ip.pure_ram            = false;
-			interface_ip.line_sz             = data;
-			interface_ip.cache_sz            = data*XML->sys.core[ithCore].phy_Regs_IRF_size;
-			interface_ip.assoc               = 0;
-			interface_ip.nbanks              = 1;
-			interface_ip.out_w               = out_w*8;
-			interface_ip.specific_tag        = 1;
-			interface_ip.tag_w               = tag;
-			interface_ip.access_mode         = 2;
-			interface_ip.throughput          = 1.0/clockRate;
-			interface_ip.latency             = 1.0/clockRate;
-			interface_ip.obj_func_dyn_energy = 0;
-			interface_ip.obj_func_dyn_power  = 0;
-			interface_ip.obj_func_leak_power = 0;
-			interface_ip.obj_func_cycle_t    = 1;
-			interface_ip.num_rw_ports    = 1;//for GCs
-			interface_ip.num_rd_ports    = coredynp.decodeW;
-			interface_ip.num_wr_ports    = coredynp.decodeW;
-			interface_ip.num_se_rd_ports = 0;
-			interface_ip.num_search_ports= 2*coredynp.decodeW;
-			iFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
-			iFRAT->area.set_area(iFRAT->area.get_area()+ iFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
-			area.set_area(area.get_area()+ iFRAT->area.get_area());
-
-			//FRAT for FP
-			tag							     = coredynp.arch_freg_width;
-			data							 = int(ceil ((coredynp.arch_freg_width+1*coredynp.globalCheckpoint)/8.0));//the address of CAM needed to be sent out
-			out_w                            = int(ceil (coredynp.arch_freg_width/8.0));
-			interface_ip.is_cache			 = true;
-			interface_ip.pure_cam            = false;
-			interface_ip.pure_ram            = false;
-			interface_ip.line_sz             = data;
-			interface_ip.cache_sz            = data*XML->sys.core[ithCore].phy_Regs_FRF_size;
-			interface_ip.assoc               = 0;
-			interface_ip.nbanks              = 1;
-			interface_ip.out_w               = out_w*8;
-			interface_ip.specific_tag        = 1;
-			interface_ip.tag_w               = tag;
-			interface_ip.access_mode         = 2;
-			interface_ip.throughput          = 1.0/clockRate;
-			interface_ip.latency             = 1.0/clockRate;
-			interface_ip.obj_func_dyn_energy = 0;
-			interface_ip.obj_func_dyn_power  = 0;
-			interface_ip.obj_func_leak_power = 0;
-			interface_ip.obj_func_cycle_t    = 1;
-			interface_ip.num_rw_ports    = 1;//for GCs
-			interface_ip.num_rd_ports    = coredynp.fp_decodeW;
-			interface_ip.num_wr_ports    = coredynp.fp_decodeW;
-			interface_ip.num_se_rd_ports = 0;
-			interface_ip.num_search_ports= 2*coredynp.fp_decodeW;
-			fFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
-			fFRAT->area.set_area(fFRAT->area.get_area()+ fFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
-			area.set_area(area.get_area()+ fFRAT->area.get_area());
-
-		}
-
-		//RRAT is always RAM based, does not have GCs, and is used only for record latest non-speculative mapping
-		data							 = int(ceil(coredynp.phy_ireg_width/8.0));
-		interface_ip.is_cache			 = false;
-		interface_ip.pure_cam            = false;
-		interface_ip.pure_ram            = true;
-		interface_ip.line_sz             = data;
-		interface_ip.cache_sz            = data*XML->sys.core[ithCore].archi_Regs_IRF_size*2;//HACK to make it as least 64B
-		interface_ip.assoc               = 1;
-		interface_ip.nbanks              = 1;
-		interface_ip.out_w               = interface_ip.line_sz*8;
-		interface_ip.access_mode         = 1;
-		interface_ip.throughput          = 1.0/clockRate;
-		interface_ip.latency             = 1.0/clockRate;
-		interface_ip.obj_func_dyn_energy = 0;
-		interface_ip.obj_func_dyn_power  = 0;
-		interface_ip.obj_func_leak_power = 0;
-		interface_ip.obj_func_cycle_t    = 1;
-		interface_ip.num_rw_ports    = 0;
-		interface_ip.num_rd_ports    = XML->sys.core[ithCore].commit_width;
-		interface_ip.num_wr_ports    = XML->sys.core[ithCore].commit_width;
-		interface_ip.num_se_rd_ports = 0;
-		iRRAT = new ArrayST(&interface_ip, "Int RetireRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
-		iRRAT->area.set_area(iRRAT->area.get_area()+ iRRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
-		area.set_area(area.get_area()+ iRRAT->area.get_area());
-
-		//RRAT for FP
-		data							 = int(ceil(coredynp.phy_freg_width/8.0));
-		interface_ip.is_cache			 = false;
-		interface_ip.pure_cam            = false;
-		interface_ip.pure_ram            = true;
-		interface_ip.line_sz             = data;
-		interface_ip.cache_sz            = data*XML->sys.core[ithCore].archi_Regs_FRF_size*2;//HACK to make it as least 64B
-		interface_ip.assoc               = 1;
-		interface_ip.nbanks              = 1;
-		interface_ip.out_w               = interface_ip.line_sz*8;
-		interface_ip.access_mode         = 1;
-		interface_ip.throughput          = 1.0/clockRate;
-		interface_ip.latency             = 1.0/clockRate;
-		interface_ip.obj_func_dyn_energy = 0;
-		interface_ip.obj_func_dyn_power  = 0;
-		interface_ip.obj_func_leak_power = 0;
-		interface_ip.obj_func_cycle_t    = 1;
-		interface_ip.num_rw_ports    = 0;
-		interface_ip.num_rd_ports    = coredynp.fp_decodeW;
-		interface_ip.num_wr_ports    = coredynp.fp_decodeW;
-		interface_ip.num_se_rd_ports = 0;
-		fRRAT = new ArrayST(&interface_ip, "Int RetireRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
-		fRRAT->area.set_area(fRRAT->area.get_area()+ fRRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
-		area.set_area(area.get_area()+ fRRAT->area.get_area());
-
-		//Freelist of renaming unit always RAM based
-		//Recycle happens at two places: 1)when DCL check there are WAW, the Phyregisters/ROB directly recycles into freelist
-		// 2)When instruction commits the Phyregisters/ROB needed to be recycled.
-		//therefore num_wr port = decode-1(-1 means at least one phy reg will be used for the current renaming group) + commit width
-		data							 = int(ceil(coredynp.phy_ireg_width/8.0));
-		interface_ip.is_cache			 = false;
-		interface_ip.pure_cam            = false;
-		interface_ip.pure_ram            = true;
-		interface_ip.line_sz             = data;
-		interface_ip.cache_sz            = data*coredynp.num_ifreelist_entries;
-		interface_ip.assoc               = 1;
-		interface_ip.nbanks              = 1;
-		interface_ip.out_w               = interface_ip.line_sz*8;
-		interface_ip.access_mode         = 1;
-		interface_ip.throughput          = 1.0/clockRate;
-		interface_ip.latency             = 1.0/clockRate;
-		interface_ip.obj_func_dyn_energy = 0;
-		interface_ip.obj_func_dyn_power  = 0;
-		interface_ip.obj_func_leak_power = 0;
-		interface_ip.obj_func_cycle_t    = 1;
-		interface_ip.num_rw_ports    = 1;//TODO
-		interface_ip.num_rd_ports    = coredynp.decodeW;
-		interface_ip.num_wr_ports    = coredynp.decodeW -1 + XML->sys.core[ithCore].commit_width;
-		//every cycle, (coredynp.decodeW -1) inst may need to send back it dest tags, committW insts needs to update freelist buffers
-		interface_ip.num_se_rd_ports = 0;
-		ifreeL = new ArrayST(&interface_ip, "Int Free List", Core_device, coredynp.opt_local, coredynp.core_ty);
-		ifreeL->area.set_area(ifreeL->area.get_area()+ ifreeL->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
-		area.set_area(area.get_area()+ ifreeL->area.get_area());
-
-		//freelist for FP
-		data							 = int(ceil(coredynp.phy_freg_width/8.0));
-		interface_ip.is_cache			 = false;
-		interface_ip.pure_cam            = false;
-		interface_ip.pure_ram            = true;
-		interface_ip.line_sz             = data;
-		interface_ip.cache_sz            = data*coredynp.num_ffreelist_entries;
-		interface_ip.assoc               = 1;
-		interface_ip.nbanks              = 1;
-		interface_ip.out_w               = interface_ip.line_sz*8;
-		interface_ip.access_mode         = 1;
-		interface_ip.throughput          = 1.0/clockRate;
-		interface_ip.latency             = 1.0/clockRate;
-		interface_ip.obj_func_dyn_energy = 0;
-		interface_ip.obj_func_dyn_power  = 0;
-		interface_ip.obj_func_leak_power = 0;
-		interface_ip.obj_func_cycle_t    = 1;
-		interface_ip.num_rw_ports    = 1;
-		interface_ip.num_rd_ports    = coredynp.fp_decodeW;
-		interface_ip.num_wr_ports    = coredynp.fp_decodeW -1 + XML->sys.core[ithCore].commit_width;
-		interface_ip.num_se_rd_ports = 0;
-		ffreeL = new ArrayST(&interface_ip, "Int Free List", Core_device, coredynp.opt_local, coredynp.core_ty);
-		ffreeL->area.set_area(ffreeL->area.get_area()+ ffreeL->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
-		area.set_area(area.get_area()+ ffreeL->area.get_area());
-
-		idcl  = new dep_resource_conflict_check(&interface_ip,coredynp,coredynp.phy_ireg_width);//TODO:Separate 2 sections See TR
-		fdcl  = new dep_resource_conflict_check(&interface_ip,coredynp,coredynp.phy_freg_width);
-
-	}
-	else if (coredynp.scheu_ty==ReservationStation){
-		if (coredynp.rm_ty ==RAMbased){
-			/*
-			 * however, RAT needs to do associative search in RAT, when instruction commits and ROB release the entry,
-			 * to make sure all the renamings associated with the ROB to be released are updated to ARF at the same time.
-			 * RAM based RAT for RS base OOO does not save the search operations. Its advantage is to have less entries than
-			 * CAM based RAT so that it is more scalable as number of ROB/physical regs increases.
-			 */
-			tag							     = coredynp.phy_ireg_width;
-			data							 = int(ceil(coredynp.phy_ireg_width*(1+coredynp.globalCheckpoint)/8.0));
-			out_w                            = int(ceil(coredynp.phy_ireg_width/8.0));
-			interface_ip.is_cache			 = true;
-			interface_ip.pure_cam            = false;
-			interface_ip.pure_ram            = false;
-			interface_ip.line_sz             = data;
-			interface_ip.cache_sz            = data*XML->sys.core[ithCore].archi_Regs_IRF_size;
-			interface_ip.assoc               = 0;
-			interface_ip.nbanks              = 1;
-			interface_ip.out_w               = out_w*8;
-			interface_ip.access_mode         = 2;
-			interface_ip.throughput          = 1.0/clockRate;
-			interface_ip.latency             = 1.0/clockRate;
-			interface_ip.obj_func_dyn_energy = 0;
-			interface_ip.obj_func_dyn_power  = 0;
-			interface_ip.obj_func_leak_power = 0;
-			interface_ip.obj_func_cycle_t    = 1;
-			interface_ip.num_rw_ports    = 1;//the extra one port is for GCs
-			interface_ip.num_rd_ports    = 2*coredynp.decodeW;
-			interface_ip.num_wr_ports    = coredynp.decodeW;
-			interface_ip.num_se_rd_ports = 0;
-			interface_ip.num_search_ports= coredynp.commitW;//TODO
-			iFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
-			iFRAT->local_result.adjust_area();
-			iFRAT->area.set_area(iFRAT->area.get_area()+ iFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
-			area.set_area(area.get_area()+ iFRAT->area.get_area());
-
-			//FP
-			tag							     = coredynp.phy_freg_width;
-			data							 = int(ceil(coredynp.phy_freg_width*(1+coredynp.globalCheckpoint)/8.0));
-			out_w                            = int(ceil(coredynp.phy_freg_width/8.0));
-			interface_ip.is_cache			 = true;
-			interface_ip.pure_cam            = false;
-			interface_ip.pure_ram            = false;
-			interface_ip.line_sz             = data;
-			interface_ip.cache_sz            = data*XML->sys.core[ithCore].archi_Regs_FRF_size;
-			interface_ip.assoc               = 0;
-			interface_ip.nbanks              = 1;
-			interface_ip.out_w               = out_w*8;
-			interface_ip.access_mode         = 2;
-			interface_ip.throughput          = 1.0/clockRate;
-			interface_ip.latency             = 1.0/clockRate;
-			interface_ip.obj_func_dyn_energy = 0;
-			interface_ip.obj_func_dyn_power  = 0;
-			interface_ip.obj_func_leak_power = 0;
-			interface_ip.obj_func_cycle_t    = 1;
-			interface_ip.num_rw_ports    = 1;//the extra one port is for GCs
-			interface_ip.num_rd_ports    = 2*coredynp.fp_decodeW;
-			interface_ip.num_wr_ports    = coredynp.fp_decodeW;
-			interface_ip.num_se_rd_ports = 0;
-			interface_ip.num_search_ports= coredynp.fp_decodeW;//actually is fp commit width
-			fFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
-			fFRAT->local_result.adjust_area();
-			fFRAT->area.set_area(fFRAT->area.get_area()+ fFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
-			area.set_area(area.get_area()+ fFRAT->area.get_area());
-
-		}
-		else if ((coredynp.rm_ty ==CAMbased))
-		{
-			//FRAT
-			tag							     = coredynp.arch_ireg_width;
-			data							 = int(ceil (coredynp.arch_ireg_width+1*coredynp.globalCheckpoint/8.0));//the address of CAM needed to be sent out
-			out_w                            = int(ceil (coredynp.arch_ireg_width/8.0));
-			interface_ip.is_cache			 = true;
-			interface_ip.pure_cam            = false;
-			interface_ip.pure_ram            = false;
-			interface_ip.line_sz             = data;
-			interface_ip.cache_sz            = data*XML->sys.core[ithCore].phy_Regs_IRF_size;
-			interface_ip.assoc               = 0;
-			interface_ip.nbanks              = 1;
-			interface_ip.out_w               = out_w*8;
-			interface_ip.specific_tag        = 1;
-			interface_ip.tag_w               = tag;
-			interface_ip.access_mode         = 2;
-			interface_ip.throughput          = 1.0/clockRate;
-			interface_ip.latency             = 1.0/clockRate;
-			interface_ip.obj_func_dyn_energy = 0;
-			interface_ip.obj_func_dyn_power  = 0;
-			interface_ip.obj_func_leak_power = 0;
-			interface_ip.obj_func_cycle_t    = 1;
-			interface_ip.num_rw_ports    = 1;//for GCs
-			interface_ip.num_rd_ports    = XML->sys.core[ithCore].decode_width;//0;TODO
-			interface_ip.num_wr_ports    = XML->sys.core[ithCore].decode_width;
-			interface_ip.num_se_rd_ports = 0;
-			interface_ip.num_search_ports= 2*XML->sys.core[ithCore].decode_width;
-			iFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
-			iFRAT->area.set_area(iFRAT->area.get_area()+ iFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
-			area.set_area(area.get_area()+ iFRAT->area.get_area());
-
-			//FRAT
-			tag							     = coredynp.arch_freg_width;
-			data							 = int(ceil (coredynp.arch_freg_width+1*coredynp.globalCheckpoint/8.0));//the address of CAM needed to be sent out
-			out_w                            = int(ceil (coredynp.arch_freg_width/8.0));
-			interface_ip.is_cache			 = true;
-			interface_ip.pure_cam            = false;
-			interface_ip.pure_ram            = false;
-			interface_ip.line_sz             = data;
-			interface_ip.cache_sz            = data*XML->sys.core[ithCore].phy_Regs_FRF_size;
-			interface_ip.assoc               = 0;
-			interface_ip.nbanks              = 1;
-			interface_ip.out_w               = out_w*8;
-			interface_ip.specific_tag        = 1;
-			interface_ip.tag_w               = tag;
-			interface_ip.access_mode         = 2;
-			interface_ip.throughput          = 1.0/clockRate;
-			interface_ip.latency             = 1.0/clockRate;
-			interface_ip.obj_func_dyn_energy = 0;
-			interface_ip.obj_func_dyn_power  = 0;
-			interface_ip.obj_func_leak_power = 0;
-			interface_ip.obj_func_cycle_t    = 1;
-			interface_ip.num_rw_ports    = 1;//for GCs
-			interface_ip.num_rd_ports    = XML->sys.core[ithCore].decode_width;//0;TODO;
-			interface_ip.num_wr_ports    = coredynp.fp_decodeW;
-			interface_ip.num_se_rd_ports = 0;
-			interface_ip.num_search_ports= 2*coredynp.fp_decodeW;
-			fFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device, coredynp.opt_local, coredynp.core_ty);
-			fFRAT->area.set_area(fFRAT->area.get_area()+ fFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
-			area.set_area(area.get_area()+ fFRAT->area.get_area());
-
-		}
-		//No RRAT for RS based OOO
-		//Freelist of renaming unit of RS based OOO is unifed for both int and fp renaming unit since the ROB is unified
-		data							 = int(ceil(coredynp.phy_ireg_width/8.0));
-		interface_ip.is_cache			 = false;
-		interface_ip.pure_cam            = false;
-		interface_ip.pure_ram            = true;
-		interface_ip.line_sz             = data;
-		interface_ip.cache_sz            = data*coredynp.num_ifreelist_entries;
-		interface_ip.assoc               = 1;
-		interface_ip.nbanks              = 1;
-		interface_ip.out_w               = interface_ip.line_sz*8;
-		interface_ip.access_mode         = 1;
-		interface_ip.throughput          = 1.0/clockRate;
-		interface_ip.latency             = 1.0/clockRate;
-		interface_ip.obj_func_dyn_energy = 0;
-		interface_ip.obj_func_dyn_power  = 0;
-		interface_ip.obj_func_leak_power = 0;
-		interface_ip.obj_func_cycle_t    = 1;
-		interface_ip.num_rw_ports    = 1;//TODO
-		interface_ip.num_rd_ports    = XML->sys.core[ithCore].decode_width;
-		interface_ip.num_wr_ports    = XML->sys.core[ithCore].decode_width -1 + XML->sys.core[ithCore].commit_width;
-		interface_ip.num_se_rd_ports = 0;
-		ifreeL = new ArrayST(&interface_ip, "Unified Free List", Core_device, coredynp.opt_local, coredynp.core_ty);
-		ifreeL->area.set_area(ifreeL->area.get_area()+ ifreeL->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
-		area.set_area(area.get_area()+ ifreeL->area.get_area());
-
-		idcl  = new dep_resource_conflict_check(&interface_ip,coredynp,coredynp.phy_ireg_width);//TODO:Separate 2 sections See TR
-		fdcl  = new dep_resource_conflict_check(&interface_ip,coredynp,coredynp.phy_freg_width);
-	}
-
-}
-    if (coredynp.core_ty==Inorder&& coredynp.issueW>1)
-    {
-	  /* Dependency check logic will only present when decode(issue) width>1.
-	  *  Multiple issue in order processor can do without renaming, but dcl is a must.
-	  */
-	idcl  = new dep_resource_conflict_check(&interface_ip,coredynp,coredynp.phy_ireg_width);//TODO:Separate 2 sections See TR
-	fdcl  = new dep_resource_conflict_check(&interface_ip,coredynp,coredynp.phy_freg_width);
+    if (coredynp.num_muls > 0) {
+      int_mul_bypass = new interconnect(
+          "Mul Bypass Data", Core_device, 1, 1,
+          int(ceil(XML->sys.machine_bits / 32.0) * 32 * 1.5),
+          rfu->fp_regfile_height + exeu->FU_height + mul->FU_height +
+              lsq_height,
+          &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+      bypass.area.set_area(bypass.area.get_area() +
+                           int_mul_bypass->area.get_area());
+      intTag_mul_Bypass = new interconnect(
+          "Mul Bypass tag", Core_device, 1, 1, coredynp.perThreadState,
+          rfu->fp_regfile_height + exeu->FU_height + mul->FU_height +
+              lsq_height + scheu->Iw_height,
+          &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+      bypass.area.set_area(bypass.area.get_area() +
+                           intTag_mul_Bypass->area.get_area());
     }
+
+    /*
+    if (coredynp.num_fpus>0)
+    {
+            fp_bypass    = new interconnect("FP Bypass Data" , Core_device, 1,
+    1, int(ceil(XML->sys.machine_bits/32.0)*32*1.5),
+                            rfu->fp_regfile_height + fp_u->FU_height,
+    &interface_ip, 3,
+                            false, 1.0, coredynp.opt_local, coredynp.core_ty);
+            bypass.area.set_area(bypass.area.get_area()
+    +fp_bypass->area.get_area());
+            fpTagBypass  = new interconnect("FP Bypass tag"  , Core_device, 1,
+    1, coredynp.perThreadState,
+                            rfu->fp_regfile_height + fp_u->FU_height +
+    lsq_height + scheu->Iw_height, &interface_ip, 3,
+                            false, 1.0, coredynp.opt_local, coredynp.core_ty);
+            bypass.area.set_area(bypass.area.get_area()
+    +fpTagBypass->area.get_area());
+    }*/
+  }       /* if (coredynp.core_ty==Inorder) */
+  else {  // OOO
+    if (coredynp.scheu_ty == PhysicalRegFile) {
+      /* For physical register based OOO,
+       * data broadcast interconnects cover across functional units, lsq, inst
+       * windows and register files,
+       * while tag broadcast interconnects also cover across ROB
+       */
+      int_bypass = new interconnect(
+          "Int Bypass Data", Core_device, 1, 1,
+          int(ceil(coredynp.int_data_width)),
+          rfu->int_regfile_height + exeu->FU_height + lsq_height, &interface_ip,
+          3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+      bypass.area.set_area(bypass.area.get_area() +
+                           int_bypass->area.get_area());
+      intTagBypass = new interconnect(
+          "Int Bypass tag", Core_device, 1, 1, coredynp.phy_ireg_width,
+          rfu->int_regfile_height + exeu->FU_height + lsq_height +
+              scheu->Iw_height + scheu->ROB_height,
+          &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+
+      if (coredynp.num_muls > 0) {
+        int_mul_bypass = new interconnect(
+            "Mul Bypass Data", Core_device, 1, 1,
+            int(ceil(coredynp.int_data_width)),
+            rfu->int_regfile_height + exeu->FU_height + mul->FU_height +
+                lsq_height,
+            &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+        intTag_mul_Bypass = new interconnect(
+            "Mul Bypass tag", Core_device, 1, 1, coredynp.phy_ireg_width,
+            rfu->int_regfile_height + exeu->FU_height + mul->FU_height +
+                lsq_height + scheu->Iw_height + scheu->ROB_height,
+            &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+        bypass.area.set_area(bypass.area.get_area() +
+                             int_mul_bypass->area.get_area());
+        bypass.area.set_area(bypass.area.get_area() +
+                             intTag_mul_Bypass->area.get_area());
+      }
+
+      if (coredynp.num_fpus > 0) {
+        fp_bypass = new interconnect("FP Bypass Data", Core_device, 1, 1,
+                                     int(ceil(coredynp.fp_data_width)),
+                                     rfu->fp_regfile_height + fp_u->FU_height,
+                                     &interface_ip, 3, false, 1.0,
+                                     coredynp.opt_local, coredynp.core_ty);
+        fpTagBypass = new interconnect(
+            "FP Bypass tag", Core_device, 1, 1, coredynp.phy_freg_width,
+            rfu->fp_regfile_height + fp_u->FU_height + lsq_height +
+                scheu->fp_Iw_height + scheu->ROB_height,
+            &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+        bypass.area.set_area(bypass.area.get_area() +
+                             fp_bypass->area.get_area());
+        bypass.area.set_area(bypass.area.get_area() +
+                             fpTagBypass->area.get_area());
+      }
+    } else {
+      /*
+       * In RS based processor both data and tag are broadcast together,
+       * covering functional units, lsq, nst windows, register files, and ROBs
+       */
+      int_bypass = new interconnect(
+          "Int Bypass Data", Core_device, 1, 1,
+          int(ceil(coredynp.int_data_width)),
+          rfu->int_regfile_height + exeu->FU_height + lsq_height +
+              scheu->Iw_height + scheu->ROB_height,
+          &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+      intTagBypass = new interconnect(
+          "Int Bypass tag", Core_device, 1, 1, coredynp.phy_ireg_width,
+          rfu->int_regfile_height + exeu->FU_height + lsq_height +
+              scheu->Iw_height + scheu->ROB_height,
+          &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+      bypass.area.set_area(bypass.area.get_area() +
+                           int_bypass->area.get_area());
+      bypass.area.set_area(bypass.area.get_area() +
+                           intTagBypass->area.get_area());
+      if (coredynp.num_muls > 0) {
+        int_mul_bypass = new interconnect(
+            "Mul Bypass Data", Core_device, 1, 1,
+            int(ceil(coredynp.int_data_width)),
+            rfu->int_regfile_height + exeu->FU_height + mul->FU_height +
+                lsq_height + scheu->Iw_height + scheu->ROB_height,
+            &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+        intTag_mul_Bypass = new interconnect(
+            "Mul Bypass tag", Core_device, 1, 1, coredynp.phy_ireg_width,
+            rfu->int_regfile_height + exeu->FU_height + mul->FU_height +
+                lsq_height + scheu->Iw_height + scheu->ROB_height,
+            &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+        bypass.area.set_area(bypass.area.get_area() +
+                             int_mul_bypass->area.get_area());
+        bypass.area.set_area(bypass.area.get_area() +
+                             intTag_mul_Bypass->area.get_area());
+      }
+
+      if (coredynp.num_fpus > 0) {
+        fp_bypass = new interconnect(
+            "FP Bypass Data", Core_device, 1, 1,
+            int(ceil(coredynp.fp_data_width)),
+            rfu->fp_regfile_height + fp_u->FU_height + lsq_height +
+                scheu->fp_Iw_height + scheu->ROB_height,
+            &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+        fpTagBypass = new interconnect(
+            "FP Bypass tag", Core_device, 1, 1, coredynp.phy_freg_width,
+            rfu->fp_regfile_height + fp_u->FU_height + lsq_height +
+                scheu->fp_Iw_height + scheu->ROB_height,
+            &interface_ip, 3, false, 1.0, coredynp.opt_local, coredynp.core_ty);
+        bypass.area.set_area(bypass.area.get_area() +
+                             fp_bypass->area.get_area());
+        bypass.area.set_area(bypass.area.get_area() +
+                             fpTagBypass->area.get_area());
+      }
+    } /* else */
+
+  } /* else */
+  area.set_area(area.get_area() /*+ bypass.area.get_area()*/);
+}
+
+RENAMINGU::RENAMINGU(ParseXML* XML_interface, int ithCore_,
+                     InputParameter* interface_ip_, const CoreDynParam& dyn_p_,
+                     bool exist_)
+    : XML(XML_interface),
+      ithCore(ithCore_),
+      interface_ip(*interface_ip_),
+      coredynp(dyn_p_),
+      iFRAT(0),
+      fFRAT(0),
+      iRRAT(0),
+      fRRAT(0),
+      ifreeL(0),
+      ffreeL(0),
+      idcl(0),
+      fdcl(0),
+      RAHT(0),
+      exist(exist_) {
+  /*
+   * Although renaming logic maybe be used in in-order processors,
+*McPAT assumes no renaming logic is used since the performance gain is very
+* limited and
+*the only major inorder processor with renaming logic is Itainium
+*that is a VLIW processor and different from current McPAT's model.
+   * physical register base OOO must have Dual-RAT architecture or equivalent
+* structure.FRAT:FrontRAT, RRAT:RetireRAT;
+   * i,f prefix mean int and fp
+   * RAT for all Renaming logic, random accessible checkpointing is used, but
+* only update when instruction retires.
+   * FRAT will be read twice and written once per instruction;
+   * RRAT will be write once per instruction when committing and reads out all
+* when context switch
+   * checkpointing is implicit
+   * Renaming logic is duplicated for each different hardware threads
+   *
+   * No Dual-RAT is needed in RS-based OOO processors,
+   * however, RAT needs to do associative search in RAT, when instruction
+* commits and ROB release the entry,
+   * to make sure all the renamings associated with the ROB to be released are
+* updated at the same time.
+   * RAM scheme has # ARchi Reg entry with each entry hold phy reg tag,
+   * CAM scheme has # Phy Reg entry with each entry hold ARchi reg tag,
+   *
+   * Both RAM and CAM have same DCL
+   */
+  if (!exist) return;
+  int tag, data, out_w;
+  //	interface_ip.wire_is_mat_type = 0;
+  //	interface_ip.wire_os_mat_type = 0;
+  //	interface_ip.wt               = Global_30;
+  clockRate = coredynp.clockRate;
+  executionTime = coredynp.executionTime;
+  if (coredynp.core_ty == OOO) {
+    // integer pipeline
+    if (coredynp.scheu_ty == PhysicalRegFile) {
+      if (coredynp.rm_ty == RAMbased) {  // FRAT with global checkpointing (GCs)
+                                         // please see paper tech report for
+                                         // detailed explaintions
+        data =
+            33;  // int(ceil(coredynp.phy_ireg_width*(1+coredynp.globalCheckpoint)/8.0));
+        //			data							 =
+        //int(ceil(coredynp.phy_ireg_width/8.0));
+        out_w = 1;  // int(ceil(coredynp.phy_ireg_width/8.0));
+        interface_ip.is_cache = false;
+        interface_ip.pure_cam = false;
+        interface_ip.pure_ram = true;
+        interface_ip.line_sz = data;
+        interface_ip.cache_sz =
+            data * XML->sys.core[ithCore].archi_Regs_IRF_size;
+        interface_ip.assoc = 1;
+        interface_ip.nbanks = 1;
+        interface_ip.out_w = out_w * 8;
+        interface_ip.access_mode = 2;
+        interface_ip.throughput = 1.0 / clockRate;
+        interface_ip.latency = 1.0 / clockRate;
+        interface_ip.obj_func_dyn_energy = 0;
+        interface_ip.obj_func_dyn_power = 0;
+        interface_ip.obj_func_leak_power = 0;
+        interface_ip.obj_func_cycle_t = 1;
+        interface_ip.num_rw_ports = 1;  // the extra one port is for GCs
+        interface_ip.num_rd_ports = 2 * coredynp.decodeW;
+        interface_ip.num_wr_ports = coredynp.decodeW;
+        interface_ip.num_se_rd_ports = 0;
+        iFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device,
+                            coredynp.opt_local, coredynp.core_ty);
+        iFRAT->area.set_area(
+            iFRAT->area.get_area() +
+            iFRAT->local_result.area *
+                XML->sys.core[ithCore].number_hardware_threads);
+        area.set_area(area.get_area() + iFRAT->area.get_area());
+
+        //			//RAHT According to Intel, combine GC with FRAT is
+        //very costly.
+        //			data							 =
+        //int(ceil(coredynp.phy_ireg_width/8.0)*coredynp.num_IRF_entry);
+        //			out_w                            = data;
+        //			interface_ip.is_cache			 =
+        //false;
+        //			interface_ip.pure_cam            = false;
+        //			interface_ip.pure_ram            = true;
+        //			interface_ip.line_sz             = data;
+        //			interface_ip.cache_sz            =
+        //data*coredynp.globalCheckpoint;
+        //			interface_ip.assoc               = 1;
+        //			interface_ip.nbanks              = 1;
+        //			interface_ip.out_w               = out_w*8;
+        //			interface_ip.access_mode         = 0;
+        //			interface_ip.throughput          =
+        //1.0/clockRate;
+        //			interface_ip.latency             =
+        //1.0/clockRate;
+        //			interface_ip.obj_func_dyn_energy = 0;
+        //			interface_ip.obj_func_dyn_power  = 0;
+        //			interface_ip.obj_func_leak_power = 0;
+        //			interface_ip.obj_func_cycle_t    = 1;
+        //			interface_ip.num_rw_ports    = 1;//the extra one
+        //port is for GCs
+        //			interface_ip.num_rd_ports    =
+        //2*coredynp.decodeW;
+        //			interface_ip.num_wr_ports    = coredynp.decodeW;
+        //			interface_ip.num_se_rd_ports = 0;
+        //			iFRAT = new ArrayST(&interface_ip, "Int
+        //FrontRAT");
+        //			iFRAT->area.set_area(iFRAT->area.get_area()+
+        //iFRAT->local_result.area*XML->sys.core[ithCore].number_hardware_threads);
+        //			area.set_area(area.get_area()+
+        //iFRAT->area.get_area());
+
+        // FRAT floating point
+        data = int(ceil(coredynp.phy_freg_width *
+                        (1 + coredynp.globalCheckpoint) / 8.0));
+        out_w = int(ceil(coredynp.phy_freg_width / 8.0));
+        interface_ip.is_cache = false;
+        interface_ip.pure_cam = false;
+        interface_ip.pure_ram = true;
+        interface_ip.line_sz = data;
+        interface_ip.cache_sz =
+            data * XML->sys.core[ithCore].archi_Regs_FRF_size;
+        interface_ip.assoc = 1;
+        interface_ip.nbanks = 1;
+        interface_ip.out_w = out_w * 8;
+        interface_ip.access_mode = 2;
+        interface_ip.throughput = 1.0 / clockRate;
+        interface_ip.latency = 1.0 / clockRate;
+        interface_ip.obj_func_dyn_energy = 0;
+        interface_ip.obj_func_dyn_power = 0;
+        interface_ip.obj_func_leak_power = 0;
+        interface_ip.obj_func_cycle_t = 1;
+        interface_ip.num_rw_ports = 1;  // the extra one port is for GCs
+        interface_ip.num_rd_ports = 2 * coredynp.fp_decodeW;
+        interface_ip.num_wr_ports = coredynp.fp_decodeW;
+        interface_ip.num_se_rd_ports = 0;
+        fFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device,
+                            coredynp.opt_local, coredynp.core_ty);
+        fFRAT->area.set_area(
+            fFRAT->area.get_area() +
+            fFRAT->local_result.area *
+                XML->sys.core[ithCore].number_hardware_threads);
+        area.set_area(area.get_area() + fFRAT->area.get_area());
+
+      } else if ((coredynp.rm_ty == CAMbased)) {
+        // FRAT
+        tag = coredynp.arch_ireg_width;
+        data = int(
+            ceil((coredynp.arch_ireg_width + 1 * coredynp.globalCheckpoint) /
+                 8.0));  // the address of CAM needed to be sent out
+        out_w = int(ceil(coredynp.arch_ireg_width / 8.0));
+        interface_ip.is_cache = true;
+        interface_ip.pure_cam = false;
+        interface_ip.pure_ram = false;
+        interface_ip.line_sz = data;
+        interface_ip.cache_sz = data * XML->sys.core[ithCore].phy_Regs_IRF_size;
+        interface_ip.assoc = 0;
+        interface_ip.nbanks = 1;
+        interface_ip.out_w = out_w * 8;
+        interface_ip.specific_tag = 1;
+        interface_ip.tag_w = tag;
+        interface_ip.access_mode = 2;
+        interface_ip.throughput = 1.0 / clockRate;
+        interface_ip.latency = 1.0 / clockRate;
+        interface_ip.obj_func_dyn_energy = 0;
+        interface_ip.obj_func_dyn_power = 0;
+        interface_ip.obj_func_leak_power = 0;
+        interface_ip.obj_func_cycle_t = 1;
+        interface_ip.num_rw_ports = 1;  // for GCs
+        interface_ip.num_rd_ports = coredynp.decodeW;
+        interface_ip.num_wr_ports = coredynp.decodeW;
+        interface_ip.num_se_rd_ports = 0;
+        interface_ip.num_search_ports = 2 * coredynp.decodeW;
+        iFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device,
+                            coredynp.opt_local, coredynp.core_ty);
+        iFRAT->area.set_area(
+            iFRAT->area.get_area() +
+            iFRAT->local_result.area *
+                XML->sys.core[ithCore].number_hardware_threads);
+        area.set_area(area.get_area() + iFRAT->area.get_area());
+
+        // FRAT for FP
+        tag = coredynp.arch_freg_width;
+        data = int(
+            ceil((coredynp.arch_freg_width + 1 * coredynp.globalCheckpoint) /
+                 8.0));  // the address of CAM needed to be sent out
+        out_w = int(ceil(coredynp.arch_freg_width / 8.0));
+        interface_ip.is_cache = true;
+        interface_ip.pure_cam = false;
+        interface_ip.pure_ram = false;
+        interface_ip.line_sz = data;
+        interface_ip.cache_sz = data * XML->sys.core[ithCore].phy_Regs_FRF_size;
+        interface_ip.assoc = 0;
+        interface_ip.nbanks = 1;
+        interface_ip.out_w = out_w * 8;
+        interface_ip.specific_tag = 1;
+        interface_ip.tag_w = tag;
+        interface_ip.access_mode = 2;
+        interface_ip.throughput = 1.0 / clockRate;
+        interface_ip.latency = 1.0 / clockRate;
+        interface_ip.obj_func_dyn_energy = 0;
+        interface_ip.obj_func_dyn_power = 0;
+        interface_ip.obj_func_leak_power = 0;
+        interface_ip.obj_func_cycle_t = 1;
+        interface_ip.num_rw_ports = 1;  // for GCs
+        interface_ip.num_rd_ports = coredynp.fp_decodeW;
+        interface_ip.num_wr_ports = coredynp.fp_decodeW;
+        interface_ip.num_se_rd_ports = 0;
+        interface_ip.num_search_ports = 2 * coredynp.fp_decodeW;
+        fFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device,
+                            coredynp.opt_local, coredynp.core_ty);
+        fFRAT->area.set_area(
+            fFRAT->area.get_area() +
+            fFRAT->local_result.area *
+                XML->sys.core[ithCore].number_hardware_threads);
+        area.set_area(area.get_area() + fFRAT->area.get_area());
+      }
+
+      // RRAT is always RAM based, does not have GCs, and is used only for
+      // record latest non-speculative mapping
+      data = int(ceil(coredynp.phy_ireg_width / 8.0));
+      interface_ip.is_cache = false;
+      interface_ip.pure_cam = false;
+      interface_ip.pure_ram = true;
+      interface_ip.line_sz = data;
+      interface_ip.cache_sz = data *
+                              XML->sys.core[ithCore].archi_Regs_IRF_size *
+                              2;  // HACK to make it as least 64B
+      interface_ip.assoc = 1;
+      interface_ip.nbanks = 1;
+      interface_ip.out_w = interface_ip.line_sz * 8;
+      interface_ip.access_mode = 1;
+      interface_ip.throughput = 1.0 / clockRate;
+      interface_ip.latency = 1.0 / clockRate;
+      interface_ip.obj_func_dyn_energy = 0;
+      interface_ip.obj_func_dyn_power = 0;
+      interface_ip.obj_func_leak_power = 0;
+      interface_ip.obj_func_cycle_t = 1;
+      interface_ip.num_rw_ports = 0;
+      interface_ip.num_rd_ports = XML->sys.core[ithCore].commit_width;
+      interface_ip.num_wr_ports = XML->sys.core[ithCore].commit_width;
+      interface_ip.num_se_rd_ports = 0;
+      iRRAT = new ArrayST(&interface_ip, "Int RetireRAT", Core_device,
+                          coredynp.opt_local, coredynp.core_ty);
+      iRRAT->area.set_area(iRRAT->area.get_area() +
+                           iRRAT->local_result.area *
+                               XML->sys.core[ithCore].number_hardware_threads);
+      area.set_area(area.get_area() + iRRAT->area.get_area());
+
+      // RRAT for FP
+      data = int(ceil(coredynp.phy_freg_width / 8.0));
+      interface_ip.is_cache = false;
+      interface_ip.pure_cam = false;
+      interface_ip.pure_ram = true;
+      interface_ip.line_sz = data;
+      interface_ip.cache_sz = data *
+                              XML->sys.core[ithCore].archi_Regs_FRF_size *
+                              2;  // HACK to make it as least 64B
+      interface_ip.assoc = 1;
+      interface_ip.nbanks = 1;
+      interface_ip.out_w = interface_ip.line_sz * 8;
+      interface_ip.access_mode = 1;
+      interface_ip.throughput = 1.0 / clockRate;
+      interface_ip.latency = 1.0 / clockRate;
+      interface_ip.obj_func_dyn_energy = 0;
+      interface_ip.obj_func_dyn_power = 0;
+      interface_ip.obj_func_leak_power = 0;
+      interface_ip.obj_func_cycle_t = 1;
+      interface_ip.num_rw_ports = 0;
+      interface_ip.num_rd_ports = coredynp.fp_decodeW;
+      interface_ip.num_wr_ports = coredynp.fp_decodeW;
+      interface_ip.num_se_rd_ports = 0;
+      fRRAT = new ArrayST(&interface_ip, "Int RetireRAT", Core_device,
+                          coredynp.opt_local, coredynp.core_ty);
+      fRRAT->area.set_area(fRRAT->area.get_area() +
+                           fRRAT->local_result.area *
+                               XML->sys.core[ithCore].number_hardware_threads);
+      area.set_area(area.get_area() + fRRAT->area.get_area());
+
+      // Freelist of renaming unit always RAM based
+      // Recycle happens at two places: 1)when DCL check there are WAW, the
+      // Phyregisters/ROB directly recycles into freelist
+      // 2)When instruction commits the Phyregisters/ROB needed to be recycled.
+      // therefore num_wr port = decode-1(-1 means at least one phy reg will be
+      // used for the current renaming group) + commit width
+      data = int(ceil(coredynp.phy_ireg_width / 8.0));
+      interface_ip.is_cache = false;
+      interface_ip.pure_cam = false;
+      interface_ip.pure_ram = true;
+      interface_ip.line_sz = data;
+      interface_ip.cache_sz = data * coredynp.num_ifreelist_entries;
+      interface_ip.assoc = 1;
+      interface_ip.nbanks = 1;
+      interface_ip.out_w = interface_ip.line_sz * 8;
+      interface_ip.access_mode = 1;
+      interface_ip.throughput = 1.0 / clockRate;
+      interface_ip.latency = 1.0 / clockRate;
+      interface_ip.obj_func_dyn_energy = 0;
+      interface_ip.obj_func_dyn_power = 0;
+      interface_ip.obj_func_leak_power = 0;
+      interface_ip.obj_func_cycle_t = 1;
+      interface_ip.num_rw_ports = 1;  // TODO
+      interface_ip.num_rd_ports = coredynp.decodeW;
+      interface_ip.num_wr_ports =
+          coredynp.decodeW - 1 + XML->sys.core[ithCore].commit_width;
+      // every cycle, (coredynp.decodeW -1) inst may need to send back it dest
+      // tags, committW insts needs to update freelist buffers
+      interface_ip.num_se_rd_ports = 0;
+      ifreeL = new ArrayST(&interface_ip, "Int Free List", Core_device,
+                           coredynp.opt_local, coredynp.core_ty);
+      ifreeL->area.set_area(ifreeL->area.get_area() +
+                            ifreeL->local_result.area *
+                                XML->sys.core[ithCore].number_hardware_threads);
+      area.set_area(area.get_area() + ifreeL->area.get_area());
+
+      // freelist for FP
+      data = int(ceil(coredynp.phy_freg_width / 8.0));
+      interface_ip.is_cache = false;
+      interface_ip.pure_cam = false;
+      interface_ip.pure_ram = true;
+      interface_ip.line_sz = data;
+      interface_ip.cache_sz = data * coredynp.num_ffreelist_entries;
+      interface_ip.assoc = 1;
+      interface_ip.nbanks = 1;
+      interface_ip.out_w = interface_ip.line_sz * 8;
+      interface_ip.access_mode = 1;
+      interface_ip.throughput = 1.0 / clockRate;
+      interface_ip.latency = 1.0 / clockRate;
+      interface_ip.obj_func_dyn_energy = 0;
+      interface_ip.obj_func_dyn_power = 0;
+      interface_ip.obj_func_leak_power = 0;
+      interface_ip.obj_func_cycle_t = 1;
+      interface_ip.num_rw_ports = 1;
+      interface_ip.num_rd_ports = coredynp.fp_decodeW;
+      interface_ip.num_wr_ports =
+          coredynp.fp_decodeW - 1 + XML->sys.core[ithCore].commit_width;
+      interface_ip.num_se_rd_ports = 0;
+      ffreeL = new ArrayST(&interface_ip, "Int Free List", Core_device,
+                           coredynp.opt_local, coredynp.core_ty);
+      ffreeL->area.set_area(ffreeL->area.get_area() +
+                            ffreeL->local_result.area *
+                                XML->sys.core[ithCore].number_hardware_threads);
+      area.set_area(area.get_area() + ffreeL->area.get_area());
+
+      idcl = new dep_resource_conflict_check(
+          &interface_ip, coredynp,
+          coredynp.phy_ireg_width);  // TODO:Separate 2 sections See TR
+      fdcl = new dep_resource_conflict_check(&interface_ip, coredynp,
+                                             coredynp.phy_freg_width);
+
+    } else if (coredynp.scheu_ty == ReservationStation) {
+      if (coredynp.rm_ty == RAMbased) {
+        /*
+         * however, RAT needs to do associative search in RAT, when instruction
+         * commits and ROB release the entry,
+         * to make sure all the renamings associated with the ROB to be released
+         * are updated to ARF at the same time.
+         * RAM based RAT for RS base OOO does not save the search operations.
+         * Its advantage is to have less entries than
+         * CAM based RAT so that it is more scalable as number of ROB/physical
+         * regs increases.
+         */
+        tag = coredynp.phy_ireg_width;
+        data = int(ceil(coredynp.phy_ireg_width *
+                        (1 + coredynp.globalCheckpoint) / 8.0));
+        out_w = int(ceil(coredynp.phy_ireg_width / 8.0));
+        interface_ip.is_cache = true;
+        interface_ip.pure_cam = false;
+        interface_ip.pure_ram = false;
+        interface_ip.line_sz = data;
+        interface_ip.cache_sz =
+            data * XML->sys.core[ithCore].archi_Regs_IRF_size;
+        interface_ip.assoc = 0;
+        interface_ip.nbanks = 1;
+        interface_ip.out_w = out_w * 8;
+        interface_ip.access_mode = 2;
+        interface_ip.throughput = 1.0 / clockRate;
+        interface_ip.latency = 1.0 / clockRate;
+        interface_ip.obj_func_dyn_energy = 0;
+        interface_ip.obj_func_dyn_power = 0;
+        interface_ip.obj_func_leak_power = 0;
+        interface_ip.obj_func_cycle_t = 1;
+        interface_ip.num_rw_ports = 1;  // the extra one port is for GCs
+        interface_ip.num_rd_ports = 2 * coredynp.decodeW;
+        interface_ip.num_wr_ports = coredynp.decodeW;
+        interface_ip.num_se_rd_ports = 0;
+        interface_ip.num_search_ports = coredynp.commitW;  // TODO
+        iFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device,
+                            coredynp.opt_local, coredynp.core_ty);
+        iFRAT->local_result.adjust_area();
+        iFRAT->area.set_area(
+            iFRAT->area.get_area() +
+            iFRAT->local_result.area *
+                XML->sys.core[ithCore].number_hardware_threads);
+        area.set_area(area.get_area() + iFRAT->area.get_area());
+
+        // FP
+        tag = coredynp.phy_freg_width;
+        data = int(ceil(coredynp.phy_freg_width *
+                        (1 + coredynp.globalCheckpoint) / 8.0));
+        out_w = int(ceil(coredynp.phy_freg_width / 8.0));
+        interface_ip.is_cache = true;
+        interface_ip.pure_cam = false;
+        interface_ip.pure_ram = false;
+        interface_ip.line_sz = data;
+        interface_ip.cache_sz =
+            data * XML->sys.core[ithCore].archi_Regs_FRF_size;
+        interface_ip.assoc = 0;
+        interface_ip.nbanks = 1;
+        interface_ip.out_w = out_w * 8;
+        interface_ip.access_mode = 2;
+        interface_ip.throughput = 1.0 / clockRate;
+        interface_ip.latency = 1.0 / clockRate;
+        interface_ip.obj_func_dyn_energy = 0;
+        interface_ip.obj_func_dyn_power = 0;
+        interface_ip.obj_func_leak_power = 0;
+        interface_ip.obj_func_cycle_t = 1;
+        interface_ip.num_rw_ports = 1;  // the extra one port is for GCs
+        interface_ip.num_rd_ports = 2 * coredynp.fp_decodeW;
+        interface_ip.num_wr_ports = coredynp.fp_decodeW;
+        interface_ip.num_se_rd_ports = 0;
+        interface_ip.num_search_ports =
+            coredynp.fp_decodeW;  // actually is fp commit width
+        fFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device,
+                            coredynp.opt_local, coredynp.core_ty);
+        fFRAT->local_result.adjust_area();
+        fFRAT->area.set_area(
+            fFRAT->area.get_area() +
+            fFRAT->local_result.area *
+                XML->sys.core[ithCore].number_hardware_threads);
+        area.set_area(area.get_area() + fFRAT->area.get_area());
+
+      } else if ((coredynp.rm_ty == CAMbased)) {
+        // FRAT
+        tag = coredynp.arch_ireg_width;
+        data = int(ceil(coredynp.arch_ireg_width +
+                        1 * coredynp.globalCheckpoint /
+                            8.0));  // the address of CAM needed to be sent out
+        out_w = int(ceil(coredynp.arch_ireg_width / 8.0));
+        interface_ip.is_cache = true;
+        interface_ip.pure_cam = false;
+        interface_ip.pure_ram = false;
+        interface_ip.line_sz = data;
+        interface_ip.cache_sz = data * XML->sys.core[ithCore].phy_Regs_IRF_size;
+        interface_ip.assoc = 0;
+        interface_ip.nbanks = 1;
+        interface_ip.out_w = out_w * 8;
+        interface_ip.specific_tag = 1;
+        interface_ip.tag_w = tag;
+        interface_ip.access_mode = 2;
+        interface_ip.throughput = 1.0 / clockRate;
+        interface_ip.latency = 1.0 / clockRate;
+        interface_ip.obj_func_dyn_energy = 0;
+        interface_ip.obj_func_dyn_power = 0;
+        interface_ip.obj_func_leak_power = 0;
+        interface_ip.obj_func_cycle_t = 1;
+        interface_ip.num_rw_ports = 1;  // for GCs
+        interface_ip.num_rd_ports =
+            XML->sys.core[ithCore].decode_width;  // 0;TODO
+        interface_ip.num_wr_ports = XML->sys.core[ithCore].decode_width;
+        interface_ip.num_se_rd_ports = 0;
+        interface_ip.num_search_ports = 2 * XML->sys.core[ithCore].decode_width;
+        iFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device,
+                            coredynp.opt_local, coredynp.core_ty);
+        iFRAT->area.set_area(
+            iFRAT->area.get_area() +
+            iFRAT->local_result.area *
+                XML->sys.core[ithCore].number_hardware_threads);
+        area.set_area(area.get_area() + iFRAT->area.get_area());
+
+        // FRAT
+        tag = coredynp.arch_freg_width;
+        data = int(ceil(coredynp.arch_freg_width +
+                        1 * coredynp.globalCheckpoint /
+                            8.0));  // the address of CAM needed to be sent out
+        out_w = int(ceil(coredynp.arch_freg_width / 8.0));
+        interface_ip.is_cache = true;
+        interface_ip.pure_cam = false;
+        interface_ip.pure_ram = false;
+        interface_ip.line_sz = data;
+        interface_ip.cache_sz = data * XML->sys.core[ithCore].phy_Regs_FRF_size;
+        interface_ip.assoc = 0;
+        interface_ip.nbanks = 1;
+        interface_ip.out_w = out_w * 8;
+        interface_ip.specific_tag = 1;
+        interface_ip.tag_w = tag;
+        interface_ip.access_mode = 2;
+        interface_ip.throughput = 1.0 / clockRate;
+        interface_ip.latency = 1.0 / clockRate;
+        interface_ip.obj_func_dyn_energy = 0;
+        interface_ip.obj_func_dyn_power = 0;
+        interface_ip.obj_func_leak_power = 0;
+        interface_ip.obj_func_cycle_t = 1;
+        interface_ip.num_rw_ports = 1;  // for GCs
+        interface_ip.num_rd_ports =
+            XML->sys.core[ithCore].decode_width;  // 0;TODO;
+        interface_ip.num_wr_ports = coredynp.fp_decodeW;
+        interface_ip.num_se_rd_ports = 0;
+        interface_ip.num_search_ports = 2 * coredynp.fp_decodeW;
+        fFRAT = new ArrayST(&interface_ip, "Int FrontRAT", Core_device,
+                            coredynp.opt_local, coredynp.core_ty);
+        fFRAT->area.set_area(
+            fFRAT->area.get_area() +
+            fFRAT->local_result.area *
+                XML->sys.core[ithCore].number_hardware_threads);
+        area.set_area(area.get_area() + fFRAT->area.get_area());
+      }
+      // No RRAT for RS based OOO
+      // Freelist of renaming unit of RS based OOO is unifed for both int and fp
+      // renaming unit since the ROB is unified
+      data = int(ceil(coredynp.phy_ireg_width / 8.0));
+      interface_ip.is_cache = false;
+      interface_ip.pure_cam = false;
+      interface_ip.pure_ram = true;
+      interface_ip.line_sz = data;
+      interface_ip.cache_sz = data * coredynp.num_ifreelist_entries;
+      interface_ip.assoc = 1;
+      interface_ip.nbanks = 1;
+      interface_ip.out_w = interface_ip.line_sz * 8;
+      interface_ip.access_mode = 1;
+      interface_ip.throughput = 1.0 / clockRate;
+      interface_ip.latency = 1.0 / clockRate;
+      interface_ip.obj_func_dyn_energy = 0;
+      interface_ip.obj_func_dyn_power = 0;
+      interface_ip.obj_func_leak_power = 0;
+      interface_ip.obj_func_cycle_t = 1;
+      interface_ip.num_rw_ports = 1;  // TODO
+      interface_ip.num_rd_ports = XML->sys.core[ithCore].decode_width;
+      interface_ip.num_wr_ports = XML->sys.core[ithCore].decode_width - 1 +
+                                  XML->sys.core[ithCore].commit_width;
+      interface_ip.num_se_rd_ports = 0;
+      ifreeL = new ArrayST(&interface_ip, "Unified Free List", Core_device,
+                           coredynp.opt_local, coredynp.core_ty);
+      ifreeL->area.set_area(ifreeL->area.get_area() +
+                            ifreeL->local_result.area *
+                                XML->sys.core[ithCore].number_hardware_threads);
+      area.set_area(area.get_area() + ifreeL->area.get_area());
+
+      idcl = new dep_resource_conflict_check(
+          &interface_ip, coredynp,
+          coredynp.phy_ireg_width);  // TODO:Separate 2 sections See TR
+      fdcl = new dep_resource_conflict_check(&interface_ip, coredynp,
+                                             coredynp.phy_freg_width);
+    }
+  }
+  if (coredynp.core_ty == Inorder && coredynp.issueW > 1) {
+    /* Dependency check logic will only present when decode(issue) width>1.
+    *  Multiple issue in order processor can do without renaming, but dcl is a
+    * must.
+    */
+    idcl = new dep_resource_conflict_check(
+        &interface_ip, coredynp,
+        coredynp.phy_ireg_width);  // TODO:Separate 2 sections See TR
+    fdcl = new dep_resource_conflict_check(&interface_ip, coredynp,
+                                           coredynp.phy_freg_width);
+  }
 }
 
 Core::Core(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_)
-:XML(XML_interface),
- ithCore(ithCore_),
- interface_ip(*interface_ip_),
- ifu  (0),
- lsu  (0),
- mmu  (0),
- exu  (0),
- rnu  (0),
- corepipe (0),
- undiffCore (0),
- l2cache (0)
-{
- /**
-  * Testing: (to be removed) added by syed
-  */
-  //XML->sys.core[ithCore].simd_width=8;// (8)
-  //XML->sys.core[ithCore].collector_units=4;// (4)
-  //XML->sys.core[ithCore].core_clock_ratio=2.0;// (2.0)
-  //XML->sys.core[ithCore].warp_size=32;// (32) 
-  
+    : XML(XML_interface),
+      ithCore(ithCore_),
+      interface_ip(*interface_ip_),
+      ifu(0),
+      lsu(0),
+      mmu(0),
+      exu(0),
+      rnu(0),
+      corepipe(0),
+      undiffCore(0),
+      l2cache(0) {
+  /**
+   * Testing: (to be removed) added by syed
+   */
+  // XML->sys.core[ithCore].simd_width=8;// (8)
+  // XML->sys.core[ithCore].collector_units=4;// (4)
+  // XML->sys.core[ithCore].core_clock_ratio=2.0;// (2.0)
+  // XML->sys.core[ithCore].warp_size=32;// (32)
+
   /*
   * initialize, compute and optimize individual components.
   */
 
-	IdleCoreEnergy=0;
-	IdlePower_PerCore = 0;
+  IdleCoreEnergy = 0;
+  IdlePower_PerCore = 0;
   double pipeline_area_per_unit;
-  if (XML->sys.Private_L2)
-  {
-	  l2cache = new SharedCache(XML,ithCore, &interface_ip);
-
+  if (XML->sys.Private_L2) {
+    l2cache = new SharedCache(XML, ithCore, &interface_ip);
   }
-//  interface_ip.wire_is_mat_type = 2;
-//  interface_ip.wire_os_mat_type = 2;
-//  interface_ip.wt               =Global_30;
+  //  interface_ip.wire_is_mat_type = 2;
+  //  interface_ip.wire_os_mat_type = 2;
+  //  interface_ip.wt               =Global_30;
   set_core_param();
   clockRate = coredynp.clockRate;
-  exClockRate = clockRate*XML->sys.core[ithCore].core_clock_ratio;
+  exClockRate = clockRate * XML->sys.core[ithCore].core_clock_ratio;
 
   executionTime = coredynp.executionTime;
-  ifu          = new InstFetchU(XML, ithCore, &interface_ip,coredynp);
-  lsu          = new LoadStoreU(XML, ithCore, &interface_ip,coredynp);
-  mmu          = new MemManU   (XML, ithCore, &interface_ip,coredynp);
-  exu          = new EXECU     (XML, ithCore, &interface_ip,lsu->lsq_height, coredynp, exClockRate,true);
-  
+  ifu = new InstFetchU(XML, ithCore, &interface_ip, coredynp);
+  lsu = new LoadStoreU(XML, ithCore, &interface_ip, coredynp);
+  mmu = new MemManU(XML, ithCore, &interface_ip, coredynp);
+  exu = new EXECU(XML, ithCore, &interface_ip, lsu->lsq_height, coredynp,
+                  exClockRate, true);
 
-
-
-
-  undiffCore   = new UndiffCore(XML, ithCore, &interface_ip,coredynp);
-  if (coredynp.core_ty==OOO)
-  {
-	  rnu = new RENAMINGU(XML, ithCore, &interface_ip,coredynp);
+  undiffCore = new UndiffCore(XML, ithCore, &interface_ip, coredynp);
+  if (coredynp.core_ty == OOO) {
+    rnu = new RENAMINGU(XML, ithCore, &interface_ip, coredynp);
   }
-  corepipe = new Pipeline(&interface_ip,coredynp);
+  corepipe = new Pipeline(&interface_ip, coredynp);
 
-  if (coredynp.core_ty==OOO)
-  {
-	  pipeline_area_per_unit    = (corepipe->area.get_area()*coredynp.num_pipelines)/5.0;
-	  if (rnu->exist)
-	  {
-		  rnu->area.set_area(rnu->area.get_area() + pipeline_area_per_unit);
-	  }
+  if (coredynp.core_ty == OOO) {
+    pipeline_area_per_unit =
+        (corepipe->area.get_area() * coredynp.num_pipelines) / 5.0;
+    if (rnu->exist) {
+      rnu->area.set_area(rnu->area.get_area() + pipeline_area_per_unit);
+    }
+  } else {
+    pipeline_area_per_unit =
+        (corepipe->area.get_area() * coredynp.num_pipelines) / 4.0;
   }
+
+  // area.set_area(area.get_area()+ corepipe->area.get_area());
+  if (ifu->exist) {
+    ifu->area.set_area(ifu->area.get_area() + pipeline_area_per_unit);
+    area.set_area(area.get_area() + ifu->area.get_area());
+  }
+  if (lsu->exist) {
+    lsu->area.set_area(lsu->area.get_area() + pipeline_area_per_unit);
+    area.set_area(area.get_area() + lsu->area.get_area());
+  }
+  if (exu->exist) {
+    exu->area.set_area(exu->area.get_area() + pipeline_area_per_unit);
+    area.set_area(area.get_area() + exu->area.get_area());
+  }
+  if (mmu->exist) {
+    mmu->area.set_area(mmu->area.get_area() + pipeline_area_per_unit);
+    area.set_area(area.get_area() + mmu->area.get_area());
+  }
+
+  if (coredynp.core_ty == OOO) {
+    if (rnu->exist) {
+      area.set_area(area.get_area() + rnu->area.get_area());
+    }
+  }
+
+  if (undiffCore->exist) {
+    area.set_area(area.get_area() + undiffCore->area.get_area());
+  }
+
+  if (XML->sys.Private_L2) {
+    area.set_area(area.get_area() + l2cache->area.get_area());
+  }
+  //  //clock power
+  //  clockNetwork.init_wire_external(is_default, &interface_ip);
+  //  clockNetwork.clk_area           =area*1.1;//10% of placement overhead.
+  //  rule of thumb
+  //  clockNetwork.end_wiring_level   =5;//toplevel metal
+  //  clockNetwork.start_wiring_level =5;//toplevel metal
+  //  clockNetwork.num_regs           = corepipe.tot_stage_vector;
+  //  clockNetwork.optimize_wire();
+}
+
+void BranchPredictor::computeEnergy(bool is_tdp) {
+  if (!exist) return;
+  double r_access;
+  double w_access;
+  if (is_tdp) {
+    r_access = coredynp.predictionW * coredynp.BR_duty_cycle;
+    w_access = 0 * coredynp.BR_duty_cycle;
+    globalBPT->stats_t.readAc.access = r_access;
+    globalBPT->stats_t.writeAc.access = w_access;
+    globalBPT->tdp_stats = globalBPT->stats_t;
+
+    L1_localBPT->stats_t.readAc.access = r_access;
+    L1_localBPT->stats_t.writeAc.access = w_access;
+    L1_localBPT->tdp_stats = L1_localBPT->stats_t;
+
+    L2_localBPT->stats_t.readAc.access = r_access;
+    L2_localBPT->stats_t.writeAc.access = w_access;
+    L2_localBPT->tdp_stats = L2_localBPT->stats_t;
+
+    chooser->stats_t.readAc.access = r_access;
+    chooser->stats_t.writeAc.access = w_access;
+    chooser->tdp_stats = chooser->stats_t;
+
+    RAS->stats_t.readAc.access = r_access;
+    RAS->stats_t.writeAc.access = w_access;
+    RAS->tdp_stats = RAS->stats_t;
+  } else {
+    // The resolution of BPT accesses is coarse, but this is
+    // because most simulators cannot track finer grained details
+    r_access = XML->sys.core[ithCore].branch_instructions;
+    w_access =
+        XML->sys.core[ithCore].branch_mispredictions +
+        0.1 *
+            XML->sys.core[ithCore]
+                .branch_instructions;  // 10% of BR will flip internal bits//0
+    globalBPT->stats_t.readAc.access = r_access;
+    globalBPT->stats_t.writeAc.access = w_access;
+    globalBPT->rtp_stats = globalBPT->stats_t;
+
+    L1_localBPT->stats_t.readAc.access = r_access;
+    L1_localBPT->stats_t.writeAc.access = w_access;
+    L1_localBPT->rtp_stats = L1_localBPT->stats_t;
+
+    L2_localBPT->stats_t.readAc.access = r_access;
+    L2_localBPT->stats_t.writeAc.access = w_access;
+    L2_localBPT->rtp_stats = L2_localBPT->stats_t;
+
+    chooser->stats_t.readAc.access = r_access;
+    chooser->stats_t.writeAc.access = w_access;
+    chooser->rtp_stats = chooser->stats_t;
+
+    RAS->stats_t.readAc.access = XML->sys.core[ithCore].function_calls;
+    RAS->stats_t.writeAc.access = XML->sys.core[ithCore].function_calls;
+    RAS->rtp_stats = RAS->stats_t;
+  }
+
+  globalBPT->power_t.reset();
+  L1_localBPT->power_t.reset();
+  L2_localBPT->power_t.reset();
+  chooser->power_t.reset();
+  RAS->power_t.reset();
+
+  globalBPT->power_t.readOp.dynamic +=
+      globalBPT->local_result.power.readOp.dynamic *
+          globalBPT->stats_t.readAc.access +
+      globalBPT->stats_t.writeAc.access *
+          globalBPT->local_result.power.writeOp.dynamic;
+  L1_localBPT->power_t.readOp.dynamic +=
+      L1_localBPT->local_result.power.readOp.dynamic *
+          L1_localBPT->stats_t.readAc.access +
+      L1_localBPT->stats_t.writeAc.access *
+          L1_localBPT->local_result.power.writeOp.dynamic;
+
+  L2_localBPT->power_t.readOp.dynamic +=
+      L2_localBPT->local_result.power.readOp.dynamic *
+          L2_localBPT->stats_t.readAc.access +
+      L2_localBPT->stats_t.writeAc.access *
+          L2_localBPT->local_result.power.writeOp.dynamic;
+
+  chooser->power_t.readOp.dynamic +=
+      chooser->local_result.power.readOp.dynamic *
+          chooser->stats_t.readAc.access +
+      chooser->stats_t.writeAc.access *
+          chooser->local_result.power.writeOp.dynamic;
+  RAS->power_t.readOp.dynamic +=
+      RAS->local_result.power.readOp.dynamic * RAS->stats_t.readAc.access +
+      RAS->stats_t.writeAc.access * RAS->local_result.power.writeOp.dynamic;
+
+  if (is_tdp) {
+    globalBPT->power =
+        globalBPT->power_t + globalBPT->local_result.power * pppm_lkg;
+    L1_localBPT->power =
+        L1_localBPT->power_t + L1_localBPT->local_result.power * pppm_lkg;
+    L2_localBPT->power =
+        L2_localBPT->power_t + L2_localBPT->local_result.power * pppm_lkg;
+    chooser->power = chooser->power_t + chooser->local_result.power * pppm_lkg;
+    RAS->power =
+        RAS->power_t + RAS->local_result.power * coredynp.pppm_lkg_multhread;
+
+    power = power + globalBPT->power + L1_localBPT->power + chooser->power +
+            RAS->power;
+  } else {
+    globalBPT->rt_power =
+        globalBPT->power_t + globalBPT->local_result.power * pppm_lkg;
+    L1_localBPT->rt_power =
+        L1_localBPT->power_t + L1_localBPT->local_result.power * pppm_lkg;
+    L2_localBPT->rt_power =
+        L2_localBPT->power_t + L2_localBPT->local_result.power * pppm_lkg;
+    chooser->rt_power =
+        chooser->power_t + chooser->local_result.power * pppm_lkg;
+    RAS->rt_power =
+        RAS->power_t + RAS->local_result.power * coredynp.pppm_lkg_multhread;
+    rt_power = rt_power + globalBPT->rt_power + L1_localBPT->rt_power +
+               chooser->rt_power + RAS->rt_power;
+  }
+}
+
+void BranchPredictor::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  if (!exist) return;
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
+  if (is_tdp) {
+    cout << indent_str << "Global Predictor:" << endl;
+    cout << indent_str_next << "Area = " << globalBPT->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << globalBPT->power.readOp.dynamic * clockRate
+         << " W" << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? globalBPT->power.readOp.longer_channel_leakage
+                          : globalBPT->power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << globalBPT->power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << globalBPT->rt_power.readOp.dynamic / executionTime << " W" << endl;
+    cout << endl;
+    cout << indent_str << "Local Predictor:" << endl;
+    cout << indent_str << "L1_Local Predictor:" << endl;
+    cout << indent_str_next << "Area = " << L1_localBPT->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << L1_localBPT->power.readOp.dynamic * clockRate
+         << " W" << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? L1_localBPT->power.readOp.longer_channel_leakage
+                          : L1_localBPT->power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << L1_localBPT->power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << L1_localBPT->rt_power.readOp.dynamic / executionTime << " W"
+         << endl;
+    cout << endl;
+    cout << indent_str << "L2_Local Predictor:" << endl;
+    cout << indent_str_next << "Area = " << L2_localBPT->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << L2_localBPT->power.readOp.dynamic * clockRate
+         << " W" << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? L2_localBPT->power.readOp.longer_channel_leakage
+                          : L2_localBPT->power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << L2_localBPT->power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << L2_localBPT->rt_power.readOp.dynamic / executionTime << " W"
+         << endl;
+    cout << endl;
+
+    cout << indent_str << "Chooser:" << endl;
+    cout << indent_str_next << "Area = " << chooser->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << chooser->power.readOp.dynamic * clockRate
+         << " W" << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? chooser->power.readOp.longer_channel_leakage
+                          : chooser->power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << chooser->power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << chooser->rt_power.readOp.dynamic / executionTime << " W" << endl;
+    cout << endl;
+    cout << indent_str << "RAS:" << endl;
+    cout << indent_str_next << "Area = " << RAS->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << RAS->power.readOp.dynamic * clockRate << " W"
+         << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? RAS->power.readOp.longer_channel_leakage
+                          : RAS->power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << RAS->power.readOp.gate_leakage << " W" << endl;
+    cout << indent_str_next
+         << "Runtime Dynamic = " << RAS->rt_power.readOp.dynamic / executionTime
+         << " W" << endl;
+    cout << endl;
+  } else {
+    //		cout << indent_str_next << "Global Predictor    Peak Dynamic = " <<
+    //globalBPT->rt_power.readOp.dynamic*clockRate << " W" << endl;
+    //		cout << indent_str_next << "Global Predictor    Subthreshold Leakage =
+    //" << globalBPT->rt_power.readOp.leakage <<" W" << endl;
+    //		cout << indent_str_next << "Global Predictor    Gate Leakage = " <<
+    //globalBPT->rt_power.readOp.gate_leakage << " W" << endl;
+    //		cout << indent_str_next << "Local Predictor   Peak Dynamic = " <<
+    //L1_localBPT->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "Local Predictor   Subthreshold Leakage = "
+    //<< L1_localBPT->rt_power.readOp.leakage  << " W" << endl;
+    //		cout << indent_str_next << "Local Predictor   Gate Leakage = " <<
+    //L1_localBPT->rt_power.readOp.gate_leakage  << " W" << endl;
+    //		cout << indent_str_next << "Chooser   Peak Dynamic = " <<
+    //chooser->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "Chooser   Subthreshold Leakage = " <<
+    //chooser->rt_power.readOp.leakage  << " W" << endl;
+    //		cout << indent_str_next << "Chooser   Gate Leakage = " <<
+    //chooser->rt_power.readOp.gate_leakage  << " W" << endl;
+    //		cout << indent_str_next << "RAS   Peak Dynamic = " <<
+    //RAS->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "RAS   Subthreshold Leakage = " <<
+    //RAS->rt_power.readOp.leakage  << " W" << endl;
+    //		cout << indent_str_next << "RAS   Gate Leakage = " <<
+    //RAS->rt_power.readOp.gate_leakage  << " W" << endl;
+  }
+}
+
+void InstFetchU::computeEnergy(bool is_tdp) {
+  executionTime =
+      XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);  // Syed
+  // cout <<"IFU: execution time:
+  // "<<XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6)<<endl;
+  // cout <<"IFU: total cycles"<<XML->sys.total_cycles<<endl;
+  if (!exist) return;
+  if (is_tdp) {
+    // init stats for Peak
+    icache.caches->stats_t.readAc.access =
+        icache.caches->l_ip.num_rw_ports * coredynp.IFU_duty_cycle;
+    icache.caches->stats_t.readAc.miss = 0;
+    icache.caches->stats_t.readAc.hit = icache.caches->stats_t.readAc.access -
+                                        icache.caches->stats_t.readAc.miss;
+    icache.caches->tdp_stats = icache.caches->stats_t;
+
+    icache.missb->stats_t.readAc.access = icache.missb->stats_t.readAc.hit =
+        icache.missb->l_ip.num_search_ports;
+    icache.missb->stats_t.writeAc.access = icache.missb->stats_t.writeAc.hit =
+        icache.missb->l_ip.num_search_ports;
+    icache.missb->tdp_stats = icache.missb->stats_t;
+
+    icache.ifb->stats_t.readAc.access = icache.ifb->stats_t.readAc.hit =
+        icache.ifb->l_ip.num_search_ports;
+    icache.ifb->stats_t.writeAc.access = icache.ifb->stats_t.writeAc.hit =
+        icache.ifb->l_ip.num_search_ports;
+    icache.ifb->tdp_stats = icache.ifb->stats_t;
+
+    icache.prefetchb->stats_t.readAc.access =
+        icache.prefetchb->stats_t.readAc.hit =
+            icache.prefetchb->l_ip.num_search_ports;
+    icache.prefetchb->stats_t.writeAc.access = icache.ifb->stats_t.writeAc.hit =
+        icache.ifb->l_ip.num_search_ports;
+    icache.prefetchb->tdp_stats = icache.prefetchb->stats_t;
+
+    IB->stats_t.readAc.access = IB->stats_t.writeAc.access =
+        XML->sys.core[ithCore].peak_issue_width;
+    IB->tdp_stats = IB->stats_t;
+
+    if (coredynp.predictionW > 0) {
+      BTB->stats_t.readAc.access =
+          coredynp.predictionW;  // XML->sys.core[ithCore].BTB.read_accesses;
+      BTB->stats_t.writeAc.access =
+          0;  // XML->sys.core[ithCore].BTB.write_accesses;
+    }
+
+    ID_inst->stats_t.readAc.access = coredynp.decodeW;
+    ID_operand->stats_t.readAc.access = coredynp.decodeW;
+    ID_misc->stats_t.readAc.access = coredynp.decodeW;
+    ID_inst->tdp_stats = ID_inst->stats_t;
+    ID_operand->tdp_stats = ID_operand->stats_t;
+    ID_misc->tdp_stats = ID_misc->stats_t;
+
+  } /* if (is_tdp) */
   else {
-	  pipeline_area_per_unit    = (corepipe->area.get_area()*coredynp.num_pipelines)/4.0;
+    rt_power.reset();
+    icache.rt_power.reset();  // Jingwen
+    // init stats for Runtime Dynamic (RTP)
+    // cout<< "****>>>>Icache stats:"<<endl;
+    // cout<<"Read accesses: "<< XML->sys.core[ithCore].icache.read_accesses <<
+    // " Read misses: "<<XML->sys.core[ithCore].icache.read_misses<<endl;
+    icache.caches->stats_t.readAc.access =
+        XML->sys.core[ithCore].icache.read_accesses;
+    icache.caches->stats_t.readAc.miss =
+        XML->sys.core[ithCore].icache.read_misses;
+    // cout<<endl<<"inside mcpat read access=
+    // "<<XML->sys.core[ithCore].icache.read_accesses;
+    // cout<<endl<<"inside mcpat read miss=
+    // "<<XML->sys.core[ithCore].icache.read_misses;
+
+    icache.caches->stats_t.readAc.hit = icache.caches->stats_t.readAc.access -
+                                        icache.caches->stats_t.readAc.miss;
+    icache.caches->rtp_stats = icache.caches->stats_t;
+    // cout<<endl<<"inside mcpat read hit=
+    // "<<icache.caches->stats_t.readAc.hit<<endl;
+    icache.missb->stats_t.readAc.access = icache.caches->stats_t.readAc.miss;
+    icache.missb->stats_t.writeAc.access = icache.caches->stats_t.readAc.miss;
+    icache.missb->rtp_stats = icache.missb->stats_t;
+
+    icache.ifb->stats_t.readAc.access = icache.caches->stats_t.readAc.miss;
+    icache.ifb->stats_t.writeAc.access = icache.caches->stats_t.readAc.miss;
+    icache.ifb->rtp_stats = icache.ifb->stats_t;
+
+    icache.prefetchb->stats_t.readAc.access =
+        icache.caches->stats_t.readAc.miss;
+    icache.prefetchb->stats_t.writeAc.access =
+        icache.caches->stats_t.readAc.miss;
+    icache.prefetchb->rtp_stats = icache.prefetchb->stats_t;
+
+    IB->stats_t.readAc.access = IB->stats_t.writeAc.access =
+        XML->sys.core[ithCore].total_instructions;
+    IB->rtp_stats = IB->stats_t;
+    // cout<<"IB: total instructions: "<<IB->stats_t.readAc.access <<endl;
+    if (coredynp.predictionW > 0) {
+      BTB->stats_t.readAc.access =
+          XML->sys.core[ithCore]
+              .BTB
+              .read_accesses;  // XML->sys.core[ithCore].branch_instructions;
+      BTB->stats_t.writeAc.access =
+          XML->sys.core[ithCore]
+              .BTB
+              .write_accesses;  // XML->sys.core[ithCore].branch_mispredictions;
+      BTB->rtp_stats = BTB->stats_t;
+    }
+    // cout<<"ID: total instructions: "<<
+    // XML->sys.core[ithCore].total_instructions<<endl;
+    ID_inst->stats_t.readAc.access = XML->sys.core[ithCore].total_instructions;
+    ID_operand->stats_t.readAc.access =
+        XML->sys.core[ithCore].total_instructions;
+    ID_misc->stats_t.readAc.access = XML->sys.core[ithCore].total_instructions;
+    ID_inst->rtp_stats = ID_inst->stats_t;
+    ID_operand->rtp_stats = ID_operand->stats_t;
+    ID_misc->rtp_stats = ID_misc->stats_t;
   }
 
-  //area.set_area(area.get_area()+ corepipe->area.get_area());
-  if (ifu->exist)
-  {
-	  ifu->area.set_area(ifu->area.get_area() + pipeline_area_per_unit);
-	  area.set_area(area.get_area() + ifu->area.get_area());
-  }
-  if (lsu->exist)
-  {
-	  lsu->area.set_area(lsu->area.get_area() + pipeline_area_per_unit);
-      area.set_area(area.get_area() + lsu->area.get_area());
-  }
-  if (exu->exist)
-  {
-	  exu->area.set_area(exu->area.get_area() + pipeline_area_per_unit);
-	  area.set_area(area.get_area()+exu->area.get_area());
-  }
-  if (mmu->exist)
-  {
-	  mmu->area.set_area(mmu->area.get_area() + pipeline_area_per_unit);
-      area.set_area(area.get_area()+mmu->area.get_area());
+  icache.power_t.reset();
+  IB->power_t.reset();
+  //	ID_inst->power_t.reset();
+  //	ID_operand->power_t.reset();
+  //	ID_misc->power_t.reset();
+  if (coredynp.predictionW > 0) {
+    BTB->power_t.reset();
   }
 
-  if (coredynp.core_ty==OOO)
-  {
-	  if (rnu->exist)
-	  {
+  icache.power_t.readOp.dynamic +=
+      (icache.caches->stats_t.readAc.hit *
+           icache.caches->local_result.power.readOp.dynamic +
+       // icache.caches->stats_t.readAc.miss*icache.caches->local_result.tag_array2->power.readOp.dynamic+
+       icache.caches->stats_t.readAc.miss *
+           icache.caches->local_result.power.readOp
+               .dynamic +  // assume tag data accessed in parallel
+       icache.caches->stats_t.readAc.miss *
+           icache.caches->local_result.power.writeOp
+               .dynamic);  // read miss in Icache cause a write to Icache
+  icache.power_t.readOp.dynamic +=
+      icache.missb->stats_t.readAc.access *
+          icache.missb->local_result.power.searchOp.dynamic +
+      icache.missb->stats_t.writeAc.access *
+          icache.missb->local_result.power.writeOp
+              .dynamic;  // each access to missb involves a CAM and a write
+  icache.power_t.readOp.dynamic +=
+      icache.ifb->stats_t.readAc.access *
+          icache.ifb->local_result.power.searchOp.dynamic +
+      icache.ifb->stats_t.writeAc.access *
+          icache.ifb->local_result.power.writeOp.dynamic;
+  icache.power_t.readOp.dynamic +=
+      icache.prefetchb->stats_t.readAc.access *
+          icache.prefetchb->local_result.power.searchOp.dynamic +
+      icache.prefetchb->stats_t.writeAc.access *
+          icache.prefetchb->local_result.power.writeOp.dynamic;
+  // cout<<"Icache power: "<<icache.power_t.readOp.dynamic	<<endl;
+  IB->power_t.readOp.dynamic +=
+      IB->local_result.power.readOp.dynamic * IB->stats_t.readAc.access +
+      IB->stats_t.writeAc.access * IB->local_result.power.writeOp.dynamic;
+  // cout << "IB power: "<<IB->power_t.readOp.dynamic<<endl;
+  if (coredynp.predictionW > 0) {
+    BTB->power_t.readOp.dynamic +=
+        BTB->local_result.power.readOp.dynamic * BTB->stats_t.readAc.access +
+        BTB->stats_t.writeAc.access * BTB->local_result.power.writeOp.dynamic;
 
-		  area.set_area(area.get_area() + rnu->area.get_area());
-	  }
+    BPT->computeEnergy(is_tdp);
   }
 
-  if (undiffCore->exist)
-  {
-	  area.set_area(area.get_area() + undiffCore->area.get_area());
+  if (is_tdp) {
+    //    	icache.power = icache.power_t +
+    //    	        (icache.caches->local_result.power)*pppm_lkg +
+    //    			(icache.missb->local_result.power +
+    //    			icache.ifb->local_result.power +
+    //    			icache.prefetchb->local_result.power)*pppm_Isub;
+    icache.power =
+        icache.power_t +
+        (icache.caches->local_result.power + icache.missb->local_result.power +
+         icache.ifb->local_result.power +
+         icache.prefetchb->local_result.power) *
+            pppm_lkg;
+
+    IB->power = IB->power_t + IB->local_result.power * pppm_lkg;
+    power = power + icache.power + IB->power;
+    if (coredynp.predictionW > 0) {
+      BTB->power = BTB->power_t + BTB->local_result.power * pppm_lkg;
+      power = power + BTB->power + BPT->power;
+    }
+
+    ID_inst->power_t.readOp.dynamic = ID_inst->power.readOp.dynamic;
+    ID_operand->power_t.readOp.dynamic = ID_operand->power.readOp.dynamic;
+    ID_misc->power_t.readOp.dynamic = ID_misc->power.readOp.dynamic;
+
+    ID_inst->power.readOp.dynamic *= ID_inst->tdp_stats.readAc.access;
+    ID_operand->power.readOp.dynamic *= ID_operand->tdp_stats.readAc.access;
+    ID_misc->power.readOp.dynamic *= ID_misc->tdp_stats.readAc.access;
+
+    power = power + (ID_inst->power + ID_operand->power + ID_misc->power);
+  } /* if (is_tdp) */
+  else {
+    //    	icache.rt_power = icache.power_t +
+    //    	        (icache.caches->local_result.power)*pppm_lkg +
+    //    			(icache.missb->local_result.power +
+    //    			icache.ifb->local_result.power +
+    //    			icache.prefetchb->local_result.power)*pppm_Isub;
+
+    icache.rt_power =
+        icache.power_t +
+        (icache.caches->local_result.power + icache.missb->local_result.power +
+         icache.ifb->local_result.power +
+         icache.prefetchb->local_result.power) *
+            pppm_lkg;
+
+    // IB->rt_power = IB->power_t + IB->local_result.power*pppm_lkg;
+    IB->rt_power.readOp.dynamic =
+        IB->local_result.power.readOp.dynamic * IB->rtp_stats.readAc.access;
+    IB->rt_power.readOp.dynamic +=
+        IB->local_result.power.writeOp.dynamic * IB->rtp_stats.writeAc.access;
+    rt_power = rt_power + icache.rt_power + IB->rt_power;
+    if (coredynp.predictionW > 0) {
+      BTB->rt_power = BTB->power_t + BTB->local_result.power * pppm_lkg;
+      rt_power = rt_power + BTB->rt_power + BPT->rt_power;
+    }
+
+    ID_inst->rt_power.readOp.dynamic =
+        ID_inst->power_t.readOp.dynamic * ID_inst->rtp_stats.readAc.access;
+    ID_operand->rt_power.readOp.dynamic = ID_operand->power_t.readOp.dynamic *
+                                          ID_operand->rtp_stats.readAc.access;
+    ID_misc->rt_power.readOp.dynamic =
+        ID_misc->power_t.readOp.dynamic * ID_misc->rtp_stats.readAc.access;
+
+    rt_power = rt_power +
+               (ID_inst->rt_power + ID_operand->rt_power + ID_misc->rt_power);
+    // cout<<"ID inst: "<<ID_inst->rt_power.readOp.dynamic << " ID operand:
+    // "<<ID_operand->rt_power.readOp.dynamic<<" ID misc:
+    // "<<ID_misc->rt_power.readOp.dynamic<<endl;
+  }
+}
+
+void InstFetchU::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  if (!exist) return;
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
+
+  if (is_tdp) {
+    cout << indent_str << "Instruction Cache:" << endl;
+    cout << indent_str_next << "Area = " << icache.area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << icache.power.readOp.dynamic * clockRate << " W"
+         << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? icache.power.readOp.longer_channel_leakage
+                          : icache.power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << icache.power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << icache.rt_power.readOp.dynamic / executionTime << " W" << endl;
+    cout << endl;
+    if (coredynp.predictionW > 0) {
+      cout << indent_str << "Branch Target Buffer:" << endl;
+      cout << indent_str_next << "Area = " << BTB->area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << BTB->power.readOp.dynamic * clockRate << " W"
+           << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? BTB->power.readOp.longer_channel_leakage
+                            : BTB->power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << BTB->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << BTB->rt_power.readOp.dynamic / executionTime << " W" << endl;
+      cout << endl;
+      if (BPT->exist) {
+        cout << indent_str << "Branch Predictor:" << endl;
+        cout << indent_str_next << "Area = " << BPT->area.get_area() * 1e-6
+             << " mm^2" << endl;
+        cout << indent_str_next
+             << "Peak Dynamic = " << BPT->power.readOp.dynamic * clockRate
+             << " W" << endl;
+        cout << indent_str_next << "Subthreshold Leakage = "
+             << (long_channel ? BPT->power.readOp.longer_channel_leakage
+                              : BPT->power.readOp.leakage)
+             << " W" << endl;
+        cout << indent_str_next
+             << "Gate Leakage = " << BPT->power.readOp.gate_leakage << " W"
+             << endl;
+        cout << indent_str_next << "Runtime Dynamic = "
+             << BPT->rt_power.readOp.dynamic / executionTime << " W" << endl;
+        cout << endl;
+        if (plevel > 3) {
+          BPT->displayEnergy(indent + 4, plevel, is_tdp);
+        }
+      }
+    }
+    cout << indent_str << "Instruction Buffer:" << endl;
+    cout << indent_str_next << "Area = " << IB->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << IB->power.readOp.dynamic * clockRate << " W"
+         << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? IB->power.readOp.longer_channel_leakage
+                          : IB->power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << IB->power.readOp.gate_leakage << " W" << endl;
+    cout << indent_str_next
+         << "Runtime Dynamic = " << IB->rt_power.readOp.dynamic / executionTime
+         << " W" << endl;
+    cout << endl;
+    cout << indent_str << "Instruction Decoder:" << endl;
+    cout << indent_str_next << "Area = "
+         << (ID_inst->area.get_area() + ID_operand->area.get_area() +
+             ID_misc->area.get_area()) *
+                coredynp.decodeW * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next << "Peak Dynamic = "
+         << (ID_inst->power.readOp.dynamic + ID_operand->power.readOp.dynamic +
+             ID_misc->power.readOp.dynamic) *
+                clockRate
+         << " W" << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? (ID_inst->power.readOp.longer_channel_leakage +
+                             ID_operand->power.readOp.longer_channel_leakage +
+                             ID_misc->power.readOp.longer_channel_leakage)
+                          : (ID_inst->power.readOp.leakage +
+                             ID_operand->power.readOp.leakage +
+                             ID_misc->power.readOp.leakage))
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << (ID_inst->power.readOp.gate_leakage +
+                                  ID_operand->power.readOp.gate_leakage +
+                                  ID_misc->power.readOp.gate_leakage)
+         << " W" << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << (ID_inst->rt_power.readOp.dynamic +
+             ID_operand->rt_power.readOp.dynamic +
+             ID_misc->rt_power.readOp.dynamic) /
+                executionTime
+         << " W" << endl;
+    cout << endl;
+  } else {
+    //		cout << indent_str_next << "Instruction Cache    Peak Dynamic = " <<
+    //icache.rt_power.readOp.dynamic*clockRate << " W" << endl;
+    //		cout << indent_str_next << "Instruction Cache    Subthreshold Leakage
+    //= " << icache.rt_power.readOp.leakage <<" W" << endl;
+    //		cout << indent_str_next << "Instruction Cache    Gate Leakage = " <<
+    //icache.rt_power.readOp.gate_leakage << " W" << endl;
+    //		cout << indent_str_next << "Instruction Buffer   Peak Dynamic = " <<
+    //IB->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "Instruction Buffer   Subthreshold Leakage
+    //= " << IB->rt_power.readOp.leakage  << " W" << endl;
+    //		cout << indent_str_next << "Instruction Buffer   Gate Leakage = " <<
+    //IB->rt_power.readOp.gate_leakage  << " W" << endl;
+    //		cout << indent_str_next << "Branch Target Buffer   Peak Dynamic = " <<
+    //BTB->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "Branch Target Buffer   Subthreshold
+    //Leakage = " << BTB->rt_power.readOp.leakage  << " W" << endl;
+    //		cout << indent_str_next << "Branch Target Buffer   Gate Leakage = " <<
+    //BTB->rt_power.readOp.gate_leakage  << " W" << endl;
+    //		cout << indent_str_next << "Branch Predictor   Peak Dynamic = " <<
+    //BPT->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "Branch Predictor   Subthreshold Leakage =
+    //" << BPT->rt_power.readOp.leakage  << " W" << endl;
+    //		cout << indent_str_next << "Branch Predictor   Gate Leakage = " <<
+    //BPT->rt_power.readOp.gate_leakage  << " W" << endl;
+  }
+}
+
+void RENAMINGU::computeEnergy(bool is_tdp) {
+  if (!exist) return;
+  double pppm_t[4] = {1, 1, 1, 1};
+  if (is_tdp) {  // init stats for Peak
+    if (coredynp.core_ty == OOO) {
+      if (coredynp.scheu_ty == PhysicalRegFile) {
+        if (coredynp.rm_ty == RAMbased) {
+          iFRAT->stats_t.readAc.access = iFRAT->l_ip.num_rd_ports;
+          iFRAT->stats_t.writeAc.access = iFRAT->l_ip.num_wr_ports;
+          iFRAT->tdp_stats = iFRAT->stats_t;
+
+          fFRAT->stats_t.readAc.access = fFRAT->l_ip.num_rd_ports;
+          fFRAT->stats_t.writeAc.access = fFRAT->l_ip.num_wr_ports;
+          fFRAT->tdp_stats = fFRAT->stats_t;
+
+        } else if ((coredynp.rm_ty == CAMbased)) {
+          iFRAT->stats_t.readAc.access = iFRAT->l_ip.num_search_ports;
+          iFRAT->stats_t.writeAc.access = iFRAT->l_ip.num_wr_ports;
+          iFRAT->tdp_stats = iFRAT->stats_t;
+
+          fFRAT->stats_t.readAc.access = fFRAT->l_ip.num_search_ports;
+          fFRAT->stats_t.writeAc.access = fFRAT->l_ip.num_wr_ports;
+          fFRAT->tdp_stats = fFRAT->stats_t;
+        }
+
+        iRRAT->stats_t.readAc.access = iRRAT->l_ip.num_rd_ports;
+        iRRAT->stats_t.writeAc.access = iRRAT->l_ip.num_wr_ports;
+        iRRAT->tdp_stats = iRRAT->stats_t;
+
+        fRRAT->stats_t.readAc.access = fRRAT->l_ip.num_rd_ports;
+        fRRAT->stats_t.writeAc.access = fRRAT->l_ip.num_wr_ports;
+        fRRAT->tdp_stats = fRRAT->stats_t;
+
+        ifreeL->stats_t.readAc.access =
+            coredynp.decodeW;  // ifreeL->l_ip.num_rd_ports;;
+        ifreeL->stats_t.writeAc.access =
+            coredynp.decodeW;  // ifreeL->l_ip.num_wr_ports;
+        ifreeL->tdp_stats = ifreeL->stats_t;
+
+        ffreeL->stats_t.readAc.access =
+            coredynp.decodeW;  // ffreeL->l_ip.num_rd_ports;
+        ffreeL->stats_t.writeAc.access =
+            coredynp.decodeW;  // ffreeL->l_ip.num_wr_ports;
+        ffreeL->tdp_stats = ffreeL->stats_t;
+      } else if (coredynp.scheu_ty == ReservationStation) {
+        if (coredynp.rm_ty == RAMbased) {
+          iFRAT->stats_t.readAc.access = iFRAT->l_ip.num_rd_ports;
+          iFRAT->stats_t.writeAc.access = iFRAT->l_ip.num_wr_ports;
+          iFRAT->stats_t.searchAc.access = iFRAT->l_ip.num_search_ports;
+          iFRAT->tdp_stats = iFRAT->stats_t;
+
+          fFRAT->stats_t.readAc.access = fFRAT->l_ip.num_rd_ports;
+          fFRAT->stats_t.writeAc.access = fFRAT->l_ip.num_wr_ports;
+          fFRAT->stats_t.searchAc.access = fFRAT->l_ip.num_search_ports;
+          fFRAT->tdp_stats = fFRAT->stats_t;
+
+        } else if ((coredynp.rm_ty == CAMbased)) {
+          iFRAT->stats_t.readAc.access = iFRAT->l_ip.num_search_ports;
+          iFRAT->stats_t.writeAc.access = iFRAT->l_ip.num_wr_ports;
+          iFRAT->tdp_stats = iFRAT->stats_t;
+
+          fFRAT->stats_t.readAc.access = fFRAT->l_ip.num_search_ports;
+          fFRAT->stats_t.writeAc.access = fFRAT->l_ip.num_wr_ports;
+          fFRAT->tdp_stats = fFRAT->stats_t;
+        }
+        // Unified free list for both int and fp
+        ifreeL->stats_t.readAc.access =
+            coredynp.decodeW;  // ifreeL->l_ip.num_rd_ports;
+        ifreeL->stats_t.writeAc.access =
+            coredynp.decodeW;  // ifreeL->l_ip.num_wr_ports;
+        ifreeL->tdp_stats = ifreeL->stats_t;
+      }
+      idcl->stats_t.readAc.access = coredynp.decodeW;
+      fdcl->stats_t.readAc.access = coredynp.decodeW;
+      idcl->tdp_stats = idcl->stats_t;
+      fdcl->tdp_stats = fdcl->stats_t;
+    } else {
+      if (coredynp.issueW > 1) {
+        idcl->stats_t.readAc.access = coredynp.decodeW;
+        fdcl->stats_t.readAc.access = coredynp.decodeW;
+        idcl->tdp_stats = idcl->stats_t;
+        fdcl->tdp_stats = fdcl->stats_t;
+      }
+    }
+
+  } else {  // init stats for Runtime Dynamic (RTP)
+    if (coredynp.core_ty == OOO) {
+      if (coredynp.scheu_ty == PhysicalRegFile) {
+        if (coredynp.rm_ty == RAMbased) {
+          iFRAT->stats_t.readAc.access = XML->sys.core[ithCore].rename_reads;
+          iFRAT->stats_t.writeAc.access = XML->sys.core[ithCore].rename_writes;
+          iFRAT->rtp_stats = iFRAT->stats_t;
+
+          fFRAT->stats_t.readAc.access = XML->sys.core[ithCore].fp_rename_reads;
+          fFRAT->stats_t.writeAc.access =
+              XML->sys.core[ithCore].fp_rename_writes;
+          fFRAT->rtp_stats = fFRAT->stats_t;
+        } else if ((coredynp.rm_ty == CAMbased)) {
+          iFRAT->stats_t.readAc.access = XML->sys.core[ithCore].rename_reads;
+          iFRAT->stats_t.writeAc.access = XML->sys.core[ithCore].rename_writes;
+          iFRAT->rtp_stats = iFRAT->stats_t;
+
+          fFRAT->stats_t.readAc.access = XML->sys.core[ithCore].fp_rename_reads;
+          fFRAT->stats_t.writeAc.access =
+              XML->sys.core[ithCore].fp_rename_writes;
+          fFRAT->rtp_stats = fFRAT->stats_t;
+        }
+
+        iRRAT->stats_t.readAc.access =
+            XML->sys.core[ithCore].rename_writes;  // Hack, should be (context
+                                                   // switch + branch
+                                                   // mispredictions)*16
+        iRRAT->stats_t.writeAc.access = XML->sys.core[ithCore].rename_writes;
+        iRRAT->rtp_stats = iRRAT->stats_t;
+
+        fRRAT->stats_t.readAc.access =
+            XML->sys.core[ithCore].fp_rename_writes;  // Hack, should be
+                                                      // (context switch +
+                                                      // branch
+                                                      // mispredictions)*16
+        fRRAT->stats_t.writeAc.access = XML->sys.core[ithCore].fp_rename_writes;
+        fRRAT->rtp_stats = fRRAT->stats_t;
+
+        ifreeL->stats_t.readAc.access = XML->sys.core[ithCore].rename_reads;
+        ifreeL->stats_t.writeAc.access =
+            2 * XML->sys.core[ithCore].rename_writes;
+        ifreeL->rtp_stats = ifreeL->stats_t;
+
+        ffreeL->stats_t.readAc.access = XML->sys.core[ithCore].fp_rename_reads;
+        ffreeL->stats_t.writeAc.access =
+            2 * XML->sys.core[ithCore].fp_rename_writes;
+        ffreeL->rtp_stats = ffreeL->stats_t;
+      } else if (coredynp.scheu_ty == ReservationStation) {
+        if (coredynp.rm_ty == RAMbased) {
+          iFRAT->stats_t.readAc.access = XML->sys.core[ithCore].rename_reads;
+          iFRAT->stats_t.writeAc.access = XML->sys.core[ithCore].rename_writes;
+          iFRAT->stats_t.searchAc.access =
+              XML->sys.core[ithCore]
+                  .committed_int_instructions;  // hack: not all committed
+                                                // instructions use regs.
+          iFRAT->rtp_stats = iFRAT->stats_t;
+
+          fFRAT->stats_t.readAc.access = XML->sys.core[ithCore].fp_rename_reads;
+          fFRAT->stats_t.writeAc.access =
+              XML->sys.core[ithCore].fp_rename_writes;
+          fFRAT->stats_t.searchAc.access =
+              XML->sys.core[ithCore].committed_fp_instructions;
+          fFRAT->rtp_stats = fFRAT->stats_t;
+        } else if ((coredynp.rm_ty == CAMbased)) {
+          iFRAT->stats_t.readAc.access = XML->sys.core[ithCore].rename_reads;
+          iFRAT->stats_t.writeAc.access = XML->sys.core[ithCore].rename_writes;
+          iFRAT->rtp_stats = iFRAT->stats_t;
+
+          fFRAT->stats_t.readAc.access = XML->sys.core[ithCore].fp_rename_reads;
+          fFRAT->stats_t.writeAc.access =
+              XML->sys.core[ithCore].fp_rename_writes;
+          fFRAT->rtp_stats = fFRAT->stats_t;
+        }
+        // Unified free list for both int and fp since the ROB act as physcial
+        // registers
+        ifreeL->stats_t.readAc.access = XML->sys.core[ithCore].rename_reads +
+                                        XML->sys.core[ithCore].fp_rename_reads;
+        ifreeL->stats_t.writeAc.access =
+            2 * (XML->sys.core[ithCore].rename_writes +
+                 XML->sys.core[ithCore].fp_rename_writes);  // HACK: 2-> since
+                                                            // some of renaming
+                                                            // in the same group
+        // are terminated early
+        ifreeL->rtp_stats = ifreeL->stats_t;
+      }
+      idcl->stats_t.readAc.access = 3 * coredynp.decodeW * coredynp.decodeW *
+                                    XML->sys.core[ithCore].rename_reads;
+      fdcl->stats_t.readAc.access = 3 * coredynp.fp_issueW *
+                                    coredynp.fp_issueW *
+                                    XML->sys.core[ithCore].fp_rename_writes;
+      idcl->rtp_stats = idcl->stats_t;
+      fdcl->rtp_stats = fdcl->stats_t;
+    } else {
+      if (coredynp.issueW > 1) {
+        idcl->stats_t.readAc.access =
+            2 * XML->sys.core[ithCore].int_instructions;
+        fdcl->stats_t.readAc.access = XML->sys.core[ithCore].fp_instructions;
+        idcl->rtp_stats = idcl->stats_t;
+        fdcl->rtp_stats = fdcl->stats_t;
+      }
+    }
+  }
+  /* Compute engine */
+  if (coredynp.core_ty == OOO) {
+    if (coredynp.scheu_ty == PhysicalRegFile) {
+      if (coredynp.rm_ty == RAMbased) {
+        iFRAT->power_t.reset();
+        fFRAT->power_t.reset();
+
+        iFRAT->power_t.readOp.dynamic +=
+            (iFRAT->stats_t.readAc.access *
+                 (iFRAT->local_result.power.readOp.dynamic +
+                  idcl->power.readOp.dynamic) +
+             iFRAT->stats_t.writeAc.access *
+                 iFRAT->local_result.power.writeOp.dynamic);
+        fFRAT->power_t.readOp.dynamic +=
+            (fFRAT->stats_t.readAc.access *
+                 (fFRAT->local_result.power.readOp.dynamic +
+                  fdcl->power.readOp.dynamic) +
+             fFRAT->stats_t.writeAc.access *
+                 fFRAT->local_result.power.writeOp.dynamic);
+      } else if ((coredynp.rm_ty == CAMbased)) {
+        iFRAT->power_t.reset();
+        fFRAT->power_t.reset();
+        iFRAT->power_t.readOp.dynamic +=
+            (iFRAT->stats_t.readAc.access *
+                 (iFRAT->local_result.power.searchOp.dynamic +
+                  idcl->power.readOp.dynamic) +
+             iFRAT->stats_t.writeAc.access *
+                 iFRAT->local_result.power.writeOp.dynamic);
+        fFRAT->power_t.readOp.dynamic +=
+            (fFRAT->stats_t.readAc.access *
+                 (fFRAT->local_result.power.searchOp.dynamic +
+                  fdcl->power.readOp.dynamic) +
+             fFRAT->stats_t.writeAc.access *
+                 fFRAT->local_result.power.writeOp.dynamic);
+      }
+
+      iRRAT->power_t.reset();
+      fRRAT->power_t.reset();
+      ifreeL->power_t.reset();
+      ffreeL->power_t.reset();
+
+      iRRAT->power_t.readOp.dynamic +=
+          (iRRAT->stats_t.readAc.access *
+               iRRAT->local_result.power.readOp.dynamic +
+           iRRAT->stats_t.writeAc.access *
+               iRRAT->local_result.power.writeOp.dynamic);
+      fRRAT->power_t.readOp.dynamic +=
+          (fRRAT->stats_t.readAc.access *
+               fRRAT->local_result.power.readOp.dynamic +
+           fRRAT->stats_t.writeAc.access *
+               fRRAT->local_result.power.writeOp.dynamic);
+      ifreeL->power_t.readOp.dynamic +=
+          (ifreeL->stats_t.readAc.access *
+               ifreeL->local_result.power.readOp.dynamic +
+           ifreeL->stats_t.writeAc.access *
+               ifreeL->local_result.power.writeOp.dynamic);
+      ffreeL->power_t.readOp.dynamic +=
+          (ffreeL->stats_t.readAc.access *
+               ffreeL->local_result.power.readOp.dynamic +
+           ffreeL->stats_t.writeAc.access *
+               ffreeL->local_result.power.writeOp.dynamic);
+
+    } else if (coredynp.scheu_ty == ReservationStation) {
+      if (coredynp.rm_ty == RAMbased) {
+        iFRAT->power_t.reset();
+        fFRAT->power_t.reset();
+
+        iFRAT->power_t.readOp.dynamic +=
+            (iFRAT->stats_t.readAc.access *
+                 (iFRAT->local_result.power.readOp.dynamic +
+                  idcl->power.readOp.dynamic) +
+             iFRAT->stats_t.writeAc.access *
+                 iFRAT->local_result.power.writeOp.dynamic +
+             iFRAT->stats_t.searchAc.access *
+                 iFRAT->local_result.power.searchOp.dynamic);
+        fFRAT->power_t.readOp.dynamic +=
+            (fFRAT->stats_t.readAc.access *
+                 (fFRAT->local_result.power.readOp.dynamic +
+                  fdcl->power.readOp.dynamic) +
+             fFRAT->stats_t.writeAc.access *
+                 fFRAT->local_result.power.writeOp.dynamic +
+             fFRAT->stats_t.searchAc.access *
+                 fFRAT->local_result.power.searchOp.dynamic);
+      } else if ((coredynp.rm_ty == CAMbased)) {
+        iFRAT->power_t.reset();
+        fFRAT->power_t.reset();
+        iFRAT->power_t.readOp.dynamic +=
+            (iFRAT->stats_t.readAc.access *
+                 (iFRAT->local_result.power.searchOp.dynamic +
+                  idcl->power.readOp.dynamic) +
+             iFRAT->stats_t.writeAc.access *
+                 iFRAT->local_result.power.writeOp.dynamic);
+        fFRAT->power_t.readOp.dynamic +=
+            (fFRAT->stats_t.readAc.access *
+                 (fFRAT->local_result.power.searchOp.dynamic +
+                  fdcl->power.readOp.dynamic) +
+             fFRAT->stats_t.writeAc.access *
+                 fFRAT->local_result.power.writeOp.dynamic);
+      }
+      ifreeL->power_t.reset();
+      ifreeL->power_t.readOp.dynamic +=
+          (ifreeL->stats_t.readAc.access *
+               ifreeL->local_result.power.readOp.dynamic +
+           ifreeL->stats_t.writeAc.access *
+               ifreeL->local_result.power.writeOp.dynamic);
+    }
+
+  } else {
+    if (coredynp.issueW > 1) {
+      idcl->power_t.reset();
+      fdcl->power_t.reset();
+      set_pppm(pppm_t, idcl->stats_t.readAc.access, coredynp.num_hthreads,
+               coredynp.num_hthreads, idcl->stats_t.readAc.access);
+      idcl->power_t = idcl->power * pppm_t;
+      set_pppm(pppm_t, fdcl->stats_t.readAc.access, coredynp.num_hthreads,
+               coredynp.num_hthreads, idcl->stats_t.readAc.access);
+      fdcl->power_t = fdcl->power * pppm_t;
+    }
   }
 
-  if (XML->sys.Private_L2)
-  {
-	  area.set_area(area.get_area() + l2cache->area.get_area());
+  // assign value to tpd and rtp
+  if (is_tdp) {
+    if (coredynp.core_ty == OOO) {
+      if (coredynp.scheu_ty == PhysicalRegFile) {
+        iFRAT->power =
+            iFRAT->power_t +
+            (iFRAT->local_result.power) * coredynp.pppm_lkg_multhread +
+            idcl->power_t;
+        fFRAT->power =
+            fFRAT->power_t +
+            (fFRAT->local_result.power) * coredynp.pppm_lkg_multhread +
+            fdcl->power_t;
+        iRRAT->power = iRRAT->power_t +
+                       iRRAT->local_result.power * coredynp.pppm_lkg_multhread;
+        fRRAT->power = fRRAT->power_t +
+                       fRRAT->local_result.power * coredynp.pppm_lkg_multhread;
+        ifreeL->power =
+            ifreeL->power_t +
+            ifreeL->local_result.power * coredynp.pppm_lkg_multhread;
+        ffreeL->power =
+            ffreeL->power_t +
+            ffreeL->local_result.power * coredynp.pppm_lkg_multhread;
+        power = power + (iFRAT->power + fFRAT->power) +
+                (iRRAT->power + fRRAT->power) + (ifreeL->power + ffreeL->power);
+      } else if (coredynp.scheu_ty == ReservationStation) {
+        iFRAT->power =
+            iFRAT->power_t +
+            (iFRAT->local_result.power) * coredynp.pppm_lkg_multhread +
+            idcl->power_t;
+        fFRAT->power =
+            fFRAT->power_t +
+            (fFRAT->local_result.power) * coredynp.pppm_lkg_multhread +
+            fdcl->power_t;
+        ifreeL->power =
+            ifreeL->power_t +
+            ifreeL->local_result.power * coredynp.pppm_lkg_multhread;
+        power = power + (iFRAT->power + fFRAT->power) + ifreeL->power;
+      }
+    } else {
+      power = power + idcl->power_t + fdcl->power_t;
+    }
 
+  } else {
+    if (coredynp.core_ty == OOO) {
+      if (coredynp.scheu_ty == PhysicalRegFile) {
+        iFRAT->rt_power =
+            iFRAT->power_t +
+            (iFRAT->local_result.power) * coredynp.pppm_lkg_multhread +
+            idcl->power_t;
+        fFRAT->rt_power =
+            fFRAT->power_t +
+            (fFRAT->local_result.power) * coredynp.pppm_lkg_multhread +
+            fdcl->power_t;
+        iRRAT->rt_power =
+            iRRAT->power_t +
+            iRRAT->local_result.power * coredynp.pppm_lkg_multhread;
+        fRRAT->rt_power =
+            fRRAT->power_t +
+            fRRAT->local_result.power * coredynp.pppm_lkg_multhread;
+        ifreeL->rt_power =
+            ifreeL->power_t +
+            ifreeL->local_result.power * coredynp.pppm_lkg_multhread;
+        ffreeL->rt_power =
+            ffreeL->power_t +
+            ffreeL->local_result.power * coredynp.pppm_lkg_multhread;
+        rt_power = rt_power + (iFRAT->rt_power + fFRAT->rt_power) +
+                   (iRRAT->rt_power + fRRAT->rt_power) +
+                   (ifreeL->rt_power + ffreeL->rt_power);
+      } else if (coredynp.scheu_ty == ReservationStation) {
+        iFRAT->rt_power =
+            iFRAT->power_t +
+            (iFRAT->local_result.power) * coredynp.pppm_lkg_multhread +
+            idcl->power_t;
+        fFRAT->rt_power =
+            fFRAT->power_t +
+            (fFRAT->local_result.power) * coredynp.pppm_lkg_multhread +
+            fdcl->power_t;
+        ifreeL->rt_power =
+            ifreeL->power_t +
+            ifreeL->local_result.power * coredynp.pppm_lkg_multhread;
+        rt_power =
+            rt_power + (iFRAT->rt_power + fFRAT->rt_power) + ifreeL->rt_power;
+      }
+    } else {
+      rt_power = rt_power + idcl->power_t + fdcl->power_t;
+    }
   }
-//  //clock power
-//  clockNetwork.init_wire_external(is_default, &interface_ip);
-//  clockNetwork.clk_area           =area*1.1;//10% of placement overhead. rule of thumb
-//  clockNetwork.end_wiring_level   =5;//toplevel metal
-//  clockNetwork.start_wiring_level =5;//toplevel metal
-//  clockNetwork.num_regs           = corepipe.tot_stage_vector;
-//  clockNetwork.optimize_wire();
 }
 
+void RENAMINGU::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  if (!exist) return;
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
 
-void BranchPredictor::computeEnergy(bool is_tdp)
-{
-	if (!exist) return;
-	double r_access;
-	double w_access;
-	if (is_tdp)
-    {
-    	r_access = coredynp.predictionW*coredynp.BR_duty_cycle;
-    	w_access = 0*coredynp.BR_duty_cycle;
-    	globalBPT->stats_t.readAc.access  = r_access;
-    	globalBPT->stats_t.writeAc.access = w_access;
-    	globalBPT->tdp_stats = globalBPT->stats_t;
+  if (is_tdp) {
+    if (coredynp.core_ty == OOO) {
+      cout << indent_str << "Int Front End RAT:" << endl;
+      cout << indent_str_next << "Area = " << iFRAT->area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << iFRAT->power.readOp.dynamic * clockRate
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? iFRAT->power.readOp.longer_channel_leakage
+                            : iFRAT->power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << iFRAT->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << iFRAT->rt_power.readOp.dynamic / executionTime << " W" << endl;
+      cout << endl;
+      cout << indent_str << "FP Front End RAT:" << endl;
+      cout << indent_str_next << "Area = " << fFRAT->area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << fFRAT->power.readOp.dynamic * clockRate
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? fFRAT->power.readOp.longer_channel_leakage
+                            : fFRAT->power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << fFRAT->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << fFRAT->rt_power.readOp.dynamic / executionTime << " W" << endl;
+      cout << endl;
+      cout << indent_str << "Free List:" << endl;
+      cout << indent_str_next << "Area = " << ifreeL->area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << ifreeL->power.readOp.dynamic * clockRate
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? ifreeL->power.readOp.longer_channel_leakage
+                            : ifreeL->power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << ifreeL->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << ifreeL->rt_power.readOp.dynamic / executionTime << " W" << endl;
+      cout << endl;
 
-    	L1_localBPT->stats_t.readAc.access  = r_access;
-    	L1_localBPT->stats_t.writeAc.access = w_access;
-    	L1_localBPT->tdp_stats = L1_localBPT->stats_t;
-
-    	L2_localBPT->stats_t.readAc.access  = r_access;
-    	L2_localBPT->stats_t.writeAc.access = w_access;
-    	L2_localBPT->tdp_stats = L2_localBPT->stats_t;
-
-    	chooser->stats_t.readAc.access  = r_access;
-    	chooser->stats_t.writeAc.access = w_access;
-    	chooser->tdp_stats = chooser->stats_t;
-
-    	RAS->stats_t.readAc.access  = r_access;
-    	RAS->stats_t.writeAc.access = w_access;
-    	RAS->tdp_stats = RAS->stats_t;
+      if (coredynp.scheu_ty == PhysicalRegFile) {
+        cout << indent_str << "Int Retire RAT: " << endl;
+        cout << indent_str_next << "Area = " << iRRAT->area.get_area() * 1e-6
+             << " mm^2" << endl;
+        cout << indent_str_next
+             << "Peak Dynamic = " << iRRAT->power.readOp.dynamic * clockRate
+             << " W" << endl;
+        cout << indent_str_next << "Subthreshold Leakage = "
+             << (long_channel ? iRRAT->power.readOp.longer_channel_leakage
+                              : iRRAT->power.readOp.leakage)
+             << " W" << endl;
+        cout << indent_str_next
+             << "Gate Leakage = " << iRRAT->power.readOp.gate_leakage << " W"
+             << endl;
+        cout << indent_str_next << "Runtime Dynamic = "
+             << iRRAT->rt_power.readOp.dynamic / executionTime << " W" << endl;
+        cout << endl;
+        cout << indent_str << "FP Retire RAT:" << endl;
+        cout << indent_str_next << "Area = " << fRRAT->area.get_area() * 1e-6
+             << " mm^2" << endl;
+        cout << indent_str_next
+             << "Peak Dynamic = " << fRRAT->power.readOp.dynamic * clockRate
+             << " W" << endl;
+        cout << indent_str_next << "Subthreshold Leakage = "
+             << (long_channel ? fRRAT->power.readOp.longer_channel_leakage
+                              : fRRAT->power.readOp.leakage)
+             << " W" << endl;
+        cout << indent_str_next
+             << "Gate Leakage = " << fRRAT->power.readOp.gate_leakage << " W"
+             << endl;
+        cout << indent_str_next << "Runtime Dynamic = "
+             << fRRAT->rt_power.readOp.dynamic / executionTime << " W" << endl;
+        cout << endl;
+        cout << indent_str << "FP Free List:" << endl;
+        cout << indent_str_next << "Area = " << ffreeL->area.get_area() * 1e-6
+             << " mm^2" << endl;
+        cout << indent_str_next
+             << "Peak Dynamic = " << ffreeL->power.readOp.dynamic * clockRate
+             << " W" << endl;
+        cout << indent_str_next << "Subthreshold Leakage = "
+             << (long_channel ? ffreeL->power.readOp.longer_channel_leakage
+                              : ffreeL->power.readOp.leakage)
+             << " W" << endl;
+        cout << indent_str_next
+             << "Gate Leakage = " << ffreeL->power.readOp.gate_leakage << " W"
+             << endl;
+        cout << indent_str_next << "Runtime Dynamic = "
+             << ffreeL->rt_power.readOp.dynamic / executionTime << " W" << endl;
+        cout << endl;
+      }
+    } else {
+      cout << indent_str << "Int DCL:" << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << idcl->power.readOp.dynamic * clockRate
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? idcl->power.readOp.longer_channel_leakage
+                            : idcl->power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << idcl->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << idcl->rt_power.readOp.dynamic / executionTime << " W" << endl;
+      cout << indent_str << "FP DCL:" << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << fdcl->power.readOp.dynamic * clockRate
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? fdcl->power.readOp.longer_channel_leakage
+                            : fdcl->power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << fdcl->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << fdcl->rt_power.readOp.dynamic / executionTime << " W" << endl;
     }
-    else
-    {
-    	//The resolution of BPT accesses is coarse, but this is
-    	//because most simulators cannot track finer grained details
-    	r_access = XML->sys.core[ithCore].branch_instructions;
-    	w_access = XML->sys.core[ithCore].branch_mispredictions + 0.1*XML->sys.core[ithCore].branch_instructions;//10% of BR will flip internal bits//0
-    	globalBPT->stats_t.readAc.access  = r_access;
-    	globalBPT->stats_t.writeAc.access = w_access;
-    	globalBPT->rtp_stats = globalBPT->stats_t;
-
-    	L1_localBPT->stats_t.readAc.access  = r_access;
-    	L1_localBPT->stats_t.writeAc.access = w_access;
-    	L1_localBPT->rtp_stats = L1_localBPT->stats_t;
-
-    	L2_localBPT->stats_t.readAc.access  = r_access;
-    	L2_localBPT->stats_t.writeAc.access = w_access;
-    	L2_localBPT->rtp_stats = L2_localBPT->stats_t;
-
-    	chooser->stats_t.readAc.access  = r_access;
-    	chooser->stats_t.writeAc.access = w_access;
-    	chooser->rtp_stats = chooser->stats_t;
-
-    	RAS->stats_t.readAc.access  = XML->sys.core[ithCore].function_calls;
-    	RAS->stats_t.writeAc.access = XML->sys.core[ithCore].function_calls;
-    	RAS->rtp_stats = RAS->stats_t;
-   }
-
-	globalBPT->power_t.reset();
-	L1_localBPT->power_t.reset();
-	L2_localBPT->power_t.reset();
-	chooser->power_t.reset();
-	RAS->power_t.reset();
-
-    globalBPT->power_t.readOp.dynamic   +=  globalBPT->local_result.power.readOp.dynamic*globalBPT->stats_t.readAc.access +
-                globalBPT->stats_t.writeAc.access*globalBPT->local_result.power.writeOp.dynamic;
-    L1_localBPT->power_t.readOp.dynamic   +=  L1_localBPT->local_result.power.readOp.dynamic*L1_localBPT->stats_t.readAc.access +
-                L1_localBPT->stats_t.writeAc.access*L1_localBPT->local_result.power.writeOp.dynamic;
-
-    L2_localBPT->power_t.readOp.dynamic   +=  L2_localBPT->local_result.power.readOp.dynamic*L2_localBPT->stats_t.readAc.access +
-                L2_localBPT->stats_t.writeAc.access*L2_localBPT->local_result.power.writeOp.dynamic;
-
-    chooser->power_t.readOp.dynamic   +=  chooser->local_result.power.readOp.dynamic*chooser->stats_t.readAc.access +
-                chooser->stats_t.writeAc.access*chooser->local_result.power.writeOp.dynamic;
-    RAS->power_t.readOp.dynamic   +=  RAS->local_result.power.readOp.dynamic*RAS->stats_t.readAc.access +
-                RAS->stats_t.writeAc.access*RAS->local_result.power.writeOp.dynamic;
-
-    if (is_tdp)
-    {
-    	globalBPT->power = globalBPT->power_t + globalBPT->local_result.power*pppm_lkg;
-    	L1_localBPT->power = L1_localBPT->power_t + L1_localBPT->local_result.power*pppm_lkg;
-    	L2_localBPT->power = L2_localBPT->power_t + L2_localBPT->local_result.power*pppm_lkg;
-    	chooser->power = chooser->power_t + chooser->local_result.power*pppm_lkg;
-    	RAS->power = RAS->power_t + RAS->local_result.power*coredynp.pppm_lkg_multhread;
-
-    	power = power + globalBPT->power + L1_localBPT->power + chooser->power + RAS->power;
+  } else {
+    if (coredynp.core_ty == OOO) {
+      cout << indent_str_next << "Int Front End RAT    Peak Dynamic = "
+           << iFRAT->rt_power.readOp.dynamic * clockRate << " W" << endl;
+      cout << indent_str_next << "Int Front End RAT    Subthreshold Leakage = "
+           << iFRAT->rt_power.readOp.leakage << " W" << endl;
+      cout << indent_str_next << "Int Front End RAT    Gate Leakage = "
+           << iFRAT->rt_power.readOp.gate_leakage << " W" << endl;
+      cout << indent_str_next << "FP Front End RAT   Peak Dynamic = "
+           << fFRAT->rt_power.readOp.dynamic * clockRate << " W" << endl;
+      cout << indent_str_next << "FP Front End RAT   Subthreshold Leakage = "
+           << fFRAT->rt_power.readOp.leakage << " W" << endl;
+      cout << indent_str_next << "FP Front End RAT   Gate Leakage = "
+           << fFRAT->rt_power.readOp.gate_leakage << " W" << endl;
+      cout << indent_str_next << "Free List   Peak Dynamic = "
+           << ifreeL->rt_power.readOp.dynamic * clockRate << " W" << endl;
+      cout << indent_str_next << "Free List   Subthreshold Leakage = "
+           << ifreeL->rt_power.readOp.leakage << " W" << endl;
+      cout << indent_str_next << "Free List   Gate Leakage = "
+           << fFRAT->rt_power.readOp.gate_leakage << " W" << endl;
+      if (coredynp.scheu_ty == PhysicalRegFile) {
+        cout << indent_str_next << "Int Retire RAT   Peak Dynamic = "
+             << iRRAT->rt_power.readOp.dynamic * clockRate << " W" << endl;
+        cout << indent_str_next << "Int Retire RAT   Subthreshold Leakage = "
+             << iRRAT->rt_power.readOp.leakage << " W" << endl;
+        cout << indent_str_next << "Int Retire RAT   Gate Leakage = "
+             << iRRAT->rt_power.readOp.gate_leakage << " W" << endl;
+        cout << indent_str_next << "FP Retire RAT   Peak Dynamic = "
+             << fRRAT->rt_power.readOp.dynamic * clockRate << " W" << endl;
+        cout << indent_str_next << "FP Retire RAT   Subthreshold Leakage = "
+             << fRRAT->rt_power.readOp.leakage << " W" << endl;
+        cout << indent_str_next << "FP Retire RAT   Gate Leakage = "
+             << fRRAT->rt_power.readOp.gate_leakage << " W" << endl;
+        cout << indent_str_next << "FP Free List   Peak Dynamic = "
+             << ffreeL->rt_power.readOp.dynamic * clockRate << " W" << endl;
+        cout << indent_str_next << "FP Free List   Subthreshold Leakage = "
+             << ffreeL->rt_power.readOp.leakage << " W" << endl;
+        cout << indent_str_next << "FP Free List   Gate Leakage = "
+             << fFRAT->rt_power.readOp.gate_leakage << " W" << endl;
+      }
+    } else {
+      cout << indent_str_next << "Int DCL   Peak Dynamic = "
+           << idcl->rt_power.readOp.dynamic * clockRate << " W" << endl;
+      cout << indent_str_next << "Int DCL   Subthreshold Leakage = "
+           << idcl->rt_power.readOp.leakage << " W" << endl;
+      cout << indent_str_next
+           << "Int DCL   Gate Leakage = " << idcl->rt_power.readOp.gate_leakage
+           << " W" << endl;
+      cout << indent_str_next << "FP DCL   Peak Dynamic = "
+           << fdcl->rt_power.readOp.dynamic * clockRate << " W" << endl;
+      cout << indent_str_next << "FP DCL   Subthreshold Leakage = "
+           << fdcl->rt_power.readOp.leakage << " W" << endl;
+      cout << indent_str_next
+           << "FP DCL   Gate Leakage = " << fdcl->rt_power.readOp.gate_leakage
+           << " W" << endl;
     }
-    else
-    {
-    	globalBPT->rt_power = globalBPT->power_t + globalBPT->local_result.power*pppm_lkg;
-    	L1_localBPT->rt_power = L1_localBPT->power_t + L1_localBPT->local_result.power*pppm_lkg;
-    	L2_localBPT->rt_power = L2_localBPT->power_t + L2_localBPT->local_result.power*pppm_lkg;
-    	chooser->rt_power = chooser->power_t + chooser->local_result.power*pppm_lkg;
-    	RAS->rt_power = RAS->power_t + RAS->local_result.power*coredynp.pppm_lkg_multhread;
-    	rt_power = rt_power + globalBPT->rt_power + L1_localBPT->rt_power + chooser->rt_power + RAS->rt_power;
-    }
+  }
 }
 
-void BranchPredictor::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	if (!exist) return;
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
-	if (is_tdp)
-	{
-		cout << indent_str<< "Global Predictor:" << endl;
-		cout << indent_str_next << "Area = " << globalBPT->area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << globalBPT->power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? globalBPT->power.readOp.longer_channel_leakage:globalBPT->power.readOp.leakage) <<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << globalBPT->power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << globalBPT->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-		cout << indent_str << "Local Predictor:" << endl;
-		cout << indent_str << "L1_Local Predictor:" << endl;
-		cout << indent_str_next << "Area = " << L1_localBPT->area.get_area() *1e-6 << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << L1_localBPT->power.readOp.dynamic*clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? L1_localBPT->power.readOp.longer_channel_leakage:L1_localBPT->power.readOp.leakage)  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << L1_localBPT->power.readOp.gate_leakage  << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << L1_localBPT->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-		cout << indent_str << "L2_Local Predictor:" << endl;
-		cout << indent_str_next << "Area = " << L2_localBPT->area.get_area() *1e-6 << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << L2_localBPT->power.readOp.dynamic*clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? L2_localBPT->power.readOp.longer_channel_leakage:L2_localBPT->power.readOp.leakage)  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << L2_localBPT->power.readOp.gate_leakage  << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << L2_localBPT->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
+void SchedulerU::computeEnergy(bool is_tdp) {
+  if (!exist) return;
+  double ROB_duty_cycle;
+  //	ROB_duty_cycle = ((coredynp.ALU_duty_cycle +
+  //coredynp.num_muls>0?coredynp.MUL_duty_cycle:0
+  //			+ coredynp.num_fpus>0?coredynp.FPU_duty_cycle:0))*1.1<1 ?
+  //(coredynp.ALU_duty_cycle + coredynp.num_muls>0?coredynp.MUL_duty_cycle:0
+  //					+
+  //coredynp.num_fpus>0?coredynp.FPU_duty_cycle:0)*1.1:1;
+  ROB_duty_cycle = 1;
+  // init stats
+  if (is_tdp) {
+    if (coredynp.core_ty == OOO) {
+      int_inst_window->stats_t.readAc.access =
+          coredynp.issueW *
+          coredynp.num_pipelines;  // int_inst_window->l_ip.num_search_ports;
+      int_inst_window->stats_t.writeAc.access =
+          coredynp.issueW *
+          coredynp.num_pipelines;  // int_inst_window->l_ip.num_wr_ports;
+      int_inst_window->stats_t.searchAc.access =
+          coredynp.issueW * coredynp.num_pipelines;
+      int_inst_window->tdp_stats = int_inst_window->stats_t;
+      fp_inst_window->stats_t.readAc.access =
+          fp_inst_window->l_ip.num_rd_ports * coredynp.num_fp_pipelines;
+      fp_inst_window->stats_t.writeAc.access =
+          fp_inst_window->l_ip.num_wr_ports * coredynp.num_fp_pipelines;
+      fp_inst_window->stats_t.searchAc.access =
+          fp_inst_window->l_ip.num_search_ports * coredynp.num_fp_pipelines;
+      fp_inst_window->tdp_stats = fp_inst_window->stats_t;
 
-		cout << indent_str << "Chooser:" << endl;
-		cout << indent_str_next << "Area = " << chooser->area.get_area()  *1e-6 << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << chooser->power.readOp.dynamic*clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? chooser->power.readOp.longer_channel_leakage:chooser->power.readOp.leakage)  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << chooser->power.readOp.gate_leakage  << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << chooser->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-		cout << indent_str << "RAS:" << endl;
-		cout << indent_str_next << "Area = " << RAS->area.get_area() *1e-6 << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << RAS->power.readOp.dynamic*clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? RAS->power.readOp.longer_channel_leakage:RAS->power.readOp.leakage)  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << RAS->power.readOp.gate_leakage  << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << RAS->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-	}
-	else
-	{
-//		cout << indent_str_next << "Global Predictor    Peak Dynamic = " << globalBPT->rt_power.readOp.dynamic*clockRate << " W" << endl;
-//		cout << indent_str_next << "Global Predictor    Subthreshold Leakage = " << globalBPT->rt_power.readOp.leakage <<" W" << endl;
-//		cout << indent_str_next << "Global Predictor    Gate Leakage = " << globalBPT->rt_power.readOp.gate_leakage << " W" << endl;
-//		cout << indent_str_next << "Local Predictor   Peak Dynamic = " << L1_localBPT->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-//		cout << indent_str_next << "Local Predictor   Subthreshold Leakage = " << L1_localBPT->rt_power.readOp.leakage  << " W" << endl;
-//		cout << indent_str_next << "Local Predictor   Gate Leakage = " << L1_localBPT->rt_power.readOp.gate_leakage  << " W" << endl;
-//		cout << indent_str_next << "Chooser   Peak Dynamic = " << chooser->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-//		cout << indent_str_next << "Chooser   Subthreshold Leakage = " << chooser->rt_power.readOp.leakage  << " W" << endl;
-//		cout << indent_str_next << "Chooser   Gate Leakage = " << chooser->rt_power.readOp.gate_leakage  << " W" << endl;
-//		cout << indent_str_next << "RAS   Peak Dynamic = " << RAS->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-//		cout << indent_str_next << "RAS   Subthreshold Leakage = " << RAS->rt_power.readOp.leakage  << " W" << endl;
-//		cout << indent_str_next << "RAS   Gate Leakage = " << RAS->rt_power.readOp.gate_leakage  << " W" << endl;
-	}
+      if (XML->sys.core[ithCore].ROB_size > 0) {
+        ROB->stats_t.readAc.access =
+            coredynp.commitW * coredynp.num_pipelines * ROB_duty_cycle;
+        ROB->stats_t.writeAc.access =
+            coredynp.issueW * coredynp.num_pipelines * ROB_duty_cycle;
+        ROB->tdp_stats = ROB->stats_t;
 
+        /*
+         * When inst commits, ROB must be read.
+         * Because for Physcial register based cores, physical register tag in
+         * ROB
+         * need to be read out and write into RRAT/CAM based RAT.
+         * For RS based cores, register content that stored in ROB must be
+         * read out and stored in architectural registers.
+         *
+         * if no-register is involved, the ROB read out operation when
+         * instruction commits can be ignored.
+         * assuming 20% insts. belong this type.
+         * TODO: ROB duty_cycle need to be revisited
+         */
+      }
+
+    } else if (coredynp.multithreaded) {
+      int_inst_window->stats_t.readAc.access =
+          coredynp.issueW *
+          coredynp.num_pipelines;  // int_inst_window->l_ip.num_search_ports;
+      int_inst_window->stats_t.writeAc.access =
+          coredynp.issueW *
+          coredynp.num_pipelines;  // int_inst_window->l_ip.num_wr_ports;
+      int_inst_window->stats_t.searchAc.access =
+          coredynp.issueW * coredynp.num_pipelines;
+      int_inst_window->tdp_stats = int_inst_window->stats_t;
+    }
+
+  } else {  // rtp
+    if (coredynp.core_ty == OOO) {
+      int_inst_window->stats_t.readAc.access =
+          XML->sys.core[ithCore].inst_window_reads;
+      int_inst_window->stats_t.writeAc.access =
+          XML->sys.core[ithCore].inst_window_writes;
+      int_inst_window->stats_t.searchAc.access =
+          XML->sys.core[ithCore].inst_window_wakeup_accesses;
+      int_inst_window->rtp_stats = int_inst_window->stats_t;
+      fp_inst_window->stats_t.readAc.access =
+          XML->sys.core[ithCore].fp_inst_window_reads;
+      fp_inst_window->stats_t.writeAc.access =
+          XML->sys.core[ithCore].fp_inst_window_writes;
+      fp_inst_window->stats_t.searchAc.access =
+          XML->sys.core[ithCore].fp_inst_window_wakeup_accesses;
+      fp_inst_window->rtp_stats = fp_inst_window->stats_t;
+
+      if (XML->sys.core[ithCore].ROB_size > 0) {
+        ROB->stats_t.readAc.access = XML->sys.core[ithCore].ROB_reads;
+        ROB->stats_t.writeAc.access = XML->sys.core[ithCore].ROB_writes;
+        /* ROB need to be updated in RS based OOO when new values are produced,
+         * this update may happen before the commit stage when ROB entry is
+         * released
+         * 1. ROB write at instruction inserted in
+         * 2. ROB write as results produced (for RS based OOO only)
+         * 3. ROB read  as instruction committed. For RS based OOO, data values
+         * are read out and sent to ARF
+         * For Physical reg based OOO, no data stored in ROB, but register tags
+         * need to be
+         * read out and used to set the RRAT and to recycle the register tag to
+         * free list buffer
+         */
+        ROB->rtp_stats = ROB->stats_t;
+      }
+
+    } else if (coredynp.multithreaded) {
+      int_inst_window->stats_t.readAc.access =
+          XML->sys.core[ithCore].int_instructions +
+          XML->sys.core[ithCore].fp_instructions;
+      int_inst_window->stats_t.writeAc.access =
+          XML->sys.core[ithCore].int_instructions +
+          XML->sys.core[ithCore].fp_instructions;
+      int_inst_window->stats_t.searchAc.access =
+          2 * (XML->sys.core[ithCore].int_instructions +
+               XML->sys.core[ithCore].fp_instructions);
+      int_inst_window->rtp_stats = int_inst_window->stats_t;
+    }
+  }
+
+  // computation engine
+  if (coredynp.core_ty == OOO) {
+    int_inst_window->power_t.reset();
+    fp_inst_window->power_t.reset();
+
+    /* each instruction needs to write to scheduler, read out when all resources
+     * and source operands are ready
+     * two search ops with one for each source operand
+     *
+     */
+    int_inst_window->power_t.readOp.dynamic +=
+        int_inst_window->local_result.power.readOp.dynamic *
+            int_inst_window->stats_t.readAc.access +
+        int_inst_window->local_result.power.searchOp.dynamic *
+            int_inst_window->stats_t.searchAc.access +
+        int_inst_window->local_result.power.writeOp.dynamic *
+            int_inst_window->stats_t.writeAc.access +
+        int_inst_window->stats_t.readAc.access *
+            instruction_selection->power.readOp.dynamic;
+
+    fp_inst_window->power_t.readOp.dynamic +=
+        fp_inst_window->local_result.power.readOp.dynamic *
+            fp_inst_window->stats_t.readAc.access +
+        fp_inst_window->local_result.power.searchOp.dynamic *
+            fp_inst_window->stats_t.searchAc.access +
+        fp_inst_window->local_result.power.writeOp.dynamic *
+            fp_inst_window->stats_t.writeAc.access +
+        fp_inst_window->stats_t.writeAc.access *
+            instruction_selection->power.readOp.dynamic;
+
+    if (XML->sys.core[ithCore].ROB_size > 0) {
+      ROB->power_t.reset();
+      ROB->power_t.readOp.dynamic +=
+          ROB->local_result.power.readOp.dynamic * ROB->stats_t.readAc.access +
+          ROB->stats_t.writeAc.access * ROB->local_result.power.writeOp.dynamic;
+    }
+
+  } else if (coredynp.multithreaded) {
+    int_inst_window->power_t.reset();
+    int_inst_window->power_t.readOp.dynamic +=
+        int_inst_window->local_result.power.readOp.dynamic *
+            int_inst_window->stats_t.readAc.access +
+        int_inst_window->local_result.power.searchOp.dynamic *
+            int_inst_window->stats_t.searchAc.access +
+        int_inst_window->local_result.power.writeOp.dynamic *
+            int_inst_window->stats_t.writeAc.access +
+        int_inst_window->stats_t.writeAc.access *
+            instruction_selection->power.readOp.dynamic;
+  }
+
+  // assign values
+  if (is_tdp) {
+    if (coredynp.core_ty == OOO) {
+      int_inst_window->power =
+          int_inst_window->power_t +
+          (int_inst_window->local_result.power + instruction_selection->power) *
+              pppm_lkg;
+      fp_inst_window->power =
+          fp_inst_window->power_t +
+          (fp_inst_window->local_result.power + instruction_selection->power) *
+              pppm_lkg;
+      power = power + int_inst_window->power + fp_inst_window->power;
+      if (XML->sys.core[ithCore].ROB_size > 0) {
+        ROB->power = ROB->power_t + ROB->local_result.power * pppm_lkg;
+        power = power + ROB->power;
+      }
+
+    } else if (coredynp.multithreaded) {
+      //			set_pppm(pppm_t,
+      //XML->sys.core[ithCore].issue_width,1, 1, 1);
+      int_inst_window->power =
+          int_inst_window->power_t +
+          (int_inst_window->local_result.power + instruction_selection->power) *
+              pppm_lkg;
+      power = power + int_inst_window->power;
+    }
+
+  } else {  // rtp
+    if (coredynp.core_ty == OOO) {
+      int_inst_window->rt_power =
+          int_inst_window->power_t +
+          (int_inst_window->local_result.power + instruction_selection->power) *
+              pppm_lkg;
+      fp_inst_window->rt_power =
+          fp_inst_window->power_t +
+          (fp_inst_window->local_result.power + instruction_selection->power) *
+              pppm_lkg;
+      rt_power =
+          rt_power + int_inst_window->rt_power + fp_inst_window->rt_power;
+      if (XML->sys.core[ithCore].ROB_size > 0) {
+        ROB->rt_power = ROB->power_t + ROB->local_result.power * pppm_lkg;
+        rt_power = rt_power + ROB->rt_power;
+      }
+
+    } else if (coredynp.multithreaded) {
+      //			set_pppm(pppm_t,
+      //XML->sys.core[ithCore].issue_width,1, 1, 1);
+      int_inst_window->rt_power =
+          int_inst_window->power_t +
+          (int_inst_window->local_result.power + instruction_selection->power) *
+              pppm_lkg;
+      rt_power = rt_power + int_inst_window->rt_power;
+    }
+  }
+  //	set_pppm(pppm_t, XML->sys.core[ithCore].issue_width,1, 1, 1);
+  //	cout<<"Scheduler
+  //power="<<power.readOp.dynamic<<"leakage="<<power.readOp.leakage<<endl;
+  //	cout<<"IW="<<int_inst_window->local_result.power.searchOp.dynamic *
+  //int_inst_window->stats_t.readAc.access +
+  //    + int_inst_window->local_result.power.writeOp.dynamic *
+  //    int_inst_window->stats_t.writeAc.access<<"leakage="<<int_inst_window->local_result.power.readOp.leakage<<endl;
+  //	cout<<"selection"<<instruction_selection->power.readOp.dynamic<<"leakage"<<instruction_selection->power.readOp.leakage<<endl;
 }
 
-void InstFetchU::computeEnergy(bool is_tdp)
-{
-  executionTime=XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);//Syed
-  //cout <<"IFU: execution time: "<<XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6)<<endl;
-  //cout <<"IFU: total cycles"<<XML->sys.total_cycles<<endl;
-	if (!exist) return;
-	if (is_tdp)
-    {
-		//init stats for Peak
-    	icache.caches->stats_t.readAc.access  = icache.caches->l_ip.num_rw_ports*coredynp.IFU_duty_cycle;
-    	icache.caches->stats_t.readAc.miss    = 0;
-    	icache.caches->stats_t.readAc.hit     = icache.caches->stats_t.readAc.access - icache.caches->stats_t.readAc.miss;
-    	icache.caches->tdp_stats = icache.caches->stats_t;
+void SchedulerU::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  if (!exist) return;
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
 
-    	icache.missb->stats_t.readAc.access  = icache.missb->stats_t.readAc.hit=  icache.missb->l_ip.num_search_ports;
-    	icache.missb->stats_t.writeAc.access = icache.missb->stats_t.writeAc.hit= icache.missb->l_ip.num_search_ports;
-    	icache.missb->tdp_stats = icache.missb->stats_t;
-
-    	icache.ifb->stats_t.readAc.access  = icache.ifb->stats_t.readAc.hit=  icache.ifb->l_ip.num_search_ports;
-    	icache.ifb->stats_t.writeAc.access = icache.ifb->stats_t.writeAc.hit= icache.ifb->l_ip.num_search_ports;
-    	icache.ifb->tdp_stats = icache.ifb->stats_t;
-
-    	icache.prefetchb->stats_t.readAc.access  = icache.prefetchb->stats_t.readAc.hit= icache.prefetchb->l_ip.num_search_ports;
-    	icache.prefetchb->stats_t.writeAc.access = icache.ifb->stats_t.writeAc.hit= icache.ifb->l_ip.num_search_ports;
-    	icache.prefetchb->tdp_stats = icache.prefetchb->stats_t;
-
-    	IB->stats_t.readAc.access = IB->stats_t.writeAc.access = XML->sys.core[ithCore].peak_issue_width;
-    	IB->tdp_stats = IB->stats_t;
-
-    	if (coredynp.predictionW>0)
-    	{
-    		BTB->stats_t.readAc.access  = coredynp.predictionW;//XML->sys.core[ithCore].BTB.read_accesses;
-    		BTB->stats_t.writeAc.access = 0;//XML->sys.core[ithCore].BTB.write_accesses;
-    	}
-
-    	ID_inst->stats_t.readAc.access     = coredynp.decodeW;
-    	ID_operand->stats_t.readAc.access  = coredynp.decodeW;
-    	ID_misc->stats_t.readAc.access     = coredynp.decodeW;
-    	ID_inst->tdp_stats = ID_inst->stats_t;
-    	ID_operand->tdp_stats = ID_operand->stats_t;
-    	ID_misc->tdp_stats = ID_misc->stats_t;
-
-
-   
-	 } /* if (is_tdp) */
-    else
-    {
-      rt_power.reset();
-      icache.rt_power.reset(); //Jingwen
-     	//init stats for Runtime Dynamic (RTP)
-		//cout<< "****>>>>Icache stats:"<<endl;
-		//cout<<"Read accesses: "<< XML->sys.core[ithCore].icache.read_accesses << " Read misses: "<<XML->sys.core[ithCore].icache.read_misses<<endl;
-    	icache.caches->stats_t.readAc.access  = XML->sys.core[ithCore].icache.read_accesses;
-    	icache.caches->stats_t.readAc.miss    = XML->sys.core[ithCore].icache.read_misses;
-    	//cout<<endl<<"inside mcpat read access= "<<XML->sys.core[ithCore].icache.read_accesses;
-    	//cout<<endl<<"inside mcpat read miss= "<<XML->sys.core[ithCore].icache.read_misses;
-
-    	icache.caches->stats_t.readAc.hit     = icache.caches->stats_t.readAc.access - icache.caches->stats_t.readAc.miss;
-    	icache.caches->rtp_stats = icache.caches->stats_t;
-    	//cout<<endl<<"inside mcpat read hit= "<<icache.caches->stats_t.readAc.hit<<endl;
-    	icache.missb->stats_t.readAc.access  = icache.caches->stats_t.readAc.miss;
-    	icache.missb->stats_t.writeAc.access = icache.caches->stats_t.readAc.miss;
-    	icache.missb->rtp_stats = icache.missb->stats_t;
-
-    	icache.ifb->stats_t.readAc.access  = icache.caches->stats_t.readAc.miss;
-    	icache.ifb->stats_t.writeAc.access = icache.caches->stats_t.readAc.miss;
-    	icache.ifb->rtp_stats = icache.ifb->stats_t;
-
-    	icache.prefetchb->stats_t.readAc.access  = icache.caches->stats_t.readAc.miss;
-    	icache.prefetchb->stats_t.writeAc.access = icache.caches->stats_t.readAc.miss;
-    	icache.prefetchb->rtp_stats = icache.prefetchb->stats_t;
-
-    	IB->stats_t.readAc.access = IB->stats_t.writeAc.access = XML->sys.core[ithCore].total_instructions;
-    	IB->rtp_stats = IB->stats_t;
-    	//cout<<"IB: total instructions: "<<IB->stats_t.readAc.access <<endl;
-    	if (coredynp.predictionW>0)
-    	{
-    		BTB->stats_t.readAc.access  = XML->sys.core[ithCore].BTB.read_accesses;//XML->sys.core[ithCore].branch_instructions;
-    		BTB->stats_t.writeAc.access = XML->sys.core[ithCore].BTB.write_accesses;//XML->sys.core[ithCore].branch_mispredictions;
-    		BTB->rtp_stats = BTB->stats_t;
-    	}
-    	//cout<<"ID: total instructions: "<< XML->sys.core[ithCore].total_instructions<<endl;
-    	ID_inst->stats_t.readAc.access     = XML->sys.core[ithCore].total_instructions;
-    	ID_operand->stats_t.readAc.access  = XML->sys.core[ithCore].total_instructions;
-    	ID_misc->stats_t.readAc.access     = XML->sys.core[ithCore].total_instructions;
-    	ID_inst->rtp_stats = ID_inst->stats_t;
-    	ID_operand->rtp_stats = ID_operand->stats_t;
-    	ID_misc->rtp_stats = ID_misc->stats_t;
-
+  if (is_tdp) {
+    if (coredynp.core_ty == OOO) {
+      cout << indent_str << "Instruction Window:" << endl;
+      cout << indent_str_next
+           << "Area = " << int_inst_window->area.get_area() * 1e-6 << " mm^2"
+           << endl;
+      cout << indent_str_next << "Peak Dynamic = "
+           << int_inst_window->power.readOp.dynamic * clockRate << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel
+                   ? int_inst_window->power.readOp.longer_channel_leakage
+                   : int_inst_window->power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << int_inst_window->power.readOp.gate_leakage
+           << " W" << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << int_inst_window->rt_power.readOp.dynamic / executionTime << " W"
+           << endl;
+      cout << endl;
+      cout << indent_str << "FP Instruction Window:" << endl;
+      cout << indent_str_next
+           << "Area = " << fp_inst_window->area.get_area() * 1e-6 << " mm^2"
+           << endl;
+      cout << indent_str_next << "Peak Dynamic = "
+           << fp_inst_window->power.readOp.dynamic * clockRate << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel
+                   ? fp_inst_window->power.readOp.longer_channel_leakage
+                   : fp_inst_window->power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << fp_inst_window->power.readOp.gate_leakage
+           << " W" << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << fp_inst_window->rt_power.readOp.dynamic / executionTime << " W"
+           << endl;
+      cout << endl;
+      if (XML->sys.core[ithCore].ROB_size > 0) {
+        cout << indent_str << "ROB:" << endl;
+        cout << indent_str_next << "Area = " << ROB->area.get_area() * 1e-6
+             << " mm^2" << endl;
+        cout << indent_str_next
+             << "Peak Dynamic = " << ROB->power.readOp.dynamic * clockRate
+             << " W" << endl;
+        cout << indent_str_next << "Subthreshold Leakage = "
+             << (long_channel ? ROB->power.readOp.longer_channel_leakage
+                              : ROB->power.readOp.leakage)
+             << " W" << endl;
+        cout << indent_str_next
+             << "Gate Leakage = " << ROB->power.readOp.gate_leakage << " W"
+             << endl;
+        cout << indent_str_next << "Runtime Dynamic = "
+             << ROB->rt_power.readOp.dynamic / executionTime << " W" << endl;
+        cout << endl;
+      }
+    } else if (coredynp.multithreaded) {
+      cout << indent_str << "Instruction Window:" << endl;
+      cout << indent_str_next
+           << "Area = " << int_inst_window->area.get_area() * 1e-6 << " mm^2"
+           << endl;
+      cout << indent_str_next << "Peak Dynamic = "
+           << int_inst_window->power.readOp.dynamic * clockRate << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel
+                   ? int_inst_window->power.readOp.longer_channel_leakage
+                   : int_inst_window->power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << int_inst_window->power.readOp.gate_leakage
+           << " W" << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << int_inst_window->rt_power.readOp.dynamic / executionTime << " W"
+           << endl;
+      cout << endl;
     }
-
-    icache.power_t.reset();
-    IB->power_t.reset();
-//	ID_inst->power_t.reset();
-//	ID_operand->power_t.reset();
-//	ID_misc->power_t.reset();
-    if (coredynp.predictionW>0)
-    {
-    	BTB->power_t.reset();
+  } else {
+    if (coredynp.core_ty == OOO) {
+      cout << indent_str_next << "Instruction Window    Peak Dynamic = "
+           << int_inst_window->rt_power.readOp.dynamic * clockRate << " W"
+           << endl;
+      cout << indent_str_next << "Instruction Window    Subthreshold Leakage = "
+           << int_inst_window->rt_power.readOp.leakage << " W" << endl;
+      cout << indent_str_next << "Instruction Window    Gate Leakage = "
+           << int_inst_window->rt_power.readOp.gate_leakage << " W" << endl;
+      cout << indent_str_next << "FP Instruction Window   Peak Dynamic = "
+           << fp_inst_window->rt_power.readOp.dynamic * clockRate << " W"
+           << endl;
+      cout << indent_str_next
+           << "FP Instruction Window   Subthreshold Leakage = "
+           << fp_inst_window->rt_power.readOp.leakage << " W" << endl;
+      cout << indent_str_next << "FP Instruction Window   Gate Leakage = "
+           << fp_inst_window->rt_power.readOp.gate_leakage << " W" << endl;
+      if (XML->sys.core[ithCore].ROB_size > 0) {
+        cout << indent_str_next << "ROB   Peak Dynamic = "
+             << ROB->rt_power.readOp.dynamic * clockRate << " W" << endl;
+        cout << indent_str_next
+             << "ROB   Subthreshold Leakage = " << ROB->rt_power.readOp.leakage
+             << " W" << endl;
+        cout << indent_str_next
+             << "ROB   Gate Leakage = " << ROB->rt_power.readOp.gate_leakage
+             << " W" << endl;
+      }
+    } else if (coredynp.multithreaded) {
+      cout << indent_str_next << "Instruction Window    Peak Dynamic = "
+           << int_inst_window->rt_power.readOp.dynamic * clockRate << " W"
+           << endl;
+      cout << indent_str_next << "Instruction Window    Subthreshold Leakage = "
+           << int_inst_window->rt_power.readOp.leakage << " W" << endl;
+      cout << indent_str_next << "Instruction Window    Gate Leakage = "
+           << int_inst_window->rt_power.readOp.gate_leakage << " W" << endl;
     }
-
-    icache.power_t.readOp.dynamic	+= (icache.caches->stats_t.readAc.hit*icache.caches->local_result.power.readOp.dynamic+
-    		//icache.caches->stats_t.readAc.miss*icache.caches->local_result.tag_array2->power.readOp.dynamic+
-    		icache.caches->stats_t.readAc.miss*icache.caches->local_result.power.readOp.dynamic+ //assume tag data accessed in parallel
-    		icache.caches->stats_t.readAc.miss*icache.caches->local_result.power.writeOp.dynamic); //read miss in Icache cause a write to Icache
-    icache.power_t.readOp.dynamic	+=  icache.missb->stats_t.readAc.access*icache.missb->local_result.power.searchOp.dynamic +
-            icache.missb->stats_t.writeAc.access*icache.missb->local_result.power.writeOp.dynamic;//each access to missb involves a CAM and a write
-    icache.power_t.readOp.dynamic	+=  icache.ifb->stats_t.readAc.access*icache.ifb->local_result.power.searchOp.dynamic +
-            icache.ifb->stats_t.writeAc.access*icache.ifb->local_result.power.writeOp.dynamic;
-    icache.power_t.readOp.dynamic	+=  icache.prefetchb->stats_t.readAc.access*icache.prefetchb->local_result.power.searchOp.dynamic +
-            icache.prefetchb->stats_t.writeAc.access*icache.prefetchb->local_result.power.writeOp.dynamic;
-   //cout<<"Icache power: "<<icache.power_t.readOp.dynamic	<<endl;
-	IB->power_t.readOp.dynamic   +=  IB->local_result.power.readOp.dynamic*IB->stats_t.readAc.access +
-			IB->stats_t.writeAc.access*IB->local_result.power.writeOp.dynamic;
-  //cout << "IB power: "<<IB->power_t.readOp.dynamic<<endl;
-	if (coredynp.predictionW>0)
-	{
-		BTB->power_t.readOp.dynamic   +=  BTB->local_result.power.readOp.dynamic*BTB->stats_t.readAc.access +
-		BTB->stats_t.writeAc.access*BTB->local_result.power.writeOp.dynamic;
-
-		BPT->computeEnergy(is_tdp);
-	}
-
-    if (is_tdp)
-    {
-//    	icache.power = icache.power_t +
-//    	        (icache.caches->local_result.power)*pppm_lkg +
-//    			(icache.missb->local_result.power +
-//    			icache.ifb->local_result.power +
-//    			icache.prefetchb->local_result.power)*pppm_Isub;
-    	icache.power = icache.power_t +
-    	        (icache.caches->local_result.power +
-    			icache.missb->local_result.power +
-    			icache.ifb->local_result.power +
-    			icache.prefetchb->local_result.power)*pppm_lkg;
-
-    	IB->power = IB->power_t + IB->local_result.power*pppm_lkg;
-    	power     = power + icache.power + IB->power;
-    	if (coredynp.predictionW>0)
-    	{
-    		BTB->power = BTB->power_t + BTB->local_result.power*pppm_lkg;
-    		power     = power  + BTB->power + BPT->power;
-    	}
-
-    	ID_inst->power_t.readOp.dynamic    = ID_inst->power.readOp.dynamic;
-    	ID_operand->power_t.readOp.dynamic = ID_operand->power.readOp.dynamic;
-    	ID_misc->power_t.readOp.dynamic    = ID_misc->power.readOp.dynamic;
-
-    	ID_inst->power.readOp.dynamic    *= ID_inst->tdp_stats.readAc.access;
-    	ID_operand->power.readOp.dynamic *= ID_operand->tdp_stats.readAc.access;
-    	ID_misc->power.readOp.dynamic    *= ID_misc->tdp_stats.readAc.access;
-
-    	power = power + (ID_inst->power +
-							ID_operand->power +
-							ID_misc->power);
-	 } /* if (is_tdp) */ 
-    else
-    {
-//    	icache.rt_power = icache.power_t +
-//    	        (icache.caches->local_result.power)*pppm_lkg +
-//    			(icache.missb->local_result.power +
-//    			icache.ifb->local_result.power +
-//    			icache.prefetchb->local_result.power)*pppm_Isub;
-
-    	icache.rt_power = icache.power_t +
-    	        (icache.caches->local_result.power +
-    			icache.missb->local_result.power +
-    			icache.ifb->local_result.power +
-    			icache.prefetchb->local_result.power)*pppm_lkg;
-
-    	//IB->rt_power = IB->power_t + IB->local_result.power*pppm_lkg;
-    	IB->rt_power.readOp.dynamic = IB->local_result.power.readOp.dynamic * IB->rtp_stats.readAc.access;
-    	IB->rt_power.readOp.dynamic += IB->local_result.power.writeOp.dynamic * IB->rtp_stats.writeAc.access;
-    	rt_power     = rt_power + icache.rt_power + IB->rt_power;
-    	if (coredynp.predictionW>0)
-    	{
-    		BTB->rt_power = BTB->power_t + BTB->local_result.power*pppm_lkg;
-    		rt_power     = rt_power + BTB->rt_power + BPT->rt_power;
-    	}
-
-    	ID_inst->rt_power.readOp.dynamic    = ID_inst->power_t.readOp.dynamic*ID_inst->rtp_stats.readAc.access;
-    	ID_operand->rt_power.readOp.dynamic = ID_operand->power_t.readOp.dynamic * ID_operand->rtp_stats.readAc.access;
-    	ID_misc->rt_power.readOp.dynamic    = ID_misc->power_t.readOp.dynamic * ID_misc->rtp_stats.readAc.access;
-
-    	rt_power = rt_power + (ID_inst->rt_power +
-							ID_operand->rt_power +
-							ID_misc->rt_power);
-		//cout<<"ID inst: "<<ID_inst->rt_power.readOp.dynamic << " ID operand: "<<ID_operand->rt_power.readOp.dynamic<<" ID misc: "<<ID_misc->rt_power.readOp.dynamic<<endl;
-    }
+  }
 }
 
-void InstFetchU::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	if (!exist) return;
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
+void LoadStoreU::computeEnergy(bool is_tdp) {
+  if (!exist) return;
 
+  executionTime =
+      XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);  // Syed
 
-	if (is_tdp)
-	{
+  // RF crossbar power (Syed)
+  xbar_shared->compute_power();
 
-		cout << indent_str<< "Instruction Cache:" << endl;
-		cout << indent_str_next << "Area = " << icache.area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << icache.power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? icache.power.readOp.longer_channel_leakage:icache.power.readOp.leakage) <<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << icache.power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << icache.rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-		if (coredynp.predictionW>0)
-		{
-			cout << indent_str<< "Branch Target Buffer:" << endl;
-			cout << indent_str_next << "Area = " << BTB->area.get_area() *1e-6 << " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << BTB->power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? BTB->power.readOp.longer_channel_leakage:BTB->power.readOp.leakage)  << " W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << BTB->power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << BTB->rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-			if (BPT->exist)
-			{
-				cout << indent_str<< "Branch Predictor:" << endl;
-				cout << indent_str_next << "Area = " << BPT->area.get_area()  *1e-6<< " mm^2" << endl;
-				cout << indent_str_next << "Peak Dynamic = " << BPT->power.readOp.dynamic*clockRate  << " W" << endl;
-				cout << indent_str_next << "Subthreshold Leakage = "
-					<< (long_channel? BPT->power.readOp.longer_channel_leakage:BPT->power.readOp.leakage)  << " W" << endl;
-				cout << indent_str_next << "Gate Leakage = " << BPT->power.readOp.gate_leakage  << " W" << endl;
-				cout << indent_str_next << "Runtime Dynamic = " << BPT->rt_power.readOp.dynamic/executionTime << " W" << endl;
-				cout <<endl;
-				if (plevel>3)
-				{
-					BPT->displayEnergy(indent+4, plevel, is_tdp);
-				}
-			}
-		}
-		cout << indent_str<< "Instruction Buffer:" << endl;
-		cout << indent_str_next << "Area = " << IB->area.get_area()*1e-6  << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << IB->power.readOp.dynamic*clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-		<< (long_channel? IB->power.readOp.longer_channel_leakage:IB->power.readOp.leakage)  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << IB->power.readOp.gate_leakage  << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << IB->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-		cout << indent_str<< "Instruction Decoder:" << endl;
-		cout << indent_str_next << "Area = " << (ID_inst->area.get_area() +
-				ID_operand->area.get_area() +
-				ID_misc->area.get_area())*coredynp.decodeW*1e-6  << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << (ID_inst->power.readOp.dynamic +
-				ID_operand->power.readOp.dynamic +
-				ID_misc->power.readOp.dynamic)*clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-		<< (long_channel? (ID_inst->power.readOp.longer_channel_leakage +
-				ID_operand->power.readOp.longer_channel_leakage +
-				ID_misc->power.readOp.longer_channel_leakage):
-					(ID_inst->power.readOp.leakage +
-							ID_operand->power.readOp.leakage +
-							ID_misc->power.readOp.leakage))  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << (ID_inst->power.readOp.gate_leakage +
-				ID_operand->power.readOp.gate_leakage +
-				ID_misc->power.readOp.gate_leakage)  << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << (ID_inst->rt_power.readOp.dynamic +
-				ID_operand->rt_power.readOp.dynamic +
-				ID_misc->rt_power.readOp.dynamic)/executionTime << " W" << endl;
-		cout <<endl;
-	}
-	else
-	{
-//		cout << indent_str_next << "Instruction Cache    Peak Dynamic = " << icache.rt_power.readOp.dynamic*clockRate << " W" << endl;
-//		cout << indent_str_next << "Instruction Cache    Subthreshold Leakage = " << icache.rt_power.readOp.leakage <<" W" << endl;
-//		cout << indent_str_next << "Instruction Cache    Gate Leakage = " << icache.rt_power.readOp.gate_leakage << " W" << endl;
-//		cout << indent_str_next << "Instruction Buffer   Peak Dynamic = " << IB->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-//		cout << indent_str_next << "Instruction Buffer   Subthreshold Leakage = " << IB->rt_power.readOp.leakage  << " W" << endl;
-//		cout << indent_str_next << "Instruction Buffer   Gate Leakage = " << IB->rt_power.readOp.gate_leakage  << " W" << endl;
-//		cout << indent_str_next << "Branch Target Buffer   Peak Dynamic = " << BTB->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-//		cout << indent_str_next << "Branch Target Buffer   Subthreshold Leakage = " << BTB->rt_power.readOp.leakage  << " W" << endl;
-//		cout << indent_str_next << "Branch Target Buffer   Gate Leakage = " << BTB->rt_power.readOp.gate_leakage  << " W" << endl;
-//		cout << indent_str_next << "Branch Predictor   Peak Dynamic = " << BPT->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-//		cout << indent_str_next << "Branch Predictor   Subthreshold Leakage = " << BPT->rt_power.readOp.leakage  << " W" << endl;
-//		cout << indent_str_next << "Branch Predictor   Gate Leakage = " << BPT->rt_power.readOp.gate_leakage  << " W" << endl;
-	}
+  if (is_tdp) {
+    // init stats for Peak
+    // added by Jingwen
+    sharedmemory.caches->stats_t.readAc.access =
+        0.67 * sharedmemory.caches->l_ip.num_rw_ports * coredynp.LSU_duty_cycle;
+    sharedmemory.caches->stats_t.readAc.miss = 0;
+    sharedmemory.caches->stats_t.readAc.hit =
+        sharedmemory.caches->stats_t.readAc.access -
+        sharedmemory.caches->stats_t.readAc.miss;
+    sharedmemory.caches->stats_t.writeAc.access =
+        0.33 * sharedmemory.caches->l_ip.num_rw_ports * coredynp.LSU_duty_cycle;
+    sharedmemory.caches->stats_t.writeAc.miss = 0;
+    sharedmemory.caches->stats_t.writeAc.hit =
+        sharedmemory.caches->stats_t.writeAc.access -
+        sharedmemory.caches->stats_t.writeAc.miss;
+    sharedmemory.caches->tdp_stats = sharedmemory.caches->stats_t;
 
-}
+    sharedmemory.missb->stats_t.readAc.access =
+        sharedmemory.missb->l_ip.num_search_ports;
+    sharedmemory.missb->stats_t.writeAc.access =
+        sharedmemory.missb->l_ip.num_search_ports;
+    sharedmemory.missb->tdp_stats = sharedmemory.missb->stats_t;
 
-void RENAMINGU::computeEnergy(bool is_tdp)
-{
-	if (!exist) return;
-	double pppm_t[4]    = {1,1,1,1};
-	if (is_tdp)
-	{//init stats for Peak
-		if (coredynp.core_ty==OOO){
-			if (coredynp.scheu_ty==PhysicalRegFile)
-			{
-				if (coredynp.rm_ty ==RAMbased)
-				{
-					iFRAT->stats_t.readAc.access   = iFRAT->l_ip.num_rd_ports;
-					iFRAT->stats_t.writeAc.access  = iFRAT->l_ip.num_wr_ports;
-					iFRAT->tdp_stats = iFRAT->stats_t;
+    sharedmemory.ifb->stats_t.readAc.access =
+        sharedmemory.ifb->l_ip.num_search_ports;
+    sharedmemory.ifb->stats_t.writeAc.access =
+        sharedmemory.ifb->l_ip.num_search_ports;
+    sharedmemory.ifb->tdp_stats = sharedmemory.ifb->stats_t;
 
-					fFRAT->stats_t.readAc.access   = fFRAT->l_ip.num_rd_ports;
-					fFRAT->stats_t.writeAc.access  = fFRAT->l_ip.num_wr_ports;
-					fFRAT->tdp_stats = fFRAT->stats_t;
-
-				}
-				else if ((coredynp.rm_ty ==CAMbased))
-				{
-					iFRAT->stats_t.readAc.access   = iFRAT->l_ip.num_search_ports;
-					iFRAT->stats_t.writeAc.access  = iFRAT->l_ip.num_wr_ports;
-					iFRAT->tdp_stats = iFRAT->stats_t;
-
-					fFRAT->stats_t.readAc.access   = fFRAT->l_ip.num_search_ports;
-					fFRAT->stats_t.writeAc.access  = fFRAT->l_ip.num_wr_ports;
-					fFRAT->tdp_stats = fFRAT->stats_t;
-				}
-
-				iRRAT->stats_t.readAc.access   = iRRAT->l_ip.num_rd_ports;
-				iRRAT->stats_t.writeAc.access  = iRRAT->l_ip.num_wr_ports;
-				iRRAT->tdp_stats = iRRAT->stats_t;
-
-				fRRAT->stats_t.readAc.access   = fRRAT->l_ip.num_rd_ports;
-				fRRAT->stats_t.writeAc.access  = fRRAT->l_ip.num_wr_ports;
-				fRRAT->tdp_stats = fRRAT->stats_t;
-
-				ifreeL->stats_t.readAc.access   = coredynp.decodeW;//ifreeL->l_ip.num_rd_ports;;
-				ifreeL->stats_t.writeAc.access  = coredynp.decodeW;//ifreeL->l_ip.num_wr_ports;
-				ifreeL->tdp_stats = ifreeL->stats_t;
-
-				ffreeL->stats_t.readAc.access   = coredynp.decodeW;//ffreeL->l_ip.num_rd_ports;
-				ffreeL->stats_t.writeAc.access  = coredynp.decodeW;//ffreeL->l_ip.num_wr_ports;
-				ffreeL->tdp_stats = ffreeL->stats_t;
-			}
-			else if (coredynp.scheu_ty==ReservationStation){
-				if (coredynp.rm_ty ==RAMbased)
-				{
-					iFRAT->stats_t.readAc.access    = iFRAT->l_ip.num_rd_ports;
-					iFRAT->stats_t.writeAc.access   = iFRAT->l_ip.num_wr_ports;
-					iFRAT->stats_t.searchAc.access  = iFRAT->l_ip.num_search_ports;
-					iFRAT->tdp_stats = iFRAT->stats_t;
-
-					fFRAT->stats_t.readAc.access    = fFRAT->l_ip.num_rd_ports;
-					fFRAT->stats_t.writeAc.access   = fFRAT->l_ip.num_wr_ports;
-					fFRAT->stats_t.searchAc.access  = fFRAT->l_ip.num_search_ports;
-					fFRAT->tdp_stats = fFRAT->stats_t;
-
-				}
-				else if ((coredynp.rm_ty ==CAMbased))
-				{
-					iFRAT->stats_t.readAc.access   = iFRAT->l_ip.num_search_ports;
-					iFRAT->stats_t.writeAc.access  = iFRAT->l_ip.num_wr_ports;
-					iFRAT->tdp_stats = iFRAT->stats_t;
-
-					fFRAT->stats_t.readAc.access   = fFRAT->l_ip.num_search_ports;
-					fFRAT->stats_t.writeAc.access  = fFRAT->l_ip.num_wr_ports;
-					fFRAT->tdp_stats = fFRAT->stats_t;
-				}
-				//Unified free list for both int and fp
-				ifreeL->stats_t.readAc.access   = coredynp.decodeW;//ifreeL->l_ip.num_rd_ports;
-				ifreeL->stats_t.writeAc.access  = coredynp.decodeW;//ifreeL->l_ip.num_wr_ports;
-				ifreeL->tdp_stats = ifreeL->stats_t;
-			}
-			idcl->stats_t.readAc.access = coredynp.decodeW;
-			fdcl->stats_t.readAc.access = coredynp.decodeW;
-			idcl->tdp_stats = idcl->stats_t;
-			fdcl->tdp_stats = fdcl->stats_t;
-		}
-		else
-		{
-			if (coredynp.issueW>1)
-			{
-				idcl->stats_t.readAc.access = coredynp.decodeW;
-				fdcl->stats_t.readAc.access = coredynp.decodeW;
-				idcl->tdp_stats = idcl->stats_t;
-				fdcl->tdp_stats = fdcl->stats_t;
-			}
-		}
-
-	}
-	else
-	{//init stats for Runtime Dynamic (RTP)
-		if (coredynp.core_ty==OOO){
-			if (coredynp.scheu_ty==PhysicalRegFile)
-			{
-				if (coredynp.rm_ty ==RAMbased)
-				{
-					iFRAT->stats_t.readAc.access   = XML->sys.core[ithCore].rename_reads;
-					iFRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].rename_writes;
-					iFRAT->rtp_stats = iFRAT->stats_t;
-
-					fFRAT->stats_t.readAc.access   = XML->sys.core[ithCore].fp_rename_reads;
-					fFRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].fp_rename_writes;
-					fFRAT->rtp_stats = fFRAT->stats_t;
-				}
-				else if ((coredynp.rm_ty ==CAMbased))
-				{
-					iFRAT->stats_t.readAc.access   = XML->sys.core[ithCore].rename_reads;
-					iFRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].rename_writes;
-					iFRAT->rtp_stats = iFRAT->stats_t;
-
-					fFRAT->stats_t.readAc.access   = XML->sys.core[ithCore].fp_rename_reads;
-					fFRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].fp_rename_writes;
-					fFRAT->rtp_stats = fFRAT->stats_t;
-				}
-
-				iRRAT->stats_t.readAc.access   = XML->sys.core[ithCore].rename_writes;//Hack, should be (context switch + branch mispredictions)*16
-				iRRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].rename_writes;
-				iRRAT->rtp_stats = iRRAT->stats_t;
-
-				fRRAT->stats_t.readAc.access   = XML->sys.core[ithCore].fp_rename_writes;//Hack, should be (context switch + branch mispredictions)*16
-				fRRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].fp_rename_writes;
-				fRRAT->rtp_stats = fRRAT->stats_t;
-
-				ifreeL->stats_t.readAc.access   = XML->sys.core[ithCore].rename_reads;
-				ifreeL->stats_t.writeAc.access  = 2*XML->sys.core[ithCore].rename_writes;
-				ifreeL->rtp_stats = ifreeL->stats_t;
-
-				ffreeL->stats_t.readAc.access   = XML->sys.core[ithCore].fp_rename_reads;
-				ffreeL->stats_t.writeAc.access  = 2*XML->sys.core[ithCore].fp_rename_writes;
-				ffreeL->rtp_stats = ffreeL->stats_t;
-			}
-			else if (coredynp.scheu_ty==ReservationStation){
-				if (coredynp.rm_ty ==RAMbased)
-				{
-					iFRAT->stats_t.readAc.access   = XML->sys.core[ithCore].rename_reads;
-					iFRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].rename_writes;
-					iFRAT->stats_t.searchAc.access  = XML->sys.core[ithCore].committed_int_instructions;//hack: not all committed instructions use regs.
-					iFRAT->rtp_stats = iFRAT->stats_t;
-
-					fFRAT->stats_t.readAc.access   = XML->sys.core[ithCore].fp_rename_reads;
-					fFRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].fp_rename_writes;
-					fFRAT->stats_t.searchAc.access  = XML->sys.core[ithCore].committed_fp_instructions;
-					fFRAT->rtp_stats = fFRAT->stats_t;
-				}
-				else if ((coredynp.rm_ty ==CAMbased))
-				{
-					iFRAT->stats_t.readAc.access   = XML->sys.core[ithCore].rename_reads;
-					iFRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].rename_writes;
-					iFRAT->rtp_stats = iFRAT->stats_t;
-
-					fFRAT->stats_t.readAc.access   = XML->sys.core[ithCore].fp_rename_reads;
-					fFRAT->stats_t.writeAc.access  = XML->sys.core[ithCore].fp_rename_writes;
-					fFRAT->rtp_stats = fFRAT->stats_t;
-				}
-				//Unified free list for both int and fp since the ROB act as physcial registers
-				ifreeL->stats_t.readAc.access   = XML->sys.core[ithCore].rename_reads +
-					XML->sys.core[ithCore].fp_rename_reads;
-				ifreeL->stats_t.writeAc.access  = 2*(XML->sys.core[ithCore].rename_writes +
-					XML->sys.core[ithCore].fp_rename_writes);//HACK: 2-> since some of renaming in the same group
-															 //are terminated early
-				ifreeL->rtp_stats = ifreeL->stats_t;
-			}
-			idcl->stats_t.readAc.access = 3*coredynp.decodeW*coredynp.decodeW*XML->sys.core[ithCore].rename_reads;
-			fdcl->stats_t.readAc.access = 3*coredynp.fp_issueW*coredynp.fp_issueW*XML->sys.core[ithCore].fp_rename_writes;
-			idcl->rtp_stats = idcl->stats_t;
-			fdcl->rtp_stats = fdcl->stats_t;
-		}
-		else
-		{
-			if (coredynp.issueW>1)
-			{
-				idcl->stats_t.readAc.access = 2*XML->sys.core[ithCore].int_instructions;
-				fdcl->stats_t.readAc.access = XML->sys.core[ithCore].fp_instructions;
-				idcl->rtp_stats = idcl->stats_t;
-				fdcl->rtp_stats = fdcl->stats_t;
-			}
-		}
-
-	}
-    /* Compute engine */
-	if (coredynp.core_ty==OOO)
-	{
-		if (coredynp.scheu_ty==PhysicalRegFile)
-		{
-			if (coredynp.rm_ty ==RAMbased)
-			{
-				iFRAT->power_t.reset();
-				fFRAT->power_t.reset();
-
-				iFRAT->power_t.readOp.dynamic  +=  (iFRAT->stats_t.readAc.access
-						*(iFRAT->local_result.power.readOp.dynamic + idcl->power.readOp.dynamic)
-						+iFRAT->stats_t.writeAc.access*iFRAT->local_result.power.writeOp.dynamic);
-				fFRAT->power_t.readOp.dynamic  +=  (fFRAT->stats_t.readAc.access
-						*(fFRAT->local_result.power.readOp.dynamic + fdcl->power.readOp.dynamic)
-						+fFRAT->stats_t.writeAc.access*fFRAT->local_result.power.writeOp.dynamic);
-			}
-			else if ((coredynp.rm_ty ==CAMbased))
-			{
-				iFRAT->power_t.reset();
-				fFRAT->power_t.reset();
-				iFRAT->power_t.readOp.dynamic  +=  (iFRAT->stats_t.readAc.access
-						*(iFRAT->local_result.power.searchOp.dynamic + idcl->power.readOp.dynamic)
-						+iFRAT->stats_t.writeAc.access*iFRAT->local_result.power.writeOp.dynamic);
-				fFRAT->power_t.readOp.dynamic  +=  (fFRAT->stats_t.readAc.access
-						*(fFRAT->local_result.power.searchOp.dynamic + fdcl->power.readOp.dynamic)
-						+fFRAT->stats_t.writeAc.access*fFRAT->local_result.power.writeOp.dynamic);
-			}
-
-			iRRAT->power_t.reset();
-			fRRAT->power_t.reset();
-			ifreeL->power_t.reset();
-			ffreeL->power_t.reset();
-
-			iRRAT->power_t.readOp.dynamic  +=  (iRRAT->stats_t.readAc.access*iRRAT->local_result.power.readOp.dynamic
-					+iRRAT->stats_t.writeAc.access*iRRAT->local_result.power.writeOp.dynamic);
-			fRRAT->power_t.readOp.dynamic  +=  (fRRAT->stats_t.readAc.access*fRRAT->local_result.power.readOp.dynamic
-					+fRRAT->stats_t.writeAc.access*fRRAT->local_result.power.writeOp.dynamic);
-			ifreeL->power_t.readOp.dynamic  +=  (ifreeL->stats_t.readAc.access*ifreeL->local_result.power.readOp.dynamic
-					+ifreeL->stats_t.writeAc.access*ifreeL->local_result.power.writeOp.dynamic);
-			ffreeL->power_t.readOp.dynamic  +=  (ffreeL->stats_t.readAc.access*ffreeL->local_result.power.readOp.dynamic
-					+ffreeL->stats_t.writeAc.access*ffreeL->local_result.power.writeOp.dynamic);
-
-		}
-		else if (coredynp.scheu_ty==ReservationStation)
-		{
-			if (coredynp.rm_ty ==RAMbased)
-			{
-				iFRAT->power_t.reset();
-				fFRAT->power_t.reset();
-
-				iFRAT->power_t.readOp.dynamic  +=  (iFRAT->stats_t.readAc.access
-						*(iFRAT->local_result.power.readOp.dynamic + idcl->power.readOp.dynamic)
-						+iFRAT->stats_t.writeAc.access*iFRAT->local_result.power.writeOp.dynamic
-						+iFRAT->stats_t.searchAc.access*iFRAT->local_result.power.searchOp.dynamic);
-				fFRAT->power_t.readOp.dynamic  +=  (fFRAT->stats_t.readAc.access
-						*(fFRAT->local_result.power.readOp.dynamic + fdcl->power.readOp.dynamic)
-						+fFRAT->stats_t.writeAc.access*fFRAT->local_result.power.writeOp.dynamic
-						+fFRAT->stats_t.searchAc.access*fFRAT->local_result.power.searchOp.dynamic);
-			}
-			else if ((coredynp.rm_ty ==CAMbased))
-			{
-				iFRAT->power_t.reset();
-				fFRAT->power_t.reset();
-				iFRAT->power_t.readOp.dynamic  +=  (iFRAT->stats_t.readAc.access
-						*(iFRAT->local_result.power.searchOp.dynamic + idcl->power.readOp.dynamic)
-						+iFRAT->stats_t.writeAc.access*iFRAT->local_result.power.writeOp.dynamic);
-				fFRAT->power_t.readOp.dynamic  +=  (fFRAT->stats_t.readAc.access
-						*(fFRAT->local_result.power.searchOp.dynamic + fdcl->power.readOp.dynamic)
-						+fFRAT->stats_t.writeAc.access*fFRAT->local_result.power.writeOp.dynamic);
-			}
-			ifreeL->power_t.reset();
-			ifreeL->power_t.readOp.dynamic  +=  (ifreeL->stats_t.readAc.access*ifreeL->local_result.power.readOp.dynamic
-					+ifreeL->stats_t.writeAc.access*ifreeL->local_result.power.writeOp.dynamic);
-		}
-
-	}
-	else
-	{
-		if (coredynp.issueW>1)
-		{
-			idcl->power_t.reset();
-			fdcl->power_t.reset();
-			set_pppm(pppm_t, idcl->stats_t.readAc.access, coredynp.num_hthreads, coredynp.num_hthreads, idcl->stats_t.readAc.access);
-			idcl->power_t = idcl->power * pppm_t;
-			set_pppm(pppm_t, fdcl->stats_t.readAc.access, coredynp.num_hthreads, coredynp.num_hthreads, idcl->stats_t.readAc.access);
-			fdcl->power_t = fdcl->power * pppm_t;
-		}
-
-	}
-
-	//assign value to tpd and rtp
-	if (is_tdp)
-	{
-		if (coredynp.core_ty==OOO)
-		{
-			if (coredynp.scheu_ty==PhysicalRegFile)
-			{
-				iFRAT->power   =  iFRAT->power_t + (iFRAT->local_result.power ) * coredynp.pppm_lkg_multhread + idcl->power_t;
-				fFRAT->power   =  fFRAT->power_t + (fFRAT->local_result.power ) * coredynp.pppm_lkg_multhread + fdcl->power_t;
-				iRRAT->power   =  iRRAT->power_t + iRRAT->local_result.power * coredynp.pppm_lkg_multhread;
-				fRRAT->power   =  fRRAT->power_t + fRRAT->local_result.power * coredynp.pppm_lkg_multhread;
-				ifreeL->power  =  ifreeL->power_t + ifreeL->local_result.power * coredynp.pppm_lkg_multhread;
-				ffreeL->power  =  ffreeL->power_t + ffreeL->local_result.power * coredynp.pppm_lkg_multhread;
-				power	       =  power + (iFRAT->power + fFRAT->power)
-				                 + (iRRAT->power + fRRAT->power)
-				                 + (ifreeL->power + ffreeL->power);
-			}
-			else if (coredynp.scheu_ty==ReservationStation)
-			{
-				iFRAT->power   =  iFRAT->power_t + (iFRAT->local_result.power ) * coredynp.pppm_lkg_multhread + idcl->power_t;
-				fFRAT->power   =  fFRAT->power_t + (fFRAT->local_result.power ) * coredynp.pppm_lkg_multhread + fdcl->power_t;
-				ifreeL->power  =  ifreeL->power_t + ifreeL->local_result.power * coredynp.pppm_lkg_multhread;
-				power	       =  power + (iFRAT->power + fFRAT->power)
-				                 + ifreeL->power;
-			}
-		}
-		else
-		{
-			power   =  power + idcl->power_t + fdcl->power_t;
-		}
-
-	}
-	else
-	{
-		if (coredynp.core_ty==OOO)
-		{
-			if (coredynp.scheu_ty==PhysicalRegFile)
-			{
-				iFRAT->rt_power   =  iFRAT->power_t + (iFRAT->local_result.power ) * coredynp.pppm_lkg_multhread + idcl->power_t;
-				fFRAT->rt_power   =  fFRAT->power_t + (fFRAT->local_result.power ) * coredynp.pppm_lkg_multhread + fdcl->power_t;
-				iRRAT->rt_power   =  iRRAT->power_t + iRRAT->local_result.power * coredynp.pppm_lkg_multhread;
-				fRRAT->rt_power   =  fRRAT->power_t + fRRAT->local_result.power * coredynp.pppm_lkg_multhread;
-				ifreeL->rt_power  =  ifreeL->power_t + ifreeL->local_result.power * coredynp.pppm_lkg_multhread;
-				ffreeL->rt_power  =  ffreeL->power_t + ffreeL->local_result.power * coredynp.pppm_lkg_multhread;
-				rt_power	      =  rt_power + (iFRAT->rt_power + fFRAT->rt_power)
-				                   + (iRRAT->rt_power + fRRAT->rt_power)
-				                   + (ifreeL->rt_power + ffreeL->rt_power);
-			}
-			else if (coredynp.scheu_ty==ReservationStation)
-			{
-				iFRAT->rt_power   =  iFRAT->power_t + (iFRAT->local_result.power ) * coredynp.pppm_lkg_multhread + idcl->power_t;
-				fFRAT->rt_power   =  fFRAT->power_t + (fFRAT->local_result.power ) * coredynp.pppm_lkg_multhread + fdcl->power_t;
-				ifreeL->rt_power  =  ifreeL->power_t + ifreeL->local_result.power * coredynp.pppm_lkg_multhread;
-				rt_power	      =  rt_power + (iFRAT->rt_power + fFRAT->rt_power)
-				                   + ifreeL->rt_power;
-			}
-		}
-		else
-		{
-			rt_power   =  rt_power + idcl->power_t + fdcl->power_t;
-		}
-
-	}
-}
-
-void RENAMINGU::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	if (!exist) return;
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
-
-
-	if (is_tdp)
-	{
-
-		if (coredynp.core_ty==OOO)
-		{
-			cout << indent_str<< "Int Front End RAT:" << endl;
-			cout << indent_str_next << "Area = " << iFRAT->area.get_area()*1e-6<< " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << iFRAT->power.readOp.dynamic*clockRate << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? iFRAT->power.readOp.longer_channel_leakage:iFRAT->power.readOp.leakage) <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << iFRAT->power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << iFRAT->rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-			cout << indent_str<< "FP Front End RAT:" << endl;
-			cout << indent_str_next << "Area = " << fFRAT->area.get_area()*1e-6  << " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << fFRAT->power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? fFRAT->power.readOp.longer_channel_leakage:fFRAT->power.readOp.leakage)  << " W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << fFRAT->power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << fFRAT->rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-			cout << indent_str<<"Free List:" << endl;
-			cout << indent_str_next << "Area = " << ifreeL->area.get_area()*1e-6  << " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << ifreeL->power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? ifreeL->power.readOp.longer_channel_leakage:ifreeL->power.readOp.leakage)  << " W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << ifreeL->power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << ifreeL->rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-
-			if (coredynp.scheu_ty==PhysicalRegFile)
-			{
-				cout << indent_str<< "Int Retire RAT: " << endl;
-				cout << indent_str_next << "Area = " << iRRAT->area.get_area() *1e-6 << " mm^2" << endl;
-				cout << indent_str_next << "Peak Dynamic = " << iRRAT->power.readOp.dynamic*clockRate  << " W" << endl;
-				cout << indent_str_next << "Subthreshold Leakage = "
-					<< (long_channel? iRRAT->power.readOp.longer_channel_leakage:iRRAT->power.readOp.leakage)  << " W" << endl;
-				cout << indent_str_next << "Gate Leakage = " << iRRAT->power.readOp.gate_leakage  << " W" << endl;
-				cout << indent_str_next << "Runtime Dynamic = " << iRRAT->rt_power.readOp.dynamic/executionTime << " W" << endl;
-				cout <<endl;
-				cout << indent_str<< "FP Retire RAT:" << endl;
-				cout << indent_str_next << "Area = " << fRRAT->area.get_area()  *1e-6<< " mm^2" << endl;
-				cout << indent_str_next << "Peak Dynamic = " << fRRAT->power.readOp.dynamic*clockRate  << " W" << endl;
-				cout << indent_str_next << "Subthreshold Leakage = "
-					<< (long_channel? fRRAT->power.readOp.longer_channel_leakage:fRRAT->power.readOp.leakage)  << " W" << endl;
-				cout << indent_str_next << "Gate Leakage = " << fRRAT->power.readOp.gate_leakage  << " W" << endl;
-				cout << indent_str_next << "Runtime Dynamic = " << fRRAT->rt_power.readOp.dynamic/executionTime << " W" << endl;
-				cout <<endl;
-				cout << indent_str<< "FP Free List:" << endl;
-				cout << indent_str_next << "Area = " << ffreeL->area.get_area()*1e-6  << " mm^2" << endl;
-				cout << indent_str_next << "Peak Dynamic = " << ffreeL->power.readOp.dynamic*clockRate  << " W" << endl;
-				cout << indent_str_next << "Subthreshold Leakage = "
-					<< (long_channel? ffreeL->power.readOp.longer_channel_leakage:ffreeL->power.readOp.leakage)  << " W" << endl;
-				cout << indent_str_next << "Gate Leakage = " << ffreeL->power.readOp.gate_leakage  << " W" << endl;
-				cout << indent_str_next << "Runtime Dynamic = " << ffreeL->rt_power.readOp.dynamic/executionTime << " W" << endl;
-				cout <<endl;
-			}
-		}
-		else
-		{
-			cout << indent_str<< "Int DCL:" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << idcl->power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? idcl->power.readOp.longer_channel_leakage:idcl->power.readOp.leakage)  << " W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << idcl->power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << idcl->rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout << indent_str<<"FP DCL:" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << fdcl->power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? fdcl->power.readOp.longer_channel_leakage:fdcl->power.readOp.leakage)  << " W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << fdcl->power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << fdcl->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		}
-	}
-	else
-	{
-		if (coredynp.core_ty==OOO)
-		{
-			cout << indent_str_next << "Int Front End RAT    Peak Dynamic = " << iFRAT->rt_power.readOp.dynamic*clockRate << " W" << endl;
-			cout << indent_str_next << "Int Front End RAT    Subthreshold Leakage = " << iFRAT->rt_power.readOp.leakage <<" W" << endl;
-			cout << indent_str_next << "Int Front End RAT    Gate Leakage = " << iFRAT->rt_power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next << "FP Front End RAT   Peak Dynamic = " << fFRAT->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "FP Front End RAT   Subthreshold Leakage = " << fFRAT->rt_power.readOp.leakage  << " W" << endl;
-			cout << indent_str_next << "FP Front End RAT   Gate Leakage = " << fFRAT->rt_power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Free List   Peak Dynamic = " << ifreeL->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Free List   Subthreshold Leakage = " << ifreeL->rt_power.readOp.leakage  << " W" << endl;
-			cout << indent_str_next << "Free List   Gate Leakage = " << fFRAT->rt_power.readOp.gate_leakage  << " W" << endl;
-			if (coredynp.scheu_ty==PhysicalRegFile)
-			{
-				cout << indent_str_next << "Int Retire RAT   Peak Dynamic = " << iRRAT->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-				cout << indent_str_next << "Int Retire RAT   Subthreshold Leakage = " << iRRAT->rt_power.readOp.leakage  << " W" << endl;
-				cout << indent_str_next << "Int Retire RAT   Gate Leakage = " << iRRAT->rt_power.readOp.gate_leakage  << " W" << endl;
-				cout << indent_str_next << "FP Retire RAT   Peak Dynamic = " << fRRAT->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-				cout << indent_str_next << "FP Retire RAT   Subthreshold Leakage = " << fRRAT->rt_power.readOp.leakage  << " W" << endl;
-				cout << indent_str_next << "FP Retire RAT   Gate Leakage = " << fRRAT->rt_power.readOp.gate_leakage  << " W" << endl;
-				cout << indent_str_next << "FP Free List   Peak Dynamic = " << ffreeL->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-				cout << indent_str_next << "FP Free List   Subthreshold Leakage = " << ffreeL->rt_power.readOp.leakage  << " W" << endl;
-				cout << indent_str_next << "FP Free List   Gate Leakage = " << fFRAT->rt_power.readOp.gate_leakage  << " W" << endl;
-			}
-		}
-		else
-		{
-			cout << indent_str_next << "Int DCL   Peak Dynamic = " << idcl->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Int DCL   Subthreshold Leakage = " << idcl->rt_power.readOp.leakage  << " W" << endl;
-			cout << indent_str_next << "Int DCL   Gate Leakage = " << idcl->rt_power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "FP DCL   Peak Dynamic = " << fdcl->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "FP DCL   Subthreshold Leakage = " << fdcl->rt_power.readOp.leakage  << " W" << endl;
-			cout << indent_str_next << "FP DCL   Gate Leakage = " << fdcl->rt_power.readOp.gate_leakage  << " W" << endl;
-		}
-	}
-
-}
-
-
-void SchedulerU::computeEnergy(bool is_tdp)
-{
-	if (!exist) return;
-	double ROB_duty_cycle;
-//	ROB_duty_cycle = ((coredynp.ALU_duty_cycle + coredynp.num_muls>0?coredynp.MUL_duty_cycle:0
-//			+ coredynp.num_fpus>0?coredynp.FPU_duty_cycle:0))*1.1<1 ? (coredynp.ALU_duty_cycle + coredynp.num_muls>0?coredynp.MUL_duty_cycle:0
-//					+ coredynp.num_fpus>0?coredynp.FPU_duty_cycle:0)*1.1:1;
-	ROB_duty_cycle = 1;
-	//init stats
-	if (is_tdp)
-	{
-		if (coredynp.core_ty==OOO)
-		{
-			int_inst_window->stats_t.readAc.access    = coredynp.issueW*coredynp.num_pipelines;//int_inst_window->l_ip.num_search_ports;
-			int_inst_window->stats_t.writeAc.access   = coredynp.issueW*coredynp.num_pipelines;//int_inst_window->l_ip.num_wr_ports;
-			int_inst_window->stats_t.searchAc.access  = coredynp.issueW*coredynp.num_pipelines;
-			int_inst_window->tdp_stats                = int_inst_window->stats_t;
-			fp_inst_window->stats_t.readAc.access     = fp_inst_window->l_ip.num_rd_ports*coredynp.num_fp_pipelines;
-			fp_inst_window->stats_t.writeAc.access    = fp_inst_window->l_ip.num_wr_ports*coredynp.num_fp_pipelines;
-			fp_inst_window->stats_t.searchAc.access   = fp_inst_window->l_ip.num_search_ports*coredynp.num_fp_pipelines;
-			fp_inst_window->tdp_stats                 = fp_inst_window->stats_t;
-
-			if (XML->sys.core[ithCore].ROB_size >0)
-			{
-				ROB->stats_t.readAc.access   = coredynp.commitW*coredynp.num_pipelines*ROB_duty_cycle;
-				ROB->stats_t.writeAc.access  = coredynp.issueW*coredynp.num_pipelines*ROB_duty_cycle;
-				ROB->tdp_stats        = ROB->stats_t;
-
-				/*
-				 * When inst commits, ROB must be read.
-				 * Because for Physcial register based cores, physical register tag in ROB
-				 * need to be read out and write into RRAT/CAM based RAT.
-				 * For RS based cores, register content that stored in ROB must be
-				 * read out and stored in architectural registers.
-				 *
-				 * if no-register is involved, the ROB read out operation when instruction commits can be ignored.
-				 * assuming 20% insts. belong this type.
-				 * TODO: ROB duty_cycle need to be revisited
-				 */
-			}
-
-		}
-		else if (coredynp.multithreaded)
-		{
-			int_inst_window->stats_t.readAc.access   = coredynp.issueW*coredynp.num_pipelines;//int_inst_window->l_ip.num_search_ports;
-			int_inst_window->stats_t.writeAc.access  = coredynp.issueW*coredynp.num_pipelines;//int_inst_window->l_ip.num_wr_ports;
-			int_inst_window->stats_t.searchAc.access = coredynp.issueW*coredynp.num_pipelines;
-			int_inst_window->tdp_stats       = int_inst_window->stats_t;
-		}
-
-     }
-    else
-    {//rtp
-		if (coredynp.core_ty==OOO)
-		{
-			int_inst_window->stats_t.readAc.access   = XML->sys.core[ithCore].inst_window_reads;
-			int_inst_window->stats_t.writeAc.access  = XML->sys.core[ithCore].inst_window_writes;
-			int_inst_window->stats_t.searchAc.access = XML->sys.core[ithCore].inst_window_wakeup_accesses;
-			int_inst_window->rtp_stats               = int_inst_window->stats_t;
-			fp_inst_window->stats_t.readAc.access    = XML->sys.core[ithCore].fp_inst_window_reads;
-			fp_inst_window->stats_t.writeAc.access   = XML->sys.core[ithCore].fp_inst_window_writes;
-			fp_inst_window->stats_t.searchAc.access  = XML->sys.core[ithCore].fp_inst_window_wakeup_accesses;
-			fp_inst_window->rtp_stats                = fp_inst_window->stats_t;
-
-			if (XML->sys.core[ithCore].ROB_size >0)
-			{
-
-				ROB->stats_t.readAc.access   = XML->sys.core[ithCore].ROB_reads;
-				ROB->stats_t.writeAc.access  = XML->sys.core[ithCore].ROB_writes;
-				/* ROB need to be updated in RS based OOO when new values are produced,
-				 * this update may happen before the commit stage when ROB entry is released
-				 * 1. ROB write at instruction inserted in
-				 * 2. ROB write as results produced (for RS based OOO only)
-				 * 3. ROB read  as instruction committed. For RS based OOO, data values are read out and sent to ARF
-				 * For Physical reg based OOO, no data stored in ROB, but register tags need to be
-				 * read out and used to set the RRAT and to recycle the register tag to free list buffer
-				 */
-				ROB->rtp_stats        = ROB->stats_t;
-			}
-
-		}
-		else if (coredynp.multithreaded)
-		{
-			int_inst_window->stats_t.readAc.access    = XML->sys.core[ithCore].int_instructions + XML->sys.core[ithCore].fp_instructions;
-			int_inst_window->stats_t.writeAc.access   = XML->sys.core[ithCore].int_instructions + XML->sys.core[ithCore].fp_instructions;
-			int_inst_window->stats_t.searchAc.access  = 2*(XML->sys.core[ithCore].int_instructions + XML->sys.core[ithCore].fp_instructions);
-			int_inst_window->rtp_stats                = int_inst_window->stats_t;
-		}
+    sharedmemory.prefetchb->stats_t.readAc.access =
+        sharedmemory.prefetchb->l_ip.num_search_ports;
+    sharedmemory.prefetchb->stats_t.writeAc.access =
+        sharedmemory.ifb->l_ip.num_search_ports;
+    sharedmemory.prefetchb->tdp_stats = sharedmemory.prefetchb->stats_t;
+    if (cache_p == Write_back) {
+      sharedmemory.wbb->stats_t.readAc.access =
+          sharedmemory.wbb->l_ip.num_search_ports;
+      sharedmemory.wbb->stats_t.writeAc.access =
+          sharedmemory.wbb->l_ip.num_search_ports;
+      sharedmemory.wbb->tdp_stats = sharedmemory.wbb->stats_t;
     }
 
-	//computation engine
-	if (coredynp.core_ty==OOO)
-	{
-		int_inst_window->power_t.reset();
-		fp_inst_window->power_t.reset();
-
-		/* each instruction needs to write to scheduler, read out when all resources and source operands are ready
-		 * two search ops with one for each source operand
-		 *
-		 */
-		int_inst_window->power_t.readOp.dynamic  +=  int_inst_window->local_result.power.readOp.dynamic * int_inst_window->stats_t.readAc.access
-					+ int_inst_window->local_result.power.searchOp.dynamic * int_inst_window->stats_t.searchAc.access
-					+ int_inst_window->local_result.power.writeOp.dynamic  * int_inst_window->stats_t.writeAc.access
-					+ int_inst_window->stats_t.readAc.access * instruction_selection->power.readOp.dynamic;
-
-		fp_inst_window->power_t.readOp.dynamic   +=  fp_inst_window->local_result.power.readOp.dynamic * fp_inst_window->stats_t.readAc.access
-					+ fp_inst_window->local_result.power.searchOp.dynamic * fp_inst_window->stats_t.searchAc.access
-					+ fp_inst_window->local_result.power.writeOp.dynamic * fp_inst_window->stats_t.writeAc.access
-					+ fp_inst_window->stats_t.writeAc.access * instruction_selection->power.readOp.dynamic;
-
-		if (XML->sys.core[ithCore].ROB_size >0)
-		{
-			ROB->power_t.reset();
-			ROB->power_t.readOp.dynamic   +=  ROB->local_result.power.readOp.dynamic*ROB->stats_t.readAc.access +
-						ROB->stats_t.writeAc.access*ROB->local_result.power.writeOp.dynamic;
-		}
-
-
-
-
-	}
-	else if (coredynp.multithreaded)
-	{
-		int_inst_window->power_t.reset();
-		int_inst_window->power_t.readOp.dynamic  +=  int_inst_window->local_result.power.readOp.dynamic * int_inst_window->stats_t.readAc.access
-						  + int_inst_window->local_result.power.searchOp.dynamic * int_inst_window->stats_t.searchAc.access
-				          + int_inst_window->local_result.power.writeOp.dynamic  * int_inst_window->stats_t.writeAc.access
-				          + int_inst_window->stats_t.writeAc.access * instruction_selection->power.readOp.dynamic;
-	}
-
-	//assign values
-	if (is_tdp)
-	{
-		if (coredynp.core_ty==OOO)
-		{
-			int_inst_window->power = int_inst_window->power_t + (int_inst_window->local_result.power +instruction_selection->power) *pppm_lkg;
-			fp_inst_window->power = fp_inst_window->power_t + (fp_inst_window->local_result.power +instruction_selection->power) *pppm_lkg;
-			power	   = power + int_inst_window->power + fp_inst_window->power;
-			if (XML->sys.core[ithCore].ROB_size >0)
-			{
-				ROB->power = ROB->power_t + ROB->local_result.power*pppm_lkg;
-				power	   = power + ROB->power;
-			}
-
-		}
-		else if (coredynp.multithreaded)
-		{
-			//			set_pppm(pppm_t, XML->sys.core[ithCore].issue_width,1, 1, 1);
-			int_inst_window->power = int_inst_window->power_t + (int_inst_window->local_result.power +instruction_selection->power) *pppm_lkg;
-			power	   = power + int_inst_window->power;
-      	}
-
-     }
-    else
-    {//rtp
-		if (coredynp.core_ty==OOO)
-		{
-			int_inst_window->rt_power = int_inst_window->power_t + (int_inst_window->local_result.power +instruction_selection->power) *pppm_lkg;
-			fp_inst_window->rt_power  = fp_inst_window->power_t + (fp_inst_window->local_result.power +instruction_selection->power) *pppm_lkg;
-			rt_power	              = rt_power + int_inst_window->rt_power + fp_inst_window->rt_power;
-			if (XML->sys.core[ithCore].ROB_size >0)
-			{
-				ROB->rt_power = ROB->power_t + ROB->local_result.power*pppm_lkg;
-				rt_power	              = rt_power + ROB->rt_power;
-			}
-
-		}
-		else if (coredynp.multithreaded)
-		{
-			//			set_pppm(pppm_t, XML->sys.core[ithCore].issue_width,1, 1, 1);
-			int_inst_window->rt_power = int_inst_window->power_t + (int_inst_window->local_result.power +instruction_selection->power) *pppm_lkg;
-			rt_power	              = rt_power + int_inst_window->rt_power;
-      	}
-    }
-//	set_pppm(pppm_t, XML->sys.core[ithCore].issue_width,1, 1, 1);
-//	cout<<"Scheduler power="<<power.readOp.dynamic<<"leakage="<<power.readOp.leakage<<endl;
-//	cout<<"IW="<<int_inst_window->local_result.power.searchOp.dynamic * int_inst_window->stats_t.readAc.access +
-//    + int_inst_window->local_result.power.writeOp.dynamic * int_inst_window->stats_t.writeAc.access<<"leakage="<<int_inst_window->local_result.power.readOp.leakage<<endl;
-//	cout<<"selection"<<instruction_selection->power.readOp.dynamic<<"leakage"<<instruction_selection->power.readOp.leakage<<endl;
-}
-
-void SchedulerU::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	if (!exist) return;
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
-
-
-	if (is_tdp)
-	{
-		if (coredynp.core_ty==OOO)
-		{
-			cout << indent_str << "Instruction Window:" << endl;
-			cout << indent_str_next << "Area = " << int_inst_window->area.get_area()*1e-6<< " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << int_inst_window->power.readOp.dynamic*clockRate << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? int_inst_window->power.readOp.longer_channel_leakage:int_inst_window->power.readOp.leakage) <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << int_inst_window->power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << int_inst_window->rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-			cout << indent_str << "FP Instruction Window:" << endl;
-			cout << indent_str_next << "Area = " << fp_inst_window->area.get_area()*1e-6  << " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << fp_inst_window->power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? fp_inst_window->power.readOp.longer_channel_leakage:fp_inst_window->power.readOp.leakage ) << " W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << fp_inst_window->power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << fp_inst_window->rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-			if (XML->sys.core[ithCore].ROB_size >0)
-			{
-				cout << indent_str<<"ROB:" << endl;
-				cout << indent_str_next << "Area = " << ROB->area.get_area() *1e-6 << " mm^2" << endl;
-				cout << indent_str_next << "Peak Dynamic = " << ROB->power.readOp.dynamic*clockRate  << " W" << endl;
-				cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? ROB->power.readOp.longer_channel_leakage:ROB->power.readOp.leakage)  << " W" << endl;
-				cout << indent_str_next << "Gate Leakage = " << ROB->power.readOp.gate_leakage  << " W" << endl;
-				cout << indent_str_next << "Runtime Dynamic = " << ROB->rt_power.readOp.dynamic/executionTime << " W" << endl;
-				cout <<endl;
-			}
-		}
-		else if (coredynp.multithreaded)
-		{
-			cout << indent_str << "Instruction Window:" << endl;
-			cout << indent_str_next << "Area = " << int_inst_window->area.get_area()*1e-6<< " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << int_inst_window->power.readOp.dynamic*clockRate << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? int_inst_window->power.readOp.longer_channel_leakage:int_inst_window->power.readOp.leakage) <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << int_inst_window->power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << int_inst_window->rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-		}
-	}
-	else
-	{
-		if (coredynp.core_ty==OOO)
-		{
-			cout << indent_str_next << "Instruction Window    Peak Dynamic = " << int_inst_window->rt_power.readOp.dynamic*clockRate << " W" << endl;
-			cout << indent_str_next << "Instruction Window    Subthreshold Leakage = " << int_inst_window->rt_power.readOp.leakage <<" W" << endl;
-			cout << indent_str_next << "Instruction Window    Gate Leakage = " << int_inst_window->rt_power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next << "FP Instruction Window   Peak Dynamic = " << fp_inst_window->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "FP Instruction Window   Subthreshold Leakage = " << fp_inst_window->rt_power.readOp.leakage  << " W" << endl;
-			cout << indent_str_next << "FP Instruction Window   Gate Leakage = " << fp_inst_window->rt_power.readOp.gate_leakage  << " W" << endl;
-			if (XML->sys.core[ithCore].ROB_size >0)
-			{
-				cout << indent_str_next << "ROB   Peak Dynamic = " << ROB->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-				cout << indent_str_next << "ROB   Subthreshold Leakage = " << ROB->rt_power.readOp.leakage  << " W" << endl;
-				cout << indent_str_next << "ROB   Gate Leakage = " << ROB->rt_power.readOp.gate_leakage  << " W" << endl;
-			}
-		}
-		else if (coredynp.multithreaded)
-		{
-			cout << indent_str_next << "Instruction Window    Peak Dynamic = " << int_inst_window->rt_power.readOp.dynamic*clockRate << " W" << endl;
-			cout << indent_str_next << "Instruction Window    Subthreshold Leakage = " << int_inst_window->rt_power.readOp.leakage <<" W" << endl;
-			cout << indent_str_next << "Instruction Window    Gate Leakage = " << int_inst_window->rt_power.readOp.gate_leakage << " W" << endl;
-		}
-	}
-
-}
-
-void LoadStoreU::computeEnergy(bool is_tdp)
-{
-	if (!exist) return;
-
-	executionTime=XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);//Syed
-
-	//RF crossbar power (Syed)
-	xbar_shared->compute_power();
-   
-	if (is_tdp)
-	    {
-
-	    	//init stats for Peak
-        // added by Jingwen
-	    	sharedmemory.caches->stats_t.readAc.access  = 0.67*sharedmemory.caches->l_ip.num_rw_ports*coredynp.LSU_duty_cycle;
-	    	sharedmemory.caches->stats_t.readAc.miss    = 0;
-	    	sharedmemory.caches->stats_t.readAc.hit     = sharedmemory.caches->stats_t.readAc.access - sharedmemory.caches->stats_t.readAc.miss;
-	    	sharedmemory.caches->stats_t.writeAc.access = 0.33*sharedmemory.caches->l_ip.num_rw_ports*coredynp.LSU_duty_cycle;
-	    	sharedmemory.caches->stats_t.writeAc.miss   = 0;
-    		sharedmemory.caches->stats_t.writeAc.hit    = sharedmemory.caches->stats_t.writeAc.access -	sharedmemory.caches->stats_t.writeAc.miss;
-	    	sharedmemory.caches->tdp_stats = sharedmemory.caches->stats_t;
-
-	    	sharedmemory.missb->stats_t.readAc.access  = sharedmemory.missb->l_ip.num_search_ports;
-	    	sharedmemory.missb->stats_t.writeAc.access = sharedmemory.missb->l_ip.num_search_ports;
-	    	sharedmemory.missb->tdp_stats = sharedmemory.missb->stats_t;
-
-	    	sharedmemory.ifb->stats_t.readAc.access  = sharedmemory.ifb->l_ip.num_search_ports;
-	    	sharedmemory.ifb->stats_t.writeAc.access = sharedmemory.ifb->l_ip.num_search_ports;
-	    	sharedmemory.ifb->tdp_stats = sharedmemory.ifb->stats_t;
-
-	    	sharedmemory.prefetchb->stats_t.readAc.access  = sharedmemory.prefetchb->l_ip.num_search_ports;
-	    	sharedmemory.prefetchb->stats_t.writeAc.access = sharedmemory.ifb->l_ip.num_search_ports;
-	    	sharedmemory.prefetchb->tdp_stats = sharedmemory.prefetchb->stats_t;
-	    	if (cache_p==Write_back)
-	    	{
-	    		sharedmemory.wbb->stats_t.readAc.access  = sharedmemory.wbb->l_ip.num_search_ports;
-	    		sharedmemory.wbb->stats_t.writeAc.access = sharedmemory.wbb->l_ip.num_search_ports;
-	    		sharedmemory.wbb->tdp_stats = sharedmemory.wbb->stats_t;
-	    	}
-
-
-
-	    	//init stats for Peak
-	    	dcache.caches->stats_t.readAc.access  = 0.67*dcache.caches->l_ip.num_rw_ports*coredynp.LSU_duty_cycle;
-	    	dcache.caches->stats_t.readAc.miss    = 0;
-	    	dcache.caches->stats_t.readAc.hit     = dcache.caches->stats_t.readAc.access - dcache.caches->stats_t.readAc.miss;
-	    	dcache.caches->stats_t.writeAc.access = 0.33*dcache.caches->l_ip.num_rw_ports*coredynp.LSU_duty_cycle;
-	    	dcache.caches->stats_t.writeAc.miss   = 0;
-    		dcache.caches->stats_t.writeAc.hit    = dcache.caches->stats_t.writeAc.access -	dcache.caches->stats_t.writeAc.miss;
-	    	dcache.caches->tdp_stats = dcache.caches->stats_t;
-
-	    	dcache.missb->stats_t.readAc.access  = dcache.missb->l_ip.num_search_ports;
-	    	dcache.missb->stats_t.writeAc.access = dcache.missb->l_ip.num_search_ports;
-	    	dcache.missb->tdp_stats = dcache.missb->stats_t;
-
-	    	dcache.ifb->stats_t.readAc.access  = dcache.ifb->l_ip.num_search_ports;
-	    	dcache.ifb->stats_t.writeAc.access = dcache.ifb->l_ip.num_search_ports;
-	    	dcache.ifb->tdp_stats = dcache.ifb->stats_t;
-
-	    	dcache.prefetchb->stats_t.readAc.access  = dcache.prefetchb->l_ip.num_search_ports;
-	    	dcache.prefetchb->stats_t.writeAc.access = dcache.ifb->l_ip.num_search_ports;
-	    	dcache.prefetchb->tdp_stats = dcache.prefetchb->stats_t;
-	    	if (cache_p==Write_back)
-	    	{
-	    		dcache.wbb->stats_t.readAc.access  = dcache.wbb->l_ip.num_search_ports;
-	    		dcache.wbb->stats_t.writeAc.access = dcache.wbb->l_ip.num_search_ports;
-	    		dcache.wbb->tdp_stats = dcache.wbb->stats_t;
-	    	}
-
-
-	    	//init stats for Peak - ccache
-	    	ccache.caches->stats_t.readAc.access  = 0.67*ccache.caches->l_ip.num_rw_ports*coredynp.LSU_duty_cycle;
-	    	ccache.caches->stats_t.readAc.miss    = 0;
-	    	ccache.caches->stats_t.readAc.hit     = ccache.caches->stats_t.readAc.access - ccache.caches->stats_t.readAc.miss;
-	    	ccache.caches->stats_t.writeAc.access = 0.33*ccache.caches->l_ip.num_rw_ports*coredynp.LSU_duty_cycle;
-	    	ccache.caches->stats_t.writeAc.miss   = 0;
-    		ccache.caches->stats_t.writeAc.hit    = ccache.caches->stats_t.writeAc.access -	ccache.caches->stats_t.writeAc.miss;
-	    	ccache.caches->tdp_stats = ccache.caches->stats_t;
-
-	    	ccache.missb->stats_t.readAc.access  = ccache.missb->l_ip.num_search_ports;
-	    	ccache.missb->stats_t.writeAc.access = ccache.missb->l_ip.num_search_ports;
-	    	ccache.missb->tdp_stats = ccache.missb->stats_t;
-
-	    	ccache.ifb->stats_t.readAc.access  = ccache.ifb->l_ip.num_search_ports;
-	    	ccache.ifb->stats_t.writeAc.access = ccache.ifb->l_ip.num_search_ports;
-	    	ccache.ifb->tdp_stats = ccache.ifb->stats_t;
-
-	    	ccache.prefetchb->stats_t.readAc.access  = ccache.prefetchb->l_ip.num_search_ports;
-	    	ccache.prefetchb->stats_t.writeAc.access = ccache.ifb->l_ip.num_search_ports;
-	    	ccache.prefetchb->tdp_stats = ccache.prefetchb->stats_t;
-	    	if (cache_p==Write_back)
-	    	{
-	    		ccache.wbb->stats_t.readAc.access  = ccache.wbb->l_ip.num_search_ports;
-	    		ccache.wbb->stats_t.writeAc.access = ccache.wbb->l_ip.num_search_ports;
-	    		ccache.wbb->tdp_stats = ccache.wbb->stats_t;
-	    	}
-
-
-	    	//init stats for Peak - tcache
-	    	tcache.caches->stats_t.readAc.access  = 0.67*tcache.caches->l_ip.num_rw_ports*coredynp.LSU_duty_cycle;
-	    	tcache.caches->stats_t.readAc.miss    = 0;
-	    	tcache.caches->stats_t.readAc.hit     = tcache.caches->stats_t.readAc.access - tcache.caches->stats_t.readAc.miss;
-	    	tcache.caches->stats_t.writeAc.access = 0.33*tcache.caches->l_ip.num_rw_ports*coredynp.LSU_duty_cycle;
-	    	tcache.caches->stats_t.writeAc.miss   = 0;
-    		tcache.caches->stats_t.writeAc.hit    = tcache.caches->stats_t.writeAc.access -	tcache.caches->stats_t.writeAc.miss;
-	    	tcache.caches->tdp_stats = tcache.caches->stats_t;
-
-	    	tcache.missb->stats_t.readAc.access  = tcache.missb->l_ip.num_search_ports;
-	    	tcache.missb->stats_t.writeAc.access = tcache.missb->l_ip.num_search_ports;
-	    	tcache.missb->tdp_stats = tcache.missb->stats_t;
-
-	    	tcache.ifb->stats_t.readAc.access  = tcache.ifb->l_ip.num_search_ports;
-	    	tcache.ifb->stats_t.writeAc.access = tcache.ifb->l_ip.num_search_ports;
-	    	tcache.ifb->tdp_stats = tcache.ifb->stats_t;
-
-	    	tcache.prefetchb->stats_t.readAc.access  = tcache.prefetchb->l_ip.num_search_ports;
-	    	tcache.prefetchb->stats_t.writeAc.access = tcache.ifb->l_ip.num_search_ports;
-	    	tcache.prefetchb->tdp_stats = tcache.prefetchb->stats_t;
-	    	if (cache_p==Write_back)
-	    	{
-	    		tcache.wbb->stats_t.readAc.access  = tcache.wbb->l_ip.num_search_ports;
-	    		tcache.wbb->stats_t.writeAc.access = tcache.wbb->l_ip.num_search_ports;
-	    		tcache.wbb->tdp_stats = tcache.wbb->stats_t;
-	    	}
-
-
-
-	    	LSQ->stats_t.readAc.access = LSQ->stats_t.writeAc.access = LSQ->l_ip.num_search_ports*coredynp.LSU_duty_cycle;
-	    	LSQ->tdp_stats = LSQ->stats_t;
-	    	if ((coredynp.core_ty==OOO) && (XML->sys.core[ithCore].load_buffer_size >0))
-	    	{
-	    		LoadQ->stats_t.readAc.access = LoadQ->stats_t.writeAc.access = LoadQ->l_ip.num_search_ports*coredynp.LSU_duty_cycle;
-	    		LoadQ->tdp_stats = LoadQ->stats_t;
-	    	}
-	    }
-	    else
-	    {
-	    	//init stats for Runtime Dynamic (RTP)
-
-	    	sharedmemory.caches->stats_t.readAc.access  = XML->sys.core[ithCore].sharedmemory.read_accesses;
-	    	sharedmemory.caches->stats_t.readAc.miss    = XML->sys.core[ithCore].sharedmemory.read_misses;
-	    	sharedmemory.caches->stats_t.readAc.hit     = sharedmemory.caches->stats_t.readAc.access - sharedmemory.caches->stats_t.readAc.miss;
-	    	sharedmemory.caches->stats_t.writeAc.access = XML->sys.core[ithCore].sharedmemory.write_accesses;
-	    	sharedmemory.caches->stats_t.writeAc.miss   = XML->sys.core[ithCore].sharedmemory.write_misses;
-    		sharedmemory.caches->stats_t.writeAc.hit    = sharedmemory.caches->stats_t.writeAc.access -	sharedmemory.caches->stats_t.writeAc.miss;
-	    	sharedmemory.caches->rtp_stats = sharedmemory.caches->stats_t;
-
-
-
-	    	dcache.caches->stats_t.readAc.access  = XML->sys.core[ithCore].dcache.read_accesses;
-	    	dcache.caches->stats_t.readAc.miss    = XML->sys.core[ithCore].dcache.read_misses;
-	    	dcache.caches->stats_t.readAc.hit     = dcache.caches->stats_t.readAc.access - dcache.caches->stats_t.readAc.miss;
-	    	dcache.caches->stats_t.writeAc.access = XML->sys.core[ithCore].dcache.write_accesses;
-	    	dcache.caches->stats_t.writeAc.miss   = XML->sys.core[ithCore].dcache.write_misses;
-    		dcache.caches->stats_t.writeAc.hit    = dcache.caches->stats_t.writeAc.access -	dcache.caches->stats_t.writeAc.miss;
-	    	dcache.caches->rtp_stats = dcache.caches->stats_t;
-
-	    	ccache.caches->stats_t.readAc.access  = XML->sys.core[ithCore].ccache.read_accesses;
-	    	ccache.caches->stats_t.readAc.miss    = XML->sys.core[ithCore].ccache.read_misses;
-	    	ccache.caches->stats_t.readAc.hit     = ccache.caches->stats_t.readAc.access - ccache.caches->stats_t.readAc.miss;
-	    	ccache.caches->stats_t.writeAc.access = XML->sys.core[ithCore].ccache.write_accesses;
-	    	ccache.caches->stats_t.writeAc.miss   = XML->sys.core[ithCore].ccache.write_misses;
-    		ccache.caches->stats_t.writeAc.hit    = ccache.caches->stats_t.writeAc.access -	ccache.caches->stats_t.writeAc.miss;
-	    	ccache.caches->rtp_stats = ccache.caches->stats_t;
-
-	    	tcache.caches->stats_t.readAc.access  = XML->sys.core[ithCore].tcache.read_accesses;
-	    	tcache.caches->stats_t.readAc.miss    = XML->sys.core[ithCore].tcache.read_misses;
-	    	tcache.caches->stats_t.readAc.hit     = tcache.caches->stats_t.readAc.access - tcache.caches->stats_t.readAc.miss;
-	    	tcache.caches->stats_t.writeAc.access = XML->sys.core[ithCore].tcache.write_accesses;
-	    	tcache.caches->stats_t.writeAc.miss   = XML->sys.core[ithCore].tcache.write_misses;
-    		tcache.caches->stats_t.writeAc.hit    = tcache.caches->stats_t.writeAc.access -	tcache.caches->stats_t.writeAc.miss;
-	    	tcache.caches->rtp_stats = tcache.caches->stats_t;
-
-	    	if (cache_p==Write_back)
-	    	{
-
-	    		sharedmemory.missb->stats_t.readAc.access  = sharedmemory.caches->stats_t.writeAc.miss;
-	    		sharedmemory.missb->stats_t.writeAc.access = sharedmemory.caches->stats_t.writeAc.miss;
-	    		sharedmemory.missb->rtp_stats = sharedmemory.missb->stats_t;
-	    		sharedmemory.ifb->stats_t.readAc.access  = sharedmemory.caches->stats_t.writeAc.miss;
-	    		sharedmemory.ifb->stats_t.writeAc.access = sharedmemory.caches->stats_t.writeAc.miss;
-	    		sharedmemory.ifb->rtp_stats = sharedmemory.ifb->stats_t;
-	    		sharedmemory.prefetchb->stats_t.readAc.access  = sharedmemory.caches->stats_t.writeAc.miss;
-	    		sharedmemory.prefetchb->stats_t.writeAc.access = sharedmemory.caches->stats_t.writeAc.miss;
-	    		sharedmemory.prefetchb->rtp_stats = sharedmemory.prefetchb->stats_t;
-	    		sharedmemory.wbb->stats_t.readAc.access  = sharedmemory.caches->stats_t.writeAc.miss;
-	    		sharedmemory.wbb->stats_t.writeAc.access = sharedmemory.caches->stats_t.writeAc.miss;
-	    		sharedmemory.wbb->rtp_stats = sharedmemory.wbb->stats_t;
-
-
-	    		dcache.missb->stats_t.readAc.access  = dcache.caches->stats_t.writeAc.miss;
-	    		dcache.missb->stats_t.writeAc.access = dcache.caches->stats_t.writeAc.miss;
-	    		dcache.missb->rtp_stats = dcache.missb->stats_t;
-	    		dcache.ifb->stats_t.readAc.access  = dcache.caches->stats_t.writeAc.miss;
-	    		dcache.ifb->stats_t.writeAc.access = dcache.caches->stats_t.writeAc.miss;
-	    		dcache.ifb->rtp_stats = dcache.ifb->stats_t;
-	    		dcache.prefetchb->stats_t.readAc.access  = dcache.caches->stats_t.writeAc.miss;
-	    		dcache.prefetchb->stats_t.writeAc.access = dcache.caches->stats_t.writeAc.miss;
-	    		dcache.prefetchb->rtp_stats = dcache.prefetchb->stats_t;
-	    		dcache.wbb->stats_t.readAc.access  = dcache.caches->stats_t.writeAc.miss;
-	    		dcache.wbb->stats_t.writeAc.access = dcache.caches->stats_t.writeAc.miss;
-	    		dcache.wbb->rtp_stats = dcache.wbb->stats_t;
-
-	    		ccache.missb->stats_t.readAc.access  = ccache.caches->stats_t.writeAc.miss;
-	    		ccache.missb->stats_t.writeAc.access = ccache.caches->stats_t.writeAc.miss;
-	    		ccache.missb->rtp_stats = ccache.missb->stats_t;
-	    		ccache.ifb->stats_t.readAc.access  = ccache.caches->stats_t.writeAc.miss;
-	    		ccache.ifb->stats_t.writeAc.access = ccache.caches->stats_t.writeAc.miss;
-	    		ccache.ifb->rtp_stats = ccache.ifb->stats_t;
-	    		ccache.prefetchb->stats_t.readAc.access  = ccache.caches->stats_t.writeAc.miss;
-	    		ccache.prefetchb->stats_t.writeAc.access = ccache.caches->stats_t.writeAc.miss;
-	    		ccache.prefetchb->rtp_stats = ccache.prefetchb->stats_t;
-	    		ccache.wbb->stats_t.readAc.access  = ccache.caches->stats_t.writeAc.miss;
-	    		ccache.wbb->stats_t.writeAc.access = ccache.caches->stats_t.writeAc.miss;
-	    		ccache.wbb->rtp_stats = ccache.wbb->stats_t;
-
-	    		tcache.missb->stats_t.readAc.access  = tcache.caches->stats_t.writeAc.miss;
-	    		tcache.missb->stats_t.writeAc.access = tcache.caches->stats_t.writeAc.miss;
-	    		tcache.missb->rtp_stats = tcache.missb->stats_t;
-	    		tcache.ifb->stats_t.readAc.access  = tcache.caches->stats_t.writeAc.miss;
-	    		tcache.ifb->stats_t.writeAc.access = tcache.caches->stats_t.writeAc.miss;
-	    		tcache.ifb->rtp_stats = tcache.ifb->stats_t;
-	    		tcache.prefetchb->stats_t.readAc.access  = tcache.caches->stats_t.writeAc.miss;
-	    		tcache.prefetchb->stats_t.writeAc.access = tcache.caches->stats_t.writeAc.miss;
-	    		tcache.prefetchb->rtp_stats = tcache.prefetchb->stats_t;
-	    		tcache.wbb->stats_t.readAc.access  = tcache.caches->stats_t.writeAc.miss;
-	    		tcache.wbb->stats_t.writeAc.access = tcache.caches->stats_t.writeAc.miss;
-	    		tcache.wbb->rtp_stats = tcache.wbb->stats_t;
-	    	}
-	    	else
-	    	{
-	    		sharedmemory.missb->stats_t.readAc.access  = sharedmemory.caches->stats_t.readAc.miss;
-	    		sharedmemory.missb->stats_t.writeAc.access = sharedmemory.caches->stats_t.readAc.miss;
-	    		sharedmemory.missb->rtp_stats = sharedmemory.missb->stats_t;
-	    		sharedmemory.ifb->stats_t.readAc.access  = sharedmemory.caches->stats_t.readAc.miss;
-	    		sharedmemory.ifb->stats_t.writeAc.access = sharedmemory.caches->stats_t.readAc.miss;
-	    		sharedmemory.ifb->rtp_stats = sharedmemory.ifb->stats_t;
-	    		sharedmemory.prefetchb->stats_t.readAc.access  = sharedmemory.caches->stats_t.readAc.miss;
-	    		sharedmemory.prefetchb->stats_t.writeAc.access = sharedmemory.caches->stats_t.readAc.miss;
-	    		sharedmemory.prefetchb->rtp_stats = sharedmemory.prefetchb->stats_t;
-
-
-	    		dcache.missb->stats_t.readAc.access  = dcache.caches->stats_t.readAc.miss;
-	    		dcache.missb->stats_t.writeAc.access = dcache.caches->stats_t.readAc.miss;
-	    		dcache.missb->rtp_stats = dcache.missb->stats_t;
-	    		dcache.ifb->stats_t.readAc.access  = dcache.caches->stats_t.readAc.miss;
-	    		dcache.ifb->stats_t.writeAc.access = dcache.caches->stats_t.readAc.miss;
-	    		dcache.ifb->rtp_stats = dcache.ifb->stats_t;
-	    		dcache.prefetchb->stats_t.readAc.access  = dcache.caches->stats_t.readAc.miss;
-	    		dcache.prefetchb->stats_t.writeAc.access = dcache.caches->stats_t.readAc.miss;
-	    		dcache.prefetchb->rtp_stats = dcache.prefetchb->stats_t;
-
-
-	    		ccache.missb->stats_t.readAc.access  = ccache.caches->stats_t.readAc.miss;
-	    		ccache.missb->stats_t.writeAc.access = ccache.caches->stats_t.readAc.miss;
-	    		ccache.missb->rtp_stats = ccache.missb->stats_t;
-	    		ccache.ifb->stats_t.readAc.access  = ccache.caches->stats_t.readAc.miss;
-	    		ccache.ifb->stats_t.writeAc.access = ccache.caches->stats_t.readAc.miss;
-	    		ccache.ifb->rtp_stats = ccache.ifb->stats_t;
-	    		ccache.prefetchb->stats_t.readAc.access  = ccache.caches->stats_t.readAc.miss;
-	    		ccache.prefetchb->stats_t.writeAc.access = ccache.caches->stats_t.readAc.miss;
-	    		ccache.prefetchb->rtp_stats = ccache.prefetchb->stats_t;
-
-	    		tcache.missb->stats_t.readAc.access  = tcache.caches->stats_t.readAc.miss;
-	    		tcache.missb->stats_t.writeAc.access = tcache.caches->stats_t.readAc.miss;
-	    		tcache.missb->rtp_stats = tcache.missb->stats_t;
-	    		tcache.ifb->stats_t.readAc.access  = tcache.caches->stats_t.readAc.miss;
-	    		tcache.ifb->stats_t.writeAc.access = tcache.caches->stats_t.readAc.miss;
-	    		tcache.ifb->rtp_stats = tcache.ifb->stats_t;
-	    		tcache.prefetchb->stats_t.readAc.access  = tcache.caches->stats_t.readAc.miss;
-	    		tcache.prefetchb->stats_t.writeAc.access = tcache.caches->stats_t.readAc.miss;
-	    		tcache.prefetchb->rtp_stats = tcache.prefetchb->stats_t;
-
-	    	}
-
-	    	LSQ->stats_t.readAc.access  = (XML->sys.core[ithCore].load_instructions + XML->sys.core[ithCore].store_instructions)*2;//flush overhead considered
-	    	LSQ->stats_t.writeAc.access = (XML->sys.core[ithCore].load_instructions + XML->sys.core[ithCore].store_instructions)*2;
-	    	LSQ->rtp_stats = LSQ->stats_t;
-
-	    	if ((coredynp.core_ty==OOO) && (XML->sys.core[ithCore].load_buffer_size >0))
-	    	{
-		    	LoadQ->stats_t.readAc.access  = XML->sys.core[ithCore].load_instructions + XML->sys.core[ithCore].store_instructions;
-		    	LoadQ->stats_t.writeAc.access = XML->sys.core[ithCore].load_instructions + XML->sys.core[ithCore].store_instructions;
-		    	LoadQ->rtp_stats = LoadQ->stats_t;
-	    	}
-
-	    }
-
-	sharedmemory.power_t.reset();
-	dcache.power_t.reset();
-	ccache.power_t.reset();
-	tcache.power_t.reset();
-	LSQ->power_t.reset();
-
-    sharedmemory.power_t.readOp.dynamic	+= (sharedmemory.caches->stats_t.readAc.hit*sharedmemory.caches->local_result.power.readOp.dynamic+
-    		sharedmemory.caches->stats_t.readAc.miss*sharedmemory.caches->local_result.power.readOp.dynamic+
-    		sharedmemory.caches->stats_t.writeAc.miss*sharedmemory.caches->local_result.tag_array2->power.readOp.dynamic+
-    		sharedmemory.caches->stats_t.writeAc.access*sharedmemory.caches->local_result.power.writeOp.dynamic +
-			xbar_shared->power.readOp.dynamic*(sharedmemory.caches->stats_t.readAc.hit+ sharedmemory.caches->stats_t.writeAc.hit));
-
-
-    dcache.power_t.readOp.dynamic	+= (dcache.caches->stats_t.readAc.hit*dcache.caches->local_result.power.readOp.dynamic+
-    		dcache.caches->stats_t.readAc.miss*dcache.caches->local_result.power.readOp.dynamic+
-    		dcache.caches->stats_t.writeAc.miss*dcache.caches->local_result.tag_array2->power.readOp.dynamic+
-    		dcache.caches->stats_t.writeAc.access*dcache.caches->local_result.power.writeOp.dynamic +
-			xbar_shared->power.readOp.dynamic*(dcache.caches->stats_t.readAc.hit+ dcache.caches->stats_t.writeAc.hit));
-    ccache.power_t.readOp.dynamic	+= (ccache.caches->stats_t.readAc.hit*ccache.caches->local_result.power.readOp.dynamic+
-    		ccache.caches->stats_t.readAc.miss*ccache.caches->local_result.power.readOp.dynamic+
-    		ccache.caches->stats_t.writeAc.miss*ccache.caches->local_result.tag_array2->power.readOp.dynamic+
-    		ccache.caches->stats_t.writeAc.access*ccache.caches->local_result.power.writeOp.dynamic + 
-			xbar_shared->power.readOp.dynamic*(ccache.caches->stats_t.readAc.hit));
-
-    tcache.power_t.readOp.dynamic	+= (tcache.caches->stats_t.readAc.hit*tcache.caches->local_result.power.readOp.dynamic+
-    		tcache.caches->stats_t.readAc.miss*tcache.caches->local_result.power.readOp.dynamic+
-    		tcache.caches->stats_t.writeAc.miss*tcache.caches->local_result.tag_array2->power.readOp.dynamic+
-    		tcache.caches->stats_t.writeAc.access*tcache.caches->local_result.power.writeOp.dynamic+
-			xbar_shared->power.readOp.dynamic*(tcache.caches->stats_t.readAc.hit+ tcache.caches->stats_t.writeAc.hit));
-
-    if (cache_p==Write_back)
-    {//write miss will generate a write later
-    	dcache.power_t.readOp.dynamic	+= dcache.caches->stats_t.writeAc.miss*dcache.caches->local_result.power.writeOp.dynamic;
-    	ccache.power_t.readOp.dynamic	+= ccache.caches->stats_t.writeAc.miss*ccache.caches->local_result.power.writeOp.dynamic;
-    	tcache.power_t.readOp.dynamic	+= tcache.caches->stats_t.writeAc.miss*tcache.caches->local_result.power.writeOp.dynamic;
-    	sharedmemory.power_t.readOp.dynamic	+= sharedmemory.caches->stats_t.writeAc.miss*sharedmemory.caches->local_result.power.writeOp.dynamic;
+    // init stats for Peak
+    dcache.caches->stats_t.readAc.access =
+        0.67 * dcache.caches->l_ip.num_rw_ports * coredynp.LSU_duty_cycle;
+    dcache.caches->stats_t.readAc.miss = 0;
+    dcache.caches->stats_t.readAc.hit = dcache.caches->stats_t.readAc.access -
+                                        dcache.caches->stats_t.readAc.miss;
+    dcache.caches->stats_t.writeAc.access =
+        0.33 * dcache.caches->l_ip.num_rw_ports * coredynp.LSU_duty_cycle;
+    dcache.caches->stats_t.writeAc.miss = 0;
+    dcache.caches->stats_t.writeAc.hit = dcache.caches->stats_t.writeAc.access -
+                                         dcache.caches->stats_t.writeAc.miss;
+    dcache.caches->tdp_stats = dcache.caches->stats_t;
+
+    dcache.missb->stats_t.readAc.access = dcache.missb->l_ip.num_search_ports;
+    dcache.missb->stats_t.writeAc.access = dcache.missb->l_ip.num_search_ports;
+    dcache.missb->tdp_stats = dcache.missb->stats_t;
+
+    dcache.ifb->stats_t.readAc.access = dcache.ifb->l_ip.num_search_ports;
+    dcache.ifb->stats_t.writeAc.access = dcache.ifb->l_ip.num_search_ports;
+    dcache.ifb->tdp_stats = dcache.ifb->stats_t;
+
+    dcache.prefetchb->stats_t.readAc.access =
+        dcache.prefetchb->l_ip.num_search_ports;
+    dcache.prefetchb->stats_t.writeAc.access =
+        dcache.ifb->l_ip.num_search_ports;
+    dcache.prefetchb->tdp_stats = dcache.prefetchb->stats_t;
+    if (cache_p == Write_back) {
+      dcache.wbb->stats_t.readAc.access = dcache.wbb->l_ip.num_search_ports;
+      dcache.wbb->stats_t.writeAc.access = dcache.wbb->l_ip.num_search_ports;
+      dcache.wbb->tdp_stats = dcache.wbb->stats_t;
     }
 
+    // init stats for Peak - ccache
+    ccache.caches->stats_t.readAc.access =
+        0.67 * ccache.caches->l_ip.num_rw_ports * coredynp.LSU_duty_cycle;
+    ccache.caches->stats_t.readAc.miss = 0;
+    ccache.caches->stats_t.readAc.hit = ccache.caches->stats_t.readAc.access -
+                                        ccache.caches->stats_t.readAc.miss;
+    ccache.caches->stats_t.writeAc.access =
+        0.33 * ccache.caches->l_ip.num_rw_ports * coredynp.LSU_duty_cycle;
+    ccache.caches->stats_t.writeAc.miss = 0;
+    ccache.caches->stats_t.writeAc.hit = ccache.caches->stats_t.writeAc.access -
+                                         ccache.caches->stats_t.writeAc.miss;
+    ccache.caches->tdp_stats = ccache.caches->stats_t;
 
-    sharedmemory.power_t.readOp.dynamic	+=  sharedmemory.missb->stats_t.readAc.access*sharedmemory.missb->local_result.power.searchOp.dynamic +
-            sharedmemory.missb->stats_t.writeAc.access*sharedmemory.missb->local_result.power.writeOp.dynamic;//each access to missb involves a CAM and a write
-    sharedmemory.power_t.readOp.dynamic	+=  sharedmemory.ifb->stats_t.readAc.access*sharedmemory.ifb->local_result.power.searchOp.dynamic +
-            sharedmemory.ifb->stats_t.writeAc.access*sharedmemory.ifb->local_result.power.writeOp.dynamic;
-    sharedmemory.power_t.readOp.dynamic	+=  sharedmemory.prefetchb->stats_t.readAc.access*sharedmemory.prefetchb->local_result.power.searchOp.dynamic +
-            sharedmemory.prefetchb->stats_t.writeAc.access*sharedmemory.prefetchb->local_result.power.writeOp.dynamic;
-    if (cache_p==Write_back)
+    ccache.missb->stats_t.readAc.access = ccache.missb->l_ip.num_search_ports;
+    ccache.missb->stats_t.writeAc.access = ccache.missb->l_ip.num_search_ports;
+    ccache.missb->tdp_stats = ccache.missb->stats_t;
+
+    ccache.ifb->stats_t.readAc.access = ccache.ifb->l_ip.num_search_ports;
+    ccache.ifb->stats_t.writeAc.access = ccache.ifb->l_ip.num_search_ports;
+    ccache.ifb->tdp_stats = ccache.ifb->stats_t;
+
+    ccache.prefetchb->stats_t.readAc.access =
+        ccache.prefetchb->l_ip.num_search_ports;
+    ccache.prefetchb->stats_t.writeAc.access =
+        ccache.ifb->l_ip.num_search_ports;
+    ccache.prefetchb->tdp_stats = ccache.prefetchb->stats_t;
+    if (cache_p == Write_back) {
+      ccache.wbb->stats_t.readAc.access = ccache.wbb->l_ip.num_search_ports;
+      ccache.wbb->stats_t.writeAc.access = ccache.wbb->l_ip.num_search_ports;
+      ccache.wbb->tdp_stats = ccache.wbb->stats_t;
+    }
+
+    // init stats for Peak - tcache
+    tcache.caches->stats_t.readAc.access =
+        0.67 * tcache.caches->l_ip.num_rw_ports * coredynp.LSU_duty_cycle;
+    tcache.caches->stats_t.readAc.miss = 0;
+    tcache.caches->stats_t.readAc.hit = tcache.caches->stats_t.readAc.access -
+                                        tcache.caches->stats_t.readAc.miss;
+    tcache.caches->stats_t.writeAc.access =
+        0.33 * tcache.caches->l_ip.num_rw_ports * coredynp.LSU_duty_cycle;
+    tcache.caches->stats_t.writeAc.miss = 0;
+    tcache.caches->stats_t.writeAc.hit = tcache.caches->stats_t.writeAc.access -
+                                         tcache.caches->stats_t.writeAc.miss;
+    tcache.caches->tdp_stats = tcache.caches->stats_t;
+
+    tcache.missb->stats_t.readAc.access = tcache.missb->l_ip.num_search_ports;
+    tcache.missb->stats_t.writeAc.access = tcache.missb->l_ip.num_search_ports;
+    tcache.missb->tdp_stats = tcache.missb->stats_t;
+
+    tcache.ifb->stats_t.readAc.access = tcache.ifb->l_ip.num_search_ports;
+    tcache.ifb->stats_t.writeAc.access = tcache.ifb->l_ip.num_search_ports;
+    tcache.ifb->tdp_stats = tcache.ifb->stats_t;
+
+    tcache.prefetchb->stats_t.readAc.access =
+        tcache.prefetchb->l_ip.num_search_ports;
+    tcache.prefetchb->stats_t.writeAc.access =
+        tcache.ifb->l_ip.num_search_ports;
+    tcache.prefetchb->tdp_stats = tcache.prefetchb->stats_t;
+    if (cache_p == Write_back) {
+      tcache.wbb->stats_t.readAc.access = tcache.wbb->l_ip.num_search_ports;
+      tcache.wbb->stats_t.writeAc.access = tcache.wbb->l_ip.num_search_ports;
+      tcache.wbb->tdp_stats = tcache.wbb->stats_t;
+    }
+
+    LSQ->stats_t.readAc.access = LSQ->stats_t.writeAc.access =
+        LSQ->l_ip.num_search_ports * coredynp.LSU_duty_cycle;
+    LSQ->tdp_stats = LSQ->stats_t;
+    if ((coredynp.core_ty == OOO) &&
+        (XML->sys.core[ithCore].load_buffer_size > 0)) {
+      LoadQ->stats_t.readAc.access = LoadQ->stats_t.writeAc.access =
+          LoadQ->l_ip.num_search_ports * coredynp.LSU_duty_cycle;
+      LoadQ->tdp_stats = LoadQ->stats_t;
+    }
+  } else {
+    // init stats for Runtime Dynamic (RTP)
+
+    sharedmemory.caches->stats_t.readAc.access =
+        XML->sys.core[ithCore].sharedmemory.read_accesses;
+    sharedmemory.caches->stats_t.readAc.miss =
+        XML->sys.core[ithCore].sharedmemory.read_misses;
+    sharedmemory.caches->stats_t.readAc.hit =
+        sharedmemory.caches->stats_t.readAc.access -
+        sharedmemory.caches->stats_t.readAc.miss;
+    sharedmemory.caches->stats_t.writeAc.access =
+        XML->sys.core[ithCore].sharedmemory.write_accesses;
+    sharedmemory.caches->stats_t.writeAc.miss =
+        XML->sys.core[ithCore].sharedmemory.write_misses;
+    sharedmemory.caches->stats_t.writeAc.hit =
+        sharedmemory.caches->stats_t.writeAc.access -
+        sharedmemory.caches->stats_t.writeAc.miss;
+    sharedmemory.caches->rtp_stats = sharedmemory.caches->stats_t;
+
+    dcache.caches->stats_t.readAc.access =
+        XML->sys.core[ithCore].dcache.read_accesses;
+    dcache.caches->stats_t.readAc.miss =
+        XML->sys.core[ithCore].dcache.read_misses;
+    dcache.caches->stats_t.readAc.hit = dcache.caches->stats_t.readAc.access -
+                                        dcache.caches->stats_t.readAc.miss;
+    dcache.caches->stats_t.writeAc.access =
+        XML->sys.core[ithCore].dcache.write_accesses;
+    dcache.caches->stats_t.writeAc.miss =
+        XML->sys.core[ithCore].dcache.write_misses;
+    dcache.caches->stats_t.writeAc.hit = dcache.caches->stats_t.writeAc.access -
+                                         dcache.caches->stats_t.writeAc.miss;
+    dcache.caches->rtp_stats = dcache.caches->stats_t;
+
+    ccache.caches->stats_t.readAc.access =
+        XML->sys.core[ithCore].ccache.read_accesses;
+    ccache.caches->stats_t.readAc.miss =
+        XML->sys.core[ithCore].ccache.read_misses;
+    ccache.caches->stats_t.readAc.hit = ccache.caches->stats_t.readAc.access -
+                                        ccache.caches->stats_t.readAc.miss;
+    ccache.caches->stats_t.writeAc.access =
+        XML->sys.core[ithCore].ccache.write_accesses;
+    ccache.caches->stats_t.writeAc.miss =
+        XML->sys.core[ithCore].ccache.write_misses;
+    ccache.caches->stats_t.writeAc.hit = ccache.caches->stats_t.writeAc.access -
+                                         ccache.caches->stats_t.writeAc.miss;
+    ccache.caches->rtp_stats = ccache.caches->stats_t;
+
+    tcache.caches->stats_t.readAc.access =
+        XML->sys.core[ithCore].tcache.read_accesses;
+    tcache.caches->stats_t.readAc.miss =
+        XML->sys.core[ithCore].tcache.read_misses;
+    tcache.caches->stats_t.readAc.hit = tcache.caches->stats_t.readAc.access -
+                                        tcache.caches->stats_t.readAc.miss;
+    tcache.caches->stats_t.writeAc.access =
+        XML->sys.core[ithCore].tcache.write_accesses;
+    tcache.caches->stats_t.writeAc.miss =
+        XML->sys.core[ithCore].tcache.write_misses;
+    tcache.caches->stats_t.writeAc.hit = tcache.caches->stats_t.writeAc.access -
+                                         tcache.caches->stats_t.writeAc.miss;
+    tcache.caches->rtp_stats = tcache.caches->stats_t;
+
+    if (cache_p == Write_back) {
+      sharedmemory.missb->stats_t.readAc.access =
+          sharedmemory.caches->stats_t.writeAc.miss;
+      sharedmemory.missb->stats_t.writeAc.access =
+          sharedmemory.caches->stats_t.writeAc.miss;
+      sharedmemory.missb->rtp_stats = sharedmemory.missb->stats_t;
+      sharedmemory.ifb->stats_t.readAc.access =
+          sharedmemory.caches->stats_t.writeAc.miss;
+      sharedmemory.ifb->stats_t.writeAc.access =
+          sharedmemory.caches->stats_t.writeAc.miss;
+      sharedmemory.ifb->rtp_stats = sharedmemory.ifb->stats_t;
+      sharedmemory.prefetchb->stats_t.readAc.access =
+          sharedmemory.caches->stats_t.writeAc.miss;
+      sharedmemory.prefetchb->stats_t.writeAc.access =
+          sharedmemory.caches->stats_t.writeAc.miss;
+      sharedmemory.prefetchb->rtp_stats = sharedmemory.prefetchb->stats_t;
+      sharedmemory.wbb->stats_t.readAc.access =
+          sharedmemory.caches->stats_t.writeAc.miss;
+      sharedmemory.wbb->stats_t.writeAc.access =
+          sharedmemory.caches->stats_t.writeAc.miss;
+      sharedmemory.wbb->rtp_stats = sharedmemory.wbb->stats_t;
+
+      dcache.missb->stats_t.readAc.access = dcache.caches->stats_t.writeAc.miss;
+      dcache.missb->stats_t.writeAc.access =
+          dcache.caches->stats_t.writeAc.miss;
+      dcache.missb->rtp_stats = dcache.missb->stats_t;
+      dcache.ifb->stats_t.readAc.access = dcache.caches->stats_t.writeAc.miss;
+      dcache.ifb->stats_t.writeAc.access = dcache.caches->stats_t.writeAc.miss;
+      dcache.ifb->rtp_stats = dcache.ifb->stats_t;
+      dcache.prefetchb->stats_t.readAc.access =
+          dcache.caches->stats_t.writeAc.miss;
+      dcache.prefetchb->stats_t.writeAc.access =
+          dcache.caches->stats_t.writeAc.miss;
+      dcache.prefetchb->rtp_stats = dcache.prefetchb->stats_t;
+      dcache.wbb->stats_t.readAc.access = dcache.caches->stats_t.writeAc.miss;
+      dcache.wbb->stats_t.writeAc.access = dcache.caches->stats_t.writeAc.miss;
+      dcache.wbb->rtp_stats = dcache.wbb->stats_t;
+
+      ccache.missb->stats_t.readAc.access = ccache.caches->stats_t.writeAc.miss;
+      ccache.missb->stats_t.writeAc.access =
+          ccache.caches->stats_t.writeAc.miss;
+      ccache.missb->rtp_stats = ccache.missb->stats_t;
+      ccache.ifb->stats_t.readAc.access = ccache.caches->stats_t.writeAc.miss;
+      ccache.ifb->stats_t.writeAc.access = ccache.caches->stats_t.writeAc.miss;
+      ccache.ifb->rtp_stats = ccache.ifb->stats_t;
+      ccache.prefetchb->stats_t.readAc.access =
+          ccache.caches->stats_t.writeAc.miss;
+      ccache.prefetchb->stats_t.writeAc.access =
+          ccache.caches->stats_t.writeAc.miss;
+      ccache.prefetchb->rtp_stats = ccache.prefetchb->stats_t;
+      ccache.wbb->stats_t.readAc.access = ccache.caches->stats_t.writeAc.miss;
+      ccache.wbb->stats_t.writeAc.access = ccache.caches->stats_t.writeAc.miss;
+      ccache.wbb->rtp_stats = ccache.wbb->stats_t;
+
+      tcache.missb->stats_t.readAc.access = tcache.caches->stats_t.writeAc.miss;
+      tcache.missb->stats_t.writeAc.access =
+          tcache.caches->stats_t.writeAc.miss;
+      tcache.missb->rtp_stats = tcache.missb->stats_t;
+      tcache.ifb->stats_t.readAc.access = tcache.caches->stats_t.writeAc.miss;
+      tcache.ifb->stats_t.writeAc.access = tcache.caches->stats_t.writeAc.miss;
+      tcache.ifb->rtp_stats = tcache.ifb->stats_t;
+      tcache.prefetchb->stats_t.readAc.access =
+          tcache.caches->stats_t.writeAc.miss;
+      tcache.prefetchb->stats_t.writeAc.access =
+          tcache.caches->stats_t.writeAc.miss;
+      tcache.prefetchb->rtp_stats = tcache.prefetchb->stats_t;
+      tcache.wbb->stats_t.readAc.access = tcache.caches->stats_t.writeAc.miss;
+      tcache.wbb->stats_t.writeAc.access = tcache.caches->stats_t.writeAc.miss;
+      tcache.wbb->rtp_stats = tcache.wbb->stats_t;
+    } else {
+      sharedmemory.missb->stats_t.readAc.access =
+          sharedmemory.caches->stats_t.readAc.miss;
+      sharedmemory.missb->stats_t.writeAc.access =
+          sharedmemory.caches->stats_t.readAc.miss;
+      sharedmemory.missb->rtp_stats = sharedmemory.missb->stats_t;
+      sharedmemory.ifb->stats_t.readAc.access =
+          sharedmemory.caches->stats_t.readAc.miss;
+      sharedmemory.ifb->stats_t.writeAc.access =
+          sharedmemory.caches->stats_t.readAc.miss;
+      sharedmemory.ifb->rtp_stats = sharedmemory.ifb->stats_t;
+      sharedmemory.prefetchb->stats_t.readAc.access =
+          sharedmemory.caches->stats_t.readAc.miss;
+      sharedmemory.prefetchb->stats_t.writeAc.access =
+          sharedmemory.caches->stats_t.readAc.miss;
+      sharedmemory.prefetchb->rtp_stats = sharedmemory.prefetchb->stats_t;
+
+      dcache.missb->stats_t.readAc.access = dcache.caches->stats_t.readAc.miss;
+      dcache.missb->stats_t.writeAc.access = dcache.caches->stats_t.readAc.miss;
+      dcache.missb->rtp_stats = dcache.missb->stats_t;
+      dcache.ifb->stats_t.readAc.access = dcache.caches->stats_t.readAc.miss;
+      dcache.ifb->stats_t.writeAc.access = dcache.caches->stats_t.readAc.miss;
+      dcache.ifb->rtp_stats = dcache.ifb->stats_t;
+      dcache.prefetchb->stats_t.readAc.access =
+          dcache.caches->stats_t.readAc.miss;
+      dcache.prefetchb->stats_t.writeAc.access =
+          dcache.caches->stats_t.readAc.miss;
+      dcache.prefetchb->rtp_stats = dcache.prefetchb->stats_t;
+
+      ccache.missb->stats_t.readAc.access = ccache.caches->stats_t.readAc.miss;
+      ccache.missb->stats_t.writeAc.access = ccache.caches->stats_t.readAc.miss;
+      ccache.missb->rtp_stats = ccache.missb->stats_t;
+      ccache.ifb->stats_t.readAc.access = ccache.caches->stats_t.readAc.miss;
+      ccache.ifb->stats_t.writeAc.access = ccache.caches->stats_t.readAc.miss;
+      ccache.ifb->rtp_stats = ccache.ifb->stats_t;
+      ccache.prefetchb->stats_t.readAc.access =
+          ccache.caches->stats_t.readAc.miss;
+      ccache.prefetchb->stats_t.writeAc.access =
+          ccache.caches->stats_t.readAc.miss;
+      ccache.prefetchb->rtp_stats = ccache.prefetchb->stats_t;
+
+      tcache.missb->stats_t.readAc.access = tcache.caches->stats_t.readAc.miss;
+      tcache.missb->stats_t.writeAc.access = tcache.caches->stats_t.readAc.miss;
+      tcache.missb->rtp_stats = tcache.missb->stats_t;
+      tcache.ifb->stats_t.readAc.access = tcache.caches->stats_t.readAc.miss;
+      tcache.ifb->stats_t.writeAc.access = tcache.caches->stats_t.readAc.miss;
+      tcache.ifb->rtp_stats = tcache.ifb->stats_t;
+      tcache.prefetchb->stats_t.readAc.access =
+          tcache.caches->stats_t.readAc.miss;
+      tcache.prefetchb->stats_t.writeAc.access =
+          tcache.caches->stats_t.readAc.miss;
+      tcache.prefetchb->rtp_stats = tcache.prefetchb->stats_t;
+    }
+
+    LSQ->stats_t.readAc.access = (XML->sys.core[ithCore].load_instructions +
+                                  XML->sys.core[ithCore].store_instructions) *
+                                 2;  // flush overhead considered
+    LSQ->stats_t.writeAc.access = (XML->sys.core[ithCore].load_instructions +
+                                   XML->sys.core[ithCore].store_instructions) *
+                                  2;
+    LSQ->rtp_stats = LSQ->stats_t;
+
+    if ((coredynp.core_ty == OOO) &&
+        (XML->sys.core[ithCore].load_buffer_size > 0)) {
+      LoadQ->stats_t.readAc.access = XML->sys.core[ithCore].load_instructions +
+                                     XML->sys.core[ithCore].store_instructions;
+      LoadQ->stats_t.writeAc.access = XML->sys.core[ithCore].load_instructions +
+                                      XML->sys.core[ithCore].store_instructions;
+      LoadQ->rtp_stats = LoadQ->stats_t;
+    }
+  }
+
+  sharedmemory.power_t.reset();
+  dcache.power_t.reset();
+  ccache.power_t.reset();
+  tcache.power_t.reset();
+  LSQ->power_t.reset();
+
+  sharedmemory.power_t.readOp.dynamic +=
+      (sharedmemory.caches->stats_t.readAc.hit *
+           sharedmemory.caches->local_result.power.readOp.dynamic +
+       sharedmemory.caches->stats_t.readAc.miss *
+           sharedmemory.caches->local_result.power.readOp.dynamic +
+       sharedmemory.caches->stats_t.writeAc.miss *
+           sharedmemory.caches->local_result.tag_array2->power.readOp.dynamic +
+       sharedmemory.caches->stats_t.writeAc.access *
+           sharedmemory.caches->local_result.power.writeOp.dynamic +
+       xbar_shared->power.readOp.dynamic *
+           (sharedmemory.caches->stats_t.readAc.hit +
+            sharedmemory.caches->stats_t.writeAc.hit));
+
+  dcache.power_t.readOp.dynamic +=
+      (dcache.caches->stats_t.readAc.hit *
+           dcache.caches->local_result.power.readOp.dynamic +
+       dcache.caches->stats_t.readAc.miss *
+           dcache.caches->local_result.power.readOp.dynamic +
+       dcache.caches->stats_t.writeAc.miss *
+           dcache.caches->local_result.tag_array2->power.readOp.dynamic +
+       dcache.caches->stats_t.writeAc.access *
+           dcache.caches->local_result.power.writeOp.dynamic +
+       xbar_shared->power.readOp.dynamic *
+           (dcache.caches->stats_t.readAc.hit +
+            dcache.caches->stats_t.writeAc.hit));
+  ccache.power_t.readOp.dynamic +=
+      (ccache.caches->stats_t.readAc.hit *
+           ccache.caches->local_result.power.readOp.dynamic +
+       ccache.caches->stats_t.readAc.miss *
+           ccache.caches->local_result.power.readOp.dynamic +
+       ccache.caches->stats_t.writeAc.miss *
+           ccache.caches->local_result.tag_array2->power.readOp.dynamic +
+       ccache.caches->stats_t.writeAc.access *
+           ccache.caches->local_result.power.writeOp.dynamic +
+       xbar_shared->power.readOp.dynamic * (ccache.caches->stats_t.readAc.hit));
+
+  tcache.power_t.readOp.dynamic +=
+      (tcache.caches->stats_t.readAc.hit *
+           tcache.caches->local_result.power.readOp.dynamic +
+       tcache.caches->stats_t.readAc.miss *
+           tcache.caches->local_result.power.readOp.dynamic +
+       tcache.caches->stats_t.writeAc.miss *
+           tcache.caches->local_result.tag_array2->power.readOp.dynamic +
+       tcache.caches->stats_t.writeAc.access *
+           tcache.caches->local_result.power.writeOp.dynamic +
+       xbar_shared->power.readOp.dynamic *
+           (tcache.caches->stats_t.readAc.hit +
+            tcache.caches->stats_t.writeAc.hit));
+
+  if (cache_p == Write_back) {  // write miss will generate a write later
+    dcache.power_t.readOp.dynamic +=
+        dcache.caches->stats_t.writeAc.miss *
+        dcache.caches->local_result.power.writeOp.dynamic;
+    ccache.power_t.readOp.dynamic +=
+        ccache.caches->stats_t.writeAc.miss *
+        ccache.caches->local_result.power.writeOp.dynamic;
+    tcache.power_t.readOp.dynamic +=
+        tcache.caches->stats_t.writeAc.miss *
+        tcache.caches->local_result.power.writeOp.dynamic;
+    sharedmemory.power_t.readOp.dynamic +=
+        sharedmemory.caches->stats_t.writeAc.miss *
+        sharedmemory.caches->local_result.power.writeOp.dynamic;
+  }
+
+  sharedmemory.power_t.readOp.dynamic +=
+      sharedmemory.missb->stats_t.readAc.access *
+          sharedmemory.missb->local_result.power.searchOp.dynamic +
+      sharedmemory.missb->stats_t.writeAc.access *
+          sharedmemory.missb->local_result.power.writeOp
+              .dynamic;  // each access to missb involves a CAM and a write
+  sharedmemory.power_t.readOp.dynamic +=
+      sharedmemory.ifb->stats_t.readAc.access *
+          sharedmemory.ifb->local_result.power.searchOp.dynamic +
+      sharedmemory.ifb->stats_t.writeAc.access *
+          sharedmemory.ifb->local_result.power.writeOp.dynamic;
+  sharedmemory.power_t.readOp.dynamic +=
+      sharedmemory.prefetchb->stats_t.readAc.access *
+          sharedmemory.prefetchb->local_result.power.searchOp.dynamic +
+      sharedmemory.prefetchb->stats_t.writeAc.access *
+          sharedmemory.prefetchb->local_result.power.writeOp.dynamic;
+  if (cache_p == Write_back) {
+    sharedmemory.power_t.readOp.dynamic +=
+        sharedmemory.wbb->stats_t.readAc.access *
+            sharedmemory.wbb->local_result.power.searchOp.dynamic +
+        sharedmemory.wbb->stats_t.writeAc.access *
+            sharedmemory.wbb->local_result.power.writeOp.dynamic;
+  }
+
+  dcache.power_t.readOp.dynamic +=
+      dcache.missb->stats_t.readAc.access *
+          dcache.missb->local_result.power.searchOp.dynamic +
+      dcache.missb->stats_t.writeAc.access *
+          dcache.missb->local_result.power.writeOp
+              .dynamic;  // each access to missb involves a CAM and a write
+  dcache.power_t.readOp.dynamic +=
+      dcache.ifb->stats_t.readAc.access *
+          dcache.ifb->local_result.power.searchOp.dynamic +
+      dcache.ifb->stats_t.writeAc.access *
+          dcache.ifb->local_result.power.writeOp.dynamic;
+  dcache.power_t.readOp.dynamic +=
+      dcache.prefetchb->stats_t.readAc.access *
+          dcache.prefetchb->local_result.power.searchOp.dynamic +
+      dcache.prefetchb->stats_t.writeAc.access *
+          dcache.prefetchb->local_result.power.writeOp.dynamic;
+  if (cache_p == Write_back) {
+    dcache.power_t.readOp.dynamic +=
+        dcache.wbb->stats_t.readAc.access *
+            dcache.wbb->local_result.power.searchOp.dynamic +
+        dcache.wbb->stats_t.writeAc.access *
+            dcache.wbb->local_result.power.writeOp.dynamic;
+  }
+
+  ccache.power_t.readOp.dynamic +=
+      ccache.missb->stats_t.readAc.access *
+          ccache.missb->local_result.power.searchOp.dynamic +
+      ccache.missb->stats_t.writeAc.access *
+          ccache.missb->local_result.power.writeOp
+              .dynamic;  // each access to missb involves a CAM and a write
+  ccache.power_t.readOp.dynamic +=
+      ccache.ifb->stats_t.readAc.access *
+          ccache.ifb->local_result.power.searchOp.dynamic +
+      ccache.ifb->stats_t.writeAc.access *
+          ccache.ifb->local_result.power.writeOp.dynamic;
+  ccache.power_t.readOp.dynamic +=
+      ccache.prefetchb->stats_t.readAc.access *
+          ccache.prefetchb->local_result.power.searchOp.dynamic +
+      ccache.prefetchb->stats_t.writeAc.access *
+          ccache.prefetchb->local_result.power.writeOp.dynamic;
+  if (cache_p == Write_back) {
+    ccache.power_t.readOp.dynamic +=
+        ccache.wbb->stats_t.readAc.access *
+            ccache.wbb->local_result.power.searchOp.dynamic +
+        ccache.wbb->stats_t.writeAc.access *
+            ccache.wbb->local_result.power.writeOp.dynamic;
+  }
+
+  tcache.power_t.readOp.dynamic +=
+      tcache.missb->stats_t.readAc.access *
+          tcache.missb->local_result.power.searchOp.dynamic +
+      tcache.missb->stats_t.writeAc.access *
+          tcache.missb->local_result.power.writeOp
+              .dynamic;  // each access to missb involves a CAM and a write
+  tcache.power_t.readOp.dynamic +=
+      tcache.ifb->stats_t.readAc.access *
+          tcache.ifb->local_result.power.searchOp.dynamic +
+      tcache.ifb->stats_t.writeAc.access *
+          tcache.ifb->local_result.power.writeOp.dynamic;
+  tcache.power_t.readOp.dynamic +=
+      tcache.prefetchb->stats_t.readAc.access *
+          tcache.prefetchb->local_result.power.searchOp.dynamic +
+      tcache.prefetchb->stats_t.writeAc.access *
+          tcache.prefetchb->local_result.power.writeOp.dynamic;
+  if (cache_p == Write_back) {
+    tcache.power_t.readOp.dynamic +=
+        tcache.wbb->stats_t.readAc.access *
+            tcache.wbb->local_result.power.searchOp.dynamic +
+        tcache.wbb->stats_t.writeAc.access *
+            tcache.wbb->local_result.power.writeOp.dynamic;
+  }
+
+  if ((coredynp.core_ty == OOO) &&
+      (XML->sys.core[ithCore].load_buffer_size > 0)) {
+    LoadQ->power_t.reset();
+    LoadQ->power_t.readOp.dynamic +=
+        LoadQ->stats_t.readAc.access *
+            (LoadQ->local_result.power.searchOp.dynamic +
+             LoadQ->local_result.power.readOp.dynamic) +
+        LoadQ->stats_t.writeAc.access *
+            LoadQ->local_result.power.writeOp.dynamic;  // every memory access
+                                                        // invloves at least two
+                                                        // operations on LoadQ
+
+    LSQ->power_t.readOp.dynamic +=
+        LSQ->stats_t.readAc.access * (LSQ->local_result.power.searchOp.dynamic +
+                                      LSQ->local_result.power.readOp.dynamic) +
+        LSQ->stats_t.writeAc.access *
+            LSQ->local_result.power.writeOp.dynamic;  // every memory access
+                                                      // invloves at least two
+                                                      // operations on LSQ
+
+  } else {
+    //	LSQ->power_t.readOp.dynamic  +=
+    //LSQ->stats_t.readAc.access*(LSQ->local_result.power.searchOp.dynamic +
+    //LSQ->local_result.power.readOp.dynamic)
+    //	        +
+    //LSQ->stats_t.writeAc.access*LSQ->local_result.power.writeOp.dynamic;//every
+    //memory access invloves at least two operations on LSQ
+    //	No LSQ in GPUs (Syed)
+  }
+
+  if (is_tdp) {
+    //    	dcache.power = dcache.power_t +
+    //    (dcache.caches->local_result.power)*pppm_lkg +
+    //    			(dcache.missb->local_result.power +
+    //    			dcache.ifb->local_result.power +
+    //    			dcache.prefetchb->local_result.power +
+    //    			dcache.wbb->local_result.power)*pppm_Isub;
+
+    sharedmemory.power =
+        sharedmemory.power_t +
+        (sharedmemory.caches->local_result.power +
+         sharedmemory.missb->local_result.power +
+         sharedmemory.ifb->local_result.power +
+         sharedmemory.prefetchb->local_result.power + xbar_shared->power) *
+            pppm_lkg;
+    if (cache_p == Write_back) {
+      sharedmemory.power =
+          sharedmemory.power + sharedmemory.wbb->local_result.power * pppm_lkg;
+    }
+
+    dcache.power =
+        dcache.power_t +
+        (dcache.caches->local_result.power + dcache.missb->local_result.power +
+         dcache.ifb->local_result.power +
+         dcache.prefetchb->local_result.power) *
+            pppm_lkg;
+    if (cache_p == Write_back) {
+      dcache.power = dcache.power + dcache.wbb->local_result.power * pppm_lkg;
+    }
+
+    ccache.power =
+        ccache.power_t +
+        (ccache.caches->local_result.power + ccache.missb->local_result.power +
+         ccache.ifb->local_result.power +
+         ccache.prefetchb->local_result.power) *
+            pppm_lkg;
+    if (cache_p == Write_back) {
+      ccache.power = ccache.power + ccache.wbb->local_result.power * pppm_lkg;
+    }
+
+    tcache.power =
+        tcache.power_t +
+        (tcache.caches->local_result.power + tcache.missb->local_result.power +
+         tcache.ifb->local_result.power +
+         tcache.prefetchb->local_result.power) *
+            pppm_lkg;
+    if (cache_p == Write_back) {
+      tcache.power = tcache.power + tcache.wbb->local_result.power * pppm_lkg;
+    }
+
+    LSQ->power = LSQ->power_t + LSQ->local_result.power * pppm_lkg;
+    // No LSQ in GPUs (Syed)
+    LSQ->power.reset();
+    power = power + dcache.power + LSQ->power + sharedmemory.power +
+            ccache.power + tcache.power;
+
+    if ((coredynp.core_ty == OOO) &&
+        (XML->sys.core[ithCore].load_buffer_size > 0)) {
+      LoadQ->power = LoadQ->power_t + LoadQ->local_result.power * pppm_lkg;
+      power = power + LoadQ->power;
+    }
+  } else {
+    //    	dcache.rt_power = dcache.power_t +
+    //    (dcache.caches->local_result.power +
+    //    			dcache.missb->local_result.power +
+    //    			dcache.ifb->local_result.power +
+    //    			dcache.prefetchb->local_result.power +
+    //    			dcache.wbb->local_result.power)*pppm_lkg;
+    rt_power.reset();
+    sharedmemory.rt_power.reset();  // Jingwen
+    tcache.rt_power.reset();
+    ccache.rt_power.reset();
+    dcache.rt_power.reset();
+    LSQ->rt_power.reset();
+
+    sharedmemory.rt_power = sharedmemory.power_t +
+                            (sharedmemory.caches->local_result.power +
+                             sharedmemory.missb->local_result.power +
+                             sharedmemory.ifb->local_result.power +
+                             sharedmemory.prefetchb->local_result.power) *
+                                pppm_lkg;
+
+    if (cache_p == Write_back) {
+      sharedmemory.rt_power = sharedmemory.rt_power +
+                              sharedmemory.wbb->local_result.power * pppm_lkg;
+    }
+
+    dcache.rt_power =
+        dcache.power_t +
+        (dcache.caches->local_result.power + dcache.missb->local_result.power +
+         dcache.ifb->local_result.power +
+         dcache.prefetchb->local_result.power) *
+            pppm_lkg;
+    if (cache_p == Write_back) {
+      dcache.rt_power =
+          dcache.rt_power + dcache.wbb->local_result.power * pppm_lkg;
+    }
+
+    ccache.rt_power =
+        ccache.power_t +
+        (ccache.caches->local_result.power + ccache.missb->local_result.power +
+         ccache.ifb->local_result.power +
+         ccache.prefetchb->local_result.power) *
+            pppm_lkg;
+    if (cache_p == Write_back) {
+      ccache.rt_power =
+          ccache.rt_power + ccache.wbb->local_result.power * pppm_lkg;
+    }
+
+    tcache.rt_power =
+        tcache.power_t +
+        (tcache.caches->local_result.power + tcache.missb->local_result.power +
+         tcache.ifb->local_result.power +
+         tcache.prefetchb->local_result.power) *
+            pppm_lkg;
+    if (cache_p == Write_back) {
+      tcache.rt_power =
+          tcache.rt_power + tcache.wbb->local_result.power * pppm_lkg;
+    }
+
+    LSQ->rt_power = LSQ->power_t + LSQ->local_result.power * pppm_lkg;
+    LSQ->rt_power.reset();
+    rt_power = rt_power + dcache.rt_power + LSQ->rt_power +
+               sharedmemory.rt_power + ccache.rt_power + tcache.rt_power;
+
+    if ((coredynp.core_ty == OOO) &&
+        (XML->sys.core[ithCore].load_buffer_size > 0)) {
+      LoadQ->rt_power = LoadQ->power_t + LoadQ->local_result.power * pppm_lkg;
+      rt_power = rt_power + LoadQ->rt_power;
+    }
+  }
+}
+
+void LoadStoreU::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  if (!exist) return;
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
+
+  if (is_tdp) {
+    cout << indent_str << "Shared Memory:" << endl;
+    cout << indent_str_next << "Area = " << sharedmemory.area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << sharedmemory.power.readOp.dynamic * clockRate
+         << " W" << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? sharedmemory.power.readOp.longer_channel_leakage
+                          : sharedmemory.power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << sharedmemory.power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << sharedmemory.rt_power.readOp.dynamic / executionTime << " W"
+         << endl;
+    cout << endl;
+
+    cout << indent_str << "Data Cache:" << endl;
+    cout << indent_str_next << "Area = " << dcache.area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << dcache.power.readOp.dynamic * clockRate << " W"
+         << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? dcache.power.readOp.longer_channel_leakage
+                          : dcache.power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << dcache.power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << dcache.rt_power.readOp.dynamic / executionTime << " W" << endl;
+    cout << endl;
+
+    cout << indent_str << "Constant Cache:" << endl;
+    cout << indent_str_next << "Area = " << ccache.area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << ccache.power.readOp.dynamic * clockRate << " W"
+         << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? dcache.power.readOp.longer_channel_leakage
+                          : dcache.power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << ccache.power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << ccache.rt_power.readOp.dynamic / executionTime << " W" << endl;
+    cout << indent_str_next
+         << "Runtime Dynamic Energy = " << ccache.rt_power.readOp.dynamic
+         << " J" << endl;
+    cout << indent_str_next << "Execution Time = " << executionTime << " s"
+         << endl;
+    cout << endl;
+
+    cout << indent_str << "Texture Cache:" << endl;
+    cout << indent_str_next << "Area = " << tcache.area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << tcache.power.readOp.dynamic * clockRate << " W"
+         << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? dcache.power.readOp.longer_channel_leakage
+                          : dcache.power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << tcache.power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << tcache.rt_power.readOp.dynamic / executionTime << " W" << endl;
+    cout << endl;
+
+    if (coredynp.core_ty == Inorder) {
+      cout << indent_str << "Load/Store Queue:" << endl;
+      cout << indent_str_next << "Area = " << LSQ->area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << LSQ->power.readOp.dynamic * clockRate << " W"
+           << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? LSQ->power.readOp.longer_channel_leakage
+                            : LSQ->power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << LSQ->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << LSQ->rt_power.readOp.dynamic / executionTime << " W" << endl;
+      cout << endl;
+    } else
+
     {
-    	sharedmemory.power_t.readOp.dynamic	+=  sharedmemory.wbb->stats_t.readAc.access*sharedmemory.wbb->local_result.power.searchOp.dynamic
-			+ sharedmemory.wbb->stats_t.writeAc.access*sharedmemory.wbb->local_result.power.writeOp.dynamic;
+      if (XML->sys.core[ithCore].load_buffer_size > 0) {
+        cout << indent_str << "LoadQ:" << endl;
+        cout << indent_str_next << "Area = " << LoadQ->area.get_area() * 1e-6
+             << " mm^2" << endl;
+        cout << indent_str_next
+             << "Peak Dynamic = " << LoadQ->power.readOp.dynamic * clockRate
+             << " W" << endl;
+        cout << indent_str_next << "Subthreshold Leakage = "
+             << (long_channel ? LoadQ->power.readOp.longer_channel_leakage
+                              : LoadQ->power.readOp.leakage)
+             << " W" << endl;
+        cout << indent_str_next
+             << "Gate Leakage = " << LoadQ->power.readOp.gate_leakage << " W"
+             << endl;
+        cout << indent_str_next << "Runtime Dynamic = "
+             << LoadQ->rt_power.readOp.dynamic / executionTime << " W" << endl;
+        cout << endl;
+      }
+      cout << indent_str << "StoreQ:" << endl;
+      cout << indent_str_next << "Area = " << LSQ->area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << LSQ->power.readOp.dynamic * clockRate << " W"
+           << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? LSQ->power.readOp.longer_channel_leakage
+                            : LSQ->power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << LSQ->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << LSQ->rt_power.readOp.dynamic / executionTime << " W" << endl;
+      cout << endl;
     }
+  } else {
+    cout << indent_str_next << "Shared Memory    Peak Dynamic = "
+         << sharedmemory.rt_power.readOp.dynamic * clockRate << " W" << endl;
+    cout << indent_str_next << "Shared Memory    Subthreshold Leakage = "
+         << sharedmemory.rt_power.readOp.leakage << " W" << endl;
+    cout << indent_str_next << "Shared Memory    Gate Leakage = "
+         << sharedmemory.rt_power.readOp.gate_leakage << " W" << endl;
 
+    cout << indent_str_next << "Data Cache    Peak Dynamic = "
+         << dcache.rt_power.readOp.dynamic * clockRate << " W" << endl;
+    cout << indent_str_next << "Data Cache    Subthreshold Leakage = "
+         << dcache.rt_power.readOp.leakage << " W" << endl;
+    cout << indent_str_next << "Data Cache    Gate Leakage = "
+         << dcache.rt_power.readOp.gate_leakage << " W" << endl;
 
-    dcache.power_t.readOp.dynamic	+=  dcache.missb->stats_t.readAc.access*dcache.missb->local_result.power.searchOp.dynamic +
-            dcache.missb->stats_t.writeAc.access*dcache.missb->local_result.power.writeOp.dynamic;//each access to missb involves a CAM and a write
-    dcache.power_t.readOp.dynamic	+=  dcache.ifb->stats_t.readAc.access*dcache.ifb->local_result.power.searchOp.dynamic +
-            dcache.ifb->stats_t.writeAc.access*dcache.ifb->local_result.power.writeOp.dynamic;
-    dcache.power_t.readOp.dynamic	+=  dcache.prefetchb->stats_t.readAc.access*dcache.prefetchb->local_result.power.searchOp.dynamic +
-            dcache.prefetchb->stats_t.writeAc.access*dcache.prefetchb->local_result.power.writeOp.dynamic;
-    if (cache_p==Write_back)
-    {
-    	dcache.power_t.readOp.dynamic	+=  dcache.wbb->stats_t.readAc.access*dcache.wbb->local_result.power.searchOp.dynamic
-			+ dcache.wbb->stats_t.writeAc.access*dcache.wbb->local_result.power.writeOp.dynamic;
+    cout << indent_str_next << "Constant Cache    Peak Dynamic = "
+         << ccache.rt_power.readOp.dynamic * clockRate << " W" << endl;
+    cout << indent_str_next << "Constant Cache    Subthreshold Leakage = "
+         << ccache.rt_power.readOp.leakage << " W" << endl;
+    cout << indent_str_next << "Constant Cache    Gate Leakage = "
+         << ccache.rt_power.readOp.gate_leakage << " W" << endl;
+
+    cout << indent_str_next << "Texture Cache    Peak Dynamic = "
+         << tcache.rt_power.readOp.dynamic * clockRate << " W" << endl;
+    cout << indent_str_next << "Texture Cache    Subthreshold Leakage = "
+         << tcache.rt_power.readOp.leakage << " W" << endl;
+    cout << indent_str_next << "Texture Cache    Gate Leakage = "
+         << tcache.rt_power.readOp.gate_leakage << " W" << endl;
+
+    if (coredynp.core_ty == Inorder) {
+      cout << indent_str_next << "Load/Store Queue   Peak Dynamic = "
+           << LSQ->rt_power.readOp.dynamic * clockRate << " W" << endl;
+      cout << indent_str_next << "Load/Store Queue   Subthreshold Leakage = "
+           << LSQ->rt_power.readOp.leakage << " W" << endl;
+      cout << indent_str_next << "Load/Store Queue   Gate Leakage = "
+           << LSQ->rt_power.readOp.gate_leakage << " W" << endl;
+    } else {
+      cout << indent_str_next << "LoadQ   Peak Dynamic = "
+           << LoadQ->rt_power.readOp.dynamic * clockRate << " W" << endl;
+      cout << indent_str_next << "LoadQ   Subthreshold Leakage = "
+           << LoadQ->rt_power.readOp.leakage << " W" << endl;
+      cout << indent_str_next
+           << "LoadQ   Gate Leakage = " << LoadQ->rt_power.readOp.gate_leakage
+           << " W" << endl;
+      cout << indent_str_next << "StoreQ   Peak Dynamic = "
+           << LSQ->rt_power.readOp.dynamic * clockRate << " W" << endl;
+      cout << indent_str_next
+           << "StoreQ   Subthreshold Leakage = " << LSQ->rt_power.readOp.leakage
+           << " W" << endl;
+      cout << indent_str_next
+           << "StoreQ   Gate Leakage = " << LSQ->rt_power.readOp.gate_leakage
+           << " W" << endl;
     }
-
-    ccache.power_t.readOp.dynamic	+=  ccache.missb->stats_t.readAc.access*ccache.missb->local_result.power.searchOp.dynamic +
-            ccache.missb->stats_t.writeAc.access*ccache.missb->local_result.power.writeOp.dynamic;//each access to missb involves a CAM and a write
-    ccache.power_t.readOp.dynamic	+=  ccache.ifb->stats_t.readAc.access*ccache.ifb->local_result.power.searchOp.dynamic +
-            ccache.ifb->stats_t.writeAc.access*ccache.ifb->local_result.power.writeOp.dynamic;
-    ccache.power_t.readOp.dynamic	+=  ccache.prefetchb->stats_t.readAc.access*ccache.prefetchb->local_result.power.searchOp.dynamic +
-            ccache.prefetchb->stats_t.writeAc.access*ccache.prefetchb->local_result.power.writeOp.dynamic;
-    if (cache_p==Write_back)
-    {
-    	ccache.power_t.readOp.dynamic	+=  ccache.wbb->stats_t.readAc.access*ccache.wbb->local_result.power.searchOp.dynamic
-			+ ccache.wbb->stats_t.writeAc.access*ccache.wbb->local_result.power.writeOp.dynamic;
-    }
-
-    tcache.power_t.readOp.dynamic	+=  tcache.missb->stats_t.readAc.access*tcache.missb->local_result.power.searchOp.dynamic +
-            tcache.missb->stats_t.writeAc.access*tcache.missb->local_result.power.writeOp.dynamic;//each access to missb involves a CAM and a write
-    tcache.power_t.readOp.dynamic	+=  tcache.ifb->stats_t.readAc.access*tcache.ifb->local_result.power.searchOp.dynamic +
-            tcache.ifb->stats_t.writeAc.access*tcache.ifb->local_result.power.writeOp.dynamic;
-    tcache.power_t.readOp.dynamic	+=  tcache.prefetchb->stats_t.readAc.access*tcache.prefetchb->local_result.power.searchOp.dynamic +
-            tcache.prefetchb->stats_t.writeAc.access*tcache.prefetchb->local_result.power.writeOp.dynamic;
-    if (cache_p==Write_back)
-    {
-    	tcache.power_t.readOp.dynamic	+=  tcache.wbb->stats_t.readAc.access*tcache.wbb->local_result.power.searchOp.dynamic
-			+ tcache.wbb->stats_t.writeAc.access*tcache.wbb->local_result.power.writeOp.dynamic;
-    }
-
-
-    if ((coredynp.core_ty==OOO) && (XML->sys.core[ithCore].load_buffer_size >0))
-    {
-    	LoadQ->power_t.reset();
-    	LoadQ->power_t.readOp.dynamic  +=  LoadQ->stats_t.readAc.access*(LoadQ->local_result.power.searchOp.dynamic+ LoadQ->local_result.power.readOp.dynamic)+
-    	        LoadQ->stats_t.writeAc.access*LoadQ->local_result.power.writeOp.dynamic;//every memory access invloves at least two operations on LoadQ
-
-    	LSQ->power_t.readOp.dynamic  +=  LSQ->stats_t.readAc.access*(LSQ->local_result.power.searchOp.dynamic + LSQ->local_result.power.readOp.dynamic)
-    		        + LSQ->stats_t.writeAc.access*LSQ->local_result.power.writeOp.dynamic;//every memory access invloves at least two operations on LSQ
-
-    }
-    else
-    {
-    //	LSQ->power_t.readOp.dynamic  +=  LSQ->stats_t.readAc.access*(LSQ->local_result.power.searchOp.dynamic + LSQ->local_result.power.readOp.dynamic)
-    	//	        + LSQ->stats_t.writeAc.access*LSQ->local_result.power.writeOp.dynamic;//every memory access invloves at least two operations on LSQ
-		//	No LSQ in GPUs (Syed)
-
-    }
-
-    if (is_tdp)
-    {
-//    	dcache.power = dcache.power_t + (dcache.caches->local_result.power)*pppm_lkg +
-//    			(dcache.missb->local_result.power +
-//    			dcache.ifb->local_result.power +
-//    			dcache.prefetchb->local_result.power +
-//    			dcache.wbb->local_result.power)*pppm_Isub;
-
-
-    	sharedmemory.power = sharedmemory.power_t + (sharedmemory.caches->local_result.power +
-    			sharedmemory.missb->local_result.power +
-    			sharedmemory.ifb->local_result.power +
-    			sharedmemory.prefetchb->local_result.power + xbar_shared->power) *pppm_lkg;
-    	if (cache_p==Write_back)
-    	{
-    		sharedmemory.power = sharedmemory.power + sharedmemory.wbb->local_result.power*pppm_lkg;
-    	}
-
-
-    	dcache.power = dcache.power_t + (dcache.caches->local_result.power +
-    			dcache.missb->local_result.power +
-    			dcache.ifb->local_result.power +
-    			dcache.prefetchb->local_result.power) *pppm_lkg;
-    	if (cache_p==Write_back)
-    	{
-    		dcache.power = dcache.power + dcache.wbb->local_result.power*pppm_lkg;
-    	}
-
-    	ccache.power = ccache.power_t + (ccache.caches->local_result.power +
-    			ccache.missb->local_result.power +
-    			ccache.ifb->local_result.power +
-    			ccache.prefetchb->local_result.power) *pppm_lkg;
-    	if (cache_p==Write_back)
-    	{
-    		ccache.power = ccache.power + ccache.wbb->local_result.power*pppm_lkg;
-    	}
-
-    	tcache.power = tcache.power_t + (tcache.caches->local_result.power +
-    			tcache.missb->local_result.power +
-    			tcache.ifb->local_result.power +
-    			tcache.prefetchb->local_result.power) *pppm_lkg;
-    	if (cache_p==Write_back)
-    	{
-    		tcache.power = tcache.power + tcache.wbb->local_result.power*pppm_lkg;
-    	}
-
-
-    	LSQ->power = LSQ->power_t + LSQ->local_result.power *pppm_lkg;
-		//No LSQ in GPUs (Syed)
-   	LSQ->power.reset();
-    	power     = power + dcache.power + LSQ->power +sharedmemory.power + ccache.power + tcache.power;
-
-    	if ((coredynp.core_ty==OOO) && (XML->sys.core[ithCore].load_buffer_size >0))
-    	{
-    		LoadQ->power = LoadQ->power_t + LoadQ->local_result.power *pppm_lkg;
-    		power     = power + LoadQ->power;
-    	}
-    }
-    else
-    {
-//    	dcache.rt_power = dcache.power_t + (dcache.caches->local_result.power +
-//    			dcache.missb->local_result.power +
-//    			dcache.ifb->local_result.power +
-//    			dcache.prefetchb->local_result.power +
-//    			dcache.wbb->local_result.power)*pppm_lkg;
-      rt_power.reset();
-      sharedmemory.rt_power.reset(); //Jingwen
-      tcache.rt_power.reset();
-      ccache.rt_power.reset();
-      dcache.rt_power.reset();
-      LSQ->rt_power.reset();
-
-
-    	sharedmemory.rt_power = sharedmemory.power_t + (sharedmemory.caches->local_result.power +
-    			sharedmemory.missb->local_result.power +
-    			sharedmemory.ifb->local_result.power +
-    			sharedmemory.prefetchb->local_result.power )*pppm_lkg;
-
-    	if (cache_p==Write_back)
-    	{
-    		sharedmemory.rt_power = sharedmemory.rt_power + sharedmemory.wbb->local_result.power*pppm_lkg;
-    	}
-
-    	dcache.rt_power = dcache.power_t + (dcache.caches->local_result.power +
-    			dcache.missb->local_result.power +
-    			dcache.ifb->local_result.power +
-    			dcache.prefetchb->local_result.power )*pppm_lkg;
-    	if (cache_p==Write_back)
-    	{
-    		dcache.rt_power = dcache.rt_power + dcache.wbb->local_result.power*pppm_lkg;
-    	}
-
-    	ccache.rt_power = ccache.power_t + (ccache.caches->local_result.power +
-    			ccache.missb->local_result.power +
-    			ccache.ifb->local_result.power +
-    			ccache.prefetchb->local_result.power )*pppm_lkg;
-    	if (cache_p==Write_back)
-    	{
-    		ccache.rt_power = ccache.rt_power + ccache.wbb->local_result.power*pppm_lkg;
-    	}
-
-    	tcache.rt_power = tcache.power_t + (tcache.caches->local_result.power +
-    			tcache.missb->local_result.power +
-    			tcache.ifb->local_result.power +
-    			tcache.prefetchb->local_result.power )*pppm_lkg;
-    	if (cache_p==Write_back)
-    	{
-    		tcache.rt_power = tcache.rt_power + tcache.wbb->local_result.power*pppm_lkg;
-    	}
-
-
-
-    	LSQ->rt_power = LSQ->power_t + LSQ->local_result.power *pppm_lkg;
-		LSQ->rt_power.reset();
-    	rt_power     = rt_power + dcache.rt_power + LSQ->rt_power + sharedmemory.rt_power + ccache.rt_power + tcache.rt_power;
-
-    	if ((coredynp.core_ty==OOO) && (XML->sys.core[ithCore].load_buffer_size >0))
-    	{
-    		LoadQ->rt_power = LoadQ->power_t + LoadQ->local_result.power *pppm_lkg;
-    		rt_power     = rt_power + LoadQ->rt_power;
-    	}
-    }
+  }
 }
 
+void MemManU::computeEnergy(bool is_tdp) {
+  if (!exist) return;
+  if (is_tdp) {
+    // init stats for Peak
+    itlb->stats_t.readAc.access = itlb->l_ip.num_search_ports;
+    itlb->stats_t.readAc.miss = 0;
+    itlb->stats_t.readAc.hit =
+        itlb->stats_t.readAc.access - itlb->stats_t.readAc.miss;
+    itlb->tdp_stats = itlb->stats_t;
 
-void LoadStoreU::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	if (!exist) return;
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
+    dtlb->stats_t.readAc.access =
+        dtlb->l_ip.num_search_ports * coredynp.LSU_duty_cycle;
+    dtlb->stats_t.readAc.miss = 0;
+    dtlb->stats_t.readAc.hit =
+        dtlb->stats_t.readAc.access - dtlb->stats_t.readAc.miss;
+    dtlb->tdp_stats = dtlb->stats_t;
+  } else {
+    // init stats for Runtime Dynamic (RTP)
+    itlb->stats_t.readAc.access = XML->sys.core[ithCore].itlb.total_accesses;
+    itlb->stats_t.readAc.miss = XML->sys.core[ithCore].itlb.total_misses;
+    itlb->stats_t.readAc.hit =
+        itlb->stats_t.readAc.access - itlb->stats_t.readAc.miss;
+    itlb->rtp_stats = itlb->stats_t;
 
+    dtlb->stats_t.readAc.access = XML->sys.core[ithCore].dtlb.total_accesses;
+    dtlb->stats_t.readAc.miss = XML->sys.core[ithCore].dtlb.total_misses;
+    dtlb->stats_t.readAc.hit =
+        dtlb->stats_t.readAc.access - dtlb->stats_t.readAc.miss;
+    dtlb->rtp_stats = dtlb->stats_t;
+  }
 
-	if (is_tdp)
-	{
+  itlb->power_t.reset();
+  dtlb->power_t.reset();
+  itlb->power_t.readOp.dynamic +=
+      itlb->stats_t.readAc.access *
+          itlb->local_result.power.searchOp.dynamic  // FA spent most power in
+                                                     // tag, so use total access
+                                                     // not hits
+      + itlb->stats_t.readAc.miss * itlb->local_result.power.writeOp.dynamic;
+  dtlb->power_t.readOp.dynamic +=
+      dtlb->stats_t.readAc.access *
+          dtlb->local_result.power.searchOp.dynamic  // FA spent most power in
+                                                     // tag, so use total access
+                                                     // not hits
+      + dtlb->stats_t.readAc.miss * dtlb->local_result.power.writeOp.dynamic;
 
-		cout << indent_str << "Shared Memory:" << endl;
-		cout << indent_str_next << "Area = " << sharedmemory.area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << sharedmemory.power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? sharedmemory.power.readOp.longer_channel_leakage:sharedmemory.power.readOp.leakage )<<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << sharedmemory.power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << sharedmemory.rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-
-
-		cout << indent_str << "Data Cache:" << endl;
-		cout << indent_str_next << "Area = " << dcache.area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << dcache.power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? dcache.power.readOp.longer_channel_leakage:dcache.power.readOp.leakage )<<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << dcache.power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << dcache.rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-
-		cout << indent_str << "Constant Cache:" << endl;
-		cout << indent_str_next << "Area = " << ccache.area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << ccache.power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? dcache.power.readOp.longer_channel_leakage:dcache.power.readOp.leakage )<<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << ccache.power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << ccache.rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic Energy = " << ccache.rt_power.readOp.dynamic<<" J"<<endl;
-      cout << indent_str_next << "Execution Time = " << executionTime<<" s"<<endl;
-		cout <<endl;
-
-
-		cout << indent_str << "Texture Cache:" << endl;
-		cout << indent_str_next << "Area = " << tcache.area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << tcache.power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? dcache.power.readOp.longer_channel_leakage:dcache.power.readOp.leakage )<<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << tcache.power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << tcache.rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-		
-    if (coredynp.core_ty==Inorder)
-		{
-			cout << indent_str << "Load/Store Queue:" << endl;
-			cout << indent_str_next << "Area = " << LSQ->area.get_area()*1e-6  << " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << LSQ->power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? LSQ->power.readOp.longer_channel_leakage:LSQ->power.readOp.leakage)  << " W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << LSQ->power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << LSQ->rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-		}
-		else
-
-		{
-			if (XML->sys.core[ithCore].load_buffer_size >0)
-			{
-				cout << indent_str << "LoadQ:" << endl;
-				cout << indent_str_next << "Area = " << LoadQ->area.get_area() *1e-6 << " mm^2" << endl;
-				cout << indent_str_next << "Peak Dynamic = " << LoadQ->power.readOp.dynamic*clockRate  << " W" << endl;
-				cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? LoadQ->power.readOp.longer_channel_leakage:LoadQ->power.readOp.leakage)  << " W" << endl;
-				cout << indent_str_next << "Gate Leakage = " << LoadQ->power.readOp.gate_leakage  << " W" << endl;
-				cout << indent_str_next << "Runtime Dynamic = " << LoadQ->rt_power.readOp.dynamic/executionTime << " W" << endl;
-				cout <<endl;
-			}
-			cout << indent_str<< "StoreQ:" << endl;
-			cout << indent_str_next << "Area = " << LSQ->area.get_area()  *1e-6<< " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << LSQ->power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? LSQ->power.readOp.longer_channel_leakage:LSQ->power.readOp.leakage)  << " W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << LSQ->power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << LSQ->rt_power.readOp.dynamic/executionTime<< " W" << endl;
-			cout <<endl;
-		}
-	}
-	else
-	{
-
-		cout << indent_str_next << "Shared Memory    Peak Dynamic = " << sharedmemory.rt_power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Shared Memory    Subthreshold Leakage = " << sharedmemory.rt_power.readOp.leakage <<" W" << endl;
-		cout << indent_str_next << "Shared Memory    Gate Leakage = " << sharedmemory.rt_power.readOp.gate_leakage << " W" << endl;
-
-
-		cout << indent_str_next << "Data Cache    Peak Dynamic = " << dcache.rt_power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Data Cache    Subthreshold Leakage = " << dcache.rt_power.readOp.leakage <<" W" << endl;
-		cout << indent_str_next << "Data Cache    Gate Leakage = " << dcache.rt_power.readOp.gate_leakage << " W" << endl;
-
-		cout << indent_str_next << "Constant Cache    Peak Dynamic = " << ccache.rt_power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Constant Cache    Subthreshold Leakage = " << ccache.rt_power.readOp.leakage <<" W" << endl;
-		cout << indent_str_next << "Constant Cache    Gate Leakage = " << ccache.rt_power.readOp.gate_leakage << " W" << endl;
-
-		cout << indent_str_next << "Texture Cache    Peak Dynamic = " << tcache.rt_power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Texture Cache    Subthreshold Leakage = " << tcache.rt_power.readOp.leakage <<" W" << endl;
-		cout << indent_str_next << "Texture Cache    Gate Leakage = " << tcache.rt_power.readOp.gate_leakage << " W" << endl;
-		
-    if (coredynp.core_ty==Inorder)
-		{
-			cout << indent_str_next << "Load/Store Queue   Peak Dynamic = " << LSQ->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Load/Store Queue   Subthreshold Leakage = " << LSQ->rt_power.readOp.leakage  << " W" << endl;
-			cout << indent_str_next << "Load/Store Queue   Gate Leakage = " << LSQ->rt_power.readOp.gate_leakage  << " W" << endl;
-		}
-		else
-		{
-			cout << indent_str_next << "LoadQ   Peak Dynamic = " << LoadQ->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "LoadQ   Subthreshold Leakage = " << LoadQ->rt_power.readOp.leakage  << " W" << endl;
-			cout << indent_str_next << "LoadQ   Gate Leakage = " << LoadQ->rt_power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "StoreQ   Peak Dynamic = " << LSQ->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "StoreQ   Subthreshold Leakage = " << LSQ->rt_power.readOp.leakage  << " W" << endl;
-			cout << indent_str_next << "StoreQ   Gate Leakage = " << LSQ->rt_power.readOp.gate_leakage  << " W" << endl;
-		}
-	}
-
+  if (is_tdp) {
+    itlb->power = itlb->power_t + itlb->local_result.power * pppm_lkg;
+    dtlb->power = dtlb->power_t + dtlb->local_result.power * pppm_lkg;
+    power = power + itlb->power + dtlb->power;
+  } else {
+    itlb->rt_power = itlb->power_t + itlb->local_result.power * pppm_lkg;
+    dtlb->rt_power = dtlb->power_t + dtlb->local_result.power * pppm_lkg;
+    rt_power = rt_power + itlb->rt_power + dtlb->rt_power;
+  }
 }
 
-void MemManU::computeEnergy(bool is_tdp)
-{
+void MemManU::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  if (!exist) return;
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
 
-	if (!exist) return;
-	if (is_tdp)
-    {
-    	//init stats for Peak
-    	itlb->stats_t.readAc.access  = itlb->l_ip.num_search_ports;
-    	itlb->stats_t.readAc.miss    = 0;
-    	itlb->stats_t.readAc.hit     = itlb->stats_t.readAc.access - itlb->stats_t.readAc.miss;
-    	itlb->tdp_stats = itlb->stats_t;
+  if (is_tdp) {
+    cout << indent_str << "Itlb:" << endl;
+    cout << indent_str_next << "Area = " << itlb->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << itlb->power.readOp.dynamic * clockRate << " W"
+         << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? itlb->power.readOp.longer_channel_leakage
+                          : itlb->power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << itlb->power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << itlb->rt_power.readOp.dynamic / executionTime << " W" << endl;
+    cout << endl;
+    cout << indent_str << "Dtlb:" << endl;
+    cout << indent_str_next << "Area = " << dtlb->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << dtlb->power.readOp.dynamic * clockRate << " W"
+         << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? dtlb->power.readOp.longer_channel_leakage
+                          : dtlb->power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << dtlb->power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << dtlb->rt_power.readOp.dynamic / executionTime << " W" << endl;
+    cout << endl;
+  } else {
+    cout << indent_str_next << "Itlb    Peak Dynamic = "
+         << itlb->rt_power.readOp.dynamic * clockRate << " W" << endl;
+    cout << indent_str_next
+         << "Itlb    Subthreshold Leakage = " << itlb->rt_power.readOp.leakage
+         << " W" << endl;
+    cout << indent_str_next
+         << "Itlb    Gate Leakage = " << itlb->rt_power.readOp.gate_leakage
+         << " W" << endl;
+    cout << indent_str_next << "Dtlb   Peak Dynamic = "
+         << dtlb->rt_power.readOp.dynamic * clockRate << " W" << endl;
+    cout << indent_str_next
+         << "Dtlb   Subthreshold Leakage = " << dtlb->rt_power.readOp.leakage
+         << " W" << endl;
+    cout << indent_str_next
+         << "Dtlb   Gate Leakage = " << dtlb->rt_power.readOp.gate_leakage
+         << " W" << endl;
+  }
+}
 
-    	dtlb->stats_t.readAc.access  = dtlb->l_ip.num_search_ports*coredynp.LSU_duty_cycle;
-    	dtlb->stats_t.readAc.miss    = 0;
-    	dtlb->stats_t.readAc.hit     = dtlb->stats_t.readAc.access - dtlb->stats_t.readAc.miss;
-    	dtlb->tdp_stats = dtlb->stats_t;
-     }
-    else
-    {
-    	//init stats for Runtime Dynamic (RTP)
-    	itlb->stats_t.readAc.access  = XML->sys.core[ithCore].itlb.total_accesses;
-    	itlb->stats_t.readAc.miss    = XML->sys.core[ithCore].itlb.total_misses;
-    	itlb->stats_t.readAc.hit     = itlb->stats_t.readAc.access - itlb->stats_t.readAc.miss;
-    	itlb->rtp_stats = itlb->stats_t;
+void RegFU::computeEnergy(bool is_tdp) {
+  /*
+   * Architecture RF and physical RF cannot be present at the same time.
+   * Therefore, the RF stats can only refer to either ARF or PRF;
+   * And the same stats can be used for both.
+   */
+  if (!exist) return;
 
-    	dtlb->stats_t.readAc.access  = XML->sys.core[ithCore].dtlb.total_accesses;
-    	dtlb->stats_t.readAc.miss    = XML->sys.core[ithCore].dtlb.total_misses;
-    	dtlb->stats_t.readAc.hit     = dtlb->stats_t.readAc.access - dtlb->stats_t.readAc.miss;
-    	dtlb->rtp_stats = dtlb->stats_t;
+  executionTime =
+      XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);  // Syed
+  // RF crossbar power (Syed Gilani)
+  xbar_rfu->compute_power();
+
+  // Arbiter power
+  arbiter_rfu->compute_power();
+
+  if (is_tdp) {
+    // RF power -- modified by Syed
+    // init stats for Peak
+
+    IRF->stats_t.readAc.access = 4;
+    IRF->stats_t.writeAc.access = 4;
+    IRF->tdp_stats = IRF->stats_t;
+
+    IRF->stats_t.readAc.access = 2;
+    IRF->stats_t.writeAc.access = 1;
+    IRF->tdp_stats = IRF->stats_t;
+
+    OPC->stats_t.readAc.access = 32;
+    OPC->stats_t.writeAc.access = 32;
+    OPC->tdp_stats = OPC->stats_t;
+
+    // Commented by Syed (GPUs have a single RF which we model by IRF)
+    // FRF->stats_t.readAc.access  =
+    // FRF->l_ip.num_rd_ports*coredynp.FPU_duty_cycle*1.05*coredynp.num_fp_pipelines;
+    // FRF->stats_t.writeAc.access  =
+    // FRF->l_ip.num_wr_ports*coredynp.FPU_duty_cycle*1.05*coredynp.num_fp_pipelines;
+    // FRF->tdp_stats = FRF->stats_t;
+    if (coredynp.regWindowing) {
+      RFWIN->stats_t.readAc.access = 0;   // 0.5*RFWIN->l_ip.num_rw_ports;
+      RFWIN->stats_t.writeAc.access = 0;  // 0.5*RFWIN->l_ip.num_rw_ports;
+      RFWIN->tdp_stats = RFWIN->stats_t;
     }
-
-    itlb->power_t.reset();
-    dtlb->power_t.reset();
-	itlb->power_t.readOp.dynamic +=  itlb->stats_t.readAc.access*itlb->local_result.power.searchOp.dynamic//FA spent most power in tag, so use total access not hits
-	                      +itlb->stats_t.readAc.miss*itlb->local_result.power.writeOp.dynamic;
-	dtlb->power_t.readOp.dynamic +=  dtlb->stats_t.readAc.access*dtlb->local_result.power.searchOp.dynamic//FA spent most power in tag, so use total access not hits
-	                      +dtlb->stats_t.readAc.miss*dtlb->local_result.power.writeOp.dynamic;
-
-	if (is_tdp)
-	    {
-		itlb->power = itlb->power_t + itlb->local_result.power *pppm_lkg;
-		dtlb->power = dtlb->power_t + dtlb->local_result.power *pppm_lkg;
-		power     = power + itlb->power + dtlb->power;
-	    }
-	    else
-	    {
-			itlb->rt_power = itlb->power_t + itlb->local_result.power *pppm_lkg;
-			dtlb->rt_power = dtlb->power_t + dtlb->local_result.power *pppm_lkg;
-			rt_power     = rt_power + itlb->rt_power + dtlb->rt_power;
-	    }
-
-}
-
-void MemManU::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	if (!exist) return;
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
-
-
-
-
-	if (is_tdp)
-	{
-		cout << indent_str << "Itlb:" << endl;
-		cout << indent_str_next << "Area = " << itlb->area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << itlb->power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? itlb->power.readOp.longer_channel_leakage:itlb->power.readOp.leakage) <<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << itlb->power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << itlb->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-		cout << indent_str<< "Dtlb:" << endl;
-		cout << indent_str_next << "Area = " << dtlb->area.get_area()*1e-6  << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << dtlb->power.readOp.dynamic*clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? dtlb->power.readOp.longer_channel_leakage:dtlb->power.readOp.leakage)  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << dtlb->power.readOp.gate_leakage  << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << dtlb->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-	}
-	else
-	{
-		cout << indent_str_next << "Itlb    Peak Dynamic = " << itlb->rt_power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Itlb    Subthreshold Leakage = " << itlb->rt_power.readOp.leakage <<" W" << endl;
-		cout << indent_str_next << "Itlb    Gate Leakage = " << itlb->rt_power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Dtlb   Peak Dynamic = " << dtlb->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-		cout << indent_str_next << "Dtlb   Subthreshold Leakage = " << dtlb->rt_power.readOp.leakage  << " W" << endl;
-		cout << indent_str_next << "Dtlb   Gate Leakage = " << dtlb->rt_power.readOp.gate_leakage  << " W" << endl;
-	}
-
-}
-
-void RegFU::computeEnergy(bool is_tdp)
-{
-/*
- * Architecture RF and physical RF cannot be present at the same time.
- * Therefore, the RF stats can only refer to either ARF or PRF;
- * And the same stats can be used for both.
- */
-	if (!exist) return;
-
-  executionTime=XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);//Syed
- //RF crossbar power (Syed Gilani)
- xbar_rfu->compute_power();
-
-
- //Arbiter power
- arbiter_rfu->compute_power(); 
-
-	if (is_tdp)
-    {
-        //RF power -- modified by Syed
-    	//init stats for Peak
-
-    	IRF->stats_t.readAc.access  = 4;
-    	IRF->stats_t.writeAc.access  = 4;
-    	IRF->tdp_stats = IRF->stats_t;
-
-    	IRF->stats_t.readAc.access  = 2;
-    	IRF->stats_t.writeAc.access  = 1;
-    	IRF->tdp_stats = IRF->stats_t;
-
-
-    	OPC->stats_t.readAc.access  = 32;
-    	OPC->stats_t.writeAc.access  = 32;
-    	OPC->tdp_stats = OPC->stats_t;
-
-        //Commented by Syed (GPUs have a single RF which we model by IRF)
-    	//FRF->stats_t.readAc.access  = FRF->l_ip.num_rd_ports*coredynp.FPU_duty_cycle*1.05*coredynp.num_fp_pipelines;
-    	//FRF->stats_t.writeAc.access  = FRF->l_ip.num_wr_ports*coredynp.FPU_duty_cycle*1.05*coredynp.num_fp_pipelines;
-    	//FRF->tdp_stats = FRF->stats_t;
-    	if (coredynp.regWindowing)
-    	{
-        	RFWIN->stats_t.readAc.access  = 0;//0.5*RFWIN->l_ip.num_rw_ports;
-        	RFWIN->stats_t.writeAc.access  = 0;//0.5*RFWIN->l_ip.num_rw_ports;
-        	RFWIN->tdp_stats = RFWIN->stats_t;
-    	}
-	 } /* if (is_tdp) */ 
-    else
-    {
-    	//init stats for Runtime Dynamic (RTP)
-		//in Tesla each RF operand accesses 2 banks, so multiply acceses by 2
-		// (read and write energies of reg_file are per bank)(Tesla) : Syed
-		// Also, for a SIMD width of 8 and warp size of 32 threads, 4 accesses
-		// (each accessing 2 banks) need to be performed per operand
-if (XML->sys.architecture==1){
-    	IRF->stats_t.readAc.access  = (XML->sys.core[ithCore].int_regfile_reads/32)*(4*2);///1.5; 
-    	IRF->stats_t.writeAc.access  = (XML->sys.core[ithCore].int_regfile_writes/32)*(4*2);///1.5;
-} else {
-    	IRF->stats_t.readAc.access  = (XML->sys.core[ithCore].int_regfile_reads/32)*(2*4);///1.5;//TODO: no diff on archi and phy
-    	IRF->stats_t.writeAc.access  = (XML->sys.core[ithCore].int_regfile_writes/32)*(2*4);///1.5;
-}
-    	IRF->rtp_stats = IRF->stats_t;
-
-    	OPC->stats_t.readAc.access  = (XML->sys.core[ithCore].int_regfile_reads)/*/1.5*/+XML->sys.core[ithCore].non_rf_operands;///1.5;//TODO: no diff on archi and phy
-    	OPC->stats_t.writeAc.access  = 0;
-    	OPC->rtp_stats = OPC->stats_t;
-
-      //cout<< "IRF read energy: "<<    IRF->local_result.power.readOp.dynamic<<endl;
-      //cout<< "IRF write energy: "<<    IRF->local_result.power.writeOp.dynamic<<endl;
-    	//FRF->stats_t.readAc.access  = XML->sys.core[ithCore].float_regfile_reads;
-    	//FRF->stats_t.writeAc.access  = XML->sys.core[ithCore].float_regfile_writes;
-    	//FRF->rtp_stats = FRF->stats_t;
-    	if (coredynp.regWindowing)
-    	{
-        	RFWIN->stats_t.readAc.access  = XML->sys.core[ithCore].function_calls*16;
-        	RFWIN->stats_t.writeAc.access  = XML->sys.core[ithCore].function_calls*16;
-        	RFWIN->rtp_stats = RFWIN->stats_t;
-
-        	IRF->stats_t.readAc.access  = XML->sys.core[ithCore].int_regfile_reads +
-        	     XML->sys.core[ithCore].function_calls*16;
-        	IRF->stats_t.writeAc.access  = XML->sys.core[ithCore].int_regfile_writes +
-        	     XML->sys.core[ithCore].function_calls*16;
-        	IRF->rtp_stats = IRF->stats_t;
-
-    	}
+  } /* if (is_tdp) */
+  else {
+    // init stats for Runtime Dynamic (RTP)
+    // in Tesla each RF operand accesses 2 banks, so multiply acceses by 2
+    // (read and write energies of reg_file are per bank)(Tesla) : Syed
+    // Also, for a SIMD width of 8 and warp size of 32 threads, 4 accesses
+    // (each accessing 2 banks) need to be performed per operand
+    if (XML->sys.architecture == 1) {
+      IRF->stats_t.readAc.access =
+          (XML->sys.core[ithCore].int_regfile_reads / 32) * (4 * 2);  /// 1.5;
+      IRF->stats_t.writeAc.access =
+          (XML->sys.core[ithCore].int_regfile_writes / 32) * (4 * 2);  /// 1.5;
+    } else {
+      IRF->stats_t.readAc.access =
+          (XML->sys.core[ithCore].int_regfile_reads / 32) *
+          (2 * 4);  /// 1.5;//TODO: no diff on archi and phy
+      IRF->stats_t.writeAc.access =
+          (XML->sys.core[ithCore].int_regfile_writes / 32) * (2 * 4);  /// 1.5;
     }
-	IRF->power_t.reset();
-	FRF->power_t.reset();
-	OPC->power_t.reset();
-	//IRF->power_t  =  IRF->power_t + IRF->local_result.power;// + xbar_rfu->power + arbiter_rfu->power;
+    IRF->rtp_stats = IRF->stats_t;
 
+    OPC->stats_t.readAc.access =
+        (XML->sys.core[ithCore].int_regfile_reads) /*/1.5*/ +
+        XML->sys.core[ithCore]
+            .non_rf_operands;  /// 1.5;//TODO: no diff on archi and phy
+    OPC->stats_t.writeAc.access = 0;
+    OPC->rtp_stats = OPC->stats_t;
 
-	
-	IRF->power_t.readOp.dynamic  =  (IRF->stats_t.readAc.access*IRF->local_result.power.readOp.dynamic
-			+IRF->stats_t.writeAc.access*IRF->local_result.power.writeOp.dynamic);
-	OPC->power_t.readOp.dynamic  =  (OPC->stats_t.readAc.access*OPC->local_result.power.readOp.dynamic);
+    // cout<< "IRF read energy: "<<
+    // IRF->local_result.power.readOp.dynamic<<endl;
+    // cout<< "IRF write energy: "<<
+    // IRF->local_result.power.writeOp.dynamic<<endl;
+    // FRF->stats_t.readAc.access  = XML->sys.core[ithCore].float_regfile_reads;
+    // FRF->stats_t.writeAc.access  =
+    // XML->sys.core[ithCore].float_regfile_writes;
+    // FRF->rtp_stats = FRF->stats_t;
+    if (coredynp.regWindowing) {
+      RFWIN->stats_t.readAc.access = XML->sys.core[ithCore].function_calls * 16;
+      RFWIN->stats_t.writeAc.access =
+          XML->sys.core[ithCore].function_calls * 16;
+      RFWIN->rtp_stats = RFWIN->stats_t;
 
-	if (coredynp.regWindowing)
-	{
-		RFWIN->power_t.reset();
-		RFWIN->power_t.readOp.dynamic   +=  (RFWIN->stats_t.readAc.access*RFWIN->local_result.power.readOp.dynamic +
-				RFWIN->stats_t.writeAc.access*RFWIN->local_result.power.writeOp.dynamic);
-	}
+      IRF->stats_t.readAc.access = XML->sys.core[ithCore].int_regfile_reads +
+                                   XML->sys.core[ithCore].function_calls * 16;
+      IRF->stats_t.writeAc.access = XML->sys.core[ithCore].int_regfile_writes +
+                                    XML->sys.core[ithCore].function_calls * 16;
+      IRF->rtp_stats = IRF->stats_t;
+    }
+  }
+  IRF->power_t.reset();
+  FRF->power_t.reset();
+  OPC->power_t.reset();
+  // IRF->power_t  =  IRF->power_t + IRF->local_result.power;// +
+  // xbar_rfu->power + arbiter_rfu->power;
 
-	if (is_tdp)
-	{
+  IRF->power_t.readOp.dynamic =
+      (IRF->stats_t.readAc.access * IRF->local_result.power.readOp.dynamic +
+       IRF->stats_t.writeAc.access * IRF->local_result.power.writeOp.dynamic);
+  OPC->power_t.readOp.dynamic =
+      (OPC->stats_t.readAc.access * OPC->local_result.power.readOp.dynamic);
 
-	  	//cout<<"pre: IRF_power_t: "<<IRF->power.readOp.dynamic<<" ("<<IRF->power.readOp.dynamic*clockRate<<") "<<" IRF_localresult: "<<
-		 //                   IRF->local_result.power.readOp.dynamic<<endl;
-		//Syed: removed the multiplication of power by hardware threads
-		//since the one IRF  is shared by all threads in GPUs
+  if (coredynp.regWindowing) {
+    RFWIN->power_t.reset();
+    RFWIN->power_t.readOp.dynamic +=
+        (RFWIN->stats_t.readAc.access *
+             RFWIN->local_result.power.readOp.dynamic +
+         RFWIN->stats_t.writeAc.access *
+             RFWIN->local_result.power.writeOp.dynamic);
+  }
 
-		//FRF->power  =  FRF->power_t + FRF->local_result.power *coredynp.pppm_lkg_multhread;
+  if (is_tdp) {
+    // cout<<"pre: IRF_power_t: "<<IRF->power.readOp.dynamic<<"
+    // ("<<IRF->power.readOp.dynamic*clockRate<<") "<<" IRF_localresult: "<<
+    //                   IRF->local_result.power.readOp.dynamic<<endl;
+    // Syed: removed the multiplication of power by hardware threads
+    // since the one IRF  is shared by all threads in GPUs
 
-	  double pppm_lkg_banks[4];
-	  set_pppm(pppm_lkg_banks, 0,XML->sys.core[ithCore].collector_units,XML->sys.core[ithCore].collector_units );
-	  IRF->power = (IRF->power_t) + IRF->local_result.power*pppm_lkg;
-	  IRF->power.readOp.dynamic=IRF->power_t.readOp.dynamic*1;
-	  OPC->power = (OPC->power_t) + OPC->local_result.power *pppm_lkg_banks;
-	  OPC->power.readOp.dynamic=OPC->power_t.readOp.dynamic*1;
+    // FRF->power  =  FRF->power_t + FRF->local_result.power
+    // *coredynp.pppm_lkg_multhread;
 
-	  
-	  power	    =  power + (IRF->power+OPC->power);
+    double pppm_lkg_banks[4];
+    set_pppm(pppm_lkg_banks, 0, XML->sys.core[ithCore].collector_units,
+             XML->sys.core[ithCore].collector_units);
+    IRF->power = (IRF->power_t) + IRF->local_result.power * pppm_lkg;
+    IRF->power.readOp.dynamic = IRF->power_t.readOp.dynamic * 1;
+    OPC->power = (OPC->power_t) + OPC->local_result.power * pppm_lkg_banks;
+    OPC->power.readOp.dynamic = OPC->power_t.readOp.dynamic * 1;
 
+    power = power + (IRF->power + OPC->power);
 
-		if (coredynp.regWindowing)
-		{
-			RFWIN->power = RFWIN->power_t + RFWIN->local_result.power *pppm_lkg;
-			power        = power + RFWIN->power;
-		}
-	} /* if (is_tdp) */	
-	else
-	{
-	  //Removed *coredynp.pppm_lkg_multhread since all hardware threads shared the same IRF
-		IRF->rt_power  =  IRF->power_t + IRF->local_result.power*pppm_lkg;/* *coredynp.pppm_lkg_multhread;*/
-		OPC->rt_power = OPC->power_t +  OPC->local_result.power*pppm_lkg;
-if(XML->sys.architecture==1){
-	//Each warp operand accesses the crossbar
-   xbar_rfu->rt_power.readOp.dynamic=((XML->sys.core[ithCore].int_regfile_reads/(32/**1.5*/))+(XML->sys.core[ithCore].non_rf_operands/(32/**1.5*/)))*xbar_rfu->power.readOp.dynamic;
-} else {
-	xbar_rfu->rt_power.readOp.dynamic=((XML->sys.core[ithCore].int_regfile_reads/(32/**1.5*/))+(XML->sys.core[ithCore].non_rf_operands/(32/**1.5*/)))*xbar_rfu->power.readOp.dynamic;
-}
-		arbiter_rfu->rt_power.readOp.dynamic=((XML->sys.core[ithCore].int_regfile_reads/(32/**1.5*/))+(XML->sys.core[ithCore].non_rf_operands/(32/**1.5*/)))*arbiter_rfu->power.readOp.dynamic;
+    if (coredynp.regWindowing) {
+      RFWIN->power = RFWIN->power_t + RFWIN->local_result.power * pppm_lkg;
+      power = power + RFWIN->power;
+    }
+  } /* if (is_tdp) */
+  else {
+    // Removed *coredynp.pppm_lkg_multhread since all hardware threads shared
+    // the same IRF
+    IRF->rt_power =
+        IRF->power_t +
+        IRF->local_result.power * pppm_lkg; /* *coredynp.pppm_lkg_multhread;*/
+    OPC->rt_power = OPC->power_t + OPC->local_result.power * pppm_lkg;
+    if (XML->sys.architecture == 1) {
+      // Each warp operand accesses the crossbar
+      xbar_rfu->rt_power.readOp.dynamic =
+          ((XML->sys.core[ithCore].int_regfile_reads / (32 /**1.5*/)) +
+           (XML->sys.core[ithCore].non_rf_operands / (32 /**1.5*/))) *
+          xbar_rfu->power.readOp.dynamic;
+    } else {
+      xbar_rfu->rt_power.readOp.dynamic =
+          ((XML->sys.core[ithCore].int_regfile_reads / (32 /**1.5*/)) +
+           (XML->sys.core[ithCore].non_rf_operands / (32 /**1.5*/))) *
+          xbar_rfu->power.readOp.dynamic;
+    }
+    arbiter_rfu->rt_power.readOp.dynamic =
+        ((XML->sys.core[ithCore].int_regfile_reads / (32 /**1.5*/)) +
+         (XML->sys.core[ithCore].non_rf_operands / (32 /**1.5*/))) *
+        arbiter_rfu->power.readOp.dynamic;
 
-
-		rt_power	   =  rt_power + (IRF->power_t /*+ FRF->power_t*/+xbar_rfu->rt_power+arbiter_rfu->rt_power+OPC->power_t);
-		if (coredynp.regWindowing)
-		{
-			RFWIN->rt_power = RFWIN->power_t + RFWIN->local_result.power *pppm_lkg;
-			rt_power        = rt_power + RFWIN->rt_power;
-		}
-	}
-}
-
-
-void RegFU::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	if (!exist) return;
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
-
-	if (is_tdp)
-	{	cout << indent_str << "Register file banks: " << endl;
-		cout << indent_str_next << "Area = " << IRF->area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << IRF->power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? IRF->power.readOp.longer_channel_leakage:IRF->power.readOp.leakage) <<" W" << endl;
-
-		cout << indent_str_next << "Gate Leakage = " << IRF->power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << IRF->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-      cout << indent_str << "Crossbar (Integer RF):" << endl;
-		cout << indent_str_next << "Area = " << xbar_rfu->area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << xbar_rfu->power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? xbar_rfu->power.readOp.longer_channel_leakage:xbar_rfu->power.readOp.leakage) <<" W" << endl;
-
-		cout << indent_str_next << "Gate Leakage = " << xbar_rfu->power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << xbar_rfu->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-      
-		cout << indent_str << "Arbiter (Integer RF):" << endl;
-		cout << indent_str_next << "Area = " << arbiter_rfu->area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << arbiter_rfu->power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? arbiter_rfu->power.readOp.longer_channel_leakage:arbiter_rfu->power.readOp.leakage) <<" W" << endl;
-
-		cout << indent_str_next << "Gate Leakage = " << arbiter_rfu->power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << arbiter_rfu->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-
-		/*
-		cout << indent_str<< "Floating Point RF:" << endl;
-		cout << indent_str_next << "Area = " << FRF->area.get_area()*1e-6  << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << FRF->power.readOp.dynamic*clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? FRF->power.readOp.longer_channel_leakage:FRF->power.readOp.leakage)  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << FRF->power.readOp.gate_leakage  << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << FRF->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-		*/
-		if (coredynp.regWindowing)
-		{
-			cout << indent_str << "Register Windows:" << endl;
-			cout << indent_str_next << "Area = " << RFWIN->area.get_area() *1e-6 << " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << RFWIN->power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? RFWIN->power.readOp.longer_channel_leakage:RFWIN->power.readOp.leakage)  << " W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << RFWIN->power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << RFWIN->rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-		}
-	}
-	else
-	{
-		cout << indent_str_next << "Integer RF    Peak Dynamic = " << IRF->rt_power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Integer RF    Subthreshold Leakage = " << IRF->rt_power.readOp.leakage <<" W" << endl;
-		cout << indent_str_next << "Integer RF    Gate Leakage = " << IRF->rt_power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Floating Point RF   Peak Dynamic = " << FRF->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-		cout << indent_str_next << "Floating Point RF   Subthreshold Leakage = " << FRF->rt_power.readOp.leakage  << " W" << endl;
-		cout << indent_str_next << "Floating Point RF   Gate Leakage = " << FRF->rt_power.readOp.gate_leakage  << " W" << endl;
-		if (coredynp.regWindowing)
-		{
-			cout << indent_str_next << "Register Windows   Peak Dynamic = " << RFWIN->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Register Windows   Subthreshold Leakage = " << RFWIN->rt_power.readOp.leakage  << " W" << endl;
-			cout << indent_str_next << "Register Windows   Gate Leakage = " << RFWIN->rt_power.readOp.gate_leakage  << " W" << endl;
-		}
-	}
+    rt_power =
+        rt_power + (IRF->power_t /*+ FRF->power_t*/ + xbar_rfu->rt_power +
+                    arbiter_rfu->rt_power + OPC->power_t);
+    if (coredynp.regWindowing) {
+      RFWIN->rt_power = RFWIN->power_t + RFWIN->local_result.power * pppm_lkg;
+      rt_power = rt_power + RFWIN->rt_power;
+    }
+  }
 }
 
+void RegFU::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  if (!exist) return;
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
 
-void EXECU::computeEnergy(bool is_tdp)
-{
-	if (!exist) return;
-	//Syed
-	double pppm_t[4]    = {1,1,1,1};
-	double pppm_freqScaling[4]    = {rf_fu_clockRate/clockRate,1,1,1};
-  executionTime=XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);//Syed
+  if (is_tdp) {
+    cout << indent_str << "Register file banks: " << endl;
+    cout << indent_str_next << "Area = " << IRF->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << IRF->power.readOp.dynamic * clockRate << " W"
+         << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? IRF->power.readOp.longer_channel_leakage
+                          : IRF->power.readOp.leakage)
+         << " W" << endl;
 
+    cout << indent_str_next
+         << "Gate Leakage = " << IRF->power.readOp.gate_leakage << " W" << endl;
+    cout << indent_str_next
+         << "Runtime Dynamic = " << IRF->rt_power.readOp.dynamic / executionTime
+         << " W" << endl;
+    cout << endl;
+    cout << indent_str << "Crossbar (Integer RF):" << endl;
+    cout << indent_str_next << "Area = " << xbar_rfu->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << xbar_rfu->power.readOp.dynamic * clockRate
+         << " W" << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? xbar_rfu->power.readOp.longer_channel_leakage
+                          : xbar_rfu->power.readOp.leakage)
+         << " W" << endl;
 
-//	rfu->power.reset();
+    cout << indent_str_next
+         << "Gate Leakage = " << xbar_rfu->power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << xbar_rfu->rt_power.readOp.dynamic / executionTime << " W" << endl;
+    cout << endl;
+
+    cout << indent_str << "Arbiter (Integer RF):" << endl;
+    cout << indent_str_next << "Area = " << arbiter_rfu->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << arbiter_rfu->power.readOp.dynamic * clockRate
+         << " W" << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? arbiter_rfu->power.readOp.longer_channel_leakage
+                          : arbiter_rfu->power.readOp.leakage)
+         << " W" << endl;
+
+    cout << indent_str_next
+         << "Gate Leakage = " << arbiter_rfu->power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << arbiter_rfu->rt_power.readOp.dynamic / executionTime << " W"
+         << endl;
+    cout << endl;
+
+    /*
+    cout << indent_str<< "Floating Point RF:" << endl;
+    cout << indent_str_next << "Area = " << FRF->area.get_area()*1e-6  << "
+    mm^2" << endl;
+    cout << indent_str_next << "Peak Dynamic = " <<
+    FRF->power.readOp.dynamic*clockRate  << " W" << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+            << (long_channel?
+    FRF->power.readOp.longer_channel_leakage:FRF->power.readOp.leakage)  << " W"
+    << endl;
+    cout << indent_str_next << "Gate Leakage = " <<
+    FRF->power.readOp.gate_leakage  << " W" << endl;
+    cout << indent_str_next << "Runtime Dynamic = " <<
+    FRF->rt_power.readOp.dynamic/executionTime << " W" << endl;
+    cout <<endl;
+    */
+    if (coredynp.regWindowing) {
+      cout << indent_str << "Register Windows:" << endl;
+      cout << indent_str_next << "Area = " << RFWIN->area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << RFWIN->power.readOp.dynamic * clockRate
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? RFWIN->power.readOp.longer_channel_leakage
+                            : RFWIN->power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << RFWIN->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << RFWIN->rt_power.readOp.dynamic / executionTime << " W" << endl;
+      cout << endl;
+    }
+  } else {
+    cout << indent_str_next << "Integer RF    Peak Dynamic = "
+         << IRF->rt_power.readOp.dynamic * clockRate << " W" << endl;
+    cout << indent_str_next << "Integer RF    Subthreshold Leakage = "
+         << IRF->rt_power.readOp.leakage << " W" << endl;
+    cout << indent_str_next
+         << "Integer RF    Gate Leakage = " << IRF->rt_power.readOp.gate_leakage
+         << " W" << endl;
+    cout << indent_str_next << "Floating Point RF   Peak Dynamic = "
+         << FRF->rt_power.readOp.dynamic * clockRate << " W" << endl;
+    cout << indent_str_next << "Floating Point RF   Subthreshold Leakage = "
+         << FRF->rt_power.readOp.leakage << " W" << endl;
+    cout << indent_str_next << "Floating Point RF   Gate Leakage = "
+         << FRF->rt_power.readOp.gate_leakage << " W" << endl;
+    if (coredynp.regWindowing) {
+      cout << indent_str_next << "Register Windows   Peak Dynamic = "
+           << RFWIN->rt_power.readOp.dynamic * clockRate << " W" << endl;
+      cout << indent_str_next << "Register Windows   Subthreshold Leakage = "
+           << RFWIN->rt_power.readOp.leakage << " W" << endl;
+      cout << indent_str_next << "Register Windows   Gate Leakage = "
+           << RFWIN->rt_power.readOp.gate_leakage << " W" << endl;
+    }
+  }
+}
+
+void EXECU::computeEnergy(bool is_tdp) {
+  if (!exist) return;
+  // Syed
+  double pppm_t[4] = {1, 1, 1, 1};
+  double pppm_freqScaling[4] = {rf_fu_clockRate / clockRate, 1, 1, 1};
+  executionTime =
+      XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);  // Syed
+
+  //	rfu->power.reset();
   rfu->rt_power.reset();
-//	scheu->power.reset();
-	scheu->rt_power.reset();
-//	exeu->power.reset();
-	exeu->rt_power.reset();
+  //	scheu->power.reset();
+  scheu->rt_power.reset();
+  //	exeu->power.reset();
+  exeu->rt_power.reset();
 
-	rfu->computeEnergy(is_tdp);
-	scheu->computeEnergy(is_tdp);
-	exeu->computeEnergy(is_tdp);
-	if (coredynp.num_fpus >0)
-	{
+  rfu->computeEnergy(is_tdp);
+  scheu->computeEnergy(is_tdp);
+  exeu->computeEnergy(is_tdp);
+  if (coredynp.num_fpus > 0) {
     fp_u->rt_power.reset();
-		fp_u->computeEnergy(is_tdp);
-	}
-	if (coredynp.num_muls >0)
-	{
+    fp_u->computeEnergy(is_tdp);
+  }
+  if (coredynp.num_muls > 0) {
     mul->rt_power.reset();
-		mul->computeEnergy(is_tdp);
-	}
+    mul->computeEnergy(is_tdp);
+  }
   bypass.rt_power.reset();
 
-	if (is_tdp)
-	{
-		set_pppm(pppm_t, 2*coredynp.ALU_cdb_duty_cycle, 2, 2, 2*coredynp.ALU_cdb_duty_cycle);//2 means two source operands needs to be passed for each int instruction.
-		//bypass.power = bypass.power + intTagBypass->power*pppm_t + int_bypass->power*pppm_t;
-		if (coredynp.num_muls >0)
-		{
-			set_pppm(pppm_t, 2*coredynp.MUL_cdb_duty_cycle, 2, 2, 2*coredynp.MUL_cdb_duty_cycle);//2 means two source operands needs to be passed for each int instruction.
-			//No conventional bypassing in GPU (Syed)
-			//bypass.power = bypass.power + intTag_mul_Bypass->power*pppm_t + int_mul_bypass->power*pppm_t;
-			power      = power + mul->power*pppm_freqScaling;
-		}
-
-		if (coredynp.num_fpus>0)
-		{
-			set_pppm(pppm_t, 3*coredynp.FPU_cdb_duty_cycle, 3, 3, 3*coredynp.FPU_cdb_duty_cycle);//3 means three source operands needs to be passed for each fp instruction.
-			//No conventional bypassing in GPU (Syed)			
-			//bypass.power = bypass.power + fp_bypass->power*pppm_t  + fpTagBypass->power*pppm_t ;
-			power      = power + fp_u->power*pppm_freqScaling;
-
-		}
-		//No conventional bypassing in GPU (Syed)
-
-		power      = power + rfu->power*pppm_freqScaling + exeu->power*pppm_freqScaling /*+ bypass.power*/ + scheu->power
-		                   ;
-
-
-	}
-	else
-	{
-		set_pppm(pppm_t, XML->sys.core[ithCore].cdb_alu_accesses, 2, 2, XML->sys.core[ithCore].cdb_alu_accesses);
-		//bypass.rt_power = bypass.rt_power + intTagBypass->power*pppm_t;
-		//bypass.rt_power = bypass.rt_power + int_bypass->power*pppm_t;
-
-		if (coredynp.num_muls >0)
-		{
-			set_pppm(pppm_t, XML->sys.core[ithCore].cdb_mul_accesses, 2, 2, XML->sys.core[ithCore].cdb_mul_accesses);//2 means two source operands needs to be passed for each int instruction.
-			//bypass.rt_power = bypass.rt_power + intTag_mul_Bypass->power*pppm_t + int_mul_bypass->power*pppm_t;
-			rt_power      = rt_power + mul->rt_power;
-		}
-
-		if (coredynp.num_fpus>0)
-		{
-			set_pppm(pppm_t, XML->sys.core[ithCore].cdb_fpu_accesses, 3, 3, XML->sys.core[ithCore].cdb_fpu_accesses);
-			//bypass.rt_power = bypass.rt_power + fp_bypass->power*pppm_t;
-			//bypass.rt_power = bypass.rt_power + fpTagBypass->power*pppm_t;
-			rt_power      = rt_power + fp_u->rt_power;
-		}
-		//No conventional bypassing in GPU (Syed)
-		rt_power      = rt_power + rfu->rt_power*pppm_freqScaling + exeu->rt_power*pppm_freqScaling + /*bypass.rt_power +*/ scheu->rt_power;
-	}
-}
-
-void EXECU::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	if (!exist) return;
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
-
-
-//	cout << indent_str_next << "Results Broadcast Bus Area = " << bypass->area.get_area() *1e-6 << " mm^2" << endl;
-	if (is_tdp)
-	{
-		cout << indent_str << "Register Files:" << endl;
-		cout << indent_str_next << "Area = " << rfu->area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << rfu->power.readOp.dynamic*rf_fu_clockRate << " W" << endl;
-		//cout << "rf_fu Clock rate: "<< rf_fu_clockRate<<endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? rfu->power.readOp.longer_channel_leakage:rfu->power.readOp.leakage) <<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << rfu->power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << rfu->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-		if (plevel>3){
-			rfu->displayEnergy(indent+4,is_tdp);
-		}
-		cout << indent_str << "Instruction Scheduler:" << endl;
-		cout << indent_str_next << "Area = " << scheu->area.get_area()*1e-6  << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << scheu->power.readOp.dynamic*clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? scheu->power.readOp.longer_channel_leakage:scheu->power.readOp.leakage)  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << scheu->power.readOp.gate_leakage  << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << scheu->rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-		if (plevel>3){
-			scheu->displayEnergy(indent+4,is_tdp);
-		}
-		exeu->displayEnergy(indent,is_tdp);
-		if (coredynp.num_fpus>0)
-		{
-			fp_u->displayEnergy(indent,is_tdp);
-		}
-		if (coredynp.num_muls >0)
-		{
-			mul->displayEnergy(indent,is_tdp);
-		}
-		cout << indent_str << "Results Broadcast Bus:" << endl;
-		cout << indent_str_next << "Area Overhead = " << bypass.area.get_area()*1e-6  << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << bypass.power.readOp.dynamic*clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? bypass.power.readOp.longer_channel_leakage:bypass.power.readOp.leakage ) << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << bypass.power.readOp.gate_leakage  << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << bypass.rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-	}
-	else
-	{
-		cout << indent_str_next << "Register Files    Peak Dynamic = " << rfu->rt_power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Register Files    Subthreshold Leakage = " << rfu->rt_power.readOp.leakage <<" W" << endl;
-		cout << indent_str_next << "Register Files    Gate Leakage = " << rfu->rt_power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Instruction Sheduler   Peak Dynamic = " << scheu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-		cout << indent_str_next << "Instruction Sheduler   Subthreshold Leakage = " << scheu->rt_power.readOp.leakage  << " W" << endl;
-		cout << indent_str_next << "Instruction Sheduler   Gate Leakage = " << scheu->rt_power.readOp.gate_leakage  << " W" << endl;
-		cout << indent_str_next << "Results Broadcast Bus   Peak Dynamic = " << bypass.rt_power.readOp.dynamic*clockRate  << " W" << endl;
-		cout << indent_str_next << "Results Broadcast Bus   Subthreshold Leakage = " << bypass.rt_power.readOp.leakage  << " W" << endl;
-		cout << indent_str_next << "Results Broadcast Bus   Gate Leakage = " << bypass.rt_power.readOp.gate_leakage  << " W" << endl;
-	}
-
-}
-
-
-
-
-
-
-//Jingwen
-void Core::compute()
-{
-    //power_point_product_masks
-    double pppm_t[4]    = {1,1,1,1};
-    double rtp_pipeline_coe;
-    double num_units = 4.0;
-    Pipeline_energy=0;
-
-	 //Set pipeline duty cycle for this inteval 
-	coredynp.pipeline_duty_cycle=XML->sys.core[ithCore].pipeline_duty_cycle;
-    rt_power.reset();
-    ifu->rt_power.reset();
-    lsu->rt_power.reset();
-    mmu->rt_power.reset();
-    exu->rt_power.reset();
-
-
-		ifu->computeEnergy(false);
-		lsu->computeEnergy(false);
-		mmu->computeEnergy(false);
-		exu->computeEnergy(false);
-
-
-		if (XML->sys.homogeneous_cores==1)
-		{
-				rtp_pipeline_coe = coredynp.pipeline_duty_cycle * XML->sys.total_cycles * XML->sys.number_of_cores;
-		}
-		else
-		{
-
-			rtp_pipeline_coe = coredynp.pipeline_duty_cycle * coredynp.total_cycles;
-			//Jingwen
-			if (coredynp.total_cycles != XML->sys.total_cycles)
-			{
-				cout << "total cycle not match!" << endl;
-				exit(1);
-			}
-		}
-      
-		set_pppm(pppm_t, coredynp.num_pipelines*rtp_pipeline_coe/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units);
-
-		if (ifu->exist)
-		{
-			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
-			ifu->rt_power = ifu->rt_power + corepipe->power*pppm_t;
-			rt_power     = rt_power + ifu->rt_power ;
-		}
-    
-		if (lsu->exist)
-		{
-			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
-			lsu->rt_power = lsu->rt_power + corepipe->power*pppm_t;
-			rt_power     = rt_power  + lsu->rt_power;
-		}
-		if (exu->exist)
-		{
-			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
-			exu->rt_power = exu->rt_power + corepipe->power*pppm_t;
-			rt_power     = rt_power  + exu->rt_power;
-		}
-		if (mmu->exist)
-		{
-			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
-			mmu->rt_power = mmu->rt_power + corepipe->power*pppm_t;
-			rt_power     = rt_power +  mmu->rt_power ;
-		}
-
-		rt_power     = rt_power +  undiffCore->power;
-    
-
-		if (XML->sys.Private_L2)
-		{
-
-			l2cache->computeEnergy(false);
-			rt_power = rt_power  + l2cache->rt_power;
-		}
-		
-		IdleCoreEnergy=XML->sys.num_idle_cores * XML->sys.idle_core_power* executionTime;
-
-		rt_power.readOp.dynamic += IdleCoreEnergy;
-
-}
-
-
-
-
-void Core::computeEnergy(bool is_tdp)
-{
-	//power_point_product_masks
-	double pppm_t[4]    = {1,1,1,1};
-    double rtp_pipeline_coe;
-    double num_units = 4.0;
-    Pipeline_energy=0;
-
-    if (XML->sys.homogeneous_cores==1)
-    {
-       rtp_pipeline_coe = coredynp.pipeline_duty_cycle * XML->sys.total_cycles * XML->sys.number_of_cores;
+  if (is_tdp) {
+    set_pppm(pppm_t, 2 * coredynp.ALU_cdb_duty_cycle, 2, 2,
+             2 * coredynp.ALU_cdb_duty_cycle);  // 2 means two source operands
+                                                // needs to be passed for each
+                                                // int instruction.
+    // bypass.power = bypass.power + intTagBypass->power*pppm_t +
+    // int_bypass->power*pppm_t;
+    if (coredynp.num_muls > 0) {
+      set_pppm(pppm_t, 2 * coredynp.MUL_cdb_duty_cycle, 2, 2,
+               2 * coredynp.MUL_cdb_duty_cycle);  // 2 means two source operands
+                                                  // needs to be passed for each
+                                                  // int instruction.
+      // No conventional bypassing in GPU (Syed)
+      // bypass.power = bypass.power + intTag_mul_Bypass->power*pppm_t +
+      // int_mul_bypass->power*pppm_t;
+      power = power + mul->power * pppm_freqScaling;
     }
-    else
-    {
-       rtp_pipeline_coe = coredynp.pipeline_duty_cycle * coredynp.total_cycles;
+
+    if (coredynp.num_fpus > 0) {
+      set_pppm(pppm_t, 3 * coredynp.FPU_cdb_duty_cycle, 3, 3,
+               3 * coredynp.FPU_cdb_duty_cycle);  // 3 means three source
+                                                  // operands needs to be passed
+                                                  // for each fp instruction.
+      // No conventional bypassing in GPU (Syed)
+      // bypass.power = bypass.power + fp_bypass->power*pppm_t  +
+      // fpTagBypass->power*pppm_t ;
+      power = power + fp_u->power * pppm_freqScaling;
     }
- 
+    // No conventional bypassing in GPU (Syed)
 
-	if (is_tdp)
-	{
-		ifu->computeEnergy(is_tdp);
-		lsu->computeEnergy(is_tdp);
-		mmu->computeEnergy(is_tdp);
-		exu->computeEnergy(is_tdp);
+    power = power + rfu->power * pppm_freqScaling +
+            exeu->power * pppm_freqScaling /*+ bypass.power*/ + scheu->power;
 
-		if (coredynp.core_ty==OOO)
-		{
-			num_units = 5.0;
-			rnu->computeEnergy(is_tdp);
-			set_pppm(pppm_t, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units);
-			if (rnu->exist)
-			{
-				rnu->power = rnu->power + corepipe->power*pppm_t;
-				power     = power + rnu->power;
-			}
-		}
+  } else {
+    set_pppm(pppm_t, XML->sys.core[ithCore].cdb_alu_accesses, 2, 2,
+             XML->sys.core[ithCore].cdb_alu_accesses);
+    // bypass.rt_power = bypass.rt_power + intTagBypass->power*pppm_t;
+    // bypass.rt_power = bypass.rt_power + int_bypass->power*pppm_t;
 
-		if (ifu->exist)
-		{
-			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
-			set_pppm(pppm_t, coredynp.num_pipelines/num_units*coredynp.IFU_duty_cycle, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units);
-//			cout << "IFU = " << ifu->power.readOp.dynamic*clockRate  << " W" << endl;
-			ifu->power = ifu->power + corepipe->power*pppm_t;
-//			cout << "IFU = " << ifu->power.readOp.dynamic*clockRate  << " W" << endl;
-//			cout << "1/4 pipe = " << corepipe->power.readOp.dynamic*clockRate/num_units  << " W" << endl;
-			power     = power + ifu->power;
-//			cout << "core = " << power.readOp.dynamic*clockRate  << " W" << endl;
-		}
-		if (lsu->exist)
-		{
-			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
-			set_pppm(pppm_t, coredynp.num_pipelines/num_units*coredynp.LSU_duty_cycle, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units);
-			lsu->power = lsu->power + corepipe->power*pppm_t;
-//			cout << "LSU = " << lsu->power.readOp.dynamic*clockRate  << " W" << endl;
-			power     = power + lsu->power;
-//			cout << "core = " << power.readOp.dynamic*clockRate  << " W" << endl;
-		}
-		if (exu->exist)
-		{
-			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
-			set_pppm(pppm_t, coredynp.num_pipelines/num_units*coredynp.ALU_duty_cycle, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units);
-			//cout<<"ExPowerScalingFactor:"<<coredynp.num_pipelines/num_units*coredynp.ALU_duty_cycle<<endl;
-			exu->power = exu->power + corepipe->power*pppm_t;
-//			cout << "EXE = " << exu->power.readOp.dynamic*clockRate  << " W" << endl;
-			power     = power + exu->power;
-//			cout << "core = " << power.readOp.dynamic*clockRate  << " W" << endl;
-		}
-		if (mmu->exist)
-		{
-			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
-			set_pppm(pppm_t, coredynp.num_pipelines/num_units*(0.5+0.5*coredynp.LSU_duty_cycle), coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units);
-			mmu->power = mmu->power + corepipe->power*pppm_t;
-//			cout << "MMU = " << mmu->power.readOp.dynamic*clockRate  << " W" << endl;
-			power     = power +  mmu->power;
-//			cout << "core = " << power.readOp.dynamic*clockRate  << " W" << endl;
-		}
+    if (coredynp.num_muls > 0) {
+      set_pppm(pppm_t, XML->sys.core[ithCore].cdb_mul_accesses, 2, 2,
+               XML->sys.core[ithCore].cdb_mul_accesses);  // 2 means two source
+                                                          // operands needs to
+                                                          // be passed for each
+                                                          // int instruction.
+      // bypass.rt_power = bypass.rt_power + intTag_mul_Bypass->power*pppm_t +
+      // int_mul_bypass->power*pppm_t;
+      rt_power = rt_power + mul->rt_power;
+    }
 
-		power     = power +  undiffCore->power;
+    if (coredynp.num_fpus > 0) {
+      set_pppm(pppm_t, XML->sys.core[ithCore].cdb_fpu_accesses, 3, 3,
+               XML->sys.core[ithCore].cdb_fpu_accesses);
+      // bypass.rt_power = bypass.rt_power + fp_bypass->power*pppm_t;
+      // bypass.rt_power = bypass.rt_power + fpTagBypass->power*pppm_t;
+      rt_power = rt_power + fp_u->rt_power;
+    }
+    // No conventional bypassing in GPU (Syed)
+    rt_power = rt_power + rfu->rt_power * pppm_freqScaling +
+               exeu->rt_power * pppm_freqScaling +
+               /*bypass.rt_power +*/ scheu->rt_power;
+  }
+}
 
-		if (XML->sys.Private_L2)
-		{
+void EXECU::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  if (!exist) return;
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
 
-			l2cache->computeEnergy(is_tdp);
-			set_pppm(pppm_t,l2cache->cachep.clockRate/clockRate, 1,1,1);
-			//l2cache->power = l2cache->power*pppm_t;
-			power = power  + l2cache->power*pppm_t;
-		}
+  //	cout << indent_str_next << "Results Broadcast Bus Area = " <<
+  //bypass->area.get_area() *1e-6 << " mm^2" << endl;
+  if (is_tdp) {
+    cout << indent_str << "Register Files:" << endl;
+    cout << indent_str_next << "Area = " << rfu->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << rfu->power.readOp.dynamic * rf_fu_clockRate
+         << " W" << endl;
+    // cout << "rf_fu Clock rate: "<< rf_fu_clockRate<<endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? rfu->power.readOp.longer_channel_leakage
+                          : rfu->power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << rfu->power.readOp.gate_leakage << " W" << endl;
+    cout << indent_str_next
+         << "Runtime Dynamic = " << rfu->rt_power.readOp.dynamic / executionTime
+         << " W" << endl;
+    cout << endl;
+    if (plevel > 3) {
+      rfu->displayEnergy(indent + 4, is_tdp);
+    }
+    cout << indent_str << "Instruction Scheduler:" << endl;
+    cout << indent_str_next << "Area = " << scheu->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << scheu->power.readOp.dynamic * clockRate << " W"
+         << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? scheu->power.readOp.longer_channel_leakage
+                          : scheu->power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << scheu->power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << scheu->rt_power.readOp.dynamic / executionTime << " W" << endl;
+    cout << endl;
+    if (plevel > 3) {
+      scheu->displayEnergy(indent + 4, is_tdp);
+    }
+    exeu->displayEnergy(indent, is_tdp);
+    if (coredynp.num_fpus > 0) {
+      fp_u->displayEnergy(indent, is_tdp);
+    }
+    if (coredynp.num_muls > 0) {
+      mul->displayEnergy(indent, is_tdp);
+    }
+    cout << indent_str << "Results Broadcast Bus:" << endl;
+    cout << indent_str_next
+         << "Area Overhead = " << bypass.area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << bypass.power.readOp.dynamic * clockRate << " W"
+         << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? bypass.power.readOp.longer_channel_leakage
+                          : bypass.power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << bypass.power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << bypass.rt_power.readOp.dynamic / executionTime << " W" << endl;
+    cout << endl;
+  } else {
+    cout << indent_str_next << "Register Files    Peak Dynamic = "
+         << rfu->rt_power.readOp.dynamic * clockRate << " W" << endl;
+    cout << indent_str_next << "Register Files    Subthreshold Leakage = "
+         << rfu->rt_power.readOp.leakage << " W" << endl;
+    cout << indent_str_next << "Register Files    Gate Leakage = "
+         << rfu->rt_power.readOp.gate_leakage << " W" << endl;
+    cout << indent_str_next << "Instruction Sheduler   Peak Dynamic = "
+         << scheu->rt_power.readOp.dynamic * clockRate << " W" << endl;
+    cout << indent_str_next << "Instruction Sheduler   Subthreshold Leakage = "
+         << scheu->rt_power.readOp.leakage << " W" << endl;
+    cout << indent_str_next << "Instruction Sheduler   Gate Leakage = "
+         << scheu->rt_power.readOp.gate_leakage << " W" << endl;
+    cout << indent_str_next << "Results Broadcast Bus   Peak Dynamic = "
+         << bypass.rt_power.readOp.dynamic * clockRate << " W" << endl;
+    cout << indent_str_next << "Results Broadcast Bus   Subthreshold Leakage = "
+         << bypass.rt_power.readOp.leakage << " W" << endl;
+    cout << indent_str_next << "Results Broadcast Bus   Gate Leakage = "
+         << bypass.rt_power.readOp.gate_leakage << " W" << endl;
+  }
+}
 
-	}
-	else
-	{
+// Jingwen
+void Core::compute() {
+  // power_point_product_masks
+  double pppm_t[4] = {1, 1, 1, 1};
+  double rtp_pipeline_coe;
+  double num_units = 4.0;
+  Pipeline_energy = 0;
+
+  // Set pipeline duty cycle for this inteval
+  coredynp.pipeline_duty_cycle = XML->sys.core[ithCore].pipeline_duty_cycle;
+  rt_power.reset();
+  ifu->rt_power.reset();
+  lsu->rt_power.reset();
+  mmu->rt_power.reset();
+  exu->rt_power.reset();
+
+  ifu->computeEnergy(false);
+  lsu->computeEnergy(false);
+  mmu->computeEnergy(false);
+  exu->computeEnergy(false);
+
+  if (XML->sys.homogeneous_cores == 1) {
+    rtp_pipeline_coe = coredynp.pipeline_duty_cycle * XML->sys.total_cycles *
+                       XML->sys.number_of_cores;
+  } else {
+    rtp_pipeline_coe = coredynp.pipeline_duty_cycle * coredynp.total_cycles;
+    // Jingwen
+    if (coredynp.total_cycles != XML->sys.total_cycles) {
+      cout << "total cycle not match!" << endl;
+      exit(1);
+    }
+  }
+
+  set_pppm(pppm_t, coredynp.num_pipelines * rtp_pipeline_coe / num_units,
+           coredynp.num_pipelines / num_units,
+           coredynp.num_pipelines / num_units,
+           coredynp.num_pipelines / num_units);
+
+  if (ifu->exist) {
+    Pipeline_energy += corepipe->power.readOp.dynamic *
+                       (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
+    ifu->rt_power = ifu->rt_power + corepipe->power * pppm_t;
+    rt_power = rt_power + ifu->rt_power;
+  }
+
+  if (lsu->exist) {
+    Pipeline_energy += corepipe->power.readOp.dynamic *
+                       (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
+    lsu->rt_power = lsu->rt_power + corepipe->power * pppm_t;
+    rt_power = rt_power + lsu->rt_power;
+  }
+  if (exu->exist) {
+    Pipeline_energy += corepipe->power.readOp.dynamic *
+                       (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
+    exu->rt_power = exu->rt_power + corepipe->power * pppm_t;
+    rt_power = rt_power + exu->rt_power;
+  }
+  if (mmu->exist) {
+    Pipeline_energy += corepipe->power.readOp.dynamic *
+                       (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
+    mmu->rt_power = mmu->rt_power + corepipe->power * pppm_t;
+    rt_power = rt_power + mmu->rt_power;
+  }
+
+  rt_power = rt_power + undiffCore->power;
+
+  if (XML->sys.Private_L2) {
+    l2cache->computeEnergy(false);
+    rt_power = rt_power + l2cache->rt_power;
+  }
+
+  IdleCoreEnergy =
+      XML->sys.num_idle_cores * XML->sys.idle_core_power * executionTime;
+
+  rt_power.readOp.dynamic += IdleCoreEnergy;
+}
+
+void Core::computeEnergy(bool is_tdp) {
+  // power_point_product_masks
+  double pppm_t[4] = {1, 1, 1, 1};
+  double rtp_pipeline_coe;
+  double num_units = 4.0;
+  Pipeline_energy = 0;
+
+  if (XML->sys.homogeneous_cores == 1) {
+    rtp_pipeline_coe = coredynp.pipeline_duty_cycle * XML->sys.total_cycles *
+                       XML->sys.number_of_cores;
+  } else {
+    rtp_pipeline_coe = coredynp.pipeline_duty_cycle * coredynp.total_cycles;
+  }
+
+  if (is_tdp) {
+    ifu->computeEnergy(is_tdp);
+    lsu->computeEnergy(is_tdp);
+    mmu->computeEnergy(is_tdp);
+    exu->computeEnergy(is_tdp);
+
+    if (coredynp.core_ty == OOO) {
+      num_units = 5.0;
+      rnu->computeEnergy(is_tdp);
+      set_pppm(pppm_t, coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units);
+      if (rnu->exist) {
+        rnu->power = rnu->power + corepipe->power * pppm_t;
+        power = power + rnu->power;
+      }
+    }
+
+    if (ifu->exist) {
+      Pipeline_energy +=
+          corepipe->power.readOp.dynamic *
+          (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
+      set_pppm(pppm_t,
+               coredynp.num_pipelines / num_units * coredynp.IFU_duty_cycle,
+               coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units);
+      //			cout << "IFU = " <<
+      //ifu->power.readOp.dynamic*clockRate  << " W" << endl;
+      ifu->power = ifu->power + corepipe->power * pppm_t;
+      //			cout << "IFU = " <<
+      //ifu->power.readOp.dynamic*clockRate  << " W" << endl;
+      //			cout << "1/4 pipe = " <<
+      //corepipe->power.readOp.dynamic*clockRate/num_units  << " W" << endl;
+      power = power + ifu->power;
+      //			cout << "core = " <<
+      //power.readOp.dynamic*clockRate  << " W" << endl;
+    }
+    if (lsu->exist) {
+      Pipeline_energy +=
+          corepipe->power.readOp.dynamic *
+          (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
+      set_pppm(pppm_t,
+               coredynp.num_pipelines / num_units * coredynp.LSU_duty_cycle,
+               coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units);
+      lsu->power = lsu->power + corepipe->power * pppm_t;
+      //			cout << "LSU = " <<
+      //lsu->power.readOp.dynamic*clockRate  << " W" << endl;
+      power = power + lsu->power;
+      //			cout << "core = " <<
+      //power.readOp.dynamic*clockRate  << " W" << endl;
+    }
+    if (exu->exist) {
+      Pipeline_energy +=
+          corepipe->power.readOp.dynamic *
+          (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
+      set_pppm(pppm_t,
+               coredynp.num_pipelines / num_units * coredynp.ALU_duty_cycle,
+               coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units);
+      // cout<<"ExPowerScalingFactor:"<<coredynp.num_pipelines/num_units*coredynp.ALU_duty_cycle<<endl;
+      exu->power = exu->power + corepipe->power * pppm_t;
+      //			cout << "EXE = " <<
+      //exu->power.readOp.dynamic*clockRate  << " W" << endl;
+      power = power + exu->power;
+      //			cout << "core = " <<
+      //power.readOp.dynamic*clockRate  << " W" << endl;
+    }
+    if (mmu->exist) {
+      Pipeline_energy +=
+          corepipe->power.readOp.dynamic *
+          (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
+      set_pppm(pppm_t, coredynp.num_pipelines / num_units *
+                           (0.5 + 0.5 * coredynp.LSU_duty_cycle),
+               coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units);
+      mmu->power = mmu->power + corepipe->power * pppm_t;
+      //			cout << "MMU = " <<
+      //mmu->power.readOp.dynamic*clockRate  << " W" << endl;
+      power = power + mmu->power;
+      //			cout << "core = " <<
+      //power.readOp.dynamic*clockRate  << " W" << endl;
+    }
+
+    power = power + undiffCore->power;
+
+    if (XML->sys.Private_L2) {
+      l2cache->computeEnergy(is_tdp);
+      set_pppm(pppm_t, l2cache->cachep.clockRate / clockRate, 1, 1, 1);
+      // l2cache->power = l2cache->power*pppm_t;
+      power = power + l2cache->power * pppm_t;
+    }
+
+  } else {
     rt_power.reset();
 
+    ifu->computeEnergy(is_tdp);
+    lsu->computeEnergy(is_tdp);
+    mmu->computeEnergy(is_tdp);
+    exu->computeEnergy(is_tdp);
+    if (coredynp.core_ty == OOO) {
+      num_units = 5.0;
+      rnu->computeEnergy(is_tdp);
+      set_pppm(pppm_t, coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units);
+      if (rnu->exist) {
+        rnu->rt_power = rnu->rt_power + corepipe->power * pppm_t;
 
+        rt_power = rt_power + rnu->rt_power;
+      }
+    } else {
+      set_pppm(pppm_t, coredynp.num_pipelines * rtp_pipeline_coe / num_units,
+               coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units,
+               coredynp.num_pipelines / num_units);
+    }
 
+    if (ifu->exist) {
+      Pipeline_energy +=
+          corepipe->power.readOp.dynamic *
+          (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
+      ifu->rt_power = ifu->rt_power + corepipe->power * pppm_t;
+      rt_power = rt_power + ifu->rt_power;
+    }
+    if (lsu->exist) {
+      Pipeline_energy +=
+          corepipe->power.readOp.dynamic *
+          (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
+      lsu->rt_power = lsu->rt_power + corepipe->power * pppm_t;
+      rt_power = rt_power + lsu->rt_power;
+    }
+    if (exu->exist) {
+      Pipeline_energy +=
+          corepipe->power.readOp.dynamic *
+          (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
+      exu->rt_power = exu->rt_power + corepipe->power * pppm_t;
+      rt_power = rt_power + exu->rt_power;
+    }
+    if (mmu->exist) {
+      Pipeline_energy +=
+          corepipe->power.readOp.dynamic *
+          (coredynp.num_pipelines * rtp_pipeline_coe / num_units);
+      mmu->rt_power = mmu->rt_power + corepipe->power * pppm_t;
+      rt_power = rt_power + mmu->rt_power;
+    }
 
-		ifu->computeEnergy(is_tdp);
-		lsu->computeEnergy(is_tdp);
-		mmu->computeEnergy(is_tdp);
-		exu->computeEnergy(is_tdp);
-		if (coredynp.core_ty==OOO)
-		{
-			num_units = 5.0;
-			rnu->computeEnergy(is_tdp);
-        	set_pppm(pppm_t, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units);
-			if (rnu->exist)
-			{
-        	rnu->rt_power = rnu->rt_power + corepipe->power*pppm_t;
-
-			rt_power      = rt_power + rnu->rt_power;
-			}
-		}
-		else
-		{
-
-		    set_pppm(pppm_t, coredynp.num_pipelines*rtp_pipeline_coe/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units, coredynp.num_pipelines/num_units);
-		}
-
-		if (ifu->exist)
-		{
-			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
-			ifu->rt_power = ifu->rt_power + corepipe->power*pppm_t;
-			rt_power     = rt_power + ifu->rt_power ;
-		}
-		if (lsu->exist)
-		{
-			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
-			lsu->rt_power = lsu->rt_power + corepipe->power*pppm_t;
-			rt_power     = rt_power  + lsu->rt_power;
-		}
-		if (exu->exist)
-		{
-			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
-			exu->rt_power = exu->rt_power + corepipe->power*pppm_t;
-			rt_power     = rt_power  + exu->rt_power;
-		}
-		if (mmu->exist)
-		{
-			Pipeline_energy+=corepipe->power.readOp.dynamic* (coredynp.num_pipelines*rtp_pipeline_coe/num_units);
-			mmu->rt_power = mmu->rt_power + corepipe->power*pppm_t;
-			rt_power     = rt_power +  mmu->rt_power ;
-		}
-
-		rt_power     = rt_power +  undiffCore->power;
-//		cout << "EXE = " << exu->power.readOp.dynamic*clockRate  << " W" << endl;
-		if (XML->sys.Private_L2)
-		{
-			l2cache->computeEnergy(is_tdp);
-			//set_pppm(pppm_t,1/l2cache->cachep.executionTime, 1,1,1);
-			//l2cache->rt_power = l2cache->rt_power*pppm_t;
-			rt_power = rt_power  + l2cache->rt_power;
-		}
-
-	}
-
+    rt_power = rt_power + undiffCore->power;
+    //		cout << "EXE = " << exu->power.readOp.dynamic*clockRate  << " W" <<
+    //endl;
+    if (XML->sys.Private_L2) {
+      l2cache->computeEnergy(is_tdp);
+      // set_pppm(pppm_t,1/l2cache->cachep.executionTime, 1,1,1);
+      // l2cache->rt_power = l2cache->rt_power*pppm_t;
+      rt_power = rt_power + l2cache->rt_power;
+    }
+  }
 }
 
-void Core::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
-	if (is_tdp)
-	{
-		cout << "Core:" << endl;
-		cout << indent_str << "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str << "Subthreshold Leakage = "
-			<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
-		//cout << indent_str << "Subthreshold Leakage = " << power.readOp.longer_channel_leakage <<" W" << endl;
-		cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str << "Runtime Dynamic = " << rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout<<endl;
-		if (ifu->exist)
-		{
-			cout << indent_str << "Instruction Fetch Unit:" << endl;
-			cout << indent_str_next << "Area = " << ifu->area.get_area()*1e-6<< " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << ifu->power.readOp.dynamic*clockRate << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? ifu->power.readOp.longer_channel_leakage:ifu->power.readOp.leakage) <<" W" << endl;
-			//cout << indent_str_next << "Subthreshold Leakage = " << ifu->power.readOp.longer_channel_leakage <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << ifu->power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << ifu->rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-			if (plevel >2){
-				ifu->displayEnergy(indent+4,plevel,is_tdp);
-			}
-		}
-		if (coredynp.core_ty==OOO)
-		{
-			if (rnu->exist)
-			{
-				cout << indent_str<< "Renaming Unit:" << endl;
-				cout << indent_str_next << "Area = " << rnu->area.get_area()*1e-6  << " mm^2" << endl;
-				cout << indent_str_next << "Peak Dynamic = " << rnu->power.readOp.dynamic*clockRate  << " W" << endl;
-				cout << indent_str_next << "Subthreshold Leakage = "
-					<< (long_channel? rnu->power.readOp.longer_channel_leakage:rnu->power.readOp.leakage)  << " W" << endl;
-				//cout << indent_str_next << "Subthreshold Leakage = " << rnu->power.readOp.longer_channel_leakage  << " W" << endl;
-				cout << indent_str_next << "Gate Leakage = " << rnu->power.readOp.gate_leakage  << " W" << endl;
-				cout << indent_str_next << "Runtime Dynamic = " << rnu->rt_power.readOp.dynamic/executionTime << " W" << endl;
-				cout <<endl;
-				if (plevel >2){
-					rnu->displayEnergy(indent+4,plevel,is_tdp);
-				}
-			}
+void Core::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
+  if (is_tdp) {
+    cout << "Core:" << endl;
+    cout << indent_str << "Area = " << area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic * clockRate
+         << " W" << endl;
+    cout << indent_str << "Subthreshold Leakage = "
+         << (long_channel ? power.readOp.longer_channel_leakage
+                          : power.readOp.leakage)
+         << " W" << endl;
+    // cout << indent_str << "Subthreshold Leakage = " <<
+    // power.readOp.longer_channel_leakage <<" W" << endl;
+    cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str
+         << "Runtime Dynamic = " << rt_power.readOp.dynamic / executionTime
+         << " W" << endl;
+    cout << endl;
+    if (ifu->exist) {
+      cout << indent_str << "Instruction Fetch Unit:" << endl;
+      cout << indent_str_next << "Area = " << ifu->area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << ifu->power.readOp.dynamic * clockRate << " W"
+           << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? ifu->power.readOp.longer_channel_leakage
+                            : ifu->power.readOp.leakage)
+           << " W" << endl;
+      // cout << indent_str_next << "Subthreshold Leakage = " <<
+      // ifu->power.readOp.longer_channel_leakage <<" W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << ifu->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << ifu->rt_power.readOp.dynamic / executionTime << " W" << endl;
+      cout << endl;
+      if (plevel > 2) {
+        ifu->displayEnergy(indent + 4, plevel, is_tdp);
+      }
+    }
+    if (coredynp.core_ty == OOO) {
+      if (rnu->exist) {
+        cout << indent_str << "Renaming Unit:" << endl;
+        cout << indent_str_next << "Area = " << rnu->area.get_area() * 1e-6
+             << " mm^2" << endl;
+        cout << indent_str_next
+             << "Peak Dynamic = " << rnu->power.readOp.dynamic * clockRate
+             << " W" << endl;
+        cout << indent_str_next << "Subthreshold Leakage = "
+             << (long_channel ? rnu->power.readOp.longer_channel_leakage
+                              : rnu->power.readOp.leakage)
+             << " W" << endl;
+        // cout << indent_str_next << "Subthreshold Leakage = " <<
+        // rnu->power.readOp.longer_channel_leakage  << " W" << endl;
+        cout << indent_str_next
+             << "Gate Leakage = " << rnu->power.readOp.gate_leakage << " W"
+             << endl;
+        cout << indent_str_next << "Runtime Dynamic = "
+             << rnu->rt_power.readOp.dynamic / executionTime << " W" << endl;
+        cout << endl;
+        if (plevel > 2) {
+          rnu->displayEnergy(indent + 4, plevel, is_tdp);
+        }
+      }
+    }
+    if (lsu->exist) {
+      cout << indent_str << "Load Store Unit:" << endl;
+      cout << indent_str_next << "Area = " << lsu->area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << lsu->power.readOp.dynamic * clockRate << " W"
+           << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? lsu->power.readOp.longer_channel_leakage
+                            : lsu->power.readOp.leakage)
+           << " W" << endl;
+      // cout << indent_str_next << "Subthreshold Leakage = " <<
+      // lsu->power.readOp.longer_channel_leakage  << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << lsu->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << lsu->rt_power.readOp.dynamic / executionTime << " W" << endl;
+      cout << endl;
+      if (plevel > 2) {
+        lsu->displayEnergy(indent + 4, plevel, is_tdp);
+      }
+    }
+    if (mmu->exist) {
+      cout << indent_str << "Memory Management Unit:" << endl;
+      cout << indent_str_next << "Area = " << mmu->area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << mmu->power.readOp.dynamic * clockRate << " W"
+           << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? mmu->power.readOp.longer_channel_leakage
+                            : mmu->power.readOp.leakage)
+           << " W" << endl;
+      // cout << indent_str_next << "Subthreshold Leakage = " <<
+      // mmu->power.readOp.longer_channel_leakage   << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << mmu->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << mmu->rt_power.readOp.dynamic / executionTime << " W" << endl;
+      cout << endl;
+      if (plevel > 2) {
+        mmu->displayEnergy(indent + 4, plevel, is_tdp);
+      }
+    }
+    if (exu->exist) {
+      cout << indent_str << "Execution Unit:" << endl;
+      cout << indent_str_next << "Area = " << exu->area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << exu->power.readOp.dynamic * clockRate << " W"
+           << endl;
+      cout << indent_str_next
+           << "Peak Dynamic Energy = " << exu->power.readOp.dynamic << " W"
+           << endl;
+      cout << indent_str_next << "clock Rate = " << clockRate << " W" << endl;
 
-		}
-		if (lsu->exist)
-		{
-			cout << indent_str<< "Load Store Unit:" << endl;
-			cout << indent_str_next << "Area = " << lsu->area.get_area()*1e-6  << " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << lsu->power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? lsu->power.readOp.longer_channel_leakage:lsu->power.readOp.leakage ) << " W" << endl;
-			//cout << indent_str_next << "Subthreshold Leakage = " << lsu->power.readOp.longer_channel_leakage  << " W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << lsu->power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << lsu->rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-			if (plevel >2){
-				lsu->displayEnergy(indent+4,plevel,is_tdp);
-			}
-		}
-		if (mmu->exist)
-		{
-			cout << indent_str<< "Memory Management Unit:" << endl;
-			cout << indent_str_next << "Area = " << mmu->area.get_area() *1e-6 << " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << mmu->power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? mmu->power.readOp.longer_channel_leakage:mmu->power.readOp.leakage)   << " W" << endl;
-			//cout << indent_str_next << "Subthreshold Leakage = " << mmu->power.readOp.longer_channel_leakage   << " W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << mmu->power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << mmu->rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-			if (plevel >2){
-				mmu->displayEnergy(indent+4,plevel,is_tdp);
-			}
-		}
-		if (exu->exist)
-		{
-			cout << indent_str<< "Execution Unit:" << endl;
-			cout << indent_str_next << "Area = " << exu->area.get_area()  *1e-6<< " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << exu->power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Peak Dynamic Energy = " << exu->power.readOp.dynamic  << " W" << endl;
-			cout << indent_str_next << "clock Rate = " << clockRate  << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? exu->power.readOp.longer_channel_leakage
+                            : exu->power.readOp.leakage)
+           << " W" << endl;
+      // cout << indent_str_next << "Subthreshold Leakage = " <<
+      // exu->power.readOp.longer_channel_leakage << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << exu->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << exu->rt_power.readOp.dynamic / executionTime << " W" << endl;
+      cout << endl;
+      if (plevel > 2) {
+        exu->displayEnergy(indent + 4, plevel, is_tdp);
+      }
+    }
+    //		if (plevel >2)
+    //		{
+    //			if (undiffCore->exist)
+    //			{
+    //				cout << indent_str << "Undifferentiated Core" <<
+    //endl;
+    //				cout << indent_str_next << "Area = " <<
+    //undiffCore->area.get_area()*1e-6<< " mm^2" << endl;
+    //				cout << indent_str_next << "Peak Dynamic = " <<
+    //undiffCore->power.readOp.dynamic*clockRate << " W" << endl;
+    ////				cout << indent_str_next << "Subthreshold Leakage = " <<
+    ///undiffCore->power.readOp.leakage <<" W" << endl;
+    //				cout << indent_str_next << "Subthreshold Leakage =
+    //"
+    //								<< (long_channel?
+    //undiffCore->power.readOp.longer_channel_leakage:undiffCore->power.readOp.leakage)
+    //<< " W" << endl;
+    //				cout << indent_str_next << "Gate Leakage = " <<
+    //undiffCore->power.readOp.gate_leakage << " W" << endl;
+    //				//		cout << indent_str_next << "Runtime Dynamic = " <<
+    //undiffCore->rt_power.readOp.dynamic/executionTime << " W" << endl;
+    //				cout <<endl;
+    //			}
+    //		}
+    if (XML->sys.Private_L2) {
+      l2cache->displayEnergy(4, is_tdp);
+    }
 
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? exu->power.readOp.longer_channel_leakage:exu->power.readOp.leakage)   << " W" << endl;
-			//cout << indent_str_next << "Subthreshold Leakage = " << exu->power.readOp.longer_channel_leakage << " W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << exu->power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << exu->rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-			if (plevel >2){
-				exu->displayEnergy(indent+4,plevel,is_tdp);
-			}
-		}
-//		if (plevel >2)
-//		{
-//			if (undiffCore->exist)
-//			{
-//				cout << indent_str << "Undifferentiated Core" << endl;
-//				cout << indent_str_next << "Area = " << undiffCore->area.get_area()*1e-6<< " mm^2" << endl;
-//				cout << indent_str_next << "Peak Dynamic = " << undiffCore->power.readOp.dynamic*clockRate << " W" << endl;
-////				cout << indent_str_next << "Subthreshold Leakage = " << undiffCore->power.readOp.leakage <<" W" << endl;
-//				cout << indent_str_next << "Subthreshold Leakage = "
-//								<< (long_channel? undiffCore->power.readOp.longer_channel_leakage:undiffCore->power.readOp.leakage)   << " W" << endl;
-//				cout << indent_str_next << "Gate Leakage = " << undiffCore->power.readOp.gate_leakage << " W" << endl;
-//				//		cout << indent_str_next << "Runtime Dynamic = " << undiffCore->rt_power.readOp.dynamic/executionTime << " W" << endl;
-//				cout <<endl;
-//			}
-//		}
-		if (XML->sys.Private_L2)
-		{
+    cout << indent_str << "Idle Core: " << endl;
+    cout << indent_str_next
+         << "Runtime Dynamic = " << IdleCoreEnergy / executionTime << " W\n"
+         << endl;
 
-			l2cache->displayEnergy(4,is_tdp);
-		}
-
-		cout << indent_str<< "Idle Core: " << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << IdleCoreEnergy/executionTime << " W\n" << endl;
-
-	}
-	else
-	{
-//		cout << indent_str_next << "Instruction Fetch Unit    Peak Dynamic = " << ifu->rt_power.readOp.dynamic*clockRate << " W" << endl;
-//		cout << indent_str_next << "Instruction Fetch Unit    Subthreshold Leakage = " << ifu->rt_power.readOp.leakage <<" W" << endl;
-//		cout << indent_str_next << "Instruction Fetch Unit    Gate Leakage = " << ifu->rt_power.readOp.gate_leakage << " W" << endl;
-//		cout << indent_str_next << "Load Store Unit   Peak Dynamic = " << lsu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-//		cout << indent_str_next << "Load Store Unit   Subthreshold Leakage = " << lsu->rt_power.readOp.leakage  << " W" << endl;
-//		cout << indent_str_next << "Load Store Unit   Gate Leakage = " << lsu->rt_power.readOp.gate_leakage  << " W" << endl;
-//		cout << indent_str_next << "Memory Management Unit   Peak Dynamic = " << mmu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-//		cout << indent_str_next << "Memory Management Unit   Subthreshold Leakage = " << mmu->rt_power.readOp.leakage  << " W" << endl;
-//		cout << indent_str_next << "Memory Management Unit   Gate Leakage = " << mmu->rt_power.readOp.gate_leakage  << " W" << endl;
-//		cout << indent_str_next << "Execution Unit   Peak Dynamic = " << exu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-//		cout << indent_str_next << "Execution Unit   Subthreshold Leakage = " << exu->rt_power.readOp.leakage  << " W" << endl;
-//		cout << indent_str_next << "Execution Unit   Gate Leakage = " << exu->rt_power.readOp.gate_leakage  << " W" << endl;
-	}
+  } else {
+    //		cout << indent_str_next << "Instruction Fetch Unit    Peak Dynamic = "
+    //<< ifu->rt_power.readOp.dynamic*clockRate << " W" << endl;
+    //		cout << indent_str_next << "Instruction Fetch Unit    Subthreshold
+    //Leakage = " << ifu->rt_power.readOp.leakage <<" W" << endl;
+    //		cout << indent_str_next << "Instruction Fetch Unit    Gate Leakage = "
+    //<< ifu->rt_power.readOp.gate_leakage << " W" << endl;
+    //		cout << indent_str_next << "Load Store Unit   Peak Dynamic = " <<
+    //lsu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "Load Store Unit   Subthreshold Leakage = "
+    //<< lsu->rt_power.readOp.leakage  << " W" << endl;
+    //		cout << indent_str_next << "Load Store Unit   Gate Leakage = " <<
+    //lsu->rt_power.readOp.gate_leakage  << " W" << endl;
+    //		cout << indent_str_next << "Memory Management Unit   Peak Dynamic = "
+    //<< mmu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "Memory Management Unit   Subthreshold
+    //Leakage = " << mmu->rt_power.readOp.leakage  << " W" << endl;
+    //		cout << indent_str_next << "Memory Management Unit   Gate Leakage = "
+    //<< mmu->rt_power.readOp.gate_leakage  << " W" << endl;
+    //		cout << indent_str_next << "Execution Unit   Peak Dynamic = " <<
+    //exu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "Execution Unit   Subthreshold Leakage = "
+    //<< exu->rt_power.readOp.leakage  << " W" << endl;
+    //		cout << indent_str_next << "Execution Unit   Gate Leakage = " <<
+    //exu->rt_power.readOp.gate_leakage  << " W" << endl;
+  }
 }
-InstFetchU ::~InstFetchU(){
-
-	if (!exist) return;
-	if(IB) 	                   {delete IB; IB = 0;}
-	if(ID_inst) 	           {delete ID_inst; ID_inst = 0;}
-	if(ID_operand) 	           {delete ID_operand; ID_operand = 0;}
-	if(ID_misc) 	           {delete ID_misc; ID_misc = 0;}
-	if (coredynp.predictionW>0)
-	{
-		if(BTB) 	               {delete BTB; BTB = 0;}
-		if(BPT) 	               {delete BPT; BPT = 0;}
-	}
+InstFetchU::~InstFetchU() {
+  if (!exist) return;
+  if (IB) {
+    delete IB;
+    IB = 0;
+  }
+  if (ID_inst) {
+    delete ID_inst;
+    ID_inst = 0;
+  }
+  if (ID_operand) {
+    delete ID_operand;
+    ID_operand = 0;
+  }
+  if (ID_misc) {
+    delete ID_misc;
+    ID_misc = 0;
+  }
+  if (coredynp.predictionW > 0) {
+    if (BTB) {
+      delete BTB;
+      BTB = 0;
+    }
+    if (BPT) {
+      delete BPT;
+      BPT = 0;
+    }
+  }
 }
 
-BranchPredictor ::~BranchPredictor(){
-
-	if (!exist) return;
-	if(globalBPT) 	           {delete globalBPT; globalBPT = 0;}
-	if(localBPT) 	           {delete localBPT; localBPT = 0;}
-    if(L1_localBPT) 	       {delete L1_localBPT; L1_localBPT = 0;}
-    if(L2_localBPT) 	       {delete L2_localBPT; L2_localBPT = 0;}
-    if(chooser) 	           {delete chooser; chooser = 0;}
-    if(RAS) 	               {delete RAS; RAS = 0;}
-	}
-
-RENAMINGU ::~RENAMINGU(){
-
-	if (!exist) return;
-	if(iFRAT ) 	               {delete iFRAT; iFRAT = 0;}
-    if(fFRAT ) 	               {delete fFRAT; fFRAT =0;}
-    if(iRRAT)                  {delete iRRAT; iRRAT = 0;}
-    if(iFRAT)                  {delete iFRAT; iFRAT = 0;}
-    if(ifreeL)                 {delete ifreeL;ifreeL= 0;}
-    if(ffreeL)                 {delete ffreeL;ffreeL= 0;}
-    if(idcl)                   {delete idcl;  idcl = 0;}
-    if(fdcl)                   {delete fdcl;  fdcl = 0;}
-    if(RAHT)                   {delete RAHT;  RAHT = 0;}
-	}
-
-LoadStoreU ::~LoadStoreU(){
-
-	if (!exist) return;
-	if(LSQ) 	               {delete LSQ; LSQ = 0;}
-	}
-
-MemManU ::~MemManU(){
-
-	if (!exist) return;
-	if(itlb) 	               {delete itlb; itlb = 0;}
-    if(dtlb) 	               {delete dtlb; dtlb = 0;}
-	}
-
-RegFU ::~RegFU(){
-
-	if (!exist) return;
-	if(IRF) 	               {delete IRF; IRF = 0;}
-    if(FRF) 	               {delete FRF; FRF = 0;}
-    if(RFWIN) 	               {delete RFWIN; RFWIN = 0;}
-	}
-
-SchedulerU ::~SchedulerU(){
-
-	if (!exist) return;
-	if(int_inst_window) 	   {delete int_inst_window; int_inst_window = 0;}
-	if(fp_inst_window) 	       {delete int_inst_window; int_inst_window = 0;}
-	if(ROB) 	               {delete ROB; ROB = 0;}
-    if(instruction_selection)  {delete instruction_selection;instruction_selection = 0;}
-	}
-
-EXECU ::~EXECU(){
-
-	if (!exist) return;
-	if(int_bypass) 	           {delete int_bypass; int_bypass = 0;}
-    if(intTagBypass) 	       {delete intTagBypass; intTagBypass =0;}
-    if(int_mul_bypass) 	       {delete int_mul_bypass; int_mul_bypass = 0;}
-    if(intTag_mul_Bypass) 	   {delete intTag_mul_Bypass; intTag_mul_Bypass =0;}
-    if(fp_bypass) 	           {delete fp_bypass;fp_bypass = 0;}
-    if(fpTagBypass) 	       {delete fpTagBypass;fpTagBypass = 0;}
-    if(fp_u)                   {delete fp_u;fp_u = 0;}
-    if(exeu)                   {delete exeu;exeu = 0;}
-    if(mul)                    {delete mul;mul = 0;}
-    if(rfu)                    {delete rfu;rfu = 0;}
-	if(scheu) 	               {delete scheu; scheu = 0;}
-	}
-
-Core ::~Core(){
-
-	if(ifu) 	               {delete ifu; ifu = 0;}
-	if(lsu) 	               {delete lsu; lsu = 0;}
-	if(rnu) 	               {delete rnu; rnu = 0;}
-	if(mmu) 	               {delete mmu; mmu = 0;}
-	if(exu) 	               {delete exu; exu = 0;}
-    if(corepipe) 	           {delete corepipe; corepipe = 0;}
-    if(undiffCore)             {delete undiffCore;undiffCore = 0;}
-    if(l2cache)                {delete l2cache;l2cache = 0;}
-	}
-
-void Core::set_core_param()
-{
-	coredynp.opt_local = XML->sys.core[ithCore].opt_local;
-	coredynp.x86 = XML->sys.core[ithCore].x86;
-	coredynp.Embedded = XML->sys.Embedded;
-	coredynp.core_ty   = (enum Core_type)XML->sys.core[ithCore].machine_type;
-	coredynp.rm_ty     = (enum Renaming_type)XML->sys.core[ithCore].rename_scheme;
-    coredynp.fetchW    = XML->sys.core[ithCore].fetch_width;
-    coredynp.decodeW   = XML->sys.core[ithCore].decode_width;
-    coredynp.issueW    = XML->sys.core[ithCore].issue_width;
-    coredynp.peak_issueW   = XML->sys.core[ithCore].peak_issue_width;
-    coredynp.commitW       = XML->sys.core[ithCore].commit_width;
-    coredynp.peak_commitW  = XML->sys.core[ithCore].peak_issue_width;
-    coredynp.predictionW   = XML->sys.core[ithCore].prediction_width;
-    coredynp.fp_issueW     = XML->sys.core[ithCore].fp_issue_width;
-    coredynp.fp_decodeW    = XML->sys.core[ithCore].fp_issue_width;
-    coredynp.num_alus      = XML->sys.core[ithCore].ALU_per_core;
-    coredynp.num_fpus      = XML->sys.core[ithCore].FPU_per_core;
-    coredynp.num_muls      = XML->sys.core[ithCore].MUL_per_core;
-
-
-    coredynp.num_hthreads	     = XML->sys.core[ithCore].number_hardware_threads;
-    coredynp.multithreaded       = coredynp.num_hthreads>1? true:false;
-    coredynp.instruction_length  = XML->sys.core[ithCore].instruction_length;
-    coredynp.pc_width            = XML->sys.virtual_address_width;
-
-   	coredynp.opcode_length       = XML->sys.core[ithCore].opcode_width;
-    coredynp.micro_opcode_length = XML->sys.core[ithCore].micro_opcode_width;
-    coredynp.num_pipelines       = XML->sys.core[ithCore].pipelines_per_core[0];
-    coredynp.pipeline_stages     = XML->sys.core[ithCore].pipeline_depth[0];
-    coredynp.num_fp_pipelines    = XML->sys.core[ithCore].pipelines_per_core[1];
-    coredynp.fp_pipeline_stages  = XML->sys.core[ithCore].pipeline_depth[1];
-    coredynp.int_data_width      = int(ceil(XML->sys.machine_bits/32.0))*32;
-    coredynp.fp_data_width       = coredynp.int_data_width;
-    coredynp.v_address_width     = XML->sys.virtual_address_width;
-    coredynp.p_address_width     = XML->sys.physical_address_width;
-
-	coredynp.scheu_ty         = (enum Scheduler_type)XML->sys.core[ithCore].instruction_window_scheme;
-	coredynp.arch_ireg_width  =  int(ceil(log2(XML->sys.core[ithCore].archi_Regs_IRF_size)));
-	coredynp.arch_freg_width  =  int(ceil(log2(XML->sys.core[ithCore].archi_Regs_FRF_size)));
-	coredynp.num_IRF_entry    = XML->sys.core[ithCore].archi_Regs_IRF_size;
-	coredynp.num_FRF_entry    = XML->sys.core[ithCore].archi_Regs_FRF_size;
-	coredynp.pipeline_duty_cycle = XML->sys.core[ithCore].pipeline_duty_cycle;
-	coredynp.total_cycles        = XML->sys.core[ithCore].total_cycles;
-	coredynp.busy_cycles         = XML->sys.core[ithCore].busy_cycles;
-	coredynp.idle_cycles         = XML->sys.core[ithCore].idle_cycles;
-
-	//Max power duty cycle for peak power estimation
-//	if (coredynp.core_ty==OOO)
-//	{
-//		coredynp.IFU_duty_cycle = 1;
-//		coredynp.LSU_duty_cycle = 1;
-//		coredynp.MemManU_I_duty_cycle =1;
-//		coredynp.MemManU_D_duty_cycle =1;
-//		coredynp.ALU_duty_cycle =1;
-//		coredynp.MUL_duty_cycle =1;
-//		coredynp.FPU_duty_cycle =1;
-//		coredynp.ALU_cdb_duty_cycle =1;
-//		coredynp.MUL_cdb_duty_cycle =1;
-//		coredynp.FPU_cdb_duty_cycle =1;
-//	}
-//	else
-//	{
-		coredynp.IFU_duty_cycle = XML->sys.core[ithCore].IFU_duty_cycle;
-		coredynp.BR_duty_cycle = XML->sys.core[ithCore].BR_duty_cycle;
-		coredynp.LSU_duty_cycle = XML->sys.core[ithCore].LSU_duty_cycle;
-		coredynp.MemManU_I_duty_cycle = XML->sys.core[ithCore].MemManU_I_duty_cycle;
-		coredynp.MemManU_D_duty_cycle = XML->sys.core[ithCore].MemManU_D_duty_cycle;
-		coredynp.ALU_duty_cycle = XML->sys.core[ithCore].ALU_duty_cycle;
-		coredynp.MUL_duty_cycle = XML->sys.core[ithCore].MUL_duty_cycle;
-		coredynp.FPU_duty_cycle = XML->sys.core[ithCore].FPU_duty_cycle;
-		coredynp.ALU_cdb_duty_cycle = XML->sys.core[ithCore].ALU_cdb_duty_cycle;
-		coredynp.MUL_cdb_duty_cycle = XML->sys.core[ithCore].MUL_cdb_duty_cycle;
-		coredynp.FPU_cdb_duty_cycle = XML->sys.core[ithCore].FPU_cdb_duty_cycle;
-//	}
-
-
-	if (!((coredynp.core_ty==OOO)||(coredynp.core_ty==Inorder)))
-	{
-		cout<<"Invalid Core Type"<<endl;
-		exit(0);
-	}
-//	if (coredynp.core_ty==OOO)
-//	{
-//		cout<<"OOO processor models are being updated and will be available in next release"<<endl;
-//		exit(0);
-//	}
-	if (!((coredynp.scheu_ty==PhysicalRegFile)||(coredynp.scheu_ty==ReservationStation)))
-	{
-		cout<<"Invalid OOO Scheduler Type"<<endl;
-		exit(0);
-	}
-
-	if (!((coredynp.rm_ty ==RAMbased)||(coredynp.rm_ty ==CAMbased)))
-	{
-		cout<<"Invalid OOO Renaming Type"<<endl;
-		exit(0);
-	}
-
-if (coredynp.core_ty==OOO)
-{
-	if (coredynp.scheu_ty==PhysicalRegFile)
-	{
-	  coredynp.phy_ireg_width  =  int(ceil(log2(XML->sys.core[ithCore].phy_Regs_IRF_size)));
-	  coredynp.phy_freg_width  =  int(ceil(log2(XML->sys.core[ithCore].phy_Regs_FRF_size)));
-	  coredynp.num_ifreelist_entries = coredynp.num_IRF_entry  = XML->sys.core[ithCore].phy_Regs_IRF_size;
-	  coredynp.num_ffreelist_entries = coredynp.num_FRF_entry  = XML->sys.core[ithCore].phy_Regs_FRF_size;
-	}
-	else if (coredynp.scheu_ty==ReservationStation)
-	{//ROB serves as Phy RF in RS based OOO
-      coredynp.phy_ireg_width  =  int(ceil(log2(XML->sys.core[ithCore].ROB_size)));
-	  coredynp.phy_freg_width  =  int(ceil(log2(XML->sys.core[ithCore].ROB_size)));
-	  coredynp.num_ifreelist_entries = XML->sys.core[ithCore].ROB_size;
-	  coredynp.num_ffreelist_entries = XML->sys.core[ithCore].ROB_size;
-
-	}
-
+BranchPredictor::~BranchPredictor() {
+  if (!exist) return;
+  if (globalBPT) {
+    delete globalBPT;
+    globalBPT = 0;
+  }
+  if (localBPT) {
+    delete localBPT;
+    localBPT = 0;
+  }
+  if (L1_localBPT) {
+    delete L1_localBPT;
+    L1_localBPT = 0;
+  }
+  if (L2_localBPT) {
+    delete L2_localBPT;
+    L2_localBPT = 0;
+  }
+  if (chooser) {
+    delete chooser;
+    chooser = 0;
+  }
+  if (RAS) {
+    delete RAS;
+    RAS = 0;
+  }
 }
-	coredynp.globalCheckpoint   =  32;//best check pointing entries for a 4~8 issue OOO should be 16~48;See TR for reference.
-	coredynp.perThreadState     =  8;
-	coredynp.instruction_length = 32;
-	coredynp.clockRate          =  XML->sys.core[ithCore].clock_rate;
-	coredynp.clockRate          *= 1e6;
-	coredynp.regWindowing= (XML->sys.core[ithCore].register_windows_size>0&&coredynp.core_ty==Inorder)?true:false;
-	coredynp.executionTime = XML->sys.total_cycles/coredynp.clockRate;
-	set_pppm(coredynp.pppm_lkg_multhread, 0, coredynp.num_hthreads, coredynp.num_hthreads, 0);
+
+RENAMINGU::~RENAMINGU() {
+  if (!exist) return;
+  if (iFRAT) {
+    delete iFRAT;
+    iFRAT = 0;
+  }
+  if (fFRAT) {
+    delete fFRAT;
+    fFRAT = 0;
+  }
+  if (iRRAT) {
+    delete iRRAT;
+    iRRAT = 0;
+  }
+  if (iFRAT) {
+    delete iFRAT;
+    iFRAT = 0;
+  }
+  if (ifreeL) {
+    delete ifreeL;
+    ifreeL = 0;
+  }
+  if (ffreeL) {
+    delete ffreeL;
+    ffreeL = 0;
+  }
+  if (idcl) {
+    delete idcl;
+    idcl = 0;
+  }
+  if (fdcl) {
+    delete fdcl;
+    fdcl = 0;
+  }
+  if (RAHT) {
+    delete RAHT;
+    RAHT = 0;
+  }
+}
+
+LoadStoreU::~LoadStoreU() {
+  if (!exist) return;
+  if (LSQ) {
+    delete LSQ;
+    LSQ = 0;
+  }
+}
+
+MemManU::~MemManU() {
+  if (!exist) return;
+  if (itlb) {
+    delete itlb;
+    itlb = 0;
+  }
+  if (dtlb) {
+    delete dtlb;
+    dtlb = 0;
+  }
+}
+
+RegFU::~RegFU() {
+  if (!exist) return;
+  if (IRF) {
+    delete IRF;
+    IRF = 0;
+  }
+  if (FRF) {
+    delete FRF;
+    FRF = 0;
+  }
+  if (RFWIN) {
+    delete RFWIN;
+    RFWIN = 0;
+  }
+}
+
+SchedulerU::~SchedulerU() {
+  if (!exist) return;
+  if (int_inst_window) {
+    delete int_inst_window;
+    int_inst_window = 0;
+  }
+  if (fp_inst_window) {
+    delete int_inst_window;
+    int_inst_window = 0;
+  }
+  if (ROB) {
+    delete ROB;
+    ROB = 0;
+  }
+  if (instruction_selection) {
+    delete instruction_selection;
+    instruction_selection = 0;
+  }
+}
+
+EXECU::~EXECU() {
+  if (!exist) return;
+  if (int_bypass) {
+    delete int_bypass;
+    int_bypass = 0;
+  }
+  if (intTagBypass) {
+    delete intTagBypass;
+    intTagBypass = 0;
+  }
+  if (int_mul_bypass) {
+    delete int_mul_bypass;
+    int_mul_bypass = 0;
+  }
+  if (intTag_mul_Bypass) {
+    delete intTag_mul_Bypass;
+    intTag_mul_Bypass = 0;
+  }
+  if (fp_bypass) {
+    delete fp_bypass;
+    fp_bypass = 0;
+  }
+  if (fpTagBypass) {
+    delete fpTagBypass;
+    fpTagBypass = 0;
+  }
+  if (fp_u) {
+    delete fp_u;
+    fp_u = 0;
+  }
+  if (exeu) {
+    delete exeu;
+    exeu = 0;
+  }
+  if (mul) {
+    delete mul;
+    mul = 0;
+  }
+  if (rfu) {
+    delete rfu;
+    rfu = 0;
+  }
+  if (scheu) {
+    delete scheu;
+    scheu = 0;
+  }
+}
+
+Core::~Core() {
+  if (ifu) {
+    delete ifu;
+    ifu = 0;
+  }
+  if (lsu) {
+    delete lsu;
+    lsu = 0;
+  }
+  if (rnu) {
+    delete rnu;
+    rnu = 0;
+  }
+  if (mmu) {
+    delete mmu;
+    mmu = 0;
+  }
+  if (exu) {
+    delete exu;
+    exu = 0;
+  }
+  if (corepipe) {
+    delete corepipe;
+    corepipe = 0;
+  }
+  if (undiffCore) {
+    delete undiffCore;
+    undiffCore = 0;
+  }
+  if (l2cache) {
+    delete l2cache;
+    l2cache = 0;
+  }
+}
+
+void Core::set_core_param() {
+  coredynp.opt_local = XML->sys.core[ithCore].opt_local;
+  coredynp.x86 = XML->sys.core[ithCore].x86;
+  coredynp.Embedded = XML->sys.Embedded;
+  coredynp.core_ty = (enum Core_type)XML->sys.core[ithCore].machine_type;
+  coredynp.rm_ty = (enum Renaming_type)XML->sys.core[ithCore].rename_scheme;
+  coredynp.fetchW = XML->sys.core[ithCore].fetch_width;
+  coredynp.decodeW = XML->sys.core[ithCore].decode_width;
+  coredynp.issueW = XML->sys.core[ithCore].issue_width;
+  coredynp.peak_issueW = XML->sys.core[ithCore].peak_issue_width;
+  coredynp.commitW = XML->sys.core[ithCore].commit_width;
+  coredynp.peak_commitW = XML->sys.core[ithCore].peak_issue_width;
+  coredynp.predictionW = XML->sys.core[ithCore].prediction_width;
+  coredynp.fp_issueW = XML->sys.core[ithCore].fp_issue_width;
+  coredynp.fp_decodeW = XML->sys.core[ithCore].fp_issue_width;
+  coredynp.num_alus = XML->sys.core[ithCore].ALU_per_core;
+  coredynp.num_fpus = XML->sys.core[ithCore].FPU_per_core;
+  coredynp.num_muls = XML->sys.core[ithCore].MUL_per_core;
+
+  coredynp.num_hthreads = XML->sys.core[ithCore].number_hardware_threads;
+  coredynp.multithreaded = coredynp.num_hthreads > 1 ? true : false;
+  coredynp.instruction_length = XML->sys.core[ithCore].instruction_length;
+  coredynp.pc_width = XML->sys.virtual_address_width;
+
+  coredynp.opcode_length = XML->sys.core[ithCore].opcode_width;
+  coredynp.micro_opcode_length = XML->sys.core[ithCore].micro_opcode_width;
+  coredynp.num_pipelines = XML->sys.core[ithCore].pipelines_per_core[0];
+  coredynp.pipeline_stages = XML->sys.core[ithCore].pipeline_depth[0];
+  coredynp.num_fp_pipelines = XML->sys.core[ithCore].pipelines_per_core[1];
+  coredynp.fp_pipeline_stages = XML->sys.core[ithCore].pipeline_depth[1];
+  coredynp.int_data_width = int(ceil(XML->sys.machine_bits / 32.0)) * 32;
+  coredynp.fp_data_width = coredynp.int_data_width;
+  coredynp.v_address_width = XML->sys.virtual_address_width;
+  coredynp.p_address_width = XML->sys.physical_address_width;
+
+  coredynp.scheu_ty =
+      (enum Scheduler_type)XML->sys.core[ithCore].instruction_window_scheme;
+  coredynp.arch_ireg_width =
+      int(ceil(log2(XML->sys.core[ithCore].archi_Regs_IRF_size)));
+  coredynp.arch_freg_width =
+      int(ceil(log2(XML->sys.core[ithCore].archi_Regs_FRF_size)));
+  coredynp.num_IRF_entry = XML->sys.core[ithCore].archi_Regs_IRF_size;
+  coredynp.num_FRF_entry = XML->sys.core[ithCore].archi_Regs_FRF_size;
+  coredynp.pipeline_duty_cycle = XML->sys.core[ithCore].pipeline_duty_cycle;
+  coredynp.total_cycles = XML->sys.core[ithCore].total_cycles;
+  coredynp.busy_cycles = XML->sys.core[ithCore].busy_cycles;
+  coredynp.idle_cycles = XML->sys.core[ithCore].idle_cycles;
+
+  // Max power duty cycle for peak power estimation
+  //	if (coredynp.core_ty==OOO)
+  //	{
+  //		coredynp.IFU_duty_cycle = 1;
+  //		coredynp.LSU_duty_cycle = 1;
+  //		coredynp.MemManU_I_duty_cycle =1;
+  //		coredynp.MemManU_D_duty_cycle =1;
+  //		coredynp.ALU_duty_cycle =1;
+  //		coredynp.MUL_duty_cycle =1;
+  //		coredynp.FPU_duty_cycle =1;
+  //		coredynp.ALU_cdb_duty_cycle =1;
+  //		coredynp.MUL_cdb_duty_cycle =1;
+  //		coredynp.FPU_cdb_duty_cycle =1;
+  //	}
+  //	else
+  //	{
+  coredynp.IFU_duty_cycle = XML->sys.core[ithCore].IFU_duty_cycle;
+  coredynp.BR_duty_cycle = XML->sys.core[ithCore].BR_duty_cycle;
+  coredynp.LSU_duty_cycle = XML->sys.core[ithCore].LSU_duty_cycle;
+  coredynp.MemManU_I_duty_cycle = XML->sys.core[ithCore].MemManU_I_duty_cycle;
+  coredynp.MemManU_D_duty_cycle = XML->sys.core[ithCore].MemManU_D_duty_cycle;
+  coredynp.ALU_duty_cycle = XML->sys.core[ithCore].ALU_duty_cycle;
+  coredynp.MUL_duty_cycle = XML->sys.core[ithCore].MUL_duty_cycle;
+  coredynp.FPU_duty_cycle = XML->sys.core[ithCore].FPU_duty_cycle;
+  coredynp.ALU_cdb_duty_cycle = XML->sys.core[ithCore].ALU_cdb_duty_cycle;
+  coredynp.MUL_cdb_duty_cycle = XML->sys.core[ithCore].MUL_cdb_duty_cycle;
+  coredynp.FPU_cdb_duty_cycle = XML->sys.core[ithCore].FPU_cdb_duty_cycle;
+  //	}
+
+  if (!((coredynp.core_ty == OOO) || (coredynp.core_ty == Inorder))) {
+    cout << "Invalid Core Type" << endl;
+    exit(0);
+  }
+  //	if (coredynp.core_ty==OOO)
+  //	{
+  //		cout<<"OOO processor models are being updated and will be available
+  //in next release"<<endl;
+  //		exit(0);
+  //	}
+  if (!((coredynp.scheu_ty == PhysicalRegFile) ||
+        (coredynp.scheu_ty == ReservationStation))) {
+    cout << "Invalid OOO Scheduler Type" << endl;
+    exit(0);
+  }
+
+  if (!((coredynp.rm_ty == RAMbased) || (coredynp.rm_ty == CAMbased))) {
+    cout << "Invalid OOO Renaming Type" << endl;
+    exit(0);
+  }
+
+  if (coredynp.core_ty == OOO) {
+    if (coredynp.scheu_ty == PhysicalRegFile) {
+      coredynp.phy_ireg_width =
+          int(ceil(log2(XML->sys.core[ithCore].phy_Regs_IRF_size)));
+      coredynp.phy_freg_width =
+          int(ceil(log2(XML->sys.core[ithCore].phy_Regs_FRF_size)));
+      coredynp.num_ifreelist_entries = coredynp.num_IRF_entry =
+          XML->sys.core[ithCore].phy_Regs_IRF_size;
+      coredynp.num_ffreelist_entries = coredynp.num_FRF_entry =
+          XML->sys.core[ithCore].phy_Regs_FRF_size;
+    } else if (coredynp.scheu_ty ==
+               ReservationStation) {  // ROB serves as Phy RF in RS based OOO
+      coredynp.phy_ireg_width =
+          int(ceil(log2(XML->sys.core[ithCore].ROB_size)));
+      coredynp.phy_freg_width =
+          int(ceil(log2(XML->sys.core[ithCore].ROB_size)));
+      coredynp.num_ifreelist_entries = XML->sys.core[ithCore].ROB_size;
+      coredynp.num_ffreelist_entries = XML->sys.core[ithCore].ROB_size;
+    }
+  }
+  coredynp.globalCheckpoint = 32;  // best check pointing entries for a 4~8
+                                   // issue OOO should be 16~48;See TR for
+                                   // reference.
+  coredynp.perThreadState = 8;
+  coredynp.instruction_length = 32;
+  coredynp.clockRate = XML->sys.core[ithCore].clock_rate;
+  coredynp.clockRate *= 1e6;
+  coredynp.regWindowing = (XML->sys.core[ithCore].register_windows_size > 0 &&
+                           coredynp.core_ty == Inorder)
+                              ? true
+                              : false;
+  coredynp.executionTime = XML->sys.total_cycles / coredynp.clockRate;
+  set_pppm(coredynp.pppm_lkg_multhread, 0, coredynp.num_hthreads,
+           coredynp.num_hthreads, 0);
 }

--- a/src/gpuwattch/core.h
+++ b/src/gpuwattch/core.h
@@ -29,470 +29,527 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:												   *
-*      Jingwen Leng, Univeristy of Texas, Austin                   *
-*      Syed Gilani, University of Wisconsin–Madison                *
-*      Tayler Hetherington, University of British Columbia         *
-*      Ahmed ElTantawy, University of British Columbia             *
-********************************************************************/
-
+ *      Modified by:
+ ** Jingwen Leng, Univeristy of Texas, Austin                   * Syed Gilani,
+ *University of Wisconsin–Madison                * Tayler Hetherington,
+ *University of British Columbia         * Ahmed ElTantawy, University of
+ *British Columbia             *
+ ********************************************************************/
 
 #ifndef CORE_H_
 #define CORE_H_
 
 #include "XML_Parse.h"
-#include "logic.h"
-#include "cacti/parameter.h"
 #include "array.h"
-#include "interconnect.h"
 #include "basic_components.h"
-#include "sharedcache.h"
-#include "cacti/crossbar.h"
 #include "cacti/arbiter.h"
+#include "cacti/crossbar.h"
+#include "cacti/parameter.h"
+#include "interconnect.h"
+#include "logic.h"
 #include "noc.h"
+#include "sharedcache.h"
 
-class BranchPredictor :public Component {
-  public:
+class BranchPredictor : public Component {
+ public:
+  ParseXML *XML;
+  int ithCore;
+  InputParameter interface_ip;
+  CoreDynParam coredynp;
+  double clockRate, executionTime;
+  double scktRatio, chip_PR_overhead, macro_PR_overhead;
+  ArrayST *globalBPT;
+  ArrayST *localBPT;
+  ArrayST *L1_localBPT;
+  ArrayST *L2_localBPT;
+  ArrayST *chooser;
+  ArrayST *RAS;
+  bool exist;
 
-	ParseXML *XML;
-	int  ithCore;
-	InputParameter interface_ip;
-	CoreDynParam  coredynp;
-	double clockRate,executionTime;
-	double scktRatio, chip_PR_overhead, macro_PR_overhead;
-	ArrayST * globalBPT;
-	ArrayST * localBPT;
-	ArrayST * L1_localBPT;
-	ArrayST * L2_localBPT;
-	ArrayST * chooser;
-	ArrayST * RAS;
-	bool exist;
-
-	BranchPredictor(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_,const CoreDynParam & dyn_p_, bool exsit=true);
-    void computeEnergy(bool is_tdp=true);
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-	~BranchPredictor();
+  BranchPredictor(ParseXML *XML_interface, int ithCore_,
+                  InputParameter *interface_ip_, const CoreDynParam &dyn_p_,
+                  bool exsit = true);
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  ~BranchPredictor();
 };
 
+class InstFetchU : public Component {
+ public:
+  ParseXML *XML;
+  int ithCore;
+  InputParameter interface_ip;
+  CoreDynParam coredynp;
+  double clockRate, executionTime;
+  double scktRatio, chip_PR_overhead, macro_PR_overhead;
+  enum Cache_policy cache_p;
+  InstCache icache;
+  ArrayST *IB;
+  ArrayST *BTB;
+  BranchPredictor *BPT;
+  inst_decoder *ID_inst;
+  inst_decoder *ID_operand;
+  inst_decoder *ID_misc;
+  bool exist;
 
-class InstFetchU :public Component {
-  public:
-
-	ParseXML *XML;
-	int  ithCore;
-	InputParameter interface_ip;
-	CoreDynParam  coredynp;
-	double clockRate,executionTime;
-	double scktRatio, chip_PR_overhead, macro_PR_overhead;
-	enum Cache_policy cache_p;
-	InstCache icache;
-	ArrayST * IB;
-	ArrayST * BTB;
-	BranchPredictor * BPT;
-	inst_decoder * ID_inst;
-	inst_decoder * ID_operand;
-	inst_decoder * ID_misc;
-	bool exist;
-
-	InstFetchU(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_,const CoreDynParam & dyn_p_, bool exsit=true);
-    void computeEnergy(bool is_tdp=true);
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-	~InstFetchU();
+  InstFetchU(ParseXML *XML_interface, int ithCore_,
+             InputParameter *interface_ip_, const CoreDynParam &dyn_p_,
+             bool exsit = true);
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  ~InstFetchU();
 };
 
+class SchedulerU : public Component {
+ public:
+  ParseXML *XML;
+  int ithCore;
+  InputParameter interface_ip;
+  CoreDynParam coredynp;
+  double clockRate, executionTime;
+  double scktRatio, chip_PR_overhead, macro_PR_overhead;
+  double Iw_height, fp_Iw_height, ROB_height;
+  ArrayST *int_inst_window;
+  ArrayST *fp_inst_window;
+  ArrayST *ROB;
+  selection_logic *instruction_selection;
+  bool exist;
 
-class SchedulerU :public Component {
-  public:
-
-	ParseXML *XML;
-	int  ithCore;
-	InputParameter interface_ip;
-	CoreDynParam  coredynp;
-	double clockRate,executionTime;
-	double scktRatio, chip_PR_overhead, macro_PR_overhead;
-	double Iw_height, fp_Iw_height,ROB_height;
-	ArrayST         * int_inst_window;
-	ArrayST         * fp_inst_window;
-	ArrayST         * ROB;
-    selection_logic * instruction_selection;
-    bool exist;
-
-    SchedulerU(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_,const CoreDynParam & dyn_p_, bool exist_=true);
-    void computeEnergy(bool is_tdp=true);
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-	~SchedulerU();
+  SchedulerU(ParseXML *XML_interface, int ithCore_,
+             InputParameter *interface_ip_, const CoreDynParam &dyn_p_,
+             bool exist_ = true);
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  ~SchedulerU();
 };
 
-class RENAMINGU :public Component {
-  public:
+class RENAMINGU : public Component {
+ public:
+  ParseXML *XML;
+  int ithCore;
+  InputParameter interface_ip;
+  double clockRate, executionTime;
+  CoreDynParam coredynp;
+  ArrayST *iFRAT;
+  ArrayST *fFRAT;
+  ArrayST *iRRAT;
+  ArrayST *fRRAT;
+  ArrayST *ifreeL;
+  ArrayST *ffreeL;
+  dep_resource_conflict_check *idcl;
+  dep_resource_conflict_check *fdcl;
+  ArrayST *RAHT;  // register alias history table Used to store GC
+  bool exist;
 
-	ParseXML *XML;
-	int  ithCore;
-	InputParameter interface_ip;
-	double clockRate,executionTime;
-	CoreDynParam  coredynp;
-	ArrayST * iFRAT;
-	ArrayST * fFRAT;
-	ArrayST * iRRAT;
-	ArrayST * fRRAT;
-	ArrayST * ifreeL;
-	ArrayST * ffreeL;
-	dep_resource_conflict_check * idcl;
-	dep_resource_conflict_check * fdcl;
-	ArrayST * RAHT;//register alias history table Used to store GC
-	bool exist;
-
-
-	RENAMINGU(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_, bool exist_=true);
-    void computeEnergy(bool is_tdp=true);
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-	~RENAMINGU();
+  RENAMINGU(ParseXML *XML_interface, int ithCore_,
+            InputParameter *interface_ip_, const CoreDynParam &dyn_p_,
+            bool exist_ = true);
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  ~RENAMINGU();
 };
 
-class LoadStoreU :public Component {
-  public:
+class LoadStoreU : public Component {
+ public:
+  ParseXML *XML;
+  int ithCore;
+  InputParameter interface_ip;
+  CoreDynParam coredynp;
+  enum Cache_policy cache_p;
+  double clockRate, executionTime;
+  double scktRatio, chip_PR_overhead, macro_PR_overhead;
+  double lsq_height;
+  DataCache dcache;
+  DataCache ccache;
+  DataCache tcache;
+  DataCache sharedmemory;
+  ArrayST *LSQ;  // it is actually the store queue but for inorder processors it
+                 // serves as both loadQ and StoreQ
+  ArrayST *LoadQ;
+  vector<NoC *> nocs;
+  bool exist;
+  Crossbar *xbar_shared;
+  Component noc;
+  LoadStoreU(ParseXML *XML_interface, int ithCore_,
+             InputParameter *interface_ip_, const CoreDynParam &dyn_p_,
+             bool exist_ = true);
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  void displayDeviceType(int device_type_,
+                         uint32_t indent);  // Added by Syed Gilani
 
-	ParseXML *XML;
-	int  ithCore;
-	InputParameter interface_ip;
-	CoreDynParam  coredynp;
-	enum Cache_policy cache_p;
-	double clockRate,executionTime;
-	double scktRatio, chip_PR_overhead, macro_PR_overhead;
-	double lsq_height;
-	DataCache dcache;
-	DataCache ccache;
-	DataCache tcache;
-	DataCache sharedmemory;
-	ArrayST * LSQ;//it is actually the store queue but for inorder processors it serves as both loadQ and StoreQ
-	ArrayST * LoadQ;
-	vector<NoC *>  nocs;
-	bool exist;
-   Crossbar *xbar_shared;
-	Component noc;
-	LoadStoreU(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_,const CoreDynParam & dyn_p_, bool exist_=true);
-    void computeEnergy(bool is_tdp=true);
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-	 void displayDeviceType(int device_type_, uint32_t indent);//Added by Syed Gilani
-
-	~LoadStoreU();
+  ~LoadStoreU();
 };
 
-class MemManU :public Component {
-  public:
+class MemManU : public Component {
+ public:
+  ParseXML *XML;
+  int ithCore;
+  InputParameter interface_ip;
+  CoreDynParam coredynp;
+  double clockRate, executionTime;
+  double scktRatio, chip_PR_overhead, macro_PR_overhead;
+  ArrayST *itlb;
+  ArrayST *dtlb;
+  bool exist;
 
-	ParseXML *XML;
-	int  ithCore;
-	InputParameter interface_ip;
-	CoreDynParam  coredynp;
-	double clockRate,executionTime;
-	double scktRatio, chip_PR_overhead, macro_PR_overhead;
-	ArrayST * itlb;
-	ArrayST * dtlb;
-	bool exist;
-
-	MemManU(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_,const CoreDynParam & dyn_p_, bool exist_=false);
-    void computeEnergy(bool is_tdp=true);
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-	~MemManU();
+  MemManU(ParseXML *XML_interface, int ithCore_, InputParameter *interface_ip_,
+          const CoreDynParam &dyn_p_, bool exist_ = false);
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  ~MemManU();
 };
 
-class RegFU :public Component {
-  public:
-
-	ParseXML *XML;
-	int  ithCore;
-	InputParameter interface_ip;
-	CoreDynParam  coredynp;
-	double clockRate,executionTime;
-	double scktRatio, chip_PR_overhead, macro_PR_overhead;
-	double int_regfile_height, fp_regfile_height;
-	ArrayST * IRF;
-	ArrayST * FRF;
-	ArrayST * RFWIN;
-	ArrayST * OPC;//Operand collectors
-	bool exist;
-   double exClockRate; 
-	//OC Modelling (Syed)
-	Crossbar * xbar_rfu;
-   MCPAT_Arbiter * arbiter_rfu;
-	RegFU(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_,const CoreDynParam & dyn_p_, double exClockRate, bool exist_=true);
-    void computeEnergy(bool is_tdp=true);
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-	~RegFU();
+class RegFU : public Component {
+ public:
+  ParseXML *XML;
+  int ithCore;
+  InputParameter interface_ip;
+  CoreDynParam coredynp;
+  double clockRate, executionTime;
+  double scktRatio, chip_PR_overhead, macro_PR_overhead;
+  double int_regfile_height, fp_regfile_height;
+  ArrayST *IRF;
+  ArrayST *FRF;
+  ArrayST *RFWIN;
+  ArrayST *OPC;  // Operand collectors
+  bool exist;
+  double exClockRate;
+  // OC Modelling (Syed)
+  Crossbar *xbar_rfu;
+  MCPAT_Arbiter *arbiter_rfu;
+  RegFU(ParseXML *XML_interface, int ithCore_, InputParameter *interface_ip_,
+        const CoreDynParam &dyn_p_, double exClockRate, bool exist_ = true);
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  ~RegFU();
 };
 
-class EXECU :public Component {
-  public:
+class EXECU : public Component {
+ public:
+  ParseXML *XML;
+  int ithCore;
+  InputParameter interface_ip;
+  double clockRate, executionTime;
+  double scktRatio, chip_PR_overhead, macro_PR_overhead;
+  double lsq_height;
+  CoreDynParam coredynp;
+  RegFU *rfu;
+  SchedulerU *scheu;
+  FunctionalUnit *fp_u;
+  FunctionalUnit *exeu;
+  FunctionalUnit *mul;
+  interconnect *int_bypass;
+  interconnect *intTagBypass;
+  interconnect *int_mul_bypass;
+  interconnect *intTag_mul_Bypass;
+  interconnect *fp_bypass;
+  interconnect *fpTagBypass;
+  bool exist;
+  double rf_fu_clockRate;
+  Component bypass;
 
-	ParseXML *XML;
-	int  ithCore;
-	InputParameter interface_ip;
-	double clockRate,executionTime;
-	double scktRatio, chip_PR_overhead, macro_PR_overhead;
-	double lsq_height;
-	CoreDynParam  coredynp;
-	RegFU          * rfu;
-	SchedulerU     * scheu;
-    FunctionalUnit * fp_u;
-    FunctionalUnit * exeu;
-    FunctionalUnit * mul;
-	interconnect * int_bypass;
-	interconnect * intTagBypass;
-	interconnect * int_mul_bypass;
-	interconnect * intTag_mul_Bypass;
-	interconnect * fp_bypass;
-	interconnect * fpTagBypass;
-	bool exist;
-	double rf_fu_clockRate;
-	Component  bypass;
-
-
-	EXECU(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_, double lsq_height_,const CoreDynParam & dyn_p_, double exClockRate, bool exist_);
-    void computeEnergy(bool is_tdp=true);
-	void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-	~EXECU();
+  EXECU(ParseXML *XML_interface, int ithCore_, InputParameter *interface_ip_,
+        double lsq_height_, const CoreDynParam &dyn_p_, double exClockRate,
+        bool exist_);
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  ~EXECU();
 };
 
+class Core : public Component {
+ public:
+  ParseXML *XML;
+  int ithCore;
+  InputParameter interface_ip;
+  double clockRate, executionTime;
+  double exClockRate;
+  double scktRatio, chip_PR_overhead, macro_PR_overhead;
+  InstFetchU *ifu;
+  LoadStoreU *lsu;
+  MemManU *mmu;
+  EXECU *exu;
+  RENAMINGU *rnu;
+  double IdleCoreEnergy;
+  double IdlePower_PerCore;
+  Pipeline *corepipe;
+  UndiffCore *undiffCore;
+  SharedCache *l2cache;
+  CoreDynParam coredynp;
+  double Pipeline_energy;
+  // full_decoder 	inst_decoder;
+  // clock_network	clockNetwork;
+  Core(ParseXML *XML_interface, int ithCore_, InputParameter *interface_ip_);
+  void set_core_param();
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
 
-class Core :public Component {
-  public:
+  float get_coefficient_icache_hits() {
+    // return 1.5*ifu->icache.caches->local_result.power.readOp.dynamic;
+    return ifu->icache.caches->local_result.power.readOp.dynamic;
+  }
 
-	ParseXML *XML;
-	int  ithCore;
-	InputParameter interface_ip;
-	double clockRate,executionTime;
-	double exClockRate;
-	double scktRatio, chip_PR_overhead, macro_PR_overhead;
-	InstFetchU * ifu;
-	LoadStoreU * lsu;
-	MemManU    * mmu;
-	EXECU      * exu;
-	RENAMINGU  * rnu;
-	double IdleCoreEnergy;
-	double IdlePower_PerCore;
-    Pipeline   * corepipe;
-    UndiffCore * undiffCore;
-    SharedCache * l2cache;
-    CoreDynParam  coredynp;
-	double Pipeline_energy;
-    //full_decoder 	inst_decoder;
-    //clock_network	clockNetwork;
-	Core(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_);
-	void set_core_param();
-	void computeEnergy(bool is_tdp=true);
-	void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
+  float get_coefficient_icache_misses() {
+    float value = 0;
+    value += ifu->icache.caches->local_result.power.writeOp.dynamic;
+    value += ifu->icache.caches->local_result.power.readOp.dynamic;
+    value += ifu->icache.missb->local_result.power.searchOp.dynamic;
+    value += ifu->icache.missb->local_result.power.writeOp.dynamic;
+    value += ifu->icache.ifb->local_result.power.searchOp.dynamic;
+    value += ifu->icache.ifb->local_result.power.writeOp.dynamic;
+    value += ifu->icache.prefetchb->local_result.power.searchOp.dynamic;
+    value += ifu->icache.prefetchb->local_result.power.writeOp.dynamic;
+    return value;
+  }
 
-	float get_coefficient_icache_hits(){
-		//return 1.5*ifu->icache.caches->local_result.power.readOp.dynamic;
-		return ifu->icache.caches->local_result.power.readOp.dynamic;
-	}
+  float get_coefficient_tot_insts() {
+    float value = 0;
+    value += ifu->IB->local_result.power.readOp.dynamic;
+    value += ifu->IB->local_result.power.writeOp.dynamic;
+    value += ifu->ID_inst->power_t.readOp.dynamic;
+    value += ifu->ID_operand->power_t.readOp.dynamic;
+    value += ifu->ID_misc->power_t.readOp.dynamic;
+    return value;
+  }
 
-	float get_coefficient_icache_misses(){
-		float value=0;
-		value+=ifu->icache.caches->local_result.power.writeOp.dynamic;
-		value+=ifu->icache.caches->local_result.power.readOp.dynamic;
-		value+=ifu->icache.missb->local_result.power.searchOp.dynamic;
-		value+=ifu->icache.missb->local_result.power.writeOp.dynamic;
-		value+=ifu->icache.ifb->local_result.power.searchOp.dynamic;
-		value+= ifu->icache.ifb->local_result.power.writeOp.dynamic;
-		value+= ifu->icache.prefetchb->local_result.power.searchOp.dynamic;
-		value+=ifu->icache.prefetchb->local_result.power.writeOp.dynamic;
-		return value;
-	}
+  float get_coefficient_fpint_insts() {
+    float value = 0;
+    value += exu->scheu->int_inst_window->local_result.power.readOp.dynamic;
+    value +=
+        2 * exu->scheu->int_inst_window->local_result.power.searchOp.dynamic;
+    value += exu->scheu->int_inst_window->local_result.power.writeOp.dynamic;
+    value += exu->scheu->instruction_selection->power.readOp.dynamic;
+    return value;
+  }
 
-	float get_coefficient_tot_insts(){
-		float value=0;
-		value+=ifu->IB->local_result.power.readOp.dynamic;
-		value+=ifu->IB->local_result.power.writeOp.dynamic;
-		value+=ifu->ID_inst->power_t.readOp.dynamic;
-		value+=ifu->ID_operand->power_t.readOp.dynamic;
-		value+=ifu->ID_misc->power_t.readOp.dynamic;
-		return value;
-	}
+  float get_coefficient_dcache_readhits() {
+    float value = 0;
+    value += lsu->dcache.caches->local_result.power.readOp.dynamic;
+    value += lsu->xbar_shared->power.readOp.dynamic;
+    // return 0.5*value;
+    return value;
+  }
+  float get_coefficient_dcache_readmisses() {
+    float value = 0;
+    value += lsu->dcache.caches->local_result.power.readOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->dcache.missb->local_result.power.searchOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->dcache.ifb->local_result.power.searchOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->dcache.prefetchb->local_result.power.searchOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->dcache.missb->local_result.power.writeOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->dcache.ifb->local_result.power.writeOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->dcache.prefetchb->local_result.power.writeOp.dynamic;
 
-	float get_coefficient_fpint_insts(){
-		float value=0;
-		value+=exu->scheu->int_inst_window->local_result.power.readOp.dynamic;
-		value+=2*exu->scheu->int_inst_window->local_result.power.searchOp.dynamic;
-		value+=exu->scheu->int_inst_window->local_result.power.writeOp.dynamic;
-		value+=exu->scheu->instruction_selection->power.readOp.dynamic;
-		return value;
-	}
+    // return 0.5*value;
+    return value;
+  }
+  float get_coefficient_dcache_writehits() {
+    float value = 0;
+    value += lsu->dcache.caches->local_result.power.writeOp.dynamic;
+    value += lsu->xbar_shared->power.readOp.dynamic;
+    return value;
+  }
+  float get_coefficient_dcache_writemisses() {
+    float value = 0;
+    value += lsu->dcache.caches->local_result.power.writeOp.dynamic;
+    value += lsu->dcache.caches->local_result.tag_array2->power.readOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? lsu->dcache.caches->local_result.power.writeOp.dynamic
+                 : 0;
+    value += (lsu->cache_p == Write_back)
+                 ? lsu->dcache.missb->local_result.power.searchOp.dynamic
+                 : 0;
+    value += (lsu->cache_p == Write_back)
+                 ? lsu->dcache.ifb->local_result.power.searchOp.dynamic
+                 : 0;
+    value += (lsu->cache_p == Write_back)
+                 ? lsu->dcache.prefetchb->local_result.power.searchOp.dynamic
+                 : 0;
+    value += (lsu->cache_p == Write_back)
+                 ? lsu->dcache.wbb->local_result.power.searchOp.dynamic
+                 : 0;
+    value += (lsu->cache_p == Write_back)
+                 ? lsu->dcache.missb->local_result.power.writeOp.dynamic
+                 : 0;
+    value += (lsu->cache_p == Write_back)
+                 ? lsu->dcache.ifb->local_result.power.writeOp.dynamic
+                 : 0;
+    value += (lsu->cache_p == Write_back)
+                 ? lsu->dcache.prefetchb->local_result.power.writeOp.dynamic
+                 : 0;
+    value += (lsu->cache_p == Write_back)
+                 ? lsu->dcache.wbb->local_result.power.writeOp.dynamic
+                 : 0;
+    // return 1.6*value;
+    return value;
+  }
 
+  float get_coefficient_tcache_readhits() {
+    float value = 0;
+    value += lsu->tcache.caches->local_result.power.readOp.dynamic;
+    value += lsu->xbar_shared->power.readOp.dynamic;
+    // return 0.2*value;
+    return value;
+  }
+  float get_coefficient_tcache_readmisses() {
+    float value = 0;
+    value += lsu->tcache.caches->local_result.power.readOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->tcache.missb->local_result.power.searchOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->tcache.missb->local_result.power.writeOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->tcache.ifb->local_result.power.searchOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->tcache.ifb->local_result.power.writeOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->tcache.prefetchb->local_result.power.searchOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->tcache.prefetchb->local_result.power.writeOp.dynamic;
 
-	float get_coefficient_dcache_readhits()
-	{
-		float value=0;
-		value+=lsu->dcache.caches->local_result.power.readOp.dynamic;
-		value+=lsu->xbar_shared->power.readOp.dynamic;
-		//return 0.5*value;
-		return value;
-	}
-	float get_coefficient_dcache_readmisses()
-	{
-		float value=0;
-		value+=lsu->dcache.caches->local_result.power.readOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->dcache.missb->local_result.power.searchOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->dcache.ifb->local_result.power.searchOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->dcache.prefetchb->local_result.power.searchOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->dcache.missb->local_result.power.writeOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->dcache.ifb->local_result.power.writeOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->dcache.prefetchb->local_result.power.writeOp.dynamic;
+    // return 0.2*value;
+    return value;
+  }
+  float get_coefficient_tcache_readmisses1() {
+    return lsu->tcache.caches->local_result.power.readOp.dynamic;
+  }
+  float get_coefficient_tcache_readmisses2() {
+    float value = 0;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->tcache.missb->local_result.power.searchOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->tcache.missb->local_result.power.writeOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->tcache.ifb->local_result.power.searchOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->tcache.ifb->local_result.power.writeOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->tcache.prefetchb->local_result.power.searchOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->tcache.prefetchb->local_result.power.writeOp.dynamic;
+    return value;
+  }
 
-		//return 0.5*value;
-		return value;
-	}
-	float get_coefficient_dcache_writehits()
-	{
-		float value=0;
-		value+=lsu->dcache.caches->local_result.power.writeOp.dynamic;
-		value+=lsu->xbar_shared->power.readOp.dynamic;
-		return value;
-	}
-	float get_coefficient_dcache_writemisses(){
-		float value=0;
-		value+=lsu->dcache.caches->local_result.power.writeOp.dynamic;
-		value+=lsu->dcache.caches->local_result.tag_array2->power.readOp.dynamic;
-		value+= (lsu->cache_p==Write_back)? lsu->dcache.caches->local_result.power.writeOp.dynamic:0;
-		value+= (lsu->cache_p==Write_back)? lsu->dcache.missb->local_result.power.searchOp.dynamic:0;
-		value+= (lsu->cache_p==Write_back)? lsu->dcache.ifb->local_result.power.searchOp.dynamic:0;
-		value+= (lsu->cache_p==Write_back)? lsu->dcache.prefetchb->local_result.power.searchOp.dynamic:0;
-		value+= (lsu->cache_p==Write_back)? lsu->dcache.wbb->local_result.power.searchOp.dynamic:0;
-		value+= (lsu->cache_p==Write_back)? lsu->dcache.missb->local_result.power.writeOp.dynamic:0;
-		value+= (lsu->cache_p==Write_back)? lsu->dcache.ifb->local_result.power.writeOp.dynamic:0;
-		value+= (lsu->cache_p==Write_back)? lsu->dcache.prefetchb->local_result.power.writeOp.dynamic:0;
-		value+= (lsu->cache_p==Write_back)? lsu->dcache.wbb->local_result.power.writeOp.dynamic:0;
-		//return 1.6*value;
-		return value;
-	}
+  float get_coefficient_ccache_readhits() {
+    // return 1.2*lsu->ccache.caches->local_result.power.readOp.dynamic+lsu->xbar_shared->power.readOp.dynamic;
+    // return 1.2*lsu->ccache.caches->local_result.power.readOp.dynamic+lsu->xbar_shared->power.readOp.dynamic;
+    return lsu->ccache.caches->local_result.power.readOp.dynamic +
+           lsu->xbar_shared->power.readOp.dynamic;
+  }
+  float get_coefficient_ccache_readmisses() {
+    float value = 0;
+    value += lsu->ccache.caches->local_result.power.readOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->ccache.missb->local_result.power.searchOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->ccache.ifb->local_result.power.searchOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->ccache.prefetchb->local_result.power.searchOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->ccache.missb->local_result.power.writeOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->ccache.ifb->local_result.power.writeOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->ccache.prefetchb->local_result.power.writeOp.dynamic;
+    return value;
+  }
 
+  float get_coefficient_sharedmemory_readhits() {
+    float value = 0;
+    value += lsu->sharedmemory.caches->local_result.power.readOp.dynamic;
+    value += lsu->xbar_shared->power.readOp.dynamic;
+    // return 3*value;
+    return value;
+  }
 
+  float get_coefficient_lsq_accesses() {
+    float value = 0;
+    // Changed by Syed -- We have removed LSQ
+    // value+=2*lsu->LSQ->local_result.power.searchOp.dynamic;
+    // value+=2*lsu->LSQ->local_result.power.readOp.dynamic;
+    // value+=2*lsu->LSQ->local_result.power.writeOp.dynamic;
+    return value;
+  }
 
-	float get_coefficient_tcache_readhits()
-	{
-		float value=0;
-		value+=lsu->tcache.caches->local_result.power.readOp.dynamic;
-		value+=lsu->xbar_shared->power.readOp.dynamic;
-		//return 0.2*value;
-		return value;
-	}
-	float get_coefficient_tcache_readmisses()
-	{
-		float value=0;
-		value+= lsu->tcache.caches->local_result.power.readOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.missb->local_result.power.searchOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.missb->local_result.power.writeOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.ifb->local_result.power.searchOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.ifb->local_result.power.writeOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.prefetchb->local_result.power.searchOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.prefetchb->local_result.power.writeOp.dynamic;
+  float get_coefficient_regreads_accesses() {
+    float value = 0;
+    value += ((exu->rfu->IRF->local_result.power.readOp.dynamic / 32) *
+              (4 * 2) /*/1.5*/);
+    value += exu->rfu->xbar_rfu->power.readOp.dynamic / (32 /**1.5*/);
+    value += (exu->rfu->arbiter_rfu->power.readOp.dynamic / 32 /**1.5)*/);
+    value += exu->rfu->OPC->local_result.power.readOp.dynamic /*/1.5*/;
+    return value;
+  }
 
-		//return 0.2*value;
-		return value;
-	}
-	float get_coefficient_tcache_readmisses1(){
+  float get_coefficient_regwrites_accesses() {
+    return ((exu->rfu->IRF->local_result.power.writeOp.dynamic / 32) *
+            (4 * 2) /*/1.5*/);
+  }
 
-		return lsu->tcache.caches->local_result.power.readOp.dynamic;
+  float get_coefficient_noregfileops_accesses() {
+    return ((exu->rfu->xbar_rfu->power.readOp.dynamic / (32 /**1.5*/)) +
+            (exu->rfu->arbiter_rfu->power.readOp.dynamic / (32 /**1.5*/)) +
+            (exu->rfu->OPC->local_result.power.readOp.dynamic /*/(1.5)*/));
+  }
 
-	}
-	float get_coefficient_tcache_readmisses2(){
-		float value=0;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.missb->local_result.power.searchOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.missb->local_result.power.writeOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.ifb->local_result.power.searchOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.ifb->local_result.power.writeOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.prefetchb->local_result.power.searchOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.prefetchb->local_result.power.writeOp.dynamic;
-		return value;
-	}
+  float get_coefficient_ialu_accesses() {
+    // return 10*exu->exeu->per_access_energy*g_tp.sckt_co_eff;
+    return exu->exeu->per_access_energy * g_tp.sckt_co_eff;
+  }
 
+  float get_coefficient_sfu_accesses() {
+    return exu->mul->per_access_energy * g_tp.sckt_co_eff;
+    // return 2.6*exu->mul->per_access_energy*g_tp.sckt_co_eff;
+  }
 
-	float get_coefficient_ccache_readhits()
-	{
-		//return 1.2*lsu->ccache.caches->local_result.power.readOp.dynamic+lsu->xbar_shared->power.readOp.dynamic;
-		//return 1.2*lsu->ccache.caches->local_result.power.readOp.dynamic+lsu->xbar_shared->power.readOp.dynamic;
-		return lsu->ccache.caches->local_result.power.readOp.dynamic+lsu->xbar_shared->power.readOp.dynamic;
-	}
-	float get_coefficient_ccache_readmisses()
-	{
-		float value=0;
-		value+=lsu->ccache.caches->local_result.power.readOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->ccache.missb->local_result.power.searchOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->ccache.ifb->local_result.power.searchOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->ccache.prefetchb->local_result.power.searchOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->ccache.missb->local_result.power.writeOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->ccache.ifb->local_result.power.writeOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->ccache.prefetchb->local_result.power.writeOp.dynamic;
-		return value;
-	}
+  float get_coefficient_fpu_accesses() {
+    // return 3.2*exu->fp_u->per_access_energy*g_tp.sckt_co_eff;
+    return exu->fp_u->per_access_energy * g_tp.sckt_co_eff;
+  }
 
-	float get_coefficient_sharedmemory_readhits()
-	{
-		float value=0;
-		value+=lsu->sharedmemory.caches->local_result.power.readOp.dynamic;
-		value+=lsu->xbar_shared->power.readOp.dynamic;
-		//return 3*value;
-		return value;
-	}
+  float get_coefficient_duty_cycle() {
+    float value = 0;
+    float num_units = 4.0;
+    value = XML->sys.total_cycles * XML->sys.number_of_cores;
+    value *= coredynp.num_pipelines;
+    value /= num_units;
+    value *= corepipe->power.readOp.dynamic;
+    value *= 3;
+    return value;
+    // return 1.5*value;
+  }
 
-	float get_coefficient_lsq_accesses()
-	{
-		float value=0;
-		//Changed by Syed -- We have removed LSQ
-		//value+=2*lsu->LSQ->local_result.power.searchOp.dynamic;
-		//value+=2*lsu->LSQ->local_result.power.readOp.dynamic;
-		//value+=2*lsu->LSQ->local_result.power.writeOp.dynamic;
-		return value;
-	}
-
-	float get_coefficient_regreads_accesses(){
-		float value=0;
-		value+=((exu->rfu->IRF->local_result.power.readOp.dynamic/32)*(4*2)/*/1.5*/);
-		value+=exu->rfu->xbar_rfu->power.readOp.dynamic/(32/**1.5*/);
-		value+=(exu->rfu->arbiter_rfu->power.readOp.dynamic/32/**1.5)*/);
-		value+=exu->rfu->OPC->local_result.power.readOp.dynamic/*/1.5*/;
-		return value;
-	}
-
-	float get_coefficient_regwrites_accesses(){return ((exu->rfu->IRF->local_result.power.writeOp.dynamic/32)*(4*2)/*/1.5*/);}
-
-	float get_coefficient_noregfileops_accesses(){return ((exu->rfu->xbar_rfu->power.readOp.dynamic/(32/**1.5*/))+
-			(exu->rfu->arbiter_rfu->power.readOp.dynamic/(32/**1.5*/))+
-			(exu->rfu->OPC->local_result.power.readOp.dynamic/*/(1.5)*/));}
-
-	float get_coefficient_ialu_accesses(){
-		//return 10*exu->exeu->per_access_energy*g_tp.sckt_co_eff;
-		return exu->exeu->per_access_energy*g_tp.sckt_co_eff;
-		}
-
-	float get_coefficient_sfu_accesses(){
-		return exu->mul->per_access_energy*g_tp.sckt_co_eff;
-		//return 2.6*exu->mul->per_access_energy*g_tp.sckt_co_eff;
-		}
-
-	float get_coefficient_fpu_accesses(){
-		//return 3.2*exu->fp_u->per_access_energy*g_tp.sckt_co_eff;
-		return exu->fp_u->per_access_energy*g_tp.sckt_co_eff;
-		}
-
-	float get_coefficient_duty_cycle()
-	{
-		float value=0;
-		float num_units=4.0;
-		value=XML->sys.total_cycles * XML->sys.number_of_cores;
-		value*=coredynp.num_pipelines;
-		value/=num_units;
-		value*=corepipe->power.readOp.dynamic;
-		value*=3;
-		return value;
-		//return 1.5*value;
-	}
-
-
-
-	void compute();
-	~Core();
+  void compute();
+  ~Core();
 };
 
 #endif /* CORE_H_ */

--- a/src/gpuwattch/core.h
+++ b/src/gpuwattch/core.h
@@ -29,530 +29,470 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:
-**
+*      Modified by:												   *
 *      Jingwen Leng, Univeristy of Texas, Austin                   *
 *      Syed Gilani, University of Wisconsin–Madison                *
 *      Tayler Hetherington, University of British Columbia         *
 *      Ahmed ElTantawy, University of British Columbia             *
 ********************************************************************/
 
+
 #ifndef CORE_H_
 #define CORE_H_
 
 #include "XML_Parse.h"
-#include "array.h"
-#include "basic_components.h"
-#include "cacti/arbiter.h"
-#include "cacti/crossbar.h"
-#include "cacti/parameter.h"
-#include "interconnect.h"
 #include "logic.h"
-#include "noc.h"
+#include "cacti/parameter.h"
+#include "array.h"
+#include "interconnect.h"
+#include "basic_components.h"
 #include "sharedcache.h"
+#include "cacti/crossbar.h"
+#include "cacti/arbiter.h"
+#include "noc.h"
 
-class BranchPredictor : public Component {
- public:
-  ParseXML *XML;
-  int ithCore;
-  InputParameter interface_ip;
-  CoreDynParam coredynp;
-  double clockRate, executionTime;
-  double scktRatio, chip_PR_overhead, macro_PR_overhead;
-  ArrayST *globalBPT;
-  ArrayST *localBPT;
-  ArrayST *L1_localBPT;
-  ArrayST *L2_localBPT;
-  ArrayST *chooser;
-  ArrayST *RAS;
-  bool exist;
+class BranchPredictor :public Component {
+  public:
 
-  BranchPredictor(ParseXML *XML_interface, int ithCore_,
-                  InputParameter *interface_ip_, const CoreDynParam &dyn_p_,
-                  bool exsit = true);
-  void computeEnergy(bool is_tdp = true);
-  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
-  ~BranchPredictor();
+	ParseXML *XML;
+	int  ithCore;
+	InputParameter interface_ip;
+	CoreDynParam  coredynp;
+	double clockRate,executionTime;
+	double scktRatio, chip_PR_overhead, macro_PR_overhead;
+	ArrayST * globalBPT;
+	ArrayST * localBPT;
+	ArrayST * L1_localBPT;
+	ArrayST * L2_localBPT;
+	ArrayST * chooser;
+	ArrayST * RAS;
+	bool exist;
+
+	BranchPredictor(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_,const CoreDynParam & dyn_p_, bool exsit=true);
+    void computeEnergy(bool is_tdp=true);
+    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
+	~BranchPredictor();
 };
 
-class InstFetchU : public Component {
- public:
-  ParseXML *XML;
-  int ithCore;
-  InputParameter interface_ip;
-  CoreDynParam coredynp;
-  double clockRate, executionTime;
-  double scktRatio, chip_PR_overhead, macro_PR_overhead;
-  enum Cache_policy cache_p;
-  InstCache icache;
-  ArrayST *IB;
-  ArrayST *BTB;
-  BranchPredictor *BPT;
-  inst_decoder *ID_inst;
-  inst_decoder *ID_operand;
-  inst_decoder *ID_misc;
-  bool exist;
 
-  InstFetchU(ParseXML *XML_interface, int ithCore_,
-             InputParameter *interface_ip_, const CoreDynParam &dyn_p_,
-             bool exsit = true);
-  void computeEnergy(bool is_tdp = true);
-  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
-  ~InstFetchU();
+class InstFetchU :public Component {
+  public:
+
+	ParseXML *XML;
+	int  ithCore;
+	InputParameter interface_ip;
+	CoreDynParam  coredynp;
+	double clockRate,executionTime;
+	double scktRatio, chip_PR_overhead, macro_PR_overhead;
+	enum Cache_policy cache_p;
+	InstCache icache;
+	ArrayST * IB;
+	ArrayST * BTB;
+	BranchPredictor * BPT;
+	inst_decoder * ID_inst;
+	inst_decoder * ID_operand;
+	inst_decoder * ID_misc;
+	bool exist;
+
+	InstFetchU(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_,const CoreDynParam & dyn_p_, bool exsit=true);
+    void computeEnergy(bool is_tdp=true);
+    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
+	~InstFetchU();
 };
 
-class SchedulerU : public Component {
- public:
-  ParseXML *XML;
-  int ithCore;
-  InputParameter interface_ip;
-  CoreDynParam coredynp;
-  double clockRate, executionTime;
-  double scktRatio, chip_PR_overhead, macro_PR_overhead;
-  double Iw_height, fp_Iw_height, ROB_height;
-  ArrayST *int_inst_window;
-  ArrayST *fp_inst_window;
-  ArrayST *ROB;
-  selection_logic *instruction_selection;
-  bool exist;
 
-  SchedulerU(ParseXML *XML_interface, int ithCore_,
-             InputParameter *interface_ip_, const CoreDynParam &dyn_p_,
-             bool exist_ = true);
-  void computeEnergy(bool is_tdp = true);
-  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
-  ~SchedulerU();
+class SchedulerU :public Component {
+  public:
+
+	ParseXML *XML;
+	int  ithCore;
+	InputParameter interface_ip;
+	CoreDynParam  coredynp;
+	double clockRate,executionTime;
+	double scktRatio, chip_PR_overhead, macro_PR_overhead;
+	double Iw_height, fp_Iw_height,ROB_height;
+	ArrayST         * int_inst_window;
+	ArrayST         * fp_inst_window;
+	ArrayST         * ROB;
+    selection_logic * instruction_selection;
+    bool exist;
+
+    SchedulerU(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_,const CoreDynParam & dyn_p_, bool exist_=true);
+    void computeEnergy(bool is_tdp=true);
+    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
+	~SchedulerU();
 };
 
-class RENAMINGU : public Component {
- public:
-  ParseXML *XML;
-  int ithCore;
-  InputParameter interface_ip;
-  double clockRate, executionTime;
-  CoreDynParam coredynp;
-  ArrayST *iFRAT;
-  ArrayST *fFRAT;
-  ArrayST *iRRAT;
-  ArrayST *fRRAT;
-  ArrayST *ifreeL;
-  ArrayST *ffreeL;
-  dep_resource_conflict_check *idcl;
-  dep_resource_conflict_check *fdcl;
-  ArrayST *RAHT;  // register alias history table Used to store GC
-  bool exist;
+class RENAMINGU :public Component {
+  public:
 
-  RENAMINGU(ParseXML *XML_interface, int ithCore_,
-            InputParameter *interface_ip_, const CoreDynParam &dyn_p_,
-            bool exist_ = true);
-  void computeEnergy(bool is_tdp = true);
-  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
-  ~RENAMINGU();
+	ParseXML *XML;
+	int  ithCore;
+	InputParameter interface_ip;
+	double clockRate,executionTime;
+	CoreDynParam  coredynp;
+	ArrayST * iFRAT;
+	ArrayST * fFRAT;
+	ArrayST * iRRAT;
+	ArrayST * fRRAT;
+	ArrayST * ifreeL;
+	ArrayST * ffreeL;
+	dep_resource_conflict_check * idcl;
+	dep_resource_conflict_check * fdcl;
+	ArrayST * RAHT;//register alias history table Used to store GC
+	bool exist;
+
+
+	RENAMINGU(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_, bool exist_=true);
+    void computeEnergy(bool is_tdp=true);
+    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
+	~RENAMINGU();
 };
 
-class LoadStoreU : public Component {
- public:
-  ParseXML *XML;
-  int ithCore;
-  InputParameter interface_ip;
-  CoreDynParam coredynp;
-  enum Cache_policy cache_p;
-  double clockRate, executionTime;
-  double scktRatio, chip_PR_overhead, macro_PR_overhead;
-  double lsq_height;
-  DataCache dcache;
-  DataCache ccache;
-  DataCache tcache;
-  DataCache sharedmemory;
-  ArrayST *LSQ;  // it is actually the store queue but for inorder processors it
-                 // serves as both loadQ and StoreQ
-  ArrayST *LoadQ;
-  vector<NoC *> nocs;
-  bool exist;
-  Crossbar *xbar_shared;
-  Component noc;
-  LoadStoreU(ParseXML *XML_interface, int ithCore_,
-             InputParameter *interface_ip_, const CoreDynParam &dyn_p_,
-             bool exist_ = true);
-  void computeEnergy(bool is_tdp = true);
-  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
-  void displayDeviceType(int device_type_,
-                         uint32_t indent);  // Added by Syed Gilani
+class LoadStoreU :public Component {
+  public:
 
-  ~LoadStoreU();
+	ParseXML *XML;
+	int  ithCore;
+	InputParameter interface_ip;
+	CoreDynParam  coredynp;
+	enum Cache_policy cache_p;
+	double clockRate,executionTime;
+	double scktRatio, chip_PR_overhead, macro_PR_overhead;
+	double lsq_height;
+	DataCache dcache;
+	DataCache ccache;
+	DataCache tcache;
+	DataCache sharedmemory;
+	ArrayST * LSQ;//it is actually the store queue but for inorder processors it serves as both loadQ and StoreQ
+	ArrayST * LoadQ;
+	vector<NoC *>  nocs;
+	bool exist;
+   Crossbar *xbar_shared;
+	Component noc;
+	LoadStoreU(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_,const CoreDynParam & dyn_p_, bool exist_=true);
+    void computeEnergy(bool is_tdp=true);
+    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
+	 void displayDeviceType(int device_type_, uint32_t indent);//Added by Syed Gilani
+
+	~LoadStoreU();
 };
 
-class MemManU : public Component {
- public:
-  ParseXML *XML;
-  int ithCore;
-  InputParameter interface_ip;
-  CoreDynParam coredynp;
-  double clockRate, executionTime;
-  double scktRatio, chip_PR_overhead, macro_PR_overhead;
-  ArrayST *itlb;
-  ArrayST *dtlb;
-  bool exist;
+class MemManU :public Component {
+  public:
 
-  MemManU(ParseXML *XML_interface, int ithCore_, InputParameter *interface_ip_,
-          const CoreDynParam &dyn_p_, bool exist_ = false);
-  void computeEnergy(bool is_tdp = true);
-  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
-  ~MemManU();
+	ParseXML *XML;
+	int  ithCore;
+	InputParameter interface_ip;
+	CoreDynParam  coredynp;
+	double clockRate,executionTime;
+	double scktRatio, chip_PR_overhead, macro_PR_overhead;
+	ArrayST * itlb;
+	ArrayST * dtlb;
+	bool exist;
+
+	MemManU(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_,const CoreDynParam & dyn_p_, bool exist_=false);
+    void computeEnergy(bool is_tdp=true);
+    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
+	~MemManU();
 };
 
-class RegFU : public Component {
- public:
-  ParseXML *XML;
-  int ithCore;
-  InputParameter interface_ip;
-  CoreDynParam coredynp;
-  double clockRate, executionTime;
-  double scktRatio, chip_PR_overhead, macro_PR_overhead;
-  double int_regfile_height, fp_regfile_height;
-  ArrayST *IRF;
-  ArrayST *FRF;
-  ArrayST *RFWIN;
-  ArrayST *OPC;  // Operand collectors
-  bool exist;
-  double exClockRate;
-  // OC Modelling (Syed)
-  Crossbar *xbar_rfu;
-  MCPAT_Arbiter *arbiter_rfu;
-  RegFU(ParseXML *XML_interface, int ithCore_, InputParameter *interface_ip_,
-        const CoreDynParam &dyn_p_, double exClockRate, bool exist_ = true);
-  void computeEnergy(bool is_tdp = true);
-  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
-  ~RegFU();
+class RegFU :public Component {
+  public:
+
+	ParseXML *XML;
+	int  ithCore;
+	InputParameter interface_ip;
+	CoreDynParam  coredynp;
+	double clockRate,executionTime;
+	double scktRatio, chip_PR_overhead, macro_PR_overhead;
+	double int_regfile_height, fp_regfile_height;
+	ArrayST * IRF;
+	ArrayST * FRF;
+	ArrayST * RFWIN;
+	ArrayST * OPC;//Operand collectors
+	bool exist;
+   double exClockRate; 
+	//OC Modelling (Syed)
+	Crossbar * xbar_rfu;
+   MCPAT_Arbiter * arbiter_rfu;
+	RegFU(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_,const CoreDynParam & dyn_p_, double exClockRate, bool exist_=true);
+    void computeEnergy(bool is_tdp=true);
+    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
+	~RegFU();
 };
 
-class EXECU : public Component {
- public:
-  ParseXML *XML;
-  int ithCore;
-  InputParameter interface_ip;
-  double clockRate, executionTime;
-  double scktRatio, chip_PR_overhead, macro_PR_overhead;
-  double lsq_height;
-  CoreDynParam coredynp;
-  RegFU *rfu;
-  SchedulerU *scheu;
-  FunctionalUnit *fp_u;
-  FunctionalUnit *exeu;
-  FunctionalUnit *mul;
-  interconnect *int_bypass;
-  interconnect *intTagBypass;
-  interconnect *int_mul_bypass;
-  interconnect *intTag_mul_Bypass;
-  interconnect *fp_bypass;
-  interconnect *fpTagBypass;
-  bool exist;
-  double rf_fu_clockRate;
-  Component bypass;
+class EXECU :public Component {
+  public:
 
-  EXECU(ParseXML *XML_interface, int ithCore_, InputParameter *interface_ip_,
-        double lsq_height_, const CoreDynParam &dyn_p_, double exClockRate,
-        bool exist_);
-  void computeEnergy(bool is_tdp = true);
-  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
-  ~EXECU();
+	ParseXML *XML;
+	int  ithCore;
+	InputParameter interface_ip;
+	double clockRate,executionTime;
+	double scktRatio, chip_PR_overhead, macro_PR_overhead;
+	double lsq_height;
+	CoreDynParam  coredynp;
+	RegFU          * rfu;
+	SchedulerU     * scheu;
+    FunctionalUnit * fp_u;
+    FunctionalUnit * exeu;
+    FunctionalUnit * mul;
+	interconnect * int_bypass;
+	interconnect * intTagBypass;
+	interconnect * int_mul_bypass;
+	interconnect * intTag_mul_Bypass;
+	interconnect * fp_bypass;
+	interconnect * fpTagBypass;
+	bool exist;
+	double rf_fu_clockRate;
+	Component  bypass;
+
+
+	EXECU(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_, double lsq_height_,const CoreDynParam & dyn_p_, double exClockRate, bool exist_);
+    void computeEnergy(bool is_tdp=true);
+	void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
+	~EXECU();
 };
 
-class Core : public Component {
- public:
-  ParseXML *XML;
-  int ithCore;
-  InputParameter interface_ip;
-  double clockRate, executionTime;
-  double exClockRate;
-  double scktRatio, chip_PR_overhead, macro_PR_overhead;
-  InstFetchU *ifu;
-  LoadStoreU *lsu;
-  MemManU *mmu;
-  EXECU *exu;
-  RENAMINGU *rnu;
-  double IdleCoreEnergy;
-  double IdlePower_PerCore;
-  Pipeline *corepipe;
-  UndiffCore *undiffCore;
-  SharedCache *l2cache;
-  CoreDynParam coredynp;
-  double Pipeline_energy;
-  // full_decoder 	inst_decoder;
-  // clock_network	clockNetwork;
-  Core(ParseXML *XML_interface, int ithCore_, InputParameter *interface_ip_);
-  void set_core_param();
-  void computeEnergy(bool is_tdp = true);
-  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
 
-  float get_coefficient_icache_hits() {
-    // return 1.5*ifu->icache.caches->local_result.power.readOp.dynamic;
-    return ifu->icache.caches->local_result.power.readOp.dynamic;
-  }
+class Core :public Component {
+  public:
 
-  float get_coefficient_icache_misses() {
-    float value = 0;
-    value += ifu->icache.caches->local_result.power.writeOp.dynamic;
-    value += ifu->icache.caches->local_result.power.readOp.dynamic;
-    value += ifu->icache.missb->local_result.power.searchOp.dynamic;
-    value += ifu->icache.missb->local_result.power.writeOp.dynamic;
-    value += ifu->icache.ifb->local_result.power.searchOp.dynamic;
-    value += ifu->icache.ifb->local_result.power.writeOp.dynamic;
-    value += ifu->icache.prefetchb->local_result.power.searchOp.dynamic;
-    value += ifu->icache.prefetchb->local_result.power.writeOp.dynamic;
-    return value;
-  }
+	ParseXML *XML;
+	int  ithCore;
+	InputParameter interface_ip;
+	double clockRate,executionTime;
+	double exClockRate;
+	double scktRatio, chip_PR_overhead, macro_PR_overhead;
+	InstFetchU * ifu;
+	LoadStoreU * lsu;
+	MemManU    * mmu;
+	EXECU      * exu;
+	RENAMINGU  * rnu;
+	double IdleCoreEnergy;
+	double IdlePower_PerCore;
+    Pipeline   * corepipe;
+    UndiffCore * undiffCore;
+    SharedCache * l2cache;
+    CoreDynParam  coredynp;
+	double Pipeline_energy;
+    //full_decoder 	inst_decoder;
+    //clock_network	clockNetwork;
+	Core(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_);
+	void set_core_param();
+	void computeEnergy(bool is_tdp=true);
+	void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
 
-  float get_coefficient_tot_insts() {
-    float value = 0;
-    value += ifu->IB->local_result.power.readOp.dynamic;
-    value += ifu->IB->local_result.power.writeOp.dynamic;
-    value += ifu->ID_inst->power_t.readOp.dynamic;
-    value += ifu->ID_operand->power_t.readOp.dynamic;
-    value += ifu->ID_misc->power_t.readOp.dynamic;
-    return value;
-  }
+	float get_coefficient_icache_hits(){
+		//return 1.5*ifu->icache.caches->local_result.power.readOp.dynamic;
+		return ifu->icache.caches->local_result.power.readOp.dynamic;
+	}
 
-  float get_coefficient_fpint_insts() {
-    float value = 0;
-    value += exu->scheu->int_inst_window->local_result.power.readOp.dynamic;
-    value +=
-        2 * exu->scheu->int_inst_window->local_result.power.searchOp.dynamic;
-    value += exu->scheu->int_inst_window->local_result.power.writeOp.dynamic;
-    value += exu->scheu->instruction_selection->power.readOp.dynamic;
-    return value;
-  }
+	float get_coefficient_icache_misses(){
+		float value=0;
+		value+=ifu->icache.caches->local_result.power.writeOp.dynamic;
+		value+=ifu->icache.caches->local_result.power.readOp.dynamic;
+		value+=ifu->icache.missb->local_result.power.searchOp.dynamic;
+		value+=ifu->icache.missb->local_result.power.writeOp.dynamic;
+		value+=ifu->icache.ifb->local_result.power.searchOp.dynamic;
+		value+= ifu->icache.ifb->local_result.power.writeOp.dynamic;
+		value+= ifu->icache.prefetchb->local_result.power.searchOp.dynamic;
+		value+=ifu->icache.prefetchb->local_result.power.writeOp.dynamic;
+		return value;
+	}
 
-  float get_coefficient_dcache_readhits() {
-    float value = 0;
-    value += lsu->dcache.caches->local_result.power.readOp.dynamic;
-    value += lsu->xbar_shared->power.readOp.dynamic;
-    // return 0.5*value;
-    return value;
-  }
-  float get_coefficient_dcache_readmisses() {
-    float value = 0;
-    value += lsu->dcache.caches->local_result.power.readOp.dynamic;
-    value += (lsu->cache_p == Write_back)
-                 ? 0
-                 : lsu->dcache.missb->local_result.power.searchOp.dynamic;
-    value += (lsu->cache_p == Write_back)
-                 ? 0
-                 : lsu->dcache.ifb->local_result.power.searchOp.dynamic;
-    value += (lsu->cache_p == Write_back)
-                 ? 0
-                 : lsu->dcache.prefetchb->local_result.power.searchOp.dynamic;
-    value += (lsu->cache_p == Write_back)
-                 ? 0
-                 : lsu->dcache.missb->local_result.power.writeOp.dynamic;
-    value += (lsu->cache_p == Write_back)
-                 ? 0
-                 : lsu->dcache.ifb->local_result.power.writeOp.dynamic;
-    value += (lsu->cache_p == Write_back)
-                 ? 0
-                 : lsu->dcache.prefetchb->local_result.power.writeOp.dynamic;
+	float get_coefficient_tot_insts(){
+		float value=0;
+		value+=ifu->IB->local_result.power.readOp.dynamic;
+		value+=ifu->IB->local_result.power.writeOp.dynamic;
+		value+=ifu->ID_inst->power_t.readOp.dynamic;
+		value+=ifu->ID_operand->power_t.readOp.dynamic;
+		value+=ifu->ID_misc->power_t.readOp.dynamic;
+		return value;
+	}
 
-    // return 0.5*value;
-    return value;
-  }
-  float get_coefficient_dcache_writehits() {
-    float value = 0;
-    value += lsu->dcache.caches->local_result.power.writeOp.dynamic;
-    value += lsu->xbar_shared->power.readOp.dynamic;
-    return value;
-  }
-  float get_coefficient_dcache_writemisses() {
-    float value = 0;
-    value += lsu->dcache.caches->local_result.power.writeOp.dynamic;
-    value += lsu->dcache.caches->local_result.tag_array2->power.readOp.dynamic;
-    value += (lsu->cache_p == Write_back)
-                 ? lsu->dcache.caches->local_result.power.writeOp.dynamic
-                 : 0;
-    value += (lsu->cache_p == Write_back)
-                 ? lsu->dcache.missb->local_result.power.searchOp.dynamic
-                 : 0;
-    value += (lsu->cache_p == Write_back)
-                 ? lsu->dcache.ifb->local_result.power.searchOp.dynamic
-                 : 0;
-    value += (lsu->cache_p == Write_back)
-                 ? lsu->dcache.prefetchb->local_result.power.searchOp.dynamic
-                 : 0;
-    value += (lsu->cache_p == Write_back)
-                 ? lsu->dcache.wbb->local_result.power.searchOp.dynamic
-                 : 0;
-    value += (lsu->cache_p == Write_back)
-                 ? lsu->dcache.missb->local_result.power.writeOp.dynamic
-                 : 0;
-    value += (lsu->cache_p == Write_back)
-                 ? lsu->dcache.ifb->local_result.power.writeOp.dynamic
-                 : 0;
-    value += (lsu->cache_p == Write_back)
-                 ? lsu->dcache.prefetchb->local_result.power.writeOp.dynamic
-                 : 0;
-    value += (lsu->cache_p == Write_back)
-                 ? lsu->dcache.wbb->local_result.power.writeOp.dynamic
-                 : 0;
-    // return 1.6*value;
-    return value;
-  }
+	float get_coefficient_fpint_insts(){
+		float value=0;
+		value+=exu->scheu->int_inst_window->local_result.power.readOp.dynamic;
+		value+=2*exu->scheu->int_inst_window->local_result.power.searchOp.dynamic;
+		value+=exu->scheu->int_inst_window->local_result.power.writeOp.dynamic;
+		value+=exu->scheu->instruction_selection->power.readOp.dynamic;
+		return value;
+	}
 
-  float get_coefficient_tcache_readhits() {
-    float value = 0;
-    value += lsu->tcache.caches->local_result.power.readOp.dynamic;
-    value += lsu->xbar_shared->power.readOp.dynamic;
-    // return 0.2*value;
-    return value;
-  }
-  float get_coefficient_tcache_readmisses() {
-    float value = 0;
-    value += lsu->tcache.caches->local_result.power.readOp.dynamic;
-    value += (lsu->cache_p == Write_back)
-                 ? 0
-                 : lsu->tcache.missb->local_result.power.searchOp.dynamic;
-    value += (lsu->cache_p == Write_back)
-                 ? 0
-                 : lsu->tcache.missb->local_result.power.writeOp.dynamic;
-    value += (lsu->cache_p == Write_back)
-                 ? 0
-                 : lsu->tcache.ifb->local_result.power.searchOp.dynamic;
-    value += (lsu->cache_p == Write_back)
-                 ? 0
-                 : lsu->tcache.ifb->local_result.power.writeOp.dynamic;
-    value += (lsu->cache_p == Write_back)
-                 ? 0
-                 : lsu->tcache.prefetchb->local_result.power.searchOp.dynamic;
-    value += (lsu->cache_p == Write_back)
-                 ? 0
-                 : lsu->tcache.prefetchb->local_result.power.writeOp.dynamic;
 
-    // return 0.2*value;
-    return value;
-  }
-  float get_coefficient_tcache_readmisses1() {
-    return lsu->tcache.caches->local_result.power.readOp.dynamic;
-  }
-  float get_coefficient_tcache_readmisses2() {
-    float value = 0;
-    value += (lsu->cache_p == Write_back)
-                 ? 0
-                 : lsu->tcache.missb->local_result.power.searchOp.dynamic;
-    value += (lsu->cache_p == Write_back)
-                 ? 0
-                 : lsu->tcache.missb->local_result.power.writeOp.dynamic;
-    value += (lsu->cache_p == Write_back)
-                 ? 0
-                 : lsu->tcache.ifb->local_result.power.searchOp.dynamic;
-    value += (lsu->cache_p == Write_back)
-                 ? 0
-                 : lsu->tcache.ifb->local_result.power.writeOp.dynamic;
-    value += (lsu->cache_p == Write_back)
-                 ? 0
-                 : lsu->tcache.prefetchb->local_result.power.searchOp.dynamic;
-    value += (lsu->cache_p == Write_back)
-                 ? 0
-                 : lsu->tcache.prefetchb->local_result.power.writeOp.dynamic;
-    return value;
-  }
+	float get_coefficient_dcache_readhits()
+	{
+		float value=0;
+		value+=lsu->dcache.caches->local_result.power.readOp.dynamic;
+		value+=lsu->xbar_shared->power.readOp.dynamic;
+		//return 0.5*value;
+		return value;
+	}
+	float get_coefficient_dcache_readmisses()
+	{
+		float value=0;
+		value+=lsu->dcache.caches->local_result.power.readOp.dynamic;
+		value+=(lsu->cache_p==Write_back)?  0:lsu->dcache.missb->local_result.power.searchOp.dynamic;
+		value+=(lsu->cache_p==Write_back)?  0:lsu->dcache.ifb->local_result.power.searchOp.dynamic;
+		value+=(lsu->cache_p==Write_back)?  0:lsu->dcache.prefetchb->local_result.power.searchOp.dynamic;
+		value+=(lsu->cache_p==Write_back)?  0:lsu->dcache.missb->local_result.power.writeOp.dynamic;
+		value+=(lsu->cache_p==Write_back)?  0:lsu->dcache.ifb->local_result.power.writeOp.dynamic;
+		value+=(lsu->cache_p==Write_back)?  0:lsu->dcache.prefetchb->local_result.power.writeOp.dynamic;
 
-  float get_coefficient_ccache_readhits() {
-    // return
-    // 1.2*lsu->ccache.caches->local_result.power.readOp.dynamic+lsu->xbar_shared->power.readOp.dynamic;
-    // return
-    // 1.2*lsu->ccache.caches->local_result.power.readOp.dynamic+lsu->xbar_shared->power.readOp.dynamic;
-    return lsu->ccache.caches->local_result.power.readOp.dynamic +
-           lsu->xbar_shared->power.readOp.dynamic;
-  }
-  float get_coefficient_ccache_readmisses() {
-    float value = 0;
-    value += lsu->ccache.caches->local_result.power.readOp.dynamic;
-    value += (lsu->cache_p == Write_back)
-                 ? 0
-                 : lsu->ccache.missb->local_result.power.searchOp.dynamic;
-    value += (lsu->cache_p == Write_back)
-                 ? 0
-                 : lsu->ccache.ifb->local_result.power.searchOp.dynamic;
-    value += (lsu->cache_p == Write_back)
-                 ? 0
-                 : lsu->ccache.prefetchb->local_result.power.searchOp.dynamic;
-    value += (lsu->cache_p == Write_back)
-                 ? 0
-                 : lsu->ccache.missb->local_result.power.writeOp.dynamic;
-    value += (lsu->cache_p == Write_back)
-                 ? 0
-                 : lsu->ccache.ifb->local_result.power.writeOp.dynamic;
-    value += (lsu->cache_p == Write_back)
-                 ? 0
-                 : lsu->ccache.prefetchb->local_result.power.writeOp.dynamic;
-    return value;
-  }
+		//return 0.5*value;
+		return value;
+	}
+	float get_coefficient_dcache_writehits()
+	{
+		float value=0;
+		value+=lsu->dcache.caches->local_result.power.writeOp.dynamic;
+		value+=lsu->xbar_shared->power.readOp.dynamic;
+		return value;
+	}
+	float get_coefficient_dcache_writemisses(){
+		float value=0;
+		value+=lsu->dcache.caches->local_result.power.writeOp.dynamic;
+		value+=lsu->dcache.caches->local_result.tag_array2->power.readOp.dynamic;
+		value+= (lsu->cache_p==Write_back)? lsu->dcache.caches->local_result.power.writeOp.dynamic:0;
+		value+= (lsu->cache_p==Write_back)? lsu->dcache.missb->local_result.power.searchOp.dynamic:0;
+		value+= (lsu->cache_p==Write_back)? lsu->dcache.ifb->local_result.power.searchOp.dynamic:0;
+		value+= (lsu->cache_p==Write_back)? lsu->dcache.prefetchb->local_result.power.searchOp.dynamic:0;
+		value+= (lsu->cache_p==Write_back)? lsu->dcache.wbb->local_result.power.searchOp.dynamic:0;
+		value+= (lsu->cache_p==Write_back)? lsu->dcache.missb->local_result.power.writeOp.dynamic:0;
+		value+= (lsu->cache_p==Write_back)? lsu->dcache.ifb->local_result.power.writeOp.dynamic:0;
+		value+= (lsu->cache_p==Write_back)? lsu->dcache.prefetchb->local_result.power.writeOp.dynamic:0;
+		value+= (lsu->cache_p==Write_back)? lsu->dcache.wbb->local_result.power.writeOp.dynamic:0;
+		//return 1.6*value;
+		return value;
+	}
 
-  float get_coefficient_sharedmemory_readhits() {
-    float value = 0;
-    value += lsu->sharedmemory.caches->local_result.power.readOp.dynamic;
-    value += lsu->xbar_shared->power.readOp.dynamic;
-    // return 3*value;
-    return value;
-  }
 
-  float get_coefficient_lsq_accesses() {
-    float value = 0;
-    // Changed by Syed -- We have removed LSQ
-    // value+=2*lsu->LSQ->local_result.power.searchOp.dynamic;
-    // value+=2*lsu->LSQ->local_result.power.readOp.dynamic;
-    // value+=2*lsu->LSQ->local_result.power.writeOp.dynamic;
-    return value;
-  }
 
-  float get_coefficient_regreads_accesses() {
-    float value = 0;
-    value += ((exu->rfu->IRF->local_result.power.readOp.dynamic / 32) *
-              (4 * 2) /*/1.5*/);
-    value += exu->rfu->xbar_rfu->power.readOp.dynamic / (32 /**1.5*/);
-    value += (exu->rfu->arbiter_rfu->power.readOp.dynamic / 32 /**1.5)*/);
-    value += exu->rfu->OPC->local_result.power.readOp.dynamic /*/1.5*/;
-    return value;
-  }
+	float get_coefficient_tcache_readhits()
+	{
+		float value=0;
+		value+=lsu->tcache.caches->local_result.power.readOp.dynamic;
+		value+=lsu->xbar_shared->power.readOp.dynamic;
+		//return 0.2*value;
+		return value;
+	}
+	float get_coefficient_tcache_readmisses()
+	{
+		float value=0;
+		value+= lsu->tcache.caches->local_result.power.readOp.dynamic;
+		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.missb->local_result.power.searchOp.dynamic;
+		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.missb->local_result.power.writeOp.dynamic;
+		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.ifb->local_result.power.searchOp.dynamic;
+		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.ifb->local_result.power.writeOp.dynamic;
+		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.prefetchb->local_result.power.searchOp.dynamic;
+		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.prefetchb->local_result.power.writeOp.dynamic;
 
-  float get_coefficient_regwrites_accesses() {
-    return ((exu->rfu->IRF->local_result.power.writeOp.dynamic / 32) *
-            (4 * 2) /*/1.5*/);
-  }
+		//return 0.2*value;
+		return value;
+	}
+	float get_coefficient_tcache_readmisses1(){
 
-  float get_coefficient_noregfileops_accesses() {
-    return ((exu->rfu->xbar_rfu->power.readOp.dynamic / (32 /**1.5*/)) +
-            (exu->rfu->arbiter_rfu->power.readOp.dynamic / (32 /**1.5*/)) +
-            (exu->rfu->OPC->local_result.power.readOp.dynamic /*/(1.5)*/));
-  }
+		return lsu->tcache.caches->local_result.power.readOp.dynamic;
 
-  float get_coefficient_ialu_accesses() {
-    // return 10*exu->exeu->per_access_energy*g_tp.sckt_co_eff;
-    return exu->exeu->per_access_energy * g_tp.sckt_co_eff;
-  }
+	}
+	float get_coefficient_tcache_readmisses2(){
+		float value=0;
+		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.missb->local_result.power.searchOp.dynamic;
+		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.missb->local_result.power.writeOp.dynamic;
+		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.ifb->local_result.power.searchOp.dynamic;
+		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.ifb->local_result.power.writeOp.dynamic;
+		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.prefetchb->local_result.power.searchOp.dynamic;
+		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.prefetchb->local_result.power.writeOp.dynamic;
+		return value;
+	}
 
-  float get_coefficient_sfu_accesses() {
-    return exu->mul->per_access_energy * g_tp.sckt_co_eff;
-    // return 2.6*exu->mul->per_access_energy*g_tp.sckt_co_eff;
-  }
 
-  float get_coefficient_fpu_accesses() {
-    // return 3.2*exu->fp_u->per_access_energy*g_tp.sckt_co_eff;
-    return exu->fp_u->per_access_energy * g_tp.sckt_co_eff;
-  }
+	float get_coefficient_ccache_readhits()
+	{
+		//return 1.2*lsu->ccache.caches->local_result.power.readOp.dynamic+lsu->xbar_shared->power.readOp.dynamic;
+		//return 1.2*lsu->ccache.caches->local_result.power.readOp.dynamic+lsu->xbar_shared->power.readOp.dynamic;
+		return lsu->ccache.caches->local_result.power.readOp.dynamic+lsu->xbar_shared->power.readOp.dynamic;
+	}
+	float get_coefficient_ccache_readmisses()
+	{
+		float value=0;
+		value+=lsu->ccache.caches->local_result.power.readOp.dynamic;
+		value+=(lsu->cache_p==Write_back)?  0:lsu->ccache.missb->local_result.power.searchOp.dynamic;
+		value+=(lsu->cache_p==Write_back)?  0:lsu->ccache.ifb->local_result.power.searchOp.dynamic;
+		value+=(lsu->cache_p==Write_back)?  0:lsu->ccache.prefetchb->local_result.power.searchOp.dynamic;
+		value+=(lsu->cache_p==Write_back)?  0:lsu->ccache.missb->local_result.power.writeOp.dynamic;
+		value+=(lsu->cache_p==Write_back)?  0:lsu->ccache.ifb->local_result.power.writeOp.dynamic;
+		value+=(lsu->cache_p==Write_back)?  0:lsu->ccache.prefetchb->local_result.power.writeOp.dynamic;
+		return value;
+	}
 
-  float get_coefficient_duty_cycle() {
-    float value = 0;
-    float num_units = 4.0;
-    value = XML->sys.total_cycles * XML->sys.number_of_cores;
-    value *= coredynp.num_pipelines;
-    value /= num_units;
-    value *= corepipe->power.readOp.dynamic;
-    value *= 3;
-    return value;
-    // return 1.5*value;
-  }
+	float get_coefficient_sharedmemory_readhits()
+	{
+		float value=0;
+		value+=lsu->sharedmemory.caches->local_result.power.readOp.dynamic;
+		value+=lsu->xbar_shared->power.readOp.dynamic;
+		//return 3*value;
+		return value;
+	}
 
-  void compute();
-  ~Core();
+	float get_coefficient_lsq_accesses()
+	{
+		float value=0;
+		//Changed by Syed -- We have removed LSQ
+		//value+=2*lsu->LSQ->local_result.power.searchOp.dynamic;
+		//value+=2*lsu->LSQ->local_result.power.readOp.dynamic;
+		//value+=2*lsu->LSQ->local_result.power.writeOp.dynamic;
+		return value;
+	}
+
+	float get_coefficient_regreads_accesses(){
+		float value=0;
+		value+=((exu->rfu->IRF->local_result.power.readOp.dynamic/32)*(4*2)/*/1.5*/);
+		value+=exu->rfu->xbar_rfu->power.readOp.dynamic/(32/**1.5*/);
+		value+=(exu->rfu->arbiter_rfu->power.readOp.dynamic/32/**1.5)*/);
+		value+=exu->rfu->OPC->local_result.power.readOp.dynamic/*/1.5*/;
+		return value;
+	}
+
+	float get_coefficient_regwrites_accesses(){return ((exu->rfu->IRF->local_result.power.writeOp.dynamic/32)*(4*2)/*/1.5*/);}
+
+	float get_coefficient_noregfileops_accesses(){return ((exu->rfu->xbar_rfu->power.readOp.dynamic/(32/**1.5*/))+
+			(exu->rfu->arbiter_rfu->power.readOp.dynamic/(32/**1.5*/))+
+			(exu->rfu->OPC->local_result.power.readOp.dynamic/*/(1.5)*/));}
+
+	float get_coefficient_ialu_accesses(){
+		//return 10*exu->exeu->per_access_energy*g_tp.sckt_co_eff;
+		return exu->exeu->per_access_energy*g_tp.sckt_co_eff;
+		}
+
+	float get_coefficient_sfu_accesses(){
+		return exu->mul->per_access_energy*g_tp.sckt_co_eff;
+		//return 2.6*exu->mul->per_access_energy*g_tp.sckt_co_eff;
+		}
+
+	float get_coefficient_fpu_accesses(){
+		//return 3.2*exu->fp_u->per_access_energy*g_tp.sckt_co_eff;
+		return exu->fp_u->per_access_energy*g_tp.sckt_co_eff;
+		}
+
+	float get_coefficient_duty_cycle()
+	{
+		float value=0;
+		float num_units=4.0;
+		value=XML->sys.total_cycles * XML->sys.number_of_cores;
+		value*=coredynp.num_pipelines;
+		value/=num_units;
+		value*=corepipe->power.readOp.dynamic;
+		value*=3;
+		return value;
+		//return 1.5*value;
+	}
+
+
+
+	void compute();
+	~Core();
 };
 
 #endif /* CORE_H_ */

--- a/src/gpuwattch/core.h
+++ b/src/gpuwattch/core.h
@@ -29,470 +29,530 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:												   *
+*      Modified by:
+**
 *      Jingwen Leng, Univeristy of Texas, Austin                   *
 *      Syed Gilani, University of Wisconsin–Madison                *
 *      Tayler Hetherington, University of British Columbia         *
 *      Ahmed ElTantawy, University of British Columbia             *
 ********************************************************************/
 
-
 #ifndef CORE_H_
 #define CORE_H_
 
 #include "XML_Parse.h"
-#include "logic.h"
-#include "cacti/parameter.h"
 #include "array.h"
-#include "interconnect.h"
 #include "basic_components.h"
-#include "sharedcache.h"
-#include "cacti/crossbar.h"
 #include "cacti/arbiter.h"
+#include "cacti/crossbar.h"
+#include "cacti/parameter.h"
+#include "interconnect.h"
+#include "logic.h"
 #include "noc.h"
+#include "sharedcache.h"
 
-class BranchPredictor :public Component {
-  public:
+class BranchPredictor : public Component {
+ public:
+  ParseXML *XML;
+  int ithCore;
+  InputParameter interface_ip;
+  CoreDynParam coredynp;
+  double clockRate, executionTime;
+  double scktRatio, chip_PR_overhead, macro_PR_overhead;
+  ArrayST *globalBPT;
+  ArrayST *localBPT;
+  ArrayST *L1_localBPT;
+  ArrayST *L2_localBPT;
+  ArrayST *chooser;
+  ArrayST *RAS;
+  bool exist;
 
-	ParseXML *XML;
-	int  ithCore;
-	InputParameter interface_ip;
-	CoreDynParam  coredynp;
-	double clockRate,executionTime;
-	double scktRatio, chip_PR_overhead, macro_PR_overhead;
-	ArrayST * globalBPT;
-	ArrayST * localBPT;
-	ArrayST * L1_localBPT;
-	ArrayST * L2_localBPT;
-	ArrayST * chooser;
-	ArrayST * RAS;
-	bool exist;
-
-	BranchPredictor(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_,const CoreDynParam & dyn_p_, bool exsit=true);
-    void computeEnergy(bool is_tdp=true);
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-	~BranchPredictor();
+  BranchPredictor(ParseXML *XML_interface, int ithCore_,
+                  InputParameter *interface_ip_, const CoreDynParam &dyn_p_,
+                  bool exsit = true);
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  ~BranchPredictor();
 };
 
+class InstFetchU : public Component {
+ public:
+  ParseXML *XML;
+  int ithCore;
+  InputParameter interface_ip;
+  CoreDynParam coredynp;
+  double clockRate, executionTime;
+  double scktRatio, chip_PR_overhead, macro_PR_overhead;
+  enum Cache_policy cache_p;
+  InstCache icache;
+  ArrayST *IB;
+  ArrayST *BTB;
+  BranchPredictor *BPT;
+  inst_decoder *ID_inst;
+  inst_decoder *ID_operand;
+  inst_decoder *ID_misc;
+  bool exist;
 
-class InstFetchU :public Component {
-  public:
-
-	ParseXML *XML;
-	int  ithCore;
-	InputParameter interface_ip;
-	CoreDynParam  coredynp;
-	double clockRate,executionTime;
-	double scktRatio, chip_PR_overhead, macro_PR_overhead;
-	enum Cache_policy cache_p;
-	InstCache icache;
-	ArrayST * IB;
-	ArrayST * BTB;
-	BranchPredictor * BPT;
-	inst_decoder * ID_inst;
-	inst_decoder * ID_operand;
-	inst_decoder * ID_misc;
-	bool exist;
-
-	InstFetchU(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_,const CoreDynParam & dyn_p_, bool exsit=true);
-    void computeEnergy(bool is_tdp=true);
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-	~InstFetchU();
+  InstFetchU(ParseXML *XML_interface, int ithCore_,
+             InputParameter *interface_ip_, const CoreDynParam &dyn_p_,
+             bool exsit = true);
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  ~InstFetchU();
 };
 
+class SchedulerU : public Component {
+ public:
+  ParseXML *XML;
+  int ithCore;
+  InputParameter interface_ip;
+  CoreDynParam coredynp;
+  double clockRate, executionTime;
+  double scktRatio, chip_PR_overhead, macro_PR_overhead;
+  double Iw_height, fp_Iw_height, ROB_height;
+  ArrayST *int_inst_window;
+  ArrayST *fp_inst_window;
+  ArrayST *ROB;
+  selection_logic *instruction_selection;
+  bool exist;
 
-class SchedulerU :public Component {
-  public:
-
-	ParseXML *XML;
-	int  ithCore;
-	InputParameter interface_ip;
-	CoreDynParam  coredynp;
-	double clockRate,executionTime;
-	double scktRatio, chip_PR_overhead, macro_PR_overhead;
-	double Iw_height, fp_Iw_height,ROB_height;
-	ArrayST         * int_inst_window;
-	ArrayST         * fp_inst_window;
-	ArrayST         * ROB;
-    selection_logic * instruction_selection;
-    bool exist;
-
-    SchedulerU(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_,const CoreDynParam & dyn_p_, bool exist_=true);
-    void computeEnergy(bool is_tdp=true);
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-	~SchedulerU();
+  SchedulerU(ParseXML *XML_interface, int ithCore_,
+             InputParameter *interface_ip_, const CoreDynParam &dyn_p_,
+             bool exist_ = true);
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  ~SchedulerU();
 };
 
-class RENAMINGU :public Component {
-  public:
+class RENAMINGU : public Component {
+ public:
+  ParseXML *XML;
+  int ithCore;
+  InputParameter interface_ip;
+  double clockRate, executionTime;
+  CoreDynParam coredynp;
+  ArrayST *iFRAT;
+  ArrayST *fFRAT;
+  ArrayST *iRRAT;
+  ArrayST *fRRAT;
+  ArrayST *ifreeL;
+  ArrayST *ffreeL;
+  dep_resource_conflict_check *idcl;
+  dep_resource_conflict_check *fdcl;
+  ArrayST *RAHT;  // register alias history table Used to store GC
+  bool exist;
 
-	ParseXML *XML;
-	int  ithCore;
-	InputParameter interface_ip;
-	double clockRate,executionTime;
-	CoreDynParam  coredynp;
-	ArrayST * iFRAT;
-	ArrayST * fFRAT;
-	ArrayST * iRRAT;
-	ArrayST * fRRAT;
-	ArrayST * ifreeL;
-	ArrayST * ffreeL;
-	dep_resource_conflict_check * idcl;
-	dep_resource_conflict_check * fdcl;
-	ArrayST * RAHT;//register alias history table Used to store GC
-	bool exist;
-
-
-	RENAMINGU(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_, bool exist_=true);
-    void computeEnergy(bool is_tdp=true);
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-	~RENAMINGU();
+  RENAMINGU(ParseXML *XML_interface, int ithCore_,
+            InputParameter *interface_ip_, const CoreDynParam &dyn_p_,
+            bool exist_ = true);
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  ~RENAMINGU();
 };
 
-class LoadStoreU :public Component {
-  public:
+class LoadStoreU : public Component {
+ public:
+  ParseXML *XML;
+  int ithCore;
+  InputParameter interface_ip;
+  CoreDynParam coredynp;
+  enum Cache_policy cache_p;
+  double clockRate, executionTime;
+  double scktRatio, chip_PR_overhead, macro_PR_overhead;
+  double lsq_height;
+  DataCache dcache;
+  DataCache ccache;
+  DataCache tcache;
+  DataCache sharedmemory;
+  ArrayST *LSQ;  // it is actually the store queue but for inorder processors it
+                 // serves as both loadQ and StoreQ
+  ArrayST *LoadQ;
+  vector<NoC *> nocs;
+  bool exist;
+  Crossbar *xbar_shared;
+  Component noc;
+  LoadStoreU(ParseXML *XML_interface, int ithCore_,
+             InputParameter *interface_ip_, const CoreDynParam &dyn_p_,
+             bool exist_ = true);
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  void displayDeviceType(int device_type_,
+                         uint32_t indent);  // Added by Syed Gilani
 
-	ParseXML *XML;
-	int  ithCore;
-	InputParameter interface_ip;
-	CoreDynParam  coredynp;
-	enum Cache_policy cache_p;
-	double clockRate,executionTime;
-	double scktRatio, chip_PR_overhead, macro_PR_overhead;
-	double lsq_height;
-	DataCache dcache;
-	DataCache ccache;
-	DataCache tcache;
-	DataCache sharedmemory;
-	ArrayST * LSQ;//it is actually the store queue but for inorder processors it serves as both loadQ and StoreQ
-	ArrayST * LoadQ;
-	vector<NoC *>  nocs;
-	bool exist;
-   Crossbar *xbar_shared;
-	Component noc;
-	LoadStoreU(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_,const CoreDynParam & dyn_p_, bool exist_=true);
-    void computeEnergy(bool is_tdp=true);
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-	 void displayDeviceType(int device_type_, uint32_t indent);//Added by Syed Gilani
-
-	~LoadStoreU();
+  ~LoadStoreU();
 };
 
-class MemManU :public Component {
-  public:
+class MemManU : public Component {
+ public:
+  ParseXML *XML;
+  int ithCore;
+  InputParameter interface_ip;
+  CoreDynParam coredynp;
+  double clockRate, executionTime;
+  double scktRatio, chip_PR_overhead, macro_PR_overhead;
+  ArrayST *itlb;
+  ArrayST *dtlb;
+  bool exist;
 
-	ParseXML *XML;
-	int  ithCore;
-	InputParameter interface_ip;
-	CoreDynParam  coredynp;
-	double clockRate,executionTime;
-	double scktRatio, chip_PR_overhead, macro_PR_overhead;
-	ArrayST * itlb;
-	ArrayST * dtlb;
-	bool exist;
-
-	MemManU(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_,const CoreDynParam & dyn_p_, bool exist_=false);
-    void computeEnergy(bool is_tdp=true);
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-	~MemManU();
+  MemManU(ParseXML *XML_interface, int ithCore_, InputParameter *interface_ip_,
+          const CoreDynParam &dyn_p_, bool exist_ = false);
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  ~MemManU();
 };
 
-class RegFU :public Component {
-  public:
-
-	ParseXML *XML;
-	int  ithCore;
-	InputParameter interface_ip;
-	CoreDynParam  coredynp;
-	double clockRate,executionTime;
-	double scktRatio, chip_PR_overhead, macro_PR_overhead;
-	double int_regfile_height, fp_regfile_height;
-	ArrayST * IRF;
-	ArrayST * FRF;
-	ArrayST * RFWIN;
-	ArrayST * OPC;//Operand collectors
-	bool exist;
-   double exClockRate; 
-	//OC Modelling (Syed)
-	Crossbar * xbar_rfu;
-   MCPAT_Arbiter * arbiter_rfu;
-	RegFU(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_,const CoreDynParam & dyn_p_, double exClockRate, bool exist_=true);
-    void computeEnergy(bool is_tdp=true);
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-	~RegFU();
+class RegFU : public Component {
+ public:
+  ParseXML *XML;
+  int ithCore;
+  InputParameter interface_ip;
+  CoreDynParam coredynp;
+  double clockRate, executionTime;
+  double scktRatio, chip_PR_overhead, macro_PR_overhead;
+  double int_regfile_height, fp_regfile_height;
+  ArrayST *IRF;
+  ArrayST *FRF;
+  ArrayST *RFWIN;
+  ArrayST *OPC;  // Operand collectors
+  bool exist;
+  double exClockRate;
+  // OC Modelling (Syed)
+  Crossbar *xbar_rfu;
+  MCPAT_Arbiter *arbiter_rfu;
+  RegFU(ParseXML *XML_interface, int ithCore_, InputParameter *interface_ip_,
+        const CoreDynParam &dyn_p_, double exClockRate, bool exist_ = true);
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  ~RegFU();
 };
 
-class EXECU :public Component {
-  public:
+class EXECU : public Component {
+ public:
+  ParseXML *XML;
+  int ithCore;
+  InputParameter interface_ip;
+  double clockRate, executionTime;
+  double scktRatio, chip_PR_overhead, macro_PR_overhead;
+  double lsq_height;
+  CoreDynParam coredynp;
+  RegFU *rfu;
+  SchedulerU *scheu;
+  FunctionalUnit *fp_u;
+  FunctionalUnit *exeu;
+  FunctionalUnit *mul;
+  interconnect *int_bypass;
+  interconnect *intTagBypass;
+  interconnect *int_mul_bypass;
+  interconnect *intTag_mul_Bypass;
+  interconnect *fp_bypass;
+  interconnect *fpTagBypass;
+  bool exist;
+  double rf_fu_clockRate;
+  Component bypass;
 
-	ParseXML *XML;
-	int  ithCore;
-	InputParameter interface_ip;
-	double clockRate,executionTime;
-	double scktRatio, chip_PR_overhead, macro_PR_overhead;
-	double lsq_height;
-	CoreDynParam  coredynp;
-	RegFU          * rfu;
-	SchedulerU     * scheu;
-    FunctionalUnit * fp_u;
-    FunctionalUnit * exeu;
-    FunctionalUnit * mul;
-	interconnect * int_bypass;
-	interconnect * intTagBypass;
-	interconnect * int_mul_bypass;
-	interconnect * intTag_mul_Bypass;
-	interconnect * fp_bypass;
-	interconnect * fpTagBypass;
-	bool exist;
-	double rf_fu_clockRate;
-	Component  bypass;
-
-
-	EXECU(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_, double lsq_height_,const CoreDynParam & dyn_p_, double exClockRate, bool exist_);
-    void computeEnergy(bool is_tdp=true);
-	void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-	~EXECU();
+  EXECU(ParseXML *XML_interface, int ithCore_, InputParameter *interface_ip_,
+        double lsq_height_, const CoreDynParam &dyn_p_, double exClockRate,
+        bool exist_);
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  ~EXECU();
 };
 
+class Core : public Component {
+ public:
+  ParseXML *XML;
+  int ithCore;
+  InputParameter interface_ip;
+  double clockRate, executionTime;
+  double exClockRate;
+  double scktRatio, chip_PR_overhead, macro_PR_overhead;
+  InstFetchU *ifu;
+  LoadStoreU *lsu;
+  MemManU *mmu;
+  EXECU *exu;
+  RENAMINGU *rnu;
+  double IdleCoreEnergy;
+  double IdlePower_PerCore;
+  Pipeline *corepipe;
+  UndiffCore *undiffCore;
+  SharedCache *l2cache;
+  CoreDynParam coredynp;
+  double Pipeline_energy;
+  // full_decoder 	inst_decoder;
+  // clock_network	clockNetwork;
+  Core(ParseXML *XML_interface, int ithCore_, InputParameter *interface_ip_);
+  void set_core_param();
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
 
-class Core :public Component {
-  public:
+  float get_coefficient_icache_hits() {
+    // return 1.5*ifu->icache.caches->local_result.power.readOp.dynamic;
+    return ifu->icache.caches->local_result.power.readOp.dynamic;
+  }
 
-	ParseXML *XML;
-	int  ithCore;
-	InputParameter interface_ip;
-	double clockRate,executionTime;
-	double exClockRate;
-	double scktRatio, chip_PR_overhead, macro_PR_overhead;
-	InstFetchU * ifu;
-	LoadStoreU * lsu;
-	MemManU    * mmu;
-	EXECU      * exu;
-	RENAMINGU  * rnu;
-	double IdleCoreEnergy;
-	double IdlePower_PerCore;
-    Pipeline   * corepipe;
-    UndiffCore * undiffCore;
-    SharedCache * l2cache;
-    CoreDynParam  coredynp;
-	double Pipeline_energy;
-    //full_decoder 	inst_decoder;
-    //clock_network	clockNetwork;
-	Core(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_);
-	void set_core_param();
-	void computeEnergy(bool is_tdp=true);
-	void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
+  float get_coefficient_icache_misses() {
+    float value = 0;
+    value += ifu->icache.caches->local_result.power.writeOp.dynamic;
+    value += ifu->icache.caches->local_result.power.readOp.dynamic;
+    value += ifu->icache.missb->local_result.power.searchOp.dynamic;
+    value += ifu->icache.missb->local_result.power.writeOp.dynamic;
+    value += ifu->icache.ifb->local_result.power.searchOp.dynamic;
+    value += ifu->icache.ifb->local_result.power.writeOp.dynamic;
+    value += ifu->icache.prefetchb->local_result.power.searchOp.dynamic;
+    value += ifu->icache.prefetchb->local_result.power.writeOp.dynamic;
+    return value;
+  }
 
-	float get_coefficient_icache_hits(){
-		//return 1.5*ifu->icache.caches->local_result.power.readOp.dynamic;
-		return ifu->icache.caches->local_result.power.readOp.dynamic;
-	}
+  float get_coefficient_tot_insts() {
+    float value = 0;
+    value += ifu->IB->local_result.power.readOp.dynamic;
+    value += ifu->IB->local_result.power.writeOp.dynamic;
+    value += ifu->ID_inst->power_t.readOp.dynamic;
+    value += ifu->ID_operand->power_t.readOp.dynamic;
+    value += ifu->ID_misc->power_t.readOp.dynamic;
+    return value;
+  }
 
-	float get_coefficient_icache_misses(){
-		float value=0;
-		value+=ifu->icache.caches->local_result.power.writeOp.dynamic;
-		value+=ifu->icache.caches->local_result.power.readOp.dynamic;
-		value+=ifu->icache.missb->local_result.power.searchOp.dynamic;
-		value+=ifu->icache.missb->local_result.power.writeOp.dynamic;
-		value+=ifu->icache.ifb->local_result.power.searchOp.dynamic;
-		value+= ifu->icache.ifb->local_result.power.writeOp.dynamic;
-		value+= ifu->icache.prefetchb->local_result.power.searchOp.dynamic;
-		value+=ifu->icache.prefetchb->local_result.power.writeOp.dynamic;
-		return value;
-	}
+  float get_coefficient_fpint_insts() {
+    float value = 0;
+    value += exu->scheu->int_inst_window->local_result.power.readOp.dynamic;
+    value +=
+        2 * exu->scheu->int_inst_window->local_result.power.searchOp.dynamic;
+    value += exu->scheu->int_inst_window->local_result.power.writeOp.dynamic;
+    value += exu->scheu->instruction_selection->power.readOp.dynamic;
+    return value;
+  }
 
-	float get_coefficient_tot_insts(){
-		float value=0;
-		value+=ifu->IB->local_result.power.readOp.dynamic;
-		value+=ifu->IB->local_result.power.writeOp.dynamic;
-		value+=ifu->ID_inst->power_t.readOp.dynamic;
-		value+=ifu->ID_operand->power_t.readOp.dynamic;
-		value+=ifu->ID_misc->power_t.readOp.dynamic;
-		return value;
-	}
+  float get_coefficient_dcache_readhits() {
+    float value = 0;
+    value += lsu->dcache.caches->local_result.power.readOp.dynamic;
+    value += lsu->xbar_shared->power.readOp.dynamic;
+    // return 0.5*value;
+    return value;
+  }
+  float get_coefficient_dcache_readmisses() {
+    float value = 0;
+    value += lsu->dcache.caches->local_result.power.readOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->dcache.missb->local_result.power.searchOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->dcache.ifb->local_result.power.searchOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->dcache.prefetchb->local_result.power.searchOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->dcache.missb->local_result.power.writeOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->dcache.ifb->local_result.power.writeOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->dcache.prefetchb->local_result.power.writeOp.dynamic;
 
-	float get_coefficient_fpint_insts(){
-		float value=0;
-		value+=exu->scheu->int_inst_window->local_result.power.readOp.dynamic;
-		value+=2*exu->scheu->int_inst_window->local_result.power.searchOp.dynamic;
-		value+=exu->scheu->int_inst_window->local_result.power.writeOp.dynamic;
-		value+=exu->scheu->instruction_selection->power.readOp.dynamic;
-		return value;
-	}
+    // return 0.5*value;
+    return value;
+  }
+  float get_coefficient_dcache_writehits() {
+    float value = 0;
+    value += lsu->dcache.caches->local_result.power.writeOp.dynamic;
+    value += lsu->xbar_shared->power.readOp.dynamic;
+    return value;
+  }
+  float get_coefficient_dcache_writemisses() {
+    float value = 0;
+    value += lsu->dcache.caches->local_result.power.writeOp.dynamic;
+    value += lsu->dcache.caches->local_result.tag_array2->power.readOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? lsu->dcache.caches->local_result.power.writeOp.dynamic
+                 : 0;
+    value += (lsu->cache_p == Write_back)
+                 ? lsu->dcache.missb->local_result.power.searchOp.dynamic
+                 : 0;
+    value += (lsu->cache_p == Write_back)
+                 ? lsu->dcache.ifb->local_result.power.searchOp.dynamic
+                 : 0;
+    value += (lsu->cache_p == Write_back)
+                 ? lsu->dcache.prefetchb->local_result.power.searchOp.dynamic
+                 : 0;
+    value += (lsu->cache_p == Write_back)
+                 ? lsu->dcache.wbb->local_result.power.searchOp.dynamic
+                 : 0;
+    value += (lsu->cache_p == Write_back)
+                 ? lsu->dcache.missb->local_result.power.writeOp.dynamic
+                 : 0;
+    value += (lsu->cache_p == Write_back)
+                 ? lsu->dcache.ifb->local_result.power.writeOp.dynamic
+                 : 0;
+    value += (lsu->cache_p == Write_back)
+                 ? lsu->dcache.prefetchb->local_result.power.writeOp.dynamic
+                 : 0;
+    value += (lsu->cache_p == Write_back)
+                 ? lsu->dcache.wbb->local_result.power.writeOp.dynamic
+                 : 0;
+    // return 1.6*value;
+    return value;
+  }
 
+  float get_coefficient_tcache_readhits() {
+    float value = 0;
+    value += lsu->tcache.caches->local_result.power.readOp.dynamic;
+    value += lsu->xbar_shared->power.readOp.dynamic;
+    // return 0.2*value;
+    return value;
+  }
+  float get_coefficient_tcache_readmisses() {
+    float value = 0;
+    value += lsu->tcache.caches->local_result.power.readOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->tcache.missb->local_result.power.searchOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->tcache.missb->local_result.power.writeOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->tcache.ifb->local_result.power.searchOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->tcache.ifb->local_result.power.writeOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->tcache.prefetchb->local_result.power.searchOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->tcache.prefetchb->local_result.power.writeOp.dynamic;
 
-	float get_coefficient_dcache_readhits()
-	{
-		float value=0;
-		value+=lsu->dcache.caches->local_result.power.readOp.dynamic;
-		value+=lsu->xbar_shared->power.readOp.dynamic;
-		//return 0.5*value;
-		return value;
-	}
-	float get_coefficient_dcache_readmisses()
-	{
-		float value=0;
-		value+=lsu->dcache.caches->local_result.power.readOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->dcache.missb->local_result.power.searchOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->dcache.ifb->local_result.power.searchOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->dcache.prefetchb->local_result.power.searchOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->dcache.missb->local_result.power.writeOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->dcache.ifb->local_result.power.writeOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->dcache.prefetchb->local_result.power.writeOp.dynamic;
+    // return 0.2*value;
+    return value;
+  }
+  float get_coefficient_tcache_readmisses1() {
+    return lsu->tcache.caches->local_result.power.readOp.dynamic;
+  }
+  float get_coefficient_tcache_readmisses2() {
+    float value = 0;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->tcache.missb->local_result.power.searchOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->tcache.missb->local_result.power.writeOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->tcache.ifb->local_result.power.searchOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->tcache.ifb->local_result.power.writeOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->tcache.prefetchb->local_result.power.searchOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->tcache.prefetchb->local_result.power.writeOp.dynamic;
+    return value;
+  }
 
-		//return 0.5*value;
-		return value;
-	}
-	float get_coefficient_dcache_writehits()
-	{
-		float value=0;
-		value+=lsu->dcache.caches->local_result.power.writeOp.dynamic;
-		value+=lsu->xbar_shared->power.readOp.dynamic;
-		return value;
-	}
-	float get_coefficient_dcache_writemisses(){
-		float value=0;
-		value+=lsu->dcache.caches->local_result.power.writeOp.dynamic;
-		value+=lsu->dcache.caches->local_result.tag_array2->power.readOp.dynamic;
-		value+= (lsu->cache_p==Write_back)? lsu->dcache.caches->local_result.power.writeOp.dynamic:0;
-		value+= (lsu->cache_p==Write_back)? lsu->dcache.missb->local_result.power.searchOp.dynamic:0;
-		value+= (lsu->cache_p==Write_back)? lsu->dcache.ifb->local_result.power.searchOp.dynamic:0;
-		value+= (lsu->cache_p==Write_back)? lsu->dcache.prefetchb->local_result.power.searchOp.dynamic:0;
-		value+= (lsu->cache_p==Write_back)? lsu->dcache.wbb->local_result.power.searchOp.dynamic:0;
-		value+= (lsu->cache_p==Write_back)? lsu->dcache.missb->local_result.power.writeOp.dynamic:0;
-		value+= (lsu->cache_p==Write_back)? lsu->dcache.ifb->local_result.power.writeOp.dynamic:0;
-		value+= (lsu->cache_p==Write_back)? lsu->dcache.prefetchb->local_result.power.writeOp.dynamic:0;
-		value+= (lsu->cache_p==Write_back)? lsu->dcache.wbb->local_result.power.writeOp.dynamic:0;
-		//return 1.6*value;
-		return value;
-	}
+  float get_coefficient_ccache_readhits() {
+    // return
+    // 1.2*lsu->ccache.caches->local_result.power.readOp.dynamic+lsu->xbar_shared->power.readOp.dynamic;
+    // return
+    // 1.2*lsu->ccache.caches->local_result.power.readOp.dynamic+lsu->xbar_shared->power.readOp.dynamic;
+    return lsu->ccache.caches->local_result.power.readOp.dynamic +
+           lsu->xbar_shared->power.readOp.dynamic;
+  }
+  float get_coefficient_ccache_readmisses() {
+    float value = 0;
+    value += lsu->ccache.caches->local_result.power.readOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->ccache.missb->local_result.power.searchOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->ccache.ifb->local_result.power.searchOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->ccache.prefetchb->local_result.power.searchOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->ccache.missb->local_result.power.writeOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->ccache.ifb->local_result.power.writeOp.dynamic;
+    value += (lsu->cache_p == Write_back)
+                 ? 0
+                 : lsu->ccache.prefetchb->local_result.power.writeOp.dynamic;
+    return value;
+  }
 
+  float get_coefficient_sharedmemory_readhits() {
+    float value = 0;
+    value += lsu->sharedmemory.caches->local_result.power.readOp.dynamic;
+    value += lsu->xbar_shared->power.readOp.dynamic;
+    // return 3*value;
+    return value;
+  }
 
+  float get_coefficient_lsq_accesses() {
+    float value = 0;
+    // Changed by Syed -- We have removed LSQ
+    // value+=2*lsu->LSQ->local_result.power.searchOp.dynamic;
+    // value+=2*lsu->LSQ->local_result.power.readOp.dynamic;
+    // value+=2*lsu->LSQ->local_result.power.writeOp.dynamic;
+    return value;
+  }
 
-	float get_coefficient_tcache_readhits()
-	{
-		float value=0;
-		value+=lsu->tcache.caches->local_result.power.readOp.dynamic;
-		value+=lsu->xbar_shared->power.readOp.dynamic;
-		//return 0.2*value;
-		return value;
-	}
-	float get_coefficient_tcache_readmisses()
-	{
-		float value=0;
-		value+= lsu->tcache.caches->local_result.power.readOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.missb->local_result.power.searchOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.missb->local_result.power.writeOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.ifb->local_result.power.searchOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.ifb->local_result.power.writeOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.prefetchb->local_result.power.searchOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.prefetchb->local_result.power.writeOp.dynamic;
+  float get_coefficient_regreads_accesses() {
+    float value = 0;
+    value += ((exu->rfu->IRF->local_result.power.readOp.dynamic / 32) *
+              (4 * 2) /*/1.5*/);
+    value += exu->rfu->xbar_rfu->power.readOp.dynamic / (32 /**1.5*/);
+    value += (exu->rfu->arbiter_rfu->power.readOp.dynamic / 32 /**1.5)*/);
+    value += exu->rfu->OPC->local_result.power.readOp.dynamic /*/1.5*/;
+    return value;
+  }
 
-		//return 0.2*value;
-		return value;
-	}
-	float get_coefficient_tcache_readmisses1(){
+  float get_coefficient_regwrites_accesses() {
+    return ((exu->rfu->IRF->local_result.power.writeOp.dynamic / 32) *
+            (4 * 2) /*/1.5*/);
+  }
 
-		return lsu->tcache.caches->local_result.power.readOp.dynamic;
+  float get_coefficient_noregfileops_accesses() {
+    return ((exu->rfu->xbar_rfu->power.readOp.dynamic / (32 /**1.5*/)) +
+            (exu->rfu->arbiter_rfu->power.readOp.dynamic / (32 /**1.5*/)) +
+            (exu->rfu->OPC->local_result.power.readOp.dynamic /*/(1.5)*/));
+  }
 
-	}
-	float get_coefficient_tcache_readmisses2(){
-		float value=0;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.missb->local_result.power.searchOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.missb->local_result.power.writeOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.ifb->local_result.power.searchOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.ifb->local_result.power.writeOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.prefetchb->local_result.power.searchOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->tcache.prefetchb->local_result.power.writeOp.dynamic;
-		return value;
-	}
+  float get_coefficient_ialu_accesses() {
+    // return 10*exu->exeu->per_access_energy*g_tp.sckt_co_eff;
+    return exu->exeu->per_access_energy * g_tp.sckt_co_eff;
+  }
 
+  float get_coefficient_sfu_accesses() {
+    return exu->mul->per_access_energy * g_tp.sckt_co_eff;
+    // return 2.6*exu->mul->per_access_energy*g_tp.sckt_co_eff;
+  }
 
-	float get_coefficient_ccache_readhits()
-	{
-		//return 1.2*lsu->ccache.caches->local_result.power.readOp.dynamic+lsu->xbar_shared->power.readOp.dynamic;
-		//return 1.2*lsu->ccache.caches->local_result.power.readOp.dynamic+lsu->xbar_shared->power.readOp.dynamic;
-		return lsu->ccache.caches->local_result.power.readOp.dynamic+lsu->xbar_shared->power.readOp.dynamic;
-	}
-	float get_coefficient_ccache_readmisses()
-	{
-		float value=0;
-		value+=lsu->ccache.caches->local_result.power.readOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->ccache.missb->local_result.power.searchOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->ccache.ifb->local_result.power.searchOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->ccache.prefetchb->local_result.power.searchOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->ccache.missb->local_result.power.writeOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->ccache.ifb->local_result.power.writeOp.dynamic;
-		value+=(lsu->cache_p==Write_back)?  0:lsu->ccache.prefetchb->local_result.power.writeOp.dynamic;
-		return value;
-	}
+  float get_coefficient_fpu_accesses() {
+    // return 3.2*exu->fp_u->per_access_energy*g_tp.sckt_co_eff;
+    return exu->fp_u->per_access_energy * g_tp.sckt_co_eff;
+  }
 
-	float get_coefficient_sharedmemory_readhits()
-	{
-		float value=0;
-		value+=lsu->sharedmemory.caches->local_result.power.readOp.dynamic;
-		value+=lsu->xbar_shared->power.readOp.dynamic;
-		//return 3*value;
-		return value;
-	}
+  float get_coefficient_duty_cycle() {
+    float value = 0;
+    float num_units = 4.0;
+    value = XML->sys.total_cycles * XML->sys.number_of_cores;
+    value *= coredynp.num_pipelines;
+    value /= num_units;
+    value *= corepipe->power.readOp.dynamic;
+    value *= 3;
+    return value;
+    // return 1.5*value;
+  }
 
-	float get_coefficient_lsq_accesses()
-	{
-		float value=0;
-		//Changed by Syed -- We have removed LSQ
-		//value+=2*lsu->LSQ->local_result.power.searchOp.dynamic;
-		//value+=2*lsu->LSQ->local_result.power.readOp.dynamic;
-		//value+=2*lsu->LSQ->local_result.power.writeOp.dynamic;
-		return value;
-	}
-
-	float get_coefficient_regreads_accesses(){
-		float value=0;
-		value+=((exu->rfu->IRF->local_result.power.readOp.dynamic/32)*(4*2)/*/1.5*/);
-		value+=exu->rfu->xbar_rfu->power.readOp.dynamic/(32/**1.5*/);
-		value+=(exu->rfu->arbiter_rfu->power.readOp.dynamic/32/**1.5)*/);
-		value+=exu->rfu->OPC->local_result.power.readOp.dynamic/*/1.5*/;
-		return value;
-	}
-
-	float get_coefficient_regwrites_accesses(){return ((exu->rfu->IRF->local_result.power.writeOp.dynamic/32)*(4*2)/*/1.5*/);}
-
-	float get_coefficient_noregfileops_accesses(){return ((exu->rfu->xbar_rfu->power.readOp.dynamic/(32/**1.5*/))+
-			(exu->rfu->arbiter_rfu->power.readOp.dynamic/(32/**1.5*/))+
-			(exu->rfu->OPC->local_result.power.readOp.dynamic/*/(1.5)*/));}
-
-	float get_coefficient_ialu_accesses(){
-		//return 10*exu->exeu->per_access_energy*g_tp.sckt_co_eff;
-		return exu->exeu->per_access_energy*g_tp.sckt_co_eff;
-		}
-
-	float get_coefficient_sfu_accesses(){
-		return exu->mul->per_access_energy*g_tp.sckt_co_eff;
-		//return 2.6*exu->mul->per_access_energy*g_tp.sckt_co_eff;
-		}
-
-	float get_coefficient_fpu_accesses(){
-		//return 3.2*exu->fp_u->per_access_energy*g_tp.sckt_co_eff;
-		return exu->fp_u->per_access_energy*g_tp.sckt_co_eff;
-		}
-
-	float get_coefficient_duty_cycle()
-	{
-		float value=0;
-		float num_units=4.0;
-		value=XML->sys.total_cycles * XML->sys.number_of_cores;
-		value*=coredynp.num_pipelines;
-		value/=num_units;
-		value*=corepipe->power.readOp.dynamic;
-		value*=3;
-		return value;
-		//return 1.5*value;
-	}
-
-
-
-	void compute();
-	~Core();
+  void compute();
+  ~Core();
 };
 
 #endif /* CORE_H_ */

--- a/src/gpuwattch/globalvar.h
+++ b/src/gpuwattch/globalvar.h
@@ -29,11 +29,10 @@
  *
  ***************************************************************************/
 
-
 #ifndef GLOBALVAR_H_
 #define GLOBALVAR_H_
 
-#ifdef  GLOBALVAR
+#ifdef GLOBALVAR
 #define EXTERN
 #else
 #define EXTERN extern
@@ -42,7 +41,3 @@
 EXTERN bool opt_for_clk;
 
 #endif /* GLOBALVAR_H_ */
-
-
-
-

--- a/src/gpuwattch/globalvar.h
+++ b/src/gpuwattch/globalvar.h
@@ -29,10 +29,11 @@
  *
  ***************************************************************************/
 
+
 #ifndef GLOBALVAR_H_
 #define GLOBALVAR_H_
 
-#ifdef GLOBALVAR
+#ifdef  GLOBALVAR
 #define EXTERN
 #else
 #define EXTERN extern
@@ -41,3 +42,7 @@
 EXTERN bool opt_for_clk;
 
 #endif /* GLOBALVAR_H_ */
+
+
+
+

--- a/src/gpuwattch/gpgpu_sim_wrapper.cc
+++ b/src/gpuwattch/gpgpu_sim_wrapper.cc
@@ -7,755 +7,857 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #include "gpgpu_sim_wrapper.h"
 #include <sys/stat.h>
 #define SP_BASE_POWER 0
-#define SFU_BASE_POWER  0
+#define SFU_BASE_POWER 0
 
-
-static const char * pwr_cmp_label[] = {"IBP,", "ICP,", "DCP,", "TCP,", "CCP,", "SHRDP,", "RFP,", "SPP,",
-								"SFUP,", "FPUP,", "SCHEDP,", "L2CP,", "MCP,", "NOCP,", "DRAMP,",
-								"PIPEP,", "IDLE_COREP,", "CONST_DYNAMICP"};
+static const char* pwr_cmp_label[] = {
+    "IBP,", "ICP,",  "DCP,",   "TCP,",   "CCP,",        "SHRDP,",
+    "RFP,", "SPP,",  "SFUP,",  "FPUP,",  "SCHEDP,",     "L2CP,",
+    "MCP,", "NOCP,", "DRAMP,", "PIPEP,", "IDLE_COREP,", "CONST_DYNAMICP"};
 
 enum pwr_cmp_t {
-   IBP=0,
-   ICP,
-   DCP,
-   TCP,
-   CCP,
-   SHRDP,
-   RFP,
-   SPP,
-   SFUP,
-   FPUP,
-   SCHEDP,
-   L2CP,
-   MCP,
-   NOCP,
-   DRAMP,
-   PIPEP,
-   IDLE_COREP,
-   CONST_DYNAMICP,
-   NUM_COMPONENTS_MODELLED
+  IBP = 0,
+  ICP,
+  DCP,
+  TCP,
+  CCP,
+  SHRDP,
+  RFP,
+  SPP,
+  SFUP,
+  FPUP,
+  SCHEDP,
+  L2CP,
+  MCP,
+  NOCP,
+  DRAMP,
+  PIPEP,
+  IDLE_COREP,
+  CONST_DYNAMICP,
+  NUM_COMPONENTS_MODELLED
 };
 
+gpgpu_sim_wrapper::gpgpu_sim_wrapper(bool power_simulation_enabled,
+                                     char* xmlfile) {
+  kernel_sample_count = 0;
+  total_sample_count = 0;
 
-gpgpu_sim_wrapper::gpgpu_sim_wrapper( bool power_simulation_enabled, char* xmlfile) {
-	   kernel_sample_count=0;
-	   total_sample_count=0;
+  kernel_tot_power = 0;
 
-	   kernel_tot_power=0;
+  num_pwr_cmps = NUM_COMPONENTS_MODELLED;
+  num_perf_counters = NUM_PERFORMANCE_COUNTERS;
 
-	   num_pwr_cmps=NUM_COMPONENTS_MODELLED;
-	   num_perf_counters=NUM_PERFORMANCE_COUNTERS;
+  // Initialize per-component counter/power vectors
+  avg_max_min_counters<double> init;
+  kernel_cmp_pwr.resize(NUM_COMPONENTS_MODELLED, init);
+  kernel_cmp_perf_counters.resize(NUM_PERFORMANCE_COUNTERS, init);
 
-	   // Initialize per-component counter/power vectors
-	   avg_max_min_counters<double> init;
-	   kernel_cmp_pwr.resize(NUM_COMPONENTS_MODELLED, init);
-	   kernel_cmp_perf_counters.resize(NUM_PERFORMANCE_COUNTERS, init);
+  kernel_power = init;   // Per-kernel powers
+  gpu_tot_power = init;  // Global powers
 
-	   kernel_power = init; // Per-kernel powers
-	   gpu_tot_power = init; // Global powers
+  sample_cmp_pwr.resize(NUM_COMPONENTS_MODELLED, 0);
 
-	   sample_cmp_pwr.resize(NUM_COMPONENTS_MODELLED, 0);
+  sample_perf_counters.resize(NUM_PERFORMANCE_COUNTERS, 0);
+  initpower_coeff.resize(NUM_PERFORMANCE_COUNTERS, 0);
+  effpower_coeff.resize(NUM_PERFORMANCE_COUNTERS, 0);
 
-	   sample_perf_counters.resize(NUM_PERFORMANCE_COUNTERS, 0);
-	   initpower_coeff.resize(NUM_PERFORMANCE_COUNTERS, 0);
-	   effpower_coeff.resize(NUM_PERFORMANCE_COUNTERS, 0);
+  const_dynamic_power = 0;
+  proc_power = 0;
 
-	   const_dynamic_power=0;
-	   proc_power=0;
+  g_power_filename = NULL;
+  g_power_trace_filename = NULL;
+  g_metric_trace_filename = NULL;
+  g_steady_state_tracking_filename = NULL;
+  xml_filename = xmlfile;
+  g_power_simulation_enabled = power_simulation_enabled;
+  g_power_trace_enabled = false;
+  g_steady_power_levels_enabled = false;
+  g_power_trace_zlevel = 0;
+  g_power_per_cycle_dump = false;
+  gpu_steady_power_deviation = 0;
+  gpu_steady_min_period = 0;
 
-	   g_power_filename = NULL;
-	   g_power_trace_filename = NULL;
-	   g_metric_trace_filename = NULL;
-	   g_steady_state_tracking_filename = NULL;
-	   xml_filename= xmlfile;
-	   g_power_simulation_enabled= power_simulation_enabled;
-	   g_power_trace_enabled= false;
-	   g_steady_power_levels_enabled= false;
-	   g_power_trace_zlevel= 0;
-	   g_power_per_cycle_dump= false;
-	   gpu_steady_power_deviation= 0;
-	   gpu_steady_min_period= 0;
-
-	   gpu_stat_sample_freq=0;
-	   p=new ParseXML();
-	   if (g_power_simulation_enabled){
-	       p->parse(xml_filename);
-	   }
-	   proc = new Processor(p);
-	   power_trace_file = NULL;
-	   metric_trace_file = NULL;
-	   steady_state_tacking_file = NULL;
-	   has_written_avg=false;
-	   init_inst_val=false;
-
+  gpu_stat_sample_freq = 0;
+  p = new ParseXML();
+  if (g_power_simulation_enabled) {
+    p->parse(xml_filename);
+  }
+  proc = new Processor(p);
+  power_trace_file = NULL;
+  metric_trace_file = NULL;
+  steady_state_tacking_file = NULL;
+  has_written_avg = false;
+  init_inst_val = false;
 }
 
-gpgpu_sim_wrapper::~gpgpu_sim_wrapper() { }
+gpgpu_sim_wrapper::~gpgpu_sim_wrapper() {}
 
-bool gpgpu_sim_wrapper::sanity_check(double a, double b)
-{
-	if (b == 0)
-		return (abs(a-b)<0.00001);
-	else
-		return (abs(a-b)/abs(b)<0.00001);
+bool gpgpu_sim_wrapper::sanity_check(double a, double b) {
+  if (b == 0)
+    return (abs(a - b) < 0.00001);
+  else
+    return (abs(a - b) / abs(b) < 0.00001);
 
-	return false;
+  return false;
 }
-void gpgpu_sim_wrapper::init_mcpat(char* xmlfile, char* powerfilename, char* power_trace_filename,char* metric_trace_filename,
-								   char * steady_state_filename, bool power_sim_enabled,bool trace_enabled,
-								   bool steady_state_enabled,bool power_per_cycle_dump,double steady_power_deviation,
-								   double steady_min_period, int zlevel, double init_val,int stat_sample_freq ){
-	// Write File Headers for (-metrics trace, -power trace)
-
-	reset_counters();
-   static bool mcpat_init=true;
-
-   // initialize file name if it is not set
-   time_t curr_time;
-   time(&curr_time);
-   char *date = ctime(&curr_time);
-   char *s = date;
-   while (*s) {
-       if (*s == ' ' || *s == '\t' || *s == ':') *s = '-';
-       if (*s == '\n' || *s == '\r' ) *s = 0;
-       s++;
-   }
-
-   if(mcpat_init){
-	   g_power_filename = powerfilename;
-	   g_power_trace_filename =power_trace_filename;
-	   g_metric_trace_filename = metric_trace_filename;
-	   g_steady_state_tracking_filename = steady_state_filename;
-	   xml_filename=xmlfile;
-	   g_power_simulation_enabled=power_sim_enabled;
-	   g_power_trace_enabled=trace_enabled;
-	   g_steady_power_levels_enabled=steady_state_enabled;
-	   g_power_trace_zlevel=zlevel;
-	   g_power_per_cycle_dump=power_per_cycle_dump;
-	   gpu_steady_power_deviation=steady_power_deviation;
-	   gpu_steady_min_period=steady_min_period;
-
-	   gpu_stat_sample_freq=stat_sample_freq;
-
-	   //p->sys.total_cycles=gpu_stat_sample_freq*4;
-	   p->sys.total_cycles=gpu_stat_sample_freq;
-	   power_trace_file = NULL;
-	   metric_trace_file = NULL;
-	   steady_state_tacking_file = NULL;
-
-
-	   if (g_power_trace_enabled ){
-		   power_trace_file = gzopen(g_power_trace_filename, "w");
-		   metric_trace_file = gzopen(g_metric_trace_filename, "w");
-		   if ((power_trace_file == NULL) || (metric_trace_file == NULL)) {
-			   printf("error - could not open trace files \n");
-			   exit(1);
-		   }
-		   gzsetparams(power_trace_file, g_power_trace_zlevel, Z_DEFAULT_STRATEGY);
-
-		   gzprintf(power_trace_file,"power,");
-		   for(unsigned i=0; i<num_pwr_cmps; i++){
-			   gzprintf(power_trace_file,pwr_cmp_label[i]);
-		   }
-		   gzprintf(power_trace_file,"\n");
-
-		   gzsetparams(metric_trace_file, g_power_trace_zlevel, Z_DEFAULT_STRATEGY);
-		   for(unsigned i=0; i<num_perf_counters; i++){
-			   gzprintf(metric_trace_file,perf_count_label[i]);
-		   }
-		   gzprintf(metric_trace_file,"\n");
-
-		   gzclose(power_trace_file);
-		   gzclose(metric_trace_file);
-	   }
-	   if(g_steady_power_levels_enabled){
-		   steady_state_tacking_file = gzopen(g_steady_state_tracking_filename, "w");
-		   if ((steady_state_tacking_file == NULL)) {
-			   printf("error - could not open trace files \n");
-			   exit(1);
-		   }
-		   gzsetparams(steady_state_tacking_file,g_power_trace_zlevel, Z_DEFAULT_STRATEGY);
-		   gzprintf(steady_state_tacking_file,"start,end,power,IPC,");
-		   for(unsigned i=0; i<num_perf_counters; i++){
-			   gzprintf(steady_state_tacking_file,perf_count_label[i]);
-		   }
-		   gzprintf(steady_state_tacking_file,"\n");
-
-		   gzclose(steady_state_tacking_file);
-	   }
-
-	   mcpat_init = false;
-	   has_written_avg=false;
-	   powerfile.open(g_power_filename);
-       int flg=chmod(g_power_filename, S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH);
-       assert(flg==0);
-   }
-   sample_val = 0;
-   init_inst_val=init_val;//gpu_tot_sim_insn+gpu_sim_insn;
-
-}
-
-void gpgpu_sim_wrapper::reset_counters(){
-
-	avg_max_min_counters<double> init;
-	for(unsigned i=0; i<num_perf_counters; ++i){
-		sample_perf_counters[i] = 0;
-		kernel_cmp_perf_counters[i] = init;
-	}
-	for(unsigned i=0; i<num_pwr_cmps; ++i){
-		sample_cmp_pwr[i] = 0;
-		kernel_cmp_pwr[i] = init;
-	}
-
-	// Reset per-kernel counters
-	kernel_sample_count = 0;
-	kernel_tot_power = 0;
-	kernel_power = init;
-
-	return;
-}
-
-void gpgpu_sim_wrapper::set_inst_power(bool clk_gated_lanes, double tot_cycles, double busy_cycles, double tot_inst, double int_inst, double fp_inst, double load_inst, double store_inst, double committed_inst)
-{
-	p->sys.core[0].gpgpu_clock_gated_lanes = clk_gated_lanes;
-	p->sys.core[0].total_cycles = tot_cycles;
-	p->sys.core[0].busy_cycles = busy_cycles;
-	p->sys.core[0].total_instructions  = tot_inst * p->sys.scaling_coefficients[TOT_INST];
-	p->sys.core[0].int_instructions    = int_inst * p->sys.scaling_coefficients[FP_INT];
-	p->sys.core[0].fp_instructions     = fp_inst  * p->sys.scaling_coefficients[FP_INT];
-	p->sys.core[0].load_instructions  = load_inst;
-	p->sys.core[0].store_instructions = store_inst;
-	p->sys.core[0].committed_instructions = committed_inst;
-	sample_perf_counters[FP_INT]=int_inst+fp_inst;
-	sample_perf_counters[TOT_INST]=tot_inst;
-}
-
-void gpgpu_sim_wrapper::set_regfile_power(double reads, double writes,double ops)
-{
-	p->sys.core[0].int_regfile_reads = reads * p->sys.scaling_coefficients[REG_RD];
-	p->sys.core[0].int_regfile_writes = writes * p->sys.scaling_coefficients[REG_WR];
-	p->sys.core[0].non_rf_operands =  ops *p->sys.scaling_coefficients[NON_REG_OPs];
-	sample_perf_counters[REG_RD]=reads;
-	sample_perf_counters[REG_WR]=writes;
-	sample_perf_counters[NON_REG_OPs]=ops;
-
-
-
-}
-
-void gpgpu_sim_wrapper::set_icache_power(double hits, double misses)
-{
-	p->sys.core[0].icache.read_accesses = hits * p->sys.scaling_coefficients[IC_H]+misses * p->sys.scaling_coefficients[IC_M];
-	p->sys.core[0].icache.read_misses = misses * p->sys.scaling_coefficients[IC_M];
-	sample_perf_counters[IC_H]=hits;
-	sample_perf_counters[IC_M]=misses;
-
-
-}
-
-void gpgpu_sim_wrapper::set_ccache_power(double hits, double misses)
-{
-	p->sys.core[0].ccache.read_accesses = hits * p->sys.scaling_coefficients[CC_H]+misses * p->sys.scaling_coefficients[CC_M];
-	p->sys.core[0].ccache.read_misses = misses * p->sys.scaling_coefficients[CC_M];
-	sample_perf_counters[CC_H]=hits;
-	sample_perf_counters[CC_M]=misses;
-	// TODO: coalescing logic is counted as part of the caches power (this is not valid for no-caches architectures)
-
-}
-
-void gpgpu_sim_wrapper::set_tcache_power(double hits, double misses)
-{
-	p->sys.core[0].tcache.read_accesses = hits * p->sys.scaling_coefficients[TC_H]+misses * p->sys.scaling_coefficients[TC_M];
-	p->sys.core[0].tcache.read_misses = misses* p->sys.scaling_coefficients[TC_M];
-	sample_perf_counters[TC_H]=hits;
-	sample_perf_counters[TC_M]=misses;
-	// TODO: coalescing logic is counted as part of the caches power (this is not valid for no-caches architectures)
-}
-
-void gpgpu_sim_wrapper::set_shrd_mem_power(double accesses)
-{
-	p->sys.core[0].sharedmemory.read_accesses = accesses * p->sys.scaling_coefficients[SHRD_ACC];
-	sample_perf_counters[SHRD_ACC]=accesses;
-
-
-}
-
-void gpgpu_sim_wrapper::set_l1cache_power(double read_hits, double read_misses, double write_hits, double write_misses)
-{
-	p->sys.core[0].dcache.read_accesses = read_hits * p->sys.scaling_coefficients[DC_RH] +read_misses * p->sys.scaling_coefficients[DC_RM];
-	p->sys.core[0].dcache.read_misses =  read_misses * p->sys.scaling_coefficients[DC_RM];
-	p->sys.core[0].dcache.write_accesses = write_hits * p->sys.scaling_coefficients[DC_WH]+write_misses * p->sys.scaling_coefficients[DC_WM];
-	p->sys.core[0].dcache.write_misses = write_misses * p->sys.scaling_coefficients[DC_WM];
-	sample_perf_counters[DC_RH]=read_hits;
-	sample_perf_counters[DC_RM]=read_misses;
-	sample_perf_counters[DC_WH]=write_hits;
-	sample_perf_counters[DC_WM]=write_misses;
-	// TODO: coalescing logic is counted as part of the caches power (this is not valid for no-caches architectures)
-
-
-
-}
-
-void gpgpu_sim_wrapper::set_l2cache_power(double read_hits, double read_misses, double write_hits, double write_misses)
-{
-	p->sys.l2.total_accesses = read_hits* p->sys.scaling_coefficients[L2_RH]+read_misses * p->sys.scaling_coefficients[L2_RM]+ write_hits * p->sys.scaling_coefficients[L2_WH]+write_misses  * p->sys.scaling_coefficients[L2_WM];
-	p->sys.l2.read_accesses = read_hits* p->sys.scaling_coefficients[L2_RH]+read_misses* p->sys.scaling_coefficients[L2_RM];
-	p->sys.l2.write_accesses = write_hits * p->sys.scaling_coefficients[L2_WH]+write_misses * p->sys.scaling_coefficients[L2_WM];
-	p->sys.l2.read_hits = read_hits * p->sys.scaling_coefficients[L2_RH];
-	p->sys.l2.read_misses = read_misses  * p->sys.scaling_coefficients[L2_RM];
-	p->sys.l2.write_hits =write_hits * p->sys.scaling_coefficients[L2_WH];
-	p->sys.l2.write_misses = write_misses * p->sys.scaling_coefficients[L2_WM];
-	sample_perf_counters[L2_RH]=read_hits;
-	sample_perf_counters[L2_RM]=read_misses;
-	sample_perf_counters[L2_WH]=write_hits;
-	sample_perf_counters[L2_WM]=write_misses;
-}
-
-void gpgpu_sim_wrapper::set_idle_core_power(double num_idle_core)
-{
-	p->sys.num_idle_cores = num_idle_core;
-	sample_perf_counters[IDLE_CORE_N]=num_idle_core;
-}
-
-void gpgpu_sim_wrapper::set_duty_cycle_power(double duty_cycle)
-{
-	p->sys.core[0].pipeline_duty_cycle = duty_cycle  * p->sys.scaling_coefficients[PIPE_A];
-	sample_perf_counters[PIPE_A]=duty_cycle;
-
-}
-
-void gpgpu_sim_wrapper::set_mem_ctrl_power(double reads, double writes, double dram_precharge)
-{
-	p->sys.mc.memory_accesses = reads  * p->sys.scaling_coefficients[MEM_RD]+ writes * p->sys.scaling_coefficients[MEM_WR];
-	p->sys.mc.memory_reads = reads *p->sys.scaling_coefficients[MEM_RD];
-	p->sys.mc.memory_writes = writes*p->sys.scaling_coefficients[MEM_WR];
-	p->sys.mc.dram_pre = dram_precharge*p->sys.scaling_coefficients[MEM_PRE];
-	sample_perf_counters[MEM_RD]=reads;
-	sample_perf_counters[MEM_WR]=writes;
-	sample_perf_counters[MEM_PRE]=dram_precharge;
-
-}
-
-void gpgpu_sim_wrapper::set_exec_unit_power(double fpu_accesses, double ialu_accesses, double sfu_accesses)
-{
-	p->sys.core[0].fpu_accesses = fpu_accesses*p->sys.scaling_coefficients[FPU_ACC];
-    //Integer ALU (not present in Tesla)
-	p->sys.core[0].ialu_accesses = ialu_accesses*p->sys.scaling_coefficients[SP_ACC];
-	//Sfu accesses
-	p->sys.core[0].mul_accesses = sfu_accesses*p->sys.scaling_coefficients[SFU_ACC];
-
-	sample_perf_counters[SP_ACC]=ialu_accesses;
-	sample_perf_counters[SFU_ACC]=sfu_accesses;
-	sample_perf_counters[FPU_ACC]=fpu_accesses;
-
-
-}
-
-void gpgpu_sim_wrapper::set_active_lanes_power(double sp_avg_active_lane, double sfu_avg_active_lane)
-{
-	p->sys.core[0].sp_average_active_lanes = sp_avg_active_lane;
-	p->sys.core[0].sfu_average_active_lanes = sfu_avg_active_lane;
-}
-
-void gpgpu_sim_wrapper::set_NoC_power(double noc_tot_reads, double noc_tot_writes )
-{
-	p->sys.NoC[0].total_accesses = noc_tot_reads * p->sys.scaling_coefficients[NOC_A] + noc_tot_writes * p->sys.scaling_coefficients[NOC_A];
-	sample_perf_counters[NOC_A]=noc_tot_reads+noc_tot_writes;
-}
-
-
-void gpgpu_sim_wrapper::power_metrics_calculations()
-{
-    total_sample_count++;
-    kernel_sample_count++;
-
-    // Current sample power
-    double sample_power = proc->rt_power.readOp.dynamic + sample_cmp_pwr[CONST_DYNAMICP];
-
-    // Average power
-    // Previous + new + constant dynamic power (e.g., dynamic clocking power)
-    kernel_tot_power += sample_power;
-    kernel_power.avg = kernel_tot_power / kernel_sample_count;
-	for(unsigned ind=0; ind<num_pwr_cmps; ++ind){
-		kernel_cmp_pwr[ind].avg += (double)sample_cmp_pwr[ind];
-	}
-
-	for(unsigned ind=0; ind<num_perf_counters; ++ind){
-		kernel_cmp_perf_counters[ind].avg += (double)sample_perf_counters[ind];
-	}
-
-	// Max Power
-	if(sample_power > kernel_power.max){
-		kernel_power.max = sample_power;
-		for(unsigned ind=0; ind<num_pwr_cmps; ++ind){
-			kernel_cmp_pwr[ind].max = (double)sample_cmp_pwr[ind];
-		}
-		for(unsigned ind=0; ind<num_perf_counters; ++ind){
-			kernel_cmp_perf_counters[ind].max = sample_perf_counters[ind];
-		}
-
-	}
-
-	// Min Power
-	if(sample_power < kernel_power.min ||(kernel_power.min==0) ){
-	  kernel_power.min = sample_power;
-	  for(unsigned ind=0; ind<num_pwr_cmps; ++ind){
-		  kernel_cmp_pwr[ind].min = (double)sample_cmp_pwr[ind];
-	  }
-	  for(unsigned ind=0; ind<num_perf_counters; ++ind){
-		  kernel_cmp_perf_counters[ind].min = sample_perf_counters[ind];
-	  }
-	}
-
-	gpu_tot_power.avg = (gpu_tot_power.avg + sample_power);
-	gpu_tot_power.max = (sample_power > gpu_tot_power.max) ? sample_power : gpu_tot_power.max;
-	gpu_tot_power.min = ((sample_power < gpu_tot_power.min) || (gpu_tot_power.min == 0)) ? sample_power : gpu_tot_power.min;
-
-}
-
-
-void gpgpu_sim_wrapper::print_trace_files()
-{
-	open_files();
-
-	for(unsigned i=0; i<num_perf_counters; ++i){
-		gzprintf(metric_trace_file,"%f,",sample_perf_counters[i]);
-	}
-	gzprintf(metric_trace_file,"\n");
-
-	gzprintf(power_trace_file,"%f,",proc_power);
-	for(unsigned i=0; i<num_pwr_cmps; ++i){
-		gzprintf(power_trace_file,"%f,",sample_cmp_pwr[i]);
-	}
-	gzprintf(power_trace_file,"\n");
-
-	close_files();
-
-}
-
-void gpgpu_sim_wrapper::update_coefficients()
-{
-
-	initpower_coeff[FP_INT]=proc->cores[0]->get_coefficient_fpint_insts();
-	effpower_coeff[FP_INT]=initpower_coeff[FP_INT] * p->sys.scaling_coefficients[FP_INT];
-
-	initpower_coeff[TOT_INST]=proc->cores[0]->get_coefficient_tot_insts();
-	effpower_coeff[TOT_INST]=initpower_coeff[TOT_INST] * p->sys.scaling_coefficients[TOT_INST];
-
-	initpower_coeff[REG_RD]=proc->cores[0]->get_coefficient_regreads_accesses()*(proc->cores[0]->exu->rf_fu_clockRate/proc->cores[0]->exu->clockRate);
-	initpower_coeff[REG_WR]=proc->cores[0]->get_coefficient_regwrites_accesses()*(proc->cores[0]->exu->rf_fu_clockRate/proc->cores[0]->exu->clockRate);
-	initpower_coeff[NON_REG_OPs]=proc->cores[0]->get_coefficient_noregfileops_accesses()*(proc->cores[0]->exu->rf_fu_clockRate/proc->cores[0]->exu->clockRate);
-	effpower_coeff[REG_RD]=initpower_coeff[REG_RD]*p->sys.scaling_coefficients[REG_RD];
-	effpower_coeff[REG_WR]=initpower_coeff[REG_WR]*p->sys.scaling_coefficients[REG_WR];
-	effpower_coeff[NON_REG_OPs]=initpower_coeff[NON_REG_OPs]*p->sys.scaling_coefficients[NON_REG_OPs];
-
-	initpower_coeff[IC_H]=proc->cores[0]->get_coefficient_icache_hits();
-	initpower_coeff[IC_M]=proc->cores[0]->get_coefficient_icache_misses();
-	effpower_coeff[IC_H]=initpower_coeff[IC_H]*p->sys.scaling_coefficients[IC_H];
-	effpower_coeff[IC_M]=initpower_coeff[IC_M]*p->sys.scaling_coefficients[IC_M];
-
-	initpower_coeff[CC_H]=(proc->cores[0]->get_coefficient_ccache_readhits()+proc->get_coefficient_readcoalescing());
-	initpower_coeff[CC_M]=(proc->cores[0]->get_coefficient_ccache_readmisses()+proc->get_coefficient_readcoalescing());
-	effpower_coeff[CC_H]=initpower_coeff[CC_H]*p->sys.scaling_coefficients[CC_H];
-	effpower_coeff[CC_M]=initpower_coeff[CC_M]*p->sys.scaling_coefficients[CC_M];
-
-	initpower_coeff[TC_H]=(proc->cores[0]->get_coefficient_tcache_readhits()+proc->get_coefficient_readcoalescing());
-	initpower_coeff[TC_M]=(proc->cores[0]->get_coefficient_tcache_readmisses()+proc->get_coefficient_readcoalescing());
-	effpower_coeff[TC_H]=initpower_coeff[TC_H]*p->sys.scaling_coefficients[TC_H];
-	effpower_coeff[TC_M]=initpower_coeff[TC_M]*p->sys.scaling_coefficients[TC_M];
-
-	initpower_coeff[SHRD_ACC]=proc->cores[0]->get_coefficient_sharedmemory_readhits();
-	effpower_coeff[SHRD_ACC]=initpower_coeff[SHRD_ACC]*p->sys.scaling_coefficients[SHRD_ACC];
-
-	initpower_coeff[DC_RH]=(proc->cores[0]->get_coefficient_dcache_readhits() + proc->get_coefficient_readcoalescing());
-	initpower_coeff[DC_RM]=(proc->cores[0]->get_coefficient_dcache_readmisses() + proc->get_coefficient_readcoalescing());
-	initpower_coeff[DC_WH]=(proc->cores[0]->get_coefficient_dcache_writehits() + proc->get_coefficient_writecoalescing());
-	initpower_coeff[DC_WM]=(proc->cores[0]->get_coefficient_dcache_writemisses() + proc->get_coefficient_writecoalescing());
-	effpower_coeff[DC_RH]=initpower_coeff[DC_RH]*p->sys.scaling_coefficients[DC_RH];
-	effpower_coeff[DC_RM]=initpower_coeff[DC_RM]*p->sys.scaling_coefficients[DC_RM];
-	effpower_coeff[DC_WH]=initpower_coeff[DC_WH]*p->sys.scaling_coefficients[DC_WH];
-	effpower_coeff[DC_WM]=initpower_coeff[DC_WM]*p->sys.scaling_coefficients[DC_WM];
-
-	initpower_coeff[L2_RH]=proc->get_coefficient_l2_read_hits();
-	initpower_coeff[L2_RM]=proc->get_coefficient_l2_read_misses();
-	initpower_coeff[L2_WH]=proc->get_coefficient_l2_write_hits();
-	initpower_coeff[L2_WM]=proc->get_coefficient_l2_write_misses();
-	effpower_coeff[L2_RH]=initpower_coeff[L2_RH]*p->sys.scaling_coefficients[L2_RH];
-	effpower_coeff[L2_RM]=initpower_coeff[L2_RM]*p->sys.scaling_coefficients[L2_RM];
-	effpower_coeff[L2_WH]=initpower_coeff[L2_WH]*p->sys.scaling_coefficients[L2_WH];
-	effpower_coeff[L2_WM]=initpower_coeff[L2_WM]*p->sys.scaling_coefficients[L2_WM];
-
-	initpower_coeff[IDLE_CORE_N]=p->sys.idle_core_power * proc->cores[0]->executionTime;
-	effpower_coeff[IDLE_CORE_N]=initpower_coeff[IDLE_CORE_N]*p->sys.scaling_coefficients[IDLE_CORE_N];
-
-	initpower_coeff[PIPE_A]=proc->cores[0]->get_coefficient_duty_cycle();
-	effpower_coeff[PIPE_A]=initpower_coeff[PIPE_A]*p->sys.scaling_coefficients[PIPE_A];
-
-	initpower_coeff[MEM_RD]=proc->get_coefficient_mem_reads();
-	initpower_coeff[MEM_WR]=proc->get_coefficient_mem_writes();
-	initpower_coeff[MEM_PRE]=proc->get_coefficient_mem_pre();
-	effpower_coeff[MEM_RD]=initpower_coeff[MEM_RD]*p->sys.scaling_coefficients[MEM_RD];
-	effpower_coeff[MEM_WR]=initpower_coeff[MEM_WR]*p->sys.scaling_coefficients[MEM_WR];
-	effpower_coeff[MEM_PRE]=initpower_coeff[MEM_PRE]*p->sys.scaling_coefficients[MEM_PRE];
-
-	initpower_coeff[SP_ACC]=proc->cores[0]->get_coefficient_ialu_accesses()*(proc->cores[0]->exu->rf_fu_clockRate/proc->cores[0]->exu->clockRate);;
-	initpower_coeff[SFU_ACC]=proc->cores[0]->get_coefficient_sfu_accesses();
-	initpower_coeff[FPU_ACC]=proc->cores[0]->get_coefficient_fpu_accesses();
-
-	effpower_coeff[SP_ACC]=initpower_coeff[SP_ACC]*p->sys.scaling_coefficients[SP_ACC];
-	effpower_coeff[SFU_ACC]=initpower_coeff[SFU_ACC]*p->sys.scaling_coefficients[SFU_ACC];
-	effpower_coeff[FPU_ACC]=initpower_coeff[FPU_ACC]*p->sys.scaling_coefficients[FPU_ACC];
-
-	initpower_coeff[NOC_A]=proc->get_coefficient_noc_accesses();
-	effpower_coeff[NOC_A]=initpower_coeff[NOC_A]*p->sys.scaling_coefficients[NOC_A];
-
-	const_dynamic_power=proc->get_const_dynamic_power()/(proc->cores[0]->executionTime);
-
-	for(unsigned i=0; i<num_perf_counters; i++){
-		initpower_coeff[i]/=(proc->cores[0]->executionTime);
-		effpower_coeff[i]/=(proc->cores[0]->executionTime);
-	}
-}
-
-void gpgpu_sim_wrapper::update_components_power()
-{
-
-	update_coefficients();
-
-	proc_power=proc->rt_power.readOp.dynamic;
-
-	sample_cmp_pwr[IBP]=(proc->cores[0]->ifu->IB->rt_power.readOp.dynamic
-			    +proc->cores[0]->ifu->IB->rt_power.writeOp.dynamic
-			    +proc->cores[0]->ifu->ID_misc->rt_power.readOp.dynamic
-			    +proc->cores[0]->ifu->ID_operand->rt_power.readOp.dynamic
-			    +proc->cores[0]->ifu->ID_inst->rt_power.readOp.dynamic)/(proc->cores[0]->executionTime);
-
-	sample_cmp_pwr[ICP]=proc->cores[0]->ifu->icache.rt_power.readOp.dynamic/(proc->cores[0]->executionTime);
-
-	sample_cmp_pwr[DCP]=proc->cores[0]->lsu->dcache.rt_power.readOp.dynamic/(proc->cores[0]->executionTime);
-
-	sample_cmp_pwr[TCP]=proc->cores[0]->lsu->tcache.rt_power.readOp.dynamic/(proc->cores[0]->executionTime);
-
-	sample_cmp_pwr[CCP]=proc->cores[0]->lsu->ccache.rt_power.readOp.dynamic/(proc->cores[0]->executionTime);
-
-	sample_cmp_pwr[SHRDP]=proc->cores[0]->lsu->sharedmemory.rt_power.readOp.dynamic/(proc->cores[0]->executionTime);
-
-	sample_cmp_pwr[RFP]=(proc->cores[0]->exu->rfu->rt_power.readOp.dynamic/(proc->cores[0]->executionTime))
-			   *(proc->cores[0]->exu->rf_fu_clockRate/proc->cores[0]->exu->clockRate);
-
-	sample_cmp_pwr[SPP]=(proc->cores[0]->exu->exeu->rt_power.readOp.dynamic/(proc->cores[0]->executionTime))
-			   *(proc->cores[0]->exu->rf_fu_clockRate/proc->cores[0]->exu->clockRate);
-
-	sample_cmp_pwr[SFUP]=(proc->cores[0]->exu->mul->rt_power.readOp.dynamic/(proc->cores[0]->executionTime));
-
-	sample_cmp_pwr[FPUP]=(proc->cores[0]->exu->fp_u->rt_power.readOp.dynamic/(proc->cores[0]->executionTime));
-
-	sample_cmp_pwr[SCHEDP]=proc->cores[0]->exu->scheu->rt_power.readOp.dynamic/(proc->cores[0]->executionTime);
-
-	sample_cmp_pwr[L2CP]=(proc->XML->sys.number_of_L2s>0)? proc->l2array[0]->rt_power.readOp.dynamic/(proc->cores[0]->executionTime):0;
-
-	sample_cmp_pwr[MCP]=(proc->mc->rt_power.readOp.dynamic-proc->mc->dram->rt_power.readOp.dynamic)/(proc->cores[0]->executionTime);
-
-	sample_cmp_pwr[NOCP]=proc->nocs[0]->rt_power.readOp.dynamic/(proc->cores[0]->executionTime);
-
-	sample_cmp_pwr[DRAMP]=proc->mc->dram->rt_power.readOp.dynamic/(proc->cores[0]->executionTime);
-
-	sample_cmp_pwr[PIPEP]=proc->cores[0]->Pipeline_energy/(proc->cores[0]->executionTime);
-
-	sample_cmp_pwr[IDLE_COREP]=proc->cores[0]->IdleCoreEnergy/(proc->cores[0]->executionTime);
-
-	// This constant dynamic power (e.g., clock power) part is estimated via regression model.
-	sample_cmp_pwr[CONST_DYNAMICP]=0;
-	double cnst_dyn = proc->get_const_dynamic_power()/(proc->cores[0]->executionTime);
-	// If the regression scaling term is greater than the recorded constant dynamic power
-	// then use the difference (other portion already added to dynamic power). Else,
-	// all the constant dynamic power is accounted for, add nothing.
-	if(p->sys.scaling_coefficients[CONST_DYNAMICN] > cnst_dyn)
-		sample_cmp_pwr[CONST_DYNAMICP] = (p->sys.scaling_coefficients[CONST_DYNAMICN]-cnst_dyn);
-
-	proc_power+=sample_cmp_pwr[CONST_DYNAMICP];
-
-	double sum_pwr_cmp=0;
-	for(unsigned i=0; i<num_pwr_cmps; i++){
-		sum_pwr_cmp+=sample_cmp_pwr[i];
-	}
-	bool check=false;
-	check=sanity_check(sum_pwr_cmp,proc_power);
-	assert("Total Power does not equal the sum of the components\n" && (check));
-
-}
-
-void gpgpu_sim_wrapper::compute()
-{
-	proc->compute();
-}
-void gpgpu_sim_wrapper::print_power_kernel_stats(double gpu_sim_cycle, double gpu_tot_sim_cycle, double init_value, const std::string & kernel_info_string, bool print_trace)
-{
-	   detect_print_steady_state(1,init_value);
-	   if(g_power_simulation_enabled){
-
-		   powerfile<<kernel_info_string<<std::endl;
-
-		   sanity_check((kernel_power.avg*kernel_sample_count), kernel_tot_power);
-		   powerfile<<"Kernel Average Power Data:"<<std::endl;
-		   powerfile<<"kernel_avg_power = " << kernel_power.avg << std::endl;
-
-		   for(unsigned i=0; i<num_pwr_cmps; ++i){
-				powerfile<<"gpu_avg_"<<pwr_cmp_label[i]<<" = "<<kernel_cmp_pwr[i].avg/kernel_sample_count<<std::endl;
-		   }
-		   for(unsigned i=0; i<num_perf_counters; ++i){
-				powerfile<<"gpu_avg_"<<perf_count_label[i]<<" = "<<kernel_cmp_perf_counters[i].avg/kernel_sample_count<<std::endl;
-		   }
-
-		   powerfile<<std::endl<<"Kernel Maximum Power Data:"<<std::endl;
-		   powerfile<<"kernel_max_power = "<< kernel_power.max<<std::endl;
-		   for(unsigned i=0; i<num_pwr_cmps; ++i){
-			   powerfile<<"gpu_max_"<<pwr_cmp_label[i]<<" = "<<kernel_cmp_pwr[i].max<<std::endl;
-		   }
-		   for(unsigned i=0; i<num_perf_counters; ++i){
-				powerfile<<"gpu_max_"<<perf_count_label[i]<<" = "<<kernel_cmp_perf_counters[i].max<<std::endl;
-		   }
-
-		   powerfile<<std::endl<<"Kernel Minimum Power Data:"<<std::endl;
-		   powerfile<<"kernel_min_power = "<< kernel_power.min<<std::endl;
-		   for(unsigned i=0; i<num_pwr_cmps; ++i){
-			   powerfile<<"gpu_min_"<<pwr_cmp_label[i]<<" = "<<kernel_cmp_pwr[i].min<<std::endl;
-		   }
-		   for(unsigned i=0; i<num_perf_counters; ++i){
-				powerfile<<"gpu_min_"<<perf_count_label[i]<<" = "<<kernel_cmp_perf_counters[i].min<<std::endl;
-		   }
-
-		   powerfile<<std::endl<<"Accumulative Power Statistics Over Previous Kernels:"<<std::endl;
-		   powerfile<<"gpu_tot_avg_power = "<< gpu_tot_power.avg/total_sample_count<<std::endl;
-		   powerfile<<"gpu_tot_max_power = "<<gpu_tot_power.max<<std::endl;
-		   powerfile<<"gpu_tot_min_power = "<<gpu_tot_power.min<<std::endl;
-		   powerfile<<std::endl<<std::endl;
-		   powerfile.flush();
-
-		   if(print_trace){
-			   print_trace_files();
-		   }
-	   }
-
-}
-void gpgpu_sim_wrapper::dump()
-{
-	if(g_power_per_cycle_dump)
-		proc->displayEnergy(2,5);
-}
-
-void gpgpu_sim_wrapper::print_steady_state(int position, double init_val){
-	double temp_avg = sample_val / (double)samples.size() ;
-	double temp_ipc = (init_val-init_inst_val)/ (double) (samples.size()*gpu_stat_sample_freq);
-
-	if((samples.size() > gpu_steady_min_period)){ // If steady state occurred for some time, print to file
-		has_written_avg=true;
-		gzprintf(steady_state_tacking_file,"%u,%d,%f,%f,",sample_start,total_sample_count,temp_avg,temp_ipc);
-		for(unsigned i=0; i<num_perf_counters; ++i){
-			gzprintf(steady_state_tacking_file,"%f,", samples_counter.at(i)/((double)samples.size()));
-		}
-		gzprintf(steady_state_tacking_file,"\n");
-	}else{
-		if(!has_written_avg && position)
-			gzprintf(steady_state_tacking_file,"ERROR! Not enough steady state points to generate average\n");
-	}
-
-	sample_start = 0;
-	sample_val = 0;
-	init_inst_val=init_val;
-	samples.clear();
-	samples_counter.clear();
-	pwr_counter.clear();
-	assert(samples.size() == 0);
-}
-
-void gpgpu_sim_wrapper::detect_print_steady_state(int position, double init_val)
-{
-	// Calculating Average
-    if(g_power_simulation_enabled && g_steady_power_levels_enabled){
-    	steady_state_tacking_file = gzopen(g_steady_state_tracking_filename,"a");
-		if(position==0){
-			if(samples.size() == 0){
-				// First sample
-				sample_start = total_sample_count;
-				sample_val = proc->rt_power.readOp.dynamic;
-				init_inst_val=init_val;
-				samples.push_back(proc->rt_power.readOp.dynamic);
-				assert(samples_counter.size() == 0);
-				assert(pwr_counter.size() == 0);
-
-				for(unsigned i=0; i<(num_perf_counters); ++i){
-					samples_counter.push_back(sample_perf_counters[i]);
-				}
-
-				for(unsigned i=0; i<(num_pwr_cmps); ++i){
-					pwr_counter.push_back(sample_cmp_pwr[i]);
-				}
-				assert(pwr_counter.size() == (double)num_pwr_cmps);
-				assert(samples_counter.size() == (double)num_perf_counters);
-			}else{
-				// Get current average
-				double temp_avg = sample_val / (double)samples.size() ;
-
-				if( abs(proc->rt_power.readOp.dynamic-temp_avg) < gpu_steady_power_deviation){ // Value is within threshold
-					sample_val += proc->rt_power.readOp.dynamic;
-					samples.push_back(proc->rt_power.readOp.dynamic);
-					for(unsigned i=0; i<(num_perf_counters); ++i){
-						samples_counter.at(i) += sample_perf_counters[i];
-					}
-
-					for(unsigned i=0; i<(num_pwr_cmps); ++i){
-						pwr_counter.at(i) += sample_cmp_pwr[i];
-					}
-
-				}else{	// Value exceeds threshold, not considered steady state
-					print_steady_state(position, init_val);
-				}
-			}
-		}else{
-			print_steady_state(position, init_val);
-		}
-		gzclose(steady_state_tacking_file);
+void gpgpu_sim_wrapper::init_mcpat(
+    char* xmlfile, char* powerfilename, char* power_trace_filename,
+    char* metric_trace_filename, char* steady_state_filename,
+    bool power_sim_enabled, bool trace_enabled, bool steady_state_enabled,
+    bool power_per_cycle_dump, double steady_power_deviation,
+    double steady_min_period, int zlevel, double init_val,
+    int stat_sample_freq) {
+  // Write File Headers for (-metrics trace, -power trace)
+
+  reset_counters();
+  static bool mcpat_init = true;
+
+  // initialize file name if it is not set
+  time_t curr_time;
+  time(&curr_time);
+  char* date = ctime(&curr_time);
+  char* s = date;
+  while (*s) {
+    if (*s == ' ' || *s == '\t' || *s == ':') *s = '-';
+    if (*s == '\n' || *s == '\r') *s = 0;
+    s++;
+  }
+
+  if (mcpat_init) {
+    g_power_filename = powerfilename;
+    g_power_trace_filename = power_trace_filename;
+    g_metric_trace_filename = metric_trace_filename;
+    g_steady_state_tracking_filename = steady_state_filename;
+    xml_filename = xmlfile;
+    g_power_simulation_enabled = power_sim_enabled;
+    g_power_trace_enabled = trace_enabled;
+    g_steady_power_levels_enabled = steady_state_enabled;
+    g_power_trace_zlevel = zlevel;
+    g_power_per_cycle_dump = power_per_cycle_dump;
+    gpu_steady_power_deviation = steady_power_deviation;
+    gpu_steady_min_period = steady_min_period;
+
+    gpu_stat_sample_freq = stat_sample_freq;
+
+    // p->sys.total_cycles=gpu_stat_sample_freq*4;
+    p->sys.total_cycles = gpu_stat_sample_freq;
+    power_trace_file = NULL;
+    metric_trace_file = NULL;
+    steady_state_tacking_file = NULL;
+
+    if (g_power_trace_enabled) {
+      power_trace_file = gzopen(g_power_trace_filename, "w");
+      metric_trace_file = gzopen(g_metric_trace_filename, "w");
+      if ((power_trace_file == NULL) || (metric_trace_file == NULL)) {
+        printf("error - could not open trace files \n");
+        exit(1);
+      }
+      gzsetparams(power_trace_file, g_power_trace_zlevel, Z_DEFAULT_STRATEGY);
+
+      gzprintf(power_trace_file, "power,");
+      for (unsigned i = 0; i < num_pwr_cmps; i++) {
+        gzprintf(power_trace_file, pwr_cmp_label[i]);
+      }
+      gzprintf(power_trace_file, "\n");
+
+      gzsetparams(metric_trace_file, g_power_trace_zlevel, Z_DEFAULT_STRATEGY);
+      for (unsigned i = 0; i < num_perf_counters; i++) {
+        gzprintf(metric_trace_file, perf_count_label[i]);
+      }
+      gzprintf(metric_trace_file, "\n");
+
+      gzclose(power_trace_file);
+      gzclose(metric_trace_file);
     }
+    if (g_steady_power_levels_enabled) {
+      steady_state_tacking_file = gzopen(g_steady_state_tracking_filename, "w");
+      if ((steady_state_tacking_file == NULL)) {
+        printf("error - could not open trace files \n");
+        exit(1);
+      }
+      gzsetparams(steady_state_tacking_file, g_power_trace_zlevel,
+                  Z_DEFAULT_STRATEGY);
+      gzprintf(steady_state_tacking_file, "start,end,power,IPC,");
+      for (unsigned i = 0; i < num_perf_counters; i++) {
+        gzprintf(steady_state_tacking_file, perf_count_label[i]);
+      }
+      gzprintf(steady_state_tacking_file, "\n");
+
+      gzclose(steady_state_tacking_file);
+    }
+
+    mcpat_init = false;
+    has_written_avg = false;
+    powerfile.open(g_power_filename);
+    int flg = chmod(g_power_filename, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+    assert(flg == 0);
+  }
+  sample_val = 0;
+  init_inst_val = init_val;  // gpu_tot_sim_insn+gpu_sim_insn;
 }
 
-void gpgpu_sim_wrapper::open_files()
-{
-    if(g_power_simulation_enabled){
-        if (g_power_trace_enabled ){
-            power_trace_file = gzopen(g_power_trace_filename,  "a");
-            metric_trace_file = gzopen(g_metric_trace_filename, "a");
+void gpgpu_sim_wrapper::reset_counters() {
+  avg_max_min_counters<double> init;
+  for (unsigned i = 0; i < num_perf_counters; ++i) {
+    sample_perf_counters[i] = 0;
+    kernel_cmp_perf_counters[i] = init;
+  }
+  for (unsigned i = 0; i < num_pwr_cmps; ++i) {
+    sample_cmp_pwr[i] = 0;
+    kernel_cmp_pwr[i] = init;
+  }
+
+  // Reset per-kernel counters
+  kernel_sample_count = 0;
+  kernel_tot_power = 0;
+  kernel_power = init;
+
+  return;
+}
+
+void gpgpu_sim_wrapper::set_inst_power(bool clk_gated_lanes, double tot_cycles,
+                                       double busy_cycles, double tot_inst,
+                                       double int_inst, double fp_inst,
+                                       double load_inst, double store_inst,
+                                       double committed_inst) {
+  p->sys.core[0].gpgpu_clock_gated_lanes = clk_gated_lanes;
+  p->sys.core[0].total_cycles = tot_cycles;
+  p->sys.core[0].busy_cycles = busy_cycles;
+  p->sys.core[0].total_instructions =
+      tot_inst * p->sys.scaling_coefficients[TOT_INST];
+  p->sys.core[0].int_instructions =
+      int_inst * p->sys.scaling_coefficients[FP_INT];
+  p->sys.core[0].fp_instructions =
+      fp_inst * p->sys.scaling_coefficients[FP_INT];
+  p->sys.core[0].load_instructions = load_inst;
+  p->sys.core[0].store_instructions = store_inst;
+  p->sys.core[0].committed_instructions = committed_inst;
+  sample_perf_counters[FP_INT] = int_inst + fp_inst;
+  sample_perf_counters[TOT_INST] = tot_inst;
+}
+
+void gpgpu_sim_wrapper::set_regfile_power(double reads, double writes,
+                                          double ops) {
+  p->sys.core[0].int_regfile_reads =
+      reads * p->sys.scaling_coefficients[REG_RD];
+  p->sys.core[0].int_regfile_writes =
+      writes * p->sys.scaling_coefficients[REG_WR];
+  p->sys.core[0].non_rf_operands =
+      ops * p->sys.scaling_coefficients[NON_REG_OPs];
+  sample_perf_counters[REG_RD] = reads;
+  sample_perf_counters[REG_WR] = writes;
+  sample_perf_counters[NON_REG_OPs] = ops;
+}
+
+void gpgpu_sim_wrapper::set_icache_power(double hits, double misses) {
+  p->sys.core[0].icache.read_accesses =
+      hits * p->sys.scaling_coefficients[IC_H] +
+      misses * p->sys.scaling_coefficients[IC_M];
+  p->sys.core[0].icache.read_misses =
+      misses * p->sys.scaling_coefficients[IC_M];
+  sample_perf_counters[IC_H] = hits;
+  sample_perf_counters[IC_M] = misses;
+}
+
+void gpgpu_sim_wrapper::set_ccache_power(double hits, double misses) {
+  p->sys.core[0].ccache.read_accesses =
+      hits * p->sys.scaling_coefficients[CC_H] +
+      misses * p->sys.scaling_coefficients[CC_M];
+  p->sys.core[0].ccache.read_misses =
+      misses * p->sys.scaling_coefficients[CC_M];
+  sample_perf_counters[CC_H] = hits;
+  sample_perf_counters[CC_M] = misses;
+  // TODO: coalescing logic is counted as part of the caches power (this is not
+  // valid for no-caches architectures)
+}
+
+void gpgpu_sim_wrapper::set_tcache_power(double hits, double misses) {
+  p->sys.core[0].tcache.read_accesses =
+      hits * p->sys.scaling_coefficients[TC_H] +
+      misses * p->sys.scaling_coefficients[TC_M];
+  p->sys.core[0].tcache.read_misses =
+      misses * p->sys.scaling_coefficients[TC_M];
+  sample_perf_counters[TC_H] = hits;
+  sample_perf_counters[TC_M] = misses;
+  // TODO: coalescing logic is counted as part of the caches power (this is not
+  // valid for no-caches architectures)
+}
+
+void gpgpu_sim_wrapper::set_shrd_mem_power(double accesses) {
+  p->sys.core[0].sharedmemory.read_accesses =
+      accesses * p->sys.scaling_coefficients[SHRD_ACC];
+  sample_perf_counters[SHRD_ACC] = accesses;
+}
+
+void gpgpu_sim_wrapper::set_l1cache_power(double read_hits, double read_misses,
+                                          double write_hits,
+                                          double write_misses) {
+  p->sys.core[0].dcache.read_accesses =
+      read_hits * p->sys.scaling_coefficients[DC_RH] +
+      read_misses * p->sys.scaling_coefficients[DC_RM];
+  p->sys.core[0].dcache.read_misses =
+      read_misses * p->sys.scaling_coefficients[DC_RM];
+  p->sys.core[0].dcache.write_accesses =
+      write_hits * p->sys.scaling_coefficients[DC_WH] +
+      write_misses * p->sys.scaling_coefficients[DC_WM];
+  p->sys.core[0].dcache.write_misses =
+      write_misses * p->sys.scaling_coefficients[DC_WM];
+  sample_perf_counters[DC_RH] = read_hits;
+  sample_perf_counters[DC_RM] = read_misses;
+  sample_perf_counters[DC_WH] = write_hits;
+  sample_perf_counters[DC_WM] = write_misses;
+  // TODO: coalescing logic is counted as part of the caches power (this is not
+  // valid for no-caches architectures)
+}
+
+void gpgpu_sim_wrapper::set_l2cache_power(double read_hits, double read_misses,
+                                          double write_hits,
+                                          double write_misses) {
+  p->sys.l2.total_accesses = read_hits * p->sys.scaling_coefficients[L2_RH] +
+                             read_misses * p->sys.scaling_coefficients[L2_RM] +
+                             write_hits * p->sys.scaling_coefficients[L2_WH] +
+                             write_misses * p->sys.scaling_coefficients[L2_WM];
+  p->sys.l2.read_accesses = read_hits * p->sys.scaling_coefficients[L2_RH] +
+                            read_misses * p->sys.scaling_coefficients[L2_RM];
+  p->sys.l2.write_accesses = write_hits * p->sys.scaling_coefficients[L2_WH] +
+                             write_misses * p->sys.scaling_coefficients[L2_WM];
+  p->sys.l2.read_hits = read_hits * p->sys.scaling_coefficients[L2_RH];
+  p->sys.l2.read_misses = read_misses * p->sys.scaling_coefficients[L2_RM];
+  p->sys.l2.write_hits = write_hits * p->sys.scaling_coefficients[L2_WH];
+  p->sys.l2.write_misses = write_misses * p->sys.scaling_coefficients[L2_WM];
+  sample_perf_counters[L2_RH] = read_hits;
+  sample_perf_counters[L2_RM] = read_misses;
+  sample_perf_counters[L2_WH] = write_hits;
+  sample_perf_counters[L2_WM] = write_misses;
+}
+
+void gpgpu_sim_wrapper::set_idle_core_power(double num_idle_core) {
+  p->sys.num_idle_cores = num_idle_core;
+  sample_perf_counters[IDLE_CORE_N] = num_idle_core;
+}
+
+void gpgpu_sim_wrapper::set_duty_cycle_power(double duty_cycle) {
+  p->sys.core[0].pipeline_duty_cycle =
+      duty_cycle * p->sys.scaling_coefficients[PIPE_A];
+  sample_perf_counters[PIPE_A] = duty_cycle;
+}
+
+void gpgpu_sim_wrapper::set_mem_ctrl_power(double reads, double writes,
+                                           double dram_precharge) {
+  p->sys.mc.memory_accesses = reads * p->sys.scaling_coefficients[MEM_RD] +
+                              writes * p->sys.scaling_coefficients[MEM_WR];
+  p->sys.mc.memory_reads = reads * p->sys.scaling_coefficients[MEM_RD];
+  p->sys.mc.memory_writes = writes * p->sys.scaling_coefficients[MEM_WR];
+  p->sys.mc.dram_pre = dram_precharge * p->sys.scaling_coefficients[MEM_PRE];
+  sample_perf_counters[MEM_RD] = reads;
+  sample_perf_counters[MEM_WR] = writes;
+  sample_perf_counters[MEM_PRE] = dram_precharge;
+}
+
+void gpgpu_sim_wrapper::set_exec_unit_power(double fpu_accesses,
+                                            double ialu_accesses,
+                                            double sfu_accesses) {
+  p->sys.core[0].fpu_accesses =
+      fpu_accesses * p->sys.scaling_coefficients[FPU_ACC];
+  // Integer ALU (not present in Tesla)
+  p->sys.core[0].ialu_accesses =
+      ialu_accesses * p->sys.scaling_coefficients[SP_ACC];
+  // Sfu accesses
+  p->sys.core[0].mul_accesses =
+      sfu_accesses * p->sys.scaling_coefficients[SFU_ACC];
+
+  sample_perf_counters[SP_ACC] = ialu_accesses;
+  sample_perf_counters[SFU_ACC] = sfu_accesses;
+  sample_perf_counters[FPU_ACC] = fpu_accesses;
+}
+
+void gpgpu_sim_wrapper::set_active_lanes_power(double sp_avg_active_lane,
+                                               double sfu_avg_active_lane) {
+  p->sys.core[0].sp_average_active_lanes = sp_avg_active_lane;
+  p->sys.core[0].sfu_average_active_lanes = sfu_avg_active_lane;
+}
+
+void gpgpu_sim_wrapper::set_NoC_power(double noc_tot_reads,
+                                      double noc_tot_writes) {
+  p->sys.NoC[0].total_accesses =
+      noc_tot_reads * p->sys.scaling_coefficients[NOC_A] +
+      noc_tot_writes * p->sys.scaling_coefficients[NOC_A];
+  sample_perf_counters[NOC_A] = noc_tot_reads + noc_tot_writes;
+}
+
+void gpgpu_sim_wrapper::power_metrics_calculations() {
+  total_sample_count++;
+  kernel_sample_count++;
+
+  // Current sample power
+  double sample_power =
+      proc->rt_power.readOp.dynamic + sample_cmp_pwr[CONST_DYNAMICP];
+
+  // Average power
+  // Previous + new + constant dynamic power (e.g., dynamic clocking power)
+  kernel_tot_power += sample_power;
+  kernel_power.avg = kernel_tot_power / kernel_sample_count;
+  for (unsigned ind = 0; ind < num_pwr_cmps; ++ind) {
+    kernel_cmp_pwr[ind].avg += (double)sample_cmp_pwr[ind];
+  }
+
+  for (unsigned ind = 0; ind < num_perf_counters; ++ind) {
+    kernel_cmp_perf_counters[ind].avg += (double)sample_perf_counters[ind];
+  }
+
+  // Max Power
+  if (sample_power > kernel_power.max) {
+    kernel_power.max = sample_power;
+    for (unsigned ind = 0; ind < num_pwr_cmps; ++ind) {
+      kernel_cmp_pwr[ind].max = (double)sample_cmp_pwr[ind];
+    }
+    for (unsigned ind = 0; ind < num_perf_counters; ++ind) {
+      kernel_cmp_perf_counters[ind].max = sample_perf_counters[ind];
+    }
+  }
+
+  // Min Power
+  if (sample_power < kernel_power.min || (kernel_power.min == 0)) {
+    kernel_power.min = sample_power;
+    for (unsigned ind = 0; ind < num_pwr_cmps; ++ind) {
+      kernel_cmp_pwr[ind].min = (double)sample_cmp_pwr[ind];
+    }
+    for (unsigned ind = 0; ind < num_perf_counters; ++ind) {
+      kernel_cmp_perf_counters[ind].min = sample_perf_counters[ind];
+    }
+  }
+
+  gpu_tot_power.avg = (gpu_tot_power.avg + sample_power);
+  gpu_tot_power.max =
+      (sample_power > gpu_tot_power.max) ? sample_power : gpu_tot_power.max;
+  gpu_tot_power.min =
+      ((sample_power < gpu_tot_power.min) || (gpu_tot_power.min == 0))
+          ? sample_power
+          : gpu_tot_power.min;
+}
+
+void gpgpu_sim_wrapper::print_trace_files() {
+  open_files();
+
+  for (unsigned i = 0; i < num_perf_counters; ++i) {
+    gzprintf(metric_trace_file, "%f,", sample_perf_counters[i]);
+  }
+  gzprintf(metric_trace_file, "\n");
+
+  gzprintf(power_trace_file, "%f,", proc_power);
+  for (unsigned i = 0; i < num_pwr_cmps; ++i) {
+    gzprintf(power_trace_file, "%f,", sample_cmp_pwr[i]);
+  }
+  gzprintf(power_trace_file, "\n");
+
+  close_files();
+}
+
+void gpgpu_sim_wrapper::update_coefficients() {
+  initpower_coeff[FP_INT] = proc->cores[0]->get_coefficient_fpint_insts();
+  effpower_coeff[FP_INT] =
+      initpower_coeff[FP_INT] * p->sys.scaling_coefficients[FP_INT];
+
+  initpower_coeff[TOT_INST] = proc->cores[0]->get_coefficient_tot_insts();
+  effpower_coeff[TOT_INST] =
+      initpower_coeff[TOT_INST] * p->sys.scaling_coefficients[TOT_INST];
+
+  initpower_coeff[REG_RD] =
+      proc->cores[0]->get_coefficient_regreads_accesses() *
+      (proc->cores[0]->exu->rf_fu_clockRate / proc->cores[0]->exu->clockRate);
+  initpower_coeff[REG_WR] =
+      proc->cores[0]->get_coefficient_regwrites_accesses() *
+      (proc->cores[0]->exu->rf_fu_clockRate / proc->cores[0]->exu->clockRate);
+  initpower_coeff[NON_REG_OPs] =
+      proc->cores[0]->get_coefficient_noregfileops_accesses() *
+      (proc->cores[0]->exu->rf_fu_clockRate / proc->cores[0]->exu->clockRate);
+  effpower_coeff[REG_RD] =
+      initpower_coeff[REG_RD] * p->sys.scaling_coefficients[REG_RD];
+  effpower_coeff[REG_WR] =
+      initpower_coeff[REG_WR] * p->sys.scaling_coefficients[REG_WR];
+  effpower_coeff[NON_REG_OPs] =
+      initpower_coeff[NON_REG_OPs] * p->sys.scaling_coefficients[NON_REG_OPs];
+
+  initpower_coeff[IC_H] = proc->cores[0]->get_coefficient_icache_hits();
+  initpower_coeff[IC_M] = proc->cores[0]->get_coefficient_icache_misses();
+  effpower_coeff[IC_H] =
+      initpower_coeff[IC_H] * p->sys.scaling_coefficients[IC_H];
+  effpower_coeff[IC_M] =
+      initpower_coeff[IC_M] * p->sys.scaling_coefficients[IC_M];
+
+  initpower_coeff[CC_H] = (proc->cores[0]->get_coefficient_ccache_readhits() +
+                           proc->get_coefficient_readcoalescing());
+  initpower_coeff[CC_M] = (proc->cores[0]->get_coefficient_ccache_readmisses() +
+                           proc->get_coefficient_readcoalescing());
+  effpower_coeff[CC_H] =
+      initpower_coeff[CC_H] * p->sys.scaling_coefficients[CC_H];
+  effpower_coeff[CC_M] =
+      initpower_coeff[CC_M] * p->sys.scaling_coefficients[CC_M];
+
+  initpower_coeff[TC_H] = (proc->cores[0]->get_coefficient_tcache_readhits() +
+                           proc->get_coefficient_readcoalescing());
+  initpower_coeff[TC_M] = (proc->cores[0]->get_coefficient_tcache_readmisses() +
+                           proc->get_coefficient_readcoalescing());
+  effpower_coeff[TC_H] =
+      initpower_coeff[TC_H] * p->sys.scaling_coefficients[TC_H];
+  effpower_coeff[TC_M] =
+      initpower_coeff[TC_M] * p->sys.scaling_coefficients[TC_M];
+
+  initpower_coeff[SHRD_ACC] =
+      proc->cores[0]->get_coefficient_sharedmemory_readhits();
+  effpower_coeff[SHRD_ACC] =
+      initpower_coeff[SHRD_ACC] * p->sys.scaling_coefficients[SHRD_ACC];
+
+  initpower_coeff[DC_RH] = (proc->cores[0]->get_coefficient_dcache_readhits() +
+                            proc->get_coefficient_readcoalescing());
+  initpower_coeff[DC_RM] =
+      (proc->cores[0]->get_coefficient_dcache_readmisses() +
+       proc->get_coefficient_readcoalescing());
+  initpower_coeff[DC_WH] = (proc->cores[0]->get_coefficient_dcache_writehits() +
+                            proc->get_coefficient_writecoalescing());
+  initpower_coeff[DC_WM] =
+      (proc->cores[0]->get_coefficient_dcache_writemisses() +
+       proc->get_coefficient_writecoalescing());
+  effpower_coeff[DC_RH] =
+      initpower_coeff[DC_RH] * p->sys.scaling_coefficients[DC_RH];
+  effpower_coeff[DC_RM] =
+      initpower_coeff[DC_RM] * p->sys.scaling_coefficients[DC_RM];
+  effpower_coeff[DC_WH] =
+      initpower_coeff[DC_WH] * p->sys.scaling_coefficients[DC_WH];
+  effpower_coeff[DC_WM] =
+      initpower_coeff[DC_WM] * p->sys.scaling_coefficients[DC_WM];
+
+  initpower_coeff[L2_RH] = proc->get_coefficient_l2_read_hits();
+  initpower_coeff[L2_RM] = proc->get_coefficient_l2_read_misses();
+  initpower_coeff[L2_WH] = proc->get_coefficient_l2_write_hits();
+  initpower_coeff[L2_WM] = proc->get_coefficient_l2_write_misses();
+  effpower_coeff[L2_RH] =
+      initpower_coeff[L2_RH] * p->sys.scaling_coefficients[L2_RH];
+  effpower_coeff[L2_RM] =
+      initpower_coeff[L2_RM] * p->sys.scaling_coefficients[L2_RM];
+  effpower_coeff[L2_WH] =
+      initpower_coeff[L2_WH] * p->sys.scaling_coefficients[L2_WH];
+  effpower_coeff[L2_WM] =
+      initpower_coeff[L2_WM] * p->sys.scaling_coefficients[L2_WM];
+
+  initpower_coeff[IDLE_CORE_N] =
+      p->sys.idle_core_power * proc->cores[0]->executionTime;
+  effpower_coeff[IDLE_CORE_N] =
+      initpower_coeff[IDLE_CORE_N] * p->sys.scaling_coefficients[IDLE_CORE_N];
+
+  initpower_coeff[PIPE_A] = proc->cores[0]->get_coefficient_duty_cycle();
+  effpower_coeff[PIPE_A] =
+      initpower_coeff[PIPE_A] * p->sys.scaling_coefficients[PIPE_A];
+
+  initpower_coeff[MEM_RD] = proc->get_coefficient_mem_reads();
+  initpower_coeff[MEM_WR] = proc->get_coefficient_mem_writes();
+  initpower_coeff[MEM_PRE] = proc->get_coefficient_mem_pre();
+  effpower_coeff[MEM_RD] =
+      initpower_coeff[MEM_RD] * p->sys.scaling_coefficients[MEM_RD];
+  effpower_coeff[MEM_WR] =
+      initpower_coeff[MEM_WR] * p->sys.scaling_coefficients[MEM_WR];
+  effpower_coeff[MEM_PRE] =
+      initpower_coeff[MEM_PRE] * p->sys.scaling_coefficients[MEM_PRE];
+
+  initpower_coeff[SP_ACC] =
+      proc->cores[0]->get_coefficient_ialu_accesses() *
+      (proc->cores[0]->exu->rf_fu_clockRate / proc->cores[0]->exu->clockRate);
+  ;
+  initpower_coeff[SFU_ACC] = proc->cores[0]->get_coefficient_sfu_accesses();
+  initpower_coeff[FPU_ACC] = proc->cores[0]->get_coefficient_fpu_accesses();
+
+  effpower_coeff[SP_ACC] =
+      initpower_coeff[SP_ACC] * p->sys.scaling_coefficients[SP_ACC];
+  effpower_coeff[SFU_ACC] =
+      initpower_coeff[SFU_ACC] * p->sys.scaling_coefficients[SFU_ACC];
+  effpower_coeff[FPU_ACC] =
+      initpower_coeff[FPU_ACC] * p->sys.scaling_coefficients[FPU_ACC];
+
+  initpower_coeff[NOC_A] = proc->get_coefficient_noc_accesses();
+  effpower_coeff[NOC_A] =
+      initpower_coeff[NOC_A] * p->sys.scaling_coefficients[NOC_A];
+
+  const_dynamic_power =
+      proc->get_const_dynamic_power() / (proc->cores[0]->executionTime);
+
+  for (unsigned i = 0; i < num_perf_counters; i++) {
+    initpower_coeff[i] /= (proc->cores[0]->executionTime);
+    effpower_coeff[i] /= (proc->cores[0]->executionTime);
+  }
+}
+
+void gpgpu_sim_wrapper::update_components_power() {
+  update_coefficients();
+
+  proc_power = proc->rt_power.readOp.dynamic;
+
+  sample_cmp_pwr[IBP] =
+      (proc->cores[0]->ifu->IB->rt_power.readOp.dynamic +
+       proc->cores[0]->ifu->IB->rt_power.writeOp.dynamic +
+       proc->cores[0]->ifu->ID_misc->rt_power.readOp.dynamic +
+       proc->cores[0]->ifu->ID_operand->rt_power.readOp.dynamic +
+       proc->cores[0]->ifu->ID_inst->rt_power.readOp.dynamic) /
+      (proc->cores[0]->executionTime);
+
+  sample_cmp_pwr[ICP] = proc->cores[0]->ifu->icache.rt_power.readOp.dynamic /
+                        (proc->cores[0]->executionTime);
+
+  sample_cmp_pwr[DCP] = proc->cores[0]->lsu->dcache.rt_power.readOp.dynamic /
+                        (proc->cores[0]->executionTime);
+
+  sample_cmp_pwr[TCP] = proc->cores[0]->lsu->tcache.rt_power.readOp.dynamic /
+                        (proc->cores[0]->executionTime);
+
+  sample_cmp_pwr[CCP] = proc->cores[0]->lsu->ccache.rt_power.readOp.dynamic /
+                        (proc->cores[0]->executionTime);
+
+  sample_cmp_pwr[SHRDP] =
+      proc->cores[0]->lsu->sharedmemory.rt_power.readOp.dynamic /
+      (proc->cores[0]->executionTime);
+
+  sample_cmp_pwr[RFP] =
+      (proc->cores[0]->exu->rfu->rt_power.readOp.dynamic /
+       (proc->cores[0]->executionTime)) *
+      (proc->cores[0]->exu->rf_fu_clockRate / proc->cores[0]->exu->clockRate);
+
+  sample_cmp_pwr[SPP] =
+      (proc->cores[0]->exu->exeu->rt_power.readOp.dynamic /
+       (proc->cores[0]->executionTime)) *
+      (proc->cores[0]->exu->rf_fu_clockRate / proc->cores[0]->exu->clockRate);
+
+  sample_cmp_pwr[SFUP] = (proc->cores[0]->exu->mul->rt_power.readOp.dynamic /
+                          (proc->cores[0]->executionTime));
+
+  sample_cmp_pwr[FPUP] = (proc->cores[0]->exu->fp_u->rt_power.readOp.dynamic /
+                          (proc->cores[0]->executionTime));
+
+  sample_cmp_pwr[SCHEDP] = proc->cores[0]->exu->scheu->rt_power.readOp.dynamic /
+                           (proc->cores[0]->executionTime);
+
+  sample_cmp_pwr[L2CP] = (proc->XML->sys.number_of_L2s > 0)
+                             ? proc->l2array[0]->rt_power.readOp.dynamic /
+                                   (proc->cores[0]->executionTime)
+                             : 0;
+
+  sample_cmp_pwr[MCP] = (proc->mc->rt_power.readOp.dynamic -
+                         proc->mc->dram->rt_power.readOp.dynamic) /
+                        (proc->cores[0]->executionTime);
+
+  sample_cmp_pwr[NOCP] =
+      proc->nocs[0]->rt_power.readOp.dynamic / (proc->cores[0]->executionTime);
+
+  sample_cmp_pwr[DRAMP] =
+      proc->mc->dram->rt_power.readOp.dynamic / (proc->cores[0]->executionTime);
+
+  sample_cmp_pwr[PIPEP] =
+      proc->cores[0]->Pipeline_energy / (proc->cores[0]->executionTime);
+
+  sample_cmp_pwr[IDLE_COREP] =
+      proc->cores[0]->IdleCoreEnergy / (proc->cores[0]->executionTime);
+
+  // This constant dynamic power (e.g., clock power) part is estimated via
+  // regression model.
+  sample_cmp_pwr[CONST_DYNAMICP] = 0;
+  double cnst_dyn =
+      proc->get_const_dynamic_power() / (proc->cores[0]->executionTime);
+  // If the regression scaling term is greater than the recorded constant
+  // dynamic power then use the difference (other portion already added to
+  // dynamic power). Else, all the constant dynamic power is accounted for, add
+  // nothing.
+  if (p->sys.scaling_coefficients[CONST_DYNAMICN] > cnst_dyn)
+    sample_cmp_pwr[CONST_DYNAMICP] =
+        (p->sys.scaling_coefficients[CONST_DYNAMICN] - cnst_dyn);
+
+  proc_power += sample_cmp_pwr[CONST_DYNAMICP];
+
+  double sum_pwr_cmp = 0;
+  for (unsigned i = 0; i < num_pwr_cmps; i++) {
+    sum_pwr_cmp += sample_cmp_pwr[i];
+  }
+  bool check = false;
+  check = sanity_check(sum_pwr_cmp, proc_power);
+  assert("Total Power does not equal the sum of the components\n" && (check));
+}
+
+void gpgpu_sim_wrapper::compute() { proc->compute(); }
+void gpgpu_sim_wrapper::print_power_kernel_stats(
+    double gpu_sim_cycle, double gpu_tot_sim_cycle, double init_value,
+    const std::string& kernel_info_string, bool print_trace) {
+  detect_print_steady_state(1, init_value);
+  if (g_power_simulation_enabled) {
+    powerfile << kernel_info_string << std::endl;
+
+    sanity_check((kernel_power.avg * kernel_sample_count), kernel_tot_power);
+    powerfile << "Kernel Average Power Data:" << std::endl;
+    powerfile << "kernel_avg_power = " << kernel_power.avg << std::endl;
+
+    for (unsigned i = 0; i < num_pwr_cmps; ++i) {
+      powerfile << "gpu_avg_" << pwr_cmp_label[i] << " = "
+                << kernel_cmp_pwr[i].avg / kernel_sample_count << std::endl;
+    }
+    for (unsigned i = 0; i < num_perf_counters; ++i) {
+      powerfile << "gpu_avg_" << perf_count_label[i] << " = "
+                << kernel_cmp_perf_counters[i].avg / kernel_sample_count
+                << std::endl;
+    }
+
+    powerfile << std::endl << "Kernel Maximum Power Data:" << std::endl;
+    powerfile << "kernel_max_power = " << kernel_power.max << std::endl;
+    for (unsigned i = 0; i < num_pwr_cmps; ++i) {
+      powerfile << "gpu_max_" << pwr_cmp_label[i] << " = "
+                << kernel_cmp_pwr[i].max << std::endl;
+    }
+    for (unsigned i = 0; i < num_perf_counters; ++i) {
+      powerfile << "gpu_max_" << perf_count_label[i] << " = "
+                << kernel_cmp_perf_counters[i].max << std::endl;
+    }
+
+    powerfile << std::endl << "Kernel Minimum Power Data:" << std::endl;
+    powerfile << "kernel_min_power = " << kernel_power.min << std::endl;
+    for (unsigned i = 0; i < num_pwr_cmps; ++i) {
+      powerfile << "gpu_min_" << pwr_cmp_label[i] << " = "
+                << kernel_cmp_pwr[i].min << std::endl;
+    }
+    for (unsigned i = 0; i < num_perf_counters; ++i) {
+      powerfile << "gpu_min_" << perf_count_label[i] << " = "
+                << kernel_cmp_perf_counters[i].min << std::endl;
+    }
+
+    powerfile << std::endl
+              << "Accumulative Power Statistics Over Previous Kernels:"
+              << std::endl;
+    powerfile << "gpu_tot_avg_power = "
+              << gpu_tot_power.avg / total_sample_count << std::endl;
+    powerfile << "gpu_tot_max_power = " << gpu_tot_power.max << std::endl;
+    powerfile << "gpu_tot_min_power = " << gpu_tot_power.min << std::endl;
+    powerfile << std::endl << std::endl;
+    powerfile.flush();
+
+    if (print_trace) {
+      print_trace_files();
+    }
+  }
+}
+void gpgpu_sim_wrapper::dump() {
+  if (g_power_per_cycle_dump) proc->displayEnergy(2, 5);
+}
+
+void gpgpu_sim_wrapper::print_steady_state(int position, double init_val) {
+  double temp_avg = sample_val / (double)samples.size();
+  double temp_ipc = (init_val - init_inst_val) /
+                    (double)(samples.size() * gpu_stat_sample_freq);
+
+  if ((samples.size() >
+       gpu_steady_min_period)) {  // If steady state occurred for some time,
+                                  // print to file
+    has_written_avg = true;
+    gzprintf(steady_state_tacking_file, "%u,%d,%f,%f,", sample_start,
+             total_sample_count, temp_avg, temp_ipc);
+    for (unsigned i = 0; i < num_perf_counters; ++i) {
+      gzprintf(steady_state_tacking_file, "%f,",
+               samples_counter.at(i) / ((double)samples.size()));
+    }
+    gzprintf(steady_state_tacking_file, "\n");
+  } else {
+    if (!has_written_avg && position)
+      gzprintf(steady_state_tacking_file,
+               "ERROR! Not enough steady state points to generate average\n");
+  }
+
+  sample_start = 0;
+  sample_val = 0;
+  init_inst_val = init_val;
+  samples.clear();
+  samples_counter.clear();
+  pwr_counter.clear();
+  assert(samples.size() == 0);
+}
+
+void gpgpu_sim_wrapper::detect_print_steady_state(int position,
+                                                  double init_val) {
+  // Calculating Average
+  if (g_power_simulation_enabled && g_steady_power_levels_enabled) {
+    steady_state_tacking_file = gzopen(g_steady_state_tracking_filename, "a");
+    if (position == 0) {
+      if (samples.size() == 0) {
+        // First sample
+        sample_start = total_sample_count;
+        sample_val = proc->rt_power.readOp.dynamic;
+        init_inst_val = init_val;
+        samples.push_back(proc->rt_power.readOp.dynamic);
+        assert(samples_counter.size() == 0);
+        assert(pwr_counter.size() == 0);
+
+        for (unsigned i = 0; i < (num_perf_counters); ++i) {
+          samples_counter.push_back(sample_perf_counters[i]);
         }
-    }
-}
-void gpgpu_sim_wrapper::close_files()
-{
-    if(g_power_simulation_enabled){
-  	  if(g_power_trace_enabled){
-  		  gzclose(power_trace_file);
-  		  gzclose(metric_trace_file);
-  	  }
-  	 }
 
+        for (unsigned i = 0; i < (num_pwr_cmps); ++i) {
+          pwr_counter.push_back(sample_cmp_pwr[i]);
+        }
+        assert(pwr_counter.size() == (double)num_pwr_cmps);
+        assert(samples_counter.size() == (double)num_perf_counters);
+      } else {
+        // Get current average
+        double temp_avg = sample_val / (double)samples.size();
+
+        if (abs(proc->rt_power.readOp.dynamic - temp_avg) <
+            gpu_steady_power_deviation) {  // Value is within threshold
+          sample_val += proc->rt_power.readOp.dynamic;
+          samples.push_back(proc->rt_power.readOp.dynamic);
+          for (unsigned i = 0; i < (num_perf_counters); ++i) {
+            samples_counter.at(i) += sample_perf_counters[i];
+          }
+
+          for (unsigned i = 0; i < (num_pwr_cmps); ++i) {
+            pwr_counter.at(i) += sample_cmp_pwr[i];
+          }
+
+        } else {  // Value exceeds threshold, not considered steady state
+          print_steady_state(position, init_val);
+        }
+      }
+    } else {
+      print_steady_state(position, init_val);
+    }
+    gzclose(steady_state_tacking_file);
+  }
+}
+
+void gpgpu_sim_wrapper::open_files() {
+  if (g_power_simulation_enabled) {
+    if (g_power_trace_enabled) {
+      power_trace_file = gzopen(g_power_trace_filename, "a");
+      metric_trace_file = gzopen(g_metric_trace_filename, "a");
+    }
+  }
+}
+void gpgpu_sim_wrapper::close_files() {
+  if (g_power_simulation_enabled) {
+    if (g_power_trace_enabled) {
+      gzclose(power_trace_file);
+      gzclose(metric_trace_file);
+    }
+  }
 }

--- a/src/gpuwattch/gpgpu_sim_wrapper.cc
+++ b/src/gpuwattch/gpgpu_sim_wrapper.cc
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -30,836 +28,734 @@
 #include "gpgpu_sim_wrapper.h"
 #include <sys/stat.h>
 #define SP_BASE_POWER 0
-#define SFU_BASE_POWER 0
+#define SFU_BASE_POWER  0
 
-static const char* pwr_cmp_label[] = {
-    "IBP,", "ICP,",  "DCP,",   "TCP,",   "CCP,",        "SHRDP,",
-    "RFP,", "SPP,",  "SFUP,",  "FPUP,",  "SCHEDP,",     "L2CP,",
-    "MCP,", "NOCP,", "DRAMP,", "PIPEP,", "IDLE_COREP,", "CONST_DYNAMICP"};
+
+static const char * pwr_cmp_label[] = {"IBP,", "ICP,", "DCP,", "TCP,", "CCP,", "SHRDP,", "RFP,", "SPP,",
+								"SFUP,", "FPUP,", "SCHEDP,", "L2CP,", "MCP,", "NOCP,", "DRAMP,",
+								"PIPEP,", "IDLE_COREP,", "CONST_DYNAMICP"};
 
 enum pwr_cmp_t {
-  IBP = 0,
-  ICP,
-  DCP,
-  TCP,
-  CCP,
-  SHRDP,
-  RFP,
-  SPP,
-  SFUP,
-  FPUP,
-  SCHEDP,
-  L2CP,
-  MCP,
-  NOCP,
-  DRAMP,
-  PIPEP,
-  IDLE_COREP,
-  CONST_DYNAMICP,
-  NUM_COMPONENTS_MODELLED
+   IBP=0,
+   ICP,
+   DCP,
+   TCP,
+   CCP,
+   SHRDP,
+   RFP,
+   SPP,
+   SFUP,
+   FPUP,
+   SCHEDP,
+   L2CP,
+   MCP,
+   NOCP,
+   DRAMP,
+   PIPEP,
+   IDLE_COREP,
+   CONST_DYNAMICP,
+   NUM_COMPONENTS_MODELLED
 };
 
-gpgpu_sim_wrapper::gpgpu_sim_wrapper(bool power_simulation_enabled,
-                                     char* xmlfile) {
-  kernel_sample_count = 0;
-  total_sample_count = 0;
 
-  kernel_tot_power = 0;
+gpgpu_sim_wrapper::gpgpu_sim_wrapper( bool power_simulation_enabled, char* xmlfile) {
+	   kernel_sample_count=0;
+	   total_sample_count=0;
 
-  num_pwr_cmps = NUM_COMPONENTS_MODELLED;
-  num_perf_counters = NUM_PERFORMANCE_COUNTERS;
+	   kernel_tot_power=0;
 
-  // Initialize per-component counter/power vectors
-  avg_max_min_counters<double> init;
-  kernel_cmp_pwr.resize(NUM_COMPONENTS_MODELLED, init);
-  kernel_cmp_perf_counters.resize(NUM_PERFORMANCE_COUNTERS, init);
+	   num_pwr_cmps=NUM_COMPONENTS_MODELLED;
+	   num_perf_counters=NUM_PERFORMANCE_COUNTERS;
 
-  kernel_power = init;   // Per-kernel powers
-  gpu_tot_power = init;  // Global powers
+	   // Initialize per-component counter/power vectors
+	   avg_max_min_counters<double> init;
+	   kernel_cmp_pwr.resize(NUM_COMPONENTS_MODELLED, init);
+	   kernel_cmp_perf_counters.resize(NUM_PERFORMANCE_COUNTERS, init);
 
-  sample_cmp_pwr.resize(NUM_COMPONENTS_MODELLED, 0);
+	   kernel_power = init; // Per-kernel powers
+	   gpu_tot_power = init; // Global powers
 
-  sample_perf_counters.resize(NUM_PERFORMANCE_COUNTERS, 0);
-  initpower_coeff.resize(NUM_PERFORMANCE_COUNTERS, 0);
-  effpower_coeff.resize(NUM_PERFORMANCE_COUNTERS, 0);
+	   sample_cmp_pwr.resize(NUM_COMPONENTS_MODELLED, 0);
 
-  const_dynamic_power = 0;
-  proc_power = 0;
+	   sample_perf_counters.resize(NUM_PERFORMANCE_COUNTERS, 0);
+	   initpower_coeff.resize(NUM_PERFORMANCE_COUNTERS, 0);
+	   effpower_coeff.resize(NUM_PERFORMANCE_COUNTERS, 0);
 
-  g_power_filename = NULL;
-  g_power_trace_filename = NULL;
-  g_metric_trace_filename = NULL;
-  g_steady_state_tracking_filename = NULL;
-  xml_filename = xmlfile;
-  g_power_simulation_enabled = power_simulation_enabled;
-  g_power_trace_enabled = false;
-  g_steady_power_levels_enabled = false;
-  g_power_trace_zlevel = 0;
-  g_power_per_cycle_dump = false;
-  gpu_steady_power_deviation = 0;
-  gpu_steady_min_period = 0;
+	   const_dynamic_power=0;
+	   proc_power=0;
 
-  gpu_stat_sample_freq = 0;
-  p = new ParseXML();
-  if (g_power_simulation_enabled) {
-    p->parse(xml_filename);
-  }
-  proc = new Processor(p);
-  power_trace_file = NULL;
-  metric_trace_file = NULL;
-  steady_state_tacking_file = NULL;
-  has_written_avg = false;
-  init_inst_val = false;
+	   g_power_filename = NULL;
+	   g_power_trace_filename = NULL;
+	   g_metric_trace_filename = NULL;
+	   g_steady_state_tracking_filename = NULL;
+	   xml_filename= xmlfile;
+	   g_power_simulation_enabled= power_simulation_enabled;
+	   g_power_trace_enabled= false;
+	   g_steady_power_levels_enabled= false;
+	   g_power_trace_zlevel= 0;
+	   g_power_per_cycle_dump= false;
+	   gpu_steady_power_deviation= 0;
+	   gpu_steady_min_period= 0;
+
+	   gpu_stat_sample_freq=0;
+	   p=new ParseXML();
+	   if (g_power_simulation_enabled){
+	       p->parse(xml_filename);
+	   }
+	   proc = new Processor(p);
+	   power_trace_file = NULL;
+	   metric_trace_file = NULL;
+	   steady_state_tacking_file = NULL;
+	   has_written_avg=false;
+	   init_inst_val=false;
+
 }
 
-gpgpu_sim_wrapper::~gpgpu_sim_wrapper() {}
+gpgpu_sim_wrapper::~gpgpu_sim_wrapper() { }
 
-bool gpgpu_sim_wrapper::sanity_check(double a, double b) {
-  if (b == 0)
-    return (abs(a - b) < 0.00001);
-  else
-    return (abs(a - b) / abs(b) < 0.00001);
+bool gpgpu_sim_wrapper::sanity_check(double a, double b)
+{
+	if (b == 0)
+		return (abs(a-b)<0.00001);
+	else
+		return (abs(a-b)/abs(b)<0.00001);
 
-  return false;
+	return false;
 }
-void gpgpu_sim_wrapper::init_mcpat(
-    char* xmlfile, char* powerfilename, char* power_trace_filename,
-    char* metric_trace_filename, char* steady_state_filename,
-    bool power_sim_enabled, bool trace_enabled, bool steady_state_enabled,
-    bool power_per_cycle_dump, double steady_power_deviation,
-    double steady_min_period, int zlevel, double init_val,
-    int stat_sample_freq) {
-  // Write File Headers for (-metrics trace, -power trace)
+void gpgpu_sim_wrapper::init_mcpat(char* xmlfile, char* powerfilename, char* power_trace_filename,char* metric_trace_filename,
+								   char * steady_state_filename, bool power_sim_enabled,bool trace_enabled,
+								   bool steady_state_enabled,bool power_per_cycle_dump,double steady_power_deviation,
+								   double steady_min_period, int zlevel, double init_val,int stat_sample_freq ){
+	// Write File Headers for (-metrics trace, -power trace)
 
-  reset_counters();
-  static bool mcpat_init = true;
+	reset_counters();
+   static bool mcpat_init=true;
 
-  // initialize file name if it is not set
-  time_t curr_time;
-  time(&curr_time);
-  char* date = ctime(&curr_time);
-  char* s = date;
-  while (*s) {
-    if (*s == ' ' || *s == '\t' || *s == ':') *s = '-';
-    if (*s == '\n' || *s == '\r') *s = 0;
-    s++;
-  }
+   // initialize file name if it is not set
+   time_t curr_time;
+   time(&curr_time);
+   char *date = ctime(&curr_time);
+   char *s = date;
+   while (*s) {
+       if (*s == ' ' || *s == '\t' || *s == ':') *s = '-';
+       if (*s == '\n' || *s == '\r' ) *s = 0;
+       s++;
+   }
 
-  if (mcpat_init) {
-    g_power_filename = powerfilename;
-    g_power_trace_filename = power_trace_filename;
-    g_metric_trace_filename = metric_trace_filename;
-    g_steady_state_tracking_filename = steady_state_filename;
-    xml_filename = xmlfile;
-    g_power_simulation_enabled = power_sim_enabled;
-    g_power_trace_enabled = trace_enabled;
-    g_steady_power_levels_enabled = steady_state_enabled;
-    g_power_trace_zlevel = zlevel;
-    g_power_per_cycle_dump = power_per_cycle_dump;
-    gpu_steady_power_deviation = steady_power_deviation;
-    gpu_steady_min_period = steady_min_period;
+   if(mcpat_init){
+	   g_power_filename = powerfilename;
+	   g_power_trace_filename =power_trace_filename;
+	   g_metric_trace_filename = metric_trace_filename;
+	   g_steady_state_tracking_filename = steady_state_filename;
+	   xml_filename=xmlfile;
+	   g_power_simulation_enabled=power_sim_enabled;
+	   g_power_trace_enabled=trace_enabled;
+	   g_steady_power_levels_enabled=steady_state_enabled;
+	   g_power_trace_zlevel=zlevel;
+	   g_power_per_cycle_dump=power_per_cycle_dump;
+	   gpu_steady_power_deviation=steady_power_deviation;
+	   gpu_steady_min_period=steady_min_period;
 
-    gpu_stat_sample_freq = stat_sample_freq;
+	   gpu_stat_sample_freq=stat_sample_freq;
 
-    // p->sys.total_cycles=gpu_stat_sample_freq*4;
-    p->sys.total_cycles = gpu_stat_sample_freq;
-    power_trace_file = NULL;
-    metric_trace_file = NULL;
-    steady_state_tacking_file = NULL;
+	   //p->sys.total_cycles=gpu_stat_sample_freq*4;
+	   p->sys.total_cycles=gpu_stat_sample_freq;
+	   power_trace_file = NULL;
+	   metric_trace_file = NULL;
+	   steady_state_tacking_file = NULL;
 
-    if (g_power_trace_enabled) {
-      power_trace_file = gzopen(g_power_trace_filename, "w");
-      metric_trace_file = gzopen(g_metric_trace_filename, "w");
-      if ((power_trace_file == NULL) || (metric_trace_file == NULL)) {
-        printf("error - could not open trace files \n");
-        exit(1);
-      }
-      gzsetparams(power_trace_file, g_power_trace_zlevel, Z_DEFAULT_STRATEGY);
 
-      gzprintf(power_trace_file, "power,");
-      for (unsigned i = 0; i < num_pwr_cmps; i++) {
-        gzprintf(power_trace_file, pwr_cmp_label[i]);
-      }
-      gzprintf(power_trace_file, "\n");
+	   if (g_power_trace_enabled ){
+		   power_trace_file = gzopen(g_power_trace_filename, "w");
+		   metric_trace_file = gzopen(g_metric_trace_filename, "w");
+		   if ((power_trace_file == NULL) || (metric_trace_file == NULL)) {
+			   printf("error - could not open trace files \n");
+			   exit(1);
+		   }
+		   gzsetparams(power_trace_file, g_power_trace_zlevel, Z_DEFAULT_STRATEGY);
 
-      gzsetparams(metric_trace_file, g_power_trace_zlevel, Z_DEFAULT_STRATEGY);
-      for (unsigned i = 0; i < num_perf_counters; i++) {
-        gzprintf(metric_trace_file, perf_count_label[i]);
-      }
-      gzprintf(metric_trace_file, "\n");
+		   gzprintf(power_trace_file,"power,");
+		   for(unsigned i=0; i<num_pwr_cmps; i++){
+			   gzprintf(power_trace_file,pwr_cmp_label[i]);
+		   }
+		   gzprintf(power_trace_file,"\n");
 
-      gzclose(power_trace_file);
-      gzclose(metric_trace_file);
+		   gzsetparams(metric_trace_file, g_power_trace_zlevel, Z_DEFAULT_STRATEGY);
+		   for(unsigned i=0; i<num_perf_counters; i++){
+			   gzprintf(metric_trace_file,perf_count_label[i]);
+		   }
+		   gzprintf(metric_trace_file,"\n");
+
+		   gzclose(power_trace_file);
+		   gzclose(metric_trace_file);
+	   }
+	   if(g_steady_power_levels_enabled){
+		   steady_state_tacking_file = gzopen(g_steady_state_tracking_filename, "w");
+		   if ((steady_state_tacking_file == NULL)) {
+			   printf("error - could not open trace files \n");
+			   exit(1);
+		   }
+		   gzsetparams(steady_state_tacking_file,g_power_trace_zlevel, Z_DEFAULT_STRATEGY);
+		   gzprintf(steady_state_tacking_file,"start,end,power,IPC,");
+		   for(unsigned i=0; i<num_perf_counters; i++){
+			   gzprintf(steady_state_tacking_file,perf_count_label[i]);
+		   }
+		   gzprintf(steady_state_tacking_file,"\n");
+
+		   gzclose(steady_state_tacking_file);
+	   }
+
+	   mcpat_init = false;
+	   has_written_avg=false;
+	   powerfile.open(g_power_filename);
+       int flg=chmod(g_power_filename, S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH);
+       assert(flg==0);
+   }
+   sample_val = 0;
+   init_inst_val=init_val;//gpu_tot_sim_insn+gpu_sim_insn;
+
+}
+
+void gpgpu_sim_wrapper::reset_counters(){
+
+	avg_max_min_counters<double> init;
+	for(unsigned i=0; i<num_perf_counters; ++i){
+		sample_perf_counters[i] = 0;
+		kernel_cmp_perf_counters[i] = init;
+	}
+	for(unsigned i=0; i<num_pwr_cmps; ++i){
+		sample_cmp_pwr[i] = 0;
+		kernel_cmp_pwr[i] = init;
+	}
+
+	// Reset per-kernel counters
+	kernel_sample_count = 0;
+	kernel_tot_power = 0;
+	kernel_power = init;
+
+	return;
+}
+
+void gpgpu_sim_wrapper::set_inst_power(bool clk_gated_lanes, double tot_cycles, double busy_cycles, double tot_inst, double int_inst, double fp_inst, double load_inst, double store_inst, double committed_inst)
+{
+	p->sys.core[0].gpgpu_clock_gated_lanes = clk_gated_lanes;
+	p->sys.core[0].total_cycles = tot_cycles;
+	p->sys.core[0].busy_cycles = busy_cycles;
+	p->sys.core[0].total_instructions  = tot_inst * p->sys.scaling_coefficients[TOT_INST];
+	p->sys.core[0].int_instructions    = int_inst * p->sys.scaling_coefficients[FP_INT];
+	p->sys.core[0].fp_instructions     = fp_inst  * p->sys.scaling_coefficients[FP_INT];
+	p->sys.core[0].load_instructions  = load_inst;
+	p->sys.core[0].store_instructions = store_inst;
+	p->sys.core[0].committed_instructions = committed_inst;
+	sample_perf_counters[FP_INT]=int_inst+fp_inst;
+	sample_perf_counters[TOT_INST]=tot_inst;
+}
+
+void gpgpu_sim_wrapper::set_regfile_power(double reads, double writes,double ops)
+{
+	p->sys.core[0].int_regfile_reads = reads * p->sys.scaling_coefficients[REG_RD];
+	p->sys.core[0].int_regfile_writes = writes * p->sys.scaling_coefficients[REG_WR];
+	p->sys.core[0].non_rf_operands =  ops *p->sys.scaling_coefficients[NON_REG_OPs];
+	sample_perf_counters[REG_RD]=reads;
+	sample_perf_counters[REG_WR]=writes;
+	sample_perf_counters[NON_REG_OPs]=ops;
+
+
+
+}
+
+void gpgpu_sim_wrapper::set_icache_power(double hits, double misses)
+{
+	p->sys.core[0].icache.read_accesses = hits * p->sys.scaling_coefficients[IC_H]+misses * p->sys.scaling_coefficients[IC_M];
+	p->sys.core[0].icache.read_misses = misses * p->sys.scaling_coefficients[IC_M];
+	sample_perf_counters[IC_H]=hits;
+	sample_perf_counters[IC_M]=misses;
+
+
+}
+
+void gpgpu_sim_wrapper::set_ccache_power(double hits, double misses)
+{
+	p->sys.core[0].ccache.read_accesses = hits * p->sys.scaling_coefficients[CC_H]+misses * p->sys.scaling_coefficients[CC_M];
+	p->sys.core[0].ccache.read_misses = misses * p->sys.scaling_coefficients[CC_M];
+	sample_perf_counters[CC_H]=hits;
+	sample_perf_counters[CC_M]=misses;
+	// TODO: coalescing logic is counted as part of the caches power (this is not valid for no-caches architectures)
+
+}
+
+void gpgpu_sim_wrapper::set_tcache_power(double hits, double misses)
+{
+	p->sys.core[0].tcache.read_accesses = hits * p->sys.scaling_coefficients[TC_H]+misses * p->sys.scaling_coefficients[TC_M];
+	p->sys.core[0].tcache.read_misses = misses* p->sys.scaling_coefficients[TC_M];
+	sample_perf_counters[TC_H]=hits;
+	sample_perf_counters[TC_M]=misses;
+	// TODO: coalescing logic is counted as part of the caches power (this is not valid for no-caches architectures)
+}
+
+void gpgpu_sim_wrapper::set_shrd_mem_power(double accesses)
+{
+	p->sys.core[0].sharedmemory.read_accesses = accesses * p->sys.scaling_coefficients[SHRD_ACC];
+	sample_perf_counters[SHRD_ACC]=accesses;
+
+
+}
+
+void gpgpu_sim_wrapper::set_l1cache_power(double read_hits, double read_misses, double write_hits, double write_misses)
+{
+	p->sys.core[0].dcache.read_accesses = read_hits * p->sys.scaling_coefficients[DC_RH] +read_misses * p->sys.scaling_coefficients[DC_RM];
+	p->sys.core[0].dcache.read_misses =  read_misses * p->sys.scaling_coefficients[DC_RM];
+	p->sys.core[0].dcache.write_accesses = write_hits * p->sys.scaling_coefficients[DC_WH]+write_misses * p->sys.scaling_coefficients[DC_WM];
+	p->sys.core[0].dcache.write_misses = write_misses * p->sys.scaling_coefficients[DC_WM];
+	sample_perf_counters[DC_RH]=read_hits;
+	sample_perf_counters[DC_RM]=read_misses;
+	sample_perf_counters[DC_WH]=write_hits;
+	sample_perf_counters[DC_WM]=write_misses;
+	// TODO: coalescing logic is counted as part of the caches power (this is not valid for no-caches architectures)
+
+
+
+}
+
+void gpgpu_sim_wrapper::set_l2cache_power(double read_hits, double read_misses, double write_hits, double write_misses)
+{
+	p->sys.l2.total_accesses = read_hits* p->sys.scaling_coefficients[L2_RH]+read_misses * p->sys.scaling_coefficients[L2_RM]+ write_hits * p->sys.scaling_coefficients[L2_WH]+write_misses  * p->sys.scaling_coefficients[L2_WM];
+	p->sys.l2.read_accesses = read_hits* p->sys.scaling_coefficients[L2_RH]+read_misses* p->sys.scaling_coefficients[L2_RM];
+	p->sys.l2.write_accesses = write_hits * p->sys.scaling_coefficients[L2_WH]+write_misses * p->sys.scaling_coefficients[L2_WM];
+	p->sys.l2.read_hits = read_hits * p->sys.scaling_coefficients[L2_RH];
+	p->sys.l2.read_misses = read_misses  * p->sys.scaling_coefficients[L2_RM];
+	p->sys.l2.write_hits =write_hits * p->sys.scaling_coefficients[L2_WH];
+	p->sys.l2.write_misses = write_misses * p->sys.scaling_coefficients[L2_WM];
+	sample_perf_counters[L2_RH]=read_hits;
+	sample_perf_counters[L2_RM]=read_misses;
+	sample_perf_counters[L2_WH]=write_hits;
+	sample_perf_counters[L2_WM]=write_misses;
+}
+
+void gpgpu_sim_wrapper::set_idle_core_power(double num_idle_core)
+{
+	p->sys.num_idle_cores = num_idle_core;
+	sample_perf_counters[IDLE_CORE_N]=num_idle_core;
+}
+
+void gpgpu_sim_wrapper::set_duty_cycle_power(double duty_cycle)
+{
+	p->sys.core[0].pipeline_duty_cycle = duty_cycle  * p->sys.scaling_coefficients[PIPE_A];
+	sample_perf_counters[PIPE_A]=duty_cycle;
+
+}
+
+void gpgpu_sim_wrapper::set_mem_ctrl_power(double reads, double writes, double dram_precharge)
+{
+	p->sys.mc.memory_accesses = reads  * p->sys.scaling_coefficients[MEM_RD]+ writes * p->sys.scaling_coefficients[MEM_WR];
+	p->sys.mc.memory_reads = reads *p->sys.scaling_coefficients[MEM_RD];
+	p->sys.mc.memory_writes = writes*p->sys.scaling_coefficients[MEM_WR];
+	p->sys.mc.dram_pre = dram_precharge*p->sys.scaling_coefficients[MEM_PRE];
+	sample_perf_counters[MEM_RD]=reads;
+	sample_perf_counters[MEM_WR]=writes;
+	sample_perf_counters[MEM_PRE]=dram_precharge;
+
+}
+
+void gpgpu_sim_wrapper::set_exec_unit_power(double fpu_accesses, double ialu_accesses, double sfu_accesses)
+{
+	p->sys.core[0].fpu_accesses = fpu_accesses*p->sys.scaling_coefficients[FPU_ACC];
+    //Integer ALU (not present in Tesla)
+	p->sys.core[0].ialu_accesses = ialu_accesses*p->sys.scaling_coefficients[SP_ACC];
+	//Sfu accesses
+	p->sys.core[0].mul_accesses = sfu_accesses*p->sys.scaling_coefficients[SFU_ACC];
+
+	sample_perf_counters[SP_ACC]=ialu_accesses;
+	sample_perf_counters[SFU_ACC]=sfu_accesses;
+	sample_perf_counters[FPU_ACC]=fpu_accesses;
+
+
+}
+
+void gpgpu_sim_wrapper::set_active_lanes_power(double sp_avg_active_lane, double sfu_avg_active_lane)
+{
+	p->sys.core[0].sp_average_active_lanes = sp_avg_active_lane;
+	p->sys.core[0].sfu_average_active_lanes = sfu_avg_active_lane;
+}
+
+void gpgpu_sim_wrapper::set_NoC_power(double noc_tot_reads, double noc_tot_writes )
+{
+	p->sys.NoC[0].total_accesses = noc_tot_reads * p->sys.scaling_coefficients[NOC_A] + noc_tot_writes * p->sys.scaling_coefficients[NOC_A];
+	sample_perf_counters[NOC_A]=noc_tot_reads+noc_tot_writes;
+}
+
+
+void gpgpu_sim_wrapper::power_metrics_calculations()
+{
+    total_sample_count++;
+    kernel_sample_count++;
+
+    // Current sample power
+    double sample_power = proc->rt_power.readOp.dynamic + sample_cmp_pwr[CONST_DYNAMICP];
+
+    // Average power
+    // Previous + new + constant dynamic power (e.g., dynamic clocking power)
+    kernel_tot_power += sample_power;
+    kernel_power.avg = kernel_tot_power / kernel_sample_count;
+	for(unsigned ind=0; ind<num_pwr_cmps; ++ind){
+		kernel_cmp_pwr[ind].avg += (double)sample_cmp_pwr[ind];
+	}
+
+	for(unsigned ind=0; ind<num_perf_counters; ++ind){
+		kernel_cmp_perf_counters[ind].avg += (double)sample_perf_counters[ind];
+	}
+
+	// Max Power
+	if(sample_power > kernel_power.max){
+		kernel_power.max = sample_power;
+		for(unsigned ind=0; ind<num_pwr_cmps; ++ind){
+			kernel_cmp_pwr[ind].max = (double)sample_cmp_pwr[ind];
+		}
+		for(unsigned ind=0; ind<num_perf_counters; ++ind){
+			kernel_cmp_perf_counters[ind].max = sample_perf_counters[ind];
+		}
+
+	}
+
+	// Min Power
+	if(sample_power < kernel_power.min ||(kernel_power.min==0) ){
+	  kernel_power.min = sample_power;
+	  for(unsigned ind=0; ind<num_pwr_cmps; ++ind){
+		  kernel_cmp_pwr[ind].min = (double)sample_cmp_pwr[ind];
+	  }
+	  for(unsigned ind=0; ind<num_perf_counters; ++ind){
+		  kernel_cmp_perf_counters[ind].min = sample_perf_counters[ind];
+	  }
+	}
+
+	gpu_tot_power.avg = (gpu_tot_power.avg + sample_power);
+	gpu_tot_power.max = (sample_power > gpu_tot_power.max) ? sample_power : gpu_tot_power.max;
+	gpu_tot_power.min = ((sample_power < gpu_tot_power.min) || (gpu_tot_power.min == 0)) ? sample_power : gpu_tot_power.min;
+
+}
+
+
+void gpgpu_sim_wrapper::print_trace_files()
+{
+	open_files();
+
+	for(unsigned i=0; i<num_perf_counters; ++i){
+		gzprintf(metric_trace_file,"%f,",sample_perf_counters[i]);
+	}
+	gzprintf(metric_trace_file,"\n");
+
+	gzprintf(power_trace_file,"%f,",proc_power);
+	for(unsigned i=0; i<num_pwr_cmps; ++i){
+		gzprintf(power_trace_file,"%f,",sample_cmp_pwr[i]);
+	}
+	gzprintf(power_trace_file,"\n");
+
+	close_files();
+
+}
+
+void gpgpu_sim_wrapper::update_coefficients()
+{
+
+	initpower_coeff[FP_INT]=proc->cores[0]->get_coefficient_fpint_insts();
+	effpower_coeff[FP_INT]=initpower_coeff[FP_INT] * p->sys.scaling_coefficients[FP_INT];
+
+	initpower_coeff[TOT_INST]=proc->cores[0]->get_coefficient_tot_insts();
+	effpower_coeff[TOT_INST]=initpower_coeff[TOT_INST] * p->sys.scaling_coefficients[TOT_INST];
+
+	initpower_coeff[REG_RD]=proc->cores[0]->get_coefficient_regreads_accesses()*(proc->cores[0]->exu->rf_fu_clockRate/proc->cores[0]->exu->clockRate);
+	initpower_coeff[REG_WR]=proc->cores[0]->get_coefficient_regwrites_accesses()*(proc->cores[0]->exu->rf_fu_clockRate/proc->cores[0]->exu->clockRate);
+	initpower_coeff[NON_REG_OPs]=proc->cores[0]->get_coefficient_noregfileops_accesses()*(proc->cores[0]->exu->rf_fu_clockRate/proc->cores[0]->exu->clockRate);
+	effpower_coeff[REG_RD]=initpower_coeff[REG_RD]*p->sys.scaling_coefficients[REG_RD];
+	effpower_coeff[REG_WR]=initpower_coeff[REG_WR]*p->sys.scaling_coefficients[REG_WR];
+	effpower_coeff[NON_REG_OPs]=initpower_coeff[NON_REG_OPs]*p->sys.scaling_coefficients[NON_REG_OPs];
+
+	initpower_coeff[IC_H]=proc->cores[0]->get_coefficient_icache_hits();
+	initpower_coeff[IC_M]=proc->cores[0]->get_coefficient_icache_misses();
+	effpower_coeff[IC_H]=initpower_coeff[IC_H]*p->sys.scaling_coefficients[IC_H];
+	effpower_coeff[IC_M]=initpower_coeff[IC_M]*p->sys.scaling_coefficients[IC_M];
+
+	initpower_coeff[CC_H]=(proc->cores[0]->get_coefficient_ccache_readhits()+proc->get_coefficient_readcoalescing());
+	initpower_coeff[CC_M]=(proc->cores[0]->get_coefficient_ccache_readmisses()+proc->get_coefficient_readcoalescing());
+	effpower_coeff[CC_H]=initpower_coeff[CC_H]*p->sys.scaling_coefficients[CC_H];
+	effpower_coeff[CC_M]=initpower_coeff[CC_M]*p->sys.scaling_coefficients[CC_M];
+
+	initpower_coeff[TC_H]=(proc->cores[0]->get_coefficient_tcache_readhits()+proc->get_coefficient_readcoalescing());
+	initpower_coeff[TC_M]=(proc->cores[0]->get_coefficient_tcache_readmisses()+proc->get_coefficient_readcoalescing());
+	effpower_coeff[TC_H]=initpower_coeff[TC_H]*p->sys.scaling_coefficients[TC_H];
+	effpower_coeff[TC_M]=initpower_coeff[TC_M]*p->sys.scaling_coefficients[TC_M];
+
+	initpower_coeff[SHRD_ACC]=proc->cores[0]->get_coefficient_sharedmemory_readhits();
+	effpower_coeff[SHRD_ACC]=initpower_coeff[SHRD_ACC]*p->sys.scaling_coefficients[SHRD_ACC];
+
+	initpower_coeff[DC_RH]=(proc->cores[0]->get_coefficient_dcache_readhits() + proc->get_coefficient_readcoalescing());
+	initpower_coeff[DC_RM]=(proc->cores[0]->get_coefficient_dcache_readmisses() + proc->get_coefficient_readcoalescing());
+	initpower_coeff[DC_WH]=(proc->cores[0]->get_coefficient_dcache_writehits() + proc->get_coefficient_writecoalescing());
+	initpower_coeff[DC_WM]=(proc->cores[0]->get_coefficient_dcache_writemisses() + proc->get_coefficient_writecoalescing());
+	effpower_coeff[DC_RH]=initpower_coeff[DC_RH]*p->sys.scaling_coefficients[DC_RH];
+	effpower_coeff[DC_RM]=initpower_coeff[DC_RM]*p->sys.scaling_coefficients[DC_RM];
+	effpower_coeff[DC_WH]=initpower_coeff[DC_WH]*p->sys.scaling_coefficients[DC_WH];
+	effpower_coeff[DC_WM]=initpower_coeff[DC_WM]*p->sys.scaling_coefficients[DC_WM];
+
+	initpower_coeff[L2_RH]=proc->get_coefficient_l2_read_hits();
+	initpower_coeff[L2_RM]=proc->get_coefficient_l2_read_misses();
+	initpower_coeff[L2_WH]=proc->get_coefficient_l2_write_hits();
+	initpower_coeff[L2_WM]=proc->get_coefficient_l2_write_misses();
+	effpower_coeff[L2_RH]=initpower_coeff[L2_RH]*p->sys.scaling_coefficients[L2_RH];
+	effpower_coeff[L2_RM]=initpower_coeff[L2_RM]*p->sys.scaling_coefficients[L2_RM];
+	effpower_coeff[L2_WH]=initpower_coeff[L2_WH]*p->sys.scaling_coefficients[L2_WH];
+	effpower_coeff[L2_WM]=initpower_coeff[L2_WM]*p->sys.scaling_coefficients[L2_WM];
+
+	initpower_coeff[IDLE_CORE_N]=p->sys.idle_core_power * proc->cores[0]->executionTime;
+	effpower_coeff[IDLE_CORE_N]=initpower_coeff[IDLE_CORE_N]*p->sys.scaling_coefficients[IDLE_CORE_N];
+
+	initpower_coeff[PIPE_A]=proc->cores[0]->get_coefficient_duty_cycle();
+	effpower_coeff[PIPE_A]=initpower_coeff[PIPE_A]*p->sys.scaling_coefficients[PIPE_A];
+
+	initpower_coeff[MEM_RD]=proc->get_coefficient_mem_reads();
+	initpower_coeff[MEM_WR]=proc->get_coefficient_mem_writes();
+	initpower_coeff[MEM_PRE]=proc->get_coefficient_mem_pre();
+	effpower_coeff[MEM_RD]=initpower_coeff[MEM_RD]*p->sys.scaling_coefficients[MEM_RD];
+	effpower_coeff[MEM_WR]=initpower_coeff[MEM_WR]*p->sys.scaling_coefficients[MEM_WR];
+	effpower_coeff[MEM_PRE]=initpower_coeff[MEM_PRE]*p->sys.scaling_coefficients[MEM_PRE];
+
+	initpower_coeff[SP_ACC]=proc->cores[0]->get_coefficient_ialu_accesses()*(proc->cores[0]->exu->rf_fu_clockRate/proc->cores[0]->exu->clockRate);;
+	initpower_coeff[SFU_ACC]=proc->cores[0]->get_coefficient_sfu_accesses();
+	initpower_coeff[FPU_ACC]=proc->cores[0]->get_coefficient_fpu_accesses();
+
+	effpower_coeff[SP_ACC]=initpower_coeff[SP_ACC]*p->sys.scaling_coefficients[SP_ACC];
+	effpower_coeff[SFU_ACC]=initpower_coeff[SFU_ACC]*p->sys.scaling_coefficients[SFU_ACC];
+	effpower_coeff[FPU_ACC]=initpower_coeff[FPU_ACC]*p->sys.scaling_coefficients[FPU_ACC];
+
+	initpower_coeff[NOC_A]=proc->get_coefficient_noc_accesses();
+	effpower_coeff[NOC_A]=initpower_coeff[NOC_A]*p->sys.scaling_coefficients[NOC_A];
+
+	const_dynamic_power=proc->get_const_dynamic_power()/(proc->cores[0]->executionTime);
+
+	for(unsigned i=0; i<num_perf_counters; i++){
+		initpower_coeff[i]/=(proc->cores[0]->executionTime);
+		effpower_coeff[i]/=(proc->cores[0]->executionTime);
+	}
+}
+
+void gpgpu_sim_wrapper::update_components_power()
+{
+
+	update_coefficients();
+
+	proc_power=proc->rt_power.readOp.dynamic;
+
+	sample_cmp_pwr[IBP]=(proc->cores[0]->ifu->IB->rt_power.readOp.dynamic
+			    +proc->cores[0]->ifu->IB->rt_power.writeOp.dynamic
+			    +proc->cores[0]->ifu->ID_misc->rt_power.readOp.dynamic
+			    +proc->cores[0]->ifu->ID_operand->rt_power.readOp.dynamic
+			    +proc->cores[0]->ifu->ID_inst->rt_power.readOp.dynamic)/(proc->cores[0]->executionTime);
+
+	sample_cmp_pwr[ICP]=proc->cores[0]->ifu->icache.rt_power.readOp.dynamic/(proc->cores[0]->executionTime);
+
+	sample_cmp_pwr[DCP]=proc->cores[0]->lsu->dcache.rt_power.readOp.dynamic/(proc->cores[0]->executionTime);
+
+	sample_cmp_pwr[TCP]=proc->cores[0]->lsu->tcache.rt_power.readOp.dynamic/(proc->cores[0]->executionTime);
+
+	sample_cmp_pwr[CCP]=proc->cores[0]->lsu->ccache.rt_power.readOp.dynamic/(proc->cores[0]->executionTime);
+
+	sample_cmp_pwr[SHRDP]=proc->cores[0]->lsu->sharedmemory.rt_power.readOp.dynamic/(proc->cores[0]->executionTime);
+
+	sample_cmp_pwr[RFP]=(proc->cores[0]->exu->rfu->rt_power.readOp.dynamic/(proc->cores[0]->executionTime))
+			   *(proc->cores[0]->exu->rf_fu_clockRate/proc->cores[0]->exu->clockRate);
+
+	sample_cmp_pwr[SPP]=(proc->cores[0]->exu->exeu->rt_power.readOp.dynamic/(proc->cores[0]->executionTime))
+			   *(proc->cores[0]->exu->rf_fu_clockRate/proc->cores[0]->exu->clockRate);
+
+	sample_cmp_pwr[SFUP]=(proc->cores[0]->exu->mul->rt_power.readOp.dynamic/(proc->cores[0]->executionTime));
+
+	sample_cmp_pwr[FPUP]=(proc->cores[0]->exu->fp_u->rt_power.readOp.dynamic/(proc->cores[0]->executionTime));
+
+	sample_cmp_pwr[SCHEDP]=proc->cores[0]->exu->scheu->rt_power.readOp.dynamic/(proc->cores[0]->executionTime);
+
+	sample_cmp_pwr[L2CP]=(proc->XML->sys.number_of_L2s>0)? proc->l2array[0]->rt_power.readOp.dynamic/(proc->cores[0]->executionTime):0;
+
+	sample_cmp_pwr[MCP]=(proc->mc->rt_power.readOp.dynamic-proc->mc->dram->rt_power.readOp.dynamic)/(proc->cores[0]->executionTime);
+
+	sample_cmp_pwr[NOCP]=proc->nocs[0]->rt_power.readOp.dynamic/(proc->cores[0]->executionTime);
+
+	sample_cmp_pwr[DRAMP]=proc->mc->dram->rt_power.readOp.dynamic/(proc->cores[0]->executionTime);
+
+	sample_cmp_pwr[PIPEP]=proc->cores[0]->Pipeline_energy/(proc->cores[0]->executionTime);
+
+	sample_cmp_pwr[IDLE_COREP]=proc->cores[0]->IdleCoreEnergy/(proc->cores[0]->executionTime);
+
+	// This constant dynamic power (e.g., clock power) part is estimated via regression model.
+	sample_cmp_pwr[CONST_DYNAMICP]=0;
+	double cnst_dyn = proc->get_const_dynamic_power()/(proc->cores[0]->executionTime);
+	// If the regression scaling term is greater than the recorded constant dynamic power
+	// then use the difference (other portion already added to dynamic power). Else,
+	// all the constant dynamic power is accounted for, add nothing.
+	if(p->sys.scaling_coefficients[CONST_DYNAMICN] > cnst_dyn)
+		sample_cmp_pwr[CONST_DYNAMICP] = (p->sys.scaling_coefficients[CONST_DYNAMICN]-cnst_dyn);
+
+	proc_power+=sample_cmp_pwr[CONST_DYNAMICP];
+
+	double sum_pwr_cmp=0;
+	for(unsigned i=0; i<num_pwr_cmps; i++){
+		sum_pwr_cmp+=sample_cmp_pwr[i];
+	}
+	bool check=false;
+	check=sanity_check(sum_pwr_cmp,proc_power);
+	assert("Total Power does not equal the sum of the components\n" && (check));
+
+}
+
+void gpgpu_sim_wrapper::compute()
+{
+	proc->compute();
+}
+void gpgpu_sim_wrapper::print_power_kernel_stats(double gpu_sim_cycle, double gpu_tot_sim_cycle, double init_value, const std::string & kernel_info_string, bool print_trace)
+{
+	   detect_print_steady_state(1,init_value);
+	   if(g_power_simulation_enabled){
+
+		   powerfile<<kernel_info_string<<std::endl;
+
+		   sanity_check((kernel_power.avg*kernel_sample_count), kernel_tot_power);
+		   powerfile<<"Kernel Average Power Data:"<<std::endl;
+		   powerfile<<"kernel_avg_power = " << kernel_power.avg << std::endl;
+
+		   for(unsigned i=0; i<num_pwr_cmps; ++i){
+				powerfile<<"gpu_avg_"<<pwr_cmp_label[i]<<" = "<<kernel_cmp_pwr[i].avg/kernel_sample_count<<std::endl;
+		   }
+		   for(unsigned i=0; i<num_perf_counters; ++i){
+				powerfile<<"gpu_avg_"<<perf_count_label[i]<<" = "<<kernel_cmp_perf_counters[i].avg/kernel_sample_count<<std::endl;
+		   }
+
+		   powerfile<<std::endl<<"Kernel Maximum Power Data:"<<std::endl;
+		   powerfile<<"kernel_max_power = "<< kernel_power.max<<std::endl;
+		   for(unsigned i=0; i<num_pwr_cmps; ++i){
+			   powerfile<<"gpu_max_"<<pwr_cmp_label[i]<<" = "<<kernel_cmp_pwr[i].max<<std::endl;
+		   }
+		   for(unsigned i=0; i<num_perf_counters; ++i){
+				powerfile<<"gpu_max_"<<perf_count_label[i]<<" = "<<kernel_cmp_perf_counters[i].max<<std::endl;
+		   }
+
+		   powerfile<<std::endl<<"Kernel Minimum Power Data:"<<std::endl;
+		   powerfile<<"kernel_min_power = "<< kernel_power.min<<std::endl;
+		   for(unsigned i=0; i<num_pwr_cmps; ++i){
+			   powerfile<<"gpu_min_"<<pwr_cmp_label[i]<<" = "<<kernel_cmp_pwr[i].min<<std::endl;
+		   }
+		   for(unsigned i=0; i<num_perf_counters; ++i){
+				powerfile<<"gpu_min_"<<perf_count_label[i]<<" = "<<kernel_cmp_perf_counters[i].min<<std::endl;
+		   }
+
+		   powerfile<<std::endl<<"Accumulative Power Statistics Over Previous Kernels:"<<std::endl;
+		   powerfile<<"gpu_tot_avg_power = "<< gpu_tot_power.avg/total_sample_count<<std::endl;
+		   powerfile<<"gpu_tot_max_power = "<<gpu_tot_power.max<<std::endl;
+		   powerfile<<"gpu_tot_min_power = "<<gpu_tot_power.min<<std::endl;
+		   powerfile<<std::endl<<std::endl;
+		   powerfile.flush();
+
+		   if(print_trace){
+			   print_trace_files();
+		   }
+	   }
+
+}
+void gpgpu_sim_wrapper::dump()
+{
+	if(g_power_per_cycle_dump)
+		proc->displayEnergy(2,5);
+}
+
+void gpgpu_sim_wrapper::print_steady_state(int position, double init_val){
+	double temp_avg = sample_val / (double)samples.size() ;
+	double temp_ipc = (init_val-init_inst_val)/ (double) (samples.size()*gpu_stat_sample_freq);
+
+	if((samples.size() > gpu_steady_min_period)){ // If steady state occurred for some time, print to file
+		has_written_avg=true;
+		gzprintf(steady_state_tacking_file,"%u,%d,%f,%f,",sample_start,total_sample_count,temp_avg,temp_ipc);
+		for(unsigned i=0; i<num_perf_counters; ++i){
+			gzprintf(steady_state_tacking_file,"%f,", samples_counter.at(i)/((double)samples.size()));
+		}
+		gzprintf(steady_state_tacking_file,"\n");
+	}else{
+		if(!has_written_avg && position)
+			gzprintf(steady_state_tacking_file,"ERROR! Not enough steady state points to generate average\n");
+	}
+
+	sample_start = 0;
+	sample_val = 0;
+	init_inst_val=init_val;
+	samples.clear();
+	samples_counter.clear();
+	pwr_counter.clear();
+	assert(samples.size() == 0);
+}
+
+void gpgpu_sim_wrapper::detect_print_steady_state(int position, double init_val)
+{
+	// Calculating Average
+    if(g_power_simulation_enabled && g_steady_power_levels_enabled){
+    	steady_state_tacking_file = gzopen(g_steady_state_tracking_filename,"a");
+		if(position==0){
+			if(samples.size() == 0){
+				// First sample
+				sample_start = total_sample_count;
+				sample_val = proc->rt_power.readOp.dynamic;
+				init_inst_val=init_val;
+				samples.push_back(proc->rt_power.readOp.dynamic);
+				assert(samples_counter.size() == 0);
+				assert(pwr_counter.size() == 0);
+
+				for(unsigned i=0; i<(num_perf_counters); ++i){
+					samples_counter.push_back(sample_perf_counters[i]);
+				}
+
+				for(unsigned i=0; i<(num_pwr_cmps); ++i){
+					pwr_counter.push_back(sample_cmp_pwr[i]);
+				}
+				assert(pwr_counter.size() == (double)num_pwr_cmps);
+				assert(samples_counter.size() == (double)num_perf_counters);
+			}else{
+				// Get current average
+				double temp_avg = sample_val / (double)samples.size() ;
+
+				if( abs(proc->rt_power.readOp.dynamic-temp_avg) < gpu_steady_power_deviation){ // Value is within threshold
+					sample_val += proc->rt_power.readOp.dynamic;
+					samples.push_back(proc->rt_power.readOp.dynamic);
+					for(unsigned i=0; i<(num_perf_counters); ++i){
+						samples_counter.at(i) += sample_perf_counters[i];
+					}
+
+					for(unsigned i=0; i<(num_pwr_cmps); ++i){
+						pwr_counter.at(i) += sample_cmp_pwr[i];
+					}
+
+				}else{	// Value exceeds threshold, not considered steady state
+					print_steady_state(position, init_val);
+				}
+			}
+		}else{
+			print_steady_state(position, init_val);
+		}
+		gzclose(steady_state_tacking_file);
     }
-    if (g_steady_power_levels_enabled) {
-      steady_state_tacking_file = gzopen(g_steady_state_tracking_filename, "w");
-      if ((steady_state_tacking_file == NULL)) {
-        printf("error - could not open trace files \n");
-        exit(1);
-      }
-      gzsetparams(steady_state_tacking_file, g_power_trace_zlevel,
-                  Z_DEFAULT_STRATEGY);
-      gzprintf(steady_state_tacking_file, "start,end,power,IPC,");
-      for (unsigned i = 0; i < num_perf_counters; i++) {
-        gzprintf(steady_state_tacking_file, perf_count_label[i]);
-      }
-      gzprintf(steady_state_tacking_file, "\n");
-
-      gzclose(steady_state_tacking_file);
-    }
-
-    mcpat_init = false;
-    has_written_avg = false;
-    powerfile.open(g_power_filename);
-    int flg = chmod(g_power_filename, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
-    assert(flg == 0);
-  }
-  sample_val = 0;
-  init_inst_val = init_val;  // gpu_tot_sim_insn+gpu_sim_insn;
 }
 
-void gpgpu_sim_wrapper::reset_counters() {
-  avg_max_min_counters<double> init;
-  for (unsigned i = 0; i < num_perf_counters; ++i) {
-    sample_perf_counters[i] = 0;
-    kernel_cmp_perf_counters[i] = init;
-  }
-  for (unsigned i = 0; i < num_pwr_cmps; ++i) {
-    sample_cmp_pwr[i] = 0;
-    kernel_cmp_pwr[i] = init;
-  }
-
-  // Reset per-kernel counters
-  kernel_sample_count = 0;
-  kernel_tot_power = 0;
-  kernel_power = init;
-
-  return;
-}
-
-void gpgpu_sim_wrapper::set_inst_power(bool clk_gated_lanes, double tot_cycles,
-                                       double busy_cycles, double tot_inst,
-                                       double int_inst, double fp_inst,
-                                       double load_inst, double store_inst,
-                                       double committed_inst) {
-  p->sys.core[0].gpgpu_clock_gated_lanes = clk_gated_lanes;
-  p->sys.core[0].total_cycles = tot_cycles;
-  p->sys.core[0].busy_cycles = busy_cycles;
-  p->sys.core[0].total_instructions =
-      tot_inst * p->sys.scaling_coefficients[TOT_INST];
-  p->sys.core[0].int_instructions =
-      int_inst * p->sys.scaling_coefficients[FP_INT];
-  p->sys.core[0].fp_instructions =
-      fp_inst * p->sys.scaling_coefficients[FP_INT];
-  p->sys.core[0].load_instructions = load_inst;
-  p->sys.core[0].store_instructions = store_inst;
-  p->sys.core[0].committed_instructions = committed_inst;
-  sample_perf_counters[FP_INT] = int_inst + fp_inst;
-  sample_perf_counters[TOT_INST] = tot_inst;
-}
-
-void gpgpu_sim_wrapper::set_regfile_power(double reads, double writes,
-                                          double ops) {
-  p->sys.core[0].int_regfile_reads =
-      reads * p->sys.scaling_coefficients[REG_RD];
-  p->sys.core[0].int_regfile_writes =
-      writes * p->sys.scaling_coefficients[REG_WR];
-  p->sys.core[0].non_rf_operands =
-      ops * p->sys.scaling_coefficients[NON_REG_OPs];
-  sample_perf_counters[REG_RD] = reads;
-  sample_perf_counters[REG_WR] = writes;
-  sample_perf_counters[NON_REG_OPs] = ops;
-}
-
-void gpgpu_sim_wrapper::set_icache_power(double hits, double misses) {
-  p->sys.core[0].icache.read_accesses =
-      hits * p->sys.scaling_coefficients[IC_H] +
-      misses * p->sys.scaling_coefficients[IC_M];
-  p->sys.core[0].icache.read_misses =
-      misses * p->sys.scaling_coefficients[IC_M];
-  sample_perf_counters[IC_H] = hits;
-  sample_perf_counters[IC_M] = misses;
-}
-
-void gpgpu_sim_wrapper::set_ccache_power(double hits, double misses) {
-  p->sys.core[0].ccache.read_accesses =
-      hits * p->sys.scaling_coefficients[CC_H] +
-      misses * p->sys.scaling_coefficients[CC_M];
-  p->sys.core[0].ccache.read_misses =
-      misses * p->sys.scaling_coefficients[CC_M];
-  sample_perf_counters[CC_H] = hits;
-  sample_perf_counters[CC_M] = misses;
-  // TODO: coalescing logic is counted as part of the caches power (this is not
-  // valid for no-caches architectures)
-}
-
-void gpgpu_sim_wrapper::set_tcache_power(double hits, double misses) {
-  p->sys.core[0].tcache.read_accesses =
-      hits * p->sys.scaling_coefficients[TC_H] +
-      misses * p->sys.scaling_coefficients[TC_M];
-  p->sys.core[0].tcache.read_misses =
-      misses * p->sys.scaling_coefficients[TC_M];
-  sample_perf_counters[TC_H] = hits;
-  sample_perf_counters[TC_M] = misses;
-  // TODO: coalescing logic is counted as part of the caches power (this is not
-  // valid for no-caches architectures)
-}
-
-void gpgpu_sim_wrapper::set_shrd_mem_power(double accesses) {
-  p->sys.core[0].sharedmemory.read_accesses =
-      accesses * p->sys.scaling_coefficients[SHRD_ACC];
-  sample_perf_counters[SHRD_ACC] = accesses;
-}
-
-void gpgpu_sim_wrapper::set_l1cache_power(double read_hits, double read_misses,
-                                          double write_hits,
-                                          double write_misses) {
-  p->sys.core[0].dcache.read_accesses =
-      read_hits * p->sys.scaling_coefficients[DC_RH] +
-      read_misses * p->sys.scaling_coefficients[DC_RM];
-  p->sys.core[0].dcache.read_misses =
-      read_misses * p->sys.scaling_coefficients[DC_RM];
-  p->sys.core[0].dcache.write_accesses =
-      write_hits * p->sys.scaling_coefficients[DC_WH] +
-      write_misses * p->sys.scaling_coefficients[DC_WM];
-  p->sys.core[0].dcache.write_misses =
-      write_misses * p->sys.scaling_coefficients[DC_WM];
-  sample_perf_counters[DC_RH] = read_hits;
-  sample_perf_counters[DC_RM] = read_misses;
-  sample_perf_counters[DC_WH] = write_hits;
-  sample_perf_counters[DC_WM] = write_misses;
-  // TODO: coalescing logic is counted as part of the caches power (this is not
-  // valid for no-caches architectures)
-}
-
-void gpgpu_sim_wrapper::set_l2cache_power(double read_hits, double read_misses,
-                                          double write_hits,
-                                          double write_misses) {
-  p->sys.l2.total_accesses = read_hits * p->sys.scaling_coefficients[L2_RH] +
-                             read_misses * p->sys.scaling_coefficients[L2_RM] +
-                             write_hits * p->sys.scaling_coefficients[L2_WH] +
-                             write_misses * p->sys.scaling_coefficients[L2_WM];
-  p->sys.l2.read_accesses = read_hits * p->sys.scaling_coefficients[L2_RH] +
-                            read_misses * p->sys.scaling_coefficients[L2_RM];
-  p->sys.l2.write_accesses = write_hits * p->sys.scaling_coefficients[L2_WH] +
-                             write_misses * p->sys.scaling_coefficients[L2_WM];
-  p->sys.l2.read_hits = read_hits * p->sys.scaling_coefficients[L2_RH];
-  p->sys.l2.read_misses = read_misses * p->sys.scaling_coefficients[L2_RM];
-  p->sys.l2.write_hits = write_hits * p->sys.scaling_coefficients[L2_WH];
-  p->sys.l2.write_misses = write_misses * p->sys.scaling_coefficients[L2_WM];
-  sample_perf_counters[L2_RH] = read_hits;
-  sample_perf_counters[L2_RM] = read_misses;
-  sample_perf_counters[L2_WH] = write_hits;
-  sample_perf_counters[L2_WM] = write_misses;
-}
-
-void gpgpu_sim_wrapper::set_idle_core_power(double num_idle_core) {
-  p->sys.num_idle_cores = num_idle_core;
-  sample_perf_counters[IDLE_CORE_N] = num_idle_core;
-}
-
-void gpgpu_sim_wrapper::set_duty_cycle_power(double duty_cycle) {
-  p->sys.core[0].pipeline_duty_cycle =
-      duty_cycle * p->sys.scaling_coefficients[PIPE_A];
-  sample_perf_counters[PIPE_A] = duty_cycle;
-}
-
-void gpgpu_sim_wrapper::set_mem_ctrl_power(double reads, double writes,
-                                           double dram_precharge) {
-  p->sys.mc.memory_accesses = reads * p->sys.scaling_coefficients[MEM_RD] +
-                              writes * p->sys.scaling_coefficients[MEM_WR];
-  p->sys.mc.memory_reads = reads * p->sys.scaling_coefficients[MEM_RD];
-  p->sys.mc.memory_writes = writes * p->sys.scaling_coefficients[MEM_WR];
-  p->sys.mc.dram_pre = dram_precharge * p->sys.scaling_coefficients[MEM_PRE];
-  sample_perf_counters[MEM_RD] = reads;
-  sample_perf_counters[MEM_WR] = writes;
-  sample_perf_counters[MEM_PRE] = dram_precharge;
-}
-
-void gpgpu_sim_wrapper::set_exec_unit_power(double fpu_accesses,
-                                            double ialu_accesses,
-                                            double sfu_accesses) {
-  p->sys.core[0].fpu_accesses =
-      fpu_accesses * p->sys.scaling_coefficients[FPU_ACC];
-  // Integer ALU (not present in Tesla)
-  p->sys.core[0].ialu_accesses =
-      ialu_accesses * p->sys.scaling_coefficients[SP_ACC];
-  // Sfu accesses
-  p->sys.core[0].mul_accesses =
-      sfu_accesses * p->sys.scaling_coefficients[SFU_ACC];
-
-  sample_perf_counters[SP_ACC] = ialu_accesses;
-  sample_perf_counters[SFU_ACC] = sfu_accesses;
-  sample_perf_counters[FPU_ACC] = fpu_accesses;
-}
-
-void gpgpu_sim_wrapper::set_active_lanes_power(double sp_avg_active_lane,
-                                               double sfu_avg_active_lane) {
-  p->sys.core[0].sp_average_active_lanes = sp_avg_active_lane;
-  p->sys.core[0].sfu_average_active_lanes = sfu_avg_active_lane;
-}
-
-void gpgpu_sim_wrapper::set_NoC_power(double noc_tot_reads,
-                                      double noc_tot_writes) {
-  p->sys.NoC[0].total_accesses =
-      noc_tot_reads * p->sys.scaling_coefficients[NOC_A] +
-      noc_tot_writes * p->sys.scaling_coefficients[NOC_A];
-  sample_perf_counters[NOC_A] = noc_tot_reads + noc_tot_writes;
-}
-
-void gpgpu_sim_wrapper::power_metrics_calculations() {
-  total_sample_count++;
-  kernel_sample_count++;
-
-  // Current sample power
-  double sample_power =
-      proc->rt_power.readOp.dynamic + sample_cmp_pwr[CONST_DYNAMICP];
-
-  // Average power
-  // Previous + new + constant dynamic power (e.g., dynamic clocking power)
-  kernel_tot_power += sample_power;
-  kernel_power.avg = kernel_tot_power / kernel_sample_count;
-  for (unsigned ind = 0; ind < num_pwr_cmps; ++ind) {
-    kernel_cmp_pwr[ind].avg += (double)sample_cmp_pwr[ind];
-  }
-
-  for (unsigned ind = 0; ind < num_perf_counters; ++ind) {
-    kernel_cmp_perf_counters[ind].avg += (double)sample_perf_counters[ind];
-  }
-
-  // Max Power
-  if (sample_power > kernel_power.max) {
-    kernel_power.max = sample_power;
-    for (unsigned ind = 0; ind < num_pwr_cmps; ++ind) {
-      kernel_cmp_pwr[ind].max = (double)sample_cmp_pwr[ind];
-    }
-    for (unsigned ind = 0; ind < num_perf_counters; ++ind) {
-      kernel_cmp_perf_counters[ind].max = sample_perf_counters[ind];
-    }
-  }
-
-  // Min Power
-  if (sample_power < kernel_power.min || (kernel_power.min == 0)) {
-    kernel_power.min = sample_power;
-    for (unsigned ind = 0; ind < num_pwr_cmps; ++ind) {
-      kernel_cmp_pwr[ind].min = (double)sample_cmp_pwr[ind];
-    }
-    for (unsigned ind = 0; ind < num_perf_counters; ++ind) {
-      kernel_cmp_perf_counters[ind].min = sample_perf_counters[ind];
-    }
-  }
-
-  gpu_tot_power.avg = (gpu_tot_power.avg + sample_power);
-  gpu_tot_power.max =
-      (sample_power > gpu_tot_power.max) ? sample_power : gpu_tot_power.max;
-  gpu_tot_power.min =
-      ((sample_power < gpu_tot_power.min) || (gpu_tot_power.min == 0))
-          ? sample_power
-          : gpu_tot_power.min;
-}
-
-void gpgpu_sim_wrapper::print_trace_files() {
-  open_files();
-
-  for (unsigned i = 0; i < num_perf_counters; ++i) {
-    gzprintf(metric_trace_file, "%f,", sample_perf_counters[i]);
-  }
-  gzprintf(metric_trace_file, "\n");
-
-  gzprintf(power_trace_file, "%f,", proc_power);
-  for (unsigned i = 0; i < num_pwr_cmps; ++i) {
-    gzprintf(power_trace_file, "%f,", sample_cmp_pwr[i]);
-  }
-  gzprintf(power_trace_file, "\n");
-
-  close_files();
-}
-
-void gpgpu_sim_wrapper::update_coefficients() {
-  initpower_coeff[FP_INT] = proc->cores[0]->get_coefficient_fpint_insts();
-  effpower_coeff[FP_INT] =
-      initpower_coeff[FP_INT] * p->sys.scaling_coefficients[FP_INT];
-
-  initpower_coeff[TOT_INST] = proc->cores[0]->get_coefficient_tot_insts();
-  effpower_coeff[TOT_INST] =
-      initpower_coeff[TOT_INST] * p->sys.scaling_coefficients[TOT_INST];
-
-  initpower_coeff[REG_RD] =
-      proc->cores[0]->get_coefficient_regreads_accesses() *
-      (proc->cores[0]->exu->rf_fu_clockRate / proc->cores[0]->exu->clockRate);
-  initpower_coeff[REG_WR] =
-      proc->cores[0]->get_coefficient_regwrites_accesses() *
-      (proc->cores[0]->exu->rf_fu_clockRate / proc->cores[0]->exu->clockRate);
-  initpower_coeff[NON_REG_OPs] =
-      proc->cores[0]->get_coefficient_noregfileops_accesses() *
-      (proc->cores[0]->exu->rf_fu_clockRate / proc->cores[0]->exu->clockRate);
-  effpower_coeff[REG_RD] =
-      initpower_coeff[REG_RD] * p->sys.scaling_coefficients[REG_RD];
-  effpower_coeff[REG_WR] =
-      initpower_coeff[REG_WR] * p->sys.scaling_coefficients[REG_WR];
-  effpower_coeff[NON_REG_OPs] =
-      initpower_coeff[NON_REG_OPs] * p->sys.scaling_coefficients[NON_REG_OPs];
-
-  initpower_coeff[IC_H] = proc->cores[0]->get_coefficient_icache_hits();
-  initpower_coeff[IC_M] = proc->cores[0]->get_coefficient_icache_misses();
-  effpower_coeff[IC_H] =
-      initpower_coeff[IC_H] * p->sys.scaling_coefficients[IC_H];
-  effpower_coeff[IC_M] =
-      initpower_coeff[IC_M] * p->sys.scaling_coefficients[IC_M];
-
-  initpower_coeff[CC_H] = (proc->cores[0]->get_coefficient_ccache_readhits() +
-                           proc->get_coefficient_readcoalescing());
-  initpower_coeff[CC_M] = (proc->cores[0]->get_coefficient_ccache_readmisses() +
-                           proc->get_coefficient_readcoalescing());
-  effpower_coeff[CC_H] =
-      initpower_coeff[CC_H] * p->sys.scaling_coefficients[CC_H];
-  effpower_coeff[CC_M] =
-      initpower_coeff[CC_M] * p->sys.scaling_coefficients[CC_M];
-
-  initpower_coeff[TC_H] = (proc->cores[0]->get_coefficient_tcache_readhits() +
-                           proc->get_coefficient_readcoalescing());
-  initpower_coeff[TC_M] = (proc->cores[0]->get_coefficient_tcache_readmisses() +
-                           proc->get_coefficient_readcoalescing());
-  effpower_coeff[TC_H] =
-      initpower_coeff[TC_H] * p->sys.scaling_coefficients[TC_H];
-  effpower_coeff[TC_M] =
-      initpower_coeff[TC_M] * p->sys.scaling_coefficients[TC_M];
-
-  initpower_coeff[SHRD_ACC] =
-      proc->cores[0]->get_coefficient_sharedmemory_readhits();
-  effpower_coeff[SHRD_ACC] =
-      initpower_coeff[SHRD_ACC] * p->sys.scaling_coefficients[SHRD_ACC];
-
-  initpower_coeff[DC_RH] = (proc->cores[0]->get_coefficient_dcache_readhits() +
-                            proc->get_coefficient_readcoalescing());
-  initpower_coeff[DC_RM] =
-      (proc->cores[0]->get_coefficient_dcache_readmisses() +
-       proc->get_coefficient_readcoalescing());
-  initpower_coeff[DC_WH] = (proc->cores[0]->get_coefficient_dcache_writehits() +
-                            proc->get_coefficient_writecoalescing());
-  initpower_coeff[DC_WM] =
-      (proc->cores[0]->get_coefficient_dcache_writemisses() +
-       proc->get_coefficient_writecoalescing());
-  effpower_coeff[DC_RH] =
-      initpower_coeff[DC_RH] * p->sys.scaling_coefficients[DC_RH];
-  effpower_coeff[DC_RM] =
-      initpower_coeff[DC_RM] * p->sys.scaling_coefficients[DC_RM];
-  effpower_coeff[DC_WH] =
-      initpower_coeff[DC_WH] * p->sys.scaling_coefficients[DC_WH];
-  effpower_coeff[DC_WM] =
-      initpower_coeff[DC_WM] * p->sys.scaling_coefficients[DC_WM];
-
-  initpower_coeff[L2_RH] = proc->get_coefficient_l2_read_hits();
-  initpower_coeff[L2_RM] = proc->get_coefficient_l2_read_misses();
-  initpower_coeff[L2_WH] = proc->get_coefficient_l2_write_hits();
-  initpower_coeff[L2_WM] = proc->get_coefficient_l2_write_misses();
-  effpower_coeff[L2_RH] =
-      initpower_coeff[L2_RH] * p->sys.scaling_coefficients[L2_RH];
-  effpower_coeff[L2_RM] =
-      initpower_coeff[L2_RM] * p->sys.scaling_coefficients[L2_RM];
-  effpower_coeff[L2_WH] =
-      initpower_coeff[L2_WH] * p->sys.scaling_coefficients[L2_WH];
-  effpower_coeff[L2_WM] =
-      initpower_coeff[L2_WM] * p->sys.scaling_coefficients[L2_WM];
-
-  initpower_coeff[IDLE_CORE_N] =
-      p->sys.idle_core_power * proc->cores[0]->executionTime;
-  effpower_coeff[IDLE_CORE_N] =
-      initpower_coeff[IDLE_CORE_N] * p->sys.scaling_coefficients[IDLE_CORE_N];
-
-  initpower_coeff[PIPE_A] = proc->cores[0]->get_coefficient_duty_cycle();
-  effpower_coeff[PIPE_A] =
-      initpower_coeff[PIPE_A] * p->sys.scaling_coefficients[PIPE_A];
-
-  initpower_coeff[MEM_RD] = proc->get_coefficient_mem_reads();
-  initpower_coeff[MEM_WR] = proc->get_coefficient_mem_writes();
-  initpower_coeff[MEM_PRE] = proc->get_coefficient_mem_pre();
-  effpower_coeff[MEM_RD] =
-      initpower_coeff[MEM_RD] * p->sys.scaling_coefficients[MEM_RD];
-  effpower_coeff[MEM_WR] =
-      initpower_coeff[MEM_WR] * p->sys.scaling_coefficients[MEM_WR];
-  effpower_coeff[MEM_PRE] =
-      initpower_coeff[MEM_PRE] * p->sys.scaling_coefficients[MEM_PRE];
-
-  initpower_coeff[SP_ACC] =
-      proc->cores[0]->get_coefficient_ialu_accesses() *
-      (proc->cores[0]->exu->rf_fu_clockRate / proc->cores[0]->exu->clockRate);
-  ;
-  initpower_coeff[SFU_ACC] = proc->cores[0]->get_coefficient_sfu_accesses();
-  initpower_coeff[FPU_ACC] = proc->cores[0]->get_coefficient_fpu_accesses();
-
-  effpower_coeff[SP_ACC] =
-      initpower_coeff[SP_ACC] * p->sys.scaling_coefficients[SP_ACC];
-  effpower_coeff[SFU_ACC] =
-      initpower_coeff[SFU_ACC] * p->sys.scaling_coefficients[SFU_ACC];
-  effpower_coeff[FPU_ACC] =
-      initpower_coeff[FPU_ACC] * p->sys.scaling_coefficients[FPU_ACC];
-
-  initpower_coeff[NOC_A] = proc->get_coefficient_noc_accesses();
-  effpower_coeff[NOC_A] =
-      initpower_coeff[NOC_A] * p->sys.scaling_coefficients[NOC_A];
-
-  const_dynamic_power =
-      proc->get_const_dynamic_power() / (proc->cores[0]->executionTime);
-
-  for (unsigned i = 0; i < num_perf_counters; i++) {
-    initpower_coeff[i] /= (proc->cores[0]->executionTime);
-    effpower_coeff[i] /= (proc->cores[0]->executionTime);
-  }
-}
-
-void gpgpu_sim_wrapper::update_components_power() {
-  update_coefficients();
-
-  proc_power = proc->rt_power.readOp.dynamic;
-
-  sample_cmp_pwr[IBP] =
-      (proc->cores[0]->ifu->IB->rt_power.readOp.dynamic +
-       proc->cores[0]->ifu->IB->rt_power.writeOp.dynamic +
-       proc->cores[0]->ifu->ID_misc->rt_power.readOp.dynamic +
-       proc->cores[0]->ifu->ID_operand->rt_power.readOp.dynamic +
-       proc->cores[0]->ifu->ID_inst->rt_power.readOp.dynamic) /
-      (proc->cores[0]->executionTime);
-
-  sample_cmp_pwr[ICP] = proc->cores[0]->ifu->icache.rt_power.readOp.dynamic /
-                        (proc->cores[0]->executionTime);
-
-  sample_cmp_pwr[DCP] = proc->cores[0]->lsu->dcache.rt_power.readOp.dynamic /
-                        (proc->cores[0]->executionTime);
-
-  sample_cmp_pwr[TCP] = proc->cores[0]->lsu->tcache.rt_power.readOp.dynamic /
-                        (proc->cores[0]->executionTime);
-
-  sample_cmp_pwr[CCP] = proc->cores[0]->lsu->ccache.rt_power.readOp.dynamic /
-                        (proc->cores[0]->executionTime);
-
-  sample_cmp_pwr[SHRDP] =
-      proc->cores[0]->lsu->sharedmemory.rt_power.readOp.dynamic /
-      (proc->cores[0]->executionTime);
-
-  sample_cmp_pwr[RFP] =
-      (proc->cores[0]->exu->rfu->rt_power.readOp.dynamic /
-       (proc->cores[0]->executionTime)) *
-      (proc->cores[0]->exu->rf_fu_clockRate / proc->cores[0]->exu->clockRate);
-
-  sample_cmp_pwr[SPP] =
-      (proc->cores[0]->exu->exeu->rt_power.readOp.dynamic /
-       (proc->cores[0]->executionTime)) *
-      (proc->cores[0]->exu->rf_fu_clockRate / proc->cores[0]->exu->clockRate);
-
-  sample_cmp_pwr[SFUP] = (proc->cores[0]->exu->mul->rt_power.readOp.dynamic /
-                          (proc->cores[0]->executionTime));
-
-  sample_cmp_pwr[FPUP] = (proc->cores[0]->exu->fp_u->rt_power.readOp.dynamic /
-                          (proc->cores[0]->executionTime));
-
-  sample_cmp_pwr[SCHEDP] = proc->cores[0]->exu->scheu->rt_power.readOp.dynamic /
-                           (proc->cores[0]->executionTime);
-
-  sample_cmp_pwr[L2CP] = (proc->XML->sys.number_of_L2s > 0)
-                             ? proc->l2array[0]->rt_power.readOp.dynamic /
-                                   (proc->cores[0]->executionTime)
-                             : 0;
-
-  sample_cmp_pwr[MCP] = (proc->mc->rt_power.readOp.dynamic -
-                         proc->mc->dram->rt_power.readOp.dynamic) /
-                        (proc->cores[0]->executionTime);
-
-  sample_cmp_pwr[NOCP] =
-      proc->nocs[0]->rt_power.readOp.dynamic / (proc->cores[0]->executionTime);
-
-  sample_cmp_pwr[DRAMP] =
-      proc->mc->dram->rt_power.readOp.dynamic / (proc->cores[0]->executionTime);
-
-  sample_cmp_pwr[PIPEP] =
-      proc->cores[0]->Pipeline_energy / (proc->cores[0]->executionTime);
-
-  sample_cmp_pwr[IDLE_COREP] =
-      proc->cores[0]->IdleCoreEnergy / (proc->cores[0]->executionTime);
-
-  // This constant dynamic power (e.g., clock power) part is estimated via
-  // regression model.
-  sample_cmp_pwr[CONST_DYNAMICP] = 0;
-  double cnst_dyn =
-      proc->get_const_dynamic_power() / (proc->cores[0]->executionTime);
-  // If the regression scaling term is greater than the recorded constant
-  // dynamic power
-  // then use the difference (other portion already added to dynamic power).
-  // Else,
-  // all the constant dynamic power is accounted for, add nothing.
-  if (p->sys.scaling_coefficients[CONST_DYNAMICN] > cnst_dyn)
-    sample_cmp_pwr[CONST_DYNAMICP] =
-        (p->sys.scaling_coefficients[CONST_DYNAMICN] - cnst_dyn);
-
-  proc_power += sample_cmp_pwr[CONST_DYNAMICP];
-
-  double sum_pwr_cmp = 0;
-  for (unsigned i = 0; i < num_pwr_cmps; i++) {
-    sum_pwr_cmp += sample_cmp_pwr[i];
-  }
-  bool check = false;
-  check = sanity_check(sum_pwr_cmp, proc_power);
-  assert("Total Power does not equal the sum of the components\n" && (check));
-}
-
-void gpgpu_sim_wrapper::compute() { proc->compute(); }
-void gpgpu_sim_wrapper::print_power_kernel_stats(
-    double gpu_sim_cycle, double gpu_tot_sim_cycle, double init_value,
-    const std::string& kernel_info_string, bool print_trace) {
-  detect_print_steady_state(1, init_value);
-  if (g_power_simulation_enabled) {
-    powerfile << kernel_info_string << std::endl;
-
-    sanity_check((kernel_power.avg * kernel_sample_count), kernel_tot_power);
-    powerfile << "Kernel Average Power Data:" << std::endl;
-    powerfile << "kernel_avg_power = " << kernel_power.avg << std::endl;
-
-    for (unsigned i = 0; i < num_pwr_cmps; ++i) {
-      powerfile << "gpu_avg_" << pwr_cmp_label[i] << " = "
-                << kernel_cmp_pwr[i].avg / kernel_sample_count << std::endl;
-    }
-    for (unsigned i = 0; i < num_perf_counters; ++i) {
-      powerfile << "gpu_avg_" << perf_count_label[i] << " = "
-                << kernel_cmp_perf_counters[i].avg / kernel_sample_count
-                << std::endl;
-    }
-
-    powerfile << std::endl << "Kernel Maximum Power Data:" << std::endl;
-    powerfile << "kernel_max_power = " << kernel_power.max << std::endl;
-    for (unsigned i = 0; i < num_pwr_cmps; ++i) {
-      powerfile << "gpu_max_" << pwr_cmp_label[i] << " = "
-                << kernel_cmp_pwr[i].max << std::endl;
-    }
-    for (unsigned i = 0; i < num_perf_counters; ++i) {
-      powerfile << "gpu_max_" << perf_count_label[i] << " = "
-                << kernel_cmp_perf_counters[i].max << std::endl;
-    }
-
-    powerfile << std::endl << "Kernel Minimum Power Data:" << std::endl;
-    powerfile << "kernel_min_power = " << kernel_power.min << std::endl;
-    for (unsigned i = 0; i < num_pwr_cmps; ++i) {
-      powerfile << "gpu_min_" << pwr_cmp_label[i] << " = "
-                << kernel_cmp_pwr[i].min << std::endl;
-    }
-    for (unsigned i = 0; i < num_perf_counters; ++i) {
-      powerfile << "gpu_min_" << perf_count_label[i] << " = "
-                << kernel_cmp_perf_counters[i].min << std::endl;
-    }
-
-    powerfile << std::endl
-              << "Accumulative Power Statistics Over Previous Kernels:"
-              << std::endl;
-    powerfile << "gpu_tot_avg_power = "
-              << gpu_tot_power.avg / total_sample_count << std::endl;
-    powerfile << "gpu_tot_max_power = " << gpu_tot_power.max << std::endl;
-    powerfile << "gpu_tot_min_power = " << gpu_tot_power.min << std::endl;
-    powerfile << std::endl << std::endl;
-    powerfile.flush();
-
-    if (print_trace) {
-      print_trace_files();
-    }
-  }
-}
-void gpgpu_sim_wrapper::dump() {
-  if (g_power_per_cycle_dump) proc->displayEnergy(2, 5);
-}
-
-void gpgpu_sim_wrapper::print_steady_state(int position, double init_val) {
-  double temp_avg = sample_val / (double)samples.size();
-  double temp_ipc = (init_val - init_inst_val) /
-                    (double)(samples.size() * gpu_stat_sample_freq);
-
-  if ((samples.size() > gpu_steady_min_period)) {  // If steady state occurred
-                                                   // for some time, print to
-                                                   // file
-    has_written_avg = true;
-    gzprintf(steady_state_tacking_file, "%u,%d,%f,%f,", sample_start,
-             total_sample_count, temp_avg, temp_ipc);
-    for (unsigned i = 0; i < num_perf_counters; ++i) {
-      gzprintf(steady_state_tacking_file, "%f,",
-               samples_counter.at(i) / ((double)samples.size()));
-    }
-    gzprintf(steady_state_tacking_file, "\n");
-  } else {
-    if (!has_written_avg && position)
-      gzprintf(steady_state_tacking_file,
-               "ERROR! Not enough steady state points to generate average\n");
-  }
-
-  sample_start = 0;
-  sample_val = 0;
-  init_inst_val = init_val;
-  samples.clear();
-  samples_counter.clear();
-  pwr_counter.clear();
-  assert(samples.size() == 0);
-}
-
-void gpgpu_sim_wrapper::detect_print_steady_state(int position,
-                                                  double init_val) {
-  // Calculating Average
-  if (g_power_simulation_enabled && g_steady_power_levels_enabled) {
-    steady_state_tacking_file = gzopen(g_steady_state_tracking_filename, "a");
-    if (position == 0) {
-      if (samples.size() == 0) {
-        // First sample
-        sample_start = total_sample_count;
-        sample_val = proc->rt_power.readOp.dynamic;
-        init_inst_val = init_val;
-        samples.push_back(proc->rt_power.readOp.dynamic);
-        assert(samples_counter.size() == 0);
-        assert(pwr_counter.size() == 0);
-
-        for (unsigned i = 0; i < (num_perf_counters); ++i) {
-          samples_counter.push_back(sample_perf_counters[i]);
+void gpgpu_sim_wrapper::open_files()
+{
+    if(g_power_simulation_enabled){
+        if (g_power_trace_enabled ){
+            power_trace_file = gzopen(g_power_trace_filename,  "a");
+            metric_trace_file = gzopen(g_metric_trace_filename, "a");
         }
-
-        for (unsigned i = 0; i < (num_pwr_cmps); ++i) {
-          pwr_counter.push_back(sample_cmp_pwr[i]);
-        }
-        assert(pwr_counter.size() == (double)num_pwr_cmps);
-        assert(samples_counter.size() == (double)num_perf_counters);
-      } else {
-        // Get current average
-        double temp_avg = sample_val / (double)samples.size();
-
-        if (abs(proc->rt_power.readOp.dynamic - temp_avg) <
-            gpu_steady_power_deviation) {  // Value is within threshold
-          sample_val += proc->rt_power.readOp.dynamic;
-          samples.push_back(proc->rt_power.readOp.dynamic);
-          for (unsigned i = 0; i < (num_perf_counters); ++i) {
-            samples_counter.at(i) += sample_perf_counters[i];
-          }
-
-          for (unsigned i = 0; i < (num_pwr_cmps); ++i) {
-            pwr_counter.at(i) += sample_cmp_pwr[i];
-          }
-
-        } else {  // Value exceeds threshold, not considered steady state
-          print_steady_state(position, init_val);
-        }
-      }
-    } else {
-      print_steady_state(position, init_val);
     }
-    gzclose(steady_state_tacking_file);
-  }
 }
+void gpgpu_sim_wrapper::close_files()
+{
+    if(g_power_simulation_enabled){
+  	  if(g_power_trace_enabled){
+  		  gzclose(power_trace_file);
+  		  gzclose(metric_trace_file);
+  	  }
+  	 }
 
-void gpgpu_sim_wrapper::open_files() {
-  if (g_power_simulation_enabled) {
-    if (g_power_trace_enabled) {
-      power_trace_file = gzopen(g_power_trace_filename, "a");
-      metric_trace_file = gzopen(g_metric_trace_filename, "a");
-    }
-  }
-}
-void gpgpu_sim_wrapper::close_files() {
-  if (g_power_simulation_enabled) {
-    if (g_power_trace_enabled) {
-      gzclose(power_trace_file);
-      gzclose(metric_trace_file);
-    }
-  }
 }

--- a/src/gpuwattch/gpgpu_sim_wrapper.cc
+++ b/src/gpuwattch/gpgpu_sim_wrapper.cc
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -28,734 +30,836 @@
 #include "gpgpu_sim_wrapper.h"
 #include <sys/stat.h>
 #define SP_BASE_POWER 0
-#define SFU_BASE_POWER  0
+#define SFU_BASE_POWER 0
 
-
-static const char * pwr_cmp_label[] = {"IBP,", "ICP,", "DCP,", "TCP,", "CCP,", "SHRDP,", "RFP,", "SPP,",
-								"SFUP,", "FPUP,", "SCHEDP,", "L2CP,", "MCP,", "NOCP,", "DRAMP,",
-								"PIPEP,", "IDLE_COREP,", "CONST_DYNAMICP"};
+static const char* pwr_cmp_label[] = {
+    "IBP,", "ICP,",  "DCP,",   "TCP,",   "CCP,",        "SHRDP,",
+    "RFP,", "SPP,",  "SFUP,",  "FPUP,",  "SCHEDP,",     "L2CP,",
+    "MCP,", "NOCP,", "DRAMP,", "PIPEP,", "IDLE_COREP,", "CONST_DYNAMICP"};
 
 enum pwr_cmp_t {
-   IBP=0,
-   ICP,
-   DCP,
-   TCP,
-   CCP,
-   SHRDP,
-   RFP,
-   SPP,
-   SFUP,
-   FPUP,
-   SCHEDP,
-   L2CP,
-   MCP,
-   NOCP,
-   DRAMP,
-   PIPEP,
-   IDLE_COREP,
-   CONST_DYNAMICP,
-   NUM_COMPONENTS_MODELLED
+  IBP = 0,
+  ICP,
+  DCP,
+  TCP,
+  CCP,
+  SHRDP,
+  RFP,
+  SPP,
+  SFUP,
+  FPUP,
+  SCHEDP,
+  L2CP,
+  MCP,
+  NOCP,
+  DRAMP,
+  PIPEP,
+  IDLE_COREP,
+  CONST_DYNAMICP,
+  NUM_COMPONENTS_MODELLED
 };
 
+gpgpu_sim_wrapper::gpgpu_sim_wrapper(bool power_simulation_enabled,
+                                     char* xmlfile) {
+  kernel_sample_count = 0;
+  total_sample_count = 0;
 
-gpgpu_sim_wrapper::gpgpu_sim_wrapper( bool power_simulation_enabled, char* xmlfile) {
-	   kernel_sample_count=0;
-	   total_sample_count=0;
+  kernel_tot_power = 0;
 
-	   kernel_tot_power=0;
+  num_pwr_cmps = NUM_COMPONENTS_MODELLED;
+  num_perf_counters = NUM_PERFORMANCE_COUNTERS;
 
-	   num_pwr_cmps=NUM_COMPONENTS_MODELLED;
-	   num_perf_counters=NUM_PERFORMANCE_COUNTERS;
+  // Initialize per-component counter/power vectors
+  avg_max_min_counters<double> init;
+  kernel_cmp_pwr.resize(NUM_COMPONENTS_MODELLED, init);
+  kernel_cmp_perf_counters.resize(NUM_PERFORMANCE_COUNTERS, init);
 
-	   // Initialize per-component counter/power vectors
-	   avg_max_min_counters<double> init;
-	   kernel_cmp_pwr.resize(NUM_COMPONENTS_MODELLED, init);
-	   kernel_cmp_perf_counters.resize(NUM_PERFORMANCE_COUNTERS, init);
+  kernel_power = init;   // Per-kernel powers
+  gpu_tot_power = init;  // Global powers
 
-	   kernel_power = init; // Per-kernel powers
-	   gpu_tot_power = init; // Global powers
+  sample_cmp_pwr.resize(NUM_COMPONENTS_MODELLED, 0);
 
-	   sample_cmp_pwr.resize(NUM_COMPONENTS_MODELLED, 0);
+  sample_perf_counters.resize(NUM_PERFORMANCE_COUNTERS, 0);
+  initpower_coeff.resize(NUM_PERFORMANCE_COUNTERS, 0);
+  effpower_coeff.resize(NUM_PERFORMANCE_COUNTERS, 0);
 
-	   sample_perf_counters.resize(NUM_PERFORMANCE_COUNTERS, 0);
-	   initpower_coeff.resize(NUM_PERFORMANCE_COUNTERS, 0);
-	   effpower_coeff.resize(NUM_PERFORMANCE_COUNTERS, 0);
+  const_dynamic_power = 0;
+  proc_power = 0;
 
-	   const_dynamic_power=0;
-	   proc_power=0;
+  g_power_filename = NULL;
+  g_power_trace_filename = NULL;
+  g_metric_trace_filename = NULL;
+  g_steady_state_tracking_filename = NULL;
+  xml_filename = xmlfile;
+  g_power_simulation_enabled = power_simulation_enabled;
+  g_power_trace_enabled = false;
+  g_steady_power_levels_enabled = false;
+  g_power_trace_zlevel = 0;
+  g_power_per_cycle_dump = false;
+  gpu_steady_power_deviation = 0;
+  gpu_steady_min_period = 0;
 
-	   g_power_filename = NULL;
-	   g_power_trace_filename = NULL;
-	   g_metric_trace_filename = NULL;
-	   g_steady_state_tracking_filename = NULL;
-	   xml_filename= xmlfile;
-	   g_power_simulation_enabled= power_simulation_enabled;
-	   g_power_trace_enabled= false;
-	   g_steady_power_levels_enabled= false;
-	   g_power_trace_zlevel= 0;
-	   g_power_per_cycle_dump= false;
-	   gpu_steady_power_deviation= 0;
-	   gpu_steady_min_period= 0;
-
-	   gpu_stat_sample_freq=0;
-	   p=new ParseXML();
-	   if (g_power_simulation_enabled){
-	       p->parse(xml_filename);
-	   }
-	   proc = new Processor(p);
-	   power_trace_file = NULL;
-	   metric_trace_file = NULL;
-	   steady_state_tacking_file = NULL;
-	   has_written_avg=false;
-	   init_inst_val=false;
-
+  gpu_stat_sample_freq = 0;
+  p = new ParseXML();
+  if (g_power_simulation_enabled) {
+    p->parse(xml_filename);
+  }
+  proc = new Processor(p);
+  power_trace_file = NULL;
+  metric_trace_file = NULL;
+  steady_state_tacking_file = NULL;
+  has_written_avg = false;
+  init_inst_val = false;
 }
 
-gpgpu_sim_wrapper::~gpgpu_sim_wrapper() { }
+gpgpu_sim_wrapper::~gpgpu_sim_wrapper() {}
 
-bool gpgpu_sim_wrapper::sanity_check(double a, double b)
-{
-	if (b == 0)
-		return (abs(a-b)<0.00001);
-	else
-		return (abs(a-b)/abs(b)<0.00001);
+bool gpgpu_sim_wrapper::sanity_check(double a, double b) {
+  if (b == 0)
+    return (abs(a - b) < 0.00001);
+  else
+    return (abs(a - b) / abs(b) < 0.00001);
 
-	return false;
+  return false;
 }
-void gpgpu_sim_wrapper::init_mcpat(char* xmlfile, char* powerfilename, char* power_trace_filename,char* metric_trace_filename,
-								   char * steady_state_filename, bool power_sim_enabled,bool trace_enabled,
-								   bool steady_state_enabled,bool power_per_cycle_dump,double steady_power_deviation,
-								   double steady_min_period, int zlevel, double init_val,int stat_sample_freq ){
-	// Write File Headers for (-metrics trace, -power trace)
-
-	reset_counters();
-   static bool mcpat_init=true;
-
-   // initialize file name if it is not set
-   time_t curr_time;
-   time(&curr_time);
-   char *date = ctime(&curr_time);
-   char *s = date;
-   while (*s) {
-       if (*s == ' ' || *s == '\t' || *s == ':') *s = '-';
-       if (*s == '\n' || *s == '\r' ) *s = 0;
-       s++;
-   }
-
-   if(mcpat_init){
-	   g_power_filename = powerfilename;
-	   g_power_trace_filename =power_trace_filename;
-	   g_metric_trace_filename = metric_trace_filename;
-	   g_steady_state_tracking_filename = steady_state_filename;
-	   xml_filename=xmlfile;
-	   g_power_simulation_enabled=power_sim_enabled;
-	   g_power_trace_enabled=trace_enabled;
-	   g_steady_power_levels_enabled=steady_state_enabled;
-	   g_power_trace_zlevel=zlevel;
-	   g_power_per_cycle_dump=power_per_cycle_dump;
-	   gpu_steady_power_deviation=steady_power_deviation;
-	   gpu_steady_min_period=steady_min_period;
-
-	   gpu_stat_sample_freq=stat_sample_freq;
-
-	   //p->sys.total_cycles=gpu_stat_sample_freq*4;
-	   p->sys.total_cycles=gpu_stat_sample_freq;
-	   power_trace_file = NULL;
-	   metric_trace_file = NULL;
-	   steady_state_tacking_file = NULL;
-
-
-	   if (g_power_trace_enabled ){
-		   power_trace_file = gzopen(g_power_trace_filename, "w");
-		   metric_trace_file = gzopen(g_metric_trace_filename, "w");
-		   if ((power_trace_file == NULL) || (metric_trace_file == NULL)) {
-			   printf("error - could not open trace files \n");
-			   exit(1);
-		   }
-		   gzsetparams(power_trace_file, g_power_trace_zlevel, Z_DEFAULT_STRATEGY);
-
-		   gzprintf(power_trace_file,"power,");
-		   for(unsigned i=0; i<num_pwr_cmps; i++){
-			   gzprintf(power_trace_file,pwr_cmp_label[i]);
-		   }
-		   gzprintf(power_trace_file,"\n");
-
-		   gzsetparams(metric_trace_file, g_power_trace_zlevel, Z_DEFAULT_STRATEGY);
-		   for(unsigned i=0; i<num_perf_counters; i++){
-			   gzprintf(metric_trace_file,perf_count_label[i]);
-		   }
-		   gzprintf(metric_trace_file,"\n");
-
-		   gzclose(power_trace_file);
-		   gzclose(metric_trace_file);
-	   }
-	   if(g_steady_power_levels_enabled){
-		   steady_state_tacking_file = gzopen(g_steady_state_tracking_filename, "w");
-		   if ((steady_state_tacking_file == NULL)) {
-			   printf("error - could not open trace files \n");
-			   exit(1);
-		   }
-		   gzsetparams(steady_state_tacking_file,g_power_trace_zlevel, Z_DEFAULT_STRATEGY);
-		   gzprintf(steady_state_tacking_file,"start,end,power,IPC,");
-		   for(unsigned i=0; i<num_perf_counters; i++){
-			   gzprintf(steady_state_tacking_file,perf_count_label[i]);
-		   }
-		   gzprintf(steady_state_tacking_file,"\n");
-
-		   gzclose(steady_state_tacking_file);
-	   }
-
-	   mcpat_init = false;
-	   has_written_avg=false;
-	   powerfile.open(g_power_filename);
-       int flg=chmod(g_power_filename, S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH);
-       assert(flg==0);
-   }
-   sample_val = 0;
-   init_inst_val=init_val;//gpu_tot_sim_insn+gpu_sim_insn;
-
-}
-
-void gpgpu_sim_wrapper::reset_counters(){
-
-	avg_max_min_counters<double> init;
-	for(unsigned i=0; i<num_perf_counters; ++i){
-		sample_perf_counters[i] = 0;
-		kernel_cmp_perf_counters[i] = init;
-	}
-	for(unsigned i=0; i<num_pwr_cmps; ++i){
-		sample_cmp_pwr[i] = 0;
-		kernel_cmp_pwr[i] = init;
-	}
-
-	// Reset per-kernel counters
-	kernel_sample_count = 0;
-	kernel_tot_power = 0;
-	kernel_power = init;
-
-	return;
-}
-
-void gpgpu_sim_wrapper::set_inst_power(bool clk_gated_lanes, double tot_cycles, double busy_cycles, double tot_inst, double int_inst, double fp_inst, double load_inst, double store_inst, double committed_inst)
-{
-	p->sys.core[0].gpgpu_clock_gated_lanes = clk_gated_lanes;
-	p->sys.core[0].total_cycles = tot_cycles;
-	p->sys.core[0].busy_cycles = busy_cycles;
-	p->sys.core[0].total_instructions  = tot_inst * p->sys.scaling_coefficients[TOT_INST];
-	p->sys.core[0].int_instructions    = int_inst * p->sys.scaling_coefficients[FP_INT];
-	p->sys.core[0].fp_instructions     = fp_inst  * p->sys.scaling_coefficients[FP_INT];
-	p->sys.core[0].load_instructions  = load_inst;
-	p->sys.core[0].store_instructions = store_inst;
-	p->sys.core[0].committed_instructions = committed_inst;
-	sample_perf_counters[FP_INT]=int_inst+fp_inst;
-	sample_perf_counters[TOT_INST]=tot_inst;
-}
-
-void gpgpu_sim_wrapper::set_regfile_power(double reads, double writes,double ops)
-{
-	p->sys.core[0].int_regfile_reads = reads * p->sys.scaling_coefficients[REG_RD];
-	p->sys.core[0].int_regfile_writes = writes * p->sys.scaling_coefficients[REG_WR];
-	p->sys.core[0].non_rf_operands =  ops *p->sys.scaling_coefficients[NON_REG_OPs];
-	sample_perf_counters[REG_RD]=reads;
-	sample_perf_counters[REG_WR]=writes;
-	sample_perf_counters[NON_REG_OPs]=ops;
-
-
-
-}
-
-void gpgpu_sim_wrapper::set_icache_power(double hits, double misses)
-{
-	p->sys.core[0].icache.read_accesses = hits * p->sys.scaling_coefficients[IC_H]+misses * p->sys.scaling_coefficients[IC_M];
-	p->sys.core[0].icache.read_misses = misses * p->sys.scaling_coefficients[IC_M];
-	sample_perf_counters[IC_H]=hits;
-	sample_perf_counters[IC_M]=misses;
-
-
-}
-
-void gpgpu_sim_wrapper::set_ccache_power(double hits, double misses)
-{
-	p->sys.core[0].ccache.read_accesses = hits * p->sys.scaling_coefficients[CC_H]+misses * p->sys.scaling_coefficients[CC_M];
-	p->sys.core[0].ccache.read_misses = misses * p->sys.scaling_coefficients[CC_M];
-	sample_perf_counters[CC_H]=hits;
-	sample_perf_counters[CC_M]=misses;
-	// TODO: coalescing logic is counted as part of the caches power (this is not valid for no-caches architectures)
-
-}
-
-void gpgpu_sim_wrapper::set_tcache_power(double hits, double misses)
-{
-	p->sys.core[0].tcache.read_accesses = hits * p->sys.scaling_coefficients[TC_H]+misses * p->sys.scaling_coefficients[TC_M];
-	p->sys.core[0].tcache.read_misses = misses* p->sys.scaling_coefficients[TC_M];
-	sample_perf_counters[TC_H]=hits;
-	sample_perf_counters[TC_M]=misses;
-	// TODO: coalescing logic is counted as part of the caches power (this is not valid for no-caches architectures)
-}
-
-void gpgpu_sim_wrapper::set_shrd_mem_power(double accesses)
-{
-	p->sys.core[0].sharedmemory.read_accesses = accesses * p->sys.scaling_coefficients[SHRD_ACC];
-	sample_perf_counters[SHRD_ACC]=accesses;
-
-
-}
-
-void gpgpu_sim_wrapper::set_l1cache_power(double read_hits, double read_misses, double write_hits, double write_misses)
-{
-	p->sys.core[0].dcache.read_accesses = read_hits * p->sys.scaling_coefficients[DC_RH] +read_misses * p->sys.scaling_coefficients[DC_RM];
-	p->sys.core[0].dcache.read_misses =  read_misses * p->sys.scaling_coefficients[DC_RM];
-	p->sys.core[0].dcache.write_accesses = write_hits * p->sys.scaling_coefficients[DC_WH]+write_misses * p->sys.scaling_coefficients[DC_WM];
-	p->sys.core[0].dcache.write_misses = write_misses * p->sys.scaling_coefficients[DC_WM];
-	sample_perf_counters[DC_RH]=read_hits;
-	sample_perf_counters[DC_RM]=read_misses;
-	sample_perf_counters[DC_WH]=write_hits;
-	sample_perf_counters[DC_WM]=write_misses;
-	// TODO: coalescing logic is counted as part of the caches power (this is not valid for no-caches architectures)
-
-
-
-}
-
-void gpgpu_sim_wrapper::set_l2cache_power(double read_hits, double read_misses, double write_hits, double write_misses)
-{
-	p->sys.l2.total_accesses = read_hits* p->sys.scaling_coefficients[L2_RH]+read_misses * p->sys.scaling_coefficients[L2_RM]+ write_hits * p->sys.scaling_coefficients[L2_WH]+write_misses  * p->sys.scaling_coefficients[L2_WM];
-	p->sys.l2.read_accesses = read_hits* p->sys.scaling_coefficients[L2_RH]+read_misses* p->sys.scaling_coefficients[L2_RM];
-	p->sys.l2.write_accesses = write_hits * p->sys.scaling_coefficients[L2_WH]+write_misses * p->sys.scaling_coefficients[L2_WM];
-	p->sys.l2.read_hits = read_hits * p->sys.scaling_coefficients[L2_RH];
-	p->sys.l2.read_misses = read_misses  * p->sys.scaling_coefficients[L2_RM];
-	p->sys.l2.write_hits =write_hits * p->sys.scaling_coefficients[L2_WH];
-	p->sys.l2.write_misses = write_misses * p->sys.scaling_coefficients[L2_WM];
-	sample_perf_counters[L2_RH]=read_hits;
-	sample_perf_counters[L2_RM]=read_misses;
-	sample_perf_counters[L2_WH]=write_hits;
-	sample_perf_counters[L2_WM]=write_misses;
-}
-
-void gpgpu_sim_wrapper::set_idle_core_power(double num_idle_core)
-{
-	p->sys.num_idle_cores = num_idle_core;
-	sample_perf_counters[IDLE_CORE_N]=num_idle_core;
-}
-
-void gpgpu_sim_wrapper::set_duty_cycle_power(double duty_cycle)
-{
-	p->sys.core[0].pipeline_duty_cycle = duty_cycle  * p->sys.scaling_coefficients[PIPE_A];
-	sample_perf_counters[PIPE_A]=duty_cycle;
-
-}
-
-void gpgpu_sim_wrapper::set_mem_ctrl_power(double reads, double writes, double dram_precharge)
-{
-	p->sys.mc.memory_accesses = reads  * p->sys.scaling_coefficients[MEM_RD]+ writes * p->sys.scaling_coefficients[MEM_WR];
-	p->sys.mc.memory_reads = reads *p->sys.scaling_coefficients[MEM_RD];
-	p->sys.mc.memory_writes = writes*p->sys.scaling_coefficients[MEM_WR];
-	p->sys.mc.dram_pre = dram_precharge*p->sys.scaling_coefficients[MEM_PRE];
-	sample_perf_counters[MEM_RD]=reads;
-	sample_perf_counters[MEM_WR]=writes;
-	sample_perf_counters[MEM_PRE]=dram_precharge;
-
-}
-
-void gpgpu_sim_wrapper::set_exec_unit_power(double fpu_accesses, double ialu_accesses, double sfu_accesses)
-{
-	p->sys.core[0].fpu_accesses = fpu_accesses*p->sys.scaling_coefficients[FPU_ACC];
-    //Integer ALU (not present in Tesla)
-	p->sys.core[0].ialu_accesses = ialu_accesses*p->sys.scaling_coefficients[SP_ACC];
-	//Sfu accesses
-	p->sys.core[0].mul_accesses = sfu_accesses*p->sys.scaling_coefficients[SFU_ACC];
-
-	sample_perf_counters[SP_ACC]=ialu_accesses;
-	sample_perf_counters[SFU_ACC]=sfu_accesses;
-	sample_perf_counters[FPU_ACC]=fpu_accesses;
-
-
-}
-
-void gpgpu_sim_wrapper::set_active_lanes_power(double sp_avg_active_lane, double sfu_avg_active_lane)
-{
-	p->sys.core[0].sp_average_active_lanes = sp_avg_active_lane;
-	p->sys.core[0].sfu_average_active_lanes = sfu_avg_active_lane;
-}
-
-void gpgpu_sim_wrapper::set_NoC_power(double noc_tot_reads, double noc_tot_writes )
-{
-	p->sys.NoC[0].total_accesses = noc_tot_reads * p->sys.scaling_coefficients[NOC_A] + noc_tot_writes * p->sys.scaling_coefficients[NOC_A];
-	sample_perf_counters[NOC_A]=noc_tot_reads+noc_tot_writes;
-}
-
-
-void gpgpu_sim_wrapper::power_metrics_calculations()
-{
-    total_sample_count++;
-    kernel_sample_count++;
-
-    // Current sample power
-    double sample_power = proc->rt_power.readOp.dynamic + sample_cmp_pwr[CONST_DYNAMICP];
-
-    // Average power
-    // Previous + new + constant dynamic power (e.g., dynamic clocking power)
-    kernel_tot_power += sample_power;
-    kernel_power.avg = kernel_tot_power / kernel_sample_count;
-	for(unsigned ind=0; ind<num_pwr_cmps; ++ind){
-		kernel_cmp_pwr[ind].avg += (double)sample_cmp_pwr[ind];
-	}
-
-	for(unsigned ind=0; ind<num_perf_counters; ++ind){
-		kernel_cmp_perf_counters[ind].avg += (double)sample_perf_counters[ind];
-	}
-
-	// Max Power
-	if(sample_power > kernel_power.max){
-		kernel_power.max = sample_power;
-		for(unsigned ind=0; ind<num_pwr_cmps; ++ind){
-			kernel_cmp_pwr[ind].max = (double)sample_cmp_pwr[ind];
-		}
-		for(unsigned ind=0; ind<num_perf_counters; ++ind){
-			kernel_cmp_perf_counters[ind].max = sample_perf_counters[ind];
-		}
-
-	}
-
-	// Min Power
-	if(sample_power < kernel_power.min ||(kernel_power.min==0) ){
-	  kernel_power.min = sample_power;
-	  for(unsigned ind=0; ind<num_pwr_cmps; ++ind){
-		  kernel_cmp_pwr[ind].min = (double)sample_cmp_pwr[ind];
-	  }
-	  for(unsigned ind=0; ind<num_perf_counters; ++ind){
-		  kernel_cmp_perf_counters[ind].min = sample_perf_counters[ind];
-	  }
-	}
-
-	gpu_tot_power.avg = (gpu_tot_power.avg + sample_power);
-	gpu_tot_power.max = (sample_power > gpu_tot_power.max) ? sample_power : gpu_tot_power.max;
-	gpu_tot_power.min = ((sample_power < gpu_tot_power.min) || (gpu_tot_power.min == 0)) ? sample_power : gpu_tot_power.min;
-
-}
-
-
-void gpgpu_sim_wrapper::print_trace_files()
-{
-	open_files();
-
-	for(unsigned i=0; i<num_perf_counters; ++i){
-		gzprintf(metric_trace_file,"%f,",sample_perf_counters[i]);
-	}
-	gzprintf(metric_trace_file,"\n");
-
-	gzprintf(power_trace_file,"%f,",proc_power);
-	for(unsigned i=0; i<num_pwr_cmps; ++i){
-		gzprintf(power_trace_file,"%f,",sample_cmp_pwr[i]);
-	}
-	gzprintf(power_trace_file,"\n");
-
-	close_files();
-
-}
-
-void gpgpu_sim_wrapper::update_coefficients()
-{
-
-	initpower_coeff[FP_INT]=proc->cores[0]->get_coefficient_fpint_insts();
-	effpower_coeff[FP_INT]=initpower_coeff[FP_INT] * p->sys.scaling_coefficients[FP_INT];
-
-	initpower_coeff[TOT_INST]=proc->cores[0]->get_coefficient_tot_insts();
-	effpower_coeff[TOT_INST]=initpower_coeff[TOT_INST] * p->sys.scaling_coefficients[TOT_INST];
-
-	initpower_coeff[REG_RD]=proc->cores[0]->get_coefficient_regreads_accesses()*(proc->cores[0]->exu->rf_fu_clockRate/proc->cores[0]->exu->clockRate);
-	initpower_coeff[REG_WR]=proc->cores[0]->get_coefficient_regwrites_accesses()*(proc->cores[0]->exu->rf_fu_clockRate/proc->cores[0]->exu->clockRate);
-	initpower_coeff[NON_REG_OPs]=proc->cores[0]->get_coefficient_noregfileops_accesses()*(proc->cores[0]->exu->rf_fu_clockRate/proc->cores[0]->exu->clockRate);
-	effpower_coeff[REG_RD]=initpower_coeff[REG_RD]*p->sys.scaling_coefficients[REG_RD];
-	effpower_coeff[REG_WR]=initpower_coeff[REG_WR]*p->sys.scaling_coefficients[REG_WR];
-	effpower_coeff[NON_REG_OPs]=initpower_coeff[NON_REG_OPs]*p->sys.scaling_coefficients[NON_REG_OPs];
-
-	initpower_coeff[IC_H]=proc->cores[0]->get_coefficient_icache_hits();
-	initpower_coeff[IC_M]=proc->cores[0]->get_coefficient_icache_misses();
-	effpower_coeff[IC_H]=initpower_coeff[IC_H]*p->sys.scaling_coefficients[IC_H];
-	effpower_coeff[IC_M]=initpower_coeff[IC_M]*p->sys.scaling_coefficients[IC_M];
-
-	initpower_coeff[CC_H]=(proc->cores[0]->get_coefficient_ccache_readhits()+proc->get_coefficient_readcoalescing());
-	initpower_coeff[CC_M]=(proc->cores[0]->get_coefficient_ccache_readmisses()+proc->get_coefficient_readcoalescing());
-	effpower_coeff[CC_H]=initpower_coeff[CC_H]*p->sys.scaling_coefficients[CC_H];
-	effpower_coeff[CC_M]=initpower_coeff[CC_M]*p->sys.scaling_coefficients[CC_M];
-
-	initpower_coeff[TC_H]=(proc->cores[0]->get_coefficient_tcache_readhits()+proc->get_coefficient_readcoalescing());
-	initpower_coeff[TC_M]=(proc->cores[0]->get_coefficient_tcache_readmisses()+proc->get_coefficient_readcoalescing());
-	effpower_coeff[TC_H]=initpower_coeff[TC_H]*p->sys.scaling_coefficients[TC_H];
-	effpower_coeff[TC_M]=initpower_coeff[TC_M]*p->sys.scaling_coefficients[TC_M];
-
-	initpower_coeff[SHRD_ACC]=proc->cores[0]->get_coefficient_sharedmemory_readhits();
-	effpower_coeff[SHRD_ACC]=initpower_coeff[SHRD_ACC]*p->sys.scaling_coefficients[SHRD_ACC];
-
-	initpower_coeff[DC_RH]=(proc->cores[0]->get_coefficient_dcache_readhits() + proc->get_coefficient_readcoalescing());
-	initpower_coeff[DC_RM]=(proc->cores[0]->get_coefficient_dcache_readmisses() + proc->get_coefficient_readcoalescing());
-	initpower_coeff[DC_WH]=(proc->cores[0]->get_coefficient_dcache_writehits() + proc->get_coefficient_writecoalescing());
-	initpower_coeff[DC_WM]=(proc->cores[0]->get_coefficient_dcache_writemisses() + proc->get_coefficient_writecoalescing());
-	effpower_coeff[DC_RH]=initpower_coeff[DC_RH]*p->sys.scaling_coefficients[DC_RH];
-	effpower_coeff[DC_RM]=initpower_coeff[DC_RM]*p->sys.scaling_coefficients[DC_RM];
-	effpower_coeff[DC_WH]=initpower_coeff[DC_WH]*p->sys.scaling_coefficients[DC_WH];
-	effpower_coeff[DC_WM]=initpower_coeff[DC_WM]*p->sys.scaling_coefficients[DC_WM];
-
-	initpower_coeff[L2_RH]=proc->get_coefficient_l2_read_hits();
-	initpower_coeff[L2_RM]=proc->get_coefficient_l2_read_misses();
-	initpower_coeff[L2_WH]=proc->get_coefficient_l2_write_hits();
-	initpower_coeff[L2_WM]=proc->get_coefficient_l2_write_misses();
-	effpower_coeff[L2_RH]=initpower_coeff[L2_RH]*p->sys.scaling_coefficients[L2_RH];
-	effpower_coeff[L2_RM]=initpower_coeff[L2_RM]*p->sys.scaling_coefficients[L2_RM];
-	effpower_coeff[L2_WH]=initpower_coeff[L2_WH]*p->sys.scaling_coefficients[L2_WH];
-	effpower_coeff[L2_WM]=initpower_coeff[L2_WM]*p->sys.scaling_coefficients[L2_WM];
-
-	initpower_coeff[IDLE_CORE_N]=p->sys.idle_core_power * proc->cores[0]->executionTime;
-	effpower_coeff[IDLE_CORE_N]=initpower_coeff[IDLE_CORE_N]*p->sys.scaling_coefficients[IDLE_CORE_N];
-
-	initpower_coeff[PIPE_A]=proc->cores[0]->get_coefficient_duty_cycle();
-	effpower_coeff[PIPE_A]=initpower_coeff[PIPE_A]*p->sys.scaling_coefficients[PIPE_A];
-
-	initpower_coeff[MEM_RD]=proc->get_coefficient_mem_reads();
-	initpower_coeff[MEM_WR]=proc->get_coefficient_mem_writes();
-	initpower_coeff[MEM_PRE]=proc->get_coefficient_mem_pre();
-	effpower_coeff[MEM_RD]=initpower_coeff[MEM_RD]*p->sys.scaling_coefficients[MEM_RD];
-	effpower_coeff[MEM_WR]=initpower_coeff[MEM_WR]*p->sys.scaling_coefficients[MEM_WR];
-	effpower_coeff[MEM_PRE]=initpower_coeff[MEM_PRE]*p->sys.scaling_coefficients[MEM_PRE];
-
-	initpower_coeff[SP_ACC]=proc->cores[0]->get_coefficient_ialu_accesses()*(proc->cores[0]->exu->rf_fu_clockRate/proc->cores[0]->exu->clockRate);;
-	initpower_coeff[SFU_ACC]=proc->cores[0]->get_coefficient_sfu_accesses();
-	initpower_coeff[FPU_ACC]=proc->cores[0]->get_coefficient_fpu_accesses();
-
-	effpower_coeff[SP_ACC]=initpower_coeff[SP_ACC]*p->sys.scaling_coefficients[SP_ACC];
-	effpower_coeff[SFU_ACC]=initpower_coeff[SFU_ACC]*p->sys.scaling_coefficients[SFU_ACC];
-	effpower_coeff[FPU_ACC]=initpower_coeff[FPU_ACC]*p->sys.scaling_coefficients[FPU_ACC];
-
-	initpower_coeff[NOC_A]=proc->get_coefficient_noc_accesses();
-	effpower_coeff[NOC_A]=initpower_coeff[NOC_A]*p->sys.scaling_coefficients[NOC_A];
-
-	const_dynamic_power=proc->get_const_dynamic_power()/(proc->cores[0]->executionTime);
-
-	for(unsigned i=0; i<num_perf_counters; i++){
-		initpower_coeff[i]/=(proc->cores[0]->executionTime);
-		effpower_coeff[i]/=(proc->cores[0]->executionTime);
-	}
-}
-
-void gpgpu_sim_wrapper::update_components_power()
-{
-
-	update_coefficients();
-
-	proc_power=proc->rt_power.readOp.dynamic;
-
-	sample_cmp_pwr[IBP]=(proc->cores[0]->ifu->IB->rt_power.readOp.dynamic
-			    +proc->cores[0]->ifu->IB->rt_power.writeOp.dynamic
-			    +proc->cores[0]->ifu->ID_misc->rt_power.readOp.dynamic
-			    +proc->cores[0]->ifu->ID_operand->rt_power.readOp.dynamic
-			    +proc->cores[0]->ifu->ID_inst->rt_power.readOp.dynamic)/(proc->cores[0]->executionTime);
-
-	sample_cmp_pwr[ICP]=proc->cores[0]->ifu->icache.rt_power.readOp.dynamic/(proc->cores[0]->executionTime);
-
-	sample_cmp_pwr[DCP]=proc->cores[0]->lsu->dcache.rt_power.readOp.dynamic/(proc->cores[0]->executionTime);
-
-	sample_cmp_pwr[TCP]=proc->cores[0]->lsu->tcache.rt_power.readOp.dynamic/(proc->cores[0]->executionTime);
-
-	sample_cmp_pwr[CCP]=proc->cores[0]->lsu->ccache.rt_power.readOp.dynamic/(proc->cores[0]->executionTime);
-
-	sample_cmp_pwr[SHRDP]=proc->cores[0]->lsu->sharedmemory.rt_power.readOp.dynamic/(proc->cores[0]->executionTime);
-
-	sample_cmp_pwr[RFP]=(proc->cores[0]->exu->rfu->rt_power.readOp.dynamic/(proc->cores[0]->executionTime))
-			   *(proc->cores[0]->exu->rf_fu_clockRate/proc->cores[0]->exu->clockRate);
-
-	sample_cmp_pwr[SPP]=(proc->cores[0]->exu->exeu->rt_power.readOp.dynamic/(proc->cores[0]->executionTime))
-			   *(proc->cores[0]->exu->rf_fu_clockRate/proc->cores[0]->exu->clockRate);
-
-	sample_cmp_pwr[SFUP]=(proc->cores[0]->exu->mul->rt_power.readOp.dynamic/(proc->cores[0]->executionTime));
-
-	sample_cmp_pwr[FPUP]=(proc->cores[0]->exu->fp_u->rt_power.readOp.dynamic/(proc->cores[0]->executionTime));
-
-	sample_cmp_pwr[SCHEDP]=proc->cores[0]->exu->scheu->rt_power.readOp.dynamic/(proc->cores[0]->executionTime);
-
-	sample_cmp_pwr[L2CP]=(proc->XML->sys.number_of_L2s>0)? proc->l2array[0]->rt_power.readOp.dynamic/(proc->cores[0]->executionTime):0;
-
-	sample_cmp_pwr[MCP]=(proc->mc->rt_power.readOp.dynamic-proc->mc->dram->rt_power.readOp.dynamic)/(proc->cores[0]->executionTime);
-
-	sample_cmp_pwr[NOCP]=proc->nocs[0]->rt_power.readOp.dynamic/(proc->cores[0]->executionTime);
-
-	sample_cmp_pwr[DRAMP]=proc->mc->dram->rt_power.readOp.dynamic/(proc->cores[0]->executionTime);
-
-	sample_cmp_pwr[PIPEP]=proc->cores[0]->Pipeline_energy/(proc->cores[0]->executionTime);
-
-	sample_cmp_pwr[IDLE_COREP]=proc->cores[0]->IdleCoreEnergy/(proc->cores[0]->executionTime);
-
-	// This constant dynamic power (e.g., clock power) part is estimated via regression model.
-	sample_cmp_pwr[CONST_DYNAMICP]=0;
-	double cnst_dyn = proc->get_const_dynamic_power()/(proc->cores[0]->executionTime);
-	// If the regression scaling term is greater than the recorded constant dynamic power
-	// then use the difference (other portion already added to dynamic power). Else,
-	// all the constant dynamic power is accounted for, add nothing.
-	if(p->sys.scaling_coefficients[CONST_DYNAMICN] > cnst_dyn)
-		sample_cmp_pwr[CONST_DYNAMICP] = (p->sys.scaling_coefficients[CONST_DYNAMICN]-cnst_dyn);
-
-	proc_power+=sample_cmp_pwr[CONST_DYNAMICP];
-
-	double sum_pwr_cmp=0;
-	for(unsigned i=0; i<num_pwr_cmps; i++){
-		sum_pwr_cmp+=sample_cmp_pwr[i];
-	}
-	bool check=false;
-	check=sanity_check(sum_pwr_cmp,proc_power);
-	assert("Total Power does not equal the sum of the components\n" && (check));
-
-}
-
-void gpgpu_sim_wrapper::compute()
-{
-	proc->compute();
-}
-void gpgpu_sim_wrapper::print_power_kernel_stats(double gpu_sim_cycle, double gpu_tot_sim_cycle, double init_value, const std::string & kernel_info_string, bool print_trace)
-{
-	   detect_print_steady_state(1,init_value);
-	   if(g_power_simulation_enabled){
-
-		   powerfile<<kernel_info_string<<std::endl;
-
-		   sanity_check((kernel_power.avg*kernel_sample_count), kernel_tot_power);
-		   powerfile<<"Kernel Average Power Data:"<<std::endl;
-		   powerfile<<"kernel_avg_power = " << kernel_power.avg << std::endl;
-
-		   for(unsigned i=0; i<num_pwr_cmps; ++i){
-				powerfile<<"gpu_avg_"<<pwr_cmp_label[i]<<" = "<<kernel_cmp_pwr[i].avg/kernel_sample_count<<std::endl;
-		   }
-		   for(unsigned i=0; i<num_perf_counters; ++i){
-				powerfile<<"gpu_avg_"<<perf_count_label[i]<<" = "<<kernel_cmp_perf_counters[i].avg/kernel_sample_count<<std::endl;
-		   }
-
-		   powerfile<<std::endl<<"Kernel Maximum Power Data:"<<std::endl;
-		   powerfile<<"kernel_max_power = "<< kernel_power.max<<std::endl;
-		   for(unsigned i=0; i<num_pwr_cmps; ++i){
-			   powerfile<<"gpu_max_"<<pwr_cmp_label[i]<<" = "<<kernel_cmp_pwr[i].max<<std::endl;
-		   }
-		   for(unsigned i=0; i<num_perf_counters; ++i){
-				powerfile<<"gpu_max_"<<perf_count_label[i]<<" = "<<kernel_cmp_perf_counters[i].max<<std::endl;
-		   }
-
-		   powerfile<<std::endl<<"Kernel Minimum Power Data:"<<std::endl;
-		   powerfile<<"kernel_min_power = "<< kernel_power.min<<std::endl;
-		   for(unsigned i=0; i<num_pwr_cmps; ++i){
-			   powerfile<<"gpu_min_"<<pwr_cmp_label[i]<<" = "<<kernel_cmp_pwr[i].min<<std::endl;
-		   }
-		   for(unsigned i=0; i<num_perf_counters; ++i){
-				powerfile<<"gpu_min_"<<perf_count_label[i]<<" = "<<kernel_cmp_perf_counters[i].min<<std::endl;
-		   }
-
-		   powerfile<<std::endl<<"Accumulative Power Statistics Over Previous Kernels:"<<std::endl;
-		   powerfile<<"gpu_tot_avg_power = "<< gpu_tot_power.avg/total_sample_count<<std::endl;
-		   powerfile<<"gpu_tot_max_power = "<<gpu_tot_power.max<<std::endl;
-		   powerfile<<"gpu_tot_min_power = "<<gpu_tot_power.min<<std::endl;
-		   powerfile<<std::endl<<std::endl;
-		   powerfile.flush();
-
-		   if(print_trace){
-			   print_trace_files();
-		   }
-	   }
-
-}
-void gpgpu_sim_wrapper::dump()
-{
-	if(g_power_per_cycle_dump)
-		proc->displayEnergy(2,5);
-}
-
-void gpgpu_sim_wrapper::print_steady_state(int position, double init_val){
-	double temp_avg = sample_val / (double)samples.size() ;
-	double temp_ipc = (init_val-init_inst_val)/ (double) (samples.size()*gpu_stat_sample_freq);
-
-	if((samples.size() > gpu_steady_min_period)){ // If steady state occurred for some time, print to file
-		has_written_avg=true;
-		gzprintf(steady_state_tacking_file,"%u,%d,%f,%f,",sample_start,total_sample_count,temp_avg,temp_ipc);
-		for(unsigned i=0; i<num_perf_counters; ++i){
-			gzprintf(steady_state_tacking_file,"%f,", samples_counter.at(i)/((double)samples.size()));
-		}
-		gzprintf(steady_state_tacking_file,"\n");
-	}else{
-		if(!has_written_avg && position)
-			gzprintf(steady_state_tacking_file,"ERROR! Not enough steady state points to generate average\n");
-	}
-
-	sample_start = 0;
-	sample_val = 0;
-	init_inst_val=init_val;
-	samples.clear();
-	samples_counter.clear();
-	pwr_counter.clear();
-	assert(samples.size() == 0);
-}
-
-void gpgpu_sim_wrapper::detect_print_steady_state(int position, double init_val)
-{
-	// Calculating Average
-    if(g_power_simulation_enabled && g_steady_power_levels_enabled){
-    	steady_state_tacking_file = gzopen(g_steady_state_tracking_filename,"a");
-		if(position==0){
-			if(samples.size() == 0){
-				// First sample
-				sample_start = total_sample_count;
-				sample_val = proc->rt_power.readOp.dynamic;
-				init_inst_val=init_val;
-				samples.push_back(proc->rt_power.readOp.dynamic);
-				assert(samples_counter.size() == 0);
-				assert(pwr_counter.size() == 0);
-
-				for(unsigned i=0; i<(num_perf_counters); ++i){
-					samples_counter.push_back(sample_perf_counters[i]);
-				}
-
-				for(unsigned i=0; i<(num_pwr_cmps); ++i){
-					pwr_counter.push_back(sample_cmp_pwr[i]);
-				}
-				assert(pwr_counter.size() == (double)num_pwr_cmps);
-				assert(samples_counter.size() == (double)num_perf_counters);
-			}else{
-				// Get current average
-				double temp_avg = sample_val / (double)samples.size() ;
-
-				if( abs(proc->rt_power.readOp.dynamic-temp_avg) < gpu_steady_power_deviation){ // Value is within threshold
-					sample_val += proc->rt_power.readOp.dynamic;
-					samples.push_back(proc->rt_power.readOp.dynamic);
-					for(unsigned i=0; i<(num_perf_counters); ++i){
-						samples_counter.at(i) += sample_perf_counters[i];
-					}
-
-					for(unsigned i=0; i<(num_pwr_cmps); ++i){
-						pwr_counter.at(i) += sample_cmp_pwr[i];
-					}
-
-				}else{	// Value exceeds threshold, not considered steady state
-					print_steady_state(position, init_val);
-				}
-			}
-		}else{
-			print_steady_state(position, init_val);
-		}
-		gzclose(steady_state_tacking_file);
+void gpgpu_sim_wrapper::init_mcpat(
+    char* xmlfile, char* powerfilename, char* power_trace_filename,
+    char* metric_trace_filename, char* steady_state_filename,
+    bool power_sim_enabled, bool trace_enabled, bool steady_state_enabled,
+    bool power_per_cycle_dump, double steady_power_deviation,
+    double steady_min_period, int zlevel, double init_val,
+    int stat_sample_freq) {
+  // Write File Headers for (-metrics trace, -power trace)
+
+  reset_counters();
+  static bool mcpat_init = true;
+
+  // initialize file name if it is not set
+  time_t curr_time;
+  time(&curr_time);
+  char* date = ctime(&curr_time);
+  char* s = date;
+  while (*s) {
+    if (*s == ' ' || *s == '\t' || *s == ':') *s = '-';
+    if (*s == '\n' || *s == '\r') *s = 0;
+    s++;
+  }
+
+  if (mcpat_init) {
+    g_power_filename = powerfilename;
+    g_power_trace_filename = power_trace_filename;
+    g_metric_trace_filename = metric_trace_filename;
+    g_steady_state_tracking_filename = steady_state_filename;
+    xml_filename = xmlfile;
+    g_power_simulation_enabled = power_sim_enabled;
+    g_power_trace_enabled = trace_enabled;
+    g_steady_power_levels_enabled = steady_state_enabled;
+    g_power_trace_zlevel = zlevel;
+    g_power_per_cycle_dump = power_per_cycle_dump;
+    gpu_steady_power_deviation = steady_power_deviation;
+    gpu_steady_min_period = steady_min_period;
+
+    gpu_stat_sample_freq = stat_sample_freq;
+
+    // p->sys.total_cycles=gpu_stat_sample_freq*4;
+    p->sys.total_cycles = gpu_stat_sample_freq;
+    power_trace_file = NULL;
+    metric_trace_file = NULL;
+    steady_state_tacking_file = NULL;
+
+    if (g_power_trace_enabled) {
+      power_trace_file = gzopen(g_power_trace_filename, "w");
+      metric_trace_file = gzopen(g_metric_trace_filename, "w");
+      if ((power_trace_file == NULL) || (metric_trace_file == NULL)) {
+        printf("error - could not open trace files \n");
+        exit(1);
+      }
+      gzsetparams(power_trace_file, g_power_trace_zlevel, Z_DEFAULT_STRATEGY);
+
+      gzprintf(power_trace_file, "power,");
+      for (unsigned i = 0; i < num_pwr_cmps; i++) {
+        gzprintf(power_trace_file, pwr_cmp_label[i]);
+      }
+      gzprintf(power_trace_file, "\n");
+
+      gzsetparams(metric_trace_file, g_power_trace_zlevel, Z_DEFAULT_STRATEGY);
+      for (unsigned i = 0; i < num_perf_counters; i++) {
+        gzprintf(metric_trace_file, perf_count_label[i]);
+      }
+      gzprintf(metric_trace_file, "\n");
+
+      gzclose(power_trace_file);
+      gzclose(metric_trace_file);
     }
+    if (g_steady_power_levels_enabled) {
+      steady_state_tacking_file = gzopen(g_steady_state_tracking_filename, "w");
+      if ((steady_state_tacking_file == NULL)) {
+        printf("error - could not open trace files \n");
+        exit(1);
+      }
+      gzsetparams(steady_state_tacking_file, g_power_trace_zlevel,
+                  Z_DEFAULT_STRATEGY);
+      gzprintf(steady_state_tacking_file, "start,end,power,IPC,");
+      for (unsigned i = 0; i < num_perf_counters; i++) {
+        gzprintf(steady_state_tacking_file, perf_count_label[i]);
+      }
+      gzprintf(steady_state_tacking_file, "\n");
+
+      gzclose(steady_state_tacking_file);
+    }
+
+    mcpat_init = false;
+    has_written_avg = false;
+    powerfile.open(g_power_filename);
+    int flg = chmod(g_power_filename, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+    assert(flg == 0);
+  }
+  sample_val = 0;
+  init_inst_val = init_val;  // gpu_tot_sim_insn+gpu_sim_insn;
 }
 
-void gpgpu_sim_wrapper::open_files()
-{
-    if(g_power_simulation_enabled){
-        if (g_power_trace_enabled ){
-            power_trace_file = gzopen(g_power_trace_filename,  "a");
-            metric_trace_file = gzopen(g_metric_trace_filename, "a");
+void gpgpu_sim_wrapper::reset_counters() {
+  avg_max_min_counters<double> init;
+  for (unsigned i = 0; i < num_perf_counters; ++i) {
+    sample_perf_counters[i] = 0;
+    kernel_cmp_perf_counters[i] = init;
+  }
+  for (unsigned i = 0; i < num_pwr_cmps; ++i) {
+    sample_cmp_pwr[i] = 0;
+    kernel_cmp_pwr[i] = init;
+  }
+
+  // Reset per-kernel counters
+  kernel_sample_count = 0;
+  kernel_tot_power = 0;
+  kernel_power = init;
+
+  return;
+}
+
+void gpgpu_sim_wrapper::set_inst_power(bool clk_gated_lanes, double tot_cycles,
+                                       double busy_cycles, double tot_inst,
+                                       double int_inst, double fp_inst,
+                                       double load_inst, double store_inst,
+                                       double committed_inst) {
+  p->sys.core[0].gpgpu_clock_gated_lanes = clk_gated_lanes;
+  p->sys.core[0].total_cycles = tot_cycles;
+  p->sys.core[0].busy_cycles = busy_cycles;
+  p->sys.core[0].total_instructions =
+      tot_inst * p->sys.scaling_coefficients[TOT_INST];
+  p->sys.core[0].int_instructions =
+      int_inst * p->sys.scaling_coefficients[FP_INT];
+  p->sys.core[0].fp_instructions =
+      fp_inst * p->sys.scaling_coefficients[FP_INT];
+  p->sys.core[0].load_instructions = load_inst;
+  p->sys.core[0].store_instructions = store_inst;
+  p->sys.core[0].committed_instructions = committed_inst;
+  sample_perf_counters[FP_INT] = int_inst + fp_inst;
+  sample_perf_counters[TOT_INST] = tot_inst;
+}
+
+void gpgpu_sim_wrapper::set_regfile_power(double reads, double writes,
+                                          double ops) {
+  p->sys.core[0].int_regfile_reads =
+      reads * p->sys.scaling_coefficients[REG_RD];
+  p->sys.core[0].int_regfile_writes =
+      writes * p->sys.scaling_coefficients[REG_WR];
+  p->sys.core[0].non_rf_operands =
+      ops * p->sys.scaling_coefficients[NON_REG_OPs];
+  sample_perf_counters[REG_RD] = reads;
+  sample_perf_counters[REG_WR] = writes;
+  sample_perf_counters[NON_REG_OPs] = ops;
+}
+
+void gpgpu_sim_wrapper::set_icache_power(double hits, double misses) {
+  p->sys.core[0].icache.read_accesses =
+      hits * p->sys.scaling_coefficients[IC_H] +
+      misses * p->sys.scaling_coefficients[IC_M];
+  p->sys.core[0].icache.read_misses =
+      misses * p->sys.scaling_coefficients[IC_M];
+  sample_perf_counters[IC_H] = hits;
+  sample_perf_counters[IC_M] = misses;
+}
+
+void gpgpu_sim_wrapper::set_ccache_power(double hits, double misses) {
+  p->sys.core[0].ccache.read_accesses =
+      hits * p->sys.scaling_coefficients[CC_H] +
+      misses * p->sys.scaling_coefficients[CC_M];
+  p->sys.core[0].ccache.read_misses =
+      misses * p->sys.scaling_coefficients[CC_M];
+  sample_perf_counters[CC_H] = hits;
+  sample_perf_counters[CC_M] = misses;
+  // TODO: coalescing logic is counted as part of the caches power (this is not
+  // valid for no-caches architectures)
+}
+
+void gpgpu_sim_wrapper::set_tcache_power(double hits, double misses) {
+  p->sys.core[0].tcache.read_accesses =
+      hits * p->sys.scaling_coefficients[TC_H] +
+      misses * p->sys.scaling_coefficients[TC_M];
+  p->sys.core[0].tcache.read_misses =
+      misses * p->sys.scaling_coefficients[TC_M];
+  sample_perf_counters[TC_H] = hits;
+  sample_perf_counters[TC_M] = misses;
+  // TODO: coalescing logic is counted as part of the caches power (this is not
+  // valid for no-caches architectures)
+}
+
+void gpgpu_sim_wrapper::set_shrd_mem_power(double accesses) {
+  p->sys.core[0].sharedmemory.read_accesses =
+      accesses * p->sys.scaling_coefficients[SHRD_ACC];
+  sample_perf_counters[SHRD_ACC] = accesses;
+}
+
+void gpgpu_sim_wrapper::set_l1cache_power(double read_hits, double read_misses,
+                                          double write_hits,
+                                          double write_misses) {
+  p->sys.core[0].dcache.read_accesses =
+      read_hits * p->sys.scaling_coefficients[DC_RH] +
+      read_misses * p->sys.scaling_coefficients[DC_RM];
+  p->sys.core[0].dcache.read_misses =
+      read_misses * p->sys.scaling_coefficients[DC_RM];
+  p->sys.core[0].dcache.write_accesses =
+      write_hits * p->sys.scaling_coefficients[DC_WH] +
+      write_misses * p->sys.scaling_coefficients[DC_WM];
+  p->sys.core[0].dcache.write_misses =
+      write_misses * p->sys.scaling_coefficients[DC_WM];
+  sample_perf_counters[DC_RH] = read_hits;
+  sample_perf_counters[DC_RM] = read_misses;
+  sample_perf_counters[DC_WH] = write_hits;
+  sample_perf_counters[DC_WM] = write_misses;
+  // TODO: coalescing logic is counted as part of the caches power (this is not
+  // valid for no-caches architectures)
+}
+
+void gpgpu_sim_wrapper::set_l2cache_power(double read_hits, double read_misses,
+                                          double write_hits,
+                                          double write_misses) {
+  p->sys.l2.total_accesses = read_hits * p->sys.scaling_coefficients[L2_RH] +
+                             read_misses * p->sys.scaling_coefficients[L2_RM] +
+                             write_hits * p->sys.scaling_coefficients[L2_WH] +
+                             write_misses * p->sys.scaling_coefficients[L2_WM];
+  p->sys.l2.read_accesses = read_hits * p->sys.scaling_coefficients[L2_RH] +
+                            read_misses * p->sys.scaling_coefficients[L2_RM];
+  p->sys.l2.write_accesses = write_hits * p->sys.scaling_coefficients[L2_WH] +
+                             write_misses * p->sys.scaling_coefficients[L2_WM];
+  p->sys.l2.read_hits = read_hits * p->sys.scaling_coefficients[L2_RH];
+  p->sys.l2.read_misses = read_misses * p->sys.scaling_coefficients[L2_RM];
+  p->sys.l2.write_hits = write_hits * p->sys.scaling_coefficients[L2_WH];
+  p->sys.l2.write_misses = write_misses * p->sys.scaling_coefficients[L2_WM];
+  sample_perf_counters[L2_RH] = read_hits;
+  sample_perf_counters[L2_RM] = read_misses;
+  sample_perf_counters[L2_WH] = write_hits;
+  sample_perf_counters[L2_WM] = write_misses;
+}
+
+void gpgpu_sim_wrapper::set_idle_core_power(double num_idle_core) {
+  p->sys.num_idle_cores = num_idle_core;
+  sample_perf_counters[IDLE_CORE_N] = num_idle_core;
+}
+
+void gpgpu_sim_wrapper::set_duty_cycle_power(double duty_cycle) {
+  p->sys.core[0].pipeline_duty_cycle =
+      duty_cycle * p->sys.scaling_coefficients[PIPE_A];
+  sample_perf_counters[PIPE_A] = duty_cycle;
+}
+
+void gpgpu_sim_wrapper::set_mem_ctrl_power(double reads, double writes,
+                                           double dram_precharge) {
+  p->sys.mc.memory_accesses = reads * p->sys.scaling_coefficients[MEM_RD] +
+                              writes * p->sys.scaling_coefficients[MEM_WR];
+  p->sys.mc.memory_reads = reads * p->sys.scaling_coefficients[MEM_RD];
+  p->sys.mc.memory_writes = writes * p->sys.scaling_coefficients[MEM_WR];
+  p->sys.mc.dram_pre = dram_precharge * p->sys.scaling_coefficients[MEM_PRE];
+  sample_perf_counters[MEM_RD] = reads;
+  sample_perf_counters[MEM_WR] = writes;
+  sample_perf_counters[MEM_PRE] = dram_precharge;
+}
+
+void gpgpu_sim_wrapper::set_exec_unit_power(double fpu_accesses,
+                                            double ialu_accesses,
+                                            double sfu_accesses) {
+  p->sys.core[0].fpu_accesses =
+      fpu_accesses * p->sys.scaling_coefficients[FPU_ACC];
+  // Integer ALU (not present in Tesla)
+  p->sys.core[0].ialu_accesses =
+      ialu_accesses * p->sys.scaling_coefficients[SP_ACC];
+  // Sfu accesses
+  p->sys.core[0].mul_accesses =
+      sfu_accesses * p->sys.scaling_coefficients[SFU_ACC];
+
+  sample_perf_counters[SP_ACC] = ialu_accesses;
+  sample_perf_counters[SFU_ACC] = sfu_accesses;
+  sample_perf_counters[FPU_ACC] = fpu_accesses;
+}
+
+void gpgpu_sim_wrapper::set_active_lanes_power(double sp_avg_active_lane,
+                                               double sfu_avg_active_lane) {
+  p->sys.core[0].sp_average_active_lanes = sp_avg_active_lane;
+  p->sys.core[0].sfu_average_active_lanes = sfu_avg_active_lane;
+}
+
+void gpgpu_sim_wrapper::set_NoC_power(double noc_tot_reads,
+                                      double noc_tot_writes) {
+  p->sys.NoC[0].total_accesses =
+      noc_tot_reads * p->sys.scaling_coefficients[NOC_A] +
+      noc_tot_writes * p->sys.scaling_coefficients[NOC_A];
+  sample_perf_counters[NOC_A] = noc_tot_reads + noc_tot_writes;
+}
+
+void gpgpu_sim_wrapper::power_metrics_calculations() {
+  total_sample_count++;
+  kernel_sample_count++;
+
+  // Current sample power
+  double sample_power =
+      proc->rt_power.readOp.dynamic + sample_cmp_pwr[CONST_DYNAMICP];
+
+  // Average power
+  // Previous + new + constant dynamic power (e.g., dynamic clocking power)
+  kernel_tot_power += sample_power;
+  kernel_power.avg = kernel_tot_power / kernel_sample_count;
+  for (unsigned ind = 0; ind < num_pwr_cmps; ++ind) {
+    kernel_cmp_pwr[ind].avg += (double)sample_cmp_pwr[ind];
+  }
+
+  for (unsigned ind = 0; ind < num_perf_counters; ++ind) {
+    kernel_cmp_perf_counters[ind].avg += (double)sample_perf_counters[ind];
+  }
+
+  // Max Power
+  if (sample_power > kernel_power.max) {
+    kernel_power.max = sample_power;
+    for (unsigned ind = 0; ind < num_pwr_cmps; ++ind) {
+      kernel_cmp_pwr[ind].max = (double)sample_cmp_pwr[ind];
+    }
+    for (unsigned ind = 0; ind < num_perf_counters; ++ind) {
+      kernel_cmp_perf_counters[ind].max = sample_perf_counters[ind];
+    }
+  }
+
+  // Min Power
+  if (sample_power < kernel_power.min || (kernel_power.min == 0)) {
+    kernel_power.min = sample_power;
+    for (unsigned ind = 0; ind < num_pwr_cmps; ++ind) {
+      kernel_cmp_pwr[ind].min = (double)sample_cmp_pwr[ind];
+    }
+    for (unsigned ind = 0; ind < num_perf_counters; ++ind) {
+      kernel_cmp_perf_counters[ind].min = sample_perf_counters[ind];
+    }
+  }
+
+  gpu_tot_power.avg = (gpu_tot_power.avg + sample_power);
+  gpu_tot_power.max =
+      (sample_power > gpu_tot_power.max) ? sample_power : gpu_tot_power.max;
+  gpu_tot_power.min =
+      ((sample_power < gpu_tot_power.min) || (gpu_tot_power.min == 0))
+          ? sample_power
+          : gpu_tot_power.min;
+}
+
+void gpgpu_sim_wrapper::print_trace_files() {
+  open_files();
+
+  for (unsigned i = 0; i < num_perf_counters; ++i) {
+    gzprintf(metric_trace_file, "%f,", sample_perf_counters[i]);
+  }
+  gzprintf(metric_trace_file, "\n");
+
+  gzprintf(power_trace_file, "%f,", proc_power);
+  for (unsigned i = 0; i < num_pwr_cmps; ++i) {
+    gzprintf(power_trace_file, "%f,", sample_cmp_pwr[i]);
+  }
+  gzprintf(power_trace_file, "\n");
+
+  close_files();
+}
+
+void gpgpu_sim_wrapper::update_coefficients() {
+  initpower_coeff[FP_INT] = proc->cores[0]->get_coefficient_fpint_insts();
+  effpower_coeff[FP_INT] =
+      initpower_coeff[FP_INT] * p->sys.scaling_coefficients[FP_INT];
+
+  initpower_coeff[TOT_INST] = proc->cores[0]->get_coefficient_tot_insts();
+  effpower_coeff[TOT_INST] =
+      initpower_coeff[TOT_INST] * p->sys.scaling_coefficients[TOT_INST];
+
+  initpower_coeff[REG_RD] =
+      proc->cores[0]->get_coefficient_regreads_accesses() *
+      (proc->cores[0]->exu->rf_fu_clockRate / proc->cores[0]->exu->clockRate);
+  initpower_coeff[REG_WR] =
+      proc->cores[0]->get_coefficient_regwrites_accesses() *
+      (proc->cores[0]->exu->rf_fu_clockRate / proc->cores[0]->exu->clockRate);
+  initpower_coeff[NON_REG_OPs] =
+      proc->cores[0]->get_coefficient_noregfileops_accesses() *
+      (proc->cores[0]->exu->rf_fu_clockRate / proc->cores[0]->exu->clockRate);
+  effpower_coeff[REG_RD] =
+      initpower_coeff[REG_RD] * p->sys.scaling_coefficients[REG_RD];
+  effpower_coeff[REG_WR] =
+      initpower_coeff[REG_WR] * p->sys.scaling_coefficients[REG_WR];
+  effpower_coeff[NON_REG_OPs] =
+      initpower_coeff[NON_REG_OPs] * p->sys.scaling_coefficients[NON_REG_OPs];
+
+  initpower_coeff[IC_H] = proc->cores[0]->get_coefficient_icache_hits();
+  initpower_coeff[IC_M] = proc->cores[0]->get_coefficient_icache_misses();
+  effpower_coeff[IC_H] =
+      initpower_coeff[IC_H] * p->sys.scaling_coefficients[IC_H];
+  effpower_coeff[IC_M] =
+      initpower_coeff[IC_M] * p->sys.scaling_coefficients[IC_M];
+
+  initpower_coeff[CC_H] = (proc->cores[0]->get_coefficient_ccache_readhits() +
+                           proc->get_coefficient_readcoalescing());
+  initpower_coeff[CC_M] = (proc->cores[0]->get_coefficient_ccache_readmisses() +
+                           proc->get_coefficient_readcoalescing());
+  effpower_coeff[CC_H] =
+      initpower_coeff[CC_H] * p->sys.scaling_coefficients[CC_H];
+  effpower_coeff[CC_M] =
+      initpower_coeff[CC_M] * p->sys.scaling_coefficients[CC_M];
+
+  initpower_coeff[TC_H] = (proc->cores[0]->get_coefficient_tcache_readhits() +
+                           proc->get_coefficient_readcoalescing());
+  initpower_coeff[TC_M] = (proc->cores[0]->get_coefficient_tcache_readmisses() +
+                           proc->get_coefficient_readcoalescing());
+  effpower_coeff[TC_H] =
+      initpower_coeff[TC_H] * p->sys.scaling_coefficients[TC_H];
+  effpower_coeff[TC_M] =
+      initpower_coeff[TC_M] * p->sys.scaling_coefficients[TC_M];
+
+  initpower_coeff[SHRD_ACC] =
+      proc->cores[0]->get_coefficient_sharedmemory_readhits();
+  effpower_coeff[SHRD_ACC] =
+      initpower_coeff[SHRD_ACC] * p->sys.scaling_coefficients[SHRD_ACC];
+
+  initpower_coeff[DC_RH] = (proc->cores[0]->get_coefficient_dcache_readhits() +
+                            proc->get_coefficient_readcoalescing());
+  initpower_coeff[DC_RM] =
+      (proc->cores[0]->get_coefficient_dcache_readmisses() +
+       proc->get_coefficient_readcoalescing());
+  initpower_coeff[DC_WH] = (proc->cores[0]->get_coefficient_dcache_writehits() +
+                            proc->get_coefficient_writecoalescing());
+  initpower_coeff[DC_WM] =
+      (proc->cores[0]->get_coefficient_dcache_writemisses() +
+       proc->get_coefficient_writecoalescing());
+  effpower_coeff[DC_RH] =
+      initpower_coeff[DC_RH] * p->sys.scaling_coefficients[DC_RH];
+  effpower_coeff[DC_RM] =
+      initpower_coeff[DC_RM] * p->sys.scaling_coefficients[DC_RM];
+  effpower_coeff[DC_WH] =
+      initpower_coeff[DC_WH] * p->sys.scaling_coefficients[DC_WH];
+  effpower_coeff[DC_WM] =
+      initpower_coeff[DC_WM] * p->sys.scaling_coefficients[DC_WM];
+
+  initpower_coeff[L2_RH] = proc->get_coefficient_l2_read_hits();
+  initpower_coeff[L2_RM] = proc->get_coefficient_l2_read_misses();
+  initpower_coeff[L2_WH] = proc->get_coefficient_l2_write_hits();
+  initpower_coeff[L2_WM] = proc->get_coefficient_l2_write_misses();
+  effpower_coeff[L2_RH] =
+      initpower_coeff[L2_RH] * p->sys.scaling_coefficients[L2_RH];
+  effpower_coeff[L2_RM] =
+      initpower_coeff[L2_RM] * p->sys.scaling_coefficients[L2_RM];
+  effpower_coeff[L2_WH] =
+      initpower_coeff[L2_WH] * p->sys.scaling_coefficients[L2_WH];
+  effpower_coeff[L2_WM] =
+      initpower_coeff[L2_WM] * p->sys.scaling_coefficients[L2_WM];
+
+  initpower_coeff[IDLE_CORE_N] =
+      p->sys.idle_core_power * proc->cores[0]->executionTime;
+  effpower_coeff[IDLE_CORE_N] =
+      initpower_coeff[IDLE_CORE_N] * p->sys.scaling_coefficients[IDLE_CORE_N];
+
+  initpower_coeff[PIPE_A] = proc->cores[0]->get_coefficient_duty_cycle();
+  effpower_coeff[PIPE_A] =
+      initpower_coeff[PIPE_A] * p->sys.scaling_coefficients[PIPE_A];
+
+  initpower_coeff[MEM_RD] = proc->get_coefficient_mem_reads();
+  initpower_coeff[MEM_WR] = proc->get_coefficient_mem_writes();
+  initpower_coeff[MEM_PRE] = proc->get_coefficient_mem_pre();
+  effpower_coeff[MEM_RD] =
+      initpower_coeff[MEM_RD] * p->sys.scaling_coefficients[MEM_RD];
+  effpower_coeff[MEM_WR] =
+      initpower_coeff[MEM_WR] * p->sys.scaling_coefficients[MEM_WR];
+  effpower_coeff[MEM_PRE] =
+      initpower_coeff[MEM_PRE] * p->sys.scaling_coefficients[MEM_PRE];
+
+  initpower_coeff[SP_ACC] =
+      proc->cores[0]->get_coefficient_ialu_accesses() *
+      (proc->cores[0]->exu->rf_fu_clockRate / proc->cores[0]->exu->clockRate);
+  ;
+  initpower_coeff[SFU_ACC] = proc->cores[0]->get_coefficient_sfu_accesses();
+  initpower_coeff[FPU_ACC] = proc->cores[0]->get_coefficient_fpu_accesses();
+
+  effpower_coeff[SP_ACC] =
+      initpower_coeff[SP_ACC] * p->sys.scaling_coefficients[SP_ACC];
+  effpower_coeff[SFU_ACC] =
+      initpower_coeff[SFU_ACC] * p->sys.scaling_coefficients[SFU_ACC];
+  effpower_coeff[FPU_ACC] =
+      initpower_coeff[FPU_ACC] * p->sys.scaling_coefficients[FPU_ACC];
+
+  initpower_coeff[NOC_A] = proc->get_coefficient_noc_accesses();
+  effpower_coeff[NOC_A] =
+      initpower_coeff[NOC_A] * p->sys.scaling_coefficients[NOC_A];
+
+  const_dynamic_power =
+      proc->get_const_dynamic_power() / (proc->cores[0]->executionTime);
+
+  for (unsigned i = 0; i < num_perf_counters; i++) {
+    initpower_coeff[i] /= (proc->cores[0]->executionTime);
+    effpower_coeff[i] /= (proc->cores[0]->executionTime);
+  }
+}
+
+void gpgpu_sim_wrapper::update_components_power() {
+  update_coefficients();
+
+  proc_power = proc->rt_power.readOp.dynamic;
+
+  sample_cmp_pwr[IBP] =
+      (proc->cores[0]->ifu->IB->rt_power.readOp.dynamic +
+       proc->cores[0]->ifu->IB->rt_power.writeOp.dynamic +
+       proc->cores[0]->ifu->ID_misc->rt_power.readOp.dynamic +
+       proc->cores[0]->ifu->ID_operand->rt_power.readOp.dynamic +
+       proc->cores[0]->ifu->ID_inst->rt_power.readOp.dynamic) /
+      (proc->cores[0]->executionTime);
+
+  sample_cmp_pwr[ICP] = proc->cores[0]->ifu->icache.rt_power.readOp.dynamic /
+                        (proc->cores[0]->executionTime);
+
+  sample_cmp_pwr[DCP] = proc->cores[0]->lsu->dcache.rt_power.readOp.dynamic /
+                        (proc->cores[0]->executionTime);
+
+  sample_cmp_pwr[TCP] = proc->cores[0]->lsu->tcache.rt_power.readOp.dynamic /
+                        (proc->cores[0]->executionTime);
+
+  sample_cmp_pwr[CCP] = proc->cores[0]->lsu->ccache.rt_power.readOp.dynamic /
+                        (proc->cores[0]->executionTime);
+
+  sample_cmp_pwr[SHRDP] =
+      proc->cores[0]->lsu->sharedmemory.rt_power.readOp.dynamic /
+      (proc->cores[0]->executionTime);
+
+  sample_cmp_pwr[RFP] =
+      (proc->cores[0]->exu->rfu->rt_power.readOp.dynamic /
+       (proc->cores[0]->executionTime)) *
+      (proc->cores[0]->exu->rf_fu_clockRate / proc->cores[0]->exu->clockRate);
+
+  sample_cmp_pwr[SPP] =
+      (proc->cores[0]->exu->exeu->rt_power.readOp.dynamic /
+       (proc->cores[0]->executionTime)) *
+      (proc->cores[0]->exu->rf_fu_clockRate / proc->cores[0]->exu->clockRate);
+
+  sample_cmp_pwr[SFUP] = (proc->cores[0]->exu->mul->rt_power.readOp.dynamic /
+                          (proc->cores[0]->executionTime));
+
+  sample_cmp_pwr[FPUP] = (proc->cores[0]->exu->fp_u->rt_power.readOp.dynamic /
+                          (proc->cores[0]->executionTime));
+
+  sample_cmp_pwr[SCHEDP] = proc->cores[0]->exu->scheu->rt_power.readOp.dynamic /
+                           (proc->cores[0]->executionTime);
+
+  sample_cmp_pwr[L2CP] = (proc->XML->sys.number_of_L2s > 0)
+                             ? proc->l2array[0]->rt_power.readOp.dynamic /
+                                   (proc->cores[0]->executionTime)
+                             : 0;
+
+  sample_cmp_pwr[MCP] = (proc->mc->rt_power.readOp.dynamic -
+                         proc->mc->dram->rt_power.readOp.dynamic) /
+                        (proc->cores[0]->executionTime);
+
+  sample_cmp_pwr[NOCP] =
+      proc->nocs[0]->rt_power.readOp.dynamic / (proc->cores[0]->executionTime);
+
+  sample_cmp_pwr[DRAMP] =
+      proc->mc->dram->rt_power.readOp.dynamic / (proc->cores[0]->executionTime);
+
+  sample_cmp_pwr[PIPEP] =
+      proc->cores[0]->Pipeline_energy / (proc->cores[0]->executionTime);
+
+  sample_cmp_pwr[IDLE_COREP] =
+      proc->cores[0]->IdleCoreEnergy / (proc->cores[0]->executionTime);
+
+  // This constant dynamic power (e.g., clock power) part is estimated via
+  // regression model.
+  sample_cmp_pwr[CONST_DYNAMICP] = 0;
+  double cnst_dyn =
+      proc->get_const_dynamic_power() / (proc->cores[0]->executionTime);
+  // If the regression scaling term is greater than the recorded constant
+  // dynamic power
+  // then use the difference (other portion already added to dynamic power).
+  // Else,
+  // all the constant dynamic power is accounted for, add nothing.
+  if (p->sys.scaling_coefficients[CONST_DYNAMICN] > cnst_dyn)
+    sample_cmp_pwr[CONST_DYNAMICP] =
+        (p->sys.scaling_coefficients[CONST_DYNAMICN] - cnst_dyn);
+
+  proc_power += sample_cmp_pwr[CONST_DYNAMICP];
+
+  double sum_pwr_cmp = 0;
+  for (unsigned i = 0; i < num_pwr_cmps; i++) {
+    sum_pwr_cmp += sample_cmp_pwr[i];
+  }
+  bool check = false;
+  check = sanity_check(sum_pwr_cmp, proc_power);
+  assert("Total Power does not equal the sum of the components\n" && (check));
+}
+
+void gpgpu_sim_wrapper::compute() { proc->compute(); }
+void gpgpu_sim_wrapper::print_power_kernel_stats(
+    double gpu_sim_cycle, double gpu_tot_sim_cycle, double init_value,
+    const std::string& kernel_info_string, bool print_trace) {
+  detect_print_steady_state(1, init_value);
+  if (g_power_simulation_enabled) {
+    powerfile << kernel_info_string << std::endl;
+
+    sanity_check((kernel_power.avg * kernel_sample_count), kernel_tot_power);
+    powerfile << "Kernel Average Power Data:" << std::endl;
+    powerfile << "kernel_avg_power = " << kernel_power.avg << std::endl;
+
+    for (unsigned i = 0; i < num_pwr_cmps; ++i) {
+      powerfile << "gpu_avg_" << pwr_cmp_label[i] << " = "
+                << kernel_cmp_pwr[i].avg / kernel_sample_count << std::endl;
+    }
+    for (unsigned i = 0; i < num_perf_counters; ++i) {
+      powerfile << "gpu_avg_" << perf_count_label[i] << " = "
+                << kernel_cmp_perf_counters[i].avg / kernel_sample_count
+                << std::endl;
+    }
+
+    powerfile << std::endl << "Kernel Maximum Power Data:" << std::endl;
+    powerfile << "kernel_max_power = " << kernel_power.max << std::endl;
+    for (unsigned i = 0; i < num_pwr_cmps; ++i) {
+      powerfile << "gpu_max_" << pwr_cmp_label[i] << " = "
+                << kernel_cmp_pwr[i].max << std::endl;
+    }
+    for (unsigned i = 0; i < num_perf_counters; ++i) {
+      powerfile << "gpu_max_" << perf_count_label[i] << " = "
+                << kernel_cmp_perf_counters[i].max << std::endl;
+    }
+
+    powerfile << std::endl << "Kernel Minimum Power Data:" << std::endl;
+    powerfile << "kernel_min_power = " << kernel_power.min << std::endl;
+    for (unsigned i = 0; i < num_pwr_cmps; ++i) {
+      powerfile << "gpu_min_" << pwr_cmp_label[i] << " = "
+                << kernel_cmp_pwr[i].min << std::endl;
+    }
+    for (unsigned i = 0; i < num_perf_counters; ++i) {
+      powerfile << "gpu_min_" << perf_count_label[i] << " = "
+                << kernel_cmp_perf_counters[i].min << std::endl;
+    }
+
+    powerfile << std::endl
+              << "Accumulative Power Statistics Over Previous Kernels:"
+              << std::endl;
+    powerfile << "gpu_tot_avg_power = "
+              << gpu_tot_power.avg / total_sample_count << std::endl;
+    powerfile << "gpu_tot_max_power = " << gpu_tot_power.max << std::endl;
+    powerfile << "gpu_tot_min_power = " << gpu_tot_power.min << std::endl;
+    powerfile << std::endl << std::endl;
+    powerfile.flush();
+
+    if (print_trace) {
+      print_trace_files();
+    }
+  }
+}
+void gpgpu_sim_wrapper::dump() {
+  if (g_power_per_cycle_dump) proc->displayEnergy(2, 5);
+}
+
+void gpgpu_sim_wrapper::print_steady_state(int position, double init_val) {
+  double temp_avg = sample_val / (double)samples.size();
+  double temp_ipc = (init_val - init_inst_val) /
+                    (double)(samples.size() * gpu_stat_sample_freq);
+
+  if ((samples.size() > gpu_steady_min_period)) {  // If steady state occurred
+                                                   // for some time, print to
+                                                   // file
+    has_written_avg = true;
+    gzprintf(steady_state_tacking_file, "%u,%d,%f,%f,", sample_start,
+             total_sample_count, temp_avg, temp_ipc);
+    for (unsigned i = 0; i < num_perf_counters; ++i) {
+      gzprintf(steady_state_tacking_file, "%f,",
+               samples_counter.at(i) / ((double)samples.size()));
+    }
+    gzprintf(steady_state_tacking_file, "\n");
+  } else {
+    if (!has_written_avg && position)
+      gzprintf(steady_state_tacking_file,
+               "ERROR! Not enough steady state points to generate average\n");
+  }
+
+  sample_start = 0;
+  sample_val = 0;
+  init_inst_val = init_val;
+  samples.clear();
+  samples_counter.clear();
+  pwr_counter.clear();
+  assert(samples.size() == 0);
+}
+
+void gpgpu_sim_wrapper::detect_print_steady_state(int position,
+                                                  double init_val) {
+  // Calculating Average
+  if (g_power_simulation_enabled && g_steady_power_levels_enabled) {
+    steady_state_tacking_file = gzopen(g_steady_state_tracking_filename, "a");
+    if (position == 0) {
+      if (samples.size() == 0) {
+        // First sample
+        sample_start = total_sample_count;
+        sample_val = proc->rt_power.readOp.dynamic;
+        init_inst_val = init_val;
+        samples.push_back(proc->rt_power.readOp.dynamic);
+        assert(samples_counter.size() == 0);
+        assert(pwr_counter.size() == 0);
+
+        for (unsigned i = 0; i < (num_perf_counters); ++i) {
+          samples_counter.push_back(sample_perf_counters[i]);
         }
-    }
-}
-void gpgpu_sim_wrapper::close_files()
-{
-    if(g_power_simulation_enabled){
-  	  if(g_power_trace_enabled){
-  		  gzclose(power_trace_file);
-  		  gzclose(metric_trace_file);
-  	  }
-  	 }
 
+        for (unsigned i = 0; i < (num_pwr_cmps); ++i) {
+          pwr_counter.push_back(sample_cmp_pwr[i]);
+        }
+        assert(pwr_counter.size() == (double)num_pwr_cmps);
+        assert(samples_counter.size() == (double)num_perf_counters);
+      } else {
+        // Get current average
+        double temp_avg = sample_val / (double)samples.size();
+
+        if (abs(proc->rt_power.readOp.dynamic - temp_avg) <
+            gpu_steady_power_deviation) {  // Value is within threshold
+          sample_val += proc->rt_power.readOp.dynamic;
+          samples.push_back(proc->rt_power.readOp.dynamic);
+          for (unsigned i = 0; i < (num_perf_counters); ++i) {
+            samples_counter.at(i) += sample_perf_counters[i];
+          }
+
+          for (unsigned i = 0; i < (num_pwr_cmps); ++i) {
+            pwr_counter.at(i) += sample_cmp_pwr[i];
+          }
+
+        } else {  // Value exceeds threshold, not considered steady state
+          print_steady_state(position, init_val);
+        }
+      }
+    } else {
+      print_steady_state(position, init_val);
+    }
+    gzclose(steady_state_tacking_file);
+  }
+}
+
+void gpgpu_sim_wrapper::open_files() {
+  if (g_power_simulation_enabled) {
+    if (g_power_trace_enabled) {
+      power_trace_file = gzopen(g_power_trace_filename, "a");
+      metric_trace_file = gzopen(g_metric_trace_filename, "a");
+    }
+  }
+}
+void gpgpu_sim_wrapper::close_files() {
+  if (g_power_simulation_enabled) {
+    if (g_power_trace_enabled) {
+      gzclose(power_trace_file);
+      gzclose(metric_trace_file);
+    }
+  }
 }

--- a/src/gpuwattch/gpgpu_sim_wrapper.h
+++ b/src/gpuwattch/gpgpu_sim_wrapper.h
@@ -7,141 +7,162 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef GPGPU_SIM_WRAPPER_H_
 #define GPGPU_SIM_WRAPPER_H_
 
-#include "processor.h"
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <assert.h>
-#include <string>
-#include <iostream>
-#include <fstream>
-#include <zlib.h>
 #include <string.h>
-
+#include <zlib.h>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include "processor.h"
 
 using namespace std;
 
 template <typename T>
-struct avg_max_min_counters{
-	T avg;
-	T max;
-	T min;
+struct avg_max_min_counters {
+  T avg;
+  T max;
+  T min;
 
-	avg_max_min_counters(){avg=0; max=0; min=0;}
+  avg_max_min_counters() {
+    avg = 0;
+    max = 0;
+    min = 0;
+  }
 };
 
 class gpgpu_sim_wrapper {
-public:
-	gpgpu_sim_wrapper(bool power_simulation_enabled, char* xmlfile);
-	~gpgpu_sim_wrapper();
+ public:
+  gpgpu_sim_wrapper(bool power_simulation_enabled, char* xmlfile);
+  ~gpgpu_sim_wrapper();
 
-	void init_mcpat(char* xmlfile, char* powerfile, char* power_trace_file,char* metric_trace_file,
-			char * steady_state_file,bool power_sim_enabled,bool trace_enabled,bool steady_state_enabled,
-			bool power_per_cycle_dump,double steady_power_deviation,double steady_min_period,int zlevel,
-			double init_val,int stat_sample_freq);
-	void detect_print_steady_state(int position, double init_val);
-	void close_files();
-	void open_files();
-	void compute();
-	void dump();
-	void print_trace_files();
-	void update_components_power();
-	void update_coefficients();
-	void reset_counters();
-	void print_power_kernel_stats(double gpu_sim_cycle, double gpu_tot_sim_cycle, double init_value, const std::string & kernel_info_string, bool print_trace);
-	void power_metrics_calculations();
-	void set_inst_power(bool clk_gated_lanes, double tot_cycles, double busy_cycles, double tot_inst, double int_inst, double fp_inst, double load_inst, double store_inst, double committed_inst);
-	void set_regfile_power(double reads, double writes, double ops);
-	void set_icache_power(double accesses, double misses);
-	void set_ccache_power(double accesses, double misses);
-	void set_tcache_power(double accesses, double misses);
-	void set_shrd_mem_power(double accesses);
-	void set_l1cache_power(double read_accesses, double read_misses, double write_accesses, double write_misses);
-	void set_l2cache_power(double read_accesses, double read_misses, double write_accesses, double write_misses);
-	void set_idle_core_power(double num_idle_core);
-	void set_duty_cycle_power(double duty_cycle);
-	void set_mem_ctrl_power(double reads, double writes, double dram_precharge);
-	void set_exec_unit_power(double fpu_accesses, double ialu_accesses, double sfu_accesses);
-	void set_active_lanes_power(double sp_avg_active_lane, double sfu_avg_active_lane);
-	void set_NoC_power(double noc_tot_reads, double noc_tot_write);
-	bool sanity_check(double a, double b);
+  void init_mcpat(char* xmlfile, char* powerfile, char* power_trace_file,
+                  char* metric_trace_file, char* steady_state_file,
+                  bool power_sim_enabled, bool trace_enabled,
+                  bool steady_state_enabled, bool power_per_cycle_dump,
+                  double steady_power_deviation, double steady_min_period,
+                  int zlevel, double init_val, int stat_sample_freq);
+  void detect_print_steady_state(int position, double init_val);
+  void close_files();
+  void open_files();
+  void compute();
+  void dump();
+  void print_trace_files();
+  void update_components_power();
+  void update_coefficients();
+  void reset_counters();
+  void print_power_kernel_stats(double gpu_sim_cycle, double gpu_tot_sim_cycle,
+                                double init_value,
+                                const std::string& kernel_info_string,
+                                bool print_trace);
+  void power_metrics_calculations();
+  void set_inst_power(bool clk_gated_lanes, double tot_cycles,
+                      double busy_cycles, double tot_inst, double int_inst,
+                      double fp_inst, double load_inst, double store_inst,
+                      double committed_inst);
+  void set_regfile_power(double reads, double writes, double ops);
+  void set_icache_power(double accesses, double misses);
+  void set_ccache_power(double accesses, double misses);
+  void set_tcache_power(double accesses, double misses);
+  void set_shrd_mem_power(double accesses);
+  void set_l1cache_power(double read_accesses, double read_misses,
+                         double write_accesses, double write_misses);
+  void set_l2cache_power(double read_accesses, double read_misses,
+                         double write_accesses, double write_misses);
+  void set_idle_core_power(double num_idle_core);
+  void set_duty_cycle_power(double duty_cycle);
+  void set_mem_ctrl_power(double reads, double writes, double dram_precharge);
+  void set_exec_unit_power(double fpu_accesses, double ialu_accesses,
+                           double sfu_accesses);
+  void set_active_lanes_power(double sp_avg_active_lane,
+                              double sfu_avg_active_lane);
+  void set_NoC_power(double noc_tot_reads, double noc_tot_write);
+  bool sanity_check(double a, double b);
 
-private:
+ private:
+  void print_steady_state(int position, double init_val);
 
-	void print_steady_state(int position, double init_val);
+  Processor* proc;
+  ParseXML* p;
+  // power parameters
+  double const_dynamic_power;
+  double proc_power;
 
-	Processor* proc;
-	ParseXML * p;
-    // power parameters
-    double const_dynamic_power;
-    double proc_power;
+  unsigned num_perf_counters;  // # of performance counters
+  unsigned num_pwr_cmps;       // # of components modelled
+  int kernel_sample_count;     // # of samples per kernel
+  int total_sample_count;      // # of samples per benchmark
 
-    unsigned num_perf_counters; // # of performance counters
-    unsigned num_pwr_cmps; // # of components modelled
-    int kernel_sample_count; // # of samples per kernel
-    int total_sample_count; // # of samples per benchmark
+  std::vector<avg_max_min_counters<double> >
+      kernel_cmp_pwr;  // Per-kernel component power avg/max/min values
+  std::vector<avg_max_min_counters<double> >
+      kernel_cmp_perf_counters;  // Per-kernel component avg/max/min performance
+                                 // counters
 
-    std::vector< avg_max_min_counters<double> > kernel_cmp_pwr; // Per-kernel component power avg/max/min values
-    std::vector< avg_max_min_counters<double> > kernel_cmp_perf_counters; // Per-kernel component avg/max/min performance counters
+  double kernel_tot_power;  // Total per-kernel power
+  avg_max_min_counters<double>
+      kernel_power;  // Per-kernel power avg/max/min values
+  avg_max_min_counters<double>
+      gpu_tot_power;  // Global GPU power avg/max/min values (across kernels)
 
-    double kernel_tot_power; // Total per-kernel power
-    avg_max_min_counters<double> kernel_power; // Per-kernel power avg/max/min values
-    avg_max_min_counters<double> gpu_tot_power; // Global GPU power avg/max/min values (across kernels)
+  bool has_written_avg;
 
-    bool has_written_avg;
+  std::vector<double> sample_cmp_pwr;  // Current sample component powers
+  std::vector<double>
+      sample_perf_counters;  // Current sample component perf. counts
+  std::vector<double> initpower_coeff;
+  std::vector<double> effpower_coeff;
 
-    std::vector<double> sample_cmp_pwr; // Current sample component powers
-    std::vector<double> sample_perf_counters; // Current sample component perf. counts
-    std::vector<double> initpower_coeff;
-    std::vector<double> effpower_coeff;
+  // For calculating steady-state average
+  unsigned sample_start;
+  double sample_val;
+  double init_inst_val;
+  std::vector<double> samples;
+  std::vector<double> samples_counter;
+  std::vector<double> pwr_counter;
 
-    // For calculating steady-state average
-    unsigned sample_start;
-    double sample_val;
-    double init_inst_val;
-    std::vector<double> samples;
-    std::vector<double> samples_counter;
-    std::vector<double> pwr_counter;
+  char* xml_filename;
+  char* g_power_filename;
+  char* g_power_trace_filename;
+  char* g_metric_trace_filename;
+  char* g_steady_state_tracking_filename;
+  bool g_power_simulation_enabled;
+  bool g_steady_power_levels_enabled;
+  bool g_power_trace_enabled;
+  bool g_power_per_cycle_dump;
+  double gpu_steady_power_deviation;
+  double gpu_steady_min_period;
+  int g_power_trace_zlevel;
+  double gpu_stat_sample_frequency;
+  int gpu_stat_sample_freq;
 
-    char *xml_filename;
-    char *g_power_filename;
-    char *g_power_trace_filename;
-    char *g_metric_trace_filename;
-    char * g_steady_state_tracking_filename;
-    bool g_power_simulation_enabled;
-    bool g_steady_power_levels_enabled;
-    bool g_power_trace_enabled;
-    bool g_power_per_cycle_dump;
-	double   gpu_steady_power_deviation;
-	double   gpu_steady_min_period;
-	int g_power_trace_zlevel;
-    double gpu_stat_sample_frequency;
-    int gpu_stat_sample_freq;
-
-    std::ofstream powerfile;
-    gzFile power_trace_file;
-    gzFile metric_trace_file;
-    gzFile steady_state_tacking_file;
+  std::ofstream powerfile;
+  gzFile power_trace_file;
+  gzFile metric_trace_file;
+  gzFile steady_state_tacking_file;
 };
 
 #endif /* GPGPU_SIM_WRAPPER_H_ */

--- a/src/gpuwattch/gpgpu_sim_wrapper.h
+++ b/src/gpuwattch/gpgpu_sim_wrapper.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -28,120 +30,140 @@
 #ifndef GPGPU_SIM_WRAPPER_H_
 #define GPGPU_SIM_WRAPPER_H_
 
-#include "processor.h"
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <assert.h>
-#include <string>
-#include <iostream>
-#include <fstream>
-#include <zlib.h>
 #include <string.h>
-
+#include <zlib.h>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include "processor.h"
 
 using namespace std;
 
 template <typename T>
-struct avg_max_min_counters{
-	T avg;
-	T max;
-	T min;
+struct avg_max_min_counters {
+  T avg;
+  T max;
+  T min;
 
-	avg_max_min_counters(){avg=0; max=0; min=0;}
+  avg_max_min_counters() {
+    avg = 0;
+    max = 0;
+    min = 0;
+  }
 };
 
 class gpgpu_sim_wrapper {
-public:
-	gpgpu_sim_wrapper(bool power_simulation_enabled, char* xmlfile);
-	~gpgpu_sim_wrapper();
+ public:
+  gpgpu_sim_wrapper(bool power_simulation_enabled, char* xmlfile);
+  ~gpgpu_sim_wrapper();
 
-	void init_mcpat(char* xmlfile, char* powerfile, char* power_trace_file,char* metric_trace_file,
-			char * steady_state_file,bool power_sim_enabled,bool trace_enabled,bool steady_state_enabled,
-			bool power_per_cycle_dump,double steady_power_deviation,double steady_min_period,int zlevel,
-			double init_val,int stat_sample_freq);
-	void detect_print_steady_state(int position, double init_val);
-	void close_files();
-	void open_files();
-	void compute();
-	void dump();
-	void print_trace_files();
-	void update_components_power();
-	void update_coefficients();
-	void reset_counters();
-	void print_power_kernel_stats(double gpu_sim_cycle, double gpu_tot_sim_cycle, double init_value, const std::string & kernel_info_string, bool print_trace);
-	void power_metrics_calculations();
-	void set_inst_power(bool clk_gated_lanes, double tot_cycles, double busy_cycles, double tot_inst, double int_inst, double fp_inst, double load_inst, double store_inst, double committed_inst);
-	void set_regfile_power(double reads, double writes, double ops);
-	void set_icache_power(double accesses, double misses);
-	void set_ccache_power(double accesses, double misses);
-	void set_tcache_power(double accesses, double misses);
-	void set_shrd_mem_power(double accesses);
-	void set_l1cache_power(double read_accesses, double read_misses, double write_accesses, double write_misses);
-	void set_l2cache_power(double read_accesses, double read_misses, double write_accesses, double write_misses);
-	void set_idle_core_power(double num_idle_core);
-	void set_duty_cycle_power(double duty_cycle);
-	void set_mem_ctrl_power(double reads, double writes, double dram_precharge);
-	void set_exec_unit_power(double fpu_accesses, double ialu_accesses, double sfu_accesses);
-	void set_active_lanes_power(double sp_avg_active_lane, double sfu_avg_active_lane);
-	void set_NoC_power(double noc_tot_reads, double noc_tot_write);
-	bool sanity_check(double a, double b);
+  void init_mcpat(char* xmlfile, char* powerfile, char* power_trace_file,
+                  char* metric_trace_file, char* steady_state_file,
+                  bool power_sim_enabled, bool trace_enabled,
+                  bool steady_state_enabled, bool power_per_cycle_dump,
+                  double steady_power_deviation, double steady_min_period,
+                  int zlevel, double init_val, int stat_sample_freq);
+  void detect_print_steady_state(int position, double init_val);
+  void close_files();
+  void open_files();
+  void compute();
+  void dump();
+  void print_trace_files();
+  void update_components_power();
+  void update_coefficients();
+  void reset_counters();
+  void print_power_kernel_stats(double gpu_sim_cycle, double gpu_tot_sim_cycle,
+                                double init_value,
+                                const std::string& kernel_info_string,
+                                bool print_trace);
+  void power_metrics_calculations();
+  void set_inst_power(bool clk_gated_lanes, double tot_cycles,
+                      double busy_cycles, double tot_inst, double int_inst,
+                      double fp_inst, double load_inst, double store_inst,
+                      double committed_inst);
+  void set_regfile_power(double reads, double writes, double ops);
+  void set_icache_power(double accesses, double misses);
+  void set_ccache_power(double accesses, double misses);
+  void set_tcache_power(double accesses, double misses);
+  void set_shrd_mem_power(double accesses);
+  void set_l1cache_power(double read_accesses, double read_misses,
+                         double write_accesses, double write_misses);
+  void set_l2cache_power(double read_accesses, double read_misses,
+                         double write_accesses, double write_misses);
+  void set_idle_core_power(double num_idle_core);
+  void set_duty_cycle_power(double duty_cycle);
+  void set_mem_ctrl_power(double reads, double writes, double dram_precharge);
+  void set_exec_unit_power(double fpu_accesses, double ialu_accesses,
+                           double sfu_accesses);
+  void set_active_lanes_power(double sp_avg_active_lane,
+                              double sfu_avg_active_lane);
+  void set_NoC_power(double noc_tot_reads, double noc_tot_write);
+  bool sanity_check(double a, double b);
 
-private:
+ private:
+  void print_steady_state(int position, double init_val);
 
-	void print_steady_state(int position, double init_val);
+  Processor* proc;
+  ParseXML* p;
+  // power parameters
+  double const_dynamic_power;
+  double proc_power;
 
-	Processor* proc;
-	ParseXML * p;
-    // power parameters
-    double const_dynamic_power;
-    double proc_power;
+  unsigned num_perf_counters;  // # of performance counters
+  unsigned num_pwr_cmps;       // # of components modelled
+  int kernel_sample_count;     // # of samples per kernel
+  int total_sample_count;      // # of samples per benchmark
 
-    unsigned num_perf_counters; // # of performance counters
-    unsigned num_pwr_cmps; // # of components modelled
-    int kernel_sample_count; // # of samples per kernel
-    int total_sample_count; // # of samples per benchmark
+  std::vector<avg_max_min_counters<double> >
+      kernel_cmp_pwr;  // Per-kernel component power avg/max/min values
+  std::vector<avg_max_min_counters<double> >
+      kernel_cmp_perf_counters;  // Per-kernel component avg/max/min performance
+                                 // counters
 
-    std::vector< avg_max_min_counters<double> > kernel_cmp_pwr; // Per-kernel component power avg/max/min values
-    std::vector< avg_max_min_counters<double> > kernel_cmp_perf_counters; // Per-kernel component avg/max/min performance counters
+  double kernel_tot_power;  // Total per-kernel power
+  avg_max_min_counters<double>
+      kernel_power;  // Per-kernel power avg/max/min values
+  avg_max_min_counters<double>
+      gpu_tot_power;  // Global GPU power avg/max/min values (across kernels)
 
-    double kernel_tot_power; // Total per-kernel power
-    avg_max_min_counters<double> kernel_power; // Per-kernel power avg/max/min values
-    avg_max_min_counters<double> gpu_tot_power; // Global GPU power avg/max/min values (across kernels)
+  bool has_written_avg;
 
-    bool has_written_avg;
+  std::vector<double> sample_cmp_pwr;  // Current sample component powers
+  std::vector<double>
+      sample_perf_counters;  // Current sample component perf. counts
+  std::vector<double> initpower_coeff;
+  std::vector<double> effpower_coeff;
 
-    std::vector<double> sample_cmp_pwr; // Current sample component powers
-    std::vector<double> sample_perf_counters; // Current sample component perf. counts
-    std::vector<double> initpower_coeff;
-    std::vector<double> effpower_coeff;
+  // For calculating steady-state average
+  unsigned sample_start;
+  double sample_val;
+  double init_inst_val;
+  std::vector<double> samples;
+  std::vector<double> samples_counter;
+  std::vector<double> pwr_counter;
 
-    // For calculating steady-state average
-    unsigned sample_start;
-    double sample_val;
-    double init_inst_val;
-    std::vector<double> samples;
-    std::vector<double> samples_counter;
-    std::vector<double> pwr_counter;
+  char* xml_filename;
+  char* g_power_filename;
+  char* g_power_trace_filename;
+  char* g_metric_trace_filename;
+  char* g_steady_state_tracking_filename;
+  bool g_power_simulation_enabled;
+  bool g_steady_power_levels_enabled;
+  bool g_power_trace_enabled;
+  bool g_power_per_cycle_dump;
+  double gpu_steady_power_deviation;
+  double gpu_steady_min_period;
+  int g_power_trace_zlevel;
+  double gpu_stat_sample_frequency;
+  int gpu_stat_sample_freq;
 
-    char *xml_filename;
-    char *g_power_filename;
-    char *g_power_trace_filename;
-    char *g_metric_trace_filename;
-    char * g_steady_state_tracking_filename;
-    bool g_power_simulation_enabled;
-    bool g_steady_power_levels_enabled;
-    bool g_power_trace_enabled;
-    bool g_power_per_cycle_dump;
-	double   gpu_steady_power_deviation;
-	double   gpu_steady_min_period;
-	int g_power_trace_zlevel;
-    double gpu_stat_sample_frequency;
-    int gpu_stat_sample_freq;
-
-    std::ofstream powerfile;
-    gzFile power_trace_file;
-    gzFile metric_trace_file;
-    gzFile steady_state_tacking_file;
+  std::ofstream powerfile;
+  gzFile power_trace_file;
+  gzFile metric_trace_file;
+  gzFile steady_state_tacking_file;
 };
 
 #endif /* GPGPU_SIM_WRAPPER_H_ */

--- a/src/gpuwattch/gpgpu_sim_wrapper.h
+++ b/src/gpuwattch/gpgpu_sim_wrapper.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -30,140 +28,120 @@
 #ifndef GPGPU_SIM_WRAPPER_H_
 #define GPGPU_SIM_WRAPPER_H_
 
-#include <assert.h>
+#include "processor.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <zlib.h>
-#include <fstream>
-#include <iostream>
+#include <assert.h>
 #include <string>
-#include "processor.h"
+#include <iostream>
+#include <fstream>
+#include <zlib.h>
+#include <string.h>
+
 
 using namespace std;
 
 template <typename T>
-struct avg_max_min_counters {
-  T avg;
-  T max;
-  T min;
+struct avg_max_min_counters{
+	T avg;
+	T max;
+	T min;
 
-  avg_max_min_counters() {
-    avg = 0;
-    max = 0;
-    min = 0;
-  }
+	avg_max_min_counters(){avg=0; max=0; min=0;}
 };
 
 class gpgpu_sim_wrapper {
- public:
-  gpgpu_sim_wrapper(bool power_simulation_enabled, char* xmlfile);
-  ~gpgpu_sim_wrapper();
+public:
+	gpgpu_sim_wrapper(bool power_simulation_enabled, char* xmlfile);
+	~gpgpu_sim_wrapper();
 
-  void init_mcpat(char* xmlfile, char* powerfile, char* power_trace_file,
-                  char* metric_trace_file, char* steady_state_file,
-                  bool power_sim_enabled, bool trace_enabled,
-                  bool steady_state_enabled, bool power_per_cycle_dump,
-                  double steady_power_deviation, double steady_min_period,
-                  int zlevel, double init_val, int stat_sample_freq);
-  void detect_print_steady_state(int position, double init_val);
-  void close_files();
-  void open_files();
-  void compute();
-  void dump();
-  void print_trace_files();
-  void update_components_power();
-  void update_coefficients();
-  void reset_counters();
-  void print_power_kernel_stats(double gpu_sim_cycle, double gpu_tot_sim_cycle,
-                                double init_value,
-                                const std::string& kernel_info_string,
-                                bool print_trace);
-  void power_metrics_calculations();
-  void set_inst_power(bool clk_gated_lanes, double tot_cycles,
-                      double busy_cycles, double tot_inst, double int_inst,
-                      double fp_inst, double load_inst, double store_inst,
-                      double committed_inst);
-  void set_regfile_power(double reads, double writes, double ops);
-  void set_icache_power(double accesses, double misses);
-  void set_ccache_power(double accesses, double misses);
-  void set_tcache_power(double accesses, double misses);
-  void set_shrd_mem_power(double accesses);
-  void set_l1cache_power(double read_accesses, double read_misses,
-                         double write_accesses, double write_misses);
-  void set_l2cache_power(double read_accesses, double read_misses,
-                         double write_accesses, double write_misses);
-  void set_idle_core_power(double num_idle_core);
-  void set_duty_cycle_power(double duty_cycle);
-  void set_mem_ctrl_power(double reads, double writes, double dram_precharge);
-  void set_exec_unit_power(double fpu_accesses, double ialu_accesses,
-                           double sfu_accesses);
-  void set_active_lanes_power(double sp_avg_active_lane,
-                              double sfu_avg_active_lane);
-  void set_NoC_power(double noc_tot_reads, double noc_tot_write);
-  bool sanity_check(double a, double b);
+	void init_mcpat(char* xmlfile, char* powerfile, char* power_trace_file,char* metric_trace_file,
+			char * steady_state_file,bool power_sim_enabled,bool trace_enabled,bool steady_state_enabled,
+			bool power_per_cycle_dump,double steady_power_deviation,double steady_min_period,int zlevel,
+			double init_val,int stat_sample_freq);
+	void detect_print_steady_state(int position, double init_val);
+	void close_files();
+	void open_files();
+	void compute();
+	void dump();
+	void print_trace_files();
+	void update_components_power();
+	void update_coefficients();
+	void reset_counters();
+	void print_power_kernel_stats(double gpu_sim_cycle, double gpu_tot_sim_cycle, double init_value, const std::string & kernel_info_string, bool print_trace);
+	void power_metrics_calculations();
+	void set_inst_power(bool clk_gated_lanes, double tot_cycles, double busy_cycles, double tot_inst, double int_inst, double fp_inst, double load_inst, double store_inst, double committed_inst);
+	void set_regfile_power(double reads, double writes, double ops);
+	void set_icache_power(double accesses, double misses);
+	void set_ccache_power(double accesses, double misses);
+	void set_tcache_power(double accesses, double misses);
+	void set_shrd_mem_power(double accesses);
+	void set_l1cache_power(double read_accesses, double read_misses, double write_accesses, double write_misses);
+	void set_l2cache_power(double read_accesses, double read_misses, double write_accesses, double write_misses);
+	void set_idle_core_power(double num_idle_core);
+	void set_duty_cycle_power(double duty_cycle);
+	void set_mem_ctrl_power(double reads, double writes, double dram_precharge);
+	void set_exec_unit_power(double fpu_accesses, double ialu_accesses, double sfu_accesses);
+	void set_active_lanes_power(double sp_avg_active_lane, double sfu_avg_active_lane);
+	void set_NoC_power(double noc_tot_reads, double noc_tot_write);
+	bool sanity_check(double a, double b);
 
- private:
-  void print_steady_state(int position, double init_val);
+private:
 
-  Processor* proc;
-  ParseXML* p;
-  // power parameters
-  double const_dynamic_power;
-  double proc_power;
+	void print_steady_state(int position, double init_val);
 
-  unsigned num_perf_counters;  // # of performance counters
-  unsigned num_pwr_cmps;       // # of components modelled
-  int kernel_sample_count;     // # of samples per kernel
-  int total_sample_count;      // # of samples per benchmark
+	Processor* proc;
+	ParseXML * p;
+    // power parameters
+    double const_dynamic_power;
+    double proc_power;
 
-  std::vector<avg_max_min_counters<double> >
-      kernel_cmp_pwr;  // Per-kernel component power avg/max/min values
-  std::vector<avg_max_min_counters<double> >
-      kernel_cmp_perf_counters;  // Per-kernel component avg/max/min performance
-                                 // counters
+    unsigned num_perf_counters; // # of performance counters
+    unsigned num_pwr_cmps; // # of components modelled
+    int kernel_sample_count; // # of samples per kernel
+    int total_sample_count; // # of samples per benchmark
 
-  double kernel_tot_power;  // Total per-kernel power
-  avg_max_min_counters<double>
-      kernel_power;  // Per-kernel power avg/max/min values
-  avg_max_min_counters<double>
-      gpu_tot_power;  // Global GPU power avg/max/min values (across kernels)
+    std::vector< avg_max_min_counters<double> > kernel_cmp_pwr; // Per-kernel component power avg/max/min values
+    std::vector< avg_max_min_counters<double> > kernel_cmp_perf_counters; // Per-kernel component avg/max/min performance counters
 
-  bool has_written_avg;
+    double kernel_tot_power; // Total per-kernel power
+    avg_max_min_counters<double> kernel_power; // Per-kernel power avg/max/min values
+    avg_max_min_counters<double> gpu_tot_power; // Global GPU power avg/max/min values (across kernels)
 
-  std::vector<double> sample_cmp_pwr;  // Current sample component powers
-  std::vector<double>
-      sample_perf_counters;  // Current sample component perf. counts
-  std::vector<double> initpower_coeff;
-  std::vector<double> effpower_coeff;
+    bool has_written_avg;
 
-  // For calculating steady-state average
-  unsigned sample_start;
-  double sample_val;
-  double init_inst_val;
-  std::vector<double> samples;
-  std::vector<double> samples_counter;
-  std::vector<double> pwr_counter;
+    std::vector<double> sample_cmp_pwr; // Current sample component powers
+    std::vector<double> sample_perf_counters; // Current sample component perf. counts
+    std::vector<double> initpower_coeff;
+    std::vector<double> effpower_coeff;
 
-  char* xml_filename;
-  char* g_power_filename;
-  char* g_power_trace_filename;
-  char* g_metric_trace_filename;
-  char* g_steady_state_tracking_filename;
-  bool g_power_simulation_enabled;
-  bool g_steady_power_levels_enabled;
-  bool g_power_trace_enabled;
-  bool g_power_per_cycle_dump;
-  double gpu_steady_power_deviation;
-  double gpu_steady_min_period;
-  int g_power_trace_zlevel;
-  double gpu_stat_sample_frequency;
-  int gpu_stat_sample_freq;
+    // For calculating steady-state average
+    unsigned sample_start;
+    double sample_val;
+    double init_inst_val;
+    std::vector<double> samples;
+    std::vector<double> samples_counter;
+    std::vector<double> pwr_counter;
 
-  std::ofstream powerfile;
-  gzFile power_trace_file;
-  gzFile metric_trace_file;
-  gzFile steady_state_tacking_file;
+    char *xml_filename;
+    char *g_power_filename;
+    char *g_power_trace_filename;
+    char *g_metric_trace_filename;
+    char * g_steady_state_tracking_filename;
+    bool g_power_simulation_enabled;
+    bool g_steady_power_levels_enabled;
+    bool g_power_trace_enabled;
+    bool g_power_per_cycle_dump;
+	double   gpu_steady_power_deviation;
+	double   gpu_steady_min_period;
+	int g_power_trace_zlevel;
+    double gpu_stat_sample_frequency;
+    int gpu_stat_sample_freq;
+
+    std::ofstream powerfile;
+    gzFile power_trace_file;
+    gzFile metric_trace_file;
+    gzFile steady_state_tacking_file;
 };
 
 #endif /* GPGPU_SIM_WRAPPER_H_ */

--- a/src/gpuwattch/interconnect.cc
+++ b/src/gpuwattch/interconnect.cc
@@ -29,51 +29,63 @@
  *
  ***************************************************************************/
 
+
 #include "interconnect.h"
+#include "wire.h"
 #include <assert.h>
 #include <iostream>
 #include "globalvar.h"
-#include "wire.h"
 
-interconnect::interconnect(string name_, enum Device_ty device_ty_,
-                           double base_w, double base_h, int data_w, double len,
-                           const InputParameter *configure_interface,
-                           int start_wiring_level_, bool pipelinable_,
-                           double route_over_perc_, bool opt_local_,
-                           enum Core_type core_ty_, enum Wire_type wire_model,
-                           double width_s, double space_s,
-                           TechnologyParameter::DeviceType *dt)
-    : name(name_),
-      device_ty(device_ty_),
-      in_rise_time(0),
-      out_rise_time(0),
-      base_width(base_w),
-      base_height(base_h),
-      data_width(data_w),
-      wt(wire_model),
-      width_scaling(width_s),
-      space_scaling(space_s),
-      start_wiring_level(start_wiring_level_),
-      length(len),
-      // interconnect_latency(1e-12),
-      // interconnect_throughput(1e-12),
-      opt_local(opt_local_),
-      core_ty(core_ty_),
-      pipelinable(pipelinable_),
-      route_over_perc(route_over_perc_),
-      deviceType(dt) {
+interconnect::interconnect(
+    string name_,
+    enum Device_ty device_ty_,
+	double base_w, double base_h,
+    int data_w, double len,const InputParameter *configure_interface,
+    int start_wiring_level_,
+    bool pipelinable_ ,
+    double route_over_perc_ ,
+    bool opt_local_,
+    enum Core_type core_ty_,
+    enum Wire_type wire_model,
+    double width_s, double space_s,
+    TechnologyParameter::DeviceType *dt
+)
+ :name(name_),
+  device_ty(device_ty_),
+  in_rise_time(0),
+  out_rise_time(0),
+  base_width(base_w),
+  base_height(base_h),
+  data_width(data_w),
+  wt(wire_model),
+  width_scaling(width_s),
+  space_scaling(space_s),
+  start_wiring_level(start_wiring_level_),
+  length(len),
+  //interconnect_latency(1e-12),
+  //interconnect_throughput(1e-12),
+  opt_local(opt_local_),
+  core_ty(core_ty_),
+  pipelinable(pipelinable_),
+  route_over_perc(route_over_perc_),
+  deviceType(dt)
+{
+
   wt = Global;
-  l_ip = *configure_interface;
+  l_ip=*configure_interface;
   local_result = init_interface(&l_ip);
 
-  max_unpipelined_link_delay = 0;  // TODO
+
+  max_unpipelined_link_delay = 0; //TODO
   min_w_nmos = g_tp.min_w_nmos_;
   min_w_pmos = deviceType->n_to_p_eff_curr_drv_ratio * min_w_nmos;
 
-  latency = l_ip.latency;
-  throughput = l_ip.throughput;
-  latency_overflow = false;
-  throughput_overflow = false;
+
+
+  latency               = l_ip.latency;
+  throughput            = l_ip.throughput;
+  latency_overflow=false;
+  throughput_overflow=false;
 
   /*
    * TODO: Add wiring option from semi-global to global automatically
@@ -84,62 +96,66 @@ interconnect::interconnect(string name_, enum Device_ty device_ty_,
    * not have fat wires.
    */
   if (pipelinable == false)
-  // Non-pipelinable wires, such as bypass logic, care latency
+  //Non-pipelinable wires, such as bypass logic, care latency
   {
-    compute();
-    if (opt_for_clk && opt_local) {
-      while (delay > latency && width_scaling < 3.0) {
-        width_scaling *= 2;
-        space_scaling *= 2;
-        Wire winit(width_scaling, space_scaling);
-        compute();
-      }
-      if (delay > latency) {
-        latency_overflow = true;
-      }
-    }
-  } else  // Pipelinable wires, such as bus, does not care latency but
-          // throughput
+	  compute();
+	  if (opt_for_clk && opt_local)
+	  {
+		  while (delay > latency && width_scaling<3.0)
+		  {
+			  width_scaling *= 2;
+			  space_scaling *= 2;
+			  Wire winit(width_scaling, space_scaling);
+			  compute();
+		  }
+		  if (delay > latency)
+		  {
+			  latency_overflow=true;
+		  }
+	  }
+  }
+  else //Pipelinable wires, such as bus, does not care latency but throughput
   {
-    /*
-     * TODO: Add pipe regs power, area, and timing;
-     * Pipelinable wires optimize latency first.
-     */
-    compute();
-    if (opt_for_clk && opt_local) {
-      while (delay > throughput && width_scaling < 3.0) {
-        width_scaling *= 2;
-        space_scaling *= 2;
-        Wire winit(width_scaling, space_scaling);
-        compute();
-      }
-      if (delay > throughput)
-      // insert pipeline stages
-      {
-        num_pipe_stages = (int)ceil(delay / throughput);
-        assert(num_pipe_stages > 0);
-        delay = delay / num_pipe_stages + num_pipe_stages * 0.05 * delay;
-      }
-    }
+	  /*
+	   * TODO: Add pipe regs power, area, and timing;
+	   * Pipelinable wires optimize latency first.
+	   */
+	  compute();
+	  if (opt_for_clk && opt_local)
+	  {
+		  while (delay > throughput && width_scaling<3.0)
+		  {
+			  width_scaling *= 2;
+			  space_scaling *= 2;
+			  Wire winit(width_scaling, space_scaling);
+			  compute();
+		  }
+		  if (delay > throughput)
+			  // insert pipeline stages
+		  {
+			  num_pipe_stages = (int)ceil(delay/throughput);
+			  assert(num_pipe_stages>0);
+			  delay = delay/num_pipe_stages + num_pipe_stages*0.05*delay;
+		  }
+	  }
   }
 
   power_bit = power;
   power.readOp.dynamic *= data_width;
   power.readOp.leakage *= data_width;
   power.readOp.gate_leakage *= data_width;
-  area.set_area(area.get_area() * data_width);
+  area.set_area(area.get_area()*data_width);
   no_device_under_wire_area.h *= data_width;
 
-  if (latency_overflow == true)
-    cout << "Warning: " << name
-         << " wire structure cannot satisfy latency constraint." << endl;
+  if (latency_overflow==true)
+  		cout<< "Warning: "<< name <<" wire structure cannot satisfy latency constraint." << endl;
+
 
   assert(power.readOp.dynamic > 0);
   assert(power.readOp.leakage > 0);
   assert(power.readOp.gate_leakage > 0);
 
-  double long_channel_device_reduction =
-      longer_channel_device_reduction(device_ty, core_ty);
+  double long_channel_device_reduction = longer_channel_device_reduction(device_ty,core_ty);
 
   double sckRation = g_tp.sckt_co_eff;
   power.readOp.dynamic *= sckRation;
@@ -147,17 +163,20 @@ interconnect::interconnect(string name_, enum Device_ty device_ty_,
   power.searchOp.dynamic *= sckRation;
 
   power.readOp.longer_channel_leakage =
-      power.readOp.leakage * long_channel_device_reduction;
+	  power.readOp.leakage*long_channel_device_reduction;
 
-  if (pipelinable)  // Only global wires has the option to choose whether
-                    // routing over or not
-    area.set_area(area.get_area() * route_over_perc +
-                  no_device_under_wire_area.get_area() * (1 - route_over_perc));
+  if (pipelinable)//Only global wires has the option to choose whether routing over or not
+	  area.set_area(area.get_area()*route_over_perc + no_device_under_wire_area.get_area()*(1-route_over_perc));
 
   Wire wreset();
 }
 
-void interconnect::compute() {
+
+
+void
+interconnect::compute()
+{
+
   Wire *wtemp1 = 0;
   wtemp1 = new Wire(wt, length, 1, width_scaling, space_scaling);
   delay = wtemp1->delay;
@@ -166,15 +185,18 @@ void interconnect::compute() {
   power.readOp.gate_leakage = wtemp1->power.readOp.gate_leakage;
 
   area.set_area(wtemp1->area.get_area());
-  no_device_under_wire_area.h = (wtemp1->wire_width + wtemp1->wire_spacing);
+  no_device_under_wire_area.h =  (wtemp1->wire_width + wtemp1->wire_spacing);
   no_device_under_wire_area.w = length;
 
-  if (wtemp1) delete wtemp1;
+  if (wtemp1)
+   delete wtemp1;
+
 }
 
-void interconnect::leakage_feedback(double temperature) {
-  l_ip.temp = (unsigned int)round(temperature / 10.0) * 10;
-  uca_org_t init_result = init_interface(&l_ip);  // init_result is dummy
+void interconnect::leakage_feedback(double temperature)
+{
+  l_ip.temp = (unsigned int)round(temperature/10.0)*10;
+  uca_org_t init_result = init_interface(&l_ip); // init_result is dummy
 
   compute();
 
@@ -187,14 +209,13 @@ void interconnect::leakage_feedback(double temperature) {
   assert(power.readOp.leakage > 0);
   assert(power.readOp.gate_leakage > 0);
 
-  double long_channel_device_reduction =
-      longer_channel_device_reduction(device_ty, core_ty);
+  double long_channel_device_reduction = longer_channel_device_reduction(device_ty,core_ty);
 
   double sckRation = g_tp.sckt_co_eff;
   power.readOp.dynamic *= sckRation;
   power.writeOp.dynamic *= sckRation;
   power.searchOp.dynamic *= sckRation;
 
-  power.readOp.longer_channel_leakage =
-      power.readOp.leakage * long_channel_device_reduction;
+  power.readOp.longer_channel_leakage = power.readOp.leakage*long_channel_device_reduction;
 }
+

--- a/src/gpuwattch/interconnect.h
+++ b/src/gpuwattch/interconnect.h
@@ -29,83 +29,72 @@
  *
  ***************************************************************************/
 
-
 #ifndef __INTERCONNECT_H__
 #define __INTERCONNECT_H__
 
-#include "cacti/basic_circuit.h"
+#include "assert.h"
 #include "basic_components.h"
+#include "cacti/basic_circuit.h"
+#include "cacti/cacti_interface.h"
 #include "cacti/component.h"
 #include "cacti/parameter.h"
-#include "assert.h"
 #include "cacti/subarray.h"
-#include "cacti/cacti_interface.h"
 #include "cacti/wire.h"
 
 // leakge power includes entire htree in a bank (when uca_tree == false)
 // leakge power includes only part to one bank when uca_tree == true
 
-class interconnect : public Component
-{
-  public:
-    interconnect(
-        string  name_,
-        enum Device_ty device_ty_,
-    	double base_w =0, double base_h =0, int data_w =0, double len =0,
-        const InputParameter *configure_interface = NULL, int start_wiring_level_ =0,
-        bool pipelinable_ = false,
-        double route_over_perc_ =0.5,
-        bool opt_local_=true,
-        enum Core_type core_ty_=Inorder,
-        enum Wire_type wire_model=Global,
-        double width_s=1.0, double space_s=1.0,
-        TechnologyParameter::DeviceType *dt = &(g_tp.peri_global)
-		);
+class interconnect : public Component {
+ public:
+  interconnect(string name_, enum Device_ty device_ty_, double base_w = 0,
+               double base_h = 0, int data_w = 0, double len = 0,
+               const InputParameter *configure_interface = NULL,
+               int start_wiring_level_ = 0, bool pipelinable_ = false,
+               double route_over_perc_ = 0.5, bool opt_local_ = true,
+               enum Core_type core_ty_ = Inorder,
+               enum Wire_type wire_model = Global, double width_s = 1.0,
+               double space_s = 1.0,
+               TechnologyParameter::DeviceType *dt = &(g_tp.peri_global));
 
-    ~interconnect() {};
+  ~interconnect(){};
 
-    void compute();
-	string   name;
-	enum Device_ty device_ty;
-    double in_rise_time, out_rise_time;
-	InputParameter l_ip;
-	uca_org_t local_result;
-    Area no_device_under_wire_area;
-    void set_in_rise_time(double rt)
-    {
-      in_rise_time = rt;
-    }
-    
-    void leakage_feedback(double temperature);
-    double max_unpipelined_link_delay;
-    powerDef power_bit;
+  void compute();
+  string name;
+  enum Device_ty device_ty;
+  double in_rise_time, out_rise_time;
+  InputParameter l_ip;
+  uca_org_t local_result;
+  Area no_device_under_wire_area;
+  void set_in_rise_time(double rt) { in_rise_time = rt; }
 
-    double wire_bw;
-    double init_wire_bw;  // bus width at root
-    double base_width;
-    double base_height;
-    int data_width;
-    enum Wire_type wt;
-    double width_scaling, space_scaling;
-    int start_wiring_level;
-    double length;
-    double min_w_nmos;
-    double min_w_pmos;
-    double latency, throughput;
-    bool  latency_overflow;
-    bool  throughput_overflow;
-    double  interconnect_latency;
-    double  interconnect_throughput;
-    bool opt_local;
-    enum Core_type core_ty;
-    bool pipelinable;
-    double route_over_perc;
-    int  num_pipe_stages;
+  void leakage_feedback(double temperature);
+  double max_unpipelined_link_delay;
+  powerDef power_bit;
 
-  private:
-    TechnologyParameter::DeviceType *deviceType;
+  double wire_bw;
+  double init_wire_bw;  // bus width at root
+  double base_width;
+  double base_height;
+  int data_width;
+  enum Wire_type wt;
+  double width_scaling, space_scaling;
+  int start_wiring_level;
+  double length;
+  double min_w_nmos;
+  double min_w_pmos;
+  double latency, throughput;
+  bool latency_overflow;
+  bool throughput_overflow;
+  double interconnect_latency;
+  double interconnect_throughput;
+  bool opt_local;
+  enum Core_type core_ty;
+  bool pipelinable;
+  double route_over_perc;
+  int num_pipe_stages;
 
+ private:
+  TechnologyParameter::DeviceType *deviceType;
 };
 
 #endif
-

--- a/src/gpuwattch/interconnect.h
+++ b/src/gpuwattch/interconnect.h
@@ -29,72 +29,83 @@
  *
  ***************************************************************************/
 
+
 #ifndef __INTERCONNECT_H__
 #define __INTERCONNECT_H__
 
-#include "assert.h"
-#include "basic_components.h"
 #include "cacti/basic_circuit.h"
-#include "cacti/cacti_interface.h"
+#include "basic_components.h"
 #include "cacti/component.h"
 #include "cacti/parameter.h"
+#include "assert.h"
 #include "cacti/subarray.h"
+#include "cacti/cacti_interface.h"
 #include "cacti/wire.h"
 
 // leakge power includes entire htree in a bank (when uca_tree == false)
 // leakge power includes only part to one bank when uca_tree == true
 
-class interconnect : public Component {
- public:
-  interconnect(string name_, enum Device_ty device_ty_, double base_w = 0,
-               double base_h = 0, int data_w = 0, double len = 0,
-               const InputParameter *configure_interface = NULL,
-               int start_wiring_level_ = 0, bool pipelinable_ = false,
-               double route_over_perc_ = 0.5, bool opt_local_ = true,
-               enum Core_type core_ty_ = Inorder,
-               enum Wire_type wire_model = Global, double width_s = 1.0,
-               double space_s = 1.0,
-               TechnologyParameter::DeviceType *dt = &(g_tp.peri_global));
+class interconnect : public Component
+{
+  public:
+    interconnect(
+        string  name_,
+        enum Device_ty device_ty_,
+    	double base_w =0, double base_h =0, int data_w =0, double len =0,
+        const InputParameter *configure_interface = NULL, int start_wiring_level_ =0,
+        bool pipelinable_ = false,
+        double route_over_perc_ =0.5,
+        bool opt_local_=true,
+        enum Core_type core_ty_=Inorder,
+        enum Wire_type wire_model=Global,
+        double width_s=1.0, double space_s=1.0,
+        TechnologyParameter::DeviceType *dt = &(g_tp.peri_global)
+		);
 
-  ~interconnect(){};
+    ~interconnect() {};
 
-  void compute();
-  string name;
-  enum Device_ty device_ty;
-  double in_rise_time, out_rise_time;
-  InputParameter l_ip;
-  uca_org_t local_result;
-  Area no_device_under_wire_area;
-  void set_in_rise_time(double rt) { in_rise_time = rt; }
+    void compute();
+	string   name;
+	enum Device_ty device_ty;
+    double in_rise_time, out_rise_time;
+	InputParameter l_ip;
+	uca_org_t local_result;
+    Area no_device_under_wire_area;
+    void set_in_rise_time(double rt)
+    {
+      in_rise_time = rt;
+    }
+    
+    void leakage_feedback(double temperature);
+    double max_unpipelined_link_delay;
+    powerDef power_bit;
 
-  void leakage_feedback(double temperature);
-  double max_unpipelined_link_delay;
-  powerDef power_bit;
+    double wire_bw;
+    double init_wire_bw;  // bus width at root
+    double base_width;
+    double base_height;
+    int data_width;
+    enum Wire_type wt;
+    double width_scaling, space_scaling;
+    int start_wiring_level;
+    double length;
+    double min_w_nmos;
+    double min_w_pmos;
+    double latency, throughput;
+    bool  latency_overflow;
+    bool  throughput_overflow;
+    double  interconnect_latency;
+    double  interconnect_throughput;
+    bool opt_local;
+    enum Core_type core_ty;
+    bool pipelinable;
+    double route_over_perc;
+    int  num_pipe_stages;
 
-  double wire_bw;
-  double init_wire_bw;  // bus width at root
-  double base_width;
-  double base_height;
-  int data_width;
-  enum Wire_type wt;
-  double width_scaling, space_scaling;
-  int start_wiring_level;
-  double length;
-  double min_w_nmos;
-  double min_w_pmos;
-  double latency, throughput;
-  bool latency_overflow;
-  bool throughput_overflow;
-  double interconnect_latency;
-  double interconnect_throughput;
-  bool opt_local;
-  enum Core_type core_ty;
-  bool pipelinable;
-  double route_over_perc;
-  int num_pipe_stages;
+  private:
+    TechnologyParameter::DeviceType *deviceType;
 
- private:
-  TechnologyParameter::DeviceType *deviceType;
 };
 
 #endif
+

--- a/src/gpuwattch/iocontrollers.cc
+++ b/src/gpuwattch/iocontrollers.cc
@@ -28,20 +28,19 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.”
  *
  ***************************************************************************/
-#include "io.h"
-#include "parameter.h"
-#include "const.h"
-#include "logic.h"
-#include "cacti/basic_circuit.h"
-#include <iostream>
-#include <algorithm>
-#include "XML_Parse.h"
-#include <string>
-#include <cmath>
-#include <assert.h>
 #include "iocontrollers.h"
+#include <assert.h>
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <string>
+#include "XML_Parse.h"
 #include "basic_components.h"
-
+#include "cacti/basic_circuit.h"
+#include "const.h"
+#include "io.h"
+#include "logic.h"
+#include "parameter.h"
 
 /*
 SUN Niagara 2 I/O power analysis:
@@ -52,390 +51,453 @@ PCIe bits:         (8 + 8)*2 = 32
 Debug I/Os:        168
 Other I/Os:        711- 32-32 - 384 - 168 = 95
 
-According to "Implementation of an 8-Core, 64-Thread, Power-Efficient SPARC Server on a Chip"
-90% of I/Os are SerDers (the calucaltion is 384+64/(711-168)=83% about the same as the 90% reported in the paper)
+According to "Implementation of an 8-Core, 64-Thread, Power-Efficient SPARC
+Server on a Chip" 90% of I/Os are SerDers (the calucaltion is
+384+64/(711-168)=83% about the same as the 90% reported in the paper)
 --> around 80Pins are common I/Os.
 Common I/Os consumes 71mW/Gb/s according to Cadence ChipEstimate @65nm
-Niagara 2 I/O clock is 1/4 of core clock. --> 87pin (<--((711-168)*17%)) * 71mW/Gb/s *0.25*1.4Ghz = 2.17W
+Niagara 2 I/O clock is 1/4 of core clock. --> 87pin (<--((711-168)*17%)) *
+71mW/Gb/s *0.25*1.4Ghz = 2.17W
 
-Total dynamic power of FBDIMM, NIC, PCIe = 84*0.132 + 84*0.049*0.132 = 11.14 - 2.17 = 8.98
-Further, if assuming I/O logic power is about 50% of I/Os then Total energy of FBDIMM, NIC, PCIe = 11.14 - 2.17*1.5 = 7.89
+Total dynamic power of FBDIMM, NIC, PCIe = 84*0.132 + 84*0.049*0.132 = 11.14
+- 2.17 = 8.98 Further, if assuming I/O logic power is about 50% of I/Os then
+Total energy of FBDIMM, NIC, PCIe = 11.14 - 2.17*1.5 = 7.89
  */
 
 /*
- * A bug in Cadence ChipEstimator: After update the clock rate in the clock tab, a user
- * need to re-select the IP clock (the same clk) and then click Estimate. if not reselect
- * the new clock rate may not be propogate into the IPs.
+ * A bug in Cadence ChipEstimator: After update the clock rate in the clock tab,
+ * a user need to re-select the IP clock (the same clk) and then click Estimate.
+ * if not reselect the new clock rate may not be propogate into the IPs.
  *
  */
 
-NIUController::NIUController(ParseXML *XML_interface,InputParameter* interface_ip_)
-:XML(XML_interface),
- interface_ip(*interface_ip_)
- {
-	  local_result = init_interface(&interface_ip);
+NIUController::NIUController(ParseXML* XML_interface,
+                             InputParameter* interface_ip_)
+    : XML(XML_interface), interface_ip(*interface_ip_) {
+  local_result = init_interface(&interface_ip);
 
-	  double frontend_area,mac_area, SerDer_area;
-      double frontend_dyn, mac_dyn, SerDer_dyn;
-      double frontend_gates, mac_gates;
-	  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
-	  double NMOS_sizing, PMOS_sizing;
+  double frontend_area, mac_area, SerDer_area;
+  double frontend_dyn, mac_dyn, SerDer_dyn;
+  double frontend_gates, mac_gates;
+  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
+  double NMOS_sizing, PMOS_sizing;
 
-	  set_niu_param();
+  set_niu_param();
 
-	  if (niup.type == 0) //high performance NIU
-	  {
-		  //Area estimation based on average of die photo from Niagara 2 and Cadence ChipEstimate using 65nm.
-		  mac_area = (1.53 + 0.3)/2 * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);
-		  //Area estimation based on average of die photo from Niagara 2, ISSCC "An 800mW 10Gb Ethernet Transceiver in 0.13μm CMOS"
-		  //and"A 1.2-V-Only 900-mW 10 Gb Ethernet Transceiver and XAUI Interface With Robust VCO Tuning Technique" Frontend is PCS
-		  frontend_area = (9.8 + (6 + 18)*65/130*65/130)/3 * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);
-		  //Area estimation based on average of die photo from Niagara 2 and Cadence ChipEstimate hard IP @65nm.
-		  //SerDer is very hard to scale
-		  SerDer_area = (1.39 + 0.36) * (interface_ip.F_sz_um/0.065);//* (interface_ip.F_sz_um/0.065);
-		  //total area
-		  area.set_area((mac_area + frontend_area + SerDer_area)*1e6);
-		  //Power
-		  //Cadence ChipEstimate using 65nm (mac, front_end are all energy. E=P*T = P/F = 1.37/1Ghz = 1.37e-9);
-		  mac_dyn      = 2.19e-9*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);//niup.clockRate; //2.19W@1GHz fully active according to Cadence ChipEstimate @65nm
-		  //Cadence ChipEstimate using 65nm soft IP;
-		  frontend_dyn = 0.27e-9*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);//niup.clockRate;
-		  //according to "A 100mW 9.6Gb/s Transceiver in 90nm CMOS..." ISSCC 2006
-		  //SerDer_dyn is power not energy, scaling from 10mw/Gb/s @90nm
-		  SerDer_dyn   = 0.01*10*sqrt(interface_ip.F_sz_um/0.09)*g_tp.peri_global.Vdd/1.2*g_tp.peri_global.Vdd/1.2;
-		  SerDer_dyn   /= niup.clockRate;//covert to energy per clock cycle of whole NIU
+  if (niup.type == 0)  // high performance NIU
+  {
+    // Area estimation based on average of die photo from Niagara 2 and Cadence
+    // ChipEstimate using 65nm.
+    mac_area = (1.53 + 0.3) / 2 * (interface_ip.F_sz_um / 0.065) *
+               (interface_ip.F_sz_um / 0.065);
+    // Area estimation based on average of die photo from Niagara 2, ISSCC "An
+    // 800mW 10Gb Ethernet Transceiver in 0.13μm CMOS" and"A 1.2-V-Only 900-mW
+    // 10 Gb Ethernet Transceiver and XAUI Interface With Robust VCO Tuning
+    // Technique" Frontend is PCS
+    frontend_area = (9.8 + (6 + 18) * 65 / 130 * 65 / 130) / 3 *
+                    (interface_ip.F_sz_um / 0.065) *
+                    (interface_ip.F_sz_um / 0.065);
+    // Area estimation based on average of die photo from Niagara 2 and Cadence
+    // ChipEstimate hard IP @65nm. SerDer is very hard to scale
+    SerDer_area = (1.39 + 0.36) * (interface_ip.F_sz_um /
+                                   0.065);  //* (interface_ip.F_sz_um/0.065);
+    // total area
+    area.set_area((mac_area + frontend_area + SerDer_area) * 1e6);
+    // Power
+    // Cadence ChipEstimate using 65nm (mac, front_end are all energy. E=P*T =
+    // P/F = 1.37/1Ghz = 1.37e-9);
+    mac_dyn = 2.19e-9 * g_tp.peri_global.Vdd / 1.1 * g_tp.peri_global.Vdd /
+              1.1 *
+              (interface_ip.F_sz_nm /
+               65.0);  // niup.clockRate; //2.19W@1GHz fully active according to
+                       // Cadence ChipEstimate @65nm
+    // Cadence ChipEstimate using 65nm soft IP;
+    frontend_dyn = 0.27e-9 * g_tp.peri_global.Vdd / 1.1 * g_tp.peri_global.Vdd /
+                   1.1 * (interface_ip.F_sz_nm / 65.0);  // niup.clockRate;
+    // according to "A 100mW 9.6Gb/s Transceiver in 90nm CMOS..." ISSCC 2006
+    // SerDer_dyn is power not energy, scaling from 10mw/Gb/s @90nm
+    SerDer_dyn = 0.01 * 10 * sqrt(interface_ip.F_sz_um / 0.09) *
+                 g_tp.peri_global.Vdd / 1.2 * g_tp.peri_global.Vdd / 1.2;
+    SerDer_dyn /=
+        niup.clockRate;  // covert to energy per clock cycle of whole NIU
 
-		  //Cadence ChipEstimate using 65nm
-		  mac_gates       = 111700;
-		  frontend_gates  = 320000;
-		  NMOS_sizing 	  = 5*g_tp.min_w_nmos_;
-		  PMOS_sizing	  = 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
+    // Cadence ChipEstimate using 65nm
+    mac_gates = 111700;
+    frontend_gates = 320000;
+    NMOS_sizing = 5 * g_tp.min_w_nmos_;
+    PMOS_sizing = 5 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r;
 
+  } else {  // Low power implementations are mostly from Cadence ChipEstimator;
+            // Ignore the multiple IP effect
+    // ---When there are multiple IP (same kind or not) selected, Cadence
+    // ChipEstimator results are not a simple summation of all IPs. Ignore this
+    // effect
+    mac_area =
+        0.24 * (interface_ip.F_sz_um / 0.065) * (interface_ip.F_sz_um / 0.065);
+    frontend_area =
+        0.1 * (interface_ip.F_sz_um / 0.065) *
+        (interface_ip.F_sz_um / 0.065);  // Frontend is the PCS layer
+    SerDer_area =
+        0.35 * (interface_ip.F_sz_um / 0.065) * (interface_ip.F_sz_um / 0.065);
+    // Compare 130um implementation in "A 1.2-V-Only 900-mW 10 Gb Ethernet
+    // Transceiver and XAUI Interface With Robust VCO Tuning Technique" and the
+    // ChipEstimator XAUI PHY hard IP, confirm that even PHY can scale perfectly
+    // with the technology total area
+    area.set_area((mac_area + frontend_area + SerDer_area) * 1e6);
+    // Power
+    // Cadence ChipEstimate using 65nm (mac, front_end are all energy. E=P*T =
+    // P/F = 1.37/1Ghz = 1.37e-9);
+    mac_dyn = 1.257e-9 * g_tp.peri_global.Vdd / 1.1 * g_tp.peri_global.Vdd /
+              1.1 *
+              (interface_ip.F_sz_nm /
+               65.0);  // niup.clockRate; //2.19W@1GHz fully active according to
+                       // Cadence ChipEstimate @65nm
+    // Cadence ChipEstimate using 65nm soft IP;
+    frontend_dyn = 0.6e-9 * g_tp.peri_global.Vdd / 1.1 * g_tp.peri_global.Vdd /
+                   1.1 * (interface_ip.F_sz_nm / 65.0);  // niup.clockRate;
+    // SerDer_dyn is power not energy, scaling from 216mw/10Gb/s @130nm
+    SerDer_dyn = 0.0216 * 10 * (interface_ip.F_sz_um / 0.13) *
+                 g_tp.peri_global.Vdd / 1.2 * g_tp.peri_global.Vdd / 1.2;
+    SerDer_dyn /=
+        niup.clockRate;  // covert to energy per clock cycle of whole NIU
 
-	  }
-	  else
-	  {//Low power implementations are mostly from Cadence ChipEstimator; Ignore the multiple IP effect
-		  // ---When there are multiple IP (same kind or not) selected, Cadence ChipEstimator results are not
-		  // a simple summation of all IPs. Ignore this effect
-		  mac_area      = 0.24 * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);
-		  frontend_area = 0.1  * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);//Frontend is the PCS layer
-		  SerDer_area   = 0.35 * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);
-		  //Compare 130um implementation in "A 1.2-V-Only 900-mW 10 Gb Ethernet Transceiver and XAUI Interface With Robust VCO Tuning Technique"
-		  //and the ChipEstimator XAUI PHY hard IP, confirm that even PHY can scale perfectly with the technology
-		  //total area
-		  area.set_area((mac_area + frontend_area + SerDer_area)*1e6);
-		  //Power
-		  //Cadence ChipEstimate using 65nm (mac, front_end are all energy. E=P*T = P/F = 1.37/1Ghz = 1.37e-9);
-		  mac_dyn      = 1.257e-9*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);//niup.clockRate; //2.19W@1GHz fully active according to Cadence ChipEstimate @65nm
-		  //Cadence ChipEstimate using 65nm soft IP;
-		  frontend_dyn = 0.6e-9*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);//niup.clockRate;
-		  //SerDer_dyn is power not energy, scaling from 216mw/10Gb/s @130nm
-		  SerDer_dyn   = 0.0216*10*(interface_ip.F_sz_um/0.13)*g_tp.peri_global.Vdd/1.2*g_tp.peri_global.Vdd/1.2;
-		  SerDer_dyn   /= niup.clockRate;//covert to energy per clock cycle of whole NIU
+    mac_gates = 111700;
+    frontend_gates = 52000;
 
-		  mac_gates       = 111700;
-		  frontend_gates  = 52000;
+    NMOS_sizing = g_tp.min_w_nmos_;
+    PMOS_sizing = g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r;
+  }
 
-		  NMOS_sizing 	  = g_tp.min_w_nmos_;
-		  PMOS_sizing	  = g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
-
-	  }
-
-	  power_t.readOp.dynamic = mac_dyn + frontend_dyn + SerDer_dyn;
-	  power_t.readOp.leakage = (mac_gates + frontend_gates + frontend_gates)*cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
-	  double long_channel_device_reduction = longer_channel_device_reduction(Uncore_device);
-	  power_t.readOp.longer_channel_leakage = power_t.readOp.leakage * long_channel_device_reduction;
-	  power_t.readOp.gate_leakage = (mac_gates + frontend_gates + frontend_gates)*cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
- }
-
-void NIUController::computeEnergy(bool is_tdp)
-{
-	if (is_tdp)
-    {
-
-
-		power	= power_t;
-    	power.readOp.dynamic *= niup.duty_cycle;
-
-    }
-    else
-    {
-    	rt_power = power_t;
-    	rt_power.readOp.dynamic *= niup.perc_load;
-    }
+  power_t.readOp.dynamic = mac_dyn + frontend_dyn + SerDer_dyn;
+  power_t.readOp.leakage =
+      (mac_gates + frontend_gates + frontend_gates) *
+      cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
+      g_tp.peri_global.Vdd;  // unit W
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(Uncore_device);
+  power_t.readOp.longer_channel_leakage =
+      power_t.readOp.leakage * long_channel_device_reduction;
+  power_t.readOp.gate_leakage =
+      (mac_gates + frontend_gates + frontend_gates) *
+      cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
+      g_tp.peri_global.Vdd;  // unit W
 }
 
-void NIUController::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
+void NIUController::computeEnergy(bool is_tdp) {
+  if (is_tdp) {
+    power = power_t;
+    power.readOp.dynamic *= niup.duty_cycle;
 
-	if (is_tdp)
-	{
-		cout << "NIU:" << endl;
-		cout << indent_str<< "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic*niup.clockRate  << " W" << endl;
-		cout << indent_str<< "Subthreshold Leakage = "
-			<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
-		//cout << indent_str<< "Subthreshold Leakage = " << power.readOp.longer_channel_leakage <<" W" << endl;
-		cout << indent_str<< "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str << "Runtime Dynamic = " << rt_power.readOp.dynamic*niup.clockRate << " W" << endl;
-		cout<<endl;
-	}
-	else
-	{
-
-	}
-
+  } else {
+    rt_power = power_t;
+    rt_power.readOp.dynamic *= niup.perc_load;
+  }
 }
 
-void NIUController::set_niu_param()
-{
-	  niup.clockRate       = XML->sys.niu.clockrate;
-	  niup.clockRate       *= 1e6;
-	  niup.num_units       = XML->sys.niu.number_units;
-	  niup.duty_cycle      = XML->sys.niu.duty_cycle;
-	  niup.perc_load       = XML->sys.niu.total_load_perc;
-	  niup.type            = XML->sys.niu.type;
-//	  niup.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
+void NIUController::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
+
+  if (is_tdp) {
+    cout << "NIU:" << endl;
+    cout << indent_str << "Area = " << area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str
+         << "Peak Dynamic = " << power.readOp.dynamic * niup.clockRate << " W"
+         << endl;
+    cout << indent_str << "Subthreshold Leakage = "
+         << (long_channel ? power.readOp.longer_channel_leakage
+                          : power.readOp.leakage)
+         << " W" << endl;
+    // cout << indent_str<< "Subthreshold Leakage = " <<
+    // power.readOp.longer_channel_leakage <<" W" << endl;
+    cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str
+         << "Runtime Dynamic = " << rt_power.readOp.dynamic * niup.clockRate
+         << " W" << endl;
+    cout << endl;
+  } else {
+  }
 }
 
-PCIeController::PCIeController(ParseXML *XML_interface,InputParameter* interface_ip_)
-:XML(XML_interface),
- interface_ip(*interface_ip_)
- {
-	  local_result = init_interface(&interface_ip);
-      double ctrl_area, SerDer_area;
-      double ctrl_dyn, SerDer_dyn;
-      double ctrl_gates, SerDer_gates;
-	  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
-	  double NMOS_sizing, PMOS_sizing;
-
-	  /* Assuming PCIe is bit-slice based architecture
-	   * This is the reason for /8 in both area and power calculation
-	   * to get per lane numbers
-	   */
-
-	  set_pcie_param();
-	  if (pciep.type == 0) //high performance NIU
-	  {
-		  //Area estimation based on average of die photo from Niagara 2 and Cadence ChipEstimate @ 65nm.
-		  ctrl_area = (5.2 + 0.5)/2 * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);
-		  //Area estimation based on average of die photo from Niagara 2, and Cadence ChipEstimate @ 65nm.
-		  //Area estimation based on average of die photo from Niagara 2 and Cadence ChipEstimate hard IP @65nm.
-		  //SerDer is very hard to scale
-		  SerDer_area = (3.03 + 0.36) * (interface_ip.F_sz_um/0.065);//* (interface_ip.F_sz_um/0.065);
-		  //total area
-		  //Power
-		  //Cadence ChipEstimate using 65nm the controller includes everything: the PHY, the data link and transaction layer
-		  ctrl_dyn      = 3.75e-9/8*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);
-		  //	  //Cadence ChipEstimate using 65nm soft IP;
-		  //	  frontend_dyn = 0.27e-9/8*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);
-		  //SerDer_dyn is power not energy, scaling from 10mw/Gb/s @90nm
-		  SerDer_dyn   = 0.01*4*(interface_ip.F_sz_um/0.09)*g_tp.peri_global.Vdd/1.2*g_tp.peri_global.Vdd/1.2;//PCIe 2.0 max per lane speed is 4Gb/s
-		  SerDer_dyn   /= pciep.clockRate;//covert to energy per clock cycle
-
-		  //power_t.readOp.dynamic = (ctrl_dyn)*pciep.num_channels;
-		  //Cadence ChipEstimate using 65nm
-		  ctrl_gates       = 900000/8*pciep.num_channels;
-		  //	  frontend_gates   = 120000/8;
-		  //	  SerDer_gates     = 200000/8;
-		  NMOS_sizing 	  = 5*g_tp.min_w_nmos_;
-		  PMOS_sizing	  = 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
-	  }
-	  else
-	  {
-		  ctrl_area = 0.412 * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);
-		  //Area estimation based on average of die photo from Niagara 2, and Cadence ChipEstimate @ 65nm.
-     	  SerDer_area = 0.36 * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);
-		  //total area
-		  //Power
-		  //Cadence ChipEstimate using 65nm the controller includes everything: the PHY, the data link and transaction layer
-		  ctrl_dyn      = 2.21e-9/8*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);
-		  //	  //Cadence ChipEstimate using 65nm soft IP;
-		  //	  frontend_dyn = 0.27e-9/8*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);
-		  //SerDer_dyn is power not energy, scaling from 10mw/Gb/s @90nm
-		  SerDer_dyn   = 0.01*4*(interface_ip.F_sz_um/0.09)*g_tp.peri_global.Vdd/1.2*g_tp.peri_global.Vdd/1.2;//PCIe 2.0 max per lane speed is 4Gb/s
-		  SerDer_dyn   /= pciep.clockRate;//covert to energy per clock cycle
-
-		  //Cadence ChipEstimate using 65nm
-		  ctrl_gates       = 200000/8*pciep.num_channels;
-		  //	  frontend_gates   = 120000/8;
-		  SerDer_gates     = 200000/8*pciep.num_channels;
-		  NMOS_sizing 	  = g_tp.min_w_nmos_;
-		  PMOS_sizing	  = g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
-
-	  }
-	  area.set_area(((ctrl_area + (pciep.withPHY? SerDer_area:0))/8*pciep.num_channels)*1e6);
-	  power_t.readOp.dynamic = (ctrl_dyn + (pciep.withPHY? SerDer_dyn:0))*pciep.num_channels;
-	  power_t.readOp.leakage = (ctrl_gates + (pciep.withPHY? SerDer_gates:0))*cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
-	  double long_channel_device_reduction = longer_channel_device_reduction(Uncore_device);
-	  power_t.readOp.longer_channel_leakage = power_t.readOp.leakage * long_channel_device_reduction;
-	  power_t.readOp.gate_leakage = (ctrl_gates + (pciep.withPHY? SerDer_gates:0))*cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
- }
-
-void PCIeController::computeEnergy(bool is_tdp)
-{
-	if (is_tdp)
-    {
-
-
-		power	= power_t;
-    	power.readOp.dynamic *= pciep.duty_cycle;
-
-    }
-    else
-    {
-    	rt_power = power_t;
-    	rt_power.readOp.dynamic *= pciep.perc_load;
-    }
+void NIUController::set_niu_param() {
+  niup.clockRate = XML->sys.niu.clockrate;
+  niup.clockRate *= 1e6;
+  niup.num_units = XML->sys.niu.number_units;
+  niup.duty_cycle = XML->sys.niu.duty_cycle;
+  niup.perc_load = XML->sys.niu.total_load_perc;
+  niup.type = XML->sys.niu.type;
+  //	  niup.executionTime   =
+  // XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
 }
 
-void PCIeController::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
+PCIeController::PCIeController(ParseXML* XML_interface,
+                               InputParameter* interface_ip_)
+    : XML(XML_interface), interface_ip(*interface_ip_) {
+  local_result = init_interface(&interface_ip);
+  double ctrl_area, SerDer_area;
+  double ctrl_dyn, SerDer_dyn;
+  double ctrl_gates, SerDer_gates;
+  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
+  double NMOS_sizing, PMOS_sizing;
 
-	if (is_tdp)
-	{
-		cout << "PCIe:" << endl;
-		cout << indent_str<< "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic*pciep.clockRate  << " W" << endl;
-		cout << indent_str<< "Subthreshold Leakage = "
-			<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
-		//cout << indent_str<< "Subthreshold Leakage = " << power.readOp.longer_channel_leakage <<" W" << endl;
-		cout << indent_str<< "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str << "Runtime Dynamic = " << rt_power.readOp.dynamic*pciep.clockRate << " W" << endl;
-		cout<<endl;
-	}
-	else
-	{
+  /* Assuming PCIe is bit-slice based architecture
+   * This is the reason for /8 in both area and power calculation
+   * to get per lane numbers
+   */
 
-	}
+  set_pcie_param();
+  if (pciep.type == 0)  // high performance NIU
+  {
+    // Area estimation based on average of die photo from Niagara 2 and Cadence
+    // ChipEstimate @ 65nm.
+    ctrl_area = (5.2 + 0.5) / 2 * (interface_ip.F_sz_um / 0.065) *
+                (interface_ip.F_sz_um / 0.065);
+    // Area estimation based on average of die photo from Niagara 2, and Cadence
+    // ChipEstimate @ 65nm. Area estimation based on average of die photo from
+    // Niagara 2 and Cadence ChipEstimate hard IP @65nm. SerDer is very hard to
+    // scale
+    SerDer_area = (3.03 + 0.36) * (interface_ip.F_sz_um /
+                                   0.065);  //* (interface_ip.F_sz_um/0.065);
+    // total area
+    // Power
+    // Cadence ChipEstimate using 65nm the controller includes everything: the
+    // PHY, the data link and transaction layer
+    ctrl_dyn = 3.75e-9 / 8 * g_tp.peri_global.Vdd / 1.1 * g_tp.peri_global.Vdd /
+               1.1 * (interface_ip.F_sz_nm / 65.0);
+    //	  //Cadence ChipEstimate using 65nm soft IP;
+    //	  frontend_dyn =
+    // 0.27e-9/8*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);
+    // SerDer_dyn is power not energy, scaling from 10mw/Gb/s @90nm
+    SerDer_dyn = 0.01 * 4 * (interface_ip.F_sz_um / 0.09) *
+                 g_tp.peri_global.Vdd / 1.2 * g_tp.peri_global.Vdd /
+                 1.2;               // PCIe 2.0 max per lane speed is 4Gb/s
+    SerDer_dyn /= pciep.clockRate;  // covert to energy per clock cycle
 
+    // power_t.readOp.dynamic = (ctrl_dyn)*pciep.num_channels;
+    // Cadence ChipEstimate using 65nm
+    ctrl_gates = 900000 / 8 * pciep.num_channels;
+    //	  frontend_gates   = 120000/8;
+    //	  SerDer_gates     = 200000/8;
+    NMOS_sizing = 5 * g_tp.min_w_nmos_;
+    PMOS_sizing = 5 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r;
+  } else {
+    ctrl_area =
+        0.412 * (interface_ip.F_sz_um / 0.065) * (interface_ip.F_sz_um / 0.065);
+    // Area estimation based on average of die photo from Niagara 2, and Cadence
+    // ChipEstimate @ 65nm.
+    SerDer_area =
+        0.36 * (interface_ip.F_sz_um / 0.065) * (interface_ip.F_sz_um / 0.065);
+    // total area
+    // Power
+    // Cadence ChipEstimate using 65nm the controller includes everything: the
+    // PHY, the data link and transaction layer
+    ctrl_dyn = 2.21e-9 / 8 * g_tp.peri_global.Vdd / 1.1 * g_tp.peri_global.Vdd /
+               1.1 * (interface_ip.F_sz_nm / 65.0);
+    //	  //Cadence ChipEstimate using 65nm soft IP;
+    //	  frontend_dyn =
+    // 0.27e-9/8*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);
+    // SerDer_dyn is power not energy, scaling from 10mw/Gb/s @90nm
+    SerDer_dyn = 0.01 * 4 * (interface_ip.F_sz_um / 0.09) *
+                 g_tp.peri_global.Vdd / 1.2 * g_tp.peri_global.Vdd /
+                 1.2;               // PCIe 2.0 max per lane speed is 4Gb/s
+    SerDer_dyn /= pciep.clockRate;  // covert to energy per clock cycle
+
+    // Cadence ChipEstimate using 65nm
+    ctrl_gates = 200000 / 8 * pciep.num_channels;
+    //	  frontend_gates   = 120000/8;
+    SerDer_gates = 200000 / 8 * pciep.num_channels;
+    NMOS_sizing = g_tp.min_w_nmos_;
+    PMOS_sizing = g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r;
+  }
+  area.set_area(((ctrl_area + (pciep.withPHY ? SerDer_area : 0)) / 8 *
+                 pciep.num_channels) *
+                1e6);
+  power_t.readOp.dynamic =
+      (ctrl_dyn + (pciep.withPHY ? SerDer_dyn : 0)) * pciep.num_channels;
+  power_t.readOp.leakage =
+      (ctrl_gates + (pciep.withPHY ? SerDer_gates : 0)) *
+      cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
+      g_tp.peri_global.Vdd;  // unit W
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(Uncore_device);
+  power_t.readOp.longer_channel_leakage =
+      power_t.readOp.leakage * long_channel_device_reduction;
+  power_t.readOp.gate_leakage =
+      (ctrl_gates + (pciep.withPHY ? SerDer_gates : 0)) *
+      cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
+      g_tp.peri_global.Vdd;  // unit W
 }
 
-void PCIeController::set_pcie_param()
-{
-	  pciep.clockRate       = XML->sys.pcie.clockrate;
-	  pciep.clockRate       *= 1e6;
-	  pciep.num_units       = XML->sys.pcie.number_units;
-	  pciep.num_channels    = XML->sys.pcie.num_channels;
-	  pciep.duty_cycle      = XML->sys.pcie.duty_cycle;
-	  pciep.perc_load       = XML->sys.pcie.total_load_perc;
-	  pciep.type            = XML->sys.pcie.type;
-	  pciep.withPHY         = XML->sys.pcie.withPHY;
-//	  pciep.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
+void PCIeController::computeEnergy(bool is_tdp) {
+  if (is_tdp) {
+    power = power_t;
+    power.readOp.dynamic *= pciep.duty_cycle;
 
+  } else {
+    rt_power = power_t;
+    rt_power.readOp.dynamic *= pciep.perc_load;
+  }
 }
 
-FlashController::FlashController(ParseXML *XML_interface,InputParameter* interface_ip_)
-:XML(XML_interface),
- interface_ip(*interface_ip_)
- {
-	  local_result = init_interface(&interface_ip);
-	  double ctrl_area, SerDer_area;
-      double ctrl_dyn, SerDer_dyn;
-      double ctrl_gates, SerDer_gates;
-	  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
-	  double NMOS_sizing, PMOS_sizing;
+void PCIeController::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
 
-	  /* Assuming PCIe is bit-slice based architecture
-	   * This is the reason for /8 in both area and power calculation
-	   * to get per lane numbers
-	   */
-
-	  set_fc_param();
-	  if (fcp.type == 0) //high performance NIU
-	  {
-		  cout<<"Current McPAT does not support high performance flash contorller since even low power designs are enough for maintain throughput"<<endl;
-		  exit(0);
-		  NMOS_sizing 	  = 5*g_tp.min_w_nmos_;
-		  PMOS_sizing	  = 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
-	  }
-	  else
-	  {
-		  ctrl_area   = 0.243 * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);
-		  //Area estimation based on Cadence ChipEstimate @ 65nm: NANDFLASH-CTRL from CAST
-     	  SerDer_area = 0.36/8 * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);
-     	  //based On PCIe PHY TSMC65GP from Cadence ChipEstimate @ 65nm, it support 8x lanes with each lane
-     	  //speed up to 250MB/s (PCIe1.1x) This is already saturate the 200MB/s of the flash controller core above.
-		  ctrl_gates      = 129267;
-		  SerDer_gates    = 200000/8;
-		  NMOS_sizing 	  = g_tp.min_w_nmos_;
-		  PMOS_sizing	  = g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
-
-		  //Power
-		  //Cadence ChipEstimate using 65nm the controller 125mW for every 200MB/s This is power not energy!
-		  ctrl_dyn      = 0.125*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);
-		  //SerDer_dyn is power not energy, scaling from 10mw/Gb/s @90nm
-		  SerDer_dyn   = 0.01*1.6*(interface_ip.F_sz_um/0.09)*g_tp.peri_global.Vdd/1.2*g_tp.peri_global.Vdd/1.2;
-		  //max  Per controller speed is 1.6Gb/s (200MB/s)
-	  }
-	  double number_channel = 1+(fcp.num_channels-1)*0.2;
-	  area.set_area((ctrl_area + (fcp.withPHY? SerDer_area:0))*1e6*number_channel);
-	  power_t.readOp.dynamic = (ctrl_dyn + (fcp.withPHY? SerDer_dyn:0))*number_channel;
-	  power_t.readOp.leakage = ((ctrl_gates + (fcp.withPHY? SerDer_gates:0))*number_channel)*cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
-	  double long_channel_device_reduction = longer_channel_device_reduction(Uncore_device);
-	  power_t.readOp.longer_channel_leakage = power_t.readOp.leakage * long_channel_device_reduction;
-	  power_t.readOp.gate_leakage = ((ctrl_gates + (fcp.withPHY? SerDer_gates:0))*number_channel)*cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
- }
-
-void FlashController::computeEnergy(bool is_tdp)
-{
-	if (is_tdp)
-    {
-
-
-		power	= power_t;
-    	power.readOp.dynamic *= fcp.duty_cycle;
-
-    }
-    else
-    {
-    	rt_power = power_t;
-    	rt_power.readOp.dynamic *= fcp.perc_load;
-    }
+  if (is_tdp) {
+    cout << "PCIe:" << endl;
+    cout << indent_str << "Area = " << area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str
+         << "Peak Dynamic = " << power.readOp.dynamic * pciep.clockRate << " W"
+         << endl;
+    cout << indent_str << "Subthreshold Leakage = "
+         << (long_channel ? power.readOp.longer_channel_leakage
+                          : power.readOp.leakage)
+         << " W" << endl;
+    // cout << indent_str<< "Subthreshold Leakage = " <<
+    // power.readOp.longer_channel_leakage <<" W" << endl;
+    cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str
+         << "Runtime Dynamic = " << rt_power.readOp.dynamic * pciep.clockRate
+         << " W" << endl;
+    cout << endl;
+  } else {
+  }
 }
 
-void FlashController::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
-
-	if (is_tdp)
-	{
-		cout << "Flash Controller:" << endl;
-		cout << indent_str<< "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic << " W" << endl;//no multiply of clock since this is power already
-		cout << indent_str<< "Subthreshold Leakage = "
-			<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
-		//cout << indent_str<< "Subthreshold Leakage = " << power.readOp.longer_channel_leakage <<" W" << endl;
-		cout << indent_str<< "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str << "Runtime Dynamic = " << rt_power.readOp.dynamic << " W" << endl;
-		cout<<endl;
-	}
-	else
-	{
-
-	}
-
+void PCIeController::set_pcie_param() {
+  pciep.clockRate = XML->sys.pcie.clockrate;
+  pciep.clockRate *= 1e6;
+  pciep.num_units = XML->sys.pcie.number_units;
+  pciep.num_channels = XML->sys.pcie.num_channels;
+  pciep.duty_cycle = XML->sys.pcie.duty_cycle;
+  pciep.perc_load = XML->sys.pcie.total_load_perc;
+  pciep.type = XML->sys.pcie.type;
+  pciep.withPHY = XML->sys.pcie.withPHY;
+  //	  pciep.executionTime   =
+  // XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
 }
 
-void FlashController::set_fc_param()
-{
-//	  fcp.clockRate       = XML->sys.flashc.mc_clock;
-//	  fcp.clockRate       *= 1e6;
-	  fcp.peakDataTransferRate = XML->sys.flashc.peak_transfer_rate;
-	  fcp.num_channels    = ceil(fcp.peakDataTransferRate/200);
-	  fcp.num_mcs         = XML->sys.flashc.number_mcs;
-	  fcp.duty_cycle      = XML->sys.flashc.duty_cycle;
-	  fcp.perc_load       = XML->sys.flashc.total_load_perc;
-	  fcp.type            = XML->sys.flashc.type;
-	  fcp.withPHY         = XML->sys.flashc.withPHY;
-//	  flashcp.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
+FlashController::FlashController(ParseXML* XML_interface,
+                                 InputParameter* interface_ip_)
+    : XML(XML_interface), interface_ip(*interface_ip_) {
+  local_result = init_interface(&interface_ip);
+  double ctrl_area, SerDer_area;
+  double ctrl_dyn, SerDer_dyn;
+  double ctrl_gates, SerDer_gates;
+  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
+  double NMOS_sizing, PMOS_sizing;
 
+  /* Assuming PCIe is bit-slice based architecture
+   * This is the reason for /8 in both area and power calculation
+   * to get per lane numbers
+   */
+
+  set_fc_param();
+  if (fcp.type == 0)  // high performance NIU
+  {
+    cout << "Current McPAT does not support high performance flash contorller "
+            "since even low power designs are enough for maintain throughput"
+         << endl;
+    exit(0);
+    NMOS_sizing = 5 * g_tp.min_w_nmos_;
+    PMOS_sizing = 5 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r;
+  } else {
+    ctrl_area =
+        0.243 * (interface_ip.F_sz_um / 0.065) * (interface_ip.F_sz_um / 0.065);
+    // Area estimation based on Cadence ChipEstimate @ 65nm: NANDFLASH-CTRL from
+    // CAST
+    SerDer_area = 0.36 / 8 * (interface_ip.F_sz_um / 0.065) *
+                  (interface_ip.F_sz_um / 0.065);
+    // based On PCIe PHY TSMC65GP from Cadence ChipEstimate @ 65nm, it support
+    // 8x lanes with each lane speed up to 250MB/s (PCIe1.1x) This is already
+    // saturate the 200MB/s of the flash controller core above.
+    ctrl_gates = 129267;
+    SerDer_gates = 200000 / 8;
+    NMOS_sizing = g_tp.min_w_nmos_;
+    PMOS_sizing = g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r;
+
+    // Power
+    // Cadence ChipEstimate using 65nm the controller 125mW for every 200MB/s
+    // This is power not energy!
+    ctrl_dyn = 0.125 * g_tp.peri_global.Vdd / 1.1 * g_tp.peri_global.Vdd / 1.1 *
+               (interface_ip.F_sz_nm / 65.0);
+    // SerDer_dyn is power not energy, scaling from 10mw/Gb/s @90nm
+    SerDer_dyn = 0.01 * 1.6 * (interface_ip.F_sz_um / 0.09) *
+                 g_tp.peri_global.Vdd / 1.2 * g_tp.peri_global.Vdd / 1.2;
+    // max  Per controller speed is 1.6Gb/s (200MB/s)
+  }
+  double number_channel = 1 + (fcp.num_channels - 1) * 0.2;
+  area.set_area((ctrl_area + (fcp.withPHY ? SerDer_area : 0)) * 1e6 *
+                number_channel);
+  power_t.readOp.dynamic =
+      (ctrl_dyn + (fcp.withPHY ? SerDer_dyn : 0)) * number_channel;
+  power_t.readOp.leakage =
+      ((ctrl_gates + (fcp.withPHY ? SerDer_gates : 0)) * number_channel) *
+      cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
+      g_tp.peri_global.Vdd;  // unit W
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(Uncore_device);
+  power_t.readOp.longer_channel_leakage =
+      power_t.readOp.leakage * long_channel_device_reduction;
+  power_t.readOp.gate_leakage =
+      ((ctrl_gates + (fcp.withPHY ? SerDer_gates : 0)) * number_channel) *
+      cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
+      g_tp.peri_global.Vdd;  // unit W
+}
+
+void FlashController::computeEnergy(bool is_tdp) {
+  if (is_tdp) {
+    power = power_t;
+    power.readOp.dynamic *= fcp.duty_cycle;
+
+  } else {
+    rt_power = power_t;
+    rt_power.readOp.dynamic *= fcp.perc_load;
+  }
+}
+
+void FlashController::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
+
+  if (is_tdp) {
+    cout << "Flash Controller:" << endl;
+    cout << indent_str << "Area = " << area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic << " W"
+         << endl;  // no multiply of clock since this is power already
+    cout << indent_str << "Subthreshold Leakage = "
+         << (long_channel ? power.readOp.longer_channel_leakage
+                          : power.readOp.leakage)
+         << " W" << endl;
+    // cout << indent_str<< "Subthreshold Leakage = " <<
+    // power.readOp.longer_channel_leakage <<" W" << endl;
+    cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str << "Runtime Dynamic = " << rt_power.readOp.dynamic
+         << " W" << endl;
+    cout << endl;
+  } else {
+  }
+}
+
+void FlashController::set_fc_param() {
+  //	  fcp.clockRate       = XML->sys.flashc.mc_clock;
+  //	  fcp.clockRate       *= 1e6;
+  fcp.peakDataTransferRate = XML->sys.flashc.peak_transfer_rate;
+  fcp.num_channels = ceil(fcp.peakDataTransferRate / 200);
+  fcp.num_mcs = XML->sys.flashc.number_mcs;
+  fcp.duty_cycle = XML->sys.flashc.duty_cycle;
+  fcp.perc_load = XML->sys.flashc.total_load_perc;
+  fcp.type = XML->sys.flashc.type;
+  fcp.withPHY = XML->sys.flashc.withPHY;
+  //	  flashcp.executionTime   =
+  // XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
 }

--- a/src/gpuwattch/iocontrollers.cc
+++ b/src/gpuwattch/iocontrollers.cc
@@ -236,7 +236,7 @@ void NIUController::set_niu_param() {
   niup.perc_load = XML->sys.niu.total_load_perc;
   niup.type = XML->sys.niu.type;
   //	  niup.executionTime   =
-  // XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
+  //XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
 }
 
 PCIeController::PCIeController(ParseXML* XML_interface,
@@ -276,7 +276,7 @@ PCIeController::PCIeController(ParseXML* XML_interface,
                1.1 * (interface_ip.F_sz_nm / 65.0);
     //	  //Cadence ChipEstimate using 65nm soft IP;
     //	  frontend_dyn =
-    // 0.27e-9/8*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);
+    //0.27e-9/8*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);
     // SerDer_dyn is power not energy, scaling from 10mw/Gb/s @90nm
     SerDer_dyn = 0.01 * 4 * (interface_ip.F_sz_um / 0.09) *
                  g_tp.peri_global.Vdd / 1.2 * g_tp.peri_global.Vdd /
@@ -305,7 +305,7 @@ PCIeController::PCIeController(ParseXML* XML_interface,
                1.1 * (interface_ip.F_sz_nm / 65.0);
     //	  //Cadence ChipEstimate using 65nm soft IP;
     //	  frontend_dyn =
-    // 0.27e-9/8*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);
+    //0.27e-9/8*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);
     // SerDer_dyn is power not energy, scaling from 10mw/Gb/s @90nm
     SerDer_dyn = 0.01 * 4 * (interface_ip.F_sz_um / 0.09) *
                  g_tp.peri_global.Vdd / 1.2 * g_tp.peri_global.Vdd /
@@ -387,7 +387,7 @@ void PCIeController::set_pcie_param() {
   pciep.type = XML->sys.pcie.type;
   pciep.withPHY = XML->sys.pcie.withPHY;
   //	  pciep.executionTime   =
-  // XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
+  //XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
 }
 
 FlashController::FlashController(ParseXML* XML_interface,
@@ -507,5 +507,5 @@ void FlashController::set_fc_param() {
   fcp.type = XML->sys.flashc.type;
   fcp.withPHY = XML->sys.flashc.withPHY;
   //	  flashcp.executionTime   =
-  // XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
+  //XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
 }

--- a/src/gpuwattch/iocontrollers.cc
+++ b/src/gpuwattch/iocontrollers.cc
@@ -236,7 +236,7 @@ void NIUController::set_niu_param() {
   niup.perc_load = XML->sys.niu.total_load_perc;
   niup.type = XML->sys.niu.type;
   //	  niup.executionTime   =
-  //XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
+  // XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
 }
 
 PCIeController::PCIeController(ParseXML* XML_interface,
@@ -276,7 +276,7 @@ PCIeController::PCIeController(ParseXML* XML_interface,
                1.1 * (interface_ip.F_sz_nm / 65.0);
     //	  //Cadence ChipEstimate using 65nm soft IP;
     //	  frontend_dyn =
-    //0.27e-9/8*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);
+    // 0.27e-9/8*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);
     // SerDer_dyn is power not energy, scaling from 10mw/Gb/s @90nm
     SerDer_dyn = 0.01 * 4 * (interface_ip.F_sz_um / 0.09) *
                  g_tp.peri_global.Vdd / 1.2 * g_tp.peri_global.Vdd /
@@ -305,7 +305,7 @@ PCIeController::PCIeController(ParseXML* XML_interface,
                1.1 * (interface_ip.F_sz_nm / 65.0);
     //	  //Cadence ChipEstimate using 65nm soft IP;
     //	  frontend_dyn =
-    //0.27e-9/8*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);
+    // 0.27e-9/8*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);
     // SerDer_dyn is power not energy, scaling from 10mw/Gb/s @90nm
     SerDer_dyn = 0.01 * 4 * (interface_ip.F_sz_um / 0.09) *
                  g_tp.peri_global.Vdd / 1.2 * g_tp.peri_global.Vdd /
@@ -387,7 +387,7 @@ void PCIeController::set_pcie_param() {
   pciep.type = XML->sys.pcie.type;
   pciep.withPHY = XML->sys.pcie.withPHY;
   //	  pciep.executionTime   =
-  //XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
+  // XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
 }
 
 FlashController::FlashController(ParseXML* XML_interface,
@@ -507,5 +507,5 @@ void FlashController::set_fc_param() {
   fcp.type = XML->sys.flashc.type;
   fcp.withPHY = XML->sys.flashc.withPHY;
   //	  flashcp.executionTime   =
-  //XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
+  // XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
 }

--- a/src/gpuwattch/iocontrollers.cc
+++ b/src/gpuwattch/iocontrollers.cc
@@ -29,19 +29,18 @@
  *
  ***************************************************************************/
 #include "io.h"
-#include "parameter.h"
-#include "const.h"
-#include "logic.h"
-#include "cacti/basic_circuit.h"
-#include <iostream>
-#include <algorithm>
-#include "XML_Parse.h"
-#include <string>
-#include <cmath>
 #include <assert.h>
-#include "iocontrollers.h"
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <string>
+#include "XML_Parse.h"
 #include "basic_components.h"
-
+#include "cacti/basic_circuit.h"
+#include "const.h"
+#include "iocontrollers.h"
+#include "logic.h"
+#include "parameter.h"
 
 /*
 SUN Niagara 2 I/O power analysis:
@@ -52,390 +51,461 @@ PCIe bits:         (8 + 8)*2 = 32
 Debug I/Os:        168
 Other I/Os:        711- 32-32 - 384 - 168 = 95
 
-According to "Implementation of an 8-Core, 64-Thread, Power-Efficient SPARC Server on a Chip"
-90% of I/Os are SerDers (the calucaltion is 384+64/(711-168)=83% about the same as the 90% reported in the paper)
+According to "Implementation of an 8-Core, 64-Thread, Power-Efficient SPARC
+Server on a Chip"
+90% of I/Os are SerDers (the calucaltion is 384+64/(711-168)=83% about the same
+as the 90% reported in the paper)
 --> around 80Pins are common I/Os.
 Common I/Os consumes 71mW/Gb/s according to Cadence ChipEstimate @65nm
-Niagara 2 I/O clock is 1/4 of core clock. --> 87pin (<--((711-168)*17%)) * 71mW/Gb/s *0.25*1.4Ghz = 2.17W
+Niagara 2 I/O clock is 1/4 of core clock. --> 87pin (<--((711-168)*17%)) *
+71mW/Gb/s *0.25*1.4Ghz = 2.17W
 
-Total dynamic power of FBDIMM, NIC, PCIe = 84*0.132 + 84*0.049*0.132 = 11.14 - 2.17 = 8.98
-Further, if assuming I/O logic power is about 50% of I/Os then Total energy of FBDIMM, NIC, PCIe = 11.14 - 2.17*1.5 = 7.89
+Total dynamic power of FBDIMM, NIC, PCIe = 84*0.132 + 84*0.049*0.132 = 11.14 -
+2.17 = 8.98
+Further, if assuming I/O logic power is about 50% of I/Os then Total energy of
+FBDIMM, NIC, PCIe = 11.14 - 2.17*1.5 = 7.89
  */
 
 /*
- * A bug in Cadence ChipEstimator: After update the clock rate in the clock tab, a user
- * need to re-select the IP clock (the same clk) and then click Estimate. if not reselect
+ * A bug in Cadence ChipEstimator: After update the clock rate in the clock tab,
+ * a user
+ * need to re-select the IP clock (the same clk) and then click Estimate. if not
+ * reselect
  * the new clock rate may not be propogate into the IPs.
  *
  */
 
-NIUController::NIUController(ParseXML *XML_interface,InputParameter* interface_ip_)
-:XML(XML_interface),
- interface_ip(*interface_ip_)
- {
-	  local_result = init_interface(&interface_ip);
+NIUController::NIUController(ParseXML* XML_interface,
+                             InputParameter* interface_ip_)
+    : XML(XML_interface), interface_ip(*interface_ip_) {
+  local_result = init_interface(&interface_ip);
 
-	  double frontend_area,mac_area, SerDer_area;
-      double frontend_dyn, mac_dyn, SerDer_dyn;
-      double frontend_gates, mac_gates;
-	  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
-	  double NMOS_sizing, PMOS_sizing;
+  double frontend_area, mac_area, SerDer_area;
+  double frontend_dyn, mac_dyn, SerDer_dyn;
+  double frontend_gates, mac_gates;
+  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
+  double NMOS_sizing, PMOS_sizing;
 
-	  set_niu_param();
+  set_niu_param();
 
-	  if (niup.type == 0) //high performance NIU
-	  {
-		  //Area estimation based on average of die photo from Niagara 2 and Cadence ChipEstimate using 65nm.
-		  mac_area = (1.53 + 0.3)/2 * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);
-		  //Area estimation based on average of die photo from Niagara 2, ISSCC "An 800mW 10Gb Ethernet Transceiver in 0.13μm CMOS"
-		  //and"A 1.2-V-Only 900-mW 10 Gb Ethernet Transceiver and XAUI Interface With Robust VCO Tuning Technique" Frontend is PCS
-		  frontend_area = (9.8 + (6 + 18)*65/130*65/130)/3 * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);
-		  //Area estimation based on average of die photo from Niagara 2 and Cadence ChipEstimate hard IP @65nm.
-		  //SerDer is very hard to scale
-		  SerDer_area = (1.39 + 0.36) * (interface_ip.F_sz_um/0.065);//* (interface_ip.F_sz_um/0.065);
-		  //total area
-		  area.set_area((mac_area + frontend_area + SerDer_area)*1e6);
-		  //Power
-		  //Cadence ChipEstimate using 65nm (mac, front_end are all energy. E=P*T = P/F = 1.37/1Ghz = 1.37e-9);
-		  mac_dyn      = 2.19e-9*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);//niup.clockRate; //2.19W@1GHz fully active according to Cadence ChipEstimate @65nm
-		  //Cadence ChipEstimate using 65nm soft IP;
-		  frontend_dyn = 0.27e-9*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);//niup.clockRate;
-		  //according to "A 100mW 9.6Gb/s Transceiver in 90nm CMOS..." ISSCC 2006
-		  //SerDer_dyn is power not energy, scaling from 10mw/Gb/s @90nm
-		  SerDer_dyn   = 0.01*10*sqrt(interface_ip.F_sz_um/0.09)*g_tp.peri_global.Vdd/1.2*g_tp.peri_global.Vdd/1.2;
-		  SerDer_dyn   /= niup.clockRate;//covert to energy per clock cycle of whole NIU
+  if (niup.type == 0)  // high performance NIU
+  {
+    // Area estimation based on average of die photo from Niagara 2 and Cadence
+    // ChipEstimate using 65nm.
+    mac_area = (1.53 + 0.3) / 2 * (interface_ip.F_sz_um / 0.065) *
+               (interface_ip.F_sz_um / 0.065);
+    // Area estimation based on average of die photo from Niagara 2, ISSCC "An
+    // 800mW 10Gb Ethernet Transceiver in 0.13μm CMOS"
+    // and"A 1.2-V-Only 900-mW 10 Gb Ethernet Transceiver and XAUI Interface
+    // With Robust VCO Tuning Technique" Frontend is PCS
+    frontend_area = (9.8 + (6 + 18) * 65 / 130 * 65 / 130) / 3 *
+                    (interface_ip.F_sz_um / 0.065) *
+                    (interface_ip.F_sz_um / 0.065);
+    // Area estimation based on average of die photo from Niagara 2 and Cadence
+    // ChipEstimate hard IP @65nm.
+    // SerDer is very hard to scale
+    SerDer_area = (1.39 + 0.36) * (interface_ip.F_sz_um /
+                                   0.065);  //* (interface_ip.F_sz_um/0.065);
+    // total area
+    area.set_area((mac_area + frontend_area + SerDer_area) * 1e6);
+    // Power
+    // Cadence ChipEstimate using 65nm (mac, front_end are all energy. E=P*T =
+    // P/F = 1.37/1Ghz = 1.37e-9);
+    mac_dyn = 2.19e-9 * g_tp.peri_global.Vdd / 1.1 * g_tp.peri_global.Vdd /
+              1.1 * (interface_ip.F_sz_nm / 65.0);  // niup.clockRate;
+                                                    // //2.19W@1GHz fully active
+                                                    // according to Cadence
+                                                    // ChipEstimate @65nm
+    // Cadence ChipEstimate using 65nm soft IP;
+    frontend_dyn = 0.27e-9 * g_tp.peri_global.Vdd / 1.1 * g_tp.peri_global.Vdd /
+                   1.1 * (interface_ip.F_sz_nm / 65.0);  // niup.clockRate;
+    // according to "A 100mW 9.6Gb/s Transceiver in 90nm CMOS..." ISSCC 2006
+    // SerDer_dyn is power not energy, scaling from 10mw/Gb/s @90nm
+    SerDer_dyn = 0.01 * 10 * sqrt(interface_ip.F_sz_um / 0.09) *
+                 g_tp.peri_global.Vdd / 1.2 * g_tp.peri_global.Vdd / 1.2;
+    SerDer_dyn /=
+        niup.clockRate;  // covert to energy per clock cycle of whole NIU
 
-		  //Cadence ChipEstimate using 65nm
-		  mac_gates       = 111700;
-		  frontend_gates  = 320000;
-		  NMOS_sizing 	  = 5*g_tp.min_w_nmos_;
-		  PMOS_sizing	  = 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
+    // Cadence ChipEstimate using 65nm
+    mac_gates = 111700;
+    frontend_gates = 320000;
+    NMOS_sizing = 5 * g_tp.min_w_nmos_;
+    PMOS_sizing = 5 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r;
 
+  } else {  // Low power implementations are mostly from Cadence ChipEstimator;
+            // Ignore the multiple IP effect
+    // ---When there are multiple IP (same kind or not) selected, Cadence
+    // ChipEstimator results are not
+    // a simple summation of all IPs. Ignore this effect
+    mac_area =
+        0.24 * (interface_ip.F_sz_um / 0.065) * (interface_ip.F_sz_um / 0.065);
+    frontend_area =
+        0.1 * (interface_ip.F_sz_um / 0.065) *
+        (interface_ip.F_sz_um / 0.065);  // Frontend is the PCS layer
+    SerDer_area =
+        0.35 * (interface_ip.F_sz_um / 0.065) * (interface_ip.F_sz_um / 0.065);
+    // Compare 130um implementation in "A 1.2-V-Only 900-mW 10 Gb Ethernet
+    // Transceiver and XAUI Interface With Robust VCO Tuning Technique"
+    // and the ChipEstimator XAUI PHY hard IP, confirm that even PHY can scale
+    // perfectly with the technology
+    // total area
+    area.set_area((mac_area + frontend_area + SerDer_area) * 1e6);
+    // Power
+    // Cadence ChipEstimate using 65nm (mac, front_end are all energy. E=P*T =
+    // P/F = 1.37/1Ghz = 1.37e-9);
+    mac_dyn = 1.257e-9 * g_tp.peri_global.Vdd / 1.1 * g_tp.peri_global.Vdd /
+              1.1 * (interface_ip.F_sz_nm / 65.0);  // niup.clockRate;
+                                                    // //2.19W@1GHz fully active
+                                                    // according to Cadence
+                                                    // ChipEstimate @65nm
+    // Cadence ChipEstimate using 65nm soft IP;
+    frontend_dyn = 0.6e-9 * g_tp.peri_global.Vdd / 1.1 * g_tp.peri_global.Vdd /
+                   1.1 * (interface_ip.F_sz_nm / 65.0);  // niup.clockRate;
+    // SerDer_dyn is power not energy, scaling from 216mw/10Gb/s @130nm
+    SerDer_dyn = 0.0216 * 10 * (interface_ip.F_sz_um / 0.13) *
+                 g_tp.peri_global.Vdd / 1.2 * g_tp.peri_global.Vdd / 1.2;
+    SerDer_dyn /=
+        niup.clockRate;  // covert to energy per clock cycle of whole NIU
 
-	  }
-	  else
-	  {//Low power implementations are mostly from Cadence ChipEstimator; Ignore the multiple IP effect
-		  // ---When there are multiple IP (same kind or not) selected, Cadence ChipEstimator results are not
-		  // a simple summation of all IPs. Ignore this effect
-		  mac_area      = 0.24 * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);
-		  frontend_area = 0.1  * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);//Frontend is the PCS layer
-		  SerDer_area   = 0.35 * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);
-		  //Compare 130um implementation in "A 1.2-V-Only 900-mW 10 Gb Ethernet Transceiver and XAUI Interface With Robust VCO Tuning Technique"
-		  //and the ChipEstimator XAUI PHY hard IP, confirm that even PHY can scale perfectly with the technology
-		  //total area
-		  area.set_area((mac_area + frontend_area + SerDer_area)*1e6);
-		  //Power
-		  //Cadence ChipEstimate using 65nm (mac, front_end are all energy. E=P*T = P/F = 1.37/1Ghz = 1.37e-9);
-		  mac_dyn      = 1.257e-9*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);//niup.clockRate; //2.19W@1GHz fully active according to Cadence ChipEstimate @65nm
-		  //Cadence ChipEstimate using 65nm soft IP;
-		  frontend_dyn = 0.6e-9*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);//niup.clockRate;
-		  //SerDer_dyn is power not energy, scaling from 216mw/10Gb/s @130nm
-		  SerDer_dyn   = 0.0216*10*(interface_ip.F_sz_um/0.13)*g_tp.peri_global.Vdd/1.2*g_tp.peri_global.Vdd/1.2;
-		  SerDer_dyn   /= niup.clockRate;//covert to energy per clock cycle of whole NIU
+    mac_gates = 111700;
+    frontend_gates = 52000;
 
-		  mac_gates       = 111700;
-		  frontend_gates  = 52000;
+    NMOS_sizing = g_tp.min_w_nmos_;
+    PMOS_sizing = g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r;
+  }
 
-		  NMOS_sizing 	  = g_tp.min_w_nmos_;
-		  PMOS_sizing	  = g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
-
-	  }
-
-	  power_t.readOp.dynamic = mac_dyn + frontend_dyn + SerDer_dyn;
-	  power_t.readOp.leakage = (mac_gates + frontend_gates + frontend_gates)*cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
-	  double long_channel_device_reduction = longer_channel_device_reduction(Uncore_device);
-	  power_t.readOp.longer_channel_leakage = power_t.readOp.leakage * long_channel_device_reduction;
-	  power_t.readOp.gate_leakage = (mac_gates + frontend_gates + frontend_gates)*cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
- }
-
-void NIUController::computeEnergy(bool is_tdp)
-{
-	if (is_tdp)
-    {
-
-
-		power	= power_t;
-    	power.readOp.dynamic *= niup.duty_cycle;
-
-    }
-    else
-    {
-    	rt_power = power_t;
-    	rt_power.readOp.dynamic *= niup.perc_load;
-    }
+  power_t.readOp.dynamic = mac_dyn + frontend_dyn + SerDer_dyn;
+  power_t.readOp.leakage =
+      (mac_gates + frontend_gates + frontend_gates) *
+      cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
+      g_tp.peri_global.Vdd;  // unit W
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(Uncore_device);
+  power_t.readOp.longer_channel_leakage =
+      power_t.readOp.leakage * long_channel_device_reduction;
+  power_t.readOp.gate_leakage =
+      (mac_gates + frontend_gates + frontend_gates) *
+      cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
+      g_tp.peri_global.Vdd;  // unit W
 }
 
-void NIUController::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
+void NIUController::computeEnergy(bool is_tdp) {
+  if (is_tdp) {
+    power = power_t;
+    power.readOp.dynamic *= niup.duty_cycle;
 
-	if (is_tdp)
-	{
-		cout << "NIU:" << endl;
-		cout << indent_str<< "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic*niup.clockRate  << " W" << endl;
-		cout << indent_str<< "Subthreshold Leakage = "
-			<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
-		//cout << indent_str<< "Subthreshold Leakage = " << power.readOp.longer_channel_leakage <<" W" << endl;
-		cout << indent_str<< "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str << "Runtime Dynamic = " << rt_power.readOp.dynamic*niup.clockRate << " W" << endl;
-		cout<<endl;
-	}
-	else
-	{
-
-	}
-
+  } else {
+    rt_power = power_t;
+    rt_power.readOp.dynamic *= niup.perc_load;
+  }
 }
 
-void NIUController::set_niu_param()
-{
-	  niup.clockRate       = XML->sys.niu.clockrate;
-	  niup.clockRate       *= 1e6;
-	  niup.num_units       = XML->sys.niu.number_units;
-	  niup.duty_cycle      = XML->sys.niu.duty_cycle;
-	  niup.perc_load       = XML->sys.niu.total_load_perc;
-	  niup.type            = XML->sys.niu.type;
-//	  niup.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
+void NIUController::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
+
+  if (is_tdp) {
+    cout << "NIU:" << endl;
+    cout << indent_str << "Area = " << area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str
+         << "Peak Dynamic = " << power.readOp.dynamic * niup.clockRate << " W"
+         << endl;
+    cout << indent_str << "Subthreshold Leakage = "
+         << (long_channel ? power.readOp.longer_channel_leakage
+                          : power.readOp.leakage)
+         << " W" << endl;
+    // cout << indent_str<< "Subthreshold Leakage = " <<
+    // power.readOp.longer_channel_leakage <<" W" << endl;
+    cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str
+         << "Runtime Dynamic = " << rt_power.readOp.dynamic * niup.clockRate
+         << " W" << endl;
+    cout << endl;
+  } else {
+  }
 }
 
-PCIeController::PCIeController(ParseXML *XML_interface,InputParameter* interface_ip_)
-:XML(XML_interface),
- interface_ip(*interface_ip_)
- {
-	  local_result = init_interface(&interface_ip);
-      double ctrl_area, SerDer_area;
-      double ctrl_dyn, SerDer_dyn;
-      double ctrl_gates, SerDer_gates;
-	  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
-	  double NMOS_sizing, PMOS_sizing;
-
-	  /* Assuming PCIe is bit-slice based architecture
-	   * This is the reason for /8 in both area and power calculation
-	   * to get per lane numbers
-	   */
-
-	  set_pcie_param();
-	  if (pciep.type == 0) //high performance NIU
-	  {
-		  //Area estimation based on average of die photo from Niagara 2 and Cadence ChipEstimate @ 65nm.
-		  ctrl_area = (5.2 + 0.5)/2 * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);
-		  //Area estimation based on average of die photo from Niagara 2, and Cadence ChipEstimate @ 65nm.
-		  //Area estimation based on average of die photo from Niagara 2 and Cadence ChipEstimate hard IP @65nm.
-		  //SerDer is very hard to scale
-		  SerDer_area = (3.03 + 0.36) * (interface_ip.F_sz_um/0.065);//* (interface_ip.F_sz_um/0.065);
-		  //total area
-		  //Power
-		  //Cadence ChipEstimate using 65nm the controller includes everything: the PHY, the data link and transaction layer
-		  ctrl_dyn      = 3.75e-9/8*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);
-		  //	  //Cadence ChipEstimate using 65nm soft IP;
-		  //	  frontend_dyn = 0.27e-9/8*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);
-		  //SerDer_dyn is power not energy, scaling from 10mw/Gb/s @90nm
-		  SerDer_dyn   = 0.01*4*(interface_ip.F_sz_um/0.09)*g_tp.peri_global.Vdd/1.2*g_tp.peri_global.Vdd/1.2;//PCIe 2.0 max per lane speed is 4Gb/s
-		  SerDer_dyn   /= pciep.clockRate;//covert to energy per clock cycle
-
-		  //power_t.readOp.dynamic = (ctrl_dyn)*pciep.num_channels;
-		  //Cadence ChipEstimate using 65nm
-		  ctrl_gates       = 900000/8*pciep.num_channels;
-		  //	  frontend_gates   = 120000/8;
-		  //	  SerDer_gates     = 200000/8;
-		  NMOS_sizing 	  = 5*g_tp.min_w_nmos_;
-		  PMOS_sizing	  = 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
-	  }
-	  else
-	  {
-		  ctrl_area = 0.412 * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);
-		  //Area estimation based on average of die photo from Niagara 2, and Cadence ChipEstimate @ 65nm.
-     	  SerDer_area = 0.36 * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);
-		  //total area
-		  //Power
-		  //Cadence ChipEstimate using 65nm the controller includes everything: the PHY, the data link and transaction layer
-		  ctrl_dyn      = 2.21e-9/8*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);
-		  //	  //Cadence ChipEstimate using 65nm soft IP;
-		  //	  frontend_dyn = 0.27e-9/8*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);
-		  //SerDer_dyn is power not energy, scaling from 10mw/Gb/s @90nm
-		  SerDer_dyn   = 0.01*4*(interface_ip.F_sz_um/0.09)*g_tp.peri_global.Vdd/1.2*g_tp.peri_global.Vdd/1.2;//PCIe 2.0 max per lane speed is 4Gb/s
-		  SerDer_dyn   /= pciep.clockRate;//covert to energy per clock cycle
-
-		  //Cadence ChipEstimate using 65nm
-		  ctrl_gates       = 200000/8*pciep.num_channels;
-		  //	  frontend_gates   = 120000/8;
-		  SerDer_gates     = 200000/8*pciep.num_channels;
-		  NMOS_sizing 	  = g_tp.min_w_nmos_;
-		  PMOS_sizing	  = g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
-
-	  }
-	  area.set_area(((ctrl_area + (pciep.withPHY? SerDer_area:0))/8*pciep.num_channels)*1e6);
-	  power_t.readOp.dynamic = (ctrl_dyn + (pciep.withPHY? SerDer_dyn:0))*pciep.num_channels;
-	  power_t.readOp.leakage = (ctrl_gates + (pciep.withPHY? SerDer_gates:0))*cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
-	  double long_channel_device_reduction = longer_channel_device_reduction(Uncore_device);
-	  power_t.readOp.longer_channel_leakage = power_t.readOp.leakage * long_channel_device_reduction;
-	  power_t.readOp.gate_leakage = (ctrl_gates + (pciep.withPHY? SerDer_gates:0))*cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
- }
-
-void PCIeController::computeEnergy(bool is_tdp)
-{
-	if (is_tdp)
-    {
-
-
-		power	= power_t;
-    	power.readOp.dynamic *= pciep.duty_cycle;
-
-    }
-    else
-    {
-    	rt_power = power_t;
-    	rt_power.readOp.dynamic *= pciep.perc_load;
-    }
+void NIUController::set_niu_param() {
+  niup.clockRate = XML->sys.niu.clockrate;
+  niup.clockRate *= 1e6;
+  niup.num_units = XML->sys.niu.number_units;
+  niup.duty_cycle = XML->sys.niu.duty_cycle;
+  niup.perc_load = XML->sys.niu.total_load_perc;
+  niup.type = XML->sys.niu.type;
+  //	  niup.executionTime   =
+  //XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
 }
 
-void PCIeController::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
+PCIeController::PCIeController(ParseXML* XML_interface,
+                               InputParameter* interface_ip_)
+    : XML(XML_interface), interface_ip(*interface_ip_) {
+  local_result = init_interface(&interface_ip);
+  double ctrl_area, SerDer_area;
+  double ctrl_dyn, SerDer_dyn;
+  double ctrl_gates, SerDer_gates;
+  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
+  double NMOS_sizing, PMOS_sizing;
 
-	if (is_tdp)
-	{
-		cout << "PCIe:" << endl;
-		cout << indent_str<< "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic*pciep.clockRate  << " W" << endl;
-		cout << indent_str<< "Subthreshold Leakage = "
-			<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
-		//cout << indent_str<< "Subthreshold Leakage = " << power.readOp.longer_channel_leakage <<" W" << endl;
-		cout << indent_str<< "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str << "Runtime Dynamic = " << rt_power.readOp.dynamic*pciep.clockRate << " W" << endl;
-		cout<<endl;
-	}
-	else
-	{
+  /* Assuming PCIe is bit-slice based architecture
+   * This is the reason for /8 in both area and power calculation
+   * to get per lane numbers
+   */
 
-	}
+  set_pcie_param();
+  if (pciep.type == 0)  // high performance NIU
+  {
+    // Area estimation based on average of die photo from Niagara 2 and Cadence
+    // ChipEstimate @ 65nm.
+    ctrl_area = (5.2 + 0.5) / 2 * (interface_ip.F_sz_um / 0.065) *
+                (interface_ip.F_sz_um / 0.065);
+    // Area estimation based on average of die photo from Niagara 2, and Cadence
+    // ChipEstimate @ 65nm.
+    // Area estimation based on average of die photo from Niagara 2 and Cadence
+    // ChipEstimate hard IP @65nm.
+    // SerDer is very hard to scale
+    SerDer_area = (3.03 + 0.36) * (interface_ip.F_sz_um /
+                                   0.065);  //* (interface_ip.F_sz_um/0.065);
+    // total area
+    // Power
+    // Cadence ChipEstimate using 65nm the controller includes everything: the
+    // PHY, the data link and transaction layer
+    ctrl_dyn = 3.75e-9 / 8 * g_tp.peri_global.Vdd / 1.1 * g_tp.peri_global.Vdd /
+               1.1 * (interface_ip.F_sz_nm / 65.0);
+    //	  //Cadence ChipEstimate using 65nm soft IP;
+    //	  frontend_dyn =
+    //0.27e-9/8*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);
+    // SerDer_dyn is power not energy, scaling from 10mw/Gb/s @90nm
+    SerDer_dyn = 0.01 * 4 * (interface_ip.F_sz_um / 0.09) *
+                 g_tp.peri_global.Vdd / 1.2 * g_tp.peri_global.Vdd /
+                 1.2;               // PCIe 2.0 max per lane speed is 4Gb/s
+    SerDer_dyn /= pciep.clockRate;  // covert to energy per clock cycle
 
+    // power_t.readOp.dynamic = (ctrl_dyn)*pciep.num_channels;
+    // Cadence ChipEstimate using 65nm
+    ctrl_gates = 900000 / 8 * pciep.num_channels;
+    //	  frontend_gates   = 120000/8;
+    //	  SerDer_gates     = 200000/8;
+    NMOS_sizing = 5 * g_tp.min_w_nmos_;
+    PMOS_sizing = 5 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r;
+  } else {
+    ctrl_area =
+        0.412 * (interface_ip.F_sz_um / 0.065) * (interface_ip.F_sz_um / 0.065);
+    // Area estimation based on average of die photo from Niagara 2, and Cadence
+    // ChipEstimate @ 65nm.
+    SerDer_area =
+        0.36 * (interface_ip.F_sz_um / 0.065) * (interface_ip.F_sz_um / 0.065);
+    // total area
+    // Power
+    // Cadence ChipEstimate using 65nm the controller includes everything: the
+    // PHY, the data link and transaction layer
+    ctrl_dyn = 2.21e-9 / 8 * g_tp.peri_global.Vdd / 1.1 * g_tp.peri_global.Vdd /
+               1.1 * (interface_ip.F_sz_nm / 65.0);
+    //	  //Cadence ChipEstimate using 65nm soft IP;
+    //	  frontend_dyn =
+    //0.27e-9/8*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);
+    // SerDer_dyn is power not energy, scaling from 10mw/Gb/s @90nm
+    SerDer_dyn = 0.01 * 4 * (interface_ip.F_sz_um / 0.09) *
+                 g_tp.peri_global.Vdd / 1.2 * g_tp.peri_global.Vdd /
+                 1.2;               // PCIe 2.0 max per lane speed is 4Gb/s
+    SerDer_dyn /= pciep.clockRate;  // covert to energy per clock cycle
+
+    // Cadence ChipEstimate using 65nm
+    ctrl_gates = 200000 / 8 * pciep.num_channels;
+    //	  frontend_gates   = 120000/8;
+    SerDer_gates = 200000 / 8 * pciep.num_channels;
+    NMOS_sizing = g_tp.min_w_nmos_;
+    PMOS_sizing = g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r;
+  }
+  area.set_area(((ctrl_area + (pciep.withPHY ? SerDer_area : 0)) / 8 *
+                 pciep.num_channels) *
+                1e6);
+  power_t.readOp.dynamic =
+      (ctrl_dyn + (pciep.withPHY ? SerDer_dyn : 0)) * pciep.num_channels;
+  power_t.readOp.leakage =
+      (ctrl_gates + (pciep.withPHY ? SerDer_gates : 0)) *
+      cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
+      g_tp.peri_global.Vdd;  // unit W
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(Uncore_device);
+  power_t.readOp.longer_channel_leakage =
+      power_t.readOp.leakage * long_channel_device_reduction;
+  power_t.readOp.gate_leakage =
+      (ctrl_gates + (pciep.withPHY ? SerDer_gates : 0)) *
+      cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
+      g_tp.peri_global.Vdd;  // unit W
 }
 
-void PCIeController::set_pcie_param()
-{
-	  pciep.clockRate       = XML->sys.pcie.clockrate;
-	  pciep.clockRate       *= 1e6;
-	  pciep.num_units       = XML->sys.pcie.number_units;
-	  pciep.num_channels    = XML->sys.pcie.num_channels;
-	  pciep.duty_cycle      = XML->sys.pcie.duty_cycle;
-	  pciep.perc_load       = XML->sys.pcie.total_load_perc;
-	  pciep.type            = XML->sys.pcie.type;
-	  pciep.withPHY         = XML->sys.pcie.withPHY;
-//	  pciep.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
+void PCIeController::computeEnergy(bool is_tdp) {
+  if (is_tdp) {
+    power = power_t;
+    power.readOp.dynamic *= pciep.duty_cycle;
 
+  } else {
+    rt_power = power_t;
+    rt_power.readOp.dynamic *= pciep.perc_load;
+  }
 }
 
-FlashController::FlashController(ParseXML *XML_interface,InputParameter* interface_ip_)
-:XML(XML_interface),
- interface_ip(*interface_ip_)
- {
-	  local_result = init_interface(&interface_ip);
-	  double ctrl_area, SerDer_area;
-      double ctrl_dyn, SerDer_dyn;
-      double ctrl_gates, SerDer_gates;
-	  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
-	  double NMOS_sizing, PMOS_sizing;
+void PCIeController::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
 
-	  /* Assuming PCIe is bit-slice based architecture
-	   * This is the reason for /8 in both area and power calculation
-	   * to get per lane numbers
-	   */
-
-	  set_fc_param();
-	  if (fcp.type == 0) //high performance NIU
-	  {
-		  cout<<"Current McPAT does not support high performance flash contorller since even low power designs are enough for maintain throughput"<<endl;
-		  exit(0);
-		  NMOS_sizing 	  = 5*g_tp.min_w_nmos_;
-		  PMOS_sizing	  = 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
-	  }
-	  else
-	  {
-		  ctrl_area   = 0.243 * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);
-		  //Area estimation based on Cadence ChipEstimate @ 65nm: NANDFLASH-CTRL from CAST
-     	  SerDer_area = 0.36/8 * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);
-     	  //based On PCIe PHY TSMC65GP from Cadence ChipEstimate @ 65nm, it support 8x lanes with each lane
-     	  //speed up to 250MB/s (PCIe1.1x) This is already saturate the 200MB/s of the flash controller core above.
-		  ctrl_gates      = 129267;
-		  SerDer_gates    = 200000/8;
-		  NMOS_sizing 	  = g_tp.min_w_nmos_;
-		  PMOS_sizing	  = g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
-
-		  //Power
-		  //Cadence ChipEstimate using 65nm the controller 125mW for every 200MB/s This is power not energy!
-		  ctrl_dyn      = 0.125*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);
-		  //SerDer_dyn is power not energy, scaling from 10mw/Gb/s @90nm
-		  SerDer_dyn   = 0.01*1.6*(interface_ip.F_sz_um/0.09)*g_tp.peri_global.Vdd/1.2*g_tp.peri_global.Vdd/1.2;
-		  //max  Per controller speed is 1.6Gb/s (200MB/s)
-	  }
-	  double number_channel = 1+(fcp.num_channels-1)*0.2;
-	  area.set_area((ctrl_area + (fcp.withPHY? SerDer_area:0))*1e6*number_channel);
-	  power_t.readOp.dynamic = (ctrl_dyn + (fcp.withPHY? SerDer_dyn:0))*number_channel;
-	  power_t.readOp.leakage = ((ctrl_gates + (fcp.withPHY? SerDer_gates:0))*number_channel)*cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
-	  double long_channel_device_reduction = longer_channel_device_reduction(Uncore_device);
-	  power_t.readOp.longer_channel_leakage = power_t.readOp.leakage * long_channel_device_reduction;
-	  power_t.readOp.gate_leakage = ((ctrl_gates + (fcp.withPHY? SerDer_gates:0))*number_channel)*cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
- }
-
-void FlashController::computeEnergy(bool is_tdp)
-{
-	if (is_tdp)
-    {
-
-
-		power	= power_t;
-    	power.readOp.dynamic *= fcp.duty_cycle;
-
-    }
-    else
-    {
-    	rt_power = power_t;
-    	rt_power.readOp.dynamic *= fcp.perc_load;
-    }
+  if (is_tdp) {
+    cout << "PCIe:" << endl;
+    cout << indent_str << "Area = " << area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str
+         << "Peak Dynamic = " << power.readOp.dynamic * pciep.clockRate << " W"
+         << endl;
+    cout << indent_str << "Subthreshold Leakage = "
+         << (long_channel ? power.readOp.longer_channel_leakage
+                          : power.readOp.leakage)
+         << " W" << endl;
+    // cout << indent_str<< "Subthreshold Leakage = " <<
+    // power.readOp.longer_channel_leakage <<" W" << endl;
+    cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str
+         << "Runtime Dynamic = " << rt_power.readOp.dynamic * pciep.clockRate
+         << " W" << endl;
+    cout << endl;
+  } else {
+  }
 }
 
-void FlashController::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
-
-	if (is_tdp)
-	{
-		cout << "Flash Controller:" << endl;
-		cout << indent_str<< "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic << " W" << endl;//no multiply of clock since this is power already
-		cout << indent_str<< "Subthreshold Leakage = "
-			<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
-		//cout << indent_str<< "Subthreshold Leakage = " << power.readOp.longer_channel_leakage <<" W" << endl;
-		cout << indent_str<< "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str << "Runtime Dynamic = " << rt_power.readOp.dynamic << " W" << endl;
-		cout<<endl;
-	}
-	else
-	{
-
-	}
-
+void PCIeController::set_pcie_param() {
+  pciep.clockRate = XML->sys.pcie.clockrate;
+  pciep.clockRate *= 1e6;
+  pciep.num_units = XML->sys.pcie.number_units;
+  pciep.num_channels = XML->sys.pcie.num_channels;
+  pciep.duty_cycle = XML->sys.pcie.duty_cycle;
+  pciep.perc_load = XML->sys.pcie.total_load_perc;
+  pciep.type = XML->sys.pcie.type;
+  pciep.withPHY = XML->sys.pcie.withPHY;
+  //	  pciep.executionTime   =
+  //XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
 }
 
-void FlashController::set_fc_param()
-{
-//	  fcp.clockRate       = XML->sys.flashc.mc_clock;
-//	  fcp.clockRate       *= 1e6;
-	  fcp.peakDataTransferRate = XML->sys.flashc.peak_transfer_rate;
-	  fcp.num_channels    = ceil(fcp.peakDataTransferRate/200);
-	  fcp.num_mcs         = XML->sys.flashc.number_mcs;
-	  fcp.duty_cycle      = XML->sys.flashc.duty_cycle;
-	  fcp.perc_load       = XML->sys.flashc.total_load_perc;
-	  fcp.type            = XML->sys.flashc.type;
-	  fcp.withPHY         = XML->sys.flashc.withPHY;
-//	  flashcp.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
+FlashController::FlashController(ParseXML* XML_interface,
+                                 InputParameter* interface_ip_)
+    : XML(XML_interface), interface_ip(*interface_ip_) {
+  local_result = init_interface(&interface_ip);
+  double ctrl_area, SerDer_area;
+  double ctrl_dyn, SerDer_dyn;
+  double ctrl_gates, SerDer_gates;
+  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
+  double NMOS_sizing, PMOS_sizing;
 
+  /* Assuming PCIe is bit-slice based architecture
+   * This is the reason for /8 in both area and power calculation
+   * to get per lane numbers
+   */
+
+  set_fc_param();
+  if (fcp.type == 0)  // high performance NIU
+  {
+    cout << "Current McPAT does not support high performance flash contorller "
+            "since even low power designs are enough for maintain throughput"
+         << endl;
+    exit(0);
+    NMOS_sizing = 5 * g_tp.min_w_nmos_;
+    PMOS_sizing = 5 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r;
+  } else {
+    ctrl_area =
+        0.243 * (interface_ip.F_sz_um / 0.065) * (interface_ip.F_sz_um / 0.065);
+    // Area estimation based on Cadence ChipEstimate @ 65nm: NANDFLASH-CTRL from
+    // CAST
+    SerDer_area = 0.36 / 8 * (interface_ip.F_sz_um / 0.065) *
+                  (interface_ip.F_sz_um / 0.065);
+    // based On PCIe PHY TSMC65GP from Cadence ChipEstimate @ 65nm, it support
+    // 8x lanes with each lane
+    // speed up to 250MB/s (PCIe1.1x) This is already saturate the 200MB/s of
+    // the flash controller core above.
+    ctrl_gates = 129267;
+    SerDer_gates = 200000 / 8;
+    NMOS_sizing = g_tp.min_w_nmos_;
+    PMOS_sizing = g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r;
+
+    // Power
+    // Cadence ChipEstimate using 65nm the controller 125mW for every 200MB/s
+    // This is power not energy!
+    ctrl_dyn = 0.125 * g_tp.peri_global.Vdd / 1.1 * g_tp.peri_global.Vdd / 1.1 *
+               (interface_ip.F_sz_nm / 65.0);
+    // SerDer_dyn is power not energy, scaling from 10mw/Gb/s @90nm
+    SerDer_dyn = 0.01 * 1.6 * (interface_ip.F_sz_um / 0.09) *
+                 g_tp.peri_global.Vdd / 1.2 * g_tp.peri_global.Vdd / 1.2;
+    // max  Per controller speed is 1.6Gb/s (200MB/s)
+  }
+  double number_channel = 1 + (fcp.num_channels - 1) * 0.2;
+  area.set_area((ctrl_area + (fcp.withPHY ? SerDer_area : 0)) * 1e6 *
+                number_channel);
+  power_t.readOp.dynamic =
+      (ctrl_dyn + (fcp.withPHY ? SerDer_dyn : 0)) * number_channel;
+  power_t.readOp.leakage =
+      ((ctrl_gates + (fcp.withPHY ? SerDer_gates : 0)) * number_channel) *
+      cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
+      g_tp.peri_global.Vdd;  // unit W
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(Uncore_device);
+  power_t.readOp.longer_channel_leakage =
+      power_t.readOp.leakage * long_channel_device_reduction;
+  power_t.readOp.gate_leakage =
+      ((ctrl_gates + (fcp.withPHY ? SerDer_gates : 0)) * number_channel) *
+      cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
+      g_tp.peri_global.Vdd;  // unit W
+}
+
+void FlashController::computeEnergy(bool is_tdp) {
+  if (is_tdp) {
+    power = power_t;
+    power.readOp.dynamic *= fcp.duty_cycle;
+
+  } else {
+    rt_power = power_t;
+    rt_power.readOp.dynamic *= fcp.perc_load;
+  }
+}
+
+void FlashController::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
+
+  if (is_tdp) {
+    cout << "Flash Controller:" << endl;
+    cout << indent_str << "Area = " << area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic << " W"
+         << endl;  // no multiply of clock since this is power already
+    cout << indent_str << "Subthreshold Leakage = "
+         << (long_channel ? power.readOp.longer_channel_leakage
+                          : power.readOp.leakage)
+         << " W" << endl;
+    // cout << indent_str<< "Subthreshold Leakage = " <<
+    // power.readOp.longer_channel_leakage <<" W" << endl;
+    cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str << "Runtime Dynamic = " << rt_power.readOp.dynamic
+         << " W" << endl;
+    cout << endl;
+  } else {
+  }
+}
+
+void FlashController::set_fc_param() {
+  //	  fcp.clockRate       = XML->sys.flashc.mc_clock;
+  //	  fcp.clockRate       *= 1e6;
+  fcp.peakDataTransferRate = XML->sys.flashc.peak_transfer_rate;
+  fcp.num_channels = ceil(fcp.peakDataTransferRate / 200);
+  fcp.num_mcs = XML->sys.flashc.number_mcs;
+  fcp.duty_cycle = XML->sys.flashc.duty_cycle;
+  fcp.perc_load = XML->sys.flashc.total_load_perc;
+  fcp.type = XML->sys.flashc.type;
+  fcp.withPHY = XML->sys.flashc.withPHY;
+  //	  flashcp.executionTime   =
+  //XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
 }

--- a/src/gpuwattch/iocontrollers.cc
+++ b/src/gpuwattch/iocontrollers.cc
@@ -29,18 +29,19 @@
  *
  ***************************************************************************/
 #include "io.h"
-#include <assert.h>
-#include <algorithm>
-#include <cmath>
-#include <iostream>
-#include <string>
-#include "XML_Parse.h"
-#include "basic_components.h"
-#include "cacti/basic_circuit.h"
-#include "const.h"
-#include "iocontrollers.h"
-#include "logic.h"
 #include "parameter.h"
+#include "const.h"
+#include "logic.h"
+#include "cacti/basic_circuit.h"
+#include <iostream>
+#include <algorithm>
+#include "XML_Parse.h"
+#include <string>
+#include <cmath>
+#include <assert.h>
+#include "iocontrollers.h"
+#include "basic_components.h"
+
 
 /*
 SUN Niagara 2 I/O power analysis:
@@ -51,461 +52,390 @@ PCIe bits:         (8 + 8)*2 = 32
 Debug I/Os:        168
 Other I/Os:        711- 32-32 - 384 - 168 = 95
 
-According to "Implementation of an 8-Core, 64-Thread, Power-Efficient SPARC
-Server on a Chip"
-90% of I/Os are SerDers (the calucaltion is 384+64/(711-168)=83% about the same
-as the 90% reported in the paper)
+According to "Implementation of an 8-Core, 64-Thread, Power-Efficient SPARC Server on a Chip"
+90% of I/Os are SerDers (the calucaltion is 384+64/(711-168)=83% about the same as the 90% reported in the paper)
 --> around 80Pins are common I/Os.
 Common I/Os consumes 71mW/Gb/s according to Cadence ChipEstimate @65nm
-Niagara 2 I/O clock is 1/4 of core clock. --> 87pin (<--((711-168)*17%)) *
-71mW/Gb/s *0.25*1.4Ghz = 2.17W
+Niagara 2 I/O clock is 1/4 of core clock. --> 87pin (<--((711-168)*17%)) * 71mW/Gb/s *0.25*1.4Ghz = 2.17W
 
-Total dynamic power of FBDIMM, NIC, PCIe = 84*0.132 + 84*0.049*0.132 = 11.14 -
-2.17 = 8.98
-Further, if assuming I/O logic power is about 50% of I/Os then Total energy of
-FBDIMM, NIC, PCIe = 11.14 - 2.17*1.5 = 7.89
+Total dynamic power of FBDIMM, NIC, PCIe = 84*0.132 + 84*0.049*0.132 = 11.14 - 2.17 = 8.98
+Further, if assuming I/O logic power is about 50% of I/Os then Total energy of FBDIMM, NIC, PCIe = 11.14 - 2.17*1.5 = 7.89
  */
 
 /*
- * A bug in Cadence ChipEstimator: After update the clock rate in the clock tab,
- * a user
- * need to re-select the IP clock (the same clk) and then click Estimate. if not
- * reselect
+ * A bug in Cadence ChipEstimator: After update the clock rate in the clock tab, a user
+ * need to re-select the IP clock (the same clk) and then click Estimate. if not reselect
  * the new clock rate may not be propogate into the IPs.
  *
  */
 
-NIUController::NIUController(ParseXML* XML_interface,
-                             InputParameter* interface_ip_)
-    : XML(XML_interface), interface_ip(*interface_ip_) {
-  local_result = init_interface(&interface_ip);
+NIUController::NIUController(ParseXML *XML_interface,InputParameter* interface_ip_)
+:XML(XML_interface),
+ interface_ip(*interface_ip_)
+ {
+	  local_result = init_interface(&interface_ip);
 
-  double frontend_area, mac_area, SerDer_area;
-  double frontend_dyn, mac_dyn, SerDer_dyn;
-  double frontend_gates, mac_gates;
-  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
-  double NMOS_sizing, PMOS_sizing;
+	  double frontend_area,mac_area, SerDer_area;
+      double frontend_dyn, mac_dyn, SerDer_dyn;
+      double frontend_gates, mac_gates;
+	  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
+	  double NMOS_sizing, PMOS_sizing;
 
-  set_niu_param();
+	  set_niu_param();
 
-  if (niup.type == 0)  // high performance NIU
-  {
-    // Area estimation based on average of die photo from Niagara 2 and Cadence
-    // ChipEstimate using 65nm.
-    mac_area = (1.53 + 0.3) / 2 * (interface_ip.F_sz_um / 0.065) *
-               (interface_ip.F_sz_um / 0.065);
-    // Area estimation based on average of die photo from Niagara 2, ISSCC "An
-    // 800mW 10Gb Ethernet Transceiver in 0.13μm CMOS"
-    // and"A 1.2-V-Only 900-mW 10 Gb Ethernet Transceiver and XAUI Interface
-    // With Robust VCO Tuning Technique" Frontend is PCS
-    frontend_area = (9.8 + (6 + 18) * 65 / 130 * 65 / 130) / 3 *
-                    (interface_ip.F_sz_um / 0.065) *
-                    (interface_ip.F_sz_um / 0.065);
-    // Area estimation based on average of die photo from Niagara 2 and Cadence
-    // ChipEstimate hard IP @65nm.
-    // SerDer is very hard to scale
-    SerDer_area = (1.39 + 0.36) * (interface_ip.F_sz_um /
-                                   0.065);  //* (interface_ip.F_sz_um/0.065);
-    // total area
-    area.set_area((mac_area + frontend_area + SerDer_area) * 1e6);
-    // Power
-    // Cadence ChipEstimate using 65nm (mac, front_end are all energy. E=P*T =
-    // P/F = 1.37/1Ghz = 1.37e-9);
-    mac_dyn = 2.19e-9 * g_tp.peri_global.Vdd / 1.1 * g_tp.peri_global.Vdd /
-              1.1 * (interface_ip.F_sz_nm / 65.0);  // niup.clockRate;
-                                                    // //2.19W@1GHz fully active
-                                                    // according to Cadence
-                                                    // ChipEstimate @65nm
-    // Cadence ChipEstimate using 65nm soft IP;
-    frontend_dyn = 0.27e-9 * g_tp.peri_global.Vdd / 1.1 * g_tp.peri_global.Vdd /
-                   1.1 * (interface_ip.F_sz_nm / 65.0);  // niup.clockRate;
-    // according to "A 100mW 9.6Gb/s Transceiver in 90nm CMOS..." ISSCC 2006
-    // SerDer_dyn is power not energy, scaling from 10mw/Gb/s @90nm
-    SerDer_dyn = 0.01 * 10 * sqrt(interface_ip.F_sz_um / 0.09) *
-                 g_tp.peri_global.Vdd / 1.2 * g_tp.peri_global.Vdd / 1.2;
-    SerDer_dyn /=
-        niup.clockRate;  // covert to energy per clock cycle of whole NIU
+	  if (niup.type == 0) //high performance NIU
+	  {
+		  //Area estimation based on average of die photo from Niagara 2 and Cadence ChipEstimate using 65nm.
+		  mac_area = (1.53 + 0.3)/2 * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);
+		  //Area estimation based on average of die photo from Niagara 2, ISSCC "An 800mW 10Gb Ethernet Transceiver in 0.13μm CMOS"
+		  //and"A 1.2-V-Only 900-mW 10 Gb Ethernet Transceiver and XAUI Interface With Robust VCO Tuning Technique" Frontend is PCS
+		  frontend_area = (9.8 + (6 + 18)*65/130*65/130)/3 * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);
+		  //Area estimation based on average of die photo from Niagara 2 and Cadence ChipEstimate hard IP @65nm.
+		  //SerDer is very hard to scale
+		  SerDer_area = (1.39 + 0.36) * (interface_ip.F_sz_um/0.065);//* (interface_ip.F_sz_um/0.065);
+		  //total area
+		  area.set_area((mac_area + frontend_area + SerDer_area)*1e6);
+		  //Power
+		  //Cadence ChipEstimate using 65nm (mac, front_end are all energy. E=P*T = P/F = 1.37/1Ghz = 1.37e-9);
+		  mac_dyn      = 2.19e-9*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);//niup.clockRate; //2.19W@1GHz fully active according to Cadence ChipEstimate @65nm
+		  //Cadence ChipEstimate using 65nm soft IP;
+		  frontend_dyn = 0.27e-9*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);//niup.clockRate;
+		  //according to "A 100mW 9.6Gb/s Transceiver in 90nm CMOS..." ISSCC 2006
+		  //SerDer_dyn is power not energy, scaling from 10mw/Gb/s @90nm
+		  SerDer_dyn   = 0.01*10*sqrt(interface_ip.F_sz_um/0.09)*g_tp.peri_global.Vdd/1.2*g_tp.peri_global.Vdd/1.2;
+		  SerDer_dyn   /= niup.clockRate;//covert to energy per clock cycle of whole NIU
 
-    // Cadence ChipEstimate using 65nm
-    mac_gates = 111700;
-    frontend_gates = 320000;
-    NMOS_sizing = 5 * g_tp.min_w_nmos_;
-    PMOS_sizing = 5 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r;
+		  //Cadence ChipEstimate using 65nm
+		  mac_gates       = 111700;
+		  frontend_gates  = 320000;
+		  NMOS_sizing 	  = 5*g_tp.min_w_nmos_;
+		  PMOS_sizing	  = 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
 
-  } else {  // Low power implementations are mostly from Cadence ChipEstimator;
-            // Ignore the multiple IP effect
-    // ---When there are multiple IP (same kind or not) selected, Cadence
-    // ChipEstimator results are not
-    // a simple summation of all IPs. Ignore this effect
-    mac_area =
-        0.24 * (interface_ip.F_sz_um / 0.065) * (interface_ip.F_sz_um / 0.065);
-    frontend_area =
-        0.1 * (interface_ip.F_sz_um / 0.065) *
-        (interface_ip.F_sz_um / 0.065);  // Frontend is the PCS layer
-    SerDer_area =
-        0.35 * (interface_ip.F_sz_um / 0.065) * (interface_ip.F_sz_um / 0.065);
-    // Compare 130um implementation in "A 1.2-V-Only 900-mW 10 Gb Ethernet
-    // Transceiver and XAUI Interface With Robust VCO Tuning Technique"
-    // and the ChipEstimator XAUI PHY hard IP, confirm that even PHY can scale
-    // perfectly with the technology
-    // total area
-    area.set_area((mac_area + frontend_area + SerDer_area) * 1e6);
-    // Power
-    // Cadence ChipEstimate using 65nm (mac, front_end are all energy. E=P*T =
-    // P/F = 1.37/1Ghz = 1.37e-9);
-    mac_dyn = 1.257e-9 * g_tp.peri_global.Vdd / 1.1 * g_tp.peri_global.Vdd /
-              1.1 * (interface_ip.F_sz_nm / 65.0);  // niup.clockRate;
-                                                    // //2.19W@1GHz fully active
-                                                    // according to Cadence
-                                                    // ChipEstimate @65nm
-    // Cadence ChipEstimate using 65nm soft IP;
-    frontend_dyn = 0.6e-9 * g_tp.peri_global.Vdd / 1.1 * g_tp.peri_global.Vdd /
-                   1.1 * (interface_ip.F_sz_nm / 65.0);  // niup.clockRate;
-    // SerDer_dyn is power not energy, scaling from 216mw/10Gb/s @130nm
-    SerDer_dyn = 0.0216 * 10 * (interface_ip.F_sz_um / 0.13) *
-                 g_tp.peri_global.Vdd / 1.2 * g_tp.peri_global.Vdd / 1.2;
-    SerDer_dyn /=
-        niup.clockRate;  // covert to energy per clock cycle of whole NIU
 
-    mac_gates = 111700;
-    frontend_gates = 52000;
+	  }
+	  else
+	  {//Low power implementations are mostly from Cadence ChipEstimator; Ignore the multiple IP effect
+		  // ---When there are multiple IP (same kind or not) selected, Cadence ChipEstimator results are not
+		  // a simple summation of all IPs. Ignore this effect
+		  mac_area      = 0.24 * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);
+		  frontend_area = 0.1  * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);//Frontend is the PCS layer
+		  SerDer_area   = 0.35 * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);
+		  //Compare 130um implementation in "A 1.2-V-Only 900-mW 10 Gb Ethernet Transceiver and XAUI Interface With Robust VCO Tuning Technique"
+		  //and the ChipEstimator XAUI PHY hard IP, confirm that even PHY can scale perfectly with the technology
+		  //total area
+		  area.set_area((mac_area + frontend_area + SerDer_area)*1e6);
+		  //Power
+		  //Cadence ChipEstimate using 65nm (mac, front_end are all energy. E=P*T = P/F = 1.37/1Ghz = 1.37e-9);
+		  mac_dyn      = 1.257e-9*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);//niup.clockRate; //2.19W@1GHz fully active according to Cadence ChipEstimate @65nm
+		  //Cadence ChipEstimate using 65nm soft IP;
+		  frontend_dyn = 0.6e-9*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);//niup.clockRate;
+		  //SerDer_dyn is power not energy, scaling from 216mw/10Gb/s @130nm
+		  SerDer_dyn   = 0.0216*10*(interface_ip.F_sz_um/0.13)*g_tp.peri_global.Vdd/1.2*g_tp.peri_global.Vdd/1.2;
+		  SerDer_dyn   /= niup.clockRate;//covert to energy per clock cycle of whole NIU
 
-    NMOS_sizing = g_tp.min_w_nmos_;
-    PMOS_sizing = g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r;
-  }
+		  mac_gates       = 111700;
+		  frontend_gates  = 52000;
 
-  power_t.readOp.dynamic = mac_dyn + frontend_dyn + SerDer_dyn;
-  power_t.readOp.leakage =
-      (mac_gates + frontend_gates + frontend_gates) *
-      cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
-      g_tp.peri_global.Vdd;  // unit W
-  double long_channel_device_reduction =
-      longer_channel_device_reduction(Uncore_device);
-  power_t.readOp.longer_channel_leakage =
-      power_t.readOp.leakage * long_channel_device_reduction;
-  power_t.readOp.gate_leakage =
-      (mac_gates + frontend_gates + frontend_gates) *
-      cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
-      g_tp.peri_global.Vdd;  // unit W
+		  NMOS_sizing 	  = g_tp.min_w_nmos_;
+		  PMOS_sizing	  = g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
+
+	  }
+
+	  power_t.readOp.dynamic = mac_dyn + frontend_dyn + SerDer_dyn;
+	  power_t.readOp.leakage = (mac_gates + frontend_gates + frontend_gates)*cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
+	  double long_channel_device_reduction = longer_channel_device_reduction(Uncore_device);
+	  power_t.readOp.longer_channel_leakage = power_t.readOp.leakage * long_channel_device_reduction;
+	  power_t.readOp.gate_leakage = (mac_gates + frontend_gates + frontend_gates)*cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
+ }
+
+void NIUController::computeEnergy(bool is_tdp)
+{
+	if (is_tdp)
+    {
+
+
+		power	= power_t;
+    	power.readOp.dynamic *= niup.duty_cycle;
+
+    }
+    else
+    {
+    	rt_power = power_t;
+    	rt_power.readOp.dynamic *= niup.perc_load;
+    }
 }
 
-void NIUController::computeEnergy(bool is_tdp) {
-  if (is_tdp) {
-    power = power_t;
-    power.readOp.dynamic *= niup.duty_cycle;
+void NIUController::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
+{
+	string indent_str(indent, ' ');
+	string indent_str_next(indent+2, ' ');
+	bool long_channel = XML->sys.longer_channel_device;
 
-  } else {
-    rt_power = power_t;
-    rt_power.readOp.dynamic *= niup.perc_load;
-  }
+	if (is_tdp)
+	{
+		cout << "NIU:" << endl;
+		cout << indent_str<< "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
+		cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic*niup.clockRate  << " W" << endl;
+		cout << indent_str<< "Subthreshold Leakage = "
+			<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
+		//cout << indent_str<< "Subthreshold Leakage = " << power.readOp.longer_channel_leakage <<" W" << endl;
+		cout << indent_str<< "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
+		cout << indent_str << "Runtime Dynamic = " << rt_power.readOp.dynamic*niup.clockRate << " W" << endl;
+		cout<<endl;
+	}
+	else
+	{
+
+	}
+
 }
 
-void NIUController::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
-  string indent_str(indent, ' ');
-  string indent_str_next(indent + 2, ' ');
-  bool long_channel = XML->sys.longer_channel_device;
-
-  if (is_tdp) {
-    cout << "NIU:" << endl;
-    cout << indent_str << "Area = " << area.get_area() * 1e-6 << " mm^2"
-         << endl;
-    cout << indent_str
-         << "Peak Dynamic = " << power.readOp.dynamic * niup.clockRate << " W"
-         << endl;
-    cout << indent_str << "Subthreshold Leakage = "
-         << (long_channel ? power.readOp.longer_channel_leakage
-                          : power.readOp.leakage)
-         << " W" << endl;
-    // cout << indent_str<< "Subthreshold Leakage = " <<
-    // power.readOp.longer_channel_leakage <<" W" << endl;
-    cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W"
-         << endl;
-    cout << indent_str
-         << "Runtime Dynamic = " << rt_power.readOp.dynamic * niup.clockRate
-         << " W" << endl;
-    cout << endl;
-  } else {
-  }
+void NIUController::set_niu_param()
+{
+	  niup.clockRate       = XML->sys.niu.clockrate;
+	  niup.clockRate       *= 1e6;
+	  niup.num_units       = XML->sys.niu.number_units;
+	  niup.duty_cycle      = XML->sys.niu.duty_cycle;
+	  niup.perc_load       = XML->sys.niu.total_load_perc;
+	  niup.type            = XML->sys.niu.type;
+//	  niup.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
 }
 
-void NIUController::set_niu_param() {
-  niup.clockRate = XML->sys.niu.clockrate;
-  niup.clockRate *= 1e6;
-  niup.num_units = XML->sys.niu.number_units;
-  niup.duty_cycle = XML->sys.niu.duty_cycle;
-  niup.perc_load = XML->sys.niu.total_load_perc;
-  niup.type = XML->sys.niu.type;
-  //	  niup.executionTime   =
-  //XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
+PCIeController::PCIeController(ParseXML *XML_interface,InputParameter* interface_ip_)
+:XML(XML_interface),
+ interface_ip(*interface_ip_)
+ {
+	  local_result = init_interface(&interface_ip);
+      double ctrl_area, SerDer_area;
+      double ctrl_dyn, SerDer_dyn;
+      double ctrl_gates, SerDer_gates;
+	  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
+	  double NMOS_sizing, PMOS_sizing;
+
+	  /* Assuming PCIe is bit-slice based architecture
+	   * This is the reason for /8 in both area and power calculation
+	   * to get per lane numbers
+	   */
+
+	  set_pcie_param();
+	  if (pciep.type == 0) //high performance NIU
+	  {
+		  //Area estimation based on average of die photo from Niagara 2 and Cadence ChipEstimate @ 65nm.
+		  ctrl_area = (5.2 + 0.5)/2 * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);
+		  //Area estimation based on average of die photo from Niagara 2, and Cadence ChipEstimate @ 65nm.
+		  //Area estimation based on average of die photo from Niagara 2 and Cadence ChipEstimate hard IP @65nm.
+		  //SerDer is very hard to scale
+		  SerDer_area = (3.03 + 0.36) * (interface_ip.F_sz_um/0.065);//* (interface_ip.F_sz_um/0.065);
+		  //total area
+		  //Power
+		  //Cadence ChipEstimate using 65nm the controller includes everything: the PHY, the data link and transaction layer
+		  ctrl_dyn      = 3.75e-9/8*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);
+		  //	  //Cadence ChipEstimate using 65nm soft IP;
+		  //	  frontend_dyn = 0.27e-9/8*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);
+		  //SerDer_dyn is power not energy, scaling from 10mw/Gb/s @90nm
+		  SerDer_dyn   = 0.01*4*(interface_ip.F_sz_um/0.09)*g_tp.peri_global.Vdd/1.2*g_tp.peri_global.Vdd/1.2;//PCIe 2.0 max per lane speed is 4Gb/s
+		  SerDer_dyn   /= pciep.clockRate;//covert to energy per clock cycle
+
+		  //power_t.readOp.dynamic = (ctrl_dyn)*pciep.num_channels;
+		  //Cadence ChipEstimate using 65nm
+		  ctrl_gates       = 900000/8*pciep.num_channels;
+		  //	  frontend_gates   = 120000/8;
+		  //	  SerDer_gates     = 200000/8;
+		  NMOS_sizing 	  = 5*g_tp.min_w_nmos_;
+		  PMOS_sizing	  = 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
+	  }
+	  else
+	  {
+		  ctrl_area = 0.412 * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);
+		  //Area estimation based on average of die photo from Niagara 2, and Cadence ChipEstimate @ 65nm.
+     	  SerDer_area = 0.36 * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);
+		  //total area
+		  //Power
+		  //Cadence ChipEstimate using 65nm the controller includes everything: the PHY, the data link and transaction layer
+		  ctrl_dyn      = 2.21e-9/8*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);
+		  //	  //Cadence ChipEstimate using 65nm soft IP;
+		  //	  frontend_dyn = 0.27e-9/8*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);
+		  //SerDer_dyn is power not energy, scaling from 10mw/Gb/s @90nm
+		  SerDer_dyn   = 0.01*4*(interface_ip.F_sz_um/0.09)*g_tp.peri_global.Vdd/1.2*g_tp.peri_global.Vdd/1.2;//PCIe 2.0 max per lane speed is 4Gb/s
+		  SerDer_dyn   /= pciep.clockRate;//covert to energy per clock cycle
+
+		  //Cadence ChipEstimate using 65nm
+		  ctrl_gates       = 200000/8*pciep.num_channels;
+		  //	  frontend_gates   = 120000/8;
+		  SerDer_gates     = 200000/8*pciep.num_channels;
+		  NMOS_sizing 	  = g_tp.min_w_nmos_;
+		  PMOS_sizing	  = g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
+
+	  }
+	  area.set_area(((ctrl_area + (pciep.withPHY? SerDer_area:0))/8*pciep.num_channels)*1e6);
+	  power_t.readOp.dynamic = (ctrl_dyn + (pciep.withPHY? SerDer_dyn:0))*pciep.num_channels;
+	  power_t.readOp.leakage = (ctrl_gates + (pciep.withPHY? SerDer_gates:0))*cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
+	  double long_channel_device_reduction = longer_channel_device_reduction(Uncore_device);
+	  power_t.readOp.longer_channel_leakage = power_t.readOp.leakage * long_channel_device_reduction;
+	  power_t.readOp.gate_leakage = (ctrl_gates + (pciep.withPHY? SerDer_gates:0))*cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
+ }
+
+void PCIeController::computeEnergy(bool is_tdp)
+{
+	if (is_tdp)
+    {
+
+
+		power	= power_t;
+    	power.readOp.dynamic *= pciep.duty_cycle;
+
+    }
+    else
+    {
+    	rt_power = power_t;
+    	rt_power.readOp.dynamic *= pciep.perc_load;
+    }
 }
 
-PCIeController::PCIeController(ParseXML* XML_interface,
-                               InputParameter* interface_ip_)
-    : XML(XML_interface), interface_ip(*interface_ip_) {
-  local_result = init_interface(&interface_ip);
-  double ctrl_area, SerDer_area;
-  double ctrl_dyn, SerDer_dyn;
-  double ctrl_gates, SerDer_gates;
-  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
-  double NMOS_sizing, PMOS_sizing;
+void PCIeController::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
+{
+	string indent_str(indent, ' ');
+	string indent_str_next(indent+2, ' ');
+	bool long_channel = XML->sys.longer_channel_device;
 
-  /* Assuming PCIe is bit-slice based architecture
-   * This is the reason for /8 in both area and power calculation
-   * to get per lane numbers
-   */
+	if (is_tdp)
+	{
+		cout << "PCIe:" << endl;
+		cout << indent_str<< "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
+		cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic*pciep.clockRate  << " W" << endl;
+		cout << indent_str<< "Subthreshold Leakage = "
+			<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
+		//cout << indent_str<< "Subthreshold Leakage = " << power.readOp.longer_channel_leakage <<" W" << endl;
+		cout << indent_str<< "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
+		cout << indent_str << "Runtime Dynamic = " << rt_power.readOp.dynamic*pciep.clockRate << " W" << endl;
+		cout<<endl;
+	}
+	else
+	{
 
-  set_pcie_param();
-  if (pciep.type == 0)  // high performance NIU
-  {
-    // Area estimation based on average of die photo from Niagara 2 and Cadence
-    // ChipEstimate @ 65nm.
-    ctrl_area = (5.2 + 0.5) / 2 * (interface_ip.F_sz_um / 0.065) *
-                (interface_ip.F_sz_um / 0.065);
-    // Area estimation based on average of die photo from Niagara 2, and Cadence
-    // ChipEstimate @ 65nm.
-    // Area estimation based on average of die photo from Niagara 2 and Cadence
-    // ChipEstimate hard IP @65nm.
-    // SerDer is very hard to scale
-    SerDer_area = (3.03 + 0.36) * (interface_ip.F_sz_um /
-                                   0.065);  //* (interface_ip.F_sz_um/0.065);
-    // total area
-    // Power
-    // Cadence ChipEstimate using 65nm the controller includes everything: the
-    // PHY, the data link and transaction layer
-    ctrl_dyn = 3.75e-9 / 8 * g_tp.peri_global.Vdd / 1.1 * g_tp.peri_global.Vdd /
-               1.1 * (interface_ip.F_sz_nm / 65.0);
-    //	  //Cadence ChipEstimate using 65nm soft IP;
-    //	  frontend_dyn =
-    //0.27e-9/8*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);
-    // SerDer_dyn is power not energy, scaling from 10mw/Gb/s @90nm
-    SerDer_dyn = 0.01 * 4 * (interface_ip.F_sz_um / 0.09) *
-                 g_tp.peri_global.Vdd / 1.2 * g_tp.peri_global.Vdd /
-                 1.2;               // PCIe 2.0 max per lane speed is 4Gb/s
-    SerDer_dyn /= pciep.clockRate;  // covert to energy per clock cycle
+	}
 
-    // power_t.readOp.dynamic = (ctrl_dyn)*pciep.num_channels;
-    // Cadence ChipEstimate using 65nm
-    ctrl_gates = 900000 / 8 * pciep.num_channels;
-    //	  frontend_gates   = 120000/8;
-    //	  SerDer_gates     = 200000/8;
-    NMOS_sizing = 5 * g_tp.min_w_nmos_;
-    PMOS_sizing = 5 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r;
-  } else {
-    ctrl_area =
-        0.412 * (interface_ip.F_sz_um / 0.065) * (interface_ip.F_sz_um / 0.065);
-    // Area estimation based on average of die photo from Niagara 2, and Cadence
-    // ChipEstimate @ 65nm.
-    SerDer_area =
-        0.36 * (interface_ip.F_sz_um / 0.065) * (interface_ip.F_sz_um / 0.065);
-    // total area
-    // Power
-    // Cadence ChipEstimate using 65nm the controller includes everything: the
-    // PHY, the data link and transaction layer
-    ctrl_dyn = 2.21e-9 / 8 * g_tp.peri_global.Vdd / 1.1 * g_tp.peri_global.Vdd /
-               1.1 * (interface_ip.F_sz_nm / 65.0);
-    //	  //Cadence ChipEstimate using 65nm soft IP;
-    //	  frontend_dyn =
-    //0.27e-9/8*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);
-    // SerDer_dyn is power not energy, scaling from 10mw/Gb/s @90nm
-    SerDer_dyn = 0.01 * 4 * (interface_ip.F_sz_um / 0.09) *
-                 g_tp.peri_global.Vdd / 1.2 * g_tp.peri_global.Vdd /
-                 1.2;               // PCIe 2.0 max per lane speed is 4Gb/s
-    SerDer_dyn /= pciep.clockRate;  // covert to energy per clock cycle
-
-    // Cadence ChipEstimate using 65nm
-    ctrl_gates = 200000 / 8 * pciep.num_channels;
-    //	  frontend_gates   = 120000/8;
-    SerDer_gates = 200000 / 8 * pciep.num_channels;
-    NMOS_sizing = g_tp.min_w_nmos_;
-    PMOS_sizing = g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r;
-  }
-  area.set_area(((ctrl_area + (pciep.withPHY ? SerDer_area : 0)) / 8 *
-                 pciep.num_channels) *
-                1e6);
-  power_t.readOp.dynamic =
-      (ctrl_dyn + (pciep.withPHY ? SerDer_dyn : 0)) * pciep.num_channels;
-  power_t.readOp.leakage =
-      (ctrl_gates + (pciep.withPHY ? SerDer_gates : 0)) *
-      cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
-      g_tp.peri_global.Vdd;  // unit W
-  double long_channel_device_reduction =
-      longer_channel_device_reduction(Uncore_device);
-  power_t.readOp.longer_channel_leakage =
-      power_t.readOp.leakage * long_channel_device_reduction;
-  power_t.readOp.gate_leakage =
-      (ctrl_gates + (pciep.withPHY ? SerDer_gates : 0)) *
-      cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
-      g_tp.peri_global.Vdd;  // unit W
 }
 
-void PCIeController::computeEnergy(bool is_tdp) {
-  if (is_tdp) {
-    power = power_t;
-    power.readOp.dynamic *= pciep.duty_cycle;
+void PCIeController::set_pcie_param()
+{
+	  pciep.clockRate       = XML->sys.pcie.clockrate;
+	  pciep.clockRate       *= 1e6;
+	  pciep.num_units       = XML->sys.pcie.number_units;
+	  pciep.num_channels    = XML->sys.pcie.num_channels;
+	  pciep.duty_cycle      = XML->sys.pcie.duty_cycle;
+	  pciep.perc_load       = XML->sys.pcie.total_load_perc;
+	  pciep.type            = XML->sys.pcie.type;
+	  pciep.withPHY         = XML->sys.pcie.withPHY;
+//	  pciep.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
 
-  } else {
-    rt_power = power_t;
-    rt_power.readOp.dynamic *= pciep.perc_load;
-  }
 }
 
-void PCIeController::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
-  string indent_str(indent, ' ');
-  string indent_str_next(indent + 2, ' ');
-  bool long_channel = XML->sys.longer_channel_device;
+FlashController::FlashController(ParseXML *XML_interface,InputParameter* interface_ip_)
+:XML(XML_interface),
+ interface_ip(*interface_ip_)
+ {
+	  local_result = init_interface(&interface_ip);
+	  double ctrl_area, SerDer_area;
+      double ctrl_dyn, SerDer_dyn;
+      double ctrl_gates, SerDer_gates;
+	  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
+	  double NMOS_sizing, PMOS_sizing;
 
-  if (is_tdp) {
-    cout << "PCIe:" << endl;
-    cout << indent_str << "Area = " << area.get_area() * 1e-6 << " mm^2"
-         << endl;
-    cout << indent_str
-         << "Peak Dynamic = " << power.readOp.dynamic * pciep.clockRate << " W"
-         << endl;
-    cout << indent_str << "Subthreshold Leakage = "
-         << (long_channel ? power.readOp.longer_channel_leakage
-                          : power.readOp.leakage)
-         << " W" << endl;
-    // cout << indent_str<< "Subthreshold Leakage = " <<
-    // power.readOp.longer_channel_leakage <<" W" << endl;
-    cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W"
-         << endl;
-    cout << indent_str
-         << "Runtime Dynamic = " << rt_power.readOp.dynamic * pciep.clockRate
-         << " W" << endl;
-    cout << endl;
-  } else {
-  }
+	  /* Assuming PCIe is bit-slice based architecture
+	   * This is the reason for /8 in both area and power calculation
+	   * to get per lane numbers
+	   */
+
+	  set_fc_param();
+	  if (fcp.type == 0) //high performance NIU
+	  {
+		  cout<<"Current McPAT does not support high performance flash contorller since even low power designs are enough for maintain throughput"<<endl;
+		  exit(0);
+		  NMOS_sizing 	  = 5*g_tp.min_w_nmos_;
+		  PMOS_sizing	  = 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
+	  }
+	  else
+	  {
+		  ctrl_area   = 0.243 * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);
+		  //Area estimation based on Cadence ChipEstimate @ 65nm: NANDFLASH-CTRL from CAST
+     	  SerDer_area = 0.36/8 * (interface_ip.F_sz_um/0.065)* (interface_ip.F_sz_um/0.065);
+     	  //based On PCIe PHY TSMC65GP from Cadence ChipEstimate @ 65nm, it support 8x lanes with each lane
+     	  //speed up to 250MB/s (PCIe1.1x) This is already saturate the 200MB/s of the flash controller core above.
+		  ctrl_gates      = 129267;
+		  SerDer_gates    = 200000/8;
+		  NMOS_sizing 	  = g_tp.min_w_nmos_;
+		  PMOS_sizing	  = g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
+
+		  //Power
+		  //Cadence ChipEstimate using 65nm the controller 125mW for every 200MB/s This is power not energy!
+		  ctrl_dyn      = 0.125*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(interface_ip.F_sz_nm/65.0);
+		  //SerDer_dyn is power not energy, scaling from 10mw/Gb/s @90nm
+		  SerDer_dyn   = 0.01*1.6*(interface_ip.F_sz_um/0.09)*g_tp.peri_global.Vdd/1.2*g_tp.peri_global.Vdd/1.2;
+		  //max  Per controller speed is 1.6Gb/s (200MB/s)
+	  }
+	  double number_channel = 1+(fcp.num_channels-1)*0.2;
+	  area.set_area((ctrl_area + (fcp.withPHY? SerDer_area:0))*1e6*number_channel);
+	  power_t.readOp.dynamic = (ctrl_dyn + (fcp.withPHY? SerDer_dyn:0))*number_channel;
+	  power_t.readOp.leakage = ((ctrl_gates + (fcp.withPHY? SerDer_gates:0))*number_channel)*cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
+	  double long_channel_device_reduction = longer_channel_device_reduction(Uncore_device);
+	  power_t.readOp.longer_channel_leakage = power_t.readOp.leakage * long_channel_device_reduction;
+	  power_t.readOp.gate_leakage = ((ctrl_gates + (fcp.withPHY? SerDer_gates:0))*number_channel)*cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
+ }
+
+void FlashController::computeEnergy(bool is_tdp)
+{
+	if (is_tdp)
+    {
+
+
+		power	= power_t;
+    	power.readOp.dynamic *= fcp.duty_cycle;
+
+    }
+    else
+    {
+    	rt_power = power_t;
+    	rt_power.readOp.dynamic *= fcp.perc_load;
+    }
 }
 
-void PCIeController::set_pcie_param() {
-  pciep.clockRate = XML->sys.pcie.clockrate;
-  pciep.clockRate *= 1e6;
-  pciep.num_units = XML->sys.pcie.number_units;
-  pciep.num_channels = XML->sys.pcie.num_channels;
-  pciep.duty_cycle = XML->sys.pcie.duty_cycle;
-  pciep.perc_load = XML->sys.pcie.total_load_perc;
-  pciep.type = XML->sys.pcie.type;
-  pciep.withPHY = XML->sys.pcie.withPHY;
-  //	  pciep.executionTime   =
-  //XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
+void FlashController::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
+{
+	string indent_str(indent, ' ');
+	string indent_str_next(indent+2, ' ');
+	bool long_channel = XML->sys.longer_channel_device;
+
+	if (is_tdp)
+	{
+		cout << "Flash Controller:" << endl;
+		cout << indent_str<< "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
+		cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic << " W" << endl;//no multiply of clock since this is power already
+		cout << indent_str<< "Subthreshold Leakage = "
+			<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
+		//cout << indent_str<< "Subthreshold Leakage = " << power.readOp.longer_channel_leakage <<" W" << endl;
+		cout << indent_str<< "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
+		cout << indent_str << "Runtime Dynamic = " << rt_power.readOp.dynamic << " W" << endl;
+		cout<<endl;
+	}
+	else
+	{
+
+	}
+
 }
 
-FlashController::FlashController(ParseXML* XML_interface,
-                                 InputParameter* interface_ip_)
-    : XML(XML_interface), interface_ip(*interface_ip_) {
-  local_result = init_interface(&interface_ip);
-  double ctrl_area, SerDer_area;
-  double ctrl_dyn, SerDer_dyn;
-  double ctrl_gates, SerDer_gates;
-  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
-  double NMOS_sizing, PMOS_sizing;
+void FlashController::set_fc_param()
+{
+//	  fcp.clockRate       = XML->sys.flashc.mc_clock;
+//	  fcp.clockRate       *= 1e6;
+	  fcp.peakDataTransferRate = XML->sys.flashc.peak_transfer_rate;
+	  fcp.num_channels    = ceil(fcp.peakDataTransferRate/200);
+	  fcp.num_mcs         = XML->sys.flashc.number_mcs;
+	  fcp.duty_cycle      = XML->sys.flashc.duty_cycle;
+	  fcp.perc_load       = XML->sys.flashc.total_load_perc;
+	  fcp.type            = XML->sys.flashc.type;
+	  fcp.withPHY         = XML->sys.flashc.withPHY;
+//	  flashcp.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
 
-  /* Assuming PCIe is bit-slice based architecture
-   * This is the reason for /8 in both area and power calculation
-   * to get per lane numbers
-   */
-
-  set_fc_param();
-  if (fcp.type == 0)  // high performance NIU
-  {
-    cout << "Current McPAT does not support high performance flash contorller "
-            "since even low power designs are enough for maintain throughput"
-         << endl;
-    exit(0);
-    NMOS_sizing = 5 * g_tp.min_w_nmos_;
-    PMOS_sizing = 5 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r;
-  } else {
-    ctrl_area =
-        0.243 * (interface_ip.F_sz_um / 0.065) * (interface_ip.F_sz_um / 0.065);
-    // Area estimation based on Cadence ChipEstimate @ 65nm: NANDFLASH-CTRL from
-    // CAST
-    SerDer_area = 0.36 / 8 * (interface_ip.F_sz_um / 0.065) *
-                  (interface_ip.F_sz_um / 0.065);
-    // based On PCIe PHY TSMC65GP from Cadence ChipEstimate @ 65nm, it support
-    // 8x lanes with each lane
-    // speed up to 250MB/s (PCIe1.1x) This is already saturate the 200MB/s of
-    // the flash controller core above.
-    ctrl_gates = 129267;
-    SerDer_gates = 200000 / 8;
-    NMOS_sizing = g_tp.min_w_nmos_;
-    PMOS_sizing = g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r;
-
-    // Power
-    // Cadence ChipEstimate using 65nm the controller 125mW for every 200MB/s
-    // This is power not energy!
-    ctrl_dyn = 0.125 * g_tp.peri_global.Vdd / 1.1 * g_tp.peri_global.Vdd / 1.1 *
-               (interface_ip.F_sz_nm / 65.0);
-    // SerDer_dyn is power not energy, scaling from 10mw/Gb/s @90nm
-    SerDer_dyn = 0.01 * 1.6 * (interface_ip.F_sz_um / 0.09) *
-                 g_tp.peri_global.Vdd / 1.2 * g_tp.peri_global.Vdd / 1.2;
-    // max  Per controller speed is 1.6Gb/s (200MB/s)
-  }
-  double number_channel = 1 + (fcp.num_channels - 1) * 0.2;
-  area.set_area((ctrl_area + (fcp.withPHY ? SerDer_area : 0)) * 1e6 *
-                number_channel);
-  power_t.readOp.dynamic =
-      (ctrl_dyn + (fcp.withPHY ? SerDer_dyn : 0)) * number_channel;
-  power_t.readOp.leakage =
-      ((ctrl_gates + (fcp.withPHY ? SerDer_gates : 0)) * number_channel) *
-      cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
-      g_tp.peri_global.Vdd;  // unit W
-  double long_channel_device_reduction =
-      longer_channel_device_reduction(Uncore_device);
-  power_t.readOp.longer_channel_leakage =
-      power_t.readOp.leakage * long_channel_device_reduction;
-  power_t.readOp.gate_leakage =
-      ((ctrl_gates + (fcp.withPHY ? SerDer_gates : 0)) * number_channel) *
-      cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
-      g_tp.peri_global.Vdd;  // unit W
-}
-
-void FlashController::computeEnergy(bool is_tdp) {
-  if (is_tdp) {
-    power = power_t;
-    power.readOp.dynamic *= fcp.duty_cycle;
-
-  } else {
-    rt_power = power_t;
-    rt_power.readOp.dynamic *= fcp.perc_load;
-  }
-}
-
-void FlashController::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
-  string indent_str(indent, ' ');
-  string indent_str_next(indent + 2, ' ');
-  bool long_channel = XML->sys.longer_channel_device;
-
-  if (is_tdp) {
-    cout << "Flash Controller:" << endl;
-    cout << indent_str << "Area = " << area.get_area() * 1e-6 << " mm^2"
-         << endl;
-    cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic << " W"
-         << endl;  // no multiply of clock since this is power already
-    cout << indent_str << "Subthreshold Leakage = "
-         << (long_channel ? power.readOp.longer_channel_leakage
-                          : power.readOp.leakage)
-         << " W" << endl;
-    // cout << indent_str<< "Subthreshold Leakage = " <<
-    // power.readOp.longer_channel_leakage <<" W" << endl;
-    cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W"
-         << endl;
-    cout << indent_str << "Runtime Dynamic = " << rt_power.readOp.dynamic
-         << " W" << endl;
-    cout << endl;
-  } else {
-  }
-}
-
-void FlashController::set_fc_param() {
-  //	  fcp.clockRate       = XML->sys.flashc.mc_clock;
-  //	  fcp.clockRate       *= 1e6;
-  fcp.peakDataTransferRate = XML->sys.flashc.peak_transfer_rate;
-  fcp.num_channels = ceil(fcp.peakDataTransferRate / 200);
-  fcp.num_mcs = XML->sys.flashc.number_mcs;
-  fcp.duty_cycle = XML->sys.flashc.duty_cycle;
-  fcp.perc_load = XML->sys.flashc.total_load_perc;
-  fcp.type = XML->sys.flashc.type;
-  fcp.withPHY = XML->sys.flashc.withPHY;
-  //	  flashcp.executionTime   =
-  //XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
 }

--- a/src/gpuwattch/iocontrollers.h
+++ b/src/gpuwattch/iocontrollers.h
@@ -31,7 +31,6 @@
 #ifndef IOCONTROLLERS_H_
 #define IOCONTROLLERS_H_
 
-
 #endif /* IOCONTROLLERS_H_ */
 
 #include "XML_Parse.h"
@@ -43,44 +42,43 @@
 #include "basic_components.h"
 
 class NIUController : public Component {
-  public:
-	ParseXML *XML;
-	InputParameter interface_ip;
-    NIUParam  niup;
-    powerDef power_t;
-    uca_org_t local_result;
-    NIUController(ParseXML *XML_interface,InputParameter* interface_ip_);
-    void set_niu_param();
-    void computeEnergy(bool is_tdp=true);
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-    ~NIUController(){};
+ public:
+  ParseXML *XML;
+  InputParameter interface_ip;
+  NIUParam niup;
+  powerDef power_t;
+  uca_org_t local_result;
+  NIUController(ParseXML *XML_interface, InputParameter *interface_ip_);
+  void set_niu_param();
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  ~NIUController(){};
 };
 
 class PCIeController : public Component {
-  public:
-	ParseXML *XML;
-	InputParameter interface_ip;
-    PCIeParam  pciep;
-    powerDef power_t;
-    uca_org_t local_result;
-    PCIeController(ParseXML *XML_interface,InputParameter* interface_ip_);
-    void set_pcie_param();
-    void computeEnergy(bool is_tdp=true);
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-    ~PCIeController(){};
+ public:
+  ParseXML *XML;
+  InputParameter interface_ip;
+  PCIeParam pciep;
+  powerDef power_t;
+  uca_org_t local_result;
+  PCIeController(ParseXML *XML_interface, InputParameter *interface_ip_);
+  void set_pcie_param();
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  ~PCIeController(){};
 };
 
 class FlashController : public Component {
-  public:
-	ParseXML *XML;
-	InputParameter interface_ip;
-    MCParam  fcp;
-    powerDef power_t;
-    uca_org_t local_result;
-    FlashController(ParseXML *XML_interface,InputParameter* interface_ip_);
-    void set_fc_param();
-    void computeEnergy(bool is_tdp=true);
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-    ~FlashController(){};
+ public:
+  ParseXML *XML;
+  InputParameter interface_ip;
+  MCParam fcp;
+  powerDef power_t;
+  uca_org_t local_result;
+  FlashController(ParseXML *XML_interface, InputParameter *interface_ip_);
+  void set_fc_param();
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  ~FlashController(){};
 };
-

--- a/src/gpuwattch/iocontrollers.h
+++ b/src/gpuwattch/iocontrollers.h
@@ -31,6 +31,7 @@
 #ifndef IOCONTROLLERS_H_
 #define IOCONTROLLERS_H_
 
+
 #endif /* IOCONTROLLERS_H_ */
 
 #include "XML_Parse.h"
@@ -42,43 +43,44 @@
 #include "basic_components.h"
 
 class NIUController : public Component {
- public:
-  ParseXML *XML;
-  InputParameter interface_ip;
-  NIUParam niup;
-  powerDef power_t;
-  uca_org_t local_result;
-  NIUController(ParseXML *XML_interface, InputParameter *interface_ip_);
-  void set_niu_param();
-  void computeEnergy(bool is_tdp = true);
-  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
-  ~NIUController(){};
+  public:
+	ParseXML *XML;
+	InputParameter interface_ip;
+    NIUParam  niup;
+    powerDef power_t;
+    uca_org_t local_result;
+    NIUController(ParseXML *XML_interface,InputParameter* interface_ip_);
+    void set_niu_param();
+    void computeEnergy(bool is_tdp=true);
+    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
+    ~NIUController(){};
 };
 
 class PCIeController : public Component {
- public:
-  ParseXML *XML;
-  InputParameter interface_ip;
-  PCIeParam pciep;
-  powerDef power_t;
-  uca_org_t local_result;
-  PCIeController(ParseXML *XML_interface, InputParameter *interface_ip_);
-  void set_pcie_param();
-  void computeEnergy(bool is_tdp = true);
-  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
-  ~PCIeController(){};
+  public:
+	ParseXML *XML;
+	InputParameter interface_ip;
+    PCIeParam  pciep;
+    powerDef power_t;
+    uca_org_t local_result;
+    PCIeController(ParseXML *XML_interface,InputParameter* interface_ip_);
+    void set_pcie_param();
+    void computeEnergy(bool is_tdp=true);
+    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
+    ~PCIeController(){};
 };
 
 class FlashController : public Component {
- public:
-  ParseXML *XML;
-  InputParameter interface_ip;
-  MCParam fcp;
-  powerDef power_t;
-  uca_org_t local_result;
-  FlashController(ParseXML *XML_interface, InputParameter *interface_ip_);
-  void set_fc_param();
-  void computeEnergy(bool is_tdp = true);
-  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
-  ~FlashController(){};
+  public:
+	ParseXML *XML;
+	InputParameter interface_ip;
+    MCParam  fcp;
+    powerDef power_t;
+    uca_org_t local_result;
+    FlashController(ParseXML *XML_interface,InputParameter* interface_ip_);
+    void set_fc_param();
+    void computeEnergy(bool is_tdp=true);
+    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
+    ~FlashController(){};
 };
+

--- a/src/gpuwattch/logic.cc
+++ b/src/gpuwattch/logic.cc
@@ -29,217 +29,256 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:												   *
-*      Jingwen Leng, Univeristy of Texas, Austin                   *
-*      Syed Gilani, University of Wisconsin–Madison                *
-*      Tayler Hetherington, University of British Columbia         *
-*      Ahmed ElTantawy, University of British Columbia             *
-********************************************************************/
+ *      Modified by:
+ ** Jingwen Leng, Univeristy of Texas, Austin                   * Syed Gilani,
+ *University of Wisconsin–Madison                * Tayler Hetherington,
+ *University of British Columbia         * Ahmed ElTantawy, University of
+ *British Columbia             *
+ ********************************************************************/
 #include "logic.h"
-#define SP_BASE_POWER 0 
+#define SP_BASE_POWER 0
 #define SFU_BASE_POWER 0
 //.67
 
-//extern double exClockRate;
-//selection_logic
-selection_logic::selection_logic(
-    bool   _is_default,
-    int    win_entries_,
-    int    issue_width_,
-    const InputParameter *configure_interface,
-    enum Device_ty device_ty_,
-    enum Core_type core_ty_)
-    //const ParseXML *_XML_interface)
- :is_default(_is_default),
-  win_entries(win_entries_),
-  issue_width(issue_width_),
-  device_ty(device_ty_),
-  core_ty(core_ty_)
- {
-    	//uca_org_t result2;
-    	l_ip=*configure_interface;
-    	local_result = init_interface(&l_ip);
-    	//init_tech_params(l_ip.F_sz_um, false);
-    	//win_entries=numIBEntries;//IQentries;
-		//issue_width=issueWidth;
-    	selection_power();
-    	double sckRation = g_tp.sckt_co_eff;
-    	power.readOp.dynamic *= sckRation;
-    	power.writeOp.dynamic *= sckRation;
-    	power.searchOp.dynamic *= sckRation;
+// extern double exClockRate;
+// selection_logic
+selection_logic::selection_logic(bool _is_default, int win_entries_,
+                                 int issue_width_,
+                                 const InputParameter *configure_interface,
+                                 enum Device_ty device_ty_,
+                                 enum Core_type core_ty_)
+    // const ParseXML *_XML_interface)
+    : is_default(_is_default),
+      win_entries(win_entries_),
+      issue_width(issue_width_),
+      device_ty(device_ty_),
+      core_ty(core_ty_) {
+  // uca_org_t result2;
+  l_ip = *configure_interface;
+  local_result = init_interface(&l_ip);
+  // init_tech_params(l_ip.F_sz_um, false);
+  // win_entries=numIBEntries;//IQentries;
+  // issue_width=issueWidth;
+  selection_power();
+  double sckRation = g_tp.sckt_co_eff;
+  power.readOp.dynamic *= sckRation;
+  power.writeOp.dynamic *= sckRation;
+  power.searchOp.dynamic *= sckRation;
 
-    	double long_channel_device_reduction = longer_channel_device_reduction(device_ty,core_ty);
-    	power.readOp.longer_channel_leakage	= power.readOp.leakage*long_channel_device_reduction;
-	 }
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(device_ty, core_ty);
+  power.readOp.longer_channel_leakage =
+      power.readOp.leakage * long_channel_device_reduction;
+}
 
-void selection_logic::selection_power()
-{//based on cost effective superscalar processor TR pp27-31
+void selection_logic::selection_power() {  // based on cost effective
+                                           // superscalar processor TR pp27-31
   double Ctotal, Cor, Cpencode;
   int num_arbiter;
   double WSelORn, WSelORprequ, WSelPn, WSelPp, WSelEnn, WSelEnp;
 
-  //TODO: the 0.8um process data is used.
-  WSelORn    	=  	12.5 * l_ip.F_sz_um;//this was 10 micron for the 0.8 micron process
-  WSelORprequ   = 	50 * l_ip.F_sz_um;//this was 40 micron for the 0.8 micron process
-  WSelPn     	= 	12.5 * l_ip.F_sz_um;//this was 10mcron for the 0.8 micron process
-  WSelPp     	=  	18.75 * l_ip.F_sz_um;//this was 15 micron for the 0.8 micron process
-  WSelEnn    	=  	6.25 * l_ip.F_sz_um;//this was 5 micron for the 0.8 micron process
-  WSelEnp    	=  	12.5 * l_ip.F_sz_um;//this was 10 micron for the 0.8 micron process
+  // TODO: the 0.8um process data is used.
+  WSelORn =
+      12.5 * l_ip.F_sz_um;  // this was 10 micron for the 0.8 micron process
+  WSelORprequ =
+      50 * l_ip.F_sz_um;  // this was 40 micron for the 0.8 micron process
+  WSelPn = 12.5 * l_ip.F_sz_um;  // this was 10mcron for the 0.8 micron process
+  WSelPp =
+      18.75 * l_ip.F_sz_um;  // this was 15 micron for the 0.8 micron process
+  WSelEnn = 6.25 * l_ip.F_sz_um;  // this was 5 micron for the 0.8 micron
+                                  // process
+  WSelEnp =
+      12.5 * l_ip.F_sz_um;  // this was 10 micron for the 0.8 micron process
 
+  Ctotal = 0;
+  num_arbiter = 1;
+  while (win_entries > 4) {
+    win_entries = (int)ceil((double)win_entries / 4.0);
+    num_arbiter += win_entries;
+  }
+  // the 4-input OR logic to generate anyreq
+  Cor = 4 * drain_C_(WSelORn, NCH, 1, 1, g_tp.cell_h_def) +
+        drain_C_(WSelORprequ, PCH, 1, 1, g_tp.cell_h_def);
+  power.readOp.gate_leakage =
+      cmos_Ig_leakage(WSelORn, WSelORprequ, 4, nor) * g_tp.peri_global.Vdd;
 
-  Ctotal=0;
-  num_arbiter=1;
-  while(win_entries > 4)
-    {
-      win_entries = (int)ceil((double)win_entries / 4.0);
-      num_arbiter += win_entries;
-    }
-  //the 4-input OR logic to generate anyreq
-  Cor = 4 * drain_C_(WSelORn,NCH,1,1, g_tp.cell_h_def) + drain_C_(WSelORprequ,PCH,1,1, g_tp.cell_h_def);
-  power.readOp.gate_leakage = cmos_Ig_leakage(WSelORn, WSelORprequ, 4, nor)*g_tp.peri_global.Vdd;
+  // The total capacity of the 4-bit priority encoder
+  Cpencode =
+      drain_C_(WSelPn, NCH, 1, 1, g_tp.cell_h_def) +
+      drain_C_(WSelPp, PCH, 1, 1, g_tp.cell_h_def) +
+      2 * drain_C_(WSelPn, NCH, 1, 1, g_tp.cell_h_def) +
+      drain_C_(WSelPp, PCH, 2, 1, g_tp.cell_h_def) +
+      3 * drain_C_(WSelPn, NCH, 1, 1, g_tp.cell_h_def) +
+      drain_C_(WSelPp, PCH, 3, 1, g_tp.cell_h_def) +
+      4 * drain_C_(WSelPn, NCH, 1, 1, g_tp.cell_h_def) +
+      drain_C_(WSelPp, PCH, 4, 1,
+               g_tp.cell_h_def) +  // precompute priority logic
+      2 * 4 * gate_C(WSelEnn + WSelEnp, 20.0) +
+      4 * drain_C_(WSelEnn, NCH, 1, 1, g_tp.cell_h_def) +
+      2 * 4 * drain_C_(WSelEnp, PCH, 1, 1, g_tp.cell_h_def) +  // enable logic
+      (2 * 4 + 2 * 3 + 2 * 2 + 2) *
+          gate_C(WSelPn + WSelPp, 10.0);  // requests signal
 
-  //The total capacity of the 4-bit priority encoder
-  Cpencode = drain_C_(WSelPn,NCH,1, 1, g_tp.cell_h_def) + drain_C_(WSelPp,PCH,1, 1, g_tp.cell_h_def) +
-    2*drain_C_(WSelPn,NCH,1, 1, g_tp.cell_h_def) + drain_C_(WSelPp,PCH,2, 1, g_tp.cell_h_def) +
-    3*drain_C_(WSelPn,NCH,1, 1, g_tp.cell_h_def) + drain_C_(WSelPp,PCH,3, 1, g_tp.cell_h_def) +
-    4*drain_C_(WSelPn,NCH,1, 1, g_tp.cell_h_def) + drain_C_(WSelPp,PCH,4, 1, g_tp.cell_h_def) +//precompute priority logic
-    2*4*gate_C(WSelEnn+WSelEnp,20.0)+
-    4*drain_C_(WSelEnn,NCH,1, 1, g_tp.cell_h_def) + 2*4*drain_C_(WSelEnp,PCH,1, 1, g_tp.cell_h_def)+//enable logic
-    (2*4+2*3+2*2+2)*gate_C(WSelPn+WSelPp,10.0);//requests signal
+  Ctotal += issue_width * num_arbiter * (Cor + Cpencode);
 
-  Ctotal += issue_width * num_arbiter*(Cor+Cpencode);
-
-  power.readOp.dynamic = Ctotal*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*2;//2 means the abitration signal need to travel round trip
-  power.readOp.leakage = issue_width * num_arbiter *
-      (cmos_Isub_leakage(WSelPn, WSelPp, 2, nor)/*approximate precompute with a nor gate*///grant1p
-       + cmos_Isub_leakage(WSelPn, WSelPp, 3, nor)//grant2p
-       + cmos_Isub_leakage(WSelPn, WSelPp, 4, nor)//grant3p
-       + cmos_Isub_leakage(WSelEnn, WSelEnp, 2, nor)*4//enable logic
-       + cmos_Isub_leakage(WSelEnn, WSelEnp, 1, inv)*2*3//for each grant there are two inverters, there are 3 grant sIsubnals
-		  )*g_tp.peri_global.Vdd;
-  power.readOp.gate_leakage = issue_width * num_arbiter *
-      (cmos_Ig_leakage(WSelPn, WSelPp, 2, nor)/*approximate precompute with a nor gate*///grant1p
-       + cmos_Ig_leakage(WSelPn, WSelPp, 3, nor)//grant2p
-       + cmos_Ig_leakage(WSelPn, WSelPp, 4, nor)//grant3p
-       + cmos_Ig_leakage(WSelEnn, WSelEnp, 2, nor)*4//enable logic
-       + cmos_Ig_leakage(WSelEnn, WSelEnp, 1, inv)*2*3//for each grant there are two inverters, there are 3 grant signals
-        )*g_tp.peri_global.Vdd;
+  power.readOp.dynamic =
+      Ctotal * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd *
+      2;  // 2 means the abitration signal need to travel round trip
+  power.readOp.leakage =
+      issue_width * num_arbiter *
+      (cmos_Isub_leakage(
+           WSelPn, WSelPp, 2,
+           nor) /*approximate precompute with a nor gate*/  // grant1p
+       + cmos_Isub_leakage(WSelPn, WSelPp, 3, nor)          // grant2p
+       + cmos_Isub_leakage(WSelPn, WSelPp, 4, nor)          // grant3p
+       + cmos_Isub_leakage(WSelEnn, WSelEnp, 2, nor) * 4    // enable logic
+       + cmos_Isub_leakage(WSelEnn, WSelEnp, 1, inv) * 2 *
+             3  // for each grant there are two inverters, there are 3 grant
+                // sIsubnals
+       ) *
+      g_tp.peri_global.Vdd;
+  power.readOp.gate_leakage =
+      issue_width * num_arbiter *
+      (cmos_Ig_leakage(
+           WSelPn, WSelPp, 2,
+           nor) /*approximate precompute with a nor gate*/  // grant1p
+       + cmos_Ig_leakage(WSelPn, WSelPp, 3, nor)            // grant2p
+       + cmos_Ig_leakage(WSelPn, WSelPp, 4, nor)            // grant3p
+       + cmos_Ig_leakage(WSelEnn, WSelEnp, 2, nor) * 4      // enable logic
+       + cmos_Ig_leakage(WSelEnn, WSelEnp, 1, inv) * 2 *
+             3  // for each grant there are two inverters, there are 3 grant
+                // signals
+       ) *
+      g_tp.peri_global.Vdd;
 }
-
 
 dep_resource_conflict_check::dep_resource_conflict_check(
-	const InputParameter *configure_interface,
-	const CoreDynParam & dyn_p_,
-	int   compare_bits_,
-    bool   _is_default)
- :  l_ip(*configure_interface),
-    coredynp(dyn_p_),
-    compare_bits(compare_bits_),
-	is_default(_is_default)
-{
-    	Wcompn    	=  	25 * l_ip.F_sz_um;//this was 20.0 micron for the 0.8 micron process
-    	Wevalinvp   = 	25 * l_ip.F_sz_um;//this was 20.0 micron for the 0.8 micron process
-    	Wevalinvn   = 	100 * l_ip.F_sz_um;//this was 80.0 mcron for the 0.8 micron process
-    	Wcomppreequ =  	50 * l_ip.F_sz_um;//this was 40.0  micron for the 0.8 micron process
-    	WNORn    	=  	6.75 * l_ip.F_sz_um;//this was 5.4 micron for the 0.8 micron process
-    	WNORp    	=  	38.125 * l_ip.F_sz_um;//this was 30.5 micron for the 0.8 micron process
+    const InputParameter *configure_interface, const CoreDynParam &dyn_p_,
+    int compare_bits_, bool _is_default)
+    : l_ip(*configure_interface),
+      coredynp(dyn_p_),
+      compare_bits(compare_bits_),
+      is_default(_is_default) {
+  Wcompn = 25 * l_ip.F_sz_um;  // this was 20.0 micron for the 0.8 micron
+                               // process
+  Wevalinvp =
+      25 * l_ip.F_sz_um;  // this was 20.0 micron for the 0.8 micron process
+  Wevalinvn =
+      100 * l_ip.F_sz_um;  // this was 80.0 mcron for the 0.8 micron process
+  Wcomppreequ =
+      50 * l_ip.F_sz_um;  // this was 40.0  micron for the 0.8 micron process
+  WNORn = 6.75 * l_ip.F_sz_um;  // this was 5.4 micron for the 0.8 micron
+                                // process
+  WNORp =
+      38.125 * l_ip.F_sz_um;  // this was 30.5 micron for the 0.8 micron process
 
-    	local_result = init_interface(&l_ip);
+  local_result = init_interface(&l_ip);
 
-    	if (coredynp.core_ty==Inorder)
-   		    compare_bits += 16 + 8 + 8;//TODO: opcode bits + log(shared resources) + REG TAG BITS-->opcode comparator
-    	else
-    		compare_bits += 16 + 8 + 8;
+  if (coredynp.core_ty == Inorder)
+    compare_bits += 16 + 8 + 8;  // TODO: opcode bits + log(shared resources) +
+                                 // REG TAG BITS-->opcode comparator
+  else
+    compare_bits += 16 + 8 + 8;
 
-   		conflict_check_power();
-    	double sckRation = g_tp.sckt_co_eff;
-    	power.readOp.dynamic *= sckRation;
-    	power.writeOp.dynamic *= sckRation;
-    	power.searchOp.dynamic *= sckRation;
-
+  conflict_check_power();
+  double sckRation = g_tp.sckt_co_eff;
+  power.readOp.dynamic *= sckRation;
+  power.writeOp.dynamic *= sckRation;
+  power.searchOp.dynamic *= sckRation;
 }
 
-void dep_resource_conflict_check::conflict_check_power()
-{
-	double Ctotal;
-	int num_comparators;
-	num_comparators = 3*((coredynp.decodeW) * (coredynp.decodeW)-coredynp.decodeW);//2(N*N-N) is used for source to dest comparison, (N*N-N) is used for dest to dest comparision.
-	//When decode-width ==1, no dcl logic
+void dep_resource_conflict_check::conflict_check_power() {
+  double Ctotal;
+  int num_comparators;
+  num_comparators =
+      3 *
+      ((coredynp.decodeW) * (coredynp.decodeW) -
+       coredynp.decodeW);  // 2(N*N-N) is used for source to dest comparison,
+                           // (N*N-N) is used for dest to dest comparision.
+  // When decode-width ==1, no dcl logic
 
-	Ctotal = num_comparators * compare_cap();
-	//printf("%i,%s\n",XML_interface->sys.core[0].predictor.predictor_entries,XML_interface->sys.core[0].predictor.prediction_scheme);
+  Ctotal = num_comparators * compare_cap();
+  // printf("%i,%s\n",XML_interface->sys.core[0].predictor.predictor_entries,XML_interface->sys.core[0].predictor.prediction_scheme);
 
-	power.readOp.dynamic=Ctotal*/*CLOCKRATE*/g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/*AF*/;
-	power.readOp.leakage=num_comparators*compare_bits*2*simplified_nmos_leakage(Wcompn,  false);
+  power.readOp.dynamic =
+      Ctotal * /*CLOCKRATE*/ g_tp.peri_global.Vdd * g_tp.peri_global.Vdd /*AF*/;
+  power.readOp.leakage = num_comparators * compare_bits * 2 *
+                         simplified_nmos_leakage(Wcompn, false);
 
-	double long_channel_device_reduction = longer_channel_device_reduction(Core_device, coredynp.core_ty);
-	power.readOp.longer_channel_leakage	= power.readOp.leakage*long_channel_device_reduction;
-	power.readOp.gate_leakage=num_comparators*compare_bits*2*cmos_Ig_leakage(Wcompn, 0, 2, nmos);
-
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(Core_device, coredynp.core_ty);
+  power.readOp.longer_channel_leakage =
+      power.readOp.leakage * long_channel_device_reduction;
+  power.readOp.gate_leakage =
+      num_comparators * compare_bits * 2 * cmos_Ig_leakage(Wcompn, 0, 2, nmos);
 }
 
 /* estimate comparator power consumption (this comparator is similar
    to the tag-match structure in a CAM */
-double dep_resource_conflict_check::compare_cap()
-{
+double dep_resource_conflict_check::compare_cap() {
   double c1, c2;
 
-  WNORp = WNORp * compare_bits/2.0;//resize the big NOR gate at the DCL according to fan in.
+  WNORp = WNORp * compare_bits /
+          2.0;  // resize the big NOR gate at the DCL according to fan in.
   /* bottom part of comparator */
-  c2 = (compare_bits)*(drain_C_(Wcompn,NCH,1,1, g_tp.cell_h_def)+drain_C_(Wcompn,NCH,2,1, g_tp.cell_h_def))+
-  drain_C_(Wevalinvp,PCH,1,1, g_tp.cell_h_def) + drain_C_(Wevalinvn,NCH,1,1, g_tp.cell_h_def);
+  c2 = (compare_bits) * (drain_C_(Wcompn, NCH, 1, 1, g_tp.cell_h_def) +
+                         drain_C_(Wcompn, NCH, 2, 1, g_tp.cell_h_def)) +
+       drain_C_(Wevalinvp, PCH, 1, 1, g_tp.cell_h_def) +
+       drain_C_(Wevalinvn, NCH, 1, 1, g_tp.cell_h_def);
 
   /* top part of comparator */
-  c1 = (compare_bits)*(drain_C_(Wcompn,NCH,1,1, g_tp.cell_h_def)+drain_C_(Wcompn,NCH,2,1, g_tp.cell_h_def)+
-		  drain_C_(Wcomppreequ,NCH,1,1, g_tp.cell_h_def)) +  gate_C(WNORn + WNORp,10.0) +
-		  drain_C_(WNORp,NCH,2,1, g_tp.cell_h_def) + compare_bits*drain_C_(WNORn,NCH,2,1, g_tp.cell_h_def);
-  return(c1 + c2);
-
+  c1 = (compare_bits) * (drain_C_(Wcompn, NCH, 1, 1, g_tp.cell_h_def) +
+                         drain_C_(Wcompn, NCH, 2, 1, g_tp.cell_h_def) +
+                         drain_C_(Wcomppreequ, NCH, 1, 1, g_tp.cell_h_def)) +
+       gate_C(WNORn + WNORp, 10.0) +
+       drain_C_(WNORp, NCH, 2, 1, g_tp.cell_h_def) +
+       compare_bits * drain_C_(WNORn, NCH, 2, 1, g_tp.cell_h_def);
+  return (c1 + c2);
 }
 
-void dep_resource_conflict_check::leakage_feedback(double temperature)
-{
-  l_ip.temp = (unsigned int)round(temperature/10.0)*10;
-  uca_org_t init_result = init_interface(&l_ip); // init_result is dummy
+void dep_resource_conflict_check::leakage_feedback(double temperature) {
+  l_ip.temp = (unsigned int)round(temperature / 10.0) * 10;
+  uca_org_t init_result = init_interface(&l_ip);  // init_result is dummy
 
   // This is part of conflict_check_power()
-  int num_comparators = 3*((coredynp.decodeW) * (coredynp.decodeW)-coredynp.decodeW);//2(N*N-N) is used for source to dest comparison, (N*N-N) is used for dest to dest comparision.
-  power.readOp.leakage=num_comparators*compare_bits*2*simplified_nmos_leakage(Wcompn,  false);
+  int num_comparators =
+      3 *
+      ((coredynp.decodeW) * (coredynp.decodeW) -
+       coredynp.decodeW);  // 2(N*N-N) is used for source to dest comparison,
+                           // (N*N-N) is used for dest to dest comparision.
+  power.readOp.leakage = num_comparators * compare_bits * 2 *
+                         simplified_nmos_leakage(Wcompn, false);
 
-  double long_channel_device_reduction = longer_channel_device_reduction(Core_device, coredynp.core_ty);
-  power.readOp.longer_channel_leakage	= power.readOp.leakage*long_channel_device_reduction;
-  power.readOp.gate_leakage=num_comparators*compare_bits*2*cmos_Ig_leakage(Wcompn, 0, 2, nmos);
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(Core_device, coredynp.core_ty);
+  power.readOp.longer_channel_leakage =
+      power.readOp.leakage * long_channel_device_reduction;
+  power.readOp.gate_leakage =
+      num_comparators * compare_bits * 2 * cmos_Ig_leakage(Wcompn, 0, 2, nmos);
 }
 
-//TODO: add inverter and transmission gate base DFF.
+// TODO: add inverter and transmission gate base DFF.
 
-DFFCell::DFFCell(
-		bool _is_dram,
-		double _WdecNANDn,
-		double _WdecNANDp,
-		double _cell_load,
-		const InputParameter *configure_interface)
-:is_dram(_is_dram),
-cell_load(_cell_load),
-WdecNANDn(_WdecNANDn),
-WdecNANDp(_WdecNANDp)
-{//this model is based on the NAND2 based DFF.
-			l_ip=*configure_interface;
-//			area.set_area(730*l_ip.F_sz_um*l_ip.F_sz_um);
-			area.set_area(5*compute_gate_area(NAND, 2,WdecNANDn,WdecNANDp, g_tp.cell_h_def)
-				+ compute_gate_area(NAND, 2,WdecNANDn,WdecNANDn, g_tp.cell_h_def));
-
-
+DFFCell::DFFCell(bool _is_dram, double _WdecNANDn, double _WdecNANDp,
+                 double _cell_load, const InputParameter *configure_interface)
+    : is_dram(_is_dram),
+      cell_load(_cell_load),
+      WdecNANDn(_WdecNANDn),
+      WdecNANDp(_WdecNANDp) {  // this model is based on the NAND2 based DFF.
+  l_ip = *configure_interface;
+  //			area.set_area(730*l_ip.F_sz_um*l_ip.F_sz_um);
+  area.set_area(
+      5 * compute_gate_area(NAND, 2, WdecNANDn, WdecNANDp, g_tp.cell_h_def) +
+      compute_gate_area(NAND, 2, WdecNANDn, WdecNANDn, g_tp.cell_h_def));
 }
 
-
-double DFFCell::fpfp_node_cap(unsigned int fan_in, unsigned int fan_out)
-{
+double DFFCell::fpfp_node_cap(unsigned int fan_in, unsigned int fan_out) {
   double Ctotal = 0;
-  //printf("WdecNANDn = %E\n", WdecNANDn);
+  // printf("WdecNANDn = %E\n", WdecNANDn);
 
   /* part 1: drain cap of NAND gate */
-  Ctotal += drain_C_(WdecNANDn, NCH, 2, 1, g_tp.cell_h_def, is_dram) + fan_in * drain_C_(WdecNANDp, PCH, 1, 1, g_tp.cell_h_def, is_dram);
+  Ctotal += drain_C_(WdecNANDn, NCH, 2, 1, g_tp.cell_h_def, is_dram) +
+            fan_in * drain_C_(WdecNANDp, PCH, 1, 1, g_tp.cell_h_def, is_dram);
 
   /* part 2: gate cap of NAND gates */
   Ctotal += fan_out * gate_C(WdecNANDn + WdecNANDp, 0, is_dram);
@@ -247,838 +286,1071 @@ double DFFCell::fpfp_node_cap(unsigned int fan_in, unsigned int fan_out)
   return Ctotal;
 }
 
+void DFFCell::compute_DFF_cell() {
+  double c1, c2, c3, c4, c5, c6;
+  /* node 5 and node 6 are identical to node 1 in capacitance */
+  c1 = c5 = c6 = fpfp_node_cap(2, 1);
+  c2 = fpfp_node_cap(2, 3);
+  c3 = fpfp_node_cap(3, 2);
+  c4 = fpfp_node_cap(2, 2);
 
-void DFFCell::compute_DFF_cell()
-{
-	double c1, c2, c3, c4, c5, c6;
-	   /* node 5 and node 6 are identical to node 1 in capacitance */
-	   c1 = c5 = c6 = fpfp_node_cap(2, 1);
-	   c2 = fpfp_node_cap(2, 3);
-	   c3 = fpfp_node_cap(3, 2);
-	   c4 = fpfp_node_cap(2, 2);
+  // cap-load of the clock signal in each Dff, actually the clock signal only
+  // connected to one NAND2
+  clock_cap = 2 * gate_C(WdecNANDn + WdecNANDp, 0, is_dram);
+  e_switch.readOp.dynamic += (c4 + c1 + c2 + c3 + c5 + c6 + 2 * cell_load) *
+                             0.5 * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd;
+  ;
 
-	   //cap-load of the clock signal in each Dff, actually the clock signal only connected to one NAND2
-	   clock_cap= 2 * gate_C(WdecNANDn + WdecNANDp, 0, is_dram);
-	   e_switch.readOp.dynamic += (c4 + c1 + c2 + c3 + c5 + c6 + 2*cell_load)*0.5*g_tp.peri_global.Vdd * g_tp.peri_global.Vdd;;
+  /* no 1/2 for e_keep and e_clock because clock signal switches twice in one
+   * cycle */
+  e_keep_1.readOp.dynamic += c3 * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd;
+  e_keep_0.readOp.dynamic += c2 * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd;
+  e_clock.readOp.dynamic +=
+      clock_cap * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd;
+  ;
 
-	   /* no 1/2 for e_keep and e_clock because clock signal switches twice in one cycle */
-	   e_keep_1.readOp.dynamic += c3 * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd ;
-	   e_keep_0.readOp.dynamic += c2 * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd ;
-	   e_clock.readOp.dynamic += clock_cap* g_tp.peri_global.Vdd * g_tp.peri_global.Vdd;;
-
-	   /* static power */
-	   e_switch.readOp.leakage +=  (cmos_Isub_leakage(WdecNANDn, WdecNANDp, 2, nand)*5//5 NAND2 and 1 NAND3 in a DFF
-                                           + cmos_Isub_leakage(WdecNANDn, WdecNANDn, 3, nand))*g_tp.peri_global.Vdd;
-	   e_switch.readOp.gate_leakage += (cmos_Ig_leakage(WdecNANDn, WdecNANDp, 2, nand)*5//5 NAND2 and 1 NAND3 in a DFF
-                                           + cmos_Ig_leakage(WdecNANDn, WdecNANDn, 3, nand))*g_tp.peri_global.Vdd;
-	   //printf("leakage =%E\n",cmos_Ileak(1, is_dram) );
+  /* static power */
+  e_switch.readOp.leakage +=
+      (cmos_Isub_leakage(WdecNANDn, WdecNANDp, 2, nand) *
+           5  // 5 NAND2 and 1 NAND3 in a DFF
+       + cmos_Isub_leakage(WdecNANDn, WdecNANDn, 3, nand)) *
+      g_tp.peri_global.Vdd;
+  e_switch.readOp.gate_leakage +=
+      (cmos_Ig_leakage(WdecNANDn, WdecNANDp, 2, nand) *
+           5  // 5 NAND2 and 1 NAND3 in a DFF
+       + cmos_Ig_leakage(WdecNANDn, WdecNANDn, 3, nand)) *
+      g_tp.peri_global.Vdd;
+  // printf("leakage =%E\n",cmos_Ileak(1, is_dram) );
 }
 
-Pipeline::Pipeline(
-		const InputParameter *configure_interface,
-		const CoreDynParam & dyn_p_,
-		enum Device_ty device_ty_,
-		bool _is_core_pipeline,
-		bool _is_default)
-: l_ip(*configure_interface),
-  coredynp(dyn_p_),
-  device_ty(device_ty_),
-  is_core_pipeline(_is_core_pipeline),
-  is_default(_is_default),
-  num_piperegs(0.0)
+Pipeline::Pipeline(const InputParameter *configure_interface,
+                   const CoreDynParam &dyn_p_, enum Device_ty device_ty_,
+                   bool _is_core_pipeline, bool _is_default)
+    : l_ip(*configure_interface),
+      coredynp(dyn_p_),
+      device_ty(device_ty_),
+      is_core_pipeline(_is_core_pipeline),
+      is_default(_is_default),
+      num_piperegs(0.0)
 
-  {
-	local_result = init_interface(&l_ip);
-	if (!coredynp.Embedded)
-		process_ind = true;
-	else
-		process_ind = false;
-	WNANDn = (process_ind)? 25 *   l_ip.F_sz_um : g_tp.min_w_nmos_ ;//this was  20 micron for the 0.8 micron process
-	WNANDp = (process_ind)? 37.5 * l_ip.F_sz_um : g_tp.min_w_nmos_*pmos_to_nmos_sz_ratio();//this was  30 micron for the 0.8 micron process
-	load_per_pipeline_stage = 2*gate_C(WNANDn + WNANDp, 0, false);
-	compute();
-
-}
-
-void Pipeline::compute()
 {
-	compute_stage_vector();
-	DFFCell pipe_reg(false, WNANDn,WNANDp, load_per_pipeline_stage, &l_ip);
-	pipe_reg.compute_DFF_cell();
-
-	double clock_power_pipereg = num_piperegs * pipe_reg.e_clock.readOp.dynamic;
-	//******************pipeline power: currently, we average all the possibilities of the states of DFFs in the pipeline. A better way to do it is to consider
-	//the harming distance of two consecutive signals, However McPAT does not have plan to do this in near future as it focuses on worst case power.
-	double pipe_reg_power = num_piperegs * (pipe_reg.e_switch.readOp.dynamic+pipe_reg.e_keep_0.readOp.dynamic+pipe_reg.e_keep_1.readOp.dynamic)/3+clock_power_pipereg;
-	double pipe_reg_leakage = num_piperegs * pipe_reg.e_switch.readOp.leakage;
-	double pipe_reg_gate_leakage = num_piperegs * pipe_reg.e_switch.readOp.gate_leakage;
-	power.readOp.dynamic	+=pipe_reg_power;
-	power.readOp.leakage	+=pipe_reg_leakage;
-	power.readOp.gate_leakage	+=pipe_reg_gate_leakage;
-	area.set_area(num_piperegs * pipe_reg.area.get_area());
-
-	double long_channel_device_reduction = longer_channel_device_reduction(device_ty, coredynp.core_ty);
-	power.readOp.longer_channel_leakage	= power.readOp.leakage*long_channel_device_reduction;
-
-
-	double sckRation = g_tp.sckt_co_eff;
-	power.readOp.dynamic *= sckRation;
-	power.writeOp.dynamic *= sckRation;
-	power.searchOp.dynamic *= sckRation;
-	double macro_layout_overhead = g_tp.macro_layout_overhead;
-	if (!coredynp.Embedded)
-		area.set_area(area.get_area()*macro_layout_overhead);
-}
-
-void Pipeline::compute_stage_vector()
-{
-	double num_stages, tot_stage_vector, per_stage_vector;
-	int opcode_length = coredynp.x86? coredynp.micro_opcode_length:coredynp.opcode_length;
-	//Hthread = thread_clock_gated? 1:num_thread;
-
-  if (!is_core_pipeline)
-  {
-	num_piperegs=l_ip.pipeline_stages*l_ip.per_stage_vector;//The number of pipeline stages are calculated based on the achievable throughput and required throughput
-  }
+  local_result = init_interface(&l_ip);
+  if (!coredynp.Embedded)
+    process_ind = true;
   else
-  {
-	if (coredynp.core_ty==Inorder)
-	{
-		/* assume 6 pipe stages and try to estimate bits per pipe stage */
-		/* pipe stage 0/IF */
-		num_piperegs += coredynp.pc_width*2*coredynp.num_hthreads;
-		/* pipe stage IF/ID */
-		num_piperegs += coredynp.fetchW*(coredynp.instruction_length + coredynp.pc_width)*coredynp.num_hthreads;
-		/* pipe stage IF/ThreadSEL */
-		if (coredynp.multithreaded) num_piperegs += coredynp.num_hthreads*coredynp.perThreadState; //8 bit thread states
-		/* pipe stage ID/EXE */
-		num_piperegs += coredynp.decodeW*(coredynp.instruction_length + coredynp.pc_width + pow(2.0,opcode_length)+ 2*coredynp.int_data_width)*coredynp.num_hthreads;
-		/* pipe stage EXE/MEM */
-		num_piperegs += coredynp.issueW*(3 * coredynp.arch_ireg_width + pow(2.0,opcode_length) + 8*2*coredynp.int_data_width/*+2*powers (2,reg_length)*/);
-		/* pipe stage MEM/WB the 2^opcode_length means the total decoded signal for the opcode*/
-		num_piperegs += coredynp.issueW*(2*coredynp.int_data_width + pow(2.0,opcode_length) + 8*2*coredynp.int_data_width/*+2*powers (2,reg_length)*/);
-//		/* pipe stage 5/6 */
-//		num_piperegs += issueWidth*(data_width + powers (2,opcode_length)/*+2*powers (2,reg_length)*/);
-//		/* pipe stage 6/7 */
-//		num_piperegs += issueWidth*(data_width + powers (2,opcode_length)/*+2*powers (2,reg_length)*/);
-//		/* pipe stage 7/8 */
-//		num_piperegs += issueWidth*(data_width + powers (2,opcode_length)/**2*powers (2,reg_length)*/);
-//		/* assume 50% extra in control signals (rule of thumb) */
-		num_stages=6;
+    process_ind = false;
+  WNANDn =
+      (process_ind)
+          ? 25 * l_ip.F_sz_um
+          : g_tp.min_w_nmos_;  // this was  20 micron for the 0.8 micron process
+  WNANDp = (process_ind)
+               ? 37.5 * l_ip.F_sz_um
+               : g_tp.min_w_nmos_ *
+                     pmos_to_nmos_sz_ratio();  // this was  30 micron for the
+                                               // 0.8 micron process
+  load_per_pipeline_stage = 2 * gate_C(WNANDn + WNANDp, 0, false);
+  compute();
+}
 
-	}
-	else
-	{
-		/* assume 12 stage pipe stages and try to estimate bits per pipe stage */
-		/*OOO: Fetch, decode, rename, IssueQ, dispatch, regread, EXE, MEM, WB, CM */
+void Pipeline::compute() {
+  compute_stage_vector();
+  DFFCell pipe_reg(false, WNANDn, WNANDp, load_per_pipeline_stage, &l_ip);
+  pipe_reg.compute_DFF_cell();
 
-		/* pipe stage 0/1F*/
-		num_piperegs += coredynp.pc_width*2*coredynp.num_hthreads ;//PC and Next PC
-		/* pipe stage IF/ID */
-		num_piperegs += coredynp.fetchW*(coredynp.instruction_length + coredynp.pc_width)*coredynp.num_hthreads;//PC is used to feed branch predictor in ID
-		/* pipe stage 1D/Renaming*/
-		num_piperegs += coredynp.decodeW*(coredynp.instruction_length + coredynp.pc_width)*coredynp.num_hthreads;//PC is for branch exe in later stage.
-		/* pipe stage Renaming/wire_drive */
-		num_piperegs += coredynp.decodeW*(coredynp.instruction_length + coredynp.pc_width);
-		/* pipe stage Renaming/IssueQ */
-		num_piperegs += coredynp.issueW*(coredynp.instruction_length  + coredynp.pc_width + 3*coredynp.phy_ireg_width)*coredynp.num_hthreads;//3*coredynp.phy_ireg_width means 2 sources and 1 dest
-		/* pipe stage IssueQ/Dispatch */
-		num_piperegs += coredynp.issueW*(coredynp.instruction_length + 3 * coredynp.phy_ireg_width);
-		/* pipe stage Dispatch/EXE */
+  double clock_power_pipereg = num_piperegs * pipe_reg.e_clock.readOp.dynamic;
+  //******************pipeline power: currently, we average all the
+  // possibilities of the states of DFFs in the pipeline. A better way to do it
+  // is to consider the harming distance of two consecutive signals, However
+  // McPAT does not have plan to do this in near future as it focuses on worst
+  // case power.
+  double pipe_reg_power =
+      num_piperegs *
+          (pipe_reg.e_switch.readOp.dynamic + pipe_reg.e_keep_0.readOp.dynamic +
+           pipe_reg.e_keep_1.readOp.dynamic) /
+          3 +
+      clock_power_pipereg;
+  double pipe_reg_leakage = num_piperegs * pipe_reg.e_switch.readOp.leakage;
+  double pipe_reg_gate_leakage =
+      num_piperegs * pipe_reg.e_switch.readOp.gate_leakage;
+  power.readOp.dynamic += pipe_reg_power;
+  power.readOp.leakage += pipe_reg_leakage;
+  power.readOp.gate_leakage += pipe_reg_gate_leakage;
+  area.set_area(num_piperegs * pipe_reg.area.get_area());
 
-		num_piperegs += coredynp.issueW*(3 * coredynp.phy_ireg_width + coredynp.pc_width + pow(2.0,opcode_length)/*+2*powers (2,reg_length)*/);
-		/* 2^opcode_length means the total decoded signal for the opcode*/
-		num_piperegs += coredynp.issueW*(2*coredynp.int_data_width + pow(2.0,opcode_length)/*+2*powers (2,reg_length)*/);
-		/*2 source operands in EXE; Assume 2EXE stages* since we do not really distinguish OP*/
-		num_piperegs += coredynp.issueW*(2*coredynp.int_data_width + pow(2.0,opcode_length)/*+2*powers (2,reg_length)*/);
-		/* pipe stage EXE/MEM, data need to be read/write, address*/
-		num_piperegs += coredynp.issueW*(coredynp.int_data_width + coredynp.v_address_width + pow(2.0,opcode_length)/*+2*powers (2,reg_length)*/);//memory Opcode still need to be passed
-		/* pipe stage MEM/WB; result data, writeback regs */
-		num_piperegs += coredynp.issueW*(coredynp.int_data_width + coredynp.phy_ireg_width /* powers (2,opcode_length) + (2,opcode_length)+2*powers (2,reg_length)*/);
-		/* pipe stage WB/CM ; result data, regs need to be updated, address for resolve memory ops in ROB's top*/
-		num_piperegs += coredynp.commitW*(coredynp.int_data_width + coredynp.v_address_width + coredynp.phy_ireg_width/*+ powers (2,opcode_length)*2*powers (2,reg_length)*/)*coredynp.num_hthreads;
-//		if (multithreaded)
-//		{
-//
-//		}
-		num_stages=12;
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(device_ty, coredynp.core_ty);
+  power.readOp.longer_channel_leakage =
+      power.readOp.leakage * long_channel_device_reduction;
 
-	}
+  double sckRation = g_tp.sckt_co_eff;
+  power.readOp.dynamic *= sckRation;
+  power.writeOp.dynamic *= sckRation;
+  power.searchOp.dynamic *= sckRation;
+  double macro_layout_overhead = g_tp.macro_layout_overhead;
+  if (!coredynp.Embedded)
+    area.set_area(area.get_area() * macro_layout_overhead);
+}
 
-	/* assume 50% extra in control registers and interrupt registers (rule of thumb) */
-	num_piperegs = num_piperegs * 1.5;
-	tot_stage_vector=num_piperegs;
-	per_stage_vector=tot_stage_vector/num_stages;
+void Pipeline::compute_stage_vector() {
+  double num_stages, tot_stage_vector, per_stage_vector;
+  int opcode_length =
+      coredynp.x86 ? coredynp.micro_opcode_length : coredynp.opcode_length;
+  // Hthread = thread_clock_gated? 1:num_thread;
 
-	if (coredynp.core_ty==Inorder)
-	{
-		if (coredynp.pipeline_stages>6)
-			num_piperegs= per_stage_vector*coredynp.pipeline_stages;
-	}
-	else//OOO
-	{
-		if (coredynp.pipeline_stages>12)
-			num_piperegs= per_stage_vector*coredynp.pipeline_stages;
-	}
+  if (!is_core_pipeline) {
+    num_piperegs = l_ip.pipeline_stages *
+                   l_ip.per_stage_vector;  // The number of pipeline stages are
+                                           // calculated based on the achievable
+                                           // throughput and required throughput
+  } else {
+    if (coredynp.core_ty == Inorder) {
+      /* assume 6 pipe stages and try to estimate bits per pipe stage */
+      /* pipe stage 0/IF */
+      num_piperegs += coredynp.pc_width * 2 * coredynp.num_hthreads;
+      /* pipe stage IF/ID */
+      num_piperegs += coredynp.fetchW *
+                      (coredynp.instruction_length + coredynp.pc_width) *
+                      coredynp.num_hthreads;
+      /* pipe stage IF/ThreadSEL */
+      if (coredynp.multithreaded)
+        num_piperegs += coredynp.num_hthreads *
+                        coredynp.perThreadState;  // 8 bit thread states
+      /* pipe stage ID/EXE */
+      num_piperegs += coredynp.decodeW *
+                      (coredynp.instruction_length + coredynp.pc_width +
+                       pow(2.0, opcode_length) + 2 * coredynp.int_data_width) *
+                      coredynp.num_hthreads;
+      /* pipe stage EXE/MEM */
+      num_piperegs +=
+          coredynp.issueW *
+          (3 * coredynp.arch_ireg_width + pow(2.0, opcode_length) +
+           8 * 2 * coredynp.int_data_width /*+2*powers (2,reg_length)*/);
+      /* pipe stage MEM/WB the 2^opcode_length means the total decoded signal
+       * for the opcode*/
+      num_piperegs +=
+          coredynp.issueW *
+          (2 * coredynp.int_data_width + pow(2.0, opcode_length) +
+           8 * 2 * coredynp.int_data_width /*+2*powers (2,reg_length)*/);
+      //		/* pipe stage 5/6 */
+      //		num_piperegs += issueWidth*(data_width + powers
+      //(2,opcode_length)/*+2*powers (2,reg_length)*/);
+      //		/* pipe stage 6/7 */
+      //		num_piperegs += issueWidth*(data_width + powers
+      //(2,opcode_length)/*+2*powers (2,reg_length)*/);
+      //		/* pipe stage 7/8 */
+      //		num_piperegs += issueWidth*(data_width + powers
+      //(2,opcode_length)/**2*powers (2,reg_length)*/);
+      //		/* assume 50% extra in control signals (rule of thumb)
+      //*/
+      num_stages = 6;
+
+    } else {
+      /* assume 12 stage pipe stages and try to estimate bits per pipe stage */
+      /*OOO: Fetch, decode, rename, IssueQ, dispatch, regread, EXE, MEM, WB, CM
+       */
+
+      /* pipe stage 0/1F*/
+      num_piperegs +=
+          coredynp.pc_width * 2 * coredynp.num_hthreads;  // PC and Next PC
+      /* pipe stage IF/ID */
+      num_piperegs +=
+          coredynp.fetchW * (coredynp.instruction_length + coredynp.pc_width) *
+          coredynp.num_hthreads;  // PC is used to feed branch predictor in ID
+      /* pipe stage 1D/Renaming*/
+      num_piperegs +=
+          coredynp.decodeW * (coredynp.instruction_length + coredynp.pc_width) *
+          coredynp.num_hthreads;  // PC is for branch exe in later stage.
+      /* pipe stage Renaming/wire_drive */
+      num_piperegs +=
+          coredynp.decodeW * (coredynp.instruction_length + coredynp.pc_width);
+      /* pipe stage Renaming/IssueQ */
+      num_piperegs += coredynp.issueW *
+                      (coredynp.instruction_length + coredynp.pc_width +
+                       3 * coredynp.phy_ireg_width) *
+                      coredynp.num_hthreads;  // 3*coredynp.phy_ireg_width means
+                                              // 2 sources and 1 dest
+      /* pipe stage IssueQ/Dispatch */
+      num_piperegs += coredynp.issueW * (coredynp.instruction_length +
+                                         3 * coredynp.phy_ireg_width);
+      /* pipe stage Dispatch/EXE */
+
+      num_piperegs += coredynp.issueW *
+                      (3 * coredynp.phy_ireg_width + coredynp.pc_width +
+                       pow(2.0, opcode_length) /*+2*powers (2,reg_length)*/);
+      /* 2^opcode_length means the total decoded signal for the opcode*/
+      num_piperegs += coredynp.issueW *
+                      (2 * coredynp.int_data_width +
+                       pow(2.0, opcode_length) /*+2*powers (2,reg_length)*/);
+      /*2 source operands in EXE; Assume 2EXE stages* since we do not really
+       * distinguish OP*/
+      num_piperegs += coredynp.issueW *
+                      (2 * coredynp.int_data_width +
+                       pow(2.0, opcode_length) /*+2*powers (2,reg_length)*/);
+      /* pipe stage EXE/MEM, data need to be read/write, address*/
+      num_piperegs +=
+          coredynp.issueW *
+          (coredynp.int_data_width + coredynp.v_address_width +
+           pow(2.0,
+               opcode_length) /*+2*powers (2,reg_length)*/);  // memory Opcode
+                                                              // still need to
+                                                              // be passed
+      /* pipe stage MEM/WB; result data, writeback regs */
+      num_piperegs +=
+          coredynp.issueW * (coredynp.int_data_width + coredynp.phy_ireg_width /* powers (2,opcode_length) + (2,opcode_length)+2*powers (2,reg_length)*/);
+      /* pipe stage WB/CM ; result data, regs need to be updated, address for
+       * resolve memory ops in ROB's top*/
+      num_piperegs +=
+          coredynp.commitW *
+          (coredynp.int_data_width + coredynp.v_address_width + coredynp.phy_ireg_width /*+ powers (2,opcode_length)*2*powers (2,reg_length)*/) *
+          coredynp.num_hthreads;
+      //		if (multithreaded)
+      //		{
+      //
+      //		}
+      num_stages = 12;
+    }
+
+    /* assume 50% extra in control registers and interrupt registers (rule of
+     * thumb) */
+    num_piperegs = num_piperegs * 1.5;
+    tot_stage_vector = num_piperegs;
+    per_stage_vector = tot_stage_vector / num_stages;
+
+    if (coredynp.core_ty == Inorder) {
+      if (coredynp.pipeline_stages > 6)
+        num_piperegs = per_stage_vector * coredynp.pipeline_stages;
+    } else  // OOO
+    {
+      if (coredynp.pipeline_stages > 12)
+        num_piperegs = per_stage_vector * coredynp.pipeline_stages;
+    }
   }
-
 }
 
-FunctionalUnit::FunctionalUnit(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_,const CoreDynParam & dyn_p_, enum FU_type fu_type_, double exClockRate)
-:XML(XML_interface),
- ithCore(ithCore_),
- interface_ip(*interface_ip_),
- coredynp(dyn_p_),
- fu_type(fu_type_)
-{
-    double area_t;//, leakage, gate_leakage;
-    double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
-	clockRate = exClockRate;//coredynp.clockRate;
-	executionTime = coredynp.executionTime;
-	//cout<<"FU executionTime: "<<executionTime<<endl;
+FunctionalUnit::FunctionalUnit(ParseXML *XML_interface, int ithCore_,
+                               InputParameter *interface_ip_,
+                               const CoreDynParam &dyn_p_,
+                               enum FU_type fu_type_, double exClockRate)
+    : XML(XML_interface),
+      ithCore(ithCore_),
+      interface_ip(*interface_ip_),
+      coredynp(dyn_p_),
+      fu_type(fu_type_) {
+  double area_t;  //, leakage, gate_leakage;
+  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
+  clockRate = exClockRate;  // coredynp.clockRate;
+  executionTime = coredynp.executionTime;
+  // cout<<"FU executionTime: "<<executionTime<<endl;
 
-	//XML_interface=_XML_interface;
-	uca_org_t result2;
-	result2 = init_interface(&interface_ip);
-	if (XML->sys.Embedded)
-	{
-		if (fu_type == FPU)
-		{
-			num_fu=coredynp.num_fpus;
-			//area_t = 8.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2
-			area_t = 4.47*1e6*(g_ip->F_sz_nm*g_ip->F_sz_nm/90.0/90.0);//this is um^2 The base number
-			//4.47 contains both VFP and NEON processing unit, VFP is about 40% and NEON is about 60%
-			if (g_ip->F_sz_nm>90)
-				area_t = 4.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2
-			leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-			gate_leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-			//energy = 0.3529/10*1e-9;//this is the energy(nJ) for a FP instruction in FPU usually it can have up to 20 cycles.
-//			base_energy = coredynp.core_ty==Inorder? 0: 89e-3*3; //W The base energy of ALU average numbers from Intel 4G and 773Mhz (Wattch)
-//			base_energy *=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
-			base_energy = 0;
-			per_access_energy = 1.15/1e9/4/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9; //This is per Hz energy(nJ)
-			//per_access_energy*=3;
-			//FPU power from Sandia's processor sizing tech report
-			FU_height=(18667*num_fu)*interface_ip.F_sz_um;//FPU from Sun's data
-		}
-		else if (fu_type == ALU)
-		{
-			num_fu=coredynp.num_alus;			
-			//FIXME: The first area_t = is from updated McAPAT, the second is from our changes (conflict from base)
-			//area_t = 280*260*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2 ALU + MUl
-			area_t = 71.85*71.85*num_fu*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2 ALU + MUl
-			leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-			gate_leakage = area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;
-			leakage = 0;
-//			base_energy = coredynp.core_ty==Inorder? 0:89e-3; //W The base energy of ALU average numbers from Intel 4G and 773Mhz (Wattch)
-//			base_energy *=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
-			base_energy = 0;
-			//per_access_energy = 1.15/3/1e9/4/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9; //This is per cycle energy(nJ)
-         per_access_energy = 1.29/1e12/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);
-         //per_access_energy*=3;
-         FU_height=(6222*num_fu)*interface_ip.F_sz_um;//integer ALU
+  // XML_interface=_XML_interface;
+  uca_org_t result2;
+  result2 = init_interface(&interface_ip);
+  if (XML->sys.Embedded) {
+    if (fu_type == FPU) {
+      num_fu = coredynp.num_fpus;
+      // area_t = 8.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is
+      // um^2
+      area_t = 4.47 * 1e6 *
+               (g_ip->F_sz_nm * g_ip->F_sz_nm / 90.0 /
+                90.0);  // this is um^2 The base number
+      // 4.47 contains both VFP and NEON processing unit, VFP is about 40% and
+      // NEON is about 60%
+      if (g_ip->F_sz_nm > 90)
+        area_t = 4.47 * 1e6 *
+                 g_tp.scaling_factor.logic_scaling_co_eff;  // this is um^2
+      leakage = area_t * (g_tp.scaling_factor.core_tx_density) *
+                cmos_Isub_leakage(5 * g_tp.min_w_nmos_,
+                                  5 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r,
+                                  1, inv) *
+                g_tp.peri_global.Vdd / 2;  // unit W
+      gate_leakage = area_t * (g_tp.scaling_factor.core_tx_density) *
+                     cmos_Ig_leakage(
+                         5 * g_tp.min_w_nmos_,
+                         5 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
+                     g_tp.peri_global.Vdd / 2;  // unit W
+      // energy = 0.3529/10*1e-9;//this is the energy(nJ) for a FP instruction
+      // in FPU usually it can have up to 20 cycles.
+      //			base_energy = coredynp.core_ty==Inorder? 0:
+      // 89e-3*3; //W The base energy of ALU average numbers from Intel 4G and
+      // 773Mhz (Wattch) 			base_energy
+      //*=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
+      base_energy = 0;
+      per_access_energy =
+          1.15 / 1e9 / 4 / 1.3 / 1.3 * g_tp.peri_global.Vdd *
+          g_tp.peri_global.Vdd *
+          (g_ip->F_sz_nm /
+           90.0);  // g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9;
+                   // //This is per Hz energy(nJ)
+      // per_access_energy*=3;
+      // FPU power from Sandia's processor sizing tech report
+      FU_height =
+          (18667 * num_fu) * interface_ip.F_sz_um;  // FPU from Sun's data
+    } else if (fu_type == ALU) {
+      num_fu = coredynp.num_alus;
+      // FIXME: The first area_t = is from updated McAPAT, the second is from
+      // our changes (conflict from base) area_t =
+      // 280*260*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2 ALU +
+      // MUl
+      area_t =
+          71.85 * 71.85 * num_fu *
+          g_tp.scaling_factor.logic_scaling_co_eff;  // this is um^2 ALU + MUl
+      leakage = area_t * (g_tp.scaling_factor.core_tx_density) *
+                cmos_Isub_leakage(20 * g_tp.min_w_nmos_,
+                                  20 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r,
+                                  1, inv) *
+                g_tp.peri_global.Vdd / 2;  // unit W
+      gate_leakage =
+          area_t * (g_tp.scaling_factor.core_tx_density) *
+          cmos_Ig_leakage(20 * g_tp.min_w_nmos_,
+                          20 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1,
+                          inv) *
+          g_tp.peri_global.Vdd / 2;
+      leakage = 0;
+      //			base_energy = coredynp.core_ty==Inorder?
+      // 0:89e-3; //W The base energy of ALU average numbers from Intel 4G and
+      // 773Mhz (Wattch) 			base_energy
+      //*=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
+      base_energy = 0;
+      // per_access_energy
+      // = 1.15/3/1e9/4/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9;
+      // //This is per cycle energy(nJ)
+      per_access_energy = 1.29 / 1e12 / 1.3 / 1.3 * g_tp.peri_global.Vdd *
+                          g_tp.peri_global.Vdd * (g_ip->F_sz_nm / 90.0);
+      // per_access_energy*=3;
+      FU_height = (6222 * num_fu) * interface_ip.F_sz_um;  // integer ALU
 
-		}
-		else if (fu_type == MUL)
-		{
-			num_fu=coredynp.num_muls;
-			area_t = 280*260*3*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2 ALU + MUl
-			leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-			gate_leakage = area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;
-//			base_energy = coredynp.core_ty==Inorder? 0:89e-3*2; //W The base energy of ALU average numbers from Intel 4G and 773Mhz (Wattch)
-//			base_energy *=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
-			base_energy = 0;
-			per_access_energy = 1.15*2/3/1e9/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2)/24;//0.00649*1e-9; //This is per cycle energy(nJ), coefficient based on Wattch (24 is the division ny latency: Syed)
-			//per_access_energy*=3;
-			FU_height=(9334*num_fu )*interface_ip.F_sz_um;//divider/mul from Sun's data
-		}
-		else
-		{
-			cout<<"Unknown Functional Unit Type"<<endl;
-			exit(0);
-		}
-		per_access_energy *=0.5;//According to ARM data embedded processor has much lower per acc energy
-	} /* if (XML->sys.Embedded) */	
-	else
-	{
-		if (fu_type == FPU)
-		  		{
-			num_fu=coredynp.num_fpus;
-		
-			/*
-			num_fu/=2; //2 DP FPUs combine to for a SP FPU
-			//area_t = 8.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2
-			area_t = 8.47*1e6*(g_ip->F_sz_nm*g_ip->F_sz_nm/90.0/90.0);//this is um^2
-			if (g_ip->F_sz_nm>90)
-				area_t = 8.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2
-			leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-			gate_leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-			//energy = 0.3529/10*1e-9;//this is the energy(nJ) for a FP instruction in FPU usually it can have up to 20 cycles.
-			base_energy = coredynp.core_ty==Inorder? 0: 89e-3*3; //W The base energy of ALU average numbers from Intel 4G and 773Mhz (Wattch)
-			base_energy *=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
-			per_access_energy = 1.15*3/1e9/4/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9; //This is per op energy(nJ)
-			FU_height=(38667*num_fu)*interface_ip.F_sz_um;//FPU from Sun's data
-			*/
-			//area_t = 8.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2
-         num_fu=num_fu/2; //2 DP FPUs combine to for a SP FPU
-			area_t = 8.47*1e6*(g_ip->F_sz_nm*g_ip->F_sz_nm/90.0/90.0);//this is um^2
-			if (g_ip->F_sz_nm>90)
-				area_t = 8.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2
-			leakage = 37e-3;//area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-			gate_leakage = 0;//area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-			//energy = 0.3529/10*1e-9;//this is the energy(nJ) for a FP instruction in FPU usually it can have up to 20 cycles.
-			base_energy = coredynp.core_ty==Inorder? 0: 89e-3*3; //W The base energy of ALU average numbers from Intel 4G and 773Mhz (Wattch)
+    } else if (fu_type == MUL) {
+      num_fu = coredynp.num_muls;
+      area_t =
+          280 * 260 * 3 *
+          g_tp.scaling_factor.logic_scaling_co_eff;  // this is um^2 ALU + MUl
+      leakage = area_t * (g_tp.scaling_factor.core_tx_density) *
+                cmos_Isub_leakage(20 * g_tp.min_w_nmos_,
+                                  20 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r,
+                                  1, inv) *
+                g_tp.peri_global.Vdd / 2;  // unit W
+      gate_leakage =
+          area_t * (g_tp.scaling_factor.core_tx_density) *
+          cmos_Ig_leakage(20 * g_tp.min_w_nmos_,
+                          20 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1,
+                          inv) *
+          g_tp.peri_global.Vdd / 2;
+      //			base_energy = coredynp.core_ty==Inorder?
+      // 0:89e-3*2; //W The base energy of ALU average numbers from Intel 4G and
+      // 773Mhz (Wattch) 			base_energy
+      //*=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
+      base_energy = 0;
+      per_access_energy =
+          1.15 * 2 / 3 / 1e9 / 1.3 / 1.3 * g_tp.peri_global.Vdd *
+          g_tp.peri_global.Vdd *
+          (g_ip->F_sz_nm /
+           90.0);  //(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2)/24;//0.00649*1e-9;
+                   ////This is per cycle energy(nJ), coefficient based on Wattch
+                   //(24 is the division ny latency: Syed)
+      // per_access_energy*=3;
+      FU_height = (9334 * num_fu) *
+                  interface_ip.F_sz_um;  // divider/mul from Sun's data
+    } else {
+      cout << "Unknown Functional Unit Type" << endl;
+      exit(0);
+    }
+    per_access_energy *= 0.5;  // According to ARM data embedded processor has
+                               // much lower per acc energy
+  }                            /* if (XML->sys.Embedded) */
+  else {
+    if (fu_type == FPU) {
+      num_fu = coredynp.num_fpus;
 
-			base_energy *=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
+      /*
+      num_fu/=2; //2 DP FPUs combine to for a SP FPU
+      //area_t = 8.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is
+      um^2 area_t = 8.47*1e6*(g_ip->F_sz_nm*g_ip->F_sz_nm/90.0/90.0);//this is
+      um^2 if (g_ip->F_sz_nm>90) area_t
+      = 8.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2 leakage
+      = area_t
+      *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(5*g_tp.min_w_nmos_,
+      5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
+      inv)*g_tp.peri_global.Vdd/2;//unit W gate_leakage = area_t
+      *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(5*g_tp.min_w_nmos_,
+      5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
+      inv)*g_tp.peri_global.Vdd/2;//unit W
+      //energy = 0.3529/10*1e-9;//this is the energy(nJ) for a FP instruction in
+      FPU usually it can have up to 20 cycles. base_energy =
+      coredynp.core_ty==Inorder? 0: 89e-3*3; //W The base energy of ALU average
+      numbers from Intel 4G and 773Mhz (Wattch) base_energy
+      *=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2); per_access_energy
+      = 1.15*3/1e9/4/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9;
+      //This is per op energy(nJ)
+      FU_height=(38667*num_fu)*interface_ip.F_sz_um;//FPU from Sun's data
+      */
+      // area_t = 8.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is
+      // um^2
+      num_fu = num_fu / 2;  // 2 DP FPUs combine to for a SP FPU
+      area_t = 8.47 * 1e6 *
+               (g_ip->F_sz_nm * g_ip->F_sz_nm / 90.0 / 90.0);  // this is um^2
+      if (g_ip->F_sz_nm > 90)
+        area_t = 8.47 * 1e6 *
+                 g_tp.scaling_factor.logic_scaling_co_eff;  // this is um^2
+      leakage =
+          37e-3;  // area_t
+                  // *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(5*g_tp.min_w_nmos_,
+                  // 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
+                  // inv)*g_tp.peri_global.Vdd/2;//unit W
+      gate_leakage =
+          0;  // area_t
+              // *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(5*g_tp.min_w_nmos_,
+              // 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
+              // inv)*g_tp.peri_global.Vdd/2;//unit W
+      // energy = 0.3529/10*1e-9;//this is the energy(nJ) for a FP instruction
+      // in FPU usually it can have up to 20 cycles.
+      base_energy =
+          coredynp.core_ty == Inorder
+              ? 0
+              : 89e-3 * 3;  // W The base energy of ALU average numbers from
+                            // Intel 4G and 773Mhz (Wattch)
 
+      base_energy *= (g_tp.peri_global.Vdd * g_tp.peri_global.Vdd / 1.2 / 1.2);
 
-			//Base energy (if the pipeline is not clock gated)
-			//TODO: add a check for clockgating enable
-			base_energy=SP_BASE_POWER;
+      // Base energy (if the pipeline is not clock gated)
+      // TODO: add a check for clockgating enable
+      base_energy = SP_BASE_POWER;
 
-			//per_access_energy = 1.15*3/1e9/4/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9; //This is per op energy(nJ)
-         per_access_energy = 3.9*14.91/1e12/1.08/1.08*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//;4.34 is scaling factor based on hardware measurements
-			//ALU instrucitons are also executed on FPUs so add 30% overhead for supporting ALU instrcutions
-			//per_access_energy = 1.3*per_access_energy;
+      // per_access_energy
+      // = 1.15*3/1e9/4/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9;
+      // //This is per op energy(nJ)
+      per_access_energy =
+          3.9 * 14.91 / 1e12 / 1.08 / 1.08 * g_tp.peri_global.Vdd *
+          g_tp.peri_global.Vdd *
+          (g_ip->F_sz_nm /
+           90.0);  //;4.34 is scaling factor based on hardware measurements
+                   // ALU instrucitons are also executed on FPUs so add 30%
+                   // overhead for supporting ALU instrcutions per_access_energy
+                   // = 1.3*per_access_energy;
 
+      // ALU instrucitons are also executed on FPUs so add 10% overhead for
+      // supporting ALU instrcutions
+      leakage = 1.1 * leakage;
+      // cout<<"FPU Per access erngy: "<<per_access_energy/2;
+      // Divide per access energy by 2 so we have 4 DP units capapble of
+      // doing 8 SP operations
+      // per_access_energy = per_access_energy/2;
+      FU_height =
+          (38667 * num_fu) * interface_ip.F_sz_um;  // FPU from Sun's data
+      per_access_energy *= 2;
+    } else if (fu_type == ALU) {
+      num_fu = coredynp.num_alus;
+      // FIXME: The first area_t = is from updated McPAT. The second is from our
+      // McPAT changes. Fix after merge area_t =
+      // 280*260*2*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2 ALU +
+      // MUl leakage = area_t
+      // *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_,
+      // 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
+      // inv)*g_tp.peri_global.Vdd/2;//unit W gate_leakage =
+      // area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_,
+      // 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
+      // inv)*g_tp.peri_global.Vdd/2;
+      area_t =
+          71.85 * 71.85 * num_fu *
+          g_tp.scaling_factor.logic_scaling_co_eff;  // this is um^2 ALU + MUl
+      // leakage = area_t
+      // *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_,
+      // 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
+      // inv)*g_tp.peri_global.Vdd/2;//unit W gate_leakage =
+      // area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_,
+      // 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
+      // inv)*g_tp.peri_global.Vdd/2; Following leakage numbers are based on
+      // Syntheis based power-estimation (SYED)
+      leakage = 2.58e-5;
+      gate_leakage = 0;
+      base_energy = coredynp.core_ty == Inorder
+                        ? 0
+                        : 89e-3;  // W The base energy of ALU average numbers
+                                  // from Intel 4G and 773Mhz (Wattch)
+      base_energy *= (g_tp.peri_global.Vdd * g_tp.peri_global.Vdd / 1.2 / 1.2);
+      // per_access_energy
+      // = 1.15/1e9/4/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9;
+      // //This is per cycle energy(nJ)
+      per_access_energy = 0.8 * 1.29 / 1e12 / 1.3 / 1.3 * g_tp.peri_global.Vdd *
+                          g_tp.peri_global.Vdd * (g_ip->F_sz_nm / 90.0);
+      FU_height = (6222 * num_fu) * interface_ip.F_sz_um;  // integer ALU
+      per_access_energy *= 2;
+    } else if (fu_type == MUL) {
+      num_fu = coredynp.num_muls;
+      area_t =
+          280 * 260 * 2 * 3 *
+          g_tp.scaling_factor.logic_scaling_co_eff;  // this is um^2 ALU + MUl
+      // leakage = area_t
+      // *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_,
+      // 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
+      // inv)*g_tp.peri_global.Vdd/2;//unit W
+      leakage = 37e-3;
+      gate_leakage =
+          0;  // area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_,
+              // 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
+              // inv)*g_tp.peri_global.Vdd/2;
+      base_energy =
+          coredynp.core_ty == Inorder
+              ? 0
+              : 89e-3 * 2;  // W The base energy of ALU average numbers from
+                            // Intel 4G and 773Mhz (Wattch)
+      base_energy *= (g_tp.peri_global.Vdd * g_tp.peri_global.Vdd / 1.2 / 1.2);
+      base_energy = SFU_BASE_POWER;
+      // SFU is modelled as a double preicison FPU
+      per_access_energy =
+          8 * 14.91 / 1e12 / 1.08 / 1.08 * g_tp.peri_global.Vdd *
+          g_tp.peri_global.Vdd *
+          (g_ip->F_sz_nm /
+           90.0);  // 1.5 is scaling factor based on hardware measuremetns
+      FU_height = (9334 * num_fu) *
+                  interface_ip.F_sz_um;  // divider/mul from Sun's data
+      per_access_energy *= 2;
+    }
 
-			//ALU instrucitons are also executed on FPUs so add 10% overhead for supporting ALU instrcutions
-	   	leakage = 1.1*leakage;
-			//cout<<"FPU Per access erngy: "<<per_access_energy/2;
-			//Divide per access energy by 2 so we have 4 DP units capapble of 
-			//doing 8 SP operations
-			//per_access_energy = per_access_energy/2;
-			FU_height=(38667*num_fu)*interface_ip.F_sz_um;//FPU from Sun's data
-			per_access_energy*=2;
-		}
-		else if (fu_type == ALU)
-		{
-			num_fu=coredynp.num_alus;
-			//FIXME: The first area_t = is from updated McPAT. The second is from our McPAT changes. Fix after merge
-			//area_t = 280*260*2*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2 ALU + MUl
-			//leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-			//gate_leakage = area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;
-			area_t = 71.85*71.85*num_fu*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2 ALU + MUl
-			//leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-			//gate_leakage = area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;
-			//Following leakage numbers are based on Syntheis based power-estimation (SYED)
-			leakage = 2.58e-5;
-			gate_leakage = 0;
-			base_energy = coredynp.core_ty==Inorder? 0:89e-3; //W The base energy of ALU average numbers from Intel 4G and 773Mhz (Wattch)
-			base_energy *=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
-			//per_access_energy = 1.15/1e9/4/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9; //This is per cycle energy(nJ)
-			per_access_energy = 0.8*1.29/1e12/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);
-			FU_height=(6222*num_fu)*interface_ip.F_sz_um;//integer ALU
-			per_access_energy*=2;
-		}
-			else if (fu_type == MUL)
-		{
-			num_fu=coredynp.num_muls;
-			area_t = 280*260*2*3*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2 ALU + MUl
-			//leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-			leakage = 37e-3;
-			gate_leakage = 0;//area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;
-			base_energy = coredynp.core_ty==Inorder? 0:89e-3*2; //W The base energy of ALU average numbers from Intel 4G and 773Mhz (Wattch)
-			base_energy *=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
-			base_energy = SFU_BASE_POWER;
-			//SFU is modelled as a double preicison FPU
-			per_access_energy = 8*14.91/1e12/1.08/1.08*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//1.5 is scaling factor based on hardware measuremetns
-			FU_height=(9334*num_fu )*interface_ip.F_sz_um;//divider/mul from Sun's data
-			per_access_energy*=2;
-		}
-
-		else
-		{
-			cout<<"Unknown Functional Unit Type"<<endl;
-			exit(0);
-		}
-	}
-	//IEXEU, simple ALU and FPU
-	//  double C_ALU, C_EXEU, C_FPU; //Lum Equivalent capacitance of IEXEU and FPU. Based on Intel and Sun 90nm process fabracation.
-	//
-	//  C_ALU	  = 0.025e-9;//F
-	//  C_EXEU  = 0.05e-9; //F
-	//  C_FPU	  = 0.35e-9;//F
-    area.set_area(area_t*num_fu);
-    leakage *= num_fu;
-    gate_leakage *=num_fu;
-	double macro_layout_overhead = g_tp.macro_layout_overhead;
-//	if (!XML->sys.Embedded)
-		area.set_area(area.get_area()*macro_layout_overhead);
+    else {
+      cout << "Unknown Functional Unit Type" << endl;
+      exit(0);
+    }
+  }
+  // IEXEU, simple ALU and FPU
+  //  double C_ALU, C_EXEU, C_FPU; //Lum Equivalent capacitance of IEXEU and
+  //  FPU. Based on Intel and Sun 90nm process fabracation.
+  //
+  //  C_ALU	  = 0.025e-9;//F
+  //  C_EXEU  = 0.05e-9; //F
+  //  C_FPU	  = 0.35e-9;//F
+  area.set_area(area_t * num_fu);
+  leakage *= num_fu;
+  gate_leakage *= num_fu;
+  double macro_layout_overhead = g_tp.macro_layout_overhead;
+  //	if (!XML->sys.Embedded)
+  area.set_area(area.get_area() * macro_layout_overhead);
 }
 
-void FunctionalUnit::computeEnergy(bool is_tdp)
-{
- 
-  executionTime=XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);//Syed
-	double pppm_t[4]    = {1,1,1,1};
-	double FU_duty_cycle;
-	if (is_tdp)
-	{
+void FunctionalUnit::computeEnergy(bool is_tdp) {
+  executionTime =
+      XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);  // Syed
+  double pppm_t[4] = {1, 1, 1, 1};
+  double FU_duty_cycle;
+  if (is_tdp) {
+    set_pppm(pppm_t, 2, 2, 2, 2);  // 2 means two source operands needs to be
+                                   // passed for each int instruction.
+    if (fu_type == FPU) {
+      stats_t.readAc.access = num_fu;
+      tdp_stats = stats_t;
+      // Syed: FPU power numbers are already average
+      // so activity factor is already accounted for
+      FU_duty_cycle = coredynp.FPU_duty_cycle;
+    } else if (fu_type == ALU) {
+      stats_t.readAc.access = 1 * num_fu;
+      tdp_stats = stats_t;
+      FU_duty_cycle = coredynp.ALU_duty_cycle;
+    } else if (fu_type == MUL) {
+      stats_t.readAc.access = num_fu;
+      tdp_stats = stats_t;
+      FU_duty_cycle = coredynp.MUL_duty_cycle;
+    }
 
+    // power.readOp.dynamic = base_energy/clockRate +
+    // energy*stats_t.readAc.access;
+    power.readOp.dynamic =
+        per_access_energy * stats_t.readAc.access + base_energy / clockRate;
+    double sckRation = g_tp.sckt_co_eff;
+    power.readOp.dynamic *= sckRation * FU_duty_cycle;
+    power.writeOp.dynamic *= sckRation;
+    power.searchOp.dynamic *= sckRation;
 
-		set_pppm(pppm_t, 2, 2, 2, 2);//2 means two source operands needs to be passed for each int instruction.
-		if (fu_type == FPU)
-		{
-			stats_t.readAc.access = num_fu;
-			tdp_stats = stats_t;
-            //Syed: FPU power numbers are already average
-            //so activity factor is already accounted for
-			FU_duty_cycle= coredynp.FPU_duty_cycle;
-		}
-		else if (fu_type == ALU)
-		{
-			stats_t.readAc.access = 1*num_fu;
-			tdp_stats = stats_t;
-			FU_duty_cycle = coredynp.ALU_duty_cycle;
-		}
-		else if (fu_type == MUL)
-		{
-			stats_t.readAc.access = num_fu;
-			tdp_stats = stats_t;
-			FU_duty_cycle = coredynp.MUL_duty_cycle;
-		}
+    power.readOp.leakage = leakage;
+    power.readOp.gate_leakage = gate_leakage;
+    double long_channel_device_reduction =
+        longer_channel_device_reduction(Core_device, coredynp.core_ty);
+    power.readOp.longer_channel_leakage =
+        power.readOp.leakage * long_channel_device_reduction;
 
-	    //power.readOp.dynamic = base_energy/clockRate + energy*stats_t.readAc.access;
-	    power.readOp.dynamic = per_access_energy*stats_t.readAc.access + base_energy/clockRate;
-		double sckRation = g_tp.sckt_co_eff;
-		power.readOp.dynamic *= sckRation*FU_duty_cycle;
-		power.writeOp.dynamic *= sckRation;
-		power.searchOp.dynamic *= sckRation;
+  } else {
+    if (fu_type == FPU) {
+      // Each access activates an equililant of a double-precision unit
+      // so divide accesses into half
+      stats_t.readAc.access = XML->sys.core[ithCore].fpu_accesses;
+      rtp_stats = stats_t;
+      // cout<<"FPU: --accesses "<<stats_t.readAc.access <<endl;
 
-	    power.readOp.leakage = leakage;
-	    power.readOp.gate_leakage = gate_leakage;
-	    double long_channel_device_reduction = longer_channel_device_reduction(Core_device, coredynp.core_ty);
-	    power.readOp.longer_channel_leakage	= power.readOp.leakage*long_channel_device_reduction;
+    } else if (fu_type == ALU) {
+      stats_t.readAc.access = XML->sys.core[ithCore].ialu_accesses;
+      rtp_stats = stats_t;
+      // cout<<"ALU: --accesses "<<stats_t.readAc.access <<endl;
+    } else if (fu_type == MUL) {
+      stats_t.readAc.access = XML->sys.core[ithCore].mul_accesses;
+      rtp_stats = stats_t;
+      // cout<<"MUL: --accesses "<<stats_t.readAc.access <<endl;
+    }
 
-	}
-	else
-	{
-		if (fu_type == FPU)
-		{
-		  //Each access activates an equililant of a double-precision unit
-		  //so divide accesses into half
-			stats_t.readAc.access = XML->sys.core[ithCore].fpu_accesses;
-			rtp_stats = stats_t;
-			//cout<<"FPU: --accesses "<<stats_t.readAc.access <<endl;
+    // rt_power.readOp.dynamic = base_energy*executionTime +
+    // energy*stats_t.readAc.access;
 
-		}
-		else if (fu_type == ALU)
-		{
-			stats_t.readAc.access = XML->sys.core[ithCore].ialu_accesses;
-			rtp_stats = stats_t;
-			//cout<<"ALU: --accesses "<<stats_t.readAc.access <<endl;
-		}
-		else if (fu_type == MUL)
-		{
-			stats_t.readAc.access = XML->sys.core[ithCore].mul_accesses;
-			rtp_stats = stats_t;
-			//cout<<"MUL: --accesses "<<stats_t.readAc.access <<endl;
-		}
+    if (fu_type == ALU) {
+      rt_power.readOp.dynamic = per_access_energy * stats_t.readAc.access +
+                                base_energy * executionTime;
+    } else {
+      rt_power.readOp.dynamic = per_access_energy * stats_t.readAc.access;
+    }
 
-	    //rt_power.readOp.dynamic = base_energy*executionTime + energy*stats_t.readAc.access;
-	    
-		if(fu_type == ALU){
-		rt_power.readOp.dynamic = per_access_energy*stats_t.readAc.access + base_energy*executionTime;
-		}
-		else{
-		  rt_power.readOp.dynamic = per_access_energy*stats_t.readAc.access;
-		}
+    double sckRation = g_tp.sckt_co_eff;
+    rt_power.readOp.dynamic *= sckRation;
+    rt_power.writeOp.dynamic *= sckRation;
+    rt_power.searchOp.dynamic *= sckRation;
+    // cout<<"Power: "<<rt_power.readOp.dynamic<<endl;
+    if (fu_type == FPU) {
+      rt_power.readOp.dynamic +=
+          base_energy * executionTime *
+          (32 - XML->sys.core[ithCore].sp_average_active_lanes);
+    }
+    if (fu_type == MUL) {
+      if (XML->sys.core[ithCore].sfu_average_active_lanes >= 1)
+        rt_power.readOp.dynamic +=
+            base_energy * executionTime *
+            (32 - XML->sys.core[ithCore].sfu_average_active_lanes);
+    }
 
-		double sckRation = g_tp.sckt_co_eff;
-		rt_power.readOp.dynamic *= sckRation;
-		rt_power.writeOp.dynamic *= sckRation;
-		rt_power.searchOp.dynamic *= sckRation;
-      //cout<<"Power: "<<rt_power.readOp.dynamic<<endl;
-		if(fu_type == FPU){
-		  rt_power.readOp.dynamic += base_energy*executionTime*(32-XML->sys.core[ithCore].sp_average_active_lanes);
-		}
-		if(fu_type == MUL){
-		  if(XML->sys.core[ithCore].sfu_average_active_lanes>=1)
-		    rt_power.readOp.dynamic += base_energy*executionTime*(32-XML->sys.core[ithCore].sfu_average_active_lanes);
-		}
-
-	} /* else */	
-
-
-
+  } /* else */
 }
 
-void FunctionalUnit::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
+void FunctionalUnit::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
 
-//	cout << indent_str_next << "Results Broadcast Bus Area = " << bypass->area.get_area() *1e-6 << " mm^2" << endl;
-	if (is_tdp)
-	{
-		if (fu_type == FPU)
-		{
-			cout << indent_str << "Floating Point Units (FPUs) (Count: "<< coredynp.num_fpus <<" ):" << endl;
-			cout << indent_str_next << "Area = " << area.get_area()*1e-6  << " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Peak Energy = " << power.readOp.dynamic  << " J" << endl;
+  //	cout << indent_str_next << "Results Broadcast Bus Area = " <<
+  // bypass->area.get_area() *1e-6 << " mm^2" << endl;
+  if (is_tdp) {
+    if (fu_type == FPU) {
+      cout << indent_str
+           << "Floating Point Units (FPUs) (Count: " << coredynp.num_fpus
+           << " ):" << endl;
+      cout << indent_str_next << "Area = " << area.get_area() * 1e-6 << " mm^2"
+           << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << power.readOp.dynamic * clockRate << " W"
+           << endl;
+      cout << indent_str_next << "Peak Energy = " << power.readOp.dynamic
+           << " J" << endl;
 
-//			cout << indent_str_next << "Subthreshold Leakage = " << power.readOp.leakage  << " W" << endl;
-        //cout <<"clock: "<<clockRate<<endl;
-			cout << indent_str_next<< "Subthreshold Leakage = "
-						<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-		}
-		else if (fu_type == ALU)
-		{
-			cout << indent_str << "Integer ALUs (Count: "<< coredynp.num_alus <<" ):" << endl;
-			cout << indent_str_next << "Area = " << area.get_area()*1e-6  << " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << power.readOp.dynamic*clockRate  << " W" << endl;
-//			cout << indent_str_next << "Subthreshold Leakage = " << power.readOp.leakage  << " W" << endl;
-			cout << indent_str_next<< "Subthreshold Leakage = "
-						<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-		}
-		else if (fu_type == MUL)
-		{
-			cout << indent_str << "Complex ALUs (Mul/Div) (Count: "<< coredynp.num_muls <<" ):" << endl;
-			cout << indent_str_next << "Area = " << area.get_area()*1e-6  << " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << power.readOp.dynamic*clockRate  << " W" << endl;
-//			cout << indent_str_next << "Subthreshold Leakage = " << power.readOp.leakage  << " W" << endl;
-			cout << indent_str_next<< "Subthreshold Leakage = "
-						<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
+      //			cout << indent_str_next << "Subthreshold Leakage
+      //= " << power.readOp.leakage  << " W" << endl; cout <<"clock:
+      // "<<clockRate<<endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? power.readOp.longer_channel_leakage
+                            : power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage
+           << " W" << endl;
+      cout << indent_str_next
+           << "Runtime Dynamic = " << rt_power.readOp.dynamic / executionTime
+           << " W" << endl;
+      cout << endl;
+    } else if (fu_type == ALU) {
+      cout << indent_str << "Integer ALUs (Count: " << coredynp.num_alus
+           << " ):" << endl;
+      cout << indent_str_next << "Area = " << area.get_area() * 1e-6 << " mm^2"
+           << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << power.readOp.dynamic * clockRate << " W"
+           << endl;
+      //			cout << indent_str_next << "Subthreshold Leakage
+      //= " << power.readOp.leakage  << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? power.readOp.longer_channel_leakage
+                            : power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage
+           << " W" << endl;
+      cout << indent_str_next
+           << "Runtime Dynamic = " << rt_power.readOp.dynamic / executionTime
+           << " W" << endl;
+      cout << endl;
+    } else if (fu_type == MUL) {
+      cout << indent_str
+           << "Complex ALUs (Mul/Div) (Count: " << coredynp.num_muls
+           << " ):" << endl;
+      cout << indent_str_next << "Area = " << area.get_area() * 1e-6 << " mm^2"
+           << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << power.readOp.dynamic * clockRate << " W"
+           << endl;
+      //			cout << indent_str_next << "Subthreshold Leakage
+      //= " << power.readOp.leakage  << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? power.readOp.longer_channel_leakage
+                            : power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage
+           << " W" << endl;
+      cout << indent_str_next
+           << "Runtime Dynamic = " << rt_power.readOp.dynamic / executionTime
+           << " W" << endl;
+      cout << endl;
+    }
 
-		}
-
-	}
-	else
-	{
-	}
-
+  } else {
+  }
 }
 
-void FunctionalUnit::leakage_feedback(double temperature)
-{
+void FunctionalUnit::leakage_feedback(double temperature) {
   // Update the temperature and initialize the global interfaces.
-  interface_ip.temp = (unsigned int)round(temperature/10.0)*10;
+  interface_ip.temp = (unsigned int)round(temperature / 10.0) * 10;
 
-  uca_org_t init_result = init_interface(&interface_ip); // init_result is dummy
+  uca_org_t init_result =
+      init_interface(&interface_ip);  // init_result is dummy
 
   // This is part of FunctionalUnit()
   double area_t, leakage, gate_leakage;
   double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
 
-  if (fu_type == FPU)
-  {
-	area_t = 4.47*1e6*(g_ip->F_sz_nm*g_ip->F_sz_nm/90.0/90.0);//this is um^2 The base number
-	if (g_ip->F_sz_nm>90)
-		area_t = 4.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2
-	leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-	gate_leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-  }
-  else if (fu_type == ALU)
-  {
-    area_t = 280*260*2*num_fu*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2 ALU + MUl
-    leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-    gate_leakage = area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;
-  }
-  else if (fu_type == MUL)
-  {
-    area_t = 280*260*2*3*num_fu*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2 ALU + MUl
-    leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-    gate_leakage = area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;
-  }
-  else
-  {
-    cout<<"Unknown Functional Unit Type"<<endl;
+  if (fu_type == FPU) {
+    area_t = 4.47 * 1e6 *
+             (g_ip->F_sz_nm * g_ip->F_sz_nm / 90.0 /
+              90.0);  // this is um^2 The base number
+    if (g_ip->F_sz_nm > 90)
+      area_t = 4.47 * 1e6 *
+               g_tp.scaling_factor.logic_scaling_co_eff;  // this is um^2
+    leakage = area_t * (g_tp.scaling_factor.core_tx_density) *
+              cmos_Isub_leakage(5 * g_tp.min_w_nmos_,
+                                5 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1,
+                                inv) *
+              g_tp.peri_global.Vdd / 2;  // unit W
+    gate_leakage =
+        area_t * (g_tp.scaling_factor.core_tx_density) *
+        cmos_Ig_leakage(5 * g_tp.min_w_nmos_,
+                        5 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
+        g_tp.peri_global.Vdd / 2;  // unit W
+  } else if (fu_type == ALU) {
+    area_t =
+        280 * 260 * 2 * num_fu *
+        g_tp.scaling_factor.logic_scaling_co_eff;  // this is um^2 ALU + MUl
+    leakage = area_t * (g_tp.scaling_factor.core_tx_density) *
+              cmos_Isub_leakage(20 * g_tp.min_w_nmos_,
+                                20 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r,
+                                1, inv) *
+              g_tp.peri_global.Vdd / 2;  // unit W
+    gate_leakage =
+        area_t * (g_tp.scaling_factor.core_tx_density) *
+        cmos_Ig_leakage(20 * g_tp.min_w_nmos_,
+                        20 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
+        g_tp.peri_global.Vdd / 2;
+  } else if (fu_type == MUL) {
+    area_t =
+        280 * 260 * 2 * 3 * num_fu *
+        g_tp.scaling_factor.logic_scaling_co_eff;  // this is um^2 ALU + MUl
+    leakage = area_t * (g_tp.scaling_factor.core_tx_density) *
+              cmos_Isub_leakage(20 * g_tp.min_w_nmos_,
+                                20 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r,
+                                1, inv) *
+              g_tp.peri_global.Vdd / 2;  // unit W
+    gate_leakage =
+        area_t * (g_tp.scaling_factor.core_tx_density) *
+        cmos_Ig_leakage(20 * g_tp.min_w_nmos_,
+                        20 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
+        g_tp.peri_global.Vdd / 2;
+  } else {
+    cout << "Unknown Functional Unit Type" << endl;
     exit(1);
   }
 
-  power.readOp.leakage = leakage*num_fu;
-  power.readOp.gate_leakage = gate_leakage*num_fu;
-  power.readOp.longer_channel_leakage = longer_channel_device_reduction(Core_device, coredynp.core_ty);
+  power.readOp.leakage = leakage * num_fu;
+  power.readOp.gate_leakage = gate_leakage * num_fu;
+  power.readOp.longer_channel_leakage =
+      longer_channel_device_reduction(Core_device, coredynp.core_ty);
 }
 
-UndiffCore::UndiffCore(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_, bool exist_,  bool embedded_)
-:XML(XML_interface),
- ithCore(ithCore_),
- interface_ip(*interface_ip_),
- coredynp(dyn_p_),
- core_ty(coredynp.core_ty),
- embedded(XML->sys.Embedded),
- pipeline_stage(coredynp.pipeline_stages),
- num_hthreads(coredynp.num_hthreads),
- issue_width(coredynp.issueW),
- exist(exist_)
+UndiffCore::UndiffCore(ParseXML *XML_interface, int ithCore_,
+                       InputParameter *interface_ip_,
+                       const CoreDynParam &dyn_p_, bool exist_, bool embedded_)
+    : XML(XML_interface),
+      ithCore(ithCore_),
+      interface_ip(*interface_ip_),
+      coredynp(dyn_p_),
+      core_ty(coredynp.core_ty),
+      embedded(XML->sys.Embedded),
+      pipeline_stage(coredynp.pipeline_stages),
+      num_hthreads(coredynp.num_hthreads),
+      issue_width(coredynp.issueW),
+      exist(exist_)
 // is_default(_is_default)
 {
-	if (!exist) return;
-	double undifferentiated_core=0;
-	double core_tx_density=0;
-	double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
-	double undifferentiated_core_coe;
-	//XML_interface=_XML_interface;
-	uca_org_t result2;
-	result2 = init_interface(&interface_ip);
+  if (!exist) return;
+  double undifferentiated_core = 0;
+  double core_tx_density = 0;
+  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
+  double undifferentiated_core_coe;
+  // XML_interface=_XML_interface;
+  uca_org_t result2;
+  result2 = init_interface(&interface_ip);
 
-	//Compute undifferentiated core area at 90nm.
-	if (embedded==false)
-	{
-		//Based on the results of polynomial/log curve fitting based on undifferentiated core of Niagara, Niagara2, Merom, Penyrn, Prescott, Opteron die measurements
-		if (core_ty==OOO)
-		{
-			//undifferentiated_core = (0.0764*pipeline_stage*pipeline_stage -2.3685*pipeline_stage + 10.405);//OOO
-			undifferentiated_core = (3.57*log(pipeline_stage)-1.2643)>0?(3.57*log(pipeline_stage)-1.2643):0;
-		}
-		else if (core_ty==Inorder)
-		{
-			//undifferentiated_core = (0.1238*pipeline_stage + 7.2572)*0.9;//inorder
-			undifferentiated_core = (-2.19*log(pipeline_stage)+6.55)>0?(-2.19*log(pipeline_stage)+6.55):0;
-		}
-		else
-		{
-			cout<<"invalid core type"<<endl;
-			exit(0);
-		}
-		undifferentiated_core *= (1+ logtwo(num_hthreads)* 0.0716);
-	}
-	else
-	{
-		//Based on the results in paper "parametrized processor models" Sandia Labs
-		if (XML->sys.opt_clockrate)
-			undifferentiated_core_coe = 0.05;
-		else
-			undifferentiated_core_coe = 0;
-		undifferentiated_core = (0.4109* pipeline_stage - 0.776)*undifferentiated_core_coe;
-		undifferentiated_core *= (1+ logtwo(num_hthreads)* 0.0426);
-	}
+  // Compute undifferentiated core area at 90nm.
+  if (embedded == false) {
+    // Based on the results of polynomial/log curve fitting based on
+    // undifferentiated core of Niagara, Niagara2, Merom, Penyrn, Prescott,
+    // Opteron die measurements
+    if (core_ty == OOO) {
+      // undifferentiated_core = (0.0764*pipeline_stage*pipeline_stage
+      // -2.3685*pipeline_stage + 10.405);//OOO
+      undifferentiated_core = (3.57 * log(pipeline_stage) - 1.2643) > 0
+                                  ? (3.57 * log(pipeline_stage) - 1.2643)
+                                  : 0;
+    } else if (core_ty == Inorder) {
+      // undifferentiated_core = (0.1238*pipeline_stage + 7.2572)*0.9;//inorder
+      undifferentiated_core = (-2.19 * log(pipeline_stage) + 6.55) > 0
+                                  ? (-2.19 * log(pipeline_stage) + 6.55)
+                                  : 0;
+    } else {
+      cout << "invalid core type" << endl;
+      exit(0);
+    }
+    undifferentiated_core *= (1 + logtwo(num_hthreads) * 0.0716);
+  } else {
+    // Based on the results in paper "parametrized processor models" Sandia Labs
+    if (XML->sys.opt_clockrate)
+      undifferentiated_core_coe = 0.05;
+    else
+      undifferentiated_core_coe = 0;
+    undifferentiated_core =
+        (0.4109 * pipeline_stage - 0.776) * undifferentiated_core_coe;
+    undifferentiated_core *= (1 + logtwo(num_hthreads) * 0.0426);
+  }
 
-	undifferentiated_core 		    *= g_tp.scaling_factor.logic_scaling_co_eff*1e6;//change from mm^2 to um^2
-	core_tx_density                 = g_tp.scaling_factor.core_tx_density;
-	//undifferentiated_core 		    = 3*1e6;
-	//undifferentiated_core			*= g_tp.scaling_factor.logic_scaling_co_eff;//(g_ip->F_sz_um*g_ip->F_sz_um/0.09/0.09)*;
-	power.readOp.leakage = undifferentiated_core*(core_tx_density)*cmos_Isub_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd;//unit W
-	power.readOp.gate_leakage = undifferentiated_core*(core_tx_density)*cmos_Ig_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd;
+  undifferentiated_core *= g_tp.scaling_factor.logic_scaling_co_eff *
+                           1e6;  // change from mm^2 to um^2
+  core_tx_density = g_tp.scaling_factor.core_tx_density;
+  // undifferentiated_core 		    = 3*1e6;
+  // undifferentiated_core			*=
+  // g_tp.scaling_factor.logic_scaling_co_eff;//(g_ip->F_sz_um*g_ip->F_sz_um/0.09/0.09)*;
+  power.readOp.leakage =
+      undifferentiated_core *
+      (core_tx_density)*cmos_Isub_leakage(
+          5 * g_tp.min_w_nmos_, 5 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1,
+          inv) *
+      g_tp.peri_global.Vdd;  // unit W
+  power.readOp.gate_leakage =
+      undifferentiated_core *
+      (core_tx_density)*cmos_Ig_leakage(
+          5 * g_tp.min_w_nmos_, 5 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1,
+          inv) *
+      g_tp.peri_global.Vdd;
 
-	double long_channel_device_reduction = longer_channel_device_reduction(Core_device, coredynp.core_ty);
-	power.readOp.longer_channel_leakage	= power.readOp.leakage*long_channel_device_reduction;
-	area.set_area(undifferentiated_core);
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(Core_device, coredynp.core_ty);
+  power.readOp.longer_channel_leakage =
+      power.readOp.leakage * long_channel_device_reduction;
+  area.set_area(undifferentiated_core);
 
-	scktRatio = g_tp.sckt_co_eff;
-	power.readOp.dynamic *= scktRatio;
-	power.writeOp.dynamic *= scktRatio;
-	power.searchOp.dynamic *= scktRatio;
-	macro_PR_overhead = g_tp.macro_layout_overhead;
-	area.set_area(area.get_area()*macro_PR_overhead);
+  scktRatio = g_tp.sckt_co_eff;
+  power.readOp.dynamic *= scktRatio;
+  power.writeOp.dynamic *= scktRatio;
+  power.searchOp.dynamic *= scktRatio;
+  macro_PR_overhead = g_tp.macro_layout_overhead;
+  area.set_area(area.get_area() * macro_PR_overhead);
 
+  //		double vt=g_tp.peri_global.Vth;
+  //		double velocity_index=1.1;
+  //		double c_in=gate_C(g_tp.min_w_nmos_,
+  // g_tp.min_w_nmos_*pmos_to_nmos_sizing_r , 0.0, false); 		double
+  // c_out= drain_C_(g_tp.min_w_nmos_, NCH, 2, 1, g_tp.cell_h_def, false) +
+  // drain_C_(g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, PCH, 1, 1,
+  // g_tp.cell_h_def, false) + c_in; 		double w_nmos=g_tp.min_w_nmos_;
+  // double w_pmos=g_tp.min_w_nmos_*pmos_to_nmos_sizing_r; 		double
+  // i_on_n=1.0; 		double
+  // i_on_p=1.0; 		double i_on_n_in=1.0; 		double
+  // i_on_p_in=1; double vdd=g_tp.peri_global.Vdd;
 
+  //		power.readOp.sc=shortcircuit_simple(vt, velocity_index, c_in,
+  // c_out, w_nmos,w_pmos, i_on_n, i_on_p,i_on_n_in, i_on_p_in, vdd);
+  //		power.readOp.dynamic=c_out*vdd*vdd/2;
 
-//		double vt=g_tp.peri_global.Vth;
-//		double velocity_index=1.1;
-//		double c_in=gate_C(g_tp.min_w_nmos_, g_tp.min_w_nmos_*pmos_to_nmos_sizing_r , 0.0, false);
-//		double c_out= drain_C_(g_tp.min_w_nmos_, NCH, 2, 1, g_tp.cell_h_def, false) + drain_C_(g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, PCH, 1, 1, g_tp.cell_h_def, false) + c_in;
-//		double w_nmos=g_tp.min_w_nmos_;
-//		double w_pmos=g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
-//		double i_on_n=1.0;
-//		double i_on_p=1.0;
-//		double i_on_n_in=1.0;
-//		double i_on_p_in=1;
-//		double vdd=g_tp.peri_global.Vdd;
+  //		cout<<power.readOp.dynamic << "dynamic" <<endl;
+  //		cout<<power.readOp.sc << "sc" << endl;
 
-//		power.readOp.sc=shortcircuit_simple(vt, velocity_index, c_in, c_out, w_nmos,w_pmos, i_on_n, i_on_p,i_on_n_in, i_on_p_in, vdd);
-//		power.readOp.dynamic=c_out*vdd*vdd/2;
-
-//		cout<<power.readOp.dynamic << "dynamic" <<endl;
-//		cout<<power.readOp.sc << "sc" << endl;
-
-//		power.readOp.sc=shortcircuit(vt, velocity_index, c_in, c_out, w_nmos,w_pmos, i_on_n, i_on_p,i_on_n_in, i_on_p_in, vdd);
-//		power.readOp.dynamic=c_out*vdd*vdd/2;
-//
-//		cout<<power.readOp.dynamic << "dynamic" <<endl;
-//		cout<<power.readOp.sc << "sc" << endl;
-
-
-
+  //		power.readOp.sc=shortcircuit(vt, velocity_index, c_in, c_out,
+  // w_nmos,w_pmos, i_on_n, i_on_p,i_on_n_in, i_on_p_in, vdd);
+  //		power.readOp.dynamic=c_out*vdd*vdd/2;
+  //
+  //		cout<<power.readOp.dynamic << "dynamic" <<endl;
+  //		cout<<power.readOp.sc << "sc" << endl;
 }
 
+void UndiffCore::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
 
-void UndiffCore::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
-
-	if (is_tdp)
-	{
-		cout << indent_str << "UndiffCore:" << endl;
-		cout << indent_str_next << "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << power.readOp.dynamic*clockRate << " W" << endl;
-		//cout << indent_str_next << "Subthreshold Leakage = " << power.readOp.leakage <<" W" << endl;
-		cout << indent_str_next<< "Subthreshold Leakage = "
-					<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
-		//cout << indent_str_next << "Runtime Dynamic = " << rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-	}
-	else
-	{
-		cout << indent_str << "UndiffCore:" << endl;
-		cout << indent_str_next << "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = " << power.readOp.leakage <<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
-		//cout << indent_str_next << "Runtime Dynamic = " << rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-	}
-
+  if (is_tdp) {
+    cout << indent_str << "UndiffCore:" << endl;
+    cout << indent_str_next << "Area = " << area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << power.readOp.dynamic * clockRate << " W"
+         << endl;
+    // cout << indent_str_next << "Subthreshold Leakage = " <<
+    // power.readOp.leakage <<" W" << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? power.readOp.longer_channel_leakage
+                          : power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage
+         << " W" << endl;
+    // cout << indent_str_next << "Runtime Dynamic = " <<
+    // rt_power.readOp.dynamic/executionTime << " W" << endl;
+    cout << endl;
+  } else {
+    cout << indent_str << "UndiffCore:" << endl;
+    cout << indent_str_next << "Area = " << area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << power.readOp.dynamic * clockRate << " W"
+         << endl;
+    cout << indent_str_next << "Subthreshold Leakage = " << power.readOp.leakage
+         << " W" << endl;
+    cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage
+         << " W" << endl;
+    // cout << indent_str_next << "Runtime Dynamic = " <<
+    // rt_power.readOp.dynamic/executionTime << " W" << endl;
+    cout << endl;
+  }
 }
 
-inst_decoder::inst_decoder(
-		bool   _is_default,
-		const InputParameter *configure_interface,
-		int opcode_length_,
-		int num_decoders_,
-		bool x86_,
-	    enum Device_ty device_ty_,
-	    enum Core_type core_ty_)
-:is_default(_is_default),
- opcode_length(opcode_length_),
- num_decoders(num_decoders_),
- x86(x86_),
- device_ty(device_ty_),
- core_ty(core_ty_)
- {
-			/*
-			 * Instruction decoder is different from n to 2^n decoders
-			 * that are commonly used in row decoders in memory arrays.
-			 * The RISC instruction decoder is typically a very simple device.
-			 * We can decode an instruction by simply
-			 * separating the machine word into small parts using wire slices
-			 * The RISC instruction decoder can be approximate by the n to 2^n decoders,
-			 * although this approximation usually underestimate power since each decoded
-			 * instruction normally has more than 1 active signal.
-			 *
-			 * However, decoding a CISC instruction word is much more difficult
-			 * than the RISC case. A CISC decoder is typically set up as a state machine.
-			 * The machine reads the opcode field to determine
-			 * what type of instruction it is,
-			 * and where the other data values are.
-			 * The instruction word is read in piece by piece,
-			 * and decisions are made at each stage as to
-			 * how the remainder of the instruction word will be read.
-			 * (sequencer and ROM are usually needed)
-			 * An x86 decoder can be even more complex since
-			 * it involve  both decoding instructions into u-ops and
-			 * merge u-ops when doing micro-ops fusion.
-			 */
-			bool is_dram=false;
-			double pmos_to_nmos_sizing_r;
-			double load_nmos_width, load_pmos_width;
-			double C_driver_load, R_wire_load;
-			Area cell;
+inst_decoder::inst_decoder(bool _is_default,
+                           const InputParameter *configure_interface,
+                           int opcode_length_, int num_decoders_, bool x86_,
+                           enum Device_ty device_ty_, enum Core_type core_ty_)
+    : is_default(_is_default),
+      opcode_length(opcode_length_),
+      num_decoders(num_decoders_),
+      x86(x86_),
+      device_ty(device_ty_),
+      core_ty(core_ty_) {
+  /*
+   * Instruction decoder is different from n to 2^n decoders
+   * that are commonly used in row decoders in memory arrays.
+   * The RISC instruction decoder is typically a very simple device.
+   * We can decode an instruction by simply
+   * separating the machine word into small parts using wire slices
+   * The RISC instruction decoder can be approximate by the n to 2^n decoders,
+   * although this approximation usually underestimate power since each decoded
+   * instruction normally has more than 1 active signal.
+   *
+   * However, decoding a CISC instruction word is much more difficult
+   * than the RISC case. A CISC decoder is typically set up as a state machine.
+   * The machine reads the opcode field to determine
+   * what type of instruction it is,
+   * and where the other data values are.
+   * The instruction word is read in piece by piece,
+   * and decisions are made at each stage as to
+   * how the remainder of the instruction word will be read.
+   * (sequencer and ROM are usually needed)
+   * An x86 decoder can be even more complex since
+   * it involve  both decoding instructions into u-ops and
+   * merge u-ops when doing micro-ops fusion.
+   */
+  bool is_dram = false;
+  double pmos_to_nmos_sizing_r;
+  double load_nmos_width, load_pmos_width;
+  double C_driver_load, R_wire_load;
+  Area cell;
 
-			l_ip=*configure_interface;
-			local_result = init_interface(&l_ip);
-			cell.h =g_tp.cell_h_def;
-			cell.w =g_tp.cell_h_def;
+  l_ip = *configure_interface;
+  local_result = init_interface(&l_ip);
+  cell.h = g_tp.cell_h_def;
+  cell.w = g_tp.cell_h_def;
 
-			num_decoder_segments = (int)ceil(opcode_length/18.0);
-			if (opcode_length > 18)	opcode_length = 18;
-			num_decoded_signals= (int)pow(2.0,opcode_length);
-			pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
-			load_nmos_width=g_tp.max_w_nmos_ /2;
-			load_pmos_width= g_tp.max_w_nmos_ * pmos_to_nmos_sizing_r;
-			C_driver_load = 1024*gate_C(load_nmos_width + load_pmos_width, 0, is_dram); //TODO: this number 1024 needs to be revisited
-			R_wire_load   = 3000*l_ip.F_sz_um * g_tp.wire_outside_mat.R_per_um;
+  num_decoder_segments = (int)ceil(opcode_length / 18.0);
+  if (opcode_length > 18) opcode_length = 18;
+  num_decoded_signals = (int)pow(2.0, opcode_length);
+  pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
+  load_nmos_width = g_tp.max_w_nmos_ / 2;
+  load_pmos_width = g_tp.max_w_nmos_ * pmos_to_nmos_sizing_r;
+  C_driver_load =
+      1024 * gate_C(load_nmos_width + load_pmos_width, 0,
+                    is_dram);  // TODO: this number 1024 needs to be revisited
+  R_wire_load = 3000 * l_ip.F_sz_um * g_tp.wire_outside_mat.R_per_um;
 
-			final_dec = new Decoder(
-					num_decoded_signals,
-					false,
-					C_driver_load,
-					R_wire_load,
-					false/*is_fa*/,
-					false/*is_dram*/,
-					false/*wl_tr*/, //to use peri device
-					cell);
+  final_dec = new Decoder(num_decoded_signals, false, C_driver_load,
+                          R_wire_load, false /*is_fa*/, false /*is_dram*/,
+                          false /*wl_tr*/,  // to use peri device
+                          cell);
 
-			PredecBlk * predec_blk1 = new PredecBlk(
-					num_decoded_signals,
-					final_dec,
-					0,//Assuming predec and dec are back to back
-					0,
-					1,//Each Predec only drives one final dec
-					false/*is_dram*/,
-					true);
-			PredecBlk * predec_blk2 = new PredecBlk(
-					num_decoded_signals,
-					final_dec,
-					0,//Assuming predec and dec are back to back
-					0,
-					1,//Each Predec only drives one final dec
-					false/*is_dram*/,
-					false);
+  PredecBlk *predec_blk1 =
+      new PredecBlk(num_decoded_signals, final_dec,
+                    0,  // Assuming predec and dec are back to back
+                    0,
+                    1,  // Each Predec only drives one final dec
+                    false /*is_dram*/, true);
+  PredecBlk *predec_blk2 =
+      new PredecBlk(num_decoded_signals, final_dec,
+                    0,  // Assuming predec and dec are back to back
+                    0,
+                    1,  // Each Predec only drives one final dec
+                    false /*is_dram*/, false);
 
-			PredecBlkDrv * predec_blk_drv1 = new PredecBlkDrv(0, predec_blk1, false);
-			PredecBlkDrv * predec_blk_drv2 = new PredecBlkDrv(0, predec_blk2, false);
+  PredecBlkDrv *predec_blk_drv1 = new PredecBlkDrv(0, predec_blk1, false);
+  PredecBlkDrv *predec_blk_drv2 = new PredecBlkDrv(0, predec_blk2, false);
 
-			pre_dec            = new Predec(predec_blk_drv1, predec_blk_drv2);
+  pre_dec = new Predec(predec_blk_drv1, predec_blk_drv2);
 
-			double area_decoder = final_dec->area.get_area() * num_decoded_signals * num_decoder_segments*num_decoders;
-			//double w_decoder    = area_decoder / area.get_h();
-			double area_pre_dec = (predec_blk_drv1->area.get_area() +
-					predec_blk_drv2->area.get_area() +
-					predec_blk1->area.get_area() +
-					predec_blk2->area.get_area())*
-					num_decoder_segments*num_decoders;
-			area.set_area(area.get_area()+ area_decoder + area_pre_dec);
-			double macro_layout_overhead   = g_tp.macro_layout_overhead;
-			double chip_PR_overhead        = g_tp.chip_layout_overhead;
-			area.set_area(area.get_area()*macro_layout_overhead*chip_PR_overhead);
+  double area_decoder = final_dec->area.get_area() * num_decoded_signals *
+                        num_decoder_segments * num_decoders;
+  // double w_decoder    = area_decoder / area.get_h();
+  double area_pre_dec =
+      (predec_blk_drv1->area.get_area() + predec_blk_drv2->area.get_area() +
+       predec_blk1->area.get_area() + predec_blk2->area.get_area()) *
+      num_decoder_segments * num_decoders;
+  area.set_area(area.get_area() + area_decoder + area_pre_dec);
+  double macro_layout_overhead = g_tp.macro_layout_overhead;
+  double chip_PR_overhead = g_tp.chip_layout_overhead;
+  area.set_area(area.get_area() * macro_layout_overhead * chip_PR_overhead);
 
-			inst_decoder_delay_power();
+  inst_decoder_delay_power();
 
-			double sckRation = g_tp.sckt_co_eff;
-			power.readOp.dynamic *= sckRation;
-			power.writeOp.dynamic *= sckRation;
-			power.searchOp.dynamic *= sckRation;
+  double sckRation = g_tp.sckt_co_eff;
+  power.readOp.dynamic *= sckRation;
+  power.writeOp.dynamic *= sckRation;
+  power.searchOp.dynamic *= sckRation;
 
-			double long_channel_device_reduction = longer_channel_device_reduction(device_ty,core_ty);
-			power.readOp.longer_channel_leakage	= power.readOp.leakage*long_channel_device_reduction;
-
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(device_ty, core_ty);
+  power.readOp.longer_channel_leakage =
+      power.readOp.leakage * long_channel_device_reduction;
 }
 
-void inst_decoder::inst_decoder_delay_power()
-{
+void inst_decoder::inst_decoder_delay_power() {
+  double pppm_t[4] = {1, 1, 1, 1};
+  double squencer_passes = x86 ? 2 : 1;
 
-	double pppm_t[4]    = {1,1,1,1};
-	double squencer_passes = x86?2:1;
-
-	set_pppm(pppm_t, squencer_passes*num_decoder_segments, num_decoder_segments, squencer_passes*num_decoder_segments, num_decoder_segments);
-    power = power + pre_dec->power*pppm_t;
-    set_pppm(pppm_t, squencer_passes*num_decoder_segments, num_decoder_segments*num_decoded_signals,
-    		num_decoder_segments*num_decoded_signals, squencer_passes*num_decoder_segments);
-    power = power + final_dec->power*pppm_t;
+  set_pppm(pppm_t, squencer_passes * num_decoder_segments, num_decoder_segments,
+           squencer_passes * num_decoder_segments, num_decoder_segments);
+  power = power + pre_dec->power * pppm_t;
+  set_pppm(pppm_t, squencer_passes * num_decoder_segments,
+           num_decoder_segments * num_decoded_signals,
+           num_decoder_segments * num_decoded_signals,
+           squencer_passes * num_decoder_segments);
+  power = power + final_dec->power * pppm_t;
 }
-void inst_decoder::leakage_feedback(double temperature)
-{
-  l_ip.temp = (unsigned int)round(temperature/10.0)*10;
-  uca_org_t init_result = init_interface(&l_ip); // init_result is dummy
+void inst_decoder::leakage_feedback(double temperature) {
+  l_ip.temp = (unsigned int)round(temperature / 10.0) * 10;
+  uca_org_t init_result = init_interface(&l_ip);  // init_result is dummy
 
   final_dec->leakage_feedback(temperature);
   pre_dec->leakage_feedback(temperature);
 
-  double pppm_t[4]    = {1,1,1,1};
-  double squencer_passes = x86?2:1;
+  double pppm_t[4] = {1, 1, 1, 1};
+  double squencer_passes = x86 ? 2 : 1;
 
-  set_pppm(pppm_t, squencer_passes*num_decoder_segments, num_decoder_segments, squencer_passes*num_decoder_segments, num_decoder_segments);
-  power = pre_dec->power*pppm_t;
+  set_pppm(pppm_t, squencer_passes * num_decoder_segments, num_decoder_segments,
+           squencer_passes * num_decoder_segments, num_decoder_segments);
+  power = pre_dec->power * pppm_t;
 
-  set_pppm(pppm_t, squencer_passes*num_decoder_segments, num_decoder_segments*num_decoded_signals,num_decoder_segments*num_decoded_signals, squencer_passes*num_decoder_segments);
-  power = power + final_dec->power*pppm_t;
+  set_pppm(pppm_t, squencer_passes * num_decoder_segments,
+           num_decoder_segments * num_decoded_signals,
+           num_decoder_segments * num_decoded_signals,
+           squencer_passes * num_decoder_segments);
+  power = power + final_dec->power * pppm_t;
 
   double sckRation = g_tp.sckt_co_eff;
 
@@ -1086,19 +1358,20 @@ void inst_decoder::leakage_feedback(double temperature)
   power.writeOp.dynamic *= sckRation;
   power.searchOp.dynamic *= sckRation;
 
-  double long_channel_device_reduction = longer_channel_device_reduction(device_ty,core_ty);
-  power.readOp.longer_channel_leakage = power.readOp.leakage*long_channel_device_reduction;
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(device_ty, core_ty);
+  power.readOp.longer_channel_leakage =
+      power.readOp.leakage * long_channel_device_reduction;
 }
 
-inst_decoder::~inst_decoder()
-{
-	  local_result.cleanup();
+inst_decoder::~inst_decoder() {
+  local_result.cleanup();
 
-	  delete final_dec;
+  delete final_dec;
 
-	  delete pre_dec->blk1;
-	  delete pre_dec->blk2;
-	  delete pre_dec->drv1;
-	  delete pre_dec->drv2;
-	  delete pre_dec;
+  delete pre_dec->blk1;
+  delete pre_dec->blk2;
+  delete pre_dec->drv1;
+  delete pre_dec->drv2;
+  delete pre_dec;
 }

--- a/src/gpuwattch/logic.cc
+++ b/src/gpuwattch/logic.cc
@@ -29,217 +29,258 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:												   *
+*      Modified by:
+**
 *      Jingwen Leng, Univeristy of Texas, Austin                   *
 *      Syed Gilani, University of Wisconsin–Madison                *
 *      Tayler Hetherington, University of British Columbia         *
 *      Ahmed ElTantawy, University of British Columbia             *
 ********************************************************************/
 #include "logic.h"
-#define SP_BASE_POWER 0 
+#define SP_BASE_POWER 0
 #define SFU_BASE_POWER 0
 //.67
 
-//extern double exClockRate;
-//selection_logic
-selection_logic::selection_logic(
-    bool   _is_default,
-    int    win_entries_,
-    int    issue_width_,
-    const InputParameter *configure_interface,
-    enum Device_ty device_ty_,
-    enum Core_type core_ty_)
-    //const ParseXML *_XML_interface)
- :is_default(_is_default),
-  win_entries(win_entries_),
-  issue_width(issue_width_),
-  device_ty(device_ty_),
-  core_ty(core_ty_)
- {
-    	//uca_org_t result2;
-    	l_ip=*configure_interface;
-    	local_result = init_interface(&l_ip);
-    	//init_tech_params(l_ip.F_sz_um, false);
-    	//win_entries=numIBEntries;//IQentries;
-		//issue_width=issueWidth;
-    	selection_power();
-    	double sckRation = g_tp.sckt_co_eff;
-    	power.readOp.dynamic *= sckRation;
-    	power.writeOp.dynamic *= sckRation;
-    	power.searchOp.dynamic *= sckRation;
+// extern double exClockRate;
+// selection_logic
+selection_logic::selection_logic(bool _is_default, int win_entries_,
+                                 int issue_width_,
+                                 const InputParameter *configure_interface,
+                                 enum Device_ty device_ty_,
+                                 enum Core_type core_ty_)
+    // const ParseXML *_XML_interface)
+    : is_default(_is_default),
+      win_entries(win_entries_),
+      issue_width(issue_width_),
+      device_ty(device_ty_),
+      core_ty(core_ty_) {
+  // uca_org_t result2;
+  l_ip = *configure_interface;
+  local_result = init_interface(&l_ip);
+  // init_tech_params(l_ip.F_sz_um, false);
+  // win_entries=numIBEntries;//IQentries;
+  // issue_width=issueWidth;
+  selection_power();
+  double sckRation = g_tp.sckt_co_eff;
+  power.readOp.dynamic *= sckRation;
+  power.writeOp.dynamic *= sckRation;
+  power.searchOp.dynamic *= sckRation;
 
-    	double long_channel_device_reduction = longer_channel_device_reduction(device_ty,core_ty);
-    	power.readOp.longer_channel_leakage	= power.readOp.leakage*long_channel_device_reduction;
-	 }
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(device_ty, core_ty);
+  power.readOp.longer_channel_leakage =
+      power.readOp.leakage * long_channel_device_reduction;
+}
 
-void selection_logic::selection_power()
-{//based on cost effective superscalar processor TR pp27-31
+void selection_logic::selection_power() {  // based on cost effective
+                                           // superscalar processor TR pp27-31
   double Ctotal, Cor, Cpencode;
   int num_arbiter;
   double WSelORn, WSelORprequ, WSelPn, WSelPp, WSelEnn, WSelEnp;
 
-  //TODO: the 0.8um process data is used.
-  WSelORn    	=  	12.5 * l_ip.F_sz_um;//this was 10 micron for the 0.8 micron process
-  WSelORprequ   = 	50 * l_ip.F_sz_um;//this was 40 micron for the 0.8 micron process
-  WSelPn     	= 	12.5 * l_ip.F_sz_um;//this was 10mcron for the 0.8 micron process
-  WSelPp     	=  	18.75 * l_ip.F_sz_um;//this was 15 micron for the 0.8 micron process
-  WSelEnn    	=  	6.25 * l_ip.F_sz_um;//this was 5 micron for the 0.8 micron process
-  WSelEnp    	=  	12.5 * l_ip.F_sz_um;//this was 10 micron for the 0.8 micron process
+  // TODO: the 0.8um process data is used.
+  WSelORn =
+      12.5 * l_ip.F_sz_um;  // this was 10 micron for the 0.8 micron process
+  WSelORprequ =
+      50 * l_ip.F_sz_um;  // this was 40 micron for the 0.8 micron process
+  WSelPn = 12.5 * l_ip.F_sz_um;  // this was 10mcron for the 0.8 micron process
+  WSelPp =
+      18.75 * l_ip.F_sz_um;  // this was 15 micron for the 0.8 micron process
+  WSelEnn = 6.25 * l_ip.F_sz_um;  // this was 5 micron for the 0.8 micron
+                                  // process
+  WSelEnp =
+      12.5 * l_ip.F_sz_um;  // this was 10 micron for the 0.8 micron process
 
+  Ctotal = 0;
+  num_arbiter = 1;
+  while (win_entries > 4) {
+    win_entries = (int)ceil((double)win_entries / 4.0);
+    num_arbiter += win_entries;
+  }
+  // the 4-input OR logic to generate anyreq
+  Cor = 4 * drain_C_(WSelORn, NCH, 1, 1, g_tp.cell_h_def) +
+        drain_C_(WSelORprequ, PCH, 1, 1, g_tp.cell_h_def);
+  power.readOp.gate_leakage =
+      cmos_Ig_leakage(WSelORn, WSelORprequ, 4, nor) * g_tp.peri_global.Vdd;
 
-  Ctotal=0;
-  num_arbiter=1;
-  while(win_entries > 4)
-    {
-      win_entries = (int)ceil((double)win_entries / 4.0);
-      num_arbiter += win_entries;
-    }
-  //the 4-input OR logic to generate anyreq
-  Cor = 4 * drain_C_(WSelORn,NCH,1,1, g_tp.cell_h_def) + drain_C_(WSelORprequ,PCH,1,1, g_tp.cell_h_def);
-  power.readOp.gate_leakage = cmos_Ig_leakage(WSelORn, WSelORprequ, 4, nor)*g_tp.peri_global.Vdd;
+  // The total capacity of the 4-bit priority encoder
+  Cpencode =
+      drain_C_(WSelPn, NCH, 1, 1, g_tp.cell_h_def) +
+      drain_C_(WSelPp, PCH, 1, 1, g_tp.cell_h_def) +
+      2 * drain_C_(WSelPn, NCH, 1, 1, g_tp.cell_h_def) +
+      drain_C_(WSelPp, PCH, 2, 1, g_tp.cell_h_def) +
+      3 * drain_C_(WSelPn, NCH, 1, 1, g_tp.cell_h_def) +
+      drain_C_(WSelPp, PCH, 3, 1, g_tp.cell_h_def) +
+      4 * drain_C_(WSelPn, NCH, 1, 1, g_tp.cell_h_def) +
+      drain_C_(WSelPp, PCH, 4, 1,
+               g_tp.cell_h_def) +  // precompute priority logic
+      2 * 4 * gate_C(WSelEnn + WSelEnp, 20.0) +
+      4 * drain_C_(WSelEnn, NCH, 1, 1, g_tp.cell_h_def) +
+      2 * 4 * drain_C_(WSelEnp, PCH, 1, 1, g_tp.cell_h_def) +  // enable logic
+      (2 * 4 + 2 * 3 + 2 * 2 + 2) *
+          gate_C(WSelPn + WSelPp, 10.0);  // requests signal
 
-  //The total capacity of the 4-bit priority encoder
-  Cpencode = drain_C_(WSelPn,NCH,1, 1, g_tp.cell_h_def) + drain_C_(WSelPp,PCH,1, 1, g_tp.cell_h_def) +
-    2*drain_C_(WSelPn,NCH,1, 1, g_tp.cell_h_def) + drain_C_(WSelPp,PCH,2, 1, g_tp.cell_h_def) +
-    3*drain_C_(WSelPn,NCH,1, 1, g_tp.cell_h_def) + drain_C_(WSelPp,PCH,3, 1, g_tp.cell_h_def) +
-    4*drain_C_(WSelPn,NCH,1, 1, g_tp.cell_h_def) + drain_C_(WSelPp,PCH,4, 1, g_tp.cell_h_def) +//precompute priority logic
-    2*4*gate_C(WSelEnn+WSelEnp,20.0)+
-    4*drain_C_(WSelEnn,NCH,1, 1, g_tp.cell_h_def) + 2*4*drain_C_(WSelEnp,PCH,1, 1, g_tp.cell_h_def)+//enable logic
-    (2*4+2*3+2*2+2)*gate_C(WSelPn+WSelPp,10.0);//requests signal
+  Ctotal += issue_width * num_arbiter * (Cor + Cpencode);
 
-  Ctotal += issue_width * num_arbiter*(Cor+Cpencode);
-
-  power.readOp.dynamic = Ctotal*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*2;//2 means the abitration signal need to travel round trip
-  power.readOp.leakage = issue_width * num_arbiter *
-      (cmos_Isub_leakage(WSelPn, WSelPp, 2, nor)/*approximate precompute with a nor gate*///grant1p
-       + cmos_Isub_leakage(WSelPn, WSelPp, 3, nor)//grant2p
-       + cmos_Isub_leakage(WSelPn, WSelPp, 4, nor)//grant3p
-       + cmos_Isub_leakage(WSelEnn, WSelEnp, 2, nor)*4//enable logic
-       + cmos_Isub_leakage(WSelEnn, WSelEnp, 1, inv)*2*3//for each grant there are two inverters, there are 3 grant sIsubnals
-		  )*g_tp.peri_global.Vdd;
-  power.readOp.gate_leakage = issue_width * num_arbiter *
-      (cmos_Ig_leakage(WSelPn, WSelPp, 2, nor)/*approximate precompute with a nor gate*///grant1p
-       + cmos_Ig_leakage(WSelPn, WSelPp, 3, nor)//grant2p
-       + cmos_Ig_leakage(WSelPn, WSelPp, 4, nor)//grant3p
-       + cmos_Ig_leakage(WSelEnn, WSelEnp, 2, nor)*4//enable logic
-       + cmos_Ig_leakage(WSelEnn, WSelEnp, 1, inv)*2*3//for each grant there are two inverters, there are 3 grant signals
-        )*g_tp.peri_global.Vdd;
+  power.readOp.dynamic =
+      Ctotal * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd *
+      2;  // 2 means the abitration signal need to travel round trip
+  power.readOp.leakage =
+      issue_width * num_arbiter *
+      (cmos_Isub_leakage(
+           WSelPn, WSelPp, 2,
+           nor) /*approximate precompute with a nor gate*/  // grant1p
+       + cmos_Isub_leakage(WSelPn, WSelPp, 3, nor)          // grant2p
+       + cmos_Isub_leakage(WSelPn, WSelPp, 4, nor)          // grant3p
+       + cmos_Isub_leakage(WSelEnn, WSelEnp, 2, nor) * 4    // enable logic
+       +
+       cmos_Isub_leakage(WSelEnn, WSelEnp, 1, inv) * 2 *
+           3  // for each grant there are two inverters, there are 3 grant
+              // sIsubnals
+       ) *
+      g_tp.peri_global.Vdd;
+  power.readOp.gate_leakage =
+      issue_width * num_arbiter *
+      (cmos_Ig_leakage(
+           WSelPn, WSelPp, 2,
+           nor) /*approximate precompute with a nor gate*/  // grant1p
+       + cmos_Ig_leakage(WSelPn, WSelPp, 3, nor)            // grant2p
+       + cmos_Ig_leakage(WSelPn, WSelPp, 4, nor)            // grant3p
+       + cmos_Ig_leakage(WSelEnn, WSelEnp, 2, nor) * 4      // enable logic
+       +
+       cmos_Ig_leakage(WSelEnn, WSelEnp, 1, inv) * 2 *
+           3  // for each grant there are two inverters, there are 3 grant
+              // signals
+       ) *
+      g_tp.peri_global.Vdd;
 }
-
 
 dep_resource_conflict_check::dep_resource_conflict_check(
-	const InputParameter *configure_interface,
-	const CoreDynParam & dyn_p_,
-	int   compare_bits_,
-    bool   _is_default)
- :  l_ip(*configure_interface),
-    coredynp(dyn_p_),
-    compare_bits(compare_bits_),
-	is_default(_is_default)
-{
-    	Wcompn    	=  	25 * l_ip.F_sz_um;//this was 20.0 micron for the 0.8 micron process
-    	Wevalinvp   = 	25 * l_ip.F_sz_um;//this was 20.0 micron for the 0.8 micron process
-    	Wevalinvn   = 	100 * l_ip.F_sz_um;//this was 80.0 mcron for the 0.8 micron process
-    	Wcomppreequ =  	50 * l_ip.F_sz_um;//this was 40.0  micron for the 0.8 micron process
-    	WNORn    	=  	6.75 * l_ip.F_sz_um;//this was 5.4 micron for the 0.8 micron process
-    	WNORp    	=  	38.125 * l_ip.F_sz_um;//this was 30.5 micron for the 0.8 micron process
+    const InputParameter *configure_interface, const CoreDynParam &dyn_p_,
+    int compare_bits_, bool _is_default)
+    : l_ip(*configure_interface),
+      coredynp(dyn_p_),
+      compare_bits(compare_bits_),
+      is_default(_is_default) {
+  Wcompn = 25 * l_ip.F_sz_um;  // this was 20.0 micron for the 0.8 micron
+                               // process
+  Wevalinvp =
+      25 * l_ip.F_sz_um;  // this was 20.0 micron for the 0.8 micron process
+  Wevalinvn =
+      100 * l_ip.F_sz_um;  // this was 80.0 mcron for the 0.8 micron process
+  Wcomppreequ =
+      50 * l_ip.F_sz_um;  // this was 40.0  micron for the 0.8 micron process
+  WNORn = 6.75 * l_ip.F_sz_um;  // this was 5.4 micron for the 0.8 micron
+                                // process
+  WNORp =
+      38.125 * l_ip.F_sz_um;  // this was 30.5 micron for the 0.8 micron process
 
-    	local_result = init_interface(&l_ip);
+  local_result = init_interface(&l_ip);
 
-    	if (coredynp.core_ty==Inorder)
-   		    compare_bits += 16 + 8 + 8;//TODO: opcode bits + log(shared resources) + REG TAG BITS-->opcode comparator
-    	else
-    		compare_bits += 16 + 8 + 8;
+  if (coredynp.core_ty == Inorder)
+    compare_bits += 16 + 8 + 8;  // TODO: opcode bits + log(shared resources) +
+                                 // REG TAG BITS-->opcode comparator
+  else
+    compare_bits += 16 + 8 + 8;
 
-   		conflict_check_power();
-    	double sckRation = g_tp.sckt_co_eff;
-    	power.readOp.dynamic *= sckRation;
-    	power.writeOp.dynamic *= sckRation;
-    	power.searchOp.dynamic *= sckRation;
-
+  conflict_check_power();
+  double sckRation = g_tp.sckt_co_eff;
+  power.readOp.dynamic *= sckRation;
+  power.writeOp.dynamic *= sckRation;
+  power.searchOp.dynamic *= sckRation;
 }
 
-void dep_resource_conflict_check::conflict_check_power()
-{
-	double Ctotal;
-	int num_comparators;
-	num_comparators = 3*((coredynp.decodeW) * (coredynp.decodeW)-coredynp.decodeW);//2(N*N-N) is used for source to dest comparison, (N*N-N) is used for dest to dest comparision.
-	//When decode-width ==1, no dcl logic
+void dep_resource_conflict_check::conflict_check_power() {
+  double Ctotal;
+  int num_comparators;
+  num_comparators = 3 * ((coredynp.decodeW) * (coredynp.decodeW) -
+                         coredynp.decodeW);  // 2(N*N-N) is used for source to
+                                             // dest comparison, (N*N-N) is used
+                                             // for dest to dest comparision.
+  // When decode-width ==1, no dcl logic
 
-	Ctotal = num_comparators * compare_cap();
-	//printf("%i,%s\n",XML_interface->sys.core[0].predictor.predictor_entries,XML_interface->sys.core[0].predictor.prediction_scheme);
+  Ctotal = num_comparators * compare_cap();
+  // printf("%i,%s\n",XML_interface->sys.core[0].predictor.predictor_entries,XML_interface->sys.core[0].predictor.prediction_scheme);
 
-	power.readOp.dynamic=Ctotal*/*CLOCKRATE*/g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/*AF*/;
-	power.readOp.leakage=num_comparators*compare_bits*2*simplified_nmos_leakage(Wcompn,  false);
+  power.readOp.dynamic =
+      Ctotal * /*CLOCKRATE*/ g_tp.peri_global.Vdd * g_tp.peri_global.Vdd /*AF*/;
+  power.readOp.leakage = num_comparators * compare_bits * 2 *
+                         simplified_nmos_leakage(Wcompn, false);
 
-	double long_channel_device_reduction = longer_channel_device_reduction(Core_device, coredynp.core_ty);
-	power.readOp.longer_channel_leakage	= power.readOp.leakage*long_channel_device_reduction;
-	power.readOp.gate_leakage=num_comparators*compare_bits*2*cmos_Ig_leakage(Wcompn, 0, 2, nmos);
-
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(Core_device, coredynp.core_ty);
+  power.readOp.longer_channel_leakage =
+      power.readOp.leakage * long_channel_device_reduction;
+  power.readOp.gate_leakage =
+      num_comparators * compare_bits * 2 * cmos_Ig_leakage(Wcompn, 0, 2, nmos);
 }
 
 /* estimate comparator power consumption (this comparator is similar
    to the tag-match structure in a CAM */
-double dep_resource_conflict_check::compare_cap()
-{
+double dep_resource_conflict_check::compare_cap() {
   double c1, c2;
 
-  WNORp = WNORp * compare_bits/2.0;//resize the big NOR gate at the DCL according to fan in.
+  WNORp = WNORp * compare_bits /
+          2.0;  // resize the big NOR gate at the DCL according to fan in.
   /* bottom part of comparator */
-  c2 = (compare_bits)*(drain_C_(Wcompn,NCH,1,1, g_tp.cell_h_def)+drain_C_(Wcompn,NCH,2,1, g_tp.cell_h_def))+
-  drain_C_(Wevalinvp,PCH,1,1, g_tp.cell_h_def) + drain_C_(Wevalinvn,NCH,1,1, g_tp.cell_h_def);
+  c2 = (compare_bits) * (drain_C_(Wcompn, NCH, 1, 1, g_tp.cell_h_def) +
+                         drain_C_(Wcompn, NCH, 2, 1, g_tp.cell_h_def)) +
+       drain_C_(Wevalinvp, PCH, 1, 1, g_tp.cell_h_def) +
+       drain_C_(Wevalinvn, NCH, 1, 1, g_tp.cell_h_def);
 
   /* top part of comparator */
-  c1 = (compare_bits)*(drain_C_(Wcompn,NCH,1,1, g_tp.cell_h_def)+drain_C_(Wcompn,NCH,2,1, g_tp.cell_h_def)+
-		  drain_C_(Wcomppreequ,NCH,1,1, g_tp.cell_h_def)) +  gate_C(WNORn + WNORp,10.0) +
-		  drain_C_(WNORp,NCH,2,1, g_tp.cell_h_def) + compare_bits*drain_C_(WNORn,NCH,2,1, g_tp.cell_h_def);
-  return(c1 + c2);
-
+  c1 = (compare_bits) * (drain_C_(Wcompn, NCH, 1, 1, g_tp.cell_h_def) +
+                         drain_C_(Wcompn, NCH, 2, 1, g_tp.cell_h_def) +
+                         drain_C_(Wcomppreequ, NCH, 1, 1, g_tp.cell_h_def)) +
+       gate_C(WNORn + WNORp, 10.0) +
+       drain_C_(WNORp, NCH, 2, 1, g_tp.cell_h_def) +
+       compare_bits * drain_C_(WNORn, NCH, 2, 1, g_tp.cell_h_def);
+  return (c1 + c2);
 }
 
-void dep_resource_conflict_check::leakage_feedback(double temperature)
-{
-  l_ip.temp = (unsigned int)round(temperature/10.0)*10;
-  uca_org_t init_result = init_interface(&l_ip); // init_result is dummy
+void dep_resource_conflict_check::leakage_feedback(double temperature) {
+  l_ip.temp = (unsigned int)round(temperature / 10.0) * 10;
+  uca_org_t init_result = init_interface(&l_ip);  // init_result is dummy
 
   // This is part of conflict_check_power()
-  int num_comparators = 3*((coredynp.decodeW) * (coredynp.decodeW)-coredynp.decodeW);//2(N*N-N) is used for source to dest comparison, (N*N-N) is used for dest to dest comparision.
-  power.readOp.leakage=num_comparators*compare_bits*2*simplified_nmos_leakage(Wcompn,  false);
+  int num_comparators = 3 * ((coredynp.decodeW) * (coredynp.decodeW) -
+                             coredynp.decodeW);  // 2(N*N-N) is used for source
+                                                 // to dest comparison, (N*N-N)
+                                                 // is used for dest to dest
+                                                 // comparision.
+  power.readOp.leakage = num_comparators * compare_bits * 2 *
+                         simplified_nmos_leakage(Wcompn, false);
 
-  double long_channel_device_reduction = longer_channel_device_reduction(Core_device, coredynp.core_ty);
-  power.readOp.longer_channel_leakage	= power.readOp.leakage*long_channel_device_reduction;
-  power.readOp.gate_leakage=num_comparators*compare_bits*2*cmos_Ig_leakage(Wcompn, 0, 2, nmos);
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(Core_device, coredynp.core_ty);
+  power.readOp.longer_channel_leakage =
+      power.readOp.leakage * long_channel_device_reduction;
+  power.readOp.gate_leakage =
+      num_comparators * compare_bits * 2 * cmos_Ig_leakage(Wcompn, 0, 2, nmos);
 }
 
-//TODO: add inverter and transmission gate base DFF.
+// TODO: add inverter and transmission gate base DFF.
 
-DFFCell::DFFCell(
-		bool _is_dram,
-		double _WdecNANDn,
-		double _WdecNANDp,
-		double _cell_load,
-		const InputParameter *configure_interface)
-:is_dram(_is_dram),
-cell_load(_cell_load),
-WdecNANDn(_WdecNANDn),
-WdecNANDp(_WdecNANDp)
-{//this model is based on the NAND2 based DFF.
-			l_ip=*configure_interface;
-//			area.set_area(730*l_ip.F_sz_um*l_ip.F_sz_um);
-			area.set_area(5*compute_gate_area(NAND, 2,WdecNANDn,WdecNANDp, g_tp.cell_h_def)
-				+ compute_gate_area(NAND, 2,WdecNANDn,WdecNANDn, g_tp.cell_h_def));
-
-
+DFFCell::DFFCell(bool _is_dram, double _WdecNANDn, double _WdecNANDp,
+                 double _cell_load, const InputParameter *configure_interface)
+    : is_dram(_is_dram),
+      cell_load(_cell_load),
+      WdecNANDn(_WdecNANDn),
+      WdecNANDp(_WdecNANDp) {  // this model is based on the NAND2 based DFF.
+  l_ip = *configure_interface;
+  //			area.set_area(730*l_ip.F_sz_um*l_ip.F_sz_um);
+  area.set_area(
+      5 * compute_gate_area(NAND, 2, WdecNANDn, WdecNANDp, g_tp.cell_h_def) +
+      compute_gate_area(NAND, 2, WdecNANDn, WdecNANDn, g_tp.cell_h_def));
 }
 
-
-double DFFCell::fpfp_node_cap(unsigned int fan_in, unsigned int fan_out)
-{
+double DFFCell::fpfp_node_cap(unsigned int fan_in, unsigned int fan_out) {
   double Ctotal = 0;
-  //printf("WdecNANDn = %E\n", WdecNANDn);
+  // printf("WdecNANDn = %E\n", WdecNANDn);
 
   /* part 1: drain cap of NAND gate */
-  Ctotal += drain_C_(WdecNANDn, NCH, 2, 1, g_tp.cell_h_def, is_dram) + fan_in * drain_C_(WdecNANDp, PCH, 1, 1, g_tp.cell_h_def, is_dram);
+  Ctotal += drain_C_(WdecNANDn, NCH, 2, 1, g_tp.cell_h_def, is_dram) +
+            fan_in * drain_C_(WdecNANDp, PCH, 1, 1, g_tp.cell_h_def, is_dram);
 
   /* part 2: gate cap of NAND gates */
   Ctotal += fan_out * gate_C(WdecNANDn + WdecNANDp, 0, is_dram);
@@ -247,838 +288,1089 @@ double DFFCell::fpfp_node_cap(unsigned int fan_in, unsigned int fan_out)
   return Ctotal;
 }
 
+void DFFCell::compute_DFF_cell() {
+  double c1, c2, c3, c4, c5, c6;
+  /* node 5 and node 6 are identical to node 1 in capacitance */
+  c1 = c5 = c6 = fpfp_node_cap(2, 1);
+  c2 = fpfp_node_cap(2, 3);
+  c3 = fpfp_node_cap(3, 2);
+  c4 = fpfp_node_cap(2, 2);
 
-void DFFCell::compute_DFF_cell()
-{
-	double c1, c2, c3, c4, c5, c6;
-	   /* node 5 and node 6 are identical to node 1 in capacitance */
-	   c1 = c5 = c6 = fpfp_node_cap(2, 1);
-	   c2 = fpfp_node_cap(2, 3);
-	   c3 = fpfp_node_cap(3, 2);
-	   c4 = fpfp_node_cap(2, 2);
+  // cap-load of the clock signal in each Dff, actually the clock signal only
+  // connected to one NAND2
+  clock_cap = 2 * gate_C(WdecNANDn + WdecNANDp, 0, is_dram);
+  e_switch.readOp.dynamic += (c4 + c1 + c2 + c3 + c5 + c6 + 2 * cell_load) *
+                             0.5 * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd;
+  ;
 
-	   //cap-load of the clock signal in each Dff, actually the clock signal only connected to one NAND2
-	   clock_cap= 2 * gate_C(WdecNANDn + WdecNANDp, 0, is_dram);
-	   e_switch.readOp.dynamic += (c4 + c1 + c2 + c3 + c5 + c6 + 2*cell_load)*0.5*g_tp.peri_global.Vdd * g_tp.peri_global.Vdd;;
+  /* no 1/2 for e_keep and e_clock because clock signal switches twice in one
+   * cycle */
+  e_keep_1.readOp.dynamic += c3 * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd;
+  e_keep_0.readOp.dynamic += c2 * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd;
+  e_clock.readOp.dynamic +=
+      clock_cap * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd;
+  ;
 
-	   /* no 1/2 for e_keep and e_clock because clock signal switches twice in one cycle */
-	   e_keep_1.readOp.dynamic += c3 * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd ;
-	   e_keep_0.readOp.dynamic += c2 * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd ;
-	   e_clock.readOp.dynamic += clock_cap* g_tp.peri_global.Vdd * g_tp.peri_global.Vdd;;
-
-	   /* static power */
-	   e_switch.readOp.leakage +=  (cmos_Isub_leakage(WdecNANDn, WdecNANDp, 2, nand)*5//5 NAND2 and 1 NAND3 in a DFF
-                                           + cmos_Isub_leakage(WdecNANDn, WdecNANDn, 3, nand))*g_tp.peri_global.Vdd;
-	   e_switch.readOp.gate_leakage += (cmos_Ig_leakage(WdecNANDn, WdecNANDp, 2, nand)*5//5 NAND2 and 1 NAND3 in a DFF
-                                           + cmos_Ig_leakage(WdecNANDn, WdecNANDn, 3, nand))*g_tp.peri_global.Vdd;
-	   //printf("leakage =%E\n",cmos_Ileak(1, is_dram) );
+  /* static power */
+  e_switch.readOp.leakage +=
+      (cmos_Isub_leakage(WdecNANDn, WdecNANDp, 2, nand) *
+           5  // 5 NAND2 and 1 NAND3 in a DFF
+       + cmos_Isub_leakage(WdecNANDn, WdecNANDn, 3, nand)) *
+      g_tp.peri_global.Vdd;
+  e_switch.readOp.gate_leakage +=
+      (cmos_Ig_leakage(WdecNANDn, WdecNANDp, 2, nand) *
+           5  // 5 NAND2 and 1 NAND3 in a DFF
+       + cmos_Ig_leakage(WdecNANDn, WdecNANDn, 3, nand)) *
+      g_tp.peri_global.Vdd;
+  // printf("leakage =%E\n",cmos_Ileak(1, is_dram) );
 }
 
-Pipeline::Pipeline(
-		const InputParameter *configure_interface,
-		const CoreDynParam & dyn_p_,
-		enum Device_ty device_ty_,
-		bool _is_core_pipeline,
-		bool _is_default)
-: l_ip(*configure_interface),
-  coredynp(dyn_p_),
-  device_ty(device_ty_),
-  is_core_pipeline(_is_core_pipeline),
-  is_default(_is_default),
-  num_piperegs(0.0)
+Pipeline::Pipeline(const InputParameter *configure_interface,
+                   const CoreDynParam &dyn_p_, enum Device_ty device_ty_,
+                   bool _is_core_pipeline, bool _is_default)
+    : l_ip(*configure_interface),
+      coredynp(dyn_p_),
+      device_ty(device_ty_),
+      is_core_pipeline(_is_core_pipeline),
+      is_default(_is_default),
+      num_piperegs(0.0)
 
-  {
-	local_result = init_interface(&l_ip);
-	if (!coredynp.Embedded)
-		process_ind = true;
-	else
-		process_ind = false;
-	WNANDn = (process_ind)? 25 *   l_ip.F_sz_um : g_tp.min_w_nmos_ ;//this was  20 micron for the 0.8 micron process
-	WNANDp = (process_ind)? 37.5 * l_ip.F_sz_um : g_tp.min_w_nmos_*pmos_to_nmos_sz_ratio();//this was  30 micron for the 0.8 micron process
-	load_per_pipeline_stage = 2*gate_C(WNANDn + WNANDp, 0, false);
-	compute();
-
-}
-
-void Pipeline::compute()
 {
-	compute_stage_vector();
-	DFFCell pipe_reg(false, WNANDn,WNANDp, load_per_pipeline_stage, &l_ip);
-	pipe_reg.compute_DFF_cell();
-
-	double clock_power_pipereg = num_piperegs * pipe_reg.e_clock.readOp.dynamic;
-	//******************pipeline power: currently, we average all the possibilities of the states of DFFs in the pipeline. A better way to do it is to consider
-	//the harming distance of two consecutive signals, However McPAT does not have plan to do this in near future as it focuses on worst case power.
-	double pipe_reg_power = num_piperegs * (pipe_reg.e_switch.readOp.dynamic+pipe_reg.e_keep_0.readOp.dynamic+pipe_reg.e_keep_1.readOp.dynamic)/3+clock_power_pipereg;
-	double pipe_reg_leakage = num_piperegs * pipe_reg.e_switch.readOp.leakage;
-	double pipe_reg_gate_leakage = num_piperegs * pipe_reg.e_switch.readOp.gate_leakage;
-	power.readOp.dynamic	+=pipe_reg_power;
-	power.readOp.leakage	+=pipe_reg_leakage;
-	power.readOp.gate_leakage	+=pipe_reg_gate_leakage;
-	area.set_area(num_piperegs * pipe_reg.area.get_area());
-
-	double long_channel_device_reduction = longer_channel_device_reduction(device_ty, coredynp.core_ty);
-	power.readOp.longer_channel_leakage	= power.readOp.leakage*long_channel_device_reduction;
-
-
-	double sckRation = g_tp.sckt_co_eff;
-	power.readOp.dynamic *= sckRation;
-	power.writeOp.dynamic *= sckRation;
-	power.searchOp.dynamic *= sckRation;
-	double macro_layout_overhead = g_tp.macro_layout_overhead;
-	if (!coredynp.Embedded)
-		area.set_area(area.get_area()*macro_layout_overhead);
-}
-
-void Pipeline::compute_stage_vector()
-{
-	double num_stages, tot_stage_vector, per_stage_vector;
-	int opcode_length = coredynp.x86? coredynp.micro_opcode_length:coredynp.opcode_length;
-	//Hthread = thread_clock_gated? 1:num_thread;
-
-  if (!is_core_pipeline)
-  {
-	num_piperegs=l_ip.pipeline_stages*l_ip.per_stage_vector;//The number of pipeline stages are calculated based on the achievable throughput and required throughput
-  }
+  local_result = init_interface(&l_ip);
+  if (!coredynp.Embedded)
+    process_ind = true;
   else
-  {
-	if (coredynp.core_ty==Inorder)
-	{
-		/* assume 6 pipe stages and try to estimate bits per pipe stage */
-		/* pipe stage 0/IF */
-		num_piperegs += coredynp.pc_width*2*coredynp.num_hthreads;
-		/* pipe stage IF/ID */
-		num_piperegs += coredynp.fetchW*(coredynp.instruction_length + coredynp.pc_width)*coredynp.num_hthreads;
-		/* pipe stage IF/ThreadSEL */
-		if (coredynp.multithreaded) num_piperegs += coredynp.num_hthreads*coredynp.perThreadState; //8 bit thread states
-		/* pipe stage ID/EXE */
-		num_piperegs += coredynp.decodeW*(coredynp.instruction_length + coredynp.pc_width + pow(2.0,opcode_length)+ 2*coredynp.int_data_width)*coredynp.num_hthreads;
-		/* pipe stage EXE/MEM */
-		num_piperegs += coredynp.issueW*(3 * coredynp.arch_ireg_width + pow(2.0,opcode_length) + 8*2*coredynp.int_data_width/*+2*powers (2,reg_length)*/);
-		/* pipe stage MEM/WB the 2^opcode_length means the total decoded signal for the opcode*/
-		num_piperegs += coredynp.issueW*(2*coredynp.int_data_width + pow(2.0,opcode_length) + 8*2*coredynp.int_data_width/*+2*powers (2,reg_length)*/);
-//		/* pipe stage 5/6 */
-//		num_piperegs += issueWidth*(data_width + powers (2,opcode_length)/*+2*powers (2,reg_length)*/);
-//		/* pipe stage 6/7 */
-//		num_piperegs += issueWidth*(data_width + powers (2,opcode_length)/*+2*powers (2,reg_length)*/);
-//		/* pipe stage 7/8 */
-//		num_piperegs += issueWidth*(data_width + powers (2,opcode_length)/**2*powers (2,reg_length)*/);
-//		/* assume 50% extra in control signals (rule of thumb) */
-		num_stages=6;
+    process_ind = false;
+  WNANDn =
+      (process_ind)
+          ? 25 * l_ip.F_sz_um
+          : g_tp.min_w_nmos_;  // this was  20 micron for the 0.8 micron process
+  WNANDp = (process_ind)
+               ? 37.5 * l_ip.F_sz_um
+               : g_tp.min_w_nmos_ * pmos_to_nmos_sz_ratio();  // this was  30
+                                                              // micron for the
+                                                              // 0.8 micron
+                                                              // process
+  load_per_pipeline_stage = 2 * gate_C(WNANDn + WNANDp, 0, false);
+  compute();
+}
 
-	}
-	else
-	{
-		/* assume 12 stage pipe stages and try to estimate bits per pipe stage */
-		/*OOO: Fetch, decode, rename, IssueQ, dispatch, regread, EXE, MEM, WB, CM */
+void Pipeline::compute() {
+  compute_stage_vector();
+  DFFCell pipe_reg(false, WNANDn, WNANDp, load_per_pipeline_stage, &l_ip);
+  pipe_reg.compute_DFF_cell();
 
-		/* pipe stage 0/1F*/
-		num_piperegs += coredynp.pc_width*2*coredynp.num_hthreads ;//PC and Next PC
-		/* pipe stage IF/ID */
-		num_piperegs += coredynp.fetchW*(coredynp.instruction_length + coredynp.pc_width)*coredynp.num_hthreads;//PC is used to feed branch predictor in ID
-		/* pipe stage 1D/Renaming*/
-		num_piperegs += coredynp.decodeW*(coredynp.instruction_length + coredynp.pc_width)*coredynp.num_hthreads;//PC is for branch exe in later stage.
-		/* pipe stage Renaming/wire_drive */
-		num_piperegs += coredynp.decodeW*(coredynp.instruction_length + coredynp.pc_width);
-		/* pipe stage Renaming/IssueQ */
-		num_piperegs += coredynp.issueW*(coredynp.instruction_length  + coredynp.pc_width + 3*coredynp.phy_ireg_width)*coredynp.num_hthreads;//3*coredynp.phy_ireg_width means 2 sources and 1 dest
-		/* pipe stage IssueQ/Dispatch */
-		num_piperegs += coredynp.issueW*(coredynp.instruction_length + 3 * coredynp.phy_ireg_width);
-		/* pipe stage Dispatch/EXE */
+  double clock_power_pipereg = num_piperegs * pipe_reg.e_clock.readOp.dynamic;
+  //******************pipeline power: currently, we average all the
+  //possibilities of the states of DFFs in the pipeline. A better way to do it
+  //is to consider
+  // the harming distance of two consecutive signals, However McPAT does not
+  // have plan to do this in near future as it focuses on worst case power.
+  double pipe_reg_power = num_piperegs * (pipe_reg.e_switch.readOp.dynamic +
+                                          pipe_reg.e_keep_0.readOp.dynamic +
+                                          pipe_reg.e_keep_1.readOp.dynamic) /
+                              3 +
+                          clock_power_pipereg;
+  double pipe_reg_leakage = num_piperegs * pipe_reg.e_switch.readOp.leakage;
+  double pipe_reg_gate_leakage =
+      num_piperegs * pipe_reg.e_switch.readOp.gate_leakage;
+  power.readOp.dynamic += pipe_reg_power;
+  power.readOp.leakage += pipe_reg_leakage;
+  power.readOp.gate_leakage += pipe_reg_gate_leakage;
+  area.set_area(num_piperegs * pipe_reg.area.get_area());
 
-		num_piperegs += coredynp.issueW*(3 * coredynp.phy_ireg_width + coredynp.pc_width + pow(2.0,opcode_length)/*+2*powers (2,reg_length)*/);
-		/* 2^opcode_length means the total decoded signal for the opcode*/
-		num_piperegs += coredynp.issueW*(2*coredynp.int_data_width + pow(2.0,opcode_length)/*+2*powers (2,reg_length)*/);
-		/*2 source operands in EXE; Assume 2EXE stages* since we do not really distinguish OP*/
-		num_piperegs += coredynp.issueW*(2*coredynp.int_data_width + pow(2.0,opcode_length)/*+2*powers (2,reg_length)*/);
-		/* pipe stage EXE/MEM, data need to be read/write, address*/
-		num_piperegs += coredynp.issueW*(coredynp.int_data_width + coredynp.v_address_width + pow(2.0,opcode_length)/*+2*powers (2,reg_length)*/);//memory Opcode still need to be passed
-		/* pipe stage MEM/WB; result data, writeback regs */
-		num_piperegs += coredynp.issueW*(coredynp.int_data_width + coredynp.phy_ireg_width /* powers (2,opcode_length) + (2,opcode_length)+2*powers (2,reg_length)*/);
-		/* pipe stage WB/CM ; result data, regs need to be updated, address for resolve memory ops in ROB's top*/
-		num_piperegs += coredynp.commitW*(coredynp.int_data_width + coredynp.v_address_width + coredynp.phy_ireg_width/*+ powers (2,opcode_length)*2*powers (2,reg_length)*/)*coredynp.num_hthreads;
-//		if (multithreaded)
-//		{
-//
-//		}
-		num_stages=12;
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(device_ty, coredynp.core_ty);
+  power.readOp.longer_channel_leakage =
+      power.readOp.leakage * long_channel_device_reduction;
 
-	}
+  double sckRation = g_tp.sckt_co_eff;
+  power.readOp.dynamic *= sckRation;
+  power.writeOp.dynamic *= sckRation;
+  power.searchOp.dynamic *= sckRation;
+  double macro_layout_overhead = g_tp.macro_layout_overhead;
+  if (!coredynp.Embedded)
+    area.set_area(area.get_area() * macro_layout_overhead);
+}
 
-	/* assume 50% extra in control registers and interrupt registers (rule of thumb) */
-	num_piperegs = num_piperegs * 1.5;
-	tot_stage_vector=num_piperegs;
-	per_stage_vector=tot_stage_vector/num_stages;
+void Pipeline::compute_stage_vector() {
+  double num_stages, tot_stage_vector, per_stage_vector;
+  int opcode_length =
+      coredynp.x86 ? coredynp.micro_opcode_length : coredynp.opcode_length;
+  // Hthread = thread_clock_gated? 1:num_thread;
 
-	if (coredynp.core_ty==Inorder)
-	{
-		if (coredynp.pipeline_stages>6)
-			num_piperegs= per_stage_vector*coredynp.pipeline_stages;
-	}
-	else//OOO
-	{
-		if (coredynp.pipeline_stages>12)
-			num_piperegs= per_stage_vector*coredynp.pipeline_stages;
-	}
+  if (!is_core_pipeline) {
+    num_piperegs = l_ip.pipeline_stages *
+                   l_ip.per_stage_vector;  // The number of pipeline stages are
+                                           // calculated based on the achievable
+                                           // throughput and required throughput
+  } else {
+    if (coredynp.core_ty == Inorder) {
+      /* assume 6 pipe stages and try to estimate bits per pipe stage */
+      /* pipe stage 0/IF */
+      num_piperegs += coredynp.pc_width * 2 * coredynp.num_hthreads;
+      /* pipe stage IF/ID */
+      num_piperegs += coredynp.fetchW *
+                      (coredynp.instruction_length + coredynp.pc_width) *
+                      coredynp.num_hthreads;
+      /* pipe stage IF/ThreadSEL */
+      if (coredynp.multithreaded)
+        num_piperegs += coredynp.num_hthreads *
+                        coredynp.perThreadState;  // 8 bit thread states
+      /* pipe stage ID/EXE */
+      num_piperegs += coredynp.decodeW *
+                      (coredynp.instruction_length + coredynp.pc_width +
+                       pow(2.0, opcode_length) + 2 * coredynp.int_data_width) *
+                      coredynp.num_hthreads;
+      /* pipe stage EXE/MEM */
+      num_piperegs +=
+          coredynp.issueW *
+          (3 * coredynp.arch_ireg_width + pow(2.0, opcode_length) +
+           8 * 2 * coredynp.int_data_width /*+2*powers (2,reg_length)*/);
+      /* pipe stage MEM/WB the 2^opcode_length means the total decoded signal
+       * for the opcode*/
+      num_piperegs +=
+          coredynp.issueW *
+          (2 * coredynp.int_data_width + pow(2.0, opcode_length) +
+           8 * 2 * coredynp.int_data_width /*+2*powers (2,reg_length)*/);
+      //		/* pipe stage 5/6 */
+      //		num_piperegs += issueWidth*(data_width + powers
+      //(2,opcode_length)/*+2*powers (2,reg_length)*/);
+      //		/* pipe stage 6/7 */
+      //		num_piperegs += issueWidth*(data_width + powers
+      //(2,opcode_length)/*+2*powers (2,reg_length)*/);
+      //		/* pipe stage 7/8 */
+      //		num_piperegs += issueWidth*(data_width + powers
+      //(2,opcode_length)/**2*powers (2,reg_length)*/);
+      //		/* assume 50% extra in control signals (rule of thumb)
+      //*/
+      num_stages = 6;
+
+    } else {
+      /* assume 12 stage pipe stages and try to estimate bits per pipe stage */
+      /*OOO: Fetch, decode, rename, IssueQ, dispatch, regread, EXE, MEM, WB, CM
+       */
+
+      /* pipe stage 0/1F*/
+      num_piperegs +=
+          coredynp.pc_width * 2 * coredynp.num_hthreads;  // PC and Next PC
+      /* pipe stage IF/ID */
+      num_piperegs +=
+          coredynp.fetchW * (coredynp.instruction_length + coredynp.pc_width) *
+          coredynp.num_hthreads;  // PC is used to feed branch predictor in ID
+      /* pipe stage 1D/Renaming*/
+      num_piperegs +=
+          coredynp.decodeW * (coredynp.instruction_length + coredynp.pc_width) *
+          coredynp.num_hthreads;  // PC is for branch exe in later stage.
+      /* pipe stage Renaming/wire_drive */
+      num_piperegs +=
+          coredynp.decodeW * (coredynp.instruction_length + coredynp.pc_width);
+      /* pipe stage Renaming/IssueQ */
+      num_piperegs += coredynp.issueW *
+                      (coredynp.instruction_length + coredynp.pc_width +
+                       3 * coredynp.phy_ireg_width) *
+                      coredynp.num_hthreads;  // 3*coredynp.phy_ireg_width means
+                                              // 2 sources and 1 dest
+      /* pipe stage IssueQ/Dispatch */
+      num_piperegs += coredynp.issueW * (coredynp.instruction_length +
+                                         3 * coredynp.phy_ireg_width);
+      /* pipe stage Dispatch/EXE */
+
+      num_piperegs += coredynp.issueW *
+                      (3 * coredynp.phy_ireg_width + coredynp.pc_width +
+                       pow(2.0, opcode_length) /*+2*powers (2,reg_length)*/);
+      /* 2^opcode_length means the total decoded signal for the opcode*/
+      num_piperegs += coredynp.issueW *
+                      (2 * coredynp.int_data_width +
+                       pow(2.0, opcode_length) /*+2*powers (2,reg_length)*/);
+      /*2 source operands in EXE; Assume 2EXE stages* since we do not really
+       * distinguish OP*/
+      num_piperegs += coredynp.issueW *
+                      (2 * coredynp.int_data_width +
+                       pow(2.0, opcode_length) /*+2*powers (2,reg_length)*/);
+      /* pipe stage EXE/MEM, data need to be read/write, address*/
+      num_piperegs +=
+          coredynp.issueW *
+          (coredynp.int_data_width + coredynp.v_address_width +
+           pow(2.0, opcode_length) /*+2*powers (2,reg_length)*/);  // memory
+                                                                   // Opcode
+                                                                   // still need
+                                                                   // to be
+                                                                   // passed
+      /* pipe stage MEM/WB; result data, writeback regs */
+      num_piperegs +=
+          coredynp.issueW *
+          (coredynp.int_data_width +
+           coredynp
+               .phy_ireg_width /* powers (2,opcode_length) + (2,opcode_length)+2*powers (2,reg_length)*/);
+      /* pipe stage WB/CM ; result data, regs need to be updated, address for
+       * resolve memory ops in ROB's top*/
+      num_piperegs +=
+          coredynp.commitW *
+          (coredynp.int_data_width + coredynp.v_address_width +
+           coredynp
+               .phy_ireg_width /*+ powers (2,opcode_length)*2*powers (2,reg_length)*/) *
+          coredynp.num_hthreads;
+      //		if (multithreaded)
+      //		{
+      //
+      //		}
+      num_stages = 12;
+    }
+
+    /* assume 50% extra in control registers and interrupt registers (rule of
+     * thumb) */
+    num_piperegs = num_piperegs * 1.5;
+    tot_stage_vector = num_piperegs;
+    per_stage_vector = tot_stage_vector / num_stages;
+
+    if (coredynp.core_ty == Inorder) {
+      if (coredynp.pipeline_stages > 6)
+        num_piperegs = per_stage_vector * coredynp.pipeline_stages;
+    } else  // OOO
+    {
+      if (coredynp.pipeline_stages > 12)
+        num_piperegs = per_stage_vector * coredynp.pipeline_stages;
+    }
   }
-
 }
 
-FunctionalUnit::FunctionalUnit(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_,const CoreDynParam & dyn_p_, enum FU_type fu_type_, double exClockRate)
-:XML(XML_interface),
- ithCore(ithCore_),
- interface_ip(*interface_ip_),
- coredynp(dyn_p_),
- fu_type(fu_type_)
-{
-    double area_t;//, leakage, gate_leakage;
-    double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
-	clockRate = exClockRate;//coredynp.clockRate;
-	executionTime = coredynp.executionTime;
-	//cout<<"FU executionTime: "<<executionTime<<endl;
+FunctionalUnit::FunctionalUnit(ParseXML *XML_interface, int ithCore_,
+                               InputParameter *interface_ip_,
+                               const CoreDynParam &dyn_p_,
+                               enum FU_type fu_type_, double exClockRate)
+    : XML(XML_interface),
+      ithCore(ithCore_),
+      interface_ip(*interface_ip_),
+      coredynp(dyn_p_),
+      fu_type(fu_type_) {
+  double area_t;  //, leakage, gate_leakage;
+  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
+  clockRate = exClockRate;  // coredynp.clockRate;
+  executionTime = coredynp.executionTime;
+  // cout<<"FU executionTime: "<<executionTime<<endl;
 
-	//XML_interface=_XML_interface;
-	uca_org_t result2;
-	result2 = init_interface(&interface_ip);
-	if (XML->sys.Embedded)
-	{
-		if (fu_type == FPU)
-		{
-			num_fu=coredynp.num_fpus;
-			//area_t = 8.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2
-			area_t = 4.47*1e6*(g_ip->F_sz_nm*g_ip->F_sz_nm/90.0/90.0);//this is um^2 The base number
-			//4.47 contains both VFP and NEON processing unit, VFP is about 40% and NEON is about 60%
-			if (g_ip->F_sz_nm>90)
-				area_t = 4.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2
-			leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-			gate_leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-			//energy = 0.3529/10*1e-9;//this is the energy(nJ) for a FP instruction in FPU usually it can have up to 20 cycles.
-//			base_energy = coredynp.core_ty==Inorder? 0: 89e-3*3; //W The base energy of ALU average numbers from Intel 4G and 773Mhz (Wattch)
-//			base_energy *=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
-			base_energy = 0;
-			per_access_energy = 1.15/1e9/4/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9; //This is per Hz energy(nJ)
-			//per_access_energy*=3;
-			//FPU power from Sandia's processor sizing tech report
-			FU_height=(18667*num_fu)*interface_ip.F_sz_um;//FPU from Sun's data
-		}
-		else if (fu_type == ALU)
-		{
-			num_fu=coredynp.num_alus;			
-			//FIXME: The first area_t = is from updated McAPAT, the second is from our changes (conflict from base)
-			//area_t = 280*260*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2 ALU + MUl
-			area_t = 71.85*71.85*num_fu*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2 ALU + MUl
-			leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-			gate_leakage = area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;
-			leakage = 0;
-//			base_energy = coredynp.core_ty==Inorder? 0:89e-3; //W The base energy of ALU average numbers from Intel 4G and 773Mhz (Wattch)
-//			base_energy *=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
-			base_energy = 0;
-			//per_access_energy = 1.15/3/1e9/4/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9; //This is per cycle energy(nJ)
-         per_access_energy = 1.29/1e12/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);
-         //per_access_energy*=3;
-         FU_height=(6222*num_fu)*interface_ip.F_sz_um;//integer ALU
+  // XML_interface=_XML_interface;
+  uca_org_t result2;
+  result2 = init_interface(&interface_ip);
+  if (XML->sys.Embedded) {
+    if (fu_type == FPU) {
+      num_fu = coredynp.num_fpus;
+      // area_t = 8.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is
+      // um^2
+      area_t = 4.47 * 1e6 * (g_ip->F_sz_nm * g_ip->F_sz_nm / 90.0 /
+                             90.0);  // this is um^2 The base number
+      // 4.47 contains both VFP and NEON processing unit, VFP is about 40% and
+      // NEON is about 60%
+      if (g_ip->F_sz_nm > 90)
+        area_t = 4.47 * 1e6 *
+                 g_tp.scaling_factor.logic_scaling_co_eff;  // this is um^2
+      leakage = area_t * (g_tp.scaling_factor.core_tx_density) *
+                cmos_Isub_leakage(5 * g_tp.min_w_nmos_,
+                                  5 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r,
+                                  1, inv) *
+                g_tp.peri_global.Vdd / 2;  // unit W
+      gate_leakage = area_t * (g_tp.scaling_factor.core_tx_density) *
+                     cmos_Ig_leakage(
+                         5 * g_tp.min_w_nmos_,
+                         5 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
+                     g_tp.peri_global.Vdd / 2;  // unit W
+      // energy = 0.3529/10*1e-9;//this is the energy(nJ) for a FP instruction
+      // in FPU usually it can have up to 20 cycles.
+      //			base_energy = coredynp.core_ty==Inorder? 0:
+      //89e-3*3; //W The base energy of ALU average numbers from Intel 4G and
+      //773Mhz (Wattch)
+      //			base_energy
+      //*=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
+      base_energy = 0;
+      per_access_energy =
+          1.15 / 1e9 / 4 / 1.3 / 1.3 * g_tp.peri_global.Vdd *
+          g_tp.peri_global.Vdd *
+          (g_ip->F_sz_nm /
+           90.0);  // g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9;
+                   // //This is per Hz energy(nJ)
+      // per_access_energy*=3;
+      // FPU power from Sandia's processor sizing tech report
+      FU_height =
+          (18667 * num_fu) * interface_ip.F_sz_um;  // FPU from Sun's data
+    } else if (fu_type == ALU) {
+      num_fu = coredynp.num_alus;
+      // FIXME: The first area_t = is from updated McAPAT, the second is from
+      // our changes (conflict from base)
+      // area_t = 280*260*g_tp.scaling_factor.logic_scaling_co_eff;//this is
+      // um^2 ALU + MUl
+      area_t =
+          71.85 * 71.85 * num_fu *
+          g_tp.scaling_factor.logic_scaling_co_eff;  // this is um^2 ALU + MUl
+      leakage = area_t * (g_tp.scaling_factor.core_tx_density) *
+                cmos_Isub_leakage(20 * g_tp.min_w_nmos_,
+                                  20 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r,
+                                  1, inv) *
+                g_tp.peri_global.Vdd / 2;  // unit W
+      gate_leakage =
+          area_t * (g_tp.scaling_factor.core_tx_density) *
+          cmos_Ig_leakage(20 * g_tp.min_w_nmos_,
+                          20 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1,
+                          inv) *
+          g_tp.peri_global.Vdd / 2;
+      leakage = 0;
+      //			base_energy = coredynp.core_ty==Inorder?
+      //0:89e-3; //W The base energy of ALU average numbers from Intel 4G and
+      //773Mhz (Wattch)
+      //			base_energy
+      //*=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
+      base_energy = 0;
+      // per_access_energy =
+      // 1.15/3/1e9/4/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9;
+      // //This is per cycle energy(nJ)
+      per_access_energy = 1.29 / 1e12 / 1.3 / 1.3 * g_tp.peri_global.Vdd *
+                          g_tp.peri_global.Vdd * (g_ip->F_sz_nm / 90.0);
+      // per_access_energy*=3;
+      FU_height = (6222 * num_fu) * interface_ip.F_sz_um;  // integer ALU
 
-		}
-		else if (fu_type == MUL)
-		{
-			num_fu=coredynp.num_muls;
-			area_t = 280*260*3*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2 ALU + MUl
-			leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-			gate_leakage = area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;
-//			base_energy = coredynp.core_ty==Inorder? 0:89e-3*2; //W The base energy of ALU average numbers from Intel 4G and 773Mhz (Wattch)
-//			base_energy *=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
-			base_energy = 0;
-			per_access_energy = 1.15*2/3/1e9/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2)/24;//0.00649*1e-9; //This is per cycle energy(nJ), coefficient based on Wattch (24 is the division ny latency: Syed)
-			//per_access_energy*=3;
-			FU_height=(9334*num_fu )*interface_ip.F_sz_um;//divider/mul from Sun's data
-		}
-		else
-		{
-			cout<<"Unknown Functional Unit Type"<<endl;
-			exit(0);
-		}
-		per_access_energy *=0.5;//According to ARM data embedded processor has much lower per acc energy
-	} /* if (XML->sys.Embedded) */	
-	else
-	{
-		if (fu_type == FPU)
-		  		{
-			num_fu=coredynp.num_fpus;
-		
-			/*
-			num_fu/=2; //2 DP FPUs combine to for a SP FPU
-			//area_t = 8.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2
-			area_t = 8.47*1e6*(g_ip->F_sz_nm*g_ip->F_sz_nm/90.0/90.0);//this is um^2
-			if (g_ip->F_sz_nm>90)
-				area_t = 8.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2
-			leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-			gate_leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-			//energy = 0.3529/10*1e-9;//this is the energy(nJ) for a FP instruction in FPU usually it can have up to 20 cycles.
-			base_energy = coredynp.core_ty==Inorder? 0: 89e-3*3; //W The base energy of ALU average numbers from Intel 4G and 773Mhz (Wattch)
-			base_energy *=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
-			per_access_energy = 1.15*3/1e9/4/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9; //This is per op energy(nJ)
-			FU_height=(38667*num_fu)*interface_ip.F_sz_um;//FPU from Sun's data
-			*/
-			//area_t = 8.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2
-         num_fu=num_fu/2; //2 DP FPUs combine to for a SP FPU
-			area_t = 8.47*1e6*(g_ip->F_sz_nm*g_ip->F_sz_nm/90.0/90.0);//this is um^2
-			if (g_ip->F_sz_nm>90)
-				area_t = 8.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2
-			leakage = 37e-3;//area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-			gate_leakage = 0;//area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-			//energy = 0.3529/10*1e-9;//this is the energy(nJ) for a FP instruction in FPU usually it can have up to 20 cycles.
-			base_energy = coredynp.core_ty==Inorder? 0: 89e-3*3; //W The base energy of ALU average numbers from Intel 4G and 773Mhz (Wattch)
+    } else if (fu_type == MUL) {
+      num_fu = coredynp.num_muls;
+      area_t =
+          280 * 260 * 3 *
+          g_tp.scaling_factor.logic_scaling_co_eff;  // this is um^2 ALU + MUl
+      leakage = area_t * (g_tp.scaling_factor.core_tx_density) *
+                cmos_Isub_leakage(20 * g_tp.min_w_nmos_,
+                                  20 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r,
+                                  1, inv) *
+                g_tp.peri_global.Vdd / 2;  // unit W
+      gate_leakage =
+          area_t * (g_tp.scaling_factor.core_tx_density) *
+          cmos_Ig_leakage(20 * g_tp.min_w_nmos_,
+                          20 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1,
+                          inv) *
+          g_tp.peri_global.Vdd / 2;
+      //			base_energy = coredynp.core_ty==Inorder?
+      //0:89e-3*2; //W The base energy of ALU average numbers from Intel 4G and
+      //773Mhz (Wattch)
+      //			base_energy
+      //*=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
+      base_energy = 0;
+      per_access_energy =
+          1.15 * 2 / 3 / 1e9 / 1.3 / 1.3 * g_tp.peri_global.Vdd *
+          g_tp.peri_global.Vdd *
+          (g_ip->F_sz_nm /
+           90.0);  //(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2)/24;//0.00649*1e-9;
+                   ////This is per cycle energy(nJ), coefficient based on Wattch
+                   //(24 is the division ny latency: Syed)
+      // per_access_energy*=3;
+      FU_height = (9334 * num_fu) *
+                  interface_ip.F_sz_um;  // divider/mul from Sun's data
+    } else {
+      cout << "Unknown Functional Unit Type" << endl;
+      exit(0);
+    }
+    per_access_energy *= 0.5;  // According to ARM data embedded processor has
+                               // much lower per acc energy
+  } /* if (XML->sys.Embedded) */
+  else {
+    if (fu_type == FPU) {
+      num_fu = coredynp.num_fpus;
 
-			base_energy *=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
+      /*
+      num_fu/=2; //2 DP FPUs combine to for a SP FPU
+      //area_t = 8.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is
+      um^2
+      area_t = 8.47*1e6*(g_ip->F_sz_nm*g_ip->F_sz_nm/90.0/90.0);//this is um^2
+      if (g_ip->F_sz_nm>90)
+              area_t = 8.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this
+      is um^2
+      leakage = area_t
+      *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(5*g_tp.min_w_nmos_,
+      5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
+      inv)*g_tp.peri_global.Vdd/2;//unit W
+      gate_leakage = area_t
+      *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(5*g_tp.min_w_nmos_,
+      5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
+      inv)*g_tp.peri_global.Vdd/2;//unit W
+      //energy = 0.3529/10*1e-9;//this is the energy(nJ) for a FP instruction in
+      FPU usually it can have up to 20 cycles.
+      base_energy = coredynp.core_ty==Inorder? 0: 89e-3*3; //W The base energy
+      of ALU average numbers from Intel 4G and 773Mhz (Wattch)
+      base_energy *=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
+      per_access_energy =
+      1.15*3/1e9/4/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9;
+      //This is per op energy(nJ)
+      FU_height=(38667*num_fu)*interface_ip.F_sz_um;//FPU from Sun's data
+      */
+      // area_t = 8.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is
+      // um^2
+      num_fu = num_fu / 2;  // 2 DP FPUs combine to for a SP FPU
+      area_t = 8.47 * 1e6 *
+               (g_ip->F_sz_nm * g_ip->F_sz_nm / 90.0 / 90.0);  // this is um^2
+      if (g_ip->F_sz_nm > 90)
+        area_t = 8.47 * 1e6 *
+                 g_tp.scaling_factor.logic_scaling_co_eff;  // this is um^2
+      leakage =
+          37e-3;  // area_t
+                  // *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(5*g_tp.min_w_nmos_,
+                  // 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
+                  // inv)*g_tp.peri_global.Vdd/2;//unit W
+      gate_leakage =
+          0;  // area_t
+              // *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(5*g_tp.min_w_nmos_,
+              // 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
+              // inv)*g_tp.peri_global.Vdd/2;//unit W
+      // energy = 0.3529/10*1e-9;//this is the energy(nJ) for a FP instruction
+      // in FPU usually it can have up to 20 cycles.
+      base_energy =
+          coredynp.core_ty == Inorder ? 0 : 89e-3 * 3;  // W The base energy of
+                                                        // ALU average numbers
+                                                        // from Intel 4G and
+                                                        // 773Mhz (Wattch)
 
+      base_energy *= (g_tp.peri_global.Vdd * g_tp.peri_global.Vdd / 1.2 / 1.2);
 
-			//Base energy (if the pipeline is not clock gated)
-			//TODO: add a check for clockgating enable
-			base_energy=SP_BASE_POWER;
+      // Base energy (if the pipeline is not clock gated)
+      // TODO: add a check for clockgating enable
+      base_energy = SP_BASE_POWER;
 
-			//per_access_energy = 1.15*3/1e9/4/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9; //This is per op energy(nJ)
-         per_access_energy = 3.9*14.91/1e12/1.08/1.08*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//;4.34 is scaling factor based on hardware measurements
-			//ALU instrucitons are also executed on FPUs so add 30% overhead for supporting ALU instrcutions
-			//per_access_energy = 1.3*per_access_energy;
+      // per_access_energy =
+      // 1.15*3/1e9/4/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9;
+      // //This is per op energy(nJ)
+      per_access_energy =
+          3.9 * 14.91 / 1e12 / 1.08 / 1.08 * g_tp.peri_global.Vdd *
+          g_tp.peri_global.Vdd *
+          (g_ip->F_sz_nm /
+           90.0);  //;4.34 is scaling factor based on hardware measurements
+      // ALU instrucitons are also executed on FPUs so add 30% overhead for
+      // supporting ALU instrcutions
+      // per_access_energy = 1.3*per_access_energy;
 
+      // ALU instrucitons are also executed on FPUs so add 10% overhead for
+      // supporting ALU instrcutions
+      leakage = 1.1 * leakage;
+      // cout<<"FPU Per access erngy: "<<per_access_energy/2;
+      // Divide per access energy by 2 so we have 4 DP units capapble of
+      // doing 8 SP operations
+      // per_access_energy = per_access_energy/2;
+      FU_height =
+          (38667 * num_fu) * interface_ip.F_sz_um;  // FPU from Sun's data
+      per_access_energy *= 2;
+    } else if (fu_type == ALU) {
+      num_fu = coredynp.num_alus;
+      // FIXME: The first area_t = is from updated McPAT. The second is from our
+      // McPAT changes. Fix after merge
+      // area_t = 280*260*2*g_tp.scaling_factor.logic_scaling_co_eff;//this is
+      // um^2 ALU + MUl
+      // leakage = area_t
+      // *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_,
+      // 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
+      // inv)*g_tp.peri_global.Vdd/2;//unit W
+      // gate_leakage =
+      // area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_,
+      // 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
+      // inv)*g_tp.peri_global.Vdd/2;
+      area_t =
+          71.85 * 71.85 * num_fu *
+          g_tp.scaling_factor.logic_scaling_co_eff;  // this is um^2 ALU + MUl
+      // leakage = area_t
+      // *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_,
+      // 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
+      // inv)*g_tp.peri_global.Vdd/2;//unit W
+      // gate_leakage =
+      // area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_,
+      // 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
+      // inv)*g_tp.peri_global.Vdd/2;
+      // Following leakage numbers are based on Syntheis based power-estimation
+      // (SYED)
+      leakage = 2.58e-5;
+      gate_leakage = 0;
+      base_energy = coredynp.core_ty == Inorder
+                        ? 0
+                        : 89e-3;  // W The base energy of ALU average numbers
+                                  // from Intel 4G and 773Mhz (Wattch)
+      base_energy *= (g_tp.peri_global.Vdd * g_tp.peri_global.Vdd / 1.2 / 1.2);
+      // per_access_energy =
+      // 1.15/1e9/4/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9;
+      // //This is per cycle energy(nJ)
+      per_access_energy = 0.8 * 1.29 / 1e12 / 1.3 / 1.3 * g_tp.peri_global.Vdd *
+                          g_tp.peri_global.Vdd * (g_ip->F_sz_nm / 90.0);
+      FU_height = (6222 * num_fu) * interface_ip.F_sz_um;  // integer ALU
+      per_access_energy *= 2;
+    } else if (fu_type == MUL) {
+      num_fu = coredynp.num_muls;
+      area_t =
+          280 * 260 * 2 * 3 *
+          g_tp.scaling_factor.logic_scaling_co_eff;  // this is um^2 ALU + MUl
+      // leakage = area_t
+      // *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_,
+      // 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
+      // inv)*g_tp.peri_global.Vdd/2;//unit W
+      leakage = 37e-3;
+      gate_leakage =
+          0;  // area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_,
+              // 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
+              // inv)*g_tp.peri_global.Vdd/2;
+      base_energy =
+          coredynp.core_ty == Inorder ? 0 : 89e-3 * 2;  // W The base energy of
+                                                        // ALU average numbers
+                                                        // from Intel 4G and
+                                                        // 773Mhz (Wattch)
+      base_energy *= (g_tp.peri_global.Vdd * g_tp.peri_global.Vdd / 1.2 / 1.2);
+      base_energy = SFU_BASE_POWER;
+      // SFU is modelled as a double preicison FPU
+      per_access_energy =
+          8 * 14.91 / 1e12 / 1.08 / 1.08 * g_tp.peri_global.Vdd *
+          g_tp.peri_global.Vdd *
+          (g_ip->F_sz_nm /
+           90.0);  // 1.5 is scaling factor based on hardware measuremetns
+      FU_height = (9334 * num_fu) *
+                  interface_ip.F_sz_um;  // divider/mul from Sun's data
+      per_access_energy *= 2;
+    }
 
-			//ALU instrucitons are also executed on FPUs so add 10% overhead for supporting ALU instrcutions
-	   	leakage = 1.1*leakage;
-			//cout<<"FPU Per access erngy: "<<per_access_energy/2;
-			//Divide per access energy by 2 so we have 4 DP units capapble of 
-			//doing 8 SP operations
-			//per_access_energy = per_access_energy/2;
-			FU_height=(38667*num_fu)*interface_ip.F_sz_um;//FPU from Sun's data
-			per_access_energy*=2;
-		}
-		else if (fu_type == ALU)
-		{
-			num_fu=coredynp.num_alus;
-			//FIXME: The first area_t = is from updated McPAT. The second is from our McPAT changes. Fix after merge
-			//area_t = 280*260*2*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2 ALU + MUl
-			//leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-			//gate_leakage = area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;
-			area_t = 71.85*71.85*num_fu*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2 ALU + MUl
-			//leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-			//gate_leakage = area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;
-			//Following leakage numbers are based on Syntheis based power-estimation (SYED)
-			leakage = 2.58e-5;
-			gate_leakage = 0;
-			base_energy = coredynp.core_ty==Inorder? 0:89e-3; //W The base energy of ALU average numbers from Intel 4G and 773Mhz (Wattch)
-			base_energy *=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
-			//per_access_energy = 1.15/1e9/4/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9; //This is per cycle energy(nJ)
-			per_access_energy = 0.8*1.29/1e12/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);
-			FU_height=(6222*num_fu)*interface_ip.F_sz_um;//integer ALU
-			per_access_energy*=2;
-		}
-			else if (fu_type == MUL)
-		{
-			num_fu=coredynp.num_muls;
-			area_t = 280*260*2*3*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2 ALU + MUl
-			//leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-			leakage = 37e-3;
-			gate_leakage = 0;//area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;
-			base_energy = coredynp.core_ty==Inorder? 0:89e-3*2; //W The base energy of ALU average numbers from Intel 4G and 773Mhz (Wattch)
-			base_energy *=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
-			base_energy = SFU_BASE_POWER;
-			//SFU is modelled as a double preicison FPU
-			per_access_energy = 8*14.91/1e12/1.08/1.08*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//1.5 is scaling factor based on hardware measuremetns
-			FU_height=(9334*num_fu )*interface_ip.F_sz_um;//divider/mul from Sun's data
-			per_access_energy*=2;
-		}
-
-		else
-		{
-			cout<<"Unknown Functional Unit Type"<<endl;
-			exit(0);
-		}
-	}
-	//IEXEU, simple ALU and FPU
-	//  double C_ALU, C_EXEU, C_FPU; //Lum Equivalent capacitance of IEXEU and FPU. Based on Intel and Sun 90nm process fabracation.
-	//
-	//  C_ALU	  = 0.025e-9;//F
-	//  C_EXEU  = 0.05e-9; //F
-	//  C_FPU	  = 0.35e-9;//F
-    area.set_area(area_t*num_fu);
-    leakage *= num_fu;
-    gate_leakage *=num_fu;
-	double macro_layout_overhead = g_tp.macro_layout_overhead;
-//	if (!XML->sys.Embedded)
-		area.set_area(area.get_area()*macro_layout_overhead);
+    else {
+      cout << "Unknown Functional Unit Type" << endl;
+      exit(0);
+    }
+  }
+  // IEXEU, simple ALU and FPU
+  //  double C_ALU, C_EXEU, C_FPU; //Lum Equivalent capacitance of IEXEU and
+  //  FPU. Based on Intel and Sun 90nm process fabracation.
+  //
+  //  C_ALU	  = 0.025e-9;//F
+  //  C_EXEU  = 0.05e-9; //F
+  //  C_FPU	  = 0.35e-9;//F
+  area.set_area(area_t * num_fu);
+  leakage *= num_fu;
+  gate_leakage *= num_fu;
+  double macro_layout_overhead = g_tp.macro_layout_overhead;
+  //	if (!XML->sys.Embedded)
+  area.set_area(area.get_area() * macro_layout_overhead);
 }
 
-void FunctionalUnit::computeEnergy(bool is_tdp)
-{
- 
-  executionTime=XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);//Syed
-	double pppm_t[4]    = {1,1,1,1};
-	double FU_duty_cycle;
-	if (is_tdp)
-	{
+void FunctionalUnit::computeEnergy(bool is_tdp) {
+  executionTime =
+      XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);  // Syed
+  double pppm_t[4] = {1, 1, 1, 1};
+  double FU_duty_cycle;
+  if (is_tdp) {
+    set_pppm(pppm_t, 2, 2, 2, 2);  // 2 means two source operands needs to be
+                                   // passed for each int instruction.
+    if (fu_type == FPU) {
+      stats_t.readAc.access = num_fu;
+      tdp_stats = stats_t;
+      // Syed: FPU power numbers are already average
+      // so activity factor is already accounted for
+      FU_duty_cycle = coredynp.FPU_duty_cycle;
+    } else if (fu_type == ALU) {
+      stats_t.readAc.access = 1 * num_fu;
+      tdp_stats = stats_t;
+      FU_duty_cycle = coredynp.ALU_duty_cycle;
+    } else if (fu_type == MUL) {
+      stats_t.readAc.access = num_fu;
+      tdp_stats = stats_t;
+      FU_duty_cycle = coredynp.MUL_duty_cycle;
+    }
 
+    // power.readOp.dynamic = base_energy/clockRate +
+    // energy*stats_t.readAc.access;
+    power.readOp.dynamic =
+        per_access_energy * stats_t.readAc.access + base_energy / clockRate;
+    double sckRation = g_tp.sckt_co_eff;
+    power.readOp.dynamic *= sckRation * FU_duty_cycle;
+    power.writeOp.dynamic *= sckRation;
+    power.searchOp.dynamic *= sckRation;
 
-		set_pppm(pppm_t, 2, 2, 2, 2);//2 means two source operands needs to be passed for each int instruction.
-		if (fu_type == FPU)
-		{
-			stats_t.readAc.access = num_fu;
-			tdp_stats = stats_t;
-            //Syed: FPU power numbers are already average
-            //so activity factor is already accounted for
-			FU_duty_cycle= coredynp.FPU_duty_cycle;
-		}
-		else if (fu_type == ALU)
-		{
-			stats_t.readAc.access = 1*num_fu;
-			tdp_stats = stats_t;
-			FU_duty_cycle = coredynp.ALU_duty_cycle;
-		}
-		else if (fu_type == MUL)
-		{
-			stats_t.readAc.access = num_fu;
-			tdp_stats = stats_t;
-			FU_duty_cycle = coredynp.MUL_duty_cycle;
-		}
+    power.readOp.leakage = leakage;
+    power.readOp.gate_leakage = gate_leakage;
+    double long_channel_device_reduction =
+        longer_channel_device_reduction(Core_device, coredynp.core_ty);
+    power.readOp.longer_channel_leakage =
+        power.readOp.leakage * long_channel_device_reduction;
 
-	    //power.readOp.dynamic = base_energy/clockRate + energy*stats_t.readAc.access;
-	    power.readOp.dynamic = per_access_energy*stats_t.readAc.access + base_energy/clockRate;
-		double sckRation = g_tp.sckt_co_eff;
-		power.readOp.dynamic *= sckRation*FU_duty_cycle;
-		power.writeOp.dynamic *= sckRation;
-		power.searchOp.dynamic *= sckRation;
+  } else {
+    if (fu_type == FPU) {
+      // Each access activates an equililant of a double-precision unit
+      // so divide accesses into half
+      stats_t.readAc.access = XML->sys.core[ithCore].fpu_accesses;
+      rtp_stats = stats_t;
+      // cout<<"FPU: --accesses "<<stats_t.readAc.access <<endl;
 
-	    power.readOp.leakage = leakage;
-	    power.readOp.gate_leakage = gate_leakage;
-	    double long_channel_device_reduction = longer_channel_device_reduction(Core_device, coredynp.core_ty);
-	    power.readOp.longer_channel_leakage	= power.readOp.leakage*long_channel_device_reduction;
+    } else if (fu_type == ALU) {
+      stats_t.readAc.access = XML->sys.core[ithCore].ialu_accesses;
+      rtp_stats = stats_t;
+      // cout<<"ALU: --accesses "<<stats_t.readAc.access <<endl;
+    } else if (fu_type == MUL) {
+      stats_t.readAc.access = XML->sys.core[ithCore].mul_accesses;
+      rtp_stats = stats_t;
+      // cout<<"MUL: --accesses "<<stats_t.readAc.access <<endl;
+    }
 
-	}
-	else
-	{
-		if (fu_type == FPU)
-		{
-		  //Each access activates an equililant of a double-precision unit
-		  //so divide accesses into half
-			stats_t.readAc.access = XML->sys.core[ithCore].fpu_accesses;
-			rtp_stats = stats_t;
-			//cout<<"FPU: --accesses "<<stats_t.readAc.access <<endl;
+    // rt_power.readOp.dynamic = base_energy*executionTime +
+    // energy*stats_t.readAc.access;
 
-		}
-		else if (fu_type == ALU)
-		{
-			stats_t.readAc.access = XML->sys.core[ithCore].ialu_accesses;
-			rtp_stats = stats_t;
-			//cout<<"ALU: --accesses "<<stats_t.readAc.access <<endl;
-		}
-		else if (fu_type == MUL)
-		{
-			stats_t.readAc.access = XML->sys.core[ithCore].mul_accesses;
-			rtp_stats = stats_t;
-			//cout<<"MUL: --accesses "<<stats_t.readAc.access <<endl;
-		}
+    if (fu_type == ALU) {
+      rt_power.readOp.dynamic = per_access_energy * stats_t.readAc.access +
+                                base_energy * executionTime;
+    } else {
+      rt_power.readOp.dynamic = per_access_energy * stats_t.readAc.access;
+    }
 
-	    //rt_power.readOp.dynamic = base_energy*executionTime + energy*stats_t.readAc.access;
-	    
-		if(fu_type == ALU){
-		rt_power.readOp.dynamic = per_access_energy*stats_t.readAc.access + base_energy*executionTime;
-		}
-		else{
-		  rt_power.readOp.dynamic = per_access_energy*stats_t.readAc.access;
-		}
+    double sckRation = g_tp.sckt_co_eff;
+    rt_power.readOp.dynamic *= sckRation;
+    rt_power.writeOp.dynamic *= sckRation;
+    rt_power.searchOp.dynamic *= sckRation;
+    // cout<<"Power: "<<rt_power.readOp.dynamic<<endl;
+    if (fu_type == FPU) {
+      rt_power.readOp.dynamic +=
+          base_energy * executionTime *
+          (32 - XML->sys.core[ithCore].sp_average_active_lanes);
+    }
+    if (fu_type == MUL) {
+      if (XML->sys.core[ithCore].sfu_average_active_lanes >= 1)
+        rt_power.readOp.dynamic +=
+            base_energy * executionTime *
+            (32 - XML->sys.core[ithCore].sfu_average_active_lanes);
+    }
 
-		double sckRation = g_tp.sckt_co_eff;
-		rt_power.readOp.dynamic *= sckRation;
-		rt_power.writeOp.dynamic *= sckRation;
-		rt_power.searchOp.dynamic *= sckRation;
-      //cout<<"Power: "<<rt_power.readOp.dynamic<<endl;
-		if(fu_type == FPU){
-		  rt_power.readOp.dynamic += base_energy*executionTime*(32-XML->sys.core[ithCore].sp_average_active_lanes);
-		}
-		if(fu_type == MUL){
-		  if(XML->sys.core[ithCore].sfu_average_active_lanes>=1)
-		    rt_power.readOp.dynamic += base_energy*executionTime*(32-XML->sys.core[ithCore].sfu_average_active_lanes);
-		}
-
-	} /* else */	
-
-
-
+  } /* else */
 }
 
-void FunctionalUnit::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
+void FunctionalUnit::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
 
-//	cout << indent_str_next << "Results Broadcast Bus Area = " << bypass->area.get_area() *1e-6 << " mm^2" << endl;
-	if (is_tdp)
-	{
-		if (fu_type == FPU)
-		{
-			cout << indent_str << "Floating Point Units (FPUs) (Count: "<< coredynp.num_fpus <<" ):" << endl;
-			cout << indent_str_next << "Area = " << area.get_area()*1e-6  << " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << power.readOp.dynamic*clockRate  << " W" << endl;
-			cout << indent_str_next << "Peak Energy = " << power.readOp.dynamic  << " J" << endl;
+  //	cout << indent_str_next << "Results Broadcast Bus Area = " <<
+  //bypass->area.get_area() *1e-6 << " mm^2" << endl;
+  if (is_tdp) {
+    if (fu_type == FPU) {
+      cout << indent_str
+           << "Floating Point Units (FPUs) (Count: " << coredynp.num_fpus
+           << " ):" << endl;
+      cout << indent_str_next << "Area = " << area.get_area() * 1e-6 << " mm^2"
+           << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << power.readOp.dynamic * clockRate << " W"
+           << endl;
+      cout << indent_str_next << "Peak Energy = " << power.readOp.dynamic
+           << " J" << endl;
 
-//			cout << indent_str_next << "Subthreshold Leakage = " << power.readOp.leakage  << " W" << endl;
-        //cout <<"clock: "<<clockRate<<endl;
-			cout << indent_str_next<< "Subthreshold Leakage = "
-						<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-		}
-		else if (fu_type == ALU)
-		{
-			cout << indent_str << "Integer ALUs (Count: "<< coredynp.num_alus <<" ):" << endl;
-			cout << indent_str_next << "Area = " << area.get_area()*1e-6  << " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << power.readOp.dynamic*clockRate  << " W" << endl;
-//			cout << indent_str_next << "Subthreshold Leakage = " << power.readOp.leakage  << " W" << endl;
-			cout << indent_str_next<< "Subthreshold Leakage = "
-						<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
-		}
-		else if (fu_type == MUL)
-		{
-			cout << indent_str << "Complex ALUs (Mul/Div) (Count: "<< coredynp.num_muls <<" ):" << endl;
-			cout << indent_str_next << "Area = " << area.get_area()*1e-6  << " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << power.readOp.dynamic*clockRate  << " W" << endl;
-//			cout << indent_str_next << "Subthreshold Leakage = " << power.readOp.leakage  << " W" << endl;
-			cout << indent_str_next<< "Subthreshold Leakage = "
-						<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage  << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << rt_power.readOp.dynamic/executionTime << " W" << endl;
-			cout <<endl;
+      //			cout << indent_str_next << "Subthreshold Leakage
+      //= " << power.readOp.leakage  << " W" << endl;
+      // cout <<"clock: "<<clockRate<<endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? power.readOp.longer_channel_leakage
+                            : power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage
+           << " W" << endl;
+      cout << indent_str_next
+           << "Runtime Dynamic = " << rt_power.readOp.dynamic / executionTime
+           << " W" << endl;
+      cout << endl;
+    } else if (fu_type == ALU) {
+      cout << indent_str << "Integer ALUs (Count: " << coredynp.num_alus
+           << " ):" << endl;
+      cout << indent_str_next << "Area = " << area.get_area() * 1e-6 << " mm^2"
+           << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << power.readOp.dynamic * clockRate << " W"
+           << endl;
+      //			cout << indent_str_next << "Subthreshold Leakage
+      //= " << power.readOp.leakage  << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? power.readOp.longer_channel_leakage
+                            : power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage
+           << " W" << endl;
+      cout << indent_str_next
+           << "Runtime Dynamic = " << rt_power.readOp.dynamic / executionTime
+           << " W" << endl;
+      cout << endl;
+    } else if (fu_type == MUL) {
+      cout << indent_str
+           << "Complex ALUs (Mul/Div) (Count: " << coredynp.num_muls
+           << " ):" << endl;
+      cout << indent_str_next << "Area = " << area.get_area() * 1e-6 << " mm^2"
+           << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << power.readOp.dynamic * clockRate << " W"
+           << endl;
+      //			cout << indent_str_next << "Subthreshold Leakage
+      //= " << power.readOp.leakage  << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? power.readOp.longer_channel_leakage
+                            : power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage
+           << " W" << endl;
+      cout << indent_str_next
+           << "Runtime Dynamic = " << rt_power.readOp.dynamic / executionTime
+           << " W" << endl;
+      cout << endl;
+    }
 
-		}
-
-	}
-	else
-	{
-	}
-
+  } else {
+  }
 }
 
-void FunctionalUnit::leakage_feedback(double temperature)
-{
+void FunctionalUnit::leakage_feedback(double temperature) {
   // Update the temperature and initialize the global interfaces.
-  interface_ip.temp = (unsigned int)round(temperature/10.0)*10;
+  interface_ip.temp = (unsigned int)round(temperature / 10.0) * 10;
 
-  uca_org_t init_result = init_interface(&interface_ip); // init_result is dummy
+  uca_org_t init_result =
+      init_interface(&interface_ip);  // init_result is dummy
 
   // This is part of FunctionalUnit()
   double area_t, leakage, gate_leakage;
   double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
 
-  if (fu_type == FPU)
-  {
-	area_t = 4.47*1e6*(g_ip->F_sz_nm*g_ip->F_sz_nm/90.0/90.0);//this is um^2 The base number
-	if (g_ip->F_sz_nm>90)
-		area_t = 4.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2
-	leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-	gate_leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-  }
-  else if (fu_type == ALU)
-  {
-    area_t = 280*260*2*num_fu*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2 ALU + MUl
-    leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-    gate_leakage = area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;
-  }
-  else if (fu_type == MUL)
-  {
-    area_t = 280*260*2*3*num_fu*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2 ALU + MUl
-    leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
-    gate_leakage = area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;
-  }
-  else
-  {
-    cout<<"Unknown Functional Unit Type"<<endl;
+  if (fu_type == FPU) {
+    area_t = 4.47 * 1e6 * (g_ip->F_sz_nm * g_ip->F_sz_nm / 90.0 /
+                           90.0);  // this is um^2 The base number
+    if (g_ip->F_sz_nm > 90)
+      area_t = 4.47 * 1e6 *
+               g_tp.scaling_factor.logic_scaling_co_eff;  // this is um^2
+    leakage = area_t * (g_tp.scaling_factor.core_tx_density) *
+              cmos_Isub_leakage(5 * g_tp.min_w_nmos_,
+                                5 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1,
+                                inv) *
+              g_tp.peri_global.Vdd / 2;  // unit W
+    gate_leakage =
+        area_t * (g_tp.scaling_factor.core_tx_density) *
+        cmos_Ig_leakage(5 * g_tp.min_w_nmos_,
+                        5 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
+        g_tp.peri_global.Vdd / 2;  // unit W
+  } else if (fu_type == ALU) {
+    area_t =
+        280 * 260 * 2 * num_fu *
+        g_tp.scaling_factor.logic_scaling_co_eff;  // this is um^2 ALU + MUl
+    leakage = area_t * (g_tp.scaling_factor.core_tx_density) *
+              cmos_Isub_leakage(20 * g_tp.min_w_nmos_,
+                                20 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r,
+                                1, inv) *
+              g_tp.peri_global.Vdd / 2;  // unit W
+    gate_leakage =
+        area_t * (g_tp.scaling_factor.core_tx_density) *
+        cmos_Ig_leakage(20 * g_tp.min_w_nmos_,
+                        20 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
+        g_tp.peri_global.Vdd / 2;
+  } else if (fu_type == MUL) {
+    area_t =
+        280 * 260 * 2 * 3 * num_fu *
+        g_tp.scaling_factor.logic_scaling_co_eff;  // this is um^2 ALU + MUl
+    leakage = area_t * (g_tp.scaling_factor.core_tx_density) *
+              cmos_Isub_leakage(20 * g_tp.min_w_nmos_,
+                                20 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r,
+                                1, inv) *
+              g_tp.peri_global.Vdd / 2;  // unit W
+    gate_leakage =
+        area_t * (g_tp.scaling_factor.core_tx_density) *
+        cmos_Ig_leakage(20 * g_tp.min_w_nmos_,
+                        20 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
+        g_tp.peri_global.Vdd / 2;
+  } else {
+    cout << "Unknown Functional Unit Type" << endl;
     exit(1);
   }
 
-  power.readOp.leakage = leakage*num_fu;
-  power.readOp.gate_leakage = gate_leakage*num_fu;
-  power.readOp.longer_channel_leakage = longer_channel_device_reduction(Core_device, coredynp.core_ty);
+  power.readOp.leakage = leakage * num_fu;
+  power.readOp.gate_leakage = gate_leakage * num_fu;
+  power.readOp.longer_channel_leakage =
+      longer_channel_device_reduction(Core_device, coredynp.core_ty);
 }
 
-UndiffCore::UndiffCore(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_, bool exist_,  bool embedded_)
-:XML(XML_interface),
- ithCore(ithCore_),
- interface_ip(*interface_ip_),
- coredynp(dyn_p_),
- core_ty(coredynp.core_ty),
- embedded(XML->sys.Embedded),
- pipeline_stage(coredynp.pipeline_stages),
- num_hthreads(coredynp.num_hthreads),
- issue_width(coredynp.issueW),
- exist(exist_)
+UndiffCore::UndiffCore(ParseXML *XML_interface, int ithCore_,
+                       InputParameter *interface_ip_,
+                       const CoreDynParam &dyn_p_, bool exist_, bool embedded_)
+    : XML(XML_interface),
+      ithCore(ithCore_),
+      interface_ip(*interface_ip_),
+      coredynp(dyn_p_),
+      core_ty(coredynp.core_ty),
+      embedded(XML->sys.Embedded),
+      pipeline_stage(coredynp.pipeline_stages),
+      num_hthreads(coredynp.num_hthreads),
+      issue_width(coredynp.issueW),
+      exist(exist_)
 // is_default(_is_default)
 {
-	if (!exist) return;
-	double undifferentiated_core=0;
-	double core_tx_density=0;
-	double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
-	double undifferentiated_core_coe;
-	//XML_interface=_XML_interface;
-	uca_org_t result2;
-	result2 = init_interface(&interface_ip);
+  if (!exist) return;
+  double undifferentiated_core = 0;
+  double core_tx_density = 0;
+  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
+  double undifferentiated_core_coe;
+  // XML_interface=_XML_interface;
+  uca_org_t result2;
+  result2 = init_interface(&interface_ip);
 
-	//Compute undifferentiated core area at 90nm.
-	if (embedded==false)
-	{
-		//Based on the results of polynomial/log curve fitting based on undifferentiated core of Niagara, Niagara2, Merom, Penyrn, Prescott, Opteron die measurements
-		if (core_ty==OOO)
-		{
-			//undifferentiated_core = (0.0764*pipeline_stage*pipeline_stage -2.3685*pipeline_stage + 10.405);//OOO
-			undifferentiated_core = (3.57*log(pipeline_stage)-1.2643)>0?(3.57*log(pipeline_stage)-1.2643):0;
-		}
-		else if (core_ty==Inorder)
-		{
-			//undifferentiated_core = (0.1238*pipeline_stage + 7.2572)*0.9;//inorder
-			undifferentiated_core = (-2.19*log(pipeline_stage)+6.55)>0?(-2.19*log(pipeline_stage)+6.55):0;
-		}
-		else
-		{
-			cout<<"invalid core type"<<endl;
-			exit(0);
-		}
-		undifferentiated_core *= (1+ logtwo(num_hthreads)* 0.0716);
-	}
-	else
-	{
-		//Based on the results in paper "parametrized processor models" Sandia Labs
-		if (XML->sys.opt_clockrate)
-			undifferentiated_core_coe = 0.05;
-		else
-			undifferentiated_core_coe = 0;
-		undifferentiated_core = (0.4109* pipeline_stage - 0.776)*undifferentiated_core_coe;
-		undifferentiated_core *= (1+ logtwo(num_hthreads)* 0.0426);
-	}
+  // Compute undifferentiated core area at 90nm.
+  if (embedded == false) {
+    // Based on the results of polynomial/log curve fitting based on
+    // undifferentiated core of Niagara, Niagara2, Merom, Penyrn, Prescott,
+    // Opteron die measurements
+    if (core_ty == OOO) {
+      // undifferentiated_core = (0.0764*pipeline_stage*pipeline_stage
+      // -2.3685*pipeline_stage + 10.405);//OOO
+      undifferentiated_core = (3.57 * log(pipeline_stage) - 1.2643) > 0
+                                  ? (3.57 * log(pipeline_stage) - 1.2643)
+                                  : 0;
+    } else if (core_ty == Inorder) {
+      // undifferentiated_core = (0.1238*pipeline_stage + 7.2572)*0.9;//inorder
+      undifferentiated_core = (-2.19 * log(pipeline_stage) + 6.55) > 0
+                                  ? (-2.19 * log(pipeline_stage) + 6.55)
+                                  : 0;
+    } else {
+      cout << "invalid core type" << endl;
+      exit(0);
+    }
+    undifferentiated_core *= (1 + logtwo(num_hthreads) * 0.0716);
+  } else {
+    // Based on the results in paper "parametrized processor models" Sandia Labs
+    if (XML->sys.opt_clockrate)
+      undifferentiated_core_coe = 0.05;
+    else
+      undifferentiated_core_coe = 0;
+    undifferentiated_core =
+        (0.4109 * pipeline_stage - 0.776) * undifferentiated_core_coe;
+    undifferentiated_core *= (1 + logtwo(num_hthreads) * 0.0426);
+  }
 
-	undifferentiated_core 		    *= g_tp.scaling_factor.logic_scaling_co_eff*1e6;//change from mm^2 to um^2
-	core_tx_density                 = g_tp.scaling_factor.core_tx_density;
-	//undifferentiated_core 		    = 3*1e6;
-	//undifferentiated_core			*= g_tp.scaling_factor.logic_scaling_co_eff;//(g_ip->F_sz_um*g_ip->F_sz_um/0.09/0.09)*;
-	power.readOp.leakage = undifferentiated_core*(core_tx_density)*cmos_Isub_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd;//unit W
-	power.readOp.gate_leakage = undifferentiated_core*(core_tx_density)*cmos_Ig_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd;
+  undifferentiated_core *= g_tp.scaling_factor.logic_scaling_co_eff *
+                           1e6;  // change from mm^2 to um^2
+  core_tx_density = g_tp.scaling_factor.core_tx_density;
+  // undifferentiated_core 		    = 3*1e6;
+  // undifferentiated_core			*=
+  // g_tp.scaling_factor.logic_scaling_co_eff;//(g_ip->F_sz_um*g_ip->F_sz_um/0.09/0.09)*;
+  power.readOp.leakage =
+      undifferentiated_core *
+      (core_tx_density)*cmos_Isub_leakage(
+          5 * g_tp.min_w_nmos_, 5 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1,
+          inv) *
+      g_tp.peri_global.Vdd;  // unit W
+  power.readOp.gate_leakage =
+      undifferentiated_core *
+      (core_tx_density)*cmos_Ig_leakage(
+          5 * g_tp.min_w_nmos_, 5 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1,
+          inv) *
+      g_tp.peri_global.Vdd;
 
-	double long_channel_device_reduction = longer_channel_device_reduction(Core_device, coredynp.core_ty);
-	power.readOp.longer_channel_leakage	= power.readOp.leakage*long_channel_device_reduction;
-	area.set_area(undifferentiated_core);
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(Core_device, coredynp.core_ty);
+  power.readOp.longer_channel_leakage =
+      power.readOp.leakage * long_channel_device_reduction;
+  area.set_area(undifferentiated_core);
 
-	scktRatio = g_tp.sckt_co_eff;
-	power.readOp.dynamic *= scktRatio;
-	power.writeOp.dynamic *= scktRatio;
-	power.searchOp.dynamic *= scktRatio;
-	macro_PR_overhead = g_tp.macro_layout_overhead;
-	area.set_area(area.get_area()*macro_PR_overhead);
+  scktRatio = g_tp.sckt_co_eff;
+  power.readOp.dynamic *= scktRatio;
+  power.writeOp.dynamic *= scktRatio;
+  power.searchOp.dynamic *= scktRatio;
+  macro_PR_overhead = g_tp.macro_layout_overhead;
+  area.set_area(area.get_area() * macro_PR_overhead);
 
+  //		double vt=g_tp.peri_global.Vth;
+  //		double velocity_index=1.1;
+  //		double c_in=gate_C(g_tp.min_w_nmos_,
+  //g_tp.min_w_nmos_*pmos_to_nmos_sizing_r , 0.0, false);
+  //		double c_out= drain_C_(g_tp.min_w_nmos_, NCH, 2, 1, g_tp.cell_h_def,
+  //false) + drain_C_(g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, PCH, 1, 1,
+  //g_tp.cell_h_def, false) + c_in;
+  //		double w_nmos=g_tp.min_w_nmos_;
+  //		double w_pmos=g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
+  //		double i_on_n=1.0;
+  //		double i_on_p=1.0;
+  //		double i_on_n_in=1.0;
+  //		double i_on_p_in=1;
+  //		double vdd=g_tp.peri_global.Vdd;
 
+  //		power.readOp.sc=shortcircuit_simple(vt, velocity_index, c_in, c_out,
+  //w_nmos,w_pmos, i_on_n, i_on_p,i_on_n_in, i_on_p_in, vdd);
+  //		power.readOp.dynamic=c_out*vdd*vdd/2;
 
-//		double vt=g_tp.peri_global.Vth;
-//		double velocity_index=1.1;
-//		double c_in=gate_C(g_tp.min_w_nmos_, g_tp.min_w_nmos_*pmos_to_nmos_sizing_r , 0.0, false);
-//		double c_out= drain_C_(g_tp.min_w_nmos_, NCH, 2, 1, g_tp.cell_h_def, false) + drain_C_(g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, PCH, 1, 1, g_tp.cell_h_def, false) + c_in;
-//		double w_nmos=g_tp.min_w_nmos_;
-//		double w_pmos=g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
-//		double i_on_n=1.0;
-//		double i_on_p=1.0;
-//		double i_on_n_in=1.0;
-//		double i_on_p_in=1;
-//		double vdd=g_tp.peri_global.Vdd;
+  //		cout<<power.readOp.dynamic << "dynamic" <<endl;
+  //		cout<<power.readOp.sc << "sc" << endl;
 
-//		power.readOp.sc=shortcircuit_simple(vt, velocity_index, c_in, c_out, w_nmos,w_pmos, i_on_n, i_on_p,i_on_n_in, i_on_p_in, vdd);
-//		power.readOp.dynamic=c_out*vdd*vdd/2;
-
-//		cout<<power.readOp.dynamic << "dynamic" <<endl;
-//		cout<<power.readOp.sc << "sc" << endl;
-
-//		power.readOp.sc=shortcircuit(vt, velocity_index, c_in, c_out, w_nmos,w_pmos, i_on_n, i_on_p,i_on_n_in, i_on_p_in, vdd);
-//		power.readOp.dynamic=c_out*vdd*vdd/2;
-//
-//		cout<<power.readOp.dynamic << "dynamic" <<endl;
-//		cout<<power.readOp.sc << "sc" << endl;
-
-
-
+  //		power.readOp.sc=shortcircuit(vt, velocity_index, c_in, c_out,
+  //w_nmos,w_pmos, i_on_n, i_on_p,i_on_n_in, i_on_p_in, vdd);
+  //		power.readOp.dynamic=c_out*vdd*vdd/2;
+  //
+  //		cout<<power.readOp.dynamic << "dynamic" <<endl;
+  //		cout<<power.readOp.sc << "sc" << endl;
 }
 
+void UndiffCore::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
 
-void UndiffCore::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
-
-	if (is_tdp)
-	{
-		cout << indent_str << "UndiffCore:" << endl;
-		cout << indent_str_next << "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << power.readOp.dynamic*clockRate << " W" << endl;
-		//cout << indent_str_next << "Subthreshold Leakage = " << power.readOp.leakage <<" W" << endl;
-		cout << indent_str_next<< "Subthreshold Leakage = "
-					<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
-		//cout << indent_str_next << "Runtime Dynamic = " << rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-	}
-	else
-	{
-		cout << indent_str << "UndiffCore:" << endl;
-		cout << indent_str_next << "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << power.readOp.dynamic*clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = " << power.readOp.leakage <<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
-		//cout << indent_str_next << "Runtime Dynamic = " << rt_power.readOp.dynamic/executionTime << " W" << endl;
-		cout <<endl;
-	}
-
+  if (is_tdp) {
+    cout << indent_str << "UndiffCore:" << endl;
+    cout << indent_str_next << "Area = " << area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << power.readOp.dynamic * clockRate << " W"
+         << endl;
+    // cout << indent_str_next << "Subthreshold Leakage = " <<
+    // power.readOp.leakage <<" W" << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? power.readOp.longer_channel_leakage
+                          : power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage
+         << " W" << endl;
+    // cout << indent_str_next << "Runtime Dynamic = " <<
+    // rt_power.readOp.dynamic/executionTime << " W" << endl;
+    cout << endl;
+  } else {
+    cout << indent_str << "UndiffCore:" << endl;
+    cout << indent_str_next << "Area = " << area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << power.readOp.dynamic * clockRate << " W"
+         << endl;
+    cout << indent_str_next << "Subthreshold Leakage = " << power.readOp.leakage
+         << " W" << endl;
+    cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage
+         << " W" << endl;
+    // cout << indent_str_next << "Runtime Dynamic = " <<
+    // rt_power.readOp.dynamic/executionTime << " W" << endl;
+    cout << endl;
+  }
 }
 
-inst_decoder::inst_decoder(
-		bool   _is_default,
-		const InputParameter *configure_interface,
-		int opcode_length_,
-		int num_decoders_,
-		bool x86_,
-	    enum Device_ty device_ty_,
-	    enum Core_type core_ty_)
-:is_default(_is_default),
- opcode_length(opcode_length_),
- num_decoders(num_decoders_),
- x86(x86_),
- device_ty(device_ty_),
- core_ty(core_ty_)
- {
-			/*
-			 * Instruction decoder is different from n to 2^n decoders
-			 * that are commonly used in row decoders in memory arrays.
-			 * The RISC instruction decoder is typically a very simple device.
-			 * We can decode an instruction by simply
-			 * separating the machine word into small parts using wire slices
-			 * The RISC instruction decoder can be approximate by the n to 2^n decoders,
-			 * although this approximation usually underestimate power since each decoded
-			 * instruction normally has more than 1 active signal.
-			 *
-			 * However, decoding a CISC instruction word is much more difficult
-			 * than the RISC case. A CISC decoder is typically set up as a state machine.
-			 * The machine reads the opcode field to determine
-			 * what type of instruction it is,
-			 * and where the other data values are.
-			 * The instruction word is read in piece by piece,
-			 * and decisions are made at each stage as to
-			 * how the remainder of the instruction word will be read.
-			 * (sequencer and ROM are usually needed)
-			 * An x86 decoder can be even more complex since
-			 * it involve  both decoding instructions into u-ops and
-			 * merge u-ops when doing micro-ops fusion.
-			 */
-			bool is_dram=false;
-			double pmos_to_nmos_sizing_r;
-			double load_nmos_width, load_pmos_width;
-			double C_driver_load, R_wire_load;
-			Area cell;
+inst_decoder::inst_decoder(bool _is_default,
+                           const InputParameter *configure_interface,
+                           int opcode_length_, int num_decoders_, bool x86_,
+                           enum Device_ty device_ty_, enum Core_type core_ty_)
+    : is_default(_is_default),
+      opcode_length(opcode_length_),
+      num_decoders(num_decoders_),
+      x86(x86_),
+      device_ty(device_ty_),
+      core_ty(core_ty_) {
+  /*
+   * Instruction decoder is different from n to 2^n decoders
+   * that are commonly used in row decoders in memory arrays.
+   * The RISC instruction decoder is typically a very simple device.
+   * We can decode an instruction by simply
+   * separating the machine word into small parts using wire slices
+   * The RISC instruction decoder can be approximate by the n to 2^n decoders,
+   * although this approximation usually underestimate power since each decoded
+   * instruction normally has more than 1 active signal.
+   *
+   * However, decoding a CISC instruction word is much more difficult
+   * than the RISC case. A CISC decoder is typically set up as a state machine.
+   * The machine reads the opcode field to determine
+   * what type of instruction it is,
+   * and where the other data values are.
+   * The instruction word is read in piece by piece,
+   * and decisions are made at each stage as to
+   * how the remainder of the instruction word will be read.
+   * (sequencer and ROM are usually needed)
+   * An x86 decoder can be even more complex since
+   * it involve  both decoding instructions into u-ops and
+   * merge u-ops when doing micro-ops fusion.
+   */
+  bool is_dram = false;
+  double pmos_to_nmos_sizing_r;
+  double load_nmos_width, load_pmos_width;
+  double C_driver_load, R_wire_load;
+  Area cell;
 
-			l_ip=*configure_interface;
-			local_result = init_interface(&l_ip);
-			cell.h =g_tp.cell_h_def;
-			cell.w =g_tp.cell_h_def;
+  l_ip = *configure_interface;
+  local_result = init_interface(&l_ip);
+  cell.h = g_tp.cell_h_def;
+  cell.w = g_tp.cell_h_def;
 
-			num_decoder_segments = (int)ceil(opcode_length/18.0);
-			if (opcode_length > 18)	opcode_length = 18;
-			num_decoded_signals= (int)pow(2.0,opcode_length);
-			pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
-			load_nmos_width=g_tp.max_w_nmos_ /2;
-			load_pmos_width= g_tp.max_w_nmos_ * pmos_to_nmos_sizing_r;
-			C_driver_load = 1024*gate_C(load_nmos_width + load_pmos_width, 0, is_dram); //TODO: this number 1024 needs to be revisited
-			R_wire_load   = 3000*l_ip.F_sz_um * g_tp.wire_outside_mat.R_per_um;
+  num_decoder_segments = (int)ceil(opcode_length / 18.0);
+  if (opcode_length > 18) opcode_length = 18;
+  num_decoded_signals = (int)pow(2.0, opcode_length);
+  pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
+  load_nmos_width = g_tp.max_w_nmos_ / 2;
+  load_pmos_width = g_tp.max_w_nmos_ * pmos_to_nmos_sizing_r;
+  C_driver_load =
+      1024 * gate_C(load_nmos_width + load_pmos_width, 0,
+                    is_dram);  // TODO: this number 1024 needs to be revisited
+  R_wire_load = 3000 * l_ip.F_sz_um * g_tp.wire_outside_mat.R_per_um;
 
-			final_dec = new Decoder(
-					num_decoded_signals,
-					false,
-					C_driver_load,
-					R_wire_load,
-					false/*is_fa*/,
-					false/*is_dram*/,
-					false/*wl_tr*/, //to use peri device
-					cell);
+  final_dec = new Decoder(num_decoded_signals, false, C_driver_load,
+                          R_wire_load, false /*is_fa*/, false /*is_dram*/,
+                          false /*wl_tr*/,  // to use peri device
+                          cell);
 
-			PredecBlk * predec_blk1 = new PredecBlk(
-					num_decoded_signals,
-					final_dec,
-					0,//Assuming predec and dec are back to back
-					0,
-					1,//Each Predec only drives one final dec
-					false/*is_dram*/,
-					true);
-			PredecBlk * predec_blk2 = new PredecBlk(
-					num_decoded_signals,
-					final_dec,
-					0,//Assuming predec and dec are back to back
-					0,
-					1,//Each Predec only drives one final dec
-					false/*is_dram*/,
-					false);
+  PredecBlk *predec_blk1 =
+      new PredecBlk(num_decoded_signals, final_dec,
+                    0,  // Assuming predec and dec are back to back
+                    0,
+                    1,  // Each Predec only drives one final dec
+                    false /*is_dram*/, true);
+  PredecBlk *predec_blk2 =
+      new PredecBlk(num_decoded_signals, final_dec,
+                    0,  // Assuming predec and dec are back to back
+                    0,
+                    1,  // Each Predec only drives one final dec
+                    false /*is_dram*/, false);
 
-			PredecBlkDrv * predec_blk_drv1 = new PredecBlkDrv(0, predec_blk1, false);
-			PredecBlkDrv * predec_blk_drv2 = new PredecBlkDrv(0, predec_blk2, false);
+  PredecBlkDrv *predec_blk_drv1 = new PredecBlkDrv(0, predec_blk1, false);
+  PredecBlkDrv *predec_blk_drv2 = new PredecBlkDrv(0, predec_blk2, false);
 
-			pre_dec            = new Predec(predec_blk_drv1, predec_blk_drv2);
+  pre_dec = new Predec(predec_blk_drv1, predec_blk_drv2);
 
-			double area_decoder = final_dec->area.get_area() * num_decoded_signals * num_decoder_segments*num_decoders;
-			//double w_decoder    = area_decoder / area.get_h();
-			double area_pre_dec = (predec_blk_drv1->area.get_area() +
-					predec_blk_drv2->area.get_area() +
-					predec_blk1->area.get_area() +
-					predec_blk2->area.get_area())*
-					num_decoder_segments*num_decoders;
-			area.set_area(area.get_area()+ area_decoder + area_pre_dec);
-			double macro_layout_overhead   = g_tp.macro_layout_overhead;
-			double chip_PR_overhead        = g_tp.chip_layout_overhead;
-			area.set_area(area.get_area()*macro_layout_overhead*chip_PR_overhead);
+  double area_decoder = final_dec->area.get_area() * num_decoded_signals *
+                        num_decoder_segments * num_decoders;
+  // double w_decoder    = area_decoder / area.get_h();
+  double area_pre_dec =
+      (predec_blk_drv1->area.get_area() + predec_blk_drv2->area.get_area() +
+       predec_blk1->area.get_area() + predec_blk2->area.get_area()) *
+      num_decoder_segments * num_decoders;
+  area.set_area(area.get_area() + area_decoder + area_pre_dec);
+  double macro_layout_overhead = g_tp.macro_layout_overhead;
+  double chip_PR_overhead = g_tp.chip_layout_overhead;
+  area.set_area(area.get_area() * macro_layout_overhead * chip_PR_overhead);
 
-			inst_decoder_delay_power();
+  inst_decoder_delay_power();
 
-			double sckRation = g_tp.sckt_co_eff;
-			power.readOp.dynamic *= sckRation;
-			power.writeOp.dynamic *= sckRation;
-			power.searchOp.dynamic *= sckRation;
+  double sckRation = g_tp.sckt_co_eff;
+  power.readOp.dynamic *= sckRation;
+  power.writeOp.dynamic *= sckRation;
+  power.searchOp.dynamic *= sckRation;
 
-			double long_channel_device_reduction = longer_channel_device_reduction(device_ty,core_ty);
-			power.readOp.longer_channel_leakage	= power.readOp.leakage*long_channel_device_reduction;
-
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(device_ty, core_ty);
+  power.readOp.longer_channel_leakage =
+      power.readOp.leakage * long_channel_device_reduction;
 }
 
-void inst_decoder::inst_decoder_delay_power()
-{
+void inst_decoder::inst_decoder_delay_power() {
+  double pppm_t[4] = {1, 1, 1, 1};
+  double squencer_passes = x86 ? 2 : 1;
 
-	double pppm_t[4]    = {1,1,1,1};
-	double squencer_passes = x86?2:1;
-
-	set_pppm(pppm_t, squencer_passes*num_decoder_segments, num_decoder_segments, squencer_passes*num_decoder_segments, num_decoder_segments);
-    power = power + pre_dec->power*pppm_t;
-    set_pppm(pppm_t, squencer_passes*num_decoder_segments, num_decoder_segments*num_decoded_signals,
-    		num_decoder_segments*num_decoded_signals, squencer_passes*num_decoder_segments);
-    power = power + final_dec->power*pppm_t;
+  set_pppm(pppm_t, squencer_passes * num_decoder_segments, num_decoder_segments,
+           squencer_passes * num_decoder_segments, num_decoder_segments);
+  power = power + pre_dec->power * pppm_t;
+  set_pppm(pppm_t, squencer_passes * num_decoder_segments,
+           num_decoder_segments * num_decoded_signals,
+           num_decoder_segments * num_decoded_signals,
+           squencer_passes * num_decoder_segments);
+  power = power + final_dec->power * pppm_t;
 }
-void inst_decoder::leakage_feedback(double temperature)
-{
-  l_ip.temp = (unsigned int)round(temperature/10.0)*10;
-  uca_org_t init_result = init_interface(&l_ip); // init_result is dummy
+void inst_decoder::leakage_feedback(double temperature) {
+  l_ip.temp = (unsigned int)round(temperature / 10.0) * 10;
+  uca_org_t init_result = init_interface(&l_ip);  // init_result is dummy
 
   final_dec->leakage_feedback(temperature);
   pre_dec->leakage_feedback(temperature);
 
-  double pppm_t[4]    = {1,1,1,1};
-  double squencer_passes = x86?2:1;
+  double pppm_t[4] = {1, 1, 1, 1};
+  double squencer_passes = x86 ? 2 : 1;
 
-  set_pppm(pppm_t, squencer_passes*num_decoder_segments, num_decoder_segments, squencer_passes*num_decoder_segments, num_decoder_segments);
-  power = pre_dec->power*pppm_t;
+  set_pppm(pppm_t, squencer_passes * num_decoder_segments, num_decoder_segments,
+           squencer_passes * num_decoder_segments, num_decoder_segments);
+  power = pre_dec->power * pppm_t;
 
-  set_pppm(pppm_t, squencer_passes*num_decoder_segments, num_decoder_segments*num_decoded_signals,num_decoder_segments*num_decoded_signals, squencer_passes*num_decoder_segments);
-  power = power + final_dec->power*pppm_t;
+  set_pppm(pppm_t, squencer_passes * num_decoder_segments,
+           num_decoder_segments * num_decoded_signals,
+           num_decoder_segments * num_decoded_signals,
+           squencer_passes * num_decoder_segments);
+  power = power + final_dec->power * pppm_t;
 
   double sckRation = g_tp.sckt_co_eff;
 
@@ -1086,19 +1378,20 @@ void inst_decoder::leakage_feedback(double temperature)
   power.writeOp.dynamic *= sckRation;
   power.searchOp.dynamic *= sckRation;
 
-  double long_channel_device_reduction = longer_channel_device_reduction(device_ty,core_ty);
-  power.readOp.longer_channel_leakage = power.readOp.leakage*long_channel_device_reduction;
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(device_ty, core_ty);
+  power.readOp.longer_channel_leakage =
+      power.readOp.leakage * long_channel_device_reduction;
 }
 
-inst_decoder::~inst_decoder()
-{
-	  local_result.cleanup();
+inst_decoder::~inst_decoder() {
+  local_result.cleanup();
 
-	  delete final_dec;
+  delete final_dec;
 
-	  delete pre_dec->blk1;
-	  delete pre_dec->blk2;
-	  delete pre_dec->drv1;
-	  delete pre_dec->drv2;
-	  delete pre_dec;
+  delete pre_dec->blk1;
+  delete pre_dec->blk2;
+  delete pre_dec->drv1;
+  delete pre_dec->drv2;
+  delete pre_dec;
 }

--- a/src/gpuwattch/logic.cc
+++ b/src/gpuwattch/logic.cc
@@ -29,258 +29,217 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:
-**
+*      Modified by:												   *
 *      Jingwen Leng, Univeristy of Texas, Austin                   *
 *      Syed Gilani, University of Wisconsin–Madison                *
 *      Tayler Hetherington, University of British Columbia         *
 *      Ahmed ElTantawy, University of British Columbia             *
 ********************************************************************/
 #include "logic.h"
-#define SP_BASE_POWER 0
+#define SP_BASE_POWER 0 
 #define SFU_BASE_POWER 0
 //.67
 
-// extern double exClockRate;
-// selection_logic
-selection_logic::selection_logic(bool _is_default, int win_entries_,
-                                 int issue_width_,
-                                 const InputParameter *configure_interface,
-                                 enum Device_ty device_ty_,
-                                 enum Core_type core_ty_)
-    // const ParseXML *_XML_interface)
-    : is_default(_is_default),
-      win_entries(win_entries_),
-      issue_width(issue_width_),
-      device_ty(device_ty_),
-      core_ty(core_ty_) {
-  // uca_org_t result2;
-  l_ip = *configure_interface;
-  local_result = init_interface(&l_ip);
-  // init_tech_params(l_ip.F_sz_um, false);
-  // win_entries=numIBEntries;//IQentries;
-  // issue_width=issueWidth;
-  selection_power();
-  double sckRation = g_tp.sckt_co_eff;
-  power.readOp.dynamic *= sckRation;
-  power.writeOp.dynamic *= sckRation;
-  power.searchOp.dynamic *= sckRation;
+//extern double exClockRate;
+//selection_logic
+selection_logic::selection_logic(
+    bool   _is_default,
+    int    win_entries_,
+    int    issue_width_,
+    const InputParameter *configure_interface,
+    enum Device_ty device_ty_,
+    enum Core_type core_ty_)
+    //const ParseXML *_XML_interface)
+ :is_default(_is_default),
+  win_entries(win_entries_),
+  issue_width(issue_width_),
+  device_ty(device_ty_),
+  core_ty(core_ty_)
+ {
+    	//uca_org_t result2;
+    	l_ip=*configure_interface;
+    	local_result = init_interface(&l_ip);
+    	//init_tech_params(l_ip.F_sz_um, false);
+    	//win_entries=numIBEntries;//IQentries;
+		//issue_width=issueWidth;
+    	selection_power();
+    	double sckRation = g_tp.sckt_co_eff;
+    	power.readOp.dynamic *= sckRation;
+    	power.writeOp.dynamic *= sckRation;
+    	power.searchOp.dynamic *= sckRation;
 
-  double long_channel_device_reduction =
-      longer_channel_device_reduction(device_ty, core_ty);
-  power.readOp.longer_channel_leakage =
-      power.readOp.leakage * long_channel_device_reduction;
-}
+    	double long_channel_device_reduction = longer_channel_device_reduction(device_ty,core_ty);
+    	power.readOp.longer_channel_leakage	= power.readOp.leakage*long_channel_device_reduction;
+	 }
 
-void selection_logic::selection_power() {  // based on cost effective
-                                           // superscalar processor TR pp27-31
+void selection_logic::selection_power()
+{//based on cost effective superscalar processor TR pp27-31
   double Ctotal, Cor, Cpencode;
   int num_arbiter;
   double WSelORn, WSelORprequ, WSelPn, WSelPp, WSelEnn, WSelEnp;
 
-  // TODO: the 0.8um process data is used.
-  WSelORn =
-      12.5 * l_ip.F_sz_um;  // this was 10 micron for the 0.8 micron process
-  WSelORprequ =
-      50 * l_ip.F_sz_um;  // this was 40 micron for the 0.8 micron process
-  WSelPn = 12.5 * l_ip.F_sz_um;  // this was 10mcron for the 0.8 micron process
-  WSelPp =
-      18.75 * l_ip.F_sz_um;  // this was 15 micron for the 0.8 micron process
-  WSelEnn = 6.25 * l_ip.F_sz_um;  // this was 5 micron for the 0.8 micron
-                                  // process
-  WSelEnp =
-      12.5 * l_ip.F_sz_um;  // this was 10 micron for the 0.8 micron process
+  //TODO: the 0.8um process data is used.
+  WSelORn    	=  	12.5 * l_ip.F_sz_um;//this was 10 micron for the 0.8 micron process
+  WSelORprequ   = 	50 * l_ip.F_sz_um;//this was 40 micron for the 0.8 micron process
+  WSelPn     	= 	12.5 * l_ip.F_sz_um;//this was 10mcron for the 0.8 micron process
+  WSelPp     	=  	18.75 * l_ip.F_sz_um;//this was 15 micron for the 0.8 micron process
+  WSelEnn    	=  	6.25 * l_ip.F_sz_um;//this was 5 micron for the 0.8 micron process
+  WSelEnp    	=  	12.5 * l_ip.F_sz_um;//this was 10 micron for the 0.8 micron process
 
-  Ctotal = 0;
-  num_arbiter = 1;
-  while (win_entries > 4) {
-    win_entries = (int)ceil((double)win_entries / 4.0);
-    num_arbiter += win_entries;
-  }
-  // the 4-input OR logic to generate anyreq
-  Cor = 4 * drain_C_(WSelORn, NCH, 1, 1, g_tp.cell_h_def) +
-        drain_C_(WSelORprequ, PCH, 1, 1, g_tp.cell_h_def);
-  power.readOp.gate_leakage =
-      cmos_Ig_leakage(WSelORn, WSelORprequ, 4, nor) * g_tp.peri_global.Vdd;
 
-  // The total capacity of the 4-bit priority encoder
-  Cpencode =
-      drain_C_(WSelPn, NCH, 1, 1, g_tp.cell_h_def) +
-      drain_C_(WSelPp, PCH, 1, 1, g_tp.cell_h_def) +
-      2 * drain_C_(WSelPn, NCH, 1, 1, g_tp.cell_h_def) +
-      drain_C_(WSelPp, PCH, 2, 1, g_tp.cell_h_def) +
-      3 * drain_C_(WSelPn, NCH, 1, 1, g_tp.cell_h_def) +
-      drain_C_(WSelPp, PCH, 3, 1, g_tp.cell_h_def) +
-      4 * drain_C_(WSelPn, NCH, 1, 1, g_tp.cell_h_def) +
-      drain_C_(WSelPp, PCH, 4, 1,
-               g_tp.cell_h_def) +  // precompute priority logic
-      2 * 4 * gate_C(WSelEnn + WSelEnp, 20.0) +
-      4 * drain_C_(WSelEnn, NCH, 1, 1, g_tp.cell_h_def) +
-      2 * 4 * drain_C_(WSelEnp, PCH, 1, 1, g_tp.cell_h_def) +  // enable logic
-      (2 * 4 + 2 * 3 + 2 * 2 + 2) *
-          gate_C(WSelPn + WSelPp, 10.0);  // requests signal
+  Ctotal=0;
+  num_arbiter=1;
+  while(win_entries > 4)
+    {
+      win_entries = (int)ceil((double)win_entries / 4.0);
+      num_arbiter += win_entries;
+    }
+  //the 4-input OR logic to generate anyreq
+  Cor = 4 * drain_C_(WSelORn,NCH,1,1, g_tp.cell_h_def) + drain_C_(WSelORprequ,PCH,1,1, g_tp.cell_h_def);
+  power.readOp.gate_leakage = cmos_Ig_leakage(WSelORn, WSelORprequ, 4, nor)*g_tp.peri_global.Vdd;
 
-  Ctotal += issue_width * num_arbiter * (Cor + Cpencode);
+  //The total capacity of the 4-bit priority encoder
+  Cpencode = drain_C_(WSelPn,NCH,1, 1, g_tp.cell_h_def) + drain_C_(WSelPp,PCH,1, 1, g_tp.cell_h_def) +
+    2*drain_C_(WSelPn,NCH,1, 1, g_tp.cell_h_def) + drain_C_(WSelPp,PCH,2, 1, g_tp.cell_h_def) +
+    3*drain_C_(WSelPn,NCH,1, 1, g_tp.cell_h_def) + drain_C_(WSelPp,PCH,3, 1, g_tp.cell_h_def) +
+    4*drain_C_(WSelPn,NCH,1, 1, g_tp.cell_h_def) + drain_C_(WSelPp,PCH,4, 1, g_tp.cell_h_def) +//precompute priority logic
+    2*4*gate_C(WSelEnn+WSelEnp,20.0)+
+    4*drain_C_(WSelEnn,NCH,1, 1, g_tp.cell_h_def) + 2*4*drain_C_(WSelEnp,PCH,1, 1, g_tp.cell_h_def)+//enable logic
+    (2*4+2*3+2*2+2)*gate_C(WSelPn+WSelPp,10.0);//requests signal
 
-  power.readOp.dynamic =
-      Ctotal * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd *
-      2;  // 2 means the abitration signal need to travel round trip
-  power.readOp.leakage =
-      issue_width * num_arbiter *
-      (cmos_Isub_leakage(
-           WSelPn, WSelPp, 2,
-           nor) /*approximate precompute with a nor gate*/  // grant1p
-       + cmos_Isub_leakage(WSelPn, WSelPp, 3, nor)          // grant2p
-       + cmos_Isub_leakage(WSelPn, WSelPp, 4, nor)          // grant3p
-       + cmos_Isub_leakage(WSelEnn, WSelEnp, 2, nor) * 4    // enable logic
-       +
-       cmos_Isub_leakage(WSelEnn, WSelEnp, 1, inv) * 2 *
-           3  // for each grant there are two inverters, there are 3 grant
-              // sIsubnals
-       ) *
-      g_tp.peri_global.Vdd;
-  power.readOp.gate_leakage =
-      issue_width * num_arbiter *
-      (cmos_Ig_leakage(
-           WSelPn, WSelPp, 2,
-           nor) /*approximate precompute with a nor gate*/  // grant1p
-       + cmos_Ig_leakage(WSelPn, WSelPp, 3, nor)            // grant2p
-       + cmos_Ig_leakage(WSelPn, WSelPp, 4, nor)            // grant3p
-       + cmos_Ig_leakage(WSelEnn, WSelEnp, 2, nor) * 4      // enable logic
-       +
-       cmos_Ig_leakage(WSelEnn, WSelEnp, 1, inv) * 2 *
-           3  // for each grant there are two inverters, there are 3 grant
-              // signals
-       ) *
-      g_tp.peri_global.Vdd;
+  Ctotal += issue_width * num_arbiter*(Cor+Cpencode);
+
+  power.readOp.dynamic = Ctotal*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*2;//2 means the abitration signal need to travel round trip
+  power.readOp.leakage = issue_width * num_arbiter *
+      (cmos_Isub_leakage(WSelPn, WSelPp, 2, nor)/*approximate precompute with a nor gate*///grant1p
+       + cmos_Isub_leakage(WSelPn, WSelPp, 3, nor)//grant2p
+       + cmos_Isub_leakage(WSelPn, WSelPp, 4, nor)//grant3p
+       + cmos_Isub_leakage(WSelEnn, WSelEnp, 2, nor)*4//enable logic
+       + cmos_Isub_leakage(WSelEnn, WSelEnp, 1, inv)*2*3//for each grant there are two inverters, there are 3 grant sIsubnals
+		  )*g_tp.peri_global.Vdd;
+  power.readOp.gate_leakage = issue_width * num_arbiter *
+      (cmos_Ig_leakage(WSelPn, WSelPp, 2, nor)/*approximate precompute with a nor gate*///grant1p
+       + cmos_Ig_leakage(WSelPn, WSelPp, 3, nor)//grant2p
+       + cmos_Ig_leakage(WSelPn, WSelPp, 4, nor)//grant3p
+       + cmos_Ig_leakage(WSelEnn, WSelEnp, 2, nor)*4//enable logic
+       + cmos_Ig_leakage(WSelEnn, WSelEnp, 1, inv)*2*3//for each grant there are two inverters, there are 3 grant signals
+        )*g_tp.peri_global.Vdd;
 }
+
 
 dep_resource_conflict_check::dep_resource_conflict_check(
-    const InputParameter *configure_interface, const CoreDynParam &dyn_p_,
-    int compare_bits_, bool _is_default)
-    : l_ip(*configure_interface),
-      coredynp(dyn_p_),
-      compare_bits(compare_bits_),
-      is_default(_is_default) {
-  Wcompn = 25 * l_ip.F_sz_um;  // this was 20.0 micron for the 0.8 micron
-                               // process
-  Wevalinvp =
-      25 * l_ip.F_sz_um;  // this was 20.0 micron for the 0.8 micron process
-  Wevalinvn =
-      100 * l_ip.F_sz_um;  // this was 80.0 mcron for the 0.8 micron process
-  Wcomppreequ =
-      50 * l_ip.F_sz_um;  // this was 40.0  micron for the 0.8 micron process
-  WNORn = 6.75 * l_ip.F_sz_um;  // this was 5.4 micron for the 0.8 micron
-                                // process
-  WNORp =
-      38.125 * l_ip.F_sz_um;  // this was 30.5 micron for the 0.8 micron process
+	const InputParameter *configure_interface,
+	const CoreDynParam & dyn_p_,
+	int   compare_bits_,
+    bool   _is_default)
+ :  l_ip(*configure_interface),
+    coredynp(dyn_p_),
+    compare_bits(compare_bits_),
+	is_default(_is_default)
+{
+    	Wcompn    	=  	25 * l_ip.F_sz_um;//this was 20.0 micron for the 0.8 micron process
+    	Wevalinvp   = 	25 * l_ip.F_sz_um;//this was 20.0 micron for the 0.8 micron process
+    	Wevalinvn   = 	100 * l_ip.F_sz_um;//this was 80.0 mcron for the 0.8 micron process
+    	Wcomppreequ =  	50 * l_ip.F_sz_um;//this was 40.0  micron for the 0.8 micron process
+    	WNORn    	=  	6.75 * l_ip.F_sz_um;//this was 5.4 micron for the 0.8 micron process
+    	WNORp    	=  	38.125 * l_ip.F_sz_um;//this was 30.5 micron for the 0.8 micron process
 
-  local_result = init_interface(&l_ip);
+    	local_result = init_interface(&l_ip);
 
-  if (coredynp.core_ty == Inorder)
-    compare_bits += 16 + 8 + 8;  // TODO: opcode bits + log(shared resources) +
-                                 // REG TAG BITS-->opcode comparator
-  else
-    compare_bits += 16 + 8 + 8;
+    	if (coredynp.core_ty==Inorder)
+   		    compare_bits += 16 + 8 + 8;//TODO: opcode bits + log(shared resources) + REG TAG BITS-->opcode comparator
+    	else
+    		compare_bits += 16 + 8 + 8;
 
-  conflict_check_power();
-  double sckRation = g_tp.sckt_co_eff;
-  power.readOp.dynamic *= sckRation;
-  power.writeOp.dynamic *= sckRation;
-  power.searchOp.dynamic *= sckRation;
+   		conflict_check_power();
+    	double sckRation = g_tp.sckt_co_eff;
+    	power.readOp.dynamic *= sckRation;
+    	power.writeOp.dynamic *= sckRation;
+    	power.searchOp.dynamic *= sckRation;
+
 }
 
-void dep_resource_conflict_check::conflict_check_power() {
-  double Ctotal;
-  int num_comparators;
-  num_comparators = 3 * ((coredynp.decodeW) * (coredynp.decodeW) -
-                         coredynp.decodeW);  // 2(N*N-N) is used for source to
-                                             // dest comparison, (N*N-N) is used
-                                             // for dest to dest comparision.
-  // When decode-width ==1, no dcl logic
+void dep_resource_conflict_check::conflict_check_power()
+{
+	double Ctotal;
+	int num_comparators;
+	num_comparators = 3*((coredynp.decodeW) * (coredynp.decodeW)-coredynp.decodeW);//2(N*N-N) is used for source to dest comparison, (N*N-N) is used for dest to dest comparision.
+	//When decode-width ==1, no dcl logic
 
-  Ctotal = num_comparators * compare_cap();
-  // printf("%i,%s\n",XML_interface->sys.core[0].predictor.predictor_entries,XML_interface->sys.core[0].predictor.prediction_scheme);
+	Ctotal = num_comparators * compare_cap();
+	//printf("%i,%s\n",XML_interface->sys.core[0].predictor.predictor_entries,XML_interface->sys.core[0].predictor.prediction_scheme);
 
-  power.readOp.dynamic =
-      Ctotal * /*CLOCKRATE*/ g_tp.peri_global.Vdd * g_tp.peri_global.Vdd /*AF*/;
-  power.readOp.leakage = num_comparators * compare_bits * 2 *
-                         simplified_nmos_leakage(Wcompn, false);
+	power.readOp.dynamic=Ctotal*/*CLOCKRATE*/g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/*AF*/;
+	power.readOp.leakage=num_comparators*compare_bits*2*simplified_nmos_leakage(Wcompn,  false);
 
-  double long_channel_device_reduction =
-      longer_channel_device_reduction(Core_device, coredynp.core_ty);
-  power.readOp.longer_channel_leakage =
-      power.readOp.leakage * long_channel_device_reduction;
-  power.readOp.gate_leakage =
-      num_comparators * compare_bits * 2 * cmos_Ig_leakage(Wcompn, 0, 2, nmos);
+	double long_channel_device_reduction = longer_channel_device_reduction(Core_device, coredynp.core_ty);
+	power.readOp.longer_channel_leakage	= power.readOp.leakage*long_channel_device_reduction;
+	power.readOp.gate_leakage=num_comparators*compare_bits*2*cmos_Ig_leakage(Wcompn, 0, 2, nmos);
+
 }
 
 /* estimate comparator power consumption (this comparator is similar
    to the tag-match structure in a CAM */
-double dep_resource_conflict_check::compare_cap() {
+double dep_resource_conflict_check::compare_cap()
+{
   double c1, c2;
 
-  WNORp = WNORp * compare_bits /
-          2.0;  // resize the big NOR gate at the DCL according to fan in.
+  WNORp = WNORp * compare_bits/2.0;//resize the big NOR gate at the DCL according to fan in.
   /* bottom part of comparator */
-  c2 = (compare_bits) * (drain_C_(Wcompn, NCH, 1, 1, g_tp.cell_h_def) +
-                         drain_C_(Wcompn, NCH, 2, 1, g_tp.cell_h_def)) +
-       drain_C_(Wevalinvp, PCH, 1, 1, g_tp.cell_h_def) +
-       drain_C_(Wevalinvn, NCH, 1, 1, g_tp.cell_h_def);
+  c2 = (compare_bits)*(drain_C_(Wcompn,NCH,1,1, g_tp.cell_h_def)+drain_C_(Wcompn,NCH,2,1, g_tp.cell_h_def))+
+  drain_C_(Wevalinvp,PCH,1,1, g_tp.cell_h_def) + drain_C_(Wevalinvn,NCH,1,1, g_tp.cell_h_def);
 
   /* top part of comparator */
-  c1 = (compare_bits) * (drain_C_(Wcompn, NCH, 1, 1, g_tp.cell_h_def) +
-                         drain_C_(Wcompn, NCH, 2, 1, g_tp.cell_h_def) +
-                         drain_C_(Wcomppreequ, NCH, 1, 1, g_tp.cell_h_def)) +
-       gate_C(WNORn + WNORp, 10.0) +
-       drain_C_(WNORp, NCH, 2, 1, g_tp.cell_h_def) +
-       compare_bits * drain_C_(WNORn, NCH, 2, 1, g_tp.cell_h_def);
-  return (c1 + c2);
+  c1 = (compare_bits)*(drain_C_(Wcompn,NCH,1,1, g_tp.cell_h_def)+drain_C_(Wcompn,NCH,2,1, g_tp.cell_h_def)+
+		  drain_C_(Wcomppreequ,NCH,1,1, g_tp.cell_h_def)) +  gate_C(WNORn + WNORp,10.0) +
+		  drain_C_(WNORp,NCH,2,1, g_tp.cell_h_def) + compare_bits*drain_C_(WNORn,NCH,2,1, g_tp.cell_h_def);
+  return(c1 + c2);
+
 }
 
-void dep_resource_conflict_check::leakage_feedback(double temperature) {
-  l_ip.temp = (unsigned int)round(temperature / 10.0) * 10;
-  uca_org_t init_result = init_interface(&l_ip);  // init_result is dummy
+void dep_resource_conflict_check::leakage_feedback(double temperature)
+{
+  l_ip.temp = (unsigned int)round(temperature/10.0)*10;
+  uca_org_t init_result = init_interface(&l_ip); // init_result is dummy
 
   // This is part of conflict_check_power()
-  int num_comparators = 3 * ((coredynp.decodeW) * (coredynp.decodeW) -
-                             coredynp.decodeW);  // 2(N*N-N) is used for source
-                                                 // to dest comparison, (N*N-N)
-                                                 // is used for dest to dest
-                                                 // comparision.
-  power.readOp.leakage = num_comparators * compare_bits * 2 *
-                         simplified_nmos_leakage(Wcompn, false);
+  int num_comparators = 3*((coredynp.decodeW) * (coredynp.decodeW)-coredynp.decodeW);//2(N*N-N) is used for source to dest comparison, (N*N-N) is used for dest to dest comparision.
+  power.readOp.leakage=num_comparators*compare_bits*2*simplified_nmos_leakage(Wcompn,  false);
 
-  double long_channel_device_reduction =
-      longer_channel_device_reduction(Core_device, coredynp.core_ty);
-  power.readOp.longer_channel_leakage =
-      power.readOp.leakage * long_channel_device_reduction;
-  power.readOp.gate_leakage =
-      num_comparators * compare_bits * 2 * cmos_Ig_leakage(Wcompn, 0, 2, nmos);
+  double long_channel_device_reduction = longer_channel_device_reduction(Core_device, coredynp.core_ty);
+  power.readOp.longer_channel_leakage	= power.readOp.leakage*long_channel_device_reduction;
+  power.readOp.gate_leakage=num_comparators*compare_bits*2*cmos_Ig_leakage(Wcompn, 0, 2, nmos);
 }
 
-// TODO: add inverter and transmission gate base DFF.
+//TODO: add inverter and transmission gate base DFF.
 
-DFFCell::DFFCell(bool _is_dram, double _WdecNANDn, double _WdecNANDp,
-                 double _cell_load, const InputParameter *configure_interface)
-    : is_dram(_is_dram),
-      cell_load(_cell_load),
-      WdecNANDn(_WdecNANDn),
-      WdecNANDp(_WdecNANDp) {  // this model is based on the NAND2 based DFF.
-  l_ip = *configure_interface;
-  //			area.set_area(730*l_ip.F_sz_um*l_ip.F_sz_um);
-  area.set_area(
-      5 * compute_gate_area(NAND, 2, WdecNANDn, WdecNANDp, g_tp.cell_h_def) +
-      compute_gate_area(NAND, 2, WdecNANDn, WdecNANDn, g_tp.cell_h_def));
+DFFCell::DFFCell(
+		bool _is_dram,
+		double _WdecNANDn,
+		double _WdecNANDp,
+		double _cell_load,
+		const InputParameter *configure_interface)
+:is_dram(_is_dram),
+cell_load(_cell_load),
+WdecNANDn(_WdecNANDn),
+WdecNANDp(_WdecNANDp)
+{//this model is based on the NAND2 based DFF.
+			l_ip=*configure_interface;
+//			area.set_area(730*l_ip.F_sz_um*l_ip.F_sz_um);
+			area.set_area(5*compute_gate_area(NAND, 2,WdecNANDn,WdecNANDp, g_tp.cell_h_def)
+				+ compute_gate_area(NAND, 2,WdecNANDn,WdecNANDn, g_tp.cell_h_def));
+
+
 }
 
-double DFFCell::fpfp_node_cap(unsigned int fan_in, unsigned int fan_out) {
+
+double DFFCell::fpfp_node_cap(unsigned int fan_in, unsigned int fan_out)
+{
   double Ctotal = 0;
-  // printf("WdecNANDn = %E\n", WdecNANDn);
+  //printf("WdecNANDn = %E\n", WdecNANDn);
 
   /* part 1: drain cap of NAND gate */
-  Ctotal += drain_C_(WdecNANDn, NCH, 2, 1, g_tp.cell_h_def, is_dram) +
-            fan_in * drain_C_(WdecNANDp, PCH, 1, 1, g_tp.cell_h_def, is_dram);
+  Ctotal += drain_C_(WdecNANDn, NCH, 2, 1, g_tp.cell_h_def, is_dram) + fan_in * drain_C_(WdecNANDp, PCH, 1, 1, g_tp.cell_h_def, is_dram);
 
   /* part 2: gate cap of NAND gates */
   Ctotal += fan_out * gate_C(WdecNANDn + WdecNANDp, 0, is_dram);
@@ -288,1089 +247,838 @@ double DFFCell::fpfp_node_cap(unsigned int fan_in, unsigned int fan_out) {
   return Ctotal;
 }
 
-void DFFCell::compute_DFF_cell() {
-  double c1, c2, c3, c4, c5, c6;
-  /* node 5 and node 6 are identical to node 1 in capacitance */
-  c1 = c5 = c6 = fpfp_node_cap(2, 1);
-  c2 = fpfp_node_cap(2, 3);
-  c3 = fpfp_node_cap(3, 2);
-  c4 = fpfp_node_cap(2, 2);
 
-  // cap-load of the clock signal in each Dff, actually the clock signal only
-  // connected to one NAND2
-  clock_cap = 2 * gate_C(WdecNANDn + WdecNANDp, 0, is_dram);
-  e_switch.readOp.dynamic += (c4 + c1 + c2 + c3 + c5 + c6 + 2 * cell_load) *
-                             0.5 * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd;
-  ;
-
-  /* no 1/2 for e_keep and e_clock because clock signal switches twice in one
-   * cycle */
-  e_keep_1.readOp.dynamic += c3 * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd;
-  e_keep_0.readOp.dynamic += c2 * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd;
-  e_clock.readOp.dynamic +=
-      clock_cap * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd;
-  ;
-
-  /* static power */
-  e_switch.readOp.leakage +=
-      (cmos_Isub_leakage(WdecNANDn, WdecNANDp, 2, nand) *
-           5  // 5 NAND2 and 1 NAND3 in a DFF
-       + cmos_Isub_leakage(WdecNANDn, WdecNANDn, 3, nand)) *
-      g_tp.peri_global.Vdd;
-  e_switch.readOp.gate_leakage +=
-      (cmos_Ig_leakage(WdecNANDn, WdecNANDp, 2, nand) *
-           5  // 5 NAND2 and 1 NAND3 in a DFF
-       + cmos_Ig_leakage(WdecNANDn, WdecNANDn, 3, nand)) *
-      g_tp.peri_global.Vdd;
-  // printf("leakage =%E\n",cmos_Ileak(1, is_dram) );
-}
-
-Pipeline::Pipeline(const InputParameter *configure_interface,
-                   const CoreDynParam &dyn_p_, enum Device_ty device_ty_,
-                   bool _is_core_pipeline, bool _is_default)
-    : l_ip(*configure_interface),
-      coredynp(dyn_p_),
-      device_ty(device_ty_),
-      is_core_pipeline(_is_core_pipeline),
-      is_default(_is_default),
-      num_piperegs(0.0)
-
+void DFFCell::compute_DFF_cell()
 {
-  local_result = init_interface(&l_ip);
-  if (!coredynp.Embedded)
-    process_ind = true;
+	double c1, c2, c3, c4, c5, c6;
+	   /* node 5 and node 6 are identical to node 1 in capacitance */
+	   c1 = c5 = c6 = fpfp_node_cap(2, 1);
+	   c2 = fpfp_node_cap(2, 3);
+	   c3 = fpfp_node_cap(3, 2);
+	   c4 = fpfp_node_cap(2, 2);
+
+	   //cap-load of the clock signal in each Dff, actually the clock signal only connected to one NAND2
+	   clock_cap= 2 * gate_C(WdecNANDn + WdecNANDp, 0, is_dram);
+	   e_switch.readOp.dynamic += (c4 + c1 + c2 + c3 + c5 + c6 + 2*cell_load)*0.5*g_tp.peri_global.Vdd * g_tp.peri_global.Vdd;;
+
+	   /* no 1/2 for e_keep and e_clock because clock signal switches twice in one cycle */
+	   e_keep_1.readOp.dynamic += c3 * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd ;
+	   e_keep_0.readOp.dynamic += c2 * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd ;
+	   e_clock.readOp.dynamic += clock_cap* g_tp.peri_global.Vdd * g_tp.peri_global.Vdd;;
+
+	   /* static power */
+	   e_switch.readOp.leakage +=  (cmos_Isub_leakage(WdecNANDn, WdecNANDp, 2, nand)*5//5 NAND2 and 1 NAND3 in a DFF
+                                           + cmos_Isub_leakage(WdecNANDn, WdecNANDn, 3, nand))*g_tp.peri_global.Vdd;
+	   e_switch.readOp.gate_leakage += (cmos_Ig_leakage(WdecNANDn, WdecNANDp, 2, nand)*5//5 NAND2 and 1 NAND3 in a DFF
+                                           + cmos_Ig_leakage(WdecNANDn, WdecNANDn, 3, nand))*g_tp.peri_global.Vdd;
+	   //printf("leakage =%E\n",cmos_Ileak(1, is_dram) );
+}
+
+Pipeline::Pipeline(
+		const InputParameter *configure_interface,
+		const CoreDynParam & dyn_p_,
+		enum Device_ty device_ty_,
+		bool _is_core_pipeline,
+		bool _is_default)
+: l_ip(*configure_interface),
+  coredynp(dyn_p_),
+  device_ty(device_ty_),
+  is_core_pipeline(_is_core_pipeline),
+  is_default(_is_default),
+  num_piperegs(0.0)
+
+  {
+	local_result = init_interface(&l_ip);
+	if (!coredynp.Embedded)
+		process_ind = true;
+	else
+		process_ind = false;
+	WNANDn = (process_ind)? 25 *   l_ip.F_sz_um : g_tp.min_w_nmos_ ;//this was  20 micron for the 0.8 micron process
+	WNANDp = (process_ind)? 37.5 * l_ip.F_sz_um : g_tp.min_w_nmos_*pmos_to_nmos_sz_ratio();//this was  30 micron for the 0.8 micron process
+	load_per_pipeline_stage = 2*gate_C(WNANDn + WNANDp, 0, false);
+	compute();
+
+}
+
+void Pipeline::compute()
+{
+	compute_stage_vector();
+	DFFCell pipe_reg(false, WNANDn,WNANDp, load_per_pipeline_stage, &l_ip);
+	pipe_reg.compute_DFF_cell();
+
+	double clock_power_pipereg = num_piperegs * pipe_reg.e_clock.readOp.dynamic;
+	//******************pipeline power: currently, we average all the possibilities of the states of DFFs in the pipeline. A better way to do it is to consider
+	//the harming distance of two consecutive signals, However McPAT does not have plan to do this in near future as it focuses on worst case power.
+	double pipe_reg_power = num_piperegs * (pipe_reg.e_switch.readOp.dynamic+pipe_reg.e_keep_0.readOp.dynamic+pipe_reg.e_keep_1.readOp.dynamic)/3+clock_power_pipereg;
+	double pipe_reg_leakage = num_piperegs * pipe_reg.e_switch.readOp.leakage;
+	double pipe_reg_gate_leakage = num_piperegs * pipe_reg.e_switch.readOp.gate_leakage;
+	power.readOp.dynamic	+=pipe_reg_power;
+	power.readOp.leakage	+=pipe_reg_leakage;
+	power.readOp.gate_leakage	+=pipe_reg_gate_leakage;
+	area.set_area(num_piperegs * pipe_reg.area.get_area());
+
+	double long_channel_device_reduction = longer_channel_device_reduction(device_ty, coredynp.core_ty);
+	power.readOp.longer_channel_leakage	= power.readOp.leakage*long_channel_device_reduction;
+
+
+	double sckRation = g_tp.sckt_co_eff;
+	power.readOp.dynamic *= sckRation;
+	power.writeOp.dynamic *= sckRation;
+	power.searchOp.dynamic *= sckRation;
+	double macro_layout_overhead = g_tp.macro_layout_overhead;
+	if (!coredynp.Embedded)
+		area.set_area(area.get_area()*macro_layout_overhead);
+}
+
+void Pipeline::compute_stage_vector()
+{
+	double num_stages, tot_stage_vector, per_stage_vector;
+	int opcode_length = coredynp.x86? coredynp.micro_opcode_length:coredynp.opcode_length;
+	//Hthread = thread_clock_gated? 1:num_thread;
+
+  if (!is_core_pipeline)
+  {
+	num_piperegs=l_ip.pipeline_stages*l_ip.per_stage_vector;//The number of pipeline stages are calculated based on the achievable throughput and required throughput
+  }
   else
-    process_ind = false;
-  WNANDn =
-      (process_ind)
-          ? 25 * l_ip.F_sz_um
-          : g_tp.min_w_nmos_;  // this was  20 micron for the 0.8 micron process
-  WNANDp = (process_ind)
-               ? 37.5 * l_ip.F_sz_um
-               : g_tp.min_w_nmos_ * pmos_to_nmos_sz_ratio();  // this was  30
-                                                              // micron for the
-                                                              // 0.8 micron
-                                                              // process
-  load_per_pipeline_stage = 2 * gate_C(WNANDn + WNANDp, 0, false);
-  compute();
-}
+  {
+	if (coredynp.core_ty==Inorder)
+	{
+		/* assume 6 pipe stages and try to estimate bits per pipe stage */
+		/* pipe stage 0/IF */
+		num_piperegs += coredynp.pc_width*2*coredynp.num_hthreads;
+		/* pipe stage IF/ID */
+		num_piperegs += coredynp.fetchW*(coredynp.instruction_length + coredynp.pc_width)*coredynp.num_hthreads;
+		/* pipe stage IF/ThreadSEL */
+		if (coredynp.multithreaded) num_piperegs += coredynp.num_hthreads*coredynp.perThreadState; //8 bit thread states
+		/* pipe stage ID/EXE */
+		num_piperegs += coredynp.decodeW*(coredynp.instruction_length + coredynp.pc_width + pow(2.0,opcode_length)+ 2*coredynp.int_data_width)*coredynp.num_hthreads;
+		/* pipe stage EXE/MEM */
+		num_piperegs += coredynp.issueW*(3 * coredynp.arch_ireg_width + pow(2.0,opcode_length) + 8*2*coredynp.int_data_width/*+2*powers (2,reg_length)*/);
+		/* pipe stage MEM/WB the 2^opcode_length means the total decoded signal for the opcode*/
+		num_piperegs += coredynp.issueW*(2*coredynp.int_data_width + pow(2.0,opcode_length) + 8*2*coredynp.int_data_width/*+2*powers (2,reg_length)*/);
+//		/* pipe stage 5/6 */
+//		num_piperegs += issueWidth*(data_width + powers (2,opcode_length)/*+2*powers (2,reg_length)*/);
+//		/* pipe stage 6/7 */
+//		num_piperegs += issueWidth*(data_width + powers (2,opcode_length)/*+2*powers (2,reg_length)*/);
+//		/* pipe stage 7/8 */
+//		num_piperegs += issueWidth*(data_width + powers (2,opcode_length)/**2*powers (2,reg_length)*/);
+//		/* assume 50% extra in control signals (rule of thumb) */
+		num_stages=6;
 
-void Pipeline::compute() {
-  compute_stage_vector();
-  DFFCell pipe_reg(false, WNANDn, WNANDp, load_per_pipeline_stage, &l_ip);
-  pipe_reg.compute_DFF_cell();
+	}
+	else
+	{
+		/* assume 12 stage pipe stages and try to estimate bits per pipe stage */
+		/*OOO: Fetch, decode, rename, IssueQ, dispatch, regread, EXE, MEM, WB, CM */
 
-  double clock_power_pipereg = num_piperegs * pipe_reg.e_clock.readOp.dynamic;
-  //******************pipeline power: currently, we average all the
-  //possibilities of the states of DFFs in the pipeline. A better way to do it
-  //is to consider
-  // the harming distance of two consecutive signals, However McPAT does not
-  // have plan to do this in near future as it focuses on worst case power.
-  double pipe_reg_power = num_piperegs * (pipe_reg.e_switch.readOp.dynamic +
-                                          pipe_reg.e_keep_0.readOp.dynamic +
-                                          pipe_reg.e_keep_1.readOp.dynamic) /
-                              3 +
-                          clock_power_pipereg;
-  double pipe_reg_leakage = num_piperegs * pipe_reg.e_switch.readOp.leakage;
-  double pipe_reg_gate_leakage =
-      num_piperegs * pipe_reg.e_switch.readOp.gate_leakage;
-  power.readOp.dynamic += pipe_reg_power;
-  power.readOp.leakage += pipe_reg_leakage;
-  power.readOp.gate_leakage += pipe_reg_gate_leakage;
-  area.set_area(num_piperegs * pipe_reg.area.get_area());
+		/* pipe stage 0/1F*/
+		num_piperegs += coredynp.pc_width*2*coredynp.num_hthreads ;//PC and Next PC
+		/* pipe stage IF/ID */
+		num_piperegs += coredynp.fetchW*(coredynp.instruction_length + coredynp.pc_width)*coredynp.num_hthreads;//PC is used to feed branch predictor in ID
+		/* pipe stage 1D/Renaming*/
+		num_piperegs += coredynp.decodeW*(coredynp.instruction_length + coredynp.pc_width)*coredynp.num_hthreads;//PC is for branch exe in later stage.
+		/* pipe stage Renaming/wire_drive */
+		num_piperegs += coredynp.decodeW*(coredynp.instruction_length + coredynp.pc_width);
+		/* pipe stage Renaming/IssueQ */
+		num_piperegs += coredynp.issueW*(coredynp.instruction_length  + coredynp.pc_width + 3*coredynp.phy_ireg_width)*coredynp.num_hthreads;//3*coredynp.phy_ireg_width means 2 sources and 1 dest
+		/* pipe stage IssueQ/Dispatch */
+		num_piperegs += coredynp.issueW*(coredynp.instruction_length + 3 * coredynp.phy_ireg_width);
+		/* pipe stage Dispatch/EXE */
 
-  double long_channel_device_reduction =
-      longer_channel_device_reduction(device_ty, coredynp.core_ty);
-  power.readOp.longer_channel_leakage =
-      power.readOp.leakage * long_channel_device_reduction;
+		num_piperegs += coredynp.issueW*(3 * coredynp.phy_ireg_width + coredynp.pc_width + pow(2.0,opcode_length)/*+2*powers (2,reg_length)*/);
+		/* 2^opcode_length means the total decoded signal for the opcode*/
+		num_piperegs += coredynp.issueW*(2*coredynp.int_data_width + pow(2.0,opcode_length)/*+2*powers (2,reg_length)*/);
+		/*2 source operands in EXE; Assume 2EXE stages* since we do not really distinguish OP*/
+		num_piperegs += coredynp.issueW*(2*coredynp.int_data_width + pow(2.0,opcode_length)/*+2*powers (2,reg_length)*/);
+		/* pipe stage EXE/MEM, data need to be read/write, address*/
+		num_piperegs += coredynp.issueW*(coredynp.int_data_width + coredynp.v_address_width + pow(2.0,opcode_length)/*+2*powers (2,reg_length)*/);//memory Opcode still need to be passed
+		/* pipe stage MEM/WB; result data, writeback regs */
+		num_piperegs += coredynp.issueW*(coredynp.int_data_width + coredynp.phy_ireg_width /* powers (2,opcode_length) + (2,opcode_length)+2*powers (2,reg_length)*/);
+		/* pipe stage WB/CM ; result data, regs need to be updated, address for resolve memory ops in ROB's top*/
+		num_piperegs += coredynp.commitW*(coredynp.int_data_width + coredynp.v_address_width + coredynp.phy_ireg_width/*+ powers (2,opcode_length)*2*powers (2,reg_length)*/)*coredynp.num_hthreads;
+//		if (multithreaded)
+//		{
+//
+//		}
+		num_stages=12;
 
-  double sckRation = g_tp.sckt_co_eff;
-  power.readOp.dynamic *= sckRation;
-  power.writeOp.dynamic *= sckRation;
-  power.searchOp.dynamic *= sckRation;
-  double macro_layout_overhead = g_tp.macro_layout_overhead;
-  if (!coredynp.Embedded)
-    area.set_area(area.get_area() * macro_layout_overhead);
-}
+	}
 
-void Pipeline::compute_stage_vector() {
-  double num_stages, tot_stage_vector, per_stage_vector;
-  int opcode_length =
-      coredynp.x86 ? coredynp.micro_opcode_length : coredynp.opcode_length;
-  // Hthread = thread_clock_gated? 1:num_thread;
+	/* assume 50% extra in control registers and interrupt registers (rule of thumb) */
+	num_piperegs = num_piperegs * 1.5;
+	tot_stage_vector=num_piperegs;
+	per_stage_vector=tot_stage_vector/num_stages;
 
-  if (!is_core_pipeline) {
-    num_piperegs = l_ip.pipeline_stages *
-                   l_ip.per_stage_vector;  // The number of pipeline stages are
-                                           // calculated based on the achievable
-                                           // throughput and required throughput
-  } else {
-    if (coredynp.core_ty == Inorder) {
-      /* assume 6 pipe stages and try to estimate bits per pipe stage */
-      /* pipe stage 0/IF */
-      num_piperegs += coredynp.pc_width * 2 * coredynp.num_hthreads;
-      /* pipe stage IF/ID */
-      num_piperegs += coredynp.fetchW *
-                      (coredynp.instruction_length + coredynp.pc_width) *
-                      coredynp.num_hthreads;
-      /* pipe stage IF/ThreadSEL */
-      if (coredynp.multithreaded)
-        num_piperegs += coredynp.num_hthreads *
-                        coredynp.perThreadState;  // 8 bit thread states
-      /* pipe stage ID/EXE */
-      num_piperegs += coredynp.decodeW *
-                      (coredynp.instruction_length + coredynp.pc_width +
-                       pow(2.0, opcode_length) + 2 * coredynp.int_data_width) *
-                      coredynp.num_hthreads;
-      /* pipe stage EXE/MEM */
-      num_piperegs +=
-          coredynp.issueW *
-          (3 * coredynp.arch_ireg_width + pow(2.0, opcode_length) +
-           8 * 2 * coredynp.int_data_width /*+2*powers (2,reg_length)*/);
-      /* pipe stage MEM/WB the 2^opcode_length means the total decoded signal
-       * for the opcode*/
-      num_piperegs +=
-          coredynp.issueW *
-          (2 * coredynp.int_data_width + pow(2.0, opcode_length) +
-           8 * 2 * coredynp.int_data_width /*+2*powers (2,reg_length)*/);
-      //		/* pipe stage 5/6 */
-      //		num_piperegs += issueWidth*(data_width + powers
-      //(2,opcode_length)/*+2*powers (2,reg_length)*/);
-      //		/* pipe stage 6/7 */
-      //		num_piperegs += issueWidth*(data_width + powers
-      //(2,opcode_length)/*+2*powers (2,reg_length)*/);
-      //		/* pipe stage 7/8 */
-      //		num_piperegs += issueWidth*(data_width + powers
-      //(2,opcode_length)/**2*powers (2,reg_length)*/);
-      //		/* assume 50% extra in control signals (rule of thumb)
-      //*/
-      num_stages = 6;
-
-    } else {
-      /* assume 12 stage pipe stages and try to estimate bits per pipe stage */
-      /*OOO: Fetch, decode, rename, IssueQ, dispatch, regread, EXE, MEM, WB, CM
-       */
-
-      /* pipe stage 0/1F*/
-      num_piperegs +=
-          coredynp.pc_width * 2 * coredynp.num_hthreads;  // PC and Next PC
-      /* pipe stage IF/ID */
-      num_piperegs +=
-          coredynp.fetchW * (coredynp.instruction_length + coredynp.pc_width) *
-          coredynp.num_hthreads;  // PC is used to feed branch predictor in ID
-      /* pipe stage 1D/Renaming*/
-      num_piperegs +=
-          coredynp.decodeW * (coredynp.instruction_length + coredynp.pc_width) *
-          coredynp.num_hthreads;  // PC is for branch exe in later stage.
-      /* pipe stage Renaming/wire_drive */
-      num_piperegs +=
-          coredynp.decodeW * (coredynp.instruction_length + coredynp.pc_width);
-      /* pipe stage Renaming/IssueQ */
-      num_piperegs += coredynp.issueW *
-                      (coredynp.instruction_length + coredynp.pc_width +
-                       3 * coredynp.phy_ireg_width) *
-                      coredynp.num_hthreads;  // 3*coredynp.phy_ireg_width means
-                                              // 2 sources and 1 dest
-      /* pipe stage IssueQ/Dispatch */
-      num_piperegs += coredynp.issueW * (coredynp.instruction_length +
-                                         3 * coredynp.phy_ireg_width);
-      /* pipe stage Dispatch/EXE */
-
-      num_piperegs += coredynp.issueW *
-                      (3 * coredynp.phy_ireg_width + coredynp.pc_width +
-                       pow(2.0, opcode_length) /*+2*powers (2,reg_length)*/);
-      /* 2^opcode_length means the total decoded signal for the opcode*/
-      num_piperegs += coredynp.issueW *
-                      (2 * coredynp.int_data_width +
-                       pow(2.0, opcode_length) /*+2*powers (2,reg_length)*/);
-      /*2 source operands in EXE; Assume 2EXE stages* since we do not really
-       * distinguish OP*/
-      num_piperegs += coredynp.issueW *
-                      (2 * coredynp.int_data_width +
-                       pow(2.0, opcode_length) /*+2*powers (2,reg_length)*/);
-      /* pipe stage EXE/MEM, data need to be read/write, address*/
-      num_piperegs +=
-          coredynp.issueW *
-          (coredynp.int_data_width + coredynp.v_address_width +
-           pow(2.0, opcode_length) /*+2*powers (2,reg_length)*/);  // memory
-                                                                   // Opcode
-                                                                   // still need
-                                                                   // to be
-                                                                   // passed
-      /* pipe stage MEM/WB; result data, writeback regs */
-      num_piperegs +=
-          coredynp.issueW *
-          (coredynp.int_data_width +
-           coredynp
-               .phy_ireg_width /* powers (2,opcode_length) + (2,opcode_length)+2*powers (2,reg_length)*/);
-      /* pipe stage WB/CM ; result data, regs need to be updated, address for
-       * resolve memory ops in ROB's top*/
-      num_piperegs +=
-          coredynp.commitW *
-          (coredynp.int_data_width + coredynp.v_address_width +
-           coredynp
-               .phy_ireg_width /*+ powers (2,opcode_length)*2*powers (2,reg_length)*/) *
-          coredynp.num_hthreads;
-      //		if (multithreaded)
-      //		{
-      //
-      //		}
-      num_stages = 12;
-    }
-
-    /* assume 50% extra in control registers and interrupt registers (rule of
-     * thumb) */
-    num_piperegs = num_piperegs * 1.5;
-    tot_stage_vector = num_piperegs;
-    per_stage_vector = tot_stage_vector / num_stages;
-
-    if (coredynp.core_ty == Inorder) {
-      if (coredynp.pipeline_stages > 6)
-        num_piperegs = per_stage_vector * coredynp.pipeline_stages;
-    } else  // OOO
-    {
-      if (coredynp.pipeline_stages > 12)
-        num_piperegs = per_stage_vector * coredynp.pipeline_stages;
-    }
+	if (coredynp.core_ty==Inorder)
+	{
+		if (coredynp.pipeline_stages>6)
+			num_piperegs= per_stage_vector*coredynp.pipeline_stages;
+	}
+	else//OOO
+	{
+		if (coredynp.pipeline_stages>12)
+			num_piperegs= per_stage_vector*coredynp.pipeline_stages;
+	}
   }
+
 }
 
-FunctionalUnit::FunctionalUnit(ParseXML *XML_interface, int ithCore_,
-                               InputParameter *interface_ip_,
-                               const CoreDynParam &dyn_p_,
-                               enum FU_type fu_type_, double exClockRate)
-    : XML(XML_interface),
-      ithCore(ithCore_),
-      interface_ip(*interface_ip_),
-      coredynp(dyn_p_),
-      fu_type(fu_type_) {
-  double area_t;  //, leakage, gate_leakage;
-  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
-  clockRate = exClockRate;  // coredynp.clockRate;
-  executionTime = coredynp.executionTime;
-  // cout<<"FU executionTime: "<<executionTime<<endl;
+FunctionalUnit::FunctionalUnit(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_,const CoreDynParam & dyn_p_, enum FU_type fu_type_, double exClockRate)
+:XML(XML_interface),
+ ithCore(ithCore_),
+ interface_ip(*interface_ip_),
+ coredynp(dyn_p_),
+ fu_type(fu_type_)
+{
+    double area_t;//, leakage, gate_leakage;
+    double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
+	clockRate = exClockRate;//coredynp.clockRate;
+	executionTime = coredynp.executionTime;
+	//cout<<"FU executionTime: "<<executionTime<<endl;
 
-  // XML_interface=_XML_interface;
-  uca_org_t result2;
-  result2 = init_interface(&interface_ip);
-  if (XML->sys.Embedded) {
-    if (fu_type == FPU) {
-      num_fu = coredynp.num_fpus;
-      // area_t = 8.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is
-      // um^2
-      area_t = 4.47 * 1e6 * (g_ip->F_sz_nm * g_ip->F_sz_nm / 90.0 /
-                             90.0);  // this is um^2 The base number
-      // 4.47 contains both VFP and NEON processing unit, VFP is about 40% and
-      // NEON is about 60%
-      if (g_ip->F_sz_nm > 90)
-        area_t = 4.47 * 1e6 *
-                 g_tp.scaling_factor.logic_scaling_co_eff;  // this is um^2
-      leakage = area_t * (g_tp.scaling_factor.core_tx_density) *
-                cmos_Isub_leakage(5 * g_tp.min_w_nmos_,
-                                  5 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r,
-                                  1, inv) *
-                g_tp.peri_global.Vdd / 2;  // unit W
-      gate_leakage = area_t * (g_tp.scaling_factor.core_tx_density) *
-                     cmos_Ig_leakage(
-                         5 * g_tp.min_w_nmos_,
-                         5 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
-                     g_tp.peri_global.Vdd / 2;  // unit W
-      // energy = 0.3529/10*1e-9;//this is the energy(nJ) for a FP instruction
-      // in FPU usually it can have up to 20 cycles.
-      //			base_energy = coredynp.core_ty==Inorder? 0:
-      //89e-3*3; //W The base energy of ALU average numbers from Intel 4G and
-      //773Mhz (Wattch)
-      //			base_energy
-      //*=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
-      base_energy = 0;
-      per_access_energy =
-          1.15 / 1e9 / 4 / 1.3 / 1.3 * g_tp.peri_global.Vdd *
-          g_tp.peri_global.Vdd *
-          (g_ip->F_sz_nm /
-           90.0);  // g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9;
-                   // //This is per Hz energy(nJ)
-      // per_access_energy*=3;
-      // FPU power from Sandia's processor sizing tech report
-      FU_height =
-          (18667 * num_fu) * interface_ip.F_sz_um;  // FPU from Sun's data
-    } else if (fu_type == ALU) {
-      num_fu = coredynp.num_alus;
-      // FIXME: The first area_t = is from updated McAPAT, the second is from
-      // our changes (conflict from base)
-      // area_t = 280*260*g_tp.scaling_factor.logic_scaling_co_eff;//this is
-      // um^2 ALU + MUl
-      area_t =
-          71.85 * 71.85 * num_fu *
-          g_tp.scaling_factor.logic_scaling_co_eff;  // this is um^2 ALU + MUl
-      leakage = area_t * (g_tp.scaling_factor.core_tx_density) *
-                cmos_Isub_leakage(20 * g_tp.min_w_nmos_,
-                                  20 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r,
-                                  1, inv) *
-                g_tp.peri_global.Vdd / 2;  // unit W
-      gate_leakage =
-          area_t * (g_tp.scaling_factor.core_tx_density) *
-          cmos_Ig_leakage(20 * g_tp.min_w_nmos_,
-                          20 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1,
-                          inv) *
-          g_tp.peri_global.Vdd / 2;
-      leakage = 0;
-      //			base_energy = coredynp.core_ty==Inorder?
-      //0:89e-3; //W The base energy of ALU average numbers from Intel 4G and
-      //773Mhz (Wattch)
-      //			base_energy
-      //*=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
-      base_energy = 0;
-      // per_access_energy =
-      // 1.15/3/1e9/4/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9;
-      // //This is per cycle energy(nJ)
-      per_access_energy = 1.29 / 1e12 / 1.3 / 1.3 * g_tp.peri_global.Vdd *
-                          g_tp.peri_global.Vdd * (g_ip->F_sz_nm / 90.0);
-      // per_access_energy*=3;
-      FU_height = (6222 * num_fu) * interface_ip.F_sz_um;  // integer ALU
+	//XML_interface=_XML_interface;
+	uca_org_t result2;
+	result2 = init_interface(&interface_ip);
+	if (XML->sys.Embedded)
+	{
+		if (fu_type == FPU)
+		{
+			num_fu=coredynp.num_fpus;
+			//area_t = 8.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2
+			area_t = 4.47*1e6*(g_ip->F_sz_nm*g_ip->F_sz_nm/90.0/90.0);//this is um^2 The base number
+			//4.47 contains both VFP and NEON processing unit, VFP is about 40% and NEON is about 60%
+			if (g_ip->F_sz_nm>90)
+				area_t = 4.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2
+			leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
+			gate_leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
+			//energy = 0.3529/10*1e-9;//this is the energy(nJ) for a FP instruction in FPU usually it can have up to 20 cycles.
+//			base_energy = coredynp.core_ty==Inorder? 0: 89e-3*3; //W The base energy of ALU average numbers from Intel 4G and 773Mhz (Wattch)
+//			base_energy *=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
+			base_energy = 0;
+			per_access_energy = 1.15/1e9/4/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9; //This is per Hz energy(nJ)
+			//per_access_energy*=3;
+			//FPU power from Sandia's processor sizing tech report
+			FU_height=(18667*num_fu)*interface_ip.F_sz_um;//FPU from Sun's data
+		}
+		else if (fu_type == ALU)
+		{
+			num_fu=coredynp.num_alus;			
+			//FIXME: The first area_t = is from updated McAPAT, the second is from our changes (conflict from base)
+			//area_t = 280*260*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2 ALU + MUl
+			area_t = 71.85*71.85*num_fu*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2 ALU + MUl
+			leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
+			gate_leakage = area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;
+			leakage = 0;
+//			base_energy = coredynp.core_ty==Inorder? 0:89e-3; //W The base energy of ALU average numbers from Intel 4G and 773Mhz (Wattch)
+//			base_energy *=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
+			base_energy = 0;
+			//per_access_energy = 1.15/3/1e9/4/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9; //This is per cycle energy(nJ)
+         per_access_energy = 1.29/1e12/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);
+         //per_access_energy*=3;
+         FU_height=(6222*num_fu)*interface_ip.F_sz_um;//integer ALU
 
-    } else if (fu_type == MUL) {
-      num_fu = coredynp.num_muls;
-      area_t =
-          280 * 260 * 3 *
-          g_tp.scaling_factor.logic_scaling_co_eff;  // this is um^2 ALU + MUl
-      leakage = area_t * (g_tp.scaling_factor.core_tx_density) *
-                cmos_Isub_leakage(20 * g_tp.min_w_nmos_,
-                                  20 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r,
-                                  1, inv) *
-                g_tp.peri_global.Vdd / 2;  // unit W
-      gate_leakage =
-          area_t * (g_tp.scaling_factor.core_tx_density) *
-          cmos_Ig_leakage(20 * g_tp.min_w_nmos_,
-                          20 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1,
-                          inv) *
-          g_tp.peri_global.Vdd / 2;
-      //			base_energy = coredynp.core_ty==Inorder?
-      //0:89e-3*2; //W The base energy of ALU average numbers from Intel 4G and
-      //773Mhz (Wattch)
-      //			base_energy
-      //*=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
-      base_energy = 0;
-      per_access_energy =
-          1.15 * 2 / 3 / 1e9 / 1.3 / 1.3 * g_tp.peri_global.Vdd *
-          g_tp.peri_global.Vdd *
-          (g_ip->F_sz_nm /
-           90.0);  //(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2)/24;//0.00649*1e-9;
-                   ////This is per cycle energy(nJ), coefficient based on Wattch
-                   //(24 is the division ny latency: Syed)
-      // per_access_energy*=3;
-      FU_height = (9334 * num_fu) *
-                  interface_ip.F_sz_um;  // divider/mul from Sun's data
-    } else {
-      cout << "Unknown Functional Unit Type" << endl;
-      exit(0);
-    }
-    per_access_energy *= 0.5;  // According to ARM data embedded processor has
-                               // much lower per acc energy
-  } /* if (XML->sys.Embedded) */
-  else {
-    if (fu_type == FPU) {
-      num_fu = coredynp.num_fpus;
+		}
+		else if (fu_type == MUL)
+		{
+			num_fu=coredynp.num_muls;
+			area_t = 280*260*3*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2 ALU + MUl
+			leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
+			gate_leakage = area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;
+//			base_energy = coredynp.core_ty==Inorder? 0:89e-3*2; //W The base energy of ALU average numbers from Intel 4G and 773Mhz (Wattch)
+//			base_energy *=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
+			base_energy = 0;
+			per_access_energy = 1.15*2/3/1e9/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2)/24;//0.00649*1e-9; //This is per cycle energy(nJ), coefficient based on Wattch (24 is the division ny latency: Syed)
+			//per_access_energy*=3;
+			FU_height=(9334*num_fu )*interface_ip.F_sz_um;//divider/mul from Sun's data
+		}
+		else
+		{
+			cout<<"Unknown Functional Unit Type"<<endl;
+			exit(0);
+		}
+		per_access_energy *=0.5;//According to ARM data embedded processor has much lower per acc energy
+	} /* if (XML->sys.Embedded) */	
+	else
+	{
+		if (fu_type == FPU)
+		  		{
+			num_fu=coredynp.num_fpus;
+		
+			/*
+			num_fu/=2; //2 DP FPUs combine to for a SP FPU
+			//area_t = 8.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2
+			area_t = 8.47*1e6*(g_ip->F_sz_nm*g_ip->F_sz_nm/90.0/90.0);//this is um^2
+			if (g_ip->F_sz_nm>90)
+				area_t = 8.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2
+			leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
+			gate_leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
+			//energy = 0.3529/10*1e-9;//this is the energy(nJ) for a FP instruction in FPU usually it can have up to 20 cycles.
+			base_energy = coredynp.core_ty==Inorder? 0: 89e-3*3; //W The base energy of ALU average numbers from Intel 4G and 773Mhz (Wattch)
+			base_energy *=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
+			per_access_energy = 1.15*3/1e9/4/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9; //This is per op energy(nJ)
+			FU_height=(38667*num_fu)*interface_ip.F_sz_um;//FPU from Sun's data
+			*/
+			//area_t = 8.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2
+         num_fu=num_fu/2; //2 DP FPUs combine to for a SP FPU
+			area_t = 8.47*1e6*(g_ip->F_sz_nm*g_ip->F_sz_nm/90.0/90.0);//this is um^2
+			if (g_ip->F_sz_nm>90)
+				area_t = 8.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2
+			leakage = 37e-3;//area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
+			gate_leakage = 0;//area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
+			//energy = 0.3529/10*1e-9;//this is the energy(nJ) for a FP instruction in FPU usually it can have up to 20 cycles.
+			base_energy = coredynp.core_ty==Inorder? 0: 89e-3*3; //W The base energy of ALU average numbers from Intel 4G and 773Mhz (Wattch)
 
-      /*
-      num_fu/=2; //2 DP FPUs combine to for a SP FPU
-      //area_t = 8.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is
-      um^2
-      area_t = 8.47*1e6*(g_ip->F_sz_nm*g_ip->F_sz_nm/90.0/90.0);//this is um^2
-      if (g_ip->F_sz_nm>90)
-              area_t = 8.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this
-      is um^2
-      leakage = area_t
-      *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(5*g_tp.min_w_nmos_,
-      5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
-      inv)*g_tp.peri_global.Vdd/2;//unit W
-      gate_leakage = area_t
-      *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(5*g_tp.min_w_nmos_,
-      5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
-      inv)*g_tp.peri_global.Vdd/2;//unit W
-      //energy = 0.3529/10*1e-9;//this is the energy(nJ) for a FP instruction in
-      FPU usually it can have up to 20 cycles.
-      base_energy = coredynp.core_ty==Inorder? 0: 89e-3*3; //W The base energy
-      of ALU average numbers from Intel 4G and 773Mhz (Wattch)
-      base_energy *=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
-      per_access_energy =
-      1.15*3/1e9/4/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9;
-      //This is per op energy(nJ)
-      FU_height=(38667*num_fu)*interface_ip.F_sz_um;//FPU from Sun's data
-      */
-      // area_t = 8.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is
-      // um^2
-      num_fu = num_fu / 2;  // 2 DP FPUs combine to for a SP FPU
-      area_t = 8.47 * 1e6 *
-               (g_ip->F_sz_nm * g_ip->F_sz_nm / 90.0 / 90.0);  // this is um^2
-      if (g_ip->F_sz_nm > 90)
-        area_t = 8.47 * 1e6 *
-                 g_tp.scaling_factor.logic_scaling_co_eff;  // this is um^2
-      leakage =
-          37e-3;  // area_t
-                  // *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(5*g_tp.min_w_nmos_,
-                  // 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
-                  // inv)*g_tp.peri_global.Vdd/2;//unit W
-      gate_leakage =
-          0;  // area_t
-              // *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(5*g_tp.min_w_nmos_,
-              // 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
-              // inv)*g_tp.peri_global.Vdd/2;//unit W
-      // energy = 0.3529/10*1e-9;//this is the energy(nJ) for a FP instruction
-      // in FPU usually it can have up to 20 cycles.
-      base_energy =
-          coredynp.core_ty == Inorder ? 0 : 89e-3 * 3;  // W The base energy of
-                                                        // ALU average numbers
-                                                        // from Intel 4G and
-                                                        // 773Mhz (Wattch)
+			base_energy *=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
 
-      base_energy *= (g_tp.peri_global.Vdd * g_tp.peri_global.Vdd / 1.2 / 1.2);
 
-      // Base energy (if the pipeline is not clock gated)
-      // TODO: add a check for clockgating enable
-      base_energy = SP_BASE_POWER;
+			//Base energy (if the pipeline is not clock gated)
+			//TODO: add a check for clockgating enable
+			base_energy=SP_BASE_POWER;
 
-      // per_access_energy =
-      // 1.15*3/1e9/4/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9;
-      // //This is per op energy(nJ)
-      per_access_energy =
-          3.9 * 14.91 / 1e12 / 1.08 / 1.08 * g_tp.peri_global.Vdd *
-          g_tp.peri_global.Vdd *
-          (g_ip->F_sz_nm /
-           90.0);  //;4.34 is scaling factor based on hardware measurements
-      // ALU instrucitons are also executed on FPUs so add 30% overhead for
-      // supporting ALU instrcutions
-      // per_access_energy = 1.3*per_access_energy;
+			//per_access_energy = 1.15*3/1e9/4/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9; //This is per op energy(nJ)
+         per_access_energy = 3.9*14.91/1e12/1.08/1.08*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//;4.34 is scaling factor based on hardware measurements
+			//ALU instrucitons are also executed on FPUs so add 30% overhead for supporting ALU instrcutions
+			//per_access_energy = 1.3*per_access_energy;
 
-      // ALU instrucitons are also executed on FPUs so add 10% overhead for
-      // supporting ALU instrcutions
-      leakage = 1.1 * leakage;
-      // cout<<"FPU Per access erngy: "<<per_access_energy/2;
-      // Divide per access energy by 2 so we have 4 DP units capapble of
-      // doing 8 SP operations
-      // per_access_energy = per_access_energy/2;
-      FU_height =
-          (38667 * num_fu) * interface_ip.F_sz_um;  // FPU from Sun's data
-      per_access_energy *= 2;
-    } else if (fu_type == ALU) {
-      num_fu = coredynp.num_alus;
-      // FIXME: The first area_t = is from updated McPAT. The second is from our
-      // McPAT changes. Fix after merge
-      // area_t = 280*260*2*g_tp.scaling_factor.logic_scaling_co_eff;//this is
-      // um^2 ALU + MUl
-      // leakage = area_t
-      // *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_,
-      // 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
-      // inv)*g_tp.peri_global.Vdd/2;//unit W
-      // gate_leakage =
-      // area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_,
-      // 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
-      // inv)*g_tp.peri_global.Vdd/2;
-      area_t =
-          71.85 * 71.85 * num_fu *
-          g_tp.scaling_factor.logic_scaling_co_eff;  // this is um^2 ALU + MUl
-      // leakage = area_t
-      // *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_,
-      // 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
-      // inv)*g_tp.peri_global.Vdd/2;//unit W
-      // gate_leakage =
-      // area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_,
-      // 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
-      // inv)*g_tp.peri_global.Vdd/2;
-      // Following leakage numbers are based on Syntheis based power-estimation
-      // (SYED)
-      leakage = 2.58e-5;
-      gate_leakage = 0;
-      base_energy = coredynp.core_ty == Inorder
-                        ? 0
-                        : 89e-3;  // W The base energy of ALU average numbers
-                                  // from Intel 4G and 773Mhz (Wattch)
-      base_energy *= (g_tp.peri_global.Vdd * g_tp.peri_global.Vdd / 1.2 / 1.2);
-      // per_access_energy =
-      // 1.15/1e9/4/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9;
-      // //This is per cycle energy(nJ)
-      per_access_energy = 0.8 * 1.29 / 1e12 / 1.3 / 1.3 * g_tp.peri_global.Vdd *
-                          g_tp.peri_global.Vdd * (g_ip->F_sz_nm / 90.0);
-      FU_height = (6222 * num_fu) * interface_ip.F_sz_um;  // integer ALU
-      per_access_energy *= 2;
-    } else if (fu_type == MUL) {
-      num_fu = coredynp.num_muls;
-      area_t =
-          280 * 260 * 2 * 3 *
-          g_tp.scaling_factor.logic_scaling_co_eff;  // this is um^2 ALU + MUl
-      // leakage = area_t
-      // *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_,
-      // 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
-      // inv)*g_tp.peri_global.Vdd/2;//unit W
-      leakage = 37e-3;
-      gate_leakage =
-          0;  // area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_,
-              // 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
-              // inv)*g_tp.peri_global.Vdd/2;
-      base_energy =
-          coredynp.core_ty == Inorder ? 0 : 89e-3 * 2;  // W The base energy of
-                                                        // ALU average numbers
-                                                        // from Intel 4G and
-                                                        // 773Mhz (Wattch)
-      base_energy *= (g_tp.peri_global.Vdd * g_tp.peri_global.Vdd / 1.2 / 1.2);
-      base_energy = SFU_BASE_POWER;
-      // SFU is modelled as a double preicison FPU
-      per_access_energy =
-          8 * 14.91 / 1e12 / 1.08 / 1.08 * g_tp.peri_global.Vdd *
-          g_tp.peri_global.Vdd *
-          (g_ip->F_sz_nm /
-           90.0);  // 1.5 is scaling factor based on hardware measuremetns
-      FU_height = (9334 * num_fu) *
-                  interface_ip.F_sz_um;  // divider/mul from Sun's data
-      per_access_energy *= 2;
-    }
 
-    else {
-      cout << "Unknown Functional Unit Type" << endl;
-      exit(0);
-    }
-  }
-  // IEXEU, simple ALU and FPU
-  //  double C_ALU, C_EXEU, C_FPU; //Lum Equivalent capacitance of IEXEU and
-  //  FPU. Based on Intel and Sun 90nm process fabracation.
-  //
-  //  C_ALU	  = 0.025e-9;//F
-  //  C_EXEU  = 0.05e-9; //F
-  //  C_FPU	  = 0.35e-9;//F
-  area.set_area(area_t * num_fu);
-  leakage *= num_fu;
-  gate_leakage *= num_fu;
-  double macro_layout_overhead = g_tp.macro_layout_overhead;
-  //	if (!XML->sys.Embedded)
-  area.set_area(area.get_area() * macro_layout_overhead);
+			//ALU instrucitons are also executed on FPUs so add 10% overhead for supporting ALU instrcutions
+	   	leakage = 1.1*leakage;
+			//cout<<"FPU Per access erngy: "<<per_access_energy/2;
+			//Divide per access energy by 2 so we have 4 DP units capapble of 
+			//doing 8 SP operations
+			//per_access_energy = per_access_energy/2;
+			FU_height=(38667*num_fu)*interface_ip.F_sz_um;//FPU from Sun's data
+			per_access_energy*=2;
+		}
+		else if (fu_type == ALU)
+		{
+			num_fu=coredynp.num_alus;
+			//FIXME: The first area_t = is from updated McPAT. The second is from our McPAT changes. Fix after merge
+			//area_t = 280*260*2*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2 ALU + MUl
+			//leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
+			//gate_leakage = area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;
+			area_t = 71.85*71.85*num_fu*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2 ALU + MUl
+			//leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
+			//gate_leakage = area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;
+			//Following leakage numbers are based on Syntheis based power-estimation (SYED)
+			leakage = 2.58e-5;
+			gate_leakage = 0;
+			base_energy = coredynp.core_ty==Inorder? 0:89e-3; //W The base energy of ALU average numbers from Intel 4G and 773Mhz (Wattch)
+			base_energy *=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
+			//per_access_energy = 1.15/1e9/4/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);//0.00649*1e-9; //This is per cycle energy(nJ)
+			per_access_energy = 0.8*1.29/1e12/1.3/1.3*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);
+			FU_height=(6222*num_fu)*interface_ip.F_sz_um;//integer ALU
+			per_access_energy*=2;
+		}
+			else if (fu_type == MUL)
+		{
+			num_fu=coredynp.num_muls;
+			area_t = 280*260*2*3*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2 ALU + MUl
+			//leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
+			leakage = 37e-3;
+			gate_leakage = 0;//area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;
+			base_energy = coredynp.core_ty==Inorder? 0:89e-3*2; //W The base energy of ALU average numbers from Intel 4G and 773Mhz (Wattch)
+			base_energy *=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
+			base_energy = SFU_BASE_POWER;
+			//SFU is modelled as a double preicison FPU
+			per_access_energy = 8*14.91/1e12/1.08/1.08*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(g_ip->F_sz_nm/90.0);//1.5 is scaling factor based on hardware measuremetns
+			FU_height=(9334*num_fu )*interface_ip.F_sz_um;//divider/mul from Sun's data
+			per_access_energy*=2;
+		}
+
+		else
+		{
+			cout<<"Unknown Functional Unit Type"<<endl;
+			exit(0);
+		}
+	}
+	//IEXEU, simple ALU and FPU
+	//  double C_ALU, C_EXEU, C_FPU; //Lum Equivalent capacitance of IEXEU and FPU. Based on Intel and Sun 90nm process fabracation.
+	//
+	//  C_ALU	  = 0.025e-9;//F
+	//  C_EXEU  = 0.05e-9; //F
+	//  C_FPU	  = 0.35e-9;//F
+    area.set_area(area_t*num_fu);
+    leakage *= num_fu;
+    gate_leakage *=num_fu;
+	double macro_layout_overhead = g_tp.macro_layout_overhead;
+//	if (!XML->sys.Embedded)
+		area.set_area(area.get_area()*macro_layout_overhead);
 }
 
-void FunctionalUnit::computeEnergy(bool is_tdp) {
-  executionTime =
-      XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);  // Syed
-  double pppm_t[4] = {1, 1, 1, 1};
-  double FU_duty_cycle;
-  if (is_tdp) {
-    set_pppm(pppm_t, 2, 2, 2, 2);  // 2 means two source operands needs to be
-                                   // passed for each int instruction.
-    if (fu_type == FPU) {
-      stats_t.readAc.access = num_fu;
-      tdp_stats = stats_t;
-      // Syed: FPU power numbers are already average
-      // so activity factor is already accounted for
-      FU_duty_cycle = coredynp.FPU_duty_cycle;
-    } else if (fu_type == ALU) {
-      stats_t.readAc.access = 1 * num_fu;
-      tdp_stats = stats_t;
-      FU_duty_cycle = coredynp.ALU_duty_cycle;
-    } else if (fu_type == MUL) {
-      stats_t.readAc.access = num_fu;
-      tdp_stats = stats_t;
-      FU_duty_cycle = coredynp.MUL_duty_cycle;
-    }
+void FunctionalUnit::computeEnergy(bool is_tdp)
+{
+ 
+  executionTime=XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);//Syed
+	double pppm_t[4]    = {1,1,1,1};
+	double FU_duty_cycle;
+	if (is_tdp)
+	{
 
-    // power.readOp.dynamic = base_energy/clockRate +
-    // energy*stats_t.readAc.access;
-    power.readOp.dynamic =
-        per_access_energy * stats_t.readAc.access + base_energy / clockRate;
-    double sckRation = g_tp.sckt_co_eff;
-    power.readOp.dynamic *= sckRation * FU_duty_cycle;
-    power.writeOp.dynamic *= sckRation;
-    power.searchOp.dynamic *= sckRation;
 
-    power.readOp.leakage = leakage;
-    power.readOp.gate_leakage = gate_leakage;
-    double long_channel_device_reduction =
-        longer_channel_device_reduction(Core_device, coredynp.core_ty);
-    power.readOp.longer_channel_leakage =
-        power.readOp.leakage * long_channel_device_reduction;
+		set_pppm(pppm_t, 2, 2, 2, 2);//2 means two source operands needs to be passed for each int instruction.
+		if (fu_type == FPU)
+		{
+			stats_t.readAc.access = num_fu;
+			tdp_stats = stats_t;
+            //Syed: FPU power numbers are already average
+            //so activity factor is already accounted for
+			FU_duty_cycle= coredynp.FPU_duty_cycle;
+		}
+		else if (fu_type == ALU)
+		{
+			stats_t.readAc.access = 1*num_fu;
+			tdp_stats = stats_t;
+			FU_duty_cycle = coredynp.ALU_duty_cycle;
+		}
+		else if (fu_type == MUL)
+		{
+			stats_t.readAc.access = num_fu;
+			tdp_stats = stats_t;
+			FU_duty_cycle = coredynp.MUL_duty_cycle;
+		}
 
-  } else {
-    if (fu_type == FPU) {
-      // Each access activates an equililant of a double-precision unit
-      // so divide accesses into half
-      stats_t.readAc.access = XML->sys.core[ithCore].fpu_accesses;
-      rtp_stats = stats_t;
-      // cout<<"FPU: --accesses "<<stats_t.readAc.access <<endl;
+	    //power.readOp.dynamic = base_energy/clockRate + energy*stats_t.readAc.access;
+	    power.readOp.dynamic = per_access_energy*stats_t.readAc.access + base_energy/clockRate;
+		double sckRation = g_tp.sckt_co_eff;
+		power.readOp.dynamic *= sckRation*FU_duty_cycle;
+		power.writeOp.dynamic *= sckRation;
+		power.searchOp.dynamic *= sckRation;
 
-    } else if (fu_type == ALU) {
-      stats_t.readAc.access = XML->sys.core[ithCore].ialu_accesses;
-      rtp_stats = stats_t;
-      // cout<<"ALU: --accesses "<<stats_t.readAc.access <<endl;
-    } else if (fu_type == MUL) {
-      stats_t.readAc.access = XML->sys.core[ithCore].mul_accesses;
-      rtp_stats = stats_t;
-      // cout<<"MUL: --accesses "<<stats_t.readAc.access <<endl;
-    }
+	    power.readOp.leakage = leakage;
+	    power.readOp.gate_leakage = gate_leakage;
+	    double long_channel_device_reduction = longer_channel_device_reduction(Core_device, coredynp.core_ty);
+	    power.readOp.longer_channel_leakage	= power.readOp.leakage*long_channel_device_reduction;
 
-    // rt_power.readOp.dynamic = base_energy*executionTime +
-    // energy*stats_t.readAc.access;
+	}
+	else
+	{
+		if (fu_type == FPU)
+		{
+		  //Each access activates an equililant of a double-precision unit
+		  //so divide accesses into half
+			stats_t.readAc.access = XML->sys.core[ithCore].fpu_accesses;
+			rtp_stats = stats_t;
+			//cout<<"FPU: --accesses "<<stats_t.readAc.access <<endl;
 
-    if (fu_type == ALU) {
-      rt_power.readOp.dynamic = per_access_energy * stats_t.readAc.access +
-                                base_energy * executionTime;
-    } else {
-      rt_power.readOp.dynamic = per_access_energy * stats_t.readAc.access;
-    }
+		}
+		else if (fu_type == ALU)
+		{
+			stats_t.readAc.access = XML->sys.core[ithCore].ialu_accesses;
+			rtp_stats = stats_t;
+			//cout<<"ALU: --accesses "<<stats_t.readAc.access <<endl;
+		}
+		else if (fu_type == MUL)
+		{
+			stats_t.readAc.access = XML->sys.core[ithCore].mul_accesses;
+			rtp_stats = stats_t;
+			//cout<<"MUL: --accesses "<<stats_t.readAc.access <<endl;
+		}
 
-    double sckRation = g_tp.sckt_co_eff;
-    rt_power.readOp.dynamic *= sckRation;
-    rt_power.writeOp.dynamic *= sckRation;
-    rt_power.searchOp.dynamic *= sckRation;
-    // cout<<"Power: "<<rt_power.readOp.dynamic<<endl;
-    if (fu_type == FPU) {
-      rt_power.readOp.dynamic +=
-          base_energy * executionTime *
-          (32 - XML->sys.core[ithCore].sp_average_active_lanes);
-    }
-    if (fu_type == MUL) {
-      if (XML->sys.core[ithCore].sfu_average_active_lanes >= 1)
-        rt_power.readOp.dynamic +=
-            base_energy * executionTime *
-            (32 - XML->sys.core[ithCore].sfu_average_active_lanes);
-    }
+	    //rt_power.readOp.dynamic = base_energy*executionTime + energy*stats_t.readAc.access;
+	    
+		if(fu_type == ALU){
+		rt_power.readOp.dynamic = per_access_energy*stats_t.readAc.access + base_energy*executionTime;
+		}
+		else{
+		  rt_power.readOp.dynamic = per_access_energy*stats_t.readAc.access;
+		}
 
-  } /* else */
+		double sckRation = g_tp.sckt_co_eff;
+		rt_power.readOp.dynamic *= sckRation;
+		rt_power.writeOp.dynamic *= sckRation;
+		rt_power.searchOp.dynamic *= sckRation;
+      //cout<<"Power: "<<rt_power.readOp.dynamic<<endl;
+		if(fu_type == FPU){
+		  rt_power.readOp.dynamic += base_energy*executionTime*(32-XML->sys.core[ithCore].sp_average_active_lanes);
+		}
+		if(fu_type == MUL){
+		  if(XML->sys.core[ithCore].sfu_average_active_lanes>=1)
+		    rt_power.readOp.dynamic += base_energy*executionTime*(32-XML->sys.core[ithCore].sfu_average_active_lanes);
+		}
+
+	} /* else */	
+
+
+
 }
 
-void FunctionalUnit::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
-  string indent_str(indent, ' ');
-  string indent_str_next(indent + 2, ' ');
-  bool long_channel = XML->sys.longer_channel_device;
+void FunctionalUnit::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
+{
+	string indent_str(indent, ' ');
+	string indent_str_next(indent+2, ' ');
+	bool long_channel = XML->sys.longer_channel_device;
 
-  //	cout << indent_str_next << "Results Broadcast Bus Area = " <<
-  //bypass->area.get_area() *1e-6 << " mm^2" << endl;
-  if (is_tdp) {
-    if (fu_type == FPU) {
-      cout << indent_str
-           << "Floating Point Units (FPUs) (Count: " << coredynp.num_fpus
-           << " ):" << endl;
-      cout << indent_str_next << "Area = " << area.get_area() * 1e-6 << " mm^2"
-           << endl;
-      cout << indent_str_next
-           << "Peak Dynamic = " << power.readOp.dynamic * clockRate << " W"
-           << endl;
-      cout << indent_str_next << "Peak Energy = " << power.readOp.dynamic
-           << " J" << endl;
+//	cout << indent_str_next << "Results Broadcast Bus Area = " << bypass->area.get_area() *1e-6 << " mm^2" << endl;
+	if (is_tdp)
+	{
+		if (fu_type == FPU)
+		{
+			cout << indent_str << "Floating Point Units (FPUs) (Count: "<< coredynp.num_fpus <<" ):" << endl;
+			cout << indent_str_next << "Area = " << area.get_area()*1e-6  << " mm^2" << endl;
+			cout << indent_str_next << "Peak Dynamic = " << power.readOp.dynamic*clockRate  << " W" << endl;
+			cout << indent_str_next << "Peak Energy = " << power.readOp.dynamic  << " J" << endl;
 
-      //			cout << indent_str_next << "Subthreshold Leakage
-      //= " << power.readOp.leakage  << " W" << endl;
-      // cout <<"clock: "<<clockRate<<endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel ? power.readOp.longer_channel_leakage
-                            : power.readOp.leakage)
-           << " W" << endl;
-      cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage
-           << " W" << endl;
-      cout << indent_str_next
-           << "Runtime Dynamic = " << rt_power.readOp.dynamic / executionTime
-           << " W" << endl;
-      cout << endl;
-    } else if (fu_type == ALU) {
-      cout << indent_str << "Integer ALUs (Count: " << coredynp.num_alus
-           << " ):" << endl;
-      cout << indent_str_next << "Area = " << area.get_area() * 1e-6 << " mm^2"
-           << endl;
-      cout << indent_str_next
-           << "Peak Dynamic = " << power.readOp.dynamic * clockRate << " W"
-           << endl;
-      //			cout << indent_str_next << "Subthreshold Leakage
-      //= " << power.readOp.leakage  << " W" << endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel ? power.readOp.longer_channel_leakage
-                            : power.readOp.leakage)
-           << " W" << endl;
-      cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage
-           << " W" << endl;
-      cout << indent_str_next
-           << "Runtime Dynamic = " << rt_power.readOp.dynamic / executionTime
-           << " W" << endl;
-      cout << endl;
-    } else if (fu_type == MUL) {
-      cout << indent_str
-           << "Complex ALUs (Mul/Div) (Count: " << coredynp.num_muls
-           << " ):" << endl;
-      cout << indent_str_next << "Area = " << area.get_area() * 1e-6 << " mm^2"
-           << endl;
-      cout << indent_str_next
-           << "Peak Dynamic = " << power.readOp.dynamic * clockRate << " W"
-           << endl;
-      //			cout << indent_str_next << "Subthreshold Leakage
-      //= " << power.readOp.leakage  << " W" << endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel ? power.readOp.longer_channel_leakage
-                            : power.readOp.leakage)
-           << " W" << endl;
-      cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage
-           << " W" << endl;
-      cout << indent_str_next
-           << "Runtime Dynamic = " << rt_power.readOp.dynamic / executionTime
-           << " W" << endl;
-      cout << endl;
-    }
+//			cout << indent_str_next << "Subthreshold Leakage = " << power.readOp.leakage  << " W" << endl;
+        //cout <<"clock: "<<clockRate<<endl;
+			cout << indent_str_next<< "Subthreshold Leakage = "
+						<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
+			cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage  << " W" << endl;
+			cout << indent_str_next << "Runtime Dynamic = " << rt_power.readOp.dynamic/executionTime << " W" << endl;
+			cout <<endl;
+		}
+		else if (fu_type == ALU)
+		{
+			cout << indent_str << "Integer ALUs (Count: "<< coredynp.num_alus <<" ):" << endl;
+			cout << indent_str_next << "Area = " << area.get_area()*1e-6  << " mm^2" << endl;
+			cout << indent_str_next << "Peak Dynamic = " << power.readOp.dynamic*clockRate  << " W" << endl;
+//			cout << indent_str_next << "Subthreshold Leakage = " << power.readOp.leakage  << " W" << endl;
+			cout << indent_str_next<< "Subthreshold Leakage = "
+						<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
+			cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage  << " W" << endl;
+			cout << indent_str_next << "Runtime Dynamic = " << rt_power.readOp.dynamic/executionTime << " W" << endl;
+			cout <<endl;
+		}
+		else if (fu_type == MUL)
+		{
+			cout << indent_str << "Complex ALUs (Mul/Div) (Count: "<< coredynp.num_muls <<" ):" << endl;
+			cout << indent_str_next << "Area = " << area.get_area()*1e-6  << " mm^2" << endl;
+			cout << indent_str_next << "Peak Dynamic = " << power.readOp.dynamic*clockRate  << " W" << endl;
+//			cout << indent_str_next << "Subthreshold Leakage = " << power.readOp.leakage  << " W" << endl;
+			cout << indent_str_next<< "Subthreshold Leakage = "
+						<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
+			cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage  << " W" << endl;
+			cout << indent_str_next << "Runtime Dynamic = " << rt_power.readOp.dynamic/executionTime << " W" << endl;
+			cout <<endl;
 
-  } else {
-  }
+		}
+
+	}
+	else
+	{
+	}
+
 }
 
-void FunctionalUnit::leakage_feedback(double temperature) {
+void FunctionalUnit::leakage_feedback(double temperature)
+{
   // Update the temperature and initialize the global interfaces.
-  interface_ip.temp = (unsigned int)round(temperature / 10.0) * 10;
+  interface_ip.temp = (unsigned int)round(temperature/10.0)*10;
 
-  uca_org_t init_result =
-      init_interface(&interface_ip);  // init_result is dummy
+  uca_org_t init_result = init_interface(&interface_ip); // init_result is dummy
 
   // This is part of FunctionalUnit()
   double area_t, leakage, gate_leakage;
   double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
 
-  if (fu_type == FPU) {
-    area_t = 4.47 * 1e6 * (g_ip->F_sz_nm * g_ip->F_sz_nm / 90.0 /
-                           90.0);  // this is um^2 The base number
-    if (g_ip->F_sz_nm > 90)
-      area_t = 4.47 * 1e6 *
-               g_tp.scaling_factor.logic_scaling_co_eff;  // this is um^2
-    leakage = area_t * (g_tp.scaling_factor.core_tx_density) *
-              cmos_Isub_leakage(5 * g_tp.min_w_nmos_,
-                                5 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1,
-                                inv) *
-              g_tp.peri_global.Vdd / 2;  // unit W
-    gate_leakage =
-        area_t * (g_tp.scaling_factor.core_tx_density) *
-        cmos_Ig_leakage(5 * g_tp.min_w_nmos_,
-                        5 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
-        g_tp.peri_global.Vdd / 2;  // unit W
-  } else if (fu_type == ALU) {
-    area_t =
-        280 * 260 * 2 * num_fu *
-        g_tp.scaling_factor.logic_scaling_co_eff;  // this is um^2 ALU + MUl
-    leakage = area_t * (g_tp.scaling_factor.core_tx_density) *
-              cmos_Isub_leakage(20 * g_tp.min_w_nmos_,
-                                20 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r,
-                                1, inv) *
-              g_tp.peri_global.Vdd / 2;  // unit W
-    gate_leakage =
-        area_t * (g_tp.scaling_factor.core_tx_density) *
-        cmos_Ig_leakage(20 * g_tp.min_w_nmos_,
-                        20 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
-        g_tp.peri_global.Vdd / 2;
-  } else if (fu_type == MUL) {
-    area_t =
-        280 * 260 * 2 * 3 * num_fu *
-        g_tp.scaling_factor.logic_scaling_co_eff;  // this is um^2 ALU + MUl
-    leakage = area_t * (g_tp.scaling_factor.core_tx_density) *
-              cmos_Isub_leakage(20 * g_tp.min_w_nmos_,
-                                20 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r,
-                                1, inv) *
-              g_tp.peri_global.Vdd / 2;  // unit W
-    gate_leakage =
-        area_t * (g_tp.scaling_factor.core_tx_density) *
-        cmos_Ig_leakage(20 * g_tp.min_w_nmos_,
-                        20 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
-        g_tp.peri_global.Vdd / 2;
-  } else {
-    cout << "Unknown Functional Unit Type" << endl;
+  if (fu_type == FPU)
+  {
+	area_t = 4.47*1e6*(g_ip->F_sz_nm*g_ip->F_sz_nm/90.0/90.0);//this is um^2 The base number
+	if (g_ip->F_sz_nm>90)
+		area_t = 4.47*1e6*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2
+	leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
+	gate_leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
+  }
+  else if (fu_type == ALU)
+  {
+    area_t = 280*260*2*num_fu*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2 ALU + MUl
+    leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
+    gate_leakage = area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;
+  }
+  else if (fu_type == MUL)
+  {
+    area_t = 280*260*2*3*num_fu*g_tp.scaling_factor.logic_scaling_co_eff;//this is um^2 ALU + MUl
+    leakage = area_t *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;//unit W
+    gate_leakage = area_t*(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(20*g_tp.min_w_nmos_, 20*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd/2;
+  }
+  else
+  {
+    cout<<"Unknown Functional Unit Type"<<endl;
     exit(1);
   }
 
-  power.readOp.leakage = leakage * num_fu;
-  power.readOp.gate_leakage = gate_leakage * num_fu;
-  power.readOp.longer_channel_leakage =
-      longer_channel_device_reduction(Core_device, coredynp.core_ty);
+  power.readOp.leakage = leakage*num_fu;
+  power.readOp.gate_leakage = gate_leakage*num_fu;
+  power.readOp.longer_channel_leakage = longer_channel_device_reduction(Core_device, coredynp.core_ty);
 }
 
-UndiffCore::UndiffCore(ParseXML *XML_interface, int ithCore_,
-                       InputParameter *interface_ip_,
-                       const CoreDynParam &dyn_p_, bool exist_, bool embedded_)
-    : XML(XML_interface),
-      ithCore(ithCore_),
-      interface_ip(*interface_ip_),
-      coredynp(dyn_p_),
-      core_ty(coredynp.core_ty),
-      embedded(XML->sys.Embedded),
-      pipeline_stage(coredynp.pipeline_stages),
-      num_hthreads(coredynp.num_hthreads),
-      issue_width(coredynp.issueW),
-      exist(exist_)
+UndiffCore::UndiffCore(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_, bool exist_,  bool embedded_)
+:XML(XML_interface),
+ ithCore(ithCore_),
+ interface_ip(*interface_ip_),
+ coredynp(dyn_p_),
+ core_ty(coredynp.core_ty),
+ embedded(XML->sys.Embedded),
+ pipeline_stage(coredynp.pipeline_stages),
+ num_hthreads(coredynp.num_hthreads),
+ issue_width(coredynp.issueW),
+ exist(exist_)
 // is_default(_is_default)
 {
-  if (!exist) return;
-  double undifferentiated_core = 0;
-  double core_tx_density = 0;
-  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
-  double undifferentiated_core_coe;
-  // XML_interface=_XML_interface;
-  uca_org_t result2;
-  result2 = init_interface(&interface_ip);
+	if (!exist) return;
+	double undifferentiated_core=0;
+	double core_tx_density=0;
+	double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
+	double undifferentiated_core_coe;
+	//XML_interface=_XML_interface;
+	uca_org_t result2;
+	result2 = init_interface(&interface_ip);
 
-  // Compute undifferentiated core area at 90nm.
-  if (embedded == false) {
-    // Based on the results of polynomial/log curve fitting based on
-    // undifferentiated core of Niagara, Niagara2, Merom, Penyrn, Prescott,
-    // Opteron die measurements
-    if (core_ty == OOO) {
-      // undifferentiated_core = (0.0764*pipeline_stage*pipeline_stage
-      // -2.3685*pipeline_stage + 10.405);//OOO
-      undifferentiated_core = (3.57 * log(pipeline_stage) - 1.2643) > 0
-                                  ? (3.57 * log(pipeline_stage) - 1.2643)
-                                  : 0;
-    } else if (core_ty == Inorder) {
-      // undifferentiated_core = (0.1238*pipeline_stage + 7.2572)*0.9;//inorder
-      undifferentiated_core = (-2.19 * log(pipeline_stage) + 6.55) > 0
-                                  ? (-2.19 * log(pipeline_stage) + 6.55)
-                                  : 0;
-    } else {
-      cout << "invalid core type" << endl;
-      exit(0);
-    }
-    undifferentiated_core *= (1 + logtwo(num_hthreads) * 0.0716);
-  } else {
-    // Based on the results in paper "parametrized processor models" Sandia Labs
-    if (XML->sys.opt_clockrate)
-      undifferentiated_core_coe = 0.05;
-    else
-      undifferentiated_core_coe = 0;
-    undifferentiated_core =
-        (0.4109 * pipeline_stage - 0.776) * undifferentiated_core_coe;
-    undifferentiated_core *= (1 + logtwo(num_hthreads) * 0.0426);
-  }
+	//Compute undifferentiated core area at 90nm.
+	if (embedded==false)
+	{
+		//Based on the results of polynomial/log curve fitting based on undifferentiated core of Niagara, Niagara2, Merom, Penyrn, Prescott, Opteron die measurements
+		if (core_ty==OOO)
+		{
+			//undifferentiated_core = (0.0764*pipeline_stage*pipeline_stage -2.3685*pipeline_stage + 10.405);//OOO
+			undifferentiated_core = (3.57*log(pipeline_stage)-1.2643)>0?(3.57*log(pipeline_stage)-1.2643):0;
+		}
+		else if (core_ty==Inorder)
+		{
+			//undifferentiated_core = (0.1238*pipeline_stage + 7.2572)*0.9;//inorder
+			undifferentiated_core = (-2.19*log(pipeline_stage)+6.55)>0?(-2.19*log(pipeline_stage)+6.55):0;
+		}
+		else
+		{
+			cout<<"invalid core type"<<endl;
+			exit(0);
+		}
+		undifferentiated_core *= (1+ logtwo(num_hthreads)* 0.0716);
+	}
+	else
+	{
+		//Based on the results in paper "parametrized processor models" Sandia Labs
+		if (XML->sys.opt_clockrate)
+			undifferentiated_core_coe = 0.05;
+		else
+			undifferentiated_core_coe = 0;
+		undifferentiated_core = (0.4109* pipeline_stage - 0.776)*undifferentiated_core_coe;
+		undifferentiated_core *= (1+ logtwo(num_hthreads)* 0.0426);
+	}
 
-  undifferentiated_core *= g_tp.scaling_factor.logic_scaling_co_eff *
-                           1e6;  // change from mm^2 to um^2
-  core_tx_density = g_tp.scaling_factor.core_tx_density;
-  // undifferentiated_core 		    = 3*1e6;
-  // undifferentiated_core			*=
-  // g_tp.scaling_factor.logic_scaling_co_eff;//(g_ip->F_sz_um*g_ip->F_sz_um/0.09/0.09)*;
-  power.readOp.leakage =
-      undifferentiated_core *
-      (core_tx_density)*cmos_Isub_leakage(
-          5 * g_tp.min_w_nmos_, 5 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1,
-          inv) *
-      g_tp.peri_global.Vdd;  // unit W
-  power.readOp.gate_leakage =
-      undifferentiated_core *
-      (core_tx_density)*cmos_Ig_leakage(
-          5 * g_tp.min_w_nmos_, 5 * g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1,
-          inv) *
-      g_tp.peri_global.Vdd;
+	undifferentiated_core 		    *= g_tp.scaling_factor.logic_scaling_co_eff*1e6;//change from mm^2 to um^2
+	core_tx_density                 = g_tp.scaling_factor.core_tx_density;
+	//undifferentiated_core 		    = 3*1e6;
+	//undifferentiated_core			*= g_tp.scaling_factor.logic_scaling_co_eff;//(g_ip->F_sz_um*g_ip->F_sz_um/0.09/0.09)*;
+	power.readOp.leakage = undifferentiated_core*(core_tx_density)*cmos_Isub_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd;//unit W
+	power.readOp.gate_leakage = undifferentiated_core*(core_tx_density)*cmos_Ig_leakage(5*g_tp.min_w_nmos_, 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd;
 
-  double long_channel_device_reduction =
-      longer_channel_device_reduction(Core_device, coredynp.core_ty);
-  power.readOp.longer_channel_leakage =
-      power.readOp.leakage * long_channel_device_reduction;
-  area.set_area(undifferentiated_core);
+	double long_channel_device_reduction = longer_channel_device_reduction(Core_device, coredynp.core_ty);
+	power.readOp.longer_channel_leakage	= power.readOp.leakage*long_channel_device_reduction;
+	area.set_area(undifferentiated_core);
 
-  scktRatio = g_tp.sckt_co_eff;
-  power.readOp.dynamic *= scktRatio;
-  power.writeOp.dynamic *= scktRatio;
-  power.searchOp.dynamic *= scktRatio;
-  macro_PR_overhead = g_tp.macro_layout_overhead;
-  area.set_area(area.get_area() * macro_PR_overhead);
+	scktRatio = g_tp.sckt_co_eff;
+	power.readOp.dynamic *= scktRatio;
+	power.writeOp.dynamic *= scktRatio;
+	power.searchOp.dynamic *= scktRatio;
+	macro_PR_overhead = g_tp.macro_layout_overhead;
+	area.set_area(area.get_area()*macro_PR_overhead);
 
-  //		double vt=g_tp.peri_global.Vth;
-  //		double velocity_index=1.1;
-  //		double c_in=gate_C(g_tp.min_w_nmos_,
-  //g_tp.min_w_nmos_*pmos_to_nmos_sizing_r , 0.0, false);
-  //		double c_out= drain_C_(g_tp.min_w_nmos_, NCH, 2, 1, g_tp.cell_h_def,
-  //false) + drain_C_(g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, PCH, 1, 1,
-  //g_tp.cell_h_def, false) + c_in;
-  //		double w_nmos=g_tp.min_w_nmos_;
-  //		double w_pmos=g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
-  //		double i_on_n=1.0;
-  //		double i_on_p=1.0;
-  //		double i_on_n_in=1.0;
-  //		double i_on_p_in=1;
-  //		double vdd=g_tp.peri_global.Vdd;
 
-  //		power.readOp.sc=shortcircuit_simple(vt, velocity_index, c_in, c_out,
-  //w_nmos,w_pmos, i_on_n, i_on_p,i_on_n_in, i_on_p_in, vdd);
-  //		power.readOp.dynamic=c_out*vdd*vdd/2;
 
-  //		cout<<power.readOp.dynamic << "dynamic" <<endl;
-  //		cout<<power.readOp.sc << "sc" << endl;
+//		double vt=g_tp.peri_global.Vth;
+//		double velocity_index=1.1;
+//		double c_in=gate_C(g_tp.min_w_nmos_, g_tp.min_w_nmos_*pmos_to_nmos_sizing_r , 0.0, false);
+//		double c_out= drain_C_(g_tp.min_w_nmos_, NCH, 2, 1, g_tp.cell_h_def, false) + drain_C_(g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, PCH, 1, 1, g_tp.cell_h_def, false) + c_in;
+//		double w_nmos=g_tp.min_w_nmos_;
+//		double w_pmos=g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
+//		double i_on_n=1.0;
+//		double i_on_p=1.0;
+//		double i_on_n_in=1.0;
+//		double i_on_p_in=1;
+//		double vdd=g_tp.peri_global.Vdd;
 
-  //		power.readOp.sc=shortcircuit(vt, velocity_index, c_in, c_out,
-  //w_nmos,w_pmos, i_on_n, i_on_p,i_on_n_in, i_on_p_in, vdd);
-  //		power.readOp.dynamic=c_out*vdd*vdd/2;
-  //
-  //		cout<<power.readOp.dynamic << "dynamic" <<endl;
-  //		cout<<power.readOp.sc << "sc" << endl;
+//		power.readOp.sc=shortcircuit_simple(vt, velocity_index, c_in, c_out, w_nmos,w_pmos, i_on_n, i_on_p,i_on_n_in, i_on_p_in, vdd);
+//		power.readOp.dynamic=c_out*vdd*vdd/2;
+
+//		cout<<power.readOp.dynamic << "dynamic" <<endl;
+//		cout<<power.readOp.sc << "sc" << endl;
+
+//		power.readOp.sc=shortcircuit(vt, velocity_index, c_in, c_out, w_nmos,w_pmos, i_on_n, i_on_p,i_on_n_in, i_on_p_in, vdd);
+//		power.readOp.dynamic=c_out*vdd*vdd/2;
+//
+//		cout<<power.readOp.dynamic << "dynamic" <<endl;
+//		cout<<power.readOp.sc << "sc" << endl;
+
+
+
 }
 
-void UndiffCore::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
-  string indent_str(indent, ' ');
-  string indent_str_next(indent + 2, ' ');
-  bool long_channel = XML->sys.longer_channel_device;
 
-  if (is_tdp) {
-    cout << indent_str << "UndiffCore:" << endl;
-    cout << indent_str_next << "Area = " << area.get_area() * 1e-6 << " mm^2"
-         << endl;
-    cout << indent_str_next
-         << "Peak Dynamic = " << power.readOp.dynamic * clockRate << " W"
-         << endl;
-    // cout << indent_str_next << "Subthreshold Leakage = " <<
-    // power.readOp.leakage <<" W" << endl;
-    cout << indent_str_next << "Subthreshold Leakage = "
-         << (long_channel ? power.readOp.longer_channel_leakage
-                          : power.readOp.leakage)
-         << " W" << endl;
-    cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage
-         << " W" << endl;
-    // cout << indent_str_next << "Runtime Dynamic = " <<
-    // rt_power.readOp.dynamic/executionTime << " W" << endl;
-    cout << endl;
-  } else {
-    cout << indent_str << "UndiffCore:" << endl;
-    cout << indent_str_next << "Area = " << area.get_area() * 1e-6 << " mm^2"
-         << endl;
-    cout << indent_str_next
-         << "Peak Dynamic = " << power.readOp.dynamic * clockRate << " W"
-         << endl;
-    cout << indent_str_next << "Subthreshold Leakage = " << power.readOp.leakage
-         << " W" << endl;
-    cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage
-         << " W" << endl;
-    // cout << indent_str_next << "Runtime Dynamic = " <<
-    // rt_power.readOp.dynamic/executionTime << " W" << endl;
-    cout << endl;
-  }
+void UndiffCore::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
+{
+	string indent_str(indent, ' ');
+	string indent_str_next(indent+2, ' ');
+	bool long_channel = XML->sys.longer_channel_device;
+
+	if (is_tdp)
+	{
+		cout << indent_str << "UndiffCore:" << endl;
+		cout << indent_str_next << "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << power.readOp.dynamic*clockRate << " W" << endl;
+		//cout << indent_str_next << "Subthreshold Leakage = " << power.readOp.leakage <<" W" << endl;
+		cout << indent_str_next<< "Subthreshold Leakage = "
+					<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
+		//cout << indent_str_next << "Runtime Dynamic = " << rt_power.readOp.dynamic/executionTime << " W" << endl;
+		cout <<endl;
+	}
+	else
+	{
+		cout << indent_str << "UndiffCore:" << endl;
+		cout << indent_str_next << "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << power.readOp.dynamic*clockRate << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = " << power.readOp.leakage <<" W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
+		//cout << indent_str_next << "Runtime Dynamic = " << rt_power.readOp.dynamic/executionTime << " W" << endl;
+		cout <<endl;
+	}
+
 }
 
-inst_decoder::inst_decoder(bool _is_default,
-                           const InputParameter *configure_interface,
-                           int opcode_length_, int num_decoders_, bool x86_,
-                           enum Device_ty device_ty_, enum Core_type core_ty_)
-    : is_default(_is_default),
-      opcode_length(opcode_length_),
-      num_decoders(num_decoders_),
-      x86(x86_),
-      device_ty(device_ty_),
-      core_ty(core_ty_) {
-  /*
-   * Instruction decoder is different from n to 2^n decoders
-   * that are commonly used in row decoders in memory arrays.
-   * The RISC instruction decoder is typically a very simple device.
-   * We can decode an instruction by simply
-   * separating the machine word into small parts using wire slices
-   * The RISC instruction decoder can be approximate by the n to 2^n decoders,
-   * although this approximation usually underestimate power since each decoded
-   * instruction normally has more than 1 active signal.
-   *
-   * However, decoding a CISC instruction word is much more difficult
-   * than the RISC case. A CISC decoder is typically set up as a state machine.
-   * The machine reads the opcode field to determine
-   * what type of instruction it is,
-   * and where the other data values are.
-   * The instruction word is read in piece by piece,
-   * and decisions are made at each stage as to
-   * how the remainder of the instruction word will be read.
-   * (sequencer and ROM are usually needed)
-   * An x86 decoder can be even more complex since
-   * it involve  both decoding instructions into u-ops and
-   * merge u-ops when doing micro-ops fusion.
-   */
-  bool is_dram = false;
-  double pmos_to_nmos_sizing_r;
-  double load_nmos_width, load_pmos_width;
-  double C_driver_load, R_wire_load;
-  Area cell;
+inst_decoder::inst_decoder(
+		bool   _is_default,
+		const InputParameter *configure_interface,
+		int opcode_length_,
+		int num_decoders_,
+		bool x86_,
+	    enum Device_ty device_ty_,
+	    enum Core_type core_ty_)
+:is_default(_is_default),
+ opcode_length(opcode_length_),
+ num_decoders(num_decoders_),
+ x86(x86_),
+ device_ty(device_ty_),
+ core_ty(core_ty_)
+ {
+			/*
+			 * Instruction decoder is different from n to 2^n decoders
+			 * that are commonly used in row decoders in memory arrays.
+			 * The RISC instruction decoder is typically a very simple device.
+			 * We can decode an instruction by simply
+			 * separating the machine word into small parts using wire slices
+			 * The RISC instruction decoder can be approximate by the n to 2^n decoders,
+			 * although this approximation usually underestimate power since each decoded
+			 * instruction normally has more than 1 active signal.
+			 *
+			 * However, decoding a CISC instruction word is much more difficult
+			 * than the RISC case. A CISC decoder is typically set up as a state machine.
+			 * The machine reads the opcode field to determine
+			 * what type of instruction it is,
+			 * and where the other data values are.
+			 * The instruction word is read in piece by piece,
+			 * and decisions are made at each stage as to
+			 * how the remainder of the instruction word will be read.
+			 * (sequencer and ROM are usually needed)
+			 * An x86 decoder can be even more complex since
+			 * it involve  both decoding instructions into u-ops and
+			 * merge u-ops when doing micro-ops fusion.
+			 */
+			bool is_dram=false;
+			double pmos_to_nmos_sizing_r;
+			double load_nmos_width, load_pmos_width;
+			double C_driver_load, R_wire_load;
+			Area cell;
 
-  l_ip = *configure_interface;
-  local_result = init_interface(&l_ip);
-  cell.h = g_tp.cell_h_def;
-  cell.w = g_tp.cell_h_def;
+			l_ip=*configure_interface;
+			local_result = init_interface(&l_ip);
+			cell.h =g_tp.cell_h_def;
+			cell.w =g_tp.cell_h_def;
 
-  num_decoder_segments = (int)ceil(opcode_length / 18.0);
-  if (opcode_length > 18) opcode_length = 18;
-  num_decoded_signals = (int)pow(2.0, opcode_length);
-  pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
-  load_nmos_width = g_tp.max_w_nmos_ / 2;
-  load_pmos_width = g_tp.max_w_nmos_ * pmos_to_nmos_sizing_r;
-  C_driver_load =
-      1024 * gate_C(load_nmos_width + load_pmos_width, 0,
-                    is_dram);  // TODO: this number 1024 needs to be revisited
-  R_wire_load = 3000 * l_ip.F_sz_um * g_tp.wire_outside_mat.R_per_um;
+			num_decoder_segments = (int)ceil(opcode_length/18.0);
+			if (opcode_length > 18)	opcode_length = 18;
+			num_decoded_signals= (int)pow(2.0,opcode_length);
+			pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
+			load_nmos_width=g_tp.max_w_nmos_ /2;
+			load_pmos_width= g_tp.max_w_nmos_ * pmos_to_nmos_sizing_r;
+			C_driver_load = 1024*gate_C(load_nmos_width + load_pmos_width, 0, is_dram); //TODO: this number 1024 needs to be revisited
+			R_wire_load   = 3000*l_ip.F_sz_um * g_tp.wire_outside_mat.R_per_um;
 
-  final_dec = new Decoder(num_decoded_signals, false, C_driver_load,
-                          R_wire_load, false /*is_fa*/, false /*is_dram*/,
-                          false /*wl_tr*/,  // to use peri device
-                          cell);
+			final_dec = new Decoder(
+					num_decoded_signals,
+					false,
+					C_driver_load,
+					R_wire_load,
+					false/*is_fa*/,
+					false/*is_dram*/,
+					false/*wl_tr*/, //to use peri device
+					cell);
 
-  PredecBlk *predec_blk1 =
-      new PredecBlk(num_decoded_signals, final_dec,
-                    0,  // Assuming predec and dec are back to back
-                    0,
-                    1,  // Each Predec only drives one final dec
-                    false /*is_dram*/, true);
-  PredecBlk *predec_blk2 =
-      new PredecBlk(num_decoded_signals, final_dec,
-                    0,  // Assuming predec and dec are back to back
-                    0,
-                    1,  // Each Predec only drives one final dec
-                    false /*is_dram*/, false);
+			PredecBlk * predec_blk1 = new PredecBlk(
+					num_decoded_signals,
+					final_dec,
+					0,//Assuming predec and dec are back to back
+					0,
+					1,//Each Predec only drives one final dec
+					false/*is_dram*/,
+					true);
+			PredecBlk * predec_blk2 = new PredecBlk(
+					num_decoded_signals,
+					final_dec,
+					0,//Assuming predec and dec are back to back
+					0,
+					1,//Each Predec only drives one final dec
+					false/*is_dram*/,
+					false);
 
-  PredecBlkDrv *predec_blk_drv1 = new PredecBlkDrv(0, predec_blk1, false);
-  PredecBlkDrv *predec_blk_drv2 = new PredecBlkDrv(0, predec_blk2, false);
+			PredecBlkDrv * predec_blk_drv1 = new PredecBlkDrv(0, predec_blk1, false);
+			PredecBlkDrv * predec_blk_drv2 = new PredecBlkDrv(0, predec_blk2, false);
 
-  pre_dec = new Predec(predec_blk_drv1, predec_blk_drv2);
+			pre_dec            = new Predec(predec_blk_drv1, predec_blk_drv2);
 
-  double area_decoder = final_dec->area.get_area() * num_decoded_signals *
-                        num_decoder_segments * num_decoders;
-  // double w_decoder    = area_decoder / area.get_h();
-  double area_pre_dec =
-      (predec_blk_drv1->area.get_area() + predec_blk_drv2->area.get_area() +
-       predec_blk1->area.get_area() + predec_blk2->area.get_area()) *
-      num_decoder_segments * num_decoders;
-  area.set_area(area.get_area() + area_decoder + area_pre_dec);
-  double macro_layout_overhead = g_tp.macro_layout_overhead;
-  double chip_PR_overhead = g_tp.chip_layout_overhead;
-  area.set_area(area.get_area() * macro_layout_overhead * chip_PR_overhead);
+			double area_decoder = final_dec->area.get_area() * num_decoded_signals * num_decoder_segments*num_decoders;
+			//double w_decoder    = area_decoder / area.get_h();
+			double area_pre_dec = (predec_blk_drv1->area.get_area() +
+					predec_blk_drv2->area.get_area() +
+					predec_blk1->area.get_area() +
+					predec_blk2->area.get_area())*
+					num_decoder_segments*num_decoders;
+			area.set_area(area.get_area()+ area_decoder + area_pre_dec);
+			double macro_layout_overhead   = g_tp.macro_layout_overhead;
+			double chip_PR_overhead        = g_tp.chip_layout_overhead;
+			area.set_area(area.get_area()*macro_layout_overhead*chip_PR_overhead);
 
-  inst_decoder_delay_power();
+			inst_decoder_delay_power();
 
-  double sckRation = g_tp.sckt_co_eff;
-  power.readOp.dynamic *= sckRation;
-  power.writeOp.dynamic *= sckRation;
-  power.searchOp.dynamic *= sckRation;
+			double sckRation = g_tp.sckt_co_eff;
+			power.readOp.dynamic *= sckRation;
+			power.writeOp.dynamic *= sckRation;
+			power.searchOp.dynamic *= sckRation;
 
-  double long_channel_device_reduction =
-      longer_channel_device_reduction(device_ty, core_ty);
-  power.readOp.longer_channel_leakage =
-      power.readOp.leakage * long_channel_device_reduction;
+			double long_channel_device_reduction = longer_channel_device_reduction(device_ty,core_ty);
+			power.readOp.longer_channel_leakage	= power.readOp.leakage*long_channel_device_reduction;
+
 }
 
-void inst_decoder::inst_decoder_delay_power() {
-  double pppm_t[4] = {1, 1, 1, 1};
-  double squencer_passes = x86 ? 2 : 1;
+void inst_decoder::inst_decoder_delay_power()
+{
 
-  set_pppm(pppm_t, squencer_passes * num_decoder_segments, num_decoder_segments,
-           squencer_passes * num_decoder_segments, num_decoder_segments);
-  power = power + pre_dec->power * pppm_t;
-  set_pppm(pppm_t, squencer_passes * num_decoder_segments,
-           num_decoder_segments * num_decoded_signals,
-           num_decoder_segments * num_decoded_signals,
-           squencer_passes * num_decoder_segments);
-  power = power + final_dec->power * pppm_t;
+	double pppm_t[4]    = {1,1,1,1};
+	double squencer_passes = x86?2:1;
+
+	set_pppm(pppm_t, squencer_passes*num_decoder_segments, num_decoder_segments, squencer_passes*num_decoder_segments, num_decoder_segments);
+    power = power + pre_dec->power*pppm_t;
+    set_pppm(pppm_t, squencer_passes*num_decoder_segments, num_decoder_segments*num_decoded_signals,
+    		num_decoder_segments*num_decoded_signals, squencer_passes*num_decoder_segments);
+    power = power + final_dec->power*pppm_t;
 }
-void inst_decoder::leakage_feedback(double temperature) {
-  l_ip.temp = (unsigned int)round(temperature / 10.0) * 10;
-  uca_org_t init_result = init_interface(&l_ip);  // init_result is dummy
+void inst_decoder::leakage_feedback(double temperature)
+{
+  l_ip.temp = (unsigned int)round(temperature/10.0)*10;
+  uca_org_t init_result = init_interface(&l_ip); // init_result is dummy
 
   final_dec->leakage_feedback(temperature);
   pre_dec->leakage_feedback(temperature);
 
-  double pppm_t[4] = {1, 1, 1, 1};
-  double squencer_passes = x86 ? 2 : 1;
+  double pppm_t[4]    = {1,1,1,1};
+  double squencer_passes = x86?2:1;
 
-  set_pppm(pppm_t, squencer_passes * num_decoder_segments, num_decoder_segments,
-           squencer_passes * num_decoder_segments, num_decoder_segments);
-  power = pre_dec->power * pppm_t;
+  set_pppm(pppm_t, squencer_passes*num_decoder_segments, num_decoder_segments, squencer_passes*num_decoder_segments, num_decoder_segments);
+  power = pre_dec->power*pppm_t;
 
-  set_pppm(pppm_t, squencer_passes * num_decoder_segments,
-           num_decoder_segments * num_decoded_signals,
-           num_decoder_segments * num_decoded_signals,
-           squencer_passes * num_decoder_segments);
-  power = power + final_dec->power * pppm_t;
+  set_pppm(pppm_t, squencer_passes*num_decoder_segments, num_decoder_segments*num_decoded_signals,num_decoder_segments*num_decoded_signals, squencer_passes*num_decoder_segments);
+  power = power + final_dec->power*pppm_t;
 
   double sckRation = g_tp.sckt_co_eff;
 
@@ -1378,20 +1086,19 @@ void inst_decoder::leakage_feedback(double temperature) {
   power.writeOp.dynamic *= sckRation;
   power.searchOp.dynamic *= sckRation;
 
-  double long_channel_device_reduction =
-      longer_channel_device_reduction(device_ty, core_ty);
-  power.readOp.longer_channel_leakage =
-      power.readOp.leakage * long_channel_device_reduction;
+  double long_channel_device_reduction = longer_channel_device_reduction(device_ty,core_ty);
+  power.readOp.longer_channel_leakage = power.readOp.leakage*long_channel_device_reduction;
 }
 
-inst_decoder::~inst_decoder() {
-  local_result.cleanup();
+inst_decoder::~inst_decoder()
+{
+	  local_result.cleanup();
 
-  delete final_dec;
+	  delete final_dec;
 
-  delete pre_dec->blk1;
-  delete pre_dec->blk2;
-  delete pre_dec->drv1;
-  delete pre_dec->drv2;
-  delete pre_dec;
+	  delete pre_dec->blk1;
+	  delete pre_dec->blk2;
+	  delete pre_dec->drv1;
+	  delete pre_dec->drv2;
+	  delete pre_dec;
 }

--- a/src/gpuwattch/logic.cc
+++ b/src/gpuwattch/logic.cc
@@ -362,8 +362,8 @@ void Pipeline::compute() {
 
   double clock_power_pipereg = num_piperegs * pipe_reg.e_clock.readOp.dynamic;
   //******************pipeline power: currently, we average all the
-  //possibilities of the states of DFFs in the pipeline. A better way to do it
-  //is to consider
+  // possibilities of the states of DFFs in the pipeline. A better way to do it
+  // is to consider
   // the harming distance of two consecutive signals, However McPAT does not
   // have plan to do this in near future as it focuses on worst case power.
   double pipe_reg_power = num_piperegs * (pipe_reg.e_switch.readOp.dynamic +
@@ -578,8 +578,8 @@ FunctionalUnit::FunctionalUnit(ParseXML *XML_interface, int ithCore_,
       // energy = 0.3529/10*1e-9;//this is the energy(nJ) for a FP instruction
       // in FPU usually it can have up to 20 cycles.
       //			base_energy = coredynp.core_ty==Inorder? 0:
-      //89e-3*3; //W The base energy of ALU average numbers from Intel 4G and
-      //773Mhz (Wattch)
+      // 89e-3*3; //W The base energy of ALU average numbers from Intel 4G and
+      // 773Mhz (Wattch)
       //			base_energy
       //*=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
       base_energy = 0;
@@ -615,8 +615,8 @@ FunctionalUnit::FunctionalUnit(ParseXML *XML_interface, int ithCore_,
           g_tp.peri_global.Vdd / 2;
       leakage = 0;
       //			base_energy = coredynp.core_ty==Inorder?
-      //0:89e-3; //W The base energy of ALU average numbers from Intel 4G and
-      //773Mhz (Wattch)
+      // 0:89e-3; //W The base energy of ALU average numbers from Intel 4G and
+      // 773Mhz (Wattch)
       //			base_energy
       //*=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
       base_energy = 0;
@@ -645,8 +645,8 @@ FunctionalUnit::FunctionalUnit(ParseXML *XML_interface, int ithCore_,
                           inv) *
           g_tp.peri_global.Vdd / 2;
       //			base_energy = coredynp.core_ty==Inorder?
-      //0:89e-3*2; //W The base energy of ALU average numbers from Intel 4G and
-      //773Mhz (Wattch)
+      // 0:89e-3*2; //W The base energy of ALU average numbers from Intel 4G and
+      // 773Mhz (Wattch)
       //			base_energy
       //*=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
       base_energy = 0;
@@ -666,7 +666,7 @@ FunctionalUnit::FunctionalUnit(ParseXML *XML_interface, int ithCore_,
     }
     per_access_energy *= 0.5;  // According to ARM data embedded processor has
                                // much lower per acc energy
-  } /* if (XML->sys.Embedded) */
+  }                            /* if (XML->sys.Embedded) */
   else {
     if (fu_type == FPU) {
       num_fu = coredynp.num_fpus;
@@ -705,16 +705,14 @@ FunctionalUnit::FunctionalUnit(ParseXML *XML_interface, int ithCore_,
       if (g_ip->F_sz_nm > 90)
         area_t = 8.47 * 1e6 *
                  g_tp.scaling_factor.logic_scaling_co_eff;  // this is um^2
-      leakage =
-          37e-3;  // area_t
-                  // *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(5*g_tp.min_w_nmos_,
-                  // 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
-                  // inv)*g_tp.peri_global.Vdd/2;//unit W
-      gate_leakage =
-          0;  // area_t
-              // *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(5*g_tp.min_w_nmos_,
-              // 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
-              // inv)*g_tp.peri_global.Vdd/2;//unit W
+      leakage = 37e-3;                                      // area_t
+      // *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(5*g_tp.min_w_nmos_,
+      // 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
+      // inv)*g_tp.peri_global.Vdd/2;//unit W
+      gate_leakage = 0;  // area_t
+      // *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(5*g_tp.min_w_nmos_,
+      // 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
+      // inv)*g_tp.peri_global.Vdd/2;//unit W
       // energy = 0.3529/10*1e-9;//this is the energy(nJ) for a FP instruction
       // in FPU usually it can have up to 20 cycles.
       base_energy =
@@ -938,7 +936,7 @@ void FunctionalUnit::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
   bool long_channel = XML->sys.longer_channel_device;
 
   //	cout << indent_str_next << "Results Broadcast Bus Area = " <<
-  //bypass->area.get_area() *1e-6 << " mm^2" << endl;
+  // bypass->area.get_area() *1e-6 << " mm^2" << endl;
   if (is_tdp) {
     if (fu_type == FPU) {
       cout << indent_str
@@ -1169,10 +1167,11 @@ UndiffCore::UndiffCore(ParseXML *XML_interface, int ithCore_,
   //		double vt=g_tp.peri_global.Vth;
   //		double velocity_index=1.1;
   //		double c_in=gate_C(g_tp.min_w_nmos_,
-  //g_tp.min_w_nmos_*pmos_to_nmos_sizing_r , 0.0, false);
-  //		double c_out= drain_C_(g_tp.min_w_nmos_, NCH, 2, 1, g_tp.cell_h_def,
-  //false) + drain_C_(g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, PCH, 1, 1,
-  //g_tp.cell_h_def, false) + c_in;
+  // g_tp.min_w_nmos_*pmos_to_nmos_sizing_r , 0.0, false);
+  //		double c_out= drain_C_(g_tp.min_w_nmos_, NCH, 2, 1,
+  // g_tp.cell_h_def,
+  // false) + drain_C_(g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, PCH, 1, 1,
+  // g_tp.cell_h_def, false) + c_in;
   //		double w_nmos=g_tp.min_w_nmos_;
   //		double w_pmos=g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
   //		double i_on_n=1.0;
@@ -1181,15 +1180,16 @@ UndiffCore::UndiffCore(ParseXML *XML_interface, int ithCore_,
   //		double i_on_p_in=1;
   //		double vdd=g_tp.peri_global.Vdd;
 
-  //		power.readOp.sc=shortcircuit_simple(vt, velocity_index, c_in, c_out,
-  //w_nmos,w_pmos, i_on_n, i_on_p,i_on_n_in, i_on_p_in, vdd);
+  //		power.readOp.sc=shortcircuit_simple(vt, velocity_index, c_in,
+  // c_out,
+  // w_nmos,w_pmos, i_on_n, i_on_p,i_on_n_in, i_on_p_in, vdd);
   //		power.readOp.dynamic=c_out*vdd*vdd/2;
 
   //		cout<<power.readOp.dynamic << "dynamic" <<endl;
   //		cout<<power.readOp.sc << "sc" << endl;
 
   //		power.readOp.sc=shortcircuit(vt, velocity_index, c_in, c_out,
-  //w_nmos,w_pmos, i_on_n, i_on_p,i_on_n_in, i_on_p_in, vdd);
+  // w_nmos,w_pmos, i_on_n, i_on_p,i_on_n_in, i_on_p_in, vdd);
   //		power.readOp.dynamic=c_out*vdd*vdd/2;
   //
   //		cout<<power.readOp.dynamic << "dynamic" <<endl;

--- a/src/gpuwattch/logic.cc
+++ b/src/gpuwattch/logic.cc
@@ -362,8 +362,8 @@ void Pipeline::compute() {
 
   double clock_power_pipereg = num_piperegs * pipe_reg.e_clock.readOp.dynamic;
   //******************pipeline power: currently, we average all the
-  // possibilities of the states of DFFs in the pipeline. A better way to do it
-  // is to consider
+  //possibilities of the states of DFFs in the pipeline. A better way to do it
+  //is to consider
   // the harming distance of two consecutive signals, However McPAT does not
   // have plan to do this in near future as it focuses on worst case power.
   double pipe_reg_power = num_piperegs * (pipe_reg.e_switch.readOp.dynamic +
@@ -578,8 +578,8 @@ FunctionalUnit::FunctionalUnit(ParseXML *XML_interface, int ithCore_,
       // energy = 0.3529/10*1e-9;//this is the energy(nJ) for a FP instruction
       // in FPU usually it can have up to 20 cycles.
       //			base_energy = coredynp.core_ty==Inorder? 0:
-      // 89e-3*3; //W The base energy of ALU average numbers from Intel 4G and
-      // 773Mhz (Wattch)
+      //89e-3*3; //W The base energy of ALU average numbers from Intel 4G and
+      //773Mhz (Wattch)
       //			base_energy
       //*=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
       base_energy = 0;
@@ -615,8 +615,8 @@ FunctionalUnit::FunctionalUnit(ParseXML *XML_interface, int ithCore_,
           g_tp.peri_global.Vdd / 2;
       leakage = 0;
       //			base_energy = coredynp.core_ty==Inorder?
-      // 0:89e-3; //W The base energy of ALU average numbers from Intel 4G and
-      // 773Mhz (Wattch)
+      //0:89e-3; //W The base energy of ALU average numbers from Intel 4G and
+      //773Mhz (Wattch)
       //			base_energy
       //*=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
       base_energy = 0;
@@ -645,8 +645,8 @@ FunctionalUnit::FunctionalUnit(ParseXML *XML_interface, int ithCore_,
                           inv) *
           g_tp.peri_global.Vdd / 2;
       //			base_energy = coredynp.core_ty==Inorder?
-      // 0:89e-3*2; //W The base energy of ALU average numbers from Intel 4G and
-      // 773Mhz (Wattch)
+      //0:89e-3*2; //W The base energy of ALU average numbers from Intel 4G and
+      //773Mhz (Wattch)
       //			base_energy
       //*=(g_tp.peri_global.Vdd*g_tp.peri_global.Vdd/1.2/1.2);
       base_energy = 0;
@@ -666,7 +666,7 @@ FunctionalUnit::FunctionalUnit(ParseXML *XML_interface, int ithCore_,
     }
     per_access_energy *= 0.5;  // According to ARM data embedded processor has
                                // much lower per acc energy
-  }                            /* if (XML->sys.Embedded) */
+  } /* if (XML->sys.Embedded) */
   else {
     if (fu_type == FPU) {
       num_fu = coredynp.num_fpus;
@@ -705,14 +705,16 @@ FunctionalUnit::FunctionalUnit(ParseXML *XML_interface, int ithCore_,
       if (g_ip->F_sz_nm > 90)
         area_t = 8.47 * 1e6 *
                  g_tp.scaling_factor.logic_scaling_co_eff;  // this is um^2
-      leakage = 37e-3;                                      // area_t
-      // *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(5*g_tp.min_w_nmos_,
-      // 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
-      // inv)*g_tp.peri_global.Vdd/2;//unit W
-      gate_leakage = 0;  // area_t
-      // *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(5*g_tp.min_w_nmos_,
-      // 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
-      // inv)*g_tp.peri_global.Vdd/2;//unit W
+      leakage =
+          37e-3;  // area_t
+                  // *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(5*g_tp.min_w_nmos_,
+                  // 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
+                  // inv)*g_tp.peri_global.Vdd/2;//unit W
+      gate_leakage =
+          0;  // area_t
+              // *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(5*g_tp.min_w_nmos_,
+              // 5*g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1,
+              // inv)*g_tp.peri_global.Vdd/2;//unit W
       // energy = 0.3529/10*1e-9;//this is the energy(nJ) for a FP instruction
       // in FPU usually it can have up to 20 cycles.
       base_energy =
@@ -936,7 +938,7 @@ void FunctionalUnit::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
   bool long_channel = XML->sys.longer_channel_device;
 
   //	cout << indent_str_next << "Results Broadcast Bus Area = " <<
-  // bypass->area.get_area() *1e-6 << " mm^2" << endl;
+  //bypass->area.get_area() *1e-6 << " mm^2" << endl;
   if (is_tdp) {
     if (fu_type == FPU) {
       cout << indent_str
@@ -1167,11 +1169,10 @@ UndiffCore::UndiffCore(ParseXML *XML_interface, int ithCore_,
   //		double vt=g_tp.peri_global.Vth;
   //		double velocity_index=1.1;
   //		double c_in=gate_C(g_tp.min_w_nmos_,
-  // g_tp.min_w_nmos_*pmos_to_nmos_sizing_r , 0.0, false);
-  //		double c_out= drain_C_(g_tp.min_w_nmos_, NCH, 2, 1,
-  // g_tp.cell_h_def,
-  // false) + drain_C_(g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, PCH, 1, 1,
-  // g_tp.cell_h_def, false) + c_in;
+  //g_tp.min_w_nmos_*pmos_to_nmos_sizing_r , 0.0, false);
+  //		double c_out= drain_C_(g_tp.min_w_nmos_, NCH, 2, 1, g_tp.cell_h_def,
+  //false) + drain_C_(g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, PCH, 1, 1,
+  //g_tp.cell_h_def, false) + c_in;
   //		double w_nmos=g_tp.min_w_nmos_;
   //		double w_pmos=g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
   //		double i_on_n=1.0;
@@ -1180,16 +1181,15 @@ UndiffCore::UndiffCore(ParseXML *XML_interface, int ithCore_,
   //		double i_on_p_in=1;
   //		double vdd=g_tp.peri_global.Vdd;
 
-  //		power.readOp.sc=shortcircuit_simple(vt, velocity_index, c_in,
-  // c_out,
-  // w_nmos,w_pmos, i_on_n, i_on_p,i_on_n_in, i_on_p_in, vdd);
+  //		power.readOp.sc=shortcircuit_simple(vt, velocity_index, c_in, c_out,
+  //w_nmos,w_pmos, i_on_n, i_on_p,i_on_n_in, i_on_p_in, vdd);
   //		power.readOp.dynamic=c_out*vdd*vdd/2;
 
   //		cout<<power.readOp.dynamic << "dynamic" <<endl;
   //		cout<<power.readOp.sc << "sc" << endl;
 
   //		power.readOp.sc=shortcircuit(vt, velocity_index, c_in, c_out,
-  // w_nmos,w_pmos, i_on_n, i_on_p,i_on_n_in, i_on_p_in, vdd);
+  //w_nmos,w_pmos, i_on_n, i_on_p,i_on_n_in, i_on_p_in, vdd);
   //		power.readOp.dynamic=c_out*vdd*vdd/2;
   //
   //		cout<<power.readOp.dynamic << "dynamic" <<endl;

--- a/src/gpuwattch/logic.h
+++ b/src/gpuwattch/logic.h
@@ -29,212 +29,210 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:												   *
-*      Jingwen Leng, Univeristy of Texas, Austin                   *
-*      Syed Gilani, University of Wisconsin–Madison                *
-*      Tayler Hetherington, University of British Columbia         *
-*      Ahmed ElTantawy, University of British Columbia             *
-********************************************************************/
+ *      Modified by:
+ ** Jingwen Leng, Univeristy of Texas, Austin                   * Syed Gilani,
+ *University of Wisconsin–Madison                * Tayler Hetherington,
+ *University of British Columbia         * Ahmed ElTantawy, University of
+ *British Columbia             *
+ ********************************************************************/
 #ifndef LOGIC_H_
 #define LOGIC_H_
 
-#include "cacti/const.h"
-#include "cacti/component.h"
+#include <cassert>
+#include <cmath>
+#include <cstring>
+#include <iostream>
+#include "XML_Parse.h"
+#include "arch_const.h"
 #include "basic_components.h"
 #include "cacti/basic_circuit.h"
 #include "cacti/cacti_interface.h"
+#include "cacti/component.h"
+#include "cacti/const.h"
 #include "cacti/decoder.h"
 #include "cacti/parameter.h"
 #include "xmlParser.h"
-#include "XML_Parse.h"
-#include "arch_const.h"
-#include <cstring>
-#include <iostream>
-#include <cmath>
-#include <cassert>
-
 
 using namespace std;
 
-class selection_logic : public Component{
-public:
-	selection_logic(bool _is_default, int    win_entries_,
-		            int  issue_width_, const InputParameter *configure_interface,
-		            enum Device_ty device_ty_=Core_device,
-		            enum Core_type core_ty_=Inorder);//, const ParseXML *_XML_interface);
-	bool is_default;
-	InputParameter l_ip;
-	uca_org_t local_result;
-	const ParseXML *XML_interface;
-	int win_entries;
-	int issue_width;
-	int num_threads;
-	enum Device_ty device_ty;
-	enum Core_type core_ty;
+class selection_logic : public Component {
+ public:
+  selection_logic(
+      bool _is_default, int win_entries_, int issue_width_,
+      const InputParameter *configure_interface,
+      enum Device_ty device_ty_ = Core_device,
+      enum Core_type core_ty_ = Inorder);  //, const ParseXML *_XML_interface);
+  bool is_default;
+  InputParameter l_ip;
+  uca_org_t local_result;
+  const ParseXML *XML_interface;
+  int win_entries;
+  int issue_width;
+  int num_threads;
+  enum Device_ty device_ty;
+  enum Core_type core_ty;
 
-	void selection_power();
-	void leakage_feedback(double temperature); // TODO	
+  void selection_power();
+  void leakage_feedback(double temperature);  // TODO
 };
 
-class dep_resource_conflict_check : public Component{
-public:
-	dep_resource_conflict_check(const InputParameter *configure_interface, const CoreDynParam & dyn_p_, int compare_bits_, bool _is_default=true);
-	InputParameter l_ip;
-	uca_org_t local_result;
-	double WNORn, WNORp, Wevalinvp, Wevalinvn, Wcompn, Wcompp, Wcomppreequ;
-	CoreDynParam  coredynp;
-	int compare_bits;
-	bool is_default;
-	statsDef       tdp_stats;
-	statsDef       rtp_stats;
-	statsDef       stats_t;
-	powerDef       power_t;
+class dep_resource_conflict_check : public Component {
+ public:
+  dep_resource_conflict_check(const InputParameter *configure_interface,
+                              const CoreDynParam &dyn_p_, int compare_bits_,
+                              bool _is_default = true);
+  InputParameter l_ip;
+  uca_org_t local_result;
+  double WNORn, WNORp, Wevalinvp, Wevalinvn, Wcompn, Wcompp, Wcomppreequ;
+  CoreDynParam coredynp;
+  int compare_bits;
+  bool is_default;
+  statsDef tdp_stats;
+  statsDef rtp_stats;
+  statsDef stats_t;
+  powerDef power_t;
 
-	void conflict_check_power();
-	double compare_cap();
-	~dep_resource_conflict_check(){
-		local_result.cleanup();
-	}
+  void conflict_check_power();
+  double compare_cap();
+  ~dep_resource_conflict_check() { local_result.cleanup(); }
 
-	void leakage_feedback(double temperature);
+  void leakage_feedback(double temperature);
 };
 
-class inst_decoder: public Component{
-public:
-	inst_decoder(bool _is_default, const InputParameter *configure_interface,
-			int opcode_length_,
-			int num_decoders_,
-			bool x86_,
-			enum Device_ty device_ty_=Core_device,
-			enum Core_type core_ty_=Inorder);
-	inst_decoder();
-	bool is_default;
-	int  opcode_length;
-	int  num_decoders;
-	bool x86;
-	int  num_decoder_segments;
-	int  num_decoded_signals;
-	InputParameter l_ip;
-	uca_org_t local_result;
-	enum Device_ty device_ty;
-	enum Core_type core_ty;
+class inst_decoder : public Component {
+ public:
+  inst_decoder(bool _is_default, const InputParameter *configure_interface,
+               int opcode_length_, int num_decoders_, bool x86_,
+               enum Device_ty device_ty_ = Core_device,
+               enum Core_type core_ty_ = Inorder);
+  inst_decoder();
+  bool is_default;
+  int opcode_length;
+  int num_decoders;
+  bool x86;
+  int num_decoder_segments;
+  int num_decoded_signals;
+  InputParameter l_ip;
+  uca_org_t local_result;
+  enum Device_ty device_ty;
+  enum Core_type core_ty;
 
-	Decoder * final_dec;
-	Predec *  pre_dec;
+  Decoder *final_dec;
+  Predec *pre_dec;
 
-	statsDef       tdp_stats;
-	statsDef       rtp_stats;
-	statsDef       stats_t;
-	powerDef       power_t;
-	void inst_decoder_delay_power();
-	~inst_decoder();
-	void leakage_feedback(double temperature);
+  statsDef tdp_stats;
+  statsDef rtp_stats;
+  statsDef stats_t;
+  powerDef power_t;
+  void inst_decoder_delay_power();
+  ~inst_decoder();
+  void leakage_feedback(double temperature);
 };
 
 class DFFCell : public Component {
-public:
-	DFFCell(bool _is_dram, double _WdecNANDn, double _WdecNANDp,double _cell_load,
-			  const InputParameter *configure_interface);
-	InputParameter l_ip;
-	bool is_dram;
-	double cell_load;
-	double WdecNANDn;
-	double WdecNANDp;
-	double clock_cap;
-	int    model;
-	int    n_switch;
-	int    n_keep_1;
-	int    n_keep_0;
-	int    n_clock;
-	powerDef e_switch;
-	powerDef e_keep_1;
-	powerDef e_keep_0;
-	powerDef e_clock;
+ public:
+  DFFCell(bool _is_dram, double _WdecNANDn, double _WdecNANDp,
+          double _cell_load, const InputParameter *configure_interface);
+  InputParameter l_ip;
+  bool is_dram;
+  double cell_load;
+  double WdecNANDn;
+  double WdecNANDp;
+  double clock_cap;
+  int model;
+  int n_switch;
+  int n_keep_1;
+  int n_keep_0;
+  int n_clock;
+  powerDef e_switch;
+  powerDef e_keep_1;
+  powerDef e_keep_0;
+  powerDef e_clock;
 
-	double fpfp_node_cap(unsigned int fan_in, unsigned int fan_out);
-	void compute_DFF_cell(void);
-	};
-
-class Pipeline : public Component{
-public:
-	Pipeline(const InputParameter *configure_interface, const CoreDynParam & dyn_p_, enum Device_ty device_ty_=Core_device, bool _is_core_pipeline=true, bool _is_default=true);
-	InputParameter l_ip;
-	uca_org_t local_result;
-	CoreDynParam  coredynp;
-	enum Device_ty device_ty;
-	bool is_core_pipeline, is_default;
-	double num_piperegs;
-//	int pipeline_stages;
-//	int tot_stage_vector, per_stage_vector;
-	bool process_ind;
-	double WNANDn ;
-	double WNANDp;
-	double load_per_pipeline_stage;
-//	int  Hthread,  num_thread, fetchWidth, decodeWidth, issueWidth, commitWidth, instruction_length;
-//	int  PC_width, opcode_length, num_arch_reg_tag, data_width,num_phsical_reg_tag, address_width;
-//	bool thread_clock_gated;
-//	bool in_order, multithreaded;
-	void compute_stage_vector();
-	void compute();
-	~Pipeline(){
-		local_result.cleanup();
-	};
-
+  double fpfp_node_cap(unsigned int fan_in, unsigned int fan_out);
+  void compute_DFF_cell(void);
 };
 
-//class core_pipeline :public pipeline{
-//public:
-//	int  Hthread,  num_thread, fetchWidth, decodeWidth, issueWidth, commitWidth, instruction_length;
-//	int  PC_width, opcode_length, num_arch_reg_tag, data_width,num_phsical_reg_tag, address_width;
-//	bool thread_clock_gated;
-//	bool in_order, multithreaded;
-//	core_pipeline(bool _is_default, const InputParameter *configure_interface);
-//	virtual void compute_stage_vector();
+class Pipeline : public Component {
+ public:
+  Pipeline(const InputParameter *configure_interface,
+           const CoreDynParam &dyn_p_, enum Device_ty device_ty_ = Core_device,
+           bool _is_core_pipeline = true, bool _is_default = true);
+  InputParameter l_ip;
+  uca_org_t local_result;
+  CoreDynParam coredynp;
+  enum Device_ty device_ty;
+  bool is_core_pipeline, is_default;
+  double num_piperegs;
+  //	int pipeline_stages;
+  //	int tot_stage_vector, per_stage_vector;
+  bool process_ind;
+  double WNANDn;
+  double WNANDp;
+  double load_per_pipeline_stage;
+  //	int  Hthread,  num_thread, fetchWidth, decodeWidth, issueWidth,
+  // commitWidth, instruction_length; 	int  PC_width, opcode_length,
+  // num_arch_reg_tag, data_width,num_phsical_reg_tag, address_width; 	bool
+  // thread_clock_gated; 	bool in_order, multithreaded;
+  void compute_stage_vector();
+  void compute();
+  ~Pipeline() { local_result.cleanup(); };
+};
+
+// class core_pipeline :public pipeline{
+// public:
+//	int  Hthread,  num_thread, fetchWidth, decodeWidth, issueWidth,
+// commitWidth, instruction_length; 	int  PC_width, opcode_length,
+// num_arch_reg_tag, data_width,num_phsical_reg_tag, address_width; 	bool
+// thread_clock_gated; 	bool in_order, multithreaded; 	core_pipeline(bool
+//_is_default, const InputParameter *configure_interface); 	virtual void
+// compute_stage_vector();
 //
 //};
 
-class FunctionalUnit :public Component{
-public:
-	ParseXML *XML;
-	int  ithCore;
-	InputParameter interface_ip;
-	CoreDynParam  coredynp;
-	double FU_height;
-	double clockRate,executionTime;
-	double num_fu;
-	double energy, base_energy,per_access_energy, leakage, gate_leakage;
-	bool  is_default;
-	enum FU_type fu_type;
-	statsDef       tdp_stats;
-	statsDef       rtp_stats;
-	statsDef       stats_t;
-	powerDef       power_t;
+class FunctionalUnit : public Component {
+ public:
+  ParseXML *XML;
+  int ithCore;
+  InputParameter interface_ip;
+  CoreDynParam coredynp;
+  double FU_height;
+  double clockRate, executionTime;
+  double num_fu;
+  double energy, base_energy, per_access_energy, leakage, gate_leakage;
+  bool is_default;
+  enum FU_type fu_type;
+  statsDef tdp_stats;
+  statsDef rtp_stats;
+  statsDef stats_t;
+  powerDef power_t;
 
-	FunctionalUnit(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_,const CoreDynParam & dyn_p_, enum FU_type fu_type, double exClockRate);
-    void computeEnergy(bool is_tdp=true);
-	void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-    void leakage_feedback(double temperature);
-
+  FunctionalUnit(ParseXML *XML_interface, int ithCore_,
+                 InputParameter *interface_ip_, const CoreDynParam &dyn_p_,
+                 enum FU_type fu_type, double exClockRate);
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  void leakage_feedback(double temperature);
 };
 
-class UndiffCore :public Component{
-public:
-	UndiffCore(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_, bool exist_=true, bool embedded_=false);
-	ParseXML *XML;
-	int  ithCore;
-	InputParameter interface_ip;
-	CoreDynParam  coredynp;
-	double clockRate,executionTime;
-	double scktRatio, chip_PR_overhead, macro_PR_overhead;
-	enum  Core_type core_ty;
-	bool   opt_performance, embedded;
-	double pipeline_stage,num_hthreads,issue_width;
-	bool   is_default;
+class UndiffCore : public Component {
+ public:
+  UndiffCore(ParseXML *XML_interface, int ithCore_,
+             InputParameter *interface_ip_, const CoreDynParam &dyn_p_,
+             bool exist_ = true, bool embedded_ = false);
+  ParseXML *XML;
+  int ithCore;
+  InputParameter interface_ip;
+  CoreDynParam coredynp;
+  double clockRate, executionTime;
+  double scktRatio, chip_PR_overhead, macro_PR_overhead;
+  enum Core_type core_ty;
+  bool opt_performance, embedded;
+  double pipeline_stage, num_hthreads, issue_width;
+  bool is_default;
 
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-	~UndiffCore(){};
-	bool exist;
-
-
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  ~UndiffCore(){};
+  bool exist;
 };
 #endif /* LOGIC_H_ */

--- a/src/gpuwattch/logic.h
+++ b/src/gpuwattch/logic.h
@@ -29,7 +29,8 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:												   *
+*      Modified by:
+**
 *      Jingwen Leng, Univeristy of Texas, Austin                   *
 *      Syed Gilani, University of Wisconsin–Madison                *
 *      Tayler Hetherington, University of British Columbia         *
@@ -38,203 +39,206 @@
 #ifndef LOGIC_H_
 #define LOGIC_H_
 
-#include "cacti/const.h"
-#include "cacti/component.h"
+#include <cassert>
+#include <cmath>
+#include <cstring>
+#include <iostream>
+#include "XML_Parse.h"
+#include "arch_const.h"
 #include "basic_components.h"
 #include "cacti/basic_circuit.h"
 #include "cacti/cacti_interface.h"
+#include "cacti/component.h"
+#include "cacti/const.h"
 #include "cacti/decoder.h"
 #include "cacti/parameter.h"
 #include "xmlParser.h"
-#include "XML_Parse.h"
-#include "arch_const.h"
-#include <cstring>
-#include <iostream>
-#include <cmath>
-#include <cassert>
-
 
 using namespace std;
 
-class selection_logic : public Component{
-public:
-	selection_logic(bool _is_default, int    win_entries_,
-		            int  issue_width_, const InputParameter *configure_interface,
-		            enum Device_ty device_ty_=Core_device,
-		            enum Core_type core_ty_=Inorder);//, const ParseXML *_XML_interface);
-	bool is_default;
-	InputParameter l_ip;
-	uca_org_t local_result;
-	const ParseXML *XML_interface;
-	int win_entries;
-	int issue_width;
-	int num_threads;
-	enum Device_ty device_ty;
-	enum Core_type core_ty;
+class selection_logic : public Component {
+ public:
+  selection_logic(
+      bool _is_default, int win_entries_, int issue_width_,
+      const InputParameter *configure_interface,
+      enum Device_ty device_ty_ = Core_device,
+      enum Core_type core_ty_ = Inorder);  //, const ParseXML *_XML_interface);
+  bool is_default;
+  InputParameter l_ip;
+  uca_org_t local_result;
+  const ParseXML *XML_interface;
+  int win_entries;
+  int issue_width;
+  int num_threads;
+  enum Device_ty device_ty;
+  enum Core_type core_ty;
 
-	void selection_power();
-	void leakage_feedback(double temperature); // TODO	
+  void selection_power();
+  void leakage_feedback(double temperature);  // TODO
 };
 
-class dep_resource_conflict_check : public Component{
-public:
-	dep_resource_conflict_check(const InputParameter *configure_interface, const CoreDynParam & dyn_p_, int compare_bits_, bool _is_default=true);
-	InputParameter l_ip;
-	uca_org_t local_result;
-	double WNORn, WNORp, Wevalinvp, Wevalinvn, Wcompn, Wcompp, Wcomppreequ;
-	CoreDynParam  coredynp;
-	int compare_bits;
-	bool is_default;
-	statsDef       tdp_stats;
-	statsDef       rtp_stats;
-	statsDef       stats_t;
-	powerDef       power_t;
+class dep_resource_conflict_check : public Component {
+ public:
+  dep_resource_conflict_check(const InputParameter *configure_interface,
+                              const CoreDynParam &dyn_p_, int compare_bits_,
+                              bool _is_default = true);
+  InputParameter l_ip;
+  uca_org_t local_result;
+  double WNORn, WNORp, Wevalinvp, Wevalinvn, Wcompn, Wcompp, Wcomppreequ;
+  CoreDynParam coredynp;
+  int compare_bits;
+  bool is_default;
+  statsDef tdp_stats;
+  statsDef rtp_stats;
+  statsDef stats_t;
+  powerDef power_t;
 
-	void conflict_check_power();
-	double compare_cap();
-	~dep_resource_conflict_check(){
-		local_result.cleanup();
-	}
+  void conflict_check_power();
+  double compare_cap();
+  ~dep_resource_conflict_check() { local_result.cleanup(); }
 
-	void leakage_feedback(double temperature);
+  void leakage_feedback(double temperature);
 };
 
-class inst_decoder: public Component{
-public:
-	inst_decoder(bool _is_default, const InputParameter *configure_interface,
-			int opcode_length_,
-			int num_decoders_,
-			bool x86_,
-			enum Device_ty device_ty_=Core_device,
-			enum Core_type core_ty_=Inorder);
-	inst_decoder();
-	bool is_default;
-	int  opcode_length;
-	int  num_decoders;
-	bool x86;
-	int  num_decoder_segments;
-	int  num_decoded_signals;
-	InputParameter l_ip;
-	uca_org_t local_result;
-	enum Device_ty device_ty;
-	enum Core_type core_ty;
+class inst_decoder : public Component {
+ public:
+  inst_decoder(bool _is_default, const InputParameter *configure_interface,
+               int opcode_length_, int num_decoders_, bool x86_,
+               enum Device_ty device_ty_ = Core_device,
+               enum Core_type core_ty_ = Inorder);
+  inst_decoder();
+  bool is_default;
+  int opcode_length;
+  int num_decoders;
+  bool x86;
+  int num_decoder_segments;
+  int num_decoded_signals;
+  InputParameter l_ip;
+  uca_org_t local_result;
+  enum Device_ty device_ty;
+  enum Core_type core_ty;
 
-	Decoder * final_dec;
-	Predec *  pre_dec;
+  Decoder *final_dec;
+  Predec *pre_dec;
 
-	statsDef       tdp_stats;
-	statsDef       rtp_stats;
-	statsDef       stats_t;
-	powerDef       power_t;
-	void inst_decoder_delay_power();
-	~inst_decoder();
-	void leakage_feedback(double temperature);
+  statsDef tdp_stats;
+  statsDef rtp_stats;
+  statsDef stats_t;
+  powerDef power_t;
+  void inst_decoder_delay_power();
+  ~inst_decoder();
+  void leakage_feedback(double temperature);
 };
 
 class DFFCell : public Component {
-public:
-	DFFCell(bool _is_dram, double _WdecNANDn, double _WdecNANDp,double _cell_load,
-			  const InputParameter *configure_interface);
-	InputParameter l_ip;
-	bool is_dram;
-	double cell_load;
-	double WdecNANDn;
-	double WdecNANDp;
-	double clock_cap;
-	int    model;
-	int    n_switch;
-	int    n_keep_1;
-	int    n_keep_0;
-	int    n_clock;
-	powerDef e_switch;
-	powerDef e_keep_1;
-	powerDef e_keep_0;
-	powerDef e_clock;
+ public:
+  DFFCell(bool _is_dram, double _WdecNANDn, double _WdecNANDp,
+          double _cell_load, const InputParameter *configure_interface);
+  InputParameter l_ip;
+  bool is_dram;
+  double cell_load;
+  double WdecNANDn;
+  double WdecNANDp;
+  double clock_cap;
+  int model;
+  int n_switch;
+  int n_keep_1;
+  int n_keep_0;
+  int n_clock;
+  powerDef e_switch;
+  powerDef e_keep_1;
+  powerDef e_keep_0;
+  powerDef e_clock;
 
-	double fpfp_node_cap(unsigned int fan_in, unsigned int fan_out);
-	void compute_DFF_cell(void);
-	};
-
-class Pipeline : public Component{
-public:
-	Pipeline(const InputParameter *configure_interface, const CoreDynParam & dyn_p_, enum Device_ty device_ty_=Core_device, bool _is_core_pipeline=true, bool _is_default=true);
-	InputParameter l_ip;
-	uca_org_t local_result;
-	CoreDynParam  coredynp;
-	enum Device_ty device_ty;
-	bool is_core_pipeline, is_default;
-	double num_piperegs;
-//	int pipeline_stages;
-//	int tot_stage_vector, per_stage_vector;
-	bool process_ind;
-	double WNANDn ;
-	double WNANDp;
-	double load_per_pipeline_stage;
-//	int  Hthread,  num_thread, fetchWidth, decodeWidth, issueWidth, commitWidth, instruction_length;
-//	int  PC_width, opcode_length, num_arch_reg_tag, data_width,num_phsical_reg_tag, address_width;
-//	bool thread_clock_gated;
-//	bool in_order, multithreaded;
-	void compute_stage_vector();
-	void compute();
-	~Pipeline(){
-		local_result.cleanup();
-	};
-
+  double fpfp_node_cap(unsigned int fan_in, unsigned int fan_out);
+  void compute_DFF_cell(void);
 };
 
-//class core_pipeline :public pipeline{
-//public:
-//	int  Hthread,  num_thread, fetchWidth, decodeWidth, issueWidth, commitWidth, instruction_length;
-//	int  PC_width, opcode_length, num_arch_reg_tag, data_width,num_phsical_reg_tag, address_width;
+class Pipeline : public Component {
+ public:
+  Pipeline(const InputParameter *configure_interface,
+           const CoreDynParam &dyn_p_, enum Device_ty device_ty_ = Core_device,
+           bool _is_core_pipeline = true, bool _is_default = true);
+  InputParameter l_ip;
+  uca_org_t local_result;
+  CoreDynParam coredynp;
+  enum Device_ty device_ty;
+  bool is_core_pipeline, is_default;
+  double num_piperegs;
+  //	int pipeline_stages;
+  //	int tot_stage_vector, per_stage_vector;
+  bool process_ind;
+  double WNANDn;
+  double WNANDp;
+  double load_per_pipeline_stage;
+  //	int  Hthread,  num_thread, fetchWidth, decodeWidth, issueWidth,
+  //commitWidth, instruction_length;
+  //	int  PC_width, opcode_length, num_arch_reg_tag,
+  //data_width,num_phsical_reg_tag, address_width;
+  //	bool thread_clock_gated;
+  //	bool in_order, multithreaded;
+  void compute_stage_vector();
+  void compute();
+  ~Pipeline() { local_result.cleanup(); };
+};
+
+// class core_pipeline :public pipeline{
+// public:
+//	int  Hthread,  num_thread, fetchWidth, decodeWidth, issueWidth,
+//commitWidth, instruction_length;
+//	int  PC_width, opcode_length, num_arch_reg_tag,
+//data_width,num_phsical_reg_tag, address_width;
 //	bool thread_clock_gated;
 //	bool in_order, multithreaded;
-//	core_pipeline(bool _is_default, const InputParameter *configure_interface);
+//	core_pipeline(bool _is_default, const InputParameter
+//*configure_interface);
 //	virtual void compute_stage_vector();
 //
 //};
 
-class FunctionalUnit :public Component{
-public:
-	ParseXML *XML;
-	int  ithCore;
-	InputParameter interface_ip;
-	CoreDynParam  coredynp;
-	double FU_height;
-	double clockRate,executionTime;
-	double num_fu;
-	double energy, base_energy,per_access_energy, leakage, gate_leakage;
-	bool  is_default;
-	enum FU_type fu_type;
-	statsDef       tdp_stats;
-	statsDef       rtp_stats;
-	statsDef       stats_t;
-	powerDef       power_t;
+class FunctionalUnit : public Component {
+ public:
+  ParseXML *XML;
+  int ithCore;
+  InputParameter interface_ip;
+  CoreDynParam coredynp;
+  double FU_height;
+  double clockRate, executionTime;
+  double num_fu;
+  double energy, base_energy, per_access_energy, leakage, gate_leakage;
+  bool is_default;
+  enum FU_type fu_type;
+  statsDef tdp_stats;
+  statsDef rtp_stats;
+  statsDef stats_t;
+  powerDef power_t;
 
-	FunctionalUnit(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_,const CoreDynParam & dyn_p_, enum FU_type fu_type, double exClockRate);
-    void computeEnergy(bool is_tdp=true);
-	void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-    void leakage_feedback(double temperature);
-
+  FunctionalUnit(ParseXML *XML_interface, int ithCore_,
+                 InputParameter *interface_ip_, const CoreDynParam &dyn_p_,
+                 enum FU_type fu_type, double exClockRate);
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  void leakage_feedback(double temperature);
 };
 
-class UndiffCore :public Component{
-public:
-	UndiffCore(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_, bool exist_=true, bool embedded_=false);
-	ParseXML *XML;
-	int  ithCore;
-	InputParameter interface_ip;
-	CoreDynParam  coredynp;
-	double clockRate,executionTime;
-	double scktRatio, chip_PR_overhead, macro_PR_overhead;
-	enum  Core_type core_ty;
-	bool   opt_performance, embedded;
-	double pipeline_stage,num_hthreads,issue_width;
-	bool   is_default;
+class UndiffCore : public Component {
+ public:
+  UndiffCore(ParseXML *XML_interface, int ithCore_,
+             InputParameter *interface_ip_, const CoreDynParam &dyn_p_,
+             bool exist_ = true, bool embedded_ = false);
+  ParseXML *XML;
+  int ithCore;
+  InputParameter interface_ip;
+  CoreDynParam coredynp;
+  double clockRate, executionTime;
+  double scktRatio, chip_PR_overhead, macro_PR_overhead;
+  enum Core_type core_ty;
+  bool opt_performance, embedded;
+  double pipeline_stage, num_hthreads, issue_width;
+  bool is_default;
 
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-	~UndiffCore(){};
-	bool exist;
-
-
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  ~UndiffCore(){};
+  bool exist;
 };
 #endif /* LOGIC_H_ */

--- a/src/gpuwattch/logic.h
+++ b/src/gpuwattch/logic.h
@@ -172,9 +172,9 @@ class Pipeline : public Component {
   double WNANDp;
   double load_per_pipeline_stage;
   //	int  Hthread,  num_thread, fetchWidth, decodeWidth, issueWidth,
-  // commitWidth, instruction_length;
+  //commitWidth, instruction_length;
   //	int  PC_width, opcode_length, num_arch_reg_tag,
-  // data_width,num_phsical_reg_tag, address_width;
+  //data_width,num_phsical_reg_tag, address_width;
   //	bool thread_clock_gated;
   //	bool in_order, multithreaded;
   void compute_stage_vector();
@@ -185,9 +185,9 @@ class Pipeline : public Component {
 // class core_pipeline :public pipeline{
 // public:
 //	int  Hthread,  num_thread, fetchWidth, decodeWidth, issueWidth,
-// commitWidth, instruction_length;
+//commitWidth, instruction_length;
 //	int  PC_width, opcode_length, num_arch_reg_tag,
-// data_width,num_phsical_reg_tag, address_width;
+//data_width,num_phsical_reg_tag, address_width;
 //	bool thread_clock_gated;
 //	bool in_order, multithreaded;
 //	core_pipeline(bool _is_default, const InputParameter

--- a/src/gpuwattch/logic.h
+++ b/src/gpuwattch/logic.h
@@ -29,8 +29,7 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:
-**
+*      Modified by:												   *
 *      Jingwen Leng, Univeristy of Texas, Austin                   *
 *      Syed Gilani, University of Wisconsin–Madison                *
 *      Tayler Hetherington, University of British Columbia         *
@@ -39,206 +38,203 @@
 #ifndef LOGIC_H_
 #define LOGIC_H_
 
-#include <cassert>
-#include <cmath>
-#include <cstring>
-#include <iostream>
-#include "XML_Parse.h"
-#include "arch_const.h"
+#include "cacti/const.h"
+#include "cacti/component.h"
 #include "basic_components.h"
 #include "cacti/basic_circuit.h"
 #include "cacti/cacti_interface.h"
-#include "cacti/component.h"
-#include "cacti/const.h"
 #include "cacti/decoder.h"
 #include "cacti/parameter.h"
 #include "xmlParser.h"
+#include "XML_Parse.h"
+#include "arch_const.h"
+#include <cstring>
+#include <iostream>
+#include <cmath>
+#include <cassert>
+
 
 using namespace std;
 
-class selection_logic : public Component {
- public:
-  selection_logic(
-      bool _is_default, int win_entries_, int issue_width_,
-      const InputParameter *configure_interface,
-      enum Device_ty device_ty_ = Core_device,
-      enum Core_type core_ty_ = Inorder);  //, const ParseXML *_XML_interface);
-  bool is_default;
-  InputParameter l_ip;
-  uca_org_t local_result;
-  const ParseXML *XML_interface;
-  int win_entries;
-  int issue_width;
-  int num_threads;
-  enum Device_ty device_ty;
-  enum Core_type core_ty;
+class selection_logic : public Component{
+public:
+	selection_logic(bool _is_default, int    win_entries_,
+		            int  issue_width_, const InputParameter *configure_interface,
+		            enum Device_ty device_ty_=Core_device,
+		            enum Core_type core_ty_=Inorder);//, const ParseXML *_XML_interface);
+	bool is_default;
+	InputParameter l_ip;
+	uca_org_t local_result;
+	const ParseXML *XML_interface;
+	int win_entries;
+	int issue_width;
+	int num_threads;
+	enum Device_ty device_ty;
+	enum Core_type core_ty;
 
-  void selection_power();
-  void leakage_feedback(double temperature);  // TODO
+	void selection_power();
+	void leakage_feedback(double temperature); // TODO	
 };
 
-class dep_resource_conflict_check : public Component {
- public:
-  dep_resource_conflict_check(const InputParameter *configure_interface,
-                              const CoreDynParam &dyn_p_, int compare_bits_,
-                              bool _is_default = true);
-  InputParameter l_ip;
-  uca_org_t local_result;
-  double WNORn, WNORp, Wevalinvp, Wevalinvn, Wcompn, Wcompp, Wcomppreequ;
-  CoreDynParam coredynp;
-  int compare_bits;
-  bool is_default;
-  statsDef tdp_stats;
-  statsDef rtp_stats;
-  statsDef stats_t;
-  powerDef power_t;
+class dep_resource_conflict_check : public Component{
+public:
+	dep_resource_conflict_check(const InputParameter *configure_interface, const CoreDynParam & dyn_p_, int compare_bits_, bool _is_default=true);
+	InputParameter l_ip;
+	uca_org_t local_result;
+	double WNORn, WNORp, Wevalinvp, Wevalinvn, Wcompn, Wcompp, Wcomppreequ;
+	CoreDynParam  coredynp;
+	int compare_bits;
+	bool is_default;
+	statsDef       tdp_stats;
+	statsDef       rtp_stats;
+	statsDef       stats_t;
+	powerDef       power_t;
 
-  void conflict_check_power();
-  double compare_cap();
-  ~dep_resource_conflict_check() { local_result.cleanup(); }
+	void conflict_check_power();
+	double compare_cap();
+	~dep_resource_conflict_check(){
+		local_result.cleanup();
+	}
 
-  void leakage_feedback(double temperature);
+	void leakage_feedback(double temperature);
 };
 
-class inst_decoder : public Component {
- public:
-  inst_decoder(bool _is_default, const InputParameter *configure_interface,
-               int opcode_length_, int num_decoders_, bool x86_,
-               enum Device_ty device_ty_ = Core_device,
-               enum Core_type core_ty_ = Inorder);
-  inst_decoder();
-  bool is_default;
-  int opcode_length;
-  int num_decoders;
-  bool x86;
-  int num_decoder_segments;
-  int num_decoded_signals;
-  InputParameter l_ip;
-  uca_org_t local_result;
-  enum Device_ty device_ty;
-  enum Core_type core_ty;
+class inst_decoder: public Component{
+public:
+	inst_decoder(bool _is_default, const InputParameter *configure_interface,
+			int opcode_length_,
+			int num_decoders_,
+			bool x86_,
+			enum Device_ty device_ty_=Core_device,
+			enum Core_type core_ty_=Inorder);
+	inst_decoder();
+	bool is_default;
+	int  opcode_length;
+	int  num_decoders;
+	bool x86;
+	int  num_decoder_segments;
+	int  num_decoded_signals;
+	InputParameter l_ip;
+	uca_org_t local_result;
+	enum Device_ty device_ty;
+	enum Core_type core_ty;
 
-  Decoder *final_dec;
-  Predec *pre_dec;
+	Decoder * final_dec;
+	Predec *  pre_dec;
 
-  statsDef tdp_stats;
-  statsDef rtp_stats;
-  statsDef stats_t;
-  powerDef power_t;
-  void inst_decoder_delay_power();
-  ~inst_decoder();
-  void leakage_feedback(double temperature);
+	statsDef       tdp_stats;
+	statsDef       rtp_stats;
+	statsDef       stats_t;
+	powerDef       power_t;
+	void inst_decoder_delay_power();
+	~inst_decoder();
+	void leakage_feedback(double temperature);
 };
 
 class DFFCell : public Component {
- public:
-  DFFCell(bool _is_dram, double _WdecNANDn, double _WdecNANDp,
-          double _cell_load, const InputParameter *configure_interface);
-  InputParameter l_ip;
-  bool is_dram;
-  double cell_load;
-  double WdecNANDn;
-  double WdecNANDp;
-  double clock_cap;
-  int model;
-  int n_switch;
-  int n_keep_1;
-  int n_keep_0;
-  int n_clock;
-  powerDef e_switch;
-  powerDef e_keep_1;
-  powerDef e_keep_0;
-  powerDef e_clock;
+public:
+	DFFCell(bool _is_dram, double _WdecNANDn, double _WdecNANDp,double _cell_load,
+			  const InputParameter *configure_interface);
+	InputParameter l_ip;
+	bool is_dram;
+	double cell_load;
+	double WdecNANDn;
+	double WdecNANDp;
+	double clock_cap;
+	int    model;
+	int    n_switch;
+	int    n_keep_1;
+	int    n_keep_0;
+	int    n_clock;
+	powerDef e_switch;
+	powerDef e_keep_1;
+	powerDef e_keep_0;
+	powerDef e_clock;
 
-  double fpfp_node_cap(unsigned int fan_in, unsigned int fan_out);
-  void compute_DFF_cell(void);
-};
+	double fpfp_node_cap(unsigned int fan_in, unsigned int fan_out);
+	void compute_DFF_cell(void);
+	};
 
-class Pipeline : public Component {
- public:
-  Pipeline(const InputParameter *configure_interface,
-           const CoreDynParam &dyn_p_, enum Device_ty device_ty_ = Core_device,
-           bool _is_core_pipeline = true, bool _is_default = true);
-  InputParameter l_ip;
-  uca_org_t local_result;
-  CoreDynParam coredynp;
-  enum Device_ty device_ty;
-  bool is_core_pipeline, is_default;
-  double num_piperegs;
-  //	int pipeline_stages;
-  //	int tot_stage_vector, per_stage_vector;
-  bool process_ind;
-  double WNANDn;
-  double WNANDp;
-  double load_per_pipeline_stage;
-  //	int  Hthread,  num_thread, fetchWidth, decodeWidth, issueWidth,
-  //commitWidth, instruction_length;
-  //	int  PC_width, opcode_length, num_arch_reg_tag,
-  //data_width,num_phsical_reg_tag, address_width;
-  //	bool thread_clock_gated;
-  //	bool in_order, multithreaded;
-  void compute_stage_vector();
-  void compute();
-  ~Pipeline() { local_result.cleanup(); };
-};
-
-// class core_pipeline :public pipeline{
-// public:
-//	int  Hthread,  num_thread, fetchWidth, decodeWidth, issueWidth,
-//commitWidth, instruction_length;
-//	int  PC_width, opcode_length, num_arch_reg_tag,
-//data_width,num_phsical_reg_tag, address_width;
+class Pipeline : public Component{
+public:
+	Pipeline(const InputParameter *configure_interface, const CoreDynParam & dyn_p_, enum Device_ty device_ty_=Core_device, bool _is_core_pipeline=true, bool _is_default=true);
+	InputParameter l_ip;
+	uca_org_t local_result;
+	CoreDynParam  coredynp;
+	enum Device_ty device_ty;
+	bool is_core_pipeline, is_default;
+	double num_piperegs;
+//	int pipeline_stages;
+//	int tot_stage_vector, per_stage_vector;
+	bool process_ind;
+	double WNANDn ;
+	double WNANDp;
+	double load_per_pipeline_stage;
+//	int  Hthread,  num_thread, fetchWidth, decodeWidth, issueWidth, commitWidth, instruction_length;
+//	int  PC_width, opcode_length, num_arch_reg_tag, data_width,num_phsical_reg_tag, address_width;
 //	bool thread_clock_gated;
 //	bool in_order, multithreaded;
-//	core_pipeline(bool _is_default, const InputParameter
-//*configure_interface);
+	void compute_stage_vector();
+	void compute();
+	~Pipeline(){
+		local_result.cleanup();
+	};
+
+};
+
+//class core_pipeline :public pipeline{
+//public:
+//	int  Hthread,  num_thread, fetchWidth, decodeWidth, issueWidth, commitWidth, instruction_length;
+//	int  PC_width, opcode_length, num_arch_reg_tag, data_width,num_phsical_reg_tag, address_width;
+//	bool thread_clock_gated;
+//	bool in_order, multithreaded;
+//	core_pipeline(bool _is_default, const InputParameter *configure_interface);
 //	virtual void compute_stage_vector();
 //
 //};
 
-class FunctionalUnit : public Component {
- public:
-  ParseXML *XML;
-  int ithCore;
-  InputParameter interface_ip;
-  CoreDynParam coredynp;
-  double FU_height;
-  double clockRate, executionTime;
-  double num_fu;
-  double energy, base_energy, per_access_energy, leakage, gate_leakage;
-  bool is_default;
-  enum FU_type fu_type;
-  statsDef tdp_stats;
-  statsDef rtp_stats;
-  statsDef stats_t;
-  powerDef power_t;
+class FunctionalUnit :public Component{
+public:
+	ParseXML *XML;
+	int  ithCore;
+	InputParameter interface_ip;
+	CoreDynParam  coredynp;
+	double FU_height;
+	double clockRate,executionTime;
+	double num_fu;
+	double energy, base_energy,per_access_energy, leakage, gate_leakage;
+	bool  is_default;
+	enum FU_type fu_type;
+	statsDef       tdp_stats;
+	statsDef       rtp_stats;
+	statsDef       stats_t;
+	powerDef       power_t;
 
-  FunctionalUnit(ParseXML *XML_interface, int ithCore_,
-                 InputParameter *interface_ip_, const CoreDynParam &dyn_p_,
-                 enum FU_type fu_type, double exClockRate);
-  void computeEnergy(bool is_tdp = true);
-  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
-  void leakage_feedback(double temperature);
+	FunctionalUnit(ParseXML *XML_interface, int ithCore_, InputParameter* interface_ip_,const CoreDynParam & dyn_p_, enum FU_type fu_type, double exClockRate);
+    void computeEnergy(bool is_tdp=true);
+	void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
+    void leakage_feedback(double temperature);
+
 };
 
-class UndiffCore : public Component {
- public:
-  UndiffCore(ParseXML *XML_interface, int ithCore_,
-             InputParameter *interface_ip_, const CoreDynParam &dyn_p_,
-             bool exist_ = true, bool embedded_ = false);
-  ParseXML *XML;
-  int ithCore;
-  InputParameter interface_ip;
-  CoreDynParam coredynp;
-  double clockRate, executionTime;
-  double scktRatio, chip_PR_overhead, macro_PR_overhead;
-  enum Core_type core_ty;
-  bool opt_performance, embedded;
-  double pipeline_stage, num_hthreads, issue_width;
-  bool is_default;
+class UndiffCore :public Component{
+public:
+	UndiffCore(ParseXML* XML_interface, int ithCore_, InputParameter* interface_ip_, const CoreDynParam & dyn_p_, bool exist_=true, bool embedded_=false);
+	ParseXML *XML;
+	int  ithCore;
+	InputParameter interface_ip;
+	CoreDynParam  coredynp;
+	double clockRate,executionTime;
+	double scktRatio, chip_PR_overhead, macro_PR_overhead;
+	enum  Core_type core_ty;
+	bool   opt_performance, embedded;
+	double pipeline_stage,num_hthreads,issue_width;
+	bool   is_default;
 
-  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
-  ~UndiffCore(){};
-  bool exist;
+    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
+	~UndiffCore(){};
+	bool exist;
+
+
 };
 #endif /* LOGIC_H_ */

--- a/src/gpuwattch/logic.h
+++ b/src/gpuwattch/logic.h
@@ -172,9 +172,9 @@ class Pipeline : public Component {
   double WNANDp;
   double load_per_pipeline_stage;
   //	int  Hthread,  num_thread, fetchWidth, decodeWidth, issueWidth,
-  //commitWidth, instruction_length;
+  // commitWidth, instruction_length;
   //	int  PC_width, opcode_length, num_arch_reg_tag,
-  //data_width,num_phsical_reg_tag, address_width;
+  // data_width,num_phsical_reg_tag, address_width;
   //	bool thread_clock_gated;
   //	bool in_order, multithreaded;
   void compute_stage_vector();
@@ -185,9 +185,9 @@ class Pipeline : public Component {
 // class core_pipeline :public pipeline{
 // public:
 //	int  Hthread,  num_thread, fetchWidth, decodeWidth, issueWidth,
-//commitWidth, instruction_length;
+// commitWidth, instruction_length;
 //	int  PC_width, opcode_length, num_arch_reg_tag,
-//data_width,num_phsical_reg_tag, address_width;
+// data_width,num_phsical_reg_tag, address_width;
 //	bool thread_clock_gated;
 //	bool in_order, multithreaded;
 //	core_pipeline(bool _is_default, const InputParameter

--- a/src/gpuwattch/main.cc
+++ b/src/gpuwattch/main.cc
@@ -28,74 +28,68 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.”
  *
  ***************************************************************************/
-#include "io.h"
 #include <iostream>
-#include "xmlParser.h"
 #include "XML_Parse.h"
-#include "processor.h"
 #include "globalvar.h"
+#include "io.h"
+#include "processor.h"
 #include "version.h"
-
+#include "xmlParser.h"
 
 using namespace std;
 
-void print_usage(char * argv0);
+void print_usage(char *argv0);
 
-int main(int argc,char *argv[])
-{
-	char * fb ;
-	bool infile_specified     = false;
-	int  plevel               = 2;
-	opt_for_clk	=true;
-	//cout.precision(10);
-	if (argc <= 1 || argv[1] == string("-h") || argv[1] == string("--help"))
-	{
-		print_usage(argv[0]);
-	}
+int main(int argc, char *argv[]) {
+  char *fb;
+  bool infile_specified = false;
+  int plevel = 2;
+  opt_for_clk = true;
+  // cout.precision(10);
+  if (argc <= 1 || argv[1] == string("-h") || argv[1] == string("--help")) {
+    print_usage(argv[0]);
+  }
 
-	for (int32_t i = 0; i < argc; i++)
-	{
-		if (argv[i] == string("-infile"))
-		{
-			infile_specified = true;
-			i++;
-			fb = argv[ i];
-		}
+  for (int32_t i = 0; i < argc; i++) {
+    if (argv[i] == string("-infile")) {
+      infile_specified = true;
+      i++;
+      fb = argv[i];
+    }
 
-		if (argv[i] == string("-print_level"))
-		{
-			i++;
-			plevel = atoi(argv[i]);
-		}
+    if (argv[i] == string("-print_level")) {
+      i++;
+      plevel = atoi(argv[i]);
+    }
 
-		if (argv[i] == string("-opt_for_clk"))
-		{
-			i++;
-			opt_for_clk = (bool)atoi(argv[i]);
-		}
-	}
-	if (infile_specified == false)
-	{
-		print_usage(argv[0]);
-	}
+    if (argv[i] == string("-opt_for_clk")) {
+      i++;
+      opt_for_clk = (bool)atoi(argv[i]);
+    }
+  }
+  if (infile_specified == false) {
+    print_usage(argv[0]);
+  }
 
+  cout << "McPAT (version " << VER_MAJOR << "." << VER_MINOR << " of "
+       << VER_UPDATE << ") is computing the target processor...\n " << endl;
 
-	cout<<"McPAT (version "<< VER_MAJOR <<"."<< VER_MINOR
-		<< " of " << VER_UPDATE << ") is computing the target processor...\n "<<endl;
-
-	//parse XML-based interface
-	ParseXML *p1= new ParseXML();
-	p1->parse(fb);
-	Processor proc(p1);
-	proc.displayEnergy(2, plevel);
-	delete p1;
-	return 0;
+  // parse XML-based interface
+  ParseXML *p1 = new ParseXML();
+  p1->parse(fb);
+  Processor proc(p1);
+  proc.displayEnergy(2, plevel);
+  delete p1;
+  return 0;
 }
 
-void print_usage(char * argv0)
-{
-    cerr << "How to use McPAT:" << endl;
-    cerr << "  mcpat -infile <input file name>  -print_level < level of details 0~5 >  -opt_for_clk < 0 (optimize for ED^2P only)/1 (optimzed for target clock rate)>"<< endl;
-    //cerr << "    Note:default print level is at processor level, please increase it to see the details" << endl;
-    exit(1);
+void print_usage(char *argv0) {
+  cerr << "How to use McPAT:" << endl;
+  cerr << "  mcpat -infile <input file name>  -print_level < level of details "
+          "0~5 >  -opt_for_clk < 0 (optimize for ED^2P only)/1 (optimzed for "
+          "target clock rate)>"
+       << endl;
+  // cerr << "    Note:default print level is at processor level, please
+  // increase it to see the details" << endl;
+  exit(1);
 }

--- a/src/gpuwattch/main.cc
+++ b/src/gpuwattch/main.cc
@@ -28,68 +28,74 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.”
  *
  ***************************************************************************/
-#include <iostream>
-#include "XML_Parse.h"
-#include "globalvar.h"
 #include "io.h"
-#include "processor.h"
-#include "version.h"
+#include <iostream>
 #include "xmlParser.h"
+#include "XML_Parse.h"
+#include "processor.h"
+#include "globalvar.h"
+#include "version.h"
+
 
 using namespace std;
 
-void print_usage(char *argv0);
+void print_usage(char * argv0);
 
-int main(int argc, char *argv[]) {
-  char *fb;
-  bool infile_specified = false;
-  int plevel = 2;
-  opt_for_clk = true;
-  // cout.precision(10);
-  if (argc <= 1 || argv[1] == string("-h") || argv[1] == string("--help")) {
-    print_usage(argv[0]);
-  }
+int main(int argc,char *argv[])
+{
+	char * fb ;
+	bool infile_specified     = false;
+	int  plevel               = 2;
+	opt_for_clk	=true;
+	//cout.precision(10);
+	if (argc <= 1 || argv[1] == string("-h") || argv[1] == string("--help"))
+	{
+		print_usage(argv[0]);
+	}
 
-  for (int32_t i = 0; i < argc; i++) {
-    if (argv[i] == string("-infile")) {
-      infile_specified = true;
-      i++;
-      fb = argv[i];
-    }
+	for (int32_t i = 0; i < argc; i++)
+	{
+		if (argv[i] == string("-infile"))
+		{
+			infile_specified = true;
+			i++;
+			fb = argv[ i];
+		}
 
-    if (argv[i] == string("-print_level")) {
-      i++;
-      plevel = atoi(argv[i]);
-    }
+		if (argv[i] == string("-print_level"))
+		{
+			i++;
+			plevel = atoi(argv[i]);
+		}
 
-    if (argv[i] == string("-opt_for_clk")) {
-      i++;
-      opt_for_clk = (bool)atoi(argv[i]);
-    }
-  }
-  if (infile_specified == false) {
-    print_usage(argv[0]);
-  }
+		if (argv[i] == string("-opt_for_clk"))
+		{
+			i++;
+			opt_for_clk = (bool)atoi(argv[i]);
+		}
+	}
+	if (infile_specified == false)
+	{
+		print_usage(argv[0]);
+	}
 
-  cout << "McPAT (version " << VER_MAJOR << "." << VER_MINOR << " of "
-       << VER_UPDATE << ") is computing the target processor...\n " << endl;
 
-  // parse XML-based interface
-  ParseXML *p1 = new ParseXML();
-  p1->parse(fb);
-  Processor proc(p1);
-  proc.displayEnergy(2, plevel);
-  delete p1;
-  return 0;
+	cout<<"McPAT (version "<< VER_MAJOR <<"."<< VER_MINOR
+		<< " of " << VER_UPDATE << ") is computing the target processor...\n "<<endl;
+
+	//parse XML-based interface
+	ParseXML *p1= new ParseXML();
+	p1->parse(fb);
+	Processor proc(p1);
+	proc.displayEnergy(2, plevel);
+	delete p1;
+	return 0;
 }
 
-void print_usage(char *argv0) {
-  cerr << "How to use McPAT:" << endl;
-  cerr << "  mcpat -infile <input file name>  -print_level < level of details "
-          "0~5 >  -opt_for_clk < 0 (optimize for ED^2P only)/1 (optimzed for "
-          "target clock rate)>"
-       << endl;
-  // cerr << "    Note:default print level is at processor level, please
-  // increase it to see the details" << endl;
-  exit(1);
+void print_usage(char * argv0)
+{
+    cerr << "How to use McPAT:" << endl;
+    cerr << "  mcpat -infile <input file name>  -print_level < level of details 0~5 >  -opt_for_clk < 0 (optimize for ED^2P only)/1 (optimzed for target clock rate)>"<< endl;
+    //cerr << "    Note:default print level is at processor level, please increase it to see the details" << endl;
+    exit(1);
 }

--- a/src/gpuwattch/memoryctrl.cc
+++ b/src/gpuwattch/memoryctrl.cc
@@ -102,7 +102,7 @@ void MCBackend::compute() {
   // double max_row_addr_width = 20.0;//Current address 12~18bits
   double C_MCB, mc_power, backend_dyn,
       backend_gates;  //, refresh_period,refresh_freq;//Equivalent per bit Cap
-                      //for backend,
+                      // for backend,
   double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
   double NMOS_sizing, PMOS_sizing;
 
@@ -535,7 +535,7 @@ MCFrontEnd::MCFrontEnd(ParseXML* XML_interface, InputParameter* interface_ip_,
                 PRT->local_result.area * XML->sys.mc.memory_channels_per_mc);
 
   //***ThreadMasks storage (coalesced threads whose memory requests are
-  //satisfied by each memory access)
+  // satisfied by each memory access)
   /* contents of the thread masks Array
         *  16-bit bit masks for up to 16 memory requests of a warp | Number of
    * pending memory requests (5 bits)
@@ -983,7 +983,7 @@ MemoryController::MemoryController(ParseXML* XML_interface,
     area.set_area(area.get_area() + PHY->area.get_area());
   }
   //+++++++++Transaction engine +++++++++++++++++ ////TODO needs better numbers,
-  //Run the RTL code from OpenSparc.
+  // Run the RTL code from OpenSparc.
   //  transecEngine.initialize(&interface_ip);
   //  transecEngine.peakDataTransferRate = XML->sys.mem.peak_transfer_rate;
   //  transecEngine.memDataWidth = dataBusWidth;
@@ -1023,7 +1023,7 @@ MemoryController::MemoryController(ParseXML* XML_interface,
   ////  //clock
   ////  clockNetwork.init_wire_external(is_default, &interface_ip);
   ////  clockNetwork.clk_area           =area*1.1;//10% of placement overhead.
-  ///rule of thumb
+  /// rule of thumb
   ////  clockNetwork.end_wiring_level   =5;//toplevel metal
   ////  clockNetwork.start_wiring_level =5;//toplevel metal
   ////  clockNetwork.num_regs           = pipeLogic.tot_stage_vector;
@@ -1199,7 +1199,7 @@ void MemoryController::set_mc_param() {
     mcp.reads = XML->sys.mc.memory_reads;
     mcp.writes = XML->sys.mc.memory_writes;
     //+++++++++Transaction engine +++++++++++++++++ ////TODO needs better
-    //numbers, Run the RTL code from OpenSparc.
+    // numbers, Run the RTL code from OpenSparc.
     mcp.peakDataTransferRate = XML->sys.mc.peak_transfer_rate;
     mcp.memRank = XML->sys.mc.number_ranks;
     //++++++++++++++PHY ++++++++++++++++++++++++++ //TODO needs better numbers
@@ -1214,16 +1214,17 @@ void MemoryController::set_mc_param() {
   //	else if (mc_type==FLASHC)
   //	{
   //		mcp.clockRate       =XML->sys.flashc.mc_clock*2;//DDR double
-  //pumped
+  // pumped
   //		mcp.clockRate       *= 1e6;
   //		mcp.executionTime   =
-  //XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
+  // XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
   //
   //		mcp.llcBlockSize
   //=int(ceil(XML->sys.flashc.llc_line_length/8.0))+XML->sys.flashc.llc_line_length;//ecc
-  //overhead
-  //		mcp.dataBusWidth    =int(ceil(XML->sys.flashc.databus_width/8.0)) +
-  //XML->sys.flashc.databus_width;
+  // overhead
+  //		mcp.dataBusWidth =int(ceil(XML->sys.flashc.databus_width/8.0))
+  //+
+  // XML->sys.flashc.databus_width;
   //		mcp.addressBusWidth
   //=int(ceil(XML->sys.flashc.addressbus_width));//XML->sys.physical_address_width;
   //		mcp.opcodeW         =16;
@@ -1232,16 +1233,18 @@ void MemoryController::set_mc_param() {
   //		mcp.reads  = XML->sys.flashc.memory_reads;
   //		mcp.writes = XML->sys.flashc.memory_writes;
   //		//+++++++++Transaction engine +++++++++++++++++ ////TODO needs
-  //better numbers, Run the RTL code from OpenSparc.
+  // better numbers, Run the RTL code from OpenSparc.
   //		mcp.peakDataTransferRate = XML->sys.flashc.peak_transfer_rate;
   //		mcp.memRank = XML->sys.flashc.number_ranks;
-  //		//++++++++++++++PHY ++++++++++++++++++++++++++ //TODO needs better
-  //numbers
+  //		//++++++++++++++PHY ++++++++++++++++++++++++++ //TODO needs
+  // better
+  // numbers
   //		//PHY.memAccesses=PHY.peakDataTransferRate;//this is the max
-  //power
+  // power
   //		//PHY.llcBlocksize=llcBlockSize;
-  //		mcp.frontend_duty_cycle = 0.5;//for max power, the actual off-chip
-  //links is bidirectional but time shared
+  //		mcp.frontend_duty_cycle = 0.5;//for max power, the actual
+  // off-chip
+  // links is bidirectional but time shared
   //		mcp.LVDS = XML->sys.flashc.LVDS;
   //		mcp.type = XML->sys.flashc.type;
   //	}

--- a/src/gpuwattch/memoryctrl.cc
+++ b/src/gpuwattch/memoryctrl.cc
@@ -35,6 +35,7 @@
 *      Tayler Hetherington, University of British Columbia         *
 *      Ahmed ElTantawy, University of British Columbia             *
 ********************************************************************/
+// clang-format off
 #include "io.h"
 #include "parameter.h"
 #include "const.h"
@@ -48,7 +49,7 @@
 #include <assert.h>
 #include "memoryctrl.h"
 #include "basic_components.h"
-
+// clang-format on
 /* overview of MC models:
  * McPAT memory controllers are modeled according to large number of industrial data points.
  * The Basic memory controller architecture is base on the Synopsis designs

--- a/src/gpuwattch/memoryctrl.cc
+++ b/src/gpuwattch/memoryctrl.cc
@@ -102,7 +102,7 @@ void MCBackend::compute() {
   // double max_row_addr_width = 20.0;//Current address 12~18bits
   double C_MCB, mc_power, backend_dyn,
       backend_gates;  //, refresh_period,refresh_freq;//Equivalent per bit Cap
-                      // for backend,
+                      //for backend,
   double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
   double NMOS_sizing, PMOS_sizing;
 
@@ -535,7 +535,7 @@ MCFrontEnd::MCFrontEnd(ParseXML* XML_interface, InputParameter* interface_ip_,
                 PRT->local_result.area * XML->sys.mc.memory_channels_per_mc);
 
   //***ThreadMasks storage (coalesced threads whose memory requests are
-  // satisfied by each memory access)
+  //satisfied by each memory access)
   /* contents of the thread masks Array
         *  16-bit bit masks for up to 16 memory requests of a warp | Number of
    * pending memory requests (5 bits)
@@ -983,7 +983,7 @@ MemoryController::MemoryController(ParseXML* XML_interface,
     area.set_area(area.get_area() + PHY->area.get_area());
   }
   //+++++++++Transaction engine +++++++++++++++++ ////TODO needs better numbers,
-  // Run the RTL code from OpenSparc.
+  //Run the RTL code from OpenSparc.
   //  transecEngine.initialize(&interface_ip);
   //  transecEngine.peakDataTransferRate = XML->sys.mem.peak_transfer_rate;
   //  transecEngine.memDataWidth = dataBusWidth;
@@ -1023,7 +1023,7 @@ MemoryController::MemoryController(ParseXML* XML_interface,
   ////  //clock
   ////  clockNetwork.init_wire_external(is_default, &interface_ip);
   ////  clockNetwork.clk_area           =area*1.1;//10% of placement overhead.
-  /// rule of thumb
+  ///rule of thumb
   ////  clockNetwork.end_wiring_level   =5;//toplevel metal
   ////  clockNetwork.start_wiring_level =5;//toplevel metal
   ////  clockNetwork.num_regs           = pipeLogic.tot_stage_vector;
@@ -1199,7 +1199,7 @@ void MemoryController::set_mc_param() {
     mcp.reads = XML->sys.mc.memory_reads;
     mcp.writes = XML->sys.mc.memory_writes;
     //+++++++++Transaction engine +++++++++++++++++ ////TODO needs better
-    // numbers, Run the RTL code from OpenSparc.
+    //numbers, Run the RTL code from OpenSparc.
     mcp.peakDataTransferRate = XML->sys.mc.peak_transfer_rate;
     mcp.memRank = XML->sys.mc.number_ranks;
     //++++++++++++++PHY ++++++++++++++++++++++++++ //TODO needs better numbers
@@ -1214,17 +1214,16 @@ void MemoryController::set_mc_param() {
   //	else if (mc_type==FLASHC)
   //	{
   //		mcp.clockRate       =XML->sys.flashc.mc_clock*2;//DDR double
-  // pumped
+  //pumped
   //		mcp.clockRate       *= 1e6;
   //		mcp.executionTime   =
-  // XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
+  //XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
   //
   //		mcp.llcBlockSize
   //=int(ceil(XML->sys.flashc.llc_line_length/8.0))+XML->sys.flashc.llc_line_length;//ecc
-  // overhead
-  //		mcp.dataBusWidth =int(ceil(XML->sys.flashc.databus_width/8.0))
-  //+
-  // XML->sys.flashc.databus_width;
+  //overhead
+  //		mcp.dataBusWidth    =int(ceil(XML->sys.flashc.databus_width/8.0)) +
+  //XML->sys.flashc.databus_width;
   //		mcp.addressBusWidth
   //=int(ceil(XML->sys.flashc.addressbus_width));//XML->sys.physical_address_width;
   //		mcp.opcodeW         =16;
@@ -1233,18 +1232,16 @@ void MemoryController::set_mc_param() {
   //		mcp.reads  = XML->sys.flashc.memory_reads;
   //		mcp.writes = XML->sys.flashc.memory_writes;
   //		//+++++++++Transaction engine +++++++++++++++++ ////TODO needs
-  // better numbers, Run the RTL code from OpenSparc.
+  //better numbers, Run the RTL code from OpenSparc.
   //		mcp.peakDataTransferRate = XML->sys.flashc.peak_transfer_rate;
   //		mcp.memRank = XML->sys.flashc.number_ranks;
-  //		//++++++++++++++PHY ++++++++++++++++++++++++++ //TODO needs
-  // better
-  // numbers
+  //		//++++++++++++++PHY ++++++++++++++++++++++++++ //TODO needs better
+  //numbers
   //		//PHY.memAccesses=PHY.peakDataTransferRate;//this is the max
-  // power
+  //power
   //		//PHY.llcBlocksize=llcBlockSize;
-  //		mcp.frontend_duty_cycle = 0.5;//for max power, the actual
-  // off-chip
-  // links is bidirectional but time shared
+  //		mcp.frontend_duty_cycle = 0.5;//for max power, the actual off-chip
+  //links is bidirectional but time shared
   //		mcp.LVDS = XML->sys.flashc.LVDS;
   //		mcp.type = XML->sys.flashc.type;
   //	}

--- a/src/gpuwattch/memoryctrl.cc
+++ b/src/gpuwattch/memoryctrl.cc
@@ -29,7 +29,8 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:												   *
+*      Modified by:
+**
 *      Jingwen Leng, Univeristy of Texas, Austin                   *
 *      Syed Gilani, University of Wisconsin–Madison                *
 *      Tayler Hetherington, University of British Columbia         *
@@ -51,944 +52,1241 @@
 #include "basic_components.h"
 // clang-format on
 /* overview of MC models:
- * McPAT memory controllers are modeled according to large number of industrial data points.
+ * McPAT memory controllers are modeled according to large number of industrial
+ * data points.
  * The Basic memory controller architecture is base on the Synopsis designs
- * (DesignWare DDR2/DDR3-Lite memory controllers and DDR2/DDR3-Lite protocol controllers)
+ * (DesignWare DDR2/DDR3-Lite memory controllers and DDR2/DDR3-Lite protocol
+ * controllers)
  * as in Cadence ChipEstimator Tool
  *
- * An MC has 3 parts as shown in this design. McPAT models both high performance MC
- * based on Niagara processor designs and curving and low power MC based on data points in
+ * An MC has 3 parts as shown in this design. McPAT models both high performance
+ * MC
+ * based on Niagara processor designs and curving and low power MC based on data
+ * points in
  * Cadence ChipEstimator Tool.
  *
- * The frontend is modeled analytically, the backend is modeled empirically according to
+ * The frontend is modeled analytically, the backend is modeled empirically
+ * according to
  * DDR2/DDR3-Lite protocol controllers in Cadence ChipEstimator Tool
  * The PHY is modeled based on
- * "A 100mW 9.6Gb/s Transceiver in 90nm CMOS for next-generation memory interfaces ," ISSCC 2006,
- * and A 14mW 6.25Gb/s Transceiver in 90nm CMOS for Serial Chip-to-Chip Communication," ISSCC 2007
+ * "A 100mW 9.6Gb/s Transceiver in 90nm CMOS for next-generation memory
+ * interfaces ," ISSCC 2006,
+ * and A 14mW 6.25Gb/s Transceiver in 90nm CMOS for Serial Chip-to-Chip
+ * Communication," ISSCC 2007
  *
- * In Cadence ChipEstimator Tool there are two types of memory controllers: the full memory controllers
- * that includes the frontend as the DesignWare DDR2/DDR3-Lite memory controllers and the backend only
- * memory controllers as the DDR2/DDR3-Lite protocol controllers (except DesignWare DDR2/DDR3-Lite memory
- * controllers, all memory controller IP in Cadence ChipEstimator Tool are backend memory controllers such as
- * DDRC 1600A and DDRC 800A). Thus,to some extend the area and power difference between DesignWare
- * DDR2/DDR3-Lite memory controllers and DDR2/DDR3-Lite protocol controllers can be an estimation to the
- * frontend power and area, which is very close the analitically modeled results of the frontend for Niagara2@65nm
+ * In Cadence ChipEstimator Tool there are two types of memory controllers: the
+ * full memory controllers
+ * that includes the frontend as the DesignWare DDR2/DDR3-Lite memory
+ * controllers and the backend only
+ * memory controllers as the DDR2/DDR3-Lite protocol controllers (except
+ * DesignWare DDR2/DDR3-Lite memory
+ * controllers, all memory controller IP in Cadence ChipEstimator Tool are
+ * backend memory controllers such as
+ * DDRC 1600A and DDRC 800A). Thus,to some extend the area and power difference
+ * between DesignWare
+ * DDR2/DDR3-Lite memory controllers and DDR2/DDR3-Lite protocol controllers can
+ * be an estimation to the
+ * frontend power and area, which is very close the analitically modeled results
+ * of the frontend for Niagara2@65nm
  *
  */
 
-MCBackend::MCBackend(InputParameter* interface_ip_, const MCParam & mcp_, enum MemoryCtrl_type mc_type_)
-:l_ip(*interface_ip_),
- mc_type(mc_type_),
- mcp(mcp_)
-{
-
+MCBackend::MCBackend(InputParameter* interface_ip_, const MCParam& mcp_,
+                     enum MemoryCtrl_type mc_type_)
+    : l_ip(*interface_ip_), mc_type(mc_type_), mcp(mcp_) {
   local_result = init_interface(&l_ip);
   compute();
-
 }
 
-
-void MCBackend::compute()
-{
-  //double max_row_addr_width = 20.0;//Current address 12~18bits
-  double C_MCB, mc_power, backend_dyn, backend_gates;//, refresh_period,refresh_freq;//Equivalent per bit Cap for backend,
+void MCBackend::compute() {
+  // double max_row_addr_width = 20.0;//Current address 12~18bits
+  double C_MCB, mc_power, backend_dyn,
+      backend_gates;  //, refresh_period,refresh_freq;//Equivalent per bit Cap
+                      //for backend,
   double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
   double NMOS_sizing, PMOS_sizing;
 
-  if (mc_type == MC)
-  {
-	  if (mcp.type == 0)
-	  {
-		  //area = (2.2927*log(peakDataTransferRate)-14.504)*memDataWidth/144.0*(l_ip.F_sz_um/0.09);
-		  area.set_area((2.7927*log(mcp.peakDataTransferRate*2)-19.862)/2.0*mcp.dataBusWidth/128.0*(l_ip.F_sz_um/0.09)*mcp.num_channels*1e6);//um^2
-		  //assuming the approximately same scaling factor as seen in processors.
-		  //C_MCB=0.2/1.3/1.3/266/64/0.09*g_ip.F_sz_um;//based on AMD Geode processor which has a very basic mc on chip.
-		  //C_MCB = 1.6/200/1e6/144/1.2/1.2*g_ip.F_sz_um/0.19;//Based on Niagara power numbers.The base power (W) is divided by device frequency and vdd and scale to target process.
-		  //mc_power = 0.0291*2;//29.1mW@200MHz @130nm From Power Analysis of SystemLevel OnChip Communication Architectures by Lahiri et
-		  mc_power = 4.32*0.1;//4.32W@1GhzMHz @65nm Cadence ChipEstimator 10% for backend
-		  C_MCB = mc_power/1e9/72/1.1/1.1*l_ip.F_sz_um/0.065;
-		  power_t.readOp.dynamic = C_MCB*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(mcp.dataBusWidth/*+mcp.addressBusWidth*/);//per access energy in memory controller
-		  power_t.readOp.leakage = area.get_area()/2 *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(g_tp.min_w_nmos_, g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd;//unit W
-		  power_t.readOp.gate_leakage = area.get_area()/2 *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(g_tp.min_w_nmos_, g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd;//unit W
+  if (mc_type == MC) {
+    if (mcp.type == 0) {
+      // area =
+      // (2.2927*log(peakDataTransferRate)-14.504)*memDataWidth/144.0*(l_ip.F_sz_um/0.09);
+      area.set_area((2.7927 * log(mcp.peakDataTransferRate * 2) - 19.862) /
+                    2.0 * mcp.dataBusWidth / 128.0 * (l_ip.F_sz_um / 0.09) *
+                    mcp.num_channels * 1e6);  // um^2
+      // assuming the approximately same scaling factor as seen in processors.
+      // C_MCB=0.2/1.3/1.3/266/64/0.09*g_ip.F_sz_um;//based on AMD Geode
+      // processor which has a very basic mc on chip.
+      // C_MCB = 1.6/200/1e6/144/1.2/1.2*g_ip.F_sz_um/0.19;//Based on Niagara
+      // power numbers.The base power (W) is divided by device frequency and vdd
+      // and scale to target process.
+      // mc_power = 0.0291*2;//29.1mW@200MHz @130nm From Power Analysis of
+      // SystemLevel OnChip Communication Architectures by Lahiri et
+      mc_power =
+          4.32 *
+          0.1;  // 4.32W@1GhzMHz @65nm Cadence ChipEstimator 10% for backend
+      C_MCB = mc_power / 1e9 / 72 / 1.1 / 1.1 * l_ip.F_sz_um / 0.065;
+      power_t.readOp.dynamic =
+          C_MCB * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd *
+          (mcp.dataBusWidth /*+mcp.addressBusWidth*/);  // per access energy in
+                                                        // memory controller
+      power_t.readOp.leakage =
+          area.get_area() / 2 * (g_tp.scaling_factor.core_tx_density) *
+          cmos_Isub_leakage(g_tp.min_w_nmos_,
+                            g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
+          g_tp.peri_global.Vdd;  // unit W
+      power_t.readOp.gate_leakage =
+          area.get_area() / 2 * (g_tp.scaling_factor.core_tx_density) *
+          cmos_Ig_leakage(g_tp.min_w_nmos_,
+                          g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
+          g_tp.peri_global.Vdd;  // unit W
 
-	  }
-	  else
-	  {   NMOS_sizing 	  = g_tp.min_w_nmos_;
-		  PMOS_sizing	  = g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
-		  area.set_area(0.15*mcp.dataBusWidth/72.0*(l_ip.F_sz_um/0.065)* (l_ip.F_sz_um/0.065)*mcp.num_channels*1e6);//um^2
-		  backend_dyn = 0.9e-9/800e6*mcp.clockRate/12800*mcp.peakDataTransferRate*mcp.dataBusWidth/72.0*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(l_ip.F_sz_nm/65.0);//Average on DDR2/3 protocol controller and DDRC 1600/800A in Cadence ChipEstimate
-		  //Scaling to technology and DIMM feature. The base IP support DDR3-1600(PC3 12800)
-		  backend_gates = 50000*mcp.dataBusWidth/64.0;//5000 is from Cadence ChipEstimator
+    } else {
+      NMOS_sizing = g_tp.min_w_nmos_;
+      PMOS_sizing = g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r;
+      area.set_area(0.15 * mcp.dataBusWidth / 72.0 * (l_ip.F_sz_um / 0.065) *
+                    (l_ip.F_sz_um / 0.065) * mcp.num_channels * 1e6);  // um^2
+      backend_dyn = 0.9e-9 / 800e6 * mcp.clockRate / 12800 *
+                    mcp.peakDataTransferRate * mcp.dataBusWidth / 72.0 *
+                    g_tp.peri_global.Vdd / 1.1 * g_tp.peri_global.Vdd / 1.1 *
+                    (l_ip.F_sz_nm / 65.0);  // Average on DDR2/3 protocol
+                                            // controller and DDRC 1600/800A in
+                                            // Cadence ChipEstimate
+      // Scaling to technology and DIMM feature. The base IP support
+      // DDR3-1600(PC3 12800)
+      backend_gates = 50000 * mcp.dataBusWidth /
+                      64.0;  // 5000 is from Cadence ChipEstimator
 
-		  power_t.readOp.dynamic = backend_dyn;
-		  power_t.readOp.leakage = (backend_gates)*cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
-		  power_t.readOp.gate_leakage = (backend_gates)*cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
-
-	  }
+      power_t.readOp.dynamic = backend_dyn;
+      power_t.readOp.leakage =
+          (backend_gates)*cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
+          g_tp.peri_global.Vdd;  // unit W
+      power_t.readOp.gate_leakage =
+          (backend_gates)*cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
+          g_tp.peri_global.Vdd;  // unit W
+    }
+  } else {  // skip old model
+    cout << "Unknown memory controllers" << endl;
+    exit(0);
+    area.set_area(0.243 * mcp.dataBusWidth /
+                  8);  // area based on Cadence ChipEstimator for 8bit bus
+    // mc_power = 4.32*0.1;//4.32W@1GhzMHz @65nm Cadence ChipEstimator 10% for
+    // backend
+    C_MCB = mc_power / 1e9 / 72 / 1.1 / 1.1 * l_ip.F_sz_um / 0.065;
+    power_t.readOp.leakage =
+        area.get_area() / 2 * (g_tp.scaling_factor.core_tx_density) *
+        cmos_Isub_leakage(g_tp.min_w_nmos_,
+                          g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
+        g_tp.peri_global.Vdd;  // unit W
+    power_t.readOp.gate_leakage =
+        area.get_area() / 2 * (g_tp.scaling_factor.core_tx_density) *
+        cmos_Ig_leakage(g_tp.min_w_nmos_,
+                        g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
+        g_tp.peri_global.Vdd;  // unit W
+    power_t.readOp.dynamic *= 1.2;
+    power_t.readOp.leakage *= 1.2;
+    power_t.readOp.gate_leakage *= 1.2;
+    // flash controller has about 20% more backend power since BCH ECC in flash
+    // is complex and power hungry
   }
-  else
-  {//skip old model
-	  cout<<"Unknown memory controllers"<<endl;exit(0);
-	  area.set_area(0.243*mcp.dataBusWidth/8);//area based on Cadence ChipEstimator for 8bit bus
-	  //mc_power = 4.32*0.1;//4.32W@1GhzMHz @65nm Cadence ChipEstimator 10% for backend
-	  C_MCB = mc_power/1e9/72/1.1/1.1*l_ip.F_sz_um/0.065;
-	  power_t.readOp.leakage = area.get_area()/2 *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(g_tp.min_w_nmos_, g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd;//unit W
-	  power_t.readOp.gate_leakage = area.get_area()/2 *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(g_tp.min_w_nmos_, g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd;//unit W
-	  power_t.readOp.dynamic *= 1.2;
-	  power_t.readOp.leakage *= 1.2;
-	  power_t.readOp.gate_leakage *= 1.2;
-	  //flash controller has about 20% more backend power since BCH ECC in flash is complex and power hungry
-  }
-  double long_channel_device_reduction = longer_channel_device_reduction(Uncore_device);
-  power_t.readOp.longer_channel_leakage = power_t.readOp.leakage * long_channel_device_reduction;
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(Uncore_device);
+  power_t.readOp.longer_channel_leakage =
+      power_t.readOp.leakage * long_channel_device_reduction;
 }
 
-void MCBackend::computeEnergy(bool is_tdp)
-{
-	//backend uses internal data buswidth
-	if (is_tdp)
-	{
-    power.reset(); //Jingwen
-		//init stats for Peak
-		stats_t.readAc.access   = 0.5*mcp.num_channels;
-		stats_t.writeAc.access  = 0.5*mcp.num_channels;
-		tdp_stats = stats_t;
-	}
-	else
-	{
-    rt_power.reset();//Jingwen
-		//init stats for runtime power (RTP)
-    //Jingwen: should use stats from XML object, modified in MemoryController::computeEnergy
-		stats_t.readAc.access   = mcp.reads;
-		stats_t.writeAc.access  = mcp.writes;
-		tdp_stats = stats_t;
-	}
-	if (is_tdp)
-    {
-		power = power_t;
-		power.readOp.dynamic	= (stats_t.readAc.access + stats_t.writeAc.access)*power_t.readOp.dynamic;
+void MCBackend::computeEnergy(bool is_tdp) {
+  // backend uses internal data buswidth
+  if (is_tdp) {
+    power.reset();  // Jingwen
+    // init stats for Peak
+    stats_t.readAc.access = 0.5 * mcp.num_channels;
+    stats_t.writeAc.access = 0.5 * mcp.num_channels;
+    tdp_stats = stats_t;
+  } else {
+    rt_power.reset();  // Jingwen
+    // init stats for runtime power (RTP)
+    // Jingwen: should use stats from XML object, modified in
+    // MemoryController::computeEnergy
+    stats_t.readAc.access = mcp.reads;
+    stats_t.writeAc.access = mcp.writes;
+    tdp_stats = stats_t;
+  }
+  if (is_tdp) {
+    power = power_t;
+    power.readOp.dynamic = (stats_t.readAc.access + stats_t.writeAc.access) *
+                           power_t.readOp.dynamic;
 
-    }
-    else
-    {
-    	rt_power.readOp.dynamic	= (stats_t.readAc.access + stats_t.writeAc.access)*mcp.llcBlockSize*8.0/mcp.dataBusWidth*power_t.readOp.dynamic;
-    	rt_power = rt_power + power_t*pppm_lkg;
-    	rt_power.readOp.dynamic = rt_power.readOp.dynamic + power.readOp.dynamic*0.1*mcp.clockRate*mcp.num_mcs*mcp.executionTime;
-    	//Assume 10% of peak power is consumed by routine job including memory refreshing and scrubbing
-    }
+  } else {
+    rt_power.readOp.dynamic = (stats_t.readAc.access + stats_t.writeAc.access) *
+                              mcp.llcBlockSize * 8.0 / mcp.dataBusWidth *
+                              power_t.readOp.dynamic;
+    rt_power = rt_power + power_t * pppm_lkg;
+    rt_power.readOp.dynamic = rt_power.readOp.dynamic +
+                              power.readOp.dynamic * 0.1 * mcp.clockRate *
+                                  mcp.num_mcs * mcp.executionTime;
+    // Assume 10% of peak power is consumed by routine job including memory
+    // refreshing and scrubbing
+  }
 }
 
-
-MCPHY::MCPHY(InputParameter* interface_ip_, const MCParam & mcp_, enum MemoryCtrl_type mc_type_)
-:l_ip(*interface_ip_),
- mc_type(mc_type_),
- mcp(mcp_)
-{
-
+MCPHY::MCPHY(InputParameter* interface_ip_, const MCParam& mcp_,
+             enum MemoryCtrl_type mc_type_)
+    : l_ip(*interface_ip_), mc_type(mc_type_), mcp(mcp_) {
   local_result = init_interface(&l_ip);
   compute();
 }
 
-void MCPHY::compute()
-{
-  //PHY uses internal data buswidth but the actuall off-chip datawidth is 64bits + ecc
-  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio() ;
+void MCPHY::compute() {
+  // PHY uses internal data buswidth but the actuall off-chip datawidth is
+  // 64bits + ecc
+  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
   /*
-   * according to "A 100mW 9.6Gb/s Transceiver in 90nm CMOS for next-generation memory interfaces ," ISSCC 2006;
+   * according to "A 100mW 9.6Gb/s Transceiver in 90nm CMOS for next-generation
+   * memory interfaces ," ISSCC 2006;
    * From Cadence ChipEstimator for normal I/O around 0.4~0.8 mW/Gb/s
    */
-  double power_per_gb_per_s,phy_gates, NMOS_sizing, PMOS_sizing;
+  double power_per_gb_per_s, phy_gates, NMOS_sizing, PMOS_sizing;
 
-  if (mc_type == MC)
-  {
-	  if (mcp.type == 0)
-	  {
-		  power_per_gb_per_s = mcp.LVDS? 0.01:0.04;
-		  //Based on die photos from Niagara 1 and 2.
-		  //TODO merge this into undifferentiated core.PHY only achieves square root of the ideal scaling.
-		  //area = (6.4323*log(peakDataTransferRate)-34.76)*memDataWidth/128.0*(l_ip.F_sz_um/0.09);
-		  area.set_area((6.4323*log(mcp.peakDataTransferRate*2)-48.134)*mcp.dataBusWidth/128.0*(l_ip.F_sz_um/0.09)*mcp.num_channels*1e6/2);//TODO:/2
-		  //This is from curve fitting based on Niagara 1 and 2's PHY die photo.
-		  //This is power not energy, 10mw/Gb/s @90nm for each channel and scaling down
-		  //power.readOp.dynamic = 0.02*memAccesses*llcBlocksize*8;//change from Bytes to bits.
-		  power_t.readOp.dynamic = power_per_gb_per_s*sqrt(l_ip.F_sz_um/0.09)*g_tp.peri_global.Vdd/1.2*g_tp.peri_global.Vdd/1.2;
-		  power_t.readOp.leakage = area.get_area()/2 *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(g_tp.min_w_nmos_, g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd;//unit W
-		  power_t.readOp.gate_leakage = area.get_area()/2 *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(g_tp.min_w_nmos_, g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd;//unit W
+  if (mc_type == MC) {
+    if (mcp.type == 0) {
+      power_per_gb_per_s = mcp.LVDS ? 0.01 : 0.04;
+      // Based on die photos from Niagara 1 and 2.
+      // TODO merge this into undifferentiated core.PHY only achieves square
+      // root of the ideal scaling.
+      // area =
+      // (6.4323*log(peakDataTransferRate)-34.76)*memDataWidth/128.0*(l_ip.F_sz_um/0.09);
+      area.set_area((6.4323 * log(mcp.peakDataTransferRate * 2) - 48.134) *
+                    mcp.dataBusWidth / 128.0 * (l_ip.F_sz_um / 0.09) *
+                    mcp.num_channels * 1e6 / 2);  // TODO:/2
+      // This is from curve fitting based on Niagara 1 and 2's PHY die photo.
+      // This is power not energy, 10mw/Gb/s @90nm for each channel and scaling
+      // down
+      // power.readOp.dynamic = 0.02*memAccesses*llcBlocksize*8;//change from
+      // Bytes to bits.
+      power_t.readOp.dynamic = power_per_gb_per_s * sqrt(l_ip.F_sz_um / 0.09) *
+                               g_tp.peri_global.Vdd / 1.2 *
+                               g_tp.peri_global.Vdd / 1.2;
+      power_t.readOp.leakage =
+          area.get_area() / 2 * (g_tp.scaling_factor.core_tx_density) *
+          cmos_Isub_leakage(g_tp.min_w_nmos_,
+                            g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
+          g_tp.peri_global.Vdd;  // unit W
+      power_t.readOp.gate_leakage =
+          area.get_area() / 2 * (g_tp.scaling_factor.core_tx_density) *
+          cmos_Ig_leakage(g_tp.min_w_nmos_,
+                          g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
+          g_tp.peri_global.Vdd;  // unit W
 
-	  }
-	  else
-	  {
-		  NMOS_sizing 	  = g_tp.min_w_nmos_;
-		  PMOS_sizing	  = g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
-		  //Designware/synopsis 16bit DDR3 PHY is 1.3mm (WITH IOs) at 40nm for upto DDR3 2133 (PC3 17066)
-		  double non_IO_percentage = 0.2;
-		  area.set_area(1.3*non_IO_percentage/2133.0e6*mcp.clockRate/17066*mcp.peakDataTransferRate*mcp.dataBusWidth/16.0*(l_ip.F_sz_um/0.040)* (l_ip.F_sz_um/0.040)*mcp.num_channels*1e6);//um^2
-		  phy_gates = 200000*mcp.dataBusWidth/64.0;
-		  power_per_gb_per_s = 0.01;
-		  //This is power not energy, 10mw/Gb/s @90nm for each channel and scaling down
-		  power_t.readOp.dynamic = power_per_gb_per_s*(l_ip.F_sz_um/0.09)*g_tp.peri_global.Vdd/1.2*g_tp.peri_global.Vdd/1.2;
-		  power_t.readOp.leakage = (mcp.withPHY? phy_gates:0)*cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
-		  power_t.readOp.gate_leakage = (mcp.withPHY? phy_gates:0)*cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
-	  }
+    } else {
+      NMOS_sizing = g_tp.min_w_nmos_;
+      PMOS_sizing = g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r;
+      // Designware/synopsis 16bit DDR3 PHY is 1.3mm (WITH IOs) at 40nm for upto
+      // DDR3 2133 (PC3 17066)
+      double non_IO_percentage = 0.2;
+      area.set_area(1.3 * non_IO_percentage / 2133.0e6 * mcp.clockRate / 17066 *
+                    mcp.peakDataTransferRate * mcp.dataBusWidth / 16.0 *
+                    (l_ip.F_sz_um / 0.040) * (l_ip.F_sz_um / 0.040) *
+                    mcp.num_channels * 1e6);  // um^2
+      phy_gates = 200000 * mcp.dataBusWidth / 64.0;
+      power_per_gb_per_s = 0.01;
+      // This is power not energy, 10mw/Gb/s @90nm for each channel and scaling
+      // down
+      power_t.readOp.dynamic = power_per_gb_per_s * (l_ip.F_sz_um / 0.09) *
+                               g_tp.peri_global.Vdd / 1.2 *
+                               g_tp.peri_global.Vdd / 1.2;
+      power_t.readOp.leakage =
+          (mcp.withPHY ? phy_gates : 0) *
+          cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
+          g_tp.peri_global.Vdd;  // unit W
+      power_t.readOp.gate_leakage =
+          (mcp.withPHY ? phy_gates : 0) *
+          cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
+          g_tp.peri_global.Vdd;  // unit W
+    }
 
+  } else {
+    area.set_area(0.4e6 / 2 * mcp.dataBusWidth /
+                  8);  // area based on Cadence ChipEstimator for 8bit bus
   }
-  else
-  {
-	  area.set_area(0.4e6/2*mcp.dataBusWidth/8);//area based on Cadence ChipEstimator for 8bit bus
-  }
 
-//  double phy_factor = (int)ceil(mcp.dataBusWidth/72.0);//Previous phy power numbers are based on 72 bit DIMM interface
-//  power_t.readOp.dynamic *= phy_factor;
-//  power_t.readOp.leakage *= phy_factor;
-//  power_t.readOp.gate_leakage *= phy_factor;
+  //  double phy_factor = (int)ceil(mcp.dataBusWidth/72.0);//Previous phy power
+  //  numbers are based on 72 bit DIMM interface
+  //  power_t.readOp.dynamic *= phy_factor;
+  //  power_t.readOp.leakage *= phy_factor;
+  //  power_t.readOp.gate_leakage *= phy_factor;
 
-  double long_channel_device_reduction = longer_channel_device_reduction(Uncore_device);
-  power_t.readOp.longer_channel_leakage = power_t.readOp.leakage * long_channel_device_reduction;
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(Uncore_device);
+  power_t.readOp.longer_channel_leakage =
+      power_t.readOp.leakage * long_channel_device_reduction;
 }
 
+void MCPHY::computeEnergy(bool is_tdp) {
+  if (is_tdp) {
+    power.reset();  // Jingwen
+    // init stats for Peak
+    stats_t.readAc.access = 0.5 * mcp.num_channels;  // time share on buses
+    stats_t.writeAc.access = 0.5 * mcp.num_channels;
+    tdp_stats = stats_t;
+  } else {
+    rt_power.reset();  // Jingwen
+    // init stats for runtime power (RTP)
+    // Jingwen: should use stats from XML object, modified in
+    // MemoryController::computeEnergy
+    stats_t.readAc.access = mcp.reads;
+    stats_t.writeAc.access = mcp.writes;
+    tdp_stats = stats_t;
+  }
 
-void MCPHY::computeEnergy(bool is_tdp)
-{
-	if (is_tdp)
-	{
-    power.reset(); //Jingwen
-		//init stats for Peak
-		stats_t.readAc.access   = 0.5*mcp.num_channels; //time share on buses
-		stats_t.writeAc.access  = 0.5*mcp.num_channels;
-		tdp_stats = stats_t;
-	}
-	else
-	{
-    rt_power.reset(); //Jingwen
-		//init stats for runtime power (RTP)
-    //Jingwen: should use stats from XML object, modified in MemoryController::computeEnergy
-		stats_t.readAc.access   = mcp.reads;
-		stats_t.writeAc.access  = mcp.writes;
-		tdp_stats = stats_t;
-	}
+  if (is_tdp) {
+    double data_transfer_unit = (mc_type == MC) ? 72 : 16; /*DIMM data width*/
+    power = power_t;
+    power.readOp.dynamic =
+        power.readOp.dynamic *
+        (mcp.peakDataTransferRate * 8 * 1e6 / 1e9 /*change to Gbs*/) *
+        mcp.dataBusWidth / data_transfer_unit * mcp.num_channels /
+        mcp.clockRate;
+    // divide by clock rate is for match the final computation where *clock is
+    // used
+    //(stats_t.readAc.access*power_t.readOp.dynamic+
+    //					stats_t.writeAc.access*power_t.readOp.dynamic);
 
-	if (is_tdp)
-    {
-		double data_transfer_unit = (mc_type == MC)? 72:16;/*DIMM data width*/
-		power = power_t;
-		power.readOp.dynamic	= power.readOp.dynamic * (mcp.peakDataTransferRate*8*1e6/1e9/*change to Gbs*/)*mcp.dataBusWidth/data_transfer_unit*mcp.num_channels/mcp.clockRate;
-		// divide by clock rate is for match the final computation where *clock is used
-		//(stats_t.readAc.access*power_t.readOp.dynamic+
-//					stats_t.writeAc.access*power_t.readOp.dynamic);
+  } else {
+    rt_power = power_t;
+    //    	rt_power.readOp.dynamic	=
+    //    (stats_t.readAc.access*power_t.readOp.dynamic+
+    //    						stats_t.writeAc.access*power_t.readOp.dynamic);
 
-    }
-    else
-    {
-    	rt_power = power_t;
-//    	rt_power.readOp.dynamic	= (stats_t.readAc.access*power_t.readOp.dynamic+
-//    						stats_t.writeAc.access*power_t.readOp.dynamic);
-
-    	rt_power.readOp.dynamic=power_t.readOp.dynamic*(stats_t.readAc.access + stats_t.writeAc.access)*(mcp.llcBlockSize)*8/1e9/mcp.executionTime*(mcp.executionTime);
-    	rt_power.readOp.dynamic = rt_power.readOp.dynamic + power.readOp.dynamic*0.1*mcp.clockRate*mcp.num_mcs*mcp.executionTime;
-    }
+    rt_power.readOp.dynamic = power_t.readOp.dynamic *
+                              (stats_t.readAc.access + stats_t.writeAc.access) *
+                              (mcp.llcBlockSize) * 8 / 1e9 / mcp.executionTime *
+                              (mcp.executionTime);
+    rt_power.readOp.dynamic = rt_power.readOp.dynamic +
+                              power.readOp.dynamic * 0.1 * mcp.clockRate *
+                                  mcp.num_mcs * mcp.executionTime;
+  }
 }
 
-MCFrontEnd::MCFrontEnd(ParseXML *XML_interface,InputParameter* interface_ip_, const MCParam & mcp_, enum MemoryCtrl_type mc_type_)
-:XML(XML_interface),
- interface_ip(*interface_ip_),
- mc_type(mc_type_),
- mcp(mcp_),
- MC_arb(0),
- frontendBuffer(0),
- readBuffer(0),
- writeBuffer(0),
- coalesce_scale(1.0)
-{
+MCFrontEnd::MCFrontEnd(ParseXML* XML_interface, InputParameter* interface_ip_,
+                       const MCParam& mcp_, enum MemoryCtrl_type mc_type_)
+    : XML(XML_interface),
+      interface_ip(*interface_ip_),
+      mc_type(mc_type_),
+      mcp(mcp_),
+      MC_arb(0),
+      frontendBuffer(0),
+      readBuffer(0),
+      writeBuffer(0),
+      coalesce_scale(1.0) {
   /* All computations are for a single MC
    *
    */
 
   int tag, data;
-  bool is_default =true;//indication for default setup
+  bool is_default = true;  // indication for default setup
 
-  /* MC frontend engine channels share the same engines but logically partitioned
+  /* MC frontend engine channels share the same engines but logically
+   * partitioned
    * For all hardware inside MC. different channels do not share resources.
-   * TODO: add docodeing/mux stage to steer memory requests to different channels.
+   * TODO: add docodeing/mux stage to steer memory requests to different
+   * channels.
    */
 
-  //memory request reorder buffer
-  tag							   = mcp.addressBusWidth  + EXTRA_TAG_BITS + mcp.opcodeW;
-  data    					 	   = int(ceil((XML->sys.physical_address_width + mcp.opcodeW)/8.0));
-  interface_ip.cache_sz            = data*XML->sys.mc.req_window_size_per_channel;
-  interface_ip.line_sz             = data;
-  interface_ip.assoc               = 0;
-  interface_ip.nbanks              = 1;
-  interface_ip.out_w               = interface_ip.line_sz*8;
-  interface_ip.specific_tag        = 1;
-  interface_ip.tag_w               = tag;
-  interface_ip.access_mode         = 0;
-  interface_ip.throughput          = 1.0/mcp.clockRate;
-  interface_ip.latency             = 1.0/mcp.clockRate;
-  interface_ip.is_cache			   = true;
-  interface_ip.pure_cam            = false;
-  interface_ip.pure_ram            = false;
+  // memory request reorder buffer
+  tag = mcp.addressBusWidth + EXTRA_TAG_BITS + mcp.opcodeW;
+  data = int(ceil((XML->sys.physical_address_width + mcp.opcodeW) / 8.0));
+  interface_ip.cache_sz = data * XML->sys.mc.req_window_size_per_channel;
+  interface_ip.line_sz = data;
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.access_mode = 0;
+  interface_ip.throughput = 1.0 / mcp.clockRate;
+  interface_ip.latency = 1.0 / mcp.clockRate;
+  interface_ip.is_cache = true;
+  interface_ip.pure_cam = false;
+  interface_ip.pure_ram = false;
   interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power  = 0;
+  interface_ip.obj_func_dyn_power = 0;
   interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t    = 1;
-  interface_ip.num_rw_ports        = 0;
-  interface_ip.num_rd_ports        = XML->sys.mc.memory_channels_per_mc;
-  interface_ip.num_wr_ports        = interface_ip.num_rd_ports;
-  interface_ip.num_se_rd_ports     = 0;
-  interface_ip.num_search_ports     = XML->sys.mc.memory_channels_per_mc;
-  frontendBuffer = new ArrayST(&interface_ip, "MC ReorderBuffer", Uncore_device);
-  frontendBuffer->area.set_area(frontendBuffer->area.get_area()+ frontendBuffer->local_result.area*XML->sys.mc.memory_channels_per_mc);
-  area.set_area(area.get_area()+ frontendBuffer->local_result.area*XML->sys.mc.memory_channels_per_mc);
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = 0;
+  interface_ip.num_rd_ports = XML->sys.mc.memory_channels_per_mc;
+  interface_ip.num_wr_ports = interface_ip.num_rd_ports;
+  interface_ip.num_se_rd_ports = 0;
+  interface_ip.num_search_ports = XML->sys.mc.memory_channels_per_mc;
+  frontendBuffer =
+      new ArrayST(&interface_ip, "MC ReorderBuffer", Uncore_device);
+  frontendBuffer->area.set_area(frontendBuffer->area.get_area() +
+                                frontendBuffer->local_result.area *
+                                    XML->sys.mc.memory_channels_per_mc);
+  area.set_area(area.get_area() +
+                frontendBuffer->local_result.area *
+                    XML->sys.mc.memory_channels_per_mc);
 
-  //selection and arbitration logic
-  MC_arb = new selection_logic(is_default, XML->sys.mc.req_window_size_per_channel,1,&interface_ip, Uncore_device);
+  // selection and arbitration logic
+  MC_arb =
+      new selection_logic(is_default, XML->sys.mc.req_window_size_per_channel,
+                          1, &interface_ip, Uncore_device);
 
-  //read buffers.
-  data    					 	   = (int)ceil(mcp.dataBusWidth/8.0);//Support key words first operation //8 means converting bit to Byte
-  interface_ip.cache_sz            = data*XML->sys.mc.IO_buffer_size_per_channel;//*llcBlockSize;
-  interface_ip.line_sz             = data;
-  interface_ip.assoc               = 1;
-  interface_ip.nbanks              = 1;
-  interface_ip.out_w               = interface_ip.line_sz*8;
-  interface_ip.access_mode         = 1;
-  interface_ip.throughput          = 1.0/mcp.clockRate;
-  interface_ip.latency             = 2.0/mcp.clockRate;
-  interface_ip.is_cache			   = false;
-  interface_ip.pure_cam            = false;
-  interface_ip.pure_ram            = true;
+  // read buffers.
+  data = (int)ceil(mcp.dataBusWidth / 8.0);  // Support key words first
+                                             // operation //8 means converting
+                                             // bit to Byte
+  interface_ip.cache_sz =
+      data * XML->sys.mc.IO_buffer_size_per_channel;  //*llcBlockSize;
+  interface_ip.line_sz = data;
+  interface_ip.assoc = 1;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 1;
+  interface_ip.throughput = 1.0 / mcp.clockRate;
+  interface_ip.latency = 2.0 / mcp.clockRate;
+  interface_ip.is_cache = false;
+  interface_ip.pure_cam = false;
+  interface_ip.pure_ram = true;
   interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power  = 0;
+  interface_ip.obj_func_dyn_power = 0;
   interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t    = 1;
-  interface_ip.num_rw_ports        = 0;//XML->sys.mc.memory_channels_per_mc*2>2?2:XML->sys.mc.memory_channels_per_mc*2;
-  interface_ip.num_rd_ports        = XML->sys.mc.memory_channels_per_mc;
-  interface_ip.num_wr_ports        = interface_ip.num_rd_ports;
-  interface_ip.num_se_rd_ports     = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports =
+      0;  // XML->sys.mc.memory_channels_per_mc*2>2?2:XML->sys.mc.memory_channels_per_mc*2;
+  interface_ip.num_rd_ports = XML->sys.mc.memory_channels_per_mc;
+  interface_ip.num_wr_ports = interface_ip.num_rd_ports;
+  interface_ip.num_se_rd_ports = 0;
   readBuffer = new ArrayST(&interface_ip, "MC ReadBuffer", Uncore_device);
-  readBuffer->area.set_area(readBuffer->area.get_area()+ readBuffer->local_result.area*XML->sys.mc.memory_channels_per_mc);
-  area.set_area(area.get_area()+ readBuffer->local_result.area*XML->sys.mc.memory_channels_per_mc);
+  readBuffer->area.set_area(readBuffer->area.get_area() +
+                            readBuffer->local_result.area *
+                                XML->sys.mc.memory_channels_per_mc);
+  area.set_area(area.get_area() +
+                readBuffer->local_result.area *
+                    XML->sys.mc.memory_channels_per_mc);
 
-  //write buffer
-  data    					 	   = (int)ceil(mcp.dataBusWidth/8.0);//Support key words first operation //8 means converting bit to Byte
-  interface_ip.cache_sz            = data*XML->sys.mc.IO_buffer_size_per_channel;//*llcBlockSize;
-  interface_ip.line_sz             = data;
-  interface_ip.assoc               = 1;
-  interface_ip.nbanks              = 1;
-  interface_ip.out_w               = interface_ip.line_sz*8;
-  interface_ip.access_mode         = 0;
-  interface_ip.throughput          = 1.0/mcp.clockRate;
-  interface_ip.latency             = 2.0/mcp.clockRate;
+  // write buffer
+  data = (int)ceil(mcp.dataBusWidth / 8.0);  // Support key words first
+                                             // operation //8 means converting
+                                             // bit to Byte
+  interface_ip.cache_sz =
+      data * XML->sys.mc.IO_buffer_size_per_channel;  //*llcBlockSize;
+  interface_ip.line_sz = data;
+  interface_ip.assoc = 1;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 0;
+  interface_ip.throughput = 1.0 / mcp.clockRate;
+  interface_ip.latency = 2.0 / mcp.clockRate;
   interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power  = 0;
+  interface_ip.obj_func_dyn_power = 0;
   interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t    = 1;
-  interface_ip.num_rw_ports        = 0;
-  interface_ip.num_rd_ports        = XML->sys.mc.memory_channels_per_mc;
-  interface_ip.num_wr_ports        = interface_ip.num_rd_ports;
-  interface_ip.num_se_rd_ports     = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = 0;
+  interface_ip.num_rd_ports = XML->sys.mc.memory_channels_per_mc;
+  interface_ip.num_wr_ports = interface_ip.num_rd_ports;
+  interface_ip.num_se_rd_ports = 0;
   writeBuffer = new ArrayST(&interface_ip, "MC writeBuffer", Uncore_device);
-  writeBuffer->area.set_area(writeBuffer->area.get_area()+ writeBuffer->local_result.area*XML->sys.mc.memory_channels_per_mc);
-  area.set_area(area.get_area()+ writeBuffer->local_result.area*XML->sys.mc.memory_channels_per_mc);
+  writeBuffer->area.set_area(writeBuffer->area.get_area() +
+                             writeBuffer->local_result.area *
+                                 XML->sys.mc.memory_channels_per_mc);
+  area.set_area(area.get_area() +
+                writeBuffer->local_result.area *
+                    XML->sys.mc.memory_channels_per_mc);
 
-  //SRAM structures for memory coalescing --Syed Gilani
-  //Pending Request Table (base addresses, offset addresses, threads IDs), Thread Masks
+  // SRAM structures for memory coalescing --Syed Gilani
+  // Pending Request Table (base addresses, offset addresses, threads IDs),
+  // Thread Masks
   //***PRT
-  //We assume 24 bits of base address and 8 bits of offset address.
-  //THese values are used for coalesing memory requests to the same base address block.
-  //TIDs are assumed to be 8 bits
-	  /*Contents of each PRT entry
-		*
-		*  Warp ID (6 bits) | Memory address (32 bits) per thread | Request Size (2-bits) per thread |   
-		*  line size= 6+ 32*16 + 2*16  ~ 64 bytes
-		*
-		*
-		*/  
-  data    					 	   = 64;//Support key words first operation //8 means converting bit to Byte
-  interface_ip.cache_sz            = data*XML->sys.mc.PRT_entries;//PRT table;
-  interface_ip.line_sz             = data;
-  interface_ip.assoc               = 1;
-  interface_ip.nbanks              = 1;
-  interface_ip.out_w               = interface_ip.line_sz*8;
-  interface_ip.access_mode         = 0;
-  interface_ip.throughput          = 1.0/XML->sys.target_core_clockrate;
-  interface_ip.latency             = 2.0/XML->sys.target_core_clockrate;
+  // We assume 24 bits of base address and 8 bits of offset address.
+  // THese values are used for coalesing memory requests to the same base
+  // address block.
+  // TIDs are assumed to be 8 bits
+  /*Contents of each PRT entry
+        *
+        *  Warp ID (6 bits) | Memory address (32 bits) per thread | Request Size
+   * (2-bits) per thread |
+        *  line size= 6+ 32*16 + 2*16  ~ 64 bytes
+        *
+        *
+        */
+  data =
+      64;  // Support key words first operation //8 means converting bit to Byte
+  interface_ip.cache_sz = data * XML->sys.mc.PRT_entries;  // PRT table;
+  interface_ip.line_sz = data;
+  interface_ip.assoc = 1;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 0;
+  interface_ip.throughput = 1.0 / XML->sys.target_core_clockrate;
+  interface_ip.latency = 2.0 / XML->sys.target_core_clockrate;
   interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power  = 0;
+  interface_ip.obj_func_dyn_power = 0;
   interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t    = 1;
-  interface_ip.num_rw_ports        = 0;
-  interface_ip.num_rd_ports        = 1;
-  interface_ip.num_wr_ports        = 1;
-  interface_ip.num_se_rd_ports     = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = 0;
+  interface_ip.num_rd_ports = 1;
+  interface_ip.num_wr_ports = 1;
+  interface_ip.num_se_rd_ports = 0;
   PRT = new ArrayST(&interface_ip, "MC PRT", Uncore_device);
-  PRT->area.set_area(PRT->area.get_area()+ PRT->local_result.area*XML->sys.mc.memory_channels_per_mc);
-  area.set_area(area.get_area()+ PRT->local_result.area*XML->sys.mc.memory_channels_per_mc);
+  PRT->area.set_area(PRT->area.get_area() +
+                     PRT->local_result.area *
+                         XML->sys.mc.memory_channels_per_mc);
+  area.set_area(area.get_area() +
+                PRT->local_result.area * XML->sys.mc.memory_channels_per_mc);
 
-
-  //***ThreadMasks storage (coalesced threads whose memory requests are satisfied by each memory access)
-	  /* contents of the thread masks Array
-		*  16-bit bit masks for up to 16 memory requests of a warp | Number of pending memory requests (5 bits)
-		*  
-		*  16*PRT_entry thread Mask, each entry has 16 mask bits.
-		*
-		*/  
-  data    					 	   = 2;
-  interface_ip.cache_sz            = data*XML->sys.mc.PRT_entries*16;//PRT table;
-  interface_ip.line_sz             = data;
-  interface_ip.assoc               = 1;
-  interface_ip.nbanks              = 1;
-  interface_ip.out_w               = interface_ip.line_sz*8;
-  interface_ip.access_mode         = 0;
-  interface_ip.throughput          = 1.0/XML->sys.target_core_clockrate;
-  interface_ip.latency             = 2.0/XML->sys.target_core_clockrate;
+  //***ThreadMasks storage (coalesced threads whose memory requests are
+  //satisfied by each memory access)
+  /* contents of the thread masks Array
+        *  16-bit bit masks for up to 16 memory requests of a warp | Number of
+   * pending memory requests (5 bits)
+        *
+        *  16*PRT_entry thread Mask, each entry has 16 mask bits.
+        *
+        */
+  data = 2;
+  interface_ip.cache_sz = data * XML->sys.mc.PRT_entries * 16;  // PRT table;
+  interface_ip.line_sz = data;
+  interface_ip.assoc = 1;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 0;
+  interface_ip.throughput = 1.0 / XML->sys.target_core_clockrate;
+  interface_ip.latency = 2.0 / XML->sys.target_core_clockrate;
   interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power  = 0;
+  interface_ip.obj_func_dyn_power = 0;
   interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t    = 1;
-  interface_ip.num_rw_ports        = 0;
-  interface_ip.num_rd_ports        = 1;
-  interface_ip.num_wr_ports        = 1;
-  interface_ip.num_se_rd_ports     = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = 0;
+  interface_ip.num_rd_ports = 1;
+  interface_ip.num_wr_ports = 1;
+  interface_ip.num_se_rd_ports = 0;
   threadMasks = new ArrayST(&interface_ip, "MC ThreadMasks", Uncore_device);
-  threadMasks->area.set_area(threadMasks->area.get_area()+ threadMasks->local_result.area*XML->sys.mc.memory_channels_per_mc);
-  area.set_area(area.get_area()+ threadMasks->local_result.area*XML->sys.mc.memory_channels_per_mc);
+  threadMasks->area.set_area(threadMasks->area.get_area() +
+                             threadMasks->local_result.area *
+                                 XML->sys.mc.memory_channels_per_mc);
+  area.set_area(area.get_area() +
+                threadMasks->local_result.area *
+                    XML->sys.mc.memory_channels_per_mc);
 
   //***Numer of pending requests per PRT entry
-	  /* 
-		* 1-byte data, PRT entries deep
-		*/  
-  data    					 	   = 1;
-  interface_ip.cache_sz            = data*XML->sys.mc.PRT_entries;//PRT table;
-  interface_ip.line_sz             = data;
-  interface_ip.assoc               = 1;
-  interface_ip.nbanks              = 1;
-  interface_ip.out_w               = interface_ip.line_sz*8;
-  interface_ip.access_mode         = 0;
-  interface_ip.throughput          = 1.0/XML->sys.target_core_clockrate;
-  interface_ip.latency             = 2.0/XML->sys.target_core_clockrate;
+  /*
+        * 1-byte data, PRT entries deep
+        */
+  data = 1;
+  interface_ip.cache_sz = data * XML->sys.mc.PRT_entries;  // PRT table;
+  interface_ip.line_sz = data;
+  interface_ip.assoc = 1;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 0;
+  interface_ip.throughput = 1.0 / XML->sys.target_core_clockrate;
+  interface_ip.latency = 2.0 / XML->sys.target_core_clockrate;
   interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power  = 0;
+  interface_ip.obj_func_dyn_power = 0;
   interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t    = 1;
-  interface_ip.num_rw_ports        = 0;
-  interface_ip.num_rd_ports        = 1;
-  interface_ip.num_wr_ports        = 1;
-  interface_ip.num_se_rd_ports     = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = 0;
+  interface_ip.num_rd_ports = 1;
+  interface_ip.num_wr_ports = 1;
+  interface_ip.num_se_rd_ports = 0;
   PRC = new ArrayST(&interface_ip, "MC PendingRequestCount", Uncore_device);
-  PRC->area.set_area(PRC->area.get_area()+ PRC->local_result.area*XML->sys.mc.memory_channels_per_mc);
-  area.set_area(area.get_area()+ PRC->local_result.area*XML->sys.mc.memory_channels_per_mc);
-
+  PRC->area.set_area(PRC->area.get_area() +
+                     PRC->local_result.area *
+                         XML->sys.mc.memory_channels_per_mc);
+  area.set_area(area.get_area() +
+                PRC->local_result.area * XML->sys.mc.memory_channels_per_mc);
 }
 
+void DRAM::computeEnergy(bool is_tdp) {
+  if (is_tdp) {
+    power.reset();
+    return;  /// not supporting TDP calculation for DRAM
+  }
+  rt_power.reset();
+  dramp.executionTime =
+      XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);
 
-void DRAM::computeEnergy(bool is_tdp)
-{
-	if (is_tdp){
-		power.reset();
-		return; /// not supporting TDP calculation for DRAM
-	}
-	rt_power.reset();
-	dramp.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
+  power_t.reset();
+  power_t.readOp.dynamic += XML->sys.mc.memory_reads * dramp.rd_coeff;
+  power_t.readOp.dynamic += XML->sys.mc.memory_writes * dramp.wr_coeff;
+  power_t.readOp.dynamic += XML->sys.mc.dram_pre * dramp.pre_coeff;
 
-	power_t.reset();
-	power_t.readOp.dynamic+=XML->sys.mc.memory_reads*dramp.rd_coeff;
-	power_t.readOp.dynamic+=XML->sys.mc.memory_writes*dramp.wr_coeff;
-	power_t.readOp.dynamic+=XML->sys.mc.dram_pre*dramp.pre_coeff;
-
-	rt_power = rt_power + power_t ;
+  rt_power = rt_power + power_t;
 }
 
+void MCFrontEnd::computeEnergy(bool is_tdp) {
+  if (is_tdp) {
+    power.reset();
+    // init stats for Peak
+    frontendBuffer->stats_t.readAc.access =
+        frontendBuffer->l_ip.num_search_ports;
+    frontendBuffer->stats_t.writeAc.access = frontendBuffer->l_ip.num_wr_ports;
+    frontendBuffer->tdp_stats = frontendBuffer->stats_t;
 
-void MCFrontEnd::computeEnergy(bool is_tdp)
-{
-	if (is_tdp)
-	    {
-        power.reset();
-	    	//init stats for Peak
-	    	frontendBuffer->stats_t.readAc.access  = frontendBuffer->l_ip.num_search_ports;
-	    	frontendBuffer->stats_t.writeAc.access = frontendBuffer->l_ip.num_wr_ports;
-	    	frontendBuffer->tdp_stats = frontendBuffer->stats_t;
+    readBuffer->stats_t.readAc.access =
+        readBuffer->l_ip.num_rd_ports * mcp.frontend_duty_cycle;
+    readBuffer->stats_t.writeAc.access =
+        readBuffer->l_ip.num_wr_ports * mcp.frontend_duty_cycle;
+    readBuffer->tdp_stats = readBuffer->stats_t;
 
-	    	readBuffer->stats_t.readAc.access  = readBuffer->l_ip.num_rd_ports*mcp.frontend_duty_cycle;
-	    	readBuffer->stats_t.writeAc.access = readBuffer->l_ip.num_wr_ports*mcp.frontend_duty_cycle;
-	    	readBuffer->tdp_stats = readBuffer->stats_t;
+    writeBuffer->stats_t.readAc.access =
+        writeBuffer->l_ip.num_rd_ports * mcp.frontend_duty_cycle;
+    writeBuffer->stats_t.writeAc.access =
+        writeBuffer->l_ip.num_wr_ports * mcp.frontend_duty_cycle;
+    writeBuffer->tdp_stats = writeBuffer->stats_t;
 
-	    	writeBuffer->stats_t.readAc.access  = writeBuffer->l_ip.num_rd_ports*mcp.frontend_duty_cycle;
-	    	writeBuffer->stats_t.writeAc.access = writeBuffer->l_ip.num_wr_ports*mcp.frontend_duty_cycle;
-	    	writeBuffer->tdp_stats = writeBuffer->stats_t;
+    PRT->stats_t.readAc.access =
+        PRT->l_ip.num_rd_ports * mcp.frontend_duty_cycle;
+    PRT->stats_t.writeAc.access =
+        PRT->l_ip.num_wr_ports * mcp.frontend_duty_cycle;
+    PRT->tdp_stats = PRT->stats_t;
 
-			PRT->stats_t.readAc.access = PRT->l_ip.num_rd_ports*mcp.frontend_duty_cycle;
-	    	PRT->stats_t.writeAc.access = PRT->l_ip.num_wr_ports*mcp.frontend_duty_cycle;
-	    	PRT->tdp_stats = PRT->stats_t;
-			
-			threadMasks->stats_t.readAc.access = threadMasks->l_ip.num_rd_ports*mcp.frontend_duty_cycle;
-	    	threadMasks->stats_t.writeAc.access = threadMasks->l_ip.num_wr_ports*mcp.frontend_duty_cycle;
-	    	threadMasks->tdp_stats = threadMasks->stats_t;
-			
-			PRC->stats_t.readAc.access = threadMasks->l_ip.num_rd_ports*mcp.frontend_duty_cycle;
-	    	PRC->stats_t.writeAc.access = threadMasks->l_ip.num_wr_ports*mcp.frontend_duty_cycle;
-	    	PRC->tdp_stats = threadMasks->stats_t;
+    threadMasks->stats_t.readAc.access =
+        threadMasks->l_ip.num_rd_ports * mcp.frontend_duty_cycle;
+    threadMasks->stats_t.writeAc.access =
+        threadMasks->l_ip.num_wr_ports * mcp.frontend_duty_cycle;
+    threadMasks->tdp_stats = threadMasks->stats_t;
 
-	    }
-	    else
-	    {
-        rt_power.reset(); //Jingwen
-	    	//init stats for runtime power (RTP)
-	    	frontendBuffer->stats_t.readAc.access  = XML->sys.mc.memory_reads *mcp.llcBlockSize*8.0/mcp.dataBusWidth*mcp.dataBusWidth/72;
-	    	//For each channel, each memory word need to check the address data to achieve best scheduling results.
-	    	//and this need to be done on all physical DIMMs in each logical memory DIMM *mcp.dataBusWidth/72
-	    	frontendBuffer->stats_t.writeAc.access = XML->sys.mc.memory_writes*mcp.llcBlockSize*8.0/mcp.dataBusWidth*mcp.dataBusWidth/72;
-	    	frontendBuffer->rtp_stats = frontendBuffer->stats_t;
+    PRC->stats_t.readAc.access =
+        threadMasks->l_ip.num_rd_ports * mcp.frontend_duty_cycle;
+    PRC->stats_t.writeAc.access =
+        threadMasks->l_ip.num_wr_ports * mcp.frontend_duty_cycle;
+    PRC->tdp_stats = threadMasks->stats_t;
 
-	    	readBuffer->stats_t.readAc.access  = XML->sys.mc.memory_reads*mcp.llcBlockSize*8.0/mcp.dataBusWidth;//support key word first
-	    	readBuffer->stats_t.writeAc.access = XML->sys.mc.memory_reads*mcp.llcBlockSize*8.0/mcp.dataBusWidth;//support key word first
-	    	readBuffer->rtp_stats = readBuffer->stats_t;
+  } else {
+    rt_power.reset();  // Jingwen
+    // init stats for runtime power (RTP)
+    frontendBuffer->stats_t.readAc.access =
+        XML->sys.mc.memory_reads * mcp.llcBlockSize * 8.0 / mcp.dataBusWidth *
+        mcp.dataBusWidth / 72;
+    // For each channel, each memory word need to check the address data to
+    // achieve best scheduling results.
+    // and this need to be done on all physical DIMMs in each logical memory
+    // DIMM *mcp.dataBusWidth/72
+    frontendBuffer->stats_t.writeAc.access =
+        XML->sys.mc.memory_writes * mcp.llcBlockSize * 8.0 / mcp.dataBusWidth *
+        mcp.dataBusWidth / 72;
+    frontendBuffer->rtp_stats = frontendBuffer->stats_t;
 
-	    	writeBuffer->stats_t.readAc.access  = XML->sys.mc.memory_writes*mcp.llcBlockSize*8.0/mcp.dataBusWidth;
-	    	writeBuffer->stats_t.writeAc.access = XML->sys.mc.memory_writes*mcp.llcBlockSize*8.0/mcp.dataBusWidth;
-	    	writeBuffer->rtp_stats = writeBuffer->stats_t;
-	    	
-			//Pending request table
-			//Co-alesce all misses in caches and add an entry for them in PRT
-			//TODO: Change 0 to ithCore and move to LSU (Syed)
-			//TODO: Do these accesses represent coalesced accesses?
-			PRT->stats_t.readAc.access  = XML->sys.core[0].dcache.read_accesses + XML->sys.core[0].ccache.read_accesses +
-			                               XML->sys.core[0].tcache.read_accesses;
-	    	PRT->stats_t.writeAc.access = XML->sys.core[0].dcache.write_accesses + XML->sys.core[0].ccache.write_accesses +
-			                               XML->sys.core[0].tcache.write_accesses;
-	    	PRT->rtp_stats = PRT->stats_t;
-			
-			threadMasks->stats_t.readAc.access  = XML->sys.core[0].dcache.read_accesses + XML->sys.core[0].ccache.read_accesses +
-			                               XML->sys.core[0].tcache.read_accesses;
-	    	threadMasks->stats_t.writeAc.access = XML->sys.core[0].dcache.write_accesses + XML->sys.core[0].ccache.write_accesses +
-			                               XML->sys.core[0].tcache.write_accesses;
-	    	threadMasks->rtp_stats = threadMasks->stats_t;
+    readBuffer->stats_t.readAc.access =
+        XML->sys.mc.memory_reads * mcp.llcBlockSize * 8.0 /
+        mcp.dataBusWidth;  // support key word first
+    readBuffer->stats_t.writeAc.access =
+        XML->sys.mc.memory_reads * mcp.llcBlockSize * 8.0 /
+        mcp.dataBusWidth;  // support key word first
+    readBuffer->rtp_stats = readBuffer->stats_t;
 
-			PRC->stats_t.readAc.access  = XML->sys.core[0].dcache.read_accesses + XML->sys.core[0].ccache.read_accesses +
-			                               XML->sys.core[0].tcache.read_accesses;
-	    	PRC->stats_t.writeAc.access = XML->sys.core[0].dcache.write_accesses + XML->sys.core[0].ccache.write_accesses +
-			                               XML->sys.core[0].tcache.write_accesses;
-	    	PRC->rtp_stats = threadMasks->stats_t;
+    writeBuffer->stats_t.readAc.access =
+        XML->sys.mc.memory_writes * mcp.llcBlockSize * 8.0 / mcp.dataBusWidth;
+    writeBuffer->stats_t.writeAc.access =
+        XML->sys.mc.memory_writes * mcp.llcBlockSize * 8.0 / mcp.dataBusWidth;
+    writeBuffer->rtp_stats = writeBuffer->stats_t;
 
-	    }
+    // Pending request table
+    // Co-alesce all misses in caches and add an entry for them in PRT
+    // TODO: Change 0 to ithCore and move to LSU (Syed)
+    // TODO: Do these accesses represent coalesced accesses?
+    PRT->stats_t.readAc.access = XML->sys.core[0].dcache.read_accesses +
+                                 XML->sys.core[0].ccache.read_accesses +
+                                 XML->sys.core[0].tcache.read_accesses;
+    PRT->stats_t.writeAc.access = XML->sys.core[0].dcache.write_accesses +
+                                  XML->sys.core[0].ccache.write_accesses +
+                                  XML->sys.core[0].tcache.write_accesses;
+    PRT->rtp_stats = PRT->stats_t;
 
-	frontendBuffer->power_t.reset();
-	readBuffer->power_t.reset();
-	writeBuffer->power_t.reset();
-    threadMasks->power_t.reset();
-    PRT->power_t.reset();
-	PRC->power_t.reset();
+    threadMasks->stats_t.readAc.access = XML->sys.core[0].dcache.read_accesses +
+                                         XML->sys.core[0].ccache.read_accesses +
+                                         XML->sys.core[0].tcache.read_accesses;
+    threadMasks->stats_t.writeAc.access =
+        XML->sys.core[0].dcache.write_accesses +
+        XML->sys.core[0].ccache.write_accesses +
+        XML->sys.core[0].tcache.write_accesses;
+    threadMasks->rtp_stats = threadMasks->stats_t;
 
-//	frontendBuffer->power_t.readOp.dynamic	+= (frontendBuffer->stats_t.readAc.access*
-//			(frontendBuffer->local_result.power.searchOp.dynamic+frontendBuffer->local_result.power.readOp.dynamic)+
-//    		frontendBuffer->stats_t.writeAc.access*frontendBuffer->local_result.power.writeOp.dynamic);
+    PRC->stats_t.readAc.access = XML->sys.core[0].dcache.read_accesses +
+                                 XML->sys.core[0].ccache.read_accesses +
+                                 XML->sys.core[0].tcache.read_accesses;
+    PRC->stats_t.writeAc.access = XML->sys.core[0].dcache.write_accesses +
+                                  XML->sys.core[0].ccache.write_accesses +
+                                  XML->sys.core[0].tcache.write_accesses;
+    PRC->rtp_stats = threadMasks->stats_t;
+  }
 
-	frontendBuffer->power_t.readOp.dynamic	+= (frontendBuffer->stats_t.readAc.access +
-			frontendBuffer->stats_t.writeAc.access)*frontendBuffer->local_result.power.searchOp.dynamic+
-		    frontendBuffer->stats_t.readAc.access * frontendBuffer->local_result.power.readOp.dynamic+
-		    frontendBuffer->stats_t.writeAc.access*frontendBuffer->local_result.power.writeOp.dynamic;
+  frontendBuffer->power_t.reset();
+  readBuffer->power_t.reset();
+  writeBuffer->power_t.reset();
+  threadMasks->power_t.reset();
+  PRT->power_t.reset();
+  PRC->power_t.reset();
 
-	readBuffer->power_t.readOp.dynamic	+= (readBuffer->stats_t.readAc.access*
-			readBuffer->local_result.power.readOp.dynamic+
-    		readBuffer->stats_t.writeAc.access*readBuffer->local_result.power.writeOp.dynamic);
-	writeBuffer->power_t.readOp.dynamic	+= (writeBuffer->stats_t.readAc.access*
-			writeBuffer->local_result.power.readOp.dynamic+
-    		writeBuffer->stats_t.writeAc.access*writeBuffer->local_result.power.writeOp.dynamic);
+  //	frontendBuffer->power_t.readOp.dynamic	+=
+  //(frontendBuffer->stats_t.readAc.access*
+  //			(frontendBuffer->local_result.power.searchOp.dynamic+frontendBuffer->local_result.power.readOp.dynamic)+
+  //    		frontendBuffer->stats_t.writeAc.access*frontendBuffer->local_result.power.writeOp.dynamic);
 
-	PRT->power_t.readOp.dynamic	+= (PRT->stats_t.readAc.access*
-			PRT->local_result.power.readOp.dynamic+
-    		PRT->stats_t.writeAc.access*PRT->local_result.power.writeOp.dynamic);
+  frontendBuffer->power_t.readOp.dynamic +=
+      (frontendBuffer->stats_t.readAc.access +
+       frontendBuffer->stats_t.writeAc.access) *
+          frontendBuffer->local_result.power.searchOp.dynamic +
+      frontendBuffer->stats_t.readAc.access *
+          frontendBuffer->local_result.power.readOp.dynamic +
+      frontendBuffer->stats_t.writeAc.access *
+          frontendBuffer->local_result.power.writeOp.dynamic;
 
-	threadMasks->power_t.readOp.dynamic	+= (threadMasks->stats_t.readAc.access*
-			threadMasks->local_result.power.readOp.dynamic+
-    		threadMasks->stats_t.writeAc.access*threadMasks->local_result.power.writeOp.dynamic);
+  readBuffer->power_t.readOp.dynamic +=
+      (readBuffer->stats_t.readAc.access *
+           readBuffer->local_result.power.readOp.dynamic +
+       readBuffer->stats_t.writeAc.access *
+           readBuffer->local_result.power.writeOp.dynamic);
+  writeBuffer->power_t.readOp.dynamic +=
+      (writeBuffer->stats_t.readAc.access *
+           writeBuffer->local_result.power.readOp.dynamic +
+       writeBuffer->stats_t.writeAc.access *
+           writeBuffer->local_result.power.writeOp.dynamic);
 
-	PRC->power_t.readOp.dynamic	+= (PRC->stats_t.readAc.access*
-			PRC->local_result.power.readOp.dynamic+
-    		PRC->stats_t.writeAc.access*PRC->local_result.power.writeOp.dynamic);
+  PRT->power_t.readOp.dynamic +=
+      (PRT->stats_t.readAc.access * PRT->local_result.power.readOp.dynamic +
+       PRT->stats_t.writeAc.access * PRT->local_result.power.writeOp.dynamic);
 
-		//Add coalescing logic power (Estimated from Verilog HDL description and Synopsys PowerCompiler)--Syed
- #define COALESCE_SCALE 1
-	double perAccessCoalescingEnergy=coalesce_scale * ((0.443e-3)*(0.5e-9)*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd)/(1*1);
-	threadMasks->power_t.readOp.dynamic += (threadMasks->stats_t.readAc.access+threadMasks->stats_t.writeAc.access)*perAccessCoalescingEnergy;
+  threadMasks->power_t.readOp.dynamic +=
+      (threadMasks->stats_t.readAc.access *
+           threadMasks->local_result.power.readOp.dynamic +
+       threadMasks->stats_t.writeAc.access *
+           threadMasks->local_result.power.writeOp.dynamic);
 
-	//printf("***PRT: %10.30f, threadMasks: %10.30f, PRC: %10.30f\n",PRT->power_t.readOp.dynamic,threadMasks->power_t.readOp.dynamic,PRC->power_t.readOp.dynamic);
-	//printf("***Accesses: read:%lf write:%lf\n",threadMasks->stats_t.readAc.access, threadMasks->stats_t.writeAc.access);
-	if (is_tdp)
-    {
-    	power = power + frontendBuffer->power_t + readBuffer->power_t + writeBuffer->power_t + PRT->power_t  + threadMasks->power_t +
-               PRC->power_t +
-		        (frontendBuffer->local_result.power +
-    	        		readBuffer->local_result.power +
-    	        		writeBuffer->local_result.power+PRT->local_result.power+
-						threadMasks->local_result.power+PRC->local_result.power)*pppm_lkg;
-		
+  PRC->power_t.readOp.dynamic +=
+      (PRC->stats_t.readAc.access * PRC->local_result.power.readOp.dynamic +
+       PRC->stats_t.writeAc.access * PRC->local_result.power.writeOp.dynamic);
 
-    }
-    else
-    {
-    	rt_power = rt_power + frontendBuffer->power_t + readBuffer->power_t + writeBuffer->power_t + PRT->power_t + threadMasks->power_t +
-		         PRC->power_t+
-    	         (frontendBuffer->local_result.power +
-    	        		readBuffer->local_result.power +
-    	        		writeBuffer->local_result.power + PRT->local_result.power + threadMasks->local_result.power+
-						PRC->local_result.power)*pppm_lkg;
-    	rt_power.readOp.dynamic = rt_power.readOp.dynamic + power.readOp.dynamic*0.1*mcp.clockRate*mcp.num_mcs*mcp.executionTime;
-    }
+// Add coalescing logic power (Estimated from Verilog HDL description and
+// Synopsys PowerCompiler)--Syed
+#define COALESCE_SCALE 1
+  double perAccessCoalescingEnergy =
+      coalesce_scale *
+      ((0.443e-3) * (0.5e-9) * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd) /
+      (1 * 1);
+  threadMasks->power_t.readOp.dynamic += (threadMasks->stats_t.readAc.access +
+                                          threadMasks->stats_t.writeAc.access) *
+                                         perAccessCoalescingEnergy;
+
+  // printf("***PRT: %10.30f, threadMasks: %10.30f, PRC:
+  // %10.30f\n",PRT->power_t.readOp.dynamic,threadMasks->power_t.readOp.dynamic,PRC->power_t.readOp.dynamic);
+  // printf("***Accesses: read:%lf
+  // write:%lf\n",threadMasks->stats_t.readAc.access,
+  // threadMasks->stats_t.writeAc.access);
+  if (is_tdp) {
+    power =
+        power + frontendBuffer->power_t + readBuffer->power_t +
+        writeBuffer->power_t + PRT->power_t + threadMasks->power_t +
+        PRC->power_t +
+        (frontendBuffer->local_result.power + readBuffer->local_result.power +
+         writeBuffer->local_result.power + PRT->local_result.power +
+         threadMasks->local_result.power + PRC->local_result.power) *
+            pppm_lkg;
+
+  } else {
+    rt_power =
+        rt_power + frontendBuffer->power_t + readBuffer->power_t +
+        writeBuffer->power_t + PRT->power_t + threadMasks->power_t +
+        PRC->power_t +
+        (frontendBuffer->local_result.power + readBuffer->local_result.power +
+         writeBuffer->local_result.power + PRT->local_result.power +
+         threadMasks->local_result.power + PRC->local_result.power) *
+            pppm_lkg;
+    rt_power.readOp.dynamic = rt_power.readOp.dynamic +
+                              power.readOp.dynamic * 0.1 * mcp.clockRate *
+                                  mcp.num_mcs * mcp.executionTime;
+  }
 }
 
-void MCFrontEnd::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
+void MCFrontEnd::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
 
-	if (is_tdp)
-	{
-		cout << indent_str << "Front End ROB:" << endl;
-		cout << indent_str_next << "Area = " << frontendBuffer->area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << frontendBuffer->power.readOp.dynamic*mcp.clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = " << frontendBuffer->power.readOp.leakage <<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << frontendBuffer->power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << frontendBuffer->rt_power.readOp.dynamic/mcp.executionTime << " W" << endl;
+  if (is_tdp) {
+    cout << indent_str << "Front End ROB:" << endl;
+    cout << indent_str_next
+         << "Area = " << frontendBuffer->area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str_next << "Peak Dynamic = "
+         << frontendBuffer->power.readOp.dynamic * mcp.clockRate << " W"
+         << endl;
+    cout << indent_str_next
+         << "Subthreshold Leakage = " << frontendBuffer->power.readOp.leakage
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << frontendBuffer->power.readOp.gate_leakage
+         << " W" << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << frontendBuffer->rt_power.readOp.dynamic / mcp.executionTime << " W"
+         << endl;
 
-		cout <<endl;
-		cout << indent_str<< "Read Buffer:" << endl;
-		cout << indent_str_next << "Area = " << readBuffer->area.get_area()*1e-6  << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << readBuffer->power.readOp.dynamic*mcp.clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = " << readBuffer->power.readOp.leakage  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << readBuffer->power.readOp.gate_leakage  << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << readBuffer->rt_power.readOp.dynamic/mcp.executionTime << " W" << endl;
-		cout <<endl;
-		cout << indent_str << "Write Buffer:" << endl;
-		cout << indent_str_next << "Area = " << writeBuffer->area.get_area() *1e-6 << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << writeBuffer->power.readOp.dynamic*mcp.clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = " << writeBuffer->power.readOp.leakage  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << writeBuffer->power.readOp.gate_leakage  << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << writeBuffer->rt_power.readOp.dynamic/mcp.executionTime << " W" << endl;
-		cout <<endl;
-		cout << indent_str << "PRT:" << endl;
-		cout << indent_str_next << "Area = " << PRT->area.get_area() *1e-6 << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << PRT->power.readOp.dynamic*mcp.clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = " << PRT->power.readOp.leakage  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << PRT->power.readOp.gate_leakage  << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << PRT->rt_power.readOp.dynamic/mcp.executionTime << " W" << endl;
-		cout <<endl;
-		cout << indent_str << "Thread Masks and coalescing logic:" << endl;
-		cout << indent_str_next << "Area = " << threadMasks->area.get_area() *1e-6 << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << threadMasks->power.readOp.dynamic*mcp.clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = " << threadMasks->power.readOp.leakage  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << threadMasks->power.readOp.gate_leakage  << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << threadMasks->rt_power.readOp.dynamic/mcp.executionTime << " W" << endl;
-		cout <<endl;
+    cout << endl;
+    cout << indent_str << "Read Buffer:" << endl;
+    cout << indent_str_next << "Area = " << readBuffer->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next << "Peak Dynamic = "
+         << readBuffer->power.readOp.dynamic * mcp.clockRate << " W" << endl;
+    cout << indent_str_next
+         << "Subthreshold Leakage = " << readBuffer->power.readOp.leakage
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << readBuffer->power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << readBuffer->rt_power.readOp.dynamic / mcp.executionTime << " W"
+         << endl;
+    cout << endl;
+    cout << indent_str << "Write Buffer:" << endl;
+    cout << indent_str_next << "Area = " << writeBuffer->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next << "Peak Dynamic = "
+         << writeBuffer->power.readOp.dynamic * mcp.clockRate << " W" << endl;
+    cout << indent_str_next
+         << "Subthreshold Leakage = " << writeBuffer->power.readOp.leakage
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << writeBuffer->power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << writeBuffer->rt_power.readOp.dynamic / mcp.executionTime << " W"
+         << endl;
+    cout << endl;
+    cout << indent_str << "PRT:" << endl;
+    cout << indent_str_next << "Area = " << PRT->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << PRT->power.readOp.dynamic * mcp.clockRate
+         << " W" << endl;
+    cout << indent_str_next
+         << "Subthreshold Leakage = " << PRT->power.readOp.leakage << " W"
+         << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << PRT->power.readOp.gate_leakage << " W" << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << PRT->rt_power.readOp.dynamic / mcp.executionTime << " W" << endl;
+    cout << endl;
+    cout << indent_str << "Thread Masks and coalescing logic:" << endl;
+    cout << indent_str_next << "Area = " << threadMasks->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next << "Peak Dynamic = "
+         << threadMasks->power.readOp.dynamic * mcp.clockRate << " W" << endl;
+    cout << indent_str_next
+         << "Subthreshold Leakage = " << threadMasks->power.readOp.leakage
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << threadMasks->power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << threadMasks->rt_power.readOp.dynamic / mcp.executionTime << " W"
+         << endl;
+    cout << endl;
 
-
-	}
-	else
-	{
-		cout << indent_str << "Front End ROB:" << endl;
-		cout << indent_str_next << "Area = " << frontendBuffer->area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << frontendBuffer->rt_power.readOp.dynamic*mcp.clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = " << frontendBuffer->rt_power.readOp.leakage <<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << frontendBuffer->rt_power.readOp.gate_leakage << " W" << endl;
-		cout <<endl;
-		cout << indent_str<< "Read Buffer:" << endl;
-		cout << indent_str_next << "Area = " << readBuffer->area.get_area()*1e-6  << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << readBuffer->rt_power.readOp.dynamic*mcp.clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = " << readBuffer->rt_power.readOp.leakage  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << readBuffer->rt_power.readOp.gate_leakage  << " W" << endl;
-		cout <<endl;
-		cout << indent_str << "Write Buffer:" << endl;
-		cout << indent_str_next << "Area = " << writeBuffer->area.get_area() *1e-6 << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << writeBuffer->rt_power.readOp.dynamic*mcp.clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = " << writeBuffer->rt_power.readOp.leakage  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << writeBuffer->rt_power.readOp.gate_leakage  << " W" << endl;
-		cout <<endl;
-		cout << indent_str << "PRT:" << endl;
-		cout << indent_str_next << "Area = " << PRT->area.get_area() *1e-6 << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << PRT->rt_power.readOp.dynamic*mcp.clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = " << PRT->rt_power.readOp.leakage  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << PRT->rt_power.readOp.gate_leakage  << " W" << endl;
-		cout <<endl;
-		cout << indent_str << "Thread masks and coalescing logic:" << endl;
-		cout << indent_str_next << "Area = " << threadMasks->area.get_area() *1e-6 << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << threadMasks->rt_power.readOp.dynamic*mcp.clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = " << threadMasks->rt_power.readOp.leakage  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << threadMasks->rt_power.readOp.gate_leakage  << " W" << endl;
-
-
-	}
-
+  } else {
+    cout << indent_str << "Front End ROB:" << endl;
+    cout << indent_str_next
+         << "Area = " << frontendBuffer->area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str_next << "Peak Dynamic = "
+         << frontendBuffer->rt_power.readOp.dynamic * mcp.clockRate << " W"
+         << endl;
+    cout << indent_str_next
+         << "Subthreshold Leakage = " << frontendBuffer->rt_power.readOp.leakage
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << frontendBuffer->rt_power.readOp.gate_leakage
+         << " W" << endl;
+    cout << endl;
+    cout << indent_str << "Read Buffer:" << endl;
+    cout << indent_str_next << "Area = " << readBuffer->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next << "Peak Dynamic = "
+         << readBuffer->rt_power.readOp.dynamic * mcp.clockRate << " W" << endl;
+    cout << indent_str_next
+         << "Subthreshold Leakage = " << readBuffer->rt_power.readOp.leakage
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << readBuffer->rt_power.readOp.gate_leakage
+         << " W" << endl;
+    cout << endl;
+    cout << indent_str << "Write Buffer:" << endl;
+    cout << indent_str_next << "Area = " << writeBuffer->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next << "Peak Dynamic = "
+         << writeBuffer->rt_power.readOp.dynamic * mcp.clockRate << " W"
+         << endl;
+    cout << indent_str_next
+         << "Subthreshold Leakage = " << writeBuffer->rt_power.readOp.leakage
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << writeBuffer->rt_power.readOp.gate_leakage
+         << " W" << endl;
+    cout << endl;
+    cout << indent_str << "PRT:" << endl;
+    cout << indent_str_next << "Area = " << PRT->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << PRT->rt_power.readOp.dynamic * mcp.clockRate
+         << " W" << endl;
+    cout << indent_str_next
+         << "Subthreshold Leakage = " << PRT->rt_power.readOp.leakage << " W"
+         << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << PRT->rt_power.readOp.gate_leakage << " W"
+         << endl;
+    cout << endl;
+    cout << indent_str << "Thread masks and coalescing logic:" << endl;
+    cout << indent_str_next << "Area = " << threadMasks->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next << "Peak Dynamic = "
+         << threadMasks->rt_power.readOp.dynamic * mcp.clockRate << " W"
+         << endl;
+    cout << indent_str_next
+         << "Subthreshold Leakage = " << threadMasks->rt_power.readOp.leakage
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << threadMasks->rt_power.readOp.gate_leakage
+         << " W" << endl;
+  }
 }
 
-DRAM::DRAM(ParseXML *XML_interface,InputParameter* interface_ip_, enum Dram_type dram_type_)
-:XML(XML_interface),
- interface_ip(*interface_ip_),
- dram_type(dram_type_)
-{
-
-		set_dram_param();
-
+DRAM::DRAM(ParseXML* XML_interface, InputParameter* interface_ip_,
+           enum Dram_type dram_type_)
+    : XML(XML_interface), interface_ip(*interface_ip_), dram_type(dram_type_) {
+  set_dram_param();
 }
-MemoryController::MemoryController(ParseXML *XML_interface,InputParameter* interface_ip_, enum MemoryCtrl_type mc_type_,enum Dram_type dram_type_)
-:XML(XML_interface),
- interface_ip(*interface_ip_),
- mc_type(mc_type_),
- frontend(0),
- transecEngine(0),
- PHY(0),
- pipeLogic(0)
-{
+MemoryController::MemoryController(ParseXML* XML_interface,
+                                   InputParameter* interface_ip_,
+                                   enum MemoryCtrl_type mc_type_,
+                                   enum Dram_type dram_type_)
+    : XML(XML_interface),
+      interface_ip(*interface_ip_),
+      mc_type(mc_type_),
+      frontend(0),
+      transecEngine(0),
+      PHY(0),
+      pipeLogic(0) {
   /* All computations are for a single MC
    *
    */
   interface_ip.wire_is_mat_type = 2;
   interface_ip.wire_os_mat_type = 2;
-  interface_ip.wt               =Global;
+  interface_ip.wt = Global;
   set_mc_param();
   frontend = new MCFrontEnd(XML, &interface_ip, mcp, mc_type);
   dram = new DRAM(XML, &interface_ip, dram_type_);
-  area.set_area(area.get_area()+ frontend->area.get_area());
+  area.set_area(area.get_area() + frontend->area.get_area());
   transecEngine = new MCBackend(&interface_ip, mcp, mc_type);
-  area.set_area(area.get_area()+ transecEngine->area.get_area());
-  if (mcp.type==0 || (mcp.type==1&&mcp.withPHY))
-  {
-	  PHY = new MCPHY(&interface_ip, mcp, mc_type);
-	  area.set_area(area.get_area()+ PHY->area.get_area());
+  area.set_area(area.get_area() + transecEngine->area.get_area());
+  if (mcp.type == 0 || (mcp.type == 1 && mcp.withPHY)) {
+    PHY = new MCPHY(&interface_ip, mcp, mc_type);
+    area.set_area(area.get_area() + PHY->area.get_area());
   }
-  //+++++++++Transaction engine +++++++++++++++++ ////TODO needs better numbers, Run the RTL code from OpenSparc.
-//  transecEngine.initialize(&interface_ip);
-//  transecEngine.peakDataTransferRate = XML->sys.mem.peak_transfer_rate;
-//  transecEngine.memDataWidth = dataBusWidth;
-//  transecEngine.memRank = XML->sys.mem.number_ranks;
-//  //transecEngine.memAccesses=XML->sys.mc.memory_accesses;
-//  //transecEngine.llcBlocksize=llcBlockSize;
-//  transecEngine.compute();
-//  transecEngine.area.set_area(XML->sys.mc.memory_channels_per_mc*transecEngine.area.get_area()) ;
-//  area.set_area(area.get_area()+ transecEngine.area.get_area());
-//  ///cout<<"area="<<area<<endl;
-////
-//  //++++++++++++++PHY ++++++++++++++++++++++++++ //TODO needs better numbers
-//  PHY.initialize(&interface_ip);
-//  PHY.peakDataTransferRate = XML->sys.mem.peak_transfer_rate;
-//  PHY.memDataWidth = dataBusWidth;
-//  //PHY.memAccesses=PHY.peakDataTransferRate;//this is the max power
-//  //PHY.llcBlocksize=llcBlockSize;
-//  PHY.compute();
-//  PHY.area.set_area(XML->sys.mc.memory_channels_per_mc*PHY.area.get_area()) ;
-//  area.set_area(area.get_area()+ PHY.area.get_area());
-  ///cout<<"area="<<area<<endl;
-//
-//  interface_ip.pipeline_stages = 5;//normal memory controller has five stages in the pipeline.
-//  interface_ip.per_stage_vector = addressBusWidth + XML->sys.core[0].opcode_width + dataBusWidth;
-//  pipeLogic = new pipeline(is_default, &interface_ip);
-//  //pipeLogic.init_pipeline(is_default, &interface_ip);
-//  pipeLogic->compute_pipeline();
-//  area.set_area(area.get_area()+ pipeLogic->area.get_area()*1e-6);
-//  area.set_area((area.get_area()+mc_area*1e-6)*1.1);//placement and routing overhead
-//
-//
-////  //clock
-////  clockNetwork.init_wire_external(is_default, &interface_ip);
-////  clockNetwork.clk_area           =area*1.1;//10% of placement overhead. rule of thumb
-////  clockNetwork.end_wiring_level   =5;//toplevel metal
-////  clockNetwork.start_wiring_level =5;//toplevel metal
-////  clockNetwork.num_regs           = pipeLogic.tot_stage_vector;
-////  clockNetwork.optimize_wire();
-
-
+  //+++++++++Transaction engine +++++++++++++++++ ////TODO needs better numbers,
+  //Run the RTL code from OpenSparc.
+  //  transecEngine.initialize(&interface_ip);
+  //  transecEngine.peakDataTransferRate = XML->sys.mem.peak_transfer_rate;
+  //  transecEngine.memDataWidth = dataBusWidth;
+  //  transecEngine.memRank = XML->sys.mem.number_ranks;
+  //  //transecEngine.memAccesses=XML->sys.mc.memory_accesses;
+  //  //transecEngine.llcBlocksize=llcBlockSize;
+  //  transecEngine.compute();
+  //  transecEngine.area.set_area(XML->sys.mc.memory_channels_per_mc*transecEngine.area.get_area())
+  //  ;
+  //  area.set_area(area.get_area()+ transecEngine.area.get_area());
+  //  ///cout<<"area="<<area<<endl;
+  ////
+  //  //++++++++++++++PHY ++++++++++++++++++++++++++ //TODO needs better numbers
+  //  PHY.initialize(&interface_ip);
+  //  PHY.peakDataTransferRate = XML->sys.mem.peak_transfer_rate;
+  //  PHY.memDataWidth = dataBusWidth;
+  //  //PHY.memAccesses=PHY.peakDataTransferRate;//this is the max power
+  //  //PHY.llcBlocksize=llcBlockSize;
+  //  PHY.compute();
+  //  PHY.area.set_area(XML->sys.mc.memory_channels_per_mc*PHY.area.get_area())
+  //  ;
+  //  area.set_area(area.get_area()+ PHY.area.get_area());
+  /// cout<<"area="<<area<<endl;
+  //
+  //  interface_ip.pipeline_stages = 5;//normal memory controller has five
+  //  stages in the pipeline.
+  //  interface_ip.per_stage_vector = addressBusWidth +
+  //  XML->sys.core[0].opcode_width + dataBusWidth;
+  //  pipeLogic = new pipeline(is_default, &interface_ip);
+  //  //pipeLogic.init_pipeline(is_default, &interface_ip);
+  //  pipeLogic->compute_pipeline();
+  //  area.set_area(area.get_area()+ pipeLogic->area.get_area()*1e-6);
+  //  area.set_area((area.get_area()+mc_area*1e-6)*1.1);//placement and routing
+  //  overhead
+  //
+  //
+  ////  //clock
+  ////  clockNetwork.init_wire_external(is_default, &interface_ip);
+  ////  clockNetwork.clk_area           =area*1.1;//10% of placement overhead.
+  ///rule of thumb
+  ////  clockNetwork.end_wiring_level   =5;//toplevel metal
+  ////  clockNetwork.start_wiring_level =5;//toplevel metal
+  ////  clockNetwork.num_regs           = pipeLogic.tot_stage_vector;
+  ////  clockNetwork.optimize_wire();
 }
-void MemoryController::computeEnergy(bool is_tdp)
-{
-
-  rt_power.reset(); //Jingwen
+void MemoryController::computeEnergy(bool is_tdp) {
+  rt_power.reset();  // Jingwen
   frontend->rt_power.reset();
   transecEngine->rt_power.reset();
   dram->rt_power.reset();
-  mcp.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6); //Jingwen
-  frontend->mcp.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6); //Jingwen
-  transecEngine->mcp.executionTime  = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6); //Jingwen
-  
+  mcp.executionTime = XML->sys.total_cycles /
+                      (XML->sys.target_core_clockrate * 1e6);  // Jingwen
+  frontend->mcp.executionTime =
+      XML->sys.total_cycles /
+      (XML->sys.target_core_clockrate * 1e6);  // Jingwen
+  transecEngine->mcp.executionTime =
+      XML->sys.total_cycles /
+      (XML->sys.target_core_clockrate * 1e6);  // Jingwen
+
   /*Jingwen: give stats for backend and phy */
-  transecEngine->mcp.reads =XML->sys.mc.memory_reads;
-  transecEngine->mcp.writes =XML->sys.mc.memory_writes;
+  transecEngine->mcp.reads = XML->sys.mc.memory_reads;
+  transecEngine->mcp.writes = XML->sys.mc.memory_writes;
 
-  //set_mc_param();
+  // set_mc_param();
 
-	frontend->computeEnergy(is_tdp);
-	transecEngine->computeEnergy(is_tdp);
-	dram->computeEnergy(is_tdp);
-	if (mcp.type==0 || (mcp.type==1&&mcp.withPHY))
-	{
-    if(!is_tdp)
-      PHY->rt_power.reset();//Jingwen
-    PHY->mcp.reads =XML->sys.mc.memory_reads;
-    PHY->mcp.writes =XML->sys.mc.memory_writes;
-    PHY->mcp.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6); //Jingwen
-		PHY->computeEnergy(is_tdp);
-	}
-	if (is_tdp)
-	{
-		power = power + frontend->power + transecEngine->power;
-		if (mcp.type==0 || (mcp.type==1&&mcp.withPHY))
-		{
-			power = power + PHY->power;
-		}
-	}
-	else
-	{
-		rt_power = rt_power + frontend->rt_power + transecEngine->rt_power+dram->rt_power;
-		if (mcp.type==0 || (mcp.type==1&&mcp.withPHY))
-		{
-			rt_power = rt_power + PHY->rt_power;
-		}
-	}
+  frontend->computeEnergy(is_tdp);
+  transecEngine->computeEnergy(is_tdp);
+  dram->computeEnergy(is_tdp);
+  if (mcp.type == 0 || (mcp.type == 1 && mcp.withPHY)) {
+    if (!is_tdp) PHY->rt_power.reset();  // Jingwen
+    PHY->mcp.reads = XML->sys.mc.memory_reads;
+    PHY->mcp.writes = XML->sys.mc.memory_writes;
+    PHY->mcp.executionTime = XML->sys.total_cycles /
+                             (XML->sys.target_core_clockrate * 1e6);  // Jingwen
+    PHY->computeEnergy(is_tdp);
+  }
+  if (is_tdp) {
+    power = power + frontend->power + transecEngine->power;
+    if (mcp.type == 0 || (mcp.type == 1 && mcp.withPHY)) {
+      power = power + PHY->power;
+    }
+  } else {
+    rt_power = rt_power + frontend->rt_power + transecEngine->rt_power +
+               dram->rt_power;
+    if (mcp.type == 0 || (mcp.type == 1 && mcp.withPHY)) {
+      rt_power = rt_power + PHY->rt_power;
+    }
+  }
 }
 
-void MemoryController::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
+void MemoryController::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
 
-	if (is_tdp)
-	{
-		cout << "Memory Controller:" << endl;
-		cout << indent_str<< "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic*mcp.clockRate  << " W" << endl;
-		cout << indent_str<< "Subthreshold Leakage = "
-			<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
-		//cout << indent_str<< "Subthreshold Leakage = " << power.readOp.longer_channel_leakage <<" W" << endl;
-		cout << indent_str<< "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str << "Runtime Dynamic = " << rt_power.readOp.dynamic/mcp.executionTime << " W" << endl;
-		cout<<endl;
-		cout << indent_str << "Front End Engine:" << endl;
-		cout << indent_str_next << "Area = " << frontend->area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << frontend->power.readOp.dynamic*mcp.clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? frontend->power.readOp.longer_channel_leakage:frontend->power.readOp.leakage) <<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << frontend->power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << frontend->rt_power.readOp.dynamic/mcp.executionTime << " W" << endl;
-		cout <<endl;
-		//if (plevel >2){
-			frontend->displayEnergy(indent+4,is_tdp);
-		//}
-		cout << indent_str << "Transaction Engine:" << endl;
-		cout << indent_str_next << "Area = " << transecEngine->area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << transecEngine->power.readOp.dynamic*mcp.clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? transecEngine->power.readOp.longer_channel_leakage:transecEngine->power.readOp.leakage) <<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << transecEngine->power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << transecEngine->rt_power.readOp.dynamic/mcp.executionTime << " W" << endl;
-		cout <<endl;
-		if (mcp.type==0 || (mcp.type==1&&mcp.withPHY))
-		{
-			cout << indent_str << "PHY:" << endl;
-			cout << indent_str_next << "Area = " << PHY->area.get_area()*1e-6<< " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << PHY->power.readOp.dynamic*mcp.clockRate << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? PHY->power.readOp.longer_channel_leakage:PHY->power.readOp.leakage) <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << PHY->power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << PHY->rt_power.readOp.dynamic/mcp.executionTime << " W" << endl;
-			cout <<endl;
-		}
-	}
-	else
-	{
-		cout << "Memory Controller:" << endl;
-		cout << indent_str_next << "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << power.readOp.dynamic*mcp.clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = " << power.readOp.leakage <<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
-		cout<<endl;
-	}
-
+  if (is_tdp) {
+    cout << "Memory Controller:" << endl;
+    cout << indent_str << "Area = " << area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str
+         << "Peak Dynamic = " << power.readOp.dynamic * mcp.clockRate << " W"
+         << endl;
+    cout << indent_str << "Subthreshold Leakage = "
+         << (long_channel ? power.readOp.longer_channel_leakage
+                          : power.readOp.leakage)
+         << " W" << endl;
+    // cout << indent_str<< "Subthreshold Leakage = " <<
+    // power.readOp.longer_channel_leakage <<" W" << endl;
+    cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str
+         << "Runtime Dynamic = " << rt_power.readOp.dynamic / mcp.executionTime
+         << " W" << endl;
+    cout << endl;
+    cout << indent_str << "Front End Engine:" << endl;
+    cout << indent_str_next << "Area = " << frontend->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << frontend->power.readOp.dynamic * mcp.clockRate
+         << " W" << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? frontend->power.readOp.longer_channel_leakage
+                          : frontend->power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << frontend->power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << frontend->rt_power.readOp.dynamic / mcp.executionTime << " W"
+         << endl;
+    cout << endl;
+    // if (plevel >2){
+    frontend->displayEnergy(indent + 4, is_tdp);
+    //}
+    cout << indent_str << "Transaction Engine:" << endl;
+    cout << indent_str_next
+         << "Area = " << transecEngine->area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str_next << "Peak Dynamic = "
+         << transecEngine->power.readOp.dynamic * mcp.clockRate << " W" << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? transecEngine->power.readOp.longer_channel_leakage
+                          : transecEngine->power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << transecEngine->power.readOp.gate_leakage
+         << " W" << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << transecEngine->rt_power.readOp.dynamic / mcp.executionTime << " W"
+         << endl;
+    cout << endl;
+    if (mcp.type == 0 || (mcp.type == 1 && mcp.withPHY)) {
+      cout << indent_str << "PHY:" << endl;
+      cout << indent_str_next << "Area = " << PHY->area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << PHY->power.readOp.dynamic * mcp.clockRate
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? PHY->power.readOp.longer_channel_leakage
+                            : PHY->power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << PHY->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << PHY->rt_power.readOp.dynamic / mcp.executionTime << " W" << endl;
+      cout << endl;
+    }
+  } else {
+    cout << "Memory Controller:" << endl;
+    cout << indent_str_next << "Area = " << area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << power.readOp.dynamic * mcp.clockRate << " W"
+         << endl;
+    cout << indent_str_next << "Subthreshold Leakage = " << power.readOp.leakage
+         << " W" << endl;
+    cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage
+         << " W" << endl;
+    cout << endl;
+  }
 }
 
-void DRAM::set_dram_param()
-{
-	dramp.cmd_coeff 		= XML->sys.mc.dram_rd_coeff;
-	dramp.act_coeff 		= XML->sys.mc.dram_act_coeff;
-	dramp.nop_coeff			= XML->sys.mc.dram_nop_coeff;
-	dramp.activity_coeff 	= XML->sys.mc.dram_activity_coeff;
-	dramp.pre_coeff			= XML->sys.mc.dram_pre_coeff;
-	dramp.rd_coeff			= XML->sys.mc.dram_rd_coeff;
-	dramp.wr_coeff			= XML->sys.mc.dram_wr_coeff;
-	dramp.req_coeff			= XML->sys.mc.dram_req_coeff;
-	dramp.const_coeff		= XML->sys.mc.dram_const_coeff;
+void DRAM::set_dram_param() {
+  dramp.cmd_coeff = XML->sys.mc.dram_rd_coeff;
+  dramp.act_coeff = XML->sys.mc.dram_act_coeff;
+  dramp.nop_coeff = XML->sys.mc.dram_nop_coeff;
+  dramp.activity_coeff = XML->sys.mc.dram_activity_coeff;
+  dramp.pre_coeff = XML->sys.mc.dram_pre_coeff;
+  dramp.rd_coeff = XML->sys.mc.dram_rd_coeff;
+  dramp.wr_coeff = XML->sys.mc.dram_wr_coeff;
+  dramp.req_coeff = XML->sys.mc.dram_req_coeff;
+  dramp.const_coeff = XML->sys.mc.dram_const_coeff;
 }
 
-void MemoryController::set_mc_param()
-{
+void MemoryController::set_mc_param() {
+  if (mc_type == MC) {
+    mcp.clockRate = XML->sys.mc.mc_clock * 2;  // DDR double pumped
+    mcp.clockRate *= 1e6;
+    mcp.executionTime =
+        XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);
 
-	if (mc_type==MC)
-	{
-	  mcp.clockRate       =XML->sys.mc.mc_clock*2;//DDR double pumped
-	  mcp.clockRate       *= 1e6;
-	  mcp.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
-
-	  mcp.llcBlockSize    =int(ceil(XML->sys.mc.llc_line_length/8.0))+XML->sys.mc.llc_line_length;//ecc overhead
-	  mcp.dataBusWidth    =int(ceil(XML->sys.mc.databus_width/8.0)) + XML->sys.mc.databus_width;
-	  mcp.addressBusWidth =int(ceil(XML->sys.mc.addressbus_width));//XML->sys.physical_address_width;
-	  mcp.opcodeW         =16;
-	  mcp.num_mcs         = XML->sys.mc.number_mcs;
-	  mcp.num_channels    = XML->sys.mc.memory_channels_per_mc;
-	  mcp.reads  = XML->sys.mc.memory_reads;
-	  mcp.writes = XML->sys.mc.memory_writes;
-	  //+++++++++Transaction engine +++++++++++++++++ ////TODO needs better numbers, Run the RTL code from OpenSparc.
-	  mcp.peakDataTransferRate = XML->sys.mc.peak_transfer_rate;
-	  mcp.memRank = XML->sys.mc.number_ranks;
-	  //++++++++++++++PHY ++++++++++++++++++++++++++ //TODO needs better numbers
-	  //PHY.memAccesses=PHY.peakDataTransferRate;//this is the max power
-	  //PHY.llcBlocksize=llcBlockSize;
-	  mcp.frontend_duty_cycle = 0.5;//for max power, the actual off-chip links is bidirectional but time shared
-	  mcp.LVDS = XML->sys.mc.LVDS;
-	  mcp.type = XML->sys.mc.type;
-	  mcp.withPHY = XML->sys.mc.withPHY;
-	}
-//	else if (mc_type==FLASHC)
-//	{
-//		mcp.clockRate       =XML->sys.flashc.mc_clock*2;//DDR double pumped
-//		mcp.clockRate       *= 1e6;
-//		mcp.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
-//
-//		mcp.llcBlockSize    =int(ceil(XML->sys.flashc.llc_line_length/8.0))+XML->sys.flashc.llc_line_length;//ecc overhead
-//		mcp.dataBusWidth    =int(ceil(XML->sys.flashc.databus_width/8.0)) + XML->sys.flashc.databus_width;
-//		mcp.addressBusWidth =int(ceil(XML->sys.flashc.addressbus_width));//XML->sys.physical_address_width;
-//		mcp.opcodeW         =16;
-//		mcp.num_mcs         = XML->sys.flashc.number_mcs;
-//		mcp.num_channels    = XML->sys.flashc.memory_channels_per_mc;
-//		mcp.reads  = XML->sys.flashc.memory_reads;
-//		mcp.writes = XML->sys.flashc.memory_writes;
-//		//+++++++++Transaction engine +++++++++++++++++ ////TODO needs better numbers, Run the RTL code from OpenSparc.
-//		mcp.peakDataTransferRate = XML->sys.flashc.peak_transfer_rate;
-//		mcp.memRank = XML->sys.flashc.number_ranks;
-//		//++++++++++++++PHY ++++++++++++++++++++++++++ //TODO needs better numbers
-//		//PHY.memAccesses=PHY.peakDataTransferRate;//this is the max power
-//		//PHY.llcBlocksize=llcBlockSize;
-//		mcp.frontend_duty_cycle = 0.5;//for max power, the actual off-chip links is bidirectional but time shared
-//		mcp.LVDS = XML->sys.flashc.LVDS;
-//		mcp.type = XML->sys.flashc.type;
-//	}
-	else
-	{
-		cout<<"Unknown memory controller type: neither DRAM controller nor Flash controller" <<endl;
-		exit(0);
-	}
+    mcp.llcBlockSize = int(ceil(XML->sys.mc.llc_line_length / 8.0)) +
+                       XML->sys.mc.llc_line_length;  // ecc overhead
+    mcp.dataBusWidth =
+        int(ceil(XML->sys.mc.databus_width / 8.0)) + XML->sys.mc.databus_width;
+    mcp.addressBusWidth = int(ceil(
+        XML->sys.mc.addressbus_width));  // XML->sys.physical_address_width;
+    mcp.opcodeW = 16;
+    mcp.num_mcs = XML->sys.mc.number_mcs;
+    mcp.num_channels = XML->sys.mc.memory_channels_per_mc;
+    mcp.reads = XML->sys.mc.memory_reads;
+    mcp.writes = XML->sys.mc.memory_writes;
+    //+++++++++Transaction engine +++++++++++++++++ ////TODO needs better
+    //numbers, Run the RTL code from OpenSparc.
+    mcp.peakDataTransferRate = XML->sys.mc.peak_transfer_rate;
+    mcp.memRank = XML->sys.mc.number_ranks;
+    //++++++++++++++PHY ++++++++++++++++++++++++++ //TODO needs better numbers
+    // PHY.memAccesses=PHY.peakDataTransferRate;//this is the max power
+    // PHY.llcBlocksize=llcBlockSize;
+    mcp.frontend_duty_cycle = 0.5;  // for max power, the actual off-chip links
+                                    // is bidirectional but time shared
+    mcp.LVDS = XML->sys.mc.LVDS;
+    mcp.type = XML->sys.mc.type;
+    mcp.withPHY = XML->sys.mc.withPHY;
+  }
+  //	else if (mc_type==FLASHC)
+  //	{
+  //		mcp.clockRate       =XML->sys.flashc.mc_clock*2;//DDR double
+  //pumped
+  //		mcp.clockRate       *= 1e6;
+  //		mcp.executionTime   =
+  //XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
+  //
+  //		mcp.llcBlockSize
+  //=int(ceil(XML->sys.flashc.llc_line_length/8.0))+XML->sys.flashc.llc_line_length;//ecc
+  //overhead
+  //		mcp.dataBusWidth    =int(ceil(XML->sys.flashc.databus_width/8.0)) +
+  //XML->sys.flashc.databus_width;
+  //		mcp.addressBusWidth
+  //=int(ceil(XML->sys.flashc.addressbus_width));//XML->sys.physical_address_width;
+  //		mcp.opcodeW         =16;
+  //		mcp.num_mcs         = XML->sys.flashc.number_mcs;
+  //		mcp.num_channels    = XML->sys.flashc.memory_channels_per_mc;
+  //		mcp.reads  = XML->sys.flashc.memory_reads;
+  //		mcp.writes = XML->sys.flashc.memory_writes;
+  //		//+++++++++Transaction engine +++++++++++++++++ ////TODO needs
+  //better numbers, Run the RTL code from OpenSparc.
+  //		mcp.peakDataTransferRate = XML->sys.flashc.peak_transfer_rate;
+  //		mcp.memRank = XML->sys.flashc.number_ranks;
+  //		//++++++++++++++PHY ++++++++++++++++++++++++++ //TODO needs better
+  //numbers
+  //		//PHY.memAccesses=PHY.peakDataTransferRate;//this is the max
+  //power
+  //		//PHY.llcBlocksize=llcBlockSize;
+  //		mcp.frontend_duty_cycle = 0.5;//for max power, the actual off-chip
+  //links is bidirectional but time shared
+  //		mcp.LVDS = XML->sys.flashc.LVDS;
+  //		mcp.type = XML->sys.flashc.type;
+  //	}
+  else {
+    cout << "Unknown memory controller type: neither DRAM controller nor Flash "
+            "controller"
+         << endl;
+    exit(0);
+  }
 }
 
-MCFrontEnd ::~MCFrontEnd(){
-
-	if(MC_arb) 	               {delete MC_arb; MC_arb = 0;}
-	if(frontendBuffer) 	       {delete frontendBuffer; frontendBuffer = 0;}
-	if(readBuffer) 	           {delete readBuffer; readBuffer = 0;}
-	if(writeBuffer) 	       {delete writeBuffer; writeBuffer = 0;}
+MCFrontEnd::~MCFrontEnd() {
+  if (MC_arb) {
+    delete MC_arb;
+    MC_arb = 0;
+  }
+  if (frontendBuffer) {
+    delete frontendBuffer;
+    frontendBuffer = 0;
+  }
+  if (readBuffer) {
+    delete readBuffer;
+    readBuffer = 0;
+  }
+  if (writeBuffer) {
+    delete writeBuffer;
+    writeBuffer = 0;
+  }
 }
 
-MemoryController ::~MemoryController(){
-
-	if(frontend) 	               {delete frontend; frontend = 0;}
-	if(transecEngine) 	           {delete transecEngine; transecEngine = 0;}
-	if(PHY) 	                   {delete PHY; PHY = 0;}
-	if(pipeLogic) 	               {delete pipeLogic; pipeLogic = 0;}
+MemoryController::~MemoryController() {
+  if (frontend) {
+    delete frontend;
+    frontend = 0;
+  }
+  if (transecEngine) {
+    delete transecEngine;
+    transecEngine = 0;
+  }
+  if (PHY) {
+    delete PHY;
+    PHY = 0;
+  }
+  if (pipeLogic) {
+    delete pipeLogic;
+    pipeLogic = 0;
+  }
 }
-

--- a/src/gpuwattch/memoryctrl.cc
+++ b/src/gpuwattch/memoryctrl.cc
@@ -29,8 +29,7 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:
-**
+*      Modified by:												   *
 *      Jingwen Leng, Univeristy of Texas, Austin                   *
 *      Syed Gilani, University of Wisconsin–Madison                *
 *      Tayler Hetherington, University of British Columbia         *
@@ -52,1241 +51,944 @@
 #include "basic_components.h"
 // clang-format on
 /* overview of MC models:
- * McPAT memory controllers are modeled according to large number of industrial
- * data points.
+ * McPAT memory controllers are modeled according to large number of industrial data points.
  * The Basic memory controller architecture is base on the Synopsis designs
- * (DesignWare DDR2/DDR3-Lite memory controllers and DDR2/DDR3-Lite protocol
- * controllers)
+ * (DesignWare DDR2/DDR3-Lite memory controllers and DDR2/DDR3-Lite protocol controllers)
  * as in Cadence ChipEstimator Tool
  *
- * An MC has 3 parts as shown in this design. McPAT models both high performance
- * MC
- * based on Niagara processor designs and curving and low power MC based on data
- * points in
+ * An MC has 3 parts as shown in this design. McPAT models both high performance MC
+ * based on Niagara processor designs and curving and low power MC based on data points in
  * Cadence ChipEstimator Tool.
  *
- * The frontend is modeled analytically, the backend is modeled empirically
- * according to
+ * The frontend is modeled analytically, the backend is modeled empirically according to
  * DDR2/DDR3-Lite protocol controllers in Cadence ChipEstimator Tool
  * The PHY is modeled based on
- * "A 100mW 9.6Gb/s Transceiver in 90nm CMOS for next-generation memory
- * interfaces ," ISSCC 2006,
- * and A 14mW 6.25Gb/s Transceiver in 90nm CMOS for Serial Chip-to-Chip
- * Communication," ISSCC 2007
+ * "A 100mW 9.6Gb/s Transceiver in 90nm CMOS for next-generation memory interfaces ," ISSCC 2006,
+ * and A 14mW 6.25Gb/s Transceiver in 90nm CMOS for Serial Chip-to-Chip Communication," ISSCC 2007
  *
- * In Cadence ChipEstimator Tool there are two types of memory controllers: the
- * full memory controllers
- * that includes the frontend as the DesignWare DDR2/DDR3-Lite memory
- * controllers and the backend only
- * memory controllers as the DDR2/DDR3-Lite protocol controllers (except
- * DesignWare DDR2/DDR3-Lite memory
- * controllers, all memory controller IP in Cadence ChipEstimator Tool are
- * backend memory controllers such as
- * DDRC 1600A and DDRC 800A). Thus,to some extend the area and power difference
- * between DesignWare
- * DDR2/DDR3-Lite memory controllers and DDR2/DDR3-Lite protocol controllers can
- * be an estimation to the
- * frontend power and area, which is very close the analitically modeled results
- * of the frontend for Niagara2@65nm
+ * In Cadence ChipEstimator Tool there are two types of memory controllers: the full memory controllers
+ * that includes the frontend as the DesignWare DDR2/DDR3-Lite memory controllers and the backend only
+ * memory controllers as the DDR2/DDR3-Lite protocol controllers (except DesignWare DDR2/DDR3-Lite memory
+ * controllers, all memory controller IP in Cadence ChipEstimator Tool are backend memory controllers such as
+ * DDRC 1600A and DDRC 800A). Thus,to some extend the area and power difference between DesignWare
+ * DDR2/DDR3-Lite memory controllers and DDR2/DDR3-Lite protocol controllers can be an estimation to the
+ * frontend power and area, which is very close the analitically modeled results of the frontend for Niagara2@65nm
  *
  */
 
-MCBackend::MCBackend(InputParameter* interface_ip_, const MCParam& mcp_,
-                     enum MemoryCtrl_type mc_type_)
-    : l_ip(*interface_ip_), mc_type(mc_type_), mcp(mcp_) {
+MCBackend::MCBackend(InputParameter* interface_ip_, const MCParam & mcp_, enum MemoryCtrl_type mc_type_)
+:l_ip(*interface_ip_),
+ mc_type(mc_type_),
+ mcp(mcp_)
+{
+
   local_result = init_interface(&l_ip);
   compute();
+
 }
 
-void MCBackend::compute() {
-  // double max_row_addr_width = 20.0;//Current address 12~18bits
-  double C_MCB, mc_power, backend_dyn,
-      backend_gates;  //, refresh_period,refresh_freq;//Equivalent per bit Cap
-                      //for backend,
+
+void MCBackend::compute()
+{
+  //double max_row_addr_width = 20.0;//Current address 12~18bits
+  double C_MCB, mc_power, backend_dyn, backend_gates;//, refresh_period,refresh_freq;//Equivalent per bit Cap for backend,
   double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
   double NMOS_sizing, PMOS_sizing;
 
-  if (mc_type == MC) {
-    if (mcp.type == 0) {
-      // area =
-      // (2.2927*log(peakDataTransferRate)-14.504)*memDataWidth/144.0*(l_ip.F_sz_um/0.09);
-      area.set_area((2.7927 * log(mcp.peakDataTransferRate * 2) - 19.862) /
-                    2.0 * mcp.dataBusWidth / 128.0 * (l_ip.F_sz_um / 0.09) *
-                    mcp.num_channels * 1e6);  // um^2
-      // assuming the approximately same scaling factor as seen in processors.
-      // C_MCB=0.2/1.3/1.3/266/64/0.09*g_ip.F_sz_um;//based on AMD Geode
-      // processor which has a very basic mc on chip.
-      // C_MCB = 1.6/200/1e6/144/1.2/1.2*g_ip.F_sz_um/0.19;//Based on Niagara
-      // power numbers.The base power (W) is divided by device frequency and vdd
-      // and scale to target process.
-      // mc_power = 0.0291*2;//29.1mW@200MHz @130nm From Power Analysis of
-      // SystemLevel OnChip Communication Architectures by Lahiri et
-      mc_power =
-          4.32 *
-          0.1;  // 4.32W@1GhzMHz @65nm Cadence ChipEstimator 10% for backend
-      C_MCB = mc_power / 1e9 / 72 / 1.1 / 1.1 * l_ip.F_sz_um / 0.065;
-      power_t.readOp.dynamic =
-          C_MCB * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd *
-          (mcp.dataBusWidth /*+mcp.addressBusWidth*/);  // per access energy in
-                                                        // memory controller
-      power_t.readOp.leakage =
-          area.get_area() / 2 * (g_tp.scaling_factor.core_tx_density) *
-          cmos_Isub_leakage(g_tp.min_w_nmos_,
-                            g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
-          g_tp.peri_global.Vdd;  // unit W
-      power_t.readOp.gate_leakage =
-          area.get_area() / 2 * (g_tp.scaling_factor.core_tx_density) *
-          cmos_Ig_leakage(g_tp.min_w_nmos_,
-                          g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
-          g_tp.peri_global.Vdd;  // unit W
+  if (mc_type == MC)
+  {
+	  if (mcp.type == 0)
+	  {
+		  //area = (2.2927*log(peakDataTransferRate)-14.504)*memDataWidth/144.0*(l_ip.F_sz_um/0.09);
+		  area.set_area((2.7927*log(mcp.peakDataTransferRate*2)-19.862)/2.0*mcp.dataBusWidth/128.0*(l_ip.F_sz_um/0.09)*mcp.num_channels*1e6);//um^2
+		  //assuming the approximately same scaling factor as seen in processors.
+		  //C_MCB=0.2/1.3/1.3/266/64/0.09*g_ip.F_sz_um;//based on AMD Geode processor which has a very basic mc on chip.
+		  //C_MCB = 1.6/200/1e6/144/1.2/1.2*g_ip.F_sz_um/0.19;//Based on Niagara power numbers.The base power (W) is divided by device frequency and vdd and scale to target process.
+		  //mc_power = 0.0291*2;//29.1mW@200MHz @130nm From Power Analysis of SystemLevel OnChip Communication Architectures by Lahiri et
+		  mc_power = 4.32*0.1;//4.32W@1GhzMHz @65nm Cadence ChipEstimator 10% for backend
+		  C_MCB = mc_power/1e9/72/1.1/1.1*l_ip.F_sz_um/0.065;
+		  power_t.readOp.dynamic = C_MCB*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(mcp.dataBusWidth/*+mcp.addressBusWidth*/);//per access energy in memory controller
+		  power_t.readOp.leakage = area.get_area()/2 *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(g_tp.min_w_nmos_, g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd;//unit W
+		  power_t.readOp.gate_leakage = area.get_area()/2 *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(g_tp.min_w_nmos_, g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd;//unit W
 
-    } else {
-      NMOS_sizing = g_tp.min_w_nmos_;
-      PMOS_sizing = g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r;
-      area.set_area(0.15 * mcp.dataBusWidth / 72.0 * (l_ip.F_sz_um / 0.065) *
-                    (l_ip.F_sz_um / 0.065) * mcp.num_channels * 1e6);  // um^2
-      backend_dyn = 0.9e-9 / 800e6 * mcp.clockRate / 12800 *
-                    mcp.peakDataTransferRate * mcp.dataBusWidth / 72.0 *
-                    g_tp.peri_global.Vdd / 1.1 * g_tp.peri_global.Vdd / 1.1 *
-                    (l_ip.F_sz_nm / 65.0);  // Average on DDR2/3 protocol
-                                            // controller and DDRC 1600/800A in
-                                            // Cadence ChipEstimate
-      // Scaling to technology and DIMM feature. The base IP support
-      // DDR3-1600(PC3 12800)
-      backend_gates = 50000 * mcp.dataBusWidth /
-                      64.0;  // 5000 is from Cadence ChipEstimator
+	  }
+	  else
+	  {   NMOS_sizing 	  = g_tp.min_w_nmos_;
+		  PMOS_sizing	  = g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
+		  area.set_area(0.15*mcp.dataBusWidth/72.0*(l_ip.F_sz_um/0.065)* (l_ip.F_sz_um/0.065)*mcp.num_channels*1e6);//um^2
+		  backend_dyn = 0.9e-9/800e6*mcp.clockRate/12800*mcp.peakDataTransferRate*mcp.dataBusWidth/72.0*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(l_ip.F_sz_nm/65.0);//Average on DDR2/3 protocol controller and DDRC 1600/800A in Cadence ChipEstimate
+		  //Scaling to technology and DIMM feature. The base IP support DDR3-1600(PC3 12800)
+		  backend_gates = 50000*mcp.dataBusWidth/64.0;//5000 is from Cadence ChipEstimator
 
-      power_t.readOp.dynamic = backend_dyn;
-      power_t.readOp.leakage =
-          (backend_gates)*cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
-          g_tp.peri_global.Vdd;  // unit W
-      power_t.readOp.gate_leakage =
-          (backend_gates)*cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
-          g_tp.peri_global.Vdd;  // unit W
+		  power_t.readOp.dynamic = backend_dyn;
+		  power_t.readOp.leakage = (backend_gates)*cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
+		  power_t.readOp.gate_leakage = (backend_gates)*cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
+
+	  }
+  }
+  else
+  {//skip old model
+	  cout<<"Unknown memory controllers"<<endl;exit(0);
+	  area.set_area(0.243*mcp.dataBusWidth/8);//area based on Cadence ChipEstimator for 8bit bus
+	  //mc_power = 4.32*0.1;//4.32W@1GhzMHz @65nm Cadence ChipEstimator 10% for backend
+	  C_MCB = mc_power/1e9/72/1.1/1.1*l_ip.F_sz_um/0.065;
+	  power_t.readOp.leakage = area.get_area()/2 *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(g_tp.min_w_nmos_, g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd;//unit W
+	  power_t.readOp.gate_leakage = area.get_area()/2 *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(g_tp.min_w_nmos_, g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd;//unit W
+	  power_t.readOp.dynamic *= 1.2;
+	  power_t.readOp.leakage *= 1.2;
+	  power_t.readOp.gate_leakage *= 1.2;
+	  //flash controller has about 20% more backend power since BCH ECC in flash is complex and power hungry
+  }
+  double long_channel_device_reduction = longer_channel_device_reduction(Uncore_device);
+  power_t.readOp.longer_channel_leakage = power_t.readOp.leakage * long_channel_device_reduction;
+}
+
+void MCBackend::computeEnergy(bool is_tdp)
+{
+	//backend uses internal data buswidth
+	if (is_tdp)
+	{
+    power.reset(); //Jingwen
+		//init stats for Peak
+		stats_t.readAc.access   = 0.5*mcp.num_channels;
+		stats_t.writeAc.access  = 0.5*mcp.num_channels;
+		tdp_stats = stats_t;
+	}
+	else
+	{
+    rt_power.reset();//Jingwen
+		//init stats for runtime power (RTP)
+    //Jingwen: should use stats from XML object, modified in MemoryController::computeEnergy
+		stats_t.readAc.access   = mcp.reads;
+		stats_t.writeAc.access  = mcp.writes;
+		tdp_stats = stats_t;
+	}
+	if (is_tdp)
+    {
+		power = power_t;
+		power.readOp.dynamic	= (stats_t.readAc.access + stats_t.writeAc.access)*power_t.readOp.dynamic;
+
     }
-  } else {  // skip old model
-    cout << "Unknown memory controllers" << endl;
-    exit(0);
-    area.set_area(0.243 * mcp.dataBusWidth /
-                  8);  // area based on Cadence ChipEstimator for 8bit bus
-    // mc_power = 4.32*0.1;//4.32W@1GhzMHz @65nm Cadence ChipEstimator 10% for
-    // backend
-    C_MCB = mc_power / 1e9 / 72 / 1.1 / 1.1 * l_ip.F_sz_um / 0.065;
-    power_t.readOp.leakage =
-        area.get_area() / 2 * (g_tp.scaling_factor.core_tx_density) *
-        cmos_Isub_leakage(g_tp.min_w_nmos_,
-                          g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
-        g_tp.peri_global.Vdd;  // unit W
-    power_t.readOp.gate_leakage =
-        area.get_area() / 2 * (g_tp.scaling_factor.core_tx_density) *
-        cmos_Ig_leakage(g_tp.min_w_nmos_,
-                        g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
-        g_tp.peri_global.Vdd;  // unit W
-    power_t.readOp.dynamic *= 1.2;
-    power_t.readOp.leakage *= 1.2;
-    power_t.readOp.gate_leakage *= 1.2;
-    // flash controller has about 20% more backend power since BCH ECC in flash
-    // is complex and power hungry
-  }
-  double long_channel_device_reduction =
-      longer_channel_device_reduction(Uncore_device);
-  power_t.readOp.longer_channel_leakage =
-      power_t.readOp.leakage * long_channel_device_reduction;
+    else
+    {
+    	rt_power.readOp.dynamic	= (stats_t.readAc.access + stats_t.writeAc.access)*mcp.llcBlockSize*8.0/mcp.dataBusWidth*power_t.readOp.dynamic;
+    	rt_power = rt_power + power_t*pppm_lkg;
+    	rt_power.readOp.dynamic = rt_power.readOp.dynamic + power.readOp.dynamic*0.1*mcp.clockRate*mcp.num_mcs*mcp.executionTime;
+    	//Assume 10% of peak power is consumed by routine job including memory refreshing and scrubbing
+    }
 }
 
-void MCBackend::computeEnergy(bool is_tdp) {
-  // backend uses internal data buswidth
-  if (is_tdp) {
-    power.reset();  // Jingwen
-    // init stats for Peak
-    stats_t.readAc.access = 0.5 * mcp.num_channels;
-    stats_t.writeAc.access = 0.5 * mcp.num_channels;
-    tdp_stats = stats_t;
-  } else {
-    rt_power.reset();  // Jingwen
-    // init stats for runtime power (RTP)
-    // Jingwen: should use stats from XML object, modified in
-    // MemoryController::computeEnergy
-    stats_t.readAc.access = mcp.reads;
-    stats_t.writeAc.access = mcp.writes;
-    tdp_stats = stats_t;
-  }
-  if (is_tdp) {
-    power = power_t;
-    power.readOp.dynamic = (stats_t.readAc.access + stats_t.writeAc.access) *
-                           power_t.readOp.dynamic;
 
-  } else {
-    rt_power.readOp.dynamic = (stats_t.readAc.access + stats_t.writeAc.access) *
-                              mcp.llcBlockSize * 8.0 / mcp.dataBusWidth *
-                              power_t.readOp.dynamic;
-    rt_power = rt_power + power_t * pppm_lkg;
-    rt_power.readOp.dynamic = rt_power.readOp.dynamic +
-                              power.readOp.dynamic * 0.1 * mcp.clockRate *
-                                  mcp.num_mcs * mcp.executionTime;
-    // Assume 10% of peak power is consumed by routine job including memory
-    // refreshing and scrubbing
-  }
-}
+MCPHY::MCPHY(InputParameter* interface_ip_, const MCParam & mcp_, enum MemoryCtrl_type mc_type_)
+:l_ip(*interface_ip_),
+ mc_type(mc_type_),
+ mcp(mcp_)
+{
 
-MCPHY::MCPHY(InputParameter* interface_ip_, const MCParam& mcp_,
-             enum MemoryCtrl_type mc_type_)
-    : l_ip(*interface_ip_), mc_type(mc_type_), mcp(mcp_) {
   local_result = init_interface(&l_ip);
   compute();
 }
 
-void MCPHY::compute() {
-  // PHY uses internal data buswidth but the actuall off-chip datawidth is
-  // 64bits + ecc
-  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
+void MCPHY::compute()
+{
+  //PHY uses internal data buswidth but the actuall off-chip datawidth is 64bits + ecc
+  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio() ;
   /*
-   * according to "A 100mW 9.6Gb/s Transceiver in 90nm CMOS for next-generation
-   * memory interfaces ," ISSCC 2006;
+   * according to "A 100mW 9.6Gb/s Transceiver in 90nm CMOS for next-generation memory interfaces ," ISSCC 2006;
    * From Cadence ChipEstimator for normal I/O around 0.4~0.8 mW/Gb/s
    */
-  double power_per_gb_per_s, phy_gates, NMOS_sizing, PMOS_sizing;
+  double power_per_gb_per_s,phy_gates, NMOS_sizing, PMOS_sizing;
 
-  if (mc_type == MC) {
-    if (mcp.type == 0) {
-      power_per_gb_per_s = mcp.LVDS ? 0.01 : 0.04;
-      // Based on die photos from Niagara 1 and 2.
-      // TODO merge this into undifferentiated core.PHY only achieves square
-      // root of the ideal scaling.
-      // area =
-      // (6.4323*log(peakDataTransferRate)-34.76)*memDataWidth/128.0*(l_ip.F_sz_um/0.09);
-      area.set_area((6.4323 * log(mcp.peakDataTransferRate * 2) - 48.134) *
-                    mcp.dataBusWidth / 128.0 * (l_ip.F_sz_um / 0.09) *
-                    mcp.num_channels * 1e6 / 2);  // TODO:/2
-      // This is from curve fitting based on Niagara 1 and 2's PHY die photo.
-      // This is power not energy, 10mw/Gb/s @90nm for each channel and scaling
-      // down
-      // power.readOp.dynamic = 0.02*memAccesses*llcBlocksize*8;//change from
-      // Bytes to bits.
-      power_t.readOp.dynamic = power_per_gb_per_s * sqrt(l_ip.F_sz_um / 0.09) *
-                               g_tp.peri_global.Vdd / 1.2 *
-                               g_tp.peri_global.Vdd / 1.2;
-      power_t.readOp.leakage =
-          area.get_area() / 2 * (g_tp.scaling_factor.core_tx_density) *
-          cmos_Isub_leakage(g_tp.min_w_nmos_,
-                            g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
-          g_tp.peri_global.Vdd;  // unit W
-      power_t.readOp.gate_leakage =
-          area.get_area() / 2 * (g_tp.scaling_factor.core_tx_density) *
-          cmos_Ig_leakage(g_tp.min_w_nmos_,
-                          g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
-          g_tp.peri_global.Vdd;  // unit W
+  if (mc_type == MC)
+  {
+	  if (mcp.type == 0)
+	  {
+		  power_per_gb_per_s = mcp.LVDS? 0.01:0.04;
+		  //Based on die photos from Niagara 1 and 2.
+		  //TODO merge this into undifferentiated core.PHY only achieves square root of the ideal scaling.
+		  //area = (6.4323*log(peakDataTransferRate)-34.76)*memDataWidth/128.0*(l_ip.F_sz_um/0.09);
+		  area.set_area((6.4323*log(mcp.peakDataTransferRate*2)-48.134)*mcp.dataBusWidth/128.0*(l_ip.F_sz_um/0.09)*mcp.num_channels*1e6/2);//TODO:/2
+		  //This is from curve fitting based on Niagara 1 and 2's PHY die photo.
+		  //This is power not energy, 10mw/Gb/s @90nm for each channel and scaling down
+		  //power.readOp.dynamic = 0.02*memAccesses*llcBlocksize*8;//change from Bytes to bits.
+		  power_t.readOp.dynamic = power_per_gb_per_s*sqrt(l_ip.F_sz_um/0.09)*g_tp.peri_global.Vdd/1.2*g_tp.peri_global.Vdd/1.2;
+		  power_t.readOp.leakage = area.get_area()/2 *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(g_tp.min_w_nmos_, g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd;//unit W
+		  power_t.readOp.gate_leakage = area.get_area()/2 *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(g_tp.min_w_nmos_, g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd;//unit W
 
-    } else {
-      NMOS_sizing = g_tp.min_w_nmos_;
-      PMOS_sizing = g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r;
-      // Designware/synopsis 16bit DDR3 PHY is 1.3mm (WITH IOs) at 40nm for upto
-      // DDR3 2133 (PC3 17066)
-      double non_IO_percentage = 0.2;
-      area.set_area(1.3 * non_IO_percentage / 2133.0e6 * mcp.clockRate / 17066 *
-                    mcp.peakDataTransferRate * mcp.dataBusWidth / 16.0 *
-                    (l_ip.F_sz_um / 0.040) * (l_ip.F_sz_um / 0.040) *
-                    mcp.num_channels * 1e6);  // um^2
-      phy_gates = 200000 * mcp.dataBusWidth / 64.0;
-      power_per_gb_per_s = 0.01;
-      // This is power not energy, 10mw/Gb/s @90nm for each channel and scaling
-      // down
-      power_t.readOp.dynamic = power_per_gb_per_s * (l_ip.F_sz_um / 0.09) *
-                               g_tp.peri_global.Vdd / 1.2 *
-                               g_tp.peri_global.Vdd / 1.2;
-      power_t.readOp.leakage =
-          (mcp.withPHY ? phy_gates : 0) *
-          cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
-          g_tp.peri_global.Vdd;  // unit W
-      power_t.readOp.gate_leakage =
-          (mcp.withPHY ? phy_gates : 0) *
-          cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
-          g_tp.peri_global.Vdd;  // unit W
+	  }
+	  else
+	  {
+		  NMOS_sizing 	  = g_tp.min_w_nmos_;
+		  PMOS_sizing	  = g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
+		  //Designware/synopsis 16bit DDR3 PHY is 1.3mm (WITH IOs) at 40nm for upto DDR3 2133 (PC3 17066)
+		  double non_IO_percentage = 0.2;
+		  area.set_area(1.3*non_IO_percentage/2133.0e6*mcp.clockRate/17066*mcp.peakDataTransferRate*mcp.dataBusWidth/16.0*(l_ip.F_sz_um/0.040)* (l_ip.F_sz_um/0.040)*mcp.num_channels*1e6);//um^2
+		  phy_gates = 200000*mcp.dataBusWidth/64.0;
+		  power_per_gb_per_s = 0.01;
+		  //This is power not energy, 10mw/Gb/s @90nm for each channel and scaling down
+		  power_t.readOp.dynamic = power_per_gb_per_s*(l_ip.F_sz_um/0.09)*g_tp.peri_global.Vdd/1.2*g_tp.peri_global.Vdd/1.2;
+		  power_t.readOp.leakage = (mcp.withPHY? phy_gates:0)*cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
+		  power_t.readOp.gate_leakage = (mcp.withPHY? phy_gates:0)*cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
+	  }
+
+  }
+  else
+  {
+	  area.set_area(0.4e6/2*mcp.dataBusWidth/8);//area based on Cadence ChipEstimator for 8bit bus
+  }
+
+//  double phy_factor = (int)ceil(mcp.dataBusWidth/72.0);//Previous phy power numbers are based on 72 bit DIMM interface
+//  power_t.readOp.dynamic *= phy_factor;
+//  power_t.readOp.leakage *= phy_factor;
+//  power_t.readOp.gate_leakage *= phy_factor;
+
+  double long_channel_device_reduction = longer_channel_device_reduction(Uncore_device);
+  power_t.readOp.longer_channel_leakage = power_t.readOp.leakage * long_channel_device_reduction;
+}
+
+
+void MCPHY::computeEnergy(bool is_tdp)
+{
+	if (is_tdp)
+	{
+    power.reset(); //Jingwen
+		//init stats for Peak
+		stats_t.readAc.access   = 0.5*mcp.num_channels; //time share on buses
+		stats_t.writeAc.access  = 0.5*mcp.num_channels;
+		tdp_stats = stats_t;
+	}
+	else
+	{
+    rt_power.reset(); //Jingwen
+		//init stats for runtime power (RTP)
+    //Jingwen: should use stats from XML object, modified in MemoryController::computeEnergy
+		stats_t.readAc.access   = mcp.reads;
+		stats_t.writeAc.access  = mcp.writes;
+		tdp_stats = stats_t;
+	}
+
+	if (is_tdp)
+    {
+		double data_transfer_unit = (mc_type == MC)? 72:16;/*DIMM data width*/
+		power = power_t;
+		power.readOp.dynamic	= power.readOp.dynamic * (mcp.peakDataTransferRate*8*1e6/1e9/*change to Gbs*/)*mcp.dataBusWidth/data_transfer_unit*mcp.num_channels/mcp.clockRate;
+		// divide by clock rate is for match the final computation where *clock is used
+		//(stats_t.readAc.access*power_t.readOp.dynamic+
+//					stats_t.writeAc.access*power_t.readOp.dynamic);
+
     }
+    else
+    {
+    	rt_power = power_t;
+//    	rt_power.readOp.dynamic	= (stats_t.readAc.access*power_t.readOp.dynamic+
+//    						stats_t.writeAc.access*power_t.readOp.dynamic);
 
-  } else {
-    area.set_area(0.4e6 / 2 * mcp.dataBusWidth /
-                  8);  // area based on Cadence ChipEstimator for 8bit bus
-  }
-
-  //  double phy_factor = (int)ceil(mcp.dataBusWidth/72.0);//Previous phy power
-  //  numbers are based on 72 bit DIMM interface
-  //  power_t.readOp.dynamic *= phy_factor;
-  //  power_t.readOp.leakage *= phy_factor;
-  //  power_t.readOp.gate_leakage *= phy_factor;
-
-  double long_channel_device_reduction =
-      longer_channel_device_reduction(Uncore_device);
-  power_t.readOp.longer_channel_leakage =
-      power_t.readOp.leakage * long_channel_device_reduction;
+    	rt_power.readOp.dynamic=power_t.readOp.dynamic*(stats_t.readAc.access + stats_t.writeAc.access)*(mcp.llcBlockSize)*8/1e9/mcp.executionTime*(mcp.executionTime);
+    	rt_power.readOp.dynamic = rt_power.readOp.dynamic + power.readOp.dynamic*0.1*mcp.clockRate*mcp.num_mcs*mcp.executionTime;
+    }
 }
 
-void MCPHY::computeEnergy(bool is_tdp) {
-  if (is_tdp) {
-    power.reset();  // Jingwen
-    // init stats for Peak
-    stats_t.readAc.access = 0.5 * mcp.num_channels;  // time share on buses
-    stats_t.writeAc.access = 0.5 * mcp.num_channels;
-    tdp_stats = stats_t;
-  } else {
-    rt_power.reset();  // Jingwen
-    // init stats for runtime power (RTP)
-    // Jingwen: should use stats from XML object, modified in
-    // MemoryController::computeEnergy
-    stats_t.readAc.access = mcp.reads;
-    stats_t.writeAc.access = mcp.writes;
-    tdp_stats = stats_t;
-  }
-
-  if (is_tdp) {
-    double data_transfer_unit = (mc_type == MC) ? 72 : 16; /*DIMM data width*/
-    power = power_t;
-    power.readOp.dynamic =
-        power.readOp.dynamic *
-        (mcp.peakDataTransferRate * 8 * 1e6 / 1e9 /*change to Gbs*/) *
-        mcp.dataBusWidth / data_transfer_unit * mcp.num_channels /
-        mcp.clockRate;
-    // divide by clock rate is for match the final computation where *clock is
-    // used
-    //(stats_t.readAc.access*power_t.readOp.dynamic+
-    //					stats_t.writeAc.access*power_t.readOp.dynamic);
-
-  } else {
-    rt_power = power_t;
-    //    	rt_power.readOp.dynamic	=
-    //    (stats_t.readAc.access*power_t.readOp.dynamic+
-    //    						stats_t.writeAc.access*power_t.readOp.dynamic);
-
-    rt_power.readOp.dynamic = power_t.readOp.dynamic *
-                              (stats_t.readAc.access + stats_t.writeAc.access) *
-                              (mcp.llcBlockSize) * 8 / 1e9 / mcp.executionTime *
-                              (mcp.executionTime);
-    rt_power.readOp.dynamic = rt_power.readOp.dynamic +
-                              power.readOp.dynamic * 0.1 * mcp.clockRate *
-                                  mcp.num_mcs * mcp.executionTime;
-  }
-}
-
-MCFrontEnd::MCFrontEnd(ParseXML* XML_interface, InputParameter* interface_ip_,
-                       const MCParam& mcp_, enum MemoryCtrl_type mc_type_)
-    : XML(XML_interface),
-      interface_ip(*interface_ip_),
-      mc_type(mc_type_),
-      mcp(mcp_),
-      MC_arb(0),
-      frontendBuffer(0),
-      readBuffer(0),
-      writeBuffer(0),
-      coalesce_scale(1.0) {
+MCFrontEnd::MCFrontEnd(ParseXML *XML_interface,InputParameter* interface_ip_, const MCParam & mcp_, enum MemoryCtrl_type mc_type_)
+:XML(XML_interface),
+ interface_ip(*interface_ip_),
+ mc_type(mc_type_),
+ mcp(mcp_),
+ MC_arb(0),
+ frontendBuffer(0),
+ readBuffer(0),
+ writeBuffer(0),
+ coalesce_scale(1.0)
+{
   /* All computations are for a single MC
    *
    */
 
   int tag, data;
-  bool is_default = true;  // indication for default setup
+  bool is_default =true;//indication for default setup
 
-  /* MC frontend engine channels share the same engines but logically
-   * partitioned
+  /* MC frontend engine channels share the same engines but logically partitioned
    * For all hardware inside MC. different channels do not share resources.
-   * TODO: add docodeing/mux stage to steer memory requests to different
-   * channels.
+   * TODO: add docodeing/mux stage to steer memory requests to different channels.
    */
 
-  // memory request reorder buffer
-  tag = mcp.addressBusWidth + EXTRA_TAG_BITS + mcp.opcodeW;
-  data = int(ceil((XML->sys.physical_address_width + mcp.opcodeW) / 8.0));
-  interface_ip.cache_sz = data * XML->sys.mc.req_window_size_per_channel;
-  interface_ip.line_sz = data;
-  interface_ip.assoc = 0;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.specific_tag = 1;
-  interface_ip.tag_w = tag;
-  interface_ip.access_mode = 0;
-  interface_ip.throughput = 1.0 / mcp.clockRate;
-  interface_ip.latency = 1.0 / mcp.clockRate;
-  interface_ip.is_cache = true;
-  interface_ip.pure_cam = false;
-  interface_ip.pure_ram = false;
+  //memory request reorder buffer
+  tag							   = mcp.addressBusWidth  + EXTRA_TAG_BITS + mcp.opcodeW;
+  data    					 	   = int(ceil((XML->sys.physical_address_width + mcp.opcodeW)/8.0));
+  interface_ip.cache_sz            = data*XML->sys.mc.req_window_size_per_channel;
+  interface_ip.line_sz             = data;
+  interface_ip.assoc               = 0;
+  interface_ip.nbanks              = 1;
+  interface_ip.out_w               = interface_ip.line_sz*8;
+  interface_ip.specific_tag        = 1;
+  interface_ip.tag_w               = tag;
+  interface_ip.access_mode         = 0;
+  interface_ip.throughput          = 1.0/mcp.clockRate;
+  interface_ip.latency             = 1.0/mcp.clockRate;
+  interface_ip.is_cache			   = true;
+  interface_ip.pure_cam            = false;
+  interface_ip.pure_ram            = false;
   interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_dyn_power  = 0;
   interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports = 0;
-  interface_ip.num_rd_ports = XML->sys.mc.memory_channels_per_mc;
-  interface_ip.num_wr_ports = interface_ip.num_rd_ports;
-  interface_ip.num_se_rd_ports = 0;
-  interface_ip.num_search_ports = XML->sys.mc.memory_channels_per_mc;
-  frontendBuffer =
-      new ArrayST(&interface_ip, "MC ReorderBuffer", Uncore_device);
-  frontendBuffer->area.set_area(frontendBuffer->area.get_area() +
-                                frontendBuffer->local_result.area *
-                                    XML->sys.mc.memory_channels_per_mc);
-  area.set_area(area.get_area() +
-                frontendBuffer->local_result.area *
-                    XML->sys.mc.memory_channels_per_mc);
+  interface_ip.obj_func_cycle_t    = 1;
+  interface_ip.num_rw_ports        = 0;
+  interface_ip.num_rd_ports        = XML->sys.mc.memory_channels_per_mc;
+  interface_ip.num_wr_ports        = interface_ip.num_rd_ports;
+  interface_ip.num_se_rd_ports     = 0;
+  interface_ip.num_search_ports     = XML->sys.mc.memory_channels_per_mc;
+  frontendBuffer = new ArrayST(&interface_ip, "MC ReorderBuffer", Uncore_device);
+  frontendBuffer->area.set_area(frontendBuffer->area.get_area()+ frontendBuffer->local_result.area*XML->sys.mc.memory_channels_per_mc);
+  area.set_area(area.get_area()+ frontendBuffer->local_result.area*XML->sys.mc.memory_channels_per_mc);
 
-  // selection and arbitration logic
-  MC_arb =
-      new selection_logic(is_default, XML->sys.mc.req_window_size_per_channel,
-                          1, &interface_ip, Uncore_device);
+  //selection and arbitration logic
+  MC_arb = new selection_logic(is_default, XML->sys.mc.req_window_size_per_channel,1,&interface_ip, Uncore_device);
 
-  // read buffers.
-  data = (int)ceil(mcp.dataBusWidth / 8.0);  // Support key words first
-                                             // operation //8 means converting
-                                             // bit to Byte
-  interface_ip.cache_sz =
-      data * XML->sys.mc.IO_buffer_size_per_channel;  //*llcBlockSize;
-  interface_ip.line_sz = data;
-  interface_ip.assoc = 1;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 1;
-  interface_ip.throughput = 1.0 / mcp.clockRate;
-  interface_ip.latency = 2.0 / mcp.clockRate;
-  interface_ip.is_cache = false;
-  interface_ip.pure_cam = false;
-  interface_ip.pure_ram = true;
+  //read buffers.
+  data    					 	   = (int)ceil(mcp.dataBusWidth/8.0);//Support key words first operation //8 means converting bit to Byte
+  interface_ip.cache_sz            = data*XML->sys.mc.IO_buffer_size_per_channel;//*llcBlockSize;
+  interface_ip.line_sz             = data;
+  interface_ip.assoc               = 1;
+  interface_ip.nbanks              = 1;
+  interface_ip.out_w               = interface_ip.line_sz*8;
+  interface_ip.access_mode         = 1;
+  interface_ip.throughput          = 1.0/mcp.clockRate;
+  interface_ip.latency             = 2.0/mcp.clockRate;
+  interface_ip.is_cache			   = false;
+  interface_ip.pure_cam            = false;
+  interface_ip.pure_ram            = true;
   interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_dyn_power  = 0;
   interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports =
-      0;  // XML->sys.mc.memory_channels_per_mc*2>2?2:XML->sys.mc.memory_channels_per_mc*2;
-  interface_ip.num_rd_ports = XML->sys.mc.memory_channels_per_mc;
-  interface_ip.num_wr_ports = interface_ip.num_rd_ports;
-  interface_ip.num_se_rd_ports = 0;
+  interface_ip.obj_func_cycle_t    = 1;
+  interface_ip.num_rw_ports        = 0;//XML->sys.mc.memory_channels_per_mc*2>2?2:XML->sys.mc.memory_channels_per_mc*2;
+  interface_ip.num_rd_ports        = XML->sys.mc.memory_channels_per_mc;
+  interface_ip.num_wr_ports        = interface_ip.num_rd_ports;
+  interface_ip.num_se_rd_ports     = 0;
   readBuffer = new ArrayST(&interface_ip, "MC ReadBuffer", Uncore_device);
-  readBuffer->area.set_area(readBuffer->area.get_area() +
-                            readBuffer->local_result.area *
-                                XML->sys.mc.memory_channels_per_mc);
-  area.set_area(area.get_area() +
-                readBuffer->local_result.area *
-                    XML->sys.mc.memory_channels_per_mc);
+  readBuffer->area.set_area(readBuffer->area.get_area()+ readBuffer->local_result.area*XML->sys.mc.memory_channels_per_mc);
+  area.set_area(area.get_area()+ readBuffer->local_result.area*XML->sys.mc.memory_channels_per_mc);
 
-  // write buffer
-  data = (int)ceil(mcp.dataBusWidth / 8.0);  // Support key words first
-                                             // operation //8 means converting
-                                             // bit to Byte
-  interface_ip.cache_sz =
-      data * XML->sys.mc.IO_buffer_size_per_channel;  //*llcBlockSize;
-  interface_ip.line_sz = data;
-  interface_ip.assoc = 1;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 0;
-  interface_ip.throughput = 1.0 / mcp.clockRate;
-  interface_ip.latency = 2.0 / mcp.clockRate;
+  //write buffer
+  data    					 	   = (int)ceil(mcp.dataBusWidth/8.0);//Support key words first operation //8 means converting bit to Byte
+  interface_ip.cache_sz            = data*XML->sys.mc.IO_buffer_size_per_channel;//*llcBlockSize;
+  interface_ip.line_sz             = data;
+  interface_ip.assoc               = 1;
+  interface_ip.nbanks              = 1;
+  interface_ip.out_w               = interface_ip.line_sz*8;
+  interface_ip.access_mode         = 0;
+  interface_ip.throughput          = 1.0/mcp.clockRate;
+  interface_ip.latency             = 2.0/mcp.clockRate;
   interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_dyn_power  = 0;
   interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports = 0;
-  interface_ip.num_rd_ports = XML->sys.mc.memory_channels_per_mc;
-  interface_ip.num_wr_ports = interface_ip.num_rd_ports;
-  interface_ip.num_se_rd_ports = 0;
+  interface_ip.obj_func_cycle_t    = 1;
+  interface_ip.num_rw_ports        = 0;
+  interface_ip.num_rd_ports        = XML->sys.mc.memory_channels_per_mc;
+  interface_ip.num_wr_ports        = interface_ip.num_rd_ports;
+  interface_ip.num_se_rd_ports     = 0;
   writeBuffer = new ArrayST(&interface_ip, "MC writeBuffer", Uncore_device);
-  writeBuffer->area.set_area(writeBuffer->area.get_area() +
-                             writeBuffer->local_result.area *
-                                 XML->sys.mc.memory_channels_per_mc);
-  area.set_area(area.get_area() +
-                writeBuffer->local_result.area *
-                    XML->sys.mc.memory_channels_per_mc);
+  writeBuffer->area.set_area(writeBuffer->area.get_area()+ writeBuffer->local_result.area*XML->sys.mc.memory_channels_per_mc);
+  area.set_area(area.get_area()+ writeBuffer->local_result.area*XML->sys.mc.memory_channels_per_mc);
 
-  // SRAM structures for memory coalescing --Syed Gilani
-  // Pending Request Table (base addresses, offset addresses, threads IDs),
-  // Thread Masks
+  //SRAM structures for memory coalescing --Syed Gilani
+  //Pending Request Table (base addresses, offset addresses, threads IDs), Thread Masks
   //***PRT
-  // We assume 24 bits of base address and 8 bits of offset address.
-  // THese values are used for coalesing memory requests to the same base
-  // address block.
-  // TIDs are assumed to be 8 bits
-  /*Contents of each PRT entry
-        *
-        *  Warp ID (6 bits) | Memory address (32 bits) per thread | Request Size
-   * (2-bits) per thread |
-        *  line size= 6+ 32*16 + 2*16  ~ 64 bytes
-        *
-        *
-        */
-  data =
-      64;  // Support key words first operation //8 means converting bit to Byte
-  interface_ip.cache_sz = data * XML->sys.mc.PRT_entries;  // PRT table;
-  interface_ip.line_sz = data;
-  interface_ip.assoc = 1;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 0;
-  interface_ip.throughput = 1.0 / XML->sys.target_core_clockrate;
-  interface_ip.latency = 2.0 / XML->sys.target_core_clockrate;
+  //We assume 24 bits of base address and 8 bits of offset address.
+  //THese values are used for coalesing memory requests to the same base address block.
+  //TIDs are assumed to be 8 bits
+	  /*Contents of each PRT entry
+		*
+		*  Warp ID (6 bits) | Memory address (32 bits) per thread | Request Size (2-bits) per thread |   
+		*  line size= 6+ 32*16 + 2*16  ~ 64 bytes
+		*
+		*
+		*/  
+  data    					 	   = 64;//Support key words first operation //8 means converting bit to Byte
+  interface_ip.cache_sz            = data*XML->sys.mc.PRT_entries;//PRT table;
+  interface_ip.line_sz             = data;
+  interface_ip.assoc               = 1;
+  interface_ip.nbanks              = 1;
+  interface_ip.out_w               = interface_ip.line_sz*8;
+  interface_ip.access_mode         = 0;
+  interface_ip.throughput          = 1.0/XML->sys.target_core_clockrate;
+  interface_ip.latency             = 2.0/XML->sys.target_core_clockrate;
   interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_dyn_power  = 0;
   interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports = 0;
-  interface_ip.num_rd_ports = 1;
-  interface_ip.num_wr_ports = 1;
-  interface_ip.num_se_rd_ports = 0;
+  interface_ip.obj_func_cycle_t    = 1;
+  interface_ip.num_rw_ports        = 0;
+  interface_ip.num_rd_ports        = 1;
+  interface_ip.num_wr_ports        = 1;
+  interface_ip.num_se_rd_ports     = 0;
   PRT = new ArrayST(&interface_ip, "MC PRT", Uncore_device);
-  PRT->area.set_area(PRT->area.get_area() +
-                     PRT->local_result.area *
-                         XML->sys.mc.memory_channels_per_mc);
-  area.set_area(area.get_area() +
-                PRT->local_result.area * XML->sys.mc.memory_channels_per_mc);
+  PRT->area.set_area(PRT->area.get_area()+ PRT->local_result.area*XML->sys.mc.memory_channels_per_mc);
+  area.set_area(area.get_area()+ PRT->local_result.area*XML->sys.mc.memory_channels_per_mc);
 
-  //***ThreadMasks storage (coalesced threads whose memory requests are
-  //satisfied by each memory access)
-  /* contents of the thread masks Array
-        *  16-bit bit masks for up to 16 memory requests of a warp | Number of
-   * pending memory requests (5 bits)
-        *
-        *  16*PRT_entry thread Mask, each entry has 16 mask bits.
-        *
-        */
-  data = 2;
-  interface_ip.cache_sz = data * XML->sys.mc.PRT_entries * 16;  // PRT table;
-  interface_ip.line_sz = data;
-  interface_ip.assoc = 1;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 0;
-  interface_ip.throughput = 1.0 / XML->sys.target_core_clockrate;
-  interface_ip.latency = 2.0 / XML->sys.target_core_clockrate;
+
+  //***ThreadMasks storage (coalesced threads whose memory requests are satisfied by each memory access)
+	  /* contents of the thread masks Array
+		*  16-bit bit masks for up to 16 memory requests of a warp | Number of pending memory requests (5 bits)
+		*  
+		*  16*PRT_entry thread Mask, each entry has 16 mask bits.
+		*
+		*/  
+  data    					 	   = 2;
+  interface_ip.cache_sz            = data*XML->sys.mc.PRT_entries*16;//PRT table;
+  interface_ip.line_sz             = data;
+  interface_ip.assoc               = 1;
+  interface_ip.nbanks              = 1;
+  interface_ip.out_w               = interface_ip.line_sz*8;
+  interface_ip.access_mode         = 0;
+  interface_ip.throughput          = 1.0/XML->sys.target_core_clockrate;
+  interface_ip.latency             = 2.0/XML->sys.target_core_clockrate;
   interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_dyn_power  = 0;
   interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports = 0;
-  interface_ip.num_rd_ports = 1;
-  interface_ip.num_wr_ports = 1;
-  interface_ip.num_se_rd_ports = 0;
+  interface_ip.obj_func_cycle_t    = 1;
+  interface_ip.num_rw_ports        = 0;
+  interface_ip.num_rd_ports        = 1;
+  interface_ip.num_wr_ports        = 1;
+  interface_ip.num_se_rd_ports     = 0;
   threadMasks = new ArrayST(&interface_ip, "MC ThreadMasks", Uncore_device);
-  threadMasks->area.set_area(threadMasks->area.get_area() +
-                             threadMasks->local_result.area *
-                                 XML->sys.mc.memory_channels_per_mc);
-  area.set_area(area.get_area() +
-                threadMasks->local_result.area *
-                    XML->sys.mc.memory_channels_per_mc);
+  threadMasks->area.set_area(threadMasks->area.get_area()+ threadMasks->local_result.area*XML->sys.mc.memory_channels_per_mc);
+  area.set_area(area.get_area()+ threadMasks->local_result.area*XML->sys.mc.memory_channels_per_mc);
 
   //***Numer of pending requests per PRT entry
-  /*
-        * 1-byte data, PRT entries deep
-        */
-  data = 1;
-  interface_ip.cache_sz = data * XML->sys.mc.PRT_entries;  // PRT table;
-  interface_ip.line_sz = data;
-  interface_ip.assoc = 1;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.access_mode = 0;
-  interface_ip.throughput = 1.0 / XML->sys.target_core_clockrate;
-  interface_ip.latency = 2.0 / XML->sys.target_core_clockrate;
+	  /* 
+		* 1-byte data, PRT entries deep
+		*/  
+  data    					 	   = 1;
+  interface_ip.cache_sz            = data*XML->sys.mc.PRT_entries;//PRT table;
+  interface_ip.line_sz             = data;
+  interface_ip.assoc               = 1;
+  interface_ip.nbanks              = 1;
+  interface_ip.out_w               = interface_ip.line_sz*8;
+  interface_ip.access_mode         = 0;
+  interface_ip.throughput          = 1.0/XML->sys.target_core_clockrate;
+  interface_ip.latency             = 2.0/XML->sys.target_core_clockrate;
   interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_dyn_power  = 0;
   interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports = 0;
-  interface_ip.num_rd_ports = 1;
-  interface_ip.num_wr_ports = 1;
-  interface_ip.num_se_rd_ports = 0;
+  interface_ip.obj_func_cycle_t    = 1;
+  interface_ip.num_rw_ports        = 0;
+  interface_ip.num_rd_ports        = 1;
+  interface_ip.num_wr_ports        = 1;
+  interface_ip.num_se_rd_ports     = 0;
   PRC = new ArrayST(&interface_ip, "MC PendingRequestCount", Uncore_device);
-  PRC->area.set_area(PRC->area.get_area() +
-                     PRC->local_result.area *
-                         XML->sys.mc.memory_channels_per_mc);
-  area.set_area(area.get_area() +
-                PRC->local_result.area * XML->sys.mc.memory_channels_per_mc);
+  PRC->area.set_area(PRC->area.get_area()+ PRC->local_result.area*XML->sys.mc.memory_channels_per_mc);
+  area.set_area(area.get_area()+ PRC->local_result.area*XML->sys.mc.memory_channels_per_mc);
+
 }
 
-void DRAM::computeEnergy(bool is_tdp) {
-  if (is_tdp) {
-    power.reset();
-    return;  /// not supporting TDP calculation for DRAM
-  }
-  rt_power.reset();
-  dramp.executionTime =
-      XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);
 
-  power_t.reset();
-  power_t.readOp.dynamic += XML->sys.mc.memory_reads * dramp.rd_coeff;
-  power_t.readOp.dynamic += XML->sys.mc.memory_writes * dramp.wr_coeff;
-  power_t.readOp.dynamic += XML->sys.mc.dram_pre * dramp.pre_coeff;
+void DRAM::computeEnergy(bool is_tdp)
+{
+	if (is_tdp){
+		power.reset();
+		return; /// not supporting TDP calculation for DRAM
+	}
+	rt_power.reset();
+	dramp.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
 
-  rt_power = rt_power + power_t;
+	power_t.reset();
+	power_t.readOp.dynamic+=XML->sys.mc.memory_reads*dramp.rd_coeff;
+	power_t.readOp.dynamic+=XML->sys.mc.memory_writes*dramp.wr_coeff;
+	power_t.readOp.dynamic+=XML->sys.mc.dram_pre*dramp.pre_coeff;
+
+	rt_power = rt_power + power_t ;
 }
 
-void MCFrontEnd::computeEnergy(bool is_tdp) {
-  if (is_tdp) {
-    power.reset();
-    // init stats for Peak
-    frontendBuffer->stats_t.readAc.access =
-        frontendBuffer->l_ip.num_search_ports;
-    frontendBuffer->stats_t.writeAc.access = frontendBuffer->l_ip.num_wr_ports;
-    frontendBuffer->tdp_stats = frontendBuffer->stats_t;
 
-    readBuffer->stats_t.readAc.access =
-        readBuffer->l_ip.num_rd_ports * mcp.frontend_duty_cycle;
-    readBuffer->stats_t.writeAc.access =
-        readBuffer->l_ip.num_wr_ports * mcp.frontend_duty_cycle;
-    readBuffer->tdp_stats = readBuffer->stats_t;
+void MCFrontEnd::computeEnergy(bool is_tdp)
+{
+	if (is_tdp)
+	    {
+        power.reset();
+	    	//init stats for Peak
+	    	frontendBuffer->stats_t.readAc.access  = frontendBuffer->l_ip.num_search_ports;
+	    	frontendBuffer->stats_t.writeAc.access = frontendBuffer->l_ip.num_wr_ports;
+	    	frontendBuffer->tdp_stats = frontendBuffer->stats_t;
 
-    writeBuffer->stats_t.readAc.access =
-        writeBuffer->l_ip.num_rd_ports * mcp.frontend_duty_cycle;
-    writeBuffer->stats_t.writeAc.access =
-        writeBuffer->l_ip.num_wr_ports * mcp.frontend_duty_cycle;
-    writeBuffer->tdp_stats = writeBuffer->stats_t;
+	    	readBuffer->stats_t.readAc.access  = readBuffer->l_ip.num_rd_ports*mcp.frontend_duty_cycle;
+	    	readBuffer->stats_t.writeAc.access = readBuffer->l_ip.num_wr_ports*mcp.frontend_duty_cycle;
+	    	readBuffer->tdp_stats = readBuffer->stats_t;
 
-    PRT->stats_t.readAc.access =
-        PRT->l_ip.num_rd_ports * mcp.frontend_duty_cycle;
-    PRT->stats_t.writeAc.access =
-        PRT->l_ip.num_wr_ports * mcp.frontend_duty_cycle;
-    PRT->tdp_stats = PRT->stats_t;
+	    	writeBuffer->stats_t.readAc.access  = writeBuffer->l_ip.num_rd_ports*mcp.frontend_duty_cycle;
+	    	writeBuffer->stats_t.writeAc.access = writeBuffer->l_ip.num_wr_ports*mcp.frontend_duty_cycle;
+	    	writeBuffer->tdp_stats = writeBuffer->stats_t;
 
-    threadMasks->stats_t.readAc.access =
-        threadMasks->l_ip.num_rd_ports * mcp.frontend_duty_cycle;
-    threadMasks->stats_t.writeAc.access =
-        threadMasks->l_ip.num_wr_ports * mcp.frontend_duty_cycle;
-    threadMasks->tdp_stats = threadMasks->stats_t;
+			PRT->stats_t.readAc.access = PRT->l_ip.num_rd_ports*mcp.frontend_duty_cycle;
+	    	PRT->stats_t.writeAc.access = PRT->l_ip.num_wr_ports*mcp.frontend_duty_cycle;
+	    	PRT->tdp_stats = PRT->stats_t;
+			
+			threadMasks->stats_t.readAc.access = threadMasks->l_ip.num_rd_ports*mcp.frontend_duty_cycle;
+	    	threadMasks->stats_t.writeAc.access = threadMasks->l_ip.num_wr_ports*mcp.frontend_duty_cycle;
+	    	threadMasks->tdp_stats = threadMasks->stats_t;
+			
+			PRC->stats_t.readAc.access = threadMasks->l_ip.num_rd_ports*mcp.frontend_duty_cycle;
+	    	PRC->stats_t.writeAc.access = threadMasks->l_ip.num_wr_ports*mcp.frontend_duty_cycle;
+	    	PRC->tdp_stats = threadMasks->stats_t;
 
-    PRC->stats_t.readAc.access =
-        threadMasks->l_ip.num_rd_ports * mcp.frontend_duty_cycle;
-    PRC->stats_t.writeAc.access =
-        threadMasks->l_ip.num_wr_ports * mcp.frontend_duty_cycle;
-    PRC->tdp_stats = threadMasks->stats_t;
+	    }
+	    else
+	    {
+        rt_power.reset(); //Jingwen
+	    	//init stats for runtime power (RTP)
+	    	frontendBuffer->stats_t.readAc.access  = XML->sys.mc.memory_reads *mcp.llcBlockSize*8.0/mcp.dataBusWidth*mcp.dataBusWidth/72;
+	    	//For each channel, each memory word need to check the address data to achieve best scheduling results.
+	    	//and this need to be done on all physical DIMMs in each logical memory DIMM *mcp.dataBusWidth/72
+	    	frontendBuffer->stats_t.writeAc.access = XML->sys.mc.memory_writes*mcp.llcBlockSize*8.0/mcp.dataBusWidth*mcp.dataBusWidth/72;
+	    	frontendBuffer->rtp_stats = frontendBuffer->stats_t;
 
-  } else {
-    rt_power.reset();  // Jingwen
-    // init stats for runtime power (RTP)
-    frontendBuffer->stats_t.readAc.access =
-        XML->sys.mc.memory_reads * mcp.llcBlockSize * 8.0 / mcp.dataBusWidth *
-        mcp.dataBusWidth / 72;
-    // For each channel, each memory word need to check the address data to
-    // achieve best scheduling results.
-    // and this need to be done on all physical DIMMs in each logical memory
-    // DIMM *mcp.dataBusWidth/72
-    frontendBuffer->stats_t.writeAc.access =
-        XML->sys.mc.memory_writes * mcp.llcBlockSize * 8.0 / mcp.dataBusWidth *
-        mcp.dataBusWidth / 72;
-    frontendBuffer->rtp_stats = frontendBuffer->stats_t;
+	    	readBuffer->stats_t.readAc.access  = XML->sys.mc.memory_reads*mcp.llcBlockSize*8.0/mcp.dataBusWidth;//support key word first
+	    	readBuffer->stats_t.writeAc.access = XML->sys.mc.memory_reads*mcp.llcBlockSize*8.0/mcp.dataBusWidth;//support key word first
+	    	readBuffer->rtp_stats = readBuffer->stats_t;
 
-    readBuffer->stats_t.readAc.access =
-        XML->sys.mc.memory_reads * mcp.llcBlockSize * 8.0 /
-        mcp.dataBusWidth;  // support key word first
-    readBuffer->stats_t.writeAc.access =
-        XML->sys.mc.memory_reads * mcp.llcBlockSize * 8.0 /
-        mcp.dataBusWidth;  // support key word first
-    readBuffer->rtp_stats = readBuffer->stats_t;
+	    	writeBuffer->stats_t.readAc.access  = XML->sys.mc.memory_writes*mcp.llcBlockSize*8.0/mcp.dataBusWidth;
+	    	writeBuffer->stats_t.writeAc.access = XML->sys.mc.memory_writes*mcp.llcBlockSize*8.0/mcp.dataBusWidth;
+	    	writeBuffer->rtp_stats = writeBuffer->stats_t;
+	    	
+			//Pending request table
+			//Co-alesce all misses in caches and add an entry for them in PRT
+			//TODO: Change 0 to ithCore and move to LSU (Syed)
+			//TODO: Do these accesses represent coalesced accesses?
+			PRT->stats_t.readAc.access  = XML->sys.core[0].dcache.read_accesses + XML->sys.core[0].ccache.read_accesses +
+			                               XML->sys.core[0].tcache.read_accesses;
+	    	PRT->stats_t.writeAc.access = XML->sys.core[0].dcache.write_accesses + XML->sys.core[0].ccache.write_accesses +
+			                               XML->sys.core[0].tcache.write_accesses;
+	    	PRT->rtp_stats = PRT->stats_t;
+			
+			threadMasks->stats_t.readAc.access  = XML->sys.core[0].dcache.read_accesses + XML->sys.core[0].ccache.read_accesses +
+			                               XML->sys.core[0].tcache.read_accesses;
+	    	threadMasks->stats_t.writeAc.access = XML->sys.core[0].dcache.write_accesses + XML->sys.core[0].ccache.write_accesses +
+			                               XML->sys.core[0].tcache.write_accesses;
+	    	threadMasks->rtp_stats = threadMasks->stats_t;
 
-    writeBuffer->stats_t.readAc.access =
-        XML->sys.mc.memory_writes * mcp.llcBlockSize * 8.0 / mcp.dataBusWidth;
-    writeBuffer->stats_t.writeAc.access =
-        XML->sys.mc.memory_writes * mcp.llcBlockSize * 8.0 / mcp.dataBusWidth;
-    writeBuffer->rtp_stats = writeBuffer->stats_t;
+			PRC->stats_t.readAc.access  = XML->sys.core[0].dcache.read_accesses + XML->sys.core[0].ccache.read_accesses +
+			                               XML->sys.core[0].tcache.read_accesses;
+	    	PRC->stats_t.writeAc.access = XML->sys.core[0].dcache.write_accesses + XML->sys.core[0].ccache.write_accesses +
+			                               XML->sys.core[0].tcache.write_accesses;
+	    	PRC->rtp_stats = threadMasks->stats_t;
 
-    // Pending request table
-    // Co-alesce all misses in caches and add an entry for them in PRT
-    // TODO: Change 0 to ithCore and move to LSU (Syed)
-    // TODO: Do these accesses represent coalesced accesses?
-    PRT->stats_t.readAc.access = XML->sys.core[0].dcache.read_accesses +
-                                 XML->sys.core[0].ccache.read_accesses +
-                                 XML->sys.core[0].tcache.read_accesses;
-    PRT->stats_t.writeAc.access = XML->sys.core[0].dcache.write_accesses +
-                                  XML->sys.core[0].ccache.write_accesses +
-                                  XML->sys.core[0].tcache.write_accesses;
-    PRT->rtp_stats = PRT->stats_t;
+	    }
 
-    threadMasks->stats_t.readAc.access = XML->sys.core[0].dcache.read_accesses +
-                                         XML->sys.core[0].ccache.read_accesses +
-                                         XML->sys.core[0].tcache.read_accesses;
-    threadMasks->stats_t.writeAc.access =
-        XML->sys.core[0].dcache.write_accesses +
-        XML->sys.core[0].ccache.write_accesses +
-        XML->sys.core[0].tcache.write_accesses;
-    threadMasks->rtp_stats = threadMasks->stats_t;
+	frontendBuffer->power_t.reset();
+	readBuffer->power_t.reset();
+	writeBuffer->power_t.reset();
+    threadMasks->power_t.reset();
+    PRT->power_t.reset();
+	PRC->power_t.reset();
 
-    PRC->stats_t.readAc.access = XML->sys.core[0].dcache.read_accesses +
-                                 XML->sys.core[0].ccache.read_accesses +
-                                 XML->sys.core[0].tcache.read_accesses;
-    PRC->stats_t.writeAc.access = XML->sys.core[0].dcache.write_accesses +
-                                  XML->sys.core[0].ccache.write_accesses +
-                                  XML->sys.core[0].tcache.write_accesses;
-    PRC->rtp_stats = threadMasks->stats_t;
-  }
+//	frontendBuffer->power_t.readOp.dynamic	+= (frontendBuffer->stats_t.readAc.access*
+//			(frontendBuffer->local_result.power.searchOp.dynamic+frontendBuffer->local_result.power.readOp.dynamic)+
+//    		frontendBuffer->stats_t.writeAc.access*frontendBuffer->local_result.power.writeOp.dynamic);
 
-  frontendBuffer->power_t.reset();
-  readBuffer->power_t.reset();
-  writeBuffer->power_t.reset();
-  threadMasks->power_t.reset();
-  PRT->power_t.reset();
-  PRC->power_t.reset();
+	frontendBuffer->power_t.readOp.dynamic	+= (frontendBuffer->stats_t.readAc.access +
+			frontendBuffer->stats_t.writeAc.access)*frontendBuffer->local_result.power.searchOp.dynamic+
+		    frontendBuffer->stats_t.readAc.access * frontendBuffer->local_result.power.readOp.dynamic+
+		    frontendBuffer->stats_t.writeAc.access*frontendBuffer->local_result.power.writeOp.dynamic;
 
-  //	frontendBuffer->power_t.readOp.dynamic	+=
-  //(frontendBuffer->stats_t.readAc.access*
-  //			(frontendBuffer->local_result.power.searchOp.dynamic+frontendBuffer->local_result.power.readOp.dynamic)+
-  //    		frontendBuffer->stats_t.writeAc.access*frontendBuffer->local_result.power.writeOp.dynamic);
+	readBuffer->power_t.readOp.dynamic	+= (readBuffer->stats_t.readAc.access*
+			readBuffer->local_result.power.readOp.dynamic+
+    		readBuffer->stats_t.writeAc.access*readBuffer->local_result.power.writeOp.dynamic);
+	writeBuffer->power_t.readOp.dynamic	+= (writeBuffer->stats_t.readAc.access*
+			writeBuffer->local_result.power.readOp.dynamic+
+    		writeBuffer->stats_t.writeAc.access*writeBuffer->local_result.power.writeOp.dynamic);
 
-  frontendBuffer->power_t.readOp.dynamic +=
-      (frontendBuffer->stats_t.readAc.access +
-       frontendBuffer->stats_t.writeAc.access) *
-          frontendBuffer->local_result.power.searchOp.dynamic +
-      frontendBuffer->stats_t.readAc.access *
-          frontendBuffer->local_result.power.readOp.dynamic +
-      frontendBuffer->stats_t.writeAc.access *
-          frontendBuffer->local_result.power.writeOp.dynamic;
+	PRT->power_t.readOp.dynamic	+= (PRT->stats_t.readAc.access*
+			PRT->local_result.power.readOp.dynamic+
+    		PRT->stats_t.writeAc.access*PRT->local_result.power.writeOp.dynamic);
 
-  readBuffer->power_t.readOp.dynamic +=
-      (readBuffer->stats_t.readAc.access *
-           readBuffer->local_result.power.readOp.dynamic +
-       readBuffer->stats_t.writeAc.access *
-           readBuffer->local_result.power.writeOp.dynamic);
-  writeBuffer->power_t.readOp.dynamic +=
-      (writeBuffer->stats_t.readAc.access *
-           writeBuffer->local_result.power.readOp.dynamic +
-       writeBuffer->stats_t.writeAc.access *
-           writeBuffer->local_result.power.writeOp.dynamic);
+	threadMasks->power_t.readOp.dynamic	+= (threadMasks->stats_t.readAc.access*
+			threadMasks->local_result.power.readOp.dynamic+
+    		threadMasks->stats_t.writeAc.access*threadMasks->local_result.power.writeOp.dynamic);
 
-  PRT->power_t.readOp.dynamic +=
-      (PRT->stats_t.readAc.access * PRT->local_result.power.readOp.dynamic +
-       PRT->stats_t.writeAc.access * PRT->local_result.power.writeOp.dynamic);
+	PRC->power_t.readOp.dynamic	+= (PRC->stats_t.readAc.access*
+			PRC->local_result.power.readOp.dynamic+
+    		PRC->stats_t.writeAc.access*PRC->local_result.power.writeOp.dynamic);
 
-  threadMasks->power_t.readOp.dynamic +=
-      (threadMasks->stats_t.readAc.access *
-           threadMasks->local_result.power.readOp.dynamic +
-       threadMasks->stats_t.writeAc.access *
-           threadMasks->local_result.power.writeOp.dynamic);
+		//Add coalescing logic power (Estimated from Verilog HDL description and Synopsys PowerCompiler)--Syed
+ #define COALESCE_SCALE 1
+	double perAccessCoalescingEnergy=coalesce_scale * ((0.443e-3)*(0.5e-9)*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd)/(1*1);
+	threadMasks->power_t.readOp.dynamic += (threadMasks->stats_t.readAc.access+threadMasks->stats_t.writeAc.access)*perAccessCoalescingEnergy;
 
-  PRC->power_t.readOp.dynamic +=
-      (PRC->stats_t.readAc.access * PRC->local_result.power.readOp.dynamic +
-       PRC->stats_t.writeAc.access * PRC->local_result.power.writeOp.dynamic);
+	//printf("***PRT: %10.30f, threadMasks: %10.30f, PRC: %10.30f\n",PRT->power_t.readOp.dynamic,threadMasks->power_t.readOp.dynamic,PRC->power_t.readOp.dynamic);
+	//printf("***Accesses: read:%lf write:%lf\n",threadMasks->stats_t.readAc.access, threadMasks->stats_t.writeAc.access);
+	if (is_tdp)
+    {
+    	power = power + frontendBuffer->power_t + readBuffer->power_t + writeBuffer->power_t + PRT->power_t  + threadMasks->power_t +
+               PRC->power_t +
+		        (frontendBuffer->local_result.power +
+    	        		readBuffer->local_result.power +
+    	        		writeBuffer->local_result.power+PRT->local_result.power+
+						threadMasks->local_result.power+PRC->local_result.power)*pppm_lkg;
+		
 
-// Add coalescing logic power (Estimated from Verilog HDL description and
-// Synopsys PowerCompiler)--Syed
-#define COALESCE_SCALE 1
-  double perAccessCoalescingEnergy =
-      coalesce_scale *
-      ((0.443e-3) * (0.5e-9) * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd) /
-      (1 * 1);
-  threadMasks->power_t.readOp.dynamic += (threadMasks->stats_t.readAc.access +
-                                          threadMasks->stats_t.writeAc.access) *
-                                         perAccessCoalescingEnergy;
-
-  // printf("***PRT: %10.30f, threadMasks: %10.30f, PRC:
-  // %10.30f\n",PRT->power_t.readOp.dynamic,threadMasks->power_t.readOp.dynamic,PRC->power_t.readOp.dynamic);
-  // printf("***Accesses: read:%lf
-  // write:%lf\n",threadMasks->stats_t.readAc.access,
-  // threadMasks->stats_t.writeAc.access);
-  if (is_tdp) {
-    power =
-        power + frontendBuffer->power_t + readBuffer->power_t +
-        writeBuffer->power_t + PRT->power_t + threadMasks->power_t +
-        PRC->power_t +
-        (frontendBuffer->local_result.power + readBuffer->local_result.power +
-         writeBuffer->local_result.power + PRT->local_result.power +
-         threadMasks->local_result.power + PRC->local_result.power) *
-            pppm_lkg;
-
-  } else {
-    rt_power =
-        rt_power + frontendBuffer->power_t + readBuffer->power_t +
-        writeBuffer->power_t + PRT->power_t + threadMasks->power_t +
-        PRC->power_t +
-        (frontendBuffer->local_result.power + readBuffer->local_result.power +
-         writeBuffer->local_result.power + PRT->local_result.power +
-         threadMasks->local_result.power + PRC->local_result.power) *
-            pppm_lkg;
-    rt_power.readOp.dynamic = rt_power.readOp.dynamic +
-                              power.readOp.dynamic * 0.1 * mcp.clockRate *
-                                  mcp.num_mcs * mcp.executionTime;
-  }
+    }
+    else
+    {
+    	rt_power = rt_power + frontendBuffer->power_t + readBuffer->power_t + writeBuffer->power_t + PRT->power_t + threadMasks->power_t +
+		         PRC->power_t+
+    	         (frontendBuffer->local_result.power +
+    	        		readBuffer->local_result.power +
+    	        		writeBuffer->local_result.power + PRT->local_result.power + threadMasks->local_result.power+
+						PRC->local_result.power)*pppm_lkg;
+    	rt_power.readOp.dynamic = rt_power.readOp.dynamic + power.readOp.dynamic*0.1*mcp.clockRate*mcp.num_mcs*mcp.executionTime;
+    }
 }
 
-void MCFrontEnd::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
-  string indent_str(indent, ' ');
-  string indent_str_next(indent + 2, ' ');
+void MCFrontEnd::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
+{
+	string indent_str(indent, ' ');
+	string indent_str_next(indent+2, ' ');
 
-  if (is_tdp) {
-    cout << indent_str << "Front End ROB:" << endl;
-    cout << indent_str_next
-         << "Area = " << frontendBuffer->area.get_area() * 1e-6 << " mm^2"
-         << endl;
-    cout << indent_str_next << "Peak Dynamic = "
-         << frontendBuffer->power.readOp.dynamic * mcp.clockRate << " W"
-         << endl;
-    cout << indent_str_next
-         << "Subthreshold Leakage = " << frontendBuffer->power.readOp.leakage
-         << " W" << endl;
-    cout << indent_str_next
-         << "Gate Leakage = " << frontendBuffer->power.readOp.gate_leakage
-         << " W" << endl;
-    cout << indent_str_next << "Runtime Dynamic = "
-         << frontendBuffer->rt_power.readOp.dynamic / mcp.executionTime << " W"
-         << endl;
+	if (is_tdp)
+	{
+		cout << indent_str << "Front End ROB:" << endl;
+		cout << indent_str_next << "Area = " << frontendBuffer->area.get_area()*1e-6<< " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << frontendBuffer->power.readOp.dynamic*mcp.clockRate << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = " << frontendBuffer->power.readOp.leakage <<" W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << frontendBuffer->power.readOp.gate_leakage << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic = " << frontendBuffer->rt_power.readOp.dynamic/mcp.executionTime << " W" << endl;
 
-    cout << endl;
-    cout << indent_str << "Read Buffer:" << endl;
-    cout << indent_str_next << "Area = " << readBuffer->area.get_area() * 1e-6
-         << " mm^2" << endl;
-    cout << indent_str_next << "Peak Dynamic = "
-         << readBuffer->power.readOp.dynamic * mcp.clockRate << " W" << endl;
-    cout << indent_str_next
-         << "Subthreshold Leakage = " << readBuffer->power.readOp.leakage
-         << " W" << endl;
-    cout << indent_str_next
-         << "Gate Leakage = " << readBuffer->power.readOp.gate_leakage << " W"
-         << endl;
-    cout << indent_str_next << "Runtime Dynamic = "
-         << readBuffer->rt_power.readOp.dynamic / mcp.executionTime << " W"
-         << endl;
-    cout << endl;
-    cout << indent_str << "Write Buffer:" << endl;
-    cout << indent_str_next << "Area = " << writeBuffer->area.get_area() * 1e-6
-         << " mm^2" << endl;
-    cout << indent_str_next << "Peak Dynamic = "
-         << writeBuffer->power.readOp.dynamic * mcp.clockRate << " W" << endl;
-    cout << indent_str_next
-         << "Subthreshold Leakage = " << writeBuffer->power.readOp.leakage
-         << " W" << endl;
-    cout << indent_str_next
-         << "Gate Leakage = " << writeBuffer->power.readOp.gate_leakage << " W"
-         << endl;
-    cout << indent_str_next << "Runtime Dynamic = "
-         << writeBuffer->rt_power.readOp.dynamic / mcp.executionTime << " W"
-         << endl;
-    cout << endl;
-    cout << indent_str << "PRT:" << endl;
-    cout << indent_str_next << "Area = " << PRT->area.get_area() * 1e-6
-         << " mm^2" << endl;
-    cout << indent_str_next
-         << "Peak Dynamic = " << PRT->power.readOp.dynamic * mcp.clockRate
-         << " W" << endl;
-    cout << indent_str_next
-         << "Subthreshold Leakage = " << PRT->power.readOp.leakage << " W"
-         << endl;
-    cout << indent_str_next
-         << "Gate Leakage = " << PRT->power.readOp.gate_leakage << " W" << endl;
-    cout << indent_str_next << "Runtime Dynamic = "
-         << PRT->rt_power.readOp.dynamic / mcp.executionTime << " W" << endl;
-    cout << endl;
-    cout << indent_str << "Thread Masks and coalescing logic:" << endl;
-    cout << indent_str_next << "Area = " << threadMasks->area.get_area() * 1e-6
-         << " mm^2" << endl;
-    cout << indent_str_next << "Peak Dynamic = "
-         << threadMasks->power.readOp.dynamic * mcp.clockRate << " W" << endl;
-    cout << indent_str_next
-         << "Subthreshold Leakage = " << threadMasks->power.readOp.leakage
-         << " W" << endl;
-    cout << indent_str_next
-         << "Gate Leakage = " << threadMasks->power.readOp.gate_leakage << " W"
-         << endl;
-    cout << indent_str_next << "Runtime Dynamic = "
-         << threadMasks->rt_power.readOp.dynamic / mcp.executionTime << " W"
-         << endl;
-    cout << endl;
+		cout <<endl;
+		cout << indent_str<< "Read Buffer:" << endl;
+		cout << indent_str_next << "Area = " << readBuffer->area.get_area()*1e-6  << " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << readBuffer->power.readOp.dynamic*mcp.clockRate  << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = " << readBuffer->power.readOp.leakage  << " W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << readBuffer->power.readOp.gate_leakage  << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic = " << readBuffer->rt_power.readOp.dynamic/mcp.executionTime << " W" << endl;
+		cout <<endl;
+		cout << indent_str << "Write Buffer:" << endl;
+		cout << indent_str_next << "Area = " << writeBuffer->area.get_area() *1e-6 << " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << writeBuffer->power.readOp.dynamic*mcp.clockRate  << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = " << writeBuffer->power.readOp.leakage  << " W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << writeBuffer->power.readOp.gate_leakage  << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic = " << writeBuffer->rt_power.readOp.dynamic/mcp.executionTime << " W" << endl;
+		cout <<endl;
+		cout << indent_str << "PRT:" << endl;
+		cout << indent_str_next << "Area = " << PRT->area.get_area() *1e-6 << " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << PRT->power.readOp.dynamic*mcp.clockRate  << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = " << PRT->power.readOp.leakage  << " W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << PRT->power.readOp.gate_leakage  << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic = " << PRT->rt_power.readOp.dynamic/mcp.executionTime << " W" << endl;
+		cout <<endl;
+		cout << indent_str << "Thread Masks and coalescing logic:" << endl;
+		cout << indent_str_next << "Area = " << threadMasks->area.get_area() *1e-6 << " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << threadMasks->power.readOp.dynamic*mcp.clockRate  << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = " << threadMasks->power.readOp.leakage  << " W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << threadMasks->power.readOp.gate_leakage  << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic = " << threadMasks->rt_power.readOp.dynamic/mcp.executionTime << " W" << endl;
+		cout <<endl;
 
-  } else {
-    cout << indent_str << "Front End ROB:" << endl;
-    cout << indent_str_next
-         << "Area = " << frontendBuffer->area.get_area() * 1e-6 << " mm^2"
-         << endl;
-    cout << indent_str_next << "Peak Dynamic = "
-         << frontendBuffer->rt_power.readOp.dynamic * mcp.clockRate << " W"
-         << endl;
-    cout << indent_str_next
-         << "Subthreshold Leakage = " << frontendBuffer->rt_power.readOp.leakage
-         << " W" << endl;
-    cout << indent_str_next
-         << "Gate Leakage = " << frontendBuffer->rt_power.readOp.gate_leakage
-         << " W" << endl;
-    cout << endl;
-    cout << indent_str << "Read Buffer:" << endl;
-    cout << indent_str_next << "Area = " << readBuffer->area.get_area() * 1e-6
-         << " mm^2" << endl;
-    cout << indent_str_next << "Peak Dynamic = "
-         << readBuffer->rt_power.readOp.dynamic * mcp.clockRate << " W" << endl;
-    cout << indent_str_next
-         << "Subthreshold Leakage = " << readBuffer->rt_power.readOp.leakage
-         << " W" << endl;
-    cout << indent_str_next
-         << "Gate Leakage = " << readBuffer->rt_power.readOp.gate_leakage
-         << " W" << endl;
-    cout << endl;
-    cout << indent_str << "Write Buffer:" << endl;
-    cout << indent_str_next << "Area = " << writeBuffer->area.get_area() * 1e-6
-         << " mm^2" << endl;
-    cout << indent_str_next << "Peak Dynamic = "
-         << writeBuffer->rt_power.readOp.dynamic * mcp.clockRate << " W"
-         << endl;
-    cout << indent_str_next
-         << "Subthreshold Leakage = " << writeBuffer->rt_power.readOp.leakage
-         << " W" << endl;
-    cout << indent_str_next
-         << "Gate Leakage = " << writeBuffer->rt_power.readOp.gate_leakage
-         << " W" << endl;
-    cout << endl;
-    cout << indent_str << "PRT:" << endl;
-    cout << indent_str_next << "Area = " << PRT->area.get_area() * 1e-6
-         << " mm^2" << endl;
-    cout << indent_str_next
-         << "Peak Dynamic = " << PRT->rt_power.readOp.dynamic * mcp.clockRate
-         << " W" << endl;
-    cout << indent_str_next
-         << "Subthreshold Leakage = " << PRT->rt_power.readOp.leakage << " W"
-         << endl;
-    cout << indent_str_next
-         << "Gate Leakage = " << PRT->rt_power.readOp.gate_leakage << " W"
-         << endl;
-    cout << endl;
-    cout << indent_str << "Thread masks and coalescing logic:" << endl;
-    cout << indent_str_next << "Area = " << threadMasks->area.get_area() * 1e-6
-         << " mm^2" << endl;
-    cout << indent_str_next << "Peak Dynamic = "
-         << threadMasks->rt_power.readOp.dynamic * mcp.clockRate << " W"
-         << endl;
-    cout << indent_str_next
-         << "Subthreshold Leakage = " << threadMasks->rt_power.readOp.leakage
-         << " W" << endl;
-    cout << indent_str_next
-         << "Gate Leakage = " << threadMasks->rt_power.readOp.gate_leakage
-         << " W" << endl;
-  }
+
+	}
+	else
+	{
+		cout << indent_str << "Front End ROB:" << endl;
+		cout << indent_str_next << "Area = " << frontendBuffer->area.get_area()*1e-6<< " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << frontendBuffer->rt_power.readOp.dynamic*mcp.clockRate << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = " << frontendBuffer->rt_power.readOp.leakage <<" W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << frontendBuffer->rt_power.readOp.gate_leakage << " W" << endl;
+		cout <<endl;
+		cout << indent_str<< "Read Buffer:" << endl;
+		cout << indent_str_next << "Area = " << readBuffer->area.get_area()*1e-6  << " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << readBuffer->rt_power.readOp.dynamic*mcp.clockRate  << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = " << readBuffer->rt_power.readOp.leakage  << " W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << readBuffer->rt_power.readOp.gate_leakage  << " W" << endl;
+		cout <<endl;
+		cout << indent_str << "Write Buffer:" << endl;
+		cout << indent_str_next << "Area = " << writeBuffer->area.get_area() *1e-6 << " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << writeBuffer->rt_power.readOp.dynamic*mcp.clockRate  << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = " << writeBuffer->rt_power.readOp.leakage  << " W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << writeBuffer->rt_power.readOp.gate_leakage  << " W" << endl;
+		cout <<endl;
+		cout << indent_str << "PRT:" << endl;
+		cout << indent_str_next << "Area = " << PRT->area.get_area() *1e-6 << " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << PRT->rt_power.readOp.dynamic*mcp.clockRate  << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = " << PRT->rt_power.readOp.leakage  << " W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << PRT->rt_power.readOp.gate_leakage  << " W" << endl;
+		cout <<endl;
+		cout << indent_str << "Thread masks and coalescing logic:" << endl;
+		cout << indent_str_next << "Area = " << threadMasks->area.get_area() *1e-6 << " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << threadMasks->rt_power.readOp.dynamic*mcp.clockRate  << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = " << threadMasks->rt_power.readOp.leakage  << " W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << threadMasks->rt_power.readOp.gate_leakage  << " W" << endl;
+
+
+	}
+
 }
 
-DRAM::DRAM(ParseXML* XML_interface, InputParameter* interface_ip_,
-           enum Dram_type dram_type_)
-    : XML(XML_interface), interface_ip(*interface_ip_), dram_type(dram_type_) {
-  set_dram_param();
+DRAM::DRAM(ParseXML *XML_interface,InputParameter* interface_ip_, enum Dram_type dram_type_)
+:XML(XML_interface),
+ interface_ip(*interface_ip_),
+ dram_type(dram_type_)
+{
+
+		set_dram_param();
+
 }
-MemoryController::MemoryController(ParseXML* XML_interface,
-                                   InputParameter* interface_ip_,
-                                   enum MemoryCtrl_type mc_type_,
-                                   enum Dram_type dram_type_)
-    : XML(XML_interface),
-      interface_ip(*interface_ip_),
-      mc_type(mc_type_),
-      frontend(0),
-      transecEngine(0),
-      PHY(0),
-      pipeLogic(0) {
+MemoryController::MemoryController(ParseXML *XML_interface,InputParameter* interface_ip_, enum MemoryCtrl_type mc_type_,enum Dram_type dram_type_)
+:XML(XML_interface),
+ interface_ip(*interface_ip_),
+ mc_type(mc_type_),
+ frontend(0),
+ transecEngine(0),
+ PHY(0),
+ pipeLogic(0)
+{
   /* All computations are for a single MC
    *
    */
   interface_ip.wire_is_mat_type = 2;
   interface_ip.wire_os_mat_type = 2;
-  interface_ip.wt = Global;
+  interface_ip.wt               =Global;
   set_mc_param();
   frontend = new MCFrontEnd(XML, &interface_ip, mcp, mc_type);
   dram = new DRAM(XML, &interface_ip, dram_type_);
-  area.set_area(area.get_area() + frontend->area.get_area());
+  area.set_area(area.get_area()+ frontend->area.get_area());
   transecEngine = new MCBackend(&interface_ip, mcp, mc_type);
-  area.set_area(area.get_area() + transecEngine->area.get_area());
-  if (mcp.type == 0 || (mcp.type == 1 && mcp.withPHY)) {
-    PHY = new MCPHY(&interface_ip, mcp, mc_type);
-    area.set_area(area.get_area() + PHY->area.get_area());
+  area.set_area(area.get_area()+ transecEngine->area.get_area());
+  if (mcp.type==0 || (mcp.type==1&&mcp.withPHY))
+  {
+	  PHY = new MCPHY(&interface_ip, mcp, mc_type);
+	  area.set_area(area.get_area()+ PHY->area.get_area());
   }
-  //+++++++++Transaction engine +++++++++++++++++ ////TODO needs better numbers,
-  //Run the RTL code from OpenSparc.
-  //  transecEngine.initialize(&interface_ip);
-  //  transecEngine.peakDataTransferRate = XML->sys.mem.peak_transfer_rate;
-  //  transecEngine.memDataWidth = dataBusWidth;
-  //  transecEngine.memRank = XML->sys.mem.number_ranks;
-  //  //transecEngine.memAccesses=XML->sys.mc.memory_accesses;
-  //  //transecEngine.llcBlocksize=llcBlockSize;
-  //  transecEngine.compute();
-  //  transecEngine.area.set_area(XML->sys.mc.memory_channels_per_mc*transecEngine.area.get_area())
-  //  ;
-  //  area.set_area(area.get_area()+ transecEngine.area.get_area());
-  //  ///cout<<"area="<<area<<endl;
-  ////
-  //  //++++++++++++++PHY ++++++++++++++++++++++++++ //TODO needs better numbers
-  //  PHY.initialize(&interface_ip);
-  //  PHY.peakDataTransferRate = XML->sys.mem.peak_transfer_rate;
-  //  PHY.memDataWidth = dataBusWidth;
-  //  //PHY.memAccesses=PHY.peakDataTransferRate;//this is the max power
-  //  //PHY.llcBlocksize=llcBlockSize;
-  //  PHY.compute();
-  //  PHY.area.set_area(XML->sys.mc.memory_channels_per_mc*PHY.area.get_area())
-  //  ;
-  //  area.set_area(area.get_area()+ PHY.area.get_area());
-  /// cout<<"area="<<area<<endl;
-  //
-  //  interface_ip.pipeline_stages = 5;//normal memory controller has five
-  //  stages in the pipeline.
-  //  interface_ip.per_stage_vector = addressBusWidth +
-  //  XML->sys.core[0].opcode_width + dataBusWidth;
-  //  pipeLogic = new pipeline(is_default, &interface_ip);
-  //  //pipeLogic.init_pipeline(is_default, &interface_ip);
-  //  pipeLogic->compute_pipeline();
-  //  area.set_area(area.get_area()+ pipeLogic->area.get_area()*1e-6);
-  //  area.set_area((area.get_area()+mc_area*1e-6)*1.1);//placement and routing
-  //  overhead
-  //
-  //
-  ////  //clock
-  ////  clockNetwork.init_wire_external(is_default, &interface_ip);
-  ////  clockNetwork.clk_area           =area*1.1;//10% of placement overhead.
-  ///rule of thumb
-  ////  clockNetwork.end_wiring_level   =5;//toplevel metal
-  ////  clockNetwork.start_wiring_level =5;//toplevel metal
-  ////  clockNetwork.num_regs           = pipeLogic.tot_stage_vector;
-  ////  clockNetwork.optimize_wire();
+  //+++++++++Transaction engine +++++++++++++++++ ////TODO needs better numbers, Run the RTL code from OpenSparc.
+//  transecEngine.initialize(&interface_ip);
+//  transecEngine.peakDataTransferRate = XML->sys.mem.peak_transfer_rate;
+//  transecEngine.memDataWidth = dataBusWidth;
+//  transecEngine.memRank = XML->sys.mem.number_ranks;
+//  //transecEngine.memAccesses=XML->sys.mc.memory_accesses;
+//  //transecEngine.llcBlocksize=llcBlockSize;
+//  transecEngine.compute();
+//  transecEngine.area.set_area(XML->sys.mc.memory_channels_per_mc*transecEngine.area.get_area()) ;
+//  area.set_area(area.get_area()+ transecEngine.area.get_area());
+//  ///cout<<"area="<<area<<endl;
+////
+//  //++++++++++++++PHY ++++++++++++++++++++++++++ //TODO needs better numbers
+//  PHY.initialize(&interface_ip);
+//  PHY.peakDataTransferRate = XML->sys.mem.peak_transfer_rate;
+//  PHY.memDataWidth = dataBusWidth;
+//  //PHY.memAccesses=PHY.peakDataTransferRate;//this is the max power
+//  //PHY.llcBlocksize=llcBlockSize;
+//  PHY.compute();
+//  PHY.area.set_area(XML->sys.mc.memory_channels_per_mc*PHY.area.get_area()) ;
+//  area.set_area(area.get_area()+ PHY.area.get_area());
+  ///cout<<"area="<<area<<endl;
+//
+//  interface_ip.pipeline_stages = 5;//normal memory controller has five stages in the pipeline.
+//  interface_ip.per_stage_vector = addressBusWidth + XML->sys.core[0].opcode_width + dataBusWidth;
+//  pipeLogic = new pipeline(is_default, &interface_ip);
+//  //pipeLogic.init_pipeline(is_default, &interface_ip);
+//  pipeLogic->compute_pipeline();
+//  area.set_area(area.get_area()+ pipeLogic->area.get_area()*1e-6);
+//  area.set_area((area.get_area()+mc_area*1e-6)*1.1);//placement and routing overhead
+//
+//
+////  //clock
+////  clockNetwork.init_wire_external(is_default, &interface_ip);
+////  clockNetwork.clk_area           =area*1.1;//10% of placement overhead. rule of thumb
+////  clockNetwork.end_wiring_level   =5;//toplevel metal
+////  clockNetwork.start_wiring_level =5;//toplevel metal
+////  clockNetwork.num_regs           = pipeLogic.tot_stage_vector;
+////  clockNetwork.optimize_wire();
+
+
 }
-void MemoryController::computeEnergy(bool is_tdp) {
-  rt_power.reset();  // Jingwen
+void MemoryController::computeEnergy(bool is_tdp)
+{
+
+  rt_power.reset(); //Jingwen
   frontend->rt_power.reset();
   transecEngine->rt_power.reset();
   dram->rt_power.reset();
-  mcp.executionTime = XML->sys.total_cycles /
-                      (XML->sys.target_core_clockrate * 1e6);  // Jingwen
-  frontend->mcp.executionTime =
-      XML->sys.total_cycles /
-      (XML->sys.target_core_clockrate * 1e6);  // Jingwen
-  transecEngine->mcp.executionTime =
-      XML->sys.total_cycles /
-      (XML->sys.target_core_clockrate * 1e6);  // Jingwen
-
+  mcp.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6); //Jingwen
+  frontend->mcp.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6); //Jingwen
+  transecEngine->mcp.executionTime  = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6); //Jingwen
+  
   /*Jingwen: give stats for backend and phy */
-  transecEngine->mcp.reads = XML->sys.mc.memory_reads;
-  transecEngine->mcp.writes = XML->sys.mc.memory_writes;
+  transecEngine->mcp.reads =XML->sys.mc.memory_reads;
+  transecEngine->mcp.writes =XML->sys.mc.memory_writes;
 
-  // set_mc_param();
+  //set_mc_param();
 
-  frontend->computeEnergy(is_tdp);
-  transecEngine->computeEnergy(is_tdp);
-  dram->computeEnergy(is_tdp);
-  if (mcp.type == 0 || (mcp.type == 1 && mcp.withPHY)) {
-    if (!is_tdp) PHY->rt_power.reset();  // Jingwen
-    PHY->mcp.reads = XML->sys.mc.memory_reads;
-    PHY->mcp.writes = XML->sys.mc.memory_writes;
-    PHY->mcp.executionTime = XML->sys.total_cycles /
-                             (XML->sys.target_core_clockrate * 1e6);  // Jingwen
-    PHY->computeEnergy(is_tdp);
-  }
-  if (is_tdp) {
-    power = power + frontend->power + transecEngine->power;
-    if (mcp.type == 0 || (mcp.type == 1 && mcp.withPHY)) {
-      power = power + PHY->power;
-    }
-  } else {
-    rt_power = rt_power + frontend->rt_power + transecEngine->rt_power +
-               dram->rt_power;
-    if (mcp.type == 0 || (mcp.type == 1 && mcp.withPHY)) {
-      rt_power = rt_power + PHY->rt_power;
-    }
-  }
+	frontend->computeEnergy(is_tdp);
+	transecEngine->computeEnergy(is_tdp);
+	dram->computeEnergy(is_tdp);
+	if (mcp.type==0 || (mcp.type==1&&mcp.withPHY))
+	{
+    if(!is_tdp)
+      PHY->rt_power.reset();//Jingwen
+    PHY->mcp.reads =XML->sys.mc.memory_reads;
+    PHY->mcp.writes =XML->sys.mc.memory_writes;
+    PHY->mcp.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6); //Jingwen
+		PHY->computeEnergy(is_tdp);
+	}
+	if (is_tdp)
+	{
+		power = power + frontend->power + transecEngine->power;
+		if (mcp.type==0 || (mcp.type==1&&mcp.withPHY))
+		{
+			power = power + PHY->power;
+		}
+	}
+	else
+	{
+		rt_power = rt_power + frontend->rt_power + transecEngine->rt_power+dram->rt_power;
+		if (mcp.type==0 || (mcp.type==1&&mcp.withPHY))
+		{
+			rt_power = rt_power + PHY->rt_power;
+		}
+	}
 }
 
-void MemoryController::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
-  string indent_str(indent, ' ');
-  string indent_str_next(indent + 2, ' ');
-  bool long_channel = XML->sys.longer_channel_device;
+void MemoryController::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
+{
+	string indent_str(indent, ' ');
+	string indent_str_next(indent+2, ' ');
+	bool long_channel = XML->sys.longer_channel_device;
 
-  if (is_tdp) {
-    cout << "Memory Controller:" << endl;
-    cout << indent_str << "Area = " << area.get_area() * 1e-6 << " mm^2"
-         << endl;
-    cout << indent_str
-         << "Peak Dynamic = " << power.readOp.dynamic * mcp.clockRate << " W"
-         << endl;
-    cout << indent_str << "Subthreshold Leakage = "
-         << (long_channel ? power.readOp.longer_channel_leakage
-                          : power.readOp.leakage)
-         << " W" << endl;
-    // cout << indent_str<< "Subthreshold Leakage = " <<
-    // power.readOp.longer_channel_leakage <<" W" << endl;
-    cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W"
-         << endl;
-    cout << indent_str
-         << "Runtime Dynamic = " << rt_power.readOp.dynamic / mcp.executionTime
-         << " W" << endl;
-    cout << endl;
-    cout << indent_str << "Front End Engine:" << endl;
-    cout << indent_str_next << "Area = " << frontend->area.get_area() * 1e-6
-         << " mm^2" << endl;
-    cout << indent_str_next
-         << "Peak Dynamic = " << frontend->power.readOp.dynamic * mcp.clockRate
-         << " W" << endl;
-    cout << indent_str_next << "Subthreshold Leakage = "
-         << (long_channel ? frontend->power.readOp.longer_channel_leakage
-                          : frontend->power.readOp.leakage)
-         << " W" << endl;
-    cout << indent_str_next
-         << "Gate Leakage = " << frontend->power.readOp.gate_leakage << " W"
-         << endl;
-    cout << indent_str_next << "Runtime Dynamic = "
-         << frontend->rt_power.readOp.dynamic / mcp.executionTime << " W"
-         << endl;
-    cout << endl;
-    // if (plevel >2){
-    frontend->displayEnergy(indent + 4, is_tdp);
-    //}
-    cout << indent_str << "Transaction Engine:" << endl;
-    cout << indent_str_next
-         << "Area = " << transecEngine->area.get_area() * 1e-6 << " mm^2"
-         << endl;
-    cout << indent_str_next << "Peak Dynamic = "
-         << transecEngine->power.readOp.dynamic * mcp.clockRate << " W" << endl;
-    cout << indent_str_next << "Subthreshold Leakage = "
-         << (long_channel ? transecEngine->power.readOp.longer_channel_leakage
-                          : transecEngine->power.readOp.leakage)
-         << " W" << endl;
-    cout << indent_str_next
-         << "Gate Leakage = " << transecEngine->power.readOp.gate_leakage
-         << " W" << endl;
-    cout << indent_str_next << "Runtime Dynamic = "
-         << transecEngine->rt_power.readOp.dynamic / mcp.executionTime << " W"
-         << endl;
-    cout << endl;
-    if (mcp.type == 0 || (mcp.type == 1 && mcp.withPHY)) {
-      cout << indent_str << "PHY:" << endl;
-      cout << indent_str_next << "Area = " << PHY->area.get_area() * 1e-6
-           << " mm^2" << endl;
-      cout << indent_str_next
-           << "Peak Dynamic = " << PHY->power.readOp.dynamic * mcp.clockRate
-           << " W" << endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel ? PHY->power.readOp.longer_channel_leakage
-                            : PHY->power.readOp.leakage)
-           << " W" << endl;
-      cout << indent_str_next
-           << "Gate Leakage = " << PHY->power.readOp.gate_leakage << " W"
-           << endl;
-      cout << indent_str_next << "Runtime Dynamic = "
-           << PHY->rt_power.readOp.dynamic / mcp.executionTime << " W" << endl;
-      cout << endl;
-    }
-  } else {
-    cout << "Memory Controller:" << endl;
-    cout << indent_str_next << "Area = " << area.get_area() * 1e-6 << " mm^2"
-         << endl;
-    cout << indent_str_next
-         << "Peak Dynamic = " << power.readOp.dynamic * mcp.clockRate << " W"
-         << endl;
-    cout << indent_str_next << "Subthreshold Leakage = " << power.readOp.leakage
-         << " W" << endl;
-    cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage
-         << " W" << endl;
-    cout << endl;
-  }
+	if (is_tdp)
+	{
+		cout << "Memory Controller:" << endl;
+		cout << indent_str<< "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
+		cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic*mcp.clockRate  << " W" << endl;
+		cout << indent_str<< "Subthreshold Leakage = "
+			<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
+		//cout << indent_str<< "Subthreshold Leakage = " << power.readOp.longer_channel_leakage <<" W" << endl;
+		cout << indent_str<< "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
+		cout << indent_str << "Runtime Dynamic = " << rt_power.readOp.dynamic/mcp.executionTime << " W" << endl;
+		cout<<endl;
+		cout << indent_str << "Front End Engine:" << endl;
+		cout << indent_str_next << "Area = " << frontend->area.get_area()*1e-6<< " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << frontend->power.readOp.dynamic*mcp.clockRate << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = "
+			<< (long_channel? frontend->power.readOp.longer_channel_leakage:frontend->power.readOp.leakage) <<" W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << frontend->power.readOp.gate_leakage << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic = " << frontend->rt_power.readOp.dynamic/mcp.executionTime << " W" << endl;
+		cout <<endl;
+		//if (plevel >2){
+			frontend->displayEnergy(indent+4,is_tdp);
+		//}
+		cout << indent_str << "Transaction Engine:" << endl;
+		cout << indent_str_next << "Area = " << transecEngine->area.get_area()*1e-6<< " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << transecEngine->power.readOp.dynamic*mcp.clockRate << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = "
+			<< (long_channel? transecEngine->power.readOp.longer_channel_leakage:transecEngine->power.readOp.leakage) <<" W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << transecEngine->power.readOp.gate_leakage << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic = " << transecEngine->rt_power.readOp.dynamic/mcp.executionTime << " W" << endl;
+		cout <<endl;
+		if (mcp.type==0 || (mcp.type==1&&mcp.withPHY))
+		{
+			cout << indent_str << "PHY:" << endl;
+			cout << indent_str_next << "Area = " << PHY->area.get_area()*1e-6<< " mm^2" << endl;
+			cout << indent_str_next << "Peak Dynamic = " << PHY->power.readOp.dynamic*mcp.clockRate << " W" << endl;
+			cout << indent_str_next << "Subthreshold Leakage = "
+			<< (long_channel? PHY->power.readOp.longer_channel_leakage:PHY->power.readOp.leakage) <<" W" << endl;
+			cout << indent_str_next << "Gate Leakage = " << PHY->power.readOp.gate_leakage << " W" << endl;
+			cout << indent_str_next << "Runtime Dynamic = " << PHY->rt_power.readOp.dynamic/mcp.executionTime << " W" << endl;
+			cout <<endl;
+		}
+	}
+	else
+	{
+		cout << "Memory Controller:" << endl;
+		cout << indent_str_next << "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << power.readOp.dynamic*mcp.clockRate << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = " << power.readOp.leakage <<" W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
+		cout<<endl;
+	}
+
 }
 
-void DRAM::set_dram_param() {
-  dramp.cmd_coeff = XML->sys.mc.dram_rd_coeff;
-  dramp.act_coeff = XML->sys.mc.dram_act_coeff;
-  dramp.nop_coeff = XML->sys.mc.dram_nop_coeff;
-  dramp.activity_coeff = XML->sys.mc.dram_activity_coeff;
-  dramp.pre_coeff = XML->sys.mc.dram_pre_coeff;
-  dramp.rd_coeff = XML->sys.mc.dram_rd_coeff;
-  dramp.wr_coeff = XML->sys.mc.dram_wr_coeff;
-  dramp.req_coeff = XML->sys.mc.dram_req_coeff;
-  dramp.const_coeff = XML->sys.mc.dram_const_coeff;
+void DRAM::set_dram_param()
+{
+	dramp.cmd_coeff 		= XML->sys.mc.dram_rd_coeff;
+	dramp.act_coeff 		= XML->sys.mc.dram_act_coeff;
+	dramp.nop_coeff			= XML->sys.mc.dram_nop_coeff;
+	dramp.activity_coeff 	= XML->sys.mc.dram_activity_coeff;
+	dramp.pre_coeff			= XML->sys.mc.dram_pre_coeff;
+	dramp.rd_coeff			= XML->sys.mc.dram_rd_coeff;
+	dramp.wr_coeff			= XML->sys.mc.dram_wr_coeff;
+	dramp.req_coeff			= XML->sys.mc.dram_req_coeff;
+	dramp.const_coeff		= XML->sys.mc.dram_const_coeff;
 }
 
-void MemoryController::set_mc_param() {
-  if (mc_type == MC) {
-    mcp.clockRate = XML->sys.mc.mc_clock * 2;  // DDR double pumped
-    mcp.clockRate *= 1e6;
-    mcp.executionTime =
-        XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);
+void MemoryController::set_mc_param()
+{
 
-    mcp.llcBlockSize = int(ceil(XML->sys.mc.llc_line_length / 8.0)) +
-                       XML->sys.mc.llc_line_length;  // ecc overhead
-    mcp.dataBusWidth =
-        int(ceil(XML->sys.mc.databus_width / 8.0)) + XML->sys.mc.databus_width;
-    mcp.addressBusWidth = int(ceil(
-        XML->sys.mc.addressbus_width));  // XML->sys.physical_address_width;
-    mcp.opcodeW = 16;
-    mcp.num_mcs = XML->sys.mc.number_mcs;
-    mcp.num_channels = XML->sys.mc.memory_channels_per_mc;
-    mcp.reads = XML->sys.mc.memory_reads;
-    mcp.writes = XML->sys.mc.memory_writes;
-    //+++++++++Transaction engine +++++++++++++++++ ////TODO needs better
-    //numbers, Run the RTL code from OpenSparc.
-    mcp.peakDataTransferRate = XML->sys.mc.peak_transfer_rate;
-    mcp.memRank = XML->sys.mc.number_ranks;
-    //++++++++++++++PHY ++++++++++++++++++++++++++ //TODO needs better numbers
-    // PHY.memAccesses=PHY.peakDataTransferRate;//this is the max power
-    // PHY.llcBlocksize=llcBlockSize;
-    mcp.frontend_duty_cycle = 0.5;  // for max power, the actual off-chip links
-                                    // is bidirectional but time shared
-    mcp.LVDS = XML->sys.mc.LVDS;
-    mcp.type = XML->sys.mc.type;
-    mcp.withPHY = XML->sys.mc.withPHY;
-  }
-  //	else if (mc_type==FLASHC)
-  //	{
-  //		mcp.clockRate       =XML->sys.flashc.mc_clock*2;//DDR double
-  //pumped
-  //		mcp.clockRate       *= 1e6;
-  //		mcp.executionTime   =
-  //XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
-  //
-  //		mcp.llcBlockSize
-  //=int(ceil(XML->sys.flashc.llc_line_length/8.0))+XML->sys.flashc.llc_line_length;//ecc
-  //overhead
-  //		mcp.dataBusWidth    =int(ceil(XML->sys.flashc.databus_width/8.0)) +
-  //XML->sys.flashc.databus_width;
-  //		mcp.addressBusWidth
-  //=int(ceil(XML->sys.flashc.addressbus_width));//XML->sys.physical_address_width;
-  //		mcp.opcodeW         =16;
-  //		mcp.num_mcs         = XML->sys.flashc.number_mcs;
-  //		mcp.num_channels    = XML->sys.flashc.memory_channels_per_mc;
-  //		mcp.reads  = XML->sys.flashc.memory_reads;
-  //		mcp.writes = XML->sys.flashc.memory_writes;
-  //		//+++++++++Transaction engine +++++++++++++++++ ////TODO needs
-  //better numbers, Run the RTL code from OpenSparc.
-  //		mcp.peakDataTransferRate = XML->sys.flashc.peak_transfer_rate;
-  //		mcp.memRank = XML->sys.flashc.number_ranks;
-  //		//++++++++++++++PHY ++++++++++++++++++++++++++ //TODO needs better
-  //numbers
-  //		//PHY.memAccesses=PHY.peakDataTransferRate;//this is the max
-  //power
-  //		//PHY.llcBlocksize=llcBlockSize;
-  //		mcp.frontend_duty_cycle = 0.5;//for max power, the actual off-chip
-  //links is bidirectional but time shared
-  //		mcp.LVDS = XML->sys.flashc.LVDS;
-  //		mcp.type = XML->sys.flashc.type;
-  //	}
-  else {
-    cout << "Unknown memory controller type: neither DRAM controller nor Flash "
-            "controller"
-         << endl;
-    exit(0);
-  }
+	if (mc_type==MC)
+	{
+	  mcp.clockRate       =XML->sys.mc.mc_clock*2;//DDR double pumped
+	  mcp.clockRate       *= 1e6;
+	  mcp.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
+
+	  mcp.llcBlockSize    =int(ceil(XML->sys.mc.llc_line_length/8.0))+XML->sys.mc.llc_line_length;//ecc overhead
+	  mcp.dataBusWidth    =int(ceil(XML->sys.mc.databus_width/8.0)) + XML->sys.mc.databus_width;
+	  mcp.addressBusWidth =int(ceil(XML->sys.mc.addressbus_width));//XML->sys.physical_address_width;
+	  mcp.opcodeW         =16;
+	  mcp.num_mcs         = XML->sys.mc.number_mcs;
+	  mcp.num_channels    = XML->sys.mc.memory_channels_per_mc;
+	  mcp.reads  = XML->sys.mc.memory_reads;
+	  mcp.writes = XML->sys.mc.memory_writes;
+	  //+++++++++Transaction engine +++++++++++++++++ ////TODO needs better numbers, Run the RTL code from OpenSparc.
+	  mcp.peakDataTransferRate = XML->sys.mc.peak_transfer_rate;
+	  mcp.memRank = XML->sys.mc.number_ranks;
+	  //++++++++++++++PHY ++++++++++++++++++++++++++ //TODO needs better numbers
+	  //PHY.memAccesses=PHY.peakDataTransferRate;//this is the max power
+	  //PHY.llcBlocksize=llcBlockSize;
+	  mcp.frontend_duty_cycle = 0.5;//for max power, the actual off-chip links is bidirectional but time shared
+	  mcp.LVDS = XML->sys.mc.LVDS;
+	  mcp.type = XML->sys.mc.type;
+	  mcp.withPHY = XML->sys.mc.withPHY;
+	}
+//	else if (mc_type==FLASHC)
+//	{
+//		mcp.clockRate       =XML->sys.flashc.mc_clock*2;//DDR double pumped
+//		mcp.clockRate       *= 1e6;
+//		mcp.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
+//
+//		mcp.llcBlockSize    =int(ceil(XML->sys.flashc.llc_line_length/8.0))+XML->sys.flashc.llc_line_length;//ecc overhead
+//		mcp.dataBusWidth    =int(ceil(XML->sys.flashc.databus_width/8.0)) + XML->sys.flashc.databus_width;
+//		mcp.addressBusWidth =int(ceil(XML->sys.flashc.addressbus_width));//XML->sys.physical_address_width;
+//		mcp.opcodeW         =16;
+//		mcp.num_mcs         = XML->sys.flashc.number_mcs;
+//		mcp.num_channels    = XML->sys.flashc.memory_channels_per_mc;
+//		mcp.reads  = XML->sys.flashc.memory_reads;
+//		mcp.writes = XML->sys.flashc.memory_writes;
+//		//+++++++++Transaction engine +++++++++++++++++ ////TODO needs better numbers, Run the RTL code from OpenSparc.
+//		mcp.peakDataTransferRate = XML->sys.flashc.peak_transfer_rate;
+//		mcp.memRank = XML->sys.flashc.number_ranks;
+//		//++++++++++++++PHY ++++++++++++++++++++++++++ //TODO needs better numbers
+//		//PHY.memAccesses=PHY.peakDataTransferRate;//this is the max power
+//		//PHY.llcBlocksize=llcBlockSize;
+//		mcp.frontend_duty_cycle = 0.5;//for max power, the actual off-chip links is bidirectional but time shared
+//		mcp.LVDS = XML->sys.flashc.LVDS;
+//		mcp.type = XML->sys.flashc.type;
+//	}
+	else
+	{
+		cout<<"Unknown memory controller type: neither DRAM controller nor Flash controller" <<endl;
+		exit(0);
+	}
 }
 
-MCFrontEnd::~MCFrontEnd() {
-  if (MC_arb) {
-    delete MC_arb;
-    MC_arb = 0;
-  }
-  if (frontendBuffer) {
-    delete frontendBuffer;
-    frontendBuffer = 0;
-  }
-  if (readBuffer) {
-    delete readBuffer;
-    readBuffer = 0;
-  }
-  if (writeBuffer) {
-    delete writeBuffer;
-    writeBuffer = 0;
-  }
+MCFrontEnd ::~MCFrontEnd(){
+
+	if(MC_arb) 	               {delete MC_arb; MC_arb = 0;}
+	if(frontendBuffer) 	       {delete frontendBuffer; frontendBuffer = 0;}
+	if(readBuffer) 	           {delete readBuffer; readBuffer = 0;}
+	if(writeBuffer) 	       {delete writeBuffer; writeBuffer = 0;}
 }
 
-MemoryController::~MemoryController() {
-  if (frontend) {
-    delete frontend;
-    frontend = 0;
-  }
-  if (transecEngine) {
-    delete transecEngine;
-    transecEngine = 0;
-  }
-  if (PHY) {
-    delete PHY;
-    PHY = 0;
-  }
-  if (pipeLogic) {
-    delete pipeLogic;
-    pipeLogic = 0;
-  }
+MemoryController ::~MemoryController(){
+
+	if(frontend) 	               {delete frontend; frontend = 0;}
+	if(transecEngine) 	           {delete transecEngine; transecEngine = 0;}
+	if(PHY) 	                   {delete PHY; PHY = 0;}
+	if(pipeLogic) 	               {delete pipeLogic; pipeLogic = 0;}
 }
+

--- a/src/gpuwattch/memoryctrl.cc
+++ b/src/gpuwattch/memoryctrl.cc
@@ -29,12 +29,12 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:												   *
-*      Jingwen Leng, Univeristy of Texas, Austin                   *
-*      Syed Gilani, University of Wisconsin–Madison                *
-*      Tayler Hetherington, University of British Columbia         *
-*      Ahmed ElTantawy, University of British Columbia             *
-********************************************************************/
+ *      Modified by:
+ ** Jingwen Leng, Univeristy of Texas, Austin                   * Syed Gilani,
+ *University of Wisconsin–Madison                * Tayler Hetherington,
+ *University of British Columbia         * Ahmed ElTantawy, University of
+ *British Columbia             *
+ ********************************************************************/
 // clang-format off
 #include "io.h"
 #include "parameter.h"
@@ -51,944 +51,1213 @@
 #include "basic_components.h"
 // clang-format on
 /* overview of MC models:
- * McPAT memory controllers are modeled according to large number of industrial data points.
- * The Basic memory controller architecture is base on the Synopsis designs
- * (DesignWare DDR2/DDR3-Lite memory controllers and DDR2/DDR3-Lite protocol controllers)
- * as in Cadence ChipEstimator Tool
+ * McPAT memory controllers are modeled according to large number of industrial
+ * data points. The Basic memory controller architecture is base on the Synopsis
+ * designs (DesignWare DDR2/DDR3-Lite memory controllers and DDR2/DDR3-Lite
+ * protocol controllers) as in Cadence ChipEstimator Tool
  *
- * An MC has 3 parts as shown in this design. McPAT models both high performance MC
- * based on Niagara processor designs and curving and low power MC based on data points in
- * Cadence ChipEstimator Tool.
+ * An MC has 3 parts as shown in this design. McPAT models both high performance
+ * MC based on Niagara processor designs and curving and low power MC based on
+ * data points in Cadence ChipEstimator Tool.
  *
- * The frontend is modeled analytically, the backend is modeled empirically according to
- * DDR2/DDR3-Lite protocol controllers in Cadence ChipEstimator Tool
- * The PHY is modeled based on
- * "A 100mW 9.6Gb/s Transceiver in 90nm CMOS for next-generation memory interfaces ," ISSCC 2006,
- * and A 14mW 6.25Gb/s Transceiver in 90nm CMOS for Serial Chip-to-Chip Communication," ISSCC 2007
+ * The frontend is modeled analytically, the backend is modeled empirically
+ * according to DDR2/DDR3-Lite protocol controllers in Cadence ChipEstimator
+ * Tool The PHY is modeled based on "A 100mW 9.6Gb/s Transceiver in 90nm CMOS
+ * for next-generation memory interfaces ," ISSCC 2006, and A 14mW 6.25Gb/s
+ * Transceiver in 90nm CMOS for Serial Chip-to-Chip Communication," ISSCC 2007
  *
- * In Cadence ChipEstimator Tool there are two types of memory controllers: the full memory controllers
- * that includes the frontend as the DesignWare DDR2/DDR3-Lite memory controllers and the backend only
- * memory controllers as the DDR2/DDR3-Lite protocol controllers (except DesignWare DDR2/DDR3-Lite memory
- * controllers, all memory controller IP in Cadence ChipEstimator Tool are backend memory controllers such as
- * DDRC 1600A and DDRC 800A). Thus,to some extend the area and power difference between DesignWare
- * DDR2/DDR3-Lite memory controllers and DDR2/DDR3-Lite protocol controllers can be an estimation to the
- * frontend power and area, which is very close the analitically modeled results of the frontend for Niagara2@65nm
+ * In Cadence ChipEstimator Tool there are two types of memory controllers: the
+ * full memory controllers that includes the frontend as the DesignWare
+ * DDR2/DDR3-Lite memory controllers and the backend only memory controllers as
+ * the DDR2/DDR3-Lite protocol controllers (except DesignWare DDR2/DDR3-Lite
+ * memory controllers, all memory controller IP in Cadence ChipEstimator Tool
+ * are backend memory controllers such as DDRC 1600A and DDRC 800A). Thus,to
+ * some extend the area and power difference between DesignWare DDR2/DDR3-Lite
+ * memory controllers and DDR2/DDR3-Lite protocol controllers can be an
+ * estimation to the frontend power and area, which is very close the
+ * analitically modeled results of the frontend for Niagara2@65nm
  *
  */
 
-MCBackend::MCBackend(InputParameter* interface_ip_, const MCParam & mcp_, enum MemoryCtrl_type mc_type_)
-:l_ip(*interface_ip_),
- mc_type(mc_type_),
- mcp(mcp_)
-{
-
+MCBackend::MCBackend(InputParameter* interface_ip_, const MCParam& mcp_,
+                     enum MemoryCtrl_type mc_type_)
+    : l_ip(*interface_ip_), mc_type(mc_type_), mcp(mcp_) {
   local_result = init_interface(&l_ip);
   compute();
-
 }
 
-
-void MCBackend::compute()
-{
-  //double max_row_addr_width = 20.0;//Current address 12~18bits
-  double C_MCB, mc_power, backend_dyn, backend_gates;//, refresh_period,refresh_freq;//Equivalent per bit Cap for backend,
+void MCBackend::compute() {
+  // double max_row_addr_width = 20.0;//Current address 12~18bits
+  double C_MCB, mc_power, backend_dyn,
+      backend_gates;  //, refresh_period,refresh_freq;//Equivalent per bit Cap
+                      // for backend,
   double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
   double NMOS_sizing, PMOS_sizing;
 
-  if (mc_type == MC)
-  {
-	  if (mcp.type == 0)
-	  {
-		  //area = (2.2927*log(peakDataTransferRate)-14.504)*memDataWidth/144.0*(l_ip.F_sz_um/0.09);
-		  area.set_area((2.7927*log(mcp.peakDataTransferRate*2)-19.862)/2.0*mcp.dataBusWidth/128.0*(l_ip.F_sz_um/0.09)*mcp.num_channels*1e6);//um^2
-		  //assuming the approximately same scaling factor as seen in processors.
-		  //C_MCB=0.2/1.3/1.3/266/64/0.09*g_ip.F_sz_um;//based on AMD Geode processor which has a very basic mc on chip.
-		  //C_MCB = 1.6/200/1e6/144/1.2/1.2*g_ip.F_sz_um/0.19;//Based on Niagara power numbers.The base power (W) is divided by device frequency and vdd and scale to target process.
-		  //mc_power = 0.0291*2;//29.1mW@200MHz @130nm From Power Analysis of SystemLevel OnChip Communication Architectures by Lahiri et
-		  mc_power = 4.32*0.1;//4.32W@1GhzMHz @65nm Cadence ChipEstimator 10% for backend
-		  C_MCB = mc_power/1e9/72/1.1/1.1*l_ip.F_sz_um/0.065;
-		  power_t.readOp.dynamic = C_MCB*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd*(mcp.dataBusWidth/*+mcp.addressBusWidth*/);//per access energy in memory controller
-		  power_t.readOp.leakage = area.get_area()/2 *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(g_tp.min_w_nmos_, g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd;//unit W
-		  power_t.readOp.gate_leakage = area.get_area()/2 *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(g_tp.min_w_nmos_, g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd;//unit W
+  if (mc_type == MC) {
+    if (mcp.type == 0) {
+      // area =
+      // (2.2927*log(peakDataTransferRate)-14.504)*memDataWidth/144.0*(l_ip.F_sz_um/0.09);
+      area.set_area((2.7927 * log(mcp.peakDataTransferRate * 2) - 19.862) /
+                    2.0 * mcp.dataBusWidth / 128.0 * (l_ip.F_sz_um / 0.09) *
+                    mcp.num_channels * 1e6);  // um^2
+      // assuming the approximately same scaling factor as seen in processors.
+      // C_MCB=0.2/1.3/1.3/266/64/0.09*g_ip.F_sz_um;//based on AMD Geode
+      // processor which has a very basic mc on chip. C_MCB
+      // = 1.6/200/1e6/144/1.2/1.2*g_ip.F_sz_um/0.19;//Based on Niagara power
+      // numbers.The base power (W) is divided by device frequency and vdd and
+      // scale to target process. mc_power = 0.0291*2;//29.1mW@200MHz @130nm
+      // From Power Analysis of SystemLevel OnChip Communication Architectures
+      // by Lahiri et
+      mc_power =
+          4.32 *
+          0.1;  // 4.32W@1GhzMHz @65nm Cadence ChipEstimator 10% for backend
+      C_MCB = mc_power / 1e9 / 72 / 1.1 / 1.1 * l_ip.F_sz_um / 0.065;
+      power_t.readOp.dynamic =
+          C_MCB * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd *
+          (mcp.dataBusWidth /*+mcp.addressBusWidth*/);  // per access energy in
+                                                        // memory controller
+      power_t.readOp.leakage =
+          area.get_area() / 2 * (g_tp.scaling_factor.core_tx_density) *
+          cmos_Isub_leakage(g_tp.min_w_nmos_,
+                            g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
+          g_tp.peri_global.Vdd;  // unit W
+      power_t.readOp.gate_leakage =
+          area.get_area() / 2 * (g_tp.scaling_factor.core_tx_density) *
+          cmos_Ig_leakage(g_tp.min_w_nmos_,
+                          g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
+          g_tp.peri_global.Vdd;  // unit W
 
-	  }
-	  else
-	  {   NMOS_sizing 	  = g_tp.min_w_nmos_;
-		  PMOS_sizing	  = g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
-		  area.set_area(0.15*mcp.dataBusWidth/72.0*(l_ip.F_sz_um/0.065)* (l_ip.F_sz_um/0.065)*mcp.num_channels*1e6);//um^2
-		  backend_dyn = 0.9e-9/800e6*mcp.clockRate/12800*mcp.peakDataTransferRate*mcp.dataBusWidth/72.0*g_tp.peri_global.Vdd/1.1*g_tp.peri_global.Vdd/1.1*(l_ip.F_sz_nm/65.0);//Average on DDR2/3 protocol controller and DDRC 1600/800A in Cadence ChipEstimate
-		  //Scaling to technology and DIMM feature. The base IP support DDR3-1600(PC3 12800)
-		  backend_gates = 50000*mcp.dataBusWidth/64.0;//5000 is from Cadence ChipEstimator
+    } else {
+      NMOS_sizing = g_tp.min_w_nmos_;
+      PMOS_sizing = g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r;
+      area.set_area(0.15 * mcp.dataBusWidth / 72.0 * (l_ip.F_sz_um / 0.065) *
+                    (l_ip.F_sz_um / 0.065) * mcp.num_channels * 1e6);  // um^2
+      backend_dyn =
+          0.9e-9 / 800e6 * mcp.clockRate / 12800 * mcp.peakDataTransferRate *
+          mcp.dataBusWidth / 72.0 * g_tp.peri_global.Vdd / 1.1 *
+          g_tp.peri_global.Vdd / 1.1 *
+          (l_ip.F_sz_nm / 65.0);  // Average on DDR2/3 protocol controller and
+                                  // DDRC 1600/800A in Cadence ChipEstimate
+      // Scaling to technology and DIMM feature. The base IP support
+      // DDR3-1600(PC3 12800)
+      backend_gates = 50000 * mcp.dataBusWidth /
+                      64.0;  // 5000 is from Cadence ChipEstimator
 
-		  power_t.readOp.dynamic = backend_dyn;
-		  power_t.readOp.leakage = (backend_gates)*cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
-		  power_t.readOp.gate_leakage = (backend_gates)*cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
-
-	  }
+      power_t.readOp.dynamic = backend_dyn;
+      power_t.readOp.leakage =
+          (backend_gates)*cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
+          g_tp.peri_global.Vdd;  // unit W
+      power_t.readOp.gate_leakage =
+          (backend_gates)*cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
+          g_tp.peri_global.Vdd;  // unit W
+    }
+  } else {  // skip old model
+    cout << "Unknown memory controllers" << endl;
+    exit(0);
+    area.set_area(0.243 * mcp.dataBusWidth /
+                  8);  // area based on Cadence ChipEstimator for 8bit bus
+    // mc_power = 4.32*0.1;//4.32W@1GhzMHz @65nm Cadence ChipEstimator 10% for
+    // backend
+    C_MCB = mc_power / 1e9 / 72 / 1.1 / 1.1 * l_ip.F_sz_um / 0.065;
+    power_t.readOp.leakage =
+        area.get_area() / 2 * (g_tp.scaling_factor.core_tx_density) *
+        cmos_Isub_leakage(g_tp.min_w_nmos_,
+                          g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
+        g_tp.peri_global.Vdd;  // unit W
+    power_t.readOp.gate_leakage =
+        area.get_area() / 2 * (g_tp.scaling_factor.core_tx_density) *
+        cmos_Ig_leakage(g_tp.min_w_nmos_,
+                        g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
+        g_tp.peri_global.Vdd;  // unit W
+    power_t.readOp.dynamic *= 1.2;
+    power_t.readOp.leakage *= 1.2;
+    power_t.readOp.gate_leakage *= 1.2;
+    // flash controller has about 20% more backend power since BCH ECC in flash
+    // is complex and power hungry
   }
-  else
-  {//skip old model
-	  cout<<"Unknown memory controllers"<<endl;exit(0);
-	  area.set_area(0.243*mcp.dataBusWidth/8);//area based on Cadence ChipEstimator for 8bit bus
-	  //mc_power = 4.32*0.1;//4.32W@1GhzMHz @65nm Cadence ChipEstimator 10% for backend
-	  C_MCB = mc_power/1e9/72/1.1/1.1*l_ip.F_sz_um/0.065;
-	  power_t.readOp.leakage = area.get_area()/2 *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(g_tp.min_w_nmos_, g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd;//unit W
-	  power_t.readOp.gate_leakage = area.get_area()/2 *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(g_tp.min_w_nmos_, g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd;//unit W
-	  power_t.readOp.dynamic *= 1.2;
-	  power_t.readOp.leakage *= 1.2;
-	  power_t.readOp.gate_leakage *= 1.2;
-	  //flash controller has about 20% more backend power since BCH ECC in flash is complex and power hungry
-  }
-  double long_channel_device_reduction = longer_channel_device_reduction(Uncore_device);
-  power_t.readOp.longer_channel_leakage = power_t.readOp.leakage * long_channel_device_reduction;
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(Uncore_device);
+  power_t.readOp.longer_channel_leakage =
+      power_t.readOp.leakage * long_channel_device_reduction;
 }
 
-void MCBackend::computeEnergy(bool is_tdp)
-{
-	//backend uses internal data buswidth
-	if (is_tdp)
-	{
-    power.reset(); //Jingwen
-		//init stats for Peak
-		stats_t.readAc.access   = 0.5*mcp.num_channels;
-		stats_t.writeAc.access  = 0.5*mcp.num_channels;
-		tdp_stats = stats_t;
-	}
-	else
-	{
-    rt_power.reset();//Jingwen
-		//init stats for runtime power (RTP)
-    //Jingwen: should use stats from XML object, modified in MemoryController::computeEnergy
-		stats_t.readAc.access   = mcp.reads;
-		stats_t.writeAc.access  = mcp.writes;
-		tdp_stats = stats_t;
-	}
-	if (is_tdp)
-    {
-		power = power_t;
-		power.readOp.dynamic	= (stats_t.readAc.access + stats_t.writeAc.access)*power_t.readOp.dynamic;
+void MCBackend::computeEnergy(bool is_tdp) {
+  // backend uses internal data buswidth
+  if (is_tdp) {
+    power.reset();  // Jingwen
+    // init stats for Peak
+    stats_t.readAc.access = 0.5 * mcp.num_channels;
+    stats_t.writeAc.access = 0.5 * mcp.num_channels;
+    tdp_stats = stats_t;
+  } else {
+    rt_power.reset();  // Jingwen
+    // init stats for runtime power (RTP)
+    // Jingwen: should use stats from XML object, modified in
+    // MemoryController::computeEnergy
+    stats_t.readAc.access = mcp.reads;
+    stats_t.writeAc.access = mcp.writes;
+    tdp_stats = stats_t;
+  }
+  if (is_tdp) {
+    power = power_t;
+    power.readOp.dynamic = (stats_t.readAc.access + stats_t.writeAc.access) *
+                           power_t.readOp.dynamic;
 
-    }
-    else
-    {
-    	rt_power.readOp.dynamic	= (stats_t.readAc.access + stats_t.writeAc.access)*mcp.llcBlockSize*8.0/mcp.dataBusWidth*power_t.readOp.dynamic;
-    	rt_power = rt_power + power_t*pppm_lkg;
-    	rt_power.readOp.dynamic = rt_power.readOp.dynamic + power.readOp.dynamic*0.1*mcp.clockRate*mcp.num_mcs*mcp.executionTime;
-    	//Assume 10% of peak power is consumed by routine job including memory refreshing and scrubbing
-    }
+  } else {
+    rt_power.readOp.dynamic = (stats_t.readAc.access + stats_t.writeAc.access) *
+                              mcp.llcBlockSize * 8.0 / mcp.dataBusWidth *
+                              power_t.readOp.dynamic;
+    rt_power = rt_power + power_t * pppm_lkg;
+    rt_power.readOp.dynamic =
+        rt_power.readOp.dynamic + power.readOp.dynamic * 0.1 * mcp.clockRate *
+                                      mcp.num_mcs * mcp.executionTime;
+    // Assume 10% of peak power is consumed by routine job including memory
+    // refreshing and scrubbing
+  }
 }
 
-
-MCPHY::MCPHY(InputParameter* interface_ip_, const MCParam & mcp_, enum MemoryCtrl_type mc_type_)
-:l_ip(*interface_ip_),
- mc_type(mc_type_),
- mcp(mcp_)
-{
-
+MCPHY::MCPHY(InputParameter* interface_ip_, const MCParam& mcp_,
+             enum MemoryCtrl_type mc_type_)
+    : l_ip(*interface_ip_), mc_type(mc_type_), mcp(mcp_) {
   local_result = init_interface(&l_ip);
   compute();
 }
 
-void MCPHY::compute()
-{
-  //PHY uses internal data buswidth but the actuall off-chip datawidth is 64bits + ecc
-  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio() ;
+void MCPHY::compute() {
+  // PHY uses internal data buswidth but the actuall off-chip datawidth is
+  // 64bits + ecc
+  double pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
   /*
-   * according to "A 100mW 9.6Gb/s Transceiver in 90nm CMOS for next-generation memory interfaces ," ISSCC 2006;
-   * From Cadence ChipEstimator for normal I/O around 0.4~0.8 mW/Gb/s
+   * according to "A 100mW 9.6Gb/s Transceiver in 90nm CMOS for next-generation
+   * memory interfaces ," ISSCC 2006; From Cadence ChipEstimator for normal I/O
+   * around 0.4~0.8 mW/Gb/s
    */
-  double power_per_gb_per_s,phy_gates, NMOS_sizing, PMOS_sizing;
+  double power_per_gb_per_s, phy_gates, NMOS_sizing, PMOS_sizing;
 
-  if (mc_type == MC)
-  {
-	  if (mcp.type == 0)
-	  {
-		  power_per_gb_per_s = mcp.LVDS? 0.01:0.04;
-		  //Based on die photos from Niagara 1 and 2.
-		  //TODO merge this into undifferentiated core.PHY only achieves square root of the ideal scaling.
-		  //area = (6.4323*log(peakDataTransferRate)-34.76)*memDataWidth/128.0*(l_ip.F_sz_um/0.09);
-		  area.set_area((6.4323*log(mcp.peakDataTransferRate*2)-48.134)*mcp.dataBusWidth/128.0*(l_ip.F_sz_um/0.09)*mcp.num_channels*1e6/2);//TODO:/2
-		  //This is from curve fitting based on Niagara 1 and 2's PHY die photo.
-		  //This is power not energy, 10mw/Gb/s @90nm for each channel and scaling down
-		  //power.readOp.dynamic = 0.02*memAccesses*llcBlocksize*8;//change from Bytes to bits.
-		  power_t.readOp.dynamic = power_per_gb_per_s*sqrt(l_ip.F_sz_um/0.09)*g_tp.peri_global.Vdd/1.2*g_tp.peri_global.Vdd/1.2;
-		  power_t.readOp.leakage = area.get_area()/2 *(g_tp.scaling_factor.core_tx_density)*cmos_Isub_leakage(g_tp.min_w_nmos_, g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd;//unit W
-		  power_t.readOp.gate_leakage = area.get_area()/2 *(g_tp.scaling_factor.core_tx_density)*cmos_Ig_leakage(g_tp.min_w_nmos_, g_tp.min_w_nmos_*pmos_to_nmos_sizing_r, 1, inv)*g_tp.peri_global.Vdd;//unit W
+  if (mc_type == MC) {
+    if (mcp.type == 0) {
+      power_per_gb_per_s = mcp.LVDS ? 0.01 : 0.04;
+      // Based on die photos from Niagara 1 and 2.
+      // TODO merge this into undifferentiated core.PHY only achieves square
+      // root of the ideal scaling. area =
+      // (6.4323*log(peakDataTransferRate)-34.76)*memDataWidth/128.0*(l_ip.F_sz_um/0.09);
+      area.set_area((6.4323 * log(mcp.peakDataTransferRate * 2) - 48.134) *
+                    mcp.dataBusWidth / 128.0 * (l_ip.F_sz_um / 0.09) *
+                    mcp.num_channels * 1e6 / 2);  // TODO:/2
+      // This is from curve fitting based on Niagara 1 and 2's PHY die photo.
+      // This is power not energy, 10mw/Gb/s @90nm for each channel and scaling
+      // down power.readOp.dynamic = 0.02*memAccesses*llcBlocksize*8;//change
+      // from Bytes to bits.
+      power_t.readOp.dynamic = power_per_gb_per_s * sqrt(l_ip.F_sz_um / 0.09) *
+                               g_tp.peri_global.Vdd / 1.2 *
+                               g_tp.peri_global.Vdd / 1.2;
+      power_t.readOp.leakage =
+          area.get_area() / 2 * (g_tp.scaling_factor.core_tx_density) *
+          cmos_Isub_leakage(g_tp.min_w_nmos_,
+                            g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
+          g_tp.peri_global.Vdd;  // unit W
+      power_t.readOp.gate_leakage =
+          area.get_area() / 2 * (g_tp.scaling_factor.core_tx_density) *
+          cmos_Ig_leakage(g_tp.min_w_nmos_,
+                          g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r, 1, inv) *
+          g_tp.peri_global.Vdd;  // unit W
 
-	  }
-	  else
-	  {
-		  NMOS_sizing 	  = g_tp.min_w_nmos_;
-		  PMOS_sizing	  = g_tp.min_w_nmos_*pmos_to_nmos_sizing_r;
-		  //Designware/synopsis 16bit DDR3 PHY is 1.3mm (WITH IOs) at 40nm for upto DDR3 2133 (PC3 17066)
-		  double non_IO_percentage = 0.2;
-		  area.set_area(1.3*non_IO_percentage/2133.0e6*mcp.clockRate/17066*mcp.peakDataTransferRate*mcp.dataBusWidth/16.0*(l_ip.F_sz_um/0.040)* (l_ip.F_sz_um/0.040)*mcp.num_channels*1e6);//um^2
-		  phy_gates = 200000*mcp.dataBusWidth/64.0;
-		  power_per_gb_per_s = 0.01;
-		  //This is power not energy, 10mw/Gb/s @90nm for each channel and scaling down
-		  power_t.readOp.dynamic = power_per_gb_per_s*(l_ip.F_sz_um/0.09)*g_tp.peri_global.Vdd/1.2*g_tp.peri_global.Vdd/1.2;
-		  power_t.readOp.leakage = (mcp.withPHY? phy_gates:0)*cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
-		  power_t.readOp.gate_leakage = (mcp.withPHY? phy_gates:0)*cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand)*g_tp.peri_global.Vdd;//unit W
-	  }
+    } else {
+      NMOS_sizing = g_tp.min_w_nmos_;
+      PMOS_sizing = g_tp.min_w_nmos_ * pmos_to_nmos_sizing_r;
+      // Designware/synopsis 16bit DDR3 PHY is 1.3mm (WITH IOs) at 40nm for upto
+      // DDR3 2133 (PC3 17066)
+      double non_IO_percentage = 0.2;
+      area.set_area(1.3 * non_IO_percentage / 2133.0e6 * mcp.clockRate / 17066 *
+                    mcp.peakDataTransferRate * mcp.dataBusWidth / 16.0 *
+                    (l_ip.F_sz_um / 0.040) * (l_ip.F_sz_um / 0.040) *
+                    mcp.num_channels * 1e6);  // um^2
+      phy_gates = 200000 * mcp.dataBusWidth / 64.0;
+      power_per_gb_per_s = 0.01;
+      // This is power not energy, 10mw/Gb/s @90nm for each channel and scaling
+      // down
+      power_t.readOp.dynamic = power_per_gb_per_s * (l_ip.F_sz_um / 0.09) *
+                               g_tp.peri_global.Vdd / 1.2 *
+                               g_tp.peri_global.Vdd / 1.2;
+      power_t.readOp.leakage =
+          (mcp.withPHY ? phy_gates : 0) *
+          cmos_Isub_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
+          g_tp.peri_global.Vdd;  // unit W
+      power_t.readOp.gate_leakage =
+          (mcp.withPHY ? phy_gates : 0) *
+          cmos_Ig_leakage(NMOS_sizing, PMOS_sizing, 2, nand) *
+          g_tp.peri_global.Vdd;  // unit W
+    }
 
+  } else {
+    area.set_area(0.4e6 / 2 * mcp.dataBusWidth /
+                  8);  // area based on Cadence ChipEstimator for 8bit bus
   }
-  else
-  {
-	  area.set_area(0.4e6/2*mcp.dataBusWidth/8);//area based on Cadence ChipEstimator for 8bit bus
-  }
 
-//  double phy_factor = (int)ceil(mcp.dataBusWidth/72.0);//Previous phy power numbers are based on 72 bit DIMM interface
-//  power_t.readOp.dynamic *= phy_factor;
-//  power_t.readOp.leakage *= phy_factor;
-//  power_t.readOp.gate_leakage *= phy_factor;
+  //  double phy_factor = (int)ceil(mcp.dataBusWidth/72.0);//Previous phy power
+  //  numbers are based on 72 bit DIMM interface power_t.readOp.dynamic *=
+  //  phy_factor; power_t.readOp.leakage *= phy_factor;
+  //  power_t.readOp.gate_leakage *= phy_factor;
 
-  double long_channel_device_reduction = longer_channel_device_reduction(Uncore_device);
-  power_t.readOp.longer_channel_leakage = power_t.readOp.leakage * long_channel_device_reduction;
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(Uncore_device);
+  power_t.readOp.longer_channel_leakage =
+      power_t.readOp.leakage * long_channel_device_reduction;
 }
 
+void MCPHY::computeEnergy(bool is_tdp) {
+  if (is_tdp) {
+    power.reset();  // Jingwen
+    // init stats for Peak
+    stats_t.readAc.access = 0.5 * mcp.num_channels;  // time share on buses
+    stats_t.writeAc.access = 0.5 * mcp.num_channels;
+    tdp_stats = stats_t;
+  } else {
+    rt_power.reset();  // Jingwen
+    // init stats for runtime power (RTP)
+    // Jingwen: should use stats from XML object, modified in
+    // MemoryController::computeEnergy
+    stats_t.readAc.access = mcp.reads;
+    stats_t.writeAc.access = mcp.writes;
+    tdp_stats = stats_t;
+  }
 
-void MCPHY::computeEnergy(bool is_tdp)
-{
-	if (is_tdp)
-	{
-    power.reset(); //Jingwen
-		//init stats for Peak
-		stats_t.readAc.access   = 0.5*mcp.num_channels; //time share on buses
-		stats_t.writeAc.access  = 0.5*mcp.num_channels;
-		tdp_stats = stats_t;
-	}
-	else
-	{
-    rt_power.reset(); //Jingwen
-		//init stats for runtime power (RTP)
-    //Jingwen: should use stats from XML object, modified in MemoryController::computeEnergy
-		stats_t.readAc.access   = mcp.reads;
-		stats_t.writeAc.access  = mcp.writes;
-		tdp_stats = stats_t;
-	}
+  if (is_tdp) {
+    double data_transfer_unit = (mc_type == MC) ? 72 : 16; /*DIMM data width*/
+    power = power_t;
+    power.readOp.dynamic =
+        power.readOp.dynamic *
+        (mcp.peakDataTransferRate * 8 * 1e6 / 1e9 /*change to Gbs*/) *
+        mcp.dataBusWidth / data_transfer_unit * mcp.num_channels /
+        mcp.clockRate;
+    // divide by clock rate is for match the final computation where *clock is
+    // used
+    //(stats_t.readAc.access*power_t.readOp.dynamic+
+    //					stats_t.writeAc.access*power_t.readOp.dynamic);
 
-	if (is_tdp)
-    {
-		double data_transfer_unit = (mc_type == MC)? 72:16;/*DIMM data width*/
-		power = power_t;
-		power.readOp.dynamic	= power.readOp.dynamic * (mcp.peakDataTransferRate*8*1e6/1e9/*change to Gbs*/)*mcp.dataBusWidth/data_transfer_unit*mcp.num_channels/mcp.clockRate;
-		// divide by clock rate is for match the final computation where *clock is used
-		//(stats_t.readAc.access*power_t.readOp.dynamic+
-//					stats_t.writeAc.access*power_t.readOp.dynamic);
+  } else {
+    rt_power = power_t;
+    //    	rt_power.readOp.dynamic	=
+    //    (stats_t.readAc.access*power_t.readOp.dynamic+
+    //    						stats_t.writeAc.access*power_t.readOp.dynamic);
 
-    }
-    else
-    {
-    	rt_power = power_t;
-//    	rt_power.readOp.dynamic	= (stats_t.readAc.access*power_t.readOp.dynamic+
-//    						stats_t.writeAc.access*power_t.readOp.dynamic);
-
-    	rt_power.readOp.dynamic=power_t.readOp.dynamic*(stats_t.readAc.access + stats_t.writeAc.access)*(mcp.llcBlockSize)*8/1e9/mcp.executionTime*(mcp.executionTime);
-    	rt_power.readOp.dynamic = rt_power.readOp.dynamic + power.readOp.dynamic*0.1*mcp.clockRate*mcp.num_mcs*mcp.executionTime;
-    }
+    rt_power.readOp.dynamic = power_t.readOp.dynamic *
+                              (stats_t.readAc.access + stats_t.writeAc.access) *
+                              (mcp.llcBlockSize) * 8 / 1e9 / mcp.executionTime *
+                              (mcp.executionTime);
+    rt_power.readOp.dynamic =
+        rt_power.readOp.dynamic + power.readOp.dynamic * 0.1 * mcp.clockRate *
+                                      mcp.num_mcs * mcp.executionTime;
+  }
 }
 
-MCFrontEnd::MCFrontEnd(ParseXML *XML_interface,InputParameter* interface_ip_, const MCParam & mcp_, enum MemoryCtrl_type mc_type_)
-:XML(XML_interface),
- interface_ip(*interface_ip_),
- mc_type(mc_type_),
- mcp(mcp_),
- MC_arb(0),
- frontendBuffer(0),
- readBuffer(0),
- writeBuffer(0),
- coalesce_scale(1.0)
-{
+MCFrontEnd::MCFrontEnd(ParseXML* XML_interface, InputParameter* interface_ip_,
+                       const MCParam& mcp_, enum MemoryCtrl_type mc_type_)
+    : XML(XML_interface),
+      interface_ip(*interface_ip_),
+      mc_type(mc_type_),
+      mcp(mcp_),
+      MC_arb(0),
+      frontendBuffer(0),
+      readBuffer(0),
+      writeBuffer(0),
+      coalesce_scale(1.0) {
   /* All computations are for a single MC
    *
    */
 
   int tag, data;
-  bool is_default =true;//indication for default setup
+  bool is_default = true;  // indication for default setup
 
-  /* MC frontend engine channels share the same engines but logically partitioned
-   * For all hardware inside MC. different channels do not share resources.
-   * TODO: add docodeing/mux stage to steer memory requests to different channels.
+  /* MC frontend engine channels share the same engines but logically
+   * partitioned For all hardware inside MC. different channels do not share
+   * resources.
+   * TODO: add docodeing/mux stage to steer memory requests to different
+   * channels.
    */
 
-  //memory request reorder buffer
-  tag							   = mcp.addressBusWidth  + EXTRA_TAG_BITS + mcp.opcodeW;
-  data    					 	   = int(ceil((XML->sys.physical_address_width + mcp.opcodeW)/8.0));
-  interface_ip.cache_sz            = data*XML->sys.mc.req_window_size_per_channel;
-  interface_ip.line_sz             = data;
-  interface_ip.assoc               = 0;
-  interface_ip.nbanks              = 1;
-  interface_ip.out_w               = interface_ip.line_sz*8;
-  interface_ip.specific_tag        = 1;
-  interface_ip.tag_w               = tag;
-  interface_ip.access_mode         = 0;
-  interface_ip.throughput          = 1.0/mcp.clockRate;
-  interface_ip.latency             = 1.0/mcp.clockRate;
-  interface_ip.is_cache			   = true;
-  interface_ip.pure_cam            = false;
-  interface_ip.pure_ram            = false;
+  // memory request reorder buffer
+  tag = mcp.addressBusWidth + EXTRA_TAG_BITS + mcp.opcodeW;
+  data = int(ceil((XML->sys.physical_address_width + mcp.opcodeW) / 8.0));
+  interface_ip.cache_sz = data * XML->sys.mc.req_window_size_per_channel;
+  interface_ip.line_sz = data;
+  interface_ip.assoc = 0;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.access_mode = 0;
+  interface_ip.throughput = 1.0 / mcp.clockRate;
+  interface_ip.latency = 1.0 / mcp.clockRate;
+  interface_ip.is_cache = true;
+  interface_ip.pure_cam = false;
+  interface_ip.pure_ram = false;
   interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power  = 0;
+  interface_ip.obj_func_dyn_power = 0;
   interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t    = 1;
-  interface_ip.num_rw_ports        = 0;
-  interface_ip.num_rd_ports        = XML->sys.mc.memory_channels_per_mc;
-  interface_ip.num_wr_ports        = interface_ip.num_rd_ports;
-  interface_ip.num_se_rd_ports     = 0;
-  interface_ip.num_search_ports     = XML->sys.mc.memory_channels_per_mc;
-  frontendBuffer = new ArrayST(&interface_ip, "MC ReorderBuffer", Uncore_device);
-  frontendBuffer->area.set_area(frontendBuffer->area.get_area()+ frontendBuffer->local_result.area*XML->sys.mc.memory_channels_per_mc);
-  area.set_area(area.get_area()+ frontendBuffer->local_result.area*XML->sys.mc.memory_channels_per_mc);
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = 0;
+  interface_ip.num_rd_ports = XML->sys.mc.memory_channels_per_mc;
+  interface_ip.num_wr_ports = interface_ip.num_rd_ports;
+  interface_ip.num_se_rd_ports = 0;
+  interface_ip.num_search_ports = XML->sys.mc.memory_channels_per_mc;
+  frontendBuffer =
+      new ArrayST(&interface_ip, "MC ReorderBuffer", Uncore_device);
+  frontendBuffer->area.set_area(frontendBuffer->area.get_area() +
+                                frontendBuffer->local_result.area *
+                                    XML->sys.mc.memory_channels_per_mc);
+  area.set_area(area.get_area() + frontendBuffer->local_result.area *
+                                      XML->sys.mc.memory_channels_per_mc);
 
-  //selection and arbitration logic
-  MC_arb = new selection_logic(is_default, XML->sys.mc.req_window_size_per_channel,1,&interface_ip, Uncore_device);
+  // selection and arbitration logic
+  MC_arb =
+      new selection_logic(is_default, XML->sys.mc.req_window_size_per_channel,
+                          1, &interface_ip, Uncore_device);
 
-  //read buffers.
-  data    					 	   = (int)ceil(mcp.dataBusWidth/8.0);//Support key words first operation //8 means converting bit to Byte
-  interface_ip.cache_sz            = data*XML->sys.mc.IO_buffer_size_per_channel;//*llcBlockSize;
-  interface_ip.line_sz             = data;
-  interface_ip.assoc               = 1;
-  interface_ip.nbanks              = 1;
-  interface_ip.out_w               = interface_ip.line_sz*8;
-  interface_ip.access_mode         = 1;
-  interface_ip.throughput          = 1.0/mcp.clockRate;
-  interface_ip.latency             = 2.0/mcp.clockRate;
-  interface_ip.is_cache			   = false;
-  interface_ip.pure_cam            = false;
-  interface_ip.pure_ram            = true;
+  // read buffers.
+  data =
+      (int)ceil(mcp.dataBusWidth / 8.0);  // Support key words first operation
+                                          // //8 means converting bit to Byte
+  interface_ip.cache_sz =
+      data * XML->sys.mc.IO_buffer_size_per_channel;  //*llcBlockSize;
+  interface_ip.line_sz = data;
+  interface_ip.assoc = 1;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 1;
+  interface_ip.throughput = 1.0 / mcp.clockRate;
+  interface_ip.latency = 2.0 / mcp.clockRate;
+  interface_ip.is_cache = false;
+  interface_ip.pure_cam = false;
+  interface_ip.pure_ram = true;
   interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power  = 0;
+  interface_ip.obj_func_dyn_power = 0;
   interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t    = 1;
-  interface_ip.num_rw_ports        = 0;//XML->sys.mc.memory_channels_per_mc*2>2?2:XML->sys.mc.memory_channels_per_mc*2;
-  interface_ip.num_rd_ports        = XML->sys.mc.memory_channels_per_mc;
-  interface_ip.num_wr_ports        = interface_ip.num_rd_ports;
-  interface_ip.num_se_rd_ports     = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports =
+      0;  // XML->sys.mc.memory_channels_per_mc*2>2?2:XML->sys.mc.memory_channels_per_mc*2;
+  interface_ip.num_rd_ports = XML->sys.mc.memory_channels_per_mc;
+  interface_ip.num_wr_ports = interface_ip.num_rd_ports;
+  interface_ip.num_se_rd_ports = 0;
   readBuffer = new ArrayST(&interface_ip, "MC ReadBuffer", Uncore_device);
-  readBuffer->area.set_area(readBuffer->area.get_area()+ readBuffer->local_result.area*XML->sys.mc.memory_channels_per_mc);
-  area.set_area(area.get_area()+ readBuffer->local_result.area*XML->sys.mc.memory_channels_per_mc);
+  readBuffer->area.set_area(readBuffer->area.get_area() +
+                            readBuffer->local_result.area *
+                                XML->sys.mc.memory_channels_per_mc);
+  area.set_area(area.get_area() + readBuffer->local_result.area *
+                                      XML->sys.mc.memory_channels_per_mc);
 
-  //write buffer
-  data    					 	   = (int)ceil(mcp.dataBusWidth/8.0);//Support key words first operation //8 means converting bit to Byte
-  interface_ip.cache_sz            = data*XML->sys.mc.IO_buffer_size_per_channel;//*llcBlockSize;
-  interface_ip.line_sz             = data;
-  interface_ip.assoc               = 1;
-  interface_ip.nbanks              = 1;
-  interface_ip.out_w               = interface_ip.line_sz*8;
-  interface_ip.access_mode         = 0;
-  interface_ip.throughput          = 1.0/mcp.clockRate;
-  interface_ip.latency             = 2.0/mcp.clockRate;
+  // write buffer
+  data =
+      (int)ceil(mcp.dataBusWidth / 8.0);  // Support key words first operation
+                                          // //8 means converting bit to Byte
+  interface_ip.cache_sz =
+      data * XML->sys.mc.IO_buffer_size_per_channel;  //*llcBlockSize;
+  interface_ip.line_sz = data;
+  interface_ip.assoc = 1;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 0;
+  interface_ip.throughput = 1.0 / mcp.clockRate;
+  interface_ip.latency = 2.0 / mcp.clockRate;
   interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power  = 0;
+  interface_ip.obj_func_dyn_power = 0;
   interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t    = 1;
-  interface_ip.num_rw_ports        = 0;
-  interface_ip.num_rd_ports        = XML->sys.mc.memory_channels_per_mc;
-  interface_ip.num_wr_ports        = interface_ip.num_rd_ports;
-  interface_ip.num_se_rd_ports     = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = 0;
+  interface_ip.num_rd_ports = XML->sys.mc.memory_channels_per_mc;
+  interface_ip.num_wr_ports = interface_ip.num_rd_ports;
+  interface_ip.num_se_rd_ports = 0;
   writeBuffer = new ArrayST(&interface_ip, "MC writeBuffer", Uncore_device);
-  writeBuffer->area.set_area(writeBuffer->area.get_area()+ writeBuffer->local_result.area*XML->sys.mc.memory_channels_per_mc);
-  area.set_area(area.get_area()+ writeBuffer->local_result.area*XML->sys.mc.memory_channels_per_mc);
+  writeBuffer->area.set_area(writeBuffer->area.get_area() +
+                             writeBuffer->local_result.area *
+                                 XML->sys.mc.memory_channels_per_mc);
+  area.set_area(area.get_area() + writeBuffer->local_result.area *
+                                      XML->sys.mc.memory_channels_per_mc);
 
-  //SRAM structures for memory coalescing --Syed Gilani
-  //Pending Request Table (base addresses, offset addresses, threads IDs), Thread Masks
+  // SRAM structures for memory coalescing --Syed Gilani
+  // Pending Request Table (base addresses, offset addresses, threads IDs),
+  // Thread Masks
   //***PRT
-  //We assume 24 bits of base address and 8 bits of offset address.
-  //THese values are used for coalesing memory requests to the same base address block.
-  //TIDs are assumed to be 8 bits
-	  /*Contents of each PRT entry
-		*
-		*  Warp ID (6 bits) | Memory address (32 bits) per thread | Request Size (2-bits) per thread |   
-		*  line size= 6+ 32*16 + 2*16  ~ 64 bytes
-		*
-		*
-		*/  
-  data    					 	   = 64;//Support key words first operation //8 means converting bit to Byte
-  interface_ip.cache_sz            = data*XML->sys.mc.PRT_entries;//PRT table;
-  interface_ip.line_sz             = data;
-  interface_ip.assoc               = 1;
-  interface_ip.nbanks              = 1;
-  interface_ip.out_w               = interface_ip.line_sz*8;
-  interface_ip.access_mode         = 0;
-  interface_ip.throughput          = 1.0/XML->sys.target_core_clockrate;
-  interface_ip.latency             = 2.0/XML->sys.target_core_clockrate;
+  // We assume 24 bits of base address and 8 bits of offset address.
+  // THese values are used for coalesing memory requests to the same base
+  // address block. TIDs are assumed to be 8 bits
+  /*Contents of each PRT entry
+   *
+   *  Warp ID (6 bits) | Memory address (32 bits) per thread | Request Size
+   * (2-bits) per thread | line size= 6+ 32*16 + 2*16  ~ 64 bytes
+   *
+   *
+   */
+  data =
+      64;  // Support key words first operation //8 means converting bit to Byte
+  interface_ip.cache_sz = data * XML->sys.mc.PRT_entries;  // PRT table;
+  interface_ip.line_sz = data;
+  interface_ip.assoc = 1;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 0;
+  interface_ip.throughput = 1.0 / XML->sys.target_core_clockrate;
+  interface_ip.latency = 2.0 / XML->sys.target_core_clockrate;
   interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power  = 0;
+  interface_ip.obj_func_dyn_power = 0;
   interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t    = 1;
-  interface_ip.num_rw_ports        = 0;
-  interface_ip.num_rd_ports        = 1;
-  interface_ip.num_wr_ports        = 1;
-  interface_ip.num_se_rd_ports     = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = 0;
+  interface_ip.num_rd_ports = 1;
+  interface_ip.num_wr_ports = 1;
+  interface_ip.num_se_rd_ports = 0;
   PRT = new ArrayST(&interface_ip, "MC PRT", Uncore_device);
-  PRT->area.set_area(PRT->area.get_area()+ PRT->local_result.area*XML->sys.mc.memory_channels_per_mc);
-  area.set_area(area.get_area()+ PRT->local_result.area*XML->sys.mc.memory_channels_per_mc);
+  PRT->area.set_area(PRT->area.get_area() +
+                     PRT->local_result.area *
+                         XML->sys.mc.memory_channels_per_mc);
+  area.set_area(area.get_area() +
+                PRT->local_result.area * XML->sys.mc.memory_channels_per_mc);
 
-
-  //***ThreadMasks storage (coalesced threads whose memory requests are satisfied by each memory access)
-	  /* contents of the thread masks Array
-		*  16-bit bit masks for up to 16 memory requests of a warp | Number of pending memory requests (5 bits)
-		*  
-		*  16*PRT_entry thread Mask, each entry has 16 mask bits.
-		*
-		*/  
-  data    					 	   = 2;
-  interface_ip.cache_sz            = data*XML->sys.mc.PRT_entries*16;//PRT table;
-  interface_ip.line_sz             = data;
-  interface_ip.assoc               = 1;
-  interface_ip.nbanks              = 1;
-  interface_ip.out_w               = interface_ip.line_sz*8;
-  interface_ip.access_mode         = 0;
-  interface_ip.throughput          = 1.0/XML->sys.target_core_clockrate;
-  interface_ip.latency             = 2.0/XML->sys.target_core_clockrate;
+  //***ThreadMasks storage (coalesced threads whose memory requests are
+  // satisfied by each memory access)
+  /* contents of the thread masks Array
+   *  16-bit bit masks for up to 16 memory requests of a warp | Number of
+   * pending memory requests (5 bits)
+   *
+   *  16*PRT_entry thread Mask, each entry has 16 mask bits.
+   *
+   */
+  data = 2;
+  interface_ip.cache_sz = data * XML->sys.mc.PRT_entries * 16;  // PRT table;
+  interface_ip.line_sz = data;
+  interface_ip.assoc = 1;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 0;
+  interface_ip.throughput = 1.0 / XML->sys.target_core_clockrate;
+  interface_ip.latency = 2.0 / XML->sys.target_core_clockrate;
   interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power  = 0;
+  interface_ip.obj_func_dyn_power = 0;
   interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t    = 1;
-  interface_ip.num_rw_ports        = 0;
-  interface_ip.num_rd_ports        = 1;
-  interface_ip.num_wr_ports        = 1;
-  interface_ip.num_se_rd_ports     = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = 0;
+  interface_ip.num_rd_ports = 1;
+  interface_ip.num_wr_ports = 1;
+  interface_ip.num_se_rd_ports = 0;
   threadMasks = new ArrayST(&interface_ip, "MC ThreadMasks", Uncore_device);
-  threadMasks->area.set_area(threadMasks->area.get_area()+ threadMasks->local_result.area*XML->sys.mc.memory_channels_per_mc);
-  area.set_area(area.get_area()+ threadMasks->local_result.area*XML->sys.mc.memory_channels_per_mc);
+  threadMasks->area.set_area(threadMasks->area.get_area() +
+                             threadMasks->local_result.area *
+                                 XML->sys.mc.memory_channels_per_mc);
+  area.set_area(area.get_area() + threadMasks->local_result.area *
+                                      XML->sys.mc.memory_channels_per_mc);
 
   //***Numer of pending requests per PRT entry
-	  /* 
-		* 1-byte data, PRT entries deep
-		*/  
-  data    					 	   = 1;
-  interface_ip.cache_sz            = data*XML->sys.mc.PRT_entries;//PRT table;
-  interface_ip.line_sz             = data;
-  interface_ip.assoc               = 1;
-  interface_ip.nbanks              = 1;
-  interface_ip.out_w               = interface_ip.line_sz*8;
-  interface_ip.access_mode         = 0;
-  interface_ip.throughput          = 1.0/XML->sys.target_core_clockrate;
-  interface_ip.latency             = 2.0/XML->sys.target_core_clockrate;
+  /*
+   * 1-byte data, PRT entries deep
+   */
+  data = 1;
+  interface_ip.cache_sz = data * XML->sys.mc.PRT_entries;  // PRT table;
+  interface_ip.line_sz = data;
+  interface_ip.assoc = 1;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.access_mode = 0;
+  interface_ip.throughput = 1.0 / XML->sys.target_core_clockrate;
+  interface_ip.latency = 2.0 / XML->sys.target_core_clockrate;
   interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power  = 0;
+  interface_ip.obj_func_dyn_power = 0;
   interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t    = 1;
-  interface_ip.num_rw_ports        = 0;
-  interface_ip.num_rd_ports        = 1;
-  interface_ip.num_wr_ports        = 1;
-  interface_ip.num_se_rd_ports     = 0;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = 0;
+  interface_ip.num_rd_ports = 1;
+  interface_ip.num_wr_ports = 1;
+  interface_ip.num_se_rd_ports = 0;
   PRC = new ArrayST(&interface_ip, "MC PendingRequestCount", Uncore_device);
-  PRC->area.set_area(PRC->area.get_area()+ PRC->local_result.area*XML->sys.mc.memory_channels_per_mc);
-  area.set_area(area.get_area()+ PRC->local_result.area*XML->sys.mc.memory_channels_per_mc);
-
+  PRC->area.set_area(PRC->area.get_area() +
+                     PRC->local_result.area *
+                         XML->sys.mc.memory_channels_per_mc);
+  area.set_area(area.get_area() +
+                PRC->local_result.area * XML->sys.mc.memory_channels_per_mc);
 }
 
+void DRAM::computeEnergy(bool is_tdp) {
+  if (is_tdp) {
+    power.reset();
+    return;  /// not supporting TDP calculation for DRAM
+  }
+  rt_power.reset();
+  dramp.executionTime =
+      XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);
 
-void DRAM::computeEnergy(bool is_tdp)
-{
-	if (is_tdp){
-		power.reset();
-		return; /// not supporting TDP calculation for DRAM
-	}
-	rt_power.reset();
-	dramp.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
+  power_t.reset();
+  power_t.readOp.dynamic += XML->sys.mc.memory_reads * dramp.rd_coeff;
+  power_t.readOp.dynamic += XML->sys.mc.memory_writes * dramp.wr_coeff;
+  power_t.readOp.dynamic += XML->sys.mc.dram_pre * dramp.pre_coeff;
 
-	power_t.reset();
-	power_t.readOp.dynamic+=XML->sys.mc.memory_reads*dramp.rd_coeff;
-	power_t.readOp.dynamic+=XML->sys.mc.memory_writes*dramp.wr_coeff;
-	power_t.readOp.dynamic+=XML->sys.mc.dram_pre*dramp.pre_coeff;
-
-	rt_power = rt_power + power_t ;
+  rt_power = rt_power + power_t;
 }
 
+void MCFrontEnd::computeEnergy(bool is_tdp) {
+  if (is_tdp) {
+    power.reset();
+    // init stats for Peak
+    frontendBuffer->stats_t.readAc.access =
+        frontendBuffer->l_ip.num_search_ports;
+    frontendBuffer->stats_t.writeAc.access = frontendBuffer->l_ip.num_wr_ports;
+    frontendBuffer->tdp_stats = frontendBuffer->stats_t;
 
-void MCFrontEnd::computeEnergy(bool is_tdp)
-{
-	if (is_tdp)
-	    {
-        power.reset();
-	    	//init stats for Peak
-	    	frontendBuffer->stats_t.readAc.access  = frontendBuffer->l_ip.num_search_ports;
-	    	frontendBuffer->stats_t.writeAc.access = frontendBuffer->l_ip.num_wr_ports;
-	    	frontendBuffer->tdp_stats = frontendBuffer->stats_t;
+    readBuffer->stats_t.readAc.access =
+        readBuffer->l_ip.num_rd_ports * mcp.frontend_duty_cycle;
+    readBuffer->stats_t.writeAc.access =
+        readBuffer->l_ip.num_wr_ports * mcp.frontend_duty_cycle;
+    readBuffer->tdp_stats = readBuffer->stats_t;
 
-	    	readBuffer->stats_t.readAc.access  = readBuffer->l_ip.num_rd_ports*mcp.frontend_duty_cycle;
-	    	readBuffer->stats_t.writeAc.access = readBuffer->l_ip.num_wr_ports*mcp.frontend_duty_cycle;
-	    	readBuffer->tdp_stats = readBuffer->stats_t;
+    writeBuffer->stats_t.readAc.access =
+        writeBuffer->l_ip.num_rd_ports * mcp.frontend_duty_cycle;
+    writeBuffer->stats_t.writeAc.access =
+        writeBuffer->l_ip.num_wr_ports * mcp.frontend_duty_cycle;
+    writeBuffer->tdp_stats = writeBuffer->stats_t;
 
-	    	writeBuffer->stats_t.readAc.access  = writeBuffer->l_ip.num_rd_ports*mcp.frontend_duty_cycle;
-	    	writeBuffer->stats_t.writeAc.access = writeBuffer->l_ip.num_wr_ports*mcp.frontend_duty_cycle;
-	    	writeBuffer->tdp_stats = writeBuffer->stats_t;
+    PRT->stats_t.readAc.access =
+        PRT->l_ip.num_rd_ports * mcp.frontend_duty_cycle;
+    PRT->stats_t.writeAc.access =
+        PRT->l_ip.num_wr_ports * mcp.frontend_duty_cycle;
+    PRT->tdp_stats = PRT->stats_t;
 
-			PRT->stats_t.readAc.access = PRT->l_ip.num_rd_ports*mcp.frontend_duty_cycle;
-	    	PRT->stats_t.writeAc.access = PRT->l_ip.num_wr_ports*mcp.frontend_duty_cycle;
-	    	PRT->tdp_stats = PRT->stats_t;
-			
-			threadMasks->stats_t.readAc.access = threadMasks->l_ip.num_rd_ports*mcp.frontend_duty_cycle;
-	    	threadMasks->stats_t.writeAc.access = threadMasks->l_ip.num_wr_ports*mcp.frontend_duty_cycle;
-	    	threadMasks->tdp_stats = threadMasks->stats_t;
-			
-			PRC->stats_t.readAc.access = threadMasks->l_ip.num_rd_ports*mcp.frontend_duty_cycle;
-	    	PRC->stats_t.writeAc.access = threadMasks->l_ip.num_wr_ports*mcp.frontend_duty_cycle;
-	    	PRC->tdp_stats = threadMasks->stats_t;
+    threadMasks->stats_t.readAc.access =
+        threadMasks->l_ip.num_rd_ports * mcp.frontend_duty_cycle;
+    threadMasks->stats_t.writeAc.access =
+        threadMasks->l_ip.num_wr_ports * mcp.frontend_duty_cycle;
+    threadMasks->tdp_stats = threadMasks->stats_t;
 
-	    }
-	    else
-	    {
-        rt_power.reset(); //Jingwen
-	    	//init stats for runtime power (RTP)
-	    	frontendBuffer->stats_t.readAc.access  = XML->sys.mc.memory_reads *mcp.llcBlockSize*8.0/mcp.dataBusWidth*mcp.dataBusWidth/72;
-	    	//For each channel, each memory word need to check the address data to achieve best scheduling results.
-	    	//and this need to be done on all physical DIMMs in each logical memory DIMM *mcp.dataBusWidth/72
-	    	frontendBuffer->stats_t.writeAc.access = XML->sys.mc.memory_writes*mcp.llcBlockSize*8.0/mcp.dataBusWidth*mcp.dataBusWidth/72;
-	    	frontendBuffer->rtp_stats = frontendBuffer->stats_t;
+    PRC->stats_t.readAc.access =
+        threadMasks->l_ip.num_rd_ports * mcp.frontend_duty_cycle;
+    PRC->stats_t.writeAc.access =
+        threadMasks->l_ip.num_wr_ports * mcp.frontend_duty_cycle;
+    PRC->tdp_stats = threadMasks->stats_t;
 
-	    	readBuffer->stats_t.readAc.access  = XML->sys.mc.memory_reads*mcp.llcBlockSize*8.0/mcp.dataBusWidth;//support key word first
-	    	readBuffer->stats_t.writeAc.access = XML->sys.mc.memory_reads*mcp.llcBlockSize*8.0/mcp.dataBusWidth;//support key word first
-	    	readBuffer->rtp_stats = readBuffer->stats_t;
+  } else {
+    rt_power.reset();  // Jingwen
+    // init stats for runtime power (RTP)
+    frontendBuffer->stats_t.readAc.access =
+        XML->sys.mc.memory_reads * mcp.llcBlockSize * 8.0 / mcp.dataBusWidth *
+        mcp.dataBusWidth / 72;
+    // For each channel, each memory word need to check the address data to
+    // achieve best scheduling results. and this need to be done on all physical
+    // DIMMs in each logical memory DIMM *mcp.dataBusWidth/72
+    frontendBuffer->stats_t.writeAc.access =
+        XML->sys.mc.memory_writes * mcp.llcBlockSize * 8.0 / mcp.dataBusWidth *
+        mcp.dataBusWidth / 72;
+    frontendBuffer->rtp_stats = frontendBuffer->stats_t;
 
-	    	writeBuffer->stats_t.readAc.access  = XML->sys.mc.memory_writes*mcp.llcBlockSize*8.0/mcp.dataBusWidth;
-	    	writeBuffer->stats_t.writeAc.access = XML->sys.mc.memory_writes*mcp.llcBlockSize*8.0/mcp.dataBusWidth;
-	    	writeBuffer->rtp_stats = writeBuffer->stats_t;
-	    	
-			//Pending request table
-			//Co-alesce all misses in caches and add an entry for them in PRT
-			//TODO: Change 0 to ithCore and move to LSU (Syed)
-			//TODO: Do these accesses represent coalesced accesses?
-			PRT->stats_t.readAc.access  = XML->sys.core[0].dcache.read_accesses + XML->sys.core[0].ccache.read_accesses +
-			                               XML->sys.core[0].tcache.read_accesses;
-	    	PRT->stats_t.writeAc.access = XML->sys.core[0].dcache.write_accesses + XML->sys.core[0].ccache.write_accesses +
-			                               XML->sys.core[0].tcache.write_accesses;
-	    	PRT->rtp_stats = PRT->stats_t;
-			
-			threadMasks->stats_t.readAc.access  = XML->sys.core[0].dcache.read_accesses + XML->sys.core[0].ccache.read_accesses +
-			                               XML->sys.core[0].tcache.read_accesses;
-	    	threadMasks->stats_t.writeAc.access = XML->sys.core[0].dcache.write_accesses + XML->sys.core[0].ccache.write_accesses +
-			                               XML->sys.core[0].tcache.write_accesses;
-	    	threadMasks->rtp_stats = threadMasks->stats_t;
+    readBuffer->stats_t.readAc.access =
+        XML->sys.mc.memory_reads * mcp.llcBlockSize * 8.0 /
+        mcp.dataBusWidth;  // support key word first
+    readBuffer->stats_t.writeAc.access =
+        XML->sys.mc.memory_reads * mcp.llcBlockSize * 8.0 /
+        mcp.dataBusWidth;  // support key word first
+    readBuffer->rtp_stats = readBuffer->stats_t;
 
-			PRC->stats_t.readAc.access  = XML->sys.core[0].dcache.read_accesses + XML->sys.core[0].ccache.read_accesses +
-			                               XML->sys.core[0].tcache.read_accesses;
-	    	PRC->stats_t.writeAc.access = XML->sys.core[0].dcache.write_accesses + XML->sys.core[0].ccache.write_accesses +
-			                               XML->sys.core[0].tcache.write_accesses;
-	    	PRC->rtp_stats = threadMasks->stats_t;
+    writeBuffer->stats_t.readAc.access =
+        XML->sys.mc.memory_writes * mcp.llcBlockSize * 8.0 / mcp.dataBusWidth;
+    writeBuffer->stats_t.writeAc.access =
+        XML->sys.mc.memory_writes * mcp.llcBlockSize * 8.0 / mcp.dataBusWidth;
+    writeBuffer->rtp_stats = writeBuffer->stats_t;
 
-	    }
+    // Pending request table
+    // Co-alesce all misses in caches and add an entry for them in PRT
+    // TODO: Change 0 to ithCore and move to LSU (Syed)
+    // TODO: Do these accesses represent coalesced accesses?
+    PRT->stats_t.readAc.access = XML->sys.core[0].dcache.read_accesses +
+                                 XML->sys.core[0].ccache.read_accesses +
+                                 XML->sys.core[0].tcache.read_accesses;
+    PRT->stats_t.writeAc.access = XML->sys.core[0].dcache.write_accesses +
+                                  XML->sys.core[0].ccache.write_accesses +
+                                  XML->sys.core[0].tcache.write_accesses;
+    PRT->rtp_stats = PRT->stats_t;
 
-	frontendBuffer->power_t.reset();
-	readBuffer->power_t.reset();
-	writeBuffer->power_t.reset();
-    threadMasks->power_t.reset();
-    PRT->power_t.reset();
-	PRC->power_t.reset();
+    threadMasks->stats_t.readAc.access = XML->sys.core[0].dcache.read_accesses +
+                                         XML->sys.core[0].ccache.read_accesses +
+                                         XML->sys.core[0].tcache.read_accesses;
+    threadMasks->stats_t.writeAc.access =
+        XML->sys.core[0].dcache.write_accesses +
+        XML->sys.core[0].ccache.write_accesses +
+        XML->sys.core[0].tcache.write_accesses;
+    threadMasks->rtp_stats = threadMasks->stats_t;
 
-//	frontendBuffer->power_t.readOp.dynamic	+= (frontendBuffer->stats_t.readAc.access*
-//			(frontendBuffer->local_result.power.searchOp.dynamic+frontendBuffer->local_result.power.readOp.dynamic)+
-//    		frontendBuffer->stats_t.writeAc.access*frontendBuffer->local_result.power.writeOp.dynamic);
+    PRC->stats_t.readAc.access = XML->sys.core[0].dcache.read_accesses +
+                                 XML->sys.core[0].ccache.read_accesses +
+                                 XML->sys.core[0].tcache.read_accesses;
+    PRC->stats_t.writeAc.access = XML->sys.core[0].dcache.write_accesses +
+                                  XML->sys.core[0].ccache.write_accesses +
+                                  XML->sys.core[0].tcache.write_accesses;
+    PRC->rtp_stats = threadMasks->stats_t;
+  }
 
-	frontendBuffer->power_t.readOp.dynamic	+= (frontendBuffer->stats_t.readAc.access +
-			frontendBuffer->stats_t.writeAc.access)*frontendBuffer->local_result.power.searchOp.dynamic+
-		    frontendBuffer->stats_t.readAc.access * frontendBuffer->local_result.power.readOp.dynamic+
-		    frontendBuffer->stats_t.writeAc.access*frontendBuffer->local_result.power.writeOp.dynamic;
+  frontendBuffer->power_t.reset();
+  readBuffer->power_t.reset();
+  writeBuffer->power_t.reset();
+  threadMasks->power_t.reset();
+  PRT->power_t.reset();
+  PRC->power_t.reset();
 
-	readBuffer->power_t.readOp.dynamic	+= (readBuffer->stats_t.readAc.access*
-			readBuffer->local_result.power.readOp.dynamic+
-    		readBuffer->stats_t.writeAc.access*readBuffer->local_result.power.writeOp.dynamic);
-	writeBuffer->power_t.readOp.dynamic	+= (writeBuffer->stats_t.readAc.access*
-			writeBuffer->local_result.power.readOp.dynamic+
-    		writeBuffer->stats_t.writeAc.access*writeBuffer->local_result.power.writeOp.dynamic);
+  //	frontendBuffer->power_t.readOp.dynamic	+=
+  //(frontendBuffer->stats_t.readAc.access*
+  //			(frontendBuffer->local_result.power.searchOp.dynamic+frontendBuffer->local_result.power.readOp.dynamic)+
+  //    		frontendBuffer->stats_t.writeAc.access*frontendBuffer->local_result.power.writeOp.dynamic);
 
-	PRT->power_t.readOp.dynamic	+= (PRT->stats_t.readAc.access*
-			PRT->local_result.power.readOp.dynamic+
-    		PRT->stats_t.writeAc.access*PRT->local_result.power.writeOp.dynamic);
+  frontendBuffer->power_t.readOp.dynamic +=
+      (frontendBuffer->stats_t.readAc.access +
+       frontendBuffer->stats_t.writeAc.access) *
+          frontendBuffer->local_result.power.searchOp.dynamic +
+      frontendBuffer->stats_t.readAc.access *
+          frontendBuffer->local_result.power.readOp.dynamic +
+      frontendBuffer->stats_t.writeAc.access *
+          frontendBuffer->local_result.power.writeOp.dynamic;
 
-	threadMasks->power_t.readOp.dynamic	+= (threadMasks->stats_t.readAc.access*
-			threadMasks->local_result.power.readOp.dynamic+
-    		threadMasks->stats_t.writeAc.access*threadMasks->local_result.power.writeOp.dynamic);
+  readBuffer->power_t.readOp.dynamic +=
+      (readBuffer->stats_t.readAc.access *
+           readBuffer->local_result.power.readOp.dynamic +
+       readBuffer->stats_t.writeAc.access *
+           readBuffer->local_result.power.writeOp.dynamic);
+  writeBuffer->power_t.readOp.dynamic +=
+      (writeBuffer->stats_t.readAc.access *
+           writeBuffer->local_result.power.readOp.dynamic +
+       writeBuffer->stats_t.writeAc.access *
+           writeBuffer->local_result.power.writeOp.dynamic);
 
-	PRC->power_t.readOp.dynamic	+= (PRC->stats_t.readAc.access*
-			PRC->local_result.power.readOp.dynamic+
-    		PRC->stats_t.writeAc.access*PRC->local_result.power.writeOp.dynamic);
+  PRT->power_t.readOp.dynamic +=
+      (PRT->stats_t.readAc.access * PRT->local_result.power.readOp.dynamic +
+       PRT->stats_t.writeAc.access * PRT->local_result.power.writeOp.dynamic);
 
-		//Add coalescing logic power (Estimated from Verilog HDL description and Synopsys PowerCompiler)--Syed
- #define COALESCE_SCALE 1
-	double perAccessCoalescingEnergy=coalesce_scale * ((0.443e-3)*(0.5e-9)*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd)/(1*1);
-	threadMasks->power_t.readOp.dynamic += (threadMasks->stats_t.readAc.access+threadMasks->stats_t.writeAc.access)*perAccessCoalescingEnergy;
+  threadMasks->power_t.readOp.dynamic +=
+      (threadMasks->stats_t.readAc.access *
+           threadMasks->local_result.power.readOp.dynamic +
+       threadMasks->stats_t.writeAc.access *
+           threadMasks->local_result.power.writeOp.dynamic);
 
-	//printf("***PRT: %10.30f, threadMasks: %10.30f, PRC: %10.30f\n",PRT->power_t.readOp.dynamic,threadMasks->power_t.readOp.dynamic,PRC->power_t.readOp.dynamic);
-	//printf("***Accesses: read:%lf write:%lf\n",threadMasks->stats_t.readAc.access, threadMasks->stats_t.writeAc.access);
-	if (is_tdp)
-    {
-    	power = power + frontendBuffer->power_t + readBuffer->power_t + writeBuffer->power_t + PRT->power_t  + threadMasks->power_t +
-               PRC->power_t +
-		        (frontendBuffer->local_result.power +
-    	        		readBuffer->local_result.power +
-    	        		writeBuffer->local_result.power+PRT->local_result.power+
-						threadMasks->local_result.power+PRC->local_result.power)*pppm_lkg;
-		
+  PRC->power_t.readOp.dynamic +=
+      (PRC->stats_t.readAc.access * PRC->local_result.power.readOp.dynamic +
+       PRC->stats_t.writeAc.access * PRC->local_result.power.writeOp.dynamic);
 
-    }
-    else
-    {
-    	rt_power = rt_power + frontendBuffer->power_t + readBuffer->power_t + writeBuffer->power_t + PRT->power_t + threadMasks->power_t +
-		         PRC->power_t+
-    	         (frontendBuffer->local_result.power +
-    	        		readBuffer->local_result.power +
-    	        		writeBuffer->local_result.power + PRT->local_result.power + threadMasks->local_result.power+
-						PRC->local_result.power)*pppm_lkg;
-    	rt_power.readOp.dynamic = rt_power.readOp.dynamic + power.readOp.dynamic*0.1*mcp.clockRate*mcp.num_mcs*mcp.executionTime;
-    }
+  // Add coalescing logic power (Estimated from Verilog HDL description and
+  // Synopsys PowerCompiler)--Syed
+#define COALESCE_SCALE 1
+  double perAccessCoalescingEnergy =
+      coalesce_scale *
+      ((0.443e-3) * (0.5e-9) * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd) /
+      (1 * 1);
+  threadMasks->power_t.readOp.dynamic += (threadMasks->stats_t.readAc.access +
+                                          threadMasks->stats_t.writeAc.access) *
+                                         perAccessCoalescingEnergy;
+
+  // printf("***PRT: %10.30f, threadMasks: %10.30f, PRC:
+  // %10.30f\n",PRT->power_t.readOp.dynamic,threadMasks->power_t.readOp.dynamic,PRC->power_t.readOp.dynamic);
+  // printf("***Accesses: read:%lf
+  // write:%lf\n",threadMasks->stats_t.readAc.access,
+  // threadMasks->stats_t.writeAc.access);
+  if (is_tdp) {
+    power =
+        power + frontendBuffer->power_t + readBuffer->power_t +
+        writeBuffer->power_t + PRT->power_t + threadMasks->power_t +
+        PRC->power_t +
+        (frontendBuffer->local_result.power + readBuffer->local_result.power +
+         writeBuffer->local_result.power + PRT->local_result.power +
+         threadMasks->local_result.power + PRC->local_result.power) *
+            pppm_lkg;
+
+  } else {
+    rt_power =
+        rt_power + frontendBuffer->power_t + readBuffer->power_t +
+        writeBuffer->power_t + PRT->power_t + threadMasks->power_t +
+        PRC->power_t +
+        (frontendBuffer->local_result.power + readBuffer->local_result.power +
+         writeBuffer->local_result.power + PRT->local_result.power +
+         threadMasks->local_result.power + PRC->local_result.power) *
+            pppm_lkg;
+    rt_power.readOp.dynamic =
+        rt_power.readOp.dynamic + power.readOp.dynamic * 0.1 * mcp.clockRate *
+                                      mcp.num_mcs * mcp.executionTime;
+  }
 }
 
-void MCFrontEnd::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
+void MCFrontEnd::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
 
-	if (is_tdp)
-	{
-		cout << indent_str << "Front End ROB:" << endl;
-		cout << indent_str_next << "Area = " << frontendBuffer->area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << frontendBuffer->power.readOp.dynamic*mcp.clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = " << frontendBuffer->power.readOp.leakage <<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << frontendBuffer->power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << frontendBuffer->rt_power.readOp.dynamic/mcp.executionTime << " W" << endl;
+  if (is_tdp) {
+    cout << indent_str << "Front End ROB:" << endl;
+    cout << indent_str_next
+         << "Area = " << frontendBuffer->area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str_next << "Peak Dynamic = "
+         << frontendBuffer->power.readOp.dynamic * mcp.clockRate << " W"
+         << endl;
+    cout << indent_str_next
+         << "Subthreshold Leakage = " << frontendBuffer->power.readOp.leakage
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << frontendBuffer->power.readOp.gate_leakage
+         << " W" << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << frontendBuffer->rt_power.readOp.dynamic / mcp.executionTime << " W"
+         << endl;
 
-		cout <<endl;
-		cout << indent_str<< "Read Buffer:" << endl;
-		cout << indent_str_next << "Area = " << readBuffer->area.get_area()*1e-6  << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << readBuffer->power.readOp.dynamic*mcp.clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = " << readBuffer->power.readOp.leakage  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << readBuffer->power.readOp.gate_leakage  << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << readBuffer->rt_power.readOp.dynamic/mcp.executionTime << " W" << endl;
-		cout <<endl;
-		cout << indent_str << "Write Buffer:" << endl;
-		cout << indent_str_next << "Area = " << writeBuffer->area.get_area() *1e-6 << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << writeBuffer->power.readOp.dynamic*mcp.clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = " << writeBuffer->power.readOp.leakage  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << writeBuffer->power.readOp.gate_leakage  << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << writeBuffer->rt_power.readOp.dynamic/mcp.executionTime << " W" << endl;
-		cout <<endl;
-		cout << indent_str << "PRT:" << endl;
-		cout << indent_str_next << "Area = " << PRT->area.get_area() *1e-6 << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << PRT->power.readOp.dynamic*mcp.clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = " << PRT->power.readOp.leakage  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << PRT->power.readOp.gate_leakage  << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << PRT->rt_power.readOp.dynamic/mcp.executionTime << " W" << endl;
-		cout <<endl;
-		cout << indent_str << "Thread Masks and coalescing logic:" << endl;
-		cout << indent_str_next << "Area = " << threadMasks->area.get_area() *1e-6 << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << threadMasks->power.readOp.dynamic*mcp.clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = " << threadMasks->power.readOp.leakage  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << threadMasks->power.readOp.gate_leakage  << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << threadMasks->rt_power.readOp.dynamic/mcp.executionTime << " W" << endl;
-		cout <<endl;
+    cout << endl;
+    cout << indent_str << "Read Buffer:" << endl;
+    cout << indent_str_next << "Area = " << readBuffer->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next << "Peak Dynamic = "
+         << readBuffer->power.readOp.dynamic * mcp.clockRate << " W" << endl;
+    cout << indent_str_next
+         << "Subthreshold Leakage = " << readBuffer->power.readOp.leakage
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << readBuffer->power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << readBuffer->rt_power.readOp.dynamic / mcp.executionTime << " W"
+         << endl;
+    cout << endl;
+    cout << indent_str << "Write Buffer:" << endl;
+    cout << indent_str_next << "Area = " << writeBuffer->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next << "Peak Dynamic = "
+         << writeBuffer->power.readOp.dynamic * mcp.clockRate << " W" << endl;
+    cout << indent_str_next
+         << "Subthreshold Leakage = " << writeBuffer->power.readOp.leakage
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << writeBuffer->power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << writeBuffer->rt_power.readOp.dynamic / mcp.executionTime << " W"
+         << endl;
+    cout << endl;
+    cout << indent_str << "PRT:" << endl;
+    cout << indent_str_next << "Area = " << PRT->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << PRT->power.readOp.dynamic * mcp.clockRate
+         << " W" << endl;
+    cout << indent_str_next
+         << "Subthreshold Leakage = " << PRT->power.readOp.leakage << " W"
+         << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << PRT->power.readOp.gate_leakage << " W" << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << PRT->rt_power.readOp.dynamic / mcp.executionTime << " W" << endl;
+    cout << endl;
+    cout << indent_str << "Thread Masks and coalescing logic:" << endl;
+    cout << indent_str_next << "Area = " << threadMasks->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next << "Peak Dynamic = "
+         << threadMasks->power.readOp.dynamic * mcp.clockRate << " W" << endl;
+    cout << indent_str_next
+         << "Subthreshold Leakage = " << threadMasks->power.readOp.leakage
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << threadMasks->power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << threadMasks->rt_power.readOp.dynamic / mcp.executionTime << " W"
+         << endl;
+    cout << endl;
 
-
-	}
-	else
-	{
-		cout << indent_str << "Front End ROB:" << endl;
-		cout << indent_str_next << "Area = " << frontendBuffer->area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << frontendBuffer->rt_power.readOp.dynamic*mcp.clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = " << frontendBuffer->rt_power.readOp.leakage <<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << frontendBuffer->rt_power.readOp.gate_leakage << " W" << endl;
-		cout <<endl;
-		cout << indent_str<< "Read Buffer:" << endl;
-		cout << indent_str_next << "Area = " << readBuffer->area.get_area()*1e-6  << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << readBuffer->rt_power.readOp.dynamic*mcp.clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = " << readBuffer->rt_power.readOp.leakage  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << readBuffer->rt_power.readOp.gate_leakage  << " W" << endl;
-		cout <<endl;
-		cout << indent_str << "Write Buffer:" << endl;
-		cout << indent_str_next << "Area = " << writeBuffer->area.get_area() *1e-6 << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << writeBuffer->rt_power.readOp.dynamic*mcp.clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = " << writeBuffer->rt_power.readOp.leakage  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << writeBuffer->rt_power.readOp.gate_leakage  << " W" << endl;
-		cout <<endl;
-		cout << indent_str << "PRT:" << endl;
-		cout << indent_str_next << "Area = " << PRT->area.get_area() *1e-6 << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << PRT->rt_power.readOp.dynamic*mcp.clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = " << PRT->rt_power.readOp.leakage  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << PRT->rt_power.readOp.gate_leakage  << " W" << endl;
-		cout <<endl;
-		cout << indent_str << "Thread masks and coalescing logic:" << endl;
-		cout << indent_str_next << "Area = " << threadMasks->area.get_area() *1e-6 << " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << threadMasks->rt_power.readOp.dynamic*mcp.clockRate  << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = " << threadMasks->rt_power.readOp.leakage  << " W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << threadMasks->rt_power.readOp.gate_leakage  << " W" << endl;
-
-
-	}
-
+  } else {
+    cout << indent_str << "Front End ROB:" << endl;
+    cout << indent_str_next
+         << "Area = " << frontendBuffer->area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str_next << "Peak Dynamic = "
+         << frontendBuffer->rt_power.readOp.dynamic * mcp.clockRate << " W"
+         << endl;
+    cout << indent_str_next
+         << "Subthreshold Leakage = " << frontendBuffer->rt_power.readOp.leakage
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << frontendBuffer->rt_power.readOp.gate_leakage
+         << " W" << endl;
+    cout << endl;
+    cout << indent_str << "Read Buffer:" << endl;
+    cout << indent_str_next << "Area = " << readBuffer->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next << "Peak Dynamic = "
+         << readBuffer->rt_power.readOp.dynamic * mcp.clockRate << " W" << endl;
+    cout << indent_str_next
+         << "Subthreshold Leakage = " << readBuffer->rt_power.readOp.leakage
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << readBuffer->rt_power.readOp.gate_leakage
+         << " W" << endl;
+    cout << endl;
+    cout << indent_str << "Write Buffer:" << endl;
+    cout << indent_str_next << "Area = " << writeBuffer->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next << "Peak Dynamic = "
+         << writeBuffer->rt_power.readOp.dynamic * mcp.clockRate << " W"
+         << endl;
+    cout << indent_str_next
+         << "Subthreshold Leakage = " << writeBuffer->rt_power.readOp.leakage
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << writeBuffer->rt_power.readOp.gate_leakage
+         << " W" << endl;
+    cout << endl;
+    cout << indent_str << "PRT:" << endl;
+    cout << indent_str_next << "Area = " << PRT->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << PRT->rt_power.readOp.dynamic * mcp.clockRate
+         << " W" << endl;
+    cout << indent_str_next
+         << "Subthreshold Leakage = " << PRT->rt_power.readOp.leakage << " W"
+         << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << PRT->rt_power.readOp.gate_leakage << " W"
+         << endl;
+    cout << endl;
+    cout << indent_str << "Thread masks and coalescing logic:" << endl;
+    cout << indent_str_next << "Area = " << threadMasks->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next << "Peak Dynamic = "
+         << threadMasks->rt_power.readOp.dynamic * mcp.clockRate << " W"
+         << endl;
+    cout << indent_str_next
+         << "Subthreshold Leakage = " << threadMasks->rt_power.readOp.leakage
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << threadMasks->rt_power.readOp.gate_leakage
+         << " W" << endl;
+  }
 }
 
-DRAM::DRAM(ParseXML *XML_interface,InputParameter* interface_ip_, enum Dram_type dram_type_)
-:XML(XML_interface),
- interface_ip(*interface_ip_),
- dram_type(dram_type_)
-{
-
-		set_dram_param();
-
+DRAM::DRAM(ParseXML* XML_interface, InputParameter* interface_ip_,
+           enum Dram_type dram_type_)
+    : XML(XML_interface), interface_ip(*interface_ip_), dram_type(dram_type_) {
+  set_dram_param();
 }
-MemoryController::MemoryController(ParseXML *XML_interface,InputParameter* interface_ip_, enum MemoryCtrl_type mc_type_,enum Dram_type dram_type_)
-:XML(XML_interface),
- interface_ip(*interface_ip_),
- mc_type(mc_type_),
- frontend(0),
- transecEngine(0),
- PHY(0),
- pipeLogic(0)
-{
+MemoryController::MemoryController(ParseXML* XML_interface,
+                                   InputParameter* interface_ip_,
+                                   enum MemoryCtrl_type mc_type_,
+                                   enum Dram_type dram_type_)
+    : XML(XML_interface),
+      interface_ip(*interface_ip_),
+      mc_type(mc_type_),
+      frontend(0),
+      transecEngine(0),
+      PHY(0),
+      pipeLogic(0) {
   /* All computations are for a single MC
    *
    */
   interface_ip.wire_is_mat_type = 2;
   interface_ip.wire_os_mat_type = 2;
-  interface_ip.wt               =Global;
+  interface_ip.wt = Global;
   set_mc_param();
   frontend = new MCFrontEnd(XML, &interface_ip, mcp, mc_type);
   dram = new DRAM(XML, &interface_ip, dram_type_);
-  area.set_area(area.get_area()+ frontend->area.get_area());
+  area.set_area(area.get_area() + frontend->area.get_area());
   transecEngine = new MCBackend(&interface_ip, mcp, mc_type);
-  area.set_area(area.get_area()+ transecEngine->area.get_area());
-  if (mcp.type==0 || (mcp.type==1&&mcp.withPHY))
-  {
-	  PHY = new MCPHY(&interface_ip, mcp, mc_type);
-	  area.set_area(area.get_area()+ PHY->area.get_area());
+  area.set_area(area.get_area() + transecEngine->area.get_area());
+  if (mcp.type == 0 || (mcp.type == 1 && mcp.withPHY)) {
+    PHY = new MCPHY(&interface_ip, mcp, mc_type);
+    area.set_area(area.get_area() + PHY->area.get_area());
   }
-  //+++++++++Transaction engine +++++++++++++++++ ////TODO needs better numbers, Run the RTL code from OpenSparc.
-//  transecEngine.initialize(&interface_ip);
-//  transecEngine.peakDataTransferRate = XML->sys.mem.peak_transfer_rate;
-//  transecEngine.memDataWidth = dataBusWidth;
-//  transecEngine.memRank = XML->sys.mem.number_ranks;
-//  //transecEngine.memAccesses=XML->sys.mc.memory_accesses;
-//  //transecEngine.llcBlocksize=llcBlockSize;
-//  transecEngine.compute();
-//  transecEngine.area.set_area(XML->sys.mc.memory_channels_per_mc*transecEngine.area.get_area()) ;
-//  area.set_area(area.get_area()+ transecEngine.area.get_area());
-//  ///cout<<"area="<<area<<endl;
-////
-//  //++++++++++++++PHY ++++++++++++++++++++++++++ //TODO needs better numbers
-//  PHY.initialize(&interface_ip);
-//  PHY.peakDataTransferRate = XML->sys.mem.peak_transfer_rate;
-//  PHY.memDataWidth = dataBusWidth;
-//  //PHY.memAccesses=PHY.peakDataTransferRate;//this is the max power
-//  //PHY.llcBlocksize=llcBlockSize;
-//  PHY.compute();
-//  PHY.area.set_area(XML->sys.mc.memory_channels_per_mc*PHY.area.get_area()) ;
-//  area.set_area(area.get_area()+ PHY.area.get_area());
-  ///cout<<"area="<<area<<endl;
-//
-//  interface_ip.pipeline_stages = 5;//normal memory controller has five stages in the pipeline.
-//  interface_ip.per_stage_vector = addressBusWidth + XML->sys.core[0].opcode_width + dataBusWidth;
-//  pipeLogic = new pipeline(is_default, &interface_ip);
-//  //pipeLogic.init_pipeline(is_default, &interface_ip);
-//  pipeLogic->compute_pipeline();
-//  area.set_area(area.get_area()+ pipeLogic->area.get_area()*1e-6);
-//  area.set_area((area.get_area()+mc_area*1e-6)*1.1);//placement and routing overhead
-//
-//
-////  //clock
-////  clockNetwork.init_wire_external(is_default, &interface_ip);
-////  clockNetwork.clk_area           =area*1.1;//10% of placement overhead. rule of thumb
-////  clockNetwork.end_wiring_level   =5;//toplevel metal
-////  clockNetwork.start_wiring_level =5;//toplevel metal
-////  clockNetwork.num_regs           = pipeLogic.tot_stage_vector;
-////  clockNetwork.optimize_wire();
-
-
+  //+++++++++Transaction engine +++++++++++++++++ ////TODO needs better numbers,
+  // Run the RTL code from OpenSparc.
+  //  transecEngine.initialize(&interface_ip);
+  //  transecEngine.peakDataTransferRate = XML->sys.mem.peak_transfer_rate;
+  //  transecEngine.memDataWidth = dataBusWidth;
+  //  transecEngine.memRank = XML->sys.mem.number_ranks;
+  //  //transecEngine.memAccesses=XML->sys.mc.memory_accesses;
+  //  //transecEngine.llcBlocksize=llcBlockSize;
+  //  transecEngine.compute();
+  //  transecEngine.area.set_area(XML->sys.mc.memory_channels_per_mc*transecEngine.area.get_area())
+  //  ; area.set_area(area.get_area()+ transecEngine.area.get_area());
+  //  ///cout<<"area="<<area<<endl;
+  ////
+  //  //++++++++++++++PHY ++++++++++++++++++++++++++ //TODO needs better numbers
+  //  PHY.initialize(&interface_ip);
+  //  PHY.peakDataTransferRate = XML->sys.mem.peak_transfer_rate;
+  //  PHY.memDataWidth = dataBusWidth;
+  //  //PHY.memAccesses=PHY.peakDataTransferRate;//this is the max power
+  //  //PHY.llcBlocksize=llcBlockSize;
+  //  PHY.compute();
+  //  PHY.area.set_area(XML->sys.mc.memory_channels_per_mc*PHY.area.get_area())
+  //  ; area.set_area(area.get_area()+ PHY.area.get_area());
+  /// cout<<"area="<<area<<endl;
+  //
+  //  interface_ip.pipeline_stages = 5;//normal memory controller has five
+  //  stages in the pipeline. interface_ip.per_stage_vector = addressBusWidth +
+  //  XML->sys.core[0].opcode_width + dataBusWidth; pipeLogic = new
+  //  pipeline(is_default, &interface_ip);
+  //  //pipeLogic.init_pipeline(is_default, &interface_ip);
+  //  pipeLogic->compute_pipeline();
+  //  area.set_area(area.get_area()+ pipeLogic->area.get_area()*1e-6);
+  //  area.set_area((area.get_area()+mc_area*1e-6)*1.1);//placement and routing
+  //  overhead
+  //
+  //
+  ////  //clock
+  ////  clockNetwork.init_wire_external(is_default, &interface_ip);
+  ////  clockNetwork.clk_area           =area*1.1;//10% of placement overhead.
+  /// rule of thumb /  clockNetwork.end_wiring_level   =5;//toplevel metal /
+  /// clockNetwork.start_wiring_level =5;//toplevel metal /
+  /// clockNetwork.num_regs = pipeLogic.tot_stage_vector; /
+  /// clockNetwork.optimize_wire();
 }
-void MemoryController::computeEnergy(bool is_tdp)
-{
-
-  rt_power.reset(); //Jingwen
+void MemoryController::computeEnergy(bool is_tdp) {
+  rt_power.reset();  // Jingwen
   frontend->rt_power.reset();
   transecEngine->rt_power.reset();
   dram->rt_power.reset();
-  mcp.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6); //Jingwen
-  frontend->mcp.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6); //Jingwen
-  transecEngine->mcp.executionTime  = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6); //Jingwen
-  
+  mcp.executionTime = XML->sys.total_cycles /
+                      (XML->sys.target_core_clockrate * 1e6);  // Jingwen
+  frontend->mcp.executionTime =
+      XML->sys.total_cycles /
+      (XML->sys.target_core_clockrate * 1e6);  // Jingwen
+  transecEngine->mcp.executionTime =
+      XML->sys.total_cycles /
+      (XML->sys.target_core_clockrate * 1e6);  // Jingwen
+
   /*Jingwen: give stats for backend and phy */
-  transecEngine->mcp.reads =XML->sys.mc.memory_reads;
-  transecEngine->mcp.writes =XML->sys.mc.memory_writes;
+  transecEngine->mcp.reads = XML->sys.mc.memory_reads;
+  transecEngine->mcp.writes = XML->sys.mc.memory_writes;
 
-  //set_mc_param();
+  // set_mc_param();
 
-	frontend->computeEnergy(is_tdp);
-	transecEngine->computeEnergy(is_tdp);
-	dram->computeEnergy(is_tdp);
-	if (mcp.type==0 || (mcp.type==1&&mcp.withPHY))
-	{
-    if(!is_tdp)
-      PHY->rt_power.reset();//Jingwen
-    PHY->mcp.reads =XML->sys.mc.memory_reads;
-    PHY->mcp.writes =XML->sys.mc.memory_writes;
-    PHY->mcp.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6); //Jingwen
-		PHY->computeEnergy(is_tdp);
-	}
-	if (is_tdp)
-	{
-		power = power + frontend->power + transecEngine->power;
-		if (mcp.type==0 || (mcp.type==1&&mcp.withPHY))
-		{
-			power = power + PHY->power;
-		}
-	}
-	else
-	{
-		rt_power = rt_power + frontend->rt_power + transecEngine->rt_power+dram->rt_power;
-		if (mcp.type==0 || (mcp.type==1&&mcp.withPHY))
-		{
-			rt_power = rt_power + PHY->rt_power;
-		}
-	}
+  frontend->computeEnergy(is_tdp);
+  transecEngine->computeEnergy(is_tdp);
+  dram->computeEnergy(is_tdp);
+  if (mcp.type == 0 || (mcp.type == 1 && mcp.withPHY)) {
+    if (!is_tdp) PHY->rt_power.reset();  // Jingwen
+    PHY->mcp.reads = XML->sys.mc.memory_reads;
+    PHY->mcp.writes = XML->sys.mc.memory_writes;
+    PHY->mcp.executionTime = XML->sys.total_cycles /
+                             (XML->sys.target_core_clockrate * 1e6);  // Jingwen
+    PHY->computeEnergy(is_tdp);
+  }
+  if (is_tdp) {
+    power = power + frontend->power + transecEngine->power;
+    if (mcp.type == 0 || (mcp.type == 1 && mcp.withPHY)) {
+      power = power + PHY->power;
+    }
+  } else {
+    rt_power = rt_power + frontend->rt_power + transecEngine->rt_power +
+               dram->rt_power;
+    if (mcp.type == 0 || (mcp.type == 1 && mcp.withPHY)) {
+      rt_power = rt_power + PHY->rt_power;
+    }
+  }
 }
 
-void MemoryController::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
+void MemoryController::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
 
-	if (is_tdp)
-	{
-		cout << "Memory Controller:" << endl;
-		cout << indent_str<< "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic*mcp.clockRate  << " W" << endl;
-		cout << indent_str<< "Subthreshold Leakage = "
-			<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
-		//cout << indent_str<< "Subthreshold Leakage = " << power.readOp.longer_channel_leakage <<" W" << endl;
-		cout << indent_str<< "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str << "Runtime Dynamic = " << rt_power.readOp.dynamic/mcp.executionTime << " W" << endl;
-		cout<<endl;
-		cout << indent_str << "Front End Engine:" << endl;
-		cout << indent_str_next << "Area = " << frontend->area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << frontend->power.readOp.dynamic*mcp.clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? frontend->power.readOp.longer_channel_leakage:frontend->power.readOp.leakage) <<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << frontend->power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << frontend->rt_power.readOp.dynamic/mcp.executionTime << " W" << endl;
-		cout <<endl;
-		//if (plevel >2){
-			frontend->displayEnergy(indent+4,is_tdp);
-		//}
-		cout << indent_str << "Transaction Engine:" << endl;
-		cout << indent_str_next << "Area = " << transecEngine->area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << transecEngine->power.readOp.dynamic*mcp.clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? transecEngine->power.readOp.longer_channel_leakage:transecEngine->power.readOp.leakage) <<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << transecEngine->power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << transecEngine->rt_power.readOp.dynamic/mcp.executionTime << " W" << endl;
-		cout <<endl;
-		if (mcp.type==0 || (mcp.type==1&&mcp.withPHY))
-		{
-			cout << indent_str << "PHY:" << endl;
-			cout << indent_str_next << "Area = " << PHY->area.get_area()*1e-6<< " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << PHY->power.readOp.dynamic*mcp.clockRate << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? PHY->power.readOp.longer_channel_leakage:PHY->power.readOp.leakage) <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << PHY->power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << PHY->rt_power.readOp.dynamic/mcp.executionTime << " W" << endl;
-			cout <<endl;
-		}
-	}
-	else
-	{
-		cout << "Memory Controller:" << endl;
-		cout << indent_str_next << "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << power.readOp.dynamic*mcp.clockRate << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = " << power.readOp.leakage <<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
-		cout<<endl;
-	}
-
+  if (is_tdp) {
+    cout << "Memory Controller:" << endl;
+    cout << indent_str << "Area = " << area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str
+         << "Peak Dynamic = " << power.readOp.dynamic * mcp.clockRate << " W"
+         << endl;
+    cout << indent_str << "Subthreshold Leakage = "
+         << (long_channel ? power.readOp.longer_channel_leakage
+                          : power.readOp.leakage)
+         << " W" << endl;
+    // cout << indent_str<< "Subthreshold Leakage = " <<
+    // power.readOp.longer_channel_leakage <<" W" << endl;
+    cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str
+         << "Runtime Dynamic = " << rt_power.readOp.dynamic / mcp.executionTime
+         << " W" << endl;
+    cout << endl;
+    cout << indent_str << "Front End Engine:" << endl;
+    cout << indent_str_next << "Area = " << frontend->area.get_area() * 1e-6
+         << " mm^2" << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << frontend->power.readOp.dynamic * mcp.clockRate
+         << " W" << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? frontend->power.readOp.longer_channel_leakage
+                          : frontend->power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << frontend->power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << frontend->rt_power.readOp.dynamic / mcp.executionTime << " W"
+         << endl;
+    cout << endl;
+    // if (plevel >2){
+    frontend->displayEnergy(indent + 4, is_tdp);
+    //}
+    cout << indent_str << "Transaction Engine:" << endl;
+    cout << indent_str_next
+         << "Area = " << transecEngine->area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str_next << "Peak Dynamic = "
+         << transecEngine->power.readOp.dynamic * mcp.clockRate << " W" << endl;
+    cout << indent_str_next << "Subthreshold Leakage = "
+         << (long_channel ? transecEngine->power.readOp.longer_channel_leakage
+                          : transecEngine->power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str_next
+         << "Gate Leakage = " << transecEngine->power.readOp.gate_leakage
+         << " W" << endl;
+    cout << indent_str_next << "Runtime Dynamic = "
+         << transecEngine->rt_power.readOp.dynamic / mcp.executionTime << " W"
+         << endl;
+    cout << endl;
+    if (mcp.type == 0 || (mcp.type == 1 && mcp.withPHY)) {
+      cout << indent_str << "PHY:" << endl;
+      cout << indent_str_next << "Area = " << PHY->area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << PHY->power.readOp.dynamic * mcp.clockRate
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? PHY->power.readOp.longer_channel_leakage
+                            : PHY->power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << PHY->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << PHY->rt_power.readOp.dynamic / mcp.executionTime << " W" << endl;
+      cout << endl;
+    }
+  } else {
+    cout << "Memory Controller:" << endl;
+    cout << indent_str_next << "Area = " << area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str_next
+         << "Peak Dynamic = " << power.readOp.dynamic * mcp.clockRate << " W"
+         << endl;
+    cout << indent_str_next << "Subthreshold Leakage = " << power.readOp.leakage
+         << " W" << endl;
+    cout << indent_str_next << "Gate Leakage = " << power.readOp.gate_leakage
+         << " W" << endl;
+    cout << endl;
+  }
 }
 
-void DRAM::set_dram_param()
-{
-	dramp.cmd_coeff 		= XML->sys.mc.dram_rd_coeff;
-	dramp.act_coeff 		= XML->sys.mc.dram_act_coeff;
-	dramp.nop_coeff			= XML->sys.mc.dram_nop_coeff;
-	dramp.activity_coeff 	= XML->sys.mc.dram_activity_coeff;
-	dramp.pre_coeff			= XML->sys.mc.dram_pre_coeff;
-	dramp.rd_coeff			= XML->sys.mc.dram_rd_coeff;
-	dramp.wr_coeff			= XML->sys.mc.dram_wr_coeff;
-	dramp.req_coeff			= XML->sys.mc.dram_req_coeff;
-	dramp.const_coeff		= XML->sys.mc.dram_const_coeff;
+void DRAM::set_dram_param() {
+  dramp.cmd_coeff = XML->sys.mc.dram_rd_coeff;
+  dramp.act_coeff = XML->sys.mc.dram_act_coeff;
+  dramp.nop_coeff = XML->sys.mc.dram_nop_coeff;
+  dramp.activity_coeff = XML->sys.mc.dram_activity_coeff;
+  dramp.pre_coeff = XML->sys.mc.dram_pre_coeff;
+  dramp.rd_coeff = XML->sys.mc.dram_rd_coeff;
+  dramp.wr_coeff = XML->sys.mc.dram_wr_coeff;
+  dramp.req_coeff = XML->sys.mc.dram_req_coeff;
+  dramp.const_coeff = XML->sys.mc.dram_const_coeff;
 }
 
-void MemoryController::set_mc_param()
-{
+void MemoryController::set_mc_param() {
+  if (mc_type == MC) {
+    mcp.clockRate = XML->sys.mc.mc_clock * 2;  // DDR double pumped
+    mcp.clockRate *= 1e6;
+    mcp.executionTime =
+        XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);
 
-	if (mc_type==MC)
-	{
-	  mcp.clockRate       =XML->sys.mc.mc_clock*2;//DDR double pumped
-	  mcp.clockRate       *= 1e6;
-	  mcp.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
-
-	  mcp.llcBlockSize    =int(ceil(XML->sys.mc.llc_line_length/8.0))+XML->sys.mc.llc_line_length;//ecc overhead
-	  mcp.dataBusWidth    =int(ceil(XML->sys.mc.databus_width/8.0)) + XML->sys.mc.databus_width;
-	  mcp.addressBusWidth =int(ceil(XML->sys.mc.addressbus_width));//XML->sys.physical_address_width;
-	  mcp.opcodeW         =16;
-	  mcp.num_mcs         = XML->sys.mc.number_mcs;
-	  mcp.num_channels    = XML->sys.mc.memory_channels_per_mc;
-	  mcp.reads  = XML->sys.mc.memory_reads;
-	  mcp.writes = XML->sys.mc.memory_writes;
-	  //+++++++++Transaction engine +++++++++++++++++ ////TODO needs better numbers, Run the RTL code from OpenSparc.
-	  mcp.peakDataTransferRate = XML->sys.mc.peak_transfer_rate;
-	  mcp.memRank = XML->sys.mc.number_ranks;
-	  //++++++++++++++PHY ++++++++++++++++++++++++++ //TODO needs better numbers
-	  //PHY.memAccesses=PHY.peakDataTransferRate;//this is the max power
-	  //PHY.llcBlocksize=llcBlockSize;
-	  mcp.frontend_duty_cycle = 0.5;//for max power, the actual off-chip links is bidirectional but time shared
-	  mcp.LVDS = XML->sys.mc.LVDS;
-	  mcp.type = XML->sys.mc.type;
-	  mcp.withPHY = XML->sys.mc.withPHY;
-	}
-//	else if (mc_type==FLASHC)
-//	{
-//		mcp.clockRate       =XML->sys.flashc.mc_clock*2;//DDR double pumped
-//		mcp.clockRate       *= 1e6;
-//		mcp.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
-//
-//		mcp.llcBlockSize    =int(ceil(XML->sys.flashc.llc_line_length/8.0))+XML->sys.flashc.llc_line_length;//ecc overhead
-//		mcp.dataBusWidth    =int(ceil(XML->sys.flashc.databus_width/8.0)) + XML->sys.flashc.databus_width;
-//		mcp.addressBusWidth =int(ceil(XML->sys.flashc.addressbus_width));//XML->sys.physical_address_width;
-//		mcp.opcodeW         =16;
-//		mcp.num_mcs         = XML->sys.flashc.number_mcs;
-//		mcp.num_channels    = XML->sys.flashc.memory_channels_per_mc;
-//		mcp.reads  = XML->sys.flashc.memory_reads;
-//		mcp.writes = XML->sys.flashc.memory_writes;
-//		//+++++++++Transaction engine +++++++++++++++++ ////TODO needs better numbers, Run the RTL code from OpenSparc.
-//		mcp.peakDataTransferRate = XML->sys.flashc.peak_transfer_rate;
-//		mcp.memRank = XML->sys.flashc.number_ranks;
-//		//++++++++++++++PHY ++++++++++++++++++++++++++ //TODO needs better numbers
-//		//PHY.memAccesses=PHY.peakDataTransferRate;//this is the max power
-//		//PHY.llcBlocksize=llcBlockSize;
-//		mcp.frontend_duty_cycle = 0.5;//for max power, the actual off-chip links is bidirectional but time shared
-//		mcp.LVDS = XML->sys.flashc.LVDS;
-//		mcp.type = XML->sys.flashc.type;
-//	}
-	else
-	{
-		cout<<"Unknown memory controller type: neither DRAM controller nor Flash controller" <<endl;
-		exit(0);
-	}
+    mcp.llcBlockSize = int(ceil(XML->sys.mc.llc_line_length / 8.0)) +
+                       XML->sys.mc.llc_line_length;  // ecc overhead
+    mcp.dataBusWidth =
+        int(ceil(XML->sys.mc.databus_width / 8.0)) + XML->sys.mc.databus_width;
+    mcp.addressBusWidth = int(ceil(
+        XML->sys.mc.addressbus_width));  // XML->sys.physical_address_width;
+    mcp.opcodeW = 16;
+    mcp.num_mcs = XML->sys.mc.number_mcs;
+    mcp.num_channels = XML->sys.mc.memory_channels_per_mc;
+    mcp.reads = XML->sys.mc.memory_reads;
+    mcp.writes = XML->sys.mc.memory_writes;
+    //+++++++++Transaction engine +++++++++++++++++ ////TODO needs better
+    // numbers, Run the RTL code from OpenSparc.
+    mcp.peakDataTransferRate = XML->sys.mc.peak_transfer_rate;
+    mcp.memRank = XML->sys.mc.number_ranks;
+    //++++++++++++++PHY ++++++++++++++++++++++++++ //TODO needs better numbers
+    // PHY.memAccesses=PHY.peakDataTransferRate;//this is the max power
+    // PHY.llcBlocksize=llcBlockSize;
+    mcp.frontend_duty_cycle = 0.5;  // for max power, the actual off-chip links
+                                    // is bidirectional but time shared
+    mcp.LVDS = XML->sys.mc.LVDS;
+    mcp.type = XML->sys.mc.type;
+    mcp.withPHY = XML->sys.mc.withPHY;
+  }
+  //	else if (mc_type==FLASHC)
+  //	{
+  //		mcp.clockRate       =XML->sys.flashc.mc_clock*2;//DDR double
+  // pumped 		mcp.clockRate       *= 1e6; mcp.executionTime =
+  // XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
+  //
+  //		mcp.llcBlockSize
+  //=int(ceil(XML->sys.flashc.llc_line_length/8.0))+XML->sys.flashc.llc_line_length;//ecc
+  // overhead 		mcp.dataBusWidth
+  // =int(ceil(XML->sys.flashc.databus_width/8.0)) +
+  // XML->sys.flashc.databus_width; 		mcp.addressBusWidth
+  //=int(ceil(XML->sys.flashc.addressbus_width));//XML->sys.physical_address_width;
+  //		mcp.opcodeW         =16;
+  //		mcp.num_mcs         = XML->sys.flashc.number_mcs;
+  //		mcp.num_channels    = XML->sys.flashc.memory_channels_per_mc;
+  //		mcp.reads  = XML->sys.flashc.memory_reads;
+  //		mcp.writes = XML->sys.flashc.memory_writes;
+  //		//+++++++++Transaction engine +++++++++++++++++ ////TODO needs
+  // better numbers, Run the RTL code from OpenSparc.
+  // mcp.peakDataTransferRate =
+  // XML->sys.flashc.peak_transfer_rate; 		mcp.memRank =
+  // XML->sys.flashc.number_ranks;
+  //		//++++++++++++++PHY ++++++++++++++++++++++++++ //TODO needs
+  // better numbers
+  //		//PHY.memAccesses=PHY.peakDataTransferRate;//this is the max
+  // power
+  //		//PHY.llcBlocksize=llcBlockSize;
+  //		mcp.frontend_duty_cycle = 0.5;//for max power, the actual
+  // off-chip links is bidirectional but time shared 		mcp.LVDS =
+  // XML->sys.flashc.LVDS; 		mcp.type = XML->sys.flashc.type;
+  //	}
+  else {
+    cout << "Unknown memory controller type: neither DRAM controller nor Flash "
+            "controller"
+         << endl;
+    exit(0);
+  }
 }
 
-MCFrontEnd ::~MCFrontEnd(){
-
-	if(MC_arb) 	               {delete MC_arb; MC_arb = 0;}
-	if(frontendBuffer) 	       {delete frontendBuffer; frontendBuffer = 0;}
-	if(readBuffer) 	           {delete readBuffer; readBuffer = 0;}
-	if(writeBuffer) 	       {delete writeBuffer; writeBuffer = 0;}
+MCFrontEnd ::~MCFrontEnd() {
+  if (MC_arb) {
+    delete MC_arb;
+    MC_arb = 0;
+  }
+  if (frontendBuffer) {
+    delete frontendBuffer;
+    frontendBuffer = 0;
+  }
+  if (readBuffer) {
+    delete readBuffer;
+    readBuffer = 0;
+  }
+  if (writeBuffer) {
+    delete writeBuffer;
+    writeBuffer = 0;
+  }
 }
 
-MemoryController ::~MemoryController(){
-
-	if(frontend) 	               {delete frontend; frontend = 0;}
-	if(transecEngine) 	           {delete transecEngine; transecEngine = 0;}
-	if(PHY) 	                   {delete PHY; PHY = 0;}
-	if(pipeLogic) 	               {delete pipeLogic; pipeLogic = 0;}
+MemoryController ::~MemoryController() {
+  if (frontend) {
+    delete frontend;
+    frontend = 0;
+  }
+  if (transecEngine) {
+    delete transecEngine;
+    transecEngine = 0;
+  }
+  if (PHY) {
+    delete PHY;
+    PHY = 0;
+  }
+  if (pipeLogic) {
+    delete pipeLogic;
+    pipeLogic = 0;
+  }
 }
-

--- a/src/gpuwattch/memoryctrl.h
+++ b/src/gpuwattch/memoryctrl.h
@@ -29,12 +29,12 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:												   *
-*      Jingwen Leng, Univeristy of Texas, Austin                   *
-*      Syed Gilani, University of Wisconsin–Madison                *
-*      Tayler Hetherington, University of British Columbia         *
-*      Ahmed ElTantawy, University of British Columbia             *
-********************************************************************/
+ *      Modified by:
+ ** Jingwen Leng, Univeristy of Texas, Austin                   * Syed Gilani,
+ *University of Wisconsin–Madison                * Tayler Hetherington,
+ *University of British Columbia         * Ahmed ElTantawy, University of
+ *British Columbia             *
+ ********************************************************************/
 
 #ifndef MEMORYCTRL_H_
 #define MEMORYCTRL_H_
@@ -48,95 +48,100 @@
 #include "basic_components.h"
 
 class MCBackend : public Component {
-  public:
-    InputParameter l_ip;
-    uca_org_t local_result;
-	enum MemoryCtrl_type mc_type;
-    MCParam  mcp;
-    statsDef tdp_stats;
-    statsDef rtp_stats;
-    statsDef stats_t;
-    powerDef power_t;
-    MCBackend(InputParameter* interface_ip_, const MCParam & mcp_, enum MemoryCtrl_type mc_type_);
-    void compute();
-	void computeEnergy(bool is_tdp=true);
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-    ~MCBackend(){};
+ public:
+  InputParameter l_ip;
+  uca_org_t local_result;
+  enum MemoryCtrl_type mc_type;
+  MCParam mcp;
+  statsDef tdp_stats;
+  statsDef rtp_stats;
+  statsDef stats_t;
+  powerDef power_t;
+  MCBackend(InputParameter *interface_ip_, const MCParam &mcp_,
+            enum MemoryCtrl_type mc_type_);
+  void compute();
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  ~MCBackend(){};
 };
 
 class MCPHY : public Component {
-  public:
-    InputParameter l_ip;
-    uca_org_t local_result;
-	enum MemoryCtrl_type mc_type;
-    MCParam  mcp;
-    statsDef       tdp_stats;
-    statsDef       rtp_stats;
-    statsDef       stats_t;
-    powerDef       power_t;
-    MCPHY(InputParameter* interface_ip_, const MCParam & mcp_, enum MemoryCtrl_type mc_type_);
-    void compute();
-	void computeEnergy(bool is_tdp=true);
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-    ~MCPHY(){};
+ public:
+  InputParameter l_ip;
+  uca_org_t local_result;
+  enum MemoryCtrl_type mc_type;
+  MCParam mcp;
+  statsDef tdp_stats;
+  statsDef rtp_stats;
+  statsDef stats_t;
+  powerDef power_t;
+  MCPHY(InputParameter *interface_ip_, const MCParam &mcp_,
+        enum MemoryCtrl_type mc_type_);
+  void compute();
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  ~MCPHY(){};
 };
 
 class MCFrontEnd : public Component {
-  public:
-	ParseXML *XML;
-	InputParameter interface_ip;
-	enum MemoryCtrl_type mc_type;
-	MCParam  mcp;
-	selection_logic * MC_arb;
-	ArrayST  * frontendBuffer;
-	ArrayST  * readBuffer;
-	ArrayST  * writeBuffer;
+ public:
+  ParseXML *XML;
+  InputParameter interface_ip;
+  enum MemoryCtrl_type mc_type;
+  MCParam mcp;
+  selection_logic *MC_arb;
+  ArrayST *frontendBuffer;
+  ArrayST *readBuffer;
+  ArrayST *writeBuffer;
 
-	ArrayST * PRT;
-	ArrayST * threadMasks;
-	ArrayST * PRC;
-	double coalesce_scale;
+  ArrayST *PRT;
+  ArrayST *threadMasks;
+  ArrayST *PRC;
+  double coalesce_scale;
 
-    MCFrontEnd(ParseXML *XML_interface,InputParameter* interface_ip_, const MCParam & mcp_, enum MemoryCtrl_type mc_type_);
-    void computeEnergy(bool is_tdp=true);
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-    ~MCFrontEnd();
+  MCFrontEnd(ParseXML *XML_interface, InputParameter *interface_ip_,
+             const MCParam &mcp_, enum MemoryCtrl_type mc_type_);
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  ~MCFrontEnd();
 };
 
 class DRAM : public Component {
-  public:
-	ParseXML *XML;
-	InputParameter interface_ip;
-	enum Dram_type dram_type;
-    DRAMParam  dramp;
-    powerDef       power_t;
-    DRAM(ParseXML *XML_interface,InputParameter* interface_ip_, enum Dram_type dram_type_);
-    void set_dram_param();
-    void computeEnergy(bool is_tdp=true);
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-    ~DRAM();
+ public:
+  ParseXML *XML;
+  InputParameter interface_ip;
+  enum Dram_type dram_type;
+  DRAMParam dramp;
+  powerDef power_t;
+  DRAM(ParseXML *XML_interface, InputParameter *interface_ip_,
+       enum Dram_type dram_type_);
+  void set_dram_param();
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  ~DRAM();
 };
 
 class MemoryController : public Component {
-  public:
-	ParseXML *XML;
-	InputParameter interface_ip;
-	enum MemoryCtrl_type mc_type;
-    MCParam  mcp;
-    DRAM * dram;
-	MCFrontEnd * frontend;
-    MCBackend * transecEngine;
-    MCPHY	 * PHY;
-    Pipeline * pipeLogic;
+ public:
+  ParseXML *XML;
+  InputParameter interface_ip;
+  enum MemoryCtrl_type mc_type;
+  MCParam mcp;
+  DRAM *dram;
+  MCFrontEnd *frontend;
+  MCBackend *transecEngine;
+  MCPHY *PHY;
+  Pipeline *pipeLogic;
 
-	 //Add coalescing logic related modules with each memory controller --Syed Gilani
-	 
+  // Add coalescing logic related modules with each memory controller --Syed
+  // Gilani
 
-    //clock_network clockNetwork;
-    MemoryController(ParseXML *XML_interface,InputParameter* interface_ip_, enum MemoryCtrl_type mc_type_,enum Dram_type dram_type_);
-    void set_mc_param();
-    void computeEnergy(bool is_tdp=true);
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-    ~MemoryController();
+  // clock_network clockNetwork;
+  MemoryController(ParseXML *XML_interface, InputParameter *interface_ip_,
+                   enum MemoryCtrl_type mc_type_, enum Dram_type dram_type_);
+  void set_mc_param();
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  ~MemoryController();
 };
 #endif /* MEMORYCTRL_H_ */

--- a/src/gpuwattch/memoryctrl.h
+++ b/src/gpuwattch/memoryctrl.h
@@ -29,8 +29,7 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:
-**
+*      Modified by:												   *
 *      Jingwen Leng, Univeristy of Texas, Austin                   *
 *      Syed Gilani, University of Wisconsin–Madison                *
 *      Tayler Hetherington, University of British Columbia         *
@@ -49,100 +48,95 @@
 #include "basic_components.h"
 
 class MCBackend : public Component {
- public:
-  InputParameter l_ip;
-  uca_org_t local_result;
-  enum MemoryCtrl_type mc_type;
-  MCParam mcp;
-  statsDef tdp_stats;
-  statsDef rtp_stats;
-  statsDef stats_t;
-  powerDef power_t;
-  MCBackend(InputParameter *interface_ip_, const MCParam &mcp_,
-            enum MemoryCtrl_type mc_type_);
-  void compute();
-  void computeEnergy(bool is_tdp = true);
-  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
-  ~MCBackend(){};
+  public:
+    InputParameter l_ip;
+    uca_org_t local_result;
+	enum MemoryCtrl_type mc_type;
+    MCParam  mcp;
+    statsDef tdp_stats;
+    statsDef rtp_stats;
+    statsDef stats_t;
+    powerDef power_t;
+    MCBackend(InputParameter* interface_ip_, const MCParam & mcp_, enum MemoryCtrl_type mc_type_);
+    void compute();
+	void computeEnergy(bool is_tdp=true);
+    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
+    ~MCBackend(){};
 };
 
 class MCPHY : public Component {
- public:
-  InputParameter l_ip;
-  uca_org_t local_result;
-  enum MemoryCtrl_type mc_type;
-  MCParam mcp;
-  statsDef tdp_stats;
-  statsDef rtp_stats;
-  statsDef stats_t;
-  powerDef power_t;
-  MCPHY(InputParameter *interface_ip_, const MCParam &mcp_,
-        enum MemoryCtrl_type mc_type_);
-  void compute();
-  void computeEnergy(bool is_tdp = true);
-  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
-  ~MCPHY(){};
+  public:
+    InputParameter l_ip;
+    uca_org_t local_result;
+	enum MemoryCtrl_type mc_type;
+    MCParam  mcp;
+    statsDef       tdp_stats;
+    statsDef       rtp_stats;
+    statsDef       stats_t;
+    powerDef       power_t;
+    MCPHY(InputParameter* interface_ip_, const MCParam & mcp_, enum MemoryCtrl_type mc_type_);
+    void compute();
+	void computeEnergy(bool is_tdp=true);
+    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
+    ~MCPHY(){};
 };
 
 class MCFrontEnd : public Component {
- public:
-  ParseXML *XML;
-  InputParameter interface_ip;
-  enum MemoryCtrl_type mc_type;
-  MCParam mcp;
-  selection_logic *MC_arb;
-  ArrayST *frontendBuffer;
-  ArrayST *readBuffer;
-  ArrayST *writeBuffer;
+  public:
+	ParseXML *XML;
+	InputParameter interface_ip;
+	enum MemoryCtrl_type mc_type;
+	MCParam  mcp;
+	selection_logic * MC_arb;
+	ArrayST  * frontendBuffer;
+	ArrayST  * readBuffer;
+	ArrayST  * writeBuffer;
 
-  ArrayST *PRT;
-  ArrayST *threadMasks;
-  ArrayST *PRC;
-  double coalesce_scale;
+	ArrayST * PRT;
+	ArrayST * threadMasks;
+	ArrayST * PRC;
+	double coalesce_scale;
 
-  MCFrontEnd(ParseXML *XML_interface, InputParameter *interface_ip_,
-             const MCParam &mcp_, enum MemoryCtrl_type mc_type_);
-  void computeEnergy(bool is_tdp = true);
-  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
-  ~MCFrontEnd();
+    MCFrontEnd(ParseXML *XML_interface,InputParameter* interface_ip_, const MCParam & mcp_, enum MemoryCtrl_type mc_type_);
+    void computeEnergy(bool is_tdp=true);
+    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
+    ~MCFrontEnd();
 };
 
 class DRAM : public Component {
- public:
-  ParseXML *XML;
-  InputParameter interface_ip;
-  enum Dram_type dram_type;
-  DRAMParam dramp;
-  powerDef power_t;
-  DRAM(ParseXML *XML_interface, InputParameter *interface_ip_,
-       enum Dram_type dram_type_);
-  void set_dram_param();
-  void computeEnergy(bool is_tdp = true);
-  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
-  ~DRAM();
+  public:
+	ParseXML *XML;
+	InputParameter interface_ip;
+	enum Dram_type dram_type;
+    DRAMParam  dramp;
+    powerDef       power_t;
+    DRAM(ParseXML *XML_interface,InputParameter* interface_ip_, enum Dram_type dram_type_);
+    void set_dram_param();
+    void computeEnergy(bool is_tdp=true);
+    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
+    ~DRAM();
 };
 
 class MemoryController : public Component {
- public:
-  ParseXML *XML;
-  InputParameter interface_ip;
-  enum MemoryCtrl_type mc_type;
-  MCParam mcp;
-  DRAM *dram;
-  MCFrontEnd *frontend;
-  MCBackend *transecEngine;
-  MCPHY *PHY;
-  Pipeline *pipeLogic;
+  public:
+	ParseXML *XML;
+	InputParameter interface_ip;
+	enum MemoryCtrl_type mc_type;
+    MCParam  mcp;
+    DRAM * dram;
+	MCFrontEnd * frontend;
+    MCBackend * transecEngine;
+    MCPHY	 * PHY;
+    Pipeline * pipeLogic;
 
-  // Add coalescing logic related modules with each memory controller --Syed
-  // Gilani
+	 //Add coalescing logic related modules with each memory controller --Syed Gilani
+	 
 
-  // clock_network clockNetwork;
-  MemoryController(ParseXML *XML_interface, InputParameter *interface_ip_,
-                   enum MemoryCtrl_type mc_type_, enum Dram_type dram_type_);
-  void set_mc_param();
-  void computeEnergy(bool is_tdp = true);
-  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
-  ~MemoryController();
+    //clock_network clockNetwork;
+    MemoryController(ParseXML *XML_interface,InputParameter* interface_ip_, enum MemoryCtrl_type mc_type_,enum Dram_type dram_type_);
+    void set_mc_param();
+    void computeEnergy(bool is_tdp=true);
+    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
+    ~MemoryController();
 };
 #endif /* MEMORYCTRL_H_ */

--- a/src/gpuwattch/memoryctrl.h
+++ b/src/gpuwattch/memoryctrl.h
@@ -29,7 +29,8 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:												   *
+*      Modified by:
+**
 *      Jingwen Leng, Univeristy of Texas, Austin                   *
 *      Syed Gilani, University of Wisconsin–Madison                *
 *      Tayler Hetherington, University of British Columbia         *
@@ -48,95 +49,100 @@
 #include "basic_components.h"
 
 class MCBackend : public Component {
-  public:
-    InputParameter l_ip;
-    uca_org_t local_result;
-	enum MemoryCtrl_type mc_type;
-    MCParam  mcp;
-    statsDef tdp_stats;
-    statsDef rtp_stats;
-    statsDef stats_t;
-    powerDef power_t;
-    MCBackend(InputParameter* interface_ip_, const MCParam & mcp_, enum MemoryCtrl_type mc_type_);
-    void compute();
-	void computeEnergy(bool is_tdp=true);
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-    ~MCBackend(){};
+ public:
+  InputParameter l_ip;
+  uca_org_t local_result;
+  enum MemoryCtrl_type mc_type;
+  MCParam mcp;
+  statsDef tdp_stats;
+  statsDef rtp_stats;
+  statsDef stats_t;
+  powerDef power_t;
+  MCBackend(InputParameter *interface_ip_, const MCParam &mcp_,
+            enum MemoryCtrl_type mc_type_);
+  void compute();
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  ~MCBackend(){};
 };
 
 class MCPHY : public Component {
-  public:
-    InputParameter l_ip;
-    uca_org_t local_result;
-	enum MemoryCtrl_type mc_type;
-    MCParam  mcp;
-    statsDef       tdp_stats;
-    statsDef       rtp_stats;
-    statsDef       stats_t;
-    powerDef       power_t;
-    MCPHY(InputParameter* interface_ip_, const MCParam & mcp_, enum MemoryCtrl_type mc_type_);
-    void compute();
-	void computeEnergy(bool is_tdp=true);
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-    ~MCPHY(){};
+ public:
+  InputParameter l_ip;
+  uca_org_t local_result;
+  enum MemoryCtrl_type mc_type;
+  MCParam mcp;
+  statsDef tdp_stats;
+  statsDef rtp_stats;
+  statsDef stats_t;
+  powerDef power_t;
+  MCPHY(InputParameter *interface_ip_, const MCParam &mcp_,
+        enum MemoryCtrl_type mc_type_);
+  void compute();
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  ~MCPHY(){};
 };
 
 class MCFrontEnd : public Component {
-  public:
-	ParseXML *XML;
-	InputParameter interface_ip;
-	enum MemoryCtrl_type mc_type;
-	MCParam  mcp;
-	selection_logic * MC_arb;
-	ArrayST  * frontendBuffer;
-	ArrayST  * readBuffer;
-	ArrayST  * writeBuffer;
+ public:
+  ParseXML *XML;
+  InputParameter interface_ip;
+  enum MemoryCtrl_type mc_type;
+  MCParam mcp;
+  selection_logic *MC_arb;
+  ArrayST *frontendBuffer;
+  ArrayST *readBuffer;
+  ArrayST *writeBuffer;
 
-	ArrayST * PRT;
-	ArrayST * threadMasks;
-	ArrayST * PRC;
-	double coalesce_scale;
+  ArrayST *PRT;
+  ArrayST *threadMasks;
+  ArrayST *PRC;
+  double coalesce_scale;
 
-    MCFrontEnd(ParseXML *XML_interface,InputParameter* interface_ip_, const MCParam & mcp_, enum MemoryCtrl_type mc_type_);
-    void computeEnergy(bool is_tdp=true);
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-    ~MCFrontEnd();
+  MCFrontEnd(ParseXML *XML_interface, InputParameter *interface_ip_,
+             const MCParam &mcp_, enum MemoryCtrl_type mc_type_);
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  ~MCFrontEnd();
 };
 
 class DRAM : public Component {
-  public:
-	ParseXML *XML;
-	InputParameter interface_ip;
-	enum Dram_type dram_type;
-    DRAMParam  dramp;
-    powerDef       power_t;
-    DRAM(ParseXML *XML_interface,InputParameter* interface_ip_, enum Dram_type dram_type_);
-    void set_dram_param();
-    void computeEnergy(bool is_tdp=true);
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-    ~DRAM();
+ public:
+  ParseXML *XML;
+  InputParameter interface_ip;
+  enum Dram_type dram_type;
+  DRAMParam dramp;
+  powerDef power_t;
+  DRAM(ParseXML *XML_interface, InputParameter *interface_ip_,
+       enum Dram_type dram_type_);
+  void set_dram_param();
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  ~DRAM();
 };
 
 class MemoryController : public Component {
-  public:
-	ParseXML *XML;
-	InputParameter interface_ip;
-	enum MemoryCtrl_type mc_type;
-    MCParam  mcp;
-    DRAM * dram;
-	MCFrontEnd * frontend;
-    MCBackend * transecEngine;
-    MCPHY	 * PHY;
-    Pipeline * pipeLogic;
+ public:
+  ParseXML *XML;
+  InputParameter interface_ip;
+  enum MemoryCtrl_type mc_type;
+  MCParam mcp;
+  DRAM *dram;
+  MCFrontEnd *frontend;
+  MCBackend *transecEngine;
+  MCPHY *PHY;
+  Pipeline *pipeLogic;
 
-	 //Add coalescing logic related modules with each memory controller --Syed Gilani
-	 
+  // Add coalescing logic related modules with each memory controller --Syed
+  // Gilani
 
-    //clock_network clockNetwork;
-    MemoryController(ParseXML *XML_interface,InputParameter* interface_ip_, enum MemoryCtrl_type mc_type_,enum Dram_type dram_type_);
-    void set_mc_param();
-    void computeEnergy(bool is_tdp=true);
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-    ~MemoryController();
+  // clock_network clockNetwork;
+  MemoryController(ParseXML *XML_interface, InputParameter *interface_ip_,
+                   enum MemoryCtrl_type mc_type_, enum Dram_type dram_type_);
+  void set_mc_param();
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  ~MemoryController();
 };
 #endif /* MEMORYCTRL_H_ */

--- a/src/gpuwattch/noc.cc
+++ b/src/gpuwattch/noc.cc
@@ -29,348 +29,425 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:												   *
-*      Jingwen Leng, Univeristy of Texas, Austin                   *
-*      Syed Gilani, University of Wisconsin–Madison                *
-*      Tayler Hetherington, University of British Columbia         *
-*      Ahmed ElTantawy, University of British Columbia             *
-********************************************************************/
+ *      Modified by:
+ ** Jingwen Leng, Univeristy of Texas, Austin                   * Syed Gilani,
+ *University of Wisconsin–Madison                * Tayler Hetherington,
+ *University of British Columbia         * Ahmed ElTantawy, University of
+ *British Columbia             *
+ ********************************************************************/
 
+#include "noc.h"
+#include <assert.h>
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <string>
+#include "XML_Parse.h"
+#include "cacti/basic_circuit.h"
+#include "const.h"
 #include "io.h"
 #include "parameter.h"
-#include "const.h"
-#include "cacti/basic_circuit.h"
-#include <iostream>
-#include <algorithm>
-#include "XML_Parse.h"
-#include <string>
-#include <cmath>
-#include <assert.h>
-#include "noc.h"
 
+NoC::NoC(ParseXML* XML_interface, int ithNoC_, InputParameter* interface_ip_,
+         double M_traffic_pattern_, double link_len_)
+    : XML(XML_interface),
+      ithNoC(ithNoC_),
+      interface_ip(*interface_ip_),
+      router(0),
+      link_bus(0),
+      link_bus_exist(false),
+      router_exist(false),
+      M_traffic_pattern(M_traffic_pattern_) {
+  /*
+   * initialize, compute and optimize individual components.
+   */
 
+  if (XML->sys.Embedded) {
+    interface_ip.wt = Global_30;
+    interface_ip.wire_is_mat_type = 0;
+    interface_ip.wire_os_mat_type = 1;
+  } else {
+    interface_ip.wt = Global;
+    interface_ip.wire_is_mat_type = 2;
+    interface_ip.wire_os_mat_type = 2;
+  }
+  set_noc_param();
+  local_result = init_interface(&interface_ip);
+  scktRatio = g_tp.sckt_co_eff;
 
-NoC::NoC(ParseXML *XML_interface, int ithNoC_, InputParameter* interface_ip_, double M_traffic_pattern_, double link_len_)
-:XML(XML_interface),
-ithNoC(ithNoC_),
-interface_ip(*interface_ip_),
-router(0),
-link_bus(0),
-link_bus_exist(false),
-router_exist(false),
-M_traffic_pattern(M_traffic_pattern_)
-{
-	/*
-	 * initialize, compute and optimize individual components.
-	 */
+  if (nocdynp.type) { /*
+                       * if NOC compute router, router links must be computed
+                       * separately and called from external since total chip
+                       * area must be known first
+                       */
+    init_router();
+  } else {
+    init_link_bus(link_len_);  // if bus compute bus
+  }
 
-	if (XML->sys.Embedded)
-			{
-			interface_ip.wt                  =Global_30;
-			interface_ip.wire_is_mat_type = 0;
-			interface_ip.wire_os_mat_type = 1;
-			}
-		else
-			{
-			interface_ip.wt                  =Global;
-			interface_ip.wire_is_mat_type = 2;
-			interface_ip.wire_os_mat_type = 2;
-			}
-	set_noc_param();
-	local_result=init_interface(&interface_ip);
-	scktRatio = g_tp.sckt_co_eff;
-
-	if (nocdynp.type)
-	{/*
-		 * if NOC compute router, router links must be computed separately
-		 * and called from external
-		 * since total chip area must be known first
-		 */
-		init_router();
-	}
-	else
-	{
-		init_link_bus(link_len_); //if bus compute bus
-	}
-
-	//  //clock power
-	//  clockNetwork.init_wire_external(is_default, &interface_ip);
-	//  clockNetwork.clk_area           =area*1.1;//10% of placement overhead. rule of thumb
-	//  clockNetwork.end_wiring_level   =5;//toplevel metal
-	//  clockNetwork.start_wiring_level =5;//toplevel metal
-	//  clockNetwork.num_regs           = corepipe.tot_stage_vector;
-	//  clockNetwork.optimize_wire();
+  //  //clock power
+  //  clockNetwork.init_wire_external(is_default, &interface_ip);
+  //  clockNetwork.clk_area           =area*1.1;//10% of placement overhead.
+  //  rule of thumb clockNetwork.end_wiring_level   =5;//toplevel metal
+  //  clockNetwork.start_wiring_level =5;//toplevel metal
+  //  clockNetwork.num_regs           = corepipe.tot_stage_vector;
+  //  clockNetwork.optimize_wire();
 }
 
-void NoC::init_router()
-{
-	router  = new MCPAT_Router(nocdynp.flit_size,
-			nocdynp.virtual_channel_per_port*nocdynp.input_buffer_entries_per_vc,
-			nocdynp.virtual_channel_per_port, &(g_tp.peri_global),
-			nocdynp.input_ports,nocdynp.output_ports, M_traffic_pattern);
-	//router->print_router();
-	area.set_area(area.get_area()+ router->area.get_area()*nocdynp.total_nodes);
+void NoC::init_router() {
+  router = new MCPAT_Router(
+      nocdynp.flit_size,
+      nocdynp.virtual_channel_per_port * nocdynp.input_buffer_entries_per_vc,
+      nocdynp.virtual_channel_per_port, &(g_tp.peri_global),
+      nocdynp.input_ports, nocdynp.output_ports, M_traffic_pattern);
+  // router->print_router();
+  area.set_area(area.get_area() +
+                router->area.get_area() * nocdynp.total_nodes);
 
-	double long_channel_device_reduction = longer_channel_device_reduction(Uncore_device);
-	router->power.readOp.longer_channel_leakage          = router->power.readOp.leakage * long_channel_device_reduction;
-	router->buffer.power.readOp.longer_channel_leakage   = router->buffer.power.readOp.leakage * long_channel_device_reduction;
-	router->crossbar.power.readOp.longer_channel_leakage = router->crossbar.power.readOp.leakage * long_channel_device_reduction;
-	router->arbiter.power.readOp.longer_channel_leakage  = router->arbiter.power.readOp.leakage * long_channel_device_reduction;
-	router_exist = true;
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(Uncore_device);
+  router->power.readOp.longer_channel_leakage =
+      router->power.readOp.leakage * long_channel_device_reduction;
+  router->buffer.power.readOp.longer_channel_leakage =
+      router->buffer.power.readOp.leakage * long_channel_device_reduction;
+  router->crossbar.power.readOp.longer_channel_leakage =
+      router->crossbar.power.readOp.leakage * long_channel_device_reduction;
+  router->arbiter.power.readOp.longer_channel_leakage =
+      router->arbiter.power.readOp.leakage * long_channel_device_reduction;
+  router_exist = true;
 }
 
-void NoC ::init_link_bus(double link_len_)
-{
+void NoC ::init_link_bus(double link_len_) {
+  //	if (nocdynp.min_ports==1 )
+  if (nocdynp.type)
+    link_name = "Links";
+  else
+    link_name = "Bus";
 
+  link_len = link_len_;
+  assert(link_len > 0);
 
-//	if (nocdynp.min_ports==1 )
-	if (nocdynp.type)
-		link_name = "Links";
-	else
-		link_name = "Bus";
+  interface_ip.throughput = nocdynp.link_throughput / nocdynp.clockRate;
+  interface_ip.latency = nocdynp.link_latency / nocdynp.clockRate;
 
-	link_len=link_len_;
-	assert(link_len>0);
+  link_len /= (nocdynp.horizontal_nodes + nocdynp.vertical_nodes) / 2;
 
-	interface_ip.throughput = nocdynp.link_throughput/nocdynp.clockRate;
-	interface_ip.latency = nocdynp.link_latency/nocdynp.clockRate;
+  if (nocdynp.total_nodes > 1)
+    link_len /= 2;  // All links are shared by neighbors
+  link_bus = new interconnect(name, Uncore_device, 1, 1, nocdynp.flit_size,
+                              link_len, &interface_ip, 3, true /*pipelinable*/,
+                              nocdynp.route_over_perc);
 
-	link_len /= (nocdynp.horizontal_nodes + nocdynp.vertical_nodes)/2;
+  link_bus_tot_per_Router.area.set_area(
+      link_bus_tot_per_Router.area.get_area() +
+      link_bus->area.get_area() * nocdynp.global_linked_ports);
 
-	if (nocdynp.total_nodes >1) link_len /=2; //All links are shared by neighbors
-	link_bus = new interconnect(name, Uncore_device, 1, 1, nocdynp.flit_size,
-				  link_len, &interface_ip, 3, true/*pipelinable*/, nocdynp.route_over_perc);
-
-	link_bus_tot_per_Router.area.set_area(link_bus_tot_per_Router.area.get_area()+ link_bus->area.get_area()
-			* nocdynp.global_linked_ports);
-
-	area.set_area(area.get_area()+ link_bus_tot_per_Router.area.get_area()* nocdynp.total_nodes);
-	link_bus_exist = true;
+  area.set_area(area.get_area() +
+                link_bus_tot_per_Router.area.get_area() * nocdynp.total_nodes);
+  link_bus_exist = true;
 }
-void NoC::computeEnergy(bool is_tdp)
-{
-	//power_point_product_masks
-	double pppm_t[4]    = {1,1,1,1};
-	double M=nocdynp.duty_cycle;
- // nocdynp.executionTime=XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);//Syed
-   //cout<<"NOC Total Cycles: "<<XML->sys.total_cycles<<endl;
-	//cout<<"NOC Clock Rate: "<<XML->sys.target_core_clockrate<<endl;
-	if (is_tdp)
-	    {
-	    	//init stats for TDP
-	    	stats_t.readAc.access  = M;
-            tdp_stats = stats_t;
-            if (router_exist)
-            {
-            	set_pppm(pppm_t, 1*M, 1, 1, 1);//reset traffic pattern
-                router->power = router->power*pppm_t;
-                set_pppm(pppm_t, nocdynp.total_nodes, nocdynp.total_nodes, nocdynp.total_nodes, nocdynp.total_nodes);
-          	    power     = power + router->power*pppm_t;
-            }
-            if (link_bus_exist)
-            {
-            	if (nocdynp.type)
-            		set_pppm(pppm_t, 1*M_traffic_pattern*M*(nocdynp.min_ports -1), nocdynp.global_linked_ports,
-            			nocdynp.global_linked_ports, nocdynp.global_linked_ports);
-            	    //reset traffic pattern; local port do not have router links
-            	else
-            		set_pppm(pppm_t, 1*M_traffic_pattern*M*(nocdynp.min_ports), nocdynp.global_linked_ports,
-            		            			nocdynp.global_linked_ports, nocdynp.global_linked_ports);//reset traffic pattern
+void NoC::computeEnergy(bool is_tdp) {
+  // power_point_product_masks
+  double pppm_t[4] = {1, 1, 1, 1};
+  double M = nocdynp.duty_cycle;
+  // nocdynp.executionTime=XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);//Syed
+  // cout<<"NOC Total Cycles: "<<XML->sys.total_cycles<<endl;
+  // cout<<"NOC Clock Rate: "<<XML->sys.target_core_clockrate<<endl;
+  if (is_tdp) {
+    // init stats for TDP
+    stats_t.readAc.access = M;
+    tdp_stats = stats_t;
+    if (router_exist) {
+      set_pppm(pppm_t, 1 * M, 1, 1, 1);  // reset traffic pattern
+      router->power = router->power * pppm_t;
+      set_pppm(pppm_t, nocdynp.total_nodes, nocdynp.total_nodes,
+               nocdynp.total_nodes, nocdynp.total_nodes);
+      power = power + router->power * pppm_t;
+    }
+    if (link_bus_exist) {
+      if (nocdynp.type)
+        set_pppm(pppm_t, 1 * M_traffic_pattern * M * (nocdynp.min_ports - 1),
+                 nocdynp.global_linked_ports, nocdynp.global_linked_ports,
+                 nocdynp.global_linked_ports);
+      // reset traffic pattern; local port do not have router links
+      else
+        set_pppm(pppm_t, 1 * M_traffic_pattern * M * (nocdynp.min_ports),
+                 nocdynp.global_linked_ports, nocdynp.global_linked_ports,
+                 nocdynp.global_linked_ports);  // reset traffic pattern
 
-            	link_bus_tot_per_Router.power = link_bus->power*pppm_t;
+      link_bus_tot_per_Router.power = link_bus->power * pppm_t;
 
-                set_pppm(pppm_t, nocdynp.total_nodes,
-                		         nocdynp.total_nodes,
-                		         nocdynp.total_nodes,
-                		         nocdynp.total_nodes);
-            	power     = power + link_bus_tot_per_Router.power*pppm_t;
+      set_pppm(pppm_t, nocdynp.total_nodes, nocdynp.total_nodes,
+               nocdynp.total_nodes, nocdynp.total_nodes);
+      power = power + link_bus_tot_per_Router.power * pppm_t;
+    }
+  } else {
+    rt_power.reset();
+    router->buffer.rt_power.reset();
+    router->crossbar.rt_power.reset();
+    router->arbiter.rt_power.reset();
+    router->rt_power.reset();
+    // link_bus->rt_power.reset();
 
-            }
-	    }
-	    else
-	    {
-			rt_power.reset();
-         router->buffer.rt_power.reset();
-         router->crossbar.rt_power.reset();
-         router->arbiter.rt_power.reset();
-			router->rt_power.reset();
-         //link_bus->rt_power.reset();
+    // init stats for runtime power (RTP)
+    stats_t.readAc.access = XML->sys.NoC[ithNoC].total_accesses;
+    // cout<<"NOC(computeEnergy) read accesses: "<< stats_t.readAc.access<<endl;
+    rtp_stats = stats_t;
+    set_pppm(pppm_t, 1, 0, 0, 0);
+    if (router_exist) {
+      router->buffer.rt_power.readOp.dynamic =
+          (router->buffer.power.readOp.dynamic +
+           router->buffer.power.writeOp.dynamic) *
+          rtp_stats.readAc.access;
+      router->crossbar.rt_power.readOp.dynamic =
+          router->crossbar.power.readOp.dynamic * rtp_stats.readAc.access;
+      router->arbiter.rt_power.readOp.dynamic =
+          router->arbiter.power.readOp.dynamic * rtp_stats.readAc.access;
 
-	    	//init stats for runtime power (RTP)
-	    	stats_t.readAc.access  = XML->sys.NoC[ithNoC].total_accesses;
-			//cout<<"NOC(computeEnergy) read accesses: "<< stats_t.readAc.access<<endl;
-            rtp_stats = stats_t;
-        	set_pppm(pppm_t, 1, 0 , 0, 0);
-        	if (router_exist)
-        	{
-            	router->buffer.rt_power.readOp.dynamic = (router->buffer.power.readOp.dynamic + router->buffer.power.writeOp.dynamic)*rtp_stats.readAc.access ;
-            	router->crossbar.rt_power.readOp.dynamic = router->crossbar.power.readOp.dynamic*rtp_stats.readAc.access ;
-            	router->arbiter.rt_power.readOp.dynamic = router->arbiter.power.readOp.dynamic*rtp_stats.readAc.access ;
-
-        		router->rt_power = router->rt_power + (router->buffer.rt_power + router->crossbar.rt_power + router->arbiter.rt_power)*pppm_t +
-					router->power*pppm_lkg;//TDP power must be calculated first!
-        		rt_power     = rt_power + router->rt_power;
-        	}
-        	if (link_bus_exist)
-        	{
-        	  link_bus->rt_power.reset();	
-			  set_pppm(pppm_t, rtp_stats.readAc.access, 1 , 1, rtp_stats.readAc.access);
-        		link_bus->rt_power = link_bus->power * pppm_t;
-        		rt_power = rt_power + link_bus->rt_power;
-        	}
-
-	    }
-}
-
-
-void NoC::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
-
-	double M =M_traffic_pattern*nocdynp.duty_cycle;
-	/*only router as a whole has been applied the M_traffic_pattern(0.6 by default) factor in router.cc;
-	 * 	When power of crossbars, arbiters, etc need to be displayed, the M_traffic_pattern factor need to
-	 * be applied together with McPAT's extra traffic pattern.
-	 * */
-	if (is_tdp)
-	{
-		cout << name << endl;
-		cout << indent_str << "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str<< "Peak Dynamic = " << power.readOp.dynamic*nocdynp.clockRate << " W" << endl;
-		cout << indent_str << "Subthreshold Leakage = "
-			<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
-		cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str<< "Runtime Dynamic = " << rt_power.readOp.dynamic/nocdynp.executionTime << " W" << endl;
-      //cout << indent_str<< "Execution Time = " << nocdynp.executionTime << " s" << endl;
-		cout<<endl;
-
-		if (router_exist)
-		{
-			cout << indent_str << "Router: " << endl;
-			cout << indent_str_next << "Area = " << router->area.get_area()*1e-6<< " mm^2" << endl;
-			cout << indent_str_next<< "Peak Dynamic = " << router->power.readOp.dynamic*nocdynp.clockRate << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? router->power.readOp.longer_channel_leakage:router->power.readOp.leakage)  <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << router->power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next<< "Runtime Dynamic = " << router->rt_power.readOp.dynamic/nocdynp.executionTime << " W" << endl;
-			cout<<endl;
-			if (plevel >2){
-				cout << indent_str<< indent_str << "Virtual Channel Buffer:" << endl;
-				cout << indent_str<< indent_str_next << "Area = " << router->buffer.area.get_area()*1e-6*nocdynp.input_ports<< " mm^2" << endl;
-				cout << indent_str<< indent_str_next << "Peak Dynamic = " <<(router->buffer.power.readOp.dynamic + router->buffer.power.writeOp.dynamic)
-				*nocdynp.min_ports*M*nocdynp.clockRate << " W" << endl;
-				cout << indent_str<< indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? router->buffer.power.readOp.longer_channel_leakage*nocdynp.input_ports:router->buffer.power.readOp.leakage*nocdynp.input_ports)  <<" W" << endl;
-				cout << indent_str<< indent_str_next << "Gate Leakage = " << router->buffer.power.readOp.gate_leakage*nocdynp.input_ports << " W" << endl;
-				cout << indent_str<< indent_str_next << "Runtime Dynamic = " << router->buffer.rt_power.readOp.dynamic/nocdynp.executionTime << " W" << endl;
-				cout <<endl;
-				cout << indent_str<< indent_str<< "Crossbar:" << endl;
-				cout << indent_str<< indent_str_next << "Area = " << router->crossbar.area.get_area()*1e-6  << " mm^2" << endl;
-				cout << indent_str<< indent_str_next << "Peak Dynamic = " << router->crossbar.power.readOp.dynamic*nocdynp.clockRate*nocdynp.min_ports*M << " W" << endl;
-				cout << indent_str<< indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? router->crossbar.power.readOp.longer_channel_leakage:router->crossbar.power.readOp.leakage)  << " W" << endl;
-				cout << indent_str<< indent_str_next << "Gate Leakage = " << router->crossbar.power.readOp.gate_leakage  << " W" << endl;
-				cout << indent_str<< indent_str_next << "Runtime Dynamic = " << router->crossbar.rt_power.readOp.dynamic/nocdynp.executionTime << " W" << endl;
-				cout <<endl;
-				cout << indent_str<< indent_str<< "Arbiter:" << endl;
-				cout << indent_str<< indent_str_next << "Peak Dynamic = " << router->arbiter.power.readOp.dynamic*nocdynp.clockRate*nocdynp.min_ports*M  << " W" << endl;
-				cout << indent_str<< indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? router->arbiter.power.readOp.longer_channel_leakage:router->arbiter.power.readOp.leakage)  << " W" << endl;
-				cout << indent_str<< indent_str_next << "Gate Leakage = " << router->arbiter.power.readOp.gate_leakage  << " W" << endl;
-				cout << indent_str<< indent_str_next << "Runtime Dynamic = " << router->arbiter.rt_power.readOp.dynamic/nocdynp.executionTime << " W" << endl;
-				cout <<endl;
-			}
-		}
-		if (link_bus_exist)
-		{
-			cout << indent_str << (nocdynp.type? "Per Router ":"") << link_name<<": " << endl;
-			cout << indent_str_next << "Area = " << link_bus_tot_per_Router.area.get_area()*1e-6<< " mm^2" << endl;
-			cout << indent_str_next<< "Peak Dynamic = " << link_bus_tot_per_Router.power.readOp.dynamic*
-				nocdynp.clockRate << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? link_bus_tot_per_Router.power.readOp.longer_channel_leakage:link_bus_tot_per_Router.power.readOp.leakage)
-			     <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << link_bus_tot_per_Router.power.readOp.gate_leakage
-				<< " W" << endl;
-			cout << indent_str_next<< "Runtime Dynamic = " << link_bus->rt_power.readOp.dynamic/nocdynp.executionTime << " W" << endl;
-			cout<<endl;
-
-		}
-	}
-	else
-	{
-//		cout << indent_str_next << "Instruction Fetch Unit    Peak Dynamic = " << ifu->rt_power.readOp.dynamic*clockRate << " W" << endl;
-//		cout << indent_str_next << "Instruction Fetch Unit    Subthreshold Leakage = " << ifu->rt_power.readOp.leakage <<" W" << endl;
-//		cout << indent_str_next << "Instruction Fetch Unit    Gate Leakage = " << ifu->rt_power.readOp.gate_leakage << " W" << endl;
-//		cout << indent_str_next << "Load Store Unit   Peak Dynamic = " << lsu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-//		cout << indent_str_next << "Load Store Unit   Subthreshold Leakage = " << lsu->rt_power.readOp.leakage  << " W" << endl;
-//		cout << indent_str_next << "Load Store Unit   Gate Leakage = " << lsu->rt_power.readOp.gate_leakage  << " W" << endl;
-//		cout << indent_str_next << "Memory Management Unit   Peak Dynamic = " << mmu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-//		cout << indent_str_next << "Memory Management Unit   Subthreshold Leakage = " << mmu->rt_power.readOp.leakage  << " W" << endl;
-//		cout << indent_str_next << "Memory Management Unit   Gate Leakage = " << mmu->rt_power.readOp.gate_leakage  << " W" << endl;
-//		cout << indent_str_next << "Execution Unit   Peak Dynamic = " << exu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-//		cout << indent_str_next << "Execution Unit   Subthreshold Leakage = " << exu->rt_power.readOp.leakage  << " W" << endl;
-//		cout << indent_str_next << "Execution Unit   Gate Leakage = " << exu->rt_power.readOp.gate_leakage  << " W" << endl;
-	}
+      router->rt_power =
+          router->rt_power +
+          (router->buffer.rt_power + router->crossbar.rt_power +
+           router->arbiter.rt_power) *
+              pppm_t +
+          router->power * pppm_lkg;  // TDP power must be calculated first!
+      rt_power = rt_power + router->rt_power;
+    }
+    if (link_bus_exist) {
+      link_bus->rt_power.reset();
+      set_pppm(pppm_t, rtp_stats.readAc.access, 1, 1, rtp_stats.readAc.access);
+      link_bus->rt_power = link_bus->power * pppm_t;
+      rt_power = rt_power + link_bus->rt_power;
+    }
+  }
 }
 
-void NoC::set_noc_param()
-{
+void NoC::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
 
-	nocdynp.type            = XML->sys.NoC[ithNoC].type;
-	nocdynp.clockRate       =XML->sys.NoC[ithNoC].clockrate;
-	nocdynp.clockRate       *= 1e6;
-	nocdynp.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
+  double M = M_traffic_pattern * nocdynp.duty_cycle;
+  /*only router as a whole has been applied the M_traffic_pattern(0.6 by
+   * default) factor in router.cc; When power of crossbars, arbiters, etc need
+   * to be displayed, the M_traffic_pattern factor need to be applied together
+   * with McPAT's extra traffic pattern.
+   * */
+  if (is_tdp) {
+    cout << name << endl;
+    cout << indent_str << "Area = " << area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str
+         << "Peak Dynamic = " << power.readOp.dynamic * nocdynp.clockRate
+         << " W" << endl;
+    cout << indent_str << "Subthreshold Leakage = "
+         << (long_channel ? power.readOp.longer_channel_leakage
+                          : power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str << "Runtime Dynamic = "
+         << rt_power.readOp.dynamic / nocdynp.executionTime << " W" << endl;
+    // cout << indent_str<< "Execution Time = " << nocdynp.executionTime << " s"
+    // << endl;
+    cout << endl;
 
-	nocdynp.flit_size     = XML->sys.NoC[ithNoC].flit_bits;
-	if (nocdynp.type)
-	{
-		nocdynp.input_ports   = XML->sys.NoC[ithNoC].input_ports;
-		nocdynp.output_ports  = XML->sys.NoC[ithNoC].output_ports;//later minus 1
-		nocdynp.min_ports     = min(nocdynp.input_ports,nocdynp.output_ports);
-		nocdynp.global_linked_ports = (nocdynp.input_ports-1) + (nocdynp.output_ports-1);
-		/*
-		 * 	Except local i/o ports, all ports needs links( global_linked_ports);
-		 *  However only min_ports can be fully active simultaneously
-		 *  since the fewer number of ports (input or output ) is the bottleneck.
-		 */
-	}
-	else
-	{
-		nocdynp.input_ports   = 1;
-		nocdynp.output_ports  = 1;
-		nocdynp.min_ports     = min(nocdynp.input_ports,nocdynp.output_ports);
-		nocdynp.global_linked_ports = 1;
-	}
-
-	nocdynp.virtual_channel_per_port     = XML->sys.NoC[ithNoC].virtual_channel_per_port;
-	nocdynp.input_buffer_entries_per_vc  = XML->sys.NoC[ithNoC].input_buffer_entries_per_vc;
-
-	nocdynp.horizontal_nodes  = XML->sys.NoC[ithNoC].horizontal_nodes;
-	nocdynp.vertical_nodes    = XML->sys.NoC[ithNoC].vertical_nodes;
-	nocdynp.total_nodes       = nocdynp.horizontal_nodes*nocdynp.vertical_nodes;
-	nocdynp.duty_cycle        = XML->sys.NoC[ithNoC].duty_cycle;
-	nocdynp.has_global_link   = XML->sys.NoC[ithNoC].has_global_link;
-	nocdynp.link_throughput   = XML->sys.NoC[ithNoC].link_throughput;
-	nocdynp.link_latency      = XML->sys.NoC[ithNoC].link_latency;
-	nocdynp.chip_coverage     = XML->sys.NoC[ithNoC].chip_coverage;
-	nocdynp.route_over_perc   = XML->sys.NoC[ithNoC].route_over_perc;
-
-	assert (nocdynp.chip_coverage <=1);
-	assert (nocdynp.route_over_perc <=1);
-
-	if (nocdynp.type)
-		name = "NOC";
-	else
-		name = "BUSES";
-
+    if (router_exist) {
+      cout << indent_str << "Router: " << endl;
+      cout << indent_str_next << "Area = " << router->area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next << "Peak Dynamic = "
+           << router->power.readOp.dynamic * nocdynp.clockRate << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? router->power.readOp.longer_channel_leakage
+                            : router->power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << router->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << router->rt_power.readOp.dynamic / nocdynp.executionTime << " W"
+           << endl;
+      cout << endl;
+      if (plevel > 2) {
+        cout << indent_str << indent_str << "Virtual Channel Buffer:" << endl;
+        cout << indent_str << indent_str_next << "Area = "
+             << router->buffer.area.get_area() * 1e-6 * nocdynp.input_ports
+             << " mm^2" << endl;
+        cout << indent_str << indent_str_next << "Peak Dynamic = "
+             << (router->buffer.power.readOp.dynamic +
+                 router->buffer.power.writeOp.dynamic) *
+                    nocdynp.min_ports * M * nocdynp.clockRate
+             << " W" << endl;
+        cout << indent_str << indent_str_next << "Subthreshold Leakage = "
+             << (long_channel
+                     ? router->buffer.power.readOp.longer_channel_leakage *
+                           nocdynp.input_ports
+                     : router->buffer.power.readOp.leakage *
+                           nocdynp.input_ports)
+             << " W" << endl;
+        cout << indent_str << indent_str_next << "Gate Leakage = "
+             << router->buffer.power.readOp.gate_leakage * nocdynp.input_ports
+             << " W" << endl;
+        cout << indent_str << indent_str_next << "Runtime Dynamic = "
+             << router->buffer.rt_power.readOp.dynamic / nocdynp.executionTime
+             << " W" << endl;
+        cout << endl;
+        cout << indent_str << indent_str << "Crossbar:" << endl;
+        cout << indent_str << indent_str_next
+             << "Area = " << router->crossbar.area.get_area() * 1e-6 << " mm^2"
+             << endl;
+        cout << indent_str << indent_str_next << "Peak Dynamic = "
+             << router->crossbar.power.readOp.dynamic * nocdynp.clockRate *
+                    nocdynp.min_ports * M
+             << " W" << endl;
+        cout << indent_str << indent_str_next << "Subthreshold Leakage = "
+             << (long_channel
+                     ? router->crossbar.power.readOp.longer_channel_leakage
+                     : router->crossbar.power.readOp.leakage)
+             << " W" << endl;
+        cout << indent_str << indent_str_next
+             << "Gate Leakage = " << router->crossbar.power.readOp.gate_leakage
+             << " W" << endl;
+        cout << indent_str << indent_str_next << "Runtime Dynamic = "
+             << router->crossbar.rt_power.readOp.dynamic / nocdynp.executionTime
+             << " W" << endl;
+        cout << endl;
+        cout << indent_str << indent_str << "Arbiter:" << endl;
+        cout << indent_str << indent_str_next << "Peak Dynamic = "
+             << router->arbiter.power.readOp.dynamic * nocdynp.clockRate *
+                    nocdynp.min_ports * M
+             << " W" << endl;
+        cout << indent_str << indent_str_next << "Subthreshold Leakage = "
+             << (long_channel
+                     ? router->arbiter.power.readOp.longer_channel_leakage
+                     : router->arbiter.power.readOp.leakage)
+             << " W" << endl;
+        cout << indent_str << indent_str_next
+             << "Gate Leakage = " << router->arbiter.power.readOp.gate_leakage
+             << " W" << endl;
+        cout << indent_str << indent_str_next << "Runtime Dynamic = "
+             << router->arbiter.rt_power.readOp.dynamic / nocdynp.executionTime
+             << " W" << endl;
+        cout << endl;
+      }
+    }
+    if (link_bus_exist) {
+      cout << indent_str << (nocdynp.type ? "Per Router " : "") << link_name
+           << ": " << endl;
+      cout << indent_str_next
+           << "Area = " << link_bus_tot_per_Router.area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next << "Peak Dynamic = "
+           << link_bus_tot_per_Router.power.readOp.dynamic * nocdynp.clockRate
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel
+                   ? link_bus_tot_per_Router.power.readOp.longer_channel_leakage
+                   : link_bus_tot_per_Router.power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next << "Gate Leakage = "
+           << link_bus_tot_per_Router.power.readOp.gate_leakage << " W" << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << link_bus->rt_power.readOp.dynamic / nocdynp.executionTime << " W"
+           << endl;
+      cout << endl;
+    }
+  } else {
+    //		cout << indent_str_next << "Instruction Fetch Unit    Peak Dynamic
+    //=
+    //"
+    //<< ifu->rt_power.readOp.dynamic*clockRate << " W" << endl;
+    //cout
+    //<< indent_str_next << "Instruction Fetch Unit    Subthreshold Leakage = "
+    // << ifu->rt_power.readOp.leakage <<" W" << endl; 		cout <<
+    // indent_str_next << "Instruction Fetch Unit    Gate Leakage = " <<
+    // ifu->rt_power.readOp.gate_leakage << " W" << endl; 		cout <<
+    // indent_str_next
+    //<< "Load Store Unit   Peak Dynamic = " <<
+    // lsu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    // cout
+    // << indent_str_next << "Load Store Unit   Subthreshold Leakage = " <<
+    // lsu->rt_power.readOp.leakage  << " W" << endl; 		cout <<
+    // indent_str_next
+    // << "Load Store Unit   Gate Leakage = " <<
+    // lsu->rt_power.readOp.gate_leakage
+    //<< " W" << endl; 		cout << indent_str_next << "Memory Management
+    //Unit Peak Dynamic = " << mmu->rt_power.readOp.dynamic*clockRate  << " W"
+    // <<
+    // endl; 		cout << indent_str_next << "Memory Management Unit
+    // Subthreshold Leakage = " << mmu->rt_power.readOp.leakage  << " W" <<
+    // endl; 		cout
+    // << indent_str_next << "Memory Management Unit   Gate Leakage = " <<
+    // mmu->rt_power.readOp.gate_leakage  << " W" << endl; 		cout <<
+    // indent_str_next << "Execution Unit   Peak Dynamic = " <<
+    // exu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    // cout
+    // << indent_str_next << "Execution Unit   Subthreshold Leakage = " <<
+    // exu->rt_power.readOp.leakage  << " W" << endl; 		cout <<
+    // indent_str_next
+    // << "Execution Unit   Gate Leakage = " <<
+    // exu->rt_power.readOp.gate_leakage
+    //<< " W" << endl;
+  }
 }
 
+void NoC::set_noc_param() {
+  nocdynp.type = XML->sys.NoC[ithNoC].type;
+  nocdynp.clockRate = XML->sys.NoC[ithNoC].clockrate;
+  nocdynp.clockRate *= 1e6;
+  nocdynp.executionTime =
+      XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);
 
-NoC ::~NoC(){
+  nocdynp.flit_size = XML->sys.NoC[ithNoC].flit_bits;
+  if (nocdynp.type) {
+    nocdynp.input_ports = XML->sys.NoC[ithNoC].input_ports;
+    nocdynp.output_ports = XML->sys.NoC[ithNoC].output_ports;  // later minus 1
+    nocdynp.min_ports = min(nocdynp.input_ports, nocdynp.output_ports);
+    nocdynp.global_linked_ports =
+        (nocdynp.input_ports - 1) + (nocdynp.output_ports - 1);
+    /*
+     * 	Except local i/o ports, all ports needs links( global_linked_ports);
+     *  However only min_ports can be fully active simultaneously
+     *  since the fewer number of ports (input or output ) is the bottleneck.
+     */
+  } else {
+    nocdynp.input_ports = 1;
+    nocdynp.output_ports = 1;
+    nocdynp.min_ports = min(nocdynp.input_ports, nocdynp.output_ports);
+    nocdynp.global_linked_ports = 1;
+  }
 
-	if(router) 	               {delete router; router = 0;}
-	if(link_bus) 	           {delete link_bus; link_bus = 0;}
+  nocdynp.virtual_channel_per_port =
+      XML->sys.NoC[ithNoC].virtual_channel_per_port;
+  nocdynp.input_buffer_entries_per_vc =
+      XML->sys.NoC[ithNoC].input_buffer_entries_per_vc;
+
+  nocdynp.horizontal_nodes = XML->sys.NoC[ithNoC].horizontal_nodes;
+  nocdynp.vertical_nodes = XML->sys.NoC[ithNoC].vertical_nodes;
+  nocdynp.total_nodes = nocdynp.horizontal_nodes * nocdynp.vertical_nodes;
+  nocdynp.duty_cycle = XML->sys.NoC[ithNoC].duty_cycle;
+  nocdynp.has_global_link = XML->sys.NoC[ithNoC].has_global_link;
+  nocdynp.link_throughput = XML->sys.NoC[ithNoC].link_throughput;
+  nocdynp.link_latency = XML->sys.NoC[ithNoC].link_latency;
+  nocdynp.chip_coverage = XML->sys.NoC[ithNoC].chip_coverage;
+  nocdynp.route_over_perc = XML->sys.NoC[ithNoC].route_over_perc;
+
+  assert(nocdynp.chip_coverage <= 1);
+  assert(nocdynp.route_over_perc <= 1);
+
+  if (nocdynp.type)
+    name = "NOC";
+  else
+    name = "BUSES";
+}
+
+NoC ::~NoC() {
+  if (router) {
+    delete router;
+    router = 0;
+  }
+  if (link_bus) {
+    delete link_bus;
+    link_bus = 0;
+  }
 }

--- a/src/gpuwattch/noc.cc
+++ b/src/gpuwattch/noc.cc
@@ -29,348 +29,418 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:												   *
+*      Modified by:
+**
 *      Jingwen Leng, Univeristy of Texas, Austin                   *
 *      Syed Gilani, University of Wisconsin–Madison                *
 *      Tayler Hetherington, University of British Columbia         *
 *      Ahmed ElTantawy, University of British Columbia             *
 ********************************************************************/
 
+#include "noc.h"
+#include <assert.h>
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <string>
+#include "XML_Parse.h"
+#include "cacti/basic_circuit.h"
+#include "const.h"
 #include "io.h"
 #include "parameter.h"
-#include "const.h"
-#include "cacti/basic_circuit.h"
-#include <iostream>
-#include <algorithm>
-#include "XML_Parse.h"
-#include <string>
-#include <cmath>
-#include <assert.h>
-#include "noc.h"
 
+NoC::NoC(ParseXML* XML_interface, int ithNoC_, InputParameter* interface_ip_,
+         double M_traffic_pattern_, double link_len_)
+    : XML(XML_interface),
+      ithNoC(ithNoC_),
+      interface_ip(*interface_ip_),
+      router(0),
+      link_bus(0),
+      link_bus_exist(false),
+      router_exist(false),
+      M_traffic_pattern(M_traffic_pattern_) {
+  /*
+   * initialize, compute and optimize individual components.
+   */
 
+  if (XML->sys.Embedded) {
+    interface_ip.wt = Global_30;
+    interface_ip.wire_is_mat_type = 0;
+    interface_ip.wire_os_mat_type = 1;
+  } else {
+    interface_ip.wt = Global;
+    interface_ip.wire_is_mat_type = 2;
+    interface_ip.wire_os_mat_type = 2;
+  }
+  set_noc_param();
+  local_result = init_interface(&interface_ip);
+  scktRatio = g_tp.sckt_co_eff;
 
-NoC::NoC(ParseXML *XML_interface, int ithNoC_, InputParameter* interface_ip_, double M_traffic_pattern_, double link_len_)
-:XML(XML_interface),
-ithNoC(ithNoC_),
-interface_ip(*interface_ip_),
-router(0),
-link_bus(0),
-link_bus_exist(false),
-router_exist(false),
-M_traffic_pattern(M_traffic_pattern_)
-{
-	/*
-	 * initialize, compute and optimize individual components.
-	 */
+  if (nocdynp.type) { /*
+                              * if NOC compute router, router links must be
+                       * computed separately
+                              * and called from external
+                              * since total chip area must be known first
+                              */
+    init_router();
+  } else {
+    init_link_bus(link_len_);  // if bus compute bus
+  }
 
-	if (XML->sys.Embedded)
-			{
-			interface_ip.wt                  =Global_30;
-			interface_ip.wire_is_mat_type = 0;
-			interface_ip.wire_os_mat_type = 1;
-			}
-		else
-			{
-			interface_ip.wt                  =Global;
-			interface_ip.wire_is_mat_type = 2;
-			interface_ip.wire_os_mat_type = 2;
-			}
-	set_noc_param();
-	local_result=init_interface(&interface_ip);
-	scktRatio = g_tp.sckt_co_eff;
-
-	if (nocdynp.type)
-	{/*
-		 * if NOC compute router, router links must be computed separately
-		 * and called from external
-		 * since total chip area must be known first
-		 */
-		init_router();
-	}
-	else
-	{
-		init_link_bus(link_len_); //if bus compute bus
-	}
-
-	//  //clock power
-	//  clockNetwork.init_wire_external(is_default, &interface_ip);
-	//  clockNetwork.clk_area           =area*1.1;//10% of placement overhead. rule of thumb
-	//  clockNetwork.end_wiring_level   =5;//toplevel metal
-	//  clockNetwork.start_wiring_level =5;//toplevel metal
-	//  clockNetwork.num_regs           = corepipe.tot_stage_vector;
-	//  clockNetwork.optimize_wire();
+  //  //clock power
+  //  clockNetwork.init_wire_external(is_default, &interface_ip);
+  //  clockNetwork.clk_area           =area*1.1;//10% of placement overhead.
+  //  rule of thumb
+  //  clockNetwork.end_wiring_level   =5;//toplevel metal
+  //  clockNetwork.start_wiring_level =5;//toplevel metal
+  //  clockNetwork.num_regs           = corepipe.tot_stage_vector;
+  //  clockNetwork.optimize_wire();
 }
 
-void NoC::init_router()
-{
-	router  = new MCPAT_Router(nocdynp.flit_size,
-			nocdynp.virtual_channel_per_port*nocdynp.input_buffer_entries_per_vc,
-			nocdynp.virtual_channel_per_port, &(g_tp.peri_global),
-			nocdynp.input_ports,nocdynp.output_ports, M_traffic_pattern);
-	//router->print_router();
-	area.set_area(area.get_area()+ router->area.get_area()*nocdynp.total_nodes);
+void NoC::init_router() {
+  router = new MCPAT_Router(
+      nocdynp.flit_size,
+      nocdynp.virtual_channel_per_port * nocdynp.input_buffer_entries_per_vc,
+      nocdynp.virtual_channel_per_port, &(g_tp.peri_global),
+      nocdynp.input_ports, nocdynp.output_ports, M_traffic_pattern);
+  // router->print_router();
+  area.set_area(area.get_area() +
+                router->area.get_area() * nocdynp.total_nodes);
 
-	double long_channel_device_reduction = longer_channel_device_reduction(Uncore_device);
-	router->power.readOp.longer_channel_leakage          = router->power.readOp.leakage * long_channel_device_reduction;
-	router->buffer.power.readOp.longer_channel_leakage   = router->buffer.power.readOp.leakage * long_channel_device_reduction;
-	router->crossbar.power.readOp.longer_channel_leakage = router->crossbar.power.readOp.leakage * long_channel_device_reduction;
-	router->arbiter.power.readOp.longer_channel_leakage  = router->arbiter.power.readOp.leakage * long_channel_device_reduction;
-	router_exist = true;
+  double long_channel_device_reduction =
+      longer_channel_device_reduction(Uncore_device);
+  router->power.readOp.longer_channel_leakage =
+      router->power.readOp.leakage * long_channel_device_reduction;
+  router->buffer.power.readOp.longer_channel_leakage =
+      router->buffer.power.readOp.leakage * long_channel_device_reduction;
+  router->crossbar.power.readOp.longer_channel_leakage =
+      router->crossbar.power.readOp.leakage * long_channel_device_reduction;
+  router->arbiter.power.readOp.longer_channel_leakage =
+      router->arbiter.power.readOp.leakage * long_channel_device_reduction;
+  router_exist = true;
 }
 
-void NoC ::init_link_bus(double link_len_)
-{
+void NoC::init_link_bus(double link_len_) {
+  //	if (nocdynp.min_ports==1 )
+  if (nocdynp.type)
+    link_name = "Links";
+  else
+    link_name = "Bus";
 
+  link_len = link_len_;
+  assert(link_len > 0);
 
-//	if (nocdynp.min_ports==1 )
-	if (nocdynp.type)
-		link_name = "Links";
-	else
-		link_name = "Bus";
+  interface_ip.throughput = nocdynp.link_throughput / nocdynp.clockRate;
+  interface_ip.latency = nocdynp.link_latency / nocdynp.clockRate;
 
-	link_len=link_len_;
-	assert(link_len>0);
+  link_len /= (nocdynp.horizontal_nodes + nocdynp.vertical_nodes) / 2;
 
-	interface_ip.throughput = nocdynp.link_throughput/nocdynp.clockRate;
-	interface_ip.latency = nocdynp.link_latency/nocdynp.clockRate;
+  if (nocdynp.total_nodes > 1)
+    link_len /= 2;  // All links are shared by neighbors
+  link_bus = new interconnect(name, Uncore_device, 1, 1, nocdynp.flit_size,
+                              link_len, &interface_ip, 3, true /*pipelinable*/,
+                              nocdynp.route_over_perc);
 
-	link_len /= (nocdynp.horizontal_nodes + nocdynp.vertical_nodes)/2;
+  link_bus_tot_per_Router.area.set_area(
+      link_bus_tot_per_Router.area.get_area() +
+      link_bus->area.get_area() * nocdynp.global_linked_ports);
 
-	if (nocdynp.total_nodes >1) link_len /=2; //All links are shared by neighbors
-	link_bus = new interconnect(name, Uncore_device, 1, 1, nocdynp.flit_size,
-				  link_len, &interface_ip, 3, true/*pipelinable*/, nocdynp.route_over_perc);
-
-	link_bus_tot_per_Router.area.set_area(link_bus_tot_per_Router.area.get_area()+ link_bus->area.get_area()
-			* nocdynp.global_linked_ports);
-
-	area.set_area(area.get_area()+ link_bus_tot_per_Router.area.get_area()* nocdynp.total_nodes);
-	link_bus_exist = true;
+  area.set_area(area.get_area() +
+                link_bus_tot_per_Router.area.get_area() * nocdynp.total_nodes);
+  link_bus_exist = true;
 }
-void NoC::computeEnergy(bool is_tdp)
-{
-	//power_point_product_masks
-	double pppm_t[4]    = {1,1,1,1};
-	double M=nocdynp.duty_cycle;
- // nocdynp.executionTime=XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);//Syed
-   //cout<<"NOC Total Cycles: "<<XML->sys.total_cycles<<endl;
-	//cout<<"NOC Clock Rate: "<<XML->sys.target_core_clockrate<<endl;
-	if (is_tdp)
-	    {
-	    	//init stats for TDP
-	    	stats_t.readAc.access  = M;
-            tdp_stats = stats_t;
-            if (router_exist)
-            {
-            	set_pppm(pppm_t, 1*M, 1, 1, 1);//reset traffic pattern
-                router->power = router->power*pppm_t;
-                set_pppm(pppm_t, nocdynp.total_nodes, nocdynp.total_nodes, nocdynp.total_nodes, nocdynp.total_nodes);
-          	    power     = power + router->power*pppm_t;
-            }
-            if (link_bus_exist)
-            {
-            	if (nocdynp.type)
-            		set_pppm(pppm_t, 1*M_traffic_pattern*M*(nocdynp.min_ports -1), nocdynp.global_linked_ports,
-            			nocdynp.global_linked_ports, nocdynp.global_linked_ports);
-            	    //reset traffic pattern; local port do not have router links
-            	else
-            		set_pppm(pppm_t, 1*M_traffic_pattern*M*(nocdynp.min_ports), nocdynp.global_linked_ports,
-            		            			nocdynp.global_linked_ports, nocdynp.global_linked_ports);//reset traffic pattern
+void NoC::computeEnergy(bool is_tdp) {
+  // power_point_product_masks
+  double pppm_t[4] = {1, 1, 1, 1};
+  double M = nocdynp.duty_cycle;
+  // nocdynp.executionTime=XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);//Syed
+  // cout<<"NOC Total Cycles: "<<XML->sys.total_cycles<<endl;
+  // cout<<"NOC Clock Rate: "<<XML->sys.target_core_clockrate<<endl;
+  if (is_tdp) {
+    // init stats for TDP
+    stats_t.readAc.access = M;
+    tdp_stats = stats_t;
+    if (router_exist) {
+      set_pppm(pppm_t, 1 * M, 1, 1, 1);  // reset traffic pattern
+      router->power = router->power * pppm_t;
+      set_pppm(pppm_t, nocdynp.total_nodes, nocdynp.total_nodes,
+               nocdynp.total_nodes, nocdynp.total_nodes);
+      power = power + router->power * pppm_t;
+    }
+    if (link_bus_exist) {
+      if (nocdynp.type)
+        set_pppm(pppm_t, 1 * M_traffic_pattern * M * (nocdynp.min_ports - 1),
+                 nocdynp.global_linked_ports, nocdynp.global_linked_ports,
+                 nocdynp.global_linked_ports);
+      // reset traffic pattern; local port do not have router links
+      else
+        set_pppm(pppm_t, 1 * M_traffic_pattern * M * (nocdynp.min_ports),
+                 nocdynp.global_linked_ports, nocdynp.global_linked_ports,
+                 nocdynp.global_linked_ports);  // reset traffic pattern
 
-            	link_bus_tot_per_Router.power = link_bus->power*pppm_t;
+      link_bus_tot_per_Router.power = link_bus->power * pppm_t;
 
-                set_pppm(pppm_t, nocdynp.total_nodes,
-                		         nocdynp.total_nodes,
-                		         nocdynp.total_nodes,
-                		         nocdynp.total_nodes);
-            	power     = power + link_bus_tot_per_Router.power*pppm_t;
+      set_pppm(pppm_t, nocdynp.total_nodes, nocdynp.total_nodes,
+               nocdynp.total_nodes, nocdynp.total_nodes);
+      power = power + link_bus_tot_per_Router.power * pppm_t;
+    }
+  } else {
+    rt_power.reset();
+    router->buffer.rt_power.reset();
+    router->crossbar.rt_power.reset();
+    router->arbiter.rt_power.reset();
+    router->rt_power.reset();
+    // link_bus->rt_power.reset();
 
-            }
-	    }
-	    else
-	    {
-			rt_power.reset();
-         router->buffer.rt_power.reset();
-         router->crossbar.rt_power.reset();
-         router->arbiter.rt_power.reset();
-			router->rt_power.reset();
-         //link_bus->rt_power.reset();
+    // init stats for runtime power (RTP)
+    stats_t.readAc.access = XML->sys.NoC[ithNoC].total_accesses;
+    // cout<<"NOC(computeEnergy) read accesses: "<< stats_t.readAc.access<<endl;
+    rtp_stats = stats_t;
+    set_pppm(pppm_t, 1, 0, 0, 0);
+    if (router_exist) {
+      router->buffer.rt_power.readOp.dynamic =
+          (router->buffer.power.readOp.dynamic +
+           router->buffer.power.writeOp.dynamic) *
+          rtp_stats.readAc.access;
+      router->crossbar.rt_power.readOp.dynamic =
+          router->crossbar.power.readOp.dynamic * rtp_stats.readAc.access;
+      router->arbiter.rt_power.readOp.dynamic =
+          router->arbiter.power.readOp.dynamic * rtp_stats.readAc.access;
 
-	    	//init stats for runtime power (RTP)
-	    	stats_t.readAc.access  = XML->sys.NoC[ithNoC].total_accesses;
-			//cout<<"NOC(computeEnergy) read accesses: "<< stats_t.readAc.access<<endl;
-            rtp_stats = stats_t;
-        	set_pppm(pppm_t, 1, 0 , 0, 0);
-        	if (router_exist)
-        	{
-            	router->buffer.rt_power.readOp.dynamic = (router->buffer.power.readOp.dynamic + router->buffer.power.writeOp.dynamic)*rtp_stats.readAc.access ;
-            	router->crossbar.rt_power.readOp.dynamic = router->crossbar.power.readOp.dynamic*rtp_stats.readAc.access ;
-            	router->arbiter.rt_power.readOp.dynamic = router->arbiter.power.readOp.dynamic*rtp_stats.readAc.access ;
-
-        		router->rt_power = router->rt_power + (router->buffer.rt_power + router->crossbar.rt_power + router->arbiter.rt_power)*pppm_t +
-					router->power*pppm_lkg;//TDP power must be calculated first!
-        		rt_power     = rt_power + router->rt_power;
-        	}
-        	if (link_bus_exist)
-        	{
-        	  link_bus->rt_power.reset();	
-			  set_pppm(pppm_t, rtp_stats.readAc.access, 1 , 1, rtp_stats.readAc.access);
-        		link_bus->rt_power = link_bus->power * pppm_t;
-        		rt_power = rt_power + link_bus->rt_power;
-        	}
-
-	    }
-}
-
-
-void NoC::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
-{
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool long_channel = XML->sys.longer_channel_device;
-
-	double M =M_traffic_pattern*nocdynp.duty_cycle;
-	/*only router as a whole has been applied the M_traffic_pattern(0.6 by default) factor in router.cc;
-	 * 	When power of crossbars, arbiters, etc need to be displayed, the M_traffic_pattern factor need to
-	 * be applied together with McPAT's extra traffic pattern.
-	 * */
-	if (is_tdp)
-	{
-		cout << name << endl;
-		cout << indent_str << "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str<< "Peak Dynamic = " << power.readOp.dynamic*nocdynp.clockRate << " W" << endl;
-		cout << indent_str << "Subthreshold Leakage = "
-			<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
-		cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str<< "Runtime Dynamic = " << rt_power.readOp.dynamic/nocdynp.executionTime << " W" << endl;
-      //cout << indent_str<< "Execution Time = " << nocdynp.executionTime << " s" << endl;
-		cout<<endl;
-
-		if (router_exist)
-		{
-			cout << indent_str << "Router: " << endl;
-			cout << indent_str_next << "Area = " << router->area.get_area()*1e-6<< " mm^2" << endl;
-			cout << indent_str_next<< "Peak Dynamic = " << router->power.readOp.dynamic*nocdynp.clockRate << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? router->power.readOp.longer_channel_leakage:router->power.readOp.leakage)  <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << router->power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next<< "Runtime Dynamic = " << router->rt_power.readOp.dynamic/nocdynp.executionTime << " W" << endl;
-			cout<<endl;
-			if (plevel >2){
-				cout << indent_str<< indent_str << "Virtual Channel Buffer:" << endl;
-				cout << indent_str<< indent_str_next << "Area = " << router->buffer.area.get_area()*1e-6*nocdynp.input_ports<< " mm^2" << endl;
-				cout << indent_str<< indent_str_next << "Peak Dynamic = " <<(router->buffer.power.readOp.dynamic + router->buffer.power.writeOp.dynamic)
-				*nocdynp.min_ports*M*nocdynp.clockRate << " W" << endl;
-				cout << indent_str<< indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? router->buffer.power.readOp.longer_channel_leakage*nocdynp.input_ports:router->buffer.power.readOp.leakage*nocdynp.input_ports)  <<" W" << endl;
-				cout << indent_str<< indent_str_next << "Gate Leakage = " << router->buffer.power.readOp.gate_leakage*nocdynp.input_ports << " W" << endl;
-				cout << indent_str<< indent_str_next << "Runtime Dynamic = " << router->buffer.rt_power.readOp.dynamic/nocdynp.executionTime << " W" << endl;
-				cout <<endl;
-				cout << indent_str<< indent_str<< "Crossbar:" << endl;
-				cout << indent_str<< indent_str_next << "Area = " << router->crossbar.area.get_area()*1e-6  << " mm^2" << endl;
-				cout << indent_str<< indent_str_next << "Peak Dynamic = " << router->crossbar.power.readOp.dynamic*nocdynp.clockRate*nocdynp.min_ports*M << " W" << endl;
-				cout << indent_str<< indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? router->crossbar.power.readOp.longer_channel_leakage:router->crossbar.power.readOp.leakage)  << " W" << endl;
-				cout << indent_str<< indent_str_next << "Gate Leakage = " << router->crossbar.power.readOp.gate_leakage  << " W" << endl;
-				cout << indent_str<< indent_str_next << "Runtime Dynamic = " << router->crossbar.rt_power.readOp.dynamic/nocdynp.executionTime << " W" << endl;
-				cout <<endl;
-				cout << indent_str<< indent_str<< "Arbiter:" << endl;
-				cout << indent_str<< indent_str_next << "Peak Dynamic = " << router->arbiter.power.readOp.dynamic*nocdynp.clockRate*nocdynp.min_ports*M  << " W" << endl;
-				cout << indent_str<< indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? router->arbiter.power.readOp.longer_channel_leakage:router->arbiter.power.readOp.leakage)  << " W" << endl;
-				cout << indent_str<< indent_str_next << "Gate Leakage = " << router->arbiter.power.readOp.gate_leakage  << " W" << endl;
-				cout << indent_str<< indent_str_next << "Runtime Dynamic = " << router->arbiter.rt_power.readOp.dynamic/nocdynp.executionTime << " W" << endl;
-				cout <<endl;
-			}
-		}
-		if (link_bus_exist)
-		{
-			cout << indent_str << (nocdynp.type? "Per Router ":"") << link_name<<": " << endl;
-			cout << indent_str_next << "Area = " << link_bus_tot_per_Router.area.get_area()*1e-6<< " mm^2" << endl;
-			cout << indent_str_next<< "Peak Dynamic = " << link_bus_tot_per_Router.power.readOp.dynamic*
-				nocdynp.clockRate << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? link_bus_tot_per_Router.power.readOp.longer_channel_leakage:link_bus_tot_per_Router.power.readOp.leakage)
-			     <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << link_bus_tot_per_Router.power.readOp.gate_leakage
-				<< " W" << endl;
-			cout << indent_str_next<< "Runtime Dynamic = " << link_bus->rt_power.readOp.dynamic/nocdynp.executionTime << " W" << endl;
-			cout<<endl;
-
-		}
-	}
-	else
-	{
-//		cout << indent_str_next << "Instruction Fetch Unit    Peak Dynamic = " << ifu->rt_power.readOp.dynamic*clockRate << " W" << endl;
-//		cout << indent_str_next << "Instruction Fetch Unit    Subthreshold Leakage = " << ifu->rt_power.readOp.leakage <<" W" << endl;
-//		cout << indent_str_next << "Instruction Fetch Unit    Gate Leakage = " << ifu->rt_power.readOp.gate_leakage << " W" << endl;
-//		cout << indent_str_next << "Load Store Unit   Peak Dynamic = " << lsu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-//		cout << indent_str_next << "Load Store Unit   Subthreshold Leakage = " << lsu->rt_power.readOp.leakage  << " W" << endl;
-//		cout << indent_str_next << "Load Store Unit   Gate Leakage = " << lsu->rt_power.readOp.gate_leakage  << " W" << endl;
-//		cout << indent_str_next << "Memory Management Unit   Peak Dynamic = " << mmu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-//		cout << indent_str_next << "Memory Management Unit   Subthreshold Leakage = " << mmu->rt_power.readOp.leakage  << " W" << endl;
-//		cout << indent_str_next << "Memory Management Unit   Gate Leakage = " << mmu->rt_power.readOp.gate_leakage  << " W" << endl;
-//		cout << indent_str_next << "Execution Unit   Peak Dynamic = " << exu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-//		cout << indent_str_next << "Execution Unit   Subthreshold Leakage = " << exu->rt_power.readOp.leakage  << " W" << endl;
-//		cout << indent_str_next << "Execution Unit   Gate Leakage = " << exu->rt_power.readOp.gate_leakage  << " W" << endl;
-	}
+      router->rt_power =
+          router->rt_power +
+          (router->buffer.rt_power + router->crossbar.rt_power +
+           router->arbiter.rt_power) *
+              pppm_t +
+          router->power * pppm_lkg;  // TDP power must be calculated first!
+      rt_power = rt_power + router->rt_power;
+    }
+    if (link_bus_exist) {
+      link_bus->rt_power.reset();
+      set_pppm(pppm_t, rtp_stats.readAc.access, 1, 1, rtp_stats.readAc.access);
+      link_bus->rt_power = link_bus->power * pppm_t;
+      rt_power = rt_power + link_bus->rt_power;
+    }
+  }
 }
 
-void NoC::set_noc_param()
-{
+void NoC::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool long_channel = XML->sys.longer_channel_device;
 
-	nocdynp.type            = XML->sys.NoC[ithNoC].type;
-	nocdynp.clockRate       =XML->sys.NoC[ithNoC].clockrate;
-	nocdynp.clockRate       *= 1e6;
-	nocdynp.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
+  double M = M_traffic_pattern * nocdynp.duty_cycle;
+  /*only router as a whole has been applied the M_traffic_pattern(0.6 by
+   * default) factor in router.cc;
+   * 	When power of crossbars, arbiters, etc need to be displayed, the
+   * M_traffic_pattern factor need to
+   * be applied together with McPAT's extra traffic pattern.
+   * */
+  if (is_tdp) {
+    cout << name << endl;
+    cout << indent_str << "Area = " << area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str
+         << "Peak Dynamic = " << power.readOp.dynamic * nocdynp.clockRate
+         << " W" << endl;
+    cout << indent_str << "Subthreshold Leakage = "
+         << (long_channel ? power.readOp.longer_channel_leakage
+                          : power.readOp.leakage)
+         << " W" << endl;
+    cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str << "Runtime Dynamic = "
+         << rt_power.readOp.dynamic / nocdynp.executionTime << " W" << endl;
+    // cout << indent_str<< "Execution Time = " << nocdynp.executionTime << " s"
+    // << endl;
+    cout << endl;
 
-	nocdynp.flit_size     = XML->sys.NoC[ithNoC].flit_bits;
-	if (nocdynp.type)
-	{
-		nocdynp.input_ports   = XML->sys.NoC[ithNoC].input_ports;
-		nocdynp.output_ports  = XML->sys.NoC[ithNoC].output_ports;//later minus 1
-		nocdynp.min_ports     = min(nocdynp.input_ports,nocdynp.output_ports);
-		nocdynp.global_linked_ports = (nocdynp.input_ports-1) + (nocdynp.output_ports-1);
-		/*
-		 * 	Except local i/o ports, all ports needs links( global_linked_ports);
-		 *  However only min_ports can be fully active simultaneously
-		 *  since the fewer number of ports (input or output ) is the bottleneck.
-		 */
-	}
-	else
-	{
-		nocdynp.input_ports   = 1;
-		nocdynp.output_ports  = 1;
-		nocdynp.min_ports     = min(nocdynp.input_ports,nocdynp.output_ports);
-		nocdynp.global_linked_ports = 1;
-	}
-
-	nocdynp.virtual_channel_per_port     = XML->sys.NoC[ithNoC].virtual_channel_per_port;
-	nocdynp.input_buffer_entries_per_vc  = XML->sys.NoC[ithNoC].input_buffer_entries_per_vc;
-
-	nocdynp.horizontal_nodes  = XML->sys.NoC[ithNoC].horizontal_nodes;
-	nocdynp.vertical_nodes    = XML->sys.NoC[ithNoC].vertical_nodes;
-	nocdynp.total_nodes       = nocdynp.horizontal_nodes*nocdynp.vertical_nodes;
-	nocdynp.duty_cycle        = XML->sys.NoC[ithNoC].duty_cycle;
-	nocdynp.has_global_link   = XML->sys.NoC[ithNoC].has_global_link;
-	nocdynp.link_throughput   = XML->sys.NoC[ithNoC].link_throughput;
-	nocdynp.link_latency      = XML->sys.NoC[ithNoC].link_latency;
-	nocdynp.chip_coverage     = XML->sys.NoC[ithNoC].chip_coverage;
-	nocdynp.route_over_perc   = XML->sys.NoC[ithNoC].route_over_perc;
-
-	assert (nocdynp.chip_coverage <=1);
-	assert (nocdynp.route_over_perc <=1);
-
-	if (nocdynp.type)
-		name = "NOC";
-	else
-		name = "BUSES";
-
+    if (router_exist) {
+      cout << indent_str << "Router: " << endl;
+      cout << indent_str_next << "Area = " << router->area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next << "Peak Dynamic = "
+           << router->power.readOp.dynamic * nocdynp.clockRate << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? router->power.readOp.longer_channel_leakage
+                            : router->power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << router->power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << router->rt_power.readOp.dynamic / nocdynp.executionTime << " W"
+           << endl;
+      cout << endl;
+      if (plevel > 2) {
+        cout << indent_str << indent_str << "Virtual Channel Buffer:" << endl;
+        cout << indent_str << indent_str_next << "Area = "
+             << router->buffer.area.get_area() * 1e-6 * nocdynp.input_ports
+             << " mm^2" << endl;
+        cout << indent_str << indent_str_next << "Peak Dynamic = "
+             << (router->buffer.power.readOp.dynamic +
+                 router->buffer.power.writeOp.dynamic) *
+                    nocdynp.min_ports * M * nocdynp.clockRate
+             << " W" << endl;
+        cout << indent_str << indent_str_next << "Subthreshold Leakage = "
+             << (long_channel
+                     ? router->buffer.power.readOp.longer_channel_leakage *
+                           nocdynp.input_ports
+                     : router->buffer.power.readOp.leakage *
+                           nocdynp.input_ports)
+             << " W" << endl;
+        cout << indent_str << indent_str_next << "Gate Leakage = "
+             << router->buffer.power.readOp.gate_leakage * nocdynp.input_ports
+             << " W" << endl;
+        cout << indent_str << indent_str_next << "Runtime Dynamic = "
+             << router->buffer.rt_power.readOp.dynamic / nocdynp.executionTime
+             << " W" << endl;
+        cout << endl;
+        cout << indent_str << indent_str << "Crossbar:" << endl;
+        cout << indent_str << indent_str_next
+             << "Area = " << router->crossbar.area.get_area() * 1e-6 << " mm^2"
+             << endl;
+        cout << indent_str << indent_str_next << "Peak Dynamic = "
+             << router->crossbar.power.readOp.dynamic * nocdynp.clockRate *
+                    nocdynp.min_ports * M
+             << " W" << endl;
+        cout << indent_str << indent_str_next << "Subthreshold Leakage = "
+             << (long_channel
+                     ? router->crossbar.power.readOp.longer_channel_leakage
+                     : router->crossbar.power.readOp.leakage)
+             << " W" << endl;
+        cout << indent_str << indent_str_next
+             << "Gate Leakage = " << router->crossbar.power.readOp.gate_leakage
+             << " W" << endl;
+        cout << indent_str << indent_str_next << "Runtime Dynamic = "
+             << router->crossbar.rt_power.readOp.dynamic / nocdynp.executionTime
+             << " W" << endl;
+        cout << endl;
+        cout << indent_str << indent_str << "Arbiter:" << endl;
+        cout << indent_str << indent_str_next << "Peak Dynamic = "
+             << router->arbiter.power.readOp.dynamic * nocdynp.clockRate *
+                    nocdynp.min_ports * M
+             << " W" << endl;
+        cout << indent_str << indent_str_next << "Subthreshold Leakage = "
+             << (long_channel
+                     ? router->arbiter.power.readOp.longer_channel_leakage
+                     : router->arbiter.power.readOp.leakage)
+             << " W" << endl;
+        cout << indent_str << indent_str_next
+             << "Gate Leakage = " << router->arbiter.power.readOp.gate_leakage
+             << " W" << endl;
+        cout << indent_str << indent_str_next << "Runtime Dynamic = "
+             << router->arbiter.rt_power.readOp.dynamic / nocdynp.executionTime
+             << " W" << endl;
+        cout << endl;
+      }
+    }
+    if (link_bus_exist) {
+      cout << indent_str << (nocdynp.type ? "Per Router " : "") << link_name
+           << ": " << endl;
+      cout << indent_str_next
+           << "Area = " << link_bus_tot_per_Router.area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next << "Peak Dynamic = "
+           << link_bus_tot_per_Router.power.readOp.dynamic * nocdynp.clockRate
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel
+                   ? link_bus_tot_per_Router.power.readOp.longer_channel_leakage
+                   : link_bus_tot_per_Router.power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next << "Gate Leakage = "
+           << link_bus_tot_per_Router.power.readOp.gate_leakage << " W" << endl;
+      cout << indent_str_next << "Runtime Dynamic = "
+           << link_bus->rt_power.readOp.dynamic / nocdynp.executionTime << " W"
+           << endl;
+      cout << endl;
+    }
+  } else {
+    //		cout << indent_str_next << "Instruction Fetch Unit    Peak Dynamic = "
+    //<< ifu->rt_power.readOp.dynamic*clockRate << " W" << endl;
+    //		cout << indent_str_next << "Instruction Fetch Unit    Subthreshold
+    //Leakage = " << ifu->rt_power.readOp.leakage <<" W" << endl;
+    //		cout << indent_str_next << "Instruction Fetch Unit    Gate Leakage = "
+    //<< ifu->rt_power.readOp.gate_leakage << " W" << endl;
+    //		cout << indent_str_next << "Load Store Unit   Peak Dynamic = " <<
+    //lsu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "Load Store Unit   Subthreshold Leakage = "
+    //<< lsu->rt_power.readOp.leakage  << " W" << endl;
+    //		cout << indent_str_next << "Load Store Unit   Gate Leakage = " <<
+    //lsu->rt_power.readOp.gate_leakage  << " W" << endl;
+    //		cout << indent_str_next << "Memory Management Unit   Peak Dynamic = "
+    //<< mmu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "Memory Management Unit   Subthreshold
+    //Leakage = " << mmu->rt_power.readOp.leakage  << " W" << endl;
+    //		cout << indent_str_next << "Memory Management Unit   Gate Leakage = "
+    //<< mmu->rt_power.readOp.gate_leakage  << " W" << endl;
+    //		cout << indent_str_next << "Execution Unit   Peak Dynamic = " <<
+    //exu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "Execution Unit   Subthreshold Leakage = "
+    //<< exu->rt_power.readOp.leakage  << " W" << endl;
+    //		cout << indent_str_next << "Execution Unit   Gate Leakage = " <<
+    //exu->rt_power.readOp.gate_leakage  << " W" << endl;
+  }
 }
 
+void NoC::set_noc_param() {
+  nocdynp.type = XML->sys.NoC[ithNoC].type;
+  nocdynp.clockRate = XML->sys.NoC[ithNoC].clockrate;
+  nocdynp.clockRate *= 1e6;
+  nocdynp.executionTime =
+      XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);
 
-NoC ::~NoC(){
+  nocdynp.flit_size = XML->sys.NoC[ithNoC].flit_bits;
+  if (nocdynp.type) {
+    nocdynp.input_ports = XML->sys.NoC[ithNoC].input_ports;
+    nocdynp.output_ports = XML->sys.NoC[ithNoC].output_ports;  // later minus 1
+    nocdynp.min_ports = min(nocdynp.input_ports, nocdynp.output_ports);
+    nocdynp.global_linked_ports =
+        (nocdynp.input_ports - 1) + (nocdynp.output_ports - 1);
+    /*
+     * 	Except local i/o ports, all ports needs links( global_linked_ports);
+     *  However only min_ports can be fully active simultaneously
+     *  since the fewer number of ports (input or output ) is the bottleneck.
+     */
+  } else {
+    nocdynp.input_ports = 1;
+    nocdynp.output_ports = 1;
+    nocdynp.min_ports = min(nocdynp.input_ports, nocdynp.output_ports);
+    nocdynp.global_linked_ports = 1;
+  }
 
-	if(router) 	               {delete router; router = 0;}
-	if(link_bus) 	           {delete link_bus; link_bus = 0;}
+  nocdynp.virtual_channel_per_port =
+      XML->sys.NoC[ithNoC].virtual_channel_per_port;
+  nocdynp.input_buffer_entries_per_vc =
+      XML->sys.NoC[ithNoC].input_buffer_entries_per_vc;
+
+  nocdynp.horizontal_nodes = XML->sys.NoC[ithNoC].horizontal_nodes;
+  nocdynp.vertical_nodes = XML->sys.NoC[ithNoC].vertical_nodes;
+  nocdynp.total_nodes = nocdynp.horizontal_nodes * nocdynp.vertical_nodes;
+  nocdynp.duty_cycle = XML->sys.NoC[ithNoC].duty_cycle;
+  nocdynp.has_global_link = XML->sys.NoC[ithNoC].has_global_link;
+  nocdynp.link_throughput = XML->sys.NoC[ithNoC].link_throughput;
+  nocdynp.link_latency = XML->sys.NoC[ithNoC].link_latency;
+  nocdynp.chip_coverage = XML->sys.NoC[ithNoC].chip_coverage;
+  nocdynp.route_over_perc = XML->sys.NoC[ithNoC].route_over_perc;
+
+  assert(nocdynp.chip_coverage <= 1);
+  assert(nocdynp.route_over_perc <= 1);
+
+  if (nocdynp.type)
+    name = "NOC";
+  else
+    name = "BUSES";
+}
+
+NoC::~NoC() {
+  if (router) {
+    delete router;
+    router = 0;
+  }
+  if (link_bus) {
+    delete link_bus;
+    link_bus = 0;
+  }
 }

--- a/src/gpuwattch/noc.cc
+++ b/src/gpuwattch/noc.cc
@@ -357,44 +357,30 @@ void NoC::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
       cout << endl;
     }
   } else {
-    //		cout << indent_str_next << "Instruction Fetch Unit    Peak Dynamic
-    //=
-    //"
+    //		cout << indent_str_next << "Instruction Fetch Unit    Peak Dynamic = "
     //<< ifu->rt_power.readOp.dynamic*clockRate << " W" << endl;
-    //		cout << indent_str_next << "Instruction Fetch Unit Subthreshold
-    // Leakage = " << ifu->rt_power.readOp.leakage <<" W" << endl;
-    //		cout << indent_str_next << "Instruction Fetch Unit    Gate Leakage
-    //=
-    //"
+    //		cout << indent_str_next << "Instruction Fetch Unit    Subthreshold
+    //Leakage = " << ifu->rt_power.readOp.leakage <<" W" << endl;
+    //		cout << indent_str_next << "Instruction Fetch Unit    Gate Leakage = "
     //<< ifu->rt_power.readOp.gate_leakage << " W" << endl;
-    //		cout << indent_str_next << "Load Store Unit   Peak Dynamic = "
-    //<<
-    // lsu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Load Store Unit   Subthreshold Leakage
-    //=
-    //"
+    //		cout << indent_str_next << "Load Store Unit   Peak Dynamic = " <<
+    //lsu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "Load Store Unit   Subthreshold Leakage = "
     //<< lsu->rt_power.readOp.leakage  << " W" << endl;
-    //		cout << indent_str_next << "Load Store Unit   Gate Leakage = "
-    //<<
-    // lsu->rt_power.readOp.gate_leakage  << " W" << endl;
-    //		cout << indent_str_next << "Memory Management Unit   Peak Dynamic
-    //=
-    //"
+    //		cout << indent_str_next << "Load Store Unit   Gate Leakage = " <<
+    //lsu->rt_power.readOp.gate_leakage  << " W" << endl;
+    //		cout << indent_str_next << "Memory Management Unit   Peak Dynamic = "
     //<< mmu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Memory Management Unit Subthreshold
-    // Leakage = " << mmu->rt_power.readOp.leakage  << " W" << endl;
-    //		cout << indent_str_next << "Memory Management Unit   Gate Leakage
-    //=
-    //"
+    //		cout << indent_str_next << "Memory Management Unit   Subthreshold
+    //Leakage = " << mmu->rt_power.readOp.leakage  << " W" << endl;
+    //		cout << indent_str_next << "Memory Management Unit   Gate Leakage = "
     //<< mmu->rt_power.readOp.gate_leakage  << " W" << endl;
     //		cout << indent_str_next << "Execution Unit   Peak Dynamic = " <<
-    // exu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Execution Unit   Subthreshold Leakage
-    //=
-    //"
+    //exu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "Execution Unit   Subthreshold Leakage = "
     //<< exu->rt_power.readOp.leakage  << " W" << endl;
     //		cout << indent_str_next << "Execution Unit   Gate Leakage = " <<
-    // exu->rt_power.readOp.gate_leakage  << " W" << endl;
+    //exu->rt_power.readOp.gate_leakage  << " W" << endl;
   }
 }
 

--- a/src/gpuwattch/noc.cc
+++ b/src/gpuwattch/noc.cc
@@ -357,30 +357,44 @@ void NoC::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
       cout << endl;
     }
   } else {
-    //		cout << indent_str_next << "Instruction Fetch Unit    Peak Dynamic = "
+    //		cout << indent_str_next << "Instruction Fetch Unit    Peak Dynamic
+    //=
+    //"
     //<< ifu->rt_power.readOp.dynamic*clockRate << " W" << endl;
-    //		cout << indent_str_next << "Instruction Fetch Unit    Subthreshold
-    //Leakage = " << ifu->rt_power.readOp.leakage <<" W" << endl;
-    //		cout << indent_str_next << "Instruction Fetch Unit    Gate Leakage = "
+    //		cout << indent_str_next << "Instruction Fetch Unit Subthreshold
+    // Leakage = " << ifu->rt_power.readOp.leakage <<" W" << endl;
+    //		cout << indent_str_next << "Instruction Fetch Unit    Gate Leakage
+    //=
+    //"
     //<< ifu->rt_power.readOp.gate_leakage << " W" << endl;
-    //		cout << indent_str_next << "Load Store Unit   Peak Dynamic = " <<
-    //lsu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Load Store Unit   Subthreshold Leakage = "
+    //		cout << indent_str_next << "Load Store Unit   Peak Dynamic = "
+    //<<
+    // lsu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "Load Store Unit   Subthreshold Leakage
+    //=
+    //"
     //<< lsu->rt_power.readOp.leakage  << " W" << endl;
-    //		cout << indent_str_next << "Load Store Unit   Gate Leakage = " <<
-    //lsu->rt_power.readOp.gate_leakage  << " W" << endl;
-    //		cout << indent_str_next << "Memory Management Unit   Peak Dynamic = "
+    //		cout << indent_str_next << "Load Store Unit   Gate Leakage = "
+    //<<
+    // lsu->rt_power.readOp.gate_leakage  << " W" << endl;
+    //		cout << indent_str_next << "Memory Management Unit   Peak Dynamic
+    //=
+    //"
     //<< mmu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Memory Management Unit   Subthreshold
-    //Leakage = " << mmu->rt_power.readOp.leakage  << " W" << endl;
-    //		cout << indent_str_next << "Memory Management Unit   Gate Leakage = "
+    //		cout << indent_str_next << "Memory Management Unit Subthreshold
+    // Leakage = " << mmu->rt_power.readOp.leakage  << " W" << endl;
+    //		cout << indent_str_next << "Memory Management Unit   Gate Leakage
+    //=
+    //"
     //<< mmu->rt_power.readOp.gate_leakage  << " W" << endl;
     //		cout << indent_str_next << "Execution Unit   Peak Dynamic = " <<
-    //exu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Execution Unit   Subthreshold Leakage = "
+    // exu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+    //		cout << indent_str_next << "Execution Unit   Subthreshold Leakage
+    //=
+    //"
     //<< exu->rt_power.readOp.leakage  << " W" << endl;
     //		cout << indent_str_next << "Execution Unit   Gate Leakage = " <<
-    //exu->rt_power.readOp.gate_leakage  << " W" << endl;
+    // exu->rt_power.readOp.gate_leakage  << " W" << endl;
   }
 }
 

--- a/src/gpuwattch/noc.cc
+++ b/src/gpuwattch/noc.cc
@@ -353,11 +353,12 @@ void NoC::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
       cout << endl;
     }
   } else {
-    //		cout << indent_str_next << "Instruction Fetch Unit    Peak Dynamic
+    //		cout << indent_str_next << "Instruction Fetch Unit    Peak
+    // Dynamic
     //=
     //"
     //<< ifu->rt_power.readOp.dynamic*clockRate << " W" << endl;
-    //cout
+    // cout
     //<< indent_str_next << "Instruction Fetch Unit    Subthreshold Leakage = "
     // << ifu->rt_power.readOp.leakage <<" W" << endl; 		cout <<
     // indent_str_next << "Instruction Fetch Unit    Gate Leakage = " <<
@@ -372,7 +373,7 @@ void NoC::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
     // << "Load Store Unit   Gate Leakage = " <<
     // lsu->rt_power.readOp.gate_leakage
     //<< " W" << endl; 		cout << indent_str_next << "Memory Management
-    //Unit Peak Dynamic = " << mmu->rt_power.readOp.dynamic*clockRate  << " W"
+    // Unit Peak Dynamic = " << mmu->rt_power.readOp.dynamic*clockRate  << " W"
     // <<
     // endl; 		cout << indent_str_next << "Memory Management Unit
     // Subthreshold Leakage = " << mmu->rt_power.readOp.leakage  << " W" <<

--- a/src/gpuwattch/noc.cc
+++ b/src/gpuwattch/noc.cc
@@ -29,418 +29,348 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:
-**
+*      Modified by:												   *
 *      Jingwen Leng, Univeristy of Texas, Austin                   *
 *      Syed Gilani, University of Wisconsin–Madison                *
 *      Tayler Hetherington, University of British Columbia         *
 *      Ahmed ElTantawy, University of British Columbia             *
 ********************************************************************/
 
-#include "noc.h"
-#include <assert.h>
-#include <algorithm>
-#include <cmath>
-#include <iostream>
-#include <string>
-#include "XML_Parse.h"
-#include "cacti/basic_circuit.h"
-#include "const.h"
 #include "io.h"
 #include "parameter.h"
+#include "const.h"
+#include "cacti/basic_circuit.h"
+#include <iostream>
+#include <algorithm>
+#include "XML_Parse.h"
+#include <string>
+#include <cmath>
+#include <assert.h>
+#include "noc.h"
 
-NoC::NoC(ParseXML* XML_interface, int ithNoC_, InputParameter* interface_ip_,
-         double M_traffic_pattern_, double link_len_)
-    : XML(XML_interface),
-      ithNoC(ithNoC_),
-      interface_ip(*interface_ip_),
-      router(0),
-      link_bus(0),
-      link_bus_exist(false),
-      router_exist(false),
-      M_traffic_pattern(M_traffic_pattern_) {
-  /*
-   * initialize, compute and optimize individual components.
-   */
 
-  if (XML->sys.Embedded) {
-    interface_ip.wt = Global_30;
-    interface_ip.wire_is_mat_type = 0;
-    interface_ip.wire_os_mat_type = 1;
-  } else {
-    interface_ip.wt = Global;
-    interface_ip.wire_is_mat_type = 2;
-    interface_ip.wire_os_mat_type = 2;
-  }
-  set_noc_param();
-  local_result = init_interface(&interface_ip);
-  scktRatio = g_tp.sckt_co_eff;
 
-  if (nocdynp.type) { /*
-                              * if NOC compute router, router links must be
-                       * computed separately
-                              * and called from external
-                              * since total chip area must be known first
-                              */
-    init_router();
-  } else {
-    init_link_bus(link_len_);  // if bus compute bus
-  }
+NoC::NoC(ParseXML *XML_interface, int ithNoC_, InputParameter* interface_ip_, double M_traffic_pattern_, double link_len_)
+:XML(XML_interface),
+ithNoC(ithNoC_),
+interface_ip(*interface_ip_),
+router(0),
+link_bus(0),
+link_bus_exist(false),
+router_exist(false),
+M_traffic_pattern(M_traffic_pattern_)
+{
+	/*
+	 * initialize, compute and optimize individual components.
+	 */
 
-  //  //clock power
-  //  clockNetwork.init_wire_external(is_default, &interface_ip);
-  //  clockNetwork.clk_area           =area*1.1;//10% of placement overhead.
-  //  rule of thumb
-  //  clockNetwork.end_wiring_level   =5;//toplevel metal
-  //  clockNetwork.start_wiring_level =5;//toplevel metal
-  //  clockNetwork.num_regs           = corepipe.tot_stage_vector;
-  //  clockNetwork.optimize_wire();
+	if (XML->sys.Embedded)
+			{
+			interface_ip.wt                  =Global_30;
+			interface_ip.wire_is_mat_type = 0;
+			interface_ip.wire_os_mat_type = 1;
+			}
+		else
+			{
+			interface_ip.wt                  =Global;
+			interface_ip.wire_is_mat_type = 2;
+			interface_ip.wire_os_mat_type = 2;
+			}
+	set_noc_param();
+	local_result=init_interface(&interface_ip);
+	scktRatio = g_tp.sckt_co_eff;
+
+	if (nocdynp.type)
+	{/*
+		 * if NOC compute router, router links must be computed separately
+		 * and called from external
+		 * since total chip area must be known first
+		 */
+		init_router();
+	}
+	else
+	{
+		init_link_bus(link_len_); //if bus compute bus
+	}
+
+	//  //clock power
+	//  clockNetwork.init_wire_external(is_default, &interface_ip);
+	//  clockNetwork.clk_area           =area*1.1;//10% of placement overhead. rule of thumb
+	//  clockNetwork.end_wiring_level   =5;//toplevel metal
+	//  clockNetwork.start_wiring_level =5;//toplevel metal
+	//  clockNetwork.num_regs           = corepipe.tot_stage_vector;
+	//  clockNetwork.optimize_wire();
 }
 
-void NoC::init_router() {
-  router = new MCPAT_Router(
-      nocdynp.flit_size,
-      nocdynp.virtual_channel_per_port * nocdynp.input_buffer_entries_per_vc,
-      nocdynp.virtual_channel_per_port, &(g_tp.peri_global),
-      nocdynp.input_ports, nocdynp.output_ports, M_traffic_pattern);
-  // router->print_router();
-  area.set_area(area.get_area() +
-                router->area.get_area() * nocdynp.total_nodes);
+void NoC::init_router()
+{
+	router  = new MCPAT_Router(nocdynp.flit_size,
+			nocdynp.virtual_channel_per_port*nocdynp.input_buffer_entries_per_vc,
+			nocdynp.virtual_channel_per_port, &(g_tp.peri_global),
+			nocdynp.input_ports,nocdynp.output_ports, M_traffic_pattern);
+	//router->print_router();
+	area.set_area(area.get_area()+ router->area.get_area()*nocdynp.total_nodes);
 
-  double long_channel_device_reduction =
-      longer_channel_device_reduction(Uncore_device);
-  router->power.readOp.longer_channel_leakage =
-      router->power.readOp.leakage * long_channel_device_reduction;
-  router->buffer.power.readOp.longer_channel_leakage =
-      router->buffer.power.readOp.leakage * long_channel_device_reduction;
-  router->crossbar.power.readOp.longer_channel_leakage =
-      router->crossbar.power.readOp.leakage * long_channel_device_reduction;
-  router->arbiter.power.readOp.longer_channel_leakage =
-      router->arbiter.power.readOp.leakage * long_channel_device_reduction;
-  router_exist = true;
+	double long_channel_device_reduction = longer_channel_device_reduction(Uncore_device);
+	router->power.readOp.longer_channel_leakage          = router->power.readOp.leakage * long_channel_device_reduction;
+	router->buffer.power.readOp.longer_channel_leakage   = router->buffer.power.readOp.leakage * long_channel_device_reduction;
+	router->crossbar.power.readOp.longer_channel_leakage = router->crossbar.power.readOp.leakage * long_channel_device_reduction;
+	router->arbiter.power.readOp.longer_channel_leakage  = router->arbiter.power.readOp.leakage * long_channel_device_reduction;
+	router_exist = true;
 }
 
-void NoC::init_link_bus(double link_len_) {
-  //	if (nocdynp.min_ports==1 )
-  if (nocdynp.type)
-    link_name = "Links";
-  else
-    link_name = "Bus";
+void NoC ::init_link_bus(double link_len_)
+{
 
-  link_len = link_len_;
-  assert(link_len > 0);
 
-  interface_ip.throughput = nocdynp.link_throughput / nocdynp.clockRate;
-  interface_ip.latency = nocdynp.link_latency / nocdynp.clockRate;
+//	if (nocdynp.min_ports==1 )
+	if (nocdynp.type)
+		link_name = "Links";
+	else
+		link_name = "Bus";
 
-  link_len /= (nocdynp.horizontal_nodes + nocdynp.vertical_nodes) / 2;
+	link_len=link_len_;
+	assert(link_len>0);
 
-  if (nocdynp.total_nodes > 1)
-    link_len /= 2;  // All links are shared by neighbors
-  link_bus = new interconnect(name, Uncore_device, 1, 1, nocdynp.flit_size,
-                              link_len, &interface_ip, 3, true /*pipelinable*/,
-                              nocdynp.route_over_perc);
+	interface_ip.throughput = nocdynp.link_throughput/nocdynp.clockRate;
+	interface_ip.latency = nocdynp.link_latency/nocdynp.clockRate;
 
-  link_bus_tot_per_Router.area.set_area(
-      link_bus_tot_per_Router.area.get_area() +
-      link_bus->area.get_area() * nocdynp.global_linked_ports);
+	link_len /= (nocdynp.horizontal_nodes + nocdynp.vertical_nodes)/2;
 
-  area.set_area(area.get_area() +
-                link_bus_tot_per_Router.area.get_area() * nocdynp.total_nodes);
-  link_bus_exist = true;
+	if (nocdynp.total_nodes >1) link_len /=2; //All links are shared by neighbors
+	link_bus = new interconnect(name, Uncore_device, 1, 1, nocdynp.flit_size,
+				  link_len, &interface_ip, 3, true/*pipelinable*/, nocdynp.route_over_perc);
+
+	link_bus_tot_per_Router.area.set_area(link_bus_tot_per_Router.area.get_area()+ link_bus->area.get_area()
+			* nocdynp.global_linked_ports);
+
+	area.set_area(area.get_area()+ link_bus_tot_per_Router.area.get_area()* nocdynp.total_nodes);
+	link_bus_exist = true;
 }
-void NoC::computeEnergy(bool is_tdp) {
-  // power_point_product_masks
-  double pppm_t[4] = {1, 1, 1, 1};
-  double M = nocdynp.duty_cycle;
-  // nocdynp.executionTime=XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);//Syed
-  // cout<<"NOC Total Cycles: "<<XML->sys.total_cycles<<endl;
-  // cout<<"NOC Clock Rate: "<<XML->sys.target_core_clockrate<<endl;
-  if (is_tdp) {
-    // init stats for TDP
-    stats_t.readAc.access = M;
-    tdp_stats = stats_t;
-    if (router_exist) {
-      set_pppm(pppm_t, 1 * M, 1, 1, 1);  // reset traffic pattern
-      router->power = router->power * pppm_t;
-      set_pppm(pppm_t, nocdynp.total_nodes, nocdynp.total_nodes,
-               nocdynp.total_nodes, nocdynp.total_nodes);
-      power = power + router->power * pppm_t;
-    }
-    if (link_bus_exist) {
-      if (nocdynp.type)
-        set_pppm(pppm_t, 1 * M_traffic_pattern * M * (nocdynp.min_ports - 1),
-                 nocdynp.global_linked_ports, nocdynp.global_linked_ports,
-                 nocdynp.global_linked_ports);
-      // reset traffic pattern; local port do not have router links
-      else
-        set_pppm(pppm_t, 1 * M_traffic_pattern * M * (nocdynp.min_ports),
-                 nocdynp.global_linked_ports, nocdynp.global_linked_ports,
-                 nocdynp.global_linked_ports);  // reset traffic pattern
+void NoC::computeEnergy(bool is_tdp)
+{
+	//power_point_product_masks
+	double pppm_t[4]    = {1,1,1,1};
+	double M=nocdynp.duty_cycle;
+ // nocdynp.executionTime=XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);//Syed
+   //cout<<"NOC Total Cycles: "<<XML->sys.total_cycles<<endl;
+	//cout<<"NOC Clock Rate: "<<XML->sys.target_core_clockrate<<endl;
+	if (is_tdp)
+	    {
+	    	//init stats for TDP
+	    	stats_t.readAc.access  = M;
+            tdp_stats = stats_t;
+            if (router_exist)
+            {
+            	set_pppm(pppm_t, 1*M, 1, 1, 1);//reset traffic pattern
+                router->power = router->power*pppm_t;
+                set_pppm(pppm_t, nocdynp.total_nodes, nocdynp.total_nodes, nocdynp.total_nodes, nocdynp.total_nodes);
+          	    power     = power + router->power*pppm_t;
+            }
+            if (link_bus_exist)
+            {
+            	if (nocdynp.type)
+            		set_pppm(pppm_t, 1*M_traffic_pattern*M*(nocdynp.min_ports -1), nocdynp.global_linked_ports,
+            			nocdynp.global_linked_ports, nocdynp.global_linked_ports);
+            	    //reset traffic pattern; local port do not have router links
+            	else
+            		set_pppm(pppm_t, 1*M_traffic_pattern*M*(nocdynp.min_ports), nocdynp.global_linked_ports,
+            		            			nocdynp.global_linked_ports, nocdynp.global_linked_ports);//reset traffic pattern
 
-      link_bus_tot_per_Router.power = link_bus->power * pppm_t;
+            	link_bus_tot_per_Router.power = link_bus->power*pppm_t;
 
-      set_pppm(pppm_t, nocdynp.total_nodes, nocdynp.total_nodes,
-               nocdynp.total_nodes, nocdynp.total_nodes);
-      power = power + link_bus_tot_per_Router.power * pppm_t;
-    }
-  } else {
-    rt_power.reset();
-    router->buffer.rt_power.reset();
-    router->crossbar.rt_power.reset();
-    router->arbiter.rt_power.reset();
-    router->rt_power.reset();
-    // link_bus->rt_power.reset();
+                set_pppm(pppm_t, nocdynp.total_nodes,
+                		         nocdynp.total_nodes,
+                		         nocdynp.total_nodes,
+                		         nocdynp.total_nodes);
+            	power     = power + link_bus_tot_per_Router.power*pppm_t;
 
-    // init stats for runtime power (RTP)
-    stats_t.readAc.access = XML->sys.NoC[ithNoC].total_accesses;
-    // cout<<"NOC(computeEnergy) read accesses: "<< stats_t.readAc.access<<endl;
-    rtp_stats = stats_t;
-    set_pppm(pppm_t, 1, 0, 0, 0);
-    if (router_exist) {
-      router->buffer.rt_power.readOp.dynamic =
-          (router->buffer.power.readOp.dynamic +
-           router->buffer.power.writeOp.dynamic) *
-          rtp_stats.readAc.access;
-      router->crossbar.rt_power.readOp.dynamic =
-          router->crossbar.power.readOp.dynamic * rtp_stats.readAc.access;
-      router->arbiter.rt_power.readOp.dynamic =
-          router->arbiter.power.readOp.dynamic * rtp_stats.readAc.access;
+            }
+	    }
+	    else
+	    {
+			rt_power.reset();
+         router->buffer.rt_power.reset();
+         router->crossbar.rt_power.reset();
+         router->arbiter.rt_power.reset();
+			router->rt_power.reset();
+         //link_bus->rt_power.reset();
 
-      router->rt_power =
-          router->rt_power +
-          (router->buffer.rt_power + router->crossbar.rt_power +
-           router->arbiter.rt_power) *
-              pppm_t +
-          router->power * pppm_lkg;  // TDP power must be calculated first!
-      rt_power = rt_power + router->rt_power;
-    }
-    if (link_bus_exist) {
-      link_bus->rt_power.reset();
-      set_pppm(pppm_t, rtp_stats.readAc.access, 1, 1, rtp_stats.readAc.access);
-      link_bus->rt_power = link_bus->power * pppm_t;
-      rt_power = rt_power + link_bus->rt_power;
-    }
-  }
-}
+	    	//init stats for runtime power (RTP)
+	    	stats_t.readAc.access  = XML->sys.NoC[ithNoC].total_accesses;
+			//cout<<"NOC(computeEnergy) read accesses: "<< stats_t.readAc.access<<endl;
+            rtp_stats = stats_t;
+        	set_pppm(pppm_t, 1, 0 , 0, 0);
+        	if (router_exist)
+        	{
+            	router->buffer.rt_power.readOp.dynamic = (router->buffer.power.readOp.dynamic + router->buffer.power.writeOp.dynamic)*rtp_stats.readAc.access ;
+            	router->crossbar.rt_power.readOp.dynamic = router->crossbar.power.readOp.dynamic*rtp_stats.readAc.access ;
+            	router->arbiter.rt_power.readOp.dynamic = router->arbiter.power.readOp.dynamic*rtp_stats.readAc.access ;
 
-void NoC::displayEnergy(uint32_t indent, int plevel, bool is_tdp) {
-  string indent_str(indent, ' ');
-  string indent_str_next(indent + 2, ' ');
-  bool long_channel = XML->sys.longer_channel_device;
+        		router->rt_power = router->rt_power + (router->buffer.rt_power + router->crossbar.rt_power + router->arbiter.rt_power)*pppm_t +
+					router->power*pppm_lkg;//TDP power must be calculated first!
+        		rt_power     = rt_power + router->rt_power;
+        	}
+        	if (link_bus_exist)
+        	{
+        	  link_bus->rt_power.reset();	
+			  set_pppm(pppm_t, rtp_stats.readAc.access, 1 , 1, rtp_stats.readAc.access);
+        		link_bus->rt_power = link_bus->power * pppm_t;
+        		rt_power = rt_power + link_bus->rt_power;
+        	}
 
-  double M = M_traffic_pattern * nocdynp.duty_cycle;
-  /*only router as a whole has been applied the M_traffic_pattern(0.6 by
-   * default) factor in router.cc;
-   * 	When power of crossbars, arbiters, etc need to be displayed, the
-   * M_traffic_pattern factor need to
-   * be applied together with McPAT's extra traffic pattern.
-   * */
-  if (is_tdp) {
-    cout << name << endl;
-    cout << indent_str << "Area = " << area.get_area() * 1e-6 << " mm^2"
-         << endl;
-    cout << indent_str
-         << "Peak Dynamic = " << power.readOp.dynamic * nocdynp.clockRate
-         << " W" << endl;
-    cout << indent_str << "Subthreshold Leakage = "
-         << (long_channel ? power.readOp.longer_channel_leakage
-                          : power.readOp.leakage)
-         << " W" << endl;
-    cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W"
-         << endl;
-    cout << indent_str << "Runtime Dynamic = "
-         << rt_power.readOp.dynamic / nocdynp.executionTime << " W" << endl;
-    // cout << indent_str<< "Execution Time = " << nocdynp.executionTime << " s"
-    // << endl;
-    cout << endl;
-
-    if (router_exist) {
-      cout << indent_str << "Router: " << endl;
-      cout << indent_str_next << "Area = " << router->area.get_area() * 1e-6
-           << " mm^2" << endl;
-      cout << indent_str_next << "Peak Dynamic = "
-           << router->power.readOp.dynamic * nocdynp.clockRate << " W" << endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel ? router->power.readOp.longer_channel_leakage
-                            : router->power.readOp.leakage)
-           << " W" << endl;
-      cout << indent_str_next
-           << "Gate Leakage = " << router->power.readOp.gate_leakage << " W"
-           << endl;
-      cout << indent_str_next << "Runtime Dynamic = "
-           << router->rt_power.readOp.dynamic / nocdynp.executionTime << " W"
-           << endl;
-      cout << endl;
-      if (plevel > 2) {
-        cout << indent_str << indent_str << "Virtual Channel Buffer:" << endl;
-        cout << indent_str << indent_str_next << "Area = "
-             << router->buffer.area.get_area() * 1e-6 * nocdynp.input_ports
-             << " mm^2" << endl;
-        cout << indent_str << indent_str_next << "Peak Dynamic = "
-             << (router->buffer.power.readOp.dynamic +
-                 router->buffer.power.writeOp.dynamic) *
-                    nocdynp.min_ports * M * nocdynp.clockRate
-             << " W" << endl;
-        cout << indent_str << indent_str_next << "Subthreshold Leakage = "
-             << (long_channel
-                     ? router->buffer.power.readOp.longer_channel_leakage *
-                           nocdynp.input_ports
-                     : router->buffer.power.readOp.leakage *
-                           nocdynp.input_ports)
-             << " W" << endl;
-        cout << indent_str << indent_str_next << "Gate Leakage = "
-             << router->buffer.power.readOp.gate_leakage * nocdynp.input_ports
-             << " W" << endl;
-        cout << indent_str << indent_str_next << "Runtime Dynamic = "
-             << router->buffer.rt_power.readOp.dynamic / nocdynp.executionTime
-             << " W" << endl;
-        cout << endl;
-        cout << indent_str << indent_str << "Crossbar:" << endl;
-        cout << indent_str << indent_str_next
-             << "Area = " << router->crossbar.area.get_area() * 1e-6 << " mm^2"
-             << endl;
-        cout << indent_str << indent_str_next << "Peak Dynamic = "
-             << router->crossbar.power.readOp.dynamic * nocdynp.clockRate *
-                    nocdynp.min_ports * M
-             << " W" << endl;
-        cout << indent_str << indent_str_next << "Subthreshold Leakage = "
-             << (long_channel
-                     ? router->crossbar.power.readOp.longer_channel_leakage
-                     : router->crossbar.power.readOp.leakage)
-             << " W" << endl;
-        cout << indent_str << indent_str_next
-             << "Gate Leakage = " << router->crossbar.power.readOp.gate_leakage
-             << " W" << endl;
-        cout << indent_str << indent_str_next << "Runtime Dynamic = "
-             << router->crossbar.rt_power.readOp.dynamic / nocdynp.executionTime
-             << " W" << endl;
-        cout << endl;
-        cout << indent_str << indent_str << "Arbiter:" << endl;
-        cout << indent_str << indent_str_next << "Peak Dynamic = "
-             << router->arbiter.power.readOp.dynamic * nocdynp.clockRate *
-                    nocdynp.min_ports * M
-             << " W" << endl;
-        cout << indent_str << indent_str_next << "Subthreshold Leakage = "
-             << (long_channel
-                     ? router->arbiter.power.readOp.longer_channel_leakage
-                     : router->arbiter.power.readOp.leakage)
-             << " W" << endl;
-        cout << indent_str << indent_str_next
-             << "Gate Leakage = " << router->arbiter.power.readOp.gate_leakage
-             << " W" << endl;
-        cout << indent_str << indent_str_next << "Runtime Dynamic = "
-             << router->arbiter.rt_power.readOp.dynamic / nocdynp.executionTime
-             << " W" << endl;
-        cout << endl;
-      }
-    }
-    if (link_bus_exist) {
-      cout << indent_str << (nocdynp.type ? "Per Router " : "") << link_name
-           << ": " << endl;
-      cout << indent_str_next
-           << "Area = " << link_bus_tot_per_Router.area.get_area() * 1e-6
-           << " mm^2" << endl;
-      cout << indent_str_next << "Peak Dynamic = "
-           << link_bus_tot_per_Router.power.readOp.dynamic * nocdynp.clockRate
-           << " W" << endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel
-                   ? link_bus_tot_per_Router.power.readOp.longer_channel_leakage
-                   : link_bus_tot_per_Router.power.readOp.leakage)
-           << " W" << endl;
-      cout << indent_str_next << "Gate Leakage = "
-           << link_bus_tot_per_Router.power.readOp.gate_leakage << " W" << endl;
-      cout << indent_str_next << "Runtime Dynamic = "
-           << link_bus->rt_power.readOp.dynamic / nocdynp.executionTime << " W"
-           << endl;
-      cout << endl;
-    }
-  } else {
-    //		cout << indent_str_next << "Instruction Fetch Unit    Peak Dynamic = "
-    //<< ifu->rt_power.readOp.dynamic*clockRate << " W" << endl;
-    //		cout << indent_str_next << "Instruction Fetch Unit    Subthreshold
-    //Leakage = " << ifu->rt_power.readOp.leakage <<" W" << endl;
-    //		cout << indent_str_next << "Instruction Fetch Unit    Gate Leakage = "
-    //<< ifu->rt_power.readOp.gate_leakage << " W" << endl;
-    //		cout << indent_str_next << "Load Store Unit   Peak Dynamic = " <<
-    //lsu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Load Store Unit   Subthreshold Leakage = "
-    //<< lsu->rt_power.readOp.leakage  << " W" << endl;
-    //		cout << indent_str_next << "Load Store Unit   Gate Leakage = " <<
-    //lsu->rt_power.readOp.gate_leakage  << " W" << endl;
-    //		cout << indent_str_next << "Memory Management Unit   Peak Dynamic = "
-    //<< mmu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Memory Management Unit   Subthreshold
-    //Leakage = " << mmu->rt_power.readOp.leakage  << " W" << endl;
-    //		cout << indent_str_next << "Memory Management Unit   Gate Leakage = "
-    //<< mmu->rt_power.readOp.gate_leakage  << " W" << endl;
-    //		cout << indent_str_next << "Execution Unit   Peak Dynamic = " <<
-    //exu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
-    //		cout << indent_str_next << "Execution Unit   Subthreshold Leakage = "
-    //<< exu->rt_power.readOp.leakage  << " W" << endl;
-    //		cout << indent_str_next << "Execution Unit   Gate Leakage = " <<
-    //exu->rt_power.readOp.gate_leakage  << " W" << endl;
-  }
+	    }
 }
 
-void NoC::set_noc_param() {
-  nocdynp.type = XML->sys.NoC[ithNoC].type;
-  nocdynp.clockRate = XML->sys.NoC[ithNoC].clockrate;
-  nocdynp.clockRate *= 1e6;
-  nocdynp.executionTime =
-      XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);
 
-  nocdynp.flit_size = XML->sys.NoC[ithNoC].flit_bits;
-  if (nocdynp.type) {
-    nocdynp.input_ports = XML->sys.NoC[ithNoC].input_ports;
-    nocdynp.output_ports = XML->sys.NoC[ithNoC].output_ports;  // later minus 1
-    nocdynp.min_ports = min(nocdynp.input_ports, nocdynp.output_ports);
-    nocdynp.global_linked_ports =
-        (nocdynp.input_ports - 1) + (nocdynp.output_ports - 1);
-    /*
-     * 	Except local i/o ports, all ports needs links( global_linked_ports);
-     *  However only min_ports can be fully active simultaneously
-     *  since the fewer number of ports (input or output ) is the bottleneck.
-     */
-  } else {
-    nocdynp.input_ports = 1;
-    nocdynp.output_ports = 1;
-    nocdynp.min_ports = min(nocdynp.input_ports, nocdynp.output_ports);
-    nocdynp.global_linked_ports = 1;
-  }
+void NoC::displayEnergy(uint32_t indent,int plevel,bool is_tdp)
+{
+	string indent_str(indent, ' ');
+	string indent_str_next(indent+2, ' ');
+	bool long_channel = XML->sys.longer_channel_device;
 
-  nocdynp.virtual_channel_per_port =
-      XML->sys.NoC[ithNoC].virtual_channel_per_port;
-  nocdynp.input_buffer_entries_per_vc =
-      XML->sys.NoC[ithNoC].input_buffer_entries_per_vc;
+	double M =M_traffic_pattern*nocdynp.duty_cycle;
+	/*only router as a whole has been applied the M_traffic_pattern(0.6 by default) factor in router.cc;
+	 * 	When power of crossbars, arbiters, etc need to be displayed, the M_traffic_pattern factor need to
+	 * be applied together with McPAT's extra traffic pattern.
+	 * */
+	if (is_tdp)
+	{
+		cout << name << endl;
+		cout << indent_str << "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
+		cout << indent_str<< "Peak Dynamic = " << power.readOp.dynamic*nocdynp.clockRate << " W" << endl;
+		cout << indent_str << "Subthreshold Leakage = "
+			<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
+		cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
+		cout << indent_str<< "Runtime Dynamic = " << rt_power.readOp.dynamic/nocdynp.executionTime << " W" << endl;
+      //cout << indent_str<< "Execution Time = " << nocdynp.executionTime << " s" << endl;
+		cout<<endl;
 
-  nocdynp.horizontal_nodes = XML->sys.NoC[ithNoC].horizontal_nodes;
-  nocdynp.vertical_nodes = XML->sys.NoC[ithNoC].vertical_nodes;
-  nocdynp.total_nodes = nocdynp.horizontal_nodes * nocdynp.vertical_nodes;
-  nocdynp.duty_cycle = XML->sys.NoC[ithNoC].duty_cycle;
-  nocdynp.has_global_link = XML->sys.NoC[ithNoC].has_global_link;
-  nocdynp.link_throughput = XML->sys.NoC[ithNoC].link_throughput;
-  nocdynp.link_latency = XML->sys.NoC[ithNoC].link_latency;
-  nocdynp.chip_coverage = XML->sys.NoC[ithNoC].chip_coverage;
-  nocdynp.route_over_perc = XML->sys.NoC[ithNoC].route_over_perc;
+		if (router_exist)
+		{
+			cout << indent_str << "Router: " << endl;
+			cout << indent_str_next << "Area = " << router->area.get_area()*1e-6<< " mm^2" << endl;
+			cout << indent_str_next<< "Peak Dynamic = " << router->power.readOp.dynamic*nocdynp.clockRate << " W" << endl;
+			cout << indent_str_next << "Subthreshold Leakage = "
+			<< (long_channel? router->power.readOp.longer_channel_leakage:router->power.readOp.leakage)  <<" W" << endl;
+			cout << indent_str_next << "Gate Leakage = " << router->power.readOp.gate_leakage << " W" << endl;
+			cout << indent_str_next<< "Runtime Dynamic = " << router->rt_power.readOp.dynamic/nocdynp.executionTime << " W" << endl;
+			cout<<endl;
+			if (plevel >2){
+				cout << indent_str<< indent_str << "Virtual Channel Buffer:" << endl;
+				cout << indent_str<< indent_str_next << "Area = " << router->buffer.area.get_area()*1e-6*nocdynp.input_ports<< " mm^2" << endl;
+				cout << indent_str<< indent_str_next << "Peak Dynamic = " <<(router->buffer.power.readOp.dynamic + router->buffer.power.writeOp.dynamic)
+				*nocdynp.min_ports*M*nocdynp.clockRate << " W" << endl;
+				cout << indent_str<< indent_str_next << "Subthreshold Leakage = "
+				<< (long_channel? router->buffer.power.readOp.longer_channel_leakage*nocdynp.input_ports:router->buffer.power.readOp.leakage*nocdynp.input_ports)  <<" W" << endl;
+				cout << indent_str<< indent_str_next << "Gate Leakage = " << router->buffer.power.readOp.gate_leakage*nocdynp.input_ports << " W" << endl;
+				cout << indent_str<< indent_str_next << "Runtime Dynamic = " << router->buffer.rt_power.readOp.dynamic/nocdynp.executionTime << " W" << endl;
+				cout <<endl;
+				cout << indent_str<< indent_str<< "Crossbar:" << endl;
+				cout << indent_str<< indent_str_next << "Area = " << router->crossbar.area.get_area()*1e-6  << " mm^2" << endl;
+				cout << indent_str<< indent_str_next << "Peak Dynamic = " << router->crossbar.power.readOp.dynamic*nocdynp.clockRate*nocdynp.min_ports*M << " W" << endl;
+				cout << indent_str<< indent_str_next << "Subthreshold Leakage = "
+				<< (long_channel? router->crossbar.power.readOp.longer_channel_leakage:router->crossbar.power.readOp.leakage)  << " W" << endl;
+				cout << indent_str<< indent_str_next << "Gate Leakage = " << router->crossbar.power.readOp.gate_leakage  << " W" << endl;
+				cout << indent_str<< indent_str_next << "Runtime Dynamic = " << router->crossbar.rt_power.readOp.dynamic/nocdynp.executionTime << " W" << endl;
+				cout <<endl;
+				cout << indent_str<< indent_str<< "Arbiter:" << endl;
+				cout << indent_str<< indent_str_next << "Peak Dynamic = " << router->arbiter.power.readOp.dynamic*nocdynp.clockRate*nocdynp.min_ports*M  << " W" << endl;
+				cout << indent_str<< indent_str_next << "Subthreshold Leakage = "
+				<< (long_channel? router->arbiter.power.readOp.longer_channel_leakage:router->arbiter.power.readOp.leakage)  << " W" << endl;
+				cout << indent_str<< indent_str_next << "Gate Leakage = " << router->arbiter.power.readOp.gate_leakage  << " W" << endl;
+				cout << indent_str<< indent_str_next << "Runtime Dynamic = " << router->arbiter.rt_power.readOp.dynamic/nocdynp.executionTime << " W" << endl;
+				cout <<endl;
+			}
+		}
+		if (link_bus_exist)
+		{
+			cout << indent_str << (nocdynp.type? "Per Router ":"") << link_name<<": " << endl;
+			cout << indent_str_next << "Area = " << link_bus_tot_per_Router.area.get_area()*1e-6<< " mm^2" << endl;
+			cout << indent_str_next<< "Peak Dynamic = " << link_bus_tot_per_Router.power.readOp.dynamic*
+				nocdynp.clockRate << " W" << endl;
+			cout << indent_str_next << "Subthreshold Leakage = "
+			<< (long_channel? link_bus_tot_per_Router.power.readOp.longer_channel_leakage:link_bus_tot_per_Router.power.readOp.leakage)
+			     <<" W" << endl;
+			cout << indent_str_next << "Gate Leakage = " << link_bus_tot_per_Router.power.readOp.gate_leakage
+				<< " W" << endl;
+			cout << indent_str_next<< "Runtime Dynamic = " << link_bus->rt_power.readOp.dynamic/nocdynp.executionTime << " W" << endl;
+			cout<<endl;
 
-  assert(nocdynp.chip_coverage <= 1);
-  assert(nocdynp.route_over_perc <= 1);
-
-  if (nocdynp.type)
-    name = "NOC";
-  else
-    name = "BUSES";
+		}
+	}
+	else
+	{
+//		cout << indent_str_next << "Instruction Fetch Unit    Peak Dynamic = " << ifu->rt_power.readOp.dynamic*clockRate << " W" << endl;
+//		cout << indent_str_next << "Instruction Fetch Unit    Subthreshold Leakage = " << ifu->rt_power.readOp.leakage <<" W" << endl;
+//		cout << indent_str_next << "Instruction Fetch Unit    Gate Leakage = " << ifu->rt_power.readOp.gate_leakage << " W" << endl;
+//		cout << indent_str_next << "Load Store Unit   Peak Dynamic = " << lsu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+//		cout << indent_str_next << "Load Store Unit   Subthreshold Leakage = " << lsu->rt_power.readOp.leakage  << " W" << endl;
+//		cout << indent_str_next << "Load Store Unit   Gate Leakage = " << lsu->rt_power.readOp.gate_leakage  << " W" << endl;
+//		cout << indent_str_next << "Memory Management Unit   Peak Dynamic = " << mmu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+//		cout << indent_str_next << "Memory Management Unit   Subthreshold Leakage = " << mmu->rt_power.readOp.leakage  << " W" << endl;
+//		cout << indent_str_next << "Memory Management Unit   Gate Leakage = " << mmu->rt_power.readOp.gate_leakage  << " W" << endl;
+//		cout << indent_str_next << "Execution Unit   Peak Dynamic = " << exu->rt_power.readOp.dynamic*clockRate  << " W" << endl;
+//		cout << indent_str_next << "Execution Unit   Subthreshold Leakage = " << exu->rt_power.readOp.leakage  << " W" << endl;
+//		cout << indent_str_next << "Execution Unit   Gate Leakage = " << exu->rt_power.readOp.gate_leakage  << " W" << endl;
+	}
 }
 
-NoC::~NoC() {
-  if (router) {
-    delete router;
-    router = 0;
-  }
-  if (link_bus) {
-    delete link_bus;
-    link_bus = 0;
-  }
+void NoC::set_noc_param()
+{
+
+	nocdynp.type            = XML->sys.NoC[ithNoC].type;
+	nocdynp.clockRate       =XML->sys.NoC[ithNoC].clockrate;
+	nocdynp.clockRate       *= 1e6;
+	nocdynp.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
+
+	nocdynp.flit_size     = XML->sys.NoC[ithNoC].flit_bits;
+	if (nocdynp.type)
+	{
+		nocdynp.input_ports   = XML->sys.NoC[ithNoC].input_ports;
+		nocdynp.output_ports  = XML->sys.NoC[ithNoC].output_ports;//later minus 1
+		nocdynp.min_ports     = min(nocdynp.input_ports,nocdynp.output_ports);
+		nocdynp.global_linked_ports = (nocdynp.input_ports-1) + (nocdynp.output_ports-1);
+		/*
+		 * 	Except local i/o ports, all ports needs links( global_linked_ports);
+		 *  However only min_ports can be fully active simultaneously
+		 *  since the fewer number of ports (input or output ) is the bottleneck.
+		 */
+	}
+	else
+	{
+		nocdynp.input_ports   = 1;
+		nocdynp.output_ports  = 1;
+		nocdynp.min_ports     = min(nocdynp.input_ports,nocdynp.output_ports);
+		nocdynp.global_linked_ports = 1;
+	}
+
+	nocdynp.virtual_channel_per_port     = XML->sys.NoC[ithNoC].virtual_channel_per_port;
+	nocdynp.input_buffer_entries_per_vc  = XML->sys.NoC[ithNoC].input_buffer_entries_per_vc;
+
+	nocdynp.horizontal_nodes  = XML->sys.NoC[ithNoC].horizontal_nodes;
+	nocdynp.vertical_nodes    = XML->sys.NoC[ithNoC].vertical_nodes;
+	nocdynp.total_nodes       = nocdynp.horizontal_nodes*nocdynp.vertical_nodes;
+	nocdynp.duty_cycle        = XML->sys.NoC[ithNoC].duty_cycle;
+	nocdynp.has_global_link   = XML->sys.NoC[ithNoC].has_global_link;
+	nocdynp.link_throughput   = XML->sys.NoC[ithNoC].link_throughput;
+	nocdynp.link_latency      = XML->sys.NoC[ithNoC].link_latency;
+	nocdynp.chip_coverage     = XML->sys.NoC[ithNoC].chip_coverage;
+	nocdynp.route_over_perc   = XML->sys.NoC[ithNoC].route_over_perc;
+
+	assert (nocdynp.chip_coverage <=1);
+	assert (nocdynp.route_over_perc <=1);
+
+	if (nocdynp.type)
+		name = "NOC";
+	else
+		name = "BUSES";
+
+}
+
+
+NoC ::~NoC(){
+
+	if(router) 	               {delete router; router = 0;}
+	if(link_bus) 	           {delete link_bus; link_bus = 0;}
 }

--- a/src/gpuwattch/noc.h
+++ b/src/gpuwattch/noc.h
@@ -29,54 +29,55 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:												   *
-*      Jingwen Leng, Univeristy of Texas, Austin                   *
-*      Syed Gilani, University of Wisconsin–Madison                *
-*      Tayler Hetherington, University of British Columbia         *
-*      Ahmed ElTantawy, University of British Columbia             *
-********************************************************************/
+ *      Modified by:
+ ** Jingwen Leng, Univeristy of Texas, Austin                   * Syed Gilani,
+ *University of Wisconsin–Madison                * Tayler Hetherington,
+ *University of British Columbia         * Ahmed ElTantawy, University of
+ *British Columbia             *
+ ********************************************************************/
 
 #ifndef NOC_H_
 #define NOC_H_
 #include "XML_Parse.h"
-#include "logic.h"
-#include "cacti/parameter.h"
 #include "array.h"
-#include "interconnect.h"
 #include "basic_components.h"
+#include "cacti/parameter.h"
 #include "cacti/router.h"
+#include "interconnect.h"
+#include "logic.h"
 
-class NoC :public Component {
-  public:
-
-	ParseXML *XML;
-	int  ithNoC;
-	InputParameter interface_ip;
-	double link_len;
-	double executionTime;
-	double scktRatio, chip_PR_overhead, macro_PR_overhead;
-	MCPAT_Router * router;
-	interconnect * link_bus;
-	NoCParam  nocdynp;
-	uca_org_t local_result;
-	statsDef       tdp_stats;
-	statsDef       rtp_stats;
-	statsDef       stats_t;
-	powerDef       power_t;
-	Component      link_bus_tot_per_Router;
-	bool link_bus_exist;
-	bool router_exist;
-	string name, link_name;
-	double M_traffic_pattern;
-	NoC(ParseXML *XML_interface, int ithNoC_, InputParameter* interface_ip_, double M_traffic_pattern_ = 0.6,double link_len_=0);
-	void set_noc_param();
-	void computeEnergy(bool is_tdp=true);
-	void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-	void init_link_bus(double link_len_);
-	void init_router();
-	void computeEnergy_link_bus(bool is_tdp=true);
-	void displayEnergy_link_bus(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-	~NoC();
+class NoC : public Component {
+ public:
+  ParseXML *XML;
+  int ithNoC;
+  InputParameter interface_ip;
+  double link_len;
+  double executionTime;
+  double scktRatio, chip_PR_overhead, macro_PR_overhead;
+  MCPAT_Router *router;
+  interconnect *link_bus;
+  NoCParam nocdynp;
+  uca_org_t local_result;
+  statsDef tdp_stats;
+  statsDef rtp_stats;
+  statsDef stats_t;
+  powerDef power_t;
+  Component link_bus_tot_per_Router;
+  bool link_bus_exist;
+  bool router_exist;
+  string name, link_name;
+  double M_traffic_pattern;
+  NoC(ParseXML *XML_interface, int ithNoC_, InputParameter *interface_ip_,
+      double M_traffic_pattern_ = 0.6, double link_len_ = 0);
+  void set_noc_param();
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  void init_link_bus(double link_len_);
+  void init_router();
+  void computeEnergy_link_bus(bool is_tdp = true);
+  void displayEnergy_link_bus(uint32_t indent = 0, int plevel = 100,
+                              bool is_tdp = true);
+  ~NoC();
 };
 
 #endif /* NOC_H_ */

--- a/src/gpuwattch/noc.h
+++ b/src/gpuwattch/noc.h
@@ -29,8 +29,7 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:
-**
+*      Modified by:												   *
 *      Jingwen Leng, Univeristy of Texas, Austin                   *
 *      Syed Gilani, University of Wisconsin–Madison                *
 *      Tayler Hetherington, University of British Columbia         *
@@ -40,45 +39,44 @@
 #ifndef NOC_H_
 #define NOC_H_
 #include "XML_Parse.h"
-#include "array.h"
-#include "basic_components.h"
-#include "cacti/parameter.h"
-#include "cacti/router.h"
-#include "interconnect.h"
 #include "logic.h"
+#include "cacti/parameter.h"
+#include "array.h"
+#include "interconnect.h"
+#include "basic_components.h"
+#include "cacti/router.h"
 
-class NoC : public Component {
- public:
-  ParseXML *XML;
-  int ithNoC;
-  InputParameter interface_ip;
-  double link_len;
-  double executionTime;
-  double scktRatio, chip_PR_overhead, macro_PR_overhead;
-  MCPAT_Router *router;
-  interconnect *link_bus;
-  NoCParam nocdynp;
-  uca_org_t local_result;
-  statsDef tdp_stats;
-  statsDef rtp_stats;
-  statsDef stats_t;
-  powerDef power_t;
-  Component link_bus_tot_per_Router;
-  bool link_bus_exist;
-  bool router_exist;
-  string name, link_name;
-  double M_traffic_pattern;
-  NoC(ParseXML *XML_interface, int ithNoC_, InputParameter *interface_ip_,
-      double M_traffic_pattern_ = 0.6, double link_len_ = 0);
-  void set_noc_param();
-  void computeEnergy(bool is_tdp = true);
-  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
-  void init_link_bus(double link_len_);
-  void init_router();
-  void computeEnergy_link_bus(bool is_tdp = true);
-  void displayEnergy_link_bus(uint32_t indent = 0, int plevel = 100,
-                              bool is_tdp = true);
-  ~NoC();
+class NoC :public Component {
+  public:
+
+	ParseXML *XML;
+	int  ithNoC;
+	InputParameter interface_ip;
+	double link_len;
+	double executionTime;
+	double scktRatio, chip_PR_overhead, macro_PR_overhead;
+	MCPAT_Router * router;
+	interconnect * link_bus;
+	NoCParam  nocdynp;
+	uca_org_t local_result;
+	statsDef       tdp_stats;
+	statsDef       rtp_stats;
+	statsDef       stats_t;
+	powerDef       power_t;
+	Component      link_bus_tot_per_Router;
+	bool link_bus_exist;
+	bool router_exist;
+	string name, link_name;
+	double M_traffic_pattern;
+	NoC(ParseXML *XML_interface, int ithNoC_, InputParameter* interface_ip_, double M_traffic_pattern_ = 0.6,double link_len_=0);
+	void set_noc_param();
+	void computeEnergy(bool is_tdp=true);
+	void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
+	void init_link_bus(double link_len_);
+	void init_router();
+	void computeEnergy_link_bus(bool is_tdp=true);
+	void displayEnergy_link_bus(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
+	~NoC();
 };
 
 #endif /* NOC_H_ */

--- a/src/gpuwattch/noc.h
+++ b/src/gpuwattch/noc.h
@@ -29,7 +29,8 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:												   *
+*      Modified by:
+**
 *      Jingwen Leng, Univeristy of Texas, Austin                   *
 *      Syed Gilani, University of Wisconsin–Madison                *
 *      Tayler Hetherington, University of British Columbia         *
@@ -39,44 +40,45 @@
 #ifndef NOC_H_
 #define NOC_H_
 #include "XML_Parse.h"
-#include "logic.h"
-#include "cacti/parameter.h"
 #include "array.h"
-#include "interconnect.h"
 #include "basic_components.h"
+#include "cacti/parameter.h"
 #include "cacti/router.h"
+#include "interconnect.h"
+#include "logic.h"
 
-class NoC :public Component {
-  public:
-
-	ParseXML *XML;
-	int  ithNoC;
-	InputParameter interface_ip;
-	double link_len;
-	double executionTime;
-	double scktRatio, chip_PR_overhead, macro_PR_overhead;
-	MCPAT_Router * router;
-	interconnect * link_bus;
-	NoCParam  nocdynp;
-	uca_org_t local_result;
-	statsDef       tdp_stats;
-	statsDef       rtp_stats;
-	statsDef       stats_t;
-	powerDef       power_t;
-	Component      link_bus_tot_per_Router;
-	bool link_bus_exist;
-	bool router_exist;
-	string name, link_name;
-	double M_traffic_pattern;
-	NoC(ParseXML *XML_interface, int ithNoC_, InputParameter* interface_ip_, double M_traffic_pattern_ = 0.6,double link_len_=0);
-	void set_noc_param();
-	void computeEnergy(bool is_tdp=true);
-	void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-	void init_link_bus(double link_len_);
-	void init_router();
-	void computeEnergy_link_bus(bool is_tdp=true);
-	void displayEnergy_link_bus(uint32_t indent = 0,int plevel = 100, bool is_tdp=true);
-	~NoC();
+class NoC : public Component {
+ public:
+  ParseXML *XML;
+  int ithNoC;
+  InputParameter interface_ip;
+  double link_len;
+  double executionTime;
+  double scktRatio, chip_PR_overhead, macro_PR_overhead;
+  MCPAT_Router *router;
+  interconnect *link_bus;
+  NoCParam nocdynp;
+  uca_org_t local_result;
+  statsDef tdp_stats;
+  statsDef rtp_stats;
+  statsDef stats_t;
+  powerDef power_t;
+  Component link_bus_tot_per_Router;
+  bool link_bus_exist;
+  bool router_exist;
+  string name, link_name;
+  double M_traffic_pattern;
+  NoC(ParseXML *XML_interface, int ithNoC_, InputParameter *interface_ip_,
+      double M_traffic_pattern_ = 0.6, double link_len_ = 0);
+  void set_noc_param();
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100, bool is_tdp = true);
+  void init_link_bus(double link_len_);
+  void init_router();
+  void computeEnergy_link_bus(bool is_tdp = true);
+  void displayEnergy_link_bus(uint32_t indent = 0, int plevel = 100,
+                              bool is_tdp = true);
+  ~NoC();
 };
 
 #endif /* NOC_H_ */

--- a/src/gpuwattch/processor.cc
+++ b/src/gpuwattch/processor.cc
@@ -29,1034 +29,1177 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:												   *
-*      Jingwen Leng, Univeristy of Texas, Austin                   *
-*      Syed Gilani, University of Wisconsin–Madison                *
-*      Tayler Hetherington, University of British Columbia         *
-*      Ahmed ElTantawy, University of British Columbia             *
-********************************************************************/
-#include <string.h>
-#include <iostream>
-#include <stdio.h>
-#include <algorithm>
-#include <string.h>
-#include <cmath>
-#include <assert.h>
-#include <fstream>
-#include "parameter.h"
-#include "array.h"
-#include "const.h"
-#include "cacti/basic_circuit.h"
-#include "XML_Parse.h"
+ *      Modified by:
+ ** Jingwen Leng, Univeristy of Texas, Austin                   * Syed Gilani,
+ *University of Wisconsin–Madison                * Tayler Hetherington,
+ *University of British Columbia         * Ahmed ElTantawy, University of
+ *British Columbia             *
+ ********************************************************************/
 #include "processor.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include "XML_Parse.h"
+#include "array.h"
+#include "cacti/basic_circuit.h"
+#include "const.h"
+#include "parameter.h"
 #include "version.h"
 
-
 Processor::Processor(ParseXML *XML_interface)
-:XML(XML_interface),//TODO: using one global copy may have problems.
- mc(0),
- niu(0),
- pcie(0),
- flashcontroller(0)
-{
+    : XML(XML_interface),  // TODO: using one global copy may have problems.
+      mc(0),
+      niu(0),
+      pcie(0),
+      flashcontroller(0) {
   /*
-   *  placement and routing overhead is 10%, core scales worse than cache 40% is accumulated from 90 to 22nm
-   *  There is no point to have heterogeneous memory controller on chip,
-   *  thus McPAT only support homogeneous memory controllers.
+   *  placement and routing overhead is 10%, core scales worse than cache 40% is
+   * accumulated from 90 to 22nm There is no point to have heterogeneous memory
+   * controller on chip, thus McPAT only support homogeneous memory controllers.
    */
   rt_power.reset();
   int i;
-  double pppm_t[4]    = {1,1,1,1};
-  l2_power=0;
-  idle_core_power=0;
+  double pppm_t[4] = {1, 1, 1, 1};
+  l2_power = 0;
+  idle_core_power = 0;
   set_proc_param();
   if (procdynp.homoCore)
-	  numCore = procdynp.numCore==0? 0:1;
+    numCore = procdynp.numCore == 0 ? 0 : 1;
   else
-	  numCore = procdynp.numCore;
+    numCore = procdynp.numCore;
 
   if (procdynp.homoL2)
-	  numL2 = procdynp.numL2==0? 0:1;
+    numL2 = procdynp.numL2 == 0 ? 0 : 1;
   else
-	  numL2 = procdynp.numL2;
+    numL2 = procdynp.numL2;
 
-  if (XML->sys.Private_L2 && numCore != numL2)
-  {
-	  cout<<"Number of private L2 does not match number of cores"<<endl;
-      exit(0);
+  if (XML->sys.Private_L2 && numCore != numL2) {
+    cout << "Number of private L2 does not match number of cores" << endl;
+    exit(0);
   }
 
   if (procdynp.homoL3)
-	  numL3 = procdynp.numL3==0? 0:1;
+    numL3 = procdynp.numL3 == 0 ? 0 : 1;
   else
-	  numL3 = procdynp.numL3;
+    numL3 = procdynp.numL3;
 
   if (procdynp.homoNOC)
-	  numNOC = procdynp.numNOC==0? 0:1;
+    numNOC = procdynp.numNOC == 0 ? 0 : 1;
   else
-	  numNOC = procdynp.numNOC;
+    numNOC = procdynp.numNOC;
 
-//  if (!procdynp.homoNOC)
-//  {
-//	  cout<<"Current McPAT does not support heterogeneous NOC"<<endl;
-//      exit(0);
-//  }
+  //  if (!procdynp.homoNOC)
+  //  {
+  //	  cout<<"Current McPAT does not support heterogeneous NOC"<<endl;
+  //      exit(0);
+  //  }
 
   if (procdynp.homoL1Dir)
-	  numL1Dir = procdynp.numL1Dir==0? 0:1;
+    numL1Dir = procdynp.numL1Dir == 0 ? 0 : 1;
   else
-	  numL1Dir = procdynp.numL1Dir;
+    numL1Dir = procdynp.numL1Dir;
 
   if (procdynp.homoL2Dir)
-	  numL2Dir = procdynp.numL2Dir==0? 0:1;
+    numL2Dir = procdynp.numL2Dir == 0 ? 0 : 1;
   else
-	  numL2Dir = procdynp.numL2Dir;
+    numL2Dir = procdynp.numL2Dir;
 
-  for (i = 0;i < numCore; i++)
-  {
-		  cores.push_back(new Core(XML,i, &interface_ip));
-		  cores[i]->computeEnergy();
-		  cores[i]->computeEnergy(false);
-		  if (procdynp.homoCore){
-			  core.area.set_area(core.area.get_area() + cores[i]->area.get_area()*procdynp.numCore);
-			  set_pppm(pppm_t,cores[i]->clockRate*procdynp.numCore, procdynp.numCore,procdynp.numCore,procdynp.numCore);
-			  //set the exClockRate
-           exClockRate=cores[0]->clockRate*2;//TODO; get from XML file
-			  //cout<<"****EX clock rate:"<<exClockRate<<endl;
-			  core.power = core.power + cores[i]->power*pppm_t;
-			  set_pppm(pppm_t,1/cores[i]->executionTime, procdynp.numCore,procdynp.numCore,procdynp.numCore);
-			  core.rt_power = core.rt_power + cores[i]->rt_power*pppm_t;
-			  area.set_area(area.get_area() + core.area.get_area());//placement and routing overhead is 10%, core scales worse than cache 40% is accumulated from 90 to 22nm
-			  power = power  + core.power;
-			  rt_power = rt_power  + core.rt_power;
-		  }
-		  else{
-			  core.area.set_area(core.area.get_area() + cores[i]->area.get_area());
-			  area.set_area(area.get_area() + cores[i]->area.get_area());//placement and routing overhead is 10%, core scales worse than cache 40% is accumulated from 90 to 22nm
+  for (i = 0; i < numCore; i++) {
+    cores.push_back(new Core(XML, i, &interface_ip));
+    cores[i]->computeEnergy();
+    cores[i]->computeEnergy(false);
+    if (procdynp.homoCore) {
+      core.area.set_area(core.area.get_area() +
+                         cores[i]->area.get_area() * procdynp.numCore);
+      set_pppm(pppm_t, cores[i]->clockRate * procdynp.numCore, procdynp.numCore,
+               procdynp.numCore, procdynp.numCore);
+      // set the exClockRate
+      exClockRate = cores[0]->clockRate * 2;  // TODO; get from XML file
+      // cout<<"****EX clock rate:"<<exClockRate<<endl;
+      core.power = core.power + cores[i]->power * pppm_t;
+      set_pppm(pppm_t, 1 / cores[i]->executionTime, procdynp.numCore,
+               procdynp.numCore, procdynp.numCore);
+      core.rt_power = core.rt_power + cores[i]->rt_power * pppm_t;
+      area.set_area(
+          area.get_area() +
+          core.area.get_area());  // placement and routing overhead is
+                                  // 10%, core scales worse than cache
+                                  // 40% is accumulated from 90 to 22nm
+      power = power + core.power;
+      rt_power = rt_power + core.rt_power;
+    } else {
+      core.area.set_area(core.area.get_area() + cores[i]->area.get_area());
+      area.set_area(
+          area.get_area() +
+          cores[i]->area.get_area());  // placement and routing overhead is 10%,
+                                       // core scales worse than cache 40% is
+                                       // accumulated from 90 to 22nm
 
-			  set_pppm(pppm_t,cores[i]->clockRate, 1, 1, 1);
-			  //set the exClockRate
-           exClockRate=cores[0]->clockRate;//TODO; get from XML file
-			  //cout<<"****EX clock rate:"<<exClockRate<<endl;
-			  core.power = core.power + cores[i]->power*pppm_t;
-			  power = power  + cores[i]->power*pppm_t;
+      set_pppm(pppm_t, cores[i]->clockRate, 1, 1, 1);
+      // set the exClockRate
+      exClockRate = cores[0]->clockRate;  // TODO; get from XML file
+      // cout<<"****EX clock rate:"<<exClockRate<<endl;
+      core.power = core.power + cores[i]->power * pppm_t;
+      power = power + cores[i]->power * pppm_t;
 
-			  set_pppm(pppm_t,1/cores[i]->executionTime, 1, 1, 1);
-			  core.rt_power = core.rt_power + cores[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + cores[i]->rt_power*pppm_t;
-		  }
+      set_pppm(pppm_t, 1 / cores[i]->executionTime, 1, 1, 1);
+      core.rt_power = core.rt_power + cores[i]->rt_power * pppm_t;
+      rt_power = rt_power + cores[i]->rt_power * pppm_t;
+    }
   }
 
-  if (!XML->sys.Private_L2)
-  {
+  if (!XML->sys.Private_L2) {
+    if (numL2 > 0)
+      for (i = 0; i < numL2; i++) {
+        l2array.push_back(new SharedCache(XML, i, &interface_ip));
 
-  if (numL2 >0)
-	  for (i = 0;i < numL2; i++)
-	  {
-		  l2array.push_back(new SharedCache(XML,i, &interface_ip));
+        l2array[i]->computeEnergy();
+        l2array[i]->computeEnergy(false);
+        if (procdynp.homoL2) {
+          l2.area.set_area(l2.area.get_area() +
+                           l2array[i]->area.get_area() * procdynp.numL2);
+          set_pppm(pppm_t, l2array[i]->cachep.clockRate * procdynp.numL2,
+                   procdynp.numL2, procdynp.numL2, procdynp.numL2);
+          l2.power = l2.power + l2array[i]->power * pppm_t;
+          set_pppm(pppm_t, 1 / l2array[i]->cachep.executionTime, procdynp.numL2,
+                   procdynp.numL2, procdynp.numL2);
+          l2.rt_power = l2.rt_power + l2array[i]->rt_power * pppm_t;
+          area.set_area(
+              area.get_area() +
+              l2.area.get_area());  // placement and routing overhead is 10%, l2
+                                    // scales worse than cache 40% is
+                                    // accumulated from 90 to 22nm
+          power = power + l2.power;
+          rt_power = rt_power + l2.rt_power;
+        } else {
+          l2.area.set_area(l2.area.get_area() + l2array[i]->area.get_area());
+          area.set_area(
+              area.get_area() +
+              l2array[i]
+                  ->area.get_area());  // placement and routing overhead is 10%,
+                                       // l2 scales worse than cache 40% is
+                                       // accumulated from 90 to 22nm
 
-		  l2array[i]->computeEnergy();
-		  l2array[i]->computeEnergy(false);
-		  if (procdynp.homoL2){
-			  l2.area.set_area(l2.area.get_area() + l2array[i]->area.get_area()*procdynp.numL2);
-			  set_pppm(pppm_t,l2array[i]->cachep.clockRate*procdynp.numL2, procdynp.numL2,procdynp.numL2,procdynp.numL2);
-			  l2.power = l2.power + l2array[i]->power*pppm_t;
-			  set_pppm(pppm_t,1/l2array[i]->cachep.executionTime, procdynp.numL2,procdynp.numL2,procdynp.numL2);
-			  l2.rt_power = l2.rt_power + l2array[i]->rt_power*pppm_t;
-			  area.set_area(area.get_area() + l2.area.get_area());//placement and routing overhead is 10%, l2 scales worse than cache 40% is accumulated from 90 to 22nm
-			  power = power  + l2.power;
-			  rt_power = rt_power  + l2.rt_power;
-		  }
-		  else{
-			  l2.area.set_area(l2.area.get_area() + l2array[i]->area.get_area());
-			  area.set_area(area.get_area() + l2array[i]->area.get_area());//placement and routing overhead is 10%, l2 scales worse than cache 40% is accumulated from 90 to 22nm
-
-			  set_pppm(pppm_t,l2array[i]->cachep.clockRate, 1, 1, 1);
-			  l2.power = l2.power + l2array[i]->power*pppm_t;
-			  power = power  + l2array[i]->power*pppm_t;;
-			  set_pppm(pppm_t,1/l2array[i]->cachep.executionTime, 1, 1, 1);
-			  l2.rt_power = l2.rt_power + l2array[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + l2array[i]->rt_power*pppm_t;
-		  }
-	  }
+          set_pppm(pppm_t, l2array[i]->cachep.clockRate, 1, 1, 1);
+          l2.power = l2.power + l2array[i]->power * pppm_t;
+          power = power + l2array[i]->power * pppm_t;
+          ;
+          set_pppm(pppm_t, 1 / l2array[i]->cachep.executionTime, 1, 1, 1);
+          l2.rt_power = l2.rt_power + l2array[i]->rt_power * pppm_t;
+          rt_power = rt_power + l2array[i]->rt_power * pppm_t;
+        }
+      }
   }
 
-  if (numL3 >0)
-	  for (i = 0;i < numL3; i++)
-	  {
-		  l3array.push_back(new SharedCache(XML,i, &interface_ip, L3));
-		  l3array[i]->computeEnergy();
-		  l3array[i]->computeEnergy(false);
-		  if (procdynp.homoL3){
-			  l3.area.set_area(l3.area.get_area() + l3array[i]->area.get_area()*procdynp.numL3);
-			  set_pppm(pppm_t,l3array[i]->cachep.clockRate*procdynp.numL3, procdynp.numL3,procdynp.numL3,procdynp.numL3);
-			  l3.power = l3.power + l3array[i]->power*pppm_t;
-			  set_pppm(pppm_t,1/l3array[i]->cachep.executionTime, procdynp.numL3,procdynp.numL3,procdynp.numL3);
-              l3.rt_power = l3.rt_power + l3array[i]->rt_power*pppm_t;
-			  area.set_area(area.get_area() + l3.area.get_area());//placement and routing overhead is 10%, l3 scales worse than cache 40% is accumulated from 90 to 22nm
-			  power = power  + l3.power;
-			  rt_power = rt_power  + l3.rt_power;
+  if (numL3 > 0)
+    for (i = 0; i < numL3; i++) {
+      l3array.push_back(new SharedCache(XML, i, &interface_ip, L3));
+      l3array[i]->computeEnergy();
+      l3array[i]->computeEnergy(false);
+      if (procdynp.homoL3) {
+        l3.area.set_area(l3.area.get_area() +
+                         l3array[i]->area.get_area() * procdynp.numL3);
+        set_pppm(pppm_t, l3array[i]->cachep.clockRate * procdynp.numL3,
+                 procdynp.numL3, procdynp.numL3, procdynp.numL3);
+        l3.power = l3.power + l3array[i]->power * pppm_t;
+        set_pppm(pppm_t, 1 / l3array[i]->cachep.executionTime, procdynp.numL3,
+                 procdynp.numL3, procdynp.numL3);
+        l3.rt_power = l3.rt_power + l3array[i]->rt_power * pppm_t;
+        area.set_area(
+            area.get_area() +
+            l3.area.get_area());  // placement and routing overhead is
+                                  // 10%, l3 scales worse than cache
+                                  // 40% is accumulated from 90 to 22nm
+        power = power + l3.power;
+        rt_power = rt_power + l3.rt_power;
 
-		  }
-		  else{
-			  l3.area.set_area(l3.area.get_area() + l3array[i]->area.get_area());
-			  area.set_area(area.get_area() + l3array[i]->area.get_area());//placement and routing overhead is 10%, l3 scales worse than cache 40% is accumulated from 90 to 22nm
-			  set_pppm(pppm_t,l3array[i]->cachep.clockRate, 1, 1, 1);
-			  l3.power = l3.power + l3array[i]->power*pppm_t;
-			  power = power  + l3array[i]->power*pppm_t;
-			  set_pppm(pppm_t,1/l3array[i]->cachep.executionTime, 1, 1, 1);
-              l3.rt_power = l3.rt_power + l3array[i]->rt_power*pppm_t;
-              rt_power = rt_power  + l3array[i]->rt_power*pppm_t;
+      } else {
+        l3.area.set_area(l3.area.get_area() + l3array[i]->area.get_area());
+        area.set_area(
+            area.get_area() +
+            l3array[i]->area.get_area());  // placement and routing overhead is
+                                           // 10%, l3 scales worse than cache
+                                           // 40% is accumulated from 90 to 22nm
+        set_pppm(pppm_t, l3array[i]->cachep.clockRate, 1, 1, 1);
+        l3.power = l3.power + l3array[i]->power * pppm_t;
+        power = power + l3array[i]->power * pppm_t;
+        set_pppm(pppm_t, 1 / l3array[i]->cachep.executionTime, 1, 1, 1);
+        l3.rt_power = l3.rt_power + l3array[i]->rt_power * pppm_t;
+        rt_power = rt_power + l3array[i]->rt_power * pppm_t;
+      }
+    }
+  if (numL1Dir > 0)
+    for (i = 0; i < numL1Dir; i++) {
+      l1dirarray.push_back(new SharedCache(XML, i, &interface_ip, L1Directory));
+      l1dirarray[i]->computeEnergy();
+      l1dirarray[i]->computeEnergy(false);
+      if (procdynp.homoL1Dir) {
+        l1dir.area.set_area(l1dir.area.get_area() +
+                            l1dirarray[i]->area.get_area() * procdynp.numL1Dir);
+        set_pppm(pppm_t, l1dirarray[i]->cachep.clockRate * procdynp.numL1Dir,
+                 procdynp.numL1Dir, procdynp.numL1Dir, procdynp.numL1Dir);
+        l1dir.power = l1dir.power + l1dirarray[i]->power * pppm_t;
+        set_pppm(pppm_t, 1 / l1dirarray[i]->cachep.executionTime,
+                 procdynp.numL1Dir, procdynp.numL1Dir, procdynp.numL1Dir);
+        l1dir.rt_power = l1dir.rt_power + l1dirarray[i]->rt_power * pppm_t;
+        area.set_area(
+            area.get_area() +
+            l1dir.area.get_area());  // placement and routing overhead is 10%,
+                                     // l1dir scales worse than cache 40% is
+                                     // accumulated from 90 to 22nm
+        power = power + l1dir.power;
+        rt_power = rt_power + l1dir.rt_power;
 
-		  }
-	  }
-  if (numL1Dir >0)
-	  for (i = 0;i < numL1Dir; i++)
-	  {
-		  l1dirarray.push_back(new SharedCache(XML,i, &interface_ip, L1Directory));
-		  l1dirarray[i]->computeEnergy();
-		  l1dirarray[i]->computeEnergy(false);
-		  if (procdynp.homoL1Dir){
-			  l1dir.area.set_area(l1dir.area.get_area() + l1dirarray[i]->area.get_area()*procdynp.numL1Dir);
-			  set_pppm(pppm_t,l1dirarray[i]->cachep.clockRate*procdynp.numL1Dir, procdynp.numL1Dir,procdynp.numL1Dir,procdynp.numL1Dir);
-			  l1dir.power = l1dir.power + l1dirarray[i]->power*pppm_t;
-			  set_pppm(pppm_t,1/l1dirarray[i]->cachep.executionTime, procdynp.numL1Dir,procdynp.numL1Dir,procdynp.numL1Dir);
-              l1dir.rt_power = l1dir.rt_power + l1dirarray[i]->rt_power*pppm_t;
-			  area.set_area(area.get_area() + l1dir.area.get_area());//placement and routing overhead is 10%, l1dir scales worse than cache 40% is accumulated from 90 to 22nm
-			  power = power  + l1dir.power;
-			  rt_power = rt_power  + l1dir.rt_power;
+      } else {
+        l1dir.area.set_area(l1dir.area.get_area() +
+                            l1dirarray[i]->area.get_area());
+        area.set_area(area.get_area() + l1dirarray[i]->area.get_area());
+        set_pppm(pppm_t, l1dirarray[i]->cachep.clockRate, 1, 1, 1);
+        l1dir.power = l1dir.power + l1dirarray[i]->power * pppm_t;
+        power = power + l1dirarray[i]->power;
+        set_pppm(pppm_t, 1 / l1dirarray[i]->cachep.executionTime, 1, 1, 1);
+        l1dir.rt_power = l1dir.rt_power + l1dirarray[i]->rt_power * pppm_t;
+        rt_power = rt_power + l1dirarray[i]->rt_power;
+      }
+    }
 
-		  }
-		  else{
-			  l1dir.area.set_area(l1dir.area.get_area() + l1dirarray[i]->area.get_area());
-			  area.set_area(area.get_area() + l1dirarray[i]->area.get_area());
-			  set_pppm(pppm_t,l1dirarray[i]->cachep.clockRate, 1, 1, 1);
-			  l1dir.power = l1dir.power + l1dirarray[i]->power*pppm_t;
-			  power = power  + l1dirarray[i]->power;
-			  set_pppm(pppm_t,1/l1dirarray[i]->cachep.executionTime, 1, 1, 1);
-              l1dir.rt_power = l1dir.rt_power + l1dirarray[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + l1dirarray[i]->rt_power;
-		  }
-	  }
+  if (numL2Dir > 0)
+    for (i = 0; i < numL2Dir; i++) {
+      l2dirarray.push_back(new SharedCache(XML, i, &interface_ip, L2Directory));
+      l2dirarray[i]->computeEnergy();
+      l2dirarray[i]->computeEnergy(false);
+      if (procdynp.homoL2Dir) {
+        l2dir.area.set_area(l2dir.area.get_area() +
+                            l2dirarray[i]->area.get_area() * procdynp.numL2Dir);
+        set_pppm(pppm_t, l2dirarray[i]->cachep.clockRate * procdynp.numL2Dir,
+                 procdynp.numL2Dir, procdynp.numL2Dir, procdynp.numL2Dir);
+        l2dir.power = l2dir.power + l2dirarray[i]->power * pppm_t;
+        set_pppm(pppm_t, 1 / l2dirarray[i]->cachep.executionTime,
+                 procdynp.numL2Dir, procdynp.numL2Dir, procdynp.numL2Dir);
+        l2dir.rt_power = l2dir.rt_power + l2dirarray[i]->rt_power * pppm_t;
+        area.set_area(
+            area.get_area() +
+            l2dir.area.get_area());  // placement and routing overhead is 10%,
+                                     // l2dir scales worse than cache 40% is
+                                     // accumulated from 90 to 22nm
+        power = power + l2dir.power;
+        rt_power = rt_power + l2dir.rt_power;
 
-  if (numL2Dir >0)
-	  for (i = 0;i < numL2Dir; i++)
-	  {
-		  l2dirarray.push_back(new SharedCache(XML,i, &interface_ip, L2Directory));
-		  l2dirarray[i]->computeEnergy();
-		  l2dirarray[i]->computeEnergy(false);
-		  if (procdynp.homoL2Dir){
-			  l2dir.area.set_area(l2dir.area.get_area() + l2dirarray[i]->area.get_area()*procdynp.numL2Dir);
-			  set_pppm(pppm_t,l2dirarray[i]->cachep.clockRate*procdynp.numL2Dir, procdynp.numL2Dir,procdynp.numL2Dir,procdynp.numL2Dir);
-			  l2dir.power = l2dir.power + l2dirarray[i]->power*pppm_t;
-			  set_pppm(pppm_t,1/l2dirarray[i]->cachep.executionTime, procdynp.numL2Dir,procdynp.numL2Dir,procdynp.numL2Dir);
-              l2dir.rt_power = l2dir.rt_power + l2dirarray[i]->rt_power*pppm_t;
-			  area.set_area(area.get_area() + l2dir.area.get_area());//placement and routing overhead is 10%, l2dir scales worse than cache 40% is accumulated from 90 to 22nm
-			  power = power  + l2dir.power;
-			  rt_power = rt_power  + l2dir.rt_power;
+      } else {
+        l2dir.area.set_area(l2dir.area.get_area() +
+                            l2dirarray[i]->area.get_area());
+        area.set_area(area.get_area() + l2dirarray[i]->area.get_area());
+        set_pppm(pppm_t, l2dirarray[i]->cachep.clockRate, 1, 1, 1);
+        l2dir.power = l2dir.power + l2dirarray[i]->power * pppm_t;
+        power = power + l2dirarray[i]->power * pppm_t;
+        set_pppm(pppm_t, 1 / l2dirarray[i]->cachep.executionTime, 1, 1, 1);
+        l2dir.rt_power = l2dir.rt_power + l2dirarray[i]->rt_power * pppm_t;
+        rt_power = rt_power + l2dirarray[i]->rt_power * pppm_t;
+      }
+    }
 
-		  }
-		  else{
-			  l2dir.area.set_area(l2dir.area.get_area() + l2dirarray[i]->area.get_area());
-			  area.set_area(area.get_area() + l2dirarray[i]->area.get_area());
-			  set_pppm(pppm_t,l2dirarray[i]->cachep.clockRate, 1, 1, 1);
-			  l2dir.power = l2dir.power + l2dirarray[i]->power*pppm_t;
-			  power = power  + l2dirarray[i]->power*pppm_t;
-			  set_pppm(pppm_t,1/l2dirarray[i]->cachep.executionTime, 1, 1, 1);
-              l2dir.rt_power = l2dir.rt_power + l2dirarray[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + l2dirarray[i]->rt_power*pppm_t;
-		  }
-	  }
-
-  if (XML->sys.mc.number_mcs >0 && XML->sys.mc.memory_channels_per_mc>0)
-  {
-	  if(XML->sys.architecture==1) // 1 for fermi
-		mc = new MemoryController(XML, &interface_ip, MC,GDDR5);
-	  else if (XML->sys.architecture==2) // 2 for quadro
-		mc = new MemoryController(XML, &interface_ip, MC,GDDR3);
-	  else {
-		printf("Architecture %d not defined!\n", XML->sys.architecture);
-		printf("use 1 for fermi and 2 for quadro!\n");
-		exit(1);
-	  }
-	  mc->computeEnergy();
-	  mc->computeEnergy(false);
-	  mcs.area.set_area(mcs.area.get_area()+mc->area.get_area()*XML->sys.mc.number_mcs);
-	  area.set_area(area.get_area()+mc->area.get_area()*XML->sys.mc.number_mcs);
-	  set_pppm(pppm_t,XML->sys.mc.number_mcs*mc->mcp.clockRate, XML->sys.mc.number_mcs,XML->sys.mc.number_mcs,XML->sys.mc.number_mcs);
-	  mcs.power = mc->power*pppm_t;
-	  power = power  + mcs.power;
-	  set_pppm(pppm_t,1/mc->mcp.executionTime, XML->sys.mc.number_mcs,XML->sys.mc.number_mcs,XML->sys.mc.number_mcs);
-	  mcs.rt_power = mc->rt_power*pppm_t;
-	  rt_power = rt_power  + mcs.rt_power;
-
+  if (XML->sys.mc.number_mcs > 0 && XML->sys.mc.memory_channels_per_mc > 0) {
+    if (XML->sys.architecture == 1)  // 1 for fermi
+      mc = new MemoryController(XML, &interface_ip, MC, GDDR5);
+    else if (XML->sys.architecture == 2)  // 2 for quadro
+      mc = new MemoryController(XML, &interface_ip, MC, GDDR3);
+    else {
+      printf("Architecture %d not defined!\n", XML->sys.architecture);
+      printf("use 1 for fermi and 2 for quadro!\n");
+      exit(1);
+    }
+    mc->computeEnergy();
+    mc->computeEnergy(false);
+    mcs.area.set_area(mcs.area.get_area() +
+                      mc->area.get_area() * XML->sys.mc.number_mcs);
+    area.set_area(area.get_area() +
+                  mc->area.get_area() * XML->sys.mc.number_mcs);
+    set_pppm(pppm_t, XML->sys.mc.number_mcs * mc->mcp.clockRate,
+             XML->sys.mc.number_mcs, XML->sys.mc.number_mcs,
+             XML->sys.mc.number_mcs);
+    mcs.power = mc->power * pppm_t;
+    power = power + mcs.power;
+    set_pppm(pppm_t, 1 / mc->mcp.executionTime, XML->sys.mc.number_mcs,
+             XML->sys.mc.number_mcs, XML->sys.mc.number_mcs);
+    mcs.rt_power = mc->rt_power * pppm_t;
+    rt_power = rt_power + mcs.rt_power;
   }
 
-  if (XML->sys.flashc.number_mcs >0 )//flash controller
+  if (XML->sys.flashc.number_mcs > 0)  // flash controller
   {
-	  flashcontroller = new FlashController(XML, &interface_ip);
-	  flashcontroller->computeEnergy();
-	  flashcontroller->computeEnergy(false);
-	  double number_fcs = flashcontroller->fcp.num_mcs;
-	  flashcontrollers.area.set_area(flashcontrollers.area.get_area()+flashcontroller->area.get_area()*number_fcs);
-	  area.set_area(area.get_area()+flashcontrollers.area.get_area());
-	  set_pppm(pppm_t,number_fcs, number_fcs ,number_fcs, number_fcs );
-	  flashcontrollers.power = flashcontroller->power*pppm_t;
-	  power = power  + flashcontrollers.power;
-	  set_pppm(pppm_t,number_fcs , number_fcs ,number_fcs ,number_fcs );
-	  flashcontrollers.rt_power = flashcontroller->rt_power*pppm_t;
-	  rt_power = rt_power  + flashcontrollers.rt_power;
-
+    flashcontroller = new FlashController(XML, &interface_ip);
+    flashcontroller->computeEnergy();
+    flashcontroller->computeEnergy(false);
+    double number_fcs = flashcontroller->fcp.num_mcs;
+    flashcontrollers.area.set_area(flashcontrollers.area.get_area() +
+                                   flashcontroller->area.get_area() *
+                                       number_fcs);
+    area.set_area(area.get_area() + flashcontrollers.area.get_area());
+    set_pppm(pppm_t, number_fcs, number_fcs, number_fcs, number_fcs);
+    flashcontrollers.power = flashcontroller->power * pppm_t;
+    power = power + flashcontrollers.power;
+    set_pppm(pppm_t, number_fcs, number_fcs, number_fcs, number_fcs);
+    flashcontrollers.rt_power = flashcontroller->rt_power * pppm_t;
+    rt_power = rt_power + flashcontrollers.rt_power;
   }
 
-  if (XML->sys.niu.number_units >0)
-  {
-	  niu = new NIUController(XML, &interface_ip);
-	  niu->computeEnergy();
-	  niu->computeEnergy(false);
-	  nius.area.set_area(nius.area.get_area()+niu->area.get_area()*XML->sys.niu.number_units);
-	  area.set_area(area.get_area()+niu->area.get_area()*XML->sys.niu.number_units);
-	  set_pppm(pppm_t,XML->sys.niu.number_units*niu->niup.clockRate, XML->sys.niu.number_units,XML->sys.niu.number_units,XML->sys.niu.number_units);
-	  nius.power = niu->power*pppm_t;
-	  power = power  + nius.power;
-	  set_pppm(pppm_t,XML->sys.niu.number_units*niu->niup.clockRate, XML->sys.niu.number_units,XML->sys.niu.number_units,XML->sys.niu.number_units);
-	  nius.rt_power = niu->rt_power*pppm_t;
-	  rt_power = rt_power  + nius.rt_power;
-
+  if (XML->sys.niu.number_units > 0) {
+    niu = new NIUController(XML, &interface_ip);
+    niu->computeEnergy();
+    niu->computeEnergy(false);
+    nius.area.set_area(nius.area.get_area() +
+                       niu->area.get_area() * XML->sys.niu.number_units);
+    area.set_area(area.get_area() +
+                  niu->area.get_area() * XML->sys.niu.number_units);
+    set_pppm(pppm_t, XML->sys.niu.number_units * niu->niup.clockRate,
+             XML->sys.niu.number_units, XML->sys.niu.number_units,
+             XML->sys.niu.number_units);
+    nius.power = niu->power * pppm_t;
+    power = power + nius.power;
+    set_pppm(pppm_t, XML->sys.niu.number_units * niu->niup.clockRate,
+             XML->sys.niu.number_units, XML->sys.niu.number_units,
+             XML->sys.niu.number_units);
+    nius.rt_power = niu->rt_power * pppm_t;
+    rt_power = rt_power + nius.rt_power;
   }
 
-  if (XML->sys.pcie.number_units >0 && XML->sys.pcie.num_channels >0)
-  {
-	  pcie = new PCIeController(XML, &interface_ip);
-	  pcie->computeEnergy();
-	  pcie->computeEnergy(false);
-	  pcies.area.set_area(pcies.area.get_area()+pcie->area.get_area()*XML->sys.pcie.number_units);
-	  area.set_area(area.get_area()+pcie->area.get_area()*XML->sys.pcie.number_units);
-	  set_pppm(pppm_t,XML->sys.pcie.number_units*pcie->pciep.clockRate, XML->sys.pcie.number_units,XML->sys.pcie.number_units,XML->sys.pcie.number_units);
-	  pcies.power = pcie->power*pppm_t;
-	  power = power  + pcies.power;
-	  set_pppm(pppm_t,XML->sys.pcie.number_units*pcie->pciep.clockRate, XML->sys.pcie.number_units,XML->sys.pcie.number_units,XML->sys.pcie.number_units);
-	  pcies.rt_power = pcie->rt_power*pppm_t;
-	  rt_power = rt_power  + pcies.rt_power;
-
+  if (XML->sys.pcie.number_units > 0 && XML->sys.pcie.num_channels > 0) {
+    pcie = new PCIeController(XML, &interface_ip);
+    pcie->computeEnergy();
+    pcie->computeEnergy(false);
+    pcies.area.set_area(pcies.area.get_area() +
+                        pcie->area.get_area() * XML->sys.pcie.number_units);
+    area.set_area(area.get_area() +
+                  pcie->area.get_area() * XML->sys.pcie.number_units);
+    set_pppm(pppm_t, XML->sys.pcie.number_units * pcie->pciep.clockRate,
+             XML->sys.pcie.number_units, XML->sys.pcie.number_units,
+             XML->sys.pcie.number_units);
+    pcies.power = pcie->power * pppm_t;
+    power = power + pcies.power;
+    set_pppm(pppm_t, XML->sys.pcie.number_units * pcie->pciep.clockRate,
+             XML->sys.pcie.number_units, XML->sys.pcie.number_units,
+             XML->sys.pcie.number_units);
+    pcies.rt_power = pcie->rt_power * pppm_t;
+    rt_power = rt_power + pcies.rt_power;
   }
 
-  if (numNOC >0)
-  {
-	  for (i = 0;i < numNOC; i++)
-	  {
-		  if (XML->sys.NoC[i].type)
-		  {//First add up area of routers if NoC is used
-			  nocs.push_back(new NoC(XML,i, &interface_ip, 1));
+  if (numNOC > 0) {
+    for (i = 0; i < numNOC; i++) {
+      if (XML->sys.NoC[i].type) {  // First add up area of routers if NoC is
+                                   // used
+        nocs.push_back(new NoC(XML, i, &interface_ip, 1));
 
-			  if (procdynp.homoNOC)
-			  {
-				  noc.area.set_area(noc.area.get_area() + nocs[i]->area.get_area()*procdynp.numNOC);
-				  area.set_area(area.get_area() + noc.area.get_area());
-			  }
-			  else
-			  {
-				  noc.area.set_area(noc.area.get_area() + nocs[i]->area.get_area());
-				  area.set_area(area.get_area() + nocs[i]->area.get_area());
-			  }
-		  }
-		  else
-		  {//Bus based interconnect
-			  nocs.push_back(new NoC(XML,i, &interface_ip, 1, sqrt(area.get_area()*XML->sys.NoC[i].chip_coverage)));
-			  if (procdynp.homoNOC){
-				  noc.area.set_area(noc.area.get_area() + nocs[i]->area.get_area()*procdynp.numNOC);
-				  area.set_area(area.get_area() + noc.area.get_area());
-			  }
-			  else
-			  {
-				  noc.area.set_area(noc.area.get_area() + nocs[i]->area.get_area());
-				  area.set_area(area.get_area() + nocs[i]->area.get_area());
-			  }
-		  }
-	  }
+        if (procdynp.homoNOC) {
+          noc.area.set_area(noc.area.get_area() +
+                            nocs[i]->area.get_area() * procdynp.numNOC);
+          area.set_area(area.get_area() + noc.area.get_area());
+        } else {
+          noc.area.set_area(noc.area.get_area() + nocs[i]->area.get_area());
+          area.set_area(area.get_area() + nocs[i]->area.get_area());
+        }
+      } else {  // Bus based interconnect
+        nocs.push_back(
+            new NoC(XML, i, &interface_ip, 1,
+                    sqrt(area.get_area() * XML->sys.NoC[i].chip_coverage)));
+        if (procdynp.homoNOC) {
+          noc.area.set_area(noc.area.get_area() +
+                            nocs[i]->area.get_area() * procdynp.numNOC);
+          area.set_area(area.get_area() + noc.area.get_area());
+        } else {
+          noc.area.set_area(noc.area.get_area() + nocs[i]->area.get_area());
+          area.set_area(area.get_area() + nocs[i]->area.get_area());
+        }
+      }
+    }
 
-	  /*
-	   * Compute global links associated with each NOC, if any. This must be done at the end (even after the NOC router part) since the total chip
-	   * area must be obtain to decide the link routing
-	   */
-	  for (i = 0;i < numNOC; i++)
-	  {
-		  if (nocs[i]->nocdynp.has_global_link && XML->sys.NoC[i].type)
-		  {
-			  nocs[i]->init_link_bus(sqrt(area.get_area()*XML->sys.NoC[i].chip_coverage));//compute global links
-			  if (procdynp.homoNOC)
-			  {
-				  noc.area.set_area(noc.area.get_area() + nocs[i]->link_bus_tot_per_Router.area.get_area()
-						  * nocs[i]->nocdynp.total_nodes
-						  * procdynp.numNOC);
-				  area.set_area(area.get_area() + nocs[i]->link_bus_tot_per_Router.area.get_area()
-						  * nocs[i]->nocdynp.total_nodes
-						  * procdynp.numNOC);
-			  }
-			  else
-			  {
-				  noc.area.set_area(noc.area.get_area() + nocs[i]->link_bus_tot_per_Router.area.get_area()
-						  * nocs[i]->nocdynp.total_nodes);
-				  area.set_area(area.get_area() + nocs[i]->link_bus_tot_per_Router.area.get_area()
-						  * nocs[i]->nocdynp.total_nodes);
-			  }
-		  }
-	  }
-	  //Compute energy of NoC (w or w/o links) or buses
-	  for (i = 0;i < numNOC; i++)
-	  {
-		 //cout<<"******************COMPUTE NOC ENERGY********************"<<endl;
-		  nocs[i]->computeEnergy();
-		  nocs[i]->computeEnergy(false);
-		  if (procdynp.homoNOC){
-
-			  set_pppm(pppm_t,procdynp.numNOC*nocs[i]->nocdynp.clockRate, procdynp.numNOC,procdynp.numNOC,procdynp.numNOC);
-			  noc.power = noc.power + nocs[i]->power*pppm_t;
-			  set_pppm(pppm_t,1/nocs[i]->nocdynp.executionTime, procdynp.numNOC,procdynp.numNOC,procdynp.numNOC);
-			  noc.rt_power = noc.rt_power + nocs[i]->rt_power*pppm_t;
-			  power = power  + noc.power;
-			  rt_power = rt_power  + noc.rt_power;
-		  }
-		  else
-		  {
-			  set_pppm(pppm_t,nocs[i]->nocdynp.clockRate, 1, 1, 1);
-			  noc.power = noc.power + nocs[i]->power*pppm_t;
-			  power = power  + nocs[i]->power*pppm_t;
-			  set_pppm(pppm_t,1/nocs[i]->nocdynp.executionTime, 1, 1, 1);
-			  noc.rt_power = noc.rt_power + nocs[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + nocs[i]->rt_power*pppm_t;
-
-
-		  }
-	  }
+    /*
+     * Compute global links associated with each NOC, if any. This must be done
+     * at the end (even after the NOC router part) since the total chip area
+     * must be obtain to decide the link routing
+     */
+    for (i = 0; i < numNOC; i++) {
+      if (nocs[i]->nocdynp.has_global_link && XML->sys.NoC[i].type) {
+        nocs[i]->init_link_bus(
+            sqrt(area.get_area() *
+                 XML->sys.NoC[i].chip_coverage));  // compute global links
+        if (procdynp.homoNOC) {
+          noc.area.set_area(noc.area.get_area() +
+                            nocs[i]->link_bus_tot_per_Router.area.get_area() *
+                                nocs[i]->nocdynp.total_nodes * procdynp.numNOC);
+          area.set_area(area.get_area() +
+                        nocs[i]->link_bus_tot_per_Router.area.get_area() *
+                            nocs[i]->nocdynp.total_nodes * procdynp.numNOC);
+        } else {
+          noc.area.set_area(noc.area.get_area() +
+                            nocs[i]->link_bus_tot_per_Router.area.get_area() *
+                                nocs[i]->nocdynp.total_nodes);
+          area.set_area(area.get_area() +
+                        nocs[i]->link_bus_tot_per_Router.area.get_area() *
+                            nocs[i]->nocdynp.total_nodes);
+        }
+      }
+    }
+    // Compute energy of NoC (w or w/o links) or buses
+    for (i = 0; i < numNOC; i++) {
+      // cout<<"******************COMPUTE NOC ENERGY********************"<<endl;
+      nocs[i]->computeEnergy();
+      nocs[i]->computeEnergy(false);
+      if (procdynp.homoNOC) {
+        set_pppm(pppm_t, procdynp.numNOC * nocs[i]->nocdynp.clockRate,
+                 procdynp.numNOC, procdynp.numNOC, procdynp.numNOC);
+        noc.power = noc.power + nocs[i]->power * pppm_t;
+        set_pppm(pppm_t, 1 / nocs[i]->nocdynp.executionTime, procdynp.numNOC,
+                 procdynp.numNOC, procdynp.numNOC);
+        noc.rt_power = noc.rt_power + nocs[i]->rt_power * pppm_t;
+        power = power + noc.power;
+        rt_power = rt_power + noc.rt_power;
+      } else {
+        set_pppm(pppm_t, nocs[i]->nocdynp.clockRate, 1, 1, 1);
+        noc.power = noc.power + nocs[i]->power * pppm_t;
+        power = power + nocs[i]->power * pppm_t;
+        set_pppm(pppm_t, 1 / nocs[i]->nocdynp.executionTime, 1, 1, 1);
+        noc.rt_power = noc.rt_power + nocs[i]->rt_power * pppm_t;
+        rt_power = rt_power + nocs[i]->rt_power * pppm_t;
+      }
+    }
   }
 
-//  //clock power
-//  globalClock.init_wire_external(is_default, &interface_ip);
-//  globalClock.clk_area           =area*1e6; //change it from mm^2 to um^2
-//  globalClock.end_wiring_level   =5;//toplevel metal
-//  globalClock.start_wiring_level =5;//toplevel metal
-//  globalClock.l_ip.with_clock_grid=false;//global clock does not drive local final nodes
-//  globalClock.optimize_wire();
+  //  //clock power
+  //  globalClock.init_wire_external(is_default, &interface_ip);
+  //  globalClock.clk_area           =area*1e6; //change it from mm^2 to um^2
+  //  globalClock.end_wiring_level   =5;//toplevel metal
+  //  globalClock.start_wiring_level =5;//toplevel metal
+  //  globalClock.l_ip.with_clock_grid=false;//global clock does not drive local
+  //  final nodes globalClock.optimize_wire();
 }
 
-void Processor::compute () 
-{
+void Processor::compute() {
   int i;
-  double pppm_t[4]    = {1,1,1,1};
+  double pppm_t[4] = {1, 1, 1, 1};
 
   rt_power.reset();
-  //power.reset();
-  //core.power.reset();
+  // power.reset();
+  // core.power.reset();
 
   core.rt_power.reset();
-  for (i = 0;i < numCore; i++)
-  {
-      cores[i]->executionTime = XML->sys.total_cycles /(XML->sys.core[i].clock_rate*1e6); 
-      cores[i]->rt_power.reset();
-		  cores[i]->compute();
-		  //cores[i]->computeEnergy(false);
-		  if (procdynp.homoCore){
-			  set_pppm(pppm_t,1/cores[i]->executionTime, procdynp.numCore,procdynp.numCore,procdynp.numCore);
-			  core.rt_power = core.rt_power + cores[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + core.rt_power;
-		  }
-		  else{
-			  set_pppm(pppm_t,1/cores[i]->executionTime, 1, 1, 1);
-			  core.rt_power = core.rt_power + cores[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + cores[i]->rt_power*pppm_t;
-		  }
+  for (i = 0; i < numCore; i++) {
+    cores[i]->executionTime =
+        XML->sys.total_cycles / (XML->sys.core[i].clock_rate * 1e6);
+    cores[i]->rt_power.reset();
+    cores[i]->compute();
+    // cores[i]->computeEnergy(false);
+    if (procdynp.homoCore) {
+      set_pppm(pppm_t, 1 / cores[i]->executionTime, procdynp.numCore,
+               procdynp.numCore, procdynp.numCore);
+      core.rt_power = core.rt_power + cores[i]->rt_power * pppm_t;
+      rt_power = rt_power + core.rt_power;
+    } else {
+      set_pppm(pppm_t, 1 / cores[i]->executionTime, 1, 1, 1);
+      core.rt_power = core.rt_power + cores[i]->rt_power * pppm_t;
+      rt_power = rt_power + cores[i]->rt_power * pppm_t;
+    }
   }
 
-  if (!XML->sys.Private_L2)
-  {
-  if (numL2 >0)
-    l2.rt_power.reset();
-	  for (i = 0;i < numL2; i++)
-	  {
+  if (!XML->sys.Private_L2) {
+    if (numL2 > 0) l2.rt_power.reset();
+    for (i = 0; i < numL2; i++) {
       l2array[i]->rt_power.reset();
-		l2array[i]->cachep.executionTime=XML->sys.total_cycles /(XML->sys.core[0].clock_rate*1e6);
-		  l2array[i]->computeEnergy(false);
-		  if (procdynp.homoL2){
-			  set_pppm(pppm_t,1/l2array[i]->cachep.executionTime, procdynp.numL2,procdynp.numL2,procdynp.numL2);
-			  l2.rt_power = l2.rt_power + l2array[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + l2.rt_power;
-		  }
-		  else{
-			  set_pppm(pppm_t,1/l2array[i]->cachep.executionTime, 1, 1, 1);
-			  l2.rt_power = l2.rt_power + l2array[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + l2array[i]->rt_power*pppm_t;
-		  }
-	  }
+      l2array[i]->cachep.executionTime =
+          XML->sys.total_cycles / (XML->sys.core[0].clock_rate * 1e6);
+      l2array[i]->computeEnergy(false);
+      if (procdynp.homoL2) {
+        set_pppm(pppm_t, 1 / l2array[i]->cachep.executionTime, procdynp.numL2,
+                 procdynp.numL2, procdynp.numL2);
+        l2.rt_power = l2.rt_power + l2array[i]->rt_power * pppm_t;
+        rt_power = rt_power + l2.rt_power;
+      } else {
+        set_pppm(pppm_t, 1 / l2array[i]->cachep.executionTime, 1, 1, 1);
+        l2.rt_power = l2.rt_power + l2array[i]->rt_power * pppm_t;
+        rt_power = rt_power + l2array[i]->rt_power * pppm_t;
+      }
+    }
   }
 
   l3.rt_power.reset();
-  if (numL3 >0)
-	  for (i = 0;i < numL3; i++)
-	  {
-		  l3array[i]->rt_power.reset();
-		  l3array[i]->computeEnergy(false);
-		  if (procdynp.homoL3){
-			  set_pppm(pppm_t,1/l3array[i]->cachep.executionTime, procdynp.numL3,procdynp.numL3,procdynp.numL3);
-        l3.rt_power = l3.rt_power + l3array[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + l3.rt_power;
+  if (numL3 > 0)
+    for (i = 0; i < numL3; i++) {
+      l3array[i]->rt_power.reset();
+      l3array[i]->computeEnergy(false);
+      if (procdynp.homoL3) {
+        set_pppm(pppm_t, 1 / l3array[i]->cachep.executionTime, procdynp.numL3,
+                 procdynp.numL3, procdynp.numL3);
+        l3.rt_power = l3.rt_power + l3array[i]->rt_power * pppm_t;
+        rt_power = rt_power + l3.rt_power;
 
-		  }
-		  else{
-			  set_pppm(pppm_t,1/l3array[i]->cachep.executionTime, 1, 1, 1);
-        l3.rt_power = l3.rt_power + l3array[i]->rt_power*pppm_t;
-        rt_power = rt_power  + l3array[i]->rt_power*pppm_t;
-
-		  }
-	  }
+      } else {
+        set_pppm(pppm_t, 1 / l3array[i]->cachep.executionTime, 1, 1, 1);
+        l3.rt_power = l3.rt_power + l3array[i]->rt_power * pppm_t;
+        rt_power = rt_power + l3array[i]->rt_power * pppm_t;
+      }
+    }
 
   l1dir.rt_power.reset();
-  if (numL1Dir >0)
-	  for (i = 0;i < numL1Dir; i++)
-	  {
-		  l1dirarray[i]->rt_power.reset();
-		  l1dirarray[i]->computeEnergy(false);
-		  if (procdynp.homoL1Dir){
-			  set_pppm(pppm_t,1/l1dirarray[i]->cachep.executionTime, procdynp.numL1Dir,procdynp.numL1Dir,procdynp.numL1Dir);
-        l1dir.rt_power = l1dir.rt_power + l1dirarray[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + l1dir.rt_power;
+  if (numL1Dir > 0)
+    for (i = 0; i < numL1Dir; i++) {
+      l1dirarray[i]->rt_power.reset();
+      l1dirarray[i]->computeEnergy(false);
+      if (procdynp.homoL1Dir) {
+        set_pppm(pppm_t, 1 / l1dirarray[i]->cachep.executionTime,
+                 procdynp.numL1Dir, procdynp.numL1Dir, procdynp.numL1Dir);
+        l1dir.rt_power = l1dir.rt_power + l1dirarray[i]->rt_power * pppm_t;
+        rt_power = rt_power + l1dir.rt_power;
 
-		  }
-		  else{
-			  set_pppm(pppm_t,1/l1dirarray[i]->cachep.executionTime, 1, 1, 1);
-        l1dir.rt_power = l1dir.rt_power + l1dirarray[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + l1dirarray[i]->rt_power;
-		  }
-	  }
-
+      } else {
+        set_pppm(pppm_t, 1 / l1dirarray[i]->cachep.executionTime, 1, 1, 1);
+        l1dir.rt_power = l1dir.rt_power + l1dirarray[i]->rt_power * pppm_t;
+        rt_power = rt_power + l1dirarray[i]->rt_power;
+      }
+    }
 
   l2dir.rt_power.reset();
-  if (numL2Dir >0)
-	  for (i = 0;i < numL2Dir; i++)
-	  {
-		  l2dirarray[i]->rt_power.reset();
-		  l2dirarray[i]->computeEnergy(false);
-		  if (procdynp.homoL2Dir){
-			  set_pppm(pppm_t,1/l2dirarray[i]->cachep.executionTime, procdynp.numL2Dir,procdynp.numL2Dir,procdynp.numL2Dir);
-        l2dir.rt_power = l2dir.rt_power + l2dirarray[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + l2dir.rt_power;
+  if (numL2Dir > 0)
+    for (i = 0; i < numL2Dir; i++) {
+      l2dirarray[i]->rt_power.reset();
+      l2dirarray[i]->computeEnergy(false);
+      if (procdynp.homoL2Dir) {
+        set_pppm(pppm_t, 1 / l2dirarray[i]->cachep.executionTime,
+                 procdynp.numL2Dir, procdynp.numL2Dir, procdynp.numL2Dir);
+        l2dir.rt_power = l2dir.rt_power + l2dirarray[i]->rt_power * pppm_t;
+        rt_power = rt_power + l2dir.rt_power;
 
-		  }
-		  else{
-			  set_pppm(pppm_t,1/l2dirarray[i]->cachep.executionTime, 1, 1, 1);
-        l2dir.rt_power = l2dir.rt_power + l2dirarray[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + l2dirarray[i]->rt_power*pppm_t;
-		  }
-	  }
-
+      } else {
+        set_pppm(pppm_t, 1 / l2dirarray[i]->cachep.executionTime, 1, 1, 1);
+        l2dir.rt_power = l2dir.rt_power + l2dirarray[i]->rt_power * pppm_t;
+        rt_power = rt_power + l2dirarray[i]->rt_power * pppm_t;
+      }
+    }
 
   mcs.rt_power.reset();
-  if (XML->sys.mc.number_mcs >0 && XML->sys.mc.memory_channels_per_mc>0)
-  {
-	  mc->rt_power.reset();
-    mc->mcp.executionTime = XML->sys.total_cycles /(XML->sys.core[0].clock_rate*1e6); //Jingwen
-	  mc->computeEnergy(false);
-	  set_pppm(pppm_t,1/mc->mcp.executionTime, XML->sys.mc.number_mcs,XML->sys.mc.number_mcs,XML->sys.mc.number_mcs);
-	  mcs.rt_power = mc->rt_power*pppm_t;
-	  rt_power = rt_power  + mcs.rt_power;
-
-  }
-  
-
-/*  
-  if (XML->sys.flashc.number_mcs >0 )//flash controller
-  {
-	  flashcontrollers.rt_power.reset();
-	  flashcontroller->computeEnergy(false);
-	  double number_fcs = flashcontroller->fcp.num_mcs;
-	  set_pppm(pppm_t,number_fcs , number_fcs ,number_fcs ,number_fcs );
-	  flashcontrollers.rt_power = flashcontroller->rt_power*pppm_t;
-	  rt_power = rt_power  + flashcontrollers.rt_power;
-
+  if (XML->sys.mc.number_mcs > 0 && XML->sys.mc.memory_channels_per_mc > 0) {
+    mc->rt_power.reset();
+    mc->mcp.executionTime =
+        XML->sys.total_cycles / (XML->sys.core[0].clock_rate * 1e6);  // Jingwen
+    mc->computeEnergy(false);
+    set_pppm(pppm_t, 1 / mc->mcp.executionTime, XML->sys.mc.number_mcs,
+             XML->sys.mc.number_mcs, XML->sys.mc.number_mcs);
+    mcs.rt_power = mc->rt_power * pppm_t;
+    rt_power = rt_power + mcs.rt_power;
   }
 
-  if (XML->sys.niu.number_units >0)
-  {
-	  niu->computeEnergy(false);
-	  nius.rt_power.reset();
-	  set_pppm(pppm_t,XML->sys.niu.number_units*niu->niup.clockRate, XML->sys.niu.number_units,XML->sys.niu.number_units,XML->sys.niu.number_units);
-	  nius.rt_power = niu->rt_power*pppm_t;
-	  rt_power = rt_power  + nius.rt_power;
+  /*
+    if (XML->sys.flashc.number_mcs >0 )//flash controller
+    {
+            flashcontrollers.rt_power.reset();
+            flashcontroller->computeEnergy(false);
+            double number_fcs = flashcontroller->fcp.num_mcs;
+            set_pppm(pppm_t,number_fcs , number_fcs ,number_fcs ,number_fcs );
+            flashcontrollers.rt_power = flashcontroller->rt_power*pppm_t;
+            rt_power = rt_power  + flashcontrollers.rt_power;
 
+    }
+
+    if (XML->sys.niu.number_units >0)
+    {
+            niu->computeEnergy(false);
+            nius.rt_power.reset();
+            set_pppm(pppm_t,XML->sys.niu.number_units*niu->niup.clockRate,
+    XML->sys.niu.number_units,XML->sys.niu.number_units,XML->sys.niu.number_units);
+            nius.rt_power = niu->rt_power*pppm_t;
+            rt_power = rt_power  + nius.rt_power;
+
+    }
+
+    if (XML->sys.pcie.number_units >0 && XML->sys.pcie.num_channels >0)
+    {
+            pcie->computeEnergy(false);
+            pcies.rt_power.reset();
+            set_pppm(pppm_t,XML->sys.pcie.number_units*pcie->pciep.clockRate,
+    XML->sys.pcie.number_units,XML->sys.pcie.number_units,XML->sys.pcie.number_units);
+            pcies.rt_power = pcie->rt_power*pppm_t;
+            rt_power = rt_power  + pcies.rt_power;
+
+    }
+
+
+             // * Compute global links associated with each NOC, if any. This
+    must be done at the end (even after the NOC router part) since the total
+    chip
+             // * area must be obtain to decide the link routing
+            */
+  // Compute energy of NoC (w or w/o links) or buses
+  noc.rt_power.reset();
+  for (i = 0; i < numNOC; i++) {
+    nocs[i]->nocdynp.executionTime =
+        XML->sys.total_cycles / (XML->sys.core[0].clock_rate * 1e6);
+    nocs[i]->computeEnergy(false);
+    if (procdynp.homoNOC) {
+      set_pppm(pppm_t, 1 / nocs[i]->nocdynp.executionTime, procdynp.numNOC,
+               procdynp.numNOC, procdynp.numNOC);
+      noc.rt_power = noc.rt_power + nocs[i]->rt_power * pppm_t;
+      rt_power = rt_power + noc.rt_power;
+    } else {
+      set_pppm(pppm_t, 1 / nocs[i]->nocdynp.executionTime, 1, 1, 1);
+      noc.rt_power = noc.rt_power + nocs[i]->rt_power * pppm_t;
+      rt_power = rt_power + nocs[i]->rt_power * pppm_t;
+    }
   }
 
-  if (XML->sys.pcie.number_units >0 && XML->sys.pcie.num_channels >0)
-  {
-	  pcie->computeEnergy(false);
-	  pcies.rt_power.reset();
-	  set_pppm(pppm_t,XML->sys.pcie.number_units*pcie->pciep.clockRate, XML->sys.pcie.number_units,XML->sys.pcie.number_units,XML->sys.pcie.number_units);
-	  pcies.rt_power = pcie->rt_power*pppm_t;
-	  rt_power = rt_power  + pcies.rt_power;
+  //  //clock power
+  //  globalClock.init_wire_external(is_default, &interface_ip);
+  //  globalClock.clk_area           =area*1e6; //change it from mm^2 to um^2
+  //  globalClock.end_wiring_level   =5;//toplevel metal
+  //  globalClock.start_wiring_level =5;//toplevel metal
+  //  globalClock.l_ip.with_clock_grid=false;//global clock does not drive local
+  //  final nodes globalClock.optimize_wire();
+}
 
+void Processor::displayDeviceType(int device_type_, uint32_t indent) {
+  string indent_str(indent, ' ');
+
+  switch (device_type_) {
+    case 0:
+      cout << indent_str << "Device Type= "
+           << "ITRS high performance device type" << endl;
+      break;
+    case 1:
+      cout << indent_str << "Device Type= "
+           << "ITRS low standby power device type" << endl;
+      break;
+    case 2:
+      cout << indent_str << "Device Type= "
+           << "ITRS low operating power device type" << endl;
+      break;
+    case 3:
+      cout << indent_str << "Device Type= "
+           << "LP-DRAM device type" << endl;
+      break;
+    case 4:
+      cout << indent_str << "Device Type= "
+           << "COMM-DRAM device type" << endl;
+      break;
+    default: {
+      cout << indent_str << "Unknown Device Type" << endl;
+      exit(0);
+    }
   }
-
-	  
-	   // * Compute global links associated with each NOC, if any. This must be done at the end (even after the NOC router part) since the total chip
-	   // * area must be obtain to decide the link routing
-	  */ 
-	  //Compute energy of NoC (w or w/o links) or buses
-    noc.rt_power.reset();
-	  for (i = 0;i < numNOC; i++)
-	  {
-		 nocs[i]->nocdynp.executionTime=XML->sys.total_cycles /(XML->sys.core[0].clock_rate*1e6);
-		  nocs[i]->computeEnergy(false);
-		  if (procdynp.homoNOC){
-			  set_pppm(pppm_t,1/nocs[i]->nocdynp.executionTime, procdynp.numNOC,procdynp.numNOC,procdynp.numNOC);
-			  noc.rt_power = noc.rt_power + nocs[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + noc.rt_power;
-		  }
-		  else
-		  {
-			  set_pppm(pppm_t,1/nocs[i]->nocdynp.executionTime, 1, 1, 1);
-			  noc.rt_power = noc.rt_power + nocs[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + nocs[i]->rt_power*pppm_t;
-		  }
-	  } 
-    
-
-//  //clock power
-//  globalClock.init_wire_external(is_default, &interface_ip);
-//  globalClock.clk_area           =area*1e6; //change it from mm^2 to um^2
-//  globalClock.end_wiring_level   =5;//toplevel metal
-//  globalClock.start_wiring_level =5;//toplevel metal
-//  globalClock.l_ip.with_clock_grid=false;//global clock does not drive local final nodes
-//  globalClock.optimize_wire();
-
 }
 
-void Processor::displayDeviceType(int device_type_, uint32_t indent)
-{
-	string indent_str(indent, ' ');
+void Processor::displayInterconnectType(int interconnect_type_,
+                                        uint32_t indent) {
+  string indent_str(indent, ' ');
 
-	switch ( device_type_ ) {
-
-	  case 0 :
-		  cout <<indent_str<<"Device Type= "<<"ITRS high performance device type"<<endl;
-	    break;
-	  case 1 :
-		  cout <<indent_str<<"Device Type= "<<"ITRS low standby power device type"<<endl;
-	    break;
-	  case 2 :
-		  cout <<indent_str<<"Device Type= "<<"ITRS low operating power device type"<<endl;
-	    break;
-	  case 3 :
-		  cout <<indent_str<<"Device Type= "<<"LP-DRAM device type"<<endl;
-	    break;
-	  case 4 :
-		  cout <<indent_str<<"Device Type= "<<"COMM-DRAM device type"<<endl;
-	    break;
-	  default :
-		  {
-			  cout <<indent_str<<"Unknown Device Type"<<endl;
-			  exit(0);
-		  }
-	}
+  switch (interconnect_type_) {
+    case 0:
+      cout << indent_str << "Interconnect metal projection= "
+           << "aggressive interconnect technology projection" << endl;
+      break;
+    case 1:
+      cout << indent_str << "Interconnect metal projection= "
+           << "conservative interconnect technology projection" << endl;
+      break;
+    default: {
+      cout << indent_str << "Unknown Interconnect Projection Type" << endl;
+      exit(0);
+    }
+  }
 }
 
-void Processor::displayInterconnectType(int interconnect_type_, uint32_t indent)
-{
-	string indent_str(indent, ' ');
+void Processor::displayEnergy(uint32_t indent, int plevel, bool is_tdp_parm) {
+  int i;
+  bool long_channel = XML->sys.longer_channel_device;
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool is_tdp = is_tdp_parm;
+  if (is_tdp_parm) {
+    if (plevel < 5) {
+      cout
+          << "\nMcPAT (version " << VER_MAJOR << "." << VER_MINOR << " of "
+          << VER_UPDATE << ") results (current print level is " << plevel
+          << ", please increase print level to see the details in components): "
+          << endl;
+    } else {
+      cout << "\nMcPAT (version " << VER_MAJOR << "." << VER_MINOR << " of "
+           << VER_UPDATE << ") results  (current print level is 5)" << endl;
+    }
+    cout << "******************************************************************"
+            "***********************"
+         << endl;
+    cout << indent_str << "Technology " << XML->sys.core_tech_node << " nm"
+         << endl;
+    // cout <<indent_str<<"Device Type= "<<XML->sys.device_type<<endl;
+    if (long_channel)
+      cout << indent_str << "Using Long Channel Devices When Appropriate"
+           << endl;
+    // cout <<indent_str<<"Interconnect metal projection=
+    // "<<XML->sys.interconnect_projection_type<<endl;
+    displayInterconnectType(XML->sys.interconnect_projection_type, indent);
+    cout << indent_str << "Core clock Rate(MHz) " << XML->sys.core[0].clock_rate
+         << endl;
+    cout << endl;
+    cout << "******************************************************************"
+            "***********************"
+         << endl;
+    cout << "Processor: " << endl;
+    cout << indent_str << "Area = " << area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str << "Peak Power = "
+         << power.readOp.dynamic +
+                (long_channel ? power.readOp.longer_channel_leakage
+                              : power.readOp.leakage) +
+                power.readOp.gate_leakage
+         << " W" << endl;
+    cout << indent_str << "Total Leakage = "
+         << (long_channel ? power.readOp.longer_channel_leakage
+                          : power.readOp.leakage) +
+                power.readOp.gate_leakage
+         << " W" << endl;
+    cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic << " W"
+         << endl;
+    cout << indent_str << "Subthreshold Leakage = "
+         << (long_channel ? power.readOp.longer_channel_leakage
+                          : power.readOp.leakage)
+         << " W" << endl;
+    // cout << indent_str << "Subthreshold Leakage = " <<
+    // power.readOp.longer_channel_leakage <<" W" << endl;
+    cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str << "Runtime Dynamic = " << rt_power.readOp.dynamic
+         << " W" << endl;
+    cout << endl;
+    if (numCore > 0) {
+      cout << indent_str << "Total Cores: " << XML->sys.number_of_cores
+           << " cores " << endl;
+      displayDeviceType(XML->sys.device_type, indent);
+      cout << indent_str_next << "Area = " << core.area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next << "Peak Dynamic = " << core.power.readOp.dynamic
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? core.power.readOp.longer_channel_leakage
+                            : core.power.readOp.leakage)
+           << " W" << endl;
+      // cout << indent_str_next << "Subthreshold Leakage = " <<
+      // core.power.readOp.longer_channel_leakage <<" W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << core.power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next
+           << "Runtime Dynamic = " << core.rt_power.readOp.dynamic << " W"
+           << endl;
+      cout << endl;
+    }
+    if (!XML->sys.Private_L2) {
+      if (numL2 > 0) {
+        cout << indent_str << "Total L2s: " << endl;
+        displayDeviceType(XML->sys.L2[0].device_type, indent);
+        cout << indent_str_next << "Area = " << l2.area.get_area() * 1e-6
+             << " mm^2" << endl;
+        cout << indent_str_next << "Peak Dynamic = " << l2.power.readOp.dynamic
+             << " W" << endl;
+        cout << indent_str_next << "Subthreshold Leakage = "
+             << (long_channel ? l2.power.readOp.longer_channel_leakage
+                              : l2.power.readOp.leakage)
+             << " W" << endl;
+        // cout << indent_str_next << "Subthreshold Leakage = " <<
+        // l2.power.readOp.longer_channel_leakage <<" W" << endl;
+        cout << indent_str_next
+             << "Gate Leakage = " << l2.power.readOp.gate_leakage << " W"
+             << endl;
+        cout << indent_str_next
+             << "Runtime Dynamic = " << l2.rt_power.readOp.dynamic << " W"
+             << endl;
+        cout << endl;
+      }
+    }
+    if (numL3 > 0) {
+      cout << indent_str << "Total L3s: " << endl;
+      displayDeviceType(XML->sys.L3[0].device_type, indent);
+      cout << indent_str_next << "Area = " << l3.area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next << "Peak Dynamic = " << l3.power.readOp.dynamic
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? l3.power.readOp.longer_channel_leakage
+                            : l3.power.readOp.leakage)
+           << " W" << endl;
+      // cout << indent_str_next << "Subthreshold Leakage = " <<
+      // l3.power.readOp.longer_channel_leakage <<" W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << l3.power.readOp.gate_leakage << " W" << endl;
+      cout << indent_str_next
+           << "Runtime Dynamic = " << l3.rt_power.readOp.dynamic << " W"
+           << endl;
+      cout << endl;
+    }
+    if (numL1Dir > 0) {
+      cout << indent_str << "Total First Level Directory: " << endl;
+      displayDeviceType(XML->sys.L1Directory[0].device_type, indent);
+      cout << indent_str_next << "Area = " << l1dir.area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next << "Peak Dynamic = " << l1dir.power.readOp.dynamic
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? l1dir.power.readOp.longer_channel_leakage
+                            : l1dir.power.readOp.leakage)
+           << " W" << endl;
+      // cout << indent_str_next << "Subthreshold Leakage = " <<
+      // l1dir.power.readOp.longer_channel_leakage <<" W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << l1dir.power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next
+           << "Runtime Dynamic = " << l1dir.rt_power.readOp.dynamic << " W"
+           << endl;
+      cout << endl;
+    }
+    if (numL2Dir > 0) {
+      cout << indent_str << "Total First Level Directory: " << endl;
+      displayDeviceType(XML->sys.L1Directory[0].device_type, indent);
+      cout << indent_str_next << "Area = " << l2dir.area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next << "Peak Dynamic = " << l2dir.power.readOp.dynamic
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? l2dir.power.readOp.longer_channel_leakage
+                            : l2dir.power.readOp.leakage)
+           << " W" << endl;
+      // cout << indent_str_next << "Subthreshold Leakage = " <<
+      // l2dir.power.readOp.longer_channel_leakage <<" W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << l2dir.power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next
+           << "Runtime Dynamic = " << l2dir.rt_power.readOp.dynamic << " W"
+           << endl;
+      cout << endl;
+    }
+    if (numNOC > 0) {
+      cout << indent_str << "Total NoCs (Network/Bus): " << endl;
+      displayDeviceType(XML->sys.device_type, indent);
+      cout << indent_str_next << "Area = " << noc.area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next << "Peak Dynamic = " << noc.power.readOp.dynamic
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? noc.power.readOp.longer_channel_leakage
+                            : noc.power.readOp.leakage)
+           << " W" << endl;
+      // cout << indent_str_next << "Subthreshold Leakage = " <<
+      // noc.power.readOp.longer_channel_leakage  <<" W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << noc.power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next
+           << "Runtime Dynamic = " << noc.rt_power.readOp.dynamic << " W"
+           << endl;
+      cout << endl;
+    }
+    if (XML->sys.mc.number_mcs > 0 && XML->sys.mc.memory_channels_per_mc > 0) {
+      cout << indent_str << "Total MCs: " << XML->sys.mc.number_mcs
+           << " Memory Controllers " << endl;
+      displayDeviceType(XML->sys.device_type, indent);
+      cout << indent_str_next << "Area = " << mcs.area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next << "Peak Dynamic = " << mcs.power.readOp.dynamic
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? mcs.power.readOp.longer_channel_leakage
+                            : mcs.power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << mcs.power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next
+           << "Runtime Dynamic = " << mcs.rt_power.readOp.dynamic << " W"
+           << endl;
+      cout << endl;
+    }
+    if (XML->sys.flashc.number_mcs > 0) {
+      cout << indent_str
+           << "Total Flash/SSD Controllers: " << flashcontroller->fcp.num_mcs
+           << " Flash/SSD Controllers " << endl;
+      displayDeviceType(XML->sys.device_type, indent);
+      cout << indent_str_next
+           << "Area = " << flashcontrollers.area.get_area() * 1e-6 << " mm^2"
+           << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << flashcontrollers.power.readOp.dynamic << " W"
+           << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel
+                   ? flashcontrollers.power.readOp.longer_channel_leakage
+                   : flashcontrollers.power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << flashcontrollers.power.readOp.gate_leakage
+           << " W" << endl;
+      cout << indent_str_next
+           << "Runtime Dynamic = " << flashcontrollers.rt_power.readOp.dynamic
+           << " W" << endl;
+      cout << endl;
+    }
+    if (XML->sys.niu.number_units > 0) {
+      cout << indent_str << "Total NIUs: " << niu->niup.num_units
+           << " Network Interface Units " << endl;
+      displayDeviceType(XML->sys.device_type, indent);
+      cout << indent_str_next << "Area = " << nius.area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next << "Peak Dynamic = " << nius.power.readOp.dynamic
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? nius.power.readOp.longer_channel_leakage
+                            : nius.power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << nius.power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next
+           << "Runtime Dynamic = " << nius.rt_power.readOp.dynamic << " W"
+           << endl;
+      cout << endl;
+    }
+    if (XML->sys.pcie.number_units > 0 && XML->sys.pcie.num_channels > 0) {
+      cout << indent_str << "Total PCIes: " << pcie->pciep.num_units
+           << " PCIe Controllers " << endl;
+      displayDeviceType(XML->sys.device_type, indent);
+      cout << indent_str_next << "Area = " << pcies.area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next << "Peak Dynamic = " << pcies.power.readOp.dynamic
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? pcies.power.readOp.longer_channel_leakage
+                            : pcies.power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << pcies.power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next
+           << "Runtime Dynamic = " << pcies.rt_power.readOp.dynamic << " W"
+           << endl;
+      cout << endl;
+    }
+    cout << "******************************************************************"
+            "***********************"
+         << endl;
+    if (plevel > 1) {
+      for (i = 0; i < numCore; i++) {
+        cores[i]->displayEnergy(indent + 4, plevel, is_tdp);
+        cout << "**************************************************************"
+                "***************************"
+             << endl;
+      }
+      if (!XML->sys.Private_L2) {
+        for (i = 0; i < numL2; i++) {
+          l2array[i]->displayEnergy(indent + 4, is_tdp);
+          cout << "************************************************************"
+                  "*****************************"
+               << endl;
+        }
+      }
+      for (i = 0; i < numL3; i++) {
+        l3array[i]->displayEnergy(indent + 4, is_tdp);
+        cout << "**************************************************************"
+                "***************************"
+             << endl;
+      }
+      for (i = 0; i < numL1Dir; i++) {
+        l1dirarray[i]->displayEnergy(indent + 4, is_tdp);
+        cout << "**************************************************************"
+                "***************************"
+             << endl;
+      }
+      for (i = 0; i < numL2Dir; i++) {
+        l2dirarray[i]->displayEnergy(indent + 4, is_tdp);
+        cout << "**************************************************************"
+                "***************************"
+             << endl;
+      }
+      if (XML->sys.mc.number_mcs > 0 &&
+          XML->sys.mc.memory_channels_per_mc > 0) {
+        mc->displayEnergy(indent + 4, is_tdp);
+        cout << "**************************************************************"
+                "***************************"
+             << endl;
+      }
+      if (XML->sys.flashc.number_mcs > 0 &&
+          XML->sys.flashc.memory_channels_per_mc > 0) {
+        flashcontroller->displayEnergy(indent + 4, is_tdp);
+        cout << "**************************************************************"
+                "***************************"
+             << endl;
+      }
+      if (XML->sys.niu.number_units > 0) {
+        niu->displayEnergy(indent + 4, is_tdp);
+        cout << "**************************************************************"
+                "***************************"
+             << endl;
+      }
+      if (XML->sys.pcie.number_units > 0 && XML->sys.pcie.num_channels > 0) {
+        pcie->displayEnergy(indent + 4, is_tdp);
+        cout << "**************************************************************"
+                "***************************"
+             << endl;
+      }
 
-	switch ( interconnect_type_ ) {
-
-	  case 0 :
-		  cout <<indent_str<<"Interconnect metal projection= "<<"aggressive interconnect technology projection"<<endl;
-	    break;
-	  case 1 :
-		  cout <<indent_str<<"Interconnect metal projection= "<<"conservative interconnect technology projection"<<endl;
-	    break;
-	  default :
-		  {
-			  cout <<indent_str<<"Unknown Interconnect Projection Type"<<endl;
-			  exit(0);
-		  }
-	}
+      for (i = 0; i < numNOC; i++) {
+        nocs[i]->displayEnergy(indent + 4, plevel, is_tdp);
+        cout << "**************************************************************"
+                "***************************"
+             << endl;
+      }
+    }
+  } else {
+  }
 }
 
-void Processor::displayEnergy(uint32_t indent, int plevel, bool is_tdp_parm)
-{
-	int i;
-	bool long_channel = XML->sys.longer_channel_device;
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool is_tdp=is_tdp_parm;
-	if (is_tdp_parm)
-	{
+void Processor::set_proc_param() {
+  bool debug = false;
 
+  procdynp.homoCore = bool(debug ? 1 : XML->sys.homogeneous_cores);
+  procdynp.homoL2 = bool(debug ? 1 : XML->sys.homogeneous_L2s);
+  procdynp.homoL3 = bool(debug ? 1 : XML->sys.homogeneous_L3s);
+  procdynp.homoNOC = bool(debug ? 1 : XML->sys.homogeneous_NoCs);
+  procdynp.homoL1Dir = bool(debug ? 1 : XML->sys.homogeneous_L1Directories);
+  procdynp.homoL2Dir = bool(debug ? 1 : XML->sys.homogeneous_L2Directories);
 
-		if (plevel<5)
-		{
-			cout<<"\nMcPAT (version "<< VER_MAJOR <<"."<< VER_MINOR
-					<< " of " << VER_UPDATE << ") results (current print level is "<< plevel
-			<<", please increase print level to see the details in components): "<<endl;
-		}
-		else
-		{
-			cout<<"\nMcPAT (version "<< VER_MAJOR <<"."<< VER_MINOR
-								<< " of " << VER_UPDATE << ") results  (current print level is 5)"<< endl;
-		}
-		cout <<"*****************************************************************************************"<<endl;
-		cout <<indent_str<<"Technology "<<XML->sys.core_tech_node<<" nm"<<endl;
-		//cout <<indent_str<<"Device Type= "<<XML->sys.device_type<<endl;
-		if (long_channel)
-			cout <<indent_str<<"Using Long Channel Devices When Appropriate"<<endl;
-		//cout <<indent_str<<"Interconnect metal projection= "<<XML->sys.interconnect_projection_type<<endl;
-		displayInterconnectType(XML->sys.interconnect_projection_type, indent);
-		cout <<indent_str<<"Core clock Rate(MHz) "<<XML->sys.core[0].clock_rate<<endl;
-    	cout <<endl;
-		cout <<"*****************************************************************************************"<<endl;
-		cout <<"Processor: "<<endl;
-		cout << indent_str << "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str << "Peak Power = " << power.readOp.dynamic +
-			(long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) + power.readOp.gate_leakage <<" W" << endl;
-		cout << indent_str << "Total Leakage = " <<
-			(long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) + power.readOp.gate_leakage <<" W" << endl;
-		cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic << " W" << endl;
-		cout << indent_str << "Subthreshold Leakage = " << (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
-		//cout << indent_str << "Subthreshold Leakage = " << power.readOp.longer_channel_leakage <<" W" << endl;
-		cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str << "Runtime Dynamic = " << rt_power.readOp.dynamic << " W" << endl;
-		cout <<endl;
-		if (numCore >0){
-		cout <<indent_str<<"Total Cores: "<<XML->sys.number_of_cores << " cores "<<endl;
-		displayDeviceType(XML->sys.device_type,indent);
-		cout << indent_str_next << "Area = " << core.area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << core.power.readOp.dynamic << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? core.power.readOp.longer_channel_leakage:core.power.readOp.leakage) <<" W" << endl;
-		//cout << indent_str_next << "Subthreshold Leakage = " << core.power.readOp.longer_channel_leakage <<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << core.power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << core.rt_power.readOp.dynamic << " W" << endl;
-		cout <<endl;
-		}
-		if (!XML->sys.Private_L2)
-		{
-			if (numL2 >0){
-				cout <<indent_str<<"Total L2s: "<<endl;
-				displayDeviceType(XML->sys.L2[0].device_type,indent);
-				cout << indent_str_next << "Area = " << l2.area.get_area()*1e-6<< " mm^2" << endl;
-				cout << indent_str_next << "Peak Dynamic = " << l2.power.readOp.dynamic << " W" << endl;
-				cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? l2.power.readOp.longer_channel_leakage:l2.power.readOp.leakage) <<" W" << endl;
-				//cout << indent_str_next << "Subthreshold Leakage = " << l2.power.readOp.longer_channel_leakage <<" W" << endl;
-				cout << indent_str_next << "Gate Leakage = " << l2.power.readOp.gate_leakage << " W" << endl;
-				cout << indent_str_next << "Runtime Dynamic = " << l2.rt_power.readOp.dynamic << " W" << endl;
-				cout <<endl;
-			}
-		}
-		if (numL3 >0){
-			cout <<indent_str<<"Total L3s: "<<endl;
-			displayDeviceType(XML->sys.L3[0].device_type, indent);
-			cout << indent_str_next << "Area = " << l3.area.get_area()*1e-6<< " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << l3.power.readOp.dynamic << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? l3.power.readOp.longer_channel_leakage:l3.power.readOp.leakage) <<" W" << endl;
-			//cout << indent_str_next << "Subthreshold Leakage = " << l3.power.readOp.longer_channel_leakage <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << l3.power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << l3.rt_power.readOp.dynamic << " W" << endl;
-			cout <<endl;
-		}
-		if (numL1Dir >0){
-			cout <<indent_str<<"Total First Level Directory: "<<endl;
-			displayDeviceType(XML->sys.L1Directory[0].device_type, indent);
-			cout << indent_str_next << "Area = " << l1dir.area.get_area()*1e-6<< " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << l1dir.power.readOp.dynamic << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? l1dir.power.readOp.longer_channel_leakage:l1dir.power.readOp.leakage) <<" W" << endl;
-			//cout << indent_str_next << "Subthreshold Leakage = " << l1dir.power.readOp.longer_channel_leakage <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << l1dir.power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << l1dir.rt_power.readOp.dynamic << " W" << endl;
-			cout <<endl;
-		}
-		if (numL2Dir >0){
-			cout <<indent_str<<"Total First Level Directory: "<<endl;
-			displayDeviceType(XML->sys.L1Directory[0].device_type, indent);
-			cout << indent_str_next << "Area = " << l2dir.area.get_area()*1e-6<< " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << l2dir.power.readOp.dynamic << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? l2dir.power.readOp.longer_channel_leakage:l2dir.power.readOp.leakage) <<" W" << endl;
-			//cout << indent_str_next << "Subthreshold Leakage = " << l2dir.power.readOp.longer_channel_leakage <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << l2dir.power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << l2dir.rt_power.readOp.dynamic << " W" << endl;
-			cout <<endl;
-		}
-		if (numNOC >0){
-			cout <<indent_str<<"Total NoCs (Network/Bus): "<<endl;
-			displayDeviceType(XML->sys.device_type, indent);
-			cout << indent_str_next << "Area = " << noc.area.get_area()*1e-6<< " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << noc.power.readOp.dynamic << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? noc.power.readOp.longer_channel_leakage:noc.power.readOp.leakage) <<" W" << endl;
-			//cout << indent_str_next << "Subthreshold Leakage = " << noc.power.readOp.longer_channel_leakage  <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << noc.power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << noc.rt_power.readOp.dynamic << " W" << endl;
-			cout <<endl;
-		}
-		if (XML->sys.mc.number_mcs >0 && XML->sys.mc.memory_channels_per_mc>0)
-		{
-			cout <<indent_str<<"Total MCs: "<<XML->sys.mc.number_mcs << " Memory Controllers "<<endl;
-			displayDeviceType(XML->sys.device_type, indent);
-			cout << indent_str_next << "Area = " << mcs.area.get_area()*1e-6<< " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << mcs.power.readOp.dynamic << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? mcs.power.readOp.longer_channel_leakage:mcs.power.readOp.leakage)  <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << mcs.power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << mcs.rt_power.readOp.dynamic << " W" << endl;
-			cout <<endl;
-		}
-		if (XML->sys.flashc.number_mcs >0)
-		{
-			cout <<indent_str<<"Total Flash/SSD Controllers: "<<flashcontroller->fcp.num_mcs << " Flash/SSD Controllers "<<endl;
-			displayDeviceType(XML->sys.device_type, indent);
-			cout << indent_str_next << "Area = " << flashcontrollers.area.get_area()*1e-6<< " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << flashcontrollers.power.readOp.dynamic << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? flashcontrollers.power.readOp.longer_channel_leakage:flashcontrollers.power.readOp.leakage)  <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << flashcontrollers.power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << flashcontrollers.rt_power.readOp.dynamic << " W" << endl;
-			cout <<endl;
-		}
-		if (XML->sys.niu.number_units >0 )
-		{
-			cout <<indent_str<<"Total NIUs: "<<niu->niup.num_units << " Network Interface Units "<<endl;
-			displayDeviceType(XML->sys.device_type, indent);
-			cout << indent_str_next << "Area = " << nius.area.get_area()*1e-6<< " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << nius.power.readOp.dynamic << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? nius.power.readOp.longer_channel_leakage:nius.power.readOp.leakage)  <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << nius.power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << nius.rt_power.readOp.dynamic << " W" << endl;
-			cout <<endl;
-		}
-		if (XML->sys.pcie.number_units >0 && XML->sys.pcie.num_channels>0)
-				{
-					cout <<indent_str<<"Total PCIes: "<<pcie->pciep.num_units << " PCIe Controllers "<<endl;
-					displayDeviceType(XML->sys.device_type, indent);
-					cout << indent_str_next << "Area = " << pcies.area.get_area()*1e-6<< " mm^2" << endl;
-					cout << indent_str_next << "Peak Dynamic = " << pcies.power.readOp.dynamic << " W" << endl;
-					cout << indent_str_next << "Subthreshold Leakage = "
-						<< (long_channel? pcies.power.readOp.longer_channel_leakage:pcies.power.readOp.leakage)  <<" W" << endl;
-					cout << indent_str_next << "Gate Leakage = " << pcies.power.readOp.gate_leakage << " W" << endl;
-					cout << indent_str_next << "Runtime Dynamic = " << pcies.rt_power.readOp.dynamic << " W" << endl;
-					cout <<endl;
-				}
-		cout <<"*****************************************************************************************"<<endl;
-		if (plevel >1)
-		{
-			for (i = 0;i < numCore; i++)
-			{
-				cores[i]->displayEnergy(indent+4,plevel,is_tdp);
-				cout <<"*****************************************************************************************"<<endl;
-			}
-			if (!XML->sys.Private_L2)
-			{
-				for (i = 0;i < numL2; i++)
-				{
-					l2array[i]->displayEnergy(indent+4,is_tdp);
-					cout <<"*****************************************************************************************"<<endl;
-				}
-			}
-			for (i = 0;i < numL3; i++)
-			{
-				l3array[i]->displayEnergy(indent+4,is_tdp);
-				cout <<"*****************************************************************************************"<<endl;
-			}
-			for (i = 0;i < numL1Dir; i++)
-			{
-				l1dirarray[i]->displayEnergy(indent+4,is_tdp);
-				cout <<"*****************************************************************************************"<<endl;
-			}
-			for (i = 0;i < numL2Dir; i++)
-			{
-				l2dirarray[i]->displayEnergy(indent+4,is_tdp);
-				cout <<"*****************************************************************************************"<<endl;
-			}
-			if (XML->sys.mc.number_mcs >0 && XML->sys.mc.memory_channels_per_mc>0)
-			{
-				mc->displayEnergy(indent+4,is_tdp);
-				cout <<"*****************************************************************************************"<<endl;
-			}
-			if (XML->sys.flashc.number_mcs >0 && XML->sys.flashc.memory_channels_per_mc>0)
-			{
-				flashcontroller->displayEnergy(indent+4,is_tdp);
-				cout <<"*****************************************************************************************"<<endl;
-			}
-			if (XML->sys.niu.number_units >0 )
-			{
-				niu->displayEnergy(indent+4,is_tdp);
-				cout <<"*****************************************************************************************"<<endl;
-			}
-			if (XML->sys.pcie.number_units >0 && XML->sys.pcie.num_channels>0)
-			{
-				pcie->displayEnergy(indent+4,is_tdp);
-				cout <<"*****************************************************************************************"<<endl;
-			}
+  procdynp.numCore = XML->sys.number_of_cores;
+  procdynp.numL2 = XML->sys.number_of_L2s;
+  procdynp.numL3 = XML->sys.number_of_L3s;
+  procdynp.numNOC = XML->sys.number_of_NoCs;
+  procdynp.numL1Dir = XML->sys.number_of_L1Directories;
+  procdynp.numL2Dir = XML->sys.number_of_L2Directories;
+  procdynp.numMC = XML->sys.mc.number_mcs;
+  procdynp.numMCChannel = XML->sys.mc.memory_channels_per_mc;
 
-			for (i = 0;i < numNOC; i++)
-			{
-				nocs[i]->displayEnergy(indent+4,plevel,is_tdp);
-				cout <<"*****************************************************************************************"<<endl;
-			}
-		}
-	}
-	else
-	{
+  //	if (procdynp.numCore<1)
+  //	{
+  //		cout<<" The target processor should at least have one core on
+  // chip."
+  //<<endl; 		exit(0);
+  //	}
 
-	}
+  //  if (numNOCs<0 || numNOCs>2)
+  //    {
+  //  	  cout <<"number of NOCs must be 1 (only global NOCs) or 2 (both global
+  //  and local NOCs)"<<endl; 	  exit(0);
+  //    }
 
+  /* Basic parameters*/
+  interface_ip.data_arr_ram_cell_tech_type = debug ? 0 : XML->sys.device_type;
+  interface_ip.data_arr_peri_global_tech_type =
+      debug ? 0 : XML->sys.device_type;
+  interface_ip.tag_arr_ram_cell_tech_type = debug ? 0 : XML->sys.device_type;
+  interface_ip.tag_arr_peri_global_tech_type = debug ? 0 : XML->sys.device_type;
+
+  interface_ip.ic_proj_type = debug ? 0 : XML->sys.interconnect_projection_type;
+  interface_ip.delay_wt =
+      100;                   // Fixed number, make sure timing can be satisfied.
+  interface_ip.area_wt = 0;  // Fixed number, This is used to exhaustive search
+                             // for individual components.
+  interface_ip.dynamic_power_wt =
+      100;  // Fixed number, This is used to exhaustive search for individual
+            // components.
+  interface_ip.leakage_power_wt = 0;
+  interface_ip.cycle_time_wt = 0;
+
+  interface_ip.delay_dev =
+      10000;  // Fixed number, make sure timing can be satisfied.
+  interface_ip.area_dev = 10000;  // Fixed number, This is used to exhaustive
+                                  // search for individual components.
+  interface_ip.dynamic_power_dev =
+      10000;  // Fixed number, This is used to exhaustive search for individual
+              // components.
+  interface_ip.leakage_power_dev = 10000;
+  interface_ip.cycle_time_dev = 10000;
+
+  interface_ip.ed = 2;
+  interface_ip.burst_len = 1;  // parameters are fixed for processor section,
+                               // since memory is processed separately
+  interface_ip.int_prefetch_w = 1;
+  interface_ip.page_sz_bits = 0;
+  interface_ip.temp = debug ? 360 : XML->sys.temperature;
+  interface_ip.F_sz_nm =
+      debug ? 90 : XML->sys.core_tech_node;  // XML->sys.core_tech_node;
+  interface_ip.F_sz_um = interface_ip.F_sz_nm / 1000;
+
+  //***********This section of code does not have real meaning, they are just to
+  // ensure all data will have initial value to prevent errors. They will be
+  // overridden  during each components initialization
+  interface_ip.cache_sz = 64;
+  interface_ip.line_sz = 1;
+  interface_ip.assoc = 1;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = 64;
+  interface_ip.access_mode = 2;
+
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+
+  interface_ip.is_main_mem = false;
+  interface_ip.rpters_in_htree = true;
+  interface_ip.ver_htree_wires_over_array = 0;
+  interface_ip.broadcast_addr_din_over_ver_htrees = 0;
+
+  interface_ip.num_rw_ports = 1;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  interface_ip.num_search_ports = 1;
+  interface_ip.nuca = 0;
+  interface_ip.nuca_bank_count = 0;
+  interface_ip.is_cache = true;
+  interface_ip.pure_ram = false;
+  interface_ip.pure_cam = false;
+  interface_ip.force_cache_config = false;
+  if (XML->sys.Embedded) {
+    interface_ip.wt = Global_30;
+    interface_ip.wire_is_mat_type = 0;
+    interface_ip.wire_os_mat_type = 0;
+  } else {
+    interface_ip.wt = Global;
+    interface_ip.wire_is_mat_type = 2;
+    interface_ip.wire_os_mat_type = 2;
+  }
+  interface_ip.force_wiretype = false;
+  interface_ip.print_detail = 1;
+  interface_ip.add_ecc_b_ = true;
 }
 
-void Processor::set_proc_param()
-{
-	bool debug = false;
-
-	procdynp.homoCore = bool(debug?1:XML->sys.homogeneous_cores);
-	procdynp.homoL2   = bool(debug?1:XML->sys.homogeneous_L2s);
-	procdynp.homoL3   = bool(debug?1:XML->sys.homogeneous_L3s);
-	procdynp.homoNOC  = bool(debug?1:XML->sys.homogeneous_NoCs);
-	procdynp.homoL1Dir  = bool(debug?1:XML->sys.homogeneous_L1Directories);
-	procdynp.homoL2Dir  = bool(debug?1:XML->sys.homogeneous_L2Directories);
-
-	procdynp.numCore = XML->sys.number_of_cores;
-	procdynp.numL2   = XML->sys.number_of_L2s;
-	procdynp.numL3   = XML->sys.number_of_L3s;
-	procdynp.numNOC  = XML->sys.number_of_NoCs;
-	procdynp.numL1Dir  = XML->sys.number_of_L1Directories;
-	procdynp.numL2Dir  = XML->sys.number_of_L2Directories;
-	procdynp.numMC = XML->sys.mc.number_mcs;
-	procdynp.numMCChannel = XML->sys.mc.memory_channels_per_mc;
-
-//	if (procdynp.numCore<1)
-//	{
-//		cout<<" The target processor should at least have one core on chip." <<endl;
-//		exit(0);
-//	}
-
-	//  if (numNOCs<0 || numNOCs>2)
-	//    {
-	//  	  cout <<"number of NOCs must be 1 (only global NOCs) or 2 (both global and local NOCs)"<<endl;
-	//  	  exit(0);
-	//    }
-
-	/* Basic parameters*/
-	interface_ip.data_arr_ram_cell_tech_type    = debug?0:XML->sys.device_type;
-	interface_ip.data_arr_peri_global_tech_type = debug?0:XML->sys.device_type;
-	interface_ip.tag_arr_ram_cell_tech_type     = debug?0:XML->sys.device_type;
-	interface_ip.tag_arr_peri_global_tech_type  = debug?0:XML->sys.device_type;
-
-	interface_ip.ic_proj_type     = debug?0:XML->sys.interconnect_projection_type;
-	interface_ip.delay_wt                = 100;//Fixed number, make sure timing can be satisfied.
-	interface_ip.area_wt                 = 0;//Fixed number, This is used to exhaustive search for individual components.
-	interface_ip.dynamic_power_wt        = 100;//Fixed number, This is used to exhaustive search for individual components.
-	interface_ip.leakage_power_wt        = 0;
-	interface_ip.cycle_time_wt           = 0;
-
-	interface_ip.delay_dev                = 10000;//Fixed number, make sure timing can be satisfied.
-	interface_ip.area_dev                 = 10000;//Fixed number, This is used to exhaustive search for individual components.
-	interface_ip.dynamic_power_dev        = 10000;//Fixed number, This is used to exhaustive search for individual components.
-	interface_ip.leakage_power_dev        = 10000;
-	interface_ip.cycle_time_dev           = 10000;
-
-	interface_ip.ed                       = 2;
-	interface_ip.burst_len      = 1;//parameters are fixed for processor section, since memory is processed separately
-	interface_ip.int_prefetch_w = 1;
-	interface_ip.page_sz_bits   = 0;
-	interface_ip.temp = debug?360: XML->sys.temperature;
-	interface_ip.F_sz_nm         = debug?90:XML->sys.core_tech_node;//XML->sys.core_tech_node;
-	interface_ip.F_sz_um         = interface_ip.F_sz_nm / 1000;
-
-	//***********This section of code does not have real meaning, they are just to ensure all data will have initial value to prevent errors.
-	//They will be overridden  during each components initialization
-	interface_ip.cache_sz            =64;
-	interface_ip.line_sz             = 1;
-	interface_ip.assoc               = 1;
-	interface_ip.nbanks              = 1;
-	interface_ip.out_w               = interface_ip.line_sz*8;
-	interface_ip.specific_tag        = 1;
-	interface_ip.tag_w               = 64;
-	interface_ip.access_mode         = 2;
-
-	interface_ip.obj_func_dyn_energy = 0;
-	interface_ip.obj_func_dyn_power  = 0;
-	interface_ip.obj_func_leak_power = 0;
-	interface_ip.obj_func_cycle_t    = 1;
-
-	interface_ip.is_main_mem     = false;
-	interface_ip.rpters_in_htree = true ;
-	interface_ip.ver_htree_wires_over_array = 0;
-	interface_ip.broadcast_addr_din_over_ver_htrees = 0;
-
-	interface_ip.num_rw_ports        = 1;
-	interface_ip.num_rd_ports        = 0;
-	interface_ip.num_wr_ports        = 0;
-	interface_ip.num_se_rd_ports     = 0;
-	interface_ip.num_search_ports    = 1;
-	interface_ip.nuca                = 0;
-	interface_ip.nuca_bank_count     = 0;
-	interface_ip.is_cache            =true;
-	interface_ip.pure_ram            =false;
-	interface_ip.pure_cam            =false;
-	interface_ip.force_cache_config  =false;
-	if (XML->sys.Embedded)
-		{
-		interface_ip.wt                  =Global_30;
-		interface_ip.wire_is_mat_type = 0;
-		interface_ip.wire_os_mat_type = 0;
-		}
-	else
-		{
-		interface_ip.wt                  =Global;
-		interface_ip.wire_is_mat_type = 2;
-		interface_ip.wire_os_mat_type = 2;
-		}
-	interface_ip.force_wiretype      = false;
-	interface_ip.print_detail        = 1;
-	interface_ip.add_ecc_b_          =true;
-}
-
-
-Processor::~Processor(){
-	while (!cores.empty())
-	{
-		delete cores.back();
-		cores.pop_back();
-	}
-	while (!l2array.empty())
-	{
-		delete l2array.back();
-		l2array.pop_back();
-	}
-	while (!l3array.empty())
-	{
-		delete l3array.back();
-		l3array.pop_back();
-	}
-	while (!nocs.empty())
-	{
-		delete nocs.back();
-		nocs.pop_back();
-	}
-	if (!mc)
-	{
-		delete mc;
-	}
-	if (!niu)
-	{
-		delete niu;
-	}
-	if (!pcie)
-	{
-		delete pcie;
-	}
-	if (!flashcontroller)
-	{
-		delete flashcontroller;
-	}
+Processor::~Processor() {
+  while (!cores.empty()) {
+    delete cores.back();
+    cores.pop_back();
+  }
+  while (!l2array.empty()) {
+    delete l2array.back();
+    l2array.pop_back();
+  }
+  while (!l3array.empty()) {
+    delete l3array.back();
+    l3array.pop_back();
+  }
+  while (!nocs.empty()) {
+    delete nocs.back();
+    nocs.pop_back();
+  }
+  if (!mc) {
+    delete mc;
+  }
+  if (!niu) {
+    delete niu;
+  }
+  if (!pcie) {
+    delete pcie;
+  }
+  if (!flashcontroller) {
+    delete flashcontroller;
+  }
 };
-
-

--- a/src/gpuwattch/processor.cc
+++ b/src/gpuwattch/processor.cc
@@ -29,1034 +29,1185 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:												   *
+*      Modified by:
+**
 *      Jingwen Leng, Univeristy of Texas, Austin                   *
 *      Syed Gilani, University of Wisconsin–Madison                *
 *      Tayler Hetherington, University of British Columbia         *
 *      Ahmed ElTantawy, University of British Columbia             *
 ********************************************************************/
-#include <string.h>
-#include <iostream>
-#include <stdio.h>
-#include <algorithm>
-#include <string.h>
-#include <cmath>
-#include <assert.h>
-#include <fstream>
-#include "parameter.h"
-#include "array.h"
-#include "const.h"
-#include "cacti/basic_circuit.h"
-#include "XML_Parse.h"
 #include "processor.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <string.h>
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include "XML_Parse.h"
+#include "array.h"
+#include "cacti/basic_circuit.h"
+#include "const.h"
+#include "parameter.h"
 #include "version.h"
 
-
 Processor::Processor(ParseXML *XML_interface)
-:XML(XML_interface),//TODO: using one global copy may have problems.
- mc(0),
- niu(0),
- pcie(0),
- flashcontroller(0)
-{
+    : XML(XML_interface),  // TODO: using one global copy may have problems.
+      mc(0),
+      niu(0),
+      pcie(0),
+      flashcontroller(0) {
   /*
-   *  placement and routing overhead is 10%, core scales worse than cache 40% is accumulated from 90 to 22nm
+   *  placement and routing overhead is 10%, core scales worse than cache 40% is
+   * accumulated from 90 to 22nm
    *  There is no point to have heterogeneous memory controller on chip,
    *  thus McPAT only support homogeneous memory controllers.
    */
   rt_power.reset();
   int i;
-  double pppm_t[4]    = {1,1,1,1};
-  l2_power=0;
-  idle_core_power=0;
+  double pppm_t[4] = {1, 1, 1, 1};
+  l2_power = 0;
+  idle_core_power = 0;
   set_proc_param();
   if (procdynp.homoCore)
-	  numCore = procdynp.numCore==0? 0:1;
+    numCore = procdynp.numCore == 0 ? 0 : 1;
   else
-	  numCore = procdynp.numCore;
+    numCore = procdynp.numCore;
 
   if (procdynp.homoL2)
-	  numL2 = procdynp.numL2==0? 0:1;
+    numL2 = procdynp.numL2 == 0 ? 0 : 1;
   else
-	  numL2 = procdynp.numL2;
+    numL2 = procdynp.numL2;
 
-  if (XML->sys.Private_L2 && numCore != numL2)
-  {
-	  cout<<"Number of private L2 does not match number of cores"<<endl;
-      exit(0);
+  if (XML->sys.Private_L2 && numCore != numL2) {
+    cout << "Number of private L2 does not match number of cores" << endl;
+    exit(0);
   }
 
   if (procdynp.homoL3)
-	  numL3 = procdynp.numL3==0? 0:1;
+    numL3 = procdynp.numL3 == 0 ? 0 : 1;
   else
-	  numL3 = procdynp.numL3;
+    numL3 = procdynp.numL3;
 
   if (procdynp.homoNOC)
-	  numNOC = procdynp.numNOC==0? 0:1;
+    numNOC = procdynp.numNOC == 0 ? 0 : 1;
   else
-	  numNOC = procdynp.numNOC;
+    numNOC = procdynp.numNOC;
 
-//  if (!procdynp.homoNOC)
-//  {
-//	  cout<<"Current McPAT does not support heterogeneous NOC"<<endl;
-//      exit(0);
-//  }
+  //  if (!procdynp.homoNOC)
+  //  {
+  //	  cout<<"Current McPAT does not support heterogeneous NOC"<<endl;
+  //      exit(0);
+  //  }
 
   if (procdynp.homoL1Dir)
-	  numL1Dir = procdynp.numL1Dir==0? 0:1;
+    numL1Dir = procdynp.numL1Dir == 0 ? 0 : 1;
   else
-	  numL1Dir = procdynp.numL1Dir;
+    numL1Dir = procdynp.numL1Dir;
 
   if (procdynp.homoL2Dir)
-	  numL2Dir = procdynp.numL2Dir==0? 0:1;
+    numL2Dir = procdynp.numL2Dir == 0 ? 0 : 1;
   else
-	  numL2Dir = procdynp.numL2Dir;
+    numL2Dir = procdynp.numL2Dir;
 
-  for (i = 0;i < numCore; i++)
-  {
-		  cores.push_back(new Core(XML,i, &interface_ip));
-		  cores[i]->computeEnergy();
-		  cores[i]->computeEnergy(false);
-		  if (procdynp.homoCore){
-			  core.area.set_area(core.area.get_area() + cores[i]->area.get_area()*procdynp.numCore);
-			  set_pppm(pppm_t,cores[i]->clockRate*procdynp.numCore, procdynp.numCore,procdynp.numCore,procdynp.numCore);
-			  //set the exClockRate
-           exClockRate=cores[0]->clockRate*2;//TODO; get from XML file
-			  //cout<<"****EX clock rate:"<<exClockRate<<endl;
-			  core.power = core.power + cores[i]->power*pppm_t;
-			  set_pppm(pppm_t,1/cores[i]->executionTime, procdynp.numCore,procdynp.numCore,procdynp.numCore);
-			  core.rt_power = core.rt_power + cores[i]->rt_power*pppm_t;
-			  area.set_area(area.get_area() + core.area.get_area());//placement and routing overhead is 10%, core scales worse than cache 40% is accumulated from 90 to 22nm
-			  power = power  + core.power;
-			  rt_power = rt_power  + core.rt_power;
-		  }
-		  else{
-			  core.area.set_area(core.area.get_area() + cores[i]->area.get_area());
-			  area.set_area(area.get_area() + cores[i]->area.get_area());//placement and routing overhead is 10%, core scales worse than cache 40% is accumulated from 90 to 22nm
+  for (i = 0; i < numCore; i++) {
+    cores.push_back(new Core(XML, i, &interface_ip));
+    cores[i]->computeEnergy();
+    cores[i]->computeEnergy(false);
+    if (procdynp.homoCore) {
+      core.area.set_area(core.area.get_area() +
+                         cores[i]->area.get_area() * procdynp.numCore);
+      set_pppm(pppm_t, cores[i]->clockRate * procdynp.numCore, procdynp.numCore,
+               procdynp.numCore, procdynp.numCore);
+      // set the exClockRate
+      exClockRate = cores[0]->clockRate * 2;  // TODO; get from XML file
+      // cout<<"****EX clock rate:"<<exClockRate<<endl;
+      core.power = core.power + cores[i]->power * pppm_t;
+      set_pppm(pppm_t, 1 / cores[i]->executionTime, procdynp.numCore,
+               procdynp.numCore, procdynp.numCore);
+      core.rt_power = core.rt_power + cores[i]->rt_power * pppm_t;
+      area.set_area(area.get_area() +
+                    core.area.get_area());  // placement and routing overhead is
+                                            // 10%, core scales worse than cache
+                                            // 40% is accumulated from 90 to
+                                            // 22nm
+      power = power + core.power;
+      rt_power = rt_power + core.rt_power;
+    } else {
+      core.area.set_area(core.area.get_area() + cores[i]->area.get_area());
+      area.set_area(area.get_area() +
+                    cores[i]->area.get_area());  // placement and routing
+                                                 // overhead is 10%, core scales
+                                                 // worse than cache 40% is
+                                                 // accumulated from 90 to 22nm
 
-			  set_pppm(pppm_t,cores[i]->clockRate, 1, 1, 1);
-			  //set the exClockRate
-           exClockRate=cores[0]->clockRate;//TODO; get from XML file
-			  //cout<<"****EX clock rate:"<<exClockRate<<endl;
-			  core.power = core.power + cores[i]->power*pppm_t;
-			  power = power  + cores[i]->power*pppm_t;
+      set_pppm(pppm_t, cores[i]->clockRate, 1, 1, 1);
+      // set the exClockRate
+      exClockRate = cores[0]->clockRate;  // TODO; get from XML file
+      // cout<<"****EX clock rate:"<<exClockRate<<endl;
+      core.power = core.power + cores[i]->power * pppm_t;
+      power = power + cores[i]->power * pppm_t;
 
-			  set_pppm(pppm_t,1/cores[i]->executionTime, 1, 1, 1);
-			  core.rt_power = core.rt_power + cores[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + cores[i]->rt_power*pppm_t;
-		  }
+      set_pppm(pppm_t, 1 / cores[i]->executionTime, 1, 1, 1);
+      core.rt_power = core.rt_power + cores[i]->rt_power * pppm_t;
+      rt_power = rt_power + cores[i]->rt_power * pppm_t;
+    }
   }
 
-  if (!XML->sys.Private_L2)
-  {
+  if (!XML->sys.Private_L2) {
+    if (numL2 > 0)
+      for (i = 0; i < numL2; i++) {
+        l2array.push_back(new SharedCache(XML, i, &interface_ip));
 
-  if (numL2 >0)
-	  for (i = 0;i < numL2; i++)
-	  {
-		  l2array.push_back(new SharedCache(XML,i, &interface_ip));
+        l2array[i]->computeEnergy();
+        l2array[i]->computeEnergy(false);
+        if (procdynp.homoL2) {
+          l2.area.set_area(l2.area.get_area() +
+                           l2array[i]->area.get_area() * procdynp.numL2);
+          set_pppm(pppm_t, l2array[i]->cachep.clockRate * procdynp.numL2,
+                   procdynp.numL2, procdynp.numL2, procdynp.numL2);
+          l2.power = l2.power + l2array[i]->power * pppm_t;
+          set_pppm(pppm_t, 1 / l2array[i]->cachep.executionTime, procdynp.numL2,
+                   procdynp.numL2, procdynp.numL2);
+          l2.rt_power = l2.rt_power + l2array[i]->rt_power * pppm_t;
+          area.set_area(area.get_area() +
+                        l2.area.get_area());  // placement and routing overhead
+                                              // is 10%, l2 scales worse than
+                                              // cache 40% is accumulated from
+                                              // 90 to 22nm
+          power = power + l2.power;
+          rt_power = rt_power + l2.rt_power;
+        } else {
+          l2.area.set_area(l2.area.get_area() + l2array[i]->area.get_area());
+          area.set_area(area.get_area() +
+                        l2array[i]->area.get_area());  // placement and routing
+                                                       // overhead is 10%, l2
+                                                       // scales worse than
+                                                       // cache 40% is
+                                                       // accumulated from 90 to
+                                                       // 22nm
 
-		  l2array[i]->computeEnergy();
-		  l2array[i]->computeEnergy(false);
-		  if (procdynp.homoL2){
-			  l2.area.set_area(l2.area.get_area() + l2array[i]->area.get_area()*procdynp.numL2);
-			  set_pppm(pppm_t,l2array[i]->cachep.clockRate*procdynp.numL2, procdynp.numL2,procdynp.numL2,procdynp.numL2);
-			  l2.power = l2.power + l2array[i]->power*pppm_t;
-			  set_pppm(pppm_t,1/l2array[i]->cachep.executionTime, procdynp.numL2,procdynp.numL2,procdynp.numL2);
-			  l2.rt_power = l2.rt_power + l2array[i]->rt_power*pppm_t;
-			  area.set_area(area.get_area() + l2.area.get_area());//placement and routing overhead is 10%, l2 scales worse than cache 40% is accumulated from 90 to 22nm
-			  power = power  + l2.power;
-			  rt_power = rt_power  + l2.rt_power;
-		  }
-		  else{
-			  l2.area.set_area(l2.area.get_area() + l2array[i]->area.get_area());
-			  area.set_area(area.get_area() + l2array[i]->area.get_area());//placement and routing overhead is 10%, l2 scales worse than cache 40% is accumulated from 90 to 22nm
-
-			  set_pppm(pppm_t,l2array[i]->cachep.clockRate, 1, 1, 1);
-			  l2.power = l2.power + l2array[i]->power*pppm_t;
-			  power = power  + l2array[i]->power*pppm_t;;
-			  set_pppm(pppm_t,1/l2array[i]->cachep.executionTime, 1, 1, 1);
-			  l2.rt_power = l2.rt_power + l2array[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + l2array[i]->rt_power*pppm_t;
-		  }
-	  }
+          set_pppm(pppm_t, l2array[i]->cachep.clockRate, 1, 1, 1);
+          l2.power = l2.power + l2array[i]->power * pppm_t;
+          power = power + l2array[i]->power * pppm_t;
+          ;
+          set_pppm(pppm_t, 1 / l2array[i]->cachep.executionTime, 1, 1, 1);
+          l2.rt_power = l2.rt_power + l2array[i]->rt_power * pppm_t;
+          rt_power = rt_power + l2array[i]->rt_power * pppm_t;
+        }
+      }
   }
 
-  if (numL3 >0)
-	  for (i = 0;i < numL3; i++)
-	  {
-		  l3array.push_back(new SharedCache(XML,i, &interface_ip, L3));
-		  l3array[i]->computeEnergy();
-		  l3array[i]->computeEnergy(false);
-		  if (procdynp.homoL3){
-			  l3.area.set_area(l3.area.get_area() + l3array[i]->area.get_area()*procdynp.numL3);
-			  set_pppm(pppm_t,l3array[i]->cachep.clockRate*procdynp.numL3, procdynp.numL3,procdynp.numL3,procdynp.numL3);
-			  l3.power = l3.power + l3array[i]->power*pppm_t;
-			  set_pppm(pppm_t,1/l3array[i]->cachep.executionTime, procdynp.numL3,procdynp.numL3,procdynp.numL3);
-              l3.rt_power = l3.rt_power + l3array[i]->rt_power*pppm_t;
-			  area.set_area(area.get_area() + l3.area.get_area());//placement and routing overhead is 10%, l3 scales worse than cache 40% is accumulated from 90 to 22nm
-			  power = power  + l3.power;
-			  rt_power = rt_power  + l3.rt_power;
+  if (numL3 > 0)
+    for (i = 0; i < numL3; i++) {
+      l3array.push_back(new SharedCache(XML, i, &interface_ip, L3));
+      l3array[i]->computeEnergy();
+      l3array[i]->computeEnergy(false);
+      if (procdynp.homoL3) {
+        l3.area.set_area(l3.area.get_area() +
+                         l3array[i]->area.get_area() * procdynp.numL3);
+        set_pppm(pppm_t, l3array[i]->cachep.clockRate * procdynp.numL3,
+                 procdynp.numL3, procdynp.numL3, procdynp.numL3);
+        l3.power = l3.power + l3array[i]->power * pppm_t;
+        set_pppm(pppm_t, 1 / l3array[i]->cachep.executionTime, procdynp.numL3,
+                 procdynp.numL3, procdynp.numL3);
+        l3.rt_power = l3.rt_power + l3array[i]->rt_power * pppm_t;
+        area.set_area(area.get_area() +
+                      l3.area.get_area());  // placement and routing overhead is
+                                            // 10%, l3 scales worse than cache
+                                            // 40% is accumulated from 90 to
+                                            // 22nm
+        power = power + l3.power;
+        rt_power = rt_power + l3.rt_power;
 
-		  }
-		  else{
-			  l3.area.set_area(l3.area.get_area() + l3array[i]->area.get_area());
-			  area.set_area(area.get_area() + l3array[i]->area.get_area());//placement and routing overhead is 10%, l3 scales worse than cache 40% is accumulated from 90 to 22nm
-			  set_pppm(pppm_t,l3array[i]->cachep.clockRate, 1, 1, 1);
-			  l3.power = l3.power + l3array[i]->power*pppm_t;
-			  power = power  + l3array[i]->power*pppm_t;
-			  set_pppm(pppm_t,1/l3array[i]->cachep.executionTime, 1, 1, 1);
-              l3.rt_power = l3.rt_power + l3array[i]->rt_power*pppm_t;
-              rt_power = rt_power  + l3array[i]->rt_power*pppm_t;
+      } else {
+        l3.area.set_area(l3.area.get_area() + l3array[i]->area.get_area());
+        area.set_area(area.get_area() +
+                      l3array[i]->area.get_area());  // placement and routing
+                                                     // overhead is 10%, l3
+                                                     // scales worse than cache
+                                                     // 40% is accumulated from
+                                                     // 90 to 22nm
+        set_pppm(pppm_t, l3array[i]->cachep.clockRate, 1, 1, 1);
+        l3.power = l3.power + l3array[i]->power * pppm_t;
+        power = power + l3array[i]->power * pppm_t;
+        set_pppm(pppm_t, 1 / l3array[i]->cachep.executionTime, 1, 1, 1);
+        l3.rt_power = l3.rt_power + l3array[i]->rt_power * pppm_t;
+        rt_power = rt_power + l3array[i]->rt_power * pppm_t;
+      }
+    }
+  if (numL1Dir > 0)
+    for (i = 0; i < numL1Dir; i++) {
+      l1dirarray.push_back(new SharedCache(XML, i, &interface_ip, L1Directory));
+      l1dirarray[i]->computeEnergy();
+      l1dirarray[i]->computeEnergy(false);
+      if (procdynp.homoL1Dir) {
+        l1dir.area.set_area(l1dir.area.get_area() +
+                            l1dirarray[i]->area.get_area() * procdynp.numL1Dir);
+        set_pppm(pppm_t, l1dirarray[i]->cachep.clockRate * procdynp.numL1Dir,
+                 procdynp.numL1Dir, procdynp.numL1Dir, procdynp.numL1Dir);
+        l1dir.power = l1dir.power + l1dirarray[i]->power * pppm_t;
+        set_pppm(pppm_t, 1 / l1dirarray[i]->cachep.executionTime,
+                 procdynp.numL1Dir, procdynp.numL1Dir, procdynp.numL1Dir);
+        l1dir.rt_power = l1dir.rt_power + l1dirarray[i]->rt_power * pppm_t;
+        area.set_area(area.get_area() +
+                      l1dir.area.get_area());  // placement and routing overhead
+                                               // is 10%, l1dir scales worse
+                                               // than cache 40% is accumulated
+                                               // from 90 to 22nm
+        power = power + l1dir.power;
+        rt_power = rt_power + l1dir.rt_power;
 
-		  }
-	  }
-  if (numL1Dir >0)
-	  for (i = 0;i < numL1Dir; i++)
-	  {
-		  l1dirarray.push_back(new SharedCache(XML,i, &interface_ip, L1Directory));
-		  l1dirarray[i]->computeEnergy();
-		  l1dirarray[i]->computeEnergy(false);
-		  if (procdynp.homoL1Dir){
-			  l1dir.area.set_area(l1dir.area.get_area() + l1dirarray[i]->area.get_area()*procdynp.numL1Dir);
-			  set_pppm(pppm_t,l1dirarray[i]->cachep.clockRate*procdynp.numL1Dir, procdynp.numL1Dir,procdynp.numL1Dir,procdynp.numL1Dir);
-			  l1dir.power = l1dir.power + l1dirarray[i]->power*pppm_t;
-			  set_pppm(pppm_t,1/l1dirarray[i]->cachep.executionTime, procdynp.numL1Dir,procdynp.numL1Dir,procdynp.numL1Dir);
-              l1dir.rt_power = l1dir.rt_power + l1dirarray[i]->rt_power*pppm_t;
-			  area.set_area(area.get_area() + l1dir.area.get_area());//placement and routing overhead is 10%, l1dir scales worse than cache 40% is accumulated from 90 to 22nm
-			  power = power  + l1dir.power;
-			  rt_power = rt_power  + l1dir.rt_power;
+      } else {
+        l1dir.area.set_area(l1dir.area.get_area() +
+                            l1dirarray[i]->area.get_area());
+        area.set_area(area.get_area() + l1dirarray[i]->area.get_area());
+        set_pppm(pppm_t, l1dirarray[i]->cachep.clockRate, 1, 1, 1);
+        l1dir.power = l1dir.power + l1dirarray[i]->power * pppm_t;
+        power = power + l1dirarray[i]->power;
+        set_pppm(pppm_t, 1 / l1dirarray[i]->cachep.executionTime, 1, 1, 1);
+        l1dir.rt_power = l1dir.rt_power + l1dirarray[i]->rt_power * pppm_t;
+        rt_power = rt_power + l1dirarray[i]->rt_power;
+      }
+    }
 
-		  }
-		  else{
-			  l1dir.area.set_area(l1dir.area.get_area() + l1dirarray[i]->area.get_area());
-			  area.set_area(area.get_area() + l1dirarray[i]->area.get_area());
-			  set_pppm(pppm_t,l1dirarray[i]->cachep.clockRate, 1, 1, 1);
-			  l1dir.power = l1dir.power + l1dirarray[i]->power*pppm_t;
-			  power = power  + l1dirarray[i]->power;
-			  set_pppm(pppm_t,1/l1dirarray[i]->cachep.executionTime, 1, 1, 1);
-              l1dir.rt_power = l1dir.rt_power + l1dirarray[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + l1dirarray[i]->rt_power;
-		  }
-	  }
+  if (numL2Dir > 0)
+    for (i = 0; i < numL2Dir; i++) {
+      l2dirarray.push_back(new SharedCache(XML, i, &interface_ip, L2Directory));
+      l2dirarray[i]->computeEnergy();
+      l2dirarray[i]->computeEnergy(false);
+      if (procdynp.homoL2Dir) {
+        l2dir.area.set_area(l2dir.area.get_area() +
+                            l2dirarray[i]->area.get_area() * procdynp.numL2Dir);
+        set_pppm(pppm_t, l2dirarray[i]->cachep.clockRate * procdynp.numL2Dir,
+                 procdynp.numL2Dir, procdynp.numL2Dir, procdynp.numL2Dir);
+        l2dir.power = l2dir.power + l2dirarray[i]->power * pppm_t;
+        set_pppm(pppm_t, 1 / l2dirarray[i]->cachep.executionTime,
+                 procdynp.numL2Dir, procdynp.numL2Dir, procdynp.numL2Dir);
+        l2dir.rt_power = l2dir.rt_power + l2dirarray[i]->rt_power * pppm_t;
+        area.set_area(area.get_area() +
+                      l2dir.area.get_area());  // placement and routing overhead
+                                               // is 10%, l2dir scales worse
+                                               // than cache 40% is accumulated
+                                               // from 90 to 22nm
+        power = power + l2dir.power;
+        rt_power = rt_power + l2dir.rt_power;
 
-  if (numL2Dir >0)
-	  for (i = 0;i < numL2Dir; i++)
-	  {
-		  l2dirarray.push_back(new SharedCache(XML,i, &interface_ip, L2Directory));
-		  l2dirarray[i]->computeEnergy();
-		  l2dirarray[i]->computeEnergy(false);
-		  if (procdynp.homoL2Dir){
-			  l2dir.area.set_area(l2dir.area.get_area() + l2dirarray[i]->area.get_area()*procdynp.numL2Dir);
-			  set_pppm(pppm_t,l2dirarray[i]->cachep.clockRate*procdynp.numL2Dir, procdynp.numL2Dir,procdynp.numL2Dir,procdynp.numL2Dir);
-			  l2dir.power = l2dir.power + l2dirarray[i]->power*pppm_t;
-			  set_pppm(pppm_t,1/l2dirarray[i]->cachep.executionTime, procdynp.numL2Dir,procdynp.numL2Dir,procdynp.numL2Dir);
-              l2dir.rt_power = l2dir.rt_power + l2dirarray[i]->rt_power*pppm_t;
-			  area.set_area(area.get_area() + l2dir.area.get_area());//placement and routing overhead is 10%, l2dir scales worse than cache 40% is accumulated from 90 to 22nm
-			  power = power  + l2dir.power;
-			  rt_power = rt_power  + l2dir.rt_power;
+      } else {
+        l2dir.area.set_area(l2dir.area.get_area() +
+                            l2dirarray[i]->area.get_area());
+        area.set_area(area.get_area() + l2dirarray[i]->area.get_area());
+        set_pppm(pppm_t, l2dirarray[i]->cachep.clockRate, 1, 1, 1);
+        l2dir.power = l2dir.power + l2dirarray[i]->power * pppm_t;
+        power = power + l2dirarray[i]->power * pppm_t;
+        set_pppm(pppm_t, 1 / l2dirarray[i]->cachep.executionTime, 1, 1, 1);
+        l2dir.rt_power = l2dir.rt_power + l2dirarray[i]->rt_power * pppm_t;
+        rt_power = rt_power + l2dirarray[i]->rt_power * pppm_t;
+      }
+    }
 
-		  }
-		  else{
-			  l2dir.area.set_area(l2dir.area.get_area() + l2dirarray[i]->area.get_area());
-			  area.set_area(area.get_area() + l2dirarray[i]->area.get_area());
-			  set_pppm(pppm_t,l2dirarray[i]->cachep.clockRate, 1, 1, 1);
-			  l2dir.power = l2dir.power + l2dirarray[i]->power*pppm_t;
-			  power = power  + l2dirarray[i]->power*pppm_t;
-			  set_pppm(pppm_t,1/l2dirarray[i]->cachep.executionTime, 1, 1, 1);
-              l2dir.rt_power = l2dir.rt_power + l2dirarray[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + l2dirarray[i]->rt_power*pppm_t;
-		  }
-	  }
-
-  if (XML->sys.mc.number_mcs >0 && XML->sys.mc.memory_channels_per_mc>0)
-  {
-	  if(XML->sys.architecture==1) // 1 for fermi
-		mc = new MemoryController(XML, &interface_ip, MC,GDDR5);
-	  else if (XML->sys.architecture==2) // 2 for quadro
-		mc = new MemoryController(XML, &interface_ip, MC,GDDR3);
-	  else {
-		printf("Architecture %d not defined!\n", XML->sys.architecture);
-		printf("use 1 for fermi and 2 for quadro!\n");
-		exit(1);
-	  }
-	  mc->computeEnergy();
-	  mc->computeEnergy(false);
-	  mcs.area.set_area(mcs.area.get_area()+mc->area.get_area()*XML->sys.mc.number_mcs);
-	  area.set_area(area.get_area()+mc->area.get_area()*XML->sys.mc.number_mcs);
-	  set_pppm(pppm_t,XML->sys.mc.number_mcs*mc->mcp.clockRate, XML->sys.mc.number_mcs,XML->sys.mc.number_mcs,XML->sys.mc.number_mcs);
-	  mcs.power = mc->power*pppm_t;
-	  power = power  + mcs.power;
-	  set_pppm(pppm_t,1/mc->mcp.executionTime, XML->sys.mc.number_mcs,XML->sys.mc.number_mcs,XML->sys.mc.number_mcs);
-	  mcs.rt_power = mc->rt_power*pppm_t;
-	  rt_power = rt_power  + mcs.rt_power;
-
+  if (XML->sys.mc.number_mcs > 0 && XML->sys.mc.memory_channels_per_mc > 0) {
+    if (XML->sys.architecture == 1)  // 1 for fermi
+      mc = new MemoryController(XML, &interface_ip, MC, GDDR5);
+    else if (XML->sys.architecture == 2)  // 2 for quadro
+      mc = new MemoryController(XML, &interface_ip, MC, GDDR3);
+    else {
+      printf("Architecture %d not defined!\n", XML->sys.architecture);
+      printf("use 1 for fermi and 2 for quadro!\n");
+      exit(1);
+    }
+    mc->computeEnergy();
+    mc->computeEnergy(false);
+    mcs.area.set_area(mcs.area.get_area() +
+                      mc->area.get_area() * XML->sys.mc.number_mcs);
+    area.set_area(area.get_area() +
+                  mc->area.get_area() * XML->sys.mc.number_mcs);
+    set_pppm(pppm_t, XML->sys.mc.number_mcs * mc->mcp.clockRate,
+             XML->sys.mc.number_mcs, XML->sys.mc.number_mcs,
+             XML->sys.mc.number_mcs);
+    mcs.power = mc->power * pppm_t;
+    power = power + mcs.power;
+    set_pppm(pppm_t, 1 / mc->mcp.executionTime, XML->sys.mc.number_mcs,
+             XML->sys.mc.number_mcs, XML->sys.mc.number_mcs);
+    mcs.rt_power = mc->rt_power * pppm_t;
+    rt_power = rt_power + mcs.rt_power;
   }
 
-  if (XML->sys.flashc.number_mcs >0 )//flash controller
+  if (XML->sys.flashc.number_mcs > 0)  // flash controller
   {
-	  flashcontroller = new FlashController(XML, &interface_ip);
-	  flashcontroller->computeEnergy();
-	  flashcontroller->computeEnergy(false);
-	  double number_fcs = flashcontroller->fcp.num_mcs;
-	  flashcontrollers.area.set_area(flashcontrollers.area.get_area()+flashcontroller->area.get_area()*number_fcs);
-	  area.set_area(area.get_area()+flashcontrollers.area.get_area());
-	  set_pppm(pppm_t,number_fcs, number_fcs ,number_fcs, number_fcs );
-	  flashcontrollers.power = flashcontroller->power*pppm_t;
-	  power = power  + flashcontrollers.power;
-	  set_pppm(pppm_t,number_fcs , number_fcs ,number_fcs ,number_fcs );
-	  flashcontrollers.rt_power = flashcontroller->rt_power*pppm_t;
-	  rt_power = rt_power  + flashcontrollers.rt_power;
-
+    flashcontroller = new FlashController(XML, &interface_ip);
+    flashcontroller->computeEnergy();
+    flashcontroller->computeEnergy(false);
+    double number_fcs = flashcontroller->fcp.num_mcs;
+    flashcontrollers.area.set_area(flashcontrollers.area.get_area() +
+                                   flashcontroller->area.get_area() *
+                                       number_fcs);
+    area.set_area(area.get_area() + flashcontrollers.area.get_area());
+    set_pppm(pppm_t, number_fcs, number_fcs, number_fcs, number_fcs);
+    flashcontrollers.power = flashcontroller->power * pppm_t;
+    power = power + flashcontrollers.power;
+    set_pppm(pppm_t, number_fcs, number_fcs, number_fcs, number_fcs);
+    flashcontrollers.rt_power = flashcontroller->rt_power * pppm_t;
+    rt_power = rt_power + flashcontrollers.rt_power;
   }
 
-  if (XML->sys.niu.number_units >0)
-  {
-	  niu = new NIUController(XML, &interface_ip);
-	  niu->computeEnergy();
-	  niu->computeEnergy(false);
-	  nius.area.set_area(nius.area.get_area()+niu->area.get_area()*XML->sys.niu.number_units);
-	  area.set_area(area.get_area()+niu->area.get_area()*XML->sys.niu.number_units);
-	  set_pppm(pppm_t,XML->sys.niu.number_units*niu->niup.clockRate, XML->sys.niu.number_units,XML->sys.niu.number_units,XML->sys.niu.number_units);
-	  nius.power = niu->power*pppm_t;
-	  power = power  + nius.power;
-	  set_pppm(pppm_t,XML->sys.niu.number_units*niu->niup.clockRate, XML->sys.niu.number_units,XML->sys.niu.number_units,XML->sys.niu.number_units);
-	  nius.rt_power = niu->rt_power*pppm_t;
-	  rt_power = rt_power  + nius.rt_power;
-
+  if (XML->sys.niu.number_units > 0) {
+    niu = new NIUController(XML, &interface_ip);
+    niu->computeEnergy();
+    niu->computeEnergy(false);
+    nius.area.set_area(nius.area.get_area() +
+                       niu->area.get_area() * XML->sys.niu.number_units);
+    area.set_area(area.get_area() +
+                  niu->area.get_area() * XML->sys.niu.number_units);
+    set_pppm(pppm_t, XML->sys.niu.number_units * niu->niup.clockRate,
+             XML->sys.niu.number_units, XML->sys.niu.number_units,
+             XML->sys.niu.number_units);
+    nius.power = niu->power * pppm_t;
+    power = power + nius.power;
+    set_pppm(pppm_t, XML->sys.niu.number_units * niu->niup.clockRate,
+             XML->sys.niu.number_units, XML->sys.niu.number_units,
+             XML->sys.niu.number_units);
+    nius.rt_power = niu->rt_power * pppm_t;
+    rt_power = rt_power + nius.rt_power;
   }
 
-  if (XML->sys.pcie.number_units >0 && XML->sys.pcie.num_channels >0)
-  {
-	  pcie = new PCIeController(XML, &interface_ip);
-	  pcie->computeEnergy();
-	  pcie->computeEnergy(false);
-	  pcies.area.set_area(pcies.area.get_area()+pcie->area.get_area()*XML->sys.pcie.number_units);
-	  area.set_area(area.get_area()+pcie->area.get_area()*XML->sys.pcie.number_units);
-	  set_pppm(pppm_t,XML->sys.pcie.number_units*pcie->pciep.clockRate, XML->sys.pcie.number_units,XML->sys.pcie.number_units,XML->sys.pcie.number_units);
-	  pcies.power = pcie->power*pppm_t;
-	  power = power  + pcies.power;
-	  set_pppm(pppm_t,XML->sys.pcie.number_units*pcie->pciep.clockRate, XML->sys.pcie.number_units,XML->sys.pcie.number_units,XML->sys.pcie.number_units);
-	  pcies.rt_power = pcie->rt_power*pppm_t;
-	  rt_power = rt_power  + pcies.rt_power;
-
+  if (XML->sys.pcie.number_units > 0 && XML->sys.pcie.num_channels > 0) {
+    pcie = new PCIeController(XML, &interface_ip);
+    pcie->computeEnergy();
+    pcie->computeEnergy(false);
+    pcies.area.set_area(pcies.area.get_area() +
+                        pcie->area.get_area() * XML->sys.pcie.number_units);
+    area.set_area(area.get_area() +
+                  pcie->area.get_area() * XML->sys.pcie.number_units);
+    set_pppm(pppm_t, XML->sys.pcie.number_units * pcie->pciep.clockRate,
+             XML->sys.pcie.number_units, XML->sys.pcie.number_units,
+             XML->sys.pcie.number_units);
+    pcies.power = pcie->power * pppm_t;
+    power = power + pcies.power;
+    set_pppm(pppm_t, XML->sys.pcie.number_units * pcie->pciep.clockRate,
+             XML->sys.pcie.number_units, XML->sys.pcie.number_units,
+             XML->sys.pcie.number_units);
+    pcies.rt_power = pcie->rt_power * pppm_t;
+    rt_power = rt_power + pcies.rt_power;
   }
 
-  if (numNOC >0)
-  {
-	  for (i = 0;i < numNOC; i++)
-	  {
-		  if (XML->sys.NoC[i].type)
-		  {//First add up area of routers if NoC is used
-			  nocs.push_back(new NoC(XML,i, &interface_ip, 1));
+  if (numNOC > 0) {
+    for (i = 0; i < numNOC; i++) {
+      if (XML->sys.NoC[i].type) {  // First add up area of routers if NoC is
+                                   // used
+        nocs.push_back(new NoC(XML, i, &interface_ip, 1));
 
-			  if (procdynp.homoNOC)
-			  {
-				  noc.area.set_area(noc.area.get_area() + nocs[i]->area.get_area()*procdynp.numNOC);
-				  area.set_area(area.get_area() + noc.area.get_area());
-			  }
-			  else
-			  {
-				  noc.area.set_area(noc.area.get_area() + nocs[i]->area.get_area());
-				  area.set_area(area.get_area() + nocs[i]->area.get_area());
-			  }
-		  }
-		  else
-		  {//Bus based interconnect
-			  nocs.push_back(new NoC(XML,i, &interface_ip, 1, sqrt(area.get_area()*XML->sys.NoC[i].chip_coverage)));
-			  if (procdynp.homoNOC){
-				  noc.area.set_area(noc.area.get_area() + nocs[i]->area.get_area()*procdynp.numNOC);
-				  area.set_area(area.get_area() + noc.area.get_area());
-			  }
-			  else
-			  {
-				  noc.area.set_area(noc.area.get_area() + nocs[i]->area.get_area());
-				  area.set_area(area.get_area() + nocs[i]->area.get_area());
-			  }
-		  }
-	  }
+        if (procdynp.homoNOC) {
+          noc.area.set_area(noc.area.get_area() +
+                            nocs[i]->area.get_area() * procdynp.numNOC);
+          area.set_area(area.get_area() + noc.area.get_area());
+        } else {
+          noc.area.set_area(noc.area.get_area() + nocs[i]->area.get_area());
+          area.set_area(area.get_area() + nocs[i]->area.get_area());
+        }
+      } else {  // Bus based interconnect
+        nocs.push_back(
+            new NoC(XML, i, &interface_ip, 1,
+                    sqrt(area.get_area() * XML->sys.NoC[i].chip_coverage)));
+        if (procdynp.homoNOC) {
+          noc.area.set_area(noc.area.get_area() +
+                            nocs[i]->area.get_area() * procdynp.numNOC);
+          area.set_area(area.get_area() + noc.area.get_area());
+        } else {
+          noc.area.set_area(noc.area.get_area() + nocs[i]->area.get_area());
+          area.set_area(area.get_area() + nocs[i]->area.get_area());
+        }
+      }
+    }
 
-	  /*
-	   * Compute global links associated with each NOC, if any. This must be done at the end (even after the NOC router part) since the total chip
-	   * area must be obtain to decide the link routing
-	   */
-	  for (i = 0;i < numNOC; i++)
-	  {
-		  if (nocs[i]->nocdynp.has_global_link && XML->sys.NoC[i].type)
-		  {
-			  nocs[i]->init_link_bus(sqrt(area.get_area()*XML->sys.NoC[i].chip_coverage));//compute global links
-			  if (procdynp.homoNOC)
-			  {
-				  noc.area.set_area(noc.area.get_area() + nocs[i]->link_bus_tot_per_Router.area.get_area()
-						  * nocs[i]->nocdynp.total_nodes
-						  * procdynp.numNOC);
-				  area.set_area(area.get_area() + nocs[i]->link_bus_tot_per_Router.area.get_area()
-						  * nocs[i]->nocdynp.total_nodes
-						  * procdynp.numNOC);
-			  }
-			  else
-			  {
-				  noc.area.set_area(noc.area.get_area() + nocs[i]->link_bus_tot_per_Router.area.get_area()
-						  * nocs[i]->nocdynp.total_nodes);
-				  area.set_area(area.get_area() + nocs[i]->link_bus_tot_per_Router.area.get_area()
-						  * nocs[i]->nocdynp.total_nodes);
-			  }
-		  }
-	  }
-	  //Compute energy of NoC (w or w/o links) or buses
-	  for (i = 0;i < numNOC; i++)
-	  {
-		 //cout<<"******************COMPUTE NOC ENERGY********************"<<endl;
-		  nocs[i]->computeEnergy();
-		  nocs[i]->computeEnergy(false);
-		  if (procdynp.homoNOC){
-
-			  set_pppm(pppm_t,procdynp.numNOC*nocs[i]->nocdynp.clockRate, procdynp.numNOC,procdynp.numNOC,procdynp.numNOC);
-			  noc.power = noc.power + nocs[i]->power*pppm_t;
-			  set_pppm(pppm_t,1/nocs[i]->nocdynp.executionTime, procdynp.numNOC,procdynp.numNOC,procdynp.numNOC);
-			  noc.rt_power = noc.rt_power + nocs[i]->rt_power*pppm_t;
-			  power = power  + noc.power;
-			  rt_power = rt_power  + noc.rt_power;
-		  }
-		  else
-		  {
-			  set_pppm(pppm_t,nocs[i]->nocdynp.clockRate, 1, 1, 1);
-			  noc.power = noc.power + nocs[i]->power*pppm_t;
-			  power = power  + nocs[i]->power*pppm_t;
-			  set_pppm(pppm_t,1/nocs[i]->nocdynp.executionTime, 1, 1, 1);
-			  noc.rt_power = noc.rt_power + nocs[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + nocs[i]->rt_power*pppm_t;
-
-
-		  }
-	  }
+    /*
+     * Compute global links associated with each NOC, if any. This must be done
+     * at the end (even after the NOC router part) since the total chip
+     * area must be obtain to decide the link routing
+     */
+    for (i = 0; i < numNOC; i++) {
+      if (nocs[i]->nocdynp.has_global_link && XML->sys.NoC[i].type) {
+        nocs[i]->init_link_bus(
+            sqrt(area.get_area() *
+                 XML->sys.NoC[i].chip_coverage));  // compute global links
+        if (procdynp.homoNOC) {
+          noc.area.set_area(noc.area.get_area() +
+                            nocs[i]->link_bus_tot_per_Router.area.get_area() *
+                                nocs[i]->nocdynp.total_nodes * procdynp.numNOC);
+          area.set_area(area.get_area() +
+                        nocs[i]->link_bus_tot_per_Router.area.get_area() *
+                            nocs[i]->nocdynp.total_nodes * procdynp.numNOC);
+        } else {
+          noc.area.set_area(noc.area.get_area() +
+                            nocs[i]->link_bus_tot_per_Router.area.get_area() *
+                                nocs[i]->nocdynp.total_nodes);
+          area.set_area(area.get_area() +
+                        nocs[i]->link_bus_tot_per_Router.area.get_area() *
+                            nocs[i]->nocdynp.total_nodes);
+        }
+      }
+    }
+    // Compute energy of NoC (w or w/o links) or buses
+    for (i = 0; i < numNOC; i++) {
+      // cout<<"******************COMPUTE NOC ENERGY********************"<<endl;
+      nocs[i]->computeEnergy();
+      nocs[i]->computeEnergy(false);
+      if (procdynp.homoNOC) {
+        set_pppm(pppm_t, procdynp.numNOC * nocs[i]->nocdynp.clockRate,
+                 procdynp.numNOC, procdynp.numNOC, procdynp.numNOC);
+        noc.power = noc.power + nocs[i]->power * pppm_t;
+        set_pppm(pppm_t, 1 / nocs[i]->nocdynp.executionTime, procdynp.numNOC,
+                 procdynp.numNOC, procdynp.numNOC);
+        noc.rt_power = noc.rt_power + nocs[i]->rt_power * pppm_t;
+        power = power + noc.power;
+        rt_power = rt_power + noc.rt_power;
+      } else {
+        set_pppm(pppm_t, nocs[i]->nocdynp.clockRate, 1, 1, 1);
+        noc.power = noc.power + nocs[i]->power * pppm_t;
+        power = power + nocs[i]->power * pppm_t;
+        set_pppm(pppm_t, 1 / nocs[i]->nocdynp.executionTime, 1, 1, 1);
+        noc.rt_power = noc.rt_power + nocs[i]->rt_power * pppm_t;
+        rt_power = rt_power + nocs[i]->rt_power * pppm_t;
+      }
+    }
   }
 
-//  //clock power
-//  globalClock.init_wire_external(is_default, &interface_ip);
-//  globalClock.clk_area           =area*1e6; //change it from mm^2 to um^2
-//  globalClock.end_wiring_level   =5;//toplevel metal
-//  globalClock.start_wiring_level =5;//toplevel metal
-//  globalClock.l_ip.with_clock_grid=false;//global clock does not drive local final nodes
-//  globalClock.optimize_wire();
+  //  //clock power
+  //  globalClock.init_wire_external(is_default, &interface_ip);
+  //  globalClock.clk_area           =area*1e6; //change it from mm^2 to um^2
+  //  globalClock.end_wiring_level   =5;//toplevel metal
+  //  globalClock.start_wiring_level =5;//toplevel metal
+  //  globalClock.l_ip.with_clock_grid=false;//global clock does not drive local
+  //  final nodes
+  //  globalClock.optimize_wire();
 }
 
-void Processor::compute () 
-{
+void Processor::compute() {
   int i;
-  double pppm_t[4]    = {1,1,1,1};
+  double pppm_t[4] = {1, 1, 1, 1};
 
   rt_power.reset();
-  //power.reset();
-  //core.power.reset();
+  // power.reset();
+  // core.power.reset();
 
   core.rt_power.reset();
-  for (i = 0;i < numCore; i++)
-  {
-      cores[i]->executionTime = XML->sys.total_cycles /(XML->sys.core[i].clock_rate*1e6); 
-      cores[i]->rt_power.reset();
-		  cores[i]->compute();
-		  //cores[i]->computeEnergy(false);
-		  if (procdynp.homoCore){
-			  set_pppm(pppm_t,1/cores[i]->executionTime, procdynp.numCore,procdynp.numCore,procdynp.numCore);
-			  core.rt_power = core.rt_power + cores[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + core.rt_power;
-		  }
-		  else{
-			  set_pppm(pppm_t,1/cores[i]->executionTime, 1, 1, 1);
-			  core.rt_power = core.rt_power + cores[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + cores[i]->rt_power*pppm_t;
-		  }
+  for (i = 0; i < numCore; i++) {
+    cores[i]->executionTime =
+        XML->sys.total_cycles / (XML->sys.core[i].clock_rate * 1e6);
+    cores[i]->rt_power.reset();
+    cores[i]->compute();
+    // cores[i]->computeEnergy(false);
+    if (procdynp.homoCore) {
+      set_pppm(pppm_t, 1 / cores[i]->executionTime, procdynp.numCore,
+               procdynp.numCore, procdynp.numCore);
+      core.rt_power = core.rt_power + cores[i]->rt_power * pppm_t;
+      rt_power = rt_power + core.rt_power;
+    } else {
+      set_pppm(pppm_t, 1 / cores[i]->executionTime, 1, 1, 1);
+      core.rt_power = core.rt_power + cores[i]->rt_power * pppm_t;
+      rt_power = rt_power + cores[i]->rt_power * pppm_t;
+    }
   }
 
-  if (!XML->sys.Private_L2)
-  {
-  if (numL2 >0)
-    l2.rt_power.reset();
-	  for (i = 0;i < numL2; i++)
-	  {
+  if (!XML->sys.Private_L2) {
+    if (numL2 > 0) l2.rt_power.reset();
+    for (i = 0; i < numL2; i++) {
       l2array[i]->rt_power.reset();
-		l2array[i]->cachep.executionTime=XML->sys.total_cycles /(XML->sys.core[0].clock_rate*1e6);
-		  l2array[i]->computeEnergy(false);
-		  if (procdynp.homoL2){
-			  set_pppm(pppm_t,1/l2array[i]->cachep.executionTime, procdynp.numL2,procdynp.numL2,procdynp.numL2);
-			  l2.rt_power = l2.rt_power + l2array[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + l2.rt_power;
-		  }
-		  else{
-			  set_pppm(pppm_t,1/l2array[i]->cachep.executionTime, 1, 1, 1);
-			  l2.rt_power = l2.rt_power + l2array[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + l2array[i]->rt_power*pppm_t;
-		  }
-	  }
+      l2array[i]->cachep.executionTime =
+          XML->sys.total_cycles / (XML->sys.core[0].clock_rate * 1e6);
+      l2array[i]->computeEnergy(false);
+      if (procdynp.homoL2) {
+        set_pppm(pppm_t, 1 / l2array[i]->cachep.executionTime, procdynp.numL2,
+                 procdynp.numL2, procdynp.numL2);
+        l2.rt_power = l2.rt_power + l2array[i]->rt_power * pppm_t;
+        rt_power = rt_power + l2.rt_power;
+      } else {
+        set_pppm(pppm_t, 1 / l2array[i]->cachep.executionTime, 1, 1, 1);
+        l2.rt_power = l2.rt_power + l2array[i]->rt_power * pppm_t;
+        rt_power = rt_power + l2array[i]->rt_power * pppm_t;
+      }
+    }
   }
 
   l3.rt_power.reset();
-  if (numL3 >0)
-	  for (i = 0;i < numL3; i++)
-	  {
-		  l3array[i]->rt_power.reset();
-		  l3array[i]->computeEnergy(false);
-		  if (procdynp.homoL3){
-			  set_pppm(pppm_t,1/l3array[i]->cachep.executionTime, procdynp.numL3,procdynp.numL3,procdynp.numL3);
-        l3.rt_power = l3.rt_power + l3array[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + l3.rt_power;
+  if (numL3 > 0)
+    for (i = 0; i < numL3; i++) {
+      l3array[i]->rt_power.reset();
+      l3array[i]->computeEnergy(false);
+      if (procdynp.homoL3) {
+        set_pppm(pppm_t, 1 / l3array[i]->cachep.executionTime, procdynp.numL3,
+                 procdynp.numL3, procdynp.numL3);
+        l3.rt_power = l3.rt_power + l3array[i]->rt_power * pppm_t;
+        rt_power = rt_power + l3.rt_power;
 
-		  }
-		  else{
-			  set_pppm(pppm_t,1/l3array[i]->cachep.executionTime, 1, 1, 1);
-        l3.rt_power = l3.rt_power + l3array[i]->rt_power*pppm_t;
-        rt_power = rt_power  + l3array[i]->rt_power*pppm_t;
-
-		  }
-	  }
+      } else {
+        set_pppm(pppm_t, 1 / l3array[i]->cachep.executionTime, 1, 1, 1);
+        l3.rt_power = l3.rt_power + l3array[i]->rt_power * pppm_t;
+        rt_power = rt_power + l3array[i]->rt_power * pppm_t;
+      }
+    }
 
   l1dir.rt_power.reset();
-  if (numL1Dir >0)
-	  for (i = 0;i < numL1Dir; i++)
-	  {
-		  l1dirarray[i]->rt_power.reset();
-		  l1dirarray[i]->computeEnergy(false);
-		  if (procdynp.homoL1Dir){
-			  set_pppm(pppm_t,1/l1dirarray[i]->cachep.executionTime, procdynp.numL1Dir,procdynp.numL1Dir,procdynp.numL1Dir);
-        l1dir.rt_power = l1dir.rt_power + l1dirarray[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + l1dir.rt_power;
+  if (numL1Dir > 0)
+    for (i = 0; i < numL1Dir; i++) {
+      l1dirarray[i]->rt_power.reset();
+      l1dirarray[i]->computeEnergy(false);
+      if (procdynp.homoL1Dir) {
+        set_pppm(pppm_t, 1 / l1dirarray[i]->cachep.executionTime,
+                 procdynp.numL1Dir, procdynp.numL1Dir, procdynp.numL1Dir);
+        l1dir.rt_power = l1dir.rt_power + l1dirarray[i]->rt_power * pppm_t;
+        rt_power = rt_power + l1dir.rt_power;
 
-		  }
-		  else{
-			  set_pppm(pppm_t,1/l1dirarray[i]->cachep.executionTime, 1, 1, 1);
-        l1dir.rt_power = l1dir.rt_power + l1dirarray[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + l1dirarray[i]->rt_power;
-		  }
-	  }
-
+      } else {
+        set_pppm(pppm_t, 1 / l1dirarray[i]->cachep.executionTime, 1, 1, 1);
+        l1dir.rt_power = l1dir.rt_power + l1dirarray[i]->rt_power * pppm_t;
+        rt_power = rt_power + l1dirarray[i]->rt_power;
+      }
+    }
 
   l2dir.rt_power.reset();
-  if (numL2Dir >0)
-	  for (i = 0;i < numL2Dir; i++)
-	  {
-		  l2dirarray[i]->rt_power.reset();
-		  l2dirarray[i]->computeEnergy(false);
-		  if (procdynp.homoL2Dir){
-			  set_pppm(pppm_t,1/l2dirarray[i]->cachep.executionTime, procdynp.numL2Dir,procdynp.numL2Dir,procdynp.numL2Dir);
-        l2dir.rt_power = l2dir.rt_power + l2dirarray[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + l2dir.rt_power;
+  if (numL2Dir > 0)
+    for (i = 0; i < numL2Dir; i++) {
+      l2dirarray[i]->rt_power.reset();
+      l2dirarray[i]->computeEnergy(false);
+      if (procdynp.homoL2Dir) {
+        set_pppm(pppm_t, 1 / l2dirarray[i]->cachep.executionTime,
+                 procdynp.numL2Dir, procdynp.numL2Dir, procdynp.numL2Dir);
+        l2dir.rt_power = l2dir.rt_power + l2dirarray[i]->rt_power * pppm_t;
+        rt_power = rt_power + l2dir.rt_power;
 
-		  }
-		  else{
-			  set_pppm(pppm_t,1/l2dirarray[i]->cachep.executionTime, 1, 1, 1);
-        l2dir.rt_power = l2dir.rt_power + l2dirarray[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + l2dirarray[i]->rt_power*pppm_t;
-		  }
-	  }
-
+      } else {
+        set_pppm(pppm_t, 1 / l2dirarray[i]->cachep.executionTime, 1, 1, 1);
+        l2dir.rt_power = l2dir.rt_power + l2dirarray[i]->rt_power * pppm_t;
+        rt_power = rt_power + l2dirarray[i]->rt_power * pppm_t;
+      }
+    }
 
   mcs.rt_power.reset();
-  if (XML->sys.mc.number_mcs >0 && XML->sys.mc.memory_channels_per_mc>0)
-  {
-	  mc->rt_power.reset();
-    mc->mcp.executionTime = XML->sys.total_cycles /(XML->sys.core[0].clock_rate*1e6); //Jingwen
-	  mc->computeEnergy(false);
-	  set_pppm(pppm_t,1/mc->mcp.executionTime, XML->sys.mc.number_mcs,XML->sys.mc.number_mcs,XML->sys.mc.number_mcs);
-	  mcs.rt_power = mc->rt_power*pppm_t;
-	  rt_power = rt_power  + mcs.rt_power;
-
-  }
-  
-
-/*  
-  if (XML->sys.flashc.number_mcs >0 )//flash controller
-  {
-	  flashcontrollers.rt_power.reset();
-	  flashcontroller->computeEnergy(false);
-	  double number_fcs = flashcontroller->fcp.num_mcs;
-	  set_pppm(pppm_t,number_fcs , number_fcs ,number_fcs ,number_fcs );
-	  flashcontrollers.rt_power = flashcontroller->rt_power*pppm_t;
-	  rt_power = rt_power  + flashcontrollers.rt_power;
-
+  if (XML->sys.mc.number_mcs > 0 && XML->sys.mc.memory_channels_per_mc > 0) {
+    mc->rt_power.reset();
+    mc->mcp.executionTime =
+        XML->sys.total_cycles / (XML->sys.core[0].clock_rate * 1e6);  // Jingwen
+    mc->computeEnergy(false);
+    set_pppm(pppm_t, 1 / mc->mcp.executionTime, XML->sys.mc.number_mcs,
+             XML->sys.mc.number_mcs, XML->sys.mc.number_mcs);
+    mcs.rt_power = mc->rt_power * pppm_t;
+    rt_power = rt_power + mcs.rt_power;
   }
 
-  if (XML->sys.niu.number_units >0)
-  {
-	  niu->computeEnergy(false);
-	  nius.rt_power.reset();
-	  set_pppm(pppm_t,XML->sys.niu.number_units*niu->niup.clockRate, XML->sys.niu.number_units,XML->sys.niu.number_units,XML->sys.niu.number_units);
-	  nius.rt_power = niu->rt_power*pppm_t;
-	  rt_power = rt_power  + nius.rt_power;
+  /*
+    if (XML->sys.flashc.number_mcs >0 )//flash controller
+    {
+            flashcontrollers.rt_power.reset();
+            flashcontroller->computeEnergy(false);
+            double number_fcs = flashcontroller->fcp.num_mcs;
+            set_pppm(pppm_t,number_fcs , number_fcs ,number_fcs ,number_fcs );
+            flashcontrollers.rt_power = flashcontroller->rt_power*pppm_t;
+            rt_power = rt_power  + flashcontrollers.rt_power;
 
+    }
+
+    if (XML->sys.niu.number_units >0)
+    {
+            niu->computeEnergy(false);
+            nius.rt_power.reset();
+            set_pppm(pppm_t,XML->sys.niu.number_units*niu->niup.clockRate,
+    XML->sys.niu.number_units,XML->sys.niu.number_units,XML->sys.niu.number_units);
+            nius.rt_power = niu->rt_power*pppm_t;
+            rt_power = rt_power  + nius.rt_power;
+
+    }
+
+    if (XML->sys.pcie.number_units >0 && XML->sys.pcie.num_channels >0)
+    {
+            pcie->computeEnergy(false);
+            pcies.rt_power.reset();
+            set_pppm(pppm_t,XML->sys.pcie.number_units*pcie->pciep.clockRate,
+    XML->sys.pcie.number_units,XML->sys.pcie.number_units,XML->sys.pcie.number_units);
+            pcies.rt_power = pcie->rt_power*pppm_t;
+            rt_power = rt_power  + pcies.rt_power;
+
+    }
+
+
+             // * Compute global links associated with each NOC, if any. This
+    must be done at the end (even after the NOC router part) since the total
+    chip
+             // * area must be obtain to decide the link routing
+            */
+  // Compute energy of NoC (w or w/o links) or buses
+  noc.rt_power.reset();
+  for (i = 0; i < numNOC; i++) {
+    nocs[i]->nocdynp.executionTime =
+        XML->sys.total_cycles / (XML->sys.core[0].clock_rate * 1e6);
+    nocs[i]->computeEnergy(false);
+    if (procdynp.homoNOC) {
+      set_pppm(pppm_t, 1 / nocs[i]->nocdynp.executionTime, procdynp.numNOC,
+               procdynp.numNOC, procdynp.numNOC);
+      noc.rt_power = noc.rt_power + nocs[i]->rt_power * pppm_t;
+      rt_power = rt_power + noc.rt_power;
+    } else {
+      set_pppm(pppm_t, 1 / nocs[i]->nocdynp.executionTime, 1, 1, 1);
+      noc.rt_power = noc.rt_power + nocs[i]->rt_power * pppm_t;
+      rt_power = rt_power + nocs[i]->rt_power * pppm_t;
+    }
   }
 
-  if (XML->sys.pcie.number_units >0 && XML->sys.pcie.num_channels >0)
-  {
-	  pcie->computeEnergy(false);
-	  pcies.rt_power.reset();
-	  set_pppm(pppm_t,XML->sys.pcie.number_units*pcie->pciep.clockRate, XML->sys.pcie.number_units,XML->sys.pcie.number_units,XML->sys.pcie.number_units);
-	  pcies.rt_power = pcie->rt_power*pppm_t;
-	  rt_power = rt_power  + pcies.rt_power;
+  //  //clock power
+  //  globalClock.init_wire_external(is_default, &interface_ip);
+  //  globalClock.clk_area           =area*1e6; //change it from mm^2 to um^2
+  //  globalClock.end_wiring_level   =5;//toplevel metal
+  //  globalClock.start_wiring_level =5;//toplevel metal
+  //  globalClock.l_ip.with_clock_grid=false;//global clock does not drive local
+  //  final nodes
+  //  globalClock.optimize_wire();
+}
 
+void Processor::displayDeviceType(int device_type_, uint32_t indent) {
+  string indent_str(indent, ' ');
+
+  switch (device_type_) {
+    case 0:
+      cout << indent_str << "Device Type= "
+           << "ITRS high performance device type" << endl;
+      break;
+    case 1:
+      cout << indent_str << "Device Type= "
+           << "ITRS low standby power device type" << endl;
+      break;
+    case 2:
+      cout << indent_str << "Device Type= "
+           << "ITRS low operating power device type" << endl;
+      break;
+    case 3:
+      cout << indent_str << "Device Type= "
+           << "LP-DRAM device type" << endl;
+      break;
+    case 4:
+      cout << indent_str << "Device Type= "
+           << "COMM-DRAM device type" << endl;
+      break;
+    default: {
+      cout << indent_str << "Unknown Device Type" << endl;
+      exit(0);
+    }
   }
-
-	  
-	   // * Compute global links associated with each NOC, if any. This must be done at the end (even after the NOC router part) since the total chip
-	   // * area must be obtain to decide the link routing
-	  */ 
-	  //Compute energy of NoC (w or w/o links) or buses
-    noc.rt_power.reset();
-	  for (i = 0;i < numNOC; i++)
-	  {
-		 nocs[i]->nocdynp.executionTime=XML->sys.total_cycles /(XML->sys.core[0].clock_rate*1e6);
-		  nocs[i]->computeEnergy(false);
-		  if (procdynp.homoNOC){
-			  set_pppm(pppm_t,1/nocs[i]->nocdynp.executionTime, procdynp.numNOC,procdynp.numNOC,procdynp.numNOC);
-			  noc.rt_power = noc.rt_power + nocs[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + noc.rt_power;
-		  }
-		  else
-		  {
-			  set_pppm(pppm_t,1/nocs[i]->nocdynp.executionTime, 1, 1, 1);
-			  noc.rt_power = noc.rt_power + nocs[i]->rt_power*pppm_t;
-			  rt_power = rt_power  + nocs[i]->rt_power*pppm_t;
-		  }
-	  } 
-    
-
-//  //clock power
-//  globalClock.init_wire_external(is_default, &interface_ip);
-//  globalClock.clk_area           =area*1e6; //change it from mm^2 to um^2
-//  globalClock.end_wiring_level   =5;//toplevel metal
-//  globalClock.start_wiring_level =5;//toplevel metal
-//  globalClock.l_ip.with_clock_grid=false;//global clock does not drive local final nodes
-//  globalClock.optimize_wire();
-
 }
 
-void Processor::displayDeviceType(int device_type_, uint32_t indent)
-{
-	string indent_str(indent, ' ');
+void Processor::displayInterconnectType(int interconnect_type_,
+                                        uint32_t indent) {
+  string indent_str(indent, ' ');
 
-	switch ( device_type_ ) {
-
-	  case 0 :
-		  cout <<indent_str<<"Device Type= "<<"ITRS high performance device type"<<endl;
-	    break;
-	  case 1 :
-		  cout <<indent_str<<"Device Type= "<<"ITRS low standby power device type"<<endl;
-	    break;
-	  case 2 :
-		  cout <<indent_str<<"Device Type= "<<"ITRS low operating power device type"<<endl;
-	    break;
-	  case 3 :
-		  cout <<indent_str<<"Device Type= "<<"LP-DRAM device type"<<endl;
-	    break;
-	  case 4 :
-		  cout <<indent_str<<"Device Type= "<<"COMM-DRAM device type"<<endl;
-	    break;
-	  default :
-		  {
-			  cout <<indent_str<<"Unknown Device Type"<<endl;
-			  exit(0);
-		  }
-	}
+  switch (interconnect_type_) {
+    case 0:
+      cout << indent_str << "Interconnect metal projection= "
+           << "aggressive interconnect technology projection" << endl;
+      break;
+    case 1:
+      cout << indent_str << "Interconnect metal projection= "
+           << "conservative interconnect technology projection" << endl;
+      break;
+    default: {
+      cout << indent_str << "Unknown Interconnect Projection Type" << endl;
+      exit(0);
+    }
+  }
 }
 
-void Processor::displayInterconnectType(int interconnect_type_, uint32_t indent)
-{
-	string indent_str(indent, ' ');
+void Processor::displayEnergy(uint32_t indent, int plevel, bool is_tdp_parm) {
+  int i;
+  bool long_channel = XML->sys.longer_channel_device;
+  string indent_str(indent, ' ');
+  string indent_str_next(indent + 2, ' ');
+  bool is_tdp = is_tdp_parm;
+  if (is_tdp_parm) {
+    if (plevel < 5) {
+      cout
+          << "\nMcPAT (version " << VER_MAJOR << "." << VER_MINOR << " of "
+          << VER_UPDATE << ") results (current print level is " << plevel
+          << ", please increase print level to see the details in components): "
+          << endl;
+    } else {
+      cout << "\nMcPAT (version " << VER_MAJOR << "." << VER_MINOR << " of "
+           << VER_UPDATE << ") results  (current print level is 5)" << endl;
+    }
+    cout << "******************************************************************"
+            "***********************"
+         << endl;
+    cout << indent_str << "Technology " << XML->sys.core_tech_node << " nm"
+         << endl;
+    // cout <<indent_str<<"Device Type= "<<XML->sys.device_type<<endl;
+    if (long_channel)
+      cout << indent_str << "Using Long Channel Devices When Appropriate"
+           << endl;
+    // cout <<indent_str<<"Interconnect metal projection=
+    // "<<XML->sys.interconnect_projection_type<<endl;
+    displayInterconnectType(XML->sys.interconnect_projection_type, indent);
+    cout << indent_str << "Core clock Rate(MHz) " << XML->sys.core[0].clock_rate
+         << endl;
+    cout << endl;
+    cout << "******************************************************************"
+            "***********************"
+         << endl;
+    cout << "Processor: " << endl;
+    cout << indent_str << "Area = " << area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str << "Peak Power = "
+         << power.readOp.dynamic +
+                (long_channel ? power.readOp.longer_channel_leakage
+                              : power.readOp.leakage) +
+                power.readOp.gate_leakage
+         << " W" << endl;
+    cout << indent_str << "Total Leakage = "
+         << (long_channel ? power.readOp.longer_channel_leakage
+                          : power.readOp.leakage) +
+                power.readOp.gate_leakage
+         << " W" << endl;
+    cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic << " W"
+         << endl;
+    cout << indent_str << "Subthreshold Leakage = "
+         << (long_channel ? power.readOp.longer_channel_leakage
+                          : power.readOp.leakage)
+         << " W" << endl;
+    // cout << indent_str << "Subthreshold Leakage = " <<
+    // power.readOp.longer_channel_leakage <<" W" << endl;
+    cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str << "Runtime Dynamic = " << rt_power.readOp.dynamic
+         << " W" << endl;
+    cout << endl;
+    if (numCore > 0) {
+      cout << indent_str << "Total Cores: " << XML->sys.number_of_cores
+           << " cores " << endl;
+      displayDeviceType(XML->sys.device_type, indent);
+      cout << indent_str_next << "Area = " << core.area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next << "Peak Dynamic = " << core.power.readOp.dynamic
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? core.power.readOp.longer_channel_leakage
+                            : core.power.readOp.leakage)
+           << " W" << endl;
+      // cout << indent_str_next << "Subthreshold Leakage = " <<
+      // core.power.readOp.longer_channel_leakage <<" W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << core.power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next
+           << "Runtime Dynamic = " << core.rt_power.readOp.dynamic << " W"
+           << endl;
+      cout << endl;
+    }
+    if (!XML->sys.Private_L2) {
+      if (numL2 > 0) {
+        cout << indent_str << "Total L2s: " << endl;
+        displayDeviceType(XML->sys.L2[0].device_type, indent);
+        cout << indent_str_next << "Area = " << l2.area.get_area() * 1e-6
+             << " mm^2" << endl;
+        cout << indent_str_next << "Peak Dynamic = " << l2.power.readOp.dynamic
+             << " W" << endl;
+        cout << indent_str_next << "Subthreshold Leakage = "
+             << (long_channel ? l2.power.readOp.longer_channel_leakage
+                              : l2.power.readOp.leakage)
+             << " W" << endl;
+        // cout << indent_str_next << "Subthreshold Leakage = " <<
+        // l2.power.readOp.longer_channel_leakage <<" W" << endl;
+        cout << indent_str_next
+             << "Gate Leakage = " << l2.power.readOp.gate_leakage << " W"
+             << endl;
+        cout << indent_str_next
+             << "Runtime Dynamic = " << l2.rt_power.readOp.dynamic << " W"
+             << endl;
+        cout << endl;
+      }
+    }
+    if (numL3 > 0) {
+      cout << indent_str << "Total L3s: " << endl;
+      displayDeviceType(XML->sys.L3[0].device_type, indent);
+      cout << indent_str_next << "Area = " << l3.area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next << "Peak Dynamic = " << l3.power.readOp.dynamic
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? l3.power.readOp.longer_channel_leakage
+                            : l3.power.readOp.leakage)
+           << " W" << endl;
+      // cout << indent_str_next << "Subthreshold Leakage = " <<
+      // l3.power.readOp.longer_channel_leakage <<" W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << l3.power.readOp.gate_leakage << " W" << endl;
+      cout << indent_str_next
+           << "Runtime Dynamic = " << l3.rt_power.readOp.dynamic << " W"
+           << endl;
+      cout << endl;
+    }
+    if (numL1Dir > 0) {
+      cout << indent_str << "Total First Level Directory: " << endl;
+      displayDeviceType(XML->sys.L1Directory[0].device_type, indent);
+      cout << indent_str_next << "Area = " << l1dir.area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next << "Peak Dynamic = " << l1dir.power.readOp.dynamic
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? l1dir.power.readOp.longer_channel_leakage
+                            : l1dir.power.readOp.leakage)
+           << " W" << endl;
+      // cout << indent_str_next << "Subthreshold Leakage = " <<
+      // l1dir.power.readOp.longer_channel_leakage <<" W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << l1dir.power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next
+           << "Runtime Dynamic = " << l1dir.rt_power.readOp.dynamic << " W"
+           << endl;
+      cout << endl;
+    }
+    if (numL2Dir > 0) {
+      cout << indent_str << "Total First Level Directory: " << endl;
+      displayDeviceType(XML->sys.L1Directory[0].device_type, indent);
+      cout << indent_str_next << "Area = " << l2dir.area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next << "Peak Dynamic = " << l2dir.power.readOp.dynamic
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? l2dir.power.readOp.longer_channel_leakage
+                            : l2dir.power.readOp.leakage)
+           << " W" << endl;
+      // cout << indent_str_next << "Subthreshold Leakage = " <<
+      // l2dir.power.readOp.longer_channel_leakage <<" W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << l2dir.power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next
+           << "Runtime Dynamic = " << l2dir.rt_power.readOp.dynamic << " W"
+           << endl;
+      cout << endl;
+    }
+    if (numNOC > 0) {
+      cout << indent_str << "Total NoCs (Network/Bus): " << endl;
+      displayDeviceType(XML->sys.device_type, indent);
+      cout << indent_str_next << "Area = " << noc.area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next << "Peak Dynamic = " << noc.power.readOp.dynamic
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? noc.power.readOp.longer_channel_leakage
+                            : noc.power.readOp.leakage)
+           << " W" << endl;
+      // cout << indent_str_next << "Subthreshold Leakage = " <<
+      // noc.power.readOp.longer_channel_leakage  <<" W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << noc.power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next
+           << "Runtime Dynamic = " << noc.rt_power.readOp.dynamic << " W"
+           << endl;
+      cout << endl;
+    }
+    if (XML->sys.mc.number_mcs > 0 && XML->sys.mc.memory_channels_per_mc > 0) {
+      cout << indent_str << "Total MCs: " << XML->sys.mc.number_mcs
+           << " Memory Controllers " << endl;
+      displayDeviceType(XML->sys.device_type, indent);
+      cout << indent_str_next << "Area = " << mcs.area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next << "Peak Dynamic = " << mcs.power.readOp.dynamic
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? mcs.power.readOp.longer_channel_leakage
+                            : mcs.power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << mcs.power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next
+           << "Runtime Dynamic = " << mcs.rt_power.readOp.dynamic << " W"
+           << endl;
+      cout << endl;
+    }
+    if (XML->sys.flashc.number_mcs > 0) {
+      cout << indent_str
+           << "Total Flash/SSD Controllers: " << flashcontroller->fcp.num_mcs
+           << " Flash/SSD Controllers " << endl;
+      displayDeviceType(XML->sys.device_type, indent);
+      cout << indent_str_next
+           << "Area = " << flashcontrollers.area.get_area() * 1e-6 << " mm^2"
+           << endl;
+      cout << indent_str_next
+           << "Peak Dynamic = " << flashcontrollers.power.readOp.dynamic << " W"
+           << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel
+                   ? flashcontrollers.power.readOp.longer_channel_leakage
+                   : flashcontrollers.power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << flashcontrollers.power.readOp.gate_leakage
+           << " W" << endl;
+      cout << indent_str_next
+           << "Runtime Dynamic = " << flashcontrollers.rt_power.readOp.dynamic
+           << " W" << endl;
+      cout << endl;
+    }
+    if (XML->sys.niu.number_units > 0) {
+      cout << indent_str << "Total NIUs: " << niu->niup.num_units
+           << " Network Interface Units " << endl;
+      displayDeviceType(XML->sys.device_type, indent);
+      cout << indent_str_next << "Area = " << nius.area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next << "Peak Dynamic = " << nius.power.readOp.dynamic
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? nius.power.readOp.longer_channel_leakage
+                            : nius.power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << nius.power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next
+           << "Runtime Dynamic = " << nius.rt_power.readOp.dynamic << " W"
+           << endl;
+      cout << endl;
+    }
+    if (XML->sys.pcie.number_units > 0 && XML->sys.pcie.num_channels > 0) {
+      cout << indent_str << "Total PCIes: " << pcie->pciep.num_units
+           << " PCIe Controllers " << endl;
+      displayDeviceType(XML->sys.device_type, indent);
+      cout << indent_str_next << "Area = " << pcies.area.get_area() * 1e-6
+           << " mm^2" << endl;
+      cout << indent_str_next << "Peak Dynamic = " << pcies.power.readOp.dynamic
+           << " W" << endl;
+      cout << indent_str_next << "Subthreshold Leakage = "
+           << (long_channel ? pcies.power.readOp.longer_channel_leakage
+                            : pcies.power.readOp.leakage)
+           << " W" << endl;
+      cout << indent_str_next
+           << "Gate Leakage = " << pcies.power.readOp.gate_leakage << " W"
+           << endl;
+      cout << indent_str_next
+           << "Runtime Dynamic = " << pcies.rt_power.readOp.dynamic << " W"
+           << endl;
+      cout << endl;
+    }
+    cout << "******************************************************************"
+            "***********************"
+         << endl;
+    if (plevel > 1) {
+      for (i = 0; i < numCore; i++) {
+        cores[i]->displayEnergy(indent + 4, plevel, is_tdp);
+        cout << "**************************************************************"
+                "***************************"
+             << endl;
+      }
+      if (!XML->sys.Private_L2) {
+        for (i = 0; i < numL2; i++) {
+          l2array[i]->displayEnergy(indent + 4, is_tdp);
+          cout << "************************************************************"
+                  "*****************************"
+               << endl;
+        }
+      }
+      for (i = 0; i < numL3; i++) {
+        l3array[i]->displayEnergy(indent + 4, is_tdp);
+        cout << "**************************************************************"
+                "***************************"
+             << endl;
+      }
+      for (i = 0; i < numL1Dir; i++) {
+        l1dirarray[i]->displayEnergy(indent + 4, is_tdp);
+        cout << "**************************************************************"
+                "***************************"
+             << endl;
+      }
+      for (i = 0; i < numL2Dir; i++) {
+        l2dirarray[i]->displayEnergy(indent + 4, is_tdp);
+        cout << "**************************************************************"
+                "***************************"
+             << endl;
+      }
+      if (XML->sys.mc.number_mcs > 0 &&
+          XML->sys.mc.memory_channels_per_mc > 0) {
+        mc->displayEnergy(indent + 4, is_tdp);
+        cout << "**************************************************************"
+                "***************************"
+             << endl;
+      }
+      if (XML->sys.flashc.number_mcs > 0 &&
+          XML->sys.flashc.memory_channels_per_mc > 0) {
+        flashcontroller->displayEnergy(indent + 4, is_tdp);
+        cout << "**************************************************************"
+                "***************************"
+             << endl;
+      }
+      if (XML->sys.niu.number_units > 0) {
+        niu->displayEnergy(indent + 4, is_tdp);
+        cout << "**************************************************************"
+                "***************************"
+             << endl;
+      }
+      if (XML->sys.pcie.number_units > 0 && XML->sys.pcie.num_channels > 0) {
+        pcie->displayEnergy(indent + 4, is_tdp);
+        cout << "**************************************************************"
+                "***************************"
+             << endl;
+      }
 
-	switch ( interconnect_type_ ) {
-
-	  case 0 :
-		  cout <<indent_str<<"Interconnect metal projection= "<<"aggressive interconnect technology projection"<<endl;
-	    break;
-	  case 1 :
-		  cout <<indent_str<<"Interconnect metal projection= "<<"conservative interconnect technology projection"<<endl;
-	    break;
-	  default :
-		  {
-			  cout <<indent_str<<"Unknown Interconnect Projection Type"<<endl;
-			  exit(0);
-		  }
-	}
+      for (i = 0; i < numNOC; i++) {
+        nocs[i]->displayEnergy(indent + 4, plevel, is_tdp);
+        cout << "**************************************************************"
+                "***************************"
+             << endl;
+      }
+    }
+  } else {
+  }
 }
 
-void Processor::displayEnergy(uint32_t indent, int plevel, bool is_tdp_parm)
-{
-	int i;
-	bool long_channel = XML->sys.longer_channel_device;
-	string indent_str(indent, ' ');
-	string indent_str_next(indent+2, ' ');
-	bool is_tdp=is_tdp_parm;
-	if (is_tdp_parm)
-	{
+void Processor::set_proc_param() {
+  bool debug = false;
 
+  procdynp.homoCore = bool(debug ? 1 : XML->sys.homogeneous_cores);
+  procdynp.homoL2 = bool(debug ? 1 : XML->sys.homogeneous_L2s);
+  procdynp.homoL3 = bool(debug ? 1 : XML->sys.homogeneous_L3s);
+  procdynp.homoNOC = bool(debug ? 1 : XML->sys.homogeneous_NoCs);
+  procdynp.homoL1Dir = bool(debug ? 1 : XML->sys.homogeneous_L1Directories);
+  procdynp.homoL2Dir = bool(debug ? 1 : XML->sys.homogeneous_L2Directories);
 
-		if (plevel<5)
-		{
-			cout<<"\nMcPAT (version "<< VER_MAJOR <<"."<< VER_MINOR
-					<< " of " << VER_UPDATE << ") results (current print level is "<< plevel
-			<<", please increase print level to see the details in components): "<<endl;
-		}
-		else
-		{
-			cout<<"\nMcPAT (version "<< VER_MAJOR <<"."<< VER_MINOR
-								<< " of " << VER_UPDATE << ") results  (current print level is 5)"<< endl;
-		}
-		cout <<"*****************************************************************************************"<<endl;
-		cout <<indent_str<<"Technology "<<XML->sys.core_tech_node<<" nm"<<endl;
-		//cout <<indent_str<<"Device Type= "<<XML->sys.device_type<<endl;
-		if (long_channel)
-			cout <<indent_str<<"Using Long Channel Devices When Appropriate"<<endl;
-		//cout <<indent_str<<"Interconnect metal projection= "<<XML->sys.interconnect_projection_type<<endl;
-		displayInterconnectType(XML->sys.interconnect_projection_type, indent);
-		cout <<indent_str<<"Core clock Rate(MHz) "<<XML->sys.core[0].clock_rate<<endl;
-    	cout <<endl;
-		cout <<"*****************************************************************************************"<<endl;
-		cout <<"Processor: "<<endl;
-		cout << indent_str << "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str << "Peak Power = " << power.readOp.dynamic +
-			(long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) + power.readOp.gate_leakage <<" W" << endl;
-		cout << indent_str << "Total Leakage = " <<
-			(long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) + power.readOp.gate_leakage <<" W" << endl;
-		cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic << " W" << endl;
-		cout << indent_str << "Subthreshold Leakage = " << (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
-		//cout << indent_str << "Subthreshold Leakage = " << power.readOp.longer_channel_leakage <<" W" << endl;
-		cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str << "Runtime Dynamic = " << rt_power.readOp.dynamic << " W" << endl;
-		cout <<endl;
-		if (numCore >0){
-		cout <<indent_str<<"Total Cores: "<<XML->sys.number_of_cores << " cores "<<endl;
-		displayDeviceType(XML->sys.device_type,indent);
-		cout << indent_str_next << "Area = " << core.area.get_area()*1e-6<< " mm^2" << endl;
-		cout << indent_str_next << "Peak Dynamic = " << core.power.readOp.dynamic << " W" << endl;
-		cout << indent_str_next << "Subthreshold Leakage = "
-			<< (long_channel? core.power.readOp.longer_channel_leakage:core.power.readOp.leakage) <<" W" << endl;
-		//cout << indent_str_next << "Subthreshold Leakage = " << core.power.readOp.longer_channel_leakage <<" W" << endl;
-		cout << indent_str_next << "Gate Leakage = " << core.power.readOp.gate_leakage << " W" << endl;
-		cout << indent_str_next << "Runtime Dynamic = " << core.rt_power.readOp.dynamic << " W" << endl;
-		cout <<endl;
-		}
-		if (!XML->sys.Private_L2)
-		{
-			if (numL2 >0){
-				cout <<indent_str<<"Total L2s: "<<endl;
-				displayDeviceType(XML->sys.L2[0].device_type,indent);
-				cout << indent_str_next << "Area = " << l2.area.get_area()*1e-6<< " mm^2" << endl;
-				cout << indent_str_next << "Peak Dynamic = " << l2.power.readOp.dynamic << " W" << endl;
-				cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? l2.power.readOp.longer_channel_leakage:l2.power.readOp.leakage) <<" W" << endl;
-				//cout << indent_str_next << "Subthreshold Leakage = " << l2.power.readOp.longer_channel_leakage <<" W" << endl;
-				cout << indent_str_next << "Gate Leakage = " << l2.power.readOp.gate_leakage << " W" << endl;
-				cout << indent_str_next << "Runtime Dynamic = " << l2.rt_power.readOp.dynamic << " W" << endl;
-				cout <<endl;
-			}
-		}
-		if (numL3 >0){
-			cout <<indent_str<<"Total L3s: "<<endl;
-			displayDeviceType(XML->sys.L3[0].device_type, indent);
-			cout << indent_str_next << "Area = " << l3.area.get_area()*1e-6<< " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << l3.power.readOp.dynamic << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? l3.power.readOp.longer_channel_leakage:l3.power.readOp.leakage) <<" W" << endl;
-			//cout << indent_str_next << "Subthreshold Leakage = " << l3.power.readOp.longer_channel_leakage <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << l3.power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << l3.rt_power.readOp.dynamic << " W" << endl;
-			cout <<endl;
-		}
-		if (numL1Dir >0){
-			cout <<indent_str<<"Total First Level Directory: "<<endl;
-			displayDeviceType(XML->sys.L1Directory[0].device_type, indent);
-			cout << indent_str_next << "Area = " << l1dir.area.get_area()*1e-6<< " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << l1dir.power.readOp.dynamic << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? l1dir.power.readOp.longer_channel_leakage:l1dir.power.readOp.leakage) <<" W" << endl;
-			//cout << indent_str_next << "Subthreshold Leakage = " << l1dir.power.readOp.longer_channel_leakage <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << l1dir.power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << l1dir.rt_power.readOp.dynamic << " W" << endl;
-			cout <<endl;
-		}
-		if (numL2Dir >0){
-			cout <<indent_str<<"Total First Level Directory: "<<endl;
-			displayDeviceType(XML->sys.L1Directory[0].device_type, indent);
-			cout << indent_str_next << "Area = " << l2dir.area.get_area()*1e-6<< " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << l2dir.power.readOp.dynamic << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? l2dir.power.readOp.longer_channel_leakage:l2dir.power.readOp.leakage) <<" W" << endl;
-			//cout << indent_str_next << "Subthreshold Leakage = " << l2dir.power.readOp.longer_channel_leakage <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << l2dir.power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << l2dir.rt_power.readOp.dynamic << " W" << endl;
-			cout <<endl;
-		}
-		if (numNOC >0){
-			cout <<indent_str<<"Total NoCs (Network/Bus): "<<endl;
-			displayDeviceType(XML->sys.device_type, indent);
-			cout << indent_str_next << "Area = " << noc.area.get_area()*1e-6<< " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << noc.power.readOp.dynamic << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? noc.power.readOp.longer_channel_leakage:noc.power.readOp.leakage) <<" W" << endl;
-			//cout << indent_str_next << "Subthreshold Leakage = " << noc.power.readOp.longer_channel_leakage  <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << noc.power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << noc.rt_power.readOp.dynamic << " W" << endl;
-			cout <<endl;
-		}
-		if (XML->sys.mc.number_mcs >0 && XML->sys.mc.memory_channels_per_mc>0)
-		{
-			cout <<indent_str<<"Total MCs: "<<XML->sys.mc.number_mcs << " Memory Controllers "<<endl;
-			displayDeviceType(XML->sys.device_type, indent);
-			cout << indent_str_next << "Area = " << mcs.area.get_area()*1e-6<< " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << mcs.power.readOp.dynamic << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? mcs.power.readOp.longer_channel_leakage:mcs.power.readOp.leakage)  <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << mcs.power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << mcs.rt_power.readOp.dynamic << " W" << endl;
-			cout <<endl;
-		}
-		if (XML->sys.flashc.number_mcs >0)
-		{
-			cout <<indent_str<<"Total Flash/SSD Controllers: "<<flashcontroller->fcp.num_mcs << " Flash/SSD Controllers "<<endl;
-			displayDeviceType(XML->sys.device_type, indent);
-			cout << indent_str_next << "Area = " << flashcontrollers.area.get_area()*1e-6<< " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << flashcontrollers.power.readOp.dynamic << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? flashcontrollers.power.readOp.longer_channel_leakage:flashcontrollers.power.readOp.leakage)  <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << flashcontrollers.power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << flashcontrollers.rt_power.readOp.dynamic << " W" << endl;
-			cout <<endl;
-		}
-		if (XML->sys.niu.number_units >0 )
-		{
-			cout <<indent_str<<"Total NIUs: "<<niu->niup.num_units << " Network Interface Units "<<endl;
-			displayDeviceType(XML->sys.device_type, indent);
-			cout << indent_str_next << "Area = " << nius.area.get_area()*1e-6<< " mm^2" << endl;
-			cout << indent_str_next << "Peak Dynamic = " << nius.power.readOp.dynamic << " W" << endl;
-			cout << indent_str_next << "Subthreshold Leakage = "
-				<< (long_channel? nius.power.readOp.longer_channel_leakage:nius.power.readOp.leakage)  <<" W" << endl;
-			cout << indent_str_next << "Gate Leakage = " << nius.power.readOp.gate_leakage << " W" << endl;
-			cout << indent_str_next << "Runtime Dynamic = " << nius.rt_power.readOp.dynamic << " W" << endl;
-			cout <<endl;
-		}
-		if (XML->sys.pcie.number_units >0 && XML->sys.pcie.num_channels>0)
-				{
-					cout <<indent_str<<"Total PCIes: "<<pcie->pciep.num_units << " PCIe Controllers "<<endl;
-					displayDeviceType(XML->sys.device_type, indent);
-					cout << indent_str_next << "Area = " << pcies.area.get_area()*1e-6<< " mm^2" << endl;
-					cout << indent_str_next << "Peak Dynamic = " << pcies.power.readOp.dynamic << " W" << endl;
-					cout << indent_str_next << "Subthreshold Leakage = "
-						<< (long_channel? pcies.power.readOp.longer_channel_leakage:pcies.power.readOp.leakage)  <<" W" << endl;
-					cout << indent_str_next << "Gate Leakage = " << pcies.power.readOp.gate_leakage << " W" << endl;
-					cout << indent_str_next << "Runtime Dynamic = " << pcies.rt_power.readOp.dynamic << " W" << endl;
-					cout <<endl;
-				}
-		cout <<"*****************************************************************************************"<<endl;
-		if (plevel >1)
-		{
-			for (i = 0;i < numCore; i++)
-			{
-				cores[i]->displayEnergy(indent+4,plevel,is_tdp);
-				cout <<"*****************************************************************************************"<<endl;
-			}
-			if (!XML->sys.Private_L2)
-			{
-				for (i = 0;i < numL2; i++)
-				{
-					l2array[i]->displayEnergy(indent+4,is_tdp);
-					cout <<"*****************************************************************************************"<<endl;
-				}
-			}
-			for (i = 0;i < numL3; i++)
-			{
-				l3array[i]->displayEnergy(indent+4,is_tdp);
-				cout <<"*****************************************************************************************"<<endl;
-			}
-			for (i = 0;i < numL1Dir; i++)
-			{
-				l1dirarray[i]->displayEnergy(indent+4,is_tdp);
-				cout <<"*****************************************************************************************"<<endl;
-			}
-			for (i = 0;i < numL2Dir; i++)
-			{
-				l2dirarray[i]->displayEnergy(indent+4,is_tdp);
-				cout <<"*****************************************************************************************"<<endl;
-			}
-			if (XML->sys.mc.number_mcs >0 && XML->sys.mc.memory_channels_per_mc>0)
-			{
-				mc->displayEnergy(indent+4,is_tdp);
-				cout <<"*****************************************************************************************"<<endl;
-			}
-			if (XML->sys.flashc.number_mcs >0 && XML->sys.flashc.memory_channels_per_mc>0)
-			{
-				flashcontroller->displayEnergy(indent+4,is_tdp);
-				cout <<"*****************************************************************************************"<<endl;
-			}
-			if (XML->sys.niu.number_units >0 )
-			{
-				niu->displayEnergy(indent+4,is_tdp);
-				cout <<"*****************************************************************************************"<<endl;
-			}
-			if (XML->sys.pcie.number_units >0 && XML->sys.pcie.num_channels>0)
-			{
-				pcie->displayEnergy(indent+4,is_tdp);
-				cout <<"*****************************************************************************************"<<endl;
-			}
+  procdynp.numCore = XML->sys.number_of_cores;
+  procdynp.numL2 = XML->sys.number_of_L2s;
+  procdynp.numL3 = XML->sys.number_of_L3s;
+  procdynp.numNOC = XML->sys.number_of_NoCs;
+  procdynp.numL1Dir = XML->sys.number_of_L1Directories;
+  procdynp.numL2Dir = XML->sys.number_of_L2Directories;
+  procdynp.numMC = XML->sys.mc.number_mcs;
+  procdynp.numMCChannel = XML->sys.mc.memory_channels_per_mc;
 
-			for (i = 0;i < numNOC; i++)
-			{
-				nocs[i]->displayEnergy(indent+4,plevel,is_tdp);
-				cout <<"*****************************************************************************************"<<endl;
-			}
-		}
-	}
-	else
-	{
+  //	if (procdynp.numCore<1)
+  //	{
+  //		cout<<" The target processor should at least have one core on chip."
+  //<<endl;
+  //		exit(0);
+  //	}
 
-	}
+  //  if (numNOCs<0 || numNOCs>2)
+  //    {
+  //  	  cout <<"number of NOCs must be 1 (only global NOCs) or 2 (both global
+  //  and local NOCs)"<<endl;
+  //  	  exit(0);
+  //    }
 
+  /* Basic parameters*/
+  interface_ip.data_arr_ram_cell_tech_type = debug ? 0 : XML->sys.device_type;
+  interface_ip.data_arr_peri_global_tech_type =
+      debug ? 0 : XML->sys.device_type;
+  interface_ip.tag_arr_ram_cell_tech_type = debug ? 0 : XML->sys.device_type;
+  interface_ip.tag_arr_peri_global_tech_type = debug ? 0 : XML->sys.device_type;
+
+  interface_ip.ic_proj_type = debug ? 0 : XML->sys.interconnect_projection_type;
+  interface_ip.delay_wt =
+      100;                   // Fixed number, make sure timing can be satisfied.
+  interface_ip.area_wt = 0;  // Fixed number, This is used to exhaustive search
+                             // for individual components.
+  interface_ip.dynamic_power_wt = 100;  // Fixed number, This is used to
+                                        // exhaustive search for individual
+                                        // components.
+  interface_ip.leakage_power_wt = 0;
+  interface_ip.cycle_time_wt = 0;
+
+  interface_ip.delay_dev =
+      10000;  // Fixed number, make sure timing can be satisfied.
+  interface_ip.area_dev = 10000;  // Fixed number, This is used to exhaustive
+                                  // search for individual components.
+  interface_ip.dynamic_power_dev = 10000;  // Fixed number, This is used to
+                                           // exhaustive search for individual
+                                           // components.
+  interface_ip.leakage_power_dev = 10000;
+  interface_ip.cycle_time_dev = 10000;
+
+  interface_ip.ed = 2;
+  interface_ip.burst_len = 1;  // parameters are fixed for processor section,
+                               // since memory is processed separately
+  interface_ip.int_prefetch_w = 1;
+  interface_ip.page_sz_bits = 0;
+  interface_ip.temp = debug ? 360 : XML->sys.temperature;
+  interface_ip.F_sz_nm =
+      debug ? 90 : XML->sys.core_tech_node;  // XML->sys.core_tech_node;
+  interface_ip.F_sz_um = interface_ip.F_sz_nm / 1000;
+
+  //***********This section of code does not have real meaning, they are just to
+  //ensure all data will have initial value to prevent errors.
+  // They will be overridden  during each components initialization
+  interface_ip.cache_sz = 64;
+  interface_ip.line_sz = 1;
+  interface_ip.assoc = 1;
+  interface_ip.nbanks = 1;
+  interface_ip.out_w = interface_ip.line_sz * 8;
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = 64;
+  interface_ip.access_mode = 2;
+
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t = 1;
+
+  interface_ip.is_main_mem = false;
+  interface_ip.rpters_in_htree = true;
+  interface_ip.ver_htree_wires_over_array = 0;
+  interface_ip.broadcast_addr_din_over_ver_htrees = 0;
+
+  interface_ip.num_rw_ports = 1;
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  interface_ip.num_search_ports = 1;
+  interface_ip.nuca = 0;
+  interface_ip.nuca_bank_count = 0;
+  interface_ip.is_cache = true;
+  interface_ip.pure_ram = false;
+  interface_ip.pure_cam = false;
+  interface_ip.force_cache_config = false;
+  if (XML->sys.Embedded) {
+    interface_ip.wt = Global_30;
+    interface_ip.wire_is_mat_type = 0;
+    interface_ip.wire_os_mat_type = 0;
+  } else {
+    interface_ip.wt = Global;
+    interface_ip.wire_is_mat_type = 2;
+    interface_ip.wire_os_mat_type = 2;
+  }
+  interface_ip.force_wiretype = false;
+  interface_ip.print_detail = 1;
+  interface_ip.add_ecc_b_ = true;
 }
 
-void Processor::set_proc_param()
-{
-	bool debug = false;
-
-	procdynp.homoCore = bool(debug?1:XML->sys.homogeneous_cores);
-	procdynp.homoL2   = bool(debug?1:XML->sys.homogeneous_L2s);
-	procdynp.homoL3   = bool(debug?1:XML->sys.homogeneous_L3s);
-	procdynp.homoNOC  = bool(debug?1:XML->sys.homogeneous_NoCs);
-	procdynp.homoL1Dir  = bool(debug?1:XML->sys.homogeneous_L1Directories);
-	procdynp.homoL2Dir  = bool(debug?1:XML->sys.homogeneous_L2Directories);
-
-	procdynp.numCore = XML->sys.number_of_cores;
-	procdynp.numL2   = XML->sys.number_of_L2s;
-	procdynp.numL3   = XML->sys.number_of_L3s;
-	procdynp.numNOC  = XML->sys.number_of_NoCs;
-	procdynp.numL1Dir  = XML->sys.number_of_L1Directories;
-	procdynp.numL2Dir  = XML->sys.number_of_L2Directories;
-	procdynp.numMC = XML->sys.mc.number_mcs;
-	procdynp.numMCChannel = XML->sys.mc.memory_channels_per_mc;
-
-//	if (procdynp.numCore<1)
-//	{
-//		cout<<" The target processor should at least have one core on chip." <<endl;
-//		exit(0);
-//	}
-
-	//  if (numNOCs<0 || numNOCs>2)
-	//    {
-	//  	  cout <<"number of NOCs must be 1 (only global NOCs) or 2 (both global and local NOCs)"<<endl;
-	//  	  exit(0);
-	//    }
-
-	/* Basic parameters*/
-	interface_ip.data_arr_ram_cell_tech_type    = debug?0:XML->sys.device_type;
-	interface_ip.data_arr_peri_global_tech_type = debug?0:XML->sys.device_type;
-	interface_ip.tag_arr_ram_cell_tech_type     = debug?0:XML->sys.device_type;
-	interface_ip.tag_arr_peri_global_tech_type  = debug?0:XML->sys.device_type;
-
-	interface_ip.ic_proj_type     = debug?0:XML->sys.interconnect_projection_type;
-	interface_ip.delay_wt                = 100;//Fixed number, make sure timing can be satisfied.
-	interface_ip.area_wt                 = 0;//Fixed number, This is used to exhaustive search for individual components.
-	interface_ip.dynamic_power_wt        = 100;//Fixed number, This is used to exhaustive search for individual components.
-	interface_ip.leakage_power_wt        = 0;
-	interface_ip.cycle_time_wt           = 0;
-
-	interface_ip.delay_dev                = 10000;//Fixed number, make sure timing can be satisfied.
-	interface_ip.area_dev                 = 10000;//Fixed number, This is used to exhaustive search for individual components.
-	interface_ip.dynamic_power_dev        = 10000;//Fixed number, This is used to exhaustive search for individual components.
-	interface_ip.leakage_power_dev        = 10000;
-	interface_ip.cycle_time_dev           = 10000;
-
-	interface_ip.ed                       = 2;
-	interface_ip.burst_len      = 1;//parameters are fixed for processor section, since memory is processed separately
-	interface_ip.int_prefetch_w = 1;
-	interface_ip.page_sz_bits   = 0;
-	interface_ip.temp = debug?360: XML->sys.temperature;
-	interface_ip.F_sz_nm         = debug?90:XML->sys.core_tech_node;//XML->sys.core_tech_node;
-	interface_ip.F_sz_um         = interface_ip.F_sz_nm / 1000;
-
-	//***********This section of code does not have real meaning, they are just to ensure all data will have initial value to prevent errors.
-	//They will be overridden  during each components initialization
-	interface_ip.cache_sz            =64;
-	interface_ip.line_sz             = 1;
-	interface_ip.assoc               = 1;
-	interface_ip.nbanks              = 1;
-	interface_ip.out_w               = interface_ip.line_sz*8;
-	interface_ip.specific_tag        = 1;
-	interface_ip.tag_w               = 64;
-	interface_ip.access_mode         = 2;
-
-	interface_ip.obj_func_dyn_energy = 0;
-	interface_ip.obj_func_dyn_power  = 0;
-	interface_ip.obj_func_leak_power = 0;
-	interface_ip.obj_func_cycle_t    = 1;
-
-	interface_ip.is_main_mem     = false;
-	interface_ip.rpters_in_htree = true ;
-	interface_ip.ver_htree_wires_over_array = 0;
-	interface_ip.broadcast_addr_din_over_ver_htrees = 0;
-
-	interface_ip.num_rw_ports        = 1;
-	interface_ip.num_rd_ports        = 0;
-	interface_ip.num_wr_ports        = 0;
-	interface_ip.num_se_rd_ports     = 0;
-	interface_ip.num_search_ports    = 1;
-	interface_ip.nuca                = 0;
-	interface_ip.nuca_bank_count     = 0;
-	interface_ip.is_cache            =true;
-	interface_ip.pure_ram            =false;
-	interface_ip.pure_cam            =false;
-	interface_ip.force_cache_config  =false;
-	if (XML->sys.Embedded)
-		{
-		interface_ip.wt                  =Global_30;
-		interface_ip.wire_is_mat_type = 0;
-		interface_ip.wire_os_mat_type = 0;
-		}
-	else
-		{
-		interface_ip.wt                  =Global;
-		interface_ip.wire_is_mat_type = 2;
-		interface_ip.wire_os_mat_type = 2;
-		}
-	interface_ip.force_wiretype      = false;
-	interface_ip.print_detail        = 1;
-	interface_ip.add_ecc_b_          =true;
-}
-
-
-Processor::~Processor(){
-	while (!cores.empty())
-	{
-		delete cores.back();
-		cores.pop_back();
-	}
-	while (!l2array.empty())
-	{
-		delete l2array.back();
-		l2array.pop_back();
-	}
-	while (!l3array.empty())
-	{
-		delete l3array.back();
-		l3array.pop_back();
-	}
-	while (!nocs.empty())
-	{
-		delete nocs.back();
-		nocs.pop_back();
-	}
-	if (!mc)
-	{
-		delete mc;
-	}
-	if (!niu)
-	{
-		delete niu;
-	}
-	if (!pcie)
-	{
-		delete pcie;
-	}
-	if (!flashcontroller)
-	{
-		delete flashcontroller;
-	}
+Processor::~Processor() {
+  while (!cores.empty()) {
+    delete cores.back();
+    cores.pop_back();
+  }
+  while (!l2array.empty()) {
+    delete l2array.back();
+    l2array.pop_back();
+  }
+  while (!l3array.empty()) {
+    delete l3array.back();
+    l3array.pop_back();
+  }
+  while (!nocs.empty()) {
+    delete nocs.back();
+    nocs.pop_back();
+  }
+  if (!mc) {
+    delete mc;
+  }
+  if (!niu) {
+    delete niu;
+  }
+  if (!pcie) {
+    delete pcie;
+  }
+  if (!flashcontroller) {
+    delete flashcontroller;
+  }
 };
-
-

--- a/src/gpuwattch/processor.cc
+++ b/src/gpuwattch/processor.cc
@@ -1084,7 +1084,8 @@ void Processor::set_proc_param() {
 
   //	if (procdynp.numCore<1)
   //	{
-  //		cout<<" The target processor should at least have one core on chip."
+  //		cout<<" The target processor should at least have one core on
+  // chip."
   //<<endl;
   //		exit(0);
   //	}
@@ -1135,7 +1136,7 @@ void Processor::set_proc_param() {
   interface_ip.F_sz_um = interface_ip.F_sz_nm / 1000;
 
   //***********This section of code does not have real meaning, they are just to
-  //ensure all data will have initial value to prevent errors.
+  // ensure all data will have initial value to prevent errors.
   // They will be overridden  during each components initialization
   interface_ip.cache_sz = 64;
   interface_ip.line_sz = 1;

--- a/src/gpuwattch/processor.cc
+++ b/src/gpuwattch/processor.cc
@@ -1084,8 +1084,7 @@ void Processor::set_proc_param() {
 
   //	if (procdynp.numCore<1)
   //	{
-  //		cout<<" The target processor should at least have one core on
-  // chip."
+  //		cout<<" The target processor should at least have one core on chip."
   //<<endl;
   //		exit(0);
   //	}
@@ -1136,7 +1135,7 @@ void Processor::set_proc_param() {
   interface_ip.F_sz_um = interface_ip.F_sz_nm / 1000;
 
   //***********This section of code does not have real meaning, they are just to
-  // ensure all data will have initial value to prevent errors.
+  //ensure all data will have initial value to prevent errors.
   // They will be overridden  during each components initialization
   interface_ip.cache_sz = 64;
   interface_ip.line_sz = 1;

--- a/src/gpuwattch/processor.cc
+++ b/src/gpuwattch/processor.cc
@@ -29,1185 +29,1034 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:
-**
+*      Modified by:												   *
 *      Jingwen Leng, Univeristy of Texas, Austin                   *
 *      Syed Gilani, University of Wisconsin–Madison                *
 *      Tayler Hetherington, University of British Columbia         *
 *      Ahmed ElTantawy, University of British Columbia             *
 ********************************************************************/
-#include "processor.h"
-#include <assert.h>
-#include <stdio.h>
 #include <string.h>
-#include <string.h>
-#include <algorithm>
-#include <cmath>
-#include <fstream>
 #include <iostream>
-#include "XML_Parse.h"
-#include "array.h"
-#include "cacti/basic_circuit.h"
-#include "const.h"
+#include <stdio.h>
+#include <algorithm>
+#include <string.h>
+#include <cmath>
+#include <assert.h>
+#include <fstream>
 #include "parameter.h"
+#include "array.h"
+#include "const.h"
+#include "cacti/basic_circuit.h"
+#include "XML_Parse.h"
+#include "processor.h"
 #include "version.h"
 
+
 Processor::Processor(ParseXML *XML_interface)
-    : XML(XML_interface),  // TODO: using one global copy may have problems.
-      mc(0),
-      niu(0),
-      pcie(0),
-      flashcontroller(0) {
+:XML(XML_interface),//TODO: using one global copy may have problems.
+ mc(0),
+ niu(0),
+ pcie(0),
+ flashcontroller(0)
+{
   /*
-   *  placement and routing overhead is 10%, core scales worse than cache 40% is
-   * accumulated from 90 to 22nm
+   *  placement and routing overhead is 10%, core scales worse than cache 40% is accumulated from 90 to 22nm
    *  There is no point to have heterogeneous memory controller on chip,
    *  thus McPAT only support homogeneous memory controllers.
    */
   rt_power.reset();
   int i;
-  double pppm_t[4] = {1, 1, 1, 1};
-  l2_power = 0;
-  idle_core_power = 0;
+  double pppm_t[4]    = {1,1,1,1};
+  l2_power=0;
+  idle_core_power=0;
   set_proc_param();
   if (procdynp.homoCore)
-    numCore = procdynp.numCore == 0 ? 0 : 1;
+	  numCore = procdynp.numCore==0? 0:1;
   else
-    numCore = procdynp.numCore;
+	  numCore = procdynp.numCore;
 
   if (procdynp.homoL2)
-    numL2 = procdynp.numL2 == 0 ? 0 : 1;
+	  numL2 = procdynp.numL2==0? 0:1;
   else
-    numL2 = procdynp.numL2;
+	  numL2 = procdynp.numL2;
 
-  if (XML->sys.Private_L2 && numCore != numL2) {
-    cout << "Number of private L2 does not match number of cores" << endl;
-    exit(0);
+  if (XML->sys.Private_L2 && numCore != numL2)
+  {
+	  cout<<"Number of private L2 does not match number of cores"<<endl;
+      exit(0);
   }
 
   if (procdynp.homoL3)
-    numL3 = procdynp.numL3 == 0 ? 0 : 1;
+	  numL3 = procdynp.numL3==0? 0:1;
   else
-    numL3 = procdynp.numL3;
+	  numL3 = procdynp.numL3;
 
   if (procdynp.homoNOC)
-    numNOC = procdynp.numNOC == 0 ? 0 : 1;
+	  numNOC = procdynp.numNOC==0? 0:1;
   else
-    numNOC = procdynp.numNOC;
+	  numNOC = procdynp.numNOC;
 
-  //  if (!procdynp.homoNOC)
-  //  {
-  //	  cout<<"Current McPAT does not support heterogeneous NOC"<<endl;
-  //      exit(0);
-  //  }
+//  if (!procdynp.homoNOC)
+//  {
+//	  cout<<"Current McPAT does not support heterogeneous NOC"<<endl;
+//      exit(0);
+//  }
 
   if (procdynp.homoL1Dir)
-    numL1Dir = procdynp.numL1Dir == 0 ? 0 : 1;
+	  numL1Dir = procdynp.numL1Dir==0? 0:1;
   else
-    numL1Dir = procdynp.numL1Dir;
+	  numL1Dir = procdynp.numL1Dir;
 
   if (procdynp.homoL2Dir)
-    numL2Dir = procdynp.numL2Dir == 0 ? 0 : 1;
+	  numL2Dir = procdynp.numL2Dir==0? 0:1;
   else
-    numL2Dir = procdynp.numL2Dir;
+	  numL2Dir = procdynp.numL2Dir;
 
-  for (i = 0; i < numCore; i++) {
-    cores.push_back(new Core(XML, i, &interface_ip));
-    cores[i]->computeEnergy();
-    cores[i]->computeEnergy(false);
-    if (procdynp.homoCore) {
-      core.area.set_area(core.area.get_area() +
-                         cores[i]->area.get_area() * procdynp.numCore);
-      set_pppm(pppm_t, cores[i]->clockRate * procdynp.numCore, procdynp.numCore,
-               procdynp.numCore, procdynp.numCore);
-      // set the exClockRate
-      exClockRate = cores[0]->clockRate * 2;  // TODO; get from XML file
-      // cout<<"****EX clock rate:"<<exClockRate<<endl;
-      core.power = core.power + cores[i]->power * pppm_t;
-      set_pppm(pppm_t, 1 / cores[i]->executionTime, procdynp.numCore,
-               procdynp.numCore, procdynp.numCore);
-      core.rt_power = core.rt_power + cores[i]->rt_power * pppm_t;
-      area.set_area(area.get_area() +
-                    core.area.get_area());  // placement and routing overhead is
-                                            // 10%, core scales worse than cache
-                                            // 40% is accumulated from 90 to
-                                            // 22nm
-      power = power + core.power;
-      rt_power = rt_power + core.rt_power;
-    } else {
-      core.area.set_area(core.area.get_area() + cores[i]->area.get_area());
-      area.set_area(area.get_area() +
-                    cores[i]->area.get_area());  // placement and routing
-                                                 // overhead is 10%, core scales
-                                                 // worse than cache 40% is
-                                                 // accumulated from 90 to 22nm
-
-      set_pppm(pppm_t, cores[i]->clockRate, 1, 1, 1);
-      // set the exClockRate
-      exClockRate = cores[0]->clockRate;  // TODO; get from XML file
-      // cout<<"****EX clock rate:"<<exClockRate<<endl;
-      core.power = core.power + cores[i]->power * pppm_t;
-      power = power + cores[i]->power * pppm_t;
-
-      set_pppm(pppm_t, 1 / cores[i]->executionTime, 1, 1, 1);
-      core.rt_power = core.rt_power + cores[i]->rt_power * pppm_t;
-      rt_power = rt_power + cores[i]->rt_power * pppm_t;
-    }
-  }
-
-  if (!XML->sys.Private_L2) {
-    if (numL2 > 0)
-      for (i = 0; i < numL2; i++) {
-        l2array.push_back(new SharedCache(XML, i, &interface_ip));
-
-        l2array[i]->computeEnergy();
-        l2array[i]->computeEnergy(false);
-        if (procdynp.homoL2) {
-          l2.area.set_area(l2.area.get_area() +
-                           l2array[i]->area.get_area() * procdynp.numL2);
-          set_pppm(pppm_t, l2array[i]->cachep.clockRate * procdynp.numL2,
-                   procdynp.numL2, procdynp.numL2, procdynp.numL2);
-          l2.power = l2.power + l2array[i]->power * pppm_t;
-          set_pppm(pppm_t, 1 / l2array[i]->cachep.executionTime, procdynp.numL2,
-                   procdynp.numL2, procdynp.numL2);
-          l2.rt_power = l2.rt_power + l2array[i]->rt_power * pppm_t;
-          area.set_area(area.get_area() +
-                        l2.area.get_area());  // placement and routing overhead
-                                              // is 10%, l2 scales worse than
-                                              // cache 40% is accumulated from
-                                              // 90 to 22nm
-          power = power + l2.power;
-          rt_power = rt_power + l2.rt_power;
-        } else {
-          l2.area.set_area(l2.area.get_area() + l2array[i]->area.get_area());
-          area.set_area(area.get_area() +
-                        l2array[i]->area.get_area());  // placement and routing
-                                                       // overhead is 10%, l2
-                                                       // scales worse than
-                                                       // cache 40% is
-                                                       // accumulated from 90 to
-                                                       // 22nm
-
-          set_pppm(pppm_t, l2array[i]->cachep.clockRate, 1, 1, 1);
-          l2.power = l2.power + l2array[i]->power * pppm_t;
-          power = power + l2array[i]->power * pppm_t;
-          ;
-          set_pppm(pppm_t, 1 / l2array[i]->cachep.executionTime, 1, 1, 1);
-          l2.rt_power = l2.rt_power + l2array[i]->rt_power * pppm_t;
-          rt_power = rt_power + l2array[i]->rt_power * pppm_t;
-        }
-      }
-  }
-
-  if (numL3 > 0)
-    for (i = 0; i < numL3; i++) {
-      l3array.push_back(new SharedCache(XML, i, &interface_ip, L3));
-      l3array[i]->computeEnergy();
-      l3array[i]->computeEnergy(false);
-      if (procdynp.homoL3) {
-        l3.area.set_area(l3.area.get_area() +
-                         l3array[i]->area.get_area() * procdynp.numL3);
-        set_pppm(pppm_t, l3array[i]->cachep.clockRate * procdynp.numL3,
-                 procdynp.numL3, procdynp.numL3, procdynp.numL3);
-        l3.power = l3.power + l3array[i]->power * pppm_t;
-        set_pppm(pppm_t, 1 / l3array[i]->cachep.executionTime, procdynp.numL3,
-                 procdynp.numL3, procdynp.numL3);
-        l3.rt_power = l3.rt_power + l3array[i]->rt_power * pppm_t;
-        area.set_area(area.get_area() +
-                      l3.area.get_area());  // placement and routing overhead is
-                                            // 10%, l3 scales worse than cache
-                                            // 40% is accumulated from 90 to
-                                            // 22nm
-        power = power + l3.power;
-        rt_power = rt_power + l3.rt_power;
-
-      } else {
-        l3.area.set_area(l3.area.get_area() + l3array[i]->area.get_area());
-        area.set_area(area.get_area() +
-                      l3array[i]->area.get_area());  // placement and routing
-                                                     // overhead is 10%, l3
-                                                     // scales worse than cache
-                                                     // 40% is accumulated from
-                                                     // 90 to 22nm
-        set_pppm(pppm_t, l3array[i]->cachep.clockRate, 1, 1, 1);
-        l3.power = l3.power + l3array[i]->power * pppm_t;
-        power = power + l3array[i]->power * pppm_t;
-        set_pppm(pppm_t, 1 / l3array[i]->cachep.executionTime, 1, 1, 1);
-        l3.rt_power = l3.rt_power + l3array[i]->rt_power * pppm_t;
-        rt_power = rt_power + l3array[i]->rt_power * pppm_t;
-      }
-    }
-  if (numL1Dir > 0)
-    for (i = 0; i < numL1Dir; i++) {
-      l1dirarray.push_back(new SharedCache(XML, i, &interface_ip, L1Directory));
-      l1dirarray[i]->computeEnergy();
-      l1dirarray[i]->computeEnergy(false);
-      if (procdynp.homoL1Dir) {
-        l1dir.area.set_area(l1dir.area.get_area() +
-                            l1dirarray[i]->area.get_area() * procdynp.numL1Dir);
-        set_pppm(pppm_t, l1dirarray[i]->cachep.clockRate * procdynp.numL1Dir,
-                 procdynp.numL1Dir, procdynp.numL1Dir, procdynp.numL1Dir);
-        l1dir.power = l1dir.power + l1dirarray[i]->power * pppm_t;
-        set_pppm(pppm_t, 1 / l1dirarray[i]->cachep.executionTime,
-                 procdynp.numL1Dir, procdynp.numL1Dir, procdynp.numL1Dir);
-        l1dir.rt_power = l1dir.rt_power + l1dirarray[i]->rt_power * pppm_t;
-        area.set_area(area.get_area() +
-                      l1dir.area.get_area());  // placement and routing overhead
-                                               // is 10%, l1dir scales worse
-                                               // than cache 40% is accumulated
-                                               // from 90 to 22nm
-        power = power + l1dir.power;
-        rt_power = rt_power + l1dir.rt_power;
-
-      } else {
-        l1dir.area.set_area(l1dir.area.get_area() +
-                            l1dirarray[i]->area.get_area());
-        area.set_area(area.get_area() + l1dirarray[i]->area.get_area());
-        set_pppm(pppm_t, l1dirarray[i]->cachep.clockRate, 1, 1, 1);
-        l1dir.power = l1dir.power + l1dirarray[i]->power * pppm_t;
-        power = power + l1dirarray[i]->power;
-        set_pppm(pppm_t, 1 / l1dirarray[i]->cachep.executionTime, 1, 1, 1);
-        l1dir.rt_power = l1dir.rt_power + l1dirarray[i]->rt_power * pppm_t;
-        rt_power = rt_power + l1dirarray[i]->rt_power;
-      }
-    }
-
-  if (numL2Dir > 0)
-    for (i = 0; i < numL2Dir; i++) {
-      l2dirarray.push_back(new SharedCache(XML, i, &interface_ip, L2Directory));
-      l2dirarray[i]->computeEnergy();
-      l2dirarray[i]->computeEnergy(false);
-      if (procdynp.homoL2Dir) {
-        l2dir.area.set_area(l2dir.area.get_area() +
-                            l2dirarray[i]->area.get_area() * procdynp.numL2Dir);
-        set_pppm(pppm_t, l2dirarray[i]->cachep.clockRate * procdynp.numL2Dir,
-                 procdynp.numL2Dir, procdynp.numL2Dir, procdynp.numL2Dir);
-        l2dir.power = l2dir.power + l2dirarray[i]->power * pppm_t;
-        set_pppm(pppm_t, 1 / l2dirarray[i]->cachep.executionTime,
-                 procdynp.numL2Dir, procdynp.numL2Dir, procdynp.numL2Dir);
-        l2dir.rt_power = l2dir.rt_power + l2dirarray[i]->rt_power * pppm_t;
-        area.set_area(area.get_area() +
-                      l2dir.area.get_area());  // placement and routing overhead
-                                               // is 10%, l2dir scales worse
-                                               // than cache 40% is accumulated
-                                               // from 90 to 22nm
-        power = power + l2dir.power;
-        rt_power = rt_power + l2dir.rt_power;
-
-      } else {
-        l2dir.area.set_area(l2dir.area.get_area() +
-                            l2dirarray[i]->area.get_area());
-        area.set_area(area.get_area() + l2dirarray[i]->area.get_area());
-        set_pppm(pppm_t, l2dirarray[i]->cachep.clockRate, 1, 1, 1);
-        l2dir.power = l2dir.power + l2dirarray[i]->power * pppm_t;
-        power = power + l2dirarray[i]->power * pppm_t;
-        set_pppm(pppm_t, 1 / l2dirarray[i]->cachep.executionTime, 1, 1, 1);
-        l2dir.rt_power = l2dir.rt_power + l2dirarray[i]->rt_power * pppm_t;
-        rt_power = rt_power + l2dirarray[i]->rt_power * pppm_t;
-      }
-    }
-
-  if (XML->sys.mc.number_mcs > 0 && XML->sys.mc.memory_channels_per_mc > 0) {
-    if (XML->sys.architecture == 1)  // 1 for fermi
-      mc = new MemoryController(XML, &interface_ip, MC, GDDR5);
-    else if (XML->sys.architecture == 2)  // 2 for quadro
-      mc = new MemoryController(XML, &interface_ip, MC, GDDR3);
-    else {
-      printf("Architecture %d not defined!\n", XML->sys.architecture);
-      printf("use 1 for fermi and 2 for quadro!\n");
-      exit(1);
-    }
-    mc->computeEnergy();
-    mc->computeEnergy(false);
-    mcs.area.set_area(mcs.area.get_area() +
-                      mc->area.get_area() * XML->sys.mc.number_mcs);
-    area.set_area(area.get_area() +
-                  mc->area.get_area() * XML->sys.mc.number_mcs);
-    set_pppm(pppm_t, XML->sys.mc.number_mcs * mc->mcp.clockRate,
-             XML->sys.mc.number_mcs, XML->sys.mc.number_mcs,
-             XML->sys.mc.number_mcs);
-    mcs.power = mc->power * pppm_t;
-    power = power + mcs.power;
-    set_pppm(pppm_t, 1 / mc->mcp.executionTime, XML->sys.mc.number_mcs,
-             XML->sys.mc.number_mcs, XML->sys.mc.number_mcs);
-    mcs.rt_power = mc->rt_power * pppm_t;
-    rt_power = rt_power + mcs.rt_power;
-  }
-
-  if (XML->sys.flashc.number_mcs > 0)  // flash controller
+  for (i = 0;i < numCore; i++)
   {
-    flashcontroller = new FlashController(XML, &interface_ip);
-    flashcontroller->computeEnergy();
-    flashcontroller->computeEnergy(false);
-    double number_fcs = flashcontroller->fcp.num_mcs;
-    flashcontrollers.area.set_area(flashcontrollers.area.get_area() +
-                                   flashcontroller->area.get_area() *
-                                       number_fcs);
-    area.set_area(area.get_area() + flashcontrollers.area.get_area());
-    set_pppm(pppm_t, number_fcs, number_fcs, number_fcs, number_fcs);
-    flashcontrollers.power = flashcontroller->power * pppm_t;
-    power = power + flashcontrollers.power;
-    set_pppm(pppm_t, number_fcs, number_fcs, number_fcs, number_fcs);
-    flashcontrollers.rt_power = flashcontroller->rt_power * pppm_t;
-    rt_power = rt_power + flashcontrollers.rt_power;
+		  cores.push_back(new Core(XML,i, &interface_ip));
+		  cores[i]->computeEnergy();
+		  cores[i]->computeEnergy(false);
+		  if (procdynp.homoCore){
+			  core.area.set_area(core.area.get_area() + cores[i]->area.get_area()*procdynp.numCore);
+			  set_pppm(pppm_t,cores[i]->clockRate*procdynp.numCore, procdynp.numCore,procdynp.numCore,procdynp.numCore);
+			  //set the exClockRate
+           exClockRate=cores[0]->clockRate*2;//TODO; get from XML file
+			  //cout<<"****EX clock rate:"<<exClockRate<<endl;
+			  core.power = core.power + cores[i]->power*pppm_t;
+			  set_pppm(pppm_t,1/cores[i]->executionTime, procdynp.numCore,procdynp.numCore,procdynp.numCore);
+			  core.rt_power = core.rt_power + cores[i]->rt_power*pppm_t;
+			  area.set_area(area.get_area() + core.area.get_area());//placement and routing overhead is 10%, core scales worse than cache 40% is accumulated from 90 to 22nm
+			  power = power  + core.power;
+			  rt_power = rt_power  + core.rt_power;
+		  }
+		  else{
+			  core.area.set_area(core.area.get_area() + cores[i]->area.get_area());
+			  area.set_area(area.get_area() + cores[i]->area.get_area());//placement and routing overhead is 10%, core scales worse than cache 40% is accumulated from 90 to 22nm
+
+			  set_pppm(pppm_t,cores[i]->clockRate, 1, 1, 1);
+			  //set the exClockRate
+           exClockRate=cores[0]->clockRate;//TODO; get from XML file
+			  //cout<<"****EX clock rate:"<<exClockRate<<endl;
+			  core.power = core.power + cores[i]->power*pppm_t;
+			  power = power  + cores[i]->power*pppm_t;
+
+			  set_pppm(pppm_t,1/cores[i]->executionTime, 1, 1, 1);
+			  core.rt_power = core.rt_power + cores[i]->rt_power*pppm_t;
+			  rt_power = rt_power  + cores[i]->rt_power*pppm_t;
+		  }
   }
 
-  if (XML->sys.niu.number_units > 0) {
-    niu = new NIUController(XML, &interface_ip);
-    niu->computeEnergy();
-    niu->computeEnergy(false);
-    nius.area.set_area(nius.area.get_area() +
-                       niu->area.get_area() * XML->sys.niu.number_units);
-    area.set_area(area.get_area() +
-                  niu->area.get_area() * XML->sys.niu.number_units);
-    set_pppm(pppm_t, XML->sys.niu.number_units * niu->niup.clockRate,
-             XML->sys.niu.number_units, XML->sys.niu.number_units,
-             XML->sys.niu.number_units);
-    nius.power = niu->power * pppm_t;
-    power = power + nius.power;
-    set_pppm(pppm_t, XML->sys.niu.number_units * niu->niup.clockRate,
-             XML->sys.niu.number_units, XML->sys.niu.number_units,
-             XML->sys.niu.number_units);
-    nius.rt_power = niu->rt_power * pppm_t;
-    rt_power = rt_power + nius.rt_power;
+  if (!XML->sys.Private_L2)
+  {
+
+  if (numL2 >0)
+	  for (i = 0;i < numL2; i++)
+	  {
+		  l2array.push_back(new SharedCache(XML,i, &interface_ip));
+
+		  l2array[i]->computeEnergy();
+		  l2array[i]->computeEnergy(false);
+		  if (procdynp.homoL2){
+			  l2.area.set_area(l2.area.get_area() + l2array[i]->area.get_area()*procdynp.numL2);
+			  set_pppm(pppm_t,l2array[i]->cachep.clockRate*procdynp.numL2, procdynp.numL2,procdynp.numL2,procdynp.numL2);
+			  l2.power = l2.power + l2array[i]->power*pppm_t;
+			  set_pppm(pppm_t,1/l2array[i]->cachep.executionTime, procdynp.numL2,procdynp.numL2,procdynp.numL2);
+			  l2.rt_power = l2.rt_power + l2array[i]->rt_power*pppm_t;
+			  area.set_area(area.get_area() + l2.area.get_area());//placement and routing overhead is 10%, l2 scales worse than cache 40% is accumulated from 90 to 22nm
+			  power = power  + l2.power;
+			  rt_power = rt_power  + l2.rt_power;
+		  }
+		  else{
+			  l2.area.set_area(l2.area.get_area() + l2array[i]->area.get_area());
+			  area.set_area(area.get_area() + l2array[i]->area.get_area());//placement and routing overhead is 10%, l2 scales worse than cache 40% is accumulated from 90 to 22nm
+
+			  set_pppm(pppm_t,l2array[i]->cachep.clockRate, 1, 1, 1);
+			  l2.power = l2.power + l2array[i]->power*pppm_t;
+			  power = power  + l2array[i]->power*pppm_t;;
+			  set_pppm(pppm_t,1/l2array[i]->cachep.executionTime, 1, 1, 1);
+			  l2.rt_power = l2.rt_power + l2array[i]->rt_power*pppm_t;
+			  rt_power = rt_power  + l2array[i]->rt_power*pppm_t;
+		  }
+	  }
   }
 
-  if (XML->sys.pcie.number_units > 0 && XML->sys.pcie.num_channels > 0) {
-    pcie = new PCIeController(XML, &interface_ip);
-    pcie->computeEnergy();
-    pcie->computeEnergy(false);
-    pcies.area.set_area(pcies.area.get_area() +
-                        pcie->area.get_area() * XML->sys.pcie.number_units);
-    area.set_area(area.get_area() +
-                  pcie->area.get_area() * XML->sys.pcie.number_units);
-    set_pppm(pppm_t, XML->sys.pcie.number_units * pcie->pciep.clockRate,
-             XML->sys.pcie.number_units, XML->sys.pcie.number_units,
-             XML->sys.pcie.number_units);
-    pcies.power = pcie->power * pppm_t;
-    power = power + pcies.power;
-    set_pppm(pppm_t, XML->sys.pcie.number_units * pcie->pciep.clockRate,
-             XML->sys.pcie.number_units, XML->sys.pcie.number_units,
-             XML->sys.pcie.number_units);
-    pcies.rt_power = pcie->rt_power * pppm_t;
-    rt_power = rt_power + pcies.rt_power;
+  if (numL3 >0)
+	  for (i = 0;i < numL3; i++)
+	  {
+		  l3array.push_back(new SharedCache(XML,i, &interface_ip, L3));
+		  l3array[i]->computeEnergy();
+		  l3array[i]->computeEnergy(false);
+		  if (procdynp.homoL3){
+			  l3.area.set_area(l3.area.get_area() + l3array[i]->area.get_area()*procdynp.numL3);
+			  set_pppm(pppm_t,l3array[i]->cachep.clockRate*procdynp.numL3, procdynp.numL3,procdynp.numL3,procdynp.numL3);
+			  l3.power = l3.power + l3array[i]->power*pppm_t;
+			  set_pppm(pppm_t,1/l3array[i]->cachep.executionTime, procdynp.numL3,procdynp.numL3,procdynp.numL3);
+              l3.rt_power = l3.rt_power + l3array[i]->rt_power*pppm_t;
+			  area.set_area(area.get_area() + l3.area.get_area());//placement and routing overhead is 10%, l3 scales worse than cache 40% is accumulated from 90 to 22nm
+			  power = power  + l3.power;
+			  rt_power = rt_power  + l3.rt_power;
+
+		  }
+		  else{
+			  l3.area.set_area(l3.area.get_area() + l3array[i]->area.get_area());
+			  area.set_area(area.get_area() + l3array[i]->area.get_area());//placement and routing overhead is 10%, l3 scales worse than cache 40% is accumulated from 90 to 22nm
+			  set_pppm(pppm_t,l3array[i]->cachep.clockRate, 1, 1, 1);
+			  l3.power = l3.power + l3array[i]->power*pppm_t;
+			  power = power  + l3array[i]->power*pppm_t;
+			  set_pppm(pppm_t,1/l3array[i]->cachep.executionTime, 1, 1, 1);
+              l3.rt_power = l3.rt_power + l3array[i]->rt_power*pppm_t;
+              rt_power = rt_power  + l3array[i]->rt_power*pppm_t;
+
+		  }
+	  }
+  if (numL1Dir >0)
+	  for (i = 0;i < numL1Dir; i++)
+	  {
+		  l1dirarray.push_back(new SharedCache(XML,i, &interface_ip, L1Directory));
+		  l1dirarray[i]->computeEnergy();
+		  l1dirarray[i]->computeEnergy(false);
+		  if (procdynp.homoL1Dir){
+			  l1dir.area.set_area(l1dir.area.get_area() + l1dirarray[i]->area.get_area()*procdynp.numL1Dir);
+			  set_pppm(pppm_t,l1dirarray[i]->cachep.clockRate*procdynp.numL1Dir, procdynp.numL1Dir,procdynp.numL1Dir,procdynp.numL1Dir);
+			  l1dir.power = l1dir.power + l1dirarray[i]->power*pppm_t;
+			  set_pppm(pppm_t,1/l1dirarray[i]->cachep.executionTime, procdynp.numL1Dir,procdynp.numL1Dir,procdynp.numL1Dir);
+              l1dir.rt_power = l1dir.rt_power + l1dirarray[i]->rt_power*pppm_t;
+			  area.set_area(area.get_area() + l1dir.area.get_area());//placement and routing overhead is 10%, l1dir scales worse than cache 40% is accumulated from 90 to 22nm
+			  power = power  + l1dir.power;
+			  rt_power = rt_power  + l1dir.rt_power;
+
+		  }
+		  else{
+			  l1dir.area.set_area(l1dir.area.get_area() + l1dirarray[i]->area.get_area());
+			  area.set_area(area.get_area() + l1dirarray[i]->area.get_area());
+			  set_pppm(pppm_t,l1dirarray[i]->cachep.clockRate, 1, 1, 1);
+			  l1dir.power = l1dir.power + l1dirarray[i]->power*pppm_t;
+			  power = power  + l1dirarray[i]->power;
+			  set_pppm(pppm_t,1/l1dirarray[i]->cachep.executionTime, 1, 1, 1);
+              l1dir.rt_power = l1dir.rt_power + l1dirarray[i]->rt_power*pppm_t;
+			  rt_power = rt_power  + l1dirarray[i]->rt_power;
+		  }
+	  }
+
+  if (numL2Dir >0)
+	  for (i = 0;i < numL2Dir; i++)
+	  {
+		  l2dirarray.push_back(new SharedCache(XML,i, &interface_ip, L2Directory));
+		  l2dirarray[i]->computeEnergy();
+		  l2dirarray[i]->computeEnergy(false);
+		  if (procdynp.homoL2Dir){
+			  l2dir.area.set_area(l2dir.area.get_area() + l2dirarray[i]->area.get_area()*procdynp.numL2Dir);
+			  set_pppm(pppm_t,l2dirarray[i]->cachep.clockRate*procdynp.numL2Dir, procdynp.numL2Dir,procdynp.numL2Dir,procdynp.numL2Dir);
+			  l2dir.power = l2dir.power + l2dirarray[i]->power*pppm_t;
+			  set_pppm(pppm_t,1/l2dirarray[i]->cachep.executionTime, procdynp.numL2Dir,procdynp.numL2Dir,procdynp.numL2Dir);
+              l2dir.rt_power = l2dir.rt_power + l2dirarray[i]->rt_power*pppm_t;
+			  area.set_area(area.get_area() + l2dir.area.get_area());//placement and routing overhead is 10%, l2dir scales worse than cache 40% is accumulated from 90 to 22nm
+			  power = power  + l2dir.power;
+			  rt_power = rt_power  + l2dir.rt_power;
+
+		  }
+		  else{
+			  l2dir.area.set_area(l2dir.area.get_area() + l2dirarray[i]->area.get_area());
+			  area.set_area(area.get_area() + l2dirarray[i]->area.get_area());
+			  set_pppm(pppm_t,l2dirarray[i]->cachep.clockRate, 1, 1, 1);
+			  l2dir.power = l2dir.power + l2dirarray[i]->power*pppm_t;
+			  power = power  + l2dirarray[i]->power*pppm_t;
+			  set_pppm(pppm_t,1/l2dirarray[i]->cachep.executionTime, 1, 1, 1);
+              l2dir.rt_power = l2dir.rt_power + l2dirarray[i]->rt_power*pppm_t;
+			  rt_power = rt_power  + l2dirarray[i]->rt_power*pppm_t;
+		  }
+	  }
+
+  if (XML->sys.mc.number_mcs >0 && XML->sys.mc.memory_channels_per_mc>0)
+  {
+	  if(XML->sys.architecture==1) // 1 for fermi
+		mc = new MemoryController(XML, &interface_ip, MC,GDDR5);
+	  else if (XML->sys.architecture==2) // 2 for quadro
+		mc = new MemoryController(XML, &interface_ip, MC,GDDR3);
+	  else {
+		printf("Architecture %d not defined!\n", XML->sys.architecture);
+		printf("use 1 for fermi and 2 for quadro!\n");
+		exit(1);
+	  }
+	  mc->computeEnergy();
+	  mc->computeEnergy(false);
+	  mcs.area.set_area(mcs.area.get_area()+mc->area.get_area()*XML->sys.mc.number_mcs);
+	  area.set_area(area.get_area()+mc->area.get_area()*XML->sys.mc.number_mcs);
+	  set_pppm(pppm_t,XML->sys.mc.number_mcs*mc->mcp.clockRate, XML->sys.mc.number_mcs,XML->sys.mc.number_mcs,XML->sys.mc.number_mcs);
+	  mcs.power = mc->power*pppm_t;
+	  power = power  + mcs.power;
+	  set_pppm(pppm_t,1/mc->mcp.executionTime, XML->sys.mc.number_mcs,XML->sys.mc.number_mcs,XML->sys.mc.number_mcs);
+	  mcs.rt_power = mc->rt_power*pppm_t;
+	  rt_power = rt_power  + mcs.rt_power;
+
   }
 
-  if (numNOC > 0) {
-    for (i = 0; i < numNOC; i++) {
-      if (XML->sys.NoC[i].type) {  // First add up area of routers if NoC is
-                                   // used
-        nocs.push_back(new NoC(XML, i, &interface_ip, 1));
+  if (XML->sys.flashc.number_mcs >0 )//flash controller
+  {
+	  flashcontroller = new FlashController(XML, &interface_ip);
+	  flashcontroller->computeEnergy();
+	  flashcontroller->computeEnergy(false);
+	  double number_fcs = flashcontroller->fcp.num_mcs;
+	  flashcontrollers.area.set_area(flashcontrollers.area.get_area()+flashcontroller->area.get_area()*number_fcs);
+	  area.set_area(area.get_area()+flashcontrollers.area.get_area());
+	  set_pppm(pppm_t,number_fcs, number_fcs ,number_fcs, number_fcs );
+	  flashcontrollers.power = flashcontroller->power*pppm_t;
+	  power = power  + flashcontrollers.power;
+	  set_pppm(pppm_t,number_fcs , number_fcs ,number_fcs ,number_fcs );
+	  flashcontrollers.rt_power = flashcontroller->rt_power*pppm_t;
+	  rt_power = rt_power  + flashcontrollers.rt_power;
 
-        if (procdynp.homoNOC) {
-          noc.area.set_area(noc.area.get_area() +
-                            nocs[i]->area.get_area() * procdynp.numNOC);
-          area.set_area(area.get_area() + noc.area.get_area());
-        } else {
-          noc.area.set_area(noc.area.get_area() + nocs[i]->area.get_area());
-          area.set_area(area.get_area() + nocs[i]->area.get_area());
-        }
-      } else {  // Bus based interconnect
-        nocs.push_back(
-            new NoC(XML, i, &interface_ip, 1,
-                    sqrt(area.get_area() * XML->sys.NoC[i].chip_coverage)));
-        if (procdynp.homoNOC) {
-          noc.area.set_area(noc.area.get_area() +
-                            nocs[i]->area.get_area() * procdynp.numNOC);
-          area.set_area(area.get_area() + noc.area.get_area());
-        } else {
-          noc.area.set_area(noc.area.get_area() + nocs[i]->area.get_area());
-          area.set_area(area.get_area() + nocs[i]->area.get_area());
-        }
-      }
-    }
-
-    /*
-     * Compute global links associated with each NOC, if any. This must be done
-     * at the end (even after the NOC router part) since the total chip
-     * area must be obtain to decide the link routing
-     */
-    for (i = 0; i < numNOC; i++) {
-      if (nocs[i]->nocdynp.has_global_link && XML->sys.NoC[i].type) {
-        nocs[i]->init_link_bus(
-            sqrt(area.get_area() *
-                 XML->sys.NoC[i].chip_coverage));  // compute global links
-        if (procdynp.homoNOC) {
-          noc.area.set_area(noc.area.get_area() +
-                            nocs[i]->link_bus_tot_per_Router.area.get_area() *
-                                nocs[i]->nocdynp.total_nodes * procdynp.numNOC);
-          area.set_area(area.get_area() +
-                        nocs[i]->link_bus_tot_per_Router.area.get_area() *
-                            nocs[i]->nocdynp.total_nodes * procdynp.numNOC);
-        } else {
-          noc.area.set_area(noc.area.get_area() +
-                            nocs[i]->link_bus_tot_per_Router.area.get_area() *
-                                nocs[i]->nocdynp.total_nodes);
-          area.set_area(area.get_area() +
-                        nocs[i]->link_bus_tot_per_Router.area.get_area() *
-                            nocs[i]->nocdynp.total_nodes);
-        }
-      }
-    }
-    // Compute energy of NoC (w or w/o links) or buses
-    for (i = 0; i < numNOC; i++) {
-      // cout<<"******************COMPUTE NOC ENERGY********************"<<endl;
-      nocs[i]->computeEnergy();
-      nocs[i]->computeEnergy(false);
-      if (procdynp.homoNOC) {
-        set_pppm(pppm_t, procdynp.numNOC * nocs[i]->nocdynp.clockRate,
-                 procdynp.numNOC, procdynp.numNOC, procdynp.numNOC);
-        noc.power = noc.power + nocs[i]->power * pppm_t;
-        set_pppm(pppm_t, 1 / nocs[i]->nocdynp.executionTime, procdynp.numNOC,
-                 procdynp.numNOC, procdynp.numNOC);
-        noc.rt_power = noc.rt_power + nocs[i]->rt_power * pppm_t;
-        power = power + noc.power;
-        rt_power = rt_power + noc.rt_power;
-      } else {
-        set_pppm(pppm_t, nocs[i]->nocdynp.clockRate, 1, 1, 1);
-        noc.power = noc.power + nocs[i]->power * pppm_t;
-        power = power + nocs[i]->power * pppm_t;
-        set_pppm(pppm_t, 1 / nocs[i]->nocdynp.executionTime, 1, 1, 1);
-        noc.rt_power = noc.rt_power + nocs[i]->rt_power * pppm_t;
-        rt_power = rt_power + nocs[i]->rt_power * pppm_t;
-      }
-    }
   }
 
-  //  //clock power
-  //  globalClock.init_wire_external(is_default, &interface_ip);
-  //  globalClock.clk_area           =area*1e6; //change it from mm^2 to um^2
-  //  globalClock.end_wiring_level   =5;//toplevel metal
-  //  globalClock.start_wiring_level =5;//toplevel metal
-  //  globalClock.l_ip.with_clock_grid=false;//global clock does not drive local
-  //  final nodes
-  //  globalClock.optimize_wire();
+  if (XML->sys.niu.number_units >0)
+  {
+	  niu = new NIUController(XML, &interface_ip);
+	  niu->computeEnergy();
+	  niu->computeEnergy(false);
+	  nius.area.set_area(nius.area.get_area()+niu->area.get_area()*XML->sys.niu.number_units);
+	  area.set_area(area.get_area()+niu->area.get_area()*XML->sys.niu.number_units);
+	  set_pppm(pppm_t,XML->sys.niu.number_units*niu->niup.clockRate, XML->sys.niu.number_units,XML->sys.niu.number_units,XML->sys.niu.number_units);
+	  nius.power = niu->power*pppm_t;
+	  power = power  + nius.power;
+	  set_pppm(pppm_t,XML->sys.niu.number_units*niu->niup.clockRate, XML->sys.niu.number_units,XML->sys.niu.number_units,XML->sys.niu.number_units);
+	  nius.rt_power = niu->rt_power*pppm_t;
+	  rt_power = rt_power  + nius.rt_power;
+
+  }
+
+  if (XML->sys.pcie.number_units >0 && XML->sys.pcie.num_channels >0)
+  {
+	  pcie = new PCIeController(XML, &interface_ip);
+	  pcie->computeEnergy();
+	  pcie->computeEnergy(false);
+	  pcies.area.set_area(pcies.area.get_area()+pcie->area.get_area()*XML->sys.pcie.number_units);
+	  area.set_area(area.get_area()+pcie->area.get_area()*XML->sys.pcie.number_units);
+	  set_pppm(pppm_t,XML->sys.pcie.number_units*pcie->pciep.clockRate, XML->sys.pcie.number_units,XML->sys.pcie.number_units,XML->sys.pcie.number_units);
+	  pcies.power = pcie->power*pppm_t;
+	  power = power  + pcies.power;
+	  set_pppm(pppm_t,XML->sys.pcie.number_units*pcie->pciep.clockRate, XML->sys.pcie.number_units,XML->sys.pcie.number_units,XML->sys.pcie.number_units);
+	  pcies.rt_power = pcie->rt_power*pppm_t;
+	  rt_power = rt_power  + pcies.rt_power;
+
+  }
+
+  if (numNOC >0)
+  {
+	  for (i = 0;i < numNOC; i++)
+	  {
+		  if (XML->sys.NoC[i].type)
+		  {//First add up area of routers if NoC is used
+			  nocs.push_back(new NoC(XML,i, &interface_ip, 1));
+
+			  if (procdynp.homoNOC)
+			  {
+				  noc.area.set_area(noc.area.get_area() + nocs[i]->area.get_area()*procdynp.numNOC);
+				  area.set_area(area.get_area() + noc.area.get_area());
+			  }
+			  else
+			  {
+				  noc.area.set_area(noc.area.get_area() + nocs[i]->area.get_area());
+				  area.set_area(area.get_area() + nocs[i]->area.get_area());
+			  }
+		  }
+		  else
+		  {//Bus based interconnect
+			  nocs.push_back(new NoC(XML,i, &interface_ip, 1, sqrt(area.get_area()*XML->sys.NoC[i].chip_coverage)));
+			  if (procdynp.homoNOC){
+				  noc.area.set_area(noc.area.get_area() + nocs[i]->area.get_area()*procdynp.numNOC);
+				  area.set_area(area.get_area() + noc.area.get_area());
+			  }
+			  else
+			  {
+				  noc.area.set_area(noc.area.get_area() + nocs[i]->area.get_area());
+				  area.set_area(area.get_area() + nocs[i]->area.get_area());
+			  }
+		  }
+	  }
+
+	  /*
+	   * Compute global links associated with each NOC, if any. This must be done at the end (even after the NOC router part) since the total chip
+	   * area must be obtain to decide the link routing
+	   */
+	  for (i = 0;i < numNOC; i++)
+	  {
+		  if (nocs[i]->nocdynp.has_global_link && XML->sys.NoC[i].type)
+		  {
+			  nocs[i]->init_link_bus(sqrt(area.get_area()*XML->sys.NoC[i].chip_coverage));//compute global links
+			  if (procdynp.homoNOC)
+			  {
+				  noc.area.set_area(noc.area.get_area() + nocs[i]->link_bus_tot_per_Router.area.get_area()
+						  * nocs[i]->nocdynp.total_nodes
+						  * procdynp.numNOC);
+				  area.set_area(area.get_area() + nocs[i]->link_bus_tot_per_Router.area.get_area()
+						  * nocs[i]->nocdynp.total_nodes
+						  * procdynp.numNOC);
+			  }
+			  else
+			  {
+				  noc.area.set_area(noc.area.get_area() + nocs[i]->link_bus_tot_per_Router.area.get_area()
+						  * nocs[i]->nocdynp.total_nodes);
+				  area.set_area(area.get_area() + nocs[i]->link_bus_tot_per_Router.area.get_area()
+						  * nocs[i]->nocdynp.total_nodes);
+			  }
+		  }
+	  }
+	  //Compute energy of NoC (w or w/o links) or buses
+	  for (i = 0;i < numNOC; i++)
+	  {
+		 //cout<<"******************COMPUTE NOC ENERGY********************"<<endl;
+		  nocs[i]->computeEnergy();
+		  nocs[i]->computeEnergy(false);
+		  if (procdynp.homoNOC){
+
+			  set_pppm(pppm_t,procdynp.numNOC*nocs[i]->nocdynp.clockRate, procdynp.numNOC,procdynp.numNOC,procdynp.numNOC);
+			  noc.power = noc.power + nocs[i]->power*pppm_t;
+			  set_pppm(pppm_t,1/nocs[i]->nocdynp.executionTime, procdynp.numNOC,procdynp.numNOC,procdynp.numNOC);
+			  noc.rt_power = noc.rt_power + nocs[i]->rt_power*pppm_t;
+			  power = power  + noc.power;
+			  rt_power = rt_power  + noc.rt_power;
+		  }
+		  else
+		  {
+			  set_pppm(pppm_t,nocs[i]->nocdynp.clockRate, 1, 1, 1);
+			  noc.power = noc.power + nocs[i]->power*pppm_t;
+			  power = power  + nocs[i]->power*pppm_t;
+			  set_pppm(pppm_t,1/nocs[i]->nocdynp.executionTime, 1, 1, 1);
+			  noc.rt_power = noc.rt_power + nocs[i]->rt_power*pppm_t;
+			  rt_power = rt_power  + nocs[i]->rt_power*pppm_t;
+
+
+		  }
+	  }
+  }
+
+//  //clock power
+//  globalClock.init_wire_external(is_default, &interface_ip);
+//  globalClock.clk_area           =area*1e6; //change it from mm^2 to um^2
+//  globalClock.end_wiring_level   =5;//toplevel metal
+//  globalClock.start_wiring_level =5;//toplevel metal
+//  globalClock.l_ip.with_clock_grid=false;//global clock does not drive local final nodes
+//  globalClock.optimize_wire();
 }
 
-void Processor::compute() {
+void Processor::compute () 
+{
   int i;
-  double pppm_t[4] = {1, 1, 1, 1};
+  double pppm_t[4]    = {1,1,1,1};
 
   rt_power.reset();
-  // power.reset();
-  // core.power.reset();
+  //power.reset();
+  //core.power.reset();
 
   core.rt_power.reset();
-  for (i = 0; i < numCore; i++) {
-    cores[i]->executionTime =
-        XML->sys.total_cycles / (XML->sys.core[i].clock_rate * 1e6);
-    cores[i]->rt_power.reset();
-    cores[i]->compute();
-    // cores[i]->computeEnergy(false);
-    if (procdynp.homoCore) {
-      set_pppm(pppm_t, 1 / cores[i]->executionTime, procdynp.numCore,
-               procdynp.numCore, procdynp.numCore);
-      core.rt_power = core.rt_power + cores[i]->rt_power * pppm_t;
-      rt_power = rt_power + core.rt_power;
-    } else {
-      set_pppm(pppm_t, 1 / cores[i]->executionTime, 1, 1, 1);
-      core.rt_power = core.rt_power + cores[i]->rt_power * pppm_t;
-      rt_power = rt_power + cores[i]->rt_power * pppm_t;
-    }
+  for (i = 0;i < numCore; i++)
+  {
+      cores[i]->executionTime = XML->sys.total_cycles /(XML->sys.core[i].clock_rate*1e6); 
+      cores[i]->rt_power.reset();
+		  cores[i]->compute();
+		  //cores[i]->computeEnergy(false);
+		  if (procdynp.homoCore){
+			  set_pppm(pppm_t,1/cores[i]->executionTime, procdynp.numCore,procdynp.numCore,procdynp.numCore);
+			  core.rt_power = core.rt_power + cores[i]->rt_power*pppm_t;
+			  rt_power = rt_power  + core.rt_power;
+		  }
+		  else{
+			  set_pppm(pppm_t,1/cores[i]->executionTime, 1, 1, 1);
+			  core.rt_power = core.rt_power + cores[i]->rt_power*pppm_t;
+			  rt_power = rt_power  + cores[i]->rt_power*pppm_t;
+		  }
   }
 
-  if (!XML->sys.Private_L2) {
-    if (numL2 > 0) l2.rt_power.reset();
-    for (i = 0; i < numL2; i++) {
+  if (!XML->sys.Private_L2)
+  {
+  if (numL2 >0)
+    l2.rt_power.reset();
+	  for (i = 0;i < numL2; i++)
+	  {
       l2array[i]->rt_power.reset();
-      l2array[i]->cachep.executionTime =
-          XML->sys.total_cycles / (XML->sys.core[0].clock_rate * 1e6);
-      l2array[i]->computeEnergy(false);
-      if (procdynp.homoL2) {
-        set_pppm(pppm_t, 1 / l2array[i]->cachep.executionTime, procdynp.numL2,
-                 procdynp.numL2, procdynp.numL2);
-        l2.rt_power = l2.rt_power + l2array[i]->rt_power * pppm_t;
-        rt_power = rt_power + l2.rt_power;
-      } else {
-        set_pppm(pppm_t, 1 / l2array[i]->cachep.executionTime, 1, 1, 1);
-        l2.rt_power = l2.rt_power + l2array[i]->rt_power * pppm_t;
-        rt_power = rt_power + l2array[i]->rt_power * pppm_t;
-      }
-    }
+		l2array[i]->cachep.executionTime=XML->sys.total_cycles /(XML->sys.core[0].clock_rate*1e6);
+		  l2array[i]->computeEnergy(false);
+		  if (procdynp.homoL2){
+			  set_pppm(pppm_t,1/l2array[i]->cachep.executionTime, procdynp.numL2,procdynp.numL2,procdynp.numL2);
+			  l2.rt_power = l2.rt_power + l2array[i]->rt_power*pppm_t;
+			  rt_power = rt_power  + l2.rt_power;
+		  }
+		  else{
+			  set_pppm(pppm_t,1/l2array[i]->cachep.executionTime, 1, 1, 1);
+			  l2.rt_power = l2.rt_power + l2array[i]->rt_power*pppm_t;
+			  rt_power = rt_power  + l2array[i]->rt_power*pppm_t;
+		  }
+	  }
   }
 
   l3.rt_power.reset();
-  if (numL3 > 0)
-    for (i = 0; i < numL3; i++) {
-      l3array[i]->rt_power.reset();
-      l3array[i]->computeEnergy(false);
-      if (procdynp.homoL3) {
-        set_pppm(pppm_t, 1 / l3array[i]->cachep.executionTime, procdynp.numL3,
-                 procdynp.numL3, procdynp.numL3);
-        l3.rt_power = l3.rt_power + l3array[i]->rt_power * pppm_t;
-        rt_power = rt_power + l3.rt_power;
+  if (numL3 >0)
+	  for (i = 0;i < numL3; i++)
+	  {
+		  l3array[i]->rt_power.reset();
+		  l3array[i]->computeEnergy(false);
+		  if (procdynp.homoL3){
+			  set_pppm(pppm_t,1/l3array[i]->cachep.executionTime, procdynp.numL3,procdynp.numL3,procdynp.numL3);
+        l3.rt_power = l3.rt_power + l3array[i]->rt_power*pppm_t;
+			  rt_power = rt_power  + l3.rt_power;
 
-      } else {
-        set_pppm(pppm_t, 1 / l3array[i]->cachep.executionTime, 1, 1, 1);
-        l3.rt_power = l3.rt_power + l3array[i]->rt_power * pppm_t;
-        rt_power = rt_power + l3array[i]->rt_power * pppm_t;
-      }
-    }
+		  }
+		  else{
+			  set_pppm(pppm_t,1/l3array[i]->cachep.executionTime, 1, 1, 1);
+        l3.rt_power = l3.rt_power + l3array[i]->rt_power*pppm_t;
+        rt_power = rt_power  + l3array[i]->rt_power*pppm_t;
+
+		  }
+	  }
 
   l1dir.rt_power.reset();
-  if (numL1Dir > 0)
-    for (i = 0; i < numL1Dir; i++) {
-      l1dirarray[i]->rt_power.reset();
-      l1dirarray[i]->computeEnergy(false);
-      if (procdynp.homoL1Dir) {
-        set_pppm(pppm_t, 1 / l1dirarray[i]->cachep.executionTime,
-                 procdynp.numL1Dir, procdynp.numL1Dir, procdynp.numL1Dir);
-        l1dir.rt_power = l1dir.rt_power + l1dirarray[i]->rt_power * pppm_t;
-        rt_power = rt_power + l1dir.rt_power;
+  if (numL1Dir >0)
+	  for (i = 0;i < numL1Dir; i++)
+	  {
+		  l1dirarray[i]->rt_power.reset();
+		  l1dirarray[i]->computeEnergy(false);
+		  if (procdynp.homoL1Dir){
+			  set_pppm(pppm_t,1/l1dirarray[i]->cachep.executionTime, procdynp.numL1Dir,procdynp.numL1Dir,procdynp.numL1Dir);
+        l1dir.rt_power = l1dir.rt_power + l1dirarray[i]->rt_power*pppm_t;
+			  rt_power = rt_power  + l1dir.rt_power;
 
-      } else {
-        set_pppm(pppm_t, 1 / l1dirarray[i]->cachep.executionTime, 1, 1, 1);
-        l1dir.rt_power = l1dir.rt_power + l1dirarray[i]->rt_power * pppm_t;
-        rt_power = rt_power + l1dirarray[i]->rt_power;
-      }
-    }
+		  }
+		  else{
+			  set_pppm(pppm_t,1/l1dirarray[i]->cachep.executionTime, 1, 1, 1);
+        l1dir.rt_power = l1dir.rt_power + l1dirarray[i]->rt_power*pppm_t;
+			  rt_power = rt_power  + l1dirarray[i]->rt_power;
+		  }
+	  }
+
 
   l2dir.rt_power.reset();
-  if (numL2Dir > 0)
-    for (i = 0; i < numL2Dir; i++) {
-      l2dirarray[i]->rt_power.reset();
-      l2dirarray[i]->computeEnergy(false);
-      if (procdynp.homoL2Dir) {
-        set_pppm(pppm_t, 1 / l2dirarray[i]->cachep.executionTime,
-                 procdynp.numL2Dir, procdynp.numL2Dir, procdynp.numL2Dir);
-        l2dir.rt_power = l2dir.rt_power + l2dirarray[i]->rt_power * pppm_t;
-        rt_power = rt_power + l2dir.rt_power;
+  if (numL2Dir >0)
+	  for (i = 0;i < numL2Dir; i++)
+	  {
+		  l2dirarray[i]->rt_power.reset();
+		  l2dirarray[i]->computeEnergy(false);
+		  if (procdynp.homoL2Dir){
+			  set_pppm(pppm_t,1/l2dirarray[i]->cachep.executionTime, procdynp.numL2Dir,procdynp.numL2Dir,procdynp.numL2Dir);
+        l2dir.rt_power = l2dir.rt_power + l2dirarray[i]->rt_power*pppm_t;
+			  rt_power = rt_power  + l2dir.rt_power;
 
-      } else {
-        set_pppm(pppm_t, 1 / l2dirarray[i]->cachep.executionTime, 1, 1, 1);
-        l2dir.rt_power = l2dir.rt_power + l2dirarray[i]->rt_power * pppm_t;
-        rt_power = rt_power + l2dirarray[i]->rt_power * pppm_t;
-      }
-    }
+		  }
+		  else{
+			  set_pppm(pppm_t,1/l2dirarray[i]->cachep.executionTime, 1, 1, 1);
+        l2dir.rt_power = l2dir.rt_power + l2dirarray[i]->rt_power*pppm_t;
+			  rt_power = rt_power  + l2dirarray[i]->rt_power*pppm_t;
+		  }
+	  }
+
 
   mcs.rt_power.reset();
-  if (XML->sys.mc.number_mcs > 0 && XML->sys.mc.memory_channels_per_mc > 0) {
-    mc->rt_power.reset();
-    mc->mcp.executionTime =
-        XML->sys.total_cycles / (XML->sys.core[0].clock_rate * 1e6);  // Jingwen
-    mc->computeEnergy(false);
-    set_pppm(pppm_t, 1 / mc->mcp.executionTime, XML->sys.mc.number_mcs,
-             XML->sys.mc.number_mcs, XML->sys.mc.number_mcs);
-    mcs.rt_power = mc->rt_power * pppm_t;
-    rt_power = rt_power + mcs.rt_power;
+  if (XML->sys.mc.number_mcs >0 && XML->sys.mc.memory_channels_per_mc>0)
+  {
+	  mc->rt_power.reset();
+    mc->mcp.executionTime = XML->sys.total_cycles /(XML->sys.core[0].clock_rate*1e6); //Jingwen
+	  mc->computeEnergy(false);
+	  set_pppm(pppm_t,1/mc->mcp.executionTime, XML->sys.mc.number_mcs,XML->sys.mc.number_mcs,XML->sys.mc.number_mcs);
+	  mcs.rt_power = mc->rt_power*pppm_t;
+	  rt_power = rt_power  + mcs.rt_power;
+
+  }
+  
+
+/*  
+  if (XML->sys.flashc.number_mcs >0 )//flash controller
+  {
+	  flashcontrollers.rt_power.reset();
+	  flashcontroller->computeEnergy(false);
+	  double number_fcs = flashcontroller->fcp.num_mcs;
+	  set_pppm(pppm_t,number_fcs , number_fcs ,number_fcs ,number_fcs );
+	  flashcontrollers.rt_power = flashcontroller->rt_power*pppm_t;
+	  rt_power = rt_power  + flashcontrollers.rt_power;
+
   }
 
-  /*
-    if (XML->sys.flashc.number_mcs >0 )//flash controller
-    {
-            flashcontrollers.rt_power.reset();
-            flashcontroller->computeEnergy(false);
-            double number_fcs = flashcontroller->fcp.num_mcs;
-            set_pppm(pppm_t,number_fcs , number_fcs ,number_fcs ,number_fcs );
-            flashcontrollers.rt_power = flashcontroller->rt_power*pppm_t;
-            rt_power = rt_power  + flashcontrollers.rt_power;
+  if (XML->sys.niu.number_units >0)
+  {
+	  niu->computeEnergy(false);
+	  nius.rt_power.reset();
+	  set_pppm(pppm_t,XML->sys.niu.number_units*niu->niup.clockRate, XML->sys.niu.number_units,XML->sys.niu.number_units,XML->sys.niu.number_units);
+	  nius.rt_power = niu->rt_power*pppm_t;
+	  rt_power = rt_power  + nius.rt_power;
 
-    }
-
-    if (XML->sys.niu.number_units >0)
-    {
-            niu->computeEnergy(false);
-            nius.rt_power.reset();
-            set_pppm(pppm_t,XML->sys.niu.number_units*niu->niup.clockRate,
-    XML->sys.niu.number_units,XML->sys.niu.number_units,XML->sys.niu.number_units);
-            nius.rt_power = niu->rt_power*pppm_t;
-            rt_power = rt_power  + nius.rt_power;
-
-    }
-
-    if (XML->sys.pcie.number_units >0 && XML->sys.pcie.num_channels >0)
-    {
-            pcie->computeEnergy(false);
-            pcies.rt_power.reset();
-            set_pppm(pppm_t,XML->sys.pcie.number_units*pcie->pciep.clockRate,
-    XML->sys.pcie.number_units,XML->sys.pcie.number_units,XML->sys.pcie.number_units);
-            pcies.rt_power = pcie->rt_power*pppm_t;
-            rt_power = rt_power  + pcies.rt_power;
-
-    }
-
-
-             // * Compute global links associated with each NOC, if any. This
-    must be done at the end (even after the NOC router part) since the total
-    chip
-             // * area must be obtain to decide the link routing
-            */
-  // Compute energy of NoC (w or w/o links) or buses
-  noc.rt_power.reset();
-  for (i = 0; i < numNOC; i++) {
-    nocs[i]->nocdynp.executionTime =
-        XML->sys.total_cycles / (XML->sys.core[0].clock_rate * 1e6);
-    nocs[i]->computeEnergy(false);
-    if (procdynp.homoNOC) {
-      set_pppm(pppm_t, 1 / nocs[i]->nocdynp.executionTime, procdynp.numNOC,
-               procdynp.numNOC, procdynp.numNOC);
-      noc.rt_power = noc.rt_power + nocs[i]->rt_power * pppm_t;
-      rt_power = rt_power + noc.rt_power;
-    } else {
-      set_pppm(pppm_t, 1 / nocs[i]->nocdynp.executionTime, 1, 1, 1);
-      noc.rt_power = noc.rt_power + nocs[i]->rt_power * pppm_t;
-      rt_power = rt_power + nocs[i]->rt_power * pppm_t;
-    }
   }
 
-  //  //clock power
-  //  globalClock.init_wire_external(is_default, &interface_ip);
-  //  globalClock.clk_area           =area*1e6; //change it from mm^2 to um^2
-  //  globalClock.end_wiring_level   =5;//toplevel metal
-  //  globalClock.start_wiring_level =5;//toplevel metal
-  //  globalClock.l_ip.with_clock_grid=false;//global clock does not drive local
-  //  final nodes
-  //  globalClock.optimize_wire();
+  if (XML->sys.pcie.number_units >0 && XML->sys.pcie.num_channels >0)
+  {
+	  pcie->computeEnergy(false);
+	  pcies.rt_power.reset();
+	  set_pppm(pppm_t,XML->sys.pcie.number_units*pcie->pciep.clockRate, XML->sys.pcie.number_units,XML->sys.pcie.number_units,XML->sys.pcie.number_units);
+	  pcies.rt_power = pcie->rt_power*pppm_t;
+	  rt_power = rt_power  + pcies.rt_power;
+
+  }
+
+	  
+	   // * Compute global links associated with each NOC, if any. This must be done at the end (even after the NOC router part) since the total chip
+	   // * area must be obtain to decide the link routing
+	  */ 
+	  //Compute energy of NoC (w or w/o links) or buses
+    noc.rt_power.reset();
+	  for (i = 0;i < numNOC; i++)
+	  {
+		 nocs[i]->nocdynp.executionTime=XML->sys.total_cycles /(XML->sys.core[0].clock_rate*1e6);
+		  nocs[i]->computeEnergy(false);
+		  if (procdynp.homoNOC){
+			  set_pppm(pppm_t,1/nocs[i]->nocdynp.executionTime, procdynp.numNOC,procdynp.numNOC,procdynp.numNOC);
+			  noc.rt_power = noc.rt_power + nocs[i]->rt_power*pppm_t;
+			  rt_power = rt_power  + noc.rt_power;
+		  }
+		  else
+		  {
+			  set_pppm(pppm_t,1/nocs[i]->nocdynp.executionTime, 1, 1, 1);
+			  noc.rt_power = noc.rt_power + nocs[i]->rt_power*pppm_t;
+			  rt_power = rt_power  + nocs[i]->rt_power*pppm_t;
+		  }
+	  } 
+    
+
+//  //clock power
+//  globalClock.init_wire_external(is_default, &interface_ip);
+//  globalClock.clk_area           =area*1e6; //change it from mm^2 to um^2
+//  globalClock.end_wiring_level   =5;//toplevel metal
+//  globalClock.start_wiring_level =5;//toplevel metal
+//  globalClock.l_ip.with_clock_grid=false;//global clock does not drive local final nodes
+//  globalClock.optimize_wire();
+
 }
 
-void Processor::displayDeviceType(int device_type_, uint32_t indent) {
-  string indent_str(indent, ' ');
+void Processor::displayDeviceType(int device_type_, uint32_t indent)
+{
+	string indent_str(indent, ' ');
 
-  switch (device_type_) {
-    case 0:
-      cout << indent_str << "Device Type= "
-           << "ITRS high performance device type" << endl;
-      break;
-    case 1:
-      cout << indent_str << "Device Type= "
-           << "ITRS low standby power device type" << endl;
-      break;
-    case 2:
-      cout << indent_str << "Device Type= "
-           << "ITRS low operating power device type" << endl;
-      break;
-    case 3:
-      cout << indent_str << "Device Type= "
-           << "LP-DRAM device type" << endl;
-      break;
-    case 4:
-      cout << indent_str << "Device Type= "
-           << "COMM-DRAM device type" << endl;
-      break;
-    default: {
-      cout << indent_str << "Unknown Device Type" << endl;
-      exit(0);
-    }
-  }
+	switch ( device_type_ ) {
+
+	  case 0 :
+		  cout <<indent_str<<"Device Type= "<<"ITRS high performance device type"<<endl;
+	    break;
+	  case 1 :
+		  cout <<indent_str<<"Device Type= "<<"ITRS low standby power device type"<<endl;
+	    break;
+	  case 2 :
+		  cout <<indent_str<<"Device Type= "<<"ITRS low operating power device type"<<endl;
+	    break;
+	  case 3 :
+		  cout <<indent_str<<"Device Type= "<<"LP-DRAM device type"<<endl;
+	    break;
+	  case 4 :
+		  cout <<indent_str<<"Device Type= "<<"COMM-DRAM device type"<<endl;
+	    break;
+	  default :
+		  {
+			  cout <<indent_str<<"Unknown Device Type"<<endl;
+			  exit(0);
+		  }
+	}
 }
 
-void Processor::displayInterconnectType(int interconnect_type_,
-                                        uint32_t indent) {
-  string indent_str(indent, ' ');
+void Processor::displayInterconnectType(int interconnect_type_, uint32_t indent)
+{
+	string indent_str(indent, ' ');
 
-  switch (interconnect_type_) {
-    case 0:
-      cout << indent_str << "Interconnect metal projection= "
-           << "aggressive interconnect technology projection" << endl;
-      break;
-    case 1:
-      cout << indent_str << "Interconnect metal projection= "
-           << "conservative interconnect technology projection" << endl;
-      break;
-    default: {
-      cout << indent_str << "Unknown Interconnect Projection Type" << endl;
-      exit(0);
-    }
-  }
+	switch ( interconnect_type_ ) {
+
+	  case 0 :
+		  cout <<indent_str<<"Interconnect metal projection= "<<"aggressive interconnect technology projection"<<endl;
+	    break;
+	  case 1 :
+		  cout <<indent_str<<"Interconnect metal projection= "<<"conservative interconnect technology projection"<<endl;
+	    break;
+	  default :
+		  {
+			  cout <<indent_str<<"Unknown Interconnect Projection Type"<<endl;
+			  exit(0);
+		  }
+	}
 }
 
-void Processor::displayEnergy(uint32_t indent, int plevel, bool is_tdp_parm) {
-  int i;
-  bool long_channel = XML->sys.longer_channel_device;
-  string indent_str(indent, ' ');
-  string indent_str_next(indent + 2, ' ');
-  bool is_tdp = is_tdp_parm;
-  if (is_tdp_parm) {
-    if (plevel < 5) {
-      cout
-          << "\nMcPAT (version " << VER_MAJOR << "." << VER_MINOR << " of "
-          << VER_UPDATE << ") results (current print level is " << plevel
-          << ", please increase print level to see the details in components): "
-          << endl;
-    } else {
-      cout << "\nMcPAT (version " << VER_MAJOR << "." << VER_MINOR << " of "
-           << VER_UPDATE << ") results  (current print level is 5)" << endl;
-    }
-    cout << "******************************************************************"
-            "***********************"
-         << endl;
-    cout << indent_str << "Technology " << XML->sys.core_tech_node << " nm"
-         << endl;
-    // cout <<indent_str<<"Device Type= "<<XML->sys.device_type<<endl;
-    if (long_channel)
-      cout << indent_str << "Using Long Channel Devices When Appropriate"
-           << endl;
-    // cout <<indent_str<<"Interconnect metal projection=
-    // "<<XML->sys.interconnect_projection_type<<endl;
-    displayInterconnectType(XML->sys.interconnect_projection_type, indent);
-    cout << indent_str << "Core clock Rate(MHz) " << XML->sys.core[0].clock_rate
-         << endl;
-    cout << endl;
-    cout << "******************************************************************"
-            "***********************"
-         << endl;
-    cout << "Processor: " << endl;
-    cout << indent_str << "Area = " << area.get_area() * 1e-6 << " mm^2"
-         << endl;
-    cout << indent_str << "Peak Power = "
-         << power.readOp.dynamic +
-                (long_channel ? power.readOp.longer_channel_leakage
-                              : power.readOp.leakage) +
-                power.readOp.gate_leakage
-         << " W" << endl;
-    cout << indent_str << "Total Leakage = "
-         << (long_channel ? power.readOp.longer_channel_leakage
-                          : power.readOp.leakage) +
-                power.readOp.gate_leakage
-         << " W" << endl;
-    cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic << " W"
-         << endl;
-    cout << indent_str << "Subthreshold Leakage = "
-         << (long_channel ? power.readOp.longer_channel_leakage
-                          : power.readOp.leakage)
-         << " W" << endl;
-    // cout << indent_str << "Subthreshold Leakage = " <<
-    // power.readOp.longer_channel_leakage <<" W" << endl;
-    cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W"
-         << endl;
-    cout << indent_str << "Runtime Dynamic = " << rt_power.readOp.dynamic
-         << " W" << endl;
-    cout << endl;
-    if (numCore > 0) {
-      cout << indent_str << "Total Cores: " << XML->sys.number_of_cores
-           << " cores " << endl;
-      displayDeviceType(XML->sys.device_type, indent);
-      cout << indent_str_next << "Area = " << core.area.get_area() * 1e-6
-           << " mm^2" << endl;
-      cout << indent_str_next << "Peak Dynamic = " << core.power.readOp.dynamic
-           << " W" << endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel ? core.power.readOp.longer_channel_leakage
-                            : core.power.readOp.leakage)
-           << " W" << endl;
-      // cout << indent_str_next << "Subthreshold Leakage = " <<
-      // core.power.readOp.longer_channel_leakage <<" W" << endl;
-      cout << indent_str_next
-           << "Gate Leakage = " << core.power.readOp.gate_leakage << " W"
-           << endl;
-      cout << indent_str_next
-           << "Runtime Dynamic = " << core.rt_power.readOp.dynamic << " W"
-           << endl;
-      cout << endl;
-    }
-    if (!XML->sys.Private_L2) {
-      if (numL2 > 0) {
-        cout << indent_str << "Total L2s: " << endl;
-        displayDeviceType(XML->sys.L2[0].device_type, indent);
-        cout << indent_str_next << "Area = " << l2.area.get_area() * 1e-6
-             << " mm^2" << endl;
-        cout << indent_str_next << "Peak Dynamic = " << l2.power.readOp.dynamic
-             << " W" << endl;
-        cout << indent_str_next << "Subthreshold Leakage = "
-             << (long_channel ? l2.power.readOp.longer_channel_leakage
-                              : l2.power.readOp.leakage)
-             << " W" << endl;
-        // cout << indent_str_next << "Subthreshold Leakage = " <<
-        // l2.power.readOp.longer_channel_leakage <<" W" << endl;
-        cout << indent_str_next
-             << "Gate Leakage = " << l2.power.readOp.gate_leakage << " W"
-             << endl;
-        cout << indent_str_next
-             << "Runtime Dynamic = " << l2.rt_power.readOp.dynamic << " W"
-             << endl;
-        cout << endl;
-      }
-    }
-    if (numL3 > 0) {
-      cout << indent_str << "Total L3s: " << endl;
-      displayDeviceType(XML->sys.L3[0].device_type, indent);
-      cout << indent_str_next << "Area = " << l3.area.get_area() * 1e-6
-           << " mm^2" << endl;
-      cout << indent_str_next << "Peak Dynamic = " << l3.power.readOp.dynamic
-           << " W" << endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel ? l3.power.readOp.longer_channel_leakage
-                            : l3.power.readOp.leakage)
-           << " W" << endl;
-      // cout << indent_str_next << "Subthreshold Leakage = " <<
-      // l3.power.readOp.longer_channel_leakage <<" W" << endl;
-      cout << indent_str_next
-           << "Gate Leakage = " << l3.power.readOp.gate_leakage << " W" << endl;
-      cout << indent_str_next
-           << "Runtime Dynamic = " << l3.rt_power.readOp.dynamic << " W"
-           << endl;
-      cout << endl;
-    }
-    if (numL1Dir > 0) {
-      cout << indent_str << "Total First Level Directory: " << endl;
-      displayDeviceType(XML->sys.L1Directory[0].device_type, indent);
-      cout << indent_str_next << "Area = " << l1dir.area.get_area() * 1e-6
-           << " mm^2" << endl;
-      cout << indent_str_next << "Peak Dynamic = " << l1dir.power.readOp.dynamic
-           << " W" << endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel ? l1dir.power.readOp.longer_channel_leakage
-                            : l1dir.power.readOp.leakage)
-           << " W" << endl;
-      // cout << indent_str_next << "Subthreshold Leakage = " <<
-      // l1dir.power.readOp.longer_channel_leakage <<" W" << endl;
-      cout << indent_str_next
-           << "Gate Leakage = " << l1dir.power.readOp.gate_leakage << " W"
-           << endl;
-      cout << indent_str_next
-           << "Runtime Dynamic = " << l1dir.rt_power.readOp.dynamic << " W"
-           << endl;
-      cout << endl;
-    }
-    if (numL2Dir > 0) {
-      cout << indent_str << "Total First Level Directory: " << endl;
-      displayDeviceType(XML->sys.L1Directory[0].device_type, indent);
-      cout << indent_str_next << "Area = " << l2dir.area.get_area() * 1e-6
-           << " mm^2" << endl;
-      cout << indent_str_next << "Peak Dynamic = " << l2dir.power.readOp.dynamic
-           << " W" << endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel ? l2dir.power.readOp.longer_channel_leakage
-                            : l2dir.power.readOp.leakage)
-           << " W" << endl;
-      // cout << indent_str_next << "Subthreshold Leakage = " <<
-      // l2dir.power.readOp.longer_channel_leakage <<" W" << endl;
-      cout << indent_str_next
-           << "Gate Leakage = " << l2dir.power.readOp.gate_leakage << " W"
-           << endl;
-      cout << indent_str_next
-           << "Runtime Dynamic = " << l2dir.rt_power.readOp.dynamic << " W"
-           << endl;
-      cout << endl;
-    }
-    if (numNOC > 0) {
-      cout << indent_str << "Total NoCs (Network/Bus): " << endl;
-      displayDeviceType(XML->sys.device_type, indent);
-      cout << indent_str_next << "Area = " << noc.area.get_area() * 1e-6
-           << " mm^2" << endl;
-      cout << indent_str_next << "Peak Dynamic = " << noc.power.readOp.dynamic
-           << " W" << endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel ? noc.power.readOp.longer_channel_leakage
-                            : noc.power.readOp.leakage)
-           << " W" << endl;
-      // cout << indent_str_next << "Subthreshold Leakage = " <<
-      // noc.power.readOp.longer_channel_leakage  <<" W" << endl;
-      cout << indent_str_next
-           << "Gate Leakage = " << noc.power.readOp.gate_leakage << " W"
-           << endl;
-      cout << indent_str_next
-           << "Runtime Dynamic = " << noc.rt_power.readOp.dynamic << " W"
-           << endl;
-      cout << endl;
-    }
-    if (XML->sys.mc.number_mcs > 0 && XML->sys.mc.memory_channels_per_mc > 0) {
-      cout << indent_str << "Total MCs: " << XML->sys.mc.number_mcs
-           << " Memory Controllers " << endl;
-      displayDeviceType(XML->sys.device_type, indent);
-      cout << indent_str_next << "Area = " << mcs.area.get_area() * 1e-6
-           << " mm^2" << endl;
-      cout << indent_str_next << "Peak Dynamic = " << mcs.power.readOp.dynamic
-           << " W" << endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel ? mcs.power.readOp.longer_channel_leakage
-                            : mcs.power.readOp.leakage)
-           << " W" << endl;
-      cout << indent_str_next
-           << "Gate Leakage = " << mcs.power.readOp.gate_leakage << " W"
-           << endl;
-      cout << indent_str_next
-           << "Runtime Dynamic = " << mcs.rt_power.readOp.dynamic << " W"
-           << endl;
-      cout << endl;
-    }
-    if (XML->sys.flashc.number_mcs > 0) {
-      cout << indent_str
-           << "Total Flash/SSD Controllers: " << flashcontroller->fcp.num_mcs
-           << " Flash/SSD Controllers " << endl;
-      displayDeviceType(XML->sys.device_type, indent);
-      cout << indent_str_next
-           << "Area = " << flashcontrollers.area.get_area() * 1e-6 << " mm^2"
-           << endl;
-      cout << indent_str_next
-           << "Peak Dynamic = " << flashcontrollers.power.readOp.dynamic << " W"
-           << endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel
-                   ? flashcontrollers.power.readOp.longer_channel_leakage
-                   : flashcontrollers.power.readOp.leakage)
-           << " W" << endl;
-      cout << indent_str_next
-           << "Gate Leakage = " << flashcontrollers.power.readOp.gate_leakage
-           << " W" << endl;
-      cout << indent_str_next
-           << "Runtime Dynamic = " << flashcontrollers.rt_power.readOp.dynamic
-           << " W" << endl;
-      cout << endl;
-    }
-    if (XML->sys.niu.number_units > 0) {
-      cout << indent_str << "Total NIUs: " << niu->niup.num_units
-           << " Network Interface Units " << endl;
-      displayDeviceType(XML->sys.device_type, indent);
-      cout << indent_str_next << "Area = " << nius.area.get_area() * 1e-6
-           << " mm^2" << endl;
-      cout << indent_str_next << "Peak Dynamic = " << nius.power.readOp.dynamic
-           << " W" << endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel ? nius.power.readOp.longer_channel_leakage
-                            : nius.power.readOp.leakage)
-           << " W" << endl;
-      cout << indent_str_next
-           << "Gate Leakage = " << nius.power.readOp.gate_leakage << " W"
-           << endl;
-      cout << indent_str_next
-           << "Runtime Dynamic = " << nius.rt_power.readOp.dynamic << " W"
-           << endl;
-      cout << endl;
-    }
-    if (XML->sys.pcie.number_units > 0 && XML->sys.pcie.num_channels > 0) {
-      cout << indent_str << "Total PCIes: " << pcie->pciep.num_units
-           << " PCIe Controllers " << endl;
-      displayDeviceType(XML->sys.device_type, indent);
-      cout << indent_str_next << "Area = " << pcies.area.get_area() * 1e-6
-           << " mm^2" << endl;
-      cout << indent_str_next << "Peak Dynamic = " << pcies.power.readOp.dynamic
-           << " W" << endl;
-      cout << indent_str_next << "Subthreshold Leakage = "
-           << (long_channel ? pcies.power.readOp.longer_channel_leakage
-                            : pcies.power.readOp.leakage)
-           << " W" << endl;
-      cout << indent_str_next
-           << "Gate Leakage = " << pcies.power.readOp.gate_leakage << " W"
-           << endl;
-      cout << indent_str_next
-           << "Runtime Dynamic = " << pcies.rt_power.readOp.dynamic << " W"
-           << endl;
-      cout << endl;
-    }
-    cout << "******************************************************************"
-            "***********************"
-         << endl;
-    if (plevel > 1) {
-      for (i = 0; i < numCore; i++) {
-        cores[i]->displayEnergy(indent + 4, plevel, is_tdp);
-        cout << "**************************************************************"
-                "***************************"
-             << endl;
-      }
-      if (!XML->sys.Private_L2) {
-        for (i = 0; i < numL2; i++) {
-          l2array[i]->displayEnergy(indent + 4, is_tdp);
-          cout << "************************************************************"
-                  "*****************************"
-               << endl;
-        }
-      }
-      for (i = 0; i < numL3; i++) {
-        l3array[i]->displayEnergy(indent + 4, is_tdp);
-        cout << "**************************************************************"
-                "***************************"
-             << endl;
-      }
-      for (i = 0; i < numL1Dir; i++) {
-        l1dirarray[i]->displayEnergy(indent + 4, is_tdp);
-        cout << "**************************************************************"
-                "***************************"
-             << endl;
-      }
-      for (i = 0; i < numL2Dir; i++) {
-        l2dirarray[i]->displayEnergy(indent + 4, is_tdp);
-        cout << "**************************************************************"
-                "***************************"
-             << endl;
-      }
-      if (XML->sys.mc.number_mcs > 0 &&
-          XML->sys.mc.memory_channels_per_mc > 0) {
-        mc->displayEnergy(indent + 4, is_tdp);
-        cout << "**************************************************************"
-                "***************************"
-             << endl;
-      }
-      if (XML->sys.flashc.number_mcs > 0 &&
-          XML->sys.flashc.memory_channels_per_mc > 0) {
-        flashcontroller->displayEnergy(indent + 4, is_tdp);
-        cout << "**************************************************************"
-                "***************************"
-             << endl;
-      }
-      if (XML->sys.niu.number_units > 0) {
-        niu->displayEnergy(indent + 4, is_tdp);
-        cout << "**************************************************************"
-                "***************************"
-             << endl;
-      }
-      if (XML->sys.pcie.number_units > 0 && XML->sys.pcie.num_channels > 0) {
-        pcie->displayEnergy(indent + 4, is_tdp);
-        cout << "**************************************************************"
-                "***************************"
-             << endl;
-      }
+void Processor::displayEnergy(uint32_t indent, int plevel, bool is_tdp_parm)
+{
+	int i;
+	bool long_channel = XML->sys.longer_channel_device;
+	string indent_str(indent, ' ');
+	string indent_str_next(indent+2, ' ');
+	bool is_tdp=is_tdp_parm;
+	if (is_tdp_parm)
+	{
 
-      for (i = 0; i < numNOC; i++) {
-        nocs[i]->displayEnergy(indent + 4, plevel, is_tdp);
-        cout << "**************************************************************"
-                "***************************"
-             << endl;
-      }
-    }
-  } else {
-  }
+
+		if (plevel<5)
+		{
+			cout<<"\nMcPAT (version "<< VER_MAJOR <<"."<< VER_MINOR
+					<< " of " << VER_UPDATE << ") results (current print level is "<< plevel
+			<<", please increase print level to see the details in components): "<<endl;
+		}
+		else
+		{
+			cout<<"\nMcPAT (version "<< VER_MAJOR <<"."<< VER_MINOR
+								<< " of " << VER_UPDATE << ") results  (current print level is 5)"<< endl;
+		}
+		cout <<"*****************************************************************************************"<<endl;
+		cout <<indent_str<<"Technology "<<XML->sys.core_tech_node<<" nm"<<endl;
+		//cout <<indent_str<<"Device Type= "<<XML->sys.device_type<<endl;
+		if (long_channel)
+			cout <<indent_str<<"Using Long Channel Devices When Appropriate"<<endl;
+		//cout <<indent_str<<"Interconnect metal projection= "<<XML->sys.interconnect_projection_type<<endl;
+		displayInterconnectType(XML->sys.interconnect_projection_type, indent);
+		cout <<indent_str<<"Core clock Rate(MHz) "<<XML->sys.core[0].clock_rate<<endl;
+    	cout <<endl;
+		cout <<"*****************************************************************************************"<<endl;
+		cout <<"Processor: "<<endl;
+		cout << indent_str << "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
+		cout << indent_str << "Peak Power = " << power.readOp.dynamic +
+			(long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) + power.readOp.gate_leakage <<" W" << endl;
+		cout << indent_str << "Total Leakage = " <<
+			(long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) + power.readOp.gate_leakage <<" W" << endl;
+		cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic << " W" << endl;
+		cout << indent_str << "Subthreshold Leakage = " << (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
+		//cout << indent_str << "Subthreshold Leakage = " << power.readOp.longer_channel_leakage <<" W" << endl;
+		cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
+		cout << indent_str << "Runtime Dynamic = " << rt_power.readOp.dynamic << " W" << endl;
+		cout <<endl;
+		if (numCore >0){
+		cout <<indent_str<<"Total Cores: "<<XML->sys.number_of_cores << " cores "<<endl;
+		displayDeviceType(XML->sys.device_type,indent);
+		cout << indent_str_next << "Area = " << core.area.get_area()*1e-6<< " mm^2" << endl;
+		cout << indent_str_next << "Peak Dynamic = " << core.power.readOp.dynamic << " W" << endl;
+		cout << indent_str_next << "Subthreshold Leakage = "
+			<< (long_channel? core.power.readOp.longer_channel_leakage:core.power.readOp.leakage) <<" W" << endl;
+		//cout << indent_str_next << "Subthreshold Leakage = " << core.power.readOp.longer_channel_leakage <<" W" << endl;
+		cout << indent_str_next << "Gate Leakage = " << core.power.readOp.gate_leakage << " W" << endl;
+		cout << indent_str_next << "Runtime Dynamic = " << core.rt_power.readOp.dynamic << " W" << endl;
+		cout <<endl;
+		}
+		if (!XML->sys.Private_L2)
+		{
+			if (numL2 >0){
+				cout <<indent_str<<"Total L2s: "<<endl;
+				displayDeviceType(XML->sys.L2[0].device_type,indent);
+				cout << indent_str_next << "Area = " << l2.area.get_area()*1e-6<< " mm^2" << endl;
+				cout << indent_str_next << "Peak Dynamic = " << l2.power.readOp.dynamic << " W" << endl;
+				cout << indent_str_next << "Subthreshold Leakage = "
+				<< (long_channel? l2.power.readOp.longer_channel_leakage:l2.power.readOp.leakage) <<" W" << endl;
+				//cout << indent_str_next << "Subthreshold Leakage = " << l2.power.readOp.longer_channel_leakage <<" W" << endl;
+				cout << indent_str_next << "Gate Leakage = " << l2.power.readOp.gate_leakage << " W" << endl;
+				cout << indent_str_next << "Runtime Dynamic = " << l2.rt_power.readOp.dynamic << " W" << endl;
+				cout <<endl;
+			}
+		}
+		if (numL3 >0){
+			cout <<indent_str<<"Total L3s: "<<endl;
+			displayDeviceType(XML->sys.L3[0].device_type, indent);
+			cout << indent_str_next << "Area = " << l3.area.get_area()*1e-6<< " mm^2" << endl;
+			cout << indent_str_next << "Peak Dynamic = " << l3.power.readOp.dynamic << " W" << endl;
+			cout << indent_str_next << "Subthreshold Leakage = "
+				<< (long_channel? l3.power.readOp.longer_channel_leakage:l3.power.readOp.leakage) <<" W" << endl;
+			//cout << indent_str_next << "Subthreshold Leakage = " << l3.power.readOp.longer_channel_leakage <<" W" << endl;
+			cout << indent_str_next << "Gate Leakage = " << l3.power.readOp.gate_leakage << " W" << endl;
+			cout << indent_str_next << "Runtime Dynamic = " << l3.rt_power.readOp.dynamic << " W" << endl;
+			cout <<endl;
+		}
+		if (numL1Dir >0){
+			cout <<indent_str<<"Total First Level Directory: "<<endl;
+			displayDeviceType(XML->sys.L1Directory[0].device_type, indent);
+			cout << indent_str_next << "Area = " << l1dir.area.get_area()*1e-6<< " mm^2" << endl;
+			cout << indent_str_next << "Peak Dynamic = " << l1dir.power.readOp.dynamic << " W" << endl;
+			cout << indent_str_next << "Subthreshold Leakage = "
+				<< (long_channel? l1dir.power.readOp.longer_channel_leakage:l1dir.power.readOp.leakage) <<" W" << endl;
+			//cout << indent_str_next << "Subthreshold Leakage = " << l1dir.power.readOp.longer_channel_leakage <<" W" << endl;
+			cout << indent_str_next << "Gate Leakage = " << l1dir.power.readOp.gate_leakage << " W" << endl;
+			cout << indent_str_next << "Runtime Dynamic = " << l1dir.rt_power.readOp.dynamic << " W" << endl;
+			cout <<endl;
+		}
+		if (numL2Dir >0){
+			cout <<indent_str<<"Total First Level Directory: "<<endl;
+			displayDeviceType(XML->sys.L1Directory[0].device_type, indent);
+			cout << indent_str_next << "Area = " << l2dir.area.get_area()*1e-6<< " mm^2" << endl;
+			cout << indent_str_next << "Peak Dynamic = " << l2dir.power.readOp.dynamic << " W" << endl;
+			cout << indent_str_next << "Subthreshold Leakage = "
+				<< (long_channel? l2dir.power.readOp.longer_channel_leakage:l2dir.power.readOp.leakage) <<" W" << endl;
+			//cout << indent_str_next << "Subthreshold Leakage = " << l2dir.power.readOp.longer_channel_leakage <<" W" << endl;
+			cout << indent_str_next << "Gate Leakage = " << l2dir.power.readOp.gate_leakage << " W" << endl;
+			cout << indent_str_next << "Runtime Dynamic = " << l2dir.rt_power.readOp.dynamic << " W" << endl;
+			cout <<endl;
+		}
+		if (numNOC >0){
+			cout <<indent_str<<"Total NoCs (Network/Bus): "<<endl;
+			displayDeviceType(XML->sys.device_type, indent);
+			cout << indent_str_next << "Area = " << noc.area.get_area()*1e-6<< " mm^2" << endl;
+			cout << indent_str_next << "Peak Dynamic = " << noc.power.readOp.dynamic << " W" << endl;
+			cout << indent_str_next << "Subthreshold Leakage = "
+				<< (long_channel? noc.power.readOp.longer_channel_leakage:noc.power.readOp.leakage) <<" W" << endl;
+			//cout << indent_str_next << "Subthreshold Leakage = " << noc.power.readOp.longer_channel_leakage  <<" W" << endl;
+			cout << indent_str_next << "Gate Leakage = " << noc.power.readOp.gate_leakage << " W" << endl;
+			cout << indent_str_next << "Runtime Dynamic = " << noc.rt_power.readOp.dynamic << " W" << endl;
+			cout <<endl;
+		}
+		if (XML->sys.mc.number_mcs >0 && XML->sys.mc.memory_channels_per_mc>0)
+		{
+			cout <<indent_str<<"Total MCs: "<<XML->sys.mc.number_mcs << " Memory Controllers "<<endl;
+			displayDeviceType(XML->sys.device_type, indent);
+			cout << indent_str_next << "Area = " << mcs.area.get_area()*1e-6<< " mm^2" << endl;
+			cout << indent_str_next << "Peak Dynamic = " << mcs.power.readOp.dynamic << " W" << endl;
+			cout << indent_str_next << "Subthreshold Leakage = "
+				<< (long_channel? mcs.power.readOp.longer_channel_leakage:mcs.power.readOp.leakage)  <<" W" << endl;
+			cout << indent_str_next << "Gate Leakage = " << mcs.power.readOp.gate_leakage << " W" << endl;
+			cout << indent_str_next << "Runtime Dynamic = " << mcs.rt_power.readOp.dynamic << " W" << endl;
+			cout <<endl;
+		}
+		if (XML->sys.flashc.number_mcs >0)
+		{
+			cout <<indent_str<<"Total Flash/SSD Controllers: "<<flashcontroller->fcp.num_mcs << " Flash/SSD Controllers "<<endl;
+			displayDeviceType(XML->sys.device_type, indent);
+			cout << indent_str_next << "Area = " << flashcontrollers.area.get_area()*1e-6<< " mm^2" << endl;
+			cout << indent_str_next << "Peak Dynamic = " << flashcontrollers.power.readOp.dynamic << " W" << endl;
+			cout << indent_str_next << "Subthreshold Leakage = "
+				<< (long_channel? flashcontrollers.power.readOp.longer_channel_leakage:flashcontrollers.power.readOp.leakage)  <<" W" << endl;
+			cout << indent_str_next << "Gate Leakage = " << flashcontrollers.power.readOp.gate_leakage << " W" << endl;
+			cout << indent_str_next << "Runtime Dynamic = " << flashcontrollers.rt_power.readOp.dynamic << " W" << endl;
+			cout <<endl;
+		}
+		if (XML->sys.niu.number_units >0 )
+		{
+			cout <<indent_str<<"Total NIUs: "<<niu->niup.num_units << " Network Interface Units "<<endl;
+			displayDeviceType(XML->sys.device_type, indent);
+			cout << indent_str_next << "Area = " << nius.area.get_area()*1e-6<< " mm^2" << endl;
+			cout << indent_str_next << "Peak Dynamic = " << nius.power.readOp.dynamic << " W" << endl;
+			cout << indent_str_next << "Subthreshold Leakage = "
+				<< (long_channel? nius.power.readOp.longer_channel_leakage:nius.power.readOp.leakage)  <<" W" << endl;
+			cout << indent_str_next << "Gate Leakage = " << nius.power.readOp.gate_leakage << " W" << endl;
+			cout << indent_str_next << "Runtime Dynamic = " << nius.rt_power.readOp.dynamic << " W" << endl;
+			cout <<endl;
+		}
+		if (XML->sys.pcie.number_units >0 && XML->sys.pcie.num_channels>0)
+				{
+					cout <<indent_str<<"Total PCIes: "<<pcie->pciep.num_units << " PCIe Controllers "<<endl;
+					displayDeviceType(XML->sys.device_type, indent);
+					cout << indent_str_next << "Area = " << pcies.area.get_area()*1e-6<< " mm^2" << endl;
+					cout << indent_str_next << "Peak Dynamic = " << pcies.power.readOp.dynamic << " W" << endl;
+					cout << indent_str_next << "Subthreshold Leakage = "
+						<< (long_channel? pcies.power.readOp.longer_channel_leakage:pcies.power.readOp.leakage)  <<" W" << endl;
+					cout << indent_str_next << "Gate Leakage = " << pcies.power.readOp.gate_leakage << " W" << endl;
+					cout << indent_str_next << "Runtime Dynamic = " << pcies.rt_power.readOp.dynamic << " W" << endl;
+					cout <<endl;
+				}
+		cout <<"*****************************************************************************************"<<endl;
+		if (plevel >1)
+		{
+			for (i = 0;i < numCore; i++)
+			{
+				cores[i]->displayEnergy(indent+4,plevel,is_tdp);
+				cout <<"*****************************************************************************************"<<endl;
+			}
+			if (!XML->sys.Private_L2)
+			{
+				for (i = 0;i < numL2; i++)
+				{
+					l2array[i]->displayEnergy(indent+4,is_tdp);
+					cout <<"*****************************************************************************************"<<endl;
+				}
+			}
+			for (i = 0;i < numL3; i++)
+			{
+				l3array[i]->displayEnergy(indent+4,is_tdp);
+				cout <<"*****************************************************************************************"<<endl;
+			}
+			for (i = 0;i < numL1Dir; i++)
+			{
+				l1dirarray[i]->displayEnergy(indent+4,is_tdp);
+				cout <<"*****************************************************************************************"<<endl;
+			}
+			for (i = 0;i < numL2Dir; i++)
+			{
+				l2dirarray[i]->displayEnergy(indent+4,is_tdp);
+				cout <<"*****************************************************************************************"<<endl;
+			}
+			if (XML->sys.mc.number_mcs >0 && XML->sys.mc.memory_channels_per_mc>0)
+			{
+				mc->displayEnergy(indent+4,is_tdp);
+				cout <<"*****************************************************************************************"<<endl;
+			}
+			if (XML->sys.flashc.number_mcs >0 && XML->sys.flashc.memory_channels_per_mc>0)
+			{
+				flashcontroller->displayEnergy(indent+4,is_tdp);
+				cout <<"*****************************************************************************************"<<endl;
+			}
+			if (XML->sys.niu.number_units >0 )
+			{
+				niu->displayEnergy(indent+4,is_tdp);
+				cout <<"*****************************************************************************************"<<endl;
+			}
+			if (XML->sys.pcie.number_units >0 && XML->sys.pcie.num_channels>0)
+			{
+				pcie->displayEnergy(indent+4,is_tdp);
+				cout <<"*****************************************************************************************"<<endl;
+			}
+
+			for (i = 0;i < numNOC; i++)
+			{
+				nocs[i]->displayEnergy(indent+4,plevel,is_tdp);
+				cout <<"*****************************************************************************************"<<endl;
+			}
+		}
+	}
+	else
+	{
+
+	}
+
 }
 
-void Processor::set_proc_param() {
-  bool debug = false;
+void Processor::set_proc_param()
+{
+	bool debug = false;
 
-  procdynp.homoCore = bool(debug ? 1 : XML->sys.homogeneous_cores);
-  procdynp.homoL2 = bool(debug ? 1 : XML->sys.homogeneous_L2s);
-  procdynp.homoL3 = bool(debug ? 1 : XML->sys.homogeneous_L3s);
-  procdynp.homoNOC = bool(debug ? 1 : XML->sys.homogeneous_NoCs);
-  procdynp.homoL1Dir = bool(debug ? 1 : XML->sys.homogeneous_L1Directories);
-  procdynp.homoL2Dir = bool(debug ? 1 : XML->sys.homogeneous_L2Directories);
+	procdynp.homoCore = bool(debug?1:XML->sys.homogeneous_cores);
+	procdynp.homoL2   = bool(debug?1:XML->sys.homogeneous_L2s);
+	procdynp.homoL3   = bool(debug?1:XML->sys.homogeneous_L3s);
+	procdynp.homoNOC  = bool(debug?1:XML->sys.homogeneous_NoCs);
+	procdynp.homoL1Dir  = bool(debug?1:XML->sys.homogeneous_L1Directories);
+	procdynp.homoL2Dir  = bool(debug?1:XML->sys.homogeneous_L2Directories);
 
-  procdynp.numCore = XML->sys.number_of_cores;
-  procdynp.numL2 = XML->sys.number_of_L2s;
-  procdynp.numL3 = XML->sys.number_of_L3s;
-  procdynp.numNOC = XML->sys.number_of_NoCs;
-  procdynp.numL1Dir = XML->sys.number_of_L1Directories;
-  procdynp.numL2Dir = XML->sys.number_of_L2Directories;
-  procdynp.numMC = XML->sys.mc.number_mcs;
-  procdynp.numMCChannel = XML->sys.mc.memory_channels_per_mc;
+	procdynp.numCore = XML->sys.number_of_cores;
+	procdynp.numL2   = XML->sys.number_of_L2s;
+	procdynp.numL3   = XML->sys.number_of_L3s;
+	procdynp.numNOC  = XML->sys.number_of_NoCs;
+	procdynp.numL1Dir  = XML->sys.number_of_L1Directories;
+	procdynp.numL2Dir  = XML->sys.number_of_L2Directories;
+	procdynp.numMC = XML->sys.mc.number_mcs;
+	procdynp.numMCChannel = XML->sys.mc.memory_channels_per_mc;
 
-  //	if (procdynp.numCore<1)
-  //	{
-  //		cout<<" The target processor should at least have one core on chip."
-  //<<endl;
-  //		exit(0);
-  //	}
+//	if (procdynp.numCore<1)
+//	{
+//		cout<<" The target processor should at least have one core on chip." <<endl;
+//		exit(0);
+//	}
 
-  //  if (numNOCs<0 || numNOCs>2)
-  //    {
-  //  	  cout <<"number of NOCs must be 1 (only global NOCs) or 2 (both global
-  //  and local NOCs)"<<endl;
-  //  	  exit(0);
-  //    }
+	//  if (numNOCs<0 || numNOCs>2)
+	//    {
+	//  	  cout <<"number of NOCs must be 1 (only global NOCs) or 2 (both global and local NOCs)"<<endl;
+	//  	  exit(0);
+	//    }
 
-  /* Basic parameters*/
-  interface_ip.data_arr_ram_cell_tech_type = debug ? 0 : XML->sys.device_type;
-  interface_ip.data_arr_peri_global_tech_type =
-      debug ? 0 : XML->sys.device_type;
-  interface_ip.tag_arr_ram_cell_tech_type = debug ? 0 : XML->sys.device_type;
-  interface_ip.tag_arr_peri_global_tech_type = debug ? 0 : XML->sys.device_type;
+	/* Basic parameters*/
+	interface_ip.data_arr_ram_cell_tech_type    = debug?0:XML->sys.device_type;
+	interface_ip.data_arr_peri_global_tech_type = debug?0:XML->sys.device_type;
+	interface_ip.tag_arr_ram_cell_tech_type     = debug?0:XML->sys.device_type;
+	interface_ip.tag_arr_peri_global_tech_type  = debug?0:XML->sys.device_type;
 
-  interface_ip.ic_proj_type = debug ? 0 : XML->sys.interconnect_projection_type;
-  interface_ip.delay_wt =
-      100;                   // Fixed number, make sure timing can be satisfied.
-  interface_ip.area_wt = 0;  // Fixed number, This is used to exhaustive search
-                             // for individual components.
-  interface_ip.dynamic_power_wt = 100;  // Fixed number, This is used to
-                                        // exhaustive search for individual
-                                        // components.
-  interface_ip.leakage_power_wt = 0;
-  interface_ip.cycle_time_wt = 0;
+	interface_ip.ic_proj_type     = debug?0:XML->sys.interconnect_projection_type;
+	interface_ip.delay_wt                = 100;//Fixed number, make sure timing can be satisfied.
+	interface_ip.area_wt                 = 0;//Fixed number, This is used to exhaustive search for individual components.
+	interface_ip.dynamic_power_wt        = 100;//Fixed number, This is used to exhaustive search for individual components.
+	interface_ip.leakage_power_wt        = 0;
+	interface_ip.cycle_time_wt           = 0;
 
-  interface_ip.delay_dev =
-      10000;  // Fixed number, make sure timing can be satisfied.
-  interface_ip.area_dev = 10000;  // Fixed number, This is used to exhaustive
-                                  // search for individual components.
-  interface_ip.dynamic_power_dev = 10000;  // Fixed number, This is used to
-                                           // exhaustive search for individual
-                                           // components.
-  interface_ip.leakage_power_dev = 10000;
-  interface_ip.cycle_time_dev = 10000;
+	interface_ip.delay_dev                = 10000;//Fixed number, make sure timing can be satisfied.
+	interface_ip.area_dev                 = 10000;//Fixed number, This is used to exhaustive search for individual components.
+	interface_ip.dynamic_power_dev        = 10000;//Fixed number, This is used to exhaustive search for individual components.
+	interface_ip.leakage_power_dev        = 10000;
+	interface_ip.cycle_time_dev           = 10000;
 
-  interface_ip.ed = 2;
-  interface_ip.burst_len = 1;  // parameters are fixed for processor section,
-                               // since memory is processed separately
-  interface_ip.int_prefetch_w = 1;
-  interface_ip.page_sz_bits = 0;
-  interface_ip.temp = debug ? 360 : XML->sys.temperature;
-  interface_ip.F_sz_nm =
-      debug ? 90 : XML->sys.core_tech_node;  // XML->sys.core_tech_node;
-  interface_ip.F_sz_um = interface_ip.F_sz_nm / 1000;
+	interface_ip.ed                       = 2;
+	interface_ip.burst_len      = 1;//parameters are fixed for processor section, since memory is processed separately
+	interface_ip.int_prefetch_w = 1;
+	interface_ip.page_sz_bits   = 0;
+	interface_ip.temp = debug?360: XML->sys.temperature;
+	interface_ip.F_sz_nm         = debug?90:XML->sys.core_tech_node;//XML->sys.core_tech_node;
+	interface_ip.F_sz_um         = interface_ip.F_sz_nm / 1000;
 
-  //***********This section of code does not have real meaning, they are just to
-  //ensure all data will have initial value to prevent errors.
-  // They will be overridden  during each components initialization
-  interface_ip.cache_sz = 64;
-  interface_ip.line_sz = 1;
-  interface_ip.assoc = 1;
-  interface_ip.nbanks = 1;
-  interface_ip.out_w = interface_ip.line_sz * 8;
-  interface_ip.specific_tag = 1;
-  interface_ip.tag_w = 64;
-  interface_ip.access_mode = 2;
+	//***********This section of code does not have real meaning, they are just to ensure all data will have initial value to prevent errors.
+	//They will be overridden  during each components initialization
+	interface_ip.cache_sz            =64;
+	interface_ip.line_sz             = 1;
+	interface_ip.assoc               = 1;
+	interface_ip.nbanks              = 1;
+	interface_ip.out_w               = interface_ip.line_sz*8;
+	interface_ip.specific_tag        = 1;
+	interface_ip.tag_w               = 64;
+	interface_ip.access_mode         = 2;
 
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
+	interface_ip.obj_func_dyn_energy = 0;
+	interface_ip.obj_func_dyn_power  = 0;
+	interface_ip.obj_func_leak_power = 0;
+	interface_ip.obj_func_cycle_t    = 1;
 
-  interface_ip.is_main_mem = false;
-  interface_ip.rpters_in_htree = true;
-  interface_ip.ver_htree_wires_over_array = 0;
-  interface_ip.broadcast_addr_din_over_ver_htrees = 0;
+	interface_ip.is_main_mem     = false;
+	interface_ip.rpters_in_htree = true ;
+	interface_ip.ver_htree_wires_over_array = 0;
+	interface_ip.broadcast_addr_din_over_ver_htrees = 0;
 
-  interface_ip.num_rw_ports = 1;
-  interface_ip.num_rd_ports = 0;
-  interface_ip.num_wr_ports = 0;
-  interface_ip.num_se_rd_ports = 0;
-  interface_ip.num_search_ports = 1;
-  interface_ip.nuca = 0;
-  interface_ip.nuca_bank_count = 0;
-  interface_ip.is_cache = true;
-  interface_ip.pure_ram = false;
-  interface_ip.pure_cam = false;
-  interface_ip.force_cache_config = false;
-  if (XML->sys.Embedded) {
-    interface_ip.wt = Global_30;
-    interface_ip.wire_is_mat_type = 0;
-    interface_ip.wire_os_mat_type = 0;
-  } else {
-    interface_ip.wt = Global;
-    interface_ip.wire_is_mat_type = 2;
-    interface_ip.wire_os_mat_type = 2;
-  }
-  interface_ip.force_wiretype = false;
-  interface_ip.print_detail = 1;
-  interface_ip.add_ecc_b_ = true;
+	interface_ip.num_rw_ports        = 1;
+	interface_ip.num_rd_ports        = 0;
+	interface_ip.num_wr_ports        = 0;
+	interface_ip.num_se_rd_ports     = 0;
+	interface_ip.num_search_ports    = 1;
+	interface_ip.nuca                = 0;
+	interface_ip.nuca_bank_count     = 0;
+	interface_ip.is_cache            =true;
+	interface_ip.pure_ram            =false;
+	interface_ip.pure_cam            =false;
+	interface_ip.force_cache_config  =false;
+	if (XML->sys.Embedded)
+		{
+		interface_ip.wt                  =Global_30;
+		interface_ip.wire_is_mat_type = 0;
+		interface_ip.wire_os_mat_type = 0;
+		}
+	else
+		{
+		interface_ip.wt                  =Global;
+		interface_ip.wire_is_mat_type = 2;
+		interface_ip.wire_os_mat_type = 2;
+		}
+	interface_ip.force_wiretype      = false;
+	interface_ip.print_detail        = 1;
+	interface_ip.add_ecc_b_          =true;
 }
 
-Processor::~Processor() {
-  while (!cores.empty()) {
-    delete cores.back();
-    cores.pop_back();
-  }
-  while (!l2array.empty()) {
-    delete l2array.back();
-    l2array.pop_back();
-  }
-  while (!l3array.empty()) {
-    delete l3array.back();
-    l3array.pop_back();
-  }
-  while (!nocs.empty()) {
-    delete nocs.back();
-    nocs.pop_back();
-  }
-  if (!mc) {
-    delete mc;
-  }
-  if (!niu) {
-    delete niu;
-  }
-  if (!pcie) {
-    delete pcie;
-  }
-  if (!flashcontroller) {
-    delete flashcontroller;
-  }
+
+Processor::~Processor(){
+	while (!cores.empty())
+	{
+		delete cores.back();
+		cores.pop_back();
+	}
+	while (!l2array.empty())
+	{
+		delete l2array.back();
+		l2array.pop_back();
+	}
+	while (!l3array.empty())
+	{
+		delete l3array.back();
+		l3array.pop_back();
+	}
+	while (!nocs.empty())
+	{
+		delete nocs.back();
+		nocs.pop_back();
+	}
+	if (!mc)
+	{
+		delete mc;
+	}
+	if (!niu)
+	{
+		delete niu;
+	}
+	if (!pcie)
+	{
+		delete pcie;
+	}
+	if (!flashcontroller)
+	{
+		delete flashcontroller;
+	}
 };
+
+

--- a/src/gpuwattch/processor.h
+++ b/src/gpuwattch/processor.h
@@ -29,262 +29,296 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:												   *
-*      Jingwen Leng, Univeristy of Texas, Austin                   *
-*      Syed Gilani, University of Wisconsin–Madison                *
-*      Tayler Hetherington, University of British Columbia         *
-*      Ahmed ElTantawy, University of British Columbia             *
-********************************************************************/
+ *      Modified by:
+ ** Jingwen Leng, Univeristy of Texas, Austin                   * Syed Gilani,
+ *University of Wisconsin–Madison                * Tayler Hetherington,
+ *University of British Columbia         * Ahmed ElTantawy, University of
+ *British Columbia             *
+ ********************************************************************/
 #ifndef PROCESSOR_H_
 #define PROCESSOR_H_
 
+#include <vector>
+#include "../gpgpu-sim/visualizer.h"
 #include "XML_Parse.h"
+#include "array.h"
+#include "basic_components.h"
+#include "cacti/arbiter.h"
 #include "cacti/area.h"
 #include "cacti/decoder.h"
 #include "cacti/parameter.h"
-#include "array.h"
-#include "cacti/arbiter.h"
-#include <vector>
-#include "basic_components.h"
-#include "core.h"
-#include "memoryctrl.h"
 #include "cacti/router.h"
-#include "sharedcache.h"
-#include "noc.h"
+#include "core.h"
 #include "iocontrollers.h"
-#include "../gpgpu-sim/visualizer.h"
+#include "memoryctrl.h"
+#include "noc.h"
+#include "sharedcache.h"
 
-class Processor : public Component
-{
-  public:
-	ParseXML *XML;
-	vector<Core *> cores;
-    vector<SharedCache *> l2array;
-    vector<SharedCache *> l3array;
-    vector<SharedCache *> l1dirarray;
-    vector<SharedCache *> l2dirarray;
-    vector<NoC *>  nocs;
-    MemoryController * mc;
-    NIUController    * niu;
-    PCIeController   * pcie;
-    FlashController  * flashcontroller;
-    InputParameter interface_ip;
-    double exClockRate;
-    ProcParam procdynp;
-	  //for debugging nonlinear model
-		double dyn_power_before_scaling;
-    
-    //wire	globalInterconnect;
-    //clock_network globalClock;
-    Component core, l2, l3, l1dir, l2dir, noc, mcs, cc, nius, pcies,flashcontrollers;
-    int  numCore, numL2, numL3, numNOC, numL1Dir, numL2Dir;
-    Processor(ParseXML *XML_interface);
-    void compute();
-    void set_proc_param();
-    void visualizer_print( gzFile visualizer_file );
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp_parm=true);
-    void displayDeviceType(int device_type_, uint32_t indent = 0);
-    void displayInterconnectType(int interconnect_type_, uint32_t indent = 0);
-    double l2_power;
-	double idle_core_power;
+class Processor : public Component {
+ public:
+  ParseXML *XML;
+  vector<Core *> cores;
+  vector<SharedCache *> l2array;
+  vector<SharedCache *> l3array;
+  vector<SharedCache *> l1dirarray;
+  vector<SharedCache *> l2dirarray;
+  vector<NoC *> nocs;
+  MemoryController *mc;
+  NIUController *niu;
+  PCIeController *pcie;
+  FlashController *flashcontroller;
+  InputParameter interface_ip;
+  double exClockRate;
+  ProcParam procdynp;
+  // for debugging nonlinear model
+  double dyn_power_before_scaling;
 
-    double get_const_dynamic_power()
-    {
+  // wire	globalInterconnect;
+  // clock_network globalClock;
+  Component core, l2, l3, l1dir, l2dir, noc, mcs, cc, nius, pcies,
+      flashcontrollers;
+  int numCore, numL2, numL3, numNOC, numL1Dir, numL2Dir;
+  Processor(ParseXML *XML_interface);
+  void compute();
+  void set_proc_param();
+  void visualizer_print(gzFile visualizer_file);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100,
+                     bool is_tdp_parm = true);
+  void displayDeviceType(int device_type_, uint32_t indent = 0);
+  void displayInterconnectType(int interconnect_type_, uint32_t indent = 0);
+  double l2_power;
+  double idle_core_power;
 
-    	double constpart=0;
-    	constpart+=(mc->frontend->power.readOp.dynamic*0.1*mc->frontend->mcp.clockRate*mc->frontend->mcp.num_mcs*mc->frontend->mcp.executionTime);
-    	constpart+=(mc->transecEngine->power.readOp.dynamic*0.1*mc->transecEngine->mcp.clockRate*mc->transecEngine->mcp.num_mcs*mc->transecEngine->mcp.executionTime);
-    	constpart+=(mc->PHY->power.readOp.dynamic*0.1*mc->PHY->mcp.clockRate*mc->PHY->mcp.num_mcs*mc->PHY->mcp.executionTime);
-    	constpart+=(cores[0]->exu->exeu->base_energy/cores[0]->exu->exeu->clockRate)*(cores[0]->exu->rf_fu_clockRate/cores[0]->exu->clockRate);
-    	constpart+=(cores[0]->exu->mul->base_energy/cores[0]->exu->mul->clockRate);
-    	constpart+=(cores[0]->exu->fp_u->base_energy/cores[0]->exu->fp_u->clockRate);
-    	return constpart;
+  double get_const_dynamic_power() {
+    double constpart = 0;
+    constpart += (mc->frontend->power.readOp.dynamic * 0.1 *
+                  mc->frontend->mcp.clockRate * mc->frontend->mcp.num_mcs *
+                  mc->frontend->mcp.executionTime);
+    constpart +=
+        (mc->transecEngine->power.readOp.dynamic * 0.1 *
+         mc->transecEngine->mcp.clockRate * mc->transecEngine->mcp.num_mcs *
+         mc->transecEngine->mcp.executionTime);
+    constpart += (mc->PHY->power.readOp.dynamic * 0.1 * mc->PHY->mcp.clockRate *
+                  mc->PHY->mcp.num_mcs * mc->PHY->mcp.executionTime);
+    constpart +=
+        (cores[0]->exu->exeu->base_energy / cores[0]->exu->exeu->clockRate) *
+        (cores[0]->exu->rf_fu_clockRate / cores[0]->exu->clockRate);
+    constpart +=
+        (cores[0]->exu->mul->base_energy / cores[0]->exu->mul->clockRate);
+    constpart +=
+        (cores[0]->exu->fp_u->base_energy / cores[0]->exu->fp_u->clockRate);
+    return constpart;
+  }
+#define COALESCE_SCALE 1
+  double get_coefficient_readcoalescing() {
+    double value = 0;
+    double perAccessCoalescingEnergy =
+        COALESCE_SCALE *
+        ((0.443e-3) * (0.5e-9) * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd) /
+        (1 * 1);
+    value += mc->frontend->PRT->local_result.power.readOp.dynamic;
+    value += mc->frontend->threadMasks->local_result.power.readOp.dynamic;
+    value += mc->frontend->PRC->local_result.power.readOp.dynamic;
+    value += perAccessCoalescingEnergy;
+    return value;
+  }
+  double get_coefficient_writecoalescing() {
+    double value = 0;
+    double perAccessCoalescingEnergy =
+        COALESCE_SCALE *
+        ((0.443e-3) * (0.5e-9) * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd) /
+        (1 * 1);
+    value += (mc->frontend->PRT->local_result.power.writeOp.dynamic);
+    value += mc->frontend->threadMasks->local_result.power.writeOp.dynamic;
+    value += mc->frontend->PRC->local_result.power.writeOp.dynamic;
+    value += perAccessCoalescingEnergy;
+    return value;
+  }
+
+  double get_coefficient_noc_accesses() {
+    double read_coef = 0;
+    // the 32/4 is applied to the NoC access counters (32/4*L2 cache access)
+    read_coef += nocs[0]->router->buffer.power.readOp.dynamic;
+    read_coef += nocs[0]->router->buffer.power.writeOp.dynamic;
+    read_coef += nocs[0]->router->crossbar.power.readOp.dynamic;
+    read_coef += nocs[0]->router->arbiter.power.readOp.dynamic;
+    return read_coef;
+  }
+
+  double get_coefficient_l2_read_hits() {
+    double read_coef = 0;
+    if (XML->sys.number_of_L2s > 0)
+      read_coef =
+          l2array[0]->unicache.caches->local_result.power.readOp.dynamic;
+    return read_coef;
+  }
+
+  double get_coefficient_l2_read_misses() {
+    double read_coef = 0;
+    if (XML->sys.number_of_L2s > 0)
+      read_coef =
+          l2array[0]
+              ->unicache.caches->local_result.tag_array2->power.readOp.dynamic;
+    return read_coef;
+  }
+
+  double get_coefficient_l2_write_hits() {
+    double read_coef = 0;
+    if (XML->sys.number_of_L2s > 0)
+      read_coef =
+          l2array[0]->unicache.caches->local_result.power.writeOp.dynamic;
+    return read_coef;
+  }
+  double get_coefficient_l2_write_misses() {
+    double read_coef = 0;
+    if (XML->sys.number_of_L2s > 0) {
+      read_coef = l2array[0]
+                      ->unicache.caches->local_result.tag_array2->power.writeOp
+                      .dynamic;  //*(32/4); // removed by Jingwen, the scaling
+                                 // of 32/4 is not used in the mcpat
+      read_coef +=
+          l2array[0]->unicache.caches->local_result.power.writeOp.dynamic;
+      read_coef +=
+          l2array[0]->unicache.missb->local_result.power.searchOp.dynamic;
+      read_coef +=
+          l2array[0]->unicache.missb->local_result.power.writeOp.dynamic;
+      read_coef +=
+          l2array[0]->unicache.ifb->local_result.power.searchOp.dynamic;
+      read_coef += l2array[0]->unicache.ifb->local_result.power.writeOp.dynamic;
+      read_coef +=
+          l2array[0]->unicache.prefetchb->local_result.power.searchOp.dynamic;
+      read_coef +=
+          l2array[0]->unicache.prefetchb->local_result.power.writeOp.dynamic;
+      read_coef +=
+          l2array[0]->unicache.wbb->local_result.power.searchOp.dynamic;
+      read_coef += l2array[0]->unicache.wbb->local_result.power.writeOp.dynamic;
     }
-#define COALESCE_SCALE  1
-    double get_coefficient_readcoalescing()
-    {
-		double value=0;
-		double perAccessCoalescingEnergy=COALESCE_SCALE * ((0.443e-3)*(0.5e-9)*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd)/(1*1);
-		value+=mc->frontend->PRT->local_result.power.readOp.dynamic;
-		value+=mc->frontend->threadMasks->local_result.power.readOp.dynamic;
-		value+=mc->frontend->PRC->local_result.power.readOp.dynamic;
-		value+=perAccessCoalescingEnergy;
-		return value;
 
-    }
-    double get_coefficient_writecoalescing()
-    {
-		double value=0;
-		double perAccessCoalescingEnergy=COALESCE_SCALE *((0.443e-3)*(0.5e-9)*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd)/(1*1);
-		value+=(mc->frontend->PRT->local_result.power.writeOp.dynamic);
-		value+=mc->frontend->threadMasks->local_result.power.writeOp.dynamic;
-		value+=mc->frontend->PRC->local_result.power.writeOp.dynamic;
-		value+=perAccessCoalescingEnergy;
-		return value;
-    }
+    return read_coef;
+  }
 
+  double get_coefficient_mem_reads() {
+    double value = 0;
+    value +=
+        (mc->frontend->mcp.llcBlockSize * 8.0 / mc->frontend->mcp.dataBusWidth *
+         mc->frontend->mcp.dataBusWidth / 72) *
+        (mc->frontend->frontendBuffer->local_result.power.searchOp.dynamic);
 
-	 double get_coefficient_noc_accesses() {
-		double read_coef=0;
-		// the 32/4 is applied to the NoC access counters (32/4*L2 cache access)
-		read_coef+= nocs[0]->router->buffer.power.readOp.dynamic;
-		read_coef+= nocs[0]->router->buffer.power.writeOp.dynamic;
-		read_coef+= nocs[0]->router->crossbar.power.readOp.dynamic;
-		read_coef+= nocs[0]->router->arbiter.power.readOp.dynamic;
-		return read_coef;
-	 }
+    value +=
+        (mc->frontend->mcp.llcBlockSize * 8.0 / mc->frontend->mcp.dataBusWidth *
+         mc->frontend->mcp.dataBusWidth / 72) *
+        (mc->frontend->frontendBuffer->local_result.power.readOp.dynamic);
 
-	 double get_coefficient_l2_read_hits(){
-      double read_coef=0;
-      if(XML->sys.number_of_L2s>0)
-    	  read_coef = l2array[0]->unicache.caches->local_result.power.readOp.dynamic;
-		return read_coef;
-	 }
-	 
-	 double get_coefficient_l2_read_misses(){
-      double read_coef=0;
-      if(XML->sys.number_of_L2s>0)
-    	  read_coef = l2array[0]->unicache.caches->local_result.tag_array2->power.readOp.dynamic;
-	  return read_coef;
+    // TODO: Jingwen this should only compute for one time?
+    // value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth*mc->frontend->mcp.dataBusWidth/72)
+    //*(mc->frontend->frontendBuffer->local_result.power.readOp.dynamic);
 
-	 }
+    value += (mc->frontend->mcp.llcBlockSize * 8.0 / mc->mcp.dataBusWidth) *
+             (mc->frontend->readBuffer->local_result.power.readOp.dynamic);
 
-	 double get_coefficient_l2_write_hits(){
-      double read_coef=0;
-      if(XML->sys.number_of_L2s>0)
-    	  read_coef = l2array[0]->unicache.caches->local_result.power.writeOp.dynamic;
-		return read_coef;
+    value += (mc->frontend->mcp.llcBlockSize * 8.0 / mc->mcp.dataBusWidth) *
+             (mc->frontend->readBuffer->local_result.power.writeOp.dynamic);
 
-	 }
-	 double get_coefficient_l2_write_misses(){
-		double read_coef=0;
-	     if(XML->sys.number_of_L2s>0){
-		read_coef = l2array[0]->unicache.caches->local_result.tag_array2->power.writeOp.dynamic;//*(32/4); // removed by Jingwen, the scaling of 32/4 is not used in the mcpat
-		read_coef +=l2array[0]->unicache.caches->local_result.power.writeOp.dynamic;
-		read_coef += l2array[0]->unicache.missb->local_result.power.searchOp.dynamic;
-		read_coef += l2array[0]->unicache.missb->local_result.power.writeOp.dynamic;
-		read_coef += l2array[0]->unicache.ifb->local_result.power.searchOp.dynamic;
-		read_coef += l2array[0]->unicache.ifb->local_result.power.writeOp.dynamic;
-		read_coef += l2array[0]->unicache.prefetchb->local_result.power.searchOp.dynamic;
-		read_coef += l2array[0]->unicache.prefetchb->local_result.power.writeOp.dynamic;
-		read_coef += l2array[0]->unicache.wbb->local_result.power.searchOp.dynamic;
-		read_coef += l2array[0]->unicache.wbb->local_result.power.writeOp.dynamic;
-	     }
+    value += mc->dram->dramp.rd_coeff;
+    /*
+            value+=mc->frontend->PRT->local_result.power.readOp.dynamic;
+            value+=mc->frontend->threadMasks->local_result.power.readOp.dynamic;
+            value+=mc->frontend->PRC->local_result.power.readOp.dynamic;
+            value+=perAccessCoalescingEnergy;
+            */
+    value += (mc->transecEngine->mcp.llcBlockSize * 8.0 /
+              mc->transecEngine->mcp.dataBusWidth *
+              mc->transecEngine->power_t.readOp.dynamic);
 
-		return read_coef;
+    // if mcp.type ==1 TODO: add this check here
+    value += (mc->PHY->power_t.readOp.dynamic) * (mc->PHY->mcp.llcBlockSize) *
+             8 / 1e9 / mc->PHY->mcp.executionTime *
+             (mc->PHY->mcp.executionTime);
+    // printf("MC PHY read power coeff:
+    // %f\n",(mc->PHY->power_t.readOp.dynamic)*(mc->PHY->mcp.llcBlockSize)*8/1e9/mc->PHY->mcp.executionTime*(mc->PHY->mcp.executionTime));
+    // printf("MC trans read power coeff:
+    // %f\n",(mc->transecEngine->mcp.llcBlockSize*8.0/mc->transecEngine->mcp.dataBusWidth*mc->transecEngine->power_t.readOp.dynamic));
 
-	 }
+    // TODO: Jingwen nocs stats should not be here
+    //		value+= nocs[0]->router->buffer.power.readOp.dynamic*(32/4);
+    //		value+= nocs[0]->router->buffer.power.writeOp.dynamic*(32/4);
+    //		value+= nocs[0]->router->crossbar.power.readOp.dynamic*(32/4);
+    //		value+= nocs[0]->router->arbiter.power.readOp.dynamic*(32/4);
 
+    // return 0.4*value;
+    return value;
+  }
 
-	 double get_coefficient_mem_reads()
-	 {
-		double value=0;
-		value+= (mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth*mc->frontend->mcp.dataBusWidth/72)*
-		  (mc->frontend->frontendBuffer->local_result.power.searchOp.dynamic);
+  double get_coefficient_mem_writes() {
+    double value = 0;
 
-		value+= (mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth*mc->frontend->mcp.dataBusWidth/72)*
-		  (mc->frontend->frontendBuffer->local_result.power.readOp.dynamic);
+    value +=
+        (mc->frontend->mcp.llcBlockSize * 8.0 / mc->frontend->mcp.dataBusWidth *
+         mc->frontend->mcp.dataBusWidth / 72) *
+        (mc->frontend->frontendBuffer->local_result.power.searchOp.dynamic);
 
-//TODO: Jingwen this should only compute for one time?
-		//value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth*mc->frontend->mcp.dataBusWidth/72)
-		  //*(mc->frontend->frontendBuffer->local_result.power.readOp.dynamic);
+    value +=
+        (mc->frontend->mcp.llcBlockSize * 8.0 / mc->frontend->mcp.dataBusWidth *
+         mc->frontend->mcp.dataBusWidth / 72) *
+        (mc->frontend->frontendBuffer->local_result.power.writeOp.dynamic);
 
-		value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->mcp.dataBusWidth)*
-		  (mc->frontend->readBuffer->local_result.power.readOp.dynamic);
+    // value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth*mc->frontend->mcp.dataBusWidth/72)*
+    // (mc->frontend->frontendBuffer->local_result.power.writeOp.dynamic);
 
-		value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->mcp.dataBusWidth)*
-		  (mc->frontend->readBuffer->local_result.power.writeOp.dynamic);
+    value += (mc->frontend->mcp.llcBlockSize * 8.0 /
+              mc->frontend->mcp.dataBusWidth) *
+             (mc->frontend->writeBuffer->local_result.power.readOp.dynamic);
 
-		value+=mc->dram->dramp.rd_coeff;
-		/*
-			value+=mc->frontend->PRT->local_result.power.readOp.dynamic;
-			value+=mc->frontend->threadMasks->local_result.power.readOp.dynamic;
-			value+=mc->frontend->PRC->local_result.power.readOp.dynamic;
-			value+=perAccessCoalescingEnergy;
-			*/
-		value+=(mc->transecEngine->mcp.llcBlockSize*8.0/mc->transecEngine->mcp.dataBusWidth*mc->transecEngine->power_t.readOp.dynamic);
+    value += (mc->frontend->mcp.llcBlockSize * 8.0 /
+              mc->frontend->mcp.dataBusWidth) *
+             (mc->frontend->writeBuffer->local_result.power.writeOp.dynamic);
 
-		//if mcp.type ==1 TODO: add this check here
-		value += (mc->PHY->power_t.readOp.dynamic)*(mc->PHY->mcp.llcBlockSize)*8/1e9/mc->PHY->mcp.executionTime*(mc->PHY->mcp.executionTime);
-                //printf("MC PHY read power coeff: %f\n",(mc->PHY->power_t.readOp.dynamic)*(mc->PHY->mcp.llcBlockSize)*8/1e9/mc->PHY->mcp.executionTime*(mc->PHY->mcp.executionTime));
-                //printf("MC trans read power coeff: %f\n",(mc->transecEngine->mcp.llcBlockSize*8.0/mc->transecEngine->mcp.dataBusWidth*mc->transecEngine->power_t.readOp.dynamic));
+    value += mc->dram->dramp.wr_coeff;
+    /*
+            value+=(mc->frontend->PRT->local_result.power.writeOp.dynamic);
 
-//TODO: Jingwen nocs stats should not be here
-//		value+= nocs[0]->router->buffer.power.readOp.dynamic*(32/4);
-//		value+= nocs[0]->router->buffer.power.writeOp.dynamic*(32/4);
-//		value+= nocs[0]->router->crossbar.power.readOp.dynamic*(32/4);
-//		value+= nocs[0]->router->arbiter.power.readOp.dynamic*(32/4);
+            value+=mc->frontend->threadMasks->local_result.power.writeOp.dynamic;
 
-		//return 0.4*value;
-		return value;
-	 }
+            value+=mc->frontend->PRC->local_result.power.writeOp.dynamic;
 
+            value+=perAccessCoalescingEnergy;
+            */
 
-	 double get_coefficient_mem_writes()
-	 {
-		double value=0;
+    value += (mc->transecEngine->mcp.llcBlockSize * 8.0 /
+              mc->transecEngine->mcp.dataBusWidth *
+              mc->transecEngine->power_t.readOp.dynamic);
 
-		value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth*mc->frontend->mcp.dataBusWidth/72)*
-		  (mc->frontend->frontendBuffer->local_result.power.searchOp.dynamic);
+    // if mcp.type ==1 TODO: add this check here
+    value += (mc->PHY->power_t.readOp.dynamic) * (mc->PHY->mcp.llcBlockSize) *
+             8 / 1e9 / mc->PHY->mcp.executionTime *
+             (mc->PHY->mcp.executionTime);
 
-		value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth*mc->frontend->mcp.dataBusWidth/72)*
-		  (mc->frontend->frontendBuffer->local_result.power.writeOp.dynamic);
+    // TODO: Jingwen nocs stats should not be here
+    //		value+= nocs[0]->router->buffer.power.readOp.dynamic*(32/4);
+    //
+    //		value+= nocs[0]->router->buffer.power.writeOp.dynamic*(32/4);
+    //
+    //		value+= nocs[0]->router->crossbar.power.readOp.dynamic*(32/4);
+    //
+    //		value+= nocs[0]->router->arbiter.power.readOp.dynamic*(32/4);
+    //
+    // return 0.4*value;
+    return value;
+  }
 
-		//value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth*mc->frontend->mcp.dataBusWidth/72)*
-		 // (mc->frontend->frontendBuffer->local_result.power.writeOp.dynamic);
+  double get_coefficient_mem_pre() {
+    double value = 0;
+    value += mc->dram->dramp.pre_coeff;
+    // return 0.4*value;
+    return value;
+  }
 
-		value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth)*
-		  (mc->frontend->writeBuffer->local_result.power.readOp.dynamic);
+  // nonlinear scale
+  void nonlinear_scale(int, double, int);
+  void coefficient_scale();
+  void iterative_lse(double *, double *);
 
-		value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth)*
-		  (mc->frontend->writeBuffer->local_result.power.writeOp.dynamic);
-
-		value+=mc->dram->dramp.wr_coeff;
-		/*
-			value+=(mc->frontend->PRT->local_result.power.writeOp.dynamic);
-
-			value+=mc->frontend->threadMasks->local_result.power.writeOp.dynamic;
-
-			value+=mc->frontend->PRC->local_result.power.writeOp.dynamic;
-
-			value+=perAccessCoalescingEnergy;
-			*/
-
-		value+=(mc->transecEngine->mcp.llcBlockSize*8.0/mc->transecEngine->mcp.dataBusWidth*mc->transecEngine->power_t.readOp.dynamic);
-
-
-		//if mcp.type ==1 TODO: add this check here
-		value += (mc->PHY->power_t.readOp.dynamic)*(mc->PHY->mcp.llcBlockSize)*8/1e9/mc->PHY->mcp.executionTime*(mc->PHY->mcp.executionTime);
-
-
-//TODO: Jingwen nocs stats should not be here
-//		value+= nocs[0]->router->buffer.power.readOp.dynamic*(32/4);
-//
-//		value+= nocs[0]->router->buffer.power.writeOp.dynamic*(32/4);
-//
-//		value+= nocs[0]->router->crossbar.power.readOp.dynamic*(32/4);
-//
-//		value+= nocs[0]->router->arbiter.power.readOp.dynamic*(32/4);
-//
-		//return 0.4*value;
-		return value;
-	 }
-
-	 double get_coefficient_mem_pre()
-	 {
-		double value=0;
-		value+=mc->dram->dramp.pre_coeff;
-		//return 0.4*value;
-		return value;
-		
-	 }
-
-	 //nonlinear scale
-	 void nonlinear_scale(int, double, int);
-	 void coefficient_scale();
-	 void iterative_lse(double *, double* );
-
-	 ~Processor();
+  ~Processor();
 };
 
 #endif /* PROCESSOR_H_ */

--- a/src/gpuwattch/processor.h
+++ b/src/gpuwattch/processor.h
@@ -29,8 +29,7 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:
-**
+*      Modified by:												   *
 *      Jingwen Leng, Univeristy of Texas, Austin                   *
 *      Syed Gilani, University of Wisconsin–Madison                *
 *      Tayler Hetherington, University of British Columbia         *
@@ -39,287 +38,253 @@
 #ifndef PROCESSOR_H_
 #define PROCESSOR_H_
 
-#include <vector>
-#include "../gpgpu-sim/visualizer.h"
 #include "XML_Parse.h"
-#include "array.h"
-#include "basic_components.h"
-#include "cacti/arbiter.h"
 #include "cacti/area.h"
 #include "cacti/decoder.h"
 #include "cacti/parameter.h"
-#include "cacti/router.h"
+#include "array.h"
+#include "cacti/arbiter.h"
+#include <vector>
+#include "basic_components.h"
 #include "core.h"
-#include "iocontrollers.h"
 #include "memoryctrl.h"
-#include "noc.h"
+#include "cacti/router.h"
 #include "sharedcache.h"
+#include "noc.h"
+#include "iocontrollers.h"
+#include "../gpgpu-sim/visualizer.h"
 
-class Processor : public Component {
- public:
-  ParseXML *XML;
-  vector<Core *> cores;
-  vector<SharedCache *> l2array;
-  vector<SharedCache *> l3array;
-  vector<SharedCache *> l1dirarray;
-  vector<SharedCache *> l2dirarray;
-  vector<NoC *> nocs;
-  MemoryController *mc;
-  NIUController *niu;
-  PCIeController *pcie;
-  FlashController *flashcontroller;
-  InputParameter interface_ip;
-  double exClockRate;
-  ProcParam procdynp;
-  // for debugging nonlinear model
-  double dyn_power_before_scaling;
+class Processor : public Component
+{
+  public:
+	ParseXML *XML;
+	vector<Core *> cores;
+    vector<SharedCache *> l2array;
+    vector<SharedCache *> l3array;
+    vector<SharedCache *> l1dirarray;
+    vector<SharedCache *> l2dirarray;
+    vector<NoC *>  nocs;
+    MemoryController * mc;
+    NIUController    * niu;
+    PCIeController   * pcie;
+    FlashController  * flashcontroller;
+    InputParameter interface_ip;
+    double exClockRate;
+    ProcParam procdynp;
+	  //for debugging nonlinear model
+		double dyn_power_before_scaling;
+    
+    //wire	globalInterconnect;
+    //clock_network globalClock;
+    Component core, l2, l3, l1dir, l2dir, noc, mcs, cc, nius, pcies,flashcontrollers;
+    int  numCore, numL2, numL3, numNOC, numL1Dir, numL2Dir;
+    Processor(ParseXML *XML_interface);
+    void compute();
+    void set_proc_param();
+    void visualizer_print( gzFile visualizer_file );
+    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp_parm=true);
+    void displayDeviceType(int device_type_, uint32_t indent = 0);
+    void displayInterconnectType(int interconnect_type_, uint32_t indent = 0);
+    double l2_power;
+	double idle_core_power;
 
-  // wire	globalInterconnect;
-  // clock_network globalClock;
-  Component core, l2, l3, l1dir, l2dir, noc, mcs, cc, nius, pcies,
-      flashcontrollers;
-  int numCore, numL2, numL3, numNOC, numL1Dir, numL2Dir;
-  Processor(ParseXML *XML_interface);
-  void compute();
-  void set_proc_param();
-  void visualizer_print(gzFile visualizer_file);
-  void displayEnergy(uint32_t indent = 0, int plevel = 100,
-                     bool is_tdp_parm = true);
-  void displayDeviceType(int device_type_, uint32_t indent = 0);
-  void displayInterconnectType(int interconnect_type_, uint32_t indent = 0);
-  double l2_power;
-  double idle_core_power;
+    double get_const_dynamic_power()
+    {
 
-  double get_const_dynamic_power() {
-    double constpart = 0;
-    constpart += (mc->frontend->power.readOp.dynamic * 0.1 *
-                  mc->frontend->mcp.clockRate * mc->frontend->mcp.num_mcs *
-                  mc->frontend->mcp.executionTime);
-    constpart +=
-        (mc->transecEngine->power.readOp.dynamic * 0.1 *
-         mc->transecEngine->mcp.clockRate * mc->transecEngine->mcp.num_mcs *
-         mc->transecEngine->mcp.executionTime);
-    constpart += (mc->PHY->power.readOp.dynamic * 0.1 * mc->PHY->mcp.clockRate *
-                  mc->PHY->mcp.num_mcs * mc->PHY->mcp.executionTime);
-    constpart +=
-        (cores[0]->exu->exeu->base_energy / cores[0]->exu->exeu->clockRate) *
-        (cores[0]->exu->rf_fu_clockRate / cores[0]->exu->clockRate);
-    constpart +=
-        (cores[0]->exu->mul->base_energy / cores[0]->exu->mul->clockRate);
-    constpart +=
-        (cores[0]->exu->fp_u->base_energy / cores[0]->exu->fp_u->clockRate);
-    return constpart;
-  }
-#define COALESCE_SCALE 1
-  double get_coefficient_readcoalescing() {
-    double value = 0;
-    double perAccessCoalescingEnergy =
-        COALESCE_SCALE *
-        ((0.443e-3) * (0.5e-9) * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd) /
-        (1 * 1);
-    value += mc->frontend->PRT->local_result.power.readOp.dynamic;
-    value += mc->frontend->threadMasks->local_result.power.readOp.dynamic;
-    value += mc->frontend->PRC->local_result.power.readOp.dynamic;
-    value += perAccessCoalescingEnergy;
-    return value;
-  }
-  double get_coefficient_writecoalescing() {
-    double value = 0;
-    double perAccessCoalescingEnergy =
-        COALESCE_SCALE *
-        ((0.443e-3) * (0.5e-9) * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd) /
-        (1 * 1);
-    value += (mc->frontend->PRT->local_result.power.writeOp.dynamic);
-    value += mc->frontend->threadMasks->local_result.power.writeOp.dynamic;
-    value += mc->frontend->PRC->local_result.power.writeOp.dynamic;
-    value += perAccessCoalescingEnergy;
-    return value;
-  }
+    	double constpart=0;
+    	constpart+=(mc->frontend->power.readOp.dynamic*0.1*mc->frontend->mcp.clockRate*mc->frontend->mcp.num_mcs*mc->frontend->mcp.executionTime);
+    	constpart+=(mc->transecEngine->power.readOp.dynamic*0.1*mc->transecEngine->mcp.clockRate*mc->transecEngine->mcp.num_mcs*mc->transecEngine->mcp.executionTime);
+    	constpart+=(mc->PHY->power.readOp.dynamic*0.1*mc->PHY->mcp.clockRate*mc->PHY->mcp.num_mcs*mc->PHY->mcp.executionTime);
+    	constpart+=(cores[0]->exu->exeu->base_energy/cores[0]->exu->exeu->clockRate)*(cores[0]->exu->rf_fu_clockRate/cores[0]->exu->clockRate);
+    	constpart+=(cores[0]->exu->mul->base_energy/cores[0]->exu->mul->clockRate);
+    	constpart+=(cores[0]->exu->fp_u->base_energy/cores[0]->exu->fp_u->clockRate);
+    	return constpart;
+    }
+#define COALESCE_SCALE  1
+    double get_coefficient_readcoalescing()
+    {
+		double value=0;
+		double perAccessCoalescingEnergy=COALESCE_SCALE * ((0.443e-3)*(0.5e-9)*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd)/(1*1);
+		value+=mc->frontend->PRT->local_result.power.readOp.dynamic;
+		value+=mc->frontend->threadMasks->local_result.power.readOp.dynamic;
+		value+=mc->frontend->PRC->local_result.power.readOp.dynamic;
+		value+=perAccessCoalescingEnergy;
+		return value;
 
-  double get_coefficient_noc_accesses() {
-    double read_coef = 0;
-    // the 32/4 is applied to the NoC access counters (32/4*L2 cache access)
-    read_coef += nocs[0]->router->buffer.power.readOp.dynamic;
-    read_coef += nocs[0]->router->buffer.power.writeOp.dynamic;
-    read_coef += nocs[0]->router->crossbar.power.readOp.dynamic;
-    read_coef += nocs[0]->router->arbiter.power.readOp.dynamic;
-    return read_coef;
-  }
-
-  double get_coefficient_l2_read_hits() {
-    double read_coef = 0;
-    if (XML->sys.number_of_L2s > 0)
-      read_coef =
-          l2array[0]->unicache.caches->local_result.power.readOp.dynamic;
-    return read_coef;
-  }
-
-  double get_coefficient_l2_read_misses() {
-    double read_coef = 0;
-    if (XML->sys.number_of_L2s > 0)
-      read_coef =
-          l2array[0]
-              ->unicache.caches->local_result.tag_array2->power.readOp.dynamic;
-    return read_coef;
-  }
-
-  double get_coefficient_l2_write_hits() {
-    double read_coef = 0;
-    if (XML->sys.number_of_L2s > 0)
-      read_coef =
-          l2array[0]->unicache.caches->local_result.power.writeOp.dynamic;
-    return read_coef;
-  }
-  double get_coefficient_l2_write_misses() {
-    double read_coef = 0;
-    if (XML->sys.number_of_L2s > 0) {
-      read_coef = l2array[0]
-                      ->unicache.caches->local_result.tag_array2->power.writeOp
-                      .dynamic;  //*(32/4); // removed by Jingwen, the scaling
-                                 //of 32/4 is not used in the mcpat
-      read_coef +=
-          l2array[0]->unicache.caches->local_result.power.writeOp.dynamic;
-      read_coef +=
-          l2array[0]->unicache.missb->local_result.power.searchOp.dynamic;
-      read_coef +=
-          l2array[0]->unicache.missb->local_result.power.writeOp.dynamic;
-      read_coef +=
-          l2array[0]->unicache.ifb->local_result.power.searchOp.dynamic;
-      read_coef += l2array[0]->unicache.ifb->local_result.power.writeOp.dynamic;
-      read_coef +=
-          l2array[0]->unicache.prefetchb->local_result.power.searchOp.dynamic;
-      read_coef +=
-          l2array[0]->unicache.prefetchb->local_result.power.writeOp.dynamic;
-      read_coef +=
-          l2array[0]->unicache.wbb->local_result.power.searchOp.dynamic;
-      read_coef += l2array[0]->unicache.wbb->local_result.power.writeOp.dynamic;
+    }
+    double get_coefficient_writecoalescing()
+    {
+		double value=0;
+		double perAccessCoalescingEnergy=COALESCE_SCALE *((0.443e-3)*(0.5e-9)*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd)/(1*1);
+		value+=(mc->frontend->PRT->local_result.power.writeOp.dynamic);
+		value+=mc->frontend->threadMasks->local_result.power.writeOp.dynamic;
+		value+=mc->frontend->PRC->local_result.power.writeOp.dynamic;
+		value+=perAccessCoalescingEnergy;
+		return value;
     }
 
-    return read_coef;
-  }
 
-  double get_coefficient_mem_reads() {
-    double value = 0;
-    value +=
-        (mc->frontend->mcp.llcBlockSize * 8.0 / mc->frontend->mcp.dataBusWidth *
-         mc->frontend->mcp.dataBusWidth / 72) *
-        (mc->frontend->frontendBuffer->local_result.power.searchOp.dynamic);
+	 double get_coefficient_noc_accesses() {
+		double read_coef=0;
+		// the 32/4 is applied to the NoC access counters (32/4*L2 cache access)
+		read_coef+= nocs[0]->router->buffer.power.readOp.dynamic;
+		read_coef+= nocs[0]->router->buffer.power.writeOp.dynamic;
+		read_coef+= nocs[0]->router->crossbar.power.readOp.dynamic;
+		read_coef+= nocs[0]->router->arbiter.power.readOp.dynamic;
+		return read_coef;
+	 }
 
-    value +=
-        (mc->frontend->mcp.llcBlockSize * 8.0 / mc->frontend->mcp.dataBusWidth *
-         mc->frontend->mcp.dataBusWidth / 72) *
-        (mc->frontend->frontendBuffer->local_result.power.readOp.dynamic);
+	 double get_coefficient_l2_read_hits(){
+      double read_coef=0;
+      if(XML->sys.number_of_L2s>0)
+    	  read_coef = l2array[0]->unicache.caches->local_result.power.readOp.dynamic;
+		return read_coef;
+	 }
+	 
+	 double get_coefficient_l2_read_misses(){
+      double read_coef=0;
+      if(XML->sys.number_of_L2s>0)
+    	  read_coef = l2array[0]->unicache.caches->local_result.tag_array2->power.readOp.dynamic;
+	  return read_coef;
 
-    // TODO: Jingwen this should only compute for one time?
-    // value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth*mc->frontend->mcp.dataBusWidth/72)
-    //*(mc->frontend->frontendBuffer->local_result.power.readOp.dynamic);
+	 }
 
-    value += (mc->frontend->mcp.llcBlockSize * 8.0 / mc->mcp.dataBusWidth) *
-             (mc->frontend->readBuffer->local_result.power.readOp.dynamic);
+	 double get_coefficient_l2_write_hits(){
+      double read_coef=0;
+      if(XML->sys.number_of_L2s>0)
+    	  read_coef = l2array[0]->unicache.caches->local_result.power.writeOp.dynamic;
+		return read_coef;
 
-    value += (mc->frontend->mcp.llcBlockSize * 8.0 / mc->mcp.dataBusWidth) *
-             (mc->frontend->readBuffer->local_result.power.writeOp.dynamic);
+	 }
+	 double get_coefficient_l2_write_misses(){
+		double read_coef=0;
+	     if(XML->sys.number_of_L2s>0){
+		read_coef = l2array[0]->unicache.caches->local_result.tag_array2->power.writeOp.dynamic;//*(32/4); // removed by Jingwen, the scaling of 32/4 is not used in the mcpat
+		read_coef +=l2array[0]->unicache.caches->local_result.power.writeOp.dynamic;
+		read_coef += l2array[0]->unicache.missb->local_result.power.searchOp.dynamic;
+		read_coef += l2array[0]->unicache.missb->local_result.power.writeOp.dynamic;
+		read_coef += l2array[0]->unicache.ifb->local_result.power.searchOp.dynamic;
+		read_coef += l2array[0]->unicache.ifb->local_result.power.writeOp.dynamic;
+		read_coef += l2array[0]->unicache.prefetchb->local_result.power.searchOp.dynamic;
+		read_coef += l2array[0]->unicache.prefetchb->local_result.power.writeOp.dynamic;
+		read_coef += l2array[0]->unicache.wbb->local_result.power.searchOp.dynamic;
+		read_coef += l2array[0]->unicache.wbb->local_result.power.writeOp.dynamic;
+	     }
 
-    value += mc->dram->dramp.rd_coeff;
-    /*
-            value+=mc->frontend->PRT->local_result.power.readOp.dynamic;
-            value+=mc->frontend->threadMasks->local_result.power.readOp.dynamic;
-            value+=mc->frontend->PRC->local_result.power.readOp.dynamic;
-            value+=perAccessCoalescingEnergy;
-            */
-    value += (mc->transecEngine->mcp.llcBlockSize * 8.0 /
-              mc->transecEngine->mcp.dataBusWidth *
-              mc->transecEngine->power_t.readOp.dynamic);
+		return read_coef;
 
-    // if mcp.type ==1 TODO: add this check here
-    value += (mc->PHY->power_t.readOp.dynamic) * (mc->PHY->mcp.llcBlockSize) *
-             8 / 1e9 / mc->PHY->mcp.executionTime *
-             (mc->PHY->mcp.executionTime);
-    // printf("MC PHY read power coeff:
-    // %f\n",(mc->PHY->power_t.readOp.dynamic)*(mc->PHY->mcp.llcBlockSize)*8/1e9/mc->PHY->mcp.executionTime*(mc->PHY->mcp.executionTime));
-    // printf("MC trans read power coeff:
-    // %f\n",(mc->transecEngine->mcp.llcBlockSize*8.0/mc->transecEngine->mcp.dataBusWidth*mc->transecEngine->power_t.readOp.dynamic));
+	 }
 
-    // TODO: Jingwen nocs stats should not be here
-    //		value+= nocs[0]->router->buffer.power.readOp.dynamic*(32/4);
-    //		value+= nocs[0]->router->buffer.power.writeOp.dynamic*(32/4);
-    //		value+= nocs[0]->router->crossbar.power.readOp.dynamic*(32/4);
-    //		value+= nocs[0]->router->arbiter.power.readOp.dynamic*(32/4);
 
-    // return 0.4*value;
-    return value;
-  }
+	 double get_coefficient_mem_reads()
+	 {
+		double value=0;
+		value+= (mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth*mc->frontend->mcp.dataBusWidth/72)*
+		  (mc->frontend->frontendBuffer->local_result.power.searchOp.dynamic);
 
-  double get_coefficient_mem_writes() {
-    double value = 0;
+		value+= (mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth*mc->frontend->mcp.dataBusWidth/72)*
+		  (mc->frontend->frontendBuffer->local_result.power.readOp.dynamic);
 
-    value +=
-        (mc->frontend->mcp.llcBlockSize * 8.0 / mc->frontend->mcp.dataBusWidth *
-         mc->frontend->mcp.dataBusWidth / 72) *
-        (mc->frontend->frontendBuffer->local_result.power.searchOp.dynamic);
+//TODO: Jingwen this should only compute for one time?
+		//value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth*mc->frontend->mcp.dataBusWidth/72)
+		  //*(mc->frontend->frontendBuffer->local_result.power.readOp.dynamic);
 
-    value +=
-        (mc->frontend->mcp.llcBlockSize * 8.0 / mc->frontend->mcp.dataBusWidth *
-         mc->frontend->mcp.dataBusWidth / 72) *
-        (mc->frontend->frontendBuffer->local_result.power.writeOp.dynamic);
+		value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->mcp.dataBusWidth)*
+		  (mc->frontend->readBuffer->local_result.power.readOp.dynamic);
 
-    // value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth*mc->frontend->mcp.dataBusWidth/72)*
-    // (mc->frontend->frontendBuffer->local_result.power.writeOp.dynamic);
+		value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->mcp.dataBusWidth)*
+		  (mc->frontend->readBuffer->local_result.power.writeOp.dynamic);
 
-    value += (mc->frontend->mcp.llcBlockSize * 8.0 /
-              mc->frontend->mcp.dataBusWidth) *
-             (mc->frontend->writeBuffer->local_result.power.readOp.dynamic);
+		value+=mc->dram->dramp.rd_coeff;
+		/*
+			value+=mc->frontend->PRT->local_result.power.readOp.dynamic;
+			value+=mc->frontend->threadMasks->local_result.power.readOp.dynamic;
+			value+=mc->frontend->PRC->local_result.power.readOp.dynamic;
+			value+=perAccessCoalescingEnergy;
+			*/
+		value+=(mc->transecEngine->mcp.llcBlockSize*8.0/mc->transecEngine->mcp.dataBusWidth*mc->transecEngine->power_t.readOp.dynamic);
 
-    value += (mc->frontend->mcp.llcBlockSize * 8.0 /
-              mc->frontend->mcp.dataBusWidth) *
-             (mc->frontend->writeBuffer->local_result.power.writeOp.dynamic);
+		//if mcp.type ==1 TODO: add this check here
+		value += (mc->PHY->power_t.readOp.dynamic)*(mc->PHY->mcp.llcBlockSize)*8/1e9/mc->PHY->mcp.executionTime*(mc->PHY->mcp.executionTime);
+                //printf("MC PHY read power coeff: %f\n",(mc->PHY->power_t.readOp.dynamic)*(mc->PHY->mcp.llcBlockSize)*8/1e9/mc->PHY->mcp.executionTime*(mc->PHY->mcp.executionTime));
+                //printf("MC trans read power coeff: %f\n",(mc->transecEngine->mcp.llcBlockSize*8.0/mc->transecEngine->mcp.dataBusWidth*mc->transecEngine->power_t.readOp.dynamic));
 
-    value += mc->dram->dramp.wr_coeff;
-    /*
-            value+=(mc->frontend->PRT->local_result.power.writeOp.dynamic);
+//TODO: Jingwen nocs stats should not be here
+//		value+= nocs[0]->router->buffer.power.readOp.dynamic*(32/4);
+//		value+= nocs[0]->router->buffer.power.writeOp.dynamic*(32/4);
+//		value+= nocs[0]->router->crossbar.power.readOp.dynamic*(32/4);
+//		value+= nocs[0]->router->arbiter.power.readOp.dynamic*(32/4);
 
-            value+=mc->frontend->threadMasks->local_result.power.writeOp.dynamic;
+		//return 0.4*value;
+		return value;
+	 }
 
-            value+=mc->frontend->PRC->local_result.power.writeOp.dynamic;
 
-            value+=perAccessCoalescingEnergy;
-            */
+	 double get_coefficient_mem_writes()
+	 {
+		double value=0;
 
-    value += (mc->transecEngine->mcp.llcBlockSize * 8.0 /
-              mc->transecEngine->mcp.dataBusWidth *
-              mc->transecEngine->power_t.readOp.dynamic);
+		value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth*mc->frontend->mcp.dataBusWidth/72)*
+		  (mc->frontend->frontendBuffer->local_result.power.searchOp.dynamic);
 
-    // if mcp.type ==1 TODO: add this check here
-    value += (mc->PHY->power_t.readOp.dynamic) * (mc->PHY->mcp.llcBlockSize) *
-             8 / 1e9 / mc->PHY->mcp.executionTime *
-             (mc->PHY->mcp.executionTime);
+		value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth*mc->frontend->mcp.dataBusWidth/72)*
+		  (mc->frontend->frontendBuffer->local_result.power.writeOp.dynamic);
 
-    // TODO: Jingwen nocs stats should not be here
-    //		value+= nocs[0]->router->buffer.power.readOp.dynamic*(32/4);
-    //
-    //		value+= nocs[0]->router->buffer.power.writeOp.dynamic*(32/4);
-    //
-    //		value+= nocs[0]->router->crossbar.power.readOp.dynamic*(32/4);
-    //
-    //		value+= nocs[0]->router->arbiter.power.readOp.dynamic*(32/4);
-    //
-    // return 0.4*value;
-    return value;
-  }
+		//value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth*mc->frontend->mcp.dataBusWidth/72)*
+		 // (mc->frontend->frontendBuffer->local_result.power.writeOp.dynamic);
 
-  double get_coefficient_mem_pre() {
-    double value = 0;
-    value += mc->dram->dramp.pre_coeff;
-    // return 0.4*value;
-    return value;
-  }
+		value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth)*
+		  (mc->frontend->writeBuffer->local_result.power.readOp.dynamic);
 
-  // nonlinear scale
-  void nonlinear_scale(int, double, int);
-  void coefficient_scale();
-  void iterative_lse(double *, double *);
+		value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth)*
+		  (mc->frontend->writeBuffer->local_result.power.writeOp.dynamic);
 
-  ~Processor();
+		value+=mc->dram->dramp.wr_coeff;
+		/*
+			value+=(mc->frontend->PRT->local_result.power.writeOp.dynamic);
+
+			value+=mc->frontend->threadMasks->local_result.power.writeOp.dynamic;
+
+			value+=mc->frontend->PRC->local_result.power.writeOp.dynamic;
+
+			value+=perAccessCoalescingEnergy;
+			*/
+
+		value+=(mc->transecEngine->mcp.llcBlockSize*8.0/mc->transecEngine->mcp.dataBusWidth*mc->transecEngine->power_t.readOp.dynamic);
+
+
+		//if mcp.type ==1 TODO: add this check here
+		value += (mc->PHY->power_t.readOp.dynamic)*(mc->PHY->mcp.llcBlockSize)*8/1e9/mc->PHY->mcp.executionTime*(mc->PHY->mcp.executionTime);
+
+
+//TODO: Jingwen nocs stats should not be here
+//		value+= nocs[0]->router->buffer.power.readOp.dynamic*(32/4);
+//
+//		value+= nocs[0]->router->buffer.power.writeOp.dynamic*(32/4);
+//
+//		value+= nocs[0]->router->crossbar.power.readOp.dynamic*(32/4);
+//
+//		value+= nocs[0]->router->arbiter.power.readOp.dynamic*(32/4);
+//
+		//return 0.4*value;
+		return value;
+	 }
+
+	 double get_coefficient_mem_pre()
+	 {
+		double value=0;
+		value+=mc->dram->dramp.pre_coeff;
+		//return 0.4*value;
+		return value;
+		
+	 }
+
+	 //nonlinear scale
+	 void nonlinear_scale(int, double, int);
+	 void coefficient_scale();
+	 void iterative_lse(double *, double* );
+
+	 ~Processor();
 };
 
 #endif /* PROCESSOR_H_ */

--- a/src/gpuwattch/processor.h
+++ b/src/gpuwattch/processor.h
@@ -29,7 +29,8 @@
  *
  ***************************************************************************/
 /********************************************************************
-*      Modified by:												   *
+*      Modified by:
+**
 *      Jingwen Leng, Univeristy of Texas, Austin                   *
 *      Syed Gilani, University of Wisconsin–Madison                *
 *      Tayler Hetherington, University of British Columbia         *
@@ -38,253 +39,287 @@
 #ifndef PROCESSOR_H_
 #define PROCESSOR_H_
 
+#include <vector>
+#include "../gpgpu-sim/visualizer.h"
 #include "XML_Parse.h"
+#include "array.h"
+#include "basic_components.h"
+#include "cacti/arbiter.h"
 #include "cacti/area.h"
 #include "cacti/decoder.h"
 #include "cacti/parameter.h"
-#include "array.h"
-#include "cacti/arbiter.h"
-#include <vector>
-#include "basic_components.h"
-#include "core.h"
-#include "memoryctrl.h"
 #include "cacti/router.h"
-#include "sharedcache.h"
-#include "noc.h"
+#include "core.h"
 #include "iocontrollers.h"
-#include "../gpgpu-sim/visualizer.h"
+#include "memoryctrl.h"
+#include "noc.h"
+#include "sharedcache.h"
 
-class Processor : public Component
-{
-  public:
-	ParseXML *XML;
-	vector<Core *> cores;
-    vector<SharedCache *> l2array;
-    vector<SharedCache *> l3array;
-    vector<SharedCache *> l1dirarray;
-    vector<SharedCache *> l2dirarray;
-    vector<NoC *>  nocs;
-    MemoryController * mc;
-    NIUController    * niu;
-    PCIeController   * pcie;
-    FlashController  * flashcontroller;
-    InputParameter interface_ip;
-    double exClockRate;
-    ProcParam procdynp;
-	  //for debugging nonlinear model
-		double dyn_power_before_scaling;
-    
-    //wire	globalInterconnect;
-    //clock_network globalClock;
-    Component core, l2, l3, l1dir, l2dir, noc, mcs, cc, nius, pcies,flashcontrollers;
-    int  numCore, numL2, numL3, numNOC, numL1Dir, numL2Dir;
-    Processor(ParseXML *XML_interface);
-    void compute();
-    void set_proc_param();
-    void visualizer_print( gzFile visualizer_file );
-    void displayEnergy(uint32_t indent = 0,int plevel = 100, bool is_tdp_parm=true);
-    void displayDeviceType(int device_type_, uint32_t indent = 0);
-    void displayInterconnectType(int interconnect_type_, uint32_t indent = 0);
-    double l2_power;
-	double idle_core_power;
+class Processor : public Component {
+ public:
+  ParseXML *XML;
+  vector<Core *> cores;
+  vector<SharedCache *> l2array;
+  vector<SharedCache *> l3array;
+  vector<SharedCache *> l1dirarray;
+  vector<SharedCache *> l2dirarray;
+  vector<NoC *> nocs;
+  MemoryController *mc;
+  NIUController *niu;
+  PCIeController *pcie;
+  FlashController *flashcontroller;
+  InputParameter interface_ip;
+  double exClockRate;
+  ProcParam procdynp;
+  // for debugging nonlinear model
+  double dyn_power_before_scaling;
 
-    double get_const_dynamic_power()
-    {
+  // wire	globalInterconnect;
+  // clock_network globalClock;
+  Component core, l2, l3, l1dir, l2dir, noc, mcs, cc, nius, pcies,
+      flashcontrollers;
+  int numCore, numL2, numL3, numNOC, numL1Dir, numL2Dir;
+  Processor(ParseXML *XML_interface);
+  void compute();
+  void set_proc_param();
+  void visualizer_print(gzFile visualizer_file);
+  void displayEnergy(uint32_t indent = 0, int plevel = 100,
+                     bool is_tdp_parm = true);
+  void displayDeviceType(int device_type_, uint32_t indent = 0);
+  void displayInterconnectType(int interconnect_type_, uint32_t indent = 0);
+  double l2_power;
+  double idle_core_power;
 
-    	double constpart=0;
-    	constpart+=(mc->frontend->power.readOp.dynamic*0.1*mc->frontend->mcp.clockRate*mc->frontend->mcp.num_mcs*mc->frontend->mcp.executionTime);
-    	constpart+=(mc->transecEngine->power.readOp.dynamic*0.1*mc->transecEngine->mcp.clockRate*mc->transecEngine->mcp.num_mcs*mc->transecEngine->mcp.executionTime);
-    	constpart+=(mc->PHY->power.readOp.dynamic*0.1*mc->PHY->mcp.clockRate*mc->PHY->mcp.num_mcs*mc->PHY->mcp.executionTime);
-    	constpart+=(cores[0]->exu->exeu->base_energy/cores[0]->exu->exeu->clockRate)*(cores[0]->exu->rf_fu_clockRate/cores[0]->exu->clockRate);
-    	constpart+=(cores[0]->exu->mul->base_energy/cores[0]->exu->mul->clockRate);
-    	constpart+=(cores[0]->exu->fp_u->base_energy/cores[0]->exu->fp_u->clockRate);
-    	return constpart;
+  double get_const_dynamic_power() {
+    double constpart = 0;
+    constpart += (mc->frontend->power.readOp.dynamic * 0.1 *
+                  mc->frontend->mcp.clockRate * mc->frontend->mcp.num_mcs *
+                  mc->frontend->mcp.executionTime);
+    constpart +=
+        (mc->transecEngine->power.readOp.dynamic * 0.1 *
+         mc->transecEngine->mcp.clockRate * mc->transecEngine->mcp.num_mcs *
+         mc->transecEngine->mcp.executionTime);
+    constpart += (mc->PHY->power.readOp.dynamic * 0.1 * mc->PHY->mcp.clockRate *
+                  mc->PHY->mcp.num_mcs * mc->PHY->mcp.executionTime);
+    constpart +=
+        (cores[0]->exu->exeu->base_energy / cores[0]->exu->exeu->clockRate) *
+        (cores[0]->exu->rf_fu_clockRate / cores[0]->exu->clockRate);
+    constpart +=
+        (cores[0]->exu->mul->base_energy / cores[0]->exu->mul->clockRate);
+    constpart +=
+        (cores[0]->exu->fp_u->base_energy / cores[0]->exu->fp_u->clockRate);
+    return constpart;
+  }
+#define COALESCE_SCALE 1
+  double get_coefficient_readcoalescing() {
+    double value = 0;
+    double perAccessCoalescingEnergy =
+        COALESCE_SCALE *
+        ((0.443e-3) * (0.5e-9) * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd) /
+        (1 * 1);
+    value += mc->frontend->PRT->local_result.power.readOp.dynamic;
+    value += mc->frontend->threadMasks->local_result.power.readOp.dynamic;
+    value += mc->frontend->PRC->local_result.power.readOp.dynamic;
+    value += perAccessCoalescingEnergy;
+    return value;
+  }
+  double get_coefficient_writecoalescing() {
+    double value = 0;
+    double perAccessCoalescingEnergy =
+        COALESCE_SCALE *
+        ((0.443e-3) * (0.5e-9) * g_tp.peri_global.Vdd * g_tp.peri_global.Vdd) /
+        (1 * 1);
+    value += (mc->frontend->PRT->local_result.power.writeOp.dynamic);
+    value += mc->frontend->threadMasks->local_result.power.writeOp.dynamic;
+    value += mc->frontend->PRC->local_result.power.writeOp.dynamic;
+    value += perAccessCoalescingEnergy;
+    return value;
+  }
+
+  double get_coefficient_noc_accesses() {
+    double read_coef = 0;
+    // the 32/4 is applied to the NoC access counters (32/4*L2 cache access)
+    read_coef += nocs[0]->router->buffer.power.readOp.dynamic;
+    read_coef += nocs[0]->router->buffer.power.writeOp.dynamic;
+    read_coef += nocs[0]->router->crossbar.power.readOp.dynamic;
+    read_coef += nocs[0]->router->arbiter.power.readOp.dynamic;
+    return read_coef;
+  }
+
+  double get_coefficient_l2_read_hits() {
+    double read_coef = 0;
+    if (XML->sys.number_of_L2s > 0)
+      read_coef =
+          l2array[0]->unicache.caches->local_result.power.readOp.dynamic;
+    return read_coef;
+  }
+
+  double get_coefficient_l2_read_misses() {
+    double read_coef = 0;
+    if (XML->sys.number_of_L2s > 0)
+      read_coef =
+          l2array[0]
+              ->unicache.caches->local_result.tag_array2->power.readOp.dynamic;
+    return read_coef;
+  }
+
+  double get_coefficient_l2_write_hits() {
+    double read_coef = 0;
+    if (XML->sys.number_of_L2s > 0)
+      read_coef =
+          l2array[0]->unicache.caches->local_result.power.writeOp.dynamic;
+    return read_coef;
+  }
+  double get_coefficient_l2_write_misses() {
+    double read_coef = 0;
+    if (XML->sys.number_of_L2s > 0) {
+      read_coef = l2array[0]
+                      ->unicache.caches->local_result.tag_array2->power.writeOp
+                      .dynamic;  //*(32/4); // removed by Jingwen, the scaling
+                                 //of 32/4 is not used in the mcpat
+      read_coef +=
+          l2array[0]->unicache.caches->local_result.power.writeOp.dynamic;
+      read_coef +=
+          l2array[0]->unicache.missb->local_result.power.searchOp.dynamic;
+      read_coef +=
+          l2array[0]->unicache.missb->local_result.power.writeOp.dynamic;
+      read_coef +=
+          l2array[0]->unicache.ifb->local_result.power.searchOp.dynamic;
+      read_coef += l2array[0]->unicache.ifb->local_result.power.writeOp.dynamic;
+      read_coef +=
+          l2array[0]->unicache.prefetchb->local_result.power.searchOp.dynamic;
+      read_coef +=
+          l2array[0]->unicache.prefetchb->local_result.power.writeOp.dynamic;
+      read_coef +=
+          l2array[0]->unicache.wbb->local_result.power.searchOp.dynamic;
+      read_coef += l2array[0]->unicache.wbb->local_result.power.writeOp.dynamic;
     }
-#define COALESCE_SCALE  1
-    double get_coefficient_readcoalescing()
-    {
-		double value=0;
-		double perAccessCoalescingEnergy=COALESCE_SCALE * ((0.443e-3)*(0.5e-9)*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd)/(1*1);
-		value+=mc->frontend->PRT->local_result.power.readOp.dynamic;
-		value+=mc->frontend->threadMasks->local_result.power.readOp.dynamic;
-		value+=mc->frontend->PRC->local_result.power.readOp.dynamic;
-		value+=perAccessCoalescingEnergy;
-		return value;
 
-    }
-    double get_coefficient_writecoalescing()
-    {
-		double value=0;
-		double perAccessCoalescingEnergy=COALESCE_SCALE *((0.443e-3)*(0.5e-9)*g_tp.peri_global.Vdd*g_tp.peri_global.Vdd)/(1*1);
-		value+=(mc->frontend->PRT->local_result.power.writeOp.dynamic);
-		value+=mc->frontend->threadMasks->local_result.power.writeOp.dynamic;
-		value+=mc->frontend->PRC->local_result.power.writeOp.dynamic;
-		value+=perAccessCoalescingEnergy;
-		return value;
-    }
+    return read_coef;
+  }
 
+  double get_coefficient_mem_reads() {
+    double value = 0;
+    value +=
+        (mc->frontend->mcp.llcBlockSize * 8.0 / mc->frontend->mcp.dataBusWidth *
+         mc->frontend->mcp.dataBusWidth / 72) *
+        (mc->frontend->frontendBuffer->local_result.power.searchOp.dynamic);
 
-	 double get_coefficient_noc_accesses() {
-		double read_coef=0;
-		// the 32/4 is applied to the NoC access counters (32/4*L2 cache access)
-		read_coef+= nocs[0]->router->buffer.power.readOp.dynamic;
-		read_coef+= nocs[0]->router->buffer.power.writeOp.dynamic;
-		read_coef+= nocs[0]->router->crossbar.power.readOp.dynamic;
-		read_coef+= nocs[0]->router->arbiter.power.readOp.dynamic;
-		return read_coef;
-	 }
+    value +=
+        (mc->frontend->mcp.llcBlockSize * 8.0 / mc->frontend->mcp.dataBusWidth *
+         mc->frontend->mcp.dataBusWidth / 72) *
+        (mc->frontend->frontendBuffer->local_result.power.readOp.dynamic);
 
-	 double get_coefficient_l2_read_hits(){
-      double read_coef=0;
-      if(XML->sys.number_of_L2s>0)
-    	  read_coef = l2array[0]->unicache.caches->local_result.power.readOp.dynamic;
-		return read_coef;
-	 }
-	 
-	 double get_coefficient_l2_read_misses(){
-      double read_coef=0;
-      if(XML->sys.number_of_L2s>0)
-    	  read_coef = l2array[0]->unicache.caches->local_result.tag_array2->power.readOp.dynamic;
-	  return read_coef;
+    // TODO: Jingwen this should only compute for one time?
+    // value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth*mc->frontend->mcp.dataBusWidth/72)
+    //*(mc->frontend->frontendBuffer->local_result.power.readOp.dynamic);
 
-	 }
+    value += (mc->frontend->mcp.llcBlockSize * 8.0 / mc->mcp.dataBusWidth) *
+             (mc->frontend->readBuffer->local_result.power.readOp.dynamic);
 
-	 double get_coefficient_l2_write_hits(){
-      double read_coef=0;
-      if(XML->sys.number_of_L2s>0)
-    	  read_coef = l2array[0]->unicache.caches->local_result.power.writeOp.dynamic;
-		return read_coef;
+    value += (mc->frontend->mcp.llcBlockSize * 8.0 / mc->mcp.dataBusWidth) *
+             (mc->frontend->readBuffer->local_result.power.writeOp.dynamic);
 
-	 }
-	 double get_coefficient_l2_write_misses(){
-		double read_coef=0;
-	     if(XML->sys.number_of_L2s>0){
-		read_coef = l2array[0]->unicache.caches->local_result.tag_array2->power.writeOp.dynamic;//*(32/4); // removed by Jingwen, the scaling of 32/4 is not used in the mcpat
-		read_coef +=l2array[0]->unicache.caches->local_result.power.writeOp.dynamic;
-		read_coef += l2array[0]->unicache.missb->local_result.power.searchOp.dynamic;
-		read_coef += l2array[0]->unicache.missb->local_result.power.writeOp.dynamic;
-		read_coef += l2array[0]->unicache.ifb->local_result.power.searchOp.dynamic;
-		read_coef += l2array[0]->unicache.ifb->local_result.power.writeOp.dynamic;
-		read_coef += l2array[0]->unicache.prefetchb->local_result.power.searchOp.dynamic;
-		read_coef += l2array[0]->unicache.prefetchb->local_result.power.writeOp.dynamic;
-		read_coef += l2array[0]->unicache.wbb->local_result.power.searchOp.dynamic;
-		read_coef += l2array[0]->unicache.wbb->local_result.power.writeOp.dynamic;
-	     }
+    value += mc->dram->dramp.rd_coeff;
+    /*
+            value+=mc->frontend->PRT->local_result.power.readOp.dynamic;
+            value+=mc->frontend->threadMasks->local_result.power.readOp.dynamic;
+            value+=mc->frontend->PRC->local_result.power.readOp.dynamic;
+            value+=perAccessCoalescingEnergy;
+            */
+    value += (mc->transecEngine->mcp.llcBlockSize * 8.0 /
+              mc->transecEngine->mcp.dataBusWidth *
+              mc->transecEngine->power_t.readOp.dynamic);
 
-		return read_coef;
+    // if mcp.type ==1 TODO: add this check here
+    value += (mc->PHY->power_t.readOp.dynamic) * (mc->PHY->mcp.llcBlockSize) *
+             8 / 1e9 / mc->PHY->mcp.executionTime *
+             (mc->PHY->mcp.executionTime);
+    // printf("MC PHY read power coeff:
+    // %f\n",(mc->PHY->power_t.readOp.dynamic)*(mc->PHY->mcp.llcBlockSize)*8/1e9/mc->PHY->mcp.executionTime*(mc->PHY->mcp.executionTime));
+    // printf("MC trans read power coeff:
+    // %f\n",(mc->transecEngine->mcp.llcBlockSize*8.0/mc->transecEngine->mcp.dataBusWidth*mc->transecEngine->power_t.readOp.dynamic));
 
-	 }
+    // TODO: Jingwen nocs stats should not be here
+    //		value+= nocs[0]->router->buffer.power.readOp.dynamic*(32/4);
+    //		value+= nocs[0]->router->buffer.power.writeOp.dynamic*(32/4);
+    //		value+= nocs[0]->router->crossbar.power.readOp.dynamic*(32/4);
+    //		value+= nocs[0]->router->arbiter.power.readOp.dynamic*(32/4);
 
+    // return 0.4*value;
+    return value;
+  }
 
-	 double get_coefficient_mem_reads()
-	 {
-		double value=0;
-		value+= (mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth*mc->frontend->mcp.dataBusWidth/72)*
-		  (mc->frontend->frontendBuffer->local_result.power.searchOp.dynamic);
+  double get_coefficient_mem_writes() {
+    double value = 0;
 
-		value+= (mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth*mc->frontend->mcp.dataBusWidth/72)*
-		  (mc->frontend->frontendBuffer->local_result.power.readOp.dynamic);
+    value +=
+        (mc->frontend->mcp.llcBlockSize * 8.0 / mc->frontend->mcp.dataBusWidth *
+         mc->frontend->mcp.dataBusWidth / 72) *
+        (mc->frontend->frontendBuffer->local_result.power.searchOp.dynamic);
 
-//TODO: Jingwen this should only compute for one time?
-		//value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth*mc->frontend->mcp.dataBusWidth/72)
-		  //*(mc->frontend->frontendBuffer->local_result.power.readOp.dynamic);
+    value +=
+        (mc->frontend->mcp.llcBlockSize * 8.0 / mc->frontend->mcp.dataBusWidth *
+         mc->frontend->mcp.dataBusWidth / 72) *
+        (mc->frontend->frontendBuffer->local_result.power.writeOp.dynamic);
 
-		value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->mcp.dataBusWidth)*
-		  (mc->frontend->readBuffer->local_result.power.readOp.dynamic);
+    // value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth*mc->frontend->mcp.dataBusWidth/72)*
+    // (mc->frontend->frontendBuffer->local_result.power.writeOp.dynamic);
 
-		value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->mcp.dataBusWidth)*
-		  (mc->frontend->readBuffer->local_result.power.writeOp.dynamic);
+    value += (mc->frontend->mcp.llcBlockSize * 8.0 /
+              mc->frontend->mcp.dataBusWidth) *
+             (mc->frontend->writeBuffer->local_result.power.readOp.dynamic);
 
-		value+=mc->dram->dramp.rd_coeff;
-		/*
-			value+=mc->frontend->PRT->local_result.power.readOp.dynamic;
-			value+=mc->frontend->threadMasks->local_result.power.readOp.dynamic;
-			value+=mc->frontend->PRC->local_result.power.readOp.dynamic;
-			value+=perAccessCoalescingEnergy;
-			*/
-		value+=(mc->transecEngine->mcp.llcBlockSize*8.0/mc->transecEngine->mcp.dataBusWidth*mc->transecEngine->power_t.readOp.dynamic);
+    value += (mc->frontend->mcp.llcBlockSize * 8.0 /
+              mc->frontend->mcp.dataBusWidth) *
+             (mc->frontend->writeBuffer->local_result.power.writeOp.dynamic);
 
-		//if mcp.type ==1 TODO: add this check here
-		value += (mc->PHY->power_t.readOp.dynamic)*(mc->PHY->mcp.llcBlockSize)*8/1e9/mc->PHY->mcp.executionTime*(mc->PHY->mcp.executionTime);
-                //printf("MC PHY read power coeff: %f\n",(mc->PHY->power_t.readOp.dynamic)*(mc->PHY->mcp.llcBlockSize)*8/1e9/mc->PHY->mcp.executionTime*(mc->PHY->mcp.executionTime));
-                //printf("MC trans read power coeff: %f\n",(mc->transecEngine->mcp.llcBlockSize*8.0/mc->transecEngine->mcp.dataBusWidth*mc->transecEngine->power_t.readOp.dynamic));
+    value += mc->dram->dramp.wr_coeff;
+    /*
+            value+=(mc->frontend->PRT->local_result.power.writeOp.dynamic);
 
-//TODO: Jingwen nocs stats should not be here
-//		value+= nocs[0]->router->buffer.power.readOp.dynamic*(32/4);
-//		value+= nocs[0]->router->buffer.power.writeOp.dynamic*(32/4);
-//		value+= nocs[0]->router->crossbar.power.readOp.dynamic*(32/4);
-//		value+= nocs[0]->router->arbiter.power.readOp.dynamic*(32/4);
+            value+=mc->frontend->threadMasks->local_result.power.writeOp.dynamic;
 
-		//return 0.4*value;
-		return value;
-	 }
+            value+=mc->frontend->PRC->local_result.power.writeOp.dynamic;
 
+            value+=perAccessCoalescingEnergy;
+            */
 
-	 double get_coefficient_mem_writes()
-	 {
-		double value=0;
+    value += (mc->transecEngine->mcp.llcBlockSize * 8.0 /
+              mc->transecEngine->mcp.dataBusWidth *
+              mc->transecEngine->power_t.readOp.dynamic);
 
-		value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth*mc->frontend->mcp.dataBusWidth/72)*
-		  (mc->frontend->frontendBuffer->local_result.power.searchOp.dynamic);
+    // if mcp.type ==1 TODO: add this check here
+    value += (mc->PHY->power_t.readOp.dynamic) * (mc->PHY->mcp.llcBlockSize) *
+             8 / 1e9 / mc->PHY->mcp.executionTime *
+             (mc->PHY->mcp.executionTime);
 
-		value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth*mc->frontend->mcp.dataBusWidth/72)*
-		  (mc->frontend->frontendBuffer->local_result.power.writeOp.dynamic);
+    // TODO: Jingwen nocs stats should not be here
+    //		value+= nocs[0]->router->buffer.power.readOp.dynamic*(32/4);
+    //
+    //		value+= nocs[0]->router->buffer.power.writeOp.dynamic*(32/4);
+    //
+    //		value+= nocs[0]->router->crossbar.power.readOp.dynamic*(32/4);
+    //
+    //		value+= nocs[0]->router->arbiter.power.readOp.dynamic*(32/4);
+    //
+    // return 0.4*value;
+    return value;
+  }
 
-		//value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth*mc->frontend->mcp.dataBusWidth/72)*
-		 // (mc->frontend->frontendBuffer->local_result.power.writeOp.dynamic);
+  double get_coefficient_mem_pre() {
+    double value = 0;
+    value += mc->dram->dramp.pre_coeff;
+    // return 0.4*value;
+    return value;
+  }
 
-		value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth)*
-		  (mc->frontend->writeBuffer->local_result.power.readOp.dynamic);
+  // nonlinear scale
+  void nonlinear_scale(int, double, int);
+  void coefficient_scale();
+  void iterative_lse(double *, double *);
 
-		value+=(mc->frontend->mcp.llcBlockSize*8.0/mc->frontend->mcp.dataBusWidth)*
-		  (mc->frontend->writeBuffer->local_result.power.writeOp.dynamic);
-
-		value+=mc->dram->dramp.wr_coeff;
-		/*
-			value+=(mc->frontend->PRT->local_result.power.writeOp.dynamic);
-
-			value+=mc->frontend->threadMasks->local_result.power.writeOp.dynamic;
-
-			value+=mc->frontend->PRC->local_result.power.writeOp.dynamic;
-
-			value+=perAccessCoalescingEnergy;
-			*/
-
-		value+=(mc->transecEngine->mcp.llcBlockSize*8.0/mc->transecEngine->mcp.dataBusWidth*mc->transecEngine->power_t.readOp.dynamic);
-
-
-		//if mcp.type ==1 TODO: add this check here
-		value += (mc->PHY->power_t.readOp.dynamic)*(mc->PHY->mcp.llcBlockSize)*8/1e9/mc->PHY->mcp.executionTime*(mc->PHY->mcp.executionTime);
-
-
-//TODO: Jingwen nocs stats should not be here
-//		value+= nocs[0]->router->buffer.power.readOp.dynamic*(32/4);
-//
-//		value+= nocs[0]->router->buffer.power.writeOp.dynamic*(32/4);
-//
-//		value+= nocs[0]->router->crossbar.power.readOp.dynamic*(32/4);
-//
-//		value+= nocs[0]->router->arbiter.power.readOp.dynamic*(32/4);
-//
-		//return 0.4*value;
-		return value;
-	 }
-
-	 double get_coefficient_mem_pre()
-	 {
-		double value=0;
-		value+=mc->dram->dramp.pre_coeff;
-		//return 0.4*value;
-		return value;
-		
-	 }
-
-	 //nonlinear scale
-	 void nonlinear_scale(int, double, int);
-	 void coefficient_scale();
-	 void iterative_lse(double *, double* );
-
-	 ~Processor();
+  ~Processor();
 };
 
 #endif /* PROCESSOR_H_ */

--- a/src/gpuwattch/processor.h
+++ b/src/gpuwattch/processor.h
@@ -176,7 +176,7 @@ class Processor : public Component {
       read_coef = l2array[0]
                       ->unicache.caches->local_result.tag_array2->power.writeOp
                       .dynamic;  //*(32/4); // removed by Jingwen, the scaling
-                                 // of 32/4 is not used in the mcpat
+                                 //of 32/4 is not used in the mcpat
       read_coef +=
           l2array[0]->unicache.caches->local_result.power.writeOp.dynamic;
       read_coef +=

--- a/src/gpuwattch/processor.h
+++ b/src/gpuwattch/processor.h
@@ -176,7 +176,7 @@ class Processor : public Component {
       read_coef = l2array[0]
                       ->unicache.caches->local_result.tag_array2->power.writeOp
                       .dynamic;  //*(32/4); // removed by Jingwen, the scaling
-                                 //of 32/4 is not used in the mcpat
+                                 // of 32/4 is not used in the mcpat
       read_coef +=
           l2array[0]->unicache.caches->local_result.power.writeOp.dynamic;
       read_coef +=

--- a/src/gpuwattch/sharedcache.cc
+++ b/src/gpuwattch/sharedcache.cc
@@ -29,257 +29,263 @@
  *
  ***************************************************************************/
 
-#include "io.h"
-#include "cacti/parameter.h"
-#include "array.h"
-#include "const.h"
-#include "logic.h"
-#include "cacti/basic_circuit.h"
-#include "cacti/arbiter.h"
-#include <string.h>
-#include <iostream>
-#include <algorithm>
-#include "XML_Parse.h"
-#include <string.h>
-#include <cmath>
-#include <assert.h>
 #include "sharedcache.h"
+#include <assert.h>
+#include <string.h>
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include "XML_Parse.h"
+#include "array.h"
+#include "cacti/arbiter.h"
+#include "cacti/basic_circuit.h"
+#include "cacti/parameter.h"
+#include "const.h"
+#include "io.h"
+#include "logic.h"
 
-
-
-SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_, InputParameter* interface_ip_, enum cache_level cacheL_)
-:XML(XML_interface),
- ithCache(ithCache_),
- interface_ip(*interface_ip_),
- cacheL(cacheL_),
- dir_overhead(0)
-{
+SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_,
+                         InputParameter* interface_ip_,
+                         enum cache_level cacheL_)
+    : XML(XML_interface),
+      ithCache(ithCache_),
+      interface_ip(*interface_ip_),
+      cacheL(cacheL_),
+      dir_overhead(0) {
   int idx;
   int tag, data;
-  bool debug; 
+  bool debug;
   enum Device_ty device_t;
-  enum Core_type  core_t;
+  enum Core_type core_t;
   double size, line, assoc, banks;
-  if (cacheL==L2 && XML->sys.Private_L2)
-  {
-	  device_t=Core_device;
-      core_t = (enum Core_type)XML->sys.core[ithCache].machine_type;
-  }
-  else
-  {
-	  device_t=LLC_device;
-	  core_t = Inorder;
+  if (cacheL == L2 && XML->sys.Private_L2) {
+    device_t = Core_device;
+    core_t = (enum Core_type)XML->sys.core[ithCache].machine_type;
+  } else {
+    device_t = LLC_device;
+    core_t = Inorder;
   }
 
-  debug           = false;
-  if (XML->sys.Embedded)
-  		{
-  		interface_ip.wt                  =Global_30;
-  		interface_ip.wire_is_mat_type = 0;
-  		interface_ip.wire_os_mat_type = 1;
-  		}
-  	else
-  		{
-  		interface_ip.wt                  =Global;
-  		interface_ip.wire_is_mat_type = 2;
-  		interface_ip.wire_os_mat_type = 2;
-  		}
+  debug = false;
+  if (XML->sys.Embedded) {
+    interface_ip.wt = Global_30;
+    interface_ip.wire_is_mat_type = 0;
+    interface_ip.wire_os_mat_type = 1;
+  } else {
+    interface_ip.wt = Global;
+    interface_ip.wire_is_mat_type = 2;
+    interface_ip.wire_os_mat_type = 2;
+  }
   set_cache_param();
 
-  //All lower level cache are physically indexed and tagged.
-  size                             = cachep.capacity;
-  line                             = cachep.blockW;
-  assoc                            = cachep.assoc;
-  banks                            = cachep.nbanks;
-  if ((cachep.dir_ty==ST&& cacheL==L1Directory)||(cachep.dir_ty==ST&& cacheL==L2Directory))
-  {
-	  assoc = 0;
-	  tag   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  interface_ip.num_search_ports    = 1;
+  // All lower level cache are physically indexed and tagged.
+  size = cachep.capacity;
+  line = cachep.blockW;
+  assoc = cachep.assoc;
+  banks = cachep.nbanks;
+  if ((cachep.dir_ty == ST && cacheL == L1Directory) ||
+      (cachep.dir_ty == ST && cacheL == L2Directory)) {
+    assoc = 0;
+    tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+    interface_ip.num_search_ports = 1;
+  } else {
+    idx = debug ? 9 : int(ceil(log2(size / line / assoc)));
+    tag = debug ? 51
+                : XML->sys.physical_address_width - idx -
+                      int(ceil(log2(line))) + EXTRA_TAG_BITS;
+    interface_ip.num_search_ports = 0;
+    if (cachep.dir_ty == SBT) {
+      dir_overhead =
+          ceil(XML->sys.number_of_cores / 8.0) * 8 / (cachep.blockW * 8);
+      line = cachep.blockW * (1 + dir_overhead);
+      size = cachep.capacity * (1 + dir_overhead);
+    }
   }
-  else
-  {
-	  idx    					 	   = debug?9:int(ceil(log2(size/line/assoc)));
-	  tag							   = debug?51:XML->sys.physical_address_width-idx-int(ceil(log2(line))) + EXTRA_TAG_BITS;
-	  interface_ip.num_search_ports    = 0;
-	  if (cachep.dir_ty==SBT)
-	  {
-		  dir_overhead = ceil(XML->sys.number_of_cores/8.0)*8/(cachep.blockW*8);
-		  line = cachep.blockW*(1+ dir_overhead) ;
-		  size = cachep.capacity*(1+ dir_overhead);
-
-	  }
-  }
-//  if (XML->sys.first_level_dir==2)
-//	  tag += int(XML->sys.domain_size + 5);
-  interface_ip.specific_tag        = 1;
-  interface_ip.tag_w               = tag;
-  interface_ip.cache_sz            = (int)size;
-  interface_ip.line_sz             = (int)line;
-  interface_ip.assoc               = (int)assoc;
-  interface_ip.nbanks              = (int)banks;
-  interface_ip.out_w               = interface_ip.line_sz*8/2;
-  interface_ip.access_mode         = 1;
-  interface_ip.throughput          = cachep.throughput;
-  interface_ip.latency             = cachep.latency;
-  interface_ip.is_cache			 = true;
-  interface_ip.pure_ram			 = false;
-  interface_ip.pure_cam          = false;
+  //  if (XML->sys.first_level_dir==2)
+  //	  tag += int(XML->sys.domain_size + 5);
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.cache_sz = (int)size;
+  interface_ip.line_sz = (int)line;
+  interface_ip.assoc = (int)assoc;
+  interface_ip.nbanks = (int)banks;
+  interface_ip.out_w = interface_ip.line_sz * 8 / 2;
+  interface_ip.access_mode = 1;
+  interface_ip.throughput = cachep.throughput;
+  interface_ip.latency = cachep.latency;
+  interface_ip.is_cache = true;
+  interface_ip.pure_ram = false;
+  interface_ip.pure_cam = false;
   interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power  = 0;
+  interface_ip.obj_func_dyn_power = 0;
   interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t    = 1;
-  interface_ip.num_rw_ports        = 1;//lower level cache usually has one port.
-  interface_ip.num_rd_ports        = 0;
-  interface_ip.num_wr_ports        = 0;
-  interface_ip.num_se_rd_ports     = 0;
-//  interface_ip.force_cache_config  =true;
-//  interface_ip.ndwl = 4;
-//  interface_ip.ndbl = 8;
-//  interface_ip.nspd = 1;
-//  interface_ip.ndcm =1 ;
-//  interface_ip.ndsam1 =1;
-//  interface_ip.ndsam2 =1;
-  unicache.caches = new ArrayST(&interface_ip, cachep.name + "cache", device_t, true, core_t);
-  unicache.area.set_area(unicache.area.get_area()+ unicache.caches->local_result.area);
-  area.set_area(area.get_area()+ unicache.caches->local_result.area);
-  interface_ip.force_cache_config  =false;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = 1;  // lower level cache usually has one port.
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  //  interface_ip.force_cache_config  =true;
+  //  interface_ip.ndwl = 4;
+  //  interface_ip.ndbl = 8;
+  //  interface_ip.nspd = 1;
+  //  interface_ip.ndcm =1 ;
+  //  interface_ip.ndsam1 =1;
+  //  interface_ip.ndsam2 =1;
+  unicache.caches =
+      new ArrayST(&interface_ip, cachep.name + "cache", device_t, true, core_t);
+  unicache.area.set_area(unicache.area.get_area() +
+                         unicache.caches->local_result.area);
+  area.set_area(area.get_area() + unicache.caches->local_result.area);
+  interface_ip.force_cache_config = false;
 
-
-  if (!((cachep.dir_ty==ST&& cacheL==L1Directory)||(cachep.dir_ty==ST&& cacheL==L2Directory)))
-  {
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  data							   = (XML->sys.physical_address_width) + int(ceil(log2(size/line))) + unicache.caches->l_ip.line_sz;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-	  interface_ip.cache_sz            = cachep.missb_size*interface_ip.line_sz;
-	  interface_ip.assoc               = 0;
-	  interface_ip.is_cache			   = true;
-	  interface_ip.pure_ram			   = false;
-	  interface_ip.pure_cam            = false;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8/2;
-	  interface_ip.access_mode         = 0;
-	  interface_ip.throughput          = cachep.throughput;//means cycle time
-	  interface_ip.latency             = cachep.latency;//means access time
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = 1;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  interface_ip.num_search_ports    = 1;
-	  unicache.missb = new ArrayST(&interface_ip, cachep.name + "MissB", device_t, true, core_t);
-	  unicache.area.set_area(unicache.area.get_area()+ unicache.missb->local_result.area);
-	  area.set_area(area.get_area()+ unicache.missb->local_result.area);
-	  //fill buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  data							   = unicache.caches->l_ip.line_sz;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-	  interface_ip.cache_sz            = data*cachep.fu_size ;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8/2;
-	  interface_ip.access_mode         = 0;
-	  interface_ip.throughput          =  cachep.throughput;
-	  interface_ip.latency             =  cachep.latency;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = 1;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  unicache.ifb = new ArrayST(&interface_ip, cachep.name + "FillB", device_t, true, core_t);
-	  unicache.area.set_area(unicache.area.get_area()+ unicache.ifb->local_result.area);
-	  area.set_area(area.get_area()+ unicache.ifb->local_result.area);
-	  //prefetch buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries to decide wthether to merge.
-	  data							   = unicache.caches->l_ip.line_sz;//separate queue to prevent from cache polution.
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-	  interface_ip.cache_sz            = cachep.prefetchb_size*interface_ip.line_sz;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8/2;
-	  interface_ip.access_mode         = 0;
-	  interface_ip.throughput          = cachep.throughput;
-	  interface_ip.latency             = cachep.latency;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = 1;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  unicache.prefetchb = new ArrayST(&interface_ip, cachep.name + "PrefetchB", device_t, true, core_t);
-	  unicache.area.set_area(unicache.area.get_area()+ unicache.prefetchb->local_result.area);
-	  area.set_area(area.get_area()+ unicache.prefetchb->local_result.area);
-	  //WBB
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  data							   = unicache.caches->l_ip.line_sz;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = data;
-	  interface_ip.cache_sz            = cachep.wbb_size*interface_ip.line_sz;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8/2;
-	  interface_ip.access_mode         = 0;
-	  interface_ip.throughput          = cachep.throughput;
-	  interface_ip.latency             = cachep.latency;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = 1;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  unicache.wbb = new ArrayST(&interface_ip, cachep.name + "WBB", device_t, true, core_t);
-	  unicache.area.set_area(unicache.area.get_area()+ unicache.wbb->local_result.area);
-	  area.set_area(area.get_area()+ unicache.wbb->local_result.area);
+  if (!((cachep.dir_ty == ST && cacheL == L1Directory) ||
+        (cachep.dir_ty == ST && cacheL == L2Directory))) {
+    tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+    data = (XML->sys.physical_address_width) + int(ceil(log2(size / line))) +
+           unicache.caches->l_ip.line_sz;
+    interface_ip.specific_tag = 1;
+    interface_ip.tag_w = tag;
+    interface_ip.line_sz =
+        int(ceil(data / 8.0));  // int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+    interface_ip.cache_sz = cachep.missb_size * interface_ip.line_sz;
+    interface_ip.assoc = 0;
+    interface_ip.is_cache = true;
+    interface_ip.pure_ram = false;
+    interface_ip.pure_cam = false;
+    interface_ip.nbanks = 1;
+    interface_ip.out_w = interface_ip.line_sz * 8 / 2;
+    interface_ip.access_mode = 0;
+    interface_ip.throughput = cachep.throughput;  // means cycle time
+    interface_ip.latency = cachep.latency;        // means access time
+    interface_ip.obj_func_dyn_energy = 0;
+    interface_ip.obj_func_dyn_power = 0;
+    interface_ip.obj_func_leak_power = 0;
+    interface_ip.obj_func_cycle_t = 1;
+    interface_ip.num_rw_ports = 1;
+    interface_ip.num_rd_ports = 0;
+    interface_ip.num_wr_ports = 0;
+    interface_ip.num_se_rd_ports = 0;
+    interface_ip.num_search_ports = 1;
+    unicache.missb = new ArrayST(&interface_ip, cachep.name + "MissB", device_t,
+                                 true, core_t);
+    unicache.area.set_area(unicache.area.get_area() +
+                           unicache.missb->local_result.area);
+    area.set_area(area.get_area() + unicache.missb->local_result.area);
+    // fill buffer
+    tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+    data = unicache.caches->l_ip.line_sz;
+    interface_ip.specific_tag = 1;
+    interface_ip.tag_w = tag;
+    interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
+    interface_ip.cache_sz = data * cachep.fu_size;
+    interface_ip.assoc = 0;
+    interface_ip.nbanks = 1;
+    interface_ip.out_w = interface_ip.line_sz * 8 / 2;
+    interface_ip.access_mode = 0;
+    interface_ip.throughput = cachep.throughput;
+    interface_ip.latency = cachep.latency;
+    interface_ip.obj_func_dyn_energy = 0;
+    interface_ip.obj_func_dyn_power = 0;
+    interface_ip.obj_func_leak_power = 0;
+    interface_ip.obj_func_cycle_t = 1;
+    interface_ip.num_rw_ports = 1;
+    interface_ip.num_rd_ports = 0;
+    interface_ip.num_wr_ports = 0;
+    interface_ip.num_se_rd_ports = 0;
+    unicache.ifb = new ArrayST(&interface_ip, cachep.name + "FillB", device_t,
+                               true, core_t);
+    unicache.area.set_area(unicache.area.get_area() +
+                           unicache.ifb->local_result.area);
+    area.set_area(area.get_area() + unicache.ifb->local_result.area);
+    // prefetch buffer
+    tag = XML->sys.physical_address_width +
+          EXTRA_TAG_BITS;  // check with previous entries to decide wthether to
+                           // merge.
+    data = unicache.caches->l_ip
+               .line_sz;  // separate queue to prevent from cache polution.
+    interface_ip.specific_tag = 1;
+    interface_ip.tag_w = tag;
+    interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
+    interface_ip.cache_sz = cachep.prefetchb_size * interface_ip.line_sz;
+    interface_ip.assoc = 0;
+    interface_ip.nbanks = 1;
+    interface_ip.out_w = interface_ip.line_sz * 8 / 2;
+    interface_ip.access_mode = 0;
+    interface_ip.throughput = cachep.throughput;
+    interface_ip.latency = cachep.latency;
+    interface_ip.obj_func_dyn_energy = 0;
+    interface_ip.obj_func_dyn_power = 0;
+    interface_ip.obj_func_leak_power = 0;
+    interface_ip.obj_func_cycle_t = 1;
+    interface_ip.num_rw_ports = 1;
+    interface_ip.num_rd_ports = 0;
+    interface_ip.num_wr_ports = 0;
+    interface_ip.num_se_rd_ports = 0;
+    unicache.prefetchb = new ArrayST(&interface_ip, cachep.name + "PrefetchB",
+                                     device_t, true, core_t);
+    unicache.area.set_area(unicache.area.get_area() +
+                           unicache.prefetchb->local_result.area);
+    area.set_area(area.get_area() + unicache.prefetchb->local_result.area);
+    // WBB
+    tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+    data = unicache.caches->l_ip.line_sz;
+    interface_ip.specific_tag = 1;
+    interface_ip.tag_w = tag;
+    interface_ip.line_sz = data;
+    interface_ip.cache_sz = cachep.wbb_size * interface_ip.line_sz;
+    interface_ip.assoc = 0;
+    interface_ip.nbanks = 1;
+    interface_ip.out_w = interface_ip.line_sz * 8 / 2;
+    interface_ip.access_mode = 0;
+    interface_ip.throughput = cachep.throughput;
+    interface_ip.latency = cachep.latency;
+    interface_ip.obj_func_dyn_energy = 0;
+    interface_ip.obj_func_dyn_power = 0;
+    interface_ip.obj_func_leak_power = 0;
+    interface_ip.obj_func_cycle_t = 1;
+    interface_ip.num_rw_ports = 1;
+    interface_ip.num_rd_ports = 0;
+    interface_ip.num_wr_ports = 0;
+    interface_ip.num_se_rd_ports = 0;
+    unicache.wbb =
+        new ArrayST(&interface_ip, cachep.name + "WBB", device_t, true, core_t);
+    unicache.area.set_area(unicache.area.get_area() +
+                           unicache.wbb->local_result.area);
+    area.set_area(area.get_area() + unicache.wbb->local_result.area);
   }
   //  //pipeline
-//  interface_ip.pipeline_stages = int(ceil(llCache.caches.local_result.access_time/llCache.caches.local_result.cycle_time));
-//  interface_ip.per_stage_vector = llCache.caches.l_ip.out_w + llCache.caches.l_ip.tag_w ;
-//  pipeLogicCache.init_pipeline(is_default, &interface_ip);
-//  pipeLogicCache.compute_pipeline();
+  //  interface_ip.pipeline_stages =
+  //  int(ceil(llCache.caches.local_result.access_time/llCache.caches.local_result.cycle_time));
+  //  interface_ip.per_stage_vector = llCache.caches.l_ip.out_w +
+  //  llCache.caches.l_ip.tag_w ; pipeLogicCache.init_pipeline(is_default,
+  //  &interface_ip); pipeLogicCache.compute_pipeline();
 
   /*
   if (!((XML->sys.number_of_dir_levels==1 && XML->sys.first_level_dir ==1)
-		  ||(XML->sys.number_of_dir_levels==1 && XML->sys.first_level_dir ==2)))//not single level IC and DIC
+                  ||(XML->sys.number_of_dir_levels==1 &&
+  XML->sys.first_level_dir ==2)))//not single level IC and DIC
   {
   //directory Now assuming one directory per bank, TODO:should change it later
   size                             = XML->sys.L2directory.L2Dir_config[0];
   line                             = XML->sys.L2directory.L2Dir_config[1];
   assoc                            = XML->sys.L2directory.L2Dir_config[2];
   banks                            = XML->sys.L2directory.L2Dir_config[3];
-  tag							   = debug?51:XML->sys.physical_address_width + EXTRA_TAG_BITS;//TODO: a little bit over estimate
-  interface_ip.specific_tag        = 0;
-  interface_ip.tag_w               = tag;
+  tag							   =
+  debug?51:XML->sys.physical_address_width + EXTRA_TAG_BITS;//TODO: a little bit
+  over estimate interface_ip.specific_tag        = 0; interface_ip.tag_w = tag;
   interface_ip.cache_sz            = XML->sys.L2directory.L2Dir_config[0];
   interface_ip.line_sz             = XML->sys.L2directory.L2Dir_config[1];
   interface_ip.assoc               = XML->sys.L2directory.L2Dir_config[2];
   interface_ip.nbanks              = XML->sys.L2directory.L2Dir_config[3];
   interface_ip.out_w               = interface_ip.line_sz*8;
-  interface_ip.access_mode         = 0;//debug?0:XML->sys.core[ithCore].icache.icache_config[5];
-  interface_ip.throughput          = XML->sys.L2directory.L2Dir_config[4]/clockRate;
-  interface_ip.latency             = XML->sys.L2directory.L2Dir_config[5]/clockRate;
-  interface_ip.is_cache			 = true;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power  = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t    = 1;
-  interface_ip.num_rw_ports    = 1;//lower level cache usually has one port.
+  interface_ip.access_mode         =
+  0;//debug?0:XML->sys.core[ithCore].icache.icache_config[5];
+  interface_ip.throughput          =
+  XML->sys.L2directory.L2Dir_config[4]/clockRate; interface_ip.latency =
+  XML->sys.L2directory.L2Dir_config[5]/clockRate; interface_ip.is_cache
+  = true; interface_ip.obj_func_dyn_energy = 0; interface_ip.obj_func_dyn_power
+  = 0; interface_ip.obj_func_leak_power = 0; interface_ip.obj_func_cycle_t    =
+  1; interface_ip.num_rw_ports    = 1;//lower level cache usually has one port.
   interface_ip.num_rd_ports    = 0;
   interface_ip.num_wr_ports    = 0;
   interface_ip.num_se_rd_ports = 0;
@@ -291,21 +297,27 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_, InputParameter*
   //output_data_csv(directory.caches.local_result);
   ///cout<<"area="<<area<<endl;
 
-  //miss buffer Each MSHR contains enough state to handle one or more accesses of any type to a single memory line.
-  //Due to the generality of the MSHR mechanism, the amount of state involved is non-trivial,
-  //including the address, pointers to the cache entry and destination register, written data, and various other pieces of state.
-  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-  data							   = (XML->sys.physical_address_width) + int(ceil(log2(size/line))) + directory.caches.l_ip.line_sz;
-  interface_ip.specific_tag        = 1;
+  //miss buffer Each MSHR contains enough state to handle one or more accesses
+  of any type to a single memory line.
+  //Due to the generality of the MSHR mechanism, the amount of state involved is
+  non-trivial,
+  //including the address, pointers to the cache entry and destination register,
+  written data, and various other pieces of state. tag
+  = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data							   =
+  (XML->sys.physical_address_width) + int(ceil(log2(size/line))) +
+  directory.caches.l_ip.line_sz; interface_ip.specific_tag        = 1;
   interface_ip.tag_w               = tag;
-  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-  interface_ip.cache_sz            = XML->sys.L2[ithCache].buffer_sizes[0]*interface_ip.line_sz;
-  interface_ip.assoc               = 0;
-  interface_ip.nbanks              = 1;
-  interface_ip.out_w               = interface_ip.line_sz*8;
-  interface_ip.access_mode         = 0;
-  interface_ip.throughput          = XML->sys.L2[ithCache].L2_config[4]/clockRate;//means cycle time
-  interface_ip.latency             = XML->sys.L2[ithCache].L2_config[5]/clockRate;//means access time
+  interface_ip.line_sz             =
+  int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+  interface_ip.cache_sz            =
+  XML->sys.L2[ithCache].buffer_sizes[0]*interface_ip.line_sz; interface_ip.assoc
+  = 0; interface_ip.nbanks              = 1; interface_ip.out_w               =
+  interface_ip.line_sz*8; interface_ip.access_mode         = 0;
+  interface_ip.throughput          =
+  XML->sys.L2[ithCache].L2_config[4]/clockRate;//means cycle time
+  interface_ip.latency             =
+  XML->sys.L2[ithCache].L2_config[5]/clockRate;//means access time
   interface_ip.obj_func_dyn_energy = 0;
   interface_ip.obj_func_dyn_power  = 0;
   interface_ip.obj_func_leak_power = 0;
@@ -322,9 +334,9 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_, InputParameter*
   ///cout<<"area="<<area<<endl;
 
   //fill buffer
-  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-  data							   = directory.caches.l_ip.line_sz;
-  interface_ip.specific_tag        = 1;
+  tag							   =
+  XML->sys.physical_address_width + EXTRA_TAG_BITS; data
+  = directory.caches.l_ip.line_sz; interface_ip.specific_tag        = 1;
   interface_ip.tag_w               = tag;
   interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
   interface_ip.cache_sz            = data*XML->sys.L2[ithCache].buffer_sizes[1];
@@ -332,13 +344,11 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_, InputParameter*
   interface_ip.nbanks              = 1;
   interface_ip.out_w               = interface_ip.line_sz*8;
   interface_ip.access_mode         = 0;
-  interface_ip.throughput          =  XML->sys.L2[ithCache].L2_config[4]/clockRate;
-  interface_ip.latency             =  XML->sys.L2[ithCache].L2_config[5]/clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power  = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t    = 1;
-  interface_ip.num_rw_ports    = 1;
+  interface_ip.throughput          =
+  XML->sys.L2[ithCache].L2_config[4]/clockRate; interface_ip.latency =
+  XML->sys.L2[ithCache].L2_config[5]/clockRate; interface_ip.obj_func_dyn_energy
+  = 0; interface_ip.obj_func_dyn_power  = 0; interface_ip.obj_func_leak_power =
+  0; interface_ip.obj_func_cycle_t    = 1; interface_ip.num_rw_ports    = 1;
   interface_ip.num_rd_ports    = 0;
   interface_ip.num_wr_ports    = 0;
   interface_ip.num_se_rd_ports = 0;
@@ -350,23 +360,23 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_, InputParameter*
   ///cout<<"area="<<area<<endl;
 
   //prefetch buffer
-  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries to decide wthether to merge.
-  data							   = directory.caches.l_ip.line_sz;//separate queue to prevent from cache polution.
+  tag							   =
+  XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries
+  to decide wthether to merge.
+  data							   =
+  directory.caches.l_ip.line_sz;//separate queue to prevent from cache polution.
   interface_ip.specific_tag        = 1;
   interface_ip.tag_w               = tag;
   interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-  interface_ip.cache_sz            = XML->sys.L2[ithCache].buffer_sizes[2]*interface_ip.line_sz;
-  interface_ip.assoc               = 0;
-  interface_ip.nbanks              = 1;
-  interface_ip.out_w               = interface_ip.line_sz*8;
-  interface_ip.access_mode         = 0;
-  interface_ip.throughput          = XML->sys.L2[ithCache].L2_config[4]/clockRate;
-  interface_ip.latency             = XML->sys.L2[ithCache].L2_config[5]/clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power  = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t    = 1;
-  interface_ip.num_rw_ports    = 1;
+  interface_ip.cache_sz            =
+  XML->sys.L2[ithCache].buffer_sizes[2]*interface_ip.line_sz; interface_ip.assoc
+  = 0; interface_ip.nbanks              = 1; interface_ip.out_w               =
+  interface_ip.line_sz*8; interface_ip.access_mode         = 0;
+  interface_ip.throughput          =
+  XML->sys.L2[ithCache].L2_config[4]/clockRate; interface_ip.latency =
+  XML->sys.L2[ithCache].L2_config[5]/clockRate; interface_ip.obj_func_dyn_energy
+  = 0; interface_ip.obj_func_dyn_power  = 0; interface_ip.obj_func_leak_power =
+  0; interface_ip.obj_func_cycle_t    = 1; interface_ip.num_rw_ports    = 1;
   interface_ip.num_rd_ports    = 0;
   interface_ip.num_wr_ports    = 0;
   interface_ip.num_se_rd_ports = 0;
@@ -378,23 +388,20 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_, InputParameter*
   ///cout<<"area="<<area<<endl;
 
   //WBB
-  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-  data							   = directory.caches.l_ip.line_sz;
-  interface_ip.specific_tag        = 1;
+  tag							   =
+  XML->sys.physical_address_width + EXTRA_TAG_BITS; data
+  = directory.caches.l_ip.line_sz; interface_ip.specific_tag        = 1;
   interface_ip.tag_w               = tag;
   interface_ip.line_sz             = data;
-  interface_ip.cache_sz            = XML->sys.L2[ithCache].buffer_sizes[3]*interface_ip.line_sz;
-  interface_ip.assoc               = 0;
-  interface_ip.nbanks              = 1;
-  interface_ip.out_w               = interface_ip.line_sz*8;
-  interface_ip.access_mode         = 0;
-  interface_ip.throughput          = XML->sys.L2[ithCache].L2_config[4]/clockRate;
-  interface_ip.latency             = XML->sys.L2[ithCache].L2_config[4]/clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power  = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t    = 1;
-  interface_ip.num_rw_ports    = 1;
+  interface_ip.cache_sz            =
+  XML->sys.L2[ithCache].buffer_sizes[3]*interface_ip.line_sz; interface_ip.assoc
+  = 0; interface_ip.nbanks              = 1; interface_ip.out_w               =
+  interface_ip.line_sz*8; interface_ip.access_mode         = 0;
+  interface_ip.throughput          =
+  XML->sys.L2[ithCache].L2_config[4]/clockRate; interface_ip.latency =
+  XML->sys.L2[ithCache].L2_config[4]/clockRate; interface_ip.obj_func_dyn_energy
+  = 0; interface_ip.obj_func_dyn_power  = 0; interface_ip.obj_func_leak_power =
+  0; interface_ip.obj_func_cycle_t    = 1; interface_ip.num_rw_ports    = 1;
   interface_ip.num_rd_ports    = 0;
   interface_ip.num_wr_ports    = 0;
   interface_ip.num_se_rd_ports = 0;
@@ -407,27 +414,26 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_, InputParameter*
   if (XML->sys.number_of_dir_levels ==2 && XML->sys.first_level_dir==0)
   {
   //first level directory
-  size                             = XML->sys.L2directory.L2Dir_config[0]*XML->sys.domain_size/128;
-  line                             = int(ceil(XML->sys.domain_size/8.0));
-  assoc                            = XML->sys.L2directory.L2Dir_config[2];
-  banks                            = XML->sys.L2directory.L2Dir_config[3];
-  tag							   = debug?51:XML->sys.physical_address_width + EXTRA_TAG_BITS;//TODO: a little bit over estimate
-  interface_ip.specific_tag        = 1;
-  interface_ip.tag_w               = tag;
-  interface_ip.cache_sz            = XML->sys.L2directory.L2Dir_config[0];
+  size                             =
+  XML->sys.L2directory.L2Dir_config[0]*XML->sys.domain_size/128; line =
+  int(ceil(XML->sys.domain_size/8.0)); assoc                            =
+  XML->sys.L2directory.L2Dir_config[2]; banks                            =
+  XML->sys.L2directory.L2Dir_config[3]; tag
+  = debug?51:XML->sys.physical_address_width + EXTRA_TAG_BITS;//TODO: a little
+  bit over estimate interface_ip.specific_tag        = 1; interface_ip.tag_w =
+  tag; interface_ip.cache_sz            = XML->sys.L2directory.L2Dir_config[0];
   interface_ip.line_sz             = XML->sys.L2directory.L2Dir_config[1];
   interface_ip.assoc               = XML->sys.L2directory.L2Dir_config[2];
   interface_ip.nbanks              = XML->sys.L2directory.L2Dir_config[3];
   interface_ip.out_w               = interface_ip.line_sz*8;
-  interface_ip.access_mode         = 0;//debug?0:XML->sys.core[ithCore].icache.icache_config[5];
-  interface_ip.throughput          = XML->sys.L2directory.L2Dir_config[4]/clockRate;
-  interface_ip.latency             = XML->sys.L2directory.L2Dir_config[5]/clockRate;
-  interface_ip.is_cache			 = true;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power  = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t    = 1;
-  interface_ip.num_rw_ports    = 1;//lower level cache usually has one port.
+  interface_ip.access_mode         =
+  0;//debug?0:XML->sys.core[ithCore].icache.icache_config[5];
+  interface_ip.throughput          =
+  XML->sys.L2directory.L2Dir_config[4]/clockRate; interface_ip.latency =
+  XML->sys.L2directory.L2Dir_config[5]/clockRate; interface_ip.is_cache
+  = true; interface_ip.obj_func_dyn_energy = 0; interface_ip.obj_func_dyn_power
+  = 0; interface_ip.obj_func_leak_power = 0; interface_ip.obj_func_cycle_t    =
+  1; interface_ip.num_rw_ports    = 1;//lower level cache usually has one port.
   interface_ip.num_rd_ports    = 0;
   interface_ip.num_wr_ports    = 0;
   interface_ip.num_se_rd_ports = 0;
@@ -439,21 +445,27 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_, InputParameter*
   //output_data_csv(directory.caches.local_result);
   ///cout<<"area="<<area<<endl;
 
-  //miss buffer Each MSHR contains enough state to handle one or more accesses of any type to a single memory line.
-  //Due to the generality of the MSHR mechanism, the amount of state involved is non-trivial,
-  //including the address, pointers to the cache entry and destination register, written data, and various other pieces of state.
-  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-  data							   = (XML->sys.physical_address_width) + int(ceil(log2(size/line))) + directory1.caches.l_ip.line_sz;
-  interface_ip.specific_tag        = 1;
+  //miss buffer Each MSHR contains enough state to handle one or more accesses
+  of any type to a single memory line.
+  //Due to the generality of the MSHR mechanism, the amount of state involved is
+  non-trivial,
+  //including the address, pointers to the cache entry and destination register,
+  written data, and various other pieces of state. tag
+  = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data							   =
+  (XML->sys.physical_address_width) + int(ceil(log2(size/line))) +
+  directory1.caches.l_ip.line_sz; interface_ip.specific_tag        = 1;
   interface_ip.tag_w               = tag;
-  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-  interface_ip.cache_sz            = XML->sys.L2[ithCache].buffer_sizes[0]*interface_ip.line_sz;
-  interface_ip.assoc               = 0;
-  interface_ip.nbanks              = 1;
-  interface_ip.out_w               = interface_ip.line_sz*8;
-  interface_ip.access_mode         = 0;
-  interface_ip.throughput          = XML->sys.L2[ithCache].L2_config[4]/clockRate;//means cycle time
-  interface_ip.latency             = XML->sys.L2[ithCache].L2_config[5]/clockRate;//means access time
+  interface_ip.line_sz             =
+  int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+  interface_ip.cache_sz            =
+  XML->sys.L2[ithCache].buffer_sizes[0]*interface_ip.line_sz; interface_ip.assoc
+  = 0; interface_ip.nbanks              = 1; interface_ip.out_w               =
+  interface_ip.line_sz*8; interface_ip.access_mode         = 0;
+  interface_ip.throughput          =
+  XML->sys.L2[ithCache].L2_config[4]/clockRate;//means cycle time
+  interface_ip.latency             =
+  XML->sys.L2[ithCache].L2_config[5]/clockRate;//means access time
   interface_ip.obj_func_dyn_energy = 0;
   interface_ip.obj_func_dyn_power  = 0;
   interface_ip.obj_func_leak_power = 0;
@@ -470,9 +482,9 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_, InputParameter*
   ///cout<<"area="<<area<<endl;
 
   //fill buffer
-  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-  data							   = directory1.caches.l_ip.line_sz;
-  interface_ip.specific_tag        = 1;
+  tag							   =
+  XML->sys.physical_address_width + EXTRA_TAG_BITS; data
+  = directory1.caches.l_ip.line_sz; interface_ip.specific_tag        = 1;
   interface_ip.tag_w               = tag;
   interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
   interface_ip.cache_sz            = data*XML->sys.L2[ithCache].buffer_sizes[1];
@@ -480,13 +492,11 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_, InputParameter*
   interface_ip.nbanks              = 1;
   interface_ip.out_w               = interface_ip.line_sz*8;
   interface_ip.access_mode         = 0;
-  interface_ip.throughput          =  XML->sys.L2[ithCache].L2_config[4]/clockRate;
-  interface_ip.latency             =  XML->sys.L2[ithCache].L2_config[5]/clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power  = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t    = 1;
-  interface_ip.num_rw_ports    = 1;
+  interface_ip.throughput          =
+  XML->sys.L2[ithCache].L2_config[4]/clockRate; interface_ip.latency =
+  XML->sys.L2[ithCache].L2_config[5]/clockRate; interface_ip.obj_func_dyn_energy
+  = 0; interface_ip.obj_func_dyn_power  = 0; interface_ip.obj_func_leak_power =
+  0; interface_ip.obj_func_cycle_t    = 1; interface_ip.num_rw_ports    = 1;
   interface_ip.num_rd_ports    = 0;
   interface_ip.num_wr_ports    = 0;
   interface_ip.num_se_rd_ports = 0;
@@ -498,23 +508,22 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_, InputParameter*
   ///cout<<"area="<<area<<endl;
 
   //prefetch buffer
-  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries to decide wthether to merge.
-  data							   = directory1.caches.l_ip.line_sz;//separate queue to prevent from cache polution.
-  interface_ip.specific_tag        = 1;
-  interface_ip.tag_w               = tag;
+  tag							   =
+  XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries
+  to decide wthether to merge.
+  data							   =
+  directory1.caches.l_ip.line_sz;//separate queue to prevent from cache
+  polution. interface_ip.specific_tag        = 1; interface_ip.tag_w = tag;
   interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-  interface_ip.cache_sz            = XML->sys.L2[ithCache].buffer_sizes[2]*interface_ip.line_sz;
-  interface_ip.assoc               = 0;
-  interface_ip.nbanks              = 1;
-  interface_ip.out_w               = interface_ip.line_sz*8;
-  interface_ip.access_mode         = 0;
-  interface_ip.throughput          = XML->sys.L2[ithCache].L2_config[4]/clockRate;
-  interface_ip.latency             = XML->sys.L2[ithCache].L2_config[5]/clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power  = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t    = 1;
-  interface_ip.num_rw_ports    = 1;
+  interface_ip.cache_sz            =
+  XML->sys.L2[ithCache].buffer_sizes[2]*interface_ip.line_sz; interface_ip.assoc
+  = 0; interface_ip.nbanks              = 1; interface_ip.out_w               =
+  interface_ip.line_sz*8; interface_ip.access_mode         = 0;
+  interface_ip.throughput          =
+  XML->sys.L2[ithCache].L2_config[4]/clockRate; interface_ip.latency =
+  XML->sys.L2[ithCache].L2_config[5]/clockRate; interface_ip.obj_func_dyn_energy
+  = 0; interface_ip.obj_func_dyn_power  = 0; interface_ip.obj_func_leak_power =
+  0; interface_ip.obj_func_cycle_t    = 1; interface_ip.num_rw_ports    = 1;
   interface_ip.num_rd_ports    = 0;
   interface_ip.num_wr_ports    = 0;
   interface_ip.num_se_rd_ports = 0;
@@ -526,23 +535,20 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_, InputParameter*
   ///cout<<"area="<<area<<endl;
 
   //WBB
-  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-  data							   = directory1.caches.l_ip.line_sz;
-  interface_ip.specific_tag        = 1;
+  tag							   =
+  XML->sys.physical_address_width + EXTRA_TAG_BITS; data
+  = directory1.caches.l_ip.line_sz; interface_ip.specific_tag        = 1;
   interface_ip.tag_w               = tag;
   interface_ip.line_sz             = data;
-  interface_ip.cache_sz            = XML->sys.L2[ithCache].buffer_sizes[3]*interface_ip.line_sz;
-  interface_ip.assoc               = 0;
-  interface_ip.nbanks              = 1;
-  interface_ip.out_w               = interface_ip.line_sz*8;
-  interface_ip.access_mode         = 0;
-  interface_ip.throughput          = XML->sys.L2[ithCache].L2_config[4]/clockRate;
-  interface_ip.latency             = XML->sys.L2[ithCache].L2_config[5]/clockRate;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power  = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t    = 1;
-  interface_ip.num_rw_ports    = 1;
+  interface_ip.cache_sz            =
+  XML->sys.L2[ithCache].buffer_sizes[3]*interface_ip.line_sz; interface_ip.assoc
+  = 0; interface_ip.nbanks              = 1; interface_ip.out_w               =
+  interface_ip.line_sz*8; interface_ip.access_mode         = 0;
+  interface_ip.throughput          =
+  XML->sys.L2[ithCache].L2_config[4]/clockRate; interface_ip.latency =
+  XML->sys.L2[ithCache].L2_config[5]/clockRate; interface_ip.obj_func_dyn_energy
+  = 0; interface_ip.obj_func_dyn_power  = 0; interface_ip.obj_func_leak_power =
+  0; interface_ip.obj_func_cycle_t    = 1; interface_ip.num_rw_ports    = 1;
   interface_ip.num_rd_ports    = 0;
   interface_ip.num_wr_ports    = 0;
   interface_ip.num_se_rd_ports = 0;
@@ -554,357 +560,462 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_, InputParameter*
 
   if (XML->sys.first_level_dir==1)//IC
   {
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  data							   = int(ceil(XML->sys.domain_size/8.0));
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = data;
-	  interface_ip.cache_sz            = XML->sys.domain_size*data*XML->sys.L2[ithCache].L2_config[0]/XML->sys.L2[ithCache].L2_config[1];
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1024;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 0;
-	  interface_ip.throughput          = XML->sys.L2[ithCache].L2_config[4]/clockRate;
-	  interface_ip.latency             = XML->sys.L2[ithCache].L2_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = 1;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  strcpy(inv_dir.caches.name,"inv_dir");
-	  inv_dir.caches.init_cache(&interface_ip);
-	  inv_dir.caches.optimize_array();
-	  inv_dir.area = inv_dir.caches.local_result.area;
+          tag							   =
+  XML->sys.physical_address_width + EXTRA_TAG_BITS; data
+  = int(ceil(XML->sys.domain_size/8.0)); interface_ip.specific_tag        = 1;
+          interface_ip.tag_w               = tag;
+          interface_ip.line_sz             = data;
+          interface_ip.cache_sz            =
+  XML->sys.domain_size*data*XML->sys.L2[ithCache].L2_config[0]/XML->sys.L2[ithCache].L2_config[1];
+          interface_ip.assoc               = 0;
+          interface_ip.nbanks              = 1024;
+          interface_ip.out_w               = interface_ip.line_sz*8;
+          interface_ip.access_mode         = 0;
+          interface_ip.throughput          =
+  XML->sys.L2[ithCache].L2_config[4]/clockRate; interface_ip.latency =
+  XML->sys.L2[ithCache].L2_config[5]/clockRate; interface_ip.obj_func_dyn_energy
+  = 0; interface_ip.obj_func_dyn_power  = 0; interface_ip.obj_func_leak_power =
+  0; interface_ip.obj_func_cycle_t    = 1; interface_ip.num_rw_ports    = 1;
+          interface_ip.num_rd_ports    = 0;
+          interface_ip.num_wr_ports    = 0;
+          interface_ip.num_se_rd_ports = 0;
+          strcpy(inv_dir.caches.name,"inv_dir");
+          inv_dir.caches.init_cache(&interface_ip);
+          inv_dir.caches.optimize_array();
+          inv_dir.area = inv_dir.caches.local_result.area;
 
   }
 */
-//  //pipeline
-//  interface_ip.pipeline_stages = int(ceil(directory.caches.local_result.access_time/directory.caches.local_result.cycle_time));
-//  interface_ip.per_stage_vector = directory.caches.l_ip.out_w + directory.caches.l_ip.tag_w ;
-//  pipeLogicDirectory.init_pipeline(is_default, &interface_ip);
-//  pipeLogicDirectory.compute_pipeline();
-//
-//  //clock power
-//  clockNetwork.init_wire_external(is_default, &interface_ip);
-//  clockNetwork.clk_area           =area*1.1;//10% of placement overhead. rule of thumb
-//  clockNetwork.end_wiring_level   =5;//toplevel metal
-//  clockNetwork.start_wiring_level =5;//toplevel metal
-//  clockNetwork.num_regs           = pipeLogicCache.tot_stage_vector + pipeLogicDirectory.tot_stage_vector;
-//  clockNetwork.optimize_wire();
-
+  //  //pipeline
+  //  interface_ip.pipeline_stages =
+  //  int(ceil(directory.caches.local_result.access_time/directory.caches.local_result.cycle_time));
+  //  interface_ip.per_stage_vector = directory.caches.l_ip.out_w +
+  //  directory.caches.l_ip.tag_w ; pipeLogicDirectory.init_pipeline(is_default,
+  //  &interface_ip); pipeLogicDirectory.compute_pipeline();
+  //
+  //  //clock power
+  //  clockNetwork.init_wire_external(is_default, &interface_ip);
+  //  clockNetwork.clk_area           =area*1.1;//10% of placement overhead.
+  //  rule of thumb clockNetwork.end_wiring_level   =5;//toplevel metal
+  //  clockNetwork.start_wiring_level =5;//toplevel metal
+  //  clockNetwork.num_regs           = pipeLogicCache.tot_stage_vector +
+  //  pipeLogicDirectory.tot_stage_vector; clockNetwork.optimize_wire();
 }
 
+void SharedCache::computeEnergy(bool is_tdp) {
+  double homenode_data_access = (cachep.dir_ty == SBT) ? 0.9 : 1.0;
+  if (is_tdp) {
+    if (!((cachep.dir_ty == ST && cacheL == L1Directory) ||
+          (cachep.dir_ty == ST && cacheL == L2Directory))) {
+      // init stats for Peak
+      unicache.caches->stats_t.readAc.access =
+          .67 * unicache.caches->l_ip.num_rw_ports * cachep.duty_cycle *
+          homenode_data_access;
+      unicache.caches->stats_t.readAc.miss = 0;
+      unicache.caches->stats_t.readAc.hit =
+          unicache.caches->stats_t.readAc.access -
+          unicache.caches->stats_t.readAc.miss;
+      unicache.caches->stats_t.writeAc.access =
+          .33 * unicache.caches->l_ip.num_rw_ports * cachep.duty_cycle *
+          homenode_data_access;
+      unicache.caches->stats_t.writeAc.miss = 0;
+      unicache.caches->stats_t.writeAc.hit =
+          unicache.caches->stats_t.writeAc.access -
+          unicache.caches->stats_t.writeAc.miss;
+      unicache.caches->tdp_stats = unicache.caches->stats_t;
 
-void SharedCache::computeEnergy(bool is_tdp)
-{
-	double homenode_data_access = (cachep.dir_ty==SBT)? 0.9:1.0;
-	if (is_tdp)
-	{
-		if (!((cachep.dir_ty==ST&& cacheL==L1Directory)||(cachep.dir_ty==ST&& cacheL==L2Directory)))
-		{
-			//init stats for Peak
-			unicache.caches->stats_t.readAc.access  = .67*unicache.caches->l_ip.num_rw_ports*cachep.duty_cycle*homenode_data_access;
-			unicache.caches->stats_t.readAc.miss    = 0;
-			unicache.caches->stats_t.readAc.hit     = unicache.caches->stats_t.readAc.access - unicache.caches->stats_t.readAc.miss;
-			unicache.caches->stats_t.writeAc.access = .33*unicache.caches->l_ip.num_rw_ports*cachep.duty_cycle*homenode_data_access;
-			unicache.caches->stats_t.writeAc.miss   = 0;
-			unicache.caches->stats_t.writeAc.hit    = unicache.caches->stats_t.writeAc.access -	unicache.caches->stats_t.writeAc.miss;
-			unicache.caches->tdp_stats = unicache.caches->stats_t;
+      if (cachep.dir_ty == SBT) {
+        homenode_stats_t.readAc.access =
+            .67 * unicache.caches->l_ip.num_rw_ports * cachep.dir_duty_cycle *
+            (1 - homenode_data_access);
+        homenode_stats_t.readAc.miss = 0;
+        homenode_stats_t.readAc.hit =
+            homenode_stats_t.readAc.access - homenode_stats_t.readAc.miss;
+        homenode_stats_t.writeAc.access =
+            .67 * unicache.caches->l_ip.num_rw_ports * cachep.dir_duty_cycle *
+            (1 - homenode_data_access);
+        homenode_stats_t.writeAc.miss = 0;
+        homenode_stats_t.writeAc.hit =
+            homenode_stats_t.writeAc.access - homenode_stats_t.writeAc.miss;
+        homenode_tdp_stats = homenode_stats_t;
+      }
 
-			if (cachep.dir_ty==SBT)
-			{
-				homenode_stats_t.readAc.access  = .67*unicache.caches->l_ip.num_rw_ports*cachep.dir_duty_cycle*(1-homenode_data_access);
-				homenode_stats_t.readAc.miss    = 0;
-				homenode_stats_t.readAc.hit     = homenode_stats_t.readAc.access - homenode_stats_t.readAc.miss;
-				homenode_stats_t.writeAc.access  = .67*unicache.caches->l_ip.num_rw_ports*cachep.dir_duty_cycle*(1-homenode_data_access);
-				homenode_stats_t.writeAc.miss   = 0;
-				homenode_stats_t.writeAc.hit    = homenode_stats_t.writeAc.access -	homenode_stats_t.writeAc.miss;
-				homenode_tdp_stats = homenode_stats_t;
-			}
+      unicache.missb->stats_t.readAc.access =
+          unicache.missb->l_ip.num_search_ports;
+      unicache.missb->stats_t.writeAc.access =
+          unicache.missb->l_ip.num_search_ports;
+      unicache.missb->tdp_stats = unicache.missb->stats_t;
 
-			unicache.missb->stats_t.readAc.access  = unicache.missb->l_ip.num_search_ports;
-			unicache.missb->stats_t.writeAc.access = unicache.missb->l_ip.num_search_ports;
-			unicache.missb->tdp_stats = unicache.missb->stats_t;
+      unicache.ifb->stats_t.readAc.access = unicache.ifb->l_ip.num_search_ports;
+      unicache.ifb->stats_t.writeAc.access =
+          unicache.ifb->l_ip.num_search_ports;
+      unicache.ifb->tdp_stats = unicache.ifb->stats_t;
 
-			unicache.ifb->stats_t.readAc.access  = unicache.ifb->l_ip.num_search_ports;
-			unicache.ifb->stats_t.writeAc.access = unicache.ifb->l_ip.num_search_ports;
-			unicache.ifb->tdp_stats = unicache.ifb->stats_t;
+      unicache.prefetchb->stats_t.readAc.access =
+          unicache.prefetchb->l_ip.num_search_ports;
+      unicache.prefetchb->stats_t.writeAc.access =
+          unicache.ifb->l_ip.num_search_ports;
+      unicache.prefetchb->tdp_stats = unicache.prefetchb->stats_t;
 
-			unicache.prefetchb->stats_t.readAc.access  = unicache.prefetchb->l_ip.num_search_ports;
-			unicache.prefetchb->stats_t.writeAc.access = unicache.ifb->l_ip.num_search_ports;
-			unicache.prefetchb->tdp_stats = unicache.prefetchb->stats_t;
+      unicache.wbb->stats_t.readAc.access = unicache.wbb->l_ip.num_search_ports;
+      unicache.wbb->stats_t.writeAc.access =
+          unicache.wbb->l_ip.num_search_ports;
+      unicache.wbb->tdp_stats = unicache.wbb->stats_t;
+    } else {
+      unicache.caches->stats_t.readAc.access =
+          unicache.caches->l_ip.num_search_ports * cachep.duty_cycle;
+      unicache.caches->stats_t.readAc.miss = 0;
+      unicache.caches->stats_t.readAc.hit =
+          unicache.caches->stats_t.readAc.access -
+          unicache.caches->stats_t.readAc.miss;
+      unicache.caches->stats_t.writeAc.access = 0;
+      unicache.caches->stats_t.writeAc.miss = 0;
+      unicache.caches->stats_t.writeAc.hit =
+          unicache.caches->stats_t.writeAc.access -
+          unicache.caches->stats_t.writeAc.miss;
+      unicache.caches->tdp_stats = unicache.caches->stats_t;
+    }
 
-			unicache.wbb->stats_t.readAc.access  = unicache.wbb->l_ip.num_search_ports;
-			unicache.wbb->stats_t.writeAc.access = unicache.wbb->l_ip.num_search_ports;
-			unicache.wbb->tdp_stats = unicache.wbb->stats_t;
-		}
-		else
-		{
-			unicache.caches->stats_t.readAc.access  = unicache.caches->l_ip.num_search_ports*cachep.duty_cycle;
-			unicache.caches->stats_t.readAc.miss    = 0;
-			unicache.caches->stats_t.readAc.hit     = unicache.caches->stats_t.readAc.access - unicache.caches->stats_t.readAc.miss;
-			unicache.caches->stats_t.writeAc.access = 0;
-			unicache.caches->stats_t.writeAc.miss   = 0;
-			unicache.caches->stats_t.writeAc.hit    = unicache.caches->stats_t.writeAc.access -	unicache.caches->stats_t.writeAc.miss;
-			unicache.caches->tdp_stats = unicache.caches->stats_t;
+  } else {
+    // init stats for runtime power (RTP)
+    if (cacheL == L2) {
+      // Copy stats from l1 to L1[0]
+      XML->sys.L2[ithCache].total_accesses = XML->sys.l2.total_accesses;
+      XML->sys.L2[ithCache].read_accesses = XML->sys.l2.read_accesses;
+      XML->sys.L2[ithCache].write_accesses = XML->sys.l2.write_accesses;
+      XML->sys.L2[ithCache].read_hits = XML->sys.l2.read_hits;
+      XML->sys.L2[ithCache].read_misses = XML->sys.l2.read_misses;
+      XML->sys.L2[ithCache].write_hits = XML->sys.l2.write_hits;
+      XML->sys.L2[ithCache].write_misses = XML->sys.l2.write_misses;
 
-		}
+      unicache.caches->stats_t.readAc.access =
+          XML->sys.L2[ithCache].read_accesses;
+      unicache.caches->stats_t.readAc.miss = XML->sys.L2[ithCache].read_misses;
+      unicache.caches->stats_t.readAc.hit =
+          unicache.caches->stats_t.readAc.access -
+          unicache.caches->stats_t.readAc.miss;
+      unicache.caches->stats_t.writeAc.access =
+          XML->sys.L2[ithCache].write_accesses;
+      unicache.caches->stats_t.writeAc.miss =
+          XML->sys.L2[ithCache].write_misses;
+      unicache.caches->stats_t.writeAc.hit =
+          unicache.caches->stats_t.writeAc.access -
+          unicache.caches->stats_t.writeAc.miss;
+      unicache.caches->rtp_stats = unicache.caches->stats_t;
 
-	}
-	else
-	{
-		//init stats for runtime power (RTP)
-		if (cacheL==L2)
-		{
-		  //Copy stats from l1 to L1[0]
-		  XML->sys.L2[ithCache].total_accesses=XML->sys.l2.total_accesses;
-		  XML->sys.L2[ithCache].read_accesses=XML->sys.l2.read_accesses;
-		  XML->sys.L2[ithCache].write_accesses=XML->sys.l2.write_accesses;
-		  XML->sys.L2[ithCache].read_hits=XML->sys.l2.read_hits;
-		  XML->sys.L2[ithCache].read_misses=XML->sys.l2.read_misses;
-		  XML->sys.L2[ithCache].write_hits=XML->sys.l2.write_hits;
-		  XML->sys.L2[ithCache].write_misses=XML->sys.l2.write_misses;
+      if (cachep.dir_ty == SBT) {
+        homenode_rtp_stats.readAc.access =
+            XML->sys.L2[ithCache].homenode_read_accesses;
+        homenode_rtp_stats.readAc.miss =
+            XML->sys.L2[ithCache].homenode_read_misses;
+        homenode_rtp_stats.readAc.hit =
+            homenode_rtp_stats.readAc.access - homenode_rtp_stats.readAc.miss;
+        homenode_rtp_stats.writeAc.access =
+            XML->sys.L2[ithCache].homenode_write_accesses;
+        homenode_rtp_stats.writeAc.miss =
+            XML->sys.L2[ithCache].homenode_write_misses;
+        homenode_rtp_stats.writeAc.hit =
+            homenode_rtp_stats.writeAc.access - homenode_rtp_stats.writeAc.miss;
+      }
+    } else if (cacheL == L3) {
+      unicache.caches->stats_t.readAc.access =
+          XML->sys.L3[ithCache].read_accesses;
+      unicache.caches->stats_t.readAc.miss = XML->sys.L3[ithCache].read_misses;
+      unicache.caches->stats_t.readAc.hit =
+          unicache.caches->stats_t.readAc.access -
+          unicache.caches->stats_t.readAc.miss;
+      unicache.caches->stats_t.writeAc.access =
+          XML->sys.L3[ithCache].write_accesses;
+      unicache.caches->stats_t.writeAc.miss =
+          XML->sys.L3[ithCache].write_misses;
+      unicache.caches->stats_t.writeAc.hit =
+          unicache.caches->stats_t.writeAc.access -
+          unicache.caches->stats_t.writeAc.miss;
+      unicache.caches->rtp_stats = unicache.caches->stats_t;
 
-		  unicache.caches->stats_t.readAc.access  = XML->sys.L2[ithCache].read_accesses;
-		  unicache.caches->stats_t.readAc.miss    = XML->sys.L2[ithCache].read_misses;
-		  unicache.caches->stats_t.readAc.hit     = unicache.caches->stats_t.readAc.access - unicache.caches->stats_t.readAc.miss;
-		  unicache.caches->stats_t.writeAc.access = XML->sys.L2[ithCache].write_accesses;
-		  unicache.caches->stats_t.writeAc.miss   = XML->sys.L2[ithCache].write_misses;
-		  unicache.caches->stats_t.writeAc.hit    = unicache.caches->stats_t.writeAc.access -	unicache.caches->stats_t.writeAc.miss;
-		  unicache.caches->rtp_stats = unicache.caches->stats_t;
+      if (cachep.dir_ty == SBT) {
+        homenode_rtp_stats.readAc.access =
+            XML->sys.L3[ithCache].homenode_read_accesses;
+        homenode_rtp_stats.readAc.miss =
+            XML->sys.L3[ithCache].homenode_read_misses;
+        homenode_rtp_stats.readAc.hit =
+            homenode_rtp_stats.readAc.access - homenode_rtp_stats.readAc.miss;
+        homenode_rtp_stats.writeAc.access =
+            XML->sys.L3[ithCache].homenode_write_accesses;
+        homenode_rtp_stats.writeAc.miss =
+            XML->sys.L3[ithCache].homenode_write_misses;
+        homenode_rtp_stats.writeAc.hit =
+            homenode_rtp_stats.writeAc.access - homenode_rtp_stats.writeAc.miss;
+      }
+    } else if (cacheL == L1Directory) {
+      unicache.caches->stats_t.readAc.access =
+          XML->sys.L1Directory[ithCache].read_accesses;
+      unicache.caches->stats_t.readAc.miss =
+          XML->sys.L1Directory[ithCache].read_misses;
+      unicache.caches->stats_t.readAc.hit =
+          unicache.caches->stats_t.readAc.access -
+          unicache.caches->stats_t.readAc.miss;
+      unicache.caches->stats_t.writeAc.access =
+          XML->sys.L1Directory[ithCache].write_accesses;
+      unicache.caches->stats_t.writeAc.miss =
+          XML->sys.L1Directory[ithCache].write_misses;
+      unicache.caches->stats_t.writeAc.hit =
+          unicache.caches->stats_t.writeAc.access -
+          unicache.caches->stats_t.writeAc.miss;
+      unicache.caches->rtp_stats = unicache.caches->stats_t;
+    } else if (cacheL == L2Directory) {  // cout<<"L2 directory"<<endl;
+      // Copy stats from l1 to L1[0]
+      // XML->sys.L2[ithCache].total_accesses=XML->sys.l2.total_accesses;
+      // XML->sys.L2[ithCache].read_accesses=XML->sys.l2.read_accesses;
+      // XML->sys.L2[ithCache].write_accesses=XML->sys.l2.write_accesses;
+      // XML->sys.L2[ithCache].read_hits=XML->sys.l2.read_hits;
+      // XML->sys.L2[ithCache].read_misses=XML->sys.l2.read_misses;
+      // XML->sys.L2[ithCache].write_hits=XML->sys.l2.write_hits;
+      // XML->sys.L2[ithCache].write_misses=XML->sys.l2.write_misses;
+      unicache.caches->stats_t.readAc.access =
+          XML->sys.L2Directory[ithCache].read_accesses;
+      unicache.caches->stats_t.readAc.miss =
+          XML->sys.L2Directory[ithCache].read_misses;
+      unicache.caches->stats_t.readAc.hit =
+          unicache.caches->stats_t.readAc.access -
+          unicache.caches->stats_t.readAc.miss;
+      unicache.caches->stats_t.writeAc.access =
+          XML->sys.L2Directory[ithCache].write_accesses;
+      unicache.caches->stats_t.writeAc.miss =
+          XML->sys.L2Directory[ithCache].write_misses;
+      unicache.caches->stats_t.writeAc.hit =
+          unicache.caches->stats_t.writeAc.access -
+          unicache.caches->stats_t.writeAc.miss;
+      unicache.caches->rtp_stats = unicache.caches->stats_t;
+    }
+    if (!((cachep.dir_ty == ST && cacheL == L1Directory) ||
+          (cachep.dir_ty == ST &&
+           cacheL ==
+               L2Directory))) {  // Assuming write back and write-allocate cache
 
-		  if (cachep.dir_ty==SBT)
-		  {
-			 homenode_rtp_stats.readAc.access  = XML->sys.L2[ithCache].homenode_read_accesses;
-			 homenode_rtp_stats.readAc.miss    = XML->sys.L2[ithCache].homenode_read_misses;
-			 homenode_rtp_stats.readAc.hit     = homenode_rtp_stats.readAc.access - homenode_rtp_stats.readAc.miss;
-			 homenode_rtp_stats.writeAc.access = XML->sys.L2[ithCache].homenode_write_accesses;
-			 homenode_rtp_stats.writeAc.miss   = XML->sys.L2[ithCache].homenode_write_misses;
-			 homenode_rtp_stats.writeAc.hit    = homenode_rtp_stats.writeAc.access -	homenode_rtp_stats.writeAc.miss;
-		  }
-		}
-		else if (cacheL==L3)
-		{
-		  unicache.caches->stats_t.readAc.access  = XML->sys.L3[ithCache].read_accesses;
-		  unicache.caches->stats_t.readAc.miss    = XML->sys.L3[ithCache].read_misses;
-		  unicache.caches->stats_t.readAc.hit     = unicache.caches->stats_t.readAc.access - unicache.caches->stats_t.readAc.miss;
-		  unicache.caches->stats_t.writeAc.access = XML->sys.L3[ithCache].write_accesses;
-		  unicache.caches->stats_t.writeAc.miss   = XML->sys.L3[ithCache].write_misses;
-		  unicache.caches->stats_t.writeAc.hit    = unicache.caches->stats_t.writeAc.access -	unicache.caches->stats_t.writeAc.miss;
-		  unicache.caches->rtp_stats = unicache.caches->stats_t;
+      unicache.missb->stats_t.readAc.access =
+          unicache.caches->stats_t.writeAc.miss;
+      unicache.missb->stats_t.writeAc.access =
+          unicache.caches->stats_t.writeAc.miss;
+      unicache.missb->rtp_stats = unicache.missb->stats_t;
 
-		  if (cachep.dir_ty==SBT)
-		  {
-			 homenode_rtp_stats.readAc.access  = XML->sys.L3[ithCache].homenode_read_accesses;
-			 homenode_rtp_stats.readAc.miss    = XML->sys.L3[ithCache].homenode_read_misses;
-			 homenode_rtp_stats.readAc.hit     = homenode_rtp_stats.readAc.access - homenode_rtp_stats.readAc.miss;
-			 homenode_rtp_stats.writeAc.access = XML->sys.L3[ithCache].homenode_write_accesses;
-			 homenode_rtp_stats.writeAc.miss   = XML->sys.L3[ithCache].homenode_write_misses;
-			 homenode_rtp_stats.writeAc.hit    = homenode_rtp_stats.writeAc.access -	homenode_rtp_stats.writeAc.miss;
-		  }
-		}
-		else if (cacheL==L1Directory)
-		{
-		  unicache.caches->stats_t.readAc.access  = XML->sys.L1Directory[ithCache].read_accesses;
-		  unicache.caches->stats_t.readAc.miss    = XML->sys.L1Directory[ithCache].read_misses;
-		  unicache.caches->stats_t.readAc.hit     = unicache.caches->stats_t.readAc.access - unicache.caches->stats_t.readAc.miss;
-		  unicache.caches->stats_t.writeAc.access = XML->sys.L1Directory[ithCache].write_accesses;
-		  unicache.caches->stats_t.writeAc.miss   = XML->sys.L1Directory[ithCache].write_misses;
-		  unicache.caches->stats_t.writeAc.hit    = unicache.caches->stats_t.writeAc.access -	unicache.caches->stats_t.writeAc.miss;
-		  unicache.caches->rtp_stats = unicache.caches->stats_t;
-		}
-		else if (cacheL==L2Directory)
-		{ //cout<<"L2 directory"<<endl;
-		  //Copy stats from l1 to L1[0]
-		  //XML->sys.L2[ithCache].total_accesses=XML->sys.l2.total_accesses;
-		  //XML->sys.L2[ithCache].read_accesses=XML->sys.l2.read_accesses;
-		  //XML->sys.L2[ithCache].write_accesses=XML->sys.l2.write_accesses;
-		  //XML->sys.L2[ithCache].read_hits=XML->sys.l2.read_hits;
-		  //XML->sys.L2[ithCache].read_misses=XML->sys.l2.read_misses;
-		  //XML->sys.L2[ithCache].write_hits=XML->sys.l2.write_hits;
-		  //XML->sys.L2[ithCache].write_misses=XML->sys.l2.write_misses;
-		  unicache.caches->stats_t.readAc.access  = XML->sys.L2Directory[ithCache].read_accesses;
-		  unicache.caches->stats_t.readAc.miss    = XML->sys.L2Directory[ithCache].read_misses;
-		  unicache.caches->stats_t.readAc.hit     = unicache.caches->stats_t.readAc.access - unicache.caches->stats_t.readAc.miss;
-		  unicache.caches->stats_t.writeAc.access = XML->sys.L2Directory[ithCache].write_accesses;
-		  unicache.caches->stats_t.writeAc.miss   = XML->sys.L2Directory[ithCache].write_misses;
-		  unicache.caches->stats_t.writeAc.hit    = unicache.caches->stats_t.writeAc.access -	unicache.caches->stats_t.writeAc.miss;
-		  unicache.caches->rtp_stats = unicache.caches->stats_t;
-		}
-		if (!((cachep.dir_ty==ST&& cacheL==L1Directory)||(cachep.dir_ty==ST&& cacheL==L2Directory)))
-		{   //Assuming write back and write-allocate cache
+      unicache.ifb->stats_t.readAc.access =
+          unicache.caches->stats_t.writeAc.miss;
+      unicache.ifb->stats_t.writeAc.access =
+          unicache.caches->stats_t.writeAc.miss;
+      unicache.ifb->rtp_stats = unicache.ifb->stats_t;
 
-		  unicache.missb->stats_t.readAc.access  = unicache.caches->stats_t.writeAc.miss ;
-		  unicache.missb->stats_t.writeAc.access = unicache.caches->stats_t.writeAc.miss;
-		  unicache.missb->rtp_stats = unicache.missb->stats_t;
+      unicache.prefetchb->stats_t.readAc.access =
+          unicache.caches->stats_t.writeAc.miss;
+      unicache.prefetchb->stats_t.writeAc.access =
+          unicache.caches->stats_t.writeAc.miss;
+      unicache.prefetchb->rtp_stats = unicache.prefetchb->stats_t;
 
-		  unicache.ifb->stats_t.readAc.access  = unicache.caches->stats_t.writeAc.miss;
-		  unicache.ifb->stats_t.writeAc.access = unicache.caches->stats_t.writeAc.miss;
-		  unicache.ifb->rtp_stats = unicache.ifb->stats_t;
+      unicache.wbb->stats_t.readAc.access =
+          unicache.caches->stats_t.writeAc.miss;
+      unicache.wbb->stats_t.writeAc.access =
+          unicache.caches->stats_t.writeAc.miss;
+      if (cachep.dir_ty == SBT) {
+        unicache.missb->stats_t.readAc.access +=
+            homenode_rtp_stats.writeAc.miss;
+        unicache.missb->stats_t.writeAc.access +=
+            homenode_rtp_stats.writeAc.miss;
+        unicache.missb->rtp_stats = unicache.missb->stats_t;
 
-		  unicache.prefetchb->stats_t.readAc.access  = unicache.caches->stats_t.writeAc.miss;
-		  unicache.prefetchb->stats_t.writeAc.access = unicache.caches->stats_t.writeAc.miss;
-		  unicache.prefetchb->rtp_stats = unicache.prefetchb->stats_t;
+        unicache.missb->stats_t.readAc.access +=
+            homenode_rtp_stats.writeAc.miss;
+        unicache.missb->stats_t.writeAc.access +=
+            homenode_rtp_stats.writeAc.miss;
+        unicache.missb->rtp_stats = unicache.missb->stats_t;
 
-		  unicache.wbb->stats_t.readAc.access  = unicache.caches->stats_t.writeAc.miss;
-		  unicache.wbb->stats_t.writeAc.access = unicache.caches->stats_t.writeAc.miss;
-		  if (cachep.dir_ty==SBT)
-		  {
-			 unicache.missb->stats_t.readAc.access  += homenode_rtp_stats.writeAc.miss;
-			 unicache.missb->stats_t.writeAc.access += homenode_rtp_stats.writeAc.miss;
-			 unicache.missb->rtp_stats = unicache.missb->stats_t;
+        unicache.ifb->stats_t.readAc.access += homenode_rtp_stats.writeAc.miss;
+        unicache.ifb->stats_t.writeAc.access += homenode_rtp_stats.writeAc.miss;
+        unicache.ifb->rtp_stats = unicache.ifb->stats_t;
 
-			 unicache.missb->stats_t.readAc.access  += homenode_rtp_stats.writeAc.miss;
-			 unicache.missb->stats_t.writeAc.access += homenode_rtp_stats.writeAc.miss;
-			 unicache.missb->rtp_stats = unicache.missb->stats_t;
+        unicache.prefetchb->stats_t.readAc.access +=
+            homenode_rtp_stats.writeAc.miss;
+        unicache.prefetchb->stats_t.writeAc.access +=
+            homenode_rtp_stats.writeAc.miss;
+        unicache.prefetchb->rtp_stats = unicache.prefetchb->stats_t;
 
-			 unicache.ifb->stats_t.readAc.access  += homenode_rtp_stats.writeAc.miss;
-			 unicache.ifb->stats_t.writeAc.access += homenode_rtp_stats.writeAc.miss;
-			 unicache.ifb->rtp_stats = unicache.ifb->stats_t;
+        unicache.wbb->stats_t.readAc.access += homenode_rtp_stats.writeAc.miss;
+        unicache.wbb->stats_t.writeAc.access += homenode_rtp_stats.writeAc.miss;
+      }
+      unicache.wbb->rtp_stats = unicache.wbb->stats_t;
+    }
+  }
 
-			 unicache.prefetchb->stats_t.readAc.access  += homenode_rtp_stats.writeAc.miss;
-			 unicache.prefetchb->stats_t.writeAc.access += homenode_rtp_stats.writeAc.miss;
-			 unicache.prefetchb->rtp_stats = unicache.prefetchb->stats_t;
+  unicache.power_t.reset();
+  unicache.rt_power.reset();
+  if (!((cachep.dir_ty == ST && cacheL == L1Directory) ||
+        (cachep.dir_ty == ST && cacheL == L2Directory))) {
+    unicache.power_t.readOp.dynamic +=
+        (unicache.caches->stats_t.readAc.hit *
+             unicache.caches->local_result.power.readOp.dynamic +
+         unicache.caches->stats_t.readAc.miss *
+             unicache.caches->local_result.tag_array2->power.readOp.dynamic +
+         unicache.caches->stats_t.writeAc.miss *
+             unicache.caches->local_result.tag_array2->power.writeOp.dynamic +
+         unicache.caches->stats_t.writeAc.access *
+             unicache.caches->local_result.power.writeOp
+                 .dynamic);  // write miss will also generate a write later
 
-			 unicache.wbb->stats_t.readAc.access  += homenode_rtp_stats.writeAc.miss;
-			 unicache.wbb->stats_t.writeAc.access += homenode_rtp_stats.writeAc.miss;
-		  }
-		  unicache.wbb->rtp_stats = unicache.wbb->stats_t;
+    if (cachep.dir_ty == SBT) {
+      unicache.power_t.readOp.dynamic +=
+          homenode_stats_t.readAc.hit *
+              (unicache.caches->local_result.data_array2->power.readOp.dynamic *
+                   dir_overhead +
+               unicache.caches->local_result.tag_array2->power.readOp.dynamic) +
+          homenode_stats_t.readAc.miss *
+              unicache.caches->local_result.tag_array2->power.readOp.dynamic +
+          homenode_stats_t.writeAc.miss *
+              unicache.caches->local_result.tag_array2->power.readOp.dynamic +
+          homenode_stats_t.writeAc.hit *
+              (unicache.caches->local_result.data_array2->power.writeOp
+                       .dynamic *
+                   dir_overhead +
+               unicache.caches->local_result.tag_array2->power.readOp.dynamic +
+               homenode_stats_t.writeAc.miss *
+                   unicache.caches->local_result.power.writeOp
+                       .dynamic);  // write miss on dynamic home node will
+                                   // generate a replacement write on whole
+                                   // cache block
+    }
 
-		}
+    unicache.power_t.readOp.dynamic +=
+        unicache.missb->stats_t.readAc.access *
+            unicache.missb->local_result.power.searchOp.dynamic +
+        unicache.missb->stats_t.writeAc.access *
+            unicache.missb->local_result.power.writeOp
+                .dynamic;  // each access to missb involves a CAM and a write
+    unicache.power_t.readOp.dynamic +=
+        unicache.ifb->stats_t.readAc.access *
+            unicache.ifb->local_result.power.searchOp.dynamic +
+        unicache.ifb->stats_t.writeAc.access *
+            unicache.ifb->local_result.power.writeOp.dynamic;
+    unicache.power_t.readOp.dynamic +=
+        unicache.prefetchb->stats_t.readAc.access *
+            unicache.prefetchb->local_result.power.searchOp.dynamic +
+        unicache.prefetchb->stats_t.writeAc.access *
+            unicache.prefetchb->local_result.power.writeOp.dynamic;
+    unicache.power_t.readOp.dynamic +=
+        unicache.wbb->stats_t.readAc.access *
+            unicache.wbb->local_result.power.searchOp.dynamic +
+        unicache.wbb->stats_t.writeAc.access *
+            unicache.wbb->local_result.power.writeOp.dynamic;
+  } else {
+    unicache.power_t.readOp.dynamic +=
+        (unicache.caches->stats_t.readAc.access *
+             unicache.caches->local_result.power.searchOp.dynamic +
+         unicache.caches->stats_t.writeAc.access *
+             unicache.caches->local_result.power.writeOp.dynamic);
+  }
 
-	}
+  if (is_tdp) {
+    unicache.power =
+        unicache.power_t + (unicache.caches->local_result.power) * pppm_lkg;
+    if (!((cachep.dir_ty == ST && cacheL == L1Directory) ||
+          (cachep.dir_ty == ST && cacheL == L2Directory))) {
+      unicache.power =
+          unicache.power + (unicache.missb->local_result.power +
+                            unicache.ifb->local_result.power +
+                            unicache.prefetchb->local_result.power +
+                            unicache.wbb->local_result.power) *
+                               pppm_lkg;
+    }
+    power = power + unicache.power;
+    //		cout<<"unicache.caches->local_result.power.readOp.dynamic"<<unicache.caches->local_result.power.readOp.dynamic<<endl;
+    //		cout<<"unicache.caches->local_result.power.writeOp.dynamic"<<unicache.caches->local_result.power.writeOp.dynamic<<endl;
+  } else {
+    unicache.rt_power =
+        unicache.power_t + (unicache.caches->local_result.power) * pppm_lkg;
+    if (!((cachep.dir_ty == ST && cacheL == L1Directory) ||
+          (cachep.dir_ty == ST && cacheL == L2Directory))) {
+      unicache.rt_power =
+          unicache.rt_power + (unicache.missb->local_result.power +
+                               unicache.ifb->local_result.power +
+                               unicache.prefetchb->local_result.power +
+                               unicache.wbb->local_result.power) *
+                                  pppm_lkg;
+    }
 
-	unicache.power_t.reset();
-   unicache.rt_power.reset();
-	if (!((cachep.dir_ty==ST&& cacheL==L1Directory)||(cachep.dir_ty==ST&& cacheL==L2Directory)))
-	{ 
-
-	  unicache.power_t.readOp.dynamic	+= (unicache.caches->stats_t.readAc.hit*unicache.caches->local_result.power.readOp.dynamic+
-			unicache.caches->stats_t.readAc.miss*unicache.caches->local_result.tag_array2->power.readOp.dynamic+
-			unicache.caches->stats_t.writeAc.miss*unicache.caches->local_result.tag_array2->power.writeOp.dynamic+
-			unicache.caches->stats_t.writeAc.access*unicache.caches->local_result.power.writeOp.dynamic);//write miss will also generate a write later
-
-	  if (cachep.dir_ty==SBT)
-	  {
-		 unicache.power_t.readOp.dynamic	+= homenode_stats_t.readAc.hit * (unicache.caches->local_result.data_array2->power.readOp.dynamic*dir_overhead +
-			  unicache.caches->local_result.tag_array2->power.readOp.dynamic) +
-			homenode_stats_t.readAc.miss*unicache.caches->local_result.tag_array2->power.readOp.dynamic +
-			homenode_stats_t.writeAc.miss*unicache.caches->local_result.tag_array2->power.readOp.dynamic +
-			homenode_stats_t.writeAc.hit*(unicache.caches->local_result.data_array2->power.writeOp.dynamic*dir_overhead +
-				 unicache.caches->local_result.tag_array2->power.readOp.dynamic+
-				 homenode_stats_t.writeAc.miss*unicache.caches->local_result.power.writeOp.dynamic);//write miss on dynamic home node will generate a replacement write on whole cache block
-
-
-	  }
-
-	  unicache.power_t.readOp.dynamic	+=  unicache.missb->stats_t.readAc.access*unicache.missb->local_result.power.searchOp.dynamic +
-		 unicache.missb->stats_t.writeAc.access*unicache.missb->local_result.power.writeOp.dynamic;//each access to missb involves a CAM and a write
-	  unicache.power_t.readOp.dynamic	+=  unicache.ifb->stats_t.readAc.access*unicache.ifb->local_result.power.searchOp.dynamic +
-		 unicache.ifb->stats_t.writeAc.access*unicache.ifb->local_result.power.writeOp.dynamic;
-	  unicache.power_t.readOp.dynamic	+=  unicache.prefetchb->stats_t.readAc.access*unicache.prefetchb->local_result.power.searchOp.dynamic +
-		 unicache.prefetchb->stats_t.writeAc.access*unicache.prefetchb->local_result.power.writeOp.dynamic;
-	  unicache.power_t.readOp.dynamic	+=  unicache.wbb->stats_t.readAc.access*unicache.wbb->local_result.power.searchOp.dynamic +
-		 unicache.wbb->stats_t.writeAc.access*unicache.wbb->local_result.power.writeOp.dynamic;
-	}
-	else
-	{
-	  unicache.power_t.readOp.dynamic	+= (unicache.caches->stats_t.readAc.access*unicache.caches->local_result.power.searchOp.dynamic+
-			unicache.caches->stats_t.writeAc.access*unicache.caches->local_result.power.writeOp.dynamic);
-	}
-
-	if (is_tdp)
-	{
-	  unicache.power = unicache.power_t + (unicache.caches->local_result.power)*pppm_lkg;
-	  if (!((cachep.dir_ty==ST&& cacheL==L1Directory)||(cachep.dir_ty==ST&& cacheL==L2Directory)))
-	  {
-		 unicache.power = unicache.power+
-			(unicache.missb->local_result.power +
-			 unicache.ifb->local_result.power +
-			 unicache.prefetchb->local_result.power +
-			 unicache.wbb->local_result.power)*pppm_lkg;
-	  }
-	  power     = power + unicache.power;
-	  //		cout<<"unicache.caches->local_result.power.readOp.dynamic"<<unicache.caches->local_result.power.readOp.dynamic<<endl;
-	  //		cout<<"unicache.caches->local_result.power.writeOp.dynamic"<<unicache.caches->local_result.power.writeOp.dynamic<<endl;
-	}
-	else
-	{
-
-	  unicache.rt_power = unicache.power_t + (unicache.caches->local_result.power)*pppm_lkg;
-	  if (!((cachep.dir_ty==ST&& cacheL==L1Directory)||(cachep.dir_ty==ST&& cacheL==L2Directory)))
-	  {
-		 unicache.rt_power = unicache.rt_power +
-		  (unicache.missb->local_result.power +
-		  unicache.ifb->local_result.power +
-		  unicache.prefetchb->local_result.power +
-		  unicache.wbb->local_result.power)*pppm_lkg;
-	  }
-
-	  rt_power     = rt_power + unicache.rt_power;
-	}
+    rt_power = rt_power + unicache.rt_power;
+  }
 }
 
-void SharedCache::displayEnergy(uint32_t indent,bool is_tdp)
-{
+void SharedCache::displayEnergy(uint32_t indent, bool is_tdp) {
   string indent_str(indent, ' ');
-  string indent_str_next(indent+2, ' ');
+  string indent_str_next(indent + 2, ' ');
   bool long_channel = XML->sys.longer_channel_device;
 
-  if (is_tdp)
-  {
-	 cout << (XML->sys.Private_L2? indent_str:"")<< cachep.name << endl;
-	 cout << indent_str << "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
-	 cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic*cachep.clockRate << " W" << endl;
-	 cout << indent_str << "Subthreshold Leakage = "
-		<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
-	 //cout << indent_str << "Subthreshold Leakage = " << power.readOp.longer_channel_leakage <<" W" << endl;
-	 cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
-	 cout << indent_str << "Runtime Dynamic = " << rt_power.readOp.dynamic/cachep.executionTime << " W" << endl;
-	 cout <<endl;
-  }
-  else
-  {
+  if (is_tdp) {
+    cout << (XML->sys.Private_L2 ? indent_str : "") << cachep.name << endl;
+    cout << indent_str << "Area = " << area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str
+         << "Peak Dynamic = " << power.readOp.dynamic * cachep.clockRate << " W"
+         << endl;
+    cout << indent_str << "Subthreshold Leakage = "
+         << (long_channel ? power.readOp.longer_channel_leakage
+                          : power.readOp.leakage)
+         << " W" << endl;
+    // cout << indent_str << "Subthreshold Leakage = " <<
+    // power.readOp.longer_channel_leakage <<" W" << endl;
+    cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str << "Runtime Dynamic = "
+         << rt_power.readOp.dynamic / cachep.executionTime << " W" << endl;
+    cout << endl;
+  } else {
   }
 }
 
-//void SharedCache::computeMaxPower()
+// void SharedCache::computeMaxPower()
 //{
 //  //Compute maximum power and runtime power.
-//  //When computing runtime power, McPAT gets or reasons out the statistics based on XML input.
-//  maxPower		= 0.0;
+//  //When computing runtime power, McPAT gets or reasons out the statistics
+//  based on XML input. maxPower		= 0.0;
 //  //llCache,itlb
 //  llCache.maxPower   = 0.0;
-//  llCache.maxPower	+=  (llCache.caches.l_ip.num_rw_ports*(0.67*llCache.caches.local_result.power.readOp.dynamic+0.33*llCache.caches.local_result.power.writeOp.dynamic)
+//  llCache.maxPower	+=
+//  (llCache.caches.l_ip.num_rw_ports*(0.67*llCache.caches.local_result.power.readOp.dynamic+0.33*llCache.caches.local_result.power.writeOp.dynamic)
 //                        +llCache.caches.l_ip.num_rd_ports*llCache.caches.local_result.power.readOp.dynamic+llCache.caches.l_ip.num_wr_ports*llCache.caches.local_result.power.writeOp.dynamic
 //                        +llCache.caches.l_ip.num_se_rd_ports*llCache.caches.local_result.power.readOp.dynamic)*clockRate;
 //  ///cout<<"llCache.maxPower=" <<llCache.maxPower<<endl;
 //
-//  llCache.maxPower	+=  llCache.missb.l_ip.num_search_ports*llCache.missb.local_result.power.searchOp.dynamic*clockRate;
+//  llCache.maxPower	+=
+//  llCache.missb.l_ip.num_search_ports*llCache.missb.local_result.power.searchOp.dynamic*clockRate;
 //  ///cout<<"llCache.maxPower=" <<llCache.maxPower<<endl;
 //
-//  llCache.maxPower	+=  llCache.ifb.l_ip.num_search_ports*llCache.ifb.local_result.power.searchOp.dynamic*clockRate;
+//  llCache.maxPower	+=
+//  llCache.ifb.l_ip.num_search_ports*llCache.ifb.local_result.power.searchOp.dynamic*clockRate;
 //  ///cout<<"llCache.maxPower=" <<llCache.maxPower<<endl;
 //
-//  llCache.maxPower	+=  llCache.prefetchb.l_ip.num_search_ports*llCache.prefetchb.local_result.power.searchOp.dynamic*clockRate;
+//  llCache.maxPower	+=
+//  llCache.prefetchb.l_ip.num_search_ports*llCache.prefetchb.local_result.power.searchOp.dynamic*clockRate;
 //  ///cout<<"llCache.maxPower=" <<llCache.maxPower<<endl;
 //
-//  llCache.maxPower	+=  llCache.wbb.l_ip.num_search_ports*llCache.wbb.local_result.power.searchOp.dynamic*clockRate;
-//  //llCache.maxPower *=  scktRatio; //TODO: this calculation should be self-contained
+//  llCache.maxPower	+=
+//  llCache.wbb.l_ip.num_search_ports*llCache.wbb.local_result.power.searchOp.dynamic*clockRate;
+//  //llCache.maxPower *=  scktRatio; //TODO: this calculation should be
+//  self-contained
 //  ///cout<<"llCache.maxPower=" <<llCache.maxPower<<endl;
 //
-////  directory_power =  (directory.caches.l_ip.num_rw_ports*(0.67*directory.caches.local_result.power.readOp.dynamic+0.33*directory.caches.local_result.power.writeOp.dynamic)
-////                        +directory.caches.l_ip.num_rd_ports*directory.caches.local_result.power.readOp.dynamic+directory.caches.l_ip.num_wr_ports*directory.caches.local_result.power.writeOp.dynamic
-////                        +directory.caches.l_ip.num_se_rd_ports*directory.caches.local_result.power.readOp.dynamic)*clockRate;
+////  directory_power =
+///(directory.caches.l_ip.num_rw_ports*(0.67*directory.caches.local_result.power.readOp.dynamic+0.33*directory.caches.local_result.power.writeOp.dynamic)
+////
+///+directory.caches.l_ip.num_rd_ports*directory.caches.local_result.power.readOp.dynamic+directory.caches.l_ip.num_wr_ports*directory.caches.local_result.power.writeOp.dynamic
+////
+///+directory.caches.l_ip.num_se_rd_ports*directory.caches.local_result.power.readOp.dynamic)*clockRate;
 //
 //  L2Tot.power.readOp.dynamic = llCache.maxPower;
-//  L2Tot.power.readOp.leakage = llCache.caches.local_result.power.readOp.leakage +
-//                               llCache.missb.local_result.power.readOp.leakage +
-//                               llCache.ifb.local_result.power.readOp.leakage +
-//                               llCache.prefetchb.local_result.power.readOp.leakage +
+//  L2Tot.power.readOp.leakage =
+//  llCache.caches.local_result.power.readOp.leakage +
+//                               llCache.missb.local_result.power.readOp.leakage
+//                               + llCache.ifb.local_result.power.readOp.leakage
+//                               +
+//                               llCache.prefetchb.local_result.power.readOp.leakage
+//                               +
 //                               llCache.wbb.local_result.power.readOp.leakage;
 //
 //  L2Tot.area.set_area(llCache.area*1.1*1e-6);//placement and routing overhead
@@ -914,27 +1025,36 @@ void SharedCache::displayEnergy(uint32_t indent,bool is_tdp)
 //	  if (XML->sys.first_level_dir==0)
 //	  {
 //		  directory.maxPower   = 0.0;
-//		  directory.maxPower	+=  (directory.caches.l_ip.num_rw_ports*(0.67*directory.caches.local_result.power.readOp.dynamic+0.33*directory.caches.local_result.power.writeOp.dynamic)
+//		  directory.maxPower	+=
+//(directory.caches.l_ip.num_rw_ports*(0.67*directory.caches.local_result.power.readOp.dynamic+0.33*directory.caches.local_result.power.writeOp.dynamic)
 //		                        +directory.caches.l_ip.num_rd_ports*directory.caches.local_result.power.readOp.dynamic+directory.caches.l_ip.num_wr_ports*directory.caches.local_result.power.writeOp.dynamic
 //		                        +directory.caches.l_ip.num_se_rd_ports*directory.caches.local_result.power.readOp.dynamic)*clockRate;
 //		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
 //
-//		  directory.maxPower	+=  directory.missb.l_ip.num_search_ports*directory.missb.local_result.power.searchOp.dynamic*clockRate;
+//		  directory.maxPower	+=
+// directory.missb.l_ip.num_search_ports*directory.missb.local_result.power.searchOp.dynamic*clockRate;
 //		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
 //
-//		  directory.maxPower	+=  directory.ifb.l_ip.num_search_ports*directory.ifb.local_result.power.searchOp.dynamic*clockRate;
+//		  directory.maxPower	+=
+// directory.ifb.l_ip.num_search_ports*directory.ifb.local_result.power.searchOp.dynamic*clockRate;
 //		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
 //
-//		  directory.maxPower	+=  directory.prefetchb.l_ip.num_search_ports*directory.prefetchb.local_result.power.searchOp.dynamic*clockRate;
+//		  directory.maxPower	+=
+// directory.prefetchb.l_ip.num_search_ports*directory.prefetchb.local_result.power.searchOp.dynamic*clockRate;
 //		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
 //
-//		  directory.maxPower	+=  directory.wbb.l_ip.num_search_ports*directory.wbb.local_result.power.searchOp.dynamic*clockRate;
+//		  directory.maxPower	+=
+// directory.wbb.l_ip.num_search_ports*directory.wbb.local_result.power.searchOp.dynamic*clockRate;
 //
-//		  cc.power.readOp.dynamic = directory.maxPower*scktRatio*8;//8 is the memory controller counts
-//		  cc.power.readOp.leakage = directory.caches.local_result.power.readOp.leakage +
-//                                     directory.missb.local_result.power.readOp.leakage +
-//                                     directory.ifb.local_result.power.readOp.leakage +
-//                                     directory.prefetchb.local_result.power.readOp.leakage +
+//		  cc.power.readOp.dynamic = directory.maxPower*scktRatio*8;//8
+// is the memory controller counts 		  cc.power.readOp.leakage =
+// directory.caches.local_result.power.readOp.leakage +
+//                                     directory.missb.local_result.power.readOp.leakage
+//                                     +
+//                                     directory.ifb.local_result.power.readOp.leakage
+//                                     +
+//                                     directory.prefetchb.local_result.power.readOp.leakage
+//                                     +
 //                                     directory.wbb.local_result.power.readOp.leakage;
 //
 //		  cc.power.readOp.leakage *=8;
@@ -944,20 +1064,25 @@ void SharedCache::displayEnergy(uint32_t indent,bool is_tdp)
 //		  cout<<"CC Power="<<cc.power.readOp.dynamic<<endl;
 //		  ccTot.area.set_area(cc.area.get_area()*1e-6);
 //		  ccTot.power = cc.power;
-//		  cout<<"DC energy per access" << cc.power.readOp.dynamic/clockRate/8;
+//		  cout<<"DC energy per access" <<
+// cc.power.readOp.dynamic/clockRate/8;
 //	  }
 //	  else if (XML->sys.first_level_dir==1)
 //	  {
-//		  inv_dir.maxPower = inv_dir.caches.local_result.power.searchOp.dynamic*clockRate*XML->sys.domain_size;
-//		  cc.power.readOp.dynamic  = inv_dir.maxPower*scktRatio*64/XML->sys.domain_size;
-//		  cc.power.readOp.leakage  = inv_dir.caches.local_result.power.readOp.leakage*inv_dir.caches.l_ip.nbanks*64/XML->sys.domain_size;
+//		  inv_dir.maxPower =
+// inv_dir.caches.local_result.power.searchOp.dynamic*clockRate*XML->sys.domain_size;
+//		  cc.power.readOp.dynamic  =
+// inv_dir.maxPower*scktRatio*64/XML->sys.domain_size;
+// cc.power.readOp.leakage  =
+// inv_dir.caches.local_result.power.readOp.leakage*inv_dir.caches.l_ip.nbanks*64/XML->sys.domain_size;
 //
 //		  cc.area.set_area(inv_dir.area*64/XML->sys.domain_size);
 //		  cout<<"CC area="<<cc.area.get_area()*1e-6<<endl;
 //		  cout<<"CC Power="<<cc.power.readOp.dynamic<<endl;
 //		  ccTot.area.set_area(cc.area.get_area()*1e-6);
-//		  cout<<"DC energy per access" << cc.power.readOp.dynamic/clockRate/8;
-//		  ccTot.power = cc.power;
+//		  cout<<"DC energy per access" <<
+// cc.power.readOp.dynamic/clockRate/8; 		  ccTot.power =
+// cc.power;
 //	  }
 //  }
 //
@@ -965,73 +1090,102 @@ void SharedCache::displayEnergy(uint32_t indent,bool is_tdp)
 //  {
 //
 //	  		  directory.maxPower   = 0.0;
-//	  		  directory.maxPower	+=  (directory.caches.l_ip.num_rw_ports*(0.67*directory.caches.local_result.power.readOp.dynamic+0.33*directory.caches.local_result.power.writeOp.dynamic)
+//	  		  directory.maxPower	+=
+//(directory.caches.l_ip.num_rw_ports*(0.67*directory.caches.local_result.power.readOp.dynamic+0.33*directory.caches.local_result.power.writeOp.dynamic)
 //	  		                        +directory.caches.l_ip.num_rd_ports*directory.caches.local_result.power.readOp.dynamic+directory.caches.l_ip.num_wr_ports*directory.caches.local_result.power.writeOp.dynamic
 //	  		                        +directory.caches.l_ip.num_se_rd_ports*directory.caches.local_result.power.readOp.dynamic)*clockRate;
-//	  		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
+//	  		  ///cout<<"directory.maxPower="
+//<<directory.maxPower<<endl;
 //
-//	  		  directory.maxPower	+=  directory.missb.l_ip.num_search_ports*directory.missb.local_result.power.searchOp.dynamic*clockRate;
-//	  		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
+//	  		  directory.maxPower	+=
+// directory.missb.l_ip.num_search_ports*directory.missb.local_result.power.searchOp.dynamic*clockRate;
+//	  		  ///cout<<"directory.maxPower="
+//<<directory.maxPower<<endl;
 //
-//	  		  directory.maxPower	+=  directory.ifb.l_ip.num_search_ports*directory.ifb.local_result.power.searchOp.dynamic*clockRate;
-//	  		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
+//	  		  directory.maxPower	+=
+// directory.ifb.l_ip.num_search_ports*directory.ifb.local_result.power.searchOp.dynamic*clockRate;
+//	  		  ///cout<<"directory.maxPower="
+//<<directory.maxPower<<endl;
 //
-//	  		  directory.maxPower	+=  directory.prefetchb.l_ip.num_search_ports*directory.prefetchb.local_result.power.searchOp.dynamic*clockRate;
-//	  		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
+//	  		  directory.maxPower	+=
+// directory.prefetchb.l_ip.num_search_ports*directory.prefetchb.local_result.power.searchOp.dynamic*clockRate;
+//	  		  ///cout<<"directory.maxPower="
+//<<directory.maxPower<<endl;
 //
-//	  		  directory.maxPower	+=  directory.wbb.l_ip.num_search_ports*directory.wbb.local_result.power.searchOp.dynamic*clockRate;
+//	  		  directory.maxPower	+=
+// directory.wbb.l_ip.num_search_ports*directory.wbb.local_result.power.searchOp.dynamic*clockRate;
 //
-//	  		  cc.power.readOp.dynamic = directory.maxPower*scktRatio*8;//8 is the memory controller counts
-//			  cc.power.readOp.leakage = directory.caches.local_result.power.readOp.leakage +
-//	                                     directory.missb.local_result.power.readOp.leakage +
-//	                                     directory.ifb.local_result.power.readOp.leakage +
-//	                                     directory.prefetchb.local_result.power.readOp.leakage +
-//	                                     directory.wbb.local_result.power.readOp.leakage;
-//			  cc.power.readOp.leakage *=8;
-//	  		  cc.area.set_area(directory.area*8);
+//	  		  cc.power.readOp.dynamic =
+// directory.maxPower*scktRatio*8;//8 is the memory controller counts
+//			  cc.power.readOp.leakage =
+// directory.caches.local_result.power.readOp.leakage +
+//	                                     directory.missb.local_result.power.readOp.leakage
+//+ directory.ifb.local_result.power.readOp.leakage +
+//	                                     directory.prefetchb.local_result.power.readOp.leakage
+//+ directory.wbb.local_result.power.readOp.leakage;
+// cc.power.readOp.leakage
+//*=8; 	  		  cc.area.set_area(directory.area*8);
 //
 //	  		if (XML->sys.first_level_dir==0)
 //	  		{
 //	  		  directory1.maxPower   = 0.0;
-//	  		  directory1.maxPower	+=  (directory1.caches.l_ip.num_rw_ports*(0.67*directory1.caches.local_result.power.readOp.dynamic+0.33*directory1.caches.local_result.power.writeOp.dynamic)
+//	  		  directory1.maxPower	+=
+//(directory1.caches.l_ip.num_rw_ports*(0.67*directory1.caches.local_result.power.readOp.dynamic+0.33*directory1.caches.local_result.power.writeOp.dynamic)
 //	  				  +directory1.caches.l_ip.num_rd_ports*directory1.caches.local_result.power.readOp.dynamic+directory1.caches.l_ip.num_wr_ports*directory1.caches.local_result.power.writeOp.dynamic
 //	  				  +directory1.caches.l_ip.num_se_rd_ports*directory1.caches.local_result.power.readOp.dynamic)*clockRate;
-//	  		  ///cout<<"directory1.maxPower=" <<directory1.maxPower<<endl;
+//	  		  ///cout<<"directory1.maxPower="
+//<<directory1.maxPower<<endl;
 //
-//	  		  directory1.maxPower	+=  directory1.missb.l_ip.num_search_ports*directory1.missb.local_result.power.searchOp.dynamic*clockRate;
-//	  		  ///cout<<"directory1.maxPower=" <<directory1.maxPower<<endl;
+//	  		  directory1.maxPower	+=
+// directory1.missb.l_ip.num_search_ports*directory1.missb.local_result.power.searchOp.dynamic*clockRate;
+//	  		  ///cout<<"directory1.maxPower="
+//<<directory1.maxPower<<endl;
 //
-//	  		  directory1.maxPower	+=  directory1.ifb.l_ip.num_search_ports*directory1.ifb.local_result.power.searchOp.dynamic*clockRate;
-//	  		  ///cout<<"directory1.maxPower=" <<directory1.maxPower<<endl;
+//	  		  directory1.maxPower	+=
+// directory1.ifb.l_ip.num_search_ports*directory1.ifb.local_result.power.searchOp.dynamic*clockRate;
+//	  		  ///cout<<"directory1.maxPower="
+//<<directory1.maxPower<<endl;
 //
-//	  		  directory1.maxPower	+=  directory1.prefetchb.l_ip.num_search_ports*directory1.prefetchb.local_result.power.searchOp.dynamic*clockRate;
-//	  		  ///cout<<"directory1.maxPower=" <<directory1.maxPower<<endl;
+//	  		  directory1.maxPower	+=
+// directory1.prefetchb.l_ip.num_search_ports*directory1.prefetchb.local_result.power.searchOp.dynamic*clockRate;
+//	  		  ///cout<<"directory1.maxPower="
+//<<directory1.maxPower<<endl;
 //
-//	  		  directory1.maxPower	+=  directory1.wbb.l_ip.num_search_ports*directory1.wbb.local_result.power.searchOp.dynamic*clockRate;
+//	  		  directory1.maxPower	+=
+// directory1.wbb.l_ip.num_search_ports*directory1.wbb.local_result.power.searchOp.dynamic*clockRate;
 //
-//	  		  cc1.power.readOp.dynamic = directory1.maxPower*scktRatio*64/XML->sys.domain_size;
-//			  cc1.power.readOp.leakage = directory1.caches.local_result.power.readOp.leakage +
-//	                                     directory1.missb.local_result.power.readOp.leakage +
-//	                                     directory1.ifb.local_result.power.readOp.leakage +
-//	                                     directory1.prefetchb.local_result.power.readOp.leakage +
-//	                                     directory1.wbb.local_result.power.readOp.leakage;
-//			  cc1.power.readOp.leakage *= 64/XML->sys.domain_size;
+//	  		  cc1.power.readOp.dynamic =
+// directory1.maxPower*scktRatio*64/XML->sys.domain_size;
+//			  cc1.power.readOp.leakage =
+// directory1.caches.local_result.power.readOp.leakage +
+//	                                     directory1.missb.local_result.power.readOp.leakage
+//+ directory1.ifb.local_result.power.readOp.leakage +
+//	                                     directory1.prefetchb.local_result.power.readOp.leakage
+//+ directory1.wbb.local_result.power.readOp.leakage;
+// cc1.power.readOp.leakage
+//*= 64/XML->sys.domain_size;
 //	  		  cc1.area.set_area(directory1.area*64/XML->sys.domain_size);
 //
-//	  		  cout<<"CC area="<<(cc.area.get_area()+cc1.area.get_area())*1e-6<<endl;
-//			  cout<<"CC Power="<<cc.power.readOp.dynamic + cc1.power.readOp.dynamic <<endl;
+//	  		  cout<<"CC
+// area="<<(cc.area.get_area()+cc1.area.get_area())*1e-6<<endl;
+// cout<<"CC Power="<<cc.power.readOp.dynamic + cc1.power.readOp.dynamic <<endl;
 //			  ccTot.area.set_area((cc.area.get_area()+cc1.area.get_area())*1e-6);
 //			  ccTot.power = cc.power + cc1.power;
 //	  	  }
 //	  	  else if (XML->sys.first_level_dir==1)
 //	  	  {
-//	  		  inv_dir.maxPower = inv_dir.caches.local_result.power.searchOp.dynamic*clockRate*XML->sys.domain_size;
-//	  		  cc1.power.readOp.dynamic = inv_dir.maxPower*scktRatio*(64/XML->sys.domain_size);
-//	  		  cc1.power.readOp.leakage  = inv_dir.caches.local_result.power.readOp.leakage*inv_dir.caches.l_ip.nbanks*XML->sys.domain_size;
+//	  		  inv_dir.maxPower =
+// inv_dir.caches.local_result.power.searchOp.dynamic*clockRate*XML->sys.domain_size;
+//	  		  cc1.power.readOp.dynamic =
+// inv_dir.maxPower*scktRatio*(64/XML->sys.domain_size);
+// cc1.power.readOp.leakage
+//=
+// inv_dir.caches.local_result.power.readOp.leakage*inv_dir.caches.l_ip.nbanks*XML->sys.domain_size;
 //
 //	  		  cc1.area.set_area(inv_dir.area*64/XML->sys.domain_size);
-//			  cout<<"CC area="<<(cc.area.get_area()+cc1.area.get_area())*1e-6<<endl;
-//			  cout<<"CC Power="<<cc.power.readOp.dynamic + cc1.power.readOp.dynamic <<endl;
+//			  cout<<"CC
+// area="<<(cc.area.get_area()+cc1.area.get_area())*1e-6<<endl;
+// cout<<"CC Power="<<cc.power.readOp.dynamic + cc1.power.readOp.dynamic <<endl;
 //			  ccTot.area.set_area((cc.area.get_area()+cc1.area.get_area())*1e-6);
 //			  ccTot.power = cc.power + cc1.power;
 //
@@ -1045,9 +1199,9 @@ void SharedCache::displayEnergy(uint32_t indent,bool is_tdp)
 //	  	  }
 //  }
 //
-//cout<<"L2cache size="<<L2Tot.area.get_area()*1e-6<<endl;
-//cout<<"L2cache dynamic power="<<L2Tot.power.readOp.dynamic<<endl;
-//cout<<"L2cache laeakge power="<<L2Tot.power.readOp.leakage<<endl;
+// cout<<"L2cache size="<<L2Tot.area.get_area()*1e-6<<endl;
+// cout<<"L2cache dynamic power="<<L2Tot.power.readOp.dynamic<<endl;
+// cout<<"L2cache laeakge power="<<L2Tot.power.readOp.leakage<<endl;
 //
 //  ///cout<<"llCache.maxPower=" <<llCache.maxPower<<endl;
 //
@@ -1056,130 +1210,142 @@ void SharedCache::displayEnergy(uint32_t indent,bool is_tdp)
 //  ///cout<<"maxpower=" <<maxPower<<endl;
 //
 ////  maxPower	  +=  pipeLogicCache.power.readOp.dynamic*clockRate;
-////  ///cout<<"pipeLogic.power="<<pipeLogicCache.power.readOp.dynamic*clockRate<<endl;
+////
+//////cout<<"pipeLogic.power="<<pipeLogicCache.power.readOp.dynamic*clockRate<<endl;
 ////  ///cout<<"maxpower=" <<maxPower<<endl;
 ////
 ////  maxPower	  +=  pipeLogicDirectory.power.readOp.dynamic*clockRate;
-////  ///cout<<"pipeLogic.power="<<pipeLogicDirectory.power.readOp.dynamic*clockRate<<endl;
+////
+//////cout<<"pipeLogic.power="<<pipeLogicDirectory.power.readOp.dynamic*clockRate<<endl;
 ////  ///cout<<"maxpower=" <<maxPower<<endl;
 ////
 ////  //clock power
 ////  maxPower += clockNetwork.total_power.readOp.dynamic*clockRate;
-////  ///cout<<"clockNetwork.total_power="<<clockNetwork.total_power.readOp.dynamic*clockRate<<endl;
+////
+//////cout<<"clockNetwork.total_power="<<clockNetwork.total_power.readOp.dynamic*clockRate<<endl;
 ////  ///cout<<"maxpower=" <<maxPower<<endl;
 //
 //}
 
-void SharedCache::set_cache_param()
-{
-  if (cacheL==L2)
-  {
-	 cachep.name = "L2";
-	 cachep.clockRate       = XML->sys.L2[ithCache].clockrate;
-	 cachep.clockRate       *= 1e6;
-	 cachep.executionTime = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
-	 interface_ip.data_arr_ram_cell_tech_type    = XML->sys.L2[ithCache].device_type;//long channel device LSTP
-	 interface_ip.data_arr_peri_global_tech_type = XML->sys.L2[ithCache].device_type;
-	 interface_ip.tag_arr_ram_cell_tech_type     = XML->sys.L2[ithCache].device_type;
-	 interface_ip.tag_arr_peri_global_tech_type  = XML->sys.L2[ithCache].device_type;
-	 cachep.capacity      = XML->sys.L2[ithCache].L2_config[0];
-	 cachep.blockW        = XML->sys.L2[ithCache].L2_config[1];
-	 cachep.assoc         = XML->sys.L2[ithCache].L2_config[2];
-	 cachep.nbanks        = XML->sys.L2[ithCache].L2_config[3];
-	 cachep.throughput    = XML->sys.L2[ithCache].L2_config[4]/cachep.clockRate;
-	 cachep.latency       = XML->sys.L2[ithCache].L2_config[5]/cachep.clockRate;
-	 cachep.missb_size    = XML->sys.L2[ithCache].buffer_sizes[0];
-	 cachep.fu_size       = XML->sys.L2[ithCache].buffer_sizes[1];
-	 cachep.prefetchb_size= XML->sys.L2[ithCache].buffer_sizes[2];
-	 cachep.wbb_size      = XML->sys.L2[ithCache].buffer_sizes[3];
-	 cachep.duty_cycle    = XML->sys.L2[ithCache].duty_cycle;
-	 if (!XML->sys.L2[ithCache].merged_dir)
-	 {
-		cachep.dir_ty = NonDir;
-	 }
-	 else
-	 {
-		cachep.dir_ty = SBT;
-		cachep.dir_duty_cycle  = XML->sys.L2[ithCache].dir_duty_cycle;
-	 }
+void SharedCache::set_cache_param() {
+  if (cacheL == L2) {
+    cachep.name = "L2";
+    cachep.clockRate = XML->sys.L2[ithCache].clockrate;
+    cachep.clockRate *= 1e6;
+    cachep.executionTime =
+        XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);
+    interface_ip.data_arr_ram_cell_tech_type =
+        XML->sys.L2[ithCache].device_type;  // long channel device LSTP
+    interface_ip.data_arr_peri_global_tech_type =
+        XML->sys.L2[ithCache].device_type;
+    interface_ip.tag_arr_ram_cell_tech_type = XML->sys.L2[ithCache].device_type;
+    interface_ip.tag_arr_peri_global_tech_type =
+        XML->sys.L2[ithCache].device_type;
+    cachep.capacity = XML->sys.L2[ithCache].L2_config[0];
+    cachep.blockW = XML->sys.L2[ithCache].L2_config[1];
+    cachep.assoc = XML->sys.L2[ithCache].L2_config[2];
+    cachep.nbanks = XML->sys.L2[ithCache].L2_config[3];
+    cachep.throughput = XML->sys.L2[ithCache].L2_config[4] / cachep.clockRate;
+    cachep.latency = XML->sys.L2[ithCache].L2_config[5] / cachep.clockRate;
+    cachep.missb_size = XML->sys.L2[ithCache].buffer_sizes[0];
+    cachep.fu_size = XML->sys.L2[ithCache].buffer_sizes[1];
+    cachep.prefetchb_size = XML->sys.L2[ithCache].buffer_sizes[2];
+    cachep.wbb_size = XML->sys.L2[ithCache].buffer_sizes[3];
+    cachep.duty_cycle = XML->sys.L2[ithCache].duty_cycle;
+    if (!XML->sys.L2[ithCache].merged_dir) {
+      cachep.dir_ty = NonDir;
+    } else {
+      cachep.dir_ty = SBT;
+      cachep.dir_duty_cycle = XML->sys.L2[ithCache].dir_duty_cycle;
+    }
+  } else if (cacheL == L3) {
+    cachep.name = "L3";
+    cachep.clockRate = XML->sys.L3[ithCache].clockrate;
+    cachep.clockRate *= 1e6;
+    cachep.executionTime =
+        XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);
+    interface_ip.data_arr_ram_cell_tech_type =
+        XML->sys.L3[ithCache].device_type;  // long channel device LSTP
+    interface_ip.data_arr_peri_global_tech_type =
+        XML->sys.L3[ithCache].device_type;
+    interface_ip.tag_arr_ram_cell_tech_type = XML->sys.L3[ithCache].device_type;
+    interface_ip.tag_arr_peri_global_tech_type =
+        XML->sys.L3[ithCache].device_type;
+    cachep.capacity = XML->sys.L3[ithCache].L3_config[0];
+    cachep.blockW = XML->sys.L3[ithCache].L3_config[1];
+    cachep.assoc = XML->sys.L3[ithCache].L3_config[2];
+    cachep.nbanks = XML->sys.L3[ithCache].L3_config[3];
+    cachep.throughput = XML->sys.L3[ithCache].L3_config[4] / cachep.clockRate;
+    cachep.latency = XML->sys.L3[ithCache].L3_config[5] / cachep.clockRate;
+    cachep.missb_size = XML->sys.L3[ithCache].buffer_sizes[0];
+    cachep.fu_size = XML->sys.L3[ithCache].buffer_sizes[1];
+    cachep.prefetchb_size = XML->sys.L3[ithCache].buffer_sizes[2];
+    cachep.wbb_size = XML->sys.L3[ithCache].buffer_sizes[3];
+    cachep.duty_cycle = XML->sys.L3[ithCache].duty_cycle;
+    if (!XML->sys.L2[ithCache].merged_dir) {
+      cachep.dir_ty = NonDir;
+    } else {
+      cachep.dir_ty = SBT;
+      cachep.dir_duty_cycle = XML->sys.L2[ithCache].dir_duty_cycle;
+    }
+  } else if (cacheL == L1Directory) {
+    cachep.name = "First Level Directory";
+    cachep.dir_ty =
+        (enum Dir_type)XML->sys.L1Directory[ithCache].Directory_type;
+    cachep.clockRate = XML->sys.L1Directory[ithCache].clockrate;
+    cachep.clockRate *= 1e6;
+    cachep.executionTime =
+        XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);
+    interface_ip.data_arr_ram_cell_tech_type =
+        XML->sys.L1Directory[ithCache].device_type;  // long channel device LSTP
+    interface_ip.data_arr_peri_global_tech_type =
+        XML->sys.L1Directory[ithCache].device_type;
+    interface_ip.tag_arr_ram_cell_tech_type =
+        XML->sys.L1Directory[ithCache].device_type;
+    interface_ip.tag_arr_peri_global_tech_type =
+        XML->sys.L1Directory[ithCache].device_type;
+    cachep.capacity = XML->sys.L1Directory[ithCache].Dir_config[0];
+    cachep.blockW = XML->sys.L1Directory[ithCache].Dir_config[1];
+    cachep.assoc = XML->sys.L1Directory[ithCache].Dir_config[2];
+    cachep.nbanks = XML->sys.L1Directory[ithCache].Dir_config[3];
+    cachep.throughput =
+        XML->sys.L1Directory[ithCache].Dir_config[4] / cachep.clockRate;
+    cachep.latency =
+        XML->sys.L1Directory[ithCache].Dir_config[5] / cachep.clockRate;
+    cachep.missb_size = XML->sys.L1Directory[ithCache].buffer_sizes[0];
+    cachep.fu_size = XML->sys.L1Directory[ithCache].buffer_sizes[1];
+    cachep.prefetchb_size = XML->sys.L1Directory[ithCache].buffer_sizes[2];
+    cachep.wbb_size = XML->sys.L1Directory[ithCache].buffer_sizes[3];
+    cachep.duty_cycle = XML->sys.L1Directory[ithCache].duty_cycle;
+  } else if (cacheL == L2Directory) {
+    cachep.name = "Second Level Directory";
+    cachep.dir_ty =
+        (enum Dir_type)XML->sys.L2Directory[ithCache].Directory_type;
+    cachep.clockRate = XML->sys.L2Directory[ithCache].clockrate;
+    cachep.clockRate *= 1e6;
+    cachep.executionTime =
+        XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);
+    interface_ip.data_arr_ram_cell_tech_type =
+        XML->sys.L2Directory[ithCache].device_type;  // long channel device LSTP
+    interface_ip.data_arr_peri_global_tech_type =
+        XML->sys.L2Directory[ithCache].device_type;
+    interface_ip.tag_arr_ram_cell_tech_type =
+        XML->sys.L2Directory[ithCache].device_type;
+    interface_ip.tag_arr_peri_global_tech_type =
+        XML->sys.L2Directory[ithCache].device_type;
+    cachep.capacity = XML->sys.L2Directory[ithCache].Dir_config[0];
+    cachep.blockW = XML->sys.L2Directory[ithCache].Dir_config[1];
+    cachep.assoc = XML->sys.L2Directory[ithCache].Dir_config[2];
+    cachep.nbanks = XML->sys.L2Directory[ithCache].Dir_config[3];
+    cachep.throughput =
+        XML->sys.L2Directory[ithCache].Dir_config[4] / cachep.clockRate;
+    cachep.latency =
+        XML->sys.L2Directory[ithCache].Dir_config[5] / cachep.clockRate;
+    cachep.missb_size = XML->sys.L2Directory[ithCache].buffer_sizes[0];
+    cachep.fu_size = XML->sys.L2Directory[ithCache].buffer_sizes[1];
+    cachep.prefetchb_size = XML->sys.L2Directory[ithCache].buffer_sizes[2];
+    cachep.wbb_size = XML->sys.L2Directory[ithCache].buffer_sizes[3];
+    cachep.duty_cycle = XML->sys.L2Directory[ithCache].duty_cycle;
   }
-  else if (cacheL==L3)
-  {
-	 cachep.name = "L3";
-	 cachep.clockRate       = XML->sys.L3[ithCache].clockrate;
-	 cachep.clockRate       *= 1e6;
-	 cachep.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
-	 interface_ip.data_arr_ram_cell_tech_type    = XML->sys.L3[ithCache].device_type;//long channel device LSTP
-	 interface_ip.data_arr_peri_global_tech_type = XML->sys.L3[ithCache].device_type;
-	 interface_ip.tag_arr_ram_cell_tech_type     = XML->sys.L3[ithCache].device_type;
-	 interface_ip.tag_arr_peri_global_tech_type  = XML->sys.L3[ithCache].device_type;
-	 cachep.capacity      = XML->sys.L3[ithCache].L3_config[0];
-	 cachep.blockW        = XML->sys.L3[ithCache].L3_config[1];
-	 cachep.assoc         = XML->sys.L3[ithCache].L3_config[2];
-	 cachep.nbanks        = XML->sys.L3[ithCache].L3_config[3];
-	 cachep.throughput    = XML->sys.L3[ithCache].L3_config[4]/cachep.clockRate;
-	 cachep.latency       = XML->sys.L3[ithCache].L3_config[5]/cachep.clockRate;
-	 cachep.missb_size    = XML->sys.L3[ithCache].buffer_sizes[0];
-	 cachep.fu_size       = XML->sys.L3[ithCache].buffer_sizes[1];
-	 cachep.prefetchb_size= XML->sys.L3[ithCache].buffer_sizes[2];
-	 cachep.wbb_size      = XML->sys.L3[ithCache].buffer_sizes[3];
-	 cachep.duty_cycle    = XML->sys.L3[ithCache].duty_cycle;
-	 if (!XML->sys.L2[ithCache].merged_dir)
-	 {
-		cachep.dir_ty = NonDir;
-	 }
-	 else
-	 {
-		cachep.dir_ty = SBT;
-		cachep.dir_duty_cycle  = XML->sys.L2[ithCache].dir_duty_cycle;
-	 }
-  }
-  else if (cacheL==L1Directory)
-  {
-	 cachep.name = "First Level Directory";
-	 cachep.dir_ty = (enum Dir_type) XML->sys.L1Directory[ithCache].Directory_type;
-	 cachep.clockRate       = XML->sys.L1Directory[ithCache].clockrate;
-	 cachep.clockRate       *= 1e6;
-	 cachep.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
-	 interface_ip.data_arr_ram_cell_tech_type    = XML->sys.L1Directory[ithCache].device_type;//long channel device LSTP
-	 interface_ip.data_arr_peri_global_tech_type = XML->sys.L1Directory[ithCache].device_type;
-	 interface_ip.tag_arr_ram_cell_tech_type     = XML->sys.L1Directory[ithCache].device_type;
-	 interface_ip.tag_arr_peri_global_tech_type  = XML->sys.L1Directory[ithCache].device_type;
-	 cachep.capacity      = XML->sys.L1Directory[ithCache].Dir_config[0];
-	 cachep.blockW        = XML->sys.L1Directory[ithCache].Dir_config[1];
-	 cachep.assoc         = XML->sys.L1Directory[ithCache].Dir_config[2];
-	 cachep.nbanks        = XML->sys.L1Directory[ithCache].Dir_config[3];
-	 cachep.throughput    = XML->sys.L1Directory[ithCache].Dir_config[4]/cachep.clockRate;
-	 cachep.latency       = XML->sys.L1Directory[ithCache].Dir_config[5]/cachep.clockRate;
-	 cachep.missb_size    = XML->sys.L1Directory[ithCache].buffer_sizes[0];
-	 cachep.fu_size       = XML->sys.L1Directory[ithCache].buffer_sizes[1];
-	 cachep.prefetchb_size= XML->sys.L1Directory[ithCache].buffer_sizes[2];
-	 cachep.wbb_size      = XML->sys.L1Directory[ithCache].buffer_sizes[3];
-	 cachep.duty_cycle    = XML->sys.L1Directory[ithCache].duty_cycle;
-  }
-  else if (cacheL==L2Directory)
-  {
-	 cachep.name = "Second Level Directory";
-	 cachep.dir_ty = (enum Dir_type) XML->sys.L2Directory[ithCache].Directory_type;
-	 cachep.clockRate       = XML->sys.L2Directory[ithCache].clockrate;
-	 cachep.clockRate       *= 1e6;
-	 cachep.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
-	 interface_ip.data_arr_ram_cell_tech_type    = XML->sys.L2Directory[ithCache].device_type;//long channel device LSTP
-	 interface_ip.data_arr_peri_global_tech_type = XML->sys.L2Directory[ithCache].device_type;
-	 interface_ip.tag_arr_ram_cell_tech_type     = XML->sys.L2Directory[ithCache].device_type;
-	 interface_ip.tag_arr_peri_global_tech_type  = XML->sys.L2Directory[ithCache].device_type;
-	 cachep.capacity      = XML->sys.L2Directory[ithCache].Dir_config[0];
-	 cachep.blockW        = XML->sys.L2Directory[ithCache].Dir_config[1];
-	 cachep.assoc         = XML->sys.L2Directory[ithCache].Dir_config[2];
-	 cachep.nbanks        = XML->sys.L2Directory[ithCache].Dir_config[3];
-	 cachep.throughput    = XML->sys.L2Directory[ithCache].Dir_config[4]/cachep.clockRate;
-	 cachep.latency       = XML->sys.L2Directory[ithCache].Dir_config[5]/cachep.clockRate;
-	 cachep.missb_size    = XML->sys.L2Directory[ithCache].buffer_sizes[0];
-	 cachep.fu_size       = XML->sys.L2Directory[ithCache].buffer_sizes[1];
-	 cachep.prefetchb_size= XML->sys.L2Directory[ithCache].buffer_sizes[2];
-	 cachep.wbb_size      = XML->sys.L2Directory[ithCache].buffer_sizes[3];
-	 cachep.duty_cycle    = XML->sys.L2Directory[ithCache].duty_cycle;
-  }
-  //cachep.cache_duty_cycle=cachep.dir_duty_cycle = 0.35;
+  // cachep.cache_duty_cycle=cachep.dir_duty_cycle = 0.35;
 }
-

--- a/src/gpuwattch/sharedcache.cc
+++ b/src/gpuwattch/sharedcache.cc
@@ -1106,25 +1106,24 @@ void SharedCache::displayEnergy(uint32_t indent, bool is_tdp) {
 //		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
 //
 //		  directory.maxPower	+=
-// directory.missb.l_ip.num_search_ports*directory.missb.local_result.power.searchOp.dynamic*clockRate;
+//directory.missb.l_ip.num_search_ports*directory.missb.local_result.power.searchOp.dynamic*clockRate;
 //		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
 //
 //		  directory.maxPower	+=
-// directory.ifb.l_ip.num_search_ports*directory.ifb.local_result.power.searchOp.dynamic*clockRate;
+//directory.ifb.l_ip.num_search_ports*directory.ifb.local_result.power.searchOp.dynamic*clockRate;
 //		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
 //
 //		  directory.maxPower	+=
-// directory.prefetchb.l_ip.num_search_ports*directory.prefetchb.local_result.power.searchOp.dynamic*clockRate;
+//directory.prefetchb.l_ip.num_search_ports*directory.prefetchb.local_result.power.searchOp.dynamic*clockRate;
 //		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
 //
 //		  directory.maxPower	+=
-// directory.wbb.l_ip.num_search_ports*directory.wbb.local_result.power.searchOp.dynamic*clockRate;
+//directory.wbb.l_ip.num_search_ports*directory.wbb.local_result.power.searchOp.dynamic*clockRate;
 //
-//		  cc.power.readOp.dynamic = directory.maxPower*scktRatio*8;//8
-// is
-// the memory controller counts
+//		  cc.power.readOp.dynamic = directory.maxPower*scktRatio*8;//8 is
+//the memory controller counts
 //		  cc.power.readOp.leakage =
-// directory.caches.local_result.power.readOp.leakage +
+//directory.caches.local_result.power.readOp.leakage +
 //                                     directory.missb.local_result.power.readOp.leakage
 //                                     +
 //                                     directory.ifb.local_result.power.readOp.leakage
@@ -1141,23 +1140,23 @@ void SharedCache::displayEnergy(uint32_t indent, bool is_tdp) {
 //		  ccTot.area.set_area(cc.area.get_area()*1e-6);
 //		  ccTot.power = cc.power;
 //		  cout<<"DC energy per access" <<
-// cc.power.readOp.dynamic/clockRate/8;
+//cc.power.readOp.dynamic/clockRate/8;
 //	  }
 //	  else if (XML->sys.first_level_dir==1)
 //	  {
 //		  inv_dir.maxPower =
-// inv_dir.caches.local_result.power.searchOp.dynamic*clockRate*XML->sys.domain_size;
+//inv_dir.caches.local_result.power.searchOp.dynamic*clockRate*XML->sys.domain_size;
 //		  cc.power.readOp.dynamic  =
-// inv_dir.maxPower*scktRatio*64/XML->sys.domain_size;
+//inv_dir.maxPower*scktRatio*64/XML->sys.domain_size;
 //		  cc.power.readOp.leakage  =
-// inv_dir.caches.local_result.power.readOp.leakage*inv_dir.caches.l_ip.nbanks*64/XML->sys.domain_size;
+//inv_dir.caches.local_result.power.readOp.leakage*inv_dir.caches.l_ip.nbanks*64/XML->sys.domain_size;
 //
 //		  cc.area.set_area(inv_dir.area*64/XML->sys.domain_size);
 //		  cout<<"CC area="<<cc.area.get_area()*1e-6<<endl;
 //		  cout<<"CC Power="<<cc.power.readOp.dynamic<<endl;
 //		  ccTot.area.set_area(cc.area.get_area()*1e-6);
 //		  cout<<"DC energy per access" <<
-// cc.power.readOp.dynamic/clockRate/8;
+//cc.power.readOp.dynamic/clockRate/8;
 //		  ccTot.power = cc.power;
 //	  }
 //  }
@@ -1174,27 +1173,27 @@ void SharedCache::displayEnergy(uint32_t indent, bool is_tdp) {
 //<<directory.maxPower<<endl;
 //
 //	  		  directory.maxPower	+=
-// directory.missb.l_ip.num_search_ports*directory.missb.local_result.power.searchOp.dynamic*clockRate;
+//directory.missb.l_ip.num_search_ports*directory.missb.local_result.power.searchOp.dynamic*clockRate;
 //	  		  ///cout<<"directory.maxPower="
 //<<directory.maxPower<<endl;
 //
 //	  		  directory.maxPower	+=
-// directory.ifb.l_ip.num_search_ports*directory.ifb.local_result.power.searchOp.dynamic*clockRate;
+//directory.ifb.l_ip.num_search_ports*directory.ifb.local_result.power.searchOp.dynamic*clockRate;
 //	  		  ///cout<<"directory.maxPower="
 //<<directory.maxPower<<endl;
 //
 //	  		  directory.maxPower	+=
-// directory.prefetchb.l_ip.num_search_ports*directory.prefetchb.local_result.power.searchOp.dynamic*clockRate;
+//directory.prefetchb.l_ip.num_search_ports*directory.prefetchb.local_result.power.searchOp.dynamic*clockRate;
 //	  		  ///cout<<"directory.maxPower="
 //<<directory.maxPower<<endl;
 //
 //	  		  directory.maxPower	+=
-// directory.wbb.l_ip.num_search_ports*directory.wbb.local_result.power.searchOp.dynamic*clockRate;
+//directory.wbb.l_ip.num_search_ports*directory.wbb.local_result.power.searchOp.dynamic*clockRate;
 //
 //	  		  cc.power.readOp.dynamic =
-// directory.maxPower*scktRatio*8;//8 is the memory controller counts
+//directory.maxPower*scktRatio*8;//8 is the memory controller counts
 //			  cc.power.readOp.leakage =
-// directory.caches.local_result.power.readOp.leakage +
+//directory.caches.local_result.power.readOp.leakage +
 //	                                     directory.missb.local_result.power.readOp.leakage
 //+
 //	                                     directory.ifb.local_result.power.readOp.leakage
@@ -1216,27 +1215,27 @@ void SharedCache::displayEnergy(uint32_t indent, bool is_tdp) {
 //<<directory1.maxPower<<endl;
 //
 //	  		  directory1.maxPower	+=
-// directory1.missb.l_ip.num_search_ports*directory1.missb.local_result.power.searchOp.dynamic*clockRate;
+//directory1.missb.l_ip.num_search_ports*directory1.missb.local_result.power.searchOp.dynamic*clockRate;
 //	  		  ///cout<<"directory1.maxPower="
 //<<directory1.maxPower<<endl;
 //
 //	  		  directory1.maxPower	+=
-// directory1.ifb.l_ip.num_search_ports*directory1.ifb.local_result.power.searchOp.dynamic*clockRate;
+//directory1.ifb.l_ip.num_search_ports*directory1.ifb.local_result.power.searchOp.dynamic*clockRate;
 //	  		  ///cout<<"directory1.maxPower="
 //<<directory1.maxPower<<endl;
 //
 //	  		  directory1.maxPower	+=
-// directory1.prefetchb.l_ip.num_search_ports*directory1.prefetchb.local_result.power.searchOp.dynamic*clockRate;
+//directory1.prefetchb.l_ip.num_search_ports*directory1.prefetchb.local_result.power.searchOp.dynamic*clockRate;
 //	  		  ///cout<<"directory1.maxPower="
 //<<directory1.maxPower<<endl;
 //
 //	  		  directory1.maxPower	+=
-// directory1.wbb.l_ip.num_search_ports*directory1.wbb.local_result.power.searchOp.dynamic*clockRate;
+//directory1.wbb.l_ip.num_search_ports*directory1.wbb.local_result.power.searchOp.dynamic*clockRate;
 //
 //	  		  cc1.power.readOp.dynamic =
-// directory1.maxPower*scktRatio*64/XML->sys.domain_size;
+//directory1.maxPower*scktRatio*64/XML->sys.domain_size;
 //			  cc1.power.readOp.leakage =
-// directory1.caches.local_result.power.readOp.leakage +
+//directory1.caches.local_result.power.readOp.leakage +
 //	                                     directory1.missb.local_result.power.readOp.leakage
 //+
 //	                                     directory1.ifb.local_result.power.readOp.leakage
@@ -1248,26 +1247,26 @@ void SharedCache::displayEnergy(uint32_t indent, bool is_tdp) {
 //	  		  cc1.area.set_area(directory1.area*64/XML->sys.domain_size);
 //
 //	  		  cout<<"CC
-// area="<<(cc.area.get_area()+cc1.area.get_area())*1e-6<<endl;
+//area="<<(cc.area.get_area()+cc1.area.get_area())*1e-6<<endl;
 //			  cout<<"CC Power="<<cc.power.readOp.dynamic +
-// cc1.power.readOp.dynamic <<endl;
+//cc1.power.readOp.dynamic <<endl;
 //			  ccTot.area.set_area((cc.area.get_area()+cc1.area.get_area())*1e-6);
 //			  ccTot.power = cc.power + cc1.power;
 //	  	  }
 //	  	  else if (XML->sys.first_level_dir==1)
 //	  	  {
 //	  		  inv_dir.maxPower =
-// inv_dir.caches.local_result.power.searchOp.dynamic*clockRate*XML->sys.domain_size;
+//inv_dir.caches.local_result.power.searchOp.dynamic*clockRate*XML->sys.domain_size;
 //	  		  cc1.power.readOp.dynamic =
-// inv_dir.maxPower*scktRatio*(64/XML->sys.domain_size);
+//inv_dir.maxPower*scktRatio*(64/XML->sys.domain_size);
 //	  		  cc1.power.readOp.leakage  =
-// inv_dir.caches.local_result.power.readOp.leakage*inv_dir.caches.l_ip.nbanks*XML->sys.domain_size;
+//inv_dir.caches.local_result.power.readOp.leakage*inv_dir.caches.l_ip.nbanks*XML->sys.domain_size;
 //
 //	  		  cc1.area.set_area(inv_dir.area*64/XML->sys.domain_size);
 //			  cout<<"CC
-// area="<<(cc.area.get_area()+cc1.area.get_area())*1e-6<<endl;
+//area="<<(cc.area.get_area()+cc1.area.get_area())*1e-6<<endl;
 //			  cout<<"CC Power="<<cc.power.readOp.dynamic +
-// cc1.power.readOp.dynamic <<endl;
+//cc1.power.readOp.dynamic <<endl;
 //			  ccTot.area.set_area((cc.area.get_area()+cc1.area.get_area())*1e-6);
 //			  ccTot.power = cc.power + cc1.power;
 //

--- a/src/gpuwattch/sharedcache.cc
+++ b/src/gpuwattch/sharedcache.cc
@@ -29,251 +29,241 @@
  *
  ***************************************************************************/
 
-#include "sharedcache.h"
-#include <assert.h>
-#include <string.h>
-#include <string.h>
-#include <algorithm>
-#include <cmath>
-#include <iostream>
-#include "XML_Parse.h"
-#include "array.h"
-#include "cacti/arbiter.h"
-#include "cacti/basic_circuit.h"
-#include "cacti/parameter.h"
-#include "const.h"
 #include "io.h"
+#include "cacti/parameter.h"
+#include "array.h"
+#include "const.h"
 #include "logic.h"
+#include "cacti/basic_circuit.h"
+#include "cacti/arbiter.h"
+#include <string.h>
+#include <iostream>
+#include <algorithm>
+#include "XML_Parse.h"
+#include <string.h>
+#include <cmath>
+#include <assert.h>
+#include "sharedcache.h"
 
-SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_,
-                         InputParameter* interface_ip_,
-                         enum cache_level cacheL_)
-    : XML(XML_interface),
-      ithCache(ithCache_),
-      interface_ip(*interface_ip_),
-      cacheL(cacheL_),
-      dir_overhead(0) {
+
+
+SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_, InputParameter* interface_ip_, enum cache_level cacheL_)
+:XML(XML_interface),
+ ithCache(ithCache_),
+ interface_ip(*interface_ip_),
+ cacheL(cacheL_),
+ dir_overhead(0)
+{
   int idx;
   int tag, data;
-  bool debug;
+  bool debug; 
   enum Device_ty device_t;
-  enum Core_type core_t;
+  enum Core_type  core_t;
   double size, line, assoc, banks;
-  if (cacheL == L2 && XML->sys.Private_L2) {
-    device_t = Core_device;
-    core_t = (enum Core_type)XML->sys.core[ithCache].machine_type;
-  } else {
-    device_t = LLC_device;
-    core_t = Inorder;
+  if (cacheL==L2 && XML->sys.Private_L2)
+  {
+	  device_t=Core_device;
+      core_t = (enum Core_type)XML->sys.core[ithCache].machine_type;
+  }
+  else
+  {
+	  device_t=LLC_device;
+	  core_t = Inorder;
   }
 
-  debug = false;
-  if (XML->sys.Embedded) {
-    interface_ip.wt = Global_30;
-    interface_ip.wire_is_mat_type = 0;
-    interface_ip.wire_os_mat_type = 1;
-  } else {
-    interface_ip.wt = Global;
-    interface_ip.wire_is_mat_type = 2;
-    interface_ip.wire_os_mat_type = 2;
-  }
+  debug           = false;
+  if (XML->sys.Embedded)
+  		{
+  		interface_ip.wt                  =Global_30;
+  		interface_ip.wire_is_mat_type = 0;
+  		interface_ip.wire_os_mat_type = 1;
+  		}
+  	else
+  		{
+  		interface_ip.wt                  =Global;
+  		interface_ip.wire_is_mat_type = 2;
+  		interface_ip.wire_os_mat_type = 2;
+  		}
   set_cache_param();
 
-  // All lower level cache are physically indexed and tagged.
-  size = cachep.capacity;
-  line = cachep.blockW;
-  assoc = cachep.assoc;
-  banks = cachep.nbanks;
-  if ((cachep.dir_ty == ST && cacheL == L1Directory) ||
-      (cachep.dir_ty == ST && cacheL == L2Directory)) {
-    assoc = 0;
-    tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-    interface_ip.num_search_ports = 1;
-  } else {
-    idx = debug ? 9 : int(ceil(log2(size / line / assoc)));
-    tag = debug ? 51 : XML->sys.physical_address_width - idx -
-                           int(ceil(log2(line))) + EXTRA_TAG_BITS;
-    interface_ip.num_search_ports = 0;
-    if (cachep.dir_ty == SBT) {
-      dir_overhead =
-          ceil(XML->sys.number_of_cores / 8.0) * 8 / (cachep.blockW * 8);
-      line = cachep.blockW * (1 + dir_overhead);
-      size = cachep.capacity * (1 + dir_overhead);
-    }
+  //All lower level cache are physically indexed and tagged.
+  size                             = cachep.capacity;
+  line                             = cachep.blockW;
+  assoc                            = cachep.assoc;
+  banks                            = cachep.nbanks;
+  if ((cachep.dir_ty==ST&& cacheL==L1Directory)||(cachep.dir_ty==ST&& cacheL==L2Directory))
+  {
+	  assoc = 0;
+	  tag   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+	  interface_ip.num_search_ports    = 1;
   }
-  //  if (XML->sys.first_level_dir==2)
-  //	  tag += int(XML->sys.domain_size + 5);
-  interface_ip.specific_tag = 1;
-  interface_ip.tag_w = tag;
-  interface_ip.cache_sz = (int)size;
-  interface_ip.line_sz = (int)line;
-  interface_ip.assoc = (int)assoc;
-  interface_ip.nbanks = (int)banks;
-  interface_ip.out_w = interface_ip.line_sz * 8 / 2;
-  interface_ip.access_mode = 1;
-  interface_ip.throughput = cachep.throughput;
-  interface_ip.latency = cachep.latency;
-  interface_ip.is_cache = true;
-  interface_ip.pure_ram = false;
-  interface_ip.pure_cam = false;
-  interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power = 0;
-  interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t = 1;
-  interface_ip.num_rw_ports = 1;  // lower level cache usually has one port.
-  interface_ip.num_rd_ports = 0;
-  interface_ip.num_wr_ports = 0;
-  interface_ip.num_se_rd_ports = 0;
-  //  interface_ip.force_cache_config  =true;
-  //  interface_ip.ndwl = 4;
-  //  interface_ip.ndbl = 8;
-  //  interface_ip.nspd = 1;
-  //  interface_ip.ndcm =1 ;
-  //  interface_ip.ndsam1 =1;
-  //  interface_ip.ndsam2 =1;
-  unicache.caches =
-      new ArrayST(&interface_ip, cachep.name + "cache", device_t, true, core_t);
-  unicache.area.set_area(unicache.area.get_area() +
-                         unicache.caches->local_result.area);
-  area.set_area(area.get_area() + unicache.caches->local_result.area);
-  interface_ip.force_cache_config = false;
+  else
+  {
+	  idx    					 	   = debug?9:int(ceil(log2(size/line/assoc)));
+	  tag							   = debug?51:XML->sys.physical_address_width-idx-int(ceil(log2(line))) + EXTRA_TAG_BITS;
+	  interface_ip.num_search_ports    = 0;
+	  if (cachep.dir_ty==SBT)
+	  {
+		  dir_overhead = ceil(XML->sys.number_of_cores/8.0)*8/(cachep.blockW*8);
+		  line = cachep.blockW*(1+ dir_overhead) ;
+		  size = cachep.capacity*(1+ dir_overhead);
 
-  if (!((cachep.dir_ty == ST && cacheL == L1Directory) ||
-        (cachep.dir_ty == ST && cacheL == L2Directory))) {
-    tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-    data = (XML->sys.physical_address_width) + int(ceil(log2(size / line))) +
-           unicache.caches->l_ip.line_sz;
-    interface_ip.specific_tag = 1;
-    interface_ip.tag_w = tag;
-    interface_ip.line_sz =
-        int(ceil(data / 8.0));  // int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-    interface_ip.cache_sz = cachep.missb_size * interface_ip.line_sz;
-    interface_ip.assoc = 0;
-    interface_ip.is_cache = true;
-    interface_ip.pure_ram = false;
-    interface_ip.pure_cam = false;
-    interface_ip.nbanks = 1;
-    interface_ip.out_w = interface_ip.line_sz * 8 / 2;
-    interface_ip.access_mode = 0;
-    interface_ip.throughput = cachep.throughput;  // means cycle time
-    interface_ip.latency = cachep.latency;        // means access time
-    interface_ip.obj_func_dyn_energy = 0;
-    interface_ip.obj_func_dyn_power = 0;
-    interface_ip.obj_func_leak_power = 0;
-    interface_ip.obj_func_cycle_t = 1;
-    interface_ip.num_rw_ports = 1;
-    interface_ip.num_rd_ports = 0;
-    interface_ip.num_wr_ports = 0;
-    interface_ip.num_se_rd_ports = 0;
-    interface_ip.num_search_ports = 1;
-    unicache.missb = new ArrayST(&interface_ip, cachep.name + "MissB", device_t,
-                                 true, core_t);
-    unicache.area.set_area(unicache.area.get_area() +
-                           unicache.missb->local_result.area);
-    area.set_area(area.get_area() + unicache.missb->local_result.area);
-    // fill buffer
-    tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-    data = unicache.caches->l_ip.line_sz;
-    interface_ip.specific_tag = 1;
-    interface_ip.tag_w = tag;
-    interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
-    interface_ip.cache_sz = data * cachep.fu_size;
-    interface_ip.assoc = 0;
-    interface_ip.nbanks = 1;
-    interface_ip.out_w = interface_ip.line_sz * 8 / 2;
-    interface_ip.access_mode = 0;
-    interface_ip.throughput = cachep.throughput;
-    interface_ip.latency = cachep.latency;
-    interface_ip.obj_func_dyn_energy = 0;
-    interface_ip.obj_func_dyn_power = 0;
-    interface_ip.obj_func_leak_power = 0;
-    interface_ip.obj_func_cycle_t = 1;
-    interface_ip.num_rw_ports = 1;
-    interface_ip.num_rd_ports = 0;
-    interface_ip.num_wr_ports = 0;
-    interface_ip.num_se_rd_ports = 0;
-    unicache.ifb = new ArrayST(&interface_ip, cachep.name + "FillB", device_t,
-                               true, core_t);
-    unicache.area.set_area(unicache.area.get_area() +
-                           unicache.ifb->local_result.area);
-    area.set_area(area.get_area() + unicache.ifb->local_result.area);
-    // prefetch buffer
-    tag = XML->sys.physical_address_width +
-          EXTRA_TAG_BITS;  // check with previous entries to decide wthether to
-                           // merge.
-    data = unicache.caches->l_ip
-               .line_sz;  // separate queue to prevent from cache polution.
-    interface_ip.specific_tag = 1;
-    interface_ip.tag_w = tag;
-    interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
-    interface_ip.cache_sz = cachep.prefetchb_size * interface_ip.line_sz;
-    interface_ip.assoc = 0;
-    interface_ip.nbanks = 1;
-    interface_ip.out_w = interface_ip.line_sz * 8 / 2;
-    interface_ip.access_mode = 0;
-    interface_ip.throughput = cachep.throughput;
-    interface_ip.latency = cachep.latency;
-    interface_ip.obj_func_dyn_energy = 0;
-    interface_ip.obj_func_dyn_power = 0;
-    interface_ip.obj_func_leak_power = 0;
-    interface_ip.obj_func_cycle_t = 1;
-    interface_ip.num_rw_ports = 1;
-    interface_ip.num_rd_ports = 0;
-    interface_ip.num_wr_ports = 0;
-    interface_ip.num_se_rd_ports = 0;
-    unicache.prefetchb = new ArrayST(&interface_ip, cachep.name + "PrefetchB",
-                                     device_t, true, core_t);
-    unicache.area.set_area(unicache.area.get_area() +
-                           unicache.prefetchb->local_result.area);
-    area.set_area(area.get_area() + unicache.prefetchb->local_result.area);
-    // WBB
-    tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-    data = unicache.caches->l_ip.line_sz;
-    interface_ip.specific_tag = 1;
-    interface_ip.tag_w = tag;
-    interface_ip.line_sz = data;
-    interface_ip.cache_sz = cachep.wbb_size * interface_ip.line_sz;
-    interface_ip.assoc = 0;
-    interface_ip.nbanks = 1;
-    interface_ip.out_w = interface_ip.line_sz * 8 / 2;
-    interface_ip.access_mode = 0;
-    interface_ip.throughput = cachep.throughput;
-    interface_ip.latency = cachep.latency;
-    interface_ip.obj_func_dyn_energy = 0;
-    interface_ip.obj_func_dyn_power = 0;
-    interface_ip.obj_func_leak_power = 0;
-    interface_ip.obj_func_cycle_t = 1;
-    interface_ip.num_rw_ports = 1;
-    interface_ip.num_rd_ports = 0;
-    interface_ip.num_wr_ports = 0;
-    interface_ip.num_se_rd_ports = 0;
-    unicache.wbb =
-        new ArrayST(&interface_ip, cachep.name + "WBB", device_t, true, core_t);
-    unicache.area.set_area(unicache.area.get_area() +
-                           unicache.wbb->local_result.area);
-    area.set_area(area.get_area() + unicache.wbb->local_result.area);
+	  }
+  }
+//  if (XML->sys.first_level_dir==2)
+//	  tag += int(XML->sys.domain_size + 5);
+  interface_ip.specific_tag        = 1;
+  interface_ip.tag_w               = tag;
+  interface_ip.cache_sz            = (int)size;
+  interface_ip.line_sz             = (int)line;
+  interface_ip.assoc               = (int)assoc;
+  interface_ip.nbanks              = (int)banks;
+  interface_ip.out_w               = interface_ip.line_sz*8/2;
+  interface_ip.access_mode         = 1;
+  interface_ip.throughput          = cachep.throughput;
+  interface_ip.latency             = cachep.latency;
+  interface_ip.is_cache			 = true;
+  interface_ip.pure_ram			 = false;
+  interface_ip.pure_cam          = false;
+  interface_ip.obj_func_dyn_energy = 0;
+  interface_ip.obj_func_dyn_power  = 0;
+  interface_ip.obj_func_leak_power = 0;
+  interface_ip.obj_func_cycle_t    = 1;
+  interface_ip.num_rw_ports        = 1;//lower level cache usually has one port.
+  interface_ip.num_rd_ports        = 0;
+  interface_ip.num_wr_ports        = 0;
+  interface_ip.num_se_rd_ports     = 0;
+//  interface_ip.force_cache_config  =true;
+//  interface_ip.ndwl = 4;
+//  interface_ip.ndbl = 8;
+//  interface_ip.nspd = 1;
+//  interface_ip.ndcm =1 ;
+//  interface_ip.ndsam1 =1;
+//  interface_ip.ndsam2 =1;
+  unicache.caches = new ArrayST(&interface_ip, cachep.name + "cache", device_t, true, core_t);
+  unicache.area.set_area(unicache.area.get_area()+ unicache.caches->local_result.area);
+  area.set_area(area.get_area()+ unicache.caches->local_result.area);
+  interface_ip.force_cache_config  =false;
+
+
+  if (!((cachep.dir_ty==ST&& cacheL==L1Directory)||(cachep.dir_ty==ST&& cacheL==L2Directory)))
+  {
+	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+	  data							   = (XML->sys.physical_address_width) + int(ceil(log2(size/line))) + unicache.caches->l_ip.line_sz;
+	  interface_ip.specific_tag        = 1;
+	  interface_ip.tag_w               = tag;
+	  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+	  interface_ip.cache_sz            = cachep.missb_size*interface_ip.line_sz;
+	  interface_ip.assoc               = 0;
+	  interface_ip.is_cache			   = true;
+	  interface_ip.pure_ram			   = false;
+	  interface_ip.pure_cam            = false;
+	  interface_ip.nbanks              = 1;
+	  interface_ip.out_w               = interface_ip.line_sz*8/2;
+	  interface_ip.access_mode         = 0;
+	  interface_ip.throughput          = cachep.throughput;//means cycle time
+	  interface_ip.latency             = cachep.latency;//means access time
+	  interface_ip.obj_func_dyn_energy = 0;
+	  interface_ip.obj_func_dyn_power  = 0;
+	  interface_ip.obj_func_leak_power = 0;
+	  interface_ip.obj_func_cycle_t    = 1;
+	  interface_ip.num_rw_ports    = 1;
+	  interface_ip.num_rd_ports    = 0;
+	  interface_ip.num_wr_ports    = 0;
+	  interface_ip.num_se_rd_ports = 0;
+	  interface_ip.num_search_ports    = 1;
+	  unicache.missb = new ArrayST(&interface_ip, cachep.name + "MissB", device_t, true, core_t);
+	  unicache.area.set_area(unicache.area.get_area()+ unicache.missb->local_result.area);
+	  area.set_area(area.get_area()+ unicache.missb->local_result.area);
+	  //fill buffer
+	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+	  data							   = unicache.caches->l_ip.line_sz;
+	  interface_ip.specific_tag        = 1;
+	  interface_ip.tag_w               = tag;
+	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
+	  interface_ip.cache_sz            = data*cachep.fu_size ;
+	  interface_ip.assoc               = 0;
+	  interface_ip.nbanks              = 1;
+	  interface_ip.out_w               = interface_ip.line_sz*8/2;
+	  interface_ip.access_mode         = 0;
+	  interface_ip.throughput          =  cachep.throughput;
+	  interface_ip.latency             =  cachep.latency;
+	  interface_ip.obj_func_dyn_energy = 0;
+	  interface_ip.obj_func_dyn_power  = 0;
+	  interface_ip.obj_func_leak_power = 0;
+	  interface_ip.obj_func_cycle_t    = 1;
+	  interface_ip.num_rw_ports    = 1;
+	  interface_ip.num_rd_ports    = 0;
+	  interface_ip.num_wr_ports    = 0;
+	  interface_ip.num_se_rd_ports = 0;
+	  unicache.ifb = new ArrayST(&interface_ip, cachep.name + "FillB", device_t, true, core_t);
+	  unicache.area.set_area(unicache.area.get_area()+ unicache.ifb->local_result.area);
+	  area.set_area(area.get_area()+ unicache.ifb->local_result.area);
+	  //prefetch buffer
+	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries to decide wthether to merge.
+	  data							   = unicache.caches->l_ip.line_sz;//separate queue to prevent from cache polution.
+	  interface_ip.specific_tag        = 1;
+	  interface_ip.tag_w               = tag;
+	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
+	  interface_ip.cache_sz            = cachep.prefetchb_size*interface_ip.line_sz;
+	  interface_ip.assoc               = 0;
+	  interface_ip.nbanks              = 1;
+	  interface_ip.out_w               = interface_ip.line_sz*8/2;
+	  interface_ip.access_mode         = 0;
+	  interface_ip.throughput          = cachep.throughput;
+	  interface_ip.latency             = cachep.latency;
+	  interface_ip.obj_func_dyn_energy = 0;
+	  interface_ip.obj_func_dyn_power  = 0;
+	  interface_ip.obj_func_leak_power = 0;
+	  interface_ip.obj_func_cycle_t    = 1;
+	  interface_ip.num_rw_ports    = 1;
+	  interface_ip.num_rd_ports    = 0;
+	  interface_ip.num_wr_ports    = 0;
+	  interface_ip.num_se_rd_ports = 0;
+	  unicache.prefetchb = new ArrayST(&interface_ip, cachep.name + "PrefetchB", device_t, true, core_t);
+	  unicache.area.set_area(unicache.area.get_area()+ unicache.prefetchb->local_result.area);
+	  area.set_area(area.get_area()+ unicache.prefetchb->local_result.area);
+	  //WBB
+	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+	  data							   = unicache.caches->l_ip.line_sz;
+	  interface_ip.specific_tag        = 1;
+	  interface_ip.tag_w               = tag;
+	  interface_ip.line_sz             = data;
+	  interface_ip.cache_sz            = cachep.wbb_size*interface_ip.line_sz;
+	  interface_ip.assoc               = 0;
+	  interface_ip.nbanks              = 1;
+	  interface_ip.out_w               = interface_ip.line_sz*8/2;
+	  interface_ip.access_mode         = 0;
+	  interface_ip.throughput          = cachep.throughput;
+	  interface_ip.latency             = cachep.latency;
+	  interface_ip.obj_func_dyn_energy = 0;
+	  interface_ip.obj_func_dyn_power  = 0;
+	  interface_ip.obj_func_leak_power = 0;
+	  interface_ip.obj_func_cycle_t    = 1;
+	  interface_ip.num_rw_ports    = 1;
+	  interface_ip.num_rd_ports    = 0;
+	  interface_ip.num_wr_ports    = 0;
+	  interface_ip.num_se_rd_ports = 0;
+	  unicache.wbb = new ArrayST(&interface_ip, cachep.name + "WBB", device_t, true, core_t);
+	  unicache.area.set_area(unicache.area.get_area()+ unicache.wbb->local_result.area);
+	  area.set_area(area.get_area()+ unicache.wbb->local_result.area);
   }
   //  //pipeline
-  //  interface_ip.pipeline_stages =
-  //  int(ceil(llCache.caches.local_result.access_time/llCache.caches.local_result.cycle_time));
-  //  interface_ip.per_stage_vector = llCache.caches.l_ip.out_w +
-  //  llCache.caches.l_ip.tag_w ;
-  //  pipeLogicCache.init_pipeline(is_default, &interface_ip);
-  //  pipeLogicCache.compute_pipeline();
+//  interface_ip.pipeline_stages = int(ceil(llCache.caches.local_result.access_time/llCache.caches.local_result.cycle_time));
+//  interface_ip.per_stage_vector = llCache.caches.l_ip.out_w + llCache.caches.l_ip.tag_w ;
+//  pipeLogicCache.init_pipeline(is_default, &interface_ip);
+//  pipeLogicCache.compute_pipeline();
 
   /*
   if (!((XML->sys.number_of_dir_levels==1 && XML->sys.first_level_dir ==1)
-                  ||(XML->sys.number_of_dir_levels==1 &&
-  XML->sys.first_level_dir ==2)))//not single level IC and DIC
+		  ||(XML->sys.number_of_dir_levels==1 && XML->sys.first_level_dir ==2)))//not single level IC and DIC
   {
   //directory Now assuming one directory per bank, TODO:should change it later
   size                             = XML->sys.L2directory.L2Dir_config[0];
   line                             = XML->sys.L2directory.L2Dir_config[1];
   assoc                            = XML->sys.L2directory.L2Dir_config[2];
   banks                            = XML->sys.L2directory.L2Dir_config[3];
-  tag							   =
-  debug?51:XML->sys.physical_address_width + EXTRA_TAG_BITS;//TODO: a little bit
-  over estimate
+  tag							   = debug?51:XML->sys.physical_address_width + EXTRA_TAG_BITS;//TODO: a little bit over estimate
   interface_ip.specific_tag        = 0;
   interface_ip.tag_w               = tag;
   interface_ip.cache_sz            = XML->sys.L2directory.L2Dir_config[0];
@@ -281,12 +271,9 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_,
   interface_ip.assoc               = XML->sys.L2directory.L2Dir_config[2];
   interface_ip.nbanks              = XML->sys.L2directory.L2Dir_config[3];
   interface_ip.out_w               = interface_ip.line_sz*8;
-  interface_ip.access_mode         =
-  0;//debug?0:XML->sys.core[ithCore].icache.icache_config[5];
-  interface_ip.throughput          =
-  XML->sys.L2directory.L2Dir_config[4]/clockRate;
-  interface_ip.latency             =
-  XML->sys.L2directory.L2Dir_config[5]/clockRate;
+  interface_ip.access_mode         = 0;//debug?0:XML->sys.core[ithCore].icache.icache_config[5];
+  interface_ip.throughput          = XML->sys.L2directory.L2Dir_config[4]/clockRate;
+  interface_ip.latency             = XML->sys.L2directory.L2Dir_config[5]/clockRate;
   interface_ip.is_cache			 = true;
   interface_ip.obj_func_dyn_energy = 0;
   interface_ip.obj_func_dyn_power  = 0;
@@ -304,31 +291,21 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_,
   //output_data_csv(directory.caches.local_result);
   ///cout<<"area="<<area<<endl;
 
-  //miss buffer Each MSHR contains enough state to handle one or more accesses
-  of any type to a single memory line.
-  //Due to the generality of the MSHR mechanism, the amount of state involved is
-  non-trivial,
-  //including the address, pointers to the cache entry and destination register,
-  written data, and various other pieces of state.
-  tag							   =
-  XML->sys.physical_address_width + EXTRA_TAG_BITS;
-  data							   =
-  (XML->sys.physical_address_width) + int(ceil(log2(size/line))) +
-  directory.caches.l_ip.line_sz;
+  //miss buffer Each MSHR contains enough state to handle one or more accesses of any type to a single memory line.
+  //Due to the generality of the MSHR mechanism, the amount of state involved is non-trivial,
+  //including the address, pointers to the cache entry and destination register, written data, and various other pieces of state.
+  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data							   = (XML->sys.physical_address_width) + int(ceil(log2(size/line))) + directory.caches.l_ip.line_sz;
   interface_ip.specific_tag        = 1;
   interface_ip.tag_w               = tag;
-  interface_ip.line_sz             =
-  int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-  interface_ip.cache_sz            =
-  XML->sys.L2[ithCache].buffer_sizes[0]*interface_ip.line_sz;
+  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+  interface_ip.cache_sz            = XML->sys.L2[ithCache].buffer_sizes[0]*interface_ip.line_sz;
   interface_ip.assoc               = 0;
   interface_ip.nbanks              = 1;
   interface_ip.out_w               = interface_ip.line_sz*8;
   interface_ip.access_mode         = 0;
-  interface_ip.throughput          =
-  XML->sys.L2[ithCache].L2_config[4]/clockRate;//means cycle time
-  interface_ip.latency             =
-  XML->sys.L2[ithCache].L2_config[5]/clockRate;//means access time
+  interface_ip.throughput          = XML->sys.L2[ithCache].L2_config[4]/clockRate;//means cycle time
+  interface_ip.latency             = XML->sys.L2[ithCache].L2_config[5]/clockRate;//means access time
   interface_ip.obj_func_dyn_energy = 0;
   interface_ip.obj_func_dyn_power  = 0;
   interface_ip.obj_func_leak_power = 0;
@@ -345,10 +322,8 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_,
   ///cout<<"area="<<area<<endl;
 
   //fill buffer
-  tag							   =
-  XML->sys.physical_address_width + EXTRA_TAG_BITS;
-  data							   =
-  directory.caches.l_ip.line_sz;
+  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data							   = directory.caches.l_ip.line_sz;
   interface_ip.specific_tag        = 1;
   interface_ip.tag_w               = tag;
   interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
@@ -357,10 +332,8 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_,
   interface_ip.nbanks              = 1;
   interface_ip.out_w               = interface_ip.line_sz*8;
   interface_ip.access_mode         = 0;
-  interface_ip.throughput          =
-  XML->sys.L2[ithCache].L2_config[4]/clockRate;
-  interface_ip.latency             =
-  XML->sys.L2[ithCache].L2_config[5]/clockRate;
+  interface_ip.throughput          =  XML->sys.L2[ithCache].L2_config[4]/clockRate;
+  interface_ip.latency             =  XML->sys.L2[ithCache].L2_config[5]/clockRate;
   interface_ip.obj_func_dyn_energy = 0;
   interface_ip.obj_func_dyn_power  = 0;
   interface_ip.obj_func_leak_power = 0;
@@ -377,24 +350,18 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_,
   ///cout<<"area="<<area<<endl;
 
   //prefetch buffer
-  tag							   =
-  XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries
-  to decide wthether to merge.
-  data							   =
-  directory.caches.l_ip.line_sz;//separate queue to prevent from cache polution.
+  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries to decide wthether to merge.
+  data							   = directory.caches.l_ip.line_sz;//separate queue to prevent from cache polution.
   interface_ip.specific_tag        = 1;
   interface_ip.tag_w               = tag;
   interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-  interface_ip.cache_sz            =
-  XML->sys.L2[ithCache].buffer_sizes[2]*interface_ip.line_sz;
+  interface_ip.cache_sz            = XML->sys.L2[ithCache].buffer_sizes[2]*interface_ip.line_sz;
   interface_ip.assoc               = 0;
   interface_ip.nbanks              = 1;
   interface_ip.out_w               = interface_ip.line_sz*8;
   interface_ip.access_mode         = 0;
-  interface_ip.throughput          =
-  XML->sys.L2[ithCache].L2_config[4]/clockRate;
-  interface_ip.latency             =
-  XML->sys.L2[ithCache].L2_config[5]/clockRate;
+  interface_ip.throughput          = XML->sys.L2[ithCache].L2_config[4]/clockRate;
+  interface_ip.latency             = XML->sys.L2[ithCache].L2_config[5]/clockRate;
   interface_ip.obj_func_dyn_energy = 0;
   interface_ip.obj_func_dyn_power  = 0;
   interface_ip.obj_func_leak_power = 0;
@@ -411,23 +378,18 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_,
   ///cout<<"area="<<area<<endl;
 
   //WBB
-  tag							   =
-  XML->sys.physical_address_width + EXTRA_TAG_BITS;
-  data							   =
-  directory.caches.l_ip.line_sz;
+  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data							   = directory.caches.l_ip.line_sz;
   interface_ip.specific_tag        = 1;
   interface_ip.tag_w               = tag;
   interface_ip.line_sz             = data;
-  interface_ip.cache_sz            =
-  XML->sys.L2[ithCache].buffer_sizes[3]*interface_ip.line_sz;
+  interface_ip.cache_sz            = XML->sys.L2[ithCache].buffer_sizes[3]*interface_ip.line_sz;
   interface_ip.assoc               = 0;
   interface_ip.nbanks              = 1;
   interface_ip.out_w               = interface_ip.line_sz*8;
   interface_ip.access_mode         = 0;
-  interface_ip.throughput          =
-  XML->sys.L2[ithCache].L2_config[4]/clockRate;
-  interface_ip.latency             =
-  XML->sys.L2[ithCache].L2_config[4]/clockRate;
+  interface_ip.throughput          = XML->sys.L2[ithCache].L2_config[4]/clockRate;
+  interface_ip.latency             = XML->sys.L2[ithCache].L2_config[4]/clockRate;
   interface_ip.obj_func_dyn_energy = 0;
   interface_ip.obj_func_dyn_power  = 0;
   interface_ip.obj_func_leak_power = 0;
@@ -445,14 +407,11 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_,
   if (XML->sys.number_of_dir_levels ==2 && XML->sys.first_level_dir==0)
   {
   //first level directory
-  size                             =
-  XML->sys.L2directory.L2Dir_config[0]*XML->sys.domain_size/128;
+  size                             = XML->sys.L2directory.L2Dir_config[0]*XML->sys.domain_size/128;
   line                             = int(ceil(XML->sys.domain_size/8.0));
   assoc                            = XML->sys.L2directory.L2Dir_config[2];
   banks                            = XML->sys.L2directory.L2Dir_config[3];
-  tag							   =
-  debug?51:XML->sys.physical_address_width + EXTRA_TAG_BITS;//TODO: a little bit
-  over estimate
+  tag							   = debug?51:XML->sys.physical_address_width + EXTRA_TAG_BITS;//TODO: a little bit over estimate
   interface_ip.specific_tag        = 1;
   interface_ip.tag_w               = tag;
   interface_ip.cache_sz            = XML->sys.L2directory.L2Dir_config[0];
@@ -460,12 +419,9 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_,
   interface_ip.assoc               = XML->sys.L2directory.L2Dir_config[2];
   interface_ip.nbanks              = XML->sys.L2directory.L2Dir_config[3];
   interface_ip.out_w               = interface_ip.line_sz*8;
-  interface_ip.access_mode         =
-  0;//debug?0:XML->sys.core[ithCore].icache.icache_config[5];
-  interface_ip.throughput          =
-  XML->sys.L2directory.L2Dir_config[4]/clockRate;
-  interface_ip.latency             =
-  XML->sys.L2directory.L2Dir_config[5]/clockRate;
+  interface_ip.access_mode         = 0;//debug?0:XML->sys.core[ithCore].icache.icache_config[5];
+  interface_ip.throughput          = XML->sys.L2directory.L2Dir_config[4]/clockRate;
+  interface_ip.latency             = XML->sys.L2directory.L2Dir_config[5]/clockRate;
   interface_ip.is_cache			 = true;
   interface_ip.obj_func_dyn_energy = 0;
   interface_ip.obj_func_dyn_power  = 0;
@@ -483,31 +439,21 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_,
   //output_data_csv(directory.caches.local_result);
   ///cout<<"area="<<area<<endl;
 
-  //miss buffer Each MSHR contains enough state to handle one or more accesses
-  of any type to a single memory line.
-  //Due to the generality of the MSHR mechanism, the amount of state involved is
-  non-trivial,
-  //including the address, pointers to the cache entry and destination register,
-  written data, and various other pieces of state.
-  tag							   =
-  XML->sys.physical_address_width + EXTRA_TAG_BITS;
-  data							   =
-  (XML->sys.physical_address_width) + int(ceil(log2(size/line))) +
-  directory1.caches.l_ip.line_sz;
+  //miss buffer Each MSHR contains enough state to handle one or more accesses of any type to a single memory line.
+  //Due to the generality of the MSHR mechanism, the amount of state involved is non-trivial,
+  //including the address, pointers to the cache entry and destination register, written data, and various other pieces of state.
+  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data							   = (XML->sys.physical_address_width) + int(ceil(log2(size/line))) + directory1.caches.l_ip.line_sz;
   interface_ip.specific_tag        = 1;
   interface_ip.tag_w               = tag;
-  interface_ip.line_sz             =
-  int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-  interface_ip.cache_sz            =
-  XML->sys.L2[ithCache].buffer_sizes[0]*interface_ip.line_sz;
+  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+  interface_ip.cache_sz            = XML->sys.L2[ithCache].buffer_sizes[0]*interface_ip.line_sz;
   interface_ip.assoc               = 0;
   interface_ip.nbanks              = 1;
   interface_ip.out_w               = interface_ip.line_sz*8;
   interface_ip.access_mode         = 0;
-  interface_ip.throughput          =
-  XML->sys.L2[ithCache].L2_config[4]/clockRate;//means cycle time
-  interface_ip.latency             =
-  XML->sys.L2[ithCache].L2_config[5]/clockRate;//means access time
+  interface_ip.throughput          = XML->sys.L2[ithCache].L2_config[4]/clockRate;//means cycle time
+  interface_ip.latency             = XML->sys.L2[ithCache].L2_config[5]/clockRate;//means access time
   interface_ip.obj_func_dyn_energy = 0;
   interface_ip.obj_func_dyn_power  = 0;
   interface_ip.obj_func_leak_power = 0;
@@ -524,10 +470,8 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_,
   ///cout<<"area="<<area<<endl;
 
   //fill buffer
-  tag							   =
-  XML->sys.physical_address_width + EXTRA_TAG_BITS;
-  data							   =
-  directory1.caches.l_ip.line_sz;
+  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data							   = directory1.caches.l_ip.line_sz;
   interface_ip.specific_tag        = 1;
   interface_ip.tag_w               = tag;
   interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
@@ -536,10 +480,8 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_,
   interface_ip.nbanks              = 1;
   interface_ip.out_w               = interface_ip.line_sz*8;
   interface_ip.access_mode         = 0;
-  interface_ip.throughput          =
-  XML->sys.L2[ithCache].L2_config[4]/clockRate;
-  interface_ip.latency             =
-  XML->sys.L2[ithCache].L2_config[5]/clockRate;
+  interface_ip.throughput          =  XML->sys.L2[ithCache].L2_config[4]/clockRate;
+  interface_ip.latency             =  XML->sys.L2[ithCache].L2_config[5]/clockRate;
   interface_ip.obj_func_dyn_energy = 0;
   interface_ip.obj_func_dyn_power  = 0;
   interface_ip.obj_func_leak_power = 0;
@@ -556,25 +498,18 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_,
   ///cout<<"area="<<area<<endl;
 
   //prefetch buffer
-  tag							   =
-  XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries
-  to decide wthether to merge.
-  data							   =
-  directory1.caches.l_ip.line_sz;//separate queue to prevent from cache
-  polution.
+  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries to decide wthether to merge.
+  data							   = directory1.caches.l_ip.line_sz;//separate queue to prevent from cache polution.
   interface_ip.specific_tag        = 1;
   interface_ip.tag_w               = tag;
   interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-  interface_ip.cache_sz            =
-  XML->sys.L2[ithCache].buffer_sizes[2]*interface_ip.line_sz;
+  interface_ip.cache_sz            = XML->sys.L2[ithCache].buffer_sizes[2]*interface_ip.line_sz;
   interface_ip.assoc               = 0;
   interface_ip.nbanks              = 1;
   interface_ip.out_w               = interface_ip.line_sz*8;
   interface_ip.access_mode         = 0;
-  interface_ip.throughput          =
-  XML->sys.L2[ithCache].L2_config[4]/clockRate;
-  interface_ip.latency             =
-  XML->sys.L2[ithCache].L2_config[5]/clockRate;
+  interface_ip.throughput          = XML->sys.L2[ithCache].L2_config[4]/clockRate;
+  interface_ip.latency             = XML->sys.L2[ithCache].L2_config[5]/clockRate;
   interface_ip.obj_func_dyn_energy = 0;
   interface_ip.obj_func_dyn_power  = 0;
   interface_ip.obj_func_leak_power = 0;
@@ -591,23 +526,18 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_,
   ///cout<<"area="<<area<<endl;
 
   //WBB
-  tag							   =
-  XML->sys.physical_address_width + EXTRA_TAG_BITS;
-  data							   =
-  directory1.caches.l_ip.line_sz;
+  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data							   = directory1.caches.l_ip.line_sz;
   interface_ip.specific_tag        = 1;
   interface_ip.tag_w               = tag;
   interface_ip.line_sz             = data;
-  interface_ip.cache_sz            =
-  XML->sys.L2[ithCache].buffer_sizes[3]*interface_ip.line_sz;
+  interface_ip.cache_sz            = XML->sys.L2[ithCache].buffer_sizes[3]*interface_ip.line_sz;
   interface_ip.assoc               = 0;
   interface_ip.nbanks              = 1;
   interface_ip.out_w               = interface_ip.line_sz*8;
   interface_ip.access_mode         = 0;
-  interface_ip.throughput          =
-  XML->sys.L2[ithCache].L2_config[4]/clockRate;
-  interface_ip.latency             =
-  XML->sys.L2[ithCache].L2_config[5]/clockRate;
+  interface_ip.throughput          = XML->sys.L2[ithCache].L2_config[4]/clockRate;
+  interface_ip.latency             = XML->sys.L2[ithCache].L2_config[5]/clockRate;
   interface_ip.obj_func_dyn_energy = 0;
   interface_ip.obj_func_dyn_power  = 0;
   interface_ip.obj_func_leak_power = 0;
@@ -624,472 +554,357 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_,
 
   if (XML->sys.first_level_dir==1)//IC
   {
-          tag							   =
-  XML->sys.physical_address_width + EXTRA_TAG_BITS;
-          data							   =
-  int(ceil(XML->sys.domain_size/8.0));
-          interface_ip.specific_tag        = 1;
-          interface_ip.tag_w               = tag;
-          interface_ip.line_sz             = data;
-          interface_ip.cache_sz            =
-  XML->sys.domain_size*data*XML->sys.L2[ithCache].L2_config[0]/XML->sys.L2[ithCache].L2_config[1];
-          interface_ip.assoc               = 0;
-          interface_ip.nbanks              = 1024;
-          interface_ip.out_w               = interface_ip.line_sz*8;
-          interface_ip.access_mode         = 0;
-          interface_ip.throughput          =
-  XML->sys.L2[ithCache].L2_config[4]/clockRate;
-          interface_ip.latency             =
-  XML->sys.L2[ithCache].L2_config[5]/clockRate;
-          interface_ip.obj_func_dyn_energy = 0;
-          interface_ip.obj_func_dyn_power  = 0;
-          interface_ip.obj_func_leak_power = 0;
-          interface_ip.obj_func_cycle_t    = 1;
-          interface_ip.num_rw_ports    = 1;
-          interface_ip.num_rd_ports    = 0;
-          interface_ip.num_wr_ports    = 0;
-          interface_ip.num_se_rd_ports = 0;
-          strcpy(inv_dir.caches.name,"inv_dir");
-          inv_dir.caches.init_cache(&interface_ip);
-          inv_dir.caches.optimize_array();
-          inv_dir.area = inv_dir.caches.local_result.area;
+	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+	  data							   = int(ceil(XML->sys.domain_size/8.0));
+	  interface_ip.specific_tag        = 1;
+	  interface_ip.tag_w               = tag;
+	  interface_ip.line_sz             = data;
+	  interface_ip.cache_sz            = XML->sys.domain_size*data*XML->sys.L2[ithCache].L2_config[0]/XML->sys.L2[ithCache].L2_config[1];
+	  interface_ip.assoc               = 0;
+	  interface_ip.nbanks              = 1024;
+	  interface_ip.out_w               = interface_ip.line_sz*8;
+	  interface_ip.access_mode         = 0;
+	  interface_ip.throughput          = XML->sys.L2[ithCache].L2_config[4]/clockRate;
+	  interface_ip.latency             = XML->sys.L2[ithCache].L2_config[5]/clockRate;
+	  interface_ip.obj_func_dyn_energy = 0;
+	  interface_ip.obj_func_dyn_power  = 0;
+	  interface_ip.obj_func_leak_power = 0;
+	  interface_ip.obj_func_cycle_t    = 1;
+	  interface_ip.num_rw_ports    = 1;
+	  interface_ip.num_rd_ports    = 0;
+	  interface_ip.num_wr_ports    = 0;
+	  interface_ip.num_se_rd_ports = 0;
+	  strcpy(inv_dir.caches.name,"inv_dir");
+	  inv_dir.caches.init_cache(&interface_ip);
+	  inv_dir.caches.optimize_array();
+	  inv_dir.area = inv_dir.caches.local_result.area;
 
   }
 */
-  //  //pipeline
-  //  interface_ip.pipeline_stages =
-  //  int(ceil(directory.caches.local_result.access_time/directory.caches.local_result.cycle_time));
-  //  interface_ip.per_stage_vector = directory.caches.l_ip.out_w +
-  //  directory.caches.l_ip.tag_w ;
-  //  pipeLogicDirectory.init_pipeline(is_default, &interface_ip);
-  //  pipeLogicDirectory.compute_pipeline();
-  //
-  //  //clock power
-  //  clockNetwork.init_wire_external(is_default, &interface_ip);
-  //  clockNetwork.clk_area           =area*1.1;//10% of placement overhead.
-  //  rule of thumb
-  //  clockNetwork.end_wiring_level   =5;//toplevel metal
-  //  clockNetwork.start_wiring_level =5;//toplevel metal
-  //  clockNetwork.num_regs           = pipeLogicCache.tot_stage_vector +
-  //  pipeLogicDirectory.tot_stage_vector;
-  //  clockNetwork.optimize_wire();
+//  //pipeline
+//  interface_ip.pipeline_stages = int(ceil(directory.caches.local_result.access_time/directory.caches.local_result.cycle_time));
+//  interface_ip.per_stage_vector = directory.caches.l_ip.out_w + directory.caches.l_ip.tag_w ;
+//  pipeLogicDirectory.init_pipeline(is_default, &interface_ip);
+//  pipeLogicDirectory.compute_pipeline();
+//
+//  //clock power
+//  clockNetwork.init_wire_external(is_default, &interface_ip);
+//  clockNetwork.clk_area           =area*1.1;//10% of placement overhead. rule of thumb
+//  clockNetwork.end_wiring_level   =5;//toplevel metal
+//  clockNetwork.start_wiring_level =5;//toplevel metal
+//  clockNetwork.num_regs           = pipeLogicCache.tot_stage_vector + pipeLogicDirectory.tot_stage_vector;
+//  clockNetwork.optimize_wire();
+
 }
 
-void SharedCache::computeEnergy(bool is_tdp) {
-  double homenode_data_access = (cachep.dir_ty == SBT) ? 0.9 : 1.0;
-  if (is_tdp) {
-    if (!((cachep.dir_ty == ST && cacheL == L1Directory) ||
-          (cachep.dir_ty == ST && cacheL == L2Directory))) {
-      // init stats for Peak
-      unicache.caches->stats_t.readAc.access =
-          .67 * unicache.caches->l_ip.num_rw_ports * cachep.duty_cycle *
-          homenode_data_access;
-      unicache.caches->stats_t.readAc.miss = 0;
-      unicache.caches->stats_t.readAc.hit =
-          unicache.caches->stats_t.readAc.access -
-          unicache.caches->stats_t.readAc.miss;
-      unicache.caches->stats_t.writeAc.access =
-          .33 * unicache.caches->l_ip.num_rw_ports * cachep.duty_cycle *
-          homenode_data_access;
-      unicache.caches->stats_t.writeAc.miss = 0;
-      unicache.caches->stats_t.writeAc.hit =
-          unicache.caches->stats_t.writeAc.access -
-          unicache.caches->stats_t.writeAc.miss;
-      unicache.caches->tdp_stats = unicache.caches->stats_t;
 
-      if (cachep.dir_ty == SBT) {
-        homenode_stats_t.readAc.access =
-            .67 * unicache.caches->l_ip.num_rw_ports * cachep.dir_duty_cycle *
-            (1 - homenode_data_access);
-        homenode_stats_t.readAc.miss = 0;
-        homenode_stats_t.readAc.hit =
-            homenode_stats_t.readAc.access - homenode_stats_t.readAc.miss;
-        homenode_stats_t.writeAc.access =
-            .67 * unicache.caches->l_ip.num_rw_ports * cachep.dir_duty_cycle *
-            (1 - homenode_data_access);
-        homenode_stats_t.writeAc.miss = 0;
-        homenode_stats_t.writeAc.hit =
-            homenode_stats_t.writeAc.access - homenode_stats_t.writeAc.miss;
-        homenode_tdp_stats = homenode_stats_t;
-      }
+void SharedCache::computeEnergy(bool is_tdp)
+{
+	double homenode_data_access = (cachep.dir_ty==SBT)? 0.9:1.0;
+	if (is_tdp)
+	{
+		if (!((cachep.dir_ty==ST&& cacheL==L1Directory)||(cachep.dir_ty==ST&& cacheL==L2Directory)))
+		{
+			//init stats for Peak
+			unicache.caches->stats_t.readAc.access  = .67*unicache.caches->l_ip.num_rw_ports*cachep.duty_cycle*homenode_data_access;
+			unicache.caches->stats_t.readAc.miss    = 0;
+			unicache.caches->stats_t.readAc.hit     = unicache.caches->stats_t.readAc.access - unicache.caches->stats_t.readAc.miss;
+			unicache.caches->stats_t.writeAc.access = .33*unicache.caches->l_ip.num_rw_ports*cachep.duty_cycle*homenode_data_access;
+			unicache.caches->stats_t.writeAc.miss   = 0;
+			unicache.caches->stats_t.writeAc.hit    = unicache.caches->stats_t.writeAc.access -	unicache.caches->stats_t.writeAc.miss;
+			unicache.caches->tdp_stats = unicache.caches->stats_t;
 
-      unicache.missb->stats_t.readAc.access =
-          unicache.missb->l_ip.num_search_ports;
-      unicache.missb->stats_t.writeAc.access =
-          unicache.missb->l_ip.num_search_ports;
-      unicache.missb->tdp_stats = unicache.missb->stats_t;
+			if (cachep.dir_ty==SBT)
+			{
+				homenode_stats_t.readAc.access  = .67*unicache.caches->l_ip.num_rw_ports*cachep.dir_duty_cycle*(1-homenode_data_access);
+				homenode_stats_t.readAc.miss    = 0;
+				homenode_stats_t.readAc.hit     = homenode_stats_t.readAc.access - homenode_stats_t.readAc.miss;
+				homenode_stats_t.writeAc.access  = .67*unicache.caches->l_ip.num_rw_ports*cachep.dir_duty_cycle*(1-homenode_data_access);
+				homenode_stats_t.writeAc.miss   = 0;
+				homenode_stats_t.writeAc.hit    = homenode_stats_t.writeAc.access -	homenode_stats_t.writeAc.miss;
+				homenode_tdp_stats = homenode_stats_t;
+			}
 
-      unicache.ifb->stats_t.readAc.access = unicache.ifb->l_ip.num_search_ports;
-      unicache.ifb->stats_t.writeAc.access =
-          unicache.ifb->l_ip.num_search_ports;
-      unicache.ifb->tdp_stats = unicache.ifb->stats_t;
+			unicache.missb->stats_t.readAc.access  = unicache.missb->l_ip.num_search_ports;
+			unicache.missb->stats_t.writeAc.access = unicache.missb->l_ip.num_search_ports;
+			unicache.missb->tdp_stats = unicache.missb->stats_t;
 
-      unicache.prefetchb->stats_t.readAc.access =
-          unicache.prefetchb->l_ip.num_search_ports;
-      unicache.prefetchb->stats_t.writeAc.access =
-          unicache.ifb->l_ip.num_search_ports;
-      unicache.prefetchb->tdp_stats = unicache.prefetchb->stats_t;
+			unicache.ifb->stats_t.readAc.access  = unicache.ifb->l_ip.num_search_ports;
+			unicache.ifb->stats_t.writeAc.access = unicache.ifb->l_ip.num_search_ports;
+			unicache.ifb->tdp_stats = unicache.ifb->stats_t;
 
-      unicache.wbb->stats_t.readAc.access = unicache.wbb->l_ip.num_search_ports;
-      unicache.wbb->stats_t.writeAc.access =
-          unicache.wbb->l_ip.num_search_ports;
-      unicache.wbb->tdp_stats = unicache.wbb->stats_t;
-    } else {
-      unicache.caches->stats_t.readAc.access =
-          unicache.caches->l_ip.num_search_ports * cachep.duty_cycle;
-      unicache.caches->stats_t.readAc.miss = 0;
-      unicache.caches->stats_t.readAc.hit =
-          unicache.caches->stats_t.readAc.access -
-          unicache.caches->stats_t.readAc.miss;
-      unicache.caches->stats_t.writeAc.access = 0;
-      unicache.caches->stats_t.writeAc.miss = 0;
-      unicache.caches->stats_t.writeAc.hit =
-          unicache.caches->stats_t.writeAc.access -
-          unicache.caches->stats_t.writeAc.miss;
-      unicache.caches->tdp_stats = unicache.caches->stats_t;
-    }
+			unicache.prefetchb->stats_t.readAc.access  = unicache.prefetchb->l_ip.num_search_ports;
+			unicache.prefetchb->stats_t.writeAc.access = unicache.ifb->l_ip.num_search_ports;
+			unicache.prefetchb->tdp_stats = unicache.prefetchb->stats_t;
 
-  } else {
-    // init stats for runtime power (RTP)
-    if (cacheL == L2) {
-      // Copy stats from l1 to L1[0]
-      XML->sys.L2[ithCache].total_accesses = XML->sys.l2.total_accesses;
-      XML->sys.L2[ithCache].read_accesses = XML->sys.l2.read_accesses;
-      XML->sys.L2[ithCache].write_accesses = XML->sys.l2.write_accesses;
-      XML->sys.L2[ithCache].read_hits = XML->sys.l2.read_hits;
-      XML->sys.L2[ithCache].read_misses = XML->sys.l2.read_misses;
-      XML->sys.L2[ithCache].write_hits = XML->sys.l2.write_hits;
-      XML->sys.L2[ithCache].write_misses = XML->sys.l2.write_misses;
+			unicache.wbb->stats_t.readAc.access  = unicache.wbb->l_ip.num_search_ports;
+			unicache.wbb->stats_t.writeAc.access = unicache.wbb->l_ip.num_search_ports;
+			unicache.wbb->tdp_stats = unicache.wbb->stats_t;
+		}
+		else
+		{
+			unicache.caches->stats_t.readAc.access  = unicache.caches->l_ip.num_search_ports*cachep.duty_cycle;
+			unicache.caches->stats_t.readAc.miss    = 0;
+			unicache.caches->stats_t.readAc.hit     = unicache.caches->stats_t.readAc.access - unicache.caches->stats_t.readAc.miss;
+			unicache.caches->stats_t.writeAc.access = 0;
+			unicache.caches->stats_t.writeAc.miss   = 0;
+			unicache.caches->stats_t.writeAc.hit    = unicache.caches->stats_t.writeAc.access -	unicache.caches->stats_t.writeAc.miss;
+			unicache.caches->tdp_stats = unicache.caches->stats_t;
 
-      unicache.caches->stats_t.readAc.access =
-          XML->sys.L2[ithCache].read_accesses;
-      unicache.caches->stats_t.readAc.miss = XML->sys.L2[ithCache].read_misses;
-      unicache.caches->stats_t.readAc.hit =
-          unicache.caches->stats_t.readAc.access -
-          unicache.caches->stats_t.readAc.miss;
-      unicache.caches->stats_t.writeAc.access =
-          XML->sys.L2[ithCache].write_accesses;
-      unicache.caches->stats_t.writeAc.miss =
-          XML->sys.L2[ithCache].write_misses;
-      unicache.caches->stats_t.writeAc.hit =
-          unicache.caches->stats_t.writeAc.access -
-          unicache.caches->stats_t.writeAc.miss;
-      unicache.caches->rtp_stats = unicache.caches->stats_t;
+		}
 
-      if (cachep.dir_ty == SBT) {
-        homenode_rtp_stats.readAc.access =
-            XML->sys.L2[ithCache].homenode_read_accesses;
-        homenode_rtp_stats.readAc.miss =
-            XML->sys.L2[ithCache].homenode_read_misses;
-        homenode_rtp_stats.readAc.hit =
-            homenode_rtp_stats.readAc.access - homenode_rtp_stats.readAc.miss;
-        homenode_rtp_stats.writeAc.access =
-            XML->sys.L2[ithCache].homenode_write_accesses;
-        homenode_rtp_stats.writeAc.miss =
-            XML->sys.L2[ithCache].homenode_write_misses;
-        homenode_rtp_stats.writeAc.hit =
-            homenode_rtp_stats.writeAc.access - homenode_rtp_stats.writeAc.miss;
-      }
-    } else if (cacheL == L3) {
-      unicache.caches->stats_t.readAc.access =
-          XML->sys.L3[ithCache].read_accesses;
-      unicache.caches->stats_t.readAc.miss = XML->sys.L3[ithCache].read_misses;
-      unicache.caches->stats_t.readAc.hit =
-          unicache.caches->stats_t.readAc.access -
-          unicache.caches->stats_t.readAc.miss;
-      unicache.caches->stats_t.writeAc.access =
-          XML->sys.L3[ithCache].write_accesses;
-      unicache.caches->stats_t.writeAc.miss =
-          XML->sys.L3[ithCache].write_misses;
-      unicache.caches->stats_t.writeAc.hit =
-          unicache.caches->stats_t.writeAc.access -
-          unicache.caches->stats_t.writeAc.miss;
-      unicache.caches->rtp_stats = unicache.caches->stats_t;
+	}
+	else
+	{
+		//init stats for runtime power (RTP)
+		if (cacheL==L2)
+		{
+		  //Copy stats from l1 to L1[0]
+		  XML->sys.L2[ithCache].total_accesses=XML->sys.l2.total_accesses;
+		  XML->sys.L2[ithCache].read_accesses=XML->sys.l2.read_accesses;
+		  XML->sys.L2[ithCache].write_accesses=XML->sys.l2.write_accesses;
+		  XML->sys.L2[ithCache].read_hits=XML->sys.l2.read_hits;
+		  XML->sys.L2[ithCache].read_misses=XML->sys.l2.read_misses;
+		  XML->sys.L2[ithCache].write_hits=XML->sys.l2.write_hits;
+		  XML->sys.L2[ithCache].write_misses=XML->sys.l2.write_misses;
 
-      if (cachep.dir_ty == SBT) {
-        homenode_rtp_stats.readAc.access =
-            XML->sys.L3[ithCache].homenode_read_accesses;
-        homenode_rtp_stats.readAc.miss =
-            XML->sys.L3[ithCache].homenode_read_misses;
-        homenode_rtp_stats.readAc.hit =
-            homenode_rtp_stats.readAc.access - homenode_rtp_stats.readAc.miss;
-        homenode_rtp_stats.writeAc.access =
-            XML->sys.L3[ithCache].homenode_write_accesses;
-        homenode_rtp_stats.writeAc.miss =
-            XML->sys.L3[ithCache].homenode_write_misses;
-        homenode_rtp_stats.writeAc.hit =
-            homenode_rtp_stats.writeAc.access - homenode_rtp_stats.writeAc.miss;
-      }
-    } else if (cacheL == L1Directory) {
-      unicache.caches->stats_t.readAc.access =
-          XML->sys.L1Directory[ithCache].read_accesses;
-      unicache.caches->stats_t.readAc.miss =
-          XML->sys.L1Directory[ithCache].read_misses;
-      unicache.caches->stats_t.readAc.hit =
-          unicache.caches->stats_t.readAc.access -
-          unicache.caches->stats_t.readAc.miss;
-      unicache.caches->stats_t.writeAc.access =
-          XML->sys.L1Directory[ithCache].write_accesses;
-      unicache.caches->stats_t.writeAc.miss =
-          XML->sys.L1Directory[ithCache].write_misses;
-      unicache.caches->stats_t.writeAc.hit =
-          unicache.caches->stats_t.writeAc.access -
-          unicache.caches->stats_t.writeAc.miss;
-      unicache.caches->rtp_stats = unicache.caches->stats_t;
-    } else if (cacheL == L2Directory) {  // cout<<"L2 directory"<<endl;
-      // Copy stats from l1 to L1[0]
-      // XML->sys.L2[ithCache].total_accesses=XML->sys.l2.total_accesses;
-      // XML->sys.L2[ithCache].read_accesses=XML->sys.l2.read_accesses;
-      // XML->sys.L2[ithCache].write_accesses=XML->sys.l2.write_accesses;
-      // XML->sys.L2[ithCache].read_hits=XML->sys.l2.read_hits;
-      // XML->sys.L2[ithCache].read_misses=XML->sys.l2.read_misses;
-      // XML->sys.L2[ithCache].write_hits=XML->sys.l2.write_hits;
-      // XML->sys.L2[ithCache].write_misses=XML->sys.l2.write_misses;
-      unicache.caches->stats_t.readAc.access =
-          XML->sys.L2Directory[ithCache].read_accesses;
-      unicache.caches->stats_t.readAc.miss =
-          XML->sys.L2Directory[ithCache].read_misses;
-      unicache.caches->stats_t.readAc.hit =
-          unicache.caches->stats_t.readAc.access -
-          unicache.caches->stats_t.readAc.miss;
-      unicache.caches->stats_t.writeAc.access =
-          XML->sys.L2Directory[ithCache].write_accesses;
-      unicache.caches->stats_t.writeAc.miss =
-          XML->sys.L2Directory[ithCache].write_misses;
-      unicache.caches->stats_t.writeAc.hit =
-          unicache.caches->stats_t.writeAc.access -
-          unicache.caches->stats_t.writeAc.miss;
-      unicache.caches->rtp_stats = unicache.caches->stats_t;
-    }
-    if (!((cachep.dir_ty == ST && cacheL == L1Directory) ||
-          (cachep.dir_ty == ST &&
-           cacheL ==
-               L2Directory))) {  // Assuming write back and write-allocate cache
+		  unicache.caches->stats_t.readAc.access  = XML->sys.L2[ithCache].read_accesses;
+		  unicache.caches->stats_t.readAc.miss    = XML->sys.L2[ithCache].read_misses;
+		  unicache.caches->stats_t.readAc.hit     = unicache.caches->stats_t.readAc.access - unicache.caches->stats_t.readAc.miss;
+		  unicache.caches->stats_t.writeAc.access = XML->sys.L2[ithCache].write_accesses;
+		  unicache.caches->stats_t.writeAc.miss   = XML->sys.L2[ithCache].write_misses;
+		  unicache.caches->stats_t.writeAc.hit    = unicache.caches->stats_t.writeAc.access -	unicache.caches->stats_t.writeAc.miss;
+		  unicache.caches->rtp_stats = unicache.caches->stats_t;
 
-      unicache.missb->stats_t.readAc.access =
-          unicache.caches->stats_t.writeAc.miss;
-      unicache.missb->stats_t.writeAc.access =
-          unicache.caches->stats_t.writeAc.miss;
-      unicache.missb->rtp_stats = unicache.missb->stats_t;
+		  if (cachep.dir_ty==SBT)
+		  {
+			 homenode_rtp_stats.readAc.access  = XML->sys.L2[ithCache].homenode_read_accesses;
+			 homenode_rtp_stats.readAc.miss    = XML->sys.L2[ithCache].homenode_read_misses;
+			 homenode_rtp_stats.readAc.hit     = homenode_rtp_stats.readAc.access - homenode_rtp_stats.readAc.miss;
+			 homenode_rtp_stats.writeAc.access = XML->sys.L2[ithCache].homenode_write_accesses;
+			 homenode_rtp_stats.writeAc.miss   = XML->sys.L2[ithCache].homenode_write_misses;
+			 homenode_rtp_stats.writeAc.hit    = homenode_rtp_stats.writeAc.access -	homenode_rtp_stats.writeAc.miss;
+		  }
+		}
+		else if (cacheL==L3)
+		{
+		  unicache.caches->stats_t.readAc.access  = XML->sys.L3[ithCache].read_accesses;
+		  unicache.caches->stats_t.readAc.miss    = XML->sys.L3[ithCache].read_misses;
+		  unicache.caches->stats_t.readAc.hit     = unicache.caches->stats_t.readAc.access - unicache.caches->stats_t.readAc.miss;
+		  unicache.caches->stats_t.writeAc.access = XML->sys.L3[ithCache].write_accesses;
+		  unicache.caches->stats_t.writeAc.miss   = XML->sys.L3[ithCache].write_misses;
+		  unicache.caches->stats_t.writeAc.hit    = unicache.caches->stats_t.writeAc.access -	unicache.caches->stats_t.writeAc.miss;
+		  unicache.caches->rtp_stats = unicache.caches->stats_t;
 
-      unicache.ifb->stats_t.readAc.access =
-          unicache.caches->stats_t.writeAc.miss;
-      unicache.ifb->stats_t.writeAc.access =
-          unicache.caches->stats_t.writeAc.miss;
-      unicache.ifb->rtp_stats = unicache.ifb->stats_t;
+		  if (cachep.dir_ty==SBT)
+		  {
+			 homenode_rtp_stats.readAc.access  = XML->sys.L3[ithCache].homenode_read_accesses;
+			 homenode_rtp_stats.readAc.miss    = XML->sys.L3[ithCache].homenode_read_misses;
+			 homenode_rtp_stats.readAc.hit     = homenode_rtp_stats.readAc.access - homenode_rtp_stats.readAc.miss;
+			 homenode_rtp_stats.writeAc.access = XML->sys.L3[ithCache].homenode_write_accesses;
+			 homenode_rtp_stats.writeAc.miss   = XML->sys.L3[ithCache].homenode_write_misses;
+			 homenode_rtp_stats.writeAc.hit    = homenode_rtp_stats.writeAc.access -	homenode_rtp_stats.writeAc.miss;
+		  }
+		}
+		else if (cacheL==L1Directory)
+		{
+		  unicache.caches->stats_t.readAc.access  = XML->sys.L1Directory[ithCache].read_accesses;
+		  unicache.caches->stats_t.readAc.miss    = XML->sys.L1Directory[ithCache].read_misses;
+		  unicache.caches->stats_t.readAc.hit     = unicache.caches->stats_t.readAc.access - unicache.caches->stats_t.readAc.miss;
+		  unicache.caches->stats_t.writeAc.access = XML->sys.L1Directory[ithCache].write_accesses;
+		  unicache.caches->stats_t.writeAc.miss   = XML->sys.L1Directory[ithCache].write_misses;
+		  unicache.caches->stats_t.writeAc.hit    = unicache.caches->stats_t.writeAc.access -	unicache.caches->stats_t.writeAc.miss;
+		  unicache.caches->rtp_stats = unicache.caches->stats_t;
+		}
+		else if (cacheL==L2Directory)
+		{ //cout<<"L2 directory"<<endl;
+		  //Copy stats from l1 to L1[0]
+		  //XML->sys.L2[ithCache].total_accesses=XML->sys.l2.total_accesses;
+		  //XML->sys.L2[ithCache].read_accesses=XML->sys.l2.read_accesses;
+		  //XML->sys.L2[ithCache].write_accesses=XML->sys.l2.write_accesses;
+		  //XML->sys.L2[ithCache].read_hits=XML->sys.l2.read_hits;
+		  //XML->sys.L2[ithCache].read_misses=XML->sys.l2.read_misses;
+		  //XML->sys.L2[ithCache].write_hits=XML->sys.l2.write_hits;
+		  //XML->sys.L2[ithCache].write_misses=XML->sys.l2.write_misses;
+		  unicache.caches->stats_t.readAc.access  = XML->sys.L2Directory[ithCache].read_accesses;
+		  unicache.caches->stats_t.readAc.miss    = XML->sys.L2Directory[ithCache].read_misses;
+		  unicache.caches->stats_t.readAc.hit     = unicache.caches->stats_t.readAc.access - unicache.caches->stats_t.readAc.miss;
+		  unicache.caches->stats_t.writeAc.access = XML->sys.L2Directory[ithCache].write_accesses;
+		  unicache.caches->stats_t.writeAc.miss   = XML->sys.L2Directory[ithCache].write_misses;
+		  unicache.caches->stats_t.writeAc.hit    = unicache.caches->stats_t.writeAc.access -	unicache.caches->stats_t.writeAc.miss;
+		  unicache.caches->rtp_stats = unicache.caches->stats_t;
+		}
+		if (!((cachep.dir_ty==ST&& cacheL==L1Directory)||(cachep.dir_ty==ST&& cacheL==L2Directory)))
+		{   //Assuming write back and write-allocate cache
 
-      unicache.prefetchb->stats_t.readAc.access =
-          unicache.caches->stats_t.writeAc.miss;
-      unicache.prefetchb->stats_t.writeAc.access =
-          unicache.caches->stats_t.writeAc.miss;
-      unicache.prefetchb->rtp_stats = unicache.prefetchb->stats_t;
+		  unicache.missb->stats_t.readAc.access  = unicache.caches->stats_t.writeAc.miss ;
+		  unicache.missb->stats_t.writeAc.access = unicache.caches->stats_t.writeAc.miss;
+		  unicache.missb->rtp_stats = unicache.missb->stats_t;
 
-      unicache.wbb->stats_t.readAc.access =
-          unicache.caches->stats_t.writeAc.miss;
-      unicache.wbb->stats_t.writeAc.access =
-          unicache.caches->stats_t.writeAc.miss;
-      if (cachep.dir_ty == SBT) {
-        unicache.missb->stats_t.readAc.access +=
-            homenode_rtp_stats.writeAc.miss;
-        unicache.missb->stats_t.writeAc.access +=
-            homenode_rtp_stats.writeAc.miss;
-        unicache.missb->rtp_stats = unicache.missb->stats_t;
+		  unicache.ifb->stats_t.readAc.access  = unicache.caches->stats_t.writeAc.miss;
+		  unicache.ifb->stats_t.writeAc.access = unicache.caches->stats_t.writeAc.miss;
+		  unicache.ifb->rtp_stats = unicache.ifb->stats_t;
 
-        unicache.missb->stats_t.readAc.access +=
-            homenode_rtp_stats.writeAc.miss;
-        unicache.missb->stats_t.writeAc.access +=
-            homenode_rtp_stats.writeAc.miss;
-        unicache.missb->rtp_stats = unicache.missb->stats_t;
+		  unicache.prefetchb->stats_t.readAc.access  = unicache.caches->stats_t.writeAc.miss;
+		  unicache.prefetchb->stats_t.writeAc.access = unicache.caches->stats_t.writeAc.miss;
+		  unicache.prefetchb->rtp_stats = unicache.prefetchb->stats_t;
 
-        unicache.ifb->stats_t.readAc.access += homenode_rtp_stats.writeAc.miss;
-        unicache.ifb->stats_t.writeAc.access += homenode_rtp_stats.writeAc.miss;
-        unicache.ifb->rtp_stats = unicache.ifb->stats_t;
+		  unicache.wbb->stats_t.readAc.access  = unicache.caches->stats_t.writeAc.miss;
+		  unicache.wbb->stats_t.writeAc.access = unicache.caches->stats_t.writeAc.miss;
+		  if (cachep.dir_ty==SBT)
+		  {
+			 unicache.missb->stats_t.readAc.access  += homenode_rtp_stats.writeAc.miss;
+			 unicache.missb->stats_t.writeAc.access += homenode_rtp_stats.writeAc.miss;
+			 unicache.missb->rtp_stats = unicache.missb->stats_t;
 
-        unicache.prefetchb->stats_t.readAc.access +=
-            homenode_rtp_stats.writeAc.miss;
-        unicache.prefetchb->stats_t.writeAc.access +=
-            homenode_rtp_stats.writeAc.miss;
-        unicache.prefetchb->rtp_stats = unicache.prefetchb->stats_t;
+			 unicache.missb->stats_t.readAc.access  += homenode_rtp_stats.writeAc.miss;
+			 unicache.missb->stats_t.writeAc.access += homenode_rtp_stats.writeAc.miss;
+			 unicache.missb->rtp_stats = unicache.missb->stats_t;
 
-        unicache.wbb->stats_t.readAc.access += homenode_rtp_stats.writeAc.miss;
-        unicache.wbb->stats_t.writeAc.access += homenode_rtp_stats.writeAc.miss;
-      }
-      unicache.wbb->rtp_stats = unicache.wbb->stats_t;
-    }
-  }
+			 unicache.ifb->stats_t.readAc.access  += homenode_rtp_stats.writeAc.miss;
+			 unicache.ifb->stats_t.writeAc.access += homenode_rtp_stats.writeAc.miss;
+			 unicache.ifb->rtp_stats = unicache.ifb->stats_t;
 
-  unicache.power_t.reset();
-  unicache.rt_power.reset();
-  if (!((cachep.dir_ty == ST && cacheL == L1Directory) ||
-        (cachep.dir_ty == ST && cacheL == L2Directory))) {
-    unicache.power_t.readOp.dynamic +=
-        (unicache.caches->stats_t.readAc.hit *
-             unicache.caches->local_result.power.readOp.dynamic +
-         unicache.caches->stats_t.readAc.miss *
-             unicache.caches->local_result.tag_array2->power.readOp.dynamic +
-         unicache.caches->stats_t.writeAc.miss *
-             unicache.caches->local_result.tag_array2->power.writeOp.dynamic +
-         unicache.caches->stats_t.writeAc.access *
-             unicache.caches->local_result.power.writeOp
-                 .dynamic);  // write miss will also generate a write later
+			 unicache.prefetchb->stats_t.readAc.access  += homenode_rtp_stats.writeAc.miss;
+			 unicache.prefetchb->stats_t.writeAc.access += homenode_rtp_stats.writeAc.miss;
+			 unicache.prefetchb->rtp_stats = unicache.prefetchb->stats_t;
 
-    if (cachep.dir_ty == SBT) {
-      unicache.power_t.readOp.dynamic +=
-          homenode_stats_t.readAc.hit *
-              (unicache.caches->local_result.data_array2->power.readOp.dynamic *
-                   dir_overhead +
-               unicache.caches->local_result.tag_array2->power.readOp.dynamic) +
-          homenode_stats_t.readAc.miss *
-              unicache.caches->local_result.tag_array2->power.readOp.dynamic +
-          homenode_stats_t.writeAc.miss *
-              unicache.caches->local_result.tag_array2->power.readOp.dynamic +
-          homenode_stats_t.writeAc.hit *
-              (unicache.caches->local_result.data_array2->power.writeOp
-                       .dynamic *
-                   dir_overhead +
-               unicache.caches->local_result.tag_array2->power.readOp.dynamic +
-               homenode_stats_t.writeAc.miss *
-                   unicache.caches->local_result.power.writeOp
-                       .dynamic);  // write miss on dynamic home node will
-                                   // generate a replacement write on whole
-                                   // cache block
-    }
+			 unicache.wbb->stats_t.readAc.access  += homenode_rtp_stats.writeAc.miss;
+			 unicache.wbb->stats_t.writeAc.access += homenode_rtp_stats.writeAc.miss;
+		  }
+		  unicache.wbb->rtp_stats = unicache.wbb->stats_t;
 
-    unicache.power_t.readOp.dynamic +=
-        unicache.missb->stats_t.readAc.access *
-            unicache.missb->local_result.power.searchOp.dynamic +
-        unicache.missb->stats_t.writeAc.access *
-            unicache.missb->local_result.power.writeOp
-                .dynamic;  // each access to missb involves a CAM and a write
-    unicache.power_t.readOp.dynamic +=
-        unicache.ifb->stats_t.readAc.access *
-            unicache.ifb->local_result.power.searchOp.dynamic +
-        unicache.ifb->stats_t.writeAc.access *
-            unicache.ifb->local_result.power.writeOp.dynamic;
-    unicache.power_t.readOp.dynamic +=
-        unicache.prefetchb->stats_t.readAc.access *
-            unicache.prefetchb->local_result.power.searchOp.dynamic +
-        unicache.prefetchb->stats_t.writeAc.access *
-            unicache.prefetchb->local_result.power.writeOp.dynamic;
-    unicache.power_t.readOp.dynamic +=
-        unicache.wbb->stats_t.readAc.access *
-            unicache.wbb->local_result.power.searchOp.dynamic +
-        unicache.wbb->stats_t.writeAc.access *
-            unicache.wbb->local_result.power.writeOp.dynamic;
-  } else {
-    unicache.power_t.readOp.dynamic +=
-        (unicache.caches->stats_t.readAc.access *
-             unicache.caches->local_result.power.searchOp.dynamic +
-         unicache.caches->stats_t.writeAc.access *
-             unicache.caches->local_result.power.writeOp.dynamic);
-  }
+		}
 
-  if (is_tdp) {
-    unicache.power =
-        unicache.power_t + (unicache.caches->local_result.power) * pppm_lkg;
-    if (!((cachep.dir_ty == ST && cacheL == L1Directory) ||
-          (cachep.dir_ty == ST && cacheL == L2Directory))) {
-      unicache.power = unicache.power +
-                       (unicache.missb->local_result.power +
-                        unicache.ifb->local_result.power +
-                        unicache.prefetchb->local_result.power +
-                        unicache.wbb->local_result.power) *
-                           pppm_lkg;
-    }
-    power = power + unicache.power;
-    //		cout<<"unicache.caches->local_result.power.readOp.dynamic"<<unicache.caches->local_result.power.readOp.dynamic<<endl;
-    //		cout<<"unicache.caches->local_result.power.writeOp.dynamic"<<unicache.caches->local_result.power.writeOp.dynamic<<endl;
-  } else {
-    unicache.rt_power =
-        unicache.power_t + (unicache.caches->local_result.power) * pppm_lkg;
-    if (!((cachep.dir_ty == ST && cacheL == L1Directory) ||
-          (cachep.dir_ty == ST && cacheL == L2Directory))) {
-      unicache.rt_power = unicache.rt_power +
-                          (unicache.missb->local_result.power +
-                           unicache.ifb->local_result.power +
-                           unicache.prefetchb->local_result.power +
-                           unicache.wbb->local_result.power) *
-                              pppm_lkg;
-    }
+	}
 
-    rt_power = rt_power + unicache.rt_power;
-  }
+	unicache.power_t.reset();
+   unicache.rt_power.reset();
+	if (!((cachep.dir_ty==ST&& cacheL==L1Directory)||(cachep.dir_ty==ST&& cacheL==L2Directory)))
+	{ 
+
+	  unicache.power_t.readOp.dynamic	+= (unicache.caches->stats_t.readAc.hit*unicache.caches->local_result.power.readOp.dynamic+
+			unicache.caches->stats_t.readAc.miss*unicache.caches->local_result.tag_array2->power.readOp.dynamic+
+			unicache.caches->stats_t.writeAc.miss*unicache.caches->local_result.tag_array2->power.writeOp.dynamic+
+			unicache.caches->stats_t.writeAc.access*unicache.caches->local_result.power.writeOp.dynamic);//write miss will also generate a write later
+
+	  if (cachep.dir_ty==SBT)
+	  {
+		 unicache.power_t.readOp.dynamic	+= homenode_stats_t.readAc.hit * (unicache.caches->local_result.data_array2->power.readOp.dynamic*dir_overhead +
+			  unicache.caches->local_result.tag_array2->power.readOp.dynamic) +
+			homenode_stats_t.readAc.miss*unicache.caches->local_result.tag_array2->power.readOp.dynamic +
+			homenode_stats_t.writeAc.miss*unicache.caches->local_result.tag_array2->power.readOp.dynamic +
+			homenode_stats_t.writeAc.hit*(unicache.caches->local_result.data_array2->power.writeOp.dynamic*dir_overhead +
+				 unicache.caches->local_result.tag_array2->power.readOp.dynamic+
+				 homenode_stats_t.writeAc.miss*unicache.caches->local_result.power.writeOp.dynamic);//write miss on dynamic home node will generate a replacement write on whole cache block
+
+
+	  }
+
+	  unicache.power_t.readOp.dynamic	+=  unicache.missb->stats_t.readAc.access*unicache.missb->local_result.power.searchOp.dynamic +
+		 unicache.missb->stats_t.writeAc.access*unicache.missb->local_result.power.writeOp.dynamic;//each access to missb involves a CAM and a write
+	  unicache.power_t.readOp.dynamic	+=  unicache.ifb->stats_t.readAc.access*unicache.ifb->local_result.power.searchOp.dynamic +
+		 unicache.ifb->stats_t.writeAc.access*unicache.ifb->local_result.power.writeOp.dynamic;
+	  unicache.power_t.readOp.dynamic	+=  unicache.prefetchb->stats_t.readAc.access*unicache.prefetchb->local_result.power.searchOp.dynamic +
+		 unicache.prefetchb->stats_t.writeAc.access*unicache.prefetchb->local_result.power.writeOp.dynamic;
+	  unicache.power_t.readOp.dynamic	+=  unicache.wbb->stats_t.readAc.access*unicache.wbb->local_result.power.searchOp.dynamic +
+		 unicache.wbb->stats_t.writeAc.access*unicache.wbb->local_result.power.writeOp.dynamic;
+	}
+	else
+	{
+	  unicache.power_t.readOp.dynamic	+= (unicache.caches->stats_t.readAc.access*unicache.caches->local_result.power.searchOp.dynamic+
+			unicache.caches->stats_t.writeAc.access*unicache.caches->local_result.power.writeOp.dynamic);
+	}
+
+	if (is_tdp)
+	{
+	  unicache.power = unicache.power_t + (unicache.caches->local_result.power)*pppm_lkg;
+	  if (!((cachep.dir_ty==ST&& cacheL==L1Directory)||(cachep.dir_ty==ST&& cacheL==L2Directory)))
+	  {
+		 unicache.power = unicache.power+
+			(unicache.missb->local_result.power +
+			 unicache.ifb->local_result.power +
+			 unicache.prefetchb->local_result.power +
+			 unicache.wbb->local_result.power)*pppm_lkg;
+	  }
+	  power     = power + unicache.power;
+	  //		cout<<"unicache.caches->local_result.power.readOp.dynamic"<<unicache.caches->local_result.power.readOp.dynamic<<endl;
+	  //		cout<<"unicache.caches->local_result.power.writeOp.dynamic"<<unicache.caches->local_result.power.writeOp.dynamic<<endl;
+	}
+	else
+	{
+
+	  unicache.rt_power = unicache.power_t + (unicache.caches->local_result.power)*pppm_lkg;
+	  if (!((cachep.dir_ty==ST&& cacheL==L1Directory)||(cachep.dir_ty==ST&& cacheL==L2Directory)))
+	  {
+		 unicache.rt_power = unicache.rt_power +
+		  (unicache.missb->local_result.power +
+		  unicache.ifb->local_result.power +
+		  unicache.prefetchb->local_result.power +
+		  unicache.wbb->local_result.power)*pppm_lkg;
+	  }
+
+	  rt_power     = rt_power + unicache.rt_power;
+	}
 }
 
-void SharedCache::displayEnergy(uint32_t indent, bool is_tdp) {
+void SharedCache::displayEnergy(uint32_t indent,bool is_tdp)
+{
   string indent_str(indent, ' ');
-  string indent_str_next(indent + 2, ' ');
+  string indent_str_next(indent+2, ' ');
   bool long_channel = XML->sys.longer_channel_device;
 
-  if (is_tdp) {
-    cout << (XML->sys.Private_L2 ? indent_str : "") << cachep.name << endl;
-    cout << indent_str << "Area = " << area.get_area() * 1e-6 << " mm^2"
-         << endl;
-    cout << indent_str
-         << "Peak Dynamic = " << power.readOp.dynamic * cachep.clockRate << " W"
-         << endl;
-    cout << indent_str << "Subthreshold Leakage = "
-         << (long_channel ? power.readOp.longer_channel_leakage
-                          : power.readOp.leakage)
-         << " W" << endl;
-    // cout << indent_str << "Subthreshold Leakage = " <<
-    // power.readOp.longer_channel_leakage <<" W" << endl;
-    cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W"
-         << endl;
-    cout << indent_str << "Runtime Dynamic = "
-         << rt_power.readOp.dynamic / cachep.executionTime << " W" << endl;
-    cout << endl;
-  } else {
+  if (is_tdp)
+  {
+	 cout << (XML->sys.Private_L2? indent_str:"")<< cachep.name << endl;
+	 cout << indent_str << "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
+	 cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic*cachep.clockRate << " W" << endl;
+	 cout << indent_str << "Subthreshold Leakage = "
+		<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
+	 //cout << indent_str << "Subthreshold Leakage = " << power.readOp.longer_channel_leakage <<" W" << endl;
+	 cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
+	 cout << indent_str << "Runtime Dynamic = " << rt_power.readOp.dynamic/cachep.executionTime << " W" << endl;
+	 cout <<endl;
+  }
+  else
+  {
   }
 }
 
-// void SharedCache::computeMaxPower()
+//void SharedCache::computeMaxPower()
 //{
 //  //Compute maximum power and runtime power.
-//  //When computing runtime power, McPAT gets or reasons out the statistics
-//  based on XML input.
+//  //When computing runtime power, McPAT gets or reasons out the statistics based on XML input.
 //  maxPower		= 0.0;
 //  //llCache,itlb
 //  llCache.maxPower   = 0.0;
-//  llCache.maxPower	+=
-//  (llCache.caches.l_ip.num_rw_ports*(0.67*llCache.caches.local_result.power.readOp.dynamic+0.33*llCache.caches.local_result.power.writeOp.dynamic)
+//  llCache.maxPower	+=  (llCache.caches.l_ip.num_rw_ports*(0.67*llCache.caches.local_result.power.readOp.dynamic+0.33*llCache.caches.local_result.power.writeOp.dynamic)
 //                        +llCache.caches.l_ip.num_rd_ports*llCache.caches.local_result.power.readOp.dynamic+llCache.caches.l_ip.num_wr_ports*llCache.caches.local_result.power.writeOp.dynamic
 //                        +llCache.caches.l_ip.num_se_rd_ports*llCache.caches.local_result.power.readOp.dynamic)*clockRate;
 //  ///cout<<"llCache.maxPower=" <<llCache.maxPower<<endl;
 //
-//  llCache.maxPower	+=
-//  llCache.missb.l_ip.num_search_ports*llCache.missb.local_result.power.searchOp.dynamic*clockRate;
+//  llCache.maxPower	+=  llCache.missb.l_ip.num_search_ports*llCache.missb.local_result.power.searchOp.dynamic*clockRate;
 //  ///cout<<"llCache.maxPower=" <<llCache.maxPower<<endl;
 //
-//  llCache.maxPower	+=
-//  llCache.ifb.l_ip.num_search_ports*llCache.ifb.local_result.power.searchOp.dynamic*clockRate;
+//  llCache.maxPower	+=  llCache.ifb.l_ip.num_search_ports*llCache.ifb.local_result.power.searchOp.dynamic*clockRate;
 //  ///cout<<"llCache.maxPower=" <<llCache.maxPower<<endl;
 //
-//  llCache.maxPower	+=
-//  llCache.prefetchb.l_ip.num_search_ports*llCache.prefetchb.local_result.power.searchOp.dynamic*clockRate;
+//  llCache.maxPower	+=  llCache.prefetchb.l_ip.num_search_ports*llCache.prefetchb.local_result.power.searchOp.dynamic*clockRate;
 //  ///cout<<"llCache.maxPower=" <<llCache.maxPower<<endl;
 //
-//  llCache.maxPower	+=
-//  llCache.wbb.l_ip.num_search_ports*llCache.wbb.local_result.power.searchOp.dynamic*clockRate;
-//  //llCache.maxPower *=  scktRatio; //TODO: this calculation should be
-//  self-contained
+//  llCache.maxPower	+=  llCache.wbb.l_ip.num_search_ports*llCache.wbb.local_result.power.searchOp.dynamic*clockRate;
+//  //llCache.maxPower *=  scktRatio; //TODO: this calculation should be self-contained
 //  ///cout<<"llCache.maxPower=" <<llCache.maxPower<<endl;
 //
-////  directory_power =
-///(directory.caches.l_ip.num_rw_ports*(0.67*directory.caches.local_result.power.readOp.dynamic+0.33*directory.caches.local_result.power.writeOp.dynamic)
-////
-///+directory.caches.l_ip.num_rd_ports*directory.caches.local_result.power.readOp.dynamic+directory.caches.l_ip.num_wr_ports*directory.caches.local_result.power.writeOp.dynamic
-////
-///+directory.caches.l_ip.num_se_rd_ports*directory.caches.local_result.power.readOp.dynamic)*clockRate;
+////  directory_power =  (directory.caches.l_ip.num_rw_ports*(0.67*directory.caches.local_result.power.readOp.dynamic+0.33*directory.caches.local_result.power.writeOp.dynamic)
+////                        +directory.caches.l_ip.num_rd_ports*directory.caches.local_result.power.readOp.dynamic+directory.caches.l_ip.num_wr_ports*directory.caches.local_result.power.writeOp.dynamic
+////                        +directory.caches.l_ip.num_se_rd_ports*directory.caches.local_result.power.readOp.dynamic)*clockRate;
 //
 //  L2Tot.power.readOp.dynamic = llCache.maxPower;
-//  L2Tot.power.readOp.leakage =
-//  llCache.caches.local_result.power.readOp.leakage +
-//                               llCache.missb.local_result.power.readOp.leakage
-//                               +
+//  L2Tot.power.readOp.leakage = llCache.caches.local_result.power.readOp.leakage +
+//                               llCache.missb.local_result.power.readOp.leakage +
 //                               llCache.ifb.local_result.power.readOp.leakage +
-//                               llCache.prefetchb.local_result.power.readOp.leakage
-//                               +
+//                               llCache.prefetchb.local_result.power.readOp.leakage +
 //                               llCache.wbb.local_result.power.readOp.leakage;
 //
 //  L2Tot.area.set_area(llCache.area*1.1*1e-6);//placement and routing overhead
@@ -1099,37 +914,27 @@ void SharedCache::displayEnergy(uint32_t indent, bool is_tdp) {
 //	  if (XML->sys.first_level_dir==0)
 //	  {
 //		  directory.maxPower   = 0.0;
-//		  directory.maxPower	+=
-//(directory.caches.l_ip.num_rw_ports*(0.67*directory.caches.local_result.power.readOp.dynamic+0.33*directory.caches.local_result.power.writeOp.dynamic)
+//		  directory.maxPower	+=  (directory.caches.l_ip.num_rw_ports*(0.67*directory.caches.local_result.power.readOp.dynamic+0.33*directory.caches.local_result.power.writeOp.dynamic)
 //		                        +directory.caches.l_ip.num_rd_ports*directory.caches.local_result.power.readOp.dynamic+directory.caches.l_ip.num_wr_ports*directory.caches.local_result.power.writeOp.dynamic
 //		                        +directory.caches.l_ip.num_se_rd_ports*directory.caches.local_result.power.readOp.dynamic)*clockRate;
 //		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
 //
-//		  directory.maxPower	+=
-//directory.missb.l_ip.num_search_ports*directory.missb.local_result.power.searchOp.dynamic*clockRate;
+//		  directory.maxPower	+=  directory.missb.l_ip.num_search_ports*directory.missb.local_result.power.searchOp.dynamic*clockRate;
 //		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
 //
-//		  directory.maxPower	+=
-//directory.ifb.l_ip.num_search_ports*directory.ifb.local_result.power.searchOp.dynamic*clockRate;
+//		  directory.maxPower	+=  directory.ifb.l_ip.num_search_ports*directory.ifb.local_result.power.searchOp.dynamic*clockRate;
 //		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
 //
-//		  directory.maxPower	+=
-//directory.prefetchb.l_ip.num_search_ports*directory.prefetchb.local_result.power.searchOp.dynamic*clockRate;
+//		  directory.maxPower	+=  directory.prefetchb.l_ip.num_search_ports*directory.prefetchb.local_result.power.searchOp.dynamic*clockRate;
 //		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
 //
-//		  directory.maxPower	+=
-//directory.wbb.l_ip.num_search_ports*directory.wbb.local_result.power.searchOp.dynamic*clockRate;
+//		  directory.maxPower	+=  directory.wbb.l_ip.num_search_ports*directory.wbb.local_result.power.searchOp.dynamic*clockRate;
 //
-//		  cc.power.readOp.dynamic = directory.maxPower*scktRatio*8;//8 is
-//the memory controller counts
-//		  cc.power.readOp.leakage =
-//directory.caches.local_result.power.readOp.leakage +
-//                                     directory.missb.local_result.power.readOp.leakage
-//                                     +
-//                                     directory.ifb.local_result.power.readOp.leakage
-//                                     +
-//                                     directory.prefetchb.local_result.power.readOp.leakage
-//                                     +
+//		  cc.power.readOp.dynamic = directory.maxPower*scktRatio*8;//8 is the memory controller counts
+//		  cc.power.readOp.leakage = directory.caches.local_result.power.readOp.leakage +
+//                                     directory.missb.local_result.power.readOp.leakage +
+//                                     directory.ifb.local_result.power.readOp.leakage +
+//                                     directory.prefetchb.local_result.power.readOp.leakage +
 //                                     directory.wbb.local_result.power.readOp.leakage;
 //
 //		  cc.power.readOp.leakage *=8;
@@ -1139,24 +944,19 @@ void SharedCache::displayEnergy(uint32_t indent, bool is_tdp) {
 //		  cout<<"CC Power="<<cc.power.readOp.dynamic<<endl;
 //		  ccTot.area.set_area(cc.area.get_area()*1e-6);
 //		  ccTot.power = cc.power;
-//		  cout<<"DC energy per access" <<
-//cc.power.readOp.dynamic/clockRate/8;
+//		  cout<<"DC energy per access" << cc.power.readOp.dynamic/clockRate/8;
 //	  }
 //	  else if (XML->sys.first_level_dir==1)
 //	  {
-//		  inv_dir.maxPower =
-//inv_dir.caches.local_result.power.searchOp.dynamic*clockRate*XML->sys.domain_size;
-//		  cc.power.readOp.dynamic  =
-//inv_dir.maxPower*scktRatio*64/XML->sys.domain_size;
-//		  cc.power.readOp.leakage  =
-//inv_dir.caches.local_result.power.readOp.leakage*inv_dir.caches.l_ip.nbanks*64/XML->sys.domain_size;
+//		  inv_dir.maxPower = inv_dir.caches.local_result.power.searchOp.dynamic*clockRate*XML->sys.domain_size;
+//		  cc.power.readOp.dynamic  = inv_dir.maxPower*scktRatio*64/XML->sys.domain_size;
+//		  cc.power.readOp.leakage  = inv_dir.caches.local_result.power.readOp.leakage*inv_dir.caches.l_ip.nbanks*64/XML->sys.domain_size;
 //
 //		  cc.area.set_area(inv_dir.area*64/XML->sys.domain_size);
 //		  cout<<"CC area="<<cc.area.get_area()*1e-6<<endl;
 //		  cout<<"CC Power="<<cc.power.readOp.dynamic<<endl;
 //		  ccTot.area.set_area(cc.area.get_area()*1e-6);
-//		  cout<<"DC energy per access" <<
-//cc.power.readOp.dynamic/clockRate/8;
+//		  cout<<"DC energy per access" << cc.power.readOp.dynamic/clockRate/8;
 //		  ccTot.power = cc.power;
 //	  }
 //  }
@@ -1165,41 +965,27 @@ void SharedCache::displayEnergy(uint32_t indent, bool is_tdp) {
 //  {
 //
 //	  		  directory.maxPower   = 0.0;
-//	  		  directory.maxPower	+=
-//(directory.caches.l_ip.num_rw_ports*(0.67*directory.caches.local_result.power.readOp.dynamic+0.33*directory.caches.local_result.power.writeOp.dynamic)
+//	  		  directory.maxPower	+=  (directory.caches.l_ip.num_rw_ports*(0.67*directory.caches.local_result.power.readOp.dynamic+0.33*directory.caches.local_result.power.writeOp.dynamic)
 //	  		                        +directory.caches.l_ip.num_rd_ports*directory.caches.local_result.power.readOp.dynamic+directory.caches.l_ip.num_wr_ports*directory.caches.local_result.power.writeOp.dynamic
 //	  		                        +directory.caches.l_ip.num_se_rd_ports*directory.caches.local_result.power.readOp.dynamic)*clockRate;
-//	  		  ///cout<<"directory.maxPower="
-//<<directory.maxPower<<endl;
+//	  		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
 //
-//	  		  directory.maxPower	+=
-//directory.missb.l_ip.num_search_ports*directory.missb.local_result.power.searchOp.dynamic*clockRate;
-//	  		  ///cout<<"directory.maxPower="
-//<<directory.maxPower<<endl;
+//	  		  directory.maxPower	+=  directory.missb.l_ip.num_search_ports*directory.missb.local_result.power.searchOp.dynamic*clockRate;
+//	  		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
 //
-//	  		  directory.maxPower	+=
-//directory.ifb.l_ip.num_search_ports*directory.ifb.local_result.power.searchOp.dynamic*clockRate;
-//	  		  ///cout<<"directory.maxPower="
-//<<directory.maxPower<<endl;
+//	  		  directory.maxPower	+=  directory.ifb.l_ip.num_search_ports*directory.ifb.local_result.power.searchOp.dynamic*clockRate;
+//	  		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
 //
-//	  		  directory.maxPower	+=
-//directory.prefetchb.l_ip.num_search_ports*directory.prefetchb.local_result.power.searchOp.dynamic*clockRate;
-//	  		  ///cout<<"directory.maxPower="
-//<<directory.maxPower<<endl;
+//	  		  directory.maxPower	+=  directory.prefetchb.l_ip.num_search_ports*directory.prefetchb.local_result.power.searchOp.dynamic*clockRate;
+//	  		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
 //
-//	  		  directory.maxPower	+=
-//directory.wbb.l_ip.num_search_ports*directory.wbb.local_result.power.searchOp.dynamic*clockRate;
+//	  		  directory.maxPower	+=  directory.wbb.l_ip.num_search_ports*directory.wbb.local_result.power.searchOp.dynamic*clockRate;
 //
-//	  		  cc.power.readOp.dynamic =
-//directory.maxPower*scktRatio*8;//8 is the memory controller counts
-//			  cc.power.readOp.leakage =
-//directory.caches.local_result.power.readOp.leakage +
-//	                                     directory.missb.local_result.power.readOp.leakage
-//+
-//	                                     directory.ifb.local_result.power.readOp.leakage
-//+
-//	                                     directory.prefetchb.local_result.power.readOp.leakage
-//+
+//	  		  cc.power.readOp.dynamic = directory.maxPower*scktRatio*8;//8 is the memory controller counts
+//			  cc.power.readOp.leakage = directory.caches.local_result.power.readOp.leakage +
+//	                                     directory.missb.local_result.power.readOp.leakage +
+//	                                     directory.ifb.local_result.power.readOp.leakage +
+//	                                     directory.prefetchb.local_result.power.readOp.leakage +
 //	                                     directory.wbb.local_result.power.readOp.leakage;
 //			  cc.power.readOp.leakage *=8;
 //	  		  cc.area.set_area(directory.area*8);
@@ -1207,66 +993,45 @@ void SharedCache::displayEnergy(uint32_t indent, bool is_tdp) {
 //	  		if (XML->sys.first_level_dir==0)
 //	  		{
 //	  		  directory1.maxPower   = 0.0;
-//	  		  directory1.maxPower	+=
-//(directory1.caches.l_ip.num_rw_ports*(0.67*directory1.caches.local_result.power.readOp.dynamic+0.33*directory1.caches.local_result.power.writeOp.dynamic)
+//	  		  directory1.maxPower	+=  (directory1.caches.l_ip.num_rw_ports*(0.67*directory1.caches.local_result.power.readOp.dynamic+0.33*directory1.caches.local_result.power.writeOp.dynamic)
 //	  				  +directory1.caches.l_ip.num_rd_ports*directory1.caches.local_result.power.readOp.dynamic+directory1.caches.l_ip.num_wr_ports*directory1.caches.local_result.power.writeOp.dynamic
 //	  				  +directory1.caches.l_ip.num_se_rd_ports*directory1.caches.local_result.power.readOp.dynamic)*clockRate;
-//	  		  ///cout<<"directory1.maxPower="
-//<<directory1.maxPower<<endl;
+//	  		  ///cout<<"directory1.maxPower=" <<directory1.maxPower<<endl;
 //
-//	  		  directory1.maxPower	+=
-//directory1.missb.l_ip.num_search_ports*directory1.missb.local_result.power.searchOp.dynamic*clockRate;
-//	  		  ///cout<<"directory1.maxPower="
-//<<directory1.maxPower<<endl;
+//	  		  directory1.maxPower	+=  directory1.missb.l_ip.num_search_ports*directory1.missb.local_result.power.searchOp.dynamic*clockRate;
+//	  		  ///cout<<"directory1.maxPower=" <<directory1.maxPower<<endl;
 //
-//	  		  directory1.maxPower	+=
-//directory1.ifb.l_ip.num_search_ports*directory1.ifb.local_result.power.searchOp.dynamic*clockRate;
-//	  		  ///cout<<"directory1.maxPower="
-//<<directory1.maxPower<<endl;
+//	  		  directory1.maxPower	+=  directory1.ifb.l_ip.num_search_ports*directory1.ifb.local_result.power.searchOp.dynamic*clockRate;
+//	  		  ///cout<<"directory1.maxPower=" <<directory1.maxPower<<endl;
 //
-//	  		  directory1.maxPower	+=
-//directory1.prefetchb.l_ip.num_search_ports*directory1.prefetchb.local_result.power.searchOp.dynamic*clockRate;
-//	  		  ///cout<<"directory1.maxPower="
-//<<directory1.maxPower<<endl;
+//	  		  directory1.maxPower	+=  directory1.prefetchb.l_ip.num_search_ports*directory1.prefetchb.local_result.power.searchOp.dynamic*clockRate;
+//	  		  ///cout<<"directory1.maxPower=" <<directory1.maxPower<<endl;
 //
-//	  		  directory1.maxPower	+=
-//directory1.wbb.l_ip.num_search_ports*directory1.wbb.local_result.power.searchOp.dynamic*clockRate;
+//	  		  directory1.maxPower	+=  directory1.wbb.l_ip.num_search_ports*directory1.wbb.local_result.power.searchOp.dynamic*clockRate;
 //
-//	  		  cc1.power.readOp.dynamic =
-//directory1.maxPower*scktRatio*64/XML->sys.domain_size;
-//			  cc1.power.readOp.leakage =
-//directory1.caches.local_result.power.readOp.leakage +
-//	                                     directory1.missb.local_result.power.readOp.leakage
-//+
-//	                                     directory1.ifb.local_result.power.readOp.leakage
-//+
-//	                                     directory1.prefetchb.local_result.power.readOp.leakage
-//+
+//	  		  cc1.power.readOp.dynamic = directory1.maxPower*scktRatio*64/XML->sys.domain_size;
+//			  cc1.power.readOp.leakage = directory1.caches.local_result.power.readOp.leakage +
+//	                                     directory1.missb.local_result.power.readOp.leakage +
+//	                                     directory1.ifb.local_result.power.readOp.leakage +
+//	                                     directory1.prefetchb.local_result.power.readOp.leakage +
 //	                                     directory1.wbb.local_result.power.readOp.leakage;
 //			  cc1.power.readOp.leakage *= 64/XML->sys.domain_size;
 //	  		  cc1.area.set_area(directory1.area*64/XML->sys.domain_size);
 //
-//	  		  cout<<"CC
-//area="<<(cc.area.get_area()+cc1.area.get_area())*1e-6<<endl;
-//			  cout<<"CC Power="<<cc.power.readOp.dynamic +
-//cc1.power.readOp.dynamic <<endl;
+//	  		  cout<<"CC area="<<(cc.area.get_area()+cc1.area.get_area())*1e-6<<endl;
+//			  cout<<"CC Power="<<cc.power.readOp.dynamic + cc1.power.readOp.dynamic <<endl;
 //			  ccTot.area.set_area((cc.area.get_area()+cc1.area.get_area())*1e-6);
 //			  ccTot.power = cc.power + cc1.power;
 //	  	  }
 //	  	  else if (XML->sys.first_level_dir==1)
 //	  	  {
-//	  		  inv_dir.maxPower =
-//inv_dir.caches.local_result.power.searchOp.dynamic*clockRate*XML->sys.domain_size;
-//	  		  cc1.power.readOp.dynamic =
-//inv_dir.maxPower*scktRatio*(64/XML->sys.domain_size);
-//	  		  cc1.power.readOp.leakage  =
-//inv_dir.caches.local_result.power.readOp.leakage*inv_dir.caches.l_ip.nbanks*XML->sys.domain_size;
+//	  		  inv_dir.maxPower = inv_dir.caches.local_result.power.searchOp.dynamic*clockRate*XML->sys.domain_size;
+//	  		  cc1.power.readOp.dynamic = inv_dir.maxPower*scktRatio*(64/XML->sys.domain_size);
+//	  		  cc1.power.readOp.leakage  = inv_dir.caches.local_result.power.readOp.leakage*inv_dir.caches.l_ip.nbanks*XML->sys.domain_size;
 //
 //	  		  cc1.area.set_area(inv_dir.area*64/XML->sys.domain_size);
-//			  cout<<"CC
-//area="<<(cc.area.get_area()+cc1.area.get_area())*1e-6<<endl;
-//			  cout<<"CC Power="<<cc.power.readOp.dynamic +
-//cc1.power.readOp.dynamic <<endl;
+//			  cout<<"CC area="<<(cc.area.get_area()+cc1.area.get_area())*1e-6<<endl;
+//			  cout<<"CC Power="<<cc.power.readOp.dynamic + cc1.power.readOp.dynamic <<endl;
 //			  ccTot.area.set_area((cc.area.get_area()+cc1.area.get_area())*1e-6);
 //			  ccTot.power = cc.power + cc1.power;
 //
@@ -1280,9 +1045,9 @@ void SharedCache::displayEnergy(uint32_t indent, bool is_tdp) {
 //	  	  }
 //  }
 //
-// cout<<"L2cache size="<<L2Tot.area.get_area()*1e-6<<endl;
-// cout<<"L2cache dynamic power="<<L2Tot.power.readOp.dynamic<<endl;
-// cout<<"L2cache laeakge power="<<L2Tot.power.readOp.leakage<<endl;
+//cout<<"L2cache size="<<L2Tot.area.get_area()*1e-6<<endl;
+//cout<<"L2cache dynamic power="<<L2Tot.power.readOp.dynamic<<endl;
+//cout<<"L2cache laeakge power="<<L2Tot.power.readOp.leakage<<endl;
 //
 //  ///cout<<"llCache.maxPower=" <<llCache.maxPower<<endl;
 //
@@ -1291,142 +1056,130 @@ void SharedCache::displayEnergy(uint32_t indent, bool is_tdp) {
 //  ///cout<<"maxpower=" <<maxPower<<endl;
 //
 ////  maxPower	  +=  pipeLogicCache.power.readOp.dynamic*clockRate;
-////
-//////cout<<"pipeLogic.power="<<pipeLogicCache.power.readOp.dynamic*clockRate<<endl;
+////  ///cout<<"pipeLogic.power="<<pipeLogicCache.power.readOp.dynamic*clockRate<<endl;
 ////  ///cout<<"maxpower=" <<maxPower<<endl;
 ////
 ////  maxPower	  +=  pipeLogicDirectory.power.readOp.dynamic*clockRate;
-////
-//////cout<<"pipeLogic.power="<<pipeLogicDirectory.power.readOp.dynamic*clockRate<<endl;
+////  ///cout<<"pipeLogic.power="<<pipeLogicDirectory.power.readOp.dynamic*clockRate<<endl;
 ////  ///cout<<"maxpower=" <<maxPower<<endl;
 ////
 ////  //clock power
 ////  maxPower += clockNetwork.total_power.readOp.dynamic*clockRate;
-////
-//////cout<<"clockNetwork.total_power="<<clockNetwork.total_power.readOp.dynamic*clockRate<<endl;
+////  ///cout<<"clockNetwork.total_power="<<clockNetwork.total_power.readOp.dynamic*clockRate<<endl;
 ////  ///cout<<"maxpower=" <<maxPower<<endl;
 //
 //}
 
-void SharedCache::set_cache_param() {
-  if (cacheL == L2) {
-    cachep.name = "L2";
-    cachep.clockRate = XML->sys.L2[ithCache].clockrate;
-    cachep.clockRate *= 1e6;
-    cachep.executionTime =
-        XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);
-    interface_ip.data_arr_ram_cell_tech_type =
-        XML->sys.L2[ithCache].device_type;  // long channel device LSTP
-    interface_ip.data_arr_peri_global_tech_type =
-        XML->sys.L2[ithCache].device_type;
-    interface_ip.tag_arr_ram_cell_tech_type = XML->sys.L2[ithCache].device_type;
-    interface_ip.tag_arr_peri_global_tech_type =
-        XML->sys.L2[ithCache].device_type;
-    cachep.capacity = XML->sys.L2[ithCache].L2_config[0];
-    cachep.blockW = XML->sys.L2[ithCache].L2_config[1];
-    cachep.assoc = XML->sys.L2[ithCache].L2_config[2];
-    cachep.nbanks = XML->sys.L2[ithCache].L2_config[3];
-    cachep.throughput = XML->sys.L2[ithCache].L2_config[4] / cachep.clockRate;
-    cachep.latency = XML->sys.L2[ithCache].L2_config[5] / cachep.clockRate;
-    cachep.missb_size = XML->sys.L2[ithCache].buffer_sizes[0];
-    cachep.fu_size = XML->sys.L2[ithCache].buffer_sizes[1];
-    cachep.prefetchb_size = XML->sys.L2[ithCache].buffer_sizes[2];
-    cachep.wbb_size = XML->sys.L2[ithCache].buffer_sizes[3];
-    cachep.duty_cycle = XML->sys.L2[ithCache].duty_cycle;
-    if (!XML->sys.L2[ithCache].merged_dir) {
-      cachep.dir_ty = NonDir;
-    } else {
-      cachep.dir_ty = SBT;
-      cachep.dir_duty_cycle = XML->sys.L2[ithCache].dir_duty_cycle;
-    }
-  } else if (cacheL == L3) {
-    cachep.name = "L3";
-    cachep.clockRate = XML->sys.L3[ithCache].clockrate;
-    cachep.clockRate *= 1e6;
-    cachep.executionTime =
-        XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);
-    interface_ip.data_arr_ram_cell_tech_type =
-        XML->sys.L3[ithCache].device_type;  // long channel device LSTP
-    interface_ip.data_arr_peri_global_tech_type =
-        XML->sys.L3[ithCache].device_type;
-    interface_ip.tag_arr_ram_cell_tech_type = XML->sys.L3[ithCache].device_type;
-    interface_ip.tag_arr_peri_global_tech_type =
-        XML->sys.L3[ithCache].device_type;
-    cachep.capacity = XML->sys.L3[ithCache].L3_config[0];
-    cachep.blockW = XML->sys.L3[ithCache].L3_config[1];
-    cachep.assoc = XML->sys.L3[ithCache].L3_config[2];
-    cachep.nbanks = XML->sys.L3[ithCache].L3_config[3];
-    cachep.throughput = XML->sys.L3[ithCache].L3_config[4] / cachep.clockRate;
-    cachep.latency = XML->sys.L3[ithCache].L3_config[5] / cachep.clockRate;
-    cachep.missb_size = XML->sys.L3[ithCache].buffer_sizes[0];
-    cachep.fu_size = XML->sys.L3[ithCache].buffer_sizes[1];
-    cachep.prefetchb_size = XML->sys.L3[ithCache].buffer_sizes[2];
-    cachep.wbb_size = XML->sys.L3[ithCache].buffer_sizes[3];
-    cachep.duty_cycle = XML->sys.L3[ithCache].duty_cycle;
-    if (!XML->sys.L2[ithCache].merged_dir) {
-      cachep.dir_ty = NonDir;
-    } else {
-      cachep.dir_ty = SBT;
-      cachep.dir_duty_cycle = XML->sys.L2[ithCache].dir_duty_cycle;
-    }
-  } else if (cacheL == L1Directory) {
-    cachep.name = "First Level Directory";
-    cachep.dir_ty =
-        (enum Dir_type)XML->sys.L1Directory[ithCache].Directory_type;
-    cachep.clockRate = XML->sys.L1Directory[ithCache].clockrate;
-    cachep.clockRate *= 1e6;
-    cachep.executionTime =
-        XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);
-    interface_ip.data_arr_ram_cell_tech_type =
-        XML->sys.L1Directory[ithCache].device_type;  // long channel device LSTP
-    interface_ip.data_arr_peri_global_tech_type =
-        XML->sys.L1Directory[ithCache].device_type;
-    interface_ip.tag_arr_ram_cell_tech_type =
-        XML->sys.L1Directory[ithCache].device_type;
-    interface_ip.tag_arr_peri_global_tech_type =
-        XML->sys.L1Directory[ithCache].device_type;
-    cachep.capacity = XML->sys.L1Directory[ithCache].Dir_config[0];
-    cachep.blockW = XML->sys.L1Directory[ithCache].Dir_config[1];
-    cachep.assoc = XML->sys.L1Directory[ithCache].Dir_config[2];
-    cachep.nbanks = XML->sys.L1Directory[ithCache].Dir_config[3];
-    cachep.throughput =
-        XML->sys.L1Directory[ithCache].Dir_config[4] / cachep.clockRate;
-    cachep.latency =
-        XML->sys.L1Directory[ithCache].Dir_config[5] / cachep.clockRate;
-    cachep.missb_size = XML->sys.L1Directory[ithCache].buffer_sizes[0];
-    cachep.fu_size = XML->sys.L1Directory[ithCache].buffer_sizes[1];
-    cachep.prefetchb_size = XML->sys.L1Directory[ithCache].buffer_sizes[2];
-    cachep.wbb_size = XML->sys.L1Directory[ithCache].buffer_sizes[3];
-    cachep.duty_cycle = XML->sys.L1Directory[ithCache].duty_cycle;
-  } else if (cacheL == L2Directory) {
-    cachep.name = "Second Level Directory";
-    cachep.dir_ty =
-        (enum Dir_type)XML->sys.L2Directory[ithCache].Directory_type;
-    cachep.clockRate = XML->sys.L2Directory[ithCache].clockrate;
-    cachep.clockRate *= 1e6;
-    cachep.executionTime =
-        XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);
-    interface_ip.data_arr_ram_cell_tech_type =
-        XML->sys.L2Directory[ithCache].device_type;  // long channel device LSTP
-    interface_ip.data_arr_peri_global_tech_type =
-        XML->sys.L2Directory[ithCache].device_type;
-    interface_ip.tag_arr_ram_cell_tech_type =
-        XML->sys.L2Directory[ithCache].device_type;
-    interface_ip.tag_arr_peri_global_tech_type =
-        XML->sys.L2Directory[ithCache].device_type;
-    cachep.capacity = XML->sys.L2Directory[ithCache].Dir_config[0];
-    cachep.blockW = XML->sys.L2Directory[ithCache].Dir_config[1];
-    cachep.assoc = XML->sys.L2Directory[ithCache].Dir_config[2];
-    cachep.nbanks = XML->sys.L2Directory[ithCache].Dir_config[3];
-    cachep.throughput =
-        XML->sys.L2Directory[ithCache].Dir_config[4] / cachep.clockRate;
-    cachep.latency =
-        XML->sys.L2Directory[ithCache].Dir_config[5] / cachep.clockRate;
-    cachep.missb_size = XML->sys.L2Directory[ithCache].buffer_sizes[0];
-    cachep.fu_size = XML->sys.L2Directory[ithCache].buffer_sizes[1];
-    cachep.prefetchb_size = XML->sys.L2Directory[ithCache].buffer_sizes[2];
-    cachep.wbb_size = XML->sys.L2Directory[ithCache].buffer_sizes[3];
-    cachep.duty_cycle = XML->sys.L2Directory[ithCache].duty_cycle;
+void SharedCache::set_cache_param()
+{
+  if (cacheL==L2)
+  {
+	 cachep.name = "L2";
+	 cachep.clockRate       = XML->sys.L2[ithCache].clockrate;
+	 cachep.clockRate       *= 1e6;
+	 cachep.executionTime = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
+	 interface_ip.data_arr_ram_cell_tech_type    = XML->sys.L2[ithCache].device_type;//long channel device LSTP
+	 interface_ip.data_arr_peri_global_tech_type = XML->sys.L2[ithCache].device_type;
+	 interface_ip.tag_arr_ram_cell_tech_type     = XML->sys.L2[ithCache].device_type;
+	 interface_ip.tag_arr_peri_global_tech_type  = XML->sys.L2[ithCache].device_type;
+	 cachep.capacity      = XML->sys.L2[ithCache].L2_config[0];
+	 cachep.blockW        = XML->sys.L2[ithCache].L2_config[1];
+	 cachep.assoc         = XML->sys.L2[ithCache].L2_config[2];
+	 cachep.nbanks        = XML->sys.L2[ithCache].L2_config[3];
+	 cachep.throughput    = XML->sys.L2[ithCache].L2_config[4]/cachep.clockRate;
+	 cachep.latency       = XML->sys.L2[ithCache].L2_config[5]/cachep.clockRate;
+	 cachep.missb_size    = XML->sys.L2[ithCache].buffer_sizes[0];
+	 cachep.fu_size       = XML->sys.L2[ithCache].buffer_sizes[1];
+	 cachep.prefetchb_size= XML->sys.L2[ithCache].buffer_sizes[2];
+	 cachep.wbb_size      = XML->sys.L2[ithCache].buffer_sizes[3];
+	 cachep.duty_cycle    = XML->sys.L2[ithCache].duty_cycle;
+	 if (!XML->sys.L2[ithCache].merged_dir)
+	 {
+		cachep.dir_ty = NonDir;
+	 }
+	 else
+	 {
+		cachep.dir_ty = SBT;
+		cachep.dir_duty_cycle  = XML->sys.L2[ithCache].dir_duty_cycle;
+	 }
   }
-  // cachep.cache_duty_cycle=cachep.dir_duty_cycle = 0.35;
+  else if (cacheL==L3)
+  {
+	 cachep.name = "L3";
+	 cachep.clockRate       = XML->sys.L3[ithCache].clockrate;
+	 cachep.clockRate       *= 1e6;
+	 cachep.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
+	 interface_ip.data_arr_ram_cell_tech_type    = XML->sys.L3[ithCache].device_type;//long channel device LSTP
+	 interface_ip.data_arr_peri_global_tech_type = XML->sys.L3[ithCache].device_type;
+	 interface_ip.tag_arr_ram_cell_tech_type     = XML->sys.L3[ithCache].device_type;
+	 interface_ip.tag_arr_peri_global_tech_type  = XML->sys.L3[ithCache].device_type;
+	 cachep.capacity      = XML->sys.L3[ithCache].L3_config[0];
+	 cachep.blockW        = XML->sys.L3[ithCache].L3_config[1];
+	 cachep.assoc         = XML->sys.L3[ithCache].L3_config[2];
+	 cachep.nbanks        = XML->sys.L3[ithCache].L3_config[3];
+	 cachep.throughput    = XML->sys.L3[ithCache].L3_config[4]/cachep.clockRate;
+	 cachep.latency       = XML->sys.L3[ithCache].L3_config[5]/cachep.clockRate;
+	 cachep.missb_size    = XML->sys.L3[ithCache].buffer_sizes[0];
+	 cachep.fu_size       = XML->sys.L3[ithCache].buffer_sizes[1];
+	 cachep.prefetchb_size= XML->sys.L3[ithCache].buffer_sizes[2];
+	 cachep.wbb_size      = XML->sys.L3[ithCache].buffer_sizes[3];
+	 cachep.duty_cycle    = XML->sys.L3[ithCache].duty_cycle;
+	 if (!XML->sys.L2[ithCache].merged_dir)
+	 {
+		cachep.dir_ty = NonDir;
+	 }
+	 else
+	 {
+		cachep.dir_ty = SBT;
+		cachep.dir_duty_cycle  = XML->sys.L2[ithCache].dir_duty_cycle;
+	 }
+  }
+  else if (cacheL==L1Directory)
+  {
+	 cachep.name = "First Level Directory";
+	 cachep.dir_ty = (enum Dir_type) XML->sys.L1Directory[ithCache].Directory_type;
+	 cachep.clockRate       = XML->sys.L1Directory[ithCache].clockrate;
+	 cachep.clockRate       *= 1e6;
+	 cachep.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
+	 interface_ip.data_arr_ram_cell_tech_type    = XML->sys.L1Directory[ithCache].device_type;//long channel device LSTP
+	 interface_ip.data_arr_peri_global_tech_type = XML->sys.L1Directory[ithCache].device_type;
+	 interface_ip.tag_arr_ram_cell_tech_type     = XML->sys.L1Directory[ithCache].device_type;
+	 interface_ip.tag_arr_peri_global_tech_type  = XML->sys.L1Directory[ithCache].device_type;
+	 cachep.capacity      = XML->sys.L1Directory[ithCache].Dir_config[0];
+	 cachep.blockW        = XML->sys.L1Directory[ithCache].Dir_config[1];
+	 cachep.assoc         = XML->sys.L1Directory[ithCache].Dir_config[2];
+	 cachep.nbanks        = XML->sys.L1Directory[ithCache].Dir_config[3];
+	 cachep.throughput    = XML->sys.L1Directory[ithCache].Dir_config[4]/cachep.clockRate;
+	 cachep.latency       = XML->sys.L1Directory[ithCache].Dir_config[5]/cachep.clockRate;
+	 cachep.missb_size    = XML->sys.L1Directory[ithCache].buffer_sizes[0];
+	 cachep.fu_size       = XML->sys.L1Directory[ithCache].buffer_sizes[1];
+	 cachep.prefetchb_size= XML->sys.L1Directory[ithCache].buffer_sizes[2];
+	 cachep.wbb_size      = XML->sys.L1Directory[ithCache].buffer_sizes[3];
+	 cachep.duty_cycle    = XML->sys.L1Directory[ithCache].duty_cycle;
+  }
+  else if (cacheL==L2Directory)
+  {
+	 cachep.name = "Second Level Directory";
+	 cachep.dir_ty = (enum Dir_type) XML->sys.L2Directory[ithCache].Directory_type;
+	 cachep.clockRate       = XML->sys.L2Directory[ithCache].clockrate;
+	 cachep.clockRate       *= 1e6;
+	 cachep.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
+	 interface_ip.data_arr_ram_cell_tech_type    = XML->sys.L2Directory[ithCache].device_type;//long channel device LSTP
+	 interface_ip.data_arr_peri_global_tech_type = XML->sys.L2Directory[ithCache].device_type;
+	 interface_ip.tag_arr_ram_cell_tech_type     = XML->sys.L2Directory[ithCache].device_type;
+	 interface_ip.tag_arr_peri_global_tech_type  = XML->sys.L2Directory[ithCache].device_type;
+	 cachep.capacity      = XML->sys.L2Directory[ithCache].Dir_config[0];
+	 cachep.blockW        = XML->sys.L2Directory[ithCache].Dir_config[1];
+	 cachep.assoc         = XML->sys.L2Directory[ithCache].Dir_config[2];
+	 cachep.nbanks        = XML->sys.L2Directory[ithCache].Dir_config[3];
+	 cachep.throughput    = XML->sys.L2Directory[ithCache].Dir_config[4]/cachep.clockRate;
+	 cachep.latency       = XML->sys.L2Directory[ithCache].Dir_config[5]/cachep.clockRate;
+	 cachep.missb_size    = XML->sys.L2Directory[ithCache].buffer_sizes[0];
+	 cachep.fu_size       = XML->sys.L2Directory[ithCache].buffer_sizes[1];
+	 cachep.prefetchb_size= XML->sys.L2Directory[ithCache].buffer_sizes[2];
+	 cachep.wbb_size      = XML->sys.L2Directory[ithCache].buffer_sizes[3];
+	 cachep.duty_cycle    = XML->sys.L2Directory[ithCache].duty_cycle;
+  }
+  //cachep.cache_duty_cycle=cachep.dir_duty_cycle = 0.35;
 }
+

--- a/src/gpuwattch/sharedcache.cc
+++ b/src/gpuwattch/sharedcache.cc
@@ -1106,24 +1106,25 @@ void SharedCache::displayEnergy(uint32_t indent, bool is_tdp) {
 //		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
 //
 //		  directory.maxPower	+=
-//directory.missb.l_ip.num_search_ports*directory.missb.local_result.power.searchOp.dynamic*clockRate;
+// directory.missb.l_ip.num_search_ports*directory.missb.local_result.power.searchOp.dynamic*clockRate;
 //		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
 //
 //		  directory.maxPower	+=
-//directory.ifb.l_ip.num_search_ports*directory.ifb.local_result.power.searchOp.dynamic*clockRate;
+// directory.ifb.l_ip.num_search_ports*directory.ifb.local_result.power.searchOp.dynamic*clockRate;
 //		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
 //
 //		  directory.maxPower	+=
-//directory.prefetchb.l_ip.num_search_ports*directory.prefetchb.local_result.power.searchOp.dynamic*clockRate;
+// directory.prefetchb.l_ip.num_search_ports*directory.prefetchb.local_result.power.searchOp.dynamic*clockRate;
 //		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
 //
 //		  directory.maxPower	+=
-//directory.wbb.l_ip.num_search_ports*directory.wbb.local_result.power.searchOp.dynamic*clockRate;
+// directory.wbb.l_ip.num_search_ports*directory.wbb.local_result.power.searchOp.dynamic*clockRate;
 //
-//		  cc.power.readOp.dynamic = directory.maxPower*scktRatio*8;//8 is
-//the memory controller counts
+//		  cc.power.readOp.dynamic = directory.maxPower*scktRatio*8;//8
+// is
+// the memory controller counts
 //		  cc.power.readOp.leakage =
-//directory.caches.local_result.power.readOp.leakage +
+// directory.caches.local_result.power.readOp.leakage +
 //                                     directory.missb.local_result.power.readOp.leakage
 //                                     +
 //                                     directory.ifb.local_result.power.readOp.leakage
@@ -1140,23 +1141,23 @@ void SharedCache::displayEnergy(uint32_t indent, bool is_tdp) {
 //		  ccTot.area.set_area(cc.area.get_area()*1e-6);
 //		  ccTot.power = cc.power;
 //		  cout<<"DC energy per access" <<
-//cc.power.readOp.dynamic/clockRate/8;
+// cc.power.readOp.dynamic/clockRate/8;
 //	  }
 //	  else if (XML->sys.first_level_dir==1)
 //	  {
 //		  inv_dir.maxPower =
-//inv_dir.caches.local_result.power.searchOp.dynamic*clockRate*XML->sys.domain_size;
+// inv_dir.caches.local_result.power.searchOp.dynamic*clockRate*XML->sys.domain_size;
 //		  cc.power.readOp.dynamic  =
-//inv_dir.maxPower*scktRatio*64/XML->sys.domain_size;
+// inv_dir.maxPower*scktRatio*64/XML->sys.domain_size;
 //		  cc.power.readOp.leakage  =
-//inv_dir.caches.local_result.power.readOp.leakage*inv_dir.caches.l_ip.nbanks*64/XML->sys.domain_size;
+// inv_dir.caches.local_result.power.readOp.leakage*inv_dir.caches.l_ip.nbanks*64/XML->sys.domain_size;
 //
 //		  cc.area.set_area(inv_dir.area*64/XML->sys.domain_size);
 //		  cout<<"CC area="<<cc.area.get_area()*1e-6<<endl;
 //		  cout<<"CC Power="<<cc.power.readOp.dynamic<<endl;
 //		  ccTot.area.set_area(cc.area.get_area()*1e-6);
 //		  cout<<"DC energy per access" <<
-//cc.power.readOp.dynamic/clockRate/8;
+// cc.power.readOp.dynamic/clockRate/8;
 //		  ccTot.power = cc.power;
 //	  }
 //  }
@@ -1173,27 +1174,27 @@ void SharedCache::displayEnergy(uint32_t indent, bool is_tdp) {
 //<<directory.maxPower<<endl;
 //
 //	  		  directory.maxPower	+=
-//directory.missb.l_ip.num_search_ports*directory.missb.local_result.power.searchOp.dynamic*clockRate;
+// directory.missb.l_ip.num_search_ports*directory.missb.local_result.power.searchOp.dynamic*clockRate;
 //	  		  ///cout<<"directory.maxPower="
 //<<directory.maxPower<<endl;
 //
 //	  		  directory.maxPower	+=
-//directory.ifb.l_ip.num_search_ports*directory.ifb.local_result.power.searchOp.dynamic*clockRate;
+// directory.ifb.l_ip.num_search_ports*directory.ifb.local_result.power.searchOp.dynamic*clockRate;
 //	  		  ///cout<<"directory.maxPower="
 //<<directory.maxPower<<endl;
 //
 //	  		  directory.maxPower	+=
-//directory.prefetchb.l_ip.num_search_ports*directory.prefetchb.local_result.power.searchOp.dynamic*clockRate;
+// directory.prefetchb.l_ip.num_search_ports*directory.prefetchb.local_result.power.searchOp.dynamic*clockRate;
 //	  		  ///cout<<"directory.maxPower="
 //<<directory.maxPower<<endl;
 //
 //	  		  directory.maxPower	+=
-//directory.wbb.l_ip.num_search_ports*directory.wbb.local_result.power.searchOp.dynamic*clockRate;
+// directory.wbb.l_ip.num_search_ports*directory.wbb.local_result.power.searchOp.dynamic*clockRate;
 //
 //	  		  cc.power.readOp.dynamic =
-//directory.maxPower*scktRatio*8;//8 is the memory controller counts
+// directory.maxPower*scktRatio*8;//8 is the memory controller counts
 //			  cc.power.readOp.leakage =
-//directory.caches.local_result.power.readOp.leakage +
+// directory.caches.local_result.power.readOp.leakage +
 //	                                     directory.missb.local_result.power.readOp.leakage
 //+
 //	                                     directory.ifb.local_result.power.readOp.leakage
@@ -1215,27 +1216,27 @@ void SharedCache::displayEnergy(uint32_t indent, bool is_tdp) {
 //<<directory1.maxPower<<endl;
 //
 //	  		  directory1.maxPower	+=
-//directory1.missb.l_ip.num_search_ports*directory1.missb.local_result.power.searchOp.dynamic*clockRate;
+// directory1.missb.l_ip.num_search_ports*directory1.missb.local_result.power.searchOp.dynamic*clockRate;
 //	  		  ///cout<<"directory1.maxPower="
 //<<directory1.maxPower<<endl;
 //
 //	  		  directory1.maxPower	+=
-//directory1.ifb.l_ip.num_search_ports*directory1.ifb.local_result.power.searchOp.dynamic*clockRate;
+// directory1.ifb.l_ip.num_search_ports*directory1.ifb.local_result.power.searchOp.dynamic*clockRate;
 //	  		  ///cout<<"directory1.maxPower="
 //<<directory1.maxPower<<endl;
 //
 //	  		  directory1.maxPower	+=
-//directory1.prefetchb.l_ip.num_search_ports*directory1.prefetchb.local_result.power.searchOp.dynamic*clockRate;
+// directory1.prefetchb.l_ip.num_search_ports*directory1.prefetchb.local_result.power.searchOp.dynamic*clockRate;
 //	  		  ///cout<<"directory1.maxPower="
 //<<directory1.maxPower<<endl;
 //
 //	  		  directory1.maxPower	+=
-//directory1.wbb.l_ip.num_search_ports*directory1.wbb.local_result.power.searchOp.dynamic*clockRate;
+// directory1.wbb.l_ip.num_search_ports*directory1.wbb.local_result.power.searchOp.dynamic*clockRate;
 //
 //	  		  cc1.power.readOp.dynamic =
-//directory1.maxPower*scktRatio*64/XML->sys.domain_size;
+// directory1.maxPower*scktRatio*64/XML->sys.domain_size;
 //			  cc1.power.readOp.leakage =
-//directory1.caches.local_result.power.readOp.leakage +
+// directory1.caches.local_result.power.readOp.leakage +
 //	                                     directory1.missb.local_result.power.readOp.leakage
 //+
 //	                                     directory1.ifb.local_result.power.readOp.leakage
@@ -1247,26 +1248,26 @@ void SharedCache::displayEnergy(uint32_t indent, bool is_tdp) {
 //	  		  cc1.area.set_area(directory1.area*64/XML->sys.domain_size);
 //
 //	  		  cout<<"CC
-//area="<<(cc.area.get_area()+cc1.area.get_area())*1e-6<<endl;
+// area="<<(cc.area.get_area()+cc1.area.get_area())*1e-6<<endl;
 //			  cout<<"CC Power="<<cc.power.readOp.dynamic +
-//cc1.power.readOp.dynamic <<endl;
+// cc1.power.readOp.dynamic <<endl;
 //			  ccTot.area.set_area((cc.area.get_area()+cc1.area.get_area())*1e-6);
 //			  ccTot.power = cc.power + cc1.power;
 //	  	  }
 //	  	  else if (XML->sys.first_level_dir==1)
 //	  	  {
 //	  		  inv_dir.maxPower =
-//inv_dir.caches.local_result.power.searchOp.dynamic*clockRate*XML->sys.domain_size;
+// inv_dir.caches.local_result.power.searchOp.dynamic*clockRate*XML->sys.domain_size;
 //	  		  cc1.power.readOp.dynamic =
-//inv_dir.maxPower*scktRatio*(64/XML->sys.domain_size);
+// inv_dir.maxPower*scktRatio*(64/XML->sys.domain_size);
 //	  		  cc1.power.readOp.leakage  =
-//inv_dir.caches.local_result.power.readOp.leakage*inv_dir.caches.l_ip.nbanks*XML->sys.domain_size;
+// inv_dir.caches.local_result.power.readOp.leakage*inv_dir.caches.l_ip.nbanks*XML->sys.domain_size;
 //
 //	  		  cc1.area.set_area(inv_dir.area*64/XML->sys.domain_size);
 //			  cout<<"CC
-//area="<<(cc.area.get_area()+cc1.area.get_area())*1e-6<<endl;
+// area="<<(cc.area.get_area()+cc1.area.get_area())*1e-6<<endl;
 //			  cout<<"CC Power="<<cc.power.readOp.dynamic +
-//cc1.power.readOp.dynamic <<endl;
+// cc1.power.readOp.dynamic <<endl;
 //			  ccTot.area.set_area((cc.area.get_area()+cc1.area.get_area())*1e-6);
 //			  ccTot.power = cc.power + cc1.power;
 //

--- a/src/gpuwattch/sharedcache.cc
+++ b/src/gpuwattch/sharedcache.cc
@@ -29,241 +29,251 @@
  *
  ***************************************************************************/
 
-#include "io.h"
-#include "cacti/parameter.h"
-#include "array.h"
-#include "const.h"
-#include "logic.h"
-#include "cacti/basic_circuit.h"
-#include "cacti/arbiter.h"
-#include <string.h>
-#include <iostream>
-#include <algorithm>
-#include "XML_Parse.h"
-#include <string.h>
-#include <cmath>
-#include <assert.h>
 #include "sharedcache.h"
+#include <assert.h>
+#include <string.h>
+#include <string.h>
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include "XML_Parse.h"
+#include "array.h"
+#include "cacti/arbiter.h"
+#include "cacti/basic_circuit.h"
+#include "cacti/parameter.h"
+#include "const.h"
+#include "io.h"
+#include "logic.h"
 
-
-
-SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_, InputParameter* interface_ip_, enum cache_level cacheL_)
-:XML(XML_interface),
- ithCache(ithCache_),
- interface_ip(*interface_ip_),
- cacheL(cacheL_),
- dir_overhead(0)
-{
+SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_,
+                         InputParameter* interface_ip_,
+                         enum cache_level cacheL_)
+    : XML(XML_interface),
+      ithCache(ithCache_),
+      interface_ip(*interface_ip_),
+      cacheL(cacheL_),
+      dir_overhead(0) {
   int idx;
   int tag, data;
-  bool debug; 
+  bool debug;
   enum Device_ty device_t;
-  enum Core_type  core_t;
+  enum Core_type core_t;
   double size, line, assoc, banks;
-  if (cacheL==L2 && XML->sys.Private_L2)
-  {
-	  device_t=Core_device;
-      core_t = (enum Core_type)XML->sys.core[ithCache].machine_type;
-  }
-  else
-  {
-	  device_t=LLC_device;
-	  core_t = Inorder;
+  if (cacheL == L2 && XML->sys.Private_L2) {
+    device_t = Core_device;
+    core_t = (enum Core_type)XML->sys.core[ithCache].machine_type;
+  } else {
+    device_t = LLC_device;
+    core_t = Inorder;
   }
 
-  debug           = false;
-  if (XML->sys.Embedded)
-  		{
-  		interface_ip.wt                  =Global_30;
-  		interface_ip.wire_is_mat_type = 0;
-  		interface_ip.wire_os_mat_type = 1;
-  		}
-  	else
-  		{
-  		interface_ip.wt                  =Global;
-  		interface_ip.wire_is_mat_type = 2;
-  		interface_ip.wire_os_mat_type = 2;
-  		}
+  debug = false;
+  if (XML->sys.Embedded) {
+    interface_ip.wt = Global_30;
+    interface_ip.wire_is_mat_type = 0;
+    interface_ip.wire_os_mat_type = 1;
+  } else {
+    interface_ip.wt = Global;
+    interface_ip.wire_is_mat_type = 2;
+    interface_ip.wire_os_mat_type = 2;
+  }
   set_cache_param();
 
-  //All lower level cache are physically indexed and tagged.
-  size                             = cachep.capacity;
-  line                             = cachep.blockW;
-  assoc                            = cachep.assoc;
-  banks                            = cachep.nbanks;
-  if ((cachep.dir_ty==ST&& cacheL==L1Directory)||(cachep.dir_ty==ST&& cacheL==L2Directory))
-  {
-	  assoc = 0;
-	  tag   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  interface_ip.num_search_ports    = 1;
+  // All lower level cache are physically indexed and tagged.
+  size = cachep.capacity;
+  line = cachep.blockW;
+  assoc = cachep.assoc;
+  banks = cachep.nbanks;
+  if ((cachep.dir_ty == ST && cacheL == L1Directory) ||
+      (cachep.dir_ty == ST && cacheL == L2Directory)) {
+    assoc = 0;
+    tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+    interface_ip.num_search_ports = 1;
+  } else {
+    idx = debug ? 9 : int(ceil(log2(size / line / assoc)));
+    tag = debug ? 51 : XML->sys.physical_address_width - idx -
+                           int(ceil(log2(line))) + EXTRA_TAG_BITS;
+    interface_ip.num_search_ports = 0;
+    if (cachep.dir_ty == SBT) {
+      dir_overhead =
+          ceil(XML->sys.number_of_cores / 8.0) * 8 / (cachep.blockW * 8);
+      line = cachep.blockW * (1 + dir_overhead);
+      size = cachep.capacity * (1 + dir_overhead);
+    }
   }
-  else
-  {
-	  idx    					 	   = debug?9:int(ceil(log2(size/line/assoc)));
-	  tag							   = debug?51:XML->sys.physical_address_width-idx-int(ceil(log2(line))) + EXTRA_TAG_BITS;
-	  interface_ip.num_search_ports    = 0;
-	  if (cachep.dir_ty==SBT)
-	  {
-		  dir_overhead = ceil(XML->sys.number_of_cores/8.0)*8/(cachep.blockW*8);
-		  line = cachep.blockW*(1+ dir_overhead) ;
-		  size = cachep.capacity*(1+ dir_overhead);
-
-	  }
-  }
-//  if (XML->sys.first_level_dir==2)
-//	  tag += int(XML->sys.domain_size + 5);
-  interface_ip.specific_tag        = 1;
-  interface_ip.tag_w               = tag;
-  interface_ip.cache_sz            = (int)size;
-  interface_ip.line_sz             = (int)line;
-  interface_ip.assoc               = (int)assoc;
-  interface_ip.nbanks              = (int)banks;
-  interface_ip.out_w               = interface_ip.line_sz*8/2;
-  interface_ip.access_mode         = 1;
-  interface_ip.throughput          = cachep.throughput;
-  interface_ip.latency             = cachep.latency;
-  interface_ip.is_cache			 = true;
-  interface_ip.pure_ram			 = false;
-  interface_ip.pure_cam          = false;
+  //  if (XML->sys.first_level_dir==2)
+  //	  tag += int(XML->sys.domain_size + 5);
+  interface_ip.specific_tag = 1;
+  interface_ip.tag_w = tag;
+  interface_ip.cache_sz = (int)size;
+  interface_ip.line_sz = (int)line;
+  interface_ip.assoc = (int)assoc;
+  interface_ip.nbanks = (int)banks;
+  interface_ip.out_w = interface_ip.line_sz * 8 / 2;
+  interface_ip.access_mode = 1;
+  interface_ip.throughput = cachep.throughput;
+  interface_ip.latency = cachep.latency;
+  interface_ip.is_cache = true;
+  interface_ip.pure_ram = false;
+  interface_ip.pure_cam = false;
   interface_ip.obj_func_dyn_energy = 0;
-  interface_ip.obj_func_dyn_power  = 0;
+  interface_ip.obj_func_dyn_power = 0;
   interface_ip.obj_func_leak_power = 0;
-  interface_ip.obj_func_cycle_t    = 1;
-  interface_ip.num_rw_ports        = 1;//lower level cache usually has one port.
-  interface_ip.num_rd_ports        = 0;
-  interface_ip.num_wr_ports        = 0;
-  interface_ip.num_se_rd_ports     = 0;
-//  interface_ip.force_cache_config  =true;
-//  interface_ip.ndwl = 4;
-//  interface_ip.ndbl = 8;
-//  interface_ip.nspd = 1;
-//  interface_ip.ndcm =1 ;
-//  interface_ip.ndsam1 =1;
-//  interface_ip.ndsam2 =1;
-  unicache.caches = new ArrayST(&interface_ip, cachep.name + "cache", device_t, true, core_t);
-  unicache.area.set_area(unicache.area.get_area()+ unicache.caches->local_result.area);
-  area.set_area(area.get_area()+ unicache.caches->local_result.area);
-  interface_ip.force_cache_config  =false;
+  interface_ip.obj_func_cycle_t = 1;
+  interface_ip.num_rw_ports = 1;  // lower level cache usually has one port.
+  interface_ip.num_rd_ports = 0;
+  interface_ip.num_wr_ports = 0;
+  interface_ip.num_se_rd_ports = 0;
+  //  interface_ip.force_cache_config  =true;
+  //  interface_ip.ndwl = 4;
+  //  interface_ip.ndbl = 8;
+  //  interface_ip.nspd = 1;
+  //  interface_ip.ndcm =1 ;
+  //  interface_ip.ndsam1 =1;
+  //  interface_ip.ndsam2 =1;
+  unicache.caches =
+      new ArrayST(&interface_ip, cachep.name + "cache", device_t, true, core_t);
+  unicache.area.set_area(unicache.area.get_area() +
+                         unicache.caches->local_result.area);
+  area.set_area(area.get_area() + unicache.caches->local_result.area);
+  interface_ip.force_cache_config = false;
 
-
-  if (!((cachep.dir_ty==ST&& cacheL==L1Directory)||(cachep.dir_ty==ST&& cacheL==L2Directory)))
-  {
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  data							   = (XML->sys.physical_address_width) + int(ceil(log2(size/line))) + unicache.caches->l_ip.line_sz;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-	  interface_ip.cache_sz            = cachep.missb_size*interface_ip.line_sz;
-	  interface_ip.assoc               = 0;
-	  interface_ip.is_cache			   = true;
-	  interface_ip.pure_ram			   = false;
-	  interface_ip.pure_cam            = false;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8/2;
-	  interface_ip.access_mode         = 0;
-	  interface_ip.throughput          = cachep.throughput;//means cycle time
-	  interface_ip.latency             = cachep.latency;//means access time
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = 1;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  interface_ip.num_search_ports    = 1;
-	  unicache.missb = new ArrayST(&interface_ip, cachep.name + "MissB", device_t, true, core_t);
-	  unicache.area.set_area(unicache.area.get_area()+ unicache.missb->local_result.area);
-	  area.set_area(area.get_area()+ unicache.missb->local_result.area);
-	  //fill buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  data							   = unicache.caches->l_ip.line_sz;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-	  interface_ip.cache_sz            = data*cachep.fu_size ;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8/2;
-	  interface_ip.access_mode         = 0;
-	  interface_ip.throughput          =  cachep.throughput;
-	  interface_ip.latency             =  cachep.latency;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = 1;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  unicache.ifb = new ArrayST(&interface_ip, cachep.name + "FillB", device_t, true, core_t);
-	  unicache.area.set_area(unicache.area.get_area()+ unicache.ifb->local_result.area);
-	  area.set_area(area.get_area()+ unicache.ifb->local_result.area);
-	  //prefetch buffer
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries to decide wthether to merge.
-	  data							   = unicache.caches->l_ip.line_sz;//separate queue to prevent from cache polution.
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-	  interface_ip.cache_sz            = cachep.prefetchb_size*interface_ip.line_sz;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8/2;
-	  interface_ip.access_mode         = 0;
-	  interface_ip.throughput          = cachep.throughput;
-	  interface_ip.latency             = cachep.latency;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = 1;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  unicache.prefetchb = new ArrayST(&interface_ip, cachep.name + "PrefetchB", device_t, true, core_t);
-	  unicache.area.set_area(unicache.area.get_area()+ unicache.prefetchb->local_result.area);
-	  area.set_area(area.get_area()+ unicache.prefetchb->local_result.area);
-	  //WBB
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  data							   = unicache.caches->l_ip.line_sz;
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = data;
-	  interface_ip.cache_sz            = cachep.wbb_size*interface_ip.line_sz;
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1;
-	  interface_ip.out_w               = interface_ip.line_sz*8/2;
-	  interface_ip.access_mode         = 0;
-	  interface_ip.throughput          = cachep.throughput;
-	  interface_ip.latency             = cachep.latency;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = 1;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  unicache.wbb = new ArrayST(&interface_ip, cachep.name + "WBB", device_t, true, core_t);
-	  unicache.area.set_area(unicache.area.get_area()+ unicache.wbb->local_result.area);
-	  area.set_area(area.get_area()+ unicache.wbb->local_result.area);
+  if (!((cachep.dir_ty == ST && cacheL == L1Directory) ||
+        (cachep.dir_ty == ST && cacheL == L2Directory))) {
+    tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+    data = (XML->sys.physical_address_width) + int(ceil(log2(size / line))) +
+           unicache.caches->l_ip.line_sz;
+    interface_ip.specific_tag = 1;
+    interface_ip.tag_w = tag;
+    interface_ip.line_sz =
+        int(ceil(data / 8.0));  // int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+    interface_ip.cache_sz = cachep.missb_size * interface_ip.line_sz;
+    interface_ip.assoc = 0;
+    interface_ip.is_cache = true;
+    interface_ip.pure_ram = false;
+    interface_ip.pure_cam = false;
+    interface_ip.nbanks = 1;
+    interface_ip.out_w = interface_ip.line_sz * 8 / 2;
+    interface_ip.access_mode = 0;
+    interface_ip.throughput = cachep.throughput;  // means cycle time
+    interface_ip.latency = cachep.latency;        // means access time
+    interface_ip.obj_func_dyn_energy = 0;
+    interface_ip.obj_func_dyn_power = 0;
+    interface_ip.obj_func_leak_power = 0;
+    interface_ip.obj_func_cycle_t = 1;
+    interface_ip.num_rw_ports = 1;
+    interface_ip.num_rd_ports = 0;
+    interface_ip.num_wr_ports = 0;
+    interface_ip.num_se_rd_ports = 0;
+    interface_ip.num_search_ports = 1;
+    unicache.missb = new ArrayST(&interface_ip, cachep.name + "MissB", device_t,
+                                 true, core_t);
+    unicache.area.set_area(unicache.area.get_area() +
+                           unicache.missb->local_result.area);
+    area.set_area(area.get_area() + unicache.missb->local_result.area);
+    // fill buffer
+    tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+    data = unicache.caches->l_ip.line_sz;
+    interface_ip.specific_tag = 1;
+    interface_ip.tag_w = tag;
+    interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
+    interface_ip.cache_sz = data * cachep.fu_size;
+    interface_ip.assoc = 0;
+    interface_ip.nbanks = 1;
+    interface_ip.out_w = interface_ip.line_sz * 8 / 2;
+    interface_ip.access_mode = 0;
+    interface_ip.throughput = cachep.throughput;
+    interface_ip.latency = cachep.latency;
+    interface_ip.obj_func_dyn_energy = 0;
+    interface_ip.obj_func_dyn_power = 0;
+    interface_ip.obj_func_leak_power = 0;
+    interface_ip.obj_func_cycle_t = 1;
+    interface_ip.num_rw_ports = 1;
+    interface_ip.num_rd_ports = 0;
+    interface_ip.num_wr_ports = 0;
+    interface_ip.num_se_rd_ports = 0;
+    unicache.ifb = new ArrayST(&interface_ip, cachep.name + "FillB", device_t,
+                               true, core_t);
+    unicache.area.set_area(unicache.area.get_area() +
+                           unicache.ifb->local_result.area);
+    area.set_area(area.get_area() + unicache.ifb->local_result.area);
+    // prefetch buffer
+    tag = XML->sys.physical_address_width +
+          EXTRA_TAG_BITS;  // check with previous entries to decide wthether to
+                           // merge.
+    data = unicache.caches->l_ip
+               .line_sz;  // separate queue to prevent from cache polution.
+    interface_ip.specific_tag = 1;
+    interface_ip.tag_w = tag;
+    interface_ip.line_sz = data;  // int(pow(2.0,ceil(log2(data))));
+    interface_ip.cache_sz = cachep.prefetchb_size * interface_ip.line_sz;
+    interface_ip.assoc = 0;
+    interface_ip.nbanks = 1;
+    interface_ip.out_w = interface_ip.line_sz * 8 / 2;
+    interface_ip.access_mode = 0;
+    interface_ip.throughput = cachep.throughput;
+    interface_ip.latency = cachep.latency;
+    interface_ip.obj_func_dyn_energy = 0;
+    interface_ip.obj_func_dyn_power = 0;
+    interface_ip.obj_func_leak_power = 0;
+    interface_ip.obj_func_cycle_t = 1;
+    interface_ip.num_rw_ports = 1;
+    interface_ip.num_rd_ports = 0;
+    interface_ip.num_wr_ports = 0;
+    interface_ip.num_se_rd_ports = 0;
+    unicache.prefetchb = new ArrayST(&interface_ip, cachep.name + "PrefetchB",
+                                     device_t, true, core_t);
+    unicache.area.set_area(unicache.area.get_area() +
+                           unicache.prefetchb->local_result.area);
+    area.set_area(area.get_area() + unicache.prefetchb->local_result.area);
+    // WBB
+    tag = XML->sys.physical_address_width + EXTRA_TAG_BITS;
+    data = unicache.caches->l_ip.line_sz;
+    interface_ip.specific_tag = 1;
+    interface_ip.tag_w = tag;
+    interface_ip.line_sz = data;
+    interface_ip.cache_sz = cachep.wbb_size * interface_ip.line_sz;
+    interface_ip.assoc = 0;
+    interface_ip.nbanks = 1;
+    interface_ip.out_w = interface_ip.line_sz * 8 / 2;
+    interface_ip.access_mode = 0;
+    interface_ip.throughput = cachep.throughput;
+    interface_ip.latency = cachep.latency;
+    interface_ip.obj_func_dyn_energy = 0;
+    interface_ip.obj_func_dyn_power = 0;
+    interface_ip.obj_func_leak_power = 0;
+    interface_ip.obj_func_cycle_t = 1;
+    interface_ip.num_rw_ports = 1;
+    interface_ip.num_rd_ports = 0;
+    interface_ip.num_wr_ports = 0;
+    interface_ip.num_se_rd_ports = 0;
+    unicache.wbb =
+        new ArrayST(&interface_ip, cachep.name + "WBB", device_t, true, core_t);
+    unicache.area.set_area(unicache.area.get_area() +
+                           unicache.wbb->local_result.area);
+    area.set_area(area.get_area() + unicache.wbb->local_result.area);
   }
   //  //pipeline
-//  interface_ip.pipeline_stages = int(ceil(llCache.caches.local_result.access_time/llCache.caches.local_result.cycle_time));
-//  interface_ip.per_stage_vector = llCache.caches.l_ip.out_w + llCache.caches.l_ip.tag_w ;
-//  pipeLogicCache.init_pipeline(is_default, &interface_ip);
-//  pipeLogicCache.compute_pipeline();
+  //  interface_ip.pipeline_stages =
+  //  int(ceil(llCache.caches.local_result.access_time/llCache.caches.local_result.cycle_time));
+  //  interface_ip.per_stage_vector = llCache.caches.l_ip.out_w +
+  //  llCache.caches.l_ip.tag_w ;
+  //  pipeLogicCache.init_pipeline(is_default, &interface_ip);
+  //  pipeLogicCache.compute_pipeline();
 
   /*
   if (!((XML->sys.number_of_dir_levels==1 && XML->sys.first_level_dir ==1)
-		  ||(XML->sys.number_of_dir_levels==1 && XML->sys.first_level_dir ==2)))//not single level IC and DIC
+                  ||(XML->sys.number_of_dir_levels==1 &&
+  XML->sys.first_level_dir ==2)))//not single level IC and DIC
   {
   //directory Now assuming one directory per bank, TODO:should change it later
   size                             = XML->sys.L2directory.L2Dir_config[0];
   line                             = XML->sys.L2directory.L2Dir_config[1];
   assoc                            = XML->sys.L2directory.L2Dir_config[2];
   banks                            = XML->sys.L2directory.L2Dir_config[3];
-  tag							   = debug?51:XML->sys.physical_address_width + EXTRA_TAG_BITS;//TODO: a little bit over estimate
+  tag							   =
+  debug?51:XML->sys.physical_address_width + EXTRA_TAG_BITS;//TODO: a little bit
+  over estimate
   interface_ip.specific_tag        = 0;
   interface_ip.tag_w               = tag;
   interface_ip.cache_sz            = XML->sys.L2directory.L2Dir_config[0];
@@ -271,9 +281,12 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_, InputParameter*
   interface_ip.assoc               = XML->sys.L2directory.L2Dir_config[2];
   interface_ip.nbanks              = XML->sys.L2directory.L2Dir_config[3];
   interface_ip.out_w               = interface_ip.line_sz*8;
-  interface_ip.access_mode         = 0;//debug?0:XML->sys.core[ithCore].icache.icache_config[5];
-  interface_ip.throughput          = XML->sys.L2directory.L2Dir_config[4]/clockRate;
-  interface_ip.latency             = XML->sys.L2directory.L2Dir_config[5]/clockRate;
+  interface_ip.access_mode         =
+  0;//debug?0:XML->sys.core[ithCore].icache.icache_config[5];
+  interface_ip.throughput          =
+  XML->sys.L2directory.L2Dir_config[4]/clockRate;
+  interface_ip.latency             =
+  XML->sys.L2directory.L2Dir_config[5]/clockRate;
   interface_ip.is_cache			 = true;
   interface_ip.obj_func_dyn_energy = 0;
   interface_ip.obj_func_dyn_power  = 0;
@@ -291,21 +304,31 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_, InputParameter*
   //output_data_csv(directory.caches.local_result);
   ///cout<<"area="<<area<<endl;
 
-  //miss buffer Each MSHR contains enough state to handle one or more accesses of any type to a single memory line.
-  //Due to the generality of the MSHR mechanism, the amount of state involved is non-trivial,
-  //including the address, pointers to the cache entry and destination register, written data, and various other pieces of state.
-  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-  data							   = (XML->sys.physical_address_width) + int(ceil(log2(size/line))) + directory.caches.l_ip.line_sz;
+  //miss buffer Each MSHR contains enough state to handle one or more accesses
+  of any type to a single memory line.
+  //Due to the generality of the MSHR mechanism, the amount of state involved is
+  non-trivial,
+  //including the address, pointers to the cache entry and destination register,
+  written data, and various other pieces of state.
+  tag							   =
+  XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data							   =
+  (XML->sys.physical_address_width) + int(ceil(log2(size/line))) +
+  directory.caches.l_ip.line_sz;
   interface_ip.specific_tag        = 1;
   interface_ip.tag_w               = tag;
-  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-  interface_ip.cache_sz            = XML->sys.L2[ithCache].buffer_sizes[0]*interface_ip.line_sz;
+  interface_ip.line_sz             =
+  int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+  interface_ip.cache_sz            =
+  XML->sys.L2[ithCache].buffer_sizes[0]*interface_ip.line_sz;
   interface_ip.assoc               = 0;
   interface_ip.nbanks              = 1;
   interface_ip.out_w               = interface_ip.line_sz*8;
   interface_ip.access_mode         = 0;
-  interface_ip.throughput          = XML->sys.L2[ithCache].L2_config[4]/clockRate;//means cycle time
-  interface_ip.latency             = XML->sys.L2[ithCache].L2_config[5]/clockRate;//means access time
+  interface_ip.throughput          =
+  XML->sys.L2[ithCache].L2_config[4]/clockRate;//means cycle time
+  interface_ip.latency             =
+  XML->sys.L2[ithCache].L2_config[5]/clockRate;//means access time
   interface_ip.obj_func_dyn_energy = 0;
   interface_ip.obj_func_dyn_power  = 0;
   interface_ip.obj_func_leak_power = 0;
@@ -322,8 +345,10 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_, InputParameter*
   ///cout<<"area="<<area<<endl;
 
   //fill buffer
-  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-  data							   = directory.caches.l_ip.line_sz;
+  tag							   =
+  XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data							   =
+  directory.caches.l_ip.line_sz;
   interface_ip.specific_tag        = 1;
   interface_ip.tag_w               = tag;
   interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
@@ -332,8 +357,10 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_, InputParameter*
   interface_ip.nbanks              = 1;
   interface_ip.out_w               = interface_ip.line_sz*8;
   interface_ip.access_mode         = 0;
-  interface_ip.throughput          =  XML->sys.L2[ithCache].L2_config[4]/clockRate;
-  interface_ip.latency             =  XML->sys.L2[ithCache].L2_config[5]/clockRate;
+  interface_ip.throughput          =
+  XML->sys.L2[ithCache].L2_config[4]/clockRate;
+  interface_ip.latency             =
+  XML->sys.L2[ithCache].L2_config[5]/clockRate;
   interface_ip.obj_func_dyn_energy = 0;
   interface_ip.obj_func_dyn_power  = 0;
   interface_ip.obj_func_leak_power = 0;
@@ -350,18 +377,24 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_, InputParameter*
   ///cout<<"area="<<area<<endl;
 
   //prefetch buffer
-  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries to decide wthether to merge.
-  data							   = directory.caches.l_ip.line_sz;//separate queue to prevent from cache polution.
+  tag							   =
+  XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries
+  to decide wthether to merge.
+  data							   =
+  directory.caches.l_ip.line_sz;//separate queue to prevent from cache polution.
   interface_ip.specific_tag        = 1;
   interface_ip.tag_w               = tag;
   interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-  interface_ip.cache_sz            = XML->sys.L2[ithCache].buffer_sizes[2]*interface_ip.line_sz;
+  interface_ip.cache_sz            =
+  XML->sys.L2[ithCache].buffer_sizes[2]*interface_ip.line_sz;
   interface_ip.assoc               = 0;
   interface_ip.nbanks              = 1;
   interface_ip.out_w               = interface_ip.line_sz*8;
   interface_ip.access_mode         = 0;
-  interface_ip.throughput          = XML->sys.L2[ithCache].L2_config[4]/clockRate;
-  interface_ip.latency             = XML->sys.L2[ithCache].L2_config[5]/clockRate;
+  interface_ip.throughput          =
+  XML->sys.L2[ithCache].L2_config[4]/clockRate;
+  interface_ip.latency             =
+  XML->sys.L2[ithCache].L2_config[5]/clockRate;
   interface_ip.obj_func_dyn_energy = 0;
   interface_ip.obj_func_dyn_power  = 0;
   interface_ip.obj_func_leak_power = 0;
@@ -378,18 +411,23 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_, InputParameter*
   ///cout<<"area="<<area<<endl;
 
   //WBB
-  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-  data							   = directory.caches.l_ip.line_sz;
+  tag							   =
+  XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data							   =
+  directory.caches.l_ip.line_sz;
   interface_ip.specific_tag        = 1;
   interface_ip.tag_w               = tag;
   interface_ip.line_sz             = data;
-  interface_ip.cache_sz            = XML->sys.L2[ithCache].buffer_sizes[3]*interface_ip.line_sz;
+  interface_ip.cache_sz            =
+  XML->sys.L2[ithCache].buffer_sizes[3]*interface_ip.line_sz;
   interface_ip.assoc               = 0;
   interface_ip.nbanks              = 1;
   interface_ip.out_w               = interface_ip.line_sz*8;
   interface_ip.access_mode         = 0;
-  interface_ip.throughput          = XML->sys.L2[ithCache].L2_config[4]/clockRate;
-  interface_ip.latency             = XML->sys.L2[ithCache].L2_config[4]/clockRate;
+  interface_ip.throughput          =
+  XML->sys.L2[ithCache].L2_config[4]/clockRate;
+  interface_ip.latency             =
+  XML->sys.L2[ithCache].L2_config[4]/clockRate;
   interface_ip.obj_func_dyn_energy = 0;
   interface_ip.obj_func_dyn_power  = 0;
   interface_ip.obj_func_leak_power = 0;
@@ -407,11 +445,14 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_, InputParameter*
   if (XML->sys.number_of_dir_levels ==2 && XML->sys.first_level_dir==0)
   {
   //first level directory
-  size                             = XML->sys.L2directory.L2Dir_config[0]*XML->sys.domain_size/128;
+  size                             =
+  XML->sys.L2directory.L2Dir_config[0]*XML->sys.domain_size/128;
   line                             = int(ceil(XML->sys.domain_size/8.0));
   assoc                            = XML->sys.L2directory.L2Dir_config[2];
   banks                            = XML->sys.L2directory.L2Dir_config[3];
-  tag							   = debug?51:XML->sys.physical_address_width + EXTRA_TAG_BITS;//TODO: a little bit over estimate
+  tag							   =
+  debug?51:XML->sys.physical_address_width + EXTRA_TAG_BITS;//TODO: a little bit
+  over estimate
   interface_ip.specific_tag        = 1;
   interface_ip.tag_w               = tag;
   interface_ip.cache_sz            = XML->sys.L2directory.L2Dir_config[0];
@@ -419,9 +460,12 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_, InputParameter*
   interface_ip.assoc               = XML->sys.L2directory.L2Dir_config[2];
   interface_ip.nbanks              = XML->sys.L2directory.L2Dir_config[3];
   interface_ip.out_w               = interface_ip.line_sz*8;
-  interface_ip.access_mode         = 0;//debug?0:XML->sys.core[ithCore].icache.icache_config[5];
-  interface_ip.throughput          = XML->sys.L2directory.L2Dir_config[4]/clockRate;
-  interface_ip.latency             = XML->sys.L2directory.L2Dir_config[5]/clockRate;
+  interface_ip.access_mode         =
+  0;//debug?0:XML->sys.core[ithCore].icache.icache_config[5];
+  interface_ip.throughput          =
+  XML->sys.L2directory.L2Dir_config[4]/clockRate;
+  interface_ip.latency             =
+  XML->sys.L2directory.L2Dir_config[5]/clockRate;
   interface_ip.is_cache			 = true;
   interface_ip.obj_func_dyn_energy = 0;
   interface_ip.obj_func_dyn_power  = 0;
@@ -439,21 +483,31 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_, InputParameter*
   //output_data_csv(directory.caches.local_result);
   ///cout<<"area="<<area<<endl;
 
-  //miss buffer Each MSHR contains enough state to handle one or more accesses of any type to a single memory line.
-  //Due to the generality of the MSHR mechanism, the amount of state involved is non-trivial,
-  //including the address, pointers to the cache entry and destination register, written data, and various other pieces of state.
-  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-  data							   = (XML->sys.physical_address_width) + int(ceil(log2(size/line))) + directory1.caches.l_ip.line_sz;
+  //miss buffer Each MSHR contains enough state to handle one or more accesses
+  of any type to a single memory line.
+  //Due to the generality of the MSHR mechanism, the amount of state involved is
+  non-trivial,
+  //including the address, pointers to the cache entry and destination register,
+  written data, and various other pieces of state.
+  tag							   =
+  XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data							   =
+  (XML->sys.physical_address_width) + int(ceil(log2(size/line))) +
+  directory1.caches.l_ip.line_sz;
   interface_ip.specific_tag        = 1;
   interface_ip.tag_w               = tag;
-  interface_ip.line_sz             = int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
-  interface_ip.cache_sz            = XML->sys.L2[ithCache].buffer_sizes[0]*interface_ip.line_sz;
+  interface_ip.line_sz             =
+  int(ceil(data/8.0));//int(ceil(pow(2.0,ceil(log2(data)))/8.0));
+  interface_ip.cache_sz            =
+  XML->sys.L2[ithCache].buffer_sizes[0]*interface_ip.line_sz;
   interface_ip.assoc               = 0;
   interface_ip.nbanks              = 1;
   interface_ip.out_w               = interface_ip.line_sz*8;
   interface_ip.access_mode         = 0;
-  interface_ip.throughput          = XML->sys.L2[ithCache].L2_config[4]/clockRate;//means cycle time
-  interface_ip.latency             = XML->sys.L2[ithCache].L2_config[5]/clockRate;//means access time
+  interface_ip.throughput          =
+  XML->sys.L2[ithCache].L2_config[4]/clockRate;//means cycle time
+  interface_ip.latency             =
+  XML->sys.L2[ithCache].L2_config[5]/clockRate;//means access time
   interface_ip.obj_func_dyn_energy = 0;
   interface_ip.obj_func_dyn_power  = 0;
   interface_ip.obj_func_leak_power = 0;
@@ -470,8 +524,10 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_, InputParameter*
   ///cout<<"area="<<area<<endl;
 
   //fill buffer
-  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-  data							   = directory1.caches.l_ip.line_sz;
+  tag							   =
+  XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data							   =
+  directory1.caches.l_ip.line_sz;
   interface_ip.specific_tag        = 1;
   interface_ip.tag_w               = tag;
   interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
@@ -480,8 +536,10 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_, InputParameter*
   interface_ip.nbanks              = 1;
   interface_ip.out_w               = interface_ip.line_sz*8;
   interface_ip.access_mode         = 0;
-  interface_ip.throughput          =  XML->sys.L2[ithCache].L2_config[4]/clockRate;
-  interface_ip.latency             =  XML->sys.L2[ithCache].L2_config[5]/clockRate;
+  interface_ip.throughput          =
+  XML->sys.L2[ithCache].L2_config[4]/clockRate;
+  interface_ip.latency             =
+  XML->sys.L2[ithCache].L2_config[5]/clockRate;
   interface_ip.obj_func_dyn_energy = 0;
   interface_ip.obj_func_dyn_power  = 0;
   interface_ip.obj_func_leak_power = 0;
@@ -498,18 +556,25 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_, InputParameter*
   ///cout<<"area="<<area<<endl;
 
   //prefetch buffer
-  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries to decide wthether to merge.
-  data							   = directory1.caches.l_ip.line_sz;//separate queue to prevent from cache polution.
+  tag							   =
+  XML->sys.physical_address_width + EXTRA_TAG_BITS;//check with previous entries
+  to decide wthether to merge.
+  data							   =
+  directory1.caches.l_ip.line_sz;//separate queue to prevent from cache
+  polution.
   interface_ip.specific_tag        = 1;
   interface_ip.tag_w               = tag;
   interface_ip.line_sz             = data;//int(pow(2.0,ceil(log2(data))));
-  interface_ip.cache_sz            = XML->sys.L2[ithCache].buffer_sizes[2]*interface_ip.line_sz;
+  interface_ip.cache_sz            =
+  XML->sys.L2[ithCache].buffer_sizes[2]*interface_ip.line_sz;
   interface_ip.assoc               = 0;
   interface_ip.nbanks              = 1;
   interface_ip.out_w               = interface_ip.line_sz*8;
   interface_ip.access_mode         = 0;
-  interface_ip.throughput          = XML->sys.L2[ithCache].L2_config[4]/clockRate;
-  interface_ip.latency             = XML->sys.L2[ithCache].L2_config[5]/clockRate;
+  interface_ip.throughput          =
+  XML->sys.L2[ithCache].L2_config[4]/clockRate;
+  interface_ip.latency             =
+  XML->sys.L2[ithCache].L2_config[5]/clockRate;
   interface_ip.obj_func_dyn_energy = 0;
   interface_ip.obj_func_dyn_power  = 0;
   interface_ip.obj_func_leak_power = 0;
@@ -526,18 +591,23 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_, InputParameter*
   ///cout<<"area="<<area<<endl;
 
   //WBB
-  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-  data							   = directory1.caches.l_ip.line_sz;
+  tag							   =
+  XML->sys.physical_address_width + EXTRA_TAG_BITS;
+  data							   =
+  directory1.caches.l_ip.line_sz;
   interface_ip.specific_tag        = 1;
   interface_ip.tag_w               = tag;
   interface_ip.line_sz             = data;
-  interface_ip.cache_sz            = XML->sys.L2[ithCache].buffer_sizes[3]*interface_ip.line_sz;
+  interface_ip.cache_sz            =
+  XML->sys.L2[ithCache].buffer_sizes[3]*interface_ip.line_sz;
   interface_ip.assoc               = 0;
   interface_ip.nbanks              = 1;
   interface_ip.out_w               = interface_ip.line_sz*8;
   interface_ip.access_mode         = 0;
-  interface_ip.throughput          = XML->sys.L2[ithCache].L2_config[4]/clockRate;
-  interface_ip.latency             = XML->sys.L2[ithCache].L2_config[5]/clockRate;
+  interface_ip.throughput          =
+  XML->sys.L2[ithCache].L2_config[4]/clockRate;
+  interface_ip.latency             =
+  XML->sys.L2[ithCache].L2_config[5]/clockRate;
   interface_ip.obj_func_dyn_energy = 0;
   interface_ip.obj_func_dyn_power  = 0;
   interface_ip.obj_func_leak_power = 0;
@@ -554,357 +624,472 @@ SharedCache::SharedCache(ParseXML* XML_interface, int ithCache_, InputParameter*
 
   if (XML->sys.first_level_dir==1)//IC
   {
-	  tag							   = XML->sys.physical_address_width + EXTRA_TAG_BITS;
-	  data							   = int(ceil(XML->sys.domain_size/8.0));
-	  interface_ip.specific_tag        = 1;
-	  interface_ip.tag_w               = tag;
-	  interface_ip.line_sz             = data;
-	  interface_ip.cache_sz            = XML->sys.domain_size*data*XML->sys.L2[ithCache].L2_config[0]/XML->sys.L2[ithCache].L2_config[1];
-	  interface_ip.assoc               = 0;
-	  interface_ip.nbanks              = 1024;
-	  interface_ip.out_w               = interface_ip.line_sz*8;
-	  interface_ip.access_mode         = 0;
-	  interface_ip.throughput          = XML->sys.L2[ithCache].L2_config[4]/clockRate;
-	  interface_ip.latency             = XML->sys.L2[ithCache].L2_config[5]/clockRate;
-	  interface_ip.obj_func_dyn_energy = 0;
-	  interface_ip.obj_func_dyn_power  = 0;
-	  interface_ip.obj_func_leak_power = 0;
-	  interface_ip.obj_func_cycle_t    = 1;
-	  interface_ip.num_rw_ports    = 1;
-	  interface_ip.num_rd_ports    = 0;
-	  interface_ip.num_wr_ports    = 0;
-	  interface_ip.num_se_rd_ports = 0;
-	  strcpy(inv_dir.caches.name,"inv_dir");
-	  inv_dir.caches.init_cache(&interface_ip);
-	  inv_dir.caches.optimize_array();
-	  inv_dir.area = inv_dir.caches.local_result.area;
+          tag							   =
+  XML->sys.physical_address_width + EXTRA_TAG_BITS;
+          data							   =
+  int(ceil(XML->sys.domain_size/8.0));
+          interface_ip.specific_tag        = 1;
+          interface_ip.tag_w               = tag;
+          interface_ip.line_sz             = data;
+          interface_ip.cache_sz            =
+  XML->sys.domain_size*data*XML->sys.L2[ithCache].L2_config[0]/XML->sys.L2[ithCache].L2_config[1];
+          interface_ip.assoc               = 0;
+          interface_ip.nbanks              = 1024;
+          interface_ip.out_w               = interface_ip.line_sz*8;
+          interface_ip.access_mode         = 0;
+          interface_ip.throughput          =
+  XML->sys.L2[ithCache].L2_config[4]/clockRate;
+          interface_ip.latency             =
+  XML->sys.L2[ithCache].L2_config[5]/clockRate;
+          interface_ip.obj_func_dyn_energy = 0;
+          interface_ip.obj_func_dyn_power  = 0;
+          interface_ip.obj_func_leak_power = 0;
+          interface_ip.obj_func_cycle_t    = 1;
+          interface_ip.num_rw_ports    = 1;
+          interface_ip.num_rd_ports    = 0;
+          interface_ip.num_wr_ports    = 0;
+          interface_ip.num_se_rd_ports = 0;
+          strcpy(inv_dir.caches.name,"inv_dir");
+          inv_dir.caches.init_cache(&interface_ip);
+          inv_dir.caches.optimize_array();
+          inv_dir.area = inv_dir.caches.local_result.area;
 
   }
 */
-//  //pipeline
-//  interface_ip.pipeline_stages = int(ceil(directory.caches.local_result.access_time/directory.caches.local_result.cycle_time));
-//  interface_ip.per_stage_vector = directory.caches.l_ip.out_w + directory.caches.l_ip.tag_w ;
-//  pipeLogicDirectory.init_pipeline(is_default, &interface_ip);
-//  pipeLogicDirectory.compute_pipeline();
-//
-//  //clock power
-//  clockNetwork.init_wire_external(is_default, &interface_ip);
-//  clockNetwork.clk_area           =area*1.1;//10% of placement overhead. rule of thumb
-//  clockNetwork.end_wiring_level   =5;//toplevel metal
-//  clockNetwork.start_wiring_level =5;//toplevel metal
-//  clockNetwork.num_regs           = pipeLogicCache.tot_stage_vector + pipeLogicDirectory.tot_stage_vector;
-//  clockNetwork.optimize_wire();
-
+  //  //pipeline
+  //  interface_ip.pipeline_stages =
+  //  int(ceil(directory.caches.local_result.access_time/directory.caches.local_result.cycle_time));
+  //  interface_ip.per_stage_vector = directory.caches.l_ip.out_w +
+  //  directory.caches.l_ip.tag_w ;
+  //  pipeLogicDirectory.init_pipeline(is_default, &interface_ip);
+  //  pipeLogicDirectory.compute_pipeline();
+  //
+  //  //clock power
+  //  clockNetwork.init_wire_external(is_default, &interface_ip);
+  //  clockNetwork.clk_area           =area*1.1;//10% of placement overhead.
+  //  rule of thumb
+  //  clockNetwork.end_wiring_level   =5;//toplevel metal
+  //  clockNetwork.start_wiring_level =5;//toplevel metal
+  //  clockNetwork.num_regs           = pipeLogicCache.tot_stage_vector +
+  //  pipeLogicDirectory.tot_stage_vector;
+  //  clockNetwork.optimize_wire();
 }
 
+void SharedCache::computeEnergy(bool is_tdp) {
+  double homenode_data_access = (cachep.dir_ty == SBT) ? 0.9 : 1.0;
+  if (is_tdp) {
+    if (!((cachep.dir_ty == ST && cacheL == L1Directory) ||
+          (cachep.dir_ty == ST && cacheL == L2Directory))) {
+      // init stats for Peak
+      unicache.caches->stats_t.readAc.access =
+          .67 * unicache.caches->l_ip.num_rw_ports * cachep.duty_cycle *
+          homenode_data_access;
+      unicache.caches->stats_t.readAc.miss = 0;
+      unicache.caches->stats_t.readAc.hit =
+          unicache.caches->stats_t.readAc.access -
+          unicache.caches->stats_t.readAc.miss;
+      unicache.caches->stats_t.writeAc.access =
+          .33 * unicache.caches->l_ip.num_rw_ports * cachep.duty_cycle *
+          homenode_data_access;
+      unicache.caches->stats_t.writeAc.miss = 0;
+      unicache.caches->stats_t.writeAc.hit =
+          unicache.caches->stats_t.writeAc.access -
+          unicache.caches->stats_t.writeAc.miss;
+      unicache.caches->tdp_stats = unicache.caches->stats_t;
 
-void SharedCache::computeEnergy(bool is_tdp)
-{
-	double homenode_data_access = (cachep.dir_ty==SBT)? 0.9:1.0;
-	if (is_tdp)
-	{
-		if (!((cachep.dir_ty==ST&& cacheL==L1Directory)||(cachep.dir_ty==ST&& cacheL==L2Directory)))
-		{
-			//init stats for Peak
-			unicache.caches->stats_t.readAc.access  = .67*unicache.caches->l_ip.num_rw_ports*cachep.duty_cycle*homenode_data_access;
-			unicache.caches->stats_t.readAc.miss    = 0;
-			unicache.caches->stats_t.readAc.hit     = unicache.caches->stats_t.readAc.access - unicache.caches->stats_t.readAc.miss;
-			unicache.caches->stats_t.writeAc.access = .33*unicache.caches->l_ip.num_rw_ports*cachep.duty_cycle*homenode_data_access;
-			unicache.caches->stats_t.writeAc.miss   = 0;
-			unicache.caches->stats_t.writeAc.hit    = unicache.caches->stats_t.writeAc.access -	unicache.caches->stats_t.writeAc.miss;
-			unicache.caches->tdp_stats = unicache.caches->stats_t;
+      if (cachep.dir_ty == SBT) {
+        homenode_stats_t.readAc.access =
+            .67 * unicache.caches->l_ip.num_rw_ports * cachep.dir_duty_cycle *
+            (1 - homenode_data_access);
+        homenode_stats_t.readAc.miss = 0;
+        homenode_stats_t.readAc.hit =
+            homenode_stats_t.readAc.access - homenode_stats_t.readAc.miss;
+        homenode_stats_t.writeAc.access =
+            .67 * unicache.caches->l_ip.num_rw_ports * cachep.dir_duty_cycle *
+            (1 - homenode_data_access);
+        homenode_stats_t.writeAc.miss = 0;
+        homenode_stats_t.writeAc.hit =
+            homenode_stats_t.writeAc.access - homenode_stats_t.writeAc.miss;
+        homenode_tdp_stats = homenode_stats_t;
+      }
 
-			if (cachep.dir_ty==SBT)
-			{
-				homenode_stats_t.readAc.access  = .67*unicache.caches->l_ip.num_rw_ports*cachep.dir_duty_cycle*(1-homenode_data_access);
-				homenode_stats_t.readAc.miss    = 0;
-				homenode_stats_t.readAc.hit     = homenode_stats_t.readAc.access - homenode_stats_t.readAc.miss;
-				homenode_stats_t.writeAc.access  = .67*unicache.caches->l_ip.num_rw_ports*cachep.dir_duty_cycle*(1-homenode_data_access);
-				homenode_stats_t.writeAc.miss   = 0;
-				homenode_stats_t.writeAc.hit    = homenode_stats_t.writeAc.access -	homenode_stats_t.writeAc.miss;
-				homenode_tdp_stats = homenode_stats_t;
-			}
+      unicache.missb->stats_t.readAc.access =
+          unicache.missb->l_ip.num_search_ports;
+      unicache.missb->stats_t.writeAc.access =
+          unicache.missb->l_ip.num_search_ports;
+      unicache.missb->tdp_stats = unicache.missb->stats_t;
 
-			unicache.missb->stats_t.readAc.access  = unicache.missb->l_ip.num_search_ports;
-			unicache.missb->stats_t.writeAc.access = unicache.missb->l_ip.num_search_ports;
-			unicache.missb->tdp_stats = unicache.missb->stats_t;
+      unicache.ifb->stats_t.readAc.access = unicache.ifb->l_ip.num_search_ports;
+      unicache.ifb->stats_t.writeAc.access =
+          unicache.ifb->l_ip.num_search_ports;
+      unicache.ifb->tdp_stats = unicache.ifb->stats_t;
 
-			unicache.ifb->stats_t.readAc.access  = unicache.ifb->l_ip.num_search_ports;
-			unicache.ifb->stats_t.writeAc.access = unicache.ifb->l_ip.num_search_ports;
-			unicache.ifb->tdp_stats = unicache.ifb->stats_t;
+      unicache.prefetchb->stats_t.readAc.access =
+          unicache.prefetchb->l_ip.num_search_ports;
+      unicache.prefetchb->stats_t.writeAc.access =
+          unicache.ifb->l_ip.num_search_ports;
+      unicache.prefetchb->tdp_stats = unicache.prefetchb->stats_t;
 
-			unicache.prefetchb->stats_t.readAc.access  = unicache.prefetchb->l_ip.num_search_ports;
-			unicache.prefetchb->stats_t.writeAc.access = unicache.ifb->l_ip.num_search_ports;
-			unicache.prefetchb->tdp_stats = unicache.prefetchb->stats_t;
+      unicache.wbb->stats_t.readAc.access = unicache.wbb->l_ip.num_search_ports;
+      unicache.wbb->stats_t.writeAc.access =
+          unicache.wbb->l_ip.num_search_ports;
+      unicache.wbb->tdp_stats = unicache.wbb->stats_t;
+    } else {
+      unicache.caches->stats_t.readAc.access =
+          unicache.caches->l_ip.num_search_ports * cachep.duty_cycle;
+      unicache.caches->stats_t.readAc.miss = 0;
+      unicache.caches->stats_t.readAc.hit =
+          unicache.caches->stats_t.readAc.access -
+          unicache.caches->stats_t.readAc.miss;
+      unicache.caches->stats_t.writeAc.access = 0;
+      unicache.caches->stats_t.writeAc.miss = 0;
+      unicache.caches->stats_t.writeAc.hit =
+          unicache.caches->stats_t.writeAc.access -
+          unicache.caches->stats_t.writeAc.miss;
+      unicache.caches->tdp_stats = unicache.caches->stats_t;
+    }
 
-			unicache.wbb->stats_t.readAc.access  = unicache.wbb->l_ip.num_search_ports;
-			unicache.wbb->stats_t.writeAc.access = unicache.wbb->l_ip.num_search_ports;
-			unicache.wbb->tdp_stats = unicache.wbb->stats_t;
-		}
-		else
-		{
-			unicache.caches->stats_t.readAc.access  = unicache.caches->l_ip.num_search_ports*cachep.duty_cycle;
-			unicache.caches->stats_t.readAc.miss    = 0;
-			unicache.caches->stats_t.readAc.hit     = unicache.caches->stats_t.readAc.access - unicache.caches->stats_t.readAc.miss;
-			unicache.caches->stats_t.writeAc.access = 0;
-			unicache.caches->stats_t.writeAc.miss   = 0;
-			unicache.caches->stats_t.writeAc.hit    = unicache.caches->stats_t.writeAc.access -	unicache.caches->stats_t.writeAc.miss;
-			unicache.caches->tdp_stats = unicache.caches->stats_t;
+  } else {
+    // init stats for runtime power (RTP)
+    if (cacheL == L2) {
+      // Copy stats from l1 to L1[0]
+      XML->sys.L2[ithCache].total_accesses = XML->sys.l2.total_accesses;
+      XML->sys.L2[ithCache].read_accesses = XML->sys.l2.read_accesses;
+      XML->sys.L2[ithCache].write_accesses = XML->sys.l2.write_accesses;
+      XML->sys.L2[ithCache].read_hits = XML->sys.l2.read_hits;
+      XML->sys.L2[ithCache].read_misses = XML->sys.l2.read_misses;
+      XML->sys.L2[ithCache].write_hits = XML->sys.l2.write_hits;
+      XML->sys.L2[ithCache].write_misses = XML->sys.l2.write_misses;
 
-		}
+      unicache.caches->stats_t.readAc.access =
+          XML->sys.L2[ithCache].read_accesses;
+      unicache.caches->stats_t.readAc.miss = XML->sys.L2[ithCache].read_misses;
+      unicache.caches->stats_t.readAc.hit =
+          unicache.caches->stats_t.readAc.access -
+          unicache.caches->stats_t.readAc.miss;
+      unicache.caches->stats_t.writeAc.access =
+          XML->sys.L2[ithCache].write_accesses;
+      unicache.caches->stats_t.writeAc.miss =
+          XML->sys.L2[ithCache].write_misses;
+      unicache.caches->stats_t.writeAc.hit =
+          unicache.caches->stats_t.writeAc.access -
+          unicache.caches->stats_t.writeAc.miss;
+      unicache.caches->rtp_stats = unicache.caches->stats_t;
 
-	}
-	else
-	{
-		//init stats for runtime power (RTP)
-		if (cacheL==L2)
-		{
-		  //Copy stats from l1 to L1[0]
-		  XML->sys.L2[ithCache].total_accesses=XML->sys.l2.total_accesses;
-		  XML->sys.L2[ithCache].read_accesses=XML->sys.l2.read_accesses;
-		  XML->sys.L2[ithCache].write_accesses=XML->sys.l2.write_accesses;
-		  XML->sys.L2[ithCache].read_hits=XML->sys.l2.read_hits;
-		  XML->sys.L2[ithCache].read_misses=XML->sys.l2.read_misses;
-		  XML->sys.L2[ithCache].write_hits=XML->sys.l2.write_hits;
-		  XML->sys.L2[ithCache].write_misses=XML->sys.l2.write_misses;
+      if (cachep.dir_ty == SBT) {
+        homenode_rtp_stats.readAc.access =
+            XML->sys.L2[ithCache].homenode_read_accesses;
+        homenode_rtp_stats.readAc.miss =
+            XML->sys.L2[ithCache].homenode_read_misses;
+        homenode_rtp_stats.readAc.hit =
+            homenode_rtp_stats.readAc.access - homenode_rtp_stats.readAc.miss;
+        homenode_rtp_stats.writeAc.access =
+            XML->sys.L2[ithCache].homenode_write_accesses;
+        homenode_rtp_stats.writeAc.miss =
+            XML->sys.L2[ithCache].homenode_write_misses;
+        homenode_rtp_stats.writeAc.hit =
+            homenode_rtp_stats.writeAc.access - homenode_rtp_stats.writeAc.miss;
+      }
+    } else if (cacheL == L3) {
+      unicache.caches->stats_t.readAc.access =
+          XML->sys.L3[ithCache].read_accesses;
+      unicache.caches->stats_t.readAc.miss = XML->sys.L3[ithCache].read_misses;
+      unicache.caches->stats_t.readAc.hit =
+          unicache.caches->stats_t.readAc.access -
+          unicache.caches->stats_t.readAc.miss;
+      unicache.caches->stats_t.writeAc.access =
+          XML->sys.L3[ithCache].write_accesses;
+      unicache.caches->stats_t.writeAc.miss =
+          XML->sys.L3[ithCache].write_misses;
+      unicache.caches->stats_t.writeAc.hit =
+          unicache.caches->stats_t.writeAc.access -
+          unicache.caches->stats_t.writeAc.miss;
+      unicache.caches->rtp_stats = unicache.caches->stats_t;
 
-		  unicache.caches->stats_t.readAc.access  = XML->sys.L2[ithCache].read_accesses;
-		  unicache.caches->stats_t.readAc.miss    = XML->sys.L2[ithCache].read_misses;
-		  unicache.caches->stats_t.readAc.hit     = unicache.caches->stats_t.readAc.access - unicache.caches->stats_t.readAc.miss;
-		  unicache.caches->stats_t.writeAc.access = XML->sys.L2[ithCache].write_accesses;
-		  unicache.caches->stats_t.writeAc.miss   = XML->sys.L2[ithCache].write_misses;
-		  unicache.caches->stats_t.writeAc.hit    = unicache.caches->stats_t.writeAc.access -	unicache.caches->stats_t.writeAc.miss;
-		  unicache.caches->rtp_stats = unicache.caches->stats_t;
+      if (cachep.dir_ty == SBT) {
+        homenode_rtp_stats.readAc.access =
+            XML->sys.L3[ithCache].homenode_read_accesses;
+        homenode_rtp_stats.readAc.miss =
+            XML->sys.L3[ithCache].homenode_read_misses;
+        homenode_rtp_stats.readAc.hit =
+            homenode_rtp_stats.readAc.access - homenode_rtp_stats.readAc.miss;
+        homenode_rtp_stats.writeAc.access =
+            XML->sys.L3[ithCache].homenode_write_accesses;
+        homenode_rtp_stats.writeAc.miss =
+            XML->sys.L3[ithCache].homenode_write_misses;
+        homenode_rtp_stats.writeAc.hit =
+            homenode_rtp_stats.writeAc.access - homenode_rtp_stats.writeAc.miss;
+      }
+    } else if (cacheL == L1Directory) {
+      unicache.caches->stats_t.readAc.access =
+          XML->sys.L1Directory[ithCache].read_accesses;
+      unicache.caches->stats_t.readAc.miss =
+          XML->sys.L1Directory[ithCache].read_misses;
+      unicache.caches->stats_t.readAc.hit =
+          unicache.caches->stats_t.readAc.access -
+          unicache.caches->stats_t.readAc.miss;
+      unicache.caches->stats_t.writeAc.access =
+          XML->sys.L1Directory[ithCache].write_accesses;
+      unicache.caches->stats_t.writeAc.miss =
+          XML->sys.L1Directory[ithCache].write_misses;
+      unicache.caches->stats_t.writeAc.hit =
+          unicache.caches->stats_t.writeAc.access -
+          unicache.caches->stats_t.writeAc.miss;
+      unicache.caches->rtp_stats = unicache.caches->stats_t;
+    } else if (cacheL == L2Directory) {  // cout<<"L2 directory"<<endl;
+      // Copy stats from l1 to L1[0]
+      // XML->sys.L2[ithCache].total_accesses=XML->sys.l2.total_accesses;
+      // XML->sys.L2[ithCache].read_accesses=XML->sys.l2.read_accesses;
+      // XML->sys.L2[ithCache].write_accesses=XML->sys.l2.write_accesses;
+      // XML->sys.L2[ithCache].read_hits=XML->sys.l2.read_hits;
+      // XML->sys.L2[ithCache].read_misses=XML->sys.l2.read_misses;
+      // XML->sys.L2[ithCache].write_hits=XML->sys.l2.write_hits;
+      // XML->sys.L2[ithCache].write_misses=XML->sys.l2.write_misses;
+      unicache.caches->stats_t.readAc.access =
+          XML->sys.L2Directory[ithCache].read_accesses;
+      unicache.caches->stats_t.readAc.miss =
+          XML->sys.L2Directory[ithCache].read_misses;
+      unicache.caches->stats_t.readAc.hit =
+          unicache.caches->stats_t.readAc.access -
+          unicache.caches->stats_t.readAc.miss;
+      unicache.caches->stats_t.writeAc.access =
+          XML->sys.L2Directory[ithCache].write_accesses;
+      unicache.caches->stats_t.writeAc.miss =
+          XML->sys.L2Directory[ithCache].write_misses;
+      unicache.caches->stats_t.writeAc.hit =
+          unicache.caches->stats_t.writeAc.access -
+          unicache.caches->stats_t.writeAc.miss;
+      unicache.caches->rtp_stats = unicache.caches->stats_t;
+    }
+    if (!((cachep.dir_ty == ST && cacheL == L1Directory) ||
+          (cachep.dir_ty == ST &&
+           cacheL ==
+               L2Directory))) {  // Assuming write back and write-allocate cache
 
-		  if (cachep.dir_ty==SBT)
-		  {
-			 homenode_rtp_stats.readAc.access  = XML->sys.L2[ithCache].homenode_read_accesses;
-			 homenode_rtp_stats.readAc.miss    = XML->sys.L2[ithCache].homenode_read_misses;
-			 homenode_rtp_stats.readAc.hit     = homenode_rtp_stats.readAc.access - homenode_rtp_stats.readAc.miss;
-			 homenode_rtp_stats.writeAc.access = XML->sys.L2[ithCache].homenode_write_accesses;
-			 homenode_rtp_stats.writeAc.miss   = XML->sys.L2[ithCache].homenode_write_misses;
-			 homenode_rtp_stats.writeAc.hit    = homenode_rtp_stats.writeAc.access -	homenode_rtp_stats.writeAc.miss;
-		  }
-		}
-		else if (cacheL==L3)
-		{
-		  unicache.caches->stats_t.readAc.access  = XML->sys.L3[ithCache].read_accesses;
-		  unicache.caches->stats_t.readAc.miss    = XML->sys.L3[ithCache].read_misses;
-		  unicache.caches->stats_t.readAc.hit     = unicache.caches->stats_t.readAc.access - unicache.caches->stats_t.readAc.miss;
-		  unicache.caches->stats_t.writeAc.access = XML->sys.L3[ithCache].write_accesses;
-		  unicache.caches->stats_t.writeAc.miss   = XML->sys.L3[ithCache].write_misses;
-		  unicache.caches->stats_t.writeAc.hit    = unicache.caches->stats_t.writeAc.access -	unicache.caches->stats_t.writeAc.miss;
-		  unicache.caches->rtp_stats = unicache.caches->stats_t;
+      unicache.missb->stats_t.readAc.access =
+          unicache.caches->stats_t.writeAc.miss;
+      unicache.missb->stats_t.writeAc.access =
+          unicache.caches->stats_t.writeAc.miss;
+      unicache.missb->rtp_stats = unicache.missb->stats_t;
 
-		  if (cachep.dir_ty==SBT)
-		  {
-			 homenode_rtp_stats.readAc.access  = XML->sys.L3[ithCache].homenode_read_accesses;
-			 homenode_rtp_stats.readAc.miss    = XML->sys.L3[ithCache].homenode_read_misses;
-			 homenode_rtp_stats.readAc.hit     = homenode_rtp_stats.readAc.access - homenode_rtp_stats.readAc.miss;
-			 homenode_rtp_stats.writeAc.access = XML->sys.L3[ithCache].homenode_write_accesses;
-			 homenode_rtp_stats.writeAc.miss   = XML->sys.L3[ithCache].homenode_write_misses;
-			 homenode_rtp_stats.writeAc.hit    = homenode_rtp_stats.writeAc.access -	homenode_rtp_stats.writeAc.miss;
-		  }
-		}
-		else if (cacheL==L1Directory)
-		{
-		  unicache.caches->stats_t.readAc.access  = XML->sys.L1Directory[ithCache].read_accesses;
-		  unicache.caches->stats_t.readAc.miss    = XML->sys.L1Directory[ithCache].read_misses;
-		  unicache.caches->stats_t.readAc.hit     = unicache.caches->stats_t.readAc.access - unicache.caches->stats_t.readAc.miss;
-		  unicache.caches->stats_t.writeAc.access = XML->sys.L1Directory[ithCache].write_accesses;
-		  unicache.caches->stats_t.writeAc.miss   = XML->sys.L1Directory[ithCache].write_misses;
-		  unicache.caches->stats_t.writeAc.hit    = unicache.caches->stats_t.writeAc.access -	unicache.caches->stats_t.writeAc.miss;
-		  unicache.caches->rtp_stats = unicache.caches->stats_t;
-		}
-		else if (cacheL==L2Directory)
-		{ //cout<<"L2 directory"<<endl;
-		  //Copy stats from l1 to L1[0]
-		  //XML->sys.L2[ithCache].total_accesses=XML->sys.l2.total_accesses;
-		  //XML->sys.L2[ithCache].read_accesses=XML->sys.l2.read_accesses;
-		  //XML->sys.L2[ithCache].write_accesses=XML->sys.l2.write_accesses;
-		  //XML->sys.L2[ithCache].read_hits=XML->sys.l2.read_hits;
-		  //XML->sys.L2[ithCache].read_misses=XML->sys.l2.read_misses;
-		  //XML->sys.L2[ithCache].write_hits=XML->sys.l2.write_hits;
-		  //XML->sys.L2[ithCache].write_misses=XML->sys.l2.write_misses;
-		  unicache.caches->stats_t.readAc.access  = XML->sys.L2Directory[ithCache].read_accesses;
-		  unicache.caches->stats_t.readAc.miss    = XML->sys.L2Directory[ithCache].read_misses;
-		  unicache.caches->stats_t.readAc.hit     = unicache.caches->stats_t.readAc.access - unicache.caches->stats_t.readAc.miss;
-		  unicache.caches->stats_t.writeAc.access = XML->sys.L2Directory[ithCache].write_accesses;
-		  unicache.caches->stats_t.writeAc.miss   = XML->sys.L2Directory[ithCache].write_misses;
-		  unicache.caches->stats_t.writeAc.hit    = unicache.caches->stats_t.writeAc.access -	unicache.caches->stats_t.writeAc.miss;
-		  unicache.caches->rtp_stats = unicache.caches->stats_t;
-		}
-		if (!((cachep.dir_ty==ST&& cacheL==L1Directory)||(cachep.dir_ty==ST&& cacheL==L2Directory)))
-		{   //Assuming write back and write-allocate cache
+      unicache.ifb->stats_t.readAc.access =
+          unicache.caches->stats_t.writeAc.miss;
+      unicache.ifb->stats_t.writeAc.access =
+          unicache.caches->stats_t.writeAc.miss;
+      unicache.ifb->rtp_stats = unicache.ifb->stats_t;
 
-		  unicache.missb->stats_t.readAc.access  = unicache.caches->stats_t.writeAc.miss ;
-		  unicache.missb->stats_t.writeAc.access = unicache.caches->stats_t.writeAc.miss;
-		  unicache.missb->rtp_stats = unicache.missb->stats_t;
+      unicache.prefetchb->stats_t.readAc.access =
+          unicache.caches->stats_t.writeAc.miss;
+      unicache.prefetchb->stats_t.writeAc.access =
+          unicache.caches->stats_t.writeAc.miss;
+      unicache.prefetchb->rtp_stats = unicache.prefetchb->stats_t;
 
-		  unicache.ifb->stats_t.readAc.access  = unicache.caches->stats_t.writeAc.miss;
-		  unicache.ifb->stats_t.writeAc.access = unicache.caches->stats_t.writeAc.miss;
-		  unicache.ifb->rtp_stats = unicache.ifb->stats_t;
+      unicache.wbb->stats_t.readAc.access =
+          unicache.caches->stats_t.writeAc.miss;
+      unicache.wbb->stats_t.writeAc.access =
+          unicache.caches->stats_t.writeAc.miss;
+      if (cachep.dir_ty == SBT) {
+        unicache.missb->stats_t.readAc.access +=
+            homenode_rtp_stats.writeAc.miss;
+        unicache.missb->stats_t.writeAc.access +=
+            homenode_rtp_stats.writeAc.miss;
+        unicache.missb->rtp_stats = unicache.missb->stats_t;
 
-		  unicache.prefetchb->stats_t.readAc.access  = unicache.caches->stats_t.writeAc.miss;
-		  unicache.prefetchb->stats_t.writeAc.access = unicache.caches->stats_t.writeAc.miss;
-		  unicache.prefetchb->rtp_stats = unicache.prefetchb->stats_t;
+        unicache.missb->stats_t.readAc.access +=
+            homenode_rtp_stats.writeAc.miss;
+        unicache.missb->stats_t.writeAc.access +=
+            homenode_rtp_stats.writeAc.miss;
+        unicache.missb->rtp_stats = unicache.missb->stats_t;
 
-		  unicache.wbb->stats_t.readAc.access  = unicache.caches->stats_t.writeAc.miss;
-		  unicache.wbb->stats_t.writeAc.access = unicache.caches->stats_t.writeAc.miss;
-		  if (cachep.dir_ty==SBT)
-		  {
-			 unicache.missb->stats_t.readAc.access  += homenode_rtp_stats.writeAc.miss;
-			 unicache.missb->stats_t.writeAc.access += homenode_rtp_stats.writeAc.miss;
-			 unicache.missb->rtp_stats = unicache.missb->stats_t;
+        unicache.ifb->stats_t.readAc.access += homenode_rtp_stats.writeAc.miss;
+        unicache.ifb->stats_t.writeAc.access += homenode_rtp_stats.writeAc.miss;
+        unicache.ifb->rtp_stats = unicache.ifb->stats_t;
 
-			 unicache.missb->stats_t.readAc.access  += homenode_rtp_stats.writeAc.miss;
-			 unicache.missb->stats_t.writeAc.access += homenode_rtp_stats.writeAc.miss;
-			 unicache.missb->rtp_stats = unicache.missb->stats_t;
+        unicache.prefetchb->stats_t.readAc.access +=
+            homenode_rtp_stats.writeAc.miss;
+        unicache.prefetchb->stats_t.writeAc.access +=
+            homenode_rtp_stats.writeAc.miss;
+        unicache.prefetchb->rtp_stats = unicache.prefetchb->stats_t;
 
-			 unicache.ifb->stats_t.readAc.access  += homenode_rtp_stats.writeAc.miss;
-			 unicache.ifb->stats_t.writeAc.access += homenode_rtp_stats.writeAc.miss;
-			 unicache.ifb->rtp_stats = unicache.ifb->stats_t;
+        unicache.wbb->stats_t.readAc.access += homenode_rtp_stats.writeAc.miss;
+        unicache.wbb->stats_t.writeAc.access += homenode_rtp_stats.writeAc.miss;
+      }
+      unicache.wbb->rtp_stats = unicache.wbb->stats_t;
+    }
+  }
 
-			 unicache.prefetchb->stats_t.readAc.access  += homenode_rtp_stats.writeAc.miss;
-			 unicache.prefetchb->stats_t.writeAc.access += homenode_rtp_stats.writeAc.miss;
-			 unicache.prefetchb->rtp_stats = unicache.prefetchb->stats_t;
+  unicache.power_t.reset();
+  unicache.rt_power.reset();
+  if (!((cachep.dir_ty == ST && cacheL == L1Directory) ||
+        (cachep.dir_ty == ST && cacheL == L2Directory))) {
+    unicache.power_t.readOp.dynamic +=
+        (unicache.caches->stats_t.readAc.hit *
+             unicache.caches->local_result.power.readOp.dynamic +
+         unicache.caches->stats_t.readAc.miss *
+             unicache.caches->local_result.tag_array2->power.readOp.dynamic +
+         unicache.caches->stats_t.writeAc.miss *
+             unicache.caches->local_result.tag_array2->power.writeOp.dynamic +
+         unicache.caches->stats_t.writeAc.access *
+             unicache.caches->local_result.power.writeOp
+                 .dynamic);  // write miss will also generate a write later
 
-			 unicache.wbb->stats_t.readAc.access  += homenode_rtp_stats.writeAc.miss;
-			 unicache.wbb->stats_t.writeAc.access += homenode_rtp_stats.writeAc.miss;
-		  }
-		  unicache.wbb->rtp_stats = unicache.wbb->stats_t;
+    if (cachep.dir_ty == SBT) {
+      unicache.power_t.readOp.dynamic +=
+          homenode_stats_t.readAc.hit *
+              (unicache.caches->local_result.data_array2->power.readOp.dynamic *
+                   dir_overhead +
+               unicache.caches->local_result.tag_array2->power.readOp.dynamic) +
+          homenode_stats_t.readAc.miss *
+              unicache.caches->local_result.tag_array2->power.readOp.dynamic +
+          homenode_stats_t.writeAc.miss *
+              unicache.caches->local_result.tag_array2->power.readOp.dynamic +
+          homenode_stats_t.writeAc.hit *
+              (unicache.caches->local_result.data_array2->power.writeOp
+                       .dynamic *
+                   dir_overhead +
+               unicache.caches->local_result.tag_array2->power.readOp.dynamic +
+               homenode_stats_t.writeAc.miss *
+                   unicache.caches->local_result.power.writeOp
+                       .dynamic);  // write miss on dynamic home node will
+                                   // generate a replacement write on whole
+                                   // cache block
+    }
 
-		}
+    unicache.power_t.readOp.dynamic +=
+        unicache.missb->stats_t.readAc.access *
+            unicache.missb->local_result.power.searchOp.dynamic +
+        unicache.missb->stats_t.writeAc.access *
+            unicache.missb->local_result.power.writeOp
+                .dynamic;  // each access to missb involves a CAM and a write
+    unicache.power_t.readOp.dynamic +=
+        unicache.ifb->stats_t.readAc.access *
+            unicache.ifb->local_result.power.searchOp.dynamic +
+        unicache.ifb->stats_t.writeAc.access *
+            unicache.ifb->local_result.power.writeOp.dynamic;
+    unicache.power_t.readOp.dynamic +=
+        unicache.prefetchb->stats_t.readAc.access *
+            unicache.prefetchb->local_result.power.searchOp.dynamic +
+        unicache.prefetchb->stats_t.writeAc.access *
+            unicache.prefetchb->local_result.power.writeOp.dynamic;
+    unicache.power_t.readOp.dynamic +=
+        unicache.wbb->stats_t.readAc.access *
+            unicache.wbb->local_result.power.searchOp.dynamic +
+        unicache.wbb->stats_t.writeAc.access *
+            unicache.wbb->local_result.power.writeOp.dynamic;
+  } else {
+    unicache.power_t.readOp.dynamic +=
+        (unicache.caches->stats_t.readAc.access *
+             unicache.caches->local_result.power.searchOp.dynamic +
+         unicache.caches->stats_t.writeAc.access *
+             unicache.caches->local_result.power.writeOp.dynamic);
+  }
 
-	}
+  if (is_tdp) {
+    unicache.power =
+        unicache.power_t + (unicache.caches->local_result.power) * pppm_lkg;
+    if (!((cachep.dir_ty == ST && cacheL == L1Directory) ||
+          (cachep.dir_ty == ST && cacheL == L2Directory))) {
+      unicache.power = unicache.power +
+                       (unicache.missb->local_result.power +
+                        unicache.ifb->local_result.power +
+                        unicache.prefetchb->local_result.power +
+                        unicache.wbb->local_result.power) *
+                           pppm_lkg;
+    }
+    power = power + unicache.power;
+    //		cout<<"unicache.caches->local_result.power.readOp.dynamic"<<unicache.caches->local_result.power.readOp.dynamic<<endl;
+    //		cout<<"unicache.caches->local_result.power.writeOp.dynamic"<<unicache.caches->local_result.power.writeOp.dynamic<<endl;
+  } else {
+    unicache.rt_power =
+        unicache.power_t + (unicache.caches->local_result.power) * pppm_lkg;
+    if (!((cachep.dir_ty == ST && cacheL == L1Directory) ||
+          (cachep.dir_ty == ST && cacheL == L2Directory))) {
+      unicache.rt_power = unicache.rt_power +
+                          (unicache.missb->local_result.power +
+                           unicache.ifb->local_result.power +
+                           unicache.prefetchb->local_result.power +
+                           unicache.wbb->local_result.power) *
+                              pppm_lkg;
+    }
 
-	unicache.power_t.reset();
-   unicache.rt_power.reset();
-	if (!((cachep.dir_ty==ST&& cacheL==L1Directory)||(cachep.dir_ty==ST&& cacheL==L2Directory)))
-	{ 
-
-	  unicache.power_t.readOp.dynamic	+= (unicache.caches->stats_t.readAc.hit*unicache.caches->local_result.power.readOp.dynamic+
-			unicache.caches->stats_t.readAc.miss*unicache.caches->local_result.tag_array2->power.readOp.dynamic+
-			unicache.caches->stats_t.writeAc.miss*unicache.caches->local_result.tag_array2->power.writeOp.dynamic+
-			unicache.caches->stats_t.writeAc.access*unicache.caches->local_result.power.writeOp.dynamic);//write miss will also generate a write later
-
-	  if (cachep.dir_ty==SBT)
-	  {
-		 unicache.power_t.readOp.dynamic	+= homenode_stats_t.readAc.hit * (unicache.caches->local_result.data_array2->power.readOp.dynamic*dir_overhead +
-			  unicache.caches->local_result.tag_array2->power.readOp.dynamic) +
-			homenode_stats_t.readAc.miss*unicache.caches->local_result.tag_array2->power.readOp.dynamic +
-			homenode_stats_t.writeAc.miss*unicache.caches->local_result.tag_array2->power.readOp.dynamic +
-			homenode_stats_t.writeAc.hit*(unicache.caches->local_result.data_array2->power.writeOp.dynamic*dir_overhead +
-				 unicache.caches->local_result.tag_array2->power.readOp.dynamic+
-				 homenode_stats_t.writeAc.miss*unicache.caches->local_result.power.writeOp.dynamic);//write miss on dynamic home node will generate a replacement write on whole cache block
-
-
-	  }
-
-	  unicache.power_t.readOp.dynamic	+=  unicache.missb->stats_t.readAc.access*unicache.missb->local_result.power.searchOp.dynamic +
-		 unicache.missb->stats_t.writeAc.access*unicache.missb->local_result.power.writeOp.dynamic;//each access to missb involves a CAM and a write
-	  unicache.power_t.readOp.dynamic	+=  unicache.ifb->stats_t.readAc.access*unicache.ifb->local_result.power.searchOp.dynamic +
-		 unicache.ifb->stats_t.writeAc.access*unicache.ifb->local_result.power.writeOp.dynamic;
-	  unicache.power_t.readOp.dynamic	+=  unicache.prefetchb->stats_t.readAc.access*unicache.prefetchb->local_result.power.searchOp.dynamic +
-		 unicache.prefetchb->stats_t.writeAc.access*unicache.prefetchb->local_result.power.writeOp.dynamic;
-	  unicache.power_t.readOp.dynamic	+=  unicache.wbb->stats_t.readAc.access*unicache.wbb->local_result.power.searchOp.dynamic +
-		 unicache.wbb->stats_t.writeAc.access*unicache.wbb->local_result.power.writeOp.dynamic;
-	}
-	else
-	{
-	  unicache.power_t.readOp.dynamic	+= (unicache.caches->stats_t.readAc.access*unicache.caches->local_result.power.searchOp.dynamic+
-			unicache.caches->stats_t.writeAc.access*unicache.caches->local_result.power.writeOp.dynamic);
-	}
-
-	if (is_tdp)
-	{
-	  unicache.power = unicache.power_t + (unicache.caches->local_result.power)*pppm_lkg;
-	  if (!((cachep.dir_ty==ST&& cacheL==L1Directory)||(cachep.dir_ty==ST&& cacheL==L2Directory)))
-	  {
-		 unicache.power = unicache.power+
-			(unicache.missb->local_result.power +
-			 unicache.ifb->local_result.power +
-			 unicache.prefetchb->local_result.power +
-			 unicache.wbb->local_result.power)*pppm_lkg;
-	  }
-	  power     = power + unicache.power;
-	  //		cout<<"unicache.caches->local_result.power.readOp.dynamic"<<unicache.caches->local_result.power.readOp.dynamic<<endl;
-	  //		cout<<"unicache.caches->local_result.power.writeOp.dynamic"<<unicache.caches->local_result.power.writeOp.dynamic<<endl;
-	}
-	else
-	{
-
-	  unicache.rt_power = unicache.power_t + (unicache.caches->local_result.power)*pppm_lkg;
-	  if (!((cachep.dir_ty==ST&& cacheL==L1Directory)||(cachep.dir_ty==ST&& cacheL==L2Directory)))
-	  {
-		 unicache.rt_power = unicache.rt_power +
-		  (unicache.missb->local_result.power +
-		  unicache.ifb->local_result.power +
-		  unicache.prefetchb->local_result.power +
-		  unicache.wbb->local_result.power)*pppm_lkg;
-	  }
-
-	  rt_power     = rt_power + unicache.rt_power;
-	}
+    rt_power = rt_power + unicache.rt_power;
+  }
 }
 
-void SharedCache::displayEnergy(uint32_t indent,bool is_tdp)
-{
+void SharedCache::displayEnergy(uint32_t indent, bool is_tdp) {
   string indent_str(indent, ' ');
-  string indent_str_next(indent+2, ' ');
+  string indent_str_next(indent + 2, ' ');
   bool long_channel = XML->sys.longer_channel_device;
 
-  if (is_tdp)
-  {
-	 cout << (XML->sys.Private_L2? indent_str:"")<< cachep.name << endl;
-	 cout << indent_str << "Area = " << area.get_area()*1e-6<< " mm^2" << endl;
-	 cout << indent_str << "Peak Dynamic = " << power.readOp.dynamic*cachep.clockRate << " W" << endl;
-	 cout << indent_str << "Subthreshold Leakage = "
-		<< (long_channel? power.readOp.longer_channel_leakage:power.readOp.leakage) <<" W" << endl;
-	 //cout << indent_str << "Subthreshold Leakage = " << power.readOp.longer_channel_leakage <<" W" << endl;
-	 cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W" << endl;
-	 cout << indent_str << "Runtime Dynamic = " << rt_power.readOp.dynamic/cachep.executionTime << " W" << endl;
-	 cout <<endl;
-  }
-  else
-  {
+  if (is_tdp) {
+    cout << (XML->sys.Private_L2 ? indent_str : "") << cachep.name << endl;
+    cout << indent_str << "Area = " << area.get_area() * 1e-6 << " mm^2"
+         << endl;
+    cout << indent_str
+         << "Peak Dynamic = " << power.readOp.dynamic * cachep.clockRate << " W"
+         << endl;
+    cout << indent_str << "Subthreshold Leakage = "
+         << (long_channel ? power.readOp.longer_channel_leakage
+                          : power.readOp.leakage)
+         << " W" << endl;
+    // cout << indent_str << "Subthreshold Leakage = " <<
+    // power.readOp.longer_channel_leakage <<" W" << endl;
+    cout << indent_str << "Gate Leakage = " << power.readOp.gate_leakage << " W"
+         << endl;
+    cout << indent_str << "Runtime Dynamic = "
+         << rt_power.readOp.dynamic / cachep.executionTime << " W" << endl;
+    cout << endl;
+  } else {
   }
 }
 
-//void SharedCache::computeMaxPower()
+// void SharedCache::computeMaxPower()
 //{
 //  //Compute maximum power and runtime power.
-//  //When computing runtime power, McPAT gets or reasons out the statistics based on XML input.
+//  //When computing runtime power, McPAT gets or reasons out the statistics
+//  based on XML input.
 //  maxPower		= 0.0;
 //  //llCache,itlb
 //  llCache.maxPower   = 0.0;
-//  llCache.maxPower	+=  (llCache.caches.l_ip.num_rw_ports*(0.67*llCache.caches.local_result.power.readOp.dynamic+0.33*llCache.caches.local_result.power.writeOp.dynamic)
+//  llCache.maxPower	+=
+//  (llCache.caches.l_ip.num_rw_ports*(0.67*llCache.caches.local_result.power.readOp.dynamic+0.33*llCache.caches.local_result.power.writeOp.dynamic)
 //                        +llCache.caches.l_ip.num_rd_ports*llCache.caches.local_result.power.readOp.dynamic+llCache.caches.l_ip.num_wr_ports*llCache.caches.local_result.power.writeOp.dynamic
 //                        +llCache.caches.l_ip.num_se_rd_ports*llCache.caches.local_result.power.readOp.dynamic)*clockRate;
 //  ///cout<<"llCache.maxPower=" <<llCache.maxPower<<endl;
 //
-//  llCache.maxPower	+=  llCache.missb.l_ip.num_search_ports*llCache.missb.local_result.power.searchOp.dynamic*clockRate;
+//  llCache.maxPower	+=
+//  llCache.missb.l_ip.num_search_ports*llCache.missb.local_result.power.searchOp.dynamic*clockRate;
 //  ///cout<<"llCache.maxPower=" <<llCache.maxPower<<endl;
 //
-//  llCache.maxPower	+=  llCache.ifb.l_ip.num_search_ports*llCache.ifb.local_result.power.searchOp.dynamic*clockRate;
+//  llCache.maxPower	+=
+//  llCache.ifb.l_ip.num_search_ports*llCache.ifb.local_result.power.searchOp.dynamic*clockRate;
 //  ///cout<<"llCache.maxPower=" <<llCache.maxPower<<endl;
 //
-//  llCache.maxPower	+=  llCache.prefetchb.l_ip.num_search_ports*llCache.prefetchb.local_result.power.searchOp.dynamic*clockRate;
+//  llCache.maxPower	+=
+//  llCache.prefetchb.l_ip.num_search_ports*llCache.prefetchb.local_result.power.searchOp.dynamic*clockRate;
 //  ///cout<<"llCache.maxPower=" <<llCache.maxPower<<endl;
 //
-//  llCache.maxPower	+=  llCache.wbb.l_ip.num_search_ports*llCache.wbb.local_result.power.searchOp.dynamic*clockRate;
-//  //llCache.maxPower *=  scktRatio; //TODO: this calculation should be self-contained
+//  llCache.maxPower	+=
+//  llCache.wbb.l_ip.num_search_ports*llCache.wbb.local_result.power.searchOp.dynamic*clockRate;
+//  //llCache.maxPower *=  scktRatio; //TODO: this calculation should be
+//  self-contained
 //  ///cout<<"llCache.maxPower=" <<llCache.maxPower<<endl;
 //
-////  directory_power =  (directory.caches.l_ip.num_rw_ports*(0.67*directory.caches.local_result.power.readOp.dynamic+0.33*directory.caches.local_result.power.writeOp.dynamic)
-////                        +directory.caches.l_ip.num_rd_ports*directory.caches.local_result.power.readOp.dynamic+directory.caches.l_ip.num_wr_ports*directory.caches.local_result.power.writeOp.dynamic
-////                        +directory.caches.l_ip.num_se_rd_ports*directory.caches.local_result.power.readOp.dynamic)*clockRate;
+////  directory_power =
+///(directory.caches.l_ip.num_rw_ports*(0.67*directory.caches.local_result.power.readOp.dynamic+0.33*directory.caches.local_result.power.writeOp.dynamic)
+////
+///+directory.caches.l_ip.num_rd_ports*directory.caches.local_result.power.readOp.dynamic+directory.caches.l_ip.num_wr_ports*directory.caches.local_result.power.writeOp.dynamic
+////
+///+directory.caches.l_ip.num_se_rd_ports*directory.caches.local_result.power.readOp.dynamic)*clockRate;
 //
 //  L2Tot.power.readOp.dynamic = llCache.maxPower;
-//  L2Tot.power.readOp.leakage = llCache.caches.local_result.power.readOp.leakage +
-//                               llCache.missb.local_result.power.readOp.leakage +
+//  L2Tot.power.readOp.leakage =
+//  llCache.caches.local_result.power.readOp.leakage +
+//                               llCache.missb.local_result.power.readOp.leakage
+//                               +
 //                               llCache.ifb.local_result.power.readOp.leakage +
-//                               llCache.prefetchb.local_result.power.readOp.leakage +
+//                               llCache.prefetchb.local_result.power.readOp.leakage
+//                               +
 //                               llCache.wbb.local_result.power.readOp.leakage;
 //
 //  L2Tot.area.set_area(llCache.area*1.1*1e-6);//placement and routing overhead
@@ -914,27 +1099,37 @@ void SharedCache::displayEnergy(uint32_t indent,bool is_tdp)
 //	  if (XML->sys.first_level_dir==0)
 //	  {
 //		  directory.maxPower   = 0.0;
-//		  directory.maxPower	+=  (directory.caches.l_ip.num_rw_ports*(0.67*directory.caches.local_result.power.readOp.dynamic+0.33*directory.caches.local_result.power.writeOp.dynamic)
+//		  directory.maxPower	+=
+//(directory.caches.l_ip.num_rw_ports*(0.67*directory.caches.local_result.power.readOp.dynamic+0.33*directory.caches.local_result.power.writeOp.dynamic)
 //		                        +directory.caches.l_ip.num_rd_ports*directory.caches.local_result.power.readOp.dynamic+directory.caches.l_ip.num_wr_ports*directory.caches.local_result.power.writeOp.dynamic
 //		                        +directory.caches.l_ip.num_se_rd_ports*directory.caches.local_result.power.readOp.dynamic)*clockRate;
 //		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
 //
-//		  directory.maxPower	+=  directory.missb.l_ip.num_search_ports*directory.missb.local_result.power.searchOp.dynamic*clockRate;
+//		  directory.maxPower	+=
+//directory.missb.l_ip.num_search_ports*directory.missb.local_result.power.searchOp.dynamic*clockRate;
 //		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
 //
-//		  directory.maxPower	+=  directory.ifb.l_ip.num_search_ports*directory.ifb.local_result.power.searchOp.dynamic*clockRate;
+//		  directory.maxPower	+=
+//directory.ifb.l_ip.num_search_ports*directory.ifb.local_result.power.searchOp.dynamic*clockRate;
 //		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
 //
-//		  directory.maxPower	+=  directory.prefetchb.l_ip.num_search_ports*directory.prefetchb.local_result.power.searchOp.dynamic*clockRate;
+//		  directory.maxPower	+=
+//directory.prefetchb.l_ip.num_search_ports*directory.prefetchb.local_result.power.searchOp.dynamic*clockRate;
 //		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
 //
-//		  directory.maxPower	+=  directory.wbb.l_ip.num_search_ports*directory.wbb.local_result.power.searchOp.dynamic*clockRate;
+//		  directory.maxPower	+=
+//directory.wbb.l_ip.num_search_ports*directory.wbb.local_result.power.searchOp.dynamic*clockRate;
 //
-//		  cc.power.readOp.dynamic = directory.maxPower*scktRatio*8;//8 is the memory controller counts
-//		  cc.power.readOp.leakage = directory.caches.local_result.power.readOp.leakage +
-//                                     directory.missb.local_result.power.readOp.leakage +
-//                                     directory.ifb.local_result.power.readOp.leakage +
-//                                     directory.prefetchb.local_result.power.readOp.leakage +
+//		  cc.power.readOp.dynamic = directory.maxPower*scktRatio*8;//8 is
+//the memory controller counts
+//		  cc.power.readOp.leakage =
+//directory.caches.local_result.power.readOp.leakage +
+//                                     directory.missb.local_result.power.readOp.leakage
+//                                     +
+//                                     directory.ifb.local_result.power.readOp.leakage
+//                                     +
+//                                     directory.prefetchb.local_result.power.readOp.leakage
+//                                     +
 //                                     directory.wbb.local_result.power.readOp.leakage;
 //
 //		  cc.power.readOp.leakage *=8;
@@ -944,19 +1139,24 @@ void SharedCache::displayEnergy(uint32_t indent,bool is_tdp)
 //		  cout<<"CC Power="<<cc.power.readOp.dynamic<<endl;
 //		  ccTot.area.set_area(cc.area.get_area()*1e-6);
 //		  ccTot.power = cc.power;
-//		  cout<<"DC energy per access" << cc.power.readOp.dynamic/clockRate/8;
+//		  cout<<"DC energy per access" <<
+//cc.power.readOp.dynamic/clockRate/8;
 //	  }
 //	  else if (XML->sys.first_level_dir==1)
 //	  {
-//		  inv_dir.maxPower = inv_dir.caches.local_result.power.searchOp.dynamic*clockRate*XML->sys.domain_size;
-//		  cc.power.readOp.dynamic  = inv_dir.maxPower*scktRatio*64/XML->sys.domain_size;
-//		  cc.power.readOp.leakage  = inv_dir.caches.local_result.power.readOp.leakage*inv_dir.caches.l_ip.nbanks*64/XML->sys.domain_size;
+//		  inv_dir.maxPower =
+//inv_dir.caches.local_result.power.searchOp.dynamic*clockRate*XML->sys.domain_size;
+//		  cc.power.readOp.dynamic  =
+//inv_dir.maxPower*scktRatio*64/XML->sys.domain_size;
+//		  cc.power.readOp.leakage  =
+//inv_dir.caches.local_result.power.readOp.leakage*inv_dir.caches.l_ip.nbanks*64/XML->sys.domain_size;
 //
 //		  cc.area.set_area(inv_dir.area*64/XML->sys.domain_size);
 //		  cout<<"CC area="<<cc.area.get_area()*1e-6<<endl;
 //		  cout<<"CC Power="<<cc.power.readOp.dynamic<<endl;
 //		  ccTot.area.set_area(cc.area.get_area()*1e-6);
-//		  cout<<"DC energy per access" << cc.power.readOp.dynamic/clockRate/8;
+//		  cout<<"DC energy per access" <<
+//cc.power.readOp.dynamic/clockRate/8;
 //		  ccTot.power = cc.power;
 //	  }
 //  }
@@ -965,27 +1165,41 @@ void SharedCache::displayEnergy(uint32_t indent,bool is_tdp)
 //  {
 //
 //	  		  directory.maxPower   = 0.0;
-//	  		  directory.maxPower	+=  (directory.caches.l_ip.num_rw_ports*(0.67*directory.caches.local_result.power.readOp.dynamic+0.33*directory.caches.local_result.power.writeOp.dynamic)
+//	  		  directory.maxPower	+=
+//(directory.caches.l_ip.num_rw_ports*(0.67*directory.caches.local_result.power.readOp.dynamic+0.33*directory.caches.local_result.power.writeOp.dynamic)
 //	  		                        +directory.caches.l_ip.num_rd_ports*directory.caches.local_result.power.readOp.dynamic+directory.caches.l_ip.num_wr_ports*directory.caches.local_result.power.writeOp.dynamic
 //	  		                        +directory.caches.l_ip.num_se_rd_ports*directory.caches.local_result.power.readOp.dynamic)*clockRate;
-//	  		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
+//	  		  ///cout<<"directory.maxPower="
+//<<directory.maxPower<<endl;
 //
-//	  		  directory.maxPower	+=  directory.missb.l_ip.num_search_ports*directory.missb.local_result.power.searchOp.dynamic*clockRate;
-//	  		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
+//	  		  directory.maxPower	+=
+//directory.missb.l_ip.num_search_ports*directory.missb.local_result.power.searchOp.dynamic*clockRate;
+//	  		  ///cout<<"directory.maxPower="
+//<<directory.maxPower<<endl;
 //
-//	  		  directory.maxPower	+=  directory.ifb.l_ip.num_search_ports*directory.ifb.local_result.power.searchOp.dynamic*clockRate;
-//	  		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
+//	  		  directory.maxPower	+=
+//directory.ifb.l_ip.num_search_ports*directory.ifb.local_result.power.searchOp.dynamic*clockRate;
+//	  		  ///cout<<"directory.maxPower="
+//<<directory.maxPower<<endl;
 //
-//	  		  directory.maxPower	+=  directory.prefetchb.l_ip.num_search_ports*directory.prefetchb.local_result.power.searchOp.dynamic*clockRate;
-//	  		  ///cout<<"directory.maxPower=" <<directory.maxPower<<endl;
+//	  		  directory.maxPower	+=
+//directory.prefetchb.l_ip.num_search_ports*directory.prefetchb.local_result.power.searchOp.dynamic*clockRate;
+//	  		  ///cout<<"directory.maxPower="
+//<<directory.maxPower<<endl;
 //
-//	  		  directory.maxPower	+=  directory.wbb.l_ip.num_search_ports*directory.wbb.local_result.power.searchOp.dynamic*clockRate;
+//	  		  directory.maxPower	+=
+//directory.wbb.l_ip.num_search_ports*directory.wbb.local_result.power.searchOp.dynamic*clockRate;
 //
-//	  		  cc.power.readOp.dynamic = directory.maxPower*scktRatio*8;//8 is the memory controller counts
-//			  cc.power.readOp.leakage = directory.caches.local_result.power.readOp.leakage +
-//	                                     directory.missb.local_result.power.readOp.leakage +
-//	                                     directory.ifb.local_result.power.readOp.leakage +
-//	                                     directory.prefetchb.local_result.power.readOp.leakage +
+//	  		  cc.power.readOp.dynamic =
+//directory.maxPower*scktRatio*8;//8 is the memory controller counts
+//			  cc.power.readOp.leakage =
+//directory.caches.local_result.power.readOp.leakage +
+//	                                     directory.missb.local_result.power.readOp.leakage
+//+
+//	                                     directory.ifb.local_result.power.readOp.leakage
+//+
+//	                                     directory.prefetchb.local_result.power.readOp.leakage
+//+
 //	                                     directory.wbb.local_result.power.readOp.leakage;
 //			  cc.power.readOp.leakage *=8;
 //	  		  cc.area.set_area(directory.area*8);
@@ -993,45 +1207,66 @@ void SharedCache::displayEnergy(uint32_t indent,bool is_tdp)
 //	  		if (XML->sys.first_level_dir==0)
 //	  		{
 //	  		  directory1.maxPower   = 0.0;
-//	  		  directory1.maxPower	+=  (directory1.caches.l_ip.num_rw_ports*(0.67*directory1.caches.local_result.power.readOp.dynamic+0.33*directory1.caches.local_result.power.writeOp.dynamic)
+//	  		  directory1.maxPower	+=
+//(directory1.caches.l_ip.num_rw_ports*(0.67*directory1.caches.local_result.power.readOp.dynamic+0.33*directory1.caches.local_result.power.writeOp.dynamic)
 //	  				  +directory1.caches.l_ip.num_rd_ports*directory1.caches.local_result.power.readOp.dynamic+directory1.caches.l_ip.num_wr_ports*directory1.caches.local_result.power.writeOp.dynamic
 //	  				  +directory1.caches.l_ip.num_se_rd_ports*directory1.caches.local_result.power.readOp.dynamic)*clockRate;
-//	  		  ///cout<<"directory1.maxPower=" <<directory1.maxPower<<endl;
+//	  		  ///cout<<"directory1.maxPower="
+//<<directory1.maxPower<<endl;
 //
-//	  		  directory1.maxPower	+=  directory1.missb.l_ip.num_search_ports*directory1.missb.local_result.power.searchOp.dynamic*clockRate;
-//	  		  ///cout<<"directory1.maxPower=" <<directory1.maxPower<<endl;
+//	  		  directory1.maxPower	+=
+//directory1.missb.l_ip.num_search_ports*directory1.missb.local_result.power.searchOp.dynamic*clockRate;
+//	  		  ///cout<<"directory1.maxPower="
+//<<directory1.maxPower<<endl;
 //
-//	  		  directory1.maxPower	+=  directory1.ifb.l_ip.num_search_ports*directory1.ifb.local_result.power.searchOp.dynamic*clockRate;
-//	  		  ///cout<<"directory1.maxPower=" <<directory1.maxPower<<endl;
+//	  		  directory1.maxPower	+=
+//directory1.ifb.l_ip.num_search_ports*directory1.ifb.local_result.power.searchOp.dynamic*clockRate;
+//	  		  ///cout<<"directory1.maxPower="
+//<<directory1.maxPower<<endl;
 //
-//	  		  directory1.maxPower	+=  directory1.prefetchb.l_ip.num_search_ports*directory1.prefetchb.local_result.power.searchOp.dynamic*clockRate;
-//	  		  ///cout<<"directory1.maxPower=" <<directory1.maxPower<<endl;
+//	  		  directory1.maxPower	+=
+//directory1.prefetchb.l_ip.num_search_ports*directory1.prefetchb.local_result.power.searchOp.dynamic*clockRate;
+//	  		  ///cout<<"directory1.maxPower="
+//<<directory1.maxPower<<endl;
 //
-//	  		  directory1.maxPower	+=  directory1.wbb.l_ip.num_search_ports*directory1.wbb.local_result.power.searchOp.dynamic*clockRate;
+//	  		  directory1.maxPower	+=
+//directory1.wbb.l_ip.num_search_ports*directory1.wbb.local_result.power.searchOp.dynamic*clockRate;
 //
-//	  		  cc1.power.readOp.dynamic = directory1.maxPower*scktRatio*64/XML->sys.domain_size;
-//			  cc1.power.readOp.leakage = directory1.caches.local_result.power.readOp.leakage +
-//	                                     directory1.missb.local_result.power.readOp.leakage +
-//	                                     directory1.ifb.local_result.power.readOp.leakage +
-//	                                     directory1.prefetchb.local_result.power.readOp.leakage +
+//	  		  cc1.power.readOp.dynamic =
+//directory1.maxPower*scktRatio*64/XML->sys.domain_size;
+//			  cc1.power.readOp.leakage =
+//directory1.caches.local_result.power.readOp.leakage +
+//	                                     directory1.missb.local_result.power.readOp.leakage
+//+
+//	                                     directory1.ifb.local_result.power.readOp.leakage
+//+
+//	                                     directory1.prefetchb.local_result.power.readOp.leakage
+//+
 //	                                     directory1.wbb.local_result.power.readOp.leakage;
 //			  cc1.power.readOp.leakage *= 64/XML->sys.domain_size;
 //	  		  cc1.area.set_area(directory1.area*64/XML->sys.domain_size);
 //
-//	  		  cout<<"CC area="<<(cc.area.get_area()+cc1.area.get_area())*1e-6<<endl;
-//			  cout<<"CC Power="<<cc.power.readOp.dynamic + cc1.power.readOp.dynamic <<endl;
+//	  		  cout<<"CC
+//area="<<(cc.area.get_area()+cc1.area.get_area())*1e-6<<endl;
+//			  cout<<"CC Power="<<cc.power.readOp.dynamic +
+//cc1.power.readOp.dynamic <<endl;
 //			  ccTot.area.set_area((cc.area.get_area()+cc1.area.get_area())*1e-6);
 //			  ccTot.power = cc.power + cc1.power;
 //	  	  }
 //	  	  else if (XML->sys.first_level_dir==1)
 //	  	  {
-//	  		  inv_dir.maxPower = inv_dir.caches.local_result.power.searchOp.dynamic*clockRate*XML->sys.domain_size;
-//	  		  cc1.power.readOp.dynamic = inv_dir.maxPower*scktRatio*(64/XML->sys.domain_size);
-//	  		  cc1.power.readOp.leakage  = inv_dir.caches.local_result.power.readOp.leakage*inv_dir.caches.l_ip.nbanks*XML->sys.domain_size;
+//	  		  inv_dir.maxPower =
+//inv_dir.caches.local_result.power.searchOp.dynamic*clockRate*XML->sys.domain_size;
+//	  		  cc1.power.readOp.dynamic =
+//inv_dir.maxPower*scktRatio*(64/XML->sys.domain_size);
+//	  		  cc1.power.readOp.leakage  =
+//inv_dir.caches.local_result.power.readOp.leakage*inv_dir.caches.l_ip.nbanks*XML->sys.domain_size;
 //
 //	  		  cc1.area.set_area(inv_dir.area*64/XML->sys.domain_size);
-//			  cout<<"CC area="<<(cc.area.get_area()+cc1.area.get_area())*1e-6<<endl;
-//			  cout<<"CC Power="<<cc.power.readOp.dynamic + cc1.power.readOp.dynamic <<endl;
+//			  cout<<"CC
+//area="<<(cc.area.get_area()+cc1.area.get_area())*1e-6<<endl;
+//			  cout<<"CC Power="<<cc.power.readOp.dynamic +
+//cc1.power.readOp.dynamic <<endl;
 //			  ccTot.area.set_area((cc.area.get_area()+cc1.area.get_area())*1e-6);
 //			  ccTot.power = cc.power + cc1.power;
 //
@@ -1045,9 +1280,9 @@ void SharedCache::displayEnergy(uint32_t indent,bool is_tdp)
 //	  	  }
 //  }
 //
-//cout<<"L2cache size="<<L2Tot.area.get_area()*1e-6<<endl;
-//cout<<"L2cache dynamic power="<<L2Tot.power.readOp.dynamic<<endl;
-//cout<<"L2cache laeakge power="<<L2Tot.power.readOp.leakage<<endl;
+// cout<<"L2cache size="<<L2Tot.area.get_area()*1e-6<<endl;
+// cout<<"L2cache dynamic power="<<L2Tot.power.readOp.dynamic<<endl;
+// cout<<"L2cache laeakge power="<<L2Tot.power.readOp.leakage<<endl;
 //
 //  ///cout<<"llCache.maxPower=" <<llCache.maxPower<<endl;
 //
@@ -1056,130 +1291,142 @@ void SharedCache::displayEnergy(uint32_t indent,bool is_tdp)
 //  ///cout<<"maxpower=" <<maxPower<<endl;
 //
 ////  maxPower	  +=  pipeLogicCache.power.readOp.dynamic*clockRate;
-////  ///cout<<"pipeLogic.power="<<pipeLogicCache.power.readOp.dynamic*clockRate<<endl;
+////
+//////cout<<"pipeLogic.power="<<pipeLogicCache.power.readOp.dynamic*clockRate<<endl;
 ////  ///cout<<"maxpower=" <<maxPower<<endl;
 ////
 ////  maxPower	  +=  pipeLogicDirectory.power.readOp.dynamic*clockRate;
-////  ///cout<<"pipeLogic.power="<<pipeLogicDirectory.power.readOp.dynamic*clockRate<<endl;
+////
+//////cout<<"pipeLogic.power="<<pipeLogicDirectory.power.readOp.dynamic*clockRate<<endl;
 ////  ///cout<<"maxpower=" <<maxPower<<endl;
 ////
 ////  //clock power
 ////  maxPower += clockNetwork.total_power.readOp.dynamic*clockRate;
-////  ///cout<<"clockNetwork.total_power="<<clockNetwork.total_power.readOp.dynamic*clockRate<<endl;
+////
+//////cout<<"clockNetwork.total_power="<<clockNetwork.total_power.readOp.dynamic*clockRate<<endl;
 ////  ///cout<<"maxpower=" <<maxPower<<endl;
 //
 //}
 
-void SharedCache::set_cache_param()
-{
-  if (cacheL==L2)
-  {
-	 cachep.name = "L2";
-	 cachep.clockRate       = XML->sys.L2[ithCache].clockrate;
-	 cachep.clockRate       *= 1e6;
-	 cachep.executionTime = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
-	 interface_ip.data_arr_ram_cell_tech_type    = XML->sys.L2[ithCache].device_type;//long channel device LSTP
-	 interface_ip.data_arr_peri_global_tech_type = XML->sys.L2[ithCache].device_type;
-	 interface_ip.tag_arr_ram_cell_tech_type     = XML->sys.L2[ithCache].device_type;
-	 interface_ip.tag_arr_peri_global_tech_type  = XML->sys.L2[ithCache].device_type;
-	 cachep.capacity      = XML->sys.L2[ithCache].L2_config[0];
-	 cachep.blockW        = XML->sys.L2[ithCache].L2_config[1];
-	 cachep.assoc         = XML->sys.L2[ithCache].L2_config[2];
-	 cachep.nbanks        = XML->sys.L2[ithCache].L2_config[3];
-	 cachep.throughput    = XML->sys.L2[ithCache].L2_config[4]/cachep.clockRate;
-	 cachep.latency       = XML->sys.L2[ithCache].L2_config[5]/cachep.clockRate;
-	 cachep.missb_size    = XML->sys.L2[ithCache].buffer_sizes[0];
-	 cachep.fu_size       = XML->sys.L2[ithCache].buffer_sizes[1];
-	 cachep.prefetchb_size= XML->sys.L2[ithCache].buffer_sizes[2];
-	 cachep.wbb_size      = XML->sys.L2[ithCache].buffer_sizes[3];
-	 cachep.duty_cycle    = XML->sys.L2[ithCache].duty_cycle;
-	 if (!XML->sys.L2[ithCache].merged_dir)
-	 {
-		cachep.dir_ty = NonDir;
-	 }
-	 else
-	 {
-		cachep.dir_ty = SBT;
-		cachep.dir_duty_cycle  = XML->sys.L2[ithCache].dir_duty_cycle;
-	 }
+void SharedCache::set_cache_param() {
+  if (cacheL == L2) {
+    cachep.name = "L2";
+    cachep.clockRate = XML->sys.L2[ithCache].clockrate;
+    cachep.clockRate *= 1e6;
+    cachep.executionTime =
+        XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);
+    interface_ip.data_arr_ram_cell_tech_type =
+        XML->sys.L2[ithCache].device_type;  // long channel device LSTP
+    interface_ip.data_arr_peri_global_tech_type =
+        XML->sys.L2[ithCache].device_type;
+    interface_ip.tag_arr_ram_cell_tech_type = XML->sys.L2[ithCache].device_type;
+    interface_ip.tag_arr_peri_global_tech_type =
+        XML->sys.L2[ithCache].device_type;
+    cachep.capacity = XML->sys.L2[ithCache].L2_config[0];
+    cachep.blockW = XML->sys.L2[ithCache].L2_config[1];
+    cachep.assoc = XML->sys.L2[ithCache].L2_config[2];
+    cachep.nbanks = XML->sys.L2[ithCache].L2_config[3];
+    cachep.throughput = XML->sys.L2[ithCache].L2_config[4] / cachep.clockRate;
+    cachep.latency = XML->sys.L2[ithCache].L2_config[5] / cachep.clockRate;
+    cachep.missb_size = XML->sys.L2[ithCache].buffer_sizes[0];
+    cachep.fu_size = XML->sys.L2[ithCache].buffer_sizes[1];
+    cachep.prefetchb_size = XML->sys.L2[ithCache].buffer_sizes[2];
+    cachep.wbb_size = XML->sys.L2[ithCache].buffer_sizes[3];
+    cachep.duty_cycle = XML->sys.L2[ithCache].duty_cycle;
+    if (!XML->sys.L2[ithCache].merged_dir) {
+      cachep.dir_ty = NonDir;
+    } else {
+      cachep.dir_ty = SBT;
+      cachep.dir_duty_cycle = XML->sys.L2[ithCache].dir_duty_cycle;
+    }
+  } else if (cacheL == L3) {
+    cachep.name = "L3";
+    cachep.clockRate = XML->sys.L3[ithCache].clockrate;
+    cachep.clockRate *= 1e6;
+    cachep.executionTime =
+        XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);
+    interface_ip.data_arr_ram_cell_tech_type =
+        XML->sys.L3[ithCache].device_type;  // long channel device LSTP
+    interface_ip.data_arr_peri_global_tech_type =
+        XML->sys.L3[ithCache].device_type;
+    interface_ip.tag_arr_ram_cell_tech_type = XML->sys.L3[ithCache].device_type;
+    interface_ip.tag_arr_peri_global_tech_type =
+        XML->sys.L3[ithCache].device_type;
+    cachep.capacity = XML->sys.L3[ithCache].L3_config[0];
+    cachep.blockW = XML->sys.L3[ithCache].L3_config[1];
+    cachep.assoc = XML->sys.L3[ithCache].L3_config[2];
+    cachep.nbanks = XML->sys.L3[ithCache].L3_config[3];
+    cachep.throughput = XML->sys.L3[ithCache].L3_config[4] / cachep.clockRate;
+    cachep.latency = XML->sys.L3[ithCache].L3_config[5] / cachep.clockRate;
+    cachep.missb_size = XML->sys.L3[ithCache].buffer_sizes[0];
+    cachep.fu_size = XML->sys.L3[ithCache].buffer_sizes[1];
+    cachep.prefetchb_size = XML->sys.L3[ithCache].buffer_sizes[2];
+    cachep.wbb_size = XML->sys.L3[ithCache].buffer_sizes[3];
+    cachep.duty_cycle = XML->sys.L3[ithCache].duty_cycle;
+    if (!XML->sys.L2[ithCache].merged_dir) {
+      cachep.dir_ty = NonDir;
+    } else {
+      cachep.dir_ty = SBT;
+      cachep.dir_duty_cycle = XML->sys.L2[ithCache].dir_duty_cycle;
+    }
+  } else if (cacheL == L1Directory) {
+    cachep.name = "First Level Directory";
+    cachep.dir_ty =
+        (enum Dir_type)XML->sys.L1Directory[ithCache].Directory_type;
+    cachep.clockRate = XML->sys.L1Directory[ithCache].clockrate;
+    cachep.clockRate *= 1e6;
+    cachep.executionTime =
+        XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);
+    interface_ip.data_arr_ram_cell_tech_type =
+        XML->sys.L1Directory[ithCache].device_type;  // long channel device LSTP
+    interface_ip.data_arr_peri_global_tech_type =
+        XML->sys.L1Directory[ithCache].device_type;
+    interface_ip.tag_arr_ram_cell_tech_type =
+        XML->sys.L1Directory[ithCache].device_type;
+    interface_ip.tag_arr_peri_global_tech_type =
+        XML->sys.L1Directory[ithCache].device_type;
+    cachep.capacity = XML->sys.L1Directory[ithCache].Dir_config[0];
+    cachep.blockW = XML->sys.L1Directory[ithCache].Dir_config[1];
+    cachep.assoc = XML->sys.L1Directory[ithCache].Dir_config[2];
+    cachep.nbanks = XML->sys.L1Directory[ithCache].Dir_config[3];
+    cachep.throughput =
+        XML->sys.L1Directory[ithCache].Dir_config[4] / cachep.clockRate;
+    cachep.latency =
+        XML->sys.L1Directory[ithCache].Dir_config[5] / cachep.clockRate;
+    cachep.missb_size = XML->sys.L1Directory[ithCache].buffer_sizes[0];
+    cachep.fu_size = XML->sys.L1Directory[ithCache].buffer_sizes[1];
+    cachep.prefetchb_size = XML->sys.L1Directory[ithCache].buffer_sizes[2];
+    cachep.wbb_size = XML->sys.L1Directory[ithCache].buffer_sizes[3];
+    cachep.duty_cycle = XML->sys.L1Directory[ithCache].duty_cycle;
+  } else if (cacheL == L2Directory) {
+    cachep.name = "Second Level Directory";
+    cachep.dir_ty =
+        (enum Dir_type)XML->sys.L2Directory[ithCache].Directory_type;
+    cachep.clockRate = XML->sys.L2Directory[ithCache].clockrate;
+    cachep.clockRate *= 1e6;
+    cachep.executionTime =
+        XML->sys.total_cycles / (XML->sys.target_core_clockrate * 1e6);
+    interface_ip.data_arr_ram_cell_tech_type =
+        XML->sys.L2Directory[ithCache].device_type;  // long channel device LSTP
+    interface_ip.data_arr_peri_global_tech_type =
+        XML->sys.L2Directory[ithCache].device_type;
+    interface_ip.tag_arr_ram_cell_tech_type =
+        XML->sys.L2Directory[ithCache].device_type;
+    interface_ip.tag_arr_peri_global_tech_type =
+        XML->sys.L2Directory[ithCache].device_type;
+    cachep.capacity = XML->sys.L2Directory[ithCache].Dir_config[0];
+    cachep.blockW = XML->sys.L2Directory[ithCache].Dir_config[1];
+    cachep.assoc = XML->sys.L2Directory[ithCache].Dir_config[2];
+    cachep.nbanks = XML->sys.L2Directory[ithCache].Dir_config[3];
+    cachep.throughput =
+        XML->sys.L2Directory[ithCache].Dir_config[4] / cachep.clockRate;
+    cachep.latency =
+        XML->sys.L2Directory[ithCache].Dir_config[5] / cachep.clockRate;
+    cachep.missb_size = XML->sys.L2Directory[ithCache].buffer_sizes[0];
+    cachep.fu_size = XML->sys.L2Directory[ithCache].buffer_sizes[1];
+    cachep.prefetchb_size = XML->sys.L2Directory[ithCache].buffer_sizes[2];
+    cachep.wbb_size = XML->sys.L2Directory[ithCache].buffer_sizes[3];
+    cachep.duty_cycle = XML->sys.L2Directory[ithCache].duty_cycle;
   }
-  else if (cacheL==L3)
-  {
-	 cachep.name = "L3";
-	 cachep.clockRate       = XML->sys.L3[ithCache].clockrate;
-	 cachep.clockRate       *= 1e6;
-	 cachep.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
-	 interface_ip.data_arr_ram_cell_tech_type    = XML->sys.L3[ithCache].device_type;//long channel device LSTP
-	 interface_ip.data_arr_peri_global_tech_type = XML->sys.L3[ithCache].device_type;
-	 interface_ip.tag_arr_ram_cell_tech_type     = XML->sys.L3[ithCache].device_type;
-	 interface_ip.tag_arr_peri_global_tech_type  = XML->sys.L3[ithCache].device_type;
-	 cachep.capacity      = XML->sys.L3[ithCache].L3_config[0];
-	 cachep.blockW        = XML->sys.L3[ithCache].L3_config[1];
-	 cachep.assoc         = XML->sys.L3[ithCache].L3_config[2];
-	 cachep.nbanks        = XML->sys.L3[ithCache].L3_config[3];
-	 cachep.throughput    = XML->sys.L3[ithCache].L3_config[4]/cachep.clockRate;
-	 cachep.latency       = XML->sys.L3[ithCache].L3_config[5]/cachep.clockRate;
-	 cachep.missb_size    = XML->sys.L3[ithCache].buffer_sizes[0];
-	 cachep.fu_size       = XML->sys.L3[ithCache].buffer_sizes[1];
-	 cachep.prefetchb_size= XML->sys.L3[ithCache].buffer_sizes[2];
-	 cachep.wbb_size      = XML->sys.L3[ithCache].buffer_sizes[3];
-	 cachep.duty_cycle    = XML->sys.L3[ithCache].duty_cycle;
-	 if (!XML->sys.L2[ithCache].merged_dir)
-	 {
-		cachep.dir_ty = NonDir;
-	 }
-	 else
-	 {
-		cachep.dir_ty = SBT;
-		cachep.dir_duty_cycle  = XML->sys.L2[ithCache].dir_duty_cycle;
-	 }
-  }
-  else if (cacheL==L1Directory)
-  {
-	 cachep.name = "First Level Directory";
-	 cachep.dir_ty = (enum Dir_type) XML->sys.L1Directory[ithCache].Directory_type;
-	 cachep.clockRate       = XML->sys.L1Directory[ithCache].clockrate;
-	 cachep.clockRate       *= 1e6;
-	 cachep.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
-	 interface_ip.data_arr_ram_cell_tech_type    = XML->sys.L1Directory[ithCache].device_type;//long channel device LSTP
-	 interface_ip.data_arr_peri_global_tech_type = XML->sys.L1Directory[ithCache].device_type;
-	 interface_ip.tag_arr_ram_cell_tech_type     = XML->sys.L1Directory[ithCache].device_type;
-	 interface_ip.tag_arr_peri_global_tech_type  = XML->sys.L1Directory[ithCache].device_type;
-	 cachep.capacity      = XML->sys.L1Directory[ithCache].Dir_config[0];
-	 cachep.blockW        = XML->sys.L1Directory[ithCache].Dir_config[1];
-	 cachep.assoc         = XML->sys.L1Directory[ithCache].Dir_config[2];
-	 cachep.nbanks        = XML->sys.L1Directory[ithCache].Dir_config[3];
-	 cachep.throughput    = XML->sys.L1Directory[ithCache].Dir_config[4]/cachep.clockRate;
-	 cachep.latency       = XML->sys.L1Directory[ithCache].Dir_config[5]/cachep.clockRate;
-	 cachep.missb_size    = XML->sys.L1Directory[ithCache].buffer_sizes[0];
-	 cachep.fu_size       = XML->sys.L1Directory[ithCache].buffer_sizes[1];
-	 cachep.prefetchb_size= XML->sys.L1Directory[ithCache].buffer_sizes[2];
-	 cachep.wbb_size      = XML->sys.L1Directory[ithCache].buffer_sizes[3];
-	 cachep.duty_cycle    = XML->sys.L1Directory[ithCache].duty_cycle;
-  }
-  else if (cacheL==L2Directory)
-  {
-	 cachep.name = "Second Level Directory";
-	 cachep.dir_ty = (enum Dir_type) XML->sys.L2Directory[ithCache].Directory_type;
-	 cachep.clockRate       = XML->sys.L2Directory[ithCache].clockrate;
-	 cachep.clockRate       *= 1e6;
-	 cachep.executionTime   = XML->sys.total_cycles/(XML->sys.target_core_clockrate*1e6);
-	 interface_ip.data_arr_ram_cell_tech_type    = XML->sys.L2Directory[ithCache].device_type;//long channel device LSTP
-	 interface_ip.data_arr_peri_global_tech_type = XML->sys.L2Directory[ithCache].device_type;
-	 interface_ip.tag_arr_ram_cell_tech_type     = XML->sys.L2Directory[ithCache].device_type;
-	 interface_ip.tag_arr_peri_global_tech_type  = XML->sys.L2Directory[ithCache].device_type;
-	 cachep.capacity      = XML->sys.L2Directory[ithCache].Dir_config[0];
-	 cachep.blockW        = XML->sys.L2Directory[ithCache].Dir_config[1];
-	 cachep.assoc         = XML->sys.L2Directory[ithCache].Dir_config[2];
-	 cachep.nbanks        = XML->sys.L2Directory[ithCache].Dir_config[3];
-	 cachep.throughput    = XML->sys.L2Directory[ithCache].Dir_config[4]/cachep.clockRate;
-	 cachep.latency       = XML->sys.L2Directory[ithCache].Dir_config[5]/cachep.clockRate;
-	 cachep.missb_size    = XML->sys.L2Directory[ithCache].buffer_sizes[0];
-	 cachep.fu_size       = XML->sys.L2Directory[ithCache].buffer_sizes[1];
-	 cachep.prefetchb_size= XML->sys.L2Directory[ithCache].buffer_sizes[2];
-	 cachep.wbb_size      = XML->sys.L2Directory[ithCache].buffer_sizes[3];
-	 cachep.duty_cycle    = XML->sys.L2Directory[ithCache].duty_cycle;
-  }
-  //cachep.cache_duty_cycle=cachep.dir_duty_cycle = 0.35;
+  // cachep.cache_duty_cycle=cachep.dir_duty_cycle = 0.35;
 }
-

--- a/src/gpuwattch/sharedcache.h
+++ b/src/gpuwattch/sharedcache.h
@@ -31,58 +31,59 @@
 
 #ifndef SHAREDCACHE_H_
 #define SHAREDCACHE_H_
+#include <vector>
 #include "XML_Parse.h"
+#include "array.h"
+#include "basic_components.h"
 #include "cacti/area.h"
 #include "cacti/parameter.h"
-#include "array.h"
 #include "logic.h"
-#include <vector>
-#include "basic_components.h"
 
-class SharedCache :public Component{
-  public:
-    ParseXML * XML;
-    int ithCache;
-	InputParameter interface_ip;
-	enum cache_level cacheL;
-    DataCache unicache;//Shared cache
-    CacheDynParam cachep;
-    statsDef   homenode_tdp_stats;
-    statsDef   homenode_rtp_stats;
-    statsDef   homenode_stats_t;
-    double	   dir_overhead;
-    //	cache_processor llCache,directory, directory1, inv_dir;
+class SharedCache : public Component {
+ public:
+  ParseXML* XML;
+  int ithCache;
+  InputParameter interface_ip;
+  enum cache_level cacheL;
+  DataCache unicache;  // Shared cache
+  CacheDynParam cachep;
+  statsDef homenode_tdp_stats;
+  statsDef homenode_rtp_stats;
+  statsDef homenode_stats_t;
+  double dir_overhead;
+  //	cache_processor llCache,directory, directory1, inv_dir;
 
-    //pipeline pipeLogicCache, pipeLogicDirectory;
-    //clock_network				clockNetwork;
-    double scktRatio, executionTime;
-    //   Component L2Tot, cc, cc1, ccTot;
+  // pipeline pipeLogicCache, pipeLogicDirectory;
+  // clock_network				clockNetwork;
+  double scktRatio, executionTime;
+  //   Component L2Tot, cc, cc1, ccTot;
 
-    SharedCache(ParseXML *XML_interface, int ithCache_, InputParameter* interface_ip_,enum cache_level cacheL_ =L2);
-    void set_cache_param();
-	void computeEnergy(bool is_tdp=true);
-    void displayEnergy(uint32_t indent = 0,bool is_tdp=true);
-    ~SharedCache(){};
+  SharedCache(ParseXML* XML_interface, int ithCache_,
+              InputParameter* interface_ip_, enum cache_level cacheL_ = L2);
+  void set_cache_param();
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, bool is_tdp = true);
+  ~SharedCache(){};
 };
 
-class CCdir :public Component{
-  public:
-    ParseXML * XML;
-    int ithCache;
-	InputParameter interface_ip;
-    DataCache dc;//Shared cache
-    ArrayST * shadow_dir;
-//	cache_processor llCache,directory, directory1, inv_dir;
+class CCdir : public Component {
+ public:
+  ParseXML* XML;
+  int ithCache;
+  InputParameter interface_ip;
+  DataCache dc;  // Shared cache
+  ArrayST* shadow_dir;
+  //	cache_processor llCache,directory, directory1, inv_dir;
 
-    //pipeline pipeLogicCache, pipeLogicDirectory;
-    //clock_network				clockNetwork;
-    double scktRatio, clockRate, executionTime;
-    Component L2Tot, cc, cc1, ccTot;
+  // pipeline pipeLogicCache, pipeLogicDirectory;
+  // clock_network				clockNetwork;
+  double scktRatio, clockRate, executionTime;
+  Component L2Tot, cc, cc1, ccTot;
 
-    CCdir(ParseXML *XML_interface, int ithCache_, InputParameter* interface_ip_);
-    void computeEnergy(bool is_tdp=true);
-    void displayEnergy(uint32_t indent = 0,bool is_tdp=true);
-    ~CCdir();
+  CCdir(ParseXML* XML_interface, int ithCache_, InputParameter* interface_ip_);
+  void computeEnergy(bool is_tdp = true);
+  void displayEnergy(uint32_t indent = 0, bool is_tdp = true);
+  ~CCdir();
 };
 
 #endif /* SHAREDCACHE_H_ */

--- a/src/gpuwattch/sharedcache.h
+++ b/src/gpuwattch/sharedcache.h
@@ -31,59 +31,58 @@
 
 #ifndef SHAREDCACHE_H_
 #define SHAREDCACHE_H_
-#include <vector>
 #include "XML_Parse.h"
-#include "array.h"
-#include "basic_components.h"
 #include "cacti/area.h"
 #include "cacti/parameter.h"
+#include "array.h"
 #include "logic.h"
+#include <vector>
+#include "basic_components.h"
 
-class SharedCache : public Component {
- public:
-  ParseXML* XML;
-  int ithCache;
-  InputParameter interface_ip;
-  enum cache_level cacheL;
-  DataCache unicache;  // Shared cache
-  CacheDynParam cachep;
-  statsDef homenode_tdp_stats;
-  statsDef homenode_rtp_stats;
-  statsDef homenode_stats_t;
-  double dir_overhead;
-  //	cache_processor llCache,directory, directory1, inv_dir;
+class SharedCache :public Component{
+  public:
+    ParseXML * XML;
+    int ithCache;
+	InputParameter interface_ip;
+	enum cache_level cacheL;
+    DataCache unicache;//Shared cache
+    CacheDynParam cachep;
+    statsDef   homenode_tdp_stats;
+    statsDef   homenode_rtp_stats;
+    statsDef   homenode_stats_t;
+    double	   dir_overhead;
+    //	cache_processor llCache,directory, directory1, inv_dir;
 
-  // pipeline pipeLogicCache, pipeLogicDirectory;
-  // clock_network				clockNetwork;
-  double scktRatio, executionTime;
-  //   Component L2Tot, cc, cc1, ccTot;
+    //pipeline pipeLogicCache, pipeLogicDirectory;
+    //clock_network				clockNetwork;
+    double scktRatio, executionTime;
+    //   Component L2Tot, cc, cc1, ccTot;
 
-  SharedCache(ParseXML* XML_interface, int ithCache_,
-              InputParameter* interface_ip_, enum cache_level cacheL_ = L2);
-  void set_cache_param();
-  void computeEnergy(bool is_tdp = true);
-  void displayEnergy(uint32_t indent = 0, bool is_tdp = true);
-  ~SharedCache(){};
+    SharedCache(ParseXML *XML_interface, int ithCache_, InputParameter* interface_ip_,enum cache_level cacheL_ =L2);
+    void set_cache_param();
+	void computeEnergy(bool is_tdp=true);
+    void displayEnergy(uint32_t indent = 0,bool is_tdp=true);
+    ~SharedCache(){};
 };
 
-class CCdir : public Component {
- public:
-  ParseXML* XML;
-  int ithCache;
-  InputParameter interface_ip;
-  DataCache dc;  // Shared cache
-  ArrayST* shadow_dir;
-  //	cache_processor llCache,directory, directory1, inv_dir;
+class CCdir :public Component{
+  public:
+    ParseXML * XML;
+    int ithCache;
+	InputParameter interface_ip;
+    DataCache dc;//Shared cache
+    ArrayST * shadow_dir;
+//	cache_processor llCache,directory, directory1, inv_dir;
 
-  // pipeline pipeLogicCache, pipeLogicDirectory;
-  // clock_network				clockNetwork;
-  double scktRatio, clockRate, executionTime;
-  Component L2Tot, cc, cc1, ccTot;
+    //pipeline pipeLogicCache, pipeLogicDirectory;
+    //clock_network				clockNetwork;
+    double scktRatio, clockRate, executionTime;
+    Component L2Tot, cc, cc1, ccTot;
 
-  CCdir(ParseXML* XML_interface, int ithCache_, InputParameter* interface_ip_);
-  void computeEnergy(bool is_tdp = true);
-  void displayEnergy(uint32_t indent = 0, bool is_tdp = true);
-  ~CCdir();
+    CCdir(ParseXML *XML_interface, int ithCache_, InputParameter* interface_ip_);
+    void computeEnergy(bool is_tdp=true);
+    void displayEnergy(uint32_t indent = 0,bool is_tdp=true);
+    ~CCdir();
 };
 
 #endif /* SHAREDCACHE_H_ */

--- a/src/gpuwattch/technology_xeon_core.cc
+++ b/src/gpuwattch/technology_xeon_core.cc
@@ -1904,8 +1904,8 @@ void init_tech_params(double technology, bool is_tag) {
 
   g_tp.min_w_nmos_ = 3 * g_ip->F_sz_um / 2;
   g_tp.max_w_nmos_ = 100 * g_ip->F_sz_um;
-  g_tp.w_iso = 12.5 * g_ip->F_sz_um;  // was 10 micron for the 0.8 micron
-                                      // process
+  g_tp.w_iso = 12.5 * g_ip->F_sz_um;      // was 10 micron for the 0.8 micron
+                                          // process
   g_tp.w_sense_n = 3.75 * g_ip->F_sz_um;  // sense amplifier N-trans; was 3
                                           // micron for the 0.8 micron process
   g_tp.w_sense_p = 7.5 * g_ip->F_sz_um;   // sense amplifier P-trans; was 6

--- a/src/gpuwattch/technology_xeon_core.cc
+++ b/src/gpuwattch/technology_xeon_core.cc
@@ -29,57 +29,64 @@
  *
  ***************************************************************************/
 
-
 #include "basic_circuit.h"
 
 #include "parameter.h"
 
-double wire_resistance(double resistivity, double wire_width, double wire_thickness,
-    double barrier_thickness, double dishing_thickness, double alpha_scatter)
-{
+double wire_resistance(double resistivity, double wire_width,
+                       double wire_thickness, double barrier_thickness,
+                       double dishing_thickness, double alpha_scatter) {
   double resistance;
-  resistance = alpha_scatter * resistivity /((wire_thickness - barrier_thickness - dishing_thickness)*(wire_width - 2 * barrier_thickness));
-  return(resistance);
+  resistance = alpha_scatter * resistivity /
+               ((wire_thickness - barrier_thickness - dishing_thickness) *
+                (wire_width - 2 * barrier_thickness));
+  return (resistance);
 }
 
-double wire_capacitance(double wire_width, double wire_thickness, double wire_spacing,
-    double ild_thickness, double miller_value, double horiz_dielectric_constant,
-    double vert_dielectric_constant, double fringe_cap)
-{
+double wire_capacitance(double wire_width, double wire_thickness,
+                        double wire_spacing, double ild_thickness,
+                        double miller_value, double horiz_dielectric_constant,
+                        double vert_dielectric_constant, double fringe_cap) {
   double vertical_cap, sidewall_cap, total_cap;
-  vertical_cap = 2 * PERMITTIVITY_FREE_SPACE * vert_dielectric_constant * wire_width / ild_thickness;
-  sidewall_cap = 2 * PERMITTIVITY_FREE_SPACE * miller_value * horiz_dielectric_constant * wire_thickness / wire_spacing;
+  vertical_cap = 2 * PERMITTIVITY_FREE_SPACE * vert_dielectric_constant *
+                 wire_width / ild_thickness;
+  sidewall_cap = 2 * PERMITTIVITY_FREE_SPACE * miller_value *
+                 horiz_dielectric_constant * wire_thickness / wire_spacing;
   total_cap = vertical_cap + sidewall_cap + fringe_cap;
-  return(total_cap);
+  return (total_cap);
 }
 
-
-void init_tech_params(double technology, bool is_tag)
-{
-  int    iter, tech, tech_lo, tech_hi;
+void init_tech_params(double technology, bool is_tag) {
+  int iter, tech, tech_lo, tech_hi;
   double curr_alpha, curr_vpp;
-  double wire_width, wire_thickness, wire_spacing,
-         fringe_cap, pmos_to_nmos_sizing_r;
-//  double aspect_ratio,ild_thickness, miller_value = 1.5, horiz_dielectric_constant, vert_dielectric_constant;
+  double wire_width, wire_thickness, wire_spacing, fringe_cap,
+      pmos_to_nmos_sizing_r;
+  //  double aspect_ratio,ild_thickness, miller_value = 1.5,
+  //  horiz_dielectric_constant, vert_dielectric_constant;
   double barrier_thickness, dishing_thickness, alpha_scatter;
-  double curr_vdd_dram_cell, curr_v_th_dram_access_transistor, curr_I_on_dram_cell, curr_c_dram_cell;
+  double curr_vdd_dram_cell, curr_v_th_dram_access_transistor,
+      curr_I_on_dram_cell, curr_c_dram_cell;
 
-  uint32_t ram_cell_tech_type    = (is_tag) ? g_ip->tag_arr_ram_cell_tech_type : g_ip->data_arr_ram_cell_tech_type;
-  uint32_t peri_global_tech_type = (is_tag) ? g_ip->tag_arr_peri_global_tech_type : g_ip->data_arr_peri_global_tech_type;
+  uint32_t ram_cell_tech_type = (is_tag) ? g_ip->tag_arr_ram_cell_tech_type
+                                         : g_ip->data_arr_ram_cell_tech_type;
+  uint32_t peri_global_tech_type = (is_tag)
+                                       ? g_ip->tag_arr_peri_global_tech_type
+                                       : g_ip->data_arr_peri_global_tech_type;
 
-  technology  = technology * 1000.0;  // in the unit of nm
+  technology = technology * 1000.0;  // in the unit of nm
 
   // initialize parameters
   g_tp.reset();
   double gmp_to_gmn_multiplier_periph_global = 0;
 
   double curr_Wmemcella_dram, curr_Wmemcellpmos_dram, curr_Wmemcellnmos_dram,
-         curr_area_cell_dram, curr_asp_ratio_cell_dram, curr_Wmemcella_sram,
-         curr_Wmemcellpmos_sram, curr_Wmemcellnmos_sram, curr_area_cell_sram,
-         curr_asp_ratio_cell_sram, curr_I_off_dram_cell_worst_case_length_temp;
-  double curr_Wmemcella_cam, curr_Wmemcellpmos_cam, curr_Wmemcellnmos_cam, curr_area_cell_cam,//Sheng: CAM data
-         curr_asp_ratio_cell_cam;
-  double SENSE_AMP_D, SENSE_AMP_P; // J
+      curr_area_cell_dram, curr_asp_ratio_cell_dram, curr_Wmemcella_sram,
+      curr_Wmemcellpmos_sram, curr_Wmemcellnmos_sram, curr_area_cell_sram,
+      curr_asp_ratio_cell_sram, curr_I_off_dram_cell_worst_case_length_temp;
+  double curr_Wmemcella_cam, curr_Wmemcellpmos_cam, curr_Wmemcellnmos_cam,
+      curr_area_cell_cam,  // Sheng: CAM data
+      curr_asp_ratio_cell_cam;
+  double SENSE_AMP_D, SENSE_AMP_P;  // J
   double area_cell_dram = 0;
   double asp_ratio_cell_dram = 0;
   double area_cell_sram = 0;
@@ -91,77 +98,63 @@ void init_tech_params(double technology, bool is_tag)
   double nmos_effective_resistance_multiplier;
   double width_dram_access_transistor;
 
-  double curr_logic_scaling_co_eff = 0;//This is based on the reported numbers of Intel Merom 65nm, Penryn45nm and IBM cell 90/65/45 date
-  double curr_core_tx_density = 0;//this is density per um^2; 90, ...22nm based on Intel Penryn
+  double curr_logic_scaling_co_eff =
+      0;  // This is based on the reported numbers of Intel Merom 65nm,
+          // Penryn45nm and IBM cell 90/65/45 date
+  double curr_core_tx_density =
+      0;  // this is density per um^2; 90, ...22nm based on Intel Penryn
   double curr_chip_layout_overhead = 0;
   double curr_macro_layout_overhead = 0;
   double curr_sckt_co_eff = 0;
 
-  if (technology < 91 && technology > 89)
-  {
+  if (technology < 91 && technology > 89) {
     tech_lo = 90;
     tech_hi = 90;
-  }
-  else if (technology < 66 && technology > 64)
-  {
+  } else if (technology < 66 && technology > 64) {
     tech_lo = 65;
     tech_hi = 65;
-  }
-  else if (technology < 46 && technology > 44)
-  {
+  } else if (technology < 46 && technology > 44) {
     tech_lo = 45;
     tech_hi = 45;
-  }
-  else if (technology < 33 && technology > 31)
-  {
+  } else if (technology < 33 && technology > 31) {
     tech_lo = 32;
     tech_hi = 32;
-  }
-  else if (technology < 23 && technology > 21)
-  {
+  } else if (technology < 23 && technology > 21) {
     tech_lo = 22;
     tech_hi = 22;
-    if (ram_cell_tech_type == 3)
-    {
-       cout<<"current version does not support eDRAM technologies at 22nm"<<endl;
-       exit(0);
+    if (ram_cell_tech_type == 3) {
+      cout << "current version does not support eDRAM technologies at 22nm"
+           << endl;
+      exit(0);
     }
   }
-//  else if (technology < 17 && technology > 15)
-//  {
-//    tech_lo = 16;
-//    tech_hi = 16;
-//  }
-  else if (technology < 90 && technology > 65)
-  {
+  //  else if (technology < 17 && technology > 15)
+  //  {
+  //    tech_lo = 16;
+  //    tech_hi = 16;
+  //  }
+  else if (technology < 90 && technology > 65) {
     tech_lo = 90;
     tech_hi = 65;
-  }
-  else if (technology < 65 && technology > 45)
-  {
+  } else if (technology < 65 && technology > 45) {
     tech_lo = 65;
     tech_hi = 45;
-  }
-  else if (technology < 45 && technology > 32)
-  {
+  } else if (technology < 45 && technology > 32) {
     tech_lo = 45;
     tech_hi = 32;
+  } else if (technology < 32 && technology > 22) {
+    tech_lo = 32;
+    tech_hi = 22;
   }
-  else if (technology < 32 && technology > 22)
-    {
-      tech_lo = 32;
-      tech_hi = 22;
-    }
-//  else if (technology < 22 && technology > 16)
-//    {
-//      tech_lo = 22;
-//      tech_hi = 16;
-//    }
-      else
-    {
-  	  cout<<"Invalid technology nodes"<<endl;
-  	  exit(0);
-    }
+  //  else if (technology < 22 && technology > 16)
+  //    {
+  //      tech_lo = 22;
+  //      tech_hi = 16;
+  //    }
+  else {
+    cout << "Invalid technology nodes" << endl;
+    exit(0);
+  }
 
   double vdd[NUMBER_TECH_FLAVORS];
   double Lphy[NUMBER_TECH_FLAVORS];
@@ -181,66 +174,59 @@ void init_tech_params(double technology, bool is_tag)
   double n_to_p_eff_curr_drv_ratio[NUMBER_TECH_FLAVORS];
   double I_off_n[NUMBER_TECH_FLAVORS][101];
   double I_g_on_n[NUMBER_TECH_FLAVORS][101];
-  //double I_off_p[NUMBER_TECH_FLAVORS][101];
+  // double I_off_p[NUMBER_TECH_FLAVORS][101];
   double gmp_to_gmn_multiplier[NUMBER_TECH_FLAVORS];
-  //double curr_sckt_co_eff[NUMBER_TECH_FLAVORS];
+  // double curr_sckt_co_eff[NUMBER_TECH_FLAVORS];
   double long_channel_leakage_reduction[NUMBER_TECH_FLAVORS];
 
-  for (iter = 0; iter <= 1; ++iter)
-  {
+  for (iter = 0; iter <= 1; ++iter) {
     // linear interpolation
-    if (iter == 0)
-    {
+    if (iter == 0) {
       tech = tech_lo;
-      if (tech_lo == tech_hi)
-      {
+      if (tech_lo == tech_hi) {
         curr_alpha = 1;
+      } else {
+        curr_alpha = (technology - tech_hi) / (tech_lo - tech_hi);
       }
-      else
-      {
-        curr_alpha = (technology - tech_hi)/(tech_lo - tech_hi);
-      }
-    }
-    else
-    {
+    } else {
       tech = tech_hi;
-      if (tech_lo == tech_hi)
-      {
+      if (tech_lo == tech_hi) {
         break;
-      }
-      else
-      {
-        curr_alpha = (tech_lo - technology)/(tech_lo - tech_hi);
+      } else {
+        curr_alpha = (tech_lo - technology) / (tech_lo - tech_hi);
       }
     }
 
-    if (tech == 90)
-    {
-      SENSE_AMP_D = .28e-9; // s
-      SENSE_AMP_P = 14.7e-15; // J
-      //90nm technology-node. Corresponds to year 2004 in ITRS
-      //ITRS HP device type
-      vdd[0]   = 1.2;
-      Lphy[0]  = 0.037;//Lphy is the physical gate-length. micron
-      Lelec[0] = 0.0266;//Lelec is the electrical gate-length. micron
-      t_ox[0]  = 1.2e-3;//micron
-      v_th[0]  = 0.23707;//V
-      c_ox[0]  = 1.79e-14;//F/micron2
-      mobility_eff[0] = 342.16 * (1e-2 * 1e6 * 1e-2 * 1e6); //micron2 / Vs
-      Vdsat[0] = 0.128; //V
-      c_g_ideal[0] = 6.64e-16;//F/micron
-      c_fringe[0]  = 0.08e-15;//F/micron
-      c_junc[0] = 1e-15;//F/micron2
-      I_on_n[0] = 1076.9e-6;//A/micron
-      I_on_p[0] = 712.6e-6;//A/micron
-      //Note that nmos_effective_resistance_multiplier, n_to_p_eff_curr_drv_ratio and gmp_to_gmn_multiplier values are calculated offline
+    if (tech == 90) {
+      SENSE_AMP_D = .28e-9;    // s
+      SENSE_AMP_P = 14.7e-15;  // J
+      // 90nm technology-node. Corresponds to year 2004 in ITRS
+      // ITRS HP device type
+      vdd[0] = 1.2;
+      Lphy[0] = 0.037;     // Lphy is the physical gate-length. micron
+      Lelec[0] = 0.0266;   // Lelec is the electrical gate-length. micron
+      t_ox[0] = 1.2e-3;    // micron
+      v_th[0] = 0.23707;   // V
+      c_ox[0] = 1.79e-14;  // F/micron2
+      mobility_eff[0] = 342.16 * (1e-2 * 1e6 * 1e-2 * 1e6);  // micron2 / Vs
+      Vdsat[0] = 0.128;                                      // V
+      c_g_ideal[0] = 6.64e-16;                               // F/micron
+      c_fringe[0] = 0.08e-15;                                // F/micron
+      c_junc[0] = 1e-15;                                     // F/micron2
+      I_on_n[0] = 1076.9e-6;                                 // A/micron
+      I_on_p[0] = 712.6e-6;                                  // A/micron
+      // Note that nmos_effective_resistance_multiplier,
+      // n_to_p_eff_curr_drv_ratio and gmp_to_gmn_multiplier values are
+      // calculated offline
       nmos_effective_resistance_multiplier = 1.54;
       n_to_p_eff_curr_drv_ratio[0] = 2.45;
       gmp_to_gmn_multiplier[0] = 1.22;
-      Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] / I_on_n[0];//ohm-micron
-      Rpchannelon[0] = n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];//ohm-micron
+      Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] /
+                       I_on_n[0];  // ohm-micron
+      Rpchannelon[0] =
+          n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];  // ohm-micron
       long_channel_leakage_reduction[0] = 1;
-      I_off_n[0][0]  = 3.24e-8;//A/micron
+      I_off_n[0][0] = 3.24e-8;  // A/micron
       I_off_n[0][10] = 4.01e-8;
       I_off_n[0][20] = 4.90e-8;
       I_off_n[0][30] = 5.92e-8;
@@ -252,7 +238,7 @@ void init_tech_params(double technology, bool is_tag)
       I_off_n[0][90] = 1.43e-7;
       I_off_n[0][100] = 1.54e-7;
 
-      I_g_on_n[0][0]  = 1.65e-8;//A/micron
+      I_g_on_n[0][0] = 1.65e-8;  // A/micron
       I_g_on_n[0][10] = 1.65e-8;
       I_g_on_n[0][20] = 1.65e-8;
       I_g_on_n[0][30] = 1.65e-8;
@@ -264,27 +250,28 @@ void init_tech_params(double technology, bool is_tag)
       I_g_on_n[0][90] = 1.65e-8;
       I_g_on_n[0][100] = 1.65e-8;
 
-      //ITRS LSTP device type
-      vdd[1]   = 1.3;
-      Lphy[1]  = 0.075;
+      // ITRS LSTP device type
+      vdd[1] = 1.3;
+      Lphy[1] = 0.075;
       Lelec[1] = 0.0486;
-      t_ox[1]  = 2.2e-3;
-      v_th[1]  = 0.48203;
-      c_ox[1]  = 1.22e-14;
+      t_ox[1] = 2.2e-3;
+      v_th[1] = 0.48203;
+      c_ox[1] = 1.22e-14;
       mobility_eff[1] = 356.76 * (1e-2 * 1e6 * 1e-2 * 1e6);
       Vdsat[1] = 0.373;
       c_g_ideal[1] = 9.15e-16;
-      c_fringe[1]  = 0.08e-15;
+      c_fringe[1] = 0.08e-15;
       c_junc[1] = 1e-15;
       I_on_n[1] = 503.6e-6;
       I_on_p[1] = 235.1e-6;
       nmos_effective_resistance_multiplier = 1.92;
       n_to_p_eff_curr_drv_ratio[1] = 2.44;
-      gmp_to_gmn_multiplier[1] =0.88;
-      Rnchannelon[1] = nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];
+      gmp_to_gmn_multiplier[1] = 0.88;
+      Rnchannelon[1] =
+          nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];
       Rpchannelon[1] = n_to_p_eff_curr_drv_ratio[1] * Rnchannelon[1];
       long_channel_leakage_reduction[1] = 1;
-      I_off_n[1][0]  = 2.81e-12;
+      I_off_n[1][0] = 2.81e-12;
       I_off_n[1][10] = 4.76e-12;
       I_off_n[1][20] = 7.82e-12;
       I_off_n[1][30] = 1.25e-11;
@@ -296,7 +283,7 @@ void init_tech_params(double technology, bool is_tag)
       I_off_n[1][90] = 1.25e-10;
       I_off_n[1][100] = 1.7e-10;
 
-      I_g_on_n[1][0]  = 3.87e-11;//A/micron
+      I_g_on_n[1][0] = 3.87e-11;  // A/micron
       I_g_on_n[1][10] = 3.87e-11;
       I_g_on_n[1][20] = 3.87e-11;
       I_g_on_n[1][30] = 3.87e-11;
@@ -308,7 +295,7 @@ void init_tech_params(double technology, bool is_tag)
       I_g_on_n[1][90] = 3.87e-11;
       I_g_on_n[1][100] = 3.87e-11;
 
-      //ITRS LOP device type
+      // ITRS LOP device type
       vdd[2] = 0.9;
       Lphy[2] = 0.053;
       Lelec[2] = 0.0354;
@@ -325,7 +312,8 @@ void init_tech_params(double technology, bool is_tag)
       nmos_effective_resistance_multiplier = 1.77;
       n_to_p_eff_curr_drv_ratio[2] = 2.54;
       gmp_to_gmn_multiplier[2] = 0.98;
-      Rnchannelon[2] = nmos_effective_resistance_multiplier * vdd[2] / I_on_n[2];
+      Rnchannelon[2] =
+          nmos_effective_resistance_multiplier * vdd[2] / I_on_n[2];
       Rpchannelon[2] = n_to_p_eff_curr_drv_ratio[2] * Rnchannelon[2];
       long_channel_leakage_reduction[2] = 1;
       I_off_n[2][0] = 2.14e-9;
@@ -340,7 +328,7 @@ void init_tech_params(double technology, bool is_tag)
       I_off_n[2][90] = 1.52e-8;
       I_off_n[2][100] = 1.73e-8;
 
-      I_g_on_n[2][0]  = 4.31e-8;//A/micron
+      I_g_on_n[2][0] = 4.31e-8;  // A/micron
       I_g_on_n[2][10] = 4.31e-8;
       I_g_on_n[2][20] = 4.31e-8;
       I_g_on_n[2][30] = 4.31e-8;
@@ -352,9 +340,8 @@ void init_tech_params(double technology, bool is_tag)
       I_g_on_n[2][90] = 4.31e-8;
       I_g_on_n[2][100] = 4.31e-8;
 
-      if (ram_cell_tech_type == lp_dram)
-      {
-        //LP-DRAM cell access transistor technology parameters
+      if (ram_cell_tech_type == lp_dram) {
+        // LP-DRAM cell access transistor technology parameters
         curr_vdd_dram_cell = 1.2;
         Lphy[3] = 0.12;
         Lelec[3] = 0.0756;
@@ -369,12 +356,12 @@ void init_tech_params(double technology, bool is_tag)
         curr_asp_ratio_cell_dram = 1.46;
         curr_c_dram_cell = 20e-15;
 
-        //LP-DRAM wordline transistor parameters
+        // LP-DRAM wordline transistor parameters
         curr_vpp = 1.6;
         t_ox[3] = 2.2e-3;
         v_th[3] = 0.4545;
         c_ox[3] = 1.22e-14;
-        mobility_eff[3] =  323.95 * (1e-2 * 1e6 * 1e-2 * 1e6);
+        mobility_eff[3] = 323.95 * (1e-2 * 1e6 * 1e-2 * 1e6);
         Vdsat[3] = 0.3;
         c_g_ideal[3] = 1.47e-15;
         c_fringe[3] = 0.08e-15;
@@ -384,7 +371,8 @@ void init_tech_params(double technology, bool is_tag)
         nmos_effective_resistance_multiplier = 1.65;
         n_to_p_eff_curr_drv_ratio[3] = 1.95;
         gmp_to_gmn_multiplier[3] = 0.90;
-        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
+        Rnchannelon[3] =
+            nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
         Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];
         long_channel_leakage_reduction[3] = 1;
         I_off_n[3][0] = 1.42e-11;
@@ -398,10 +386,8 @@ void init_tech_params(double technology, bool is_tag)
         I_off_n[3][80] = 2.57e-10;
         I_off_n[3][90] = 3.14e-10;
         I_off_n[3][100] = 3.85e-10;
-      }
-      else if (ram_cell_tech_type == comm_dram)
-      {
-        //COMM-DRAM cell access transistor technology parameters
+      } else if (ram_cell_tech_type == comm_dram) {
+        // COMM-DRAM cell access transistor technology parameters
         curr_vdd_dram_cell = 1.6;
         Lphy[3] = 0.09;
         Lelec[3] = 0.0576;
@@ -412,16 +398,16 @@ void init_tech_params(double technology, bool is_tag)
         curr_Wmemcella_dram = width_dram_access_transistor;
         curr_Wmemcellpmos_dram = 0;
         curr_Wmemcellnmos_dram = 0;
-        curr_area_cell_dram = 6*0.09*0.09;
+        curr_area_cell_dram = 6 * 0.09 * 0.09;
         curr_asp_ratio_cell_dram = 1.5;
         curr_c_dram_cell = 30e-15;
 
-        //COMM-DRAM wordline transistor parameters
+        // COMM-DRAM wordline transistor parameters
         curr_vpp = 3.7;
         t_ox[3] = 5.5e-3;
         v_th[3] = 1.0;
         c_ox[3] = 5.65e-15;
-        mobility_eff[3] =  302.2 * (1e-2 * 1e6 * 1e-2 * 1e6);
+        mobility_eff[3] = 302.2 * (1e-2 * 1e6 * 1e-2 * 1e6);
         Vdsat[3] = 0.32;
         c_g_ideal[3] = 5.08e-16;
         c_fringe[3] = 0.08e-15;
@@ -431,7 +417,8 @@ void init_tech_params(double technology, bool is_tag)
         nmos_effective_resistance_multiplier = 1.62;
         n_to_p_eff_curr_drv_ratio[3] = 2.05;
         gmp_to_gmn_multiplier[3] = 0.90;
-        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
+        Rnchannelon[3] =
+            nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
         Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];
         long_channel_leakage_reduction[3] = 1;
         I_off_n[3][0] = 5.80e-15;
@@ -447,126 +434,128 @@ void init_tech_params(double technology, bool is_tag)
         I_off_n[3][100] = 1.67e-12;
       }
 
-      //SRAM cell properties
+      // SRAM cell properties
       curr_Wmemcella_sram = 1.31 * g_ip->F_sz_um;
       curr_Wmemcellpmos_sram = 1.23 * g_ip->F_sz_um;
       curr_Wmemcellnmos_sram = 2.08 * g_ip->F_sz_um;
       curr_area_cell_sram = 146 * g_ip->F_sz_um * g_ip->F_sz_um;
       curr_asp_ratio_cell_sram = 1.46;
-      //CAM cell properties //TODO: data need to be revisited
+      // CAM cell properties //TODO: data need to be revisited
       curr_Wmemcella_cam = 1.31 * g_ip->F_sz_um;
       curr_Wmemcellpmos_cam = 1.23 * g_ip->F_sz_um;
       curr_Wmemcellnmos_cam = 2.08 * g_ip->F_sz_um;
-      curr_area_cell_cam = 292 * g_ip->F_sz_um * g_ip->F_sz_um;//360
-      curr_asp_ratio_cell_cam = 2.92;//2.5
-      //Empirical undifferetiated core/FU coefficient
-      curr_logic_scaling_co_eff  = 1;
-      curr_core_tx_density       = 1.25*0.7*0.7;
-      curr_sckt_co_eff           = 1.1539;
-      curr_chip_layout_overhead  = 1.2;//die measurement results based on Niagara 1 and 2
-      curr_macro_layout_overhead = 1.1;//EDA placement and routing tool rule of thumb
-
-
+      curr_area_cell_cam = 292 * g_ip->F_sz_um * g_ip->F_sz_um;  // 360
+      curr_asp_ratio_cell_cam = 2.92;                            // 2.5
+      // Empirical undifferetiated core/FU coefficient
+      curr_logic_scaling_co_eff = 1;
+      curr_core_tx_density = 1.25 * 0.7 * 0.7;
+      curr_sckt_co_eff = 1.1539;
+      curr_chip_layout_overhead =
+          1.2;  // die measurement results based on Niagara 1 and 2
+      curr_macro_layout_overhead =
+          1.1;  // EDA placement and routing tool rule of thumb
     }
 
-    if (tech == 65)
-    { //65nm technology-node. Corresponds to year 2007 in ITRS
-      //ITRS HP device type
-//      SENSE_AMP_D = .2e-9; // s
-//      SENSE_AMP_P = 5.7e-15; // J
-//      vdd[0] = 1.1;
-//      Lphy[0] = 0.025;
-//      Lelec[0] = 0.019;
-//      t_ox[0] = 1.1e-3;
-//      v_th[0] = .19491;
-//      c_ox[0] = 1.88e-14;
-//      mobility_eff[0] = 436.24 * (1e-2 * 1e6 * 1e-2 * 1e6);
-//      Vdsat[0] = 7.71e-2;
-//      c_g_ideal[0] = 4.69e-16;
-//      c_fringe[0] = 0.077e-15;
-//      c_junc[0] = 1e-15;
-//      I_on_n[0] = 1197.2e-6;
-//      I_on_p[0] = 870.8e-6;
-//      nmos_effective_resistance_multiplier = 1.50;
-//      n_to_p_eff_curr_drv_ratio[0] = 2.41;
-//      gmp_to_gmn_multiplier[0] = 1.38;
-//      Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] / I_on_n[0];
-//      Rpchannelon[0] = n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];
-//      long_channel_leakage_reduction[0] = 1/3.74;
-//      //Using MASTAR, @380K, increase Lgate until Ion reduces to 90% or Lgate increase by 10%, whichever comes first
-//      //Ioff(Lgate normal)/Ioff(Lgate long)= 3.74.
-//      I_off_n[0][0] = 1.96e-7;
-//      I_off_n[0][10] = 2.29e-7;
-//      I_off_n[0][20] = 2.66e-7;
-//      I_off_n[0][30] = 3.05e-7;
-//      I_off_n[0][40] = 3.49e-7;
-//      I_off_n[0][50] = 3.95e-7;
-//      I_off_n[0][60] = 4.45e-7;
-//      I_off_n[0][70] = 4.97e-7;
-//      I_off_n[0][80] = 5.48e-7;
-//      I_off_n[0][90] = 5.94e-7;
-//      I_off_n[0][100] = 6.3e-7;
-//      I_g_on_n[0][0]  = 4.09e-8;//A/micron
-//      I_g_on_n[0][10] = 4.09e-8;
-//      I_g_on_n[0][20] = 4.09e-8;
-//      I_g_on_n[0][30] = 4.09e-8;
-//      I_g_on_n[0][40] = 4.09e-8;
-//      I_g_on_n[0][50] = 4.09e-8;
-//      I_g_on_n[0][60] = 4.09e-8;
-//      I_g_on_n[0][70] = 4.09e-8;
-//      I_g_on_n[0][80] = 4.09e-8;
-//      I_g_on_n[0][90] = 4.09e-8;
-//      I_g_on_n[0][100] = 4.09e-8;
+    if (tech == 65) {  // 65nm technology-node. Corresponds to year 2007 in ITRS
+                       // ITRS HP device type
+      //      SENSE_AMP_D = .2e-9; // s
+      //      SENSE_AMP_P = 5.7e-15; // J
+      //      vdd[0] = 1.1;
+      //      Lphy[0] = 0.025;
+      //      Lelec[0] = 0.019;
+      //      t_ox[0] = 1.1e-3;
+      //      v_th[0] = .19491;
+      //      c_ox[0] = 1.88e-14;
+      //      mobility_eff[0] = 436.24 * (1e-2 * 1e6 * 1e-2 * 1e6);
+      //      Vdsat[0] = 7.71e-2;
+      //      c_g_ideal[0] = 4.69e-16;
+      //      c_fringe[0] = 0.077e-15;
+      //      c_junc[0] = 1e-15;
+      //      I_on_n[0] = 1197.2e-6;
+      //      I_on_p[0] = 870.8e-6;
+      //      nmos_effective_resistance_multiplier = 1.50;
+      //      n_to_p_eff_curr_drv_ratio[0] = 2.41;
+      //      gmp_to_gmn_multiplier[0] = 1.38;
+      //      Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] /
+      //      I_on_n[0]; Rpchannelon[0] = n_to_p_eff_curr_drv_ratio[0] *
+      //      Rnchannelon[0]; long_channel_leakage_reduction[0] = 1/3.74;
+      //      //Using MASTAR, @380K, increase Lgate until Ion reduces to 90% or
+      //      Lgate increase by 10%, whichever comes first
+      //      //Ioff(Lgate normal)/Ioff(Lgate long)= 3.74.
+      //      I_off_n[0][0] = 1.96e-7;
+      //      I_off_n[0][10] = 2.29e-7;
+      //      I_off_n[0][20] = 2.66e-7;
+      //      I_off_n[0][30] = 3.05e-7;
+      //      I_off_n[0][40] = 3.49e-7;
+      //      I_off_n[0][50] = 3.95e-7;
+      //      I_off_n[0][60] = 4.45e-7;
+      //      I_off_n[0][70] = 4.97e-7;
+      //      I_off_n[0][80] = 5.48e-7;
+      //      I_off_n[0][90] = 5.94e-7;
+      //      I_off_n[0][100] = 6.3e-7;
+      //      I_g_on_n[0][0]  = 4.09e-8;//A/micron
+      //      I_g_on_n[0][10] = 4.09e-8;
+      //      I_g_on_n[0][20] = 4.09e-8;
+      //      I_g_on_n[0][30] = 4.09e-8;
+      //      I_g_on_n[0][40] = 4.09e-8;
+      //      I_g_on_n[0][50] = 4.09e-8;
+      //      I_g_on_n[0][60] = 4.09e-8;
+      //      I_g_on_n[0][70] = 4.09e-8;
+      //      I_g_on_n[0][80] = 4.09e-8;
+      //      I_g_on_n[0][90] = 4.09e-8;
+      //      I_g_on_n[0][100] = 4.09e-8;
 
-    	SENSE_AMP_D = .2e-9; // s
-    	SENSE_AMP_P = 5.7e-15; // J
-    	vdd[0] = 1.25;
-    	Lphy[0] = 0.025;
-    	Lelec[0] = 0.019;
-    	t_ox[0] = 1.1e-3;
-    	v_th[0] = .12491;
-    	c_ox[0] = 1.88e-14;
-    	mobility_eff[0] = 409.31 * (1e-2 * 1e6 * 1e-2 * 1e6);
-    	Vdsat[0] = 9.08e-2;
-    	c_g_ideal[0] = 4.72e-16;
-    	c_fringe[0] = 0.08e-15;
-    	c_junc[0] = 1e-15;
-    	I_on_n[0] = 1486.4e-6;
-    	I_on_p[0] = 1131.5e-6;
-    	nmos_effective_resistance_multiplier = 1.57;
-    	n_to_p_eff_curr_drv_ratio[0] = 2;
-    	gmp_to_gmn_multiplier[0] = 1.38;
-    	Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] / I_on_n[0];
-    	Rpchannelon[0] = n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];
-    	long_channel_leakage_reduction[0] = 1.0/4.97;
-    	//Using MASTAR, @380K, increase Lgate until Ion reduces to 90% or Lgate increase by 10%, whichever comes first
-    	//Ioff(Lgate normal)/Ioff(Lgate long)= 4.97@Vdd=1.25; (3.74@Vdd=1.1), however, Intel paper suggest the reduction factor is 3.
-    	I_off_n[0][0]  = 8.62e-7;
-    	I_off_n[0][10] = 9.08e-7;
-    	I_off_n[0][20] = 9.55e-7;
-    	I_off_n[0][30] = 1.00e-6;
-    	I_off_n[0][40] = 1.05e-6;
-    	I_off_n[0][50] = 1.09e-6;
-    	I_off_n[0][60] = 1.14e-6;
-    	I_off_n[0][70] = 1.18e-6;
-    	I_off_n[0][80] = 1.23e-6;
-    	I_off_n[0][90] = 1.27e-6;
-    	I_off_n[0][100] = 1.31e-6;
+      SENSE_AMP_D = .2e-9;    // s
+      SENSE_AMP_P = 5.7e-15;  // J
+      vdd[0] = 1.25;
+      Lphy[0] = 0.025;
+      Lelec[0] = 0.019;
+      t_ox[0] = 1.1e-3;
+      v_th[0] = .12491;
+      c_ox[0] = 1.88e-14;
+      mobility_eff[0] = 409.31 * (1e-2 * 1e6 * 1e-2 * 1e6);
+      Vdsat[0] = 9.08e-2;
+      c_g_ideal[0] = 4.72e-16;
+      c_fringe[0] = 0.08e-15;
+      c_junc[0] = 1e-15;
+      I_on_n[0] = 1486.4e-6;
+      I_on_p[0] = 1131.5e-6;
+      nmos_effective_resistance_multiplier = 1.57;
+      n_to_p_eff_curr_drv_ratio[0] = 2;
+      gmp_to_gmn_multiplier[0] = 1.38;
+      Rnchannelon[0] =
+          nmos_effective_resistance_multiplier * vdd[0] / I_on_n[0];
+      Rpchannelon[0] = n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];
+      long_channel_leakage_reduction[0] = 1.0 / 4.97;
+      // Using MASTAR, @380K, increase Lgate until Ion reduces to 90% or Lgate
+      // increase by 10%, whichever comes first Ioff(Lgate normal)/Ioff(Lgate
+      // long)= 4.97@Vdd=1.25; (3.74@Vdd=1.1), however, Intel paper suggest the
+      // reduction factor is 3.
+      I_off_n[0][0] = 8.62e-7;
+      I_off_n[0][10] = 9.08e-7;
+      I_off_n[0][20] = 9.55e-7;
+      I_off_n[0][30] = 1.00e-6;
+      I_off_n[0][40] = 1.05e-6;
+      I_off_n[0][50] = 1.09e-6;
+      I_off_n[0][60] = 1.14e-6;
+      I_off_n[0][70] = 1.18e-6;
+      I_off_n[0][80] = 1.23e-6;
+      I_off_n[0][90] = 1.27e-6;
+      I_off_n[0][100] = 1.31e-6;
 
+      I_g_on_n[0][0] = 7.02e-8;  // A/micron
+      I_g_on_n[0][10] = 7.02e-8;
+      I_g_on_n[0][20] = 7.02e-8;
+      I_g_on_n[0][30] = 7.02e-8;
+      I_g_on_n[0][40] = 7.02e-8;
+      I_g_on_n[0][50] = 7.02e-8;
+      I_g_on_n[0][60] = 7.02e-8;
+      I_g_on_n[0][70] = 7.02e-8;
+      I_g_on_n[0][80] = 7.02e-8;
+      I_g_on_n[0][90] = 7.02e-8;
+      I_g_on_n[0][100] = 7.02e-8;
 
-    	I_g_on_n[0][0]  = 7.02e-8;//A/micron
-    	I_g_on_n[0][10] = 7.02e-8;
-    	I_g_on_n[0][20] = 7.02e-8;
-    	I_g_on_n[0][30] = 7.02e-8;
-    	I_g_on_n[0][40] = 7.02e-8;
-    	I_g_on_n[0][50] = 7.02e-8;
-    	I_g_on_n[0][60] = 7.02e-8;
-    	I_g_on_n[0][70] = 7.02e-8;
-    	I_g_on_n[0][80] = 7.02e-8;
-    	I_g_on_n[0][90] = 7.02e-8;
-    	I_g_on_n[0][100] = 7.02e-8;
-
-      //ITRS LSTP device type
+      // ITRS LSTP device type
       vdd[1] = 1.2;
       Lphy[1] = 0.045;
       Lelec[1] = 0.0298;
@@ -583,9 +572,10 @@ void init_tech_params(double technology, bool is_tag)
       nmos_effective_resistance_multiplier = 1.96;
       n_to_p_eff_curr_drv_ratio[1] = 2.23;
       gmp_to_gmn_multiplier[1] = 0.99;
-      Rnchannelon[1] = nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];
+      Rnchannelon[1] =
+          nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];
       Rpchannelon[1] = n_to_p_eff_curr_drv_ratio[1] * Rnchannelon[1];
-      long_channel_leakage_reduction[1] = 1/2.82;
+      long_channel_leakage_reduction[1] = 1 / 2.82;
       I_off_n[1][0] = 9.12e-12;
       I_off_n[1][10] = 1.49e-11;
       I_off_n[1][20] = 2.36e-11;
@@ -598,7 +588,7 @@ void init_tech_params(double technology, bool is_tag)
       I_off_n[1][90] = 2.62e-10;
       I_off_n[1][100] = 3.21e-10;
 
-      I_g_on_n[1][0]  = 1.09e-10;//A/micron
+      I_g_on_n[1][0] = 1.09e-10;  // A/micron
       I_g_on_n[1][10] = 1.09e-10;
       I_g_on_n[1][20] = 1.09e-10;
       I_g_on_n[1][30] = 1.09e-10;
@@ -610,7 +600,7 @@ void init_tech_params(double technology, bool is_tag)
       I_g_on_n[1][90] = 1.09e-10;
       I_g_on_n[1][100] = 1.09e-10;
 
-      //ITRS LOP device type
+      // ITRS LOP device type
       vdd[2] = 0.8;
       Lphy[2] = 0.032;
       Lelec[2] = 0.0216;
@@ -627,9 +617,10 @@ void init_tech_params(double technology, bool is_tag)
       nmos_effective_resistance_multiplier = 1.82;
       n_to_p_eff_curr_drv_ratio[2] = 2.28;
       gmp_to_gmn_multiplier[2] = 1.11;
-      Rnchannelon[2] = nmos_effective_resistance_multiplier * vdd[2] / I_on_n[2];
+      Rnchannelon[2] =
+          nmos_effective_resistance_multiplier * vdd[2] / I_on_n[2];
       Rpchannelon[2] = n_to_p_eff_curr_drv_ratio[2] * Rnchannelon[2];
-      long_channel_leakage_reduction[2] = 1/2.05;
+      long_channel_leakage_reduction[2] = 1 / 2.05;
       I_off_n[2][0] = 4.9e-9;
       I_off_n[2][10] = 6.49e-9;
       I_off_n[2][20] = 8.45e-9;
@@ -642,7 +633,7 @@ void init_tech_params(double technology, bool is_tag)
       I_off_n[2][90] = 3.13e-8;
       I_off_n[2][100] = 3.42e-8;
 
-      I_g_on_n[2][0]  = 9.61e-9;//A/micron
+      I_g_on_n[2][0] = 9.61e-9;  // A/micron
       I_g_on_n[2][10] = 9.61e-9;
       I_g_on_n[2][20] = 9.61e-9;
       I_g_on_n[2][30] = 9.61e-9;
@@ -654,9 +645,8 @@ void init_tech_params(double technology, bool is_tag)
       I_g_on_n[2][90] = 9.61e-9;
       I_g_on_n[2][100] = 9.61e-9;
 
-      if (ram_cell_tech_type == lp_dram)
-      {
-        //LP-DRAM cell access transistor technology parameters
+      if (ram_cell_tech_type == lp_dram) {
+        // LP-DRAM cell access transistor technology parameters
         curr_vdd_dram_cell = 1.2;
         Lphy[3] = 0.12;
         Lelec[3] = 0.0756;
@@ -671,25 +661,26 @@ void init_tech_params(double technology, bool is_tag)
         curr_asp_ratio_cell_dram = 1.46;
         curr_c_dram_cell = 20e-15;
 
-        //LP-DRAM wordline transistor parameters
+        // LP-DRAM wordline transistor parameters
         curr_vpp = 1.6;
         t_ox[3] = 2.2e-3;
         v_th[3] = 0.43806;
         c_ox[3] = 1.22e-14;
-        mobility_eff[3] =  328.32 * (1e-2 * 1e6 * 1e-2 * 1e6);
+        mobility_eff[3] = 328.32 * (1e-2 * 1e6 * 1e-2 * 1e6);
         Vdsat[3] = 0.43806;
         c_g_ideal[3] = 1.46e-15;
         c_fringe[3] = 0.08e-15;
-        c_junc[3] = 1e-15 ;
+        c_junc[3] = 1e-15;
         I_on_n[3] = 399.8e-6;
         I_on_p[3] = 243.4e-6;
         nmos_effective_resistance_multiplier = 1.65;
         n_to_p_eff_curr_drv_ratio[3] = 2.05;
         gmp_to_gmn_multiplier[3] = 0.90;
-        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
+        Rnchannelon[3] =
+            nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
         Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];
         long_channel_leakage_reduction[3] = 1;
-        I_off_n[3][0]  = 2.23e-11;
+        I_off_n[3][0] = 2.23e-11;
         I_off_n[3][10] = 3.46e-11;
         I_off_n[3][20] = 5.24e-11;
         I_off_n[3][30] = 7.75e-11;
@@ -700,10 +691,8 @@ void init_tech_params(double technology, bool is_tag)
         I_off_n[3][80] = 3.63e-10;
         I_off_n[3][90] = 4.41e-10;
         I_off_n[3][100] = 5.36e-10;
-      }
-      else if (ram_cell_tech_type == comm_dram)
-      {
-        //COMM-DRAM cell access transistor technology parameters
+      } else if (ram_cell_tech_type == comm_dram) {
+        // COMM-DRAM cell access transistor technology parameters
         curr_vdd_dram_cell = 1.3;
         Lphy[3] = 0.065;
         Lelec[3] = 0.0426;
@@ -714,29 +703,30 @@ void init_tech_params(double technology, bool is_tag)
         curr_Wmemcella_dram = width_dram_access_transistor;
         curr_Wmemcellpmos_dram = 0;
         curr_Wmemcellnmos_dram = 0;
-        curr_area_cell_dram = 6*0.065*0.065;
+        curr_area_cell_dram = 6 * 0.065 * 0.065;
         curr_asp_ratio_cell_dram = 1.5;
         curr_c_dram_cell = 30e-15;
 
-        //COMM-DRAM wordline transistor parameters
+        // COMM-DRAM wordline transistor parameters
         curr_vpp = 3.3;
         t_ox[3] = 5e-3;
         v_th[3] = 1.0;
         c_ox[3] = 6.16e-15;
-        mobility_eff[3] =  303.44 * (1e-2 * 1e6 * 1e-2 * 1e6);
+        mobility_eff[3] = 303.44 * (1e-2 * 1e6 * 1e-2 * 1e6);
         Vdsat[3] = 0.385;
         c_g_ideal[3] = 4e-16;
         c_fringe[3] = 0.08e-15;
-        c_junc[3] = 1e-15 ;
+        c_junc[3] = 1e-15;
         I_on_n[3] = 1031e-6;
         I_on_p[3] = I_on_n[3] / 2;
         nmos_effective_resistance_multiplier = 1.69;
         n_to_p_eff_curr_drv_ratio[3] = 2.39;
         gmp_to_gmn_multiplier[3] = 0.90;
-        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
+        Rnchannelon[3] =
+            nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
         Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];
         long_channel_leakage_reduction[3] = 1;
-        I_off_n[3][0]  = 1.80e-14;
+        I_off_n[3][0] = 1.80e-14;
         I_off_n[3][10] = 3.64e-14;
         I_off_n[3][20] = 7.03e-14;
         I_off_n[3][30] = 1.31e-13;
@@ -749,31 +739,32 @@ void init_tech_params(double technology, bool is_tag)
         I_off_n[3][100] = 3.99e-12;
       }
 
-      //SRAM cell properties
+      // SRAM cell properties
       curr_Wmemcella_sram = 1.31 * g_ip->F_sz_um;
       curr_Wmemcellpmos_sram = 1.23 * g_ip->F_sz_um;
       curr_Wmemcellnmos_sram = 2.08 * g_ip->F_sz_um;
       curr_area_cell_sram = 146 * g_ip->F_sz_um * g_ip->F_sz_um;
       curr_asp_ratio_cell_sram = 1.46;
-      //CAM cell properties //TODO: data need to be revisited
+      // CAM cell properties //TODO: data need to be revisited
       curr_Wmemcella_cam = 1.31 * g_ip->F_sz_um;
       curr_Wmemcellpmos_cam = 1.23 * g_ip->F_sz_um;
       curr_Wmemcellnmos_cam = 2.08 * g_ip->F_sz_um;
       curr_area_cell_cam = 292 * g_ip->F_sz_um * g_ip->F_sz_um;
       curr_asp_ratio_cell_cam = 2.92;
-      //Empirical undifferetiated core/FU coefficient
+      // Empirical undifferetiated core/FU coefficient
       curr_logic_scaling_co_eff = 0.7;
-      curr_core_tx_density      = 1.25*0.7;
-      curr_sckt_co_eff           = 1.1359;
-      curr_chip_layout_overhead  = 1.2;//die measurement results based on Niagara 1 and 2
-      curr_macro_layout_overhead = 1.1;//EDA placement and routing tool rule of thumb
+      curr_core_tx_density = 1.25 * 0.7;
+      curr_sckt_co_eff = 1.1359;
+      curr_chip_layout_overhead =
+          1.2;  // die measurement results based on Niagara 1 and 2
+      curr_macro_layout_overhead =
+          1.1;  // EDA placement and routing tool rule of thumb
     }
 
-    if (tech == 45)
-    { //45nm technology-node. Corresponds to year 2010 in ITRS
-      //ITRS HP device type
-      SENSE_AMP_D = .04e-9; // s
-      SENSE_AMP_P = 2.7e-15; // J
+    if (tech == 45) {  // 45nm technology-node. Corresponds to year 2010 in ITRS
+      // ITRS HP device type
+      SENSE_AMP_D = .04e-9;   // s
+      SENSE_AMP_P = 2.7e-15;  // J
       vdd[0] = 1.0;
       Lphy[0] = 0.018;
       Lelec[0] = 0.01345;
@@ -786,15 +777,20 @@ void init_tech_params(double technology, bool is_tag)
       c_fringe[0] = 0.05e-15;
       c_junc[0] = 1e-15;
       I_on_n[0] = 2046.6e-6;
-      //There are certain problems with the ITRS PMOS numbers in MASTAR for 45nm. So we are using 65nm values of
-      //n_to_p_eff_curr_drv_ratio and gmp_to_gmn_multiplier for 45nm
-      I_on_p[0] = I_on_n[0] / 2;//This value is fixed arbitrarily but I_on_p is not being used in CACTI
+      // There are certain problems with the ITRS PMOS numbers in MASTAR for
+      // 45nm. So we are using 65nm values of n_to_p_eff_curr_drv_ratio and
+      // gmp_to_gmn_multiplier for 45nm
+      I_on_p[0] = I_on_n[0] / 2;  // This value is fixed arbitrarily but I_on_p
+                                  // is not being used in CACTI
       nmos_effective_resistance_multiplier = 1.51;
       n_to_p_eff_curr_drv_ratio[0] = 2.41;
       gmp_to_gmn_multiplier[0] = 1.38;
-      Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] / I_on_n[0];
+      Rnchannelon[0] =
+          nmos_effective_resistance_multiplier * vdd[0] / I_on_n[0];
       Rpchannelon[0] = n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];
-      long_channel_leakage_reduction[0] = 1/3.546;//Using MASTAR, @380K, increase Lgate until Ion reduces to 90%, Ioff(Lgate normal)/Ioff(Lgate long)= 3.74
+      long_channel_leakage_reduction[0] =
+          1 / 3.546;  // Using MASTAR, @380K, increase Lgate until Ion reduces
+                      // to 90%, Ioff(Lgate normal)/Ioff(Lgate long)= 3.74
       I_off_n[0][0] = 2.8e-7;
       I_off_n[0][10] = 3.28e-7;
       I_off_n[0][20] = 3.81e-7;
@@ -807,7 +803,7 @@ void init_tech_params(double technology, bool is_tag)
       I_off_n[0][90] = 8.91e-7;
       I_off_n[0][100] = 9.84e-7;
 
-      I_g_on_n[0][0]  = 3.59e-8;//A/micron
+      I_g_on_n[0][0] = 3.59e-8;  // A/micron
       I_g_on_n[0][10] = 3.59e-8;
       I_g_on_n[0][20] = 3.59e-8;
       I_g_on_n[0][30] = 3.59e-8;
@@ -819,14 +815,14 @@ void init_tech_params(double technology, bool is_tag)
       I_g_on_n[0][90] = 3.59e-8;
       I_g_on_n[0][100] = 3.59e-8;
 
-      //ITRS LSTP device type
+      // ITRS LSTP device type
       vdd[1] = 1.1;
-      Lphy[1] =  0.028;
+      Lphy[1] = 0.028;
       Lelec[1] = 0.0212;
       t_ox[1] = 1.4e-3;
       v_th[1] = 0.50245;
       c_ox[1] = 2.01e-14;
-      mobility_eff[1] =  363.96 * (1e-2 * 1e6 * 1e-2 * 1e6);
+      mobility_eff[1] = 363.96 * (1e-2 * 1e6 * 1e-2 * 1e6);
       Vdsat[1] = 9.12e-2;
       c_g_ideal[1] = 5.18e-16;
       c_fringe[1] = 0.08e-15;
@@ -836,9 +832,10 @@ void init_tech_params(double technology, bool is_tag)
       nmos_effective_resistance_multiplier = 1.99;
       n_to_p_eff_curr_drv_ratio[1] = 2.23;
       gmp_to_gmn_multiplier[1] = 0.99;
-      Rnchannelon[1] = nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];
+      Rnchannelon[1] =
+          nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];
       Rpchannelon[1] = n_to_p_eff_curr_drv_ratio[1] * Rnchannelon[1];
-      long_channel_leakage_reduction[1] = 1/2.08;
+      long_channel_leakage_reduction[1] = 1 / 2.08;
       I_off_n[1][0] = 1.01e-11;
       I_off_n[1][10] = 1.65e-11;
       I_off_n[1][20] = 2.62e-11;
@@ -851,7 +848,7 @@ void init_tech_params(double technology, bool is_tag)
       I_off_n[1][90] = 3.29e-10;
       I_off_n[1][100] = 4.1e-10;
 
-      I_g_on_n[1][0]  = 9.47e-12;//A/micron
+      I_g_on_n[1][0] = 9.47e-12;  // A/micron
       I_g_on_n[1][10] = 9.47e-12;
       I_g_on_n[1][20] = 9.47e-12;
       I_g_on_n[1][30] = 9.47e-12;
@@ -863,13 +860,13 @@ void init_tech_params(double technology, bool is_tag)
       I_g_on_n[1][90] = 9.47e-12;
       I_g_on_n[1][100] = 9.47e-12;
 
-      //ITRS LOP device type
+      // ITRS LOP device type
       vdd[2] = 0.7;
       Lphy[2] = 0.022;
       Lelec[2] = 0.016;
       t_ox[2] = 0.9e-3;
       v_th[2] = 0.22599;
-      c_ox[2] = 2.82e-14;//F/micron2
+      c_ox[2] = 2.82e-14;  // F/micron2
       mobility_eff[2] = 508.9 * (1e-2 * 1e6 * 1e-2 * 1e6);
       Vdsat[2] = 5.71e-2;
       c_g_ideal[2] = 6.2e-16;
@@ -880,9 +877,10 @@ void init_tech_params(double technology, bool is_tag)
       nmos_effective_resistance_multiplier = 1.76;
       n_to_p_eff_curr_drv_ratio[2] = 2.28;
       gmp_to_gmn_multiplier[2] = 1.11;
-      Rnchannelon[2] = nmos_effective_resistance_multiplier * vdd[2] / I_on_n[2];
+      Rnchannelon[2] =
+          nmos_effective_resistance_multiplier * vdd[2] / I_on_n[2];
       Rpchannelon[2] = n_to_p_eff_curr_drv_ratio[2] * Rnchannelon[2];
-      long_channel_leakage_reduction[2] = 1/1.92;
+      long_channel_leakage_reduction[2] = 1 / 1.92;
       I_off_n[2][0] = 4.03e-9;
       I_off_n[2][10] = 5.02e-9;
       I_off_n[2][20] = 6.18e-9;
@@ -895,7 +893,7 @@ void init_tech_params(double technology, bool is_tag)
       I_off_n[2][90] = 1.84e-8;
       I_off_n[2][100] = 2.03e-8;
 
-      I_g_on_n[2][0]  = 3.24e-8;//A/micron
+      I_g_on_n[2][0] = 3.24e-8;  // A/micron
       I_g_on_n[2][10] = 4.01e-8;
       I_g_on_n[2][20] = 4.90e-8;
       I_g_on_n[2][30] = 5.92e-8;
@@ -907,29 +905,29 @@ void init_tech_params(double technology, bool is_tag)
       I_g_on_n[2][90] = 1.43e-7;
       I_g_on_n[2][100] = 1.54e-7;
 
-      if (ram_cell_tech_type == lp_dram)
-      {
-        //LP-DRAM cell access transistor technology parameters
+      if (ram_cell_tech_type == lp_dram) {
+        // LP-DRAM cell access transistor technology parameters
         curr_vdd_dram_cell = 1.1;
         Lphy[3] = 0.078;
-        Lelec[3] = 0.0504;// Assume Lelec is 30% lesser than Lphy for DRAM access and wordline transistors.
+        Lelec[3] = 0.0504;  // Assume Lelec is 30% lesser than Lphy for DRAM
+                            // access and wordline transistors.
         curr_v_th_dram_access_transistor = 0.44559;
         width_dram_access_transistor = 0.079;
-        curr_I_on_dram_cell = 36e-6;//A
+        curr_I_on_dram_cell = 36e-6;  // A
         curr_I_off_dram_cell_worst_case_length_temp = 19.5e-12;
         curr_Wmemcella_dram = width_dram_access_transistor;
         curr_Wmemcellpmos_dram = 0;
-        curr_Wmemcellnmos_dram  = 0;
+        curr_Wmemcellnmos_dram = 0;
         curr_area_cell_dram = width_dram_access_transistor * Lphy[3] * 10.0;
         curr_asp_ratio_cell_dram = 1.46;
         curr_c_dram_cell = 20e-15;
 
-        //LP-DRAM wordline transistor parameters
+        // LP-DRAM wordline transistor parameters
         curr_vpp = 1.5;
         t_ox[3] = 2.1e-3;
         v_th[3] = 0.44559;
         c_ox[3] = 1.41e-14;
-        mobility_eff[3] =   426.30 * (1e-2 * 1e6 * 1e-2 * 1e6);
+        mobility_eff[3] = 426.30 * (1e-2 * 1e6 * 1e-2 * 1e6);
         Vdsat[3] = 0.181;
         c_g_ideal[3] = 1.10e-15;
         c_fringe[3] = 0.08e-15;
@@ -939,7 +937,8 @@ void init_tech_params(double technology, bool is_tag)
         nmos_effective_resistance_multiplier = 1.65;
         n_to_p_eff_curr_drv_ratio[3] = 2.05;
         gmp_to_gmn_multiplier[3] = 0.90;
-        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
+        Rnchannelon[3] =
+            nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
         Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];
         long_channel_leakage_reduction[3] = 1;
         I_off_n[3][0] = 2.54e-11;
@@ -953,25 +952,23 @@ void init_tech_params(double technology, bool is_tag)
         I_off_n[3][80] = 4.26e-10;
         I_off_n[3][90] = 5.27e-10;
         I_off_n[3][100] = 6.46e-10;
-      }
-      else if (ram_cell_tech_type == comm_dram)
-      {
-        //COMM-DRAM cell access transistor technology parameters
+      } else if (ram_cell_tech_type == comm_dram) {
+        // COMM-DRAM cell access transistor technology parameters
         curr_vdd_dram_cell = 1.1;
         Lphy[3] = 0.045;
         Lelec[3] = 0.0298;
         curr_v_th_dram_access_transistor = 1;
         width_dram_access_transistor = 0.045;
-        curr_I_on_dram_cell = 20e-6;//A
+        curr_I_on_dram_cell = 20e-6;  // A
         curr_I_off_dram_cell_worst_case_length_temp = 1e-15;
         curr_Wmemcella_dram = width_dram_access_transistor;
         curr_Wmemcellpmos_dram = 0;
-        curr_Wmemcellnmos_dram  = 0;
-        curr_area_cell_dram = 6*0.045*0.045;
+        curr_Wmemcellnmos_dram = 0;
+        curr_area_cell_dram = 6 * 0.045 * 0.045;
         curr_asp_ratio_cell_dram = 1.5;
         curr_c_dram_cell = 30e-15;
 
-        //COMM-DRAM wordline transistor parameters
+        // COMM-DRAM wordline transistor parameters
         curr_vpp = 2.7;
         t_ox[3] = 4e-3;
         v_th[3] = 1.0;
@@ -986,7 +983,8 @@ void init_tech_params(double technology, bool is_tag)
         nmos_effective_resistance_multiplier = 1.69;
         n_to_p_eff_curr_drv_ratio[3] = 1.95;
         gmp_to_gmn_multiplier[3] = 0.90;
-        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
+        Rnchannelon[3] =
+            nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
         Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];
         long_channel_leakage_reduction[3] = 1;
         I_off_n[3][0] = 1.31e-14;
@@ -1002,34 +1000,34 @@ void init_tech_params(double technology, bool is_tag)
         I_off_n[3][100] = 3.29e-12;
       }
 
-
-      //SRAM cell properties
+      // SRAM cell properties
       curr_Wmemcella_sram = 1.31 * g_ip->F_sz_um;
       curr_Wmemcellpmos_sram = 1.23 * g_ip->F_sz_um;
       curr_Wmemcellnmos_sram = 2.08 * g_ip->F_sz_um;
       curr_area_cell_sram = 146 * g_ip->F_sz_um * g_ip->F_sz_um;
       curr_asp_ratio_cell_sram = 1.46;
-      //CAM cell properties //TODO: data need to be revisited
+      // CAM cell properties //TODO: data need to be revisited
       curr_Wmemcella_cam = 1.31 * g_ip->F_sz_um;
       curr_Wmemcellpmos_cam = 1.23 * g_ip->F_sz_um;
       curr_Wmemcellnmos_cam = 2.08 * g_ip->F_sz_um;
       curr_area_cell_cam = 292 * g_ip->F_sz_um * g_ip->F_sz_um;
       curr_asp_ratio_cell_cam = 2.92;
-      //Empirical undifferetiated core/FU coefficient
-      curr_logic_scaling_co_eff = 0.7*0.7;
-      curr_core_tx_density      = 1.25;
-      curr_sckt_co_eff           = 1.1387;
-      curr_chip_layout_overhead  = 1.2;//die measurement results based on Niagara 1 and 2
-      curr_macro_layout_overhead = 1.1;//EDA placement and routing tool rule of thumb
+      // Empirical undifferetiated core/FU coefficient
+      curr_logic_scaling_co_eff = 0.7 * 0.7;
+      curr_core_tx_density = 1.25;
+      curr_sckt_co_eff = 1.1387;
+      curr_chip_layout_overhead =
+          1.2;  // die measurement results based on Niagara 1 and 2
+      curr_macro_layout_overhead =
+          1.1;  // EDA placement and routing tool rule of thumb
     }
 
-    if (tech == 32)
-    {
-      SENSE_AMP_D = .03e-9; // s
-      SENSE_AMP_P = 2.16e-15; // J
-      //For 2013, MPU/ASIC stagger-contacted M1 half-pitch is 32 nm (so this is 32 nm
-      //technology i.e. FEATURESIZE = 0.032). Using the SOI process numbers for
-      //HP and LSTP.
+    if (tech == 32) {
+      SENSE_AMP_D = .03e-9;    // s
+      SENSE_AMP_P = 2.16e-15;  // J
+      // For 2013, MPU/ASIC stagger-contacted M1 half-pitch is 32 nm (so this is
+      // 32 nm technology i.e. FEATURESIZE = 0.032). Using the SOI process
+      // numbers for HP and LSTP.
       vdd[0] = 0.9;
       Lphy[0] = 0.013;
       Lelec[0] = 0.01013;
@@ -1041,16 +1039,19 @@ void init_tech_params(double technology, bool is_tag)
       c_g_ideal[0] = 5.34e-16;
       c_fringe[0] = 0.04e-15;
       c_junc[0] = 1e-15;
-      I_on_n[0] =  2211.7e-6;
+      I_on_n[0] = 2211.7e-6;
       I_on_p[0] = I_on_n[0] / 2;
       nmos_effective_resistance_multiplier = 1.49;
       n_to_p_eff_curr_drv_ratio[0] = 2.41;
       gmp_to_gmn_multiplier[0] = 1.38;
-      Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] / I_on_n[0];//ohm-micron
-      Rpchannelon[0] = n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];//ohm-micron
-      long_channel_leakage_reduction[0] = 1/3.706;
-      //Using MASTAR, @300K (380K does not work in MASTAR), increase Lgate until Ion reduces to 95% or Lgate increase by 5% (DG device can only increase by 5%),
-      //whichever comes first
+      Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] /
+                       I_on_n[0];  // ohm-micron
+      Rpchannelon[0] =
+          n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];  // ohm-micron
+      long_channel_leakage_reduction[0] = 1 / 3.706;
+      // Using MASTAR, @300K (380K does not work in MASTAR), increase Lgate
+      // until Ion reduces to 95% or Lgate increase by 5% (DG device can only
+      // increase by 5%), whichever comes first
       I_off_n[0][0] = 1.52e-7;
       I_off_n[0][10] = 1.55e-7;
       I_off_n[0][20] = 1.59e-7;
@@ -1063,7 +1064,7 @@ void init_tech_params(double technology, bool is_tag)
       I_off_n[0][90] = 2.73e-6;
       I_off_n[0][100] = 6.1e-6;
 
-      I_g_on_n[0][0]  = 6.55e-8;//A/micron
+      I_g_on_n[0][0] = 6.55e-8;  // A/micron
       I_g_on_n[0][10] = 6.55e-8;
       I_g_on_n[0][20] = 6.55e-8;
       I_g_on_n[0][30] = 6.55e-8;
@@ -1075,27 +1076,27 @@ void init_tech_params(double technology, bool is_tag)
       I_g_on_n[0][90] = 6.55e-8;
       I_g_on_n[0][100] = 6.55e-8;
 
-//      32 DG
-//      I_g_on_n[0][0]  = 2.71e-9;//A/micron
-//      I_g_on_n[0][10] = 2.71e-9;
-//      I_g_on_n[0][20] = 2.71e-9;
-//      I_g_on_n[0][30] = 2.71e-9;
-//      I_g_on_n[0][40] = 2.71e-9;
-//      I_g_on_n[0][50] = 2.71e-9;
-//      I_g_on_n[0][60] = 2.71e-9;
-//      I_g_on_n[0][70] = 2.71e-9;
-//      I_g_on_n[0][80] = 2.71e-9;
-//      I_g_on_n[0][90] = 2.71e-9;
-//      I_g_on_n[0][100] = 2.71e-9;
+      //      32 DG
+      //      I_g_on_n[0][0]  = 2.71e-9;//A/micron
+      //      I_g_on_n[0][10] = 2.71e-9;
+      //      I_g_on_n[0][20] = 2.71e-9;
+      //      I_g_on_n[0][30] = 2.71e-9;
+      //      I_g_on_n[0][40] = 2.71e-9;
+      //      I_g_on_n[0][50] = 2.71e-9;
+      //      I_g_on_n[0][60] = 2.71e-9;
+      //      I_g_on_n[0][70] = 2.71e-9;
+      //      I_g_on_n[0][80] = 2.71e-9;
+      //      I_g_on_n[0][90] = 2.71e-9;
+      //      I_g_on_n[0][100] = 2.71e-9;
 
-      //LSTP device type
+      // LSTP device type
       vdd[1] = 1;
       Lphy[1] = 0.020;
       Lelec[1] = 0.0173;
       t_ox[1] = 1.2e-3;
       v_th[1] = 0.513;
       c_ox[1] = 2.29e-14;
-      mobility_eff[1] =  347.46 * (1e-2 * 1e6 * 1e-2 * 1e6);
+      mobility_eff[1] = 347.46 * (1e-2 * 1e6 * 1e-2 * 1e6);
       Vdsat[1] = 8.64e-2;
       c_g_ideal[1] = 4.58e-16;
       c_fringe[1] = 0.053e-15;
@@ -1105,9 +1106,10 @@ void init_tech_params(double technology, bool is_tag)
       nmos_effective_resistance_multiplier = 1.99;
       n_to_p_eff_curr_drv_ratio[1] = 2.23;
       gmp_to_gmn_multiplier[1] = 0.99;
-      Rnchannelon[1] = nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];
+      Rnchannelon[1] =
+          nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];
       Rpchannelon[1] = n_to_p_eff_curr_drv_ratio[1] * Rnchannelon[1];
-      long_channel_leakage_reduction[1] = 1/1.93;
+      long_channel_leakage_reduction[1] = 1 / 1.93;
       I_off_n[1][0] = 2.06e-11;
       I_off_n[1][10] = 3.30e-11;
       I_off_n[1][20] = 5.15e-11;
@@ -1120,7 +1122,7 @@ void init_tech_params(double technology, bool is_tag)
       I_off_n[1][90] = 5.96e-10;
       I_off_n[1][100] = 7.44e-10;
 
-      I_g_on_n[1][0]  = 3.73e-11;//A/micron
+      I_g_on_n[1][0] = 3.73e-11;  // A/micron
       I_g_on_n[1][10] = 3.73e-11;
       I_g_on_n[1][20] = 3.73e-11;
       I_g_on_n[1][30] = 3.73e-11;
@@ -1132,15 +1134,14 @@ void init_tech_params(double technology, bool is_tag)
       I_g_on_n[1][90] = 3.73e-11;
       I_g_on_n[1][100] = 3.73e-11;
 
-
-      //LOP device type
+      // LOP device type
       vdd[2] = 0.6;
       Lphy[2] = 0.016;
       Lelec[2] = 0.01232;
       t_ox[2] = 0.9e-3;
       v_th[2] = 0.24227;
       c_ox[2] = 2.84e-14;
-      mobility_eff[2] =  513.52 * (1e-2 * 1e6 * 1e-2 * 1e6);
+      mobility_eff[2] = 513.52 * (1e-2 * 1e6 * 1e-2 * 1e6);
       Vdsat[2] = 4.64e-2;
       c_g_ideal[2] = 4.54e-16;
       c_fringe[2] = 0.057e-15;
@@ -1150,9 +1151,10 @@ void init_tech_params(double technology, bool is_tag)
       nmos_effective_resistance_multiplier = 1.73;
       n_to_p_eff_curr_drv_ratio[2] = 2.28;
       gmp_to_gmn_multiplier[2] = 1.11;
-      Rnchannelon[2] = nmos_effective_resistance_multiplier * vdd[2] / I_on_n[2];
+      Rnchannelon[2] =
+          nmos_effective_resistance_multiplier * vdd[2] / I_on_n[2];
       Rpchannelon[2] = n_to_p_eff_curr_drv_ratio[2] * Rnchannelon[2];
-      long_channel_leakage_reduction[2] = 1/1.89;
+      long_channel_leakage_reduction[2] = 1 / 1.89;
       I_off_n[2][0] = 5.94e-8;
       I_off_n[2][10] = 7.23e-8;
       I_off_n[2][20] = 8.7e-8;
@@ -1165,7 +1167,7 @@ void init_tech_params(double technology, bool is_tag)
       I_off_n[2][90] = 2.39e-7;
       I_off_n[2][100] = 2.63e-7;
 
-      I_g_on_n[2][0]  = 2.93e-9;//A/micron
+      I_g_on_n[2][0] = 2.93e-9;  // A/micron
       I_g_on_n[2][10] = 2.93e-9;
       I_g_on_n[2][20] = 2.93e-9;
       I_g_on_n[2][30] = 2.93e-9;
@@ -1177,12 +1179,12 @@ void init_tech_params(double technology, bool is_tag)
       I_g_on_n[2][90] = 2.93e-9;
       I_g_on_n[2][100] = 2.93e-9;
 
-      if (ram_cell_tech_type == lp_dram)
-      {
-        //LP-DRAM cell access transistor technology parameters
+      if (ram_cell_tech_type == lp_dram) {
+        // LP-DRAM cell access transistor technology parameters
         curr_vdd_dram_cell = 1.0;
         Lphy[3] = 0.056;
-        Lelec[3] = 0.0419;//Assume Lelec is 30% lesser than Lphy for DRAM access and wordline transistors.
+        Lelec[3] = 0.0419;  // Assume Lelec is 30% lesser than Lphy for DRAM
+                            // access and wordline transistors.
         curr_v_th_dram_access_transistor = 0.44129;
         width_dram_access_transistor = 0.056;
         curr_I_on_dram_cell = 36e-6;
@@ -1194,12 +1196,12 @@ void init_tech_params(double technology, bool is_tag)
         curr_asp_ratio_cell_dram = 1.46;
         curr_c_dram_cell = 20e-15;
 
-        //LP-DRAM wordline transistor parameters
+        // LP-DRAM wordline transistor parameters
         curr_vpp = 1.5;
         t_ox[3] = 2e-3;
         v_th[3] = 0.44467;
         c_ox[3] = 1.48e-14;
-        mobility_eff[3] =  408.12 * (1e-2 * 1e6 * 1e-2 * 1e6);
+        mobility_eff[3] = 408.12 * (1e-2 * 1e6 * 1e-2 * 1e6);
         Vdsat[3] = 0.174;
         c_g_ideal[3] = 7.45e-16;
         c_fringe[3] = 0.053e-15;
@@ -1209,10 +1211,11 @@ void init_tech_params(double technology, bool is_tag)
         nmos_effective_resistance_multiplier = 1.65;
         n_to_p_eff_curr_drv_ratio[3] = 2.05;
         gmp_to_gmn_multiplier[3] = 0.90;
-        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
+        Rnchannelon[3] =
+            nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
         Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];
         long_channel_leakage_reduction[3] = 1;
-        I_off_n[3][0]  = 3.57e-11;
+        I_off_n[3][0] = 3.57e-11;
         I_off_n[3][10] = 5.51e-11;
         I_off_n[3][20] = 8.27e-11;
         I_off_n[3][30] = 1.21e-10;
@@ -1223,13 +1226,12 @@ void init_tech_params(double technology, bool is_tag)
         I_off_n[3][80] = 5.87e-10;
         I_off_n[3][90] = 7.29e-10;
         I_off_n[3][100] = 8.87e-10;
-      }
-      else if (ram_cell_tech_type == comm_dram)
-      {
-        //COMM-DRAM cell access transistor technology parameters
+      } else if (ram_cell_tech_type == comm_dram) {
+        // COMM-DRAM cell access transistor technology parameters
         curr_vdd_dram_cell = 1.0;
         Lphy[3] = 0.032;
-        Lelec[3] = 0.0205;//Assume Lelec is 30% lesser than Lphy for DRAM access and wordline transistors.
+        Lelec[3] = 0.0205;  // Assume Lelec is 30% lesser than Lphy for DRAM
+                            // access and wordline transistors.
         curr_v_th_dram_access_transistor = 1;
         width_dram_access_transistor = 0.032;
         curr_I_on_dram_cell = 20e-6;
@@ -1237,16 +1239,16 @@ void init_tech_params(double technology, bool is_tag)
         curr_Wmemcella_dram = width_dram_access_transistor;
         curr_Wmemcellpmos_dram = 0;
         curr_Wmemcellnmos_dram = 0;
-        curr_area_cell_dram = 6*0.032*0.032;
+        curr_area_cell_dram = 6 * 0.032 * 0.032;
         curr_asp_ratio_cell_dram = 1.5;
         curr_c_dram_cell = 30e-15;
 
-        //COMM-DRAM wordline transistor parameters
+        // COMM-DRAM wordline transistor parameters
         curr_vpp = 2.6;
         t_ox[3] = 4e-3;
         v_th[3] = 1.0;
         c_ox[3] = 7.99e-15;
-        mobility_eff[3] =  380.76 * (1e-2 * 1e6 * 1e-2 * 1e6);
+        mobility_eff[3] = 380.76 * (1e-2 * 1e6 * 1e-2 * 1e6);
         Vdsat[3] = 0.129;
         c_g_ideal[3] = 2.56e-16;
         c_fringe[3] = 0.053e-15;
@@ -1256,10 +1258,11 @@ void init_tech_params(double technology, bool is_tag)
         nmos_effective_resistance_multiplier = 1.69;
         n_to_p_eff_curr_drv_ratio[3] = 1.95;
         gmp_to_gmn_multiplier[3] = 0.90;
-        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
+        Rnchannelon[3] =
+            nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
         Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];
         long_channel_leakage_reduction[3] = 1;
-        I_off_n[3][0]  = 3.63e-14;
+        I_off_n[3][0] = 3.63e-14;
         I_off_n[3][10] = 7.18e-14;
         I_off_n[3][20] = 1.36e-13;
         I_off_n[3][30] = 2.49e-13;
@@ -1272,550 +1275,612 @@ void init_tech_params(double technology, bool is_tag)
         I_off_n[3][100] = 7.16e-12;
       }
 
-      //SRAM cell properties
-      curr_Wmemcella_sram    = 1.31 * g_ip->F_sz_um;
+      // SRAM cell properties
+      curr_Wmemcella_sram = 1.31 * g_ip->F_sz_um;
       curr_Wmemcellpmos_sram = 1.23 * g_ip->F_sz_um;
       curr_Wmemcellnmos_sram = 2.08 * g_ip->F_sz_um;
-      curr_area_cell_sram    = 146 * g_ip->F_sz_um * g_ip->F_sz_um;
+      curr_area_cell_sram = 146 * g_ip->F_sz_um * g_ip->F_sz_um;
       curr_asp_ratio_cell_sram = 1.46;
-      //CAM cell properties //TODO: data need to be revisited
+      // CAM cell properties //TODO: data need to be revisited
       curr_Wmemcella_cam = 1.31 * g_ip->F_sz_um;
       curr_Wmemcellpmos_cam = 1.23 * g_ip->F_sz_um;
       curr_Wmemcellnmos_cam = 2.08 * g_ip->F_sz_um;
       curr_area_cell_cam = 292 * g_ip->F_sz_um * g_ip->F_sz_um;
       curr_asp_ratio_cell_cam = 2.92;
-      //Empirical undifferetiated core/FU coefficient
-      curr_logic_scaling_co_eff = 0.7*0.7*0.7;
-      curr_core_tx_density      = 1.25/0.7;
-      curr_sckt_co_eff           = 1.1111;
-      curr_chip_layout_overhead  = 1.2;//die measurement results based on Niagara 1 and 2
-      curr_macro_layout_overhead = 1.1;//EDA placement and routing tool rule of thumb
+      // Empirical undifferetiated core/FU coefficient
+      curr_logic_scaling_co_eff = 0.7 * 0.7 * 0.7;
+      curr_core_tx_density = 1.25 / 0.7;
+      curr_sckt_co_eff = 1.1111;
+      curr_chip_layout_overhead =
+          1.2;  // die measurement results based on Niagara 1 and 2
+      curr_macro_layout_overhead =
+          1.1;  // EDA placement and routing tool rule of thumb
     }
 
-    if(tech == 22){
-    	//For 2016, MPU/ASIC stagger-contacted M1 half-pitch is 22 nm (so this is 22 nm
-    	//technology i.e. FEATURESIZE = 0.022). Using the DG process numbers for HP.
-    	//22 nm HP
-    	vdd[0] = 0.8;
-    	Lphy[0] = 0.009;//Lphy is the physical gate-length.
-    	Lelec[0] = 0.00468;//Lelec is the electrical gate-length.
-    	t_ox[0] = 0.55e-3;//micron
-    	v_th[0] = 0.1395;//V
-    	c_ox[0] = 3.63e-14;//F/micron2
-    	mobility_eff[0] = 426.07 * (1e-2 * 1e6 * 1e-2 * 1e6); //micron2 / Vs
-    	Vdsat[0] = 2.33e-2; //V/micron
-    	c_g_ideal[0] = 3.27e-16;//F/micron
-    	c_fringe[0] = 0.06e-15;//F/micron
-    	c_junc[0] = 0;//F/micron2
-    	I_on_n[0] =  2626.4e-6;//A/micron
-    	I_on_p[0] = I_on_n[0] / 2;//A/micron //This value for I_on_p is not really used.
-        nmos_effective_resistance_multiplier = 1.45;
-        n_to_p_eff_curr_drv_ratio[0] = 2; //Wpmos/Wnmos = 2 in 2007 MASTAR. Look in
-    	//"Dynamic" tab of Device workspace.
-        gmp_to_gmn_multiplier[0] = 1.38; //Just using the 32nm SOI value.
-        Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] / I_on_n[0];//ohm-micron
-        Rpchannelon[0] = n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];//ohm-micron
-        long_channel_leakage_reduction[0] = 1/3.274;
-        I_off_n[0][0] = 1.52e-7/1.5*1.2;//From 22nm, leakage current are directly from ITRS report rather than MASTAR, since MASTAR has serious bugs there.
-        I_off_n[0][10] = 1.55e-7/1.5*1.2;
-        I_off_n[0][20] = 1.59e-7/1.5*1.2;
-        I_off_n[0][30] = 1.68e-7/1.5*1.2;
-        I_off_n[0][40] = 1.90e-7/1.5*1.2;
-        I_off_n[0][50] = 2.69e-7/1.5*1.2;
-        I_off_n[0][60] = 5.32e-7/1.5*1.2;
-        I_off_n[0][70] = 1.02e-6/1.5*1.2;
-        I_off_n[0][80] = 1.62e-6/1.5*1.2;
-        I_off_n[0][90] = 2.73e-6/1.5*1.2;
-        I_off_n[0][100] = 6.1e-6/1.5*1.2;
-        //for 22nm DG HP
-        I_g_on_n[0][0]  = 1.81e-9;//A/micron
-        I_g_on_n[0][10] = 1.81e-9;
-        I_g_on_n[0][20] = 1.81e-9;
-        I_g_on_n[0][30] = 1.81e-9;
-        I_g_on_n[0][40] = 1.81e-9;
-        I_g_on_n[0][50] = 1.81e-9;
-        I_g_on_n[0][60] = 1.81e-9;
-        I_g_on_n[0][70] = 1.81e-9;
-        I_g_on_n[0][80] = 1.81e-9;
-        I_g_on_n[0][90] = 1.81e-9;
-        I_g_on_n[0][100] = 1.81e-9;
+    if (tech == 22) {
+      // For 2016, MPU/ASIC stagger-contacted M1 half-pitch is 22 nm (so this is
+      // 22 nm technology i.e. FEATURESIZE = 0.022). Using the DG process
+      // numbers for HP. 22 nm HP
+      vdd[0] = 0.8;
+      Lphy[0] = 0.009;     // Lphy is the physical gate-length.
+      Lelec[0] = 0.00468;  // Lelec is the electrical gate-length.
+      t_ox[0] = 0.55e-3;   // micron
+      v_th[0] = 0.1395;    // V
+      c_ox[0] = 3.63e-14;  // F/micron2
+      mobility_eff[0] = 426.07 * (1e-2 * 1e6 * 1e-2 * 1e6);  // micron2 / Vs
+      Vdsat[0] = 2.33e-2;                                    // V/micron
+      c_g_ideal[0] = 3.27e-16;                               // F/micron
+      c_fringe[0] = 0.06e-15;                                // F/micron
+      c_junc[0] = 0;                                         // F/micron2
+      I_on_n[0] = 2626.4e-6;                                 // A/micron
+      I_on_p[0] = I_on_n[0] /
+                  2;  // A/micron //This value for I_on_p is not really used.
+      nmos_effective_resistance_multiplier = 1.45;
+      n_to_p_eff_curr_drv_ratio[0] =
+          2;  // Wpmos/Wnmos = 2 in 2007 MASTAR. Look in
+      //"Dynamic" tab of Device workspace.
+      gmp_to_gmn_multiplier[0] = 1.38;  // Just using the 32nm SOI value.
+      Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] /
+                       I_on_n[0];  // ohm-micron
+      Rpchannelon[0] =
+          n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];  // ohm-micron
+      long_channel_leakage_reduction[0] = 1 / 3.274;
+      I_off_n[0][0] =
+          1.52e-7 / 1.5 *
+          1.2;  // From 22nm, leakage current are directly from ITRS report
+                // rather than MASTAR, since MASTAR has serious bugs there.
+      I_off_n[0][10] = 1.55e-7 / 1.5 * 1.2;
+      I_off_n[0][20] = 1.59e-7 / 1.5 * 1.2;
+      I_off_n[0][30] = 1.68e-7 / 1.5 * 1.2;
+      I_off_n[0][40] = 1.90e-7 / 1.5 * 1.2;
+      I_off_n[0][50] = 2.69e-7 / 1.5 * 1.2;
+      I_off_n[0][60] = 5.32e-7 / 1.5 * 1.2;
+      I_off_n[0][70] = 1.02e-6 / 1.5 * 1.2;
+      I_off_n[0][80] = 1.62e-6 / 1.5 * 1.2;
+      I_off_n[0][90] = 2.73e-6 / 1.5 * 1.2;
+      I_off_n[0][100] = 6.1e-6 / 1.5 * 1.2;
+      // for 22nm DG HP
+      I_g_on_n[0][0] = 1.81e-9;  // A/micron
+      I_g_on_n[0][10] = 1.81e-9;
+      I_g_on_n[0][20] = 1.81e-9;
+      I_g_on_n[0][30] = 1.81e-9;
+      I_g_on_n[0][40] = 1.81e-9;
+      I_g_on_n[0][50] = 1.81e-9;
+      I_g_on_n[0][60] = 1.81e-9;
+      I_g_on_n[0][70] = 1.81e-9;
+      I_g_on_n[0][80] = 1.81e-9;
+      I_g_on_n[0][90] = 1.81e-9;
+      I_g_on_n[0][100] = 1.81e-9;
 
-    	//22 nm LSTP DG
-    	vdd[1] = 0.8;
-    	Lphy[1] = 0.014;
-    	Lelec[1] = 0.008;//Lelec is the electrical gate-length.
-    	t_ox[1] = 1.1e-3;//micron
-    	v_th[1] = 0.40126;//V
-    	c_ox[1] = 2.30e-14;//F/micron2
-    	mobility_eff[1] =  738.09 * (1e-2 * 1e6 * 1e-2 * 1e6); //micron2 / Vs
-    	Vdsat[1] = 6.64e-2; //V/micron
-    	c_g_ideal[1] = 3.22e-16;//F/micron
-    	c_fringe[1] = 0.08e-15;
-    	c_junc[1] = 0;//F/micron2
-    	I_on_n[1] = 727.6e-6;//A/micron
-    	I_on_p[1] = I_on_n[1] / 2;
-    	nmos_effective_resistance_multiplier = 1.99;
-    	n_to_p_eff_curr_drv_ratio[1] = 2;
-    	gmp_to_gmn_multiplier[1] = 0.99;
-    	Rnchannelon[1] = nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];//ohm-micron
-    	Rpchannelon[1] = n_to_p_eff_curr_drv_ratio[1] * Rnchannelon[1];//ohm-micron
-    	long_channel_leakage_reduction[1] = 1/1.89;
-    	I_off_n[1][0] = 2.43e-11;
-    	I_off_n[1][10] = 4.85e-11;
-    	I_off_n[1][20] = 9.68e-11;
-    	I_off_n[1][30] = 1.94e-10;
-    	I_off_n[1][40] = 3.87e-10;
-    	I_off_n[1][50] = 7.73e-10;
-    	I_off_n[1][60] = 3.55e-10;
-    	I_off_n[1][70] = 3.09e-9;
-    	I_off_n[1][80] = 6.19e-9;
-    	I_off_n[1][90] = 1.24e-8;
-    	I_off_n[1][100]= 2.48e-8;
+      // 22 nm LSTP DG
+      vdd[1] = 0.8;
+      Lphy[1] = 0.014;
+      Lelec[1] = 0.008;    // Lelec is the electrical gate-length.
+      t_ox[1] = 1.1e-3;    // micron
+      v_th[1] = 0.40126;   // V
+      c_ox[1] = 2.30e-14;  // F/micron2
+      mobility_eff[1] = 738.09 * (1e-2 * 1e6 * 1e-2 * 1e6);  // micron2 / Vs
+      Vdsat[1] = 6.64e-2;                                    // V/micron
+      c_g_ideal[1] = 3.22e-16;                               // F/micron
+      c_fringe[1] = 0.08e-15;
+      c_junc[1] = 0;         // F/micron2
+      I_on_n[1] = 727.6e-6;  // A/micron
+      I_on_p[1] = I_on_n[1] / 2;
+      nmos_effective_resistance_multiplier = 1.99;
+      n_to_p_eff_curr_drv_ratio[1] = 2;
+      gmp_to_gmn_multiplier[1] = 0.99;
+      Rnchannelon[1] = nmos_effective_resistance_multiplier * vdd[1] /
+                       I_on_n[1];  // ohm-micron
+      Rpchannelon[1] =
+          n_to_p_eff_curr_drv_ratio[1] * Rnchannelon[1];  // ohm-micron
+      long_channel_leakage_reduction[1] = 1 / 1.89;
+      I_off_n[1][0] = 2.43e-11;
+      I_off_n[1][10] = 4.85e-11;
+      I_off_n[1][20] = 9.68e-11;
+      I_off_n[1][30] = 1.94e-10;
+      I_off_n[1][40] = 3.87e-10;
+      I_off_n[1][50] = 7.73e-10;
+      I_off_n[1][60] = 3.55e-10;
+      I_off_n[1][70] = 3.09e-9;
+      I_off_n[1][80] = 6.19e-9;
+      I_off_n[1][90] = 1.24e-8;
+      I_off_n[1][100] = 2.48e-8;
 
-    	I_g_on_n[1][0]  = 4.51e-10;//A/micron
-    	I_g_on_n[1][10] = 4.51e-10;
-    	I_g_on_n[1][20] = 4.51e-10;
-    	I_g_on_n[1][30] = 4.51e-10;
-    	I_g_on_n[1][40] = 4.51e-10;
-    	I_g_on_n[1][50] = 4.51e-10;
-    	I_g_on_n[1][60] = 4.51e-10;
-    	I_g_on_n[1][70] = 4.51e-10;
-    	I_g_on_n[1][80] = 4.51e-10;
-    	I_g_on_n[1][90] = 4.51e-10;
-    	I_g_on_n[1][100] = 4.51e-10;
+      I_g_on_n[1][0] = 4.51e-10;  // A/micron
+      I_g_on_n[1][10] = 4.51e-10;
+      I_g_on_n[1][20] = 4.51e-10;
+      I_g_on_n[1][30] = 4.51e-10;
+      I_g_on_n[1][40] = 4.51e-10;
+      I_g_on_n[1][50] = 4.51e-10;
+      I_g_on_n[1][60] = 4.51e-10;
+      I_g_on_n[1][70] = 4.51e-10;
+      I_g_on_n[1][80] = 4.51e-10;
+      I_g_on_n[1][90] = 4.51e-10;
+      I_g_on_n[1][100] = 4.51e-10;
 
-    	//22 nm LOP
-    	vdd[2] = 0.6;
-    	Lphy[2] = 0.011;
-    	Lelec[2] = 0.00604;//Lelec is the electrical gate-length.
-    	t_ox[2] = 0.8e-3;//micron
-    	v_th[2] = 0.2315;//V
-    	c_ox[2] = 2.87e-14;//F/micron2
-    	mobility_eff[2] =  698.37 * (1e-2 * 1e6 * 1e-2 * 1e6); //micron2 / Vs
-    	Vdsat[2] = 1.81e-2; //V/micron
-    	c_g_ideal[2] = 3.16e-16;//F/micron
-    	c_fringe[2] = 0.08e-15;
-    	c_junc[2] = 0;//F/micron2 This is Cj0 not Cjunc in MASTAR results->Dynamic Tab
-    	I_on_n[2] = 916.1e-6;//A/micron
-    	I_on_p[2] = I_on_n[2] / 2;
-    	nmos_effective_resistance_multiplier = 1.73;
-    	n_to_p_eff_curr_drv_ratio[2] = 2;
-    	gmp_to_gmn_multiplier[2] = 1.11;
-    	Rnchannelon[2] = nmos_effective_resistance_multiplier * vdd[2] / I_on_n[2];//ohm-micron
-    	Rpchannelon[2] = n_to_p_eff_curr_drv_ratio[2] * Rnchannelon[2];//ohm-micron
-    	long_channel_leakage_reduction[2] = 1/2.38;
+      // 22 nm LOP
+      vdd[2] = 0.6;
+      Lphy[2] = 0.011;
+      Lelec[2] = 0.00604;  // Lelec is the electrical gate-length.
+      t_ox[2] = 0.8e-3;    // micron
+      v_th[2] = 0.2315;    // V
+      c_ox[2] = 2.87e-14;  // F/micron2
+      mobility_eff[2] = 698.37 * (1e-2 * 1e6 * 1e-2 * 1e6);  // micron2 / Vs
+      Vdsat[2] = 1.81e-2;                                    // V/micron
+      c_g_ideal[2] = 3.16e-16;                               // F/micron
+      c_fringe[2] = 0.08e-15;
+      c_junc[2] =
+          0;  // F/micron2 This is Cj0 not Cjunc in MASTAR results->Dynamic Tab
+      I_on_n[2] = 916.1e-6;  // A/micron
+      I_on_p[2] = I_on_n[2] / 2;
+      nmos_effective_resistance_multiplier = 1.73;
+      n_to_p_eff_curr_drv_ratio[2] = 2;
+      gmp_to_gmn_multiplier[2] = 1.11;
+      Rnchannelon[2] = nmos_effective_resistance_multiplier * vdd[2] /
+                       I_on_n[2];  // ohm-micron
+      Rpchannelon[2] =
+          n_to_p_eff_curr_drv_ratio[2] * Rnchannelon[2];  // ohm-micron
+      long_channel_leakage_reduction[2] = 1 / 2.38;
 
-    	I_off_n[2][0] = 1.31e-8;
-    	I_off_n[2][10] = 2.60e-8;
-    	I_off_n[2][20] = 5.14e-8;
-    	I_off_n[2][30] = 1.02e-7;
-    	I_off_n[2][40] = 2.02e-7;
-    	I_off_n[2][50] = 3.99e-7;
-    	I_off_n[2][60] = 7.91e-7;
-    	I_off_n[2][70] = 1.09e-6;
-    	I_off_n[2][80] = 2.09e-6;
-    	I_off_n[2][90] = 4.04e-6;
-    	I_off_n[2][100]= 4.48e-6;
+      I_off_n[2][0] = 1.31e-8;
+      I_off_n[2][10] = 2.60e-8;
+      I_off_n[2][20] = 5.14e-8;
+      I_off_n[2][30] = 1.02e-7;
+      I_off_n[2][40] = 2.02e-7;
+      I_off_n[2][50] = 3.99e-7;
+      I_off_n[2][60] = 7.91e-7;
+      I_off_n[2][70] = 1.09e-6;
+      I_off_n[2][80] = 2.09e-6;
+      I_off_n[2][90] = 4.04e-6;
+      I_off_n[2][100] = 4.48e-6;
 
-    	I_g_on_n[2][0]  = 2.74e-9;//A/micron
-    	I_g_on_n[2][10] = 2.74e-9;
-    	I_g_on_n[2][20] = 2.74e-9;
-    	I_g_on_n[2][30] = 2.74e-9;
-    	I_g_on_n[2][40] = 2.74e-9;
-    	I_g_on_n[2][50] = 2.74e-9;
-    	I_g_on_n[2][60] = 2.74e-9;
-    	I_g_on_n[2][70] = 2.74e-9;
-    	I_g_on_n[2][80] = 2.74e-9;
-    	I_g_on_n[2][90] = 2.74e-9;
-    	I_g_on_n[2][100] = 2.74e-9;
+      I_g_on_n[2][0] = 2.74e-9;  // A/micron
+      I_g_on_n[2][10] = 2.74e-9;
+      I_g_on_n[2][20] = 2.74e-9;
+      I_g_on_n[2][30] = 2.74e-9;
+      I_g_on_n[2][40] = 2.74e-9;
+      I_g_on_n[2][50] = 2.74e-9;
+      I_g_on_n[2][60] = 2.74e-9;
+      I_g_on_n[2][70] = 2.74e-9;
+      I_g_on_n[2][80] = 2.74e-9;
+      I_g_on_n[2][90] = 2.74e-9;
+      I_g_on_n[2][100] = 2.74e-9;
 
+      if (ram_cell_tech_type == 3) {
+      } else if (ram_cell_tech_type == 4) {
+        // 22 nm commodity DRAM cell access transistor technology parameters.
+        // parameters
+        curr_vdd_dram_cell = 0.9;  // 0.45;//This value has reduced greatly in
+                                   // 2007 ITRS for all technology nodes. In
+        // 2005 ITRS, the value was about twice the value in 2007 ITRS
+        Lphy[3] = 0.022;                       // micron
+        Lelec[3] = 0.0181;                     // micron.
+        curr_v_th_dram_access_transistor = 1;  // V
+        width_dram_access_transistor = 0.022;  // micron
+        curr_I_on_dram_cell =
+            20e-6;  // This is a typical value that I have always
+        // kept constant. In reality this could perhaps be lower
+        curr_I_off_dram_cell_worst_case_length_temp = 1e-15;  // A
+        curr_Wmemcella_dram = width_dram_access_transistor;
+        curr_Wmemcellpmos_dram = 0;
+        curr_Wmemcellnmos_dram = 0;
+        curr_area_cell_dram = 6 * 0.022 * 0.022;  // micron2.
+        curr_asp_ratio_cell_dram = 0.667;
+        curr_c_dram_cell = 30e-15;  // This is a typical value that I have
+                                    // alwaus
+        // kept constant.
 
+        // 22 nm commodity DRAM wordline transistor parameters obtained using
+        // MASTAR.
+        curr_vpp = 2.3;                                        // vpp. V
+        t_ox[3] = 3.5e-3;                                      // micron
+        v_th[3] = 1.0;                                         // V
+        c_ox[3] = 9.06e-15;                                    // F/micron2
+        mobility_eff[3] = 367.29 * (1e-2 * 1e6 * 1e-2 * 1e6);  // micron2 / Vs
+        Vdsat[3] = 0.0972;                                     // V/micron
+        c_g_ideal[3] = 1.99e-16;                               // F/micron
+        c_fringe[3] = 0.053e-15;                               // F/micron
+        c_junc[3] = 1e-15;                                     // F/micron2
+        I_on_n[3] = 910.5e-6;                                  // A/micron
+        I_on_p[3] = I_on_n[3] / 2;  // This value for I_on_p is not really used.
+        nmos_effective_resistance_multiplier =
+            1.69;  // Using the value from 32nm.
+        //
+        n_to_p_eff_curr_drv_ratio[3] = 1.95;  // Using the value from 32nm
+        gmp_to_gmn_multiplier[3] = 0.90;
+        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp /
+                         I_on_n[3];  // ohm-micron
+        Rpchannelon[3] =
+            n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];  // ohm-micron
+        long_channel_leakage_reduction[3] = 1;
+        I_off_n[3][0] = 1.1e-13;  // A/micron
+        I_off_n[3][10] = 2.11e-13;
+        I_off_n[3][20] = 3.88e-13;
+        I_off_n[3][30] = 6.9e-13;
+        I_off_n[3][40] = 1.19e-12;
+        I_off_n[3][50] = 1.98e-12;
+        I_off_n[3][60] = 3.22e-12;
+        I_off_n[3][70] = 5.09e-12;
+        I_off_n[3][80] = 7.85e-12;
+        I_off_n[3][90] = 1.18e-11;
+        I_off_n[3][100] = 1.72e-11;
 
-        if (ram_cell_tech_type == 3)
-              {}
-        else if (ram_cell_tech_type == 4)
-        {
-    	//22 nm commodity DRAM cell access transistor technology parameters.
-    		//parameters
-        	curr_vdd_dram_cell = 0.9;//0.45;//This value has reduced greatly in 2007 ITRS for all technology nodes. In
-    		//2005 ITRS, the value was about twice the value in 2007 ITRS
-    		Lphy[3] = 0.022;//micron
-    		Lelec[3] = 0.0181;//micron.
-    		curr_v_th_dram_access_transistor = 1;//V
-    		width_dram_access_transistor = 0.022;//micron
-    		curr_I_on_dram_cell = 20e-6; //This is a typical value that I have always
-    		//kept constant. In reality this could perhaps be lower
-    		curr_I_off_dram_cell_worst_case_length_temp = 1e-15;//A
-    		curr_Wmemcella_dram = width_dram_access_transistor;
-    		curr_Wmemcellpmos_dram = 0;
-    		curr_Wmemcellnmos_dram = 0;
-    		curr_area_cell_dram = 6*0.022*0.022;//micron2.
-    		curr_asp_ratio_cell_dram = 0.667;
-    		curr_c_dram_cell = 30e-15;//This is a typical value that I have alwaus
-    		//kept constant.
+      } else {
+        // some error handler
+      }
 
-    	//22 nm commodity DRAM wordline transistor parameters obtained using MASTAR.
-    		curr_vpp = 2.3;//vpp. V
-    		t_ox[3] = 3.5e-3;//micron
-    		v_th[3] = 1.0;//V
-    		c_ox[3] = 9.06e-15;//F/micron2
-    		mobility_eff[3] =  367.29 * (1e-2 * 1e6 * 1e-2 * 1e6);//micron2 / Vs
-    		Vdsat[3] = 0.0972; //V/micron
-    		c_g_ideal[3] = 1.99e-16;//F/micron
-    		c_fringe[3] = 0.053e-15;//F/micron
-    		c_junc[3] = 1e-15;//F/micron2
-    		I_on_n[3] = 910.5e-6;//A/micron
-    		I_on_p[3] = I_on_n[3] / 2;//This value for I_on_p is not really used.
-    		nmos_effective_resistance_multiplier = 1.69;//Using the value from 32nm.
-    		//
-    		n_to_p_eff_curr_drv_ratio[3] = 1.95;//Using the value from 32nm
-    		gmp_to_gmn_multiplier[3] = 0.90;
-    		Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp  / I_on_n[3];//ohm-micron
-    		Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];//ohm-micron
-    		long_channel_leakage_reduction[3] = 1;
-    		I_off_n[3][0] = 1.1e-13; //A/micron
-    		I_off_n[3][10] = 2.11e-13;
-    		I_off_n[3][20] = 3.88e-13;
-    		I_off_n[3][30] = 6.9e-13;
-    		I_off_n[3][40] = 1.19e-12;
-    		I_off_n[3][50] = 1.98e-12;
-    		I_off_n[3][60] = 3.22e-12;
-    		I_off_n[3][70] = 5.09e-12;
-    		I_off_n[3][80] = 7.85e-12;
-    		I_off_n[3][90] = 1.18e-11;
-    		I_off_n[3][100] = 1.72e-11;
+      // SRAM cell properties
+      curr_Wmemcella_sram = 1.31 * g_ip->F_sz_um;
+      curr_Wmemcellpmos_sram = 1.23 * g_ip->F_sz_um;
+      curr_Wmemcellnmos_sram = 2.08 * g_ip->F_sz_um;
+      curr_area_cell_sram = 146 * g_ip->F_sz_um * g_ip->F_sz_um;
+      curr_asp_ratio_cell_sram = 1.46;
+      // CAM cell properties //TODO: data need to be revisited
+      curr_Wmemcella_cam = 1.31 * g_ip->F_sz_um;
+      curr_Wmemcellpmos_cam = 1.23 * g_ip->F_sz_um;
+      curr_Wmemcellnmos_cam = 2.08 * g_ip->F_sz_um;
+      curr_area_cell_cam = 292 * g_ip->F_sz_um * g_ip->F_sz_um;
+      curr_asp_ratio_cell_cam = 2.92;
+      // Empirical undifferetiated core/FU coefficient
+      curr_logic_scaling_co_eff = 0.7 * 0.7 * 0.7 * 0.7;
+      curr_core_tx_density = 1.25 / 0.7 / 0.7;
+      curr_sckt_co_eff = 1.1296;
+      curr_chip_layout_overhead =
+          1.2;  // die measurement results based on Niagara 1 and 2
+      curr_macro_layout_overhead =
+          1.1;  // EDA placement and routing tool rule of thumb
+    }
 
-    	}
-        else
-        {
-      	  //some error handler
-        }
+    if (tech == 16) {
+      // For 2019, MPU/ASIC stagger-contacted M1 half-pitch is 16 nm (so this is
+      // 16 nm technology i.e. FEATURESIZE = 0.016). Using the DG process
+      // numbers for HP. 16 nm HP
+      vdd[0] = 0.7;
+      Lphy[0] = 0.006;     // Lphy is the physical gate-length.
+      Lelec[0] = 0.00315;  // Lelec is the electrical gate-length.
+      t_ox[0] = 0.5e-3;    // micron
+      v_th[0] = 0.1489;    // V
+      c_ox[0] = 3.83e-14;  // F/micron2 Cox_elec in MASTAR
+      mobility_eff[0] = 476.15 * (1e-2 * 1e6 * 1e-2 * 1e6);  // micron2 / Vs
+      Vdsat[0] = 1.42e-2;       // V/micron calculated in spreadsheet
+      c_g_ideal[0] = 2.30e-16;  // F/micron
+      c_fringe[0] = 0.06e-15;   // F/micron MASTAR inputdynamic/3
+      c_junc[0] = 0;            // F/micron2 MASTAR result dynamic
+      I_on_n[0] = 2768.4e-6;    // A/micron
+      I_on_p[0] = I_on_n[0] /
+                  2;  // A/micron //This value for I_on_p is not really used.
+      nmos_effective_resistance_multiplier =
+          1.48;  // nmos_effective_resistance_multiplier  is the ratio of Ieff
+                 // to Idsat where Ieff is the effective NMOS current and Idsat
+                 // is the saturation current.
+      n_to_p_eff_curr_drv_ratio[0] =
+          2;  // Wpmos/Wnmos = 2 in 2007 MASTAR. Look in
+      //"Dynamic" tab of Device workspace.
+      gmp_to_gmn_multiplier[0] = 1.38;  // Just using the 32nm SOI value.
+      Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] /
+                       I_on_n[0];  // ohm-micron
+      Rpchannelon[0] =
+          n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];  // ohm-micron
+      long_channel_leakage_reduction[0] = 1 / 2.655;
+      I_off_n[0][0] = 1.52e-7 / 1.5 * 1.2 * 1.07;
+      I_off_n[0][10] = 1.55e-7 / 1.5 * 1.2 * 1.07;
+      I_off_n[0][20] = 1.59e-7 / 1.5 * 1.2 * 1.07;
+      I_off_n[0][30] = 1.68e-7 / 1.5 * 1.2 * 1.07;
+      I_off_n[0][40] = 1.90e-7 / 1.5 * 1.2 * 1.07;
+      I_off_n[0][50] = 2.69e-7 / 1.5 * 1.2 * 1.07;
+      I_off_n[0][60] = 5.32e-7 / 1.5 * 1.2 * 1.07;
+      I_off_n[0][70] = 1.02e-6 / 1.5 * 1.2 * 1.07;
+      I_off_n[0][80] = 1.62e-6 / 1.5 * 1.2 * 1.07;
+      I_off_n[0][90] = 2.73e-6 / 1.5 * 1.2 * 1.07;
+      I_off_n[0][100] = 6.1e-6 / 1.5 * 1.2 * 1.07;
+      // for 16nm DG HP
+      I_g_on_n[0][0] = 1.07e-9;  // A/micron
+      I_g_on_n[0][10] = 1.07e-9;
+      I_g_on_n[0][20] = 1.07e-9;
+      I_g_on_n[0][30] = 1.07e-9;
+      I_g_on_n[0][40] = 1.07e-9;
+      I_g_on_n[0][50] = 1.07e-9;
+      I_g_on_n[0][60] = 1.07e-9;
+      I_g_on_n[0][70] = 1.07e-9;
+      I_g_on_n[0][80] = 1.07e-9;
+      I_g_on_n[0][90] = 1.07e-9;
+      I_g_on_n[0][100] = 1.07e-9;
 
-        //SRAM cell properties
-        curr_Wmemcella_sram    = 1.31 * g_ip->F_sz_um;
-        curr_Wmemcellpmos_sram = 1.23 * g_ip->F_sz_um;
-        curr_Wmemcellnmos_sram = 2.08 * g_ip->F_sz_um;
-        curr_area_cell_sram    = 146 * g_ip->F_sz_um * g_ip->F_sz_um;
-        curr_asp_ratio_cell_sram = 1.46;
-        //CAM cell properties //TODO: data need to be revisited
-        curr_Wmemcella_cam = 1.31 * g_ip->F_sz_um;
-        curr_Wmemcellpmos_cam = 1.23 * g_ip->F_sz_um;
-        curr_Wmemcellnmos_cam = 2.08 * g_ip->F_sz_um;
-        curr_area_cell_cam = 292 * g_ip->F_sz_um * g_ip->F_sz_um;
-        curr_asp_ratio_cell_cam = 2.92;
-        //Empirical undifferetiated core/FU coefficient
-        curr_logic_scaling_co_eff = 0.7*0.7*0.7*0.7;
-        curr_core_tx_density      = 1.25/0.7/0.7;
-        curr_sckt_co_eff           = 1.1296;
-        curr_chip_layout_overhead  = 1.2;//die measurement results based on Niagara 1 and 2
-        curr_macro_layout_overhead = 1.1;//EDA placement and routing tool rule of thumb
-    	}
+      //    	//16 nm LSTP DG
+      //    	vdd[1] = 0.8;
+      //    	Lphy[1] = 0.014;
+      //    	Lelec[1] = 0.008;//Lelec is the electrical gate-length.
+      //    	t_ox[1] = 1.1e-3;//micron
+      //    	v_th[1] = 0.40126;//V
+      //    	c_ox[1] = 2.30e-14;//F/micron2
+      //    	mobility_eff[1] =  738.09 * (1e-2 * 1e6 * 1e-2 * 1e6); //micron2
+      //    / Vs 	Vdsat[1] = 6.64e-2; //V/micron 	c_g_ideal[1]
+      //    = 3.22e-16;//F/micron 	c_fringe[1] = 0.008e-15; c_junc[1]
+      //    =
+      //    0;//F/micron2 	I_on_n[1] = 727.6e-6;//A/micron 	I_on_p[1]
+      //    = I_on_n[1] / 2; 	nmos_effective_resistance_multiplier = 1.99;
+      //    	n_to_p_eff_curr_drv_ratio[1] = 2;
+      //    	gmp_to_gmn_multiplier[1] = 0.99;
+      //    	Rnchannelon[1] = nmos_effective_resistance_multiplier * vdd[1] /
+      //    I_on_n[1];//ohm-micron 	Rpchannelon[1] =
+      //    n_to_p_eff_curr_drv_ratio[1]
+      //    * Rnchannelon[1];//ohm-micron 	I_off_n[1][0] = 2.43e-11;
+      //    	I_off_n[1][10] = 4.85e-11;
+      //    	I_off_n[1][20] = 9.68e-11;
+      //    	I_off_n[1][30] = 1.94e-10;
+      //    	I_off_n[1][40] = 3.87e-10;
+      //    	I_off_n[1][50] = 7.73e-10;
+      //    	I_off_n[1][60] = 3.55e-10;
+      //    	I_off_n[1][70] = 3.09e-9;
+      //    	I_off_n[1][80] = 6.19e-9;
+      //    	I_off_n[1][90] = 1.24e-8;
+      //    	I_off_n[1][100]= 2.48e-8;
+      //
+      //    	//    for 22nm LSTP HP
+      //    	I_g_on_n[1][0]  = 4.51e-10;//A/micron
+      //    	I_g_on_n[1][10] = 4.51e-10;
+      //    	I_g_on_n[1][20] = 4.51e-10;
+      //    	I_g_on_n[1][30] = 4.51e-10;
+      //    	I_g_on_n[1][40] = 4.51e-10;
+      //    	I_g_on_n[1][50] = 4.51e-10;
+      //    	I_g_on_n[1][60] = 4.51e-10;
+      //    	I_g_on_n[1][70] = 4.51e-10;
+      //    	I_g_on_n[1][80] = 4.51e-10;
+      //    	I_g_on_n[1][90] = 4.51e-10;
+      //    	I_g_on_n[1][100] = 4.51e-10;
 
-    if(tech == 16){
-    	//For 2019, MPU/ASIC stagger-contacted M1 half-pitch is 16 nm (so this is 16 nm
-    	//technology i.e. FEATURESIZE = 0.016). Using the DG process numbers for HP.
-    	//16 nm HP
-    	vdd[0] = 0.7;
-    	Lphy[0] = 0.006;//Lphy is the physical gate-length.
-    	Lelec[0] = 0.00315;//Lelec is the electrical gate-length.
-    	t_ox[0] = 0.5e-3;//micron
-    	v_th[0] = 0.1489;//V
-    	c_ox[0] = 3.83e-14;//F/micron2 Cox_elec in MASTAR
-    	mobility_eff[0] = 476.15 * (1e-2 * 1e6 * 1e-2 * 1e6); //micron2 / Vs
-    	Vdsat[0] = 1.42e-2; //V/micron calculated in spreadsheet
-    	c_g_ideal[0] = 2.30e-16;//F/micron
-    	c_fringe[0] = 0.06e-15;//F/micron MASTAR inputdynamic/3
-    	c_junc[0] = 0;//F/micron2 MASTAR result dynamic
-    	I_on_n[0] =  2768.4e-6;//A/micron
-    	I_on_p[0] = I_on_n[0] / 2;//A/micron //This value for I_on_p is not really used.
-        nmos_effective_resistance_multiplier = 1.48;//nmos_effective_resistance_multiplier  is the ratio of Ieff to Idsat where Ieff is the effective NMOS current and Idsat is the saturation current.
-        n_to_p_eff_curr_drv_ratio[0] = 2; //Wpmos/Wnmos = 2 in 2007 MASTAR. Look in
-    	//"Dynamic" tab of Device workspace.
-        gmp_to_gmn_multiplier[0] = 1.38; //Just using the 32nm SOI value.
-        Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] / I_on_n[0];//ohm-micron
-        Rpchannelon[0] = n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];//ohm-micron
-        long_channel_leakage_reduction[0] = 1/2.655;
-        I_off_n[0][0] = 1.52e-7/1.5*1.2*1.07;
-        I_off_n[0][10] = 1.55e-7/1.5*1.2*1.07;
-        I_off_n[0][20] = 1.59e-7/1.5*1.2*1.07;
-        I_off_n[0][30] = 1.68e-7/1.5*1.2*1.07;
-        I_off_n[0][40] = 1.90e-7/1.5*1.2*1.07;
-        I_off_n[0][50] = 2.69e-7/1.5*1.2*1.07;
-        I_off_n[0][60] = 5.32e-7/1.5*1.2*1.07;
-        I_off_n[0][70] = 1.02e-6/1.5*1.2*1.07;
-        I_off_n[0][80] = 1.62e-6/1.5*1.2*1.07;
-        I_off_n[0][90] = 2.73e-6/1.5*1.2*1.07;
-        I_off_n[0][100] = 6.1e-6/1.5*1.2*1.07;
-        //for 16nm DG HP
-        I_g_on_n[0][0]  = 1.07e-9;//A/micron
-        I_g_on_n[0][10] = 1.07e-9;
-        I_g_on_n[0][20] = 1.07e-9;
-        I_g_on_n[0][30] = 1.07e-9;
-        I_g_on_n[0][40] = 1.07e-9;
-        I_g_on_n[0][50] = 1.07e-9;
-        I_g_on_n[0][60] = 1.07e-9;
-        I_g_on_n[0][70] = 1.07e-9;
-        I_g_on_n[0][80] = 1.07e-9;
-        I_g_on_n[0][90] = 1.07e-9;
-        I_g_on_n[0][100] = 1.07e-9;
+      if (ram_cell_tech_type == 3) {
+      } else if (ram_cell_tech_type == 4) {
+        // 22 nm commodity DRAM cell access transistor technology parameters.
+        // parameters
+        curr_vdd_dram_cell = 0.9;  // 0.45;//This value has reduced greatly in
+                                   // 2007 ITRS for all technology nodes. In
+        // 2005 ITRS, the value was about twice the value in 2007 ITRS
+        Lphy[3] = 0.022;                       // micron
+        Lelec[3] = 0.0181;                     // micron.
+        curr_v_th_dram_access_transistor = 1;  // V
+        width_dram_access_transistor = 0.022;  // micron
+        curr_I_on_dram_cell =
+            20e-6;  // This is a typical value that I have always
+        // kept constant. In reality this could perhaps be lower
+        curr_I_off_dram_cell_worst_case_length_temp = 1e-15;  // A
+        curr_Wmemcella_dram = width_dram_access_transistor;
+        curr_Wmemcellpmos_dram = 0;
+        curr_Wmemcellnmos_dram = 0;
+        curr_area_cell_dram = 6 * 0.022 * 0.022;  // micron2.
+        curr_asp_ratio_cell_dram = 0.667;
+        curr_c_dram_cell = 30e-15;  // This is a typical value that I have
+                                    // alwaus
+        // kept constant.
 
-//    	//16 nm LSTP DG
-//    	vdd[1] = 0.8;
-//    	Lphy[1] = 0.014;
-//    	Lelec[1] = 0.008;//Lelec is the electrical gate-length.
-//    	t_ox[1] = 1.1e-3;//micron
-//    	v_th[1] = 0.40126;//V
-//    	c_ox[1] = 2.30e-14;//F/micron2
-//    	mobility_eff[1] =  738.09 * (1e-2 * 1e6 * 1e-2 * 1e6); //micron2 / Vs
-//    	Vdsat[1] = 6.64e-2; //V/micron
-//    	c_g_ideal[1] = 3.22e-16;//F/micron
-//    	c_fringe[1] = 0.008e-15;
-//    	c_junc[1] = 0;//F/micron2
-//    	I_on_n[1] = 727.6e-6;//A/micron
-//    	I_on_p[1] = I_on_n[1] / 2;
-//    	nmos_effective_resistance_multiplier = 1.99;
-//    	n_to_p_eff_curr_drv_ratio[1] = 2;
-//    	gmp_to_gmn_multiplier[1] = 0.99;
-//    	Rnchannelon[1] = nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];//ohm-micron
-//    	Rpchannelon[1] = n_to_p_eff_curr_drv_ratio[1] * Rnchannelon[1];//ohm-micron
-//    	I_off_n[1][0] = 2.43e-11;
-//    	I_off_n[1][10] = 4.85e-11;
-//    	I_off_n[1][20] = 9.68e-11;
-//    	I_off_n[1][30] = 1.94e-10;
-//    	I_off_n[1][40] = 3.87e-10;
-//    	I_off_n[1][50] = 7.73e-10;
-//    	I_off_n[1][60] = 3.55e-10;
-//    	I_off_n[1][70] = 3.09e-9;
-//    	I_off_n[1][80] = 6.19e-9;
-//    	I_off_n[1][90] = 1.24e-8;
-//    	I_off_n[1][100]= 2.48e-8;
-//
-//    	//    for 22nm LSTP HP
-//    	I_g_on_n[1][0]  = 4.51e-10;//A/micron
-//    	I_g_on_n[1][10] = 4.51e-10;
-//    	I_g_on_n[1][20] = 4.51e-10;
-//    	I_g_on_n[1][30] = 4.51e-10;
-//    	I_g_on_n[1][40] = 4.51e-10;
-//    	I_g_on_n[1][50] = 4.51e-10;
-//    	I_g_on_n[1][60] = 4.51e-10;
-//    	I_g_on_n[1][70] = 4.51e-10;
-//    	I_g_on_n[1][80] = 4.51e-10;
-//    	I_g_on_n[1][90] = 4.51e-10;
-//    	I_g_on_n[1][100] = 4.51e-10;
+        // 22 nm commodity DRAM wordline transistor parameters obtained using
+        // MASTAR.
+        curr_vpp = 2.3;                                        // vpp. V
+        t_ox[3] = 3.5e-3;                                      // micron
+        v_th[3] = 1.0;                                         // V
+        c_ox[3] = 9.06e-15;                                    // F/micron2
+        mobility_eff[3] = 367.29 * (1e-2 * 1e6 * 1e-2 * 1e6);  // micron2 / Vs
+        Vdsat[3] = 0.0972;                                     // V/micron
+        c_g_ideal[3] = 1.99e-16;                               // F/micron
+        c_fringe[3] = 0.053e-15;                               // F/micron
+        c_junc[3] = 1e-15;                                     // F/micron2
+        I_on_n[3] = 910.5e-6;                                  // A/micron
+        I_on_p[3] = I_on_n[3] / 2;  // This value for I_on_p is not really used.
+        nmos_effective_resistance_multiplier =
+            1.69;  // Using the value from 32nm.
+        //
+        n_to_p_eff_curr_drv_ratio[3] = 1.95;  // Using the value from 32nm
+        gmp_to_gmn_multiplier[3] = 0.90;
+        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp /
+                         I_on_n[3];  // ohm-micron
+        Rpchannelon[3] =
+            n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];  // ohm-micron
+        long_channel_leakage_reduction[3] = 1;
+        I_off_n[3][0] = 1.1e-13;  // A/micron
+        I_off_n[3][10] = 2.11e-13;
+        I_off_n[3][20] = 3.88e-13;
+        I_off_n[3][30] = 6.9e-13;
+        I_off_n[3][40] = 1.19e-12;
+        I_off_n[3][50] = 1.98e-12;
+        I_off_n[3][60] = 3.22e-12;
+        I_off_n[3][70] = 5.09e-12;
+        I_off_n[3][80] = 7.85e-12;
+        I_off_n[3][90] = 1.18e-11;
+        I_off_n[3][100] = 1.72e-11;
 
+      } else {
+        // some error handler
+      }
 
-        if (ram_cell_tech_type == 3)
-              {}
-        else if (ram_cell_tech_type == 4)
-        {
-    	//22 nm commodity DRAM cell access transistor technology parameters.
-    		//parameters
-        	curr_vdd_dram_cell = 0.9;//0.45;//This value has reduced greatly in 2007 ITRS for all technology nodes. In
-    		//2005 ITRS, the value was about twice the value in 2007 ITRS
-    		Lphy[3] = 0.022;//micron
-    		Lelec[3] = 0.0181;//micron.
-    		curr_v_th_dram_access_transistor = 1;//V
-    		width_dram_access_transistor = 0.022;//micron
-    		curr_I_on_dram_cell = 20e-6; //This is a typical value that I have always
-    		//kept constant. In reality this could perhaps be lower
-    		curr_I_off_dram_cell_worst_case_length_temp = 1e-15;//A
-    		curr_Wmemcella_dram = width_dram_access_transistor;
-    		curr_Wmemcellpmos_dram = 0;
-    		curr_Wmemcellnmos_dram = 0;
-    		curr_area_cell_dram = 6*0.022*0.022;//micron2.
-    		curr_asp_ratio_cell_dram = 0.667;
-    		curr_c_dram_cell = 30e-15;//This is a typical value that I have alwaus
-    		//kept constant.
+      // SRAM cell properties
+      curr_Wmemcella_sram = 1.31 * g_ip->F_sz_um;
+      curr_Wmemcellpmos_sram = 1.23 * g_ip->F_sz_um;
+      curr_Wmemcellnmos_sram = 2.08 * g_ip->F_sz_um;
+      curr_area_cell_sram = 146 * g_ip->F_sz_um * g_ip->F_sz_um;
+      curr_asp_ratio_cell_sram = 1.46;
+      // CAM cell properties //TODO: data need to be revisited
+      curr_Wmemcella_cam = 1.31 * g_ip->F_sz_um;
+      curr_Wmemcellpmos_cam = 1.23 * g_ip->F_sz_um;
+      curr_Wmemcellnmos_cam = 2.08 * g_ip->F_sz_um;
+      curr_area_cell_cam = 292 * g_ip->F_sz_um * g_ip->F_sz_um;
+      curr_asp_ratio_cell_cam = 2.92;
+      // Empirical undifferetiated core/FU coefficient
+      curr_logic_scaling_co_eff = 0.7 * 0.7 * 0.7 * 0.7 * 0.7;
+      curr_core_tx_density = 1.25 / 0.7 / 0.7 / 0.7;
+      curr_sckt_co_eff = 1.1296;
+      curr_chip_layout_overhead =
+          1.2;  // die measurement results based on Niagara 1 and 2
+      curr_macro_layout_overhead =
+          1.1;  // EDA placement and routing tool rule of thumb
+    }
 
-    	//22 nm commodity DRAM wordline transistor parameters obtained using MASTAR.
-    		curr_vpp = 2.3;//vpp. V
-    		t_ox[3] = 3.5e-3;//micron
-    		v_th[3] = 1.0;//V
-    		c_ox[3] = 9.06e-15;//F/micron2
-    		mobility_eff[3] =  367.29 * (1e-2 * 1e6 * 1e-2 * 1e6);//micron2 / Vs
-    		Vdsat[3] = 0.0972; //V/micron
-    		c_g_ideal[3] = 1.99e-16;//F/micron
-    		c_fringe[3] = 0.053e-15;//F/micron
-    		c_junc[3] = 1e-15;//F/micron2
-    		I_on_n[3] = 910.5e-6;//A/micron
-    		I_on_p[3] = I_on_n[3] / 2;//This value for I_on_p is not really used.
-    		nmos_effective_resistance_multiplier = 1.69;//Using the value from 32nm.
-    		//
-    		n_to_p_eff_curr_drv_ratio[3] = 1.95;//Using the value from 32nm
-    		gmp_to_gmn_multiplier[3] = 0.90;
-    		Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp  / I_on_n[3];//ohm-micron
-    		Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];//ohm-micron
-    		long_channel_leakage_reduction[3] = 1;
-    		I_off_n[3][0] = 1.1e-13; //A/micron
-    		I_off_n[3][10] = 2.11e-13;
-    		I_off_n[3][20] = 3.88e-13;
-    		I_off_n[3][30] = 6.9e-13;
-    		I_off_n[3][40] = 1.19e-12;
-    		I_off_n[3][50] = 1.98e-12;
-    		I_off_n[3][60] = 3.22e-12;
-    		I_off_n[3][70] = 5.09e-12;
-    		I_off_n[3][80] = 7.85e-12;
-    		I_off_n[3][90] = 1.18e-11;
-    		I_off_n[3][100] = 1.72e-11;
-
-    	}
-        else
-        {
-      	  //some error handler
-        }
-
-        //SRAM cell properties
-        curr_Wmemcella_sram    = 1.31 * g_ip->F_sz_um;
-        curr_Wmemcellpmos_sram = 1.23 * g_ip->F_sz_um;
-        curr_Wmemcellnmos_sram = 2.08 * g_ip->F_sz_um;
-        curr_area_cell_sram    = 146 * g_ip->F_sz_um * g_ip->F_sz_um;
-        curr_asp_ratio_cell_sram = 1.46;
-        //CAM cell properties //TODO: data need to be revisited
-        curr_Wmemcella_cam = 1.31 * g_ip->F_sz_um;
-        curr_Wmemcellpmos_cam = 1.23 * g_ip->F_sz_um;
-        curr_Wmemcellnmos_cam = 2.08 * g_ip->F_sz_um;
-        curr_area_cell_cam = 292 * g_ip->F_sz_um * g_ip->F_sz_um;
-        curr_asp_ratio_cell_cam = 2.92;
-        //Empirical undifferetiated core/FU coefficient
-        curr_logic_scaling_co_eff = 0.7*0.7*0.7*0.7*0.7;
-        curr_core_tx_density      = 1.25/0.7/0.7/0.7;
-        curr_sckt_co_eff           = 1.1296;
-        curr_chip_layout_overhead  = 1.2;//die measurement results based on Niagara 1 and 2
-        curr_macro_layout_overhead = 1.1;//EDA placement and routing tool rule of thumb
-    	}
-
-
-    g_tp.peri_global.Vdd       += curr_alpha * vdd[peri_global_tech_type];
-    g_tp.peri_global.t_ox      += curr_alpha * t_ox[peri_global_tech_type];
-    g_tp.peri_global.Vth       += curr_alpha * v_th[peri_global_tech_type];
-    g_tp.peri_global.C_ox      += curr_alpha * c_ox[peri_global_tech_type];
+    g_tp.peri_global.Vdd += curr_alpha * vdd[peri_global_tech_type];
+    g_tp.peri_global.t_ox += curr_alpha * t_ox[peri_global_tech_type];
+    g_tp.peri_global.Vth += curr_alpha * v_th[peri_global_tech_type];
+    g_tp.peri_global.C_ox += curr_alpha * c_ox[peri_global_tech_type];
     g_tp.peri_global.C_g_ideal += curr_alpha * c_g_ideal[peri_global_tech_type];
-    g_tp.peri_global.C_fringe  += curr_alpha * c_fringe[peri_global_tech_type];
-    g_tp.peri_global.C_junc    += curr_alpha * c_junc[peri_global_tech_type];
+    g_tp.peri_global.C_fringe += curr_alpha * c_fringe[peri_global_tech_type];
+    g_tp.peri_global.C_junc += curr_alpha * c_junc[peri_global_tech_type];
     g_tp.peri_global.C_junc_sidewall = 0.25e-15;  // F/micron
-    g_tp.peri_global.l_phy     += curr_alpha * Lphy[peri_global_tech_type];
-    g_tp.peri_global.l_elec    += curr_alpha * Lelec[peri_global_tech_type];
-    g_tp.peri_global.I_on_n    += curr_alpha * I_on_n[peri_global_tech_type];
-    g_tp.peri_global.R_nch_on  += curr_alpha * Rnchannelon[peri_global_tech_type];
-    g_tp.peri_global.R_pch_on  += curr_alpha * Rpchannelon[peri_global_tech_type];
-    g_tp.peri_global.n_to_p_eff_curr_drv_ratio
-      += curr_alpha * n_to_p_eff_curr_drv_ratio[peri_global_tech_type];
-    g_tp.peri_global.long_channel_leakage_reduction
-      += curr_alpha * long_channel_leakage_reduction[peri_global_tech_type];
-    g_tp.peri_global.I_off_n   += curr_alpha * I_off_n[peri_global_tech_type][g_ip->temp - 300];
-    g_tp.peri_global.I_off_p   += curr_alpha * I_off_n[peri_global_tech_type][g_ip->temp - 300];
-    g_tp.peri_global.I_g_on_n   += curr_alpha * I_g_on_n[peri_global_tech_type][g_ip->temp - 300];
-    g_tp.peri_global.I_g_on_p   += curr_alpha * I_g_on_n[peri_global_tech_type][g_ip->temp - 300];
-    gmp_to_gmn_multiplier_periph_global += curr_alpha * gmp_to_gmn_multiplier[peri_global_tech_type];
+    g_tp.peri_global.l_phy += curr_alpha * Lphy[peri_global_tech_type];
+    g_tp.peri_global.l_elec += curr_alpha * Lelec[peri_global_tech_type];
+    g_tp.peri_global.I_on_n += curr_alpha * I_on_n[peri_global_tech_type];
+    g_tp.peri_global.R_nch_on +=
+        curr_alpha * Rnchannelon[peri_global_tech_type];
+    g_tp.peri_global.R_pch_on +=
+        curr_alpha * Rpchannelon[peri_global_tech_type];
+    g_tp.peri_global.n_to_p_eff_curr_drv_ratio +=
+        curr_alpha * n_to_p_eff_curr_drv_ratio[peri_global_tech_type];
+    g_tp.peri_global.long_channel_leakage_reduction +=
+        curr_alpha * long_channel_leakage_reduction[peri_global_tech_type];
+    g_tp.peri_global.I_off_n +=
+        curr_alpha * I_off_n[peri_global_tech_type][g_ip->temp - 300];
+    g_tp.peri_global.I_off_p +=
+        curr_alpha * I_off_n[peri_global_tech_type][g_ip->temp - 300];
+    g_tp.peri_global.I_g_on_n +=
+        curr_alpha * I_g_on_n[peri_global_tech_type][g_ip->temp - 300];
+    g_tp.peri_global.I_g_on_p +=
+        curr_alpha * I_g_on_n[peri_global_tech_type][g_ip->temp - 300];
+    gmp_to_gmn_multiplier_periph_global +=
+        curr_alpha * gmp_to_gmn_multiplier[peri_global_tech_type];
 
-    g_tp.sram_cell.Vdd       += curr_alpha * vdd[ram_cell_tech_type];
-    g_tp.sram_cell.l_phy     += curr_alpha * Lphy[ram_cell_tech_type];
-    g_tp.sram_cell.l_elec    += curr_alpha * Lelec[ram_cell_tech_type];
-    g_tp.sram_cell.t_ox      += curr_alpha * t_ox[ram_cell_tech_type];
-    g_tp.sram_cell.Vth       += curr_alpha * v_th[ram_cell_tech_type];
+    g_tp.sram_cell.Vdd += curr_alpha * vdd[ram_cell_tech_type];
+    g_tp.sram_cell.l_phy += curr_alpha * Lphy[ram_cell_tech_type];
+    g_tp.sram_cell.l_elec += curr_alpha * Lelec[ram_cell_tech_type];
+    g_tp.sram_cell.t_ox += curr_alpha * t_ox[ram_cell_tech_type];
+    g_tp.sram_cell.Vth += curr_alpha * v_th[ram_cell_tech_type];
     g_tp.sram_cell.C_g_ideal += curr_alpha * c_g_ideal[ram_cell_tech_type];
-    g_tp.sram_cell.C_fringe  += curr_alpha * c_fringe[ram_cell_tech_type];
-    g_tp.sram_cell.C_junc    += curr_alpha * c_junc[ram_cell_tech_type];
+    g_tp.sram_cell.C_fringe += curr_alpha * c_fringe[ram_cell_tech_type];
+    g_tp.sram_cell.C_junc += curr_alpha * c_junc[ram_cell_tech_type];
     g_tp.sram_cell.C_junc_sidewall = 0.25e-15;  // F/micron
-    g_tp.sram_cell.I_on_n    += curr_alpha * I_on_n[ram_cell_tech_type];
-    g_tp.sram_cell.R_nch_on  += curr_alpha * Rnchannelon[ram_cell_tech_type];
-    g_tp.sram_cell.R_pch_on  += curr_alpha * Rpchannelon[ram_cell_tech_type];
-    g_tp.sram_cell.n_to_p_eff_curr_drv_ratio += curr_alpha * n_to_p_eff_curr_drv_ratio[ram_cell_tech_type];
-    g_tp.sram_cell.long_channel_leakage_reduction += curr_alpha * long_channel_leakage_reduction[ram_cell_tech_type];
-    g_tp.sram_cell.I_off_n   += curr_alpha * I_off_n[ram_cell_tech_type][g_ip->temp - 300];
-    g_tp.sram_cell.I_off_p   += curr_alpha * I_off_n[ram_cell_tech_type][g_ip->temp - 300];
-    g_tp.sram_cell.I_g_on_n   += curr_alpha * I_g_on_n[ram_cell_tech_type][g_ip->temp - 300];
-    g_tp.sram_cell.I_g_on_p   += curr_alpha * I_g_on_n[ram_cell_tech_type][g_ip->temp - 300];
+    g_tp.sram_cell.I_on_n += curr_alpha * I_on_n[ram_cell_tech_type];
+    g_tp.sram_cell.R_nch_on += curr_alpha * Rnchannelon[ram_cell_tech_type];
+    g_tp.sram_cell.R_pch_on += curr_alpha * Rpchannelon[ram_cell_tech_type];
+    g_tp.sram_cell.n_to_p_eff_curr_drv_ratio +=
+        curr_alpha * n_to_p_eff_curr_drv_ratio[ram_cell_tech_type];
+    g_tp.sram_cell.long_channel_leakage_reduction +=
+        curr_alpha * long_channel_leakage_reduction[ram_cell_tech_type];
+    g_tp.sram_cell.I_off_n +=
+        curr_alpha * I_off_n[ram_cell_tech_type][g_ip->temp - 300];
+    g_tp.sram_cell.I_off_p +=
+        curr_alpha * I_off_n[ram_cell_tech_type][g_ip->temp - 300];
+    g_tp.sram_cell.I_g_on_n +=
+        curr_alpha * I_g_on_n[ram_cell_tech_type][g_ip->temp - 300];
+    g_tp.sram_cell.I_g_on_p +=
+        curr_alpha * I_g_on_n[ram_cell_tech_type][g_ip->temp - 300];
 
-    g_tp.dram_cell_Vdd      += curr_alpha * curr_vdd_dram_cell;
-    g_tp.dram_acc.Vth       += curr_alpha * curr_v_th_dram_access_transistor;
-    g_tp.dram_acc.l_phy     += curr_alpha * Lphy[dram_cell_tech_flavor];
-    g_tp.dram_acc.l_elec    += curr_alpha * Lelec[dram_cell_tech_flavor];
+    g_tp.dram_cell_Vdd += curr_alpha * curr_vdd_dram_cell;
+    g_tp.dram_acc.Vth += curr_alpha * curr_v_th_dram_access_transistor;
+    g_tp.dram_acc.l_phy += curr_alpha * Lphy[dram_cell_tech_flavor];
+    g_tp.dram_acc.l_elec += curr_alpha * Lelec[dram_cell_tech_flavor];
     g_tp.dram_acc.C_g_ideal += curr_alpha * c_g_ideal[dram_cell_tech_flavor];
-    g_tp.dram_acc.C_fringe  += curr_alpha * c_fringe[dram_cell_tech_flavor];
-    g_tp.dram_acc.C_junc    += curr_alpha * c_junc[dram_cell_tech_flavor];
+    g_tp.dram_acc.C_fringe += curr_alpha * c_fringe[dram_cell_tech_flavor];
+    g_tp.dram_acc.C_junc += curr_alpha * c_junc[dram_cell_tech_flavor];
     g_tp.dram_acc.C_junc_sidewall = 0.25e-15;  // F/micron
-    g_tp.dram_cell_I_on     += curr_alpha * curr_I_on_dram_cell;
-    g_tp.dram_cell_I_off_worst_case_len_temp += curr_alpha * curr_I_off_dram_cell_worst_case_length_temp;
-    g_tp.dram_acc.I_on_n    += curr_alpha * I_on_n[dram_cell_tech_flavor];
-    g_tp.dram_cell_C        += curr_alpha * curr_c_dram_cell;
-    g_tp.vpp                += curr_alpha * curr_vpp;
-    g_tp.dram_wl.l_phy      += curr_alpha * Lphy[dram_cell_tech_flavor];
-    g_tp.dram_wl.l_elec     += curr_alpha * Lelec[dram_cell_tech_flavor];
-    g_tp.dram_wl.C_g_ideal  += curr_alpha * c_g_ideal[dram_cell_tech_flavor];
-    g_tp.dram_wl.C_fringe   += curr_alpha * c_fringe[dram_cell_tech_flavor];
-    g_tp.dram_wl.C_junc     += curr_alpha * c_junc[dram_cell_tech_flavor];
+    g_tp.dram_cell_I_on += curr_alpha * curr_I_on_dram_cell;
+    g_tp.dram_cell_I_off_worst_case_len_temp +=
+        curr_alpha * curr_I_off_dram_cell_worst_case_length_temp;
+    g_tp.dram_acc.I_on_n += curr_alpha * I_on_n[dram_cell_tech_flavor];
+    g_tp.dram_cell_C += curr_alpha * curr_c_dram_cell;
+    g_tp.vpp += curr_alpha * curr_vpp;
+    g_tp.dram_wl.l_phy += curr_alpha * Lphy[dram_cell_tech_flavor];
+    g_tp.dram_wl.l_elec += curr_alpha * Lelec[dram_cell_tech_flavor];
+    g_tp.dram_wl.C_g_ideal += curr_alpha * c_g_ideal[dram_cell_tech_flavor];
+    g_tp.dram_wl.C_fringe += curr_alpha * c_fringe[dram_cell_tech_flavor];
+    g_tp.dram_wl.C_junc += curr_alpha * c_junc[dram_cell_tech_flavor];
     g_tp.dram_wl.C_junc_sidewall = 0.25e-15;  // F/micron
-    g_tp.dram_wl.I_on_n     += curr_alpha * I_on_n[dram_cell_tech_flavor];
-    g_tp.dram_wl.R_nch_on   += curr_alpha * Rnchannelon[dram_cell_tech_flavor];
-    g_tp.dram_wl.R_pch_on   += curr_alpha * Rpchannelon[dram_cell_tech_flavor];
-    g_tp.dram_wl.n_to_p_eff_curr_drv_ratio += curr_alpha * n_to_p_eff_curr_drv_ratio[dram_cell_tech_flavor];
-    g_tp.dram_wl.long_channel_leakage_reduction += curr_alpha * long_channel_leakage_reduction[dram_cell_tech_flavor];
-    g_tp.dram_wl.I_off_n    += curr_alpha * I_off_n[dram_cell_tech_flavor][g_ip->temp - 300];
-    g_tp.dram_wl.I_off_p    += curr_alpha * I_off_n[dram_cell_tech_flavor][g_ip->temp - 300];
+    g_tp.dram_wl.I_on_n += curr_alpha * I_on_n[dram_cell_tech_flavor];
+    g_tp.dram_wl.R_nch_on += curr_alpha * Rnchannelon[dram_cell_tech_flavor];
+    g_tp.dram_wl.R_pch_on += curr_alpha * Rpchannelon[dram_cell_tech_flavor];
+    g_tp.dram_wl.n_to_p_eff_curr_drv_ratio +=
+        curr_alpha * n_to_p_eff_curr_drv_ratio[dram_cell_tech_flavor];
+    g_tp.dram_wl.long_channel_leakage_reduction +=
+        curr_alpha * long_channel_leakage_reduction[dram_cell_tech_flavor];
+    g_tp.dram_wl.I_off_n +=
+        curr_alpha * I_off_n[dram_cell_tech_flavor][g_ip->temp - 300];
+    g_tp.dram_wl.I_off_p +=
+        curr_alpha * I_off_n[dram_cell_tech_flavor][g_ip->temp - 300];
 
-    g_tp.cam_cell.Vdd       += curr_alpha * vdd[ram_cell_tech_type];
-    g_tp.cam_cell.l_phy     += curr_alpha * Lphy[ram_cell_tech_type];
-    g_tp.cam_cell.l_elec    += curr_alpha * Lelec[ram_cell_tech_type];
-    g_tp.cam_cell.t_ox      += curr_alpha * t_ox[ram_cell_tech_type];
-    g_tp.cam_cell.Vth       += curr_alpha * v_th[ram_cell_tech_type];
+    g_tp.cam_cell.Vdd += curr_alpha * vdd[ram_cell_tech_type];
+    g_tp.cam_cell.l_phy += curr_alpha * Lphy[ram_cell_tech_type];
+    g_tp.cam_cell.l_elec += curr_alpha * Lelec[ram_cell_tech_type];
+    g_tp.cam_cell.t_ox += curr_alpha * t_ox[ram_cell_tech_type];
+    g_tp.cam_cell.Vth += curr_alpha * v_th[ram_cell_tech_type];
     g_tp.cam_cell.C_g_ideal += curr_alpha * c_g_ideal[ram_cell_tech_type];
-    g_tp.cam_cell.C_fringe  += curr_alpha * c_fringe[ram_cell_tech_type];
-    g_tp.cam_cell.C_junc    += curr_alpha * c_junc[ram_cell_tech_type];
+    g_tp.cam_cell.C_fringe += curr_alpha * c_fringe[ram_cell_tech_type];
+    g_tp.cam_cell.C_junc += curr_alpha * c_junc[ram_cell_tech_type];
     g_tp.cam_cell.C_junc_sidewall = 0.25e-15;  // F/micron
-    g_tp.cam_cell.I_on_n    += curr_alpha * I_on_n[ram_cell_tech_type];
-    g_tp.cam_cell.R_nch_on  += curr_alpha * Rnchannelon[ram_cell_tech_type];
-    g_tp.cam_cell.R_pch_on  += curr_alpha * Rpchannelon[ram_cell_tech_type];
-    g_tp.cam_cell.n_to_p_eff_curr_drv_ratio += curr_alpha * n_to_p_eff_curr_drv_ratio[ram_cell_tech_type];
-    g_tp.cam_cell.long_channel_leakage_reduction += curr_alpha * long_channel_leakage_reduction[ram_cell_tech_type];
-    g_tp.cam_cell.I_off_n   += curr_alpha * I_off_n[ram_cell_tech_type][g_ip->temp - 300];
-    g_tp.cam_cell.I_off_p   += curr_alpha * I_off_n[ram_cell_tech_type][g_ip->temp - 300];
-    g_tp.cam_cell.I_g_on_n   += curr_alpha * I_g_on_n[ram_cell_tech_type][g_ip->temp - 300];
-    g_tp.cam_cell.I_g_on_p   += curr_alpha * I_g_on_n[ram_cell_tech_type][g_ip->temp - 300];
+    g_tp.cam_cell.I_on_n += curr_alpha * I_on_n[ram_cell_tech_type];
+    g_tp.cam_cell.R_nch_on += curr_alpha * Rnchannelon[ram_cell_tech_type];
+    g_tp.cam_cell.R_pch_on += curr_alpha * Rpchannelon[ram_cell_tech_type];
+    g_tp.cam_cell.n_to_p_eff_curr_drv_ratio +=
+        curr_alpha * n_to_p_eff_curr_drv_ratio[ram_cell_tech_type];
+    g_tp.cam_cell.long_channel_leakage_reduction +=
+        curr_alpha * long_channel_leakage_reduction[ram_cell_tech_type];
+    g_tp.cam_cell.I_off_n +=
+        curr_alpha * I_off_n[ram_cell_tech_type][g_ip->temp - 300];
+    g_tp.cam_cell.I_off_p +=
+        curr_alpha * I_off_n[ram_cell_tech_type][g_ip->temp - 300];
+    g_tp.cam_cell.I_g_on_n +=
+        curr_alpha * I_g_on_n[ram_cell_tech_type][g_ip->temp - 300];
+    g_tp.cam_cell.I_g_on_p +=
+        curr_alpha * I_g_on_n[ram_cell_tech_type][g_ip->temp - 300];
 
-    g_tp.dram.cell_a_w    += curr_alpha * curr_Wmemcella_dram;
+    g_tp.dram.cell_a_w += curr_alpha * curr_Wmemcella_dram;
     g_tp.dram.cell_pmos_w += curr_alpha * curr_Wmemcellpmos_dram;
     g_tp.dram.cell_nmos_w += curr_alpha * curr_Wmemcellnmos_dram;
-    area_cell_dram        += curr_alpha * curr_area_cell_dram;
-    asp_ratio_cell_dram   += curr_alpha * curr_asp_ratio_cell_dram;
+    area_cell_dram += curr_alpha * curr_area_cell_dram;
+    asp_ratio_cell_dram += curr_alpha * curr_asp_ratio_cell_dram;
 
-    g_tp.sram.cell_a_w    += curr_alpha * curr_Wmemcella_sram;
+    g_tp.sram.cell_a_w += curr_alpha * curr_Wmemcella_sram;
     g_tp.sram.cell_pmos_w += curr_alpha * curr_Wmemcellpmos_sram;
     g_tp.sram.cell_nmos_w += curr_alpha * curr_Wmemcellnmos_sram;
     area_cell_sram += curr_alpha * curr_area_cell_sram;
     asp_ratio_cell_sram += curr_alpha * curr_asp_ratio_cell_sram;
 
-    g_tp.cam.cell_a_w    += curr_alpha * curr_Wmemcella_cam;//sheng
+    g_tp.cam.cell_a_w += curr_alpha * curr_Wmemcella_cam;  // sheng
     g_tp.cam.cell_pmos_w += curr_alpha * curr_Wmemcellpmos_cam;
     g_tp.cam.cell_nmos_w += curr_alpha * curr_Wmemcellnmos_cam;
     area_cell_cam += curr_alpha * curr_area_cell_cam;
     asp_ratio_cell_cam += curr_alpha * curr_asp_ratio_cell_cam;
 
-    //Sense amplifier latch Gm calculation
-    mobility_eff_periph_global += curr_alpha * mobility_eff[peri_global_tech_type];
+    // Sense amplifier latch Gm calculation
+    mobility_eff_periph_global +=
+        curr_alpha * mobility_eff[peri_global_tech_type];
     Vdsat_periph_global += curr_alpha * Vdsat[peri_global_tech_type];
 
-    //Empirical undifferetiated core/FU coefficient
-    g_tp.scaling_factor.logic_scaling_co_eff += curr_alpha * curr_logic_scaling_co_eff;
+    // Empirical undifferetiated core/FU coefficient
+    g_tp.scaling_factor.logic_scaling_co_eff +=
+        curr_alpha * curr_logic_scaling_co_eff;
     g_tp.scaling_factor.core_tx_density += curr_alpha * curr_core_tx_density;
-    g_tp.chip_layout_overhead  += curr_alpha * curr_chip_layout_overhead;
+    g_tp.chip_layout_overhead += curr_alpha * curr_chip_layout_overhead;
     g_tp.macro_layout_overhead += curr_alpha * curr_macro_layout_overhead;
-    g_tp.sckt_co_eff           += curr_alpha * curr_sckt_co_eff;
+    g_tp.sckt_co_eff += curr_alpha * curr_sckt_co_eff;
   }
 
-
-  //Currently we are not modeling the resistance/capacitance of poly anywhere.
-  //Continuous function (or date have been processed) does not need linear interpolation
-  g_tp.w_comp_inv_p1 = 12.5 * g_ip->F_sz_um;//this was 10 micron for the 0.8 micron process
-  g_tp.w_comp_inv_n1 =  7.5 * g_ip->F_sz_um;//this was  6 micron for the 0.8 micron process
-  g_tp.w_comp_inv_p2 =   25 * g_ip->F_sz_um;//this was 20 micron for the 0.8 micron process
-  g_tp.w_comp_inv_n2 =   15 * g_ip->F_sz_um;//this was 12 micron for the 0.8 micron process
-  g_tp.w_comp_inv_p3 =   50 * g_ip->F_sz_um;//this was 40 micron for the 0.8 micron process
-  g_tp.w_comp_inv_n3 =   30 * g_ip->F_sz_um;//this was 24 micron for the 0.8 micron process
-  g_tp.w_eval_inv_p  =  100 * g_ip->F_sz_um;//this was 80 micron for the 0.8 micron process
-  g_tp.w_eval_inv_n  =   50 * g_ip->F_sz_um;//this was 40 micron for the 0.8 micron process
-  g_tp.w_comp_n     = 12.5 * g_ip->F_sz_um;//this was 10 micron for the 0.8 micron process
-  g_tp.w_comp_p     = 37.5 * g_ip->F_sz_um;//this was 30 micron for the 0.8 micron process
+  // Currently we are not modeling the resistance/capacitance of poly anywhere.
+  // Continuous function (or date have been processed) does not need linear
+  // interpolation
+  g_tp.w_comp_inv_p1 =
+      12.5 * g_ip->F_sz_um;  // this was 10 micron for the 0.8 micron process
+  g_tp.w_comp_inv_n1 =
+      7.5 * g_ip->F_sz_um;  // this was  6 micron for the 0.8 micron process
+  g_tp.w_comp_inv_p2 =
+      25 * g_ip->F_sz_um;  // this was 20 micron for the 0.8 micron process
+  g_tp.w_comp_inv_n2 =
+      15 * g_ip->F_sz_um;  // this was 12 micron for the 0.8 micron process
+  g_tp.w_comp_inv_p3 =
+      50 * g_ip->F_sz_um;  // this was 40 micron for the 0.8 micron process
+  g_tp.w_comp_inv_n3 =
+      30 * g_ip->F_sz_um;  // this was 24 micron for the 0.8 micron process
+  g_tp.w_eval_inv_p =
+      100 * g_ip->F_sz_um;  // this was 80 micron for the 0.8 micron process
+  g_tp.w_eval_inv_n =
+      50 * g_ip->F_sz_um;  // this was 40 micron for the 0.8 micron process
+  g_tp.w_comp_n =
+      12.5 * g_ip->F_sz_um;  // this was 10 micron for the 0.8 micron process
+  g_tp.w_comp_p =
+      37.5 * g_ip->F_sz_um;  // this was 30 micron for the 0.8 micron process
 
   g_tp.MIN_GAP_BET_P_AND_N_DIFFS = 5 * g_ip->F_sz_um;
   g_tp.MIN_GAP_BET_SAME_TYPE_DIFFS = 1.5 * g_ip->F_sz_um;
@@ -1828,255 +1893,264 @@ void init_tech_params(double technology, bool is_tag)
 
   g_tp.min_w_nmos_ = 3 * g_ip->F_sz_um / 2;
   g_tp.max_w_nmos_ = 100 * g_ip->F_sz_um;
-  g_tp.w_iso       = 12.5*g_ip->F_sz_um;//was 10 micron for the 0.8 micron process
-  g_tp.w_sense_n   = 3.75*g_ip->F_sz_um; // sense amplifier N-trans; was 3 micron for the 0.8 micron process
-  g_tp.w_sense_p   = 7.5*g_ip->F_sz_um; // sense amplifier P-trans; was 6 micron for the 0.8 micron process
-  g_tp.w_sense_en  = 5*g_ip->F_sz_um; // Sense enable transistor of the sense amplifier; was 4 micron for the 0.8 micron process
-  g_tp.w_nmos_b_mux  = 6 * g_tp.min_w_nmos_;
+  g_tp.w_iso = 12.5 * g_ip->F_sz_um;      // was 10 micron for the 0.8 micron
+                                          // process
+  g_tp.w_sense_n = 3.75 * g_ip->F_sz_um;  // sense amplifier N-trans; was 3
+                                          // micron for the 0.8 micron process
+  g_tp.w_sense_p = 7.5 * g_ip->F_sz_um;   // sense amplifier P-trans; was 6
+                                          // micron for the 0.8 micron process
+  g_tp.w_sense_en =
+      5 * g_ip->F_sz_um;  // Sense enable transistor of the sense amplifier; was
+                          // 4 micron for the 0.8 micron process
+  g_tp.w_nmos_b_mux = 6 * g_tp.min_w_nmos_;
   g_tp.w_nmos_sa_mux = 6 * g_tp.min_w_nmos_;
 
-  if (ram_cell_tech_type == comm_dram)
-  {
+  if (ram_cell_tech_type == comm_dram) {
     g_tp.max_w_nmos_dec = 8 * g_ip->F_sz_um;
-    g_tp.h_dec          = 8;  // in the unit of memory cell height
-  }
-  else
-  {
+    g_tp.h_dec = 8;  // in the unit of memory cell height
+  } else {
     g_tp.max_w_nmos_dec = g_tp.max_w_nmos_;
-    g_tp.h_dec          = 4;  // in the unit of memory cell height
+    g_tp.h_dec = 4;  // in the unit of memory cell height
   }
 
   g_tp.peri_global.C_overlap = 0.2 * g_tp.peri_global.C_g_ideal;
-  g_tp.sram_cell.C_overlap   = 0.2 * g_tp.sram_cell.C_g_ideal;
-  g_tp.cam_cell.C_overlap    = 0.2 * g_tp.cam_cell.C_g_ideal;
+  g_tp.sram_cell.C_overlap = 0.2 * g_tp.sram_cell.C_g_ideal;
+  g_tp.cam_cell.C_overlap = 0.2 * g_tp.cam_cell.C_g_ideal;
 
   g_tp.dram_acc.C_overlap = 0.2 * g_tp.dram_acc.C_g_ideal;
   g_tp.dram_acc.R_nch_on = g_tp.dram_cell_Vdd / g_tp.dram_acc.I_on_n;
-  //g_tp.dram_acc.R_pch_on = g_tp.dram_cell_Vdd / g_tp.dram_acc.I_on_p;
+  // g_tp.dram_acc.R_pch_on = g_tp.dram_cell_Vdd / g_tp.dram_acc.I_on_p;
 
   g_tp.dram_wl.C_overlap = 0.2 * g_tp.dram_wl.C_g_ideal;
 
-  double gmn_sense_amp_latch = (mobility_eff_periph_global / 2) * g_tp.peri_global.C_ox * (g_tp.w_sense_n / g_tp.peri_global.l_elec) * Vdsat_periph_global;
-  double gmp_sense_amp_latch = gmp_to_gmn_multiplier_periph_global * gmn_sense_amp_latch;
+  double gmn_sense_amp_latch =
+      (mobility_eff_periph_global / 2) * g_tp.peri_global.C_ox *
+      (g_tp.w_sense_n / g_tp.peri_global.l_elec) * Vdsat_periph_global;
+  double gmp_sense_amp_latch =
+      gmp_to_gmn_multiplier_periph_global * gmn_sense_amp_latch;
   g_tp.gm_sense_amp_latch = gmn_sense_amp_latch + gmp_sense_amp_latch;
 
   g_tp.dram.b_w = sqrt(area_cell_dram / (asp_ratio_cell_dram));
   g_tp.dram.b_h = asp_ratio_cell_dram * g_tp.dram.b_w;
   g_tp.sram.b_w = sqrt(area_cell_sram / (asp_ratio_cell_sram));
   g_tp.sram.b_h = asp_ratio_cell_sram * g_tp.sram.b_w;
-  g_tp.cam.b_w =  sqrt(area_cell_cam / (asp_ratio_cell_cam));//Sheng
+  g_tp.cam.b_w = sqrt(area_cell_cam / (asp_ratio_cell_cam));  // Sheng
   g_tp.cam.b_h = asp_ratio_cell_cam * g_tp.cam.b_w;
 
   g_tp.dram.Vbitpre = g_tp.dram_cell_Vdd;
   g_tp.sram.Vbitpre = vdd[ram_cell_tech_type];
-  g_tp.cam.Vbitpre = vdd[ram_cell_tech_type];//Sheng
+  g_tp.cam.Vbitpre = vdd[ram_cell_tech_type];  // Sheng
   pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
   g_tp.w_pmos_bl_precharge = 6 * pmos_to_nmos_sizing_r * g_tp.min_w_nmos_;
   g_tp.w_pmos_bl_eq = pmos_to_nmos_sizing_r * g_tp.min_w_nmos_;
 
+  double wire_pitch[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
+      wire_r_per_micron[NUMBER_INTERCONNECT_PROJECTION_TYPES]
+                       [NUMBER_WIRE_TYPES],
+      wire_c_per_micron[NUMBER_INTERCONNECT_PROJECTION_TYPES]
+                       [NUMBER_WIRE_TYPES],
+      horiz_dielectric_constant[NUMBER_INTERCONNECT_PROJECTION_TYPES]
+                               [NUMBER_WIRE_TYPES],
+      vert_dielectric_constant[NUMBER_INTERCONNECT_PROJECTION_TYPES]
+                              [NUMBER_WIRE_TYPES],
+      aspect_ratio[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
+      miller_value[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
+      ild_thickness[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES];
 
-  double wire_pitch       [NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
-         wire_r_per_micron[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
-         wire_c_per_micron[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
-         horiz_dielectric_constant[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
-         vert_dielectric_constant[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
-         aspect_ratio[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
-         miller_value[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
-         ild_thickness[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES];
-
-  for (iter=0; iter<=1; ++iter)
-  {
+  for (iter = 0; iter <= 1; ++iter) {
     // linear interpolation
-    if (iter == 0)
-    {
+    if (iter == 0) {
       tech = tech_lo;
-      if (tech_lo == tech_hi)
-      {
+      if (tech_lo == tech_hi) {
         curr_alpha = 1;
+      } else {
+        curr_alpha = (technology - tech_hi) / (tech_lo - tech_hi);
       }
-      else
-      {
-        curr_alpha = (technology - tech_hi)/(tech_lo - tech_hi);
-      }
-    }
-    else
-    {
+    } else {
       tech = tech_hi;
-      if (tech_lo == tech_hi)
-      {
+      if (tech_lo == tech_hi) {
         break;
-      }
-      else
-      {
-        curr_alpha = (tech_lo - technology)/(tech_lo - tech_hi);
+      } else {
+        curr_alpha = (tech_lo - technology) / (tech_lo - tech_hi);
       }
     }
 
-    if (tech == 90)
-    {
-      //Aggressive projections
-      wire_pitch[0][0] = 2.5 * g_ip->F_sz_um;//micron
+    if (tech == 90) {
+      // Aggressive projections
+      wire_pitch[0][0] = 2.5 * g_ip->F_sz_um;  // micron
       aspect_ratio[0][0] = 2.4;
-      wire_width = wire_pitch[0][0] / 2; //micron
-      wire_thickness = aspect_ratio[0][0] * wire_width;//micron
-      wire_spacing = wire_pitch[0][0] - wire_width;//micron
-      barrier_thickness = 0.01;//micron
-      dishing_thickness = 0;//micron
+      wire_width = wire_pitch[0][0] / 2;                 // micron
+      wire_thickness = aspect_ratio[0][0] * wire_width;  // micron
+      wire_spacing = wire_pitch[0][0] - wire_width;      // micron
+      barrier_thickness = 0.01;                          // micron
+      dishing_thickness = 0;                             // micron
       alpha_scatter = 1;
-      wire_r_per_micron[0][0] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);//ohm/micron
-      ild_thickness[0][0] = 0.48;//micron
+      wire_r_per_micron[0][0] = wire_resistance(
+          CU_RESISTIVITY, wire_width, wire_thickness, barrier_thickness,
+          dishing_thickness, alpha_scatter);  // ohm/micron
+      ild_thickness[0][0] = 0.48;             // micron
       miller_value[0][0] = 1.5;
       horiz_dielectric_constant[0][0] = 2.709;
       vert_dielectric_constant[0][0] = 3.9;
-      fringe_cap = 0.115e-15; //F/micron
-      wire_c_per_micron[0][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[0][0], miller_value[0][0], horiz_dielectric_constant[0][0],
+      fringe_cap = 0.115e-15;  // F/micron
+      wire_c_per_micron[0][0] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][0],
+          miller_value[0][0], horiz_dielectric_constant[0][0],
           vert_dielectric_constant[0][0],
-          fringe_cap);//F/micron.
+          fringe_cap);  // F/micron.
 
       wire_pitch[0][1] = 4 * g_ip->F_sz_um;
       wire_width = wire_pitch[0][1] / 2;
       aspect_ratio[0][1] = 2.4;
       wire_thickness = aspect_ratio[0][1] * wire_width;
       wire_spacing = wire_pitch[0][1] - wire_width;
-      wire_r_per_micron[0][1] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[0][1] = 0.48;//micron
+      wire_r_per_micron[0][1] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][1] = 0.48;  // micron
       miller_value[0][1] = 1.5;
       horiz_dielectric_constant[0][1] = 2.709;
       vert_dielectric_constant[0][1] = 3.9;
-      wire_c_per_micron[0][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[0][1], miller_value[0][1], horiz_dielectric_constant[0][1],
-          vert_dielectric_constant[0][1],
-          fringe_cap);
+      wire_c_per_micron[0][1] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][1],
+          miller_value[0][1], horiz_dielectric_constant[0][1],
+          vert_dielectric_constant[0][1], fringe_cap);
 
       wire_pitch[0][2] = 8 * g_ip->F_sz_um;
       aspect_ratio[0][2] = 2.7;
       wire_width = wire_pitch[0][2] / 2;
       wire_thickness = aspect_ratio[0][2] * wire_width;
       wire_spacing = wire_pitch[0][2] - wire_width;
-      wire_r_per_micron[0][2] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+      wire_r_per_micron[0][2] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[0][2] = 0.96;
       miller_value[0][2] = 1.5;
       horiz_dielectric_constant[0][2] = 2.709;
       vert_dielectric_constant[0][2] = 3.9;
-      wire_c_per_micron[0][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[0][2], miller_value[0][2], horiz_dielectric_constant[0][2], vert_dielectric_constant[0][2],
-          fringe_cap);
+      wire_c_per_micron[0][2] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][2],
+          miller_value[0][2], horiz_dielectric_constant[0][2],
+          vert_dielectric_constant[0][2], fringe_cap);
 
-      //Conservative projections
+      // Conservative projections
       wire_pitch[1][0] = 2.5 * g_ip->F_sz_um;
-      aspect_ratio[1][0]  = 2.0;
+      aspect_ratio[1][0] = 2.0;
       wire_width = wire_pitch[1][0] / 2;
       wire_thickness = aspect_ratio[1][0] * wire_width;
       wire_spacing = wire_pitch[1][0] - wire_width;
       barrier_thickness = 0.008;
       dishing_thickness = 0;
       alpha_scatter = 1;
-      wire_r_per_micron[1][0] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[1][0]  = 0.48;
-      miller_value[1][0]  = 1.5;
-      horiz_dielectric_constant[1][0]  = 3.038;
-      vert_dielectric_constant[1][0]  = 3.9;
+      wire_r_per_micron[1][0] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[1][0] = 0.48;
+      miller_value[1][0] = 1.5;
+      horiz_dielectric_constant[1][0] = 3.038;
+      vert_dielectric_constant[1][0] = 3.9;
       fringe_cap = 0.115e-15;
-      wire_c_per_micron[1][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[1][0], miller_value[1][0], horiz_dielectric_constant[1][0],
-          vert_dielectric_constant[1][0],
-          fringe_cap);
+      wire_c_per_micron[1][0] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][0],
+          miller_value[1][0], horiz_dielectric_constant[1][0],
+          vert_dielectric_constant[1][0], fringe_cap);
 
       wire_pitch[1][1] = 4 * g_ip->F_sz_um;
       wire_width = wire_pitch[1][1] / 2;
       aspect_ratio[1][1] = 2.0;
       wire_thickness = aspect_ratio[1][1] * wire_width;
       wire_spacing = wire_pitch[1][1] - wire_width;
-      wire_r_per_micron[1][1] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[1][1]  = 0.48;
-      miller_value[1][1]  = 1.5;
-      horiz_dielectric_constant[1][1]  = 3.038;
-      vert_dielectric_constant[1][1]  = 3.9;
-      wire_c_per_micron[1][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[1][1], miller_value[1][1], horiz_dielectric_constant[1][1],
-          vert_dielectric_constant[1][1],
-          fringe_cap);
+      wire_r_per_micron[1][1] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[1][1] = 0.48;
+      miller_value[1][1] = 1.5;
+      horiz_dielectric_constant[1][1] = 3.038;
+      vert_dielectric_constant[1][1] = 3.9;
+      wire_c_per_micron[1][1] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][1],
+          miller_value[1][1], horiz_dielectric_constant[1][1],
+          vert_dielectric_constant[1][1], fringe_cap);
 
       wire_pitch[1][2] = 8 * g_ip->F_sz_um;
-      aspect_ratio[1][2]  = 2.2;
+      aspect_ratio[1][2] = 2.2;
       wire_width = wire_pitch[1][2] / 2;
       wire_thickness = aspect_ratio[1][2] * wire_width;
       wire_spacing = wire_pitch[1][2] - wire_width;
-      dishing_thickness = 0.1 *  wire_thickness;
-      wire_r_per_micron[1][2] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[1][2]  = 1.1;
-      miller_value[1][2]  = 1.5;
-      horiz_dielectric_constant[1][2]  = 3.038;
-      vert_dielectric_constant[1][2]  = 3.9;
-      wire_c_per_micron[1][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[1][2] , miller_value[1][2], horiz_dielectric_constant[1][2], vert_dielectric_constant[1][2],
-          fringe_cap);
-      //Nominal projections for commodity DRAM wordline/bitline
+      dishing_thickness = 0.1 * wire_thickness;
+      wire_r_per_micron[1][2] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[1][2] = 1.1;
+      miller_value[1][2] = 1.5;
+      horiz_dielectric_constant[1][2] = 3.038;
+      vert_dielectric_constant[1][2] = 3.9;
+      wire_c_per_micron[1][2] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][2],
+          miller_value[1][2], horiz_dielectric_constant[1][2],
+          vert_dielectric_constant[1][2], fringe_cap);
+      // Nominal projections for commodity DRAM wordline/bitline
       wire_pitch[1][3] = 2 * 0.09;
       wire_c_per_micron[1][3] = 60e-15 / (256 * 2 * 0.09);
       wire_r_per_micron[1][3] = 12 / 0.09;
-    }
-    else if (tech == 65)
-    {
-      //Aggressive projections
+    } else if (tech == 65) {
+      // Aggressive projections
       wire_pitch[0][0] = 2.5 * g_ip->F_sz_um;
-      aspect_ratio[0][0]  = 2.7;
+      aspect_ratio[0][0] = 2.7;
       wire_width = wire_pitch[0][0] / 2;
-      wire_thickness = aspect_ratio[0][0]  * wire_width;
+      wire_thickness = aspect_ratio[0][0] * wire_width;
       wire_spacing = wire_pitch[0][0] - wire_width;
       barrier_thickness = 0;
       dishing_thickness = 0;
       alpha_scatter = 1;
-      wire_r_per_micron[0][0] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[0][0]  = 0.405;
-      miller_value[0][0]   = 1.5;
-      horiz_dielectric_constant[0][0]  = 2.303;
-      vert_dielectric_constant[0][0]   = 3.9;
+      wire_r_per_micron[0][0] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][0] = 0.405;
+      miller_value[0][0] = 1.5;
+      horiz_dielectric_constant[0][0] = 2.303;
+      vert_dielectric_constant[0][0] = 3.9;
       fringe_cap = 0.115e-15;
-      wire_c_per_micron[0][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[0][0] , miller_value[0][0] , horiz_dielectric_constant[0][0] , vert_dielectric_constant[0][0] ,
-          fringe_cap);
+      wire_c_per_micron[0][0] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][0],
+          miller_value[0][0], horiz_dielectric_constant[0][0],
+          vert_dielectric_constant[0][0], fringe_cap);
 
       wire_pitch[0][1] = 4 * g_ip->F_sz_um;
       wire_width = wire_pitch[0][1] / 2;
-      aspect_ratio[0][1]  = 2.7;
-      wire_thickness = aspect_ratio[0][1]  * wire_width;
+      aspect_ratio[0][1] = 2.7;
+      wire_thickness = aspect_ratio[0][1] * wire_width;
       wire_spacing = wire_pitch[0][1] - wire_width;
-      wire_r_per_micron[0][1] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[0][1]  = 0.405;
-      miller_value[0][1]   = 1.5;
-      horiz_dielectric_constant[0][1]  = 2.303;
-      vert_dielectric_constant[0][1]   = 3.9;
-      wire_c_per_micron[0][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[0][1], miller_value[0][1], horiz_dielectric_constant[0][1],
-          vert_dielectric_constant[0][1],
-          fringe_cap);
+      wire_r_per_micron[0][1] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][1] = 0.405;
+      miller_value[0][1] = 1.5;
+      horiz_dielectric_constant[0][1] = 2.303;
+      vert_dielectric_constant[0][1] = 3.9;
+      wire_c_per_micron[0][1] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][1],
+          miller_value[0][1], horiz_dielectric_constant[0][1],
+          vert_dielectric_constant[0][1], fringe_cap);
 
       wire_pitch[0][2] = 8 * g_ip->F_sz_um;
       aspect_ratio[0][2] = 2.8;
       wire_width = wire_pitch[0][2] / 2;
       wire_thickness = aspect_ratio[0][2] * wire_width;
       wire_spacing = wire_pitch[0][2] - wire_width;
-      wire_r_per_micron[0][2] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+      wire_r_per_micron[0][2] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[0][2] = 0.81;
-      miller_value[0][2]   = 1.5;
-      horiz_dielectric_constant[0][2]  = 2.303;
-      vert_dielectric_constant[0][2]   = 3.9;
-      wire_c_per_micron[0][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[0][2], miller_value[0][2], horiz_dielectric_constant[0][2], vert_dielectric_constant[0][2],
-          fringe_cap);
+      miller_value[0][2] = 1.5;
+      horiz_dielectric_constant[0][2] = 2.303;
+      vert_dielectric_constant[0][2] = 3.9;
+      wire_c_per_micron[0][2] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][2],
+          miller_value[0][2], horiz_dielectric_constant[0][2],
+          vert_dielectric_constant[0][2], fringe_cap);
 
-      //Conservative projections
+      // Conservative projections
       wire_pitch[1][0] = 2.5 * g_ip->F_sz_um;
       aspect_ratio[1][0] = 2.0;
       wire_width = wire_pitch[1][0] / 2;
@@ -2085,139 +2159,35 @@ void init_tech_params(double technology, bool is_tag)
       barrier_thickness = 0.006;
       dishing_thickness = 0;
       alpha_scatter = 1;
-      wire_r_per_micron[1][0] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+      wire_r_per_micron[1][0] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[1][0] = 0.405;
       miller_value[1][0] = 1.5;
       horiz_dielectric_constant[1][0] = 2.734;
       vert_dielectric_constant[1][0] = 3.9;
       fringe_cap = 0.115e-15;
-      wire_c_per_micron[1][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[1][0], miller_value[1][0], horiz_dielectric_constant[1][0], vert_dielectric_constant[1][0],
-          fringe_cap);
+      wire_c_per_micron[1][0] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][0],
+          miller_value[1][0], horiz_dielectric_constant[1][0],
+          vert_dielectric_constant[1][0], fringe_cap);
 
       wire_pitch[1][1] = 4 * g_ip->F_sz_um;
       wire_width = wire_pitch[1][1] / 2;
       aspect_ratio[1][1] = 2.0;
       wire_thickness = aspect_ratio[1][1] * wire_width;
       wire_spacing = wire_pitch[1][1] - wire_width;
-      wire_r_per_micron[1][1] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+      wire_r_per_micron[1][1] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[1][1] = 0.405;
       miller_value[1][1] = 1.5;
       horiz_dielectric_constant[1][1] = 2.734;
       vert_dielectric_constant[1][1] = 3.9;
-      wire_c_per_micron[1][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[1][1], miller_value[1][1], horiz_dielectric_constant[1][1], vert_dielectric_constant[1][1],
-          fringe_cap);
-
-      wire_pitch[1][2] = 8 * g_ip->F_sz_um;
-      aspect_ratio[1][2] = 2.2;
-      wire_width = wire_pitch[1][2] / 2;
-      wire_thickness = aspect_ratio[1][2] * wire_width;
-      wire_spacing = wire_pitch[1][2] - wire_width;
-      dishing_thickness = 0.1 *  wire_thickness;
-      wire_r_per_micron[1][2] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[1][2] = 0.77;
-      miller_value[1][2] = 1.5;
-      horiz_dielectric_constant[1][2] = 2.734;
-      vert_dielectric_constant[1][2] = 3.9;
-      wire_c_per_micron[1][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[1][2], miller_value[1][2], horiz_dielectric_constant[1][2], vert_dielectric_constant[1][2],
-          fringe_cap);
-      //Nominal projections for commodity DRAM wordline/bitline
-      wire_pitch[1][3] = 2 * 0.065;
-      wire_c_per_micron[1][3] = 52.5e-15 / (256 * 2 * 0.065);
-      wire_r_per_micron[1][3] = 12 / 0.065;
-    }
-    else if (tech == 45)
-    {
-      //Aggressive projections.
-      wire_pitch[0][0] = 2.5 * g_ip->F_sz_um;
-      aspect_ratio[0][0]  = 3.0;
-      wire_width = wire_pitch[0][0] / 2;
-      wire_thickness = aspect_ratio[0][0]  * wire_width;
-      wire_spacing = wire_pitch[0][0] - wire_width;
-      barrier_thickness = 0;
-      dishing_thickness = 0;
-      alpha_scatter = 1;
-      wire_r_per_micron[0][0] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[0][0]  = 0.315;
-      miller_value[0][0]  = 1.5;
-      horiz_dielectric_constant[0][0]  = 1.958;
-      vert_dielectric_constant[0][0]  = 3.9;
-      fringe_cap = 0.115e-15;
-      wire_c_per_micron[0][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[0][0] , miller_value[0][0] , horiz_dielectric_constant[0][0] , vert_dielectric_constant[0][0] ,
-          fringe_cap);
-
-      wire_pitch[0][1] = 4 * g_ip->F_sz_um;
-      wire_width = wire_pitch[0][1] / 2;
-      aspect_ratio[0][1]  = 3.0;
-      wire_thickness = aspect_ratio[0][1] * wire_width;
-      wire_spacing = wire_pitch[0][1] - wire_width;
-      wire_r_per_micron[0][1] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[0][1]  = 0.315;
-      miller_value[0][1]  = 1.5;
-      horiz_dielectric_constant[0][1]  = 1.958;
-      vert_dielectric_constant[0][1]  = 3.9;
-      wire_c_per_micron[0][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[0][1], miller_value[0][1], horiz_dielectric_constant[0][1], vert_dielectric_constant[0][1],
-          fringe_cap);
-
-      wire_pitch[0][2] = 8 * g_ip->F_sz_um;
-      aspect_ratio[0][2] = 3.0;
-      wire_width = wire_pitch[0][2] / 2;
-      wire_thickness = aspect_ratio[0][2] * wire_width;
-      wire_spacing = wire_pitch[0][2] - wire_width;
-      wire_r_per_micron[0][2] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[0][2] = 0.63;
-      miller_value[0][2]  = 1.5;
-      horiz_dielectric_constant[0][2]  = 1.958;
-      vert_dielectric_constant[0][2]  = 3.9;
-      wire_c_per_micron[0][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[0][2], miller_value[0][2], horiz_dielectric_constant[0][2], vert_dielectric_constant[0][2],
-          fringe_cap);
-
-      //Conservative projections
-      wire_pitch[1][0] = 2.5 * g_ip->F_sz_um;
-      aspect_ratio[1][0] = 2.0;
-      wire_width = wire_pitch[1][0] / 2;
-      wire_thickness = aspect_ratio[1][0] * wire_width;
-      wire_spacing = wire_pitch[1][0] - wire_width;
-      barrier_thickness = 0.004;
-      dishing_thickness = 0;
-      alpha_scatter = 1;
-      wire_r_per_micron[1][0] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[1][0] = 0.315;
-      miller_value[1][0] = 1.5;
-      horiz_dielectric_constant[1][0] = 2.46;
-      vert_dielectric_constant[1][0] = 3.9;
-      fringe_cap = 0.115e-15;
-      wire_c_per_micron[1][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[1][0], miller_value[1][0], horiz_dielectric_constant[1][0], vert_dielectric_constant[1][0],
-          fringe_cap);
-
-      wire_pitch[1][1] = 4 * g_ip->F_sz_um;
-      wire_width = wire_pitch[1][1] / 2;
-      aspect_ratio[1][1] = 2.0;
-      wire_thickness = aspect_ratio[1][1] * wire_width;
-      wire_spacing = wire_pitch[1][1] - wire_width;
-      wire_r_per_micron[1][1] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[1][1] = 0.315;
-      miller_value[1][1] = 1.5;
-      horiz_dielectric_constant[1][1] = 2.46;
-      vert_dielectric_constant[1][1] = 3.9;
-      fringe_cap = 0.115e-15;
-      wire_c_per_micron[1][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[1][1], miller_value[1][1], horiz_dielectric_constant[1][1], vert_dielectric_constant[1][1],
-          fringe_cap);
+      wire_c_per_micron[1][1] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][1],
+          miller_value[1][1], horiz_dielectric_constant[1][1],
+          vert_dielectric_constant[1][1], fringe_cap);
 
       wire_pitch[1][2] = 8 * g_ip->F_sz_um;
       aspect_ratio[1][2] = 2.2;
@@ -2225,23 +2195,23 @@ void init_tech_params(double technology, bool is_tag)
       wire_thickness = aspect_ratio[1][2] * wire_width;
       wire_spacing = wire_pitch[1][2] - wire_width;
       dishing_thickness = 0.1 * wire_thickness;
-      wire_r_per_micron[1][2] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[1][2] = 0.55;
+      wire_r_per_micron[1][2] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[1][2] = 0.77;
       miller_value[1][2] = 1.5;
-      horiz_dielectric_constant[1][2] = 2.46;
+      horiz_dielectric_constant[1][2] = 2.734;
       vert_dielectric_constant[1][2] = 3.9;
-      wire_c_per_micron[1][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[1][2], miller_value[1][2], horiz_dielectric_constant[1][2], vert_dielectric_constant[1][2],
-          fringe_cap);
-      //Nominal projections for commodity DRAM wordline/bitline
-      wire_pitch[1][3] = 2 * 0.045;
-      wire_c_per_micron[1][3] = 37.5e-15 / (256 * 2 * 0.045);
-      wire_r_per_micron[1][3] = 12 / 0.045;
-    }
-    else if (tech == 32)
-    {
-      //Aggressive projections.
+      wire_c_per_micron[1][2] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][2],
+          miller_value[1][2], horiz_dielectric_constant[1][2],
+          vert_dielectric_constant[1][2], fringe_cap);
+      // Nominal projections for commodity DRAM wordline/bitline
+      wire_pitch[1][3] = 2 * 0.065;
+      wire_c_per_micron[1][3] = 52.5e-15 / (256 * 2 * 0.065);
+      wire_r_per_micron[1][3] = 12 / 0.065;
+    } else if (tech == 45) {
+      // Aggressive projections.
       wire_pitch[0][0] = 2.5 * g_ip->F_sz_um;
       aspect_ratio[0][0] = 3.0;
       wire_width = wire_pitch[0][0] / 2;
@@ -2250,48 +2220,172 @@ void init_tech_params(double technology, bool is_tag)
       barrier_thickness = 0;
       dishing_thickness = 0;
       alpha_scatter = 1;
-      wire_r_per_micron[0][0] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[0][0] = 0.21;
+      wire_r_per_micron[0][0] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][0] = 0.315;
       miller_value[0][0] = 1.5;
-      horiz_dielectric_constant[0][0] = 1.664;
+      horiz_dielectric_constant[0][0] = 1.958;
       vert_dielectric_constant[0][0] = 3.9;
       fringe_cap = 0.115e-15;
-      wire_c_per_micron[0][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[0][0], miller_value[0][0], horiz_dielectric_constant[0][0], vert_dielectric_constant[0][0],
-          fringe_cap);
+      wire_c_per_micron[0][0] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][0],
+          miller_value[0][0], horiz_dielectric_constant[0][0],
+          vert_dielectric_constant[0][0], fringe_cap);
 
       wire_pitch[0][1] = 4 * g_ip->F_sz_um;
       wire_width = wire_pitch[0][1] / 2;
       aspect_ratio[0][1] = 3.0;
       wire_thickness = aspect_ratio[0][1] * wire_width;
       wire_spacing = wire_pitch[0][1] - wire_width;
-      wire_r_per_micron[0][1] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[0][1] = 0.21;
+      wire_r_per_micron[0][1] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][1] = 0.315;
       miller_value[0][1] = 1.5;
-      horiz_dielectric_constant[0][1] = 1.664;
+      horiz_dielectric_constant[0][1] = 1.958;
       vert_dielectric_constant[0][1] = 3.9;
-      wire_c_per_micron[0][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[0][1], miller_value[0][1], horiz_dielectric_constant[0][1], vert_dielectric_constant[0][1],
-          fringe_cap);
+      wire_c_per_micron[0][1] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][1],
+          miller_value[0][1], horiz_dielectric_constant[0][1],
+          vert_dielectric_constant[0][1], fringe_cap);
 
       wire_pitch[0][2] = 8 * g_ip->F_sz_um;
       aspect_ratio[0][2] = 3.0;
       wire_width = wire_pitch[0][2] / 2;
       wire_thickness = aspect_ratio[0][2] * wire_width;
       wire_spacing = wire_pitch[0][2] - wire_width;
-      wire_r_per_micron[0][2] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+      wire_r_per_micron[0][2] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][2] = 0.63;
+      miller_value[0][2] = 1.5;
+      horiz_dielectric_constant[0][2] = 1.958;
+      vert_dielectric_constant[0][2] = 3.9;
+      wire_c_per_micron[0][2] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][2],
+          miller_value[0][2], horiz_dielectric_constant[0][2],
+          vert_dielectric_constant[0][2], fringe_cap);
+
+      // Conservative projections
+      wire_pitch[1][0] = 2.5 * g_ip->F_sz_um;
+      aspect_ratio[1][0] = 2.0;
+      wire_width = wire_pitch[1][0] / 2;
+      wire_thickness = aspect_ratio[1][0] * wire_width;
+      wire_spacing = wire_pitch[1][0] - wire_width;
+      barrier_thickness = 0.004;
+      dishing_thickness = 0;
+      alpha_scatter = 1;
+      wire_r_per_micron[1][0] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[1][0] = 0.315;
+      miller_value[1][0] = 1.5;
+      horiz_dielectric_constant[1][0] = 2.46;
+      vert_dielectric_constant[1][0] = 3.9;
+      fringe_cap = 0.115e-15;
+      wire_c_per_micron[1][0] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][0],
+          miller_value[1][0], horiz_dielectric_constant[1][0],
+          vert_dielectric_constant[1][0], fringe_cap);
+
+      wire_pitch[1][1] = 4 * g_ip->F_sz_um;
+      wire_width = wire_pitch[1][1] / 2;
+      aspect_ratio[1][1] = 2.0;
+      wire_thickness = aspect_ratio[1][1] * wire_width;
+      wire_spacing = wire_pitch[1][1] - wire_width;
+      wire_r_per_micron[1][1] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[1][1] = 0.315;
+      miller_value[1][1] = 1.5;
+      horiz_dielectric_constant[1][1] = 2.46;
+      vert_dielectric_constant[1][1] = 3.9;
+      fringe_cap = 0.115e-15;
+      wire_c_per_micron[1][1] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][1],
+          miller_value[1][1], horiz_dielectric_constant[1][1],
+          vert_dielectric_constant[1][1], fringe_cap);
+
+      wire_pitch[1][2] = 8 * g_ip->F_sz_um;
+      aspect_ratio[1][2] = 2.2;
+      wire_width = wire_pitch[1][2] / 2;
+      wire_thickness = aspect_ratio[1][2] * wire_width;
+      wire_spacing = wire_pitch[1][2] - wire_width;
+      dishing_thickness = 0.1 * wire_thickness;
+      wire_r_per_micron[1][2] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[1][2] = 0.55;
+      miller_value[1][2] = 1.5;
+      horiz_dielectric_constant[1][2] = 2.46;
+      vert_dielectric_constant[1][2] = 3.9;
+      wire_c_per_micron[1][2] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][2],
+          miller_value[1][2], horiz_dielectric_constant[1][2],
+          vert_dielectric_constant[1][2], fringe_cap);
+      // Nominal projections for commodity DRAM wordline/bitline
+      wire_pitch[1][3] = 2 * 0.045;
+      wire_c_per_micron[1][3] = 37.5e-15 / (256 * 2 * 0.045);
+      wire_r_per_micron[1][3] = 12 / 0.045;
+    } else if (tech == 32) {
+      // Aggressive projections.
+      wire_pitch[0][0] = 2.5 * g_ip->F_sz_um;
+      aspect_ratio[0][0] = 3.0;
+      wire_width = wire_pitch[0][0] / 2;
+      wire_thickness = aspect_ratio[0][0] * wire_width;
+      wire_spacing = wire_pitch[0][0] - wire_width;
+      barrier_thickness = 0;
+      dishing_thickness = 0;
+      alpha_scatter = 1;
+      wire_r_per_micron[0][0] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][0] = 0.21;
+      miller_value[0][0] = 1.5;
+      horiz_dielectric_constant[0][0] = 1.664;
+      vert_dielectric_constant[0][0] = 3.9;
+      fringe_cap = 0.115e-15;
+      wire_c_per_micron[0][0] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][0],
+          miller_value[0][0], horiz_dielectric_constant[0][0],
+          vert_dielectric_constant[0][0], fringe_cap);
+
+      wire_pitch[0][1] = 4 * g_ip->F_sz_um;
+      wire_width = wire_pitch[0][1] / 2;
+      aspect_ratio[0][1] = 3.0;
+      wire_thickness = aspect_ratio[0][1] * wire_width;
+      wire_spacing = wire_pitch[0][1] - wire_width;
+      wire_r_per_micron[0][1] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][1] = 0.21;
+      miller_value[0][1] = 1.5;
+      horiz_dielectric_constant[0][1] = 1.664;
+      vert_dielectric_constant[0][1] = 3.9;
+      wire_c_per_micron[0][1] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][1],
+          miller_value[0][1], horiz_dielectric_constant[0][1],
+          vert_dielectric_constant[0][1], fringe_cap);
+
+      wire_pitch[0][2] = 8 * g_ip->F_sz_um;
+      aspect_ratio[0][2] = 3.0;
+      wire_width = wire_pitch[0][2] / 2;
+      wire_thickness = aspect_ratio[0][2] * wire_width;
+      wire_spacing = wire_pitch[0][2] - wire_width;
+      wire_r_per_micron[0][2] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[0][2] = 0.42;
       miller_value[0][2] = 1.5;
       horiz_dielectric_constant[0][2] = 1.664;
       vert_dielectric_constant[0][2] = 3.9;
-      wire_c_per_micron[0][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[0][2], miller_value[0][2], horiz_dielectric_constant[0][2], vert_dielectric_constant[0][2],
-          fringe_cap);
+      wire_c_per_micron[0][2] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][2],
+          miller_value[0][2], horiz_dielectric_constant[0][2],
+          vert_dielectric_constant[0][2], fringe_cap);
 
-      //Conservative projections
+      // Conservative projections
       wire_pitch[1][0] = 2.5 * g_ip->F_sz_um;
       aspect_ratio[1][0] = 2.0;
       wire_width = wire_pitch[1][0] / 2;
@@ -2300,460 +2394,561 @@ void init_tech_params(double technology, bool is_tag)
       barrier_thickness = 0.003;
       dishing_thickness = 0;
       alpha_scatter = 1;
-      wire_r_per_micron[1][0] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+      wire_r_per_micron[1][0] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[1][0] = 0.21;
       miller_value[1][0] = 1.5;
       horiz_dielectric_constant[1][0] = 2.214;
       vert_dielectric_constant[1][0] = 3.9;
       fringe_cap = 0.115e-15;
-      wire_c_per_micron[1][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[1][0], miller_value[1][0], horiz_dielectric_constant[1][0], vert_dielectric_constant[1][0],
-          fringe_cap);
+      wire_c_per_micron[1][0] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][0],
+          miller_value[1][0], horiz_dielectric_constant[1][0],
+          vert_dielectric_constant[1][0], fringe_cap);
 
       wire_pitch[1][1] = 4 * g_ip->F_sz_um;
       aspect_ratio[1][1] = 2.0;
       wire_width = wire_pitch[1][1] / 2;
       wire_thickness = aspect_ratio[1][1] * wire_width;
       wire_spacing = wire_pitch[1][1] - wire_width;
-      wire_r_per_micron[1][1] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+      wire_r_per_micron[1][1] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[1][1] = 0.21;
       miller_value[1][1] = 1.5;
       horiz_dielectric_constant[1][1] = 2.214;
       vert_dielectric_constant[1][1] = 3.9;
-      wire_c_per_micron[1][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[1][1], miller_value[1][1], horiz_dielectric_constant[1][1], vert_dielectric_constant[1][1],
-          fringe_cap);
+      wire_c_per_micron[1][1] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][1],
+          miller_value[1][1], horiz_dielectric_constant[1][1],
+          vert_dielectric_constant[1][1], fringe_cap);
 
       wire_pitch[1][2] = 8 * g_ip->F_sz_um;
       aspect_ratio[1][2] = 2.2;
       wire_width = wire_pitch[1][2] / 2;
       wire_thickness = aspect_ratio[1][2] * wire_width;
       wire_spacing = wire_pitch[1][2] - wire_width;
-      dishing_thickness = 0.1 *  wire_thickness;
-      wire_r_per_micron[1][2] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+      dishing_thickness = 0.1 * wire_thickness;
+      wire_r_per_micron[1][2] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[1][2] = 0.385;
       miller_value[1][2] = 1.5;
       horiz_dielectric_constant[1][2] = 2.214;
       vert_dielectric_constant[1][2] = 3.9;
-      wire_c_per_micron[1][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[1][2], miller_value[1][2], horiz_dielectric_constant[1][2], vert_dielectric_constant[1][2],
-          fringe_cap);
-      //Nominal projections for commodity DRAM wordline/bitline
-      wire_pitch[1][3] = 2 * 0.032;//micron
-      wire_c_per_micron[1][3] = 31e-15 / (256 * 2 * 0.032);//F/micron
-      wire_r_per_micron[1][3] = 12 / 0.032;//ohm/micron
+      wire_c_per_micron[1][2] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][2],
+          miller_value[1][2], horiz_dielectric_constant[1][2],
+          vert_dielectric_constant[1][2], fringe_cap);
+      // Nominal projections for commodity DRAM wordline/bitline
+      wire_pitch[1][3] = 2 * 0.032;                          // micron
+      wire_c_per_micron[1][3] = 31e-15 / (256 * 2 * 0.032);  // F/micron
+      wire_r_per_micron[1][3] = 12 / 0.032;                  // ohm/micron
+    } else if (tech == 22) {
+      // Aggressive projections.
+      wire_pitch[0][0] = 2.5 * g_ip->F_sz_um;  // local
+      aspect_ratio[0][0] = 3.0;
+      wire_width = wire_pitch[0][0] / 2;
+      wire_thickness = aspect_ratio[0][0] * wire_width;
+      wire_spacing = wire_pitch[0][0] - wire_width;
+      barrier_thickness = 0;
+      dishing_thickness = 0;
+      alpha_scatter = 1;
+      wire_r_per_micron[0][0] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][0] = 0.15;
+      miller_value[0][0] = 1.5;
+      horiz_dielectric_constant[0][0] = 1.414;
+      vert_dielectric_constant[0][0] = 3.9;
+      fringe_cap = 0.115e-15;
+      wire_c_per_micron[0][0] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][0],
+          miller_value[0][0], horiz_dielectric_constant[0][0],
+          vert_dielectric_constant[0][0], fringe_cap);
+
+      wire_pitch[0][1] = 4 * g_ip->F_sz_um;  // semi-global
+      wire_width = wire_pitch[0][1] / 2;
+      aspect_ratio[0][1] = 3.0;
+      wire_thickness = aspect_ratio[0][1] * wire_width;
+      wire_spacing = wire_pitch[0][1] - wire_width;
+      wire_r_per_micron[0][1] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][1] = 0.15;
+      miller_value[0][1] = 1.5;
+      horiz_dielectric_constant[0][1] = 1.414;
+      vert_dielectric_constant[0][1] = 3.9;
+      wire_c_per_micron[0][1] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][1],
+          miller_value[0][1], horiz_dielectric_constant[0][1],
+          vert_dielectric_constant[0][1], fringe_cap);
+
+      wire_pitch[0][2] = 8 * g_ip->F_sz_um;  // global
+      aspect_ratio[0][2] = 3.0;
+      wire_width = wire_pitch[0][2] / 2;
+      wire_thickness = aspect_ratio[0][2] * wire_width;
+      wire_spacing = wire_pitch[0][2] - wire_width;
+      wire_r_per_micron[0][2] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][2] = 0.3;
+      miller_value[0][2] = 1.5;
+      horiz_dielectric_constant[0][2] = 1.414;
+      vert_dielectric_constant[0][2] = 3.9;
+      wire_c_per_micron[0][2] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][2],
+          miller_value[0][2], horiz_dielectric_constant[0][2],
+          vert_dielectric_constant[0][2], fringe_cap);
+
+      //          //*************************
+      //          wire_pitch[0][4] = 16 * g_ip.F_sz_um;//global
+      //          aspect_ratio = 3.0;
+      //          wire_width = wire_pitch[0][4] / 2;
+      //          wire_thickness = aspect_ratio * wire_width;
+      //          wire_spacing = wire_pitch[0][4] - wire_width;
+      //          wire_r_per_micron[0][4] = wire_resistance(BULK_CU_RESISTIVITY,
+      //          wire_width,
+      //        		  wire_thickness, barrier_thickness,
+      //        dishing_thickness, alpha_scatter);
+      //          ild_thickness = 0.3;
+      //          wire_c_per_micron[0][4] = wire_capacitance(wire_width,
+      //          wire_thickness, wire_spacing,
+      //        		  ild_thickness, miller_value,
+      //        horiz_dielectric_constant, vert_dielectric_constant,
+      //        		  fringe_cap);
+      //
+      //          wire_pitch[0][5] = 24 * g_ip.F_sz_um;//global
+      //          aspect_ratio = 3.0;
+      //          wire_width = wire_pitch[0][5] / 2;
+      //          wire_thickness = aspect_ratio * wire_width;
+      //          wire_spacing = wire_pitch[0][5] - wire_width;
+      //          wire_r_per_micron[0][5] = wire_resistance(BULK_CU_RESISTIVITY,
+      //          wire_width,
+      //        		  wire_thickness, barrier_thickness,
+      //        dishing_thickness, alpha_scatter);
+      //          ild_thickness = 0.3;
+      //          wire_c_per_micron[0][5] = wire_capacitance(wire_width,
+      //          wire_thickness, wire_spacing,
+      //        		  ild_thickness, miller_value,
+      //        horiz_dielectric_constant, vert_dielectric_constant,
+      //        		  fringe_cap);
+      //
+      //          wire_pitch[0][6] = 32 * g_ip.F_sz_um;//global
+      //          aspect_ratio = 3.0;
+      //          wire_width = wire_pitch[0][6] / 2;
+      //          wire_thickness = aspect_ratio * wire_width;
+      //          wire_spacing = wire_pitch[0][6] - wire_width;
+      //          wire_r_per_micron[0][6] = wire_resistance(BULK_CU_RESISTIVITY,
+      //          wire_width,
+      //        		  wire_thickness, barrier_thickness,
+      //        dishing_thickness, alpha_scatter);
+      //          ild_thickness = 0.3;
+      //          wire_c_per_micron[0][6] = wire_capacitance(wire_width,
+      //          wire_thickness, wire_spacing,
+      //        		  ild_thickness, miller_value,
+      //        horiz_dielectric_constant, vert_dielectric_constant,
+      //        		  fringe_cap);
+      //*************************
+
+      // Conservative projections
+      wire_pitch[1][0] = 2.5 * g_ip->F_sz_um;
+      aspect_ratio[1][0] = 2.0;
+      wire_width = wire_pitch[1][0] / 2;
+      wire_thickness = aspect_ratio[1][0] * wire_width;
+      wire_spacing = wire_pitch[1][0] - wire_width;
+      barrier_thickness = 0.003;
+      dishing_thickness = 0;
+      alpha_scatter = 1.05;
+      wire_r_per_micron[1][0] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[1][0] = 0.15;
+      miller_value[1][0] = 1.5;
+      horiz_dielectric_constant[1][0] = 2.104;
+      vert_dielectric_constant[1][0] = 3.9;
+      fringe_cap = 0.115e-15;
+      wire_c_per_micron[1][0] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][0],
+          miller_value[1][0], horiz_dielectric_constant[1][0],
+          vert_dielectric_constant[1][0], fringe_cap);
+
+      wire_pitch[1][1] = 4 * g_ip->F_sz_um;
+      wire_width = wire_pitch[1][1] / 2;
+      aspect_ratio[1][1] = 2.0;
+      wire_thickness = aspect_ratio[1][1] * wire_width;
+      wire_spacing = wire_pitch[1][1] - wire_width;
+      wire_r_per_micron[1][1] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[1][1] = 0.15;
+      miller_value[1][1] = 1.5;
+      horiz_dielectric_constant[1][1] = 2.104;
+      vert_dielectric_constant[1][1] = 3.9;
+      wire_c_per_micron[1][1] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][1],
+          miller_value[1][1], horiz_dielectric_constant[1][1],
+          vert_dielectric_constant[1][1], fringe_cap);
+
+      wire_pitch[1][2] = 8 * g_ip->F_sz_um;
+      aspect_ratio[1][2] = 2.2;
+      wire_width = wire_pitch[1][2] / 2;
+      wire_thickness = aspect_ratio[1][2] * wire_width;
+      wire_spacing = wire_pitch[1][2] - wire_width;
+      dishing_thickness = 0.1 * wire_thickness;
+      wire_r_per_micron[1][2] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[1][2] = 0.275;
+      miller_value[1][2] = 1.5;
+      horiz_dielectric_constant[1][2] = 2.104;
+      vert_dielectric_constant[1][2] = 3.9;
+      wire_c_per_micron[1][2] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][2],
+          miller_value[1][2], horiz_dielectric_constant[1][2],
+          vert_dielectric_constant[1][2], fringe_cap);
+      // Nominal projections for commodity DRAM wordline/bitline
+      wire_pitch[1][3] = 2 * 0.022;                          // micron
+      wire_c_per_micron[1][3] = 31e-15 / (256 * 2 * 0.022);  // F/micron
+      wire_r_per_micron[1][3] = 12 / 0.022;                  // ohm/micron
+
+      //******************
+      //            wire_pitch[1][4] = 16 * g_ip.F_sz_um;
+      //            aspect_ratio = 2.2;
+      //            wire_width = wire_pitch[1][4] / 2;
+      //            wire_thickness = aspect_ratio * wire_width;
+      //            wire_spacing = wire_pitch[1][4] - wire_width;
+      //            dishing_thickness = 0.1 *  wire_thickness;
+      //            wire_r_per_micron[1][4] = wire_resistance(CU_RESISTIVITY,
+      //            wire_width, 		wire_thickness,
+      //            barrier_thickness, dishing_thickness, alpha_scatter);
+      //            ild_thickness = 0.275; wire_c_per_micron[1][4] =
+      //            wire_capacitance(wire_width, wire_thickness, wire_spacing,
+      //            ild_thickness, miller_value, horiz_dielectric_constant,
+      //            vert_dielectric_constant, 		fringe_cap);
+      //
+      //            wire_pitch[1][5] = 24 * g_ip.F_sz_um;
+      //            aspect_ratio = 2.2;
+      //            wire_width = wire_pitch[1][5] / 2;
+      //            wire_thickness = aspect_ratio * wire_width;
+      //            wire_spacing = wire_pitch[1][5] - wire_width;
+      //            dishing_thickness = 0.1 *  wire_thickness;
+      //            wire_r_per_micron[1][5] = wire_resistance(CU_RESISTIVITY,
+      //            wire_width, 		wire_thickness,
+      //            barrier_thickness, dishing_thickness, alpha_scatter);
+      //            ild_thickness = 0.275; wire_c_per_micron[1][5] =
+      //            wire_capacitance(wire_width, wire_thickness, wire_spacing,
+      //            ild_thickness, miller_value, horiz_dielectric_constant,
+      //            vert_dielectric_constant, 		fringe_cap);
+      //
+      //            wire_pitch[1][6] = 32 * g_ip.F_sz_um;
+      //            aspect_ratio = 2.2;
+      //            wire_width = wire_pitch[1][6] / 2;
+      //            wire_thickness = aspect_ratio * wire_width;
+      //            wire_spacing = wire_pitch[1][6] - wire_width;
+      //            dishing_thickness = 0.1 *  wire_thickness;
+      //            wire_r_per_micron[1][6] = wire_resistance(CU_RESISTIVITY,
+      //            wire_width, 		wire_thickness,
+      //            barrier_thickness, dishing_thickness, alpha_scatter);
+      //            ild_thickness = 0.275; wire_c_per_micron[1][6] =
+      //            wire_capacitance(wire_width, wire_thickness, wire_spacing,
+      //            ild_thickness, miller_value, horiz_dielectric_constant,
+      //            vert_dielectric_constant, 		fringe_cap);
     }
-    else if (tech == 22)
-        {
-          //Aggressive projections.
-          wire_pitch[0][0] = 2.5 * g_ip->F_sz_um;//local
-          aspect_ratio[0][0] = 3.0;
-          wire_width = wire_pitch[0][0] / 2;
-          wire_thickness = aspect_ratio[0][0] * wire_width;
-          wire_spacing = wire_pitch[0][0] - wire_width;
-          barrier_thickness = 0;
-          dishing_thickness = 0;
-          alpha_scatter = 1;
-          wire_r_per_micron[0][0] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-            wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-          ild_thickness[0][0] = 0.15;
-          miller_value[0][0] = 1.5;
-          horiz_dielectric_constant[0][0] = 1.414;
-          vert_dielectric_constant[0][0] = 3.9;
-          fringe_cap = 0.115e-15;
-          wire_c_per_micron[0][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-            ild_thickness[0][0], miller_value[0][0], horiz_dielectric_constant[0][0], vert_dielectric_constant[0][0],
-            fringe_cap);
 
-          wire_pitch[0][1] = 4 * g_ip->F_sz_um;//semi-global
-          wire_width = wire_pitch[0][1] / 2;
-          aspect_ratio[0][1] = 3.0;
-          wire_thickness = aspect_ratio[0][1] * wire_width;
-          wire_spacing = wire_pitch[0][1] - wire_width;
-          wire_r_per_micron[0][1] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-            wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-          ild_thickness[0][1] = 0.15;
-          miller_value[0][1] = 1.5;
-          horiz_dielectric_constant[0][1] = 1.414;
-          vert_dielectric_constant[0][1] = 3.9;
-          wire_c_per_micron[0][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-            ild_thickness[0][1], miller_value[0][1], horiz_dielectric_constant[0][1], vert_dielectric_constant[0][1],
-            fringe_cap);
+    else if (tech == 16) {
+      // Aggressive projections.
+      wire_pitch[0][0] = 2.5 * g_ip->F_sz_um;  // local
+      aspect_ratio[0][0] = 3.0;
+      wire_width = wire_pitch[0][0] / 2;
+      wire_thickness = aspect_ratio[0][0] * wire_width;
+      wire_spacing = wire_pitch[0][0] - wire_width;
+      barrier_thickness = 0;
+      dishing_thickness = 0;
+      alpha_scatter = 1;
+      wire_r_per_micron[0][0] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][0] = 0.108;
+      miller_value[0][0] = 1.5;
+      horiz_dielectric_constant[0][0] = 1.202;
+      vert_dielectric_constant[0][0] = 3.9;
+      fringe_cap = 0.115e-15;
+      wire_c_per_micron[0][0] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][0],
+          miller_value[0][0], horiz_dielectric_constant[0][0],
+          vert_dielectric_constant[0][0], fringe_cap);
 
-          wire_pitch[0][2] = 8 * g_ip->F_sz_um;//global
-          aspect_ratio[0][2] = 3.0;
-          wire_width = wire_pitch[0][2] / 2;
-          wire_thickness = aspect_ratio[0][2] * wire_width;
-          wire_spacing = wire_pitch[0][2] - wire_width;
-          wire_r_per_micron[0][2] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-        		  wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-          ild_thickness[0][2] = 0.3;
-          miller_value[0][2] = 1.5;
-          horiz_dielectric_constant[0][2] = 1.414;
-          vert_dielectric_constant[0][2] = 3.9;
-          wire_c_per_micron[0][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-        		  ild_thickness[0][2], miller_value[0][2], horiz_dielectric_constant[0][2], vert_dielectric_constant[0][2],
-        		  fringe_cap);
+      wire_pitch[0][1] = 4 * g_ip->F_sz_um;  // semi-global
+      aspect_ratio[0][1] = 3.0;
+      wire_width = wire_pitch[0][1] / 2;
+      wire_thickness = aspect_ratio[0][1] * wire_width;
+      wire_spacing = wire_pitch[0][1] - wire_width;
+      wire_r_per_micron[0][1] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][1] = 0.108;
+      miller_value[0][1] = 1.5;
+      horiz_dielectric_constant[0][1] = 1.202;
+      vert_dielectric_constant[0][1] = 3.9;
+      wire_c_per_micron[0][1] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][1],
+          miller_value[0][1], horiz_dielectric_constant[0][1],
+          vert_dielectric_constant[0][1], fringe_cap);
 
-//          //*************************
-//          wire_pitch[0][4] = 16 * g_ip.F_sz_um;//global
-//          aspect_ratio = 3.0;
-//          wire_width = wire_pitch[0][4] / 2;
-//          wire_thickness = aspect_ratio * wire_width;
-//          wire_spacing = wire_pitch[0][4] - wire_width;
-//          wire_r_per_micron[0][4] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-//        		  wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-//          ild_thickness = 0.3;
-//          wire_c_per_micron[0][4] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-//        		  ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
-//        		  fringe_cap);
-//
-//          wire_pitch[0][5] = 24 * g_ip.F_sz_um;//global
-//          aspect_ratio = 3.0;
-//          wire_width = wire_pitch[0][5] / 2;
-//          wire_thickness = aspect_ratio * wire_width;
-//          wire_spacing = wire_pitch[0][5] - wire_width;
-//          wire_r_per_micron[0][5] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-//        		  wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-//          ild_thickness = 0.3;
-//          wire_c_per_micron[0][5] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-//        		  ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
-//        		  fringe_cap);
-//
-//          wire_pitch[0][6] = 32 * g_ip.F_sz_um;//global
-//          aspect_ratio = 3.0;
-//          wire_width = wire_pitch[0][6] / 2;
-//          wire_thickness = aspect_ratio * wire_width;
-//          wire_spacing = wire_pitch[0][6] - wire_width;
-//          wire_r_per_micron[0][6] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-//        		  wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-//          ild_thickness = 0.3;
-//          wire_c_per_micron[0][6] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-//        		  ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
-//        		  fringe_cap);
-          //*************************
+      wire_pitch[0][2] = 8 * g_ip->F_sz_um;  // global
+      aspect_ratio[0][2] = 3.0;
+      wire_width = wire_pitch[0][2] / 2;
+      wire_thickness = aspect_ratio[0][2] * wire_width;
+      wire_spacing = wire_pitch[0][2] - wire_width;
+      wire_r_per_micron[0][2] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][2] = 0.216;
+      miller_value[0][2] = 1.5;
+      horiz_dielectric_constant[0][2] = 1.202;
+      vert_dielectric_constant[0][2] = 3.9;
+      wire_c_per_micron[0][2] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][2],
+          miller_value[0][2], horiz_dielectric_constant[0][2],
+          vert_dielectric_constant[0][2], fringe_cap);
 
-          //Conservative projections
-          wire_pitch[1][0] = 2.5 * g_ip->F_sz_um;
-          aspect_ratio[1][0] = 2.0;
-          wire_width = wire_pitch[1][0] / 2;
-          wire_thickness = aspect_ratio[1][0] * wire_width;
-          wire_spacing = wire_pitch[1][0] - wire_width;
-          barrier_thickness = 0.003;
-          dishing_thickness = 0;
-          alpha_scatter = 1.05;
-          wire_r_per_micron[1][0] = wire_resistance(CU_RESISTIVITY, wire_width,
-            wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-          ild_thickness[1][0] = 0.15;
-          miller_value[1][0] = 1.5;
-          horiz_dielectric_constant[1][0] = 2.104;
-          vert_dielectric_constant[1][0] = 3.9;
-          fringe_cap = 0.115e-15;
-          wire_c_per_micron[1][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-            ild_thickness[1][0], miller_value[1][0], horiz_dielectric_constant[1][0], vert_dielectric_constant[1][0],
-            fringe_cap);
+      //          //*************************
+      //          wire_pitch[0][4] = 16 * g_ip.F_sz_um;//global
+      //          aspect_ratio = 3.0;
+      //          wire_width = wire_pitch[0][4] / 2;
+      //          wire_thickness = aspect_ratio * wire_width;
+      //          wire_spacing = wire_pitch[0][4] - wire_width;
+      //          wire_r_per_micron[0][4] = wire_resistance(BULK_CU_RESISTIVITY,
+      //          wire_width,
+      //        		  wire_thickness, barrier_thickness,
+      //        dishing_thickness, alpha_scatter);
+      //          ild_thickness = 0.3;
+      //          wire_c_per_micron[0][4] = wire_capacitance(wire_width,
+      //          wire_thickness, wire_spacing,
+      //        		  ild_thickness, miller_value,
+      //        horiz_dielectric_constant, vert_dielectric_constant,
+      //        		  fringe_cap);
+      //
+      //          wire_pitch[0][5] = 24 * g_ip.F_sz_um;//global
+      //          aspect_ratio = 3.0;
+      //          wire_width = wire_pitch[0][5] / 2;
+      //          wire_thickness = aspect_ratio * wire_width;
+      //          wire_spacing = wire_pitch[0][5] - wire_width;
+      //          wire_r_per_micron[0][5] = wire_resistance(BULK_CU_RESISTIVITY,
+      //          wire_width,
+      //        		  wire_thickness, barrier_thickness,
+      //        dishing_thickness, alpha_scatter);
+      //          ild_thickness = 0.3;
+      //          wire_c_per_micron[0][5] = wire_capacitance(wire_width,
+      //          wire_thickness, wire_spacing,
+      //        		  ild_thickness, miller_value,
+      //        horiz_dielectric_constant, vert_dielectric_constant,
+      //        		  fringe_cap);
+      //
+      //          wire_pitch[0][6] = 32 * g_ip.F_sz_um;//global
+      //          aspect_ratio = 3.0;
+      //          wire_width = wire_pitch[0][6] / 2;
+      //          wire_thickness = aspect_ratio * wire_width;
+      //          wire_spacing = wire_pitch[0][6] - wire_width;
+      //          wire_r_per_micron[0][6] = wire_resistance(BULK_CU_RESISTIVITY,
+      //          wire_width,
+      //        		  wire_thickness, barrier_thickness,
+      //        dishing_thickness, alpha_scatter);
+      //          ild_thickness = 0.3;
+      //          wire_c_per_micron[0][6] = wire_capacitance(wire_width,
+      //          wire_thickness, wire_spacing,
+      //        		  ild_thickness, miller_value,
+      //        horiz_dielectric_constant, vert_dielectric_constant,
+      //        		  fringe_cap);
+      //*************************
 
-          wire_pitch[1][1] = 4 * g_ip->F_sz_um;
-          wire_width = wire_pitch[1][1] / 2;
-          aspect_ratio[1][1] = 2.0;
-          wire_thickness = aspect_ratio[1][1] * wire_width;
-          wire_spacing = wire_pitch[1][1] - wire_width;
-          wire_r_per_micron[1][1] = wire_resistance(CU_RESISTIVITY, wire_width,
-            wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-          ild_thickness[1][1] = 0.15;
-          miller_value[1][1] = 1.5;
-          horiz_dielectric_constant[1][1] = 2.104;
-          vert_dielectric_constant[1][1] = 3.9;
-          wire_c_per_micron[1][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-            ild_thickness[1][1], miller_value[1][1], horiz_dielectric_constant[1][1], vert_dielectric_constant[1][1],
-            fringe_cap);
+      // Conservative projections
+      wire_pitch[1][0] = 2.5 * g_ip->F_sz_um;
+      aspect_ratio[1][0] = 2.0;
+      wire_width = wire_pitch[1][0] / 2;
+      wire_thickness = aspect_ratio[1][0] * wire_width;
+      wire_spacing = wire_pitch[1][0] - wire_width;
+      barrier_thickness = 0.002;
+      dishing_thickness = 0;
+      alpha_scatter = 1.05;
+      wire_r_per_micron[1][0] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[1][0] = 0.108;
+      miller_value[1][0] = 1.5;
+      horiz_dielectric_constant[1][0] = 1.998;
+      vert_dielectric_constant[1][0] = 3.9;
+      fringe_cap = 0.115e-15;
+      wire_c_per_micron[1][0] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][0],
+          miller_value[1][0], horiz_dielectric_constant[1][0],
+          vert_dielectric_constant[1][0], fringe_cap);
 
-            wire_pitch[1][2] = 8 * g_ip->F_sz_um;
-            aspect_ratio[1][2] = 2.2;
-            wire_width = wire_pitch[1][2] / 2;
-            wire_thickness = aspect_ratio[1][2] * wire_width;
-            wire_spacing = wire_pitch[1][2] - wire_width;
-            dishing_thickness = 0.1 *  wire_thickness;
-            wire_r_per_micron[1][2] = wire_resistance(CU_RESISTIVITY, wire_width,
-            		wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-            ild_thickness[1][2] = 0.275;
-            miller_value[1][2] = 1.5;
-            horiz_dielectric_constant[1][2] = 2.104;
-            vert_dielectric_constant[1][2] = 3.9;
-            wire_c_per_micron[1][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-            		ild_thickness[1][2], miller_value[1][2], horiz_dielectric_constant[1][2], vert_dielectric_constant[1][2],
-            		fringe_cap);
-            //Nominal projections for commodity DRAM wordline/bitline
-            wire_pitch[1][3] = 2 * 0.022;//micron
-            wire_c_per_micron[1][3] = 31e-15 / (256 * 2 * 0.022);//F/micron
-            wire_r_per_micron[1][3] = 12 / 0.022;//ohm/micron
+      wire_pitch[1][1] = 4 * g_ip->F_sz_um;
+      wire_width = wire_pitch[1][1] / 2;
+      aspect_ratio[1][1] = 2.0;
+      wire_thickness = aspect_ratio[1][1] * wire_width;
+      wire_spacing = wire_pitch[1][1] - wire_width;
+      wire_r_per_micron[1][1] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[1][1] = 0.108;
+      miller_value[1][1] = 1.5;
+      horiz_dielectric_constant[1][1] = 1.998;
+      vert_dielectric_constant[1][1] = 3.9;
+      wire_c_per_micron[1][1] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][1],
+          miller_value[1][1], horiz_dielectric_constant[1][1],
+          vert_dielectric_constant[1][1], fringe_cap);
 
-            //******************
-//            wire_pitch[1][4] = 16 * g_ip.F_sz_um;
-//            aspect_ratio = 2.2;
-//            wire_width = wire_pitch[1][4] / 2;
-//            wire_thickness = aspect_ratio * wire_width;
-//            wire_spacing = wire_pitch[1][4] - wire_width;
-//            dishing_thickness = 0.1 *  wire_thickness;
-//            wire_r_per_micron[1][4] = wire_resistance(CU_RESISTIVITY, wire_width,
-//            		wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-//            ild_thickness = 0.275;
-//            wire_c_per_micron[1][4] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-//            		ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
-//            		fringe_cap);
-//
-//            wire_pitch[1][5] = 24 * g_ip.F_sz_um;
-//            aspect_ratio = 2.2;
-//            wire_width = wire_pitch[1][5] / 2;
-//            wire_thickness = aspect_ratio * wire_width;
-//            wire_spacing = wire_pitch[1][5] - wire_width;
-//            dishing_thickness = 0.1 *  wire_thickness;
-//            wire_r_per_micron[1][5] = wire_resistance(CU_RESISTIVITY, wire_width,
-//            		wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-//            ild_thickness = 0.275;
-//            wire_c_per_micron[1][5] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-//            		ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
-//            		fringe_cap);
-//
-//            wire_pitch[1][6] = 32 * g_ip.F_sz_um;
-//            aspect_ratio = 2.2;
-//            wire_width = wire_pitch[1][6] / 2;
-//            wire_thickness = aspect_ratio * wire_width;
-//            wire_spacing = wire_pitch[1][6] - wire_width;
-//            dishing_thickness = 0.1 *  wire_thickness;
-//            wire_r_per_micron[1][6] = wire_resistance(CU_RESISTIVITY, wire_width,
-//            		wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-//            ild_thickness = 0.275;
-//            wire_c_per_micron[1][6] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-//            		ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
-//            		fringe_cap);
-        }
+      wire_pitch[1][2] = 8 * g_ip->F_sz_um;
+      aspect_ratio[1][2] = 2.2;
+      wire_width = wire_pitch[1][2] / 2;
+      wire_thickness = aspect_ratio[1][2] * wire_width;
+      wire_spacing = wire_pitch[1][2] - wire_width;
+      dishing_thickness = 0.1 * wire_thickness;
+      wire_r_per_micron[1][2] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[1][2] = 0.198;
+      miller_value[1][2] = 1.5;
+      horiz_dielectric_constant[1][2] = 1.998;
+      vert_dielectric_constant[1][2] = 3.9;
+      wire_c_per_micron[1][2] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][2],
+          miller_value[1][2], horiz_dielectric_constant[1][2],
+          vert_dielectric_constant[1][2], fringe_cap);
+      // Nominal projections for commodity DRAM wordline/bitline
+      wire_pitch[1][3] = 2 * 0.016;                          // micron
+      wire_c_per_micron[1][3] = 31e-15 / (256 * 2 * 0.016);  // F/micron
+      wire_r_per_micron[1][3] = 12 / 0.016;                  // ohm/micron
 
-    else if (tech == 16)
-        {
-          //Aggressive projections.
-          wire_pitch[0][0] = 2.5 * g_ip->F_sz_um;//local
-          aspect_ratio[0][0] = 3.0;
-          wire_width = wire_pitch[0][0] / 2;
-          wire_thickness = aspect_ratio[0][0] * wire_width;
-          wire_spacing = wire_pitch[0][0] - wire_width;
-          barrier_thickness = 0;
-          dishing_thickness = 0;
-          alpha_scatter = 1;
-          wire_r_per_micron[0][0] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-            wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-          ild_thickness[0][0] = 0.108;
-          miller_value[0][0] = 1.5;
-          horiz_dielectric_constant[0][0] = 1.202;
-          vert_dielectric_constant[0][0] = 3.9;
-          fringe_cap = 0.115e-15;
-          wire_c_per_micron[0][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-            ild_thickness[0][0], miller_value[0][0], horiz_dielectric_constant[0][0], vert_dielectric_constant[0][0],
-            fringe_cap);
+      //******************
+      //            wire_pitch[1][4] = 16 * g_ip.F_sz_um;
+      //            aspect_ratio = 2.2;
+      //            wire_width = wire_pitch[1][4] / 2;
+      //            wire_thickness = aspect_ratio * wire_width;
+      //            wire_spacing = wire_pitch[1][4] - wire_width;
+      //            dishing_thickness = 0.1 *  wire_thickness;
+      //            wire_r_per_micron[1][4] = wire_resistance(CU_RESISTIVITY,
+      //            wire_width, 		wire_thickness,
+      //            barrier_thickness, dishing_thickness, alpha_scatter);
+      //            ild_thickness = 0.275; wire_c_per_micron[1][4] =
+      //            wire_capacitance(wire_width, wire_thickness, wire_spacing,
+      //            ild_thickness, miller_value, horiz_dielectric_constant,
+      //            vert_dielectric_constant, 		fringe_cap);
+      //
+      //            wire_pitch[1][5] = 24 * g_ip.F_sz_um;
+      //            aspect_ratio = 2.2;
+      //            wire_width = wire_pitch[1][5] / 2;
+      //            wire_thickness = aspect_ratio * wire_width;
+      //            wire_spacing = wire_pitch[1][5] - wire_width;
+      //            dishing_thickness = 0.1 *  wire_thickness;
+      //            wire_r_per_micron[1][5] = wire_resistance(CU_RESISTIVITY,
+      //            wire_width, 		wire_thickness,
+      //            barrier_thickness, dishing_thickness, alpha_scatter);
+      //            ild_thickness = 0.275; wire_c_per_micron[1][5] =
+      //            wire_capacitance(wire_width, wire_thickness, wire_spacing,
+      //            ild_thickness, miller_value, horiz_dielectric_constant,
+      //            vert_dielectric_constant, 		fringe_cap);
+      //
+      //            wire_pitch[1][6] = 32 * g_ip.F_sz_um;
+      //            aspect_ratio = 2.2;
+      //            wire_width = wire_pitch[1][6] / 2;
+      //            wire_thickness = aspect_ratio * wire_width;
+      //            wire_spacing = wire_pitch[1][6] - wire_width;
+      //            dishing_thickness = 0.1 *  wire_thickness;
+      //            wire_r_per_micron[1][6] = wire_resistance(CU_RESISTIVITY,
+      //            wire_width, 		wire_thickness,
+      //            barrier_thickness, dishing_thickness, alpha_scatter);
+      //            ild_thickness = 0.275; wire_c_per_micron[1][6] =
+      //            wire_capacitance(wire_width, wire_thickness, wire_spacing,
+      //            ild_thickness, miller_value, horiz_dielectric_constant,
+      //            vert_dielectric_constant, 		fringe_cap);
+    }
+    g_tp.wire_local.pitch +=
+        curr_alpha * wire_pitch[g_ip->ic_proj_type]
+                               [(ram_cell_tech_type == comm_dram) ? 3 : 0];
+    g_tp.wire_local.R_per_um +=
+        curr_alpha *
+        wire_r_per_micron[g_ip->ic_proj_type]
+                         [(ram_cell_tech_type == comm_dram) ? 3 : 0];
+    g_tp.wire_local.C_per_um +=
+        curr_alpha *
+        wire_c_per_micron[g_ip->ic_proj_type]
+                         [(ram_cell_tech_type == comm_dram) ? 3 : 0];
+    g_tp.wire_local.aspect_ratio +=
+        curr_alpha * aspect_ratio[g_ip->ic_proj_type]
+                                 [(ram_cell_tech_type == comm_dram) ? 3 : 0];
+    g_tp.wire_local.ild_thickness +=
+        curr_alpha * ild_thickness[g_ip->ic_proj_type]
+                                  [(ram_cell_tech_type == comm_dram) ? 3 : 0];
+    g_tp.wire_local.miller_value +=
+        curr_alpha * miller_value[g_ip->ic_proj_type]
+                                 [(ram_cell_tech_type == comm_dram) ? 3 : 0];
+    g_tp.wire_local.horiz_dielectric_constant +=
+        curr_alpha *
+        horiz_dielectric_constant[g_ip->ic_proj_type]
+                                 [(ram_cell_tech_type == comm_dram) ? 3 : 0];
+    g_tp.wire_local.vert_dielectric_constant +=
+        curr_alpha *
+        vert_dielectric_constant[g_ip->ic_proj_type]
+                                [(ram_cell_tech_type == comm_dram) ? 3 : 0];
 
-          wire_pitch[0][1] = 4 * g_ip->F_sz_um;//semi-global
-          aspect_ratio[0][1] = 3.0;
-          wire_width = wire_pitch[0][1] / 2;
-          wire_thickness = aspect_ratio[0][1] * wire_width;
-          wire_spacing = wire_pitch[0][1] - wire_width;
-          wire_r_per_micron[0][1] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-            wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-          ild_thickness[0][1] = 0.108;
-          miller_value[0][1] = 1.5;
-          horiz_dielectric_constant[0][1] = 1.202;
-          vert_dielectric_constant[0][1] = 3.9;
-          wire_c_per_micron[0][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-            ild_thickness[0][1], miller_value[0][1], horiz_dielectric_constant[0][1], vert_dielectric_constant[0][1],
-            fringe_cap);
+    g_tp.wire_inside_mat.pitch +=
+        curr_alpha * wire_pitch[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
+    g_tp.wire_inside_mat.R_per_um +=
+        curr_alpha *
+        wire_r_per_micron[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
+    g_tp.wire_inside_mat.C_per_um +=
+        curr_alpha *
+        wire_c_per_micron[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
+    g_tp.wire_inside_mat.aspect_ratio +=
+        curr_alpha * aspect_ratio[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
+    g_tp.wire_inside_mat.ild_thickness +=
+        curr_alpha * ild_thickness[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
+    g_tp.wire_inside_mat.miller_value +=
+        curr_alpha * miller_value[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
+    g_tp.wire_inside_mat.horiz_dielectric_constant +=
+        curr_alpha *
+        horiz_dielectric_constant[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
+    g_tp.wire_inside_mat.vert_dielectric_constant +=
+        curr_alpha *
+        vert_dielectric_constant[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
 
-          wire_pitch[0][2] = 8 * g_ip->F_sz_um;//global
-          aspect_ratio[0][2] = 3.0;
-          wire_width = wire_pitch[0][2] / 2;
-          wire_thickness = aspect_ratio[0][2] * wire_width;
-          wire_spacing = wire_pitch[0][2] - wire_width;
-          wire_r_per_micron[0][2] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-        		  wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-          ild_thickness[0][2] = 0.216;
-          miller_value[0][2] = 1.5;
-          horiz_dielectric_constant[0][2] = 1.202;
-          vert_dielectric_constant[0][2] = 3.9;
-          wire_c_per_micron[0][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-        		  ild_thickness[0][2], miller_value[0][2], horiz_dielectric_constant[0][2], vert_dielectric_constant[0][2],
-        		  fringe_cap);
+    g_tp.wire_outside_mat.pitch +=
+        curr_alpha * wire_pitch[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
+    g_tp.wire_outside_mat.R_per_um +=
+        curr_alpha *
+        wire_r_per_micron[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
+    g_tp.wire_outside_mat.C_per_um +=
+        curr_alpha *
+        wire_c_per_micron[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
+    g_tp.wire_outside_mat.aspect_ratio +=
+        curr_alpha * aspect_ratio[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
+    g_tp.wire_outside_mat.ild_thickness +=
+        curr_alpha * ild_thickness[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
+    g_tp.wire_outside_mat.miller_value +=
+        curr_alpha * miller_value[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
+    g_tp.wire_outside_mat.horiz_dielectric_constant +=
+        curr_alpha *
+        horiz_dielectric_constant[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
+    g_tp.wire_outside_mat.vert_dielectric_constant +=
+        curr_alpha *
+        vert_dielectric_constant[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
 
-//          //*************************
-//          wire_pitch[0][4] = 16 * g_ip.F_sz_um;//global
-//          aspect_ratio = 3.0;
-//          wire_width = wire_pitch[0][4] / 2;
-//          wire_thickness = aspect_ratio * wire_width;
-//          wire_spacing = wire_pitch[0][4] - wire_width;
-//          wire_r_per_micron[0][4] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-//        		  wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-//          ild_thickness = 0.3;
-//          wire_c_per_micron[0][4] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-//        		  ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
-//        		  fringe_cap);
-//
-//          wire_pitch[0][5] = 24 * g_ip.F_sz_um;//global
-//          aspect_ratio = 3.0;
-//          wire_width = wire_pitch[0][5] / 2;
-//          wire_thickness = aspect_ratio * wire_width;
-//          wire_spacing = wire_pitch[0][5] - wire_width;
-//          wire_r_per_micron[0][5] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-//        		  wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-//          ild_thickness = 0.3;
-//          wire_c_per_micron[0][5] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-//        		  ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
-//        		  fringe_cap);
-//
-//          wire_pitch[0][6] = 32 * g_ip.F_sz_um;//global
-//          aspect_ratio = 3.0;
-//          wire_width = wire_pitch[0][6] / 2;
-//          wire_thickness = aspect_ratio * wire_width;
-//          wire_spacing = wire_pitch[0][6] - wire_width;
-//          wire_r_per_micron[0][6] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-//        		  wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-//          ild_thickness = 0.3;
-//          wire_c_per_micron[0][6] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-//        		  ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
-//        		  fringe_cap);
-          //*************************
+    g_tp.unit_len_wire_del =
+        g_tp.wire_inside_mat.R_per_um * g_tp.wire_inside_mat.C_per_um / 2;
 
-          //Conservative projections
-          wire_pitch[1][0] = 2.5 * g_ip->F_sz_um;
-          aspect_ratio[1][0] = 2.0;
-          wire_width = wire_pitch[1][0] / 2;
-          wire_thickness = aspect_ratio[1][0] * wire_width;
-          wire_spacing = wire_pitch[1][0] - wire_width;
-          barrier_thickness = 0.002;
-          dishing_thickness = 0;
-          alpha_scatter = 1.05;
-          wire_r_per_micron[1][0] = wire_resistance(CU_RESISTIVITY, wire_width,
-            wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-          ild_thickness[1][0] = 0.108;
-          miller_value[1][0] = 1.5;
-          horiz_dielectric_constant[1][0] = 1.998;
-          vert_dielectric_constant[1][0] = 3.9;
-          fringe_cap = 0.115e-15;
-          wire_c_per_micron[1][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-            ild_thickness[1][0], miller_value[1][0], horiz_dielectric_constant[1][0], vert_dielectric_constant[1][0],
-            fringe_cap);
-
-          wire_pitch[1][1] = 4 * g_ip->F_sz_um;
-          wire_width = wire_pitch[1][1] / 2;
-          aspect_ratio[1][1] = 2.0;
-          wire_thickness = aspect_ratio[1][1] * wire_width;
-          wire_spacing = wire_pitch[1][1] - wire_width;
-          wire_r_per_micron[1][1] = wire_resistance(CU_RESISTIVITY, wire_width,
-            wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-          ild_thickness[1][1] = 0.108;
-          miller_value[1][1] = 1.5;
-          horiz_dielectric_constant[1][1] = 1.998;
-          vert_dielectric_constant[1][1] = 3.9;
-            wire_c_per_micron[1][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-            ild_thickness[1][1], miller_value[1][1], horiz_dielectric_constant[1][1], vert_dielectric_constant[1][1],
-            fringe_cap);
-
-            wire_pitch[1][2] = 8 * g_ip->F_sz_um;
-            aspect_ratio[1][2] = 2.2;
-            wire_width = wire_pitch[1][2] / 2;
-            wire_thickness = aspect_ratio[1][2] * wire_width;
-            wire_spacing = wire_pitch[1][2] - wire_width;
-            dishing_thickness = 0.1 *  wire_thickness;
-            wire_r_per_micron[1][2] = wire_resistance(CU_RESISTIVITY, wire_width,
-            		wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-            ild_thickness[1][2] = 0.198;
-            miller_value[1][2] = 1.5;
-            horiz_dielectric_constant[1][2] = 1.998;
-            vert_dielectric_constant[1][2] = 3.9;
-            wire_c_per_micron[1][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-            		ild_thickness[1][2], miller_value[1][2], horiz_dielectric_constant[1][2], vert_dielectric_constant[1][2],
-            		fringe_cap);
-            //Nominal projections for commodity DRAM wordline/bitline
-            wire_pitch[1][3] = 2 * 0.016;//micron
-            wire_c_per_micron[1][3] = 31e-15 / (256 * 2 * 0.016);//F/micron
-            wire_r_per_micron[1][3] = 12 / 0.016;//ohm/micron
-
-            //******************
-//            wire_pitch[1][4] = 16 * g_ip.F_sz_um;
-//            aspect_ratio = 2.2;
-//            wire_width = wire_pitch[1][4] / 2;
-//            wire_thickness = aspect_ratio * wire_width;
-//            wire_spacing = wire_pitch[1][4] - wire_width;
-//            dishing_thickness = 0.1 *  wire_thickness;
-//            wire_r_per_micron[1][4] = wire_resistance(CU_RESISTIVITY, wire_width,
-//            		wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-//            ild_thickness = 0.275;
-//            wire_c_per_micron[1][4] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-//            		ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
-//            		fringe_cap);
-//
-//            wire_pitch[1][5] = 24 * g_ip.F_sz_um;
-//            aspect_ratio = 2.2;
-//            wire_width = wire_pitch[1][5] / 2;
-//            wire_thickness = aspect_ratio * wire_width;
-//            wire_spacing = wire_pitch[1][5] - wire_width;
-//            dishing_thickness = 0.1 *  wire_thickness;
-//            wire_r_per_micron[1][5] = wire_resistance(CU_RESISTIVITY, wire_width,
-//            		wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-//            ild_thickness = 0.275;
-//            wire_c_per_micron[1][5] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-//            		ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
-//            		fringe_cap);
-//
-//            wire_pitch[1][6] = 32 * g_ip.F_sz_um;
-//            aspect_ratio = 2.2;
-//            wire_width = wire_pitch[1][6] / 2;
-//            wire_thickness = aspect_ratio * wire_width;
-//            wire_spacing = wire_pitch[1][6] - wire_width;
-//            dishing_thickness = 0.1 *  wire_thickness;
-//            wire_r_per_micron[1][6] = wire_resistance(CU_RESISTIVITY, wire_width,
-//            		wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-//            ild_thickness = 0.275;
-//            wire_c_per_micron[1][6] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-//            		ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
-//            		fringe_cap);
-        }
-    g_tp.wire_local.pitch    += curr_alpha * wire_pitch[g_ip->ic_proj_type][(ram_cell_tech_type == comm_dram)?3:0];
-    g_tp.wire_local.R_per_um += curr_alpha * wire_r_per_micron[g_ip->ic_proj_type][(ram_cell_tech_type == comm_dram)?3:0];
-    g_tp.wire_local.C_per_um += curr_alpha * wire_c_per_micron[g_ip->ic_proj_type][(ram_cell_tech_type == comm_dram)?3:0];
-    g_tp.wire_local.aspect_ratio  += curr_alpha * aspect_ratio[g_ip->ic_proj_type][(ram_cell_tech_type == comm_dram)?3:0];
-    g_tp.wire_local.ild_thickness += curr_alpha * ild_thickness[g_ip->ic_proj_type][(ram_cell_tech_type == comm_dram)?3:0];
-    g_tp.wire_local.miller_value   += curr_alpha * miller_value[g_ip->ic_proj_type][(ram_cell_tech_type == comm_dram)?3:0];
-    g_tp.wire_local.horiz_dielectric_constant += curr_alpha* horiz_dielectric_constant[g_ip->ic_proj_type][(ram_cell_tech_type == comm_dram)?3:0];
-    g_tp.wire_local.vert_dielectric_constant  += curr_alpha* vert_dielectric_constant [g_ip->ic_proj_type][(ram_cell_tech_type == comm_dram)?3:0];
-
-    g_tp.wire_inside_mat.pitch     += curr_alpha * wire_pitch[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
-    g_tp.wire_inside_mat.R_per_um  += curr_alpha* wire_r_per_micron[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
-    g_tp.wire_inside_mat.C_per_um  += curr_alpha* wire_c_per_micron[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
-    g_tp.wire_inside_mat.aspect_ratio  += curr_alpha * aspect_ratio[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
-    g_tp.wire_inside_mat.ild_thickness += curr_alpha * ild_thickness[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
-    g_tp.wire_inside_mat.miller_value   += curr_alpha * miller_value[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
-    g_tp.wire_inside_mat.horiz_dielectric_constant += curr_alpha* horiz_dielectric_constant[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
-    g_tp.wire_inside_mat.vert_dielectric_constant  += curr_alpha* vert_dielectric_constant [g_ip->ic_proj_type][g_ip->wire_is_mat_type];
-
-    g_tp.wire_outside_mat.pitch    += curr_alpha * wire_pitch[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
-    g_tp.wire_outside_mat.R_per_um += curr_alpha*wire_r_per_micron[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
-    g_tp.wire_outside_mat.C_per_um += curr_alpha*wire_c_per_micron[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
-    g_tp.wire_outside_mat.aspect_ratio  += curr_alpha * aspect_ratio[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
-    g_tp.wire_outside_mat.ild_thickness += curr_alpha * ild_thickness[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
-    g_tp.wire_outside_mat.miller_value   += curr_alpha * miller_value[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
-    g_tp.wire_outside_mat.horiz_dielectric_constant += curr_alpha* horiz_dielectric_constant[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
-    g_tp.wire_outside_mat.vert_dielectric_constant  += curr_alpha* vert_dielectric_constant [g_ip->ic_proj_type][g_ip->wire_os_mat_type];
-
-    g_tp.unit_len_wire_del = g_tp.wire_inside_mat.R_per_um * g_tp.wire_inside_mat.C_per_um / 2;
-
-    g_tp.sense_delay               += curr_alpha *SENSE_AMP_D;
-    g_tp.sense_dy_power            += curr_alpha *SENSE_AMP_P;
-//    g_tp.horiz_dielectric_constant += horiz_dielectric_constant;
-//    g_tp.vert_dielectric_constant  += vert_dielectric_constant;
-//    g_tp.aspect_ratio              += aspect_ratio;
-//    g_tp.miller_value              += miller_value;
-//    g_tp.ild_thickness             += ild_thickness;
-
+    g_tp.sense_delay += curr_alpha * SENSE_AMP_D;
+    g_tp.sense_dy_power += curr_alpha * SENSE_AMP_P;
+    //    g_tp.horiz_dielectric_constant += horiz_dielectric_constant;
+    //    g_tp.vert_dielectric_constant  += vert_dielectric_constant;
+    //    g_tp.aspect_ratio              += aspect_ratio;
+    //    g_tp.miller_value              += miller_value;
+    //    g_tp.ild_thickness             += ild_thickness;
   }
   g_tp.fringe_cap = fringe_cap;
 
@@ -2764,9 +2959,9 @@ void init_tech_params(double technology, bool is_tag)
   g_tp.kinv = horowitz(0, tf, 0.5, 0.5, RISE);
   double KLOAD = 1;
   c_load = KLOAD * (drain_C_(g_tp.min_w_nmos_, NCH, 1, 1, g_tp.cell_h_def) +
-                    drain_C_(g_tp.min_w_nmos_ * p_to_n_sizing_r, PCH, 1, 1, g_tp.cell_h_def) +
+                    drain_C_(g_tp.min_w_nmos_ * p_to_n_sizing_r, PCH, 1, 1,
+                             g_tp.cell_h_def) +
                     gate_C(g_tp.min_w_nmos_ * 4 * (1 + p_to_n_sizing_r), 0.0));
   tf = rd * c_load;
   g_tp.FO4 = horowitz(0, tf, 0.5, 0.5, RISE);
 }
-

--- a/src/gpuwattch/technology_xeon_core.cc
+++ b/src/gpuwattch/technology_xeon_core.cc
@@ -1904,8 +1904,8 @@ void init_tech_params(double technology, bool is_tag) {
 
   g_tp.min_w_nmos_ = 3 * g_ip->F_sz_um / 2;
   g_tp.max_w_nmos_ = 100 * g_ip->F_sz_um;
-  g_tp.w_iso = 12.5 * g_ip->F_sz_um;      // was 10 micron for the 0.8 micron
-                                          // process
+  g_tp.w_iso = 12.5 * g_ip->F_sz_um;  // was 10 micron for the 0.8 micron
+                                      // process
   g_tp.w_sense_n = 3.75 * g_ip->F_sz_um;  // sense amplifier N-trans; was 3
                                           // micron for the 0.8 micron process
   g_tp.w_sense_p = 7.5 * g_ip->F_sz_um;   // sense amplifier P-trans; was 6

--- a/src/gpuwattch/technology_xeon_core.cc
+++ b/src/gpuwattch/technology_xeon_core.cc
@@ -1597,8 +1597,8 @@ void init_tech_params(double technology, bool is_tag) {
       //    / Vs 	Vdsat[1] = 6.64e-2; //V/micron 	c_g_ideal[1]
       //    = 3.22e-16;//F/micron 	c_fringe[1] = 0.008e-15; c_junc[1]
       //    =
-      //    0;//F/micron2 	I_on_n[1] = 727.6e-6;//A/micron 	I_on_p[1]
-      //    = I_on_n[1] / 2; 	nmos_effective_resistance_multiplier = 1.99;
+      //    0;//F/micron2 	I_on_n[1] = 727.6e-6;//A/micron I_on_p[1] =
+      //    I_on_n[1] / 2; 	nmos_effective_resistance_multiplier = 1.99;
       //    	n_to_p_eff_curr_drv_ratio[1] = 2;
       //    	gmp_to_gmn_multiplier[1] = 0.99;
       //    	Rnchannelon[1] = nmos_effective_resistance_multiplier * vdd[1] /

--- a/src/gpuwattch/technology_xeon_core.cc
+++ b/src/gpuwattch/technology_xeon_core.cc
@@ -29,57 +29,64 @@
  *
  ***************************************************************************/
 
-
 #include "basic_circuit.h"
 
 #include "parameter.h"
 
-double wire_resistance(double resistivity, double wire_width, double wire_thickness,
-    double barrier_thickness, double dishing_thickness, double alpha_scatter)
-{
+double wire_resistance(double resistivity, double wire_width,
+                       double wire_thickness, double barrier_thickness,
+                       double dishing_thickness, double alpha_scatter) {
   double resistance;
-  resistance = alpha_scatter * resistivity /((wire_thickness - barrier_thickness - dishing_thickness)*(wire_width - 2 * barrier_thickness));
-  return(resistance);
+  resistance = alpha_scatter * resistivity /
+               ((wire_thickness - barrier_thickness - dishing_thickness) *
+                (wire_width - 2 * barrier_thickness));
+  return (resistance);
 }
 
-double wire_capacitance(double wire_width, double wire_thickness, double wire_spacing,
-    double ild_thickness, double miller_value, double horiz_dielectric_constant,
-    double vert_dielectric_constant, double fringe_cap)
-{
+double wire_capacitance(double wire_width, double wire_thickness,
+                        double wire_spacing, double ild_thickness,
+                        double miller_value, double horiz_dielectric_constant,
+                        double vert_dielectric_constant, double fringe_cap) {
   double vertical_cap, sidewall_cap, total_cap;
-  vertical_cap = 2 * PERMITTIVITY_FREE_SPACE * vert_dielectric_constant * wire_width / ild_thickness;
-  sidewall_cap = 2 * PERMITTIVITY_FREE_SPACE * miller_value * horiz_dielectric_constant * wire_thickness / wire_spacing;
+  vertical_cap = 2 * PERMITTIVITY_FREE_SPACE * vert_dielectric_constant *
+                 wire_width / ild_thickness;
+  sidewall_cap = 2 * PERMITTIVITY_FREE_SPACE * miller_value *
+                 horiz_dielectric_constant * wire_thickness / wire_spacing;
   total_cap = vertical_cap + sidewall_cap + fringe_cap;
-  return(total_cap);
+  return (total_cap);
 }
 
-
-void init_tech_params(double technology, bool is_tag)
-{
-  int    iter, tech, tech_lo, tech_hi;
+void init_tech_params(double technology, bool is_tag) {
+  int iter, tech, tech_lo, tech_hi;
   double curr_alpha, curr_vpp;
-  double wire_width, wire_thickness, wire_spacing,
-         fringe_cap, pmos_to_nmos_sizing_r;
-//  double aspect_ratio,ild_thickness, miller_value = 1.5, horiz_dielectric_constant, vert_dielectric_constant;
+  double wire_width, wire_thickness, wire_spacing, fringe_cap,
+      pmos_to_nmos_sizing_r;
+  //  double aspect_ratio,ild_thickness, miller_value = 1.5,
+  //  horiz_dielectric_constant, vert_dielectric_constant;
   double barrier_thickness, dishing_thickness, alpha_scatter;
-  double curr_vdd_dram_cell, curr_v_th_dram_access_transistor, curr_I_on_dram_cell, curr_c_dram_cell;
+  double curr_vdd_dram_cell, curr_v_th_dram_access_transistor,
+      curr_I_on_dram_cell, curr_c_dram_cell;
 
-  uint32_t ram_cell_tech_type    = (is_tag) ? g_ip->tag_arr_ram_cell_tech_type : g_ip->data_arr_ram_cell_tech_type;
-  uint32_t peri_global_tech_type = (is_tag) ? g_ip->tag_arr_peri_global_tech_type : g_ip->data_arr_peri_global_tech_type;
+  uint32_t ram_cell_tech_type = (is_tag) ? g_ip->tag_arr_ram_cell_tech_type
+                                         : g_ip->data_arr_ram_cell_tech_type;
+  uint32_t peri_global_tech_type = (is_tag)
+                                       ? g_ip->tag_arr_peri_global_tech_type
+                                       : g_ip->data_arr_peri_global_tech_type;
 
-  technology  = technology * 1000.0;  // in the unit of nm
+  technology = technology * 1000.0;  // in the unit of nm
 
   // initialize parameters
   g_tp.reset();
   double gmp_to_gmn_multiplier_periph_global = 0;
 
   double curr_Wmemcella_dram, curr_Wmemcellpmos_dram, curr_Wmemcellnmos_dram,
-         curr_area_cell_dram, curr_asp_ratio_cell_dram, curr_Wmemcella_sram,
-         curr_Wmemcellpmos_sram, curr_Wmemcellnmos_sram, curr_area_cell_sram,
-         curr_asp_ratio_cell_sram, curr_I_off_dram_cell_worst_case_length_temp;
-  double curr_Wmemcella_cam, curr_Wmemcellpmos_cam, curr_Wmemcellnmos_cam, curr_area_cell_cam,//Sheng: CAM data
-         curr_asp_ratio_cell_cam;
-  double SENSE_AMP_D, SENSE_AMP_P; // J
+      curr_area_cell_dram, curr_asp_ratio_cell_dram, curr_Wmemcella_sram,
+      curr_Wmemcellpmos_sram, curr_Wmemcellnmos_sram, curr_area_cell_sram,
+      curr_asp_ratio_cell_sram, curr_I_off_dram_cell_worst_case_length_temp;
+  double curr_Wmemcella_cam, curr_Wmemcellpmos_cam, curr_Wmemcellnmos_cam,
+      curr_area_cell_cam,  // Sheng: CAM data
+      curr_asp_ratio_cell_cam;
+  double SENSE_AMP_D, SENSE_AMP_P;  // J
   double area_cell_dram = 0;
   double asp_ratio_cell_dram = 0;
   double area_cell_sram = 0;
@@ -91,77 +98,63 @@ void init_tech_params(double technology, bool is_tag)
   double nmos_effective_resistance_multiplier;
   double width_dram_access_transistor;
 
-  double curr_logic_scaling_co_eff = 0;//This is based on the reported numbers of Intel Merom 65nm, Penryn45nm and IBM cell 90/65/45 date
-  double curr_core_tx_density = 0;//this is density per um^2; 90, ...22nm based on Intel Penryn
+  double curr_logic_scaling_co_eff =
+      0;  // This is based on the reported numbers of Intel Merom 65nm,
+          // Penryn45nm and IBM cell 90/65/45 date
+  double curr_core_tx_density =
+      0;  // this is density per um^2; 90, ...22nm based on Intel Penryn
   double curr_chip_layout_overhead = 0;
   double curr_macro_layout_overhead = 0;
   double curr_sckt_co_eff = 0;
 
-  if (technology < 91 && technology > 89)
-  {
+  if (technology < 91 && technology > 89) {
     tech_lo = 90;
     tech_hi = 90;
-  }
-  else if (technology < 66 && technology > 64)
-  {
+  } else if (technology < 66 && technology > 64) {
     tech_lo = 65;
     tech_hi = 65;
-  }
-  else if (technology < 46 && technology > 44)
-  {
+  } else if (technology < 46 && technology > 44) {
     tech_lo = 45;
     tech_hi = 45;
-  }
-  else if (technology < 33 && technology > 31)
-  {
+  } else if (technology < 33 && technology > 31) {
     tech_lo = 32;
     tech_hi = 32;
-  }
-  else if (technology < 23 && technology > 21)
-  {
+  } else if (technology < 23 && technology > 21) {
     tech_lo = 22;
     tech_hi = 22;
-    if (ram_cell_tech_type == 3)
-    {
-       cout<<"current version does not support eDRAM technologies at 22nm"<<endl;
-       exit(0);
+    if (ram_cell_tech_type == 3) {
+      cout << "current version does not support eDRAM technologies at 22nm"
+           << endl;
+      exit(0);
     }
   }
-//  else if (technology < 17 && technology > 15)
-//  {
-//    tech_lo = 16;
-//    tech_hi = 16;
-//  }
-  else if (technology < 90 && technology > 65)
-  {
+  //  else if (technology < 17 && technology > 15)
+  //  {
+  //    tech_lo = 16;
+  //    tech_hi = 16;
+  //  }
+  else if (technology < 90 && technology > 65) {
     tech_lo = 90;
     tech_hi = 65;
-  }
-  else if (technology < 65 && technology > 45)
-  {
+  } else if (technology < 65 && technology > 45) {
     tech_lo = 65;
     tech_hi = 45;
-  }
-  else if (technology < 45 && technology > 32)
-  {
+  } else if (technology < 45 && technology > 32) {
     tech_lo = 45;
     tech_hi = 32;
+  } else if (technology < 32 && technology > 22) {
+    tech_lo = 32;
+    tech_hi = 22;
   }
-  else if (technology < 32 && technology > 22)
-    {
-      tech_lo = 32;
-      tech_hi = 22;
-    }
-//  else if (technology < 22 && technology > 16)
-//    {
-//      tech_lo = 22;
-//      tech_hi = 16;
-//    }
-      else
-    {
-  	  cout<<"Invalid technology nodes"<<endl;
-  	  exit(0);
-    }
+  //  else if (technology < 22 && technology > 16)
+  //    {
+  //      tech_lo = 22;
+  //      tech_hi = 16;
+  //    }
+  else {
+    cout << "Invalid technology nodes" << endl;
+    exit(0);
+  }
 
   double vdd[NUMBER_TECH_FLAVORS];
   double Lphy[NUMBER_TECH_FLAVORS];
@@ -181,66 +174,59 @@ void init_tech_params(double technology, bool is_tag)
   double n_to_p_eff_curr_drv_ratio[NUMBER_TECH_FLAVORS];
   double I_off_n[NUMBER_TECH_FLAVORS][101];
   double I_g_on_n[NUMBER_TECH_FLAVORS][101];
-  //double I_off_p[NUMBER_TECH_FLAVORS][101];
+  // double I_off_p[NUMBER_TECH_FLAVORS][101];
   double gmp_to_gmn_multiplier[NUMBER_TECH_FLAVORS];
-  //double curr_sckt_co_eff[NUMBER_TECH_FLAVORS];
+  // double curr_sckt_co_eff[NUMBER_TECH_FLAVORS];
   double long_channel_leakage_reduction[NUMBER_TECH_FLAVORS];
 
-  for (iter = 0; iter <= 1; ++iter)
-  {
+  for (iter = 0; iter <= 1; ++iter) {
     // linear interpolation
-    if (iter == 0)
-    {
+    if (iter == 0) {
       tech = tech_lo;
-      if (tech_lo == tech_hi)
-      {
+      if (tech_lo == tech_hi) {
         curr_alpha = 1;
+      } else {
+        curr_alpha = (technology - tech_hi) / (tech_lo - tech_hi);
       }
-      else
-      {
-        curr_alpha = (technology - tech_hi)/(tech_lo - tech_hi);
-      }
-    }
-    else
-    {
+    } else {
       tech = tech_hi;
-      if (tech_lo == tech_hi)
-      {
+      if (tech_lo == tech_hi) {
         break;
-      }
-      else
-      {
-        curr_alpha = (tech_lo - technology)/(tech_lo - tech_hi);
+      } else {
+        curr_alpha = (tech_lo - technology) / (tech_lo - tech_hi);
       }
     }
 
-    if (tech == 90)
-    {
-      SENSE_AMP_D = .28e-9; // s
-      SENSE_AMP_P = 14.7e-15; // J
-      //90nm technology-node. Corresponds to year 2004 in ITRS
-      //ITRS HP device type
-      vdd[0]   = 1.2;
-      Lphy[0]  = 0.037;//Lphy is the physical gate-length. micron
-      Lelec[0] = 0.0266;//Lelec is the electrical gate-length. micron
-      t_ox[0]  = 1.2e-3;//micron
-      v_th[0]  = 0.23707;//V
-      c_ox[0]  = 1.79e-14;//F/micron2
-      mobility_eff[0] = 342.16 * (1e-2 * 1e6 * 1e-2 * 1e6); //micron2 / Vs
-      Vdsat[0] = 0.128; //V
-      c_g_ideal[0] = 6.64e-16;//F/micron
-      c_fringe[0]  = 0.08e-15;//F/micron
-      c_junc[0] = 1e-15;//F/micron2
-      I_on_n[0] = 1076.9e-6;//A/micron
-      I_on_p[0] = 712.6e-6;//A/micron
-      //Note that nmos_effective_resistance_multiplier, n_to_p_eff_curr_drv_ratio and gmp_to_gmn_multiplier values are calculated offline
+    if (tech == 90) {
+      SENSE_AMP_D = .28e-9;    // s
+      SENSE_AMP_P = 14.7e-15;  // J
+      // 90nm technology-node. Corresponds to year 2004 in ITRS
+      // ITRS HP device type
+      vdd[0] = 1.2;
+      Lphy[0] = 0.037;     // Lphy is the physical gate-length. micron
+      Lelec[0] = 0.0266;   // Lelec is the electrical gate-length. micron
+      t_ox[0] = 1.2e-3;    // micron
+      v_th[0] = 0.23707;   // V
+      c_ox[0] = 1.79e-14;  // F/micron2
+      mobility_eff[0] = 342.16 * (1e-2 * 1e6 * 1e-2 * 1e6);  // micron2 / Vs
+      Vdsat[0] = 0.128;                                      // V
+      c_g_ideal[0] = 6.64e-16;                               // F/micron
+      c_fringe[0] = 0.08e-15;                                // F/micron
+      c_junc[0] = 1e-15;                                     // F/micron2
+      I_on_n[0] = 1076.9e-6;                                 // A/micron
+      I_on_p[0] = 712.6e-6;                                  // A/micron
+      // Note that nmos_effective_resistance_multiplier,
+      // n_to_p_eff_curr_drv_ratio and gmp_to_gmn_multiplier values are
+      // calculated offline
       nmos_effective_resistance_multiplier = 1.54;
       n_to_p_eff_curr_drv_ratio[0] = 2.45;
       gmp_to_gmn_multiplier[0] = 1.22;
-      Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] / I_on_n[0];//ohm-micron
-      Rpchannelon[0] = n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];//ohm-micron
+      Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] /
+                       I_on_n[0];  // ohm-micron
+      Rpchannelon[0] =
+          n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];  // ohm-micron
       long_channel_leakage_reduction[0] = 1;
-      I_off_n[0][0]  = 3.24e-8;//A/micron
+      I_off_n[0][0] = 3.24e-8;  // A/micron
       I_off_n[0][10] = 4.01e-8;
       I_off_n[0][20] = 4.90e-8;
       I_off_n[0][30] = 5.92e-8;
@@ -252,7 +238,7 @@ void init_tech_params(double technology, bool is_tag)
       I_off_n[0][90] = 1.43e-7;
       I_off_n[0][100] = 1.54e-7;
 
-      I_g_on_n[0][0]  = 1.65e-8;//A/micron
+      I_g_on_n[0][0] = 1.65e-8;  // A/micron
       I_g_on_n[0][10] = 1.65e-8;
       I_g_on_n[0][20] = 1.65e-8;
       I_g_on_n[0][30] = 1.65e-8;
@@ -264,27 +250,28 @@ void init_tech_params(double technology, bool is_tag)
       I_g_on_n[0][90] = 1.65e-8;
       I_g_on_n[0][100] = 1.65e-8;
 
-      //ITRS LSTP device type
-      vdd[1]   = 1.3;
-      Lphy[1]  = 0.075;
+      // ITRS LSTP device type
+      vdd[1] = 1.3;
+      Lphy[1] = 0.075;
       Lelec[1] = 0.0486;
-      t_ox[1]  = 2.2e-3;
-      v_th[1]  = 0.48203;
-      c_ox[1]  = 1.22e-14;
+      t_ox[1] = 2.2e-3;
+      v_th[1] = 0.48203;
+      c_ox[1] = 1.22e-14;
       mobility_eff[1] = 356.76 * (1e-2 * 1e6 * 1e-2 * 1e6);
       Vdsat[1] = 0.373;
       c_g_ideal[1] = 9.15e-16;
-      c_fringe[1]  = 0.08e-15;
+      c_fringe[1] = 0.08e-15;
       c_junc[1] = 1e-15;
       I_on_n[1] = 503.6e-6;
       I_on_p[1] = 235.1e-6;
       nmos_effective_resistance_multiplier = 1.92;
       n_to_p_eff_curr_drv_ratio[1] = 2.44;
-      gmp_to_gmn_multiplier[1] =0.88;
-      Rnchannelon[1] = nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];
+      gmp_to_gmn_multiplier[1] = 0.88;
+      Rnchannelon[1] =
+          nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];
       Rpchannelon[1] = n_to_p_eff_curr_drv_ratio[1] * Rnchannelon[1];
       long_channel_leakage_reduction[1] = 1;
-      I_off_n[1][0]  = 2.81e-12;
+      I_off_n[1][0] = 2.81e-12;
       I_off_n[1][10] = 4.76e-12;
       I_off_n[1][20] = 7.82e-12;
       I_off_n[1][30] = 1.25e-11;
@@ -296,7 +283,7 @@ void init_tech_params(double technology, bool is_tag)
       I_off_n[1][90] = 1.25e-10;
       I_off_n[1][100] = 1.7e-10;
 
-      I_g_on_n[1][0]  = 3.87e-11;//A/micron
+      I_g_on_n[1][0] = 3.87e-11;  // A/micron
       I_g_on_n[1][10] = 3.87e-11;
       I_g_on_n[1][20] = 3.87e-11;
       I_g_on_n[1][30] = 3.87e-11;
@@ -308,7 +295,7 @@ void init_tech_params(double technology, bool is_tag)
       I_g_on_n[1][90] = 3.87e-11;
       I_g_on_n[1][100] = 3.87e-11;
 
-      //ITRS LOP device type
+      // ITRS LOP device type
       vdd[2] = 0.9;
       Lphy[2] = 0.053;
       Lelec[2] = 0.0354;
@@ -325,7 +312,8 @@ void init_tech_params(double technology, bool is_tag)
       nmos_effective_resistance_multiplier = 1.77;
       n_to_p_eff_curr_drv_ratio[2] = 2.54;
       gmp_to_gmn_multiplier[2] = 0.98;
-      Rnchannelon[2] = nmos_effective_resistance_multiplier * vdd[2] / I_on_n[2];
+      Rnchannelon[2] =
+          nmos_effective_resistance_multiplier * vdd[2] / I_on_n[2];
       Rpchannelon[2] = n_to_p_eff_curr_drv_ratio[2] * Rnchannelon[2];
       long_channel_leakage_reduction[2] = 1;
       I_off_n[2][0] = 2.14e-9;
@@ -340,7 +328,7 @@ void init_tech_params(double technology, bool is_tag)
       I_off_n[2][90] = 1.52e-8;
       I_off_n[2][100] = 1.73e-8;
 
-      I_g_on_n[2][0]  = 4.31e-8;//A/micron
+      I_g_on_n[2][0] = 4.31e-8;  // A/micron
       I_g_on_n[2][10] = 4.31e-8;
       I_g_on_n[2][20] = 4.31e-8;
       I_g_on_n[2][30] = 4.31e-8;
@@ -352,9 +340,8 @@ void init_tech_params(double technology, bool is_tag)
       I_g_on_n[2][90] = 4.31e-8;
       I_g_on_n[2][100] = 4.31e-8;
 
-      if (ram_cell_tech_type == lp_dram)
-      {
-        //LP-DRAM cell access transistor technology parameters
+      if (ram_cell_tech_type == lp_dram) {
+        // LP-DRAM cell access transistor technology parameters
         curr_vdd_dram_cell = 1.2;
         Lphy[3] = 0.12;
         Lelec[3] = 0.0756;
@@ -369,12 +356,12 @@ void init_tech_params(double technology, bool is_tag)
         curr_asp_ratio_cell_dram = 1.46;
         curr_c_dram_cell = 20e-15;
 
-        //LP-DRAM wordline transistor parameters
+        // LP-DRAM wordline transistor parameters
         curr_vpp = 1.6;
         t_ox[3] = 2.2e-3;
         v_th[3] = 0.4545;
         c_ox[3] = 1.22e-14;
-        mobility_eff[3] =  323.95 * (1e-2 * 1e6 * 1e-2 * 1e6);
+        mobility_eff[3] = 323.95 * (1e-2 * 1e6 * 1e-2 * 1e6);
         Vdsat[3] = 0.3;
         c_g_ideal[3] = 1.47e-15;
         c_fringe[3] = 0.08e-15;
@@ -384,7 +371,8 @@ void init_tech_params(double technology, bool is_tag)
         nmos_effective_resistance_multiplier = 1.65;
         n_to_p_eff_curr_drv_ratio[3] = 1.95;
         gmp_to_gmn_multiplier[3] = 0.90;
-        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
+        Rnchannelon[3] =
+            nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
         Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];
         long_channel_leakage_reduction[3] = 1;
         I_off_n[3][0] = 1.42e-11;
@@ -398,10 +386,8 @@ void init_tech_params(double technology, bool is_tag)
         I_off_n[3][80] = 2.57e-10;
         I_off_n[3][90] = 3.14e-10;
         I_off_n[3][100] = 3.85e-10;
-      }
-      else if (ram_cell_tech_type == comm_dram)
-      {
-        //COMM-DRAM cell access transistor technology parameters
+      } else if (ram_cell_tech_type == comm_dram) {
+        // COMM-DRAM cell access transistor technology parameters
         curr_vdd_dram_cell = 1.6;
         Lphy[3] = 0.09;
         Lelec[3] = 0.0576;
@@ -412,16 +398,16 @@ void init_tech_params(double technology, bool is_tag)
         curr_Wmemcella_dram = width_dram_access_transistor;
         curr_Wmemcellpmos_dram = 0;
         curr_Wmemcellnmos_dram = 0;
-        curr_area_cell_dram = 6*0.09*0.09;
+        curr_area_cell_dram = 6 * 0.09 * 0.09;
         curr_asp_ratio_cell_dram = 1.5;
         curr_c_dram_cell = 30e-15;
 
-        //COMM-DRAM wordline transistor parameters
+        // COMM-DRAM wordline transistor parameters
         curr_vpp = 3.7;
         t_ox[3] = 5.5e-3;
         v_th[3] = 1.0;
         c_ox[3] = 5.65e-15;
-        mobility_eff[3] =  302.2 * (1e-2 * 1e6 * 1e-2 * 1e6);
+        mobility_eff[3] = 302.2 * (1e-2 * 1e6 * 1e-2 * 1e6);
         Vdsat[3] = 0.32;
         c_g_ideal[3] = 5.08e-16;
         c_fringe[3] = 0.08e-15;
@@ -431,7 +417,8 @@ void init_tech_params(double technology, bool is_tag)
         nmos_effective_resistance_multiplier = 1.62;
         n_to_p_eff_curr_drv_ratio[3] = 2.05;
         gmp_to_gmn_multiplier[3] = 0.90;
-        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
+        Rnchannelon[3] =
+            nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
         Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];
         long_channel_leakage_reduction[3] = 1;
         I_off_n[3][0] = 5.80e-15;
@@ -447,126 +434,129 @@ void init_tech_params(double technology, bool is_tag)
         I_off_n[3][100] = 1.67e-12;
       }
 
-      //SRAM cell properties
+      // SRAM cell properties
       curr_Wmemcella_sram = 1.31 * g_ip->F_sz_um;
       curr_Wmemcellpmos_sram = 1.23 * g_ip->F_sz_um;
       curr_Wmemcellnmos_sram = 2.08 * g_ip->F_sz_um;
       curr_area_cell_sram = 146 * g_ip->F_sz_um * g_ip->F_sz_um;
       curr_asp_ratio_cell_sram = 1.46;
-      //CAM cell properties //TODO: data need to be revisited
+      // CAM cell properties //TODO: data need to be revisited
       curr_Wmemcella_cam = 1.31 * g_ip->F_sz_um;
       curr_Wmemcellpmos_cam = 1.23 * g_ip->F_sz_um;
       curr_Wmemcellnmos_cam = 2.08 * g_ip->F_sz_um;
-      curr_area_cell_cam = 292 * g_ip->F_sz_um * g_ip->F_sz_um;//360
-      curr_asp_ratio_cell_cam = 2.92;//2.5
-      //Empirical undifferetiated core/FU coefficient
-      curr_logic_scaling_co_eff  = 1;
-      curr_core_tx_density       = 1.25*0.7*0.7;
-      curr_sckt_co_eff           = 1.1539;
-      curr_chip_layout_overhead  = 1.2;//die measurement results based on Niagara 1 and 2
-      curr_macro_layout_overhead = 1.1;//EDA placement and routing tool rule of thumb
-
-
+      curr_area_cell_cam = 292 * g_ip->F_sz_um * g_ip->F_sz_um;  // 360
+      curr_asp_ratio_cell_cam = 2.92;                            // 2.5
+      // Empirical undifferetiated core/FU coefficient
+      curr_logic_scaling_co_eff = 1;
+      curr_core_tx_density = 1.25 * 0.7 * 0.7;
+      curr_sckt_co_eff = 1.1539;
+      curr_chip_layout_overhead =
+          1.2;  // die measurement results based on Niagara 1 and 2
+      curr_macro_layout_overhead =
+          1.1;  // EDA placement and routing tool rule of thumb
     }
 
-    if (tech == 65)
-    { //65nm technology-node. Corresponds to year 2007 in ITRS
-      //ITRS HP device type
-//      SENSE_AMP_D = .2e-9; // s
-//      SENSE_AMP_P = 5.7e-15; // J
-//      vdd[0] = 1.1;
-//      Lphy[0] = 0.025;
-//      Lelec[0] = 0.019;
-//      t_ox[0] = 1.1e-3;
-//      v_th[0] = .19491;
-//      c_ox[0] = 1.88e-14;
-//      mobility_eff[0] = 436.24 * (1e-2 * 1e6 * 1e-2 * 1e6);
-//      Vdsat[0] = 7.71e-2;
-//      c_g_ideal[0] = 4.69e-16;
-//      c_fringe[0] = 0.077e-15;
-//      c_junc[0] = 1e-15;
-//      I_on_n[0] = 1197.2e-6;
-//      I_on_p[0] = 870.8e-6;
-//      nmos_effective_resistance_multiplier = 1.50;
-//      n_to_p_eff_curr_drv_ratio[0] = 2.41;
-//      gmp_to_gmn_multiplier[0] = 1.38;
-//      Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] / I_on_n[0];
-//      Rpchannelon[0] = n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];
-//      long_channel_leakage_reduction[0] = 1/3.74;
-//      //Using MASTAR, @380K, increase Lgate until Ion reduces to 90% or Lgate increase by 10%, whichever comes first
-//      //Ioff(Lgate normal)/Ioff(Lgate long)= 3.74.
-//      I_off_n[0][0] = 1.96e-7;
-//      I_off_n[0][10] = 2.29e-7;
-//      I_off_n[0][20] = 2.66e-7;
-//      I_off_n[0][30] = 3.05e-7;
-//      I_off_n[0][40] = 3.49e-7;
-//      I_off_n[0][50] = 3.95e-7;
-//      I_off_n[0][60] = 4.45e-7;
-//      I_off_n[0][70] = 4.97e-7;
-//      I_off_n[0][80] = 5.48e-7;
-//      I_off_n[0][90] = 5.94e-7;
-//      I_off_n[0][100] = 6.3e-7;
-//      I_g_on_n[0][0]  = 4.09e-8;//A/micron
-//      I_g_on_n[0][10] = 4.09e-8;
-//      I_g_on_n[0][20] = 4.09e-8;
-//      I_g_on_n[0][30] = 4.09e-8;
-//      I_g_on_n[0][40] = 4.09e-8;
-//      I_g_on_n[0][50] = 4.09e-8;
-//      I_g_on_n[0][60] = 4.09e-8;
-//      I_g_on_n[0][70] = 4.09e-8;
-//      I_g_on_n[0][80] = 4.09e-8;
-//      I_g_on_n[0][90] = 4.09e-8;
-//      I_g_on_n[0][100] = 4.09e-8;
+    if (tech == 65) {  // 65nm technology-node. Corresponds to year 2007 in ITRS
+      // ITRS HP device type
+      //      SENSE_AMP_D = .2e-9; // s
+      //      SENSE_AMP_P = 5.7e-15; // J
+      //      vdd[0] = 1.1;
+      //      Lphy[0] = 0.025;
+      //      Lelec[0] = 0.019;
+      //      t_ox[0] = 1.1e-3;
+      //      v_th[0] = .19491;
+      //      c_ox[0] = 1.88e-14;
+      //      mobility_eff[0] = 436.24 * (1e-2 * 1e6 * 1e-2 * 1e6);
+      //      Vdsat[0] = 7.71e-2;
+      //      c_g_ideal[0] = 4.69e-16;
+      //      c_fringe[0] = 0.077e-15;
+      //      c_junc[0] = 1e-15;
+      //      I_on_n[0] = 1197.2e-6;
+      //      I_on_p[0] = 870.8e-6;
+      //      nmos_effective_resistance_multiplier = 1.50;
+      //      n_to_p_eff_curr_drv_ratio[0] = 2.41;
+      //      gmp_to_gmn_multiplier[0] = 1.38;
+      //      Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] /
+      //      I_on_n[0];
+      //      Rpchannelon[0] = n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];
+      //      long_channel_leakage_reduction[0] = 1/3.74;
+      //      //Using MASTAR, @380K, increase Lgate until Ion reduces to 90% or
+      //      Lgate increase by 10%, whichever comes first
+      //      //Ioff(Lgate normal)/Ioff(Lgate long)= 3.74.
+      //      I_off_n[0][0] = 1.96e-7;
+      //      I_off_n[0][10] = 2.29e-7;
+      //      I_off_n[0][20] = 2.66e-7;
+      //      I_off_n[0][30] = 3.05e-7;
+      //      I_off_n[0][40] = 3.49e-7;
+      //      I_off_n[0][50] = 3.95e-7;
+      //      I_off_n[0][60] = 4.45e-7;
+      //      I_off_n[0][70] = 4.97e-7;
+      //      I_off_n[0][80] = 5.48e-7;
+      //      I_off_n[0][90] = 5.94e-7;
+      //      I_off_n[0][100] = 6.3e-7;
+      //      I_g_on_n[0][0]  = 4.09e-8;//A/micron
+      //      I_g_on_n[0][10] = 4.09e-8;
+      //      I_g_on_n[0][20] = 4.09e-8;
+      //      I_g_on_n[0][30] = 4.09e-8;
+      //      I_g_on_n[0][40] = 4.09e-8;
+      //      I_g_on_n[0][50] = 4.09e-8;
+      //      I_g_on_n[0][60] = 4.09e-8;
+      //      I_g_on_n[0][70] = 4.09e-8;
+      //      I_g_on_n[0][80] = 4.09e-8;
+      //      I_g_on_n[0][90] = 4.09e-8;
+      //      I_g_on_n[0][100] = 4.09e-8;
 
-    	SENSE_AMP_D = .2e-9; // s
-    	SENSE_AMP_P = 5.7e-15; // J
-    	vdd[0] = 1.25;
-    	Lphy[0] = 0.025;
-    	Lelec[0] = 0.019;
-    	t_ox[0] = 1.1e-3;
-    	v_th[0] = .12491;
-    	c_ox[0] = 1.88e-14;
-    	mobility_eff[0] = 409.31 * (1e-2 * 1e6 * 1e-2 * 1e6);
-    	Vdsat[0] = 9.08e-2;
-    	c_g_ideal[0] = 4.72e-16;
-    	c_fringe[0] = 0.08e-15;
-    	c_junc[0] = 1e-15;
-    	I_on_n[0] = 1486.4e-6;
-    	I_on_p[0] = 1131.5e-6;
-    	nmos_effective_resistance_multiplier = 1.57;
-    	n_to_p_eff_curr_drv_ratio[0] = 2;
-    	gmp_to_gmn_multiplier[0] = 1.38;
-    	Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] / I_on_n[0];
-    	Rpchannelon[0] = n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];
-    	long_channel_leakage_reduction[0] = 1.0/4.97;
-    	//Using MASTAR, @380K, increase Lgate until Ion reduces to 90% or Lgate increase by 10%, whichever comes first
-    	//Ioff(Lgate normal)/Ioff(Lgate long)= 4.97@Vdd=1.25; (3.74@Vdd=1.1), however, Intel paper suggest the reduction factor is 3.
-    	I_off_n[0][0]  = 8.62e-7;
-    	I_off_n[0][10] = 9.08e-7;
-    	I_off_n[0][20] = 9.55e-7;
-    	I_off_n[0][30] = 1.00e-6;
-    	I_off_n[0][40] = 1.05e-6;
-    	I_off_n[0][50] = 1.09e-6;
-    	I_off_n[0][60] = 1.14e-6;
-    	I_off_n[0][70] = 1.18e-6;
-    	I_off_n[0][80] = 1.23e-6;
-    	I_off_n[0][90] = 1.27e-6;
-    	I_off_n[0][100] = 1.31e-6;
+      SENSE_AMP_D = .2e-9;    // s
+      SENSE_AMP_P = 5.7e-15;  // J
+      vdd[0] = 1.25;
+      Lphy[0] = 0.025;
+      Lelec[0] = 0.019;
+      t_ox[0] = 1.1e-3;
+      v_th[0] = .12491;
+      c_ox[0] = 1.88e-14;
+      mobility_eff[0] = 409.31 * (1e-2 * 1e6 * 1e-2 * 1e6);
+      Vdsat[0] = 9.08e-2;
+      c_g_ideal[0] = 4.72e-16;
+      c_fringe[0] = 0.08e-15;
+      c_junc[0] = 1e-15;
+      I_on_n[0] = 1486.4e-6;
+      I_on_p[0] = 1131.5e-6;
+      nmos_effective_resistance_multiplier = 1.57;
+      n_to_p_eff_curr_drv_ratio[0] = 2;
+      gmp_to_gmn_multiplier[0] = 1.38;
+      Rnchannelon[0] =
+          nmos_effective_resistance_multiplier * vdd[0] / I_on_n[0];
+      Rpchannelon[0] = n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];
+      long_channel_leakage_reduction[0] = 1.0 / 4.97;
+      // Using MASTAR, @380K, increase Lgate until Ion reduces to 90% or Lgate
+      // increase by 10%, whichever comes first
+      // Ioff(Lgate normal)/Ioff(Lgate long)= 4.97@Vdd=1.25; (3.74@Vdd=1.1),
+      // however, Intel paper suggest the reduction factor is 3.
+      I_off_n[0][0] = 8.62e-7;
+      I_off_n[0][10] = 9.08e-7;
+      I_off_n[0][20] = 9.55e-7;
+      I_off_n[0][30] = 1.00e-6;
+      I_off_n[0][40] = 1.05e-6;
+      I_off_n[0][50] = 1.09e-6;
+      I_off_n[0][60] = 1.14e-6;
+      I_off_n[0][70] = 1.18e-6;
+      I_off_n[0][80] = 1.23e-6;
+      I_off_n[0][90] = 1.27e-6;
+      I_off_n[0][100] = 1.31e-6;
 
+      I_g_on_n[0][0] = 7.02e-8;  // A/micron
+      I_g_on_n[0][10] = 7.02e-8;
+      I_g_on_n[0][20] = 7.02e-8;
+      I_g_on_n[0][30] = 7.02e-8;
+      I_g_on_n[0][40] = 7.02e-8;
+      I_g_on_n[0][50] = 7.02e-8;
+      I_g_on_n[0][60] = 7.02e-8;
+      I_g_on_n[0][70] = 7.02e-8;
+      I_g_on_n[0][80] = 7.02e-8;
+      I_g_on_n[0][90] = 7.02e-8;
+      I_g_on_n[0][100] = 7.02e-8;
 
-    	I_g_on_n[0][0]  = 7.02e-8;//A/micron
-    	I_g_on_n[0][10] = 7.02e-8;
-    	I_g_on_n[0][20] = 7.02e-8;
-    	I_g_on_n[0][30] = 7.02e-8;
-    	I_g_on_n[0][40] = 7.02e-8;
-    	I_g_on_n[0][50] = 7.02e-8;
-    	I_g_on_n[0][60] = 7.02e-8;
-    	I_g_on_n[0][70] = 7.02e-8;
-    	I_g_on_n[0][80] = 7.02e-8;
-    	I_g_on_n[0][90] = 7.02e-8;
-    	I_g_on_n[0][100] = 7.02e-8;
-
-      //ITRS LSTP device type
+      // ITRS LSTP device type
       vdd[1] = 1.2;
       Lphy[1] = 0.045;
       Lelec[1] = 0.0298;
@@ -583,9 +573,10 @@ void init_tech_params(double technology, bool is_tag)
       nmos_effective_resistance_multiplier = 1.96;
       n_to_p_eff_curr_drv_ratio[1] = 2.23;
       gmp_to_gmn_multiplier[1] = 0.99;
-      Rnchannelon[1] = nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];
+      Rnchannelon[1] =
+          nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];
       Rpchannelon[1] = n_to_p_eff_curr_drv_ratio[1] * Rnchannelon[1];
-      long_channel_leakage_reduction[1] = 1/2.82;
+      long_channel_leakage_reduction[1] = 1 / 2.82;
       I_off_n[1][0] = 9.12e-12;
       I_off_n[1][10] = 1.49e-11;
       I_off_n[1][20] = 2.36e-11;
@@ -598,7 +589,7 @@ void init_tech_params(double technology, bool is_tag)
       I_off_n[1][90] = 2.62e-10;
       I_off_n[1][100] = 3.21e-10;
 
-      I_g_on_n[1][0]  = 1.09e-10;//A/micron
+      I_g_on_n[1][0] = 1.09e-10;  // A/micron
       I_g_on_n[1][10] = 1.09e-10;
       I_g_on_n[1][20] = 1.09e-10;
       I_g_on_n[1][30] = 1.09e-10;
@@ -610,7 +601,7 @@ void init_tech_params(double technology, bool is_tag)
       I_g_on_n[1][90] = 1.09e-10;
       I_g_on_n[1][100] = 1.09e-10;
 
-      //ITRS LOP device type
+      // ITRS LOP device type
       vdd[2] = 0.8;
       Lphy[2] = 0.032;
       Lelec[2] = 0.0216;
@@ -627,9 +618,10 @@ void init_tech_params(double technology, bool is_tag)
       nmos_effective_resistance_multiplier = 1.82;
       n_to_p_eff_curr_drv_ratio[2] = 2.28;
       gmp_to_gmn_multiplier[2] = 1.11;
-      Rnchannelon[2] = nmos_effective_resistance_multiplier * vdd[2] / I_on_n[2];
+      Rnchannelon[2] =
+          nmos_effective_resistance_multiplier * vdd[2] / I_on_n[2];
       Rpchannelon[2] = n_to_p_eff_curr_drv_ratio[2] * Rnchannelon[2];
-      long_channel_leakage_reduction[2] = 1/2.05;
+      long_channel_leakage_reduction[2] = 1 / 2.05;
       I_off_n[2][0] = 4.9e-9;
       I_off_n[2][10] = 6.49e-9;
       I_off_n[2][20] = 8.45e-9;
@@ -642,7 +634,7 @@ void init_tech_params(double technology, bool is_tag)
       I_off_n[2][90] = 3.13e-8;
       I_off_n[2][100] = 3.42e-8;
 
-      I_g_on_n[2][0]  = 9.61e-9;//A/micron
+      I_g_on_n[2][0] = 9.61e-9;  // A/micron
       I_g_on_n[2][10] = 9.61e-9;
       I_g_on_n[2][20] = 9.61e-9;
       I_g_on_n[2][30] = 9.61e-9;
@@ -654,9 +646,8 @@ void init_tech_params(double technology, bool is_tag)
       I_g_on_n[2][90] = 9.61e-9;
       I_g_on_n[2][100] = 9.61e-9;
 
-      if (ram_cell_tech_type == lp_dram)
-      {
-        //LP-DRAM cell access transistor technology parameters
+      if (ram_cell_tech_type == lp_dram) {
+        // LP-DRAM cell access transistor technology parameters
         curr_vdd_dram_cell = 1.2;
         Lphy[3] = 0.12;
         Lelec[3] = 0.0756;
@@ -671,25 +662,26 @@ void init_tech_params(double technology, bool is_tag)
         curr_asp_ratio_cell_dram = 1.46;
         curr_c_dram_cell = 20e-15;
 
-        //LP-DRAM wordline transistor parameters
+        // LP-DRAM wordline transistor parameters
         curr_vpp = 1.6;
         t_ox[3] = 2.2e-3;
         v_th[3] = 0.43806;
         c_ox[3] = 1.22e-14;
-        mobility_eff[3] =  328.32 * (1e-2 * 1e6 * 1e-2 * 1e6);
+        mobility_eff[3] = 328.32 * (1e-2 * 1e6 * 1e-2 * 1e6);
         Vdsat[3] = 0.43806;
         c_g_ideal[3] = 1.46e-15;
         c_fringe[3] = 0.08e-15;
-        c_junc[3] = 1e-15 ;
+        c_junc[3] = 1e-15;
         I_on_n[3] = 399.8e-6;
         I_on_p[3] = 243.4e-6;
         nmos_effective_resistance_multiplier = 1.65;
         n_to_p_eff_curr_drv_ratio[3] = 2.05;
         gmp_to_gmn_multiplier[3] = 0.90;
-        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
+        Rnchannelon[3] =
+            nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
         Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];
         long_channel_leakage_reduction[3] = 1;
-        I_off_n[3][0]  = 2.23e-11;
+        I_off_n[3][0] = 2.23e-11;
         I_off_n[3][10] = 3.46e-11;
         I_off_n[3][20] = 5.24e-11;
         I_off_n[3][30] = 7.75e-11;
@@ -700,10 +692,8 @@ void init_tech_params(double technology, bool is_tag)
         I_off_n[3][80] = 3.63e-10;
         I_off_n[3][90] = 4.41e-10;
         I_off_n[3][100] = 5.36e-10;
-      }
-      else if (ram_cell_tech_type == comm_dram)
-      {
-        //COMM-DRAM cell access transistor technology parameters
+      } else if (ram_cell_tech_type == comm_dram) {
+        // COMM-DRAM cell access transistor technology parameters
         curr_vdd_dram_cell = 1.3;
         Lphy[3] = 0.065;
         Lelec[3] = 0.0426;
@@ -714,29 +704,30 @@ void init_tech_params(double technology, bool is_tag)
         curr_Wmemcella_dram = width_dram_access_transistor;
         curr_Wmemcellpmos_dram = 0;
         curr_Wmemcellnmos_dram = 0;
-        curr_area_cell_dram = 6*0.065*0.065;
+        curr_area_cell_dram = 6 * 0.065 * 0.065;
         curr_asp_ratio_cell_dram = 1.5;
         curr_c_dram_cell = 30e-15;
 
-        //COMM-DRAM wordline transistor parameters
+        // COMM-DRAM wordline transistor parameters
         curr_vpp = 3.3;
         t_ox[3] = 5e-3;
         v_th[3] = 1.0;
         c_ox[3] = 6.16e-15;
-        mobility_eff[3] =  303.44 * (1e-2 * 1e6 * 1e-2 * 1e6);
+        mobility_eff[3] = 303.44 * (1e-2 * 1e6 * 1e-2 * 1e6);
         Vdsat[3] = 0.385;
         c_g_ideal[3] = 4e-16;
         c_fringe[3] = 0.08e-15;
-        c_junc[3] = 1e-15 ;
+        c_junc[3] = 1e-15;
         I_on_n[3] = 1031e-6;
         I_on_p[3] = I_on_n[3] / 2;
         nmos_effective_resistance_multiplier = 1.69;
         n_to_p_eff_curr_drv_ratio[3] = 2.39;
         gmp_to_gmn_multiplier[3] = 0.90;
-        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
+        Rnchannelon[3] =
+            nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
         Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];
         long_channel_leakage_reduction[3] = 1;
-        I_off_n[3][0]  = 1.80e-14;
+        I_off_n[3][0] = 1.80e-14;
         I_off_n[3][10] = 3.64e-14;
         I_off_n[3][20] = 7.03e-14;
         I_off_n[3][30] = 1.31e-13;
@@ -749,31 +740,32 @@ void init_tech_params(double technology, bool is_tag)
         I_off_n[3][100] = 3.99e-12;
       }
 
-      //SRAM cell properties
+      // SRAM cell properties
       curr_Wmemcella_sram = 1.31 * g_ip->F_sz_um;
       curr_Wmemcellpmos_sram = 1.23 * g_ip->F_sz_um;
       curr_Wmemcellnmos_sram = 2.08 * g_ip->F_sz_um;
       curr_area_cell_sram = 146 * g_ip->F_sz_um * g_ip->F_sz_um;
       curr_asp_ratio_cell_sram = 1.46;
-      //CAM cell properties //TODO: data need to be revisited
+      // CAM cell properties //TODO: data need to be revisited
       curr_Wmemcella_cam = 1.31 * g_ip->F_sz_um;
       curr_Wmemcellpmos_cam = 1.23 * g_ip->F_sz_um;
       curr_Wmemcellnmos_cam = 2.08 * g_ip->F_sz_um;
       curr_area_cell_cam = 292 * g_ip->F_sz_um * g_ip->F_sz_um;
       curr_asp_ratio_cell_cam = 2.92;
-      //Empirical undifferetiated core/FU coefficient
+      // Empirical undifferetiated core/FU coefficient
       curr_logic_scaling_co_eff = 0.7;
-      curr_core_tx_density      = 1.25*0.7;
-      curr_sckt_co_eff           = 1.1359;
-      curr_chip_layout_overhead  = 1.2;//die measurement results based on Niagara 1 and 2
-      curr_macro_layout_overhead = 1.1;//EDA placement and routing tool rule of thumb
+      curr_core_tx_density = 1.25 * 0.7;
+      curr_sckt_co_eff = 1.1359;
+      curr_chip_layout_overhead =
+          1.2;  // die measurement results based on Niagara 1 and 2
+      curr_macro_layout_overhead =
+          1.1;  // EDA placement and routing tool rule of thumb
     }
 
-    if (tech == 45)
-    { //45nm technology-node. Corresponds to year 2010 in ITRS
-      //ITRS HP device type
-      SENSE_AMP_D = .04e-9; // s
-      SENSE_AMP_P = 2.7e-15; // J
+    if (tech == 45) {  // 45nm technology-node. Corresponds to year 2010 in ITRS
+      // ITRS HP device type
+      SENSE_AMP_D = .04e-9;   // s
+      SENSE_AMP_P = 2.7e-15;  // J
       vdd[0] = 1.0;
       Lphy[0] = 0.018;
       Lelec[0] = 0.01345;
@@ -786,15 +778,20 @@ void init_tech_params(double technology, bool is_tag)
       c_fringe[0] = 0.05e-15;
       c_junc[0] = 1e-15;
       I_on_n[0] = 2046.6e-6;
-      //There are certain problems with the ITRS PMOS numbers in MASTAR for 45nm. So we are using 65nm values of
-      //n_to_p_eff_curr_drv_ratio and gmp_to_gmn_multiplier for 45nm
-      I_on_p[0] = I_on_n[0] / 2;//This value is fixed arbitrarily but I_on_p is not being used in CACTI
+      // There are certain problems with the ITRS PMOS numbers in MASTAR for
+      // 45nm. So we are using 65nm values of
+      // n_to_p_eff_curr_drv_ratio and gmp_to_gmn_multiplier for 45nm
+      I_on_p[0] = I_on_n[0] / 2;  // This value is fixed arbitrarily but I_on_p
+                                  // is not being used in CACTI
       nmos_effective_resistance_multiplier = 1.51;
       n_to_p_eff_curr_drv_ratio[0] = 2.41;
       gmp_to_gmn_multiplier[0] = 1.38;
-      Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] / I_on_n[0];
+      Rnchannelon[0] =
+          nmos_effective_resistance_multiplier * vdd[0] / I_on_n[0];
       Rpchannelon[0] = n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];
-      long_channel_leakage_reduction[0] = 1/3.546;//Using MASTAR, @380K, increase Lgate until Ion reduces to 90%, Ioff(Lgate normal)/Ioff(Lgate long)= 3.74
+      long_channel_leakage_reduction[0] =
+          1 / 3.546;  // Using MASTAR, @380K, increase Lgate until Ion reduces
+                      // to 90%, Ioff(Lgate normal)/Ioff(Lgate long)= 3.74
       I_off_n[0][0] = 2.8e-7;
       I_off_n[0][10] = 3.28e-7;
       I_off_n[0][20] = 3.81e-7;
@@ -807,7 +804,7 @@ void init_tech_params(double technology, bool is_tag)
       I_off_n[0][90] = 8.91e-7;
       I_off_n[0][100] = 9.84e-7;
 
-      I_g_on_n[0][0]  = 3.59e-8;//A/micron
+      I_g_on_n[0][0] = 3.59e-8;  // A/micron
       I_g_on_n[0][10] = 3.59e-8;
       I_g_on_n[0][20] = 3.59e-8;
       I_g_on_n[0][30] = 3.59e-8;
@@ -819,14 +816,14 @@ void init_tech_params(double technology, bool is_tag)
       I_g_on_n[0][90] = 3.59e-8;
       I_g_on_n[0][100] = 3.59e-8;
 
-      //ITRS LSTP device type
+      // ITRS LSTP device type
       vdd[1] = 1.1;
-      Lphy[1] =  0.028;
+      Lphy[1] = 0.028;
       Lelec[1] = 0.0212;
       t_ox[1] = 1.4e-3;
       v_th[1] = 0.50245;
       c_ox[1] = 2.01e-14;
-      mobility_eff[1] =  363.96 * (1e-2 * 1e6 * 1e-2 * 1e6);
+      mobility_eff[1] = 363.96 * (1e-2 * 1e6 * 1e-2 * 1e6);
       Vdsat[1] = 9.12e-2;
       c_g_ideal[1] = 5.18e-16;
       c_fringe[1] = 0.08e-15;
@@ -836,9 +833,10 @@ void init_tech_params(double technology, bool is_tag)
       nmos_effective_resistance_multiplier = 1.99;
       n_to_p_eff_curr_drv_ratio[1] = 2.23;
       gmp_to_gmn_multiplier[1] = 0.99;
-      Rnchannelon[1] = nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];
+      Rnchannelon[1] =
+          nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];
       Rpchannelon[1] = n_to_p_eff_curr_drv_ratio[1] * Rnchannelon[1];
-      long_channel_leakage_reduction[1] = 1/2.08;
+      long_channel_leakage_reduction[1] = 1 / 2.08;
       I_off_n[1][0] = 1.01e-11;
       I_off_n[1][10] = 1.65e-11;
       I_off_n[1][20] = 2.62e-11;
@@ -851,7 +849,7 @@ void init_tech_params(double technology, bool is_tag)
       I_off_n[1][90] = 3.29e-10;
       I_off_n[1][100] = 4.1e-10;
 
-      I_g_on_n[1][0]  = 9.47e-12;//A/micron
+      I_g_on_n[1][0] = 9.47e-12;  // A/micron
       I_g_on_n[1][10] = 9.47e-12;
       I_g_on_n[1][20] = 9.47e-12;
       I_g_on_n[1][30] = 9.47e-12;
@@ -863,13 +861,13 @@ void init_tech_params(double technology, bool is_tag)
       I_g_on_n[1][90] = 9.47e-12;
       I_g_on_n[1][100] = 9.47e-12;
 
-      //ITRS LOP device type
+      // ITRS LOP device type
       vdd[2] = 0.7;
       Lphy[2] = 0.022;
       Lelec[2] = 0.016;
       t_ox[2] = 0.9e-3;
       v_th[2] = 0.22599;
-      c_ox[2] = 2.82e-14;//F/micron2
+      c_ox[2] = 2.82e-14;  // F/micron2
       mobility_eff[2] = 508.9 * (1e-2 * 1e6 * 1e-2 * 1e6);
       Vdsat[2] = 5.71e-2;
       c_g_ideal[2] = 6.2e-16;
@@ -880,9 +878,10 @@ void init_tech_params(double technology, bool is_tag)
       nmos_effective_resistance_multiplier = 1.76;
       n_to_p_eff_curr_drv_ratio[2] = 2.28;
       gmp_to_gmn_multiplier[2] = 1.11;
-      Rnchannelon[2] = nmos_effective_resistance_multiplier * vdd[2] / I_on_n[2];
+      Rnchannelon[2] =
+          nmos_effective_resistance_multiplier * vdd[2] / I_on_n[2];
       Rpchannelon[2] = n_to_p_eff_curr_drv_ratio[2] * Rnchannelon[2];
-      long_channel_leakage_reduction[2] = 1/1.92;
+      long_channel_leakage_reduction[2] = 1 / 1.92;
       I_off_n[2][0] = 4.03e-9;
       I_off_n[2][10] = 5.02e-9;
       I_off_n[2][20] = 6.18e-9;
@@ -895,7 +894,7 @@ void init_tech_params(double technology, bool is_tag)
       I_off_n[2][90] = 1.84e-8;
       I_off_n[2][100] = 2.03e-8;
 
-      I_g_on_n[2][0]  = 3.24e-8;//A/micron
+      I_g_on_n[2][0] = 3.24e-8;  // A/micron
       I_g_on_n[2][10] = 4.01e-8;
       I_g_on_n[2][20] = 4.90e-8;
       I_g_on_n[2][30] = 5.92e-8;
@@ -907,29 +906,29 @@ void init_tech_params(double technology, bool is_tag)
       I_g_on_n[2][90] = 1.43e-7;
       I_g_on_n[2][100] = 1.54e-7;
 
-      if (ram_cell_tech_type == lp_dram)
-      {
-        //LP-DRAM cell access transistor technology parameters
+      if (ram_cell_tech_type == lp_dram) {
+        // LP-DRAM cell access transistor technology parameters
         curr_vdd_dram_cell = 1.1;
         Lphy[3] = 0.078;
-        Lelec[3] = 0.0504;// Assume Lelec is 30% lesser than Lphy for DRAM access and wordline transistors.
+        Lelec[3] = 0.0504;  // Assume Lelec is 30% lesser than Lphy for DRAM
+                            // access and wordline transistors.
         curr_v_th_dram_access_transistor = 0.44559;
         width_dram_access_transistor = 0.079;
-        curr_I_on_dram_cell = 36e-6;//A
+        curr_I_on_dram_cell = 36e-6;  // A
         curr_I_off_dram_cell_worst_case_length_temp = 19.5e-12;
         curr_Wmemcella_dram = width_dram_access_transistor;
         curr_Wmemcellpmos_dram = 0;
-        curr_Wmemcellnmos_dram  = 0;
+        curr_Wmemcellnmos_dram = 0;
         curr_area_cell_dram = width_dram_access_transistor * Lphy[3] * 10.0;
         curr_asp_ratio_cell_dram = 1.46;
         curr_c_dram_cell = 20e-15;
 
-        //LP-DRAM wordline transistor parameters
+        // LP-DRAM wordline transistor parameters
         curr_vpp = 1.5;
         t_ox[3] = 2.1e-3;
         v_th[3] = 0.44559;
         c_ox[3] = 1.41e-14;
-        mobility_eff[3] =   426.30 * (1e-2 * 1e6 * 1e-2 * 1e6);
+        mobility_eff[3] = 426.30 * (1e-2 * 1e6 * 1e-2 * 1e6);
         Vdsat[3] = 0.181;
         c_g_ideal[3] = 1.10e-15;
         c_fringe[3] = 0.08e-15;
@@ -939,7 +938,8 @@ void init_tech_params(double technology, bool is_tag)
         nmos_effective_resistance_multiplier = 1.65;
         n_to_p_eff_curr_drv_ratio[3] = 2.05;
         gmp_to_gmn_multiplier[3] = 0.90;
-        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
+        Rnchannelon[3] =
+            nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
         Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];
         long_channel_leakage_reduction[3] = 1;
         I_off_n[3][0] = 2.54e-11;
@@ -953,25 +953,23 @@ void init_tech_params(double technology, bool is_tag)
         I_off_n[3][80] = 4.26e-10;
         I_off_n[3][90] = 5.27e-10;
         I_off_n[3][100] = 6.46e-10;
-      }
-      else if (ram_cell_tech_type == comm_dram)
-      {
-        //COMM-DRAM cell access transistor technology parameters
+      } else if (ram_cell_tech_type == comm_dram) {
+        // COMM-DRAM cell access transistor technology parameters
         curr_vdd_dram_cell = 1.1;
         Lphy[3] = 0.045;
         Lelec[3] = 0.0298;
         curr_v_th_dram_access_transistor = 1;
         width_dram_access_transistor = 0.045;
-        curr_I_on_dram_cell = 20e-6;//A
+        curr_I_on_dram_cell = 20e-6;  // A
         curr_I_off_dram_cell_worst_case_length_temp = 1e-15;
         curr_Wmemcella_dram = width_dram_access_transistor;
         curr_Wmemcellpmos_dram = 0;
-        curr_Wmemcellnmos_dram  = 0;
-        curr_area_cell_dram = 6*0.045*0.045;
+        curr_Wmemcellnmos_dram = 0;
+        curr_area_cell_dram = 6 * 0.045 * 0.045;
         curr_asp_ratio_cell_dram = 1.5;
         curr_c_dram_cell = 30e-15;
 
-        //COMM-DRAM wordline transistor parameters
+        // COMM-DRAM wordline transistor parameters
         curr_vpp = 2.7;
         t_ox[3] = 4e-3;
         v_th[3] = 1.0;
@@ -986,7 +984,8 @@ void init_tech_params(double technology, bool is_tag)
         nmos_effective_resistance_multiplier = 1.69;
         n_to_p_eff_curr_drv_ratio[3] = 1.95;
         gmp_to_gmn_multiplier[3] = 0.90;
-        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
+        Rnchannelon[3] =
+            nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
         Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];
         long_channel_leakage_reduction[3] = 1;
         I_off_n[3][0] = 1.31e-14;
@@ -1002,34 +1001,35 @@ void init_tech_params(double technology, bool is_tag)
         I_off_n[3][100] = 3.29e-12;
       }
 
-
-      //SRAM cell properties
+      // SRAM cell properties
       curr_Wmemcella_sram = 1.31 * g_ip->F_sz_um;
       curr_Wmemcellpmos_sram = 1.23 * g_ip->F_sz_um;
       curr_Wmemcellnmos_sram = 2.08 * g_ip->F_sz_um;
       curr_area_cell_sram = 146 * g_ip->F_sz_um * g_ip->F_sz_um;
       curr_asp_ratio_cell_sram = 1.46;
-      //CAM cell properties //TODO: data need to be revisited
+      // CAM cell properties //TODO: data need to be revisited
       curr_Wmemcella_cam = 1.31 * g_ip->F_sz_um;
       curr_Wmemcellpmos_cam = 1.23 * g_ip->F_sz_um;
       curr_Wmemcellnmos_cam = 2.08 * g_ip->F_sz_um;
       curr_area_cell_cam = 292 * g_ip->F_sz_um * g_ip->F_sz_um;
       curr_asp_ratio_cell_cam = 2.92;
-      //Empirical undifferetiated core/FU coefficient
-      curr_logic_scaling_co_eff = 0.7*0.7;
-      curr_core_tx_density      = 1.25;
-      curr_sckt_co_eff           = 1.1387;
-      curr_chip_layout_overhead  = 1.2;//die measurement results based on Niagara 1 and 2
-      curr_macro_layout_overhead = 1.1;//EDA placement and routing tool rule of thumb
+      // Empirical undifferetiated core/FU coefficient
+      curr_logic_scaling_co_eff = 0.7 * 0.7;
+      curr_core_tx_density = 1.25;
+      curr_sckt_co_eff = 1.1387;
+      curr_chip_layout_overhead =
+          1.2;  // die measurement results based on Niagara 1 and 2
+      curr_macro_layout_overhead =
+          1.1;  // EDA placement and routing tool rule of thumb
     }
 
-    if (tech == 32)
-    {
-      SENSE_AMP_D = .03e-9; // s
-      SENSE_AMP_P = 2.16e-15; // J
-      //For 2013, MPU/ASIC stagger-contacted M1 half-pitch is 32 nm (so this is 32 nm
-      //technology i.e. FEATURESIZE = 0.032). Using the SOI process numbers for
-      //HP and LSTP.
+    if (tech == 32) {
+      SENSE_AMP_D = .03e-9;    // s
+      SENSE_AMP_P = 2.16e-15;  // J
+      // For 2013, MPU/ASIC stagger-contacted M1 half-pitch is 32 nm (so this is
+      // 32 nm
+      // technology i.e. FEATURESIZE = 0.032). Using the SOI process numbers for
+      // HP and LSTP.
       vdd[0] = 0.9;
       Lphy[0] = 0.013;
       Lelec[0] = 0.01013;
@@ -1041,16 +1041,20 @@ void init_tech_params(double technology, bool is_tag)
       c_g_ideal[0] = 5.34e-16;
       c_fringe[0] = 0.04e-15;
       c_junc[0] = 1e-15;
-      I_on_n[0] =  2211.7e-6;
+      I_on_n[0] = 2211.7e-6;
       I_on_p[0] = I_on_n[0] / 2;
       nmos_effective_resistance_multiplier = 1.49;
       n_to_p_eff_curr_drv_ratio[0] = 2.41;
       gmp_to_gmn_multiplier[0] = 1.38;
-      Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] / I_on_n[0];//ohm-micron
-      Rpchannelon[0] = n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];//ohm-micron
-      long_channel_leakage_reduction[0] = 1/3.706;
-      //Using MASTAR, @300K (380K does not work in MASTAR), increase Lgate until Ion reduces to 95% or Lgate increase by 5% (DG device can only increase by 5%),
-      //whichever comes first
+      Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] /
+                       I_on_n[0];  // ohm-micron
+      Rpchannelon[0] =
+          n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];  // ohm-micron
+      long_channel_leakage_reduction[0] = 1 / 3.706;
+      // Using MASTAR, @300K (380K does not work in MASTAR), increase Lgate
+      // until Ion reduces to 95% or Lgate increase by 5% (DG device can only
+      // increase by 5%),
+      // whichever comes first
       I_off_n[0][0] = 1.52e-7;
       I_off_n[0][10] = 1.55e-7;
       I_off_n[0][20] = 1.59e-7;
@@ -1063,7 +1067,7 @@ void init_tech_params(double technology, bool is_tag)
       I_off_n[0][90] = 2.73e-6;
       I_off_n[0][100] = 6.1e-6;
 
-      I_g_on_n[0][0]  = 6.55e-8;//A/micron
+      I_g_on_n[0][0] = 6.55e-8;  // A/micron
       I_g_on_n[0][10] = 6.55e-8;
       I_g_on_n[0][20] = 6.55e-8;
       I_g_on_n[0][30] = 6.55e-8;
@@ -1075,27 +1079,27 @@ void init_tech_params(double technology, bool is_tag)
       I_g_on_n[0][90] = 6.55e-8;
       I_g_on_n[0][100] = 6.55e-8;
 
-//      32 DG
-//      I_g_on_n[0][0]  = 2.71e-9;//A/micron
-//      I_g_on_n[0][10] = 2.71e-9;
-//      I_g_on_n[0][20] = 2.71e-9;
-//      I_g_on_n[0][30] = 2.71e-9;
-//      I_g_on_n[0][40] = 2.71e-9;
-//      I_g_on_n[0][50] = 2.71e-9;
-//      I_g_on_n[0][60] = 2.71e-9;
-//      I_g_on_n[0][70] = 2.71e-9;
-//      I_g_on_n[0][80] = 2.71e-9;
-//      I_g_on_n[0][90] = 2.71e-9;
-//      I_g_on_n[0][100] = 2.71e-9;
+      //      32 DG
+      //      I_g_on_n[0][0]  = 2.71e-9;//A/micron
+      //      I_g_on_n[0][10] = 2.71e-9;
+      //      I_g_on_n[0][20] = 2.71e-9;
+      //      I_g_on_n[0][30] = 2.71e-9;
+      //      I_g_on_n[0][40] = 2.71e-9;
+      //      I_g_on_n[0][50] = 2.71e-9;
+      //      I_g_on_n[0][60] = 2.71e-9;
+      //      I_g_on_n[0][70] = 2.71e-9;
+      //      I_g_on_n[0][80] = 2.71e-9;
+      //      I_g_on_n[0][90] = 2.71e-9;
+      //      I_g_on_n[0][100] = 2.71e-9;
 
-      //LSTP device type
+      // LSTP device type
       vdd[1] = 1;
       Lphy[1] = 0.020;
       Lelec[1] = 0.0173;
       t_ox[1] = 1.2e-3;
       v_th[1] = 0.513;
       c_ox[1] = 2.29e-14;
-      mobility_eff[1] =  347.46 * (1e-2 * 1e6 * 1e-2 * 1e6);
+      mobility_eff[1] = 347.46 * (1e-2 * 1e6 * 1e-2 * 1e6);
       Vdsat[1] = 8.64e-2;
       c_g_ideal[1] = 4.58e-16;
       c_fringe[1] = 0.053e-15;
@@ -1105,9 +1109,10 @@ void init_tech_params(double technology, bool is_tag)
       nmos_effective_resistance_multiplier = 1.99;
       n_to_p_eff_curr_drv_ratio[1] = 2.23;
       gmp_to_gmn_multiplier[1] = 0.99;
-      Rnchannelon[1] = nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];
+      Rnchannelon[1] =
+          nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];
       Rpchannelon[1] = n_to_p_eff_curr_drv_ratio[1] * Rnchannelon[1];
-      long_channel_leakage_reduction[1] = 1/1.93;
+      long_channel_leakage_reduction[1] = 1 / 1.93;
       I_off_n[1][0] = 2.06e-11;
       I_off_n[1][10] = 3.30e-11;
       I_off_n[1][20] = 5.15e-11;
@@ -1120,7 +1125,7 @@ void init_tech_params(double technology, bool is_tag)
       I_off_n[1][90] = 5.96e-10;
       I_off_n[1][100] = 7.44e-10;
 
-      I_g_on_n[1][0]  = 3.73e-11;//A/micron
+      I_g_on_n[1][0] = 3.73e-11;  // A/micron
       I_g_on_n[1][10] = 3.73e-11;
       I_g_on_n[1][20] = 3.73e-11;
       I_g_on_n[1][30] = 3.73e-11;
@@ -1132,15 +1137,14 @@ void init_tech_params(double technology, bool is_tag)
       I_g_on_n[1][90] = 3.73e-11;
       I_g_on_n[1][100] = 3.73e-11;
 
-
-      //LOP device type
+      // LOP device type
       vdd[2] = 0.6;
       Lphy[2] = 0.016;
       Lelec[2] = 0.01232;
       t_ox[2] = 0.9e-3;
       v_th[2] = 0.24227;
       c_ox[2] = 2.84e-14;
-      mobility_eff[2] =  513.52 * (1e-2 * 1e6 * 1e-2 * 1e6);
+      mobility_eff[2] = 513.52 * (1e-2 * 1e6 * 1e-2 * 1e6);
       Vdsat[2] = 4.64e-2;
       c_g_ideal[2] = 4.54e-16;
       c_fringe[2] = 0.057e-15;
@@ -1150,9 +1154,10 @@ void init_tech_params(double technology, bool is_tag)
       nmos_effective_resistance_multiplier = 1.73;
       n_to_p_eff_curr_drv_ratio[2] = 2.28;
       gmp_to_gmn_multiplier[2] = 1.11;
-      Rnchannelon[2] = nmos_effective_resistance_multiplier * vdd[2] / I_on_n[2];
+      Rnchannelon[2] =
+          nmos_effective_resistance_multiplier * vdd[2] / I_on_n[2];
       Rpchannelon[2] = n_to_p_eff_curr_drv_ratio[2] * Rnchannelon[2];
-      long_channel_leakage_reduction[2] = 1/1.89;
+      long_channel_leakage_reduction[2] = 1 / 1.89;
       I_off_n[2][0] = 5.94e-8;
       I_off_n[2][10] = 7.23e-8;
       I_off_n[2][20] = 8.7e-8;
@@ -1165,7 +1170,7 @@ void init_tech_params(double technology, bool is_tag)
       I_off_n[2][90] = 2.39e-7;
       I_off_n[2][100] = 2.63e-7;
 
-      I_g_on_n[2][0]  = 2.93e-9;//A/micron
+      I_g_on_n[2][0] = 2.93e-9;  // A/micron
       I_g_on_n[2][10] = 2.93e-9;
       I_g_on_n[2][20] = 2.93e-9;
       I_g_on_n[2][30] = 2.93e-9;
@@ -1177,12 +1182,12 @@ void init_tech_params(double technology, bool is_tag)
       I_g_on_n[2][90] = 2.93e-9;
       I_g_on_n[2][100] = 2.93e-9;
 
-      if (ram_cell_tech_type == lp_dram)
-      {
-        //LP-DRAM cell access transistor technology parameters
+      if (ram_cell_tech_type == lp_dram) {
+        // LP-DRAM cell access transistor technology parameters
         curr_vdd_dram_cell = 1.0;
         Lphy[3] = 0.056;
-        Lelec[3] = 0.0419;//Assume Lelec is 30% lesser than Lphy for DRAM access and wordline transistors.
+        Lelec[3] = 0.0419;  // Assume Lelec is 30% lesser than Lphy for DRAM
+                            // access and wordline transistors.
         curr_v_th_dram_access_transistor = 0.44129;
         width_dram_access_transistor = 0.056;
         curr_I_on_dram_cell = 36e-6;
@@ -1194,12 +1199,12 @@ void init_tech_params(double technology, bool is_tag)
         curr_asp_ratio_cell_dram = 1.46;
         curr_c_dram_cell = 20e-15;
 
-        //LP-DRAM wordline transistor parameters
+        // LP-DRAM wordline transistor parameters
         curr_vpp = 1.5;
         t_ox[3] = 2e-3;
         v_th[3] = 0.44467;
         c_ox[3] = 1.48e-14;
-        mobility_eff[3] =  408.12 * (1e-2 * 1e6 * 1e-2 * 1e6);
+        mobility_eff[3] = 408.12 * (1e-2 * 1e6 * 1e-2 * 1e6);
         Vdsat[3] = 0.174;
         c_g_ideal[3] = 7.45e-16;
         c_fringe[3] = 0.053e-15;
@@ -1209,10 +1214,11 @@ void init_tech_params(double technology, bool is_tag)
         nmos_effective_resistance_multiplier = 1.65;
         n_to_p_eff_curr_drv_ratio[3] = 2.05;
         gmp_to_gmn_multiplier[3] = 0.90;
-        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
+        Rnchannelon[3] =
+            nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
         Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];
         long_channel_leakage_reduction[3] = 1;
-        I_off_n[3][0]  = 3.57e-11;
+        I_off_n[3][0] = 3.57e-11;
         I_off_n[3][10] = 5.51e-11;
         I_off_n[3][20] = 8.27e-11;
         I_off_n[3][30] = 1.21e-10;
@@ -1223,13 +1229,12 @@ void init_tech_params(double technology, bool is_tag)
         I_off_n[3][80] = 5.87e-10;
         I_off_n[3][90] = 7.29e-10;
         I_off_n[3][100] = 8.87e-10;
-      }
-      else if (ram_cell_tech_type == comm_dram)
-      {
-        //COMM-DRAM cell access transistor technology parameters
+      } else if (ram_cell_tech_type == comm_dram) {
+        // COMM-DRAM cell access transistor technology parameters
         curr_vdd_dram_cell = 1.0;
         Lphy[3] = 0.032;
-        Lelec[3] = 0.0205;//Assume Lelec is 30% lesser than Lphy for DRAM access and wordline transistors.
+        Lelec[3] = 0.0205;  // Assume Lelec is 30% lesser than Lphy for DRAM
+                            // access and wordline transistors.
         curr_v_th_dram_access_transistor = 1;
         width_dram_access_transistor = 0.032;
         curr_I_on_dram_cell = 20e-6;
@@ -1237,16 +1242,16 @@ void init_tech_params(double technology, bool is_tag)
         curr_Wmemcella_dram = width_dram_access_transistor;
         curr_Wmemcellpmos_dram = 0;
         curr_Wmemcellnmos_dram = 0;
-        curr_area_cell_dram = 6*0.032*0.032;
+        curr_area_cell_dram = 6 * 0.032 * 0.032;
         curr_asp_ratio_cell_dram = 1.5;
         curr_c_dram_cell = 30e-15;
 
-        //COMM-DRAM wordline transistor parameters
+        // COMM-DRAM wordline transistor parameters
         curr_vpp = 2.6;
         t_ox[3] = 4e-3;
         v_th[3] = 1.0;
         c_ox[3] = 7.99e-15;
-        mobility_eff[3] =  380.76 * (1e-2 * 1e6 * 1e-2 * 1e6);
+        mobility_eff[3] = 380.76 * (1e-2 * 1e6 * 1e-2 * 1e6);
         Vdsat[3] = 0.129;
         c_g_ideal[3] = 2.56e-16;
         c_fringe[3] = 0.053e-15;
@@ -1256,10 +1261,11 @@ void init_tech_params(double technology, bool is_tag)
         nmos_effective_resistance_multiplier = 1.69;
         n_to_p_eff_curr_drv_ratio[3] = 1.95;
         gmp_to_gmn_multiplier[3] = 0.90;
-        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
+        Rnchannelon[3] =
+            nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
         Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];
         long_channel_leakage_reduction[3] = 1;
-        I_off_n[3][0]  = 3.63e-14;
+        I_off_n[3][0] = 3.63e-14;
         I_off_n[3][10] = 7.18e-14;
         I_off_n[3][20] = 1.36e-13;
         I_off_n[3][30] = 2.49e-13;
@@ -1272,550 +1278,620 @@ void init_tech_params(double technology, bool is_tag)
         I_off_n[3][100] = 7.16e-12;
       }
 
-      //SRAM cell properties
-      curr_Wmemcella_sram    = 1.31 * g_ip->F_sz_um;
+      // SRAM cell properties
+      curr_Wmemcella_sram = 1.31 * g_ip->F_sz_um;
       curr_Wmemcellpmos_sram = 1.23 * g_ip->F_sz_um;
       curr_Wmemcellnmos_sram = 2.08 * g_ip->F_sz_um;
-      curr_area_cell_sram    = 146 * g_ip->F_sz_um * g_ip->F_sz_um;
+      curr_area_cell_sram = 146 * g_ip->F_sz_um * g_ip->F_sz_um;
       curr_asp_ratio_cell_sram = 1.46;
-      //CAM cell properties //TODO: data need to be revisited
+      // CAM cell properties //TODO: data need to be revisited
       curr_Wmemcella_cam = 1.31 * g_ip->F_sz_um;
       curr_Wmemcellpmos_cam = 1.23 * g_ip->F_sz_um;
       curr_Wmemcellnmos_cam = 2.08 * g_ip->F_sz_um;
       curr_area_cell_cam = 292 * g_ip->F_sz_um * g_ip->F_sz_um;
       curr_asp_ratio_cell_cam = 2.92;
-      //Empirical undifferetiated core/FU coefficient
-      curr_logic_scaling_co_eff = 0.7*0.7*0.7;
-      curr_core_tx_density      = 1.25/0.7;
-      curr_sckt_co_eff           = 1.1111;
-      curr_chip_layout_overhead  = 1.2;//die measurement results based on Niagara 1 and 2
-      curr_macro_layout_overhead = 1.1;//EDA placement and routing tool rule of thumb
+      // Empirical undifferetiated core/FU coefficient
+      curr_logic_scaling_co_eff = 0.7 * 0.7 * 0.7;
+      curr_core_tx_density = 1.25 / 0.7;
+      curr_sckt_co_eff = 1.1111;
+      curr_chip_layout_overhead =
+          1.2;  // die measurement results based on Niagara 1 and 2
+      curr_macro_layout_overhead =
+          1.1;  // EDA placement and routing tool rule of thumb
     }
 
-    if(tech == 22){
-    	//For 2016, MPU/ASIC stagger-contacted M1 half-pitch is 22 nm (so this is 22 nm
-    	//technology i.e. FEATURESIZE = 0.022). Using the DG process numbers for HP.
-    	//22 nm HP
-    	vdd[0] = 0.8;
-    	Lphy[0] = 0.009;//Lphy is the physical gate-length.
-    	Lelec[0] = 0.00468;//Lelec is the electrical gate-length.
-    	t_ox[0] = 0.55e-3;//micron
-    	v_th[0] = 0.1395;//V
-    	c_ox[0] = 3.63e-14;//F/micron2
-    	mobility_eff[0] = 426.07 * (1e-2 * 1e6 * 1e-2 * 1e6); //micron2 / Vs
-    	Vdsat[0] = 2.33e-2; //V/micron
-    	c_g_ideal[0] = 3.27e-16;//F/micron
-    	c_fringe[0] = 0.06e-15;//F/micron
-    	c_junc[0] = 0;//F/micron2
-    	I_on_n[0] =  2626.4e-6;//A/micron
-    	I_on_p[0] = I_on_n[0] / 2;//A/micron //This value for I_on_p is not really used.
-        nmos_effective_resistance_multiplier = 1.45;
-        n_to_p_eff_curr_drv_ratio[0] = 2; //Wpmos/Wnmos = 2 in 2007 MASTAR. Look in
-    	//"Dynamic" tab of Device workspace.
-        gmp_to_gmn_multiplier[0] = 1.38; //Just using the 32nm SOI value.
-        Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] / I_on_n[0];//ohm-micron
-        Rpchannelon[0] = n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];//ohm-micron
-        long_channel_leakage_reduction[0] = 1/3.274;
-        I_off_n[0][0] = 1.52e-7/1.5*1.2;//From 22nm, leakage current are directly from ITRS report rather than MASTAR, since MASTAR has serious bugs there.
-        I_off_n[0][10] = 1.55e-7/1.5*1.2;
-        I_off_n[0][20] = 1.59e-7/1.5*1.2;
-        I_off_n[0][30] = 1.68e-7/1.5*1.2;
-        I_off_n[0][40] = 1.90e-7/1.5*1.2;
-        I_off_n[0][50] = 2.69e-7/1.5*1.2;
-        I_off_n[0][60] = 5.32e-7/1.5*1.2;
-        I_off_n[0][70] = 1.02e-6/1.5*1.2;
-        I_off_n[0][80] = 1.62e-6/1.5*1.2;
-        I_off_n[0][90] = 2.73e-6/1.5*1.2;
-        I_off_n[0][100] = 6.1e-6/1.5*1.2;
-        //for 22nm DG HP
-        I_g_on_n[0][0]  = 1.81e-9;//A/micron
-        I_g_on_n[0][10] = 1.81e-9;
-        I_g_on_n[0][20] = 1.81e-9;
-        I_g_on_n[0][30] = 1.81e-9;
-        I_g_on_n[0][40] = 1.81e-9;
-        I_g_on_n[0][50] = 1.81e-9;
-        I_g_on_n[0][60] = 1.81e-9;
-        I_g_on_n[0][70] = 1.81e-9;
-        I_g_on_n[0][80] = 1.81e-9;
-        I_g_on_n[0][90] = 1.81e-9;
-        I_g_on_n[0][100] = 1.81e-9;
+    if (tech == 22) {
+      // For 2016, MPU/ASIC stagger-contacted M1 half-pitch is 22 nm (so this is
+      // 22 nm
+      // technology i.e. FEATURESIZE = 0.022). Using the DG process numbers for
+      // HP.
+      // 22 nm HP
+      vdd[0] = 0.8;
+      Lphy[0] = 0.009;     // Lphy is the physical gate-length.
+      Lelec[0] = 0.00468;  // Lelec is the electrical gate-length.
+      t_ox[0] = 0.55e-3;   // micron
+      v_th[0] = 0.1395;    // V
+      c_ox[0] = 3.63e-14;  // F/micron2
+      mobility_eff[0] = 426.07 * (1e-2 * 1e6 * 1e-2 * 1e6);  // micron2 / Vs
+      Vdsat[0] = 2.33e-2;                                    // V/micron
+      c_g_ideal[0] = 3.27e-16;                               // F/micron
+      c_fringe[0] = 0.06e-15;                                // F/micron
+      c_junc[0] = 0;                                         // F/micron2
+      I_on_n[0] = 2626.4e-6;                                 // A/micron
+      I_on_p[0] = I_on_n[0] /
+                  2;  // A/micron //This value for I_on_p is not really used.
+      nmos_effective_resistance_multiplier = 1.45;
+      n_to_p_eff_curr_drv_ratio[0] =
+          2;  // Wpmos/Wnmos = 2 in 2007 MASTAR. Look in
+      //"Dynamic" tab of Device workspace.
+      gmp_to_gmn_multiplier[0] = 1.38;  // Just using the 32nm SOI value.
+      Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] /
+                       I_on_n[0];  // ohm-micron
+      Rpchannelon[0] =
+          n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];  // ohm-micron
+      long_channel_leakage_reduction[0] = 1 / 3.274;
+      I_off_n[0][0] = 1.52e-7 / 1.5 * 1.2;  // From 22nm, leakage current are
+                                            // directly from ITRS report rather
+                                            // than MASTAR, since MASTAR has
+                                            // serious bugs there.
+      I_off_n[0][10] = 1.55e-7 / 1.5 * 1.2;
+      I_off_n[0][20] = 1.59e-7 / 1.5 * 1.2;
+      I_off_n[0][30] = 1.68e-7 / 1.5 * 1.2;
+      I_off_n[0][40] = 1.90e-7 / 1.5 * 1.2;
+      I_off_n[0][50] = 2.69e-7 / 1.5 * 1.2;
+      I_off_n[0][60] = 5.32e-7 / 1.5 * 1.2;
+      I_off_n[0][70] = 1.02e-6 / 1.5 * 1.2;
+      I_off_n[0][80] = 1.62e-6 / 1.5 * 1.2;
+      I_off_n[0][90] = 2.73e-6 / 1.5 * 1.2;
+      I_off_n[0][100] = 6.1e-6 / 1.5 * 1.2;
+      // for 22nm DG HP
+      I_g_on_n[0][0] = 1.81e-9;  // A/micron
+      I_g_on_n[0][10] = 1.81e-9;
+      I_g_on_n[0][20] = 1.81e-9;
+      I_g_on_n[0][30] = 1.81e-9;
+      I_g_on_n[0][40] = 1.81e-9;
+      I_g_on_n[0][50] = 1.81e-9;
+      I_g_on_n[0][60] = 1.81e-9;
+      I_g_on_n[0][70] = 1.81e-9;
+      I_g_on_n[0][80] = 1.81e-9;
+      I_g_on_n[0][90] = 1.81e-9;
+      I_g_on_n[0][100] = 1.81e-9;
 
-    	//22 nm LSTP DG
-    	vdd[1] = 0.8;
-    	Lphy[1] = 0.014;
-    	Lelec[1] = 0.008;//Lelec is the electrical gate-length.
-    	t_ox[1] = 1.1e-3;//micron
-    	v_th[1] = 0.40126;//V
-    	c_ox[1] = 2.30e-14;//F/micron2
-    	mobility_eff[1] =  738.09 * (1e-2 * 1e6 * 1e-2 * 1e6); //micron2 / Vs
-    	Vdsat[1] = 6.64e-2; //V/micron
-    	c_g_ideal[1] = 3.22e-16;//F/micron
-    	c_fringe[1] = 0.08e-15;
-    	c_junc[1] = 0;//F/micron2
-    	I_on_n[1] = 727.6e-6;//A/micron
-    	I_on_p[1] = I_on_n[1] / 2;
-    	nmos_effective_resistance_multiplier = 1.99;
-    	n_to_p_eff_curr_drv_ratio[1] = 2;
-    	gmp_to_gmn_multiplier[1] = 0.99;
-    	Rnchannelon[1] = nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];//ohm-micron
-    	Rpchannelon[1] = n_to_p_eff_curr_drv_ratio[1] * Rnchannelon[1];//ohm-micron
-    	long_channel_leakage_reduction[1] = 1/1.89;
-    	I_off_n[1][0] = 2.43e-11;
-    	I_off_n[1][10] = 4.85e-11;
-    	I_off_n[1][20] = 9.68e-11;
-    	I_off_n[1][30] = 1.94e-10;
-    	I_off_n[1][40] = 3.87e-10;
-    	I_off_n[1][50] = 7.73e-10;
-    	I_off_n[1][60] = 3.55e-10;
-    	I_off_n[1][70] = 3.09e-9;
-    	I_off_n[1][80] = 6.19e-9;
-    	I_off_n[1][90] = 1.24e-8;
-    	I_off_n[1][100]= 2.48e-8;
+      // 22 nm LSTP DG
+      vdd[1] = 0.8;
+      Lphy[1] = 0.014;
+      Lelec[1] = 0.008;    // Lelec is the electrical gate-length.
+      t_ox[1] = 1.1e-3;    // micron
+      v_th[1] = 0.40126;   // V
+      c_ox[1] = 2.30e-14;  // F/micron2
+      mobility_eff[1] = 738.09 * (1e-2 * 1e6 * 1e-2 * 1e6);  // micron2 / Vs
+      Vdsat[1] = 6.64e-2;                                    // V/micron
+      c_g_ideal[1] = 3.22e-16;                               // F/micron
+      c_fringe[1] = 0.08e-15;
+      c_junc[1] = 0;         // F/micron2
+      I_on_n[1] = 727.6e-6;  // A/micron
+      I_on_p[1] = I_on_n[1] / 2;
+      nmos_effective_resistance_multiplier = 1.99;
+      n_to_p_eff_curr_drv_ratio[1] = 2;
+      gmp_to_gmn_multiplier[1] = 0.99;
+      Rnchannelon[1] = nmos_effective_resistance_multiplier * vdd[1] /
+                       I_on_n[1];  // ohm-micron
+      Rpchannelon[1] =
+          n_to_p_eff_curr_drv_ratio[1] * Rnchannelon[1];  // ohm-micron
+      long_channel_leakage_reduction[1] = 1 / 1.89;
+      I_off_n[1][0] = 2.43e-11;
+      I_off_n[1][10] = 4.85e-11;
+      I_off_n[1][20] = 9.68e-11;
+      I_off_n[1][30] = 1.94e-10;
+      I_off_n[1][40] = 3.87e-10;
+      I_off_n[1][50] = 7.73e-10;
+      I_off_n[1][60] = 3.55e-10;
+      I_off_n[1][70] = 3.09e-9;
+      I_off_n[1][80] = 6.19e-9;
+      I_off_n[1][90] = 1.24e-8;
+      I_off_n[1][100] = 2.48e-8;
 
-    	I_g_on_n[1][0]  = 4.51e-10;//A/micron
-    	I_g_on_n[1][10] = 4.51e-10;
-    	I_g_on_n[1][20] = 4.51e-10;
-    	I_g_on_n[1][30] = 4.51e-10;
-    	I_g_on_n[1][40] = 4.51e-10;
-    	I_g_on_n[1][50] = 4.51e-10;
-    	I_g_on_n[1][60] = 4.51e-10;
-    	I_g_on_n[1][70] = 4.51e-10;
-    	I_g_on_n[1][80] = 4.51e-10;
-    	I_g_on_n[1][90] = 4.51e-10;
-    	I_g_on_n[1][100] = 4.51e-10;
+      I_g_on_n[1][0] = 4.51e-10;  // A/micron
+      I_g_on_n[1][10] = 4.51e-10;
+      I_g_on_n[1][20] = 4.51e-10;
+      I_g_on_n[1][30] = 4.51e-10;
+      I_g_on_n[1][40] = 4.51e-10;
+      I_g_on_n[1][50] = 4.51e-10;
+      I_g_on_n[1][60] = 4.51e-10;
+      I_g_on_n[1][70] = 4.51e-10;
+      I_g_on_n[1][80] = 4.51e-10;
+      I_g_on_n[1][90] = 4.51e-10;
+      I_g_on_n[1][100] = 4.51e-10;
 
-    	//22 nm LOP
-    	vdd[2] = 0.6;
-    	Lphy[2] = 0.011;
-    	Lelec[2] = 0.00604;//Lelec is the electrical gate-length.
-    	t_ox[2] = 0.8e-3;//micron
-    	v_th[2] = 0.2315;//V
-    	c_ox[2] = 2.87e-14;//F/micron2
-    	mobility_eff[2] =  698.37 * (1e-2 * 1e6 * 1e-2 * 1e6); //micron2 / Vs
-    	Vdsat[2] = 1.81e-2; //V/micron
-    	c_g_ideal[2] = 3.16e-16;//F/micron
-    	c_fringe[2] = 0.08e-15;
-    	c_junc[2] = 0;//F/micron2 This is Cj0 not Cjunc in MASTAR results->Dynamic Tab
-    	I_on_n[2] = 916.1e-6;//A/micron
-    	I_on_p[2] = I_on_n[2] / 2;
-    	nmos_effective_resistance_multiplier = 1.73;
-    	n_to_p_eff_curr_drv_ratio[2] = 2;
-    	gmp_to_gmn_multiplier[2] = 1.11;
-    	Rnchannelon[2] = nmos_effective_resistance_multiplier * vdd[2] / I_on_n[2];//ohm-micron
-    	Rpchannelon[2] = n_to_p_eff_curr_drv_ratio[2] * Rnchannelon[2];//ohm-micron
-    	long_channel_leakage_reduction[2] = 1/2.38;
+      // 22 nm LOP
+      vdd[2] = 0.6;
+      Lphy[2] = 0.011;
+      Lelec[2] = 0.00604;  // Lelec is the electrical gate-length.
+      t_ox[2] = 0.8e-3;    // micron
+      v_th[2] = 0.2315;    // V
+      c_ox[2] = 2.87e-14;  // F/micron2
+      mobility_eff[2] = 698.37 * (1e-2 * 1e6 * 1e-2 * 1e6);  // micron2 / Vs
+      Vdsat[2] = 1.81e-2;                                    // V/micron
+      c_g_ideal[2] = 3.16e-16;                               // F/micron
+      c_fringe[2] = 0.08e-15;
+      c_junc[2] =
+          0;  // F/micron2 This is Cj0 not Cjunc in MASTAR results->Dynamic Tab
+      I_on_n[2] = 916.1e-6;  // A/micron
+      I_on_p[2] = I_on_n[2] / 2;
+      nmos_effective_resistance_multiplier = 1.73;
+      n_to_p_eff_curr_drv_ratio[2] = 2;
+      gmp_to_gmn_multiplier[2] = 1.11;
+      Rnchannelon[2] = nmos_effective_resistance_multiplier * vdd[2] /
+                       I_on_n[2];  // ohm-micron
+      Rpchannelon[2] =
+          n_to_p_eff_curr_drv_ratio[2] * Rnchannelon[2];  // ohm-micron
+      long_channel_leakage_reduction[2] = 1 / 2.38;
 
-    	I_off_n[2][0] = 1.31e-8;
-    	I_off_n[2][10] = 2.60e-8;
-    	I_off_n[2][20] = 5.14e-8;
-    	I_off_n[2][30] = 1.02e-7;
-    	I_off_n[2][40] = 2.02e-7;
-    	I_off_n[2][50] = 3.99e-7;
-    	I_off_n[2][60] = 7.91e-7;
-    	I_off_n[2][70] = 1.09e-6;
-    	I_off_n[2][80] = 2.09e-6;
-    	I_off_n[2][90] = 4.04e-6;
-    	I_off_n[2][100]= 4.48e-6;
+      I_off_n[2][0] = 1.31e-8;
+      I_off_n[2][10] = 2.60e-8;
+      I_off_n[2][20] = 5.14e-8;
+      I_off_n[2][30] = 1.02e-7;
+      I_off_n[2][40] = 2.02e-7;
+      I_off_n[2][50] = 3.99e-7;
+      I_off_n[2][60] = 7.91e-7;
+      I_off_n[2][70] = 1.09e-6;
+      I_off_n[2][80] = 2.09e-6;
+      I_off_n[2][90] = 4.04e-6;
+      I_off_n[2][100] = 4.48e-6;
 
-    	I_g_on_n[2][0]  = 2.74e-9;//A/micron
-    	I_g_on_n[2][10] = 2.74e-9;
-    	I_g_on_n[2][20] = 2.74e-9;
-    	I_g_on_n[2][30] = 2.74e-9;
-    	I_g_on_n[2][40] = 2.74e-9;
-    	I_g_on_n[2][50] = 2.74e-9;
-    	I_g_on_n[2][60] = 2.74e-9;
-    	I_g_on_n[2][70] = 2.74e-9;
-    	I_g_on_n[2][80] = 2.74e-9;
-    	I_g_on_n[2][90] = 2.74e-9;
-    	I_g_on_n[2][100] = 2.74e-9;
+      I_g_on_n[2][0] = 2.74e-9;  // A/micron
+      I_g_on_n[2][10] = 2.74e-9;
+      I_g_on_n[2][20] = 2.74e-9;
+      I_g_on_n[2][30] = 2.74e-9;
+      I_g_on_n[2][40] = 2.74e-9;
+      I_g_on_n[2][50] = 2.74e-9;
+      I_g_on_n[2][60] = 2.74e-9;
+      I_g_on_n[2][70] = 2.74e-9;
+      I_g_on_n[2][80] = 2.74e-9;
+      I_g_on_n[2][90] = 2.74e-9;
+      I_g_on_n[2][100] = 2.74e-9;
 
+      if (ram_cell_tech_type == 3) {
+      } else if (ram_cell_tech_type == 4) {
+        // 22 nm commodity DRAM cell access transistor technology parameters.
+        // parameters
+        curr_vdd_dram_cell = 0.9;  // 0.45;//This value has reduced greatly in
+                                   // 2007 ITRS for all technology nodes. In
+        // 2005 ITRS, the value was about twice the value in 2007 ITRS
+        Lphy[3] = 0.022;                       // micron
+        Lelec[3] = 0.0181;                     // micron.
+        curr_v_th_dram_access_transistor = 1;  // V
+        width_dram_access_transistor = 0.022;  // micron
+        curr_I_on_dram_cell =
+            20e-6;  // This is a typical value that I have always
+        // kept constant. In reality this could perhaps be lower
+        curr_I_off_dram_cell_worst_case_length_temp = 1e-15;  // A
+        curr_Wmemcella_dram = width_dram_access_transistor;
+        curr_Wmemcellpmos_dram = 0;
+        curr_Wmemcellnmos_dram = 0;
+        curr_area_cell_dram = 6 * 0.022 * 0.022;  // micron2.
+        curr_asp_ratio_cell_dram = 0.667;
+        curr_c_dram_cell = 30e-15;  // This is a typical value that I have
+                                    // alwaus
+        // kept constant.
 
+        // 22 nm commodity DRAM wordline transistor parameters obtained using
+        // MASTAR.
+        curr_vpp = 2.3;                                        // vpp. V
+        t_ox[3] = 3.5e-3;                                      // micron
+        v_th[3] = 1.0;                                         // V
+        c_ox[3] = 9.06e-15;                                    // F/micron2
+        mobility_eff[3] = 367.29 * (1e-2 * 1e6 * 1e-2 * 1e6);  // micron2 / Vs
+        Vdsat[3] = 0.0972;                                     // V/micron
+        c_g_ideal[3] = 1.99e-16;                               // F/micron
+        c_fringe[3] = 0.053e-15;                               // F/micron
+        c_junc[3] = 1e-15;                                     // F/micron2
+        I_on_n[3] = 910.5e-6;                                  // A/micron
+        I_on_p[3] = I_on_n[3] / 2;  // This value for I_on_p is not really used.
+        nmos_effective_resistance_multiplier =
+            1.69;  // Using the value from 32nm.
+        //
+        n_to_p_eff_curr_drv_ratio[3] = 1.95;  // Using the value from 32nm
+        gmp_to_gmn_multiplier[3] = 0.90;
+        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp /
+                         I_on_n[3];  // ohm-micron
+        Rpchannelon[3] =
+            n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];  // ohm-micron
+        long_channel_leakage_reduction[3] = 1;
+        I_off_n[3][0] = 1.1e-13;  // A/micron
+        I_off_n[3][10] = 2.11e-13;
+        I_off_n[3][20] = 3.88e-13;
+        I_off_n[3][30] = 6.9e-13;
+        I_off_n[3][40] = 1.19e-12;
+        I_off_n[3][50] = 1.98e-12;
+        I_off_n[3][60] = 3.22e-12;
+        I_off_n[3][70] = 5.09e-12;
+        I_off_n[3][80] = 7.85e-12;
+        I_off_n[3][90] = 1.18e-11;
+        I_off_n[3][100] = 1.72e-11;
 
-        if (ram_cell_tech_type == 3)
-              {}
-        else if (ram_cell_tech_type == 4)
-        {
-    	//22 nm commodity DRAM cell access transistor technology parameters.
-    		//parameters
-        	curr_vdd_dram_cell = 0.9;//0.45;//This value has reduced greatly in 2007 ITRS for all technology nodes. In
-    		//2005 ITRS, the value was about twice the value in 2007 ITRS
-    		Lphy[3] = 0.022;//micron
-    		Lelec[3] = 0.0181;//micron.
-    		curr_v_th_dram_access_transistor = 1;//V
-    		width_dram_access_transistor = 0.022;//micron
-    		curr_I_on_dram_cell = 20e-6; //This is a typical value that I have always
-    		//kept constant. In reality this could perhaps be lower
-    		curr_I_off_dram_cell_worst_case_length_temp = 1e-15;//A
-    		curr_Wmemcella_dram = width_dram_access_transistor;
-    		curr_Wmemcellpmos_dram = 0;
-    		curr_Wmemcellnmos_dram = 0;
-    		curr_area_cell_dram = 6*0.022*0.022;//micron2.
-    		curr_asp_ratio_cell_dram = 0.667;
-    		curr_c_dram_cell = 30e-15;//This is a typical value that I have alwaus
-    		//kept constant.
+      } else {
+        // some error handler
+      }
 
-    	//22 nm commodity DRAM wordline transistor parameters obtained using MASTAR.
-    		curr_vpp = 2.3;//vpp. V
-    		t_ox[3] = 3.5e-3;//micron
-    		v_th[3] = 1.0;//V
-    		c_ox[3] = 9.06e-15;//F/micron2
-    		mobility_eff[3] =  367.29 * (1e-2 * 1e6 * 1e-2 * 1e6);//micron2 / Vs
-    		Vdsat[3] = 0.0972; //V/micron
-    		c_g_ideal[3] = 1.99e-16;//F/micron
-    		c_fringe[3] = 0.053e-15;//F/micron
-    		c_junc[3] = 1e-15;//F/micron2
-    		I_on_n[3] = 910.5e-6;//A/micron
-    		I_on_p[3] = I_on_n[3] / 2;//This value for I_on_p is not really used.
-    		nmos_effective_resistance_multiplier = 1.69;//Using the value from 32nm.
-    		//
-    		n_to_p_eff_curr_drv_ratio[3] = 1.95;//Using the value from 32nm
-    		gmp_to_gmn_multiplier[3] = 0.90;
-    		Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp  / I_on_n[3];//ohm-micron
-    		Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];//ohm-micron
-    		long_channel_leakage_reduction[3] = 1;
-    		I_off_n[3][0] = 1.1e-13; //A/micron
-    		I_off_n[3][10] = 2.11e-13;
-    		I_off_n[3][20] = 3.88e-13;
-    		I_off_n[3][30] = 6.9e-13;
-    		I_off_n[3][40] = 1.19e-12;
-    		I_off_n[3][50] = 1.98e-12;
-    		I_off_n[3][60] = 3.22e-12;
-    		I_off_n[3][70] = 5.09e-12;
-    		I_off_n[3][80] = 7.85e-12;
-    		I_off_n[3][90] = 1.18e-11;
-    		I_off_n[3][100] = 1.72e-11;
+      // SRAM cell properties
+      curr_Wmemcella_sram = 1.31 * g_ip->F_sz_um;
+      curr_Wmemcellpmos_sram = 1.23 * g_ip->F_sz_um;
+      curr_Wmemcellnmos_sram = 2.08 * g_ip->F_sz_um;
+      curr_area_cell_sram = 146 * g_ip->F_sz_um * g_ip->F_sz_um;
+      curr_asp_ratio_cell_sram = 1.46;
+      // CAM cell properties //TODO: data need to be revisited
+      curr_Wmemcella_cam = 1.31 * g_ip->F_sz_um;
+      curr_Wmemcellpmos_cam = 1.23 * g_ip->F_sz_um;
+      curr_Wmemcellnmos_cam = 2.08 * g_ip->F_sz_um;
+      curr_area_cell_cam = 292 * g_ip->F_sz_um * g_ip->F_sz_um;
+      curr_asp_ratio_cell_cam = 2.92;
+      // Empirical undifferetiated core/FU coefficient
+      curr_logic_scaling_co_eff = 0.7 * 0.7 * 0.7 * 0.7;
+      curr_core_tx_density = 1.25 / 0.7 / 0.7;
+      curr_sckt_co_eff = 1.1296;
+      curr_chip_layout_overhead =
+          1.2;  // die measurement results based on Niagara 1 and 2
+      curr_macro_layout_overhead =
+          1.1;  // EDA placement and routing tool rule of thumb
+    }
 
-    	}
-        else
-        {
-      	  //some error handler
-        }
+    if (tech == 16) {
+      // For 2019, MPU/ASIC stagger-contacted M1 half-pitch is 16 nm (so this is
+      // 16 nm
+      // technology i.e. FEATURESIZE = 0.016). Using the DG process numbers for
+      // HP.
+      // 16 nm HP
+      vdd[0] = 0.7;
+      Lphy[0] = 0.006;     // Lphy is the physical gate-length.
+      Lelec[0] = 0.00315;  // Lelec is the electrical gate-length.
+      t_ox[0] = 0.5e-3;    // micron
+      v_th[0] = 0.1489;    // V
+      c_ox[0] = 3.83e-14;  // F/micron2 Cox_elec in MASTAR
+      mobility_eff[0] = 476.15 * (1e-2 * 1e6 * 1e-2 * 1e6);  // micron2 / Vs
+      Vdsat[0] = 1.42e-2;       // V/micron calculated in spreadsheet
+      c_g_ideal[0] = 2.30e-16;  // F/micron
+      c_fringe[0] = 0.06e-15;   // F/micron MASTAR inputdynamic/3
+      c_junc[0] = 0;            // F/micron2 MASTAR result dynamic
+      I_on_n[0] = 2768.4e-6;    // A/micron
+      I_on_p[0] = I_on_n[0] /
+                  2;  // A/micron //This value for I_on_p is not really used.
+      nmos_effective_resistance_multiplier =
+          1.48;  // nmos_effective_resistance_multiplier  is the ratio of Ieff
+                 // to Idsat where Ieff is the effective NMOS current and Idsat
+                 // is the saturation current.
+      n_to_p_eff_curr_drv_ratio[0] =
+          2;  // Wpmos/Wnmos = 2 in 2007 MASTAR. Look in
+      //"Dynamic" tab of Device workspace.
+      gmp_to_gmn_multiplier[0] = 1.38;  // Just using the 32nm SOI value.
+      Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] /
+                       I_on_n[0];  // ohm-micron
+      Rpchannelon[0] =
+          n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];  // ohm-micron
+      long_channel_leakage_reduction[0] = 1 / 2.655;
+      I_off_n[0][0] = 1.52e-7 / 1.5 * 1.2 * 1.07;
+      I_off_n[0][10] = 1.55e-7 / 1.5 * 1.2 * 1.07;
+      I_off_n[0][20] = 1.59e-7 / 1.5 * 1.2 * 1.07;
+      I_off_n[0][30] = 1.68e-7 / 1.5 * 1.2 * 1.07;
+      I_off_n[0][40] = 1.90e-7 / 1.5 * 1.2 * 1.07;
+      I_off_n[0][50] = 2.69e-7 / 1.5 * 1.2 * 1.07;
+      I_off_n[0][60] = 5.32e-7 / 1.5 * 1.2 * 1.07;
+      I_off_n[0][70] = 1.02e-6 / 1.5 * 1.2 * 1.07;
+      I_off_n[0][80] = 1.62e-6 / 1.5 * 1.2 * 1.07;
+      I_off_n[0][90] = 2.73e-6 / 1.5 * 1.2 * 1.07;
+      I_off_n[0][100] = 6.1e-6 / 1.5 * 1.2 * 1.07;
+      // for 16nm DG HP
+      I_g_on_n[0][0] = 1.07e-9;  // A/micron
+      I_g_on_n[0][10] = 1.07e-9;
+      I_g_on_n[0][20] = 1.07e-9;
+      I_g_on_n[0][30] = 1.07e-9;
+      I_g_on_n[0][40] = 1.07e-9;
+      I_g_on_n[0][50] = 1.07e-9;
+      I_g_on_n[0][60] = 1.07e-9;
+      I_g_on_n[0][70] = 1.07e-9;
+      I_g_on_n[0][80] = 1.07e-9;
+      I_g_on_n[0][90] = 1.07e-9;
+      I_g_on_n[0][100] = 1.07e-9;
 
-        //SRAM cell properties
-        curr_Wmemcella_sram    = 1.31 * g_ip->F_sz_um;
-        curr_Wmemcellpmos_sram = 1.23 * g_ip->F_sz_um;
-        curr_Wmemcellnmos_sram = 2.08 * g_ip->F_sz_um;
-        curr_area_cell_sram    = 146 * g_ip->F_sz_um * g_ip->F_sz_um;
-        curr_asp_ratio_cell_sram = 1.46;
-        //CAM cell properties //TODO: data need to be revisited
-        curr_Wmemcella_cam = 1.31 * g_ip->F_sz_um;
-        curr_Wmemcellpmos_cam = 1.23 * g_ip->F_sz_um;
-        curr_Wmemcellnmos_cam = 2.08 * g_ip->F_sz_um;
-        curr_area_cell_cam = 292 * g_ip->F_sz_um * g_ip->F_sz_um;
-        curr_asp_ratio_cell_cam = 2.92;
-        //Empirical undifferetiated core/FU coefficient
-        curr_logic_scaling_co_eff = 0.7*0.7*0.7*0.7;
-        curr_core_tx_density      = 1.25/0.7/0.7;
-        curr_sckt_co_eff           = 1.1296;
-        curr_chip_layout_overhead  = 1.2;//die measurement results based on Niagara 1 and 2
-        curr_macro_layout_overhead = 1.1;//EDA placement and routing tool rule of thumb
-    	}
+      //    	//16 nm LSTP DG
+      //    	vdd[1] = 0.8;
+      //    	Lphy[1] = 0.014;
+      //    	Lelec[1] = 0.008;//Lelec is the electrical gate-length.
+      //    	t_ox[1] = 1.1e-3;//micron
+      //    	v_th[1] = 0.40126;//V
+      //    	c_ox[1] = 2.30e-14;//F/micron2
+      //    	mobility_eff[1] =  738.09 * (1e-2 * 1e6 * 1e-2 * 1e6); //micron2
+      //    / Vs
+      //    	Vdsat[1] = 6.64e-2; //V/micron
+      //    	c_g_ideal[1] = 3.22e-16;//F/micron
+      //    	c_fringe[1] = 0.008e-15;
+      //    	c_junc[1] = 0;//F/micron2
+      //    	I_on_n[1] = 727.6e-6;//A/micron
+      //    	I_on_p[1] = I_on_n[1] / 2;
+      //    	nmos_effective_resistance_multiplier = 1.99;
+      //    	n_to_p_eff_curr_drv_ratio[1] = 2;
+      //    	gmp_to_gmn_multiplier[1] = 0.99;
+      //    	Rnchannelon[1] = nmos_effective_resistance_multiplier * vdd[1] /
+      //    I_on_n[1];//ohm-micron
+      //    	Rpchannelon[1] = n_to_p_eff_curr_drv_ratio[1] *
+      //    Rnchannelon[1];//ohm-micron
+      //    	I_off_n[1][0] = 2.43e-11;
+      //    	I_off_n[1][10] = 4.85e-11;
+      //    	I_off_n[1][20] = 9.68e-11;
+      //    	I_off_n[1][30] = 1.94e-10;
+      //    	I_off_n[1][40] = 3.87e-10;
+      //    	I_off_n[1][50] = 7.73e-10;
+      //    	I_off_n[1][60] = 3.55e-10;
+      //    	I_off_n[1][70] = 3.09e-9;
+      //    	I_off_n[1][80] = 6.19e-9;
+      //    	I_off_n[1][90] = 1.24e-8;
+      //    	I_off_n[1][100]= 2.48e-8;
+      //
+      //    	//    for 22nm LSTP HP
+      //    	I_g_on_n[1][0]  = 4.51e-10;//A/micron
+      //    	I_g_on_n[1][10] = 4.51e-10;
+      //    	I_g_on_n[1][20] = 4.51e-10;
+      //    	I_g_on_n[1][30] = 4.51e-10;
+      //    	I_g_on_n[1][40] = 4.51e-10;
+      //    	I_g_on_n[1][50] = 4.51e-10;
+      //    	I_g_on_n[1][60] = 4.51e-10;
+      //    	I_g_on_n[1][70] = 4.51e-10;
+      //    	I_g_on_n[1][80] = 4.51e-10;
+      //    	I_g_on_n[1][90] = 4.51e-10;
+      //    	I_g_on_n[1][100] = 4.51e-10;
 
-    if(tech == 16){
-    	//For 2019, MPU/ASIC stagger-contacted M1 half-pitch is 16 nm (so this is 16 nm
-    	//technology i.e. FEATURESIZE = 0.016). Using the DG process numbers for HP.
-    	//16 nm HP
-    	vdd[0] = 0.7;
-    	Lphy[0] = 0.006;//Lphy is the physical gate-length.
-    	Lelec[0] = 0.00315;//Lelec is the electrical gate-length.
-    	t_ox[0] = 0.5e-3;//micron
-    	v_th[0] = 0.1489;//V
-    	c_ox[0] = 3.83e-14;//F/micron2 Cox_elec in MASTAR
-    	mobility_eff[0] = 476.15 * (1e-2 * 1e6 * 1e-2 * 1e6); //micron2 / Vs
-    	Vdsat[0] = 1.42e-2; //V/micron calculated in spreadsheet
-    	c_g_ideal[0] = 2.30e-16;//F/micron
-    	c_fringe[0] = 0.06e-15;//F/micron MASTAR inputdynamic/3
-    	c_junc[0] = 0;//F/micron2 MASTAR result dynamic
-    	I_on_n[0] =  2768.4e-6;//A/micron
-    	I_on_p[0] = I_on_n[0] / 2;//A/micron //This value for I_on_p is not really used.
-        nmos_effective_resistance_multiplier = 1.48;//nmos_effective_resistance_multiplier  is the ratio of Ieff to Idsat where Ieff is the effective NMOS current and Idsat is the saturation current.
-        n_to_p_eff_curr_drv_ratio[0] = 2; //Wpmos/Wnmos = 2 in 2007 MASTAR. Look in
-    	//"Dynamic" tab of Device workspace.
-        gmp_to_gmn_multiplier[0] = 1.38; //Just using the 32nm SOI value.
-        Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] / I_on_n[0];//ohm-micron
-        Rpchannelon[0] = n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];//ohm-micron
-        long_channel_leakage_reduction[0] = 1/2.655;
-        I_off_n[0][0] = 1.52e-7/1.5*1.2*1.07;
-        I_off_n[0][10] = 1.55e-7/1.5*1.2*1.07;
-        I_off_n[0][20] = 1.59e-7/1.5*1.2*1.07;
-        I_off_n[0][30] = 1.68e-7/1.5*1.2*1.07;
-        I_off_n[0][40] = 1.90e-7/1.5*1.2*1.07;
-        I_off_n[0][50] = 2.69e-7/1.5*1.2*1.07;
-        I_off_n[0][60] = 5.32e-7/1.5*1.2*1.07;
-        I_off_n[0][70] = 1.02e-6/1.5*1.2*1.07;
-        I_off_n[0][80] = 1.62e-6/1.5*1.2*1.07;
-        I_off_n[0][90] = 2.73e-6/1.5*1.2*1.07;
-        I_off_n[0][100] = 6.1e-6/1.5*1.2*1.07;
-        //for 16nm DG HP
-        I_g_on_n[0][0]  = 1.07e-9;//A/micron
-        I_g_on_n[0][10] = 1.07e-9;
-        I_g_on_n[0][20] = 1.07e-9;
-        I_g_on_n[0][30] = 1.07e-9;
-        I_g_on_n[0][40] = 1.07e-9;
-        I_g_on_n[0][50] = 1.07e-9;
-        I_g_on_n[0][60] = 1.07e-9;
-        I_g_on_n[0][70] = 1.07e-9;
-        I_g_on_n[0][80] = 1.07e-9;
-        I_g_on_n[0][90] = 1.07e-9;
-        I_g_on_n[0][100] = 1.07e-9;
+      if (ram_cell_tech_type == 3) {
+      } else if (ram_cell_tech_type == 4) {
+        // 22 nm commodity DRAM cell access transistor technology parameters.
+        // parameters
+        curr_vdd_dram_cell = 0.9;  // 0.45;//This value has reduced greatly in
+                                   // 2007 ITRS for all technology nodes. In
+        // 2005 ITRS, the value was about twice the value in 2007 ITRS
+        Lphy[3] = 0.022;                       // micron
+        Lelec[3] = 0.0181;                     // micron.
+        curr_v_th_dram_access_transistor = 1;  // V
+        width_dram_access_transistor = 0.022;  // micron
+        curr_I_on_dram_cell =
+            20e-6;  // This is a typical value that I have always
+        // kept constant. In reality this could perhaps be lower
+        curr_I_off_dram_cell_worst_case_length_temp = 1e-15;  // A
+        curr_Wmemcella_dram = width_dram_access_transistor;
+        curr_Wmemcellpmos_dram = 0;
+        curr_Wmemcellnmos_dram = 0;
+        curr_area_cell_dram = 6 * 0.022 * 0.022;  // micron2.
+        curr_asp_ratio_cell_dram = 0.667;
+        curr_c_dram_cell = 30e-15;  // This is a typical value that I have
+                                    // alwaus
+        // kept constant.
 
-//    	//16 nm LSTP DG
-//    	vdd[1] = 0.8;
-//    	Lphy[1] = 0.014;
-//    	Lelec[1] = 0.008;//Lelec is the electrical gate-length.
-//    	t_ox[1] = 1.1e-3;//micron
-//    	v_th[1] = 0.40126;//V
-//    	c_ox[1] = 2.30e-14;//F/micron2
-//    	mobility_eff[1] =  738.09 * (1e-2 * 1e6 * 1e-2 * 1e6); //micron2 / Vs
-//    	Vdsat[1] = 6.64e-2; //V/micron
-//    	c_g_ideal[1] = 3.22e-16;//F/micron
-//    	c_fringe[1] = 0.008e-15;
-//    	c_junc[1] = 0;//F/micron2
-//    	I_on_n[1] = 727.6e-6;//A/micron
-//    	I_on_p[1] = I_on_n[1] / 2;
-//    	nmos_effective_resistance_multiplier = 1.99;
-//    	n_to_p_eff_curr_drv_ratio[1] = 2;
-//    	gmp_to_gmn_multiplier[1] = 0.99;
-//    	Rnchannelon[1] = nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];//ohm-micron
-//    	Rpchannelon[1] = n_to_p_eff_curr_drv_ratio[1] * Rnchannelon[1];//ohm-micron
-//    	I_off_n[1][0] = 2.43e-11;
-//    	I_off_n[1][10] = 4.85e-11;
-//    	I_off_n[1][20] = 9.68e-11;
-//    	I_off_n[1][30] = 1.94e-10;
-//    	I_off_n[1][40] = 3.87e-10;
-//    	I_off_n[1][50] = 7.73e-10;
-//    	I_off_n[1][60] = 3.55e-10;
-//    	I_off_n[1][70] = 3.09e-9;
-//    	I_off_n[1][80] = 6.19e-9;
-//    	I_off_n[1][90] = 1.24e-8;
-//    	I_off_n[1][100]= 2.48e-8;
-//
-//    	//    for 22nm LSTP HP
-//    	I_g_on_n[1][0]  = 4.51e-10;//A/micron
-//    	I_g_on_n[1][10] = 4.51e-10;
-//    	I_g_on_n[1][20] = 4.51e-10;
-//    	I_g_on_n[1][30] = 4.51e-10;
-//    	I_g_on_n[1][40] = 4.51e-10;
-//    	I_g_on_n[1][50] = 4.51e-10;
-//    	I_g_on_n[1][60] = 4.51e-10;
-//    	I_g_on_n[1][70] = 4.51e-10;
-//    	I_g_on_n[1][80] = 4.51e-10;
-//    	I_g_on_n[1][90] = 4.51e-10;
-//    	I_g_on_n[1][100] = 4.51e-10;
+        // 22 nm commodity DRAM wordline transistor parameters obtained using
+        // MASTAR.
+        curr_vpp = 2.3;                                        // vpp. V
+        t_ox[3] = 3.5e-3;                                      // micron
+        v_th[3] = 1.0;                                         // V
+        c_ox[3] = 9.06e-15;                                    // F/micron2
+        mobility_eff[3] = 367.29 * (1e-2 * 1e6 * 1e-2 * 1e6);  // micron2 / Vs
+        Vdsat[3] = 0.0972;                                     // V/micron
+        c_g_ideal[3] = 1.99e-16;                               // F/micron
+        c_fringe[3] = 0.053e-15;                               // F/micron
+        c_junc[3] = 1e-15;                                     // F/micron2
+        I_on_n[3] = 910.5e-6;                                  // A/micron
+        I_on_p[3] = I_on_n[3] / 2;  // This value for I_on_p is not really used.
+        nmos_effective_resistance_multiplier =
+            1.69;  // Using the value from 32nm.
+        //
+        n_to_p_eff_curr_drv_ratio[3] = 1.95;  // Using the value from 32nm
+        gmp_to_gmn_multiplier[3] = 0.90;
+        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp /
+                         I_on_n[3];  // ohm-micron
+        Rpchannelon[3] =
+            n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];  // ohm-micron
+        long_channel_leakage_reduction[3] = 1;
+        I_off_n[3][0] = 1.1e-13;  // A/micron
+        I_off_n[3][10] = 2.11e-13;
+        I_off_n[3][20] = 3.88e-13;
+        I_off_n[3][30] = 6.9e-13;
+        I_off_n[3][40] = 1.19e-12;
+        I_off_n[3][50] = 1.98e-12;
+        I_off_n[3][60] = 3.22e-12;
+        I_off_n[3][70] = 5.09e-12;
+        I_off_n[3][80] = 7.85e-12;
+        I_off_n[3][90] = 1.18e-11;
+        I_off_n[3][100] = 1.72e-11;
 
+      } else {
+        // some error handler
+      }
 
-        if (ram_cell_tech_type == 3)
-              {}
-        else if (ram_cell_tech_type == 4)
-        {
-    	//22 nm commodity DRAM cell access transistor technology parameters.
-    		//parameters
-        	curr_vdd_dram_cell = 0.9;//0.45;//This value has reduced greatly in 2007 ITRS for all technology nodes. In
-    		//2005 ITRS, the value was about twice the value in 2007 ITRS
-    		Lphy[3] = 0.022;//micron
-    		Lelec[3] = 0.0181;//micron.
-    		curr_v_th_dram_access_transistor = 1;//V
-    		width_dram_access_transistor = 0.022;//micron
-    		curr_I_on_dram_cell = 20e-6; //This is a typical value that I have always
-    		//kept constant. In reality this could perhaps be lower
-    		curr_I_off_dram_cell_worst_case_length_temp = 1e-15;//A
-    		curr_Wmemcella_dram = width_dram_access_transistor;
-    		curr_Wmemcellpmos_dram = 0;
-    		curr_Wmemcellnmos_dram = 0;
-    		curr_area_cell_dram = 6*0.022*0.022;//micron2.
-    		curr_asp_ratio_cell_dram = 0.667;
-    		curr_c_dram_cell = 30e-15;//This is a typical value that I have alwaus
-    		//kept constant.
+      // SRAM cell properties
+      curr_Wmemcella_sram = 1.31 * g_ip->F_sz_um;
+      curr_Wmemcellpmos_sram = 1.23 * g_ip->F_sz_um;
+      curr_Wmemcellnmos_sram = 2.08 * g_ip->F_sz_um;
+      curr_area_cell_sram = 146 * g_ip->F_sz_um * g_ip->F_sz_um;
+      curr_asp_ratio_cell_sram = 1.46;
+      // CAM cell properties //TODO: data need to be revisited
+      curr_Wmemcella_cam = 1.31 * g_ip->F_sz_um;
+      curr_Wmemcellpmos_cam = 1.23 * g_ip->F_sz_um;
+      curr_Wmemcellnmos_cam = 2.08 * g_ip->F_sz_um;
+      curr_area_cell_cam = 292 * g_ip->F_sz_um * g_ip->F_sz_um;
+      curr_asp_ratio_cell_cam = 2.92;
+      // Empirical undifferetiated core/FU coefficient
+      curr_logic_scaling_co_eff = 0.7 * 0.7 * 0.7 * 0.7 * 0.7;
+      curr_core_tx_density = 1.25 / 0.7 / 0.7 / 0.7;
+      curr_sckt_co_eff = 1.1296;
+      curr_chip_layout_overhead =
+          1.2;  // die measurement results based on Niagara 1 and 2
+      curr_macro_layout_overhead =
+          1.1;  // EDA placement and routing tool rule of thumb
+    }
 
-    	//22 nm commodity DRAM wordline transistor parameters obtained using MASTAR.
-    		curr_vpp = 2.3;//vpp. V
-    		t_ox[3] = 3.5e-3;//micron
-    		v_th[3] = 1.0;//V
-    		c_ox[3] = 9.06e-15;//F/micron2
-    		mobility_eff[3] =  367.29 * (1e-2 * 1e6 * 1e-2 * 1e6);//micron2 / Vs
-    		Vdsat[3] = 0.0972; //V/micron
-    		c_g_ideal[3] = 1.99e-16;//F/micron
-    		c_fringe[3] = 0.053e-15;//F/micron
-    		c_junc[3] = 1e-15;//F/micron2
-    		I_on_n[3] = 910.5e-6;//A/micron
-    		I_on_p[3] = I_on_n[3] / 2;//This value for I_on_p is not really used.
-    		nmos_effective_resistance_multiplier = 1.69;//Using the value from 32nm.
-    		//
-    		n_to_p_eff_curr_drv_ratio[3] = 1.95;//Using the value from 32nm
-    		gmp_to_gmn_multiplier[3] = 0.90;
-    		Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp  / I_on_n[3];//ohm-micron
-    		Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];//ohm-micron
-    		long_channel_leakage_reduction[3] = 1;
-    		I_off_n[3][0] = 1.1e-13; //A/micron
-    		I_off_n[3][10] = 2.11e-13;
-    		I_off_n[3][20] = 3.88e-13;
-    		I_off_n[3][30] = 6.9e-13;
-    		I_off_n[3][40] = 1.19e-12;
-    		I_off_n[3][50] = 1.98e-12;
-    		I_off_n[3][60] = 3.22e-12;
-    		I_off_n[3][70] = 5.09e-12;
-    		I_off_n[3][80] = 7.85e-12;
-    		I_off_n[3][90] = 1.18e-11;
-    		I_off_n[3][100] = 1.72e-11;
-
-    	}
-        else
-        {
-      	  //some error handler
-        }
-
-        //SRAM cell properties
-        curr_Wmemcella_sram    = 1.31 * g_ip->F_sz_um;
-        curr_Wmemcellpmos_sram = 1.23 * g_ip->F_sz_um;
-        curr_Wmemcellnmos_sram = 2.08 * g_ip->F_sz_um;
-        curr_area_cell_sram    = 146 * g_ip->F_sz_um * g_ip->F_sz_um;
-        curr_asp_ratio_cell_sram = 1.46;
-        //CAM cell properties //TODO: data need to be revisited
-        curr_Wmemcella_cam = 1.31 * g_ip->F_sz_um;
-        curr_Wmemcellpmos_cam = 1.23 * g_ip->F_sz_um;
-        curr_Wmemcellnmos_cam = 2.08 * g_ip->F_sz_um;
-        curr_area_cell_cam = 292 * g_ip->F_sz_um * g_ip->F_sz_um;
-        curr_asp_ratio_cell_cam = 2.92;
-        //Empirical undifferetiated core/FU coefficient
-        curr_logic_scaling_co_eff = 0.7*0.7*0.7*0.7*0.7;
-        curr_core_tx_density      = 1.25/0.7/0.7/0.7;
-        curr_sckt_co_eff           = 1.1296;
-        curr_chip_layout_overhead  = 1.2;//die measurement results based on Niagara 1 and 2
-        curr_macro_layout_overhead = 1.1;//EDA placement and routing tool rule of thumb
-    	}
-
-
-    g_tp.peri_global.Vdd       += curr_alpha * vdd[peri_global_tech_type];
-    g_tp.peri_global.t_ox      += curr_alpha * t_ox[peri_global_tech_type];
-    g_tp.peri_global.Vth       += curr_alpha * v_th[peri_global_tech_type];
-    g_tp.peri_global.C_ox      += curr_alpha * c_ox[peri_global_tech_type];
+    g_tp.peri_global.Vdd += curr_alpha * vdd[peri_global_tech_type];
+    g_tp.peri_global.t_ox += curr_alpha * t_ox[peri_global_tech_type];
+    g_tp.peri_global.Vth += curr_alpha * v_th[peri_global_tech_type];
+    g_tp.peri_global.C_ox += curr_alpha * c_ox[peri_global_tech_type];
     g_tp.peri_global.C_g_ideal += curr_alpha * c_g_ideal[peri_global_tech_type];
-    g_tp.peri_global.C_fringe  += curr_alpha * c_fringe[peri_global_tech_type];
-    g_tp.peri_global.C_junc    += curr_alpha * c_junc[peri_global_tech_type];
+    g_tp.peri_global.C_fringe += curr_alpha * c_fringe[peri_global_tech_type];
+    g_tp.peri_global.C_junc += curr_alpha * c_junc[peri_global_tech_type];
     g_tp.peri_global.C_junc_sidewall = 0.25e-15;  // F/micron
-    g_tp.peri_global.l_phy     += curr_alpha * Lphy[peri_global_tech_type];
-    g_tp.peri_global.l_elec    += curr_alpha * Lelec[peri_global_tech_type];
-    g_tp.peri_global.I_on_n    += curr_alpha * I_on_n[peri_global_tech_type];
-    g_tp.peri_global.R_nch_on  += curr_alpha * Rnchannelon[peri_global_tech_type];
-    g_tp.peri_global.R_pch_on  += curr_alpha * Rpchannelon[peri_global_tech_type];
-    g_tp.peri_global.n_to_p_eff_curr_drv_ratio
-      += curr_alpha * n_to_p_eff_curr_drv_ratio[peri_global_tech_type];
-    g_tp.peri_global.long_channel_leakage_reduction
-      += curr_alpha * long_channel_leakage_reduction[peri_global_tech_type];
-    g_tp.peri_global.I_off_n   += curr_alpha * I_off_n[peri_global_tech_type][g_ip->temp - 300];
-    g_tp.peri_global.I_off_p   += curr_alpha * I_off_n[peri_global_tech_type][g_ip->temp - 300];
-    g_tp.peri_global.I_g_on_n   += curr_alpha * I_g_on_n[peri_global_tech_type][g_ip->temp - 300];
-    g_tp.peri_global.I_g_on_p   += curr_alpha * I_g_on_n[peri_global_tech_type][g_ip->temp - 300];
-    gmp_to_gmn_multiplier_periph_global += curr_alpha * gmp_to_gmn_multiplier[peri_global_tech_type];
+    g_tp.peri_global.l_phy += curr_alpha * Lphy[peri_global_tech_type];
+    g_tp.peri_global.l_elec += curr_alpha * Lelec[peri_global_tech_type];
+    g_tp.peri_global.I_on_n += curr_alpha * I_on_n[peri_global_tech_type];
+    g_tp.peri_global.R_nch_on +=
+        curr_alpha * Rnchannelon[peri_global_tech_type];
+    g_tp.peri_global.R_pch_on +=
+        curr_alpha * Rpchannelon[peri_global_tech_type];
+    g_tp.peri_global.n_to_p_eff_curr_drv_ratio +=
+        curr_alpha * n_to_p_eff_curr_drv_ratio[peri_global_tech_type];
+    g_tp.peri_global.long_channel_leakage_reduction +=
+        curr_alpha * long_channel_leakage_reduction[peri_global_tech_type];
+    g_tp.peri_global.I_off_n +=
+        curr_alpha * I_off_n[peri_global_tech_type][g_ip->temp - 300];
+    g_tp.peri_global.I_off_p +=
+        curr_alpha * I_off_n[peri_global_tech_type][g_ip->temp - 300];
+    g_tp.peri_global.I_g_on_n +=
+        curr_alpha * I_g_on_n[peri_global_tech_type][g_ip->temp - 300];
+    g_tp.peri_global.I_g_on_p +=
+        curr_alpha * I_g_on_n[peri_global_tech_type][g_ip->temp - 300];
+    gmp_to_gmn_multiplier_periph_global +=
+        curr_alpha * gmp_to_gmn_multiplier[peri_global_tech_type];
 
-    g_tp.sram_cell.Vdd       += curr_alpha * vdd[ram_cell_tech_type];
-    g_tp.sram_cell.l_phy     += curr_alpha * Lphy[ram_cell_tech_type];
-    g_tp.sram_cell.l_elec    += curr_alpha * Lelec[ram_cell_tech_type];
-    g_tp.sram_cell.t_ox      += curr_alpha * t_ox[ram_cell_tech_type];
-    g_tp.sram_cell.Vth       += curr_alpha * v_th[ram_cell_tech_type];
+    g_tp.sram_cell.Vdd += curr_alpha * vdd[ram_cell_tech_type];
+    g_tp.sram_cell.l_phy += curr_alpha * Lphy[ram_cell_tech_type];
+    g_tp.sram_cell.l_elec += curr_alpha * Lelec[ram_cell_tech_type];
+    g_tp.sram_cell.t_ox += curr_alpha * t_ox[ram_cell_tech_type];
+    g_tp.sram_cell.Vth += curr_alpha * v_th[ram_cell_tech_type];
     g_tp.sram_cell.C_g_ideal += curr_alpha * c_g_ideal[ram_cell_tech_type];
-    g_tp.sram_cell.C_fringe  += curr_alpha * c_fringe[ram_cell_tech_type];
-    g_tp.sram_cell.C_junc    += curr_alpha * c_junc[ram_cell_tech_type];
+    g_tp.sram_cell.C_fringe += curr_alpha * c_fringe[ram_cell_tech_type];
+    g_tp.sram_cell.C_junc += curr_alpha * c_junc[ram_cell_tech_type];
     g_tp.sram_cell.C_junc_sidewall = 0.25e-15;  // F/micron
-    g_tp.sram_cell.I_on_n    += curr_alpha * I_on_n[ram_cell_tech_type];
-    g_tp.sram_cell.R_nch_on  += curr_alpha * Rnchannelon[ram_cell_tech_type];
-    g_tp.sram_cell.R_pch_on  += curr_alpha * Rpchannelon[ram_cell_tech_type];
-    g_tp.sram_cell.n_to_p_eff_curr_drv_ratio += curr_alpha * n_to_p_eff_curr_drv_ratio[ram_cell_tech_type];
-    g_tp.sram_cell.long_channel_leakage_reduction += curr_alpha * long_channel_leakage_reduction[ram_cell_tech_type];
-    g_tp.sram_cell.I_off_n   += curr_alpha * I_off_n[ram_cell_tech_type][g_ip->temp - 300];
-    g_tp.sram_cell.I_off_p   += curr_alpha * I_off_n[ram_cell_tech_type][g_ip->temp - 300];
-    g_tp.sram_cell.I_g_on_n   += curr_alpha * I_g_on_n[ram_cell_tech_type][g_ip->temp - 300];
-    g_tp.sram_cell.I_g_on_p   += curr_alpha * I_g_on_n[ram_cell_tech_type][g_ip->temp - 300];
+    g_tp.sram_cell.I_on_n += curr_alpha * I_on_n[ram_cell_tech_type];
+    g_tp.sram_cell.R_nch_on += curr_alpha * Rnchannelon[ram_cell_tech_type];
+    g_tp.sram_cell.R_pch_on += curr_alpha * Rpchannelon[ram_cell_tech_type];
+    g_tp.sram_cell.n_to_p_eff_curr_drv_ratio +=
+        curr_alpha * n_to_p_eff_curr_drv_ratio[ram_cell_tech_type];
+    g_tp.sram_cell.long_channel_leakage_reduction +=
+        curr_alpha * long_channel_leakage_reduction[ram_cell_tech_type];
+    g_tp.sram_cell.I_off_n +=
+        curr_alpha * I_off_n[ram_cell_tech_type][g_ip->temp - 300];
+    g_tp.sram_cell.I_off_p +=
+        curr_alpha * I_off_n[ram_cell_tech_type][g_ip->temp - 300];
+    g_tp.sram_cell.I_g_on_n +=
+        curr_alpha * I_g_on_n[ram_cell_tech_type][g_ip->temp - 300];
+    g_tp.sram_cell.I_g_on_p +=
+        curr_alpha * I_g_on_n[ram_cell_tech_type][g_ip->temp - 300];
 
-    g_tp.dram_cell_Vdd      += curr_alpha * curr_vdd_dram_cell;
-    g_tp.dram_acc.Vth       += curr_alpha * curr_v_th_dram_access_transistor;
-    g_tp.dram_acc.l_phy     += curr_alpha * Lphy[dram_cell_tech_flavor];
-    g_tp.dram_acc.l_elec    += curr_alpha * Lelec[dram_cell_tech_flavor];
+    g_tp.dram_cell_Vdd += curr_alpha * curr_vdd_dram_cell;
+    g_tp.dram_acc.Vth += curr_alpha * curr_v_th_dram_access_transistor;
+    g_tp.dram_acc.l_phy += curr_alpha * Lphy[dram_cell_tech_flavor];
+    g_tp.dram_acc.l_elec += curr_alpha * Lelec[dram_cell_tech_flavor];
     g_tp.dram_acc.C_g_ideal += curr_alpha * c_g_ideal[dram_cell_tech_flavor];
-    g_tp.dram_acc.C_fringe  += curr_alpha * c_fringe[dram_cell_tech_flavor];
-    g_tp.dram_acc.C_junc    += curr_alpha * c_junc[dram_cell_tech_flavor];
+    g_tp.dram_acc.C_fringe += curr_alpha * c_fringe[dram_cell_tech_flavor];
+    g_tp.dram_acc.C_junc += curr_alpha * c_junc[dram_cell_tech_flavor];
     g_tp.dram_acc.C_junc_sidewall = 0.25e-15;  // F/micron
-    g_tp.dram_cell_I_on     += curr_alpha * curr_I_on_dram_cell;
-    g_tp.dram_cell_I_off_worst_case_len_temp += curr_alpha * curr_I_off_dram_cell_worst_case_length_temp;
-    g_tp.dram_acc.I_on_n    += curr_alpha * I_on_n[dram_cell_tech_flavor];
-    g_tp.dram_cell_C        += curr_alpha * curr_c_dram_cell;
-    g_tp.vpp                += curr_alpha * curr_vpp;
-    g_tp.dram_wl.l_phy      += curr_alpha * Lphy[dram_cell_tech_flavor];
-    g_tp.dram_wl.l_elec     += curr_alpha * Lelec[dram_cell_tech_flavor];
-    g_tp.dram_wl.C_g_ideal  += curr_alpha * c_g_ideal[dram_cell_tech_flavor];
-    g_tp.dram_wl.C_fringe   += curr_alpha * c_fringe[dram_cell_tech_flavor];
-    g_tp.dram_wl.C_junc     += curr_alpha * c_junc[dram_cell_tech_flavor];
+    g_tp.dram_cell_I_on += curr_alpha * curr_I_on_dram_cell;
+    g_tp.dram_cell_I_off_worst_case_len_temp +=
+        curr_alpha * curr_I_off_dram_cell_worst_case_length_temp;
+    g_tp.dram_acc.I_on_n += curr_alpha * I_on_n[dram_cell_tech_flavor];
+    g_tp.dram_cell_C += curr_alpha * curr_c_dram_cell;
+    g_tp.vpp += curr_alpha * curr_vpp;
+    g_tp.dram_wl.l_phy += curr_alpha * Lphy[dram_cell_tech_flavor];
+    g_tp.dram_wl.l_elec += curr_alpha * Lelec[dram_cell_tech_flavor];
+    g_tp.dram_wl.C_g_ideal += curr_alpha * c_g_ideal[dram_cell_tech_flavor];
+    g_tp.dram_wl.C_fringe += curr_alpha * c_fringe[dram_cell_tech_flavor];
+    g_tp.dram_wl.C_junc += curr_alpha * c_junc[dram_cell_tech_flavor];
     g_tp.dram_wl.C_junc_sidewall = 0.25e-15;  // F/micron
-    g_tp.dram_wl.I_on_n     += curr_alpha * I_on_n[dram_cell_tech_flavor];
-    g_tp.dram_wl.R_nch_on   += curr_alpha * Rnchannelon[dram_cell_tech_flavor];
-    g_tp.dram_wl.R_pch_on   += curr_alpha * Rpchannelon[dram_cell_tech_flavor];
-    g_tp.dram_wl.n_to_p_eff_curr_drv_ratio += curr_alpha * n_to_p_eff_curr_drv_ratio[dram_cell_tech_flavor];
-    g_tp.dram_wl.long_channel_leakage_reduction += curr_alpha * long_channel_leakage_reduction[dram_cell_tech_flavor];
-    g_tp.dram_wl.I_off_n    += curr_alpha * I_off_n[dram_cell_tech_flavor][g_ip->temp - 300];
-    g_tp.dram_wl.I_off_p    += curr_alpha * I_off_n[dram_cell_tech_flavor][g_ip->temp - 300];
+    g_tp.dram_wl.I_on_n += curr_alpha * I_on_n[dram_cell_tech_flavor];
+    g_tp.dram_wl.R_nch_on += curr_alpha * Rnchannelon[dram_cell_tech_flavor];
+    g_tp.dram_wl.R_pch_on += curr_alpha * Rpchannelon[dram_cell_tech_flavor];
+    g_tp.dram_wl.n_to_p_eff_curr_drv_ratio +=
+        curr_alpha * n_to_p_eff_curr_drv_ratio[dram_cell_tech_flavor];
+    g_tp.dram_wl.long_channel_leakage_reduction +=
+        curr_alpha * long_channel_leakage_reduction[dram_cell_tech_flavor];
+    g_tp.dram_wl.I_off_n +=
+        curr_alpha * I_off_n[dram_cell_tech_flavor][g_ip->temp - 300];
+    g_tp.dram_wl.I_off_p +=
+        curr_alpha * I_off_n[dram_cell_tech_flavor][g_ip->temp - 300];
 
-    g_tp.cam_cell.Vdd       += curr_alpha * vdd[ram_cell_tech_type];
-    g_tp.cam_cell.l_phy     += curr_alpha * Lphy[ram_cell_tech_type];
-    g_tp.cam_cell.l_elec    += curr_alpha * Lelec[ram_cell_tech_type];
-    g_tp.cam_cell.t_ox      += curr_alpha * t_ox[ram_cell_tech_type];
-    g_tp.cam_cell.Vth       += curr_alpha * v_th[ram_cell_tech_type];
+    g_tp.cam_cell.Vdd += curr_alpha * vdd[ram_cell_tech_type];
+    g_tp.cam_cell.l_phy += curr_alpha * Lphy[ram_cell_tech_type];
+    g_tp.cam_cell.l_elec += curr_alpha * Lelec[ram_cell_tech_type];
+    g_tp.cam_cell.t_ox += curr_alpha * t_ox[ram_cell_tech_type];
+    g_tp.cam_cell.Vth += curr_alpha * v_th[ram_cell_tech_type];
     g_tp.cam_cell.C_g_ideal += curr_alpha * c_g_ideal[ram_cell_tech_type];
-    g_tp.cam_cell.C_fringe  += curr_alpha * c_fringe[ram_cell_tech_type];
-    g_tp.cam_cell.C_junc    += curr_alpha * c_junc[ram_cell_tech_type];
+    g_tp.cam_cell.C_fringe += curr_alpha * c_fringe[ram_cell_tech_type];
+    g_tp.cam_cell.C_junc += curr_alpha * c_junc[ram_cell_tech_type];
     g_tp.cam_cell.C_junc_sidewall = 0.25e-15;  // F/micron
-    g_tp.cam_cell.I_on_n    += curr_alpha * I_on_n[ram_cell_tech_type];
-    g_tp.cam_cell.R_nch_on  += curr_alpha * Rnchannelon[ram_cell_tech_type];
-    g_tp.cam_cell.R_pch_on  += curr_alpha * Rpchannelon[ram_cell_tech_type];
-    g_tp.cam_cell.n_to_p_eff_curr_drv_ratio += curr_alpha * n_to_p_eff_curr_drv_ratio[ram_cell_tech_type];
-    g_tp.cam_cell.long_channel_leakage_reduction += curr_alpha * long_channel_leakage_reduction[ram_cell_tech_type];
-    g_tp.cam_cell.I_off_n   += curr_alpha * I_off_n[ram_cell_tech_type][g_ip->temp - 300];
-    g_tp.cam_cell.I_off_p   += curr_alpha * I_off_n[ram_cell_tech_type][g_ip->temp - 300];
-    g_tp.cam_cell.I_g_on_n   += curr_alpha * I_g_on_n[ram_cell_tech_type][g_ip->temp - 300];
-    g_tp.cam_cell.I_g_on_p   += curr_alpha * I_g_on_n[ram_cell_tech_type][g_ip->temp - 300];
+    g_tp.cam_cell.I_on_n += curr_alpha * I_on_n[ram_cell_tech_type];
+    g_tp.cam_cell.R_nch_on += curr_alpha * Rnchannelon[ram_cell_tech_type];
+    g_tp.cam_cell.R_pch_on += curr_alpha * Rpchannelon[ram_cell_tech_type];
+    g_tp.cam_cell.n_to_p_eff_curr_drv_ratio +=
+        curr_alpha * n_to_p_eff_curr_drv_ratio[ram_cell_tech_type];
+    g_tp.cam_cell.long_channel_leakage_reduction +=
+        curr_alpha * long_channel_leakage_reduction[ram_cell_tech_type];
+    g_tp.cam_cell.I_off_n +=
+        curr_alpha * I_off_n[ram_cell_tech_type][g_ip->temp - 300];
+    g_tp.cam_cell.I_off_p +=
+        curr_alpha * I_off_n[ram_cell_tech_type][g_ip->temp - 300];
+    g_tp.cam_cell.I_g_on_n +=
+        curr_alpha * I_g_on_n[ram_cell_tech_type][g_ip->temp - 300];
+    g_tp.cam_cell.I_g_on_p +=
+        curr_alpha * I_g_on_n[ram_cell_tech_type][g_ip->temp - 300];
 
-    g_tp.dram.cell_a_w    += curr_alpha * curr_Wmemcella_dram;
+    g_tp.dram.cell_a_w += curr_alpha * curr_Wmemcella_dram;
     g_tp.dram.cell_pmos_w += curr_alpha * curr_Wmemcellpmos_dram;
     g_tp.dram.cell_nmos_w += curr_alpha * curr_Wmemcellnmos_dram;
-    area_cell_dram        += curr_alpha * curr_area_cell_dram;
-    asp_ratio_cell_dram   += curr_alpha * curr_asp_ratio_cell_dram;
+    area_cell_dram += curr_alpha * curr_area_cell_dram;
+    asp_ratio_cell_dram += curr_alpha * curr_asp_ratio_cell_dram;
 
-    g_tp.sram.cell_a_w    += curr_alpha * curr_Wmemcella_sram;
+    g_tp.sram.cell_a_w += curr_alpha * curr_Wmemcella_sram;
     g_tp.sram.cell_pmos_w += curr_alpha * curr_Wmemcellpmos_sram;
     g_tp.sram.cell_nmos_w += curr_alpha * curr_Wmemcellnmos_sram;
     area_cell_sram += curr_alpha * curr_area_cell_sram;
     asp_ratio_cell_sram += curr_alpha * curr_asp_ratio_cell_sram;
 
-    g_tp.cam.cell_a_w    += curr_alpha * curr_Wmemcella_cam;//sheng
+    g_tp.cam.cell_a_w += curr_alpha * curr_Wmemcella_cam;  // sheng
     g_tp.cam.cell_pmos_w += curr_alpha * curr_Wmemcellpmos_cam;
     g_tp.cam.cell_nmos_w += curr_alpha * curr_Wmemcellnmos_cam;
     area_cell_cam += curr_alpha * curr_area_cell_cam;
     asp_ratio_cell_cam += curr_alpha * curr_asp_ratio_cell_cam;
 
-    //Sense amplifier latch Gm calculation
-    mobility_eff_periph_global += curr_alpha * mobility_eff[peri_global_tech_type];
+    // Sense amplifier latch Gm calculation
+    mobility_eff_periph_global +=
+        curr_alpha * mobility_eff[peri_global_tech_type];
     Vdsat_periph_global += curr_alpha * Vdsat[peri_global_tech_type];
 
-    //Empirical undifferetiated core/FU coefficient
-    g_tp.scaling_factor.logic_scaling_co_eff += curr_alpha * curr_logic_scaling_co_eff;
+    // Empirical undifferetiated core/FU coefficient
+    g_tp.scaling_factor.logic_scaling_co_eff +=
+        curr_alpha * curr_logic_scaling_co_eff;
     g_tp.scaling_factor.core_tx_density += curr_alpha * curr_core_tx_density;
-    g_tp.chip_layout_overhead  += curr_alpha * curr_chip_layout_overhead;
+    g_tp.chip_layout_overhead += curr_alpha * curr_chip_layout_overhead;
     g_tp.macro_layout_overhead += curr_alpha * curr_macro_layout_overhead;
-    g_tp.sckt_co_eff           += curr_alpha * curr_sckt_co_eff;
+    g_tp.sckt_co_eff += curr_alpha * curr_sckt_co_eff;
   }
 
-
-  //Currently we are not modeling the resistance/capacitance of poly anywhere.
-  //Continuous function (or date have been processed) does not need linear interpolation
-  g_tp.w_comp_inv_p1 = 12.5 * g_ip->F_sz_um;//this was 10 micron for the 0.8 micron process
-  g_tp.w_comp_inv_n1 =  7.5 * g_ip->F_sz_um;//this was  6 micron for the 0.8 micron process
-  g_tp.w_comp_inv_p2 =   25 * g_ip->F_sz_um;//this was 20 micron for the 0.8 micron process
-  g_tp.w_comp_inv_n2 =   15 * g_ip->F_sz_um;//this was 12 micron for the 0.8 micron process
-  g_tp.w_comp_inv_p3 =   50 * g_ip->F_sz_um;//this was 40 micron for the 0.8 micron process
-  g_tp.w_comp_inv_n3 =   30 * g_ip->F_sz_um;//this was 24 micron for the 0.8 micron process
-  g_tp.w_eval_inv_p  =  100 * g_ip->F_sz_um;//this was 80 micron for the 0.8 micron process
-  g_tp.w_eval_inv_n  =   50 * g_ip->F_sz_um;//this was 40 micron for the 0.8 micron process
-  g_tp.w_comp_n     = 12.5 * g_ip->F_sz_um;//this was 10 micron for the 0.8 micron process
-  g_tp.w_comp_p     = 37.5 * g_ip->F_sz_um;//this was 30 micron for the 0.8 micron process
+  // Currently we are not modeling the resistance/capacitance of poly anywhere.
+  // Continuous function (or date have been processed) does not need linear
+  // interpolation
+  g_tp.w_comp_inv_p1 =
+      12.5 * g_ip->F_sz_um;  // this was 10 micron for the 0.8 micron process
+  g_tp.w_comp_inv_n1 =
+      7.5 * g_ip->F_sz_um;  // this was  6 micron for the 0.8 micron process
+  g_tp.w_comp_inv_p2 =
+      25 * g_ip->F_sz_um;  // this was 20 micron for the 0.8 micron process
+  g_tp.w_comp_inv_n2 =
+      15 * g_ip->F_sz_um;  // this was 12 micron for the 0.8 micron process
+  g_tp.w_comp_inv_p3 =
+      50 * g_ip->F_sz_um;  // this was 40 micron for the 0.8 micron process
+  g_tp.w_comp_inv_n3 =
+      30 * g_ip->F_sz_um;  // this was 24 micron for the 0.8 micron process
+  g_tp.w_eval_inv_p =
+      100 * g_ip->F_sz_um;  // this was 80 micron for the 0.8 micron process
+  g_tp.w_eval_inv_n =
+      50 * g_ip->F_sz_um;  // this was 40 micron for the 0.8 micron process
+  g_tp.w_comp_n =
+      12.5 * g_ip->F_sz_um;  // this was 10 micron for the 0.8 micron process
+  g_tp.w_comp_p =
+      37.5 * g_ip->F_sz_um;  // this was 30 micron for the 0.8 micron process
 
   g_tp.MIN_GAP_BET_P_AND_N_DIFFS = 5 * g_ip->F_sz_um;
   g_tp.MIN_GAP_BET_SAME_TYPE_DIFFS = 1.5 * g_ip->F_sz_um;
@@ -1828,255 +1904,264 @@ void init_tech_params(double technology, bool is_tag)
 
   g_tp.min_w_nmos_ = 3 * g_ip->F_sz_um / 2;
   g_tp.max_w_nmos_ = 100 * g_ip->F_sz_um;
-  g_tp.w_iso       = 12.5*g_ip->F_sz_um;//was 10 micron for the 0.8 micron process
-  g_tp.w_sense_n   = 3.75*g_ip->F_sz_um; // sense amplifier N-trans; was 3 micron for the 0.8 micron process
-  g_tp.w_sense_p   = 7.5*g_ip->F_sz_um; // sense amplifier P-trans; was 6 micron for the 0.8 micron process
-  g_tp.w_sense_en  = 5*g_ip->F_sz_um; // Sense enable transistor of the sense amplifier; was 4 micron for the 0.8 micron process
-  g_tp.w_nmos_b_mux  = 6 * g_tp.min_w_nmos_;
+  g_tp.w_iso = 12.5 * g_ip->F_sz_um;  // was 10 micron for the 0.8 micron
+                                      // process
+  g_tp.w_sense_n = 3.75 * g_ip->F_sz_um;  // sense amplifier N-trans; was 3
+                                          // micron for the 0.8 micron process
+  g_tp.w_sense_p = 7.5 * g_ip->F_sz_um;   // sense amplifier P-trans; was 6
+                                          // micron for the 0.8 micron process
+  g_tp.w_sense_en = 5 * g_ip->F_sz_um;  // Sense enable transistor of the sense
+                                        // amplifier; was 4 micron for the 0.8
+                                        // micron process
+  g_tp.w_nmos_b_mux = 6 * g_tp.min_w_nmos_;
   g_tp.w_nmos_sa_mux = 6 * g_tp.min_w_nmos_;
 
-  if (ram_cell_tech_type == comm_dram)
-  {
+  if (ram_cell_tech_type == comm_dram) {
     g_tp.max_w_nmos_dec = 8 * g_ip->F_sz_um;
-    g_tp.h_dec          = 8;  // in the unit of memory cell height
-  }
-  else
-  {
+    g_tp.h_dec = 8;  // in the unit of memory cell height
+  } else {
     g_tp.max_w_nmos_dec = g_tp.max_w_nmos_;
-    g_tp.h_dec          = 4;  // in the unit of memory cell height
+    g_tp.h_dec = 4;  // in the unit of memory cell height
   }
 
   g_tp.peri_global.C_overlap = 0.2 * g_tp.peri_global.C_g_ideal;
-  g_tp.sram_cell.C_overlap   = 0.2 * g_tp.sram_cell.C_g_ideal;
-  g_tp.cam_cell.C_overlap    = 0.2 * g_tp.cam_cell.C_g_ideal;
+  g_tp.sram_cell.C_overlap = 0.2 * g_tp.sram_cell.C_g_ideal;
+  g_tp.cam_cell.C_overlap = 0.2 * g_tp.cam_cell.C_g_ideal;
 
   g_tp.dram_acc.C_overlap = 0.2 * g_tp.dram_acc.C_g_ideal;
   g_tp.dram_acc.R_nch_on = g_tp.dram_cell_Vdd / g_tp.dram_acc.I_on_n;
-  //g_tp.dram_acc.R_pch_on = g_tp.dram_cell_Vdd / g_tp.dram_acc.I_on_p;
+  // g_tp.dram_acc.R_pch_on = g_tp.dram_cell_Vdd / g_tp.dram_acc.I_on_p;
 
   g_tp.dram_wl.C_overlap = 0.2 * g_tp.dram_wl.C_g_ideal;
 
-  double gmn_sense_amp_latch = (mobility_eff_periph_global / 2) * g_tp.peri_global.C_ox * (g_tp.w_sense_n / g_tp.peri_global.l_elec) * Vdsat_periph_global;
-  double gmp_sense_amp_latch = gmp_to_gmn_multiplier_periph_global * gmn_sense_amp_latch;
+  double gmn_sense_amp_latch =
+      (mobility_eff_periph_global / 2) * g_tp.peri_global.C_ox *
+      (g_tp.w_sense_n / g_tp.peri_global.l_elec) * Vdsat_periph_global;
+  double gmp_sense_amp_latch =
+      gmp_to_gmn_multiplier_periph_global * gmn_sense_amp_latch;
   g_tp.gm_sense_amp_latch = gmn_sense_amp_latch + gmp_sense_amp_latch;
 
   g_tp.dram.b_w = sqrt(area_cell_dram / (asp_ratio_cell_dram));
   g_tp.dram.b_h = asp_ratio_cell_dram * g_tp.dram.b_w;
   g_tp.sram.b_w = sqrt(area_cell_sram / (asp_ratio_cell_sram));
   g_tp.sram.b_h = asp_ratio_cell_sram * g_tp.sram.b_w;
-  g_tp.cam.b_w =  sqrt(area_cell_cam / (asp_ratio_cell_cam));//Sheng
+  g_tp.cam.b_w = sqrt(area_cell_cam / (asp_ratio_cell_cam));  // Sheng
   g_tp.cam.b_h = asp_ratio_cell_cam * g_tp.cam.b_w;
 
   g_tp.dram.Vbitpre = g_tp.dram_cell_Vdd;
   g_tp.sram.Vbitpre = vdd[ram_cell_tech_type];
-  g_tp.cam.Vbitpre = vdd[ram_cell_tech_type];//Sheng
+  g_tp.cam.Vbitpre = vdd[ram_cell_tech_type];  // Sheng
   pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
   g_tp.w_pmos_bl_precharge = 6 * pmos_to_nmos_sizing_r * g_tp.min_w_nmos_;
   g_tp.w_pmos_bl_eq = pmos_to_nmos_sizing_r * g_tp.min_w_nmos_;
 
+  double wire_pitch[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
+      wire_r_per_micron[NUMBER_INTERCONNECT_PROJECTION_TYPES]
+                       [NUMBER_WIRE_TYPES],
+      wire_c_per_micron[NUMBER_INTERCONNECT_PROJECTION_TYPES]
+                       [NUMBER_WIRE_TYPES],
+      horiz_dielectric_constant[NUMBER_INTERCONNECT_PROJECTION_TYPES]
+                               [NUMBER_WIRE_TYPES],
+      vert_dielectric_constant[NUMBER_INTERCONNECT_PROJECTION_TYPES]
+                              [NUMBER_WIRE_TYPES],
+      aspect_ratio[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
+      miller_value[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
+      ild_thickness[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES];
 
-  double wire_pitch       [NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
-         wire_r_per_micron[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
-         wire_c_per_micron[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
-         horiz_dielectric_constant[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
-         vert_dielectric_constant[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
-         aspect_ratio[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
-         miller_value[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
-         ild_thickness[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES];
-
-  for (iter=0; iter<=1; ++iter)
-  {
+  for (iter = 0; iter <= 1; ++iter) {
     // linear interpolation
-    if (iter == 0)
-    {
+    if (iter == 0) {
       tech = tech_lo;
-      if (tech_lo == tech_hi)
-      {
+      if (tech_lo == tech_hi) {
         curr_alpha = 1;
+      } else {
+        curr_alpha = (technology - tech_hi) / (tech_lo - tech_hi);
       }
-      else
-      {
-        curr_alpha = (technology - tech_hi)/(tech_lo - tech_hi);
-      }
-    }
-    else
-    {
+    } else {
       tech = tech_hi;
-      if (tech_lo == tech_hi)
-      {
+      if (tech_lo == tech_hi) {
         break;
-      }
-      else
-      {
-        curr_alpha = (tech_lo - technology)/(tech_lo - tech_hi);
+      } else {
+        curr_alpha = (tech_lo - technology) / (tech_lo - tech_hi);
       }
     }
 
-    if (tech == 90)
-    {
-      //Aggressive projections
-      wire_pitch[0][0] = 2.5 * g_ip->F_sz_um;//micron
+    if (tech == 90) {
+      // Aggressive projections
+      wire_pitch[0][0] = 2.5 * g_ip->F_sz_um;  // micron
       aspect_ratio[0][0] = 2.4;
-      wire_width = wire_pitch[0][0] / 2; //micron
-      wire_thickness = aspect_ratio[0][0] * wire_width;//micron
-      wire_spacing = wire_pitch[0][0] - wire_width;//micron
-      barrier_thickness = 0.01;//micron
-      dishing_thickness = 0;//micron
+      wire_width = wire_pitch[0][0] / 2;                 // micron
+      wire_thickness = aspect_ratio[0][0] * wire_width;  // micron
+      wire_spacing = wire_pitch[0][0] - wire_width;      // micron
+      barrier_thickness = 0.01;                          // micron
+      dishing_thickness = 0;                             // micron
       alpha_scatter = 1;
-      wire_r_per_micron[0][0] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);//ohm/micron
-      ild_thickness[0][0] = 0.48;//micron
+      wire_r_per_micron[0][0] = wire_resistance(
+          CU_RESISTIVITY, wire_width, wire_thickness, barrier_thickness,
+          dishing_thickness, alpha_scatter);  // ohm/micron
+      ild_thickness[0][0] = 0.48;             // micron
       miller_value[0][0] = 1.5;
       horiz_dielectric_constant[0][0] = 2.709;
       vert_dielectric_constant[0][0] = 3.9;
-      fringe_cap = 0.115e-15; //F/micron
-      wire_c_per_micron[0][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[0][0], miller_value[0][0], horiz_dielectric_constant[0][0],
+      fringe_cap = 0.115e-15;  // F/micron
+      wire_c_per_micron[0][0] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][0],
+          miller_value[0][0], horiz_dielectric_constant[0][0],
           vert_dielectric_constant[0][0],
-          fringe_cap);//F/micron.
+          fringe_cap);  // F/micron.
 
       wire_pitch[0][1] = 4 * g_ip->F_sz_um;
       wire_width = wire_pitch[0][1] / 2;
       aspect_ratio[0][1] = 2.4;
       wire_thickness = aspect_ratio[0][1] * wire_width;
       wire_spacing = wire_pitch[0][1] - wire_width;
-      wire_r_per_micron[0][1] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[0][1] = 0.48;//micron
+      wire_r_per_micron[0][1] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][1] = 0.48;  // micron
       miller_value[0][1] = 1.5;
       horiz_dielectric_constant[0][1] = 2.709;
       vert_dielectric_constant[0][1] = 3.9;
-      wire_c_per_micron[0][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[0][1], miller_value[0][1], horiz_dielectric_constant[0][1],
-          vert_dielectric_constant[0][1],
-          fringe_cap);
+      wire_c_per_micron[0][1] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][1],
+          miller_value[0][1], horiz_dielectric_constant[0][1],
+          vert_dielectric_constant[0][1], fringe_cap);
 
       wire_pitch[0][2] = 8 * g_ip->F_sz_um;
       aspect_ratio[0][2] = 2.7;
       wire_width = wire_pitch[0][2] / 2;
       wire_thickness = aspect_ratio[0][2] * wire_width;
       wire_spacing = wire_pitch[0][2] - wire_width;
-      wire_r_per_micron[0][2] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+      wire_r_per_micron[0][2] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[0][2] = 0.96;
       miller_value[0][2] = 1.5;
       horiz_dielectric_constant[0][2] = 2.709;
       vert_dielectric_constant[0][2] = 3.9;
-      wire_c_per_micron[0][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[0][2], miller_value[0][2], horiz_dielectric_constant[0][2], vert_dielectric_constant[0][2],
-          fringe_cap);
+      wire_c_per_micron[0][2] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][2],
+          miller_value[0][2], horiz_dielectric_constant[0][2],
+          vert_dielectric_constant[0][2], fringe_cap);
 
-      //Conservative projections
+      // Conservative projections
       wire_pitch[1][0] = 2.5 * g_ip->F_sz_um;
-      aspect_ratio[1][0]  = 2.0;
+      aspect_ratio[1][0] = 2.0;
       wire_width = wire_pitch[1][0] / 2;
       wire_thickness = aspect_ratio[1][0] * wire_width;
       wire_spacing = wire_pitch[1][0] - wire_width;
       barrier_thickness = 0.008;
       dishing_thickness = 0;
       alpha_scatter = 1;
-      wire_r_per_micron[1][0] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[1][0]  = 0.48;
-      miller_value[1][0]  = 1.5;
-      horiz_dielectric_constant[1][0]  = 3.038;
-      vert_dielectric_constant[1][0]  = 3.9;
+      wire_r_per_micron[1][0] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[1][0] = 0.48;
+      miller_value[1][0] = 1.5;
+      horiz_dielectric_constant[1][0] = 3.038;
+      vert_dielectric_constant[1][0] = 3.9;
       fringe_cap = 0.115e-15;
-      wire_c_per_micron[1][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[1][0], miller_value[1][0], horiz_dielectric_constant[1][0],
-          vert_dielectric_constant[1][0],
-          fringe_cap);
+      wire_c_per_micron[1][0] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][0],
+          miller_value[1][0], horiz_dielectric_constant[1][0],
+          vert_dielectric_constant[1][0], fringe_cap);
 
       wire_pitch[1][1] = 4 * g_ip->F_sz_um;
       wire_width = wire_pitch[1][1] / 2;
       aspect_ratio[1][1] = 2.0;
       wire_thickness = aspect_ratio[1][1] * wire_width;
       wire_spacing = wire_pitch[1][1] - wire_width;
-      wire_r_per_micron[1][1] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[1][1]  = 0.48;
-      miller_value[1][1]  = 1.5;
-      horiz_dielectric_constant[1][1]  = 3.038;
-      vert_dielectric_constant[1][1]  = 3.9;
-      wire_c_per_micron[1][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[1][1], miller_value[1][1], horiz_dielectric_constant[1][1],
-          vert_dielectric_constant[1][1],
-          fringe_cap);
+      wire_r_per_micron[1][1] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[1][1] = 0.48;
+      miller_value[1][1] = 1.5;
+      horiz_dielectric_constant[1][1] = 3.038;
+      vert_dielectric_constant[1][1] = 3.9;
+      wire_c_per_micron[1][1] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][1],
+          miller_value[1][1], horiz_dielectric_constant[1][1],
+          vert_dielectric_constant[1][1], fringe_cap);
 
       wire_pitch[1][2] = 8 * g_ip->F_sz_um;
-      aspect_ratio[1][2]  = 2.2;
+      aspect_ratio[1][2] = 2.2;
       wire_width = wire_pitch[1][2] / 2;
       wire_thickness = aspect_ratio[1][2] * wire_width;
       wire_spacing = wire_pitch[1][2] - wire_width;
-      dishing_thickness = 0.1 *  wire_thickness;
-      wire_r_per_micron[1][2] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[1][2]  = 1.1;
-      miller_value[1][2]  = 1.5;
-      horiz_dielectric_constant[1][2]  = 3.038;
-      vert_dielectric_constant[1][2]  = 3.9;
-      wire_c_per_micron[1][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[1][2] , miller_value[1][2], horiz_dielectric_constant[1][2], vert_dielectric_constant[1][2],
-          fringe_cap);
-      //Nominal projections for commodity DRAM wordline/bitline
+      dishing_thickness = 0.1 * wire_thickness;
+      wire_r_per_micron[1][2] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[1][2] = 1.1;
+      miller_value[1][2] = 1.5;
+      horiz_dielectric_constant[1][2] = 3.038;
+      vert_dielectric_constant[1][2] = 3.9;
+      wire_c_per_micron[1][2] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][2],
+          miller_value[1][2], horiz_dielectric_constant[1][2],
+          vert_dielectric_constant[1][2], fringe_cap);
+      // Nominal projections for commodity DRAM wordline/bitline
       wire_pitch[1][3] = 2 * 0.09;
       wire_c_per_micron[1][3] = 60e-15 / (256 * 2 * 0.09);
       wire_r_per_micron[1][3] = 12 / 0.09;
-    }
-    else if (tech == 65)
-    {
-      //Aggressive projections
+    } else if (tech == 65) {
+      // Aggressive projections
       wire_pitch[0][0] = 2.5 * g_ip->F_sz_um;
-      aspect_ratio[0][0]  = 2.7;
+      aspect_ratio[0][0] = 2.7;
       wire_width = wire_pitch[0][0] / 2;
-      wire_thickness = aspect_ratio[0][0]  * wire_width;
+      wire_thickness = aspect_ratio[0][0] * wire_width;
       wire_spacing = wire_pitch[0][0] - wire_width;
       barrier_thickness = 0;
       dishing_thickness = 0;
       alpha_scatter = 1;
-      wire_r_per_micron[0][0] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[0][0]  = 0.405;
-      miller_value[0][0]   = 1.5;
-      horiz_dielectric_constant[0][0]  = 2.303;
-      vert_dielectric_constant[0][0]   = 3.9;
+      wire_r_per_micron[0][0] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][0] = 0.405;
+      miller_value[0][0] = 1.5;
+      horiz_dielectric_constant[0][0] = 2.303;
+      vert_dielectric_constant[0][0] = 3.9;
       fringe_cap = 0.115e-15;
-      wire_c_per_micron[0][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[0][0] , miller_value[0][0] , horiz_dielectric_constant[0][0] , vert_dielectric_constant[0][0] ,
-          fringe_cap);
+      wire_c_per_micron[0][0] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][0],
+          miller_value[0][0], horiz_dielectric_constant[0][0],
+          vert_dielectric_constant[0][0], fringe_cap);
 
       wire_pitch[0][1] = 4 * g_ip->F_sz_um;
       wire_width = wire_pitch[0][1] / 2;
-      aspect_ratio[0][1]  = 2.7;
-      wire_thickness = aspect_ratio[0][1]  * wire_width;
+      aspect_ratio[0][1] = 2.7;
+      wire_thickness = aspect_ratio[0][1] * wire_width;
       wire_spacing = wire_pitch[0][1] - wire_width;
-      wire_r_per_micron[0][1] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[0][1]  = 0.405;
-      miller_value[0][1]   = 1.5;
-      horiz_dielectric_constant[0][1]  = 2.303;
-      vert_dielectric_constant[0][1]   = 3.9;
-      wire_c_per_micron[0][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[0][1], miller_value[0][1], horiz_dielectric_constant[0][1],
-          vert_dielectric_constant[0][1],
-          fringe_cap);
+      wire_r_per_micron[0][1] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][1] = 0.405;
+      miller_value[0][1] = 1.5;
+      horiz_dielectric_constant[0][1] = 2.303;
+      vert_dielectric_constant[0][1] = 3.9;
+      wire_c_per_micron[0][1] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][1],
+          miller_value[0][1], horiz_dielectric_constant[0][1],
+          vert_dielectric_constant[0][1], fringe_cap);
 
       wire_pitch[0][2] = 8 * g_ip->F_sz_um;
       aspect_ratio[0][2] = 2.8;
       wire_width = wire_pitch[0][2] / 2;
       wire_thickness = aspect_ratio[0][2] * wire_width;
       wire_spacing = wire_pitch[0][2] - wire_width;
-      wire_r_per_micron[0][2] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+      wire_r_per_micron[0][2] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[0][2] = 0.81;
-      miller_value[0][2]   = 1.5;
-      horiz_dielectric_constant[0][2]  = 2.303;
-      vert_dielectric_constant[0][2]   = 3.9;
-      wire_c_per_micron[0][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[0][2], miller_value[0][2], horiz_dielectric_constant[0][2], vert_dielectric_constant[0][2],
-          fringe_cap);
+      miller_value[0][2] = 1.5;
+      horiz_dielectric_constant[0][2] = 2.303;
+      vert_dielectric_constant[0][2] = 3.9;
+      wire_c_per_micron[0][2] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][2],
+          miller_value[0][2], horiz_dielectric_constant[0][2],
+          vert_dielectric_constant[0][2], fringe_cap);
 
-      //Conservative projections
+      // Conservative projections
       wire_pitch[1][0] = 2.5 * g_ip->F_sz_um;
       aspect_ratio[1][0] = 2.0;
       wire_width = wire_pitch[1][0] / 2;
@@ -2085,139 +2170,35 @@ void init_tech_params(double technology, bool is_tag)
       barrier_thickness = 0.006;
       dishing_thickness = 0;
       alpha_scatter = 1;
-      wire_r_per_micron[1][0] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+      wire_r_per_micron[1][0] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[1][0] = 0.405;
       miller_value[1][0] = 1.5;
       horiz_dielectric_constant[1][0] = 2.734;
       vert_dielectric_constant[1][0] = 3.9;
       fringe_cap = 0.115e-15;
-      wire_c_per_micron[1][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[1][0], miller_value[1][0], horiz_dielectric_constant[1][0], vert_dielectric_constant[1][0],
-          fringe_cap);
+      wire_c_per_micron[1][0] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][0],
+          miller_value[1][0], horiz_dielectric_constant[1][0],
+          vert_dielectric_constant[1][0], fringe_cap);
 
       wire_pitch[1][1] = 4 * g_ip->F_sz_um;
       wire_width = wire_pitch[1][1] / 2;
       aspect_ratio[1][1] = 2.0;
       wire_thickness = aspect_ratio[1][1] * wire_width;
       wire_spacing = wire_pitch[1][1] - wire_width;
-      wire_r_per_micron[1][1] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+      wire_r_per_micron[1][1] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[1][1] = 0.405;
       miller_value[1][1] = 1.5;
       horiz_dielectric_constant[1][1] = 2.734;
       vert_dielectric_constant[1][1] = 3.9;
-      wire_c_per_micron[1][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[1][1], miller_value[1][1], horiz_dielectric_constant[1][1], vert_dielectric_constant[1][1],
-          fringe_cap);
-
-      wire_pitch[1][2] = 8 * g_ip->F_sz_um;
-      aspect_ratio[1][2] = 2.2;
-      wire_width = wire_pitch[1][2] / 2;
-      wire_thickness = aspect_ratio[1][2] * wire_width;
-      wire_spacing = wire_pitch[1][2] - wire_width;
-      dishing_thickness = 0.1 *  wire_thickness;
-      wire_r_per_micron[1][2] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[1][2] = 0.77;
-      miller_value[1][2] = 1.5;
-      horiz_dielectric_constant[1][2] = 2.734;
-      vert_dielectric_constant[1][2] = 3.9;
-      wire_c_per_micron[1][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[1][2], miller_value[1][2], horiz_dielectric_constant[1][2], vert_dielectric_constant[1][2],
-          fringe_cap);
-      //Nominal projections for commodity DRAM wordline/bitline
-      wire_pitch[1][3] = 2 * 0.065;
-      wire_c_per_micron[1][3] = 52.5e-15 / (256 * 2 * 0.065);
-      wire_r_per_micron[1][3] = 12 / 0.065;
-    }
-    else if (tech == 45)
-    {
-      //Aggressive projections.
-      wire_pitch[0][0] = 2.5 * g_ip->F_sz_um;
-      aspect_ratio[0][0]  = 3.0;
-      wire_width = wire_pitch[0][0] / 2;
-      wire_thickness = aspect_ratio[0][0]  * wire_width;
-      wire_spacing = wire_pitch[0][0] - wire_width;
-      barrier_thickness = 0;
-      dishing_thickness = 0;
-      alpha_scatter = 1;
-      wire_r_per_micron[0][0] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[0][0]  = 0.315;
-      miller_value[0][0]  = 1.5;
-      horiz_dielectric_constant[0][0]  = 1.958;
-      vert_dielectric_constant[0][0]  = 3.9;
-      fringe_cap = 0.115e-15;
-      wire_c_per_micron[0][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[0][0] , miller_value[0][0] , horiz_dielectric_constant[0][0] , vert_dielectric_constant[0][0] ,
-          fringe_cap);
-
-      wire_pitch[0][1] = 4 * g_ip->F_sz_um;
-      wire_width = wire_pitch[0][1] / 2;
-      aspect_ratio[0][1]  = 3.0;
-      wire_thickness = aspect_ratio[0][1] * wire_width;
-      wire_spacing = wire_pitch[0][1] - wire_width;
-      wire_r_per_micron[0][1] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[0][1]  = 0.315;
-      miller_value[0][1]  = 1.5;
-      horiz_dielectric_constant[0][1]  = 1.958;
-      vert_dielectric_constant[0][1]  = 3.9;
-      wire_c_per_micron[0][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[0][1], miller_value[0][1], horiz_dielectric_constant[0][1], vert_dielectric_constant[0][1],
-          fringe_cap);
-
-      wire_pitch[0][2] = 8 * g_ip->F_sz_um;
-      aspect_ratio[0][2] = 3.0;
-      wire_width = wire_pitch[0][2] / 2;
-      wire_thickness = aspect_ratio[0][2] * wire_width;
-      wire_spacing = wire_pitch[0][2] - wire_width;
-      wire_r_per_micron[0][2] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[0][2] = 0.63;
-      miller_value[0][2]  = 1.5;
-      horiz_dielectric_constant[0][2]  = 1.958;
-      vert_dielectric_constant[0][2]  = 3.9;
-      wire_c_per_micron[0][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[0][2], miller_value[0][2], horiz_dielectric_constant[0][2], vert_dielectric_constant[0][2],
-          fringe_cap);
-
-      //Conservative projections
-      wire_pitch[1][0] = 2.5 * g_ip->F_sz_um;
-      aspect_ratio[1][0] = 2.0;
-      wire_width = wire_pitch[1][0] / 2;
-      wire_thickness = aspect_ratio[1][0] * wire_width;
-      wire_spacing = wire_pitch[1][0] - wire_width;
-      barrier_thickness = 0.004;
-      dishing_thickness = 0;
-      alpha_scatter = 1;
-      wire_r_per_micron[1][0] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[1][0] = 0.315;
-      miller_value[1][0] = 1.5;
-      horiz_dielectric_constant[1][0] = 2.46;
-      vert_dielectric_constant[1][0] = 3.9;
-      fringe_cap = 0.115e-15;
-      wire_c_per_micron[1][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[1][0], miller_value[1][0], horiz_dielectric_constant[1][0], vert_dielectric_constant[1][0],
-          fringe_cap);
-
-      wire_pitch[1][1] = 4 * g_ip->F_sz_um;
-      wire_width = wire_pitch[1][1] / 2;
-      aspect_ratio[1][1] = 2.0;
-      wire_thickness = aspect_ratio[1][1] * wire_width;
-      wire_spacing = wire_pitch[1][1] - wire_width;
-      wire_r_per_micron[1][1] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[1][1] = 0.315;
-      miller_value[1][1] = 1.5;
-      horiz_dielectric_constant[1][1] = 2.46;
-      vert_dielectric_constant[1][1] = 3.9;
-      fringe_cap = 0.115e-15;
-      wire_c_per_micron[1][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[1][1], miller_value[1][1], horiz_dielectric_constant[1][1], vert_dielectric_constant[1][1],
-          fringe_cap);
+      wire_c_per_micron[1][1] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][1],
+          miller_value[1][1], horiz_dielectric_constant[1][1],
+          vert_dielectric_constant[1][1], fringe_cap);
 
       wire_pitch[1][2] = 8 * g_ip->F_sz_um;
       aspect_ratio[1][2] = 2.2;
@@ -2225,23 +2206,23 @@ void init_tech_params(double technology, bool is_tag)
       wire_thickness = aspect_ratio[1][2] * wire_width;
       wire_spacing = wire_pitch[1][2] - wire_width;
       dishing_thickness = 0.1 * wire_thickness;
-      wire_r_per_micron[1][2] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[1][2] = 0.55;
+      wire_r_per_micron[1][2] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[1][2] = 0.77;
       miller_value[1][2] = 1.5;
-      horiz_dielectric_constant[1][2] = 2.46;
+      horiz_dielectric_constant[1][2] = 2.734;
       vert_dielectric_constant[1][2] = 3.9;
-      wire_c_per_micron[1][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[1][2], miller_value[1][2], horiz_dielectric_constant[1][2], vert_dielectric_constant[1][2],
-          fringe_cap);
-      //Nominal projections for commodity DRAM wordline/bitline
-      wire_pitch[1][3] = 2 * 0.045;
-      wire_c_per_micron[1][3] = 37.5e-15 / (256 * 2 * 0.045);
-      wire_r_per_micron[1][3] = 12 / 0.045;
-    }
-    else if (tech == 32)
-    {
-      //Aggressive projections.
+      wire_c_per_micron[1][2] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][2],
+          miller_value[1][2], horiz_dielectric_constant[1][2],
+          vert_dielectric_constant[1][2], fringe_cap);
+      // Nominal projections for commodity DRAM wordline/bitline
+      wire_pitch[1][3] = 2 * 0.065;
+      wire_c_per_micron[1][3] = 52.5e-15 / (256 * 2 * 0.065);
+      wire_r_per_micron[1][3] = 12 / 0.065;
+    } else if (tech == 45) {
+      // Aggressive projections.
       wire_pitch[0][0] = 2.5 * g_ip->F_sz_um;
       aspect_ratio[0][0] = 3.0;
       wire_width = wire_pitch[0][0] / 2;
@@ -2250,48 +2231,172 @@ void init_tech_params(double technology, bool is_tag)
       barrier_thickness = 0;
       dishing_thickness = 0;
       alpha_scatter = 1;
-      wire_r_per_micron[0][0] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[0][0] = 0.21;
+      wire_r_per_micron[0][0] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][0] = 0.315;
       miller_value[0][0] = 1.5;
-      horiz_dielectric_constant[0][0] = 1.664;
+      horiz_dielectric_constant[0][0] = 1.958;
       vert_dielectric_constant[0][0] = 3.9;
       fringe_cap = 0.115e-15;
-      wire_c_per_micron[0][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[0][0], miller_value[0][0], horiz_dielectric_constant[0][0], vert_dielectric_constant[0][0],
-          fringe_cap);
+      wire_c_per_micron[0][0] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][0],
+          miller_value[0][0], horiz_dielectric_constant[0][0],
+          vert_dielectric_constant[0][0], fringe_cap);
 
       wire_pitch[0][1] = 4 * g_ip->F_sz_um;
       wire_width = wire_pitch[0][1] / 2;
       aspect_ratio[0][1] = 3.0;
       wire_thickness = aspect_ratio[0][1] * wire_width;
       wire_spacing = wire_pitch[0][1] - wire_width;
-      wire_r_per_micron[0][1] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[0][1] = 0.21;
+      wire_r_per_micron[0][1] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][1] = 0.315;
       miller_value[0][1] = 1.5;
-      horiz_dielectric_constant[0][1] = 1.664;
+      horiz_dielectric_constant[0][1] = 1.958;
       vert_dielectric_constant[0][1] = 3.9;
-      wire_c_per_micron[0][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[0][1], miller_value[0][1], horiz_dielectric_constant[0][1], vert_dielectric_constant[0][1],
-          fringe_cap);
+      wire_c_per_micron[0][1] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][1],
+          miller_value[0][1], horiz_dielectric_constant[0][1],
+          vert_dielectric_constant[0][1], fringe_cap);
 
       wire_pitch[0][2] = 8 * g_ip->F_sz_um;
       aspect_ratio[0][2] = 3.0;
       wire_width = wire_pitch[0][2] / 2;
       wire_thickness = aspect_ratio[0][2] * wire_width;
       wire_spacing = wire_pitch[0][2] - wire_width;
-      wire_r_per_micron[0][2] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+      wire_r_per_micron[0][2] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][2] = 0.63;
+      miller_value[0][2] = 1.5;
+      horiz_dielectric_constant[0][2] = 1.958;
+      vert_dielectric_constant[0][2] = 3.9;
+      wire_c_per_micron[0][2] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][2],
+          miller_value[0][2], horiz_dielectric_constant[0][2],
+          vert_dielectric_constant[0][2], fringe_cap);
+
+      // Conservative projections
+      wire_pitch[1][0] = 2.5 * g_ip->F_sz_um;
+      aspect_ratio[1][0] = 2.0;
+      wire_width = wire_pitch[1][0] / 2;
+      wire_thickness = aspect_ratio[1][0] * wire_width;
+      wire_spacing = wire_pitch[1][0] - wire_width;
+      barrier_thickness = 0.004;
+      dishing_thickness = 0;
+      alpha_scatter = 1;
+      wire_r_per_micron[1][0] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[1][0] = 0.315;
+      miller_value[1][0] = 1.5;
+      horiz_dielectric_constant[1][0] = 2.46;
+      vert_dielectric_constant[1][0] = 3.9;
+      fringe_cap = 0.115e-15;
+      wire_c_per_micron[1][0] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][0],
+          miller_value[1][0], horiz_dielectric_constant[1][0],
+          vert_dielectric_constant[1][0], fringe_cap);
+
+      wire_pitch[1][1] = 4 * g_ip->F_sz_um;
+      wire_width = wire_pitch[1][1] / 2;
+      aspect_ratio[1][1] = 2.0;
+      wire_thickness = aspect_ratio[1][1] * wire_width;
+      wire_spacing = wire_pitch[1][1] - wire_width;
+      wire_r_per_micron[1][1] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[1][1] = 0.315;
+      miller_value[1][1] = 1.5;
+      horiz_dielectric_constant[1][1] = 2.46;
+      vert_dielectric_constant[1][1] = 3.9;
+      fringe_cap = 0.115e-15;
+      wire_c_per_micron[1][1] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][1],
+          miller_value[1][1], horiz_dielectric_constant[1][1],
+          vert_dielectric_constant[1][1], fringe_cap);
+
+      wire_pitch[1][2] = 8 * g_ip->F_sz_um;
+      aspect_ratio[1][2] = 2.2;
+      wire_width = wire_pitch[1][2] / 2;
+      wire_thickness = aspect_ratio[1][2] * wire_width;
+      wire_spacing = wire_pitch[1][2] - wire_width;
+      dishing_thickness = 0.1 * wire_thickness;
+      wire_r_per_micron[1][2] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[1][2] = 0.55;
+      miller_value[1][2] = 1.5;
+      horiz_dielectric_constant[1][2] = 2.46;
+      vert_dielectric_constant[1][2] = 3.9;
+      wire_c_per_micron[1][2] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][2],
+          miller_value[1][2], horiz_dielectric_constant[1][2],
+          vert_dielectric_constant[1][2], fringe_cap);
+      // Nominal projections for commodity DRAM wordline/bitline
+      wire_pitch[1][3] = 2 * 0.045;
+      wire_c_per_micron[1][3] = 37.5e-15 / (256 * 2 * 0.045);
+      wire_r_per_micron[1][3] = 12 / 0.045;
+    } else if (tech == 32) {
+      // Aggressive projections.
+      wire_pitch[0][0] = 2.5 * g_ip->F_sz_um;
+      aspect_ratio[0][0] = 3.0;
+      wire_width = wire_pitch[0][0] / 2;
+      wire_thickness = aspect_ratio[0][0] * wire_width;
+      wire_spacing = wire_pitch[0][0] - wire_width;
+      barrier_thickness = 0;
+      dishing_thickness = 0;
+      alpha_scatter = 1;
+      wire_r_per_micron[0][0] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][0] = 0.21;
+      miller_value[0][0] = 1.5;
+      horiz_dielectric_constant[0][0] = 1.664;
+      vert_dielectric_constant[0][0] = 3.9;
+      fringe_cap = 0.115e-15;
+      wire_c_per_micron[0][0] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][0],
+          miller_value[0][0], horiz_dielectric_constant[0][0],
+          vert_dielectric_constant[0][0], fringe_cap);
+
+      wire_pitch[0][1] = 4 * g_ip->F_sz_um;
+      wire_width = wire_pitch[0][1] / 2;
+      aspect_ratio[0][1] = 3.0;
+      wire_thickness = aspect_ratio[0][1] * wire_width;
+      wire_spacing = wire_pitch[0][1] - wire_width;
+      wire_r_per_micron[0][1] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][1] = 0.21;
+      miller_value[0][1] = 1.5;
+      horiz_dielectric_constant[0][1] = 1.664;
+      vert_dielectric_constant[0][1] = 3.9;
+      wire_c_per_micron[0][1] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][1],
+          miller_value[0][1], horiz_dielectric_constant[0][1],
+          vert_dielectric_constant[0][1], fringe_cap);
+
+      wire_pitch[0][2] = 8 * g_ip->F_sz_um;
+      aspect_ratio[0][2] = 3.0;
+      wire_width = wire_pitch[0][2] / 2;
+      wire_thickness = aspect_ratio[0][2] * wire_width;
+      wire_spacing = wire_pitch[0][2] - wire_width;
+      wire_r_per_micron[0][2] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[0][2] = 0.42;
       miller_value[0][2] = 1.5;
       horiz_dielectric_constant[0][2] = 1.664;
       vert_dielectric_constant[0][2] = 3.9;
-      wire_c_per_micron[0][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[0][2], miller_value[0][2], horiz_dielectric_constant[0][2], vert_dielectric_constant[0][2],
-          fringe_cap);
+      wire_c_per_micron[0][2] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][2],
+          miller_value[0][2], horiz_dielectric_constant[0][2],
+          vert_dielectric_constant[0][2], fringe_cap);
 
-      //Conservative projections
+      // Conservative projections
       wire_pitch[1][0] = 2.5 * g_ip->F_sz_um;
       aspect_ratio[1][0] = 2.0;
       wire_width = wire_pitch[1][0] / 2;
@@ -2300,460 +2405,579 @@ void init_tech_params(double technology, bool is_tag)
       barrier_thickness = 0.003;
       dishing_thickness = 0;
       alpha_scatter = 1;
-      wire_r_per_micron[1][0] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+      wire_r_per_micron[1][0] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[1][0] = 0.21;
       miller_value[1][0] = 1.5;
       horiz_dielectric_constant[1][0] = 2.214;
       vert_dielectric_constant[1][0] = 3.9;
       fringe_cap = 0.115e-15;
-      wire_c_per_micron[1][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[1][0], miller_value[1][0], horiz_dielectric_constant[1][0], vert_dielectric_constant[1][0],
-          fringe_cap);
+      wire_c_per_micron[1][0] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][0],
+          miller_value[1][0], horiz_dielectric_constant[1][0],
+          vert_dielectric_constant[1][0], fringe_cap);
 
       wire_pitch[1][1] = 4 * g_ip->F_sz_um;
       aspect_ratio[1][1] = 2.0;
       wire_width = wire_pitch[1][1] / 2;
       wire_thickness = aspect_ratio[1][1] * wire_width;
       wire_spacing = wire_pitch[1][1] - wire_width;
-      wire_r_per_micron[1][1] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+      wire_r_per_micron[1][1] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[1][1] = 0.21;
       miller_value[1][1] = 1.5;
       horiz_dielectric_constant[1][1] = 2.214;
       vert_dielectric_constant[1][1] = 3.9;
-      wire_c_per_micron[1][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[1][1], miller_value[1][1], horiz_dielectric_constant[1][1], vert_dielectric_constant[1][1],
-          fringe_cap);
+      wire_c_per_micron[1][1] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][1],
+          miller_value[1][1], horiz_dielectric_constant[1][1],
+          vert_dielectric_constant[1][1], fringe_cap);
 
       wire_pitch[1][2] = 8 * g_ip->F_sz_um;
       aspect_ratio[1][2] = 2.2;
       wire_width = wire_pitch[1][2] / 2;
       wire_thickness = aspect_ratio[1][2] * wire_width;
       wire_spacing = wire_pitch[1][2] - wire_width;
-      dishing_thickness = 0.1 *  wire_thickness;
-      wire_r_per_micron[1][2] = wire_resistance(CU_RESISTIVITY, wire_width,
-          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+      dishing_thickness = 0.1 * wire_thickness;
+      wire_r_per_micron[1][2] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[1][2] = 0.385;
       miller_value[1][2] = 1.5;
       horiz_dielectric_constant[1][2] = 2.214;
       vert_dielectric_constant[1][2] = 3.9;
-      wire_c_per_micron[1][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-          ild_thickness[1][2], miller_value[1][2], horiz_dielectric_constant[1][2], vert_dielectric_constant[1][2],
-          fringe_cap);
-      //Nominal projections for commodity DRAM wordline/bitline
-      wire_pitch[1][3] = 2 * 0.032;//micron
-      wire_c_per_micron[1][3] = 31e-15 / (256 * 2 * 0.032);//F/micron
-      wire_r_per_micron[1][3] = 12 / 0.032;//ohm/micron
+      wire_c_per_micron[1][2] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][2],
+          miller_value[1][2], horiz_dielectric_constant[1][2],
+          vert_dielectric_constant[1][2], fringe_cap);
+      // Nominal projections for commodity DRAM wordline/bitline
+      wire_pitch[1][3] = 2 * 0.032;                          // micron
+      wire_c_per_micron[1][3] = 31e-15 / (256 * 2 * 0.032);  // F/micron
+      wire_r_per_micron[1][3] = 12 / 0.032;                  // ohm/micron
+    } else if (tech == 22) {
+      // Aggressive projections.
+      wire_pitch[0][0] = 2.5 * g_ip->F_sz_um;  // local
+      aspect_ratio[0][0] = 3.0;
+      wire_width = wire_pitch[0][0] / 2;
+      wire_thickness = aspect_ratio[0][0] * wire_width;
+      wire_spacing = wire_pitch[0][0] - wire_width;
+      barrier_thickness = 0;
+      dishing_thickness = 0;
+      alpha_scatter = 1;
+      wire_r_per_micron[0][0] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][0] = 0.15;
+      miller_value[0][0] = 1.5;
+      horiz_dielectric_constant[0][0] = 1.414;
+      vert_dielectric_constant[0][0] = 3.9;
+      fringe_cap = 0.115e-15;
+      wire_c_per_micron[0][0] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][0],
+          miller_value[0][0], horiz_dielectric_constant[0][0],
+          vert_dielectric_constant[0][0], fringe_cap);
+
+      wire_pitch[0][1] = 4 * g_ip->F_sz_um;  // semi-global
+      wire_width = wire_pitch[0][1] / 2;
+      aspect_ratio[0][1] = 3.0;
+      wire_thickness = aspect_ratio[0][1] * wire_width;
+      wire_spacing = wire_pitch[0][1] - wire_width;
+      wire_r_per_micron[0][1] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][1] = 0.15;
+      miller_value[0][1] = 1.5;
+      horiz_dielectric_constant[0][1] = 1.414;
+      vert_dielectric_constant[0][1] = 3.9;
+      wire_c_per_micron[0][1] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][1],
+          miller_value[0][1], horiz_dielectric_constant[0][1],
+          vert_dielectric_constant[0][1], fringe_cap);
+
+      wire_pitch[0][2] = 8 * g_ip->F_sz_um;  // global
+      aspect_ratio[0][2] = 3.0;
+      wire_width = wire_pitch[0][2] / 2;
+      wire_thickness = aspect_ratio[0][2] * wire_width;
+      wire_spacing = wire_pitch[0][2] - wire_width;
+      wire_r_per_micron[0][2] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][2] = 0.3;
+      miller_value[0][2] = 1.5;
+      horiz_dielectric_constant[0][2] = 1.414;
+      vert_dielectric_constant[0][2] = 3.9;
+      wire_c_per_micron[0][2] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][2],
+          miller_value[0][2], horiz_dielectric_constant[0][2],
+          vert_dielectric_constant[0][2], fringe_cap);
+
+      //          //*************************
+      //          wire_pitch[0][4] = 16 * g_ip.F_sz_um;//global
+      //          aspect_ratio = 3.0;
+      //          wire_width = wire_pitch[0][4] / 2;
+      //          wire_thickness = aspect_ratio * wire_width;
+      //          wire_spacing = wire_pitch[0][4] - wire_width;
+      //          wire_r_per_micron[0][4] = wire_resistance(BULK_CU_RESISTIVITY,
+      //          wire_width,
+      //        		  wire_thickness, barrier_thickness,
+      //        dishing_thickness, alpha_scatter);
+      //          ild_thickness = 0.3;
+      //          wire_c_per_micron[0][4] = wire_capacitance(wire_width,
+      //          wire_thickness, wire_spacing,
+      //        		  ild_thickness, miller_value,
+      //        horiz_dielectric_constant, vert_dielectric_constant,
+      //        		  fringe_cap);
+      //
+      //          wire_pitch[0][5] = 24 * g_ip.F_sz_um;//global
+      //          aspect_ratio = 3.0;
+      //          wire_width = wire_pitch[0][5] / 2;
+      //          wire_thickness = aspect_ratio * wire_width;
+      //          wire_spacing = wire_pitch[0][5] - wire_width;
+      //          wire_r_per_micron[0][5] = wire_resistance(BULK_CU_RESISTIVITY,
+      //          wire_width,
+      //        		  wire_thickness, barrier_thickness,
+      //        dishing_thickness, alpha_scatter);
+      //          ild_thickness = 0.3;
+      //          wire_c_per_micron[0][5] = wire_capacitance(wire_width,
+      //          wire_thickness, wire_spacing,
+      //        		  ild_thickness, miller_value,
+      //        horiz_dielectric_constant, vert_dielectric_constant,
+      //        		  fringe_cap);
+      //
+      //          wire_pitch[0][6] = 32 * g_ip.F_sz_um;//global
+      //          aspect_ratio = 3.0;
+      //          wire_width = wire_pitch[0][6] / 2;
+      //          wire_thickness = aspect_ratio * wire_width;
+      //          wire_spacing = wire_pitch[0][6] - wire_width;
+      //          wire_r_per_micron[0][6] = wire_resistance(BULK_CU_RESISTIVITY,
+      //          wire_width,
+      //        		  wire_thickness, barrier_thickness,
+      //        dishing_thickness, alpha_scatter);
+      //          ild_thickness = 0.3;
+      //          wire_c_per_micron[0][6] = wire_capacitance(wire_width,
+      //          wire_thickness, wire_spacing,
+      //        		  ild_thickness, miller_value,
+      //        horiz_dielectric_constant, vert_dielectric_constant,
+      //        		  fringe_cap);
+      //*************************
+
+      // Conservative projections
+      wire_pitch[1][0] = 2.5 * g_ip->F_sz_um;
+      aspect_ratio[1][0] = 2.0;
+      wire_width = wire_pitch[1][0] / 2;
+      wire_thickness = aspect_ratio[1][0] * wire_width;
+      wire_spacing = wire_pitch[1][0] - wire_width;
+      barrier_thickness = 0.003;
+      dishing_thickness = 0;
+      alpha_scatter = 1.05;
+      wire_r_per_micron[1][0] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[1][0] = 0.15;
+      miller_value[1][0] = 1.5;
+      horiz_dielectric_constant[1][0] = 2.104;
+      vert_dielectric_constant[1][0] = 3.9;
+      fringe_cap = 0.115e-15;
+      wire_c_per_micron[1][0] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][0],
+          miller_value[1][0], horiz_dielectric_constant[1][0],
+          vert_dielectric_constant[1][0], fringe_cap);
+
+      wire_pitch[1][1] = 4 * g_ip->F_sz_um;
+      wire_width = wire_pitch[1][1] / 2;
+      aspect_ratio[1][1] = 2.0;
+      wire_thickness = aspect_ratio[1][1] * wire_width;
+      wire_spacing = wire_pitch[1][1] - wire_width;
+      wire_r_per_micron[1][1] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[1][1] = 0.15;
+      miller_value[1][1] = 1.5;
+      horiz_dielectric_constant[1][1] = 2.104;
+      vert_dielectric_constant[1][1] = 3.9;
+      wire_c_per_micron[1][1] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][1],
+          miller_value[1][1], horiz_dielectric_constant[1][1],
+          vert_dielectric_constant[1][1], fringe_cap);
+
+      wire_pitch[1][2] = 8 * g_ip->F_sz_um;
+      aspect_ratio[1][2] = 2.2;
+      wire_width = wire_pitch[1][2] / 2;
+      wire_thickness = aspect_ratio[1][2] * wire_width;
+      wire_spacing = wire_pitch[1][2] - wire_width;
+      dishing_thickness = 0.1 * wire_thickness;
+      wire_r_per_micron[1][2] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[1][2] = 0.275;
+      miller_value[1][2] = 1.5;
+      horiz_dielectric_constant[1][2] = 2.104;
+      vert_dielectric_constant[1][2] = 3.9;
+      wire_c_per_micron[1][2] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][2],
+          miller_value[1][2], horiz_dielectric_constant[1][2],
+          vert_dielectric_constant[1][2], fringe_cap);
+      // Nominal projections for commodity DRAM wordline/bitline
+      wire_pitch[1][3] = 2 * 0.022;                          // micron
+      wire_c_per_micron[1][3] = 31e-15 / (256 * 2 * 0.022);  // F/micron
+      wire_r_per_micron[1][3] = 12 / 0.022;                  // ohm/micron
+
+      //******************
+      //            wire_pitch[1][4] = 16 * g_ip.F_sz_um;
+      //            aspect_ratio = 2.2;
+      //            wire_width = wire_pitch[1][4] / 2;
+      //            wire_thickness = aspect_ratio * wire_width;
+      //            wire_spacing = wire_pitch[1][4] - wire_width;
+      //            dishing_thickness = 0.1 *  wire_thickness;
+      //            wire_r_per_micron[1][4] = wire_resistance(CU_RESISTIVITY,
+      //            wire_width,
+      //            		wire_thickness, barrier_thickness,
+      //            dishing_thickness, alpha_scatter);
+      //            ild_thickness = 0.275;
+      //            wire_c_per_micron[1][4] = wire_capacitance(wire_width,
+      //            wire_thickness, wire_spacing,
+      //            		ild_thickness, miller_value,
+      //            horiz_dielectric_constant, vert_dielectric_constant,
+      //            		fringe_cap);
+      //
+      //            wire_pitch[1][5] = 24 * g_ip.F_sz_um;
+      //            aspect_ratio = 2.2;
+      //            wire_width = wire_pitch[1][5] / 2;
+      //            wire_thickness = aspect_ratio * wire_width;
+      //            wire_spacing = wire_pitch[1][5] - wire_width;
+      //            dishing_thickness = 0.1 *  wire_thickness;
+      //            wire_r_per_micron[1][5] = wire_resistance(CU_RESISTIVITY,
+      //            wire_width,
+      //            		wire_thickness, barrier_thickness,
+      //            dishing_thickness, alpha_scatter);
+      //            ild_thickness = 0.275;
+      //            wire_c_per_micron[1][5] = wire_capacitance(wire_width,
+      //            wire_thickness, wire_spacing,
+      //            		ild_thickness, miller_value,
+      //            horiz_dielectric_constant, vert_dielectric_constant,
+      //            		fringe_cap);
+      //
+      //            wire_pitch[1][6] = 32 * g_ip.F_sz_um;
+      //            aspect_ratio = 2.2;
+      //            wire_width = wire_pitch[1][6] / 2;
+      //            wire_thickness = aspect_ratio * wire_width;
+      //            wire_spacing = wire_pitch[1][6] - wire_width;
+      //            dishing_thickness = 0.1 *  wire_thickness;
+      //            wire_r_per_micron[1][6] = wire_resistance(CU_RESISTIVITY,
+      //            wire_width,
+      //            		wire_thickness, barrier_thickness,
+      //            dishing_thickness, alpha_scatter);
+      //            ild_thickness = 0.275;
+      //            wire_c_per_micron[1][6] = wire_capacitance(wire_width,
+      //            wire_thickness, wire_spacing,
+      //            		ild_thickness, miller_value,
+      //            horiz_dielectric_constant, vert_dielectric_constant,
+      //            		fringe_cap);
     }
-    else if (tech == 22)
-        {
-          //Aggressive projections.
-          wire_pitch[0][0] = 2.5 * g_ip->F_sz_um;//local
-          aspect_ratio[0][0] = 3.0;
-          wire_width = wire_pitch[0][0] / 2;
-          wire_thickness = aspect_ratio[0][0] * wire_width;
-          wire_spacing = wire_pitch[0][0] - wire_width;
-          barrier_thickness = 0;
-          dishing_thickness = 0;
-          alpha_scatter = 1;
-          wire_r_per_micron[0][0] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-            wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-          ild_thickness[0][0] = 0.15;
-          miller_value[0][0] = 1.5;
-          horiz_dielectric_constant[0][0] = 1.414;
-          vert_dielectric_constant[0][0] = 3.9;
-          fringe_cap = 0.115e-15;
-          wire_c_per_micron[0][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-            ild_thickness[0][0], miller_value[0][0], horiz_dielectric_constant[0][0], vert_dielectric_constant[0][0],
-            fringe_cap);
 
-          wire_pitch[0][1] = 4 * g_ip->F_sz_um;//semi-global
-          wire_width = wire_pitch[0][1] / 2;
-          aspect_ratio[0][1] = 3.0;
-          wire_thickness = aspect_ratio[0][1] * wire_width;
-          wire_spacing = wire_pitch[0][1] - wire_width;
-          wire_r_per_micron[0][1] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-            wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-          ild_thickness[0][1] = 0.15;
-          miller_value[0][1] = 1.5;
-          horiz_dielectric_constant[0][1] = 1.414;
-          vert_dielectric_constant[0][1] = 3.9;
-          wire_c_per_micron[0][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-            ild_thickness[0][1], miller_value[0][1], horiz_dielectric_constant[0][1], vert_dielectric_constant[0][1],
-            fringe_cap);
+    else if (tech == 16) {
+      // Aggressive projections.
+      wire_pitch[0][0] = 2.5 * g_ip->F_sz_um;  // local
+      aspect_ratio[0][0] = 3.0;
+      wire_width = wire_pitch[0][0] / 2;
+      wire_thickness = aspect_ratio[0][0] * wire_width;
+      wire_spacing = wire_pitch[0][0] - wire_width;
+      barrier_thickness = 0;
+      dishing_thickness = 0;
+      alpha_scatter = 1;
+      wire_r_per_micron[0][0] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][0] = 0.108;
+      miller_value[0][0] = 1.5;
+      horiz_dielectric_constant[0][0] = 1.202;
+      vert_dielectric_constant[0][0] = 3.9;
+      fringe_cap = 0.115e-15;
+      wire_c_per_micron[0][0] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][0],
+          miller_value[0][0], horiz_dielectric_constant[0][0],
+          vert_dielectric_constant[0][0], fringe_cap);
 
-          wire_pitch[0][2] = 8 * g_ip->F_sz_um;//global
-          aspect_ratio[0][2] = 3.0;
-          wire_width = wire_pitch[0][2] / 2;
-          wire_thickness = aspect_ratio[0][2] * wire_width;
-          wire_spacing = wire_pitch[0][2] - wire_width;
-          wire_r_per_micron[0][2] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-        		  wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-          ild_thickness[0][2] = 0.3;
-          miller_value[0][2] = 1.5;
-          horiz_dielectric_constant[0][2] = 1.414;
-          vert_dielectric_constant[0][2] = 3.9;
-          wire_c_per_micron[0][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-        		  ild_thickness[0][2], miller_value[0][2], horiz_dielectric_constant[0][2], vert_dielectric_constant[0][2],
-        		  fringe_cap);
+      wire_pitch[0][1] = 4 * g_ip->F_sz_um;  // semi-global
+      aspect_ratio[0][1] = 3.0;
+      wire_width = wire_pitch[0][1] / 2;
+      wire_thickness = aspect_ratio[0][1] * wire_width;
+      wire_spacing = wire_pitch[0][1] - wire_width;
+      wire_r_per_micron[0][1] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][1] = 0.108;
+      miller_value[0][1] = 1.5;
+      horiz_dielectric_constant[0][1] = 1.202;
+      vert_dielectric_constant[0][1] = 3.9;
+      wire_c_per_micron[0][1] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][1],
+          miller_value[0][1], horiz_dielectric_constant[0][1],
+          vert_dielectric_constant[0][1], fringe_cap);
 
-//          //*************************
-//          wire_pitch[0][4] = 16 * g_ip.F_sz_um;//global
-//          aspect_ratio = 3.0;
-//          wire_width = wire_pitch[0][4] / 2;
-//          wire_thickness = aspect_ratio * wire_width;
-//          wire_spacing = wire_pitch[0][4] - wire_width;
-//          wire_r_per_micron[0][4] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-//        		  wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-//          ild_thickness = 0.3;
-//          wire_c_per_micron[0][4] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-//        		  ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
-//        		  fringe_cap);
-//
-//          wire_pitch[0][5] = 24 * g_ip.F_sz_um;//global
-//          aspect_ratio = 3.0;
-//          wire_width = wire_pitch[0][5] / 2;
-//          wire_thickness = aspect_ratio * wire_width;
-//          wire_spacing = wire_pitch[0][5] - wire_width;
-//          wire_r_per_micron[0][5] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-//        		  wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-//          ild_thickness = 0.3;
-//          wire_c_per_micron[0][5] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-//        		  ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
-//        		  fringe_cap);
-//
-//          wire_pitch[0][6] = 32 * g_ip.F_sz_um;//global
-//          aspect_ratio = 3.0;
-//          wire_width = wire_pitch[0][6] / 2;
-//          wire_thickness = aspect_ratio * wire_width;
-//          wire_spacing = wire_pitch[0][6] - wire_width;
-//          wire_r_per_micron[0][6] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-//        		  wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-//          ild_thickness = 0.3;
-//          wire_c_per_micron[0][6] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-//        		  ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
-//        		  fringe_cap);
-          //*************************
+      wire_pitch[0][2] = 8 * g_ip->F_sz_um;  // global
+      aspect_ratio[0][2] = 3.0;
+      wire_width = wire_pitch[0][2] / 2;
+      wire_thickness = aspect_ratio[0][2] * wire_width;
+      wire_spacing = wire_pitch[0][2] - wire_width;
+      wire_r_per_micron[0][2] =
+          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][2] = 0.216;
+      miller_value[0][2] = 1.5;
+      horiz_dielectric_constant[0][2] = 1.202;
+      vert_dielectric_constant[0][2] = 3.9;
+      wire_c_per_micron[0][2] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[0][2],
+          miller_value[0][2], horiz_dielectric_constant[0][2],
+          vert_dielectric_constant[0][2], fringe_cap);
 
-          //Conservative projections
-          wire_pitch[1][0] = 2.5 * g_ip->F_sz_um;
-          aspect_ratio[1][0] = 2.0;
-          wire_width = wire_pitch[1][0] / 2;
-          wire_thickness = aspect_ratio[1][0] * wire_width;
-          wire_spacing = wire_pitch[1][0] - wire_width;
-          barrier_thickness = 0.003;
-          dishing_thickness = 0;
-          alpha_scatter = 1.05;
-          wire_r_per_micron[1][0] = wire_resistance(CU_RESISTIVITY, wire_width,
-            wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-          ild_thickness[1][0] = 0.15;
-          miller_value[1][0] = 1.5;
-          horiz_dielectric_constant[1][0] = 2.104;
-          vert_dielectric_constant[1][0] = 3.9;
-          fringe_cap = 0.115e-15;
-          wire_c_per_micron[1][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-            ild_thickness[1][0], miller_value[1][0], horiz_dielectric_constant[1][0], vert_dielectric_constant[1][0],
-            fringe_cap);
+      //          //*************************
+      //          wire_pitch[0][4] = 16 * g_ip.F_sz_um;//global
+      //          aspect_ratio = 3.0;
+      //          wire_width = wire_pitch[0][4] / 2;
+      //          wire_thickness = aspect_ratio * wire_width;
+      //          wire_spacing = wire_pitch[0][4] - wire_width;
+      //          wire_r_per_micron[0][4] = wire_resistance(BULK_CU_RESISTIVITY,
+      //          wire_width,
+      //        		  wire_thickness, barrier_thickness,
+      //        dishing_thickness, alpha_scatter);
+      //          ild_thickness = 0.3;
+      //          wire_c_per_micron[0][4] = wire_capacitance(wire_width,
+      //          wire_thickness, wire_spacing,
+      //        		  ild_thickness, miller_value,
+      //        horiz_dielectric_constant, vert_dielectric_constant,
+      //        		  fringe_cap);
+      //
+      //          wire_pitch[0][5] = 24 * g_ip.F_sz_um;//global
+      //          aspect_ratio = 3.0;
+      //          wire_width = wire_pitch[0][5] / 2;
+      //          wire_thickness = aspect_ratio * wire_width;
+      //          wire_spacing = wire_pitch[0][5] - wire_width;
+      //          wire_r_per_micron[0][5] = wire_resistance(BULK_CU_RESISTIVITY,
+      //          wire_width,
+      //        		  wire_thickness, barrier_thickness,
+      //        dishing_thickness, alpha_scatter);
+      //          ild_thickness = 0.3;
+      //          wire_c_per_micron[0][5] = wire_capacitance(wire_width,
+      //          wire_thickness, wire_spacing,
+      //        		  ild_thickness, miller_value,
+      //        horiz_dielectric_constant, vert_dielectric_constant,
+      //        		  fringe_cap);
+      //
+      //          wire_pitch[0][6] = 32 * g_ip.F_sz_um;//global
+      //          aspect_ratio = 3.0;
+      //          wire_width = wire_pitch[0][6] / 2;
+      //          wire_thickness = aspect_ratio * wire_width;
+      //          wire_spacing = wire_pitch[0][6] - wire_width;
+      //          wire_r_per_micron[0][6] = wire_resistance(BULK_CU_RESISTIVITY,
+      //          wire_width,
+      //        		  wire_thickness, barrier_thickness,
+      //        dishing_thickness, alpha_scatter);
+      //          ild_thickness = 0.3;
+      //          wire_c_per_micron[0][6] = wire_capacitance(wire_width,
+      //          wire_thickness, wire_spacing,
+      //        		  ild_thickness, miller_value,
+      //        horiz_dielectric_constant, vert_dielectric_constant,
+      //        		  fringe_cap);
+      //*************************
 
-          wire_pitch[1][1] = 4 * g_ip->F_sz_um;
-          wire_width = wire_pitch[1][1] / 2;
-          aspect_ratio[1][1] = 2.0;
-          wire_thickness = aspect_ratio[1][1] * wire_width;
-          wire_spacing = wire_pitch[1][1] - wire_width;
-          wire_r_per_micron[1][1] = wire_resistance(CU_RESISTIVITY, wire_width,
-            wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-          ild_thickness[1][1] = 0.15;
-          miller_value[1][1] = 1.5;
-          horiz_dielectric_constant[1][1] = 2.104;
-          vert_dielectric_constant[1][1] = 3.9;
-          wire_c_per_micron[1][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-            ild_thickness[1][1], miller_value[1][1], horiz_dielectric_constant[1][1], vert_dielectric_constant[1][1],
-            fringe_cap);
+      // Conservative projections
+      wire_pitch[1][0] = 2.5 * g_ip->F_sz_um;
+      aspect_ratio[1][0] = 2.0;
+      wire_width = wire_pitch[1][0] / 2;
+      wire_thickness = aspect_ratio[1][0] * wire_width;
+      wire_spacing = wire_pitch[1][0] - wire_width;
+      barrier_thickness = 0.002;
+      dishing_thickness = 0;
+      alpha_scatter = 1.05;
+      wire_r_per_micron[1][0] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[1][0] = 0.108;
+      miller_value[1][0] = 1.5;
+      horiz_dielectric_constant[1][0] = 1.998;
+      vert_dielectric_constant[1][0] = 3.9;
+      fringe_cap = 0.115e-15;
+      wire_c_per_micron[1][0] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][0],
+          miller_value[1][0], horiz_dielectric_constant[1][0],
+          vert_dielectric_constant[1][0], fringe_cap);
 
-            wire_pitch[1][2] = 8 * g_ip->F_sz_um;
-            aspect_ratio[1][2] = 2.2;
-            wire_width = wire_pitch[1][2] / 2;
-            wire_thickness = aspect_ratio[1][2] * wire_width;
-            wire_spacing = wire_pitch[1][2] - wire_width;
-            dishing_thickness = 0.1 *  wire_thickness;
-            wire_r_per_micron[1][2] = wire_resistance(CU_RESISTIVITY, wire_width,
-            		wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-            ild_thickness[1][2] = 0.275;
-            miller_value[1][2] = 1.5;
-            horiz_dielectric_constant[1][2] = 2.104;
-            vert_dielectric_constant[1][2] = 3.9;
-            wire_c_per_micron[1][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-            		ild_thickness[1][2], miller_value[1][2], horiz_dielectric_constant[1][2], vert_dielectric_constant[1][2],
-            		fringe_cap);
-            //Nominal projections for commodity DRAM wordline/bitline
-            wire_pitch[1][3] = 2 * 0.022;//micron
-            wire_c_per_micron[1][3] = 31e-15 / (256 * 2 * 0.022);//F/micron
-            wire_r_per_micron[1][3] = 12 / 0.022;//ohm/micron
+      wire_pitch[1][1] = 4 * g_ip->F_sz_um;
+      wire_width = wire_pitch[1][1] / 2;
+      aspect_ratio[1][1] = 2.0;
+      wire_thickness = aspect_ratio[1][1] * wire_width;
+      wire_spacing = wire_pitch[1][1] - wire_width;
+      wire_r_per_micron[1][1] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[1][1] = 0.108;
+      miller_value[1][1] = 1.5;
+      horiz_dielectric_constant[1][1] = 1.998;
+      vert_dielectric_constant[1][1] = 3.9;
+      wire_c_per_micron[1][1] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][1],
+          miller_value[1][1], horiz_dielectric_constant[1][1],
+          vert_dielectric_constant[1][1], fringe_cap);
 
-            //******************
-//            wire_pitch[1][4] = 16 * g_ip.F_sz_um;
-//            aspect_ratio = 2.2;
-//            wire_width = wire_pitch[1][4] / 2;
-//            wire_thickness = aspect_ratio * wire_width;
-//            wire_spacing = wire_pitch[1][4] - wire_width;
-//            dishing_thickness = 0.1 *  wire_thickness;
-//            wire_r_per_micron[1][4] = wire_resistance(CU_RESISTIVITY, wire_width,
-//            		wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-//            ild_thickness = 0.275;
-//            wire_c_per_micron[1][4] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-//            		ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
-//            		fringe_cap);
-//
-//            wire_pitch[1][5] = 24 * g_ip.F_sz_um;
-//            aspect_ratio = 2.2;
-//            wire_width = wire_pitch[1][5] / 2;
-//            wire_thickness = aspect_ratio * wire_width;
-//            wire_spacing = wire_pitch[1][5] - wire_width;
-//            dishing_thickness = 0.1 *  wire_thickness;
-//            wire_r_per_micron[1][5] = wire_resistance(CU_RESISTIVITY, wire_width,
-//            		wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-//            ild_thickness = 0.275;
-//            wire_c_per_micron[1][5] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-//            		ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
-//            		fringe_cap);
-//
-//            wire_pitch[1][6] = 32 * g_ip.F_sz_um;
-//            aspect_ratio = 2.2;
-//            wire_width = wire_pitch[1][6] / 2;
-//            wire_thickness = aspect_ratio * wire_width;
-//            wire_spacing = wire_pitch[1][6] - wire_width;
-//            dishing_thickness = 0.1 *  wire_thickness;
-//            wire_r_per_micron[1][6] = wire_resistance(CU_RESISTIVITY, wire_width,
-//            		wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-//            ild_thickness = 0.275;
-//            wire_c_per_micron[1][6] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-//            		ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
-//            		fringe_cap);
-        }
+      wire_pitch[1][2] = 8 * g_ip->F_sz_um;
+      aspect_ratio[1][2] = 2.2;
+      wire_width = wire_pitch[1][2] / 2;
+      wire_thickness = aspect_ratio[1][2] * wire_width;
+      wire_spacing = wire_pitch[1][2] - wire_width;
+      dishing_thickness = 0.1 * wire_thickness;
+      wire_r_per_micron[1][2] =
+          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
+                          barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[1][2] = 0.198;
+      miller_value[1][2] = 1.5;
+      horiz_dielectric_constant[1][2] = 1.998;
+      vert_dielectric_constant[1][2] = 3.9;
+      wire_c_per_micron[1][2] = wire_capacitance(
+          wire_width, wire_thickness, wire_spacing, ild_thickness[1][2],
+          miller_value[1][2], horiz_dielectric_constant[1][2],
+          vert_dielectric_constant[1][2], fringe_cap);
+      // Nominal projections for commodity DRAM wordline/bitline
+      wire_pitch[1][3] = 2 * 0.016;                          // micron
+      wire_c_per_micron[1][3] = 31e-15 / (256 * 2 * 0.016);  // F/micron
+      wire_r_per_micron[1][3] = 12 / 0.016;                  // ohm/micron
 
-    else if (tech == 16)
-        {
-          //Aggressive projections.
-          wire_pitch[0][0] = 2.5 * g_ip->F_sz_um;//local
-          aspect_ratio[0][0] = 3.0;
-          wire_width = wire_pitch[0][0] / 2;
-          wire_thickness = aspect_ratio[0][0] * wire_width;
-          wire_spacing = wire_pitch[0][0] - wire_width;
-          barrier_thickness = 0;
-          dishing_thickness = 0;
-          alpha_scatter = 1;
-          wire_r_per_micron[0][0] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-            wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-          ild_thickness[0][0] = 0.108;
-          miller_value[0][0] = 1.5;
-          horiz_dielectric_constant[0][0] = 1.202;
-          vert_dielectric_constant[0][0] = 3.9;
-          fringe_cap = 0.115e-15;
-          wire_c_per_micron[0][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-            ild_thickness[0][0], miller_value[0][0], horiz_dielectric_constant[0][0], vert_dielectric_constant[0][0],
-            fringe_cap);
+      //******************
+      //            wire_pitch[1][4] = 16 * g_ip.F_sz_um;
+      //            aspect_ratio = 2.2;
+      //            wire_width = wire_pitch[1][4] / 2;
+      //            wire_thickness = aspect_ratio * wire_width;
+      //            wire_spacing = wire_pitch[1][4] - wire_width;
+      //            dishing_thickness = 0.1 *  wire_thickness;
+      //            wire_r_per_micron[1][4] = wire_resistance(CU_RESISTIVITY,
+      //            wire_width,
+      //            		wire_thickness, barrier_thickness,
+      //            dishing_thickness, alpha_scatter);
+      //            ild_thickness = 0.275;
+      //            wire_c_per_micron[1][4] = wire_capacitance(wire_width,
+      //            wire_thickness, wire_spacing,
+      //            		ild_thickness, miller_value,
+      //            horiz_dielectric_constant, vert_dielectric_constant,
+      //            		fringe_cap);
+      //
+      //            wire_pitch[1][5] = 24 * g_ip.F_sz_um;
+      //            aspect_ratio = 2.2;
+      //            wire_width = wire_pitch[1][5] / 2;
+      //            wire_thickness = aspect_ratio * wire_width;
+      //            wire_spacing = wire_pitch[1][5] - wire_width;
+      //            dishing_thickness = 0.1 *  wire_thickness;
+      //            wire_r_per_micron[1][5] = wire_resistance(CU_RESISTIVITY,
+      //            wire_width,
+      //            		wire_thickness, barrier_thickness,
+      //            dishing_thickness, alpha_scatter);
+      //            ild_thickness = 0.275;
+      //            wire_c_per_micron[1][5] = wire_capacitance(wire_width,
+      //            wire_thickness, wire_spacing,
+      //            		ild_thickness, miller_value,
+      //            horiz_dielectric_constant, vert_dielectric_constant,
+      //            		fringe_cap);
+      //
+      //            wire_pitch[1][6] = 32 * g_ip.F_sz_um;
+      //            aspect_ratio = 2.2;
+      //            wire_width = wire_pitch[1][6] / 2;
+      //            wire_thickness = aspect_ratio * wire_width;
+      //            wire_spacing = wire_pitch[1][6] - wire_width;
+      //            dishing_thickness = 0.1 *  wire_thickness;
+      //            wire_r_per_micron[1][6] = wire_resistance(CU_RESISTIVITY,
+      //            wire_width,
+      //            		wire_thickness, barrier_thickness,
+      //            dishing_thickness, alpha_scatter);
+      //            ild_thickness = 0.275;
+      //            wire_c_per_micron[1][6] = wire_capacitance(wire_width,
+      //            wire_thickness, wire_spacing,
+      //            		ild_thickness, miller_value,
+      //            horiz_dielectric_constant, vert_dielectric_constant,
+      //            		fringe_cap);
+    }
+    g_tp.wire_local.pitch +=
+        curr_alpha * wire_pitch[g_ip->ic_proj_type]
+                               [(ram_cell_tech_type == comm_dram) ? 3 : 0];
+    g_tp.wire_local.R_per_um +=
+        curr_alpha *
+        wire_r_per_micron[g_ip->ic_proj_type]
+                         [(ram_cell_tech_type == comm_dram) ? 3 : 0];
+    g_tp.wire_local.C_per_um +=
+        curr_alpha *
+        wire_c_per_micron[g_ip->ic_proj_type]
+                         [(ram_cell_tech_type == comm_dram) ? 3 : 0];
+    g_tp.wire_local.aspect_ratio +=
+        curr_alpha * aspect_ratio[g_ip->ic_proj_type]
+                                 [(ram_cell_tech_type == comm_dram) ? 3 : 0];
+    g_tp.wire_local.ild_thickness +=
+        curr_alpha * ild_thickness[g_ip->ic_proj_type]
+                                  [(ram_cell_tech_type == comm_dram) ? 3 : 0];
+    g_tp.wire_local.miller_value +=
+        curr_alpha * miller_value[g_ip->ic_proj_type]
+                                 [(ram_cell_tech_type == comm_dram) ? 3 : 0];
+    g_tp.wire_local.horiz_dielectric_constant +=
+        curr_alpha *
+        horiz_dielectric_constant[g_ip->ic_proj_type]
+                                 [(ram_cell_tech_type == comm_dram) ? 3 : 0];
+    g_tp.wire_local.vert_dielectric_constant +=
+        curr_alpha *
+        vert_dielectric_constant[g_ip->ic_proj_type]
+                                [(ram_cell_tech_type == comm_dram) ? 3 : 0];
 
-          wire_pitch[0][1] = 4 * g_ip->F_sz_um;//semi-global
-          aspect_ratio[0][1] = 3.0;
-          wire_width = wire_pitch[0][1] / 2;
-          wire_thickness = aspect_ratio[0][1] * wire_width;
-          wire_spacing = wire_pitch[0][1] - wire_width;
-          wire_r_per_micron[0][1] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-            wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-          ild_thickness[0][1] = 0.108;
-          miller_value[0][1] = 1.5;
-          horiz_dielectric_constant[0][1] = 1.202;
-          vert_dielectric_constant[0][1] = 3.9;
-          wire_c_per_micron[0][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-            ild_thickness[0][1], miller_value[0][1], horiz_dielectric_constant[0][1], vert_dielectric_constant[0][1],
-            fringe_cap);
+    g_tp.wire_inside_mat.pitch +=
+        curr_alpha * wire_pitch[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
+    g_tp.wire_inside_mat.R_per_um +=
+        curr_alpha *
+        wire_r_per_micron[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
+    g_tp.wire_inside_mat.C_per_um +=
+        curr_alpha *
+        wire_c_per_micron[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
+    g_tp.wire_inside_mat.aspect_ratio +=
+        curr_alpha * aspect_ratio[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
+    g_tp.wire_inside_mat.ild_thickness +=
+        curr_alpha * ild_thickness[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
+    g_tp.wire_inside_mat.miller_value +=
+        curr_alpha * miller_value[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
+    g_tp.wire_inside_mat.horiz_dielectric_constant +=
+        curr_alpha *
+        horiz_dielectric_constant[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
+    g_tp.wire_inside_mat.vert_dielectric_constant +=
+        curr_alpha *
+        vert_dielectric_constant[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
 
-          wire_pitch[0][2] = 8 * g_ip->F_sz_um;//global
-          aspect_ratio[0][2] = 3.0;
-          wire_width = wire_pitch[0][2] / 2;
-          wire_thickness = aspect_ratio[0][2] * wire_width;
-          wire_spacing = wire_pitch[0][2] - wire_width;
-          wire_r_per_micron[0][2] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-        		  wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-          ild_thickness[0][2] = 0.216;
-          miller_value[0][2] = 1.5;
-          horiz_dielectric_constant[0][2] = 1.202;
-          vert_dielectric_constant[0][2] = 3.9;
-          wire_c_per_micron[0][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-        		  ild_thickness[0][2], miller_value[0][2], horiz_dielectric_constant[0][2], vert_dielectric_constant[0][2],
-        		  fringe_cap);
+    g_tp.wire_outside_mat.pitch +=
+        curr_alpha * wire_pitch[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
+    g_tp.wire_outside_mat.R_per_um +=
+        curr_alpha *
+        wire_r_per_micron[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
+    g_tp.wire_outside_mat.C_per_um +=
+        curr_alpha *
+        wire_c_per_micron[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
+    g_tp.wire_outside_mat.aspect_ratio +=
+        curr_alpha * aspect_ratio[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
+    g_tp.wire_outside_mat.ild_thickness +=
+        curr_alpha * ild_thickness[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
+    g_tp.wire_outside_mat.miller_value +=
+        curr_alpha * miller_value[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
+    g_tp.wire_outside_mat.horiz_dielectric_constant +=
+        curr_alpha *
+        horiz_dielectric_constant[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
+    g_tp.wire_outside_mat.vert_dielectric_constant +=
+        curr_alpha *
+        vert_dielectric_constant[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
 
-//          //*************************
-//          wire_pitch[0][4] = 16 * g_ip.F_sz_um;//global
-//          aspect_ratio = 3.0;
-//          wire_width = wire_pitch[0][4] / 2;
-//          wire_thickness = aspect_ratio * wire_width;
-//          wire_spacing = wire_pitch[0][4] - wire_width;
-//          wire_r_per_micron[0][4] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-//        		  wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-//          ild_thickness = 0.3;
-//          wire_c_per_micron[0][4] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-//        		  ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
-//        		  fringe_cap);
-//
-//          wire_pitch[0][5] = 24 * g_ip.F_sz_um;//global
-//          aspect_ratio = 3.0;
-//          wire_width = wire_pitch[0][5] / 2;
-//          wire_thickness = aspect_ratio * wire_width;
-//          wire_spacing = wire_pitch[0][5] - wire_width;
-//          wire_r_per_micron[0][5] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-//        		  wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-//          ild_thickness = 0.3;
-//          wire_c_per_micron[0][5] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-//        		  ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
-//        		  fringe_cap);
-//
-//          wire_pitch[0][6] = 32 * g_ip.F_sz_um;//global
-//          aspect_ratio = 3.0;
-//          wire_width = wire_pitch[0][6] / 2;
-//          wire_thickness = aspect_ratio * wire_width;
-//          wire_spacing = wire_pitch[0][6] - wire_width;
-//          wire_r_per_micron[0][6] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
-//        		  wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-//          ild_thickness = 0.3;
-//          wire_c_per_micron[0][6] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-//        		  ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
-//        		  fringe_cap);
-          //*************************
+    g_tp.unit_len_wire_del =
+        g_tp.wire_inside_mat.R_per_um * g_tp.wire_inside_mat.C_per_um / 2;
 
-          //Conservative projections
-          wire_pitch[1][0] = 2.5 * g_ip->F_sz_um;
-          aspect_ratio[1][0] = 2.0;
-          wire_width = wire_pitch[1][0] / 2;
-          wire_thickness = aspect_ratio[1][0] * wire_width;
-          wire_spacing = wire_pitch[1][0] - wire_width;
-          barrier_thickness = 0.002;
-          dishing_thickness = 0;
-          alpha_scatter = 1.05;
-          wire_r_per_micron[1][0] = wire_resistance(CU_RESISTIVITY, wire_width,
-            wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-          ild_thickness[1][0] = 0.108;
-          miller_value[1][0] = 1.5;
-          horiz_dielectric_constant[1][0] = 1.998;
-          vert_dielectric_constant[1][0] = 3.9;
-          fringe_cap = 0.115e-15;
-          wire_c_per_micron[1][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-            ild_thickness[1][0], miller_value[1][0], horiz_dielectric_constant[1][0], vert_dielectric_constant[1][0],
-            fringe_cap);
-
-          wire_pitch[1][1] = 4 * g_ip->F_sz_um;
-          wire_width = wire_pitch[1][1] / 2;
-          aspect_ratio[1][1] = 2.0;
-          wire_thickness = aspect_ratio[1][1] * wire_width;
-          wire_spacing = wire_pitch[1][1] - wire_width;
-          wire_r_per_micron[1][1] = wire_resistance(CU_RESISTIVITY, wire_width,
-            wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-          ild_thickness[1][1] = 0.108;
-          miller_value[1][1] = 1.5;
-          horiz_dielectric_constant[1][1] = 1.998;
-          vert_dielectric_constant[1][1] = 3.9;
-            wire_c_per_micron[1][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-            ild_thickness[1][1], miller_value[1][1], horiz_dielectric_constant[1][1], vert_dielectric_constant[1][1],
-            fringe_cap);
-
-            wire_pitch[1][2] = 8 * g_ip->F_sz_um;
-            aspect_ratio[1][2] = 2.2;
-            wire_width = wire_pitch[1][2] / 2;
-            wire_thickness = aspect_ratio[1][2] * wire_width;
-            wire_spacing = wire_pitch[1][2] - wire_width;
-            dishing_thickness = 0.1 *  wire_thickness;
-            wire_r_per_micron[1][2] = wire_resistance(CU_RESISTIVITY, wire_width,
-            		wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-            ild_thickness[1][2] = 0.198;
-            miller_value[1][2] = 1.5;
-            horiz_dielectric_constant[1][2] = 1.998;
-            vert_dielectric_constant[1][2] = 3.9;
-            wire_c_per_micron[1][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-            		ild_thickness[1][2], miller_value[1][2], horiz_dielectric_constant[1][2], vert_dielectric_constant[1][2],
-            		fringe_cap);
-            //Nominal projections for commodity DRAM wordline/bitline
-            wire_pitch[1][3] = 2 * 0.016;//micron
-            wire_c_per_micron[1][3] = 31e-15 / (256 * 2 * 0.016);//F/micron
-            wire_r_per_micron[1][3] = 12 / 0.016;//ohm/micron
-
-            //******************
-//            wire_pitch[1][4] = 16 * g_ip.F_sz_um;
-//            aspect_ratio = 2.2;
-//            wire_width = wire_pitch[1][4] / 2;
-//            wire_thickness = aspect_ratio * wire_width;
-//            wire_spacing = wire_pitch[1][4] - wire_width;
-//            dishing_thickness = 0.1 *  wire_thickness;
-//            wire_r_per_micron[1][4] = wire_resistance(CU_RESISTIVITY, wire_width,
-//            		wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-//            ild_thickness = 0.275;
-//            wire_c_per_micron[1][4] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-//            		ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
-//            		fringe_cap);
-//
-//            wire_pitch[1][5] = 24 * g_ip.F_sz_um;
-//            aspect_ratio = 2.2;
-//            wire_width = wire_pitch[1][5] / 2;
-//            wire_thickness = aspect_ratio * wire_width;
-//            wire_spacing = wire_pitch[1][5] - wire_width;
-//            dishing_thickness = 0.1 *  wire_thickness;
-//            wire_r_per_micron[1][5] = wire_resistance(CU_RESISTIVITY, wire_width,
-//            		wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-//            ild_thickness = 0.275;
-//            wire_c_per_micron[1][5] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-//            		ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
-//            		fringe_cap);
-//
-//            wire_pitch[1][6] = 32 * g_ip.F_sz_um;
-//            aspect_ratio = 2.2;
-//            wire_width = wire_pitch[1][6] / 2;
-//            wire_thickness = aspect_ratio * wire_width;
-//            wire_spacing = wire_pitch[1][6] - wire_width;
-//            dishing_thickness = 0.1 *  wire_thickness;
-//            wire_r_per_micron[1][6] = wire_resistance(CU_RESISTIVITY, wire_width,
-//            		wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
-//            ild_thickness = 0.275;
-//            wire_c_per_micron[1][6] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
-//            		ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
-//            		fringe_cap);
-        }
-    g_tp.wire_local.pitch    += curr_alpha * wire_pitch[g_ip->ic_proj_type][(ram_cell_tech_type == comm_dram)?3:0];
-    g_tp.wire_local.R_per_um += curr_alpha * wire_r_per_micron[g_ip->ic_proj_type][(ram_cell_tech_type == comm_dram)?3:0];
-    g_tp.wire_local.C_per_um += curr_alpha * wire_c_per_micron[g_ip->ic_proj_type][(ram_cell_tech_type == comm_dram)?3:0];
-    g_tp.wire_local.aspect_ratio  += curr_alpha * aspect_ratio[g_ip->ic_proj_type][(ram_cell_tech_type == comm_dram)?3:0];
-    g_tp.wire_local.ild_thickness += curr_alpha * ild_thickness[g_ip->ic_proj_type][(ram_cell_tech_type == comm_dram)?3:0];
-    g_tp.wire_local.miller_value   += curr_alpha * miller_value[g_ip->ic_proj_type][(ram_cell_tech_type == comm_dram)?3:0];
-    g_tp.wire_local.horiz_dielectric_constant += curr_alpha* horiz_dielectric_constant[g_ip->ic_proj_type][(ram_cell_tech_type == comm_dram)?3:0];
-    g_tp.wire_local.vert_dielectric_constant  += curr_alpha* vert_dielectric_constant [g_ip->ic_proj_type][(ram_cell_tech_type == comm_dram)?3:0];
-
-    g_tp.wire_inside_mat.pitch     += curr_alpha * wire_pitch[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
-    g_tp.wire_inside_mat.R_per_um  += curr_alpha* wire_r_per_micron[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
-    g_tp.wire_inside_mat.C_per_um  += curr_alpha* wire_c_per_micron[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
-    g_tp.wire_inside_mat.aspect_ratio  += curr_alpha * aspect_ratio[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
-    g_tp.wire_inside_mat.ild_thickness += curr_alpha * ild_thickness[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
-    g_tp.wire_inside_mat.miller_value   += curr_alpha * miller_value[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
-    g_tp.wire_inside_mat.horiz_dielectric_constant += curr_alpha* horiz_dielectric_constant[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
-    g_tp.wire_inside_mat.vert_dielectric_constant  += curr_alpha* vert_dielectric_constant [g_ip->ic_proj_type][g_ip->wire_is_mat_type];
-
-    g_tp.wire_outside_mat.pitch    += curr_alpha * wire_pitch[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
-    g_tp.wire_outside_mat.R_per_um += curr_alpha*wire_r_per_micron[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
-    g_tp.wire_outside_mat.C_per_um += curr_alpha*wire_c_per_micron[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
-    g_tp.wire_outside_mat.aspect_ratio  += curr_alpha * aspect_ratio[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
-    g_tp.wire_outside_mat.ild_thickness += curr_alpha * ild_thickness[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
-    g_tp.wire_outside_mat.miller_value   += curr_alpha * miller_value[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
-    g_tp.wire_outside_mat.horiz_dielectric_constant += curr_alpha* horiz_dielectric_constant[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
-    g_tp.wire_outside_mat.vert_dielectric_constant  += curr_alpha* vert_dielectric_constant [g_ip->ic_proj_type][g_ip->wire_os_mat_type];
-
-    g_tp.unit_len_wire_del = g_tp.wire_inside_mat.R_per_um * g_tp.wire_inside_mat.C_per_um / 2;
-
-    g_tp.sense_delay               += curr_alpha *SENSE_AMP_D;
-    g_tp.sense_dy_power            += curr_alpha *SENSE_AMP_P;
-//    g_tp.horiz_dielectric_constant += horiz_dielectric_constant;
-//    g_tp.vert_dielectric_constant  += vert_dielectric_constant;
-//    g_tp.aspect_ratio              += aspect_ratio;
-//    g_tp.miller_value              += miller_value;
-//    g_tp.ild_thickness             += ild_thickness;
-
+    g_tp.sense_delay += curr_alpha * SENSE_AMP_D;
+    g_tp.sense_dy_power += curr_alpha * SENSE_AMP_P;
+    //    g_tp.horiz_dielectric_constant += horiz_dielectric_constant;
+    //    g_tp.vert_dielectric_constant  += vert_dielectric_constant;
+    //    g_tp.aspect_ratio              += aspect_ratio;
+    //    g_tp.miller_value              += miller_value;
+    //    g_tp.ild_thickness             += ild_thickness;
   }
   g_tp.fringe_cap = fringe_cap;
 
@@ -2764,9 +2988,9 @@ void init_tech_params(double technology, bool is_tag)
   g_tp.kinv = horowitz(0, tf, 0.5, 0.5, RISE);
   double KLOAD = 1;
   c_load = KLOAD * (drain_C_(g_tp.min_w_nmos_, NCH, 1, 1, g_tp.cell_h_def) +
-                    drain_C_(g_tp.min_w_nmos_ * p_to_n_sizing_r, PCH, 1, 1, g_tp.cell_h_def) +
+                    drain_C_(g_tp.min_w_nmos_ * p_to_n_sizing_r, PCH, 1, 1,
+                             g_tp.cell_h_def) +
                     gate_C(g_tp.min_w_nmos_ * 4 * (1 + p_to_n_sizing_r), 0.0));
   tf = rd * c_load;
   g_tp.FO4 = horowitz(0, tf, 0.5, 0.5, RISE);
 }
-

--- a/src/gpuwattch/technology_xeon_core.cc
+++ b/src/gpuwattch/technology_xeon_core.cc
@@ -29,64 +29,57 @@
  *
  ***************************************************************************/
 
+
 #include "basic_circuit.h"
 
 #include "parameter.h"
 
-double wire_resistance(double resistivity, double wire_width,
-                       double wire_thickness, double barrier_thickness,
-                       double dishing_thickness, double alpha_scatter) {
+double wire_resistance(double resistivity, double wire_width, double wire_thickness,
+    double barrier_thickness, double dishing_thickness, double alpha_scatter)
+{
   double resistance;
-  resistance = alpha_scatter * resistivity /
-               ((wire_thickness - barrier_thickness - dishing_thickness) *
-                (wire_width - 2 * barrier_thickness));
-  return (resistance);
+  resistance = alpha_scatter * resistivity /((wire_thickness - barrier_thickness - dishing_thickness)*(wire_width - 2 * barrier_thickness));
+  return(resistance);
 }
 
-double wire_capacitance(double wire_width, double wire_thickness,
-                        double wire_spacing, double ild_thickness,
-                        double miller_value, double horiz_dielectric_constant,
-                        double vert_dielectric_constant, double fringe_cap) {
+double wire_capacitance(double wire_width, double wire_thickness, double wire_spacing,
+    double ild_thickness, double miller_value, double horiz_dielectric_constant,
+    double vert_dielectric_constant, double fringe_cap)
+{
   double vertical_cap, sidewall_cap, total_cap;
-  vertical_cap = 2 * PERMITTIVITY_FREE_SPACE * vert_dielectric_constant *
-                 wire_width / ild_thickness;
-  sidewall_cap = 2 * PERMITTIVITY_FREE_SPACE * miller_value *
-                 horiz_dielectric_constant * wire_thickness / wire_spacing;
+  vertical_cap = 2 * PERMITTIVITY_FREE_SPACE * vert_dielectric_constant * wire_width / ild_thickness;
+  sidewall_cap = 2 * PERMITTIVITY_FREE_SPACE * miller_value * horiz_dielectric_constant * wire_thickness / wire_spacing;
   total_cap = vertical_cap + sidewall_cap + fringe_cap;
-  return (total_cap);
+  return(total_cap);
 }
 
-void init_tech_params(double technology, bool is_tag) {
-  int iter, tech, tech_lo, tech_hi;
+
+void init_tech_params(double technology, bool is_tag)
+{
+  int    iter, tech, tech_lo, tech_hi;
   double curr_alpha, curr_vpp;
-  double wire_width, wire_thickness, wire_spacing, fringe_cap,
-      pmos_to_nmos_sizing_r;
-  //  double aspect_ratio,ild_thickness, miller_value = 1.5,
-  //  horiz_dielectric_constant, vert_dielectric_constant;
+  double wire_width, wire_thickness, wire_spacing,
+         fringe_cap, pmos_to_nmos_sizing_r;
+//  double aspect_ratio,ild_thickness, miller_value = 1.5, horiz_dielectric_constant, vert_dielectric_constant;
   double barrier_thickness, dishing_thickness, alpha_scatter;
-  double curr_vdd_dram_cell, curr_v_th_dram_access_transistor,
-      curr_I_on_dram_cell, curr_c_dram_cell;
+  double curr_vdd_dram_cell, curr_v_th_dram_access_transistor, curr_I_on_dram_cell, curr_c_dram_cell;
 
-  uint32_t ram_cell_tech_type = (is_tag) ? g_ip->tag_arr_ram_cell_tech_type
-                                         : g_ip->data_arr_ram_cell_tech_type;
-  uint32_t peri_global_tech_type = (is_tag)
-                                       ? g_ip->tag_arr_peri_global_tech_type
-                                       : g_ip->data_arr_peri_global_tech_type;
+  uint32_t ram_cell_tech_type    = (is_tag) ? g_ip->tag_arr_ram_cell_tech_type : g_ip->data_arr_ram_cell_tech_type;
+  uint32_t peri_global_tech_type = (is_tag) ? g_ip->tag_arr_peri_global_tech_type : g_ip->data_arr_peri_global_tech_type;
 
-  technology = technology * 1000.0;  // in the unit of nm
+  technology  = technology * 1000.0;  // in the unit of nm
 
   // initialize parameters
   g_tp.reset();
   double gmp_to_gmn_multiplier_periph_global = 0;
 
   double curr_Wmemcella_dram, curr_Wmemcellpmos_dram, curr_Wmemcellnmos_dram,
-      curr_area_cell_dram, curr_asp_ratio_cell_dram, curr_Wmemcella_sram,
-      curr_Wmemcellpmos_sram, curr_Wmemcellnmos_sram, curr_area_cell_sram,
-      curr_asp_ratio_cell_sram, curr_I_off_dram_cell_worst_case_length_temp;
-  double curr_Wmemcella_cam, curr_Wmemcellpmos_cam, curr_Wmemcellnmos_cam,
-      curr_area_cell_cam,  // Sheng: CAM data
-      curr_asp_ratio_cell_cam;
-  double SENSE_AMP_D, SENSE_AMP_P;  // J
+         curr_area_cell_dram, curr_asp_ratio_cell_dram, curr_Wmemcella_sram,
+         curr_Wmemcellpmos_sram, curr_Wmemcellnmos_sram, curr_area_cell_sram,
+         curr_asp_ratio_cell_sram, curr_I_off_dram_cell_worst_case_length_temp;
+  double curr_Wmemcella_cam, curr_Wmemcellpmos_cam, curr_Wmemcellnmos_cam, curr_area_cell_cam,//Sheng: CAM data
+         curr_asp_ratio_cell_cam;
+  double SENSE_AMP_D, SENSE_AMP_P; // J
   double area_cell_dram = 0;
   double asp_ratio_cell_dram = 0;
   double area_cell_sram = 0;
@@ -98,63 +91,77 @@ void init_tech_params(double technology, bool is_tag) {
   double nmos_effective_resistance_multiplier;
   double width_dram_access_transistor;
 
-  double curr_logic_scaling_co_eff =
-      0;  // This is based on the reported numbers of Intel Merom 65nm,
-          // Penryn45nm and IBM cell 90/65/45 date
-  double curr_core_tx_density =
-      0;  // this is density per um^2; 90, ...22nm based on Intel Penryn
+  double curr_logic_scaling_co_eff = 0;//This is based on the reported numbers of Intel Merom 65nm, Penryn45nm and IBM cell 90/65/45 date
+  double curr_core_tx_density = 0;//this is density per um^2; 90, ...22nm based on Intel Penryn
   double curr_chip_layout_overhead = 0;
   double curr_macro_layout_overhead = 0;
   double curr_sckt_co_eff = 0;
 
-  if (technology < 91 && technology > 89) {
+  if (technology < 91 && technology > 89)
+  {
     tech_lo = 90;
     tech_hi = 90;
-  } else if (technology < 66 && technology > 64) {
+  }
+  else if (technology < 66 && technology > 64)
+  {
     tech_lo = 65;
     tech_hi = 65;
-  } else if (technology < 46 && technology > 44) {
+  }
+  else if (technology < 46 && technology > 44)
+  {
     tech_lo = 45;
     tech_hi = 45;
-  } else if (technology < 33 && technology > 31) {
+  }
+  else if (technology < 33 && technology > 31)
+  {
     tech_lo = 32;
     tech_hi = 32;
-  } else if (technology < 23 && technology > 21) {
+  }
+  else if (technology < 23 && technology > 21)
+  {
     tech_lo = 22;
     tech_hi = 22;
-    if (ram_cell_tech_type == 3) {
-      cout << "current version does not support eDRAM technologies at 22nm"
-           << endl;
-      exit(0);
+    if (ram_cell_tech_type == 3)
+    {
+       cout<<"current version does not support eDRAM technologies at 22nm"<<endl;
+       exit(0);
     }
   }
-  //  else if (technology < 17 && technology > 15)
-  //  {
-  //    tech_lo = 16;
-  //    tech_hi = 16;
-  //  }
-  else if (technology < 90 && technology > 65) {
+//  else if (technology < 17 && technology > 15)
+//  {
+//    tech_lo = 16;
+//    tech_hi = 16;
+//  }
+  else if (technology < 90 && technology > 65)
+  {
     tech_lo = 90;
     tech_hi = 65;
-  } else if (technology < 65 && technology > 45) {
+  }
+  else if (technology < 65 && technology > 45)
+  {
     tech_lo = 65;
     tech_hi = 45;
-  } else if (technology < 45 && technology > 32) {
+  }
+  else if (technology < 45 && technology > 32)
+  {
     tech_lo = 45;
     tech_hi = 32;
-  } else if (technology < 32 && technology > 22) {
-    tech_lo = 32;
-    tech_hi = 22;
   }
-  //  else if (technology < 22 && technology > 16)
-  //    {
-  //      tech_lo = 22;
-  //      tech_hi = 16;
-  //    }
-  else {
-    cout << "Invalid technology nodes" << endl;
-    exit(0);
-  }
+  else if (technology < 32 && technology > 22)
+    {
+      tech_lo = 32;
+      tech_hi = 22;
+    }
+//  else if (technology < 22 && technology > 16)
+//    {
+//      tech_lo = 22;
+//      tech_hi = 16;
+//    }
+      else
+    {
+  	  cout<<"Invalid technology nodes"<<endl;
+  	  exit(0);
+    }
 
   double vdd[NUMBER_TECH_FLAVORS];
   double Lphy[NUMBER_TECH_FLAVORS];
@@ -174,59 +181,66 @@ void init_tech_params(double technology, bool is_tag) {
   double n_to_p_eff_curr_drv_ratio[NUMBER_TECH_FLAVORS];
   double I_off_n[NUMBER_TECH_FLAVORS][101];
   double I_g_on_n[NUMBER_TECH_FLAVORS][101];
-  // double I_off_p[NUMBER_TECH_FLAVORS][101];
+  //double I_off_p[NUMBER_TECH_FLAVORS][101];
   double gmp_to_gmn_multiplier[NUMBER_TECH_FLAVORS];
-  // double curr_sckt_co_eff[NUMBER_TECH_FLAVORS];
+  //double curr_sckt_co_eff[NUMBER_TECH_FLAVORS];
   double long_channel_leakage_reduction[NUMBER_TECH_FLAVORS];
 
-  for (iter = 0; iter <= 1; ++iter) {
+  for (iter = 0; iter <= 1; ++iter)
+  {
     // linear interpolation
-    if (iter == 0) {
+    if (iter == 0)
+    {
       tech = tech_lo;
-      if (tech_lo == tech_hi) {
+      if (tech_lo == tech_hi)
+      {
         curr_alpha = 1;
-      } else {
-        curr_alpha = (technology - tech_hi) / (tech_lo - tech_hi);
       }
-    } else {
+      else
+      {
+        curr_alpha = (technology - tech_hi)/(tech_lo - tech_hi);
+      }
+    }
+    else
+    {
       tech = tech_hi;
-      if (tech_lo == tech_hi) {
+      if (tech_lo == tech_hi)
+      {
         break;
-      } else {
-        curr_alpha = (tech_lo - technology) / (tech_lo - tech_hi);
+      }
+      else
+      {
+        curr_alpha = (tech_lo - technology)/(tech_lo - tech_hi);
       }
     }
 
-    if (tech == 90) {
-      SENSE_AMP_D = .28e-9;    // s
-      SENSE_AMP_P = 14.7e-15;  // J
-      // 90nm technology-node. Corresponds to year 2004 in ITRS
-      // ITRS HP device type
-      vdd[0] = 1.2;
-      Lphy[0] = 0.037;     // Lphy is the physical gate-length. micron
-      Lelec[0] = 0.0266;   // Lelec is the electrical gate-length. micron
-      t_ox[0] = 1.2e-3;    // micron
-      v_th[0] = 0.23707;   // V
-      c_ox[0] = 1.79e-14;  // F/micron2
-      mobility_eff[0] = 342.16 * (1e-2 * 1e6 * 1e-2 * 1e6);  // micron2 / Vs
-      Vdsat[0] = 0.128;                                      // V
-      c_g_ideal[0] = 6.64e-16;                               // F/micron
-      c_fringe[0] = 0.08e-15;                                // F/micron
-      c_junc[0] = 1e-15;                                     // F/micron2
-      I_on_n[0] = 1076.9e-6;                                 // A/micron
-      I_on_p[0] = 712.6e-6;                                  // A/micron
-      // Note that nmos_effective_resistance_multiplier,
-      // n_to_p_eff_curr_drv_ratio and gmp_to_gmn_multiplier values are
-      // calculated offline
+    if (tech == 90)
+    {
+      SENSE_AMP_D = .28e-9; // s
+      SENSE_AMP_P = 14.7e-15; // J
+      //90nm technology-node. Corresponds to year 2004 in ITRS
+      //ITRS HP device type
+      vdd[0]   = 1.2;
+      Lphy[0]  = 0.037;//Lphy is the physical gate-length. micron
+      Lelec[0] = 0.0266;//Lelec is the electrical gate-length. micron
+      t_ox[0]  = 1.2e-3;//micron
+      v_th[0]  = 0.23707;//V
+      c_ox[0]  = 1.79e-14;//F/micron2
+      mobility_eff[0] = 342.16 * (1e-2 * 1e6 * 1e-2 * 1e6); //micron2 / Vs
+      Vdsat[0] = 0.128; //V
+      c_g_ideal[0] = 6.64e-16;//F/micron
+      c_fringe[0]  = 0.08e-15;//F/micron
+      c_junc[0] = 1e-15;//F/micron2
+      I_on_n[0] = 1076.9e-6;//A/micron
+      I_on_p[0] = 712.6e-6;//A/micron
+      //Note that nmos_effective_resistance_multiplier, n_to_p_eff_curr_drv_ratio and gmp_to_gmn_multiplier values are calculated offline
       nmos_effective_resistance_multiplier = 1.54;
       n_to_p_eff_curr_drv_ratio[0] = 2.45;
       gmp_to_gmn_multiplier[0] = 1.22;
-      Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] /
-                       I_on_n[0];  // ohm-micron
-      Rpchannelon[0] =
-          n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];  // ohm-micron
+      Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] / I_on_n[0];//ohm-micron
+      Rpchannelon[0] = n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];//ohm-micron
       long_channel_leakage_reduction[0] = 1;
-      I_off_n[0][0] = 3.24e-8;  // A/micron
+      I_off_n[0][0]  = 3.24e-8;//A/micron
       I_off_n[0][10] = 4.01e-8;
       I_off_n[0][20] = 4.90e-8;
       I_off_n[0][30] = 5.92e-8;
@@ -238,7 +252,7 @@ void init_tech_params(double technology, bool is_tag) {
       I_off_n[0][90] = 1.43e-7;
       I_off_n[0][100] = 1.54e-7;
 
-      I_g_on_n[0][0] = 1.65e-8;  // A/micron
+      I_g_on_n[0][0]  = 1.65e-8;//A/micron
       I_g_on_n[0][10] = 1.65e-8;
       I_g_on_n[0][20] = 1.65e-8;
       I_g_on_n[0][30] = 1.65e-8;
@@ -250,28 +264,27 @@ void init_tech_params(double technology, bool is_tag) {
       I_g_on_n[0][90] = 1.65e-8;
       I_g_on_n[0][100] = 1.65e-8;
 
-      // ITRS LSTP device type
-      vdd[1] = 1.3;
-      Lphy[1] = 0.075;
+      //ITRS LSTP device type
+      vdd[1]   = 1.3;
+      Lphy[1]  = 0.075;
       Lelec[1] = 0.0486;
-      t_ox[1] = 2.2e-3;
-      v_th[1] = 0.48203;
-      c_ox[1] = 1.22e-14;
+      t_ox[1]  = 2.2e-3;
+      v_th[1]  = 0.48203;
+      c_ox[1]  = 1.22e-14;
       mobility_eff[1] = 356.76 * (1e-2 * 1e6 * 1e-2 * 1e6);
       Vdsat[1] = 0.373;
       c_g_ideal[1] = 9.15e-16;
-      c_fringe[1] = 0.08e-15;
+      c_fringe[1]  = 0.08e-15;
       c_junc[1] = 1e-15;
       I_on_n[1] = 503.6e-6;
       I_on_p[1] = 235.1e-6;
       nmos_effective_resistance_multiplier = 1.92;
       n_to_p_eff_curr_drv_ratio[1] = 2.44;
-      gmp_to_gmn_multiplier[1] = 0.88;
-      Rnchannelon[1] =
-          nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];
+      gmp_to_gmn_multiplier[1] =0.88;
+      Rnchannelon[1] = nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];
       Rpchannelon[1] = n_to_p_eff_curr_drv_ratio[1] * Rnchannelon[1];
       long_channel_leakage_reduction[1] = 1;
-      I_off_n[1][0] = 2.81e-12;
+      I_off_n[1][0]  = 2.81e-12;
       I_off_n[1][10] = 4.76e-12;
       I_off_n[1][20] = 7.82e-12;
       I_off_n[1][30] = 1.25e-11;
@@ -283,7 +296,7 @@ void init_tech_params(double technology, bool is_tag) {
       I_off_n[1][90] = 1.25e-10;
       I_off_n[1][100] = 1.7e-10;
 
-      I_g_on_n[1][0] = 3.87e-11;  // A/micron
+      I_g_on_n[1][0]  = 3.87e-11;//A/micron
       I_g_on_n[1][10] = 3.87e-11;
       I_g_on_n[1][20] = 3.87e-11;
       I_g_on_n[1][30] = 3.87e-11;
@@ -295,7 +308,7 @@ void init_tech_params(double technology, bool is_tag) {
       I_g_on_n[1][90] = 3.87e-11;
       I_g_on_n[1][100] = 3.87e-11;
 
-      // ITRS LOP device type
+      //ITRS LOP device type
       vdd[2] = 0.9;
       Lphy[2] = 0.053;
       Lelec[2] = 0.0354;
@@ -312,8 +325,7 @@ void init_tech_params(double technology, bool is_tag) {
       nmos_effective_resistance_multiplier = 1.77;
       n_to_p_eff_curr_drv_ratio[2] = 2.54;
       gmp_to_gmn_multiplier[2] = 0.98;
-      Rnchannelon[2] =
-          nmos_effective_resistance_multiplier * vdd[2] / I_on_n[2];
+      Rnchannelon[2] = nmos_effective_resistance_multiplier * vdd[2] / I_on_n[2];
       Rpchannelon[2] = n_to_p_eff_curr_drv_ratio[2] * Rnchannelon[2];
       long_channel_leakage_reduction[2] = 1;
       I_off_n[2][0] = 2.14e-9;
@@ -328,7 +340,7 @@ void init_tech_params(double technology, bool is_tag) {
       I_off_n[2][90] = 1.52e-8;
       I_off_n[2][100] = 1.73e-8;
 
-      I_g_on_n[2][0] = 4.31e-8;  // A/micron
+      I_g_on_n[2][0]  = 4.31e-8;//A/micron
       I_g_on_n[2][10] = 4.31e-8;
       I_g_on_n[2][20] = 4.31e-8;
       I_g_on_n[2][30] = 4.31e-8;
@@ -340,8 +352,9 @@ void init_tech_params(double technology, bool is_tag) {
       I_g_on_n[2][90] = 4.31e-8;
       I_g_on_n[2][100] = 4.31e-8;
 
-      if (ram_cell_tech_type == lp_dram) {
-        // LP-DRAM cell access transistor technology parameters
+      if (ram_cell_tech_type == lp_dram)
+      {
+        //LP-DRAM cell access transistor technology parameters
         curr_vdd_dram_cell = 1.2;
         Lphy[3] = 0.12;
         Lelec[3] = 0.0756;
@@ -356,12 +369,12 @@ void init_tech_params(double technology, bool is_tag) {
         curr_asp_ratio_cell_dram = 1.46;
         curr_c_dram_cell = 20e-15;
 
-        // LP-DRAM wordline transistor parameters
+        //LP-DRAM wordline transistor parameters
         curr_vpp = 1.6;
         t_ox[3] = 2.2e-3;
         v_th[3] = 0.4545;
         c_ox[3] = 1.22e-14;
-        mobility_eff[3] = 323.95 * (1e-2 * 1e6 * 1e-2 * 1e6);
+        mobility_eff[3] =  323.95 * (1e-2 * 1e6 * 1e-2 * 1e6);
         Vdsat[3] = 0.3;
         c_g_ideal[3] = 1.47e-15;
         c_fringe[3] = 0.08e-15;
@@ -371,8 +384,7 @@ void init_tech_params(double technology, bool is_tag) {
         nmos_effective_resistance_multiplier = 1.65;
         n_to_p_eff_curr_drv_ratio[3] = 1.95;
         gmp_to_gmn_multiplier[3] = 0.90;
-        Rnchannelon[3] =
-            nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
+        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
         Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];
         long_channel_leakage_reduction[3] = 1;
         I_off_n[3][0] = 1.42e-11;
@@ -386,8 +398,10 @@ void init_tech_params(double technology, bool is_tag) {
         I_off_n[3][80] = 2.57e-10;
         I_off_n[3][90] = 3.14e-10;
         I_off_n[3][100] = 3.85e-10;
-      } else if (ram_cell_tech_type == comm_dram) {
-        // COMM-DRAM cell access transistor technology parameters
+      }
+      else if (ram_cell_tech_type == comm_dram)
+      {
+        //COMM-DRAM cell access transistor technology parameters
         curr_vdd_dram_cell = 1.6;
         Lphy[3] = 0.09;
         Lelec[3] = 0.0576;
@@ -398,16 +412,16 @@ void init_tech_params(double technology, bool is_tag) {
         curr_Wmemcella_dram = width_dram_access_transistor;
         curr_Wmemcellpmos_dram = 0;
         curr_Wmemcellnmos_dram = 0;
-        curr_area_cell_dram = 6 * 0.09 * 0.09;
+        curr_area_cell_dram = 6*0.09*0.09;
         curr_asp_ratio_cell_dram = 1.5;
         curr_c_dram_cell = 30e-15;
 
-        // COMM-DRAM wordline transistor parameters
+        //COMM-DRAM wordline transistor parameters
         curr_vpp = 3.7;
         t_ox[3] = 5.5e-3;
         v_th[3] = 1.0;
         c_ox[3] = 5.65e-15;
-        mobility_eff[3] = 302.2 * (1e-2 * 1e6 * 1e-2 * 1e6);
+        mobility_eff[3] =  302.2 * (1e-2 * 1e6 * 1e-2 * 1e6);
         Vdsat[3] = 0.32;
         c_g_ideal[3] = 5.08e-16;
         c_fringe[3] = 0.08e-15;
@@ -417,8 +431,7 @@ void init_tech_params(double technology, bool is_tag) {
         nmos_effective_resistance_multiplier = 1.62;
         n_to_p_eff_curr_drv_ratio[3] = 2.05;
         gmp_to_gmn_multiplier[3] = 0.90;
-        Rnchannelon[3] =
-            nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
+        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
         Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];
         long_channel_leakage_reduction[3] = 1;
         I_off_n[3][0] = 5.80e-15;
@@ -434,129 +447,126 @@ void init_tech_params(double technology, bool is_tag) {
         I_off_n[3][100] = 1.67e-12;
       }
 
-      // SRAM cell properties
+      //SRAM cell properties
       curr_Wmemcella_sram = 1.31 * g_ip->F_sz_um;
       curr_Wmemcellpmos_sram = 1.23 * g_ip->F_sz_um;
       curr_Wmemcellnmos_sram = 2.08 * g_ip->F_sz_um;
       curr_area_cell_sram = 146 * g_ip->F_sz_um * g_ip->F_sz_um;
       curr_asp_ratio_cell_sram = 1.46;
-      // CAM cell properties //TODO: data need to be revisited
+      //CAM cell properties //TODO: data need to be revisited
       curr_Wmemcella_cam = 1.31 * g_ip->F_sz_um;
       curr_Wmemcellpmos_cam = 1.23 * g_ip->F_sz_um;
       curr_Wmemcellnmos_cam = 2.08 * g_ip->F_sz_um;
-      curr_area_cell_cam = 292 * g_ip->F_sz_um * g_ip->F_sz_um;  // 360
-      curr_asp_ratio_cell_cam = 2.92;                            // 2.5
-      // Empirical undifferetiated core/FU coefficient
-      curr_logic_scaling_co_eff = 1;
-      curr_core_tx_density = 1.25 * 0.7 * 0.7;
-      curr_sckt_co_eff = 1.1539;
-      curr_chip_layout_overhead =
-          1.2;  // die measurement results based on Niagara 1 and 2
-      curr_macro_layout_overhead =
-          1.1;  // EDA placement and routing tool rule of thumb
+      curr_area_cell_cam = 292 * g_ip->F_sz_um * g_ip->F_sz_um;//360
+      curr_asp_ratio_cell_cam = 2.92;//2.5
+      //Empirical undifferetiated core/FU coefficient
+      curr_logic_scaling_co_eff  = 1;
+      curr_core_tx_density       = 1.25*0.7*0.7;
+      curr_sckt_co_eff           = 1.1539;
+      curr_chip_layout_overhead  = 1.2;//die measurement results based on Niagara 1 and 2
+      curr_macro_layout_overhead = 1.1;//EDA placement and routing tool rule of thumb
+
+
     }
 
-    if (tech == 65) {  // 65nm technology-node. Corresponds to year 2007 in ITRS
-      // ITRS HP device type
-      //      SENSE_AMP_D = .2e-9; // s
-      //      SENSE_AMP_P = 5.7e-15; // J
-      //      vdd[0] = 1.1;
-      //      Lphy[0] = 0.025;
-      //      Lelec[0] = 0.019;
-      //      t_ox[0] = 1.1e-3;
-      //      v_th[0] = .19491;
-      //      c_ox[0] = 1.88e-14;
-      //      mobility_eff[0] = 436.24 * (1e-2 * 1e6 * 1e-2 * 1e6);
-      //      Vdsat[0] = 7.71e-2;
-      //      c_g_ideal[0] = 4.69e-16;
-      //      c_fringe[0] = 0.077e-15;
-      //      c_junc[0] = 1e-15;
-      //      I_on_n[0] = 1197.2e-6;
-      //      I_on_p[0] = 870.8e-6;
-      //      nmos_effective_resistance_multiplier = 1.50;
-      //      n_to_p_eff_curr_drv_ratio[0] = 2.41;
-      //      gmp_to_gmn_multiplier[0] = 1.38;
-      //      Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] /
-      //      I_on_n[0];
-      //      Rpchannelon[0] = n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];
-      //      long_channel_leakage_reduction[0] = 1/3.74;
-      //      //Using MASTAR, @380K, increase Lgate until Ion reduces to 90% or
-      //      Lgate increase by 10%, whichever comes first
-      //      //Ioff(Lgate normal)/Ioff(Lgate long)= 3.74.
-      //      I_off_n[0][0] = 1.96e-7;
-      //      I_off_n[0][10] = 2.29e-7;
-      //      I_off_n[0][20] = 2.66e-7;
-      //      I_off_n[0][30] = 3.05e-7;
-      //      I_off_n[0][40] = 3.49e-7;
-      //      I_off_n[0][50] = 3.95e-7;
-      //      I_off_n[0][60] = 4.45e-7;
-      //      I_off_n[0][70] = 4.97e-7;
-      //      I_off_n[0][80] = 5.48e-7;
-      //      I_off_n[0][90] = 5.94e-7;
-      //      I_off_n[0][100] = 6.3e-7;
-      //      I_g_on_n[0][0]  = 4.09e-8;//A/micron
-      //      I_g_on_n[0][10] = 4.09e-8;
-      //      I_g_on_n[0][20] = 4.09e-8;
-      //      I_g_on_n[0][30] = 4.09e-8;
-      //      I_g_on_n[0][40] = 4.09e-8;
-      //      I_g_on_n[0][50] = 4.09e-8;
-      //      I_g_on_n[0][60] = 4.09e-8;
-      //      I_g_on_n[0][70] = 4.09e-8;
-      //      I_g_on_n[0][80] = 4.09e-8;
-      //      I_g_on_n[0][90] = 4.09e-8;
-      //      I_g_on_n[0][100] = 4.09e-8;
+    if (tech == 65)
+    { //65nm technology-node. Corresponds to year 2007 in ITRS
+      //ITRS HP device type
+//      SENSE_AMP_D = .2e-9; // s
+//      SENSE_AMP_P = 5.7e-15; // J
+//      vdd[0] = 1.1;
+//      Lphy[0] = 0.025;
+//      Lelec[0] = 0.019;
+//      t_ox[0] = 1.1e-3;
+//      v_th[0] = .19491;
+//      c_ox[0] = 1.88e-14;
+//      mobility_eff[0] = 436.24 * (1e-2 * 1e6 * 1e-2 * 1e6);
+//      Vdsat[0] = 7.71e-2;
+//      c_g_ideal[0] = 4.69e-16;
+//      c_fringe[0] = 0.077e-15;
+//      c_junc[0] = 1e-15;
+//      I_on_n[0] = 1197.2e-6;
+//      I_on_p[0] = 870.8e-6;
+//      nmos_effective_resistance_multiplier = 1.50;
+//      n_to_p_eff_curr_drv_ratio[0] = 2.41;
+//      gmp_to_gmn_multiplier[0] = 1.38;
+//      Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] / I_on_n[0];
+//      Rpchannelon[0] = n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];
+//      long_channel_leakage_reduction[0] = 1/3.74;
+//      //Using MASTAR, @380K, increase Lgate until Ion reduces to 90% or Lgate increase by 10%, whichever comes first
+//      //Ioff(Lgate normal)/Ioff(Lgate long)= 3.74.
+//      I_off_n[0][0] = 1.96e-7;
+//      I_off_n[0][10] = 2.29e-7;
+//      I_off_n[0][20] = 2.66e-7;
+//      I_off_n[0][30] = 3.05e-7;
+//      I_off_n[0][40] = 3.49e-7;
+//      I_off_n[0][50] = 3.95e-7;
+//      I_off_n[0][60] = 4.45e-7;
+//      I_off_n[0][70] = 4.97e-7;
+//      I_off_n[0][80] = 5.48e-7;
+//      I_off_n[0][90] = 5.94e-7;
+//      I_off_n[0][100] = 6.3e-7;
+//      I_g_on_n[0][0]  = 4.09e-8;//A/micron
+//      I_g_on_n[0][10] = 4.09e-8;
+//      I_g_on_n[0][20] = 4.09e-8;
+//      I_g_on_n[0][30] = 4.09e-8;
+//      I_g_on_n[0][40] = 4.09e-8;
+//      I_g_on_n[0][50] = 4.09e-8;
+//      I_g_on_n[0][60] = 4.09e-8;
+//      I_g_on_n[0][70] = 4.09e-8;
+//      I_g_on_n[0][80] = 4.09e-8;
+//      I_g_on_n[0][90] = 4.09e-8;
+//      I_g_on_n[0][100] = 4.09e-8;
 
-      SENSE_AMP_D = .2e-9;    // s
-      SENSE_AMP_P = 5.7e-15;  // J
-      vdd[0] = 1.25;
-      Lphy[0] = 0.025;
-      Lelec[0] = 0.019;
-      t_ox[0] = 1.1e-3;
-      v_th[0] = .12491;
-      c_ox[0] = 1.88e-14;
-      mobility_eff[0] = 409.31 * (1e-2 * 1e6 * 1e-2 * 1e6);
-      Vdsat[0] = 9.08e-2;
-      c_g_ideal[0] = 4.72e-16;
-      c_fringe[0] = 0.08e-15;
-      c_junc[0] = 1e-15;
-      I_on_n[0] = 1486.4e-6;
-      I_on_p[0] = 1131.5e-6;
-      nmos_effective_resistance_multiplier = 1.57;
-      n_to_p_eff_curr_drv_ratio[0] = 2;
-      gmp_to_gmn_multiplier[0] = 1.38;
-      Rnchannelon[0] =
-          nmos_effective_resistance_multiplier * vdd[0] / I_on_n[0];
-      Rpchannelon[0] = n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];
-      long_channel_leakage_reduction[0] = 1.0 / 4.97;
-      // Using MASTAR, @380K, increase Lgate until Ion reduces to 90% or Lgate
-      // increase by 10%, whichever comes first
-      // Ioff(Lgate normal)/Ioff(Lgate long)= 4.97@Vdd=1.25; (3.74@Vdd=1.1),
-      // however, Intel paper suggest the reduction factor is 3.
-      I_off_n[0][0] = 8.62e-7;
-      I_off_n[0][10] = 9.08e-7;
-      I_off_n[0][20] = 9.55e-7;
-      I_off_n[0][30] = 1.00e-6;
-      I_off_n[0][40] = 1.05e-6;
-      I_off_n[0][50] = 1.09e-6;
-      I_off_n[0][60] = 1.14e-6;
-      I_off_n[0][70] = 1.18e-6;
-      I_off_n[0][80] = 1.23e-6;
-      I_off_n[0][90] = 1.27e-6;
-      I_off_n[0][100] = 1.31e-6;
+    	SENSE_AMP_D = .2e-9; // s
+    	SENSE_AMP_P = 5.7e-15; // J
+    	vdd[0] = 1.25;
+    	Lphy[0] = 0.025;
+    	Lelec[0] = 0.019;
+    	t_ox[0] = 1.1e-3;
+    	v_th[0] = .12491;
+    	c_ox[0] = 1.88e-14;
+    	mobility_eff[0] = 409.31 * (1e-2 * 1e6 * 1e-2 * 1e6);
+    	Vdsat[0] = 9.08e-2;
+    	c_g_ideal[0] = 4.72e-16;
+    	c_fringe[0] = 0.08e-15;
+    	c_junc[0] = 1e-15;
+    	I_on_n[0] = 1486.4e-6;
+    	I_on_p[0] = 1131.5e-6;
+    	nmos_effective_resistance_multiplier = 1.57;
+    	n_to_p_eff_curr_drv_ratio[0] = 2;
+    	gmp_to_gmn_multiplier[0] = 1.38;
+    	Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] / I_on_n[0];
+    	Rpchannelon[0] = n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];
+    	long_channel_leakage_reduction[0] = 1.0/4.97;
+    	//Using MASTAR, @380K, increase Lgate until Ion reduces to 90% or Lgate increase by 10%, whichever comes first
+    	//Ioff(Lgate normal)/Ioff(Lgate long)= 4.97@Vdd=1.25; (3.74@Vdd=1.1), however, Intel paper suggest the reduction factor is 3.
+    	I_off_n[0][0]  = 8.62e-7;
+    	I_off_n[0][10] = 9.08e-7;
+    	I_off_n[0][20] = 9.55e-7;
+    	I_off_n[0][30] = 1.00e-6;
+    	I_off_n[0][40] = 1.05e-6;
+    	I_off_n[0][50] = 1.09e-6;
+    	I_off_n[0][60] = 1.14e-6;
+    	I_off_n[0][70] = 1.18e-6;
+    	I_off_n[0][80] = 1.23e-6;
+    	I_off_n[0][90] = 1.27e-6;
+    	I_off_n[0][100] = 1.31e-6;
 
-      I_g_on_n[0][0] = 7.02e-8;  // A/micron
-      I_g_on_n[0][10] = 7.02e-8;
-      I_g_on_n[0][20] = 7.02e-8;
-      I_g_on_n[0][30] = 7.02e-8;
-      I_g_on_n[0][40] = 7.02e-8;
-      I_g_on_n[0][50] = 7.02e-8;
-      I_g_on_n[0][60] = 7.02e-8;
-      I_g_on_n[0][70] = 7.02e-8;
-      I_g_on_n[0][80] = 7.02e-8;
-      I_g_on_n[0][90] = 7.02e-8;
-      I_g_on_n[0][100] = 7.02e-8;
 
-      // ITRS LSTP device type
+    	I_g_on_n[0][0]  = 7.02e-8;//A/micron
+    	I_g_on_n[0][10] = 7.02e-8;
+    	I_g_on_n[0][20] = 7.02e-8;
+    	I_g_on_n[0][30] = 7.02e-8;
+    	I_g_on_n[0][40] = 7.02e-8;
+    	I_g_on_n[0][50] = 7.02e-8;
+    	I_g_on_n[0][60] = 7.02e-8;
+    	I_g_on_n[0][70] = 7.02e-8;
+    	I_g_on_n[0][80] = 7.02e-8;
+    	I_g_on_n[0][90] = 7.02e-8;
+    	I_g_on_n[0][100] = 7.02e-8;
+
+      //ITRS LSTP device type
       vdd[1] = 1.2;
       Lphy[1] = 0.045;
       Lelec[1] = 0.0298;
@@ -573,10 +583,9 @@ void init_tech_params(double technology, bool is_tag) {
       nmos_effective_resistance_multiplier = 1.96;
       n_to_p_eff_curr_drv_ratio[1] = 2.23;
       gmp_to_gmn_multiplier[1] = 0.99;
-      Rnchannelon[1] =
-          nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];
+      Rnchannelon[1] = nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];
       Rpchannelon[1] = n_to_p_eff_curr_drv_ratio[1] * Rnchannelon[1];
-      long_channel_leakage_reduction[1] = 1 / 2.82;
+      long_channel_leakage_reduction[1] = 1/2.82;
       I_off_n[1][0] = 9.12e-12;
       I_off_n[1][10] = 1.49e-11;
       I_off_n[1][20] = 2.36e-11;
@@ -589,7 +598,7 @@ void init_tech_params(double technology, bool is_tag) {
       I_off_n[1][90] = 2.62e-10;
       I_off_n[1][100] = 3.21e-10;
 
-      I_g_on_n[1][0] = 1.09e-10;  // A/micron
+      I_g_on_n[1][0]  = 1.09e-10;//A/micron
       I_g_on_n[1][10] = 1.09e-10;
       I_g_on_n[1][20] = 1.09e-10;
       I_g_on_n[1][30] = 1.09e-10;
@@ -601,7 +610,7 @@ void init_tech_params(double technology, bool is_tag) {
       I_g_on_n[1][90] = 1.09e-10;
       I_g_on_n[1][100] = 1.09e-10;
 
-      // ITRS LOP device type
+      //ITRS LOP device type
       vdd[2] = 0.8;
       Lphy[2] = 0.032;
       Lelec[2] = 0.0216;
@@ -618,10 +627,9 @@ void init_tech_params(double technology, bool is_tag) {
       nmos_effective_resistance_multiplier = 1.82;
       n_to_p_eff_curr_drv_ratio[2] = 2.28;
       gmp_to_gmn_multiplier[2] = 1.11;
-      Rnchannelon[2] =
-          nmos_effective_resistance_multiplier * vdd[2] / I_on_n[2];
+      Rnchannelon[2] = nmos_effective_resistance_multiplier * vdd[2] / I_on_n[2];
       Rpchannelon[2] = n_to_p_eff_curr_drv_ratio[2] * Rnchannelon[2];
-      long_channel_leakage_reduction[2] = 1 / 2.05;
+      long_channel_leakage_reduction[2] = 1/2.05;
       I_off_n[2][0] = 4.9e-9;
       I_off_n[2][10] = 6.49e-9;
       I_off_n[2][20] = 8.45e-9;
@@ -634,7 +642,7 @@ void init_tech_params(double technology, bool is_tag) {
       I_off_n[2][90] = 3.13e-8;
       I_off_n[2][100] = 3.42e-8;
 
-      I_g_on_n[2][0] = 9.61e-9;  // A/micron
+      I_g_on_n[2][0]  = 9.61e-9;//A/micron
       I_g_on_n[2][10] = 9.61e-9;
       I_g_on_n[2][20] = 9.61e-9;
       I_g_on_n[2][30] = 9.61e-9;
@@ -646,8 +654,9 @@ void init_tech_params(double technology, bool is_tag) {
       I_g_on_n[2][90] = 9.61e-9;
       I_g_on_n[2][100] = 9.61e-9;
 
-      if (ram_cell_tech_type == lp_dram) {
-        // LP-DRAM cell access transistor technology parameters
+      if (ram_cell_tech_type == lp_dram)
+      {
+        //LP-DRAM cell access transistor technology parameters
         curr_vdd_dram_cell = 1.2;
         Lphy[3] = 0.12;
         Lelec[3] = 0.0756;
@@ -662,26 +671,25 @@ void init_tech_params(double technology, bool is_tag) {
         curr_asp_ratio_cell_dram = 1.46;
         curr_c_dram_cell = 20e-15;
 
-        // LP-DRAM wordline transistor parameters
+        //LP-DRAM wordline transistor parameters
         curr_vpp = 1.6;
         t_ox[3] = 2.2e-3;
         v_th[3] = 0.43806;
         c_ox[3] = 1.22e-14;
-        mobility_eff[3] = 328.32 * (1e-2 * 1e6 * 1e-2 * 1e6);
+        mobility_eff[3] =  328.32 * (1e-2 * 1e6 * 1e-2 * 1e6);
         Vdsat[3] = 0.43806;
         c_g_ideal[3] = 1.46e-15;
         c_fringe[3] = 0.08e-15;
-        c_junc[3] = 1e-15;
+        c_junc[3] = 1e-15 ;
         I_on_n[3] = 399.8e-6;
         I_on_p[3] = 243.4e-6;
         nmos_effective_resistance_multiplier = 1.65;
         n_to_p_eff_curr_drv_ratio[3] = 2.05;
         gmp_to_gmn_multiplier[3] = 0.90;
-        Rnchannelon[3] =
-            nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
+        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
         Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];
         long_channel_leakage_reduction[3] = 1;
-        I_off_n[3][0] = 2.23e-11;
+        I_off_n[3][0]  = 2.23e-11;
         I_off_n[3][10] = 3.46e-11;
         I_off_n[3][20] = 5.24e-11;
         I_off_n[3][30] = 7.75e-11;
@@ -692,8 +700,10 @@ void init_tech_params(double technology, bool is_tag) {
         I_off_n[3][80] = 3.63e-10;
         I_off_n[3][90] = 4.41e-10;
         I_off_n[3][100] = 5.36e-10;
-      } else if (ram_cell_tech_type == comm_dram) {
-        // COMM-DRAM cell access transistor technology parameters
+      }
+      else if (ram_cell_tech_type == comm_dram)
+      {
+        //COMM-DRAM cell access transistor technology parameters
         curr_vdd_dram_cell = 1.3;
         Lphy[3] = 0.065;
         Lelec[3] = 0.0426;
@@ -704,30 +714,29 @@ void init_tech_params(double technology, bool is_tag) {
         curr_Wmemcella_dram = width_dram_access_transistor;
         curr_Wmemcellpmos_dram = 0;
         curr_Wmemcellnmos_dram = 0;
-        curr_area_cell_dram = 6 * 0.065 * 0.065;
+        curr_area_cell_dram = 6*0.065*0.065;
         curr_asp_ratio_cell_dram = 1.5;
         curr_c_dram_cell = 30e-15;
 
-        // COMM-DRAM wordline transistor parameters
+        //COMM-DRAM wordline transistor parameters
         curr_vpp = 3.3;
         t_ox[3] = 5e-3;
         v_th[3] = 1.0;
         c_ox[3] = 6.16e-15;
-        mobility_eff[3] = 303.44 * (1e-2 * 1e6 * 1e-2 * 1e6);
+        mobility_eff[3] =  303.44 * (1e-2 * 1e6 * 1e-2 * 1e6);
         Vdsat[3] = 0.385;
         c_g_ideal[3] = 4e-16;
         c_fringe[3] = 0.08e-15;
-        c_junc[3] = 1e-15;
+        c_junc[3] = 1e-15 ;
         I_on_n[3] = 1031e-6;
         I_on_p[3] = I_on_n[3] / 2;
         nmos_effective_resistance_multiplier = 1.69;
         n_to_p_eff_curr_drv_ratio[3] = 2.39;
         gmp_to_gmn_multiplier[3] = 0.90;
-        Rnchannelon[3] =
-            nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
+        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
         Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];
         long_channel_leakage_reduction[3] = 1;
-        I_off_n[3][0] = 1.80e-14;
+        I_off_n[3][0]  = 1.80e-14;
         I_off_n[3][10] = 3.64e-14;
         I_off_n[3][20] = 7.03e-14;
         I_off_n[3][30] = 1.31e-13;
@@ -740,32 +749,31 @@ void init_tech_params(double technology, bool is_tag) {
         I_off_n[3][100] = 3.99e-12;
       }
 
-      // SRAM cell properties
+      //SRAM cell properties
       curr_Wmemcella_sram = 1.31 * g_ip->F_sz_um;
       curr_Wmemcellpmos_sram = 1.23 * g_ip->F_sz_um;
       curr_Wmemcellnmos_sram = 2.08 * g_ip->F_sz_um;
       curr_area_cell_sram = 146 * g_ip->F_sz_um * g_ip->F_sz_um;
       curr_asp_ratio_cell_sram = 1.46;
-      // CAM cell properties //TODO: data need to be revisited
+      //CAM cell properties //TODO: data need to be revisited
       curr_Wmemcella_cam = 1.31 * g_ip->F_sz_um;
       curr_Wmemcellpmos_cam = 1.23 * g_ip->F_sz_um;
       curr_Wmemcellnmos_cam = 2.08 * g_ip->F_sz_um;
       curr_area_cell_cam = 292 * g_ip->F_sz_um * g_ip->F_sz_um;
       curr_asp_ratio_cell_cam = 2.92;
-      // Empirical undifferetiated core/FU coefficient
+      //Empirical undifferetiated core/FU coefficient
       curr_logic_scaling_co_eff = 0.7;
-      curr_core_tx_density = 1.25 * 0.7;
-      curr_sckt_co_eff = 1.1359;
-      curr_chip_layout_overhead =
-          1.2;  // die measurement results based on Niagara 1 and 2
-      curr_macro_layout_overhead =
-          1.1;  // EDA placement and routing tool rule of thumb
+      curr_core_tx_density      = 1.25*0.7;
+      curr_sckt_co_eff           = 1.1359;
+      curr_chip_layout_overhead  = 1.2;//die measurement results based on Niagara 1 and 2
+      curr_macro_layout_overhead = 1.1;//EDA placement and routing tool rule of thumb
     }
 
-    if (tech == 45) {  // 45nm technology-node. Corresponds to year 2010 in ITRS
-      // ITRS HP device type
-      SENSE_AMP_D = .04e-9;   // s
-      SENSE_AMP_P = 2.7e-15;  // J
+    if (tech == 45)
+    { //45nm technology-node. Corresponds to year 2010 in ITRS
+      //ITRS HP device type
+      SENSE_AMP_D = .04e-9; // s
+      SENSE_AMP_P = 2.7e-15; // J
       vdd[0] = 1.0;
       Lphy[0] = 0.018;
       Lelec[0] = 0.01345;
@@ -778,20 +786,15 @@ void init_tech_params(double technology, bool is_tag) {
       c_fringe[0] = 0.05e-15;
       c_junc[0] = 1e-15;
       I_on_n[0] = 2046.6e-6;
-      // There are certain problems with the ITRS PMOS numbers in MASTAR for
-      // 45nm. So we are using 65nm values of
-      // n_to_p_eff_curr_drv_ratio and gmp_to_gmn_multiplier for 45nm
-      I_on_p[0] = I_on_n[0] / 2;  // This value is fixed arbitrarily but I_on_p
-                                  // is not being used in CACTI
+      //There are certain problems with the ITRS PMOS numbers in MASTAR for 45nm. So we are using 65nm values of
+      //n_to_p_eff_curr_drv_ratio and gmp_to_gmn_multiplier for 45nm
+      I_on_p[0] = I_on_n[0] / 2;//This value is fixed arbitrarily but I_on_p is not being used in CACTI
       nmos_effective_resistance_multiplier = 1.51;
       n_to_p_eff_curr_drv_ratio[0] = 2.41;
       gmp_to_gmn_multiplier[0] = 1.38;
-      Rnchannelon[0] =
-          nmos_effective_resistance_multiplier * vdd[0] / I_on_n[0];
+      Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] / I_on_n[0];
       Rpchannelon[0] = n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];
-      long_channel_leakage_reduction[0] =
-          1 / 3.546;  // Using MASTAR, @380K, increase Lgate until Ion reduces
-                      // to 90%, Ioff(Lgate normal)/Ioff(Lgate long)= 3.74
+      long_channel_leakage_reduction[0] = 1/3.546;//Using MASTAR, @380K, increase Lgate until Ion reduces to 90%, Ioff(Lgate normal)/Ioff(Lgate long)= 3.74
       I_off_n[0][0] = 2.8e-7;
       I_off_n[0][10] = 3.28e-7;
       I_off_n[0][20] = 3.81e-7;
@@ -804,7 +807,7 @@ void init_tech_params(double technology, bool is_tag) {
       I_off_n[0][90] = 8.91e-7;
       I_off_n[0][100] = 9.84e-7;
 
-      I_g_on_n[0][0] = 3.59e-8;  // A/micron
+      I_g_on_n[0][0]  = 3.59e-8;//A/micron
       I_g_on_n[0][10] = 3.59e-8;
       I_g_on_n[0][20] = 3.59e-8;
       I_g_on_n[0][30] = 3.59e-8;
@@ -816,14 +819,14 @@ void init_tech_params(double technology, bool is_tag) {
       I_g_on_n[0][90] = 3.59e-8;
       I_g_on_n[0][100] = 3.59e-8;
 
-      // ITRS LSTP device type
+      //ITRS LSTP device type
       vdd[1] = 1.1;
-      Lphy[1] = 0.028;
+      Lphy[1] =  0.028;
       Lelec[1] = 0.0212;
       t_ox[1] = 1.4e-3;
       v_th[1] = 0.50245;
       c_ox[1] = 2.01e-14;
-      mobility_eff[1] = 363.96 * (1e-2 * 1e6 * 1e-2 * 1e6);
+      mobility_eff[1] =  363.96 * (1e-2 * 1e6 * 1e-2 * 1e6);
       Vdsat[1] = 9.12e-2;
       c_g_ideal[1] = 5.18e-16;
       c_fringe[1] = 0.08e-15;
@@ -833,10 +836,9 @@ void init_tech_params(double technology, bool is_tag) {
       nmos_effective_resistance_multiplier = 1.99;
       n_to_p_eff_curr_drv_ratio[1] = 2.23;
       gmp_to_gmn_multiplier[1] = 0.99;
-      Rnchannelon[1] =
-          nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];
+      Rnchannelon[1] = nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];
       Rpchannelon[1] = n_to_p_eff_curr_drv_ratio[1] * Rnchannelon[1];
-      long_channel_leakage_reduction[1] = 1 / 2.08;
+      long_channel_leakage_reduction[1] = 1/2.08;
       I_off_n[1][0] = 1.01e-11;
       I_off_n[1][10] = 1.65e-11;
       I_off_n[1][20] = 2.62e-11;
@@ -849,7 +851,7 @@ void init_tech_params(double technology, bool is_tag) {
       I_off_n[1][90] = 3.29e-10;
       I_off_n[1][100] = 4.1e-10;
 
-      I_g_on_n[1][0] = 9.47e-12;  // A/micron
+      I_g_on_n[1][0]  = 9.47e-12;//A/micron
       I_g_on_n[1][10] = 9.47e-12;
       I_g_on_n[1][20] = 9.47e-12;
       I_g_on_n[1][30] = 9.47e-12;
@@ -861,13 +863,13 @@ void init_tech_params(double technology, bool is_tag) {
       I_g_on_n[1][90] = 9.47e-12;
       I_g_on_n[1][100] = 9.47e-12;
 
-      // ITRS LOP device type
+      //ITRS LOP device type
       vdd[2] = 0.7;
       Lphy[2] = 0.022;
       Lelec[2] = 0.016;
       t_ox[2] = 0.9e-3;
       v_th[2] = 0.22599;
-      c_ox[2] = 2.82e-14;  // F/micron2
+      c_ox[2] = 2.82e-14;//F/micron2
       mobility_eff[2] = 508.9 * (1e-2 * 1e6 * 1e-2 * 1e6);
       Vdsat[2] = 5.71e-2;
       c_g_ideal[2] = 6.2e-16;
@@ -878,10 +880,9 @@ void init_tech_params(double technology, bool is_tag) {
       nmos_effective_resistance_multiplier = 1.76;
       n_to_p_eff_curr_drv_ratio[2] = 2.28;
       gmp_to_gmn_multiplier[2] = 1.11;
-      Rnchannelon[2] =
-          nmos_effective_resistance_multiplier * vdd[2] / I_on_n[2];
+      Rnchannelon[2] = nmos_effective_resistance_multiplier * vdd[2] / I_on_n[2];
       Rpchannelon[2] = n_to_p_eff_curr_drv_ratio[2] * Rnchannelon[2];
-      long_channel_leakage_reduction[2] = 1 / 1.92;
+      long_channel_leakage_reduction[2] = 1/1.92;
       I_off_n[2][0] = 4.03e-9;
       I_off_n[2][10] = 5.02e-9;
       I_off_n[2][20] = 6.18e-9;
@@ -894,7 +895,7 @@ void init_tech_params(double technology, bool is_tag) {
       I_off_n[2][90] = 1.84e-8;
       I_off_n[2][100] = 2.03e-8;
 
-      I_g_on_n[2][0] = 3.24e-8;  // A/micron
+      I_g_on_n[2][0]  = 3.24e-8;//A/micron
       I_g_on_n[2][10] = 4.01e-8;
       I_g_on_n[2][20] = 4.90e-8;
       I_g_on_n[2][30] = 5.92e-8;
@@ -906,29 +907,29 @@ void init_tech_params(double technology, bool is_tag) {
       I_g_on_n[2][90] = 1.43e-7;
       I_g_on_n[2][100] = 1.54e-7;
 
-      if (ram_cell_tech_type == lp_dram) {
-        // LP-DRAM cell access transistor technology parameters
+      if (ram_cell_tech_type == lp_dram)
+      {
+        //LP-DRAM cell access transistor technology parameters
         curr_vdd_dram_cell = 1.1;
         Lphy[3] = 0.078;
-        Lelec[3] = 0.0504;  // Assume Lelec is 30% lesser than Lphy for DRAM
-                            // access and wordline transistors.
+        Lelec[3] = 0.0504;// Assume Lelec is 30% lesser than Lphy for DRAM access and wordline transistors.
         curr_v_th_dram_access_transistor = 0.44559;
         width_dram_access_transistor = 0.079;
-        curr_I_on_dram_cell = 36e-6;  // A
+        curr_I_on_dram_cell = 36e-6;//A
         curr_I_off_dram_cell_worst_case_length_temp = 19.5e-12;
         curr_Wmemcella_dram = width_dram_access_transistor;
         curr_Wmemcellpmos_dram = 0;
-        curr_Wmemcellnmos_dram = 0;
+        curr_Wmemcellnmos_dram  = 0;
         curr_area_cell_dram = width_dram_access_transistor * Lphy[3] * 10.0;
         curr_asp_ratio_cell_dram = 1.46;
         curr_c_dram_cell = 20e-15;
 
-        // LP-DRAM wordline transistor parameters
+        //LP-DRAM wordline transistor parameters
         curr_vpp = 1.5;
         t_ox[3] = 2.1e-3;
         v_th[3] = 0.44559;
         c_ox[3] = 1.41e-14;
-        mobility_eff[3] = 426.30 * (1e-2 * 1e6 * 1e-2 * 1e6);
+        mobility_eff[3] =   426.30 * (1e-2 * 1e6 * 1e-2 * 1e6);
         Vdsat[3] = 0.181;
         c_g_ideal[3] = 1.10e-15;
         c_fringe[3] = 0.08e-15;
@@ -938,8 +939,7 @@ void init_tech_params(double technology, bool is_tag) {
         nmos_effective_resistance_multiplier = 1.65;
         n_to_p_eff_curr_drv_ratio[3] = 2.05;
         gmp_to_gmn_multiplier[3] = 0.90;
-        Rnchannelon[3] =
-            nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
+        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
         Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];
         long_channel_leakage_reduction[3] = 1;
         I_off_n[3][0] = 2.54e-11;
@@ -953,23 +953,25 @@ void init_tech_params(double technology, bool is_tag) {
         I_off_n[3][80] = 4.26e-10;
         I_off_n[3][90] = 5.27e-10;
         I_off_n[3][100] = 6.46e-10;
-      } else if (ram_cell_tech_type == comm_dram) {
-        // COMM-DRAM cell access transistor technology parameters
+      }
+      else if (ram_cell_tech_type == comm_dram)
+      {
+        //COMM-DRAM cell access transistor technology parameters
         curr_vdd_dram_cell = 1.1;
         Lphy[3] = 0.045;
         Lelec[3] = 0.0298;
         curr_v_th_dram_access_transistor = 1;
         width_dram_access_transistor = 0.045;
-        curr_I_on_dram_cell = 20e-6;  // A
+        curr_I_on_dram_cell = 20e-6;//A
         curr_I_off_dram_cell_worst_case_length_temp = 1e-15;
         curr_Wmemcella_dram = width_dram_access_transistor;
         curr_Wmemcellpmos_dram = 0;
-        curr_Wmemcellnmos_dram = 0;
-        curr_area_cell_dram = 6 * 0.045 * 0.045;
+        curr_Wmemcellnmos_dram  = 0;
+        curr_area_cell_dram = 6*0.045*0.045;
         curr_asp_ratio_cell_dram = 1.5;
         curr_c_dram_cell = 30e-15;
 
-        // COMM-DRAM wordline transistor parameters
+        //COMM-DRAM wordline transistor parameters
         curr_vpp = 2.7;
         t_ox[3] = 4e-3;
         v_th[3] = 1.0;
@@ -984,8 +986,7 @@ void init_tech_params(double technology, bool is_tag) {
         nmos_effective_resistance_multiplier = 1.69;
         n_to_p_eff_curr_drv_ratio[3] = 1.95;
         gmp_to_gmn_multiplier[3] = 0.90;
-        Rnchannelon[3] =
-            nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
+        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
         Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];
         long_channel_leakage_reduction[3] = 1;
         I_off_n[3][0] = 1.31e-14;
@@ -1001,35 +1002,34 @@ void init_tech_params(double technology, bool is_tag) {
         I_off_n[3][100] = 3.29e-12;
       }
 
-      // SRAM cell properties
+
+      //SRAM cell properties
       curr_Wmemcella_sram = 1.31 * g_ip->F_sz_um;
       curr_Wmemcellpmos_sram = 1.23 * g_ip->F_sz_um;
       curr_Wmemcellnmos_sram = 2.08 * g_ip->F_sz_um;
       curr_area_cell_sram = 146 * g_ip->F_sz_um * g_ip->F_sz_um;
       curr_asp_ratio_cell_sram = 1.46;
-      // CAM cell properties //TODO: data need to be revisited
+      //CAM cell properties //TODO: data need to be revisited
       curr_Wmemcella_cam = 1.31 * g_ip->F_sz_um;
       curr_Wmemcellpmos_cam = 1.23 * g_ip->F_sz_um;
       curr_Wmemcellnmos_cam = 2.08 * g_ip->F_sz_um;
       curr_area_cell_cam = 292 * g_ip->F_sz_um * g_ip->F_sz_um;
       curr_asp_ratio_cell_cam = 2.92;
-      // Empirical undifferetiated core/FU coefficient
-      curr_logic_scaling_co_eff = 0.7 * 0.7;
-      curr_core_tx_density = 1.25;
-      curr_sckt_co_eff = 1.1387;
-      curr_chip_layout_overhead =
-          1.2;  // die measurement results based on Niagara 1 and 2
-      curr_macro_layout_overhead =
-          1.1;  // EDA placement and routing tool rule of thumb
+      //Empirical undifferetiated core/FU coefficient
+      curr_logic_scaling_co_eff = 0.7*0.7;
+      curr_core_tx_density      = 1.25;
+      curr_sckt_co_eff           = 1.1387;
+      curr_chip_layout_overhead  = 1.2;//die measurement results based on Niagara 1 and 2
+      curr_macro_layout_overhead = 1.1;//EDA placement and routing tool rule of thumb
     }
 
-    if (tech == 32) {
-      SENSE_AMP_D = .03e-9;    // s
-      SENSE_AMP_P = 2.16e-15;  // J
-      // For 2013, MPU/ASIC stagger-contacted M1 half-pitch is 32 nm (so this is
-      // 32 nm
-      // technology i.e. FEATURESIZE = 0.032). Using the SOI process numbers for
-      // HP and LSTP.
+    if (tech == 32)
+    {
+      SENSE_AMP_D = .03e-9; // s
+      SENSE_AMP_P = 2.16e-15; // J
+      //For 2013, MPU/ASIC stagger-contacted M1 half-pitch is 32 nm (so this is 32 nm
+      //technology i.e. FEATURESIZE = 0.032). Using the SOI process numbers for
+      //HP and LSTP.
       vdd[0] = 0.9;
       Lphy[0] = 0.013;
       Lelec[0] = 0.01013;
@@ -1041,20 +1041,16 @@ void init_tech_params(double technology, bool is_tag) {
       c_g_ideal[0] = 5.34e-16;
       c_fringe[0] = 0.04e-15;
       c_junc[0] = 1e-15;
-      I_on_n[0] = 2211.7e-6;
+      I_on_n[0] =  2211.7e-6;
       I_on_p[0] = I_on_n[0] / 2;
       nmos_effective_resistance_multiplier = 1.49;
       n_to_p_eff_curr_drv_ratio[0] = 2.41;
       gmp_to_gmn_multiplier[0] = 1.38;
-      Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] /
-                       I_on_n[0];  // ohm-micron
-      Rpchannelon[0] =
-          n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];  // ohm-micron
-      long_channel_leakage_reduction[0] = 1 / 3.706;
-      // Using MASTAR, @300K (380K does not work in MASTAR), increase Lgate
-      // until Ion reduces to 95% or Lgate increase by 5% (DG device can only
-      // increase by 5%),
-      // whichever comes first
+      Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] / I_on_n[0];//ohm-micron
+      Rpchannelon[0] = n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];//ohm-micron
+      long_channel_leakage_reduction[0] = 1/3.706;
+      //Using MASTAR, @300K (380K does not work in MASTAR), increase Lgate until Ion reduces to 95% or Lgate increase by 5% (DG device can only increase by 5%),
+      //whichever comes first
       I_off_n[0][0] = 1.52e-7;
       I_off_n[0][10] = 1.55e-7;
       I_off_n[0][20] = 1.59e-7;
@@ -1067,7 +1063,7 @@ void init_tech_params(double technology, bool is_tag) {
       I_off_n[0][90] = 2.73e-6;
       I_off_n[0][100] = 6.1e-6;
 
-      I_g_on_n[0][0] = 6.55e-8;  // A/micron
+      I_g_on_n[0][0]  = 6.55e-8;//A/micron
       I_g_on_n[0][10] = 6.55e-8;
       I_g_on_n[0][20] = 6.55e-8;
       I_g_on_n[0][30] = 6.55e-8;
@@ -1079,27 +1075,27 @@ void init_tech_params(double technology, bool is_tag) {
       I_g_on_n[0][90] = 6.55e-8;
       I_g_on_n[0][100] = 6.55e-8;
 
-      //      32 DG
-      //      I_g_on_n[0][0]  = 2.71e-9;//A/micron
-      //      I_g_on_n[0][10] = 2.71e-9;
-      //      I_g_on_n[0][20] = 2.71e-9;
-      //      I_g_on_n[0][30] = 2.71e-9;
-      //      I_g_on_n[0][40] = 2.71e-9;
-      //      I_g_on_n[0][50] = 2.71e-9;
-      //      I_g_on_n[0][60] = 2.71e-9;
-      //      I_g_on_n[0][70] = 2.71e-9;
-      //      I_g_on_n[0][80] = 2.71e-9;
-      //      I_g_on_n[0][90] = 2.71e-9;
-      //      I_g_on_n[0][100] = 2.71e-9;
+//      32 DG
+//      I_g_on_n[0][0]  = 2.71e-9;//A/micron
+//      I_g_on_n[0][10] = 2.71e-9;
+//      I_g_on_n[0][20] = 2.71e-9;
+//      I_g_on_n[0][30] = 2.71e-9;
+//      I_g_on_n[0][40] = 2.71e-9;
+//      I_g_on_n[0][50] = 2.71e-9;
+//      I_g_on_n[0][60] = 2.71e-9;
+//      I_g_on_n[0][70] = 2.71e-9;
+//      I_g_on_n[0][80] = 2.71e-9;
+//      I_g_on_n[0][90] = 2.71e-9;
+//      I_g_on_n[0][100] = 2.71e-9;
 
-      // LSTP device type
+      //LSTP device type
       vdd[1] = 1;
       Lphy[1] = 0.020;
       Lelec[1] = 0.0173;
       t_ox[1] = 1.2e-3;
       v_th[1] = 0.513;
       c_ox[1] = 2.29e-14;
-      mobility_eff[1] = 347.46 * (1e-2 * 1e6 * 1e-2 * 1e6);
+      mobility_eff[1] =  347.46 * (1e-2 * 1e6 * 1e-2 * 1e6);
       Vdsat[1] = 8.64e-2;
       c_g_ideal[1] = 4.58e-16;
       c_fringe[1] = 0.053e-15;
@@ -1109,10 +1105,9 @@ void init_tech_params(double technology, bool is_tag) {
       nmos_effective_resistance_multiplier = 1.99;
       n_to_p_eff_curr_drv_ratio[1] = 2.23;
       gmp_to_gmn_multiplier[1] = 0.99;
-      Rnchannelon[1] =
-          nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];
+      Rnchannelon[1] = nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];
       Rpchannelon[1] = n_to_p_eff_curr_drv_ratio[1] * Rnchannelon[1];
-      long_channel_leakage_reduction[1] = 1 / 1.93;
+      long_channel_leakage_reduction[1] = 1/1.93;
       I_off_n[1][0] = 2.06e-11;
       I_off_n[1][10] = 3.30e-11;
       I_off_n[1][20] = 5.15e-11;
@@ -1125,7 +1120,7 @@ void init_tech_params(double technology, bool is_tag) {
       I_off_n[1][90] = 5.96e-10;
       I_off_n[1][100] = 7.44e-10;
 
-      I_g_on_n[1][0] = 3.73e-11;  // A/micron
+      I_g_on_n[1][0]  = 3.73e-11;//A/micron
       I_g_on_n[1][10] = 3.73e-11;
       I_g_on_n[1][20] = 3.73e-11;
       I_g_on_n[1][30] = 3.73e-11;
@@ -1137,14 +1132,15 @@ void init_tech_params(double technology, bool is_tag) {
       I_g_on_n[1][90] = 3.73e-11;
       I_g_on_n[1][100] = 3.73e-11;
 
-      // LOP device type
+
+      //LOP device type
       vdd[2] = 0.6;
       Lphy[2] = 0.016;
       Lelec[2] = 0.01232;
       t_ox[2] = 0.9e-3;
       v_th[2] = 0.24227;
       c_ox[2] = 2.84e-14;
-      mobility_eff[2] = 513.52 * (1e-2 * 1e6 * 1e-2 * 1e6);
+      mobility_eff[2] =  513.52 * (1e-2 * 1e6 * 1e-2 * 1e6);
       Vdsat[2] = 4.64e-2;
       c_g_ideal[2] = 4.54e-16;
       c_fringe[2] = 0.057e-15;
@@ -1154,10 +1150,9 @@ void init_tech_params(double technology, bool is_tag) {
       nmos_effective_resistance_multiplier = 1.73;
       n_to_p_eff_curr_drv_ratio[2] = 2.28;
       gmp_to_gmn_multiplier[2] = 1.11;
-      Rnchannelon[2] =
-          nmos_effective_resistance_multiplier * vdd[2] / I_on_n[2];
+      Rnchannelon[2] = nmos_effective_resistance_multiplier * vdd[2] / I_on_n[2];
       Rpchannelon[2] = n_to_p_eff_curr_drv_ratio[2] * Rnchannelon[2];
-      long_channel_leakage_reduction[2] = 1 / 1.89;
+      long_channel_leakage_reduction[2] = 1/1.89;
       I_off_n[2][0] = 5.94e-8;
       I_off_n[2][10] = 7.23e-8;
       I_off_n[2][20] = 8.7e-8;
@@ -1170,7 +1165,7 @@ void init_tech_params(double technology, bool is_tag) {
       I_off_n[2][90] = 2.39e-7;
       I_off_n[2][100] = 2.63e-7;
 
-      I_g_on_n[2][0] = 2.93e-9;  // A/micron
+      I_g_on_n[2][0]  = 2.93e-9;//A/micron
       I_g_on_n[2][10] = 2.93e-9;
       I_g_on_n[2][20] = 2.93e-9;
       I_g_on_n[2][30] = 2.93e-9;
@@ -1182,12 +1177,12 @@ void init_tech_params(double technology, bool is_tag) {
       I_g_on_n[2][90] = 2.93e-9;
       I_g_on_n[2][100] = 2.93e-9;
 
-      if (ram_cell_tech_type == lp_dram) {
-        // LP-DRAM cell access transistor technology parameters
+      if (ram_cell_tech_type == lp_dram)
+      {
+        //LP-DRAM cell access transistor technology parameters
         curr_vdd_dram_cell = 1.0;
         Lphy[3] = 0.056;
-        Lelec[3] = 0.0419;  // Assume Lelec is 30% lesser than Lphy for DRAM
-                            // access and wordline transistors.
+        Lelec[3] = 0.0419;//Assume Lelec is 30% lesser than Lphy for DRAM access and wordline transistors.
         curr_v_th_dram_access_transistor = 0.44129;
         width_dram_access_transistor = 0.056;
         curr_I_on_dram_cell = 36e-6;
@@ -1199,12 +1194,12 @@ void init_tech_params(double technology, bool is_tag) {
         curr_asp_ratio_cell_dram = 1.46;
         curr_c_dram_cell = 20e-15;
 
-        // LP-DRAM wordline transistor parameters
+        //LP-DRAM wordline transistor parameters
         curr_vpp = 1.5;
         t_ox[3] = 2e-3;
         v_th[3] = 0.44467;
         c_ox[3] = 1.48e-14;
-        mobility_eff[3] = 408.12 * (1e-2 * 1e6 * 1e-2 * 1e6);
+        mobility_eff[3] =  408.12 * (1e-2 * 1e6 * 1e-2 * 1e6);
         Vdsat[3] = 0.174;
         c_g_ideal[3] = 7.45e-16;
         c_fringe[3] = 0.053e-15;
@@ -1214,11 +1209,10 @@ void init_tech_params(double technology, bool is_tag) {
         nmos_effective_resistance_multiplier = 1.65;
         n_to_p_eff_curr_drv_ratio[3] = 2.05;
         gmp_to_gmn_multiplier[3] = 0.90;
-        Rnchannelon[3] =
-            nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
+        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
         Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];
         long_channel_leakage_reduction[3] = 1;
-        I_off_n[3][0] = 3.57e-11;
+        I_off_n[3][0]  = 3.57e-11;
         I_off_n[3][10] = 5.51e-11;
         I_off_n[3][20] = 8.27e-11;
         I_off_n[3][30] = 1.21e-10;
@@ -1229,12 +1223,13 @@ void init_tech_params(double technology, bool is_tag) {
         I_off_n[3][80] = 5.87e-10;
         I_off_n[3][90] = 7.29e-10;
         I_off_n[3][100] = 8.87e-10;
-      } else if (ram_cell_tech_type == comm_dram) {
-        // COMM-DRAM cell access transistor technology parameters
+      }
+      else if (ram_cell_tech_type == comm_dram)
+      {
+        //COMM-DRAM cell access transistor technology parameters
         curr_vdd_dram_cell = 1.0;
         Lphy[3] = 0.032;
-        Lelec[3] = 0.0205;  // Assume Lelec is 30% lesser than Lphy for DRAM
-                            // access and wordline transistors.
+        Lelec[3] = 0.0205;//Assume Lelec is 30% lesser than Lphy for DRAM access and wordline transistors.
         curr_v_th_dram_access_transistor = 1;
         width_dram_access_transistor = 0.032;
         curr_I_on_dram_cell = 20e-6;
@@ -1242,16 +1237,16 @@ void init_tech_params(double technology, bool is_tag) {
         curr_Wmemcella_dram = width_dram_access_transistor;
         curr_Wmemcellpmos_dram = 0;
         curr_Wmemcellnmos_dram = 0;
-        curr_area_cell_dram = 6 * 0.032 * 0.032;
+        curr_area_cell_dram = 6*0.032*0.032;
         curr_asp_ratio_cell_dram = 1.5;
         curr_c_dram_cell = 30e-15;
 
-        // COMM-DRAM wordline transistor parameters
+        //COMM-DRAM wordline transistor parameters
         curr_vpp = 2.6;
         t_ox[3] = 4e-3;
         v_th[3] = 1.0;
         c_ox[3] = 7.99e-15;
-        mobility_eff[3] = 380.76 * (1e-2 * 1e6 * 1e-2 * 1e6);
+        mobility_eff[3] =  380.76 * (1e-2 * 1e6 * 1e-2 * 1e6);
         Vdsat[3] = 0.129;
         c_g_ideal[3] = 2.56e-16;
         c_fringe[3] = 0.053e-15;
@@ -1261,11 +1256,10 @@ void init_tech_params(double technology, bool is_tag) {
         nmos_effective_resistance_multiplier = 1.69;
         n_to_p_eff_curr_drv_ratio[3] = 1.95;
         gmp_to_gmn_multiplier[3] = 0.90;
-        Rnchannelon[3] =
-            nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
+        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp / I_on_n[3];
         Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];
         long_channel_leakage_reduction[3] = 1;
-        I_off_n[3][0] = 3.63e-14;
+        I_off_n[3][0]  = 3.63e-14;
         I_off_n[3][10] = 7.18e-14;
         I_off_n[3][20] = 1.36e-13;
         I_off_n[3][30] = 2.49e-13;
@@ -1278,620 +1272,550 @@ void init_tech_params(double technology, bool is_tag) {
         I_off_n[3][100] = 7.16e-12;
       }
 
-      // SRAM cell properties
-      curr_Wmemcella_sram = 1.31 * g_ip->F_sz_um;
+      //SRAM cell properties
+      curr_Wmemcella_sram    = 1.31 * g_ip->F_sz_um;
       curr_Wmemcellpmos_sram = 1.23 * g_ip->F_sz_um;
       curr_Wmemcellnmos_sram = 2.08 * g_ip->F_sz_um;
-      curr_area_cell_sram = 146 * g_ip->F_sz_um * g_ip->F_sz_um;
+      curr_area_cell_sram    = 146 * g_ip->F_sz_um * g_ip->F_sz_um;
       curr_asp_ratio_cell_sram = 1.46;
-      // CAM cell properties //TODO: data need to be revisited
+      //CAM cell properties //TODO: data need to be revisited
       curr_Wmemcella_cam = 1.31 * g_ip->F_sz_um;
       curr_Wmemcellpmos_cam = 1.23 * g_ip->F_sz_um;
       curr_Wmemcellnmos_cam = 2.08 * g_ip->F_sz_um;
       curr_area_cell_cam = 292 * g_ip->F_sz_um * g_ip->F_sz_um;
       curr_asp_ratio_cell_cam = 2.92;
-      // Empirical undifferetiated core/FU coefficient
-      curr_logic_scaling_co_eff = 0.7 * 0.7 * 0.7;
-      curr_core_tx_density = 1.25 / 0.7;
-      curr_sckt_co_eff = 1.1111;
-      curr_chip_layout_overhead =
-          1.2;  // die measurement results based on Niagara 1 and 2
-      curr_macro_layout_overhead =
-          1.1;  // EDA placement and routing tool rule of thumb
+      //Empirical undifferetiated core/FU coefficient
+      curr_logic_scaling_co_eff = 0.7*0.7*0.7;
+      curr_core_tx_density      = 1.25/0.7;
+      curr_sckt_co_eff           = 1.1111;
+      curr_chip_layout_overhead  = 1.2;//die measurement results based on Niagara 1 and 2
+      curr_macro_layout_overhead = 1.1;//EDA placement and routing tool rule of thumb
     }
 
-    if (tech == 22) {
-      // For 2016, MPU/ASIC stagger-contacted M1 half-pitch is 22 nm (so this is
-      // 22 nm
-      // technology i.e. FEATURESIZE = 0.022). Using the DG process numbers for
-      // HP.
-      // 22 nm HP
-      vdd[0] = 0.8;
-      Lphy[0] = 0.009;     // Lphy is the physical gate-length.
-      Lelec[0] = 0.00468;  // Lelec is the electrical gate-length.
-      t_ox[0] = 0.55e-3;   // micron
-      v_th[0] = 0.1395;    // V
-      c_ox[0] = 3.63e-14;  // F/micron2
-      mobility_eff[0] = 426.07 * (1e-2 * 1e6 * 1e-2 * 1e6);  // micron2 / Vs
-      Vdsat[0] = 2.33e-2;                                    // V/micron
-      c_g_ideal[0] = 3.27e-16;                               // F/micron
-      c_fringe[0] = 0.06e-15;                                // F/micron
-      c_junc[0] = 0;                                         // F/micron2
-      I_on_n[0] = 2626.4e-6;                                 // A/micron
-      I_on_p[0] = I_on_n[0] /
-                  2;  // A/micron //This value for I_on_p is not really used.
-      nmos_effective_resistance_multiplier = 1.45;
-      n_to_p_eff_curr_drv_ratio[0] =
-          2;  // Wpmos/Wnmos = 2 in 2007 MASTAR. Look in
-      //"Dynamic" tab of Device workspace.
-      gmp_to_gmn_multiplier[0] = 1.38;  // Just using the 32nm SOI value.
-      Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] /
-                       I_on_n[0];  // ohm-micron
-      Rpchannelon[0] =
-          n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];  // ohm-micron
-      long_channel_leakage_reduction[0] = 1 / 3.274;
-      I_off_n[0][0] = 1.52e-7 / 1.5 * 1.2;  // From 22nm, leakage current are
-                                            // directly from ITRS report rather
-                                            // than MASTAR, since MASTAR has
-                                            // serious bugs there.
-      I_off_n[0][10] = 1.55e-7 / 1.5 * 1.2;
-      I_off_n[0][20] = 1.59e-7 / 1.5 * 1.2;
-      I_off_n[0][30] = 1.68e-7 / 1.5 * 1.2;
-      I_off_n[0][40] = 1.90e-7 / 1.5 * 1.2;
-      I_off_n[0][50] = 2.69e-7 / 1.5 * 1.2;
-      I_off_n[0][60] = 5.32e-7 / 1.5 * 1.2;
-      I_off_n[0][70] = 1.02e-6 / 1.5 * 1.2;
-      I_off_n[0][80] = 1.62e-6 / 1.5 * 1.2;
-      I_off_n[0][90] = 2.73e-6 / 1.5 * 1.2;
-      I_off_n[0][100] = 6.1e-6 / 1.5 * 1.2;
-      // for 22nm DG HP
-      I_g_on_n[0][0] = 1.81e-9;  // A/micron
-      I_g_on_n[0][10] = 1.81e-9;
-      I_g_on_n[0][20] = 1.81e-9;
-      I_g_on_n[0][30] = 1.81e-9;
-      I_g_on_n[0][40] = 1.81e-9;
-      I_g_on_n[0][50] = 1.81e-9;
-      I_g_on_n[0][60] = 1.81e-9;
-      I_g_on_n[0][70] = 1.81e-9;
-      I_g_on_n[0][80] = 1.81e-9;
-      I_g_on_n[0][90] = 1.81e-9;
-      I_g_on_n[0][100] = 1.81e-9;
+    if(tech == 22){
+    	//For 2016, MPU/ASIC stagger-contacted M1 half-pitch is 22 nm (so this is 22 nm
+    	//technology i.e. FEATURESIZE = 0.022). Using the DG process numbers for HP.
+    	//22 nm HP
+    	vdd[0] = 0.8;
+    	Lphy[0] = 0.009;//Lphy is the physical gate-length.
+    	Lelec[0] = 0.00468;//Lelec is the electrical gate-length.
+    	t_ox[0] = 0.55e-3;//micron
+    	v_th[0] = 0.1395;//V
+    	c_ox[0] = 3.63e-14;//F/micron2
+    	mobility_eff[0] = 426.07 * (1e-2 * 1e6 * 1e-2 * 1e6); //micron2 / Vs
+    	Vdsat[0] = 2.33e-2; //V/micron
+    	c_g_ideal[0] = 3.27e-16;//F/micron
+    	c_fringe[0] = 0.06e-15;//F/micron
+    	c_junc[0] = 0;//F/micron2
+    	I_on_n[0] =  2626.4e-6;//A/micron
+    	I_on_p[0] = I_on_n[0] / 2;//A/micron //This value for I_on_p is not really used.
+        nmos_effective_resistance_multiplier = 1.45;
+        n_to_p_eff_curr_drv_ratio[0] = 2; //Wpmos/Wnmos = 2 in 2007 MASTAR. Look in
+    	//"Dynamic" tab of Device workspace.
+        gmp_to_gmn_multiplier[0] = 1.38; //Just using the 32nm SOI value.
+        Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] / I_on_n[0];//ohm-micron
+        Rpchannelon[0] = n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];//ohm-micron
+        long_channel_leakage_reduction[0] = 1/3.274;
+        I_off_n[0][0] = 1.52e-7/1.5*1.2;//From 22nm, leakage current are directly from ITRS report rather than MASTAR, since MASTAR has serious bugs there.
+        I_off_n[0][10] = 1.55e-7/1.5*1.2;
+        I_off_n[0][20] = 1.59e-7/1.5*1.2;
+        I_off_n[0][30] = 1.68e-7/1.5*1.2;
+        I_off_n[0][40] = 1.90e-7/1.5*1.2;
+        I_off_n[0][50] = 2.69e-7/1.5*1.2;
+        I_off_n[0][60] = 5.32e-7/1.5*1.2;
+        I_off_n[0][70] = 1.02e-6/1.5*1.2;
+        I_off_n[0][80] = 1.62e-6/1.5*1.2;
+        I_off_n[0][90] = 2.73e-6/1.5*1.2;
+        I_off_n[0][100] = 6.1e-6/1.5*1.2;
+        //for 22nm DG HP
+        I_g_on_n[0][0]  = 1.81e-9;//A/micron
+        I_g_on_n[0][10] = 1.81e-9;
+        I_g_on_n[0][20] = 1.81e-9;
+        I_g_on_n[0][30] = 1.81e-9;
+        I_g_on_n[0][40] = 1.81e-9;
+        I_g_on_n[0][50] = 1.81e-9;
+        I_g_on_n[0][60] = 1.81e-9;
+        I_g_on_n[0][70] = 1.81e-9;
+        I_g_on_n[0][80] = 1.81e-9;
+        I_g_on_n[0][90] = 1.81e-9;
+        I_g_on_n[0][100] = 1.81e-9;
 
-      // 22 nm LSTP DG
-      vdd[1] = 0.8;
-      Lphy[1] = 0.014;
-      Lelec[1] = 0.008;    // Lelec is the electrical gate-length.
-      t_ox[1] = 1.1e-3;    // micron
-      v_th[1] = 0.40126;   // V
-      c_ox[1] = 2.30e-14;  // F/micron2
-      mobility_eff[1] = 738.09 * (1e-2 * 1e6 * 1e-2 * 1e6);  // micron2 / Vs
-      Vdsat[1] = 6.64e-2;                                    // V/micron
-      c_g_ideal[1] = 3.22e-16;                               // F/micron
-      c_fringe[1] = 0.08e-15;
-      c_junc[1] = 0;         // F/micron2
-      I_on_n[1] = 727.6e-6;  // A/micron
-      I_on_p[1] = I_on_n[1] / 2;
-      nmos_effective_resistance_multiplier = 1.99;
-      n_to_p_eff_curr_drv_ratio[1] = 2;
-      gmp_to_gmn_multiplier[1] = 0.99;
-      Rnchannelon[1] = nmos_effective_resistance_multiplier * vdd[1] /
-                       I_on_n[1];  // ohm-micron
-      Rpchannelon[1] =
-          n_to_p_eff_curr_drv_ratio[1] * Rnchannelon[1];  // ohm-micron
-      long_channel_leakage_reduction[1] = 1 / 1.89;
-      I_off_n[1][0] = 2.43e-11;
-      I_off_n[1][10] = 4.85e-11;
-      I_off_n[1][20] = 9.68e-11;
-      I_off_n[1][30] = 1.94e-10;
-      I_off_n[1][40] = 3.87e-10;
-      I_off_n[1][50] = 7.73e-10;
-      I_off_n[1][60] = 3.55e-10;
-      I_off_n[1][70] = 3.09e-9;
-      I_off_n[1][80] = 6.19e-9;
-      I_off_n[1][90] = 1.24e-8;
-      I_off_n[1][100] = 2.48e-8;
+    	//22 nm LSTP DG
+    	vdd[1] = 0.8;
+    	Lphy[1] = 0.014;
+    	Lelec[1] = 0.008;//Lelec is the electrical gate-length.
+    	t_ox[1] = 1.1e-3;//micron
+    	v_th[1] = 0.40126;//V
+    	c_ox[1] = 2.30e-14;//F/micron2
+    	mobility_eff[1] =  738.09 * (1e-2 * 1e6 * 1e-2 * 1e6); //micron2 / Vs
+    	Vdsat[1] = 6.64e-2; //V/micron
+    	c_g_ideal[1] = 3.22e-16;//F/micron
+    	c_fringe[1] = 0.08e-15;
+    	c_junc[1] = 0;//F/micron2
+    	I_on_n[1] = 727.6e-6;//A/micron
+    	I_on_p[1] = I_on_n[1] / 2;
+    	nmos_effective_resistance_multiplier = 1.99;
+    	n_to_p_eff_curr_drv_ratio[1] = 2;
+    	gmp_to_gmn_multiplier[1] = 0.99;
+    	Rnchannelon[1] = nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];//ohm-micron
+    	Rpchannelon[1] = n_to_p_eff_curr_drv_ratio[1] * Rnchannelon[1];//ohm-micron
+    	long_channel_leakage_reduction[1] = 1/1.89;
+    	I_off_n[1][0] = 2.43e-11;
+    	I_off_n[1][10] = 4.85e-11;
+    	I_off_n[1][20] = 9.68e-11;
+    	I_off_n[1][30] = 1.94e-10;
+    	I_off_n[1][40] = 3.87e-10;
+    	I_off_n[1][50] = 7.73e-10;
+    	I_off_n[1][60] = 3.55e-10;
+    	I_off_n[1][70] = 3.09e-9;
+    	I_off_n[1][80] = 6.19e-9;
+    	I_off_n[1][90] = 1.24e-8;
+    	I_off_n[1][100]= 2.48e-8;
 
-      I_g_on_n[1][0] = 4.51e-10;  // A/micron
-      I_g_on_n[1][10] = 4.51e-10;
-      I_g_on_n[1][20] = 4.51e-10;
-      I_g_on_n[1][30] = 4.51e-10;
-      I_g_on_n[1][40] = 4.51e-10;
-      I_g_on_n[1][50] = 4.51e-10;
-      I_g_on_n[1][60] = 4.51e-10;
-      I_g_on_n[1][70] = 4.51e-10;
-      I_g_on_n[1][80] = 4.51e-10;
-      I_g_on_n[1][90] = 4.51e-10;
-      I_g_on_n[1][100] = 4.51e-10;
+    	I_g_on_n[1][0]  = 4.51e-10;//A/micron
+    	I_g_on_n[1][10] = 4.51e-10;
+    	I_g_on_n[1][20] = 4.51e-10;
+    	I_g_on_n[1][30] = 4.51e-10;
+    	I_g_on_n[1][40] = 4.51e-10;
+    	I_g_on_n[1][50] = 4.51e-10;
+    	I_g_on_n[1][60] = 4.51e-10;
+    	I_g_on_n[1][70] = 4.51e-10;
+    	I_g_on_n[1][80] = 4.51e-10;
+    	I_g_on_n[1][90] = 4.51e-10;
+    	I_g_on_n[1][100] = 4.51e-10;
 
-      // 22 nm LOP
-      vdd[2] = 0.6;
-      Lphy[2] = 0.011;
-      Lelec[2] = 0.00604;  // Lelec is the electrical gate-length.
-      t_ox[2] = 0.8e-3;    // micron
-      v_th[2] = 0.2315;    // V
-      c_ox[2] = 2.87e-14;  // F/micron2
-      mobility_eff[2] = 698.37 * (1e-2 * 1e6 * 1e-2 * 1e6);  // micron2 / Vs
-      Vdsat[2] = 1.81e-2;                                    // V/micron
-      c_g_ideal[2] = 3.16e-16;                               // F/micron
-      c_fringe[2] = 0.08e-15;
-      c_junc[2] =
-          0;  // F/micron2 This is Cj0 not Cjunc in MASTAR results->Dynamic Tab
-      I_on_n[2] = 916.1e-6;  // A/micron
-      I_on_p[2] = I_on_n[2] / 2;
-      nmos_effective_resistance_multiplier = 1.73;
-      n_to_p_eff_curr_drv_ratio[2] = 2;
-      gmp_to_gmn_multiplier[2] = 1.11;
-      Rnchannelon[2] = nmos_effective_resistance_multiplier * vdd[2] /
-                       I_on_n[2];  // ohm-micron
-      Rpchannelon[2] =
-          n_to_p_eff_curr_drv_ratio[2] * Rnchannelon[2];  // ohm-micron
-      long_channel_leakage_reduction[2] = 1 / 2.38;
+    	//22 nm LOP
+    	vdd[2] = 0.6;
+    	Lphy[2] = 0.011;
+    	Lelec[2] = 0.00604;//Lelec is the electrical gate-length.
+    	t_ox[2] = 0.8e-3;//micron
+    	v_th[2] = 0.2315;//V
+    	c_ox[2] = 2.87e-14;//F/micron2
+    	mobility_eff[2] =  698.37 * (1e-2 * 1e6 * 1e-2 * 1e6); //micron2 / Vs
+    	Vdsat[2] = 1.81e-2; //V/micron
+    	c_g_ideal[2] = 3.16e-16;//F/micron
+    	c_fringe[2] = 0.08e-15;
+    	c_junc[2] = 0;//F/micron2 This is Cj0 not Cjunc in MASTAR results->Dynamic Tab
+    	I_on_n[2] = 916.1e-6;//A/micron
+    	I_on_p[2] = I_on_n[2] / 2;
+    	nmos_effective_resistance_multiplier = 1.73;
+    	n_to_p_eff_curr_drv_ratio[2] = 2;
+    	gmp_to_gmn_multiplier[2] = 1.11;
+    	Rnchannelon[2] = nmos_effective_resistance_multiplier * vdd[2] / I_on_n[2];//ohm-micron
+    	Rpchannelon[2] = n_to_p_eff_curr_drv_ratio[2] * Rnchannelon[2];//ohm-micron
+    	long_channel_leakage_reduction[2] = 1/2.38;
 
-      I_off_n[2][0] = 1.31e-8;
-      I_off_n[2][10] = 2.60e-8;
-      I_off_n[2][20] = 5.14e-8;
-      I_off_n[2][30] = 1.02e-7;
-      I_off_n[2][40] = 2.02e-7;
-      I_off_n[2][50] = 3.99e-7;
-      I_off_n[2][60] = 7.91e-7;
-      I_off_n[2][70] = 1.09e-6;
-      I_off_n[2][80] = 2.09e-6;
-      I_off_n[2][90] = 4.04e-6;
-      I_off_n[2][100] = 4.48e-6;
+    	I_off_n[2][0] = 1.31e-8;
+    	I_off_n[2][10] = 2.60e-8;
+    	I_off_n[2][20] = 5.14e-8;
+    	I_off_n[2][30] = 1.02e-7;
+    	I_off_n[2][40] = 2.02e-7;
+    	I_off_n[2][50] = 3.99e-7;
+    	I_off_n[2][60] = 7.91e-7;
+    	I_off_n[2][70] = 1.09e-6;
+    	I_off_n[2][80] = 2.09e-6;
+    	I_off_n[2][90] = 4.04e-6;
+    	I_off_n[2][100]= 4.48e-6;
 
-      I_g_on_n[2][0] = 2.74e-9;  // A/micron
-      I_g_on_n[2][10] = 2.74e-9;
-      I_g_on_n[2][20] = 2.74e-9;
-      I_g_on_n[2][30] = 2.74e-9;
-      I_g_on_n[2][40] = 2.74e-9;
-      I_g_on_n[2][50] = 2.74e-9;
-      I_g_on_n[2][60] = 2.74e-9;
-      I_g_on_n[2][70] = 2.74e-9;
-      I_g_on_n[2][80] = 2.74e-9;
-      I_g_on_n[2][90] = 2.74e-9;
-      I_g_on_n[2][100] = 2.74e-9;
+    	I_g_on_n[2][0]  = 2.74e-9;//A/micron
+    	I_g_on_n[2][10] = 2.74e-9;
+    	I_g_on_n[2][20] = 2.74e-9;
+    	I_g_on_n[2][30] = 2.74e-9;
+    	I_g_on_n[2][40] = 2.74e-9;
+    	I_g_on_n[2][50] = 2.74e-9;
+    	I_g_on_n[2][60] = 2.74e-9;
+    	I_g_on_n[2][70] = 2.74e-9;
+    	I_g_on_n[2][80] = 2.74e-9;
+    	I_g_on_n[2][90] = 2.74e-9;
+    	I_g_on_n[2][100] = 2.74e-9;
 
-      if (ram_cell_tech_type == 3) {
-      } else if (ram_cell_tech_type == 4) {
-        // 22 nm commodity DRAM cell access transistor technology parameters.
-        // parameters
-        curr_vdd_dram_cell = 0.9;  // 0.45;//This value has reduced greatly in
-                                   // 2007 ITRS for all technology nodes. In
-        // 2005 ITRS, the value was about twice the value in 2007 ITRS
-        Lphy[3] = 0.022;                       // micron
-        Lelec[3] = 0.0181;                     // micron.
-        curr_v_th_dram_access_transistor = 1;  // V
-        width_dram_access_transistor = 0.022;  // micron
-        curr_I_on_dram_cell =
-            20e-6;  // This is a typical value that I have always
-        // kept constant. In reality this could perhaps be lower
-        curr_I_off_dram_cell_worst_case_length_temp = 1e-15;  // A
-        curr_Wmemcella_dram = width_dram_access_transistor;
-        curr_Wmemcellpmos_dram = 0;
-        curr_Wmemcellnmos_dram = 0;
-        curr_area_cell_dram = 6 * 0.022 * 0.022;  // micron2.
-        curr_asp_ratio_cell_dram = 0.667;
-        curr_c_dram_cell = 30e-15;  // This is a typical value that I have
-                                    // alwaus
-        // kept constant.
 
-        // 22 nm commodity DRAM wordline transistor parameters obtained using
-        // MASTAR.
-        curr_vpp = 2.3;                                        // vpp. V
-        t_ox[3] = 3.5e-3;                                      // micron
-        v_th[3] = 1.0;                                         // V
-        c_ox[3] = 9.06e-15;                                    // F/micron2
-        mobility_eff[3] = 367.29 * (1e-2 * 1e6 * 1e-2 * 1e6);  // micron2 / Vs
-        Vdsat[3] = 0.0972;                                     // V/micron
-        c_g_ideal[3] = 1.99e-16;                               // F/micron
-        c_fringe[3] = 0.053e-15;                               // F/micron
-        c_junc[3] = 1e-15;                                     // F/micron2
-        I_on_n[3] = 910.5e-6;                                  // A/micron
-        I_on_p[3] = I_on_n[3] / 2;  // This value for I_on_p is not really used.
-        nmos_effective_resistance_multiplier =
-            1.69;  // Using the value from 32nm.
-        //
-        n_to_p_eff_curr_drv_ratio[3] = 1.95;  // Using the value from 32nm
-        gmp_to_gmn_multiplier[3] = 0.90;
-        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp /
-                         I_on_n[3];  // ohm-micron
-        Rpchannelon[3] =
-            n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];  // ohm-micron
-        long_channel_leakage_reduction[3] = 1;
-        I_off_n[3][0] = 1.1e-13;  // A/micron
-        I_off_n[3][10] = 2.11e-13;
-        I_off_n[3][20] = 3.88e-13;
-        I_off_n[3][30] = 6.9e-13;
-        I_off_n[3][40] = 1.19e-12;
-        I_off_n[3][50] = 1.98e-12;
-        I_off_n[3][60] = 3.22e-12;
-        I_off_n[3][70] = 5.09e-12;
-        I_off_n[3][80] = 7.85e-12;
-        I_off_n[3][90] = 1.18e-11;
-        I_off_n[3][100] = 1.72e-11;
 
-      } else {
-        // some error handler
-      }
+        if (ram_cell_tech_type == 3)
+              {}
+        else if (ram_cell_tech_type == 4)
+        {
+    	//22 nm commodity DRAM cell access transistor technology parameters.
+    		//parameters
+        	curr_vdd_dram_cell = 0.9;//0.45;//This value has reduced greatly in 2007 ITRS for all technology nodes. In
+    		//2005 ITRS, the value was about twice the value in 2007 ITRS
+    		Lphy[3] = 0.022;//micron
+    		Lelec[3] = 0.0181;//micron.
+    		curr_v_th_dram_access_transistor = 1;//V
+    		width_dram_access_transistor = 0.022;//micron
+    		curr_I_on_dram_cell = 20e-6; //This is a typical value that I have always
+    		//kept constant. In reality this could perhaps be lower
+    		curr_I_off_dram_cell_worst_case_length_temp = 1e-15;//A
+    		curr_Wmemcella_dram = width_dram_access_transistor;
+    		curr_Wmemcellpmos_dram = 0;
+    		curr_Wmemcellnmos_dram = 0;
+    		curr_area_cell_dram = 6*0.022*0.022;//micron2.
+    		curr_asp_ratio_cell_dram = 0.667;
+    		curr_c_dram_cell = 30e-15;//This is a typical value that I have alwaus
+    		//kept constant.
 
-      // SRAM cell properties
-      curr_Wmemcella_sram = 1.31 * g_ip->F_sz_um;
-      curr_Wmemcellpmos_sram = 1.23 * g_ip->F_sz_um;
-      curr_Wmemcellnmos_sram = 2.08 * g_ip->F_sz_um;
-      curr_area_cell_sram = 146 * g_ip->F_sz_um * g_ip->F_sz_um;
-      curr_asp_ratio_cell_sram = 1.46;
-      // CAM cell properties //TODO: data need to be revisited
-      curr_Wmemcella_cam = 1.31 * g_ip->F_sz_um;
-      curr_Wmemcellpmos_cam = 1.23 * g_ip->F_sz_um;
-      curr_Wmemcellnmos_cam = 2.08 * g_ip->F_sz_um;
-      curr_area_cell_cam = 292 * g_ip->F_sz_um * g_ip->F_sz_um;
-      curr_asp_ratio_cell_cam = 2.92;
-      // Empirical undifferetiated core/FU coefficient
-      curr_logic_scaling_co_eff = 0.7 * 0.7 * 0.7 * 0.7;
-      curr_core_tx_density = 1.25 / 0.7 / 0.7;
-      curr_sckt_co_eff = 1.1296;
-      curr_chip_layout_overhead =
-          1.2;  // die measurement results based on Niagara 1 and 2
-      curr_macro_layout_overhead =
-          1.1;  // EDA placement and routing tool rule of thumb
-    }
+    	//22 nm commodity DRAM wordline transistor parameters obtained using MASTAR.
+    		curr_vpp = 2.3;//vpp. V
+    		t_ox[3] = 3.5e-3;//micron
+    		v_th[3] = 1.0;//V
+    		c_ox[3] = 9.06e-15;//F/micron2
+    		mobility_eff[3] =  367.29 * (1e-2 * 1e6 * 1e-2 * 1e6);//micron2 / Vs
+    		Vdsat[3] = 0.0972; //V/micron
+    		c_g_ideal[3] = 1.99e-16;//F/micron
+    		c_fringe[3] = 0.053e-15;//F/micron
+    		c_junc[3] = 1e-15;//F/micron2
+    		I_on_n[3] = 910.5e-6;//A/micron
+    		I_on_p[3] = I_on_n[3] / 2;//This value for I_on_p is not really used.
+    		nmos_effective_resistance_multiplier = 1.69;//Using the value from 32nm.
+    		//
+    		n_to_p_eff_curr_drv_ratio[3] = 1.95;//Using the value from 32nm
+    		gmp_to_gmn_multiplier[3] = 0.90;
+    		Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp  / I_on_n[3];//ohm-micron
+    		Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];//ohm-micron
+    		long_channel_leakage_reduction[3] = 1;
+    		I_off_n[3][0] = 1.1e-13; //A/micron
+    		I_off_n[3][10] = 2.11e-13;
+    		I_off_n[3][20] = 3.88e-13;
+    		I_off_n[3][30] = 6.9e-13;
+    		I_off_n[3][40] = 1.19e-12;
+    		I_off_n[3][50] = 1.98e-12;
+    		I_off_n[3][60] = 3.22e-12;
+    		I_off_n[3][70] = 5.09e-12;
+    		I_off_n[3][80] = 7.85e-12;
+    		I_off_n[3][90] = 1.18e-11;
+    		I_off_n[3][100] = 1.72e-11;
 
-    if (tech == 16) {
-      // For 2019, MPU/ASIC stagger-contacted M1 half-pitch is 16 nm (so this is
-      // 16 nm
-      // technology i.e. FEATURESIZE = 0.016). Using the DG process numbers for
-      // HP.
-      // 16 nm HP
-      vdd[0] = 0.7;
-      Lphy[0] = 0.006;     // Lphy is the physical gate-length.
-      Lelec[0] = 0.00315;  // Lelec is the electrical gate-length.
-      t_ox[0] = 0.5e-3;    // micron
-      v_th[0] = 0.1489;    // V
-      c_ox[0] = 3.83e-14;  // F/micron2 Cox_elec in MASTAR
-      mobility_eff[0] = 476.15 * (1e-2 * 1e6 * 1e-2 * 1e6);  // micron2 / Vs
-      Vdsat[0] = 1.42e-2;       // V/micron calculated in spreadsheet
-      c_g_ideal[0] = 2.30e-16;  // F/micron
-      c_fringe[0] = 0.06e-15;   // F/micron MASTAR inputdynamic/3
-      c_junc[0] = 0;            // F/micron2 MASTAR result dynamic
-      I_on_n[0] = 2768.4e-6;    // A/micron
-      I_on_p[0] = I_on_n[0] /
-                  2;  // A/micron //This value for I_on_p is not really used.
-      nmos_effective_resistance_multiplier =
-          1.48;  // nmos_effective_resistance_multiplier  is the ratio of Ieff
-                 // to Idsat where Ieff is the effective NMOS current and Idsat
-                 // is the saturation current.
-      n_to_p_eff_curr_drv_ratio[0] =
-          2;  // Wpmos/Wnmos = 2 in 2007 MASTAR. Look in
-      //"Dynamic" tab of Device workspace.
-      gmp_to_gmn_multiplier[0] = 1.38;  // Just using the 32nm SOI value.
-      Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] /
-                       I_on_n[0];  // ohm-micron
-      Rpchannelon[0] =
-          n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];  // ohm-micron
-      long_channel_leakage_reduction[0] = 1 / 2.655;
-      I_off_n[0][0] = 1.52e-7 / 1.5 * 1.2 * 1.07;
-      I_off_n[0][10] = 1.55e-7 / 1.5 * 1.2 * 1.07;
-      I_off_n[0][20] = 1.59e-7 / 1.5 * 1.2 * 1.07;
-      I_off_n[0][30] = 1.68e-7 / 1.5 * 1.2 * 1.07;
-      I_off_n[0][40] = 1.90e-7 / 1.5 * 1.2 * 1.07;
-      I_off_n[0][50] = 2.69e-7 / 1.5 * 1.2 * 1.07;
-      I_off_n[0][60] = 5.32e-7 / 1.5 * 1.2 * 1.07;
-      I_off_n[0][70] = 1.02e-6 / 1.5 * 1.2 * 1.07;
-      I_off_n[0][80] = 1.62e-6 / 1.5 * 1.2 * 1.07;
-      I_off_n[0][90] = 2.73e-6 / 1.5 * 1.2 * 1.07;
-      I_off_n[0][100] = 6.1e-6 / 1.5 * 1.2 * 1.07;
-      // for 16nm DG HP
-      I_g_on_n[0][0] = 1.07e-9;  // A/micron
-      I_g_on_n[0][10] = 1.07e-9;
-      I_g_on_n[0][20] = 1.07e-9;
-      I_g_on_n[0][30] = 1.07e-9;
-      I_g_on_n[0][40] = 1.07e-9;
-      I_g_on_n[0][50] = 1.07e-9;
-      I_g_on_n[0][60] = 1.07e-9;
-      I_g_on_n[0][70] = 1.07e-9;
-      I_g_on_n[0][80] = 1.07e-9;
-      I_g_on_n[0][90] = 1.07e-9;
-      I_g_on_n[0][100] = 1.07e-9;
+    	}
+        else
+        {
+      	  //some error handler
+        }
 
-      //    	//16 nm LSTP DG
-      //    	vdd[1] = 0.8;
-      //    	Lphy[1] = 0.014;
-      //    	Lelec[1] = 0.008;//Lelec is the electrical gate-length.
-      //    	t_ox[1] = 1.1e-3;//micron
-      //    	v_th[1] = 0.40126;//V
-      //    	c_ox[1] = 2.30e-14;//F/micron2
-      //    	mobility_eff[1] =  738.09 * (1e-2 * 1e6 * 1e-2 * 1e6); //micron2
-      //    / Vs
-      //    	Vdsat[1] = 6.64e-2; //V/micron
-      //    	c_g_ideal[1] = 3.22e-16;//F/micron
-      //    	c_fringe[1] = 0.008e-15;
-      //    	c_junc[1] = 0;//F/micron2
-      //    	I_on_n[1] = 727.6e-6;//A/micron
-      //    	I_on_p[1] = I_on_n[1] / 2;
-      //    	nmos_effective_resistance_multiplier = 1.99;
-      //    	n_to_p_eff_curr_drv_ratio[1] = 2;
-      //    	gmp_to_gmn_multiplier[1] = 0.99;
-      //    	Rnchannelon[1] = nmos_effective_resistance_multiplier * vdd[1] /
-      //    I_on_n[1];//ohm-micron
-      //    	Rpchannelon[1] = n_to_p_eff_curr_drv_ratio[1] *
-      //    Rnchannelon[1];//ohm-micron
-      //    	I_off_n[1][0] = 2.43e-11;
-      //    	I_off_n[1][10] = 4.85e-11;
-      //    	I_off_n[1][20] = 9.68e-11;
-      //    	I_off_n[1][30] = 1.94e-10;
-      //    	I_off_n[1][40] = 3.87e-10;
-      //    	I_off_n[1][50] = 7.73e-10;
-      //    	I_off_n[1][60] = 3.55e-10;
-      //    	I_off_n[1][70] = 3.09e-9;
-      //    	I_off_n[1][80] = 6.19e-9;
-      //    	I_off_n[1][90] = 1.24e-8;
-      //    	I_off_n[1][100]= 2.48e-8;
-      //
-      //    	//    for 22nm LSTP HP
-      //    	I_g_on_n[1][0]  = 4.51e-10;//A/micron
-      //    	I_g_on_n[1][10] = 4.51e-10;
-      //    	I_g_on_n[1][20] = 4.51e-10;
-      //    	I_g_on_n[1][30] = 4.51e-10;
-      //    	I_g_on_n[1][40] = 4.51e-10;
-      //    	I_g_on_n[1][50] = 4.51e-10;
-      //    	I_g_on_n[1][60] = 4.51e-10;
-      //    	I_g_on_n[1][70] = 4.51e-10;
-      //    	I_g_on_n[1][80] = 4.51e-10;
-      //    	I_g_on_n[1][90] = 4.51e-10;
-      //    	I_g_on_n[1][100] = 4.51e-10;
+        //SRAM cell properties
+        curr_Wmemcella_sram    = 1.31 * g_ip->F_sz_um;
+        curr_Wmemcellpmos_sram = 1.23 * g_ip->F_sz_um;
+        curr_Wmemcellnmos_sram = 2.08 * g_ip->F_sz_um;
+        curr_area_cell_sram    = 146 * g_ip->F_sz_um * g_ip->F_sz_um;
+        curr_asp_ratio_cell_sram = 1.46;
+        //CAM cell properties //TODO: data need to be revisited
+        curr_Wmemcella_cam = 1.31 * g_ip->F_sz_um;
+        curr_Wmemcellpmos_cam = 1.23 * g_ip->F_sz_um;
+        curr_Wmemcellnmos_cam = 2.08 * g_ip->F_sz_um;
+        curr_area_cell_cam = 292 * g_ip->F_sz_um * g_ip->F_sz_um;
+        curr_asp_ratio_cell_cam = 2.92;
+        //Empirical undifferetiated core/FU coefficient
+        curr_logic_scaling_co_eff = 0.7*0.7*0.7*0.7;
+        curr_core_tx_density      = 1.25/0.7/0.7;
+        curr_sckt_co_eff           = 1.1296;
+        curr_chip_layout_overhead  = 1.2;//die measurement results based on Niagara 1 and 2
+        curr_macro_layout_overhead = 1.1;//EDA placement and routing tool rule of thumb
+    	}
 
-      if (ram_cell_tech_type == 3) {
-      } else if (ram_cell_tech_type == 4) {
-        // 22 nm commodity DRAM cell access transistor technology parameters.
-        // parameters
-        curr_vdd_dram_cell = 0.9;  // 0.45;//This value has reduced greatly in
-                                   // 2007 ITRS for all technology nodes. In
-        // 2005 ITRS, the value was about twice the value in 2007 ITRS
-        Lphy[3] = 0.022;                       // micron
-        Lelec[3] = 0.0181;                     // micron.
-        curr_v_th_dram_access_transistor = 1;  // V
-        width_dram_access_transistor = 0.022;  // micron
-        curr_I_on_dram_cell =
-            20e-6;  // This is a typical value that I have always
-        // kept constant. In reality this could perhaps be lower
-        curr_I_off_dram_cell_worst_case_length_temp = 1e-15;  // A
-        curr_Wmemcella_dram = width_dram_access_transistor;
-        curr_Wmemcellpmos_dram = 0;
-        curr_Wmemcellnmos_dram = 0;
-        curr_area_cell_dram = 6 * 0.022 * 0.022;  // micron2.
-        curr_asp_ratio_cell_dram = 0.667;
-        curr_c_dram_cell = 30e-15;  // This is a typical value that I have
-                                    // alwaus
-        // kept constant.
+    if(tech == 16){
+    	//For 2019, MPU/ASIC stagger-contacted M1 half-pitch is 16 nm (so this is 16 nm
+    	//technology i.e. FEATURESIZE = 0.016). Using the DG process numbers for HP.
+    	//16 nm HP
+    	vdd[0] = 0.7;
+    	Lphy[0] = 0.006;//Lphy is the physical gate-length.
+    	Lelec[0] = 0.00315;//Lelec is the electrical gate-length.
+    	t_ox[0] = 0.5e-3;//micron
+    	v_th[0] = 0.1489;//V
+    	c_ox[0] = 3.83e-14;//F/micron2 Cox_elec in MASTAR
+    	mobility_eff[0] = 476.15 * (1e-2 * 1e6 * 1e-2 * 1e6); //micron2 / Vs
+    	Vdsat[0] = 1.42e-2; //V/micron calculated in spreadsheet
+    	c_g_ideal[0] = 2.30e-16;//F/micron
+    	c_fringe[0] = 0.06e-15;//F/micron MASTAR inputdynamic/3
+    	c_junc[0] = 0;//F/micron2 MASTAR result dynamic
+    	I_on_n[0] =  2768.4e-6;//A/micron
+    	I_on_p[0] = I_on_n[0] / 2;//A/micron //This value for I_on_p is not really used.
+        nmos_effective_resistance_multiplier = 1.48;//nmos_effective_resistance_multiplier  is the ratio of Ieff to Idsat where Ieff is the effective NMOS current and Idsat is the saturation current.
+        n_to_p_eff_curr_drv_ratio[0] = 2; //Wpmos/Wnmos = 2 in 2007 MASTAR. Look in
+    	//"Dynamic" tab of Device workspace.
+        gmp_to_gmn_multiplier[0] = 1.38; //Just using the 32nm SOI value.
+        Rnchannelon[0] = nmos_effective_resistance_multiplier * vdd[0] / I_on_n[0];//ohm-micron
+        Rpchannelon[0] = n_to_p_eff_curr_drv_ratio[0] * Rnchannelon[0];//ohm-micron
+        long_channel_leakage_reduction[0] = 1/2.655;
+        I_off_n[0][0] = 1.52e-7/1.5*1.2*1.07;
+        I_off_n[0][10] = 1.55e-7/1.5*1.2*1.07;
+        I_off_n[0][20] = 1.59e-7/1.5*1.2*1.07;
+        I_off_n[0][30] = 1.68e-7/1.5*1.2*1.07;
+        I_off_n[0][40] = 1.90e-7/1.5*1.2*1.07;
+        I_off_n[0][50] = 2.69e-7/1.5*1.2*1.07;
+        I_off_n[0][60] = 5.32e-7/1.5*1.2*1.07;
+        I_off_n[0][70] = 1.02e-6/1.5*1.2*1.07;
+        I_off_n[0][80] = 1.62e-6/1.5*1.2*1.07;
+        I_off_n[0][90] = 2.73e-6/1.5*1.2*1.07;
+        I_off_n[0][100] = 6.1e-6/1.5*1.2*1.07;
+        //for 16nm DG HP
+        I_g_on_n[0][0]  = 1.07e-9;//A/micron
+        I_g_on_n[0][10] = 1.07e-9;
+        I_g_on_n[0][20] = 1.07e-9;
+        I_g_on_n[0][30] = 1.07e-9;
+        I_g_on_n[0][40] = 1.07e-9;
+        I_g_on_n[0][50] = 1.07e-9;
+        I_g_on_n[0][60] = 1.07e-9;
+        I_g_on_n[0][70] = 1.07e-9;
+        I_g_on_n[0][80] = 1.07e-9;
+        I_g_on_n[0][90] = 1.07e-9;
+        I_g_on_n[0][100] = 1.07e-9;
 
-        // 22 nm commodity DRAM wordline transistor parameters obtained using
-        // MASTAR.
-        curr_vpp = 2.3;                                        // vpp. V
-        t_ox[3] = 3.5e-3;                                      // micron
-        v_th[3] = 1.0;                                         // V
-        c_ox[3] = 9.06e-15;                                    // F/micron2
-        mobility_eff[3] = 367.29 * (1e-2 * 1e6 * 1e-2 * 1e6);  // micron2 / Vs
-        Vdsat[3] = 0.0972;                                     // V/micron
-        c_g_ideal[3] = 1.99e-16;                               // F/micron
-        c_fringe[3] = 0.053e-15;                               // F/micron
-        c_junc[3] = 1e-15;                                     // F/micron2
-        I_on_n[3] = 910.5e-6;                                  // A/micron
-        I_on_p[3] = I_on_n[3] / 2;  // This value for I_on_p is not really used.
-        nmos_effective_resistance_multiplier =
-            1.69;  // Using the value from 32nm.
-        //
-        n_to_p_eff_curr_drv_ratio[3] = 1.95;  // Using the value from 32nm
-        gmp_to_gmn_multiplier[3] = 0.90;
-        Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp /
-                         I_on_n[3];  // ohm-micron
-        Rpchannelon[3] =
-            n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];  // ohm-micron
-        long_channel_leakage_reduction[3] = 1;
-        I_off_n[3][0] = 1.1e-13;  // A/micron
-        I_off_n[3][10] = 2.11e-13;
-        I_off_n[3][20] = 3.88e-13;
-        I_off_n[3][30] = 6.9e-13;
-        I_off_n[3][40] = 1.19e-12;
-        I_off_n[3][50] = 1.98e-12;
-        I_off_n[3][60] = 3.22e-12;
-        I_off_n[3][70] = 5.09e-12;
-        I_off_n[3][80] = 7.85e-12;
-        I_off_n[3][90] = 1.18e-11;
-        I_off_n[3][100] = 1.72e-11;
+//    	//16 nm LSTP DG
+//    	vdd[1] = 0.8;
+//    	Lphy[1] = 0.014;
+//    	Lelec[1] = 0.008;//Lelec is the electrical gate-length.
+//    	t_ox[1] = 1.1e-3;//micron
+//    	v_th[1] = 0.40126;//V
+//    	c_ox[1] = 2.30e-14;//F/micron2
+//    	mobility_eff[1] =  738.09 * (1e-2 * 1e6 * 1e-2 * 1e6); //micron2 / Vs
+//    	Vdsat[1] = 6.64e-2; //V/micron
+//    	c_g_ideal[1] = 3.22e-16;//F/micron
+//    	c_fringe[1] = 0.008e-15;
+//    	c_junc[1] = 0;//F/micron2
+//    	I_on_n[1] = 727.6e-6;//A/micron
+//    	I_on_p[1] = I_on_n[1] / 2;
+//    	nmos_effective_resistance_multiplier = 1.99;
+//    	n_to_p_eff_curr_drv_ratio[1] = 2;
+//    	gmp_to_gmn_multiplier[1] = 0.99;
+//    	Rnchannelon[1] = nmos_effective_resistance_multiplier * vdd[1] / I_on_n[1];//ohm-micron
+//    	Rpchannelon[1] = n_to_p_eff_curr_drv_ratio[1] * Rnchannelon[1];//ohm-micron
+//    	I_off_n[1][0] = 2.43e-11;
+//    	I_off_n[1][10] = 4.85e-11;
+//    	I_off_n[1][20] = 9.68e-11;
+//    	I_off_n[1][30] = 1.94e-10;
+//    	I_off_n[1][40] = 3.87e-10;
+//    	I_off_n[1][50] = 7.73e-10;
+//    	I_off_n[1][60] = 3.55e-10;
+//    	I_off_n[1][70] = 3.09e-9;
+//    	I_off_n[1][80] = 6.19e-9;
+//    	I_off_n[1][90] = 1.24e-8;
+//    	I_off_n[1][100]= 2.48e-8;
+//
+//    	//    for 22nm LSTP HP
+//    	I_g_on_n[1][0]  = 4.51e-10;//A/micron
+//    	I_g_on_n[1][10] = 4.51e-10;
+//    	I_g_on_n[1][20] = 4.51e-10;
+//    	I_g_on_n[1][30] = 4.51e-10;
+//    	I_g_on_n[1][40] = 4.51e-10;
+//    	I_g_on_n[1][50] = 4.51e-10;
+//    	I_g_on_n[1][60] = 4.51e-10;
+//    	I_g_on_n[1][70] = 4.51e-10;
+//    	I_g_on_n[1][80] = 4.51e-10;
+//    	I_g_on_n[1][90] = 4.51e-10;
+//    	I_g_on_n[1][100] = 4.51e-10;
 
-      } else {
-        // some error handler
-      }
 
-      // SRAM cell properties
-      curr_Wmemcella_sram = 1.31 * g_ip->F_sz_um;
-      curr_Wmemcellpmos_sram = 1.23 * g_ip->F_sz_um;
-      curr_Wmemcellnmos_sram = 2.08 * g_ip->F_sz_um;
-      curr_area_cell_sram = 146 * g_ip->F_sz_um * g_ip->F_sz_um;
-      curr_asp_ratio_cell_sram = 1.46;
-      // CAM cell properties //TODO: data need to be revisited
-      curr_Wmemcella_cam = 1.31 * g_ip->F_sz_um;
-      curr_Wmemcellpmos_cam = 1.23 * g_ip->F_sz_um;
-      curr_Wmemcellnmos_cam = 2.08 * g_ip->F_sz_um;
-      curr_area_cell_cam = 292 * g_ip->F_sz_um * g_ip->F_sz_um;
-      curr_asp_ratio_cell_cam = 2.92;
-      // Empirical undifferetiated core/FU coefficient
-      curr_logic_scaling_co_eff = 0.7 * 0.7 * 0.7 * 0.7 * 0.7;
-      curr_core_tx_density = 1.25 / 0.7 / 0.7 / 0.7;
-      curr_sckt_co_eff = 1.1296;
-      curr_chip_layout_overhead =
-          1.2;  // die measurement results based on Niagara 1 and 2
-      curr_macro_layout_overhead =
-          1.1;  // EDA placement and routing tool rule of thumb
-    }
+        if (ram_cell_tech_type == 3)
+              {}
+        else if (ram_cell_tech_type == 4)
+        {
+    	//22 nm commodity DRAM cell access transistor technology parameters.
+    		//parameters
+        	curr_vdd_dram_cell = 0.9;//0.45;//This value has reduced greatly in 2007 ITRS for all technology nodes. In
+    		//2005 ITRS, the value was about twice the value in 2007 ITRS
+    		Lphy[3] = 0.022;//micron
+    		Lelec[3] = 0.0181;//micron.
+    		curr_v_th_dram_access_transistor = 1;//V
+    		width_dram_access_transistor = 0.022;//micron
+    		curr_I_on_dram_cell = 20e-6; //This is a typical value that I have always
+    		//kept constant. In reality this could perhaps be lower
+    		curr_I_off_dram_cell_worst_case_length_temp = 1e-15;//A
+    		curr_Wmemcella_dram = width_dram_access_transistor;
+    		curr_Wmemcellpmos_dram = 0;
+    		curr_Wmemcellnmos_dram = 0;
+    		curr_area_cell_dram = 6*0.022*0.022;//micron2.
+    		curr_asp_ratio_cell_dram = 0.667;
+    		curr_c_dram_cell = 30e-15;//This is a typical value that I have alwaus
+    		//kept constant.
 
-    g_tp.peri_global.Vdd += curr_alpha * vdd[peri_global_tech_type];
-    g_tp.peri_global.t_ox += curr_alpha * t_ox[peri_global_tech_type];
-    g_tp.peri_global.Vth += curr_alpha * v_th[peri_global_tech_type];
-    g_tp.peri_global.C_ox += curr_alpha * c_ox[peri_global_tech_type];
+    	//22 nm commodity DRAM wordline transistor parameters obtained using MASTAR.
+    		curr_vpp = 2.3;//vpp. V
+    		t_ox[3] = 3.5e-3;//micron
+    		v_th[3] = 1.0;//V
+    		c_ox[3] = 9.06e-15;//F/micron2
+    		mobility_eff[3] =  367.29 * (1e-2 * 1e6 * 1e-2 * 1e6);//micron2 / Vs
+    		Vdsat[3] = 0.0972; //V/micron
+    		c_g_ideal[3] = 1.99e-16;//F/micron
+    		c_fringe[3] = 0.053e-15;//F/micron
+    		c_junc[3] = 1e-15;//F/micron2
+    		I_on_n[3] = 910.5e-6;//A/micron
+    		I_on_p[3] = I_on_n[3] / 2;//This value for I_on_p is not really used.
+    		nmos_effective_resistance_multiplier = 1.69;//Using the value from 32nm.
+    		//
+    		n_to_p_eff_curr_drv_ratio[3] = 1.95;//Using the value from 32nm
+    		gmp_to_gmn_multiplier[3] = 0.90;
+    		Rnchannelon[3] = nmos_effective_resistance_multiplier * curr_vpp  / I_on_n[3];//ohm-micron
+    		Rpchannelon[3] = n_to_p_eff_curr_drv_ratio[3] * Rnchannelon[3];//ohm-micron
+    		long_channel_leakage_reduction[3] = 1;
+    		I_off_n[3][0] = 1.1e-13; //A/micron
+    		I_off_n[3][10] = 2.11e-13;
+    		I_off_n[3][20] = 3.88e-13;
+    		I_off_n[3][30] = 6.9e-13;
+    		I_off_n[3][40] = 1.19e-12;
+    		I_off_n[3][50] = 1.98e-12;
+    		I_off_n[3][60] = 3.22e-12;
+    		I_off_n[3][70] = 5.09e-12;
+    		I_off_n[3][80] = 7.85e-12;
+    		I_off_n[3][90] = 1.18e-11;
+    		I_off_n[3][100] = 1.72e-11;
+
+    	}
+        else
+        {
+      	  //some error handler
+        }
+
+        //SRAM cell properties
+        curr_Wmemcella_sram    = 1.31 * g_ip->F_sz_um;
+        curr_Wmemcellpmos_sram = 1.23 * g_ip->F_sz_um;
+        curr_Wmemcellnmos_sram = 2.08 * g_ip->F_sz_um;
+        curr_area_cell_sram    = 146 * g_ip->F_sz_um * g_ip->F_sz_um;
+        curr_asp_ratio_cell_sram = 1.46;
+        //CAM cell properties //TODO: data need to be revisited
+        curr_Wmemcella_cam = 1.31 * g_ip->F_sz_um;
+        curr_Wmemcellpmos_cam = 1.23 * g_ip->F_sz_um;
+        curr_Wmemcellnmos_cam = 2.08 * g_ip->F_sz_um;
+        curr_area_cell_cam = 292 * g_ip->F_sz_um * g_ip->F_sz_um;
+        curr_asp_ratio_cell_cam = 2.92;
+        //Empirical undifferetiated core/FU coefficient
+        curr_logic_scaling_co_eff = 0.7*0.7*0.7*0.7*0.7;
+        curr_core_tx_density      = 1.25/0.7/0.7/0.7;
+        curr_sckt_co_eff           = 1.1296;
+        curr_chip_layout_overhead  = 1.2;//die measurement results based on Niagara 1 and 2
+        curr_macro_layout_overhead = 1.1;//EDA placement and routing tool rule of thumb
+    	}
+
+
+    g_tp.peri_global.Vdd       += curr_alpha * vdd[peri_global_tech_type];
+    g_tp.peri_global.t_ox      += curr_alpha * t_ox[peri_global_tech_type];
+    g_tp.peri_global.Vth       += curr_alpha * v_th[peri_global_tech_type];
+    g_tp.peri_global.C_ox      += curr_alpha * c_ox[peri_global_tech_type];
     g_tp.peri_global.C_g_ideal += curr_alpha * c_g_ideal[peri_global_tech_type];
-    g_tp.peri_global.C_fringe += curr_alpha * c_fringe[peri_global_tech_type];
-    g_tp.peri_global.C_junc += curr_alpha * c_junc[peri_global_tech_type];
+    g_tp.peri_global.C_fringe  += curr_alpha * c_fringe[peri_global_tech_type];
+    g_tp.peri_global.C_junc    += curr_alpha * c_junc[peri_global_tech_type];
     g_tp.peri_global.C_junc_sidewall = 0.25e-15;  // F/micron
-    g_tp.peri_global.l_phy += curr_alpha * Lphy[peri_global_tech_type];
-    g_tp.peri_global.l_elec += curr_alpha * Lelec[peri_global_tech_type];
-    g_tp.peri_global.I_on_n += curr_alpha * I_on_n[peri_global_tech_type];
-    g_tp.peri_global.R_nch_on +=
-        curr_alpha * Rnchannelon[peri_global_tech_type];
-    g_tp.peri_global.R_pch_on +=
-        curr_alpha * Rpchannelon[peri_global_tech_type];
-    g_tp.peri_global.n_to_p_eff_curr_drv_ratio +=
-        curr_alpha * n_to_p_eff_curr_drv_ratio[peri_global_tech_type];
-    g_tp.peri_global.long_channel_leakage_reduction +=
-        curr_alpha * long_channel_leakage_reduction[peri_global_tech_type];
-    g_tp.peri_global.I_off_n +=
-        curr_alpha * I_off_n[peri_global_tech_type][g_ip->temp - 300];
-    g_tp.peri_global.I_off_p +=
-        curr_alpha * I_off_n[peri_global_tech_type][g_ip->temp - 300];
-    g_tp.peri_global.I_g_on_n +=
-        curr_alpha * I_g_on_n[peri_global_tech_type][g_ip->temp - 300];
-    g_tp.peri_global.I_g_on_p +=
-        curr_alpha * I_g_on_n[peri_global_tech_type][g_ip->temp - 300];
-    gmp_to_gmn_multiplier_periph_global +=
-        curr_alpha * gmp_to_gmn_multiplier[peri_global_tech_type];
+    g_tp.peri_global.l_phy     += curr_alpha * Lphy[peri_global_tech_type];
+    g_tp.peri_global.l_elec    += curr_alpha * Lelec[peri_global_tech_type];
+    g_tp.peri_global.I_on_n    += curr_alpha * I_on_n[peri_global_tech_type];
+    g_tp.peri_global.R_nch_on  += curr_alpha * Rnchannelon[peri_global_tech_type];
+    g_tp.peri_global.R_pch_on  += curr_alpha * Rpchannelon[peri_global_tech_type];
+    g_tp.peri_global.n_to_p_eff_curr_drv_ratio
+      += curr_alpha * n_to_p_eff_curr_drv_ratio[peri_global_tech_type];
+    g_tp.peri_global.long_channel_leakage_reduction
+      += curr_alpha * long_channel_leakage_reduction[peri_global_tech_type];
+    g_tp.peri_global.I_off_n   += curr_alpha * I_off_n[peri_global_tech_type][g_ip->temp - 300];
+    g_tp.peri_global.I_off_p   += curr_alpha * I_off_n[peri_global_tech_type][g_ip->temp - 300];
+    g_tp.peri_global.I_g_on_n   += curr_alpha * I_g_on_n[peri_global_tech_type][g_ip->temp - 300];
+    g_tp.peri_global.I_g_on_p   += curr_alpha * I_g_on_n[peri_global_tech_type][g_ip->temp - 300];
+    gmp_to_gmn_multiplier_periph_global += curr_alpha * gmp_to_gmn_multiplier[peri_global_tech_type];
 
-    g_tp.sram_cell.Vdd += curr_alpha * vdd[ram_cell_tech_type];
-    g_tp.sram_cell.l_phy += curr_alpha * Lphy[ram_cell_tech_type];
-    g_tp.sram_cell.l_elec += curr_alpha * Lelec[ram_cell_tech_type];
-    g_tp.sram_cell.t_ox += curr_alpha * t_ox[ram_cell_tech_type];
-    g_tp.sram_cell.Vth += curr_alpha * v_th[ram_cell_tech_type];
+    g_tp.sram_cell.Vdd       += curr_alpha * vdd[ram_cell_tech_type];
+    g_tp.sram_cell.l_phy     += curr_alpha * Lphy[ram_cell_tech_type];
+    g_tp.sram_cell.l_elec    += curr_alpha * Lelec[ram_cell_tech_type];
+    g_tp.sram_cell.t_ox      += curr_alpha * t_ox[ram_cell_tech_type];
+    g_tp.sram_cell.Vth       += curr_alpha * v_th[ram_cell_tech_type];
     g_tp.sram_cell.C_g_ideal += curr_alpha * c_g_ideal[ram_cell_tech_type];
-    g_tp.sram_cell.C_fringe += curr_alpha * c_fringe[ram_cell_tech_type];
-    g_tp.sram_cell.C_junc += curr_alpha * c_junc[ram_cell_tech_type];
+    g_tp.sram_cell.C_fringe  += curr_alpha * c_fringe[ram_cell_tech_type];
+    g_tp.sram_cell.C_junc    += curr_alpha * c_junc[ram_cell_tech_type];
     g_tp.sram_cell.C_junc_sidewall = 0.25e-15;  // F/micron
-    g_tp.sram_cell.I_on_n += curr_alpha * I_on_n[ram_cell_tech_type];
-    g_tp.sram_cell.R_nch_on += curr_alpha * Rnchannelon[ram_cell_tech_type];
-    g_tp.sram_cell.R_pch_on += curr_alpha * Rpchannelon[ram_cell_tech_type];
-    g_tp.sram_cell.n_to_p_eff_curr_drv_ratio +=
-        curr_alpha * n_to_p_eff_curr_drv_ratio[ram_cell_tech_type];
-    g_tp.sram_cell.long_channel_leakage_reduction +=
-        curr_alpha * long_channel_leakage_reduction[ram_cell_tech_type];
-    g_tp.sram_cell.I_off_n +=
-        curr_alpha * I_off_n[ram_cell_tech_type][g_ip->temp - 300];
-    g_tp.sram_cell.I_off_p +=
-        curr_alpha * I_off_n[ram_cell_tech_type][g_ip->temp - 300];
-    g_tp.sram_cell.I_g_on_n +=
-        curr_alpha * I_g_on_n[ram_cell_tech_type][g_ip->temp - 300];
-    g_tp.sram_cell.I_g_on_p +=
-        curr_alpha * I_g_on_n[ram_cell_tech_type][g_ip->temp - 300];
+    g_tp.sram_cell.I_on_n    += curr_alpha * I_on_n[ram_cell_tech_type];
+    g_tp.sram_cell.R_nch_on  += curr_alpha * Rnchannelon[ram_cell_tech_type];
+    g_tp.sram_cell.R_pch_on  += curr_alpha * Rpchannelon[ram_cell_tech_type];
+    g_tp.sram_cell.n_to_p_eff_curr_drv_ratio += curr_alpha * n_to_p_eff_curr_drv_ratio[ram_cell_tech_type];
+    g_tp.sram_cell.long_channel_leakage_reduction += curr_alpha * long_channel_leakage_reduction[ram_cell_tech_type];
+    g_tp.sram_cell.I_off_n   += curr_alpha * I_off_n[ram_cell_tech_type][g_ip->temp - 300];
+    g_tp.sram_cell.I_off_p   += curr_alpha * I_off_n[ram_cell_tech_type][g_ip->temp - 300];
+    g_tp.sram_cell.I_g_on_n   += curr_alpha * I_g_on_n[ram_cell_tech_type][g_ip->temp - 300];
+    g_tp.sram_cell.I_g_on_p   += curr_alpha * I_g_on_n[ram_cell_tech_type][g_ip->temp - 300];
 
-    g_tp.dram_cell_Vdd += curr_alpha * curr_vdd_dram_cell;
-    g_tp.dram_acc.Vth += curr_alpha * curr_v_th_dram_access_transistor;
-    g_tp.dram_acc.l_phy += curr_alpha * Lphy[dram_cell_tech_flavor];
-    g_tp.dram_acc.l_elec += curr_alpha * Lelec[dram_cell_tech_flavor];
+    g_tp.dram_cell_Vdd      += curr_alpha * curr_vdd_dram_cell;
+    g_tp.dram_acc.Vth       += curr_alpha * curr_v_th_dram_access_transistor;
+    g_tp.dram_acc.l_phy     += curr_alpha * Lphy[dram_cell_tech_flavor];
+    g_tp.dram_acc.l_elec    += curr_alpha * Lelec[dram_cell_tech_flavor];
     g_tp.dram_acc.C_g_ideal += curr_alpha * c_g_ideal[dram_cell_tech_flavor];
-    g_tp.dram_acc.C_fringe += curr_alpha * c_fringe[dram_cell_tech_flavor];
-    g_tp.dram_acc.C_junc += curr_alpha * c_junc[dram_cell_tech_flavor];
+    g_tp.dram_acc.C_fringe  += curr_alpha * c_fringe[dram_cell_tech_flavor];
+    g_tp.dram_acc.C_junc    += curr_alpha * c_junc[dram_cell_tech_flavor];
     g_tp.dram_acc.C_junc_sidewall = 0.25e-15;  // F/micron
-    g_tp.dram_cell_I_on += curr_alpha * curr_I_on_dram_cell;
-    g_tp.dram_cell_I_off_worst_case_len_temp +=
-        curr_alpha * curr_I_off_dram_cell_worst_case_length_temp;
-    g_tp.dram_acc.I_on_n += curr_alpha * I_on_n[dram_cell_tech_flavor];
-    g_tp.dram_cell_C += curr_alpha * curr_c_dram_cell;
-    g_tp.vpp += curr_alpha * curr_vpp;
-    g_tp.dram_wl.l_phy += curr_alpha * Lphy[dram_cell_tech_flavor];
-    g_tp.dram_wl.l_elec += curr_alpha * Lelec[dram_cell_tech_flavor];
-    g_tp.dram_wl.C_g_ideal += curr_alpha * c_g_ideal[dram_cell_tech_flavor];
-    g_tp.dram_wl.C_fringe += curr_alpha * c_fringe[dram_cell_tech_flavor];
-    g_tp.dram_wl.C_junc += curr_alpha * c_junc[dram_cell_tech_flavor];
+    g_tp.dram_cell_I_on     += curr_alpha * curr_I_on_dram_cell;
+    g_tp.dram_cell_I_off_worst_case_len_temp += curr_alpha * curr_I_off_dram_cell_worst_case_length_temp;
+    g_tp.dram_acc.I_on_n    += curr_alpha * I_on_n[dram_cell_tech_flavor];
+    g_tp.dram_cell_C        += curr_alpha * curr_c_dram_cell;
+    g_tp.vpp                += curr_alpha * curr_vpp;
+    g_tp.dram_wl.l_phy      += curr_alpha * Lphy[dram_cell_tech_flavor];
+    g_tp.dram_wl.l_elec     += curr_alpha * Lelec[dram_cell_tech_flavor];
+    g_tp.dram_wl.C_g_ideal  += curr_alpha * c_g_ideal[dram_cell_tech_flavor];
+    g_tp.dram_wl.C_fringe   += curr_alpha * c_fringe[dram_cell_tech_flavor];
+    g_tp.dram_wl.C_junc     += curr_alpha * c_junc[dram_cell_tech_flavor];
     g_tp.dram_wl.C_junc_sidewall = 0.25e-15;  // F/micron
-    g_tp.dram_wl.I_on_n += curr_alpha * I_on_n[dram_cell_tech_flavor];
-    g_tp.dram_wl.R_nch_on += curr_alpha * Rnchannelon[dram_cell_tech_flavor];
-    g_tp.dram_wl.R_pch_on += curr_alpha * Rpchannelon[dram_cell_tech_flavor];
-    g_tp.dram_wl.n_to_p_eff_curr_drv_ratio +=
-        curr_alpha * n_to_p_eff_curr_drv_ratio[dram_cell_tech_flavor];
-    g_tp.dram_wl.long_channel_leakage_reduction +=
-        curr_alpha * long_channel_leakage_reduction[dram_cell_tech_flavor];
-    g_tp.dram_wl.I_off_n +=
-        curr_alpha * I_off_n[dram_cell_tech_flavor][g_ip->temp - 300];
-    g_tp.dram_wl.I_off_p +=
-        curr_alpha * I_off_n[dram_cell_tech_flavor][g_ip->temp - 300];
+    g_tp.dram_wl.I_on_n     += curr_alpha * I_on_n[dram_cell_tech_flavor];
+    g_tp.dram_wl.R_nch_on   += curr_alpha * Rnchannelon[dram_cell_tech_flavor];
+    g_tp.dram_wl.R_pch_on   += curr_alpha * Rpchannelon[dram_cell_tech_flavor];
+    g_tp.dram_wl.n_to_p_eff_curr_drv_ratio += curr_alpha * n_to_p_eff_curr_drv_ratio[dram_cell_tech_flavor];
+    g_tp.dram_wl.long_channel_leakage_reduction += curr_alpha * long_channel_leakage_reduction[dram_cell_tech_flavor];
+    g_tp.dram_wl.I_off_n    += curr_alpha * I_off_n[dram_cell_tech_flavor][g_ip->temp - 300];
+    g_tp.dram_wl.I_off_p    += curr_alpha * I_off_n[dram_cell_tech_flavor][g_ip->temp - 300];
 
-    g_tp.cam_cell.Vdd += curr_alpha * vdd[ram_cell_tech_type];
-    g_tp.cam_cell.l_phy += curr_alpha * Lphy[ram_cell_tech_type];
-    g_tp.cam_cell.l_elec += curr_alpha * Lelec[ram_cell_tech_type];
-    g_tp.cam_cell.t_ox += curr_alpha * t_ox[ram_cell_tech_type];
-    g_tp.cam_cell.Vth += curr_alpha * v_th[ram_cell_tech_type];
+    g_tp.cam_cell.Vdd       += curr_alpha * vdd[ram_cell_tech_type];
+    g_tp.cam_cell.l_phy     += curr_alpha * Lphy[ram_cell_tech_type];
+    g_tp.cam_cell.l_elec    += curr_alpha * Lelec[ram_cell_tech_type];
+    g_tp.cam_cell.t_ox      += curr_alpha * t_ox[ram_cell_tech_type];
+    g_tp.cam_cell.Vth       += curr_alpha * v_th[ram_cell_tech_type];
     g_tp.cam_cell.C_g_ideal += curr_alpha * c_g_ideal[ram_cell_tech_type];
-    g_tp.cam_cell.C_fringe += curr_alpha * c_fringe[ram_cell_tech_type];
-    g_tp.cam_cell.C_junc += curr_alpha * c_junc[ram_cell_tech_type];
+    g_tp.cam_cell.C_fringe  += curr_alpha * c_fringe[ram_cell_tech_type];
+    g_tp.cam_cell.C_junc    += curr_alpha * c_junc[ram_cell_tech_type];
     g_tp.cam_cell.C_junc_sidewall = 0.25e-15;  // F/micron
-    g_tp.cam_cell.I_on_n += curr_alpha * I_on_n[ram_cell_tech_type];
-    g_tp.cam_cell.R_nch_on += curr_alpha * Rnchannelon[ram_cell_tech_type];
-    g_tp.cam_cell.R_pch_on += curr_alpha * Rpchannelon[ram_cell_tech_type];
-    g_tp.cam_cell.n_to_p_eff_curr_drv_ratio +=
-        curr_alpha * n_to_p_eff_curr_drv_ratio[ram_cell_tech_type];
-    g_tp.cam_cell.long_channel_leakage_reduction +=
-        curr_alpha * long_channel_leakage_reduction[ram_cell_tech_type];
-    g_tp.cam_cell.I_off_n +=
-        curr_alpha * I_off_n[ram_cell_tech_type][g_ip->temp - 300];
-    g_tp.cam_cell.I_off_p +=
-        curr_alpha * I_off_n[ram_cell_tech_type][g_ip->temp - 300];
-    g_tp.cam_cell.I_g_on_n +=
-        curr_alpha * I_g_on_n[ram_cell_tech_type][g_ip->temp - 300];
-    g_tp.cam_cell.I_g_on_p +=
-        curr_alpha * I_g_on_n[ram_cell_tech_type][g_ip->temp - 300];
+    g_tp.cam_cell.I_on_n    += curr_alpha * I_on_n[ram_cell_tech_type];
+    g_tp.cam_cell.R_nch_on  += curr_alpha * Rnchannelon[ram_cell_tech_type];
+    g_tp.cam_cell.R_pch_on  += curr_alpha * Rpchannelon[ram_cell_tech_type];
+    g_tp.cam_cell.n_to_p_eff_curr_drv_ratio += curr_alpha * n_to_p_eff_curr_drv_ratio[ram_cell_tech_type];
+    g_tp.cam_cell.long_channel_leakage_reduction += curr_alpha * long_channel_leakage_reduction[ram_cell_tech_type];
+    g_tp.cam_cell.I_off_n   += curr_alpha * I_off_n[ram_cell_tech_type][g_ip->temp - 300];
+    g_tp.cam_cell.I_off_p   += curr_alpha * I_off_n[ram_cell_tech_type][g_ip->temp - 300];
+    g_tp.cam_cell.I_g_on_n   += curr_alpha * I_g_on_n[ram_cell_tech_type][g_ip->temp - 300];
+    g_tp.cam_cell.I_g_on_p   += curr_alpha * I_g_on_n[ram_cell_tech_type][g_ip->temp - 300];
 
-    g_tp.dram.cell_a_w += curr_alpha * curr_Wmemcella_dram;
+    g_tp.dram.cell_a_w    += curr_alpha * curr_Wmemcella_dram;
     g_tp.dram.cell_pmos_w += curr_alpha * curr_Wmemcellpmos_dram;
     g_tp.dram.cell_nmos_w += curr_alpha * curr_Wmemcellnmos_dram;
-    area_cell_dram += curr_alpha * curr_area_cell_dram;
-    asp_ratio_cell_dram += curr_alpha * curr_asp_ratio_cell_dram;
+    area_cell_dram        += curr_alpha * curr_area_cell_dram;
+    asp_ratio_cell_dram   += curr_alpha * curr_asp_ratio_cell_dram;
 
-    g_tp.sram.cell_a_w += curr_alpha * curr_Wmemcella_sram;
+    g_tp.sram.cell_a_w    += curr_alpha * curr_Wmemcella_sram;
     g_tp.sram.cell_pmos_w += curr_alpha * curr_Wmemcellpmos_sram;
     g_tp.sram.cell_nmos_w += curr_alpha * curr_Wmemcellnmos_sram;
     area_cell_sram += curr_alpha * curr_area_cell_sram;
     asp_ratio_cell_sram += curr_alpha * curr_asp_ratio_cell_sram;
 
-    g_tp.cam.cell_a_w += curr_alpha * curr_Wmemcella_cam;  // sheng
+    g_tp.cam.cell_a_w    += curr_alpha * curr_Wmemcella_cam;//sheng
     g_tp.cam.cell_pmos_w += curr_alpha * curr_Wmemcellpmos_cam;
     g_tp.cam.cell_nmos_w += curr_alpha * curr_Wmemcellnmos_cam;
     area_cell_cam += curr_alpha * curr_area_cell_cam;
     asp_ratio_cell_cam += curr_alpha * curr_asp_ratio_cell_cam;
 
-    // Sense amplifier latch Gm calculation
-    mobility_eff_periph_global +=
-        curr_alpha * mobility_eff[peri_global_tech_type];
+    //Sense amplifier latch Gm calculation
+    mobility_eff_periph_global += curr_alpha * mobility_eff[peri_global_tech_type];
     Vdsat_periph_global += curr_alpha * Vdsat[peri_global_tech_type];
 
-    // Empirical undifferetiated core/FU coefficient
-    g_tp.scaling_factor.logic_scaling_co_eff +=
-        curr_alpha * curr_logic_scaling_co_eff;
+    //Empirical undifferetiated core/FU coefficient
+    g_tp.scaling_factor.logic_scaling_co_eff += curr_alpha * curr_logic_scaling_co_eff;
     g_tp.scaling_factor.core_tx_density += curr_alpha * curr_core_tx_density;
-    g_tp.chip_layout_overhead += curr_alpha * curr_chip_layout_overhead;
+    g_tp.chip_layout_overhead  += curr_alpha * curr_chip_layout_overhead;
     g_tp.macro_layout_overhead += curr_alpha * curr_macro_layout_overhead;
-    g_tp.sckt_co_eff += curr_alpha * curr_sckt_co_eff;
+    g_tp.sckt_co_eff           += curr_alpha * curr_sckt_co_eff;
   }
 
-  // Currently we are not modeling the resistance/capacitance of poly anywhere.
-  // Continuous function (or date have been processed) does not need linear
-  // interpolation
-  g_tp.w_comp_inv_p1 =
-      12.5 * g_ip->F_sz_um;  // this was 10 micron for the 0.8 micron process
-  g_tp.w_comp_inv_n1 =
-      7.5 * g_ip->F_sz_um;  // this was  6 micron for the 0.8 micron process
-  g_tp.w_comp_inv_p2 =
-      25 * g_ip->F_sz_um;  // this was 20 micron for the 0.8 micron process
-  g_tp.w_comp_inv_n2 =
-      15 * g_ip->F_sz_um;  // this was 12 micron for the 0.8 micron process
-  g_tp.w_comp_inv_p3 =
-      50 * g_ip->F_sz_um;  // this was 40 micron for the 0.8 micron process
-  g_tp.w_comp_inv_n3 =
-      30 * g_ip->F_sz_um;  // this was 24 micron for the 0.8 micron process
-  g_tp.w_eval_inv_p =
-      100 * g_ip->F_sz_um;  // this was 80 micron for the 0.8 micron process
-  g_tp.w_eval_inv_n =
-      50 * g_ip->F_sz_um;  // this was 40 micron for the 0.8 micron process
-  g_tp.w_comp_n =
-      12.5 * g_ip->F_sz_um;  // this was 10 micron for the 0.8 micron process
-  g_tp.w_comp_p =
-      37.5 * g_ip->F_sz_um;  // this was 30 micron for the 0.8 micron process
+
+  //Currently we are not modeling the resistance/capacitance of poly anywhere.
+  //Continuous function (or date have been processed) does not need linear interpolation
+  g_tp.w_comp_inv_p1 = 12.5 * g_ip->F_sz_um;//this was 10 micron for the 0.8 micron process
+  g_tp.w_comp_inv_n1 =  7.5 * g_ip->F_sz_um;//this was  6 micron for the 0.8 micron process
+  g_tp.w_comp_inv_p2 =   25 * g_ip->F_sz_um;//this was 20 micron for the 0.8 micron process
+  g_tp.w_comp_inv_n2 =   15 * g_ip->F_sz_um;//this was 12 micron for the 0.8 micron process
+  g_tp.w_comp_inv_p3 =   50 * g_ip->F_sz_um;//this was 40 micron for the 0.8 micron process
+  g_tp.w_comp_inv_n3 =   30 * g_ip->F_sz_um;//this was 24 micron for the 0.8 micron process
+  g_tp.w_eval_inv_p  =  100 * g_ip->F_sz_um;//this was 80 micron for the 0.8 micron process
+  g_tp.w_eval_inv_n  =   50 * g_ip->F_sz_um;//this was 40 micron for the 0.8 micron process
+  g_tp.w_comp_n     = 12.5 * g_ip->F_sz_um;//this was 10 micron for the 0.8 micron process
+  g_tp.w_comp_p     = 37.5 * g_ip->F_sz_um;//this was 30 micron for the 0.8 micron process
 
   g_tp.MIN_GAP_BET_P_AND_N_DIFFS = 5 * g_ip->F_sz_um;
   g_tp.MIN_GAP_BET_SAME_TYPE_DIFFS = 1.5 * g_ip->F_sz_um;
@@ -1904,264 +1828,255 @@ void init_tech_params(double technology, bool is_tag) {
 
   g_tp.min_w_nmos_ = 3 * g_ip->F_sz_um / 2;
   g_tp.max_w_nmos_ = 100 * g_ip->F_sz_um;
-  g_tp.w_iso = 12.5 * g_ip->F_sz_um;  // was 10 micron for the 0.8 micron
-                                      // process
-  g_tp.w_sense_n = 3.75 * g_ip->F_sz_um;  // sense amplifier N-trans; was 3
-                                          // micron for the 0.8 micron process
-  g_tp.w_sense_p = 7.5 * g_ip->F_sz_um;   // sense amplifier P-trans; was 6
-                                          // micron for the 0.8 micron process
-  g_tp.w_sense_en = 5 * g_ip->F_sz_um;  // Sense enable transistor of the sense
-                                        // amplifier; was 4 micron for the 0.8
-                                        // micron process
-  g_tp.w_nmos_b_mux = 6 * g_tp.min_w_nmos_;
+  g_tp.w_iso       = 12.5*g_ip->F_sz_um;//was 10 micron for the 0.8 micron process
+  g_tp.w_sense_n   = 3.75*g_ip->F_sz_um; // sense amplifier N-trans; was 3 micron for the 0.8 micron process
+  g_tp.w_sense_p   = 7.5*g_ip->F_sz_um; // sense amplifier P-trans; was 6 micron for the 0.8 micron process
+  g_tp.w_sense_en  = 5*g_ip->F_sz_um; // Sense enable transistor of the sense amplifier; was 4 micron for the 0.8 micron process
+  g_tp.w_nmos_b_mux  = 6 * g_tp.min_w_nmos_;
   g_tp.w_nmos_sa_mux = 6 * g_tp.min_w_nmos_;
 
-  if (ram_cell_tech_type == comm_dram) {
+  if (ram_cell_tech_type == comm_dram)
+  {
     g_tp.max_w_nmos_dec = 8 * g_ip->F_sz_um;
-    g_tp.h_dec = 8;  // in the unit of memory cell height
-  } else {
+    g_tp.h_dec          = 8;  // in the unit of memory cell height
+  }
+  else
+  {
     g_tp.max_w_nmos_dec = g_tp.max_w_nmos_;
-    g_tp.h_dec = 4;  // in the unit of memory cell height
+    g_tp.h_dec          = 4;  // in the unit of memory cell height
   }
 
   g_tp.peri_global.C_overlap = 0.2 * g_tp.peri_global.C_g_ideal;
-  g_tp.sram_cell.C_overlap = 0.2 * g_tp.sram_cell.C_g_ideal;
-  g_tp.cam_cell.C_overlap = 0.2 * g_tp.cam_cell.C_g_ideal;
+  g_tp.sram_cell.C_overlap   = 0.2 * g_tp.sram_cell.C_g_ideal;
+  g_tp.cam_cell.C_overlap    = 0.2 * g_tp.cam_cell.C_g_ideal;
 
   g_tp.dram_acc.C_overlap = 0.2 * g_tp.dram_acc.C_g_ideal;
   g_tp.dram_acc.R_nch_on = g_tp.dram_cell_Vdd / g_tp.dram_acc.I_on_n;
-  // g_tp.dram_acc.R_pch_on = g_tp.dram_cell_Vdd / g_tp.dram_acc.I_on_p;
+  //g_tp.dram_acc.R_pch_on = g_tp.dram_cell_Vdd / g_tp.dram_acc.I_on_p;
 
   g_tp.dram_wl.C_overlap = 0.2 * g_tp.dram_wl.C_g_ideal;
 
-  double gmn_sense_amp_latch =
-      (mobility_eff_periph_global / 2) * g_tp.peri_global.C_ox *
-      (g_tp.w_sense_n / g_tp.peri_global.l_elec) * Vdsat_periph_global;
-  double gmp_sense_amp_latch =
-      gmp_to_gmn_multiplier_periph_global * gmn_sense_amp_latch;
+  double gmn_sense_amp_latch = (mobility_eff_periph_global / 2) * g_tp.peri_global.C_ox * (g_tp.w_sense_n / g_tp.peri_global.l_elec) * Vdsat_periph_global;
+  double gmp_sense_amp_latch = gmp_to_gmn_multiplier_periph_global * gmn_sense_amp_latch;
   g_tp.gm_sense_amp_latch = gmn_sense_amp_latch + gmp_sense_amp_latch;
 
   g_tp.dram.b_w = sqrt(area_cell_dram / (asp_ratio_cell_dram));
   g_tp.dram.b_h = asp_ratio_cell_dram * g_tp.dram.b_w;
   g_tp.sram.b_w = sqrt(area_cell_sram / (asp_ratio_cell_sram));
   g_tp.sram.b_h = asp_ratio_cell_sram * g_tp.sram.b_w;
-  g_tp.cam.b_w = sqrt(area_cell_cam / (asp_ratio_cell_cam));  // Sheng
+  g_tp.cam.b_w =  sqrt(area_cell_cam / (asp_ratio_cell_cam));//Sheng
   g_tp.cam.b_h = asp_ratio_cell_cam * g_tp.cam.b_w;
 
   g_tp.dram.Vbitpre = g_tp.dram_cell_Vdd;
   g_tp.sram.Vbitpre = vdd[ram_cell_tech_type];
-  g_tp.cam.Vbitpre = vdd[ram_cell_tech_type];  // Sheng
+  g_tp.cam.Vbitpre = vdd[ram_cell_tech_type];//Sheng
   pmos_to_nmos_sizing_r = pmos_to_nmos_sz_ratio();
   g_tp.w_pmos_bl_precharge = 6 * pmos_to_nmos_sizing_r * g_tp.min_w_nmos_;
   g_tp.w_pmos_bl_eq = pmos_to_nmos_sizing_r * g_tp.min_w_nmos_;
 
-  double wire_pitch[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
-      wire_r_per_micron[NUMBER_INTERCONNECT_PROJECTION_TYPES]
-                       [NUMBER_WIRE_TYPES],
-      wire_c_per_micron[NUMBER_INTERCONNECT_PROJECTION_TYPES]
-                       [NUMBER_WIRE_TYPES],
-      horiz_dielectric_constant[NUMBER_INTERCONNECT_PROJECTION_TYPES]
-                               [NUMBER_WIRE_TYPES],
-      vert_dielectric_constant[NUMBER_INTERCONNECT_PROJECTION_TYPES]
-                              [NUMBER_WIRE_TYPES],
-      aspect_ratio[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
-      miller_value[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
-      ild_thickness[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES];
 
-  for (iter = 0; iter <= 1; ++iter) {
+  double wire_pitch       [NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
+         wire_r_per_micron[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
+         wire_c_per_micron[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
+         horiz_dielectric_constant[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
+         vert_dielectric_constant[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
+         aspect_ratio[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
+         miller_value[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES],
+         ild_thickness[NUMBER_INTERCONNECT_PROJECTION_TYPES][NUMBER_WIRE_TYPES];
+
+  for (iter=0; iter<=1; ++iter)
+  {
     // linear interpolation
-    if (iter == 0) {
+    if (iter == 0)
+    {
       tech = tech_lo;
-      if (tech_lo == tech_hi) {
+      if (tech_lo == tech_hi)
+      {
         curr_alpha = 1;
-      } else {
-        curr_alpha = (technology - tech_hi) / (tech_lo - tech_hi);
       }
-    } else {
+      else
+      {
+        curr_alpha = (technology - tech_hi)/(tech_lo - tech_hi);
+      }
+    }
+    else
+    {
       tech = tech_hi;
-      if (tech_lo == tech_hi) {
+      if (tech_lo == tech_hi)
+      {
         break;
-      } else {
-        curr_alpha = (tech_lo - technology) / (tech_lo - tech_hi);
+      }
+      else
+      {
+        curr_alpha = (tech_lo - technology)/(tech_lo - tech_hi);
       }
     }
 
-    if (tech == 90) {
-      // Aggressive projections
-      wire_pitch[0][0] = 2.5 * g_ip->F_sz_um;  // micron
+    if (tech == 90)
+    {
+      //Aggressive projections
+      wire_pitch[0][0] = 2.5 * g_ip->F_sz_um;//micron
       aspect_ratio[0][0] = 2.4;
-      wire_width = wire_pitch[0][0] / 2;                 // micron
-      wire_thickness = aspect_ratio[0][0] * wire_width;  // micron
-      wire_spacing = wire_pitch[0][0] - wire_width;      // micron
-      barrier_thickness = 0.01;                          // micron
-      dishing_thickness = 0;                             // micron
+      wire_width = wire_pitch[0][0] / 2; //micron
+      wire_thickness = aspect_ratio[0][0] * wire_width;//micron
+      wire_spacing = wire_pitch[0][0] - wire_width;//micron
+      barrier_thickness = 0.01;//micron
+      dishing_thickness = 0;//micron
       alpha_scatter = 1;
-      wire_r_per_micron[0][0] = wire_resistance(
-          CU_RESISTIVITY, wire_width, wire_thickness, barrier_thickness,
-          dishing_thickness, alpha_scatter);  // ohm/micron
-      ild_thickness[0][0] = 0.48;             // micron
+      wire_r_per_micron[0][0] = wire_resistance(CU_RESISTIVITY, wire_width,
+          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);//ohm/micron
+      ild_thickness[0][0] = 0.48;//micron
       miller_value[0][0] = 1.5;
       horiz_dielectric_constant[0][0] = 2.709;
       vert_dielectric_constant[0][0] = 3.9;
-      fringe_cap = 0.115e-15;  // F/micron
-      wire_c_per_micron[0][0] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[0][0],
-          miller_value[0][0], horiz_dielectric_constant[0][0],
+      fringe_cap = 0.115e-15; //F/micron
+      wire_c_per_micron[0][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+          ild_thickness[0][0], miller_value[0][0], horiz_dielectric_constant[0][0],
           vert_dielectric_constant[0][0],
-          fringe_cap);  // F/micron.
+          fringe_cap);//F/micron.
 
       wire_pitch[0][1] = 4 * g_ip->F_sz_um;
       wire_width = wire_pitch[0][1] / 2;
       aspect_ratio[0][1] = 2.4;
       wire_thickness = aspect_ratio[0][1] * wire_width;
       wire_spacing = wire_pitch[0][1] - wire_width;
-      wire_r_per_micron[0][1] =
-          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[0][1] = 0.48;  // micron
+      wire_r_per_micron[0][1] = wire_resistance(CU_RESISTIVITY, wire_width,
+          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][1] = 0.48;//micron
       miller_value[0][1] = 1.5;
       horiz_dielectric_constant[0][1] = 2.709;
       vert_dielectric_constant[0][1] = 3.9;
-      wire_c_per_micron[0][1] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[0][1],
-          miller_value[0][1], horiz_dielectric_constant[0][1],
-          vert_dielectric_constant[0][1], fringe_cap);
+      wire_c_per_micron[0][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+          ild_thickness[0][1], miller_value[0][1], horiz_dielectric_constant[0][1],
+          vert_dielectric_constant[0][1],
+          fringe_cap);
 
       wire_pitch[0][2] = 8 * g_ip->F_sz_um;
       aspect_ratio[0][2] = 2.7;
       wire_width = wire_pitch[0][2] / 2;
       wire_thickness = aspect_ratio[0][2] * wire_width;
       wire_spacing = wire_pitch[0][2] - wire_width;
-      wire_r_per_micron[0][2] =
-          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
+      wire_r_per_micron[0][2] = wire_resistance(CU_RESISTIVITY, wire_width,
+          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[0][2] = 0.96;
       miller_value[0][2] = 1.5;
       horiz_dielectric_constant[0][2] = 2.709;
       vert_dielectric_constant[0][2] = 3.9;
-      wire_c_per_micron[0][2] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[0][2],
-          miller_value[0][2], horiz_dielectric_constant[0][2],
-          vert_dielectric_constant[0][2], fringe_cap);
+      wire_c_per_micron[0][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+          ild_thickness[0][2], miller_value[0][2], horiz_dielectric_constant[0][2], vert_dielectric_constant[0][2],
+          fringe_cap);
 
-      // Conservative projections
+      //Conservative projections
       wire_pitch[1][0] = 2.5 * g_ip->F_sz_um;
-      aspect_ratio[1][0] = 2.0;
+      aspect_ratio[1][0]  = 2.0;
       wire_width = wire_pitch[1][0] / 2;
       wire_thickness = aspect_ratio[1][0] * wire_width;
       wire_spacing = wire_pitch[1][0] - wire_width;
       barrier_thickness = 0.008;
       dishing_thickness = 0;
       alpha_scatter = 1;
-      wire_r_per_micron[1][0] =
-          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[1][0] = 0.48;
-      miller_value[1][0] = 1.5;
-      horiz_dielectric_constant[1][0] = 3.038;
-      vert_dielectric_constant[1][0] = 3.9;
+      wire_r_per_micron[1][0] = wire_resistance(CU_RESISTIVITY, wire_width,
+          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[1][0]  = 0.48;
+      miller_value[1][0]  = 1.5;
+      horiz_dielectric_constant[1][0]  = 3.038;
+      vert_dielectric_constant[1][0]  = 3.9;
       fringe_cap = 0.115e-15;
-      wire_c_per_micron[1][0] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[1][0],
-          miller_value[1][0], horiz_dielectric_constant[1][0],
-          vert_dielectric_constant[1][0], fringe_cap);
+      wire_c_per_micron[1][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+          ild_thickness[1][0], miller_value[1][0], horiz_dielectric_constant[1][0],
+          vert_dielectric_constant[1][0],
+          fringe_cap);
 
       wire_pitch[1][1] = 4 * g_ip->F_sz_um;
       wire_width = wire_pitch[1][1] / 2;
       aspect_ratio[1][1] = 2.0;
       wire_thickness = aspect_ratio[1][1] * wire_width;
       wire_spacing = wire_pitch[1][1] - wire_width;
-      wire_r_per_micron[1][1] =
-          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[1][1] = 0.48;
-      miller_value[1][1] = 1.5;
-      horiz_dielectric_constant[1][1] = 3.038;
-      vert_dielectric_constant[1][1] = 3.9;
-      wire_c_per_micron[1][1] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[1][1],
-          miller_value[1][1], horiz_dielectric_constant[1][1],
-          vert_dielectric_constant[1][1], fringe_cap);
+      wire_r_per_micron[1][1] = wire_resistance(CU_RESISTIVITY, wire_width,
+          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[1][1]  = 0.48;
+      miller_value[1][1]  = 1.5;
+      horiz_dielectric_constant[1][1]  = 3.038;
+      vert_dielectric_constant[1][1]  = 3.9;
+      wire_c_per_micron[1][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+          ild_thickness[1][1], miller_value[1][1], horiz_dielectric_constant[1][1],
+          vert_dielectric_constant[1][1],
+          fringe_cap);
 
       wire_pitch[1][2] = 8 * g_ip->F_sz_um;
-      aspect_ratio[1][2] = 2.2;
+      aspect_ratio[1][2]  = 2.2;
       wire_width = wire_pitch[1][2] / 2;
       wire_thickness = aspect_ratio[1][2] * wire_width;
       wire_spacing = wire_pitch[1][2] - wire_width;
-      dishing_thickness = 0.1 * wire_thickness;
-      wire_r_per_micron[1][2] =
-          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[1][2] = 1.1;
-      miller_value[1][2] = 1.5;
-      horiz_dielectric_constant[1][2] = 3.038;
-      vert_dielectric_constant[1][2] = 3.9;
-      wire_c_per_micron[1][2] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[1][2],
-          miller_value[1][2], horiz_dielectric_constant[1][2],
-          vert_dielectric_constant[1][2], fringe_cap);
-      // Nominal projections for commodity DRAM wordline/bitline
+      dishing_thickness = 0.1 *  wire_thickness;
+      wire_r_per_micron[1][2] = wire_resistance(CU_RESISTIVITY, wire_width,
+          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[1][2]  = 1.1;
+      miller_value[1][2]  = 1.5;
+      horiz_dielectric_constant[1][2]  = 3.038;
+      vert_dielectric_constant[1][2]  = 3.9;
+      wire_c_per_micron[1][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+          ild_thickness[1][2] , miller_value[1][2], horiz_dielectric_constant[1][2], vert_dielectric_constant[1][2],
+          fringe_cap);
+      //Nominal projections for commodity DRAM wordline/bitline
       wire_pitch[1][3] = 2 * 0.09;
       wire_c_per_micron[1][3] = 60e-15 / (256 * 2 * 0.09);
       wire_r_per_micron[1][3] = 12 / 0.09;
-    } else if (tech == 65) {
-      // Aggressive projections
+    }
+    else if (tech == 65)
+    {
+      //Aggressive projections
       wire_pitch[0][0] = 2.5 * g_ip->F_sz_um;
-      aspect_ratio[0][0] = 2.7;
+      aspect_ratio[0][0]  = 2.7;
       wire_width = wire_pitch[0][0] / 2;
-      wire_thickness = aspect_ratio[0][0] * wire_width;
+      wire_thickness = aspect_ratio[0][0]  * wire_width;
       wire_spacing = wire_pitch[0][0] - wire_width;
       barrier_thickness = 0;
       dishing_thickness = 0;
       alpha_scatter = 1;
-      wire_r_per_micron[0][0] =
-          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[0][0] = 0.405;
-      miller_value[0][0] = 1.5;
-      horiz_dielectric_constant[0][0] = 2.303;
-      vert_dielectric_constant[0][0] = 3.9;
+      wire_r_per_micron[0][0] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
+          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][0]  = 0.405;
+      miller_value[0][0]   = 1.5;
+      horiz_dielectric_constant[0][0]  = 2.303;
+      vert_dielectric_constant[0][0]   = 3.9;
       fringe_cap = 0.115e-15;
-      wire_c_per_micron[0][0] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[0][0],
-          miller_value[0][0], horiz_dielectric_constant[0][0],
-          vert_dielectric_constant[0][0], fringe_cap);
+      wire_c_per_micron[0][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+          ild_thickness[0][0] , miller_value[0][0] , horiz_dielectric_constant[0][0] , vert_dielectric_constant[0][0] ,
+          fringe_cap);
 
       wire_pitch[0][1] = 4 * g_ip->F_sz_um;
       wire_width = wire_pitch[0][1] / 2;
-      aspect_ratio[0][1] = 2.7;
-      wire_thickness = aspect_ratio[0][1] * wire_width;
+      aspect_ratio[0][1]  = 2.7;
+      wire_thickness = aspect_ratio[0][1]  * wire_width;
       wire_spacing = wire_pitch[0][1] - wire_width;
-      wire_r_per_micron[0][1] =
-          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[0][1] = 0.405;
-      miller_value[0][1] = 1.5;
-      horiz_dielectric_constant[0][1] = 2.303;
-      vert_dielectric_constant[0][1] = 3.9;
-      wire_c_per_micron[0][1] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[0][1],
-          miller_value[0][1], horiz_dielectric_constant[0][1],
-          vert_dielectric_constant[0][1], fringe_cap);
+      wire_r_per_micron[0][1] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
+          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][1]  = 0.405;
+      miller_value[0][1]   = 1.5;
+      horiz_dielectric_constant[0][1]  = 2.303;
+      vert_dielectric_constant[0][1]   = 3.9;
+      wire_c_per_micron[0][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+          ild_thickness[0][1], miller_value[0][1], horiz_dielectric_constant[0][1],
+          vert_dielectric_constant[0][1],
+          fringe_cap);
 
       wire_pitch[0][2] = 8 * g_ip->F_sz_um;
       aspect_ratio[0][2] = 2.8;
       wire_width = wire_pitch[0][2] / 2;
       wire_thickness = aspect_ratio[0][2] * wire_width;
       wire_spacing = wire_pitch[0][2] - wire_width;
-      wire_r_per_micron[0][2] =
-          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
+      wire_r_per_micron[0][2] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
+          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[0][2] = 0.81;
-      miller_value[0][2] = 1.5;
-      horiz_dielectric_constant[0][2] = 2.303;
-      vert_dielectric_constant[0][2] = 3.9;
-      wire_c_per_micron[0][2] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[0][2],
-          miller_value[0][2], horiz_dielectric_constant[0][2],
-          vert_dielectric_constant[0][2], fringe_cap);
+      miller_value[0][2]   = 1.5;
+      horiz_dielectric_constant[0][2]  = 2.303;
+      vert_dielectric_constant[0][2]   = 3.9;
+      wire_c_per_micron[0][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+          ild_thickness[0][2], miller_value[0][2], horiz_dielectric_constant[0][2], vert_dielectric_constant[0][2],
+          fringe_cap);
 
-      // Conservative projections
+      //Conservative projections
       wire_pitch[1][0] = 2.5 * g_ip->F_sz_um;
       aspect_ratio[1][0] = 2.0;
       wire_width = wire_pitch[1][0] / 2;
@@ -2170,115 +2085,105 @@ void init_tech_params(double technology, bool is_tag) {
       barrier_thickness = 0.006;
       dishing_thickness = 0;
       alpha_scatter = 1;
-      wire_r_per_micron[1][0] =
-          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
+      wire_r_per_micron[1][0] = wire_resistance(CU_RESISTIVITY, wire_width,
+          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[1][0] = 0.405;
       miller_value[1][0] = 1.5;
       horiz_dielectric_constant[1][0] = 2.734;
       vert_dielectric_constant[1][0] = 3.9;
       fringe_cap = 0.115e-15;
-      wire_c_per_micron[1][0] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[1][0],
-          miller_value[1][0], horiz_dielectric_constant[1][0],
-          vert_dielectric_constant[1][0], fringe_cap);
+      wire_c_per_micron[1][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+          ild_thickness[1][0], miller_value[1][0], horiz_dielectric_constant[1][0], vert_dielectric_constant[1][0],
+          fringe_cap);
 
       wire_pitch[1][1] = 4 * g_ip->F_sz_um;
       wire_width = wire_pitch[1][1] / 2;
       aspect_ratio[1][1] = 2.0;
       wire_thickness = aspect_ratio[1][1] * wire_width;
       wire_spacing = wire_pitch[1][1] - wire_width;
-      wire_r_per_micron[1][1] =
-          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
+      wire_r_per_micron[1][1] = wire_resistance(CU_RESISTIVITY, wire_width,
+          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[1][1] = 0.405;
       miller_value[1][1] = 1.5;
       horiz_dielectric_constant[1][1] = 2.734;
       vert_dielectric_constant[1][1] = 3.9;
-      wire_c_per_micron[1][1] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[1][1],
-          miller_value[1][1], horiz_dielectric_constant[1][1],
-          vert_dielectric_constant[1][1], fringe_cap);
+      wire_c_per_micron[1][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+          ild_thickness[1][1], miller_value[1][1], horiz_dielectric_constant[1][1], vert_dielectric_constant[1][1],
+          fringe_cap);
 
       wire_pitch[1][2] = 8 * g_ip->F_sz_um;
       aspect_ratio[1][2] = 2.2;
       wire_width = wire_pitch[1][2] / 2;
       wire_thickness = aspect_ratio[1][2] * wire_width;
       wire_spacing = wire_pitch[1][2] - wire_width;
-      dishing_thickness = 0.1 * wire_thickness;
-      wire_r_per_micron[1][2] =
-          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
+      dishing_thickness = 0.1 *  wire_thickness;
+      wire_r_per_micron[1][2] = wire_resistance(CU_RESISTIVITY, wire_width,
+          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[1][2] = 0.77;
       miller_value[1][2] = 1.5;
       horiz_dielectric_constant[1][2] = 2.734;
       vert_dielectric_constant[1][2] = 3.9;
-      wire_c_per_micron[1][2] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[1][2],
-          miller_value[1][2], horiz_dielectric_constant[1][2],
-          vert_dielectric_constant[1][2], fringe_cap);
-      // Nominal projections for commodity DRAM wordline/bitline
+      wire_c_per_micron[1][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+          ild_thickness[1][2], miller_value[1][2], horiz_dielectric_constant[1][2], vert_dielectric_constant[1][2],
+          fringe_cap);
+      //Nominal projections for commodity DRAM wordline/bitline
       wire_pitch[1][3] = 2 * 0.065;
       wire_c_per_micron[1][3] = 52.5e-15 / (256 * 2 * 0.065);
       wire_r_per_micron[1][3] = 12 / 0.065;
-    } else if (tech == 45) {
-      // Aggressive projections.
+    }
+    else if (tech == 45)
+    {
+      //Aggressive projections.
       wire_pitch[0][0] = 2.5 * g_ip->F_sz_um;
-      aspect_ratio[0][0] = 3.0;
+      aspect_ratio[0][0]  = 3.0;
       wire_width = wire_pitch[0][0] / 2;
-      wire_thickness = aspect_ratio[0][0] * wire_width;
+      wire_thickness = aspect_ratio[0][0]  * wire_width;
       wire_spacing = wire_pitch[0][0] - wire_width;
       barrier_thickness = 0;
       dishing_thickness = 0;
       alpha_scatter = 1;
-      wire_r_per_micron[0][0] =
-          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[0][0] = 0.315;
-      miller_value[0][0] = 1.5;
-      horiz_dielectric_constant[0][0] = 1.958;
-      vert_dielectric_constant[0][0] = 3.9;
+      wire_r_per_micron[0][0] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
+          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][0]  = 0.315;
+      miller_value[0][0]  = 1.5;
+      horiz_dielectric_constant[0][0]  = 1.958;
+      vert_dielectric_constant[0][0]  = 3.9;
       fringe_cap = 0.115e-15;
-      wire_c_per_micron[0][0] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[0][0],
-          miller_value[0][0], horiz_dielectric_constant[0][0],
-          vert_dielectric_constant[0][0], fringe_cap);
+      wire_c_per_micron[0][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+          ild_thickness[0][0] , miller_value[0][0] , horiz_dielectric_constant[0][0] , vert_dielectric_constant[0][0] ,
+          fringe_cap);
 
       wire_pitch[0][1] = 4 * g_ip->F_sz_um;
       wire_width = wire_pitch[0][1] / 2;
-      aspect_ratio[0][1] = 3.0;
+      aspect_ratio[0][1]  = 3.0;
       wire_thickness = aspect_ratio[0][1] * wire_width;
       wire_spacing = wire_pitch[0][1] - wire_width;
-      wire_r_per_micron[0][1] =
-          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[0][1] = 0.315;
-      miller_value[0][1] = 1.5;
-      horiz_dielectric_constant[0][1] = 1.958;
-      vert_dielectric_constant[0][1] = 3.9;
-      wire_c_per_micron[0][1] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[0][1],
-          miller_value[0][1], horiz_dielectric_constant[0][1],
-          vert_dielectric_constant[0][1], fringe_cap);
+      wire_r_per_micron[0][1] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
+          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+      ild_thickness[0][1]  = 0.315;
+      miller_value[0][1]  = 1.5;
+      horiz_dielectric_constant[0][1]  = 1.958;
+      vert_dielectric_constant[0][1]  = 3.9;
+      wire_c_per_micron[0][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+          ild_thickness[0][1], miller_value[0][1], horiz_dielectric_constant[0][1], vert_dielectric_constant[0][1],
+          fringe_cap);
 
       wire_pitch[0][2] = 8 * g_ip->F_sz_um;
       aspect_ratio[0][2] = 3.0;
       wire_width = wire_pitch[0][2] / 2;
       wire_thickness = aspect_ratio[0][2] * wire_width;
       wire_spacing = wire_pitch[0][2] - wire_width;
-      wire_r_per_micron[0][2] =
-          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
+      wire_r_per_micron[0][2] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
+          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[0][2] = 0.63;
-      miller_value[0][2] = 1.5;
-      horiz_dielectric_constant[0][2] = 1.958;
-      vert_dielectric_constant[0][2] = 3.9;
-      wire_c_per_micron[0][2] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[0][2],
-          miller_value[0][2], horiz_dielectric_constant[0][2],
-          vert_dielectric_constant[0][2], fringe_cap);
+      miller_value[0][2]  = 1.5;
+      horiz_dielectric_constant[0][2]  = 1.958;
+      vert_dielectric_constant[0][2]  = 3.9;
+      wire_c_per_micron[0][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+          ild_thickness[0][2], miller_value[0][2], horiz_dielectric_constant[0][2], vert_dielectric_constant[0][2],
+          fringe_cap);
 
-      // Conservative projections
+      //Conservative projections
       wire_pitch[1][0] = 2.5 * g_ip->F_sz_um;
       aspect_ratio[1][0] = 2.0;
       wire_width = wire_pitch[1][0] / 2;
@@ -2287,36 +2192,32 @@ void init_tech_params(double technology, bool is_tag) {
       barrier_thickness = 0.004;
       dishing_thickness = 0;
       alpha_scatter = 1;
-      wire_r_per_micron[1][0] =
-          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
+      wire_r_per_micron[1][0] = wire_resistance(CU_RESISTIVITY, wire_width,
+          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[1][0] = 0.315;
       miller_value[1][0] = 1.5;
       horiz_dielectric_constant[1][0] = 2.46;
       vert_dielectric_constant[1][0] = 3.9;
       fringe_cap = 0.115e-15;
-      wire_c_per_micron[1][0] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[1][0],
-          miller_value[1][0], horiz_dielectric_constant[1][0],
-          vert_dielectric_constant[1][0], fringe_cap);
+      wire_c_per_micron[1][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+          ild_thickness[1][0], miller_value[1][0], horiz_dielectric_constant[1][0], vert_dielectric_constant[1][0],
+          fringe_cap);
 
       wire_pitch[1][1] = 4 * g_ip->F_sz_um;
       wire_width = wire_pitch[1][1] / 2;
       aspect_ratio[1][1] = 2.0;
       wire_thickness = aspect_ratio[1][1] * wire_width;
       wire_spacing = wire_pitch[1][1] - wire_width;
-      wire_r_per_micron[1][1] =
-          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
+      wire_r_per_micron[1][1] = wire_resistance(CU_RESISTIVITY, wire_width,
+          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[1][1] = 0.315;
       miller_value[1][1] = 1.5;
       horiz_dielectric_constant[1][1] = 2.46;
       vert_dielectric_constant[1][1] = 3.9;
       fringe_cap = 0.115e-15;
-      wire_c_per_micron[1][1] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[1][1],
-          miller_value[1][1], horiz_dielectric_constant[1][1],
-          vert_dielectric_constant[1][1], fringe_cap);
+      wire_c_per_micron[1][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+          ild_thickness[1][1], miller_value[1][1], horiz_dielectric_constant[1][1], vert_dielectric_constant[1][1],
+          fringe_cap);
 
       wire_pitch[1][2] = 8 * g_ip->F_sz_um;
       aspect_ratio[1][2] = 2.2;
@@ -2324,23 +2225,23 @@ void init_tech_params(double technology, bool is_tag) {
       wire_thickness = aspect_ratio[1][2] * wire_width;
       wire_spacing = wire_pitch[1][2] - wire_width;
       dishing_thickness = 0.1 * wire_thickness;
-      wire_r_per_micron[1][2] =
-          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
+      wire_r_per_micron[1][2] = wire_resistance(CU_RESISTIVITY, wire_width,
+          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[1][2] = 0.55;
       miller_value[1][2] = 1.5;
       horiz_dielectric_constant[1][2] = 2.46;
       vert_dielectric_constant[1][2] = 3.9;
-      wire_c_per_micron[1][2] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[1][2],
-          miller_value[1][2], horiz_dielectric_constant[1][2],
-          vert_dielectric_constant[1][2], fringe_cap);
-      // Nominal projections for commodity DRAM wordline/bitline
+      wire_c_per_micron[1][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+          ild_thickness[1][2], miller_value[1][2], horiz_dielectric_constant[1][2], vert_dielectric_constant[1][2],
+          fringe_cap);
+      //Nominal projections for commodity DRAM wordline/bitline
       wire_pitch[1][3] = 2 * 0.045;
       wire_c_per_micron[1][3] = 37.5e-15 / (256 * 2 * 0.045);
       wire_r_per_micron[1][3] = 12 / 0.045;
-    } else if (tech == 32) {
-      // Aggressive projections.
+    }
+    else if (tech == 32)
+    {
+      //Aggressive projections.
       wire_pitch[0][0] = 2.5 * g_ip->F_sz_um;
       aspect_ratio[0][0] = 3.0;
       wire_width = wire_pitch[0][0] / 2;
@@ -2349,54 +2250,48 @@ void init_tech_params(double technology, bool is_tag) {
       barrier_thickness = 0;
       dishing_thickness = 0;
       alpha_scatter = 1;
-      wire_r_per_micron[0][0] =
-          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
+      wire_r_per_micron[0][0] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
+          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[0][0] = 0.21;
       miller_value[0][0] = 1.5;
       horiz_dielectric_constant[0][0] = 1.664;
       vert_dielectric_constant[0][0] = 3.9;
       fringe_cap = 0.115e-15;
-      wire_c_per_micron[0][0] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[0][0],
-          miller_value[0][0], horiz_dielectric_constant[0][0],
-          vert_dielectric_constant[0][0], fringe_cap);
+      wire_c_per_micron[0][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+          ild_thickness[0][0], miller_value[0][0], horiz_dielectric_constant[0][0], vert_dielectric_constant[0][0],
+          fringe_cap);
 
       wire_pitch[0][1] = 4 * g_ip->F_sz_um;
       wire_width = wire_pitch[0][1] / 2;
       aspect_ratio[0][1] = 3.0;
       wire_thickness = aspect_ratio[0][1] * wire_width;
       wire_spacing = wire_pitch[0][1] - wire_width;
-      wire_r_per_micron[0][1] =
-          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
+      wire_r_per_micron[0][1] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
+          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[0][1] = 0.21;
       miller_value[0][1] = 1.5;
       horiz_dielectric_constant[0][1] = 1.664;
       vert_dielectric_constant[0][1] = 3.9;
-      wire_c_per_micron[0][1] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[0][1],
-          miller_value[0][1], horiz_dielectric_constant[0][1],
-          vert_dielectric_constant[0][1], fringe_cap);
+      wire_c_per_micron[0][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+          ild_thickness[0][1], miller_value[0][1], horiz_dielectric_constant[0][1], vert_dielectric_constant[0][1],
+          fringe_cap);
 
       wire_pitch[0][2] = 8 * g_ip->F_sz_um;
       aspect_ratio[0][2] = 3.0;
       wire_width = wire_pitch[0][2] / 2;
       wire_thickness = aspect_ratio[0][2] * wire_width;
       wire_spacing = wire_pitch[0][2] - wire_width;
-      wire_r_per_micron[0][2] =
-          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
+      wire_r_per_micron[0][2] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
+          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[0][2] = 0.42;
       miller_value[0][2] = 1.5;
       horiz_dielectric_constant[0][2] = 1.664;
       vert_dielectric_constant[0][2] = 3.9;
-      wire_c_per_micron[0][2] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[0][2],
-          miller_value[0][2], horiz_dielectric_constant[0][2],
-          vert_dielectric_constant[0][2], fringe_cap);
+      wire_c_per_micron[0][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+          ild_thickness[0][2], miller_value[0][2], horiz_dielectric_constant[0][2], vert_dielectric_constant[0][2],
+          fringe_cap);
 
-      // Conservative projections
+      //Conservative projections
       wire_pitch[1][0] = 2.5 * g_ip->F_sz_um;
       aspect_ratio[1][0] = 2.0;
       wire_width = wire_pitch[1][0] / 2;
@@ -2405,579 +2300,460 @@ void init_tech_params(double technology, bool is_tag) {
       barrier_thickness = 0.003;
       dishing_thickness = 0;
       alpha_scatter = 1;
-      wire_r_per_micron[1][0] =
-          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
+      wire_r_per_micron[1][0] = wire_resistance(CU_RESISTIVITY, wire_width,
+          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[1][0] = 0.21;
       miller_value[1][0] = 1.5;
       horiz_dielectric_constant[1][0] = 2.214;
       vert_dielectric_constant[1][0] = 3.9;
       fringe_cap = 0.115e-15;
-      wire_c_per_micron[1][0] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[1][0],
-          miller_value[1][0], horiz_dielectric_constant[1][0],
-          vert_dielectric_constant[1][0], fringe_cap);
+      wire_c_per_micron[1][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+          ild_thickness[1][0], miller_value[1][0], horiz_dielectric_constant[1][0], vert_dielectric_constant[1][0],
+          fringe_cap);
 
       wire_pitch[1][1] = 4 * g_ip->F_sz_um;
       aspect_ratio[1][1] = 2.0;
       wire_width = wire_pitch[1][1] / 2;
       wire_thickness = aspect_ratio[1][1] * wire_width;
       wire_spacing = wire_pitch[1][1] - wire_width;
-      wire_r_per_micron[1][1] =
-          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
+      wire_r_per_micron[1][1] = wire_resistance(CU_RESISTIVITY, wire_width,
+          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[1][1] = 0.21;
       miller_value[1][1] = 1.5;
       horiz_dielectric_constant[1][1] = 2.214;
       vert_dielectric_constant[1][1] = 3.9;
-      wire_c_per_micron[1][1] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[1][1],
-          miller_value[1][1], horiz_dielectric_constant[1][1],
-          vert_dielectric_constant[1][1], fringe_cap);
+      wire_c_per_micron[1][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+          ild_thickness[1][1], miller_value[1][1], horiz_dielectric_constant[1][1], vert_dielectric_constant[1][1],
+          fringe_cap);
 
       wire_pitch[1][2] = 8 * g_ip->F_sz_um;
       aspect_ratio[1][2] = 2.2;
       wire_width = wire_pitch[1][2] / 2;
       wire_thickness = aspect_ratio[1][2] * wire_width;
       wire_spacing = wire_pitch[1][2] - wire_width;
-      dishing_thickness = 0.1 * wire_thickness;
-      wire_r_per_micron[1][2] =
-          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
+      dishing_thickness = 0.1 *  wire_thickness;
+      wire_r_per_micron[1][2] = wire_resistance(CU_RESISTIVITY, wire_width,
+          wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
       ild_thickness[1][2] = 0.385;
       miller_value[1][2] = 1.5;
       horiz_dielectric_constant[1][2] = 2.214;
       vert_dielectric_constant[1][2] = 3.9;
-      wire_c_per_micron[1][2] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[1][2],
-          miller_value[1][2], horiz_dielectric_constant[1][2],
-          vert_dielectric_constant[1][2], fringe_cap);
-      // Nominal projections for commodity DRAM wordline/bitline
-      wire_pitch[1][3] = 2 * 0.032;                          // micron
-      wire_c_per_micron[1][3] = 31e-15 / (256 * 2 * 0.032);  // F/micron
-      wire_r_per_micron[1][3] = 12 / 0.032;                  // ohm/micron
-    } else if (tech == 22) {
-      // Aggressive projections.
-      wire_pitch[0][0] = 2.5 * g_ip->F_sz_um;  // local
-      aspect_ratio[0][0] = 3.0;
-      wire_width = wire_pitch[0][0] / 2;
-      wire_thickness = aspect_ratio[0][0] * wire_width;
-      wire_spacing = wire_pitch[0][0] - wire_width;
-      barrier_thickness = 0;
-      dishing_thickness = 0;
-      alpha_scatter = 1;
-      wire_r_per_micron[0][0] =
-          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[0][0] = 0.15;
-      miller_value[0][0] = 1.5;
-      horiz_dielectric_constant[0][0] = 1.414;
-      vert_dielectric_constant[0][0] = 3.9;
-      fringe_cap = 0.115e-15;
-      wire_c_per_micron[0][0] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[0][0],
-          miller_value[0][0], horiz_dielectric_constant[0][0],
-          vert_dielectric_constant[0][0], fringe_cap);
-
-      wire_pitch[0][1] = 4 * g_ip->F_sz_um;  // semi-global
-      wire_width = wire_pitch[0][1] / 2;
-      aspect_ratio[0][1] = 3.0;
-      wire_thickness = aspect_ratio[0][1] * wire_width;
-      wire_spacing = wire_pitch[0][1] - wire_width;
-      wire_r_per_micron[0][1] =
-          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[0][1] = 0.15;
-      miller_value[0][1] = 1.5;
-      horiz_dielectric_constant[0][1] = 1.414;
-      vert_dielectric_constant[0][1] = 3.9;
-      wire_c_per_micron[0][1] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[0][1],
-          miller_value[0][1], horiz_dielectric_constant[0][1],
-          vert_dielectric_constant[0][1], fringe_cap);
-
-      wire_pitch[0][2] = 8 * g_ip->F_sz_um;  // global
-      aspect_ratio[0][2] = 3.0;
-      wire_width = wire_pitch[0][2] / 2;
-      wire_thickness = aspect_ratio[0][2] * wire_width;
-      wire_spacing = wire_pitch[0][2] - wire_width;
-      wire_r_per_micron[0][2] =
-          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[0][2] = 0.3;
-      miller_value[0][2] = 1.5;
-      horiz_dielectric_constant[0][2] = 1.414;
-      vert_dielectric_constant[0][2] = 3.9;
-      wire_c_per_micron[0][2] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[0][2],
-          miller_value[0][2], horiz_dielectric_constant[0][2],
-          vert_dielectric_constant[0][2], fringe_cap);
-
-      //          //*************************
-      //          wire_pitch[0][4] = 16 * g_ip.F_sz_um;//global
-      //          aspect_ratio = 3.0;
-      //          wire_width = wire_pitch[0][4] / 2;
-      //          wire_thickness = aspect_ratio * wire_width;
-      //          wire_spacing = wire_pitch[0][4] - wire_width;
-      //          wire_r_per_micron[0][4] = wire_resistance(BULK_CU_RESISTIVITY,
-      //          wire_width,
-      //        		  wire_thickness, barrier_thickness,
-      //        dishing_thickness, alpha_scatter);
-      //          ild_thickness = 0.3;
-      //          wire_c_per_micron[0][4] = wire_capacitance(wire_width,
-      //          wire_thickness, wire_spacing,
-      //        		  ild_thickness, miller_value,
-      //        horiz_dielectric_constant, vert_dielectric_constant,
-      //        		  fringe_cap);
-      //
-      //          wire_pitch[0][5] = 24 * g_ip.F_sz_um;//global
-      //          aspect_ratio = 3.0;
-      //          wire_width = wire_pitch[0][5] / 2;
-      //          wire_thickness = aspect_ratio * wire_width;
-      //          wire_spacing = wire_pitch[0][5] - wire_width;
-      //          wire_r_per_micron[0][5] = wire_resistance(BULK_CU_RESISTIVITY,
-      //          wire_width,
-      //        		  wire_thickness, barrier_thickness,
-      //        dishing_thickness, alpha_scatter);
-      //          ild_thickness = 0.3;
-      //          wire_c_per_micron[0][5] = wire_capacitance(wire_width,
-      //          wire_thickness, wire_spacing,
-      //        		  ild_thickness, miller_value,
-      //        horiz_dielectric_constant, vert_dielectric_constant,
-      //        		  fringe_cap);
-      //
-      //          wire_pitch[0][6] = 32 * g_ip.F_sz_um;//global
-      //          aspect_ratio = 3.0;
-      //          wire_width = wire_pitch[0][6] / 2;
-      //          wire_thickness = aspect_ratio * wire_width;
-      //          wire_spacing = wire_pitch[0][6] - wire_width;
-      //          wire_r_per_micron[0][6] = wire_resistance(BULK_CU_RESISTIVITY,
-      //          wire_width,
-      //        		  wire_thickness, barrier_thickness,
-      //        dishing_thickness, alpha_scatter);
-      //          ild_thickness = 0.3;
-      //          wire_c_per_micron[0][6] = wire_capacitance(wire_width,
-      //          wire_thickness, wire_spacing,
-      //        		  ild_thickness, miller_value,
-      //        horiz_dielectric_constant, vert_dielectric_constant,
-      //        		  fringe_cap);
-      //*************************
-
-      // Conservative projections
-      wire_pitch[1][0] = 2.5 * g_ip->F_sz_um;
-      aspect_ratio[1][0] = 2.0;
-      wire_width = wire_pitch[1][0] / 2;
-      wire_thickness = aspect_ratio[1][0] * wire_width;
-      wire_spacing = wire_pitch[1][0] - wire_width;
-      barrier_thickness = 0.003;
-      dishing_thickness = 0;
-      alpha_scatter = 1.05;
-      wire_r_per_micron[1][0] =
-          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[1][0] = 0.15;
-      miller_value[1][0] = 1.5;
-      horiz_dielectric_constant[1][0] = 2.104;
-      vert_dielectric_constant[1][0] = 3.9;
-      fringe_cap = 0.115e-15;
-      wire_c_per_micron[1][0] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[1][0],
-          miller_value[1][0], horiz_dielectric_constant[1][0],
-          vert_dielectric_constant[1][0], fringe_cap);
-
-      wire_pitch[1][1] = 4 * g_ip->F_sz_um;
-      wire_width = wire_pitch[1][1] / 2;
-      aspect_ratio[1][1] = 2.0;
-      wire_thickness = aspect_ratio[1][1] * wire_width;
-      wire_spacing = wire_pitch[1][1] - wire_width;
-      wire_r_per_micron[1][1] =
-          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[1][1] = 0.15;
-      miller_value[1][1] = 1.5;
-      horiz_dielectric_constant[1][1] = 2.104;
-      vert_dielectric_constant[1][1] = 3.9;
-      wire_c_per_micron[1][1] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[1][1],
-          miller_value[1][1], horiz_dielectric_constant[1][1],
-          vert_dielectric_constant[1][1], fringe_cap);
-
-      wire_pitch[1][2] = 8 * g_ip->F_sz_um;
-      aspect_ratio[1][2] = 2.2;
-      wire_width = wire_pitch[1][2] / 2;
-      wire_thickness = aspect_ratio[1][2] * wire_width;
-      wire_spacing = wire_pitch[1][2] - wire_width;
-      dishing_thickness = 0.1 * wire_thickness;
-      wire_r_per_micron[1][2] =
-          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[1][2] = 0.275;
-      miller_value[1][2] = 1.5;
-      horiz_dielectric_constant[1][2] = 2.104;
-      vert_dielectric_constant[1][2] = 3.9;
-      wire_c_per_micron[1][2] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[1][2],
-          miller_value[1][2], horiz_dielectric_constant[1][2],
-          vert_dielectric_constant[1][2], fringe_cap);
-      // Nominal projections for commodity DRAM wordline/bitline
-      wire_pitch[1][3] = 2 * 0.022;                          // micron
-      wire_c_per_micron[1][3] = 31e-15 / (256 * 2 * 0.022);  // F/micron
-      wire_r_per_micron[1][3] = 12 / 0.022;                  // ohm/micron
-
-      //******************
-      //            wire_pitch[1][4] = 16 * g_ip.F_sz_um;
-      //            aspect_ratio = 2.2;
-      //            wire_width = wire_pitch[1][4] / 2;
-      //            wire_thickness = aspect_ratio * wire_width;
-      //            wire_spacing = wire_pitch[1][4] - wire_width;
-      //            dishing_thickness = 0.1 *  wire_thickness;
-      //            wire_r_per_micron[1][4] = wire_resistance(CU_RESISTIVITY,
-      //            wire_width,
-      //            		wire_thickness, barrier_thickness,
-      //            dishing_thickness, alpha_scatter);
-      //            ild_thickness = 0.275;
-      //            wire_c_per_micron[1][4] = wire_capacitance(wire_width,
-      //            wire_thickness, wire_spacing,
-      //            		ild_thickness, miller_value,
-      //            horiz_dielectric_constant, vert_dielectric_constant,
-      //            		fringe_cap);
-      //
-      //            wire_pitch[1][5] = 24 * g_ip.F_sz_um;
-      //            aspect_ratio = 2.2;
-      //            wire_width = wire_pitch[1][5] / 2;
-      //            wire_thickness = aspect_ratio * wire_width;
-      //            wire_spacing = wire_pitch[1][5] - wire_width;
-      //            dishing_thickness = 0.1 *  wire_thickness;
-      //            wire_r_per_micron[1][5] = wire_resistance(CU_RESISTIVITY,
-      //            wire_width,
-      //            		wire_thickness, barrier_thickness,
-      //            dishing_thickness, alpha_scatter);
-      //            ild_thickness = 0.275;
-      //            wire_c_per_micron[1][5] = wire_capacitance(wire_width,
-      //            wire_thickness, wire_spacing,
-      //            		ild_thickness, miller_value,
-      //            horiz_dielectric_constant, vert_dielectric_constant,
-      //            		fringe_cap);
-      //
-      //            wire_pitch[1][6] = 32 * g_ip.F_sz_um;
-      //            aspect_ratio = 2.2;
-      //            wire_width = wire_pitch[1][6] / 2;
-      //            wire_thickness = aspect_ratio * wire_width;
-      //            wire_spacing = wire_pitch[1][6] - wire_width;
-      //            dishing_thickness = 0.1 *  wire_thickness;
-      //            wire_r_per_micron[1][6] = wire_resistance(CU_RESISTIVITY,
-      //            wire_width,
-      //            		wire_thickness, barrier_thickness,
-      //            dishing_thickness, alpha_scatter);
-      //            ild_thickness = 0.275;
-      //            wire_c_per_micron[1][6] = wire_capacitance(wire_width,
-      //            wire_thickness, wire_spacing,
-      //            		ild_thickness, miller_value,
-      //            horiz_dielectric_constant, vert_dielectric_constant,
-      //            		fringe_cap);
+      wire_c_per_micron[1][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+          ild_thickness[1][2], miller_value[1][2], horiz_dielectric_constant[1][2], vert_dielectric_constant[1][2],
+          fringe_cap);
+      //Nominal projections for commodity DRAM wordline/bitline
+      wire_pitch[1][3] = 2 * 0.032;//micron
+      wire_c_per_micron[1][3] = 31e-15 / (256 * 2 * 0.032);//F/micron
+      wire_r_per_micron[1][3] = 12 / 0.032;//ohm/micron
     }
+    else if (tech == 22)
+        {
+          //Aggressive projections.
+          wire_pitch[0][0] = 2.5 * g_ip->F_sz_um;//local
+          aspect_ratio[0][0] = 3.0;
+          wire_width = wire_pitch[0][0] / 2;
+          wire_thickness = aspect_ratio[0][0] * wire_width;
+          wire_spacing = wire_pitch[0][0] - wire_width;
+          barrier_thickness = 0;
+          dishing_thickness = 0;
+          alpha_scatter = 1;
+          wire_r_per_micron[0][0] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
+            wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+          ild_thickness[0][0] = 0.15;
+          miller_value[0][0] = 1.5;
+          horiz_dielectric_constant[0][0] = 1.414;
+          vert_dielectric_constant[0][0] = 3.9;
+          fringe_cap = 0.115e-15;
+          wire_c_per_micron[0][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+            ild_thickness[0][0], miller_value[0][0], horiz_dielectric_constant[0][0], vert_dielectric_constant[0][0],
+            fringe_cap);
 
-    else if (tech == 16) {
-      // Aggressive projections.
-      wire_pitch[0][0] = 2.5 * g_ip->F_sz_um;  // local
-      aspect_ratio[0][0] = 3.0;
-      wire_width = wire_pitch[0][0] / 2;
-      wire_thickness = aspect_ratio[0][0] * wire_width;
-      wire_spacing = wire_pitch[0][0] - wire_width;
-      barrier_thickness = 0;
-      dishing_thickness = 0;
-      alpha_scatter = 1;
-      wire_r_per_micron[0][0] =
-          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[0][0] = 0.108;
-      miller_value[0][0] = 1.5;
-      horiz_dielectric_constant[0][0] = 1.202;
-      vert_dielectric_constant[0][0] = 3.9;
-      fringe_cap = 0.115e-15;
-      wire_c_per_micron[0][0] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[0][0],
-          miller_value[0][0], horiz_dielectric_constant[0][0],
-          vert_dielectric_constant[0][0], fringe_cap);
+          wire_pitch[0][1] = 4 * g_ip->F_sz_um;//semi-global
+          wire_width = wire_pitch[0][1] / 2;
+          aspect_ratio[0][1] = 3.0;
+          wire_thickness = aspect_ratio[0][1] * wire_width;
+          wire_spacing = wire_pitch[0][1] - wire_width;
+          wire_r_per_micron[0][1] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
+            wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+          ild_thickness[0][1] = 0.15;
+          miller_value[0][1] = 1.5;
+          horiz_dielectric_constant[0][1] = 1.414;
+          vert_dielectric_constant[0][1] = 3.9;
+          wire_c_per_micron[0][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+            ild_thickness[0][1], miller_value[0][1], horiz_dielectric_constant[0][1], vert_dielectric_constant[0][1],
+            fringe_cap);
 
-      wire_pitch[0][1] = 4 * g_ip->F_sz_um;  // semi-global
-      aspect_ratio[0][1] = 3.0;
-      wire_width = wire_pitch[0][1] / 2;
-      wire_thickness = aspect_ratio[0][1] * wire_width;
-      wire_spacing = wire_pitch[0][1] - wire_width;
-      wire_r_per_micron[0][1] =
-          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[0][1] = 0.108;
-      miller_value[0][1] = 1.5;
-      horiz_dielectric_constant[0][1] = 1.202;
-      vert_dielectric_constant[0][1] = 3.9;
-      wire_c_per_micron[0][1] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[0][1],
-          miller_value[0][1], horiz_dielectric_constant[0][1],
-          vert_dielectric_constant[0][1], fringe_cap);
+          wire_pitch[0][2] = 8 * g_ip->F_sz_um;//global
+          aspect_ratio[0][2] = 3.0;
+          wire_width = wire_pitch[0][2] / 2;
+          wire_thickness = aspect_ratio[0][2] * wire_width;
+          wire_spacing = wire_pitch[0][2] - wire_width;
+          wire_r_per_micron[0][2] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
+        		  wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+          ild_thickness[0][2] = 0.3;
+          miller_value[0][2] = 1.5;
+          horiz_dielectric_constant[0][2] = 1.414;
+          vert_dielectric_constant[0][2] = 3.9;
+          wire_c_per_micron[0][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+        		  ild_thickness[0][2], miller_value[0][2], horiz_dielectric_constant[0][2], vert_dielectric_constant[0][2],
+        		  fringe_cap);
 
-      wire_pitch[0][2] = 8 * g_ip->F_sz_um;  // global
-      aspect_ratio[0][2] = 3.0;
-      wire_width = wire_pitch[0][2] / 2;
-      wire_thickness = aspect_ratio[0][2] * wire_width;
-      wire_spacing = wire_pitch[0][2] - wire_width;
-      wire_r_per_micron[0][2] =
-          wire_resistance(BULK_CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[0][2] = 0.216;
-      miller_value[0][2] = 1.5;
-      horiz_dielectric_constant[0][2] = 1.202;
-      vert_dielectric_constant[0][2] = 3.9;
-      wire_c_per_micron[0][2] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[0][2],
-          miller_value[0][2], horiz_dielectric_constant[0][2],
-          vert_dielectric_constant[0][2], fringe_cap);
+//          //*************************
+//          wire_pitch[0][4] = 16 * g_ip.F_sz_um;//global
+//          aspect_ratio = 3.0;
+//          wire_width = wire_pitch[0][4] / 2;
+//          wire_thickness = aspect_ratio * wire_width;
+//          wire_spacing = wire_pitch[0][4] - wire_width;
+//          wire_r_per_micron[0][4] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
+//        		  wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+//          ild_thickness = 0.3;
+//          wire_c_per_micron[0][4] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+//        		  ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
+//        		  fringe_cap);
+//
+//          wire_pitch[0][5] = 24 * g_ip.F_sz_um;//global
+//          aspect_ratio = 3.0;
+//          wire_width = wire_pitch[0][5] / 2;
+//          wire_thickness = aspect_ratio * wire_width;
+//          wire_spacing = wire_pitch[0][5] - wire_width;
+//          wire_r_per_micron[0][5] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
+//        		  wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+//          ild_thickness = 0.3;
+//          wire_c_per_micron[0][5] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+//        		  ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
+//        		  fringe_cap);
+//
+//          wire_pitch[0][6] = 32 * g_ip.F_sz_um;//global
+//          aspect_ratio = 3.0;
+//          wire_width = wire_pitch[0][6] / 2;
+//          wire_thickness = aspect_ratio * wire_width;
+//          wire_spacing = wire_pitch[0][6] - wire_width;
+//          wire_r_per_micron[0][6] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
+//        		  wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+//          ild_thickness = 0.3;
+//          wire_c_per_micron[0][6] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+//        		  ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
+//        		  fringe_cap);
+          //*************************
 
-      //          //*************************
-      //          wire_pitch[0][4] = 16 * g_ip.F_sz_um;//global
-      //          aspect_ratio = 3.0;
-      //          wire_width = wire_pitch[0][4] / 2;
-      //          wire_thickness = aspect_ratio * wire_width;
-      //          wire_spacing = wire_pitch[0][4] - wire_width;
-      //          wire_r_per_micron[0][4] = wire_resistance(BULK_CU_RESISTIVITY,
-      //          wire_width,
-      //        		  wire_thickness, barrier_thickness,
-      //        dishing_thickness, alpha_scatter);
-      //          ild_thickness = 0.3;
-      //          wire_c_per_micron[0][4] = wire_capacitance(wire_width,
-      //          wire_thickness, wire_spacing,
-      //        		  ild_thickness, miller_value,
-      //        horiz_dielectric_constant, vert_dielectric_constant,
-      //        		  fringe_cap);
-      //
-      //          wire_pitch[0][5] = 24 * g_ip.F_sz_um;//global
-      //          aspect_ratio = 3.0;
-      //          wire_width = wire_pitch[0][5] / 2;
-      //          wire_thickness = aspect_ratio * wire_width;
-      //          wire_spacing = wire_pitch[0][5] - wire_width;
-      //          wire_r_per_micron[0][5] = wire_resistance(BULK_CU_RESISTIVITY,
-      //          wire_width,
-      //        		  wire_thickness, barrier_thickness,
-      //        dishing_thickness, alpha_scatter);
-      //          ild_thickness = 0.3;
-      //          wire_c_per_micron[0][5] = wire_capacitance(wire_width,
-      //          wire_thickness, wire_spacing,
-      //        		  ild_thickness, miller_value,
-      //        horiz_dielectric_constant, vert_dielectric_constant,
-      //        		  fringe_cap);
-      //
-      //          wire_pitch[0][6] = 32 * g_ip.F_sz_um;//global
-      //          aspect_ratio = 3.0;
-      //          wire_width = wire_pitch[0][6] / 2;
-      //          wire_thickness = aspect_ratio * wire_width;
-      //          wire_spacing = wire_pitch[0][6] - wire_width;
-      //          wire_r_per_micron[0][6] = wire_resistance(BULK_CU_RESISTIVITY,
-      //          wire_width,
-      //        		  wire_thickness, barrier_thickness,
-      //        dishing_thickness, alpha_scatter);
-      //          ild_thickness = 0.3;
-      //          wire_c_per_micron[0][6] = wire_capacitance(wire_width,
-      //          wire_thickness, wire_spacing,
-      //        		  ild_thickness, miller_value,
-      //        horiz_dielectric_constant, vert_dielectric_constant,
-      //        		  fringe_cap);
-      //*************************
+          //Conservative projections
+          wire_pitch[1][0] = 2.5 * g_ip->F_sz_um;
+          aspect_ratio[1][0] = 2.0;
+          wire_width = wire_pitch[1][0] / 2;
+          wire_thickness = aspect_ratio[1][0] * wire_width;
+          wire_spacing = wire_pitch[1][0] - wire_width;
+          barrier_thickness = 0.003;
+          dishing_thickness = 0;
+          alpha_scatter = 1.05;
+          wire_r_per_micron[1][0] = wire_resistance(CU_RESISTIVITY, wire_width,
+            wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+          ild_thickness[1][0] = 0.15;
+          miller_value[1][0] = 1.5;
+          horiz_dielectric_constant[1][0] = 2.104;
+          vert_dielectric_constant[1][0] = 3.9;
+          fringe_cap = 0.115e-15;
+          wire_c_per_micron[1][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+            ild_thickness[1][0], miller_value[1][0], horiz_dielectric_constant[1][0], vert_dielectric_constant[1][0],
+            fringe_cap);
 
-      // Conservative projections
-      wire_pitch[1][0] = 2.5 * g_ip->F_sz_um;
-      aspect_ratio[1][0] = 2.0;
-      wire_width = wire_pitch[1][0] / 2;
-      wire_thickness = aspect_ratio[1][0] * wire_width;
-      wire_spacing = wire_pitch[1][0] - wire_width;
-      barrier_thickness = 0.002;
-      dishing_thickness = 0;
-      alpha_scatter = 1.05;
-      wire_r_per_micron[1][0] =
-          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[1][0] = 0.108;
-      miller_value[1][0] = 1.5;
-      horiz_dielectric_constant[1][0] = 1.998;
-      vert_dielectric_constant[1][0] = 3.9;
-      fringe_cap = 0.115e-15;
-      wire_c_per_micron[1][0] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[1][0],
-          miller_value[1][0], horiz_dielectric_constant[1][0],
-          vert_dielectric_constant[1][0], fringe_cap);
+          wire_pitch[1][1] = 4 * g_ip->F_sz_um;
+          wire_width = wire_pitch[1][1] / 2;
+          aspect_ratio[1][1] = 2.0;
+          wire_thickness = aspect_ratio[1][1] * wire_width;
+          wire_spacing = wire_pitch[1][1] - wire_width;
+          wire_r_per_micron[1][1] = wire_resistance(CU_RESISTIVITY, wire_width,
+            wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+          ild_thickness[1][1] = 0.15;
+          miller_value[1][1] = 1.5;
+          horiz_dielectric_constant[1][1] = 2.104;
+          vert_dielectric_constant[1][1] = 3.9;
+          wire_c_per_micron[1][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+            ild_thickness[1][1], miller_value[1][1], horiz_dielectric_constant[1][1], vert_dielectric_constant[1][1],
+            fringe_cap);
 
-      wire_pitch[1][1] = 4 * g_ip->F_sz_um;
-      wire_width = wire_pitch[1][1] / 2;
-      aspect_ratio[1][1] = 2.0;
-      wire_thickness = aspect_ratio[1][1] * wire_width;
-      wire_spacing = wire_pitch[1][1] - wire_width;
-      wire_r_per_micron[1][1] =
-          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[1][1] = 0.108;
-      miller_value[1][1] = 1.5;
-      horiz_dielectric_constant[1][1] = 1.998;
-      vert_dielectric_constant[1][1] = 3.9;
-      wire_c_per_micron[1][1] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[1][1],
-          miller_value[1][1], horiz_dielectric_constant[1][1],
-          vert_dielectric_constant[1][1], fringe_cap);
+            wire_pitch[1][2] = 8 * g_ip->F_sz_um;
+            aspect_ratio[1][2] = 2.2;
+            wire_width = wire_pitch[1][2] / 2;
+            wire_thickness = aspect_ratio[1][2] * wire_width;
+            wire_spacing = wire_pitch[1][2] - wire_width;
+            dishing_thickness = 0.1 *  wire_thickness;
+            wire_r_per_micron[1][2] = wire_resistance(CU_RESISTIVITY, wire_width,
+            		wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+            ild_thickness[1][2] = 0.275;
+            miller_value[1][2] = 1.5;
+            horiz_dielectric_constant[1][2] = 2.104;
+            vert_dielectric_constant[1][2] = 3.9;
+            wire_c_per_micron[1][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+            		ild_thickness[1][2], miller_value[1][2], horiz_dielectric_constant[1][2], vert_dielectric_constant[1][2],
+            		fringe_cap);
+            //Nominal projections for commodity DRAM wordline/bitline
+            wire_pitch[1][3] = 2 * 0.022;//micron
+            wire_c_per_micron[1][3] = 31e-15 / (256 * 2 * 0.022);//F/micron
+            wire_r_per_micron[1][3] = 12 / 0.022;//ohm/micron
 
-      wire_pitch[1][2] = 8 * g_ip->F_sz_um;
-      aspect_ratio[1][2] = 2.2;
-      wire_width = wire_pitch[1][2] / 2;
-      wire_thickness = aspect_ratio[1][2] * wire_width;
-      wire_spacing = wire_pitch[1][2] - wire_width;
-      dishing_thickness = 0.1 * wire_thickness;
-      wire_r_per_micron[1][2] =
-          wire_resistance(CU_RESISTIVITY, wire_width, wire_thickness,
-                          barrier_thickness, dishing_thickness, alpha_scatter);
-      ild_thickness[1][2] = 0.198;
-      miller_value[1][2] = 1.5;
-      horiz_dielectric_constant[1][2] = 1.998;
-      vert_dielectric_constant[1][2] = 3.9;
-      wire_c_per_micron[1][2] = wire_capacitance(
-          wire_width, wire_thickness, wire_spacing, ild_thickness[1][2],
-          miller_value[1][2], horiz_dielectric_constant[1][2],
-          vert_dielectric_constant[1][2], fringe_cap);
-      // Nominal projections for commodity DRAM wordline/bitline
-      wire_pitch[1][3] = 2 * 0.016;                          // micron
-      wire_c_per_micron[1][3] = 31e-15 / (256 * 2 * 0.016);  // F/micron
-      wire_r_per_micron[1][3] = 12 / 0.016;                  // ohm/micron
+            //******************
+//            wire_pitch[1][4] = 16 * g_ip.F_sz_um;
+//            aspect_ratio = 2.2;
+//            wire_width = wire_pitch[1][4] / 2;
+//            wire_thickness = aspect_ratio * wire_width;
+//            wire_spacing = wire_pitch[1][4] - wire_width;
+//            dishing_thickness = 0.1 *  wire_thickness;
+//            wire_r_per_micron[1][4] = wire_resistance(CU_RESISTIVITY, wire_width,
+//            		wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+//            ild_thickness = 0.275;
+//            wire_c_per_micron[1][4] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+//            		ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
+//            		fringe_cap);
+//
+//            wire_pitch[1][5] = 24 * g_ip.F_sz_um;
+//            aspect_ratio = 2.2;
+//            wire_width = wire_pitch[1][5] / 2;
+//            wire_thickness = aspect_ratio * wire_width;
+//            wire_spacing = wire_pitch[1][5] - wire_width;
+//            dishing_thickness = 0.1 *  wire_thickness;
+//            wire_r_per_micron[1][5] = wire_resistance(CU_RESISTIVITY, wire_width,
+//            		wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+//            ild_thickness = 0.275;
+//            wire_c_per_micron[1][5] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+//            		ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
+//            		fringe_cap);
+//
+//            wire_pitch[1][6] = 32 * g_ip.F_sz_um;
+//            aspect_ratio = 2.2;
+//            wire_width = wire_pitch[1][6] / 2;
+//            wire_thickness = aspect_ratio * wire_width;
+//            wire_spacing = wire_pitch[1][6] - wire_width;
+//            dishing_thickness = 0.1 *  wire_thickness;
+//            wire_r_per_micron[1][6] = wire_resistance(CU_RESISTIVITY, wire_width,
+//            		wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+//            ild_thickness = 0.275;
+//            wire_c_per_micron[1][6] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+//            		ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
+//            		fringe_cap);
+        }
 
-      //******************
-      //            wire_pitch[1][4] = 16 * g_ip.F_sz_um;
-      //            aspect_ratio = 2.2;
-      //            wire_width = wire_pitch[1][4] / 2;
-      //            wire_thickness = aspect_ratio * wire_width;
-      //            wire_spacing = wire_pitch[1][4] - wire_width;
-      //            dishing_thickness = 0.1 *  wire_thickness;
-      //            wire_r_per_micron[1][4] = wire_resistance(CU_RESISTIVITY,
-      //            wire_width,
-      //            		wire_thickness, barrier_thickness,
-      //            dishing_thickness, alpha_scatter);
-      //            ild_thickness = 0.275;
-      //            wire_c_per_micron[1][4] = wire_capacitance(wire_width,
-      //            wire_thickness, wire_spacing,
-      //            		ild_thickness, miller_value,
-      //            horiz_dielectric_constant, vert_dielectric_constant,
-      //            		fringe_cap);
-      //
-      //            wire_pitch[1][5] = 24 * g_ip.F_sz_um;
-      //            aspect_ratio = 2.2;
-      //            wire_width = wire_pitch[1][5] / 2;
-      //            wire_thickness = aspect_ratio * wire_width;
-      //            wire_spacing = wire_pitch[1][5] - wire_width;
-      //            dishing_thickness = 0.1 *  wire_thickness;
-      //            wire_r_per_micron[1][5] = wire_resistance(CU_RESISTIVITY,
-      //            wire_width,
-      //            		wire_thickness, barrier_thickness,
-      //            dishing_thickness, alpha_scatter);
-      //            ild_thickness = 0.275;
-      //            wire_c_per_micron[1][5] = wire_capacitance(wire_width,
-      //            wire_thickness, wire_spacing,
-      //            		ild_thickness, miller_value,
-      //            horiz_dielectric_constant, vert_dielectric_constant,
-      //            		fringe_cap);
-      //
-      //            wire_pitch[1][6] = 32 * g_ip.F_sz_um;
-      //            aspect_ratio = 2.2;
-      //            wire_width = wire_pitch[1][6] / 2;
-      //            wire_thickness = aspect_ratio * wire_width;
-      //            wire_spacing = wire_pitch[1][6] - wire_width;
-      //            dishing_thickness = 0.1 *  wire_thickness;
-      //            wire_r_per_micron[1][6] = wire_resistance(CU_RESISTIVITY,
-      //            wire_width,
-      //            		wire_thickness, barrier_thickness,
-      //            dishing_thickness, alpha_scatter);
-      //            ild_thickness = 0.275;
-      //            wire_c_per_micron[1][6] = wire_capacitance(wire_width,
-      //            wire_thickness, wire_spacing,
-      //            		ild_thickness, miller_value,
-      //            horiz_dielectric_constant, vert_dielectric_constant,
-      //            		fringe_cap);
-    }
-    g_tp.wire_local.pitch +=
-        curr_alpha * wire_pitch[g_ip->ic_proj_type]
-                               [(ram_cell_tech_type == comm_dram) ? 3 : 0];
-    g_tp.wire_local.R_per_um +=
-        curr_alpha *
-        wire_r_per_micron[g_ip->ic_proj_type]
-                         [(ram_cell_tech_type == comm_dram) ? 3 : 0];
-    g_tp.wire_local.C_per_um +=
-        curr_alpha *
-        wire_c_per_micron[g_ip->ic_proj_type]
-                         [(ram_cell_tech_type == comm_dram) ? 3 : 0];
-    g_tp.wire_local.aspect_ratio +=
-        curr_alpha * aspect_ratio[g_ip->ic_proj_type]
-                                 [(ram_cell_tech_type == comm_dram) ? 3 : 0];
-    g_tp.wire_local.ild_thickness +=
-        curr_alpha * ild_thickness[g_ip->ic_proj_type]
-                                  [(ram_cell_tech_type == comm_dram) ? 3 : 0];
-    g_tp.wire_local.miller_value +=
-        curr_alpha * miller_value[g_ip->ic_proj_type]
-                                 [(ram_cell_tech_type == comm_dram) ? 3 : 0];
-    g_tp.wire_local.horiz_dielectric_constant +=
-        curr_alpha *
-        horiz_dielectric_constant[g_ip->ic_proj_type]
-                                 [(ram_cell_tech_type == comm_dram) ? 3 : 0];
-    g_tp.wire_local.vert_dielectric_constant +=
-        curr_alpha *
-        vert_dielectric_constant[g_ip->ic_proj_type]
-                                [(ram_cell_tech_type == comm_dram) ? 3 : 0];
+    else if (tech == 16)
+        {
+          //Aggressive projections.
+          wire_pitch[0][0] = 2.5 * g_ip->F_sz_um;//local
+          aspect_ratio[0][0] = 3.0;
+          wire_width = wire_pitch[0][0] / 2;
+          wire_thickness = aspect_ratio[0][0] * wire_width;
+          wire_spacing = wire_pitch[0][0] - wire_width;
+          barrier_thickness = 0;
+          dishing_thickness = 0;
+          alpha_scatter = 1;
+          wire_r_per_micron[0][0] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
+            wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+          ild_thickness[0][0] = 0.108;
+          miller_value[0][0] = 1.5;
+          horiz_dielectric_constant[0][0] = 1.202;
+          vert_dielectric_constant[0][0] = 3.9;
+          fringe_cap = 0.115e-15;
+          wire_c_per_micron[0][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+            ild_thickness[0][0], miller_value[0][0], horiz_dielectric_constant[0][0], vert_dielectric_constant[0][0],
+            fringe_cap);
 
-    g_tp.wire_inside_mat.pitch +=
-        curr_alpha * wire_pitch[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
-    g_tp.wire_inside_mat.R_per_um +=
-        curr_alpha *
-        wire_r_per_micron[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
-    g_tp.wire_inside_mat.C_per_um +=
-        curr_alpha *
-        wire_c_per_micron[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
-    g_tp.wire_inside_mat.aspect_ratio +=
-        curr_alpha * aspect_ratio[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
-    g_tp.wire_inside_mat.ild_thickness +=
-        curr_alpha * ild_thickness[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
-    g_tp.wire_inside_mat.miller_value +=
-        curr_alpha * miller_value[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
-    g_tp.wire_inside_mat.horiz_dielectric_constant +=
-        curr_alpha *
-        horiz_dielectric_constant[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
-    g_tp.wire_inside_mat.vert_dielectric_constant +=
-        curr_alpha *
-        vert_dielectric_constant[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
+          wire_pitch[0][1] = 4 * g_ip->F_sz_um;//semi-global
+          aspect_ratio[0][1] = 3.0;
+          wire_width = wire_pitch[0][1] / 2;
+          wire_thickness = aspect_ratio[0][1] * wire_width;
+          wire_spacing = wire_pitch[0][1] - wire_width;
+          wire_r_per_micron[0][1] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
+            wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+          ild_thickness[0][1] = 0.108;
+          miller_value[0][1] = 1.5;
+          horiz_dielectric_constant[0][1] = 1.202;
+          vert_dielectric_constant[0][1] = 3.9;
+          wire_c_per_micron[0][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+            ild_thickness[0][1], miller_value[0][1], horiz_dielectric_constant[0][1], vert_dielectric_constant[0][1],
+            fringe_cap);
 
-    g_tp.wire_outside_mat.pitch +=
-        curr_alpha * wire_pitch[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
-    g_tp.wire_outside_mat.R_per_um +=
-        curr_alpha *
-        wire_r_per_micron[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
-    g_tp.wire_outside_mat.C_per_um +=
-        curr_alpha *
-        wire_c_per_micron[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
-    g_tp.wire_outside_mat.aspect_ratio +=
-        curr_alpha * aspect_ratio[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
-    g_tp.wire_outside_mat.ild_thickness +=
-        curr_alpha * ild_thickness[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
-    g_tp.wire_outside_mat.miller_value +=
-        curr_alpha * miller_value[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
-    g_tp.wire_outside_mat.horiz_dielectric_constant +=
-        curr_alpha *
-        horiz_dielectric_constant[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
-    g_tp.wire_outside_mat.vert_dielectric_constant +=
-        curr_alpha *
-        vert_dielectric_constant[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
+          wire_pitch[0][2] = 8 * g_ip->F_sz_um;//global
+          aspect_ratio[0][2] = 3.0;
+          wire_width = wire_pitch[0][2] / 2;
+          wire_thickness = aspect_ratio[0][2] * wire_width;
+          wire_spacing = wire_pitch[0][2] - wire_width;
+          wire_r_per_micron[0][2] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
+        		  wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+          ild_thickness[0][2] = 0.216;
+          miller_value[0][2] = 1.5;
+          horiz_dielectric_constant[0][2] = 1.202;
+          vert_dielectric_constant[0][2] = 3.9;
+          wire_c_per_micron[0][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+        		  ild_thickness[0][2], miller_value[0][2], horiz_dielectric_constant[0][2], vert_dielectric_constant[0][2],
+        		  fringe_cap);
 
-    g_tp.unit_len_wire_del =
-        g_tp.wire_inside_mat.R_per_um * g_tp.wire_inside_mat.C_per_um / 2;
+//          //*************************
+//          wire_pitch[0][4] = 16 * g_ip.F_sz_um;//global
+//          aspect_ratio = 3.0;
+//          wire_width = wire_pitch[0][4] / 2;
+//          wire_thickness = aspect_ratio * wire_width;
+//          wire_spacing = wire_pitch[0][4] - wire_width;
+//          wire_r_per_micron[0][4] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
+//        		  wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+//          ild_thickness = 0.3;
+//          wire_c_per_micron[0][4] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+//        		  ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
+//        		  fringe_cap);
+//
+//          wire_pitch[0][5] = 24 * g_ip.F_sz_um;//global
+//          aspect_ratio = 3.0;
+//          wire_width = wire_pitch[0][5] / 2;
+//          wire_thickness = aspect_ratio * wire_width;
+//          wire_spacing = wire_pitch[0][5] - wire_width;
+//          wire_r_per_micron[0][5] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
+//        		  wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+//          ild_thickness = 0.3;
+//          wire_c_per_micron[0][5] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+//        		  ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
+//        		  fringe_cap);
+//
+//          wire_pitch[0][6] = 32 * g_ip.F_sz_um;//global
+//          aspect_ratio = 3.0;
+//          wire_width = wire_pitch[0][6] / 2;
+//          wire_thickness = aspect_ratio * wire_width;
+//          wire_spacing = wire_pitch[0][6] - wire_width;
+//          wire_r_per_micron[0][6] = wire_resistance(BULK_CU_RESISTIVITY, wire_width,
+//        		  wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+//          ild_thickness = 0.3;
+//          wire_c_per_micron[0][6] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+//        		  ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
+//        		  fringe_cap);
+          //*************************
 
-    g_tp.sense_delay += curr_alpha * SENSE_AMP_D;
-    g_tp.sense_dy_power += curr_alpha * SENSE_AMP_P;
-    //    g_tp.horiz_dielectric_constant += horiz_dielectric_constant;
-    //    g_tp.vert_dielectric_constant  += vert_dielectric_constant;
-    //    g_tp.aspect_ratio              += aspect_ratio;
-    //    g_tp.miller_value              += miller_value;
-    //    g_tp.ild_thickness             += ild_thickness;
+          //Conservative projections
+          wire_pitch[1][0] = 2.5 * g_ip->F_sz_um;
+          aspect_ratio[1][0] = 2.0;
+          wire_width = wire_pitch[1][0] / 2;
+          wire_thickness = aspect_ratio[1][0] * wire_width;
+          wire_spacing = wire_pitch[1][0] - wire_width;
+          barrier_thickness = 0.002;
+          dishing_thickness = 0;
+          alpha_scatter = 1.05;
+          wire_r_per_micron[1][0] = wire_resistance(CU_RESISTIVITY, wire_width,
+            wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+          ild_thickness[1][0] = 0.108;
+          miller_value[1][0] = 1.5;
+          horiz_dielectric_constant[1][0] = 1.998;
+          vert_dielectric_constant[1][0] = 3.9;
+          fringe_cap = 0.115e-15;
+          wire_c_per_micron[1][0] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+            ild_thickness[1][0], miller_value[1][0], horiz_dielectric_constant[1][0], vert_dielectric_constant[1][0],
+            fringe_cap);
+
+          wire_pitch[1][1] = 4 * g_ip->F_sz_um;
+          wire_width = wire_pitch[1][1] / 2;
+          aspect_ratio[1][1] = 2.0;
+          wire_thickness = aspect_ratio[1][1] * wire_width;
+          wire_spacing = wire_pitch[1][1] - wire_width;
+          wire_r_per_micron[1][1] = wire_resistance(CU_RESISTIVITY, wire_width,
+            wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+          ild_thickness[1][1] = 0.108;
+          miller_value[1][1] = 1.5;
+          horiz_dielectric_constant[1][1] = 1.998;
+          vert_dielectric_constant[1][1] = 3.9;
+            wire_c_per_micron[1][1] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+            ild_thickness[1][1], miller_value[1][1], horiz_dielectric_constant[1][1], vert_dielectric_constant[1][1],
+            fringe_cap);
+
+            wire_pitch[1][2] = 8 * g_ip->F_sz_um;
+            aspect_ratio[1][2] = 2.2;
+            wire_width = wire_pitch[1][2] / 2;
+            wire_thickness = aspect_ratio[1][2] * wire_width;
+            wire_spacing = wire_pitch[1][2] - wire_width;
+            dishing_thickness = 0.1 *  wire_thickness;
+            wire_r_per_micron[1][2] = wire_resistance(CU_RESISTIVITY, wire_width,
+            		wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+            ild_thickness[1][2] = 0.198;
+            miller_value[1][2] = 1.5;
+            horiz_dielectric_constant[1][2] = 1.998;
+            vert_dielectric_constant[1][2] = 3.9;
+            wire_c_per_micron[1][2] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+            		ild_thickness[1][2], miller_value[1][2], horiz_dielectric_constant[1][2], vert_dielectric_constant[1][2],
+            		fringe_cap);
+            //Nominal projections for commodity DRAM wordline/bitline
+            wire_pitch[1][3] = 2 * 0.016;//micron
+            wire_c_per_micron[1][3] = 31e-15 / (256 * 2 * 0.016);//F/micron
+            wire_r_per_micron[1][3] = 12 / 0.016;//ohm/micron
+
+            //******************
+//            wire_pitch[1][4] = 16 * g_ip.F_sz_um;
+//            aspect_ratio = 2.2;
+//            wire_width = wire_pitch[1][4] / 2;
+//            wire_thickness = aspect_ratio * wire_width;
+//            wire_spacing = wire_pitch[1][4] - wire_width;
+//            dishing_thickness = 0.1 *  wire_thickness;
+//            wire_r_per_micron[1][4] = wire_resistance(CU_RESISTIVITY, wire_width,
+//            		wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+//            ild_thickness = 0.275;
+//            wire_c_per_micron[1][4] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+//            		ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
+//            		fringe_cap);
+//
+//            wire_pitch[1][5] = 24 * g_ip.F_sz_um;
+//            aspect_ratio = 2.2;
+//            wire_width = wire_pitch[1][5] / 2;
+//            wire_thickness = aspect_ratio * wire_width;
+//            wire_spacing = wire_pitch[1][5] - wire_width;
+//            dishing_thickness = 0.1 *  wire_thickness;
+//            wire_r_per_micron[1][5] = wire_resistance(CU_RESISTIVITY, wire_width,
+//            		wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+//            ild_thickness = 0.275;
+//            wire_c_per_micron[1][5] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+//            		ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
+//            		fringe_cap);
+//
+//            wire_pitch[1][6] = 32 * g_ip.F_sz_um;
+//            aspect_ratio = 2.2;
+//            wire_width = wire_pitch[1][6] / 2;
+//            wire_thickness = aspect_ratio * wire_width;
+//            wire_spacing = wire_pitch[1][6] - wire_width;
+//            dishing_thickness = 0.1 *  wire_thickness;
+//            wire_r_per_micron[1][6] = wire_resistance(CU_RESISTIVITY, wire_width,
+//            		wire_thickness, barrier_thickness, dishing_thickness, alpha_scatter);
+//            ild_thickness = 0.275;
+//            wire_c_per_micron[1][6] = wire_capacitance(wire_width, wire_thickness, wire_spacing,
+//            		ild_thickness, miller_value, horiz_dielectric_constant, vert_dielectric_constant,
+//            		fringe_cap);
+        }
+    g_tp.wire_local.pitch    += curr_alpha * wire_pitch[g_ip->ic_proj_type][(ram_cell_tech_type == comm_dram)?3:0];
+    g_tp.wire_local.R_per_um += curr_alpha * wire_r_per_micron[g_ip->ic_proj_type][(ram_cell_tech_type == comm_dram)?3:0];
+    g_tp.wire_local.C_per_um += curr_alpha * wire_c_per_micron[g_ip->ic_proj_type][(ram_cell_tech_type == comm_dram)?3:0];
+    g_tp.wire_local.aspect_ratio  += curr_alpha * aspect_ratio[g_ip->ic_proj_type][(ram_cell_tech_type == comm_dram)?3:0];
+    g_tp.wire_local.ild_thickness += curr_alpha * ild_thickness[g_ip->ic_proj_type][(ram_cell_tech_type == comm_dram)?3:0];
+    g_tp.wire_local.miller_value   += curr_alpha * miller_value[g_ip->ic_proj_type][(ram_cell_tech_type == comm_dram)?3:0];
+    g_tp.wire_local.horiz_dielectric_constant += curr_alpha* horiz_dielectric_constant[g_ip->ic_proj_type][(ram_cell_tech_type == comm_dram)?3:0];
+    g_tp.wire_local.vert_dielectric_constant  += curr_alpha* vert_dielectric_constant [g_ip->ic_proj_type][(ram_cell_tech_type == comm_dram)?3:0];
+
+    g_tp.wire_inside_mat.pitch     += curr_alpha * wire_pitch[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
+    g_tp.wire_inside_mat.R_per_um  += curr_alpha* wire_r_per_micron[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
+    g_tp.wire_inside_mat.C_per_um  += curr_alpha* wire_c_per_micron[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
+    g_tp.wire_inside_mat.aspect_ratio  += curr_alpha * aspect_ratio[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
+    g_tp.wire_inside_mat.ild_thickness += curr_alpha * ild_thickness[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
+    g_tp.wire_inside_mat.miller_value   += curr_alpha * miller_value[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
+    g_tp.wire_inside_mat.horiz_dielectric_constant += curr_alpha* horiz_dielectric_constant[g_ip->ic_proj_type][g_ip->wire_is_mat_type];
+    g_tp.wire_inside_mat.vert_dielectric_constant  += curr_alpha* vert_dielectric_constant [g_ip->ic_proj_type][g_ip->wire_is_mat_type];
+
+    g_tp.wire_outside_mat.pitch    += curr_alpha * wire_pitch[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
+    g_tp.wire_outside_mat.R_per_um += curr_alpha*wire_r_per_micron[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
+    g_tp.wire_outside_mat.C_per_um += curr_alpha*wire_c_per_micron[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
+    g_tp.wire_outside_mat.aspect_ratio  += curr_alpha * aspect_ratio[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
+    g_tp.wire_outside_mat.ild_thickness += curr_alpha * ild_thickness[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
+    g_tp.wire_outside_mat.miller_value   += curr_alpha * miller_value[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
+    g_tp.wire_outside_mat.horiz_dielectric_constant += curr_alpha* horiz_dielectric_constant[g_ip->ic_proj_type][g_ip->wire_os_mat_type];
+    g_tp.wire_outside_mat.vert_dielectric_constant  += curr_alpha* vert_dielectric_constant [g_ip->ic_proj_type][g_ip->wire_os_mat_type];
+
+    g_tp.unit_len_wire_del = g_tp.wire_inside_mat.R_per_um * g_tp.wire_inside_mat.C_per_um / 2;
+
+    g_tp.sense_delay               += curr_alpha *SENSE_AMP_D;
+    g_tp.sense_dy_power            += curr_alpha *SENSE_AMP_P;
+//    g_tp.horiz_dielectric_constant += horiz_dielectric_constant;
+//    g_tp.vert_dielectric_constant  += vert_dielectric_constant;
+//    g_tp.aspect_ratio              += aspect_ratio;
+//    g_tp.miller_value              += miller_value;
+//    g_tp.ild_thickness             += ild_thickness;
+
   }
   g_tp.fringe_cap = fringe_cap;
 
@@ -2988,9 +2764,9 @@ void init_tech_params(double technology, bool is_tag) {
   g_tp.kinv = horowitz(0, tf, 0.5, 0.5, RISE);
   double KLOAD = 1;
   c_load = KLOAD * (drain_C_(g_tp.min_w_nmos_, NCH, 1, 1, g_tp.cell_h_def) +
-                    drain_C_(g_tp.min_w_nmos_ * p_to_n_sizing_r, PCH, 1, 1,
-                             g_tp.cell_h_def) +
+                    drain_C_(g_tp.min_w_nmos_ * p_to_n_sizing_r, PCH, 1, 1, g_tp.cell_h_def) +
                     gate_C(g_tp.min_w_nmos_ * 4 * (1 + p_to_n_sizing_r), 0.0));
   tf = rd * c_load;
   g_tp.FO4 = horowitz(0, tf, 0.5, 0.5, RISE);
 }
+

--- a/src/gpuwattch/version.h
+++ b/src/gpuwattch/version.h
@@ -32,9 +32,9 @@
 #ifndef VERSION_H_
 #define VERSION_H_
 
-#define VER_MAJOR		0	/* beta release */
-#define VER_MINOR		8
+#define VER_MAJOR 0 /* beta release */
+#define VER_MINOR 8
 
-#define VER_UPDATE	        "Aug, 2010"
+#define VER_UPDATE "Aug, 2010"
 
 #endif /* VERSION_H_ */

--- a/src/gpuwattch/version.h
+++ b/src/gpuwattch/version.h
@@ -32,9 +32,9 @@
 #ifndef VERSION_H_
 #define VERSION_H_
 
-#define VER_MAJOR 0 /* beta release */
-#define VER_MINOR 8
+#define VER_MAJOR		0	/* beta release */
+#define VER_MINOR		8
 
-#define VER_UPDATE "Aug, 2010"
+#define VER_UPDATE	        "Aug, 2010"
 
 #endif /* VERSION_H_ */

--- a/src/gpuwattch/xmlParser.cc
+++ b/src/gpuwattch/xmlParser.cc
@@ -37,23 +37,23 @@
  *
  * NOTE:
  *
- *   If you add "#define _XMLPARSER_NO_MESSAGEBOX_" on the first line of this file
- *   the "openFileHelper" function will always display error messages inside the
- *   console instead of inside a message-box-window. Message-box-windows are
+ *   If you add "#define _XMLPARSER_NO_MESSAGEBOX_" on the first line of this
+ *file the "openFileHelper" function will always display error messages inside
+ *the console instead of inside a message-box-window. Message-box-windows are
  *   available on windows 9x/NT/2000/XP/Vista only.
  *
- * The following license terms for the "XMLParser library from Business-Insight" apply to projects
- * that are in some way related to
- * the "mcpat project", including applications
- * using "mcpat project" and tools developed
- * for enhancing "mcpat project". All other projects
- * (not related to "mcpat project") have to use the "XMLParser library from Business-Insight"
- * code under the Aladdin Free Public License (AFPL)
- * See the file "AFPL-license.txt" for more informations about the AFPL license.
- * (see http://www.artifex.com/downloads/doc/Public.htm for detailed AFPL terms)
+ * The following license terms for the "XMLParser library from Business-Insight"
+ *apply to projects that are in some way related to the "mcpat project",
+ *including applications using "mcpat project" and tools developed for enhancing
+ *"mcpat project". All other projects (not related to "mcpat project") have to
+ *use the "XMLParser library from Business-Insight" code under the Aladdin Free
+ *Public License (AFPL) See the file "AFPL-license.txt" for more informations
+ *about the AFPL license. (see http://www.artifex.com/downloads/doc/Public.htm
+ *for detailed AFPL terms)
  *
- * Redistribution and use of the "XMLParser library from Business-Insight" in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Redistribution and use of the "XMLParser library from Business-Insight" in
+ *source and binary forms, with or without modification, are permitted provided
+ *that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
  *       notice, this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright
@@ -90,266 +90,354 @@
 //#include <crtdbg.h>
 //#endif
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h> // to have IsTextUnicode, MultiByteToWideChar, WideCharToMultiByte to handle unicode files
-                     // to have "MessageBoxA" to display error messages for openFilHelper
+#include <Windows.h>  // to have IsTextUnicode, MultiByteToWideChar, WideCharToMultiByte to handle unicode files
+// to have "MessageBoxA" to display error messages for openFilHelper
 #endif
 
-#include <memory.h>
 #include <assert.h>
+#include <memory.h>
 #include <stdio.h>
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
 
 XMLCSTR XMLNode::getVersion() { return _CXML("v2.39"); }
-void freeXMLString(XMLSTR t){if(t)free(t);}
+void freeXMLString(XMLSTR t) {
+  if (t) free(t);
+}
 
-static XMLNode::XMLCharEncoding characterEncoding=XMLNode::char_encoding_UTF8;
-static char guessWideCharChars=1, dropWhiteSpace=1, removeCommentsInMiddleOfText=1;
+static XMLNode::XMLCharEncoding characterEncoding = XMLNode::char_encoding_UTF8;
+static char guessWideCharChars = 1, dropWhiteSpace = 1,
+            removeCommentsInMiddleOfText = 1;
 
-inline int mmin( const int t1, const int t2 ) { return t1 < t2 ? t1 : t2; }
+inline int mmin(const int t1, const int t2) { return t1 < t2 ? t1 : t2; }
 
 // You can modify the initialization of the variable "XMLClearTags" below
 // to change the clearTags that are currently recognized by the library.
 // The number on the second columns is the length of the string inside the
 // first column. The "<!DOCTYPE" declaration must be the second in the list.
 // The "<!--" declaration must be the third in the list.
-typedef struct { XMLCSTR lpszOpen; int openTagLen; XMLCSTR lpszClose;} ALLXMLClearTag;
-static ALLXMLClearTag XMLClearTags[] =
-{
-    {    _CXML("<![CDATA["),9,  _CXML("]]>")      },
-    {    _CXML("<!DOCTYPE"),9,  _CXML(">")        },
-    {    _CXML("<!--")     ,4,  _CXML("-->")      },
-    {    _CXML("<PRE>")    ,5,  _CXML("</PRE>")   },
-//  {    _CXML("<Script>") ,8,  _CXML("</Script>")},
-    {    NULL              ,0,  NULL           }
-};
+typedef struct {
+  XMLCSTR lpszOpen;
+  int openTagLen;
+  XMLCSTR lpszClose;
+} ALLXMLClearTag;
+static ALLXMLClearTag XMLClearTags[] = {
+    {_CXML("<![CDATA["), 9, _CXML("]]>")},
+    {_CXML("<!DOCTYPE"), 9, _CXML(">")},
+    {_CXML("<!--"), 4, _CXML("-->")},
+    {_CXML("<PRE>"), 5, _CXML("</PRE>")},
+    //  {    _CXML("<Script>") ,8,  _CXML("</Script>")},
+    {NULL, 0, NULL}};
 
 // You can modify the initialization of the variable "XMLEntities" below
-// to change the character entities that are currently recognized by the library.
-// The number on the second columns is the length of the string inside the
-// first column. Additionally, the syntaxes "&#xA0;" and "&#160;" are recognized.
-typedef struct { XMLCSTR s; int l; XMLCHAR c;} XMLCharacterEntity;
-static XMLCharacterEntity XMLEntities[] =
-{
-    { _CXML("&amp;" ), 5, _CXML('&' )},
-    { _CXML("&lt;"  ), 4, _CXML('<' )},
-    { _CXML("&gt;"  ), 4, _CXML('>' )},
-    { _CXML("&quot;"), 6, _CXML('\"')},
-    { _CXML("&apos;"), 6, _CXML('\'')},
-    { NULL           , 0, '\0'    }
-};
+// to change the character entities that are currently recognized by the
+// library. The number on the second columns is the length of the string inside
+// the first column. Additionally, the syntaxes "&#xA0;" and "&#160;" are
+// recognized.
+typedef struct {
+  XMLCSTR s;
+  int l;
+  XMLCHAR c;
+} XMLCharacterEntity;
+static XMLCharacterEntity XMLEntities[] = {
+    {_CXML("&amp;"), 5, _CXML('&')},   {_CXML("&lt;"), 4, _CXML('<')},
+    {_CXML("&gt;"), 4, _CXML('>')},    {_CXML("&quot;"), 6, _CXML('\"')},
+    {_CXML("&apos;"), 6, _CXML('\'')}, {NULL, 0, '\0'}};
 
-// When rendering the XMLNode to a string (using the "createXMLString" function),
-// you can ask for a beautiful formatting. This formatting is using the
-// following indentation character:
+// When rendering the XMLNode to a string (using the "createXMLString"
+// function), you can ask for a beautiful formatting. This formatting is using
+// the following indentation character:
 #define INDENTCHAR _CXML('\t')
 
 // The following function parses the XML errors into a user friendly string.
-// You can edit this to change the output language of the library to something else.
-XMLCSTR XMLNode::getError(XMLError xerror)
-{
-    switch (xerror)
-    {
-    case eXMLErrorNone:                  return _CXML("No error");
-    case eXMLErrorMissingEndTag:         return _CXML("Warning: Unmatched end tag");
-    case eXMLErrorNoXMLTagFound:         return _CXML("Warning: No XML tag found");
-    case eXMLErrorEmpty:                 return _CXML("Error: No XML data");
-    case eXMLErrorMissingTagName:        return _CXML("Error: Missing start tag name");
-    case eXMLErrorMissingEndTagName:     return _CXML("Error: Missing end tag name");
-    case eXMLErrorUnmatchedEndTag:       return _CXML("Error: Unmatched end tag");
-    case eXMLErrorUnmatchedEndClearTag:  return _CXML("Error: Unmatched clear tag end");
-    case eXMLErrorUnexpectedToken:       return _CXML("Error: Unexpected token found");
-    case eXMLErrorNoElements:            return _CXML("Error: No elements found");
-    case eXMLErrorFileNotFound:          return _CXML("Error: File not found");
-    case eXMLErrorFirstTagNotFound:      return _CXML("Error: First Tag not found");
-    case eXMLErrorUnknownCharacterEntity:return _CXML("Error: Unknown character entity");
-    case eXMLErrorCharacterCodeAbove255: return _CXML("Error: Character code above 255 is forbidden in MultiByte char mode.");
-    case eXMLErrorCharConversionError:   return _CXML("Error: unable to convert between WideChar and MultiByte chars");
-    case eXMLErrorCannotOpenWriteFile:   return _CXML("Error: unable to open file for writing");
-    case eXMLErrorCannotWriteFile:       return _CXML("Error: cannot write into file");
+// You can edit this to change the output language of the library to something
+// else.
+XMLCSTR XMLNode::getError(XMLError xerror) {
+  switch (xerror) {
+    case eXMLErrorNone:
+      return _CXML("No error");
+    case eXMLErrorMissingEndTag:
+      return _CXML("Warning: Unmatched end tag");
+    case eXMLErrorNoXMLTagFound:
+      return _CXML("Warning: No XML tag found");
+    case eXMLErrorEmpty:
+      return _CXML("Error: No XML data");
+    case eXMLErrorMissingTagName:
+      return _CXML("Error: Missing start tag name");
+    case eXMLErrorMissingEndTagName:
+      return _CXML("Error: Missing end tag name");
+    case eXMLErrorUnmatchedEndTag:
+      return _CXML("Error: Unmatched end tag");
+    case eXMLErrorUnmatchedEndClearTag:
+      return _CXML("Error: Unmatched clear tag end");
+    case eXMLErrorUnexpectedToken:
+      return _CXML("Error: Unexpected token found");
+    case eXMLErrorNoElements:
+      return _CXML("Error: No elements found");
+    case eXMLErrorFileNotFound:
+      return _CXML("Error: File not found");
+    case eXMLErrorFirstTagNotFound:
+      return _CXML("Error: First Tag not found");
+    case eXMLErrorUnknownCharacterEntity:
+      return _CXML("Error: Unknown character entity");
+    case eXMLErrorCharacterCodeAbove255:
+      return _CXML(
+          "Error: Character code above 255 is forbidden in MultiByte char "
+          "mode.");
+    case eXMLErrorCharConversionError:
+      return _CXML(
+          "Error: unable to convert between WideChar and MultiByte chars");
+    case eXMLErrorCannotOpenWriteFile:
+      return _CXML("Error: unable to open file for writing");
+    case eXMLErrorCannotWriteFile:
+      return _CXML("Error: cannot write into file");
 
-    case eXMLErrorBase64DataSizeIsNotMultipleOf4: return _CXML("Warning: Base64-string length is not a multiple of 4");
-    case eXMLErrorBase64DecodeTruncatedData:      return _CXML("Warning: Base64-string is truncated");
-    case eXMLErrorBase64DecodeIllegalCharacter:   return _CXML("Error: Base64-string contains an illegal character");
-    case eXMLErrorBase64DecodeBufferTooSmall:     return _CXML("Error: Base64 decode output buffer is too small");
-    };
-    return _CXML("Unknown");
+    case eXMLErrorBase64DataSizeIsNotMultipleOf4:
+      return _CXML("Warning: Base64-string length is not a multiple of 4");
+    case eXMLErrorBase64DecodeTruncatedData:
+      return _CXML("Warning: Base64-string is truncated");
+    case eXMLErrorBase64DecodeIllegalCharacter:
+      return _CXML("Error: Base64-string contains an illegal character");
+    case eXMLErrorBase64DecodeBufferTooSmall:
+      return _CXML("Error: Base64 decode output buffer is too small");
+  };
+  return _CXML("Unknown");
 }
 
 /////////////////////////////////////////////////////////////////////////
 //      Here start the abstraction layer to be OS-independent          //
 /////////////////////////////////////////////////////////////////////////
 
-// Here is an abstraction layer to access some common string manipulation functions.
-// The abstraction layer is currently working for gcc, Microsoft Visual Studio 6.0,
-// Microsoft Visual Studio .NET, CC (sun compiler) and Borland C++.
-// If you plan to "port" the library to a new system/compiler, all you have to do is
-// to edit the following lines.
+// Here is an abstraction layer to access some common string manipulation
+// functions. The abstraction layer is currently working for gcc, Microsoft
+// Visual Studio 6.0, Microsoft Visual Studio .NET, CC (sun compiler) and
+// Borland C++. If you plan to "port" the library to a new system/compiler, all
+// you have to do is to edit the following lines.
 #ifdef XML_NO_WIDE_CHAR
 char myIsTextWideChar(const void *b, int len) { return FALSE; }
 #else
-    #if defined (UNDER_CE) || !defined(_XMLWINDOWS)
-    char myIsTextWideChar(const void *b, int len) // inspired by the Wine API: RtlIsTextUnicode
-    {
+#if defined(UNDER_CE) || !defined(_XMLWINDOWS)
+char myIsTextWideChar(const void *b,
+                      int len)  // inspired by the Wine API: RtlIsTextUnicode
+{
 #ifdef sun
-        // for SPARC processors: wchar_t* buffers must always be alligned, otherwise it's a char* buffer.
-        if ((((unsigned long)b)%sizeof(wchar_t))!=0) return FALSE;
+  // for SPARC processors: wchar_t* buffers must always be alligned, otherwise
+  // it's a char* buffer.
+  if ((((unsigned long)b) % sizeof(wchar_t)) != 0) return FALSE;
 #endif
-        const wchar_t *s=(const wchar_t*)b;
+  const wchar_t *s = (const wchar_t *)b;
 
-        // buffer too small:
-        if (len<(int)sizeof(wchar_t)) return FALSE;
+  // buffer too small:
+  if (len < (int)sizeof(wchar_t)) return FALSE;
 
-        // odd length test
-        if (len&1) return FALSE;
+  // odd length test
+  if (len & 1) return FALSE;
 
-        /* only checks the first 256 characters */
-        len=mmin(256,len/sizeof(wchar_t));
+  /* only checks the first 256 characters */
+  len = mmin(256, len / sizeof(wchar_t));
 
-        // Check for the special byte order:
-        if (*((unsigned short*)s) == 0xFFFE) return TRUE;     // IS_TEXT_UNICODE_REVERSE_SIGNATURE;
-        if (*((unsigned short*)s) == 0xFEFF) return TRUE;      // IS_TEXT_UNICODE_SIGNATURE
+  // Check for the special byte order:
+  if (*((unsigned short *)s) == 0xFFFE)
+    return TRUE;  // IS_TEXT_UNICODE_REVERSE_SIGNATURE;
+  if (*((unsigned short *)s) == 0xFEFF)
+    return TRUE;  // IS_TEXT_UNICODE_SIGNATURE
 
-        // checks for ASCII characters in the UNICODE stream
-        int i,stats=0;
-        for (i=0; i<len; i++) if (s[i]<=(unsigned short)255) stats++;
-        if (stats>len/2) return TRUE;
+  // checks for ASCII characters in the UNICODE stream
+  int i, stats = 0;
+  for (i = 0; i < len; i++)
+    if (s[i] <= (unsigned short)255) stats++;
+  if (stats > len / 2) return TRUE;
 
-        // Check for UNICODE NULL chars
-        for (i=0; i<len; i++) if (!s[i]) return TRUE;
+  // Check for UNICODE NULL chars
+  for (i = 0; i < len; i++)
+    if (!s[i]) return TRUE;
 
-        return FALSE;
-    }
-    #else
-    char myIsTextWideChar(const void *b,int l) { return (char)IsTextUnicode((CONST LPVOID)b,l,NULL); };
-    #endif
+  return FALSE;
+}
+#else
+char myIsTextWideChar(const void *b, int l) {
+  return (char)IsTextUnicode((CONST LPVOID)b, l, NULL);
+};
+#endif
 #endif
 
 #ifdef _XMLWINDOWS
-// for Microsoft Visual Studio 6.0 and Microsoft Visual Studio .NET and Borland C++ Builder 6.0
-    #ifdef _XMLWIDECHAR
-        wchar_t *myMultiByteToWideChar(const char *s, XMLNode::XMLCharEncoding ce)
-        {
-            int i;
-            if (ce==XMLNode::char_encoding_UTF8) i=(int)MultiByteToWideChar(CP_UTF8,0             ,s,-1,NULL,0);
-            else                            i=(int)MultiByteToWideChar(CP_ACP ,MB_PRECOMPOSED,s,-1,NULL,0);
-            if (i<0) return NULL;
-            wchar_t *d=(wchar_t *)malloc((i+1)*sizeof(XMLCHAR));
-            if (ce==XMLNode::char_encoding_UTF8) i=(int)MultiByteToWideChar(CP_UTF8,0             ,s,-1,d,i);
-            else                            i=(int)MultiByteToWideChar(CP_ACP ,MB_PRECOMPOSED,s,-1,d,i);
-            d[i]=0;
-            return d;
-        }
-        static inline FILE *xfopen(XMLCSTR filename,XMLCSTR mode) { return _wfopen(filename,mode); }
-        static inline int xstrlen(XMLCSTR c)   { return (int)wcslen(c); }
-        static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) { return _wcsnicmp(c1,c2,l);}
-        static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) { return wcsncmp(c1,c2,l);}
-        static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return _wcsicmp(c1,c2); }
-        static inline XMLSTR xstrstr(XMLCSTR c1, XMLCSTR c2) { return (XMLSTR)wcsstr(c1,c2); }
-        static inline XMLSTR xstrcpy(XMLSTR c1, XMLCSTR c2) { return (XMLSTR)wcscpy(c1,c2); }
-    #else
-        char *myWideCharToMultiByte(const wchar_t *s)
-        {
-            UINT codePage=CP_ACP; if (characterEncoding==XMLNode::char_encoding_UTF8) codePage=CP_UTF8;
-            int i=(int)WideCharToMultiByte(codePage,  // code page
-                0,                       // performance and mapping flags
-                s,                       // wide-character string
-                -1,                       // number of chars in string
-                NULL,                       // buffer for new string
-                0,                       // size of buffer
-                NULL,                    // default for unmappable chars
-                NULL                     // set when default char used
-                );
-            if (i<0) return NULL;
-            char *d=(char*)malloc(i+1);
-            WideCharToMultiByte(codePage,  // code page
-                0,                       // performance and mapping flags
-                s,                       // wide-character string
-                -1,                       // number of chars in string
-                d,                       // buffer for new string
-                i,                       // size of buffer
-                NULL,                    // default for unmappable chars
-                NULL                     // set when default char used
-                );
-            d[i]=0;
-            return d;
-        }
-        static inline FILE *xfopen(XMLCSTR filename,XMLCSTR mode) { return fopen(filename,mode); }
-        static inline int xstrlen(XMLCSTR c)   { return (int)strlen(c); }
-        #ifdef __BORLANDC__
-            static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) { return strnicmp(c1,c2,l);}
-            static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return stricmp(c1,c2); }
-        #else
-            static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) { return _strnicmp(c1,c2,l);}
-            static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return _stricmp(c1,c2); }
-        #endif
-        static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) { return strncmp(c1,c2,l);}
-        static inline XMLSTR xstrstr(XMLCSTR c1, XMLCSTR c2) { return (XMLSTR)strstr(c1,c2); }
-        static inline XMLSTR xstrcpy(XMLSTR c1, XMLCSTR c2) { return (XMLSTR)strcpy(c1,c2); }
-    #endif
+// for Microsoft Visual Studio 6.0 and Microsoft Visual Studio .NET and Borland
+// C++ Builder 6.0
+#ifdef _XMLWIDECHAR
+wchar_t *myMultiByteToWideChar(const char *s, XMLNode::XMLCharEncoding ce) {
+  int i;
+  if (ce == XMLNode::char_encoding_UTF8)
+    i = (int)MultiByteToWideChar(CP_UTF8, 0, s, -1, NULL, 0);
+  else
+    i = (int)MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, s, -1, NULL, 0);
+  if (i < 0) return NULL;
+  wchar_t *d = (wchar_t *)malloc((i + 1) * sizeof(XMLCHAR));
+  if (ce == XMLNode::char_encoding_UTF8)
+    i = (int)MultiByteToWideChar(CP_UTF8, 0, s, -1, d, i);
+  else
+    i = (int)MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, s, -1, d, i);
+  d[i] = 0;
+  return d;
+}
+static inline FILE *xfopen(XMLCSTR filename, XMLCSTR mode) {
+  return _wfopen(filename, mode);
+}
+static inline int xstrlen(XMLCSTR c) { return (int)wcslen(c); }
+static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) {
+  return _wcsnicmp(c1, c2, l);
+}
+static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) {
+  return wcsncmp(c1, c2, l);
+}
+static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return _wcsicmp(c1, c2); }
+static inline XMLSTR xstrstr(XMLCSTR c1, XMLCSTR c2) {
+  return (XMLSTR)wcsstr(c1, c2);
+}
+static inline XMLSTR xstrcpy(XMLSTR c1, XMLCSTR c2) {
+  return (XMLSTR)wcscpy(c1, c2);
+}
+#else
+char *myWideCharToMultiByte(const wchar_t *s) {
+  UINT codePage = CP_ACP;
+  if (characterEncoding == XMLNode::char_encoding_UTF8) codePage = CP_UTF8;
+  int i = (int)WideCharToMultiByte(codePage,  // code page
+                                   0,         // performance and mapping flags
+                                   s,         // wide-character string
+                                   -1,        // number of chars in string
+                                   NULL,      // buffer for new string
+                                   0,         // size of buffer
+                                   NULL,      // default for unmappable chars
+                                   NULL       // set when default char used
+  );
+  if (i < 0) return NULL;
+  char *d = (char *)malloc(i + 1);
+  WideCharToMultiByte(codePage,  // code page
+                      0,         // performance and mapping flags
+                      s,         // wide-character string
+                      -1,        // number of chars in string
+                      d,         // buffer for new string
+                      i,         // size of buffer
+                      NULL,      // default for unmappable chars
+                      NULL       // set when default char used
+  );
+  d[i] = 0;
+  return d;
+}
+static inline FILE *xfopen(XMLCSTR filename, XMLCSTR mode) {
+  return fopen(filename, mode);
+}
+static inline int xstrlen(XMLCSTR c) { return (int)strlen(c); }
+#ifdef __BORLANDC__
+static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) {
+  return strnicmp(c1, c2, l);
+}
+static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return stricmp(c1, c2); }
+#else
+static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) {
+  return _strnicmp(c1, c2, l);
+}
+static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return _stricmp(c1, c2); }
+#endif
+static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) {
+  return strncmp(c1, c2, l);
+}
+static inline XMLSTR xstrstr(XMLCSTR c1, XMLCSTR c2) {
+  return (XMLSTR)strstr(c1, c2);
+}
+static inline XMLSTR xstrcpy(XMLSTR c1, XMLCSTR c2) {
+  return (XMLSTR)strcpy(c1, c2);
+}
+#endif
 #else
 // for gcc and CC
-    #ifdef XML_NO_WIDE_CHAR
-        char *myWideCharToMultiByte(const wchar_t *s) { return NULL; }
-    #else
-        char *myWideCharToMultiByte(const wchar_t *s)
-        {
-            const wchar_t *ss=s;
-            int i=(int)wcsrtombs(NULL,&ss,0,NULL);
-            if (i<0) return NULL;
-            char *d=(char *)malloc(i+1);
-            wcsrtombs(d,&s,i,NULL);
-            d[i]=0;
-            return d;
-        }
-    #endif
-    #ifdef _XMLWIDECHAR
-        wchar_t *myMultiByteToWideChar(const char *s, XMLNode::XMLCharEncoding ce)
-        {
-            const char *ss=s;
-            int i=(int)mbsrtowcs(NULL,&ss,0,NULL);
-            if (i<0) return NULL;
-            wchar_t *d=(wchar_t *)malloc((i+1)*sizeof(wchar_t));
-            mbsrtowcs(d,&s,i,NULL);
-            d[i]=0;
-            return d;
-        }
-        int xstrlen(XMLCSTR c)   { return wcslen(c); }
-        #ifdef sun
-        // for CC
-           #include <widec.h>
-           static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) { return wsncasecmp(c1,c2,l);}
-           static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) { return wsncmp(c1,c2,l);}
-           static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return wscasecmp(c1,c2); }
-        #else
-        // for gcc
-           static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) { return wcsncasecmp(c1,c2,l);}
-           static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) { return wcsncmp(c1,c2,l);}
-           static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return wcscasecmp(c1,c2); }
-        #endif
-        static inline XMLSTR xstrstr(XMLCSTR c1, XMLCSTR c2) { return (XMLSTR)wcsstr(c1,c2); }
-        static inline XMLSTR xstrcpy(XMLSTR c1, XMLCSTR c2) { return (XMLSTR)wcscpy(c1,c2); }
-        static inline FILE *xfopen(XMLCSTR filename,XMLCSTR mode)
-        {
-            char *filenameAscii=myWideCharToMultiByte(filename);
-            FILE *f;
-            if (mode[0]==_CXML('r')) f=fopen(filenameAscii,"rb");
-            else                     f=fopen(filenameAscii,"wb");
-            free(filenameAscii);
-            return f;
-        }
-    #else
-        static inline FILE *xfopen(XMLCSTR filename,XMLCSTR mode) { return fopen(filename,mode); }
-        static inline int xstrlen(XMLCSTR c)   { return strlen(c); }
-        static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) { return strncasecmp(c1,c2,l);}
-        static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) { return strncmp(c1,c2,l);}
-        static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return strcasecmp(c1,c2); }
-        static inline XMLSTR xstrstr(XMLCSTR c1, XMLCSTR c2) { return (XMLSTR)strstr(c1,c2); }
-        static inline XMLSTR xstrcpy(XMLSTR c1, XMLCSTR c2) { return (XMLSTR)strcpy(c1,c2); }
-    #endif
-    static inline int _strnicmp(const char *c1,const char *c2, int l) { return strncasecmp(c1,c2,l);}
+#ifdef XML_NO_WIDE_CHAR
+char *myWideCharToMultiByte(const wchar_t *s) { return NULL; }
+#else
+char *myWideCharToMultiByte(const wchar_t *s) {
+  const wchar_t *ss = s;
+  int i = (int)wcsrtombs(NULL, &ss, 0, NULL);
+  if (i < 0) return NULL;
+  char *d = (char *)malloc(i + 1);
+  wcsrtombs(d, &s, i, NULL);
+  d[i] = 0;
+  return d;
+}
 #endif
-
+#ifdef _XMLWIDECHAR
+wchar_t *myMultiByteToWideChar(const char *s, XMLNode::XMLCharEncoding ce) {
+  const char *ss = s;
+  int i = (int)mbsrtowcs(NULL, &ss, 0, NULL);
+  if (i < 0) return NULL;
+  wchar_t *d = (wchar_t *)malloc((i + 1) * sizeof(wchar_t));
+  mbsrtowcs(d, &s, i, NULL);
+  d[i] = 0;
+  return d;
+}
+int xstrlen(XMLCSTR c) { return wcslen(c); }
+#ifdef sun
+// for CC
+#include <widec.h>
+static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) {
+  return wsncasecmp(c1, c2, l);
+}
+static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) {
+  return wsncmp(c1, c2, l);
+}
+static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return wscasecmp(c1, c2); }
+#else
+// for gcc
+static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) {
+  return wcsncasecmp(c1, c2, l);
+}
+static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) {
+  return wcsncmp(c1, c2, l);
+}
+static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) {
+  return wcscasecmp(c1, c2);
+}
+#endif
+static inline XMLSTR xstrstr(XMLCSTR c1, XMLCSTR c2) {
+  return (XMLSTR)wcsstr(c1, c2);
+}
+static inline XMLSTR xstrcpy(XMLSTR c1, XMLCSTR c2) {
+  return (XMLSTR)wcscpy(c1, c2);
+}
+static inline FILE *xfopen(XMLCSTR filename, XMLCSTR mode) {
+  char *filenameAscii = myWideCharToMultiByte(filename);
+  FILE *f;
+  if (mode[0] == _CXML('r'))
+    f = fopen(filenameAscii, "rb");
+  else
+    f = fopen(filenameAscii, "wb");
+  free(filenameAscii);
+  return f;
+}
+#else
+static inline FILE *xfopen(XMLCSTR filename, XMLCSTR mode) {
+  return fopen(filename, mode);
+}
+static inline int xstrlen(XMLCSTR c) { return strlen(c); }
+static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) {
+  return strncasecmp(c1, c2, l);
+}
+static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) {
+  return strncmp(c1, c2, l);
+}
+static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) {
+  return strcasecmp(c1, c2);
+}
+static inline XMLSTR xstrstr(XMLCSTR c1, XMLCSTR c2) {
+  return (XMLSTR)strstr(c1, c2);
+}
+static inline XMLSTR xstrcpy(XMLSTR c1, XMLCSTR c2) {
+  return (XMLSTR)strcpy(c1, c2);
+}
+#endif
+static inline int _strnicmp(const char *c1, const char *c2, int l) {
+  return strncasecmp(c1, c2, l);
+}
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 //            the "xmltoc,xmltob,xmltoi,xmltol,xmltof,xmltoa" functions      //
@@ -358,82 +446,144 @@ char myIsTextWideChar(const void *b, int len) { return FALSE; }
 // There are only here as "convenience" functions for the user.
 // If you don't need them, you can delete them without any trouble.
 #ifdef _XMLWIDECHAR
-    #ifdef _XMLWINDOWS
-    // for Microsoft Visual Studio 6.0 and Microsoft Visual Studio .NET and Borland C++ Builder 6.0
-        char    xmltob(XMLCSTR t,int     v){ if (t&&(*t)) return (char)_wtoi(t); return v; }
-        int     xmltoi(XMLCSTR t,int     v){ if (t&&(*t)) return _wtoi(t); return v; }
-        long    xmltol(XMLCSTR t,long    v){ if (t&&(*t)) return _wtol(t); return v; }
-        double  xmltof(XMLCSTR t,double  v){ if (t&&(*t)) wscanf(t, "%f", &v); /*v=_wtof(t);*/ return v; }
-    #else
-        #ifdef sun
-        // for CC
-           #include <widec.h>
-           char    xmltob(XMLCSTR t,int     v){ if (t) return (char)wstol(t,NULL,10); return v; }
-           int     xmltoi(XMLCSTR t,int     v){ if (t) return (int)wstol(t,NULL,10); return v; }
-           long    xmltol(XMLCSTR t,long    v){ if (t) return wstol(t,NULL,10); return v; }
-        #else
-        // for gcc
-           char    xmltob(XMLCSTR t,int     v){ if (t) return (char)wcstol(t,NULL,10); return v; }
-           int     xmltoi(XMLCSTR t,int     v){ if (t) return (int)wcstol(t,NULL,10); return v; }
-           long    xmltol(XMLCSTR t,long    v){ if (t) return wcstol(t,NULL,10); return v; }
-        #endif
-		double  xmltof(XMLCSTR t,double  v){ if (t&&(*t)) wscanf(t, "%f", &v); /*v=_wtof(t);*/ return v; }
-    #endif
+#ifdef _XMLWINDOWS
+// for Microsoft Visual Studio 6.0 and Microsoft Visual Studio .NET and Borland
+// C++ Builder 6.0
+char xmltob(XMLCSTR t, int v) {
+  if (t && (*t)) return (char)_wtoi(t);
+  return v;
+}
+int xmltoi(XMLCSTR t, int v) {
+  if (t && (*t)) return _wtoi(t);
+  return v;
+}
+long xmltol(XMLCSTR t, long v) {
+  if (t && (*t)) return _wtol(t);
+  return v;
+}
+double xmltof(XMLCSTR t, double v) {
+  if (t && (*t)) wscanf(t, "%f", &v); /*v=_wtof(t);*/
+  return v;
+}
 #else
-    char    xmltob(XMLCSTR t,char    v){ if (t&&(*t)) return (char)atoi(t); return v; }
-    int     xmltoi(XMLCSTR t,int     v){ if (t&&(*t)) return atoi(t); return v; }
-    long    xmltol(XMLCSTR t,long    v){ if (t&&(*t)) return atol(t); return v; }
-    double  xmltof(XMLCSTR t,double  v){ if (t&&(*t)) return atof(t); return v; }
+#ifdef sun
+// for CC
+#include <widec.h>
+char xmltob(XMLCSTR t, int v) {
+  if (t) return (char)wstol(t, NULL, 10);
+  return v;
+}
+int xmltoi(XMLCSTR t, int v) {
+  if (t) return (int)wstol(t, NULL, 10);
+  return v;
+}
+long xmltol(XMLCSTR t, long v) {
+  if (t) return wstol(t, NULL, 10);
+  return v;
+}
+#else
+// for gcc
+char xmltob(XMLCSTR t, int v) {
+  if (t) return (char)wcstol(t, NULL, 10);
+  return v;
+}
+int xmltoi(XMLCSTR t, int v) {
+  if (t) return (int)wcstol(t, NULL, 10);
+  return v;
+}
+long xmltol(XMLCSTR t, long v) {
+  if (t) return wcstol(t, NULL, 10);
+  return v;
+}
 #endif
-XMLCSTR xmltoa(XMLCSTR t,XMLCSTR v){ if (t)       return  t; return v; }
-XMLCHAR xmltoc(XMLCSTR t,XMLCHAR v){ if (t&&(*t)) return *t; return v; }
+double xmltof(XMLCSTR t, double v) {
+  if (t && (*t)) wscanf(t, "%f", &v); /*v=_wtof(t);*/
+  return v;
+}
+#endif
+#else
+char xmltob(XMLCSTR t, char v) {
+  if (t && (*t)) return (char)atoi(t);
+  return v;
+}
+int xmltoi(XMLCSTR t, int v) {
+  if (t && (*t)) return atoi(t);
+  return v;
+}
+long xmltol(XMLCSTR t, long v) {
+  if (t && (*t)) return atol(t);
+  return v;
+}
+double xmltof(XMLCSTR t, double v) {
+  if (t && (*t)) return atof(t);
+  return v;
+}
+#endif
+XMLCSTR xmltoa(XMLCSTR t, XMLCSTR v) {
+  if (t) return t;
+  return v;
+}
+XMLCHAR xmltoc(XMLCSTR t, XMLCHAR v) {
+  if (t && (*t)) return *t;
+  return v;
+}
 
 /////////////////////////////////////////////////////////////////////////
 //                    the "openFileHelper" function                    //
 /////////////////////////////////////////////////////////////////////////
 
-// Since each application has its own way to report and deal with errors, you should modify & rewrite
-// the following "openFileHelper" function to get an "error reporting mechanism" tailored to your needs.
-XMLNode XMLNode::openFileHelper(XMLCSTR filename, XMLCSTR tag)
-{
-    // guess the value of the global parameter "characterEncoding"
-    // (the guess is based on the first 200 bytes of the file).
-    FILE *f=xfopen(filename,_CXML("rb"));
-    if (f)
-    {
-        char bb[205];
-        int l=(int)fread(bb,1,200,f);
-        setGlobalOptions(guessCharEncoding(bb,l),guessWideCharChars,dropWhiteSpace,removeCommentsInMiddleOfText);
-        fclose(f);
+// Since each application has its own way to report and deal with errors, you
+// should modify & rewrite the following "openFileHelper" function to get an
+// "error reporting mechanism" tailored to your needs.
+XMLNode XMLNode::openFileHelper(XMLCSTR filename, XMLCSTR tag) {
+  // guess the value of the global parameter "characterEncoding"
+  // (the guess is based on the first 200 bytes of the file).
+  FILE *f = xfopen(filename, _CXML("rb"));
+  if (f) {
+    char bb[205];
+    int l = (int)fread(bb, 1, 200, f);
+    setGlobalOptions(guessCharEncoding(bb, l), guessWideCharChars,
+                     dropWhiteSpace, removeCommentsInMiddleOfText);
+    fclose(f);
+  }
+
+  // parse the file
+  XMLResults pResults;
+  XMLNode xnode = XMLNode::parseFile(filename, tag, &pResults);
+
+  // display error message (if any)
+  if (pResults.error != eXMLErrorNone) {
+    // create message
+    char message[2000], *s1 = (char *)"", *s3 = (char *)"";
+    XMLCSTR s2 = _CXML("");
+    if (pResults.error == eXMLErrorFirstTagNotFound) {
+      s1 = (char *)"First Tag should be '";
+      s2 = tag;
+      s3 = (char *)"'.\n";
     }
-
-    // parse the file
-    XMLResults pResults;
-    XMLNode xnode=XMLNode::parseFile(filename,tag,&pResults);
-
-    // display error message (if any)
-    if (pResults.error != eXMLErrorNone)
-    {
-        // create message
-        char message[2000],*s1=(char*)"",*s3=(char*)""; XMLCSTR s2=_CXML("");
-        if (pResults.error==eXMLErrorFirstTagNotFound) { s1=(char*)"First Tag should be '"; s2=tag; s3=(char*)"'.\n"; }
-        sprintf(message,
+    sprintf(message,
 #ifdef _XMLWIDECHAR
-            "XML Parsing error inside file '%S'.\n%S\nAt line %i, column %i.\n%s%S%s"
+            "XML Parsing error inside file '%S'.\n%S\nAt line %i, column "
+            "%i.\n%s%S%s"
 #else
-            "XML Parsing error inside file '%s'.\n%s\nAt line %i, column %i.\n%s%s%s"
+            "XML Parsing error inside file '%s'.\n%s\nAt line %i, column "
+            "%i.\n%s%s%s"
 #endif
-            ,filename,XMLNode::getError(pResults.error),pResults.nLine,pResults.nColumn,s1,s2,s3);
+            ,
+            filename, XMLNode::getError(pResults.error), pResults.nLine,
+            pResults.nColumn, s1, s2, s3);
 
-        // display message
-#if defined(_XMLWINDOWS) && !defined(UNDER_CE) && !defined(_XMLPARSER_NO_MESSAGEBOX_)
-        MessageBoxA(NULL,message,"XML Parsing error",MB_OK|MB_ICONERROR|MB_TOPMOST);
+    // display message
+#if defined(_XMLWINDOWS) && !defined(UNDER_CE) && \
+    !defined(_XMLPARSER_NO_MESSAGEBOX_)
+    MessageBoxA(NULL, message, "XML Parsing error",
+                MB_OK | MB_ICONERROR | MB_TOPMOST);
 #else
-        printf("%s",message);
+    printf("%s", message);
 #endif
-        exit(255);
-    }
-    return xnode;
+    exit(255);
+  }
+  return xnode;
 }
 
 /////////////////////////////////////////////////////////////////////////
@@ -443,400 +593,491 @@ XMLNode XMLNode::openFileHelper(XMLCSTR filename, XMLCSTR tag)
 // You should normally not change anything below this point.
 
 #ifndef _XMLWIDECHAR
-// If "characterEncoding=ascii" then we assume that all characters have the same length of 1 byte.
-// If "characterEncoding=UTF8" then the characters have different lengths (from 1 byte to 4 bytes).
-// If "characterEncoding=ShiftJIS" then the characters have different lengths (from 1 byte to 2 bytes).
-// This table is used as lookup-table to know the length of a character (in byte) based on the
-// content of the first byte of the character.
-// (note: if you modify this, you must always have XML_utf8ByteTable[0]=0 ).
-static const char XML_utf8ByteTable[256] =
-{
+// If "characterEncoding=ascii" then we assume that all characters have the same
+// length of 1 byte. If "characterEncoding=UTF8" then the characters have
+// different lengths (from 1 byte to 4 bytes). If "characterEncoding=ShiftJIS"
+// then the characters have different lengths (from 1 byte to 2 bytes). This
+// table is used as lookup-table to know the length of a character (in byte)
+// based on the content of the first byte of the character. (note: if you modify
+// this, you must always have XML_utf8ByteTable[0]=0 ).
+static const char XML_utf8ByteTable[256] = {
     //  0 1 2 3 4 5 6 7 8 9 a b c d e f
-    0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x00
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x10
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x20
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x30
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x40
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x50
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x60
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x70 End of ASCII range
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x80 0x80 to 0xc1 invalid
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x90
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0xa0
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0xb0
-    1,1,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xc0 0xc2 to 0xdf 2 byte
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xd0
-    3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,// 0xe0 0xe0 to 0xef 3 byte
-    4,4,4,4,4,1,1,1,1,1,1,1,1,1,1,1 // 0xf0 0xf0 to 0xf4 4 byte, 0xf5 and higher invalid
+    0, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x00
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x10
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x20
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x30
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x40
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x50
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x60
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x70 End of ASCII range
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x80 0x80 to 0xc1 invalid
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x90
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0xa0
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0xb0
+    1, 1, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0xc0 0xc2 to 0xdf 2 byte
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0xd0
+    3, 3, 3, 3, 3, 3, 3, 3,
+    3, 3, 3, 3, 3, 3, 3, 3,  // 0xe0 0xe0 to 0xef 3 byte
+    4, 4, 4, 4, 4, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1  // 0xf0 0xf0 to 0xf4 4 byte, 0xf5 and higher invalid
 };
-static const char XML_legacyByteTable[256] =
-{
-    0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1
-};
-static const char XML_sjisByteTable[256] =
-{
+static const char XML_legacyByteTable[256] = {
+    0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+static const char XML_sjisByteTable[256] = {
     //  0 1 2 3 4 5 6 7 8 9 a b c d e f
-    0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x00
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x10
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x20
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x30
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x40
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x50
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x60
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x70
-    1,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0x80 0x81 to 0x9F 2 bytes
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0x90
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0xa0
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0xb0
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0xc0
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0xd0
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xe0 0xe0 to 0xef 2 bytes
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1 // 0xf0
+    0, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x00
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x10
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x20
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x30
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x40
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x50
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x60
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x70
+    1, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0x80 0x81 to 0x9F 2 bytes
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0x90
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0xa0
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0xb0
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0xc0
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0xd0
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0xe0 0xe0 to 0xef 2 bytes
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1  // 0xf0
 };
-static const char XML_gb2312ByteTable[256] =
-{
-//  0 1 2 3 4 5 6 7 8 9 a b c d e f
-    0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x00
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x10
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x20
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x30
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x40
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x50
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x60
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x70
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x80
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x90
-    1,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xa0 0xa1 to 0xf7 2 bytes
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xb0
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xc0
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xd0
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xe0
-    2,2,2,2,2,2,2,2,1,1,1,1,1,1,1,1 // 0xf0
-};
-static const char XML_gbk_big5_ByteTable[256] =
-{
+static const char XML_gb2312ByteTable[256] = {
     //  0 1 2 3 4 5 6 7 8 9 a b c d e f
-    0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x00
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x10
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x20
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x30
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x40
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x50
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x60
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x70
-    1,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0x80 0x81 to 0xfe 2 bytes
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0x90
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xa0
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xb0
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xc0
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xd0
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xe0
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,1 // 0xf0
+    0, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x00
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x10
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x20
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x30
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x40
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x50
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x60
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x70
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x80
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x90
+    1, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0xa0 0xa1 to 0xf7 2 bytes
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0xb0
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0xc0
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0xd0
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0xe0
+    2, 2, 2, 2, 2, 2, 2, 2,
+    1, 1, 1, 1, 1, 1, 1, 1  // 0xf0
 };
-static const char *XML_ByteTable=(const char *)XML_utf8ByteTable; // the default is "characterEncoding=XMLNode::encoding_UTF8"
+static const char XML_gbk_big5_ByteTable[256] = {
+    //  0 1 2 3 4 5 6 7 8 9 a b c d e f
+    0, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x00
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x10
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x20
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x30
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x40
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x50
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x60
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x70
+    1, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0x80 0x81 to 0xfe 2 bytes
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0x90
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0xa0
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0xb0
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0xc0
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0xd0
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0xe0
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 1  // 0xf0
+};
+static const char *XML_ByteTable = (const char *)
+    XML_utf8ByteTable;  // the default is
+                        // "characterEncoding=XMLNode::encoding_UTF8"
 #endif
 
-
 XMLNode XMLNode::emptyXMLNode;
-XMLClear XMLNode::emptyXMLClear={ NULL, NULL, NULL};
-XMLAttribute XMLNode::emptyXMLAttribute={ NULL, NULL};
+XMLClear XMLNode::emptyXMLClear = {NULL, NULL, NULL};
+XMLAttribute XMLNode::emptyXMLAttribute = {NULL, NULL};
 
 // Enumeration used to decipher what type a token is
-typedef enum XMLTokenTypeTag
-{
-    eTokenText = 0,
-    eTokenQuotedText,
-    eTokenTagStart,         /* "<"            */
-    eTokenTagEnd,           /* "</"           */
-    eTokenCloseTag,         /* ">"            */
-    eTokenEquals,           /* "="            */
-    eTokenDeclaration,      /* "<?"           */
-    eTokenShortHandClose,   /* "/>"           */
-    eTokenClear,
-    eTokenError
+typedef enum XMLTokenTypeTag {
+  eTokenText = 0,
+  eTokenQuotedText,
+  eTokenTagStart,       /* "<"            */
+  eTokenTagEnd,         /* "</"           */
+  eTokenCloseTag,       /* ">"            */
+  eTokenEquals,         /* "="            */
+  eTokenDeclaration,    /* "<?"           */
+  eTokenShortHandClose, /* "/>"           */
+  eTokenClear,
+  eTokenError
 } XMLTokenType;
 
 // Main structure used for parsing XML
-typedef struct XML
-{
-    XMLCSTR                lpXML;
-    XMLCSTR                lpszText;
-    int                    nIndex,nIndexMissigEndTag;
-    enum XMLError          error;
-    XMLCSTR                lpEndTag;
-    int                    cbEndTag;
-    XMLCSTR                lpNewElement;
-    int                    cbNewElement;
-    int                    nFirst;
+typedef struct XML {
+  XMLCSTR lpXML;
+  XMLCSTR lpszText;
+  int nIndex, nIndexMissigEndTag;
+  enum XMLError error;
+  XMLCSTR lpEndTag;
+  int cbEndTag;
+  XMLCSTR lpNewElement;
+  int cbNewElement;
+  int nFirst;
 } XML;
 
-typedef struct
-{
-    ALLXMLClearTag *pClr;
-    XMLCSTR     pStr;
+typedef struct {
+  ALLXMLClearTag *pClr;
+  XMLCSTR pStr;
 } NextToken;
 
 // Enumeration used when parsing attributes
-typedef enum Attrib
-{
-    eAttribName = 0,
-    eAttribEquals,
-    eAttribValue
-} Attrib;
+typedef enum Attrib { eAttribName = 0, eAttribEquals, eAttribValue } Attrib;
 
 // Enumeration used when parsing elements to dictate whether we are currently
 // inside a tag
-typedef enum Status
-{
-    eInsideTag = 0,
-    eOutsideTag
-} Status;
+typedef enum Status { eInsideTag = 0, eOutsideTag } Status;
 
-XMLError XMLNode::writeToFile(XMLCSTR filename, const char *encoding, char nFormat) const
-{
-    if (!d) return eXMLErrorNone;
-    FILE *f=xfopen(filename,_CXML("wb"));
-    if (!f) return eXMLErrorCannotOpenWriteFile;
+XMLError XMLNode::writeToFile(XMLCSTR filename, const char *encoding,
+                              char nFormat) const {
+  if (!d) return eXMLErrorNone;
+  FILE *f = xfopen(filename, _CXML("wb"));
+  if (!f) return eXMLErrorCannotOpenWriteFile;
 #ifdef _XMLWIDECHAR
-    unsigned char h[2]={ 0xFF, 0xFE };
-    if (!fwrite(h,2,1,f)) return eXMLErrorCannotWriteFile;
-    if ((!isDeclaration())&&((d->lpszName)||(!getChildNode().isDeclaration())))
-    {
-        if (!fwrite(L"<?xml version=\"1.0\" encoding=\"utf-16\"?>\n",sizeof(wchar_t)*40,1,f))
-            return eXMLErrorCannotWriteFile;
-    }
+  unsigned char h[2] = {0xFF, 0xFE};
+  if (!fwrite(h, 2, 1, f)) return eXMLErrorCannotWriteFile;
+  if ((!isDeclaration()) &&
+      ((d->lpszName) || (!getChildNode().isDeclaration()))) {
+    if (!fwrite(L"<?xml version=\"1.0\" encoding=\"utf-16\"?>\n",
+                sizeof(wchar_t) * 40, 1, f))
+      return eXMLErrorCannotWriteFile;
+  }
 #else
-    if ((!isDeclaration())&&((d->lpszName)||(!getChildNode().isDeclaration())))
-    {
-        if (characterEncoding==char_encoding_UTF8)
-        {
-            // header so that windows recognize the file as UTF-8:
-            unsigned char h[3]={0xEF,0xBB,0xBF}; if (!fwrite(h,3,1,f)) return eXMLErrorCannotWriteFile;
-            encoding="utf-8";
-        } else if (characterEncoding==char_encoding_ShiftJIS) encoding="SHIFT-JIS";
+  if ((!isDeclaration()) &&
+      ((d->lpszName) || (!getChildNode().isDeclaration()))) {
+    if (characterEncoding == char_encoding_UTF8) {
+      // header so that windows recognize the file as UTF-8:
+      unsigned char h[3] = {0xEF, 0xBB, 0xBF};
+      if (!fwrite(h, 3, 1, f)) return eXMLErrorCannotWriteFile;
+      encoding = "utf-8";
+    } else if (characterEncoding == char_encoding_ShiftJIS)
+      encoding = "SHIFT-JIS";
 
-        if (!encoding) encoding="ISO-8859-1";
-        if (fprintf(f,"<?xml version=\"1.0\" encoding=\"%s\"?>\n",encoding)<0) return eXMLErrorCannotWriteFile;
-    } else
-    {
-        if (characterEncoding==char_encoding_UTF8)
-        {
-            unsigned char h[3]={0xEF,0xBB,0xBF}; if (!fwrite(h,3,1,f)) return eXMLErrorCannotWriteFile;
-        }
+    if (!encoding) encoding = "ISO-8859-1";
+    if (fprintf(f, "<?xml version=\"1.0\" encoding=\"%s\"?>\n", encoding) < 0)
+      return eXMLErrorCannotWriteFile;
+  } else {
+    if (characterEncoding == char_encoding_UTF8) {
+      unsigned char h[3] = {0xEF, 0xBB, 0xBF};
+      if (!fwrite(h, 3, 1, f)) return eXMLErrorCannotWriteFile;
     }
+  }
 #endif
-    int i;
-    XMLSTR t=createXMLString(nFormat,&i);
-    if (!fwrite(t,sizeof(XMLCHAR)*i,1,f)) return eXMLErrorCannotWriteFile;
-    if (fclose(f)!=0) return eXMLErrorCannotWriteFile;
-    free(t);
-    return eXMLErrorNone;
+  int i;
+  XMLSTR t = createXMLString(nFormat, &i);
+  if (!fwrite(t, sizeof(XMLCHAR) * i, 1, f)) return eXMLErrorCannotWriteFile;
+  if (fclose(f) != 0) return eXMLErrorCannotWriteFile;
+  free(t);
+  return eXMLErrorNone;
 }
 
 // Duplicate a given string.
-XMLSTR stringDup(XMLCSTR lpszData, int cbData)
-{
-    if (lpszData==NULL) return NULL;
+XMLSTR stringDup(XMLCSTR lpszData, int cbData) {
+  if (lpszData == NULL) return NULL;
 
-    XMLSTR lpszNew;
-    if (cbData==-1) cbData=(int)xstrlen(lpszData);
-    lpszNew = (XMLSTR)malloc((cbData+1) * sizeof(XMLCHAR));
-    if (lpszNew)
-    {
-        memcpy(lpszNew, lpszData, (cbData) * sizeof(XMLCHAR));
-        lpszNew[cbData] = (XMLCHAR)NULL;
-    }
-    return lpszNew;
+  XMLSTR lpszNew;
+  if (cbData == -1) cbData = (int)xstrlen(lpszData);
+  lpszNew = (XMLSTR)malloc((cbData + 1) * sizeof(XMLCHAR));
+  if (lpszNew) {
+    memcpy(lpszNew, lpszData, (cbData) * sizeof(XMLCHAR));
+    lpszNew[cbData] = (XMLCHAR)NULL;
+  }
+  return lpszNew;
 }
 
-XMLSTR ToXMLStringTool::toXMLUnSafe(XMLSTR dest,XMLCSTR source)
-{
-    XMLSTR dd=dest;
-    XMLCHAR ch;
-    XMLCharacterEntity *entity;
-    while ((ch=*source))
-    {
-        entity=XMLEntities;
-        do
-        {
-            if (ch==entity->c) {xstrcpy(dest,entity->s); dest+=entity->l; source++; goto out_of_loop1; }
-            entity++;
-        } while(entity->s);
+XMLSTR ToXMLStringTool::toXMLUnSafe(XMLSTR dest, XMLCSTR source) {
+  XMLSTR dd = dest;
+  XMLCHAR ch;
+  XMLCharacterEntity *entity;
+  while ((ch = *source)) {
+    entity = XMLEntities;
+    do {
+      if (ch == entity->c) {
+        xstrcpy(dest, entity->s);
+        dest += entity->l;
+        source++;
+        goto out_of_loop1;
+      }
+      entity++;
+    } while (entity->s);
 #ifdef _XMLWIDECHAR
-        *(dest++)=*(source++);
+    *(dest++) = *(source++);
 #else
-        switch(XML_ByteTable[(unsigned char)ch])
-        {
-        case 4: *(dest++)=*(source++);
-        case 3: *(dest++)=*(source++);
-        case 2: *(dest++)=*(source++);
-        case 1: *(dest++)=*(source++);
-        }
-#endif
-out_of_loop1:
-        ;
+    switch (XML_ByteTable[(unsigned char)ch]) {
+      case 4:
+        *(dest++) = *(source++);
+      case 3:
+        *(dest++) = *(source++);
+      case 2:
+        *(dest++) = *(source++);
+      case 1:
+        *(dest++) = *(source++);
     }
-    *dest=0;
-    return dd;
+#endif
+  out_of_loop1:;
+  }
+  *dest = 0;
+  return dd;
 }
 
 // private (used while rendering):
-int ToXMLStringTool::lengthXMLString(XMLCSTR source)
-{
-    int r=0;
-    XMLCharacterEntity *entity;
-    XMLCHAR ch;
-    while ((ch=*source))
-    {
-        entity=XMLEntities;
-        do
-        {
-            if (ch==entity->c) { r+=entity->l; source++; goto out_of_loop1; }
-            entity++;
-        } while(entity->s);
+int ToXMLStringTool::lengthXMLString(XMLCSTR source) {
+  int r = 0;
+  XMLCharacterEntity *entity;
+  XMLCHAR ch;
+  while ((ch = *source)) {
+    entity = XMLEntities;
+    do {
+      if (ch == entity->c) {
+        r += entity->l;
+        source++;
+        goto out_of_loop1;
+      }
+      entity++;
+    } while (entity->s);
 #ifdef _XMLWIDECHAR
-        r++; source++;
+    r++;
+    source++;
 #else
-        ch=XML_ByteTable[(unsigned char)ch]; r+=ch; source+=ch;
+    ch = XML_ByteTable[(unsigned char)ch];
+    r += ch;
+    source += ch;
 #endif
-out_of_loop1:
-        ;
-    }
-    return r;
+  out_of_loop1:;
+  }
+  return r;
 }
 
-ToXMLStringTool::~ToXMLStringTool(){ freeBuffer(); }
-void ToXMLStringTool::freeBuffer(){ if (buf) free(buf); buf=NULL; buflen=0; }
-XMLSTR ToXMLStringTool::toXML(XMLCSTR source)
-{
-    int l=lengthXMLString(source)+1;
-    if (l>buflen) { buflen=l; buf=(XMLSTR)realloc(buf,l*sizeof(XMLCHAR)); }
-    return toXMLUnSafe(buf,source);
+ToXMLStringTool::~ToXMLStringTool() { freeBuffer(); }
+void ToXMLStringTool::freeBuffer() {
+  if (buf) free(buf);
+  buf = NULL;
+  buflen = 0;
+}
+XMLSTR ToXMLStringTool::toXML(XMLCSTR source) {
+  int l = lengthXMLString(source) + 1;
+  if (l > buflen) {
+    buflen = l;
+    buf = (XMLSTR)realloc(buf, l * sizeof(XMLCHAR));
+  }
+  return toXMLUnSafe(buf, source);
 }
 
 // private:
-XMLSTR fromXMLString(XMLCSTR s, int lo, XML *pXML)
-{
-    // This function is the opposite of the function "toXMLString". It decodes the escape
-    // sequences &amp;, &quot;, &apos;, &lt;, &gt; and replace them by the characters
-    // &,",',<,>. This function is used internally by the XML Parser. All the calls to
-    // the XML library will always gives you back "decoded" strings.
-    //
-    // in: string (s) and length (lo) of string
-    // out:  new allocated string converted from xml
-    if (!s) return NULL;
+XMLSTR fromXMLString(XMLCSTR s, int lo, XML *pXML) {
+  // This function is the opposite of the function "toXMLString". It decodes the
+  // escape sequences &amp;, &quot;, &apos;, &lt;, &gt; and replace them by the
+  // characters
+  // &,",',<,>. This function is used internally by the XML Parser. All the
+  // calls to the XML library will always gives you back "decoded" strings.
+  //
+  // in: string (s) and length (lo) of string
+  // out:  new allocated string converted from xml
+  if (!s) return NULL;
 
-    int ll=0,j;
-    XMLSTR d;
-    XMLCSTR ss=s;
-    XMLCharacterEntity *entity;
-    while ((lo>0)&&(*s))
-    {
-        if (*s==_CXML('&'))
-        {
-            if ((lo>2)&&(s[1]==_CXML('#')))
-            {
-                s+=2; lo-=2;
-                if ((*s==_CXML('X'))||(*s==_CXML('x'))) { s++; lo--; }
-                while ((*s)&&(*s!=_CXML(';'))&&((lo--)>0)) s++;
-                if (*s!=_CXML(';'))
-                {
-                    pXML->error=eXMLErrorUnknownCharacterEntity;
-                    return NULL;
-                }
-                s++; lo--;
-            } else
-            {
-                entity=XMLEntities;
-                do
-                {
-                    if ((lo>=entity->l)&&(xstrnicmp(s,entity->s,entity->l)==0)) { s+=entity->l; lo-=entity->l; break; }
-                    entity++;
-                } while(entity->s);
-                if (!entity->s)
-                {
-                    pXML->error=eXMLErrorUnknownCharacterEntity;
-                    return NULL;
-                }
-            }
-        } else
-        {
-#ifdef _XMLWIDECHAR
-            s++; lo--;
-#else
-            j=XML_ByteTable[(unsigned char)*s]; s+=j; lo-=j; ll+=j-1;
-#endif
+  int ll = 0, j;
+  XMLSTR d;
+  XMLCSTR ss = s;
+  XMLCharacterEntity *entity;
+  while ((lo > 0) && (*s)) {
+    if (*s == _CXML('&')) {
+      if ((lo > 2) && (s[1] == _CXML('#'))) {
+        s += 2;
+        lo -= 2;
+        if ((*s == _CXML('X')) || (*s == _CXML('x'))) {
+          s++;
+          lo--;
         }
-        ll++;
+        while ((*s) && (*s != _CXML(';')) && ((lo--) > 0)) s++;
+        if (*s != _CXML(';')) {
+          pXML->error = eXMLErrorUnknownCharacterEntity;
+          return NULL;
+        }
+        s++;
+        lo--;
+      } else {
+        entity = XMLEntities;
+        do {
+          if ((lo >= entity->l) && (xstrnicmp(s, entity->s, entity->l) == 0)) {
+            s += entity->l;
+            lo -= entity->l;
+            break;
+          }
+          entity++;
+        } while (entity->s);
+        if (!entity->s) {
+          pXML->error = eXMLErrorUnknownCharacterEntity;
+          return NULL;
+        }
+      }
+    } else {
+#ifdef _XMLWIDECHAR
+      s++;
+      lo--;
+#else
+      j = XML_ByteTable[(unsigned char)*s];
+      s += j;
+      lo -= j;
+      ll += j - 1;
+#endif
     }
+    ll++;
+  }
 
-    d=(XMLSTR)malloc((ll+1)*sizeof(XMLCHAR));
-    s=d;
-    while (ll-->0)
-    {
-        if (*ss==_CXML('&'))
-        {
-            if (ss[1]==_CXML('#'))
-            {
-                ss+=2; j=0;
-                if ((*ss==_CXML('X'))||(*ss==_CXML('x')))
-                {
-                    ss++;
-                    while (*ss!=_CXML(';'))
-                    {
-                        if ((*ss>=_CXML('0'))&&(*ss<=_CXML('9'))) j=(j<<4)+*ss-_CXML('0');
-                        else if ((*ss>=_CXML('A'))&&(*ss<=_CXML('F'))) j=(j<<4)+*ss-_CXML('A')+10;
-                        else if ((*ss>=_CXML('a'))&&(*ss<=_CXML('f'))) j=(j<<4)+*ss-_CXML('a')+10;
-                        else { free((void*)s); pXML->error=eXMLErrorUnknownCharacterEntity;return NULL;}
-                        ss++;
-                    }
-                } else
-                {
-                    while (*ss!=_CXML(';'))
-                    {
-                        if ((*ss>=_CXML('0'))&&(*ss<=_CXML('9'))) j=(j*10)+*ss-_CXML('0');
-                        else { free((void*)s); pXML->error=eXMLErrorUnknownCharacterEntity;return NULL;}
-                        ss++;
-                    }
-                }
+  d = (XMLSTR)malloc((ll + 1) * sizeof(XMLCHAR));
+  s = d;
+  while (ll-- > 0) {
+    if (*ss == _CXML('&')) {
+      if (ss[1] == _CXML('#')) {
+        ss += 2;
+        j = 0;
+        if ((*ss == _CXML('X')) || (*ss == _CXML('x'))) {
+          ss++;
+          while (*ss != _CXML(';')) {
+            if ((*ss >= _CXML('0')) && (*ss <= _CXML('9')))
+              j = (j << 4) + *ss - _CXML('0');
+            else if ((*ss >= _CXML('A')) && (*ss <= _CXML('F')))
+              j = (j << 4) + *ss - _CXML('A') + 10;
+            else if ((*ss >= _CXML('a')) && (*ss <= _CXML('f')))
+              j = (j << 4) + *ss - _CXML('a') + 10;
+            else {
+              free((void *)s);
+              pXML->error = eXMLErrorUnknownCharacterEntity;
+              return NULL;
+            }
+            ss++;
+          }
+        } else {
+          while (*ss != _CXML(';')) {
+            if ((*ss >= _CXML('0')) && (*ss <= _CXML('9')))
+              j = (j * 10) + *ss - _CXML('0');
+            else {
+              free((void *)s);
+              pXML->error = eXMLErrorUnknownCharacterEntity;
+              return NULL;
+            }
+            ss++;
+          }
+        }
 #ifndef _XMLWIDECHAR
-                if (j>255) { free((void*)s); pXML->error=eXMLErrorCharacterCodeAbove255;return NULL;}
-#endif
-                (*d++)=(XMLCHAR)j; ss++;
-            } else
-            {
-                entity=XMLEntities;
-                do
-                {
-                    if (xstrnicmp(ss,entity->s,entity->l)==0) { *(d++)=entity->c; ss+=entity->l; break; }
-                    entity++;
-                } while(entity->s);
-            }
-        } else
-        {
-#ifdef _XMLWIDECHAR
-            *(d++)=*(ss++);
-#else
-            switch(XML_ByteTable[(unsigned char)*ss])
-            {
-            case 4: *(d++)=*(ss++); ll--;
-            case 3: *(d++)=*(ss++); ll--;
-            case 2: *(d++)=*(ss++); ll--;
-            case 1: *(d++)=*(ss++);
-            }
-#endif
+        if (j > 255) {
+          free((void *)s);
+          pXML->error = eXMLErrorCharacterCodeAbove255;
+          return NULL;
         }
+#endif
+        (*d++) = (XMLCHAR)j;
+        ss++;
+      } else {
+        entity = XMLEntities;
+        do {
+          if (xstrnicmp(ss, entity->s, entity->l) == 0) {
+            *(d++) = entity->c;
+            ss += entity->l;
+            break;
+          }
+          entity++;
+        } while (entity->s);
+      }
+    } else {
+#ifdef _XMLWIDECHAR
+      *(d++) = *(ss++);
+#else
+      switch (XML_ByteTable[(unsigned char)*ss]) {
+        case 4:
+          *(d++) = *(ss++);
+          ll--;
+        case 3:
+          *(d++) = *(ss++);
+          ll--;
+        case 2:
+          *(d++) = *(ss++);
+          ll--;
+        case 1:
+          *(d++) = *(ss++);
+      }
+#endif
     }
-    *d=0;
-    return (XMLSTR)s;
+  }
+  *d = 0;
+  return (XMLSTR)s;
 }
 
-#define XML_isSPACECHAR(ch) ((ch==_CXML('\n'))||(ch==_CXML(' '))||(ch== _CXML('\t'))||(ch==_CXML('\r')))
+#define XML_isSPACECHAR(ch)                                            \
+  ((ch == _CXML('\n')) || (ch == _CXML(' ')) || (ch == _CXML('\t')) || \
+   (ch == _CXML('\r')))
 
 // private:
 char myTagCompare(XMLCSTR cclose, XMLCSTR copen)
@@ -844,1233 +1085,1259 @@ char myTagCompare(XMLCSTR cclose, XMLCSTR copen)
 // return 0 if equals
 // return 1 if different
 {
-    if (!cclose) return 1;
-    int l=(int)xstrlen(cclose);
-    if (xstrnicmp(cclose, copen, l)!=0) return 1;
-    const XMLCHAR c=copen[l];
-    if (XML_isSPACECHAR(c)||
-        (c==_CXML('/' ))||
-        (c==_CXML('<' ))||
-        (c==_CXML('>' ))||
-        (c==_CXML('=' ))) return 0;
-    return 1;
+  if (!cclose) return 1;
+  int l = (int)xstrlen(cclose);
+  if (xstrnicmp(cclose, copen, l) != 0) return 1;
+  const XMLCHAR c = copen[l];
+  if (XML_isSPACECHAR(c) || (c == _CXML('/')) || (c == _CXML('<')) ||
+      (c == _CXML('>')) || (c == _CXML('=')))
+    return 0;
+  return 1;
 }
 
 // Obtain the next character from the string.
-static inline XMLCHAR getNextChar(XML *pXML)
-{
-    XMLCHAR ch = pXML->lpXML[pXML->nIndex];
+static inline XMLCHAR getNextChar(XML *pXML) {
+  XMLCHAR ch = pXML->lpXML[pXML->nIndex];
 #ifdef _XMLWIDECHAR
-    if (ch!=0) pXML->nIndex++;
+  if (ch != 0) pXML->nIndex++;
 #else
-    pXML->nIndex+=XML_ByteTable[(unsigned char)ch];
+  pXML->nIndex += XML_ByteTable[(unsigned char)ch];
 #endif
-    return ch;
+  return ch;
 }
 
 // Find the next token in a string.
 // pcbToken contains the number of characters that have been read.
-static NextToken GetNextToken(XML *pXML, int *pcbToken, enum XMLTokenTypeTag *pType)
-{
-    NextToken        result;
-    XMLCHAR            ch;
-    XMLCHAR            chTemp;
-    int              indexStart,nFoundMatch,nIsText=FALSE;
-    result.pClr=NULL; // prevent warning
+static NextToken GetNextToken(XML *pXML, int *pcbToken,
+                              enum XMLTokenTypeTag *pType) {
+  NextToken result;
+  XMLCHAR ch;
+  XMLCHAR chTemp;
+  int indexStart, nFoundMatch, nIsText = FALSE;
+  result.pClr = NULL;  // prevent warning
 
-    // Find next non-white space character
-    do { indexStart=pXML->nIndex; ch=getNextChar(pXML); } while XML_isSPACECHAR(ch);
+  // Find next non-white space character
+  do {
+    indexStart = pXML->nIndex;
+    ch = getNextChar(pXML);
+  } while XML_isSPACECHAR(ch);
 
-    if (ch)
-    {
-        // Cache the current string pointer
-        result.pStr = &pXML->lpXML[indexStart];
+  if (ch) {
+    // Cache the current string pointer
+    result.pStr = &pXML->lpXML[indexStart];
 
-        // First check whether the token is in the clear tag list (meaning it
-        // does not need formatting).
-        ALLXMLClearTag *ctag=XMLClearTags;
-        do
-        {
-            if (xstrncmp(ctag->lpszOpen, result.pStr, ctag->openTagLen)==0)
-            {
-                result.pClr=ctag;
-                pXML->nIndex+=ctag->openTagLen-1;
-                *pType=eTokenClear;
-                return result;
-            }
-            ctag++;
-        } while(ctag->lpszOpen);
+    // First check whether the token is in the clear tag list (meaning it
+    // does not need formatting).
+    ALLXMLClearTag *ctag = XMLClearTags;
+    do {
+      if (xstrncmp(ctag->lpszOpen, result.pStr, ctag->openTagLen) == 0) {
+        result.pClr = ctag;
+        pXML->nIndex += ctag->openTagLen - 1;
+        *pType = eTokenClear;
+        return result;
+      }
+      ctag++;
+    } while (ctag->lpszOpen);
 
-        // If we didn't find a clear tag then check for standard tokens
-        switch(ch)
-        {
-        // Check for quotes
-        case _CXML('\''):
-        case _CXML('\"'):
-            // Type of token
-            *pType = eTokenQuotedText;
-            chTemp = ch;
+    // If we didn't find a clear tag then check for standard tokens
+    switch (ch) {
+      // Check for quotes
+      case _CXML('\''):
+      case _CXML('\"'):
+        // Type of token
+        *pType = eTokenQuotedText;
+        chTemp = ch;
 
-            // Set the size
-            nFoundMatch = FALSE;
+        // Set the size
+        nFoundMatch = FALSE;
 
-            // Search through the string to find a matching quote
-            while((ch = getNextChar(pXML)))
-            {
-                if (ch==chTemp) { nFoundMatch = TRUE; break; }
-                if (ch==_CXML('<')) break;
-            }
-
-            // If we failed to find a matching quote
-            if (nFoundMatch == FALSE)
-            {
-                pXML->nIndex=indexStart+1;
-                nIsText=TRUE;
-                break;
-            }
-
-//  4.02.2002
-//            if (FindNonWhiteSpace(pXML)) pXML->nIndex--;
-
+        // Search through the string to find a matching quote
+        while ((ch = getNextChar(pXML))) {
+          if (ch == chTemp) {
+            nFoundMatch = TRUE;
             break;
-
-        // Equals (used with attribute values)
-        case _CXML('='):
-            *pType = eTokenEquals;
-            break;
-
-        // Close tag
-        case _CXML('>'):
-            *pType = eTokenCloseTag;
-            break;
-
-        // Check for tag start and tag end
-        case _CXML('<'):
-
-            // Peek at the next character to see if we have an end tag '</',
-            // or an xml declaration '<?'
-            chTemp = pXML->lpXML[pXML->nIndex];
-
-            // If we have a tag end...
-            if (chTemp == _CXML('/'))
-            {
-                // Set the type and ensure we point at the next character
-                getNextChar(pXML);
-                *pType = eTokenTagEnd;
-            }
-
-            // If we have an XML declaration tag
-            else if (chTemp == _CXML('?'))
-            {
-
-                // Set the type and ensure we point at the next character
-                getNextChar(pXML);
-                *pType = eTokenDeclaration;
-            }
-
-            // Otherwise we must have a start tag
-            else
-            {
-                *pType = eTokenTagStart;
-            }
-            break;
-
-        // Check to see if we have a short hand type end tag ('/>').
-        case _CXML('/'):
-
-            // Peek at the next character to see if we have a short end tag '/>'
-            chTemp = pXML->lpXML[pXML->nIndex];
-
-            // If we have a short hand end tag...
-            if (chTemp == _CXML('>'))
-            {
-                // Set the type and ensure we point at the next character
-                getNextChar(pXML);
-                *pType = eTokenShortHandClose;
-                break;
-            }
-
-            // If we haven't found a short hand closing tag then drop into the
-            // text process
-
-        // Other characters
-        default:
-            nIsText = TRUE;
+          }
+          if (ch == _CXML('<')) break;
         }
 
-        // If this is a TEXT node
-        if (nIsText)
-        {
-            // Indicate we are dealing with text
-            *pType = eTokenText;
-            while((ch = getNextChar(pXML)))
-            {
-                if XML_isSPACECHAR(ch)
-                {
-                    indexStart++; break;
-
-                } else if (ch==_CXML('/'))
-                {
-                    // If we find a slash then this maybe text or a short hand end tag
-                    // Peek at the next character to see it we have short hand end tag
-                    ch=pXML->lpXML[pXML->nIndex];
-                    // If we found a short hand end tag then we need to exit the loop
-                    if (ch==_CXML('>')) { pXML->nIndex--; break; }
-
-                } else if ((ch==_CXML('<'))||(ch==_CXML('>'))||(ch==_CXML('=')))
-                {
-                    pXML->nIndex--; break;
-                }
-            }
+        // If we failed to find a matching quote
+        if (nFoundMatch == FALSE) {
+          pXML->nIndex = indexStart + 1;
+          nIsText = TRUE;
+          break;
         }
-        *pcbToken = pXML->nIndex-indexStart;
-    } else
-    {
-        // If we failed to obtain a valid character
-        *pcbToken = 0;
-        *pType = eTokenError;
-        result.pStr=NULL;
+
+        //  4.02.2002
+        //            if (FindNonWhiteSpace(pXML)) pXML->nIndex--;
+
+        break;
+
+      // Equals (used with attribute values)
+      case _CXML('='):
+        *pType = eTokenEquals;
+        break;
+
+      // Close tag
+      case _CXML('>'):
+        *pType = eTokenCloseTag;
+        break;
+
+      // Check for tag start and tag end
+      case _CXML('<'):
+
+        // Peek at the next character to see if we have an end tag '</',
+        // or an xml declaration '<?'
+        chTemp = pXML->lpXML[pXML->nIndex];
+
+        // If we have a tag end...
+        if (chTemp == _CXML('/')) {
+          // Set the type and ensure we point at the next character
+          getNextChar(pXML);
+          *pType = eTokenTagEnd;
+        }
+
+        // If we have an XML declaration tag
+        else if (chTemp == _CXML('?')) {
+          // Set the type and ensure we point at the next character
+          getNextChar(pXML);
+          *pType = eTokenDeclaration;
+        }
+
+        // Otherwise we must have a start tag
+        else {
+          *pType = eTokenTagStart;
+        }
+        break;
+
+      // Check to see if we have a short hand type end tag ('/>').
+      case _CXML('/'):
+
+        // Peek at the next character to see if we have a short end tag '/>'
+        chTemp = pXML->lpXML[pXML->nIndex];
+
+        // If we have a short hand end tag...
+        if (chTemp == _CXML('>')) {
+          // Set the type and ensure we point at the next character
+          getNextChar(pXML);
+          *pType = eTokenShortHandClose;
+          break;
+        }
+
+        // If we haven't found a short hand closing tag then drop into the
+        // text process
+
+      // Other characters
+      default:
+        nIsText = TRUE;
     }
 
-    return result;
+    // If this is a TEXT node
+    if (nIsText) {
+      // Indicate we are dealing with text
+      *pType = eTokenText;
+      while ((ch = getNextChar(pXML))) {
+        if
+          XML_isSPACECHAR(ch) {
+            indexStart++;
+            break;
+          }
+        else if (ch == _CXML('/')) {
+          // If we find a slash then this maybe text or a short hand end tag
+          // Peek at the next character to see it we have short hand end tag
+          ch = pXML->lpXML[pXML->nIndex];
+          // If we found a short hand end tag then we need to exit the loop
+          if (ch == _CXML('>')) {
+            pXML->nIndex--;
+            break;
+          }
+
+        } else if ((ch == _CXML('<')) || (ch == _CXML('>')) ||
+                   (ch == _CXML('='))) {
+          pXML->nIndex--;
+          break;
+        }
+      }
+    }
+    *pcbToken = pXML->nIndex - indexStart;
+  } else {
+    // If we failed to obtain a valid character
+    *pcbToken = 0;
+    *pType = eTokenError;
+    result.pStr = NULL;
+  }
+
+  return result;
 }
 
-XMLCSTR XMLNode::updateName_WOSD(XMLSTR lpszName)
-{
-    if (!d) { free(lpszName); return NULL; }
-    if (d->lpszName&&(lpszName!=d->lpszName)) free((void*)d->lpszName);
-    d->lpszName=lpszName;
-    return lpszName;
+XMLCSTR XMLNode::updateName_WOSD(XMLSTR lpszName) {
+  if (!d) {
+    free(lpszName);
+    return NULL;
+  }
+  if (d->lpszName && (lpszName != d->lpszName)) free((void *)d->lpszName);
+  d->lpszName = lpszName;
+  return lpszName;
 }
 
 // private:
-XMLNode::XMLNode(struct XMLNodeDataTag *p){ d=p; (p->ref_count)++; }
-XMLNode::XMLNode(XMLNodeData *pParent, XMLSTR lpszName, char isDeclaration)
-{
-    d=(XMLNodeData*)malloc(sizeof(XMLNodeData));
-    d->ref_count=1;
+XMLNode::XMLNode(struct XMLNodeDataTag *p) {
+  d = p;
+  (p->ref_count)++;
+}
+XMLNode::XMLNode(XMLNodeData *pParent, XMLSTR lpszName, char isDeclaration) {
+  d = (XMLNodeData *)malloc(sizeof(XMLNodeData));
+  d->ref_count = 1;
 
-    d->lpszName=NULL;
-    d->nChild= 0;
-    d->nText = 0;
-    d->nClear = 0;
-    d->nAttribute = 0;
+  d->lpszName = NULL;
+  d->nChild = 0;
+  d->nText = 0;
+  d->nClear = 0;
+  d->nAttribute = 0;
 
-    d->isDeclaration = isDeclaration;
+  d->isDeclaration = isDeclaration;
 
-    d->pParent = pParent;
-    d->pChild= NULL;
-    d->pText= NULL;
-    d->pClear= NULL;
-    d->pAttribute= NULL;
-    d->pOrder= NULL;
+  d->pParent = pParent;
+  d->pChild = NULL;
+  d->pText = NULL;
+  d->pClear = NULL;
+  d->pAttribute = NULL;
+  d->pOrder = NULL;
 
-    updateName_WOSD(lpszName);
+  updateName_WOSD(lpszName);
 }
 
-XMLNode XMLNode::createXMLTopNode_WOSD(XMLSTR lpszName, char isDeclaration) { return XMLNode(NULL,lpszName,isDeclaration); }
-XMLNode XMLNode::createXMLTopNode(XMLCSTR lpszName, char isDeclaration) { return XMLNode(NULL,stringDup(lpszName),isDeclaration); }
+XMLNode XMLNode::createXMLTopNode_WOSD(XMLSTR lpszName, char isDeclaration) {
+  return XMLNode(NULL, lpszName, isDeclaration);
+}
+XMLNode XMLNode::createXMLTopNode(XMLCSTR lpszName, char isDeclaration) {
+  return XMLNode(NULL, stringDup(lpszName), isDeclaration);
+}
 
 #define MEMORYINCREASE 50
 
-static inline void myFree(void *p) { if (p) free(p); }
-static inline void *myRealloc(void *p, int newsize, int memInc, int sizeofElem)
-{
-    if (p==NULL) { if (memInc) return malloc(memInc*sizeofElem); return malloc(sizeofElem); }
-    if ((memInc==0)||((newsize%memInc)==0)) p=realloc(p,(newsize+memInc)*sizeofElem);
-//    if (!p)
-//    {
-//        printf("XMLParser Error: Not enough memory! Aborting...\n"); exit(220);
-//    }
-    return p;
+static inline void myFree(void *p) {
+  if (p) free(p);
+}
+static inline void *myRealloc(void *p, int newsize, int memInc,
+                              int sizeofElem) {
+  if (p == NULL) {
+    if (memInc) return malloc(memInc * sizeofElem);
+    return malloc(sizeofElem);
+  }
+  if ((memInc == 0) || ((newsize % memInc) == 0))
+    p = realloc(p, (newsize + memInc) * sizeofElem);
+  //    if (!p)
+  //    {
+  //        printf("XMLParser Error: Not enough memory! Aborting...\n");
+  //        exit(220);
+  //    }
+  return p;
 }
 
 // private:
-XMLElementPosition XMLNode::findPosition(XMLNodeData *d, int index, XMLElementType xxtype)
-{
-    if (index<0) return -1;
-    int i=0,j=(int)((index<<2)+xxtype),*o=d->pOrder; while (o[i]!=j) i++; return i;
+XMLElementPosition XMLNode::findPosition(XMLNodeData *d, int index,
+                                         XMLElementType xxtype) {
+  if (index < 0) return -1;
+  int i = 0, j = (int)((index << 2) + xxtype), *o = d->pOrder;
+  while (o[i] != j) i++;
+  return i;
 }
 
 // private:
 // update "order" information when deleting a content of a XMLNode
-int XMLNode::removeOrderElement(XMLNodeData *d, XMLElementType t, int index)
-{
-    int n=d->nChild+d->nText+d->nClear, *o=d->pOrder,i=findPosition(d,index,t);
-    memmove(o+i, o+i+1, (n-i)*sizeof(int));
-    for (;i<n;i++)
-        if ((o[i]&3)==(int)t) o[i]-=4;
-    // We should normally do:
-    // d->pOrder=(int)realloc(d->pOrder,n*sizeof(int));
-    // but we skip reallocation because it's too time consuming.
-    // Anyway, at the end, it will be free'd completely at once.
-    return i;
+int XMLNode::removeOrderElement(XMLNodeData *d, XMLElementType t, int index) {
+  int n = d->nChild + d->nText + d->nClear, *o = d->pOrder,
+      i = findPosition(d, index, t);
+  memmove(o + i, o + i + 1, (n - i) * sizeof(int));
+  for (; i < n; i++)
+    if ((o[i] & 3) == (int)t) o[i] -= 4;
+  // We should normally do:
+  // d->pOrder=(int)realloc(d->pOrder,n*sizeof(int));
+  // but we skip reallocation because it's too time consuming.
+  // Anyway, at the end, it will be free'd completely at once.
+  return i;
 }
 
-void *XMLNode::addToOrder(int memoryIncrease,int *_pos, int nc, void *p, int size, XMLElementType xtype)
-{
-    //  in: *_pos is the position inside d->pOrder ("-1" means "EndOf")
-    // out: *_pos is the index inside p
-    p=myRealloc(p,(nc+1),memoryIncrease,size);
-    int n=d->nChild+d->nText+d->nClear;
-    d->pOrder=(int*)myRealloc(d->pOrder,n+1,memoryIncrease*3,sizeof(int));
-    int pos=*_pos,*o=d->pOrder;
+void *XMLNode::addToOrder(int memoryIncrease, int *_pos, int nc, void *p,
+                          int size, XMLElementType xtype) {
+  //  in: *_pos is the position inside d->pOrder ("-1" means "EndOf")
+  // out: *_pos is the index inside p
+  p = myRealloc(p, (nc + 1), memoryIncrease, size);
+  int n = d->nChild + d->nText + d->nClear;
+  d->pOrder =
+      (int *)myRealloc(d->pOrder, n + 1, memoryIncrease * 3, sizeof(int));
+  int pos = *_pos, *o = d->pOrder;
 
-    if ((pos<0)||(pos>=n)) { *_pos=nc; o[n]=(int)((nc<<2)+xtype); return p; }
-
-    int i=pos;
-    memmove(o+i+1, o+i, (n-i)*sizeof(int));
-
-    while ((pos<n)&&((o[pos]&3)!=(int)xtype)) pos++;
-    if (pos==n) { *_pos=nc; o[n]=(int)((nc<<2)+xtype); return p; }
-
-    o[i]=o[pos];
-    for (i=pos+1;i<=n;i++) if ((o[i]&3)==(int)xtype) o[i]+=4;
-
-    *_pos=pos=o[pos]>>2;
-    memmove(((char*)p)+(pos+1)*size,((char*)p)+pos*size,(nc-pos)*size);
-
+  if ((pos < 0) || (pos >= n)) {
+    *_pos = nc;
+    o[n] = (int)((nc << 2) + xtype);
     return p;
+  }
+
+  int i = pos;
+  memmove(o + i + 1, o + i, (n - i) * sizeof(int));
+
+  while ((pos < n) && ((o[pos] & 3) != (int)xtype)) pos++;
+  if (pos == n) {
+    *_pos = nc;
+    o[n] = (int)((nc << 2) + xtype);
+    return p;
+  }
+
+  o[i] = o[pos];
+  for (i = pos + 1; i <= n; i++)
+    if ((o[i] & 3) == (int)xtype) o[i] += 4;
+
+  *_pos = pos = o[pos] >> 2;
+  memmove(((char *)p) + (pos + 1) * size, ((char *)p) + pos * size,
+          (nc - pos) * size);
+
+  return p;
 }
 
 // Add a child node to the given element.
-XMLNode XMLNode::addChild_priv(int memoryIncrease, XMLSTR lpszName, char isDeclaration, int pos)
-{
-    if (!lpszName) return emptyXMLNode;
-    d->pChild=(XMLNode*)addToOrder(memoryIncrease,&pos,d->nChild,d->pChild,sizeof(XMLNode),eNodeChild);
-    d->pChild[pos].d=NULL;
-    d->pChild[pos]=XMLNode(d,lpszName,isDeclaration);
-    d->nChild++;
-    return d->pChild[pos];
+XMLNode XMLNode::addChild_priv(int memoryIncrease, XMLSTR lpszName,
+                               char isDeclaration, int pos) {
+  if (!lpszName) return emptyXMLNode;
+  d->pChild = (XMLNode *)addToOrder(memoryIncrease, &pos, d->nChild, d->pChild,
+                                    sizeof(XMLNode), eNodeChild);
+  d->pChild[pos].d = NULL;
+  d->pChild[pos] = XMLNode(d, lpszName, isDeclaration);
+  d->nChild++;
+  return d->pChild[pos];
 }
 
 // Add an attribute to an element.
-XMLAttribute *XMLNode::addAttribute_priv(int memoryIncrease,XMLSTR lpszName, XMLSTR lpszValuev)
-{
-    if (!lpszName) return &emptyXMLAttribute;
-    if (!d) { myFree(lpszName); myFree(lpszValuev); return &emptyXMLAttribute; }
-    int nc=d->nAttribute;
-    d->pAttribute=(XMLAttribute*)myRealloc(d->pAttribute,(nc+1),memoryIncrease,sizeof(XMLAttribute));
-    XMLAttribute *pAttr=d->pAttribute+nc;
-    pAttr->lpszName = lpszName;
-    pAttr->lpszValue = lpszValuev;
-    d->nAttribute++;
-    return pAttr;
+XMLAttribute *XMLNode::addAttribute_priv(int memoryIncrease, XMLSTR lpszName,
+                                         XMLSTR lpszValuev) {
+  if (!lpszName) return &emptyXMLAttribute;
+  if (!d) {
+    myFree(lpszName);
+    myFree(lpszValuev);
+    return &emptyXMLAttribute;
+  }
+  int nc = d->nAttribute;
+  d->pAttribute = (XMLAttribute *)myRealloc(
+      d->pAttribute, (nc + 1), memoryIncrease, sizeof(XMLAttribute));
+  XMLAttribute *pAttr = d->pAttribute + nc;
+  pAttr->lpszName = lpszName;
+  pAttr->lpszValue = lpszValuev;
+  d->nAttribute++;
+  return pAttr;
 }
 
 // Add text to the element.
-XMLCSTR XMLNode::addText_priv(int memoryIncrease, XMLSTR lpszValue, int pos)
-{
-    if (!lpszValue) return NULL;
-    if (!d) { myFree(lpszValue); return NULL; }
-    d->pText=(XMLCSTR*)addToOrder(memoryIncrease,&pos,d->nText,d->pText,sizeof(XMLSTR),eNodeText);
-    d->pText[pos]=lpszValue;
-    d->nText++;
-    return lpszValue;
+XMLCSTR XMLNode::addText_priv(int memoryIncrease, XMLSTR lpszValue, int pos) {
+  if (!lpszValue) return NULL;
+  if (!d) {
+    myFree(lpszValue);
+    return NULL;
+  }
+  d->pText = (XMLCSTR *)addToOrder(memoryIncrease, &pos, d->nText, d->pText,
+                                   sizeof(XMLSTR), eNodeText);
+  d->pText[pos] = lpszValue;
+  d->nText++;
+  return lpszValue;
 }
 
 // Add clear (unformatted) text to the element.
-XMLClear *XMLNode::addClear_priv(int memoryIncrease, XMLSTR lpszValue, XMLCSTR lpszOpen, XMLCSTR lpszClose, int pos)
-{
-    if (!lpszValue) return &emptyXMLClear;
-    if (!d) { myFree(lpszValue); return &emptyXMLClear; }
-    d->pClear=(XMLClear *)addToOrder(memoryIncrease,&pos,d->nClear,d->pClear,sizeof(XMLClear),eNodeClear);
-    XMLClear *pNewClear=d->pClear+pos;
-    pNewClear->lpszValue = lpszValue;
-    if (!lpszOpen) lpszOpen=XMLClearTags->lpszOpen;
-    if (!lpszClose) lpszClose=XMLClearTags->lpszClose;
-    pNewClear->lpszOpenTag = lpszOpen;
-    pNewClear->lpszCloseTag = lpszClose;
-    d->nClear++;
-    return pNewClear;
+XMLClear *XMLNode::addClear_priv(int memoryIncrease, XMLSTR lpszValue,
+                                 XMLCSTR lpszOpen, XMLCSTR lpszClose, int pos) {
+  if (!lpszValue) return &emptyXMLClear;
+  if (!d) {
+    myFree(lpszValue);
+    return &emptyXMLClear;
+  }
+  d->pClear = (XMLClear *)addToOrder(memoryIncrease, &pos, d->nClear, d->pClear,
+                                     sizeof(XMLClear), eNodeClear);
+  XMLClear *pNewClear = d->pClear + pos;
+  pNewClear->lpszValue = lpszValue;
+  if (!lpszOpen) lpszOpen = XMLClearTags->lpszOpen;
+  if (!lpszClose) lpszClose = XMLClearTags->lpszClose;
+  pNewClear->lpszOpenTag = lpszOpen;
+  pNewClear->lpszCloseTag = lpszClose;
+  d->nClear++;
+  return pNewClear;
 }
 
 // private:
 // Parse a clear (unformatted) type node.
-char XMLNode::parseClearTag(void *px, void *_pClear)
-{
-    XML *pXML=(XML *)px;
-    ALLXMLClearTag pClear=*((ALLXMLClearTag*)_pClear);
-    int cbTemp=0;
-    XMLCSTR lpszTemp=NULL;
-    XMLCSTR lpXML=&pXML->lpXML[pXML->nIndex];
-    static XMLCSTR docTypeEnd=_CXML("]>");
+char XMLNode::parseClearTag(void *px, void *_pClear) {
+  XML *pXML = (XML *)px;
+  ALLXMLClearTag pClear = *((ALLXMLClearTag *)_pClear);
+  int cbTemp = 0;
+  XMLCSTR lpszTemp = NULL;
+  XMLCSTR lpXML = &pXML->lpXML[pXML->nIndex];
+  static XMLCSTR docTypeEnd = _CXML("]>");
 
-    // Find the closing tag
-    // Seems the <!DOCTYPE need a better treatment so lets handle it
-    if (pClear.lpszOpen==XMLClearTags[1].lpszOpen)
-    {
-        XMLCSTR pCh=lpXML;
-        while (*pCh)
-        {
-            if (*pCh==_CXML('<')) { pClear.lpszClose=docTypeEnd; lpszTemp=xstrstr(lpXML,docTypeEnd); break; }
-            else if (*pCh==_CXML('>')) { lpszTemp=pCh; break; }
+  // Find the closing tag
+  // Seems the <!DOCTYPE need a better treatment so lets handle it
+  if (pClear.lpszOpen == XMLClearTags[1].lpszOpen) {
+    XMLCSTR pCh = lpXML;
+    while (*pCh) {
+      if (*pCh == _CXML('<')) {
+        pClear.lpszClose = docTypeEnd;
+        lpszTemp = xstrstr(lpXML, docTypeEnd);
+        break;
+      } else if (*pCh == _CXML('>')) {
+        lpszTemp = pCh;
+        break;
+      }
 #ifdef _XMLWIDECHAR
-            pCh++;
+      pCh++;
 #else
-            pCh+=XML_ByteTable[(unsigned char)(*pCh)];
+      pCh += XML_ByteTable[(unsigned char)(*pCh)];
 #endif
-        }
-    } else lpszTemp=xstrstr(lpXML, pClear.lpszClose);
-
-    if (lpszTemp)
-    {
-        // Cache the size and increment the index
-        cbTemp = (int)(lpszTemp - lpXML);
-
-        pXML->nIndex += cbTemp+(int)xstrlen(pClear.lpszClose);
-
-        // Add the clear node to the current element
-        addClear_priv(MEMORYINCREASE,stringDup(lpXML,cbTemp), pClear.lpszOpen, pClear.lpszClose,-1);
-        return 0;
     }
+  } else
+    lpszTemp = xstrstr(lpXML, pClear.lpszClose);
 
-    // If we failed to find the end tag
-    pXML->error = eXMLErrorUnmatchedEndClearTag;
-    return 1;
-}
+  if (lpszTemp) {
+    // Cache the size and increment the index
+    cbTemp = (int)(lpszTemp - lpXML);
 
-void XMLNode::exactMemory(XMLNodeData *d)
-{
-    if (d->pOrder)     d->pOrder=(int*)realloc(d->pOrder,(d->nChild+d->nText+d->nClear)*sizeof(int));
-    if (d->pChild)     d->pChild=(XMLNode*)realloc(d->pChild,d->nChild*sizeof(XMLNode));
-    if (d->pAttribute) d->pAttribute=(XMLAttribute*)realloc(d->pAttribute,d->nAttribute*sizeof(XMLAttribute));
-    if (d->pText)      d->pText=(XMLCSTR*)realloc(d->pText,d->nText*sizeof(XMLSTR));
-    if (d->pClear)     d->pClear=(XMLClear *)realloc(d->pClear,d->nClear*sizeof(XMLClear));
-}
+    pXML->nIndex += cbTemp + (int)xstrlen(pClear.lpszClose);
 
-char XMLNode::maybeAddTxT(void *pa, XMLCSTR tokenPStr)
-{
-    XML *pXML=(XML *)pa;
-    XMLCSTR lpszText=pXML->lpszText;
-    if (!lpszText) return 0;
-    if (dropWhiteSpace) while (XML_isSPACECHAR(*lpszText)&&(lpszText!=tokenPStr)) lpszText++;
-    int cbText = (int)(tokenPStr - lpszText);
-    if (!cbText) { pXML->lpszText=NULL; return 0; }
-    if (dropWhiteSpace) { cbText--; while ((cbText)&&XML_isSPACECHAR(lpszText[cbText])) cbText--; cbText++; }
-    if (!cbText) { pXML->lpszText=NULL; return 0; }
-    XMLSTR lpt=fromXMLString(lpszText,cbText,pXML);
-    if (!lpt) return 1;
-    pXML->lpszText=NULL;
-    if (removeCommentsInMiddleOfText && d->nText && d->nClear)
-    {
-        // if the previous insertion was a comment (<!-- -->) AND
-        // if the previous previous insertion was a text then, delete the comment and append the text
-        int n=d->nChild+d->nText+d->nClear-1,*o=d->pOrder;
-        if (((o[n]&3)==eNodeClear)&&((o[n-1]&3)==eNodeText))
-        {
-            int i=o[n]>>2;
-            if (d->pClear[i].lpszOpenTag==XMLClearTags[2].lpszOpen)
-            {
-                deleteClear(i);
-                i=o[n-1]>>2;
-                n=xstrlen(d->pText[i]);
-                int n2=xstrlen(lpt)+1;
-                d->pText[i]=(XMLSTR)realloc((void*)d->pText[i],(n+n2)*sizeof(XMLCHAR));
-                if (!d->pText[i]) return 1;
-                memcpy((void*)(d->pText[i]+n),lpt,n2*sizeof(XMLCHAR));
-                free(lpt);
-                return 0;
-            }
-        }
-    }
-    addText_priv(MEMORYINCREASE,lpt,-1);
+    // Add the clear node to the current element
+    addClear_priv(MEMORYINCREASE, stringDup(lpXML, cbTemp), pClear.lpszOpen,
+                  pClear.lpszClose, -1);
     return 0;
+  }
+
+  // If we failed to find the end tag
+  pXML->error = eXMLErrorUnmatchedEndClearTag;
+  return 1;
+}
+
+void XMLNode::exactMemory(XMLNodeData *d) {
+  if (d->pOrder)
+    d->pOrder = (int *)realloc(
+        d->pOrder, (d->nChild + d->nText + d->nClear) * sizeof(int));
+  if (d->pChild)
+    d->pChild = (XMLNode *)realloc(d->pChild, d->nChild * sizeof(XMLNode));
+  if (d->pAttribute)
+    d->pAttribute = (XMLAttribute *)realloc(
+        d->pAttribute, d->nAttribute * sizeof(XMLAttribute));
+  if (d->pText)
+    d->pText = (XMLCSTR *)realloc(d->pText, d->nText * sizeof(XMLSTR));
+  if (d->pClear)
+    d->pClear = (XMLClear *)realloc(d->pClear, d->nClear * sizeof(XMLClear));
+}
+
+char XMLNode::maybeAddTxT(void *pa, XMLCSTR tokenPStr) {
+  XML *pXML = (XML *)pa;
+  XMLCSTR lpszText = pXML->lpszText;
+  if (!lpszText) return 0;
+  if (dropWhiteSpace)
+    while (XML_isSPACECHAR(*lpszText) && (lpszText != tokenPStr)) lpszText++;
+  int cbText = (int)(tokenPStr - lpszText);
+  if (!cbText) {
+    pXML->lpszText = NULL;
+    return 0;
+  }
+  if (dropWhiteSpace) {
+    cbText--;
+    while ((cbText) && XML_isSPACECHAR(lpszText[cbText])) cbText--;
+    cbText++;
+  }
+  if (!cbText) {
+    pXML->lpszText = NULL;
+    return 0;
+  }
+  XMLSTR lpt = fromXMLString(lpszText, cbText, pXML);
+  if (!lpt) return 1;
+  pXML->lpszText = NULL;
+  if (removeCommentsInMiddleOfText && d->nText && d->nClear) {
+    // if the previous insertion was a comment (<!-- -->) AND
+    // if the previous previous insertion was a text then, delete the comment
+    // and append the text
+    int n = d->nChild + d->nText + d->nClear - 1, *o = d->pOrder;
+    if (((o[n] & 3) == eNodeClear) && ((o[n - 1] & 3) == eNodeText)) {
+      int i = o[n] >> 2;
+      if (d->pClear[i].lpszOpenTag == XMLClearTags[2].lpszOpen) {
+        deleteClear(i);
+        i = o[n - 1] >> 2;
+        n = xstrlen(d->pText[i]);
+        int n2 = xstrlen(lpt) + 1;
+        d->pText[i] =
+            (XMLSTR)realloc((void *)d->pText[i], (n + n2) * sizeof(XMLCHAR));
+        if (!d->pText[i]) return 1;
+        memcpy((void *)(d->pText[i] + n), lpt, n2 * sizeof(XMLCHAR));
+        free(lpt);
+        return 0;
+      }
+    }
+  }
+  addText_priv(MEMORYINCREASE, lpt, -1);
+  return 0;
 }
 // private:
 // Recursively parse an XML element.
-int XMLNode::ParseXMLElement(void *pa)
-{
-    XML *pXML=(XML *)pa;
-    int cbToken;
-    enum XMLTokenTypeTag xtype;
-    NextToken token;
-    XMLCSTR lpszTemp=NULL;
-    int cbTemp=0;
-    char nDeclaration;
-    XMLNode pNew;
-    enum Status status; // inside or outside a tag
-    enum Attrib attrib = eAttribName;
+int XMLNode::ParseXMLElement(void *pa) {
+  XML *pXML = (XML *)pa;
+  int cbToken;
+  enum XMLTokenTypeTag xtype;
+  NextToken token;
+  XMLCSTR lpszTemp = NULL;
+  int cbTemp = 0;
+  char nDeclaration;
+  XMLNode pNew;
+  enum Status status;  // inside or outside a tag
+  enum Attrib attrib = eAttribName;
 
-    assert(pXML);
+  assert(pXML);
 
-    // If this is the first call to the function
-    if (pXML->nFirst)
-    {
-        // Assume we are outside of a tag definition
-        pXML->nFirst = FALSE;
-        status = eOutsideTag;
-    } else
-    {
-        // If this is not the first call then we should only be called when inside a tag.
-        status = eInsideTag;
-    }
+  // If this is the first call to the function
+  if (pXML->nFirst) {
+    // Assume we are outside of a tag definition
+    pXML->nFirst = FALSE;
+    status = eOutsideTag;
+  } else {
+    // If this is not the first call then we should only be called when inside a
+    // tag.
+    status = eInsideTag;
+  }
 
-    // Iterate through the tokens in the document
-    for(;;)
-    {
-        // Obtain the next token
-        token = GetNextToken(pXML, &cbToken, &xtype);
+  // Iterate through the tokens in the document
+  for (;;) {
+    // Obtain the next token
+    token = GetNextToken(pXML, &cbToken, &xtype);
 
-        if (xtype != eTokenError)
-        {
-            // Check the current status
-            switch(status)
-            {
+    if (xtype != eTokenError) {
+      // Check the current status
+      switch (status) {
+        // If we are outside of a tag definition
+        case eOutsideTag:
 
-            // If we are outside of a tag definition
-            case eOutsideTag:
+          // Check what type of token we obtained
+          switch (xtype) {
+            // If we have found text or quoted text
+            case eTokenText:
+            case eTokenCloseTag:       /* '>'         */
+            case eTokenShortHandClose: /* '/>'        */
+            case eTokenQuotedText:
+            case eTokenEquals:
+              break;
 
-                // Check what type of token we obtained
-                switch(xtype)
-                {
-                // If we have found text or quoted text
-                case eTokenText:
-                case eTokenCloseTag:          /* '>'         */
-                case eTokenShortHandClose:    /* '/>'        */
-                case eTokenQuotedText:
-                case eTokenEquals:
-                    break;
+            // If we found a start tag '<' and declarations '<?'
+            case eTokenTagStart:
+            case eTokenDeclaration:
 
-                // If we found a start tag '<' and declarations '<?'
-                case eTokenTagStart:
-                case eTokenDeclaration:
+              // Cache whether this new element is a declaration or not
+              nDeclaration = (xtype == eTokenDeclaration);
 
-                    // Cache whether this new element is a declaration or not
-                    nDeclaration = (xtype == eTokenDeclaration);
+              // If we have node text then add this to the element
+              if (maybeAddTxT(pXML, token.pStr)) return FALSE;
 
-                    // If we have node text then add this to the element
-                    if (maybeAddTxT(pXML,token.pStr)) return FALSE;
+              // Find the name of the tag
+              token = GetNextToken(pXML, &cbToken, &xtype);
 
-                    // Find the name of the tag
-                    token = GetNextToken(pXML, &cbToken, &xtype);
+              // Return an error if we couldn't obtain the next token or
+              // it wasnt text
+              if (xtype != eTokenText) {
+                pXML->error = eXMLErrorMissingTagName;
+                return FALSE;
+              }
 
-                    // Return an error if we couldn't obtain the next token or
-                    // it wasnt text
-                    if (xtype != eTokenText)
-                    {
-                        pXML->error = eXMLErrorMissingTagName;
-                        return FALSE;
-                    }
-
-                    // If we found a new element which is the same as this
-                    // element then we need to pass this back to the caller..
+              // If we found a new element which is the same as this
+              // element then we need to pass this back to the caller..
 
 #ifdef APPROXIMATE_PARSING
-                    if (d->lpszName &&
-                        myTagCompare(d->lpszName, token.pStr) == 0)
-                    {
-                        // Indicate to the caller that it needs to create a
-                        // new element.
-                        pXML->lpNewElement = token.pStr;
-                        pXML->cbNewElement = cbToken;
+              if (d->lpszName && myTagCompare(d->lpszName, token.pStr) == 0) {
+                // Indicate to the caller that it needs to create a
+                // new element.
+                pXML->lpNewElement = token.pStr;
+                pXML->cbNewElement = cbToken;
+                return TRUE;
+              } else
+#endif
+              {
+                // If the name of the new element differs from the name of
+                // the current element we need to add the new element to
+                // the current one and recurse
+                pNew = addChild_priv(MEMORYINCREASE,
+                                     stringDup(token.pStr, cbToken),
+                                     nDeclaration, -1);
+
+                while (!pNew.isEmpty()) {
+                  // Callself to process the new node.  If we return
+                  // FALSE this means we dont have any more
+                  // processing to do...
+
+                  if (!pNew.ParseXMLElement(pXML))
+                    return FALSE;
+                  else {
+                    // If the call to recurse this function
+                    // evented in a end tag specified in XML then
+                    // we need to unwind the calls to this
+                    // function until we find the appropriate node
+                    // (the element name and end tag name must
+                    // match)
+                    if (pXML->cbEndTag) {
+                      // If we are back at the root node then we
+                      // have an unmatched end tag
+                      if (!d->lpszName) {
+                        pXML->error = eXMLErrorUnmatchedEndTag;
+                        return FALSE;
+                      }
+
+                      // If the end tag matches the name of this
+                      // element then we only need to unwind
+                      // once more...
+
+                      if (myTagCompare(d->lpszName, pXML->lpEndTag) == 0) {
+                        pXML->cbEndTag = 0;
+                      }
+
+                      return TRUE;
+                    } else if (pXML->cbNewElement) {
+                      // If the call indicated a new element is to
+                      // be created on THIS element.
+
+                      // If the name of this element matches the
+                      // name of the element we need to create
+                      // then we need to return to the caller
+                      // and let it process the element.
+
+                      if (myTagCompare(d->lpszName, pXML->lpNewElement) == 0) {
                         return TRUE;
-                    } else
-#endif
-                    {
-                        // If the name of the new element differs from the name of
-                        // the current element we need to add the new element to
-                        // the current one and recurse
-                        pNew = addChild_priv(MEMORYINCREASE,stringDup(token.pStr,cbToken), nDeclaration,-1);
+                      }
 
-                        while (!pNew.isEmpty())
-                        {
-                            // Callself to process the new node.  If we return
-                            // FALSE this means we dont have any more
-                            // processing to do...
-
-                            if (!pNew.ParseXMLElement(pXML)) return FALSE;
-                            else
-                            {
-                                // If the call to recurse this function
-                                // evented in a end tag specified in XML then
-                                // we need to unwind the calls to this
-                                // function until we find the appropriate node
-                                // (the element name and end tag name must
-                                // match)
-                                if (pXML->cbEndTag)
-                                {
-                                    // If we are back at the root node then we
-                                    // have an unmatched end tag
-                                    if (!d->lpszName)
-                                    {
-                                        pXML->error=eXMLErrorUnmatchedEndTag;
-                                        return FALSE;
-                                    }
-
-                                    // If the end tag matches the name of this
-                                    // element then we only need to unwind
-                                    // once more...
-
-                                    if (myTagCompare(d->lpszName, pXML->lpEndTag)==0)
-                                    {
-                                        pXML->cbEndTag = 0;
-                                    }
-
-                                    return TRUE;
-                                } else
-                                    if (pXML->cbNewElement)
-                                    {
-                                        // If the call indicated a new element is to
-                                        // be created on THIS element.
-
-                                        // If the name of this element matches the
-                                        // name of the element we need to create
-                                        // then we need to return to the caller
-                                        // and let it process the element.
-
-                                        if (myTagCompare(d->lpszName, pXML->lpNewElement)==0)
-                                        {
-                                            return TRUE;
-                                        }
-
-                                        // Add the new element and recurse
-                                        pNew = addChild_priv(MEMORYINCREASE,stringDup(pXML->lpNewElement,pXML->cbNewElement),0,-1);
-                                        pXML->cbNewElement = 0;
-                                    }
-                                    else
-                                    {
-                                        // If we didn't have a new element to create
-                                        pNew = emptyXMLNode;
-
-                                    }
-                            }
-                        }
+                      // Add the new element and recurse
+                      pNew = addChild_priv(
+                          MEMORYINCREASE,
+                          stringDup(pXML->lpNewElement, pXML->cbNewElement), 0,
+                          -1);
+                      pXML->cbNewElement = 0;
+                    } else {
+                      // If we didn't have a new element to create
+                      pNew = emptyXMLNode;
                     }
-                    break;
+                  }
+                }
+              }
+              break;
 
-                // If we found an end tag
-                case eTokenTagEnd:
+            // If we found an end tag
+            case eTokenTagEnd:
 
-                    // If we have node text then add this to the element
-                    if (maybeAddTxT(pXML,token.pStr)) return FALSE;
+              // If we have node text then add this to the element
+              if (maybeAddTxT(pXML, token.pStr)) return FALSE;
 
-                    // Find the name of the end tag
-                    token = GetNextToken(pXML, &cbTemp, &xtype);
+              // Find the name of the end tag
+              token = GetNextToken(pXML, &cbTemp, &xtype);
 
-                    // The end tag should be text
-                    if (xtype != eTokenText)
-                    {
-                        pXML->error = eXMLErrorMissingEndTagName;
-                        return FALSE;
-                    }
-                    lpszTemp = token.pStr;
+              // The end tag should be text
+              if (xtype != eTokenText) {
+                pXML->error = eXMLErrorMissingEndTagName;
+                return FALSE;
+              }
+              lpszTemp = token.pStr;
 
-                    // After the end tag we should find a closing tag
-                    token = GetNextToken(pXML, &cbToken, &xtype);
-                    if (xtype != eTokenCloseTag)
-                    {
-                        pXML->error = eXMLErrorMissingEndTagName;
-                        return FALSE;
-                    }
-                    pXML->lpszText=pXML->lpXML+pXML->nIndex;
+              // After the end tag we should find a closing tag
+              token = GetNextToken(pXML, &cbToken, &xtype);
+              if (xtype != eTokenCloseTag) {
+                pXML->error = eXMLErrorMissingEndTagName;
+                return FALSE;
+              }
+              pXML->lpszText = pXML->lpXML + pXML->nIndex;
 
-                    // We need to return to the previous caller.  If the name
-                    // of the tag cannot be found we need to keep returning to
-                    // caller until we find a match
-                    if (myTagCompare(d->lpszName, lpszTemp) != 0)
+              // We need to return to the previous caller.  If the name
+              // of the tag cannot be found we need to keep returning to
+              // caller until we find a match
+              if (myTagCompare(d->lpszName, lpszTemp) != 0)
 #ifdef STRICT_PARSING
-                    {
-                        pXML->error=eXMLErrorUnmatchedEndTag;
-                        pXML->nIndexMissigEndTag=pXML->nIndex;
-                        return FALSE;
-                    }
+              {
+                pXML->error = eXMLErrorUnmatchedEndTag;
+                pXML->nIndexMissigEndTag = pXML->nIndex;
+                return FALSE;
+              }
 #else
-                    {
-                        pXML->error=eXMLErrorMissingEndTag;
-                        pXML->nIndexMissigEndTag=pXML->nIndex;
-                        pXML->lpEndTag = lpszTemp;
-                        pXML->cbEndTag = cbTemp;
-                    }
+              {
+                pXML->error = eXMLErrorMissingEndTag;
+                pXML->nIndexMissigEndTag = pXML->nIndex;
+                pXML->lpEndTag = lpszTemp;
+                pXML->cbEndTag = cbTemp;
+              }
 #endif
 
-                    // Return to the caller
+              // Return to the caller
+              exactMemory(d);
+              return TRUE;
+
+            // If we found a clear (unformatted) token
+            case eTokenClear:
+              // If we have node text then add this to the element
+              if (maybeAddTxT(pXML, token.pStr)) return FALSE;
+              if (parseClearTag(pXML, token.pClr)) return FALSE;
+              pXML->lpszText = pXML->lpXML + pXML->nIndex;
+              break;
+
+            default:
+              break;
+          }
+          break;
+
+        // If we are inside a tag definition we need to search for attributes
+        case eInsideTag:
+
+          // Check what part of the attribute (name, equals, value) we
+          // are looking for.
+          switch (attrib) {
+            // If we are looking for a new attribute
+            case eAttribName:
+
+              // Check what the current token type is
+              switch (xtype) {
+                // If the current type is text...
+                // Eg.  'attribute'
+                case eTokenText:
+                  // Cache the token then indicate that we are next to
+                  // look for the equals
+                  lpszTemp = token.pStr;
+                  cbTemp = cbToken;
+                  attrib = eAttribEquals;
+                  break;
+
+                // If we found a closing tag...
+                // Eg.  '>'
+                case eTokenCloseTag:
+                  // We are now outside the tag
+                  status = eOutsideTag;
+                  pXML->lpszText = pXML->lpXML + pXML->nIndex;
+                  break;
+
+                // If we found a short hand '/>' closing tag then we can
+                // return to the caller
+                case eTokenShortHandClose:
+                  exactMemory(d);
+                  pXML->lpszText = pXML->lpXML + pXML->nIndex;
+                  return TRUE;
+
+                // Errors...
+                case eTokenQuotedText:  /* '"SomeText"'   */
+                case eTokenTagStart:    /* '<'            */
+                case eTokenTagEnd:      /* '</'           */
+                case eTokenEquals:      /* '='            */
+                case eTokenDeclaration: /* '<?'           */
+                case eTokenClear:
+                  pXML->error = eXMLErrorUnexpectedToken;
+                  return FALSE;
+                default:
+                  break;
+              }
+              break;
+
+            // If we are looking for an equals
+            case eAttribEquals:
+              // Check what the current token type is
+              switch (xtype) {
+                // If the current type is text...
+                // Eg.  'Attribute AnotherAttribute'
+                case eTokenText:
+                  // Add the unvalued attribute to the list
+                  addAttribute_priv(MEMORYINCREASE, stringDup(lpszTemp, cbTemp),
+                                    NULL);
+                  // Cache the token then indicate.  We are next to
+                  // look for the equals attribute
+                  lpszTemp = token.pStr;
+                  cbTemp = cbToken;
+                  break;
+
+                // If we found a closing tag 'Attribute >' or a short hand
+                // closing tag 'Attribute />'
+                case eTokenShortHandClose:
+                case eTokenCloseTag:
+                  // If we are a declaration element '<?' then we need
+                  // to remove extra closing '?' if it exists
+                  pXML->lpszText = pXML->lpXML + pXML->nIndex;
+
+                  if (d->isDeclaration &&
+                      (lpszTemp[cbTemp - 1]) == _CXML('?')) {
+                    cbTemp--;
+                    if (d->pParent && d->pParent->pParent)
+                      xtype = eTokenShortHandClose;
+                  }
+
+                  if (cbTemp) {
+                    // Add the unvalued attribute to the list
+                    addAttribute_priv(MEMORYINCREASE,
+                                      stringDup(lpszTemp, cbTemp), NULL);
+                  }
+
+                  // If this is the end of the tag then return to the caller
+                  if (xtype == eTokenShortHandClose) {
                     exactMemory(d);
                     return TRUE;
+                  }
 
-                // If we found a clear (unformatted) token
+                  // We are now outside the tag
+                  status = eOutsideTag;
+                  break;
+
+                // If we found the equals token...
+                // Eg.  'Attribute ='
+                case eTokenEquals:
+                  // Indicate that we next need to search for the value
+                  // for the attribute
+                  attrib = eAttribValue;
+                  break;
+
+                // Errors...
+                case eTokenQuotedText:  /* 'Attribute "InvalidAttr"'*/
+                case eTokenTagStart:    /* 'Attribute <'            */
+                case eTokenTagEnd:      /* 'Attribute </'           */
+                case eTokenDeclaration: /* 'Attribute <?'           */
                 case eTokenClear:
-                    // If we have node text then add this to the element
-                    if (maybeAddTxT(pXML,token.pStr)) return FALSE;
-                    if (parseClearTag(pXML, token.pClr)) return FALSE;
-                    pXML->lpszText=pXML->lpXML+pXML->nIndex;
-                    break;
-
+                  pXML->error = eXMLErrorUnexpectedToken;
+                  return FALSE;
                 default:
-                    break;
-                }
-                break;
+                  break;
+              }
+              break;
 
-            // If we are inside a tag definition we need to search for attributes
-            case eInsideTag:
+            // If we are looking for an attribute value
+            case eAttribValue:
+              // Check what the current token type is
+              switch (xtype) {
+                // If the current type is text or quoted text...
+                // Eg.  'Attribute = "Value"' or 'Attribute = Value' or
+                // 'Attribute = 'Value''.
+                case eTokenText:
+                case eTokenQuotedText:
+                  // If we are a declaration element '<?' then we need
+                  // to remove extra closing '?' if it exists
+                  if (d->isDeclaration &&
+                      (token.pStr[cbToken - 1]) == _CXML('?')) {
+                    cbToken--;
+                  }
 
-                // Check what part of the attribute (name, equals, value) we
-                // are looking for.
-                switch(attrib)
-                {
-                // If we are looking for a new attribute
-                case eAttribName:
-
-                    // Check what the current token type is
-                    switch(xtype)
-                    {
-                    // If the current type is text...
-                    // Eg.  'attribute'
-                    case eTokenText:
-                        // Cache the token then indicate that we are next to
-                        // look for the equals
-                        lpszTemp = token.pStr;
-                        cbTemp = cbToken;
-                        attrib = eAttribEquals;
-                        break;
-
-                    // If we found a closing tag...
-                    // Eg.  '>'
-                    case eTokenCloseTag:
-                        // We are now outside the tag
-                        status = eOutsideTag;
-                        pXML->lpszText=pXML->lpXML+pXML->nIndex;
-                        break;
-
-                    // If we found a short hand '/>' closing tag then we can
-                    // return to the caller
-                    case eTokenShortHandClose:
-                        exactMemory(d);
-                        pXML->lpszText=pXML->lpXML+pXML->nIndex;
-                        return TRUE;
-
-                    // Errors...
-                    case eTokenQuotedText:    /* '"SomeText"'   */
-                    case eTokenTagStart:      /* '<'            */
-                    case eTokenTagEnd:        /* '</'           */
-                    case eTokenEquals:        /* '='            */
-                    case eTokenDeclaration:   /* '<?'           */
-                    case eTokenClear:
-                        pXML->error = eXMLErrorUnexpectedToken;
-                        return FALSE;
-                    default: break;
+                  if (cbTemp) {
+                    // Add the valued attribute to the list
+                    if (xtype == eTokenQuotedText) {
+                      token.pStr++;
+                      cbToken -= 2;
                     }
-                    break;
-
-                // If we are looking for an equals
-                case eAttribEquals:
-                    // Check what the current token type is
-                    switch(xtype)
-                    {
-                    // If the current type is text...
-                    // Eg.  'Attribute AnotherAttribute'
-                    case eTokenText:
-                        // Add the unvalued attribute to the list
-                        addAttribute_priv(MEMORYINCREASE,stringDup(lpszTemp,cbTemp), NULL);
-                        // Cache the token then indicate.  We are next to
-                        // look for the equals attribute
-                        lpszTemp = token.pStr;
-                        cbTemp = cbToken;
-                        break;
-
-                    // If we found a closing tag 'Attribute >' or a short hand
-                    // closing tag 'Attribute />'
-                    case eTokenShortHandClose:
-                    case eTokenCloseTag:
-                        // If we are a declaration element '<?' then we need
-                        // to remove extra closing '?' if it exists
-                        pXML->lpszText=pXML->lpXML+pXML->nIndex;
-
-                        if (d->isDeclaration &&
-                            (lpszTemp[cbTemp-1]) == _CXML('?'))
-                        {
-                            cbTemp--;
-                            if (d->pParent && d->pParent->pParent) xtype = eTokenShortHandClose;
-                        }
-
-                        if (cbTemp)
-                        {
-                            // Add the unvalued attribute to the list
-                            addAttribute_priv(MEMORYINCREASE,stringDup(lpszTemp,cbTemp), NULL);
-                        }
-
-                        // If this is the end of the tag then return to the caller
-                        if (xtype == eTokenShortHandClose)
-                        {
-                            exactMemory(d);
-                            return TRUE;
-                        }
-
-                        // We are now outside the tag
-                        status = eOutsideTag;
-                        break;
-
-                    // If we found the equals token...
-                    // Eg.  'Attribute ='
-                    case eTokenEquals:
-                        // Indicate that we next need to search for the value
-                        // for the attribute
-                        attrib = eAttribValue;
-                        break;
-
-                    // Errors...
-                    case eTokenQuotedText:    /* 'Attribute "InvalidAttr"'*/
-                    case eTokenTagStart:      /* 'Attribute <'            */
-                    case eTokenTagEnd:        /* 'Attribute </'           */
-                    case eTokenDeclaration:   /* 'Attribute <?'           */
-                    case eTokenClear:
-                        pXML->error = eXMLErrorUnexpectedToken;
-                        return FALSE;
-                    default: break;
+                    XMLSTR attrVal = (XMLSTR)token.pStr;
+                    if (attrVal) {
+                      attrVal = fromXMLString(attrVal, cbToken, pXML);
+                      if (!attrVal) return FALSE;
                     }
-                    break;
+                    addAttribute_priv(MEMORYINCREASE,
+                                      stringDup(lpszTemp, cbTemp), attrVal);
+                  }
 
-                // If we are looking for an attribute value
-                case eAttribValue:
-                    // Check what the current token type is
-                    switch(xtype)
-                    {
-                    // If the current type is text or quoted text...
-                    // Eg.  'Attribute = "Value"' or 'Attribute = Value' or
-                    // 'Attribute = 'Value''.
-                    case eTokenText:
-                    case eTokenQuotedText:
-                        // If we are a declaration element '<?' then we need
-                        // to remove extra closing '?' if it exists
-                        if (d->isDeclaration &&
-                            (token.pStr[cbToken-1]) == _CXML('?'))
-                        {
-                            cbToken--;
-                        }
+                  // Indicate we are searching for a new attribute
+                  attrib = eAttribName;
+                  break;
 
-                        if (cbTemp)
-                        {
-                            // Add the valued attribute to the list
-                            if (xtype==eTokenQuotedText) { token.pStr++; cbToken-=2; }
-                            XMLSTR attrVal=(XMLSTR)token.pStr;
-                            if (attrVal)
-                            {
-                                attrVal=fromXMLString(attrVal,cbToken,pXML);
-                                if (!attrVal) return FALSE;
-                            }
-                            addAttribute_priv(MEMORYINCREASE,stringDup(lpszTemp,cbTemp),attrVal);
-                        }
-
-                        // Indicate we are searching for a new attribute
-                        attrib = eAttribName;
-                        break;
-
-                    // Errors...
-                    case eTokenTagStart:        /* 'Attr = <'          */
-                    case eTokenTagEnd:          /* 'Attr = </'         */
-                    case eTokenCloseTag:        /* 'Attr = >'          */
-                    case eTokenShortHandClose:  /* "Attr = />"         */
-                    case eTokenEquals:          /* 'Attr = ='          */
-                    case eTokenDeclaration:     /* 'Attr = <?'         */
-                    case eTokenClear:
-                        pXML->error = eXMLErrorUnexpectedToken;
-                        return FALSE;
-                        break;
-                    default: break;
-                    }
-                }
-            }
-        }
-        // If we failed to obtain the next token
-        else
-        {
-            if ((!d->isDeclaration)&&(d->pParent))
-            {
-#ifdef STRICT_PARSING
-                pXML->error=eXMLErrorUnmatchedEndTag;
-#else
-                pXML->error=eXMLErrorMissingEndTag;
-#endif
-                pXML->nIndexMissigEndTag=pXML->nIndex;
-            }
-            maybeAddTxT(pXML,pXML->lpXML+pXML->nIndex);
-            return FALSE;
-        }
+                // Errors...
+                case eTokenTagStart:       /* 'Attr = <'          */
+                case eTokenTagEnd:         /* 'Attr = </'         */
+                case eTokenCloseTag:       /* 'Attr = >'          */
+                case eTokenShortHandClose: /* "Attr = />"         */
+                case eTokenEquals:         /* 'Attr = ='          */
+                case eTokenDeclaration:    /* 'Attr = <?'         */
+                case eTokenClear:
+                  pXML->error = eXMLErrorUnexpectedToken;
+                  return FALSE;
+                  break;
+                default:
+                  break;
+              }
+          }
+      }
     }
+    // If we failed to obtain the next token
+    else {
+      if ((!d->isDeclaration) && (d->pParent)) {
+#ifdef STRICT_PARSING
+        pXML->error = eXMLErrorUnmatchedEndTag;
+#else
+        pXML->error = eXMLErrorMissingEndTag;
+#endif
+        pXML->nIndexMissigEndTag = pXML->nIndex;
+      }
+      maybeAddTxT(pXML, pXML->lpXML + pXML->nIndex);
+      return FALSE;
+    }
+  }
 }
 
 // Count the number of lines and columns in an XML string.
-static void CountLinesAndColumns(XMLCSTR lpXML, int nUpto, XMLResults *pResults)
-{
-    XMLCHAR ch;
-    assert(lpXML);
-    assert(pResults);
+static void CountLinesAndColumns(XMLCSTR lpXML, int nUpto,
+                                 XMLResults *pResults) {
+  XMLCHAR ch;
+  assert(lpXML);
+  assert(pResults);
 
-    struct XML xml={ lpXML,lpXML, 0, 0, eXMLErrorNone, NULL, 0, NULL, 0, TRUE };
+  struct XML xml = {lpXML, lpXML, 0, 0, eXMLErrorNone, NULL, 0, NULL, 0, TRUE};
 
-    pResults->nLine = 1;
-    pResults->nColumn = 1;
-    while (xml.nIndex<nUpto)
-    {
-        ch = getNextChar(&xml);
-        if (ch != _CXML('\n')) pResults->nColumn++;
-        else
-        {
-            pResults->nLine++;
-            pResults->nColumn=1;
-        }
+  pResults->nLine = 1;
+  pResults->nColumn = 1;
+  while (xml.nIndex < nUpto) {
+    ch = getNextChar(&xml);
+    if (ch != _CXML('\n'))
+      pResults->nColumn++;
+    else {
+      pResults->nLine++;
+      pResults->nColumn = 1;
     }
+  }
 }
 
 // Parse XML and return the root element.
-XMLNode XMLNode::parseString(XMLCSTR lpszXML, XMLCSTR tag, XMLResults *pResults)
-{
-    if (!lpszXML)
-    {
-        if (pResults)
-        {
-            pResults->error=eXMLErrorNoElements;
-            pResults->nLine=0;
-            pResults->nColumn=0;
+XMLNode XMLNode::parseString(XMLCSTR lpszXML, XMLCSTR tag,
+                             XMLResults *pResults) {
+  if (!lpszXML) {
+    if (pResults) {
+      pResults->error = eXMLErrorNoElements;
+      pResults->nLine = 0;
+      pResults->nColumn = 0;
+    }
+    return emptyXMLNode;
+  }
+
+  XMLNode xnode(NULL, NULL, FALSE);
+  struct XML xml = {lpszXML, lpszXML, 0,    0, eXMLErrorNone,
+                    NULL,    0,       NULL, 0, TRUE};
+
+  // Create header element
+  xnode.ParseXMLElement(&xml);
+  enum XMLError error = xml.error;
+  if (!xnode.nChildNode()) error = eXMLErrorNoXMLTagFound;
+  if ((xnode.nChildNode() == 1) && (xnode.nElement() == 1))
+    xnode = xnode.getChildNode();  // skip the empty node
+
+  // If no error occurred
+  if ((error == eXMLErrorNone) || (error == eXMLErrorMissingEndTag) ||
+      (error == eXMLErrorNoXMLTagFound)) {
+    XMLCSTR name = xnode.getName();
+    if (tag && (*tag) && ((!name) || (xstricmp(name, tag)))) {
+      xnode = xnode.getChildNode(tag);
+      if (xnode.isEmpty()) {
+        if (pResults) {
+          pResults->error = eXMLErrorFirstTagNotFound;
+          pResults->nLine = 0;
+          pResults->nColumn = 0;
         }
         return emptyXMLNode;
+      }
     }
+  } else {
+    // Cleanup: this will destroy all the nodes
+    xnode = emptyXMLNode;
+  }
 
-    XMLNode xnode(NULL,NULL,FALSE);
-    struct XML xml={ lpszXML, lpszXML, 0, 0, eXMLErrorNone, NULL, 0, NULL, 0, TRUE };
+  // If we have been given somewhere to place results
+  if (pResults) {
+    pResults->error = error;
 
-    // Create header element
-    xnode.ParseXMLElement(&xml);
-    enum XMLError error = xml.error;
-    if (!xnode.nChildNode()) error=eXMLErrorNoXMLTagFound;
-    if ((xnode.nChildNode()==1)&&(xnode.nElement()==1)) xnode=xnode.getChildNode(); // skip the empty node
-
-    // If no error occurred
-    if ((error==eXMLErrorNone)||(error==eXMLErrorMissingEndTag)||(error==eXMLErrorNoXMLTagFound))
-    {
-        XMLCSTR name=xnode.getName();
-        if (tag&&(*tag)&&((!name)||(xstricmp(name,tag))))
-        {
-            xnode=xnode.getChildNode(tag);
-            if (xnode.isEmpty())
-            {
-                if (pResults)
-                {
-                    pResults->error=eXMLErrorFirstTagNotFound;
-                    pResults->nLine=0;
-                    pResults->nColumn=0;
-                }
-                return emptyXMLNode;
-            }
-        }
-    } else
-    {
-        // Cleanup: this will destroy all the nodes
-        xnode = emptyXMLNode;
+    // If we have an error
+    if (error != eXMLErrorNone) {
+      if (error == eXMLErrorMissingEndTag) xml.nIndex = xml.nIndexMissigEndTag;
+      // Find which line and column it starts on.
+      CountLinesAndColumns(xml.lpXML, xml.nIndex, pResults);
     }
-
-
-    // If we have been given somewhere to place results
-    if (pResults)
-    {
-        pResults->error = error;
-
-        // If we have an error
-        if (error!=eXMLErrorNone)
-        {
-            if (error==eXMLErrorMissingEndTag) xml.nIndex=xml.nIndexMissigEndTag;
-            // Find which line and column it starts on.
-            CountLinesAndColumns(xml.lpXML, xml.nIndex, pResults);
-        }
-    }
-    return xnode;
+  }
+  return xnode;
 }
 
-XMLNode XMLNode::parseFile(XMLCSTR filename, XMLCSTR tag, XMLResults *pResults)
-{
-    if (pResults) { pResults->nLine=0; pResults->nColumn=0; }
-    FILE *f=xfopen(filename,_CXML("rb"));
-    if (f==NULL) { if (pResults) pResults->error=eXMLErrorFileNotFound; return emptyXMLNode; }
-    fseek(f,0,SEEK_END);
-    int l=ftell(f),headerSz=0;
-    if (!l) { if (pResults) pResults->error=eXMLErrorEmpty; fclose(f); return emptyXMLNode; }
-    fseek(f,0,SEEK_SET);
-    unsigned char *buf=(unsigned char*)malloc(l+4);
-    l=fread(buf,1,l,f);
+XMLNode XMLNode::parseFile(XMLCSTR filename, XMLCSTR tag,
+                           XMLResults *pResults) {
+  if (pResults) {
+    pResults->nLine = 0;
+    pResults->nColumn = 0;
+  }
+  FILE *f = xfopen(filename, _CXML("rb"));
+  if (f == NULL) {
+    if (pResults) pResults->error = eXMLErrorFileNotFound;
+    return emptyXMLNode;
+  }
+  fseek(f, 0, SEEK_END);
+  int l = ftell(f), headerSz = 0;
+  if (!l) {
+    if (pResults) pResults->error = eXMLErrorEmpty;
     fclose(f);
-    buf[l]=0;buf[l+1]=0;buf[l+2]=0;buf[l+3]=0;
+    return emptyXMLNode;
+  }
+  fseek(f, 0, SEEK_SET);
+  unsigned char *buf = (unsigned char *)malloc(l + 4);
+  l = fread(buf, 1, l, f);
+  fclose(f);
+  buf[l] = 0;
+  buf[l + 1] = 0;
+  buf[l + 2] = 0;
+  buf[l + 3] = 0;
 #ifdef _XMLWIDECHAR
-    if (guessWideCharChars)
-    {
-        if (!myIsTextWideChar(buf,l))
-        {
-            XMLNode::XMLCharEncoding ce=XMLNode::char_encoding_legacy;
-            if ((buf[0]==0xef)&&(buf[1]==0xbb)&&(buf[2]==0xbf)) { headerSz=3; ce=XMLNode::char_encoding_UTF8; }
-            XMLSTR b2=myMultiByteToWideChar((const char*)(buf+headerSz),ce);
-            free(buf); buf=(unsigned char*)b2; headerSz=0;
-        } else
-        {
-            if ((buf[0]==0xef)&&(buf[1]==0xff)) headerSz=2;
-            if ((buf[0]==0xff)&&(buf[1]==0xfe)) headerSz=2;
-        }
+  if (guessWideCharChars) {
+    if (!myIsTextWideChar(buf, l)) {
+      XMLNode::XMLCharEncoding ce = XMLNode::char_encoding_legacy;
+      if ((buf[0] == 0xef) && (buf[1] == 0xbb) && (buf[2] == 0xbf)) {
+        headerSz = 3;
+        ce = XMLNode::char_encoding_UTF8;
+      }
+      XMLSTR b2 = myMultiByteToWideChar((const char *)(buf + headerSz), ce);
+      free(buf);
+      buf = (unsigned char *)b2;
+      headerSz = 0;
+    } else {
+      if ((buf[0] == 0xef) && (buf[1] == 0xff)) headerSz = 2;
+      if ((buf[0] == 0xff) && (buf[1] == 0xfe)) headerSz = 2;
     }
+  }
 #else
-    if (guessWideCharChars)
-    {
-        if (myIsTextWideChar(buf,l))
-        {
-            if ((buf[0]==0xef)&&(buf[1]==0xff)) headerSz=2;
-            if ((buf[0]==0xff)&&(buf[1]==0xfe)) headerSz=2;
-            char *b2=myWideCharToMultiByte((const wchar_t*)(buf+headerSz));
-            free(buf); buf=(unsigned char*)b2; headerSz=0;
-        } else
-        {
-            if ((buf[0]==0xef)&&(buf[1]==0xbb)&&(buf[2]==0xbf)) headerSz=3;
-        }
+  if (guessWideCharChars) {
+    if (myIsTextWideChar(buf, l)) {
+      if ((buf[0] == 0xef) && (buf[1] == 0xff)) headerSz = 2;
+      if ((buf[0] == 0xff) && (buf[1] == 0xfe)) headerSz = 2;
+      char *b2 = myWideCharToMultiByte((const wchar_t *)(buf + headerSz));
+      free(buf);
+      buf = (unsigned char *)b2;
+      headerSz = 0;
+    } else {
+      if ((buf[0] == 0xef) && (buf[1] == 0xbb) && (buf[2] == 0xbf))
+        headerSz = 3;
     }
+  }
 #endif
 
-    if (!buf) { if (pResults) pResults->error=eXMLErrorCharConversionError; return emptyXMLNode; }
-    XMLNode x=parseString((XMLSTR)(buf+headerSz),tag,pResults);
-    free(buf);
-    return x;
+  if (!buf) {
+    if (pResults) pResults->error = eXMLErrorCharConversionError;
+    return emptyXMLNode;
+  }
+  XMLNode x = parseString((XMLSTR)(buf + headerSz), tag, pResults);
+  free(buf);
+  return x;
 }
 
-static inline void charmemset(XMLSTR dest,XMLCHAR c,int l) { while (l--) *(dest++)=c; }
+static inline void charmemset(XMLSTR dest, XMLCHAR c, int l) {
+  while (l--) *(dest++) = c;
+}
 // private:
 // Creates an user friendly XML string from a given element with
 // appropriate white space and carriage returns.
 //
 // This recurses through all subnodes then adds contents of the nodes to the
 // string.
-int XMLNode::CreateXMLStringR(XMLNodeData *pEntry, XMLSTR lpszMarker, int nFormat)
-{
-    int nResult = 0;
-    int cb=nFormat<0?0:nFormat;
-    int cbElement;
-    int nChildFormat=-1;
-    int nElementI=pEntry->nChild+pEntry->nText+pEntry->nClear;
-    int i,j;
-    if ((nFormat>=0)&&(nElementI==1)&&(pEntry->nText==1)&&(!pEntry->isDeclaration)) nFormat=-2;
+int XMLNode::CreateXMLStringR(XMLNodeData *pEntry, XMLSTR lpszMarker,
+                              int nFormat) {
+  int nResult = 0;
+  int cb = nFormat < 0 ? 0 : nFormat;
+  int cbElement;
+  int nChildFormat = -1;
+  int nElementI = pEntry->nChild + pEntry->nText + pEntry->nClear;
+  int i, j;
+  if ((nFormat >= 0) && (nElementI == 1) && (pEntry->nText == 1) &&
+      (!pEntry->isDeclaration))
+    nFormat = -2;
 
-    assert(pEntry);
+  assert(pEntry);
 
 #define LENSTR(lpsz) (lpsz ? xstrlen(lpsz) : 0)
 
-    // If the element has no name then assume this is the head node.
-    cbElement = (int)LENSTR(pEntry->lpszName);
+  // If the element has no name then assume this is the head node.
+  cbElement = (int)LENSTR(pEntry->lpszName);
 
-    if (cbElement)
-    {
-        // "<elementname "
-        if (lpszMarker)
-        {
-            if (cb) charmemset(lpszMarker, INDENTCHAR, cb);
-            nResult = cb;
-            lpszMarker[nResult++]=_CXML('<');
-            if (pEntry->isDeclaration) lpszMarker[nResult++]=_CXML('?');
-            xstrcpy(&lpszMarker[nResult], pEntry->lpszName);
-            nResult+=cbElement;
-            lpszMarker[nResult++]=_CXML(' ');
+  if (cbElement) {
+    // "<elementname "
+    if (lpszMarker) {
+      if (cb) charmemset(lpszMarker, INDENTCHAR, cb);
+      nResult = cb;
+      lpszMarker[nResult++] = _CXML('<');
+      if (pEntry->isDeclaration) lpszMarker[nResult++] = _CXML('?');
+      xstrcpy(&lpszMarker[nResult], pEntry->lpszName);
+      nResult += cbElement;
+      lpszMarker[nResult++] = _CXML(' ');
 
-        } else
-        {
-            nResult+=cbElement+2+cb;
-            if (pEntry->isDeclaration) nResult++;
-        }
+    } else {
+      nResult += cbElement + 2 + cb;
+      if (pEntry->isDeclaration) nResult++;
+    }
 
-        // Enumerate attributes and add them to the string
-        XMLAttribute *pAttr=pEntry->pAttribute;
-        for (i=0; i<pEntry->nAttribute; i++)
-        {
-            // "Attrib
-            cb = (int)LENSTR(pAttr->lpszName);
+    // Enumerate attributes and add them to the string
+    XMLAttribute *pAttr = pEntry->pAttribute;
+    for (i = 0; i < pEntry->nAttribute; i++) {
+      // "Attrib
+      cb = (int)LENSTR(pAttr->lpszName);
+      if (cb) {
+        if (lpszMarker) xstrcpy(&lpszMarker[nResult], pAttr->lpszName);
+        nResult += cb;
+        // "Attrib=Value "
+        if (pAttr->lpszValue) {
+          cb = (int)ToXMLStringTool::lengthXMLString(pAttr->lpszValue);
+          if (lpszMarker) {
+            lpszMarker[nResult] = _CXML('=');
+            lpszMarker[nResult + 1] = _CXML('"');
             if (cb)
-            {
-                if (lpszMarker) xstrcpy(&lpszMarker[nResult], pAttr->lpszName);
-                nResult += cb;
-                // "Attrib=Value "
-                if (pAttr->lpszValue)
-                {
-                    cb=(int)ToXMLStringTool::lengthXMLString(pAttr->lpszValue);
-                    if (lpszMarker)
-                    {
-                        lpszMarker[nResult]=_CXML('=');
-                        lpszMarker[nResult+1]=_CXML('"');
-                        if (cb) ToXMLStringTool::toXMLUnSafe(&lpszMarker[nResult+2],pAttr->lpszValue);
-                        lpszMarker[nResult+cb+2]=_CXML('"');
-                    }
-                    nResult+=cb+3;
-                }
-                if (lpszMarker) lpszMarker[nResult] = _CXML(' ');
-                nResult++;
+              ToXMLStringTool::toXMLUnSafe(&lpszMarker[nResult + 2],
+                                           pAttr->lpszValue);
+            lpszMarker[nResult + cb + 2] = _CXML('"');
+          }
+          nResult += cb + 3;
+        }
+        if (lpszMarker) lpszMarker[nResult] = _CXML(' ');
+        nResult++;
+      }
+      pAttr++;
+    }
+
+    if (pEntry->isDeclaration) {
+      if (lpszMarker) {
+        lpszMarker[nResult - 1] = _CXML('?');
+        lpszMarker[nResult] = _CXML('>');
+      }
+      nResult++;
+      if (nFormat != -1) {
+        if (lpszMarker) lpszMarker[nResult] = _CXML('\n');
+        nResult++;
+      }
+    } else
+        // If there are child nodes we need to terminate the start tag
+        if (nElementI) {
+      if (lpszMarker) lpszMarker[nResult - 1] = _CXML('>');
+      if (nFormat >= 0) {
+        if (lpszMarker) lpszMarker[nResult] = _CXML('\n');
+        nResult++;
+      }
+    } else
+      nResult--;
+  }
+
+  // Calculate the child format for when we recurse.  This is used to
+  // determine the number of spaces used for prefixes.
+  if (nFormat != -1) {
+    if (cbElement && (!pEntry->isDeclaration))
+      nChildFormat = nFormat + 1;
+    else
+      nChildFormat = nFormat;
+  }
+
+  // Enumerate through remaining children
+  for (i = 0; i < nElementI; i++) {
+    j = pEntry->pOrder[i];
+    switch ((XMLElementType)(j & 3)) {
+      // Text nodes
+      case eNodeText: {
+        // "Text"
+        XMLCSTR pChild = pEntry->pText[j >> 2];
+        cb = (int)ToXMLStringTool::lengthXMLString(pChild);
+        if (cb) {
+          if (nFormat >= 0) {
+            if (lpszMarker) {
+              charmemset(&lpszMarker[nResult], INDENTCHAR, nFormat + 1);
+              ToXMLStringTool::toXMLUnSafe(&lpszMarker[nResult + nFormat + 1],
+                                           pChild);
+              lpszMarker[nResult + nFormat + 1 + cb] = _CXML('\n');
             }
-            pAttr++;
+            nResult += cb + nFormat + 2;
+          } else {
+            if (lpszMarker)
+              ToXMLStringTool::toXMLUnSafe(&lpszMarker[nResult], pChild);
+            nResult += cb;
+          }
+        }
+        break;
+      }
+
+      // Clear type nodes
+      case eNodeClear: {
+        XMLClear *pChild = pEntry->pClear + (j >> 2);
+        // "OpenTag"
+        cb = (int)LENSTR(pChild->lpszOpenTag);
+        if (cb) {
+          if (nFormat != -1) {
+            if (lpszMarker) {
+              charmemset(&lpszMarker[nResult], INDENTCHAR, nFormat + 1);
+              xstrcpy(&lpszMarker[nResult + nFormat + 1], pChild->lpszOpenTag);
+            }
+            nResult += cb + nFormat + 1;
+          } else {
+            if (lpszMarker) xstrcpy(&lpszMarker[nResult], pChild->lpszOpenTag);
+            nResult += cb;
+          }
         }
 
-        if (pEntry->isDeclaration)
-        {
-            if (lpszMarker)
-            {
-                lpszMarker[nResult-1]=_CXML('?');
-                lpszMarker[nResult]=_CXML('>');
-            }
-            nResult++;
-            if (nFormat!=-1)
-            {
-                if (lpszMarker) lpszMarker[nResult]=_CXML('\n');
-                nResult++;
-            }
-        } else
-            // If there are child nodes we need to terminate the start tag
-            if (nElementI)
-            {
-                if (lpszMarker) lpszMarker[nResult-1]=_CXML('>');
-                if (nFormat>=0)
-                {
-                    if (lpszMarker) lpszMarker[nResult]=_CXML('\n');
-                    nResult++;
-                }
-            } else nResult--;
-    }
-
-    // Calculate the child format for when we recurse.  This is used to
-    // determine the number of spaces used for prefixes.
-    if (nFormat!=-1)
-    {
-        if (cbElement&&(!pEntry->isDeclaration)) nChildFormat=nFormat+1;
-        else nChildFormat=nFormat;
-    }
-
-    // Enumerate through remaining children
-    for (i=0; i<nElementI; i++)
-    {
-        j=pEntry->pOrder[i];
-        switch((XMLElementType)(j&3))
-        {
-        // Text nodes
-        case eNodeText:
-            {
-                // "Text"
-                XMLCSTR pChild=pEntry->pText[j>>2];
-                cb = (int)ToXMLStringTool::lengthXMLString(pChild);
-                if (cb)
-                {
-                    if (nFormat>=0)
-                    {
-                        if (lpszMarker)
-                        {
-                            charmemset(&lpszMarker[nResult],INDENTCHAR,nFormat+1);
-                            ToXMLStringTool::toXMLUnSafe(&lpszMarker[nResult+nFormat+1],pChild);
-                            lpszMarker[nResult+nFormat+1+cb]=_CXML('\n');
-                        }
-                        nResult+=cb+nFormat+2;
-                    } else
-                    {
-                        if (lpszMarker) ToXMLStringTool::toXMLUnSafe(&lpszMarker[nResult], pChild);
-                        nResult += cb;
-                    }
-                }
-                break;
-            }
-
-        // Clear type nodes
-        case eNodeClear:
-            {
-                XMLClear *pChild=pEntry->pClear+(j>>2);
-                // "OpenTag"
-                cb = (int)LENSTR(pChild->lpszOpenTag);
-                if (cb)
-                {
-                    if (nFormat!=-1)
-                    {
-                        if (lpszMarker)
-                        {
-                            charmemset(&lpszMarker[nResult], INDENTCHAR, nFormat+1);
-                            xstrcpy(&lpszMarker[nResult+nFormat+1], pChild->lpszOpenTag);
-                        }
-                        nResult+=cb+nFormat+1;
-                    }
-                    else
-                    {
-                        if (lpszMarker)xstrcpy(&lpszMarker[nResult], pChild->lpszOpenTag);
-                        nResult += cb;
-                    }
-                }
-
-                // "OpenTag Value"
-                cb = (int)LENSTR(pChild->lpszValue);
-                if (cb)
-                {
-                    if (lpszMarker) xstrcpy(&lpszMarker[nResult], pChild->lpszValue);
-                    nResult += cb;
-                }
-
-                // "OpenTag Value CloseTag"
-                cb = (int)LENSTR(pChild->lpszCloseTag);
-                if (cb)
-                {
-                    if (lpszMarker) xstrcpy(&lpszMarker[nResult], pChild->lpszCloseTag);
-                    nResult += cb;
-                }
-
-                if (nFormat!=-1)
-                {
-                    if (lpszMarker) lpszMarker[nResult] = _CXML('\n');
-                    nResult++;
-                }
-                break;
-            }
-
-        // Element nodes
-        case eNodeChild:
-            {
-                // Recursively add child nodes
-                nResult += CreateXMLStringR(pEntry->pChild[j>>2].d, lpszMarker ? lpszMarker + nResult : 0, nChildFormat);
-                break;
-            }
-        default: break;
+        // "OpenTag Value"
+        cb = (int)LENSTR(pChild->lpszValue);
+        if (cb) {
+          if (lpszMarker) xstrcpy(&lpszMarker[nResult], pChild->lpszValue);
+          nResult += cb;
         }
-    }
 
-    if ((cbElement)&&(!pEntry->isDeclaration))
-    {
-        // If we have child entries we need to use long XML notation for
-        // closing the element - "<elementname>blah blah blah</elementname>"
-        if (nElementI)
-        {
-            // "</elementname>\0"
-            if (lpszMarker)
-            {
-                if (nFormat >=0)
-                {
-                    charmemset(&lpszMarker[nResult], INDENTCHAR,nFormat);
-                    nResult+=nFormat;
-                }
-
-                lpszMarker[nResult]=_CXML('<'); lpszMarker[nResult+1]=_CXML('/');
-                nResult += 2;
-                xstrcpy(&lpszMarker[nResult], pEntry->lpszName);
-                nResult += cbElement;
-
-                lpszMarker[nResult]=_CXML('>');
-                if (nFormat == -1) nResult++;
-                else
-                {
-                    lpszMarker[nResult+1]=_CXML('\n');
-                    nResult+=2;
-                }
-            } else
-            {
-                if (nFormat>=0) nResult+=cbElement+4+nFormat;
-                else if (nFormat==-1) nResult+=cbElement+3;
-                else nResult+=cbElement+4;
-            }
-        } else
-        {
-            // If there are no children we can use shorthand XML notation -
-            // "<elementname/>"
-            // "/>\0"
-            if (lpszMarker)
-            {
-                lpszMarker[nResult]=_CXML('/'); lpszMarker[nResult+1]=_CXML('>');
-                if (nFormat != -1) lpszMarker[nResult+2]=_CXML('\n');
-            }
-            nResult += nFormat == -1 ? 2 : 3;
+        // "OpenTag Value CloseTag"
+        cb = (int)LENSTR(pChild->lpszCloseTag);
+        if (cb) {
+          if (lpszMarker) xstrcpy(&lpszMarker[nResult], pChild->lpszCloseTag);
+          nResult += cb;
         }
-    }
 
-    return nResult;
+        if (nFormat != -1) {
+          if (lpszMarker) lpszMarker[nResult] = _CXML('\n');
+          nResult++;
+        }
+        break;
+      }
+
+      // Element nodes
+      case eNodeChild: {
+        // Recursively add child nodes
+        nResult += CreateXMLStringR(pEntry->pChild[j >> 2].d,
+                                    lpszMarker ? lpszMarker + nResult : 0,
+                                    nChildFormat);
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  if ((cbElement) && (!pEntry->isDeclaration)) {
+    // If we have child entries we need to use long XML notation for
+    // closing the element - "<elementname>blah blah blah</elementname>"
+    if (nElementI) {
+      // "</elementname>\0"
+      if (lpszMarker) {
+        if (nFormat >= 0) {
+          charmemset(&lpszMarker[nResult], INDENTCHAR, nFormat);
+          nResult += nFormat;
+        }
+
+        lpszMarker[nResult] = _CXML('<');
+        lpszMarker[nResult + 1] = _CXML('/');
+        nResult += 2;
+        xstrcpy(&lpszMarker[nResult], pEntry->lpszName);
+        nResult += cbElement;
+
+        lpszMarker[nResult] = _CXML('>');
+        if (nFormat == -1)
+          nResult++;
+        else {
+          lpszMarker[nResult + 1] = _CXML('\n');
+          nResult += 2;
+        }
+      } else {
+        if (nFormat >= 0)
+          nResult += cbElement + 4 + nFormat;
+        else if (nFormat == -1)
+          nResult += cbElement + 3;
+        else
+          nResult += cbElement + 4;
+      }
+    } else {
+      // If there are no children we can use shorthand XML notation -
+      // "<elementname/>"
+      // "/>\0"
+      if (lpszMarker) {
+        lpszMarker[nResult] = _CXML('/');
+        lpszMarker[nResult + 1] = _CXML('>');
+        if (nFormat != -1) lpszMarker[nResult + 2] = _CXML('\n');
+      }
+      nResult += nFormat == -1 ? 2 : 3;
+    }
+  }
+
+  return nResult;
 }
 
 #undef LENSTR
@@ -2084,638 +2351,832 @@ int XMLNode::CreateXMLStringR(XMLNodeData *pEntry, XMLSTR lpszMarker, int nForma
 //                                        NULL terminator.
 // @return      XMLSTR                  - Allocated XML string, you must free
 //                                        this with free().
-XMLSTR XMLNode::createXMLString(int nFormat, int *pnSize) const
-{
-    if (!d) { if (pnSize) *pnSize=0; return NULL; }
-
-    XMLSTR lpszResult = NULL;
-    int cbStr;
-
-    // Recursively Calculate the size of the XML string
-    if (!dropWhiteSpace) nFormat=0;
-    nFormat = nFormat ? 0 : -1;
-    cbStr = CreateXMLStringR(d, 0, nFormat);
-    // Alllocate memory for the XML string + the NULL terminator and
-    // create the recursively XML string.
-    lpszResult=(XMLSTR)malloc((cbStr+1)*sizeof(XMLCHAR));
-    CreateXMLStringR(d, lpszResult, nFormat);
-    lpszResult[cbStr]=_CXML('\0');
-    if (pnSize) *pnSize = cbStr;
-    return lpszResult;
-}
-
-int XMLNode::detachFromParent(XMLNodeData *d)
-{
-    XMLNode *pa=d->pParent->pChild;
-    int i=0;
-    while (((void*)(pa[i].d))!=((void*)d)) i++;
-    d->pParent->nChild--;
-    if (d->pParent->nChild) memmove(pa+i,pa+i+1,(d->pParent->nChild-i)*sizeof(XMLNode));
-    else { free(pa); d->pParent->pChild=NULL; }
-    return removeOrderElement(d->pParent,eNodeChild,i);
-}
-
-XMLNode::~XMLNode()
-{
-    if (!d) return;
-    d->ref_count--;
-    emptyTheNode(0);
-}
-void XMLNode::deleteNodeContent()
-{
-    if (!d) return;
-    if (d->pParent) { detachFromParent(d); d->pParent=NULL; d->ref_count--; }
-    emptyTheNode(1);
-}
-void XMLNode::emptyTheNode(char force)
-{
-    XMLNodeData *dd=d; // warning: must stay this way!
-    if ((dd->ref_count==0)||force)
-    {
-        if (d->pParent) detachFromParent(d);
-        int i;
-        XMLNode *pc;
-        for(i=0; i<dd->nChild; i++)
-        {
-            pc=dd->pChild+i;
-            pc->d->pParent=NULL;
-            pc->d->ref_count--;
-            pc->emptyTheNode(force);
-        }
-        myFree(dd->pChild);
-        for(i=0; i<dd->nText; i++) free((void*)dd->pText[i]);
-        myFree(dd->pText);
-        for(i=0; i<dd->nClear; i++) free((void*)dd->pClear[i].lpszValue);
-        myFree(dd->pClear);
-        for(i=0; i<dd->nAttribute; i++)
-        {
-            free((void*)dd->pAttribute[i].lpszName);
-            if (dd->pAttribute[i].lpszValue) free((void*)dd->pAttribute[i].lpszValue);
-        }
-        myFree(dd->pAttribute);
-        myFree(dd->pOrder);
-        myFree((void*)dd->lpszName);
-        dd->nChild=0;    dd->nText=0;    dd->nClear=0;    dd->nAttribute=0;
-        dd->pChild=NULL; dd->pText=NULL; dd->pClear=NULL; dd->pAttribute=NULL;
-        dd->pOrder=NULL; dd->lpszName=NULL; dd->pParent=NULL;
-    }
-    if (dd->ref_count==0)
-    {
-        free(dd);
-        d=NULL;
-    }
-}
-
-XMLNode& XMLNode::operator=( const XMLNode& A )
-{
-    // shallow copy
-    if (this != &A)
-    {
-        if (d) { d->ref_count--; emptyTheNode(0); }
-        d=A.d;
-        if (d) (d->ref_count) ++ ;
-    }
-    return *this;
-}
-
-XMLNode::XMLNode(const XMLNode &A)
-{
-    // shallow copy
-    d=A.d;
-    if (d) (d->ref_count)++ ;
-}
-
-XMLNode XMLNode::deepCopy() const
-{
-    if (!d) return XMLNode::emptyXMLNode;
-    XMLNode x(NULL,stringDup(d->lpszName),d->isDeclaration);
-    XMLNodeData *p=x.d;
-    int n=d->nAttribute;
-    if (n)
-    {
-        p->nAttribute=n; p->pAttribute=(XMLAttribute*)malloc(n*sizeof(XMLAttribute));
-        while (n--)
-        {
-            p->pAttribute[n].lpszName=stringDup(d->pAttribute[n].lpszName);
-            p->pAttribute[n].lpszValue=stringDup(d->pAttribute[n].lpszValue);
-        }
-    }
-    if (d->pOrder)
-    {
-        n=(d->nChild+d->nText+d->nClear)*sizeof(int); p->pOrder=(int*)malloc(n); memcpy(p->pOrder,d->pOrder,n);
-    }
-    n=d->nText;
-    if (n)
-    {
-        p->nText=n; p->pText=(XMLCSTR*)malloc(n*sizeof(XMLCSTR));
-        while(n--) p->pText[n]=stringDup(d->pText[n]);
-    }
-    n=d->nClear;
-    if (n)
-    {
-        p->nClear=n; p->pClear=(XMLClear*)malloc(n*sizeof(XMLClear));
-        while (n--)
-        {
-            p->pClear[n].lpszCloseTag=d->pClear[n].lpszCloseTag;
-            p->pClear[n].lpszOpenTag=d->pClear[n].lpszOpenTag;
-            p->pClear[n].lpszValue=stringDup(d->pClear[n].lpszValue);
-        }
-    }
-    n=d->nChild;
-    if (n)
-    {
-        p->nChild=n; p->pChild=(XMLNode*)malloc(n*sizeof(XMLNode));
-        while (n--)
-        {
-            p->pChild[n].d=NULL;
-            p->pChild[n]=d->pChild[n].deepCopy();
-            p->pChild[n].d->pParent=p;
-        }
-    }
-    return x;
-}
-
-XMLNode XMLNode::addChild(XMLNode childNode, int pos)
-{
-    XMLNodeData *dc=childNode.d;
-    if ((!dc)||(!d)) return childNode;
-    if (!dc->lpszName)
-    {
-        // this is a root node: todo: correct fix
-        int j=pos;
-        while (dc->nChild)
-        {
-            addChild(dc->pChild[0],j);
-            if (pos>=0) j++;
-        }
-        return childNode;
-    }
-    if (dc->pParent) { if ((detachFromParent(dc)<=pos)&&(dc->pParent==d)) pos--; } else dc->ref_count++;
-    dc->pParent=d;
-//     int nc=d->nChild;
-//     d->pChild=(XMLNode*)myRealloc(d->pChild,(nc+1),memoryIncrease,sizeof(XMLNode));
-    d->pChild=(XMLNode*)addToOrder(0,&pos,d->nChild,d->pChild,sizeof(XMLNode),eNodeChild);
-    d->pChild[pos].d=dc;
-    d->nChild++;
-    return childNode;
-}
-
-void XMLNode::deleteAttribute(int i)
-{
-    if ((!d)||(i<0)||(i>=d->nAttribute)) return;
-    d->nAttribute--;
-    XMLAttribute *p=d->pAttribute+i;
-    free((void*)p->lpszName);
-    if (p->lpszValue) free((void*)p->lpszValue);
-    if (d->nAttribute) memmove(p,p+1,(d->nAttribute-i)*sizeof(XMLAttribute)); else { free(p); d->pAttribute=NULL; }
-}
-
-void XMLNode::deleteAttribute(XMLAttribute *a){ if (a) deleteAttribute(a->lpszName); }
-void XMLNode::deleteAttribute(XMLCSTR lpszName)
-{
-    int j=0;
-    getAttribute(lpszName,&j);
-    if (j) deleteAttribute(j-1);
-}
-
-XMLAttribute *XMLNode::updateAttribute_WOSD(XMLSTR lpszNewValue, XMLSTR lpszNewName,int i)
-{
-    if (!d) { if (lpszNewValue) free(lpszNewValue); if (lpszNewName) free(lpszNewName); return NULL; }
-    if (i>=d->nAttribute)
-    {
-        if (lpszNewName) return addAttribute_WOSD(lpszNewName,lpszNewValue);
-        return NULL;
-    }
-    XMLAttribute *p=d->pAttribute+i;
-    if (p->lpszValue&&p->lpszValue!=lpszNewValue) free((void*)p->lpszValue);
-    p->lpszValue=lpszNewValue;
-    if (lpszNewName&&p->lpszName!=lpszNewName) { free((void*)p->lpszName); p->lpszName=lpszNewName; };
-    return p;
-}
-
-XMLAttribute *XMLNode::updateAttribute_WOSD(XMLAttribute *newAttribute, XMLAttribute *oldAttribute)
-{
-    if (oldAttribute) return updateAttribute_WOSD((XMLSTR)newAttribute->lpszValue,(XMLSTR)newAttribute->lpszName,oldAttribute->lpszName);
-    return addAttribute_WOSD((XMLSTR)newAttribute->lpszName,(XMLSTR)newAttribute->lpszValue);
-}
-
-XMLAttribute *XMLNode::updateAttribute_WOSD(XMLSTR lpszNewValue, XMLSTR lpszNewName,XMLCSTR lpszOldName)
-{
-    int j=0;
-    getAttribute(lpszOldName,&j);
-    if (j) return updateAttribute_WOSD(lpszNewValue,lpszNewName,j-1);
-    else
-    {
-        if (lpszNewName) return addAttribute_WOSD(lpszNewName,lpszNewValue);
-        else             return addAttribute_WOSD(stringDup(lpszOldName),lpszNewValue);
-    }
-}
-
-int XMLNode::indexText(XMLCSTR lpszValue) const
-{
-    if (!d) return -1;
-    int i,l=d->nText;
-    if (!lpszValue) { if (l) return 0; return -1; }
-    XMLCSTR *p=d->pText;
-    for (i=0; i<l; i++) if (lpszValue==p[i]) return i;
-    return -1;
-}
-
-void XMLNode::deleteText(int i)
-{
-    if ((!d)||(i<0)||(i>=d->nText)) return;
-    d->nText--;
-    XMLCSTR *p=d->pText+i;
-    free((void*)*p);
-    if (d->nText) memmove(p,p+1,(d->nText-i)*sizeof(XMLCSTR)); else { free(p); d->pText=NULL; }
-    removeOrderElement(d,eNodeText,i);
-}
-
-void XMLNode::deleteText(XMLCSTR lpszValue) { deleteText(indexText(lpszValue)); }
-
-XMLCSTR XMLNode::updateText_WOSD(XMLSTR lpszNewValue, int i)
-{
-    if (!d) { if (lpszNewValue) free(lpszNewValue); return NULL; }
-    if (i>=d->nText) return addText_WOSD(lpszNewValue);
-    XMLCSTR *p=d->pText+i;
-    if (*p!=lpszNewValue) { free((void*)*p); *p=lpszNewValue; }
-    return lpszNewValue;
-}
-
-XMLCSTR XMLNode::updateText_WOSD(XMLSTR lpszNewValue, XMLCSTR lpszOldValue)
-{
-    if (!d) { if (lpszNewValue) free(lpszNewValue); return NULL; }
-    int i=indexText(lpszOldValue);
-    if (i>=0) return updateText_WOSD(lpszNewValue,i);
-    return addText_WOSD(lpszNewValue);
-}
-
-void XMLNode::deleteClear(int i)
-{
-    if ((!d)||(i<0)||(i>=d->nClear)) return;
-    d->nClear--;
-    XMLClear *p=d->pClear+i;
-    free((void*)p->lpszValue);
-    if (d->nClear) memmove(p,p+1,(d->nClear-i)*sizeof(XMLClear)); else { free(p); d->pClear=NULL; }
-    removeOrderElement(d,eNodeClear,i);
-}
-
-int XMLNode::indexClear(XMLCSTR lpszValue) const
-{
-    if (!d) return -1;
-    int i,l=d->nClear;
-    if (!lpszValue) { if (l) return 0; return -1; }
-    XMLClear *p=d->pClear;
-    for (i=0; i<l; i++) if (lpszValue==p[i].lpszValue) return i;
-    return -1;
-}
-
-void XMLNode::deleteClear(XMLCSTR lpszValue) { deleteClear(indexClear(lpszValue)); }
-void XMLNode::deleteClear(XMLClear *a) { if (a) deleteClear(a->lpszValue); }
-
-XMLClear *XMLNode::updateClear_WOSD(XMLSTR lpszNewContent, int i)
-{
-    if (!d) { if (lpszNewContent) free(lpszNewContent); return NULL; }
-    if (i>=d->nClear) return addClear_WOSD(lpszNewContent);
-    XMLClear *p=d->pClear+i;
-    if (lpszNewContent!=p->lpszValue) { free((void*)p->lpszValue); p->lpszValue=lpszNewContent; }
-    return p;
-}
-
-XMLClear *XMLNode::updateClear_WOSD(XMLSTR lpszNewContent, XMLCSTR lpszOldValue)
-{
-    if (!d) { if (lpszNewContent) free(lpszNewContent); return NULL; }
-    int i=indexClear(lpszOldValue);
-    if (i>=0) return updateClear_WOSD(lpszNewContent,i);
-    return addClear_WOSD(lpszNewContent);
-}
-
-XMLClear *XMLNode::updateClear_WOSD(XMLClear *newP,XMLClear *oldP)
-{
-    if (oldP) return updateClear_WOSD((XMLSTR)newP->lpszValue,(XMLSTR)oldP->lpszValue);
+XMLSTR XMLNode::createXMLString(int nFormat, int *pnSize) const {
+  if (!d) {
+    if (pnSize) *pnSize = 0;
     return NULL;
+  }
+
+  XMLSTR lpszResult = NULL;
+  int cbStr;
+
+  // Recursively Calculate the size of the XML string
+  if (!dropWhiteSpace) nFormat = 0;
+  nFormat = nFormat ? 0 : -1;
+  cbStr = CreateXMLStringR(d, 0, nFormat);
+  // Alllocate memory for the XML string + the NULL terminator and
+  // create the recursively XML string.
+  lpszResult = (XMLSTR)malloc((cbStr + 1) * sizeof(XMLCHAR));
+  CreateXMLStringR(d, lpszResult, nFormat);
+  lpszResult[cbStr] = _CXML('\0');
+  if (pnSize) *pnSize = cbStr;
+  return lpszResult;
 }
 
-int XMLNode::nChildNode(XMLCSTR name) const
-{
-    if (!d) return 0;
-    int i,j=0,n=d->nChild;
-    XMLNode *pc=d->pChild;
-    for (i=0; i<n; i++)
-    {
-        if (xstricmp(pc->d->lpszName, name)==0) j++;
-        pc++;
+int XMLNode::detachFromParent(XMLNodeData *d) {
+  XMLNode *pa = d->pParent->pChild;
+  int i = 0;
+  while (((void *)(pa[i].d)) != ((void *)d)) i++;
+  d->pParent->nChild--;
+  if (d->pParent->nChild)
+    memmove(pa + i, pa + i + 1, (d->pParent->nChild - i) * sizeof(XMLNode));
+  else {
+    free(pa);
+    d->pParent->pChild = NULL;
+  }
+  return removeOrderElement(d->pParent, eNodeChild, i);
+}
+
+XMLNode::~XMLNode() {
+  if (!d) return;
+  d->ref_count--;
+  emptyTheNode(0);
+}
+void XMLNode::deleteNodeContent() {
+  if (!d) return;
+  if (d->pParent) {
+    detachFromParent(d);
+    d->pParent = NULL;
+    d->ref_count--;
+  }
+  emptyTheNode(1);
+}
+void XMLNode::emptyTheNode(char force) {
+  XMLNodeData *dd = d;  // warning: must stay this way!
+  if ((dd->ref_count == 0) || force) {
+    if (d->pParent) detachFromParent(d);
+    int i;
+    XMLNode *pc;
+    for (i = 0; i < dd->nChild; i++) {
+      pc = dd->pChild + i;
+      pc->d->pParent = NULL;
+      pc->d->ref_count--;
+      pc->emptyTheNode(force);
     }
-    return j;
-}
-
-XMLNode XMLNode::getChildNode(XMLCSTR name, int *j) const
-{
-    if (!d) return emptyXMLNode;
-    int i=0,n=d->nChild;
-    if (j) i=*j;
-    XMLNode *pc=d->pChild+i;
-    for (; i<n; i++)
-    {
-        if (!xstricmp(pc->d->lpszName, name))
-        {
-            if (j) *j=i+1;
-            return *pc;
-        }
-        pc++;
+    myFree(dd->pChild);
+    for (i = 0; i < dd->nText; i++) free((void *)dd->pText[i]);
+    myFree(dd->pText);
+    for (i = 0; i < dd->nClear; i++) free((void *)dd->pClear[i].lpszValue);
+    myFree(dd->pClear);
+    for (i = 0; i < dd->nAttribute; i++) {
+      free((void *)dd->pAttribute[i].lpszName);
+      if (dd->pAttribute[i].lpszValue)
+        free((void *)dd->pAttribute[i].lpszValue);
     }
-    return emptyXMLNode;
+    myFree(dd->pAttribute);
+    myFree(dd->pOrder);
+    myFree((void *)dd->lpszName);
+    dd->nChild = 0;
+    dd->nText = 0;
+    dd->nClear = 0;
+    dd->nAttribute = 0;
+    dd->pChild = NULL;
+    dd->pText = NULL;
+    dd->pClear = NULL;
+    dd->pAttribute = NULL;
+    dd->pOrder = NULL;
+    dd->lpszName = NULL;
+    dd->pParent = NULL;
+  }
+  if (dd->ref_count == 0) {
+    free(dd);
+    d = NULL;
+  }
 }
 
-XMLNode XMLNode::getChildNode(XMLCSTR name, int j) const
-{
-    if (!d) return emptyXMLNode;
-    if (j>=0)
-    {
-        int i=0;
-        while (j-->0) getChildNode(name,&i);
-        return getChildNode(name,&i);
+XMLNode &XMLNode::operator=(const XMLNode &A) {
+  // shallow copy
+  if (this != &A) {
+    if (d) {
+      d->ref_count--;
+      emptyTheNode(0);
     }
-    int i=d->nChild;
-    while (i--) if (!xstricmp(name,d->pChild[i].d->lpszName)) break;
-    if (i<0) return emptyXMLNode;
-    return getChildNode(i);
+    d = A.d;
+    if (d) (d->ref_count)++;
+  }
+  return *this;
 }
 
-XMLNode XMLNode::getChildNodeByPath(XMLCSTR _path, char createMissing, XMLCHAR sep)
-{
-    XMLSTR path=stringDup(_path);
-    XMLNode x=getChildNodeByPathNonConst(path,createMissing,sep);
-    if (path) free(path);
-    return x;
+XMLNode::XMLNode(const XMLNode &A) {
+  // shallow copy
+  d = A.d;
+  if (d) (d->ref_count)++;
 }
 
-XMLNode XMLNode::getChildNodeByPathNonConst(XMLSTR path, char createIfMissing, XMLCHAR sep)
-{
-    if ((!path)||(!(*path))) return *this;
-    XMLNode xn,xbase=*this;
-    XMLCHAR *tend1,sepString[2]; sepString[0]=sep; sepString[1]=0;
-    tend1=xstrstr(path,sepString);
-    while(tend1)
-    {
-        *tend1=0;
-        xn=xbase.getChildNode(path);
-        if (xn.isEmpty())
-        {
-            if (createIfMissing) xn=xbase.addChild(path);
-            else { *tend1=sep; return XMLNode::emptyXMLNode; }
-        }
-        *tend1=sep;
-        xbase=xn;
-        path=tend1+1;
-        tend1=xstrstr(path,sepString);
+XMLNode XMLNode::deepCopy() const {
+  if (!d) return XMLNode::emptyXMLNode;
+  XMLNode x(NULL, stringDup(d->lpszName), d->isDeclaration);
+  XMLNodeData *p = x.d;
+  int n = d->nAttribute;
+  if (n) {
+    p->nAttribute = n;
+    p->pAttribute = (XMLAttribute *)malloc(n * sizeof(XMLAttribute));
+    while (n--) {
+      p->pAttribute[n].lpszName = stringDup(d->pAttribute[n].lpszName);
+      p->pAttribute[n].lpszValue = stringDup(d->pAttribute[n].lpszValue);
     }
-    xn=xbase.getChildNode(path);
-    if (xn.isEmpty()&&createIfMissing) xn=xbase.addChild(path);
-    return xn;
+  }
+  if (d->pOrder) {
+    n = (d->nChild + d->nText + d->nClear) * sizeof(int);
+    p->pOrder = (int *)malloc(n);
+    memcpy(p->pOrder, d->pOrder, n);
+  }
+  n = d->nText;
+  if (n) {
+    p->nText = n;
+    p->pText = (XMLCSTR *)malloc(n * sizeof(XMLCSTR));
+    while (n--) p->pText[n] = stringDup(d->pText[n]);
+  }
+  n = d->nClear;
+  if (n) {
+    p->nClear = n;
+    p->pClear = (XMLClear *)malloc(n * sizeof(XMLClear));
+    while (n--) {
+      p->pClear[n].lpszCloseTag = d->pClear[n].lpszCloseTag;
+      p->pClear[n].lpszOpenTag = d->pClear[n].lpszOpenTag;
+      p->pClear[n].lpszValue = stringDup(d->pClear[n].lpszValue);
+    }
+  }
+  n = d->nChild;
+  if (n) {
+    p->nChild = n;
+    p->pChild = (XMLNode *)malloc(n * sizeof(XMLNode));
+    while (n--) {
+      p->pChild[n].d = NULL;
+      p->pChild[n] = d->pChild[n].deepCopy();
+      p->pChild[n].d->pParent = p;
+    }
+  }
+  return x;
 }
 
-XMLElementPosition XMLNode::positionOfText     (int i) const { if (i>=d->nText ) i=d->nText-1;  return findPosition(d,i,eNodeText ); }
-XMLElementPosition XMLNode::positionOfClear    (int i) const { if (i>=d->nClear) i=d->nClear-1; return findPosition(d,i,eNodeClear); }
-XMLElementPosition XMLNode::positionOfChildNode(int i) const { if (i>=d->nChild) i=d->nChild-1; return findPosition(d,i,eNodeChild); }
-XMLElementPosition XMLNode::positionOfText (XMLCSTR lpszValue) const { return positionOfText (indexText (lpszValue)); }
-XMLElementPosition XMLNode::positionOfClear(XMLCSTR lpszValue) const { return positionOfClear(indexClear(lpszValue)); }
-XMLElementPosition XMLNode::positionOfClear(XMLClear *a) const { if (a) return positionOfClear(a->lpszValue); return positionOfClear(); }
-XMLElementPosition XMLNode::positionOfChildNode(XMLNode x)  const
-{
-    if ((!d)||(!x.d)) return -1;
-    XMLNodeData *dd=x.d;
-    XMLNode *pc=d->pChild;
-    int i=d->nChild;
-    while (i--) if (pc[i].d==dd) return findPosition(d,i,eNodeChild);
+XMLNode XMLNode::addChild(XMLNode childNode, int pos) {
+  XMLNodeData *dc = childNode.d;
+  if ((!dc) || (!d)) return childNode;
+  if (!dc->lpszName) {
+    // this is a root node: todo: correct fix
+    int j = pos;
+    while (dc->nChild) {
+      addChild(dc->pChild[0], j);
+      if (pos >= 0) j++;
+    }
+    return childNode;
+  }
+  if (dc->pParent) {
+    if ((detachFromParent(dc) <= pos) && (dc->pParent == d)) pos--;
+  } else
+    dc->ref_count++;
+  dc->pParent = d;
+  //     int nc=d->nChild;
+  //     d->pChild=(XMLNode*)myRealloc(d->pChild,(nc+1),memoryIncrease,sizeof(XMLNode));
+  d->pChild = (XMLNode *)addToOrder(0, &pos, d->nChild, d->pChild,
+                                    sizeof(XMLNode), eNodeChild);
+  d->pChild[pos].d = dc;
+  d->nChild++;
+  return childNode;
+}
+
+void XMLNode::deleteAttribute(int i) {
+  if ((!d) || (i < 0) || (i >= d->nAttribute)) return;
+  d->nAttribute--;
+  XMLAttribute *p = d->pAttribute + i;
+  free((void *)p->lpszName);
+  if (p->lpszValue) free((void *)p->lpszValue);
+  if (d->nAttribute)
+    memmove(p, p + 1, (d->nAttribute - i) * sizeof(XMLAttribute));
+  else {
+    free(p);
+    d->pAttribute = NULL;
+  }
+}
+
+void XMLNode::deleteAttribute(XMLAttribute *a) {
+  if (a) deleteAttribute(a->lpszName);
+}
+void XMLNode::deleteAttribute(XMLCSTR lpszName) {
+  int j = 0;
+  getAttribute(lpszName, &j);
+  if (j) deleteAttribute(j - 1);
+}
+
+XMLAttribute *XMLNode::updateAttribute_WOSD(XMLSTR lpszNewValue,
+                                            XMLSTR lpszNewName, int i) {
+  if (!d) {
+    if (lpszNewValue) free(lpszNewValue);
+    if (lpszNewName) free(lpszNewName);
+    return NULL;
+  }
+  if (i >= d->nAttribute) {
+    if (lpszNewName) return addAttribute_WOSD(lpszNewName, lpszNewValue);
+    return NULL;
+  }
+  XMLAttribute *p = d->pAttribute + i;
+  if (p->lpszValue && p->lpszValue != lpszNewValue) free((void *)p->lpszValue);
+  p->lpszValue = lpszNewValue;
+  if (lpszNewName && p->lpszName != lpszNewName) {
+    free((void *)p->lpszName);
+    p->lpszName = lpszNewName;
+  };
+  return p;
+}
+
+XMLAttribute *XMLNode::updateAttribute_WOSD(XMLAttribute *newAttribute,
+                                            XMLAttribute *oldAttribute) {
+  if (oldAttribute)
+    return updateAttribute_WOSD((XMLSTR)newAttribute->lpszValue,
+                                (XMLSTR)newAttribute->lpszName,
+                                oldAttribute->lpszName);
+  return addAttribute_WOSD((XMLSTR)newAttribute->lpszName,
+                           (XMLSTR)newAttribute->lpszValue);
+}
+
+XMLAttribute *XMLNode::updateAttribute_WOSD(XMLSTR lpszNewValue,
+                                            XMLSTR lpszNewName,
+                                            XMLCSTR lpszOldName) {
+  int j = 0;
+  getAttribute(lpszOldName, &j);
+  if (j)
+    return updateAttribute_WOSD(lpszNewValue, lpszNewName, j - 1);
+  else {
+    if (lpszNewName)
+      return addAttribute_WOSD(lpszNewName, lpszNewValue);
+    else
+      return addAttribute_WOSD(stringDup(lpszOldName), lpszNewValue);
+  }
+}
+
+int XMLNode::indexText(XMLCSTR lpszValue) const {
+  if (!d) return -1;
+  int i, l = d->nText;
+  if (!lpszValue) {
+    if (l) return 0;
     return -1;
-}
-XMLElementPosition XMLNode::positionOfChildNode(XMLCSTR name, int count) const
-{
-    if (!name) return positionOfChildNode(count);
-    int j=0;
-    do { getChildNode(name,&j); if (j<0) return -1; } while (count--);
-    return findPosition(d,j-1,eNodeChild);
+  }
+  XMLCSTR *p = d->pText;
+  for (i = 0; i < l; i++)
+    if (lpszValue == p[i]) return i;
+  return -1;
 }
 
-XMLNode XMLNode::getChildNodeWithAttribute(XMLCSTR name,XMLCSTR attributeName,XMLCSTR attributeValue, int *k) const
-{
-     int i=0,j;
-     if (k) i=*k;
-     XMLNode x;
-     XMLCSTR t;
-     do
-     {
-         x=getChildNode(name,&i);
-         if (!x.isEmpty())
-         {
-             if (attributeValue)
-             {
-                 j=0;
-                 do
-                 {
-                     t=x.getAttribute(attributeName,&j);
-                     if (t&&(xstricmp(attributeValue,t)==0)) { if (k) *k=i; return x; }
-                 } while (t);
-             } else
-             {
-                 if (x.isAttributeSet(attributeName)) { if (k) *k=i; return x; }
-             }
-         }
-     } while (!x.isEmpty());
-     return emptyXMLNode;
+void XMLNode::deleteText(int i) {
+  if ((!d) || (i < 0) || (i >= d->nText)) return;
+  d->nText--;
+  XMLCSTR *p = d->pText + i;
+  free((void *)*p);
+  if (d->nText)
+    memmove(p, p + 1, (d->nText - i) * sizeof(XMLCSTR));
+  else {
+    free(p);
+    d->pText = NULL;
+  }
+  removeOrderElement(d, eNodeText, i);
+}
+
+void XMLNode::deleteText(XMLCSTR lpszValue) {
+  deleteText(indexText(lpszValue));
+}
+
+XMLCSTR XMLNode::updateText_WOSD(XMLSTR lpszNewValue, int i) {
+  if (!d) {
+    if (lpszNewValue) free(lpszNewValue);
+    return NULL;
+  }
+  if (i >= d->nText) return addText_WOSD(lpszNewValue);
+  XMLCSTR *p = d->pText + i;
+  if (*p != lpszNewValue) {
+    free((void *)*p);
+    *p = lpszNewValue;
+  }
+  return lpszNewValue;
+}
+
+XMLCSTR XMLNode::updateText_WOSD(XMLSTR lpszNewValue, XMLCSTR lpszOldValue) {
+  if (!d) {
+    if (lpszNewValue) free(lpszNewValue);
+    return NULL;
+  }
+  int i = indexText(lpszOldValue);
+  if (i >= 0) return updateText_WOSD(lpszNewValue, i);
+  return addText_WOSD(lpszNewValue);
+}
+
+void XMLNode::deleteClear(int i) {
+  if ((!d) || (i < 0) || (i >= d->nClear)) return;
+  d->nClear--;
+  XMLClear *p = d->pClear + i;
+  free((void *)p->lpszValue);
+  if (d->nClear)
+    memmove(p, p + 1, (d->nClear - i) * sizeof(XMLClear));
+  else {
+    free(p);
+    d->pClear = NULL;
+  }
+  removeOrderElement(d, eNodeClear, i);
+}
+
+int XMLNode::indexClear(XMLCSTR lpszValue) const {
+  if (!d) return -1;
+  int i, l = d->nClear;
+  if (!lpszValue) {
+    if (l) return 0;
+    return -1;
+  }
+  XMLClear *p = d->pClear;
+  for (i = 0; i < l; i++)
+    if (lpszValue == p[i].lpszValue) return i;
+  return -1;
+}
+
+void XMLNode::deleteClear(XMLCSTR lpszValue) {
+  deleteClear(indexClear(lpszValue));
+}
+void XMLNode::deleteClear(XMLClear *a) {
+  if (a) deleteClear(a->lpszValue);
+}
+
+XMLClear *XMLNode::updateClear_WOSD(XMLSTR lpszNewContent, int i) {
+  if (!d) {
+    if (lpszNewContent) free(lpszNewContent);
+    return NULL;
+  }
+  if (i >= d->nClear) return addClear_WOSD(lpszNewContent);
+  XMLClear *p = d->pClear + i;
+  if (lpszNewContent != p->lpszValue) {
+    free((void *)p->lpszValue);
+    p->lpszValue = lpszNewContent;
+  }
+  return p;
+}
+
+XMLClear *XMLNode::updateClear_WOSD(XMLSTR lpszNewContent,
+                                    XMLCSTR lpszOldValue) {
+  if (!d) {
+    if (lpszNewContent) free(lpszNewContent);
+    return NULL;
+  }
+  int i = indexClear(lpszOldValue);
+  if (i >= 0) return updateClear_WOSD(lpszNewContent, i);
+  return addClear_WOSD(lpszNewContent);
+}
+
+XMLClear *XMLNode::updateClear_WOSD(XMLClear *newP, XMLClear *oldP) {
+  if (oldP)
+    return updateClear_WOSD((XMLSTR)newP->lpszValue, (XMLSTR)oldP->lpszValue);
+  return NULL;
+}
+
+int XMLNode::nChildNode(XMLCSTR name) const {
+  if (!d) return 0;
+  int i, j = 0, n = d->nChild;
+  XMLNode *pc = d->pChild;
+  for (i = 0; i < n; i++) {
+    if (xstricmp(pc->d->lpszName, name) == 0) j++;
+    pc++;
+  }
+  return j;
+}
+
+XMLNode XMLNode::getChildNode(XMLCSTR name, int *j) const {
+  if (!d) return emptyXMLNode;
+  int i = 0, n = d->nChild;
+  if (j) i = *j;
+  XMLNode *pc = d->pChild + i;
+  for (; i < n; i++) {
+    if (!xstricmp(pc->d->lpszName, name)) {
+      if (j) *j = i + 1;
+      return *pc;
+    }
+    pc++;
+  }
+  return emptyXMLNode;
+}
+
+XMLNode XMLNode::getChildNode(XMLCSTR name, int j) const {
+  if (!d) return emptyXMLNode;
+  if (j >= 0) {
+    int i = 0;
+    while (j-- > 0) getChildNode(name, &i);
+    return getChildNode(name, &i);
+  }
+  int i = d->nChild;
+  while (i--)
+    if (!xstricmp(name, d->pChild[i].d->lpszName)) break;
+  if (i < 0) return emptyXMLNode;
+  return getChildNode(i);
+}
+
+XMLNode XMLNode::getChildNodeByPath(XMLCSTR _path, char createMissing,
+                                    XMLCHAR sep) {
+  XMLSTR path = stringDup(_path);
+  XMLNode x = getChildNodeByPathNonConst(path, createMissing, sep);
+  if (path) free(path);
+  return x;
+}
+
+XMLNode XMLNode::getChildNodeByPathNonConst(XMLSTR path, char createIfMissing,
+                                            XMLCHAR sep) {
+  if ((!path) || (!(*path))) return *this;
+  XMLNode xn, xbase = *this;
+  XMLCHAR *tend1, sepString[2];
+  sepString[0] = sep;
+  sepString[1] = 0;
+  tend1 = xstrstr(path, sepString);
+  while (tend1) {
+    *tend1 = 0;
+    xn = xbase.getChildNode(path);
+    if (xn.isEmpty()) {
+      if (createIfMissing)
+        xn = xbase.addChild(path);
+      else {
+        *tend1 = sep;
+        return XMLNode::emptyXMLNode;
+      }
+    }
+    *tend1 = sep;
+    xbase = xn;
+    path = tend1 + 1;
+    tend1 = xstrstr(path, sepString);
+  }
+  xn = xbase.getChildNode(path);
+  if (xn.isEmpty() && createIfMissing) xn = xbase.addChild(path);
+  return xn;
+}
+
+XMLElementPosition XMLNode::positionOfText(int i) const {
+  if (i >= d->nText) i = d->nText - 1;
+  return findPosition(d, i, eNodeText);
+}
+XMLElementPosition XMLNode::positionOfClear(int i) const {
+  if (i >= d->nClear) i = d->nClear - 1;
+  return findPosition(d, i, eNodeClear);
+}
+XMLElementPosition XMLNode::positionOfChildNode(int i) const {
+  if (i >= d->nChild) i = d->nChild - 1;
+  return findPosition(d, i, eNodeChild);
+}
+XMLElementPosition XMLNode::positionOfText(XMLCSTR lpszValue) const {
+  return positionOfText(indexText(lpszValue));
+}
+XMLElementPosition XMLNode::positionOfClear(XMLCSTR lpszValue) const {
+  return positionOfClear(indexClear(lpszValue));
+}
+XMLElementPosition XMLNode::positionOfClear(XMLClear *a) const {
+  if (a) return positionOfClear(a->lpszValue);
+  return positionOfClear();
+}
+XMLElementPosition XMLNode::positionOfChildNode(XMLNode x) const {
+  if ((!d) || (!x.d)) return -1;
+  XMLNodeData *dd = x.d;
+  XMLNode *pc = d->pChild;
+  int i = d->nChild;
+  while (i--)
+    if (pc[i].d == dd) return findPosition(d, i, eNodeChild);
+  return -1;
+}
+XMLElementPosition XMLNode::positionOfChildNode(XMLCSTR name, int count) const {
+  if (!name) return positionOfChildNode(count);
+  int j = 0;
+  do {
+    getChildNode(name, &j);
+    if (j < 0) return -1;
+  } while (count--);
+  return findPosition(d, j - 1, eNodeChild);
+}
+
+XMLNode XMLNode::getChildNodeWithAttribute(XMLCSTR name, XMLCSTR attributeName,
+                                           XMLCSTR attributeValue,
+                                           int *k) const {
+  int i = 0, j;
+  if (k) i = *k;
+  XMLNode x;
+  XMLCSTR t;
+  do {
+    x = getChildNode(name, &i);
+    if (!x.isEmpty()) {
+      if (attributeValue) {
+        j = 0;
+        do {
+          t = x.getAttribute(attributeName, &j);
+          if (t && (xstricmp(attributeValue, t) == 0)) {
+            if (k) *k = i;
+            return x;
+          }
+        } while (t);
+      } else {
+        if (x.isAttributeSet(attributeName)) {
+          if (k) *k = i;
+          return x;
+        }
+      }
+    }
+  } while (!x.isEmpty());
+  return emptyXMLNode;
 }
 
 // Find an attribute on an node.
-XMLCSTR XMLNode::getAttribute(XMLCSTR lpszAttrib, int *j) const
-{
-    if (!d) return NULL;
-    int i=0,n=d->nAttribute;
-    if (j) i=*j;
-    XMLAttribute *pAttr=d->pAttribute+i;
-    for (; i<n; i++)
-    {
-        if (xstricmp(pAttr->lpszName, lpszAttrib)==0)
-        {
-            if (j) *j=i+1;
-            return pAttr->lpszValue;
-        }
-        pAttr++;
+XMLCSTR XMLNode::getAttribute(XMLCSTR lpszAttrib, int *j) const {
+  if (!d) return NULL;
+  int i = 0, n = d->nAttribute;
+  if (j) i = *j;
+  XMLAttribute *pAttr = d->pAttribute + i;
+  for (; i < n; i++) {
+    if (xstricmp(pAttr->lpszName, lpszAttrib) == 0) {
+      if (j) *j = i + 1;
+      return pAttr->lpszValue;
     }
-    return NULL;
+    pAttr++;
+  }
+  return NULL;
 }
 
-char XMLNode::isAttributeSet(XMLCSTR lpszAttrib) const
-{
-    if (!d) return FALSE;
-    int i,n=d->nAttribute;
-    XMLAttribute *pAttr=d->pAttribute;
-    for (i=0; i<n; i++)
-    {
-        if (xstricmp(pAttr->lpszName, lpszAttrib)==0)
-        {
-            return TRUE;
-        }
-        pAttr++;
+char XMLNode::isAttributeSet(XMLCSTR lpszAttrib) const {
+  if (!d) return FALSE;
+  int i, n = d->nAttribute;
+  XMLAttribute *pAttr = d->pAttribute;
+  for (i = 0; i < n; i++) {
+    if (xstricmp(pAttr->lpszName, lpszAttrib) == 0) {
+      return TRUE;
     }
-    return FALSE;
+    pAttr++;
+  }
+  return FALSE;
 }
 
-XMLCSTR XMLNode::getAttribute(XMLCSTR name, int j) const
-{
-    if (!d) return NULL;
-    int i=0;
-    while (j-->0) getAttribute(name,&i);
-    return getAttribute(name,&i);
+XMLCSTR XMLNode::getAttribute(XMLCSTR name, int j) const {
+  if (!d) return NULL;
+  int i = 0;
+  while (j-- > 0) getAttribute(name, &i);
+  return getAttribute(name, &i);
 }
 
-XMLNodeContents XMLNode::enumContents(int i) const
-{
-    XMLNodeContents c;
-    if (!d) { c.etype=eNodeNULL; return c; }
-    if (i<d->nAttribute)
-    {
-        c.etype=eNodeAttribute;
-        c.attrib=d->pAttribute[i];
-        return c;
-    }
-    i-=d->nAttribute;
-    c.etype=(XMLElementType)(d->pOrder[i]&3);
-    i=(d->pOrder[i])>>2;
-    switch (c.etype)
-    {
-    case eNodeChild:     c.child = d->pChild[i];      break;
-    case eNodeText:      c.text  = d->pText[i];       break;
-    case eNodeClear:     c.clear = d->pClear[i];      break;
-    default: break;
-    }
+XMLNodeContents XMLNode::enumContents(int i) const {
+  XMLNodeContents c;
+  if (!d) {
+    c.etype = eNodeNULL;
     return c;
+  }
+  if (i < d->nAttribute) {
+    c.etype = eNodeAttribute;
+    c.attrib = d->pAttribute[i];
+    return c;
+  }
+  i -= d->nAttribute;
+  c.etype = (XMLElementType)(d->pOrder[i] & 3);
+  i = (d->pOrder[i]) >> 2;
+  switch (c.etype) {
+    case eNodeChild:
+      c.child = d->pChild[i];
+      break;
+    case eNodeText:
+      c.text = d->pText[i];
+      break;
+    case eNodeClear:
+      c.clear = d->pClear[i];
+      break;
+    default:
+      break;
+  }
+  return c;
 }
 
-XMLCSTR XMLNode::getName() const { if (!d) return NULL; return d->lpszName;   }
-int XMLNode::nText()       const { if (!d) return 0;    return d->nText;      }
-int XMLNode::nChildNode()  const { if (!d) return 0;    return d->nChild;     }
-int XMLNode::nAttribute()  const { if (!d) return 0;    return d->nAttribute; }
-int XMLNode::nClear()      const { if (!d) return 0;    return d->nClear;     }
-int XMLNode::nElement()    const { if (!d) return 0;    return d->nAttribute+d->nChild+d->nText+d->nClear; }
-XMLClear     XMLNode::getClear         (int i) const { if ((!d)||(i>=d->nClear    )) return emptyXMLClear;     return d->pClear[i];     }
-XMLAttribute XMLNode::getAttribute     (int i) const { if ((!d)||(i>=d->nAttribute)) return emptyXMLAttribute; return d->pAttribute[i]; }
-XMLCSTR      XMLNode::getAttributeName (int i) const { if ((!d)||(i>=d->nAttribute)) return NULL;              return d->pAttribute[i].lpszName;  }
-XMLCSTR      XMLNode::getAttributeValue(int i) const { if ((!d)||(i>=d->nAttribute)) return NULL;              return d->pAttribute[i].lpszValue; }
-XMLCSTR      XMLNode::getText          (int i) const { if ((!d)||(i>=d->nText     )) return NULL;              return d->pText[i];      }
-XMLNode      XMLNode::getChildNode     (int i) const { if ((!d)||(i>=d->nChild    )) return emptyXMLNode;      return d->pChild[i];     }
-XMLNode      XMLNode::getParentNode    (     ) const { if ((!d)||(!d->pParent     )) return emptyXMLNode;      return XMLNode(d->pParent); }
-char         XMLNode::isDeclaration    (     ) const { if (!d) return 0;             return d->isDeclaration; }
-char         XMLNode::isEmpty          (     ) const { return (d==NULL); }
-XMLNode       XMLNode::emptyNode       (     )       { return XMLNode::emptyXMLNode; }
+XMLCSTR XMLNode::getName() const {
+  if (!d) return NULL;
+  return d->lpszName;
+}
+int XMLNode::nText() const {
+  if (!d) return 0;
+  return d->nText;
+}
+int XMLNode::nChildNode() const {
+  if (!d) return 0;
+  return d->nChild;
+}
+int XMLNode::nAttribute() const {
+  if (!d) return 0;
+  return d->nAttribute;
+}
+int XMLNode::nClear() const {
+  if (!d) return 0;
+  return d->nClear;
+}
+int XMLNode::nElement() const {
+  if (!d) return 0;
+  return d->nAttribute + d->nChild + d->nText + d->nClear;
+}
+XMLClear XMLNode::getClear(int i) const {
+  if ((!d) || (i >= d->nClear)) return emptyXMLClear;
+  return d->pClear[i];
+}
+XMLAttribute XMLNode::getAttribute(int i) const {
+  if ((!d) || (i >= d->nAttribute)) return emptyXMLAttribute;
+  return d->pAttribute[i];
+}
+XMLCSTR XMLNode::getAttributeName(int i) const {
+  if ((!d) || (i >= d->nAttribute)) return NULL;
+  return d->pAttribute[i].lpszName;
+}
+XMLCSTR XMLNode::getAttributeValue(int i) const {
+  if ((!d) || (i >= d->nAttribute)) return NULL;
+  return d->pAttribute[i].lpszValue;
+}
+XMLCSTR XMLNode::getText(int i) const {
+  if ((!d) || (i >= d->nText)) return NULL;
+  return d->pText[i];
+}
+XMLNode XMLNode::getChildNode(int i) const {
+  if ((!d) || (i >= d->nChild)) return emptyXMLNode;
+  return d->pChild[i];
+}
+XMLNode XMLNode::getParentNode() const {
+  if ((!d) || (!d->pParent)) return emptyXMLNode;
+  return XMLNode(d->pParent);
+}
+char XMLNode::isDeclaration() const {
+  if (!d) return 0;
+  return d->isDeclaration;
+}
+char XMLNode::isEmpty() const { return (d == NULL); }
+XMLNode XMLNode::emptyNode() { return XMLNode::emptyXMLNode; }
 
-XMLNode       XMLNode::addChild(XMLCSTR lpszName, char isDeclaration, XMLElementPosition pos)
-              { return addChild_priv(0,stringDup(lpszName),isDeclaration,pos); }
-XMLNode       XMLNode::addChild_WOSD(XMLSTR lpszName, char isDeclaration, XMLElementPosition pos)
-              { return addChild_priv(0,lpszName,isDeclaration,pos); }
-XMLAttribute *XMLNode::addAttribute(XMLCSTR lpszName, XMLCSTR lpszValue)
-              { return addAttribute_priv(0,stringDup(lpszName),stringDup(lpszValue)); }
-XMLAttribute *XMLNode::addAttribute_WOSD(XMLSTR lpszName, XMLSTR lpszValuev)
-              { return addAttribute_priv(0,lpszName,lpszValuev); }
-XMLCSTR       XMLNode::addText(XMLCSTR lpszValue, XMLElementPosition pos)
-              { return addText_priv(0,stringDup(lpszValue),pos); }
-XMLCSTR       XMLNode::addText_WOSD(XMLSTR lpszValue, XMLElementPosition pos)
-              { return addText_priv(0,lpszValue,pos); }
-XMLClear     *XMLNode::addClear(XMLCSTR lpszValue, XMLCSTR lpszOpen, XMLCSTR lpszClose, XMLElementPosition pos)
-              { return addClear_priv(0,stringDup(lpszValue),lpszOpen,lpszClose,pos); }
-XMLClear     *XMLNode::addClear_WOSD(XMLSTR lpszValue, XMLCSTR lpszOpen, XMLCSTR lpszClose, XMLElementPosition pos)
-              { return addClear_priv(0,lpszValue,lpszOpen,lpszClose,pos); }
-XMLCSTR       XMLNode::updateName(XMLCSTR lpszName)
-              { return updateName_WOSD(stringDup(lpszName)); }
-XMLAttribute *XMLNode::updateAttribute(XMLAttribute *newAttribute, XMLAttribute *oldAttribute)
-              { return updateAttribute_WOSD(stringDup(newAttribute->lpszValue),stringDup(newAttribute->lpszName),oldAttribute->lpszName); }
-XMLAttribute *XMLNode::updateAttribute(XMLCSTR lpszNewValue, XMLCSTR lpszNewName,int i)
-              { return updateAttribute_WOSD(stringDup(lpszNewValue),stringDup(lpszNewName),i); }
-XMLAttribute *XMLNode::updateAttribute(XMLCSTR lpszNewValue, XMLCSTR lpszNewName,XMLCSTR lpszOldName)
-              { return updateAttribute_WOSD(stringDup(lpszNewValue),stringDup(lpszNewName),lpszOldName); }
-XMLCSTR       XMLNode::updateText(XMLCSTR lpszNewValue, int i)
-              { return updateText_WOSD(stringDup(lpszNewValue),i); }
-XMLCSTR       XMLNode::updateText(XMLCSTR lpszNewValue, XMLCSTR lpszOldValue)
-              { return updateText_WOSD(stringDup(lpszNewValue),lpszOldValue); }
-XMLClear     *XMLNode::updateClear(XMLCSTR lpszNewContent, int i)
-              { return updateClear_WOSD(stringDup(lpszNewContent),i); }
-XMLClear     *XMLNode::updateClear(XMLCSTR lpszNewValue, XMLCSTR lpszOldValue)
-              { return updateClear_WOSD(stringDup(lpszNewValue),lpszOldValue); }
-XMLClear     *XMLNode::updateClear(XMLClear *newP,XMLClear *oldP)
-              { return updateClear_WOSD(stringDup(newP->lpszValue),oldP->lpszValue); }
+XMLNode XMLNode::addChild(XMLCSTR lpszName, char isDeclaration,
+                          XMLElementPosition pos) {
+  return addChild_priv(0, stringDup(lpszName), isDeclaration, pos);
+}
+XMLNode XMLNode::addChild_WOSD(XMLSTR lpszName, char isDeclaration,
+                               XMLElementPosition pos) {
+  return addChild_priv(0, lpszName, isDeclaration, pos);
+}
+XMLAttribute *XMLNode::addAttribute(XMLCSTR lpszName, XMLCSTR lpszValue) {
+  return addAttribute_priv(0, stringDup(lpszName), stringDup(lpszValue));
+}
+XMLAttribute *XMLNode::addAttribute_WOSD(XMLSTR lpszName, XMLSTR lpszValuev) {
+  return addAttribute_priv(0, lpszName, lpszValuev);
+}
+XMLCSTR XMLNode::addText(XMLCSTR lpszValue, XMLElementPosition pos) {
+  return addText_priv(0, stringDup(lpszValue), pos);
+}
+XMLCSTR XMLNode::addText_WOSD(XMLSTR lpszValue, XMLElementPosition pos) {
+  return addText_priv(0, lpszValue, pos);
+}
+XMLClear *XMLNode::addClear(XMLCSTR lpszValue, XMLCSTR lpszOpen,
+                            XMLCSTR lpszClose, XMLElementPosition pos) {
+  return addClear_priv(0, stringDup(lpszValue), lpszOpen, lpszClose, pos);
+}
+XMLClear *XMLNode::addClear_WOSD(XMLSTR lpszValue, XMLCSTR lpszOpen,
+                                 XMLCSTR lpszClose, XMLElementPosition pos) {
+  return addClear_priv(0, lpszValue, lpszOpen, lpszClose, pos);
+}
+XMLCSTR XMLNode::updateName(XMLCSTR lpszName) {
+  return updateName_WOSD(stringDup(lpszName));
+}
+XMLAttribute *XMLNode::updateAttribute(XMLAttribute *newAttribute,
+                                       XMLAttribute *oldAttribute) {
+  return updateAttribute_WOSD(stringDup(newAttribute->lpszValue),
+                              stringDup(newAttribute->lpszName),
+                              oldAttribute->lpszName);
+}
+XMLAttribute *XMLNode::updateAttribute(XMLCSTR lpszNewValue,
+                                       XMLCSTR lpszNewName, int i) {
+  return updateAttribute_WOSD(stringDup(lpszNewValue), stringDup(lpszNewName),
+                              i);
+}
+XMLAttribute *XMLNode::updateAttribute(XMLCSTR lpszNewValue,
+                                       XMLCSTR lpszNewName,
+                                       XMLCSTR lpszOldName) {
+  return updateAttribute_WOSD(stringDup(lpszNewValue), stringDup(lpszNewName),
+                              lpszOldName);
+}
+XMLCSTR XMLNode::updateText(XMLCSTR lpszNewValue, int i) {
+  return updateText_WOSD(stringDup(lpszNewValue), i);
+}
+XMLCSTR XMLNode::updateText(XMLCSTR lpszNewValue, XMLCSTR lpszOldValue) {
+  return updateText_WOSD(stringDup(lpszNewValue), lpszOldValue);
+}
+XMLClear *XMLNode::updateClear(XMLCSTR lpszNewContent, int i) {
+  return updateClear_WOSD(stringDup(lpszNewContent), i);
+}
+XMLClear *XMLNode::updateClear(XMLCSTR lpszNewValue, XMLCSTR lpszOldValue) {
+  return updateClear_WOSD(stringDup(lpszNewValue), lpszOldValue);
+}
+XMLClear *XMLNode::updateClear(XMLClear *newP, XMLClear *oldP) {
+  return updateClear_WOSD(stringDup(newP->lpszValue), oldP->lpszValue);
+}
 
-char XMLNode::setGlobalOptions(XMLCharEncoding _characterEncoding, char _guessWideCharChars,
-                               char _dropWhiteSpace, char _removeCommentsInMiddleOfText)
-{
-    guessWideCharChars=_guessWideCharChars; dropWhiteSpace=_dropWhiteSpace; removeCommentsInMiddleOfText=_removeCommentsInMiddleOfText;
+char XMLNode::setGlobalOptions(XMLCharEncoding _characterEncoding,
+                               char _guessWideCharChars, char _dropWhiteSpace,
+                               char _removeCommentsInMiddleOfText) {
+  guessWideCharChars = _guessWideCharChars;
+  dropWhiteSpace = _dropWhiteSpace;
+  removeCommentsInMiddleOfText = _removeCommentsInMiddleOfText;
 #ifdef _XMLWIDECHAR
-    if (_characterEncoding) characterEncoding=_characterEncoding;
+  if (_characterEncoding) characterEncoding = _characterEncoding;
 #else
-    switch(_characterEncoding)
-    {
-    case char_encoding_UTF8:     characterEncoding=_characterEncoding; XML_ByteTable=XML_utf8ByteTable; break;
-    case char_encoding_legacy:   characterEncoding=_characterEncoding; XML_ByteTable=XML_legacyByteTable; break;
-    case char_encoding_ShiftJIS: characterEncoding=_characterEncoding; XML_ByteTable=XML_sjisByteTable; break;
-    case char_encoding_GB2312:   characterEncoding=_characterEncoding; XML_ByteTable=XML_gb2312ByteTable; break;
+  switch (_characterEncoding) {
+    case char_encoding_UTF8:
+      characterEncoding = _characterEncoding;
+      XML_ByteTable = XML_utf8ByteTable;
+      break;
+    case char_encoding_legacy:
+      characterEncoding = _characterEncoding;
+      XML_ByteTable = XML_legacyByteTable;
+      break;
+    case char_encoding_ShiftJIS:
+      characterEncoding = _characterEncoding;
+      XML_ByteTable = XML_sjisByteTable;
+      break;
+    case char_encoding_GB2312:
+      characterEncoding = _characterEncoding;
+      XML_ByteTable = XML_gb2312ByteTable;
+      break;
     case char_encoding_Big5:
-    case char_encoding_GBK:      characterEncoding=_characterEncoding; XML_ByteTable=XML_gbk_big5_ByteTable; break;
-    default: return 1;
-    }
+    case char_encoding_GBK:
+      characterEncoding = _characterEncoding;
+      XML_ByteTable = XML_gbk_big5_ByteTable;
+      break;
+    default:
+      return 1;
+  }
 #endif
-    return 0;
+  return 0;
 }
 
-XMLNode::XMLCharEncoding XMLNode::guessCharEncoding(void *buf,int l, char useXMLEncodingAttribute)
-{
+XMLNode::XMLCharEncoding XMLNode::guessCharEncoding(
+    void *buf, int l, char useXMLEncodingAttribute) {
 #ifdef _XMLWIDECHAR
-    return (XMLCharEncoding)0;
+  return (XMLCharEncoding)0;
 #else
-    if (l<25) return (XMLCharEncoding)0;
-    if (guessWideCharChars&&(myIsTextWideChar(buf,l))) return (XMLCharEncoding)0;
-    unsigned char *b=(unsigned char*)buf;
-    if ((b[0]==0xef)&&(b[1]==0xbb)&&(b[2]==0xbf)) return char_encoding_UTF8;
+  if (l < 25) return (XMLCharEncoding)0;
+  if (guessWideCharChars && (myIsTextWideChar(buf, l)))
+    return (XMLCharEncoding)0;
+  unsigned char *b = (unsigned char *)buf;
+  if ((b[0] == 0xef) && (b[1] == 0xbb) && (b[2] == 0xbf))
+    return char_encoding_UTF8;
 
-    // Match utf-8 model ?
-    XMLCharEncoding bestGuess=char_encoding_UTF8;
-    int i=0;
-    while (i<l)
-        switch (XML_utf8ByteTable[b[i]])
-        {
-        case 4: i++; if ((i<l)&&(b[i]& 0xC0)!=0x80) { bestGuess=char_encoding_legacy; i=l; } // 10bbbbbb ?
-        case 3: i++; if ((i<l)&&(b[i]& 0xC0)!=0x80) { bestGuess=char_encoding_legacy; i=l; } // 10bbbbbb ?
-        case 2: i++; if ((i<l)&&(b[i]& 0xC0)!=0x80) { bestGuess=char_encoding_legacy; i=l; } // 10bbbbbb ?
-        case 1: i++; break;
-        case 0: i=l;
-        }
-    if (!useXMLEncodingAttribute) return bestGuess;
-    // if encoding is specified and different from utf-8 than it's non-utf8
-    // otherwise it's utf-8
-    char bb[201];
-    l=mmin(l,200);
-    memcpy(bb,buf,l); // copy buf into bb to be able to do "bb[l]=0"
-    bb[l]=0;
-    b=(unsigned char*)strstr(bb,"encoding");
-    if (!b) return bestGuess;
-    b+=8; while XML_isSPACECHAR(*b) b++; if (*b!='=') return bestGuess;
-    b++;  while XML_isSPACECHAR(*b) b++; if ((*b!='\'')&&(*b!='"')) return bestGuess;
-    b++;  while XML_isSPACECHAR(*b) b++;
-
-    if ((xstrnicmp((char*)b,"utf-8",5)==0)||
-        (xstrnicmp((char*)b,"utf8",4)==0))
-    {
-        if (bestGuess==char_encoding_legacy) return char_encoding_error;
-        return char_encoding_UTF8;
+  // Match utf-8 model ?
+  XMLCharEncoding bestGuess = char_encoding_UTF8;
+  int i = 0;
+  while (i < l) switch (XML_utf8ByteTable[b[i]]) {
+      case 4:
+        i++;
+        if ((i < l) && (b[i] & 0xC0) != 0x80) {
+          bestGuess = char_encoding_legacy;
+          i = l;
+        }  // 10bbbbbb ?
+      case 3:
+        i++;
+        if ((i < l) && (b[i] & 0xC0) != 0x80) {
+          bestGuess = char_encoding_legacy;
+          i = l;
+        }  // 10bbbbbb ?
+      case 2:
+        i++;
+        if ((i < l) && (b[i] & 0xC0) != 0x80) {
+          bestGuess = char_encoding_legacy;
+          i = l;
+        }  // 10bbbbbb ?
+      case 1:
+        i++;
+        break;
+      case 0:
+        i = l;
     }
+  if (!useXMLEncodingAttribute) return bestGuess;
+  // if encoding is specified and different from utf-8 than it's non-utf8
+  // otherwise it's utf-8
+  char bb[201];
+  l = mmin(l, 200);
+  memcpy(bb, buf, l);  // copy buf into bb to be able to do "bb[l]=0"
+  bb[l] = 0;
+  b = (unsigned char *)strstr(bb, "encoding");
+  if (!b) return bestGuess;
+  b += 8;
+  while
+    XML_isSPACECHAR(*b) b++;
+  if (*b != '=') return bestGuess;
+  b++;
+  while
+    XML_isSPACECHAR(*b) b++;
+  if ((*b != '\'') && (*b != '"')) return bestGuess;
+  b++;
+  while
+    XML_isSPACECHAR(*b) b++;
 
-    if ((xstrnicmp((char*)b,"shiftjis",8)==0)||
-        (xstrnicmp((char*)b,"shift-jis",9)==0)||
-        (xstrnicmp((char*)b,"sjis",4)==0)) return char_encoding_ShiftJIS;
+  if ((xstrnicmp((char *)b, "utf-8", 5) == 0) ||
+      (xstrnicmp((char *)b, "utf8", 4) == 0)) {
+    if (bestGuess == char_encoding_legacy) return char_encoding_error;
+    return char_encoding_UTF8;
+  }
 
-    if (xstrnicmp((char*)b,"GB2312",6)==0) return char_encoding_GB2312;
-    if (xstrnicmp((char*)b,"Big5",4)==0) return char_encoding_Big5;
-    if (xstrnicmp((char*)b,"GBK",3)==0) return char_encoding_GBK;
+  if ((xstrnicmp((char *)b, "shiftjis", 8) == 0) ||
+      (xstrnicmp((char *)b, "shift-jis", 9) == 0) ||
+      (xstrnicmp((char *)b, "sjis", 4) == 0))
+    return char_encoding_ShiftJIS;
 
-    return char_encoding_legacy;
+  if (xstrnicmp((char *)b, "GB2312", 6) == 0) return char_encoding_GB2312;
+  if (xstrnicmp((char *)b, "Big5", 4) == 0) return char_encoding_Big5;
+  if (xstrnicmp((char *)b, "GBK", 3) == 0) return char_encoding_GBK;
+
+  return char_encoding_legacy;
 #endif
 }
 #undef XML_isSPACECHAR
@@ -2724,167 +3185,228 @@ XMLNode::XMLCharEncoding XMLNode::guessCharEncoding(void *buf,int l, char useXML
 //      Here starts the base64 conversion functions.    //
 //////////////////////////////////////////////////////////
 
-static const char base64Fillchar = _CXML('='); // used to mark partial words at the end
+static const char base64Fillchar =
+    _CXML('=');  // used to mark partial words at the end
 
 // this lookup table defines the base64 encoding
-XMLCSTR base64EncodeTable=_CXML("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/");
+XMLCSTR base64EncodeTable =
+    _CXML("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/");
 
-// Decode Table gives the index of any valid base64 character in the Base64 table]
-// 96: '='  -   97: space char   -   98: illegal char   -   99: end of string
+// Decode Table gives the index of any valid base64 character in the Base64
+// table] 96: '='  -   97: space char   -   98: illegal char   -   99: end of
+// string
 const unsigned char base64DecodeTable[] = {
-    99,98,98,98,98,98,98,98,98,97,  97,98,98,97,98,98,98,98,98,98,  98,98,98,98,98,98,98,98,98,98,  //00 -29
-    98,98,97,98,98,98,98,98,98,98,  98,98,98,62,98,98,98,63,52,53,  54,55,56,57,58,59,60,61,98,98,  //30 -59
-    98,96,98,98,98, 0, 1, 2, 3, 4,   5, 6, 7, 8, 9,10,11,12,13,14,  15,16,17,18,19,20,21,22,23,24,  //60 -89
-    25,98,98,98,98,98,98,26,27,28,  29,30,31,32,33,34,35,36,37,38,  39,40,41,42,43,44,45,46,47,48,  //90 -119
-    49,50,51,98,98,98,98,98,98,98,  98,98,98,98,98,98,98,98,98,98,  98,98,98,98,98,98,98,98,98,98,  //120 -149
-    98,98,98,98,98,98,98,98,98,98,  98,98,98,98,98,98,98,98,98,98,  98,98,98,98,98,98,98,98,98,98,  //150 -179
-    98,98,98,98,98,98,98,98,98,98,  98,98,98,98,98,98,98,98,98,98,  98,98,98,98,98,98,98,98,98,98,  //180 -209
-    98,98,98,98,98,98,98,98,98,98,  98,98,98,98,98,98,98,98,98,98,  98,98,98,98,98,98,98,98,98,98,  //210 -239
-    98,98,98,98,98,98,98,98,98,98,  98,98,98,98,98,98                                               //240 -255
+    99, 98, 98, 98, 98, 98, 98, 98, 98, 97, 97, 98, 98, 97, 98, 98,
+    98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98,  // 00 -29
+    98, 98, 97, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 62, 98, 98,
+    98, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 98, 98,  // 30 -59
+    98, 96, 98, 98, 98, 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
+    11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,  // 60 -89
+    25, 98, 98, 98, 98, 98, 98, 26, 27, 28, 29, 30, 31, 32, 33, 34,
+    35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,  // 90 -119
+    49, 50, 51, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98,
+    98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98,  // 120 -149
+    98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98,
+    98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98,  // 150 -179
+    98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98,
+    98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98,  // 180 -209
+    98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98,
+    98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98,         // 210 -239
+    98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98  // 240 -255
 };
 
-XMLParserBase64Tool::~XMLParserBase64Tool(){ freeBuffer(); }
+XMLParserBase64Tool::~XMLParserBase64Tool() { freeBuffer(); }
 
-void XMLParserBase64Tool::freeBuffer(){ if (buf) free(buf); buf=NULL; buflen=0; }
-
-int XMLParserBase64Tool::encodeLength(int inlen, char formatted)
-{
-    unsigned int i=((inlen-1)/3*4+4+1);
-    if (formatted) i+=inlen/54;
-    return i;
+void XMLParserBase64Tool::freeBuffer() {
+  if (buf) free(buf);
+  buf = NULL;
+  buflen = 0;
 }
 
-XMLSTR XMLParserBase64Tool::encode(unsigned char *inbuf, unsigned int inlen, char formatted)
-{
-    int i=encodeLength(inlen,formatted),k=17,eLen=inlen/3,j;
-    alloc(i*sizeof(XMLCHAR));
-    XMLSTR curr=(XMLSTR)buf;
-    for(i=0;i<eLen;i++)
-    {
-        // Copy next three bytes into lower 24 bits of int, paying attention to sign.
-        j=(inbuf[0]<<16)|(inbuf[1]<<8)|inbuf[2]; inbuf+=3;
-        // Encode the int into four chars
-        *(curr++)=base64EncodeTable[ j>>18      ];
-        *(curr++)=base64EncodeTable[(j>>12)&0x3f];
-        *(curr++)=base64EncodeTable[(j>> 6)&0x3f];
-        *(curr++)=base64EncodeTable[(j    )&0x3f];
-        if (formatted) { if (!k) { *(curr++)=_CXML('\n'); k=18; } k--; }
-    }
-    eLen=inlen-eLen*3; // 0 - 2.
-    if (eLen==1)
-    {
-        *(curr++)=base64EncodeTable[ inbuf[0]>>2      ];
-        *(curr++)=base64EncodeTable[(inbuf[0]<<4)&0x3F];
-        *(curr++)=base64Fillchar;
-        *(curr++)=base64Fillchar;
-    } else if (eLen==2)
-    {
-        j=(inbuf[0]<<8)|inbuf[1];
-        *(curr++)=base64EncodeTable[ j>>10      ];
-        *(curr++)=base64EncodeTable[(j>> 4)&0x3f];
-        *(curr++)=base64EncodeTable[(j<< 2)&0x3f];
-        *(curr++)=base64Fillchar;
-    }
-    *(curr++)=0;
-    return (XMLSTR)buf;
+int XMLParserBase64Tool::encodeLength(int inlen, char formatted) {
+  unsigned int i = ((inlen - 1) / 3 * 4 + 4 + 1);
+  if (formatted) i += inlen / 54;
+  return i;
 }
 
-unsigned int XMLParserBase64Tool::decodeSize(XMLCSTR data,XMLError *xe)
-{
-     if (xe) *xe=eXMLErrorNone;
-    int size=0;
-    unsigned char c;
-    //skip any extra characters (e.g. newlines or spaces)
-    while (*data)
-    {
+XMLSTR XMLParserBase64Tool::encode(unsigned char *inbuf, unsigned int inlen,
+                                   char formatted) {
+  int i = encodeLength(inlen, formatted), k = 17, eLen = inlen / 3, j;
+  alloc(i * sizeof(XMLCHAR));
+  XMLSTR curr = (XMLSTR)buf;
+  for (i = 0; i < eLen; i++) {
+    // Copy next three bytes into lower 24 bits of int, paying attention to
+    // sign.
+    j = (inbuf[0] << 16) | (inbuf[1] << 8) | inbuf[2];
+    inbuf += 3;
+    // Encode the int into four chars
+    *(curr++) = base64EncodeTable[j >> 18];
+    *(curr++) = base64EncodeTable[(j >> 12) & 0x3f];
+    *(curr++) = base64EncodeTable[(j >> 6) & 0x3f];
+    *(curr++) = base64EncodeTable[(j)&0x3f];
+    if (formatted) {
+      if (!k) {
+        *(curr++) = _CXML('\n');
+        k = 18;
+      }
+      k--;
+    }
+  }
+  eLen = inlen - eLen * 3;  // 0 - 2.
+  if (eLen == 1) {
+    *(curr++) = base64EncodeTable[inbuf[0] >> 2];
+    *(curr++) = base64EncodeTable[(inbuf[0] << 4) & 0x3F];
+    *(curr++) = base64Fillchar;
+    *(curr++) = base64Fillchar;
+  } else if (eLen == 2) {
+    j = (inbuf[0] << 8) | inbuf[1];
+    *(curr++) = base64EncodeTable[j >> 10];
+    *(curr++) = base64EncodeTable[(j >> 4) & 0x3f];
+    *(curr++) = base64EncodeTable[(j << 2) & 0x3f];
+    *(curr++) = base64Fillchar;
+  }
+  *(curr++) = 0;
+  return (XMLSTR)buf;
+}
+
+unsigned int XMLParserBase64Tool::decodeSize(XMLCSTR data, XMLError *xe) {
+  if (xe) *xe = eXMLErrorNone;
+  int size = 0;
+  unsigned char c;
+  // skip any extra characters (e.g. newlines or spaces)
+  while (*data) {
 #ifdef _XMLWIDECHAR
-        if (*data>255) { if (xe) *xe=eXMLErrorBase64DecodeIllegalCharacter; return 0; }
+    if (*data > 255) {
+      if (xe) *xe = eXMLErrorBase64DecodeIllegalCharacter;
+      return 0;
+    }
 #endif
-        c=base64DecodeTable[(unsigned char)(*data)];
-        if (c<97) size++;
-        else if (c==98) { if (xe) *xe=eXMLErrorBase64DecodeIllegalCharacter; return 0; }
-        data++;
+    c = base64DecodeTable[(unsigned char)(*data)];
+    if (c < 97)
+      size++;
+    else if (c == 98) {
+      if (xe) *xe = eXMLErrorBase64DecodeIllegalCharacter;
+      return 0;
     }
-    if (xe&&(size%4!=0)) *xe=eXMLErrorBase64DataSizeIsNotMultipleOf4;
-    if (size==0) return 0;
-    do { data--; size--; } while(*data==base64Fillchar); size++;
-    return (unsigned int)((size*3)/4);
+    data++;
+  }
+  if (xe && (size % 4 != 0)) *xe = eXMLErrorBase64DataSizeIsNotMultipleOf4;
+  if (size == 0) return 0;
+  do {
+    data--;
+    size--;
+  } while (*data == base64Fillchar);
+  size++;
+  return (unsigned int)((size * 3) / 4);
 }
 
-unsigned char XMLParserBase64Tool::decode(XMLCSTR data, unsigned char *buf, int len, XMLError *xe)
-{
-    if (xe) *xe=eXMLErrorNone;
-    int i=0,p=0;
-    unsigned char d,c;
-    for(;;)
-    {
-
+unsigned char XMLParserBase64Tool::decode(XMLCSTR data, unsigned char *buf,
+                                          int len, XMLError *xe) {
+  if (xe) *xe = eXMLErrorNone;
+  int i = 0, p = 0;
+  unsigned char d, c;
+  for (;;) {
 #ifdef _XMLWIDECHAR
-#define BASE64DECODE_READ_NEXT_CHAR(c)                                              \
-        do {                                                                        \
-            if (data[i]>255){ c=98; break; }                                        \
-            c=base64DecodeTable[(unsigned char)data[i++]];                       \
-        }while (c==97);                                                             \
-        if(c==98){ if(xe)*xe=eXMLErrorBase64DecodeIllegalCharacter; return 0; }
+#define BASE64DECODE_READ_NEXT_CHAR(c)                   \
+  do {                                                   \
+    if (data[i] > 255) {                                 \
+      c = 98;                                            \
+      break;                                             \
+    }                                                    \
+    c = base64DecodeTable[(unsigned char)data[i++]];     \
+  } while (c == 97);                                     \
+  if (c == 98) {                                         \
+    if (xe) *xe = eXMLErrorBase64DecodeIllegalCharacter; \
+    return 0;                                            \
+  }
 #else
-#define BASE64DECODE_READ_NEXT_CHAR(c)                                           \
-        do { c=base64DecodeTable[(unsigned char)data[i++]]; }while (c==97);   \
-        if(c==98){ if(xe)*xe=eXMLErrorBase64DecodeIllegalCharacter; return 0; }
+#define BASE64DECODE_READ_NEXT_CHAR(c)                   \
+  do {                                                   \
+    c = base64DecodeTable[(unsigned char)data[i++]];     \
+  } while (c == 97);                                     \
+  if (c == 98) {                                         \
+    if (xe) *xe = eXMLErrorBase64DecodeIllegalCharacter; \
+    return 0;                                            \
+  }
 #endif
 
-        BASE64DECODE_READ_NEXT_CHAR(c)
-        if (c==99) { return 2; }
-        if (c==96)
-        {
-            if (p==(int)len) return 2;
-            if (xe) *xe=eXMLErrorBase64DecodeTruncatedData;
-            return 1;
-        }
-
-        BASE64DECODE_READ_NEXT_CHAR(d)
-        if ((d==99)||(d==96)) { if (xe) *xe=eXMLErrorBase64DecodeTruncatedData;  return 1; }
-        if (p==(int)len) {      if (xe) *xe=eXMLErrorBase64DecodeBufferTooSmall; return 0; }
-        buf[p++]=(unsigned char)((c<<2)|((d>>4)&0x3));
-
-        BASE64DECODE_READ_NEXT_CHAR(c)
-        if (c==99) { if (xe) *xe=eXMLErrorBase64DecodeTruncatedData;  return 1; }
-        if (p==(int)len)
-        {
-            if (c==96) return 2;
-            if (xe) *xe=eXMLErrorBase64DecodeBufferTooSmall;
-            return 0;
-        }
-        if (c==96) { if (xe) *xe=eXMLErrorBase64DecodeTruncatedData;  return 1; }
-        buf[p++]=(unsigned char)(((d<<4)&0xf0)|((c>>2)&0xf));
-
-        BASE64DECODE_READ_NEXT_CHAR(d)
-        if (d==99 ) { if (xe) *xe=eXMLErrorBase64DecodeTruncatedData;  return 1; }
-        if (p==(int)len)
-        {
-            if (d==96) return 2;
-            if (xe) *xe=eXMLErrorBase64DecodeBufferTooSmall;
-            return 0;
-        }
-        if (d==96) { if (xe) *xe=eXMLErrorBase64DecodeTruncatedData;  return 1; }
-        buf[p++]=(unsigned char)(((c<<6)&0xc0)|d);
+    BASE64DECODE_READ_NEXT_CHAR(c)
+    if (c == 99) {
+      return 2;
     }
+    if (c == 96) {
+      if (p == (int)len) return 2;
+      if (xe) *xe = eXMLErrorBase64DecodeTruncatedData;
+      return 1;
+    }
+
+    BASE64DECODE_READ_NEXT_CHAR(d)
+    if ((d == 99) || (d == 96)) {
+      if (xe) *xe = eXMLErrorBase64DecodeTruncatedData;
+      return 1;
+    }
+    if (p == (int)len) {
+      if (xe) *xe = eXMLErrorBase64DecodeBufferTooSmall;
+      return 0;
+    }
+    buf[p++] = (unsigned char)((c << 2) | ((d >> 4) & 0x3));
+
+    BASE64DECODE_READ_NEXT_CHAR(c)
+    if (c == 99) {
+      if (xe) *xe = eXMLErrorBase64DecodeTruncatedData;
+      return 1;
+    }
+    if (p == (int)len) {
+      if (c == 96) return 2;
+      if (xe) *xe = eXMLErrorBase64DecodeBufferTooSmall;
+      return 0;
+    }
+    if (c == 96) {
+      if (xe) *xe = eXMLErrorBase64DecodeTruncatedData;
+      return 1;
+    }
+    buf[p++] = (unsigned char)(((d << 4) & 0xf0) | ((c >> 2) & 0xf));
+
+    BASE64DECODE_READ_NEXT_CHAR(d)
+    if (d == 99) {
+      if (xe) *xe = eXMLErrorBase64DecodeTruncatedData;
+      return 1;
+    }
+    if (p == (int)len) {
+      if (d == 96) return 2;
+      if (xe) *xe = eXMLErrorBase64DecodeBufferTooSmall;
+      return 0;
+    }
+    if (d == 96) {
+      if (xe) *xe = eXMLErrorBase64DecodeTruncatedData;
+      return 1;
+    }
+    buf[p++] = (unsigned char)(((c << 6) & 0xc0) | d);
+  }
 }
 #undef BASE64DECODE_READ_NEXT_CHAR
 
-void XMLParserBase64Tool::alloc(int newsize)
-{
-    if ((!buf)&&(newsize)) { buf=malloc(newsize); buflen=newsize; return; }
-    if (newsize>buflen) { buf=realloc(buf,newsize); buflen=newsize; }
+void XMLParserBase64Tool::alloc(int newsize) {
+  if ((!buf) && (newsize)) {
+    buf = malloc(newsize);
+    buflen = newsize;
+    return;
+  }
+  if (newsize > buflen) {
+    buf = realloc(buf, newsize);
+    buflen = newsize;
+  }
 }
 
-unsigned char *XMLParserBase64Tool::decode(XMLCSTR data, int *outlen, XMLError *xe)
-{
-    if (xe) *xe=eXMLErrorNone;
-    unsigned int len=decodeSize(data,xe);
-    if (outlen) *outlen=len;
-    if (!len) return NULL;
-    alloc(len+1);
-    if(!decode(data,(unsigned char*)buf,len,xe)){ return NULL; }
-    return (unsigned char*)buf;
+unsigned char *XMLParserBase64Tool::decode(XMLCSTR data, int *outlen,
+                                           XMLError *xe) {
+  if (xe) *xe = eXMLErrorNone;
+  unsigned int len = decodeSize(data, xe);
+  if (outlen) *outlen = len;
+  if (!len) return NULL;
+  alloc(len + 1);
+  if (!decode(data, (unsigned char *)buf, len, xe)) {
+    return NULL;
+  }
+  return (unsigned char *)buf;
 }
-

--- a/src/gpuwattch/xmlParser.cc
+++ b/src/gpuwattch/xmlParser.cc
@@ -765,9 +765,9 @@ static const char XML_gbk_big5_ByteTable[256] = {
     2, 2, 2, 2, 2, 2, 2, 2,
     2, 2, 2, 2, 2, 2, 2, 1  // 0xf0
 };
-static const char *XML_ByteTable = (const char *)
-    XML_utf8ByteTable;  // the default is
-                        // "characterEncoding=XMLNode::encoding_UTF8"
+static const char *XML_ByteTable =
+    (const char *)XML_utf8ByteTable;  // the default is
+// "characterEncoding=XMLNode::encoding_UTF8"
 #endif
 
 XMLNode XMLNode::emptyXMLNode;

--- a/src/gpuwattch/xmlParser.cc
+++ b/src/gpuwattch/xmlParser.cc
@@ -765,9 +765,9 @@ static const char XML_gbk_big5_ByteTable[256] = {
     2, 2, 2, 2, 2, 2, 2, 2,
     2, 2, 2, 2, 2, 2, 2, 1  // 0xf0
 };
-static const char *XML_ByteTable =
-    (const char *)XML_utf8ByteTable;  // the default is
-// "characterEncoding=XMLNode::encoding_UTF8"
+static const char *XML_ByteTable = (const char *)
+    XML_utf8ByteTable;  // the default is
+                        // "characterEncoding=XMLNode::encoding_UTF8"
 #endif
 
 XMLNode XMLNode::emptyXMLNode;

--- a/src/gpuwattch/xmlParser.cc
+++ b/src/gpuwattch/xmlParser.cc
@@ -37,26 +37,22 @@
  *
  * NOTE:
  *
- *   If you add "#define _XMLPARSER_NO_MESSAGEBOX_" on the first line of this
- *file
+ *   If you add "#define _XMLPARSER_NO_MESSAGEBOX_" on the first line of this file
  *   the "openFileHelper" function will always display error messages inside the
  *   console instead of inside a message-box-window. Message-box-windows are
  *   available on windows 9x/NT/2000/XP/Vista only.
  *
- * The following license terms for the "XMLParser library from Business-Insight"
- *apply to projects
+ * The following license terms for the "XMLParser library from Business-Insight" apply to projects
  * that are in some way related to
  * the "mcpat project", including applications
  * using "mcpat project" and tools developed
  * for enhancing "mcpat project". All other projects
- * (not related to "mcpat project") have to use the "XMLParser library from
- *Business-Insight"
+ * (not related to "mcpat project") have to use the "XMLParser library from Business-Insight"
  * code under the Aladdin Free Public License (AFPL)
  * See the file "AFPL-license.txt" for more informations about the AFPL license.
  * (see http://www.artifex.com/downloads/doc/Public.htm for detailed AFPL terms)
  *
- * Redistribution and use of the "XMLParser library from Business-Insight" in
- *source and binary forms, with or without
+ * Redistribution and use of the "XMLParser library from Business-Insight" in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
  *       notice, this list of conditions and the following disclaimer.
@@ -94,359 +90,266 @@
 //#include <crtdbg.h>
 //#endif
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>  // to have IsTextUnicode, MultiByteToWideChar, WideCharToMultiByte to handle unicode files
-// to have "MessageBoxA" to display error messages for openFilHelper
+#include <Windows.h> // to have IsTextUnicode, MultiByteToWideChar, WideCharToMultiByte to handle unicode files
+                     // to have "MessageBoxA" to display error messages for openFilHelper
 #endif
 
-#include <assert.h>
 #include <memory.h>
+#include <assert.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
+#include <stdlib.h>
 
 XMLCSTR XMLNode::getVersion() { return _CXML("v2.39"); }
-void freeXMLString(XMLSTR t) {
-  if (t) free(t);
-}
+void freeXMLString(XMLSTR t){if(t)free(t);}
 
-static XMLNode::XMLCharEncoding characterEncoding = XMLNode::char_encoding_UTF8;
-static char guessWideCharChars = 1, dropWhiteSpace = 1,
-            removeCommentsInMiddleOfText = 1;
+static XMLNode::XMLCharEncoding characterEncoding=XMLNode::char_encoding_UTF8;
+static char guessWideCharChars=1, dropWhiteSpace=1, removeCommentsInMiddleOfText=1;
 
-inline int mmin(const int t1, const int t2) { return t1 < t2 ? t1 : t2; }
+inline int mmin( const int t1, const int t2 ) { return t1 < t2 ? t1 : t2; }
 
 // You can modify the initialization of the variable "XMLClearTags" below
 // to change the clearTags that are currently recognized by the library.
 // The number on the second columns is the length of the string inside the
 // first column. The "<!DOCTYPE" declaration must be the second in the list.
 // The "<!--" declaration must be the third in the list.
-typedef struct {
-  XMLCSTR lpszOpen;
-  int openTagLen;
-  XMLCSTR lpszClose;
-} ALLXMLClearTag;
-static ALLXMLClearTag XMLClearTags[] = {
-    {_CXML("<![CDATA["), 9, _CXML("]]>")},
-    {_CXML("<!DOCTYPE"), 9, _CXML(">")},
-    {_CXML("<!--"), 4, _CXML("-->")},
-    {_CXML("<PRE>"), 5, _CXML("</PRE>")},
-    //  {    _CXML("<Script>") ,8,  _CXML("</Script>")},
-    {NULL, 0, NULL}};
+typedef struct { XMLCSTR lpszOpen; int openTagLen; XMLCSTR lpszClose;} ALLXMLClearTag;
+static ALLXMLClearTag XMLClearTags[] =
+{
+    {    _CXML("<![CDATA["),9,  _CXML("]]>")      },
+    {    _CXML("<!DOCTYPE"),9,  _CXML(">")        },
+    {    _CXML("<!--")     ,4,  _CXML("-->")      },
+    {    _CXML("<PRE>")    ,5,  _CXML("</PRE>")   },
+//  {    _CXML("<Script>") ,8,  _CXML("</Script>")},
+    {    NULL              ,0,  NULL           }
+};
 
 // You can modify the initialization of the variable "XMLEntities" below
-// to change the character entities that are currently recognized by the
-// library.
+// to change the character entities that are currently recognized by the library.
 // The number on the second columns is the length of the string inside the
-// first column. Additionally, the syntaxes "&#xA0;" and "&#160;" are
-// recognized.
-typedef struct {
-  XMLCSTR s;
-  int l;
-  XMLCHAR c;
-} XMLCharacterEntity;
-static XMLCharacterEntity XMLEntities[] = {
-    {_CXML("&amp;"), 5, _CXML('&')},   {_CXML("&lt;"), 4, _CXML('<')},
-    {_CXML("&gt;"), 4, _CXML('>')},    {_CXML("&quot;"), 6, _CXML('\"')},
-    {_CXML("&apos;"), 6, _CXML('\'')}, {NULL, 0, '\0'}};
+// first column. Additionally, the syntaxes "&#xA0;" and "&#160;" are recognized.
+typedef struct { XMLCSTR s; int l; XMLCHAR c;} XMLCharacterEntity;
+static XMLCharacterEntity XMLEntities[] =
+{
+    { _CXML("&amp;" ), 5, _CXML('&' )},
+    { _CXML("&lt;"  ), 4, _CXML('<' )},
+    { _CXML("&gt;"  ), 4, _CXML('>' )},
+    { _CXML("&quot;"), 6, _CXML('\"')},
+    { _CXML("&apos;"), 6, _CXML('\'')},
+    { NULL           , 0, '\0'    }
+};
 
-// When rendering the XMLNode to a string (using the "createXMLString"
-// function),
+// When rendering the XMLNode to a string (using the "createXMLString" function),
 // you can ask for a beautiful formatting. This formatting is using the
 // following indentation character:
 #define INDENTCHAR _CXML('\t')
 
 // The following function parses the XML errors into a user friendly string.
-// You can edit this to change the output language of the library to something
-// else.
-XMLCSTR XMLNode::getError(XMLError xerror) {
-  switch (xerror) {
-    case eXMLErrorNone:
-      return _CXML("No error");
-    case eXMLErrorMissingEndTag:
-      return _CXML("Warning: Unmatched end tag");
-    case eXMLErrorNoXMLTagFound:
-      return _CXML("Warning: No XML tag found");
-    case eXMLErrorEmpty:
-      return _CXML("Error: No XML data");
-    case eXMLErrorMissingTagName:
-      return _CXML("Error: Missing start tag name");
-    case eXMLErrorMissingEndTagName:
-      return _CXML("Error: Missing end tag name");
-    case eXMLErrorUnmatchedEndTag:
-      return _CXML("Error: Unmatched end tag");
-    case eXMLErrorUnmatchedEndClearTag:
-      return _CXML("Error: Unmatched clear tag end");
-    case eXMLErrorUnexpectedToken:
-      return _CXML("Error: Unexpected token found");
-    case eXMLErrorNoElements:
-      return _CXML("Error: No elements found");
-    case eXMLErrorFileNotFound:
-      return _CXML("Error: File not found");
-    case eXMLErrorFirstTagNotFound:
-      return _CXML("Error: First Tag not found");
-    case eXMLErrorUnknownCharacterEntity:
-      return _CXML("Error: Unknown character entity");
-    case eXMLErrorCharacterCodeAbove255:
-      return _CXML(
-          "Error: Character code above 255 is forbidden in MultiByte char "
-          "mode.");
-    case eXMLErrorCharConversionError:
-      return _CXML(
-          "Error: unable to convert between WideChar and MultiByte chars");
-    case eXMLErrorCannotOpenWriteFile:
-      return _CXML("Error: unable to open file for writing");
-    case eXMLErrorCannotWriteFile:
-      return _CXML("Error: cannot write into file");
+// You can edit this to change the output language of the library to something else.
+XMLCSTR XMLNode::getError(XMLError xerror)
+{
+    switch (xerror)
+    {
+    case eXMLErrorNone:                  return _CXML("No error");
+    case eXMLErrorMissingEndTag:         return _CXML("Warning: Unmatched end tag");
+    case eXMLErrorNoXMLTagFound:         return _CXML("Warning: No XML tag found");
+    case eXMLErrorEmpty:                 return _CXML("Error: No XML data");
+    case eXMLErrorMissingTagName:        return _CXML("Error: Missing start tag name");
+    case eXMLErrorMissingEndTagName:     return _CXML("Error: Missing end tag name");
+    case eXMLErrorUnmatchedEndTag:       return _CXML("Error: Unmatched end tag");
+    case eXMLErrorUnmatchedEndClearTag:  return _CXML("Error: Unmatched clear tag end");
+    case eXMLErrorUnexpectedToken:       return _CXML("Error: Unexpected token found");
+    case eXMLErrorNoElements:            return _CXML("Error: No elements found");
+    case eXMLErrorFileNotFound:          return _CXML("Error: File not found");
+    case eXMLErrorFirstTagNotFound:      return _CXML("Error: First Tag not found");
+    case eXMLErrorUnknownCharacterEntity:return _CXML("Error: Unknown character entity");
+    case eXMLErrorCharacterCodeAbove255: return _CXML("Error: Character code above 255 is forbidden in MultiByte char mode.");
+    case eXMLErrorCharConversionError:   return _CXML("Error: unable to convert between WideChar and MultiByte chars");
+    case eXMLErrorCannotOpenWriteFile:   return _CXML("Error: unable to open file for writing");
+    case eXMLErrorCannotWriteFile:       return _CXML("Error: cannot write into file");
 
-    case eXMLErrorBase64DataSizeIsNotMultipleOf4:
-      return _CXML("Warning: Base64-string length is not a multiple of 4");
-    case eXMLErrorBase64DecodeTruncatedData:
-      return _CXML("Warning: Base64-string is truncated");
-    case eXMLErrorBase64DecodeIllegalCharacter:
-      return _CXML("Error: Base64-string contains an illegal character");
-    case eXMLErrorBase64DecodeBufferTooSmall:
-      return _CXML("Error: Base64 decode output buffer is too small");
-  };
-  return _CXML("Unknown");
+    case eXMLErrorBase64DataSizeIsNotMultipleOf4: return _CXML("Warning: Base64-string length is not a multiple of 4");
+    case eXMLErrorBase64DecodeTruncatedData:      return _CXML("Warning: Base64-string is truncated");
+    case eXMLErrorBase64DecodeIllegalCharacter:   return _CXML("Error: Base64-string contains an illegal character");
+    case eXMLErrorBase64DecodeBufferTooSmall:     return _CXML("Error: Base64 decode output buffer is too small");
+    };
+    return _CXML("Unknown");
 }
 
 /////////////////////////////////////////////////////////////////////////
 //      Here start the abstraction layer to be OS-independent          //
 /////////////////////////////////////////////////////////////////////////
 
-// Here is an abstraction layer to access some common string manipulation
-// functions.
-// The abstraction layer is currently working for gcc, Microsoft Visual Studio
-// 6.0,
+// Here is an abstraction layer to access some common string manipulation functions.
+// The abstraction layer is currently working for gcc, Microsoft Visual Studio 6.0,
 // Microsoft Visual Studio .NET, CC (sun compiler) and Borland C++.
-// If you plan to "port" the library to a new system/compiler, all you have to
-// do is
+// If you plan to "port" the library to a new system/compiler, all you have to do is
 // to edit the following lines.
 #ifdef XML_NO_WIDE_CHAR
 char myIsTextWideChar(const void *b, int len) { return FALSE; }
 #else
-#if defined(UNDER_CE) || !defined(_XMLWINDOWS)
-char myIsTextWideChar(const void *b,
-                      int len)  // inspired by the Wine API: RtlIsTextUnicode
-{
+    #if defined (UNDER_CE) || !defined(_XMLWINDOWS)
+    char myIsTextWideChar(const void *b, int len) // inspired by the Wine API: RtlIsTextUnicode
+    {
 #ifdef sun
-  // for SPARC processors: wchar_t* buffers must always be alligned, otherwise
-  // it's a char* buffer.
-  if ((((unsigned long)b) % sizeof(wchar_t)) != 0) return FALSE;
+        // for SPARC processors: wchar_t* buffers must always be alligned, otherwise it's a char* buffer.
+        if ((((unsigned long)b)%sizeof(wchar_t))!=0) return FALSE;
 #endif
-  const wchar_t *s = (const wchar_t *)b;
+        const wchar_t *s=(const wchar_t*)b;
 
-  // buffer too small:
-  if (len < (int)sizeof(wchar_t)) return FALSE;
+        // buffer too small:
+        if (len<(int)sizeof(wchar_t)) return FALSE;
 
-  // odd length test
-  if (len & 1) return FALSE;
+        // odd length test
+        if (len&1) return FALSE;
 
-  /* only checks the first 256 characters */
-  len = mmin(256, len / sizeof(wchar_t));
+        /* only checks the first 256 characters */
+        len=mmin(256,len/sizeof(wchar_t));
 
-  // Check for the special byte order:
-  if (*((unsigned short *)s) == 0xFFFE)
-    return TRUE;  // IS_TEXT_UNICODE_REVERSE_SIGNATURE;
-  if (*((unsigned short *)s) == 0xFEFF)
-    return TRUE;  // IS_TEXT_UNICODE_SIGNATURE
+        // Check for the special byte order:
+        if (*((unsigned short*)s) == 0xFFFE) return TRUE;     // IS_TEXT_UNICODE_REVERSE_SIGNATURE;
+        if (*((unsigned short*)s) == 0xFEFF) return TRUE;      // IS_TEXT_UNICODE_SIGNATURE
 
-  // checks for ASCII characters in the UNICODE stream
-  int i, stats = 0;
-  for (i = 0; i < len; i++)
-    if (s[i] <= (unsigned short)255) stats++;
-  if (stats > len / 2) return TRUE;
+        // checks for ASCII characters in the UNICODE stream
+        int i,stats=0;
+        for (i=0; i<len; i++) if (s[i]<=(unsigned short)255) stats++;
+        if (stats>len/2) return TRUE;
 
-  // Check for UNICODE NULL chars
-  for (i = 0; i < len; i++)
-    if (!s[i]) return TRUE;
+        // Check for UNICODE NULL chars
+        for (i=0; i<len; i++) if (!s[i]) return TRUE;
 
-  return FALSE;
-}
-#else
-char myIsTextWideChar(const void *b, int l) {
-  return (char)IsTextUnicode((CONST LPVOID)b, l, NULL);
-};
-#endif
+        return FALSE;
+    }
+    #else
+    char myIsTextWideChar(const void *b,int l) { return (char)IsTextUnicode((CONST LPVOID)b,l,NULL); };
+    #endif
 #endif
 
 #ifdef _XMLWINDOWS
-// for Microsoft Visual Studio 6.0 and Microsoft Visual Studio .NET and Borland
-// C++ Builder 6.0
-#ifdef _XMLWIDECHAR
-wchar_t *myMultiByteToWideChar(const char *s, XMLNode::XMLCharEncoding ce) {
-  int i;
-  if (ce == XMLNode::char_encoding_UTF8)
-    i = (int)MultiByteToWideChar(CP_UTF8, 0, s, -1, NULL, 0);
-  else
-    i = (int)MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, s, -1, NULL, 0);
-  if (i < 0) return NULL;
-  wchar_t *d = (wchar_t *)malloc((i + 1) * sizeof(XMLCHAR));
-  if (ce == XMLNode::char_encoding_UTF8)
-    i = (int)MultiByteToWideChar(CP_UTF8, 0, s, -1, d, i);
-  else
-    i = (int)MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, s, -1, d, i);
-  d[i] = 0;
-  return d;
-}
-static inline FILE *xfopen(XMLCSTR filename, XMLCSTR mode) {
-  return _wfopen(filename, mode);
-}
-static inline int xstrlen(XMLCSTR c) { return (int)wcslen(c); }
-static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) {
-  return _wcsnicmp(c1, c2, l);
-}
-static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) {
-  return wcsncmp(c1, c2, l);
-}
-static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return _wcsicmp(c1, c2); }
-static inline XMLSTR xstrstr(XMLCSTR c1, XMLCSTR c2) {
-  return (XMLSTR)wcsstr(c1, c2);
-}
-static inline XMLSTR xstrcpy(XMLSTR c1, XMLCSTR c2) {
-  return (XMLSTR)wcscpy(c1, c2);
-}
-#else
-char *myWideCharToMultiByte(const wchar_t *s) {
-  UINT codePage = CP_ACP;
-  if (characterEncoding == XMLNode::char_encoding_UTF8) codePage = CP_UTF8;
-  int i = (int)WideCharToMultiByte(codePage,  // code page
-                                   0,         // performance and mapping flags
-                                   s,         // wide-character string
-                                   -1,        // number of chars in string
-                                   NULL,      // buffer for new string
-                                   0,         // size of buffer
-                                   NULL,      // default for unmappable chars
-                                   NULL       // set when default char used
-                                   );
-  if (i < 0) return NULL;
-  char *d = (char *)malloc(i + 1);
-  WideCharToMultiByte(codePage,  // code page
-                      0,         // performance and mapping flags
-                      s,         // wide-character string
-                      -1,        // number of chars in string
-                      d,         // buffer for new string
-                      i,         // size of buffer
-                      NULL,      // default for unmappable chars
-                      NULL       // set when default char used
-                      );
-  d[i] = 0;
-  return d;
-}
-static inline FILE *xfopen(XMLCSTR filename, XMLCSTR mode) {
-  return fopen(filename, mode);
-}
-static inline int xstrlen(XMLCSTR c) { return (int)strlen(c); }
-#ifdef __BORLANDC__
-static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) {
-  return strnicmp(c1, c2, l);
-}
-static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return stricmp(c1, c2); }
-#else
-static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) {
-  return _strnicmp(c1, c2, l);
-}
-static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return _stricmp(c1, c2); }
-#endif
-static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) {
-  return strncmp(c1, c2, l);
-}
-static inline XMLSTR xstrstr(XMLCSTR c1, XMLCSTR c2) {
-  return (XMLSTR)strstr(c1, c2);
-}
-static inline XMLSTR xstrcpy(XMLSTR c1, XMLCSTR c2) {
-  return (XMLSTR)strcpy(c1, c2);
-}
-#endif
+// for Microsoft Visual Studio 6.0 and Microsoft Visual Studio .NET and Borland C++ Builder 6.0
+    #ifdef _XMLWIDECHAR
+        wchar_t *myMultiByteToWideChar(const char *s, XMLNode::XMLCharEncoding ce)
+        {
+            int i;
+            if (ce==XMLNode::char_encoding_UTF8) i=(int)MultiByteToWideChar(CP_UTF8,0             ,s,-1,NULL,0);
+            else                            i=(int)MultiByteToWideChar(CP_ACP ,MB_PRECOMPOSED,s,-1,NULL,0);
+            if (i<0) return NULL;
+            wchar_t *d=(wchar_t *)malloc((i+1)*sizeof(XMLCHAR));
+            if (ce==XMLNode::char_encoding_UTF8) i=(int)MultiByteToWideChar(CP_UTF8,0             ,s,-1,d,i);
+            else                            i=(int)MultiByteToWideChar(CP_ACP ,MB_PRECOMPOSED,s,-1,d,i);
+            d[i]=0;
+            return d;
+        }
+        static inline FILE *xfopen(XMLCSTR filename,XMLCSTR mode) { return _wfopen(filename,mode); }
+        static inline int xstrlen(XMLCSTR c)   { return (int)wcslen(c); }
+        static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) { return _wcsnicmp(c1,c2,l);}
+        static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) { return wcsncmp(c1,c2,l);}
+        static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return _wcsicmp(c1,c2); }
+        static inline XMLSTR xstrstr(XMLCSTR c1, XMLCSTR c2) { return (XMLSTR)wcsstr(c1,c2); }
+        static inline XMLSTR xstrcpy(XMLSTR c1, XMLCSTR c2) { return (XMLSTR)wcscpy(c1,c2); }
+    #else
+        char *myWideCharToMultiByte(const wchar_t *s)
+        {
+            UINT codePage=CP_ACP; if (characterEncoding==XMLNode::char_encoding_UTF8) codePage=CP_UTF8;
+            int i=(int)WideCharToMultiByte(codePage,  // code page
+                0,                       // performance and mapping flags
+                s,                       // wide-character string
+                -1,                       // number of chars in string
+                NULL,                       // buffer for new string
+                0,                       // size of buffer
+                NULL,                    // default for unmappable chars
+                NULL                     // set when default char used
+                );
+            if (i<0) return NULL;
+            char *d=(char*)malloc(i+1);
+            WideCharToMultiByte(codePage,  // code page
+                0,                       // performance and mapping flags
+                s,                       // wide-character string
+                -1,                       // number of chars in string
+                d,                       // buffer for new string
+                i,                       // size of buffer
+                NULL,                    // default for unmappable chars
+                NULL                     // set when default char used
+                );
+            d[i]=0;
+            return d;
+        }
+        static inline FILE *xfopen(XMLCSTR filename,XMLCSTR mode) { return fopen(filename,mode); }
+        static inline int xstrlen(XMLCSTR c)   { return (int)strlen(c); }
+        #ifdef __BORLANDC__
+            static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) { return strnicmp(c1,c2,l);}
+            static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return stricmp(c1,c2); }
+        #else
+            static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) { return _strnicmp(c1,c2,l);}
+            static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return _stricmp(c1,c2); }
+        #endif
+        static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) { return strncmp(c1,c2,l);}
+        static inline XMLSTR xstrstr(XMLCSTR c1, XMLCSTR c2) { return (XMLSTR)strstr(c1,c2); }
+        static inline XMLSTR xstrcpy(XMLSTR c1, XMLCSTR c2) { return (XMLSTR)strcpy(c1,c2); }
+    #endif
 #else
 // for gcc and CC
-#ifdef XML_NO_WIDE_CHAR
-char *myWideCharToMultiByte(const wchar_t *s) { return NULL; }
-#else
-char *myWideCharToMultiByte(const wchar_t *s) {
-  const wchar_t *ss = s;
-  int i = (int)wcsrtombs(NULL, &ss, 0, NULL);
-  if (i < 0) return NULL;
-  char *d = (char *)malloc(i + 1);
-  wcsrtombs(d, &s, i, NULL);
-  d[i] = 0;
-  return d;
-}
+    #ifdef XML_NO_WIDE_CHAR
+        char *myWideCharToMultiByte(const wchar_t *s) { return NULL; }
+    #else
+        char *myWideCharToMultiByte(const wchar_t *s)
+        {
+            const wchar_t *ss=s;
+            int i=(int)wcsrtombs(NULL,&ss,0,NULL);
+            if (i<0) return NULL;
+            char *d=(char *)malloc(i+1);
+            wcsrtombs(d,&s,i,NULL);
+            d[i]=0;
+            return d;
+        }
+    #endif
+    #ifdef _XMLWIDECHAR
+        wchar_t *myMultiByteToWideChar(const char *s, XMLNode::XMLCharEncoding ce)
+        {
+            const char *ss=s;
+            int i=(int)mbsrtowcs(NULL,&ss,0,NULL);
+            if (i<0) return NULL;
+            wchar_t *d=(wchar_t *)malloc((i+1)*sizeof(wchar_t));
+            mbsrtowcs(d,&s,i,NULL);
+            d[i]=0;
+            return d;
+        }
+        int xstrlen(XMLCSTR c)   { return wcslen(c); }
+        #ifdef sun
+        // for CC
+           #include <widec.h>
+           static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) { return wsncasecmp(c1,c2,l);}
+           static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) { return wsncmp(c1,c2,l);}
+           static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return wscasecmp(c1,c2); }
+        #else
+        // for gcc
+           static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) { return wcsncasecmp(c1,c2,l);}
+           static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) { return wcsncmp(c1,c2,l);}
+           static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return wcscasecmp(c1,c2); }
+        #endif
+        static inline XMLSTR xstrstr(XMLCSTR c1, XMLCSTR c2) { return (XMLSTR)wcsstr(c1,c2); }
+        static inline XMLSTR xstrcpy(XMLSTR c1, XMLCSTR c2) { return (XMLSTR)wcscpy(c1,c2); }
+        static inline FILE *xfopen(XMLCSTR filename,XMLCSTR mode)
+        {
+            char *filenameAscii=myWideCharToMultiByte(filename);
+            FILE *f;
+            if (mode[0]==_CXML('r')) f=fopen(filenameAscii,"rb");
+            else                     f=fopen(filenameAscii,"wb");
+            free(filenameAscii);
+            return f;
+        }
+    #else
+        static inline FILE *xfopen(XMLCSTR filename,XMLCSTR mode) { return fopen(filename,mode); }
+        static inline int xstrlen(XMLCSTR c)   { return strlen(c); }
+        static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) { return strncasecmp(c1,c2,l);}
+        static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) { return strncmp(c1,c2,l);}
+        static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return strcasecmp(c1,c2); }
+        static inline XMLSTR xstrstr(XMLCSTR c1, XMLCSTR c2) { return (XMLSTR)strstr(c1,c2); }
+        static inline XMLSTR xstrcpy(XMLSTR c1, XMLCSTR c2) { return (XMLSTR)strcpy(c1,c2); }
+    #endif
+    static inline int _strnicmp(const char *c1,const char *c2, int l) { return strncasecmp(c1,c2,l);}
 #endif
-#ifdef _XMLWIDECHAR
-wchar_t *myMultiByteToWideChar(const char *s, XMLNode::XMLCharEncoding ce) {
-  const char *ss = s;
-  int i = (int)mbsrtowcs(NULL, &ss, 0, NULL);
-  if (i < 0) return NULL;
-  wchar_t *d = (wchar_t *)malloc((i + 1) * sizeof(wchar_t));
-  mbsrtowcs(d, &s, i, NULL);
-  d[i] = 0;
-  return d;
-}
-int xstrlen(XMLCSTR c) { return wcslen(c); }
-#ifdef sun
-// for CC
-#include <widec.h>
-static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) {
-  return wsncasecmp(c1, c2, l);
-}
-static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) {
-  return wsncmp(c1, c2, l);
-}
-static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return wscasecmp(c1, c2); }
-#else
-// for gcc
-static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) {
-  return wcsncasecmp(c1, c2, l);
-}
-static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) {
-  return wcsncmp(c1, c2, l);
-}
-static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) {
-  return wcscasecmp(c1, c2);
-}
-#endif
-static inline XMLSTR xstrstr(XMLCSTR c1, XMLCSTR c2) {
-  return (XMLSTR)wcsstr(c1, c2);
-}
-static inline XMLSTR xstrcpy(XMLSTR c1, XMLCSTR c2) {
-  return (XMLSTR)wcscpy(c1, c2);
-}
-static inline FILE *xfopen(XMLCSTR filename, XMLCSTR mode) {
-  char *filenameAscii = myWideCharToMultiByte(filename);
-  FILE *f;
-  if (mode[0] == _CXML('r'))
-    f = fopen(filenameAscii, "rb");
-  else
-    f = fopen(filenameAscii, "wb");
-  free(filenameAscii);
-  return f;
-}
-#else
-static inline FILE *xfopen(XMLCSTR filename, XMLCSTR mode) {
-  return fopen(filename, mode);
-}
-static inline int xstrlen(XMLCSTR c) { return strlen(c); }
-static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) {
-  return strncasecmp(c1, c2, l);
-}
-static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) {
-  return strncmp(c1, c2, l);
-}
-static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) {
-  return strcasecmp(c1, c2);
-}
-static inline XMLSTR xstrstr(XMLCSTR c1, XMLCSTR c2) {
-  return (XMLSTR)strstr(c1, c2);
-}
-static inline XMLSTR xstrcpy(XMLSTR c1, XMLCSTR c2) {
-  return (XMLSTR)strcpy(c1, c2);
-}
-#endif
-static inline int _strnicmp(const char *c1, const char *c2, int l) {
-  return strncasecmp(c1, c2, l);
-}
-#endif
+
 
 ///////////////////////////////////////////////////////////////////////////////
 //            the "xmltoc,xmltob,xmltoi,xmltol,xmltof,xmltoa" functions      //
@@ -455,145 +358,82 @@ static inline int _strnicmp(const char *c1, const char *c2, int l) {
 // There are only here as "convenience" functions for the user.
 // If you don't need them, you can delete them without any trouble.
 #ifdef _XMLWIDECHAR
-#ifdef _XMLWINDOWS
-// for Microsoft Visual Studio 6.0 and Microsoft Visual Studio .NET and Borland
-// C++ Builder 6.0
-char xmltob(XMLCSTR t, int v) {
-  if (t && (*t)) return (char)_wtoi(t);
-  return v;
-}
-int xmltoi(XMLCSTR t, int v) {
-  if (t && (*t)) return _wtoi(t);
-  return v;
-}
-long xmltol(XMLCSTR t, long v) {
-  if (t && (*t)) return _wtol(t);
-  return v;
-}
-double xmltof(XMLCSTR t, double v) {
-  if (t && (*t)) wscanf(t, "%f", &v); /*v=_wtof(t);*/
-  return v;
-}
+    #ifdef _XMLWINDOWS
+    // for Microsoft Visual Studio 6.0 and Microsoft Visual Studio .NET and Borland C++ Builder 6.0
+        char    xmltob(XMLCSTR t,int     v){ if (t&&(*t)) return (char)_wtoi(t); return v; }
+        int     xmltoi(XMLCSTR t,int     v){ if (t&&(*t)) return _wtoi(t); return v; }
+        long    xmltol(XMLCSTR t,long    v){ if (t&&(*t)) return _wtol(t); return v; }
+        double  xmltof(XMLCSTR t,double  v){ if (t&&(*t)) wscanf(t, "%f", &v); /*v=_wtof(t);*/ return v; }
+    #else
+        #ifdef sun
+        // for CC
+           #include <widec.h>
+           char    xmltob(XMLCSTR t,int     v){ if (t) return (char)wstol(t,NULL,10); return v; }
+           int     xmltoi(XMLCSTR t,int     v){ if (t) return (int)wstol(t,NULL,10); return v; }
+           long    xmltol(XMLCSTR t,long    v){ if (t) return wstol(t,NULL,10); return v; }
+        #else
+        // for gcc
+           char    xmltob(XMLCSTR t,int     v){ if (t) return (char)wcstol(t,NULL,10); return v; }
+           int     xmltoi(XMLCSTR t,int     v){ if (t) return (int)wcstol(t,NULL,10); return v; }
+           long    xmltol(XMLCSTR t,long    v){ if (t) return wcstol(t,NULL,10); return v; }
+        #endif
+		double  xmltof(XMLCSTR t,double  v){ if (t&&(*t)) wscanf(t, "%f", &v); /*v=_wtof(t);*/ return v; }
+    #endif
 #else
-#ifdef sun
-// for CC
-#include <widec.h>
-char xmltob(XMLCSTR t, int v) {
-  if (t) return (char)wstol(t, NULL, 10);
-  return v;
-}
-int xmltoi(XMLCSTR t, int v) {
-  if (t) return (int)wstol(t, NULL, 10);
-  return v;
-}
-long xmltol(XMLCSTR t, long v) {
-  if (t) return wstol(t, NULL, 10);
-  return v;
-}
-#else
-// for gcc
-char xmltob(XMLCSTR t, int v) {
-  if (t) return (char)wcstol(t, NULL, 10);
-  return v;
-}
-int xmltoi(XMLCSTR t, int v) {
-  if (t) return (int)wcstol(t, NULL, 10);
-  return v;
-}
-long xmltol(XMLCSTR t, long v) {
-  if (t) return wcstol(t, NULL, 10);
-  return v;
-}
+    char    xmltob(XMLCSTR t,char    v){ if (t&&(*t)) return (char)atoi(t); return v; }
+    int     xmltoi(XMLCSTR t,int     v){ if (t&&(*t)) return atoi(t); return v; }
+    long    xmltol(XMLCSTR t,long    v){ if (t&&(*t)) return atol(t); return v; }
+    double  xmltof(XMLCSTR t,double  v){ if (t&&(*t)) return atof(t); return v; }
 #endif
-double xmltof(XMLCSTR t, double v) {
-  if (t && (*t)) wscanf(t, "%f", &v); /*v=_wtof(t);*/
-  return v;
-}
-#endif
-#else
-char xmltob(XMLCSTR t, char v) {
-  if (t && (*t)) return (char)atoi(t);
-  return v;
-}
-int xmltoi(XMLCSTR t, int v) {
-  if (t && (*t)) return atoi(t);
-  return v;
-}
-long xmltol(XMLCSTR t, long v) {
-  if (t && (*t)) return atol(t);
-  return v;
-}
-double xmltof(XMLCSTR t, double v) {
-  if (t && (*t)) return atof(t);
-  return v;
-}
-#endif
-XMLCSTR xmltoa(XMLCSTR t, XMLCSTR v) {
-  if (t) return t;
-  return v;
-}
-XMLCHAR xmltoc(XMLCSTR t, XMLCHAR v) {
-  if (t && (*t)) return *t;
-  return v;
-}
+XMLCSTR xmltoa(XMLCSTR t,XMLCSTR v){ if (t)       return  t; return v; }
+XMLCHAR xmltoc(XMLCSTR t,XMLCHAR v){ if (t&&(*t)) return *t; return v; }
 
 /////////////////////////////////////////////////////////////////////////
 //                    the "openFileHelper" function                    //
 /////////////////////////////////////////////////////////////////////////
 
-// Since each application has its own way to report and deal with errors, you
-// should modify & rewrite
-// the following "openFileHelper" function to get an "error reporting mechanism"
-// tailored to your needs.
-XMLNode XMLNode::openFileHelper(XMLCSTR filename, XMLCSTR tag) {
-  // guess the value of the global parameter "characterEncoding"
-  // (the guess is based on the first 200 bytes of the file).
-  FILE *f = xfopen(filename, _CXML("rb"));
-  if (f) {
-    char bb[205];
-    int l = (int)fread(bb, 1, 200, f);
-    setGlobalOptions(guessCharEncoding(bb, l), guessWideCharChars,
-                     dropWhiteSpace, removeCommentsInMiddleOfText);
-    fclose(f);
-  }
-
-  // parse the file
-  XMLResults pResults;
-  XMLNode xnode = XMLNode::parseFile(filename, tag, &pResults);
-
-  // display error message (if any)
-  if (pResults.error != eXMLErrorNone) {
-    // create message
-    char message[2000], *s1 = (char *)"", *s3 = (char *)"";
-    XMLCSTR s2 = _CXML("");
-    if (pResults.error == eXMLErrorFirstTagNotFound) {
-      s1 = (char *)"First Tag should be '";
-      s2 = tag;
-      s3 = (char *)"'.\n";
+// Since each application has its own way to report and deal with errors, you should modify & rewrite
+// the following "openFileHelper" function to get an "error reporting mechanism" tailored to your needs.
+XMLNode XMLNode::openFileHelper(XMLCSTR filename, XMLCSTR tag)
+{
+    // guess the value of the global parameter "characterEncoding"
+    // (the guess is based on the first 200 bytes of the file).
+    FILE *f=xfopen(filename,_CXML("rb"));
+    if (f)
+    {
+        char bb[205];
+        int l=(int)fread(bb,1,200,f);
+        setGlobalOptions(guessCharEncoding(bb,l),guessWideCharChars,dropWhiteSpace,removeCommentsInMiddleOfText);
+        fclose(f);
     }
-    sprintf(message,
-#ifdef _XMLWIDECHAR
-            "XML Parsing error inside file '%S'.\n%S\nAt line %i, column "
-            "%i.\n%s%S%s"
-#else
-            "XML Parsing error inside file '%s'.\n%s\nAt line %i, column "
-            "%i.\n%s%s%s"
-#endif
-            ,
-            filename, XMLNode::getError(pResults.error), pResults.nLine,
-            pResults.nColumn, s1, s2, s3);
 
-// display message
-#if defined(_XMLWINDOWS) && !defined(UNDER_CE) && \
-    !defined(_XMLPARSER_NO_MESSAGEBOX_)
-    MessageBoxA(NULL, message, "XML Parsing error",
-                MB_OK | MB_ICONERROR | MB_TOPMOST);
+    // parse the file
+    XMLResults pResults;
+    XMLNode xnode=XMLNode::parseFile(filename,tag,&pResults);
+
+    // display error message (if any)
+    if (pResults.error != eXMLErrorNone)
+    {
+        // create message
+        char message[2000],*s1=(char*)"",*s3=(char*)""; XMLCSTR s2=_CXML("");
+        if (pResults.error==eXMLErrorFirstTagNotFound) { s1=(char*)"First Tag should be '"; s2=tag; s3=(char*)"'.\n"; }
+        sprintf(message,
+#ifdef _XMLWIDECHAR
+            "XML Parsing error inside file '%S'.\n%S\nAt line %i, column %i.\n%s%S%s"
 #else
-    printf("%s", message);
+            "XML Parsing error inside file '%s'.\n%s\nAt line %i, column %i.\n%s%s%s"
 #endif
-    exit(255);
-  }
-  return xnode;
+            ,filename,XMLNode::getError(pResults.error),pResults.nLine,pResults.nColumn,s1,s2,s3);
+
+        // display message
+#if defined(_XMLWINDOWS) && !defined(UNDER_CE) && !defined(_XMLPARSER_NO_MESSAGEBOX_)
+        MessageBoxA(NULL,message,"XML Parsing error",MB_OK|MB_ICONERROR|MB_TOPMOST);
+#else
+        printf("%s",message);
+#endif
+        exit(255);
+    }
+    return xnode;
 }
 
 /////////////////////////////////////////////////////////////////////////
@@ -603,496 +443,400 @@ XMLNode XMLNode::openFileHelper(XMLCSTR filename, XMLCSTR tag) {
 // You should normally not change anything below this point.
 
 #ifndef _XMLWIDECHAR
-// If "characterEncoding=ascii" then we assume that all characters have the same
-// length of 1 byte.
-// If "characterEncoding=UTF8" then the characters have different lengths (from
-// 1 byte to 4 bytes).
-// If "characterEncoding=ShiftJIS" then the characters have different lengths
-// (from 1 byte to 2 bytes).
-// This table is used as lookup-table to know the length of a character (in
-// byte) based on the
+// If "characterEncoding=ascii" then we assume that all characters have the same length of 1 byte.
+// If "characterEncoding=UTF8" then the characters have different lengths (from 1 byte to 4 bytes).
+// If "characterEncoding=ShiftJIS" then the characters have different lengths (from 1 byte to 2 bytes).
+// This table is used as lookup-table to know the length of a character (in byte) based on the
 // content of the first byte of the character.
 // (note: if you modify this, you must always have XML_utf8ByteTable[0]=0 ).
-static const char XML_utf8ByteTable[256] = {
+static const char XML_utf8ByteTable[256] =
+{
     //  0 1 2 3 4 5 6 7 8 9 a b c d e f
-    0, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x00
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x10
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x20
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x30
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x40
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x50
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x60
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x70 End of ASCII range
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x80 0x80 to 0xc1 invalid
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x90
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0xa0
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0xb0
-    1, 1, 2, 2, 2, 2, 2, 2,
-    2, 2, 2, 2, 2, 2, 2, 2,  // 0xc0 0xc2 to 0xdf 2 byte
-    2, 2, 2, 2, 2, 2, 2, 2,
-    2, 2, 2, 2, 2, 2, 2, 2,  // 0xd0
-    3, 3, 3, 3, 3, 3, 3, 3,
-    3, 3, 3, 3, 3, 3, 3, 3,  // 0xe0 0xe0 to 0xef 3 byte
-    4, 4, 4, 4, 4, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1  // 0xf0 0xf0 to 0xf4 4 byte, 0xf5 and higher invalid
+    0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x00
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x10
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x20
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x30
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x40
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x50
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x60
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x70 End of ASCII range
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x80 0x80 to 0xc1 invalid
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x90
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0xa0
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0xb0
+    1,1,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xc0 0xc2 to 0xdf 2 byte
+    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xd0
+    3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,// 0xe0 0xe0 to 0xef 3 byte
+    4,4,4,4,4,1,1,1,1,1,1,1,1,1,1,1 // 0xf0 0xf0 to 0xf4 4 byte, 0xf5 and higher invalid
 };
-static const char XML_legacyByteTable[256] = {
-    0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
-static const char XML_sjisByteTable[256] = {
+static const char XML_legacyByteTable[256] =
+{
+    0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1
+};
+static const char XML_sjisByteTable[256] =
+{
     //  0 1 2 3 4 5 6 7 8 9 a b c d e f
-    0, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x00
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x10
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x20
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x30
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x40
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x50
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x60
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x70
-    1, 2, 2, 2, 2, 2, 2, 2,
-    2, 2, 2, 2, 2, 2, 2, 2,  // 0x80 0x81 to 0x9F 2 bytes
-    2, 2, 2, 2, 2, 2, 2, 2,
-    2, 2, 2, 2, 2, 2, 2, 2,  // 0x90
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0xa0
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0xb0
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0xc0
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0xd0
-    2, 2, 2, 2, 2, 2, 2, 2,
-    2, 2, 2, 2, 2, 2, 2, 2,  // 0xe0 0xe0 to 0xef 2 bytes
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1  // 0xf0
+    0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x00
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x10
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x20
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x30
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x40
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x50
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x60
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x70
+    1,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0x80 0x81 to 0x9F 2 bytes
+    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0x90
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0xa0
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0xb0
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0xc0
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0xd0
+    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xe0 0xe0 to 0xef 2 bytes
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1 // 0xf0
 };
-static const char XML_gb2312ByteTable[256] = {
+static const char XML_gb2312ByteTable[256] =
+{
+//  0 1 2 3 4 5 6 7 8 9 a b c d e f
+    0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x00
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x10
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x20
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x30
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x40
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x50
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x60
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x70
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x80
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x90
+    1,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xa0 0xa1 to 0xf7 2 bytes
+    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xb0
+    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xc0
+    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xd0
+    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xe0
+    2,2,2,2,2,2,2,2,1,1,1,1,1,1,1,1 // 0xf0
+};
+static const char XML_gbk_big5_ByteTable[256] =
+{
     //  0 1 2 3 4 5 6 7 8 9 a b c d e f
-    0, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x00
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x10
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x20
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x30
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x40
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x50
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x60
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x70
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x80
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x90
-    1, 2, 2, 2, 2, 2, 2, 2,
-    2, 2, 2, 2, 2, 2, 2, 2,  // 0xa0 0xa1 to 0xf7 2 bytes
-    2, 2, 2, 2, 2, 2, 2, 2,
-    2, 2, 2, 2, 2, 2, 2, 2,  // 0xb0
-    2, 2, 2, 2, 2, 2, 2, 2,
-    2, 2, 2, 2, 2, 2, 2, 2,  // 0xc0
-    2, 2, 2, 2, 2, 2, 2, 2,
-    2, 2, 2, 2, 2, 2, 2, 2,  // 0xd0
-    2, 2, 2, 2, 2, 2, 2, 2,
-    2, 2, 2, 2, 2, 2, 2, 2,  // 0xe0
-    2, 2, 2, 2, 2, 2, 2, 2,
-    1, 1, 1, 1, 1, 1, 1, 1  // 0xf0
+    0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x00
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x10
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x20
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x30
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x40
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x50
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x60
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x70
+    1,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0x80 0x81 to 0xfe 2 bytes
+    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0x90
+    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xa0
+    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xb0
+    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xc0
+    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xd0
+    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xe0
+    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,1 // 0xf0
 };
-static const char XML_gbk_big5_ByteTable[256] = {
-    //  0 1 2 3 4 5 6 7 8 9 a b c d e f
-    0, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x00
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x10
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x20
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x30
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x40
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x50
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x60
-    1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1,  // 0x70
-    1, 2, 2, 2, 2, 2, 2, 2,
-    2, 2, 2, 2, 2, 2, 2, 2,  // 0x80 0x81 to 0xfe 2 bytes
-    2, 2, 2, 2, 2, 2, 2, 2,
-    2, 2, 2, 2, 2, 2, 2, 2,  // 0x90
-    2, 2, 2, 2, 2, 2, 2, 2,
-    2, 2, 2, 2, 2, 2, 2, 2,  // 0xa0
-    2, 2, 2, 2, 2, 2, 2, 2,
-    2, 2, 2, 2, 2, 2, 2, 2,  // 0xb0
-    2, 2, 2, 2, 2, 2, 2, 2,
-    2, 2, 2, 2, 2, 2, 2, 2,  // 0xc0
-    2, 2, 2, 2, 2, 2, 2, 2,
-    2, 2, 2, 2, 2, 2, 2, 2,  // 0xd0
-    2, 2, 2, 2, 2, 2, 2, 2,
-    2, 2, 2, 2, 2, 2, 2, 2,  // 0xe0
-    2, 2, 2, 2, 2, 2, 2, 2,
-    2, 2, 2, 2, 2, 2, 2, 1  // 0xf0
-};
-static const char *XML_ByteTable = (const char *)
-    XML_utf8ByteTable;  // the default is
-                        // "characterEncoding=XMLNode::encoding_UTF8"
+static const char *XML_ByteTable=(const char *)XML_utf8ByteTable; // the default is "characterEncoding=XMLNode::encoding_UTF8"
 #endif
 
+
 XMLNode XMLNode::emptyXMLNode;
-XMLClear XMLNode::emptyXMLClear = {NULL, NULL, NULL};
-XMLAttribute XMLNode::emptyXMLAttribute = {NULL, NULL};
+XMLClear XMLNode::emptyXMLClear={ NULL, NULL, NULL};
+XMLAttribute XMLNode::emptyXMLAttribute={ NULL, NULL};
 
 // Enumeration used to decipher what type a token is
-typedef enum XMLTokenTypeTag {
-  eTokenText = 0,
-  eTokenQuotedText,
-  eTokenTagStart,       /* "<"            */
-  eTokenTagEnd,         /* "</"           */
-  eTokenCloseTag,       /* ">"            */
-  eTokenEquals,         /* "="            */
-  eTokenDeclaration,    /* "<?"           */
-  eTokenShortHandClose, /* "/>"           */
-  eTokenClear,
-  eTokenError
+typedef enum XMLTokenTypeTag
+{
+    eTokenText = 0,
+    eTokenQuotedText,
+    eTokenTagStart,         /* "<"            */
+    eTokenTagEnd,           /* "</"           */
+    eTokenCloseTag,         /* ">"            */
+    eTokenEquals,           /* "="            */
+    eTokenDeclaration,      /* "<?"           */
+    eTokenShortHandClose,   /* "/>"           */
+    eTokenClear,
+    eTokenError
 } XMLTokenType;
 
 // Main structure used for parsing XML
-typedef struct XML {
-  XMLCSTR lpXML;
-  XMLCSTR lpszText;
-  int nIndex, nIndexMissigEndTag;
-  enum XMLError error;
-  XMLCSTR lpEndTag;
-  int cbEndTag;
-  XMLCSTR lpNewElement;
-  int cbNewElement;
-  int nFirst;
+typedef struct XML
+{
+    XMLCSTR                lpXML;
+    XMLCSTR                lpszText;
+    int                    nIndex,nIndexMissigEndTag;
+    enum XMLError          error;
+    XMLCSTR                lpEndTag;
+    int                    cbEndTag;
+    XMLCSTR                lpNewElement;
+    int                    cbNewElement;
+    int                    nFirst;
 } XML;
 
-typedef struct {
-  ALLXMLClearTag *pClr;
-  XMLCSTR pStr;
+typedef struct
+{
+    ALLXMLClearTag *pClr;
+    XMLCSTR     pStr;
 } NextToken;
 
 // Enumeration used when parsing attributes
-typedef enum Attrib { eAttribName = 0, eAttribEquals, eAttribValue } Attrib;
+typedef enum Attrib
+{
+    eAttribName = 0,
+    eAttribEquals,
+    eAttribValue
+} Attrib;
 
 // Enumeration used when parsing elements to dictate whether we are currently
 // inside a tag
-typedef enum Status { eInsideTag = 0, eOutsideTag } Status;
+typedef enum Status
+{
+    eInsideTag = 0,
+    eOutsideTag
+} Status;
 
-XMLError XMLNode::writeToFile(XMLCSTR filename, const char *encoding,
-                              char nFormat) const {
-  if (!d) return eXMLErrorNone;
-  FILE *f = xfopen(filename, _CXML("wb"));
-  if (!f) return eXMLErrorCannotOpenWriteFile;
+XMLError XMLNode::writeToFile(XMLCSTR filename, const char *encoding, char nFormat) const
+{
+    if (!d) return eXMLErrorNone;
+    FILE *f=xfopen(filename,_CXML("wb"));
+    if (!f) return eXMLErrorCannotOpenWriteFile;
 #ifdef _XMLWIDECHAR
-  unsigned char h[2] = {0xFF, 0xFE};
-  if (!fwrite(h, 2, 1, f)) return eXMLErrorCannotWriteFile;
-  if ((!isDeclaration()) &&
-      ((d->lpszName) || (!getChildNode().isDeclaration()))) {
-    if (!fwrite(L"<?xml version=\"1.0\" encoding=\"utf-16\"?>\n",
-                sizeof(wchar_t) * 40, 1, f))
-      return eXMLErrorCannotWriteFile;
-  }
-#else
-  if ((!isDeclaration()) &&
-      ((d->lpszName) || (!getChildNode().isDeclaration()))) {
-    if (characterEncoding == char_encoding_UTF8) {
-      // header so that windows recognize the file as UTF-8:
-      unsigned char h[3] = {0xEF, 0xBB, 0xBF};
-      if (!fwrite(h, 3, 1, f)) return eXMLErrorCannotWriteFile;
-      encoding = "utf-8";
-    } else if (characterEncoding == char_encoding_ShiftJIS)
-      encoding = "SHIFT-JIS";
-
-    if (!encoding) encoding = "ISO-8859-1";
-    if (fprintf(f, "<?xml version=\"1.0\" encoding=\"%s\"?>\n", encoding) < 0)
-      return eXMLErrorCannotWriteFile;
-  } else {
-    if (characterEncoding == char_encoding_UTF8) {
-      unsigned char h[3] = {0xEF, 0xBB, 0xBF};
-      if (!fwrite(h, 3, 1, f)) return eXMLErrorCannotWriteFile;
+    unsigned char h[2]={ 0xFF, 0xFE };
+    if (!fwrite(h,2,1,f)) return eXMLErrorCannotWriteFile;
+    if ((!isDeclaration())&&((d->lpszName)||(!getChildNode().isDeclaration())))
+    {
+        if (!fwrite(L"<?xml version=\"1.0\" encoding=\"utf-16\"?>\n",sizeof(wchar_t)*40,1,f))
+            return eXMLErrorCannotWriteFile;
     }
-  }
+#else
+    if ((!isDeclaration())&&((d->lpszName)||(!getChildNode().isDeclaration())))
+    {
+        if (characterEncoding==char_encoding_UTF8)
+        {
+            // header so that windows recognize the file as UTF-8:
+            unsigned char h[3]={0xEF,0xBB,0xBF}; if (!fwrite(h,3,1,f)) return eXMLErrorCannotWriteFile;
+            encoding="utf-8";
+        } else if (characterEncoding==char_encoding_ShiftJIS) encoding="SHIFT-JIS";
+
+        if (!encoding) encoding="ISO-8859-1";
+        if (fprintf(f,"<?xml version=\"1.0\" encoding=\"%s\"?>\n",encoding)<0) return eXMLErrorCannotWriteFile;
+    } else
+    {
+        if (characterEncoding==char_encoding_UTF8)
+        {
+            unsigned char h[3]={0xEF,0xBB,0xBF}; if (!fwrite(h,3,1,f)) return eXMLErrorCannotWriteFile;
+        }
+    }
 #endif
-  int i;
-  XMLSTR t = createXMLString(nFormat, &i);
-  if (!fwrite(t, sizeof(XMLCHAR) * i, 1, f)) return eXMLErrorCannotWriteFile;
-  if (fclose(f) != 0) return eXMLErrorCannotWriteFile;
-  free(t);
-  return eXMLErrorNone;
+    int i;
+    XMLSTR t=createXMLString(nFormat,&i);
+    if (!fwrite(t,sizeof(XMLCHAR)*i,1,f)) return eXMLErrorCannotWriteFile;
+    if (fclose(f)!=0) return eXMLErrorCannotWriteFile;
+    free(t);
+    return eXMLErrorNone;
 }
 
 // Duplicate a given string.
-XMLSTR stringDup(XMLCSTR lpszData, int cbData) {
-  if (lpszData == NULL) return NULL;
+XMLSTR stringDup(XMLCSTR lpszData, int cbData)
+{
+    if (lpszData==NULL) return NULL;
 
-  XMLSTR lpszNew;
-  if (cbData == -1) cbData = (int)xstrlen(lpszData);
-  lpszNew = (XMLSTR)malloc((cbData + 1) * sizeof(XMLCHAR));
-  if (lpszNew) {
-    memcpy(lpszNew, lpszData, (cbData) * sizeof(XMLCHAR));
-    lpszNew[cbData] = (XMLCHAR)NULL;
-  }
-  return lpszNew;
+    XMLSTR lpszNew;
+    if (cbData==-1) cbData=(int)xstrlen(lpszData);
+    lpszNew = (XMLSTR)malloc((cbData+1) * sizeof(XMLCHAR));
+    if (lpszNew)
+    {
+        memcpy(lpszNew, lpszData, (cbData) * sizeof(XMLCHAR));
+        lpszNew[cbData] = (XMLCHAR)NULL;
+    }
+    return lpszNew;
 }
 
-XMLSTR ToXMLStringTool::toXMLUnSafe(XMLSTR dest, XMLCSTR source) {
-  XMLSTR dd = dest;
-  XMLCHAR ch;
-  XMLCharacterEntity *entity;
-  while ((ch = *source)) {
-    entity = XMLEntities;
-    do {
-      if (ch == entity->c) {
-        xstrcpy(dest, entity->s);
-        dest += entity->l;
-        source++;
-        goto out_of_loop1;
-      }
-      entity++;
-    } while (entity->s);
+XMLSTR ToXMLStringTool::toXMLUnSafe(XMLSTR dest,XMLCSTR source)
+{
+    XMLSTR dd=dest;
+    XMLCHAR ch;
+    XMLCharacterEntity *entity;
+    while ((ch=*source))
+    {
+        entity=XMLEntities;
+        do
+        {
+            if (ch==entity->c) {xstrcpy(dest,entity->s); dest+=entity->l; source++; goto out_of_loop1; }
+            entity++;
+        } while(entity->s);
 #ifdef _XMLWIDECHAR
-    *(dest++) = *(source++);
+        *(dest++)=*(source++);
 #else
-    switch (XML_ByteTable[(unsigned char)ch]) {
-      case 4:
-        *(dest++) = *(source++);
-      case 3:
-        *(dest++) = *(source++);
-      case 2:
-        *(dest++) = *(source++);
-      case 1:
-        *(dest++) = *(source++);
-    }
+        switch(XML_ByteTable[(unsigned char)ch])
+        {
+        case 4: *(dest++)=*(source++);
+        case 3: *(dest++)=*(source++);
+        case 2: *(dest++)=*(source++);
+        case 1: *(dest++)=*(source++);
+        }
 #endif
-  out_of_loop1:;
-  }
-  *dest = 0;
-  return dd;
+out_of_loop1:
+        ;
+    }
+    *dest=0;
+    return dd;
 }
 
 // private (used while rendering):
-int ToXMLStringTool::lengthXMLString(XMLCSTR source) {
-  int r = 0;
-  XMLCharacterEntity *entity;
-  XMLCHAR ch;
-  while ((ch = *source)) {
-    entity = XMLEntities;
-    do {
-      if (ch == entity->c) {
-        r += entity->l;
-        source++;
-        goto out_of_loop1;
-      }
-      entity++;
-    } while (entity->s);
+int ToXMLStringTool::lengthXMLString(XMLCSTR source)
+{
+    int r=0;
+    XMLCharacterEntity *entity;
+    XMLCHAR ch;
+    while ((ch=*source))
+    {
+        entity=XMLEntities;
+        do
+        {
+            if (ch==entity->c) { r+=entity->l; source++; goto out_of_loop1; }
+            entity++;
+        } while(entity->s);
 #ifdef _XMLWIDECHAR
-    r++;
-    source++;
+        r++; source++;
 #else
-    ch = XML_ByteTable[(unsigned char)ch];
-    r += ch;
-    source += ch;
+        ch=XML_ByteTable[(unsigned char)ch]; r+=ch; source+=ch;
 #endif
-  out_of_loop1:;
-  }
-  return r;
+out_of_loop1:
+        ;
+    }
+    return r;
 }
 
-ToXMLStringTool::~ToXMLStringTool() { freeBuffer(); }
-void ToXMLStringTool::freeBuffer() {
-  if (buf) free(buf);
-  buf = NULL;
-  buflen = 0;
-}
-XMLSTR ToXMLStringTool::toXML(XMLCSTR source) {
-  int l = lengthXMLString(source) + 1;
-  if (l > buflen) {
-    buflen = l;
-    buf = (XMLSTR)realloc(buf, l * sizeof(XMLCHAR));
-  }
-  return toXMLUnSafe(buf, source);
+ToXMLStringTool::~ToXMLStringTool(){ freeBuffer(); }
+void ToXMLStringTool::freeBuffer(){ if (buf) free(buf); buf=NULL; buflen=0; }
+XMLSTR ToXMLStringTool::toXML(XMLCSTR source)
+{
+    int l=lengthXMLString(source)+1;
+    if (l>buflen) { buflen=l; buf=(XMLSTR)realloc(buf,l*sizeof(XMLCHAR)); }
+    return toXMLUnSafe(buf,source);
 }
 
 // private:
-XMLSTR fromXMLString(XMLCSTR s, int lo, XML *pXML) {
-  // This function is the opposite of the function "toXMLString". It decodes the
-  // escape
-  // sequences &amp;, &quot;, &apos;, &lt;, &gt; and replace them by the
-  // characters
-  // &,",',<,>. This function is used internally by the XML Parser. All the
-  // calls to
-  // the XML library will always gives you back "decoded" strings.
-  //
-  // in: string (s) and length (lo) of string
-  // out:  new allocated string converted from xml
-  if (!s) return NULL;
+XMLSTR fromXMLString(XMLCSTR s, int lo, XML *pXML)
+{
+    // This function is the opposite of the function "toXMLString". It decodes the escape
+    // sequences &amp;, &quot;, &apos;, &lt;, &gt; and replace them by the characters
+    // &,",',<,>. This function is used internally by the XML Parser. All the calls to
+    // the XML library will always gives you back "decoded" strings.
+    //
+    // in: string (s) and length (lo) of string
+    // out:  new allocated string converted from xml
+    if (!s) return NULL;
 
-  int ll = 0, j;
-  XMLSTR d;
-  XMLCSTR ss = s;
-  XMLCharacterEntity *entity;
-  while ((lo > 0) && (*s)) {
-    if (*s == _CXML('&')) {
-      if ((lo > 2) && (s[1] == _CXML('#'))) {
-        s += 2;
-        lo -= 2;
-        if ((*s == _CXML('X')) || (*s == _CXML('x'))) {
-          s++;
-          lo--;
-        }
-        while ((*s) && (*s != _CXML(';')) && ((lo--) > 0)) s++;
-        if (*s != _CXML(';')) {
-          pXML->error = eXMLErrorUnknownCharacterEntity;
-          return NULL;
-        }
-        s++;
-        lo--;
-      } else {
-        entity = XMLEntities;
-        do {
-          if ((lo >= entity->l) && (xstrnicmp(s, entity->s, entity->l) == 0)) {
-            s += entity->l;
-            lo -= entity->l;
-            break;
-          }
-          entity++;
-        } while (entity->s);
-        if (!entity->s) {
-          pXML->error = eXMLErrorUnknownCharacterEntity;
-          return NULL;
-        }
-      }
-    } else {
+    int ll=0,j;
+    XMLSTR d;
+    XMLCSTR ss=s;
+    XMLCharacterEntity *entity;
+    while ((lo>0)&&(*s))
+    {
+        if (*s==_CXML('&'))
+        {
+            if ((lo>2)&&(s[1]==_CXML('#')))
+            {
+                s+=2; lo-=2;
+                if ((*s==_CXML('X'))||(*s==_CXML('x'))) { s++; lo--; }
+                while ((*s)&&(*s!=_CXML(';'))&&((lo--)>0)) s++;
+                if (*s!=_CXML(';'))
+                {
+                    pXML->error=eXMLErrorUnknownCharacterEntity;
+                    return NULL;
+                }
+                s++; lo--;
+            } else
+            {
+                entity=XMLEntities;
+                do
+                {
+                    if ((lo>=entity->l)&&(xstrnicmp(s,entity->s,entity->l)==0)) { s+=entity->l; lo-=entity->l; break; }
+                    entity++;
+                } while(entity->s);
+                if (!entity->s)
+                {
+                    pXML->error=eXMLErrorUnknownCharacterEntity;
+                    return NULL;
+                }
+            }
+        } else
+        {
 #ifdef _XMLWIDECHAR
-      s++;
-      lo--;
+            s++; lo--;
 #else
-      j = XML_ByteTable[(unsigned char)*s];
-      s += j;
-      lo -= j;
-      ll += j - 1;
+            j=XML_ByteTable[(unsigned char)*s]; s+=j; lo-=j; ll+=j-1;
 #endif
-    }
-    ll++;
-  }
-
-  d = (XMLSTR)malloc((ll + 1) * sizeof(XMLCHAR));
-  s = d;
-  while (ll-- > 0) {
-    if (*ss == _CXML('&')) {
-      if (ss[1] == _CXML('#')) {
-        ss += 2;
-        j = 0;
-        if ((*ss == _CXML('X')) || (*ss == _CXML('x'))) {
-          ss++;
-          while (*ss != _CXML(';')) {
-            if ((*ss >= _CXML('0')) && (*ss <= _CXML('9')))
-              j = (j << 4) + *ss - _CXML('0');
-            else if ((*ss >= _CXML('A')) && (*ss <= _CXML('F')))
-              j = (j << 4) + *ss - _CXML('A') + 10;
-            else if ((*ss >= _CXML('a')) && (*ss <= _CXML('f')))
-              j = (j << 4) + *ss - _CXML('a') + 10;
-            else {
-              free((void *)s);
-              pXML->error = eXMLErrorUnknownCharacterEntity;
-              return NULL;
-            }
-            ss++;
-          }
-        } else {
-          while (*ss != _CXML(';')) {
-            if ((*ss >= _CXML('0')) && (*ss <= _CXML('9')))
-              j = (j * 10) + *ss - _CXML('0');
-            else {
-              free((void *)s);
-              pXML->error = eXMLErrorUnknownCharacterEntity;
-              return NULL;
-            }
-            ss++;
-          }
         }
+        ll++;
+    }
+
+    d=(XMLSTR)malloc((ll+1)*sizeof(XMLCHAR));
+    s=d;
+    while (ll-->0)
+    {
+        if (*ss==_CXML('&'))
+        {
+            if (ss[1]==_CXML('#'))
+            {
+                ss+=2; j=0;
+                if ((*ss==_CXML('X'))||(*ss==_CXML('x')))
+                {
+                    ss++;
+                    while (*ss!=_CXML(';'))
+                    {
+                        if ((*ss>=_CXML('0'))&&(*ss<=_CXML('9'))) j=(j<<4)+*ss-_CXML('0');
+                        else if ((*ss>=_CXML('A'))&&(*ss<=_CXML('F'))) j=(j<<4)+*ss-_CXML('A')+10;
+                        else if ((*ss>=_CXML('a'))&&(*ss<=_CXML('f'))) j=(j<<4)+*ss-_CXML('a')+10;
+                        else { free((void*)s); pXML->error=eXMLErrorUnknownCharacterEntity;return NULL;}
+                        ss++;
+                    }
+                } else
+                {
+                    while (*ss!=_CXML(';'))
+                    {
+                        if ((*ss>=_CXML('0'))&&(*ss<=_CXML('9'))) j=(j*10)+*ss-_CXML('0');
+                        else { free((void*)s); pXML->error=eXMLErrorUnknownCharacterEntity;return NULL;}
+                        ss++;
+                    }
+                }
 #ifndef _XMLWIDECHAR
-        if (j > 255) {
-          free((void *)s);
-          pXML->error = eXMLErrorCharacterCodeAbove255;
-          return NULL;
-        }
+                if (j>255) { free((void*)s); pXML->error=eXMLErrorCharacterCodeAbove255;return NULL;}
 #endif
-        (*d++) = (XMLCHAR)j;
-        ss++;
-      } else {
-        entity = XMLEntities;
-        do {
-          if (xstrnicmp(ss, entity->s, entity->l) == 0) {
-            *(d++) = entity->c;
-            ss += entity->l;
-            break;
-          }
-          entity++;
-        } while (entity->s);
-      }
-    } else {
+                (*d++)=(XMLCHAR)j; ss++;
+            } else
+            {
+                entity=XMLEntities;
+                do
+                {
+                    if (xstrnicmp(ss,entity->s,entity->l)==0) { *(d++)=entity->c; ss+=entity->l; break; }
+                    entity++;
+                } while(entity->s);
+            }
+        } else
+        {
 #ifdef _XMLWIDECHAR
-      *(d++) = *(ss++);
+            *(d++)=*(ss++);
 #else
-      switch (XML_ByteTable[(unsigned char)*ss]) {
-        case 4:
-          *(d++) = *(ss++);
-          ll--;
-        case 3:
-          *(d++) = *(ss++);
-          ll--;
-        case 2:
-          *(d++) = *(ss++);
-          ll--;
-        case 1:
-          *(d++) = *(ss++);
-      }
+            switch(XML_ByteTable[(unsigned char)*ss])
+            {
+            case 4: *(d++)=*(ss++); ll--;
+            case 3: *(d++)=*(ss++); ll--;
+            case 2: *(d++)=*(ss++); ll--;
+            case 1: *(d++)=*(ss++);
+            }
 #endif
+        }
     }
-  }
-  *d = 0;
-  return (XMLSTR)s;
+    *d=0;
+    return (XMLSTR)s;
 }
 
-#define XML_isSPACECHAR(ch)                                            \
-  ((ch == _CXML('\n')) || (ch == _CXML(' ')) || (ch == _CXML('\t')) || \
-   (ch == _CXML('\r')))
+#define XML_isSPACECHAR(ch) ((ch==_CXML('\n'))||(ch==_CXML(' '))||(ch== _CXML('\t'))||(ch==_CXML('\r')))
 
 // private:
 char myTagCompare(XMLCSTR cclose, XMLCSTR copen)
@@ -1100,1259 +844,1233 @@ char myTagCompare(XMLCSTR cclose, XMLCSTR copen)
 // return 0 if equals
 // return 1 if different
 {
-  if (!cclose) return 1;
-  int l = (int)xstrlen(cclose);
-  if (xstrnicmp(cclose, copen, l) != 0) return 1;
-  const XMLCHAR c = copen[l];
-  if (XML_isSPACECHAR(c) || (c == _CXML('/')) || (c == _CXML('<')) ||
-      (c == _CXML('>')) || (c == _CXML('=')))
-    return 0;
-  return 1;
+    if (!cclose) return 1;
+    int l=(int)xstrlen(cclose);
+    if (xstrnicmp(cclose, copen, l)!=0) return 1;
+    const XMLCHAR c=copen[l];
+    if (XML_isSPACECHAR(c)||
+        (c==_CXML('/' ))||
+        (c==_CXML('<' ))||
+        (c==_CXML('>' ))||
+        (c==_CXML('=' ))) return 0;
+    return 1;
 }
 
 // Obtain the next character from the string.
-static inline XMLCHAR getNextChar(XML *pXML) {
-  XMLCHAR ch = pXML->lpXML[pXML->nIndex];
+static inline XMLCHAR getNextChar(XML *pXML)
+{
+    XMLCHAR ch = pXML->lpXML[pXML->nIndex];
 #ifdef _XMLWIDECHAR
-  if (ch != 0) pXML->nIndex++;
+    if (ch!=0) pXML->nIndex++;
 #else
-  pXML->nIndex += XML_ByteTable[(unsigned char)ch];
+    pXML->nIndex+=XML_ByteTable[(unsigned char)ch];
 #endif
-  return ch;
+    return ch;
 }
 
 // Find the next token in a string.
 // pcbToken contains the number of characters that have been read.
-static NextToken GetNextToken(XML *pXML, int *pcbToken,
-                              enum XMLTokenTypeTag *pType) {
-  NextToken result;
-  XMLCHAR ch;
-  XMLCHAR chTemp;
-  int indexStart, nFoundMatch, nIsText = FALSE;
-  result.pClr = NULL;  // prevent warning
+static NextToken GetNextToken(XML *pXML, int *pcbToken, enum XMLTokenTypeTag *pType)
+{
+    NextToken        result;
+    XMLCHAR            ch;
+    XMLCHAR            chTemp;
+    int              indexStart,nFoundMatch,nIsText=FALSE;
+    result.pClr=NULL; // prevent warning
 
-  // Find next non-white space character
-  do {
-    indexStart = pXML->nIndex;
-    ch = getNextChar(pXML);
-  } while XML_isSPACECHAR(ch);
+    // Find next non-white space character
+    do { indexStart=pXML->nIndex; ch=getNextChar(pXML); } while XML_isSPACECHAR(ch);
 
-  if (ch) {
-    // Cache the current string pointer
-    result.pStr = &pXML->lpXML[indexStart];
+    if (ch)
+    {
+        // Cache the current string pointer
+        result.pStr = &pXML->lpXML[indexStart];
 
-    // First check whether the token is in the clear tag list (meaning it
-    // does not need formatting).
-    ALLXMLClearTag *ctag = XMLClearTags;
-    do {
-      if (xstrncmp(ctag->lpszOpen, result.pStr, ctag->openTagLen) == 0) {
-        result.pClr = ctag;
-        pXML->nIndex += ctag->openTagLen - 1;
-        *pType = eTokenClear;
-        return result;
-      }
-      ctag++;
-    } while (ctag->lpszOpen);
+        // First check whether the token is in the clear tag list (meaning it
+        // does not need formatting).
+        ALLXMLClearTag *ctag=XMLClearTags;
+        do
+        {
+            if (xstrncmp(ctag->lpszOpen, result.pStr, ctag->openTagLen)==0)
+            {
+                result.pClr=ctag;
+                pXML->nIndex+=ctag->openTagLen-1;
+                *pType=eTokenClear;
+                return result;
+            }
+            ctag++;
+        } while(ctag->lpszOpen);
 
-    // If we didn't find a clear tag then check for standard tokens
-    switch (ch) {
-      // Check for quotes
-      case _CXML('\''):
-      case _CXML('\"'):
-        // Type of token
-        *pType = eTokenQuotedText;
-        chTemp = ch;
+        // If we didn't find a clear tag then check for standard tokens
+        switch(ch)
+        {
+        // Check for quotes
+        case _CXML('\''):
+        case _CXML('\"'):
+            // Type of token
+            *pType = eTokenQuotedText;
+            chTemp = ch;
 
-        // Set the size
-        nFoundMatch = FALSE;
+            // Set the size
+            nFoundMatch = FALSE;
 
-        // Search through the string to find a matching quote
-        while ((ch = getNextChar(pXML))) {
-          if (ch == chTemp) {
-            nFoundMatch = TRUE;
+            // Search through the string to find a matching quote
+            while((ch = getNextChar(pXML)))
+            {
+                if (ch==chTemp) { nFoundMatch = TRUE; break; }
+                if (ch==_CXML('<')) break;
+            }
+
+            // If we failed to find a matching quote
+            if (nFoundMatch == FALSE)
+            {
+                pXML->nIndex=indexStart+1;
+                nIsText=TRUE;
+                break;
+            }
+
+//  4.02.2002
+//            if (FindNonWhiteSpace(pXML)) pXML->nIndex--;
+
             break;
-          }
-          if (ch == _CXML('<')) break;
+
+        // Equals (used with attribute values)
+        case _CXML('='):
+            *pType = eTokenEquals;
+            break;
+
+        // Close tag
+        case _CXML('>'):
+            *pType = eTokenCloseTag;
+            break;
+
+        // Check for tag start and tag end
+        case _CXML('<'):
+
+            // Peek at the next character to see if we have an end tag '</',
+            // or an xml declaration '<?'
+            chTemp = pXML->lpXML[pXML->nIndex];
+
+            // If we have a tag end...
+            if (chTemp == _CXML('/'))
+            {
+                // Set the type and ensure we point at the next character
+                getNextChar(pXML);
+                *pType = eTokenTagEnd;
+            }
+
+            // If we have an XML declaration tag
+            else if (chTemp == _CXML('?'))
+            {
+
+                // Set the type and ensure we point at the next character
+                getNextChar(pXML);
+                *pType = eTokenDeclaration;
+            }
+
+            // Otherwise we must have a start tag
+            else
+            {
+                *pType = eTokenTagStart;
+            }
+            break;
+
+        // Check to see if we have a short hand type end tag ('/>').
+        case _CXML('/'):
+
+            // Peek at the next character to see if we have a short end tag '/>'
+            chTemp = pXML->lpXML[pXML->nIndex];
+
+            // If we have a short hand end tag...
+            if (chTemp == _CXML('>'))
+            {
+                // Set the type and ensure we point at the next character
+                getNextChar(pXML);
+                *pType = eTokenShortHandClose;
+                break;
+            }
+
+            // If we haven't found a short hand closing tag then drop into the
+            // text process
+
+        // Other characters
+        default:
+            nIsText = TRUE;
         }
 
-        // If we failed to find a matching quote
-        if (nFoundMatch == FALSE) {
-          pXML->nIndex = indexStart + 1;
-          nIsText = TRUE;
-          break;
+        // If this is a TEXT node
+        if (nIsText)
+        {
+            // Indicate we are dealing with text
+            *pType = eTokenText;
+            while((ch = getNextChar(pXML)))
+            {
+                if XML_isSPACECHAR(ch)
+                {
+                    indexStart++; break;
+
+                } else if (ch==_CXML('/'))
+                {
+                    // If we find a slash then this maybe text or a short hand end tag
+                    // Peek at the next character to see it we have short hand end tag
+                    ch=pXML->lpXML[pXML->nIndex];
+                    // If we found a short hand end tag then we need to exit the loop
+                    if (ch==_CXML('>')) { pXML->nIndex--; break; }
+
+                } else if ((ch==_CXML('<'))||(ch==_CXML('>'))||(ch==_CXML('=')))
+                {
+                    pXML->nIndex--; break;
+                }
+            }
         }
-
-        //  4.02.2002
-        //            if (FindNonWhiteSpace(pXML)) pXML->nIndex--;
-
-        break;
-
-      // Equals (used with attribute values)
-      case _CXML('='):
-        *pType = eTokenEquals;
-        break;
-
-      // Close tag
-      case _CXML('>'):
-        *pType = eTokenCloseTag;
-        break;
-
-      // Check for tag start and tag end
-      case _CXML('<'):
-
-        // Peek at the next character to see if we have an end tag '</',
-        // or an xml declaration '<?'
-        chTemp = pXML->lpXML[pXML->nIndex];
-
-        // If we have a tag end...
-        if (chTemp == _CXML('/')) {
-          // Set the type and ensure we point at the next character
-          getNextChar(pXML);
-          *pType = eTokenTagEnd;
-        }
-
-        // If we have an XML declaration tag
-        else if (chTemp == _CXML('?')) {
-          // Set the type and ensure we point at the next character
-          getNextChar(pXML);
-          *pType = eTokenDeclaration;
-        }
-
-        // Otherwise we must have a start tag
-        else {
-          *pType = eTokenTagStart;
-        }
-        break;
-
-      // Check to see if we have a short hand type end tag ('/>').
-      case _CXML('/'):
-
-        // Peek at the next character to see if we have a short end tag '/>'
-        chTemp = pXML->lpXML[pXML->nIndex];
-
-        // If we have a short hand end tag...
-        if (chTemp == _CXML('>')) {
-          // Set the type and ensure we point at the next character
-          getNextChar(pXML);
-          *pType = eTokenShortHandClose;
-          break;
-        }
-
-      // If we haven't found a short hand closing tag then drop into the
-      // text process
-
-      // Other characters
-      default:
-        nIsText = TRUE;
+        *pcbToken = pXML->nIndex-indexStart;
+    } else
+    {
+        // If we failed to obtain a valid character
+        *pcbToken = 0;
+        *pType = eTokenError;
+        result.pStr=NULL;
     }
 
-    // If this is a TEXT node
-    if (nIsText) {
-      // Indicate we are dealing with text
-      *pType = eTokenText;
-      while ((ch = getNextChar(pXML))) {
-        if
-          XML_isSPACECHAR(ch) {
-            indexStart++;
-            break;
-          }
-        else if (ch == _CXML('/')) {
-          // If we find a slash then this maybe text or a short hand end tag
-          // Peek at the next character to see it we have short hand end tag
-          ch = pXML->lpXML[pXML->nIndex];
-          // If we found a short hand end tag then we need to exit the loop
-          if (ch == _CXML('>')) {
-            pXML->nIndex--;
-            break;
-          }
-
-        } else if ((ch == _CXML('<')) || (ch == _CXML('>')) ||
-                   (ch == _CXML('='))) {
-          pXML->nIndex--;
-          break;
-        }
-      }
-    }
-    *pcbToken = pXML->nIndex - indexStart;
-  } else {
-    // If we failed to obtain a valid character
-    *pcbToken = 0;
-    *pType = eTokenError;
-    result.pStr = NULL;
-  }
-
-  return result;
+    return result;
 }
 
-XMLCSTR XMLNode::updateName_WOSD(XMLSTR lpszName) {
-  if (!d) {
-    free(lpszName);
-    return NULL;
-  }
-  if (d->lpszName && (lpszName != d->lpszName)) free((void *)d->lpszName);
-  d->lpszName = lpszName;
-  return lpszName;
+XMLCSTR XMLNode::updateName_WOSD(XMLSTR lpszName)
+{
+    if (!d) { free(lpszName); return NULL; }
+    if (d->lpszName&&(lpszName!=d->lpszName)) free((void*)d->lpszName);
+    d->lpszName=lpszName;
+    return lpszName;
 }
 
 // private:
-XMLNode::XMLNode(struct XMLNodeDataTag *p) {
-  d = p;
-  (p->ref_count)++;
-}
-XMLNode::XMLNode(XMLNodeData *pParent, XMLSTR lpszName, char isDeclaration) {
-  d = (XMLNodeData *)malloc(sizeof(XMLNodeData));
-  d->ref_count = 1;
+XMLNode::XMLNode(struct XMLNodeDataTag *p){ d=p; (p->ref_count)++; }
+XMLNode::XMLNode(XMLNodeData *pParent, XMLSTR lpszName, char isDeclaration)
+{
+    d=(XMLNodeData*)malloc(sizeof(XMLNodeData));
+    d->ref_count=1;
 
-  d->lpszName = NULL;
-  d->nChild = 0;
-  d->nText = 0;
-  d->nClear = 0;
-  d->nAttribute = 0;
+    d->lpszName=NULL;
+    d->nChild= 0;
+    d->nText = 0;
+    d->nClear = 0;
+    d->nAttribute = 0;
 
-  d->isDeclaration = isDeclaration;
+    d->isDeclaration = isDeclaration;
 
-  d->pParent = pParent;
-  d->pChild = NULL;
-  d->pText = NULL;
-  d->pClear = NULL;
-  d->pAttribute = NULL;
-  d->pOrder = NULL;
+    d->pParent = pParent;
+    d->pChild= NULL;
+    d->pText= NULL;
+    d->pClear= NULL;
+    d->pAttribute= NULL;
+    d->pOrder= NULL;
 
-  updateName_WOSD(lpszName);
+    updateName_WOSD(lpszName);
 }
 
-XMLNode XMLNode::createXMLTopNode_WOSD(XMLSTR lpszName, char isDeclaration) {
-  return XMLNode(NULL, lpszName, isDeclaration);
-}
-XMLNode XMLNode::createXMLTopNode(XMLCSTR lpszName, char isDeclaration) {
-  return XMLNode(NULL, stringDup(lpszName), isDeclaration);
-}
+XMLNode XMLNode::createXMLTopNode_WOSD(XMLSTR lpszName, char isDeclaration) { return XMLNode(NULL,lpszName,isDeclaration); }
+XMLNode XMLNode::createXMLTopNode(XMLCSTR lpszName, char isDeclaration) { return XMLNode(NULL,stringDup(lpszName),isDeclaration); }
 
 #define MEMORYINCREASE 50
 
-static inline void myFree(void *p) {
-  if (p) free(p);
-}
-static inline void *myRealloc(void *p, int newsize, int memInc,
-                              int sizeofElem) {
-  if (p == NULL) {
-    if (memInc) return malloc(memInc * sizeofElem);
-    return malloc(sizeofElem);
-  }
-  if ((memInc == 0) || ((newsize % memInc) == 0))
-    p = realloc(p, (newsize + memInc) * sizeofElem);
-  //    if (!p)
-  //    {
-  //        printf("XMLParser Error: Not enough memory! Aborting...\n");
-  //        exit(220);
-  //    }
-  return p;
+static inline void myFree(void *p) { if (p) free(p); }
+static inline void *myRealloc(void *p, int newsize, int memInc, int sizeofElem)
+{
+    if (p==NULL) { if (memInc) return malloc(memInc*sizeofElem); return malloc(sizeofElem); }
+    if ((memInc==0)||((newsize%memInc)==0)) p=realloc(p,(newsize+memInc)*sizeofElem);
+//    if (!p)
+//    {
+//        printf("XMLParser Error: Not enough memory! Aborting...\n"); exit(220);
+//    }
+    return p;
 }
 
 // private:
-XMLElementPosition XMLNode::findPosition(XMLNodeData *d, int index,
-                                         XMLElementType xxtype) {
-  if (index < 0) return -1;
-  int i = 0, j = (int)((index << 2) + xxtype), *o = d->pOrder;
-  while (o[i] != j) i++;
-  return i;
+XMLElementPosition XMLNode::findPosition(XMLNodeData *d, int index, XMLElementType xxtype)
+{
+    if (index<0) return -1;
+    int i=0,j=(int)((index<<2)+xxtype),*o=d->pOrder; while (o[i]!=j) i++; return i;
 }
 
 // private:
 // update "order" information when deleting a content of a XMLNode
-int XMLNode::removeOrderElement(XMLNodeData *d, XMLElementType t, int index) {
-  int n = d->nChild + d->nText + d->nClear, *o = d->pOrder,
-      i = findPosition(d, index, t);
-  memmove(o + i, o + i + 1, (n - i) * sizeof(int));
-  for (; i < n; i++)
-    if ((o[i] & 3) == (int)t) o[i] -= 4;
-  // We should normally do:
-  // d->pOrder=(int)realloc(d->pOrder,n*sizeof(int));
-  // but we skip reallocation because it's too time consuming.
-  // Anyway, at the end, it will be free'd completely at once.
-  return i;
+int XMLNode::removeOrderElement(XMLNodeData *d, XMLElementType t, int index)
+{
+    int n=d->nChild+d->nText+d->nClear, *o=d->pOrder,i=findPosition(d,index,t);
+    memmove(o+i, o+i+1, (n-i)*sizeof(int));
+    for (;i<n;i++)
+        if ((o[i]&3)==(int)t) o[i]-=4;
+    // We should normally do:
+    // d->pOrder=(int)realloc(d->pOrder,n*sizeof(int));
+    // but we skip reallocation because it's too time consuming.
+    // Anyway, at the end, it will be free'd completely at once.
+    return i;
 }
 
-void *XMLNode::addToOrder(int memoryIncrease, int *_pos, int nc, void *p,
-                          int size, XMLElementType xtype) {
-  //  in: *_pos is the position inside d->pOrder ("-1" means "EndOf")
-  // out: *_pos is the index inside p
-  p = myRealloc(p, (nc + 1), memoryIncrease, size);
-  int n = d->nChild + d->nText + d->nClear;
-  d->pOrder =
-      (int *)myRealloc(d->pOrder, n + 1, memoryIncrease * 3, sizeof(int));
-  int pos = *_pos, *o = d->pOrder;
+void *XMLNode::addToOrder(int memoryIncrease,int *_pos, int nc, void *p, int size, XMLElementType xtype)
+{
+    //  in: *_pos is the position inside d->pOrder ("-1" means "EndOf")
+    // out: *_pos is the index inside p
+    p=myRealloc(p,(nc+1),memoryIncrease,size);
+    int n=d->nChild+d->nText+d->nClear;
+    d->pOrder=(int*)myRealloc(d->pOrder,n+1,memoryIncrease*3,sizeof(int));
+    int pos=*_pos,*o=d->pOrder;
 
-  if ((pos < 0) || (pos >= n)) {
-    *_pos = nc;
-    o[n] = (int)((nc << 2) + xtype);
+    if ((pos<0)||(pos>=n)) { *_pos=nc; o[n]=(int)((nc<<2)+xtype); return p; }
+
+    int i=pos;
+    memmove(o+i+1, o+i, (n-i)*sizeof(int));
+
+    while ((pos<n)&&((o[pos]&3)!=(int)xtype)) pos++;
+    if (pos==n) { *_pos=nc; o[n]=(int)((nc<<2)+xtype); return p; }
+
+    o[i]=o[pos];
+    for (i=pos+1;i<=n;i++) if ((o[i]&3)==(int)xtype) o[i]+=4;
+
+    *_pos=pos=o[pos]>>2;
+    memmove(((char*)p)+(pos+1)*size,((char*)p)+pos*size,(nc-pos)*size);
+
     return p;
-  }
-
-  int i = pos;
-  memmove(o + i + 1, o + i, (n - i) * sizeof(int));
-
-  while ((pos < n) && ((o[pos] & 3) != (int)xtype)) pos++;
-  if (pos == n) {
-    *_pos = nc;
-    o[n] = (int)((nc << 2) + xtype);
-    return p;
-  }
-
-  o[i] = o[pos];
-  for (i = pos + 1; i <= n; i++)
-    if ((o[i] & 3) == (int)xtype) o[i] += 4;
-
-  *_pos = pos = o[pos] >> 2;
-  memmove(((char *)p) + (pos + 1) * size, ((char *)p) + pos * size,
-          (nc - pos) * size);
-
-  return p;
 }
 
 // Add a child node to the given element.
-XMLNode XMLNode::addChild_priv(int memoryIncrease, XMLSTR lpszName,
-                               char isDeclaration, int pos) {
-  if (!lpszName) return emptyXMLNode;
-  d->pChild = (XMLNode *)addToOrder(memoryIncrease, &pos, d->nChild, d->pChild,
-                                    sizeof(XMLNode), eNodeChild);
-  d->pChild[pos].d = NULL;
-  d->pChild[pos] = XMLNode(d, lpszName, isDeclaration);
-  d->nChild++;
-  return d->pChild[pos];
+XMLNode XMLNode::addChild_priv(int memoryIncrease, XMLSTR lpszName, char isDeclaration, int pos)
+{
+    if (!lpszName) return emptyXMLNode;
+    d->pChild=(XMLNode*)addToOrder(memoryIncrease,&pos,d->nChild,d->pChild,sizeof(XMLNode),eNodeChild);
+    d->pChild[pos].d=NULL;
+    d->pChild[pos]=XMLNode(d,lpszName,isDeclaration);
+    d->nChild++;
+    return d->pChild[pos];
 }
 
 // Add an attribute to an element.
-XMLAttribute *XMLNode::addAttribute_priv(int memoryIncrease, XMLSTR lpszName,
-                                         XMLSTR lpszValuev) {
-  if (!lpszName) return &emptyXMLAttribute;
-  if (!d) {
-    myFree(lpszName);
-    myFree(lpszValuev);
-    return &emptyXMLAttribute;
-  }
-  int nc = d->nAttribute;
-  d->pAttribute = (XMLAttribute *)myRealloc(
-      d->pAttribute, (nc + 1), memoryIncrease, sizeof(XMLAttribute));
-  XMLAttribute *pAttr = d->pAttribute + nc;
-  pAttr->lpszName = lpszName;
-  pAttr->lpszValue = lpszValuev;
-  d->nAttribute++;
-  return pAttr;
+XMLAttribute *XMLNode::addAttribute_priv(int memoryIncrease,XMLSTR lpszName, XMLSTR lpszValuev)
+{
+    if (!lpszName) return &emptyXMLAttribute;
+    if (!d) { myFree(lpszName); myFree(lpszValuev); return &emptyXMLAttribute; }
+    int nc=d->nAttribute;
+    d->pAttribute=(XMLAttribute*)myRealloc(d->pAttribute,(nc+1),memoryIncrease,sizeof(XMLAttribute));
+    XMLAttribute *pAttr=d->pAttribute+nc;
+    pAttr->lpszName = lpszName;
+    pAttr->lpszValue = lpszValuev;
+    d->nAttribute++;
+    return pAttr;
 }
 
 // Add text to the element.
-XMLCSTR XMLNode::addText_priv(int memoryIncrease, XMLSTR lpszValue, int pos) {
-  if (!lpszValue) return NULL;
-  if (!d) {
-    myFree(lpszValue);
-    return NULL;
-  }
-  d->pText = (XMLCSTR *)addToOrder(memoryIncrease, &pos, d->nText, d->pText,
-                                   sizeof(XMLSTR), eNodeText);
-  d->pText[pos] = lpszValue;
-  d->nText++;
-  return lpszValue;
+XMLCSTR XMLNode::addText_priv(int memoryIncrease, XMLSTR lpszValue, int pos)
+{
+    if (!lpszValue) return NULL;
+    if (!d) { myFree(lpszValue); return NULL; }
+    d->pText=(XMLCSTR*)addToOrder(memoryIncrease,&pos,d->nText,d->pText,sizeof(XMLSTR),eNodeText);
+    d->pText[pos]=lpszValue;
+    d->nText++;
+    return lpszValue;
 }
 
 // Add clear (unformatted) text to the element.
-XMLClear *XMLNode::addClear_priv(int memoryIncrease, XMLSTR lpszValue,
-                                 XMLCSTR lpszOpen, XMLCSTR lpszClose, int pos) {
-  if (!lpszValue) return &emptyXMLClear;
-  if (!d) {
-    myFree(lpszValue);
-    return &emptyXMLClear;
-  }
-  d->pClear = (XMLClear *)addToOrder(memoryIncrease, &pos, d->nClear, d->pClear,
-                                     sizeof(XMLClear), eNodeClear);
-  XMLClear *pNewClear = d->pClear + pos;
-  pNewClear->lpszValue = lpszValue;
-  if (!lpszOpen) lpszOpen = XMLClearTags->lpszOpen;
-  if (!lpszClose) lpszClose = XMLClearTags->lpszClose;
-  pNewClear->lpszOpenTag = lpszOpen;
-  pNewClear->lpszCloseTag = lpszClose;
-  d->nClear++;
-  return pNewClear;
+XMLClear *XMLNode::addClear_priv(int memoryIncrease, XMLSTR lpszValue, XMLCSTR lpszOpen, XMLCSTR lpszClose, int pos)
+{
+    if (!lpszValue) return &emptyXMLClear;
+    if (!d) { myFree(lpszValue); return &emptyXMLClear; }
+    d->pClear=(XMLClear *)addToOrder(memoryIncrease,&pos,d->nClear,d->pClear,sizeof(XMLClear),eNodeClear);
+    XMLClear *pNewClear=d->pClear+pos;
+    pNewClear->lpszValue = lpszValue;
+    if (!lpszOpen) lpszOpen=XMLClearTags->lpszOpen;
+    if (!lpszClose) lpszClose=XMLClearTags->lpszClose;
+    pNewClear->lpszOpenTag = lpszOpen;
+    pNewClear->lpszCloseTag = lpszClose;
+    d->nClear++;
+    return pNewClear;
 }
 
 // private:
 // Parse a clear (unformatted) type node.
-char XMLNode::parseClearTag(void *px, void *_pClear) {
-  XML *pXML = (XML *)px;
-  ALLXMLClearTag pClear = *((ALLXMLClearTag *)_pClear);
-  int cbTemp = 0;
-  XMLCSTR lpszTemp = NULL;
-  XMLCSTR lpXML = &pXML->lpXML[pXML->nIndex];
-  static XMLCSTR docTypeEnd = _CXML("]>");
+char XMLNode::parseClearTag(void *px, void *_pClear)
+{
+    XML *pXML=(XML *)px;
+    ALLXMLClearTag pClear=*((ALLXMLClearTag*)_pClear);
+    int cbTemp=0;
+    XMLCSTR lpszTemp=NULL;
+    XMLCSTR lpXML=&pXML->lpXML[pXML->nIndex];
+    static XMLCSTR docTypeEnd=_CXML("]>");
 
-  // Find the closing tag
-  // Seems the <!DOCTYPE need a better treatment so lets handle it
-  if (pClear.lpszOpen == XMLClearTags[1].lpszOpen) {
-    XMLCSTR pCh = lpXML;
-    while (*pCh) {
-      if (*pCh == _CXML('<')) {
-        pClear.lpszClose = docTypeEnd;
-        lpszTemp = xstrstr(lpXML, docTypeEnd);
-        break;
-      } else if (*pCh == _CXML('>')) {
-        lpszTemp = pCh;
-        break;
-      }
+    // Find the closing tag
+    // Seems the <!DOCTYPE need a better treatment so lets handle it
+    if (pClear.lpszOpen==XMLClearTags[1].lpszOpen)
+    {
+        XMLCSTR pCh=lpXML;
+        while (*pCh)
+        {
+            if (*pCh==_CXML('<')) { pClear.lpszClose=docTypeEnd; lpszTemp=xstrstr(lpXML,docTypeEnd); break; }
+            else if (*pCh==_CXML('>')) { lpszTemp=pCh; break; }
 #ifdef _XMLWIDECHAR
-      pCh++;
+            pCh++;
 #else
-      pCh += XML_ByteTable[(unsigned char)(*pCh)];
+            pCh+=XML_ByteTable[(unsigned char)(*pCh)];
 #endif
-    }
-  } else
-    lpszTemp = xstrstr(lpXML, pClear.lpszClose);
+        }
+    } else lpszTemp=xstrstr(lpXML, pClear.lpszClose);
 
-  if (lpszTemp) {
-    // Cache the size and increment the index
-    cbTemp = (int)(lpszTemp - lpXML);
+    if (lpszTemp)
+    {
+        // Cache the size and increment the index
+        cbTemp = (int)(lpszTemp - lpXML);
 
-    pXML->nIndex += cbTemp + (int)xstrlen(pClear.lpszClose);
+        pXML->nIndex += cbTemp+(int)xstrlen(pClear.lpszClose);
 
-    // Add the clear node to the current element
-    addClear_priv(MEMORYINCREASE, stringDup(lpXML, cbTemp), pClear.lpszOpen,
-                  pClear.lpszClose, -1);
-    return 0;
-  }
-
-  // If we failed to find the end tag
-  pXML->error = eXMLErrorUnmatchedEndClearTag;
-  return 1;
-}
-
-void XMLNode::exactMemory(XMLNodeData *d) {
-  if (d->pOrder)
-    d->pOrder = (int *)realloc(
-        d->pOrder, (d->nChild + d->nText + d->nClear) * sizeof(int));
-  if (d->pChild)
-    d->pChild = (XMLNode *)realloc(d->pChild, d->nChild * sizeof(XMLNode));
-  if (d->pAttribute)
-    d->pAttribute = (XMLAttribute *)realloc(
-        d->pAttribute, d->nAttribute * sizeof(XMLAttribute));
-  if (d->pText)
-    d->pText = (XMLCSTR *)realloc(d->pText, d->nText * sizeof(XMLSTR));
-  if (d->pClear)
-    d->pClear = (XMLClear *)realloc(d->pClear, d->nClear * sizeof(XMLClear));
-}
-
-char XMLNode::maybeAddTxT(void *pa, XMLCSTR tokenPStr) {
-  XML *pXML = (XML *)pa;
-  XMLCSTR lpszText = pXML->lpszText;
-  if (!lpszText) return 0;
-  if (dropWhiteSpace)
-    while (XML_isSPACECHAR(*lpszText) && (lpszText != tokenPStr)) lpszText++;
-  int cbText = (int)(tokenPStr - lpszText);
-  if (!cbText) {
-    pXML->lpszText = NULL;
-    return 0;
-  }
-  if (dropWhiteSpace) {
-    cbText--;
-    while ((cbText) && XML_isSPACECHAR(lpszText[cbText])) cbText--;
-    cbText++;
-  }
-  if (!cbText) {
-    pXML->lpszText = NULL;
-    return 0;
-  }
-  XMLSTR lpt = fromXMLString(lpszText, cbText, pXML);
-  if (!lpt) return 1;
-  pXML->lpszText = NULL;
-  if (removeCommentsInMiddleOfText && d->nText && d->nClear) {
-    // if the previous insertion was a comment (<!-- -->) AND
-    // if the previous previous insertion was a text then, delete the comment
-    // and append the text
-    int n = d->nChild + d->nText + d->nClear - 1, *o = d->pOrder;
-    if (((o[n] & 3) == eNodeClear) && ((o[n - 1] & 3) == eNodeText)) {
-      int i = o[n] >> 2;
-      if (d->pClear[i].lpszOpenTag == XMLClearTags[2].lpszOpen) {
-        deleteClear(i);
-        i = o[n - 1] >> 2;
-        n = xstrlen(d->pText[i]);
-        int n2 = xstrlen(lpt) + 1;
-        d->pText[i] =
-            (XMLSTR)realloc((void *)d->pText[i], (n + n2) * sizeof(XMLCHAR));
-        if (!d->pText[i]) return 1;
-        memcpy((void *)(d->pText[i] + n), lpt, n2 * sizeof(XMLCHAR));
-        free(lpt);
+        // Add the clear node to the current element
+        addClear_priv(MEMORYINCREASE,stringDup(lpXML,cbTemp), pClear.lpszOpen, pClear.lpszClose,-1);
         return 0;
-      }
     }
-  }
-  addText_priv(MEMORYINCREASE, lpt, -1);
-  return 0;
+
+    // If we failed to find the end tag
+    pXML->error = eXMLErrorUnmatchedEndClearTag;
+    return 1;
+}
+
+void XMLNode::exactMemory(XMLNodeData *d)
+{
+    if (d->pOrder)     d->pOrder=(int*)realloc(d->pOrder,(d->nChild+d->nText+d->nClear)*sizeof(int));
+    if (d->pChild)     d->pChild=(XMLNode*)realloc(d->pChild,d->nChild*sizeof(XMLNode));
+    if (d->pAttribute) d->pAttribute=(XMLAttribute*)realloc(d->pAttribute,d->nAttribute*sizeof(XMLAttribute));
+    if (d->pText)      d->pText=(XMLCSTR*)realloc(d->pText,d->nText*sizeof(XMLSTR));
+    if (d->pClear)     d->pClear=(XMLClear *)realloc(d->pClear,d->nClear*sizeof(XMLClear));
+}
+
+char XMLNode::maybeAddTxT(void *pa, XMLCSTR tokenPStr)
+{
+    XML *pXML=(XML *)pa;
+    XMLCSTR lpszText=pXML->lpszText;
+    if (!lpszText) return 0;
+    if (dropWhiteSpace) while (XML_isSPACECHAR(*lpszText)&&(lpszText!=tokenPStr)) lpszText++;
+    int cbText = (int)(tokenPStr - lpszText);
+    if (!cbText) { pXML->lpszText=NULL; return 0; }
+    if (dropWhiteSpace) { cbText--; while ((cbText)&&XML_isSPACECHAR(lpszText[cbText])) cbText--; cbText++; }
+    if (!cbText) { pXML->lpszText=NULL; return 0; }
+    XMLSTR lpt=fromXMLString(lpszText,cbText,pXML);
+    if (!lpt) return 1;
+    pXML->lpszText=NULL;
+    if (removeCommentsInMiddleOfText && d->nText && d->nClear)
+    {
+        // if the previous insertion was a comment (<!-- -->) AND
+        // if the previous previous insertion was a text then, delete the comment and append the text
+        int n=d->nChild+d->nText+d->nClear-1,*o=d->pOrder;
+        if (((o[n]&3)==eNodeClear)&&((o[n-1]&3)==eNodeText))
+        {
+            int i=o[n]>>2;
+            if (d->pClear[i].lpszOpenTag==XMLClearTags[2].lpszOpen)
+            {
+                deleteClear(i);
+                i=o[n-1]>>2;
+                n=xstrlen(d->pText[i]);
+                int n2=xstrlen(lpt)+1;
+                d->pText[i]=(XMLSTR)realloc((void*)d->pText[i],(n+n2)*sizeof(XMLCHAR));
+                if (!d->pText[i]) return 1;
+                memcpy((void*)(d->pText[i]+n),lpt,n2*sizeof(XMLCHAR));
+                free(lpt);
+                return 0;
+            }
+        }
+    }
+    addText_priv(MEMORYINCREASE,lpt,-1);
+    return 0;
 }
 // private:
 // Recursively parse an XML element.
-int XMLNode::ParseXMLElement(void *pa) {
-  XML *pXML = (XML *)pa;
-  int cbToken;
-  enum XMLTokenTypeTag xtype;
-  NextToken token;
-  XMLCSTR lpszTemp = NULL;
-  int cbTemp = 0;
-  char nDeclaration;
-  XMLNode pNew;
-  enum Status status;  // inside or outside a tag
-  enum Attrib attrib = eAttribName;
+int XMLNode::ParseXMLElement(void *pa)
+{
+    XML *pXML=(XML *)pa;
+    int cbToken;
+    enum XMLTokenTypeTag xtype;
+    NextToken token;
+    XMLCSTR lpszTemp=NULL;
+    int cbTemp=0;
+    char nDeclaration;
+    XMLNode pNew;
+    enum Status status; // inside or outside a tag
+    enum Attrib attrib = eAttribName;
 
-  assert(pXML);
+    assert(pXML);
 
-  // If this is the first call to the function
-  if (pXML->nFirst) {
-    // Assume we are outside of a tag definition
-    pXML->nFirst = FALSE;
-    status = eOutsideTag;
-  } else {
-    // If this is not the first call then we should only be called when inside a
-    // tag.
-    status = eInsideTag;
-  }
+    // If this is the first call to the function
+    if (pXML->nFirst)
+    {
+        // Assume we are outside of a tag definition
+        pXML->nFirst = FALSE;
+        status = eOutsideTag;
+    } else
+    {
+        // If this is not the first call then we should only be called when inside a tag.
+        status = eInsideTag;
+    }
 
-  // Iterate through the tokens in the document
-  for (;;) {
-    // Obtain the next token
-    token = GetNextToken(pXML, &cbToken, &xtype);
+    // Iterate through the tokens in the document
+    for(;;)
+    {
+        // Obtain the next token
+        token = GetNextToken(pXML, &cbToken, &xtype);
 
-    if (xtype != eTokenError) {
-      // Check the current status
-      switch (status) {
-        // If we are outside of a tag definition
-        case eOutsideTag:
+        if (xtype != eTokenError)
+        {
+            // Check the current status
+            switch(status)
+            {
 
-          // Check what type of token we obtained
-          switch (xtype) {
-            // If we have found text or quoted text
-            case eTokenText:
-            case eTokenCloseTag:       /* '>'         */
-            case eTokenShortHandClose: /* '/>'        */
-            case eTokenQuotedText:
-            case eTokenEquals:
-              break;
+            // If we are outside of a tag definition
+            case eOutsideTag:
 
-            // If we found a start tag '<' and declarations '<?'
-            case eTokenTagStart:
-            case eTokenDeclaration:
+                // Check what type of token we obtained
+                switch(xtype)
+                {
+                // If we have found text or quoted text
+                case eTokenText:
+                case eTokenCloseTag:          /* '>'         */
+                case eTokenShortHandClose:    /* '/>'        */
+                case eTokenQuotedText:
+                case eTokenEquals:
+                    break;
 
-              // Cache whether this new element is a declaration or not
-              nDeclaration = (xtype == eTokenDeclaration);
+                // If we found a start tag '<' and declarations '<?'
+                case eTokenTagStart:
+                case eTokenDeclaration:
 
-              // If we have node text then add this to the element
-              if (maybeAddTxT(pXML, token.pStr)) return FALSE;
+                    // Cache whether this new element is a declaration or not
+                    nDeclaration = (xtype == eTokenDeclaration);
 
-              // Find the name of the tag
-              token = GetNextToken(pXML, &cbToken, &xtype);
+                    // If we have node text then add this to the element
+                    if (maybeAddTxT(pXML,token.pStr)) return FALSE;
 
-              // Return an error if we couldn't obtain the next token or
-              // it wasnt text
-              if (xtype != eTokenText) {
-                pXML->error = eXMLErrorMissingTagName;
-                return FALSE;
-              }
+                    // Find the name of the tag
+                    token = GetNextToken(pXML, &cbToken, &xtype);
 
-// If we found a new element which is the same as this
-// element then we need to pass this back to the caller..
+                    // Return an error if we couldn't obtain the next token or
+                    // it wasnt text
+                    if (xtype != eTokenText)
+                    {
+                        pXML->error = eXMLErrorMissingTagName;
+                        return FALSE;
+                    }
+
+                    // If we found a new element which is the same as this
+                    // element then we need to pass this back to the caller..
 
 #ifdef APPROXIMATE_PARSING
-              if (d->lpszName && myTagCompare(d->lpszName, token.pStr) == 0) {
-                // Indicate to the caller that it needs to create a
-                // new element.
-                pXML->lpNewElement = token.pStr;
-                pXML->cbNewElement = cbToken;
-                return TRUE;
-              } else
-#endif
-              {
-                // If the name of the new element differs from the name of
-                // the current element we need to add the new element to
-                // the current one and recurse
-                pNew = addChild_priv(MEMORYINCREASE,
-                                     stringDup(token.pStr, cbToken),
-                                     nDeclaration, -1);
-
-                while (!pNew.isEmpty()) {
-                  // Callself to process the new node.  If we return
-                  // FALSE this means we dont have any more
-                  // processing to do...
-
-                  if (!pNew.ParseXMLElement(pXML))
-                    return FALSE;
-                  else {
-                    // If the call to recurse this function
-                    // evented in a end tag specified in XML then
-                    // we need to unwind the calls to this
-                    // function until we find the appropriate node
-                    // (the element name and end tag name must
-                    // match)
-                    if (pXML->cbEndTag) {
-                      // If we are back at the root node then we
-                      // have an unmatched end tag
-                      if (!d->lpszName) {
-                        pXML->error = eXMLErrorUnmatchedEndTag;
-                        return FALSE;
-                      }
-
-                      // If the end tag matches the name of this
-                      // element then we only need to unwind
-                      // once more...
-
-                      if (myTagCompare(d->lpszName, pXML->lpEndTag) == 0) {
-                        pXML->cbEndTag = 0;
-                      }
-
-                      return TRUE;
-                    } else if (pXML->cbNewElement) {
-                      // If the call indicated a new element is to
-                      // be created on THIS element.
-
-                      // If the name of this element matches the
-                      // name of the element we need to create
-                      // then we need to return to the caller
-                      // and let it process the element.
-
-                      if (myTagCompare(d->lpszName, pXML->lpNewElement) == 0) {
+                    if (d->lpszName &&
+                        myTagCompare(d->lpszName, token.pStr) == 0)
+                    {
+                        // Indicate to the caller that it needs to create a
+                        // new element.
+                        pXML->lpNewElement = token.pStr;
+                        pXML->cbNewElement = cbToken;
                         return TRUE;
-                      }
+                    } else
+#endif
+                    {
+                        // If the name of the new element differs from the name of
+                        // the current element we need to add the new element to
+                        // the current one and recurse
+                        pNew = addChild_priv(MEMORYINCREASE,stringDup(token.pStr,cbToken), nDeclaration,-1);
 
-                      // Add the new element and recurse
-                      pNew = addChild_priv(
-                          MEMORYINCREASE,
-                          stringDup(pXML->lpNewElement, pXML->cbNewElement), 0,
-                          -1);
-                      pXML->cbNewElement = 0;
-                    } else {
-                      // If we didn't have a new element to create
-                      pNew = emptyXMLNode;
+                        while (!pNew.isEmpty())
+                        {
+                            // Callself to process the new node.  If we return
+                            // FALSE this means we dont have any more
+                            // processing to do...
+
+                            if (!pNew.ParseXMLElement(pXML)) return FALSE;
+                            else
+                            {
+                                // If the call to recurse this function
+                                // evented in a end tag specified in XML then
+                                // we need to unwind the calls to this
+                                // function until we find the appropriate node
+                                // (the element name and end tag name must
+                                // match)
+                                if (pXML->cbEndTag)
+                                {
+                                    // If we are back at the root node then we
+                                    // have an unmatched end tag
+                                    if (!d->lpszName)
+                                    {
+                                        pXML->error=eXMLErrorUnmatchedEndTag;
+                                        return FALSE;
+                                    }
+
+                                    // If the end tag matches the name of this
+                                    // element then we only need to unwind
+                                    // once more...
+
+                                    if (myTagCompare(d->lpszName, pXML->lpEndTag)==0)
+                                    {
+                                        pXML->cbEndTag = 0;
+                                    }
+
+                                    return TRUE;
+                                } else
+                                    if (pXML->cbNewElement)
+                                    {
+                                        // If the call indicated a new element is to
+                                        // be created on THIS element.
+
+                                        // If the name of this element matches the
+                                        // name of the element we need to create
+                                        // then we need to return to the caller
+                                        // and let it process the element.
+
+                                        if (myTagCompare(d->lpszName, pXML->lpNewElement)==0)
+                                        {
+                                            return TRUE;
+                                        }
+
+                                        // Add the new element and recurse
+                                        pNew = addChild_priv(MEMORYINCREASE,stringDup(pXML->lpNewElement,pXML->cbNewElement),0,-1);
+                                        pXML->cbNewElement = 0;
+                                    }
+                                    else
+                                    {
+                                        // If we didn't have a new element to create
+                                        pNew = emptyXMLNode;
+
+                                    }
+                            }
+                        }
                     }
-                  }
-                }
-              }
-              break;
+                    break;
 
-            // If we found an end tag
-            case eTokenTagEnd:
+                // If we found an end tag
+                case eTokenTagEnd:
 
-              // If we have node text then add this to the element
-              if (maybeAddTxT(pXML, token.pStr)) return FALSE;
+                    // If we have node text then add this to the element
+                    if (maybeAddTxT(pXML,token.pStr)) return FALSE;
 
-              // Find the name of the end tag
-              token = GetNextToken(pXML, &cbTemp, &xtype);
+                    // Find the name of the end tag
+                    token = GetNextToken(pXML, &cbTemp, &xtype);
 
-              // The end tag should be text
-              if (xtype != eTokenText) {
-                pXML->error = eXMLErrorMissingEndTagName;
-                return FALSE;
-              }
-              lpszTemp = token.pStr;
+                    // The end tag should be text
+                    if (xtype != eTokenText)
+                    {
+                        pXML->error = eXMLErrorMissingEndTagName;
+                        return FALSE;
+                    }
+                    lpszTemp = token.pStr;
 
-              // After the end tag we should find a closing tag
-              token = GetNextToken(pXML, &cbToken, &xtype);
-              if (xtype != eTokenCloseTag) {
-                pXML->error = eXMLErrorMissingEndTagName;
-                return FALSE;
-              }
-              pXML->lpszText = pXML->lpXML + pXML->nIndex;
+                    // After the end tag we should find a closing tag
+                    token = GetNextToken(pXML, &cbToken, &xtype);
+                    if (xtype != eTokenCloseTag)
+                    {
+                        pXML->error = eXMLErrorMissingEndTagName;
+                        return FALSE;
+                    }
+                    pXML->lpszText=pXML->lpXML+pXML->nIndex;
 
-              // We need to return to the previous caller.  If the name
-              // of the tag cannot be found we need to keep returning to
-              // caller until we find a match
-              if (myTagCompare(d->lpszName, lpszTemp) != 0)
+                    // We need to return to the previous caller.  If the name
+                    // of the tag cannot be found we need to keep returning to
+                    // caller until we find a match
+                    if (myTagCompare(d->lpszName, lpszTemp) != 0)
 #ifdef STRICT_PARSING
-              {
-                pXML->error = eXMLErrorUnmatchedEndTag;
-                pXML->nIndexMissigEndTag = pXML->nIndex;
-                return FALSE;
-              }
+                    {
+                        pXML->error=eXMLErrorUnmatchedEndTag;
+                        pXML->nIndexMissigEndTag=pXML->nIndex;
+                        return FALSE;
+                    }
 #else
-              {
-                pXML->error = eXMLErrorMissingEndTag;
-                pXML->nIndexMissigEndTag = pXML->nIndex;
-                pXML->lpEndTag = lpszTemp;
-                pXML->cbEndTag = cbTemp;
-              }
+                    {
+                        pXML->error=eXMLErrorMissingEndTag;
+                        pXML->nIndexMissigEndTag=pXML->nIndex;
+                        pXML->lpEndTag = lpszTemp;
+                        pXML->cbEndTag = cbTemp;
+                    }
 #endif
 
-              // Return to the caller
-              exactMemory(d);
-              return TRUE;
-
-            // If we found a clear (unformatted) token
-            case eTokenClear:
-              // If we have node text then add this to the element
-              if (maybeAddTxT(pXML, token.pStr)) return FALSE;
-              if (parseClearTag(pXML, token.pClr)) return FALSE;
-              pXML->lpszText = pXML->lpXML + pXML->nIndex;
-              break;
-
-            default:
-              break;
-          }
-          break;
-
-        // If we are inside a tag definition we need to search for attributes
-        case eInsideTag:
-
-          // Check what part of the attribute (name, equals, value) we
-          // are looking for.
-          switch (attrib) {
-            // If we are looking for a new attribute
-            case eAttribName:
-
-              // Check what the current token type is
-              switch (xtype) {
-                // If the current type is text...
-                // Eg.  'attribute'
-                case eTokenText:
-                  // Cache the token then indicate that we are next to
-                  // look for the equals
-                  lpszTemp = token.pStr;
-                  cbTemp = cbToken;
-                  attrib = eAttribEquals;
-                  break;
-
-                // If we found a closing tag...
-                // Eg.  '>'
-                case eTokenCloseTag:
-                  // We are now outside the tag
-                  status = eOutsideTag;
-                  pXML->lpszText = pXML->lpXML + pXML->nIndex;
-                  break;
-
-                // If we found a short hand '/>' closing tag then we can
-                // return to the caller
-                case eTokenShortHandClose:
-                  exactMemory(d);
-                  pXML->lpszText = pXML->lpXML + pXML->nIndex;
-                  return TRUE;
-
-                // Errors...
-                case eTokenQuotedText:  /* '"SomeText"'   */
-                case eTokenTagStart:    /* '<'            */
-                case eTokenTagEnd:      /* '</'           */
-                case eTokenEquals:      /* '='            */
-                case eTokenDeclaration: /* '<?'           */
-                case eTokenClear:
-                  pXML->error = eXMLErrorUnexpectedToken;
-                  return FALSE;
-                default:
-                  break;
-              }
-              break;
-
-            // If we are looking for an equals
-            case eAttribEquals:
-              // Check what the current token type is
-              switch (xtype) {
-                // If the current type is text...
-                // Eg.  'Attribute AnotherAttribute'
-                case eTokenText:
-                  // Add the unvalued attribute to the list
-                  addAttribute_priv(MEMORYINCREASE, stringDup(lpszTemp, cbTemp),
-                                    NULL);
-                  // Cache the token then indicate.  We are next to
-                  // look for the equals attribute
-                  lpszTemp = token.pStr;
-                  cbTemp = cbToken;
-                  break;
-
-                // If we found a closing tag 'Attribute >' or a short hand
-                // closing tag 'Attribute />'
-                case eTokenShortHandClose:
-                case eTokenCloseTag:
-                  // If we are a declaration element '<?' then we need
-                  // to remove extra closing '?' if it exists
-                  pXML->lpszText = pXML->lpXML + pXML->nIndex;
-
-                  if (d->isDeclaration &&
-                      (lpszTemp[cbTemp - 1]) == _CXML('?')) {
-                    cbTemp--;
-                    if (d->pParent && d->pParent->pParent)
-                      xtype = eTokenShortHandClose;
-                  }
-
-                  if (cbTemp) {
-                    // Add the unvalued attribute to the list
-                    addAttribute_priv(MEMORYINCREASE,
-                                      stringDup(lpszTemp, cbTemp), NULL);
-                  }
-
-                  // If this is the end of the tag then return to the caller
-                  if (xtype == eTokenShortHandClose) {
+                    // Return to the caller
                     exactMemory(d);
                     return TRUE;
-                  }
 
-                  // We are now outside the tag
-                  status = eOutsideTag;
-                  break;
-
-                // If we found the equals token...
-                // Eg.  'Attribute ='
-                case eTokenEquals:
-                  // Indicate that we next need to search for the value
-                  // for the attribute
-                  attrib = eAttribValue;
-                  break;
-
-                // Errors...
-                case eTokenQuotedText:  /* 'Attribute "InvalidAttr"'*/
-                case eTokenTagStart:    /* 'Attribute <'            */
-                case eTokenTagEnd:      /* 'Attribute </'           */
-                case eTokenDeclaration: /* 'Attribute <?'           */
+                // If we found a clear (unformatted) token
                 case eTokenClear:
-                  pXML->error = eXMLErrorUnexpectedToken;
-                  return FALSE;
+                    // If we have node text then add this to the element
+                    if (maybeAddTxT(pXML,token.pStr)) return FALSE;
+                    if (parseClearTag(pXML, token.pClr)) return FALSE;
+                    pXML->lpszText=pXML->lpXML+pXML->nIndex;
+                    break;
+
                 default:
-                  break;
-              }
-              break;
+                    break;
+                }
+                break;
 
-            // If we are looking for an attribute value
-            case eAttribValue:
-              // Check what the current token type is
-              switch (xtype) {
-                // If the current type is text or quoted text...
-                // Eg.  'Attribute = "Value"' or 'Attribute = Value' or
-                // 'Attribute = 'Value''.
-                case eTokenText:
-                case eTokenQuotedText:
-                  // If we are a declaration element '<?' then we need
-                  // to remove extra closing '?' if it exists
-                  if (d->isDeclaration &&
-                      (token.pStr[cbToken - 1]) == _CXML('?')) {
-                    cbToken--;
-                  }
+            // If we are inside a tag definition we need to search for attributes
+            case eInsideTag:
 
-                  if (cbTemp) {
-                    // Add the valued attribute to the list
-                    if (xtype == eTokenQuotedText) {
-                      token.pStr++;
-                      cbToken -= 2;
+                // Check what part of the attribute (name, equals, value) we
+                // are looking for.
+                switch(attrib)
+                {
+                // If we are looking for a new attribute
+                case eAttribName:
+
+                    // Check what the current token type is
+                    switch(xtype)
+                    {
+                    // If the current type is text...
+                    // Eg.  'attribute'
+                    case eTokenText:
+                        // Cache the token then indicate that we are next to
+                        // look for the equals
+                        lpszTemp = token.pStr;
+                        cbTemp = cbToken;
+                        attrib = eAttribEquals;
+                        break;
+
+                    // If we found a closing tag...
+                    // Eg.  '>'
+                    case eTokenCloseTag:
+                        // We are now outside the tag
+                        status = eOutsideTag;
+                        pXML->lpszText=pXML->lpXML+pXML->nIndex;
+                        break;
+
+                    // If we found a short hand '/>' closing tag then we can
+                    // return to the caller
+                    case eTokenShortHandClose:
+                        exactMemory(d);
+                        pXML->lpszText=pXML->lpXML+pXML->nIndex;
+                        return TRUE;
+
+                    // Errors...
+                    case eTokenQuotedText:    /* '"SomeText"'   */
+                    case eTokenTagStart:      /* '<'            */
+                    case eTokenTagEnd:        /* '</'           */
+                    case eTokenEquals:        /* '='            */
+                    case eTokenDeclaration:   /* '<?'           */
+                    case eTokenClear:
+                        pXML->error = eXMLErrorUnexpectedToken;
+                        return FALSE;
+                    default: break;
                     }
-                    XMLSTR attrVal = (XMLSTR)token.pStr;
-                    if (attrVal) {
-                      attrVal = fromXMLString(attrVal, cbToken, pXML);
-                      if (!attrVal) return FALSE;
+                    break;
+
+                // If we are looking for an equals
+                case eAttribEquals:
+                    // Check what the current token type is
+                    switch(xtype)
+                    {
+                    // If the current type is text...
+                    // Eg.  'Attribute AnotherAttribute'
+                    case eTokenText:
+                        // Add the unvalued attribute to the list
+                        addAttribute_priv(MEMORYINCREASE,stringDup(lpszTemp,cbTemp), NULL);
+                        // Cache the token then indicate.  We are next to
+                        // look for the equals attribute
+                        lpszTemp = token.pStr;
+                        cbTemp = cbToken;
+                        break;
+
+                    // If we found a closing tag 'Attribute >' or a short hand
+                    // closing tag 'Attribute />'
+                    case eTokenShortHandClose:
+                    case eTokenCloseTag:
+                        // If we are a declaration element '<?' then we need
+                        // to remove extra closing '?' if it exists
+                        pXML->lpszText=pXML->lpXML+pXML->nIndex;
+
+                        if (d->isDeclaration &&
+                            (lpszTemp[cbTemp-1]) == _CXML('?'))
+                        {
+                            cbTemp--;
+                            if (d->pParent && d->pParent->pParent) xtype = eTokenShortHandClose;
+                        }
+
+                        if (cbTemp)
+                        {
+                            // Add the unvalued attribute to the list
+                            addAttribute_priv(MEMORYINCREASE,stringDup(lpszTemp,cbTemp), NULL);
+                        }
+
+                        // If this is the end of the tag then return to the caller
+                        if (xtype == eTokenShortHandClose)
+                        {
+                            exactMemory(d);
+                            return TRUE;
+                        }
+
+                        // We are now outside the tag
+                        status = eOutsideTag;
+                        break;
+
+                    // If we found the equals token...
+                    // Eg.  'Attribute ='
+                    case eTokenEquals:
+                        // Indicate that we next need to search for the value
+                        // for the attribute
+                        attrib = eAttribValue;
+                        break;
+
+                    // Errors...
+                    case eTokenQuotedText:    /* 'Attribute "InvalidAttr"'*/
+                    case eTokenTagStart:      /* 'Attribute <'            */
+                    case eTokenTagEnd:        /* 'Attribute </'           */
+                    case eTokenDeclaration:   /* 'Attribute <?'           */
+                    case eTokenClear:
+                        pXML->error = eXMLErrorUnexpectedToken;
+                        return FALSE;
+                    default: break;
                     }
-                    addAttribute_priv(MEMORYINCREASE,
-                                      stringDup(lpszTemp, cbTemp), attrVal);
-                  }
+                    break;
 
-                  // Indicate we are searching for a new attribute
-                  attrib = eAttribName;
-                  break;
+                // If we are looking for an attribute value
+                case eAttribValue:
+                    // Check what the current token type is
+                    switch(xtype)
+                    {
+                    // If the current type is text or quoted text...
+                    // Eg.  'Attribute = "Value"' or 'Attribute = Value' or
+                    // 'Attribute = 'Value''.
+                    case eTokenText:
+                    case eTokenQuotedText:
+                        // If we are a declaration element '<?' then we need
+                        // to remove extra closing '?' if it exists
+                        if (d->isDeclaration &&
+                            (token.pStr[cbToken-1]) == _CXML('?'))
+                        {
+                            cbToken--;
+                        }
 
-                // Errors...
-                case eTokenTagStart:       /* 'Attr = <'          */
-                case eTokenTagEnd:         /* 'Attr = </'         */
-                case eTokenCloseTag:       /* 'Attr = >'          */
-                case eTokenShortHandClose: /* "Attr = />"         */
-                case eTokenEquals:         /* 'Attr = ='          */
-                case eTokenDeclaration:    /* 'Attr = <?'         */
-                case eTokenClear:
-                  pXML->error = eXMLErrorUnexpectedToken;
-                  return FALSE;
-                  break;
-                default:
-                  break;
-              }
-          }
-      }
-    }
-    // If we failed to obtain the next token
-    else {
-      if ((!d->isDeclaration) && (d->pParent)) {
+                        if (cbTemp)
+                        {
+                            // Add the valued attribute to the list
+                            if (xtype==eTokenQuotedText) { token.pStr++; cbToken-=2; }
+                            XMLSTR attrVal=(XMLSTR)token.pStr;
+                            if (attrVal)
+                            {
+                                attrVal=fromXMLString(attrVal,cbToken,pXML);
+                                if (!attrVal) return FALSE;
+                            }
+                            addAttribute_priv(MEMORYINCREASE,stringDup(lpszTemp,cbTemp),attrVal);
+                        }
+
+                        // Indicate we are searching for a new attribute
+                        attrib = eAttribName;
+                        break;
+
+                    // Errors...
+                    case eTokenTagStart:        /* 'Attr = <'          */
+                    case eTokenTagEnd:          /* 'Attr = </'         */
+                    case eTokenCloseTag:        /* 'Attr = >'          */
+                    case eTokenShortHandClose:  /* "Attr = />"         */
+                    case eTokenEquals:          /* 'Attr = ='          */
+                    case eTokenDeclaration:     /* 'Attr = <?'         */
+                    case eTokenClear:
+                        pXML->error = eXMLErrorUnexpectedToken;
+                        return FALSE;
+                        break;
+                    default: break;
+                    }
+                }
+            }
+        }
+        // If we failed to obtain the next token
+        else
+        {
+            if ((!d->isDeclaration)&&(d->pParent))
+            {
 #ifdef STRICT_PARSING
-        pXML->error = eXMLErrorUnmatchedEndTag;
+                pXML->error=eXMLErrorUnmatchedEndTag;
 #else
-        pXML->error = eXMLErrorMissingEndTag;
+                pXML->error=eXMLErrorMissingEndTag;
 #endif
-        pXML->nIndexMissigEndTag = pXML->nIndex;
-      }
-      maybeAddTxT(pXML, pXML->lpXML + pXML->nIndex);
-      return FALSE;
+                pXML->nIndexMissigEndTag=pXML->nIndex;
+            }
+            maybeAddTxT(pXML,pXML->lpXML+pXML->nIndex);
+            return FALSE;
+        }
     }
-  }
 }
 
 // Count the number of lines and columns in an XML string.
-static void CountLinesAndColumns(XMLCSTR lpXML, int nUpto,
-                                 XMLResults *pResults) {
-  XMLCHAR ch;
-  assert(lpXML);
-  assert(pResults);
+static void CountLinesAndColumns(XMLCSTR lpXML, int nUpto, XMLResults *pResults)
+{
+    XMLCHAR ch;
+    assert(lpXML);
+    assert(pResults);
 
-  struct XML xml = {lpXML, lpXML, 0, 0, eXMLErrorNone, NULL, 0, NULL, 0, TRUE};
+    struct XML xml={ lpXML,lpXML, 0, 0, eXMLErrorNone, NULL, 0, NULL, 0, TRUE };
 
-  pResults->nLine = 1;
-  pResults->nColumn = 1;
-  while (xml.nIndex < nUpto) {
-    ch = getNextChar(&xml);
-    if (ch != _CXML('\n'))
-      pResults->nColumn++;
-    else {
-      pResults->nLine++;
-      pResults->nColumn = 1;
+    pResults->nLine = 1;
+    pResults->nColumn = 1;
+    while (xml.nIndex<nUpto)
+    {
+        ch = getNextChar(&xml);
+        if (ch != _CXML('\n')) pResults->nColumn++;
+        else
+        {
+            pResults->nLine++;
+            pResults->nColumn=1;
+        }
     }
-  }
 }
 
 // Parse XML and return the root element.
-XMLNode XMLNode::parseString(XMLCSTR lpszXML, XMLCSTR tag,
-                             XMLResults *pResults) {
-  if (!lpszXML) {
-    if (pResults) {
-      pResults->error = eXMLErrorNoElements;
-      pResults->nLine = 0;
-      pResults->nColumn = 0;
-    }
-    return emptyXMLNode;
-  }
-
-  XMLNode xnode(NULL, NULL, FALSE);
-  struct XML xml = {lpszXML, lpszXML, 0,    0, eXMLErrorNone,
-                    NULL,    0,       NULL, 0, TRUE};
-
-  // Create header element
-  xnode.ParseXMLElement(&xml);
-  enum XMLError error = xml.error;
-  if (!xnode.nChildNode()) error = eXMLErrorNoXMLTagFound;
-  if ((xnode.nChildNode() == 1) && (xnode.nElement() == 1))
-    xnode = xnode.getChildNode();  // skip the empty node
-
-  // If no error occurred
-  if ((error == eXMLErrorNone) || (error == eXMLErrorMissingEndTag) ||
-      (error == eXMLErrorNoXMLTagFound)) {
-    XMLCSTR name = xnode.getName();
-    if (tag && (*tag) && ((!name) || (xstricmp(name, tag)))) {
-      xnode = xnode.getChildNode(tag);
-      if (xnode.isEmpty()) {
-        if (pResults) {
-          pResults->error = eXMLErrorFirstTagNotFound;
-          pResults->nLine = 0;
-          pResults->nColumn = 0;
+XMLNode XMLNode::parseString(XMLCSTR lpszXML, XMLCSTR tag, XMLResults *pResults)
+{
+    if (!lpszXML)
+    {
+        if (pResults)
+        {
+            pResults->error=eXMLErrorNoElements;
+            pResults->nLine=0;
+            pResults->nColumn=0;
         }
         return emptyXMLNode;
-      }
     }
-  } else {
-    // Cleanup: this will destroy all the nodes
-    xnode = emptyXMLNode;
-  }
 
-  // If we have been given somewhere to place results
-  if (pResults) {
-    pResults->error = error;
+    XMLNode xnode(NULL,NULL,FALSE);
+    struct XML xml={ lpszXML, lpszXML, 0, 0, eXMLErrorNone, NULL, 0, NULL, 0, TRUE };
 
-    // If we have an error
-    if (error != eXMLErrorNone) {
-      if (error == eXMLErrorMissingEndTag) xml.nIndex = xml.nIndexMissigEndTag;
-      // Find which line and column it starts on.
-      CountLinesAndColumns(xml.lpXML, xml.nIndex, pResults);
+    // Create header element
+    xnode.ParseXMLElement(&xml);
+    enum XMLError error = xml.error;
+    if (!xnode.nChildNode()) error=eXMLErrorNoXMLTagFound;
+    if ((xnode.nChildNode()==1)&&(xnode.nElement()==1)) xnode=xnode.getChildNode(); // skip the empty node
+
+    // If no error occurred
+    if ((error==eXMLErrorNone)||(error==eXMLErrorMissingEndTag)||(error==eXMLErrorNoXMLTagFound))
+    {
+        XMLCSTR name=xnode.getName();
+        if (tag&&(*tag)&&((!name)||(xstricmp(name,tag))))
+        {
+            xnode=xnode.getChildNode(tag);
+            if (xnode.isEmpty())
+            {
+                if (pResults)
+                {
+                    pResults->error=eXMLErrorFirstTagNotFound;
+                    pResults->nLine=0;
+                    pResults->nColumn=0;
+                }
+                return emptyXMLNode;
+            }
+        }
+    } else
+    {
+        // Cleanup: this will destroy all the nodes
+        xnode = emptyXMLNode;
     }
-  }
-  return xnode;
+
+
+    // If we have been given somewhere to place results
+    if (pResults)
+    {
+        pResults->error = error;
+
+        // If we have an error
+        if (error!=eXMLErrorNone)
+        {
+            if (error==eXMLErrorMissingEndTag) xml.nIndex=xml.nIndexMissigEndTag;
+            // Find which line and column it starts on.
+            CountLinesAndColumns(xml.lpXML, xml.nIndex, pResults);
+        }
+    }
+    return xnode;
 }
 
-XMLNode XMLNode::parseFile(XMLCSTR filename, XMLCSTR tag,
-                           XMLResults *pResults) {
-  if (pResults) {
-    pResults->nLine = 0;
-    pResults->nColumn = 0;
-  }
-  FILE *f = xfopen(filename, _CXML("rb"));
-  if (f == NULL) {
-    if (pResults) pResults->error = eXMLErrorFileNotFound;
-    return emptyXMLNode;
-  }
-  fseek(f, 0, SEEK_END);
-  int l = ftell(f), headerSz = 0;
-  if (!l) {
-    if (pResults) pResults->error = eXMLErrorEmpty;
+XMLNode XMLNode::parseFile(XMLCSTR filename, XMLCSTR tag, XMLResults *pResults)
+{
+    if (pResults) { pResults->nLine=0; pResults->nColumn=0; }
+    FILE *f=xfopen(filename,_CXML("rb"));
+    if (f==NULL) { if (pResults) pResults->error=eXMLErrorFileNotFound; return emptyXMLNode; }
+    fseek(f,0,SEEK_END);
+    int l=ftell(f),headerSz=0;
+    if (!l) { if (pResults) pResults->error=eXMLErrorEmpty; fclose(f); return emptyXMLNode; }
+    fseek(f,0,SEEK_SET);
+    unsigned char *buf=(unsigned char*)malloc(l+4);
+    l=fread(buf,1,l,f);
     fclose(f);
-    return emptyXMLNode;
-  }
-  fseek(f, 0, SEEK_SET);
-  unsigned char *buf = (unsigned char *)malloc(l + 4);
-  l = fread(buf, 1, l, f);
-  fclose(f);
-  buf[l] = 0;
-  buf[l + 1] = 0;
-  buf[l + 2] = 0;
-  buf[l + 3] = 0;
+    buf[l]=0;buf[l+1]=0;buf[l+2]=0;buf[l+3]=0;
 #ifdef _XMLWIDECHAR
-  if (guessWideCharChars) {
-    if (!myIsTextWideChar(buf, l)) {
-      XMLNode::XMLCharEncoding ce = XMLNode::char_encoding_legacy;
-      if ((buf[0] == 0xef) && (buf[1] == 0xbb) && (buf[2] == 0xbf)) {
-        headerSz = 3;
-        ce = XMLNode::char_encoding_UTF8;
-      }
-      XMLSTR b2 = myMultiByteToWideChar((const char *)(buf + headerSz), ce);
-      free(buf);
-      buf = (unsigned char *)b2;
-      headerSz = 0;
-    } else {
-      if ((buf[0] == 0xef) && (buf[1] == 0xff)) headerSz = 2;
-      if ((buf[0] == 0xff) && (buf[1] == 0xfe)) headerSz = 2;
+    if (guessWideCharChars)
+    {
+        if (!myIsTextWideChar(buf,l))
+        {
+            XMLNode::XMLCharEncoding ce=XMLNode::char_encoding_legacy;
+            if ((buf[0]==0xef)&&(buf[1]==0xbb)&&(buf[2]==0xbf)) { headerSz=3; ce=XMLNode::char_encoding_UTF8; }
+            XMLSTR b2=myMultiByteToWideChar((const char*)(buf+headerSz),ce);
+            free(buf); buf=(unsigned char*)b2; headerSz=0;
+        } else
+        {
+            if ((buf[0]==0xef)&&(buf[1]==0xff)) headerSz=2;
+            if ((buf[0]==0xff)&&(buf[1]==0xfe)) headerSz=2;
+        }
     }
-  }
 #else
-  if (guessWideCharChars) {
-    if (myIsTextWideChar(buf, l)) {
-      if ((buf[0] == 0xef) && (buf[1] == 0xff)) headerSz = 2;
-      if ((buf[0] == 0xff) && (buf[1] == 0xfe)) headerSz = 2;
-      char *b2 = myWideCharToMultiByte((const wchar_t *)(buf + headerSz));
-      free(buf);
-      buf = (unsigned char *)b2;
-      headerSz = 0;
-    } else {
-      if ((buf[0] == 0xef) && (buf[1] == 0xbb) && (buf[2] == 0xbf))
-        headerSz = 3;
+    if (guessWideCharChars)
+    {
+        if (myIsTextWideChar(buf,l))
+        {
+            if ((buf[0]==0xef)&&(buf[1]==0xff)) headerSz=2;
+            if ((buf[0]==0xff)&&(buf[1]==0xfe)) headerSz=2;
+            char *b2=myWideCharToMultiByte((const wchar_t*)(buf+headerSz));
+            free(buf); buf=(unsigned char*)b2; headerSz=0;
+        } else
+        {
+            if ((buf[0]==0xef)&&(buf[1]==0xbb)&&(buf[2]==0xbf)) headerSz=3;
+        }
     }
-  }
 #endif
 
-  if (!buf) {
-    if (pResults) pResults->error = eXMLErrorCharConversionError;
-    return emptyXMLNode;
-  }
-  XMLNode x = parseString((XMLSTR)(buf + headerSz), tag, pResults);
-  free(buf);
-  return x;
+    if (!buf) { if (pResults) pResults->error=eXMLErrorCharConversionError; return emptyXMLNode; }
+    XMLNode x=parseString((XMLSTR)(buf+headerSz),tag,pResults);
+    free(buf);
+    return x;
 }
 
-static inline void charmemset(XMLSTR dest, XMLCHAR c, int l) {
-  while (l--) *(dest++) = c;
-}
+static inline void charmemset(XMLSTR dest,XMLCHAR c,int l) { while (l--) *(dest++)=c; }
 // private:
 // Creates an user friendly XML string from a given element with
 // appropriate white space and carriage returns.
 //
 // This recurses through all subnodes then adds contents of the nodes to the
 // string.
-int XMLNode::CreateXMLStringR(XMLNodeData *pEntry, XMLSTR lpszMarker,
-                              int nFormat) {
-  int nResult = 0;
-  int cb = nFormat < 0 ? 0 : nFormat;
-  int cbElement;
-  int nChildFormat = -1;
-  int nElementI = pEntry->nChild + pEntry->nText + pEntry->nClear;
-  int i, j;
-  if ((nFormat >= 0) && (nElementI == 1) && (pEntry->nText == 1) &&
-      (!pEntry->isDeclaration))
-    nFormat = -2;
+int XMLNode::CreateXMLStringR(XMLNodeData *pEntry, XMLSTR lpszMarker, int nFormat)
+{
+    int nResult = 0;
+    int cb=nFormat<0?0:nFormat;
+    int cbElement;
+    int nChildFormat=-1;
+    int nElementI=pEntry->nChild+pEntry->nText+pEntry->nClear;
+    int i,j;
+    if ((nFormat>=0)&&(nElementI==1)&&(pEntry->nText==1)&&(!pEntry->isDeclaration)) nFormat=-2;
 
-  assert(pEntry);
+    assert(pEntry);
 
 #define LENSTR(lpsz) (lpsz ? xstrlen(lpsz) : 0)
 
-  // If the element has no name then assume this is the head node.
-  cbElement = (int)LENSTR(pEntry->lpszName);
+    // If the element has no name then assume this is the head node.
+    cbElement = (int)LENSTR(pEntry->lpszName);
 
-  if (cbElement) {
-    // "<elementname "
-    if (lpszMarker) {
-      if (cb) charmemset(lpszMarker, INDENTCHAR, cb);
-      nResult = cb;
-      lpszMarker[nResult++] = _CXML('<');
-      if (pEntry->isDeclaration) lpszMarker[nResult++] = _CXML('?');
-      xstrcpy(&lpszMarker[nResult], pEntry->lpszName);
-      nResult += cbElement;
-      lpszMarker[nResult++] = _CXML(' ');
+    if (cbElement)
+    {
+        // "<elementname "
+        if (lpszMarker)
+        {
+            if (cb) charmemset(lpszMarker, INDENTCHAR, cb);
+            nResult = cb;
+            lpszMarker[nResult++]=_CXML('<');
+            if (pEntry->isDeclaration) lpszMarker[nResult++]=_CXML('?');
+            xstrcpy(&lpszMarker[nResult], pEntry->lpszName);
+            nResult+=cbElement;
+            lpszMarker[nResult++]=_CXML(' ');
 
-    } else {
-      nResult += cbElement + 2 + cb;
-      if (pEntry->isDeclaration) nResult++;
-    }
+        } else
+        {
+            nResult+=cbElement+2+cb;
+            if (pEntry->isDeclaration) nResult++;
+        }
 
-    // Enumerate attributes and add them to the string
-    XMLAttribute *pAttr = pEntry->pAttribute;
-    for (i = 0; i < pEntry->nAttribute; i++) {
-      // "Attrib
-      cb = (int)LENSTR(pAttr->lpszName);
-      if (cb) {
-        if (lpszMarker) xstrcpy(&lpszMarker[nResult], pAttr->lpszName);
-        nResult += cb;
-        // "Attrib=Value "
-        if (pAttr->lpszValue) {
-          cb = (int)ToXMLStringTool::lengthXMLString(pAttr->lpszValue);
-          if (lpszMarker) {
-            lpszMarker[nResult] = _CXML('=');
-            lpszMarker[nResult + 1] = _CXML('"');
+        // Enumerate attributes and add them to the string
+        XMLAttribute *pAttr=pEntry->pAttribute;
+        for (i=0; i<pEntry->nAttribute; i++)
+        {
+            // "Attrib
+            cb = (int)LENSTR(pAttr->lpszName);
             if (cb)
-              ToXMLStringTool::toXMLUnSafe(&lpszMarker[nResult + 2],
-                                           pAttr->lpszValue);
-            lpszMarker[nResult + cb + 2] = _CXML('"');
-          }
-          nResult += cb + 3;
-        }
-        if (lpszMarker) lpszMarker[nResult] = _CXML(' ');
-        nResult++;
-      }
-      pAttr++;
-    }
-
-    if (pEntry->isDeclaration) {
-      if (lpszMarker) {
-        lpszMarker[nResult - 1] = _CXML('?');
-        lpszMarker[nResult] = _CXML('>');
-      }
-      nResult++;
-      if (nFormat != -1) {
-        if (lpszMarker) lpszMarker[nResult] = _CXML('\n');
-        nResult++;
-      }
-    } else
-        // If there are child nodes we need to terminate the start tag
-        if (nElementI) {
-      if (lpszMarker) lpszMarker[nResult - 1] = _CXML('>');
-      if (nFormat >= 0) {
-        if (lpszMarker) lpszMarker[nResult] = _CXML('\n');
-        nResult++;
-      }
-    } else
-      nResult--;
-  }
-
-  // Calculate the child format for when we recurse.  This is used to
-  // determine the number of spaces used for prefixes.
-  if (nFormat != -1) {
-    if (cbElement && (!pEntry->isDeclaration))
-      nChildFormat = nFormat + 1;
-    else
-      nChildFormat = nFormat;
-  }
-
-  // Enumerate through remaining children
-  for (i = 0; i < nElementI; i++) {
-    j = pEntry->pOrder[i];
-    switch ((XMLElementType)(j & 3)) {
-      // Text nodes
-      case eNodeText: {
-        // "Text"
-        XMLCSTR pChild = pEntry->pText[j >> 2];
-        cb = (int)ToXMLStringTool::lengthXMLString(pChild);
-        if (cb) {
-          if (nFormat >= 0) {
-            if (lpszMarker) {
-              charmemset(&lpszMarker[nResult], INDENTCHAR, nFormat + 1);
-              ToXMLStringTool::toXMLUnSafe(&lpszMarker[nResult + nFormat + 1],
-                                           pChild);
-              lpszMarker[nResult + nFormat + 1 + cb] = _CXML('\n');
+            {
+                if (lpszMarker) xstrcpy(&lpszMarker[nResult], pAttr->lpszName);
+                nResult += cb;
+                // "Attrib=Value "
+                if (pAttr->lpszValue)
+                {
+                    cb=(int)ToXMLStringTool::lengthXMLString(pAttr->lpszValue);
+                    if (lpszMarker)
+                    {
+                        lpszMarker[nResult]=_CXML('=');
+                        lpszMarker[nResult+1]=_CXML('"');
+                        if (cb) ToXMLStringTool::toXMLUnSafe(&lpszMarker[nResult+2],pAttr->lpszValue);
+                        lpszMarker[nResult+cb+2]=_CXML('"');
+                    }
+                    nResult+=cb+3;
+                }
+                if (lpszMarker) lpszMarker[nResult] = _CXML(' ');
+                nResult++;
             }
-            nResult += cb + nFormat + 2;
-          } else {
+            pAttr++;
+        }
+
+        if (pEntry->isDeclaration)
+        {
             if (lpszMarker)
-              ToXMLStringTool::toXMLUnSafe(&lpszMarker[nResult], pChild);
-            nResult += cb;
-          }
-        }
-        break;
-      }
-
-      // Clear type nodes
-      case eNodeClear: {
-        XMLClear *pChild = pEntry->pClear + (j >> 2);
-        // "OpenTag"
-        cb = (int)LENSTR(pChild->lpszOpenTag);
-        if (cb) {
-          if (nFormat != -1) {
-            if (lpszMarker) {
-              charmemset(&lpszMarker[nResult], INDENTCHAR, nFormat + 1);
-              xstrcpy(&lpszMarker[nResult + nFormat + 1], pChild->lpszOpenTag);
+            {
+                lpszMarker[nResult-1]=_CXML('?');
+                lpszMarker[nResult]=_CXML('>');
             }
-            nResult += cb + nFormat + 1;
-          } else {
-            if (lpszMarker) xstrcpy(&lpszMarker[nResult], pChild->lpszOpenTag);
-            nResult += cb;
-          }
-        }
-
-        // "OpenTag Value"
-        cb = (int)LENSTR(pChild->lpszValue);
-        if (cb) {
-          if (lpszMarker) xstrcpy(&lpszMarker[nResult], pChild->lpszValue);
-          nResult += cb;
-        }
-
-        // "OpenTag Value CloseTag"
-        cb = (int)LENSTR(pChild->lpszCloseTag);
-        if (cb) {
-          if (lpszMarker) xstrcpy(&lpszMarker[nResult], pChild->lpszCloseTag);
-          nResult += cb;
-        }
-
-        if (nFormat != -1) {
-          if (lpszMarker) lpszMarker[nResult] = _CXML('\n');
-          nResult++;
-        }
-        break;
-      }
-
-      // Element nodes
-      case eNodeChild: {
-        // Recursively add child nodes
-        nResult += CreateXMLStringR(pEntry->pChild[j >> 2].d,
-                                    lpszMarker ? lpszMarker + nResult : 0,
-                                    nChildFormat);
-        break;
-      }
-      default:
-        break;
+            nResult++;
+            if (nFormat!=-1)
+            {
+                if (lpszMarker) lpszMarker[nResult]=_CXML('\n');
+                nResult++;
+            }
+        } else
+            // If there are child nodes we need to terminate the start tag
+            if (nElementI)
+            {
+                if (lpszMarker) lpszMarker[nResult-1]=_CXML('>');
+                if (nFormat>=0)
+                {
+                    if (lpszMarker) lpszMarker[nResult]=_CXML('\n');
+                    nResult++;
+                }
+            } else nResult--;
     }
-  }
 
-  if ((cbElement) && (!pEntry->isDeclaration)) {
-    // If we have child entries we need to use long XML notation for
-    // closing the element - "<elementname>blah blah blah</elementname>"
-    if (nElementI) {
-      // "</elementname>\0"
-      if (lpszMarker) {
-        if (nFormat >= 0) {
-          charmemset(&lpszMarker[nResult], INDENTCHAR, nFormat);
-          nResult += nFormat;
-        }
-
-        lpszMarker[nResult] = _CXML('<');
-        lpszMarker[nResult + 1] = _CXML('/');
-        nResult += 2;
-        xstrcpy(&lpszMarker[nResult], pEntry->lpszName);
-        nResult += cbElement;
-
-        lpszMarker[nResult] = _CXML('>');
-        if (nFormat == -1)
-          nResult++;
-        else {
-          lpszMarker[nResult + 1] = _CXML('\n');
-          nResult += 2;
-        }
-      } else {
-        if (nFormat >= 0)
-          nResult += cbElement + 4 + nFormat;
-        else if (nFormat == -1)
-          nResult += cbElement + 3;
-        else
-          nResult += cbElement + 4;
-      }
-    } else {
-      // If there are no children we can use shorthand XML notation -
-      // "<elementname/>"
-      // "/>\0"
-      if (lpszMarker) {
-        lpszMarker[nResult] = _CXML('/');
-        lpszMarker[nResult + 1] = _CXML('>');
-        if (nFormat != -1) lpszMarker[nResult + 2] = _CXML('\n');
-      }
-      nResult += nFormat == -1 ? 2 : 3;
+    // Calculate the child format for when we recurse.  This is used to
+    // determine the number of spaces used for prefixes.
+    if (nFormat!=-1)
+    {
+        if (cbElement&&(!pEntry->isDeclaration)) nChildFormat=nFormat+1;
+        else nChildFormat=nFormat;
     }
-  }
 
-  return nResult;
+    // Enumerate through remaining children
+    for (i=0; i<nElementI; i++)
+    {
+        j=pEntry->pOrder[i];
+        switch((XMLElementType)(j&3))
+        {
+        // Text nodes
+        case eNodeText:
+            {
+                // "Text"
+                XMLCSTR pChild=pEntry->pText[j>>2];
+                cb = (int)ToXMLStringTool::lengthXMLString(pChild);
+                if (cb)
+                {
+                    if (nFormat>=0)
+                    {
+                        if (lpszMarker)
+                        {
+                            charmemset(&lpszMarker[nResult],INDENTCHAR,nFormat+1);
+                            ToXMLStringTool::toXMLUnSafe(&lpszMarker[nResult+nFormat+1],pChild);
+                            lpszMarker[nResult+nFormat+1+cb]=_CXML('\n');
+                        }
+                        nResult+=cb+nFormat+2;
+                    } else
+                    {
+                        if (lpszMarker) ToXMLStringTool::toXMLUnSafe(&lpszMarker[nResult], pChild);
+                        nResult += cb;
+                    }
+                }
+                break;
+            }
+
+        // Clear type nodes
+        case eNodeClear:
+            {
+                XMLClear *pChild=pEntry->pClear+(j>>2);
+                // "OpenTag"
+                cb = (int)LENSTR(pChild->lpszOpenTag);
+                if (cb)
+                {
+                    if (nFormat!=-1)
+                    {
+                        if (lpszMarker)
+                        {
+                            charmemset(&lpszMarker[nResult], INDENTCHAR, nFormat+1);
+                            xstrcpy(&lpszMarker[nResult+nFormat+1], pChild->lpszOpenTag);
+                        }
+                        nResult+=cb+nFormat+1;
+                    }
+                    else
+                    {
+                        if (lpszMarker)xstrcpy(&lpszMarker[nResult], pChild->lpszOpenTag);
+                        nResult += cb;
+                    }
+                }
+
+                // "OpenTag Value"
+                cb = (int)LENSTR(pChild->lpszValue);
+                if (cb)
+                {
+                    if (lpszMarker) xstrcpy(&lpszMarker[nResult], pChild->lpszValue);
+                    nResult += cb;
+                }
+
+                // "OpenTag Value CloseTag"
+                cb = (int)LENSTR(pChild->lpszCloseTag);
+                if (cb)
+                {
+                    if (lpszMarker) xstrcpy(&lpszMarker[nResult], pChild->lpszCloseTag);
+                    nResult += cb;
+                }
+
+                if (nFormat!=-1)
+                {
+                    if (lpszMarker) lpszMarker[nResult] = _CXML('\n');
+                    nResult++;
+                }
+                break;
+            }
+
+        // Element nodes
+        case eNodeChild:
+            {
+                // Recursively add child nodes
+                nResult += CreateXMLStringR(pEntry->pChild[j>>2].d, lpszMarker ? lpszMarker + nResult : 0, nChildFormat);
+                break;
+            }
+        default: break;
+        }
+    }
+
+    if ((cbElement)&&(!pEntry->isDeclaration))
+    {
+        // If we have child entries we need to use long XML notation for
+        // closing the element - "<elementname>blah blah blah</elementname>"
+        if (nElementI)
+        {
+            // "</elementname>\0"
+            if (lpszMarker)
+            {
+                if (nFormat >=0)
+                {
+                    charmemset(&lpszMarker[nResult], INDENTCHAR,nFormat);
+                    nResult+=nFormat;
+                }
+
+                lpszMarker[nResult]=_CXML('<'); lpszMarker[nResult+1]=_CXML('/');
+                nResult += 2;
+                xstrcpy(&lpszMarker[nResult], pEntry->lpszName);
+                nResult += cbElement;
+
+                lpszMarker[nResult]=_CXML('>');
+                if (nFormat == -1) nResult++;
+                else
+                {
+                    lpszMarker[nResult+1]=_CXML('\n');
+                    nResult+=2;
+                }
+            } else
+            {
+                if (nFormat>=0) nResult+=cbElement+4+nFormat;
+                else if (nFormat==-1) nResult+=cbElement+3;
+                else nResult+=cbElement+4;
+            }
+        } else
+        {
+            // If there are no children we can use shorthand XML notation -
+            // "<elementname/>"
+            // "/>\0"
+            if (lpszMarker)
+            {
+                lpszMarker[nResult]=_CXML('/'); lpszMarker[nResult+1]=_CXML('>');
+                if (nFormat != -1) lpszMarker[nResult+2]=_CXML('\n');
+            }
+            nResult += nFormat == -1 ? 2 : 3;
+        }
+    }
+
+    return nResult;
 }
 
 #undef LENSTR
@@ -2366,832 +2084,638 @@ int XMLNode::CreateXMLStringR(XMLNodeData *pEntry, XMLSTR lpszMarker,
 //                                        NULL terminator.
 // @return      XMLSTR                  - Allocated XML string, you must free
 //                                        this with free().
-XMLSTR XMLNode::createXMLString(int nFormat, int *pnSize) const {
-  if (!d) {
-    if (pnSize) *pnSize = 0;
-    return NULL;
-  }
+XMLSTR XMLNode::createXMLString(int nFormat, int *pnSize) const
+{
+    if (!d) { if (pnSize) *pnSize=0; return NULL; }
 
-  XMLSTR lpszResult = NULL;
-  int cbStr;
+    XMLSTR lpszResult = NULL;
+    int cbStr;
 
-  // Recursively Calculate the size of the XML string
-  if (!dropWhiteSpace) nFormat = 0;
-  nFormat = nFormat ? 0 : -1;
-  cbStr = CreateXMLStringR(d, 0, nFormat);
-  // Alllocate memory for the XML string + the NULL terminator and
-  // create the recursively XML string.
-  lpszResult = (XMLSTR)malloc((cbStr + 1) * sizeof(XMLCHAR));
-  CreateXMLStringR(d, lpszResult, nFormat);
-  lpszResult[cbStr] = _CXML('\0');
-  if (pnSize) *pnSize = cbStr;
-  return lpszResult;
+    // Recursively Calculate the size of the XML string
+    if (!dropWhiteSpace) nFormat=0;
+    nFormat = nFormat ? 0 : -1;
+    cbStr = CreateXMLStringR(d, 0, nFormat);
+    // Alllocate memory for the XML string + the NULL terminator and
+    // create the recursively XML string.
+    lpszResult=(XMLSTR)malloc((cbStr+1)*sizeof(XMLCHAR));
+    CreateXMLStringR(d, lpszResult, nFormat);
+    lpszResult[cbStr]=_CXML('\0');
+    if (pnSize) *pnSize = cbStr;
+    return lpszResult;
 }
 
-int XMLNode::detachFromParent(XMLNodeData *d) {
-  XMLNode *pa = d->pParent->pChild;
-  int i = 0;
-  while (((void *)(pa[i].d)) != ((void *)d)) i++;
-  d->pParent->nChild--;
-  if (d->pParent->nChild)
-    memmove(pa + i, pa + i + 1, (d->pParent->nChild - i) * sizeof(XMLNode));
-  else {
-    free(pa);
-    d->pParent->pChild = NULL;
-  }
-  return removeOrderElement(d->pParent, eNodeChild, i);
+int XMLNode::detachFromParent(XMLNodeData *d)
+{
+    XMLNode *pa=d->pParent->pChild;
+    int i=0;
+    while (((void*)(pa[i].d))!=((void*)d)) i++;
+    d->pParent->nChild--;
+    if (d->pParent->nChild) memmove(pa+i,pa+i+1,(d->pParent->nChild-i)*sizeof(XMLNode));
+    else { free(pa); d->pParent->pChild=NULL; }
+    return removeOrderElement(d->pParent,eNodeChild,i);
 }
 
-XMLNode::~XMLNode() {
-  if (!d) return;
-  d->ref_count--;
-  emptyTheNode(0);
-}
-void XMLNode::deleteNodeContent() {
-  if (!d) return;
-  if (d->pParent) {
-    detachFromParent(d);
-    d->pParent = NULL;
+XMLNode::~XMLNode()
+{
+    if (!d) return;
     d->ref_count--;
-  }
-  emptyTheNode(1);
+    emptyTheNode(0);
 }
-void XMLNode::emptyTheNode(char force) {
-  XMLNodeData *dd = d;  // warning: must stay this way!
-  if ((dd->ref_count == 0) || force) {
-    if (d->pParent) detachFromParent(d);
-    int i;
-    XMLNode *pc;
-    for (i = 0; i < dd->nChild; i++) {
-      pc = dd->pChild + i;
-      pc->d->pParent = NULL;
-      pc->d->ref_count--;
-      pc->emptyTheNode(force);
-    }
-    myFree(dd->pChild);
-    for (i = 0; i < dd->nText; i++) free((void *)dd->pText[i]);
-    myFree(dd->pText);
-    for (i = 0; i < dd->nClear; i++) free((void *)dd->pClear[i].lpszValue);
-    myFree(dd->pClear);
-    for (i = 0; i < dd->nAttribute; i++) {
-      free((void *)dd->pAttribute[i].lpszName);
-      if (dd->pAttribute[i].lpszValue)
-        free((void *)dd->pAttribute[i].lpszValue);
-    }
-    myFree(dd->pAttribute);
-    myFree(dd->pOrder);
-    myFree((void *)dd->lpszName);
-    dd->nChild = 0;
-    dd->nText = 0;
-    dd->nClear = 0;
-    dd->nAttribute = 0;
-    dd->pChild = NULL;
-    dd->pText = NULL;
-    dd->pClear = NULL;
-    dd->pAttribute = NULL;
-    dd->pOrder = NULL;
-    dd->lpszName = NULL;
-    dd->pParent = NULL;
-  }
-  if (dd->ref_count == 0) {
-    free(dd);
-    d = NULL;
-  }
+void XMLNode::deleteNodeContent()
+{
+    if (!d) return;
+    if (d->pParent) { detachFromParent(d); d->pParent=NULL; d->ref_count--; }
+    emptyTheNode(1);
 }
-
-XMLNode &XMLNode::operator=(const XMLNode &A) {
-  // shallow copy
-  if (this != &A) {
-    if (d) {
-      d->ref_count--;
-      emptyTheNode(0);
-    }
-    d = A.d;
-    if (d) (d->ref_count)++;
-  }
-  return *this;
-}
-
-XMLNode::XMLNode(const XMLNode &A) {
-  // shallow copy
-  d = A.d;
-  if (d) (d->ref_count)++;
-}
-
-XMLNode XMLNode::deepCopy() const {
-  if (!d) return XMLNode::emptyXMLNode;
-  XMLNode x(NULL, stringDup(d->lpszName), d->isDeclaration);
-  XMLNodeData *p = x.d;
-  int n = d->nAttribute;
-  if (n) {
-    p->nAttribute = n;
-    p->pAttribute = (XMLAttribute *)malloc(n * sizeof(XMLAttribute));
-    while (n--) {
-      p->pAttribute[n].lpszName = stringDup(d->pAttribute[n].lpszName);
-      p->pAttribute[n].lpszValue = stringDup(d->pAttribute[n].lpszValue);
-    }
-  }
-  if (d->pOrder) {
-    n = (d->nChild + d->nText + d->nClear) * sizeof(int);
-    p->pOrder = (int *)malloc(n);
-    memcpy(p->pOrder, d->pOrder, n);
-  }
-  n = d->nText;
-  if (n) {
-    p->nText = n;
-    p->pText = (XMLCSTR *)malloc(n * sizeof(XMLCSTR));
-    while (n--) p->pText[n] = stringDup(d->pText[n]);
-  }
-  n = d->nClear;
-  if (n) {
-    p->nClear = n;
-    p->pClear = (XMLClear *)malloc(n * sizeof(XMLClear));
-    while (n--) {
-      p->pClear[n].lpszCloseTag = d->pClear[n].lpszCloseTag;
-      p->pClear[n].lpszOpenTag = d->pClear[n].lpszOpenTag;
-      p->pClear[n].lpszValue = stringDup(d->pClear[n].lpszValue);
-    }
-  }
-  n = d->nChild;
-  if (n) {
-    p->nChild = n;
-    p->pChild = (XMLNode *)malloc(n * sizeof(XMLNode));
-    while (n--) {
-      p->pChild[n].d = NULL;
-      p->pChild[n] = d->pChild[n].deepCopy();
-      p->pChild[n].d->pParent = p;
-    }
-  }
-  return x;
-}
-
-XMLNode XMLNode::addChild(XMLNode childNode, int pos) {
-  XMLNodeData *dc = childNode.d;
-  if ((!dc) || (!d)) return childNode;
-  if (!dc->lpszName) {
-    // this is a root node: todo: correct fix
-    int j = pos;
-    while (dc->nChild) {
-      addChild(dc->pChild[0], j);
-      if (pos >= 0) j++;
-    }
-    return childNode;
-  }
-  if (dc->pParent) {
-    if ((detachFromParent(dc) <= pos) && (dc->pParent == d)) pos--;
-  } else
-    dc->ref_count++;
-  dc->pParent = d;
-  //     int nc=d->nChild;
-  //     d->pChild=(XMLNode*)myRealloc(d->pChild,(nc+1),memoryIncrease,sizeof(XMLNode));
-  d->pChild = (XMLNode *)addToOrder(0, &pos, d->nChild, d->pChild,
-                                    sizeof(XMLNode), eNodeChild);
-  d->pChild[pos].d = dc;
-  d->nChild++;
-  return childNode;
-}
-
-void XMLNode::deleteAttribute(int i) {
-  if ((!d) || (i < 0) || (i >= d->nAttribute)) return;
-  d->nAttribute--;
-  XMLAttribute *p = d->pAttribute + i;
-  free((void *)p->lpszName);
-  if (p->lpszValue) free((void *)p->lpszValue);
-  if (d->nAttribute)
-    memmove(p, p + 1, (d->nAttribute - i) * sizeof(XMLAttribute));
-  else {
-    free(p);
-    d->pAttribute = NULL;
-  }
-}
-
-void XMLNode::deleteAttribute(XMLAttribute *a) {
-  if (a) deleteAttribute(a->lpszName);
-}
-void XMLNode::deleteAttribute(XMLCSTR lpszName) {
-  int j = 0;
-  getAttribute(lpszName, &j);
-  if (j) deleteAttribute(j - 1);
-}
-
-XMLAttribute *XMLNode::updateAttribute_WOSD(XMLSTR lpszNewValue,
-                                            XMLSTR lpszNewName, int i) {
-  if (!d) {
-    if (lpszNewValue) free(lpszNewValue);
-    if (lpszNewName) free(lpszNewName);
-    return NULL;
-  }
-  if (i >= d->nAttribute) {
-    if (lpszNewName) return addAttribute_WOSD(lpszNewName, lpszNewValue);
-    return NULL;
-  }
-  XMLAttribute *p = d->pAttribute + i;
-  if (p->lpszValue && p->lpszValue != lpszNewValue) free((void *)p->lpszValue);
-  p->lpszValue = lpszNewValue;
-  if (lpszNewName && p->lpszName != lpszNewName) {
-    free((void *)p->lpszName);
-    p->lpszName = lpszNewName;
-  };
-  return p;
-}
-
-XMLAttribute *XMLNode::updateAttribute_WOSD(XMLAttribute *newAttribute,
-                                            XMLAttribute *oldAttribute) {
-  if (oldAttribute)
-    return updateAttribute_WOSD((XMLSTR)newAttribute->lpszValue,
-                                (XMLSTR)newAttribute->lpszName,
-                                oldAttribute->lpszName);
-  return addAttribute_WOSD((XMLSTR)newAttribute->lpszName,
-                           (XMLSTR)newAttribute->lpszValue);
-}
-
-XMLAttribute *XMLNode::updateAttribute_WOSD(XMLSTR lpszNewValue,
-                                            XMLSTR lpszNewName,
-                                            XMLCSTR lpszOldName) {
-  int j = 0;
-  getAttribute(lpszOldName, &j);
-  if (j)
-    return updateAttribute_WOSD(lpszNewValue, lpszNewName, j - 1);
-  else {
-    if (lpszNewName)
-      return addAttribute_WOSD(lpszNewName, lpszNewValue);
-    else
-      return addAttribute_WOSD(stringDup(lpszOldName), lpszNewValue);
-  }
-}
-
-int XMLNode::indexText(XMLCSTR lpszValue) const {
-  if (!d) return -1;
-  int i, l = d->nText;
-  if (!lpszValue) {
-    if (l) return 0;
-    return -1;
-  }
-  XMLCSTR *p = d->pText;
-  for (i = 0; i < l; i++)
-    if (lpszValue == p[i]) return i;
-  return -1;
-}
-
-void XMLNode::deleteText(int i) {
-  if ((!d) || (i < 0) || (i >= d->nText)) return;
-  d->nText--;
-  XMLCSTR *p = d->pText + i;
-  free((void *)*p);
-  if (d->nText)
-    memmove(p, p + 1, (d->nText - i) * sizeof(XMLCSTR));
-  else {
-    free(p);
-    d->pText = NULL;
-  }
-  removeOrderElement(d, eNodeText, i);
-}
-
-void XMLNode::deleteText(XMLCSTR lpszValue) {
-  deleteText(indexText(lpszValue));
-}
-
-XMLCSTR XMLNode::updateText_WOSD(XMLSTR lpszNewValue, int i) {
-  if (!d) {
-    if (lpszNewValue) free(lpszNewValue);
-    return NULL;
-  }
-  if (i >= d->nText) return addText_WOSD(lpszNewValue);
-  XMLCSTR *p = d->pText + i;
-  if (*p != lpszNewValue) {
-    free((void *)*p);
-    *p = lpszNewValue;
-  }
-  return lpszNewValue;
-}
-
-XMLCSTR XMLNode::updateText_WOSD(XMLSTR lpszNewValue, XMLCSTR lpszOldValue) {
-  if (!d) {
-    if (lpszNewValue) free(lpszNewValue);
-    return NULL;
-  }
-  int i = indexText(lpszOldValue);
-  if (i >= 0) return updateText_WOSD(lpszNewValue, i);
-  return addText_WOSD(lpszNewValue);
-}
-
-void XMLNode::deleteClear(int i) {
-  if ((!d) || (i < 0) || (i >= d->nClear)) return;
-  d->nClear--;
-  XMLClear *p = d->pClear + i;
-  free((void *)p->lpszValue);
-  if (d->nClear)
-    memmove(p, p + 1, (d->nClear - i) * sizeof(XMLClear));
-  else {
-    free(p);
-    d->pClear = NULL;
-  }
-  removeOrderElement(d, eNodeClear, i);
-}
-
-int XMLNode::indexClear(XMLCSTR lpszValue) const {
-  if (!d) return -1;
-  int i, l = d->nClear;
-  if (!lpszValue) {
-    if (l) return 0;
-    return -1;
-  }
-  XMLClear *p = d->pClear;
-  for (i = 0; i < l; i++)
-    if (lpszValue == p[i].lpszValue) return i;
-  return -1;
-}
-
-void XMLNode::deleteClear(XMLCSTR lpszValue) {
-  deleteClear(indexClear(lpszValue));
-}
-void XMLNode::deleteClear(XMLClear *a) {
-  if (a) deleteClear(a->lpszValue);
-}
-
-XMLClear *XMLNode::updateClear_WOSD(XMLSTR lpszNewContent, int i) {
-  if (!d) {
-    if (lpszNewContent) free(lpszNewContent);
-    return NULL;
-  }
-  if (i >= d->nClear) return addClear_WOSD(lpszNewContent);
-  XMLClear *p = d->pClear + i;
-  if (lpszNewContent != p->lpszValue) {
-    free((void *)p->lpszValue);
-    p->lpszValue = lpszNewContent;
-  }
-  return p;
-}
-
-XMLClear *XMLNode::updateClear_WOSD(XMLSTR lpszNewContent,
-                                    XMLCSTR lpszOldValue) {
-  if (!d) {
-    if (lpszNewContent) free(lpszNewContent);
-    return NULL;
-  }
-  int i = indexClear(lpszOldValue);
-  if (i >= 0) return updateClear_WOSD(lpszNewContent, i);
-  return addClear_WOSD(lpszNewContent);
-}
-
-XMLClear *XMLNode::updateClear_WOSD(XMLClear *newP, XMLClear *oldP) {
-  if (oldP)
-    return updateClear_WOSD((XMLSTR)newP->lpszValue, (XMLSTR)oldP->lpszValue);
-  return NULL;
-}
-
-int XMLNode::nChildNode(XMLCSTR name) const {
-  if (!d) return 0;
-  int i, j = 0, n = d->nChild;
-  XMLNode *pc = d->pChild;
-  for (i = 0; i < n; i++) {
-    if (xstricmp(pc->d->lpszName, name) == 0) j++;
-    pc++;
-  }
-  return j;
-}
-
-XMLNode XMLNode::getChildNode(XMLCSTR name, int *j) const {
-  if (!d) return emptyXMLNode;
-  int i = 0, n = d->nChild;
-  if (j) i = *j;
-  XMLNode *pc = d->pChild + i;
-  for (; i < n; i++) {
-    if (!xstricmp(pc->d->lpszName, name)) {
-      if (j) *j = i + 1;
-      return *pc;
-    }
-    pc++;
-  }
-  return emptyXMLNode;
-}
-
-XMLNode XMLNode::getChildNode(XMLCSTR name, int j) const {
-  if (!d) return emptyXMLNode;
-  if (j >= 0) {
-    int i = 0;
-    while (j-- > 0) getChildNode(name, &i);
-    return getChildNode(name, &i);
-  }
-  int i = d->nChild;
-  while (i--)
-    if (!xstricmp(name, d->pChild[i].d->lpszName)) break;
-  if (i < 0) return emptyXMLNode;
-  return getChildNode(i);
-}
-
-XMLNode XMLNode::getChildNodeByPath(XMLCSTR _path, char createMissing,
-                                    XMLCHAR sep) {
-  XMLSTR path = stringDup(_path);
-  XMLNode x = getChildNodeByPathNonConst(path, createMissing, sep);
-  if (path) free(path);
-  return x;
-}
-
-XMLNode XMLNode::getChildNodeByPathNonConst(XMLSTR path, char createIfMissing,
-                                            XMLCHAR sep) {
-  if ((!path) || (!(*path))) return *this;
-  XMLNode xn, xbase = *this;
-  XMLCHAR *tend1, sepString[2];
-  sepString[0] = sep;
-  sepString[1] = 0;
-  tend1 = xstrstr(path, sepString);
-  while (tend1) {
-    *tend1 = 0;
-    xn = xbase.getChildNode(path);
-    if (xn.isEmpty()) {
-      if (createIfMissing)
-        xn = xbase.addChild(path);
-      else {
-        *tend1 = sep;
-        return XMLNode::emptyXMLNode;
-      }
-    }
-    *tend1 = sep;
-    xbase = xn;
-    path = tend1 + 1;
-    tend1 = xstrstr(path, sepString);
-  }
-  xn = xbase.getChildNode(path);
-  if (xn.isEmpty() && createIfMissing) xn = xbase.addChild(path);
-  return xn;
-}
-
-XMLElementPosition XMLNode::positionOfText(int i) const {
-  if (i >= d->nText) i = d->nText - 1;
-  return findPosition(d, i, eNodeText);
-}
-XMLElementPosition XMLNode::positionOfClear(int i) const {
-  if (i >= d->nClear) i = d->nClear - 1;
-  return findPosition(d, i, eNodeClear);
-}
-XMLElementPosition XMLNode::positionOfChildNode(int i) const {
-  if (i >= d->nChild) i = d->nChild - 1;
-  return findPosition(d, i, eNodeChild);
-}
-XMLElementPosition XMLNode::positionOfText(XMLCSTR lpszValue) const {
-  return positionOfText(indexText(lpszValue));
-}
-XMLElementPosition XMLNode::positionOfClear(XMLCSTR lpszValue) const {
-  return positionOfClear(indexClear(lpszValue));
-}
-XMLElementPosition XMLNode::positionOfClear(XMLClear *a) const {
-  if (a) return positionOfClear(a->lpszValue);
-  return positionOfClear();
-}
-XMLElementPosition XMLNode::positionOfChildNode(XMLNode x) const {
-  if ((!d) || (!x.d)) return -1;
-  XMLNodeData *dd = x.d;
-  XMLNode *pc = d->pChild;
-  int i = d->nChild;
-  while (i--)
-    if (pc[i].d == dd) return findPosition(d, i, eNodeChild);
-  return -1;
-}
-XMLElementPosition XMLNode::positionOfChildNode(XMLCSTR name, int count) const {
-  if (!name) return positionOfChildNode(count);
-  int j = 0;
-  do {
-    getChildNode(name, &j);
-    if (j < 0) return -1;
-  } while (count--);
-  return findPosition(d, j - 1, eNodeChild);
-}
-
-XMLNode XMLNode::getChildNodeWithAttribute(XMLCSTR name, XMLCSTR attributeName,
-                                           XMLCSTR attributeValue,
-                                           int *k) const {
-  int i = 0, j;
-  if (k) i = *k;
-  XMLNode x;
-  XMLCSTR t;
-  do {
-    x = getChildNode(name, &i);
-    if (!x.isEmpty()) {
-      if (attributeValue) {
-        j = 0;
-        do {
-          t = x.getAttribute(attributeName, &j);
-          if (t && (xstricmp(attributeValue, t) == 0)) {
-            if (k) *k = i;
-            return x;
-          }
-        } while (t);
-      } else {
-        if (x.isAttributeSet(attributeName)) {
-          if (k) *k = i;
-          return x;
+void XMLNode::emptyTheNode(char force)
+{
+    XMLNodeData *dd=d; // warning: must stay this way!
+    if ((dd->ref_count==0)||force)
+    {
+        if (d->pParent) detachFromParent(d);
+        int i;
+        XMLNode *pc;
+        for(i=0; i<dd->nChild; i++)
+        {
+            pc=dd->pChild+i;
+            pc->d->pParent=NULL;
+            pc->d->ref_count--;
+            pc->emptyTheNode(force);
         }
-      }
+        myFree(dd->pChild);
+        for(i=0; i<dd->nText; i++) free((void*)dd->pText[i]);
+        myFree(dd->pText);
+        for(i=0; i<dd->nClear; i++) free((void*)dd->pClear[i].lpszValue);
+        myFree(dd->pClear);
+        for(i=0; i<dd->nAttribute; i++)
+        {
+            free((void*)dd->pAttribute[i].lpszName);
+            if (dd->pAttribute[i].lpszValue) free((void*)dd->pAttribute[i].lpszValue);
+        }
+        myFree(dd->pAttribute);
+        myFree(dd->pOrder);
+        myFree((void*)dd->lpszName);
+        dd->nChild=0;    dd->nText=0;    dd->nClear=0;    dd->nAttribute=0;
+        dd->pChild=NULL; dd->pText=NULL; dd->pClear=NULL; dd->pAttribute=NULL;
+        dd->pOrder=NULL; dd->lpszName=NULL; dd->pParent=NULL;
     }
-  } while (!x.isEmpty());
-  return emptyXMLNode;
+    if (dd->ref_count==0)
+    {
+        free(dd);
+        d=NULL;
+    }
+}
+
+XMLNode& XMLNode::operator=( const XMLNode& A )
+{
+    // shallow copy
+    if (this != &A)
+    {
+        if (d) { d->ref_count--; emptyTheNode(0); }
+        d=A.d;
+        if (d) (d->ref_count) ++ ;
+    }
+    return *this;
+}
+
+XMLNode::XMLNode(const XMLNode &A)
+{
+    // shallow copy
+    d=A.d;
+    if (d) (d->ref_count)++ ;
+}
+
+XMLNode XMLNode::deepCopy() const
+{
+    if (!d) return XMLNode::emptyXMLNode;
+    XMLNode x(NULL,stringDup(d->lpszName),d->isDeclaration);
+    XMLNodeData *p=x.d;
+    int n=d->nAttribute;
+    if (n)
+    {
+        p->nAttribute=n; p->pAttribute=(XMLAttribute*)malloc(n*sizeof(XMLAttribute));
+        while (n--)
+        {
+            p->pAttribute[n].lpszName=stringDup(d->pAttribute[n].lpszName);
+            p->pAttribute[n].lpszValue=stringDup(d->pAttribute[n].lpszValue);
+        }
+    }
+    if (d->pOrder)
+    {
+        n=(d->nChild+d->nText+d->nClear)*sizeof(int); p->pOrder=(int*)malloc(n); memcpy(p->pOrder,d->pOrder,n);
+    }
+    n=d->nText;
+    if (n)
+    {
+        p->nText=n; p->pText=(XMLCSTR*)malloc(n*sizeof(XMLCSTR));
+        while(n--) p->pText[n]=stringDup(d->pText[n]);
+    }
+    n=d->nClear;
+    if (n)
+    {
+        p->nClear=n; p->pClear=(XMLClear*)malloc(n*sizeof(XMLClear));
+        while (n--)
+        {
+            p->pClear[n].lpszCloseTag=d->pClear[n].lpszCloseTag;
+            p->pClear[n].lpszOpenTag=d->pClear[n].lpszOpenTag;
+            p->pClear[n].lpszValue=stringDup(d->pClear[n].lpszValue);
+        }
+    }
+    n=d->nChild;
+    if (n)
+    {
+        p->nChild=n; p->pChild=(XMLNode*)malloc(n*sizeof(XMLNode));
+        while (n--)
+        {
+            p->pChild[n].d=NULL;
+            p->pChild[n]=d->pChild[n].deepCopy();
+            p->pChild[n].d->pParent=p;
+        }
+    }
+    return x;
+}
+
+XMLNode XMLNode::addChild(XMLNode childNode, int pos)
+{
+    XMLNodeData *dc=childNode.d;
+    if ((!dc)||(!d)) return childNode;
+    if (!dc->lpszName)
+    {
+        // this is a root node: todo: correct fix
+        int j=pos;
+        while (dc->nChild)
+        {
+            addChild(dc->pChild[0],j);
+            if (pos>=0) j++;
+        }
+        return childNode;
+    }
+    if (dc->pParent) { if ((detachFromParent(dc)<=pos)&&(dc->pParent==d)) pos--; } else dc->ref_count++;
+    dc->pParent=d;
+//     int nc=d->nChild;
+//     d->pChild=(XMLNode*)myRealloc(d->pChild,(nc+1),memoryIncrease,sizeof(XMLNode));
+    d->pChild=(XMLNode*)addToOrder(0,&pos,d->nChild,d->pChild,sizeof(XMLNode),eNodeChild);
+    d->pChild[pos].d=dc;
+    d->nChild++;
+    return childNode;
+}
+
+void XMLNode::deleteAttribute(int i)
+{
+    if ((!d)||(i<0)||(i>=d->nAttribute)) return;
+    d->nAttribute--;
+    XMLAttribute *p=d->pAttribute+i;
+    free((void*)p->lpszName);
+    if (p->lpszValue) free((void*)p->lpszValue);
+    if (d->nAttribute) memmove(p,p+1,(d->nAttribute-i)*sizeof(XMLAttribute)); else { free(p); d->pAttribute=NULL; }
+}
+
+void XMLNode::deleteAttribute(XMLAttribute *a){ if (a) deleteAttribute(a->lpszName); }
+void XMLNode::deleteAttribute(XMLCSTR lpszName)
+{
+    int j=0;
+    getAttribute(lpszName,&j);
+    if (j) deleteAttribute(j-1);
+}
+
+XMLAttribute *XMLNode::updateAttribute_WOSD(XMLSTR lpszNewValue, XMLSTR lpszNewName,int i)
+{
+    if (!d) { if (lpszNewValue) free(lpszNewValue); if (lpszNewName) free(lpszNewName); return NULL; }
+    if (i>=d->nAttribute)
+    {
+        if (lpszNewName) return addAttribute_WOSD(lpszNewName,lpszNewValue);
+        return NULL;
+    }
+    XMLAttribute *p=d->pAttribute+i;
+    if (p->lpszValue&&p->lpszValue!=lpszNewValue) free((void*)p->lpszValue);
+    p->lpszValue=lpszNewValue;
+    if (lpszNewName&&p->lpszName!=lpszNewName) { free((void*)p->lpszName); p->lpszName=lpszNewName; };
+    return p;
+}
+
+XMLAttribute *XMLNode::updateAttribute_WOSD(XMLAttribute *newAttribute, XMLAttribute *oldAttribute)
+{
+    if (oldAttribute) return updateAttribute_WOSD((XMLSTR)newAttribute->lpszValue,(XMLSTR)newAttribute->lpszName,oldAttribute->lpszName);
+    return addAttribute_WOSD((XMLSTR)newAttribute->lpszName,(XMLSTR)newAttribute->lpszValue);
+}
+
+XMLAttribute *XMLNode::updateAttribute_WOSD(XMLSTR lpszNewValue, XMLSTR lpszNewName,XMLCSTR lpszOldName)
+{
+    int j=0;
+    getAttribute(lpszOldName,&j);
+    if (j) return updateAttribute_WOSD(lpszNewValue,lpszNewName,j-1);
+    else
+    {
+        if (lpszNewName) return addAttribute_WOSD(lpszNewName,lpszNewValue);
+        else             return addAttribute_WOSD(stringDup(lpszOldName),lpszNewValue);
+    }
+}
+
+int XMLNode::indexText(XMLCSTR lpszValue) const
+{
+    if (!d) return -1;
+    int i,l=d->nText;
+    if (!lpszValue) { if (l) return 0; return -1; }
+    XMLCSTR *p=d->pText;
+    for (i=0; i<l; i++) if (lpszValue==p[i]) return i;
+    return -1;
+}
+
+void XMLNode::deleteText(int i)
+{
+    if ((!d)||(i<0)||(i>=d->nText)) return;
+    d->nText--;
+    XMLCSTR *p=d->pText+i;
+    free((void*)*p);
+    if (d->nText) memmove(p,p+1,(d->nText-i)*sizeof(XMLCSTR)); else { free(p); d->pText=NULL; }
+    removeOrderElement(d,eNodeText,i);
+}
+
+void XMLNode::deleteText(XMLCSTR lpszValue) { deleteText(indexText(lpszValue)); }
+
+XMLCSTR XMLNode::updateText_WOSD(XMLSTR lpszNewValue, int i)
+{
+    if (!d) { if (lpszNewValue) free(lpszNewValue); return NULL; }
+    if (i>=d->nText) return addText_WOSD(lpszNewValue);
+    XMLCSTR *p=d->pText+i;
+    if (*p!=lpszNewValue) { free((void*)*p); *p=lpszNewValue; }
+    return lpszNewValue;
+}
+
+XMLCSTR XMLNode::updateText_WOSD(XMLSTR lpszNewValue, XMLCSTR lpszOldValue)
+{
+    if (!d) { if (lpszNewValue) free(lpszNewValue); return NULL; }
+    int i=indexText(lpszOldValue);
+    if (i>=0) return updateText_WOSD(lpszNewValue,i);
+    return addText_WOSD(lpszNewValue);
+}
+
+void XMLNode::deleteClear(int i)
+{
+    if ((!d)||(i<0)||(i>=d->nClear)) return;
+    d->nClear--;
+    XMLClear *p=d->pClear+i;
+    free((void*)p->lpszValue);
+    if (d->nClear) memmove(p,p+1,(d->nClear-i)*sizeof(XMLClear)); else { free(p); d->pClear=NULL; }
+    removeOrderElement(d,eNodeClear,i);
+}
+
+int XMLNode::indexClear(XMLCSTR lpszValue) const
+{
+    if (!d) return -1;
+    int i,l=d->nClear;
+    if (!lpszValue) { if (l) return 0; return -1; }
+    XMLClear *p=d->pClear;
+    for (i=0; i<l; i++) if (lpszValue==p[i].lpszValue) return i;
+    return -1;
+}
+
+void XMLNode::deleteClear(XMLCSTR lpszValue) { deleteClear(indexClear(lpszValue)); }
+void XMLNode::deleteClear(XMLClear *a) { if (a) deleteClear(a->lpszValue); }
+
+XMLClear *XMLNode::updateClear_WOSD(XMLSTR lpszNewContent, int i)
+{
+    if (!d) { if (lpszNewContent) free(lpszNewContent); return NULL; }
+    if (i>=d->nClear) return addClear_WOSD(lpszNewContent);
+    XMLClear *p=d->pClear+i;
+    if (lpszNewContent!=p->lpszValue) { free((void*)p->lpszValue); p->lpszValue=lpszNewContent; }
+    return p;
+}
+
+XMLClear *XMLNode::updateClear_WOSD(XMLSTR lpszNewContent, XMLCSTR lpszOldValue)
+{
+    if (!d) { if (lpszNewContent) free(lpszNewContent); return NULL; }
+    int i=indexClear(lpszOldValue);
+    if (i>=0) return updateClear_WOSD(lpszNewContent,i);
+    return addClear_WOSD(lpszNewContent);
+}
+
+XMLClear *XMLNode::updateClear_WOSD(XMLClear *newP,XMLClear *oldP)
+{
+    if (oldP) return updateClear_WOSD((XMLSTR)newP->lpszValue,(XMLSTR)oldP->lpszValue);
+    return NULL;
+}
+
+int XMLNode::nChildNode(XMLCSTR name) const
+{
+    if (!d) return 0;
+    int i,j=0,n=d->nChild;
+    XMLNode *pc=d->pChild;
+    for (i=0; i<n; i++)
+    {
+        if (xstricmp(pc->d->lpszName, name)==0) j++;
+        pc++;
+    }
+    return j;
+}
+
+XMLNode XMLNode::getChildNode(XMLCSTR name, int *j) const
+{
+    if (!d) return emptyXMLNode;
+    int i=0,n=d->nChild;
+    if (j) i=*j;
+    XMLNode *pc=d->pChild+i;
+    for (; i<n; i++)
+    {
+        if (!xstricmp(pc->d->lpszName, name))
+        {
+            if (j) *j=i+1;
+            return *pc;
+        }
+        pc++;
+    }
+    return emptyXMLNode;
+}
+
+XMLNode XMLNode::getChildNode(XMLCSTR name, int j) const
+{
+    if (!d) return emptyXMLNode;
+    if (j>=0)
+    {
+        int i=0;
+        while (j-->0) getChildNode(name,&i);
+        return getChildNode(name,&i);
+    }
+    int i=d->nChild;
+    while (i--) if (!xstricmp(name,d->pChild[i].d->lpszName)) break;
+    if (i<0) return emptyXMLNode;
+    return getChildNode(i);
+}
+
+XMLNode XMLNode::getChildNodeByPath(XMLCSTR _path, char createMissing, XMLCHAR sep)
+{
+    XMLSTR path=stringDup(_path);
+    XMLNode x=getChildNodeByPathNonConst(path,createMissing,sep);
+    if (path) free(path);
+    return x;
+}
+
+XMLNode XMLNode::getChildNodeByPathNonConst(XMLSTR path, char createIfMissing, XMLCHAR sep)
+{
+    if ((!path)||(!(*path))) return *this;
+    XMLNode xn,xbase=*this;
+    XMLCHAR *tend1,sepString[2]; sepString[0]=sep; sepString[1]=0;
+    tend1=xstrstr(path,sepString);
+    while(tend1)
+    {
+        *tend1=0;
+        xn=xbase.getChildNode(path);
+        if (xn.isEmpty())
+        {
+            if (createIfMissing) xn=xbase.addChild(path);
+            else { *tend1=sep; return XMLNode::emptyXMLNode; }
+        }
+        *tend1=sep;
+        xbase=xn;
+        path=tend1+1;
+        tend1=xstrstr(path,sepString);
+    }
+    xn=xbase.getChildNode(path);
+    if (xn.isEmpty()&&createIfMissing) xn=xbase.addChild(path);
+    return xn;
+}
+
+XMLElementPosition XMLNode::positionOfText     (int i) const { if (i>=d->nText ) i=d->nText-1;  return findPosition(d,i,eNodeText ); }
+XMLElementPosition XMLNode::positionOfClear    (int i) const { if (i>=d->nClear) i=d->nClear-1; return findPosition(d,i,eNodeClear); }
+XMLElementPosition XMLNode::positionOfChildNode(int i) const { if (i>=d->nChild) i=d->nChild-1; return findPosition(d,i,eNodeChild); }
+XMLElementPosition XMLNode::positionOfText (XMLCSTR lpszValue) const { return positionOfText (indexText (lpszValue)); }
+XMLElementPosition XMLNode::positionOfClear(XMLCSTR lpszValue) const { return positionOfClear(indexClear(lpszValue)); }
+XMLElementPosition XMLNode::positionOfClear(XMLClear *a) const { if (a) return positionOfClear(a->lpszValue); return positionOfClear(); }
+XMLElementPosition XMLNode::positionOfChildNode(XMLNode x)  const
+{
+    if ((!d)||(!x.d)) return -1;
+    XMLNodeData *dd=x.d;
+    XMLNode *pc=d->pChild;
+    int i=d->nChild;
+    while (i--) if (pc[i].d==dd) return findPosition(d,i,eNodeChild);
+    return -1;
+}
+XMLElementPosition XMLNode::positionOfChildNode(XMLCSTR name, int count) const
+{
+    if (!name) return positionOfChildNode(count);
+    int j=0;
+    do { getChildNode(name,&j); if (j<0) return -1; } while (count--);
+    return findPosition(d,j-1,eNodeChild);
+}
+
+XMLNode XMLNode::getChildNodeWithAttribute(XMLCSTR name,XMLCSTR attributeName,XMLCSTR attributeValue, int *k) const
+{
+     int i=0,j;
+     if (k) i=*k;
+     XMLNode x;
+     XMLCSTR t;
+     do
+     {
+         x=getChildNode(name,&i);
+         if (!x.isEmpty())
+         {
+             if (attributeValue)
+             {
+                 j=0;
+                 do
+                 {
+                     t=x.getAttribute(attributeName,&j);
+                     if (t&&(xstricmp(attributeValue,t)==0)) { if (k) *k=i; return x; }
+                 } while (t);
+             } else
+             {
+                 if (x.isAttributeSet(attributeName)) { if (k) *k=i; return x; }
+             }
+         }
+     } while (!x.isEmpty());
+     return emptyXMLNode;
 }
 
 // Find an attribute on an node.
-XMLCSTR XMLNode::getAttribute(XMLCSTR lpszAttrib, int *j) const {
-  if (!d) return NULL;
-  int i = 0, n = d->nAttribute;
-  if (j) i = *j;
-  XMLAttribute *pAttr = d->pAttribute + i;
-  for (; i < n; i++) {
-    if (xstricmp(pAttr->lpszName, lpszAttrib) == 0) {
-      if (j) *j = i + 1;
-      return pAttr->lpszValue;
+XMLCSTR XMLNode::getAttribute(XMLCSTR lpszAttrib, int *j) const
+{
+    if (!d) return NULL;
+    int i=0,n=d->nAttribute;
+    if (j) i=*j;
+    XMLAttribute *pAttr=d->pAttribute+i;
+    for (; i<n; i++)
+    {
+        if (xstricmp(pAttr->lpszName, lpszAttrib)==0)
+        {
+            if (j) *j=i+1;
+            return pAttr->lpszValue;
+        }
+        pAttr++;
     }
-    pAttr++;
-  }
-  return NULL;
+    return NULL;
 }
 
-char XMLNode::isAttributeSet(XMLCSTR lpszAttrib) const {
-  if (!d) return FALSE;
-  int i, n = d->nAttribute;
-  XMLAttribute *pAttr = d->pAttribute;
-  for (i = 0; i < n; i++) {
-    if (xstricmp(pAttr->lpszName, lpszAttrib) == 0) {
-      return TRUE;
+char XMLNode::isAttributeSet(XMLCSTR lpszAttrib) const
+{
+    if (!d) return FALSE;
+    int i,n=d->nAttribute;
+    XMLAttribute *pAttr=d->pAttribute;
+    for (i=0; i<n; i++)
+    {
+        if (xstricmp(pAttr->lpszName, lpszAttrib)==0)
+        {
+            return TRUE;
+        }
+        pAttr++;
     }
-    pAttr++;
-  }
-  return FALSE;
+    return FALSE;
 }
 
-XMLCSTR XMLNode::getAttribute(XMLCSTR name, int j) const {
-  if (!d) return NULL;
-  int i = 0;
-  while (j-- > 0) getAttribute(name, &i);
-  return getAttribute(name, &i);
+XMLCSTR XMLNode::getAttribute(XMLCSTR name, int j) const
+{
+    if (!d) return NULL;
+    int i=0;
+    while (j-->0) getAttribute(name,&i);
+    return getAttribute(name,&i);
 }
 
-XMLNodeContents XMLNode::enumContents(int i) const {
-  XMLNodeContents c;
-  if (!d) {
-    c.etype = eNodeNULL;
+XMLNodeContents XMLNode::enumContents(int i) const
+{
+    XMLNodeContents c;
+    if (!d) { c.etype=eNodeNULL; return c; }
+    if (i<d->nAttribute)
+    {
+        c.etype=eNodeAttribute;
+        c.attrib=d->pAttribute[i];
+        return c;
+    }
+    i-=d->nAttribute;
+    c.etype=(XMLElementType)(d->pOrder[i]&3);
+    i=(d->pOrder[i])>>2;
+    switch (c.etype)
+    {
+    case eNodeChild:     c.child = d->pChild[i];      break;
+    case eNodeText:      c.text  = d->pText[i];       break;
+    case eNodeClear:     c.clear = d->pClear[i];      break;
+    default: break;
+    }
     return c;
-  }
-  if (i < d->nAttribute) {
-    c.etype = eNodeAttribute;
-    c.attrib = d->pAttribute[i];
-    return c;
-  }
-  i -= d->nAttribute;
-  c.etype = (XMLElementType)(d->pOrder[i] & 3);
-  i = (d->pOrder[i]) >> 2;
-  switch (c.etype) {
-    case eNodeChild:
-      c.child = d->pChild[i];
-      break;
-    case eNodeText:
-      c.text = d->pText[i];
-      break;
-    case eNodeClear:
-      c.clear = d->pClear[i];
-      break;
-    default:
-      break;
-  }
-  return c;
 }
 
-XMLCSTR XMLNode::getName() const {
-  if (!d) return NULL;
-  return d->lpszName;
-}
-int XMLNode::nText() const {
-  if (!d) return 0;
-  return d->nText;
-}
-int XMLNode::nChildNode() const {
-  if (!d) return 0;
-  return d->nChild;
-}
-int XMLNode::nAttribute() const {
-  if (!d) return 0;
-  return d->nAttribute;
-}
-int XMLNode::nClear() const {
-  if (!d) return 0;
-  return d->nClear;
-}
-int XMLNode::nElement() const {
-  if (!d) return 0;
-  return d->nAttribute + d->nChild + d->nText + d->nClear;
-}
-XMLClear XMLNode::getClear(int i) const {
-  if ((!d) || (i >= d->nClear)) return emptyXMLClear;
-  return d->pClear[i];
-}
-XMLAttribute XMLNode::getAttribute(int i) const {
-  if ((!d) || (i >= d->nAttribute)) return emptyXMLAttribute;
-  return d->pAttribute[i];
-}
-XMLCSTR XMLNode::getAttributeName(int i) const {
-  if ((!d) || (i >= d->nAttribute)) return NULL;
-  return d->pAttribute[i].lpszName;
-}
-XMLCSTR XMLNode::getAttributeValue(int i) const {
-  if ((!d) || (i >= d->nAttribute)) return NULL;
-  return d->pAttribute[i].lpszValue;
-}
-XMLCSTR XMLNode::getText(int i) const {
-  if ((!d) || (i >= d->nText)) return NULL;
-  return d->pText[i];
-}
-XMLNode XMLNode::getChildNode(int i) const {
-  if ((!d) || (i >= d->nChild)) return emptyXMLNode;
-  return d->pChild[i];
-}
-XMLNode XMLNode::getParentNode() const {
-  if ((!d) || (!d->pParent)) return emptyXMLNode;
-  return XMLNode(d->pParent);
-}
-char XMLNode::isDeclaration() const {
-  if (!d) return 0;
-  return d->isDeclaration;
-}
-char XMLNode::isEmpty() const { return (d == NULL); }
-XMLNode XMLNode::emptyNode() { return XMLNode::emptyXMLNode; }
+XMLCSTR XMLNode::getName() const { if (!d) return NULL; return d->lpszName;   }
+int XMLNode::nText()       const { if (!d) return 0;    return d->nText;      }
+int XMLNode::nChildNode()  const { if (!d) return 0;    return d->nChild;     }
+int XMLNode::nAttribute()  const { if (!d) return 0;    return d->nAttribute; }
+int XMLNode::nClear()      const { if (!d) return 0;    return d->nClear;     }
+int XMLNode::nElement()    const { if (!d) return 0;    return d->nAttribute+d->nChild+d->nText+d->nClear; }
+XMLClear     XMLNode::getClear         (int i) const { if ((!d)||(i>=d->nClear    )) return emptyXMLClear;     return d->pClear[i];     }
+XMLAttribute XMLNode::getAttribute     (int i) const { if ((!d)||(i>=d->nAttribute)) return emptyXMLAttribute; return d->pAttribute[i]; }
+XMLCSTR      XMLNode::getAttributeName (int i) const { if ((!d)||(i>=d->nAttribute)) return NULL;              return d->pAttribute[i].lpszName;  }
+XMLCSTR      XMLNode::getAttributeValue(int i) const { if ((!d)||(i>=d->nAttribute)) return NULL;              return d->pAttribute[i].lpszValue; }
+XMLCSTR      XMLNode::getText          (int i) const { if ((!d)||(i>=d->nText     )) return NULL;              return d->pText[i];      }
+XMLNode      XMLNode::getChildNode     (int i) const { if ((!d)||(i>=d->nChild    )) return emptyXMLNode;      return d->pChild[i];     }
+XMLNode      XMLNode::getParentNode    (     ) const { if ((!d)||(!d->pParent     )) return emptyXMLNode;      return XMLNode(d->pParent); }
+char         XMLNode::isDeclaration    (     ) const { if (!d) return 0;             return d->isDeclaration; }
+char         XMLNode::isEmpty          (     ) const { return (d==NULL); }
+XMLNode       XMLNode::emptyNode       (     )       { return XMLNode::emptyXMLNode; }
 
-XMLNode XMLNode::addChild(XMLCSTR lpszName, char isDeclaration,
-                          XMLElementPosition pos) {
-  return addChild_priv(0, stringDup(lpszName), isDeclaration, pos);
-}
-XMLNode XMLNode::addChild_WOSD(XMLSTR lpszName, char isDeclaration,
-                               XMLElementPosition pos) {
-  return addChild_priv(0, lpszName, isDeclaration, pos);
-}
-XMLAttribute *XMLNode::addAttribute(XMLCSTR lpszName, XMLCSTR lpszValue) {
-  return addAttribute_priv(0, stringDup(lpszName), stringDup(lpszValue));
-}
-XMLAttribute *XMLNode::addAttribute_WOSD(XMLSTR lpszName, XMLSTR lpszValuev) {
-  return addAttribute_priv(0, lpszName, lpszValuev);
-}
-XMLCSTR XMLNode::addText(XMLCSTR lpszValue, XMLElementPosition pos) {
-  return addText_priv(0, stringDup(lpszValue), pos);
-}
-XMLCSTR XMLNode::addText_WOSD(XMLSTR lpszValue, XMLElementPosition pos) {
-  return addText_priv(0, lpszValue, pos);
-}
-XMLClear *XMLNode::addClear(XMLCSTR lpszValue, XMLCSTR lpszOpen,
-                            XMLCSTR lpszClose, XMLElementPosition pos) {
-  return addClear_priv(0, stringDup(lpszValue), lpszOpen, lpszClose, pos);
-}
-XMLClear *XMLNode::addClear_WOSD(XMLSTR lpszValue, XMLCSTR lpszOpen,
-                                 XMLCSTR lpszClose, XMLElementPosition pos) {
-  return addClear_priv(0, lpszValue, lpszOpen, lpszClose, pos);
-}
-XMLCSTR XMLNode::updateName(XMLCSTR lpszName) {
-  return updateName_WOSD(stringDup(lpszName));
-}
-XMLAttribute *XMLNode::updateAttribute(XMLAttribute *newAttribute,
-                                       XMLAttribute *oldAttribute) {
-  return updateAttribute_WOSD(stringDup(newAttribute->lpszValue),
-                              stringDup(newAttribute->lpszName),
-                              oldAttribute->lpszName);
-}
-XMLAttribute *XMLNode::updateAttribute(XMLCSTR lpszNewValue,
-                                       XMLCSTR lpszNewName, int i) {
-  return updateAttribute_WOSD(stringDup(lpszNewValue), stringDup(lpszNewName),
-                              i);
-}
-XMLAttribute *XMLNode::updateAttribute(XMLCSTR lpszNewValue,
-                                       XMLCSTR lpszNewName,
-                                       XMLCSTR lpszOldName) {
-  return updateAttribute_WOSD(stringDup(lpszNewValue), stringDup(lpszNewName),
-                              lpszOldName);
-}
-XMLCSTR XMLNode::updateText(XMLCSTR lpszNewValue, int i) {
-  return updateText_WOSD(stringDup(lpszNewValue), i);
-}
-XMLCSTR XMLNode::updateText(XMLCSTR lpszNewValue, XMLCSTR lpszOldValue) {
-  return updateText_WOSD(stringDup(lpszNewValue), lpszOldValue);
-}
-XMLClear *XMLNode::updateClear(XMLCSTR lpszNewContent, int i) {
-  return updateClear_WOSD(stringDup(lpszNewContent), i);
-}
-XMLClear *XMLNode::updateClear(XMLCSTR lpszNewValue, XMLCSTR lpszOldValue) {
-  return updateClear_WOSD(stringDup(lpszNewValue), lpszOldValue);
-}
-XMLClear *XMLNode::updateClear(XMLClear *newP, XMLClear *oldP) {
-  return updateClear_WOSD(stringDup(newP->lpszValue), oldP->lpszValue);
-}
+XMLNode       XMLNode::addChild(XMLCSTR lpszName, char isDeclaration, XMLElementPosition pos)
+              { return addChild_priv(0,stringDup(lpszName),isDeclaration,pos); }
+XMLNode       XMLNode::addChild_WOSD(XMLSTR lpszName, char isDeclaration, XMLElementPosition pos)
+              { return addChild_priv(0,lpszName,isDeclaration,pos); }
+XMLAttribute *XMLNode::addAttribute(XMLCSTR lpszName, XMLCSTR lpszValue)
+              { return addAttribute_priv(0,stringDup(lpszName),stringDup(lpszValue)); }
+XMLAttribute *XMLNode::addAttribute_WOSD(XMLSTR lpszName, XMLSTR lpszValuev)
+              { return addAttribute_priv(0,lpszName,lpszValuev); }
+XMLCSTR       XMLNode::addText(XMLCSTR lpszValue, XMLElementPosition pos)
+              { return addText_priv(0,stringDup(lpszValue),pos); }
+XMLCSTR       XMLNode::addText_WOSD(XMLSTR lpszValue, XMLElementPosition pos)
+              { return addText_priv(0,lpszValue,pos); }
+XMLClear     *XMLNode::addClear(XMLCSTR lpszValue, XMLCSTR lpszOpen, XMLCSTR lpszClose, XMLElementPosition pos)
+              { return addClear_priv(0,stringDup(lpszValue),lpszOpen,lpszClose,pos); }
+XMLClear     *XMLNode::addClear_WOSD(XMLSTR lpszValue, XMLCSTR lpszOpen, XMLCSTR lpszClose, XMLElementPosition pos)
+              { return addClear_priv(0,lpszValue,lpszOpen,lpszClose,pos); }
+XMLCSTR       XMLNode::updateName(XMLCSTR lpszName)
+              { return updateName_WOSD(stringDup(lpszName)); }
+XMLAttribute *XMLNode::updateAttribute(XMLAttribute *newAttribute, XMLAttribute *oldAttribute)
+              { return updateAttribute_WOSD(stringDup(newAttribute->lpszValue),stringDup(newAttribute->lpszName),oldAttribute->lpszName); }
+XMLAttribute *XMLNode::updateAttribute(XMLCSTR lpszNewValue, XMLCSTR lpszNewName,int i)
+              { return updateAttribute_WOSD(stringDup(lpszNewValue),stringDup(lpszNewName),i); }
+XMLAttribute *XMLNode::updateAttribute(XMLCSTR lpszNewValue, XMLCSTR lpszNewName,XMLCSTR lpszOldName)
+              { return updateAttribute_WOSD(stringDup(lpszNewValue),stringDup(lpszNewName),lpszOldName); }
+XMLCSTR       XMLNode::updateText(XMLCSTR lpszNewValue, int i)
+              { return updateText_WOSD(stringDup(lpszNewValue),i); }
+XMLCSTR       XMLNode::updateText(XMLCSTR lpszNewValue, XMLCSTR lpszOldValue)
+              { return updateText_WOSD(stringDup(lpszNewValue),lpszOldValue); }
+XMLClear     *XMLNode::updateClear(XMLCSTR lpszNewContent, int i)
+              { return updateClear_WOSD(stringDup(lpszNewContent),i); }
+XMLClear     *XMLNode::updateClear(XMLCSTR lpszNewValue, XMLCSTR lpszOldValue)
+              { return updateClear_WOSD(stringDup(lpszNewValue),lpszOldValue); }
+XMLClear     *XMLNode::updateClear(XMLClear *newP,XMLClear *oldP)
+              { return updateClear_WOSD(stringDup(newP->lpszValue),oldP->lpszValue); }
 
-char XMLNode::setGlobalOptions(XMLCharEncoding _characterEncoding,
-                               char _guessWideCharChars, char _dropWhiteSpace,
-                               char _removeCommentsInMiddleOfText) {
-  guessWideCharChars = _guessWideCharChars;
-  dropWhiteSpace = _dropWhiteSpace;
-  removeCommentsInMiddleOfText = _removeCommentsInMiddleOfText;
+char XMLNode::setGlobalOptions(XMLCharEncoding _characterEncoding, char _guessWideCharChars,
+                               char _dropWhiteSpace, char _removeCommentsInMiddleOfText)
+{
+    guessWideCharChars=_guessWideCharChars; dropWhiteSpace=_dropWhiteSpace; removeCommentsInMiddleOfText=_removeCommentsInMiddleOfText;
 #ifdef _XMLWIDECHAR
-  if (_characterEncoding) characterEncoding = _characterEncoding;
+    if (_characterEncoding) characterEncoding=_characterEncoding;
 #else
-  switch (_characterEncoding) {
-    case char_encoding_UTF8:
-      characterEncoding = _characterEncoding;
-      XML_ByteTable = XML_utf8ByteTable;
-      break;
-    case char_encoding_legacy:
-      characterEncoding = _characterEncoding;
-      XML_ByteTable = XML_legacyByteTable;
-      break;
-    case char_encoding_ShiftJIS:
-      characterEncoding = _characterEncoding;
-      XML_ByteTable = XML_sjisByteTable;
-      break;
-    case char_encoding_GB2312:
-      characterEncoding = _characterEncoding;
-      XML_ByteTable = XML_gb2312ByteTable;
-      break;
+    switch(_characterEncoding)
+    {
+    case char_encoding_UTF8:     characterEncoding=_characterEncoding; XML_ByteTable=XML_utf8ByteTable; break;
+    case char_encoding_legacy:   characterEncoding=_characterEncoding; XML_ByteTable=XML_legacyByteTable; break;
+    case char_encoding_ShiftJIS: characterEncoding=_characterEncoding; XML_ByteTable=XML_sjisByteTable; break;
+    case char_encoding_GB2312:   characterEncoding=_characterEncoding; XML_ByteTable=XML_gb2312ByteTable; break;
     case char_encoding_Big5:
-    case char_encoding_GBK:
-      characterEncoding = _characterEncoding;
-      XML_ByteTable = XML_gbk_big5_ByteTable;
-      break;
-    default:
-      return 1;
-  }
+    case char_encoding_GBK:      characterEncoding=_characterEncoding; XML_ByteTable=XML_gbk_big5_ByteTable; break;
+    default: return 1;
+    }
 #endif
-  return 0;
+    return 0;
 }
 
-XMLNode::XMLCharEncoding XMLNode::guessCharEncoding(
-    void *buf, int l, char useXMLEncodingAttribute) {
+XMLNode::XMLCharEncoding XMLNode::guessCharEncoding(void *buf,int l, char useXMLEncodingAttribute)
+{
 #ifdef _XMLWIDECHAR
-  return (XMLCharEncoding)0;
-#else
-  if (l < 25) return (XMLCharEncoding)0;
-  if (guessWideCharChars && (myIsTextWideChar(buf, l)))
     return (XMLCharEncoding)0;
-  unsigned char *b = (unsigned char *)buf;
-  if ((b[0] == 0xef) && (b[1] == 0xbb) && (b[2] == 0xbf))
-    return char_encoding_UTF8;
+#else
+    if (l<25) return (XMLCharEncoding)0;
+    if (guessWideCharChars&&(myIsTextWideChar(buf,l))) return (XMLCharEncoding)0;
+    unsigned char *b=(unsigned char*)buf;
+    if ((b[0]==0xef)&&(b[1]==0xbb)&&(b[2]==0xbf)) return char_encoding_UTF8;
 
-  // Match utf-8 model ?
-  XMLCharEncoding bestGuess = char_encoding_UTF8;
-  int i = 0;
-  while (i < l) switch (XML_utf8ByteTable[b[i]]) {
-      case 4:
-        i++;
-        if ((i < l) && (b[i] & 0xC0) != 0x80) {
-          bestGuess = char_encoding_legacy;
-          i = l;
-        }  // 10bbbbbb ?
-      case 3:
-        i++;
-        if ((i < l) && (b[i] & 0xC0) != 0x80) {
-          bestGuess = char_encoding_legacy;
-          i = l;
-        }  // 10bbbbbb ?
-      case 2:
-        i++;
-        if ((i < l) && (b[i] & 0xC0) != 0x80) {
-          bestGuess = char_encoding_legacy;
-          i = l;
-        }  // 10bbbbbb ?
-      case 1:
-        i++;
-        break;
-      case 0:
-        i = l;
+    // Match utf-8 model ?
+    XMLCharEncoding bestGuess=char_encoding_UTF8;
+    int i=0;
+    while (i<l)
+        switch (XML_utf8ByteTable[b[i]])
+        {
+        case 4: i++; if ((i<l)&&(b[i]& 0xC0)!=0x80) { bestGuess=char_encoding_legacy; i=l; } // 10bbbbbb ?
+        case 3: i++; if ((i<l)&&(b[i]& 0xC0)!=0x80) { bestGuess=char_encoding_legacy; i=l; } // 10bbbbbb ?
+        case 2: i++; if ((i<l)&&(b[i]& 0xC0)!=0x80) { bestGuess=char_encoding_legacy; i=l; } // 10bbbbbb ?
+        case 1: i++; break;
+        case 0: i=l;
+        }
+    if (!useXMLEncodingAttribute) return bestGuess;
+    // if encoding is specified and different from utf-8 than it's non-utf8
+    // otherwise it's utf-8
+    char bb[201];
+    l=mmin(l,200);
+    memcpy(bb,buf,l); // copy buf into bb to be able to do "bb[l]=0"
+    bb[l]=0;
+    b=(unsigned char*)strstr(bb,"encoding");
+    if (!b) return bestGuess;
+    b+=8; while XML_isSPACECHAR(*b) b++; if (*b!='=') return bestGuess;
+    b++;  while XML_isSPACECHAR(*b) b++; if ((*b!='\'')&&(*b!='"')) return bestGuess;
+    b++;  while XML_isSPACECHAR(*b) b++;
+
+    if ((xstrnicmp((char*)b,"utf-8",5)==0)||
+        (xstrnicmp((char*)b,"utf8",4)==0))
+    {
+        if (bestGuess==char_encoding_legacy) return char_encoding_error;
+        return char_encoding_UTF8;
     }
-  if (!useXMLEncodingAttribute) return bestGuess;
-  // if encoding is specified and different from utf-8 than it's non-utf8
-  // otherwise it's utf-8
-  char bb[201];
-  l = mmin(l, 200);
-  memcpy(bb, buf, l);  // copy buf into bb to be able to do "bb[l]=0"
-  bb[l] = 0;
-  b = (unsigned char *)strstr(bb, "encoding");
-  if (!b) return bestGuess;
-  b += 8;
-  while
-    XML_isSPACECHAR(*b) b++;
-  if (*b != '=') return bestGuess;
-  b++;
-  while
-    XML_isSPACECHAR(*b) b++;
-  if ((*b != '\'') && (*b != '"')) return bestGuess;
-  b++;
-  while
-    XML_isSPACECHAR(*b) b++;
 
-  if ((xstrnicmp((char *)b, "utf-8", 5) == 0) ||
-      (xstrnicmp((char *)b, "utf8", 4) == 0)) {
-    if (bestGuess == char_encoding_legacy) return char_encoding_error;
-    return char_encoding_UTF8;
-  }
+    if ((xstrnicmp((char*)b,"shiftjis",8)==0)||
+        (xstrnicmp((char*)b,"shift-jis",9)==0)||
+        (xstrnicmp((char*)b,"sjis",4)==0)) return char_encoding_ShiftJIS;
 
-  if ((xstrnicmp((char *)b, "shiftjis", 8) == 0) ||
-      (xstrnicmp((char *)b, "shift-jis", 9) == 0) ||
-      (xstrnicmp((char *)b, "sjis", 4) == 0))
-    return char_encoding_ShiftJIS;
+    if (xstrnicmp((char*)b,"GB2312",6)==0) return char_encoding_GB2312;
+    if (xstrnicmp((char*)b,"Big5",4)==0) return char_encoding_Big5;
+    if (xstrnicmp((char*)b,"GBK",3)==0) return char_encoding_GBK;
 
-  if (xstrnicmp((char *)b, "GB2312", 6) == 0) return char_encoding_GB2312;
-  if (xstrnicmp((char *)b, "Big5", 4) == 0) return char_encoding_Big5;
-  if (xstrnicmp((char *)b, "GBK", 3) == 0) return char_encoding_GBK;
-
-  return char_encoding_legacy;
+    return char_encoding_legacy;
 #endif
 }
 #undef XML_isSPACECHAR
@@ -3200,228 +2724,167 @@ XMLNode::XMLCharEncoding XMLNode::guessCharEncoding(
 //      Here starts the base64 conversion functions.    //
 //////////////////////////////////////////////////////////
 
-static const char base64Fillchar =
-    _CXML('=');  // used to mark partial words at the end
+static const char base64Fillchar = _CXML('='); // used to mark partial words at the end
 
 // this lookup table defines the base64 encoding
-XMLCSTR base64EncodeTable =
-    _CXML("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/");
+XMLCSTR base64EncodeTable=_CXML("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/");
 
-// Decode Table gives the index of any valid base64 character in the Base64
-// table]
+// Decode Table gives the index of any valid base64 character in the Base64 table]
 // 96: '='  -   97: space char   -   98: illegal char   -   99: end of string
 const unsigned char base64DecodeTable[] = {
-    99, 98, 98, 98, 98, 98, 98, 98, 98, 97, 97, 98, 98, 97, 98, 98,
-    98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98,  // 00 -29
-    98, 98, 97, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 62, 98, 98,
-    98, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 98, 98,  // 30 -59
-    98, 96, 98, 98, 98, 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
-    11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,  // 60 -89
-    25, 98, 98, 98, 98, 98, 98, 26, 27, 28, 29, 30, 31, 32, 33, 34,
-    35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,  // 90 -119
-    49, 50, 51, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98,
-    98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98,  // 120 -149
-    98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98,
-    98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98,  // 150 -179
-    98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98,
-    98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98,  // 180 -209
-    98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98,
-    98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98,         // 210 -239
-    98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98  // 240 -255
+    99,98,98,98,98,98,98,98,98,97,  97,98,98,97,98,98,98,98,98,98,  98,98,98,98,98,98,98,98,98,98,  //00 -29
+    98,98,97,98,98,98,98,98,98,98,  98,98,98,62,98,98,98,63,52,53,  54,55,56,57,58,59,60,61,98,98,  //30 -59
+    98,96,98,98,98, 0, 1, 2, 3, 4,   5, 6, 7, 8, 9,10,11,12,13,14,  15,16,17,18,19,20,21,22,23,24,  //60 -89
+    25,98,98,98,98,98,98,26,27,28,  29,30,31,32,33,34,35,36,37,38,  39,40,41,42,43,44,45,46,47,48,  //90 -119
+    49,50,51,98,98,98,98,98,98,98,  98,98,98,98,98,98,98,98,98,98,  98,98,98,98,98,98,98,98,98,98,  //120 -149
+    98,98,98,98,98,98,98,98,98,98,  98,98,98,98,98,98,98,98,98,98,  98,98,98,98,98,98,98,98,98,98,  //150 -179
+    98,98,98,98,98,98,98,98,98,98,  98,98,98,98,98,98,98,98,98,98,  98,98,98,98,98,98,98,98,98,98,  //180 -209
+    98,98,98,98,98,98,98,98,98,98,  98,98,98,98,98,98,98,98,98,98,  98,98,98,98,98,98,98,98,98,98,  //210 -239
+    98,98,98,98,98,98,98,98,98,98,  98,98,98,98,98,98                                               //240 -255
 };
 
-XMLParserBase64Tool::~XMLParserBase64Tool() { freeBuffer(); }
+XMLParserBase64Tool::~XMLParserBase64Tool(){ freeBuffer(); }
 
-void XMLParserBase64Tool::freeBuffer() {
-  if (buf) free(buf);
-  buf = NULL;
-  buflen = 0;
+void XMLParserBase64Tool::freeBuffer(){ if (buf) free(buf); buf=NULL; buflen=0; }
+
+int XMLParserBase64Tool::encodeLength(int inlen, char formatted)
+{
+    unsigned int i=((inlen-1)/3*4+4+1);
+    if (formatted) i+=inlen/54;
+    return i;
 }
 
-int XMLParserBase64Tool::encodeLength(int inlen, char formatted) {
-  unsigned int i = ((inlen - 1) / 3 * 4 + 4 + 1);
-  if (formatted) i += inlen / 54;
-  return i;
-}
-
-XMLSTR XMLParserBase64Tool::encode(unsigned char *inbuf, unsigned int inlen,
-                                   char formatted) {
-  int i = encodeLength(inlen, formatted), k = 17, eLen = inlen / 3, j;
-  alloc(i * sizeof(XMLCHAR));
-  XMLSTR curr = (XMLSTR)buf;
-  for (i = 0; i < eLen; i++) {
-    // Copy next three bytes into lower 24 bits of int, paying attention to
-    // sign.
-    j = (inbuf[0] << 16) | (inbuf[1] << 8) | inbuf[2];
-    inbuf += 3;
-    // Encode the int into four chars
-    *(curr++) = base64EncodeTable[j >> 18];
-    *(curr++) = base64EncodeTable[(j >> 12) & 0x3f];
-    *(curr++) = base64EncodeTable[(j >> 6) & 0x3f];
-    *(curr++) = base64EncodeTable[(j)&0x3f];
-    if (formatted) {
-      if (!k) {
-        *(curr++) = _CXML('\n');
-        k = 18;
-      }
-      k--;
+XMLSTR XMLParserBase64Tool::encode(unsigned char *inbuf, unsigned int inlen, char formatted)
+{
+    int i=encodeLength(inlen,formatted),k=17,eLen=inlen/3,j;
+    alloc(i*sizeof(XMLCHAR));
+    XMLSTR curr=(XMLSTR)buf;
+    for(i=0;i<eLen;i++)
+    {
+        // Copy next three bytes into lower 24 bits of int, paying attention to sign.
+        j=(inbuf[0]<<16)|(inbuf[1]<<8)|inbuf[2]; inbuf+=3;
+        // Encode the int into four chars
+        *(curr++)=base64EncodeTable[ j>>18      ];
+        *(curr++)=base64EncodeTable[(j>>12)&0x3f];
+        *(curr++)=base64EncodeTable[(j>> 6)&0x3f];
+        *(curr++)=base64EncodeTable[(j    )&0x3f];
+        if (formatted) { if (!k) { *(curr++)=_CXML('\n'); k=18; } k--; }
     }
-  }
-  eLen = inlen - eLen * 3;  // 0 - 2.
-  if (eLen == 1) {
-    *(curr++) = base64EncodeTable[inbuf[0] >> 2];
-    *(curr++) = base64EncodeTable[(inbuf[0] << 4) & 0x3F];
-    *(curr++) = base64Fillchar;
-    *(curr++) = base64Fillchar;
-  } else if (eLen == 2) {
-    j = (inbuf[0] << 8) | inbuf[1];
-    *(curr++) = base64EncodeTable[j >> 10];
-    *(curr++) = base64EncodeTable[(j >> 4) & 0x3f];
-    *(curr++) = base64EncodeTable[(j << 2) & 0x3f];
-    *(curr++) = base64Fillchar;
-  }
-  *(curr++) = 0;
-  return (XMLSTR)buf;
+    eLen=inlen-eLen*3; // 0 - 2.
+    if (eLen==1)
+    {
+        *(curr++)=base64EncodeTable[ inbuf[0]>>2      ];
+        *(curr++)=base64EncodeTable[(inbuf[0]<<4)&0x3F];
+        *(curr++)=base64Fillchar;
+        *(curr++)=base64Fillchar;
+    } else if (eLen==2)
+    {
+        j=(inbuf[0]<<8)|inbuf[1];
+        *(curr++)=base64EncodeTable[ j>>10      ];
+        *(curr++)=base64EncodeTable[(j>> 4)&0x3f];
+        *(curr++)=base64EncodeTable[(j<< 2)&0x3f];
+        *(curr++)=base64Fillchar;
+    }
+    *(curr++)=0;
+    return (XMLSTR)buf;
 }
 
-unsigned int XMLParserBase64Tool::decodeSize(XMLCSTR data, XMLError *xe) {
-  if (xe) *xe = eXMLErrorNone;
-  int size = 0;
-  unsigned char c;
-  // skip any extra characters (e.g. newlines or spaces)
-  while (*data) {
+unsigned int XMLParserBase64Tool::decodeSize(XMLCSTR data,XMLError *xe)
+{
+     if (xe) *xe=eXMLErrorNone;
+    int size=0;
+    unsigned char c;
+    //skip any extra characters (e.g. newlines or spaces)
+    while (*data)
+    {
 #ifdef _XMLWIDECHAR
-    if (*data > 255) {
-      if (xe) *xe = eXMLErrorBase64DecodeIllegalCharacter;
-      return 0;
-    }
+        if (*data>255) { if (xe) *xe=eXMLErrorBase64DecodeIllegalCharacter; return 0; }
 #endif
-    c = base64DecodeTable[(unsigned char)(*data)];
-    if (c < 97)
-      size++;
-    else if (c == 98) {
-      if (xe) *xe = eXMLErrorBase64DecodeIllegalCharacter;
-      return 0;
+        c=base64DecodeTable[(unsigned char)(*data)];
+        if (c<97) size++;
+        else if (c==98) { if (xe) *xe=eXMLErrorBase64DecodeIllegalCharacter; return 0; }
+        data++;
     }
-    data++;
-  }
-  if (xe && (size % 4 != 0)) *xe = eXMLErrorBase64DataSizeIsNotMultipleOf4;
-  if (size == 0) return 0;
-  do {
-    data--;
-    size--;
-  } while (*data == base64Fillchar);
-  size++;
-  return (unsigned int)((size * 3) / 4);
+    if (xe&&(size%4!=0)) *xe=eXMLErrorBase64DataSizeIsNotMultipleOf4;
+    if (size==0) return 0;
+    do { data--; size--; } while(*data==base64Fillchar); size++;
+    return (unsigned int)((size*3)/4);
 }
 
-unsigned char XMLParserBase64Tool::decode(XMLCSTR data, unsigned char *buf,
-                                          int len, XMLError *xe) {
-  if (xe) *xe = eXMLErrorNone;
-  int i = 0, p = 0;
-  unsigned char d, c;
-  for (;;) {
+unsigned char XMLParserBase64Tool::decode(XMLCSTR data, unsigned char *buf, int len, XMLError *xe)
+{
+    if (xe) *xe=eXMLErrorNone;
+    int i=0,p=0;
+    unsigned char d,c;
+    for(;;)
+    {
+
 #ifdef _XMLWIDECHAR
-#define BASE64DECODE_READ_NEXT_CHAR(c)                   \
-  do {                                                   \
-    if (data[i] > 255) {                                 \
-      c = 98;                                            \
-      break;                                             \
-    }                                                    \
-    c = base64DecodeTable[(unsigned char)data[i++]];     \
-  } while (c == 97);                                     \
-  if (c == 98) {                                         \
-    if (xe) *xe = eXMLErrorBase64DecodeIllegalCharacter; \
-    return 0;                                            \
-  }
+#define BASE64DECODE_READ_NEXT_CHAR(c)                                              \
+        do {                                                                        \
+            if (data[i]>255){ c=98; break; }                                        \
+            c=base64DecodeTable[(unsigned char)data[i++]];                       \
+        }while (c==97);                                                             \
+        if(c==98){ if(xe)*xe=eXMLErrorBase64DecodeIllegalCharacter; return 0; }
 #else
-#define BASE64DECODE_READ_NEXT_CHAR(c)                   \
-  do {                                                   \
-    c = base64DecodeTable[(unsigned char)data[i++]];     \
-  } while (c == 97);                                     \
-  if (c == 98) {                                         \
-    if (xe) *xe = eXMLErrorBase64DecodeIllegalCharacter; \
-    return 0;                                            \
-  }
+#define BASE64DECODE_READ_NEXT_CHAR(c)                                           \
+        do { c=base64DecodeTable[(unsigned char)data[i++]]; }while (c==97);   \
+        if(c==98){ if(xe)*xe=eXMLErrorBase64DecodeIllegalCharacter; return 0; }
 #endif
 
-    BASE64DECODE_READ_NEXT_CHAR(c)
-    if (c == 99) {
-      return 2;
-    }
-    if (c == 96) {
-      if (p == (int)len) return 2;
-      if (xe) *xe = eXMLErrorBase64DecodeTruncatedData;
-      return 1;
-    }
+        BASE64DECODE_READ_NEXT_CHAR(c)
+        if (c==99) { return 2; }
+        if (c==96)
+        {
+            if (p==(int)len) return 2;
+            if (xe) *xe=eXMLErrorBase64DecodeTruncatedData;
+            return 1;
+        }
 
-    BASE64DECODE_READ_NEXT_CHAR(d)
-    if ((d == 99) || (d == 96)) {
-      if (xe) *xe = eXMLErrorBase64DecodeTruncatedData;
-      return 1;
-    }
-    if (p == (int)len) {
-      if (xe) *xe = eXMLErrorBase64DecodeBufferTooSmall;
-      return 0;
-    }
-    buf[p++] = (unsigned char)((c << 2) | ((d >> 4) & 0x3));
+        BASE64DECODE_READ_NEXT_CHAR(d)
+        if ((d==99)||(d==96)) { if (xe) *xe=eXMLErrorBase64DecodeTruncatedData;  return 1; }
+        if (p==(int)len) {      if (xe) *xe=eXMLErrorBase64DecodeBufferTooSmall; return 0; }
+        buf[p++]=(unsigned char)((c<<2)|((d>>4)&0x3));
 
-    BASE64DECODE_READ_NEXT_CHAR(c)
-    if (c == 99) {
-      if (xe) *xe = eXMLErrorBase64DecodeTruncatedData;
-      return 1;
-    }
-    if (p == (int)len) {
-      if (c == 96) return 2;
-      if (xe) *xe = eXMLErrorBase64DecodeBufferTooSmall;
-      return 0;
-    }
-    if (c == 96) {
-      if (xe) *xe = eXMLErrorBase64DecodeTruncatedData;
-      return 1;
-    }
-    buf[p++] = (unsigned char)(((d << 4) & 0xf0) | ((c >> 2) & 0xf));
+        BASE64DECODE_READ_NEXT_CHAR(c)
+        if (c==99) { if (xe) *xe=eXMLErrorBase64DecodeTruncatedData;  return 1; }
+        if (p==(int)len)
+        {
+            if (c==96) return 2;
+            if (xe) *xe=eXMLErrorBase64DecodeBufferTooSmall;
+            return 0;
+        }
+        if (c==96) { if (xe) *xe=eXMLErrorBase64DecodeTruncatedData;  return 1; }
+        buf[p++]=(unsigned char)(((d<<4)&0xf0)|((c>>2)&0xf));
 
-    BASE64DECODE_READ_NEXT_CHAR(d)
-    if (d == 99) {
-      if (xe) *xe = eXMLErrorBase64DecodeTruncatedData;
-      return 1;
+        BASE64DECODE_READ_NEXT_CHAR(d)
+        if (d==99 ) { if (xe) *xe=eXMLErrorBase64DecodeTruncatedData;  return 1; }
+        if (p==(int)len)
+        {
+            if (d==96) return 2;
+            if (xe) *xe=eXMLErrorBase64DecodeBufferTooSmall;
+            return 0;
+        }
+        if (d==96) { if (xe) *xe=eXMLErrorBase64DecodeTruncatedData;  return 1; }
+        buf[p++]=(unsigned char)(((c<<6)&0xc0)|d);
     }
-    if (p == (int)len) {
-      if (d == 96) return 2;
-      if (xe) *xe = eXMLErrorBase64DecodeBufferTooSmall;
-      return 0;
-    }
-    if (d == 96) {
-      if (xe) *xe = eXMLErrorBase64DecodeTruncatedData;
-      return 1;
-    }
-    buf[p++] = (unsigned char)(((c << 6) & 0xc0) | d);
-  }
 }
 #undef BASE64DECODE_READ_NEXT_CHAR
 
-void XMLParserBase64Tool::alloc(int newsize) {
-  if ((!buf) && (newsize)) {
-    buf = malloc(newsize);
-    buflen = newsize;
-    return;
-  }
-  if (newsize > buflen) {
-    buf = realloc(buf, newsize);
-    buflen = newsize;
-  }
+void XMLParserBase64Tool::alloc(int newsize)
+{
+    if ((!buf)&&(newsize)) { buf=malloc(newsize); buflen=newsize; return; }
+    if (newsize>buflen) { buf=realloc(buf,newsize); buflen=newsize; }
 }
 
-unsigned char *XMLParserBase64Tool::decode(XMLCSTR data, int *outlen,
-                                           XMLError *xe) {
-  if (xe) *xe = eXMLErrorNone;
-  unsigned int len = decodeSize(data, xe);
-  if (outlen) *outlen = len;
-  if (!len) return NULL;
-  alloc(len + 1);
-  if (!decode(data, (unsigned char *)buf, len, xe)) {
-    return NULL;
-  }
-  return (unsigned char *)buf;
+unsigned char *XMLParserBase64Tool::decode(XMLCSTR data, int *outlen, XMLError *xe)
+{
+    if (xe) *xe=eXMLErrorNone;
+    unsigned int len=decodeSize(data,xe);
+    if (outlen) *outlen=len;
+    if (!len) return NULL;
+    alloc(len+1);
+    if(!decode(data,(unsigned char*)buf,len,xe)){ return NULL; }
+    return (unsigned char*)buf;
 }
+

--- a/src/gpuwattch/xmlParser.cc
+++ b/src/gpuwattch/xmlParser.cc
@@ -37,22 +37,26 @@
  *
  * NOTE:
  *
- *   If you add "#define _XMLPARSER_NO_MESSAGEBOX_" on the first line of this file
+ *   If you add "#define _XMLPARSER_NO_MESSAGEBOX_" on the first line of this
+ *file
  *   the "openFileHelper" function will always display error messages inside the
  *   console instead of inside a message-box-window. Message-box-windows are
  *   available on windows 9x/NT/2000/XP/Vista only.
  *
- * The following license terms for the "XMLParser library from Business-Insight" apply to projects
+ * The following license terms for the "XMLParser library from Business-Insight"
+ *apply to projects
  * that are in some way related to
  * the "mcpat project", including applications
  * using "mcpat project" and tools developed
  * for enhancing "mcpat project". All other projects
- * (not related to "mcpat project") have to use the "XMLParser library from Business-Insight"
+ * (not related to "mcpat project") have to use the "XMLParser library from
+ *Business-Insight"
  * code under the Aladdin Free Public License (AFPL)
  * See the file "AFPL-license.txt" for more informations about the AFPL license.
  * (see http://www.artifex.com/downloads/doc/Public.htm for detailed AFPL terms)
  *
- * Redistribution and use of the "XMLParser library from Business-Insight" in source and binary forms, with or without
+ * Redistribution and use of the "XMLParser library from Business-Insight" in
+ *source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
  *       notice, this list of conditions and the following disclaimer.
@@ -90,266 +94,359 @@
 //#include <crtdbg.h>
 //#endif
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h> // to have IsTextUnicode, MultiByteToWideChar, WideCharToMultiByte to handle unicode files
-                     // to have "MessageBoxA" to display error messages for openFilHelper
+#include <Windows.h>  // to have IsTextUnicode, MultiByteToWideChar, WideCharToMultiByte to handle unicode files
+// to have "MessageBoxA" to display error messages for openFilHelper
 #endif
 
-#include <memory.h>
 #include <assert.h>
+#include <memory.h>
 #include <stdio.h>
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
 
 XMLCSTR XMLNode::getVersion() { return _CXML("v2.39"); }
-void freeXMLString(XMLSTR t){if(t)free(t);}
+void freeXMLString(XMLSTR t) {
+  if (t) free(t);
+}
 
-static XMLNode::XMLCharEncoding characterEncoding=XMLNode::char_encoding_UTF8;
-static char guessWideCharChars=1, dropWhiteSpace=1, removeCommentsInMiddleOfText=1;
+static XMLNode::XMLCharEncoding characterEncoding = XMLNode::char_encoding_UTF8;
+static char guessWideCharChars = 1, dropWhiteSpace = 1,
+            removeCommentsInMiddleOfText = 1;
 
-inline int mmin( const int t1, const int t2 ) { return t1 < t2 ? t1 : t2; }
+inline int mmin(const int t1, const int t2) { return t1 < t2 ? t1 : t2; }
 
 // You can modify the initialization of the variable "XMLClearTags" below
 // to change the clearTags that are currently recognized by the library.
 // The number on the second columns is the length of the string inside the
 // first column. The "<!DOCTYPE" declaration must be the second in the list.
 // The "<!--" declaration must be the third in the list.
-typedef struct { XMLCSTR lpszOpen; int openTagLen; XMLCSTR lpszClose;} ALLXMLClearTag;
-static ALLXMLClearTag XMLClearTags[] =
-{
-    {    _CXML("<![CDATA["),9,  _CXML("]]>")      },
-    {    _CXML("<!DOCTYPE"),9,  _CXML(">")        },
-    {    _CXML("<!--")     ,4,  _CXML("-->")      },
-    {    _CXML("<PRE>")    ,5,  _CXML("</PRE>")   },
-//  {    _CXML("<Script>") ,8,  _CXML("</Script>")},
-    {    NULL              ,0,  NULL           }
-};
+typedef struct {
+  XMLCSTR lpszOpen;
+  int openTagLen;
+  XMLCSTR lpszClose;
+} ALLXMLClearTag;
+static ALLXMLClearTag XMLClearTags[] = {
+    {_CXML("<![CDATA["), 9, _CXML("]]>")},
+    {_CXML("<!DOCTYPE"), 9, _CXML(">")},
+    {_CXML("<!--"), 4, _CXML("-->")},
+    {_CXML("<PRE>"), 5, _CXML("</PRE>")},
+    //  {    _CXML("<Script>") ,8,  _CXML("</Script>")},
+    {NULL, 0, NULL}};
 
 // You can modify the initialization of the variable "XMLEntities" below
-// to change the character entities that are currently recognized by the library.
+// to change the character entities that are currently recognized by the
+// library.
 // The number on the second columns is the length of the string inside the
-// first column. Additionally, the syntaxes "&#xA0;" and "&#160;" are recognized.
-typedef struct { XMLCSTR s; int l; XMLCHAR c;} XMLCharacterEntity;
-static XMLCharacterEntity XMLEntities[] =
-{
-    { _CXML("&amp;" ), 5, _CXML('&' )},
-    { _CXML("&lt;"  ), 4, _CXML('<' )},
-    { _CXML("&gt;"  ), 4, _CXML('>' )},
-    { _CXML("&quot;"), 6, _CXML('\"')},
-    { _CXML("&apos;"), 6, _CXML('\'')},
-    { NULL           , 0, '\0'    }
-};
+// first column. Additionally, the syntaxes "&#xA0;" and "&#160;" are
+// recognized.
+typedef struct {
+  XMLCSTR s;
+  int l;
+  XMLCHAR c;
+} XMLCharacterEntity;
+static XMLCharacterEntity XMLEntities[] = {
+    {_CXML("&amp;"), 5, _CXML('&')},   {_CXML("&lt;"), 4, _CXML('<')},
+    {_CXML("&gt;"), 4, _CXML('>')},    {_CXML("&quot;"), 6, _CXML('\"')},
+    {_CXML("&apos;"), 6, _CXML('\'')}, {NULL, 0, '\0'}};
 
-// When rendering the XMLNode to a string (using the "createXMLString" function),
+// When rendering the XMLNode to a string (using the "createXMLString"
+// function),
 // you can ask for a beautiful formatting. This formatting is using the
 // following indentation character:
 #define INDENTCHAR _CXML('\t')
 
 // The following function parses the XML errors into a user friendly string.
-// You can edit this to change the output language of the library to something else.
-XMLCSTR XMLNode::getError(XMLError xerror)
-{
-    switch (xerror)
-    {
-    case eXMLErrorNone:                  return _CXML("No error");
-    case eXMLErrorMissingEndTag:         return _CXML("Warning: Unmatched end tag");
-    case eXMLErrorNoXMLTagFound:         return _CXML("Warning: No XML tag found");
-    case eXMLErrorEmpty:                 return _CXML("Error: No XML data");
-    case eXMLErrorMissingTagName:        return _CXML("Error: Missing start tag name");
-    case eXMLErrorMissingEndTagName:     return _CXML("Error: Missing end tag name");
-    case eXMLErrorUnmatchedEndTag:       return _CXML("Error: Unmatched end tag");
-    case eXMLErrorUnmatchedEndClearTag:  return _CXML("Error: Unmatched clear tag end");
-    case eXMLErrorUnexpectedToken:       return _CXML("Error: Unexpected token found");
-    case eXMLErrorNoElements:            return _CXML("Error: No elements found");
-    case eXMLErrorFileNotFound:          return _CXML("Error: File not found");
-    case eXMLErrorFirstTagNotFound:      return _CXML("Error: First Tag not found");
-    case eXMLErrorUnknownCharacterEntity:return _CXML("Error: Unknown character entity");
-    case eXMLErrorCharacterCodeAbove255: return _CXML("Error: Character code above 255 is forbidden in MultiByte char mode.");
-    case eXMLErrorCharConversionError:   return _CXML("Error: unable to convert between WideChar and MultiByte chars");
-    case eXMLErrorCannotOpenWriteFile:   return _CXML("Error: unable to open file for writing");
-    case eXMLErrorCannotWriteFile:       return _CXML("Error: cannot write into file");
+// You can edit this to change the output language of the library to something
+// else.
+XMLCSTR XMLNode::getError(XMLError xerror) {
+  switch (xerror) {
+    case eXMLErrorNone:
+      return _CXML("No error");
+    case eXMLErrorMissingEndTag:
+      return _CXML("Warning: Unmatched end tag");
+    case eXMLErrorNoXMLTagFound:
+      return _CXML("Warning: No XML tag found");
+    case eXMLErrorEmpty:
+      return _CXML("Error: No XML data");
+    case eXMLErrorMissingTagName:
+      return _CXML("Error: Missing start tag name");
+    case eXMLErrorMissingEndTagName:
+      return _CXML("Error: Missing end tag name");
+    case eXMLErrorUnmatchedEndTag:
+      return _CXML("Error: Unmatched end tag");
+    case eXMLErrorUnmatchedEndClearTag:
+      return _CXML("Error: Unmatched clear tag end");
+    case eXMLErrorUnexpectedToken:
+      return _CXML("Error: Unexpected token found");
+    case eXMLErrorNoElements:
+      return _CXML("Error: No elements found");
+    case eXMLErrorFileNotFound:
+      return _CXML("Error: File not found");
+    case eXMLErrorFirstTagNotFound:
+      return _CXML("Error: First Tag not found");
+    case eXMLErrorUnknownCharacterEntity:
+      return _CXML("Error: Unknown character entity");
+    case eXMLErrorCharacterCodeAbove255:
+      return _CXML(
+          "Error: Character code above 255 is forbidden in MultiByte char "
+          "mode.");
+    case eXMLErrorCharConversionError:
+      return _CXML(
+          "Error: unable to convert between WideChar and MultiByte chars");
+    case eXMLErrorCannotOpenWriteFile:
+      return _CXML("Error: unable to open file for writing");
+    case eXMLErrorCannotWriteFile:
+      return _CXML("Error: cannot write into file");
 
-    case eXMLErrorBase64DataSizeIsNotMultipleOf4: return _CXML("Warning: Base64-string length is not a multiple of 4");
-    case eXMLErrorBase64DecodeTruncatedData:      return _CXML("Warning: Base64-string is truncated");
-    case eXMLErrorBase64DecodeIllegalCharacter:   return _CXML("Error: Base64-string contains an illegal character");
-    case eXMLErrorBase64DecodeBufferTooSmall:     return _CXML("Error: Base64 decode output buffer is too small");
-    };
-    return _CXML("Unknown");
+    case eXMLErrorBase64DataSizeIsNotMultipleOf4:
+      return _CXML("Warning: Base64-string length is not a multiple of 4");
+    case eXMLErrorBase64DecodeTruncatedData:
+      return _CXML("Warning: Base64-string is truncated");
+    case eXMLErrorBase64DecodeIllegalCharacter:
+      return _CXML("Error: Base64-string contains an illegal character");
+    case eXMLErrorBase64DecodeBufferTooSmall:
+      return _CXML("Error: Base64 decode output buffer is too small");
+  };
+  return _CXML("Unknown");
 }
 
 /////////////////////////////////////////////////////////////////////////
 //      Here start the abstraction layer to be OS-independent          //
 /////////////////////////////////////////////////////////////////////////
 
-// Here is an abstraction layer to access some common string manipulation functions.
-// The abstraction layer is currently working for gcc, Microsoft Visual Studio 6.0,
+// Here is an abstraction layer to access some common string manipulation
+// functions.
+// The abstraction layer is currently working for gcc, Microsoft Visual Studio
+// 6.0,
 // Microsoft Visual Studio .NET, CC (sun compiler) and Borland C++.
-// If you plan to "port" the library to a new system/compiler, all you have to do is
+// If you plan to "port" the library to a new system/compiler, all you have to
+// do is
 // to edit the following lines.
 #ifdef XML_NO_WIDE_CHAR
 char myIsTextWideChar(const void *b, int len) { return FALSE; }
 #else
-    #if defined (UNDER_CE) || !defined(_XMLWINDOWS)
-    char myIsTextWideChar(const void *b, int len) // inspired by the Wine API: RtlIsTextUnicode
-    {
+#if defined(UNDER_CE) || !defined(_XMLWINDOWS)
+char myIsTextWideChar(const void *b,
+                      int len)  // inspired by the Wine API: RtlIsTextUnicode
+{
 #ifdef sun
-        // for SPARC processors: wchar_t* buffers must always be alligned, otherwise it's a char* buffer.
-        if ((((unsigned long)b)%sizeof(wchar_t))!=0) return FALSE;
+  // for SPARC processors: wchar_t* buffers must always be alligned, otherwise
+  // it's a char* buffer.
+  if ((((unsigned long)b) % sizeof(wchar_t)) != 0) return FALSE;
 #endif
-        const wchar_t *s=(const wchar_t*)b;
+  const wchar_t *s = (const wchar_t *)b;
 
-        // buffer too small:
-        if (len<(int)sizeof(wchar_t)) return FALSE;
+  // buffer too small:
+  if (len < (int)sizeof(wchar_t)) return FALSE;
 
-        // odd length test
-        if (len&1) return FALSE;
+  // odd length test
+  if (len & 1) return FALSE;
 
-        /* only checks the first 256 characters */
-        len=mmin(256,len/sizeof(wchar_t));
+  /* only checks the first 256 characters */
+  len = mmin(256, len / sizeof(wchar_t));
 
-        // Check for the special byte order:
-        if (*((unsigned short*)s) == 0xFFFE) return TRUE;     // IS_TEXT_UNICODE_REVERSE_SIGNATURE;
-        if (*((unsigned short*)s) == 0xFEFF) return TRUE;      // IS_TEXT_UNICODE_SIGNATURE
+  // Check for the special byte order:
+  if (*((unsigned short *)s) == 0xFFFE)
+    return TRUE;  // IS_TEXT_UNICODE_REVERSE_SIGNATURE;
+  if (*((unsigned short *)s) == 0xFEFF)
+    return TRUE;  // IS_TEXT_UNICODE_SIGNATURE
 
-        // checks for ASCII characters in the UNICODE stream
-        int i,stats=0;
-        for (i=0; i<len; i++) if (s[i]<=(unsigned short)255) stats++;
-        if (stats>len/2) return TRUE;
+  // checks for ASCII characters in the UNICODE stream
+  int i, stats = 0;
+  for (i = 0; i < len; i++)
+    if (s[i] <= (unsigned short)255) stats++;
+  if (stats > len / 2) return TRUE;
 
-        // Check for UNICODE NULL chars
-        for (i=0; i<len; i++) if (!s[i]) return TRUE;
+  // Check for UNICODE NULL chars
+  for (i = 0; i < len; i++)
+    if (!s[i]) return TRUE;
 
-        return FALSE;
-    }
-    #else
-    char myIsTextWideChar(const void *b,int l) { return (char)IsTextUnicode((CONST LPVOID)b,l,NULL); };
-    #endif
+  return FALSE;
+}
+#else
+char myIsTextWideChar(const void *b, int l) {
+  return (char)IsTextUnicode((CONST LPVOID)b, l, NULL);
+};
+#endif
 #endif
 
 #ifdef _XMLWINDOWS
-// for Microsoft Visual Studio 6.0 and Microsoft Visual Studio .NET and Borland C++ Builder 6.0
-    #ifdef _XMLWIDECHAR
-        wchar_t *myMultiByteToWideChar(const char *s, XMLNode::XMLCharEncoding ce)
-        {
-            int i;
-            if (ce==XMLNode::char_encoding_UTF8) i=(int)MultiByteToWideChar(CP_UTF8,0             ,s,-1,NULL,0);
-            else                            i=(int)MultiByteToWideChar(CP_ACP ,MB_PRECOMPOSED,s,-1,NULL,0);
-            if (i<0) return NULL;
-            wchar_t *d=(wchar_t *)malloc((i+1)*sizeof(XMLCHAR));
-            if (ce==XMLNode::char_encoding_UTF8) i=(int)MultiByteToWideChar(CP_UTF8,0             ,s,-1,d,i);
-            else                            i=(int)MultiByteToWideChar(CP_ACP ,MB_PRECOMPOSED,s,-1,d,i);
-            d[i]=0;
-            return d;
-        }
-        static inline FILE *xfopen(XMLCSTR filename,XMLCSTR mode) { return _wfopen(filename,mode); }
-        static inline int xstrlen(XMLCSTR c)   { return (int)wcslen(c); }
-        static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) { return _wcsnicmp(c1,c2,l);}
-        static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) { return wcsncmp(c1,c2,l);}
-        static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return _wcsicmp(c1,c2); }
-        static inline XMLSTR xstrstr(XMLCSTR c1, XMLCSTR c2) { return (XMLSTR)wcsstr(c1,c2); }
-        static inline XMLSTR xstrcpy(XMLSTR c1, XMLCSTR c2) { return (XMLSTR)wcscpy(c1,c2); }
-    #else
-        char *myWideCharToMultiByte(const wchar_t *s)
-        {
-            UINT codePage=CP_ACP; if (characterEncoding==XMLNode::char_encoding_UTF8) codePage=CP_UTF8;
-            int i=(int)WideCharToMultiByte(codePage,  // code page
-                0,                       // performance and mapping flags
-                s,                       // wide-character string
-                -1,                       // number of chars in string
-                NULL,                       // buffer for new string
-                0,                       // size of buffer
-                NULL,                    // default for unmappable chars
-                NULL                     // set when default char used
-                );
-            if (i<0) return NULL;
-            char *d=(char*)malloc(i+1);
-            WideCharToMultiByte(codePage,  // code page
-                0,                       // performance and mapping flags
-                s,                       // wide-character string
-                -1,                       // number of chars in string
-                d,                       // buffer for new string
-                i,                       // size of buffer
-                NULL,                    // default for unmappable chars
-                NULL                     // set when default char used
-                );
-            d[i]=0;
-            return d;
-        }
-        static inline FILE *xfopen(XMLCSTR filename,XMLCSTR mode) { return fopen(filename,mode); }
-        static inline int xstrlen(XMLCSTR c)   { return (int)strlen(c); }
-        #ifdef __BORLANDC__
-            static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) { return strnicmp(c1,c2,l);}
-            static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return stricmp(c1,c2); }
-        #else
-            static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) { return _strnicmp(c1,c2,l);}
-            static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return _stricmp(c1,c2); }
-        #endif
-        static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) { return strncmp(c1,c2,l);}
-        static inline XMLSTR xstrstr(XMLCSTR c1, XMLCSTR c2) { return (XMLSTR)strstr(c1,c2); }
-        static inline XMLSTR xstrcpy(XMLSTR c1, XMLCSTR c2) { return (XMLSTR)strcpy(c1,c2); }
-    #endif
+// for Microsoft Visual Studio 6.0 and Microsoft Visual Studio .NET and Borland
+// C++ Builder 6.0
+#ifdef _XMLWIDECHAR
+wchar_t *myMultiByteToWideChar(const char *s, XMLNode::XMLCharEncoding ce) {
+  int i;
+  if (ce == XMLNode::char_encoding_UTF8)
+    i = (int)MultiByteToWideChar(CP_UTF8, 0, s, -1, NULL, 0);
+  else
+    i = (int)MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, s, -1, NULL, 0);
+  if (i < 0) return NULL;
+  wchar_t *d = (wchar_t *)malloc((i + 1) * sizeof(XMLCHAR));
+  if (ce == XMLNode::char_encoding_UTF8)
+    i = (int)MultiByteToWideChar(CP_UTF8, 0, s, -1, d, i);
+  else
+    i = (int)MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, s, -1, d, i);
+  d[i] = 0;
+  return d;
+}
+static inline FILE *xfopen(XMLCSTR filename, XMLCSTR mode) {
+  return _wfopen(filename, mode);
+}
+static inline int xstrlen(XMLCSTR c) { return (int)wcslen(c); }
+static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) {
+  return _wcsnicmp(c1, c2, l);
+}
+static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) {
+  return wcsncmp(c1, c2, l);
+}
+static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return _wcsicmp(c1, c2); }
+static inline XMLSTR xstrstr(XMLCSTR c1, XMLCSTR c2) {
+  return (XMLSTR)wcsstr(c1, c2);
+}
+static inline XMLSTR xstrcpy(XMLSTR c1, XMLCSTR c2) {
+  return (XMLSTR)wcscpy(c1, c2);
+}
+#else
+char *myWideCharToMultiByte(const wchar_t *s) {
+  UINT codePage = CP_ACP;
+  if (characterEncoding == XMLNode::char_encoding_UTF8) codePage = CP_UTF8;
+  int i = (int)WideCharToMultiByte(codePage,  // code page
+                                   0,         // performance and mapping flags
+                                   s,         // wide-character string
+                                   -1,        // number of chars in string
+                                   NULL,      // buffer for new string
+                                   0,         // size of buffer
+                                   NULL,      // default for unmappable chars
+                                   NULL       // set when default char used
+                                   );
+  if (i < 0) return NULL;
+  char *d = (char *)malloc(i + 1);
+  WideCharToMultiByte(codePage,  // code page
+                      0,         // performance and mapping flags
+                      s,         // wide-character string
+                      -1,        // number of chars in string
+                      d,         // buffer for new string
+                      i,         // size of buffer
+                      NULL,      // default for unmappable chars
+                      NULL       // set when default char used
+                      );
+  d[i] = 0;
+  return d;
+}
+static inline FILE *xfopen(XMLCSTR filename, XMLCSTR mode) {
+  return fopen(filename, mode);
+}
+static inline int xstrlen(XMLCSTR c) { return (int)strlen(c); }
+#ifdef __BORLANDC__
+static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) {
+  return strnicmp(c1, c2, l);
+}
+static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return stricmp(c1, c2); }
+#else
+static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) {
+  return _strnicmp(c1, c2, l);
+}
+static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return _stricmp(c1, c2); }
+#endif
+static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) {
+  return strncmp(c1, c2, l);
+}
+static inline XMLSTR xstrstr(XMLCSTR c1, XMLCSTR c2) {
+  return (XMLSTR)strstr(c1, c2);
+}
+static inline XMLSTR xstrcpy(XMLSTR c1, XMLCSTR c2) {
+  return (XMLSTR)strcpy(c1, c2);
+}
+#endif
 #else
 // for gcc and CC
-    #ifdef XML_NO_WIDE_CHAR
-        char *myWideCharToMultiByte(const wchar_t *s) { return NULL; }
-    #else
-        char *myWideCharToMultiByte(const wchar_t *s)
-        {
-            const wchar_t *ss=s;
-            int i=(int)wcsrtombs(NULL,&ss,0,NULL);
-            if (i<0) return NULL;
-            char *d=(char *)malloc(i+1);
-            wcsrtombs(d,&s,i,NULL);
-            d[i]=0;
-            return d;
-        }
-    #endif
-    #ifdef _XMLWIDECHAR
-        wchar_t *myMultiByteToWideChar(const char *s, XMLNode::XMLCharEncoding ce)
-        {
-            const char *ss=s;
-            int i=(int)mbsrtowcs(NULL,&ss,0,NULL);
-            if (i<0) return NULL;
-            wchar_t *d=(wchar_t *)malloc((i+1)*sizeof(wchar_t));
-            mbsrtowcs(d,&s,i,NULL);
-            d[i]=0;
-            return d;
-        }
-        int xstrlen(XMLCSTR c)   { return wcslen(c); }
-        #ifdef sun
-        // for CC
-           #include <widec.h>
-           static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) { return wsncasecmp(c1,c2,l);}
-           static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) { return wsncmp(c1,c2,l);}
-           static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return wscasecmp(c1,c2); }
-        #else
-        // for gcc
-           static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) { return wcsncasecmp(c1,c2,l);}
-           static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) { return wcsncmp(c1,c2,l);}
-           static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return wcscasecmp(c1,c2); }
-        #endif
-        static inline XMLSTR xstrstr(XMLCSTR c1, XMLCSTR c2) { return (XMLSTR)wcsstr(c1,c2); }
-        static inline XMLSTR xstrcpy(XMLSTR c1, XMLCSTR c2) { return (XMLSTR)wcscpy(c1,c2); }
-        static inline FILE *xfopen(XMLCSTR filename,XMLCSTR mode)
-        {
-            char *filenameAscii=myWideCharToMultiByte(filename);
-            FILE *f;
-            if (mode[0]==_CXML('r')) f=fopen(filenameAscii,"rb");
-            else                     f=fopen(filenameAscii,"wb");
-            free(filenameAscii);
-            return f;
-        }
-    #else
-        static inline FILE *xfopen(XMLCSTR filename,XMLCSTR mode) { return fopen(filename,mode); }
-        static inline int xstrlen(XMLCSTR c)   { return strlen(c); }
-        static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) { return strncasecmp(c1,c2,l);}
-        static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) { return strncmp(c1,c2,l);}
-        static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return strcasecmp(c1,c2); }
-        static inline XMLSTR xstrstr(XMLCSTR c1, XMLCSTR c2) { return (XMLSTR)strstr(c1,c2); }
-        static inline XMLSTR xstrcpy(XMLSTR c1, XMLCSTR c2) { return (XMLSTR)strcpy(c1,c2); }
-    #endif
-    static inline int _strnicmp(const char *c1,const char *c2, int l) { return strncasecmp(c1,c2,l);}
+#ifdef XML_NO_WIDE_CHAR
+char *myWideCharToMultiByte(const wchar_t *s) { return NULL; }
+#else
+char *myWideCharToMultiByte(const wchar_t *s) {
+  const wchar_t *ss = s;
+  int i = (int)wcsrtombs(NULL, &ss, 0, NULL);
+  if (i < 0) return NULL;
+  char *d = (char *)malloc(i + 1);
+  wcsrtombs(d, &s, i, NULL);
+  d[i] = 0;
+  return d;
+}
 #endif
-
+#ifdef _XMLWIDECHAR
+wchar_t *myMultiByteToWideChar(const char *s, XMLNode::XMLCharEncoding ce) {
+  const char *ss = s;
+  int i = (int)mbsrtowcs(NULL, &ss, 0, NULL);
+  if (i < 0) return NULL;
+  wchar_t *d = (wchar_t *)malloc((i + 1) * sizeof(wchar_t));
+  mbsrtowcs(d, &s, i, NULL);
+  d[i] = 0;
+  return d;
+}
+int xstrlen(XMLCSTR c) { return wcslen(c); }
+#ifdef sun
+// for CC
+#include <widec.h>
+static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) {
+  return wsncasecmp(c1, c2, l);
+}
+static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) {
+  return wsncmp(c1, c2, l);
+}
+static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) { return wscasecmp(c1, c2); }
+#else
+// for gcc
+static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) {
+  return wcsncasecmp(c1, c2, l);
+}
+static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) {
+  return wcsncmp(c1, c2, l);
+}
+static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) {
+  return wcscasecmp(c1, c2);
+}
+#endif
+static inline XMLSTR xstrstr(XMLCSTR c1, XMLCSTR c2) {
+  return (XMLSTR)wcsstr(c1, c2);
+}
+static inline XMLSTR xstrcpy(XMLSTR c1, XMLCSTR c2) {
+  return (XMLSTR)wcscpy(c1, c2);
+}
+static inline FILE *xfopen(XMLCSTR filename, XMLCSTR mode) {
+  char *filenameAscii = myWideCharToMultiByte(filename);
+  FILE *f;
+  if (mode[0] == _CXML('r'))
+    f = fopen(filenameAscii, "rb");
+  else
+    f = fopen(filenameAscii, "wb");
+  free(filenameAscii);
+  return f;
+}
+#else
+static inline FILE *xfopen(XMLCSTR filename, XMLCSTR mode) {
+  return fopen(filename, mode);
+}
+static inline int xstrlen(XMLCSTR c) { return strlen(c); }
+static inline int xstrnicmp(XMLCSTR c1, XMLCSTR c2, int l) {
+  return strncasecmp(c1, c2, l);
+}
+static inline int xstrncmp(XMLCSTR c1, XMLCSTR c2, int l) {
+  return strncmp(c1, c2, l);
+}
+static inline int xstricmp(XMLCSTR c1, XMLCSTR c2) {
+  return strcasecmp(c1, c2);
+}
+static inline XMLSTR xstrstr(XMLCSTR c1, XMLCSTR c2) {
+  return (XMLSTR)strstr(c1, c2);
+}
+static inline XMLSTR xstrcpy(XMLSTR c1, XMLCSTR c2) {
+  return (XMLSTR)strcpy(c1, c2);
+}
+#endif
+static inline int _strnicmp(const char *c1, const char *c2, int l) {
+  return strncasecmp(c1, c2, l);
+}
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 //            the "xmltoc,xmltob,xmltoi,xmltol,xmltof,xmltoa" functions      //
@@ -358,82 +455,145 @@ char myIsTextWideChar(const void *b, int len) { return FALSE; }
 // There are only here as "convenience" functions for the user.
 // If you don't need them, you can delete them without any trouble.
 #ifdef _XMLWIDECHAR
-    #ifdef _XMLWINDOWS
-    // for Microsoft Visual Studio 6.0 and Microsoft Visual Studio .NET and Borland C++ Builder 6.0
-        char    xmltob(XMLCSTR t,int     v){ if (t&&(*t)) return (char)_wtoi(t); return v; }
-        int     xmltoi(XMLCSTR t,int     v){ if (t&&(*t)) return _wtoi(t); return v; }
-        long    xmltol(XMLCSTR t,long    v){ if (t&&(*t)) return _wtol(t); return v; }
-        double  xmltof(XMLCSTR t,double  v){ if (t&&(*t)) wscanf(t, "%f", &v); /*v=_wtof(t);*/ return v; }
-    #else
-        #ifdef sun
-        // for CC
-           #include <widec.h>
-           char    xmltob(XMLCSTR t,int     v){ if (t) return (char)wstol(t,NULL,10); return v; }
-           int     xmltoi(XMLCSTR t,int     v){ if (t) return (int)wstol(t,NULL,10); return v; }
-           long    xmltol(XMLCSTR t,long    v){ if (t) return wstol(t,NULL,10); return v; }
-        #else
-        // for gcc
-           char    xmltob(XMLCSTR t,int     v){ if (t) return (char)wcstol(t,NULL,10); return v; }
-           int     xmltoi(XMLCSTR t,int     v){ if (t) return (int)wcstol(t,NULL,10); return v; }
-           long    xmltol(XMLCSTR t,long    v){ if (t) return wcstol(t,NULL,10); return v; }
-        #endif
-		double  xmltof(XMLCSTR t,double  v){ if (t&&(*t)) wscanf(t, "%f", &v); /*v=_wtof(t);*/ return v; }
-    #endif
+#ifdef _XMLWINDOWS
+// for Microsoft Visual Studio 6.0 and Microsoft Visual Studio .NET and Borland
+// C++ Builder 6.0
+char xmltob(XMLCSTR t, int v) {
+  if (t && (*t)) return (char)_wtoi(t);
+  return v;
+}
+int xmltoi(XMLCSTR t, int v) {
+  if (t && (*t)) return _wtoi(t);
+  return v;
+}
+long xmltol(XMLCSTR t, long v) {
+  if (t && (*t)) return _wtol(t);
+  return v;
+}
+double xmltof(XMLCSTR t, double v) {
+  if (t && (*t)) wscanf(t, "%f", &v); /*v=_wtof(t);*/
+  return v;
+}
 #else
-    char    xmltob(XMLCSTR t,char    v){ if (t&&(*t)) return (char)atoi(t); return v; }
-    int     xmltoi(XMLCSTR t,int     v){ if (t&&(*t)) return atoi(t); return v; }
-    long    xmltol(XMLCSTR t,long    v){ if (t&&(*t)) return atol(t); return v; }
-    double  xmltof(XMLCSTR t,double  v){ if (t&&(*t)) return atof(t); return v; }
+#ifdef sun
+// for CC
+#include <widec.h>
+char xmltob(XMLCSTR t, int v) {
+  if (t) return (char)wstol(t, NULL, 10);
+  return v;
+}
+int xmltoi(XMLCSTR t, int v) {
+  if (t) return (int)wstol(t, NULL, 10);
+  return v;
+}
+long xmltol(XMLCSTR t, long v) {
+  if (t) return wstol(t, NULL, 10);
+  return v;
+}
+#else
+// for gcc
+char xmltob(XMLCSTR t, int v) {
+  if (t) return (char)wcstol(t, NULL, 10);
+  return v;
+}
+int xmltoi(XMLCSTR t, int v) {
+  if (t) return (int)wcstol(t, NULL, 10);
+  return v;
+}
+long xmltol(XMLCSTR t, long v) {
+  if (t) return wcstol(t, NULL, 10);
+  return v;
+}
 #endif
-XMLCSTR xmltoa(XMLCSTR t,XMLCSTR v){ if (t)       return  t; return v; }
-XMLCHAR xmltoc(XMLCSTR t,XMLCHAR v){ if (t&&(*t)) return *t; return v; }
+double xmltof(XMLCSTR t, double v) {
+  if (t && (*t)) wscanf(t, "%f", &v); /*v=_wtof(t);*/
+  return v;
+}
+#endif
+#else
+char xmltob(XMLCSTR t, char v) {
+  if (t && (*t)) return (char)atoi(t);
+  return v;
+}
+int xmltoi(XMLCSTR t, int v) {
+  if (t && (*t)) return atoi(t);
+  return v;
+}
+long xmltol(XMLCSTR t, long v) {
+  if (t && (*t)) return atol(t);
+  return v;
+}
+double xmltof(XMLCSTR t, double v) {
+  if (t && (*t)) return atof(t);
+  return v;
+}
+#endif
+XMLCSTR xmltoa(XMLCSTR t, XMLCSTR v) {
+  if (t) return t;
+  return v;
+}
+XMLCHAR xmltoc(XMLCSTR t, XMLCHAR v) {
+  if (t && (*t)) return *t;
+  return v;
+}
 
 /////////////////////////////////////////////////////////////////////////
 //                    the "openFileHelper" function                    //
 /////////////////////////////////////////////////////////////////////////
 
-// Since each application has its own way to report and deal with errors, you should modify & rewrite
-// the following "openFileHelper" function to get an "error reporting mechanism" tailored to your needs.
-XMLNode XMLNode::openFileHelper(XMLCSTR filename, XMLCSTR tag)
-{
-    // guess the value of the global parameter "characterEncoding"
-    // (the guess is based on the first 200 bytes of the file).
-    FILE *f=xfopen(filename,_CXML("rb"));
-    if (f)
-    {
-        char bb[205];
-        int l=(int)fread(bb,1,200,f);
-        setGlobalOptions(guessCharEncoding(bb,l),guessWideCharChars,dropWhiteSpace,removeCommentsInMiddleOfText);
-        fclose(f);
+// Since each application has its own way to report and deal with errors, you
+// should modify & rewrite
+// the following "openFileHelper" function to get an "error reporting mechanism"
+// tailored to your needs.
+XMLNode XMLNode::openFileHelper(XMLCSTR filename, XMLCSTR tag) {
+  // guess the value of the global parameter "characterEncoding"
+  // (the guess is based on the first 200 bytes of the file).
+  FILE *f = xfopen(filename, _CXML("rb"));
+  if (f) {
+    char bb[205];
+    int l = (int)fread(bb, 1, 200, f);
+    setGlobalOptions(guessCharEncoding(bb, l), guessWideCharChars,
+                     dropWhiteSpace, removeCommentsInMiddleOfText);
+    fclose(f);
+  }
+
+  // parse the file
+  XMLResults pResults;
+  XMLNode xnode = XMLNode::parseFile(filename, tag, &pResults);
+
+  // display error message (if any)
+  if (pResults.error != eXMLErrorNone) {
+    // create message
+    char message[2000], *s1 = (char *)"", *s3 = (char *)"";
+    XMLCSTR s2 = _CXML("");
+    if (pResults.error == eXMLErrorFirstTagNotFound) {
+      s1 = (char *)"First Tag should be '";
+      s2 = tag;
+      s3 = (char *)"'.\n";
     }
-
-    // parse the file
-    XMLResults pResults;
-    XMLNode xnode=XMLNode::parseFile(filename,tag,&pResults);
-
-    // display error message (if any)
-    if (pResults.error != eXMLErrorNone)
-    {
-        // create message
-        char message[2000],*s1=(char*)"",*s3=(char*)""; XMLCSTR s2=_CXML("");
-        if (pResults.error==eXMLErrorFirstTagNotFound) { s1=(char*)"First Tag should be '"; s2=tag; s3=(char*)"'.\n"; }
-        sprintf(message,
+    sprintf(message,
 #ifdef _XMLWIDECHAR
-            "XML Parsing error inside file '%S'.\n%S\nAt line %i, column %i.\n%s%S%s"
+            "XML Parsing error inside file '%S'.\n%S\nAt line %i, column "
+            "%i.\n%s%S%s"
 #else
-            "XML Parsing error inside file '%s'.\n%s\nAt line %i, column %i.\n%s%s%s"
+            "XML Parsing error inside file '%s'.\n%s\nAt line %i, column "
+            "%i.\n%s%s%s"
 #endif
-            ,filename,XMLNode::getError(pResults.error),pResults.nLine,pResults.nColumn,s1,s2,s3);
+            ,
+            filename, XMLNode::getError(pResults.error), pResults.nLine,
+            pResults.nColumn, s1, s2, s3);
 
-        // display message
-#if defined(_XMLWINDOWS) && !defined(UNDER_CE) && !defined(_XMLPARSER_NO_MESSAGEBOX_)
-        MessageBoxA(NULL,message,"XML Parsing error",MB_OK|MB_ICONERROR|MB_TOPMOST);
+// display message
+#if defined(_XMLWINDOWS) && !defined(UNDER_CE) && \
+    !defined(_XMLPARSER_NO_MESSAGEBOX_)
+    MessageBoxA(NULL, message, "XML Parsing error",
+                MB_OK | MB_ICONERROR | MB_TOPMOST);
 #else
-        printf("%s",message);
+    printf("%s", message);
 #endif
-        exit(255);
-    }
-    return xnode;
+    exit(255);
+  }
+  return xnode;
 }
 
 /////////////////////////////////////////////////////////////////////////
@@ -443,400 +603,496 @@ XMLNode XMLNode::openFileHelper(XMLCSTR filename, XMLCSTR tag)
 // You should normally not change anything below this point.
 
 #ifndef _XMLWIDECHAR
-// If "characterEncoding=ascii" then we assume that all characters have the same length of 1 byte.
-// If "characterEncoding=UTF8" then the characters have different lengths (from 1 byte to 4 bytes).
-// If "characterEncoding=ShiftJIS" then the characters have different lengths (from 1 byte to 2 bytes).
-// This table is used as lookup-table to know the length of a character (in byte) based on the
+// If "characterEncoding=ascii" then we assume that all characters have the same
+// length of 1 byte.
+// If "characterEncoding=UTF8" then the characters have different lengths (from
+// 1 byte to 4 bytes).
+// If "characterEncoding=ShiftJIS" then the characters have different lengths
+// (from 1 byte to 2 bytes).
+// This table is used as lookup-table to know the length of a character (in
+// byte) based on the
 // content of the first byte of the character.
 // (note: if you modify this, you must always have XML_utf8ByteTable[0]=0 ).
-static const char XML_utf8ByteTable[256] =
-{
+static const char XML_utf8ByteTable[256] = {
     //  0 1 2 3 4 5 6 7 8 9 a b c d e f
-    0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x00
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x10
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x20
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x30
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x40
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x50
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x60
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x70 End of ASCII range
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x80 0x80 to 0xc1 invalid
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x90
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0xa0
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0xb0
-    1,1,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xc0 0xc2 to 0xdf 2 byte
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xd0
-    3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,// 0xe0 0xe0 to 0xef 3 byte
-    4,4,4,4,4,1,1,1,1,1,1,1,1,1,1,1 // 0xf0 0xf0 to 0xf4 4 byte, 0xf5 and higher invalid
+    0, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x00
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x10
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x20
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x30
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x40
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x50
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x60
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x70 End of ASCII range
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x80 0x80 to 0xc1 invalid
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x90
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0xa0
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0xb0
+    1, 1, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0xc0 0xc2 to 0xdf 2 byte
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0xd0
+    3, 3, 3, 3, 3, 3, 3, 3,
+    3, 3, 3, 3, 3, 3, 3, 3,  // 0xe0 0xe0 to 0xef 3 byte
+    4, 4, 4, 4, 4, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1  // 0xf0 0xf0 to 0xf4 4 byte, 0xf5 and higher invalid
 };
-static const char XML_legacyByteTable[256] =
-{
-    0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1
-};
-static const char XML_sjisByteTable[256] =
-{
+static const char XML_legacyByteTable[256] = {
+    0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+static const char XML_sjisByteTable[256] = {
     //  0 1 2 3 4 5 6 7 8 9 a b c d e f
-    0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x00
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x10
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x20
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x30
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x40
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x50
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x60
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x70
-    1,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0x80 0x81 to 0x9F 2 bytes
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0x90
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0xa0
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0xb0
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0xc0
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0xd0
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xe0 0xe0 to 0xef 2 bytes
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1 // 0xf0
+    0, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x00
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x10
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x20
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x30
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x40
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x50
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x60
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x70
+    1, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0x80 0x81 to 0x9F 2 bytes
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0x90
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0xa0
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0xb0
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0xc0
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0xd0
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0xe0 0xe0 to 0xef 2 bytes
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1  // 0xf0
 };
-static const char XML_gb2312ByteTable[256] =
-{
-//  0 1 2 3 4 5 6 7 8 9 a b c d e f
-    0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x00
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x10
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x20
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x30
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x40
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x50
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x60
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x70
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x80
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x90
-    1,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xa0 0xa1 to 0xf7 2 bytes
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xb0
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xc0
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xd0
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xe0
-    2,2,2,2,2,2,2,2,1,1,1,1,1,1,1,1 // 0xf0
-};
-static const char XML_gbk_big5_ByteTable[256] =
-{
+static const char XML_gb2312ByteTable[256] = {
     //  0 1 2 3 4 5 6 7 8 9 a b c d e f
-    0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x00
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x10
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x20
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x30
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x40
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x50
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x60
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,// 0x70
-    1,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0x80 0x81 to 0xfe 2 bytes
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0x90
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xa0
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xb0
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xc0
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xd0
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,// 0xe0
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,1 // 0xf0
+    0, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x00
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x10
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x20
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x30
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x40
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x50
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x60
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x70
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x80
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x90
+    1, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0xa0 0xa1 to 0xf7 2 bytes
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0xb0
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0xc0
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0xd0
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0xe0
+    2, 2, 2, 2, 2, 2, 2, 2,
+    1, 1, 1, 1, 1, 1, 1, 1  // 0xf0
 };
-static const char *XML_ByteTable=(const char *)XML_utf8ByteTable; // the default is "characterEncoding=XMLNode::encoding_UTF8"
+static const char XML_gbk_big5_ByteTable[256] = {
+    //  0 1 2 3 4 5 6 7 8 9 a b c d e f
+    0, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x00
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x10
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x20
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x30
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x40
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x50
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x60
+    1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1,  // 0x70
+    1, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0x80 0x81 to 0xfe 2 bytes
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0x90
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0xa0
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0xb0
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0xc0
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0xd0
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2,  // 0xe0
+    2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 1  // 0xf0
+};
+static const char *XML_ByteTable = (const char *)
+    XML_utf8ByteTable;  // the default is
+                        // "characterEncoding=XMLNode::encoding_UTF8"
 #endif
 
-
 XMLNode XMLNode::emptyXMLNode;
-XMLClear XMLNode::emptyXMLClear={ NULL, NULL, NULL};
-XMLAttribute XMLNode::emptyXMLAttribute={ NULL, NULL};
+XMLClear XMLNode::emptyXMLClear = {NULL, NULL, NULL};
+XMLAttribute XMLNode::emptyXMLAttribute = {NULL, NULL};
 
 // Enumeration used to decipher what type a token is
-typedef enum XMLTokenTypeTag
-{
-    eTokenText = 0,
-    eTokenQuotedText,
-    eTokenTagStart,         /* "<"            */
-    eTokenTagEnd,           /* "</"           */
-    eTokenCloseTag,         /* ">"            */
-    eTokenEquals,           /* "="            */
-    eTokenDeclaration,      /* "<?"           */
-    eTokenShortHandClose,   /* "/>"           */
-    eTokenClear,
-    eTokenError
+typedef enum XMLTokenTypeTag {
+  eTokenText = 0,
+  eTokenQuotedText,
+  eTokenTagStart,       /* "<"            */
+  eTokenTagEnd,         /* "</"           */
+  eTokenCloseTag,       /* ">"            */
+  eTokenEquals,         /* "="            */
+  eTokenDeclaration,    /* "<?"           */
+  eTokenShortHandClose, /* "/>"           */
+  eTokenClear,
+  eTokenError
 } XMLTokenType;
 
 // Main structure used for parsing XML
-typedef struct XML
-{
-    XMLCSTR                lpXML;
-    XMLCSTR                lpszText;
-    int                    nIndex,nIndexMissigEndTag;
-    enum XMLError          error;
-    XMLCSTR                lpEndTag;
-    int                    cbEndTag;
-    XMLCSTR                lpNewElement;
-    int                    cbNewElement;
-    int                    nFirst;
+typedef struct XML {
+  XMLCSTR lpXML;
+  XMLCSTR lpszText;
+  int nIndex, nIndexMissigEndTag;
+  enum XMLError error;
+  XMLCSTR lpEndTag;
+  int cbEndTag;
+  XMLCSTR lpNewElement;
+  int cbNewElement;
+  int nFirst;
 } XML;
 
-typedef struct
-{
-    ALLXMLClearTag *pClr;
-    XMLCSTR     pStr;
+typedef struct {
+  ALLXMLClearTag *pClr;
+  XMLCSTR pStr;
 } NextToken;
 
 // Enumeration used when parsing attributes
-typedef enum Attrib
-{
-    eAttribName = 0,
-    eAttribEquals,
-    eAttribValue
-} Attrib;
+typedef enum Attrib { eAttribName = 0, eAttribEquals, eAttribValue } Attrib;
 
 // Enumeration used when parsing elements to dictate whether we are currently
 // inside a tag
-typedef enum Status
-{
-    eInsideTag = 0,
-    eOutsideTag
-} Status;
+typedef enum Status { eInsideTag = 0, eOutsideTag } Status;
 
-XMLError XMLNode::writeToFile(XMLCSTR filename, const char *encoding, char nFormat) const
-{
-    if (!d) return eXMLErrorNone;
-    FILE *f=xfopen(filename,_CXML("wb"));
-    if (!f) return eXMLErrorCannotOpenWriteFile;
+XMLError XMLNode::writeToFile(XMLCSTR filename, const char *encoding,
+                              char nFormat) const {
+  if (!d) return eXMLErrorNone;
+  FILE *f = xfopen(filename, _CXML("wb"));
+  if (!f) return eXMLErrorCannotOpenWriteFile;
 #ifdef _XMLWIDECHAR
-    unsigned char h[2]={ 0xFF, 0xFE };
-    if (!fwrite(h,2,1,f)) return eXMLErrorCannotWriteFile;
-    if ((!isDeclaration())&&((d->lpszName)||(!getChildNode().isDeclaration())))
-    {
-        if (!fwrite(L"<?xml version=\"1.0\" encoding=\"utf-16\"?>\n",sizeof(wchar_t)*40,1,f))
-            return eXMLErrorCannotWriteFile;
-    }
+  unsigned char h[2] = {0xFF, 0xFE};
+  if (!fwrite(h, 2, 1, f)) return eXMLErrorCannotWriteFile;
+  if ((!isDeclaration()) &&
+      ((d->lpszName) || (!getChildNode().isDeclaration()))) {
+    if (!fwrite(L"<?xml version=\"1.0\" encoding=\"utf-16\"?>\n",
+                sizeof(wchar_t) * 40, 1, f))
+      return eXMLErrorCannotWriteFile;
+  }
 #else
-    if ((!isDeclaration())&&((d->lpszName)||(!getChildNode().isDeclaration())))
-    {
-        if (characterEncoding==char_encoding_UTF8)
-        {
-            // header so that windows recognize the file as UTF-8:
-            unsigned char h[3]={0xEF,0xBB,0xBF}; if (!fwrite(h,3,1,f)) return eXMLErrorCannotWriteFile;
-            encoding="utf-8";
-        } else if (characterEncoding==char_encoding_ShiftJIS) encoding="SHIFT-JIS";
+  if ((!isDeclaration()) &&
+      ((d->lpszName) || (!getChildNode().isDeclaration()))) {
+    if (characterEncoding == char_encoding_UTF8) {
+      // header so that windows recognize the file as UTF-8:
+      unsigned char h[3] = {0xEF, 0xBB, 0xBF};
+      if (!fwrite(h, 3, 1, f)) return eXMLErrorCannotWriteFile;
+      encoding = "utf-8";
+    } else if (characterEncoding == char_encoding_ShiftJIS)
+      encoding = "SHIFT-JIS";
 
-        if (!encoding) encoding="ISO-8859-1";
-        if (fprintf(f,"<?xml version=\"1.0\" encoding=\"%s\"?>\n",encoding)<0) return eXMLErrorCannotWriteFile;
-    } else
-    {
-        if (characterEncoding==char_encoding_UTF8)
-        {
-            unsigned char h[3]={0xEF,0xBB,0xBF}; if (!fwrite(h,3,1,f)) return eXMLErrorCannotWriteFile;
-        }
+    if (!encoding) encoding = "ISO-8859-1";
+    if (fprintf(f, "<?xml version=\"1.0\" encoding=\"%s\"?>\n", encoding) < 0)
+      return eXMLErrorCannotWriteFile;
+  } else {
+    if (characterEncoding == char_encoding_UTF8) {
+      unsigned char h[3] = {0xEF, 0xBB, 0xBF};
+      if (!fwrite(h, 3, 1, f)) return eXMLErrorCannotWriteFile;
     }
+  }
 #endif
-    int i;
-    XMLSTR t=createXMLString(nFormat,&i);
-    if (!fwrite(t,sizeof(XMLCHAR)*i,1,f)) return eXMLErrorCannotWriteFile;
-    if (fclose(f)!=0) return eXMLErrorCannotWriteFile;
-    free(t);
-    return eXMLErrorNone;
+  int i;
+  XMLSTR t = createXMLString(nFormat, &i);
+  if (!fwrite(t, sizeof(XMLCHAR) * i, 1, f)) return eXMLErrorCannotWriteFile;
+  if (fclose(f) != 0) return eXMLErrorCannotWriteFile;
+  free(t);
+  return eXMLErrorNone;
 }
 
 // Duplicate a given string.
-XMLSTR stringDup(XMLCSTR lpszData, int cbData)
-{
-    if (lpszData==NULL) return NULL;
+XMLSTR stringDup(XMLCSTR lpszData, int cbData) {
+  if (lpszData == NULL) return NULL;
 
-    XMLSTR lpszNew;
-    if (cbData==-1) cbData=(int)xstrlen(lpszData);
-    lpszNew = (XMLSTR)malloc((cbData+1) * sizeof(XMLCHAR));
-    if (lpszNew)
-    {
-        memcpy(lpszNew, lpszData, (cbData) * sizeof(XMLCHAR));
-        lpszNew[cbData] = (XMLCHAR)NULL;
-    }
-    return lpszNew;
+  XMLSTR lpszNew;
+  if (cbData == -1) cbData = (int)xstrlen(lpszData);
+  lpszNew = (XMLSTR)malloc((cbData + 1) * sizeof(XMLCHAR));
+  if (lpszNew) {
+    memcpy(lpszNew, lpszData, (cbData) * sizeof(XMLCHAR));
+    lpszNew[cbData] = (XMLCHAR)NULL;
+  }
+  return lpszNew;
 }
 
-XMLSTR ToXMLStringTool::toXMLUnSafe(XMLSTR dest,XMLCSTR source)
-{
-    XMLSTR dd=dest;
-    XMLCHAR ch;
-    XMLCharacterEntity *entity;
-    while ((ch=*source))
-    {
-        entity=XMLEntities;
-        do
-        {
-            if (ch==entity->c) {xstrcpy(dest,entity->s); dest+=entity->l; source++; goto out_of_loop1; }
-            entity++;
-        } while(entity->s);
+XMLSTR ToXMLStringTool::toXMLUnSafe(XMLSTR dest, XMLCSTR source) {
+  XMLSTR dd = dest;
+  XMLCHAR ch;
+  XMLCharacterEntity *entity;
+  while ((ch = *source)) {
+    entity = XMLEntities;
+    do {
+      if (ch == entity->c) {
+        xstrcpy(dest, entity->s);
+        dest += entity->l;
+        source++;
+        goto out_of_loop1;
+      }
+      entity++;
+    } while (entity->s);
 #ifdef _XMLWIDECHAR
-        *(dest++)=*(source++);
+    *(dest++) = *(source++);
 #else
-        switch(XML_ByteTable[(unsigned char)ch])
-        {
-        case 4: *(dest++)=*(source++);
-        case 3: *(dest++)=*(source++);
-        case 2: *(dest++)=*(source++);
-        case 1: *(dest++)=*(source++);
-        }
-#endif
-out_of_loop1:
-        ;
+    switch (XML_ByteTable[(unsigned char)ch]) {
+      case 4:
+        *(dest++) = *(source++);
+      case 3:
+        *(dest++) = *(source++);
+      case 2:
+        *(dest++) = *(source++);
+      case 1:
+        *(dest++) = *(source++);
     }
-    *dest=0;
-    return dd;
+#endif
+  out_of_loop1:;
+  }
+  *dest = 0;
+  return dd;
 }
 
 // private (used while rendering):
-int ToXMLStringTool::lengthXMLString(XMLCSTR source)
-{
-    int r=0;
-    XMLCharacterEntity *entity;
-    XMLCHAR ch;
-    while ((ch=*source))
-    {
-        entity=XMLEntities;
-        do
-        {
-            if (ch==entity->c) { r+=entity->l; source++; goto out_of_loop1; }
-            entity++;
-        } while(entity->s);
+int ToXMLStringTool::lengthXMLString(XMLCSTR source) {
+  int r = 0;
+  XMLCharacterEntity *entity;
+  XMLCHAR ch;
+  while ((ch = *source)) {
+    entity = XMLEntities;
+    do {
+      if (ch == entity->c) {
+        r += entity->l;
+        source++;
+        goto out_of_loop1;
+      }
+      entity++;
+    } while (entity->s);
 #ifdef _XMLWIDECHAR
-        r++; source++;
+    r++;
+    source++;
 #else
-        ch=XML_ByteTable[(unsigned char)ch]; r+=ch; source+=ch;
+    ch = XML_ByteTable[(unsigned char)ch];
+    r += ch;
+    source += ch;
 #endif
-out_of_loop1:
-        ;
-    }
-    return r;
+  out_of_loop1:;
+  }
+  return r;
 }
 
-ToXMLStringTool::~ToXMLStringTool(){ freeBuffer(); }
-void ToXMLStringTool::freeBuffer(){ if (buf) free(buf); buf=NULL; buflen=0; }
-XMLSTR ToXMLStringTool::toXML(XMLCSTR source)
-{
-    int l=lengthXMLString(source)+1;
-    if (l>buflen) { buflen=l; buf=(XMLSTR)realloc(buf,l*sizeof(XMLCHAR)); }
-    return toXMLUnSafe(buf,source);
+ToXMLStringTool::~ToXMLStringTool() { freeBuffer(); }
+void ToXMLStringTool::freeBuffer() {
+  if (buf) free(buf);
+  buf = NULL;
+  buflen = 0;
+}
+XMLSTR ToXMLStringTool::toXML(XMLCSTR source) {
+  int l = lengthXMLString(source) + 1;
+  if (l > buflen) {
+    buflen = l;
+    buf = (XMLSTR)realloc(buf, l * sizeof(XMLCHAR));
+  }
+  return toXMLUnSafe(buf, source);
 }
 
 // private:
-XMLSTR fromXMLString(XMLCSTR s, int lo, XML *pXML)
-{
-    // This function is the opposite of the function "toXMLString". It decodes the escape
-    // sequences &amp;, &quot;, &apos;, &lt;, &gt; and replace them by the characters
-    // &,",',<,>. This function is used internally by the XML Parser. All the calls to
-    // the XML library will always gives you back "decoded" strings.
-    //
-    // in: string (s) and length (lo) of string
-    // out:  new allocated string converted from xml
-    if (!s) return NULL;
+XMLSTR fromXMLString(XMLCSTR s, int lo, XML *pXML) {
+  // This function is the opposite of the function "toXMLString". It decodes the
+  // escape
+  // sequences &amp;, &quot;, &apos;, &lt;, &gt; and replace them by the
+  // characters
+  // &,",',<,>. This function is used internally by the XML Parser. All the
+  // calls to
+  // the XML library will always gives you back "decoded" strings.
+  //
+  // in: string (s) and length (lo) of string
+  // out:  new allocated string converted from xml
+  if (!s) return NULL;
 
-    int ll=0,j;
-    XMLSTR d;
-    XMLCSTR ss=s;
-    XMLCharacterEntity *entity;
-    while ((lo>0)&&(*s))
-    {
-        if (*s==_CXML('&'))
-        {
-            if ((lo>2)&&(s[1]==_CXML('#')))
-            {
-                s+=2; lo-=2;
-                if ((*s==_CXML('X'))||(*s==_CXML('x'))) { s++; lo--; }
-                while ((*s)&&(*s!=_CXML(';'))&&((lo--)>0)) s++;
-                if (*s!=_CXML(';'))
-                {
-                    pXML->error=eXMLErrorUnknownCharacterEntity;
-                    return NULL;
-                }
-                s++; lo--;
-            } else
-            {
-                entity=XMLEntities;
-                do
-                {
-                    if ((lo>=entity->l)&&(xstrnicmp(s,entity->s,entity->l)==0)) { s+=entity->l; lo-=entity->l; break; }
-                    entity++;
-                } while(entity->s);
-                if (!entity->s)
-                {
-                    pXML->error=eXMLErrorUnknownCharacterEntity;
-                    return NULL;
-                }
-            }
-        } else
-        {
-#ifdef _XMLWIDECHAR
-            s++; lo--;
-#else
-            j=XML_ByteTable[(unsigned char)*s]; s+=j; lo-=j; ll+=j-1;
-#endif
+  int ll = 0, j;
+  XMLSTR d;
+  XMLCSTR ss = s;
+  XMLCharacterEntity *entity;
+  while ((lo > 0) && (*s)) {
+    if (*s == _CXML('&')) {
+      if ((lo > 2) && (s[1] == _CXML('#'))) {
+        s += 2;
+        lo -= 2;
+        if ((*s == _CXML('X')) || (*s == _CXML('x'))) {
+          s++;
+          lo--;
         }
-        ll++;
+        while ((*s) && (*s != _CXML(';')) && ((lo--) > 0)) s++;
+        if (*s != _CXML(';')) {
+          pXML->error = eXMLErrorUnknownCharacterEntity;
+          return NULL;
+        }
+        s++;
+        lo--;
+      } else {
+        entity = XMLEntities;
+        do {
+          if ((lo >= entity->l) && (xstrnicmp(s, entity->s, entity->l) == 0)) {
+            s += entity->l;
+            lo -= entity->l;
+            break;
+          }
+          entity++;
+        } while (entity->s);
+        if (!entity->s) {
+          pXML->error = eXMLErrorUnknownCharacterEntity;
+          return NULL;
+        }
+      }
+    } else {
+#ifdef _XMLWIDECHAR
+      s++;
+      lo--;
+#else
+      j = XML_ByteTable[(unsigned char)*s];
+      s += j;
+      lo -= j;
+      ll += j - 1;
+#endif
     }
+    ll++;
+  }
 
-    d=(XMLSTR)malloc((ll+1)*sizeof(XMLCHAR));
-    s=d;
-    while (ll-->0)
-    {
-        if (*ss==_CXML('&'))
-        {
-            if (ss[1]==_CXML('#'))
-            {
-                ss+=2; j=0;
-                if ((*ss==_CXML('X'))||(*ss==_CXML('x')))
-                {
-                    ss++;
-                    while (*ss!=_CXML(';'))
-                    {
-                        if ((*ss>=_CXML('0'))&&(*ss<=_CXML('9'))) j=(j<<4)+*ss-_CXML('0');
-                        else if ((*ss>=_CXML('A'))&&(*ss<=_CXML('F'))) j=(j<<4)+*ss-_CXML('A')+10;
-                        else if ((*ss>=_CXML('a'))&&(*ss<=_CXML('f'))) j=(j<<4)+*ss-_CXML('a')+10;
-                        else { free((void*)s); pXML->error=eXMLErrorUnknownCharacterEntity;return NULL;}
-                        ss++;
-                    }
-                } else
-                {
-                    while (*ss!=_CXML(';'))
-                    {
-                        if ((*ss>=_CXML('0'))&&(*ss<=_CXML('9'))) j=(j*10)+*ss-_CXML('0');
-                        else { free((void*)s); pXML->error=eXMLErrorUnknownCharacterEntity;return NULL;}
-                        ss++;
-                    }
-                }
+  d = (XMLSTR)malloc((ll + 1) * sizeof(XMLCHAR));
+  s = d;
+  while (ll-- > 0) {
+    if (*ss == _CXML('&')) {
+      if (ss[1] == _CXML('#')) {
+        ss += 2;
+        j = 0;
+        if ((*ss == _CXML('X')) || (*ss == _CXML('x'))) {
+          ss++;
+          while (*ss != _CXML(';')) {
+            if ((*ss >= _CXML('0')) && (*ss <= _CXML('9')))
+              j = (j << 4) + *ss - _CXML('0');
+            else if ((*ss >= _CXML('A')) && (*ss <= _CXML('F')))
+              j = (j << 4) + *ss - _CXML('A') + 10;
+            else if ((*ss >= _CXML('a')) && (*ss <= _CXML('f')))
+              j = (j << 4) + *ss - _CXML('a') + 10;
+            else {
+              free((void *)s);
+              pXML->error = eXMLErrorUnknownCharacterEntity;
+              return NULL;
+            }
+            ss++;
+          }
+        } else {
+          while (*ss != _CXML(';')) {
+            if ((*ss >= _CXML('0')) && (*ss <= _CXML('9')))
+              j = (j * 10) + *ss - _CXML('0');
+            else {
+              free((void *)s);
+              pXML->error = eXMLErrorUnknownCharacterEntity;
+              return NULL;
+            }
+            ss++;
+          }
+        }
 #ifndef _XMLWIDECHAR
-                if (j>255) { free((void*)s); pXML->error=eXMLErrorCharacterCodeAbove255;return NULL;}
-#endif
-                (*d++)=(XMLCHAR)j; ss++;
-            } else
-            {
-                entity=XMLEntities;
-                do
-                {
-                    if (xstrnicmp(ss,entity->s,entity->l)==0) { *(d++)=entity->c; ss+=entity->l; break; }
-                    entity++;
-                } while(entity->s);
-            }
-        } else
-        {
-#ifdef _XMLWIDECHAR
-            *(d++)=*(ss++);
-#else
-            switch(XML_ByteTable[(unsigned char)*ss])
-            {
-            case 4: *(d++)=*(ss++); ll--;
-            case 3: *(d++)=*(ss++); ll--;
-            case 2: *(d++)=*(ss++); ll--;
-            case 1: *(d++)=*(ss++);
-            }
-#endif
+        if (j > 255) {
+          free((void *)s);
+          pXML->error = eXMLErrorCharacterCodeAbove255;
+          return NULL;
         }
+#endif
+        (*d++) = (XMLCHAR)j;
+        ss++;
+      } else {
+        entity = XMLEntities;
+        do {
+          if (xstrnicmp(ss, entity->s, entity->l) == 0) {
+            *(d++) = entity->c;
+            ss += entity->l;
+            break;
+          }
+          entity++;
+        } while (entity->s);
+      }
+    } else {
+#ifdef _XMLWIDECHAR
+      *(d++) = *(ss++);
+#else
+      switch (XML_ByteTable[(unsigned char)*ss]) {
+        case 4:
+          *(d++) = *(ss++);
+          ll--;
+        case 3:
+          *(d++) = *(ss++);
+          ll--;
+        case 2:
+          *(d++) = *(ss++);
+          ll--;
+        case 1:
+          *(d++) = *(ss++);
+      }
+#endif
     }
-    *d=0;
-    return (XMLSTR)s;
+  }
+  *d = 0;
+  return (XMLSTR)s;
 }
 
-#define XML_isSPACECHAR(ch) ((ch==_CXML('\n'))||(ch==_CXML(' '))||(ch== _CXML('\t'))||(ch==_CXML('\r')))
+#define XML_isSPACECHAR(ch)                                            \
+  ((ch == _CXML('\n')) || (ch == _CXML(' ')) || (ch == _CXML('\t')) || \
+   (ch == _CXML('\r')))
 
 // private:
 char myTagCompare(XMLCSTR cclose, XMLCSTR copen)
@@ -844,1233 +1100,1259 @@ char myTagCompare(XMLCSTR cclose, XMLCSTR copen)
 // return 0 if equals
 // return 1 if different
 {
-    if (!cclose) return 1;
-    int l=(int)xstrlen(cclose);
-    if (xstrnicmp(cclose, copen, l)!=0) return 1;
-    const XMLCHAR c=copen[l];
-    if (XML_isSPACECHAR(c)||
-        (c==_CXML('/' ))||
-        (c==_CXML('<' ))||
-        (c==_CXML('>' ))||
-        (c==_CXML('=' ))) return 0;
-    return 1;
+  if (!cclose) return 1;
+  int l = (int)xstrlen(cclose);
+  if (xstrnicmp(cclose, copen, l) != 0) return 1;
+  const XMLCHAR c = copen[l];
+  if (XML_isSPACECHAR(c) || (c == _CXML('/')) || (c == _CXML('<')) ||
+      (c == _CXML('>')) || (c == _CXML('=')))
+    return 0;
+  return 1;
 }
 
 // Obtain the next character from the string.
-static inline XMLCHAR getNextChar(XML *pXML)
-{
-    XMLCHAR ch = pXML->lpXML[pXML->nIndex];
+static inline XMLCHAR getNextChar(XML *pXML) {
+  XMLCHAR ch = pXML->lpXML[pXML->nIndex];
 #ifdef _XMLWIDECHAR
-    if (ch!=0) pXML->nIndex++;
+  if (ch != 0) pXML->nIndex++;
 #else
-    pXML->nIndex+=XML_ByteTable[(unsigned char)ch];
+  pXML->nIndex += XML_ByteTable[(unsigned char)ch];
 #endif
-    return ch;
+  return ch;
 }
 
 // Find the next token in a string.
 // pcbToken contains the number of characters that have been read.
-static NextToken GetNextToken(XML *pXML, int *pcbToken, enum XMLTokenTypeTag *pType)
-{
-    NextToken        result;
-    XMLCHAR            ch;
-    XMLCHAR            chTemp;
-    int              indexStart,nFoundMatch,nIsText=FALSE;
-    result.pClr=NULL; // prevent warning
+static NextToken GetNextToken(XML *pXML, int *pcbToken,
+                              enum XMLTokenTypeTag *pType) {
+  NextToken result;
+  XMLCHAR ch;
+  XMLCHAR chTemp;
+  int indexStart, nFoundMatch, nIsText = FALSE;
+  result.pClr = NULL;  // prevent warning
 
-    // Find next non-white space character
-    do { indexStart=pXML->nIndex; ch=getNextChar(pXML); } while XML_isSPACECHAR(ch);
+  // Find next non-white space character
+  do {
+    indexStart = pXML->nIndex;
+    ch = getNextChar(pXML);
+  } while XML_isSPACECHAR(ch);
 
-    if (ch)
-    {
-        // Cache the current string pointer
-        result.pStr = &pXML->lpXML[indexStart];
+  if (ch) {
+    // Cache the current string pointer
+    result.pStr = &pXML->lpXML[indexStart];
 
-        // First check whether the token is in the clear tag list (meaning it
-        // does not need formatting).
-        ALLXMLClearTag *ctag=XMLClearTags;
-        do
-        {
-            if (xstrncmp(ctag->lpszOpen, result.pStr, ctag->openTagLen)==0)
-            {
-                result.pClr=ctag;
-                pXML->nIndex+=ctag->openTagLen-1;
-                *pType=eTokenClear;
-                return result;
-            }
-            ctag++;
-        } while(ctag->lpszOpen);
+    // First check whether the token is in the clear tag list (meaning it
+    // does not need formatting).
+    ALLXMLClearTag *ctag = XMLClearTags;
+    do {
+      if (xstrncmp(ctag->lpszOpen, result.pStr, ctag->openTagLen) == 0) {
+        result.pClr = ctag;
+        pXML->nIndex += ctag->openTagLen - 1;
+        *pType = eTokenClear;
+        return result;
+      }
+      ctag++;
+    } while (ctag->lpszOpen);
 
-        // If we didn't find a clear tag then check for standard tokens
-        switch(ch)
-        {
-        // Check for quotes
-        case _CXML('\''):
-        case _CXML('\"'):
-            // Type of token
-            *pType = eTokenQuotedText;
-            chTemp = ch;
+    // If we didn't find a clear tag then check for standard tokens
+    switch (ch) {
+      // Check for quotes
+      case _CXML('\''):
+      case _CXML('\"'):
+        // Type of token
+        *pType = eTokenQuotedText;
+        chTemp = ch;
 
-            // Set the size
-            nFoundMatch = FALSE;
+        // Set the size
+        nFoundMatch = FALSE;
 
-            // Search through the string to find a matching quote
-            while((ch = getNextChar(pXML)))
-            {
-                if (ch==chTemp) { nFoundMatch = TRUE; break; }
-                if (ch==_CXML('<')) break;
-            }
-
-            // If we failed to find a matching quote
-            if (nFoundMatch == FALSE)
-            {
-                pXML->nIndex=indexStart+1;
-                nIsText=TRUE;
-                break;
-            }
-
-//  4.02.2002
-//            if (FindNonWhiteSpace(pXML)) pXML->nIndex--;
-
+        // Search through the string to find a matching quote
+        while ((ch = getNextChar(pXML))) {
+          if (ch == chTemp) {
+            nFoundMatch = TRUE;
             break;
-
-        // Equals (used with attribute values)
-        case _CXML('='):
-            *pType = eTokenEquals;
-            break;
-
-        // Close tag
-        case _CXML('>'):
-            *pType = eTokenCloseTag;
-            break;
-
-        // Check for tag start and tag end
-        case _CXML('<'):
-
-            // Peek at the next character to see if we have an end tag '</',
-            // or an xml declaration '<?'
-            chTemp = pXML->lpXML[pXML->nIndex];
-
-            // If we have a tag end...
-            if (chTemp == _CXML('/'))
-            {
-                // Set the type and ensure we point at the next character
-                getNextChar(pXML);
-                *pType = eTokenTagEnd;
-            }
-
-            // If we have an XML declaration tag
-            else if (chTemp == _CXML('?'))
-            {
-
-                // Set the type and ensure we point at the next character
-                getNextChar(pXML);
-                *pType = eTokenDeclaration;
-            }
-
-            // Otherwise we must have a start tag
-            else
-            {
-                *pType = eTokenTagStart;
-            }
-            break;
-
-        // Check to see if we have a short hand type end tag ('/>').
-        case _CXML('/'):
-
-            // Peek at the next character to see if we have a short end tag '/>'
-            chTemp = pXML->lpXML[pXML->nIndex];
-
-            // If we have a short hand end tag...
-            if (chTemp == _CXML('>'))
-            {
-                // Set the type and ensure we point at the next character
-                getNextChar(pXML);
-                *pType = eTokenShortHandClose;
-                break;
-            }
-
-            // If we haven't found a short hand closing tag then drop into the
-            // text process
-
-        // Other characters
-        default:
-            nIsText = TRUE;
+          }
+          if (ch == _CXML('<')) break;
         }
 
-        // If this is a TEXT node
-        if (nIsText)
-        {
-            // Indicate we are dealing with text
-            *pType = eTokenText;
-            while((ch = getNextChar(pXML)))
-            {
-                if XML_isSPACECHAR(ch)
-                {
-                    indexStart++; break;
-
-                } else if (ch==_CXML('/'))
-                {
-                    // If we find a slash then this maybe text or a short hand end tag
-                    // Peek at the next character to see it we have short hand end tag
-                    ch=pXML->lpXML[pXML->nIndex];
-                    // If we found a short hand end tag then we need to exit the loop
-                    if (ch==_CXML('>')) { pXML->nIndex--; break; }
-
-                } else if ((ch==_CXML('<'))||(ch==_CXML('>'))||(ch==_CXML('=')))
-                {
-                    pXML->nIndex--; break;
-                }
-            }
+        // If we failed to find a matching quote
+        if (nFoundMatch == FALSE) {
+          pXML->nIndex = indexStart + 1;
+          nIsText = TRUE;
+          break;
         }
-        *pcbToken = pXML->nIndex-indexStart;
-    } else
-    {
-        // If we failed to obtain a valid character
-        *pcbToken = 0;
-        *pType = eTokenError;
-        result.pStr=NULL;
+
+        //  4.02.2002
+        //            if (FindNonWhiteSpace(pXML)) pXML->nIndex--;
+
+        break;
+
+      // Equals (used with attribute values)
+      case _CXML('='):
+        *pType = eTokenEquals;
+        break;
+
+      // Close tag
+      case _CXML('>'):
+        *pType = eTokenCloseTag;
+        break;
+
+      // Check for tag start and tag end
+      case _CXML('<'):
+
+        // Peek at the next character to see if we have an end tag '</',
+        // or an xml declaration '<?'
+        chTemp = pXML->lpXML[pXML->nIndex];
+
+        // If we have a tag end...
+        if (chTemp == _CXML('/')) {
+          // Set the type and ensure we point at the next character
+          getNextChar(pXML);
+          *pType = eTokenTagEnd;
+        }
+
+        // If we have an XML declaration tag
+        else if (chTemp == _CXML('?')) {
+          // Set the type and ensure we point at the next character
+          getNextChar(pXML);
+          *pType = eTokenDeclaration;
+        }
+
+        // Otherwise we must have a start tag
+        else {
+          *pType = eTokenTagStart;
+        }
+        break;
+
+      // Check to see if we have a short hand type end tag ('/>').
+      case _CXML('/'):
+
+        // Peek at the next character to see if we have a short end tag '/>'
+        chTemp = pXML->lpXML[pXML->nIndex];
+
+        // If we have a short hand end tag...
+        if (chTemp == _CXML('>')) {
+          // Set the type and ensure we point at the next character
+          getNextChar(pXML);
+          *pType = eTokenShortHandClose;
+          break;
+        }
+
+      // If we haven't found a short hand closing tag then drop into the
+      // text process
+
+      // Other characters
+      default:
+        nIsText = TRUE;
     }
 
-    return result;
+    // If this is a TEXT node
+    if (nIsText) {
+      // Indicate we are dealing with text
+      *pType = eTokenText;
+      while ((ch = getNextChar(pXML))) {
+        if
+          XML_isSPACECHAR(ch) {
+            indexStart++;
+            break;
+          }
+        else if (ch == _CXML('/')) {
+          // If we find a slash then this maybe text or a short hand end tag
+          // Peek at the next character to see it we have short hand end tag
+          ch = pXML->lpXML[pXML->nIndex];
+          // If we found a short hand end tag then we need to exit the loop
+          if (ch == _CXML('>')) {
+            pXML->nIndex--;
+            break;
+          }
+
+        } else if ((ch == _CXML('<')) || (ch == _CXML('>')) ||
+                   (ch == _CXML('='))) {
+          pXML->nIndex--;
+          break;
+        }
+      }
+    }
+    *pcbToken = pXML->nIndex - indexStart;
+  } else {
+    // If we failed to obtain a valid character
+    *pcbToken = 0;
+    *pType = eTokenError;
+    result.pStr = NULL;
+  }
+
+  return result;
 }
 
-XMLCSTR XMLNode::updateName_WOSD(XMLSTR lpszName)
-{
-    if (!d) { free(lpszName); return NULL; }
-    if (d->lpszName&&(lpszName!=d->lpszName)) free((void*)d->lpszName);
-    d->lpszName=lpszName;
-    return lpszName;
+XMLCSTR XMLNode::updateName_WOSD(XMLSTR lpszName) {
+  if (!d) {
+    free(lpszName);
+    return NULL;
+  }
+  if (d->lpszName && (lpszName != d->lpszName)) free((void *)d->lpszName);
+  d->lpszName = lpszName;
+  return lpszName;
 }
 
 // private:
-XMLNode::XMLNode(struct XMLNodeDataTag *p){ d=p; (p->ref_count)++; }
-XMLNode::XMLNode(XMLNodeData *pParent, XMLSTR lpszName, char isDeclaration)
-{
-    d=(XMLNodeData*)malloc(sizeof(XMLNodeData));
-    d->ref_count=1;
+XMLNode::XMLNode(struct XMLNodeDataTag *p) {
+  d = p;
+  (p->ref_count)++;
+}
+XMLNode::XMLNode(XMLNodeData *pParent, XMLSTR lpszName, char isDeclaration) {
+  d = (XMLNodeData *)malloc(sizeof(XMLNodeData));
+  d->ref_count = 1;
 
-    d->lpszName=NULL;
-    d->nChild= 0;
-    d->nText = 0;
-    d->nClear = 0;
-    d->nAttribute = 0;
+  d->lpszName = NULL;
+  d->nChild = 0;
+  d->nText = 0;
+  d->nClear = 0;
+  d->nAttribute = 0;
 
-    d->isDeclaration = isDeclaration;
+  d->isDeclaration = isDeclaration;
 
-    d->pParent = pParent;
-    d->pChild= NULL;
-    d->pText= NULL;
-    d->pClear= NULL;
-    d->pAttribute= NULL;
-    d->pOrder= NULL;
+  d->pParent = pParent;
+  d->pChild = NULL;
+  d->pText = NULL;
+  d->pClear = NULL;
+  d->pAttribute = NULL;
+  d->pOrder = NULL;
 
-    updateName_WOSD(lpszName);
+  updateName_WOSD(lpszName);
 }
 
-XMLNode XMLNode::createXMLTopNode_WOSD(XMLSTR lpszName, char isDeclaration) { return XMLNode(NULL,lpszName,isDeclaration); }
-XMLNode XMLNode::createXMLTopNode(XMLCSTR lpszName, char isDeclaration) { return XMLNode(NULL,stringDup(lpszName),isDeclaration); }
+XMLNode XMLNode::createXMLTopNode_WOSD(XMLSTR lpszName, char isDeclaration) {
+  return XMLNode(NULL, lpszName, isDeclaration);
+}
+XMLNode XMLNode::createXMLTopNode(XMLCSTR lpszName, char isDeclaration) {
+  return XMLNode(NULL, stringDup(lpszName), isDeclaration);
+}
 
 #define MEMORYINCREASE 50
 
-static inline void myFree(void *p) { if (p) free(p); }
-static inline void *myRealloc(void *p, int newsize, int memInc, int sizeofElem)
-{
-    if (p==NULL) { if (memInc) return malloc(memInc*sizeofElem); return malloc(sizeofElem); }
-    if ((memInc==0)||((newsize%memInc)==0)) p=realloc(p,(newsize+memInc)*sizeofElem);
-//    if (!p)
-//    {
-//        printf("XMLParser Error: Not enough memory! Aborting...\n"); exit(220);
-//    }
-    return p;
+static inline void myFree(void *p) {
+  if (p) free(p);
+}
+static inline void *myRealloc(void *p, int newsize, int memInc,
+                              int sizeofElem) {
+  if (p == NULL) {
+    if (memInc) return malloc(memInc * sizeofElem);
+    return malloc(sizeofElem);
+  }
+  if ((memInc == 0) || ((newsize % memInc) == 0))
+    p = realloc(p, (newsize + memInc) * sizeofElem);
+  //    if (!p)
+  //    {
+  //        printf("XMLParser Error: Not enough memory! Aborting...\n");
+  //        exit(220);
+  //    }
+  return p;
 }
 
 // private:
-XMLElementPosition XMLNode::findPosition(XMLNodeData *d, int index, XMLElementType xxtype)
-{
-    if (index<0) return -1;
-    int i=0,j=(int)((index<<2)+xxtype),*o=d->pOrder; while (o[i]!=j) i++; return i;
+XMLElementPosition XMLNode::findPosition(XMLNodeData *d, int index,
+                                         XMLElementType xxtype) {
+  if (index < 0) return -1;
+  int i = 0, j = (int)((index << 2) + xxtype), *o = d->pOrder;
+  while (o[i] != j) i++;
+  return i;
 }
 
 // private:
 // update "order" information when deleting a content of a XMLNode
-int XMLNode::removeOrderElement(XMLNodeData *d, XMLElementType t, int index)
-{
-    int n=d->nChild+d->nText+d->nClear, *o=d->pOrder,i=findPosition(d,index,t);
-    memmove(o+i, o+i+1, (n-i)*sizeof(int));
-    for (;i<n;i++)
-        if ((o[i]&3)==(int)t) o[i]-=4;
-    // We should normally do:
-    // d->pOrder=(int)realloc(d->pOrder,n*sizeof(int));
-    // but we skip reallocation because it's too time consuming.
-    // Anyway, at the end, it will be free'd completely at once.
-    return i;
+int XMLNode::removeOrderElement(XMLNodeData *d, XMLElementType t, int index) {
+  int n = d->nChild + d->nText + d->nClear, *o = d->pOrder,
+      i = findPosition(d, index, t);
+  memmove(o + i, o + i + 1, (n - i) * sizeof(int));
+  for (; i < n; i++)
+    if ((o[i] & 3) == (int)t) o[i] -= 4;
+  // We should normally do:
+  // d->pOrder=(int)realloc(d->pOrder,n*sizeof(int));
+  // but we skip reallocation because it's too time consuming.
+  // Anyway, at the end, it will be free'd completely at once.
+  return i;
 }
 
-void *XMLNode::addToOrder(int memoryIncrease,int *_pos, int nc, void *p, int size, XMLElementType xtype)
-{
-    //  in: *_pos is the position inside d->pOrder ("-1" means "EndOf")
-    // out: *_pos is the index inside p
-    p=myRealloc(p,(nc+1),memoryIncrease,size);
-    int n=d->nChild+d->nText+d->nClear;
-    d->pOrder=(int*)myRealloc(d->pOrder,n+1,memoryIncrease*3,sizeof(int));
-    int pos=*_pos,*o=d->pOrder;
+void *XMLNode::addToOrder(int memoryIncrease, int *_pos, int nc, void *p,
+                          int size, XMLElementType xtype) {
+  //  in: *_pos is the position inside d->pOrder ("-1" means "EndOf")
+  // out: *_pos is the index inside p
+  p = myRealloc(p, (nc + 1), memoryIncrease, size);
+  int n = d->nChild + d->nText + d->nClear;
+  d->pOrder =
+      (int *)myRealloc(d->pOrder, n + 1, memoryIncrease * 3, sizeof(int));
+  int pos = *_pos, *o = d->pOrder;
 
-    if ((pos<0)||(pos>=n)) { *_pos=nc; o[n]=(int)((nc<<2)+xtype); return p; }
-
-    int i=pos;
-    memmove(o+i+1, o+i, (n-i)*sizeof(int));
-
-    while ((pos<n)&&((o[pos]&3)!=(int)xtype)) pos++;
-    if (pos==n) { *_pos=nc; o[n]=(int)((nc<<2)+xtype); return p; }
-
-    o[i]=o[pos];
-    for (i=pos+1;i<=n;i++) if ((o[i]&3)==(int)xtype) o[i]+=4;
-
-    *_pos=pos=o[pos]>>2;
-    memmove(((char*)p)+(pos+1)*size,((char*)p)+pos*size,(nc-pos)*size);
-
+  if ((pos < 0) || (pos >= n)) {
+    *_pos = nc;
+    o[n] = (int)((nc << 2) + xtype);
     return p;
+  }
+
+  int i = pos;
+  memmove(o + i + 1, o + i, (n - i) * sizeof(int));
+
+  while ((pos < n) && ((o[pos] & 3) != (int)xtype)) pos++;
+  if (pos == n) {
+    *_pos = nc;
+    o[n] = (int)((nc << 2) + xtype);
+    return p;
+  }
+
+  o[i] = o[pos];
+  for (i = pos + 1; i <= n; i++)
+    if ((o[i] & 3) == (int)xtype) o[i] += 4;
+
+  *_pos = pos = o[pos] >> 2;
+  memmove(((char *)p) + (pos + 1) * size, ((char *)p) + pos * size,
+          (nc - pos) * size);
+
+  return p;
 }
 
 // Add a child node to the given element.
-XMLNode XMLNode::addChild_priv(int memoryIncrease, XMLSTR lpszName, char isDeclaration, int pos)
-{
-    if (!lpszName) return emptyXMLNode;
-    d->pChild=(XMLNode*)addToOrder(memoryIncrease,&pos,d->nChild,d->pChild,sizeof(XMLNode),eNodeChild);
-    d->pChild[pos].d=NULL;
-    d->pChild[pos]=XMLNode(d,lpszName,isDeclaration);
-    d->nChild++;
-    return d->pChild[pos];
+XMLNode XMLNode::addChild_priv(int memoryIncrease, XMLSTR lpszName,
+                               char isDeclaration, int pos) {
+  if (!lpszName) return emptyXMLNode;
+  d->pChild = (XMLNode *)addToOrder(memoryIncrease, &pos, d->nChild, d->pChild,
+                                    sizeof(XMLNode), eNodeChild);
+  d->pChild[pos].d = NULL;
+  d->pChild[pos] = XMLNode(d, lpszName, isDeclaration);
+  d->nChild++;
+  return d->pChild[pos];
 }
 
 // Add an attribute to an element.
-XMLAttribute *XMLNode::addAttribute_priv(int memoryIncrease,XMLSTR lpszName, XMLSTR lpszValuev)
-{
-    if (!lpszName) return &emptyXMLAttribute;
-    if (!d) { myFree(lpszName); myFree(lpszValuev); return &emptyXMLAttribute; }
-    int nc=d->nAttribute;
-    d->pAttribute=(XMLAttribute*)myRealloc(d->pAttribute,(nc+1),memoryIncrease,sizeof(XMLAttribute));
-    XMLAttribute *pAttr=d->pAttribute+nc;
-    pAttr->lpszName = lpszName;
-    pAttr->lpszValue = lpszValuev;
-    d->nAttribute++;
-    return pAttr;
+XMLAttribute *XMLNode::addAttribute_priv(int memoryIncrease, XMLSTR lpszName,
+                                         XMLSTR lpszValuev) {
+  if (!lpszName) return &emptyXMLAttribute;
+  if (!d) {
+    myFree(lpszName);
+    myFree(lpszValuev);
+    return &emptyXMLAttribute;
+  }
+  int nc = d->nAttribute;
+  d->pAttribute = (XMLAttribute *)myRealloc(
+      d->pAttribute, (nc + 1), memoryIncrease, sizeof(XMLAttribute));
+  XMLAttribute *pAttr = d->pAttribute + nc;
+  pAttr->lpszName = lpszName;
+  pAttr->lpszValue = lpszValuev;
+  d->nAttribute++;
+  return pAttr;
 }
 
 // Add text to the element.
-XMLCSTR XMLNode::addText_priv(int memoryIncrease, XMLSTR lpszValue, int pos)
-{
-    if (!lpszValue) return NULL;
-    if (!d) { myFree(lpszValue); return NULL; }
-    d->pText=(XMLCSTR*)addToOrder(memoryIncrease,&pos,d->nText,d->pText,sizeof(XMLSTR),eNodeText);
-    d->pText[pos]=lpszValue;
-    d->nText++;
-    return lpszValue;
+XMLCSTR XMLNode::addText_priv(int memoryIncrease, XMLSTR lpszValue, int pos) {
+  if (!lpszValue) return NULL;
+  if (!d) {
+    myFree(lpszValue);
+    return NULL;
+  }
+  d->pText = (XMLCSTR *)addToOrder(memoryIncrease, &pos, d->nText, d->pText,
+                                   sizeof(XMLSTR), eNodeText);
+  d->pText[pos] = lpszValue;
+  d->nText++;
+  return lpszValue;
 }
 
 // Add clear (unformatted) text to the element.
-XMLClear *XMLNode::addClear_priv(int memoryIncrease, XMLSTR lpszValue, XMLCSTR lpszOpen, XMLCSTR lpszClose, int pos)
-{
-    if (!lpszValue) return &emptyXMLClear;
-    if (!d) { myFree(lpszValue); return &emptyXMLClear; }
-    d->pClear=(XMLClear *)addToOrder(memoryIncrease,&pos,d->nClear,d->pClear,sizeof(XMLClear),eNodeClear);
-    XMLClear *pNewClear=d->pClear+pos;
-    pNewClear->lpszValue = lpszValue;
-    if (!lpszOpen) lpszOpen=XMLClearTags->lpszOpen;
-    if (!lpszClose) lpszClose=XMLClearTags->lpszClose;
-    pNewClear->lpszOpenTag = lpszOpen;
-    pNewClear->lpszCloseTag = lpszClose;
-    d->nClear++;
-    return pNewClear;
+XMLClear *XMLNode::addClear_priv(int memoryIncrease, XMLSTR lpszValue,
+                                 XMLCSTR lpszOpen, XMLCSTR lpszClose, int pos) {
+  if (!lpszValue) return &emptyXMLClear;
+  if (!d) {
+    myFree(lpszValue);
+    return &emptyXMLClear;
+  }
+  d->pClear = (XMLClear *)addToOrder(memoryIncrease, &pos, d->nClear, d->pClear,
+                                     sizeof(XMLClear), eNodeClear);
+  XMLClear *pNewClear = d->pClear + pos;
+  pNewClear->lpszValue = lpszValue;
+  if (!lpszOpen) lpszOpen = XMLClearTags->lpszOpen;
+  if (!lpszClose) lpszClose = XMLClearTags->lpszClose;
+  pNewClear->lpszOpenTag = lpszOpen;
+  pNewClear->lpszCloseTag = lpszClose;
+  d->nClear++;
+  return pNewClear;
 }
 
 // private:
 // Parse a clear (unformatted) type node.
-char XMLNode::parseClearTag(void *px, void *_pClear)
-{
-    XML *pXML=(XML *)px;
-    ALLXMLClearTag pClear=*((ALLXMLClearTag*)_pClear);
-    int cbTemp=0;
-    XMLCSTR lpszTemp=NULL;
-    XMLCSTR lpXML=&pXML->lpXML[pXML->nIndex];
-    static XMLCSTR docTypeEnd=_CXML("]>");
+char XMLNode::parseClearTag(void *px, void *_pClear) {
+  XML *pXML = (XML *)px;
+  ALLXMLClearTag pClear = *((ALLXMLClearTag *)_pClear);
+  int cbTemp = 0;
+  XMLCSTR lpszTemp = NULL;
+  XMLCSTR lpXML = &pXML->lpXML[pXML->nIndex];
+  static XMLCSTR docTypeEnd = _CXML("]>");
 
-    // Find the closing tag
-    // Seems the <!DOCTYPE need a better treatment so lets handle it
-    if (pClear.lpszOpen==XMLClearTags[1].lpszOpen)
-    {
-        XMLCSTR pCh=lpXML;
-        while (*pCh)
-        {
-            if (*pCh==_CXML('<')) { pClear.lpszClose=docTypeEnd; lpszTemp=xstrstr(lpXML,docTypeEnd); break; }
-            else if (*pCh==_CXML('>')) { lpszTemp=pCh; break; }
+  // Find the closing tag
+  // Seems the <!DOCTYPE need a better treatment so lets handle it
+  if (pClear.lpszOpen == XMLClearTags[1].lpszOpen) {
+    XMLCSTR pCh = lpXML;
+    while (*pCh) {
+      if (*pCh == _CXML('<')) {
+        pClear.lpszClose = docTypeEnd;
+        lpszTemp = xstrstr(lpXML, docTypeEnd);
+        break;
+      } else if (*pCh == _CXML('>')) {
+        lpszTemp = pCh;
+        break;
+      }
 #ifdef _XMLWIDECHAR
-            pCh++;
+      pCh++;
 #else
-            pCh+=XML_ByteTable[(unsigned char)(*pCh)];
+      pCh += XML_ByteTable[(unsigned char)(*pCh)];
 #endif
-        }
-    } else lpszTemp=xstrstr(lpXML, pClear.lpszClose);
-
-    if (lpszTemp)
-    {
-        // Cache the size and increment the index
-        cbTemp = (int)(lpszTemp - lpXML);
-
-        pXML->nIndex += cbTemp+(int)xstrlen(pClear.lpszClose);
-
-        // Add the clear node to the current element
-        addClear_priv(MEMORYINCREASE,stringDup(lpXML,cbTemp), pClear.lpszOpen, pClear.lpszClose,-1);
-        return 0;
     }
+  } else
+    lpszTemp = xstrstr(lpXML, pClear.lpszClose);
 
-    // If we failed to find the end tag
-    pXML->error = eXMLErrorUnmatchedEndClearTag;
-    return 1;
-}
+  if (lpszTemp) {
+    // Cache the size and increment the index
+    cbTemp = (int)(lpszTemp - lpXML);
 
-void XMLNode::exactMemory(XMLNodeData *d)
-{
-    if (d->pOrder)     d->pOrder=(int*)realloc(d->pOrder,(d->nChild+d->nText+d->nClear)*sizeof(int));
-    if (d->pChild)     d->pChild=(XMLNode*)realloc(d->pChild,d->nChild*sizeof(XMLNode));
-    if (d->pAttribute) d->pAttribute=(XMLAttribute*)realloc(d->pAttribute,d->nAttribute*sizeof(XMLAttribute));
-    if (d->pText)      d->pText=(XMLCSTR*)realloc(d->pText,d->nText*sizeof(XMLSTR));
-    if (d->pClear)     d->pClear=(XMLClear *)realloc(d->pClear,d->nClear*sizeof(XMLClear));
-}
+    pXML->nIndex += cbTemp + (int)xstrlen(pClear.lpszClose);
 
-char XMLNode::maybeAddTxT(void *pa, XMLCSTR tokenPStr)
-{
-    XML *pXML=(XML *)pa;
-    XMLCSTR lpszText=pXML->lpszText;
-    if (!lpszText) return 0;
-    if (dropWhiteSpace) while (XML_isSPACECHAR(*lpszText)&&(lpszText!=tokenPStr)) lpszText++;
-    int cbText = (int)(tokenPStr - lpszText);
-    if (!cbText) { pXML->lpszText=NULL; return 0; }
-    if (dropWhiteSpace) { cbText--; while ((cbText)&&XML_isSPACECHAR(lpszText[cbText])) cbText--; cbText++; }
-    if (!cbText) { pXML->lpszText=NULL; return 0; }
-    XMLSTR lpt=fromXMLString(lpszText,cbText,pXML);
-    if (!lpt) return 1;
-    pXML->lpszText=NULL;
-    if (removeCommentsInMiddleOfText && d->nText && d->nClear)
-    {
-        // if the previous insertion was a comment (<!-- -->) AND
-        // if the previous previous insertion was a text then, delete the comment and append the text
-        int n=d->nChild+d->nText+d->nClear-1,*o=d->pOrder;
-        if (((o[n]&3)==eNodeClear)&&((o[n-1]&3)==eNodeText))
-        {
-            int i=o[n]>>2;
-            if (d->pClear[i].lpszOpenTag==XMLClearTags[2].lpszOpen)
-            {
-                deleteClear(i);
-                i=o[n-1]>>2;
-                n=xstrlen(d->pText[i]);
-                int n2=xstrlen(lpt)+1;
-                d->pText[i]=(XMLSTR)realloc((void*)d->pText[i],(n+n2)*sizeof(XMLCHAR));
-                if (!d->pText[i]) return 1;
-                memcpy((void*)(d->pText[i]+n),lpt,n2*sizeof(XMLCHAR));
-                free(lpt);
-                return 0;
-            }
-        }
-    }
-    addText_priv(MEMORYINCREASE,lpt,-1);
+    // Add the clear node to the current element
+    addClear_priv(MEMORYINCREASE, stringDup(lpXML, cbTemp), pClear.lpszOpen,
+                  pClear.lpszClose, -1);
     return 0;
+  }
+
+  // If we failed to find the end tag
+  pXML->error = eXMLErrorUnmatchedEndClearTag;
+  return 1;
+}
+
+void XMLNode::exactMemory(XMLNodeData *d) {
+  if (d->pOrder)
+    d->pOrder = (int *)realloc(
+        d->pOrder, (d->nChild + d->nText + d->nClear) * sizeof(int));
+  if (d->pChild)
+    d->pChild = (XMLNode *)realloc(d->pChild, d->nChild * sizeof(XMLNode));
+  if (d->pAttribute)
+    d->pAttribute = (XMLAttribute *)realloc(
+        d->pAttribute, d->nAttribute * sizeof(XMLAttribute));
+  if (d->pText)
+    d->pText = (XMLCSTR *)realloc(d->pText, d->nText * sizeof(XMLSTR));
+  if (d->pClear)
+    d->pClear = (XMLClear *)realloc(d->pClear, d->nClear * sizeof(XMLClear));
+}
+
+char XMLNode::maybeAddTxT(void *pa, XMLCSTR tokenPStr) {
+  XML *pXML = (XML *)pa;
+  XMLCSTR lpszText = pXML->lpszText;
+  if (!lpszText) return 0;
+  if (dropWhiteSpace)
+    while (XML_isSPACECHAR(*lpszText) && (lpszText != tokenPStr)) lpszText++;
+  int cbText = (int)(tokenPStr - lpszText);
+  if (!cbText) {
+    pXML->lpszText = NULL;
+    return 0;
+  }
+  if (dropWhiteSpace) {
+    cbText--;
+    while ((cbText) && XML_isSPACECHAR(lpszText[cbText])) cbText--;
+    cbText++;
+  }
+  if (!cbText) {
+    pXML->lpszText = NULL;
+    return 0;
+  }
+  XMLSTR lpt = fromXMLString(lpszText, cbText, pXML);
+  if (!lpt) return 1;
+  pXML->lpszText = NULL;
+  if (removeCommentsInMiddleOfText && d->nText && d->nClear) {
+    // if the previous insertion was a comment (<!-- -->) AND
+    // if the previous previous insertion was a text then, delete the comment
+    // and append the text
+    int n = d->nChild + d->nText + d->nClear - 1, *o = d->pOrder;
+    if (((o[n] & 3) == eNodeClear) && ((o[n - 1] & 3) == eNodeText)) {
+      int i = o[n] >> 2;
+      if (d->pClear[i].lpszOpenTag == XMLClearTags[2].lpszOpen) {
+        deleteClear(i);
+        i = o[n - 1] >> 2;
+        n = xstrlen(d->pText[i]);
+        int n2 = xstrlen(lpt) + 1;
+        d->pText[i] =
+            (XMLSTR)realloc((void *)d->pText[i], (n + n2) * sizeof(XMLCHAR));
+        if (!d->pText[i]) return 1;
+        memcpy((void *)(d->pText[i] + n), lpt, n2 * sizeof(XMLCHAR));
+        free(lpt);
+        return 0;
+      }
+    }
+  }
+  addText_priv(MEMORYINCREASE, lpt, -1);
+  return 0;
 }
 // private:
 // Recursively parse an XML element.
-int XMLNode::ParseXMLElement(void *pa)
-{
-    XML *pXML=(XML *)pa;
-    int cbToken;
-    enum XMLTokenTypeTag xtype;
-    NextToken token;
-    XMLCSTR lpszTemp=NULL;
-    int cbTemp=0;
-    char nDeclaration;
-    XMLNode pNew;
-    enum Status status; // inside or outside a tag
-    enum Attrib attrib = eAttribName;
+int XMLNode::ParseXMLElement(void *pa) {
+  XML *pXML = (XML *)pa;
+  int cbToken;
+  enum XMLTokenTypeTag xtype;
+  NextToken token;
+  XMLCSTR lpszTemp = NULL;
+  int cbTemp = 0;
+  char nDeclaration;
+  XMLNode pNew;
+  enum Status status;  // inside or outside a tag
+  enum Attrib attrib = eAttribName;
 
-    assert(pXML);
+  assert(pXML);
 
-    // If this is the first call to the function
-    if (pXML->nFirst)
-    {
-        // Assume we are outside of a tag definition
-        pXML->nFirst = FALSE;
-        status = eOutsideTag;
-    } else
-    {
-        // If this is not the first call then we should only be called when inside a tag.
-        status = eInsideTag;
-    }
+  // If this is the first call to the function
+  if (pXML->nFirst) {
+    // Assume we are outside of a tag definition
+    pXML->nFirst = FALSE;
+    status = eOutsideTag;
+  } else {
+    // If this is not the first call then we should only be called when inside a
+    // tag.
+    status = eInsideTag;
+  }
 
-    // Iterate through the tokens in the document
-    for(;;)
-    {
-        // Obtain the next token
-        token = GetNextToken(pXML, &cbToken, &xtype);
+  // Iterate through the tokens in the document
+  for (;;) {
+    // Obtain the next token
+    token = GetNextToken(pXML, &cbToken, &xtype);
 
-        if (xtype != eTokenError)
-        {
-            // Check the current status
-            switch(status)
-            {
+    if (xtype != eTokenError) {
+      // Check the current status
+      switch (status) {
+        // If we are outside of a tag definition
+        case eOutsideTag:
 
-            // If we are outside of a tag definition
-            case eOutsideTag:
+          // Check what type of token we obtained
+          switch (xtype) {
+            // If we have found text or quoted text
+            case eTokenText:
+            case eTokenCloseTag:       /* '>'         */
+            case eTokenShortHandClose: /* '/>'        */
+            case eTokenQuotedText:
+            case eTokenEquals:
+              break;
 
-                // Check what type of token we obtained
-                switch(xtype)
-                {
-                // If we have found text or quoted text
-                case eTokenText:
-                case eTokenCloseTag:          /* '>'         */
-                case eTokenShortHandClose:    /* '/>'        */
-                case eTokenQuotedText:
-                case eTokenEquals:
-                    break;
+            // If we found a start tag '<' and declarations '<?'
+            case eTokenTagStart:
+            case eTokenDeclaration:
 
-                // If we found a start tag '<' and declarations '<?'
-                case eTokenTagStart:
-                case eTokenDeclaration:
+              // Cache whether this new element is a declaration or not
+              nDeclaration = (xtype == eTokenDeclaration);
 
-                    // Cache whether this new element is a declaration or not
-                    nDeclaration = (xtype == eTokenDeclaration);
+              // If we have node text then add this to the element
+              if (maybeAddTxT(pXML, token.pStr)) return FALSE;
 
-                    // If we have node text then add this to the element
-                    if (maybeAddTxT(pXML,token.pStr)) return FALSE;
+              // Find the name of the tag
+              token = GetNextToken(pXML, &cbToken, &xtype);
 
-                    // Find the name of the tag
-                    token = GetNextToken(pXML, &cbToken, &xtype);
+              // Return an error if we couldn't obtain the next token or
+              // it wasnt text
+              if (xtype != eTokenText) {
+                pXML->error = eXMLErrorMissingTagName;
+                return FALSE;
+              }
 
-                    // Return an error if we couldn't obtain the next token or
-                    // it wasnt text
-                    if (xtype != eTokenText)
-                    {
-                        pXML->error = eXMLErrorMissingTagName;
-                        return FALSE;
-                    }
-
-                    // If we found a new element which is the same as this
-                    // element then we need to pass this back to the caller..
+// If we found a new element which is the same as this
+// element then we need to pass this back to the caller..
 
 #ifdef APPROXIMATE_PARSING
-                    if (d->lpszName &&
-                        myTagCompare(d->lpszName, token.pStr) == 0)
-                    {
-                        // Indicate to the caller that it needs to create a
-                        // new element.
-                        pXML->lpNewElement = token.pStr;
-                        pXML->cbNewElement = cbToken;
+              if (d->lpszName && myTagCompare(d->lpszName, token.pStr) == 0) {
+                // Indicate to the caller that it needs to create a
+                // new element.
+                pXML->lpNewElement = token.pStr;
+                pXML->cbNewElement = cbToken;
+                return TRUE;
+              } else
+#endif
+              {
+                // If the name of the new element differs from the name of
+                // the current element we need to add the new element to
+                // the current one and recurse
+                pNew = addChild_priv(MEMORYINCREASE,
+                                     stringDup(token.pStr, cbToken),
+                                     nDeclaration, -1);
+
+                while (!pNew.isEmpty()) {
+                  // Callself to process the new node.  If we return
+                  // FALSE this means we dont have any more
+                  // processing to do...
+
+                  if (!pNew.ParseXMLElement(pXML))
+                    return FALSE;
+                  else {
+                    // If the call to recurse this function
+                    // evented in a end tag specified in XML then
+                    // we need to unwind the calls to this
+                    // function until we find the appropriate node
+                    // (the element name and end tag name must
+                    // match)
+                    if (pXML->cbEndTag) {
+                      // If we are back at the root node then we
+                      // have an unmatched end tag
+                      if (!d->lpszName) {
+                        pXML->error = eXMLErrorUnmatchedEndTag;
+                        return FALSE;
+                      }
+
+                      // If the end tag matches the name of this
+                      // element then we only need to unwind
+                      // once more...
+
+                      if (myTagCompare(d->lpszName, pXML->lpEndTag) == 0) {
+                        pXML->cbEndTag = 0;
+                      }
+
+                      return TRUE;
+                    } else if (pXML->cbNewElement) {
+                      // If the call indicated a new element is to
+                      // be created on THIS element.
+
+                      // If the name of this element matches the
+                      // name of the element we need to create
+                      // then we need to return to the caller
+                      // and let it process the element.
+
+                      if (myTagCompare(d->lpszName, pXML->lpNewElement) == 0) {
                         return TRUE;
-                    } else
-#endif
-                    {
-                        // If the name of the new element differs from the name of
-                        // the current element we need to add the new element to
-                        // the current one and recurse
-                        pNew = addChild_priv(MEMORYINCREASE,stringDup(token.pStr,cbToken), nDeclaration,-1);
+                      }
 
-                        while (!pNew.isEmpty())
-                        {
-                            // Callself to process the new node.  If we return
-                            // FALSE this means we dont have any more
-                            // processing to do...
-
-                            if (!pNew.ParseXMLElement(pXML)) return FALSE;
-                            else
-                            {
-                                // If the call to recurse this function
-                                // evented in a end tag specified in XML then
-                                // we need to unwind the calls to this
-                                // function until we find the appropriate node
-                                // (the element name and end tag name must
-                                // match)
-                                if (pXML->cbEndTag)
-                                {
-                                    // If we are back at the root node then we
-                                    // have an unmatched end tag
-                                    if (!d->lpszName)
-                                    {
-                                        pXML->error=eXMLErrorUnmatchedEndTag;
-                                        return FALSE;
-                                    }
-
-                                    // If the end tag matches the name of this
-                                    // element then we only need to unwind
-                                    // once more...
-
-                                    if (myTagCompare(d->lpszName, pXML->lpEndTag)==0)
-                                    {
-                                        pXML->cbEndTag = 0;
-                                    }
-
-                                    return TRUE;
-                                } else
-                                    if (pXML->cbNewElement)
-                                    {
-                                        // If the call indicated a new element is to
-                                        // be created on THIS element.
-
-                                        // If the name of this element matches the
-                                        // name of the element we need to create
-                                        // then we need to return to the caller
-                                        // and let it process the element.
-
-                                        if (myTagCompare(d->lpszName, pXML->lpNewElement)==0)
-                                        {
-                                            return TRUE;
-                                        }
-
-                                        // Add the new element and recurse
-                                        pNew = addChild_priv(MEMORYINCREASE,stringDup(pXML->lpNewElement,pXML->cbNewElement),0,-1);
-                                        pXML->cbNewElement = 0;
-                                    }
-                                    else
-                                    {
-                                        // If we didn't have a new element to create
-                                        pNew = emptyXMLNode;
-
-                                    }
-                            }
-                        }
+                      // Add the new element and recurse
+                      pNew = addChild_priv(
+                          MEMORYINCREASE,
+                          stringDup(pXML->lpNewElement, pXML->cbNewElement), 0,
+                          -1);
+                      pXML->cbNewElement = 0;
+                    } else {
+                      // If we didn't have a new element to create
+                      pNew = emptyXMLNode;
                     }
-                    break;
+                  }
+                }
+              }
+              break;
 
-                // If we found an end tag
-                case eTokenTagEnd:
+            // If we found an end tag
+            case eTokenTagEnd:
 
-                    // If we have node text then add this to the element
-                    if (maybeAddTxT(pXML,token.pStr)) return FALSE;
+              // If we have node text then add this to the element
+              if (maybeAddTxT(pXML, token.pStr)) return FALSE;
 
-                    // Find the name of the end tag
-                    token = GetNextToken(pXML, &cbTemp, &xtype);
+              // Find the name of the end tag
+              token = GetNextToken(pXML, &cbTemp, &xtype);
 
-                    // The end tag should be text
-                    if (xtype != eTokenText)
-                    {
-                        pXML->error = eXMLErrorMissingEndTagName;
-                        return FALSE;
-                    }
-                    lpszTemp = token.pStr;
+              // The end tag should be text
+              if (xtype != eTokenText) {
+                pXML->error = eXMLErrorMissingEndTagName;
+                return FALSE;
+              }
+              lpszTemp = token.pStr;
 
-                    // After the end tag we should find a closing tag
-                    token = GetNextToken(pXML, &cbToken, &xtype);
-                    if (xtype != eTokenCloseTag)
-                    {
-                        pXML->error = eXMLErrorMissingEndTagName;
-                        return FALSE;
-                    }
-                    pXML->lpszText=pXML->lpXML+pXML->nIndex;
+              // After the end tag we should find a closing tag
+              token = GetNextToken(pXML, &cbToken, &xtype);
+              if (xtype != eTokenCloseTag) {
+                pXML->error = eXMLErrorMissingEndTagName;
+                return FALSE;
+              }
+              pXML->lpszText = pXML->lpXML + pXML->nIndex;
 
-                    // We need to return to the previous caller.  If the name
-                    // of the tag cannot be found we need to keep returning to
-                    // caller until we find a match
-                    if (myTagCompare(d->lpszName, lpszTemp) != 0)
+              // We need to return to the previous caller.  If the name
+              // of the tag cannot be found we need to keep returning to
+              // caller until we find a match
+              if (myTagCompare(d->lpszName, lpszTemp) != 0)
 #ifdef STRICT_PARSING
-                    {
-                        pXML->error=eXMLErrorUnmatchedEndTag;
-                        pXML->nIndexMissigEndTag=pXML->nIndex;
-                        return FALSE;
-                    }
+              {
+                pXML->error = eXMLErrorUnmatchedEndTag;
+                pXML->nIndexMissigEndTag = pXML->nIndex;
+                return FALSE;
+              }
 #else
-                    {
-                        pXML->error=eXMLErrorMissingEndTag;
-                        pXML->nIndexMissigEndTag=pXML->nIndex;
-                        pXML->lpEndTag = lpszTemp;
-                        pXML->cbEndTag = cbTemp;
-                    }
+              {
+                pXML->error = eXMLErrorMissingEndTag;
+                pXML->nIndexMissigEndTag = pXML->nIndex;
+                pXML->lpEndTag = lpszTemp;
+                pXML->cbEndTag = cbTemp;
+              }
 #endif
 
-                    // Return to the caller
+              // Return to the caller
+              exactMemory(d);
+              return TRUE;
+
+            // If we found a clear (unformatted) token
+            case eTokenClear:
+              // If we have node text then add this to the element
+              if (maybeAddTxT(pXML, token.pStr)) return FALSE;
+              if (parseClearTag(pXML, token.pClr)) return FALSE;
+              pXML->lpszText = pXML->lpXML + pXML->nIndex;
+              break;
+
+            default:
+              break;
+          }
+          break;
+
+        // If we are inside a tag definition we need to search for attributes
+        case eInsideTag:
+
+          // Check what part of the attribute (name, equals, value) we
+          // are looking for.
+          switch (attrib) {
+            // If we are looking for a new attribute
+            case eAttribName:
+
+              // Check what the current token type is
+              switch (xtype) {
+                // If the current type is text...
+                // Eg.  'attribute'
+                case eTokenText:
+                  // Cache the token then indicate that we are next to
+                  // look for the equals
+                  lpszTemp = token.pStr;
+                  cbTemp = cbToken;
+                  attrib = eAttribEquals;
+                  break;
+
+                // If we found a closing tag...
+                // Eg.  '>'
+                case eTokenCloseTag:
+                  // We are now outside the tag
+                  status = eOutsideTag;
+                  pXML->lpszText = pXML->lpXML + pXML->nIndex;
+                  break;
+
+                // If we found a short hand '/>' closing tag then we can
+                // return to the caller
+                case eTokenShortHandClose:
+                  exactMemory(d);
+                  pXML->lpszText = pXML->lpXML + pXML->nIndex;
+                  return TRUE;
+
+                // Errors...
+                case eTokenQuotedText:  /* '"SomeText"'   */
+                case eTokenTagStart:    /* '<'            */
+                case eTokenTagEnd:      /* '</'           */
+                case eTokenEquals:      /* '='            */
+                case eTokenDeclaration: /* '<?'           */
+                case eTokenClear:
+                  pXML->error = eXMLErrorUnexpectedToken;
+                  return FALSE;
+                default:
+                  break;
+              }
+              break;
+
+            // If we are looking for an equals
+            case eAttribEquals:
+              // Check what the current token type is
+              switch (xtype) {
+                // If the current type is text...
+                // Eg.  'Attribute AnotherAttribute'
+                case eTokenText:
+                  // Add the unvalued attribute to the list
+                  addAttribute_priv(MEMORYINCREASE, stringDup(lpszTemp, cbTemp),
+                                    NULL);
+                  // Cache the token then indicate.  We are next to
+                  // look for the equals attribute
+                  lpszTemp = token.pStr;
+                  cbTemp = cbToken;
+                  break;
+
+                // If we found a closing tag 'Attribute >' or a short hand
+                // closing tag 'Attribute />'
+                case eTokenShortHandClose:
+                case eTokenCloseTag:
+                  // If we are a declaration element '<?' then we need
+                  // to remove extra closing '?' if it exists
+                  pXML->lpszText = pXML->lpXML + pXML->nIndex;
+
+                  if (d->isDeclaration &&
+                      (lpszTemp[cbTemp - 1]) == _CXML('?')) {
+                    cbTemp--;
+                    if (d->pParent && d->pParent->pParent)
+                      xtype = eTokenShortHandClose;
+                  }
+
+                  if (cbTemp) {
+                    // Add the unvalued attribute to the list
+                    addAttribute_priv(MEMORYINCREASE,
+                                      stringDup(lpszTemp, cbTemp), NULL);
+                  }
+
+                  // If this is the end of the tag then return to the caller
+                  if (xtype == eTokenShortHandClose) {
                     exactMemory(d);
                     return TRUE;
+                  }
 
-                // If we found a clear (unformatted) token
+                  // We are now outside the tag
+                  status = eOutsideTag;
+                  break;
+
+                // If we found the equals token...
+                // Eg.  'Attribute ='
+                case eTokenEquals:
+                  // Indicate that we next need to search for the value
+                  // for the attribute
+                  attrib = eAttribValue;
+                  break;
+
+                // Errors...
+                case eTokenQuotedText:  /* 'Attribute "InvalidAttr"'*/
+                case eTokenTagStart:    /* 'Attribute <'            */
+                case eTokenTagEnd:      /* 'Attribute </'           */
+                case eTokenDeclaration: /* 'Attribute <?'           */
                 case eTokenClear:
-                    // If we have node text then add this to the element
-                    if (maybeAddTxT(pXML,token.pStr)) return FALSE;
-                    if (parseClearTag(pXML, token.pClr)) return FALSE;
-                    pXML->lpszText=pXML->lpXML+pXML->nIndex;
-                    break;
-
+                  pXML->error = eXMLErrorUnexpectedToken;
+                  return FALSE;
                 default:
-                    break;
-                }
-                break;
+                  break;
+              }
+              break;
 
-            // If we are inside a tag definition we need to search for attributes
-            case eInsideTag:
+            // If we are looking for an attribute value
+            case eAttribValue:
+              // Check what the current token type is
+              switch (xtype) {
+                // If the current type is text or quoted text...
+                // Eg.  'Attribute = "Value"' or 'Attribute = Value' or
+                // 'Attribute = 'Value''.
+                case eTokenText:
+                case eTokenQuotedText:
+                  // If we are a declaration element '<?' then we need
+                  // to remove extra closing '?' if it exists
+                  if (d->isDeclaration &&
+                      (token.pStr[cbToken - 1]) == _CXML('?')) {
+                    cbToken--;
+                  }
 
-                // Check what part of the attribute (name, equals, value) we
-                // are looking for.
-                switch(attrib)
-                {
-                // If we are looking for a new attribute
-                case eAttribName:
-
-                    // Check what the current token type is
-                    switch(xtype)
-                    {
-                    // If the current type is text...
-                    // Eg.  'attribute'
-                    case eTokenText:
-                        // Cache the token then indicate that we are next to
-                        // look for the equals
-                        lpszTemp = token.pStr;
-                        cbTemp = cbToken;
-                        attrib = eAttribEquals;
-                        break;
-
-                    // If we found a closing tag...
-                    // Eg.  '>'
-                    case eTokenCloseTag:
-                        // We are now outside the tag
-                        status = eOutsideTag;
-                        pXML->lpszText=pXML->lpXML+pXML->nIndex;
-                        break;
-
-                    // If we found a short hand '/>' closing tag then we can
-                    // return to the caller
-                    case eTokenShortHandClose:
-                        exactMemory(d);
-                        pXML->lpszText=pXML->lpXML+pXML->nIndex;
-                        return TRUE;
-
-                    // Errors...
-                    case eTokenQuotedText:    /* '"SomeText"'   */
-                    case eTokenTagStart:      /* '<'            */
-                    case eTokenTagEnd:        /* '</'           */
-                    case eTokenEquals:        /* '='            */
-                    case eTokenDeclaration:   /* '<?'           */
-                    case eTokenClear:
-                        pXML->error = eXMLErrorUnexpectedToken;
-                        return FALSE;
-                    default: break;
+                  if (cbTemp) {
+                    // Add the valued attribute to the list
+                    if (xtype == eTokenQuotedText) {
+                      token.pStr++;
+                      cbToken -= 2;
                     }
-                    break;
-
-                // If we are looking for an equals
-                case eAttribEquals:
-                    // Check what the current token type is
-                    switch(xtype)
-                    {
-                    // If the current type is text...
-                    // Eg.  'Attribute AnotherAttribute'
-                    case eTokenText:
-                        // Add the unvalued attribute to the list
-                        addAttribute_priv(MEMORYINCREASE,stringDup(lpszTemp,cbTemp), NULL);
-                        // Cache the token then indicate.  We are next to
-                        // look for the equals attribute
-                        lpszTemp = token.pStr;
-                        cbTemp = cbToken;
-                        break;
-
-                    // If we found a closing tag 'Attribute >' or a short hand
-                    // closing tag 'Attribute />'
-                    case eTokenShortHandClose:
-                    case eTokenCloseTag:
-                        // If we are a declaration element '<?' then we need
-                        // to remove extra closing '?' if it exists
-                        pXML->lpszText=pXML->lpXML+pXML->nIndex;
-
-                        if (d->isDeclaration &&
-                            (lpszTemp[cbTemp-1]) == _CXML('?'))
-                        {
-                            cbTemp--;
-                            if (d->pParent && d->pParent->pParent) xtype = eTokenShortHandClose;
-                        }
-
-                        if (cbTemp)
-                        {
-                            // Add the unvalued attribute to the list
-                            addAttribute_priv(MEMORYINCREASE,stringDup(lpszTemp,cbTemp), NULL);
-                        }
-
-                        // If this is the end of the tag then return to the caller
-                        if (xtype == eTokenShortHandClose)
-                        {
-                            exactMemory(d);
-                            return TRUE;
-                        }
-
-                        // We are now outside the tag
-                        status = eOutsideTag;
-                        break;
-
-                    // If we found the equals token...
-                    // Eg.  'Attribute ='
-                    case eTokenEquals:
-                        // Indicate that we next need to search for the value
-                        // for the attribute
-                        attrib = eAttribValue;
-                        break;
-
-                    // Errors...
-                    case eTokenQuotedText:    /* 'Attribute "InvalidAttr"'*/
-                    case eTokenTagStart:      /* 'Attribute <'            */
-                    case eTokenTagEnd:        /* 'Attribute </'           */
-                    case eTokenDeclaration:   /* 'Attribute <?'           */
-                    case eTokenClear:
-                        pXML->error = eXMLErrorUnexpectedToken;
-                        return FALSE;
-                    default: break;
+                    XMLSTR attrVal = (XMLSTR)token.pStr;
+                    if (attrVal) {
+                      attrVal = fromXMLString(attrVal, cbToken, pXML);
+                      if (!attrVal) return FALSE;
                     }
-                    break;
+                    addAttribute_priv(MEMORYINCREASE,
+                                      stringDup(lpszTemp, cbTemp), attrVal);
+                  }
 
-                // If we are looking for an attribute value
-                case eAttribValue:
-                    // Check what the current token type is
-                    switch(xtype)
-                    {
-                    // If the current type is text or quoted text...
-                    // Eg.  'Attribute = "Value"' or 'Attribute = Value' or
-                    // 'Attribute = 'Value''.
-                    case eTokenText:
-                    case eTokenQuotedText:
-                        // If we are a declaration element '<?' then we need
-                        // to remove extra closing '?' if it exists
-                        if (d->isDeclaration &&
-                            (token.pStr[cbToken-1]) == _CXML('?'))
-                        {
-                            cbToken--;
-                        }
+                  // Indicate we are searching for a new attribute
+                  attrib = eAttribName;
+                  break;
 
-                        if (cbTemp)
-                        {
-                            // Add the valued attribute to the list
-                            if (xtype==eTokenQuotedText) { token.pStr++; cbToken-=2; }
-                            XMLSTR attrVal=(XMLSTR)token.pStr;
-                            if (attrVal)
-                            {
-                                attrVal=fromXMLString(attrVal,cbToken,pXML);
-                                if (!attrVal) return FALSE;
-                            }
-                            addAttribute_priv(MEMORYINCREASE,stringDup(lpszTemp,cbTemp),attrVal);
-                        }
-
-                        // Indicate we are searching for a new attribute
-                        attrib = eAttribName;
-                        break;
-
-                    // Errors...
-                    case eTokenTagStart:        /* 'Attr = <'          */
-                    case eTokenTagEnd:          /* 'Attr = </'         */
-                    case eTokenCloseTag:        /* 'Attr = >'          */
-                    case eTokenShortHandClose:  /* "Attr = />"         */
-                    case eTokenEquals:          /* 'Attr = ='          */
-                    case eTokenDeclaration:     /* 'Attr = <?'         */
-                    case eTokenClear:
-                        pXML->error = eXMLErrorUnexpectedToken;
-                        return FALSE;
-                        break;
-                    default: break;
-                    }
-                }
-            }
-        }
-        // If we failed to obtain the next token
-        else
-        {
-            if ((!d->isDeclaration)&&(d->pParent))
-            {
-#ifdef STRICT_PARSING
-                pXML->error=eXMLErrorUnmatchedEndTag;
-#else
-                pXML->error=eXMLErrorMissingEndTag;
-#endif
-                pXML->nIndexMissigEndTag=pXML->nIndex;
-            }
-            maybeAddTxT(pXML,pXML->lpXML+pXML->nIndex);
-            return FALSE;
-        }
+                // Errors...
+                case eTokenTagStart:       /* 'Attr = <'          */
+                case eTokenTagEnd:         /* 'Attr = </'         */
+                case eTokenCloseTag:       /* 'Attr = >'          */
+                case eTokenShortHandClose: /* "Attr = />"         */
+                case eTokenEquals:         /* 'Attr = ='          */
+                case eTokenDeclaration:    /* 'Attr = <?'         */
+                case eTokenClear:
+                  pXML->error = eXMLErrorUnexpectedToken;
+                  return FALSE;
+                  break;
+                default:
+                  break;
+              }
+          }
+      }
     }
+    // If we failed to obtain the next token
+    else {
+      if ((!d->isDeclaration) && (d->pParent)) {
+#ifdef STRICT_PARSING
+        pXML->error = eXMLErrorUnmatchedEndTag;
+#else
+        pXML->error = eXMLErrorMissingEndTag;
+#endif
+        pXML->nIndexMissigEndTag = pXML->nIndex;
+      }
+      maybeAddTxT(pXML, pXML->lpXML + pXML->nIndex);
+      return FALSE;
+    }
+  }
 }
 
 // Count the number of lines and columns in an XML string.
-static void CountLinesAndColumns(XMLCSTR lpXML, int nUpto, XMLResults *pResults)
-{
-    XMLCHAR ch;
-    assert(lpXML);
-    assert(pResults);
+static void CountLinesAndColumns(XMLCSTR lpXML, int nUpto,
+                                 XMLResults *pResults) {
+  XMLCHAR ch;
+  assert(lpXML);
+  assert(pResults);
 
-    struct XML xml={ lpXML,lpXML, 0, 0, eXMLErrorNone, NULL, 0, NULL, 0, TRUE };
+  struct XML xml = {lpXML, lpXML, 0, 0, eXMLErrorNone, NULL, 0, NULL, 0, TRUE};
 
-    pResults->nLine = 1;
-    pResults->nColumn = 1;
-    while (xml.nIndex<nUpto)
-    {
-        ch = getNextChar(&xml);
-        if (ch != _CXML('\n')) pResults->nColumn++;
-        else
-        {
-            pResults->nLine++;
-            pResults->nColumn=1;
-        }
+  pResults->nLine = 1;
+  pResults->nColumn = 1;
+  while (xml.nIndex < nUpto) {
+    ch = getNextChar(&xml);
+    if (ch != _CXML('\n'))
+      pResults->nColumn++;
+    else {
+      pResults->nLine++;
+      pResults->nColumn = 1;
     }
+  }
 }
 
 // Parse XML and return the root element.
-XMLNode XMLNode::parseString(XMLCSTR lpszXML, XMLCSTR tag, XMLResults *pResults)
-{
-    if (!lpszXML)
-    {
-        if (pResults)
-        {
-            pResults->error=eXMLErrorNoElements;
-            pResults->nLine=0;
-            pResults->nColumn=0;
+XMLNode XMLNode::parseString(XMLCSTR lpszXML, XMLCSTR tag,
+                             XMLResults *pResults) {
+  if (!lpszXML) {
+    if (pResults) {
+      pResults->error = eXMLErrorNoElements;
+      pResults->nLine = 0;
+      pResults->nColumn = 0;
+    }
+    return emptyXMLNode;
+  }
+
+  XMLNode xnode(NULL, NULL, FALSE);
+  struct XML xml = {lpszXML, lpszXML, 0,    0, eXMLErrorNone,
+                    NULL,    0,       NULL, 0, TRUE};
+
+  // Create header element
+  xnode.ParseXMLElement(&xml);
+  enum XMLError error = xml.error;
+  if (!xnode.nChildNode()) error = eXMLErrorNoXMLTagFound;
+  if ((xnode.nChildNode() == 1) && (xnode.nElement() == 1))
+    xnode = xnode.getChildNode();  // skip the empty node
+
+  // If no error occurred
+  if ((error == eXMLErrorNone) || (error == eXMLErrorMissingEndTag) ||
+      (error == eXMLErrorNoXMLTagFound)) {
+    XMLCSTR name = xnode.getName();
+    if (tag && (*tag) && ((!name) || (xstricmp(name, tag)))) {
+      xnode = xnode.getChildNode(tag);
+      if (xnode.isEmpty()) {
+        if (pResults) {
+          pResults->error = eXMLErrorFirstTagNotFound;
+          pResults->nLine = 0;
+          pResults->nColumn = 0;
         }
         return emptyXMLNode;
+      }
     }
+  } else {
+    // Cleanup: this will destroy all the nodes
+    xnode = emptyXMLNode;
+  }
 
-    XMLNode xnode(NULL,NULL,FALSE);
-    struct XML xml={ lpszXML, lpszXML, 0, 0, eXMLErrorNone, NULL, 0, NULL, 0, TRUE };
+  // If we have been given somewhere to place results
+  if (pResults) {
+    pResults->error = error;
 
-    // Create header element
-    xnode.ParseXMLElement(&xml);
-    enum XMLError error = xml.error;
-    if (!xnode.nChildNode()) error=eXMLErrorNoXMLTagFound;
-    if ((xnode.nChildNode()==1)&&(xnode.nElement()==1)) xnode=xnode.getChildNode(); // skip the empty node
-
-    // If no error occurred
-    if ((error==eXMLErrorNone)||(error==eXMLErrorMissingEndTag)||(error==eXMLErrorNoXMLTagFound))
-    {
-        XMLCSTR name=xnode.getName();
-        if (tag&&(*tag)&&((!name)||(xstricmp(name,tag))))
-        {
-            xnode=xnode.getChildNode(tag);
-            if (xnode.isEmpty())
-            {
-                if (pResults)
-                {
-                    pResults->error=eXMLErrorFirstTagNotFound;
-                    pResults->nLine=0;
-                    pResults->nColumn=0;
-                }
-                return emptyXMLNode;
-            }
-        }
-    } else
-    {
-        // Cleanup: this will destroy all the nodes
-        xnode = emptyXMLNode;
+    // If we have an error
+    if (error != eXMLErrorNone) {
+      if (error == eXMLErrorMissingEndTag) xml.nIndex = xml.nIndexMissigEndTag;
+      // Find which line and column it starts on.
+      CountLinesAndColumns(xml.lpXML, xml.nIndex, pResults);
     }
-
-
-    // If we have been given somewhere to place results
-    if (pResults)
-    {
-        pResults->error = error;
-
-        // If we have an error
-        if (error!=eXMLErrorNone)
-        {
-            if (error==eXMLErrorMissingEndTag) xml.nIndex=xml.nIndexMissigEndTag;
-            // Find which line and column it starts on.
-            CountLinesAndColumns(xml.lpXML, xml.nIndex, pResults);
-        }
-    }
-    return xnode;
+  }
+  return xnode;
 }
 
-XMLNode XMLNode::parseFile(XMLCSTR filename, XMLCSTR tag, XMLResults *pResults)
-{
-    if (pResults) { pResults->nLine=0; pResults->nColumn=0; }
-    FILE *f=xfopen(filename,_CXML("rb"));
-    if (f==NULL) { if (pResults) pResults->error=eXMLErrorFileNotFound; return emptyXMLNode; }
-    fseek(f,0,SEEK_END);
-    int l=ftell(f),headerSz=0;
-    if (!l) { if (pResults) pResults->error=eXMLErrorEmpty; fclose(f); return emptyXMLNode; }
-    fseek(f,0,SEEK_SET);
-    unsigned char *buf=(unsigned char*)malloc(l+4);
-    l=fread(buf,1,l,f);
+XMLNode XMLNode::parseFile(XMLCSTR filename, XMLCSTR tag,
+                           XMLResults *pResults) {
+  if (pResults) {
+    pResults->nLine = 0;
+    pResults->nColumn = 0;
+  }
+  FILE *f = xfopen(filename, _CXML("rb"));
+  if (f == NULL) {
+    if (pResults) pResults->error = eXMLErrorFileNotFound;
+    return emptyXMLNode;
+  }
+  fseek(f, 0, SEEK_END);
+  int l = ftell(f), headerSz = 0;
+  if (!l) {
+    if (pResults) pResults->error = eXMLErrorEmpty;
     fclose(f);
-    buf[l]=0;buf[l+1]=0;buf[l+2]=0;buf[l+3]=0;
+    return emptyXMLNode;
+  }
+  fseek(f, 0, SEEK_SET);
+  unsigned char *buf = (unsigned char *)malloc(l + 4);
+  l = fread(buf, 1, l, f);
+  fclose(f);
+  buf[l] = 0;
+  buf[l + 1] = 0;
+  buf[l + 2] = 0;
+  buf[l + 3] = 0;
 #ifdef _XMLWIDECHAR
-    if (guessWideCharChars)
-    {
-        if (!myIsTextWideChar(buf,l))
-        {
-            XMLNode::XMLCharEncoding ce=XMLNode::char_encoding_legacy;
-            if ((buf[0]==0xef)&&(buf[1]==0xbb)&&(buf[2]==0xbf)) { headerSz=3; ce=XMLNode::char_encoding_UTF8; }
-            XMLSTR b2=myMultiByteToWideChar((const char*)(buf+headerSz),ce);
-            free(buf); buf=(unsigned char*)b2; headerSz=0;
-        } else
-        {
-            if ((buf[0]==0xef)&&(buf[1]==0xff)) headerSz=2;
-            if ((buf[0]==0xff)&&(buf[1]==0xfe)) headerSz=2;
-        }
+  if (guessWideCharChars) {
+    if (!myIsTextWideChar(buf, l)) {
+      XMLNode::XMLCharEncoding ce = XMLNode::char_encoding_legacy;
+      if ((buf[0] == 0xef) && (buf[1] == 0xbb) && (buf[2] == 0xbf)) {
+        headerSz = 3;
+        ce = XMLNode::char_encoding_UTF8;
+      }
+      XMLSTR b2 = myMultiByteToWideChar((const char *)(buf + headerSz), ce);
+      free(buf);
+      buf = (unsigned char *)b2;
+      headerSz = 0;
+    } else {
+      if ((buf[0] == 0xef) && (buf[1] == 0xff)) headerSz = 2;
+      if ((buf[0] == 0xff) && (buf[1] == 0xfe)) headerSz = 2;
     }
+  }
 #else
-    if (guessWideCharChars)
-    {
-        if (myIsTextWideChar(buf,l))
-        {
-            if ((buf[0]==0xef)&&(buf[1]==0xff)) headerSz=2;
-            if ((buf[0]==0xff)&&(buf[1]==0xfe)) headerSz=2;
-            char *b2=myWideCharToMultiByte((const wchar_t*)(buf+headerSz));
-            free(buf); buf=(unsigned char*)b2; headerSz=0;
-        } else
-        {
-            if ((buf[0]==0xef)&&(buf[1]==0xbb)&&(buf[2]==0xbf)) headerSz=3;
-        }
+  if (guessWideCharChars) {
+    if (myIsTextWideChar(buf, l)) {
+      if ((buf[0] == 0xef) && (buf[1] == 0xff)) headerSz = 2;
+      if ((buf[0] == 0xff) && (buf[1] == 0xfe)) headerSz = 2;
+      char *b2 = myWideCharToMultiByte((const wchar_t *)(buf + headerSz));
+      free(buf);
+      buf = (unsigned char *)b2;
+      headerSz = 0;
+    } else {
+      if ((buf[0] == 0xef) && (buf[1] == 0xbb) && (buf[2] == 0xbf))
+        headerSz = 3;
     }
+  }
 #endif
 
-    if (!buf) { if (pResults) pResults->error=eXMLErrorCharConversionError; return emptyXMLNode; }
-    XMLNode x=parseString((XMLSTR)(buf+headerSz),tag,pResults);
-    free(buf);
-    return x;
+  if (!buf) {
+    if (pResults) pResults->error = eXMLErrorCharConversionError;
+    return emptyXMLNode;
+  }
+  XMLNode x = parseString((XMLSTR)(buf + headerSz), tag, pResults);
+  free(buf);
+  return x;
 }
 
-static inline void charmemset(XMLSTR dest,XMLCHAR c,int l) { while (l--) *(dest++)=c; }
+static inline void charmemset(XMLSTR dest, XMLCHAR c, int l) {
+  while (l--) *(dest++) = c;
+}
 // private:
 // Creates an user friendly XML string from a given element with
 // appropriate white space and carriage returns.
 //
 // This recurses through all subnodes then adds contents of the nodes to the
 // string.
-int XMLNode::CreateXMLStringR(XMLNodeData *pEntry, XMLSTR lpszMarker, int nFormat)
-{
-    int nResult = 0;
-    int cb=nFormat<0?0:nFormat;
-    int cbElement;
-    int nChildFormat=-1;
-    int nElementI=pEntry->nChild+pEntry->nText+pEntry->nClear;
-    int i,j;
-    if ((nFormat>=0)&&(nElementI==1)&&(pEntry->nText==1)&&(!pEntry->isDeclaration)) nFormat=-2;
+int XMLNode::CreateXMLStringR(XMLNodeData *pEntry, XMLSTR lpszMarker,
+                              int nFormat) {
+  int nResult = 0;
+  int cb = nFormat < 0 ? 0 : nFormat;
+  int cbElement;
+  int nChildFormat = -1;
+  int nElementI = pEntry->nChild + pEntry->nText + pEntry->nClear;
+  int i, j;
+  if ((nFormat >= 0) && (nElementI == 1) && (pEntry->nText == 1) &&
+      (!pEntry->isDeclaration))
+    nFormat = -2;
 
-    assert(pEntry);
+  assert(pEntry);
 
 #define LENSTR(lpsz) (lpsz ? xstrlen(lpsz) : 0)
 
-    // If the element has no name then assume this is the head node.
-    cbElement = (int)LENSTR(pEntry->lpszName);
+  // If the element has no name then assume this is the head node.
+  cbElement = (int)LENSTR(pEntry->lpszName);
 
-    if (cbElement)
-    {
-        // "<elementname "
-        if (lpszMarker)
-        {
-            if (cb) charmemset(lpszMarker, INDENTCHAR, cb);
-            nResult = cb;
-            lpszMarker[nResult++]=_CXML('<');
-            if (pEntry->isDeclaration) lpszMarker[nResult++]=_CXML('?');
-            xstrcpy(&lpszMarker[nResult], pEntry->lpszName);
-            nResult+=cbElement;
-            lpszMarker[nResult++]=_CXML(' ');
+  if (cbElement) {
+    // "<elementname "
+    if (lpszMarker) {
+      if (cb) charmemset(lpszMarker, INDENTCHAR, cb);
+      nResult = cb;
+      lpszMarker[nResult++] = _CXML('<');
+      if (pEntry->isDeclaration) lpszMarker[nResult++] = _CXML('?');
+      xstrcpy(&lpszMarker[nResult], pEntry->lpszName);
+      nResult += cbElement;
+      lpszMarker[nResult++] = _CXML(' ');
 
-        } else
-        {
-            nResult+=cbElement+2+cb;
-            if (pEntry->isDeclaration) nResult++;
-        }
+    } else {
+      nResult += cbElement + 2 + cb;
+      if (pEntry->isDeclaration) nResult++;
+    }
 
-        // Enumerate attributes and add them to the string
-        XMLAttribute *pAttr=pEntry->pAttribute;
-        for (i=0; i<pEntry->nAttribute; i++)
-        {
-            // "Attrib
-            cb = (int)LENSTR(pAttr->lpszName);
+    // Enumerate attributes and add them to the string
+    XMLAttribute *pAttr = pEntry->pAttribute;
+    for (i = 0; i < pEntry->nAttribute; i++) {
+      // "Attrib
+      cb = (int)LENSTR(pAttr->lpszName);
+      if (cb) {
+        if (lpszMarker) xstrcpy(&lpszMarker[nResult], pAttr->lpszName);
+        nResult += cb;
+        // "Attrib=Value "
+        if (pAttr->lpszValue) {
+          cb = (int)ToXMLStringTool::lengthXMLString(pAttr->lpszValue);
+          if (lpszMarker) {
+            lpszMarker[nResult] = _CXML('=');
+            lpszMarker[nResult + 1] = _CXML('"');
             if (cb)
-            {
-                if (lpszMarker) xstrcpy(&lpszMarker[nResult], pAttr->lpszName);
-                nResult += cb;
-                // "Attrib=Value "
-                if (pAttr->lpszValue)
-                {
-                    cb=(int)ToXMLStringTool::lengthXMLString(pAttr->lpszValue);
-                    if (lpszMarker)
-                    {
-                        lpszMarker[nResult]=_CXML('=');
-                        lpszMarker[nResult+1]=_CXML('"');
-                        if (cb) ToXMLStringTool::toXMLUnSafe(&lpszMarker[nResult+2],pAttr->lpszValue);
-                        lpszMarker[nResult+cb+2]=_CXML('"');
-                    }
-                    nResult+=cb+3;
-                }
-                if (lpszMarker) lpszMarker[nResult] = _CXML(' ');
-                nResult++;
+              ToXMLStringTool::toXMLUnSafe(&lpszMarker[nResult + 2],
+                                           pAttr->lpszValue);
+            lpszMarker[nResult + cb + 2] = _CXML('"');
+          }
+          nResult += cb + 3;
+        }
+        if (lpszMarker) lpszMarker[nResult] = _CXML(' ');
+        nResult++;
+      }
+      pAttr++;
+    }
+
+    if (pEntry->isDeclaration) {
+      if (lpszMarker) {
+        lpszMarker[nResult - 1] = _CXML('?');
+        lpszMarker[nResult] = _CXML('>');
+      }
+      nResult++;
+      if (nFormat != -1) {
+        if (lpszMarker) lpszMarker[nResult] = _CXML('\n');
+        nResult++;
+      }
+    } else
+        // If there are child nodes we need to terminate the start tag
+        if (nElementI) {
+      if (lpszMarker) lpszMarker[nResult - 1] = _CXML('>');
+      if (nFormat >= 0) {
+        if (lpszMarker) lpszMarker[nResult] = _CXML('\n');
+        nResult++;
+      }
+    } else
+      nResult--;
+  }
+
+  // Calculate the child format for when we recurse.  This is used to
+  // determine the number of spaces used for prefixes.
+  if (nFormat != -1) {
+    if (cbElement && (!pEntry->isDeclaration))
+      nChildFormat = nFormat + 1;
+    else
+      nChildFormat = nFormat;
+  }
+
+  // Enumerate through remaining children
+  for (i = 0; i < nElementI; i++) {
+    j = pEntry->pOrder[i];
+    switch ((XMLElementType)(j & 3)) {
+      // Text nodes
+      case eNodeText: {
+        // "Text"
+        XMLCSTR pChild = pEntry->pText[j >> 2];
+        cb = (int)ToXMLStringTool::lengthXMLString(pChild);
+        if (cb) {
+          if (nFormat >= 0) {
+            if (lpszMarker) {
+              charmemset(&lpszMarker[nResult], INDENTCHAR, nFormat + 1);
+              ToXMLStringTool::toXMLUnSafe(&lpszMarker[nResult + nFormat + 1],
+                                           pChild);
+              lpszMarker[nResult + nFormat + 1 + cb] = _CXML('\n');
             }
-            pAttr++;
+            nResult += cb + nFormat + 2;
+          } else {
+            if (lpszMarker)
+              ToXMLStringTool::toXMLUnSafe(&lpszMarker[nResult], pChild);
+            nResult += cb;
+          }
+        }
+        break;
+      }
+
+      // Clear type nodes
+      case eNodeClear: {
+        XMLClear *pChild = pEntry->pClear + (j >> 2);
+        // "OpenTag"
+        cb = (int)LENSTR(pChild->lpszOpenTag);
+        if (cb) {
+          if (nFormat != -1) {
+            if (lpszMarker) {
+              charmemset(&lpszMarker[nResult], INDENTCHAR, nFormat + 1);
+              xstrcpy(&lpszMarker[nResult + nFormat + 1], pChild->lpszOpenTag);
+            }
+            nResult += cb + nFormat + 1;
+          } else {
+            if (lpszMarker) xstrcpy(&lpszMarker[nResult], pChild->lpszOpenTag);
+            nResult += cb;
+          }
         }
 
-        if (pEntry->isDeclaration)
-        {
-            if (lpszMarker)
-            {
-                lpszMarker[nResult-1]=_CXML('?');
-                lpszMarker[nResult]=_CXML('>');
-            }
-            nResult++;
-            if (nFormat!=-1)
-            {
-                if (lpszMarker) lpszMarker[nResult]=_CXML('\n');
-                nResult++;
-            }
-        } else
-            // If there are child nodes we need to terminate the start tag
-            if (nElementI)
-            {
-                if (lpszMarker) lpszMarker[nResult-1]=_CXML('>');
-                if (nFormat>=0)
-                {
-                    if (lpszMarker) lpszMarker[nResult]=_CXML('\n');
-                    nResult++;
-                }
-            } else nResult--;
-    }
-
-    // Calculate the child format for when we recurse.  This is used to
-    // determine the number of spaces used for prefixes.
-    if (nFormat!=-1)
-    {
-        if (cbElement&&(!pEntry->isDeclaration)) nChildFormat=nFormat+1;
-        else nChildFormat=nFormat;
-    }
-
-    // Enumerate through remaining children
-    for (i=0; i<nElementI; i++)
-    {
-        j=pEntry->pOrder[i];
-        switch((XMLElementType)(j&3))
-        {
-        // Text nodes
-        case eNodeText:
-            {
-                // "Text"
-                XMLCSTR pChild=pEntry->pText[j>>2];
-                cb = (int)ToXMLStringTool::lengthXMLString(pChild);
-                if (cb)
-                {
-                    if (nFormat>=0)
-                    {
-                        if (lpszMarker)
-                        {
-                            charmemset(&lpszMarker[nResult],INDENTCHAR,nFormat+1);
-                            ToXMLStringTool::toXMLUnSafe(&lpszMarker[nResult+nFormat+1],pChild);
-                            lpszMarker[nResult+nFormat+1+cb]=_CXML('\n');
-                        }
-                        nResult+=cb+nFormat+2;
-                    } else
-                    {
-                        if (lpszMarker) ToXMLStringTool::toXMLUnSafe(&lpszMarker[nResult], pChild);
-                        nResult += cb;
-                    }
-                }
-                break;
-            }
-
-        // Clear type nodes
-        case eNodeClear:
-            {
-                XMLClear *pChild=pEntry->pClear+(j>>2);
-                // "OpenTag"
-                cb = (int)LENSTR(pChild->lpszOpenTag);
-                if (cb)
-                {
-                    if (nFormat!=-1)
-                    {
-                        if (lpszMarker)
-                        {
-                            charmemset(&lpszMarker[nResult], INDENTCHAR, nFormat+1);
-                            xstrcpy(&lpszMarker[nResult+nFormat+1], pChild->lpszOpenTag);
-                        }
-                        nResult+=cb+nFormat+1;
-                    }
-                    else
-                    {
-                        if (lpszMarker)xstrcpy(&lpszMarker[nResult], pChild->lpszOpenTag);
-                        nResult += cb;
-                    }
-                }
-
-                // "OpenTag Value"
-                cb = (int)LENSTR(pChild->lpszValue);
-                if (cb)
-                {
-                    if (lpszMarker) xstrcpy(&lpszMarker[nResult], pChild->lpszValue);
-                    nResult += cb;
-                }
-
-                // "OpenTag Value CloseTag"
-                cb = (int)LENSTR(pChild->lpszCloseTag);
-                if (cb)
-                {
-                    if (lpszMarker) xstrcpy(&lpszMarker[nResult], pChild->lpszCloseTag);
-                    nResult += cb;
-                }
-
-                if (nFormat!=-1)
-                {
-                    if (lpszMarker) lpszMarker[nResult] = _CXML('\n');
-                    nResult++;
-                }
-                break;
-            }
-
-        // Element nodes
-        case eNodeChild:
-            {
-                // Recursively add child nodes
-                nResult += CreateXMLStringR(pEntry->pChild[j>>2].d, lpszMarker ? lpszMarker + nResult : 0, nChildFormat);
-                break;
-            }
-        default: break;
+        // "OpenTag Value"
+        cb = (int)LENSTR(pChild->lpszValue);
+        if (cb) {
+          if (lpszMarker) xstrcpy(&lpszMarker[nResult], pChild->lpszValue);
+          nResult += cb;
         }
-    }
 
-    if ((cbElement)&&(!pEntry->isDeclaration))
-    {
-        // If we have child entries we need to use long XML notation for
-        // closing the element - "<elementname>blah blah blah</elementname>"
-        if (nElementI)
-        {
-            // "</elementname>\0"
-            if (lpszMarker)
-            {
-                if (nFormat >=0)
-                {
-                    charmemset(&lpszMarker[nResult], INDENTCHAR,nFormat);
-                    nResult+=nFormat;
-                }
-
-                lpszMarker[nResult]=_CXML('<'); lpszMarker[nResult+1]=_CXML('/');
-                nResult += 2;
-                xstrcpy(&lpszMarker[nResult], pEntry->lpszName);
-                nResult += cbElement;
-
-                lpszMarker[nResult]=_CXML('>');
-                if (nFormat == -1) nResult++;
-                else
-                {
-                    lpszMarker[nResult+1]=_CXML('\n');
-                    nResult+=2;
-                }
-            } else
-            {
-                if (nFormat>=0) nResult+=cbElement+4+nFormat;
-                else if (nFormat==-1) nResult+=cbElement+3;
-                else nResult+=cbElement+4;
-            }
-        } else
-        {
-            // If there are no children we can use shorthand XML notation -
-            // "<elementname/>"
-            // "/>\0"
-            if (lpszMarker)
-            {
-                lpszMarker[nResult]=_CXML('/'); lpszMarker[nResult+1]=_CXML('>');
-                if (nFormat != -1) lpszMarker[nResult+2]=_CXML('\n');
-            }
-            nResult += nFormat == -1 ? 2 : 3;
+        // "OpenTag Value CloseTag"
+        cb = (int)LENSTR(pChild->lpszCloseTag);
+        if (cb) {
+          if (lpszMarker) xstrcpy(&lpszMarker[nResult], pChild->lpszCloseTag);
+          nResult += cb;
         }
-    }
 
-    return nResult;
+        if (nFormat != -1) {
+          if (lpszMarker) lpszMarker[nResult] = _CXML('\n');
+          nResult++;
+        }
+        break;
+      }
+
+      // Element nodes
+      case eNodeChild: {
+        // Recursively add child nodes
+        nResult += CreateXMLStringR(pEntry->pChild[j >> 2].d,
+                                    lpszMarker ? lpszMarker + nResult : 0,
+                                    nChildFormat);
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  if ((cbElement) && (!pEntry->isDeclaration)) {
+    // If we have child entries we need to use long XML notation for
+    // closing the element - "<elementname>blah blah blah</elementname>"
+    if (nElementI) {
+      // "</elementname>\0"
+      if (lpszMarker) {
+        if (nFormat >= 0) {
+          charmemset(&lpszMarker[nResult], INDENTCHAR, nFormat);
+          nResult += nFormat;
+        }
+
+        lpszMarker[nResult] = _CXML('<');
+        lpszMarker[nResult + 1] = _CXML('/');
+        nResult += 2;
+        xstrcpy(&lpszMarker[nResult], pEntry->lpszName);
+        nResult += cbElement;
+
+        lpszMarker[nResult] = _CXML('>');
+        if (nFormat == -1)
+          nResult++;
+        else {
+          lpszMarker[nResult + 1] = _CXML('\n');
+          nResult += 2;
+        }
+      } else {
+        if (nFormat >= 0)
+          nResult += cbElement + 4 + nFormat;
+        else if (nFormat == -1)
+          nResult += cbElement + 3;
+        else
+          nResult += cbElement + 4;
+      }
+    } else {
+      // If there are no children we can use shorthand XML notation -
+      // "<elementname/>"
+      // "/>\0"
+      if (lpszMarker) {
+        lpszMarker[nResult] = _CXML('/');
+        lpszMarker[nResult + 1] = _CXML('>');
+        if (nFormat != -1) lpszMarker[nResult + 2] = _CXML('\n');
+      }
+      nResult += nFormat == -1 ? 2 : 3;
+    }
+  }
+
+  return nResult;
 }
 
 #undef LENSTR
@@ -2084,638 +2366,832 @@ int XMLNode::CreateXMLStringR(XMLNodeData *pEntry, XMLSTR lpszMarker, int nForma
 //                                        NULL terminator.
 // @return      XMLSTR                  - Allocated XML string, you must free
 //                                        this with free().
-XMLSTR XMLNode::createXMLString(int nFormat, int *pnSize) const
-{
-    if (!d) { if (pnSize) *pnSize=0; return NULL; }
-
-    XMLSTR lpszResult = NULL;
-    int cbStr;
-
-    // Recursively Calculate the size of the XML string
-    if (!dropWhiteSpace) nFormat=0;
-    nFormat = nFormat ? 0 : -1;
-    cbStr = CreateXMLStringR(d, 0, nFormat);
-    // Alllocate memory for the XML string + the NULL terminator and
-    // create the recursively XML string.
-    lpszResult=(XMLSTR)malloc((cbStr+1)*sizeof(XMLCHAR));
-    CreateXMLStringR(d, lpszResult, nFormat);
-    lpszResult[cbStr]=_CXML('\0');
-    if (pnSize) *pnSize = cbStr;
-    return lpszResult;
-}
-
-int XMLNode::detachFromParent(XMLNodeData *d)
-{
-    XMLNode *pa=d->pParent->pChild;
-    int i=0;
-    while (((void*)(pa[i].d))!=((void*)d)) i++;
-    d->pParent->nChild--;
-    if (d->pParent->nChild) memmove(pa+i,pa+i+1,(d->pParent->nChild-i)*sizeof(XMLNode));
-    else { free(pa); d->pParent->pChild=NULL; }
-    return removeOrderElement(d->pParent,eNodeChild,i);
-}
-
-XMLNode::~XMLNode()
-{
-    if (!d) return;
-    d->ref_count--;
-    emptyTheNode(0);
-}
-void XMLNode::deleteNodeContent()
-{
-    if (!d) return;
-    if (d->pParent) { detachFromParent(d); d->pParent=NULL; d->ref_count--; }
-    emptyTheNode(1);
-}
-void XMLNode::emptyTheNode(char force)
-{
-    XMLNodeData *dd=d; // warning: must stay this way!
-    if ((dd->ref_count==0)||force)
-    {
-        if (d->pParent) detachFromParent(d);
-        int i;
-        XMLNode *pc;
-        for(i=0; i<dd->nChild; i++)
-        {
-            pc=dd->pChild+i;
-            pc->d->pParent=NULL;
-            pc->d->ref_count--;
-            pc->emptyTheNode(force);
-        }
-        myFree(dd->pChild);
-        for(i=0; i<dd->nText; i++) free((void*)dd->pText[i]);
-        myFree(dd->pText);
-        for(i=0; i<dd->nClear; i++) free((void*)dd->pClear[i].lpszValue);
-        myFree(dd->pClear);
-        for(i=0; i<dd->nAttribute; i++)
-        {
-            free((void*)dd->pAttribute[i].lpszName);
-            if (dd->pAttribute[i].lpszValue) free((void*)dd->pAttribute[i].lpszValue);
-        }
-        myFree(dd->pAttribute);
-        myFree(dd->pOrder);
-        myFree((void*)dd->lpszName);
-        dd->nChild=0;    dd->nText=0;    dd->nClear=0;    dd->nAttribute=0;
-        dd->pChild=NULL; dd->pText=NULL; dd->pClear=NULL; dd->pAttribute=NULL;
-        dd->pOrder=NULL; dd->lpszName=NULL; dd->pParent=NULL;
-    }
-    if (dd->ref_count==0)
-    {
-        free(dd);
-        d=NULL;
-    }
-}
-
-XMLNode& XMLNode::operator=( const XMLNode& A )
-{
-    // shallow copy
-    if (this != &A)
-    {
-        if (d) { d->ref_count--; emptyTheNode(0); }
-        d=A.d;
-        if (d) (d->ref_count) ++ ;
-    }
-    return *this;
-}
-
-XMLNode::XMLNode(const XMLNode &A)
-{
-    // shallow copy
-    d=A.d;
-    if (d) (d->ref_count)++ ;
-}
-
-XMLNode XMLNode::deepCopy() const
-{
-    if (!d) return XMLNode::emptyXMLNode;
-    XMLNode x(NULL,stringDup(d->lpszName),d->isDeclaration);
-    XMLNodeData *p=x.d;
-    int n=d->nAttribute;
-    if (n)
-    {
-        p->nAttribute=n; p->pAttribute=(XMLAttribute*)malloc(n*sizeof(XMLAttribute));
-        while (n--)
-        {
-            p->pAttribute[n].lpszName=stringDup(d->pAttribute[n].lpszName);
-            p->pAttribute[n].lpszValue=stringDup(d->pAttribute[n].lpszValue);
-        }
-    }
-    if (d->pOrder)
-    {
-        n=(d->nChild+d->nText+d->nClear)*sizeof(int); p->pOrder=(int*)malloc(n); memcpy(p->pOrder,d->pOrder,n);
-    }
-    n=d->nText;
-    if (n)
-    {
-        p->nText=n; p->pText=(XMLCSTR*)malloc(n*sizeof(XMLCSTR));
-        while(n--) p->pText[n]=stringDup(d->pText[n]);
-    }
-    n=d->nClear;
-    if (n)
-    {
-        p->nClear=n; p->pClear=(XMLClear*)malloc(n*sizeof(XMLClear));
-        while (n--)
-        {
-            p->pClear[n].lpszCloseTag=d->pClear[n].lpszCloseTag;
-            p->pClear[n].lpszOpenTag=d->pClear[n].lpszOpenTag;
-            p->pClear[n].lpszValue=stringDup(d->pClear[n].lpszValue);
-        }
-    }
-    n=d->nChild;
-    if (n)
-    {
-        p->nChild=n; p->pChild=(XMLNode*)malloc(n*sizeof(XMLNode));
-        while (n--)
-        {
-            p->pChild[n].d=NULL;
-            p->pChild[n]=d->pChild[n].deepCopy();
-            p->pChild[n].d->pParent=p;
-        }
-    }
-    return x;
-}
-
-XMLNode XMLNode::addChild(XMLNode childNode, int pos)
-{
-    XMLNodeData *dc=childNode.d;
-    if ((!dc)||(!d)) return childNode;
-    if (!dc->lpszName)
-    {
-        // this is a root node: todo: correct fix
-        int j=pos;
-        while (dc->nChild)
-        {
-            addChild(dc->pChild[0],j);
-            if (pos>=0) j++;
-        }
-        return childNode;
-    }
-    if (dc->pParent) { if ((detachFromParent(dc)<=pos)&&(dc->pParent==d)) pos--; } else dc->ref_count++;
-    dc->pParent=d;
-//     int nc=d->nChild;
-//     d->pChild=(XMLNode*)myRealloc(d->pChild,(nc+1),memoryIncrease,sizeof(XMLNode));
-    d->pChild=(XMLNode*)addToOrder(0,&pos,d->nChild,d->pChild,sizeof(XMLNode),eNodeChild);
-    d->pChild[pos].d=dc;
-    d->nChild++;
-    return childNode;
-}
-
-void XMLNode::deleteAttribute(int i)
-{
-    if ((!d)||(i<0)||(i>=d->nAttribute)) return;
-    d->nAttribute--;
-    XMLAttribute *p=d->pAttribute+i;
-    free((void*)p->lpszName);
-    if (p->lpszValue) free((void*)p->lpszValue);
-    if (d->nAttribute) memmove(p,p+1,(d->nAttribute-i)*sizeof(XMLAttribute)); else { free(p); d->pAttribute=NULL; }
-}
-
-void XMLNode::deleteAttribute(XMLAttribute *a){ if (a) deleteAttribute(a->lpszName); }
-void XMLNode::deleteAttribute(XMLCSTR lpszName)
-{
-    int j=0;
-    getAttribute(lpszName,&j);
-    if (j) deleteAttribute(j-1);
-}
-
-XMLAttribute *XMLNode::updateAttribute_WOSD(XMLSTR lpszNewValue, XMLSTR lpszNewName,int i)
-{
-    if (!d) { if (lpszNewValue) free(lpszNewValue); if (lpszNewName) free(lpszNewName); return NULL; }
-    if (i>=d->nAttribute)
-    {
-        if (lpszNewName) return addAttribute_WOSD(lpszNewName,lpszNewValue);
-        return NULL;
-    }
-    XMLAttribute *p=d->pAttribute+i;
-    if (p->lpszValue&&p->lpszValue!=lpszNewValue) free((void*)p->lpszValue);
-    p->lpszValue=lpszNewValue;
-    if (lpszNewName&&p->lpszName!=lpszNewName) { free((void*)p->lpszName); p->lpszName=lpszNewName; };
-    return p;
-}
-
-XMLAttribute *XMLNode::updateAttribute_WOSD(XMLAttribute *newAttribute, XMLAttribute *oldAttribute)
-{
-    if (oldAttribute) return updateAttribute_WOSD((XMLSTR)newAttribute->lpszValue,(XMLSTR)newAttribute->lpszName,oldAttribute->lpszName);
-    return addAttribute_WOSD((XMLSTR)newAttribute->lpszName,(XMLSTR)newAttribute->lpszValue);
-}
-
-XMLAttribute *XMLNode::updateAttribute_WOSD(XMLSTR lpszNewValue, XMLSTR lpszNewName,XMLCSTR lpszOldName)
-{
-    int j=0;
-    getAttribute(lpszOldName,&j);
-    if (j) return updateAttribute_WOSD(lpszNewValue,lpszNewName,j-1);
-    else
-    {
-        if (lpszNewName) return addAttribute_WOSD(lpszNewName,lpszNewValue);
-        else             return addAttribute_WOSD(stringDup(lpszOldName),lpszNewValue);
-    }
-}
-
-int XMLNode::indexText(XMLCSTR lpszValue) const
-{
-    if (!d) return -1;
-    int i,l=d->nText;
-    if (!lpszValue) { if (l) return 0; return -1; }
-    XMLCSTR *p=d->pText;
-    for (i=0; i<l; i++) if (lpszValue==p[i]) return i;
-    return -1;
-}
-
-void XMLNode::deleteText(int i)
-{
-    if ((!d)||(i<0)||(i>=d->nText)) return;
-    d->nText--;
-    XMLCSTR *p=d->pText+i;
-    free((void*)*p);
-    if (d->nText) memmove(p,p+1,(d->nText-i)*sizeof(XMLCSTR)); else { free(p); d->pText=NULL; }
-    removeOrderElement(d,eNodeText,i);
-}
-
-void XMLNode::deleteText(XMLCSTR lpszValue) { deleteText(indexText(lpszValue)); }
-
-XMLCSTR XMLNode::updateText_WOSD(XMLSTR lpszNewValue, int i)
-{
-    if (!d) { if (lpszNewValue) free(lpszNewValue); return NULL; }
-    if (i>=d->nText) return addText_WOSD(lpszNewValue);
-    XMLCSTR *p=d->pText+i;
-    if (*p!=lpszNewValue) { free((void*)*p); *p=lpszNewValue; }
-    return lpszNewValue;
-}
-
-XMLCSTR XMLNode::updateText_WOSD(XMLSTR lpszNewValue, XMLCSTR lpszOldValue)
-{
-    if (!d) { if (lpszNewValue) free(lpszNewValue); return NULL; }
-    int i=indexText(lpszOldValue);
-    if (i>=0) return updateText_WOSD(lpszNewValue,i);
-    return addText_WOSD(lpszNewValue);
-}
-
-void XMLNode::deleteClear(int i)
-{
-    if ((!d)||(i<0)||(i>=d->nClear)) return;
-    d->nClear--;
-    XMLClear *p=d->pClear+i;
-    free((void*)p->lpszValue);
-    if (d->nClear) memmove(p,p+1,(d->nClear-i)*sizeof(XMLClear)); else { free(p); d->pClear=NULL; }
-    removeOrderElement(d,eNodeClear,i);
-}
-
-int XMLNode::indexClear(XMLCSTR lpszValue) const
-{
-    if (!d) return -1;
-    int i,l=d->nClear;
-    if (!lpszValue) { if (l) return 0; return -1; }
-    XMLClear *p=d->pClear;
-    for (i=0; i<l; i++) if (lpszValue==p[i].lpszValue) return i;
-    return -1;
-}
-
-void XMLNode::deleteClear(XMLCSTR lpszValue) { deleteClear(indexClear(lpszValue)); }
-void XMLNode::deleteClear(XMLClear *a) { if (a) deleteClear(a->lpszValue); }
-
-XMLClear *XMLNode::updateClear_WOSD(XMLSTR lpszNewContent, int i)
-{
-    if (!d) { if (lpszNewContent) free(lpszNewContent); return NULL; }
-    if (i>=d->nClear) return addClear_WOSD(lpszNewContent);
-    XMLClear *p=d->pClear+i;
-    if (lpszNewContent!=p->lpszValue) { free((void*)p->lpszValue); p->lpszValue=lpszNewContent; }
-    return p;
-}
-
-XMLClear *XMLNode::updateClear_WOSD(XMLSTR lpszNewContent, XMLCSTR lpszOldValue)
-{
-    if (!d) { if (lpszNewContent) free(lpszNewContent); return NULL; }
-    int i=indexClear(lpszOldValue);
-    if (i>=0) return updateClear_WOSD(lpszNewContent,i);
-    return addClear_WOSD(lpszNewContent);
-}
-
-XMLClear *XMLNode::updateClear_WOSD(XMLClear *newP,XMLClear *oldP)
-{
-    if (oldP) return updateClear_WOSD((XMLSTR)newP->lpszValue,(XMLSTR)oldP->lpszValue);
+XMLSTR XMLNode::createXMLString(int nFormat, int *pnSize) const {
+  if (!d) {
+    if (pnSize) *pnSize = 0;
     return NULL;
+  }
+
+  XMLSTR lpszResult = NULL;
+  int cbStr;
+
+  // Recursively Calculate the size of the XML string
+  if (!dropWhiteSpace) nFormat = 0;
+  nFormat = nFormat ? 0 : -1;
+  cbStr = CreateXMLStringR(d, 0, nFormat);
+  // Alllocate memory for the XML string + the NULL terminator and
+  // create the recursively XML string.
+  lpszResult = (XMLSTR)malloc((cbStr + 1) * sizeof(XMLCHAR));
+  CreateXMLStringR(d, lpszResult, nFormat);
+  lpszResult[cbStr] = _CXML('\0');
+  if (pnSize) *pnSize = cbStr;
+  return lpszResult;
 }
 
-int XMLNode::nChildNode(XMLCSTR name) const
-{
-    if (!d) return 0;
-    int i,j=0,n=d->nChild;
-    XMLNode *pc=d->pChild;
-    for (i=0; i<n; i++)
-    {
-        if (xstricmp(pc->d->lpszName, name)==0) j++;
-        pc++;
+int XMLNode::detachFromParent(XMLNodeData *d) {
+  XMLNode *pa = d->pParent->pChild;
+  int i = 0;
+  while (((void *)(pa[i].d)) != ((void *)d)) i++;
+  d->pParent->nChild--;
+  if (d->pParent->nChild)
+    memmove(pa + i, pa + i + 1, (d->pParent->nChild - i) * sizeof(XMLNode));
+  else {
+    free(pa);
+    d->pParent->pChild = NULL;
+  }
+  return removeOrderElement(d->pParent, eNodeChild, i);
+}
+
+XMLNode::~XMLNode() {
+  if (!d) return;
+  d->ref_count--;
+  emptyTheNode(0);
+}
+void XMLNode::deleteNodeContent() {
+  if (!d) return;
+  if (d->pParent) {
+    detachFromParent(d);
+    d->pParent = NULL;
+    d->ref_count--;
+  }
+  emptyTheNode(1);
+}
+void XMLNode::emptyTheNode(char force) {
+  XMLNodeData *dd = d;  // warning: must stay this way!
+  if ((dd->ref_count == 0) || force) {
+    if (d->pParent) detachFromParent(d);
+    int i;
+    XMLNode *pc;
+    for (i = 0; i < dd->nChild; i++) {
+      pc = dd->pChild + i;
+      pc->d->pParent = NULL;
+      pc->d->ref_count--;
+      pc->emptyTheNode(force);
     }
-    return j;
-}
-
-XMLNode XMLNode::getChildNode(XMLCSTR name, int *j) const
-{
-    if (!d) return emptyXMLNode;
-    int i=0,n=d->nChild;
-    if (j) i=*j;
-    XMLNode *pc=d->pChild+i;
-    for (; i<n; i++)
-    {
-        if (!xstricmp(pc->d->lpszName, name))
-        {
-            if (j) *j=i+1;
-            return *pc;
-        }
-        pc++;
+    myFree(dd->pChild);
+    for (i = 0; i < dd->nText; i++) free((void *)dd->pText[i]);
+    myFree(dd->pText);
+    for (i = 0; i < dd->nClear; i++) free((void *)dd->pClear[i].lpszValue);
+    myFree(dd->pClear);
+    for (i = 0; i < dd->nAttribute; i++) {
+      free((void *)dd->pAttribute[i].lpszName);
+      if (dd->pAttribute[i].lpszValue)
+        free((void *)dd->pAttribute[i].lpszValue);
     }
-    return emptyXMLNode;
+    myFree(dd->pAttribute);
+    myFree(dd->pOrder);
+    myFree((void *)dd->lpszName);
+    dd->nChild = 0;
+    dd->nText = 0;
+    dd->nClear = 0;
+    dd->nAttribute = 0;
+    dd->pChild = NULL;
+    dd->pText = NULL;
+    dd->pClear = NULL;
+    dd->pAttribute = NULL;
+    dd->pOrder = NULL;
+    dd->lpszName = NULL;
+    dd->pParent = NULL;
+  }
+  if (dd->ref_count == 0) {
+    free(dd);
+    d = NULL;
+  }
 }
 
-XMLNode XMLNode::getChildNode(XMLCSTR name, int j) const
-{
-    if (!d) return emptyXMLNode;
-    if (j>=0)
-    {
-        int i=0;
-        while (j-->0) getChildNode(name,&i);
-        return getChildNode(name,&i);
+XMLNode &XMLNode::operator=(const XMLNode &A) {
+  // shallow copy
+  if (this != &A) {
+    if (d) {
+      d->ref_count--;
+      emptyTheNode(0);
     }
-    int i=d->nChild;
-    while (i--) if (!xstricmp(name,d->pChild[i].d->lpszName)) break;
-    if (i<0) return emptyXMLNode;
-    return getChildNode(i);
+    d = A.d;
+    if (d) (d->ref_count)++;
+  }
+  return *this;
 }
 
-XMLNode XMLNode::getChildNodeByPath(XMLCSTR _path, char createMissing, XMLCHAR sep)
-{
-    XMLSTR path=stringDup(_path);
-    XMLNode x=getChildNodeByPathNonConst(path,createMissing,sep);
-    if (path) free(path);
-    return x;
+XMLNode::XMLNode(const XMLNode &A) {
+  // shallow copy
+  d = A.d;
+  if (d) (d->ref_count)++;
 }
 
-XMLNode XMLNode::getChildNodeByPathNonConst(XMLSTR path, char createIfMissing, XMLCHAR sep)
-{
-    if ((!path)||(!(*path))) return *this;
-    XMLNode xn,xbase=*this;
-    XMLCHAR *tend1,sepString[2]; sepString[0]=sep; sepString[1]=0;
-    tend1=xstrstr(path,sepString);
-    while(tend1)
-    {
-        *tend1=0;
-        xn=xbase.getChildNode(path);
-        if (xn.isEmpty())
-        {
-            if (createIfMissing) xn=xbase.addChild(path);
-            else { *tend1=sep; return XMLNode::emptyXMLNode; }
-        }
-        *tend1=sep;
-        xbase=xn;
-        path=tend1+1;
-        tend1=xstrstr(path,sepString);
+XMLNode XMLNode::deepCopy() const {
+  if (!d) return XMLNode::emptyXMLNode;
+  XMLNode x(NULL, stringDup(d->lpszName), d->isDeclaration);
+  XMLNodeData *p = x.d;
+  int n = d->nAttribute;
+  if (n) {
+    p->nAttribute = n;
+    p->pAttribute = (XMLAttribute *)malloc(n * sizeof(XMLAttribute));
+    while (n--) {
+      p->pAttribute[n].lpszName = stringDup(d->pAttribute[n].lpszName);
+      p->pAttribute[n].lpszValue = stringDup(d->pAttribute[n].lpszValue);
     }
-    xn=xbase.getChildNode(path);
-    if (xn.isEmpty()&&createIfMissing) xn=xbase.addChild(path);
-    return xn;
+  }
+  if (d->pOrder) {
+    n = (d->nChild + d->nText + d->nClear) * sizeof(int);
+    p->pOrder = (int *)malloc(n);
+    memcpy(p->pOrder, d->pOrder, n);
+  }
+  n = d->nText;
+  if (n) {
+    p->nText = n;
+    p->pText = (XMLCSTR *)malloc(n * sizeof(XMLCSTR));
+    while (n--) p->pText[n] = stringDup(d->pText[n]);
+  }
+  n = d->nClear;
+  if (n) {
+    p->nClear = n;
+    p->pClear = (XMLClear *)malloc(n * sizeof(XMLClear));
+    while (n--) {
+      p->pClear[n].lpszCloseTag = d->pClear[n].lpszCloseTag;
+      p->pClear[n].lpszOpenTag = d->pClear[n].lpszOpenTag;
+      p->pClear[n].lpszValue = stringDup(d->pClear[n].lpszValue);
+    }
+  }
+  n = d->nChild;
+  if (n) {
+    p->nChild = n;
+    p->pChild = (XMLNode *)malloc(n * sizeof(XMLNode));
+    while (n--) {
+      p->pChild[n].d = NULL;
+      p->pChild[n] = d->pChild[n].deepCopy();
+      p->pChild[n].d->pParent = p;
+    }
+  }
+  return x;
 }
 
-XMLElementPosition XMLNode::positionOfText     (int i) const { if (i>=d->nText ) i=d->nText-1;  return findPosition(d,i,eNodeText ); }
-XMLElementPosition XMLNode::positionOfClear    (int i) const { if (i>=d->nClear) i=d->nClear-1; return findPosition(d,i,eNodeClear); }
-XMLElementPosition XMLNode::positionOfChildNode(int i) const { if (i>=d->nChild) i=d->nChild-1; return findPosition(d,i,eNodeChild); }
-XMLElementPosition XMLNode::positionOfText (XMLCSTR lpszValue) const { return positionOfText (indexText (lpszValue)); }
-XMLElementPosition XMLNode::positionOfClear(XMLCSTR lpszValue) const { return positionOfClear(indexClear(lpszValue)); }
-XMLElementPosition XMLNode::positionOfClear(XMLClear *a) const { if (a) return positionOfClear(a->lpszValue); return positionOfClear(); }
-XMLElementPosition XMLNode::positionOfChildNode(XMLNode x)  const
-{
-    if ((!d)||(!x.d)) return -1;
-    XMLNodeData *dd=x.d;
-    XMLNode *pc=d->pChild;
-    int i=d->nChild;
-    while (i--) if (pc[i].d==dd) return findPosition(d,i,eNodeChild);
+XMLNode XMLNode::addChild(XMLNode childNode, int pos) {
+  XMLNodeData *dc = childNode.d;
+  if ((!dc) || (!d)) return childNode;
+  if (!dc->lpszName) {
+    // this is a root node: todo: correct fix
+    int j = pos;
+    while (dc->nChild) {
+      addChild(dc->pChild[0], j);
+      if (pos >= 0) j++;
+    }
+    return childNode;
+  }
+  if (dc->pParent) {
+    if ((detachFromParent(dc) <= pos) && (dc->pParent == d)) pos--;
+  } else
+    dc->ref_count++;
+  dc->pParent = d;
+  //     int nc=d->nChild;
+  //     d->pChild=(XMLNode*)myRealloc(d->pChild,(nc+1),memoryIncrease,sizeof(XMLNode));
+  d->pChild = (XMLNode *)addToOrder(0, &pos, d->nChild, d->pChild,
+                                    sizeof(XMLNode), eNodeChild);
+  d->pChild[pos].d = dc;
+  d->nChild++;
+  return childNode;
+}
+
+void XMLNode::deleteAttribute(int i) {
+  if ((!d) || (i < 0) || (i >= d->nAttribute)) return;
+  d->nAttribute--;
+  XMLAttribute *p = d->pAttribute + i;
+  free((void *)p->lpszName);
+  if (p->lpszValue) free((void *)p->lpszValue);
+  if (d->nAttribute)
+    memmove(p, p + 1, (d->nAttribute - i) * sizeof(XMLAttribute));
+  else {
+    free(p);
+    d->pAttribute = NULL;
+  }
+}
+
+void XMLNode::deleteAttribute(XMLAttribute *a) {
+  if (a) deleteAttribute(a->lpszName);
+}
+void XMLNode::deleteAttribute(XMLCSTR lpszName) {
+  int j = 0;
+  getAttribute(lpszName, &j);
+  if (j) deleteAttribute(j - 1);
+}
+
+XMLAttribute *XMLNode::updateAttribute_WOSD(XMLSTR lpszNewValue,
+                                            XMLSTR lpszNewName, int i) {
+  if (!d) {
+    if (lpszNewValue) free(lpszNewValue);
+    if (lpszNewName) free(lpszNewName);
+    return NULL;
+  }
+  if (i >= d->nAttribute) {
+    if (lpszNewName) return addAttribute_WOSD(lpszNewName, lpszNewValue);
+    return NULL;
+  }
+  XMLAttribute *p = d->pAttribute + i;
+  if (p->lpszValue && p->lpszValue != lpszNewValue) free((void *)p->lpszValue);
+  p->lpszValue = lpszNewValue;
+  if (lpszNewName && p->lpszName != lpszNewName) {
+    free((void *)p->lpszName);
+    p->lpszName = lpszNewName;
+  };
+  return p;
+}
+
+XMLAttribute *XMLNode::updateAttribute_WOSD(XMLAttribute *newAttribute,
+                                            XMLAttribute *oldAttribute) {
+  if (oldAttribute)
+    return updateAttribute_WOSD((XMLSTR)newAttribute->lpszValue,
+                                (XMLSTR)newAttribute->lpszName,
+                                oldAttribute->lpszName);
+  return addAttribute_WOSD((XMLSTR)newAttribute->lpszName,
+                           (XMLSTR)newAttribute->lpszValue);
+}
+
+XMLAttribute *XMLNode::updateAttribute_WOSD(XMLSTR lpszNewValue,
+                                            XMLSTR lpszNewName,
+                                            XMLCSTR lpszOldName) {
+  int j = 0;
+  getAttribute(lpszOldName, &j);
+  if (j)
+    return updateAttribute_WOSD(lpszNewValue, lpszNewName, j - 1);
+  else {
+    if (lpszNewName)
+      return addAttribute_WOSD(lpszNewName, lpszNewValue);
+    else
+      return addAttribute_WOSD(stringDup(lpszOldName), lpszNewValue);
+  }
+}
+
+int XMLNode::indexText(XMLCSTR lpszValue) const {
+  if (!d) return -1;
+  int i, l = d->nText;
+  if (!lpszValue) {
+    if (l) return 0;
     return -1;
-}
-XMLElementPosition XMLNode::positionOfChildNode(XMLCSTR name, int count) const
-{
-    if (!name) return positionOfChildNode(count);
-    int j=0;
-    do { getChildNode(name,&j); if (j<0) return -1; } while (count--);
-    return findPosition(d,j-1,eNodeChild);
+  }
+  XMLCSTR *p = d->pText;
+  for (i = 0; i < l; i++)
+    if (lpszValue == p[i]) return i;
+  return -1;
 }
 
-XMLNode XMLNode::getChildNodeWithAttribute(XMLCSTR name,XMLCSTR attributeName,XMLCSTR attributeValue, int *k) const
-{
-     int i=0,j;
-     if (k) i=*k;
-     XMLNode x;
-     XMLCSTR t;
-     do
-     {
-         x=getChildNode(name,&i);
-         if (!x.isEmpty())
-         {
-             if (attributeValue)
-             {
-                 j=0;
-                 do
-                 {
-                     t=x.getAttribute(attributeName,&j);
-                     if (t&&(xstricmp(attributeValue,t)==0)) { if (k) *k=i; return x; }
-                 } while (t);
-             } else
-             {
-                 if (x.isAttributeSet(attributeName)) { if (k) *k=i; return x; }
-             }
-         }
-     } while (!x.isEmpty());
-     return emptyXMLNode;
+void XMLNode::deleteText(int i) {
+  if ((!d) || (i < 0) || (i >= d->nText)) return;
+  d->nText--;
+  XMLCSTR *p = d->pText + i;
+  free((void *)*p);
+  if (d->nText)
+    memmove(p, p + 1, (d->nText - i) * sizeof(XMLCSTR));
+  else {
+    free(p);
+    d->pText = NULL;
+  }
+  removeOrderElement(d, eNodeText, i);
+}
+
+void XMLNode::deleteText(XMLCSTR lpszValue) {
+  deleteText(indexText(lpszValue));
+}
+
+XMLCSTR XMLNode::updateText_WOSD(XMLSTR lpszNewValue, int i) {
+  if (!d) {
+    if (lpszNewValue) free(lpszNewValue);
+    return NULL;
+  }
+  if (i >= d->nText) return addText_WOSD(lpszNewValue);
+  XMLCSTR *p = d->pText + i;
+  if (*p != lpszNewValue) {
+    free((void *)*p);
+    *p = lpszNewValue;
+  }
+  return lpszNewValue;
+}
+
+XMLCSTR XMLNode::updateText_WOSD(XMLSTR lpszNewValue, XMLCSTR lpszOldValue) {
+  if (!d) {
+    if (lpszNewValue) free(lpszNewValue);
+    return NULL;
+  }
+  int i = indexText(lpszOldValue);
+  if (i >= 0) return updateText_WOSD(lpszNewValue, i);
+  return addText_WOSD(lpszNewValue);
+}
+
+void XMLNode::deleteClear(int i) {
+  if ((!d) || (i < 0) || (i >= d->nClear)) return;
+  d->nClear--;
+  XMLClear *p = d->pClear + i;
+  free((void *)p->lpszValue);
+  if (d->nClear)
+    memmove(p, p + 1, (d->nClear - i) * sizeof(XMLClear));
+  else {
+    free(p);
+    d->pClear = NULL;
+  }
+  removeOrderElement(d, eNodeClear, i);
+}
+
+int XMLNode::indexClear(XMLCSTR lpszValue) const {
+  if (!d) return -1;
+  int i, l = d->nClear;
+  if (!lpszValue) {
+    if (l) return 0;
+    return -1;
+  }
+  XMLClear *p = d->pClear;
+  for (i = 0; i < l; i++)
+    if (lpszValue == p[i].lpszValue) return i;
+  return -1;
+}
+
+void XMLNode::deleteClear(XMLCSTR lpszValue) {
+  deleteClear(indexClear(lpszValue));
+}
+void XMLNode::deleteClear(XMLClear *a) {
+  if (a) deleteClear(a->lpszValue);
+}
+
+XMLClear *XMLNode::updateClear_WOSD(XMLSTR lpszNewContent, int i) {
+  if (!d) {
+    if (lpszNewContent) free(lpszNewContent);
+    return NULL;
+  }
+  if (i >= d->nClear) return addClear_WOSD(lpszNewContent);
+  XMLClear *p = d->pClear + i;
+  if (lpszNewContent != p->lpszValue) {
+    free((void *)p->lpszValue);
+    p->lpszValue = lpszNewContent;
+  }
+  return p;
+}
+
+XMLClear *XMLNode::updateClear_WOSD(XMLSTR lpszNewContent,
+                                    XMLCSTR lpszOldValue) {
+  if (!d) {
+    if (lpszNewContent) free(lpszNewContent);
+    return NULL;
+  }
+  int i = indexClear(lpszOldValue);
+  if (i >= 0) return updateClear_WOSD(lpszNewContent, i);
+  return addClear_WOSD(lpszNewContent);
+}
+
+XMLClear *XMLNode::updateClear_WOSD(XMLClear *newP, XMLClear *oldP) {
+  if (oldP)
+    return updateClear_WOSD((XMLSTR)newP->lpszValue, (XMLSTR)oldP->lpszValue);
+  return NULL;
+}
+
+int XMLNode::nChildNode(XMLCSTR name) const {
+  if (!d) return 0;
+  int i, j = 0, n = d->nChild;
+  XMLNode *pc = d->pChild;
+  for (i = 0; i < n; i++) {
+    if (xstricmp(pc->d->lpszName, name) == 0) j++;
+    pc++;
+  }
+  return j;
+}
+
+XMLNode XMLNode::getChildNode(XMLCSTR name, int *j) const {
+  if (!d) return emptyXMLNode;
+  int i = 0, n = d->nChild;
+  if (j) i = *j;
+  XMLNode *pc = d->pChild + i;
+  for (; i < n; i++) {
+    if (!xstricmp(pc->d->lpszName, name)) {
+      if (j) *j = i + 1;
+      return *pc;
+    }
+    pc++;
+  }
+  return emptyXMLNode;
+}
+
+XMLNode XMLNode::getChildNode(XMLCSTR name, int j) const {
+  if (!d) return emptyXMLNode;
+  if (j >= 0) {
+    int i = 0;
+    while (j-- > 0) getChildNode(name, &i);
+    return getChildNode(name, &i);
+  }
+  int i = d->nChild;
+  while (i--)
+    if (!xstricmp(name, d->pChild[i].d->lpszName)) break;
+  if (i < 0) return emptyXMLNode;
+  return getChildNode(i);
+}
+
+XMLNode XMLNode::getChildNodeByPath(XMLCSTR _path, char createMissing,
+                                    XMLCHAR sep) {
+  XMLSTR path = stringDup(_path);
+  XMLNode x = getChildNodeByPathNonConst(path, createMissing, sep);
+  if (path) free(path);
+  return x;
+}
+
+XMLNode XMLNode::getChildNodeByPathNonConst(XMLSTR path, char createIfMissing,
+                                            XMLCHAR sep) {
+  if ((!path) || (!(*path))) return *this;
+  XMLNode xn, xbase = *this;
+  XMLCHAR *tend1, sepString[2];
+  sepString[0] = sep;
+  sepString[1] = 0;
+  tend1 = xstrstr(path, sepString);
+  while (tend1) {
+    *tend1 = 0;
+    xn = xbase.getChildNode(path);
+    if (xn.isEmpty()) {
+      if (createIfMissing)
+        xn = xbase.addChild(path);
+      else {
+        *tend1 = sep;
+        return XMLNode::emptyXMLNode;
+      }
+    }
+    *tend1 = sep;
+    xbase = xn;
+    path = tend1 + 1;
+    tend1 = xstrstr(path, sepString);
+  }
+  xn = xbase.getChildNode(path);
+  if (xn.isEmpty() && createIfMissing) xn = xbase.addChild(path);
+  return xn;
+}
+
+XMLElementPosition XMLNode::positionOfText(int i) const {
+  if (i >= d->nText) i = d->nText - 1;
+  return findPosition(d, i, eNodeText);
+}
+XMLElementPosition XMLNode::positionOfClear(int i) const {
+  if (i >= d->nClear) i = d->nClear - 1;
+  return findPosition(d, i, eNodeClear);
+}
+XMLElementPosition XMLNode::positionOfChildNode(int i) const {
+  if (i >= d->nChild) i = d->nChild - 1;
+  return findPosition(d, i, eNodeChild);
+}
+XMLElementPosition XMLNode::positionOfText(XMLCSTR lpszValue) const {
+  return positionOfText(indexText(lpszValue));
+}
+XMLElementPosition XMLNode::positionOfClear(XMLCSTR lpszValue) const {
+  return positionOfClear(indexClear(lpszValue));
+}
+XMLElementPosition XMLNode::positionOfClear(XMLClear *a) const {
+  if (a) return positionOfClear(a->lpszValue);
+  return positionOfClear();
+}
+XMLElementPosition XMLNode::positionOfChildNode(XMLNode x) const {
+  if ((!d) || (!x.d)) return -1;
+  XMLNodeData *dd = x.d;
+  XMLNode *pc = d->pChild;
+  int i = d->nChild;
+  while (i--)
+    if (pc[i].d == dd) return findPosition(d, i, eNodeChild);
+  return -1;
+}
+XMLElementPosition XMLNode::positionOfChildNode(XMLCSTR name, int count) const {
+  if (!name) return positionOfChildNode(count);
+  int j = 0;
+  do {
+    getChildNode(name, &j);
+    if (j < 0) return -1;
+  } while (count--);
+  return findPosition(d, j - 1, eNodeChild);
+}
+
+XMLNode XMLNode::getChildNodeWithAttribute(XMLCSTR name, XMLCSTR attributeName,
+                                           XMLCSTR attributeValue,
+                                           int *k) const {
+  int i = 0, j;
+  if (k) i = *k;
+  XMLNode x;
+  XMLCSTR t;
+  do {
+    x = getChildNode(name, &i);
+    if (!x.isEmpty()) {
+      if (attributeValue) {
+        j = 0;
+        do {
+          t = x.getAttribute(attributeName, &j);
+          if (t && (xstricmp(attributeValue, t) == 0)) {
+            if (k) *k = i;
+            return x;
+          }
+        } while (t);
+      } else {
+        if (x.isAttributeSet(attributeName)) {
+          if (k) *k = i;
+          return x;
+        }
+      }
+    }
+  } while (!x.isEmpty());
+  return emptyXMLNode;
 }
 
 // Find an attribute on an node.
-XMLCSTR XMLNode::getAttribute(XMLCSTR lpszAttrib, int *j) const
-{
-    if (!d) return NULL;
-    int i=0,n=d->nAttribute;
-    if (j) i=*j;
-    XMLAttribute *pAttr=d->pAttribute+i;
-    for (; i<n; i++)
-    {
-        if (xstricmp(pAttr->lpszName, lpszAttrib)==0)
-        {
-            if (j) *j=i+1;
-            return pAttr->lpszValue;
-        }
-        pAttr++;
+XMLCSTR XMLNode::getAttribute(XMLCSTR lpszAttrib, int *j) const {
+  if (!d) return NULL;
+  int i = 0, n = d->nAttribute;
+  if (j) i = *j;
+  XMLAttribute *pAttr = d->pAttribute + i;
+  for (; i < n; i++) {
+    if (xstricmp(pAttr->lpszName, lpszAttrib) == 0) {
+      if (j) *j = i + 1;
+      return pAttr->lpszValue;
     }
-    return NULL;
+    pAttr++;
+  }
+  return NULL;
 }
 
-char XMLNode::isAttributeSet(XMLCSTR lpszAttrib) const
-{
-    if (!d) return FALSE;
-    int i,n=d->nAttribute;
-    XMLAttribute *pAttr=d->pAttribute;
-    for (i=0; i<n; i++)
-    {
-        if (xstricmp(pAttr->lpszName, lpszAttrib)==0)
-        {
-            return TRUE;
-        }
-        pAttr++;
+char XMLNode::isAttributeSet(XMLCSTR lpszAttrib) const {
+  if (!d) return FALSE;
+  int i, n = d->nAttribute;
+  XMLAttribute *pAttr = d->pAttribute;
+  for (i = 0; i < n; i++) {
+    if (xstricmp(pAttr->lpszName, lpszAttrib) == 0) {
+      return TRUE;
     }
-    return FALSE;
+    pAttr++;
+  }
+  return FALSE;
 }
 
-XMLCSTR XMLNode::getAttribute(XMLCSTR name, int j) const
-{
-    if (!d) return NULL;
-    int i=0;
-    while (j-->0) getAttribute(name,&i);
-    return getAttribute(name,&i);
+XMLCSTR XMLNode::getAttribute(XMLCSTR name, int j) const {
+  if (!d) return NULL;
+  int i = 0;
+  while (j-- > 0) getAttribute(name, &i);
+  return getAttribute(name, &i);
 }
 
-XMLNodeContents XMLNode::enumContents(int i) const
-{
-    XMLNodeContents c;
-    if (!d) { c.etype=eNodeNULL; return c; }
-    if (i<d->nAttribute)
-    {
-        c.etype=eNodeAttribute;
-        c.attrib=d->pAttribute[i];
-        return c;
-    }
-    i-=d->nAttribute;
-    c.etype=(XMLElementType)(d->pOrder[i]&3);
-    i=(d->pOrder[i])>>2;
-    switch (c.etype)
-    {
-    case eNodeChild:     c.child = d->pChild[i];      break;
-    case eNodeText:      c.text  = d->pText[i];       break;
-    case eNodeClear:     c.clear = d->pClear[i];      break;
-    default: break;
-    }
+XMLNodeContents XMLNode::enumContents(int i) const {
+  XMLNodeContents c;
+  if (!d) {
+    c.etype = eNodeNULL;
     return c;
+  }
+  if (i < d->nAttribute) {
+    c.etype = eNodeAttribute;
+    c.attrib = d->pAttribute[i];
+    return c;
+  }
+  i -= d->nAttribute;
+  c.etype = (XMLElementType)(d->pOrder[i] & 3);
+  i = (d->pOrder[i]) >> 2;
+  switch (c.etype) {
+    case eNodeChild:
+      c.child = d->pChild[i];
+      break;
+    case eNodeText:
+      c.text = d->pText[i];
+      break;
+    case eNodeClear:
+      c.clear = d->pClear[i];
+      break;
+    default:
+      break;
+  }
+  return c;
 }
 
-XMLCSTR XMLNode::getName() const { if (!d) return NULL; return d->lpszName;   }
-int XMLNode::nText()       const { if (!d) return 0;    return d->nText;      }
-int XMLNode::nChildNode()  const { if (!d) return 0;    return d->nChild;     }
-int XMLNode::nAttribute()  const { if (!d) return 0;    return d->nAttribute; }
-int XMLNode::nClear()      const { if (!d) return 0;    return d->nClear;     }
-int XMLNode::nElement()    const { if (!d) return 0;    return d->nAttribute+d->nChild+d->nText+d->nClear; }
-XMLClear     XMLNode::getClear         (int i) const { if ((!d)||(i>=d->nClear    )) return emptyXMLClear;     return d->pClear[i];     }
-XMLAttribute XMLNode::getAttribute     (int i) const { if ((!d)||(i>=d->nAttribute)) return emptyXMLAttribute; return d->pAttribute[i]; }
-XMLCSTR      XMLNode::getAttributeName (int i) const { if ((!d)||(i>=d->nAttribute)) return NULL;              return d->pAttribute[i].lpszName;  }
-XMLCSTR      XMLNode::getAttributeValue(int i) const { if ((!d)||(i>=d->nAttribute)) return NULL;              return d->pAttribute[i].lpszValue; }
-XMLCSTR      XMLNode::getText          (int i) const { if ((!d)||(i>=d->nText     )) return NULL;              return d->pText[i];      }
-XMLNode      XMLNode::getChildNode     (int i) const { if ((!d)||(i>=d->nChild    )) return emptyXMLNode;      return d->pChild[i];     }
-XMLNode      XMLNode::getParentNode    (     ) const { if ((!d)||(!d->pParent     )) return emptyXMLNode;      return XMLNode(d->pParent); }
-char         XMLNode::isDeclaration    (     ) const { if (!d) return 0;             return d->isDeclaration; }
-char         XMLNode::isEmpty          (     ) const { return (d==NULL); }
-XMLNode       XMLNode::emptyNode       (     )       { return XMLNode::emptyXMLNode; }
+XMLCSTR XMLNode::getName() const {
+  if (!d) return NULL;
+  return d->lpszName;
+}
+int XMLNode::nText() const {
+  if (!d) return 0;
+  return d->nText;
+}
+int XMLNode::nChildNode() const {
+  if (!d) return 0;
+  return d->nChild;
+}
+int XMLNode::nAttribute() const {
+  if (!d) return 0;
+  return d->nAttribute;
+}
+int XMLNode::nClear() const {
+  if (!d) return 0;
+  return d->nClear;
+}
+int XMLNode::nElement() const {
+  if (!d) return 0;
+  return d->nAttribute + d->nChild + d->nText + d->nClear;
+}
+XMLClear XMLNode::getClear(int i) const {
+  if ((!d) || (i >= d->nClear)) return emptyXMLClear;
+  return d->pClear[i];
+}
+XMLAttribute XMLNode::getAttribute(int i) const {
+  if ((!d) || (i >= d->nAttribute)) return emptyXMLAttribute;
+  return d->pAttribute[i];
+}
+XMLCSTR XMLNode::getAttributeName(int i) const {
+  if ((!d) || (i >= d->nAttribute)) return NULL;
+  return d->pAttribute[i].lpszName;
+}
+XMLCSTR XMLNode::getAttributeValue(int i) const {
+  if ((!d) || (i >= d->nAttribute)) return NULL;
+  return d->pAttribute[i].lpszValue;
+}
+XMLCSTR XMLNode::getText(int i) const {
+  if ((!d) || (i >= d->nText)) return NULL;
+  return d->pText[i];
+}
+XMLNode XMLNode::getChildNode(int i) const {
+  if ((!d) || (i >= d->nChild)) return emptyXMLNode;
+  return d->pChild[i];
+}
+XMLNode XMLNode::getParentNode() const {
+  if ((!d) || (!d->pParent)) return emptyXMLNode;
+  return XMLNode(d->pParent);
+}
+char XMLNode::isDeclaration() const {
+  if (!d) return 0;
+  return d->isDeclaration;
+}
+char XMLNode::isEmpty() const { return (d == NULL); }
+XMLNode XMLNode::emptyNode() { return XMLNode::emptyXMLNode; }
 
-XMLNode       XMLNode::addChild(XMLCSTR lpszName, char isDeclaration, XMLElementPosition pos)
-              { return addChild_priv(0,stringDup(lpszName),isDeclaration,pos); }
-XMLNode       XMLNode::addChild_WOSD(XMLSTR lpszName, char isDeclaration, XMLElementPosition pos)
-              { return addChild_priv(0,lpszName,isDeclaration,pos); }
-XMLAttribute *XMLNode::addAttribute(XMLCSTR lpszName, XMLCSTR lpszValue)
-              { return addAttribute_priv(0,stringDup(lpszName),stringDup(lpszValue)); }
-XMLAttribute *XMLNode::addAttribute_WOSD(XMLSTR lpszName, XMLSTR lpszValuev)
-              { return addAttribute_priv(0,lpszName,lpszValuev); }
-XMLCSTR       XMLNode::addText(XMLCSTR lpszValue, XMLElementPosition pos)
-              { return addText_priv(0,stringDup(lpszValue),pos); }
-XMLCSTR       XMLNode::addText_WOSD(XMLSTR lpszValue, XMLElementPosition pos)
-              { return addText_priv(0,lpszValue,pos); }
-XMLClear     *XMLNode::addClear(XMLCSTR lpszValue, XMLCSTR lpszOpen, XMLCSTR lpszClose, XMLElementPosition pos)
-              { return addClear_priv(0,stringDup(lpszValue),lpszOpen,lpszClose,pos); }
-XMLClear     *XMLNode::addClear_WOSD(XMLSTR lpszValue, XMLCSTR lpszOpen, XMLCSTR lpszClose, XMLElementPosition pos)
-              { return addClear_priv(0,lpszValue,lpszOpen,lpszClose,pos); }
-XMLCSTR       XMLNode::updateName(XMLCSTR lpszName)
-              { return updateName_WOSD(stringDup(lpszName)); }
-XMLAttribute *XMLNode::updateAttribute(XMLAttribute *newAttribute, XMLAttribute *oldAttribute)
-              { return updateAttribute_WOSD(stringDup(newAttribute->lpszValue),stringDup(newAttribute->lpszName),oldAttribute->lpszName); }
-XMLAttribute *XMLNode::updateAttribute(XMLCSTR lpszNewValue, XMLCSTR lpszNewName,int i)
-              { return updateAttribute_WOSD(stringDup(lpszNewValue),stringDup(lpszNewName),i); }
-XMLAttribute *XMLNode::updateAttribute(XMLCSTR lpszNewValue, XMLCSTR lpszNewName,XMLCSTR lpszOldName)
-              { return updateAttribute_WOSD(stringDup(lpszNewValue),stringDup(lpszNewName),lpszOldName); }
-XMLCSTR       XMLNode::updateText(XMLCSTR lpszNewValue, int i)
-              { return updateText_WOSD(stringDup(lpszNewValue),i); }
-XMLCSTR       XMLNode::updateText(XMLCSTR lpszNewValue, XMLCSTR lpszOldValue)
-              { return updateText_WOSD(stringDup(lpszNewValue),lpszOldValue); }
-XMLClear     *XMLNode::updateClear(XMLCSTR lpszNewContent, int i)
-              { return updateClear_WOSD(stringDup(lpszNewContent),i); }
-XMLClear     *XMLNode::updateClear(XMLCSTR lpszNewValue, XMLCSTR lpszOldValue)
-              { return updateClear_WOSD(stringDup(lpszNewValue),lpszOldValue); }
-XMLClear     *XMLNode::updateClear(XMLClear *newP,XMLClear *oldP)
-              { return updateClear_WOSD(stringDup(newP->lpszValue),oldP->lpszValue); }
+XMLNode XMLNode::addChild(XMLCSTR lpszName, char isDeclaration,
+                          XMLElementPosition pos) {
+  return addChild_priv(0, stringDup(lpszName), isDeclaration, pos);
+}
+XMLNode XMLNode::addChild_WOSD(XMLSTR lpszName, char isDeclaration,
+                               XMLElementPosition pos) {
+  return addChild_priv(0, lpszName, isDeclaration, pos);
+}
+XMLAttribute *XMLNode::addAttribute(XMLCSTR lpszName, XMLCSTR lpszValue) {
+  return addAttribute_priv(0, stringDup(lpszName), stringDup(lpszValue));
+}
+XMLAttribute *XMLNode::addAttribute_WOSD(XMLSTR lpszName, XMLSTR lpszValuev) {
+  return addAttribute_priv(0, lpszName, lpszValuev);
+}
+XMLCSTR XMLNode::addText(XMLCSTR lpszValue, XMLElementPosition pos) {
+  return addText_priv(0, stringDup(lpszValue), pos);
+}
+XMLCSTR XMLNode::addText_WOSD(XMLSTR lpszValue, XMLElementPosition pos) {
+  return addText_priv(0, lpszValue, pos);
+}
+XMLClear *XMLNode::addClear(XMLCSTR lpszValue, XMLCSTR lpszOpen,
+                            XMLCSTR lpszClose, XMLElementPosition pos) {
+  return addClear_priv(0, stringDup(lpszValue), lpszOpen, lpszClose, pos);
+}
+XMLClear *XMLNode::addClear_WOSD(XMLSTR lpszValue, XMLCSTR lpszOpen,
+                                 XMLCSTR lpszClose, XMLElementPosition pos) {
+  return addClear_priv(0, lpszValue, lpszOpen, lpszClose, pos);
+}
+XMLCSTR XMLNode::updateName(XMLCSTR lpszName) {
+  return updateName_WOSD(stringDup(lpszName));
+}
+XMLAttribute *XMLNode::updateAttribute(XMLAttribute *newAttribute,
+                                       XMLAttribute *oldAttribute) {
+  return updateAttribute_WOSD(stringDup(newAttribute->lpszValue),
+                              stringDup(newAttribute->lpszName),
+                              oldAttribute->lpszName);
+}
+XMLAttribute *XMLNode::updateAttribute(XMLCSTR lpszNewValue,
+                                       XMLCSTR lpszNewName, int i) {
+  return updateAttribute_WOSD(stringDup(lpszNewValue), stringDup(lpszNewName),
+                              i);
+}
+XMLAttribute *XMLNode::updateAttribute(XMLCSTR lpszNewValue,
+                                       XMLCSTR lpszNewName,
+                                       XMLCSTR lpszOldName) {
+  return updateAttribute_WOSD(stringDup(lpszNewValue), stringDup(lpszNewName),
+                              lpszOldName);
+}
+XMLCSTR XMLNode::updateText(XMLCSTR lpszNewValue, int i) {
+  return updateText_WOSD(stringDup(lpszNewValue), i);
+}
+XMLCSTR XMLNode::updateText(XMLCSTR lpszNewValue, XMLCSTR lpszOldValue) {
+  return updateText_WOSD(stringDup(lpszNewValue), lpszOldValue);
+}
+XMLClear *XMLNode::updateClear(XMLCSTR lpszNewContent, int i) {
+  return updateClear_WOSD(stringDup(lpszNewContent), i);
+}
+XMLClear *XMLNode::updateClear(XMLCSTR lpszNewValue, XMLCSTR lpszOldValue) {
+  return updateClear_WOSD(stringDup(lpszNewValue), lpszOldValue);
+}
+XMLClear *XMLNode::updateClear(XMLClear *newP, XMLClear *oldP) {
+  return updateClear_WOSD(stringDup(newP->lpszValue), oldP->lpszValue);
+}
 
-char XMLNode::setGlobalOptions(XMLCharEncoding _characterEncoding, char _guessWideCharChars,
-                               char _dropWhiteSpace, char _removeCommentsInMiddleOfText)
-{
-    guessWideCharChars=_guessWideCharChars; dropWhiteSpace=_dropWhiteSpace; removeCommentsInMiddleOfText=_removeCommentsInMiddleOfText;
+char XMLNode::setGlobalOptions(XMLCharEncoding _characterEncoding,
+                               char _guessWideCharChars, char _dropWhiteSpace,
+                               char _removeCommentsInMiddleOfText) {
+  guessWideCharChars = _guessWideCharChars;
+  dropWhiteSpace = _dropWhiteSpace;
+  removeCommentsInMiddleOfText = _removeCommentsInMiddleOfText;
 #ifdef _XMLWIDECHAR
-    if (_characterEncoding) characterEncoding=_characterEncoding;
+  if (_characterEncoding) characterEncoding = _characterEncoding;
 #else
-    switch(_characterEncoding)
-    {
-    case char_encoding_UTF8:     characterEncoding=_characterEncoding; XML_ByteTable=XML_utf8ByteTable; break;
-    case char_encoding_legacy:   characterEncoding=_characterEncoding; XML_ByteTable=XML_legacyByteTable; break;
-    case char_encoding_ShiftJIS: characterEncoding=_characterEncoding; XML_ByteTable=XML_sjisByteTable; break;
-    case char_encoding_GB2312:   characterEncoding=_characterEncoding; XML_ByteTable=XML_gb2312ByteTable; break;
+  switch (_characterEncoding) {
+    case char_encoding_UTF8:
+      characterEncoding = _characterEncoding;
+      XML_ByteTable = XML_utf8ByteTable;
+      break;
+    case char_encoding_legacy:
+      characterEncoding = _characterEncoding;
+      XML_ByteTable = XML_legacyByteTable;
+      break;
+    case char_encoding_ShiftJIS:
+      characterEncoding = _characterEncoding;
+      XML_ByteTable = XML_sjisByteTable;
+      break;
+    case char_encoding_GB2312:
+      characterEncoding = _characterEncoding;
+      XML_ByteTable = XML_gb2312ByteTable;
+      break;
     case char_encoding_Big5:
-    case char_encoding_GBK:      characterEncoding=_characterEncoding; XML_ByteTable=XML_gbk_big5_ByteTable; break;
-    default: return 1;
-    }
+    case char_encoding_GBK:
+      characterEncoding = _characterEncoding;
+      XML_ByteTable = XML_gbk_big5_ByteTable;
+      break;
+    default:
+      return 1;
+  }
 #endif
-    return 0;
+  return 0;
 }
 
-XMLNode::XMLCharEncoding XMLNode::guessCharEncoding(void *buf,int l, char useXMLEncodingAttribute)
-{
+XMLNode::XMLCharEncoding XMLNode::guessCharEncoding(
+    void *buf, int l, char useXMLEncodingAttribute) {
 #ifdef _XMLWIDECHAR
-    return (XMLCharEncoding)0;
+  return (XMLCharEncoding)0;
 #else
-    if (l<25) return (XMLCharEncoding)0;
-    if (guessWideCharChars&&(myIsTextWideChar(buf,l))) return (XMLCharEncoding)0;
-    unsigned char *b=(unsigned char*)buf;
-    if ((b[0]==0xef)&&(b[1]==0xbb)&&(b[2]==0xbf)) return char_encoding_UTF8;
+  if (l < 25) return (XMLCharEncoding)0;
+  if (guessWideCharChars && (myIsTextWideChar(buf, l)))
+    return (XMLCharEncoding)0;
+  unsigned char *b = (unsigned char *)buf;
+  if ((b[0] == 0xef) && (b[1] == 0xbb) && (b[2] == 0xbf))
+    return char_encoding_UTF8;
 
-    // Match utf-8 model ?
-    XMLCharEncoding bestGuess=char_encoding_UTF8;
-    int i=0;
-    while (i<l)
-        switch (XML_utf8ByteTable[b[i]])
-        {
-        case 4: i++; if ((i<l)&&(b[i]& 0xC0)!=0x80) { bestGuess=char_encoding_legacy; i=l; } // 10bbbbbb ?
-        case 3: i++; if ((i<l)&&(b[i]& 0xC0)!=0x80) { bestGuess=char_encoding_legacy; i=l; } // 10bbbbbb ?
-        case 2: i++; if ((i<l)&&(b[i]& 0xC0)!=0x80) { bestGuess=char_encoding_legacy; i=l; } // 10bbbbbb ?
-        case 1: i++; break;
-        case 0: i=l;
-        }
-    if (!useXMLEncodingAttribute) return bestGuess;
-    // if encoding is specified and different from utf-8 than it's non-utf8
-    // otherwise it's utf-8
-    char bb[201];
-    l=mmin(l,200);
-    memcpy(bb,buf,l); // copy buf into bb to be able to do "bb[l]=0"
-    bb[l]=0;
-    b=(unsigned char*)strstr(bb,"encoding");
-    if (!b) return bestGuess;
-    b+=8; while XML_isSPACECHAR(*b) b++; if (*b!='=') return bestGuess;
-    b++;  while XML_isSPACECHAR(*b) b++; if ((*b!='\'')&&(*b!='"')) return bestGuess;
-    b++;  while XML_isSPACECHAR(*b) b++;
-
-    if ((xstrnicmp((char*)b,"utf-8",5)==0)||
-        (xstrnicmp((char*)b,"utf8",4)==0))
-    {
-        if (bestGuess==char_encoding_legacy) return char_encoding_error;
-        return char_encoding_UTF8;
+  // Match utf-8 model ?
+  XMLCharEncoding bestGuess = char_encoding_UTF8;
+  int i = 0;
+  while (i < l) switch (XML_utf8ByteTable[b[i]]) {
+      case 4:
+        i++;
+        if ((i < l) && (b[i] & 0xC0) != 0x80) {
+          bestGuess = char_encoding_legacy;
+          i = l;
+        }  // 10bbbbbb ?
+      case 3:
+        i++;
+        if ((i < l) && (b[i] & 0xC0) != 0x80) {
+          bestGuess = char_encoding_legacy;
+          i = l;
+        }  // 10bbbbbb ?
+      case 2:
+        i++;
+        if ((i < l) && (b[i] & 0xC0) != 0x80) {
+          bestGuess = char_encoding_legacy;
+          i = l;
+        }  // 10bbbbbb ?
+      case 1:
+        i++;
+        break;
+      case 0:
+        i = l;
     }
+  if (!useXMLEncodingAttribute) return bestGuess;
+  // if encoding is specified and different from utf-8 than it's non-utf8
+  // otherwise it's utf-8
+  char bb[201];
+  l = mmin(l, 200);
+  memcpy(bb, buf, l);  // copy buf into bb to be able to do "bb[l]=0"
+  bb[l] = 0;
+  b = (unsigned char *)strstr(bb, "encoding");
+  if (!b) return bestGuess;
+  b += 8;
+  while
+    XML_isSPACECHAR(*b) b++;
+  if (*b != '=') return bestGuess;
+  b++;
+  while
+    XML_isSPACECHAR(*b) b++;
+  if ((*b != '\'') && (*b != '"')) return bestGuess;
+  b++;
+  while
+    XML_isSPACECHAR(*b) b++;
 
-    if ((xstrnicmp((char*)b,"shiftjis",8)==0)||
-        (xstrnicmp((char*)b,"shift-jis",9)==0)||
-        (xstrnicmp((char*)b,"sjis",4)==0)) return char_encoding_ShiftJIS;
+  if ((xstrnicmp((char *)b, "utf-8", 5) == 0) ||
+      (xstrnicmp((char *)b, "utf8", 4) == 0)) {
+    if (bestGuess == char_encoding_legacy) return char_encoding_error;
+    return char_encoding_UTF8;
+  }
 
-    if (xstrnicmp((char*)b,"GB2312",6)==0) return char_encoding_GB2312;
-    if (xstrnicmp((char*)b,"Big5",4)==0) return char_encoding_Big5;
-    if (xstrnicmp((char*)b,"GBK",3)==0) return char_encoding_GBK;
+  if ((xstrnicmp((char *)b, "shiftjis", 8) == 0) ||
+      (xstrnicmp((char *)b, "shift-jis", 9) == 0) ||
+      (xstrnicmp((char *)b, "sjis", 4) == 0))
+    return char_encoding_ShiftJIS;
 
-    return char_encoding_legacy;
+  if (xstrnicmp((char *)b, "GB2312", 6) == 0) return char_encoding_GB2312;
+  if (xstrnicmp((char *)b, "Big5", 4) == 0) return char_encoding_Big5;
+  if (xstrnicmp((char *)b, "GBK", 3) == 0) return char_encoding_GBK;
+
+  return char_encoding_legacy;
 #endif
 }
 #undef XML_isSPACECHAR
@@ -2724,167 +3200,228 @@ XMLNode::XMLCharEncoding XMLNode::guessCharEncoding(void *buf,int l, char useXML
 //      Here starts the base64 conversion functions.    //
 //////////////////////////////////////////////////////////
 
-static const char base64Fillchar = _CXML('='); // used to mark partial words at the end
+static const char base64Fillchar =
+    _CXML('=');  // used to mark partial words at the end
 
 // this lookup table defines the base64 encoding
-XMLCSTR base64EncodeTable=_CXML("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/");
+XMLCSTR base64EncodeTable =
+    _CXML("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/");
 
-// Decode Table gives the index of any valid base64 character in the Base64 table]
+// Decode Table gives the index of any valid base64 character in the Base64
+// table]
 // 96: '='  -   97: space char   -   98: illegal char   -   99: end of string
 const unsigned char base64DecodeTable[] = {
-    99,98,98,98,98,98,98,98,98,97,  97,98,98,97,98,98,98,98,98,98,  98,98,98,98,98,98,98,98,98,98,  //00 -29
-    98,98,97,98,98,98,98,98,98,98,  98,98,98,62,98,98,98,63,52,53,  54,55,56,57,58,59,60,61,98,98,  //30 -59
-    98,96,98,98,98, 0, 1, 2, 3, 4,   5, 6, 7, 8, 9,10,11,12,13,14,  15,16,17,18,19,20,21,22,23,24,  //60 -89
-    25,98,98,98,98,98,98,26,27,28,  29,30,31,32,33,34,35,36,37,38,  39,40,41,42,43,44,45,46,47,48,  //90 -119
-    49,50,51,98,98,98,98,98,98,98,  98,98,98,98,98,98,98,98,98,98,  98,98,98,98,98,98,98,98,98,98,  //120 -149
-    98,98,98,98,98,98,98,98,98,98,  98,98,98,98,98,98,98,98,98,98,  98,98,98,98,98,98,98,98,98,98,  //150 -179
-    98,98,98,98,98,98,98,98,98,98,  98,98,98,98,98,98,98,98,98,98,  98,98,98,98,98,98,98,98,98,98,  //180 -209
-    98,98,98,98,98,98,98,98,98,98,  98,98,98,98,98,98,98,98,98,98,  98,98,98,98,98,98,98,98,98,98,  //210 -239
-    98,98,98,98,98,98,98,98,98,98,  98,98,98,98,98,98                                               //240 -255
+    99, 98, 98, 98, 98, 98, 98, 98, 98, 97, 97, 98, 98, 97, 98, 98,
+    98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98,  // 00 -29
+    98, 98, 97, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 62, 98, 98,
+    98, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 98, 98,  // 30 -59
+    98, 96, 98, 98, 98, 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
+    11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,  // 60 -89
+    25, 98, 98, 98, 98, 98, 98, 26, 27, 28, 29, 30, 31, 32, 33, 34,
+    35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,  // 90 -119
+    49, 50, 51, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98,
+    98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98,  // 120 -149
+    98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98,
+    98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98,  // 150 -179
+    98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98,
+    98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98,  // 180 -209
+    98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98,
+    98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98,         // 210 -239
+    98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98, 98  // 240 -255
 };
 
-XMLParserBase64Tool::~XMLParserBase64Tool(){ freeBuffer(); }
+XMLParserBase64Tool::~XMLParserBase64Tool() { freeBuffer(); }
 
-void XMLParserBase64Tool::freeBuffer(){ if (buf) free(buf); buf=NULL; buflen=0; }
-
-int XMLParserBase64Tool::encodeLength(int inlen, char formatted)
-{
-    unsigned int i=((inlen-1)/3*4+4+1);
-    if (formatted) i+=inlen/54;
-    return i;
+void XMLParserBase64Tool::freeBuffer() {
+  if (buf) free(buf);
+  buf = NULL;
+  buflen = 0;
 }
 
-XMLSTR XMLParserBase64Tool::encode(unsigned char *inbuf, unsigned int inlen, char formatted)
-{
-    int i=encodeLength(inlen,formatted),k=17,eLen=inlen/3,j;
-    alloc(i*sizeof(XMLCHAR));
-    XMLSTR curr=(XMLSTR)buf;
-    for(i=0;i<eLen;i++)
-    {
-        // Copy next three bytes into lower 24 bits of int, paying attention to sign.
-        j=(inbuf[0]<<16)|(inbuf[1]<<8)|inbuf[2]; inbuf+=3;
-        // Encode the int into four chars
-        *(curr++)=base64EncodeTable[ j>>18      ];
-        *(curr++)=base64EncodeTable[(j>>12)&0x3f];
-        *(curr++)=base64EncodeTable[(j>> 6)&0x3f];
-        *(curr++)=base64EncodeTable[(j    )&0x3f];
-        if (formatted) { if (!k) { *(curr++)=_CXML('\n'); k=18; } k--; }
-    }
-    eLen=inlen-eLen*3; // 0 - 2.
-    if (eLen==1)
-    {
-        *(curr++)=base64EncodeTable[ inbuf[0]>>2      ];
-        *(curr++)=base64EncodeTable[(inbuf[0]<<4)&0x3F];
-        *(curr++)=base64Fillchar;
-        *(curr++)=base64Fillchar;
-    } else if (eLen==2)
-    {
-        j=(inbuf[0]<<8)|inbuf[1];
-        *(curr++)=base64EncodeTable[ j>>10      ];
-        *(curr++)=base64EncodeTable[(j>> 4)&0x3f];
-        *(curr++)=base64EncodeTable[(j<< 2)&0x3f];
-        *(curr++)=base64Fillchar;
-    }
-    *(curr++)=0;
-    return (XMLSTR)buf;
+int XMLParserBase64Tool::encodeLength(int inlen, char formatted) {
+  unsigned int i = ((inlen - 1) / 3 * 4 + 4 + 1);
+  if (formatted) i += inlen / 54;
+  return i;
 }
 
-unsigned int XMLParserBase64Tool::decodeSize(XMLCSTR data,XMLError *xe)
-{
-     if (xe) *xe=eXMLErrorNone;
-    int size=0;
-    unsigned char c;
-    //skip any extra characters (e.g. newlines or spaces)
-    while (*data)
-    {
+XMLSTR XMLParserBase64Tool::encode(unsigned char *inbuf, unsigned int inlen,
+                                   char formatted) {
+  int i = encodeLength(inlen, formatted), k = 17, eLen = inlen / 3, j;
+  alloc(i * sizeof(XMLCHAR));
+  XMLSTR curr = (XMLSTR)buf;
+  for (i = 0; i < eLen; i++) {
+    // Copy next three bytes into lower 24 bits of int, paying attention to
+    // sign.
+    j = (inbuf[0] << 16) | (inbuf[1] << 8) | inbuf[2];
+    inbuf += 3;
+    // Encode the int into four chars
+    *(curr++) = base64EncodeTable[j >> 18];
+    *(curr++) = base64EncodeTable[(j >> 12) & 0x3f];
+    *(curr++) = base64EncodeTable[(j >> 6) & 0x3f];
+    *(curr++) = base64EncodeTable[(j)&0x3f];
+    if (formatted) {
+      if (!k) {
+        *(curr++) = _CXML('\n');
+        k = 18;
+      }
+      k--;
+    }
+  }
+  eLen = inlen - eLen * 3;  // 0 - 2.
+  if (eLen == 1) {
+    *(curr++) = base64EncodeTable[inbuf[0] >> 2];
+    *(curr++) = base64EncodeTable[(inbuf[0] << 4) & 0x3F];
+    *(curr++) = base64Fillchar;
+    *(curr++) = base64Fillchar;
+  } else if (eLen == 2) {
+    j = (inbuf[0] << 8) | inbuf[1];
+    *(curr++) = base64EncodeTable[j >> 10];
+    *(curr++) = base64EncodeTable[(j >> 4) & 0x3f];
+    *(curr++) = base64EncodeTable[(j << 2) & 0x3f];
+    *(curr++) = base64Fillchar;
+  }
+  *(curr++) = 0;
+  return (XMLSTR)buf;
+}
+
+unsigned int XMLParserBase64Tool::decodeSize(XMLCSTR data, XMLError *xe) {
+  if (xe) *xe = eXMLErrorNone;
+  int size = 0;
+  unsigned char c;
+  // skip any extra characters (e.g. newlines or spaces)
+  while (*data) {
 #ifdef _XMLWIDECHAR
-        if (*data>255) { if (xe) *xe=eXMLErrorBase64DecodeIllegalCharacter; return 0; }
+    if (*data > 255) {
+      if (xe) *xe = eXMLErrorBase64DecodeIllegalCharacter;
+      return 0;
+    }
 #endif
-        c=base64DecodeTable[(unsigned char)(*data)];
-        if (c<97) size++;
-        else if (c==98) { if (xe) *xe=eXMLErrorBase64DecodeIllegalCharacter; return 0; }
-        data++;
+    c = base64DecodeTable[(unsigned char)(*data)];
+    if (c < 97)
+      size++;
+    else if (c == 98) {
+      if (xe) *xe = eXMLErrorBase64DecodeIllegalCharacter;
+      return 0;
     }
-    if (xe&&(size%4!=0)) *xe=eXMLErrorBase64DataSizeIsNotMultipleOf4;
-    if (size==0) return 0;
-    do { data--; size--; } while(*data==base64Fillchar); size++;
-    return (unsigned int)((size*3)/4);
+    data++;
+  }
+  if (xe && (size % 4 != 0)) *xe = eXMLErrorBase64DataSizeIsNotMultipleOf4;
+  if (size == 0) return 0;
+  do {
+    data--;
+    size--;
+  } while (*data == base64Fillchar);
+  size++;
+  return (unsigned int)((size * 3) / 4);
 }
 
-unsigned char XMLParserBase64Tool::decode(XMLCSTR data, unsigned char *buf, int len, XMLError *xe)
-{
-    if (xe) *xe=eXMLErrorNone;
-    int i=0,p=0;
-    unsigned char d,c;
-    for(;;)
-    {
-
+unsigned char XMLParserBase64Tool::decode(XMLCSTR data, unsigned char *buf,
+                                          int len, XMLError *xe) {
+  if (xe) *xe = eXMLErrorNone;
+  int i = 0, p = 0;
+  unsigned char d, c;
+  for (;;) {
 #ifdef _XMLWIDECHAR
-#define BASE64DECODE_READ_NEXT_CHAR(c)                                              \
-        do {                                                                        \
-            if (data[i]>255){ c=98; break; }                                        \
-            c=base64DecodeTable[(unsigned char)data[i++]];                       \
-        }while (c==97);                                                             \
-        if(c==98){ if(xe)*xe=eXMLErrorBase64DecodeIllegalCharacter; return 0; }
+#define BASE64DECODE_READ_NEXT_CHAR(c)                   \
+  do {                                                   \
+    if (data[i] > 255) {                                 \
+      c = 98;                                            \
+      break;                                             \
+    }                                                    \
+    c = base64DecodeTable[(unsigned char)data[i++]];     \
+  } while (c == 97);                                     \
+  if (c == 98) {                                         \
+    if (xe) *xe = eXMLErrorBase64DecodeIllegalCharacter; \
+    return 0;                                            \
+  }
 #else
-#define BASE64DECODE_READ_NEXT_CHAR(c)                                           \
-        do { c=base64DecodeTable[(unsigned char)data[i++]]; }while (c==97);   \
-        if(c==98){ if(xe)*xe=eXMLErrorBase64DecodeIllegalCharacter; return 0; }
+#define BASE64DECODE_READ_NEXT_CHAR(c)                   \
+  do {                                                   \
+    c = base64DecodeTable[(unsigned char)data[i++]];     \
+  } while (c == 97);                                     \
+  if (c == 98) {                                         \
+    if (xe) *xe = eXMLErrorBase64DecodeIllegalCharacter; \
+    return 0;                                            \
+  }
 #endif
 
-        BASE64DECODE_READ_NEXT_CHAR(c)
-        if (c==99) { return 2; }
-        if (c==96)
-        {
-            if (p==(int)len) return 2;
-            if (xe) *xe=eXMLErrorBase64DecodeTruncatedData;
-            return 1;
-        }
-
-        BASE64DECODE_READ_NEXT_CHAR(d)
-        if ((d==99)||(d==96)) { if (xe) *xe=eXMLErrorBase64DecodeTruncatedData;  return 1; }
-        if (p==(int)len) {      if (xe) *xe=eXMLErrorBase64DecodeBufferTooSmall; return 0; }
-        buf[p++]=(unsigned char)((c<<2)|((d>>4)&0x3));
-
-        BASE64DECODE_READ_NEXT_CHAR(c)
-        if (c==99) { if (xe) *xe=eXMLErrorBase64DecodeTruncatedData;  return 1; }
-        if (p==(int)len)
-        {
-            if (c==96) return 2;
-            if (xe) *xe=eXMLErrorBase64DecodeBufferTooSmall;
-            return 0;
-        }
-        if (c==96) { if (xe) *xe=eXMLErrorBase64DecodeTruncatedData;  return 1; }
-        buf[p++]=(unsigned char)(((d<<4)&0xf0)|((c>>2)&0xf));
-
-        BASE64DECODE_READ_NEXT_CHAR(d)
-        if (d==99 ) { if (xe) *xe=eXMLErrorBase64DecodeTruncatedData;  return 1; }
-        if (p==(int)len)
-        {
-            if (d==96) return 2;
-            if (xe) *xe=eXMLErrorBase64DecodeBufferTooSmall;
-            return 0;
-        }
-        if (d==96) { if (xe) *xe=eXMLErrorBase64DecodeTruncatedData;  return 1; }
-        buf[p++]=(unsigned char)(((c<<6)&0xc0)|d);
+    BASE64DECODE_READ_NEXT_CHAR(c)
+    if (c == 99) {
+      return 2;
     }
+    if (c == 96) {
+      if (p == (int)len) return 2;
+      if (xe) *xe = eXMLErrorBase64DecodeTruncatedData;
+      return 1;
+    }
+
+    BASE64DECODE_READ_NEXT_CHAR(d)
+    if ((d == 99) || (d == 96)) {
+      if (xe) *xe = eXMLErrorBase64DecodeTruncatedData;
+      return 1;
+    }
+    if (p == (int)len) {
+      if (xe) *xe = eXMLErrorBase64DecodeBufferTooSmall;
+      return 0;
+    }
+    buf[p++] = (unsigned char)((c << 2) | ((d >> 4) & 0x3));
+
+    BASE64DECODE_READ_NEXT_CHAR(c)
+    if (c == 99) {
+      if (xe) *xe = eXMLErrorBase64DecodeTruncatedData;
+      return 1;
+    }
+    if (p == (int)len) {
+      if (c == 96) return 2;
+      if (xe) *xe = eXMLErrorBase64DecodeBufferTooSmall;
+      return 0;
+    }
+    if (c == 96) {
+      if (xe) *xe = eXMLErrorBase64DecodeTruncatedData;
+      return 1;
+    }
+    buf[p++] = (unsigned char)(((d << 4) & 0xf0) | ((c >> 2) & 0xf));
+
+    BASE64DECODE_READ_NEXT_CHAR(d)
+    if (d == 99) {
+      if (xe) *xe = eXMLErrorBase64DecodeTruncatedData;
+      return 1;
+    }
+    if (p == (int)len) {
+      if (d == 96) return 2;
+      if (xe) *xe = eXMLErrorBase64DecodeBufferTooSmall;
+      return 0;
+    }
+    if (d == 96) {
+      if (xe) *xe = eXMLErrorBase64DecodeTruncatedData;
+      return 1;
+    }
+    buf[p++] = (unsigned char)(((c << 6) & 0xc0) | d);
+  }
 }
 #undef BASE64DECODE_READ_NEXT_CHAR
 
-void XMLParserBase64Tool::alloc(int newsize)
-{
-    if ((!buf)&&(newsize)) { buf=malloc(newsize); buflen=newsize; return; }
-    if (newsize>buflen) { buf=realloc(buf,newsize); buflen=newsize; }
+void XMLParserBase64Tool::alloc(int newsize) {
+  if ((!buf) && (newsize)) {
+    buf = malloc(newsize);
+    buflen = newsize;
+    return;
+  }
+  if (newsize > buflen) {
+    buf = realloc(buf, newsize);
+    buflen = newsize;
+  }
 }
 
-unsigned char *XMLParserBase64Tool::decode(XMLCSTR data, int *outlen, XMLError *xe)
-{
-    if (xe) *xe=eXMLErrorNone;
-    unsigned int len=decodeSize(data,xe);
-    if (outlen) *outlen=len;
-    if (!len) return NULL;
-    alloc(len+1);
-    if(!decode(data,(unsigned char*)buf,len,xe)){ return NULL; }
-    return (unsigned char*)buf;
+unsigned char *XMLParserBase64Tool::decode(XMLCSTR data, int *outlen,
+                                           XMLError *xe) {
+  if (xe) *xe = eXMLErrorNone;
+  unsigned int len = decodeSize(data, xe);
+  if (outlen) *outlen = len;
+  if (!len) return NULL;
+  alloc(len + 1);
+  if (!decode(data, (unsigned char *)buf, len, xe)) {
+    return NULL;
+  }
+  return (unsigned char *)buf;
 }
-

--- a/src/gpuwattch/xmlParser.h
+++ b/src/gpuwattch/xmlParser.h
@@ -9,18 +9,18 @@
  * @version     V2.41
  * @author      Frank Vanden Berghen
  *
- * The following license terms for the "XMLParser library from Business-Insight" apply to projects
- * that are in some way related to
- * the "mcpat project", including applications
- * using "mcpat project" and tools developed
- * for enhancing "mcpat project". All other projects
- * (not related to "mcpat project") have to use the "XMLParser library from Business-Insight"
- * code under the Aladdin Free Public License (AFPL)
- * See the file "AFPL-license.txt" for more informations about the AFPL license.
- * (see http://www.artifex.com/downloads/doc/Public.htm for detailed AFPL terms)
+ * The following license terms for the "XMLParser library from Business-Insight"
+ *apply to projects that are in some way related to the "mcpat project",
+ *including applications using "mcpat project" and tools developed for enhancing
+ *"mcpat project". All other projects (not related to "mcpat project") have to
+ *use the "XMLParser library from Business-Insight" code under the Aladdin Free
+ *Public License (AFPL) See the file "AFPL-license.txt" for more informations
+ *about the AFPL license. (see http://www.artifex.com/downloads/doc/Public.htm
+ *for detailed AFPL terms)
  *
- * Redistribution and use of the "XMLParser library from Business-Insight" in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Redistribution and use of the "XMLParser library from Business-Insight" in
+ *source and binary forms, with or without modification, are permitted provided
+ *that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
  *       notice, this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright
@@ -46,71 +46,81 @@
  * All rights reserved.
  *
  * \section tutorial First Tutorial
- * You can follow a simple <a href="../../xmlParser.html">Tutorial</a> to know the basics...
+ * You can follow a simple <a href="../../xmlParser.html">Tutorial</a> to know
+ *the basics...
  *
- * \section usage General usage: How to include the XMLParser library inside your project.
+ * \section usage General usage: How to include the XMLParser library inside
+ *your project.
  *
- * The library is composed of two files: <a href="../../xmlParser.cpp">xmlParser.cpp</a> and
- * <a href="../../xmlParser.h">xmlParser.h</a>. These are the ONLY 2 files that you need when
- * using the library inside your own projects.
+ * The library is composed of two files: <a
+ *href="../../xmlParser.cpp">xmlParser.cpp</a> and <a
+ *href="../../xmlParser.h">xmlParser.h</a>. These are the ONLY 2 files that you
+ *need when using the library inside your own projects.
  *
- * All the functions of the library are documented inside the comments of the file
- * <a href="../../xmlParser.h">xmlParser.h</a>. These comments can be transformed in
- * full-fledged HTML documentation using the DOXYGEN software: simply type: "doxygen doxy.cfg"
+ * All the functions of the library are documented inside the comments of the
+ *file <a href="../../xmlParser.h">xmlParser.h</a>. These comments can be
+ *transformed in full-fledged HTML documentation using the DOXYGEN software:
+ *simply type: "doxygen doxy.cfg"
  *
- * By default, the XMLParser library uses (char*) for string representation.To use the (wchar_t*)
- * version of the library, you need to define the "_UNICODE" preprocessor definition variable
- * (this is usually done inside your project definition file) (This is done automatically for you
- * when using Visual Studio).
+ * By default, the XMLParser library uses (char*) for string representation.To
+ *use the (wchar_t*) version of the library, you need to define the "_UNICODE"
+ *preprocessor definition variable (this is usually done inside your project
+ *definition file) (This is done automatically for you when using Visual
+ *Studio).
  *
  * \section example Advanced Tutorial and Many Examples of usage.
  *
  * Some very small introductory examples are described inside the Tutorial file
  * <a href="../../xmlParser.html">xmlParser.html</a>
  *
- * Some additional small examples are also inside the file <a href="../../xmlTest.cpp">xmlTest.cpp</a>
- * (for the "char*" version of the library) and inside the file
- * <a href="../../xmlTestUnicode.cpp">xmlTestUnicode.cpp</a> (for the "wchar_t*"
- * version of the library). If you have a question, please review these additionnal examples
- * before sending an e-mail to the author.
+ * Some additional small examples are also inside the file <a
+ *href="../../xmlTest.cpp">xmlTest.cpp</a> (for the "char*" version of the
+ *library) and inside the file <a
+ *href="../../xmlTestUnicode.cpp">xmlTestUnicode.cpp</a> (for the "wchar_t*"
+ * version of the library). If you have a question, please review these
+ *additionnal examples before sending an e-mail to the author.
  *
  * To build the examples:
  * - linux/unix: type "make"
  * - solaris: type "make -f makefile.solaris"
  * - windows: Visual Studio: double-click on xmlParser.dsw
- *   (under Visual Studio .NET, the .dsp and .dsw files will be automatically converted to .vcproj and .sln files)
+ *   (under Visual Studio .NET, the .dsp and .dsw files will be automatically
+ *converted to .vcproj and .sln files)
  *
  * In order to build the examples you need some additional files:
  * - linux/unix: makefile
  * - solaris: makefile.solaris
- * - windows: Visual Studio: *.dsp, xmlParser.dsw and also xmlParser.lib and xmlParser.dll
+ * - windows: Visual Studio: *.dsp, xmlParser.dsw and also xmlParser.lib and
+ *xmlParser.dll
  *
  * \section debugging Debugging with the XMLParser library
  *
  * \subsection debugwin Debugging under WINDOWS
  *
- * 	Inside Visual C++, the "debug versions" of the memory allocation functions are
- * 	very slow: Do not forget to compile in "release mode" to get maximum speed.
- * 	When I had to debug a software that was using the XMLParser Library, it was usually
- * 	a nightmare because the library was sooOOOoooo slow in debug mode (because of the
- *  slow memory allocations in Debug mode). To solve this
- * 	problem, during all the debugging session, I am now using a very fast DLL version of the
- * 	XMLParser Library (the DLL is compiled in release mode). Using the DLL version of
- * 	the XMLParser Library allows me to have lightening XML parsing speed even in debug!
- * 	Other than that, the DLL version is useless: In the release version of my tool,
- * 	I always use the normal, ".cpp"-based, XMLParser Library (I simply include the
- * <a href="../../xmlParser.cpp">xmlParser.cpp</a> and
- * <a href="../../xmlParser.h">xmlParser.h</a> files into the project).
+ * 	Inside Visual C++, the "debug versions" of the memory allocation
+ *functions are very slow: Do not forget to compile in "release mode" to get
+ *maximum speed. When I had to debug a software that was using the XMLParser
+ *Library, it was usually a nightmare because the library was sooOOOoooo slow in
+ *debug mode (because of the slow memory allocations in Debug mode). To solve
+ *this problem, during all the debugging session, I am now using a very fast DLL
+ *version of the XMLParser Library (the DLL is compiled in release mode). Using
+ *the DLL version of the XMLParser Library allows me to have lightening XML
+ *parsing speed even in debug! Other than that, the DLL version is useless: In
+ *the release version of my tool, I always use the normal, ".cpp"-based,
+ *XMLParser Library (I simply include the <a
+ *href="../../xmlParser.cpp">xmlParser.cpp</a> and <a
+ *href="../../xmlParser.h">xmlParser.h</a> files into the project).
  *
- * 	The file <a href="../../XMLNodeAutoexp.txt">XMLNodeAutoexp.txt</a> contains some
- * "tweaks" that improve substancially the display of the content of the XMLNode objects
- * inside the Visual Studio Debugger. Believe me, once you have seen inside the debugger
- * the "smooth" display of the XMLNode objects, you cannot live without it anymore!
+ * 	The file <a href="../../XMLNodeAutoexp.txt">XMLNodeAutoexp.txt</a>
+ *contains some "tweaks" that improve substancially the display of the content
+ *of the XMLNode objects inside the Visual Studio Debugger. Believe me, once you
+ *have seen inside the debugger the "smooth" display of the XMLNode objects, you
+ *cannot live without it anymore!
  *
  * \subsection debuglinux Debugging under LINUX/UNIX
  *
- * 	The speed of the debug version of the XMLParser library is tolerable so no extra
- * work.has been done.
+ * 	The speed of the debug version of the XMLParser library is tolerable so
+ *no extra work.has been done.
  *
  ****************************************************************************/
 
@@ -120,16 +130,21 @@
 #include <stdlib.h>
 
 #ifdef _UNICODE
-// If you comment the next "define" line then the library will never "switch to" _UNICODE (wchar_t*) mode (16/32 bits per characters).
-// This is useful when you get error messages like:
-//    'XMLNode::openFileHelper' : cannot convert parameter 2 from 'const char [5]' to 'const wchar_t *'
-// The _XMLWIDECHAR preprocessor variable force the XMLParser library into either utf16/32-mode (the proprocessor variable
-// must be defined) or utf8-mode(the pre-processor variable must be undefined).
+// If you comment the next "define" line then the library will never "switch to"
+// _UNICODE (wchar_t*) mode (16/32 bits per characters). This is useful when you
+// get error messages like:
+//    'XMLNode::openFileHelper' : cannot convert parameter 2 from 'const char
+//    [5]' to 'const wchar_t *'
+// The _XMLWIDECHAR preprocessor variable force the XMLParser library into
+// either utf16/32-mode (the proprocessor variable must be defined) or
+// utf8-mode(the pre-processor variable must be undefined).
 #define _XMLWIDECHAR
 #endif
 
-#if defined(WIN32) || defined(UNDER_CE) || defined(_WIN32) || defined(WIN64) || defined(__BORLANDC__)
-// comment the next line if you are under windows and the compiler is not Microsoft Visual Studio (6.0 or .NET) or Borland
+#if defined(WIN32) || defined(UNDER_CE) || defined(_WIN32) || \
+    defined(WIN64) || defined(__BORLANDC__)
+// comment the next line if you are under windows and the compiler is not
+// Microsoft Visual Studio (6.0 or .NET) or Borland
 #define _XMLWINDOWS
 #endif
 
@@ -146,7 +161,8 @@
 #define XMLDLLENTRY
 #endif
 
-// uncomment the next line if you want no support for wchar_t* (no need for the <wchar.h> or <tchar.h> libraries anymore to compile)
+// uncomment the next line if you want no support for wchar_t* (no need for the
+// <wchar.h> or <tchar.h> libraries anymore to compile)
 //#define XML_NO_WIDE_CHAR
 
 #ifdef XML_NO_WIDE_CHAR
@@ -159,84 +175,83 @@
 #else
 #define XMLDLLENTRY
 #ifndef XML_NO_WIDE_CHAR
-#include <wchar.h> // to have 'wcsrtombs' for ANSI version
-                   // to have 'mbsrtowcs' for WIDECHAR version
+#include <wchar.h>  // to have 'wcsrtombs' for ANSI version
+                    // to have 'mbsrtowcs' for WIDECHAR version
 #endif
 #endif
 
 // Some common types for char set portable code
 #ifdef _XMLWIDECHAR
-    #define _CXML(c) L ## c
-    #define XMLCSTR const wchar_t *
-    #define XMLSTR  wchar_t *
-    #define XMLCHAR wchar_t
+#define _CXML(c) L##c
+#define XMLCSTR const wchar_t *
+#define XMLSTR wchar_t *
+#define XMLCHAR wchar_t
 #else
-    #define _CXML(c) c
-    #define XMLCSTR const char *
-    #define XMLSTR  char *
-    #define XMLCHAR char
+#define _CXML(c) c
+#define XMLCSTR const char *
+#define XMLSTR char *
+#define XMLCHAR char
 #endif
 #ifndef FALSE
-    #define FALSE 0
+#define FALSE 0
 #endif /* FALSE */
 #ifndef TRUE
-    #define TRUE 1
+#define TRUE 1
 #endif /* TRUE */
 
-
 /// Enumeration for XML parse errors.
-typedef enum XMLError
-{
-    eXMLErrorNone = 0,
-    eXMLErrorMissingEndTag,
-    eXMLErrorNoXMLTagFound,
-    eXMLErrorEmpty,
-    eXMLErrorMissingTagName,
-    eXMLErrorMissingEndTagName,
-    eXMLErrorUnmatchedEndTag,
-    eXMLErrorUnmatchedEndClearTag,
-    eXMLErrorUnexpectedToken,
-    eXMLErrorNoElements,
-    eXMLErrorFileNotFound,
-    eXMLErrorFirstTagNotFound,
-    eXMLErrorUnknownCharacterEntity,
-    eXMLErrorCharacterCodeAbove255,
-    eXMLErrorCharConversionError,
-    eXMLErrorCannotOpenWriteFile,
-    eXMLErrorCannotWriteFile,
+typedef enum XMLError {
+  eXMLErrorNone = 0,
+  eXMLErrorMissingEndTag,
+  eXMLErrorNoXMLTagFound,
+  eXMLErrorEmpty,
+  eXMLErrorMissingTagName,
+  eXMLErrorMissingEndTagName,
+  eXMLErrorUnmatchedEndTag,
+  eXMLErrorUnmatchedEndClearTag,
+  eXMLErrorUnexpectedToken,
+  eXMLErrorNoElements,
+  eXMLErrorFileNotFound,
+  eXMLErrorFirstTagNotFound,
+  eXMLErrorUnknownCharacterEntity,
+  eXMLErrorCharacterCodeAbove255,
+  eXMLErrorCharConversionError,
+  eXMLErrorCannotOpenWriteFile,
+  eXMLErrorCannotWriteFile,
 
-    eXMLErrorBase64DataSizeIsNotMultipleOf4,
-    eXMLErrorBase64DecodeIllegalCharacter,
-    eXMLErrorBase64DecodeTruncatedData,
-    eXMLErrorBase64DecodeBufferTooSmall
+  eXMLErrorBase64DataSizeIsNotMultipleOf4,
+  eXMLErrorBase64DecodeIllegalCharacter,
+  eXMLErrorBase64DecodeTruncatedData,
+  eXMLErrorBase64DecodeBufferTooSmall
 } XMLError;
 
-
-/// Enumeration used to manage type of data. Use in conjunction with structure XMLNodeContents
-typedef enum XMLElementType
-{
-    eNodeChild=0,
-    eNodeAttribute=1,
-    eNodeText=2,
-    eNodeClear=3,
-    eNodeNULL=4
+/// Enumeration used to manage type of data. Use in conjunction with structure
+/// XMLNodeContents
+typedef enum XMLElementType {
+  eNodeChild = 0,
+  eNodeAttribute = 1,
+  eNodeText = 2,
+  eNodeClear = 3,
+  eNodeNULL = 4
 } XMLElementType;
 
 /// Structure used to obtain error details if the parse fails.
-typedef struct XMLResults
-{
-    enum XMLError error;
-    int  nLine,nColumn;
+typedef struct XMLResults {
+  enum XMLError error;
+  int nLine, nColumn;
 } XMLResults;
 
 /// Structure for XML clear (unformatted) node (usually comments)
 typedef struct XMLClear {
-    XMLCSTR lpszValue; XMLCSTR lpszOpenTag; XMLCSTR lpszCloseTag;
+  XMLCSTR lpszValue;
+  XMLCSTR lpszOpenTag;
+  XMLCSTR lpszCloseTag;
 } XMLClear;
 
 /// Structure for XML attribute.
 typedef struct XMLAttribute {
-    XMLCSTR lpszName; XMLCSTR lpszValue;
+  XMLCSTR lpszName;
+  XMLCSTR lpszValue;
 } XMLAttribute;
 
 /// XMLElementPosition are not interchangeable with simple indexes
@@ -249,395 +264,556 @@ struct XMLNodeContents;
 /// Main Class representing a XML node
 /**
  * All operations are performed using this class.
- * \note The constructors of the XMLNode class are protected, so use instead one of these four methods to get your first instance of XMLNode:
- * <ul>
- *    <li> XMLNode::parseString </li>
- *    <li> XMLNode::parseFile </li>
- *    <li> XMLNode::openFileHelper </li>
- *    <li> XMLNode::createXMLTopNode (or XMLNode::createXMLTopNode_WOSD)</li>
+ * \note The constructors of the XMLNode class are protected, so use instead one
+ * of these four methods to get your first instance of XMLNode: <ul> <li>
+ * XMLNode::parseString </li> <li> XMLNode::parseFile </li> <li>
+ * XMLNode::openFileHelper </li> <li> XMLNode::createXMLTopNode (or
+ * XMLNode::createXMLTopNode_WOSD)</li>
  * </ul> */
-typedef struct XMLDLLENTRY XMLNode
-{
-  private:
+typedef struct XMLDLLENTRY XMLNode {
+ private:
+  struct XMLNodeDataTag;
 
-    struct XMLNodeDataTag;
+  /// Constructors are protected, so use instead one of: XMLNode::parseString,
+  /// XMLNode::parseFile, XMLNode::openFileHelper, XMLNode::createXMLTopNode
+  XMLNode(struct XMLNodeDataTag *pParent, XMLSTR lpszName, char isDeclaration);
+  /// Constructors are protected, so use instead one of: XMLNode::parseString,
+  /// XMLNode::parseFile, XMLNode::openFileHelper, XMLNode::createXMLTopNode
+  XMLNode(struct XMLNodeDataTag *p);
 
-    /// Constructors are protected, so use instead one of: XMLNode::parseString, XMLNode::parseFile, XMLNode::openFileHelper, XMLNode::createXMLTopNode
-    XMLNode(struct XMLNodeDataTag *pParent, XMLSTR lpszName, char isDeclaration);
-    /// Constructors are protected, so use instead one of: XMLNode::parseString, XMLNode::parseFile, XMLNode::openFileHelper, XMLNode::createXMLTopNode
-    XMLNode(struct XMLNodeDataTag *p);
+ public:
+  static XMLCSTR getVersion();  ///< Return the XMLParser library version number
 
-  public:
-    static XMLCSTR getVersion();///< Return the XMLParser library version number
+  /** @defgroup conversions Parsing XML files/strings to an XMLNode structure
+   * and Rendering XMLNode's to files/string.
+   * @ingroup XMLParserGeneral
+   * @{ */
 
-    /** @defgroup conversions Parsing XML files/strings to an XMLNode structure and Rendering XMLNode's to files/string.
-     * @ingroup XMLParserGeneral
-     * @{ */
+  /// Parse an XML string and return the root of a XMLNode tree representing the
+  /// string.
+  static XMLNode parseString(XMLCSTR lpXMLString, XMLCSTR tag = NULL,
+                             XMLResults *pResults = NULL);
+  /**< The "parseString" function parse an XML string and return the root of a
+   * XMLNode tree. The "opposite" of this function is the function
+   * "createXMLString" that re-creates an XML string from an XMLNode tree. If
+   * the XML document is corrupted, the "parseString" method will initialize the
+   * "pResults" variable with some information that can be used to trace the
+   * error. If you still want to parse the file, you can use the
+   * APPROXIMATE_PARSING option as explained inside the note at the beginning of
+   * the "xmlParser.cpp" file.
+   *
+   * @param lpXMLString the XML string to parse
+   * @param tag  the name of the first tag inside the XML file. If the tag
+   * parameter is omitted, this function returns a node that represents the head
+   * of the xml document including the declaration term (<? ... ?>).
+   * @param pResults a pointer to a XMLResults variable that will contain some
+   * information that can be used to trace the XML parsing error. You can have a
+   * user-friendly explanation of the parsing error with the "getError"
+   * function.
+   */
 
-    /// Parse an XML string and return the root of a XMLNode tree representing the string.
-    static XMLNode parseString   (XMLCSTR  lpXMLString, XMLCSTR tag=NULL, XMLResults *pResults=NULL);
-    /**< The "parseString" function parse an XML string and return the root of a XMLNode tree. The "opposite" of this function is
-     * the function "createXMLString" that re-creates an XML string from an XMLNode tree. If the XML document is corrupted, the
-     * "parseString" method will initialize the "pResults" variable with some information that can be used to trace the error.
-     * If you still want to parse the file, you can use the APPROXIMATE_PARSING option as explained inside the note at the
-     * beginning of the "xmlParser.cpp" file.
-     *
-     * @param lpXMLString the XML string to parse
-     * @param tag  the name of the first tag inside the XML file. If the tag parameter is omitted, this function returns a node that represents the head of the xml document including the declaration term (<? ... ?>).
-     * @param pResults a pointer to a XMLResults variable that will contain some information that can be used to trace the XML parsing error. You can have a user-friendly explanation of the parsing error with the "getError" function.
-     */
+  /// Parse an XML file and return the root of a XMLNode tree representing the
+  /// file.
+  static XMLNode parseFile(XMLCSTR filename, XMLCSTR tag = NULL,
+                           XMLResults *pResults = NULL);
+  /**< The "parseFile" function parse an XML file and return the root of a
+   * XMLNode tree. The "opposite" of this function is the function "writeToFile"
+   * that re-creates an XML file from an XMLNode tree. If the XML document is
+   * corrupted, the "parseFile" method will initialize the "pResults" variable
+   * with some information that can be used to trace the error. If you still
+   * want to parse the file, you can use the APPROXIMATE_PARSING option as
+   * explained inside the note at the beginning of the "xmlParser.cpp" file.
+   *
+   * @param filename the path to the XML file to parse
+   * @param tag the name of the first tag inside the XML file. If the tag
+   * parameter is omitted, this function returns a node that represents the head
+   * of the xml document including the declaration term (<? ... ?>).
+   * @param pResults a pointer to a XMLResults variable that will contain some
+   * information that can be used to trace the XML parsing error. You can have a
+   * user-friendly explanation of the parsing error with the "getError"
+   * function.
+   */
 
-    /// Parse an XML file and return the root of a XMLNode tree representing the file.
-    static XMLNode parseFile     (XMLCSTR     filename, XMLCSTR tag=NULL, XMLResults *pResults=NULL);
-    /**< The "parseFile" function parse an XML file and return the root of a XMLNode tree. The "opposite" of this function is
-     * the function "writeToFile" that re-creates an XML file from an XMLNode tree. If the XML document is corrupted, the
-     * "parseFile" method will initialize the "pResults" variable with some information that can be used to trace the error.
-     * If you still want to parse the file, you can use the APPROXIMATE_PARSING option as explained inside the note at the
-     * beginning of the "xmlParser.cpp" file.
-     *
-     * @param filename the path to the XML file to parse
-     * @param tag the name of the first tag inside the XML file. If the tag parameter is omitted, this function returns a node that represents the head of the xml document including the declaration term (<? ... ?>).
-     * @param pResults a pointer to a XMLResults variable that will contain some information that can be used to trace the XML parsing error. You can have a user-friendly explanation of the parsing error with the "getError" function.
-     */
+  /// Parse an XML file and return the root of a XMLNode tree representing the
+  /// file. A very crude error checking is made. An attempt to guess the Char
+  /// Encoding used in the file is made.
+  static XMLNode openFileHelper(XMLCSTR filename, XMLCSTR tag = NULL);
+  /**< The "openFileHelper" function reports to the screen all the warnings and
+   * errors that occurred during parsing of the XML file. This function also
+   * tries to guess char Encoding (UTF-8, ASCII or SHIT-JIS) based on the first
+   * 200 bytes of the file. Since each application has its own way to report and
+   * deal with errors, you should rather use the "parseFile" function to parse
+   * XML files and program yourself thereafter an "error reporting" tailored for
+   * your needs (instead of using the very crude "error reporting" mechanism
+   * included inside the "openFileHelper" function).
+   *
+   * If the XML document is corrupted, the "openFileHelper" method will:
+   *         - display an error message on the console (or inside a messageBox
+   * for windows).
+   *         - stop execution (exit).
+   *
+   * I strongly suggest that you write your own "openFileHelper" method tailored
+   * to your needs. If you still want to parse the file, you can use the
+   * APPROXIMATE_PARSING option as explained inside the note at the beginning of
+   * the "xmlParser.cpp" file.
+   *
+   * @param filename the path of the XML file to parse.
+   * @param tag the name of the first tag inside the XML file. If the tag
+   * parameter is omitted, this function returns a node that represents the head
+   * of the xml document including the declaration term (<? ... ?>).
+   */
 
-    /// Parse an XML file and return the root of a XMLNode tree representing the file. A very crude error checking is made. An attempt to guess the Char Encoding used in the file is made.
-    static XMLNode openFileHelper(XMLCSTR     filename, XMLCSTR tag=NULL);
-    /**< The "openFileHelper" function reports to the screen all the warnings and errors that occurred during parsing of the XML file.
-     * This function also tries to guess char Encoding (UTF-8, ASCII or SHIT-JIS) based on the first 200 bytes of the file. Since each
-     * application has its own way to report and deal with errors, you should rather use the "parseFile" function to parse XML files
-     * and program yourself thereafter an "error reporting" tailored for your needs (instead of using the very crude "error reporting"
-     * mechanism included inside the "openFileHelper" function).
-     *
-     * If the XML document is corrupted, the "openFileHelper" method will:
-     *         - display an error message on the console (or inside a messageBox for windows).
-     *         - stop execution (exit).
-     *
-     * I strongly suggest that you write your own "openFileHelper" method tailored to your needs. If you still want to parse
-     * the file, you can use the APPROXIMATE_PARSING option as explained inside the note at the beginning of the "xmlParser.cpp" file.
-     *
-     * @param filename the path of the XML file to parse.
-     * @param tag the name of the first tag inside the XML file. If the tag parameter is omitted, this function returns a node that represents the head of the xml document including the declaration term (<? ... ?>).
-     */
+  static XMLCSTR getError(
+      XMLError error);  ///< this gives you a user-friendly explanation of the
+                        ///< parsing error
 
-    static XMLCSTR getError(XMLError error); ///< this gives you a user-friendly explanation of the parsing error
+  /// Create an XML string starting from the current XMLNode.
+  XMLSTR createXMLString(int nFormat = 1, int *pnSize = NULL) const;
+  /**< The returned string should be free'd using the "freeXMLString" function.
+   *
+   *   If nFormat==0, no formatting is required otherwise this returns an user
+   * friendly XML string from a given element
+   *   with appropriate white spaces and carriage returns. if pnSize is given it
+   * returns the size in character of the string. */
 
-    /// Create an XML string starting from the current XMLNode.
-    XMLSTR createXMLString(int nFormat=1, int *pnSize=NULL) const;
-    /**< The returned string should be free'd using the "freeXMLString" function.
-     *
-     *   If nFormat==0, no formatting is required otherwise this returns an user friendly XML string from a given element
-     *   with appropriate white spaces and carriage returns. if pnSize is given it returns the size in character of the string. */
+  /// Save the content of an xmlNode inside a file
+  XMLError writeToFile(XMLCSTR filename, const char *encoding = NULL,
+                       char nFormat = 1) const;
+  /**< If nFormat==0, no formatting is required otherwise this returns an user
+   * friendly XML string from a given element with appropriate white spaces and
+   * carriage returns. If the global parameter
+   * "characterEncoding==encoding_UTF8", then the "encoding" parameter is
+   * ignored and always set to "utf-8". If the global parameter
+   * "characterEncoding==encoding_ShiftJIS", then the "encoding" parameter is
+   * ignored and always set to "SHIFT-JIS". If "_XMLWIDECHAR=1", then the
+   * "encoding" parameter is ignored and always set to "utf-16". If no
+   * "encoding" parameter is given the "ISO-8859-1" encoding is used. */
+  /** @} */
 
-    /// Save the content of an xmlNode inside a file
-    XMLError writeToFile(XMLCSTR filename,
-                         const char *encoding=NULL,
-                         char nFormat=1) const;
-    /**< If nFormat==0, no formatting is required otherwise this returns an user friendly XML string from a given element with appropriate white spaces and carriage returns.
-     * If the global parameter "characterEncoding==encoding_UTF8", then the "encoding" parameter is ignored and always set to "utf-8".
-     * If the global parameter "characterEncoding==encoding_ShiftJIS", then the "encoding" parameter is ignored and always set to "SHIFT-JIS".
-     * If "_XMLWIDECHAR=1", then the "encoding" parameter is ignored and always set to "utf-16".
-     * If no "encoding" parameter is given the "ISO-8859-1" encoding is used. */
-    /** @} */
+  /** @defgroup navigate Navigate the XMLNode structure
+   * @ingroup XMLParserGeneral
+   * @{ */
+  XMLCSTR getName() const;                ///< name of the node
+  XMLCSTR getText(int i = 0) const;       ///< return ith text field
+  int nText() const;                      ///< nbr of text field
+  XMLNode getParentNode() const;          ///< return the parent node
+  XMLNode getChildNode(int i = 0) const;  ///< return ith child node
+  XMLNode getChildNode(XMLCSTR name, int i)
+      const;  ///< return ith child node with specific name (return an empty
+              ///< node if failing). If i==-1, this returns the last XMLNode
+              ///< with the given name.
+  XMLNode getChildNode(XMLCSTR name, int *i = NULL)
+      const;  ///< return next child node with specific name (return an empty
+              ///< node if failing)
+  XMLNode getChildNodeWithAttribute(
+      XMLCSTR tagName, XMLCSTR attributeName, XMLCSTR attributeValue = NULL,
+      int *i = NULL) const;  ///< return child node with specific name/attribute
+                             ///< (return an empty node if failing)
+  XMLNode getChildNodeByPath(XMLCSTR path, char createNodeIfMissing = 0,
+                             XMLCHAR sep = '/');
+  ///< return the first child node with specific path
+  XMLNode getChildNodeByPathNonConst(XMLSTR path, char createNodeIfMissing = 0,
+                                     XMLCHAR sep = '/');
+  ///< return the first child node with specific path.
 
-    /** @defgroup navigate Navigate the XMLNode structure
-     * @ingroup XMLParserGeneral
-     * @{ */
-    XMLCSTR getName() const;                                       ///< name of the node
-    XMLCSTR getText(int i=0) const;                                ///< return ith text field
-    int nText() const;                                             ///< nbr of text field
-    XMLNode getParentNode() const;                                 ///< return the parent node
-    XMLNode getChildNode(int i=0) const;                           ///< return ith child node
-    XMLNode getChildNode(XMLCSTR name, int i)  const;              ///< return ith child node with specific name (return an empty node if failing). If i==-1, this returns the last XMLNode with the given name.
-    XMLNode getChildNode(XMLCSTR name, int *i=NULL) const;         ///< return next child node with specific name (return an empty node if failing)
-    XMLNode getChildNodeWithAttribute(XMLCSTR tagName,
-                                      XMLCSTR attributeName,
-                                      XMLCSTR attributeValue=NULL,
-                                      int *i=NULL)  const;         ///< return child node with specific name/attribute (return an empty node if failing)
-    XMLNode getChildNodeByPath(XMLCSTR path, char createNodeIfMissing=0, XMLCHAR sep='/');
-                                                                   ///< return the first child node with specific path
-    XMLNode getChildNodeByPathNonConst(XMLSTR  path, char createNodeIfMissing=0, XMLCHAR sep='/');
-                                                                   ///< return the first child node with specific path.
+  int nChildNode(XMLCSTR name)
+      const;  ///< return the number of child node with specific name
+  int nChildNode() const;                      ///< nbr of child node
+  XMLAttribute getAttribute(int i = 0) const;  ///< return ith attribute
+  XMLCSTR getAttributeName(int i = 0) const;   ///< return ith attribute name
+  XMLCSTR getAttributeValue(int i = 0) const;  ///< return ith attribute value
+  char isAttributeSet(XMLCSTR name)
+      const;  ///< test if an attribute with a specific name is given
+  XMLCSTR getAttribute(
+      XMLCSTR name, int i) const;  ///< return ith attribute content with
+                                   ///< specific name (return a NULL if failing)
+  XMLCSTR getAttribute(XMLCSTR name, int *i = NULL)
+      const;  ///< return next attribute content with specific name (return a
+              ///< NULL if failing)
+  int nAttribute() const;              ///< nbr of attribute
+  XMLClear getClear(int i = 0) const;  ///< return ith clear field (comments)
+  int nClear() const;                  ///< nbr of clear field
+  XMLNodeContents enumContents(XMLElementPosition i)
+      const;  ///< enumerate all the different contents (attribute,child,text,
+              ///< clear) of the current XMLNode. The order is reflecting the
+              ///< order of the original file/string. NOTE: 0 <= i < nElement();
+  int nElement() const;        ///< nbr of different contents for current node
+  char isEmpty() const;        ///< is this node Empty?
+  char isDeclaration() const;  ///< is this node a declaration <? .... ?>
+  XMLNode deepCopy() const;    ///< deep copy (duplicate/clone) a XMLNode
+  static XMLNode emptyNode();  ///< return XMLNode::emptyXMLNode;
+  /** @} */
 
-    int nChildNode(XMLCSTR name) const;                            ///< return the number of child node with specific name
-    int nChildNode() const;                                        ///< nbr of child node
-    XMLAttribute getAttribute(int i=0) const;                      ///< return ith attribute
-    XMLCSTR      getAttributeName(int i=0) const;                  ///< return ith attribute name
-    XMLCSTR      getAttributeValue(int i=0) const;                 ///< return ith attribute value
-    char  isAttributeSet(XMLCSTR name) const;                      ///< test if an attribute with a specific name is given
-    XMLCSTR getAttribute(XMLCSTR name, int i) const;               ///< return ith attribute content with specific name (return a NULL if failing)
-    XMLCSTR getAttribute(XMLCSTR name, int *i=NULL) const;         ///< return next attribute content with specific name (return a NULL if failing)
-    int nAttribute() const;                                        ///< nbr of attribute
-    XMLClear getClear(int i=0) const;                              ///< return ith clear field (comments)
-    int nClear() const;                                            ///< nbr of clear field
-    XMLNodeContents enumContents(XMLElementPosition i) const;      ///< enumerate all the different contents (attribute,child,text, clear) of the current XMLNode. The order is reflecting the order of the original file/string. NOTE: 0 <= i < nElement();
-    int nElement() const;                                          ///< nbr of different contents for current node
-    char isEmpty() const;                                          ///< is this node Empty?
-    char isDeclaration() const;                                    ///< is this node a declaration <? .... ?>
-    XMLNode deepCopy() const;                                      ///< deep copy (duplicate/clone) a XMLNode
-    static XMLNode emptyNode();                                    ///< return XMLNode::emptyXMLNode;
-    /** @} */
+  ~XMLNode();
+  XMLNode(const XMLNode &A);             ///< to allow shallow/fast copy:
+  XMLNode &operator=(const XMLNode &A);  ///< to allow shallow/fast copy:
 
-    ~XMLNode();
-    XMLNode(const XMLNode &A);                                     ///< to allow shallow/fast copy:
-    XMLNode& operator=( const XMLNode& A );                        ///< to allow shallow/fast copy:
+  XMLNode() : d(NULL){};
+  static XMLNode emptyXMLNode;
+  static XMLClear emptyXMLClear;
+  static XMLAttribute emptyXMLAttribute;
 
-    XMLNode(): d(NULL){};
-    static XMLNode emptyXMLNode;
-    static XMLClear emptyXMLClear;
-    static XMLAttribute emptyXMLAttribute;
+  /** @defgroup xmlModify Create or Update the XMLNode structure
+   * @ingroup XMLParserGeneral
+   *  The functions in this group allows you to create from scratch (or update)
+   * a XMLNode structure. Start by creating your top node with the
+   * "createXMLTopNode" function and then add new nodes with the "addChild"
+   * function. The parameter 'pos' gives the position where the childNode, the
+   * text or the XMLClearTag will be inserted. The default value (pos=-1)
+   * inserts at the end. The value (pos=0) insert at the beginning (Insertion at
+   * the beginning is slower than at the end). <br>
+   *
+   *  REMARK: 0 <= pos < nChild()+nText()+nClear() <br>
+   */
 
-    /** @defgroup xmlModify Create or Update the XMLNode structure
-     * @ingroup XMLParserGeneral
-     *  The functions in this group allows you to create from scratch (or update) a XMLNode structure. Start by creating your top
-     *  node with the "createXMLTopNode" function and then add new nodes with the "addChild" function. The parameter 'pos' gives
-     *  the position where the childNode, the text or the XMLClearTag will be inserted. The default value (pos=-1) inserts at the
-     *  end. The value (pos=0) insert at the beginning (Insertion at the beginning is slower than at the end). <br>
-     *
-     *  REMARK: 0 <= pos < nChild()+nText()+nClear() <br>
-     */
+  /** @defgroup creation Creating from scratch a XMLNode structure
+   * @ingroup xmlModify
+   * @{ */
+  static XMLNode createXMLTopNode(
+      XMLCSTR lpszName,
+      char isDeclaration =
+          FALSE);  ///< Create the top node of an XMLNode structure
+  XMLNode addChild(XMLCSTR lpszName, char isDeclaration = FALSE,
+                   XMLElementPosition pos = -1);  ///< Add a new child node
+  XMLNode addChild(XMLNode nodeToAdd,
+                   XMLElementPosition pos =
+                       -1);  ///< If the "nodeToAdd" has some parents, it will
+                             ///< be detached from it's parents before being
+                             ///< attached to the current XMLNode
+  XMLAttribute *addAttribute(XMLCSTR lpszName,
+                             XMLCSTR lpszValuev);  ///< Add a new attribute
+  XMLCSTR addText(XMLCSTR lpszValue,
+                  XMLElementPosition pos = -1);  ///< Add a new text content
+  XMLClear *addClear(XMLCSTR lpszValue, XMLCSTR lpszOpen = NULL,
+                     XMLCSTR lpszClose = NULL, XMLElementPosition pos = -1);
+  /**< Add a new clear tag
+   * @param lpszOpen default value "<![CDATA["
+   * @param lpszClose default value "]]>"
+   */
+  /** @} */
 
-    /** @defgroup creation Creating from scratch a XMLNode structure
-     * @ingroup xmlModify
-     * @{ */
-    static XMLNode createXMLTopNode(XMLCSTR lpszName, char isDeclaration=FALSE);                    ///< Create the top node of an XMLNode structure
-    XMLNode        addChild(XMLCSTR lpszName, char isDeclaration=FALSE, XMLElementPosition pos=-1); ///< Add a new child node
-    XMLNode        addChild(XMLNode nodeToAdd, XMLElementPosition pos=-1);                          ///< If the "nodeToAdd" has some parents, it will be detached from it's parents before being attached to the current XMLNode
-    XMLAttribute  *addAttribute(XMLCSTR lpszName, XMLCSTR lpszValuev);                              ///< Add a new attribute
-    XMLCSTR        addText(XMLCSTR lpszValue, XMLElementPosition pos=-1);                           ///< Add a new text content
-    XMLClear      *addClear(XMLCSTR lpszValue, XMLCSTR lpszOpen=NULL, XMLCSTR lpszClose=NULL, XMLElementPosition pos=-1);
-    /**< Add a new clear tag
-     * @param lpszOpen default value "<![CDATA["
-     * @param lpszClose default value "]]>"
-     */
-    /** @} */
+  /** @defgroup xmlUpdate Updating Nodes
+   * @ingroup xmlModify
+   * Some update functions:
+   * @{
+   */
+  XMLCSTR updateName(XMLCSTR lpszName);  ///< change node's name
+  XMLAttribute *updateAttribute(
+      XMLAttribute *newAttribute,
+      XMLAttribute *oldAttribute);  ///< if the attribute to update is missing,
+                                    ///< a new one will be added
+  XMLAttribute *updateAttribute(
+      XMLCSTR lpszNewValue, XMLCSTR lpszNewName = NULL,
+      int i = 0);  ///< if the attribute to update is missing, a new one will be
+                   ///< added
+  XMLAttribute *updateAttribute(
+      XMLCSTR lpszNewValue, XMLCSTR lpszNewName,
+      XMLCSTR
+          lpszOldName);  ///< set lpszNewName=NULL if you don't want to change
+                         ///< the name of the attribute if the attribute to
+                         ///< update is missing, a new one will be added
+  XMLCSTR updateText(XMLCSTR lpszNewValue,
+                     int i = 0);  ///< if the text to update is missing, a new
+                                  ///< one will be added
+  XMLCSTR updateText(
+      XMLCSTR lpszNewValue,
+      XMLCSTR lpszOldValue);  ///< if the text to update is missing, a new one
+                              ///< will be added
+  XMLClear *updateClear(XMLCSTR lpszNewContent,
+                        int i = 0);  ///< if the clearTag to update is missing,
+                                     ///< a new one will be added
+  XMLClear *updateClear(XMLClear *newP,
+                        XMLClear *oldP);  ///< if the clearTag to update is
+                                          ///< missing, a new one will be added
+  XMLClear *updateClear(
+      XMLCSTR lpszNewValue,
+      XMLCSTR lpszOldValue);  ///< if the clearTag to update is missing, a new
+                              ///< one will be added
+  /** @} */
 
-    /** @defgroup xmlUpdate Updating Nodes
-     * @ingroup xmlModify
-     * Some update functions:
-     * @{
-     */
-    XMLCSTR       updateName(XMLCSTR lpszName);                                                  ///< change node's name
-    XMLAttribute *updateAttribute(XMLAttribute *newAttribute, XMLAttribute *oldAttribute);       ///< if the attribute to update is missing, a new one will be added
-    XMLAttribute *updateAttribute(XMLCSTR lpszNewValue, XMLCSTR lpszNewName=NULL,int i=0);       ///< if the attribute to update is missing, a new one will be added
-    XMLAttribute *updateAttribute(XMLCSTR lpszNewValue, XMLCSTR lpszNewName,XMLCSTR lpszOldName);///< set lpszNewName=NULL if you don't want to change the name of the attribute if the attribute to update is missing, a new one will be added
-    XMLCSTR       updateText(XMLCSTR lpszNewValue, int i=0);                                     ///< if the text to update is missing, a new one will be added
-    XMLCSTR       updateText(XMLCSTR lpszNewValue, XMLCSTR lpszOldValue);                        ///< if the text to update is missing, a new one will be added
-    XMLClear     *updateClear(XMLCSTR lpszNewContent, int i=0);                                  ///< if the clearTag to update is missing, a new one will be added
-    XMLClear     *updateClear(XMLClear *newP,XMLClear *oldP);                                    ///< if the clearTag to update is missing, a new one will be added
-    XMLClear     *updateClear(XMLCSTR lpszNewValue, XMLCSTR lpszOldValue);                       ///< if the clearTag to update is missing, a new one will be added
-    /** @} */
+  /** @defgroup xmlDelete Deleting Nodes or Attributes
+   * @ingroup xmlModify
+   * Some deletion functions:
+   * @{
+   */
+  /// The "deleteNodeContent" function forces the deletion of the content of
+  /// this XMLNode and the subtree.
+  void deleteNodeContent();
+  /**< \note The XMLNode instances that are referring to the part of the subtree
+   * that has been deleted CANNOT be used anymore!!. Unexpected results will
+   * occur if you continue using them. */
+  void deleteAttribute(
+      int i = 0);  ///< Delete the ith attribute of the current XMLNode
+  void deleteAttribute(
+      XMLCSTR lpszName);  ///< Delete the attribute with the given name (the
+                          ///< "strcmp" function is used to find the right
+                          ///< attribute)
+  void deleteAttribute(
+      XMLAttribute
+          *anAttribute);  ///< Delete the attribute with the name
+                          ///< "anAttribute->lpszName" (the "strcmp" function is
+                          ///< used to find the right attribute)
+  void deleteText(
+      int i = 0);  ///< Delete the Ith text content of the current XMLNode
+  void deleteText(
+      XMLCSTR lpszValue);  ///< Delete the text content "lpszValue" inside the
+                           ///< current XMLNode (direct "pointer-to-pointer"
+                           ///< comparison is used to find the right text)
+  void deleteClear(
+      int i = 0);  ///< Delete the Ith clear tag inside the current XMLNode
+  void deleteClear(
+      XMLCSTR lpszValue);  ///< Delete the clear tag "lpszValue" inside the
+                           ///< current XMLNode (direct "pointer-to-pointer"
+                           ///< comparison is used to find the clear tag)
+  void deleteClear(
+      XMLClear
+          *p);  ///< Delete the clear tag "p" inside the current XMLNode (direct
+                ///< "pointer-to-pointer" comparison on the lpszName of the
+                ///< clear tag is used to find the clear tag)
+  /** @} */
 
-    /** @defgroup xmlDelete Deleting Nodes or Attributes
-     * @ingroup xmlModify
-     * Some deletion functions:
-     * @{
-     */
-    /// The "deleteNodeContent" function forces the deletion of the content of this XMLNode and the subtree.
-    void deleteNodeContent();
-    /**< \note The XMLNode instances that are referring to the part of the subtree that has been deleted CANNOT be used anymore!!. Unexpected results will occur if you continue using them. */
-    void deleteAttribute(int i=0);                   ///< Delete the ith attribute of the current XMLNode
-    void deleteAttribute(XMLCSTR lpszName);          ///< Delete the attribute with the given name (the "strcmp" function is used to find the right attribute)
-    void deleteAttribute(XMLAttribute *anAttribute); ///< Delete the attribute with the name "anAttribute->lpszName" (the "strcmp" function is used to find the right attribute)
-    void deleteText(int i=0);                        ///< Delete the Ith text content of the current XMLNode
-    void deleteText(XMLCSTR lpszValue);              ///< Delete the text content "lpszValue" inside the current XMLNode (direct "pointer-to-pointer" comparison is used to find the right text)
-    void deleteClear(int i=0);                       ///< Delete the Ith clear tag inside the current XMLNode
-    void deleteClear(XMLCSTR lpszValue);             ///< Delete the clear tag "lpszValue" inside the current XMLNode (direct "pointer-to-pointer" comparison is used to find the clear tag)
-    void deleteClear(XMLClear *p);                   ///< Delete the clear tag "p" inside the current XMLNode (direct "pointer-to-pointer" comparison on the lpszName of the clear tag is used to find the clear tag)
-    /** @} */
+  /** @defgroup xmlWOSD ???_WOSD functions.
+   * @ingroup xmlModify
+   *  The strings given as parameters for the "add" and "update" methods that
+   * have a name with the postfix "_WOSD" (that means "WithOut String
+   * Duplication")(for example "addText_WOSD") will be free'd by the XMLNode
+   * class. For example, it means that this is incorrect: \code
+   *     xNode.addText_WOSD("foo");
+   *     xNode.updateAttribute_WOSD("#newcolor" ,NULL,"color");
+   *  \endcode
+   *  In opposition, this is correct:
+   *  \code
+   *     xNode.addText("foo");
+   *     xNode.addText_WOSD(stringDup("foo"));
+   *     xNode.updateAttribute("#newcolor" ,NULL,"color");
+   *     xNode.updateAttribute_WOSD(stringDup("#newcolor"),NULL,"color");
+   *  \endcode
+   *  Typically, you will never do:
+   *  \code
+   *     char *b=(char*)malloc(...);
+   *     xNode.addText(b);
+   *     free(b);
+   *  \endcode
+   *  ... but rather:
+   *  \code
+   *     char *b=(char*)malloc(...);
+   *     xNode.addText_WOSD(b);
+   *  \endcode
+   *  ('free(b)' is performed by the XMLNode class)
+   * @{ */
+  static XMLNode createXMLTopNode_WOSD(
+      XMLSTR lpszName,
+      char isDeclaration =
+          FALSE);  ///< Create the top node of an XMLNode structure
+  XMLNode addChild_WOSD(XMLSTR lpszName, char isDeclaration = FALSE,
+                        XMLElementPosition pos = -1);  ///< Add a new child node
+  XMLAttribute *addAttribute_WOSD(XMLSTR lpszName,
+                                  XMLSTR lpszValue);  ///< Add a new attribute
+  XMLCSTR addText_WOSD(XMLSTR lpszValue, XMLElementPosition pos =
+                                             -1);  ///< Add a new text content
+  XMLClear *addClear_WOSD(
+      XMLSTR lpszValue, XMLCSTR lpszOpen = NULL, XMLCSTR lpszClose = NULL,
+      XMLElementPosition pos = -1);  ///< Add a new clear Tag
 
-    /** @defgroup xmlWOSD ???_WOSD functions.
-     * @ingroup xmlModify
-     *  The strings given as parameters for the "add" and "update" methods that have a name with
-     *  the postfix "_WOSD" (that means "WithOut String Duplication")(for example "addText_WOSD")
-     *  will be free'd by the XMLNode class. For example, it means that this is incorrect:
-     *  \code
-     *     xNode.addText_WOSD("foo");
-     *     xNode.updateAttribute_WOSD("#newcolor" ,NULL,"color");
-     *  \endcode
-     *  In opposition, this is correct:
-     *  \code
-     *     xNode.addText("foo");
-     *     xNode.addText_WOSD(stringDup("foo"));
-     *     xNode.updateAttribute("#newcolor" ,NULL,"color");
-     *     xNode.updateAttribute_WOSD(stringDup("#newcolor"),NULL,"color");
-     *  \endcode
-     *  Typically, you will never do:
-     *  \code
-     *     char *b=(char*)malloc(...);
-     *     xNode.addText(b);
-     *     free(b);
-     *  \endcode
-     *  ... but rather:
-     *  \code
-     *     char *b=(char*)malloc(...);
-     *     xNode.addText_WOSD(b);
-     *  \endcode
-     *  ('free(b)' is performed by the XMLNode class)
-     * @{ */
-    static XMLNode createXMLTopNode_WOSD(XMLSTR lpszName, char isDeclaration=FALSE);                     ///< Create the top node of an XMLNode structure
-    XMLNode        addChild_WOSD(XMLSTR lpszName, char isDeclaration=FALSE, XMLElementPosition pos=-1);  ///< Add a new child node
-    XMLAttribute  *addAttribute_WOSD(XMLSTR lpszName, XMLSTR lpszValue);                                 ///< Add a new attribute
-    XMLCSTR        addText_WOSD(XMLSTR lpszValue, XMLElementPosition pos=-1);                            ///< Add a new text content
-    XMLClear      *addClear_WOSD(XMLSTR lpszValue, XMLCSTR lpszOpen=NULL, XMLCSTR lpszClose=NULL, XMLElementPosition pos=-1); ///< Add a new clear Tag
+  XMLCSTR updateName_WOSD(XMLSTR lpszName);  ///< change node's name
+  XMLAttribute *updateAttribute_WOSD(
+      XMLAttribute *newAttribute,
+      XMLAttribute *oldAttribute);  ///< if the attribute to update is missing,
+                                    ///< a new one will be added
+  XMLAttribute *updateAttribute_WOSD(
+      XMLSTR lpszNewValue, XMLSTR lpszNewName = NULL,
+      int i = 0);  ///< if the attribute to update is missing, a new one will be
+                   ///< added
+  XMLAttribute *updateAttribute_WOSD(
+      XMLSTR lpszNewValue, XMLSTR lpszNewName,
+      XMLCSTR
+          lpszOldName);  ///< set lpszNewName=NULL if you don't want to change
+                         ///< the name of the attribute if the attribute to
+                         ///< update is missing, a new one will be added
+  XMLCSTR updateText_WOSD(XMLSTR lpszNewValue,
+                          int i = 0);  ///< if the text to update is missing, a
+                                       ///< new one will be added
+  XMLCSTR updateText_WOSD(
+      XMLSTR lpszNewValue,
+      XMLCSTR lpszOldValue);  ///< if the text to update is missing, a new one
+                              ///< will be added
+  XMLClear *updateClear_WOSD(XMLSTR lpszNewContent,
+                             int i = 0);  ///< if the clearTag to update is
+                                          ///< missing, a new one will be added
+  XMLClear *updateClear_WOSD(
+      XMLClear *newP, XMLClear *oldP);  ///< if the clearTag to update is
+                                        ///< missing, a new one will be added
+  XMLClear *updateClear_WOSD(
+      XMLSTR lpszNewValue,
+      XMLCSTR lpszOldValue);  ///< if the clearTag to update is missing, a new
+                              ///< one will be added
+  /** @} */
 
-    XMLCSTR        updateName_WOSD(XMLSTR lpszName);                                                  ///< change node's name
-    XMLAttribute  *updateAttribute_WOSD(XMLAttribute *newAttribute, XMLAttribute *oldAttribute);      ///< if the attribute to update is missing, a new one will be added
-    XMLAttribute  *updateAttribute_WOSD(XMLSTR lpszNewValue, XMLSTR lpszNewName=NULL,int i=0);        ///< if the attribute to update is missing, a new one will be added
-    XMLAttribute  *updateAttribute_WOSD(XMLSTR lpszNewValue, XMLSTR lpszNewName,XMLCSTR lpszOldName); ///< set lpszNewName=NULL if you don't want to change the name of the attribute if the attribute to update is missing, a new one will be added
-    XMLCSTR        updateText_WOSD(XMLSTR lpszNewValue, int i=0);                                     ///< if the text to update is missing, a new one will be added
-    XMLCSTR        updateText_WOSD(XMLSTR lpszNewValue, XMLCSTR lpszOldValue);                        ///< if the text to update is missing, a new one will be added
-    XMLClear      *updateClear_WOSD(XMLSTR lpszNewContent, int i=0);                                  ///< if the clearTag to update is missing, a new one will be added
-    XMLClear      *updateClear_WOSD(XMLClear *newP,XMLClear *oldP);                                   ///< if the clearTag to update is missing, a new one will be added
-    XMLClear      *updateClear_WOSD(XMLSTR lpszNewValue, XMLCSTR lpszOldValue);                       ///< if the clearTag to update is missing, a new one will be added
-    /** @} */
+  /** @defgroup xmlPosition Position helper functions (use in conjunction with
+   * the update&add functions
+   * @ingroup xmlModify
+   * These are some useful functions when you want to insert a childNode, a text
+   * or a XMLClearTag in the middle (at a specified position) of a XMLNode tree
+   * already constructed. The value returned by these methods is to be used as
+   * last parameter (parameter 'pos') of addChild, addText or addClear.
+   * @{ */
+  XMLElementPosition positionOfText(int i = 0) const;
+  XMLElementPosition positionOfText(XMLCSTR lpszValue) const;
+  XMLElementPosition positionOfClear(int i = 0) const;
+  XMLElementPosition positionOfClear(XMLCSTR lpszValue) const;
+  XMLElementPosition positionOfClear(XMLClear *a) const;
+  XMLElementPosition positionOfChildNode(int i = 0) const;
+  XMLElementPosition positionOfChildNode(XMLNode x) const;
+  XMLElementPosition positionOfChildNode(XMLCSTR name, int i = 0)
+      const;  ///< return the position of the ith childNode with the specified
+              ///< name if (name==NULL) return the position of the ith childNode
+  /** @} */
 
-    /** @defgroup xmlPosition Position helper functions (use in conjunction with the update&add functions
-     * @ingroup xmlModify
-     * These are some useful functions when you want to insert a childNode, a text or a XMLClearTag in the
-     * middle (at a specified position) of a XMLNode tree already constructed. The value returned by these
-     * methods is to be used as last parameter (parameter 'pos') of addChild, addText or addClear.
-     * @{ */
-    XMLElementPosition positionOfText(int i=0) const;
-    XMLElementPosition positionOfText(XMLCSTR lpszValue) const;
-    XMLElementPosition positionOfClear(int i=0) const;
-    XMLElementPosition positionOfClear(XMLCSTR lpszValue) const;
-    XMLElementPosition positionOfClear(XMLClear *a) const;
-    XMLElementPosition positionOfChildNode(int i=0) const;
-    XMLElementPosition positionOfChildNode(XMLNode x) const;
-    XMLElementPosition positionOfChildNode(XMLCSTR name, int i=0) const; ///< return the position of the ith childNode with the specified name if (name==NULL) return the position of the ith childNode
-    /** @} */
+  /// Enumeration for XML character encoding.
+  typedef enum XMLCharEncoding {
+    char_encoding_error = 0,
+    char_encoding_UTF8 = 1,
+    char_encoding_legacy = 2,
+    char_encoding_ShiftJIS = 3,
+    char_encoding_GB2312 = 4,
+    char_encoding_Big5 = 5,
+    char_encoding_GBK = 6  // this is actually the same as Big5
+  } XMLCharEncoding;
 
-    /// Enumeration for XML character encoding.
-    typedef enum XMLCharEncoding
-    {
-        char_encoding_error=0,
-        char_encoding_UTF8=1,
-        char_encoding_legacy=2,
-        char_encoding_ShiftJIS=3,
-        char_encoding_GB2312=4,
-        char_encoding_Big5=5,
-        char_encoding_GBK=6     // this is actually the same as Big5
-    } XMLCharEncoding;
+  /** \addtogroup conversions
+   * @{ */
 
-    /** \addtogroup conversions
-     * @{ */
+  /// Sets the global options for the conversions
+  static char setGlobalOptions(
+      XMLCharEncoding characterEncoding = XMLNode::char_encoding_UTF8,
+      char guessWideCharChars = 1, char dropWhiteSpace = 1,
+      char removeCommentsInMiddleOfText = 1);
+  /**< The "setGlobalOptions" function allows you to change four global
+   * parameters that affect string & file parsing. First of all, you
+   * most-probably will never have to change these 3 global parameters.
+   *
+   * @param guessWideCharChars If "guessWideCharChars"=1 and if this library is
+   * compiled in WideChar mode, then the XMLNode::parseFile and
+   * XMLNode::openFileHelper functions will test if the file contains ASCII
+   *     characters. If this is the case, then the file will be loaded and
+   * converted in memory to WideChar before being parsed. If 0, no conversion
+   * will be performed.
+   *
+   * @param guessWideCharChars If "guessWideCharChars"=1 and if this library is
+   * compiled in ASCII/UTF8/char* mode, then the XMLNode::parseFile and
+   * XMLNode::openFileHelper functions will test if the file contains WideChar
+   *     characters. If this is the case, then the file will be loaded and
+   * converted in memory to ASCII/UTF8/char* before being parsed. If 0, no
+   * conversion will be performed.
+   *
+   * @param characterEncoding This parameter is only meaningful when compiling
+   * in char* mode (multibyte character mode). In wchar_t* (wide char mode),
+   * this parameter is ignored. This parameter should be one of the three
+   * currently recognized encodings: XMLNode::encoding_UTF8,
+   * XMLNode::encoding_ascii, XMLNode::encoding_ShiftJIS.
+   *
+   * @param dropWhiteSpace In most situations, text fields containing only white
+   * spaces (and carriage returns) are useless. Even more, these "empty" text
+   * fields are annoying because they increase the complexity of the user's code
+   * for parsing. So, 99% of the time, it's better to drop the "empty" text
+   * fields. However The XML specification indicates that no white spaces should
+   * be lost when parsing the file. So to be perfectly XML-compliant, you should
+   * set dropWhiteSpace=0. A note of caution: if you set "dropWhiteSpace=0", the
+   * parser will be slower and your code will be more complex.
+   *
+   * @param removeCommentsInMiddleOfText To explain this parameter, let's
+   * consider this code: \code XMLNode x=XMLNode::parseString("<a>foo<!-- hello
+   * -->bar<!DOCTYPE world >chu</a>","a"); \endcode If
+   * removeCommentsInMiddleOfText=0, then we will have: \code x.getText(0) ->
+   * "foo" x.getText(1) -> "bar" x.getText(2) -> "chu" x.getClear(0) --> "<!--
+   * hello -->" x.getClear(1) --> "<!DOCTYPE world >" \endcode If
+   * removeCommentsInMiddleOfText=1, then we will have: \code x.getText(0) ->
+   * "foobar" x.getText(1) -> "chu" x.getClear(0) --> "<!DOCTYPE world >"
+   * \endcode
+   *
+   * \return "0" when there are no errors. If you try to set an unrecognized
+   * encoding then the return value will be "1" to signal an error.
+   *
+   * \note Sometime, it's useful to set "guessWideCharChars=0" to disable any
+   * conversion because the test to detect the file-type (ASCII/UTF8/char* or
+   * WideChar) may fail (rarely). */
 
-    /// Sets the global options for the conversions
-    static char setGlobalOptions(XMLCharEncoding characterEncoding=XMLNode::char_encoding_UTF8, char guessWideCharChars=1,
-                                 char dropWhiteSpace=1, char removeCommentsInMiddleOfText=1);
-    /**< The "setGlobalOptions" function allows you to change four global parameters that affect string & file
-     * parsing. First of all, you most-probably will never have to change these 3 global parameters.
-     *
-     * @param guessWideCharChars If "guessWideCharChars"=1 and if this library is compiled in WideChar mode, then the
-     *     XMLNode::parseFile and XMLNode::openFileHelper functions will test if the file contains ASCII
-     *     characters. If this is the case, then the file will be loaded and converted in memory to
-     *     WideChar before being parsed. If 0, no conversion will be performed.
-     *
-     * @param guessWideCharChars If "guessWideCharChars"=1 and if this library is compiled in ASCII/UTF8/char* mode, then the
-     *     XMLNode::parseFile and XMLNode::openFileHelper functions will test if the file contains WideChar
-     *     characters. If this is the case, then the file will be loaded and converted in memory to
-     *     ASCII/UTF8/char* before being parsed. If 0, no conversion will be performed.
-     *
-     * @param characterEncoding This parameter is only meaningful when compiling in char* mode (multibyte character mode).
-     *     In wchar_t* (wide char mode), this parameter is ignored. This parameter should be one of the
-     *     three currently recognized encodings: XMLNode::encoding_UTF8, XMLNode::encoding_ascii,
-     *     XMLNode::encoding_ShiftJIS.
-     *
-     * @param dropWhiteSpace In most situations, text fields containing only white spaces (and carriage returns)
-     *     are useless. Even more, these "empty" text fields are annoying because they increase the
-     *     complexity of the user's code for parsing. So, 99% of the time, it's better to drop
-     *     the "empty" text fields. However The XML specification indicates that no white spaces
-     *     should be lost when parsing the file. So to be perfectly XML-compliant, you should set
-     *     dropWhiteSpace=0. A note of caution: if you set "dropWhiteSpace=0", the parser will be
-     *     slower and your code will be more complex.
-     *
-     * @param removeCommentsInMiddleOfText To explain this parameter, let's consider this code:
-     * \code
-     *        XMLNode x=XMLNode::parseString("<a>foo<!-- hello -->bar<!DOCTYPE world >chu</a>","a");
-     * \endcode
-     *     If removeCommentsInMiddleOfText=0, then we will have:
-     * \code
-     *        x.getText(0) -> "foo"
-     *        x.getText(1) -> "bar"
-     *        x.getText(2) -> "chu"
-     *        x.getClear(0) --> "<!-- hello -->"
-     *        x.getClear(1) --> "<!DOCTYPE world >"
-     * \endcode
-     *     If removeCommentsInMiddleOfText=1, then we will have:
-     * \code
-     *        x.getText(0) -> "foobar"
-     *        x.getText(1) -> "chu"
-     *        x.getClear(0) --> "<!DOCTYPE world >"
-     * \endcode
-     *
-     * \return "0" when there are no errors. If you try to set an unrecognized encoding then the return value will be "1" to signal an error.
-     *
-     * \note Sometime, it's useful to set "guessWideCharChars=0" to disable any conversion
-     * because the test to detect the file-type (ASCII/UTF8/char* or WideChar) may fail (rarely). */
+  /// Guess the character encoding of the string (ascii, utf8 or shift-JIS)
+  static XMLCharEncoding guessCharEncoding(void *buffer, int bufLen,
+                                           char useXMLEncodingAttribute = 1);
+  /**< The "guessCharEncoding" function try to guess the character encoding. You
+   * most-probably will never have to use this function. It then returns the
+   * appropriate value of the global parameter "characterEncoding" described in
+   * the XMLNode::setGlobalOptions. The guess is based on the content of a
+   * buffer of length "bufLen" bytes that contains the first bytes (minimum 25
+   * bytes; 200 bytes is a good value) of the file to be parsed. The
+   * XMLNode::openFileHelper function is using this function to automatically
+   * compute the value of the "characterEncoding" global parameter. There are
+   * several heuristics used to do the guess. One of the heuristic is based on
+   * the "encoding" attribute. The original XML specifications forbids to use
+   * this attribute to do the guess but you can still use it if you set
+   * "useXMLEncodingAttribute" to 1 (this is the default behavior and the
+   * behavior of most parsers).
+   * If an inconsistency in the encoding is detected, then the return value is
+   * "0". */
+  /** @} */
 
-    /// Guess the character encoding of the string (ascii, utf8 or shift-JIS)
-    static XMLCharEncoding guessCharEncoding(void *buffer, int bufLen, char useXMLEncodingAttribute=1);
-    /**< The "guessCharEncoding" function try to guess the character encoding. You most-probably will never
-     * have to use this function. It then returns the appropriate value of the global parameter
-     * "characterEncoding" described in the XMLNode::setGlobalOptions. The guess is based on the content of a buffer of length
-     * "bufLen" bytes that contains the first bytes (minimum 25 bytes; 200 bytes is a good value) of the
-     * file to be parsed. The XMLNode::openFileHelper function is using this function to automatically compute
-     * the value of the "characterEncoding" global parameter. There are several heuristics used to do the
-     * guess. One of the heuristic is based on the "encoding" attribute. The original XML specifications
-     * forbids to use this attribute to do the guess but you can still use it if you set
-     * "useXMLEncodingAttribute" to 1 (this is the default behavior and the behavior of most parsers).
-     * If an inconsistency in the encoding is detected, then the return value is "0". */
-    /** @} */
+ private:
+  // these are functions and structures used internally by the XMLNode class
+  // (don't bother about them):
 
-  private:
-      // these are functions and structures used internally by the XMLNode class (don't bother about them):
+  typedef struct XMLNodeDataTag  // to allow shallow copy and
+                                 // "intelligent/smart" pointers (automatic
+                                 // delete):
+  {
+    XMLCSTR lpszName;    // Element name (=NULL if root)
+    int nChild,          // Number of child nodes
+        nText,           // Number of text fields
+        nClear,          // Number of Clear fields (comments)
+        nAttribute;      // Number of attributes
+    char isDeclaration;  // Whether node is an XML declaration - '<?xml ?>'
+    struct XMLNodeDataTag
+        *pParent;              // Pointer to parent element (=NULL if root)
+    XMLNode *pChild;           // Array of child nodes
+    XMLCSTR *pText;            // Array of text fields
+    XMLClear *pClear;          // Array of clear fields
+    XMLAttribute *pAttribute;  // Array of attributes
+    int *pOrder;    // order of the child_nodes,text_fields,clear_fields
+    int ref_count;  // for garbage collection (smart pointers)
+  } XMLNodeData;
+  XMLNodeData *d;
 
-      typedef struct XMLNodeDataTag // to allow shallow copy and "intelligent/smart" pointers (automatic delete):
-      {
-          XMLCSTR                lpszName;        // Element name (=NULL if root)
-          int                    nChild,          // Number of child nodes
-                                 nText,           // Number of text fields
-                                 nClear,          // Number of Clear fields (comments)
-                                 nAttribute;      // Number of attributes
-          char                   isDeclaration;   // Whether node is an XML declaration - '<?xml ?>'
-          struct XMLNodeDataTag  *pParent;        // Pointer to parent element (=NULL if root)
-          XMLNode                *pChild;         // Array of child nodes
-          XMLCSTR                *pText;          // Array of text fields
-          XMLClear               *pClear;         // Array of clear fields
-          XMLAttribute           *pAttribute;     // Array of attributes
-          int                    *pOrder;         // order of the child_nodes,text_fields,clear_fields
-          int                    ref_count;       // for garbage collection (smart pointers)
-      } XMLNodeData;
-      XMLNodeData *d;
-
-      char parseClearTag(void *px, void *pa);
-      char maybeAddTxT(void *pa, XMLCSTR tokenPStr);
-      int ParseXMLElement(void *pXML);
-      void *addToOrder(int memInc, int *_pos, int nc, void *p, int size, XMLElementType xtype);
-      int indexText(XMLCSTR lpszValue) const;
-      int indexClear(XMLCSTR lpszValue) const;
-      XMLNode addChild_priv(int,XMLSTR,char,int);
-      XMLAttribute *addAttribute_priv(int,XMLSTR,XMLSTR);
-      XMLCSTR addText_priv(int,XMLSTR,int);
-      XMLClear *addClear_priv(int,XMLSTR,XMLCSTR,XMLCSTR,int);
-      void emptyTheNode(char force);
-      static inline XMLElementPosition findPosition(XMLNodeData *d, int index, XMLElementType xtype);
-      static int CreateXMLStringR(XMLNodeData *pEntry, XMLSTR lpszMarker, int nFormat);
-      static int removeOrderElement(XMLNodeData *d, XMLElementType t, int index);
-      static void exactMemory(XMLNodeData *d);
-      static int detachFromParent(XMLNodeData *d);
+  char parseClearTag(void *px, void *pa);
+  char maybeAddTxT(void *pa, XMLCSTR tokenPStr);
+  int ParseXMLElement(void *pXML);
+  void *addToOrder(int memInc, int *_pos, int nc, void *p, int size,
+                   XMLElementType xtype);
+  int indexText(XMLCSTR lpszValue) const;
+  int indexClear(XMLCSTR lpszValue) const;
+  XMLNode addChild_priv(int, XMLSTR, char, int);
+  XMLAttribute *addAttribute_priv(int, XMLSTR, XMLSTR);
+  XMLCSTR addText_priv(int, XMLSTR, int);
+  XMLClear *addClear_priv(int, XMLSTR, XMLCSTR, XMLCSTR, int);
+  void emptyTheNode(char force);
+  static inline XMLElementPosition findPosition(XMLNodeData *d, int index,
+                                                XMLElementType xtype);
+  static int CreateXMLStringR(XMLNodeData *pEntry, XMLSTR lpszMarker,
+                              int nFormat);
+  static int removeOrderElement(XMLNodeData *d, XMLElementType t, int index);
+  static void exactMemory(XMLNodeData *d);
+  static int detachFromParent(XMLNodeData *d);
 } XMLNode;
 
 /// This structure is given by the function XMLNode::enumContents.
-typedef struct XMLNodeContents
-{
-    /// This dictates what's the content of the XMLNodeContent
-    enum XMLElementType etype;
-    /**< should be an union to access the appropriate data. Compiler does not allow union of object with constructor... too bad. */
-    XMLNode child;
-    XMLAttribute attrib;
-    XMLCSTR text;
-    XMLClear clear;
+typedef struct XMLNodeContents {
+  /// This dictates what's the content of the XMLNodeContent
+  enum XMLElementType etype;
+  /**< should be an union to access the appropriate data. Compiler does not
+   * allow union of object with constructor... too bad. */
+  XMLNode child;
+  XMLAttribute attrib;
+  XMLCSTR text;
+  XMLClear clear;
 
 } XMLNodeContents;
 
@@ -645,118 +821,150 @@ typedef struct XMLNodeContents
  * @ingroup xmlModify
  * @{ */
 /// Duplicate (copy in a new allocated buffer) the source string.
-XMLDLLENTRY XMLSTR stringDup(XMLCSTR source, int cbData=-1);
+XMLDLLENTRY XMLSTR stringDup(XMLCSTR source, int cbData = -1);
 /**< This is
- * a very handy function when used with all the "XMLNode::*_WOSD" functions (\link xmlWOSD \endlink).
- * @param cbData If !=0 then cbData is the number of chars to duplicate. New strings allocated with
- * this function should be free'd using the "freeXMLString" function. */
+ * a very handy function when used with all the "XMLNode::*_WOSD" functions
+ * (\link xmlWOSD \endlink).
+ * @param cbData If !=0 then cbData is the number of chars to duplicate. New
+ * strings allocated with this function should be free'd using the
+ * "freeXMLString" function. */
 
-/// to free the string allocated inside the "stringDup" function or the "createXMLString" function.
-XMLDLLENTRY void freeXMLString(XMLSTR t); // {free(t);}
+/// to free the string allocated inside the "stringDup" function or the
+/// "createXMLString" function.
+XMLDLLENTRY void freeXMLString(XMLSTR t);  // {free(t);}
 /** @} */
 
 /** @defgroup atoX ato? like functions
  * @ingroup XMLParserGeneral
  * The "xmlto?" functions are equivalents to the atoi, atol, atof functions.
- * The only difference is: If the variable "xmlString" is NULL, than the return value
- * is "defautValue". These 6 functions are only here as "convenience" functions for the
- * user (they are not used inside the XMLparser). If you don't need them, you can
- * delete them without any trouble.
+ * The only difference is: If the variable "xmlString" is NULL, than the return
+ * value is "defautValue". These 6 functions are only here as "convenience"
+ * functions for the user (they are not used inside the XMLparser). If you don't
+ * need them, you can delete them without any trouble.
  *
  * @{ */
-XMLDLLENTRY char    xmltob(XMLCSTR xmlString,char   defautValue=0);
-XMLDLLENTRY int     xmltoi(XMLCSTR xmlString,int    defautValue=0);
-XMLDLLENTRY long    xmltol(XMLCSTR xmlString,long   defautValue=0);
-XMLDLLENTRY double  xmltof(XMLCSTR xmlString,double defautValue=.0);
-XMLDLLENTRY XMLCSTR xmltoa(XMLCSTR xmlString,XMLCSTR defautValue=_CXML(""));
-XMLDLLENTRY XMLCHAR xmltoc(XMLCSTR xmlString,XMLCHAR defautValue=_CXML('\0'));
+XMLDLLENTRY char xmltob(XMLCSTR xmlString, char defautValue = 0);
+XMLDLLENTRY int xmltoi(XMLCSTR xmlString, int defautValue = 0);
+XMLDLLENTRY long xmltol(XMLCSTR xmlString, long defautValue = 0);
+XMLDLLENTRY double xmltof(XMLCSTR xmlString, double defautValue = .0);
+XMLDLLENTRY XMLCSTR xmltoa(XMLCSTR xmlString, XMLCSTR defautValue = _CXML(""));
+XMLDLLENTRY XMLCHAR xmltoc(XMLCSTR xmlString,
+                           XMLCHAR defautValue = _CXML('\0'));
 /** @} */
 
-/** @defgroup ToXMLStringTool Helper class to create XML files using "printf", "fprintf", "cout",... functions.
+/** @defgroup ToXMLStringTool Helper class to create XML files using "printf",
+ * "fprintf", "cout",... functions.
  * @ingroup XMLParserGeneral
  * @{ */
-/// Helper class to create XML files using "printf", "fprintf", "cout",... functions.
-/** The ToXMLStringTool class helps you creating XML files using "printf", "fprintf", "cout",... functions.
- * The "ToXMLStringTool" class is processing strings so that all the characters
+/// Helper class to create XML files using "printf", "fprintf", "cout",...
+/// functions.
+/** The ToXMLStringTool class helps you creating XML files using "printf",
+ * "fprintf", "cout",... functions. The "ToXMLStringTool" class is processing
+ * strings so that all the characters
  * &,",',<,> are replaced by their XML equivalent:
  * \verbatim &amp;, &quot;, &apos;, &lt;, &gt; \endverbatim
- * Using the "ToXMLStringTool class" and the "fprintf function" is THE most efficient
- * way to produce VERY large XML documents VERY fast.
- * \note If you are creating from scratch an XML file using the provided XMLNode class
- * you must not use the "ToXMLStringTool" class (because the "XMLNode" class does the
+ * Using the "ToXMLStringTool class" and the "fprintf function" is THE most
+ * efficient way to produce VERY large XML documents VERY fast. \note If you are
+ * creating from scratch an XML file using the provided XMLNode class you must
+ * not use the "ToXMLStringTool" class (because the "XMLNode" class does the
  * processing job for you during rendering).*/
-typedef struct XMLDLLENTRY ToXMLStringTool
-{
-public:
-    ToXMLStringTool(): buf(NULL),buflen(0){}
-    ~ToXMLStringTool();
-    void freeBuffer();///<call this function when you have finished using this object to release memory used by the internal buffer.
+typedef struct XMLDLLENTRY ToXMLStringTool {
+ public:
+  ToXMLStringTool() : buf(NULL), buflen(0) {}
+  ~ToXMLStringTool();
+  void freeBuffer();  ///< call this function when you have finished using this
+                      ///< object to release memory used by the internal buffer.
 
-    XMLSTR toXML(XMLCSTR source);///< returns a pointer to an internal buffer that contains a XML-encoded string based on the "source" parameter.
+  XMLSTR toXML(XMLCSTR source);  ///< returns a pointer to an internal buffer
+                                 ///< that contains a XML-encoded string based
+                                 ///< on the "source" parameter.
 
-    /** The "toXMLUnSafe" function is deprecated because there is a possibility of
-     * "destination-buffer-overflow". It converts the string
-     * "source" to the string "dest". */
-    static XMLSTR toXMLUnSafe(XMLSTR dest,XMLCSTR source); ///< deprecated: use "toXML" instead
-    static int lengthXMLString(XMLCSTR source);            ///< deprecated: use "toXML" instead
+  /** The "toXMLUnSafe" function is deprecated because there is a possibility of
+   * "destination-buffer-overflow". It converts the string
+   * "source" to the string "dest". */
+  static XMLSTR toXMLUnSafe(
+      XMLSTR dest, XMLCSTR source);  ///< deprecated: use "toXML" instead
+  static int lengthXMLString(
+      XMLCSTR source);  ///< deprecated: use "toXML" instead
 
-private:
-    XMLSTR buf;
-    int buflen;
+ private:
+  XMLSTR buf;
+  int buflen;
 } ToXMLStringTool;
 /** @} */
 
-/** @defgroup XMLParserBase64Tool Helper class to include binary data inside XML strings using "Base64 encoding".
+/** @defgroup XMLParserBase64Tool Helper class to include binary data inside XML
+ * strings using "Base64 encoding".
  * @ingroup XMLParserGeneral
  * @{ */
-/// Helper class to include binary data inside XML strings using "Base64 encoding".
-/** The "XMLParserBase64Tool" class allows you to include any binary data (images, sounds,...)
- * into an XML document using "Base64 encoding". This class is completely
- * separated from the rest of the xmlParser library and can be removed without any problem.
- * To include some binary data into an XML file, you must convert the binary data into
- * standard text (using "encode"). To retrieve the original binary data from the
- * b64-encoded text included inside the XML file, use "decode". Alternatively, these
- * functions can also be used to "encrypt/decrypt" some critical data contained inside
- * the XML (it's not a strong encryption at all, but sometimes it can be useful). */
-typedef struct XMLDLLENTRY XMLParserBase64Tool
-{
-public:
-    XMLParserBase64Tool(): buf(NULL),buflen(0){}
-    ~XMLParserBase64Tool();
-    void freeBuffer();///< Call this function when you have finished using this object to release memory used by the internal buffer.
+/// Helper class to include binary data inside XML strings using "Base64
+/// encoding".
+/** The "XMLParserBase64Tool" class allows you to include any binary data
+ * (images, sounds,...) into an XML document using "Base64 encoding". This class
+ * is completely separated from the rest of the xmlParser library and can be
+ * removed without any problem. To include some binary data into an XML file,
+ * you must convert the binary data into standard text (using "encode"). To
+ * retrieve the original binary data from the b64-encoded text included inside
+ * the XML file, use "decode". Alternatively, these functions can also be used
+ * to "encrypt/decrypt" some critical data contained inside
+ * the XML (it's not a strong encryption at all, but sometimes it can be
+ * useful). */
+typedef struct XMLDLLENTRY XMLParserBase64Tool {
+ public:
+  XMLParserBase64Tool() : buf(NULL), buflen(0) {}
+  ~XMLParserBase64Tool();
+  void freeBuffer();  ///< Call this function when you have finished using this
+                      ///< object to release memory used by the internal buffer.
 
-    /**
-     * @param formatted If "formatted"=true, some space will be reserved for a carriage-return every 72 chars. */
-    static int encodeLength(int inBufLen, char formatted=0); ///< return the length of the base64 string that encodes a data buffer of size inBufLen bytes.
+  /**
+   * @param formatted If "formatted"=true, some space will be reserved for a
+   * carriage-return every 72 chars. */
+  static int encodeLength(
+      int inBufLen,
+      char formatted = 0);  ///< return the length of the base64 string that
+                            ///< encodes a data buffer of size inBufLen bytes.
 
-    /**
-     * The "base64Encode" function returns a string containing the base64 encoding of "inByteLen" bytes
-     * from "inByteBuf". If "formatted" parameter is true, then there will be a carriage-return every 72 chars.
-     * The string will be free'd when the XMLParserBase64Tool object is deleted.
-     * All returned strings are sharing the same memory space. */
-    XMLSTR encode(unsigned char *inByteBuf, unsigned int inByteLen, char formatted=0); ///< returns a pointer to an internal buffer containing the base64 string containing the binary data encoded from "inByteBuf"
+  /**
+   * The "base64Encode" function returns a string containing the base64 encoding
+   * of "inByteLen" bytes from "inByteBuf". If "formatted" parameter is true,
+   * then there will be a carriage-return every 72 chars. The string will be
+   * free'd when the XMLParserBase64Tool object is deleted.
+   * All returned strings are sharing the same memory space. */
+  XMLSTR encode(
+      unsigned char *inByteBuf, unsigned int inByteLen,
+      char formatted = 0);  ///< returns a pointer to an internal buffer
+                            ///< containing the base64 string containing the
+                            ///< binary data encoded from "inByteBuf"
 
-    /// returns the number of bytes which will be decoded from "inString".
-    static unsigned int decodeSize(XMLCSTR inString, XMLError *xe=NULL);
+  /// returns the number of bytes which will be decoded from "inString".
+  static unsigned int decodeSize(XMLCSTR inString, XMLError *xe = NULL);
 
-    /**
-     * The "decode" function returns a pointer to a buffer containing the binary data decoded from "inString"
-     * The output buffer will be free'd when the XMLParserBase64Tool object is deleted.
-     * All output buffer are sharing the same memory space.
-     * @param inString If "instring" is malformed, NULL will be returned */
-    unsigned char* decode(XMLCSTR inString, int *outByteLen=NULL, XMLError *xe=NULL); ///< returns a pointer to an internal buffer containing the binary data decoded from "inString"
+  /**
+   * The "decode" function returns a pointer to a buffer containing the binary
+   * data decoded from "inString" The output buffer will be free'd when the
+   * XMLParserBase64Tool object is deleted. All output buffer are sharing the
+   * same memory space.
+   * @param inString If "instring" is malformed, NULL will be returned */
+  unsigned char *decode(
+      XMLCSTR inString, int *outByteLen = NULL,
+      XMLError *xe =
+          NULL);  ///< returns a pointer to an internal buffer containing the
+                  ///< binary data decoded from "inString"
 
-    /**
-     * decodes data from "inString" to "outByteBuf". You need to provide the size (in byte) of "outByteBuf"
-     * in "inMaxByteOutBuflen". If "outByteBuf" is not large enough or if data is malformed, then "FALSE"
-     * will be returned; otherwise "TRUE". */
-    static unsigned char decode(XMLCSTR inString, unsigned char *outByteBuf, int inMaxByteOutBuflen, XMLError *xe=NULL); ///< deprecated.
+  /**
+   * decodes data from "inString" to "outByteBuf". You need to provide the size
+   * (in byte) of "outByteBuf" in "inMaxByteOutBuflen". If "outByteBuf" is not
+   * large enough or if data is malformed, then "FALSE" will be returned;
+   * otherwise "TRUE". */
+  static unsigned char decode(XMLCSTR inString, unsigned char *outByteBuf,
+                              int inMaxByteOutBuflen,
+                              XMLError *xe = NULL);  ///< deprecated.
 
-private:
-    void *buf;
-    int buflen;
-    void alloc(int newsize);
-}XMLParserBase64Tool;
+ private:
+  void *buf;
+  int buflen;
+  void alloc(int newsize);
+} XMLParserBase64Tool;
 /** @} */
 
 #undef XMLDLLENTRY

--- a/src/gpuwattch/xmlParser.h
+++ b/src/gpuwattch/xmlParser.h
@@ -9,17 +9,20 @@
  * @version     V2.41
  * @author      Frank Vanden Berghen
  *
- * The following license terms for the "XMLParser library from Business-Insight" apply to projects
+ * The following license terms for the "XMLParser library from Business-Insight"
+ *apply to projects
  * that are in some way related to
  * the "mcpat project", including applications
  * using "mcpat project" and tools developed
  * for enhancing "mcpat project". All other projects
- * (not related to "mcpat project") have to use the "XMLParser library from Business-Insight"
+ * (not related to "mcpat project") have to use the "XMLParser library from
+ *Business-Insight"
  * code under the Aladdin Free Public License (AFPL)
  * See the file "AFPL-license.txt" for more informations about the AFPL license.
  * (see http://www.artifex.com/downloads/doc/Public.htm for detailed AFPL terms)
  *
- * Redistribution and use of the "XMLParser library from Business-Insight" in source and binary forms, with or without
+ * Redistribution and use of the "XMLParser library from Business-Insight" in
+ *source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
  *       notice, this list of conditions and the following disclaimer.
@@ -46,21 +49,31 @@
  * All rights reserved.
  *
  * \section tutorial First Tutorial
- * You can follow a simple <a href="../../xmlParser.html">Tutorial</a> to know the basics...
+ * You can follow a simple <a href="../../xmlParser.html">Tutorial</a> to know
+ *the basics...
  *
- * \section usage General usage: How to include the XMLParser library inside your project.
+ * \section usage General usage: How to include the XMLParser library inside
+ *your project.
  *
- * The library is composed of two files: <a href="../../xmlParser.cpp">xmlParser.cpp</a> and
- * <a href="../../xmlParser.h">xmlParser.h</a>. These are the ONLY 2 files that you need when
+ * The library is composed of two files: <a
+ *href="../../xmlParser.cpp">xmlParser.cpp</a> and
+ * <a href="../../xmlParser.h">xmlParser.h</a>. These are the ONLY 2 files that
+ *you need when
  * using the library inside your own projects.
  *
- * All the functions of the library are documented inside the comments of the file
- * <a href="../../xmlParser.h">xmlParser.h</a>. These comments can be transformed in
- * full-fledged HTML documentation using the DOXYGEN software: simply type: "doxygen doxy.cfg"
+ * All the functions of the library are documented inside the comments of the
+ *file
+ * <a href="../../xmlParser.h">xmlParser.h</a>. These comments can be
+ *transformed in
+ * full-fledged HTML documentation using the DOXYGEN software: simply type:
+ *"doxygen doxy.cfg"
  *
- * By default, the XMLParser library uses (char*) for string representation.To use the (wchar_t*)
- * version of the library, you need to define the "_UNICODE" preprocessor definition variable
- * (this is usually done inside your project definition file) (This is done automatically for you
+ * By default, the XMLParser library uses (char*) for string representation.To
+ *use the (wchar_t*)
+ * version of the library, you need to define the "_UNICODE" preprocessor
+ *definition variable
+ * (this is usually done inside your project definition file) (This is done
+ *automatically for you
  * when using Visual Studio).
  *
  * \section example Advanced Tutorial and Many Examples of usage.
@@ -68,48 +81,66 @@
  * Some very small introductory examples are described inside the Tutorial file
  * <a href="../../xmlParser.html">xmlParser.html</a>
  *
- * Some additional small examples are also inside the file <a href="../../xmlTest.cpp">xmlTest.cpp</a>
+ * Some additional small examples are also inside the file <a
+ *href="../../xmlTest.cpp">xmlTest.cpp</a>
  * (for the "char*" version of the library) and inside the file
  * <a href="../../xmlTestUnicode.cpp">xmlTestUnicode.cpp</a> (for the "wchar_t*"
- * version of the library). If you have a question, please review these additionnal examples
+ * version of the library). If you have a question, please review these
+ *additionnal examples
  * before sending an e-mail to the author.
  *
  * To build the examples:
  * - linux/unix: type "make"
  * - solaris: type "make -f makefile.solaris"
  * - windows: Visual Studio: double-click on xmlParser.dsw
- *   (under Visual Studio .NET, the .dsp and .dsw files will be automatically converted to .vcproj and .sln files)
+ *   (under Visual Studio .NET, the .dsp and .dsw files will be automatically
+ *converted to .vcproj and .sln files)
  *
  * In order to build the examples you need some additional files:
  * - linux/unix: makefile
  * - solaris: makefile.solaris
- * - windows: Visual Studio: *.dsp, xmlParser.dsw and also xmlParser.lib and xmlParser.dll
+ * - windows: Visual Studio: *.dsp, xmlParser.dsw and also xmlParser.lib and
+ *xmlParser.dll
  *
  * \section debugging Debugging with the XMLParser library
  *
  * \subsection debugwin Debugging under WINDOWS
  *
- * 	Inside Visual C++, the "debug versions" of the memory allocation functions are
- * 	very slow: Do not forget to compile in "release mode" to get maximum speed.
- * 	When I had to debug a software that was using the XMLParser Library, it was usually
- * 	a nightmare because the library was sooOOOoooo slow in debug mode (because of the
+ * 	Inside Visual C++, the "debug versions" of the memory allocation
+ *functions are
+ * 	very slow: Do not forget to compile in "release mode" to get maximum
+ *speed.
+ * 	When I had to debug a software that was using the XMLParser Library, it
+ *was usually
+ * 	a nightmare because the library was sooOOOoooo slow in debug mode
+ *(because of the
  *  slow memory allocations in Debug mode). To solve this
- * 	problem, during all the debugging session, I am now using a very fast DLL version of the
- * 	XMLParser Library (the DLL is compiled in release mode). Using the DLL version of
- * 	the XMLParser Library allows me to have lightening XML parsing speed even in debug!
- * 	Other than that, the DLL version is useless: In the release version of my tool,
- * 	I always use the normal, ".cpp"-based, XMLParser Library (I simply include the
+ * 	problem, during all the debugging session, I am now using a very fast
+ *DLL version of the
+ * 	XMLParser Library (the DLL is compiled in release mode). Using the DLL
+ *version of
+ * 	the XMLParser Library allows me to have lightening XML parsing speed
+ *even in debug!
+ * 	Other than that, the DLL version is useless: In the release version of
+ *my tool,
+ * 	I always use the normal, ".cpp"-based, XMLParser Library (I simply
+ *include the
  * <a href="../../xmlParser.cpp">xmlParser.cpp</a> and
  * <a href="../../xmlParser.h">xmlParser.h</a> files into the project).
  *
- * 	The file <a href="../../XMLNodeAutoexp.txt">XMLNodeAutoexp.txt</a> contains some
- * "tweaks" that improve substancially the display of the content of the XMLNode objects
- * inside the Visual Studio Debugger. Believe me, once you have seen inside the debugger
- * the "smooth" display of the XMLNode objects, you cannot live without it anymore!
+ * 	The file <a href="../../XMLNodeAutoexp.txt">XMLNodeAutoexp.txt</a>
+ *contains some
+ * "tweaks" that improve substancially the display of the content of the XMLNode
+ *objects
+ * inside the Visual Studio Debugger. Believe me, once you have seen inside the
+ *debugger
+ * the "smooth" display of the XMLNode objects, you cannot live without it
+ *anymore!
  *
  * \subsection debuglinux Debugging under LINUX/UNIX
  *
- * 	The speed of the debug version of the XMLParser library is tolerable so no extra
+ * 	The speed of the debug version of the XMLParser library is tolerable so
+ *no extra
  * work.has been done.
  *
  ****************************************************************************/
@@ -120,16 +151,21 @@
 #include <stdlib.h>
 
 #ifdef _UNICODE
-// If you comment the next "define" line then the library will never "switch to" _UNICODE (wchar_t*) mode (16/32 bits per characters).
+// If you comment the next "define" line then the library will never "switch to"
+// _UNICODE (wchar_t*) mode (16/32 bits per characters).
 // This is useful when you get error messages like:
-//    'XMLNode::openFileHelper' : cannot convert parameter 2 from 'const char [5]' to 'const wchar_t *'
-// The _XMLWIDECHAR preprocessor variable force the XMLParser library into either utf16/32-mode (the proprocessor variable
+//    'XMLNode::openFileHelper' : cannot convert parameter 2 from 'const char
+//    [5]' to 'const wchar_t *'
+// The _XMLWIDECHAR preprocessor variable force the XMLParser library into
+// either utf16/32-mode (the proprocessor variable
 // must be defined) or utf8-mode(the pre-processor variable must be undefined).
 #define _XMLWIDECHAR
 #endif
 
-#if defined(WIN32) || defined(UNDER_CE) || defined(_WIN32) || defined(WIN64) || defined(__BORLANDC__)
-// comment the next line if you are under windows and the compiler is not Microsoft Visual Studio (6.0 or .NET) or Borland
+#if defined(WIN32) || defined(UNDER_CE) || defined(_WIN32) || \
+    defined(WIN64) || defined(__BORLANDC__)
+// comment the next line if you are under windows and the compiler is not
+// Microsoft Visual Studio (6.0 or .NET) or Borland
 #define _XMLWINDOWS
 #endif
 
@@ -146,7 +182,8 @@
 #define XMLDLLENTRY
 #endif
 
-// uncomment the next line if you want no support for wchar_t* (no need for the <wchar.h> or <tchar.h> libraries anymore to compile)
+// uncomment the next line if you want no support for wchar_t* (no need for the
+// <wchar.h> or <tchar.h> libraries anymore to compile)
 //#define XML_NO_WIDE_CHAR
 
 #ifdef XML_NO_WIDE_CHAR
@@ -159,84 +196,83 @@
 #else
 #define XMLDLLENTRY
 #ifndef XML_NO_WIDE_CHAR
-#include <wchar.h> // to have 'wcsrtombs' for ANSI version
-                   // to have 'mbsrtowcs' for WIDECHAR version
+#include <wchar.h>  // to have 'wcsrtombs' for ANSI version
+// to have 'mbsrtowcs' for WIDECHAR version
 #endif
 #endif
 
 // Some common types for char set portable code
 #ifdef _XMLWIDECHAR
-    #define _CXML(c) L ## c
-    #define XMLCSTR const wchar_t *
-    #define XMLSTR  wchar_t *
-    #define XMLCHAR wchar_t
+#define _CXML(c) L##c
+#define XMLCSTR const wchar_t *
+#define XMLSTR wchar_t *
+#define XMLCHAR wchar_t
 #else
-    #define _CXML(c) c
-    #define XMLCSTR const char *
-    #define XMLSTR  char *
-    #define XMLCHAR char
+#define _CXML(c) c
+#define XMLCSTR const char *
+#define XMLSTR char *
+#define XMLCHAR char
 #endif
 #ifndef FALSE
-    #define FALSE 0
+#define FALSE 0
 #endif /* FALSE */
 #ifndef TRUE
-    #define TRUE 1
+#define TRUE 1
 #endif /* TRUE */
 
-
 /// Enumeration for XML parse errors.
-typedef enum XMLError
-{
-    eXMLErrorNone = 0,
-    eXMLErrorMissingEndTag,
-    eXMLErrorNoXMLTagFound,
-    eXMLErrorEmpty,
-    eXMLErrorMissingTagName,
-    eXMLErrorMissingEndTagName,
-    eXMLErrorUnmatchedEndTag,
-    eXMLErrorUnmatchedEndClearTag,
-    eXMLErrorUnexpectedToken,
-    eXMLErrorNoElements,
-    eXMLErrorFileNotFound,
-    eXMLErrorFirstTagNotFound,
-    eXMLErrorUnknownCharacterEntity,
-    eXMLErrorCharacterCodeAbove255,
-    eXMLErrorCharConversionError,
-    eXMLErrorCannotOpenWriteFile,
-    eXMLErrorCannotWriteFile,
+typedef enum XMLError {
+  eXMLErrorNone = 0,
+  eXMLErrorMissingEndTag,
+  eXMLErrorNoXMLTagFound,
+  eXMLErrorEmpty,
+  eXMLErrorMissingTagName,
+  eXMLErrorMissingEndTagName,
+  eXMLErrorUnmatchedEndTag,
+  eXMLErrorUnmatchedEndClearTag,
+  eXMLErrorUnexpectedToken,
+  eXMLErrorNoElements,
+  eXMLErrorFileNotFound,
+  eXMLErrorFirstTagNotFound,
+  eXMLErrorUnknownCharacterEntity,
+  eXMLErrorCharacterCodeAbove255,
+  eXMLErrorCharConversionError,
+  eXMLErrorCannotOpenWriteFile,
+  eXMLErrorCannotWriteFile,
 
-    eXMLErrorBase64DataSizeIsNotMultipleOf4,
-    eXMLErrorBase64DecodeIllegalCharacter,
-    eXMLErrorBase64DecodeTruncatedData,
-    eXMLErrorBase64DecodeBufferTooSmall
+  eXMLErrorBase64DataSizeIsNotMultipleOf4,
+  eXMLErrorBase64DecodeIllegalCharacter,
+  eXMLErrorBase64DecodeTruncatedData,
+  eXMLErrorBase64DecodeBufferTooSmall
 } XMLError;
 
-
-/// Enumeration used to manage type of data. Use in conjunction with structure XMLNodeContents
-typedef enum XMLElementType
-{
-    eNodeChild=0,
-    eNodeAttribute=1,
-    eNodeText=2,
-    eNodeClear=3,
-    eNodeNULL=4
+/// Enumeration used to manage type of data. Use in conjunction with structure
+/// XMLNodeContents
+typedef enum XMLElementType {
+  eNodeChild = 0,
+  eNodeAttribute = 1,
+  eNodeText = 2,
+  eNodeClear = 3,
+  eNodeNULL = 4
 } XMLElementType;
 
 /// Structure used to obtain error details if the parse fails.
-typedef struct XMLResults
-{
-    enum XMLError error;
-    int  nLine,nColumn;
+typedef struct XMLResults {
+  enum XMLError error;
+  int nLine, nColumn;
 } XMLResults;
 
 /// Structure for XML clear (unformatted) node (usually comments)
 typedef struct XMLClear {
-    XMLCSTR lpszValue; XMLCSTR lpszOpenTag; XMLCSTR lpszCloseTag;
+  XMLCSTR lpszValue;
+  XMLCSTR lpszOpenTag;
+  XMLCSTR lpszCloseTag;
 } XMLClear;
 
 /// Structure for XML attribute.
 typedef struct XMLAttribute {
-    XMLCSTR lpszName; XMLCSTR lpszValue;
+  XMLCSTR lpszName;
+  XMLCSTR lpszValue;
 } XMLAttribute;
 
 /// XMLElementPosition are not interchangeable with simple indexes
@@ -249,395 +285,626 @@ struct XMLNodeContents;
 /// Main Class representing a XML node
 /**
  * All operations are performed using this class.
- * \note The constructors of the XMLNode class are protected, so use instead one of these four methods to get your first instance of XMLNode:
+ * \note The constructors of the XMLNode class are protected, so use instead one
+ * of these four methods to get your first instance of XMLNode:
  * <ul>
  *    <li> XMLNode::parseString </li>
  *    <li> XMLNode::parseFile </li>
  *    <li> XMLNode::openFileHelper </li>
  *    <li> XMLNode::createXMLTopNode (or XMLNode::createXMLTopNode_WOSD)</li>
  * </ul> */
-typedef struct XMLDLLENTRY XMLNode
-{
-  private:
+typedef struct XMLDLLENTRY XMLNode {
+ private:
+  struct XMLNodeDataTag;
 
-    struct XMLNodeDataTag;
+  /// Constructors are protected, so use instead one of: XMLNode::parseString,
+  /// XMLNode::parseFile, XMLNode::openFileHelper, XMLNode::createXMLTopNode
+  XMLNode(struct XMLNodeDataTag *pParent, XMLSTR lpszName, char isDeclaration);
+  /// Constructors are protected, so use instead one of: XMLNode::parseString,
+  /// XMLNode::parseFile, XMLNode::openFileHelper, XMLNode::createXMLTopNode
+  XMLNode(struct XMLNodeDataTag *p);
 
-    /// Constructors are protected, so use instead one of: XMLNode::parseString, XMLNode::parseFile, XMLNode::openFileHelper, XMLNode::createXMLTopNode
-    XMLNode(struct XMLNodeDataTag *pParent, XMLSTR lpszName, char isDeclaration);
-    /// Constructors are protected, so use instead one of: XMLNode::parseString, XMLNode::parseFile, XMLNode::openFileHelper, XMLNode::createXMLTopNode
-    XMLNode(struct XMLNodeDataTag *p);
+ public:
+  static XMLCSTR getVersion();  ///< Return the XMLParser library version number
 
-  public:
-    static XMLCSTR getVersion();///< Return the XMLParser library version number
+  /** @defgroup conversions Parsing XML files/strings to an XMLNode structure
+   * and Rendering XMLNode's to files/string.
+   * @ingroup XMLParserGeneral
+   * @{ */
 
-    /** @defgroup conversions Parsing XML files/strings to an XMLNode structure and Rendering XMLNode's to files/string.
-     * @ingroup XMLParserGeneral
-     * @{ */
+  /// Parse an XML string and return the root of a XMLNode tree representing the
+  /// string.
+  static XMLNode parseString(XMLCSTR lpXMLString, XMLCSTR tag = NULL,
+                             XMLResults *pResults = NULL);
+  /**< The "parseString" function parse an XML string and return the root of a
+   * XMLNode tree. The "opposite" of this function is
+   * the function "createXMLString" that re-creates an XML string from an
+   * XMLNode tree. If the XML document is corrupted, the
+   * "parseString" method will initialize the "pResults" variable with some
+   * information that can be used to trace the error.
+   * If you still want to parse the file, you can use the APPROXIMATE_PARSING
+   * option as explained inside the note at the
+   * beginning of the "xmlParser.cpp" file.
+   *
+   * @param lpXMLString the XML string to parse
+   * @param tag  the name of the first tag inside the XML file. If the tag
+   * parameter is omitted, this function returns a node that represents the head
+   * of the xml document including the declaration term (<? ... ?>).
+   * @param pResults a pointer to a XMLResults variable that will contain some
+   * information that can be used to trace the XML parsing error. You can have a
+   * user-friendly explanation of the parsing error with the "getError"
+   * function.
+   */
 
-    /// Parse an XML string and return the root of a XMLNode tree representing the string.
-    static XMLNode parseString   (XMLCSTR  lpXMLString, XMLCSTR tag=NULL, XMLResults *pResults=NULL);
-    /**< The "parseString" function parse an XML string and return the root of a XMLNode tree. The "opposite" of this function is
-     * the function "createXMLString" that re-creates an XML string from an XMLNode tree. If the XML document is corrupted, the
-     * "parseString" method will initialize the "pResults" variable with some information that can be used to trace the error.
-     * If you still want to parse the file, you can use the APPROXIMATE_PARSING option as explained inside the note at the
-     * beginning of the "xmlParser.cpp" file.
-     *
-     * @param lpXMLString the XML string to parse
-     * @param tag  the name of the first tag inside the XML file. If the tag parameter is omitted, this function returns a node that represents the head of the xml document including the declaration term (<? ... ?>).
-     * @param pResults a pointer to a XMLResults variable that will contain some information that can be used to trace the XML parsing error. You can have a user-friendly explanation of the parsing error with the "getError" function.
-     */
+  /// Parse an XML file and return the root of a XMLNode tree representing the
+  /// file.
+  static XMLNode parseFile(XMLCSTR filename, XMLCSTR tag = NULL,
+                           XMLResults *pResults = NULL);
+  /**< The "parseFile" function parse an XML file and return the root of a
+   * XMLNode tree. The "opposite" of this function is
+   * the function "writeToFile" that re-creates an XML file from an XMLNode
+   * tree. If the XML document is corrupted, the
+   * "parseFile" method will initialize the "pResults" variable with some
+   * information that can be used to trace the error.
+   * If you still want to parse the file, you can use the APPROXIMATE_PARSING
+   * option as explained inside the note at the
+   * beginning of the "xmlParser.cpp" file.
+   *
+   * @param filename the path to the XML file to parse
+   * @param tag the name of the first tag inside the XML file. If the tag
+   * parameter is omitted, this function returns a node that represents the head
+   * of the xml document including the declaration term (<? ... ?>).
+   * @param pResults a pointer to a XMLResults variable that will contain some
+   * information that can be used to trace the XML parsing error. You can have a
+   * user-friendly explanation of the parsing error with the "getError"
+   * function.
+   */
 
-    /// Parse an XML file and return the root of a XMLNode tree representing the file.
-    static XMLNode parseFile     (XMLCSTR     filename, XMLCSTR tag=NULL, XMLResults *pResults=NULL);
-    /**< The "parseFile" function parse an XML file and return the root of a XMLNode tree. The "opposite" of this function is
-     * the function "writeToFile" that re-creates an XML file from an XMLNode tree. If the XML document is corrupted, the
-     * "parseFile" method will initialize the "pResults" variable with some information that can be used to trace the error.
-     * If you still want to parse the file, you can use the APPROXIMATE_PARSING option as explained inside the note at the
-     * beginning of the "xmlParser.cpp" file.
-     *
-     * @param filename the path to the XML file to parse
-     * @param tag the name of the first tag inside the XML file. If the tag parameter is omitted, this function returns a node that represents the head of the xml document including the declaration term (<? ... ?>).
-     * @param pResults a pointer to a XMLResults variable that will contain some information that can be used to trace the XML parsing error. You can have a user-friendly explanation of the parsing error with the "getError" function.
-     */
+  /// Parse an XML file and return the root of a XMLNode tree representing the
+  /// file. A very crude error checking is made. An attempt to guess the Char
+  /// Encoding used in the file is made.
+  static XMLNode openFileHelper(XMLCSTR filename, XMLCSTR tag = NULL);
+  /**< The "openFileHelper" function reports to the screen all the warnings and
+   * errors that occurred during parsing of the XML file.
+   * This function also tries to guess char Encoding (UTF-8, ASCII or SHIT-JIS)
+   * based on the first 200 bytes of the file. Since each
+   * application has its own way to report and deal with errors, you should
+   * rather use the "parseFile" function to parse XML files
+   * and program yourself thereafter an "error reporting" tailored for your
+   * needs (instead of using the very crude "error reporting"
+   * mechanism included inside the "openFileHelper" function).
+   *
+   * If the XML document is corrupted, the "openFileHelper" method will:
+   *         - display an error message on the console (or inside a messageBox
+   * for windows).
+   *         - stop execution (exit).
+   *
+   * I strongly suggest that you write your own "openFileHelper" method tailored
+   * to your needs. If you still want to parse
+   * the file, you can use the APPROXIMATE_PARSING option as explained inside
+   * the note at the beginning of the "xmlParser.cpp" file.
+   *
+   * @param filename the path of the XML file to parse.
+   * @param tag the name of the first tag inside the XML file. If the tag
+   * parameter is omitted, this function returns a node that represents the head
+   * of the xml document including the declaration term (<? ... ?>).
+   */
 
-    /// Parse an XML file and return the root of a XMLNode tree representing the file. A very crude error checking is made. An attempt to guess the Char Encoding used in the file is made.
-    static XMLNode openFileHelper(XMLCSTR     filename, XMLCSTR tag=NULL);
-    /**< The "openFileHelper" function reports to the screen all the warnings and errors that occurred during parsing of the XML file.
-     * This function also tries to guess char Encoding (UTF-8, ASCII or SHIT-JIS) based on the first 200 bytes of the file. Since each
-     * application has its own way to report and deal with errors, you should rather use the "parseFile" function to parse XML files
-     * and program yourself thereafter an "error reporting" tailored for your needs (instead of using the very crude "error reporting"
-     * mechanism included inside the "openFileHelper" function).
-     *
-     * If the XML document is corrupted, the "openFileHelper" method will:
-     *         - display an error message on the console (or inside a messageBox for windows).
-     *         - stop execution (exit).
-     *
-     * I strongly suggest that you write your own "openFileHelper" method tailored to your needs. If you still want to parse
-     * the file, you can use the APPROXIMATE_PARSING option as explained inside the note at the beginning of the "xmlParser.cpp" file.
-     *
-     * @param filename the path of the XML file to parse.
-     * @param tag the name of the first tag inside the XML file. If the tag parameter is omitted, this function returns a node that represents the head of the xml document including the declaration term (<? ... ?>).
-     */
+  static XMLCSTR getError(XMLError error);  ///< this gives you a user-friendly
+                                            ///explanation of the parsing error
 
-    static XMLCSTR getError(XMLError error); ///< this gives you a user-friendly explanation of the parsing error
+  /// Create an XML string starting from the current XMLNode.
+  XMLSTR createXMLString(int nFormat = 1, int *pnSize = NULL) const;
+  /**< The returned string should be free'd using the "freeXMLString" function.
+   *
+   *   If nFormat==0, no formatting is required otherwise this returns an user
+   * friendly XML string from a given element
+   *   with appropriate white spaces and carriage returns. if pnSize is given it
+   * returns the size in character of the string. */
 
-    /// Create an XML string starting from the current XMLNode.
-    XMLSTR createXMLString(int nFormat=1, int *pnSize=NULL) const;
-    /**< The returned string should be free'd using the "freeXMLString" function.
-     *
-     *   If nFormat==0, no formatting is required otherwise this returns an user friendly XML string from a given element
-     *   with appropriate white spaces and carriage returns. if pnSize is given it returns the size in character of the string. */
+  /// Save the content of an xmlNode inside a file
+  XMLError writeToFile(XMLCSTR filename, const char *encoding = NULL,
+                       char nFormat = 1) const;
+  /**< If nFormat==0, no formatting is required otherwise this returns an user
+   * friendly XML string from a given element with appropriate white spaces and
+   * carriage returns.
+   * If the global parameter "characterEncoding==encoding_UTF8", then the
+   * "encoding" parameter is ignored and always set to "utf-8".
+   * If the global parameter "characterEncoding==encoding_ShiftJIS", then the
+   * "encoding" parameter is ignored and always set to "SHIFT-JIS".
+   * If "_XMLWIDECHAR=1", then the "encoding" parameter is ignored and always
+   * set to "utf-16".
+   * If no "encoding" parameter is given the "ISO-8859-1" encoding is used. */
+  /** @} */
 
-    /// Save the content of an xmlNode inside a file
-    XMLError writeToFile(XMLCSTR filename,
-                         const char *encoding=NULL,
-                         char nFormat=1) const;
-    /**< If nFormat==0, no formatting is required otherwise this returns an user friendly XML string from a given element with appropriate white spaces and carriage returns.
-     * If the global parameter "characterEncoding==encoding_UTF8", then the "encoding" parameter is ignored and always set to "utf-8".
-     * If the global parameter "characterEncoding==encoding_ShiftJIS", then the "encoding" parameter is ignored and always set to "SHIFT-JIS".
-     * If "_XMLWIDECHAR=1", then the "encoding" parameter is ignored and always set to "utf-16".
-     * If no "encoding" parameter is given the "ISO-8859-1" encoding is used. */
-    /** @} */
+  /** @defgroup navigate Navigate the XMLNode structure
+   * @ingroup XMLParserGeneral
+   * @{ */
+  XMLCSTR getName() const;                          ///< name of the node
+  XMLCSTR getText(int i = 0) const;                 ///< return ith text field
+  int nText() const;                                ///< nbr of text field
+  XMLNode getParentNode() const;                    ///< return the parent node
+  XMLNode getChildNode(int i = 0) const;            ///< return ith child node
+  XMLNode getChildNode(XMLCSTR name, int i) const;  ///< return ith child node
+                                                    ///with specific name
+                                                    ///(return an empty node if
+                                                    ///failing). If i==-1, this
+                                                    ///returns the last XMLNode
+                                                    ///with the given name.
+  XMLNode getChildNode(XMLCSTR name, int *i = NULL) const;  ///< return next
+                                                            ///child node with
+                                                            ///specific name
+                                                            ///(return an empty
+                                                            ///node if failing)
+  XMLNode getChildNodeWithAttribute(XMLCSTR tagName, XMLCSTR attributeName,
+                                    XMLCSTR attributeValue = NULL,
+                                    int *i = NULL) const;  ///< return child
+                                                           ///node with specific
+                                                           ///name/attribute
+                                                           ///(return an empty
+                                                           ///node if failing)
+  XMLNode getChildNodeByPath(XMLCSTR path, char createNodeIfMissing = 0,
+                             XMLCHAR sep = '/');
+  ///< return the first child node with specific path
+  XMLNode getChildNodeByPathNonConst(XMLSTR path, char createNodeIfMissing = 0,
+                                     XMLCHAR sep = '/');
+  ///< return the first child node with specific path.
 
-    /** @defgroup navigate Navigate the XMLNode structure
-     * @ingroup XMLParserGeneral
-     * @{ */
-    XMLCSTR getName() const;                                       ///< name of the node
-    XMLCSTR getText(int i=0) const;                                ///< return ith text field
-    int nText() const;                                             ///< nbr of text field
-    XMLNode getParentNode() const;                                 ///< return the parent node
-    XMLNode getChildNode(int i=0) const;                           ///< return ith child node
-    XMLNode getChildNode(XMLCSTR name, int i)  const;              ///< return ith child node with specific name (return an empty node if failing). If i==-1, this returns the last XMLNode with the given name.
-    XMLNode getChildNode(XMLCSTR name, int *i=NULL) const;         ///< return next child node with specific name (return an empty node if failing)
-    XMLNode getChildNodeWithAttribute(XMLCSTR tagName,
-                                      XMLCSTR attributeName,
-                                      XMLCSTR attributeValue=NULL,
-                                      int *i=NULL)  const;         ///< return child node with specific name/attribute (return an empty node if failing)
-    XMLNode getChildNodeByPath(XMLCSTR path, char createNodeIfMissing=0, XMLCHAR sep='/');
-                                                                   ///< return the first child node with specific path
-    XMLNode getChildNodeByPathNonConst(XMLSTR  path, char createNodeIfMissing=0, XMLCHAR sep='/');
-                                                                   ///< return the first child node with specific path.
+  int nChildNode(XMLCSTR name)
+      const;  ///< return the number of child node with specific name
+  int nChildNode() const;                      ///< nbr of child node
+  XMLAttribute getAttribute(int i = 0) const;  ///< return ith attribute
+  XMLCSTR getAttributeName(int i = 0) const;   ///< return ith attribute name
+  XMLCSTR getAttributeValue(int i = 0) const;  ///< return ith attribute value
+  char isAttributeSet(XMLCSTR name)
+      const;  ///< test if an attribute with a specific name is given
+  XMLCSTR getAttribute(XMLCSTR name, int i) const;  ///< return ith attribute
+                                                    ///content with specific
+                                                    ///name (return a NULL if
+                                                    ///failing)
+  XMLCSTR getAttribute(XMLCSTR name, int *i = NULL) const;  ///< return next
+                                                            ///attribute content
+                                                            ///with specific
+                                                            ///name (return a
+                                                            ///NULL if failing)
+  int nAttribute() const;              ///< nbr of attribute
+  XMLClear getClear(int i = 0) const;  ///< return ith clear field (comments)
+  int nClear() const;                  ///< nbr of clear field
+  XMLNodeContents enumContents(XMLElementPosition i)
+      const;  ///< enumerate all the different contents (attribute,child,text,
+              ///clear) of the current XMLNode. The order is reflecting the
+              ///order of the original file/string. NOTE: 0 <= i < nElement();
+  int nElement() const;        ///< nbr of different contents for current node
+  char isEmpty() const;        ///< is this node Empty?
+  char isDeclaration() const;  ///< is this node a declaration <? .... ?>
+  XMLNode deepCopy() const;    ///< deep copy (duplicate/clone) a XMLNode
+  static XMLNode emptyNode();  ///< return XMLNode::emptyXMLNode;
+  /** @} */
 
-    int nChildNode(XMLCSTR name) const;                            ///< return the number of child node with specific name
-    int nChildNode() const;                                        ///< nbr of child node
-    XMLAttribute getAttribute(int i=0) const;                      ///< return ith attribute
-    XMLCSTR      getAttributeName(int i=0) const;                  ///< return ith attribute name
-    XMLCSTR      getAttributeValue(int i=0) const;                 ///< return ith attribute value
-    char  isAttributeSet(XMLCSTR name) const;                      ///< test if an attribute with a specific name is given
-    XMLCSTR getAttribute(XMLCSTR name, int i) const;               ///< return ith attribute content with specific name (return a NULL if failing)
-    XMLCSTR getAttribute(XMLCSTR name, int *i=NULL) const;         ///< return next attribute content with specific name (return a NULL if failing)
-    int nAttribute() const;                                        ///< nbr of attribute
-    XMLClear getClear(int i=0) const;                              ///< return ith clear field (comments)
-    int nClear() const;                                            ///< nbr of clear field
-    XMLNodeContents enumContents(XMLElementPosition i) const;      ///< enumerate all the different contents (attribute,child,text, clear) of the current XMLNode. The order is reflecting the order of the original file/string. NOTE: 0 <= i < nElement();
-    int nElement() const;                                          ///< nbr of different contents for current node
-    char isEmpty() const;                                          ///< is this node Empty?
-    char isDeclaration() const;                                    ///< is this node a declaration <? .... ?>
-    XMLNode deepCopy() const;                                      ///< deep copy (duplicate/clone) a XMLNode
-    static XMLNode emptyNode();                                    ///< return XMLNode::emptyXMLNode;
-    /** @} */
+  ~XMLNode();
+  XMLNode(const XMLNode &A);             ///< to allow shallow/fast copy:
+  XMLNode &operator=(const XMLNode &A);  ///< to allow shallow/fast copy:
 
-    ~XMLNode();
-    XMLNode(const XMLNode &A);                                     ///< to allow shallow/fast copy:
-    XMLNode& operator=( const XMLNode& A );                        ///< to allow shallow/fast copy:
+  XMLNode() : d(NULL){};
+  static XMLNode emptyXMLNode;
+  static XMLClear emptyXMLClear;
+  static XMLAttribute emptyXMLAttribute;
 
-    XMLNode(): d(NULL){};
-    static XMLNode emptyXMLNode;
-    static XMLClear emptyXMLClear;
-    static XMLAttribute emptyXMLAttribute;
+  /** @defgroup xmlModify Create or Update the XMLNode structure
+   * @ingroup XMLParserGeneral
+   *  The functions in this group allows you to create from scratch (or update)
+   * a XMLNode structure. Start by creating your top
+   *  node with the "createXMLTopNode" function and then add new nodes with the
+   * "addChild" function. The parameter 'pos' gives
+   *  the position where the childNode, the text or the XMLClearTag will be
+   * inserted. The default value (pos=-1) inserts at the
+   *  end. The value (pos=0) insert at the beginning (Insertion at the beginning
+   * is slower than at the end). <br>
+   *
+   *  REMARK: 0 <= pos < nChild()+nText()+nClear() <br>
+   */
 
-    /** @defgroup xmlModify Create or Update the XMLNode structure
-     * @ingroup XMLParserGeneral
-     *  The functions in this group allows you to create from scratch (or update) a XMLNode structure. Start by creating your top
-     *  node with the "createXMLTopNode" function and then add new nodes with the "addChild" function. The parameter 'pos' gives
-     *  the position where the childNode, the text or the XMLClearTag will be inserted. The default value (pos=-1) inserts at the
-     *  end. The value (pos=0) insert at the beginning (Insertion at the beginning is slower than at the end). <br>
-     *
-     *  REMARK: 0 <= pos < nChild()+nText()+nClear() <br>
-     */
+  /** @defgroup creation Creating from scratch a XMLNode structure
+   * @ingroup xmlModify
+   * @{ */
+  static XMLNode createXMLTopNode(
+      XMLCSTR lpszName,
+      char isDeclaration =
+          FALSE);  ///< Create the top node of an XMLNode structure
+  XMLNode addChild(XMLCSTR lpszName, char isDeclaration = FALSE,
+                   XMLElementPosition pos = -1);  ///< Add a new child node
+  XMLNode addChild(XMLNode nodeToAdd,
+                   XMLElementPosition pos = -1);  ///< If the "nodeToAdd" has
+                                                  ///some parents, it will be
+                                                  ///detached from it's parents
+                                                  ///before being attached to
+                                                  ///the current XMLNode
+  XMLAttribute *addAttribute(XMLCSTR lpszName,
+                             XMLCSTR lpszValuev);  ///< Add a new attribute
+  XMLCSTR addText(XMLCSTR lpszValue,
+                  XMLElementPosition pos = -1);  ///< Add a new text content
+  XMLClear *addClear(XMLCSTR lpszValue, XMLCSTR lpszOpen = NULL,
+                     XMLCSTR lpszClose = NULL, XMLElementPosition pos = -1);
+  /**< Add a new clear tag
+   * @param lpszOpen default value "<![CDATA["
+   * @param lpszClose default value "]]>"
+   */
+  /** @} */
 
-    /** @defgroup creation Creating from scratch a XMLNode structure
-     * @ingroup xmlModify
-     * @{ */
-    static XMLNode createXMLTopNode(XMLCSTR lpszName, char isDeclaration=FALSE);                    ///< Create the top node of an XMLNode structure
-    XMLNode        addChild(XMLCSTR lpszName, char isDeclaration=FALSE, XMLElementPosition pos=-1); ///< Add a new child node
-    XMLNode        addChild(XMLNode nodeToAdd, XMLElementPosition pos=-1);                          ///< If the "nodeToAdd" has some parents, it will be detached from it's parents before being attached to the current XMLNode
-    XMLAttribute  *addAttribute(XMLCSTR lpszName, XMLCSTR lpszValuev);                              ///< Add a new attribute
-    XMLCSTR        addText(XMLCSTR lpszValue, XMLElementPosition pos=-1);                           ///< Add a new text content
-    XMLClear      *addClear(XMLCSTR lpszValue, XMLCSTR lpszOpen=NULL, XMLCSTR lpszClose=NULL, XMLElementPosition pos=-1);
-    /**< Add a new clear tag
-     * @param lpszOpen default value "<![CDATA["
-     * @param lpszClose default value "]]>"
-     */
-    /** @} */
+  /** @defgroup xmlUpdate Updating Nodes
+   * @ingroup xmlModify
+   * Some update functions:
+   * @{
+   */
+  XMLCSTR updateName(XMLCSTR lpszName);  ///< change node's name
+  XMLAttribute *updateAttribute(XMLAttribute *newAttribute,
+                                XMLAttribute *oldAttribute);  ///< if the
+                                                              ///attribute to
+                                                              ///update is
+                                                              ///missing, a new
+                                                              ///one will be
+                                                              ///added
+  XMLAttribute *updateAttribute(XMLCSTR lpszNewValue,
+                                XMLCSTR lpszNewName = NULL,
+                                int i = 0);  ///< if the attribute to update is
+                                             ///missing, a new one will be added
+  XMLAttribute *updateAttribute(XMLCSTR lpszNewValue, XMLCSTR lpszNewName,
+                                XMLCSTR lpszOldName);  ///< set lpszNewName=NULL
+                                                       ///if you don't want to
+                                                       ///change the name of the
+                                                       ///attribute if the
+                                                       ///attribute to update is
+                                                       ///missing, a new one
+                                                       ///will be added
+  XMLCSTR updateText(XMLCSTR lpszNewValue, int i = 0);  ///< if the text to
+                                                        ///update is missing, a
+                                                        ///new one will be added
+  XMLCSTR updateText(XMLCSTR lpszNewValue,
+                     XMLCSTR lpszOldValue);  ///< if the text to update is
+                                             ///missing, a new one will be added
+  XMLClear *updateClear(XMLCSTR lpszNewContent,
+                        int i = 0);  ///< if the clearTag to update is missing,
+                                     ///a new one will be added
+  XMLClear *updateClear(XMLClear *newP, XMLClear *oldP);  ///< if the clearTag
+                                                          ///to update is
+                                                          ///missing, a new one
+                                                          ///will be added
+  XMLClear *updateClear(XMLCSTR lpszNewValue,
+                        XMLCSTR lpszOldValue);  ///< if the clearTag to update
+                                                ///is missing, a new one will be
+                                                ///added
+                                                /** @} */
 
-    /** @defgroup xmlUpdate Updating Nodes
-     * @ingroup xmlModify
-     * Some update functions:
-     * @{
-     */
-    XMLCSTR       updateName(XMLCSTR lpszName);                                                  ///< change node's name
-    XMLAttribute *updateAttribute(XMLAttribute *newAttribute, XMLAttribute *oldAttribute);       ///< if the attribute to update is missing, a new one will be added
-    XMLAttribute *updateAttribute(XMLCSTR lpszNewValue, XMLCSTR lpszNewName=NULL,int i=0);       ///< if the attribute to update is missing, a new one will be added
-    XMLAttribute *updateAttribute(XMLCSTR lpszNewValue, XMLCSTR lpszNewName,XMLCSTR lpszOldName);///< set lpszNewName=NULL if you don't want to change the name of the attribute if the attribute to update is missing, a new one will be added
-    XMLCSTR       updateText(XMLCSTR lpszNewValue, int i=0);                                     ///< if the text to update is missing, a new one will be added
-    XMLCSTR       updateText(XMLCSTR lpszNewValue, XMLCSTR lpszOldValue);                        ///< if the text to update is missing, a new one will be added
-    XMLClear     *updateClear(XMLCSTR lpszNewContent, int i=0);                                  ///< if the clearTag to update is missing, a new one will be added
-    XMLClear     *updateClear(XMLClear *newP,XMLClear *oldP);                                    ///< if the clearTag to update is missing, a new one will be added
-    XMLClear     *updateClear(XMLCSTR lpszNewValue, XMLCSTR lpszOldValue);                       ///< if the clearTag to update is missing, a new one will be added
-    /** @} */
+  /** @defgroup xmlDelete Deleting Nodes or Attributes
+   * @ingroup xmlModify
+   * Some deletion functions:
+   * @{
+   */
+  /// The "deleteNodeContent" function forces the deletion of the content of
+  /// this XMLNode and the subtree.
+  void deleteNodeContent();
+  /**< \note The XMLNode instances that are referring to the part of the subtree
+   * that has been deleted CANNOT be used anymore!!. Unexpected results will
+   * occur if you continue using them. */
+  void deleteAttribute(
+      int i = 0);  ///< Delete the ith attribute of the current XMLNode
+  void deleteAttribute(XMLCSTR lpszName);  ///< Delete the attribute with the
+                                           ///given name (the "strcmp" function
+                                           ///is used to find the right
+                                           ///attribute)
+  void deleteAttribute(XMLAttribute *anAttribute);  ///< Delete the attribute
+                                                    ///with the name
+                                                    ///"anAttribute->lpszName"
+                                                    ///(the "strcmp" function is
+                                                    ///used to find the right
+                                                    ///attribute)
+  void deleteText(
+      int i = 0);  ///< Delete the Ith text content of the current XMLNode
+  void deleteText(XMLCSTR lpszValue);  ///< Delete the text content "lpszValue"
+                                       ///inside the current XMLNode (direct
+                                       ///"pointer-to-pointer" comparison is
+                                       ///used to find the right text)
+  void deleteClear(
+      int i = 0);  ///< Delete the Ith clear tag inside the current XMLNode
+  void deleteClear(XMLCSTR lpszValue);  ///< Delete the clear tag "lpszValue"
+                                        ///inside the current XMLNode (direct
+                                        ///"pointer-to-pointer" comparison is
+                                        ///used to find the clear tag)
+  void deleteClear(XMLClear *p);        ///< Delete the clear tag "p" inside the
+                                        ///current XMLNode (direct
+                                  ///"pointer-to-pointer" comparison on the
+                                  ///lpszName of the clear tag is used to find
+                                  ///the clear tag)
+  /** @} */
 
-    /** @defgroup xmlDelete Deleting Nodes or Attributes
-     * @ingroup xmlModify
-     * Some deletion functions:
-     * @{
-     */
-    /// The "deleteNodeContent" function forces the deletion of the content of this XMLNode and the subtree.
-    void deleteNodeContent();
-    /**< \note The XMLNode instances that are referring to the part of the subtree that has been deleted CANNOT be used anymore!!. Unexpected results will occur if you continue using them. */
-    void deleteAttribute(int i=0);                   ///< Delete the ith attribute of the current XMLNode
-    void deleteAttribute(XMLCSTR lpszName);          ///< Delete the attribute with the given name (the "strcmp" function is used to find the right attribute)
-    void deleteAttribute(XMLAttribute *anAttribute); ///< Delete the attribute with the name "anAttribute->lpszName" (the "strcmp" function is used to find the right attribute)
-    void deleteText(int i=0);                        ///< Delete the Ith text content of the current XMLNode
-    void deleteText(XMLCSTR lpszValue);              ///< Delete the text content "lpszValue" inside the current XMLNode (direct "pointer-to-pointer" comparison is used to find the right text)
-    void deleteClear(int i=0);                       ///< Delete the Ith clear tag inside the current XMLNode
-    void deleteClear(XMLCSTR lpszValue);             ///< Delete the clear tag "lpszValue" inside the current XMLNode (direct "pointer-to-pointer" comparison is used to find the clear tag)
-    void deleteClear(XMLClear *p);                   ///< Delete the clear tag "p" inside the current XMLNode (direct "pointer-to-pointer" comparison on the lpszName of the clear tag is used to find the clear tag)
-    /** @} */
+  /** @defgroup xmlWOSD ???_WOSD functions.
+   * @ingroup xmlModify
+   *  The strings given as parameters for the "add" and "update" methods that
+   * have a name with
+   *  the postfix "_WOSD" (that means "WithOut String Duplication")(for example
+   * "addText_WOSD")
+   *  will be free'd by the XMLNode class. For example, it means that this is
+   * incorrect:
+   *  \code
+   *     xNode.addText_WOSD("foo");
+   *     xNode.updateAttribute_WOSD("#newcolor" ,NULL,"color");
+   *  \endcode
+   *  In opposition, this is correct:
+   *  \code
+   *     xNode.addText("foo");
+   *     xNode.addText_WOSD(stringDup("foo"));
+   *     xNode.updateAttribute("#newcolor" ,NULL,"color");
+   *     xNode.updateAttribute_WOSD(stringDup("#newcolor"),NULL,"color");
+   *  \endcode
+   *  Typically, you will never do:
+   *  \code
+   *     char *b=(char*)malloc(...);
+   *     xNode.addText(b);
+   *     free(b);
+   *  \endcode
+   *  ... but rather:
+   *  \code
+   *     char *b=(char*)malloc(...);
+   *     xNode.addText_WOSD(b);
+   *  \endcode
+   *  ('free(b)' is performed by the XMLNode class)
+   * @{ */
+  static XMLNode createXMLTopNode_WOSD(
+      XMLSTR lpszName,
+      char isDeclaration =
+          FALSE);  ///< Create the top node of an XMLNode structure
+  XMLNode addChild_WOSD(XMLSTR lpszName, char isDeclaration = FALSE,
+                        XMLElementPosition pos = -1);  ///< Add a new child node
+  XMLAttribute *addAttribute_WOSD(XMLSTR lpszName,
+                                  XMLSTR lpszValue);  ///< Add a new attribute
+  XMLCSTR addText_WOSD(XMLSTR lpszValue, XMLElementPosition pos =
+                                             -1);  ///< Add a new text content
+  XMLClear *addClear_WOSD(
+      XMLSTR lpszValue, XMLCSTR lpszOpen = NULL, XMLCSTR lpszClose = NULL,
+      XMLElementPosition pos = -1);  ///< Add a new clear Tag
 
-    /** @defgroup xmlWOSD ???_WOSD functions.
-     * @ingroup xmlModify
-     *  The strings given as parameters for the "add" and "update" methods that have a name with
-     *  the postfix "_WOSD" (that means "WithOut String Duplication")(for example "addText_WOSD")
-     *  will be free'd by the XMLNode class. For example, it means that this is incorrect:
-     *  \code
-     *     xNode.addText_WOSD("foo");
-     *     xNode.updateAttribute_WOSD("#newcolor" ,NULL,"color");
-     *  \endcode
-     *  In opposition, this is correct:
-     *  \code
-     *     xNode.addText("foo");
-     *     xNode.addText_WOSD(stringDup("foo"));
-     *     xNode.updateAttribute("#newcolor" ,NULL,"color");
-     *     xNode.updateAttribute_WOSD(stringDup("#newcolor"),NULL,"color");
-     *  \endcode
-     *  Typically, you will never do:
-     *  \code
-     *     char *b=(char*)malloc(...);
-     *     xNode.addText(b);
-     *     free(b);
-     *  \endcode
-     *  ... but rather:
-     *  \code
-     *     char *b=(char*)malloc(...);
-     *     xNode.addText_WOSD(b);
-     *  \endcode
-     *  ('free(b)' is performed by the XMLNode class)
-     * @{ */
-    static XMLNode createXMLTopNode_WOSD(XMLSTR lpszName, char isDeclaration=FALSE);                     ///< Create the top node of an XMLNode structure
-    XMLNode        addChild_WOSD(XMLSTR lpszName, char isDeclaration=FALSE, XMLElementPosition pos=-1);  ///< Add a new child node
-    XMLAttribute  *addAttribute_WOSD(XMLSTR lpszName, XMLSTR lpszValue);                                 ///< Add a new attribute
-    XMLCSTR        addText_WOSD(XMLSTR lpszValue, XMLElementPosition pos=-1);                            ///< Add a new text content
-    XMLClear      *addClear_WOSD(XMLSTR lpszValue, XMLCSTR lpszOpen=NULL, XMLCSTR lpszClose=NULL, XMLElementPosition pos=-1); ///< Add a new clear Tag
+  XMLCSTR updateName_WOSD(XMLSTR lpszName);  ///< change node's name
+  XMLAttribute *updateAttribute_WOSD(XMLAttribute *newAttribute,
+                                     XMLAttribute *oldAttribute);  ///< if the
+                                                                   ///attribute
+                                                                   ///to update
+                                                                   ///is
+                                                                   ///missing, a
+                                                                   ///new one
+                                                                   ///will be
+                                                                   ///added
+  XMLAttribute *updateAttribute_WOSD(XMLSTR lpszNewValue,
+                                     XMLSTR lpszNewName = NULL,
+                                     int i = 0);  ///< if the attribute to
+                                                  ///update is missing, a new
+                                                  ///one will be added
+  XMLAttribute *updateAttribute_WOSD(XMLSTR lpszNewValue, XMLSTR lpszNewName,
+                                     XMLCSTR lpszOldName);  ///< set
+                                                            ///lpszNewName=NULL
+                                                            ///if you don't want
+                                                            ///to change the
+                                                            ///name of the
+                                                            ///attribute if the
+                                                            ///attribute to
+                                                            ///update is
+                                                            ///missing, a new
+                                                            ///one will be added
+  XMLCSTR updateText_WOSD(XMLSTR lpszNewValue, int i = 0);  ///< if the text to
+                                                            ///update is
+                                                            ///missing, a new
+                                                            ///one will be added
+  XMLCSTR updateText_WOSD(XMLSTR lpszNewValue,
+                          XMLCSTR lpszOldValue);  ///< if the text to update is
+                                                  ///missing, a new one will be
+                                                  ///added
+  XMLClear *updateClear_WOSD(XMLSTR lpszNewContent,
+                             int i = 0);  ///< if the clearTag to update is
+                                          ///missing, a new one will be added
+  XMLClear *updateClear_WOSD(XMLClear *newP,
+                             XMLClear *oldP);  ///< if the clearTag to update is
+                                               ///missing, a new one will be
+                                               ///added
+  XMLClear *updateClear_WOSD(XMLSTR lpszNewValue,
+                             XMLCSTR lpszOldValue);  ///< if the clearTag to
+                                                     ///update is missing, a new
+                                                     ///one will be added
+                                                     /** @} */
 
-    XMLCSTR        updateName_WOSD(XMLSTR lpszName);                                                  ///< change node's name
-    XMLAttribute  *updateAttribute_WOSD(XMLAttribute *newAttribute, XMLAttribute *oldAttribute);      ///< if the attribute to update is missing, a new one will be added
-    XMLAttribute  *updateAttribute_WOSD(XMLSTR lpszNewValue, XMLSTR lpszNewName=NULL,int i=0);        ///< if the attribute to update is missing, a new one will be added
-    XMLAttribute  *updateAttribute_WOSD(XMLSTR lpszNewValue, XMLSTR lpszNewName,XMLCSTR lpszOldName); ///< set lpszNewName=NULL if you don't want to change the name of the attribute if the attribute to update is missing, a new one will be added
-    XMLCSTR        updateText_WOSD(XMLSTR lpszNewValue, int i=0);                                     ///< if the text to update is missing, a new one will be added
-    XMLCSTR        updateText_WOSD(XMLSTR lpszNewValue, XMLCSTR lpszOldValue);                        ///< if the text to update is missing, a new one will be added
-    XMLClear      *updateClear_WOSD(XMLSTR lpszNewContent, int i=0);                                  ///< if the clearTag to update is missing, a new one will be added
-    XMLClear      *updateClear_WOSD(XMLClear *newP,XMLClear *oldP);                                   ///< if the clearTag to update is missing, a new one will be added
-    XMLClear      *updateClear_WOSD(XMLSTR lpszNewValue, XMLCSTR lpszOldValue);                       ///< if the clearTag to update is missing, a new one will be added
-    /** @} */
+  /** @defgroup xmlPosition Position helper functions (use in conjunction with
+   * the update&add functions
+   * @ingroup xmlModify
+   * These are some useful functions when you want to insert a childNode, a text
+   * or a XMLClearTag in the
+   * middle (at a specified position) of a XMLNode tree already constructed. The
+   * value returned by these
+   * methods is to be used as last parameter (parameter 'pos') of addChild,
+   * addText or addClear.
+   * @{ */
+  XMLElementPosition positionOfText(int i = 0) const;
+  XMLElementPosition positionOfText(XMLCSTR lpszValue) const;
+  XMLElementPosition positionOfClear(int i = 0) const;
+  XMLElementPosition positionOfClear(XMLCSTR lpszValue) const;
+  XMLElementPosition positionOfClear(XMLClear *a) const;
+  XMLElementPosition positionOfChildNode(int i = 0) const;
+  XMLElementPosition positionOfChildNode(XMLNode x) const;
+  XMLElementPosition positionOfChildNode(XMLCSTR name, int i = 0)
+      const;  ///< return the position of the ith childNode with the specified
+              ///name if (name==NULL) return the position of the ith childNode
+  /** @} */
 
-    /** @defgroup xmlPosition Position helper functions (use in conjunction with the update&add functions
-     * @ingroup xmlModify
-     * These are some useful functions when you want to insert a childNode, a text or a XMLClearTag in the
-     * middle (at a specified position) of a XMLNode tree already constructed. The value returned by these
-     * methods is to be used as last parameter (parameter 'pos') of addChild, addText or addClear.
-     * @{ */
-    XMLElementPosition positionOfText(int i=0) const;
-    XMLElementPosition positionOfText(XMLCSTR lpszValue) const;
-    XMLElementPosition positionOfClear(int i=0) const;
-    XMLElementPosition positionOfClear(XMLCSTR lpszValue) const;
-    XMLElementPosition positionOfClear(XMLClear *a) const;
-    XMLElementPosition positionOfChildNode(int i=0) const;
-    XMLElementPosition positionOfChildNode(XMLNode x) const;
-    XMLElementPosition positionOfChildNode(XMLCSTR name, int i=0) const; ///< return the position of the ith childNode with the specified name if (name==NULL) return the position of the ith childNode
-    /** @} */
+  /// Enumeration for XML character encoding.
+  typedef enum XMLCharEncoding {
+    char_encoding_error = 0,
+    char_encoding_UTF8 = 1,
+    char_encoding_legacy = 2,
+    char_encoding_ShiftJIS = 3,
+    char_encoding_GB2312 = 4,
+    char_encoding_Big5 = 5,
+    char_encoding_GBK = 6  // this is actually the same as Big5
+  } XMLCharEncoding;
 
-    /// Enumeration for XML character encoding.
-    typedef enum XMLCharEncoding
-    {
-        char_encoding_error=0,
-        char_encoding_UTF8=1,
-        char_encoding_legacy=2,
-        char_encoding_ShiftJIS=3,
-        char_encoding_GB2312=4,
-        char_encoding_Big5=5,
-        char_encoding_GBK=6     // this is actually the same as Big5
-    } XMLCharEncoding;
+  /** \addtogroup conversions
+   * @{ */
 
-    /** \addtogroup conversions
-     * @{ */
+  /// Sets the global options for the conversions
+  static char setGlobalOptions(
+      XMLCharEncoding characterEncoding = XMLNode::char_encoding_UTF8,
+      char guessWideCharChars = 1, char dropWhiteSpace = 1,
+      char removeCommentsInMiddleOfText = 1);
+  /**< The "setGlobalOptions" function allows you to change four global
+   * parameters that affect string & file
+   * parsing. First of all, you most-probably will never have to change these 3
+   * global parameters.
+   *
+   * @param guessWideCharChars If "guessWideCharChars"=1 and if this library is
+   * compiled in WideChar mode, then the
+   *     XMLNode::parseFile and XMLNode::openFileHelper functions will test if
+   * the file contains ASCII
+   *     characters. If this is the case, then the file will be loaded and
+   * converted in memory to
+   *     WideChar before being parsed. If 0, no conversion will be performed.
+   *
+   * @param guessWideCharChars If "guessWideCharChars"=1 and if this library is
+   * compiled in ASCII/UTF8/char* mode, then the
+   *     XMLNode::parseFile and XMLNode::openFileHelper functions will test if
+   * the file contains WideChar
+   *     characters. If this is the case, then the file will be loaded and
+   * converted in memory to
+   *     ASCII/UTF8/char* before being parsed. If 0, no conversion will be
+   * performed.
+   *
+   * @param characterEncoding This parameter is only meaningful when compiling
+   * in char* mode (multibyte character mode).
+   *     In wchar_t* (wide char mode), this parameter is ignored. This parameter
+   * should be one of the
+   *     three currently recognized encodings: XMLNode::encoding_UTF8,
+   * XMLNode::encoding_ascii,
+   *     XMLNode::encoding_ShiftJIS.
+   *
+   * @param dropWhiteSpace In most situations, text fields containing only white
+   * spaces (and carriage returns)
+   *     are useless. Even more, these "empty" text fields are annoying because
+   * they increase the
+   *     complexity of the user's code for parsing. So, 99% of the time, it's
+   * better to drop
+   *     the "empty" text fields. However The XML specification indicates that
+   * no white spaces
+   *     should be lost when parsing the file. So to be perfectly XML-compliant,
+   * you should set
+   *     dropWhiteSpace=0. A note of caution: if you set "dropWhiteSpace=0", the
+   * parser will be
+   *     slower and your code will be more complex.
+   *
+   * @param removeCommentsInMiddleOfText To explain this parameter, let's
+   * consider this code:
+   * \code
+   *        XMLNode x=XMLNode::parseString("<a>foo<!-- hello -->bar<!DOCTYPE
+   * world >chu</a>","a");
+   * \endcode
+   *     If removeCommentsInMiddleOfText=0, then we will have:
+   * \code
+   *        x.getText(0) -> "foo"
+   *        x.getText(1) -> "bar"
+   *        x.getText(2) -> "chu"
+   *        x.getClear(0) --> "<!-- hello -->"
+   *        x.getClear(1) --> "<!DOCTYPE world >"
+   * \endcode
+   *     If removeCommentsInMiddleOfText=1, then we will have:
+   * \code
+   *        x.getText(0) -> "foobar"
+   *        x.getText(1) -> "chu"
+   *        x.getClear(0) --> "<!DOCTYPE world >"
+   * \endcode
+   *
+   * \return "0" when there are no errors. If you try to set an unrecognized
+   * encoding then the return value will be "1" to signal an error.
+   *
+   * \note Sometime, it's useful to set "guessWideCharChars=0" to disable any
+   * conversion
+   * because the test to detect the file-type (ASCII/UTF8/char* or WideChar) may
+   * fail (rarely). */
 
-    /// Sets the global options for the conversions
-    static char setGlobalOptions(XMLCharEncoding characterEncoding=XMLNode::char_encoding_UTF8, char guessWideCharChars=1,
-                                 char dropWhiteSpace=1, char removeCommentsInMiddleOfText=1);
-    /**< The "setGlobalOptions" function allows you to change four global parameters that affect string & file
-     * parsing. First of all, you most-probably will never have to change these 3 global parameters.
-     *
-     * @param guessWideCharChars If "guessWideCharChars"=1 and if this library is compiled in WideChar mode, then the
-     *     XMLNode::parseFile and XMLNode::openFileHelper functions will test if the file contains ASCII
-     *     characters. If this is the case, then the file will be loaded and converted in memory to
-     *     WideChar before being parsed. If 0, no conversion will be performed.
-     *
-     * @param guessWideCharChars If "guessWideCharChars"=1 and if this library is compiled in ASCII/UTF8/char* mode, then the
-     *     XMLNode::parseFile and XMLNode::openFileHelper functions will test if the file contains WideChar
-     *     characters. If this is the case, then the file will be loaded and converted in memory to
-     *     ASCII/UTF8/char* before being parsed. If 0, no conversion will be performed.
-     *
-     * @param characterEncoding This parameter is only meaningful when compiling in char* mode (multibyte character mode).
-     *     In wchar_t* (wide char mode), this parameter is ignored. This parameter should be one of the
-     *     three currently recognized encodings: XMLNode::encoding_UTF8, XMLNode::encoding_ascii,
-     *     XMLNode::encoding_ShiftJIS.
-     *
-     * @param dropWhiteSpace In most situations, text fields containing only white spaces (and carriage returns)
-     *     are useless. Even more, these "empty" text fields are annoying because they increase the
-     *     complexity of the user's code for parsing. So, 99% of the time, it's better to drop
-     *     the "empty" text fields. However The XML specification indicates that no white spaces
-     *     should be lost when parsing the file. So to be perfectly XML-compliant, you should set
-     *     dropWhiteSpace=0. A note of caution: if you set "dropWhiteSpace=0", the parser will be
-     *     slower and your code will be more complex.
-     *
-     * @param removeCommentsInMiddleOfText To explain this parameter, let's consider this code:
-     * \code
-     *        XMLNode x=XMLNode::parseString("<a>foo<!-- hello -->bar<!DOCTYPE world >chu</a>","a");
-     * \endcode
-     *     If removeCommentsInMiddleOfText=0, then we will have:
-     * \code
-     *        x.getText(0) -> "foo"
-     *        x.getText(1) -> "bar"
-     *        x.getText(2) -> "chu"
-     *        x.getClear(0) --> "<!-- hello -->"
-     *        x.getClear(1) --> "<!DOCTYPE world >"
-     * \endcode
-     *     If removeCommentsInMiddleOfText=1, then we will have:
-     * \code
-     *        x.getText(0) -> "foobar"
-     *        x.getText(1) -> "chu"
-     *        x.getClear(0) --> "<!DOCTYPE world >"
-     * \endcode
-     *
-     * \return "0" when there are no errors. If you try to set an unrecognized encoding then the return value will be "1" to signal an error.
-     *
-     * \note Sometime, it's useful to set "guessWideCharChars=0" to disable any conversion
-     * because the test to detect the file-type (ASCII/UTF8/char* or WideChar) may fail (rarely). */
+  /// Guess the character encoding of the string (ascii, utf8 or shift-JIS)
+  static XMLCharEncoding guessCharEncoding(void *buffer, int bufLen,
+                                           char useXMLEncodingAttribute = 1);
+  /**< The "guessCharEncoding" function try to guess the character encoding. You
+   * most-probably will never
+   * have to use this function. It then returns the appropriate value of the
+   * global parameter
+   * "characterEncoding" described in the XMLNode::setGlobalOptions. The guess
+   * is based on the content of a buffer of length
+   * "bufLen" bytes that contains the first bytes (minimum 25 bytes; 200 bytes
+   * is a good value) of the
+   * file to be parsed. The XMLNode::openFileHelper function is using this
+   * function to automatically compute
+   * the value of the "characterEncoding" global parameter. There are several
+   * heuristics used to do the
+   * guess. One of the heuristic is based on the "encoding" attribute. The
+   * original XML specifications
+   * forbids to use this attribute to do the guess but you can still use it if
+   * you set
+   * "useXMLEncodingAttribute" to 1 (this is the default behavior and the
+   * behavior of most parsers).
+   * If an inconsistency in the encoding is detected, then the return value is
+   * "0". */
+  /** @} */
 
-    /// Guess the character encoding of the string (ascii, utf8 or shift-JIS)
-    static XMLCharEncoding guessCharEncoding(void *buffer, int bufLen, char useXMLEncodingAttribute=1);
-    /**< The "guessCharEncoding" function try to guess the character encoding. You most-probably will never
-     * have to use this function. It then returns the appropriate value of the global parameter
-     * "characterEncoding" described in the XMLNode::setGlobalOptions. The guess is based on the content of a buffer of length
-     * "bufLen" bytes that contains the first bytes (minimum 25 bytes; 200 bytes is a good value) of the
-     * file to be parsed. The XMLNode::openFileHelper function is using this function to automatically compute
-     * the value of the "characterEncoding" global parameter. There are several heuristics used to do the
-     * guess. One of the heuristic is based on the "encoding" attribute. The original XML specifications
-     * forbids to use this attribute to do the guess but you can still use it if you set
-     * "useXMLEncodingAttribute" to 1 (this is the default behavior and the behavior of most parsers).
-     * If an inconsistency in the encoding is detected, then the return value is "0". */
-    /** @} */
+ private:
+  // these are functions and structures used internally by the XMLNode class
+  // (don't bother about them):
 
-  private:
-      // these are functions and structures used internally by the XMLNode class (don't bother about them):
+  typedef struct XMLNodeDataTag  // to allow shallow copy and
+                                 // "intelligent/smart" pointers (automatic
+                                 // delete):
+  {
+    XMLCSTR lpszName;    // Element name (=NULL if root)
+    int nChild,          // Number of child nodes
+        nText,           // Number of text fields
+        nClear,          // Number of Clear fields (comments)
+        nAttribute;      // Number of attributes
+    char isDeclaration;  // Whether node is an XML declaration - '<?xml ?>'
+    struct XMLNodeDataTag
+        *pParent;              // Pointer to parent element (=NULL if root)
+    XMLNode *pChild;           // Array of child nodes
+    XMLCSTR *pText;            // Array of text fields
+    XMLClear *pClear;          // Array of clear fields
+    XMLAttribute *pAttribute;  // Array of attributes
+    int *pOrder;    // order of the child_nodes,text_fields,clear_fields
+    int ref_count;  // for garbage collection (smart pointers)
+  } XMLNodeData;
+  XMLNodeData *d;
 
-      typedef struct XMLNodeDataTag // to allow shallow copy and "intelligent/smart" pointers (automatic delete):
-      {
-          XMLCSTR                lpszName;        // Element name (=NULL if root)
-          int                    nChild,          // Number of child nodes
-                                 nText,           // Number of text fields
-                                 nClear,          // Number of Clear fields (comments)
-                                 nAttribute;      // Number of attributes
-          char                   isDeclaration;   // Whether node is an XML declaration - '<?xml ?>'
-          struct XMLNodeDataTag  *pParent;        // Pointer to parent element (=NULL if root)
-          XMLNode                *pChild;         // Array of child nodes
-          XMLCSTR                *pText;          // Array of text fields
-          XMLClear               *pClear;         // Array of clear fields
-          XMLAttribute           *pAttribute;     // Array of attributes
-          int                    *pOrder;         // order of the child_nodes,text_fields,clear_fields
-          int                    ref_count;       // for garbage collection (smart pointers)
-      } XMLNodeData;
-      XMLNodeData *d;
-
-      char parseClearTag(void *px, void *pa);
-      char maybeAddTxT(void *pa, XMLCSTR tokenPStr);
-      int ParseXMLElement(void *pXML);
-      void *addToOrder(int memInc, int *_pos, int nc, void *p, int size, XMLElementType xtype);
-      int indexText(XMLCSTR lpszValue) const;
-      int indexClear(XMLCSTR lpszValue) const;
-      XMLNode addChild_priv(int,XMLSTR,char,int);
-      XMLAttribute *addAttribute_priv(int,XMLSTR,XMLSTR);
-      XMLCSTR addText_priv(int,XMLSTR,int);
-      XMLClear *addClear_priv(int,XMLSTR,XMLCSTR,XMLCSTR,int);
-      void emptyTheNode(char force);
-      static inline XMLElementPosition findPosition(XMLNodeData *d, int index, XMLElementType xtype);
-      static int CreateXMLStringR(XMLNodeData *pEntry, XMLSTR lpszMarker, int nFormat);
-      static int removeOrderElement(XMLNodeData *d, XMLElementType t, int index);
-      static void exactMemory(XMLNodeData *d);
-      static int detachFromParent(XMLNodeData *d);
+  char parseClearTag(void *px, void *pa);
+  char maybeAddTxT(void *pa, XMLCSTR tokenPStr);
+  int ParseXMLElement(void *pXML);
+  void *addToOrder(int memInc, int *_pos, int nc, void *p, int size,
+                   XMLElementType xtype);
+  int indexText(XMLCSTR lpszValue) const;
+  int indexClear(XMLCSTR lpszValue) const;
+  XMLNode addChild_priv(int, XMLSTR, char, int);
+  XMLAttribute *addAttribute_priv(int, XMLSTR, XMLSTR);
+  XMLCSTR addText_priv(int, XMLSTR, int);
+  XMLClear *addClear_priv(int, XMLSTR, XMLCSTR, XMLCSTR, int);
+  void emptyTheNode(char force);
+  static inline XMLElementPosition findPosition(XMLNodeData *d, int index,
+                                                XMLElementType xtype);
+  static int CreateXMLStringR(XMLNodeData *pEntry, XMLSTR lpszMarker,
+                              int nFormat);
+  static int removeOrderElement(XMLNodeData *d, XMLElementType t, int index);
+  static void exactMemory(XMLNodeData *d);
+  static int detachFromParent(XMLNodeData *d);
 } XMLNode;
 
 /// This structure is given by the function XMLNode::enumContents.
-typedef struct XMLNodeContents
-{
-    /// This dictates what's the content of the XMLNodeContent
-    enum XMLElementType etype;
-    /**< should be an union to access the appropriate data. Compiler does not allow union of object with constructor... too bad. */
-    XMLNode child;
-    XMLAttribute attrib;
-    XMLCSTR text;
-    XMLClear clear;
+typedef struct XMLNodeContents {
+  /// This dictates what's the content of the XMLNodeContent
+  enum XMLElementType etype;
+  /**< should be an union to access the appropriate data. Compiler does not
+   * allow union of object with constructor... too bad. */
+  XMLNode child;
+  XMLAttribute attrib;
+  XMLCSTR text;
+  XMLClear clear;
 
 } XMLNodeContents;
 
@@ -645,118 +912,164 @@ typedef struct XMLNodeContents
  * @ingroup xmlModify
  * @{ */
 /// Duplicate (copy in a new allocated buffer) the source string.
-XMLDLLENTRY XMLSTR stringDup(XMLCSTR source, int cbData=-1);
+XMLDLLENTRY XMLSTR stringDup(XMLCSTR source, int cbData = -1);
 /**< This is
- * a very handy function when used with all the "XMLNode::*_WOSD" functions (\link xmlWOSD \endlink).
- * @param cbData If !=0 then cbData is the number of chars to duplicate. New strings allocated with
+ * a very handy function when used with all the "XMLNode::*_WOSD" functions
+ * (\link xmlWOSD \endlink).
+ * @param cbData If !=0 then cbData is the number of chars to duplicate. New
+ * strings allocated with
  * this function should be free'd using the "freeXMLString" function. */
 
-/// to free the string allocated inside the "stringDup" function or the "createXMLString" function.
-XMLDLLENTRY void freeXMLString(XMLSTR t); // {free(t);}
-/** @} */
+/// to free the string allocated inside the "stringDup" function or the
+/// "createXMLString" function.
+XMLDLLENTRY void freeXMLString(XMLSTR t);  // {free(t);}
+                                           /** @} */
 
 /** @defgroup atoX ato? like functions
  * @ingroup XMLParserGeneral
  * The "xmlto?" functions are equivalents to the atoi, atol, atof functions.
- * The only difference is: If the variable "xmlString" is NULL, than the return value
- * is "defautValue". These 6 functions are only here as "convenience" functions for the
- * user (they are not used inside the XMLparser). If you don't need them, you can
+ * The only difference is: If the variable "xmlString" is NULL, than the return
+ * value
+ * is "defautValue". These 6 functions are only here as "convenience" functions
+ * for the
+ * user (they are not used inside the XMLparser). If you don't need them, you
+ * can
  * delete them without any trouble.
  *
  * @{ */
-XMLDLLENTRY char    xmltob(XMLCSTR xmlString,char   defautValue=0);
-XMLDLLENTRY int     xmltoi(XMLCSTR xmlString,int    defautValue=0);
-XMLDLLENTRY long    xmltol(XMLCSTR xmlString,long   defautValue=0);
-XMLDLLENTRY double  xmltof(XMLCSTR xmlString,double defautValue=.0);
-XMLDLLENTRY XMLCSTR xmltoa(XMLCSTR xmlString,XMLCSTR defautValue=_CXML(""));
-XMLDLLENTRY XMLCHAR xmltoc(XMLCSTR xmlString,XMLCHAR defautValue=_CXML('\0'));
+XMLDLLENTRY char xmltob(XMLCSTR xmlString, char defautValue = 0);
+XMLDLLENTRY int xmltoi(XMLCSTR xmlString, int defautValue = 0);
+XMLDLLENTRY long xmltol(XMLCSTR xmlString, long defautValue = 0);
+XMLDLLENTRY double xmltof(XMLCSTR xmlString, double defautValue = .0);
+XMLDLLENTRY XMLCSTR xmltoa(XMLCSTR xmlString, XMLCSTR defautValue = _CXML(""));
+XMLDLLENTRY XMLCHAR xmltoc(XMLCSTR xmlString,
+                           XMLCHAR defautValue = _CXML('\0'));
 /** @} */
 
-/** @defgroup ToXMLStringTool Helper class to create XML files using "printf", "fprintf", "cout",... functions.
+/** @defgroup ToXMLStringTool Helper class to create XML files using "printf",
+ * "fprintf", "cout",... functions.
  * @ingroup XMLParserGeneral
  * @{ */
-/// Helper class to create XML files using "printf", "fprintf", "cout",... functions.
-/** The ToXMLStringTool class helps you creating XML files using "printf", "fprintf", "cout",... functions.
+/// Helper class to create XML files using "printf", "fprintf", "cout",...
+/// functions.
+/** The ToXMLStringTool class helps you creating XML files using "printf",
+ * "fprintf", "cout",... functions.
  * The "ToXMLStringTool" class is processing strings so that all the characters
  * &,",',<,> are replaced by their XML equivalent:
  * \verbatim &amp;, &quot;, &apos;, &lt;, &gt; \endverbatim
- * Using the "ToXMLStringTool class" and the "fprintf function" is THE most efficient
+ * Using the "ToXMLStringTool class" and the "fprintf function" is THE most
+ * efficient
  * way to produce VERY large XML documents VERY fast.
- * \note If you are creating from scratch an XML file using the provided XMLNode class
- * you must not use the "ToXMLStringTool" class (because the "XMLNode" class does the
+ * \note If you are creating from scratch an XML file using the provided XMLNode
+ * class
+ * you must not use the "ToXMLStringTool" class (because the "XMLNode" class
+ * does the
  * processing job for you during rendering).*/
-typedef struct XMLDLLENTRY ToXMLStringTool
-{
-public:
-    ToXMLStringTool(): buf(NULL),buflen(0){}
-    ~ToXMLStringTool();
-    void freeBuffer();///<call this function when you have finished using this object to release memory used by the internal buffer.
+typedef struct XMLDLLENTRY ToXMLStringTool {
+ public:
+  ToXMLStringTool() : buf(NULL), buflen(0) {}
+  ~ToXMLStringTool();
+  void freeBuffer();  ///<call this function when you have finished using this
+                      ///object to release memory used by the internal buffer.
 
-    XMLSTR toXML(XMLCSTR source);///< returns a pointer to an internal buffer that contains a XML-encoded string based on the "source" parameter.
+  XMLSTR toXML(XMLCSTR source);  ///< returns a pointer to an internal buffer
+                                 ///that contains a XML-encoded string based on
+                                 ///the "source" parameter.
 
-    /** The "toXMLUnSafe" function is deprecated because there is a possibility of
-     * "destination-buffer-overflow". It converts the string
-     * "source" to the string "dest". */
-    static XMLSTR toXMLUnSafe(XMLSTR dest,XMLCSTR source); ///< deprecated: use "toXML" instead
-    static int lengthXMLString(XMLCSTR source);            ///< deprecated: use "toXML" instead
+  /** The "toXMLUnSafe" function is deprecated because there is a possibility of
+   * "destination-buffer-overflow". It converts the string
+   * "source" to the string "dest". */
+  static XMLSTR toXMLUnSafe(
+      XMLSTR dest, XMLCSTR source);  ///< deprecated: use "toXML" instead
+  static int lengthXMLString(
+      XMLCSTR source);  ///< deprecated: use "toXML" instead
 
-private:
-    XMLSTR buf;
-    int buflen;
+ private:
+  XMLSTR buf;
+  int buflen;
 } ToXMLStringTool;
 /** @} */
 
-/** @defgroup XMLParserBase64Tool Helper class to include binary data inside XML strings using "Base64 encoding".
+/** @defgroup XMLParserBase64Tool Helper class to include binary data inside XML
+ * strings using "Base64 encoding".
  * @ingroup XMLParserGeneral
  * @{ */
-/// Helper class to include binary data inside XML strings using "Base64 encoding".
-/** The "XMLParserBase64Tool" class allows you to include any binary data (images, sounds,...)
+/// Helper class to include binary data inside XML strings using "Base64
+/// encoding".
+/** The "XMLParserBase64Tool" class allows you to include any binary data
+ * (images, sounds,...)
  * into an XML document using "Base64 encoding". This class is completely
- * separated from the rest of the xmlParser library and can be removed without any problem.
- * To include some binary data into an XML file, you must convert the binary data into
+ * separated from the rest of the xmlParser library and can be removed without
+ * any problem.
+ * To include some binary data into an XML file, you must convert the binary
+ * data into
  * standard text (using "encode"). To retrieve the original binary data from the
- * b64-encoded text included inside the XML file, use "decode". Alternatively, these
- * functions can also be used to "encrypt/decrypt" some critical data contained inside
- * the XML (it's not a strong encryption at all, but sometimes it can be useful). */
-typedef struct XMLDLLENTRY XMLParserBase64Tool
-{
-public:
-    XMLParserBase64Tool(): buf(NULL),buflen(0){}
-    ~XMLParserBase64Tool();
-    void freeBuffer();///< Call this function when you have finished using this object to release memory used by the internal buffer.
+ * b64-encoded text included inside the XML file, use "decode". Alternatively,
+ * these
+ * functions can also be used to "encrypt/decrypt" some critical data contained
+ * inside
+ * the XML (it's not a strong encryption at all, but sometimes it can be
+ * useful). */
+typedef struct XMLDLLENTRY XMLParserBase64Tool {
+ public:
+  XMLParserBase64Tool() : buf(NULL), buflen(0) {}
+  ~XMLParserBase64Tool();
+  void freeBuffer();  ///< Call this function when you have finished using this
+                      ///object to release memory used by the internal buffer.
 
-    /**
-     * @param formatted If "formatted"=true, some space will be reserved for a carriage-return every 72 chars. */
-    static int encodeLength(int inBufLen, char formatted=0); ///< return the length of the base64 string that encodes a data buffer of size inBufLen bytes.
+  /**
+   * @param formatted If "formatted"=true, some space will be reserved for a
+   * carriage-return every 72 chars. */
+  static int encodeLength(int inBufLen,
+                          char formatted = 0);  ///< return the length of the
+                                                ///base64 string that encodes a
+                                                ///data buffer of size inBufLen
+                                                ///bytes.
 
-    /**
-     * The "base64Encode" function returns a string containing the base64 encoding of "inByteLen" bytes
-     * from "inByteBuf". If "formatted" parameter is true, then there will be a carriage-return every 72 chars.
-     * The string will be free'd when the XMLParserBase64Tool object is deleted.
-     * All returned strings are sharing the same memory space. */
-    XMLSTR encode(unsigned char *inByteBuf, unsigned int inByteLen, char formatted=0); ///< returns a pointer to an internal buffer containing the base64 string containing the binary data encoded from "inByteBuf"
+  /**
+   * The "base64Encode" function returns a string containing the base64 encoding
+   * of "inByteLen" bytes
+   * from "inByteBuf". If "formatted" parameter is true, then there will be a
+   * carriage-return every 72 chars.
+   * The string will be free'd when the XMLParserBase64Tool object is deleted.
+   * All returned strings are sharing the same memory space. */
+  XMLSTR encode(unsigned char *inByteBuf, unsigned int inByteLen,
+                char formatted = 0);  ///< returns a pointer to an internal
+                                      ///buffer containing the base64 string
+                                      ///containing the binary data encoded from
+                                      ///"inByteBuf"
 
-    /// returns the number of bytes which will be decoded from "inString".
-    static unsigned int decodeSize(XMLCSTR inString, XMLError *xe=NULL);
+  /// returns the number of bytes which will be decoded from "inString".
+  static unsigned int decodeSize(XMLCSTR inString, XMLError *xe = NULL);
 
-    /**
-     * The "decode" function returns a pointer to a buffer containing the binary data decoded from "inString"
-     * The output buffer will be free'd when the XMLParserBase64Tool object is deleted.
-     * All output buffer are sharing the same memory space.
-     * @param inString If "instring" is malformed, NULL will be returned */
-    unsigned char* decode(XMLCSTR inString, int *outByteLen=NULL, XMLError *xe=NULL); ///< returns a pointer to an internal buffer containing the binary data decoded from "inString"
+  /**
+   * The "decode" function returns a pointer to a buffer containing the binary
+   * data decoded from "inString"
+   * The output buffer will be free'd when the XMLParserBase64Tool object is
+   * deleted.
+   * All output buffer are sharing the same memory space.
+   * @param inString If "instring" is malformed, NULL will be returned */
+  unsigned char *decode(XMLCSTR inString, int *outByteLen = NULL,
+                        XMLError *xe = NULL);  ///< returns a pointer to an
+                                               ///internal buffer containing the
+                                               ///binary data decoded from
+                                               ///"inString"
 
-    /**
-     * decodes data from "inString" to "outByteBuf". You need to provide the size (in byte) of "outByteBuf"
-     * in "inMaxByteOutBuflen". If "outByteBuf" is not large enough or if data is malformed, then "FALSE"
-     * will be returned; otherwise "TRUE". */
-    static unsigned char decode(XMLCSTR inString, unsigned char *outByteBuf, int inMaxByteOutBuflen, XMLError *xe=NULL); ///< deprecated.
+  /**
+   * decodes data from "inString" to "outByteBuf". You need to provide the size
+   * (in byte) of "outByteBuf"
+   * in "inMaxByteOutBuflen". If "outByteBuf" is not large enough or if data is
+   * malformed, then "FALSE"
+   * will be returned; otherwise "TRUE". */
+  static unsigned char decode(XMLCSTR inString, unsigned char *outByteBuf,
+                              int inMaxByteOutBuflen,
+                              XMLError *xe = NULL);  ///< deprecated.
 
-private:
-    void *buf;
-    int buflen;
-    void alloc(int newsize);
-}XMLParserBase64Tool;
+ private:
+  void *buf;
+  int buflen;
+  void alloc(int newsize);
+} XMLParserBase64Tool;
 /** @} */
 
 #undef XMLDLLENTRY

--- a/src/gpuwattch/xmlParser.h
+++ b/src/gpuwattch/xmlParser.h
@@ -391,7 +391,7 @@ typedef struct XMLDLLENTRY XMLNode {
    */
 
   static XMLCSTR getError(XMLError error);  ///< this gives you a user-friendly
-                                            ///explanation of the parsing error
+                                            /// explanation of the parsing error
 
   /// Create an XML string starting from the current XMLNode.
   XMLSTR createXMLString(int nFormat = 1, int *pnSize = NULL) const;
@@ -426,23 +426,23 @@ typedef struct XMLDLLENTRY XMLNode {
   XMLNode getParentNode() const;                    ///< return the parent node
   XMLNode getChildNode(int i = 0) const;            ///< return ith child node
   XMLNode getChildNode(XMLCSTR name, int i) const;  ///< return ith child node
-                                                    ///with specific name
-                                                    ///(return an empty node if
-                                                    ///failing). If i==-1, this
-                                                    ///returns the last XMLNode
-                                                    ///with the given name.
+                                                    /// with specific name
+  ///(return an empty node if
+  /// failing). If i==-1, this
+  /// returns the last XMLNode
+  /// with the given name.
   XMLNode getChildNode(XMLCSTR name, int *i = NULL) const;  ///< return next
-                                                            ///child node with
-                                                            ///specific name
-                                                            ///(return an empty
-                                                            ///node if failing)
+                                                            /// child node with
+  /// specific name
+  ///(return an empty
+  /// node if failing)
   XMLNode getChildNodeWithAttribute(XMLCSTR tagName, XMLCSTR attributeName,
                                     XMLCSTR attributeValue = NULL,
                                     int *i = NULL) const;  ///< return child
-                                                           ///node with specific
-                                                           ///name/attribute
-                                                           ///(return an empty
-                                                           ///node if failing)
+  /// node with specific
+  /// name/attribute
+  ///(return an empty
+  /// node if failing)
   XMLNode getChildNodeByPath(XMLCSTR path, char createNodeIfMissing = 0,
                              XMLCHAR sep = '/');
   ///< return the first child node with specific path
@@ -459,21 +459,21 @@ typedef struct XMLDLLENTRY XMLNode {
   char isAttributeSet(XMLCSTR name)
       const;  ///< test if an attribute with a specific name is given
   XMLCSTR getAttribute(XMLCSTR name, int i) const;  ///< return ith attribute
-                                                    ///content with specific
-                                                    ///name (return a NULL if
-                                                    ///failing)
+                                                    /// content with specific
+  /// name (return a NULL if
+  /// failing)
   XMLCSTR getAttribute(XMLCSTR name, int *i = NULL) const;  ///< return next
-                                                            ///attribute content
-                                                            ///with specific
-                                                            ///name (return a
-                                                            ///NULL if failing)
+  /// attribute content
+  /// with specific
+  /// name (return a
+  /// NULL if failing)
   int nAttribute() const;              ///< nbr of attribute
   XMLClear getClear(int i = 0) const;  ///< return ith clear field (comments)
   int nClear() const;                  ///< nbr of clear field
   XMLNodeContents enumContents(XMLElementPosition i)
       const;  ///< enumerate all the different contents (attribute,child,text,
-              ///clear) of the current XMLNode. The order is reflecting the
-              ///order of the original file/string. NOTE: 0 <= i < nElement();
+              /// clear) of the current XMLNode. The order is reflecting the
+  /// order of the original file/string. NOTE: 0 <= i < nElement();
   int nElement() const;        ///< nbr of different contents for current node
   char isEmpty() const;        ///< is this node Empty?
   char isDeclaration() const;  ///< is this node a declaration <? .... ?>
@@ -515,10 +515,10 @@ typedef struct XMLDLLENTRY XMLNode {
                    XMLElementPosition pos = -1);  ///< Add a new child node
   XMLNode addChild(XMLNode nodeToAdd,
                    XMLElementPosition pos = -1);  ///< If the "nodeToAdd" has
-                                                  ///some parents, it will be
-                                                  ///detached from it's parents
-                                                  ///before being attached to
-                                                  ///the current XMLNode
+                                                  /// some parents, it will be
+  /// detached from it's parents
+  /// before being attached to
+  /// the current XMLNode
   XMLAttribute *addAttribute(XMLCSTR lpszName,
                              XMLCSTR lpszValuev);  ///< Add a new attribute
   XMLCSTR addText(XMLCSTR lpszValue,
@@ -539,41 +539,41 @@ typedef struct XMLDLLENTRY XMLNode {
   XMLCSTR updateName(XMLCSTR lpszName);  ///< change node's name
   XMLAttribute *updateAttribute(XMLAttribute *newAttribute,
                                 XMLAttribute *oldAttribute);  ///< if the
-                                                              ///attribute to
-                                                              ///update is
-                                                              ///missing, a new
-                                                              ///one will be
-                                                              ///added
+                                                              /// attribute to
+  /// update is
+  /// missing, a new
+  /// one will be
+  /// added
   XMLAttribute *updateAttribute(XMLCSTR lpszNewValue,
                                 XMLCSTR lpszNewName = NULL,
                                 int i = 0);  ///< if the attribute to update is
-                                             ///missing, a new one will be added
+  /// missing, a new one will be added
   XMLAttribute *updateAttribute(XMLCSTR lpszNewValue, XMLCSTR lpszNewName,
                                 XMLCSTR lpszOldName);  ///< set lpszNewName=NULL
-                                                       ///if you don't want to
-                                                       ///change the name of the
-                                                       ///attribute if the
-                                                       ///attribute to update is
-                                                       ///missing, a new one
-                                                       ///will be added
+                                                       /// if you don't want to
+  /// change the name of the
+  /// attribute if the
+  /// attribute to update is
+  /// missing, a new one
+  /// will be added
   XMLCSTR updateText(XMLCSTR lpszNewValue, int i = 0);  ///< if the text to
-                                                        ///update is missing, a
-                                                        ///new one will be added
+                                                        /// update is missing, a
+  /// new one will be added
   XMLCSTR updateText(XMLCSTR lpszNewValue,
                      XMLCSTR lpszOldValue);  ///< if the text to update is
-                                             ///missing, a new one will be added
+  /// missing, a new one will be added
   XMLClear *updateClear(XMLCSTR lpszNewContent,
                         int i = 0);  ///< if the clearTag to update is missing,
-                                     ///a new one will be added
+                                     /// a new one will be added
   XMLClear *updateClear(XMLClear *newP, XMLClear *oldP);  ///< if the clearTag
-                                                          ///to update is
-                                                          ///missing, a new one
-                                                          ///will be added
+                                                          /// to update is
+  /// missing, a new one
+  /// will be added
   XMLClear *updateClear(XMLCSTR lpszNewValue,
                         XMLCSTR lpszOldValue);  ///< if the clearTag to update
-                                                ///is missing, a new one will be
-                                                ///added
-                                                /** @} */
+  /// is missing, a new one will be
+  /// added
+  /** @} */
 
   /** @defgroup xmlDelete Deleting Nodes or Attributes
    * @ingroup xmlModify
@@ -589,33 +589,33 @@ typedef struct XMLDLLENTRY XMLNode {
   void deleteAttribute(
       int i = 0);  ///< Delete the ith attribute of the current XMLNode
   void deleteAttribute(XMLCSTR lpszName);  ///< Delete the attribute with the
-                                           ///given name (the "strcmp" function
-                                           ///is used to find the right
-                                           ///attribute)
+                                           /// given name (the "strcmp" function
+  /// is used to find the right
+  /// attribute)
   void deleteAttribute(XMLAttribute *anAttribute);  ///< Delete the attribute
-                                                    ///with the name
-                                                    ///"anAttribute->lpszName"
-                                                    ///(the "strcmp" function is
-                                                    ///used to find the right
-                                                    ///attribute)
+                                                    /// with the name
+  ///"anAttribute->lpszName"
+  ///(the "strcmp" function is
+  /// used to find the right
+  /// attribute)
   void deleteText(
       int i = 0);  ///< Delete the Ith text content of the current XMLNode
   void deleteText(XMLCSTR lpszValue);  ///< Delete the text content "lpszValue"
-                                       ///inside the current XMLNode (direct
-                                       ///"pointer-to-pointer" comparison is
-                                       ///used to find the right text)
+                                       /// inside the current XMLNode (direct
+  ///"pointer-to-pointer" comparison is
+  /// used to find the right text)
   void deleteClear(
       int i = 0);  ///< Delete the Ith clear tag inside the current XMLNode
   void deleteClear(XMLCSTR lpszValue);  ///< Delete the clear tag "lpszValue"
-                                        ///inside the current XMLNode (direct
-                                        ///"pointer-to-pointer" comparison is
-                                        ///used to find the clear tag)
-  void deleteClear(XMLClear *p);        ///< Delete the clear tag "p" inside the
-                                        ///current XMLNode (direct
+                                        /// inside the current XMLNode (direct
+  ///"pointer-to-pointer" comparison is
+  /// used to find the clear tag)
+  void deleteClear(XMLClear *p);  ///< Delete the clear tag "p" inside the
+                                  /// current XMLNode (direct
                                   ///"pointer-to-pointer" comparison on the
-                                  ///lpszName of the clear tag is used to find
-                                  ///the clear tag)
-  /** @} */
+                                  /// lpszName of the clear tag is used to find
+                                  /// the clear tag)
+                                  /** @} */
 
   /** @defgroup xmlWOSD ???_WOSD functions.
    * @ingroup xmlModify
@@ -666,49 +666,49 @@ typedef struct XMLDLLENTRY XMLNode {
   XMLCSTR updateName_WOSD(XMLSTR lpszName);  ///< change node's name
   XMLAttribute *updateAttribute_WOSD(XMLAttribute *newAttribute,
                                      XMLAttribute *oldAttribute);  ///< if the
-                                                                   ///attribute
-                                                                   ///to update
-                                                                   ///is
-                                                                   ///missing, a
-                                                                   ///new one
-                                                                   ///will be
-                                                                   ///added
+                                                                   /// attribute
+  /// to update
+  /// is
+  /// missing, a
+  /// new one
+  /// will be
+  /// added
   XMLAttribute *updateAttribute_WOSD(XMLSTR lpszNewValue,
                                      XMLSTR lpszNewName = NULL,
                                      int i = 0);  ///< if the attribute to
-                                                  ///update is missing, a new
-                                                  ///one will be added
+                                                  /// update is missing, a new
+  /// one will be added
   XMLAttribute *updateAttribute_WOSD(XMLSTR lpszNewValue, XMLSTR lpszNewName,
                                      XMLCSTR lpszOldName);  ///< set
-                                                            ///lpszNewName=NULL
-                                                            ///if you don't want
-                                                            ///to change the
-                                                            ///name of the
-                                                            ///attribute if the
-                                                            ///attribute to
-                                                            ///update is
-                                                            ///missing, a new
-                                                            ///one will be added
+                                                            /// lpszNewName=NULL
+  /// if you don't want
+  /// to change the
+  /// name of the
+  /// attribute if the
+  /// attribute to
+  /// update is
+  /// missing, a new
+  /// one will be added
   XMLCSTR updateText_WOSD(XMLSTR lpszNewValue, int i = 0);  ///< if the text to
-                                                            ///update is
-                                                            ///missing, a new
-                                                            ///one will be added
+                                                            /// update is
+  /// missing, a new
+  /// one will be added
   XMLCSTR updateText_WOSD(XMLSTR lpszNewValue,
                           XMLCSTR lpszOldValue);  ///< if the text to update is
-                                                  ///missing, a new one will be
-                                                  ///added
+                                                  /// missing, a new one will be
+  /// added
   XMLClear *updateClear_WOSD(XMLSTR lpszNewContent,
                              int i = 0);  ///< if the clearTag to update is
-                                          ///missing, a new one will be added
+                                          /// missing, a new one will be added
   XMLClear *updateClear_WOSD(XMLClear *newP,
                              XMLClear *oldP);  ///< if the clearTag to update is
-                                               ///missing, a new one will be
-                                               ///added
+                                               /// missing, a new one will be
+  /// added
   XMLClear *updateClear_WOSD(XMLSTR lpszNewValue,
                              XMLCSTR lpszOldValue);  ///< if the clearTag to
-                                                     ///update is missing, a new
-                                                     ///one will be added
-                                                     /** @} */
+  /// update is missing, a new
+  /// one will be added
+  /** @} */
 
   /** @defgroup xmlPosition Position helper functions (use in conjunction with
    * the update&add functions
@@ -729,7 +729,7 @@ typedef struct XMLDLLENTRY XMLNode {
   XMLElementPosition positionOfChildNode(XMLNode x) const;
   XMLElementPosition positionOfChildNode(XMLCSTR name, int i = 0)
       const;  ///< return the position of the ith childNode with the specified
-              ///name if (name==NULL) return the position of the ith childNode
+              /// name if (name==NULL) return the position of the ith childNode
   /** @} */
 
   /// Enumeration for XML character encoding.
@@ -970,11 +970,11 @@ typedef struct XMLDLLENTRY ToXMLStringTool {
   ToXMLStringTool() : buf(NULL), buflen(0) {}
   ~ToXMLStringTool();
   void freeBuffer();  ///<call this function when you have finished using this
-                      ///object to release memory used by the internal buffer.
+                      /// object to release memory used by the internal buffer.
 
   XMLSTR toXML(XMLCSTR source);  ///< returns a pointer to an internal buffer
-                                 ///that contains a XML-encoded string based on
-                                 ///the "source" parameter.
+                                 /// that contains a XML-encoded string based on
+                                 /// the "source" parameter.
 
   /** The "toXMLUnSafe" function is deprecated because there is a possibility of
    * "destination-buffer-overflow". It converts the string
@@ -1015,16 +1015,16 @@ typedef struct XMLDLLENTRY XMLParserBase64Tool {
   XMLParserBase64Tool() : buf(NULL), buflen(0) {}
   ~XMLParserBase64Tool();
   void freeBuffer();  ///< Call this function when you have finished using this
-                      ///object to release memory used by the internal buffer.
+                      /// object to release memory used by the internal buffer.
 
   /**
    * @param formatted If "formatted"=true, some space will be reserved for a
    * carriage-return every 72 chars. */
   static int encodeLength(int inBufLen,
                           char formatted = 0);  ///< return the length of the
-                                                ///base64 string that encodes a
-                                                ///data buffer of size inBufLen
-                                                ///bytes.
+                                                /// base64 string that encodes a
+                                                /// data buffer of size inBufLen
+                                                /// bytes.
 
   /**
    * The "base64Encode" function returns a string containing the base64 encoding
@@ -1035,9 +1035,9 @@ typedef struct XMLDLLENTRY XMLParserBase64Tool {
    * All returned strings are sharing the same memory space. */
   XMLSTR encode(unsigned char *inByteBuf, unsigned int inByteLen,
                 char formatted = 0);  ///< returns a pointer to an internal
-                                      ///buffer containing the base64 string
-                                      ///containing the binary data encoded from
-                                      ///"inByteBuf"
+                                      /// buffer containing the base64 string
+  /// containing the binary data encoded from
+  ///"inByteBuf"
 
   /// returns the number of bytes which will be decoded from "inString".
   static unsigned int decodeSize(XMLCSTR inString, XMLError *xe = NULL);
@@ -1051,9 +1051,9 @@ typedef struct XMLDLLENTRY XMLParserBase64Tool {
    * @param inString If "instring" is malformed, NULL will be returned */
   unsigned char *decode(XMLCSTR inString, int *outByteLen = NULL,
                         XMLError *xe = NULL);  ///< returns a pointer to an
-                                               ///internal buffer containing the
-                                               ///binary data decoded from
-                                               ///"inString"
+  /// internal buffer containing the
+  /// binary data decoded from
+  ///"inString"
 
   /**
    * decodes data from "inString" to "outByteBuf". You need to provide the size

--- a/src/gpuwattch/xmlParser.h
+++ b/src/gpuwattch/xmlParser.h
@@ -9,20 +9,17 @@
  * @version     V2.41
  * @author      Frank Vanden Berghen
  *
- * The following license terms for the "XMLParser library from Business-Insight"
- *apply to projects
+ * The following license terms for the "XMLParser library from Business-Insight" apply to projects
  * that are in some way related to
  * the "mcpat project", including applications
  * using "mcpat project" and tools developed
  * for enhancing "mcpat project". All other projects
- * (not related to "mcpat project") have to use the "XMLParser library from
- *Business-Insight"
+ * (not related to "mcpat project") have to use the "XMLParser library from Business-Insight"
  * code under the Aladdin Free Public License (AFPL)
  * See the file "AFPL-license.txt" for more informations about the AFPL license.
  * (see http://www.artifex.com/downloads/doc/Public.htm for detailed AFPL terms)
  *
- * Redistribution and use of the "XMLParser library from Business-Insight" in
- *source and binary forms, with or without
+ * Redistribution and use of the "XMLParser library from Business-Insight" in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
  *       notice, this list of conditions and the following disclaimer.
@@ -49,31 +46,21 @@
  * All rights reserved.
  *
  * \section tutorial First Tutorial
- * You can follow a simple <a href="../../xmlParser.html">Tutorial</a> to know
- *the basics...
+ * You can follow a simple <a href="../../xmlParser.html">Tutorial</a> to know the basics...
  *
- * \section usage General usage: How to include the XMLParser library inside
- *your project.
+ * \section usage General usage: How to include the XMLParser library inside your project.
  *
- * The library is composed of two files: <a
- *href="../../xmlParser.cpp">xmlParser.cpp</a> and
- * <a href="../../xmlParser.h">xmlParser.h</a>. These are the ONLY 2 files that
- *you need when
+ * The library is composed of two files: <a href="../../xmlParser.cpp">xmlParser.cpp</a> and
+ * <a href="../../xmlParser.h">xmlParser.h</a>. These are the ONLY 2 files that you need when
  * using the library inside your own projects.
  *
- * All the functions of the library are documented inside the comments of the
- *file
- * <a href="../../xmlParser.h">xmlParser.h</a>. These comments can be
- *transformed in
- * full-fledged HTML documentation using the DOXYGEN software: simply type:
- *"doxygen doxy.cfg"
+ * All the functions of the library are documented inside the comments of the file
+ * <a href="../../xmlParser.h">xmlParser.h</a>. These comments can be transformed in
+ * full-fledged HTML documentation using the DOXYGEN software: simply type: "doxygen doxy.cfg"
  *
- * By default, the XMLParser library uses (char*) for string representation.To
- *use the (wchar_t*)
- * version of the library, you need to define the "_UNICODE" preprocessor
- *definition variable
- * (this is usually done inside your project definition file) (This is done
- *automatically for you
+ * By default, the XMLParser library uses (char*) for string representation.To use the (wchar_t*)
+ * version of the library, you need to define the "_UNICODE" preprocessor definition variable
+ * (this is usually done inside your project definition file) (This is done automatically for you
  * when using Visual Studio).
  *
  * \section example Advanced Tutorial and Many Examples of usage.
@@ -81,66 +68,48 @@
  * Some very small introductory examples are described inside the Tutorial file
  * <a href="../../xmlParser.html">xmlParser.html</a>
  *
- * Some additional small examples are also inside the file <a
- *href="../../xmlTest.cpp">xmlTest.cpp</a>
+ * Some additional small examples are also inside the file <a href="../../xmlTest.cpp">xmlTest.cpp</a>
  * (for the "char*" version of the library) and inside the file
  * <a href="../../xmlTestUnicode.cpp">xmlTestUnicode.cpp</a> (for the "wchar_t*"
- * version of the library). If you have a question, please review these
- *additionnal examples
+ * version of the library). If you have a question, please review these additionnal examples
  * before sending an e-mail to the author.
  *
  * To build the examples:
  * - linux/unix: type "make"
  * - solaris: type "make -f makefile.solaris"
  * - windows: Visual Studio: double-click on xmlParser.dsw
- *   (under Visual Studio .NET, the .dsp and .dsw files will be automatically
- *converted to .vcproj and .sln files)
+ *   (under Visual Studio .NET, the .dsp and .dsw files will be automatically converted to .vcproj and .sln files)
  *
  * In order to build the examples you need some additional files:
  * - linux/unix: makefile
  * - solaris: makefile.solaris
- * - windows: Visual Studio: *.dsp, xmlParser.dsw and also xmlParser.lib and
- *xmlParser.dll
+ * - windows: Visual Studio: *.dsp, xmlParser.dsw and also xmlParser.lib and xmlParser.dll
  *
  * \section debugging Debugging with the XMLParser library
  *
  * \subsection debugwin Debugging under WINDOWS
  *
- * 	Inside Visual C++, the "debug versions" of the memory allocation
- *functions are
- * 	very slow: Do not forget to compile in "release mode" to get maximum
- *speed.
- * 	When I had to debug a software that was using the XMLParser Library, it
- *was usually
- * 	a nightmare because the library was sooOOOoooo slow in debug mode
- *(because of the
+ * 	Inside Visual C++, the "debug versions" of the memory allocation functions are
+ * 	very slow: Do not forget to compile in "release mode" to get maximum speed.
+ * 	When I had to debug a software that was using the XMLParser Library, it was usually
+ * 	a nightmare because the library was sooOOOoooo slow in debug mode (because of the
  *  slow memory allocations in Debug mode). To solve this
- * 	problem, during all the debugging session, I am now using a very fast
- *DLL version of the
- * 	XMLParser Library (the DLL is compiled in release mode). Using the DLL
- *version of
- * 	the XMLParser Library allows me to have lightening XML parsing speed
- *even in debug!
- * 	Other than that, the DLL version is useless: In the release version of
- *my tool,
- * 	I always use the normal, ".cpp"-based, XMLParser Library (I simply
- *include the
+ * 	problem, during all the debugging session, I am now using a very fast DLL version of the
+ * 	XMLParser Library (the DLL is compiled in release mode). Using the DLL version of
+ * 	the XMLParser Library allows me to have lightening XML parsing speed even in debug!
+ * 	Other than that, the DLL version is useless: In the release version of my tool,
+ * 	I always use the normal, ".cpp"-based, XMLParser Library (I simply include the
  * <a href="../../xmlParser.cpp">xmlParser.cpp</a> and
  * <a href="../../xmlParser.h">xmlParser.h</a> files into the project).
  *
- * 	The file <a href="../../XMLNodeAutoexp.txt">XMLNodeAutoexp.txt</a>
- *contains some
- * "tweaks" that improve substancially the display of the content of the XMLNode
- *objects
- * inside the Visual Studio Debugger. Believe me, once you have seen inside the
- *debugger
- * the "smooth" display of the XMLNode objects, you cannot live without it
- *anymore!
+ * 	The file <a href="../../XMLNodeAutoexp.txt">XMLNodeAutoexp.txt</a> contains some
+ * "tweaks" that improve substancially the display of the content of the XMLNode objects
+ * inside the Visual Studio Debugger. Believe me, once you have seen inside the debugger
+ * the "smooth" display of the XMLNode objects, you cannot live without it anymore!
  *
  * \subsection debuglinux Debugging under LINUX/UNIX
  *
- * 	The speed of the debug version of the XMLParser library is tolerable so
- *no extra
+ * 	The speed of the debug version of the XMLParser library is tolerable so no extra
  * work.has been done.
  *
  ****************************************************************************/
@@ -151,21 +120,16 @@
 #include <stdlib.h>
 
 #ifdef _UNICODE
-// If you comment the next "define" line then the library will never "switch to"
-// _UNICODE (wchar_t*) mode (16/32 bits per characters).
+// If you comment the next "define" line then the library will never "switch to" _UNICODE (wchar_t*) mode (16/32 bits per characters).
 // This is useful when you get error messages like:
-//    'XMLNode::openFileHelper' : cannot convert parameter 2 from 'const char
-//    [5]' to 'const wchar_t *'
-// The _XMLWIDECHAR preprocessor variable force the XMLParser library into
-// either utf16/32-mode (the proprocessor variable
+//    'XMLNode::openFileHelper' : cannot convert parameter 2 from 'const char [5]' to 'const wchar_t *'
+// The _XMLWIDECHAR preprocessor variable force the XMLParser library into either utf16/32-mode (the proprocessor variable
 // must be defined) or utf8-mode(the pre-processor variable must be undefined).
 #define _XMLWIDECHAR
 #endif
 
-#if defined(WIN32) || defined(UNDER_CE) || defined(_WIN32) || \
-    defined(WIN64) || defined(__BORLANDC__)
-// comment the next line if you are under windows and the compiler is not
-// Microsoft Visual Studio (6.0 or .NET) or Borland
+#if defined(WIN32) || defined(UNDER_CE) || defined(_WIN32) || defined(WIN64) || defined(__BORLANDC__)
+// comment the next line if you are under windows and the compiler is not Microsoft Visual Studio (6.0 or .NET) or Borland
 #define _XMLWINDOWS
 #endif
 
@@ -182,8 +146,7 @@
 #define XMLDLLENTRY
 #endif
 
-// uncomment the next line if you want no support for wchar_t* (no need for the
-// <wchar.h> or <tchar.h> libraries anymore to compile)
+// uncomment the next line if you want no support for wchar_t* (no need for the <wchar.h> or <tchar.h> libraries anymore to compile)
 //#define XML_NO_WIDE_CHAR
 
 #ifdef XML_NO_WIDE_CHAR
@@ -196,83 +159,84 @@
 #else
 #define XMLDLLENTRY
 #ifndef XML_NO_WIDE_CHAR
-#include <wchar.h>  // to have 'wcsrtombs' for ANSI version
-// to have 'mbsrtowcs' for WIDECHAR version
+#include <wchar.h> // to have 'wcsrtombs' for ANSI version
+                   // to have 'mbsrtowcs' for WIDECHAR version
 #endif
 #endif
 
 // Some common types for char set portable code
 #ifdef _XMLWIDECHAR
-#define _CXML(c) L##c
-#define XMLCSTR const wchar_t *
-#define XMLSTR wchar_t *
-#define XMLCHAR wchar_t
+    #define _CXML(c) L ## c
+    #define XMLCSTR const wchar_t *
+    #define XMLSTR  wchar_t *
+    #define XMLCHAR wchar_t
 #else
-#define _CXML(c) c
-#define XMLCSTR const char *
-#define XMLSTR char *
-#define XMLCHAR char
+    #define _CXML(c) c
+    #define XMLCSTR const char *
+    #define XMLSTR  char *
+    #define XMLCHAR char
 #endif
 #ifndef FALSE
-#define FALSE 0
+    #define FALSE 0
 #endif /* FALSE */
 #ifndef TRUE
-#define TRUE 1
+    #define TRUE 1
 #endif /* TRUE */
 
-/// Enumeration for XML parse errors.
-typedef enum XMLError {
-  eXMLErrorNone = 0,
-  eXMLErrorMissingEndTag,
-  eXMLErrorNoXMLTagFound,
-  eXMLErrorEmpty,
-  eXMLErrorMissingTagName,
-  eXMLErrorMissingEndTagName,
-  eXMLErrorUnmatchedEndTag,
-  eXMLErrorUnmatchedEndClearTag,
-  eXMLErrorUnexpectedToken,
-  eXMLErrorNoElements,
-  eXMLErrorFileNotFound,
-  eXMLErrorFirstTagNotFound,
-  eXMLErrorUnknownCharacterEntity,
-  eXMLErrorCharacterCodeAbove255,
-  eXMLErrorCharConversionError,
-  eXMLErrorCannotOpenWriteFile,
-  eXMLErrorCannotWriteFile,
 
-  eXMLErrorBase64DataSizeIsNotMultipleOf4,
-  eXMLErrorBase64DecodeIllegalCharacter,
-  eXMLErrorBase64DecodeTruncatedData,
-  eXMLErrorBase64DecodeBufferTooSmall
+/// Enumeration for XML parse errors.
+typedef enum XMLError
+{
+    eXMLErrorNone = 0,
+    eXMLErrorMissingEndTag,
+    eXMLErrorNoXMLTagFound,
+    eXMLErrorEmpty,
+    eXMLErrorMissingTagName,
+    eXMLErrorMissingEndTagName,
+    eXMLErrorUnmatchedEndTag,
+    eXMLErrorUnmatchedEndClearTag,
+    eXMLErrorUnexpectedToken,
+    eXMLErrorNoElements,
+    eXMLErrorFileNotFound,
+    eXMLErrorFirstTagNotFound,
+    eXMLErrorUnknownCharacterEntity,
+    eXMLErrorCharacterCodeAbove255,
+    eXMLErrorCharConversionError,
+    eXMLErrorCannotOpenWriteFile,
+    eXMLErrorCannotWriteFile,
+
+    eXMLErrorBase64DataSizeIsNotMultipleOf4,
+    eXMLErrorBase64DecodeIllegalCharacter,
+    eXMLErrorBase64DecodeTruncatedData,
+    eXMLErrorBase64DecodeBufferTooSmall
 } XMLError;
 
-/// Enumeration used to manage type of data. Use in conjunction with structure
-/// XMLNodeContents
-typedef enum XMLElementType {
-  eNodeChild = 0,
-  eNodeAttribute = 1,
-  eNodeText = 2,
-  eNodeClear = 3,
-  eNodeNULL = 4
+
+/// Enumeration used to manage type of data. Use in conjunction with structure XMLNodeContents
+typedef enum XMLElementType
+{
+    eNodeChild=0,
+    eNodeAttribute=1,
+    eNodeText=2,
+    eNodeClear=3,
+    eNodeNULL=4
 } XMLElementType;
 
 /// Structure used to obtain error details if the parse fails.
-typedef struct XMLResults {
-  enum XMLError error;
-  int nLine, nColumn;
+typedef struct XMLResults
+{
+    enum XMLError error;
+    int  nLine,nColumn;
 } XMLResults;
 
 /// Structure for XML clear (unformatted) node (usually comments)
 typedef struct XMLClear {
-  XMLCSTR lpszValue;
-  XMLCSTR lpszOpenTag;
-  XMLCSTR lpszCloseTag;
+    XMLCSTR lpszValue; XMLCSTR lpszOpenTag; XMLCSTR lpszCloseTag;
 } XMLClear;
 
 /// Structure for XML attribute.
 typedef struct XMLAttribute {
-  XMLCSTR lpszName;
-  XMLCSTR lpszValue;
+    XMLCSTR lpszName; XMLCSTR lpszValue;
 } XMLAttribute;
 
 /// XMLElementPosition are not interchangeable with simple indexes
@@ -285,626 +249,395 @@ struct XMLNodeContents;
 /// Main Class representing a XML node
 /**
  * All operations are performed using this class.
- * \note The constructors of the XMLNode class are protected, so use instead one
- * of these four methods to get your first instance of XMLNode:
+ * \note The constructors of the XMLNode class are protected, so use instead one of these four methods to get your first instance of XMLNode:
  * <ul>
  *    <li> XMLNode::parseString </li>
  *    <li> XMLNode::parseFile </li>
  *    <li> XMLNode::openFileHelper </li>
  *    <li> XMLNode::createXMLTopNode (or XMLNode::createXMLTopNode_WOSD)</li>
  * </ul> */
-typedef struct XMLDLLENTRY XMLNode {
- private:
-  struct XMLNodeDataTag;
+typedef struct XMLDLLENTRY XMLNode
+{
+  private:
 
-  /// Constructors are protected, so use instead one of: XMLNode::parseString,
-  /// XMLNode::parseFile, XMLNode::openFileHelper, XMLNode::createXMLTopNode
-  XMLNode(struct XMLNodeDataTag *pParent, XMLSTR lpszName, char isDeclaration);
-  /// Constructors are protected, so use instead one of: XMLNode::parseString,
-  /// XMLNode::parseFile, XMLNode::openFileHelper, XMLNode::createXMLTopNode
-  XMLNode(struct XMLNodeDataTag *p);
+    struct XMLNodeDataTag;
 
- public:
-  static XMLCSTR getVersion();  ///< Return the XMLParser library version number
+    /// Constructors are protected, so use instead one of: XMLNode::parseString, XMLNode::parseFile, XMLNode::openFileHelper, XMLNode::createXMLTopNode
+    XMLNode(struct XMLNodeDataTag *pParent, XMLSTR lpszName, char isDeclaration);
+    /// Constructors are protected, so use instead one of: XMLNode::parseString, XMLNode::parseFile, XMLNode::openFileHelper, XMLNode::createXMLTopNode
+    XMLNode(struct XMLNodeDataTag *p);
 
-  /** @defgroup conversions Parsing XML files/strings to an XMLNode structure
-   * and Rendering XMLNode's to files/string.
-   * @ingroup XMLParserGeneral
-   * @{ */
+  public:
+    static XMLCSTR getVersion();///< Return the XMLParser library version number
 
-  /// Parse an XML string and return the root of a XMLNode tree representing the
-  /// string.
-  static XMLNode parseString(XMLCSTR lpXMLString, XMLCSTR tag = NULL,
-                             XMLResults *pResults = NULL);
-  /**< The "parseString" function parse an XML string and return the root of a
-   * XMLNode tree. The "opposite" of this function is
-   * the function "createXMLString" that re-creates an XML string from an
-   * XMLNode tree. If the XML document is corrupted, the
-   * "parseString" method will initialize the "pResults" variable with some
-   * information that can be used to trace the error.
-   * If you still want to parse the file, you can use the APPROXIMATE_PARSING
-   * option as explained inside the note at the
-   * beginning of the "xmlParser.cpp" file.
-   *
-   * @param lpXMLString the XML string to parse
-   * @param tag  the name of the first tag inside the XML file. If the tag
-   * parameter is omitted, this function returns a node that represents the head
-   * of the xml document including the declaration term (<? ... ?>).
-   * @param pResults a pointer to a XMLResults variable that will contain some
-   * information that can be used to trace the XML parsing error. You can have a
-   * user-friendly explanation of the parsing error with the "getError"
-   * function.
-   */
+    /** @defgroup conversions Parsing XML files/strings to an XMLNode structure and Rendering XMLNode's to files/string.
+     * @ingroup XMLParserGeneral
+     * @{ */
 
-  /// Parse an XML file and return the root of a XMLNode tree representing the
-  /// file.
-  static XMLNode parseFile(XMLCSTR filename, XMLCSTR tag = NULL,
-                           XMLResults *pResults = NULL);
-  /**< The "parseFile" function parse an XML file and return the root of a
-   * XMLNode tree. The "opposite" of this function is
-   * the function "writeToFile" that re-creates an XML file from an XMLNode
-   * tree. If the XML document is corrupted, the
-   * "parseFile" method will initialize the "pResults" variable with some
-   * information that can be used to trace the error.
-   * If you still want to parse the file, you can use the APPROXIMATE_PARSING
-   * option as explained inside the note at the
-   * beginning of the "xmlParser.cpp" file.
-   *
-   * @param filename the path to the XML file to parse
-   * @param tag the name of the first tag inside the XML file. If the tag
-   * parameter is omitted, this function returns a node that represents the head
-   * of the xml document including the declaration term (<? ... ?>).
-   * @param pResults a pointer to a XMLResults variable that will contain some
-   * information that can be used to trace the XML parsing error. You can have a
-   * user-friendly explanation of the parsing error with the "getError"
-   * function.
-   */
+    /// Parse an XML string and return the root of a XMLNode tree representing the string.
+    static XMLNode parseString   (XMLCSTR  lpXMLString, XMLCSTR tag=NULL, XMLResults *pResults=NULL);
+    /**< The "parseString" function parse an XML string and return the root of a XMLNode tree. The "opposite" of this function is
+     * the function "createXMLString" that re-creates an XML string from an XMLNode tree. If the XML document is corrupted, the
+     * "parseString" method will initialize the "pResults" variable with some information that can be used to trace the error.
+     * If you still want to parse the file, you can use the APPROXIMATE_PARSING option as explained inside the note at the
+     * beginning of the "xmlParser.cpp" file.
+     *
+     * @param lpXMLString the XML string to parse
+     * @param tag  the name of the first tag inside the XML file. If the tag parameter is omitted, this function returns a node that represents the head of the xml document including the declaration term (<? ... ?>).
+     * @param pResults a pointer to a XMLResults variable that will contain some information that can be used to trace the XML parsing error. You can have a user-friendly explanation of the parsing error with the "getError" function.
+     */
 
-  /// Parse an XML file and return the root of a XMLNode tree representing the
-  /// file. A very crude error checking is made. An attempt to guess the Char
-  /// Encoding used in the file is made.
-  static XMLNode openFileHelper(XMLCSTR filename, XMLCSTR tag = NULL);
-  /**< The "openFileHelper" function reports to the screen all the warnings and
-   * errors that occurred during parsing of the XML file.
-   * This function also tries to guess char Encoding (UTF-8, ASCII or SHIT-JIS)
-   * based on the first 200 bytes of the file. Since each
-   * application has its own way to report and deal with errors, you should
-   * rather use the "parseFile" function to parse XML files
-   * and program yourself thereafter an "error reporting" tailored for your
-   * needs (instead of using the very crude "error reporting"
-   * mechanism included inside the "openFileHelper" function).
-   *
-   * If the XML document is corrupted, the "openFileHelper" method will:
-   *         - display an error message on the console (or inside a messageBox
-   * for windows).
-   *         - stop execution (exit).
-   *
-   * I strongly suggest that you write your own "openFileHelper" method tailored
-   * to your needs. If you still want to parse
-   * the file, you can use the APPROXIMATE_PARSING option as explained inside
-   * the note at the beginning of the "xmlParser.cpp" file.
-   *
-   * @param filename the path of the XML file to parse.
-   * @param tag the name of the first tag inside the XML file. If the tag
-   * parameter is omitted, this function returns a node that represents the head
-   * of the xml document including the declaration term (<? ... ?>).
-   */
+    /// Parse an XML file and return the root of a XMLNode tree representing the file.
+    static XMLNode parseFile     (XMLCSTR     filename, XMLCSTR tag=NULL, XMLResults *pResults=NULL);
+    /**< The "parseFile" function parse an XML file and return the root of a XMLNode tree. The "opposite" of this function is
+     * the function "writeToFile" that re-creates an XML file from an XMLNode tree. If the XML document is corrupted, the
+     * "parseFile" method will initialize the "pResults" variable with some information that can be used to trace the error.
+     * If you still want to parse the file, you can use the APPROXIMATE_PARSING option as explained inside the note at the
+     * beginning of the "xmlParser.cpp" file.
+     *
+     * @param filename the path to the XML file to parse
+     * @param tag the name of the first tag inside the XML file. If the tag parameter is omitted, this function returns a node that represents the head of the xml document including the declaration term (<? ... ?>).
+     * @param pResults a pointer to a XMLResults variable that will contain some information that can be used to trace the XML parsing error. You can have a user-friendly explanation of the parsing error with the "getError" function.
+     */
 
-  static XMLCSTR getError(XMLError error);  ///< this gives you a user-friendly
-                                            ///explanation of the parsing error
+    /// Parse an XML file and return the root of a XMLNode tree representing the file. A very crude error checking is made. An attempt to guess the Char Encoding used in the file is made.
+    static XMLNode openFileHelper(XMLCSTR     filename, XMLCSTR tag=NULL);
+    /**< The "openFileHelper" function reports to the screen all the warnings and errors that occurred during parsing of the XML file.
+     * This function also tries to guess char Encoding (UTF-8, ASCII or SHIT-JIS) based on the first 200 bytes of the file. Since each
+     * application has its own way to report and deal with errors, you should rather use the "parseFile" function to parse XML files
+     * and program yourself thereafter an "error reporting" tailored for your needs (instead of using the very crude "error reporting"
+     * mechanism included inside the "openFileHelper" function).
+     *
+     * If the XML document is corrupted, the "openFileHelper" method will:
+     *         - display an error message on the console (or inside a messageBox for windows).
+     *         - stop execution (exit).
+     *
+     * I strongly suggest that you write your own "openFileHelper" method tailored to your needs. If you still want to parse
+     * the file, you can use the APPROXIMATE_PARSING option as explained inside the note at the beginning of the "xmlParser.cpp" file.
+     *
+     * @param filename the path of the XML file to parse.
+     * @param tag the name of the first tag inside the XML file. If the tag parameter is omitted, this function returns a node that represents the head of the xml document including the declaration term (<? ... ?>).
+     */
 
-  /// Create an XML string starting from the current XMLNode.
-  XMLSTR createXMLString(int nFormat = 1, int *pnSize = NULL) const;
-  /**< The returned string should be free'd using the "freeXMLString" function.
-   *
-   *   If nFormat==0, no formatting is required otherwise this returns an user
-   * friendly XML string from a given element
-   *   with appropriate white spaces and carriage returns. if pnSize is given it
-   * returns the size in character of the string. */
+    static XMLCSTR getError(XMLError error); ///< this gives you a user-friendly explanation of the parsing error
 
-  /// Save the content of an xmlNode inside a file
-  XMLError writeToFile(XMLCSTR filename, const char *encoding = NULL,
-                       char nFormat = 1) const;
-  /**< If nFormat==0, no formatting is required otherwise this returns an user
-   * friendly XML string from a given element with appropriate white spaces and
-   * carriage returns.
-   * If the global parameter "characterEncoding==encoding_UTF8", then the
-   * "encoding" parameter is ignored and always set to "utf-8".
-   * If the global parameter "characterEncoding==encoding_ShiftJIS", then the
-   * "encoding" parameter is ignored and always set to "SHIFT-JIS".
-   * If "_XMLWIDECHAR=1", then the "encoding" parameter is ignored and always
-   * set to "utf-16".
-   * If no "encoding" parameter is given the "ISO-8859-1" encoding is used. */
-  /** @} */
+    /// Create an XML string starting from the current XMLNode.
+    XMLSTR createXMLString(int nFormat=1, int *pnSize=NULL) const;
+    /**< The returned string should be free'd using the "freeXMLString" function.
+     *
+     *   If nFormat==0, no formatting is required otherwise this returns an user friendly XML string from a given element
+     *   with appropriate white spaces and carriage returns. if pnSize is given it returns the size in character of the string. */
 
-  /** @defgroup navigate Navigate the XMLNode structure
-   * @ingroup XMLParserGeneral
-   * @{ */
-  XMLCSTR getName() const;                          ///< name of the node
-  XMLCSTR getText(int i = 0) const;                 ///< return ith text field
-  int nText() const;                                ///< nbr of text field
-  XMLNode getParentNode() const;                    ///< return the parent node
-  XMLNode getChildNode(int i = 0) const;            ///< return ith child node
-  XMLNode getChildNode(XMLCSTR name, int i) const;  ///< return ith child node
-                                                    ///with specific name
-                                                    ///(return an empty node if
-                                                    ///failing). If i==-1, this
-                                                    ///returns the last XMLNode
-                                                    ///with the given name.
-  XMLNode getChildNode(XMLCSTR name, int *i = NULL) const;  ///< return next
-                                                            ///child node with
-                                                            ///specific name
-                                                            ///(return an empty
-                                                            ///node if failing)
-  XMLNode getChildNodeWithAttribute(XMLCSTR tagName, XMLCSTR attributeName,
-                                    XMLCSTR attributeValue = NULL,
-                                    int *i = NULL) const;  ///< return child
-                                                           ///node with specific
-                                                           ///name/attribute
-                                                           ///(return an empty
-                                                           ///node if failing)
-  XMLNode getChildNodeByPath(XMLCSTR path, char createNodeIfMissing = 0,
-                             XMLCHAR sep = '/');
-  ///< return the first child node with specific path
-  XMLNode getChildNodeByPathNonConst(XMLSTR path, char createNodeIfMissing = 0,
-                                     XMLCHAR sep = '/');
-  ///< return the first child node with specific path.
+    /// Save the content of an xmlNode inside a file
+    XMLError writeToFile(XMLCSTR filename,
+                         const char *encoding=NULL,
+                         char nFormat=1) const;
+    /**< If nFormat==0, no formatting is required otherwise this returns an user friendly XML string from a given element with appropriate white spaces and carriage returns.
+     * If the global parameter "characterEncoding==encoding_UTF8", then the "encoding" parameter is ignored and always set to "utf-8".
+     * If the global parameter "characterEncoding==encoding_ShiftJIS", then the "encoding" parameter is ignored and always set to "SHIFT-JIS".
+     * If "_XMLWIDECHAR=1", then the "encoding" parameter is ignored and always set to "utf-16".
+     * If no "encoding" parameter is given the "ISO-8859-1" encoding is used. */
+    /** @} */
 
-  int nChildNode(XMLCSTR name)
-      const;  ///< return the number of child node with specific name
-  int nChildNode() const;                      ///< nbr of child node
-  XMLAttribute getAttribute(int i = 0) const;  ///< return ith attribute
-  XMLCSTR getAttributeName(int i = 0) const;   ///< return ith attribute name
-  XMLCSTR getAttributeValue(int i = 0) const;  ///< return ith attribute value
-  char isAttributeSet(XMLCSTR name)
-      const;  ///< test if an attribute with a specific name is given
-  XMLCSTR getAttribute(XMLCSTR name, int i) const;  ///< return ith attribute
-                                                    ///content with specific
-                                                    ///name (return a NULL if
-                                                    ///failing)
-  XMLCSTR getAttribute(XMLCSTR name, int *i = NULL) const;  ///< return next
-                                                            ///attribute content
-                                                            ///with specific
-                                                            ///name (return a
-                                                            ///NULL if failing)
-  int nAttribute() const;              ///< nbr of attribute
-  XMLClear getClear(int i = 0) const;  ///< return ith clear field (comments)
-  int nClear() const;                  ///< nbr of clear field
-  XMLNodeContents enumContents(XMLElementPosition i)
-      const;  ///< enumerate all the different contents (attribute,child,text,
-              ///clear) of the current XMLNode. The order is reflecting the
-              ///order of the original file/string. NOTE: 0 <= i < nElement();
-  int nElement() const;        ///< nbr of different contents for current node
-  char isEmpty() const;        ///< is this node Empty?
-  char isDeclaration() const;  ///< is this node a declaration <? .... ?>
-  XMLNode deepCopy() const;    ///< deep copy (duplicate/clone) a XMLNode
-  static XMLNode emptyNode();  ///< return XMLNode::emptyXMLNode;
-  /** @} */
+    /** @defgroup navigate Navigate the XMLNode structure
+     * @ingroup XMLParserGeneral
+     * @{ */
+    XMLCSTR getName() const;                                       ///< name of the node
+    XMLCSTR getText(int i=0) const;                                ///< return ith text field
+    int nText() const;                                             ///< nbr of text field
+    XMLNode getParentNode() const;                                 ///< return the parent node
+    XMLNode getChildNode(int i=0) const;                           ///< return ith child node
+    XMLNode getChildNode(XMLCSTR name, int i)  const;              ///< return ith child node with specific name (return an empty node if failing). If i==-1, this returns the last XMLNode with the given name.
+    XMLNode getChildNode(XMLCSTR name, int *i=NULL) const;         ///< return next child node with specific name (return an empty node if failing)
+    XMLNode getChildNodeWithAttribute(XMLCSTR tagName,
+                                      XMLCSTR attributeName,
+                                      XMLCSTR attributeValue=NULL,
+                                      int *i=NULL)  const;         ///< return child node with specific name/attribute (return an empty node if failing)
+    XMLNode getChildNodeByPath(XMLCSTR path, char createNodeIfMissing=0, XMLCHAR sep='/');
+                                                                   ///< return the first child node with specific path
+    XMLNode getChildNodeByPathNonConst(XMLSTR  path, char createNodeIfMissing=0, XMLCHAR sep='/');
+                                                                   ///< return the first child node with specific path.
 
-  ~XMLNode();
-  XMLNode(const XMLNode &A);             ///< to allow shallow/fast copy:
-  XMLNode &operator=(const XMLNode &A);  ///< to allow shallow/fast copy:
+    int nChildNode(XMLCSTR name) const;                            ///< return the number of child node with specific name
+    int nChildNode() const;                                        ///< nbr of child node
+    XMLAttribute getAttribute(int i=0) const;                      ///< return ith attribute
+    XMLCSTR      getAttributeName(int i=0) const;                  ///< return ith attribute name
+    XMLCSTR      getAttributeValue(int i=0) const;                 ///< return ith attribute value
+    char  isAttributeSet(XMLCSTR name) const;                      ///< test if an attribute with a specific name is given
+    XMLCSTR getAttribute(XMLCSTR name, int i) const;               ///< return ith attribute content with specific name (return a NULL if failing)
+    XMLCSTR getAttribute(XMLCSTR name, int *i=NULL) const;         ///< return next attribute content with specific name (return a NULL if failing)
+    int nAttribute() const;                                        ///< nbr of attribute
+    XMLClear getClear(int i=0) const;                              ///< return ith clear field (comments)
+    int nClear() const;                                            ///< nbr of clear field
+    XMLNodeContents enumContents(XMLElementPosition i) const;      ///< enumerate all the different contents (attribute,child,text, clear) of the current XMLNode. The order is reflecting the order of the original file/string. NOTE: 0 <= i < nElement();
+    int nElement() const;                                          ///< nbr of different contents for current node
+    char isEmpty() const;                                          ///< is this node Empty?
+    char isDeclaration() const;                                    ///< is this node a declaration <? .... ?>
+    XMLNode deepCopy() const;                                      ///< deep copy (duplicate/clone) a XMLNode
+    static XMLNode emptyNode();                                    ///< return XMLNode::emptyXMLNode;
+    /** @} */
 
-  XMLNode() : d(NULL){};
-  static XMLNode emptyXMLNode;
-  static XMLClear emptyXMLClear;
-  static XMLAttribute emptyXMLAttribute;
+    ~XMLNode();
+    XMLNode(const XMLNode &A);                                     ///< to allow shallow/fast copy:
+    XMLNode& operator=( const XMLNode& A );                        ///< to allow shallow/fast copy:
 
-  /** @defgroup xmlModify Create or Update the XMLNode structure
-   * @ingroup XMLParserGeneral
-   *  The functions in this group allows you to create from scratch (or update)
-   * a XMLNode structure. Start by creating your top
-   *  node with the "createXMLTopNode" function and then add new nodes with the
-   * "addChild" function. The parameter 'pos' gives
-   *  the position where the childNode, the text or the XMLClearTag will be
-   * inserted. The default value (pos=-1) inserts at the
-   *  end. The value (pos=0) insert at the beginning (Insertion at the beginning
-   * is slower than at the end). <br>
-   *
-   *  REMARK: 0 <= pos < nChild()+nText()+nClear() <br>
-   */
+    XMLNode(): d(NULL){};
+    static XMLNode emptyXMLNode;
+    static XMLClear emptyXMLClear;
+    static XMLAttribute emptyXMLAttribute;
 
-  /** @defgroup creation Creating from scratch a XMLNode structure
-   * @ingroup xmlModify
-   * @{ */
-  static XMLNode createXMLTopNode(
-      XMLCSTR lpszName,
-      char isDeclaration =
-          FALSE);  ///< Create the top node of an XMLNode structure
-  XMLNode addChild(XMLCSTR lpszName, char isDeclaration = FALSE,
-                   XMLElementPosition pos = -1);  ///< Add a new child node
-  XMLNode addChild(XMLNode nodeToAdd,
-                   XMLElementPosition pos = -1);  ///< If the "nodeToAdd" has
-                                                  ///some parents, it will be
-                                                  ///detached from it's parents
-                                                  ///before being attached to
-                                                  ///the current XMLNode
-  XMLAttribute *addAttribute(XMLCSTR lpszName,
-                             XMLCSTR lpszValuev);  ///< Add a new attribute
-  XMLCSTR addText(XMLCSTR lpszValue,
-                  XMLElementPosition pos = -1);  ///< Add a new text content
-  XMLClear *addClear(XMLCSTR lpszValue, XMLCSTR lpszOpen = NULL,
-                     XMLCSTR lpszClose = NULL, XMLElementPosition pos = -1);
-  /**< Add a new clear tag
-   * @param lpszOpen default value "<![CDATA["
-   * @param lpszClose default value "]]>"
-   */
-  /** @} */
+    /** @defgroup xmlModify Create or Update the XMLNode structure
+     * @ingroup XMLParserGeneral
+     *  The functions in this group allows you to create from scratch (or update) a XMLNode structure. Start by creating your top
+     *  node with the "createXMLTopNode" function and then add new nodes with the "addChild" function. The parameter 'pos' gives
+     *  the position where the childNode, the text or the XMLClearTag will be inserted. The default value (pos=-1) inserts at the
+     *  end. The value (pos=0) insert at the beginning (Insertion at the beginning is slower than at the end). <br>
+     *
+     *  REMARK: 0 <= pos < nChild()+nText()+nClear() <br>
+     */
 
-  /** @defgroup xmlUpdate Updating Nodes
-   * @ingroup xmlModify
-   * Some update functions:
-   * @{
-   */
-  XMLCSTR updateName(XMLCSTR lpszName);  ///< change node's name
-  XMLAttribute *updateAttribute(XMLAttribute *newAttribute,
-                                XMLAttribute *oldAttribute);  ///< if the
-                                                              ///attribute to
-                                                              ///update is
-                                                              ///missing, a new
-                                                              ///one will be
-                                                              ///added
-  XMLAttribute *updateAttribute(XMLCSTR lpszNewValue,
-                                XMLCSTR lpszNewName = NULL,
-                                int i = 0);  ///< if the attribute to update is
-                                             ///missing, a new one will be added
-  XMLAttribute *updateAttribute(XMLCSTR lpszNewValue, XMLCSTR lpszNewName,
-                                XMLCSTR lpszOldName);  ///< set lpszNewName=NULL
-                                                       ///if you don't want to
-                                                       ///change the name of the
-                                                       ///attribute if the
-                                                       ///attribute to update is
-                                                       ///missing, a new one
-                                                       ///will be added
-  XMLCSTR updateText(XMLCSTR lpszNewValue, int i = 0);  ///< if the text to
-                                                        ///update is missing, a
-                                                        ///new one will be added
-  XMLCSTR updateText(XMLCSTR lpszNewValue,
-                     XMLCSTR lpszOldValue);  ///< if the text to update is
-                                             ///missing, a new one will be added
-  XMLClear *updateClear(XMLCSTR lpszNewContent,
-                        int i = 0);  ///< if the clearTag to update is missing,
-                                     ///a new one will be added
-  XMLClear *updateClear(XMLClear *newP, XMLClear *oldP);  ///< if the clearTag
-                                                          ///to update is
-                                                          ///missing, a new one
-                                                          ///will be added
-  XMLClear *updateClear(XMLCSTR lpszNewValue,
-                        XMLCSTR lpszOldValue);  ///< if the clearTag to update
-                                                ///is missing, a new one will be
-                                                ///added
-                                                /** @} */
+    /** @defgroup creation Creating from scratch a XMLNode structure
+     * @ingroup xmlModify
+     * @{ */
+    static XMLNode createXMLTopNode(XMLCSTR lpszName, char isDeclaration=FALSE);                    ///< Create the top node of an XMLNode structure
+    XMLNode        addChild(XMLCSTR lpszName, char isDeclaration=FALSE, XMLElementPosition pos=-1); ///< Add a new child node
+    XMLNode        addChild(XMLNode nodeToAdd, XMLElementPosition pos=-1);                          ///< If the "nodeToAdd" has some parents, it will be detached from it's parents before being attached to the current XMLNode
+    XMLAttribute  *addAttribute(XMLCSTR lpszName, XMLCSTR lpszValuev);                              ///< Add a new attribute
+    XMLCSTR        addText(XMLCSTR lpszValue, XMLElementPosition pos=-1);                           ///< Add a new text content
+    XMLClear      *addClear(XMLCSTR lpszValue, XMLCSTR lpszOpen=NULL, XMLCSTR lpszClose=NULL, XMLElementPosition pos=-1);
+    /**< Add a new clear tag
+     * @param lpszOpen default value "<![CDATA["
+     * @param lpszClose default value "]]>"
+     */
+    /** @} */
 
-  /** @defgroup xmlDelete Deleting Nodes or Attributes
-   * @ingroup xmlModify
-   * Some deletion functions:
-   * @{
-   */
-  /// The "deleteNodeContent" function forces the deletion of the content of
-  /// this XMLNode and the subtree.
-  void deleteNodeContent();
-  /**< \note The XMLNode instances that are referring to the part of the subtree
-   * that has been deleted CANNOT be used anymore!!. Unexpected results will
-   * occur if you continue using them. */
-  void deleteAttribute(
-      int i = 0);  ///< Delete the ith attribute of the current XMLNode
-  void deleteAttribute(XMLCSTR lpszName);  ///< Delete the attribute with the
-                                           ///given name (the "strcmp" function
-                                           ///is used to find the right
-                                           ///attribute)
-  void deleteAttribute(XMLAttribute *anAttribute);  ///< Delete the attribute
-                                                    ///with the name
-                                                    ///"anAttribute->lpszName"
-                                                    ///(the "strcmp" function is
-                                                    ///used to find the right
-                                                    ///attribute)
-  void deleteText(
-      int i = 0);  ///< Delete the Ith text content of the current XMLNode
-  void deleteText(XMLCSTR lpszValue);  ///< Delete the text content "lpszValue"
-                                       ///inside the current XMLNode (direct
-                                       ///"pointer-to-pointer" comparison is
-                                       ///used to find the right text)
-  void deleteClear(
-      int i = 0);  ///< Delete the Ith clear tag inside the current XMLNode
-  void deleteClear(XMLCSTR lpszValue);  ///< Delete the clear tag "lpszValue"
-                                        ///inside the current XMLNode (direct
-                                        ///"pointer-to-pointer" comparison is
-                                        ///used to find the clear tag)
-  void deleteClear(XMLClear *p);        ///< Delete the clear tag "p" inside the
-                                        ///current XMLNode (direct
-                                  ///"pointer-to-pointer" comparison on the
-                                  ///lpszName of the clear tag is used to find
-                                  ///the clear tag)
-  /** @} */
+    /** @defgroup xmlUpdate Updating Nodes
+     * @ingroup xmlModify
+     * Some update functions:
+     * @{
+     */
+    XMLCSTR       updateName(XMLCSTR lpszName);                                                  ///< change node's name
+    XMLAttribute *updateAttribute(XMLAttribute *newAttribute, XMLAttribute *oldAttribute);       ///< if the attribute to update is missing, a new one will be added
+    XMLAttribute *updateAttribute(XMLCSTR lpszNewValue, XMLCSTR lpszNewName=NULL,int i=0);       ///< if the attribute to update is missing, a new one will be added
+    XMLAttribute *updateAttribute(XMLCSTR lpszNewValue, XMLCSTR lpszNewName,XMLCSTR lpszOldName);///< set lpszNewName=NULL if you don't want to change the name of the attribute if the attribute to update is missing, a new one will be added
+    XMLCSTR       updateText(XMLCSTR lpszNewValue, int i=0);                                     ///< if the text to update is missing, a new one will be added
+    XMLCSTR       updateText(XMLCSTR lpszNewValue, XMLCSTR lpszOldValue);                        ///< if the text to update is missing, a new one will be added
+    XMLClear     *updateClear(XMLCSTR lpszNewContent, int i=0);                                  ///< if the clearTag to update is missing, a new one will be added
+    XMLClear     *updateClear(XMLClear *newP,XMLClear *oldP);                                    ///< if the clearTag to update is missing, a new one will be added
+    XMLClear     *updateClear(XMLCSTR lpszNewValue, XMLCSTR lpszOldValue);                       ///< if the clearTag to update is missing, a new one will be added
+    /** @} */
 
-  /** @defgroup xmlWOSD ???_WOSD functions.
-   * @ingroup xmlModify
-   *  The strings given as parameters for the "add" and "update" methods that
-   * have a name with
-   *  the postfix "_WOSD" (that means "WithOut String Duplication")(for example
-   * "addText_WOSD")
-   *  will be free'd by the XMLNode class. For example, it means that this is
-   * incorrect:
-   *  \code
-   *     xNode.addText_WOSD("foo");
-   *     xNode.updateAttribute_WOSD("#newcolor" ,NULL,"color");
-   *  \endcode
-   *  In opposition, this is correct:
-   *  \code
-   *     xNode.addText("foo");
-   *     xNode.addText_WOSD(stringDup("foo"));
-   *     xNode.updateAttribute("#newcolor" ,NULL,"color");
-   *     xNode.updateAttribute_WOSD(stringDup("#newcolor"),NULL,"color");
-   *  \endcode
-   *  Typically, you will never do:
-   *  \code
-   *     char *b=(char*)malloc(...);
-   *     xNode.addText(b);
-   *     free(b);
-   *  \endcode
-   *  ... but rather:
-   *  \code
-   *     char *b=(char*)malloc(...);
-   *     xNode.addText_WOSD(b);
-   *  \endcode
-   *  ('free(b)' is performed by the XMLNode class)
-   * @{ */
-  static XMLNode createXMLTopNode_WOSD(
-      XMLSTR lpszName,
-      char isDeclaration =
-          FALSE);  ///< Create the top node of an XMLNode structure
-  XMLNode addChild_WOSD(XMLSTR lpszName, char isDeclaration = FALSE,
-                        XMLElementPosition pos = -1);  ///< Add a new child node
-  XMLAttribute *addAttribute_WOSD(XMLSTR lpszName,
-                                  XMLSTR lpszValue);  ///< Add a new attribute
-  XMLCSTR addText_WOSD(XMLSTR lpszValue, XMLElementPosition pos =
-                                             -1);  ///< Add a new text content
-  XMLClear *addClear_WOSD(
-      XMLSTR lpszValue, XMLCSTR lpszOpen = NULL, XMLCSTR lpszClose = NULL,
-      XMLElementPosition pos = -1);  ///< Add a new clear Tag
+    /** @defgroup xmlDelete Deleting Nodes or Attributes
+     * @ingroup xmlModify
+     * Some deletion functions:
+     * @{
+     */
+    /// The "deleteNodeContent" function forces the deletion of the content of this XMLNode and the subtree.
+    void deleteNodeContent();
+    /**< \note The XMLNode instances that are referring to the part of the subtree that has been deleted CANNOT be used anymore!!. Unexpected results will occur if you continue using them. */
+    void deleteAttribute(int i=0);                   ///< Delete the ith attribute of the current XMLNode
+    void deleteAttribute(XMLCSTR lpszName);          ///< Delete the attribute with the given name (the "strcmp" function is used to find the right attribute)
+    void deleteAttribute(XMLAttribute *anAttribute); ///< Delete the attribute with the name "anAttribute->lpszName" (the "strcmp" function is used to find the right attribute)
+    void deleteText(int i=0);                        ///< Delete the Ith text content of the current XMLNode
+    void deleteText(XMLCSTR lpszValue);              ///< Delete the text content "lpszValue" inside the current XMLNode (direct "pointer-to-pointer" comparison is used to find the right text)
+    void deleteClear(int i=0);                       ///< Delete the Ith clear tag inside the current XMLNode
+    void deleteClear(XMLCSTR lpszValue);             ///< Delete the clear tag "lpszValue" inside the current XMLNode (direct "pointer-to-pointer" comparison is used to find the clear tag)
+    void deleteClear(XMLClear *p);                   ///< Delete the clear tag "p" inside the current XMLNode (direct "pointer-to-pointer" comparison on the lpszName of the clear tag is used to find the clear tag)
+    /** @} */
 
-  XMLCSTR updateName_WOSD(XMLSTR lpszName);  ///< change node's name
-  XMLAttribute *updateAttribute_WOSD(XMLAttribute *newAttribute,
-                                     XMLAttribute *oldAttribute);  ///< if the
-                                                                   ///attribute
-                                                                   ///to update
-                                                                   ///is
-                                                                   ///missing, a
-                                                                   ///new one
-                                                                   ///will be
-                                                                   ///added
-  XMLAttribute *updateAttribute_WOSD(XMLSTR lpszNewValue,
-                                     XMLSTR lpszNewName = NULL,
-                                     int i = 0);  ///< if the attribute to
-                                                  ///update is missing, a new
-                                                  ///one will be added
-  XMLAttribute *updateAttribute_WOSD(XMLSTR lpszNewValue, XMLSTR lpszNewName,
-                                     XMLCSTR lpszOldName);  ///< set
-                                                            ///lpszNewName=NULL
-                                                            ///if you don't want
-                                                            ///to change the
-                                                            ///name of the
-                                                            ///attribute if the
-                                                            ///attribute to
-                                                            ///update is
-                                                            ///missing, a new
-                                                            ///one will be added
-  XMLCSTR updateText_WOSD(XMLSTR lpszNewValue, int i = 0);  ///< if the text to
-                                                            ///update is
-                                                            ///missing, a new
-                                                            ///one will be added
-  XMLCSTR updateText_WOSD(XMLSTR lpszNewValue,
-                          XMLCSTR lpszOldValue);  ///< if the text to update is
-                                                  ///missing, a new one will be
-                                                  ///added
-  XMLClear *updateClear_WOSD(XMLSTR lpszNewContent,
-                             int i = 0);  ///< if the clearTag to update is
-                                          ///missing, a new one will be added
-  XMLClear *updateClear_WOSD(XMLClear *newP,
-                             XMLClear *oldP);  ///< if the clearTag to update is
-                                               ///missing, a new one will be
-                                               ///added
-  XMLClear *updateClear_WOSD(XMLSTR lpszNewValue,
-                             XMLCSTR lpszOldValue);  ///< if the clearTag to
-                                                     ///update is missing, a new
-                                                     ///one will be added
-                                                     /** @} */
+    /** @defgroup xmlWOSD ???_WOSD functions.
+     * @ingroup xmlModify
+     *  The strings given as parameters for the "add" and "update" methods that have a name with
+     *  the postfix "_WOSD" (that means "WithOut String Duplication")(for example "addText_WOSD")
+     *  will be free'd by the XMLNode class. For example, it means that this is incorrect:
+     *  \code
+     *     xNode.addText_WOSD("foo");
+     *     xNode.updateAttribute_WOSD("#newcolor" ,NULL,"color");
+     *  \endcode
+     *  In opposition, this is correct:
+     *  \code
+     *     xNode.addText("foo");
+     *     xNode.addText_WOSD(stringDup("foo"));
+     *     xNode.updateAttribute("#newcolor" ,NULL,"color");
+     *     xNode.updateAttribute_WOSD(stringDup("#newcolor"),NULL,"color");
+     *  \endcode
+     *  Typically, you will never do:
+     *  \code
+     *     char *b=(char*)malloc(...);
+     *     xNode.addText(b);
+     *     free(b);
+     *  \endcode
+     *  ... but rather:
+     *  \code
+     *     char *b=(char*)malloc(...);
+     *     xNode.addText_WOSD(b);
+     *  \endcode
+     *  ('free(b)' is performed by the XMLNode class)
+     * @{ */
+    static XMLNode createXMLTopNode_WOSD(XMLSTR lpszName, char isDeclaration=FALSE);                     ///< Create the top node of an XMLNode structure
+    XMLNode        addChild_WOSD(XMLSTR lpszName, char isDeclaration=FALSE, XMLElementPosition pos=-1);  ///< Add a new child node
+    XMLAttribute  *addAttribute_WOSD(XMLSTR lpszName, XMLSTR lpszValue);                                 ///< Add a new attribute
+    XMLCSTR        addText_WOSD(XMLSTR lpszValue, XMLElementPosition pos=-1);                            ///< Add a new text content
+    XMLClear      *addClear_WOSD(XMLSTR lpszValue, XMLCSTR lpszOpen=NULL, XMLCSTR lpszClose=NULL, XMLElementPosition pos=-1); ///< Add a new clear Tag
 
-  /** @defgroup xmlPosition Position helper functions (use in conjunction with
-   * the update&add functions
-   * @ingroup xmlModify
-   * These are some useful functions when you want to insert a childNode, a text
-   * or a XMLClearTag in the
-   * middle (at a specified position) of a XMLNode tree already constructed. The
-   * value returned by these
-   * methods is to be used as last parameter (parameter 'pos') of addChild,
-   * addText or addClear.
-   * @{ */
-  XMLElementPosition positionOfText(int i = 0) const;
-  XMLElementPosition positionOfText(XMLCSTR lpszValue) const;
-  XMLElementPosition positionOfClear(int i = 0) const;
-  XMLElementPosition positionOfClear(XMLCSTR lpszValue) const;
-  XMLElementPosition positionOfClear(XMLClear *a) const;
-  XMLElementPosition positionOfChildNode(int i = 0) const;
-  XMLElementPosition positionOfChildNode(XMLNode x) const;
-  XMLElementPosition positionOfChildNode(XMLCSTR name, int i = 0)
-      const;  ///< return the position of the ith childNode with the specified
-              ///name if (name==NULL) return the position of the ith childNode
-  /** @} */
+    XMLCSTR        updateName_WOSD(XMLSTR lpszName);                                                  ///< change node's name
+    XMLAttribute  *updateAttribute_WOSD(XMLAttribute *newAttribute, XMLAttribute *oldAttribute);      ///< if the attribute to update is missing, a new one will be added
+    XMLAttribute  *updateAttribute_WOSD(XMLSTR lpszNewValue, XMLSTR lpszNewName=NULL,int i=0);        ///< if the attribute to update is missing, a new one will be added
+    XMLAttribute  *updateAttribute_WOSD(XMLSTR lpszNewValue, XMLSTR lpszNewName,XMLCSTR lpszOldName); ///< set lpszNewName=NULL if you don't want to change the name of the attribute if the attribute to update is missing, a new one will be added
+    XMLCSTR        updateText_WOSD(XMLSTR lpszNewValue, int i=0);                                     ///< if the text to update is missing, a new one will be added
+    XMLCSTR        updateText_WOSD(XMLSTR lpszNewValue, XMLCSTR lpszOldValue);                        ///< if the text to update is missing, a new one will be added
+    XMLClear      *updateClear_WOSD(XMLSTR lpszNewContent, int i=0);                                  ///< if the clearTag to update is missing, a new one will be added
+    XMLClear      *updateClear_WOSD(XMLClear *newP,XMLClear *oldP);                                   ///< if the clearTag to update is missing, a new one will be added
+    XMLClear      *updateClear_WOSD(XMLSTR lpszNewValue, XMLCSTR lpszOldValue);                       ///< if the clearTag to update is missing, a new one will be added
+    /** @} */
 
-  /// Enumeration for XML character encoding.
-  typedef enum XMLCharEncoding {
-    char_encoding_error = 0,
-    char_encoding_UTF8 = 1,
-    char_encoding_legacy = 2,
-    char_encoding_ShiftJIS = 3,
-    char_encoding_GB2312 = 4,
-    char_encoding_Big5 = 5,
-    char_encoding_GBK = 6  // this is actually the same as Big5
-  } XMLCharEncoding;
+    /** @defgroup xmlPosition Position helper functions (use in conjunction with the update&add functions
+     * @ingroup xmlModify
+     * These are some useful functions when you want to insert a childNode, a text or a XMLClearTag in the
+     * middle (at a specified position) of a XMLNode tree already constructed. The value returned by these
+     * methods is to be used as last parameter (parameter 'pos') of addChild, addText or addClear.
+     * @{ */
+    XMLElementPosition positionOfText(int i=0) const;
+    XMLElementPosition positionOfText(XMLCSTR lpszValue) const;
+    XMLElementPosition positionOfClear(int i=0) const;
+    XMLElementPosition positionOfClear(XMLCSTR lpszValue) const;
+    XMLElementPosition positionOfClear(XMLClear *a) const;
+    XMLElementPosition positionOfChildNode(int i=0) const;
+    XMLElementPosition positionOfChildNode(XMLNode x) const;
+    XMLElementPosition positionOfChildNode(XMLCSTR name, int i=0) const; ///< return the position of the ith childNode with the specified name if (name==NULL) return the position of the ith childNode
+    /** @} */
 
-  /** \addtogroup conversions
-   * @{ */
+    /// Enumeration for XML character encoding.
+    typedef enum XMLCharEncoding
+    {
+        char_encoding_error=0,
+        char_encoding_UTF8=1,
+        char_encoding_legacy=2,
+        char_encoding_ShiftJIS=3,
+        char_encoding_GB2312=4,
+        char_encoding_Big5=5,
+        char_encoding_GBK=6     // this is actually the same as Big5
+    } XMLCharEncoding;
 
-  /// Sets the global options for the conversions
-  static char setGlobalOptions(
-      XMLCharEncoding characterEncoding = XMLNode::char_encoding_UTF8,
-      char guessWideCharChars = 1, char dropWhiteSpace = 1,
-      char removeCommentsInMiddleOfText = 1);
-  /**< The "setGlobalOptions" function allows you to change four global
-   * parameters that affect string & file
-   * parsing. First of all, you most-probably will never have to change these 3
-   * global parameters.
-   *
-   * @param guessWideCharChars If "guessWideCharChars"=1 and if this library is
-   * compiled in WideChar mode, then the
-   *     XMLNode::parseFile and XMLNode::openFileHelper functions will test if
-   * the file contains ASCII
-   *     characters. If this is the case, then the file will be loaded and
-   * converted in memory to
-   *     WideChar before being parsed. If 0, no conversion will be performed.
-   *
-   * @param guessWideCharChars If "guessWideCharChars"=1 and if this library is
-   * compiled in ASCII/UTF8/char* mode, then the
-   *     XMLNode::parseFile and XMLNode::openFileHelper functions will test if
-   * the file contains WideChar
-   *     characters. If this is the case, then the file will be loaded and
-   * converted in memory to
-   *     ASCII/UTF8/char* before being parsed. If 0, no conversion will be
-   * performed.
-   *
-   * @param characterEncoding This parameter is only meaningful when compiling
-   * in char* mode (multibyte character mode).
-   *     In wchar_t* (wide char mode), this parameter is ignored. This parameter
-   * should be one of the
-   *     three currently recognized encodings: XMLNode::encoding_UTF8,
-   * XMLNode::encoding_ascii,
-   *     XMLNode::encoding_ShiftJIS.
-   *
-   * @param dropWhiteSpace In most situations, text fields containing only white
-   * spaces (and carriage returns)
-   *     are useless. Even more, these "empty" text fields are annoying because
-   * they increase the
-   *     complexity of the user's code for parsing. So, 99% of the time, it's
-   * better to drop
-   *     the "empty" text fields. However The XML specification indicates that
-   * no white spaces
-   *     should be lost when parsing the file. So to be perfectly XML-compliant,
-   * you should set
-   *     dropWhiteSpace=0. A note of caution: if you set "dropWhiteSpace=0", the
-   * parser will be
-   *     slower and your code will be more complex.
-   *
-   * @param removeCommentsInMiddleOfText To explain this parameter, let's
-   * consider this code:
-   * \code
-   *        XMLNode x=XMLNode::parseString("<a>foo<!-- hello -->bar<!DOCTYPE
-   * world >chu</a>","a");
-   * \endcode
-   *     If removeCommentsInMiddleOfText=0, then we will have:
-   * \code
-   *        x.getText(0) -> "foo"
-   *        x.getText(1) -> "bar"
-   *        x.getText(2) -> "chu"
-   *        x.getClear(0) --> "<!-- hello -->"
-   *        x.getClear(1) --> "<!DOCTYPE world >"
-   * \endcode
-   *     If removeCommentsInMiddleOfText=1, then we will have:
-   * \code
-   *        x.getText(0) -> "foobar"
-   *        x.getText(1) -> "chu"
-   *        x.getClear(0) --> "<!DOCTYPE world >"
-   * \endcode
-   *
-   * \return "0" when there are no errors. If you try to set an unrecognized
-   * encoding then the return value will be "1" to signal an error.
-   *
-   * \note Sometime, it's useful to set "guessWideCharChars=0" to disable any
-   * conversion
-   * because the test to detect the file-type (ASCII/UTF8/char* or WideChar) may
-   * fail (rarely). */
+    /** \addtogroup conversions
+     * @{ */
 
-  /// Guess the character encoding of the string (ascii, utf8 or shift-JIS)
-  static XMLCharEncoding guessCharEncoding(void *buffer, int bufLen,
-                                           char useXMLEncodingAttribute = 1);
-  /**< The "guessCharEncoding" function try to guess the character encoding. You
-   * most-probably will never
-   * have to use this function. It then returns the appropriate value of the
-   * global parameter
-   * "characterEncoding" described in the XMLNode::setGlobalOptions. The guess
-   * is based on the content of a buffer of length
-   * "bufLen" bytes that contains the first bytes (minimum 25 bytes; 200 bytes
-   * is a good value) of the
-   * file to be parsed. The XMLNode::openFileHelper function is using this
-   * function to automatically compute
-   * the value of the "characterEncoding" global parameter. There are several
-   * heuristics used to do the
-   * guess. One of the heuristic is based on the "encoding" attribute. The
-   * original XML specifications
-   * forbids to use this attribute to do the guess but you can still use it if
-   * you set
-   * "useXMLEncodingAttribute" to 1 (this is the default behavior and the
-   * behavior of most parsers).
-   * If an inconsistency in the encoding is detected, then the return value is
-   * "0". */
-  /** @} */
+    /// Sets the global options for the conversions
+    static char setGlobalOptions(XMLCharEncoding characterEncoding=XMLNode::char_encoding_UTF8, char guessWideCharChars=1,
+                                 char dropWhiteSpace=1, char removeCommentsInMiddleOfText=1);
+    /**< The "setGlobalOptions" function allows you to change four global parameters that affect string & file
+     * parsing. First of all, you most-probably will never have to change these 3 global parameters.
+     *
+     * @param guessWideCharChars If "guessWideCharChars"=1 and if this library is compiled in WideChar mode, then the
+     *     XMLNode::parseFile and XMLNode::openFileHelper functions will test if the file contains ASCII
+     *     characters. If this is the case, then the file will be loaded and converted in memory to
+     *     WideChar before being parsed. If 0, no conversion will be performed.
+     *
+     * @param guessWideCharChars If "guessWideCharChars"=1 and if this library is compiled in ASCII/UTF8/char* mode, then the
+     *     XMLNode::parseFile and XMLNode::openFileHelper functions will test if the file contains WideChar
+     *     characters. If this is the case, then the file will be loaded and converted in memory to
+     *     ASCII/UTF8/char* before being parsed. If 0, no conversion will be performed.
+     *
+     * @param characterEncoding This parameter is only meaningful when compiling in char* mode (multibyte character mode).
+     *     In wchar_t* (wide char mode), this parameter is ignored. This parameter should be one of the
+     *     three currently recognized encodings: XMLNode::encoding_UTF8, XMLNode::encoding_ascii,
+     *     XMLNode::encoding_ShiftJIS.
+     *
+     * @param dropWhiteSpace In most situations, text fields containing only white spaces (and carriage returns)
+     *     are useless. Even more, these "empty" text fields are annoying because they increase the
+     *     complexity of the user's code for parsing. So, 99% of the time, it's better to drop
+     *     the "empty" text fields. However The XML specification indicates that no white spaces
+     *     should be lost when parsing the file. So to be perfectly XML-compliant, you should set
+     *     dropWhiteSpace=0. A note of caution: if you set "dropWhiteSpace=0", the parser will be
+     *     slower and your code will be more complex.
+     *
+     * @param removeCommentsInMiddleOfText To explain this parameter, let's consider this code:
+     * \code
+     *        XMLNode x=XMLNode::parseString("<a>foo<!-- hello -->bar<!DOCTYPE world >chu</a>","a");
+     * \endcode
+     *     If removeCommentsInMiddleOfText=0, then we will have:
+     * \code
+     *        x.getText(0) -> "foo"
+     *        x.getText(1) -> "bar"
+     *        x.getText(2) -> "chu"
+     *        x.getClear(0) --> "<!-- hello -->"
+     *        x.getClear(1) --> "<!DOCTYPE world >"
+     * \endcode
+     *     If removeCommentsInMiddleOfText=1, then we will have:
+     * \code
+     *        x.getText(0) -> "foobar"
+     *        x.getText(1) -> "chu"
+     *        x.getClear(0) --> "<!DOCTYPE world >"
+     * \endcode
+     *
+     * \return "0" when there are no errors. If you try to set an unrecognized encoding then the return value will be "1" to signal an error.
+     *
+     * \note Sometime, it's useful to set "guessWideCharChars=0" to disable any conversion
+     * because the test to detect the file-type (ASCII/UTF8/char* or WideChar) may fail (rarely). */
 
- private:
-  // these are functions and structures used internally by the XMLNode class
-  // (don't bother about them):
+    /// Guess the character encoding of the string (ascii, utf8 or shift-JIS)
+    static XMLCharEncoding guessCharEncoding(void *buffer, int bufLen, char useXMLEncodingAttribute=1);
+    /**< The "guessCharEncoding" function try to guess the character encoding. You most-probably will never
+     * have to use this function. It then returns the appropriate value of the global parameter
+     * "characterEncoding" described in the XMLNode::setGlobalOptions. The guess is based on the content of a buffer of length
+     * "bufLen" bytes that contains the first bytes (minimum 25 bytes; 200 bytes is a good value) of the
+     * file to be parsed. The XMLNode::openFileHelper function is using this function to automatically compute
+     * the value of the "characterEncoding" global parameter. There are several heuristics used to do the
+     * guess. One of the heuristic is based on the "encoding" attribute. The original XML specifications
+     * forbids to use this attribute to do the guess but you can still use it if you set
+     * "useXMLEncodingAttribute" to 1 (this is the default behavior and the behavior of most parsers).
+     * If an inconsistency in the encoding is detected, then the return value is "0". */
+    /** @} */
 
-  typedef struct XMLNodeDataTag  // to allow shallow copy and
-                                 // "intelligent/smart" pointers (automatic
-                                 // delete):
-  {
-    XMLCSTR lpszName;    // Element name (=NULL if root)
-    int nChild,          // Number of child nodes
-        nText,           // Number of text fields
-        nClear,          // Number of Clear fields (comments)
-        nAttribute;      // Number of attributes
-    char isDeclaration;  // Whether node is an XML declaration - '<?xml ?>'
-    struct XMLNodeDataTag
-        *pParent;              // Pointer to parent element (=NULL if root)
-    XMLNode *pChild;           // Array of child nodes
-    XMLCSTR *pText;            // Array of text fields
-    XMLClear *pClear;          // Array of clear fields
-    XMLAttribute *pAttribute;  // Array of attributes
-    int *pOrder;    // order of the child_nodes,text_fields,clear_fields
-    int ref_count;  // for garbage collection (smart pointers)
-  } XMLNodeData;
-  XMLNodeData *d;
+  private:
+      // these are functions and structures used internally by the XMLNode class (don't bother about them):
 
-  char parseClearTag(void *px, void *pa);
-  char maybeAddTxT(void *pa, XMLCSTR tokenPStr);
-  int ParseXMLElement(void *pXML);
-  void *addToOrder(int memInc, int *_pos, int nc, void *p, int size,
-                   XMLElementType xtype);
-  int indexText(XMLCSTR lpszValue) const;
-  int indexClear(XMLCSTR lpszValue) const;
-  XMLNode addChild_priv(int, XMLSTR, char, int);
-  XMLAttribute *addAttribute_priv(int, XMLSTR, XMLSTR);
-  XMLCSTR addText_priv(int, XMLSTR, int);
-  XMLClear *addClear_priv(int, XMLSTR, XMLCSTR, XMLCSTR, int);
-  void emptyTheNode(char force);
-  static inline XMLElementPosition findPosition(XMLNodeData *d, int index,
-                                                XMLElementType xtype);
-  static int CreateXMLStringR(XMLNodeData *pEntry, XMLSTR lpszMarker,
-                              int nFormat);
-  static int removeOrderElement(XMLNodeData *d, XMLElementType t, int index);
-  static void exactMemory(XMLNodeData *d);
-  static int detachFromParent(XMLNodeData *d);
+      typedef struct XMLNodeDataTag // to allow shallow copy and "intelligent/smart" pointers (automatic delete):
+      {
+          XMLCSTR                lpszName;        // Element name (=NULL if root)
+          int                    nChild,          // Number of child nodes
+                                 nText,           // Number of text fields
+                                 nClear,          // Number of Clear fields (comments)
+                                 nAttribute;      // Number of attributes
+          char                   isDeclaration;   // Whether node is an XML declaration - '<?xml ?>'
+          struct XMLNodeDataTag  *pParent;        // Pointer to parent element (=NULL if root)
+          XMLNode                *pChild;         // Array of child nodes
+          XMLCSTR                *pText;          // Array of text fields
+          XMLClear               *pClear;         // Array of clear fields
+          XMLAttribute           *pAttribute;     // Array of attributes
+          int                    *pOrder;         // order of the child_nodes,text_fields,clear_fields
+          int                    ref_count;       // for garbage collection (smart pointers)
+      } XMLNodeData;
+      XMLNodeData *d;
+
+      char parseClearTag(void *px, void *pa);
+      char maybeAddTxT(void *pa, XMLCSTR tokenPStr);
+      int ParseXMLElement(void *pXML);
+      void *addToOrder(int memInc, int *_pos, int nc, void *p, int size, XMLElementType xtype);
+      int indexText(XMLCSTR lpszValue) const;
+      int indexClear(XMLCSTR lpszValue) const;
+      XMLNode addChild_priv(int,XMLSTR,char,int);
+      XMLAttribute *addAttribute_priv(int,XMLSTR,XMLSTR);
+      XMLCSTR addText_priv(int,XMLSTR,int);
+      XMLClear *addClear_priv(int,XMLSTR,XMLCSTR,XMLCSTR,int);
+      void emptyTheNode(char force);
+      static inline XMLElementPosition findPosition(XMLNodeData *d, int index, XMLElementType xtype);
+      static int CreateXMLStringR(XMLNodeData *pEntry, XMLSTR lpszMarker, int nFormat);
+      static int removeOrderElement(XMLNodeData *d, XMLElementType t, int index);
+      static void exactMemory(XMLNodeData *d);
+      static int detachFromParent(XMLNodeData *d);
 } XMLNode;
 
 /// This structure is given by the function XMLNode::enumContents.
-typedef struct XMLNodeContents {
-  /// This dictates what's the content of the XMLNodeContent
-  enum XMLElementType etype;
-  /**< should be an union to access the appropriate data. Compiler does not
-   * allow union of object with constructor... too bad. */
-  XMLNode child;
-  XMLAttribute attrib;
-  XMLCSTR text;
-  XMLClear clear;
+typedef struct XMLNodeContents
+{
+    /// This dictates what's the content of the XMLNodeContent
+    enum XMLElementType etype;
+    /**< should be an union to access the appropriate data. Compiler does not allow union of object with constructor... too bad. */
+    XMLNode child;
+    XMLAttribute attrib;
+    XMLCSTR text;
+    XMLClear clear;
 
 } XMLNodeContents;
 
@@ -912,164 +645,118 @@ typedef struct XMLNodeContents {
  * @ingroup xmlModify
  * @{ */
 /// Duplicate (copy in a new allocated buffer) the source string.
-XMLDLLENTRY XMLSTR stringDup(XMLCSTR source, int cbData = -1);
+XMLDLLENTRY XMLSTR stringDup(XMLCSTR source, int cbData=-1);
 /**< This is
- * a very handy function when used with all the "XMLNode::*_WOSD" functions
- * (\link xmlWOSD \endlink).
- * @param cbData If !=0 then cbData is the number of chars to duplicate. New
- * strings allocated with
+ * a very handy function when used with all the "XMLNode::*_WOSD" functions (\link xmlWOSD \endlink).
+ * @param cbData If !=0 then cbData is the number of chars to duplicate. New strings allocated with
  * this function should be free'd using the "freeXMLString" function. */
 
-/// to free the string allocated inside the "stringDup" function or the
-/// "createXMLString" function.
-XMLDLLENTRY void freeXMLString(XMLSTR t);  // {free(t);}
-                                           /** @} */
+/// to free the string allocated inside the "stringDup" function or the "createXMLString" function.
+XMLDLLENTRY void freeXMLString(XMLSTR t); // {free(t);}
+/** @} */
 
 /** @defgroup atoX ato? like functions
  * @ingroup XMLParserGeneral
  * The "xmlto?" functions are equivalents to the atoi, atol, atof functions.
- * The only difference is: If the variable "xmlString" is NULL, than the return
- * value
- * is "defautValue". These 6 functions are only here as "convenience" functions
- * for the
- * user (they are not used inside the XMLparser). If you don't need them, you
- * can
+ * The only difference is: If the variable "xmlString" is NULL, than the return value
+ * is "defautValue". These 6 functions are only here as "convenience" functions for the
+ * user (they are not used inside the XMLparser). If you don't need them, you can
  * delete them without any trouble.
  *
  * @{ */
-XMLDLLENTRY char xmltob(XMLCSTR xmlString, char defautValue = 0);
-XMLDLLENTRY int xmltoi(XMLCSTR xmlString, int defautValue = 0);
-XMLDLLENTRY long xmltol(XMLCSTR xmlString, long defautValue = 0);
-XMLDLLENTRY double xmltof(XMLCSTR xmlString, double defautValue = .0);
-XMLDLLENTRY XMLCSTR xmltoa(XMLCSTR xmlString, XMLCSTR defautValue = _CXML(""));
-XMLDLLENTRY XMLCHAR xmltoc(XMLCSTR xmlString,
-                           XMLCHAR defautValue = _CXML('\0'));
+XMLDLLENTRY char    xmltob(XMLCSTR xmlString,char   defautValue=0);
+XMLDLLENTRY int     xmltoi(XMLCSTR xmlString,int    defautValue=0);
+XMLDLLENTRY long    xmltol(XMLCSTR xmlString,long   defautValue=0);
+XMLDLLENTRY double  xmltof(XMLCSTR xmlString,double defautValue=.0);
+XMLDLLENTRY XMLCSTR xmltoa(XMLCSTR xmlString,XMLCSTR defautValue=_CXML(""));
+XMLDLLENTRY XMLCHAR xmltoc(XMLCSTR xmlString,XMLCHAR defautValue=_CXML('\0'));
 /** @} */
 
-/** @defgroup ToXMLStringTool Helper class to create XML files using "printf",
- * "fprintf", "cout",... functions.
+/** @defgroup ToXMLStringTool Helper class to create XML files using "printf", "fprintf", "cout",... functions.
  * @ingroup XMLParserGeneral
  * @{ */
-/// Helper class to create XML files using "printf", "fprintf", "cout",...
-/// functions.
-/** The ToXMLStringTool class helps you creating XML files using "printf",
- * "fprintf", "cout",... functions.
+/// Helper class to create XML files using "printf", "fprintf", "cout",... functions.
+/** The ToXMLStringTool class helps you creating XML files using "printf", "fprintf", "cout",... functions.
  * The "ToXMLStringTool" class is processing strings so that all the characters
  * &,",',<,> are replaced by their XML equivalent:
  * \verbatim &amp;, &quot;, &apos;, &lt;, &gt; \endverbatim
- * Using the "ToXMLStringTool class" and the "fprintf function" is THE most
- * efficient
+ * Using the "ToXMLStringTool class" and the "fprintf function" is THE most efficient
  * way to produce VERY large XML documents VERY fast.
- * \note If you are creating from scratch an XML file using the provided XMLNode
- * class
- * you must not use the "ToXMLStringTool" class (because the "XMLNode" class
- * does the
+ * \note If you are creating from scratch an XML file using the provided XMLNode class
+ * you must not use the "ToXMLStringTool" class (because the "XMLNode" class does the
  * processing job for you during rendering).*/
-typedef struct XMLDLLENTRY ToXMLStringTool {
- public:
-  ToXMLStringTool() : buf(NULL), buflen(0) {}
-  ~ToXMLStringTool();
-  void freeBuffer();  ///<call this function when you have finished using this
-                      ///object to release memory used by the internal buffer.
+typedef struct XMLDLLENTRY ToXMLStringTool
+{
+public:
+    ToXMLStringTool(): buf(NULL),buflen(0){}
+    ~ToXMLStringTool();
+    void freeBuffer();///<call this function when you have finished using this object to release memory used by the internal buffer.
 
-  XMLSTR toXML(XMLCSTR source);  ///< returns a pointer to an internal buffer
-                                 ///that contains a XML-encoded string based on
-                                 ///the "source" parameter.
+    XMLSTR toXML(XMLCSTR source);///< returns a pointer to an internal buffer that contains a XML-encoded string based on the "source" parameter.
 
-  /** The "toXMLUnSafe" function is deprecated because there is a possibility of
-   * "destination-buffer-overflow". It converts the string
-   * "source" to the string "dest". */
-  static XMLSTR toXMLUnSafe(
-      XMLSTR dest, XMLCSTR source);  ///< deprecated: use "toXML" instead
-  static int lengthXMLString(
-      XMLCSTR source);  ///< deprecated: use "toXML" instead
+    /** The "toXMLUnSafe" function is deprecated because there is a possibility of
+     * "destination-buffer-overflow". It converts the string
+     * "source" to the string "dest". */
+    static XMLSTR toXMLUnSafe(XMLSTR dest,XMLCSTR source); ///< deprecated: use "toXML" instead
+    static int lengthXMLString(XMLCSTR source);            ///< deprecated: use "toXML" instead
 
- private:
-  XMLSTR buf;
-  int buflen;
+private:
+    XMLSTR buf;
+    int buflen;
 } ToXMLStringTool;
 /** @} */
 
-/** @defgroup XMLParserBase64Tool Helper class to include binary data inside XML
- * strings using "Base64 encoding".
+/** @defgroup XMLParserBase64Tool Helper class to include binary data inside XML strings using "Base64 encoding".
  * @ingroup XMLParserGeneral
  * @{ */
-/// Helper class to include binary data inside XML strings using "Base64
-/// encoding".
-/** The "XMLParserBase64Tool" class allows you to include any binary data
- * (images, sounds,...)
+/// Helper class to include binary data inside XML strings using "Base64 encoding".
+/** The "XMLParserBase64Tool" class allows you to include any binary data (images, sounds,...)
  * into an XML document using "Base64 encoding". This class is completely
- * separated from the rest of the xmlParser library and can be removed without
- * any problem.
- * To include some binary data into an XML file, you must convert the binary
- * data into
+ * separated from the rest of the xmlParser library and can be removed without any problem.
+ * To include some binary data into an XML file, you must convert the binary data into
  * standard text (using "encode"). To retrieve the original binary data from the
- * b64-encoded text included inside the XML file, use "decode". Alternatively,
- * these
- * functions can also be used to "encrypt/decrypt" some critical data contained
- * inside
- * the XML (it's not a strong encryption at all, but sometimes it can be
- * useful). */
-typedef struct XMLDLLENTRY XMLParserBase64Tool {
- public:
-  XMLParserBase64Tool() : buf(NULL), buflen(0) {}
-  ~XMLParserBase64Tool();
-  void freeBuffer();  ///< Call this function when you have finished using this
-                      ///object to release memory used by the internal buffer.
+ * b64-encoded text included inside the XML file, use "decode". Alternatively, these
+ * functions can also be used to "encrypt/decrypt" some critical data contained inside
+ * the XML (it's not a strong encryption at all, but sometimes it can be useful). */
+typedef struct XMLDLLENTRY XMLParserBase64Tool
+{
+public:
+    XMLParserBase64Tool(): buf(NULL),buflen(0){}
+    ~XMLParserBase64Tool();
+    void freeBuffer();///< Call this function when you have finished using this object to release memory used by the internal buffer.
 
-  /**
-   * @param formatted If "formatted"=true, some space will be reserved for a
-   * carriage-return every 72 chars. */
-  static int encodeLength(int inBufLen,
-                          char formatted = 0);  ///< return the length of the
-                                                ///base64 string that encodes a
-                                                ///data buffer of size inBufLen
-                                                ///bytes.
+    /**
+     * @param formatted If "formatted"=true, some space will be reserved for a carriage-return every 72 chars. */
+    static int encodeLength(int inBufLen, char formatted=0); ///< return the length of the base64 string that encodes a data buffer of size inBufLen bytes.
 
-  /**
-   * The "base64Encode" function returns a string containing the base64 encoding
-   * of "inByteLen" bytes
-   * from "inByteBuf". If "formatted" parameter is true, then there will be a
-   * carriage-return every 72 chars.
-   * The string will be free'd when the XMLParserBase64Tool object is deleted.
-   * All returned strings are sharing the same memory space. */
-  XMLSTR encode(unsigned char *inByteBuf, unsigned int inByteLen,
-                char formatted = 0);  ///< returns a pointer to an internal
-                                      ///buffer containing the base64 string
-                                      ///containing the binary data encoded from
-                                      ///"inByteBuf"
+    /**
+     * The "base64Encode" function returns a string containing the base64 encoding of "inByteLen" bytes
+     * from "inByteBuf". If "formatted" parameter is true, then there will be a carriage-return every 72 chars.
+     * The string will be free'd when the XMLParserBase64Tool object is deleted.
+     * All returned strings are sharing the same memory space. */
+    XMLSTR encode(unsigned char *inByteBuf, unsigned int inByteLen, char formatted=0); ///< returns a pointer to an internal buffer containing the base64 string containing the binary data encoded from "inByteBuf"
 
-  /// returns the number of bytes which will be decoded from "inString".
-  static unsigned int decodeSize(XMLCSTR inString, XMLError *xe = NULL);
+    /// returns the number of bytes which will be decoded from "inString".
+    static unsigned int decodeSize(XMLCSTR inString, XMLError *xe=NULL);
 
-  /**
-   * The "decode" function returns a pointer to a buffer containing the binary
-   * data decoded from "inString"
-   * The output buffer will be free'd when the XMLParserBase64Tool object is
-   * deleted.
-   * All output buffer are sharing the same memory space.
-   * @param inString If "instring" is malformed, NULL will be returned */
-  unsigned char *decode(XMLCSTR inString, int *outByteLen = NULL,
-                        XMLError *xe = NULL);  ///< returns a pointer to an
-                                               ///internal buffer containing the
-                                               ///binary data decoded from
-                                               ///"inString"
+    /**
+     * The "decode" function returns a pointer to a buffer containing the binary data decoded from "inString"
+     * The output buffer will be free'd when the XMLParserBase64Tool object is deleted.
+     * All output buffer are sharing the same memory space.
+     * @param inString If "instring" is malformed, NULL will be returned */
+    unsigned char* decode(XMLCSTR inString, int *outByteLen=NULL, XMLError *xe=NULL); ///< returns a pointer to an internal buffer containing the binary data decoded from "inString"
 
-  /**
-   * decodes data from "inString" to "outByteBuf". You need to provide the size
-   * (in byte) of "outByteBuf"
-   * in "inMaxByteOutBuflen". If "outByteBuf" is not large enough or if data is
-   * malformed, then "FALSE"
-   * will be returned; otherwise "TRUE". */
-  static unsigned char decode(XMLCSTR inString, unsigned char *outByteBuf,
-                              int inMaxByteOutBuflen,
-                              XMLError *xe = NULL);  ///< deprecated.
+    /**
+     * decodes data from "inString" to "outByteBuf". You need to provide the size (in byte) of "outByteBuf"
+     * in "inMaxByteOutBuflen". If "outByteBuf" is not large enough or if data is malformed, then "FALSE"
+     * will be returned; otherwise "TRUE". */
+    static unsigned char decode(XMLCSTR inString, unsigned char *outByteBuf, int inMaxByteOutBuflen, XMLError *xe=NULL); ///< deprecated.
 
- private:
-  void *buf;
-  int buflen;
-  void alloc(int newsize);
-} XMLParserBase64Tool;
+private:
+    void *buf;
+    int buflen;
+    void alloc(int newsize);
+}XMLParserBase64Tool;
 /** @} */
 
 #undef XMLDLLENTRY

--- a/src/gpuwattch/xmlParser.h
+++ b/src/gpuwattch/xmlParser.h
@@ -391,7 +391,7 @@ typedef struct XMLDLLENTRY XMLNode {
    */
 
   static XMLCSTR getError(XMLError error);  ///< this gives you a user-friendly
-                                            /// explanation of the parsing error
+                                            ///explanation of the parsing error
 
   /// Create an XML string starting from the current XMLNode.
   XMLSTR createXMLString(int nFormat = 1, int *pnSize = NULL) const;
@@ -426,23 +426,23 @@ typedef struct XMLDLLENTRY XMLNode {
   XMLNode getParentNode() const;                    ///< return the parent node
   XMLNode getChildNode(int i = 0) const;            ///< return ith child node
   XMLNode getChildNode(XMLCSTR name, int i) const;  ///< return ith child node
-                                                    /// with specific name
-  ///(return an empty node if
-  /// failing). If i==-1, this
-  /// returns the last XMLNode
-  /// with the given name.
+                                                    ///with specific name
+                                                    ///(return an empty node if
+                                                    ///failing). If i==-1, this
+                                                    ///returns the last XMLNode
+                                                    ///with the given name.
   XMLNode getChildNode(XMLCSTR name, int *i = NULL) const;  ///< return next
-                                                            /// child node with
-  /// specific name
-  ///(return an empty
-  /// node if failing)
+                                                            ///child node with
+                                                            ///specific name
+                                                            ///(return an empty
+                                                            ///node if failing)
   XMLNode getChildNodeWithAttribute(XMLCSTR tagName, XMLCSTR attributeName,
                                     XMLCSTR attributeValue = NULL,
                                     int *i = NULL) const;  ///< return child
-  /// node with specific
-  /// name/attribute
-  ///(return an empty
-  /// node if failing)
+                                                           ///node with specific
+                                                           ///name/attribute
+                                                           ///(return an empty
+                                                           ///node if failing)
   XMLNode getChildNodeByPath(XMLCSTR path, char createNodeIfMissing = 0,
                              XMLCHAR sep = '/');
   ///< return the first child node with specific path
@@ -459,21 +459,21 @@ typedef struct XMLDLLENTRY XMLNode {
   char isAttributeSet(XMLCSTR name)
       const;  ///< test if an attribute with a specific name is given
   XMLCSTR getAttribute(XMLCSTR name, int i) const;  ///< return ith attribute
-                                                    /// content with specific
-  /// name (return a NULL if
-  /// failing)
+                                                    ///content with specific
+                                                    ///name (return a NULL if
+                                                    ///failing)
   XMLCSTR getAttribute(XMLCSTR name, int *i = NULL) const;  ///< return next
-  /// attribute content
-  /// with specific
-  /// name (return a
-  /// NULL if failing)
+                                                            ///attribute content
+                                                            ///with specific
+                                                            ///name (return a
+                                                            ///NULL if failing)
   int nAttribute() const;              ///< nbr of attribute
   XMLClear getClear(int i = 0) const;  ///< return ith clear field (comments)
   int nClear() const;                  ///< nbr of clear field
   XMLNodeContents enumContents(XMLElementPosition i)
       const;  ///< enumerate all the different contents (attribute,child,text,
-              /// clear) of the current XMLNode. The order is reflecting the
-  /// order of the original file/string. NOTE: 0 <= i < nElement();
+              ///clear) of the current XMLNode. The order is reflecting the
+              ///order of the original file/string. NOTE: 0 <= i < nElement();
   int nElement() const;        ///< nbr of different contents for current node
   char isEmpty() const;        ///< is this node Empty?
   char isDeclaration() const;  ///< is this node a declaration <? .... ?>
@@ -515,10 +515,10 @@ typedef struct XMLDLLENTRY XMLNode {
                    XMLElementPosition pos = -1);  ///< Add a new child node
   XMLNode addChild(XMLNode nodeToAdd,
                    XMLElementPosition pos = -1);  ///< If the "nodeToAdd" has
-                                                  /// some parents, it will be
-  /// detached from it's parents
-  /// before being attached to
-  /// the current XMLNode
+                                                  ///some parents, it will be
+                                                  ///detached from it's parents
+                                                  ///before being attached to
+                                                  ///the current XMLNode
   XMLAttribute *addAttribute(XMLCSTR lpszName,
                              XMLCSTR lpszValuev);  ///< Add a new attribute
   XMLCSTR addText(XMLCSTR lpszValue,
@@ -539,41 +539,41 @@ typedef struct XMLDLLENTRY XMLNode {
   XMLCSTR updateName(XMLCSTR lpszName);  ///< change node's name
   XMLAttribute *updateAttribute(XMLAttribute *newAttribute,
                                 XMLAttribute *oldAttribute);  ///< if the
-                                                              /// attribute to
-  /// update is
-  /// missing, a new
-  /// one will be
-  /// added
+                                                              ///attribute to
+                                                              ///update is
+                                                              ///missing, a new
+                                                              ///one will be
+                                                              ///added
   XMLAttribute *updateAttribute(XMLCSTR lpszNewValue,
                                 XMLCSTR lpszNewName = NULL,
                                 int i = 0);  ///< if the attribute to update is
-  /// missing, a new one will be added
+                                             ///missing, a new one will be added
   XMLAttribute *updateAttribute(XMLCSTR lpszNewValue, XMLCSTR lpszNewName,
                                 XMLCSTR lpszOldName);  ///< set lpszNewName=NULL
-                                                       /// if you don't want to
-  /// change the name of the
-  /// attribute if the
-  /// attribute to update is
-  /// missing, a new one
-  /// will be added
+                                                       ///if you don't want to
+                                                       ///change the name of the
+                                                       ///attribute if the
+                                                       ///attribute to update is
+                                                       ///missing, a new one
+                                                       ///will be added
   XMLCSTR updateText(XMLCSTR lpszNewValue, int i = 0);  ///< if the text to
-                                                        /// update is missing, a
-  /// new one will be added
+                                                        ///update is missing, a
+                                                        ///new one will be added
   XMLCSTR updateText(XMLCSTR lpszNewValue,
                      XMLCSTR lpszOldValue);  ///< if the text to update is
-  /// missing, a new one will be added
+                                             ///missing, a new one will be added
   XMLClear *updateClear(XMLCSTR lpszNewContent,
                         int i = 0);  ///< if the clearTag to update is missing,
-                                     /// a new one will be added
+                                     ///a new one will be added
   XMLClear *updateClear(XMLClear *newP, XMLClear *oldP);  ///< if the clearTag
-                                                          /// to update is
-  /// missing, a new one
-  /// will be added
+                                                          ///to update is
+                                                          ///missing, a new one
+                                                          ///will be added
   XMLClear *updateClear(XMLCSTR lpszNewValue,
                         XMLCSTR lpszOldValue);  ///< if the clearTag to update
-  /// is missing, a new one will be
-  /// added
-  /** @} */
+                                                ///is missing, a new one will be
+                                                ///added
+                                                /** @} */
 
   /** @defgroup xmlDelete Deleting Nodes or Attributes
    * @ingroup xmlModify
@@ -589,33 +589,33 @@ typedef struct XMLDLLENTRY XMLNode {
   void deleteAttribute(
       int i = 0);  ///< Delete the ith attribute of the current XMLNode
   void deleteAttribute(XMLCSTR lpszName);  ///< Delete the attribute with the
-                                           /// given name (the "strcmp" function
-  /// is used to find the right
-  /// attribute)
+                                           ///given name (the "strcmp" function
+                                           ///is used to find the right
+                                           ///attribute)
   void deleteAttribute(XMLAttribute *anAttribute);  ///< Delete the attribute
-                                                    /// with the name
-  ///"anAttribute->lpszName"
-  ///(the "strcmp" function is
-  /// used to find the right
-  /// attribute)
+                                                    ///with the name
+                                                    ///"anAttribute->lpszName"
+                                                    ///(the "strcmp" function is
+                                                    ///used to find the right
+                                                    ///attribute)
   void deleteText(
       int i = 0);  ///< Delete the Ith text content of the current XMLNode
   void deleteText(XMLCSTR lpszValue);  ///< Delete the text content "lpszValue"
-                                       /// inside the current XMLNode (direct
-  ///"pointer-to-pointer" comparison is
-  /// used to find the right text)
+                                       ///inside the current XMLNode (direct
+                                       ///"pointer-to-pointer" comparison is
+                                       ///used to find the right text)
   void deleteClear(
       int i = 0);  ///< Delete the Ith clear tag inside the current XMLNode
   void deleteClear(XMLCSTR lpszValue);  ///< Delete the clear tag "lpszValue"
-                                        /// inside the current XMLNode (direct
-  ///"pointer-to-pointer" comparison is
-  /// used to find the clear tag)
-  void deleteClear(XMLClear *p);  ///< Delete the clear tag "p" inside the
-                                  /// current XMLNode (direct
+                                        ///inside the current XMLNode (direct
+                                        ///"pointer-to-pointer" comparison is
+                                        ///used to find the clear tag)
+  void deleteClear(XMLClear *p);        ///< Delete the clear tag "p" inside the
+                                        ///current XMLNode (direct
                                   ///"pointer-to-pointer" comparison on the
-                                  /// lpszName of the clear tag is used to find
-                                  /// the clear tag)
-                                  /** @} */
+                                  ///lpszName of the clear tag is used to find
+                                  ///the clear tag)
+  /** @} */
 
   /** @defgroup xmlWOSD ???_WOSD functions.
    * @ingroup xmlModify
@@ -666,49 +666,49 @@ typedef struct XMLDLLENTRY XMLNode {
   XMLCSTR updateName_WOSD(XMLSTR lpszName);  ///< change node's name
   XMLAttribute *updateAttribute_WOSD(XMLAttribute *newAttribute,
                                      XMLAttribute *oldAttribute);  ///< if the
-                                                                   /// attribute
-  /// to update
-  /// is
-  /// missing, a
-  /// new one
-  /// will be
-  /// added
+                                                                   ///attribute
+                                                                   ///to update
+                                                                   ///is
+                                                                   ///missing, a
+                                                                   ///new one
+                                                                   ///will be
+                                                                   ///added
   XMLAttribute *updateAttribute_WOSD(XMLSTR lpszNewValue,
                                      XMLSTR lpszNewName = NULL,
                                      int i = 0);  ///< if the attribute to
-                                                  /// update is missing, a new
-  /// one will be added
+                                                  ///update is missing, a new
+                                                  ///one will be added
   XMLAttribute *updateAttribute_WOSD(XMLSTR lpszNewValue, XMLSTR lpszNewName,
                                      XMLCSTR lpszOldName);  ///< set
-                                                            /// lpszNewName=NULL
-  /// if you don't want
-  /// to change the
-  /// name of the
-  /// attribute if the
-  /// attribute to
-  /// update is
-  /// missing, a new
-  /// one will be added
+                                                            ///lpszNewName=NULL
+                                                            ///if you don't want
+                                                            ///to change the
+                                                            ///name of the
+                                                            ///attribute if the
+                                                            ///attribute to
+                                                            ///update is
+                                                            ///missing, a new
+                                                            ///one will be added
   XMLCSTR updateText_WOSD(XMLSTR lpszNewValue, int i = 0);  ///< if the text to
-                                                            /// update is
-  /// missing, a new
-  /// one will be added
+                                                            ///update is
+                                                            ///missing, a new
+                                                            ///one will be added
   XMLCSTR updateText_WOSD(XMLSTR lpszNewValue,
                           XMLCSTR lpszOldValue);  ///< if the text to update is
-                                                  /// missing, a new one will be
-  /// added
+                                                  ///missing, a new one will be
+                                                  ///added
   XMLClear *updateClear_WOSD(XMLSTR lpszNewContent,
                              int i = 0);  ///< if the clearTag to update is
-                                          /// missing, a new one will be added
+                                          ///missing, a new one will be added
   XMLClear *updateClear_WOSD(XMLClear *newP,
                              XMLClear *oldP);  ///< if the clearTag to update is
-                                               /// missing, a new one will be
-  /// added
+                                               ///missing, a new one will be
+                                               ///added
   XMLClear *updateClear_WOSD(XMLSTR lpszNewValue,
                              XMLCSTR lpszOldValue);  ///< if the clearTag to
-  /// update is missing, a new
-  /// one will be added
-  /** @} */
+                                                     ///update is missing, a new
+                                                     ///one will be added
+                                                     /** @} */
 
   /** @defgroup xmlPosition Position helper functions (use in conjunction with
    * the update&add functions
@@ -729,7 +729,7 @@ typedef struct XMLDLLENTRY XMLNode {
   XMLElementPosition positionOfChildNode(XMLNode x) const;
   XMLElementPosition positionOfChildNode(XMLCSTR name, int i = 0)
       const;  ///< return the position of the ith childNode with the specified
-              /// name if (name==NULL) return the position of the ith childNode
+              ///name if (name==NULL) return the position of the ith childNode
   /** @} */
 
   /// Enumeration for XML character encoding.
@@ -970,11 +970,11 @@ typedef struct XMLDLLENTRY ToXMLStringTool {
   ToXMLStringTool() : buf(NULL), buflen(0) {}
   ~ToXMLStringTool();
   void freeBuffer();  ///<call this function when you have finished using this
-                      /// object to release memory used by the internal buffer.
+                      ///object to release memory used by the internal buffer.
 
   XMLSTR toXML(XMLCSTR source);  ///< returns a pointer to an internal buffer
-                                 /// that contains a XML-encoded string based on
-                                 /// the "source" parameter.
+                                 ///that contains a XML-encoded string based on
+                                 ///the "source" parameter.
 
   /** The "toXMLUnSafe" function is deprecated because there is a possibility of
    * "destination-buffer-overflow". It converts the string
@@ -1015,16 +1015,16 @@ typedef struct XMLDLLENTRY XMLParserBase64Tool {
   XMLParserBase64Tool() : buf(NULL), buflen(0) {}
   ~XMLParserBase64Tool();
   void freeBuffer();  ///< Call this function when you have finished using this
-                      /// object to release memory used by the internal buffer.
+                      ///object to release memory used by the internal buffer.
 
   /**
    * @param formatted If "formatted"=true, some space will be reserved for a
    * carriage-return every 72 chars. */
   static int encodeLength(int inBufLen,
                           char formatted = 0);  ///< return the length of the
-                                                /// base64 string that encodes a
-                                                /// data buffer of size inBufLen
-                                                /// bytes.
+                                                ///base64 string that encodes a
+                                                ///data buffer of size inBufLen
+                                                ///bytes.
 
   /**
    * The "base64Encode" function returns a string containing the base64 encoding
@@ -1035,9 +1035,9 @@ typedef struct XMLDLLENTRY XMLParserBase64Tool {
    * All returned strings are sharing the same memory space. */
   XMLSTR encode(unsigned char *inByteBuf, unsigned int inByteLen,
                 char formatted = 0);  ///< returns a pointer to an internal
-                                      /// buffer containing the base64 string
-  /// containing the binary data encoded from
-  ///"inByteBuf"
+                                      ///buffer containing the base64 string
+                                      ///containing the binary data encoded from
+                                      ///"inByteBuf"
 
   /// returns the number of bytes which will be decoded from "inString".
   static unsigned int decodeSize(XMLCSTR inString, XMLError *xe = NULL);
@@ -1051,9 +1051,9 @@ typedef struct XMLDLLENTRY XMLParserBase64Tool {
    * @param inString If "instring" is malformed, NULL will be returned */
   unsigned char *decode(XMLCSTR inString, int *outByteLen = NULL,
                         XMLError *xe = NULL);  ///< returns a pointer to an
-  /// internal buffer containing the
-  /// binary data decoded from
-  ///"inString"
+                                               ///internal buffer containing the
+                                               ///binary data decoded from
+                                               ///"inString"
 
   /**
    * decodes data from "inString" to "outByteBuf". You need to provide the size

--- a/src/option_parser.cc
+++ b/src/option_parser.cc
@@ -7,541 +7,546 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
+#include "option_parser.h"
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <assert.h>
-#include <string>
-#include <iostream>
-#include <iomanip>
-#include <sstream>
+#include <string.h>
 #include <fstream>
-#include <vector>
+#include <iomanip>
+#include <iostream>
 #include <list>
 #include <map>
-#include <string.h>
-#include "option_parser.h"
-
+#include <sstream>
+#include <string>
+#include <vector>
 
 using namespace std;
 
 // A generic option registry regardless of data type
-class OptionRegistryInterface 
-{
-public:
-   OptionRegistryInterface(const string optionName, const string optionDesc) 
-      : m_optionName(optionName), m_optionDesc(optionDesc), m_isParsed(false) 
-   {}
+class OptionRegistryInterface {
+ public:
+  OptionRegistryInterface(const string optionName, const string optionDesc)
+      : m_optionName(optionName), m_optionDesc(optionDesc), m_isParsed(false) {}
 
-   virtual ~OptionRegistryInterface() {}
+  virtual ~OptionRegistryInterface() {}
 
-   const string& GetName() { return m_optionName; }
-   const string& GetDesc() { return m_optionDesc; }
-   const bool isParsed() { return m_isParsed; }
-   virtual string toString() = 0;
-   virtual bool fromString(const string str) = 0;
-   virtual bool isFlag() = 0;
-   virtual bool assignDefault(const char *str) = 0;
+  const string &GetName() { return m_optionName; }
+  const string &GetDesc() { return m_optionDesc; }
+  const bool isParsed() { return m_isParsed; }
+  virtual string toString() = 0;
+  virtual bool fromString(const string str) = 0;
+  virtual bool isFlag() = 0;
+  virtual bool assignDefault(const char *str) = 0;
 
-protected:
-   string m_optionName;
-   string m_optionDesc;
-   bool m_isParsed; // true if the target variable has been updated by fromString()
+ protected:
+  string m_optionName;
+  string m_optionDesc;
+  bool m_isParsed;  // true if the target variable has been updated by
+                    // fromString()
 };
 
 // Template for option registry - class T = specify data type of the option
 template <class T>
-class OptionRegistry : public OptionRegistryInterface 
-{
-public:
-   OptionRegistry(const string name, const string desc, T &variable)
-      : OptionRegistryInterface(name, desc), m_variable(variable)
-   {}
+class OptionRegistry : public OptionRegistryInterface {
+ public:
+  OptionRegistry(const string name, const string desc, T &variable)
+      : OptionRegistryInterface(name, desc), m_variable(variable) {}
 
-   virtual ~OptionRegistry() {}
+  virtual ~OptionRegistry() {}
 
-   virtual string toString() 
-   {
-      stringstream ss;
-      ss << m_variable;
-      return ss.str();
-   }
+  virtual string toString() {
+    stringstream ss;
+    ss << m_variable;
+    return ss.str();
+  }
 
-   virtual bool fromString(const string str)
-   {
-      stringstream ss(str);
-      ss.exceptions(stringstream::failbit | stringstream::badbit);
-      ss << setbase(10);
-      if (str.size() > 1 && str[0] == '0') {
-         if (str.size() > 2 && str[1] == 'x') { 
-            ss.ignore(2);
-            ss << setbase(16);
-         } else {
-            ss.ignore(1);
-            ss << setbase(8);
-         }
+  virtual bool fromString(const string str) {
+    stringstream ss(str);
+    ss.exceptions(stringstream::failbit | stringstream::badbit);
+    ss << setbase(10);
+    if (str.size() > 1 && str[0] == '0') {
+      if (str.size() > 2 && str[1] == 'x') {
+        ss.ignore(2);
+        ss << setbase(16);
+      } else {
+        ss.ignore(1);
+        ss << setbase(8);
       }
-      try {
-         ss >> m_variable;
-      } catch (exception &e) {
-         return false;
-      }
-      m_isParsed = true; 
-      return true;
-   }
+    }
+    try {
+      ss >> m_variable;
+    } catch (exception &e) {
+      return false;
+    }
+    m_isParsed = true;
+    return true;
+  }
 
-   virtual bool isFlag() { return false; }
-   virtual bool assignDefault(const char *str) { return fromString(str); }
+  virtual bool isFlag() { return false; }
+  virtual bool assignDefault(const char *str) { return fromString(str); }
 
-   operator T()
-   {
-      return m_variable;
-   }
+  operator T() { return m_variable; }
 
-private:
-   T &m_variable;
+ private:
+  T &m_variable;
 };
 
 // specialized parser for string-type options
-template<>
-bool OptionRegistry<string>::fromString(const string str)
-{
-   m_variable = str;
-   m_isParsed = true; 
-   return true;
+template <>
+bool OptionRegistry<string>::fromString(const string str) {
+  m_variable = str;
+  m_isParsed = true;
+  return true;
 }
 
 // specialized parser for c-string type options
-template<>
-bool OptionRegistry<char *>::fromString(const string str)
-{
-   m_variable = new char[str.size() + 1];
-   strcpy(m_variable, str.c_str());
-   m_isParsed = true; 
-   return true;
+template <>
+bool OptionRegistry<char *>::fromString(const string str) {
+  m_variable = new char[str.size() + 1];
+  strcpy(m_variable, str.c_str());
+  m_isParsed = true;
+  return true;
 }
 
 // specialized default assignment for c-string type option to allow NULL default
-template<>
-bool OptionRegistry<char *>::assignDefault(const char *str) 
-{
-    m_variable = const_cast<char *>(str); // c-string options are not meant to be edited anyway
-    m_isParsed = true; 
-    return true;
+template <>
+bool OptionRegistry<char *>::assignDefault(const char *str) {
+  m_variable = const_cast<char *>(
+      str);  // c-string options are not meant to be edited anyway
+  m_isParsed = true;
+  return true;
 }
 
 // specialized default assignment for c-string type option to allow NULL default
-template<>
-string OptionRegistry<char *>::toString() 
-{
-    stringstream ss;
-    if (m_variable != NULL) {
-        ss << m_variable;
-    } else {
-        ss << "NULL";
-    }
-    return ss.str();
+template <>
+string OptionRegistry<char *>::toString() {
+  stringstream ss;
+  if (m_variable != NULL) {
+    ss << m_variable;
+  } else {
+    ss << "NULL";
+  }
+  return ss.str();
 }
 
-// specialized parser for boolean options 
-template<>
-bool OptionRegistry<bool>::fromString(const string str)
-{
-   int value = 1;
-   bool parsed = true;
-   stringstream ss(str);
-   ss.exceptions(stringstream::failbit | stringstream::badbit);
-   try {
-      ss >> value;
-   } catch (stringstream::failure &ep) {
-      parsed = false;
-   }
-   assert(value == 0 or value == 1); // sanity check for boolean options (it can only be 1 or 0)
-   m_variable = (value != 0);
-   m_isParsed = true; 
-   return parsed;
+// specialized parser for boolean options
+template <>
+bool OptionRegistry<bool>::fromString(const string str) {
+  int value = 1;
+  bool parsed = true;
+  stringstream ss(str);
+  ss.exceptions(stringstream::failbit | stringstream::badbit);
+  try {
+    ss >> value;
+  } catch (stringstream::failure &ep) {
+    parsed = false;
+  }
+  assert(value == 0 or
+         value ==
+             1);  // sanity check for boolean options (it can only be 1 or 0)
+  m_variable = (value != 0);
+  m_isParsed = true;
+  return parsed;
 }
 
 // specializing a flag query function to identify boolean option
-template<>
-bool OptionRegistry<bool>::isFlag() { return true; }
+template <>
+bool OptionRegistry<bool>::isFlag() {
+  return true;
+}
 
-// class holding a collection of options and parse them from command line/configfile
-class OptionParser
-{
-public:
-   OptionParser() {}
-   ~OptionParser() 
-   {
-      OptionCollection::iterator i_option;
-      for (i_option = m_optionReg.begin(); i_option != m_optionReg.end(); ++i_option) {
-         delete (*i_option);
-      }
-   } 
+// class holding a collection of options and parse them from command
+// line/configfile
+class OptionParser {
+ public:
+  OptionParser() {}
+  ~OptionParser() {
+    OptionCollection::iterator i_option;
+    for (i_option = m_optionReg.begin(); i_option != m_optionReg.end();
+         ++i_option) {
+      delete (*i_option);
+    }
+  }
 
-   template<class T>
-   void Register(const string optionName, const string optionDesc, T &optionVariable, const char *optionDefault)
-   {
-      OptionRegistry<T> *p_option = new OptionRegistry<T>(optionName, optionDesc, optionVariable);
-      m_optionReg.push_back(p_option);
-      m_optionMap[optionName] = p_option;
-      p_option->assignDefault(optionDefault);
-   }
+  template <class T>
+  void Register(const string optionName, const string optionDesc,
+                T &optionVariable, const char *optionDefault) {
+    OptionRegistry<T> *p_option =
+        new OptionRegistry<T>(optionName, optionDesc, optionVariable);
+    m_optionReg.push_back(p_option);
+    m_optionMap[optionName] = p_option;
+    p_option->assignDefault(optionDefault);
+  }
 
-   void ParseCommandLine(int argc, const char * const argv[])
-   {
-      for (int i = 1; i < argc; i++) {
-         OptionMap::iterator i_option;
-         bool optionFound = false;
+  void ParseCommandLine(int argc, const char *const argv[]) {
+    for (int i = 1; i < argc; i++) {
+      OptionMap::iterator i_option;
+      bool optionFound = false;
 
-         i_option = m_optionMap.find(argv[i]);
-         if (i_option != m_optionMap.end()) {
-            const char *argstr = (i + 1 < argc)? argv[i + 1] : "";
-            OptionRegistryInterface *p_option = i_option->second;
-            if (p_option->isFlag()) { 
-               if (p_option->fromString(argstr) == true) {
-                  i += 1;
-               } 
-            } else { 
-               if (p_option->fromString(argstr) == false) {
-                  fprintf(stderr, "\n\nGPGPU-Sim ** ERROR: Cannot parse value '%s' for option '%s'.\n", argstr, argv[i]);
-                  exit(1);
-               }
-               i += 1;
-            }
-            optionFound = true;
-         } else if (string(argv[i]) == "-config") {
-            if (i + 1 >= argc) {
-               fprintf(stderr, "\n\nGPGPU-Sim ** ERROR: Missing filename for option '-config'.\n");
-               exit(1);
-            }
-
-            ParseFile(argv[i + 1]);
+      i_option = m_optionMap.find(argv[i]);
+      if (i_option != m_optionMap.end()) {
+        const char *argstr = (i + 1 < argc) ? argv[i + 1] : "";
+        OptionRegistryInterface *p_option = i_option->second;
+        if (p_option->isFlag()) {
+          if (p_option->fromString(argstr) == true) {
             i += 1;
-            optionFound = true;
-         }
-         if (optionFound == false) {
-            fprintf(stderr, "\n\nGPGPU-Sim ** ERROR: Unknown Option: '%s' \n", argv[i]);
+          }
+        } else {
+          if (p_option->fromString(argstr) == false) {
+            fprintf(stderr,
+                    "\n\nGPGPU-Sim ** ERROR: Cannot parse value '%s' for "
+                    "option '%s'.\n",
+                    argstr, argv[i]);
             exit(1);
-         }
+          }
+          i += 1;
+        }
+        optionFound = true;
+      } else if (string(argv[i]) == "-config") {
+        if (i + 1 >= argc) {
+          fprintf(stderr,
+                  "\n\nGPGPU-Sim ** ERROR: Missing filename for option "
+                  "'-config'.\n");
+          exit(1);
+        }
+
+        ParseFile(argv[i + 1]);
+        i += 1;
+        optionFound = true;
       }
-   }
-
-
-   void ParseFile(const char *filename) {
-      ifstream inputFile;
-      stringstream args;
-
-      // open config file, stream every line into a continuous buffer 
-      // get rid of comments in the process
-      inputFile.open(filename);
-      if (!inputFile.good()) {
-         fprintf(stderr, "\n\nGPGPU-Sim ** ERROR: Cannot open config file '%s'\n", filename);
-         exit(1);
+      if (optionFound == false) {
+        fprintf(stderr, "\n\nGPGPU-Sim ** ERROR: Unknown Option: '%s' \n",
+                argv[i]);
+        exit(1);
       }
-      while (inputFile.good()) {
-         string line;
-         getline(inputFile, line);
-         size_t commentStart = line.find_first_of("#");
-         if (commentStart != line.npos) {
-            line.erase(commentStart);
-         }
-         args << line << ' ';
+    }
+  }
+
+  void ParseFile(const char *filename) {
+    ifstream inputFile;
+    stringstream args;
+
+    // open config file, stream every line into a continuous buffer
+    // get rid of comments in the process
+    inputFile.open(filename);
+    if (!inputFile.good()) {
+      fprintf(stderr, "\n\nGPGPU-Sim ** ERROR: Cannot open config file '%s'\n",
+              filename);
+      exit(1);
+    }
+    while (inputFile.good()) {
+      string line;
+      getline(inputFile, line);
+      size_t commentStart = line.find_first_of("#");
+      if (commentStart != line.npos) {
+        line.erase(commentStart);
       }
-      inputFile.close();
+      args << line << ' ';
+    }
+    inputFile.close();
 
-      ParseStringStream(args); 
-   }
+    ParseStringStream(args);
+  }
 
-   // parse the given string as tokens separated by a set of given delimiters 
-   void ParseString(string inputString, const string delimiters = string(" ;")) {
-      // convert all delimiter characters into whitespaces 
-      for (unsigned t = 0; t < inputString.size(); t++) {
-         for (unsigned d = 0; d < delimiters.size(); d++) {
-            if (inputString[t] == delimiters.at(d)) {
-               inputString[t] = ' '; 
-               break; 
-            }
-         }
+  // parse the given string as tokens separated by a set of given delimiters
+  void ParseString(string inputString, const string delimiters = string(" ;")) {
+    // convert all delimiter characters into whitespaces
+    for (unsigned t = 0; t < inputString.size(); t++) {
+      for (unsigned d = 0; d < delimiters.size(); d++) {
+        if (inputString[t] == delimiters.at(d)) {
+          inputString[t] = ' ';
+          break;
+        }
       }
-      stringstream args(inputString); 
-      ParseStringStream(args); 
-   }
+    }
+    stringstream args(inputString);
+    ParseStringStream(args);
+  }
 
-   // parse the given stringstream as whitespace-separated tokens. drain the stream in the process 
-   void ParseStringStream(stringstream &args) {
-      // extract non-whitespace string tokens
-      vector<char*> argv;
-      argv.push_back(new char[6]); 
-      strcpy(argv[0], "dummy");
-      while (args.good()) {
-         string argNew;
-         args >> argNew;
+  // parse the given stringstream as whitespace-separated tokens. drain the
+  // stream in the process
+  void ParseStringStream(stringstream &args) {
+    // extract non-whitespace string tokens
+    vector<char *> argv;
+    argv.push_back(new char[6]);
+    strcpy(argv[0], "dummy");
+    while (args.good()) {
+      string argNew;
+      args >> argNew;
 
-         if (argNew.size() == 0) continue; // this is probably the last token
+      if (argNew.size() == 0) continue;  // this is probably the last token
 
-         if (argNew[0] == '"') {
-            while (args.good() && argNew[argNew.size()-1] != '"') {
-               string argCont;
-               args >> argCont;
-               argNew += " " + argCont;
-            }
-            argNew.erase(0,1);
-            argNew.erase(argNew.size()-1);
-         }
-
-         char *c_argNew = new char[argNew.size() + 1];
-         strcpy(c_argNew, argNew.c_str());
-         argv.push_back(c_argNew);
+      if (argNew[0] == '"') {
+        while (args.good() && argNew[argNew.size() - 1] != '"') {
+          string argCont;
+          args >> argCont;
+          argNew += " " + argCont;
+        }
+        argNew.erase(0, 1);
+        argNew.erase(argNew.size() - 1);
       }
 
-      // pass the string token into normal commandline parser
-      char **targv = (char**)calloc(argv.size(), sizeof(char*));
-      for( unsigned k=0; k < argv.size(); k++ ) 
-         targv[k] = argv[k];
-      ParseCommandLine(argv.size(), targv);
-      free(targv);
-      for (size_t i = 0; i < argv.size(); i++) {
-         delete[] argv[i];
-      }
-   }
+      char *c_argNew = new char[argNew.size() + 1];
+      strcpy(c_argNew, argNew.c_str());
+      argv.push_back(c_argNew);
+    }
 
-   void Print(FILE *fout)
-   {
-      OptionCollection::iterator i_option;
-      for (i_option = m_optionReg.begin(); i_option != m_optionReg.end(); ++i_option) {
-         stringstream sout;
-         if ((*i_option)->isParsed() == false) {
-            cerr << "\n\nGPGPU-Sim ** ERROR: Missing option '" << (*i_option)->GetName() << "'\n"; 
-            assert(0); 
-         }
-         sout << setw(20) << left << (*i_option)->GetName() << " "; 
-         sout << setw(20) << right << (*i_option)->toString() << " # ";
-         sout << left << (*i_option)->GetDesc();
-         sout << std::endl;
-         fprintf(fout, "%s", sout.str().c_str());
-      }
-   }
+    // pass the string token into normal commandline parser
+    char **targv = (char **)calloc(argv.size(), sizeof(char *));
+    for (unsigned k = 0; k < argv.size(); k++) targv[k] = argv[k];
+    ParseCommandLine(argv.size(), targv);
+    free(targv);
+    for (size_t i = 0; i < argv.size(); i++) {
+      delete[] argv[i];
+    }
+  }
 
-private:
-   typedef list<OptionRegistryInterface*> OptionCollection;
-   OptionCollection m_optionReg;
-   typedef map<string, OptionRegistryInterface*> OptionMap;
-   OptionMap m_optionMap;
+  void Print(FILE *fout) {
+    OptionCollection::iterator i_option;
+    for (i_option = m_optionReg.begin(); i_option != m_optionReg.end();
+         ++i_option) {
+      stringstream sout;
+      if ((*i_option)->isParsed() == false) {
+        cerr << "\n\nGPGPU-Sim ** ERROR: Missing option '"
+             << (*i_option)->GetName() << "'\n";
+        assert(0);
+      }
+      sout << setw(20) << left << (*i_option)->GetName() << " ";
+      sout << setw(20) << right << (*i_option)->toString() << " # ";
+      sout << left << (*i_option)->GetDesc();
+      sout << std::endl;
+      fprintf(fout, "%s", sout.str().c_str());
+    }
+  }
+
+ private:
+  typedef list<OptionRegistryInterface *> OptionCollection;
+  OptionCollection m_optionReg;
+  typedef map<string, OptionRegistryInterface *> OptionMap;
+  OptionMap m_optionMap;
 };
 
 #include "option_parser.h"
 
-option_parser_t option_parser_create() 
-{
-   OptionParser *p_opr = new OptionParser();
-   return reinterpret_cast<option_parser_t>(p_opr);
+option_parser_t option_parser_create() {
+  OptionParser *p_opr = new OptionParser();
+  return reinterpret_cast<option_parser_t>(p_opr);
 }
 
-void option_parser_destroy(option_parser_t opp)
-{
-   OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
-   delete p_opr;
+void option_parser_destroy(option_parser_t opp) {
+  OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
+  delete p_opr;
 }
 
-void option_parser_register(option_parser_t opp, 
-                            const char *name, 
-                            enum option_dtype type, 
-                            void *variable, 
-                            const char *desc,  
-                            const char *defaultvalue)
-{
-   OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
-   switch (type) {
-      case OPT_INT32:     p_opr->Register<int>(name, desc, *(int*)variable, defaultvalue); break;
-      case OPT_UINT32:    p_opr->Register<unsigned int>(name, desc, *(unsigned int*)variable, defaultvalue); break;
-      case OPT_INT64:     p_opr->Register<long long>(name, desc, *(long long*)variable, defaultvalue); break;
-      case OPT_UINT64:    p_opr->Register<unsigned long long>(name, desc, *(unsigned long long*)variable, defaultvalue); break;
-      case OPT_BOOL:      p_opr->Register<bool>(name, desc, *(bool*)variable, defaultvalue); break;
-      case OPT_FLOAT:     p_opr->Register<float>(name, desc, *(float*)variable, defaultvalue); break;
-      case OPT_DOUBLE:    p_opr->Register<double>(name, desc, *(double*)variable, defaultvalue); break;
-      case OPT_CHAR:      p_opr->Register<char>(name, desc, *(char*)variable, defaultvalue); break;
-      case OPT_CSTR:      p_opr->Register<char*>(name, desc, *(char**)variable, defaultvalue); break;
-        default:
-            fprintf(stderr, "\n\nGPGPU-Sim ** ERROR: option data type (%d) not supported!\n", type);
-            exit(1);
-            break;
-    }
+void option_parser_register(option_parser_t opp, const char *name,
+                            enum option_dtype type, void *variable,
+                            const char *desc, const char *defaultvalue) {
+  OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
+  switch (type) {
+    case OPT_INT32:
+      p_opr->Register<int>(name, desc, *(int *)variable, defaultvalue);
+      break;
+    case OPT_UINT32:
+      p_opr->Register<unsigned int>(name, desc, *(unsigned int *)variable,
+                                    defaultvalue);
+      break;
+    case OPT_INT64:
+      p_opr->Register<long long>(name, desc, *(long long *)variable,
+                                 defaultvalue);
+      break;
+    case OPT_UINT64:
+      p_opr->Register<unsigned long long>(
+          name, desc, *(unsigned long long *)variable, defaultvalue);
+      break;
+    case OPT_BOOL:
+      p_opr->Register<bool>(name, desc, *(bool *)variable, defaultvalue);
+      break;
+    case OPT_FLOAT:
+      p_opr->Register<float>(name, desc, *(float *)variable, defaultvalue);
+      break;
+    case OPT_DOUBLE:
+      p_opr->Register<double>(name, desc, *(double *)variable, defaultvalue);
+      break;
+    case OPT_CHAR:
+      p_opr->Register<char>(name, desc, *(char *)variable, defaultvalue);
+      break;
+    case OPT_CSTR:
+      p_opr->Register<char *>(name, desc, *(char **)variable, defaultvalue);
+      break;
+    default:
+      fprintf(stderr,
+              "\n\nGPGPU-Sim ** ERROR: option data type (%d) not supported!\n",
+              type);
+      exit(1);
+      break;
+  }
 }
 
-void option_parser_cmdline(option_parser_t opp,
-                           int argc, const char *argv[])
-{
-    OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
-    return p_opr->ParseCommandLine(argc,argv);
-
+void option_parser_cmdline(option_parser_t opp, int argc, const char *argv[]) {
+  OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
+  return p_opr->ParseCommandLine(argc, argv);
 }
 
-
-void option_parser_cfgfile(option_parser_t opp,
-                           const char *filename)
-{
-    OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
-    p_opr->ParseFile(filename);
+void option_parser_cfgfile(option_parser_t opp, const char *filename) {
+  OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
+  p_opr->ParseFile(filename);
 }
 
 void option_parser_delimited_string(option_parser_t opp,
-                                    const char *inputstring, 
-                                    const char *delimiters)
-{
-    OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
-    p_opr->ParseString(inputstring, delimiters);
+                                    const char *inputstring,
+                                    const char *delimiters) {
+  OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
+  p_opr->ParseString(inputstring, delimiters);
 }
 
-void option_parser_print(option_parser_t opp, 
-                         FILE *fout)
-{
-    OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
-    p_opr->Print(fout);
+void option_parser_print(option_parser_t opp, FILE *fout) {
+  OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
+  p_opr->Print(fout);
 }
-
-
 
 // #define UNIT_TEST
 #ifdef UNIT_TEST
 
-class testtype
-{
-public:
-   int idata;
-   float fdata;
-   string sdata;
-   unsigned long long ulldata;
-   bool bdata;
-   unsigned int boolint;
-   char * coption;
+class testtype {
+ public:
+  int idata;
+  float fdata;
+  string sdata;
+  unsigned long long ulldata;
+  bool bdata;
+  unsigned int boolint;
+  char *coption;
 
-   testtype() 
-      : idata(0), 
-        fdata(0.0f), 
-        sdata(""),
-        ulldata(0),
-        bdata(false)
-   { }
+  testtype() : idata(0), fdata(0.0f), sdata(""), ulldata(0), bdata(false) {}
 };
 
+int cppinterfacetest(int argc, const char *argv[]) {
+  testtype c;
+  OptionParser optionparser;
+  c.idata = 123;
+  c.fdata = 3249586.333;
+  c.sdata = string("haha");
 
-int cppinterfacetest(int argc, const char *argv[])
-{
-   testtype c;
-   OptionParser optionparser;
-   c.idata = 123;
-   c.fdata = 3249586.333;
-   c.sdata = string("haha");
+  optionparser.Register<int>("-idata", "integer data", c.idata, "-456");
+  optionparser.Register<float>("-fdata", "floating point data", c.fdata,
+                               "0.001");
+  optionparser.Register<string>("-sdata", "first string data", c.sdata,
+                                "hellow");
+  optionparser.Register<unsigned long long>(
+      "-ulldata", "unsigned long long data", c.ulldata, "0x123456789abcdef1");
+  optionparser.Register<bool>("-someflag", "first flag", c.bdata, "0");
+  optionparser.Register<bool>("-otherflag", "second flag", (bool &)c.boolint,
+                              "1");
+  optionparser.Register<char *>("-coption", "char * data", c.coption, NULL);
 
-   optionparser.Register<int>("-idata", "integer data", c.idata, "-456");
-   optionparser.Register<float>("-fdata", "floating point data", c.fdata, "0.001");
-   optionparser.Register<string>("-sdata", "first string data", c.sdata, "hellow");
-   optionparser.Register<unsigned long long>("-ulldata", "unsigned long long data", c.ulldata, "0x123456789abcdef1");
-   optionparser.Register<bool>("-someflag", "first flag", c.bdata, "0");
-   optionparser.Register<bool>("-otherflag", "second flag", (bool&)c.boolint, "1");
-   optionparser.Register<char *>("-coption", "char * data", c.coption, NULL);
+  cout << "Default: \n";
+  optionparser.Print(stdout);
 
-   cout << "Default: \n";
-   optionparser.Print(stdout);
+  optionparser.ParseCommandLine(argc, argv);
 
-   optionparser.ParseCommandLine(argc, argv);
+  cout << "Commandline Parse Results: \n";
+  optionparser.Print(stdout);
 
-   cout << "Commandline Parse Results: \n";
-   optionparser.Print(stdout);
+  optionparser.ParseFile("test.config");
+  cout << "File Parse Results: \n";
+  optionparser.Print(stdout);
+  cout << c.sdata << ' ' << c.idata << endl;
 
-   optionparser.ParseFile("test.config");
-   cout << "File Parse Results: \n";
-   optionparser.Print(stdout);
-   cout << c.sdata << ' ' << c.idata << endl;
-
-   return 0;
+  return 0;
 }
 
-int cinterfacetest(int argc, const char *argv[])
-{
-   testtype c;
-   option_parser_t opp = option_parser_create();
-   c.idata = 123;
-   c.fdata = 3249586.333;
-   c.sdata = string("haha");
-   char *otherstr;
+int cinterfacetest(int argc, const char *argv[]) {
+  testtype c;
+  option_parser_t opp = option_parser_create();
+  c.idata = 123;
+  c.fdata = 3249586.333;
+  c.sdata = string("haha");
+  char *otherstr;
 
-   option_parser_register(opp, "-idata", OPT_INT32, &c.idata, "integer data", "-456");
-   option_parser_register(opp, "-fdata", OPT_FLOAT, &c.fdata, "floating point data", "0.001");
-   option_parser_register(opp, "-sdata", OPT_CSTR, &otherstr, "first string data", "hellow");
-   option_parser_register(opp, "-ulldata", OPT_UINT64, &c.ulldata, "unsigend long long data", "0x123456789abcdef1");
-   option_parser_register(opp, "-someflag", OPT_BOOL, &c.bdata, "first flag", "0");
-   option_parser_register(opp, "-otherflag", OPT_BOOL, &c.boolint, "second flag", "1");
-   option_parser_register(opp, "-coption", OPT_CSTR, &c.coption, "char * data", NULL);
+  option_parser_register(opp, "-idata", OPT_INT32, &c.idata, "integer data",
+                         "-456");
+  option_parser_register(opp, "-fdata", OPT_FLOAT, &c.fdata,
+                         "floating point data", "0.001");
+  option_parser_register(opp, "-sdata", OPT_CSTR, &otherstr,
+                         "first string data", "hellow");
+  option_parser_register(opp, "-ulldata", OPT_UINT64, &c.ulldata,
+                         "unsigend long long data", "0x123456789abcdef1");
+  option_parser_register(opp, "-someflag", OPT_BOOL, &c.bdata, "first flag",
+                         "0");
+  option_parser_register(opp, "-otherflag", OPT_BOOL, &c.boolint, "second flag",
+                         "1");
+  option_parser_register(opp, "-coption", OPT_CSTR, &c.coption, "char * data",
+                         NULL);
 
-   printf("Default: \n");
-   option_parser_print(opp, stdout);
+  printf("Default: \n");
+  option_parser_print(opp, stdout);
 
-   option_parser_cmdline(opp, argc, argv);
+  option_parser_cmdline(opp, argc, argv);
 
-   printf("Commandline Parse Results: \n");
-   option_parser_print(opp, stdout);
+  printf("Commandline Parse Results: \n");
+  option_parser_print(opp, stdout);
 
-   option_parser_cfgfile(opp, "test.config");
-   printf("File Parse Results: \n");
-   option_parser_print(opp, stdout);
-   printf("%s %d\n", otherstr, c.idata);
+  option_parser_cfgfile(opp, "test.config");
+  printf("File Parse Results: \n");
+  option_parser_print(opp, stdout);
+  printf("%s %d\n", otherstr, c.idata);
 
-   option_parser_destroy(opp);
+  option_parser_destroy(opp);
 
-   return 0;
+  return 0;
 }
 
-int stringparsertest()
-{
-   int tABC; 
-   int tDEF; 
-   char tMode;
-   char *tName; 
+int stringparsertest() {
+  int tABC;
+  int tDEF;
+  char tMode;
+  char *tName;
 
-   option_parser_t opp = option_parser_create();
-   option_parser_register(opp, "ABC", OPT_INT32, &tABC, "tABC", "34");
-   option_parser_register(opp, "DEF", OPT_INT32, &tDEF, "tDEF", "-56");
-   option_parser_register(opp, "Mode", OPT_CHAR, &tMode, "tMode", "P");
-   option_parser_register(opp, "Name", OPT_CSTR, &tName, "tName", "Cache");
+  option_parser_t opp = option_parser_create();
+  option_parser_register(opp, "ABC", OPT_INT32, &tABC, "tABC", "34");
+  option_parser_register(opp, "DEF", OPT_INT32, &tDEF, "tDEF", "-56");
+  option_parser_register(opp, "Mode", OPT_CHAR, &tMode, "tMode", "P");
+  option_parser_register(opp, "Name", OPT_CSTR, &tName, "tName", "Cache");
 
-   option_parser_delimited_string(opp, "ABC 1111; DEF 88; Mode A; Name out", " ;");
-   printf("String Parse Results: \n");
-   option_parser_print(opp, stdout);
+  option_parser_delimited_string(opp, "ABC 1111; DEF 88; Mode A; Name out",
+                                 " ;");
+  printf("String Parse Results: \n");
+  option_parser_print(opp, stdout);
 
-   option_parser_delimited_string(opp, "Name=dram;DEF=702;Mode=B;ABC=-9573;", " =;");
-   printf("String Parse Results: \n");
-   option_parser_print(opp, stdout);
+  option_parser_delimited_string(opp, "Name=dram;DEF=702;Mode=B;ABC=-9573;",
+                                 " =;");
+  printf("String Parse Results: \n");
+  option_parser_print(opp, stdout);
 
-   return 0; 
+  return 0;
 }
 
-int main(int argc, const char *argv[]) 
-{
-    cppinterfacetest(argc,argv);
-    cinterfacetest(argc,argv);
-    stringparsertest(); 
+int main(int argc, const char *argv[]) {
+  cppinterfacetest(argc, argv);
+  cinterfacetest(argc, argv);
+  stringparsertest();
 
-    return 0;
+  return 0;
 }
 
 #endif
-

--- a/src/option_parser.cc
+++ b/src/option_parser.cc
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -25,523 +27,527 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include "option_parser.h"
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <assert.h>
-#include <string>
-#include <iostream>
-#include <iomanip>
-#include <sstream>
+#include <string.h>
 #include <fstream>
-#include <vector>
+#include <iomanip>
+#include <iostream>
 #include <list>
 #include <map>
-#include <string.h>
-#include "option_parser.h"
-
+#include <sstream>
+#include <string>
+#include <vector>
 
 using namespace std;
 
 // A generic option registry regardless of data type
-class OptionRegistryInterface 
-{
-public:
-   OptionRegistryInterface(const string optionName, const string optionDesc) 
-      : m_optionName(optionName), m_optionDesc(optionDesc), m_isParsed(false) 
-   {}
+class OptionRegistryInterface {
+ public:
+  OptionRegistryInterface(const string optionName, const string optionDesc)
+      : m_optionName(optionName), m_optionDesc(optionDesc), m_isParsed(false) {}
 
-   virtual ~OptionRegistryInterface() {}
+  virtual ~OptionRegistryInterface() {}
 
-   const string& GetName() { return m_optionName; }
-   const string& GetDesc() { return m_optionDesc; }
-   const bool isParsed() { return m_isParsed; }
-   virtual string toString() = 0;
-   virtual bool fromString(const string str) = 0;
-   virtual bool isFlag() = 0;
-   virtual bool assignDefault(const char *str) = 0;
+  const string &GetName() { return m_optionName; }
+  const string &GetDesc() { return m_optionDesc; }
+  const bool isParsed() { return m_isParsed; }
+  virtual string toString() = 0;
+  virtual bool fromString(const string str) = 0;
+  virtual bool isFlag() = 0;
+  virtual bool assignDefault(const char *str) = 0;
 
-protected:
-   string m_optionName;
-   string m_optionDesc;
-   bool m_isParsed; // true if the target variable has been updated by fromString()
+ protected:
+  string m_optionName;
+  string m_optionDesc;
+  bool m_isParsed;  // true if the target variable has been updated by
+                    // fromString()
 };
 
 // Template for option registry - class T = specify data type of the option
 template <class T>
-class OptionRegistry : public OptionRegistryInterface 
-{
-public:
-   OptionRegistry(const string name, const string desc, T &variable)
-      : OptionRegistryInterface(name, desc), m_variable(variable)
-   {}
+class OptionRegistry : public OptionRegistryInterface {
+ public:
+  OptionRegistry(const string name, const string desc, T &variable)
+      : OptionRegistryInterface(name, desc), m_variable(variable) {}
 
-   virtual ~OptionRegistry() {}
+  virtual ~OptionRegistry() {}
 
-   virtual string toString() 
-   {
-      stringstream ss;
-      ss << m_variable;
-      return ss.str();
-   }
+  virtual string toString() {
+    stringstream ss;
+    ss << m_variable;
+    return ss.str();
+  }
 
-   virtual bool fromString(const string str)
-   {
-      stringstream ss(str);
-      ss.exceptions(stringstream::failbit | stringstream::badbit);
-      ss << setbase(10);
-      if (str.size() > 1 && str[0] == '0') {
-         if (str.size() > 2 && str[1] == 'x') { 
-            ss.ignore(2);
-            ss << setbase(16);
-         } else {
-            ss.ignore(1);
-            ss << setbase(8);
-         }
+  virtual bool fromString(const string str) {
+    stringstream ss(str);
+    ss.exceptions(stringstream::failbit | stringstream::badbit);
+    ss << setbase(10);
+    if (str.size() > 1 && str[0] == '0') {
+      if (str.size() > 2 && str[1] == 'x') {
+        ss.ignore(2);
+        ss << setbase(16);
+      } else {
+        ss.ignore(1);
+        ss << setbase(8);
       }
-      try {
-         ss >> m_variable;
-      } catch (exception &e) {
-         return false;
-      }
-      m_isParsed = true; 
-      return true;
-   }
+    }
+    try {
+      ss >> m_variable;
+    } catch (exception &e) {
+      return false;
+    }
+    m_isParsed = true;
+    return true;
+  }
 
-   virtual bool isFlag() { return false; }
-   virtual bool assignDefault(const char *str) { return fromString(str); }
+  virtual bool isFlag() { return false; }
+  virtual bool assignDefault(const char *str) { return fromString(str); }
 
-   operator T()
-   {
-      return m_variable;
-   }
+  operator T() { return m_variable; }
 
-private:
-   T &m_variable;
+ private:
+  T &m_variable;
 };
 
 // specialized parser for string-type options
-template<>
-bool OptionRegistry<string>::fromString(const string str)
-{
-   m_variable = str;
-   m_isParsed = true; 
-   return true;
+template <>
+bool OptionRegistry<string>::fromString(const string str) {
+  m_variable = str;
+  m_isParsed = true;
+  return true;
 }
 
 // specialized parser for c-string type options
-template<>
-bool OptionRegistry<char *>::fromString(const string str)
-{
-   m_variable = new char[str.size() + 1];
-   strcpy(m_variable, str.c_str());
-   m_isParsed = true; 
-   return true;
+template <>
+bool OptionRegistry<char *>::fromString(const string str) {
+  m_variable = new char[str.size() + 1];
+  strcpy(m_variable, str.c_str());
+  m_isParsed = true;
+  return true;
 }
 
 // specialized default assignment for c-string type option to allow NULL default
-template<>
-bool OptionRegistry<char *>::assignDefault(const char *str) 
-{
-    m_variable = const_cast<char *>(str); // c-string options are not meant to be edited anyway
-    m_isParsed = true; 
-    return true;
+template <>
+bool OptionRegistry<char *>::assignDefault(const char *str) {
+  m_variable = const_cast<char *>(
+      str);  // c-string options are not meant to be edited anyway
+  m_isParsed = true;
+  return true;
 }
 
 // specialized default assignment for c-string type option to allow NULL default
-template<>
-string OptionRegistry<char *>::toString() 
-{
-    stringstream ss;
-    if (m_variable != NULL) {
-        ss << m_variable;
-    } else {
-        ss << "NULL";
-    }
-    return ss.str();
+template <>
+string OptionRegistry<char *>::toString() {
+  stringstream ss;
+  if (m_variable != NULL) {
+    ss << m_variable;
+  } else {
+    ss << "NULL";
+  }
+  return ss.str();
 }
 
-// specialized parser for boolean options 
-template<>
-bool OptionRegistry<bool>::fromString(const string str)
-{
-   int value = 1;
-   bool parsed = true;
-   stringstream ss(str);
-   ss.exceptions(stringstream::failbit | stringstream::badbit);
-   try {
-      ss >> value;
-   } catch (stringstream::failure &ep) {
-      parsed = false;
-   }
-   assert(value == 0 or value == 1); // sanity check for boolean options (it can only be 1 or 0)
-   m_variable = (value != 0);
-   m_isParsed = true; 
-   return parsed;
+// specialized parser for boolean options
+template <>
+bool OptionRegistry<bool>::fromString(const string str) {
+  int value = 1;
+  bool parsed = true;
+  stringstream ss(str);
+  ss.exceptions(stringstream::failbit | stringstream::badbit);
+  try {
+    ss >> value;
+  } catch (stringstream::failure &ep) {
+    parsed = false;
+  }
+  assert(value == 0 or
+         value ==
+             1);  // sanity check for boolean options (it can only be 1 or 0)
+  m_variable = (value != 0);
+  m_isParsed = true;
+  return parsed;
 }
 
 // specializing a flag query function to identify boolean option
-template<>
-bool OptionRegistry<bool>::isFlag() { return true; }
+template <>
+bool OptionRegistry<bool>::isFlag() {
+  return true;
+}
 
-// class holding a collection of options and parse them from command line/configfile
-class OptionParser
-{
-public:
-   OptionParser() {}
-   ~OptionParser() 
-   {
-      OptionCollection::iterator i_option;
-      for (i_option = m_optionReg.begin(); i_option != m_optionReg.end(); ++i_option) {
-         delete (*i_option);
-      }
-   } 
+// class holding a collection of options and parse them from command
+// line/configfile
+class OptionParser {
+ public:
+  OptionParser() {}
+  ~OptionParser() {
+    OptionCollection::iterator i_option;
+    for (i_option = m_optionReg.begin(); i_option != m_optionReg.end();
+         ++i_option) {
+      delete (*i_option);
+    }
+  }
 
-   template<class T>
-   void Register(const string optionName, const string optionDesc, T &optionVariable, const char *optionDefault)
-   {
-      OptionRegistry<T> *p_option = new OptionRegistry<T>(optionName, optionDesc, optionVariable);
-      m_optionReg.push_back(p_option);
-      m_optionMap[optionName] = p_option;
-      p_option->assignDefault(optionDefault);
-   }
+  template <class T>
+  void Register(const string optionName, const string optionDesc,
+                T &optionVariable, const char *optionDefault) {
+    OptionRegistry<T> *p_option =
+        new OptionRegistry<T>(optionName, optionDesc, optionVariable);
+    m_optionReg.push_back(p_option);
+    m_optionMap[optionName] = p_option;
+    p_option->assignDefault(optionDefault);
+  }
 
-   void ParseCommandLine(int argc, const char * const argv[])
-   {
-      for (int i = 1; i < argc; i++) {
-         OptionMap::iterator i_option;
-         bool optionFound = false;
+  void ParseCommandLine(int argc, const char *const argv[]) {
+    for (int i = 1; i < argc; i++) {
+      OptionMap::iterator i_option;
+      bool optionFound = false;
 
-         i_option = m_optionMap.find(argv[i]);
-         if (i_option != m_optionMap.end()) {
-            const char *argstr = (i + 1 < argc)? argv[i + 1] : "";
-            OptionRegistryInterface *p_option = i_option->second;
-            if (p_option->isFlag()) { 
-               if (p_option->fromString(argstr) == true) {
-                  i += 1;
-               } 
-            } else { 
-               if (p_option->fromString(argstr) == false) {
-                  fprintf(stderr, "\n\nGPGPU-Sim ** ERROR: Cannot parse value '%s' for option '%s'.\n", argstr, argv[i]);
-                  exit(1);
-               }
-               i += 1;
-            }
-            optionFound = true;
-         } else if (string(argv[i]) == "-config") {
-            if (i + 1 >= argc) {
-               fprintf(stderr, "\n\nGPGPU-Sim ** ERROR: Missing filename for option '-config'.\n");
-               exit(1);
-            }
-
-            ParseFile(argv[i + 1]);
+      i_option = m_optionMap.find(argv[i]);
+      if (i_option != m_optionMap.end()) {
+        const char *argstr = (i + 1 < argc) ? argv[i + 1] : "";
+        OptionRegistryInterface *p_option = i_option->second;
+        if (p_option->isFlag()) {
+          if (p_option->fromString(argstr) == true) {
             i += 1;
-            optionFound = true;
-         }
-         if (optionFound == false) {
-            fprintf(stderr, "\n\nGPGPU-Sim ** ERROR: Unknown Option: '%s' \n", argv[i]);
+          }
+        } else {
+          if (p_option->fromString(argstr) == false) {
+            fprintf(stderr,
+                    "\n\nGPGPU-Sim ** ERROR: Cannot parse value '%s' for "
+                    "option '%s'.\n",
+                    argstr, argv[i]);
             exit(1);
-         }
+          }
+          i += 1;
+        }
+        optionFound = true;
+      } else if (string(argv[i]) == "-config") {
+        if (i + 1 >= argc) {
+          fprintf(stderr,
+                  "\n\nGPGPU-Sim ** ERROR: Missing filename for option "
+                  "'-config'.\n");
+          exit(1);
+        }
+
+        ParseFile(argv[i + 1]);
+        i += 1;
+        optionFound = true;
       }
-   }
-
-
-   void ParseFile(const char *filename) {
-      ifstream inputFile;
-      stringstream args;
-
-      // open config file, stream every line into a continuous buffer 
-      // get rid of comments in the process
-      inputFile.open(filename);
-      if (!inputFile.good()) {
-         fprintf(stderr, "\n\nGPGPU-Sim ** ERROR: Cannot open config file '%s'\n", filename);
-         exit(1);
+      if (optionFound == false) {
+        fprintf(stderr, "\n\nGPGPU-Sim ** ERROR: Unknown Option: '%s' \n",
+                argv[i]);
+        exit(1);
       }
-      while (inputFile.good()) {
-         string line;
-         getline(inputFile, line);
-         size_t commentStart = line.find_first_of("#");
-         if (commentStart != line.npos) {
-            line.erase(commentStart);
-         }
-         args << line << ' ';
+    }
+  }
+
+  void ParseFile(const char *filename) {
+    ifstream inputFile;
+    stringstream args;
+
+    // open config file, stream every line into a continuous buffer
+    // get rid of comments in the process
+    inputFile.open(filename);
+    if (!inputFile.good()) {
+      fprintf(stderr, "\n\nGPGPU-Sim ** ERROR: Cannot open config file '%s'\n",
+              filename);
+      exit(1);
+    }
+    while (inputFile.good()) {
+      string line;
+      getline(inputFile, line);
+      size_t commentStart = line.find_first_of("#");
+      if (commentStart != line.npos) {
+        line.erase(commentStart);
       }
-      inputFile.close();
+      args << line << ' ';
+    }
+    inputFile.close();
 
-      ParseStringStream(args); 
-   }
+    ParseStringStream(args);
+  }
 
-   // parse the given string as tokens separated by a set of given delimiters 
-   void ParseString(string inputString, const string delimiters = string(" ;")) {
-      // convert all delimiter characters into whitespaces 
-      for (unsigned t = 0; t < inputString.size(); t++) {
-         for (unsigned d = 0; d < delimiters.size(); d++) {
-            if (inputString[t] == delimiters.at(d)) {
-               inputString[t] = ' '; 
-               break; 
-            }
-         }
+  // parse the given string as tokens separated by a set of given delimiters
+  void ParseString(string inputString, const string delimiters = string(" ;")) {
+    // convert all delimiter characters into whitespaces
+    for (unsigned t = 0; t < inputString.size(); t++) {
+      for (unsigned d = 0; d < delimiters.size(); d++) {
+        if (inputString[t] == delimiters.at(d)) {
+          inputString[t] = ' ';
+          break;
+        }
       }
-      stringstream args(inputString); 
-      ParseStringStream(args); 
-   }
+    }
+    stringstream args(inputString);
+    ParseStringStream(args);
+  }
 
-   // parse the given stringstream as whitespace-separated tokens. drain the stream in the process 
-   void ParseStringStream(stringstream &args) {
-      // extract non-whitespace string tokens
-      vector<char*> argv;
-      argv.push_back(new char[6]); 
-      strcpy(argv[0], "dummy");
-      while (args.good()) {
-         string argNew;
-         args >> argNew;
+  // parse the given stringstream as whitespace-separated tokens. drain the
+  // stream in the process
+  void ParseStringStream(stringstream &args) {
+    // extract non-whitespace string tokens
+    vector<char *> argv;
+    argv.push_back(new char[6]);
+    strcpy(argv[0], "dummy");
+    while (args.good()) {
+      string argNew;
+      args >> argNew;
 
-         if (argNew.size() == 0) continue; // this is probably the last token
+      if (argNew.size() == 0) continue;  // this is probably the last token
 
-         if (argNew[0] == '"') {
-            while (args.good() && argNew[argNew.size()-1] != '"') {
-               string argCont;
-               args >> argCont;
-               argNew += " " + argCont;
-            }
-            argNew.erase(0,1);
-            argNew.erase(argNew.size()-1);
-         }
-
-         char *c_argNew = new char[argNew.size() + 1];
-         strcpy(c_argNew, argNew.c_str());
-         argv.push_back(c_argNew);
+      if (argNew[0] == '"') {
+        while (args.good() && argNew[argNew.size() - 1] != '"') {
+          string argCont;
+          args >> argCont;
+          argNew += " " + argCont;
+        }
+        argNew.erase(0, 1);
+        argNew.erase(argNew.size() - 1);
       }
 
-      // pass the string token into normal commandline parser
-      char **targv = (char**)calloc(argv.size(), sizeof(char*));
-      for( unsigned k=0; k < argv.size(); k++ ) 
-         targv[k] = argv[k];
-      ParseCommandLine(argv.size(), targv);
-      free(targv);
-      for (size_t i = 0; i < argv.size(); i++) {
-         delete[] argv[i];
-      }
-   }
+      char *c_argNew = new char[argNew.size() + 1];
+      strcpy(c_argNew, argNew.c_str());
+      argv.push_back(c_argNew);
+    }
 
-   void Print(FILE *fout)
-   {
-      OptionCollection::iterator i_option;
-      for (i_option = m_optionReg.begin(); i_option != m_optionReg.end(); ++i_option) {
-         stringstream sout;
-         if ((*i_option)->isParsed() == false) {
-            cerr << "\n\nGPGPU-Sim ** ERROR: Missing option '" << (*i_option)->GetName() << "'\n"; 
-            assert(0); 
-         }
-         sout << setw(20) << left << (*i_option)->GetName() << " "; 
-         sout << setw(20) << right << (*i_option)->toString() << " # ";
-         sout << left << (*i_option)->GetDesc();
-         sout << std::endl;
-         fprintf(fout, "%s", sout.str().c_str());
-      }
-   }
+    // pass the string token into normal commandline parser
+    char **targv = (char **)calloc(argv.size(), sizeof(char *));
+    for (unsigned k = 0; k < argv.size(); k++) targv[k] = argv[k];
+    ParseCommandLine(argv.size(), targv);
+    free(targv);
+    for (size_t i = 0; i < argv.size(); i++) {
+      delete[] argv[i];
+    }
+  }
 
-private:
-   typedef list<OptionRegistryInterface*> OptionCollection;
-   OptionCollection m_optionReg;
-   typedef map<string, OptionRegistryInterface*> OptionMap;
-   OptionMap m_optionMap;
+  void Print(FILE *fout) {
+    OptionCollection::iterator i_option;
+    for (i_option = m_optionReg.begin(); i_option != m_optionReg.end();
+         ++i_option) {
+      stringstream sout;
+      if ((*i_option)->isParsed() == false) {
+        cerr << "\n\nGPGPU-Sim ** ERROR: Missing option '"
+             << (*i_option)->GetName() << "'\n";
+        assert(0);
+      }
+      sout << setw(20) << left << (*i_option)->GetName() << " ";
+      sout << setw(20) << right << (*i_option)->toString() << " # ";
+      sout << left << (*i_option)->GetDesc();
+      sout << std::endl;
+      fprintf(fout, "%s", sout.str().c_str());
+    }
+  }
+
+ private:
+  typedef list<OptionRegistryInterface *> OptionCollection;
+  OptionCollection m_optionReg;
+  typedef map<string, OptionRegistryInterface *> OptionMap;
+  OptionMap m_optionMap;
 };
 
 #include "option_parser.h"
 
-option_parser_t option_parser_create() 
-{
-   OptionParser *p_opr = new OptionParser();
-   return reinterpret_cast<option_parser_t>(p_opr);
+option_parser_t option_parser_create() {
+  OptionParser *p_opr = new OptionParser();
+  return reinterpret_cast<option_parser_t>(p_opr);
 }
 
-void option_parser_destroy(option_parser_t opp)
-{
-   OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
-   delete p_opr;
+void option_parser_destroy(option_parser_t opp) {
+  OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
+  delete p_opr;
 }
 
-void option_parser_register(option_parser_t opp, 
-                            const char *name, 
-                            enum option_dtype type, 
-                            void *variable, 
-                            const char *desc,  
-                            const char *defaultvalue)
-{
-   OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
-   switch (type) {
-      case OPT_INT32:     p_opr->Register<int>(name, desc, *(int*)variable, defaultvalue); break;
-      case OPT_UINT32:    p_opr->Register<unsigned int>(name, desc, *(unsigned int*)variable, defaultvalue); break;
-      case OPT_INT64:     p_opr->Register<long long>(name, desc, *(long long*)variable, defaultvalue); break;
-      case OPT_UINT64:    p_opr->Register<unsigned long long>(name, desc, *(unsigned long long*)variable, defaultvalue); break;
-      case OPT_BOOL:      p_opr->Register<bool>(name, desc, *(bool*)variable, defaultvalue); break;
-      case OPT_FLOAT:     p_opr->Register<float>(name, desc, *(float*)variable, defaultvalue); break;
-      case OPT_DOUBLE:    p_opr->Register<double>(name, desc, *(double*)variable, defaultvalue); break;
-      case OPT_CHAR:      p_opr->Register<char>(name, desc, *(char*)variable, defaultvalue); break;
-      case OPT_CSTR:      p_opr->Register<char*>(name, desc, *(char**)variable, defaultvalue); break;
-        default:
-            fprintf(stderr, "\n\nGPGPU-Sim ** ERROR: option data type (%d) not supported!\n", type);
-            exit(1);
-            break;
-    }
+void option_parser_register(option_parser_t opp, const char *name,
+                            enum option_dtype type, void *variable,
+                            const char *desc, const char *defaultvalue) {
+  OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
+  switch (type) {
+    case OPT_INT32:
+      p_opr->Register<int>(name, desc, *(int *)variable, defaultvalue);
+      break;
+    case OPT_UINT32:
+      p_opr->Register<unsigned int>(name, desc, *(unsigned int *)variable,
+                                    defaultvalue);
+      break;
+    case OPT_INT64:
+      p_opr->Register<long long>(name, desc, *(long long *)variable,
+                                 defaultvalue);
+      break;
+    case OPT_UINT64:
+      p_opr->Register<unsigned long long>(
+          name, desc, *(unsigned long long *)variable, defaultvalue);
+      break;
+    case OPT_BOOL:
+      p_opr->Register<bool>(name, desc, *(bool *)variable, defaultvalue);
+      break;
+    case OPT_FLOAT:
+      p_opr->Register<float>(name, desc, *(float *)variable, defaultvalue);
+      break;
+    case OPT_DOUBLE:
+      p_opr->Register<double>(name, desc, *(double *)variable, defaultvalue);
+      break;
+    case OPT_CHAR:
+      p_opr->Register<char>(name, desc, *(char *)variable, defaultvalue);
+      break;
+    case OPT_CSTR:
+      p_opr->Register<char *>(name, desc, *(char **)variable, defaultvalue);
+      break;
+    default:
+      fprintf(stderr,
+              "\n\nGPGPU-Sim ** ERROR: option data type (%d) not supported!\n",
+              type);
+      exit(1);
+      break;
+  }
 }
 
-void option_parser_cmdline(option_parser_t opp,
-                           int argc, const char *argv[])
-{
-    OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
-    return p_opr->ParseCommandLine(argc,argv);
-
+void option_parser_cmdline(option_parser_t opp, int argc, const char *argv[]) {
+  OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
+  return p_opr->ParseCommandLine(argc, argv);
 }
 
-
-void option_parser_cfgfile(option_parser_t opp,
-                           const char *filename)
-{
-    OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
-    p_opr->ParseFile(filename);
+void option_parser_cfgfile(option_parser_t opp, const char *filename) {
+  OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
+  p_opr->ParseFile(filename);
 }
 
 void option_parser_delimited_string(option_parser_t opp,
-                                    const char *inputstring, 
-                                    const char *delimiters)
-{
-    OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
-    p_opr->ParseString(inputstring, delimiters);
+                                    const char *inputstring,
+                                    const char *delimiters) {
+  OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
+  p_opr->ParseString(inputstring, delimiters);
 }
 
-void option_parser_print(option_parser_t opp, 
-                         FILE *fout)
-{
-    OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
-    p_opr->Print(fout);
+void option_parser_print(option_parser_t opp, FILE *fout) {
+  OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
+  p_opr->Print(fout);
 }
-
-
 
 // #define UNIT_TEST
 #ifdef UNIT_TEST
 
-class testtype
-{
-public:
-   int idata;
-   float fdata;
-   string sdata;
-   unsigned long long ulldata;
-   bool bdata;
-   unsigned int boolint;
-   char * coption;
+class testtype {
+ public:
+  int idata;
+  float fdata;
+  string sdata;
+  unsigned long long ulldata;
+  bool bdata;
+  unsigned int boolint;
+  char *coption;
 
-   testtype() 
-      : idata(0), 
-        fdata(0.0f), 
-        sdata(""),
-        ulldata(0),
-        bdata(false)
-   { }
+  testtype() : idata(0), fdata(0.0f), sdata(""), ulldata(0), bdata(false) {}
 };
 
+int cppinterfacetest(int argc, const char *argv[]) {
+  testtype c;
+  OptionParser optionparser;
+  c.idata = 123;
+  c.fdata = 3249586.333;
+  c.sdata = string("haha");
 
-int cppinterfacetest(int argc, const char *argv[])
-{
-   testtype c;
-   OptionParser optionparser;
-   c.idata = 123;
-   c.fdata = 3249586.333;
-   c.sdata = string("haha");
+  optionparser.Register<int>("-idata", "integer data", c.idata, "-456");
+  optionparser.Register<float>("-fdata", "floating point data", c.fdata,
+                               "0.001");
+  optionparser.Register<string>("-sdata", "first string data", c.sdata,
+                                "hellow");
+  optionparser.Register<unsigned long long>(
+      "-ulldata", "unsigned long long data", c.ulldata, "0x123456789abcdef1");
+  optionparser.Register<bool>("-someflag", "first flag", c.bdata, "0");
+  optionparser.Register<bool>("-otherflag", "second flag", (bool &)c.boolint,
+                              "1");
+  optionparser.Register<char *>("-coption", "char * data", c.coption, NULL);
 
-   optionparser.Register<int>("-idata", "integer data", c.idata, "-456");
-   optionparser.Register<float>("-fdata", "floating point data", c.fdata, "0.001");
-   optionparser.Register<string>("-sdata", "first string data", c.sdata, "hellow");
-   optionparser.Register<unsigned long long>("-ulldata", "unsigned long long data", c.ulldata, "0x123456789abcdef1");
-   optionparser.Register<bool>("-someflag", "first flag", c.bdata, "0");
-   optionparser.Register<bool>("-otherflag", "second flag", (bool&)c.boolint, "1");
-   optionparser.Register<char *>("-coption", "char * data", c.coption, NULL);
+  cout << "Default: \n";
+  optionparser.Print(stdout);
 
-   cout << "Default: \n";
-   optionparser.Print(stdout);
+  optionparser.ParseCommandLine(argc, argv);
 
-   optionparser.ParseCommandLine(argc, argv);
+  cout << "Commandline Parse Results: \n";
+  optionparser.Print(stdout);
 
-   cout << "Commandline Parse Results: \n";
-   optionparser.Print(stdout);
+  optionparser.ParseFile("test.config");
+  cout << "File Parse Results: \n";
+  optionparser.Print(stdout);
+  cout << c.sdata << ' ' << c.idata << endl;
 
-   optionparser.ParseFile("test.config");
-   cout << "File Parse Results: \n";
-   optionparser.Print(stdout);
-   cout << c.sdata << ' ' << c.idata << endl;
-
-   return 0;
+  return 0;
 }
 
-int cinterfacetest(int argc, const char *argv[])
-{
-   testtype c;
-   option_parser_t opp = option_parser_create();
-   c.idata = 123;
-   c.fdata = 3249586.333;
-   c.sdata = string("haha");
-   char *otherstr;
+int cinterfacetest(int argc, const char *argv[]) {
+  testtype c;
+  option_parser_t opp = option_parser_create();
+  c.idata = 123;
+  c.fdata = 3249586.333;
+  c.sdata = string("haha");
+  char *otherstr;
 
-   option_parser_register(opp, "-idata", OPT_INT32, &c.idata, "integer data", "-456");
-   option_parser_register(opp, "-fdata", OPT_FLOAT, &c.fdata, "floating point data", "0.001");
-   option_parser_register(opp, "-sdata", OPT_CSTR, &otherstr, "first string data", "hellow");
-   option_parser_register(opp, "-ulldata", OPT_UINT64, &c.ulldata, "unsigend long long data", "0x123456789abcdef1");
-   option_parser_register(opp, "-someflag", OPT_BOOL, &c.bdata, "first flag", "0");
-   option_parser_register(opp, "-otherflag", OPT_BOOL, &c.boolint, "second flag", "1");
-   option_parser_register(opp, "-coption", OPT_CSTR, &c.coption, "char * data", NULL);
+  option_parser_register(opp, "-idata", OPT_INT32, &c.idata, "integer data",
+                         "-456");
+  option_parser_register(opp, "-fdata", OPT_FLOAT, &c.fdata,
+                         "floating point data", "0.001");
+  option_parser_register(opp, "-sdata", OPT_CSTR, &otherstr,
+                         "first string data", "hellow");
+  option_parser_register(opp, "-ulldata", OPT_UINT64, &c.ulldata,
+                         "unsigend long long data", "0x123456789abcdef1");
+  option_parser_register(opp, "-someflag", OPT_BOOL, &c.bdata, "first flag",
+                         "0");
+  option_parser_register(opp, "-otherflag", OPT_BOOL, &c.boolint, "second flag",
+                         "1");
+  option_parser_register(opp, "-coption", OPT_CSTR, &c.coption, "char * data",
+                         NULL);
 
-   printf("Default: \n");
-   option_parser_print(opp, stdout);
+  printf("Default: \n");
+  option_parser_print(opp, stdout);
 
-   option_parser_cmdline(opp, argc, argv);
+  option_parser_cmdline(opp, argc, argv);
 
-   printf("Commandline Parse Results: \n");
-   option_parser_print(opp, stdout);
+  printf("Commandline Parse Results: \n");
+  option_parser_print(opp, stdout);
 
-   option_parser_cfgfile(opp, "test.config");
-   printf("File Parse Results: \n");
-   option_parser_print(opp, stdout);
-   printf("%s %d\n", otherstr, c.idata);
+  option_parser_cfgfile(opp, "test.config");
+  printf("File Parse Results: \n");
+  option_parser_print(opp, stdout);
+  printf("%s %d\n", otherstr, c.idata);
 
-   option_parser_destroy(opp);
+  option_parser_destroy(opp);
 
-   return 0;
+  return 0;
 }
 
-int stringparsertest()
-{
-   int tABC; 
-   int tDEF; 
-   char tMode;
-   char *tName; 
+int stringparsertest() {
+  int tABC;
+  int tDEF;
+  char tMode;
+  char *tName;
 
-   option_parser_t opp = option_parser_create();
-   option_parser_register(opp, "ABC", OPT_INT32, &tABC, "tABC", "34");
-   option_parser_register(opp, "DEF", OPT_INT32, &tDEF, "tDEF", "-56");
-   option_parser_register(opp, "Mode", OPT_CHAR, &tMode, "tMode", "P");
-   option_parser_register(opp, "Name", OPT_CSTR, &tName, "tName", "Cache");
+  option_parser_t opp = option_parser_create();
+  option_parser_register(opp, "ABC", OPT_INT32, &tABC, "tABC", "34");
+  option_parser_register(opp, "DEF", OPT_INT32, &tDEF, "tDEF", "-56");
+  option_parser_register(opp, "Mode", OPT_CHAR, &tMode, "tMode", "P");
+  option_parser_register(opp, "Name", OPT_CSTR, &tName, "tName", "Cache");
 
-   option_parser_delimited_string(opp, "ABC 1111; DEF 88; Mode A; Name out", " ;");
-   printf("String Parse Results: \n");
-   option_parser_print(opp, stdout);
+  option_parser_delimited_string(opp, "ABC 1111; DEF 88; Mode A; Name out",
+                                 " ;");
+  printf("String Parse Results: \n");
+  option_parser_print(opp, stdout);
 
-   option_parser_delimited_string(opp, "Name=dram;DEF=702;Mode=B;ABC=-9573;", " =;");
-   printf("String Parse Results: \n");
-   option_parser_print(opp, stdout);
+  option_parser_delimited_string(opp, "Name=dram;DEF=702;Mode=B;ABC=-9573;",
+                                 " =;");
+  printf("String Parse Results: \n");
+  option_parser_print(opp, stdout);
 
-   return 0; 
+  return 0;
 }
 
-int main(int argc, const char *argv[]) 
-{
-    cppinterfacetest(argc,argv);
-    cinterfacetest(argc,argv);
-    stringparsertest(); 
+int main(int argc, const char *argv[]) {
+  cppinterfacetest(argc, argv);
+  cinterfacetest(argc, argv);
+  stringparsertest();
 
-    return 0;
+  return 0;
 }
 
 #endif
-

--- a/src/option_parser.cc
+++ b/src/option_parser.cc
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -27,527 +25,523 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "option_parser.h"
-#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <fstream>
-#include <iomanip>
+#include <assert.h>
+#include <string>
 #include <iostream>
+#include <iomanip>
+#include <sstream>
+#include <fstream>
+#include <vector>
 #include <list>
 #include <map>
-#include <sstream>
-#include <string>
-#include <vector>
+#include <string.h>
+#include "option_parser.h"
+
 
 using namespace std;
 
 // A generic option registry regardless of data type
-class OptionRegistryInterface {
- public:
-  OptionRegistryInterface(const string optionName, const string optionDesc)
-      : m_optionName(optionName), m_optionDesc(optionDesc), m_isParsed(false) {}
+class OptionRegistryInterface 
+{
+public:
+   OptionRegistryInterface(const string optionName, const string optionDesc) 
+      : m_optionName(optionName), m_optionDesc(optionDesc), m_isParsed(false) 
+   {}
 
-  virtual ~OptionRegistryInterface() {}
+   virtual ~OptionRegistryInterface() {}
 
-  const string &GetName() { return m_optionName; }
-  const string &GetDesc() { return m_optionDesc; }
-  const bool isParsed() { return m_isParsed; }
-  virtual string toString() = 0;
-  virtual bool fromString(const string str) = 0;
-  virtual bool isFlag() = 0;
-  virtual bool assignDefault(const char *str) = 0;
+   const string& GetName() { return m_optionName; }
+   const string& GetDesc() { return m_optionDesc; }
+   const bool isParsed() { return m_isParsed; }
+   virtual string toString() = 0;
+   virtual bool fromString(const string str) = 0;
+   virtual bool isFlag() = 0;
+   virtual bool assignDefault(const char *str) = 0;
 
- protected:
-  string m_optionName;
-  string m_optionDesc;
-  bool m_isParsed;  // true if the target variable has been updated by
-                    // fromString()
+protected:
+   string m_optionName;
+   string m_optionDesc;
+   bool m_isParsed; // true if the target variable has been updated by fromString()
 };
 
 // Template for option registry - class T = specify data type of the option
 template <class T>
-class OptionRegistry : public OptionRegistryInterface {
- public:
-  OptionRegistry(const string name, const string desc, T &variable)
-      : OptionRegistryInterface(name, desc), m_variable(variable) {}
+class OptionRegistry : public OptionRegistryInterface 
+{
+public:
+   OptionRegistry(const string name, const string desc, T &variable)
+      : OptionRegistryInterface(name, desc), m_variable(variable)
+   {}
 
-  virtual ~OptionRegistry() {}
+   virtual ~OptionRegistry() {}
 
-  virtual string toString() {
-    stringstream ss;
-    ss << m_variable;
-    return ss.str();
-  }
+   virtual string toString() 
+   {
+      stringstream ss;
+      ss << m_variable;
+      return ss.str();
+   }
 
-  virtual bool fromString(const string str) {
-    stringstream ss(str);
-    ss.exceptions(stringstream::failbit | stringstream::badbit);
-    ss << setbase(10);
-    if (str.size() > 1 && str[0] == '0') {
-      if (str.size() > 2 && str[1] == 'x') {
-        ss.ignore(2);
-        ss << setbase(16);
-      } else {
-        ss.ignore(1);
-        ss << setbase(8);
+   virtual bool fromString(const string str)
+   {
+      stringstream ss(str);
+      ss.exceptions(stringstream::failbit | stringstream::badbit);
+      ss << setbase(10);
+      if (str.size() > 1 && str[0] == '0') {
+         if (str.size() > 2 && str[1] == 'x') { 
+            ss.ignore(2);
+            ss << setbase(16);
+         } else {
+            ss.ignore(1);
+            ss << setbase(8);
+         }
       }
-    }
-    try {
-      ss >> m_variable;
-    } catch (exception &e) {
-      return false;
-    }
-    m_isParsed = true;
-    return true;
-  }
+      try {
+         ss >> m_variable;
+      } catch (exception &e) {
+         return false;
+      }
+      m_isParsed = true; 
+      return true;
+   }
 
-  virtual bool isFlag() { return false; }
-  virtual bool assignDefault(const char *str) { return fromString(str); }
+   virtual bool isFlag() { return false; }
+   virtual bool assignDefault(const char *str) { return fromString(str); }
 
-  operator T() { return m_variable; }
+   operator T()
+   {
+      return m_variable;
+   }
 
- private:
-  T &m_variable;
+private:
+   T &m_variable;
 };
 
 // specialized parser for string-type options
-template <>
-bool OptionRegistry<string>::fromString(const string str) {
-  m_variable = str;
-  m_isParsed = true;
-  return true;
+template<>
+bool OptionRegistry<string>::fromString(const string str)
+{
+   m_variable = str;
+   m_isParsed = true; 
+   return true;
 }
 
 // specialized parser for c-string type options
-template <>
-bool OptionRegistry<char *>::fromString(const string str) {
-  m_variable = new char[str.size() + 1];
-  strcpy(m_variable, str.c_str());
-  m_isParsed = true;
-  return true;
+template<>
+bool OptionRegistry<char *>::fromString(const string str)
+{
+   m_variable = new char[str.size() + 1];
+   strcpy(m_variable, str.c_str());
+   m_isParsed = true; 
+   return true;
 }
 
 // specialized default assignment for c-string type option to allow NULL default
-template <>
-bool OptionRegistry<char *>::assignDefault(const char *str) {
-  m_variable = const_cast<char *>(
-      str);  // c-string options are not meant to be edited anyway
-  m_isParsed = true;
-  return true;
+template<>
+bool OptionRegistry<char *>::assignDefault(const char *str) 
+{
+    m_variable = const_cast<char *>(str); // c-string options are not meant to be edited anyway
+    m_isParsed = true; 
+    return true;
 }
 
 // specialized default assignment for c-string type option to allow NULL default
-template <>
-string OptionRegistry<char *>::toString() {
-  stringstream ss;
-  if (m_variable != NULL) {
-    ss << m_variable;
-  } else {
-    ss << "NULL";
-  }
-  return ss.str();
+template<>
+string OptionRegistry<char *>::toString() 
+{
+    stringstream ss;
+    if (m_variable != NULL) {
+        ss << m_variable;
+    } else {
+        ss << "NULL";
+    }
+    return ss.str();
 }
 
-// specialized parser for boolean options
-template <>
-bool OptionRegistry<bool>::fromString(const string str) {
-  int value = 1;
-  bool parsed = true;
-  stringstream ss(str);
-  ss.exceptions(stringstream::failbit | stringstream::badbit);
-  try {
-    ss >> value;
-  } catch (stringstream::failure &ep) {
-    parsed = false;
-  }
-  assert(value == 0 or
-         value ==
-             1);  // sanity check for boolean options (it can only be 1 or 0)
-  m_variable = (value != 0);
-  m_isParsed = true;
-  return parsed;
+// specialized parser for boolean options 
+template<>
+bool OptionRegistry<bool>::fromString(const string str)
+{
+   int value = 1;
+   bool parsed = true;
+   stringstream ss(str);
+   ss.exceptions(stringstream::failbit | stringstream::badbit);
+   try {
+      ss >> value;
+   } catch (stringstream::failure &ep) {
+      parsed = false;
+   }
+   assert(value == 0 or value == 1); // sanity check for boolean options (it can only be 1 or 0)
+   m_variable = (value != 0);
+   m_isParsed = true; 
+   return parsed;
 }
 
 // specializing a flag query function to identify boolean option
-template <>
-bool OptionRegistry<bool>::isFlag() {
-  return true;
-}
+template<>
+bool OptionRegistry<bool>::isFlag() { return true; }
 
-// class holding a collection of options and parse them from command
-// line/configfile
-class OptionParser {
- public:
-  OptionParser() {}
-  ~OptionParser() {
-    OptionCollection::iterator i_option;
-    for (i_option = m_optionReg.begin(); i_option != m_optionReg.end();
-         ++i_option) {
-      delete (*i_option);
-    }
-  }
+// class holding a collection of options and parse them from command line/configfile
+class OptionParser
+{
+public:
+   OptionParser() {}
+   ~OptionParser() 
+   {
+      OptionCollection::iterator i_option;
+      for (i_option = m_optionReg.begin(); i_option != m_optionReg.end(); ++i_option) {
+         delete (*i_option);
+      }
+   } 
 
-  template <class T>
-  void Register(const string optionName, const string optionDesc,
-                T &optionVariable, const char *optionDefault) {
-    OptionRegistry<T> *p_option =
-        new OptionRegistry<T>(optionName, optionDesc, optionVariable);
-    m_optionReg.push_back(p_option);
-    m_optionMap[optionName] = p_option;
-    p_option->assignDefault(optionDefault);
-  }
+   template<class T>
+   void Register(const string optionName, const string optionDesc, T &optionVariable, const char *optionDefault)
+   {
+      OptionRegistry<T> *p_option = new OptionRegistry<T>(optionName, optionDesc, optionVariable);
+      m_optionReg.push_back(p_option);
+      m_optionMap[optionName] = p_option;
+      p_option->assignDefault(optionDefault);
+   }
 
-  void ParseCommandLine(int argc, const char *const argv[]) {
-    for (int i = 1; i < argc; i++) {
-      OptionMap::iterator i_option;
-      bool optionFound = false;
+   void ParseCommandLine(int argc, const char * const argv[])
+   {
+      for (int i = 1; i < argc; i++) {
+         OptionMap::iterator i_option;
+         bool optionFound = false;
 
-      i_option = m_optionMap.find(argv[i]);
-      if (i_option != m_optionMap.end()) {
-        const char *argstr = (i + 1 < argc) ? argv[i + 1] : "";
-        OptionRegistryInterface *p_option = i_option->second;
-        if (p_option->isFlag()) {
-          if (p_option->fromString(argstr) == true) {
+         i_option = m_optionMap.find(argv[i]);
+         if (i_option != m_optionMap.end()) {
+            const char *argstr = (i + 1 < argc)? argv[i + 1] : "";
+            OptionRegistryInterface *p_option = i_option->second;
+            if (p_option->isFlag()) { 
+               if (p_option->fromString(argstr) == true) {
+                  i += 1;
+               } 
+            } else { 
+               if (p_option->fromString(argstr) == false) {
+                  fprintf(stderr, "\n\nGPGPU-Sim ** ERROR: Cannot parse value '%s' for option '%s'.\n", argstr, argv[i]);
+                  exit(1);
+               }
+               i += 1;
+            }
+            optionFound = true;
+         } else if (string(argv[i]) == "-config") {
+            if (i + 1 >= argc) {
+               fprintf(stderr, "\n\nGPGPU-Sim ** ERROR: Missing filename for option '-config'.\n");
+               exit(1);
+            }
+
+            ParseFile(argv[i + 1]);
             i += 1;
-          }
-        } else {
-          if (p_option->fromString(argstr) == false) {
-            fprintf(stderr,
-                    "\n\nGPGPU-Sim ** ERROR: Cannot parse value '%s' for "
-                    "option '%s'.\n",
-                    argstr, argv[i]);
+            optionFound = true;
+         }
+         if (optionFound == false) {
+            fprintf(stderr, "\n\nGPGPU-Sim ** ERROR: Unknown Option: '%s' \n", argv[i]);
             exit(1);
-          }
-          i += 1;
-        }
-        optionFound = true;
-      } else if (string(argv[i]) == "-config") {
-        if (i + 1 >= argc) {
-          fprintf(stderr,
-                  "\n\nGPGPU-Sim ** ERROR: Missing filename for option "
-                  "'-config'.\n");
-          exit(1);
-        }
-
-        ParseFile(argv[i + 1]);
-        i += 1;
-        optionFound = true;
+         }
       }
-      if (optionFound == false) {
-        fprintf(stderr, "\n\nGPGPU-Sim ** ERROR: Unknown Option: '%s' \n",
-                argv[i]);
-        exit(1);
+   }
+
+
+   void ParseFile(const char *filename) {
+      ifstream inputFile;
+      stringstream args;
+
+      // open config file, stream every line into a continuous buffer 
+      // get rid of comments in the process
+      inputFile.open(filename);
+      if (!inputFile.good()) {
+         fprintf(stderr, "\n\nGPGPU-Sim ** ERROR: Cannot open config file '%s'\n", filename);
+         exit(1);
       }
-    }
-  }
-
-  void ParseFile(const char *filename) {
-    ifstream inputFile;
-    stringstream args;
-
-    // open config file, stream every line into a continuous buffer
-    // get rid of comments in the process
-    inputFile.open(filename);
-    if (!inputFile.good()) {
-      fprintf(stderr, "\n\nGPGPU-Sim ** ERROR: Cannot open config file '%s'\n",
-              filename);
-      exit(1);
-    }
-    while (inputFile.good()) {
-      string line;
-      getline(inputFile, line);
-      size_t commentStart = line.find_first_of("#");
-      if (commentStart != line.npos) {
-        line.erase(commentStart);
+      while (inputFile.good()) {
+         string line;
+         getline(inputFile, line);
+         size_t commentStart = line.find_first_of("#");
+         if (commentStart != line.npos) {
+            line.erase(commentStart);
+         }
+         args << line << ' ';
       }
-      args << line << ' ';
-    }
-    inputFile.close();
+      inputFile.close();
 
-    ParseStringStream(args);
-  }
+      ParseStringStream(args); 
+   }
 
-  // parse the given string as tokens separated by a set of given delimiters
-  void ParseString(string inputString, const string delimiters = string(" ;")) {
-    // convert all delimiter characters into whitespaces
-    for (unsigned t = 0; t < inputString.size(); t++) {
-      for (unsigned d = 0; d < delimiters.size(); d++) {
-        if (inputString[t] == delimiters.at(d)) {
-          inputString[t] = ' ';
-          break;
-        }
+   // parse the given string as tokens separated by a set of given delimiters 
+   void ParseString(string inputString, const string delimiters = string(" ;")) {
+      // convert all delimiter characters into whitespaces 
+      for (unsigned t = 0; t < inputString.size(); t++) {
+         for (unsigned d = 0; d < delimiters.size(); d++) {
+            if (inputString[t] == delimiters.at(d)) {
+               inputString[t] = ' '; 
+               break; 
+            }
+         }
       }
-    }
-    stringstream args(inputString);
-    ParseStringStream(args);
-  }
+      stringstream args(inputString); 
+      ParseStringStream(args); 
+   }
 
-  // parse the given stringstream as whitespace-separated tokens. drain the
-  // stream in the process
-  void ParseStringStream(stringstream &args) {
-    // extract non-whitespace string tokens
-    vector<char *> argv;
-    argv.push_back(new char[6]);
-    strcpy(argv[0], "dummy");
-    while (args.good()) {
-      string argNew;
-      args >> argNew;
+   // parse the given stringstream as whitespace-separated tokens. drain the stream in the process 
+   void ParseStringStream(stringstream &args) {
+      // extract non-whitespace string tokens
+      vector<char*> argv;
+      argv.push_back(new char[6]); 
+      strcpy(argv[0], "dummy");
+      while (args.good()) {
+         string argNew;
+         args >> argNew;
 
-      if (argNew.size() == 0) continue;  // this is probably the last token
+         if (argNew.size() == 0) continue; // this is probably the last token
 
-      if (argNew[0] == '"') {
-        while (args.good() && argNew[argNew.size() - 1] != '"') {
-          string argCont;
-          args >> argCont;
-          argNew += " " + argCont;
-        }
-        argNew.erase(0, 1);
-        argNew.erase(argNew.size() - 1);
+         if (argNew[0] == '"') {
+            while (args.good() && argNew[argNew.size()-1] != '"') {
+               string argCont;
+               args >> argCont;
+               argNew += " " + argCont;
+            }
+            argNew.erase(0,1);
+            argNew.erase(argNew.size()-1);
+         }
+
+         char *c_argNew = new char[argNew.size() + 1];
+         strcpy(c_argNew, argNew.c_str());
+         argv.push_back(c_argNew);
       }
 
-      char *c_argNew = new char[argNew.size() + 1];
-      strcpy(c_argNew, argNew.c_str());
-      argv.push_back(c_argNew);
-    }
-
-    // pass the string token into normal commandline parser
-    char **targv = (char **)calloc(argv.size(), sizeof(char *));
-    for (unsigned k = 0; k < argv.size(); k++) targv[k] = argv[k];
-    ParseCommandLine(argv.size(), targv);
-    free(targv);
-    for (size_t i = 0; i < argv.size(); i++) {
-      delete[] argv[i];
-    }
-  }
-
-  void Print(FILE *fout) {
-    OptionCollection::iterator i_option;
-    for (i_option = m_optionReg.begin(); i_option != m_optionReg.end();
-         ++i_option) {
-      stringstream sout;
-      if ((*i_option)->isParsed() == false) {
-        cerr << "\n\nGPGPU-Sim ** ERROR: Missing option '"
-             << (*i_option)->GetName() << "'\n";
-        assert(0);
+      // pass the string token into normal commandline parser
+      char **targv = (char**)calloc(argv.size(), sizeof(char*));
+      for( unsigned k=0; k < argv.size(); k++ ) 
+         targv[k] = argv[k];
+      ParseCommandLine(argv.size(), targv);
+      free(targv);
+      for (size_t i = 0; i < argv.size(); i++) {
+         delete[] argv[i];
       }
-      sout << setw(20) << left << (*i_option)->GetName() << " ";
-      sout << setw(20) << right << (*i_option)->toString() << " # ";
-      sout << left << (*i_option)->GetDesc();
-      sout << std::endl;
-      fprintf(fout, "%s", sout.str().c_str());
-    }
-  }
+   }
 
- private:
-  typedef list<OptionRegistryInterface *> OptionCollection;
-  OptionCollection m_optionReg;
-  typedef map<string, OptionRegistryInterface *> OptionMap;
-  OptionMap m_optionMap;
+   void Print(FILE *fout)
+   {
+      OptionCollection::iterator i_option;
+      for (i_option = m_optionReg.begin(); i_option != m_optionReg.end(); ++i_option) {
+         stringstream sout;
+         if ((*i_option)->isParsed() == false) {
+            cerr << "\n\nGPGPU-Sim ** ERROR: Missing option '" << (*i_option)->GetName() << "'\n"; 
+            assert(0); 
+         }
+         sout << setw(20) << left << (*i_option)->GetName() << " "; 
+         sout << setw(20) << right << (*i_option)->toString() << " # ";
+         sout << left << (*i_option)->GetDesc();
+         sout << std::endl;
+         fprintf(fout, "%s", sout.str().c_str());
+      }
+   }
+
+private:
+   typedef list<OptionRegistryInterface*> OptionCollection;
+   OptionCollection m_optionReg;
+   typedef map<string, OptionRegistryInterface*> OptionMap;
+   OptionMap m_optionMap;
 };
 
 #include "option_parser.h"
 
-option_parser_t option_parser_create() {
-  OptionParser *p_opr = new OptionParser();
-  return reinterpret_cast<option_parser_t>(p_opr);
+option_parser_t option_parser_create() 
+{
+   OptionParser *p_opr = new OptionParser();
+   return reinterpret_cast<option_parser_t>(p_opr);
 }
 
-void option_parser_destroy(option_parser_t opp) {
-  OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
-  delete p_opr;
+void option_parser_destroy(option_parser_t opp)
+{
+   OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
+   delete p_opr;
 }
 
-void option_parser_register(option_parser_t opp, const char *name,
-                            enum option_dtype type, void *variable,
-                            const char *desc, const char *defaultvalue) {
-  OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
-  switch (type) {
-    case OPT_INT32:
-      p_opr->Register<int>(name, desc, *(int *)variable, defaultvalue);
-      break;
-    case OPT_UINT32:
-      p_opr->Register<unsigned int>(name, desc, *(unsigned int *)variable,
-                                    defaultvalue);
-      break;
-    case OPT_INT64:
-      p_opr->Register<long long>(name, desc, *(long long *)variable,
-                                 defaultvalue);
-      break;
-    case OPT_UINT64:
-      p_opr->Register<unsigned long long>(
-          name, desc, *(unsigned long long *)variable, defaultvalue);
-      break;
-    case OPT_BOOL:
-      p_opr->Register<bool>(name, desc, *(bool *)variable, defaultvalue);
-      break;
-    case OPT_FLOAT:
-      p_opr->Register<float>(name, desc, *(float *)variable, defaultvalue);
-      break;
-    case OPT_DOUBLE:
-      p_opr->Register<double>(name, desc, *(double *)variable, defaultvalue);
-      break;
-    case OPT_CHAR:
-      p_opr->Register<char>(name, desc, *(char *)variable, defaultvalue);
-      break;
-    case OPT_CSTR:
-      p_opr->Register<char *>(name, desc, *(char **)variable, defaultvalue);
-      break;
-    default:
-      fprintf(stderr,
-              "\n\nGPGPU-Sim ** ERROR: option data type (%d) not supported!\n",
-              type);
-      exit(1);
-      break;
-  }
+void option_parser_register(option_parser_t opp, 
+                            const char *name, 
+                            enum option_dtype type, 
+                            void *variable, 
+                            const char *desc,  
+                            const char *defaultvalue)
+{
+   OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
+   switch (type) {
+      case OPT_INT32:     p_opr->Register<int>(name, desc, *(int*)variable, defaultvalue); break;
+      case OPT_UINT32:    p_opr->Register<unsigned int>(name, desc, *(unsigned int*)variable, defaultvalue); break;
+      case OPT_INT64:     p_opr->Register<long long>(name, desc, *(long long*)variable, defaultvalue); break;
+      case OPT_UINT64:    p_opr->Register<unsigned long long>(name, desc, *(unsigned long long*)variable, defaultvalue); break;
+      case OPT_BOOL:      p_opr->Register<bool>(name, desc, *(bool*)variable, defaultvalue); break;
+      case OPT_FLOAT:     p_opr->Register<float>(name, desc, *(float*)variable, defaultvalue); break;
+      case OPT_DOUBLE:    p_opr->Register<double>(name, desc, *(double*)variable, defaultvalue); break;
+      case OPT_CHAR:      p_opr->Register<char>(name, desc, *(char*)variable, defaultvalue); break;
+      case OPT_CSTR:      p_opr->Register<char*>(name, desc, *(char**)variable, defaultvalue); break;
+        default:
+            fprintf(stderr, "\n\nGPGPU-Sim ** ERROR: option data type (%d) not supported!\n", type);
+            exit(1);
+            break;
+    }
 }
 
-void option_parser_cmdline(option_parser_t opp, int argc, const char *argv[]) {
-  OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
-  return p_opr->ParseCommandLine(argc, argv);
+void option_parser_cmdline(option_parser_t opp,
+                           int argc, const char *argv[])
+{
+    OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
+    return p_opr->ParseCommandLine(argc,argv);
+
 }
 
-void option_parser_cfgfile(option_parser_t opp, const char *filename) {
-  OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
-  p_opr->ParseFile(filename);
+
+void option_parser_cfgfile(option_parser_t opp,
+                           const char *filename)
+{
+    OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
+    p_opr->ParseFile(filename);
 }
 
 void option_parser_delimited_string(option_parser_t opp,
-                                    const char *inputstring,
-                                    const char *delimiters) {
-  OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
-  p_opr->ParseString(inputstring, delimiters);
+                                    const char *inputstring, 
+                                    const char *delimiters)
+{
+    OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
+    p_opr->ParseString(inputstring, delimiters);
 }
 
-void option_parser_print(option_parser_t opp, FILE *fout) {
-  OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
-  p_opr->Print(fout);
+void option_parser_print(option_parser_t opp, 
+                         FILE *fout)
+{
+    OptionParser *p_opr = reinterpret_cast<OptionParser *>(opp);
+    p_opr->Print(fout);
 }
+
+
 
 // #define UNIT_TEST
 #ifdef UNIT_TEST
 
-class testtype {
- public:
-  int idata;
-  float fdata;
-  string sdata;
-  unsigned long long ulldata;
-  bool bdata;
-  unsigned int boolint;
-  char *coption;
+class testtype
+{
+public:
+   int idata;
+   float fdata;
+   string sdata;
+   unsigned long long ulldata;
+   bool bdata;
+   unsigned int boolint;
+   char * coption;
 
-  testtype() : idata(0), fdata(0.0f), sdata(""), ulldata(0), bdata(false) {}
+   testtype() 
+      : idata(0), 
+        fdata(0.0f), 
+        sdata(""),
+        ulldata(0),
+        bdata(false)
+   { }
 };
 
-int cppinterfacetest(int argc, const char *argv[]) {
-  testtype c;
-  OptionParser optionparser;
-  c.idata = 123;
-  c.fdata = 3249586.333;
-  c.sdata = string("haha");
 
-  optionparser.Register<int>("-idata", "integer data", c.idata, "-456");
-  optionparser.Register<float>("-fdata", "floating point data", c.fdata,
-                               "0.001");
-  optionparser.Register<string>("-sdata", "first string data", c.sdata,
-                                "hellow");
-  optionparser.Register<unsigned long long>(
-      "-ulldata", "unsigned long long data", c.ulldata, "0x123456789abcdef1");
-  optionparser.Register<bool>("-someflag", "first flag", c.bdata, "0");
-  optionparser.Register<bool>("-otherflag", "second flag", (bool &)c.boolint,
-                              "1");
-  optionparser.Register<char *>("-coption", "char * data", c.coption, NULL);
+int cppinterfacetest(int argc, const char *argv[])
+{
+   testtype c;
+   OptionParser optionparser;
+   c.idata = 123;
+   c.fdata = 3249586.333;
+   c.sdata = string("haha");
 
-  cout << "Default: \n";
-  optionparser.Print(stdout);
+   optionparser.Register<int>("-idata", "integer data", c.idata, "-456");
+   optionparser.Register<float>("-fdata", "floating point data", c.fdata, "0.001");
+   optionparser.Register<string>("-sdata", "first string data", c.sdata, "hellow");
+   optionparser.Register<unsigned long long>("-ulldata", "unsigned long long data", c.ulldata, "0x123456789abcdef1");
+   optionparser.Register<bool>("-someflag", "first flag", c.bdata, "0");
+   optionparser.Register<bool>("-otherflag", "second flag", (bool&)c.boolint, "1");
+   optionparser.Register<char *>("-coption", "char * data", c.coption, NULL);
 
-  optionparser.ParseCommandLine(argc, argv);
+   cout << "Default: \n";
+   optionparser.Print(stdout);
 
-  cout << "Commandline Parse Results: \n";
-  optionparser.Print(stdout);
+   optionparser.ParseCommandLine(argc, argv);
 
-  optionparser.ParseFile("test.config");
-  cout << "File Parse Results: \n";
-  optionparser.Print(stdout);
-  cout << c.sdata << ' ' << c.idata << endl;
+   cout << "Commandline Parse Results: \n";
+   optionparser.Print(stdout);
 
-  return 0;
+   optionparser.ParseFile("test.config");
+   cout << "File Parse Results: \n";
+   optionparser.Print(stdout);
+   cout << c.sdata << ' ' << c.idata << endl;
+
+   return 0;
 }
 
-int cinterfacetest(int argc, const char *argv[]) {
-  testtype c;
-  option_parser_t opp = option_parser_create();
-  c.idata = 123;
-  c.fdata = 3249586.333;
-  c.sdata = string("haha");
-  char *otherstr;
+int cinterfacetest(int argc, const char *argv[])
+{
+   testtype c;
+   option_parser_t opp = option_parser_create();
+   c.idata = 123;
+   c.fdata = 3249586.333;
+   c.sdata = string("haha");
+   char *otherstr;
 
-  option_parser_register(opp, "-idata", OPT_INT32, &c.idata, "integer data",
-                         "-456");
-  option_parser_register(opp, "-fdata", OPT_FLOAT, &c.fdata,
-                         "floating point data", "0.001");
-  option_parser_register(opp, "-sdata", OPT_CSTR, &otherstr,
-                         "first string data", "hellow");
-  option_parser_register(opp, "-ulldata", OPT_UINT64, &c.ulldata,
-                         "unsigend long long data", "0x123456789abcdef1");
-  option_parser_register(opp, "-someflag", OPT_BOOL, &c.bdata, "first flag",
-                         "0");
-  option_parser_register(opp, "-otherflag", OPT_BOOL, &c.boolint, "second flag",
-                         "1");
-  option_parser_register(opp, "-coption", OPT_CSTR, &c.coption, "char * data",
-                         NULL);
+   option_parser_register(opp, "-idata", OPT_INT32, &c.idata, "integer data", "-456");
+   option_parser_register(opp, "-fdata", OPT_FLOAT, &c.fdata, "floating point data", "0.001");
+   option_parser_register(opp, "-sdata", OPT_CSTR, &otherstr, "first string data", "hellow");
+   option_parser_register(opp, "-ulldata", OPT_UINT64, &c.ulldata, "unsigend long long data", "0x123456789abcdef1");
+   option_parser_register(opp, "-someflag", OPT_BOOL, &c.bdata, "first flag", "0");
+   option_parser_register(opp, "-otherflag", OPT_BOOL, &c.boolint, "second flag", "1");
+   option_parser_register(opp, "-coption", OPT_CSTR, &c.coption, "char * data", NULL);
 
-  printf("Default: \n");
-  option_parser_print(opp, stdout);
+   printf("Default: \n");
+   option_parser_print(opp, stdout);
 
-  option_parser_cmdline(opp, argc, argv);
+   option_parser_cmdline(opp, argc, argv);
 
-  printf("Commandline Parse Results: \n");
-  option_parser_print(opp, stdout);
+   printf("Commandline Parse Results: \n");
+   option_parser_print(opp, stdout);
 
-  option_parser_cfgfile(opp, "test.config");
-  printf("File Parse Results: \n");
-  option_parser_print(opp, stdout);
-  printf("%s %d\n", otherstr, c.idata);
+   option_parser_cfgfile(opp, "test.config");
+   printf("File Parse Results: \n");
+   option_parser_print(opp, stdout);
+   printf("%s %d\n", otherstr, c.idata);
 
-  option_parser_destroy(opp);
+   option_parser_destroy(opp);
 
-  return 0;
+   return 0;
 }
 
-int stringparsertest() {
-  int tABC;
-  int tDEF;
-  char tMode;
-  char *tName;
+int stringparsertest()
+{
+   int tABC; 
+   int tDEF; 
+   char tMode;
+   char *tName; 
 
-  option_parser_t opp = option_parser_create();
-  option_parser_register(opp, "ABC", OPT_INT32, &tABC, "tABC", "34");
-  option_parser_register(opp, "DEF", OPT_INT32, &tDEF, "tDEF", "-56");
-  option_parser_register(opp, "Mode", OPT_CHAR, &tMode, "tMode", "P");
-  option_parser_register(opp, "Name", OPT_CSTR, &tName, "tName", "Cache");
+   option_parser_t opp = option_parser_create();
+   option_parser_register(opp, "ABC", OPT_INT32, &tABC, "tABC", "34");
+   option_parser_register(opp, "DEF", OPT_INT32, &tDEF, "tDEF", "-56");
+   option_parser_register(opp, "Mode", OPT_CHAR, &tMode, "tMode", "P");
+   option_parser_register(opp, "Name", OPT_CSTR, &tName, "tName", "Cache");
 
-  option_parser_delimited_string(opp, "ABC 1111; DEF 88; Mode A; Name out",
-                                 " ;");
-  printf("String Parse Results: \n");
-  option_parser_print(opp, stdout);
+   option_parser_delimited_string(opp, "ABC 1111; DEF 88; Mode A; Name out", " ;");
+   printf("String Parse Results: \n");
+   option_parser_print(opp, stdout);
 
-  option_parser_delimited_string(opp, "Name=dram;DEF=702;Mode=B;ABC=-9573;",
-                                 " =;");
-  printf("String Parse Results: \n");
-  option_parser_print(opp, stdout);
+   option_parser_delimited_string(opp, "Name=dram;DEF=702;Mode=B;ABC=-9573;", " =;");
+   printf("String Parse Results: \n");
+   option_parser_print(opp, stdout);
 
-  return 0;
+   return 0; 
 }
 
-int main(int argc, const char *argv[]) {
-  cppinterfacetest(argc, argv);
-  cinterfacetest(argc, argv);
-  stringparsertest();
+int main(int argc, const char *argv[]) 
+{
+    cppinterfacetest(argc,argv);
+    cinterfacetest(argc,argv);
+    stringparsertest(); 
 
-  return 0;
+    return 0;
 }
 
 #endif
+

--- a/src/option_parser.h
+++ b/src/option_parser.h
@@ -7,44 +7,44 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
-#pragma once 
+#pragma once
 
 #include <stdio.h>
 #include <stdlib.h>
-
 
 // pointer to C++ class
 typedef class OptionParser *option_parser_t;
 
 // data type of the option
 enum option_dtype {
-    OPT_INT32,
-    OPT_UINT32,
-    OPT_INT64,
-    OPT_UINT64,
-    OPT_BOOL,
-    OPT_FLOAT,
-    OPT_DOUBLE,
-    OPT_CHAR,
-    OPT_CSTR
+  OPT_INT32,
+  OPT_UINT32,
+  OPT_INT64,
+  OPT_UINT64,
+  OPT_BOOL,
+  OPT_FLOAT,
+  OPT_DOUBLE,
+  OPT_CHAR,
+  OPT_CSTR
 };
 
 // create and destroy option parser
@@ -52,28 +52,19 @@ option_parser_t option_parser_create();
 void option_parser_destroy(option_parser_t opp);
 
 // register new option
-void option_parser_register(option_parser_t opp, 
-                            const char *name, 
-                            enum option_dtype type, 
-                            void *variable, 
-                            const char *desc,  
-                            const char *defaultvalue);
+void option_parser_register(option_parser_t opp, const char *name,
+                            enum option_dtype type, void *variable,
+                            const char *desc, const char *defaultvalue);
 
 // parse command line
-void option_parser_cmdline(option_parser_t opp,
-                           int argc, const char *argv[]);
-
-
+void option_parser_cmdline(option_parser_t opp, int argc, const char *argv[]);
 
 // parse config file
-void option_parser_cfgfile(option_parser_t opp,
-                           const char *filename);
+void option_parser_cfgfile(option_parser_t opp, const char *filename);
 
 // parse a delimited string
 void option_parser_delimited_string(option_parser_t opp,
-                                    const char *inputstring, 
+                                    const char *inputstring,
                                     const char *delimiters);
 // print options
-void option_parser_print(option_parser_t opp, 
-                         FILE *fout);
-
+void option_parser_print(option_parser_t opp, FILE *fout);

--- a/src/option_parser.h
+++ b/src/option_parser.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -25,26 +27,25 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#pragma once 
+#pragma once
 
 #include <stdio.h>
 #include <stdlib.h>
-
 
 // pointer to C++ class
 typedef class OptionParser *option_parser_t;
 
 // data type of the option
 enum option_dtype {
-    OPT_INT32,
-    OPT_UINT32,
-    OPT_INT64,
-    OPT_UINT64,
-    OPT_BOOL,
-    OPT_FLOAT,
-    OPT_DOUBLE,
-    OPT_CHAR,
-    OPT_CSTR
+  OPT_INT32,
+  OPT_UINT32,
+  OPT_INT64,
+  OPT_UINT64,
+  OPT_BOOL,
+  OPT_FLOAT,
+  OPT_DOUBLE,
+  OPT_CHAR,
+  OPT_CSTR
 };
 
 // create and destroy option parser
@@ -52,28 +53,19 @@ option_parser_t option_parser_create();
 void option_parser_destroy(option_parser_t opp);
 
 // register new option
-void option_parser_register(option_parser_t opp, 
-                            const char *name, 
-                            enum option_dtype type, 
-                            void *variable, 
-                            const char *desc,  
-                            const char *defaultvalue);
+void option_parser_register(option_parser_t opp, const char *name,
+                            enum option_dtype type, void *variable,
+                            const char *desc, const char *defaultvalue);
 
 // parse command line
-void option_parser_cmdline(option_parser_t opp,
-                           int argc, const char *argv[]);
-
-
+void option_parser_cmdline(option_parser_t opp, int argc, const char *argv[]);
 
 // parse config file
-void option_parser_cfgfile(option_parser_t opp,
-                           const char *filename);
+void option_parser_cfgfile(option_parser_t opp, const char *filename);
 
 // parse a delimited string
 void option_parser_delimited_string(option_parser_t opp,
-                                    const char *inputstring, 
+                                    const char *inputstring,
                                     const char *delimiters);
 // print options
-void option_parser_print(option_parser_t opp, 
-                         FILE *fout);
-
+void option_parser_print(option_parser_t opp, FILE *fout);

--- a/src/option_parser.h
+++ b/src/option_parser.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -27,25 +25,26 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#pragma once
+#pragma once 
 
 #include <stdio.h>
 #include <stdlib.h>
+
 
 // pointer to C++ class
 typedef class OptionParser *option_parser_t;
 
 // data type of the option
 enum option_dtype {
-  OPT_INT32,
-  OPT_UINT32,
-  OPT_INT64,
-  OPT_UINT64,
-  OPT_BOOL,
-  OPT_FLOAT,
-  OPT_DOUBLE,
-  OPT_CHAR,
-  OPT_CSTR
+    OPT_INT32,
+    OPT_UINT32,
+    OPT_INT64,
+    OPT_UINT64,
+    OPT_BOOL,
+    OPT_FLOAT,
+    OPT_DOUBLE,
+    OPT_CHAR,
+    OPT_CSTR
 };
 
 // create and destroy option parser
@@ -53,19 +52,28 @@ option_parser_t option_parser_create();
 void option_parser_destroy(option_parser_t opp);
 
 // register new option
-void option_parser_register(option_parser_t opp, const char *name,
-                            enum option_dtype type, void *variable,
-                            const char *desc, const char *defaultvalue);
+void option_parser_register(option_parser_t opp, 
+                            const char *name, 
+                            enum option_dtype type, 
+                            void *variable, 
+                            const char *desc,  
+                            const char *defaultvalue);
 
 // parse command line
-void option_parser_cmdline(option_parser_t opp, int argc, const char *argv[]);
+void option_parser_cmdline(option_parser_t opp,
+                           int argc, const char *argv[]);
+
+
 
 // parse config file
-void option_parser_cfgfile(option_parser_t opp, const char *filename);
+void option_parser_cfgfile(option_parser_t opp,
+                           const char *filename);
 
 // parse a delimited string
 void option_parser_delimited_string(option_parser_t opp,
-                                    const char *inputstring,
+                                    const char *inputstring, 
                                     const char *delimiters);
 // print options
-void option_parser_print(option_parser_t opp, FILE *fout);
+void option_parser_print(option_parser_t opp, 
+                         FILE *fout);
+

--- a/src/statwrapper.cc
+++ b/src/statwrapper.cc
@@ -1,48 +1,33 @@
-//a Wraper function for stats class
-#include "intersim2/stats.hpp"
+// a Wraper function for stats class
 #include <stdio.h>
+#include "intersim2/stats.hpp"
 
-Stats* StatCreate (const char * name, double bin_size, int num_bins) {
-   Stats* newstat = new Stats(NULL,name,bin_size,num_bins);
-   newstat->Clear ();
-   return newstat;  
+Stats *StatCreate(const char *name, double bin_size, int num_bins) {
+  Stats *newstat = new Stats(NULL, name, bin_size, num_bins);
+  newstat->Clear();
+  return newstat;
 }
 
-void StatClear(void * st)
-{
-   ((Stats *)st)->Clear();
-}
+void StatClear(void *st) { ((Stats *)st)->Clear(); }
 
-void StatAddSample (void * st, int val)
-{
-   ((Stats *)st)->AddSample(val);
-}
+void StatAddSample(void *st, int val) { ((Stats *)st)->AddSample(val); }
 
-double StatAverage(void * st) 
-{
-   return((Stats *)st)->Average();
-}
+double StatAverage(void *st) { return ((Stats *)st)->Average(); }
 
-double StatMax(void * st) 
-{
-   return((Stats *)st)->Max();
-}
+double StatMax(void *st) { return ((Stats *)st)->Max(); }
 
-double StatMin(void * st) 
-{
-   return((Stats *)st)->Min();
-}
+double StatMin(void *st) { return ((Stats *)st)->Min(); }
 
-void StatDisp (void * st)
-{
-   printf ("Stats for ");
-   ((Stats *)st)->DisplayHierarchy();
-//   if (((Stats *)st)->NeverUsed()) {
-//      printf (" was never updated!\n");
-//   } else {
-      printf("Min %f Max %f Average %f \n",((Stats *)st)->Min(),((Stats *)st)->Max(),StatAverage(st));
-      ((Stats *)st)->Display();
-//   }
+void StatDisp(void *st) {
+  printf("Stats for ");
+  ((Stats *)st)->DisplayHierarchy();
+  //   if (((Stats *)st)->NeverUsed()) {
+  //      printf (" was never updated!\n");
+  //   } else {
+  printf("Min %f Max %f Average %f \n", ((Stats *)st)->Min(),
+         ((Stats *)st)->Max(), StatAverage(st));
+  ((Stats *)st)->Display();
+  //   }
 }
 
 #if 0 
@@ -55,5 +40,3 @@ int main ()
    StatDisp(mytest);
 }
 #endif
-
-

--- a/src/statwrapper.cc
+++ b/src/statwrapper.cc
@@ -1,33 +1,48 @@
-// a Wraper function for stats class
-#include <stdio.h>
+//a Wraper function for stats class
 #include "intersim2/stats.hpp"
+#include <stdio.h>
 
-Stats *StatCreate(const char *name, double bin_size, int num_bins) {
-  Stats *newstat = new Stats(NULL, name, bin_size, num_bins);
-  newstat->Clear();
-  return newstat;
+Stats* StatCreate (const char * name, double bin_size, int num_bins) {
+   Stats* newstat = new Stats(NULL,name,bin_size,num_bins);
+   newstat->Clear ();
+   return newstat;  
 }
 
-void StatClear(void *st) { ((Stats *)st)->Clear(); }
+void StatClear(void * st)
+{
+   ((Stats *)st)->Clear();
+}
 
-void StatAddSample(void *st, int val) { ((Stats *)st)->AddSample(val); }
+void StatAddSample (void * st, int val)
+{
+   ((Stats *)st)->AddSample(val);
+}
 
-double StatAverage(void *st) { return ((Stats *)st)->Average(); }
+double StatAverage(void * st) 
+{
+   return((Stats *)st)->Average();
+}
 
-double StatMax(void *st) { return ((Stats *)st)->Max(); }
+double StatMax(void * st) 
+{
+   return((Stats *)st)->Max();
+}
 
-double StatMin(void *st) { return ((Stats *)st)->Min(); }
+double StatMin(void * st) 
+{
+   return((Stats *)st)->Min();
+}
 
-void StatDisp(void *st) {
-  printf("Stats for ");
-  ((Stats *)st)->DisplayHierarchy();
-  //   if (((Stats *)st)->NeverUsed()) {
-  //      printf (" was never updated!\n");
-  //   } else {
-  printf("Min %f Max %f Average %f \n", ((Stats *)st)->Min(),
-         ((Stats *)st)->Max(), StatAverage(st));
-  ((Stats *)st)->Display();
-  //   }
+void StatDisp (void * st)
+{
+   printf ("Stats for ");
+   ((Stats *)st)->DisplayHierarchy();
+//   if (((Stats *)st)->NeverUsed()) {
+//      printf (" was never updated!\n");
+//   } else {
+      printf("Min %f Max %f Average %f \n",((Stats *)st)->Min(),((Stats *)st)->Max(),StatAverage(st));
+      ((Stats *)st)->Display();
+//   }
 }
 
 #if 0 
@@ -40,3 +55,5 @@ int main ()
    StatDisp(mytest);
 }
 #endif
+
+

--- a/src/statwrapper.h
+++ b/src/statwrapper.h
@@ -1,12 +1,12 @@
 #ifndef STAT_WRAPER_H
 #define STAT_WRAPER_H
 
-class Stats* StatCreate (const char * name, double bin_size, int num_bins) ;
-void StatClear(void * st);
-void StatAddSample (void * st, int val);
-double StatAverage(void * st) ;
-double StatMax(void * st) ;
-double StatMin(void * st) ;
-void StatDisp (void * st);
+class Stats* StatCreate(const char* name, double bin_size, int num_bins);
+void StatClear(void* st);
+void StatAddSample(void* st, int val);
+double StatAverage(void* st);
+double StatMax(void* st);
+double StatMin(void* st);
+void StatDisp(void* st);
 
 #endif

--- a/src/statwrapper.h
+++ b/src/statwrapper.h
@@ -1,12 +1,12 @@
 #ifndef STAT_WRAPER_H
 #define STAT_WRAPER_H
 
-class Stats* StatCreate(const char* name, double bin_size, int num_bins);
-void StatClear(void* st);
-void StatAddSample(void* st, int val);
-double StatAverage(void* st);
-double StatMax(void* st);
-double StatMin(void* st);
-void StatDisp(void* st);
+class Stats* StatCreate (const char * name, double bin_size, int num_bins) ;
+void StatClear(void * st);
+void StatAddSample (void * st, int val);
+double StatAverage(void * st) ;
+double StatMax(void * st) ;
+double StatMin(void * st) ;
+void StatDisp (void * st);
 
 #endif

--- a/src/stream_manager.cc
+++ b/src/stream_manager.cc
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -28,445 +26,463 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "stream_manager.h"
-#include "../libcuda/gpgpu_context.h"
+#include "gpgpusim_entrypoint.h"
 #include "cuda-sim/cuda-sim.h"
 #include "gpgpu-sim/gpu-sim.h"
-#include "gpgpusim_entrypoint.h"
+#include "../libcuda/gpgpu_context.h"
 
 unsigned CUstream_st::sm_next_stream_uid = 0;
 
-CUstream_st::CUstream_st() {
-  m_pending = false;
-  m_uid = sm_next_stream_uid++;
-  pthread_mutex_init(&m_lock, NULL);
+CUstream_st::CUstream_st() 
+{
+    m_pending = false;
+    m_uid = sm_next_stream_uid++;
+    pthread_mutex_init(&m_lock,NULL);
 }
 
-bool CUstream_st::empty() {
-  pthread_mutex_lock(&m_lock);
-  bool empty = m_operations.empty();
-  pthread_mutex_unlock(&m_lock);
-  return empty;
-}
-
-bool CUstream_st::busy() {
-  pthread_mutex_lock(&m_lock);
-  bool pending = m_pending;
-  pthread_mutex_unlock(&m_lock);
-  return pending;
-}
-
-void CUstream_st::synchronize() {
-  // called by host thread
-  bool done = false;
-  do {
+bool CUstream_st::empty()
+{
     pthread_mutex_lock(&m_lock);
-    done = m_operations.empty();
+    bool empty = m_operations.empty();
     pthread_mutex_unlock(&m_lock);
-  } while (!done);
+    return empty;
 }
 
-void CUstream_st::push(const stream_operation &op) {
-  // called by host thread
-  pthread_mutex_lock(&m_lock);
-  m_operations.push_back(op);
-  pthread_mutex_unlock(&m_lock);
+bool CUstream_st::busy()
+{
+    pthread_mutex_lock(&m_lock);
+    bool pending = m_pending;
+    pthread_mutex_unlock(&m_lock);
+    return pending;
 }
 
-void CUstream_st::record_next_done() {
-  // called by gpu thread
-  pthread_mutex_lock(&m_lock);
-  assert(m_pending);
-  m_operations.pop_front();
-  m_pending = false;
-  pthread_mutex_unlock(&m_lock);
+void CUstream_st::synchronize() 
+{
+    // called by host thread
+    bool done=false;
+    do{
+        pthread_mutex_lock(&m_lock);
+        done = m_operations.empty();
+        pthread_mutex_unlock(&m_lock);
+    } while ( !done );
 }
 
-stream_operation CUstream_st::next() {
-  // called by gpu thread
-  pthread_mutex_lock(&m_lock);
-  m_pending = true;
-  stream_operation result = m_operations.front();
-  pthread_mutex_unlock(&m_lock);
-  return result;
+void CUstream_st::push( const stream_operation &op )
+{
+    // called by host thread
+    pthread_mutex_lock(&m_lock);
+    m_operations.push_back( op );
+    pthread_mutex_unlock(&m_lock);
 }
 
-void CUstream_st::cancel_front() {
-  pthread_mutex_lock(&m_lock);
-  assert(m_pending);
-  m_pending = false;
-  pthread_mutex_unlock(&m_lock);
+void CUstream_st::record_next_done()
+{
+    // called by gpu thread
+    pthread_mutex_lock(&m_lock);
+    assert(m_pending);
+    m_operations.pop_front();
+    m_pending=false;
+    pthread_mutex_unlock(&m_lock);
 }
 
-void CUstream_st::print(FILE *fp) {
-  pthread_mutex_lock(&m_lock);
-  fprintf(fp, "GPGPU-Sim API:    stream %u has %zu operations\n", m_uid,
-          m_operations.size());
-  std::list<stream_operation>::iterator i;
-  unsigned n = 0;
-  for (i = m_operations.begin(); i != m_operations.end(); i++) {
-    stream_operation &op = *i;
-    fprintf(fp, "GPGPU-Sim API:       %u : ", n++);
-    op.print(fp);
-    fprintf(fp, "\n");
-  }
-  pthread_mutex_unlock(&m_lock);
+
+stream_operation CUstream_st::next()
+{
+    // called by gpu thread
+    pthread_mutex_lock(&m_lock);
+    m_pending = true;
+    stream_operation result = m_operations.front();
+    pthread_mutex_unlock(&m_lock);
+    return result;
 }
 
-bool stream_operation::do_operation(gpgpu_sim *gpu) {
-  if (is_noop()) return true;
+void CUstream_st::cancel_front()
+{
+    pthread_mutex_lock(&m_lock);
+    assert(m_pending);
+    m_pending = false;
+    pthread_mutex_unlock(&m_lock);
 
-  assert(!m_done && m_stream);
-  if (g_debug_execution >= 3)
-    printf("GPGPU-Sim API: stream %u performing ", m_stream->get_uid());
-  switch (m_type) {
+}
+
+void CUstream_st::print(FILE *fp)
+{
+    pthread_mutex_lock(&m_lock);
+    fprintf(fp,"GPGPU-Sim API:    stream %u has %zu operations\n", m_uid, m_operations.size() );
+    std::list<stream_operation>::iterator i;
+    unsigned n=0;
+    for( i=m_operations.begin(); i!=m_operations.end(); i++ ) {
+        stream_operation &op = *i;
+        fprintf(fp,"GPGPU-Sim API:       %u : ", n++);
+        op.print(fp);
+        fprintf(fp,"\n");
+    }
+    pthread_mutex_unlock(&m_lock);
+}
+
+
+bool stream_operation::do_operation( gpgpu_sim *gpu )
+{
+    if( is_noop() ) 
+        return true;
+
+    assert(!m_done && m_stream);
+    if(g_debug_execution >= 3)
+       printf("GPGPU-Sim API: stream %u performing ", m_stream->get_uid() );
+    switch( m_type ) {
     case stream_memcpy_host_to_device:
-      if (g_debug_execution >= 3) printf("memcpy host-to-device\n");
-      gpu->memcpy_to_gpu(m_device_address_dst, m_host_address_src, m_cnt);
-      m_stream->record_next_done();
-      break;
+        if(g_debug_execution >= 3)
+            printf("memcpy host-to-device\n");
+        gpu->memcpy_to_gpu(m_device_address_dst,m_host_address_src,m_cnt);
+        m_stream->record_next_done();
+        break;
     case stream_memcpy_device_to_host:
-      if (g_debug_execution >= 3) printf("memcpy device-to-host\n");
-      gpu->memcpy_from_gpu(m_host_address_dst, m_device_address_src, m_cnt);
-      m_stream->record_next_done();
-      break;
+        if(g_debug_execution >= 3)
+            printf("memcpy device-to-host\n");
+        gpu->memcpy_from_gpu(m_host_address_dst,m_device_address_src,m_cnt);
+        m_stream->record_next_done();
+        break;
     case stream_memcpy_device_to_device:
-      if (g_debug_execution >= 3) printf("memcpy device-to-device\n");
-      gpu->memcpy_gpu_to_gpu(m_device_address_dst, m_device_address_src, m_cnt);
-      m_stream->record_next_done();
-      break;
+        if(g_debug_execution >= 3)
+            printf("memcpy device-to-device\n");
+        gpu->memcpy_gpu_to_gpu(m_device_address_dst,m_device_address_src,m_cnt); 
+        m_stream->record_next_done();
+        break;
     case stream_memcpy_to_symbol:
-      if (g_debug_execution >= 3) printf("memcpy to symbol\n");
-      gpu->gpgpu_ctx->func_sim->gpgpu_ptx_sim_memcpy_symbol(
-          m_symbol, m_host_address_src, m_cnt, m_offset, 1, gpu);
-      m_stream->record_next_done();
-      break;
+        if(g_debug_execution >= 3)
+            printf("memcpy to symbol\n");
+        gpu->gpgpu_ctx->func_sim->gpgpu_ptx_sim_memcpy_symbol(m_symbol,m_host_address_src,m_cnt,m_offset,1,gpu);
+        m_stream->record_next_done();
+        break;
     case stream_memcpy_from_symbol:
-      if (g_debug_execution >= 3) printf("memcpy from symbol\n");
-      gpu->gpgpu_ctx->func_sim->gpgpu_ptx_sim_memcpy_symbol(
-          m_symbol, m_host_address_dst, m_cnt, m_offset, 0, gpu);
-      m_stream->record_next_done();
-      break;
+        if(g_debug_execution >= 3)
+            printf("memcpy from symbol\n");
+        gpu->gpgpu_ctx->func_sim->gpgpu_ptx_sim_memcpy_symbol(m_symbol,m_host_address_dst,m_cnt,m_offset,0,gpu);
+        m_stream->record_next_done();
+        break;
     case stream_kernel_launch:
-      if (m_sim_mode) {  // Functional Sim
-        if (g_debug_execution >= 3) {
-          printf("kernel %d: \'%s\' transfer to GPU hardware scheduler\n",
-                 m_kernel->get_uid(), m_kernel->name().c_str());
-          m_kernel->print_parent_info();
+        if( m_sim_mode ) { //Functional Sim
+            if(g_debug_execution >= 3) {
+                printf("kernel %d: \'%s\' transfer to GPU hardware scheduler\n", m_kernel->get_uid(), m_kernel->name().c_str() );
+                m_kernel->print_parent_info();
+            }
+            gpu->set_cache_config(m_kernel->name());
+            gpu->functional_launch( m_kernel );
         }
-        gpu->set_cache_config(m_kernel->name());
-        gpu->functional_launch(m_kernel);
-      } else {  // Performance Sim
-        if (gpu->can_start_kernel() && m_kernel->m_launch_latency == 0) {
-          if (g_debug_execution >= 3) {
-            printf("kernel %d: \'%s\' transfer to GPU hardware scheduler\n",
-                   m_kernel->get_uid(), m_kernel->name().c_str());
-            m_kernel->print_parent_info();
-          }
-          gpu->set_cache_config(m_kernel->name());
-          gpu->launch(m_kernel);
-        } else {
-          if (m_kernel->m_launch_latency) m_kernel->m_launch_latency--;
-          if (g_debug_execution >= 3)
-            printf(
-                "kernel %d: \'%s\', latency %u not ready to transfer to GPU "
-                "hardware scheduler\n",
-                m_kernel->get_uid(), m_kernel->name().c_str(),
-                m_kernel->m_launch_latency);
-          return false;
-        }
-      }
-      break;
-    case stream_event: {
-      printf("event update\n");
-      time_t wallclock = time((time_t *)NULL);
-      m_event->update(gpu->gpu_tot_sim_cycle, wallclock);
-      m_stream->record_next_done();
-    } break;
-    case stream_wait_event: {
-      // only allows next op to go if event is done
-      // otherwise stays in the stream queue
-      printf("stream wait event processing...\n");
-      if (m_event->done()) printf("stream wait event done\n");
-      m_stream->record_next_done();
-    } break;
-    default:
-      abort();
-  }
-  m_done = true;
-  fflush(stdout);
-  return true;
-}
-
-void stream_operation::print(FILE *fp) const {
-  fprintf(fp, " stream operation ");
-  switch (m_type) {
-    case stream_event:
-      fprintf(fp, "event");
-      break;
-    case stream_kernel_launch:
-      fprintf(fp, "kernel");
-      break;
-    case stream_memcpy_device_to_device:
-      fprintf(fp, "memcpy device-to-device");
-      break;
-    case stream_memcpy_device_to_host:
-      fprintf(fp, "memcpy device-to-host");
-      break;
-    case stream_memcpy_host_to_device:
-      fprintf(fp, "memcpy host-to-device");
-      break;
-    case stream_memcpy_to_symbol:
-      fprintf(fp, "memcpy to symbol");
-      break;
-    case stream_memcpy_from_symbol:
-      fprintf(fp, "memcpy from symbol");
-      break;
-    case stream_no_op:
-      fprintf(fp, "no-op");
-      break;
-  }
-}
-
-stream_manager::stream_manager(gpgpu_sim *gpu, bool cuda_launch_blocking) {
-  m_gpu = gpu;
-  m_service_stream_zero = false;
-  m_cuda_launch_blocking = cuda_launch_blocking;
-  pthread_mutex_init(&m_lock, NULL);
-}
-
-bool stream_manager::operation(bool *sim) {
-  bool check = check_finished_kernel();
-  pthread_mutex_lock(&m_lock);
-  //    if(check)m_gpu->print_stats();
-  stream_operation op = front();
-  if (!op.do_operation(m_gpu))  // not ready to execute
-  {
-    // cancel operation
-    if (op.is_kernel()) {
-      unsigned grid_uid = op.get_kernel()->get_uid();
-      m_grid_id_to_stream.erase(grid_uid);
-    }
-    op.get_stream()->cancel_front();
-  }
-  pthread_mutex_unlock(&m_lock);
-  // pthread_mutex_lock(&m_lock);
-  // simulate a clock cycle on the GPU
-  return check;
-}
-
-bool stream_manager::check_finished_kernel() {
-  unsigned grid_uid = m_gpu->finished_kernel();
-  bool check = register_finished_kernel(grid_uid);
-  return check;
-}
-
-bool stream_manager::register_finished_kernel(unsigned grid_uid) {
-  // called by gpu simulation thread
-  if (grid_uid > 0) {
-    CUstream_st *stream = m_grid_id_to_stream[grid_uid];
-    kernel_info_t *kernel = stream->front().get_kernel();
-    assert(grid_uid == kernel->get_uid());
-
-    // Jin: should check children kernels for CDP
-    if (kernel->is_finished()) {
-      //            std::ofstream kernel_stat("kernel_stat.txt",
-      //            std::ofstream::out | std::ofstream::app);
-      //            kernel_stat<< " kernel " << grid_uid << ": " <<
-      //            kernel->name();
-      //            if(kernel->get_parent())
-      //                kernel_stat << ", parent " <<
-      //                kernel->get_parent()->get_uid() <<
-      //                ", launch " << kernel->launch_cycle;
-      //            kernel_stat<< ", start " << kernel->start_cycle <<
-      //                ", end " << kernel->end_cycle << ", retire " <<
-      //                gpu_sim_cycle + gpu_tot_sim_cycle << "\n";
-      //            printf("kernel %d finishes, retires from stream %d\n",
-      //            grid_uid, stream->get_uid());
-      //            kernel_stat.flush();
-      //            kernel_stat.close();
-      stream->record_next_done();
-      m_grid_id_to_stream.erase(grid_uid);
-      kernel->notify_parent_finished();
-      delete kernel;
-      return true;
-    }
-  }
-
-  return false;
-}
-
-void stream_manager::stop_all_running_kernels() {
-  pthread_mutex_lock(&m_lock);
-
-  // Signal m_gpu to stop all running kernels
-  m_gpu->stop_all_running_kernels();
-
-  // Clean up all streams waiting on running kernels
-  int count = 0;
-  while (check_finished_kernel()) {
-    count++;
-  }
-
-  // If any kernels completed, print out the current stats
-  if (count > 0) m_gpu->print_stats();
-
-  pthread_mutex_unlock(&m_lock);
-}
-
-stream_operation stream_manager::front() {
-  // called by gpu simulation thread
-  stream_operation result;
-  //    if( concurrent_streams_empty() )
-  m_service_stream_zero = true;
-  if (m_service_stream_zero) {
-    if (!m_stream_zero.empty() && !m_stream_zero.busy()) {
-      result = m_stream_zero.next();
-      if (result.is_kernel()) {
-        unsigned grid_id = result.get_kernel()->get_uid();
-        m_grid_id_to_stream[grid_id] = &m_stream_zero;
-      }
-    } else {
-      m_service_stream_zero = false;
-    }
-  }
-
-  if (!m_service_stream_zero) {
-    std::list<struct CUstream_st *>::iterator s;
-    for (s = m_streams.begin(); s != m_streams.end(); s++) {
-      CUstream_st *stream = *s;
-      if (!stream->busy() && !stream->empty()) {
-        result = stream->next();
-        if (result.is_kernel()) {
-          unsigned grid_id = result.get_kernel()->get_uid();
-          m_grid_id_to_stream[grid_id] = stream;
+        else { //Performance Sim
+            if( gpu->can_start_kernel() && m_kernel->m_launch_latency == 0) {
+                if(g_debug_execution >= 3) {
+                    printf("kernel %d: \'%s\' transfer to GPU hardware scheduler\n", m_kernel->get_uid(), m_kernel->name().c_str() );
+                    m_kernel->print_parent_info();
+                }
+                gpu->set_cache_config(m_kernel->name());
+                gpu->launch( m_kernel );
+            }
+            else {
+                if(m_kernel->m_launch_latency)
+                    m_kernel->m_launch_latency--;
+                if(g_debug_execution >= 3)
+                    printf("kernel %d: \'%s\', latency %u not ready to transfer to GPU hardware scheduler\n", 
+                        m_kernel->get_uid(), m_kernel->name().c_str(), m_kernel->m_launch_latency);
+                return false;    
+            }
         }
         break;
-      }
+    case stream_event: {
+        printf("event update\n");
+        time_t wallclock = time((time_t *)NULL);
+        m_event->update( gpu->gpu_tot_sim_cycle, wallclock );
+        m_stream->record_next_done();
+        } 
+        break;
+    case stream_wait_event: {
+        //only allows next op to go if event is done
+        //otherwise stays in the stream queue
+        printf("stream wait event processing...\n");
+        if(m_event->done())
+            printf("stream wait event done\n");
+            m_stream->record_next_done();
+        }
+        break;
+    default:
+        abort();
     }
-  }
-  return result;
+    m_done=true;
+    fflush(stdout);
+    return true;
 }
 
-void stream_manager::add_stream(struct CUstream_st *stream) {
-  // called by host thread
-  pthread_mutex_lock(&m_lock);
-  m_streams.push_back(stream);
-  pthread_mutex_unlock(&m_lock);
-}
-
-void stream_manager::destroy_stream(CUstream_st *stream) {
-  // called by host thread
-  pthread_mutex_lock(&m_lock);
-  while (!stream->empty())
-    ;
-  std::list<CUstream_st *>::iterator s;
-  for (s = m_streams.begin(); s != m_streams.end(); s++) {
-    if (*s == stream) {
-      m_streams.erase(s);
-      break;
+void stream_operation::print( FILE *fp ) const
+{
+    fprintf(fp," stream operation " );
+    switch( m_type ) {
+    case stream_event: fprintf(fp,"event"); break;
+    case stream_kernel_launch: fprintf(fp,"kernel"); break;
+    case stream_memcpy_device_to_device: fprintf(fp,"memcpy device-to-device"); break;
+    case stream_memcpy_device_to_host: fprintf(fp,"memcpy device-to-host"); break;
+    case stream_memcpy_host_to_device: fprintf(fp,"memcpy host-to-device"); break;
+    case stream_memcpy_to_symbol: fprintf(fp,"memcpy to symbol"); break;
+    case stream_memcpy_from_symbol: fprintf(fp,"memcpy from symbol"); break;
+    case stream_no_op: fprintf(fp,"no-op"); break;
     }
-  }
-  delete stream;
-  pthread_mutex_unlock(&m_lock);
 }
 
-bool stream_manager::concurrent_streams_empty() {
-  bool result = true;
-  if (m_streams.empty()) return true;
-  // called by gpu simulation thread
-  std::list<struct CUstream_st *>::iterator s;
-  for (s = m_streams.begin(); s != m_streams.end(); ++s) {
-    struct CUstream_st *stream = *s;
-    if (!stream->empty()) {
-      // stream->print(stdout);
-      result = false;
-      break;
-    }
-  }
-  return result;
+stream_manager::stream_manager( gpgpu_sim *gpu, bool cuda_launch_blocking ) 
+{
+    m_gpu = gpu;
+    m_service_stream_zero = false;
+    m_cuda_launch_blocking = cuda_launch_blocking;
+    pthread_mutex_init(&m_lock,NULL);
 }
 
-bool stream_manager::empty_protected() {
-  bool result = true;
-  pthread_mutex_lock(&m_lock);
-  if (!concurrent_streams_empty()) result = false;
-  if (!m_stream_zero.empty()) result = false;
-  pthread_mutex_unlock(&m_lock);
-  return result;
-}
-
-bool stream_manager::empty() {
-  bool result = true;
-  if (!concurrent_streams_empty()) result = false;
-  if (!m_stream_zero.empty()) result = false;
-  return result;
-}
-
-void stream_manager::print(FILE *fp) {
-  pthread_mutex_lock(&m_lock);
-  print_impl(fp);
-  pthread_mutex_unlock(&m_lock);
-}
-void stream_manager::print_impl(FILE *fp) {
-  fprintf(fp, "GPGPU-Sim API: Stream Manager State\n");
-  std::list<struct CUstream_st *>::iterator s;
-  for (s = m_streams.begin(); s != m_streams.end(); ++s) {
-    struct CUstream_st *stream = *s;
-    if (!stream->empty()) stream->print(fp);
-  }
-  if (!m_stream_zero.empty()) m_stream_zero.print(fp);
-}
-
-void stream_manager::push(stream_operation op) {
-  struct CUstream_st *stream = op.get_stream();
-
-  // block if stream 0 (or concurrency disabled) and pending concurrent
-  // operations exist
-  bool block = !stream || m_cuda_launch_blocking;
-  while (block) {
+bool stream_manager::operation( bool * sim)
+{
+    bool check=check_finished_kernel();
     pthread_mutex_lock(&m_lock);
-    block = !concurrent_streams_empty();
-    pthread_mutex_unlock(&m_lock);
-  };
+//    if(check)m_gpu->print_stats();
+    stream_operation op =front();
+    if(!op.do_operation( m_gpu )) //not ready to execute
+    {
+        //cancel operation
+        if( op.is_kernel() ) {
+            unsigned grid_uid = op.get_kernel()->get_uid();
+            m_grid_id_to_stream.erase(grid_uid);
+        }
+        op.get_stream()->cancel_front();
 
-  pthread_mutex_lock(&m_lock);
-  if (!m_gpu->cycle_insn_cta_max_hit()) {
-    // Accept the stream operation if the maximum cycle/instruction/cta counts
-    // are not triggered
-    if (stream && !m_cuda_launch_blocking) {
-      stream->push(op);
-    } else {
-      op.set_stream(&m_stream_zero);
-      m_stream_zero.push(op);
     }
-  } else {
-    // Otherwise, ignore operation and continue
-    printf(
-        "GPGPU-Sim API: Maximum cycle, instruction, or CTA count hit. "
-        "Skipping:");
-    op.print(stdout);
-    printf("\n");
-  }
-  if (g_debug_execution >= 3) print_impl(stdout);
-  pthread_mutex_unlock(&m_lock);
-  if (m_cuda_launch_blocking || stream == NULL) {
-    unsigned int wait_amount = 100;
-    unsigned int wait_cap = 100000;  // 100ms
-    while (!empty()) {
-      // sleep to prevent CPU hog by empty spin
-      // sleep time increased exponentially ensure fast response when needed
-      usleep(wait_amount);
-      wait_amount *= 2;
-      if (wait_amount > wait_cap) wait_amount = wait_cap;
-    }
-  }
+    pthread_mutex_unlock(&m_lock);
+    //pthread_mutex_lock(&m_lock);
+    // simulate a clock cycle on the GPU
+    return check;
 }
 
-void stream_manager::pushCudaStreamWaitEventToAllStreams(CUevent_st *e,
-                                                         unsigned int flags) {
-  std::list<CUstream_st *>::iterator s;
-  for (s = m_streams.begin(); s != m_streams.end(); s++) {
-    stream_operation op(*s, e, flags);
-    push(op);
-  }
+bool stream_manager::check_finished_kernel()
+{
+    unsigned grid_uid = m_gpu->finished_kernel();
+    bool check=register_finished_kernel(grid_uid);
+    return check;
+}
+
+bool stream_manager::register_finished_kernel(unsigned grid_uid)
+{
+    // called by gpu simulation thread
+    if(grid_uid > 0){
+        CUstream_st *stream = m_grid_id_to_stream[grid_uid];
+        kernel_info_t *kernel = stream->front().get_kernel();
+        assert( grid_uid == kernel->get_uid() );
+
+        //Jin: should check children kernels for CDP
+        if(kernel->is_finished()) {
+//            std::ofstream kernel_stat("kernel_stat.txt", std::ofstream::out | std::ofstream::app);
+//            kernel_stat<< " kernel " << grid_uid << ": " << kernel->name();
+//            if(kernel->get_parent())
+//                kernel_stat << ", parent " << kernel->get_parent()->get_uid() <<
+//                ", launch " << kernel->launch_cycle;
+//            kernel_stat<< ", start " << kernel->start_cycle <<
+//                ", end " << kernel->end_cycle << ", retire " << gpu_sim_cycle + gpu_tot_sim_cycle << "\n";
+//            printf("kernel %d finishes, retires from stream %d\n", grid_uid, stream->get_uid());
+//            kernel_stat.flush();
+//            kernel_stat.close();
+            stream->record_next_done();
+            m_grid_id_to_stream.erase(grid_uid);
+            kernel->notify_parent_finished();
+            delete kernel;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void stream_manager::stop_all_running_kernels(){
+    pthread_mutex_lock(&m_lock);
+
+    // Signal m_gpu to stop all running kernels
+    m_gpu->stop_all_running_kernels();
+
+    // Clean up all streams waiting on running kernels
+    int count=0;
+    while(check_finished_kernel()){
+        count++;
+    }
+
+    // If any kernels completed, print out the current stats
+    if(count > 0)
+        m_gpu->print_stats();
+
+    pthread_mutex_unlock(&m_lock);
+}
+
+stream_operation stream_manager::front() 
+{
+    // called by gpu simulation thread
+    stream_operation result;
+//    if( concurrent_streams_empty() )
+    m_service_stream_zero = true;
+    if( m_service_stream_zero ) {
+        if( !m_stream_zero.empty() && !m_stream_zero.busy() ) {
+                result = m_stream_zero.next();
+                if( result.is_kernel() ) {
+                    unsigned grid_id = result.get_kernel()->get_uid();
+                    m_grid_id_to_stream[grid_id] = &m_stream_zero;
+                }
+        } else {
+            m_service_stream_zero = false;
+        }
+    }
+    
+    if(!m_service_stream_zero)
+    {
+        std::list<struct CUstream_st*>::iterator s;
+        for( s=m_streams.begin(); s != m_streams.end(); s++) {
+            CUstream_st *stream = *s;
+            if( !stream->busy() && !stream->empty() ) {
+                result = stream->next();
+                if( result.is_kernel() ) {
+                    unsigned grid_id = result.get_kernel()->get_uid();
+                    m_grid_id_to_stream[grid_id] = stream;
+                }
+                break;
+            }
+        }
+    }
+    return result;
+}
+
+void stream_manager::add_stream( struct CUstream_st *stream )
+{
+    // called by host thread
+    pthread_mutex_lock(&m_lock);
+    m_streams.push_back(stream);
+    pthread_mutex_unlock(&m_lock);
+}
+
+void stream_manager::destroy_stream( CUstream_st *stream )
+{
+    // called by host thread
+    pthread_mutex_lock(&m_lock);
+    while( !stream->empty() )
+        ; 
+    std::list<CUstream_st *>::iterator s;
+    for( s=m_streams.begin(); s != m_streams.end(); s++ ) {
+        if( *s == stream ) {
+            m_streams.erase(s);
+            break;
+        }
+    }
+    delete stream; 
+    pthread_mutex_unlock(&m_lock);
+}
+
+bool stream_manager::concurrent_streams_empty()
+{
+    bool result = true;
+    if (m_streams.empty())
+       return true;
+    // called by gpu simulation thread
+    std::list<struct CUstream_st *>::iterator s;
+    for( s=m_streams.begin(); s!=m_streams.end();++s ) {
+        struct CUstream_st *stream = *s;
+        if( !stream->empty() ) {
+            //stream->print(stdout);
+            result = false;
+            break;
+        }
+    }
+    return result;
+}
+
+bool stream_manager::empty_protected()
+{
+    bool result = true;
+    pthread_mutex_lock(&m_lock);
+    if( !concurrent_streams_empty() )
+        result = false;
+    if( !m_stream_zero.empty() )
+        result = false;
+    pthread_mutex_unlock(&m_lock);
+    return result;
+}
+
+bool stream_manager::empty()
+{
+    bool result = true;
+    if( !concurrent_streams_empty() ) 
+        result = false;
+    if( !m_stream_zero.empty() ) 
+        result = false;
+    return result;
+}
+
+
+void stream_manager::print( FILE *fp)
+{
+    pthread_mutex_lock(&m_lock);
+    print_impl(fp);
+    pthread_mutex_unlock(&m_lock);
+}
+void stream_manager::print_impl( FILE *fp)
+{
+    fprintf(fp,"GPGPU-Sim API: Stream Manager State\n");
+    std::list<struct CUstream_st *>::iterator s;
+    for( s=m_streams.begin(); s!=m_streams.end();++s ) {
+        struct CUstream_st *stream = *s;
+        if( !stream->empty() ) 
+            stream->print(fp);
+    }
+    if( !m_stream_zero.empty() ) 
+        m_stream_zero.print(fp);
+}
+
+void stream_manager::push( stream_operation op )
+{
+    struct CUstream_st *stream = op.get_stream();
+
+    // block if stream 0 (or concurrency disabled) and pending concurrent operations exist
+    bool block= !stream || m_cuda_launch_blocking;
+    while(block) {
+        pthread_mutex_lock(&m_lock);
+        block = !concurrent_streams_empty();
+        pthread_mutex_unlock(&m_lock);
+    };
+
+    pthread_mutex_lock(&m_lock);
+    if(!m_gpu->cycle_insn_cta_max_hit()) {
+        // Accept the stream operation if the maximum cycle/instruction/cta counts are not triggered
+        if( stream && !m_cuda_launch_blocking ) {
+            stream->push(op);
+        } else {
+            op.set_stream(&m_stream_zero);
+            m_stream_zero.push(op);
+        }
+    }else {
+        // Otherwise, ignore operation and continue
+        printf("GPGPU-Sim API: Maximum cycle, instruction, or CTA count hit. Skipping:");
+        op.print(stdout);
+        printf("\n");
+    }
+    if(g_debug_execution >= 3)
+       print_impl(stdout);
+    pthread_mutex_unlock(&m_lock);
+    if( m_cuda_launch_blocking || stream == NULL ) {
+        unsigned int wait_amount = 100; 
+        unsigned int wait_cap = 100000; // 100ms 
+        while( !empty() ) {
+            // sleep to prevent CPU hog by empty spin
+            // sleep time increased exponentially ensure fast response when needed 
+            usleep(wait_amount); 
+            wait_amount *= 2; 
+            if (wait_amount > wait_cap) 
+               wait_amount = wait_cap; 
+        }
+    }
+}
+
+void stream_manager::pushCudaStreamWaitEventToAllStreams( CUevent_st *e, unsigned int flags ){
+    std::list<CUstream_st *>::iterator s;
+    for( s=m_streams.begin(); s != m_streams.end(); s++ ) {
+        stream_operation op(*s,e,flags);
+        push(op);
+    }
 }

--- a/src/stream_manager.cc
+++ b/src/stream_manager.cc
@@ -7,482 +7,463 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #include "stream_manager.h"
-#include "gpgpusim_entrypoint.h"
+#include "../libcuda/gpgpu_context.h"
 #include "cuda-sim/cuda-sim.h"
 #include "gpgpu-sim/gpu-sim.h"
-#include "../libcuda/gpgpu_context.h"
+#include "gpgpusim_entrypoint.h"
 
 unsigned CUstream_st::sm_next_stream_uid = 0;
 
-CUstream_st::CUstream_st() 
-{
-    m_pending = false;
-    m_uid = sm_next_stream_uid++;
-    pthread_mutex_init(&m_lock,NULL);
+CUstream_st::CUstream_st() {
+  m_pending = false;
+  m_uid = sm_next_stream_uid++;
+  pthread_mutex_init(&m_lock, NULL);
 }
 
-bool CUstream_st::empty()
-{
+bool CUstream_st::empty() {
+  pthread_mutex_lock(&m_lock);
+  bool empty = m_operations.empty();
+  pthread_mutex_unlock(&m_lock);
+  return empty;
+}
+
+bool CUstream_st::busy() {
+  pthread_mutex_lock(&m_lock);
+  bool pending = m_pending;
+  pthread_mutex_unlock(&m_lock);
+  return pending;
+}
+
+void CUstream_st::synchronize() {
+  // called by host thread
+  bool done = false;
+  do {
     pthread_mutex_lock(&m_lock);
-    bool empty = m_operations.empty();
+    done = m_operations.empty();
     pthread_mutex_unlock(&m_lock);
-    return empty;
+  } while (!done);
 }
 
-bool CUstream_st::busy()
-{
-    pthread_mutex_lock(&m_lock);
-    bool pending = m_pending;
-    pthread_mutex_unlock(&m_lock);
-    return pending;
+void CUstream_st::push(const stream_operation &op) {
+  // called by host thread
+  pthread_mutex_lock(&m_lock);
+  m_operations.push_back(op);
+  pthread_mutex_unlock(&m_lock);
 }
 
-void CUstream_st::synchronize() 
-{
-    // called by host thread
-    bool done=false;
-    do{
-        pthread_mutex_lock(&m_lock);
-        done = m_operations.empty();
-        pthread_mutex_unlock(&m_lock);
-    } while ( !done );
+void CUstream_st::record_next_done() {
+  // called by gpu thread
+  pthread_mutex_lock(&m_lock);
+  assert(m_pending);
+  m_operations.pop_front();
+  m_pending = false;
+  pthread_mutex_unlock(&m_lock);
 }
 
-void CUstream_st::push( const stream_operation &op )
-{
-    // called by host thread
-    pthread_mutex_lock(&m_lock);
-    m_operations.push_back( op );
-    pthread_mutex_unlock(&m_lock);
+stream_operation CUstream_st::next() {
+  // called by gpu thread
+  pthread_mutex_lock(&m_lock);
+  m_pending = true;
+  stream_operation result = m_operations.front();
+  pthread_mutex_unlock(&m_lock);
+  return result;
 }
 
-void CUstream_st::record_next_done()
-{
-    // called by gpu thread
-    pthread_mutex_lock(&m_lock);
-    assert(m_pending);
-    m_operations.pop_front();
-    m_pending=false;
-    pthread_mutex_unlock(&m_lock);
+void CUstream_st::cancel_front() {
+  pthread_mutex_lock(&m_lock);
+  assert(m_pending);
+  m_pending = false;
+  pthread_mutex_unlock(&m_lock);
 }
 
-
-stream_operation CUstream_st::next()
-{
-    // called by gpu thread
-    pthread_mutex_lock(&m_lock);
-    m_pending = true;
-    stream_operation result = m_operations.front();
-    pthread_mutex_unlock(&m_lock);
-    return result;
+void CUstream_st::print(FILE *fp) {
+  pthread_mutex_lock(&m_lock);
+  fprintf(fp, "GPGPU-Sim API:    stream %u has %zu operations\n", m_uid,
+          m_operations.size());
+  std::list<stream_operation>::iterator i;
+  unsigned n = 0;
+  for (i = m_operations.begin(); i != m_operations.end(); i++) {
+    stream_operation &op = *i;
+    fprintf(fp, "GPGPU-Sim API:       %u : ", n++);
+    op.print(fp);
+    fprintf(fp, "\n");
+  }
+  pthread_mutex_unlock(&m_lock);
 }
 
-void CUstream_st::cancel_front()
-{
-    pthread_mutex_lock(&m_lock);
-    assert(m_pending);
-    m_pending = false;
-    pthread_mutex_unlock(&m_lock);
+bool stream_operation::do_operation(gpgpu_sim *gpu) {
+  if (is_noop()) return true;
 
-}
-
-void CUstream_st::print(FILE *fp)
-{
-    pthread_mutex_lock(&m_lock);
-    fprintf(fp,"GPGPU-Sim API:    stream %u has %zu operations\n", m_uid, m_operations.size() );
-    std::list<stream_operation>::iterator i;
-    unsigned n=0;
-    for( i=m_operations.begin(); i!=m_operations.end(); i++ ) {
-        stream_operation &op = *i;
-        fprintf(fp,"GPGPU-Sim API:       %u : ", n++);
-        op.print(fp);
-        fprintf(fp,"\n");
-    }
-    pthread_mutex_unlock(&m_lock);
-}
-
-
-bool stream_operation::do_operation( gpgpu_sim *gpu )
-{
-    if( is_noop() ) 
-        return true;
-
-    assert(!m_done && m_stream);
-    if(g_debug_execution >= 3)
-       printf("GPGPU-Sim API: stream %u performing ", m_stream->get_uid() );
-    switch( m_type ) {
+  assert(!m_done && m_stream);
+  if (g_debug_execution >= 3)
+    printf("GPGPU-Sim API: stream %u performing ", m_stream->get_uid());
+  switch (m_type) {
     case stream_memcpy_host_to_device:
-        if(g_debug_execution >= 3)
-            printf("memcpy host-to-device\n");
-        gpu->memcpy_to_gpu(m_device_address_dst,m_host_address_src,m_cnt);
-        m_stream->record_next_done();
-        break;
+      if (g_debug_execution >= 3) printf("memcpy host-to-device\n");
+      gpu->memcpy_to_gpu(m_device_address_dst, m_host_address_src, m_cnt);
+      m_stream->record_next_done();
+      break;
     case stream_memcpy_device_to_host:
-        if(g_debug_execution >= 3)
-            printf("memcpy device-to-host\n");
-        gpu->memcpy_from_gpu(m_host_address_dst,m_device_address_src,m_cnt);
-        m_stream->record_next_done();
-        break;
+      if (g_debug_execution >= 3) printf("memcpy device-to-host\n");
+      gpu->memcpy_from_gpu(m_host_address_dst, m_device_address_src, m_cnt);
+      m_stream->record_next_done();
+      break;
     case stream_memcpy_device_to_device:
-        if(g_debug_execution >= 3)
-            printf("memcpy device-to-device\n");
-        gpu->memcpy_gpu_to_gpu(m_device_address_dst,m_device_address_src,m_cnt); 
-        m_stream->record_next_done();
-        break;
+      if (g_debug_execution >= 3) printf("memcpy device-to-device\n");
+      gpu->memcpy_gpu_to_gpu(m_device_address_dst, m_device_address_src, m_cnt);
+      m_stream->record_next_done();
+      break;
     case stream_memcpy_to_symbol:
-        if(g_debug_execution >= 3)
-            printf("memcpy to symbol\n");
-        gpu->gpgpu_ctx->func_sim->gpgpu_ptx_sim_memcpy_symbol(m_symbol,m_host_address_src,m_cnt,m_offset,1,gpu);
-        m_stream->record_next_done();
-        break;
+      if (g_debug_execution >= 3) printf("memcpy to symbol\n");
+      gpu->gpgpu_ctx->func_sim->gpgpu_ptx_sim_memcpy_symbol(
+          m_symbol, m_host_address_src, m_cnt, m_offset, 1, gpu);
+      m_stream->record_next_done();
+      break;
     case stream_memcpy_from_symbol:
-        if(g_debug_execution >= 3)
-            printf("memcpy from symbol\n");
-        gpu->gpgpu_ctx->func_sim->gpgpu_ptx_sim_memcpy_symbol(m_symbol,m_host_address_dst,m_cnt,m_offset,0,gpu);
-        m_stream->record_next_done();
-        break;
+      if (g_debug_execution >= 3) printf("memcpy from symbol\n");
+      gpu->gpgpu_ctx->func_sim->gpgpu_ptx_sim_memcpy_symbol(
+          m_symbol, m_host_address_dst, m_cnt, m_offset, 0, gpu);
+      m_stream->record_next_done();
+      break;
     case stream_kernel_launch:
-        if( m_sim_mode ) { //Functional Sim
-            if(g_debug_execution >= 3) {
-                printf("kernel %d: \'%s\' transfer to GPU hardware scheduler\n", m_kernel->get_uid(), m_kernel->name().c_str() );
-                m_kernel->print_parent_info();
-            }
-            gpu->set_cache_config(m_kernel->name());
-            gpu->functional_launch( m_kernel );
+      if (m_sim_mode) {  // Functional Sim
+        if (g_debug_execution >= 3) {
+          printf("kernel %d: \'%s\' transfer to GPU hardware scheduler\n",
+                 m_kernel->get_uid(), m_kernel->name().c_str());
+          m_kernel->print_parent_info();
         }
-        else { //Performance Sim
-            if( gpu->can_start_kernel() && m_kernel->m_launch_latency == 0) {
-                if(g_debug_execution >= 3) {
-                    printf("kernel %d: \'%s\' transfer to GPU hardware scheduler\n", m_kernel->get_uid(), m_kernel->name().c_str() );
-                    m_kernel->print_parent_info();
-                }
-                gpu->set_cache_config(m_kernel->name());
-                gpu->launch( m_kernel );
-            }
-            else {
-                if(m_kernel->m_launch_latency)
-                    m_kernel->m_launch_latency--;
-                if(g_debug_execution >= 3)
-                    printf("kernel %d: \'%s\', latency %u not ready to transfer to GPU hardware scheduler\n", 
-                        m_kernel->get_uid(), m_kernel->name().c_str(), m_kernel->m_launch_latency);
-                return false;    
-            }
+        gpu->set_cache_config(m_kernel->name());
+        gpu->functional_launch(m_kernel);
+      } else {  // Performance Sim
+        if (gpu->can_start_kernel() && m_kernel->m_launch_latency == 0) {
+          if (g_debug_execution >= 3) {
+            printf("kernel %d: \'%s\' transfer to GPU hardware scheduler\n",
+                   m_kernel->get_uid(), m_kernel->name().c_str());
+            m_kernel->print_parent_info();
+          }
+          gpu->set_cache_config(m_kernel->name());
+          gpu->launch(m_kernel);
+        } else {
+          if (m_kernel->m_launch_latency) m_kernel->m_launch_latency--;
+          if (g_debug_execution >= 3)
+            printf(
+                "kernel %d: \'%s\', latency %u not ready to transfer to GPU "
+                "hardware scheduler\n",
+                m_kernel->get_uid(), m_kernel->name().c_str(),
+                m_kernel->m_launch_latency);
+          return false;
         }
-        break;
+      }
+      break;
     case stream_event: {
-        printf("event update\n");
-        time_t wallclock = time((time_t *)NULL);
-        m_event->update( gpu->gpu_tot_sim_cycle, wallclock );
-        m_stream->record_next_done();
-        } 
-        break;
+      printf("event update\n");
+      time_t wallclock = time((time_t *)NULL);
+      m_event->update(gpu->gpu_tot_sim_cycle, wallclock);
+      m_stream->record_next_done();
+    } break;
     case stream_wait_event: {
-        //only allows next op to go if event is done
-        //otherwise stays in the stream queue
-        printf("stream wait event processing...\n");
-        if(m_event->done())
-            printf("stream wait event done\n");
-            m_stream->record_next_done();
+      // only allows next op to go if event is done
+      // otherwise stays in the stream queue
+      printf("stream wait event processing...\n");
+      if (m_event->done()) printf("stream wait event done\n");
+      m_stream->record_next_done();
+    } break;
+    default:
+      abort();
+  }
+  m_done = true;
+  fflush(stdout);
+  return true;
+}
+
+void stream_operation::print(FILE *fp) const {
+  fprintf(fp, " stream operation ");
+  switch (m_type) {
+    case stream_event:
+      fprintf(fp, "event");
+      break;
+    case stream_kernel_launch:
+      fprintf(fp, "kernel");
+      break;
+    case stream_memcpy_device_to_device:
+      fprintf(fp, "memcpy device-to-device");
+      break;
+    case stream_memcpy_device_to_host:
+      fprintf(fp, "memcpy device-to-host");
+      break;
+    case stream_memcpy_host_to_device:
+      fprintf(fp, "memcpy host-to-device");
+      break;
+    case stream_memcpy_to_symbol:
+      fprintf(fp, "memcpy to symbol");
+      break;
+    case stream_memcpy_from_symbol:
+      fprintf(fp, "memcpy from symbol");
+      break;
+    case stream_no_op:
+      fprintf(fp, "no-op");
+      break;
+  }
+}
+
+stream_manager::stream_manager(gpgpu_sim *gpu, bool cuda_launch_blocking) {
+  m_gpu = gpu;
+  m_service_stream_zero = false;
+  m_cuda_launch_blocking = cuda_launch_blocking;
+  pthread_mutex_init(&m_lock, NULL);
+}
+
+bool stream_manager::operation(bool *sim) {
+  bool check = check_finished_kernel();
+  pthread_mutex_lock(&m_lock);
+  //    if(check)m_gpu->print_stats();
+  stream_operation op = front();
+  if (!op.do_operation(m_gpu))  // not ready to execute
+  {
+    // cancel operation
+    if (op.is_kernel()) {
+      unsigned grid_uid = op.get_kernel()->get_uid();
+      m_grid_id_to_stream.erase(grid_uid);
+    }
+    op.get_stream()->cancel_front();
+  }
+  pthread_mutex_unlock(&m_lock);
+  // pthread_mutex_lock(&m_lock);
+  // simulate a clock cycle on the GPU
+  return check;
+}
+
+bool stream_manager::check_finished_kernel() {
+  unsigned grid_uid = m_gpu->finished_kernel();
+  bool check = register_finished_kernel(grid_uid);
+  return check;
+}
+
+bool stream_manager::register_finished_kernel(unsigned grid_uid) {
+  // called by gpu simulation thread
+  if (grid_uid > 0) {
+    CUstream_st *stream = m_grid_id_to_stream[grid_uid];
+    kernel_info_t *kernel = stream->front().get_kernel();
+    assert(grid_uid == kernel->get_uid());
+
+    // Jin: should check children kernels for CDP
+    if (kernel->is_finished()) {
+      //            std::ofstream kernel_stat("kernel_stat.txt",
+      //            std::ofstream::out | std::ofstream::app); kernel_stat<< "
+      //            kernel " << grid_uid << ": " << kernel->name();
+      //            if(kernel->get_parent())
+      //                kernel_stat << ", parent " <<
+      //                kernel->get_parent()->get_uid() <<
+      //                ", launch " << kernel->launch_cycle;
+      //            kernel_stat<< ", start " << kernel->start_cycle <<
+      //                ", end " << kernel->end_cycle << ", retire " <<
+      //                gpu_sim_cycle + gpu_tot_sim_cycle << "\n";
+      //            printf("kernel %d finishes, retires from stream %d\n",
+      //            grid_uid, stream->get_uid()); kernel_stat.flush();
+      //            kernel_stat.close();
+      stream->record_next_done();
+      m_grid_id_to_stream.erase(grid_uid);
+      kernel->notify_parent_finished();
+      delete kernel;
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void stream_manager::stop_all_running_kernels() {
+  pthread_mutex_lock(&m_lock);
+
+  // Signal m_gpu to stop all running kernels
+  m_gpu->stop_all_running_kernels();
+
+  // Clean up all streams waiting on running kernels
+  int count = 0;
+  while (check_finished_kernel()) {
+    count++;
+  }
+
+  // If any kernels completed, print out the current stats
+  if (count > 0) m_gpu->print_stats();
+
+  pthread_mutex_unlock(&m_lock);
+}
+
+stream_operation stream_manager::front() {
+  // called by gpu simulation thread
+  stream_operation result;
+  //    if( concurrent_streams_empty() )
+  m_service_stream_zero = true;
+  if (m_service_stream_zero) {
+    if (!m_stream_zero.empty() && !m_stream_zero.busy()) {
+      result = m_stream_zero.next();
+      if (result.is_kernel()) {
+        unsigned grid_id = result.get_kernel()->get_uid();
+        m_grid_id_to_stream[grid_id] = &m_stream_zero;
+      }
+    } else {
+      m_service_stream_zero = false;
+    }
+  }
+
+  if (!m_service_stream_zero) {
+    std::list<struct CUstream_st *>::iterator s;
+    for (s = m_streams.begin(); s != m_streams.end(); s++) {
+      CUstream_st *stream = *s;
+      if (!stream->busy() && !stream->empty()) {
+        result = stream->next();
+        if (result.is_kernel()) {
+          unsigned grid_id = result.get_kernel()->get_uid();
+          m_grid_id_to_stream[grid_id] = stream;
         }
         break;
-    default:
-        abort();
+      }
     }
-    m_done=true;
-    fflush(stdout);
-    return true;
+  }
+  return result;
 }
 
-void stream_operation::print( FILE *fp ) const
-{
-    fprintf(fp," stream operation " );
-    switch( m_type ) {
-    case stream_event: fprintf(fp,"event"); break;
-    case stream_kernel_launch: fprintf(fp,"kernel"); break;
-    case stream_memcpy_device_to_device: fprintf(fp,"memcpy device-to-device"); break;
-    case stream_memcpy_device_to_host: fprintf(fp,"memcpy device-to-host"); break;
-    case stream_memcpy_host_to_device: fprintf(fp,"memcpy host-to-device"); break;
-    case stream_memcpy_to_symbol: fprintf(fp,"memcpy to symbol"); break;
-    case stream_memcpy_from_symbol: fprintf(fp,"memcpy from symbol"); break;
-    case stream_no_op: fprintf(fp,"no-op"); break;
+void stream_manager::add_stream(struct CUstream_st *stream) {
+  // called by host thread
+  pthread_mutex_lock(&m_lock);
+  m_streams.push_back(stream);
+  pthread_mutex_unlock(&m_lock);
+}
+
+void stream_manager::destroy_stream(CUstream_st *stream) {
+  // called by host thread
+  pthread_mutex_lock(&m_lock);
+  while (!stream->empty())
+    ;
+  std::list<CUstream_st *>::iterator s;
+  for (s = m_streams.begin(); s != m_streams.end(); s++) {
+    if (*s == stream) {
+      m_streams.erase(s);
+      break;
     }
+  }
+  delete stream;
+  pthread_mutex_unlock(&m_lock);
 }
 
-stream_manager::stream_manager( gpgpu_sim *gpu, bool cuda_launch_blocking ) 
-{
-    m_gpu = gpu;
-    m_service_stream_zero = false;
-    m_cuda_launch_blocking = cuda_launch_blocking;
-    pthread_mutex_init(&m_lock,NULL);
+bool stream_manager::concurrent_streams_empty() {
+  bool result = true;
+  if (m_streams.empty()) return true;
+  // called by gpu simulation thread
+  std::list<struct CUstream_st *>::iterator s;
+  for (s = m_streams.begin(); s != m_streams.end(); ++s) {
+    struct CUstream_st *stream = *s;
+    if (!stream->empty()) {
+      // stream->print(stdout);
+      result = false;
+      break;
+    }
+  }
+  return result;
 }
 
-bool stream_manager::operation( bool * sim)
-{
-    bool check=check_finished_kernel();
+bool stream_manager::empty_protected() {
+  bool result = true;
+  pthread_mutex_lock(&m_lock);
+  if (!concurrent_streams_empty()) result = false;
+  if (!m_stream_zero.empty()) result = false;
+  pthread_mutex_unlock(&m_lock);
+  return result;
+}
+
+bool stream_manager::empty() {
+  bool result = true;
+  if (!concurrent_streams_empty()) result = false;
+  if (!m_stream_zero.empty()) result = false;
+  return result;
+}
+
+void stream_manager::print(FILE *fp) {
+  pthread_mutex_lock(&m_lock);
+  print_impl(fp);
+  pthread_mutex_unlock(&m_lock);
+}
+void stream_manager::print_impl(FILE *fp) {
+  fprintf(fp, "GPGPU-Sim API: Stream Manager State\n");
+  std::list<struct CUstream_st *>::iterator s;
+  for (s = m_streams.begin(); s != m_streams.end(); ++s) {
+    struct CUstream_st *stream = *s;
+    if (!stream->empty()) stream->print(fp);
+  }
+  if (!m_stream_zero.empty()) m_stream_zero.print(fp);
+}
+
+void stream_manager::push(stream_operation op) {
+  struct CUstream_st *stream = op.get_stream();
+
+  // block if stream 0 (or concurrency disabled) and pending concurrent
+  // operations exist
+  bool block = !stream || m_cuda_launch_blocking;
+  while (block) {
     pthread_mutex_lock(&m_lock);
-//    if(check)m_gpu->print_stats();
-    stream_operation op =front();
-    if(!op.do_operation( m_gpu )) //not ready to execute
-    {
-        //cancel operation
-        if( op.is_kernel() ) {
-            unsigned grid_uid = op.get_kernel()->get_uid();
-            m_grid_id_to_stream.erase(grid_uid);
-        }
-        op.get_stream()->cancel_front();
-
-    }
+    block = !concurrent_streams_empty();
     pthread_mutex_unlock(&m_lock);
-    //pthread_mutex_lock(&m_lock);
-    // simulate a clock cycle on the GPU
-    return check;
-}
+  };
 
-bool stream_manager::check_finished_kernel()
-{
-    unsigned grid_uid = m_gpu->finished_kernel();
-    bool check=register_finished_kernel(grid_uid);
-    return check;
-}
-
-bool stream_manager::register_finished_kernel(unsigned grid_uid)
-{
-    // called by gpu simulation thread
-    if(grid_uid > 0){
-        CUstream_st *stream = m_grid_id_to_stream[grid_uid];
-        kernel_info_t *kernel = stream->front().get_kernel();
-        assert( grid_uid == kernel->get_uid() );
-
-        //Jin: should check children kernels for CDP
-        if(kernel->is_finished()) {
-//            std::ofstream kernel_stat("kernel_stat.txt", std::ofstream::out | std::ofstream::app);
-//            kernel_stat<< " kernel " << grid_uid << ": " << kernel->name();
-//            if(kernel->get_parent())
-//                kernel_stat << ", parent " << kernel->get_parent()->get_uid() <<
-//                ", launch " << kernel->launch_cycle;
-//            kernel_stat<< ", start " << kernel->start_cycle <<
-//                ", end " << kernel->end_cycle << ", retire " << gpu_sim_cycle + gpu_tot_sim_cycle << "\n";
-//            printf("kernel %d finishes, retires from stream %d\n", grid_uid, stream->get_uid());
-//            kernel_stat.flush();
-//            kernel_stat.close();
-            stream->record_next_done();
-            m_grid_id_to_stream.erase(grid_uid);
-            kernel->notify_parent_finished();
-            delete kernel;
-            return true;
-        }
+  pthread_mutex_lock(&m_lock);
+  if (!m_gpu->cycle_insn_cta_max_hit()) {
+    // Accept the stream operation if the maximum cycle/instruction/cta counts
+    // are not triggered
+    if (stream && !m_cuda_launch_blocking) {
+      stream->push(op);
+    } else {
+      op.set_stream(&m_stream_zero);
+      m_stream_zero.push(op);
     }
-
-    return false;
-}
-
-void stream_manager::stop_all_running_kernels(){
-    pthread_mutex_lock(&m_lock);
-
-    // Signal m_gpu to stop all running kernels
-    m_gpu->stop_all_running_kernels();
-
-    // Clean up all streams waiting on running kernels
-    int count=0;
-    while(check_finished_kernel()){
-        count++;
+  } else {
+    // Otherwise, ignore operation and continue
+    printf(
+        "GPGPU-Sim API: Maximum cycle, instruction, or CTA count hit. "
+        "Skipping:");
+    op.print(stdout);
+    printf("\n");
+  }
+  if (g_debug_execution >= 3) print_impl(stdout);
+  pthread_mutex_unlock(&m_lock);
+  if (m_cuda_launch_blocking || stream == NULL) {
+    unsigned int wait_amount = 100;
+    unsigned int wait_cap = 100000;  // 100ms
+    while (!empty()) {
+      // sleep to prevent CPU hog by empty spin
+      // sleep time increased exponentially ensure fast response when needed
+      usleep(wait_amount);
+      wait_amount *= 2;
+      if (wait_amount > wait_cap) wait_amount = wait_cap;
     }
-
-    // If any kernels completed, print out the current stats
-    if(count > 0)
-        m_gpu->print_stats();
-
-    pthread_mutex_unlock(&m_lock);
+  }
 }
 
-stream_operation stream_manager::front() 
-{
-    // called by gpu simulation thread
-    stream_operation result;
-//    if( concurrent_streams_empty() )
-    m_service_stream_zero = true;
-    if( m_service_stream_zero ) {
-        if( !m_stream_zero.empty() && !m_stream_zero.busy() ) {
-                result = m_stream_zero.next();
-                if( result.is_kernel() ) {
-                    unsigned grid_id = result.get_kernel()->get_uid();
-                    m_grid_id_to_stream[grid_id] = &m_stream_zero;
-                }
-        } else {
-            m_service_stream_zero = false;
-        }
-    }
-    
-    if(!m_service_stream_zero)
-    {
-        std::list<struct CUstream_st*>::iterator s;
-        for( s=m_streams.begin(); s != m_streams.end(); s++) {
-            CUstream_st *stream = *s;
-            if( !stream->busy() && !stream->empty() ) {
-                result = stream->next();
-                if( result.is_kernel() ) {
-                    unsigned grid_id = result.get_kernel()->get_uid();
-                    m_grid_id_to_stream[grid_id] = stream;
-                }
-                break;
-            }
-        }
-    }
-    return result;
-}
-
-void stream_manager::add_stream( struct CUstream_st *stream )
-{
-    // called by host thread
-    pthread_mutex_lock(&m_lock);
-    m_streams.push_back(stream);
-    pthread_mutex_unlock(&m_lock);
-}
-
-void stream_manager::destroy_stream( CUstream_st *stream )
-{
-    // called by host thread
-    pthread_mutex_lock(&m_lock);
-    while( !stream->empty() )
-        ; 
-    std::list<CUstream_st *>::iterator s;
-    for( s=m_streams.begin(); s != m_streams.end(); s++ ) {
-        if( *s == stream ) {
-            m_streams.erase(s);
-            break;
-        }
-    }
-    delete stream; 
-    pthread_mutex_unlock(&m_lock);
-}
-
-bool stream_manager::concurrent_streams_empty()
-{
-    bool result = true;
-    if (m_streams.empty())
-       return true;
-    // called by gpu simulation thread
-    std::list<struct CUstream_st *>::iterator s;
-    for( s=m_streams.begin(); s!=m_streams.end();++s ) {
-        struct CUstream_st *stream = *s;
-        if( !stream->empty() ) {
-            //stream->print(stdout);
-            result = false;
-            break;
-        }
-    }
-    return result;
-}
-
-bool stream_manager::empty_protected()
-{
-    bool result = true;
-    pthread_mutex_lock(&m_lock);
-    if( !concurrent_streams_empty() )
-        result = false;
-    if( !m_stream_zero.empty() )
-        result = false;
-    pthread_mutex_unlock(&m_lock);
-    return result;
-}
-
-bool stream_manager::empty()
-{
-    bool result = true;
-    if( !concurrent_streams_empty() ) 
-        result = false;
-    if( !m_stream_zero.empty() ) 
-        result = false;
-    return result;
-}
-
-
-void stream_manager::print( FILE *fp)
-{
-    pthread_mutex_lock(&m_lock);
-    print_impl(fp);
-    pthread_mutex_unlock(&m_lock);
-}
-void stream_manager::print_impl( FILE *fp)
-{
-    fprintf(fp,"GPGPU-Sim API: Stream Manager State\n");
-    std::list<struct CUstream_st *>::iterator s;
-    for( s=m_streams.begin(); s!=m_streams.end();++s ) {
-        struct CUstream_st *stream = *s;
-        if( !stream->empty() ) 
-            stream->print(fp);
-    }
-    if( !m_stream_zero.empty() ) 
-        m_stream_zero.print(fp);
-}
-
-void stream_manager::push( stream_operation op )
-{
-    struct CUstream_st *stream = op.get_stream();
-
-    // block if stream 0 (or concurrency disabled) and pending concurrent operations exist
-    bool block= !stream || m_cuda_launch_blocking;
-    while(block) {
-        pthread_mutex_lock(&m_lock);
-        block = !concurrent_streams_empty();
-        pthread_mutex_unlock(&m_lock);
-    };
-
-    pthread_mutex_lock(&m_lock);
-    if(!m_gpu->cycle_insn_cta_max_hit()) {
-        // Accept the stream operation if the maximum cycle/instruction/cta counts are not triggered
-        if( stream && !m_cuda_launch_blocking ) {
-            stream->push(op);
-        } else {
-            op.set_stream(&m_stream_zero);
-            m_stream_zero.push(op);
-        }
-    }else {
-        // Otherwise, ignore operation and continue
-        printf("GPGPU-Sim API: Maximum cycle, instruction, or CTA count hit. Skipping:");
-        op.print(stdout);
-        printf("\n");
-    }
-    if(g_debug_execution >= 3)
-       print_impl(stdout);
-    pthread_mutex_unlock(&m_lock);
-    if( m_cuda_launch_blocking || stream == NULL ) {
-        unsigned int wait_amount = 100; 
-        unsigned int wait_cap = 100000; // 100ms 
-        while( !empty() ) {
-            // sleep to prevent CPU hog by empty spin
-            // sleep time increased exponentially ensure fast response when needed 
-            usleep(wait_amount); 
-            wait_amount *= 2; 
-            if (wait_amount > wait_cap) 
-               wait_amount = wait_cap; 
-        }
-    }
-}
-
-void stream_manager::pushCudaStreamWaitEventToAllStreams( CUevent_st *e, unsigned int flags ){
-    std::list<CUstream_st *>::iterator s;
-    for( s=m_streams.begin(); s != m_streams.end(); s++ ) {
-        stream_operation op(*s,e,flags);
-        push(op);
-    }
+void stream_manager::pushCudaStreamWaitEventToAllStreams(CUevent_st *e,
+                                                         unsigned int flags) {
+  std::list<CUstream_st *>::iterator s;
+  for (s = m_streams.begin(); s != m_streams.end(); s++) {
+    stream_operation op(*s, e, flags);
+    push(op);
+  }
 }

--- a/src/stream_manager.cc
+++ b/src/stream_manager.cc
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -26,463 +28,445 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "stream_manager.h"
-#include "gpgpusim_entrypoint.h"
+#include "../libcuda/gpgpu_context.h"
 #include "cuda-sim/cuda-sim.h"
 #include "gpgpu-sim/gpu-sim.h"
-#include "../libcuda/gpgpu_context.h"
+#include "gpgpusim_entrypoint.h"
 
 unsigned CUstream_st::sm_next_stream_uid = 0;
 
-CUstream_st::CUstream_st() 
-{
-    m_pending = false;
-    m_uid = sm_next_stream_uid++;
-    pthread_mutex_init(&m_lock,NULL);
+CUstream_st::CUstream_st() {
+  m_pending = false;
+  m_uid = sm_next_stream_uid++;
+  pthread_mutex_init(&m_lock, NULL);
 }
 
-bool CUstream_st::empty()
-{
+bool CUstream_st::empty() {
+  pthread_mutex_lock(&m_lock);
+  bool empty = m_operations.empty();
+  pthread_mutex_unlock(&m_lock);
+  return empty;
+}
+
+bool CUstream_st::busy() {
+  pthread_mutex_lock(&m_lock);
+  bool pending = m_pending;
+  pthread_mutex_unlock(&m_lock);
+  return pending;
+}
+
+void CUstream_st::synchronize() {
+  // called by host thread
+  bool done = false;
+  do {
     pthread_mutex_lock(&m_lock);
-    bool empty = m_operations.empty();
+    done = m_operations.empty();
     pthread_mutex_unlock(&m_lock);
-    return empty;
+  } while (!done);
 }
 
-bool CUstream_st::busy()
-{
-    pthread_mutex_lock(&m_lock);
-    bool pending = m_pending;
-    pthread_mutex_unlock(&m_lock);
-    return pending;
+void CUstream_st::push(const stream_operation &op) {
+  // called by host thread
+  pthread_mutex_lock(&m_lock);
+  m_operations.push_back(op);
+  pthread_mutex_unlock(&m_lock);
 }
 
-void CUstream_st::synchronize() 
-{
-    // called by host thread
-    bool done=false;
-    do{
-        pthread_mutex_lock(&m_lock);
-        done = m_operations.empty();
-        pthread_mutex_unlock(&m_lock);
-    } while ( !done );
+void CUstream_st::record_next_done() {
+  // called by gpu thread
+  pthread_mutex_lock(&m_lock);
+  assert(m_pending);
+  m_operations.pop_front();
+  m_pending = false;
+  pthread_mutex_unlock(&m_lock);
 }
 
-void CUstream_st::push( const stream_operation &op )
-{
-    // called by host thread
-    pthread_mutex_lock(&m_lock);
-    m_operations.push_back( op );
-    pthread_mutex_unlock(&m_lock);
+stream_operation CUstream_st::next() {
+  // called by gpu thread
+  pthread_mutex_lock(&m_lock);
+  m_pending = true;
+  stream_operation result = m_operations.front();
+  pthread_mutex_unlock(&m_lock);
+  return result;
 }
 
-void CUstream_st::record_next_done()
-{
-    // called by gpu thread
-    pthread_mutex_lock(&m_lock);
-    assert(m_pending);
-    m_operations.pop_front();
-    m_pending=false;
-    pthread_mutex_unlock(&m_lock);
+void CUstream_st::cancel_front() {
+  pthread_mutex_lock(&m_lock);
+  assert(m_pending);
+  m_pending = false;
+  pthread_mutex_unlock(&m_lock);
 }
 
-
-stream_operation CUstream_st::next()
-{
-    // called by gpu thread
-    pthread_mutex_lock(&m_lock);
-    m_pending = true;
-    stream_operation result = m_operations.front();
-    pthread_mutex_unlock(&m_lock);
-    return result;
+void CUstream_st::print(FILE *fp) {
+  pthread_mutex_lock(&m_lock);
+  fprintf(fp, "GPGPU-Sim API:    stream %u has %zu operations\n", m_uid,
+          m_operations.size());
+  std::list<stream_operation>::iterator i;
+  unsigned n = 0;
+  for (i = m_operations.begin(); i != m_operations.end(); i++) {
+    stream_operation &op = *i;
+    fprintf(fp, "GPGPU-Sim API:       %u : ", n++);
+    op.print(fp);
+    fprintf(fp, "\n");
+  }
+  pthread_mutex_unlock(&m_lock);
 }
 
-void CUstream_st::cancel_front()
-{
-    pthread_mutex_lock(&m_lock);
-    assert(m_pending);
-    m_pending = false;
-    pthread_mutex_unlock(&m_lock);
+bool stream_operation::do_operation(gpgpu_sim *gpu) {
+  if (is_noop()) return true;
 
-}
-
-void CUstream_st::print(FILE *fp)
-{
-    pthread_mutex_lock(&m_lock);
-    fprintf(fp,"GPGPU-Sim API:    stream %u has %zu operations\n", m_uid, m_operations.size() );
-    std::list<stream_operation>::iterator i;
-    unsigned n=0;
-    for( i=m_operations.begin(); i!=m_operations.end(); i++ ) {
-        stream_operation &op = *i;
-        fprintf(fp,"GPGPU-Sim API:       %u : ", n++);
-        op.print(fp);
-        fprintf(fp,"\n");
-    }
-    pthread_mutex_unlock(&m_lock);
-}
-
-
-bool stream_operation::do_operation( gpgpu_sim *gpu )
-{
-    if( is_noop() ) 
-        return true;
-
-    assert(!m_done && m_stream);
-    if(g_debug_execution >= 3)
-       printf("GPGPU-Sim API: stream %u performing ", m_stream->get_uid() );
-    switch( m_type ) {
+  assert(!m_done && m_stream);
+  if (g_debug_execution >= 3)
+    printf("GPGPU-Sim API: stream %u performing ", m_stream->get_uid());
+  switch (m_type) {
     case stream_memcpy_host_to_device:
-        if(g_debug_execution >= 3)
-            printf("memcpy host-to-device\n");
-        gpu->memcpy_to_gpu(m_device_address_dst,m_host_address_src,m_cnt);
-        m_stream->record_next_done();
-        break;
+      if (g_debug_execution >= 3) printf("memcpy host-to-device\n");
+      gpu->memcpy_to_gpu(m_device_address_dst, m_host_address_src, m_cnt);
+      m_stream->record_next_done();
+      break;
     case stream_memcpy_device_to_host:
-        if(g_debug_execution >= 3)
-            printf("memcpy device-to-host\n");
-        gpu->memcpy_from_gpu(m_host_address_dst,m_device_address_src,m_cnt);
-        m_stream->record_next_done();
-        break;
+      if (g_debug_execution >= 3) printf("memcpy device-to-host\n");
+      gpu->memcpy_from_gpu(m_host_address_dst, m_device_address_src, m_cnt);
+      m_stream->record_next_done();
+      break;
     case stream_memcpy_device_to_device:
-        if(g_debug_execution >= 3)
-            printf("memcpy device-to-device\n");
-        gpu->memcpy_gpu_to_gpu(m_device_address_dst,m_device_address_src,m_cnt); 
-        m_stream->record_next_done();
-        break;
+      if (g_debug_execution >= 3) printf("memcpy device-to-device\n");
+      gpu->memcpy_gpu_to_gpu(m_device_address_dst, m_device_address_src, m_cnt);
+      m_stream->record_next_done();
+      break;
     case stream_memcpy_to_symbol:
-        if(g_debug_execution >= 3)
-            printf("memcpy to symbol\n");
-        gpu->gpgpu_ctx->func_sim->gpgpu_ptx_sim_memcpy_symbol(m_symbol,m_host_address_src,m_cnt,m_offset,1,gpu);
-        m_stream->record_next_done();
-        break;
+      if (g_debug_execution >= 3) printf("memcpy to symbol\n");
+      gpu->gpgpu_ctx->func_sim->gpgpu_ptx_sim_memcpy_symbol(
+          m_symbol, m_host_address_src, m_cnt, m_offset, 1, gpu);
+      m_stream->record_next_done();
+      break;
     case stream_memcpy_from_symbol:
-        if(g_debug_execution >= 3)
-            printf("memcpy from symbol\n");
-        gpu->gpgpu_ctx->func_sim->gpgpu_ptx_sim_memcpy_symbol(m_symbol,m_host_address_dst,m_cnt,m_offset,0,gpu);
-        m_stream->record_next_done();
-        break;
+      if (g_debug_execution >= 3) printf("memcpy from symbol\n");
+      gpu->gpgpu_ctx->func_sim->gpgpu_ptx_sim_memcpy_symbol(
+          m_symbol, m_host_address_dst, m_cnt, m_offset, 0, gpu);
+      m_stream->record_next_done();
+      break;
     case stream_kernel_launch:
-        if( m_sim_mode ) { //Functional Sim
-            if(g_debug_execution >= 3) {
-                printf("kernel %d: \'%s\' transfer to GPU hardware scheduler\n", m_kernel->get_uid(), m_kernel->name().c_str() );
-                m_kernel->print_parent_info();
-            }
-            gpu->set_cache_config(m_kernel->name());
-            gpu->functional_launch( m_kernel );
+      if (m_sim_mode) {  // Functional Sim
+        if (g_debug_execution >= 3) {
+          printf("kernel %d: \'%s\' transfer to GPU hardware scheduler\n",
+                 m_kernel->get_uid(), m_kernel->name().c_str());
+          m_kernel->print_parent_info();
         }
-        else { //Performance Sim
-            if( gpu->can_start_kernel() && m_kernel->m_launch_latency == 0) {
-                if(g_debug_execution >= 3) {
-                    printf("kernel %d: \'%s\' transfer to GPU hardware scheduler\n", m_kernel->get_uid(), m_kernel->name().c_str() );
-                    m_kernel->print_parent_info();
-                }
-                gpu->set_cache_config(m_kernel->name());
-                gpu->launch( m_kernel );
-            }
-            else {
-                if(m_kernel->m_launch_latency)
-                    m_kernel->m_launch_latency--;
-                if(g_debug_execution >= 3)
-                    printf("kernel %d: \'%s\', latency %u not ready to transfer to GPU hardware scheduler\n", 
-                        m_kernel->get_uid(), m_kernel->name().c_str(), m_kernel->m_launch_latency);
-                return false;    
-            }
+        gpu->set_cache_config(m_kernel->name());
+        gpu->functional_launch(m_kernel);
+      } else {  // Performance Sim
+        if (gpu->can_start_kernel() && m_kernel->m_launch_latency == 0) {
+          if (g_debug_execution >= 3) {
+            printf("kernel %d: \'%s\' transfer to GPU hardware scheduler\n",
+                   m_kernel->get_uid(), m_kernel->name().c_str());
+            m_kernel->print_parent_info();
+          }
+          gpu->set_cache_config(m_kernel->name());
+          gpu->launch(m_kernel);
+        } else {
+          if (m_kernel->m_launch_latency) m_kernel->m_launch_latency--;
+          if (g_debug_execution >= 3)
+            printf(
+                "kernel %d: \'%s\', latency %u not ready to transfer to GPU "
+                "hardware scheduler\n",
+                m_kernel->get_uid(), m_kernel->name().c_str(),
+                m_kernel->m_launch_latency);
+          return false;
         }
-        break;
+      }
+      break;
     case stream_event: {
-        printf("event update\n");
-        time_t wallclock = time((time_t *)NULL);
-        m_event->update( gpu->gpu_tot_sim_cycle, wallclock );
-        m_stream->record_next_done();
-        } 
-        break;
+      printf("event update\n");
+      time_t wallclock = time((time_t *)NULL);
+      m_event->update(gpu->gpu_tot_sim_cycle, wallclock);
+      m_stream->record_next_done();
+    } break;
     case stream_wait_event: {
-        //only allows next op to go if event is done
-        //otherwise stays in the stream queue
-        printf("stream wait event processing...\n");
-        if(m_event->done())
-            printf("stream wait event done\n");
-            m_stream->record_next_done();
+      // only allows next op to go if event is done
+      // otherwise stays in the stream queue
+      printf("stream wait event processing...\n");
+      if (m_event->done()) printf("stream wait event done\n");
+      m_stream->record_next_done();
+    } break;
+    default:
+      abort();
+  }
+  m_done = true;
+  fflush(stdout);
+  return true;
+}
+
+void stream_operation::print(FILE *fp) const {
+  fprintf(fp, " stream operation ");
+  switch (m_type) {
+    case stream_event:
+      fprintf(fp, "event");
+      break;
+    case stream_kernel_launch:
+      fprintf(fp, "kernel");
+      break;
+    case stream_memcpy_device_to_device:
+      fprintf(fp, "memcpy device-to-device");
+      break;
+    case stream_memcpy_device_to_host:
+      fprintf(fp, "memcpy device-to-host");
+      break;
+    case stream_memcpy_host_to_device:
+      fprintf(fp, "memcpy host-to-device");
+      break;
+    case stream_memcpy_to_symbol:
+      fprintf(fp, "memcpy to symbol");
+      break;
+    case stream_memcpy_from_symbol:
+      fprintf(fp, "memcpy from symbol");
+      break;
+    case stream_no_op:
+      fprintf(fp, "no-op");
+      break;
+  }
+}
+
+stream_manager::stream_manager(gpgpu_sim *gpu, bool cuda_launch_blocking) {
+  m_gpu = gpu;
+  m_service_stream_zero = false;
+  m_cuda_launch_blocking = cuda_launch_blocking;
+  pthread_mutex_init(&m_lock, NULL);
+}
+
+bool stream_manager::operation(bool *sim) {
+  bool check = check_finished_kernel();
+  pthread_mutex_lock(&m_lock);
+  //    if(check)m_gpu->print_stats();
+  stream_operation op = front();
+  if (!op.do_operation(m_gpu))  // not ready to execute
+  {
+    // cancel operation
+    if (op.is_kernel()) {
+      unsigned grid_uid = op.get_kernel()->get_uid();
+      m_grid_id_to_stream.erase(grid_uid);
+    }
+    op.get_stream()->cancel_front();
+  }
+  pthread_mutex_unlock(&m_lock);
+  // pthread_mutex_lock(&m_lock);
+  // simulate a clock cycle on the GPU
+  return check;
+}
+
+bool stream_manager::check_finished_kernel() {
+  unsigned grid_uid = m_gpu->finished_kernel();
+  bool check = register_finished_kernel(grid_uid);
+  return check;
+}
+
+bool stream_manager::register_finished_kernel(unsigned grid_uid) {
+  // called by gpu simulation thread
+  if (grid_uid > 0) {
+    CUstream_st *stream = m_grid_id_to_stream[grid_uid];
+    kernel_info_t *kernel = stream->front().get_kernel();
+    assert(grid_uid == kernel->get_uid());
+
+    // Jin: should check children kernels for CDP
+    if (kernel->is_finished()) {
+      //            std::ofstream kernel_stat("kernel_stat.txt",
+      //            std::ofstream::out | std::ofstream::app);
+      //            kernel_stat<< " kernel " << grid_uid << ": " <<
+      //            kernel->name();
+      //            if(kernel->get_parent())
+      //                kernel_stat << ", parent " <<
+      //                kernel->get_parent()->get_uid() <<
+      //                ", launch " << kernel->launch_cycle;
+      //            kernel_stat<< ", start " << kernel->start_cycle <<
+      //                ", end " << kernel->end_cycle << ", retire " <<
+      //                gpu_sim_cycle + gpu_tot_sim_cycle << "\n";
+      //            printf("kernel %d finishes, retires from stream %d\n",
+      //            grid_uid, stream->get_uid());
+      //            kernel_stat.flush();
+      //            kernel_stat.close();
+      stream->record_next_done();
+      m_grid_id_to_stream.erase(grid_uid);
+      kernel->notify_parent_finished();
+      delete kernel;
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void stream_manager::stop_all_running_kernels() {
+  pthread_mutex_lock(&m_lock);
+
+  // Signal m_gpu to stop all running kernels
+  m_gpu->stop_all_running_kernels();
+
+  // Clean up all streams waiting on running kernels
+  int count = 0;
+  while (check_finished_kernel()) {
+    count++;
+  }
+
+  // If any kernels completed, print out the current stats
+  if (count > 0) m_gpu->print_stats();
+
+  pthread_mutex_unlock(&m_lock);
+}
+
+stream_operation stream_manager::front() {
+  // called by gpu simulation thread
+  stream_operation result;
+  //    if( concurrent_streams_empty() )
+  m_service_stream_zero = true;
+  if (m_service_stream_zero) {
+    if (!m_stream_zero.empty() && !m_stream_zero.busy()) {
+      result = m_stream_zero.next();
+      if (result.is_kernel()) {
+        unsigned grid_id = result.get_kernel()->get_uid();
+        m_grid_id_to_stream[grid_id] = &m_stream_zero;
+      }
+    } else {
+      m_service_stream_zero = false;
+    }
+  }
+
+  if (!m_service_stream_zero) {
+    std::list<struct CUstream_st *>::iterator s;
+    for (s = m_streams.begin(); s != m_streams.end(); s++) {
+      CUstream_st *stream = *s;
+      if (!stream->busy() && !stream->empty()) {
+        result = stream->next();
+        if (result.is_kernel()) {
+          unsigned grid_id = result.get_kernel()->get_uid();
+          m_grid_id_to_stream[grid_id] = stream;
         }
         break;
-    default:
-        abort();
+      }
     }
-    m_done=true;
-    fflush(stdout);
-    return true;
+  }
+  return result;
 }
 
-void stream_operation::print( FILE *fp ) const
-{
-    fprintf(fp," stream operation " );
-    switch( m_type ) {
-    case stream_event: fprintf(fp,"event"); break;
-    case stream_kernel_launch: fprintf(fp,"kernel"); break;
-    case stream_memcpy_device_to_device: fprintf(fp,"memcpy device-to-device"); break;
-    case stream_memcpy_device_to_host: fprintf(fp,"memcpy device-to-host"); break;
-    case stream_memcpy_host_to_device: fprintf(fp,"memcpy host-to-device"); break;
-    case stream_memcpy_to_symbol: fprintf(fp,"memcpy to symbol"); break;
-    case stream_memcpy_from_symbol: fprintf(fp,"memcpy from symbol"); break;
-    case stream_no_op: fprintf(fp,"no-op"); break;
+void stream_manager::add_stream(struct CUstream_st *stream) {
+  // called by host thread
+  pthread_mutex_lock(&m_lock);
+  m_streams.push_back(stream);
+  pthread_mutex_unlock(&m_lock);
+}
+
+void stream_manager::destroy_stream(CUstream_st *stream) {
+  // called by host thread
+  pthread_mutex_lock(&m_lock);
+  while (!stream->empty())
+    ;
+  std::list<CUstream_st *>::iterator s;
+  for (s = m_streams.begin(); s != m_streams.end(); s++) {
+    if (*s == stream) {
+      m_streams.erase(s);
+      break;
     }
+  }
+  delete stream;
+  pthread_mutex_unlock(&m_lock);
 }
 
-stream_manager::stream_manager( gpgpu_sim *gpu, bool cuda_launch_blocking ) 
-{
-    m_gpu = gpu;
-    m_service_stream_zero = false;
-    m_cuda_launch_blocking = cuda_launch_blocking;
-    pthread_mutex_init(&m_lock,NULL);
+bool stream_manager::concurrent_streams_empty() {
+  bool result = true;
+  if (m_streams.empty()) return true;
+  // called by gpu simulation thread
+  std::list<struct CUstream_st *>::iterator s;
+  for (s = m_streams.begin(); s != m_streams.end(); ++s) {
+    struct CUstream_st *stream = *s;
+    if (!stream->empty()) {
+      // stream->print(stdout);
+      result = false;
+      break;
+    }
+  }
+  return result;
 }
 
-bool stream_manager::operation( bool * sim)
-{
-    bool check=check_finished_kernel();
+bool stream_manager::empty_protected() {
+  bool result = true;
+  pthread_mutex_lock(&m_lock);
+  if (!concurrent_streams_empty()) result = false;
+  if (!m_stream_zero.empty()) result = false;
+  pthread_mutex_unlock(&m_lock);
+  return result;
+}
+
+bool stream_manager::empty() {
+  bool result = true;
+  if (!concurrent_streams_empty()) result = false;
+  if (!m_stream_zero.empty()) result = false;
+  return result;
+}
+
+void stream_manager::print(FILE *fp) {
+  pthread_mutex_lock(&m_lock);
+  print_impl(fp);
+  pthread_mutex_unlock(&m_lock);
+}
+void stream_manager::print_impl(FILE *fp) {
+  fprintf(fp, "GPGPU-Sim API: Stream Manager State\n");
+  std::list<struct CUstream_st *>::iterator s;
+  for (s = m_streams.begin(); s != m_streams.end(); ++s) {
+    struct CUstream_st *stream = *s;
+    if (!stream->empty()) stream->print(fp);
+  }
+  if (!m_stream_zero.empty()) m_stream_zero.print(fp);
+}
+
+void stream_manager::push(stream_operation op) {
+  struct CUstream_st *stream = op.get_stream();
+
+  // block if stream 0 (or concurrency disabled) and pending concurrent
+  // operations exist
+  bool block = !stream || m_cuda_launch_blocking;
+  while (block) {
     pthread_mutex_lock(&m_lock);
-//    if(check)m_gpu->print_stats();
-    stream_operation op =front();
-    if(!op.do_operation( m_gpu )) //not ready to execute
-    {
-        //cancel operation
-        if( op.is_kernel() ) {
-            unsigned grid_uid = op.get_kernel()->get_uid();
-            m_grid_id_to_stream.erase(grid_uid);
-        }
-        op.get_stream()->cancel_front();
-
-    }
+    block = !concurrent_streams_empty();
     pthread_mutex_unlock(&m_lock);
-    //pthread_mutex_lock(&m_lock);
-    // simulate a clock cycle on the GPU
-    return check;
-}
+  };
 
-bool stream_manager::check_finished_kernel()
-{
-    unsigned grid_uid = m_gpu->finished_kernel();
-    bool check=register_finished_kernel(grid_uid);
-    return check;
-}
-
-bool stream_manager::register_finished_kernel(unsigned grid_uid)
-{
-    // called by gpu simulation thread
-    if(grid_uid > 0){
-        CUstream_st *stream = m_grid_id_to_stream[grid_uid];
-        kernel_info_t *kernel = stream->front().get_kernel();
-        assert( grid_uid == kernel->get_uid() );
-
-        //Jin: should check children kernels for CDP
-        if(kernel->is_finished()) {
-//            std::ofstream kernel_stat("kernel_stat.txt", std::ofstream::out | std::ofstream::app);
-//            kernel_stat<< " kernel " << grid_uid << ": " << kernel->name();
-//            if(kernel->get_parent())
-//                kernel_stat << ", parent " << kernel->get_parent()->get_uid() <<
-//                ", launch " << kernel->launch_cycle;
-//            kernel_stat<< ", start " << kernel->start_cycle <<
-//                ", end " << kernel->end_cycle << ", retire " << gpu_sim_cycle + gpu_tot_sim_cycle << "\n";
-//            printf("kernel %d finishes, retires from stream %d\n", grid_uid, stream->get_uid());
-//            kernel_stat.flush();
-//            kernel_stat.close();
-            stream->record_next_done();
-            m_grid_id_to_stream.erase(grid_uid);
-            kernel->notify_parent_finished();
-            delete kernel;
-            return true;
-        }
+  pthread_mutex_lock(&m_lock);
+  if (!m_gpu->cycle_insn_cta_max_hit()) {
+    // Accept the stream operation if the maximum cycle/instruction/cta counts
+    // are not triggered
+    if (stream && !m_cuda_launch_blocking) {
+      stream->push(op);
+    } else {
+      op.set_stream(&m_stream_zero);
+      m_stream_zero.push(op);
     }
-
-    return false;
-}
-
-void stream_manager::stop_all_running_kernels(){
-    pthread_mutex_lock(&m_lock);
-
-    // Signal m_gpu to stop all running kernels
-    m_gpu->stop_all_running_kernels();
-
-    // Clean up all streams waiting on running kernels
-    int count=0;
-    while(check_finished_kernel()){
-        count++;
+  } else {
+    // Otherwise, ignore operation and continue
+    printf(
+        "GPGPU-Sim API: Maximum cycle, instruction, or CTA count hit. "
+        "Skipping:");
+    op.print(stdout);
+    printf("\n");
+  }
+  if (g_debug_execution >= 3) print_impl(stdout);
+  pthread_mutex_unlock(&m_lock);
+  if (m_cuda_launch_blocking || stream == NULL) {
+    unsigned int wait_amount = 100;
+    unsigned int wait_cap = 100000;  // 100ms
+    while (!empty()) {
+      // sleep to prevent CPU hog by empty spin
+      // sleep time increased exponentially ensure fast response when needed
+      usleep(wait_amount);
+      wait_amount *= 2;
+      if (wait_amount > wait_cap) wait_amount = wait_cap;
     }
-
-    // If any kernels completed, print out the current stats
-    if(count > 0)
-        m_gpu->print_stats();
-
-    pthread_mutex_unlock(&m_lock);
+  }
 }
 
-stream_operation stream_manager::front() 
-{
-    // called by gpu simulation thread
-    stream_operation result;
-//    if( concurrent_streams_empty() )
-    m_service_stream_zero = true;
-    if( m_service_stream_zero ) {
-        if( !m_stream_zero.empty() && !m_stream_zero.busy() ) {
-                result = m_stream_zero.next();
-                if( result.is_kernel() ) {
-                    unsigned grid_id = result.get_kernel()->get_uid();
-                    m_grid_id_to_stream[grid_id] = &m_stream_zero;
-                }
-        } else {
-            m_service_stream_zero = false;
-        }
-    }
-    
-    if(!m_service_stream_zero)
-    {
-        std::list<struct CUstream_st*>::iterator s;
-        for( s=m_streams.begin(); s != m_streams.end(); s++) {
-            CUstream_st *stream = *s;
-            if( !stream->busy() && !stream->empty() ) {
-                result = stream->next();
-                if( result.is_kernel() ) {
-                    unsigned grid_id = result.get_kernel()->get_uid();
-                    m_grid_id_to_stream[grid_id] = stream;
-                }
-                break;
-            }
-        }
-    }
-    return result;
-}
-
-void stream_manager::add_stream( struct CUstream_st *stream )
-{
-    // called by host thread
-    pthread_mutex_lock(&m_lock);
-    m_streams.push_back(stream);
-    pthread_mutex_unlock(&m_lock);
-}
-
-void stream_manager::destroy_stream( CUstream_st *stream )
-{
-    // called by host thread
-    pthread_mutex_lock(&m_lock);
-    while( !stream->empty() )
-        ; 
-    std::list<CUstream_st *>::iterator s;
-    for( s=m_streams.begin(); s != m_streams.end(); s++ ) {
-        if( *s == stream ) {
-            m_streams.erase(s);
-            break;
-        }
-    }
-    delete stream; 
-    pthread_mutex_unlock(&m_lock);
-}
-
-bool stream_manager::concurrent_streams_empty()
-{
-    bool result = true;
-    if (m_streams.empty())
-       return true;
-    // called by gpu simulation thread
-    std::list<struct CUstream_st *>::iterator s;
-    for( s=m_streams.begin(); s!=m_streams.end();++s ) {
-        struct CUstream_st *stream = *s;
-        if( !stream->empty() ) {
-            //stream->print(stdout);
-            result = false;
-            break;
-        }
-    }
-    return result;
-}
-
-bool stream_manager::empty_protected()
-{
-    bool result = true;
-    pthread_mutex_lock(&m_lock);
-    if( !concurrent_streams_empty() )
-        result = false;
-    if( !m_stream_zero.empty() )
-        result = false;
-    pthread_mutex_unlock(&m_lock);
-    return result;
-}
-
-bool stream_manager::empty()
-{
-    bool result = true;
-    if( !concurrent_streams_empty() ) 
-        result = false;
-    if( !m_stream_zero.empty() ) 
-        result = false;
-    return result;
-}
-
-
-void stream_manager::print( FILE *fp)
-{
-    pthread_mutex_lock(&m_lock);
-    print_impl(fp);
-    pthread_mutex_unlock(&m_lock);
-}
-void stream_manager::print_impl( FILE *fp)
-{
-    fprintf(fp,"GPGPU-Sim API: Stream Manager State\n");
-    std::list<struct CUstream_st *>::iterator s;
-    for( s=m_streams.begin(); s!=m_streams.end();++s ) {
-        struct CUstream_st *stream = *s;
-        if( !stream->empty() ) 
-            stream->print(fp);
-    }
-    if( !m_stream_zero.empty() ) 
-        m_stream_zero.print(fp);
-}
-
-void stream_manager::push( stream_operation op )
-{
-    struct CUstream_st *stream = op.get_stream();
-
-    // block if stream 0 (or concurrency disabled) and pending concurrent operations exist
-    bool block= !stream || m_cuda_launch_blocking;
-    while(block) {
-        pthread_mutex_lock(&m_lock);
-        block = !concurrent_streams_empty();
-        pthread_mutex_unlock(&m_lock);
-    };
-
-    pthread_mutex_lock(&m_lock);
-    if(!m_gpu->cycle_insn_cta_max_hit()) {
-        // Accept the stream operation if the maximum cycle/instruction/cta counts are not triggered
-        if( stream && !m_cuda_launch_blocking ) {
-            stream->push(op);
-        } else {
-            op.set_stream(&m_stream_zero);
-            m_stream_zero.push(op);
-        }
-    }else {
-        // Otherwise, ignore operation and continue
-        printf("GPGPU-Sim API: Maximum cycle, instruction, or CTA count hit. Skipping:");
-        op.print(stdout);
-        printf("\n");
-    }
-    if(g_debug_execution >= 3)
-       print_impl(stdout);
-    pthread_mutex_unlock(&m_lock);
-    if( m_cuda_launch_blocking || stream == NULL ) {
-        unsigned int wait_amount = 100; 
-        unsigned int wait_cap = 100000; // 100ms 
-        while( !empty() ) {
-            // sleep to prevent CPU hog by empty spin
-            // sleep time increased exponentially ensure fast response when needed 
-            usleep(wait_amount); 
-            wait_amount *= 2; 
-            if (wait_amount > wait_cap) 
-               wait_amount = wait_cap; 
-        }
-    }
-}
-
-void stream_manager::pushCudaStreamWaitEventToAllStreams( CUevent_st *e, unsigned int flags ){
-    std::list<CUstream_st *>::iterator s;
-    for( s=m_streams.begin(); s != m_streams.end(); s++ ) {
-        stream_operation op(*s,e,flags);
-        push(op);
-    }
+void stream_manager::pushCudaStreamWaitEventToAllStreams(CUevent_st *e,
+                                                         unsigned int flags) {
+  std::list<CUstream_st *>::iterator s;
+  for (s = m_streams.begin(); s != m_streams.end(); s++) {
+    stream_operation op(*s, e, flags);
+    push(op);
+  }
 }

--- a/src/stream_manager.h
+++ b/src/stream_manager.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -28,248 +30,249 @@
 #ifndef STREAM_MANAGER_H_INCLUDED
 #define STREAM_MANAGER_H_INCLUDED
 
-#include "abstract_hardware_model.h"
-#include <list>
 #include <pthread.h>
 #include <time.h>
+#include <list>
+#include "abstract_hardware_model.h"
 
-//class stream_barrier {
-//public:
+// class stream_barrier {
+// public:
 //    stream_barrier() { m_pending_streams=0; }
 //    void inc() { m_pending_streams++; }
 //    void dec() { assert(m_pending_streams); m_pending_streams--; }
 //    unsigned value() const { return m_pending_streams; }
-//private:
+// private:
 //    unsigned m_pending_streams;
 //};
 
 enum stream_operation_type {
-    stream_no_op,
-    stream_memcpy_host_to_device,
-    stream_memcpy_device_to_host,
-    stream_memcpy_device_to_device,
-    stream_memcpy_to_symbol,
-    stream_memcpy_from_symbol,
-    stream_kernel_launch,
-    stream_event,
-    stream_wait_event
+  stream_no_op,
+  stream_memcpy_host_to_device,
+  stream_memcpy_device_to_host,
+  stream_memcpy_device_to_device,
+  stream_memcpy_to_symbol,
+  stream_memcpy_from_symbol,
+  stream_kernel_launch,
+  stream_event,
+  stream_wait_event
 };
 
 class stream_operation {
-public:
-    stream_operation()
-    {
-        m_kernel=NULL;
-        m_type = stream_no_op;
-        m_stream = NULL;
-        m_done=true;
-    }
-    stream_operation( const void *src, const char *symbol, size_t count, size_t offset, struct CUstream_st *stream )
-    {
-        m_kernel=NULL;
-        m_stream = stream;
-        m_type=stream_memcpy_to_symbol;
-        m_host_address_src=src;
-        m_symbol=symbol;
-        m_cnt=count;
-        m_offset=offset;
-        m_done=false;
-    }
-    stream_operation( const char *symbol, void *dst, size_t count, size_t offset, struct CUstream_st *stream )
-    {
-        m_kernel=NULL;
-        m_stream = stream;
-        m_type=stream_memcpy_from_symbol;
-        m_host_address_dst=dst;
-        m_symbol=symbol;
-        m_cnt=count;
-        m_offset=offset;
-        m_done=false;
-    }
-    stream_operation( kernel_info_t *kernel, bool sim_mode, struct CUstream_st *stream )
-    {
-        m_type=stream_kernel_launch;
-        m_kernel=kernel;
-        m_sim_mode=sim_mode;
-        m_stream=stream;
-        m_done=false;
-    }
-    stream_operation( struct CUevent_st *e, struct CUstream_st *stream )
-    {
-        m_kernel=NULL;
-        m_type=stream_event;
-        m_event=e;
-        m_stream=stream;
-        m_done=false;
-    }
-    stream_operation( struct CUstream_st *stream, class CUevent_st *e, unsigned int flags )
-    {
-        m_kernel=NULL;
-        m_type=stream_wait_event;
-        m_event=e;
-        m_stream=stream;
-        m_done=false;
-    }
-    stream_operation( const void *host_address_src, size_t device_address_dst, size_t cnt, struct CUstream_st *stream )
-    {
-        m_kernel=NULL;
-        m_type=stream_memcpy_host_to_device;
-        m_host_address_src  =host_address_src;
-        m_device_address_dst=device_address_dst;
-        m_host_address_dst=NULL;
-        m_device_address_src=0;
-        m_cnt=cnt;
-        m_stream=stream;
-        m_sim_mode=false;
-        m_done=false;
-    }
-    stream_operation( size_t device_address_src, void *host_address_dst, size_t cnt, struct CUstream_st *stream  )
-    {
-        m_kernel=NULL;
-        m_type=stream_memcpy_device_to_host;
-        m_device_address_src=device_address_src;
-        m_host_address_dst=host_address_dst;
-        m_device_address_dst=0;
-        m_host_address_src=NULL;
-        m_cnt=cnt;
-        m_stream=stream;
-        m_sim_mode=false;
-        m_done=false;
-    }
-    stream_operation( size_t device_address_src, size_t device_address_dst, size_t cnt, struct CUstream_st *stream  )
-    {
-        m_kernel=NULL;
-        m_type=stream_memcpy_device_to_device;
-        m_device_address_src=device_address_src;
-        m_device_address_dst=device_address_dst;
-        m_host_address_src=NULL;
-        m_host_address_dst=NULL;
-        m_cnt=cnt;
-        m_stream=stream;
-        m_sim_mode=false;
-        m_done=false;
-    }
+ public:
+  stream_operation() {
+    m_kernel = NULL;
+    m_type = stream_no_op;
+    m_stream = NULL;
+    m_done = true;
+  }
+  stream_operation(const void *src, const char *symbol, size_t count,
+                   size_t offset, struct CUstream_st *stream) {
+    m_kernel = NULL;
+    m_stream = stream;
+    m_type = stream_memcpy_to_symbol;
+    m_host_address_src = src;
+    m_symbol = symbol;
+    m_cnt = count;
+    m_offset = offset;
+    m_done = false;
+  }
+  stream_operation(const char *symbol, void *dst, size_t count, size_t offset,
+                   struct CUstream_st *stream) {
+    m_kernel = NULL;
+    m_stream = stream;
+    m_type = stream_memcpy_from_symbol;
+    m_host_address_dst = dst;
+    m_symbol = symbol;
+    m_cnt = count;
+    m_offset = offset;
+    m_done = false;
+  }
+  stream_operation(kernel_info_t *kernel, bool sim_mode,
+                   struct CUstream_st *stream) {
+    m_type = stream_kernel_launch;
+    m_kernel = kernel;
+    m_sim_mode = sim_mode;
+    m_stream = stream;
+    m_done = false;
+  }
+  stream_operation(struct CUevent_st *e, struct CUstream_st *stream) {
+    m_kernel = NULL;
+    m_type = stream_event;
+    m_event = e;
+    m_stream = stream;
+    m_done = false;
+  }
+  stream_operation(struct CUstream_st *stream, class CUevent_st *e,
+                   unsigned int flags) {
+    m_kernel = NULL;
+    m_type = stream_wait_event;
+    m_event = e;
+    m_stream = stream;
+    m_done = false;
+  }
+  stream_operation(const void *host_address_src, size_t device_address_dst,
+                   size_t cnt, struct CUstream_st *stream) {
+    m_kernel = NULL;
+    m_type = stream_memcpy_host_to_device;
+    m_host_address_src = host_address_src;
+    m_device_address_dst = device_address_dst;
+    m_host_address_dst = NULL;
+    m_device_address_src = 0;
+    m_cnt = cnt;
+    m_stream = stream;
+    m_sim_mode = false;
+    m_done = false;
+  }
+  stream_operation(size_t device_address_src, void *host_address_dst,
+                   size_t cnt, struct CUstream_st *stream) {
+    m_kernel = NULL;
+    m_type = stream_memcpy_device_to_host;
+    m_device_address_src = device_address_src;
+    m_host_address_dst = host_address_dst;
+    m_device_address_dst = 0;
+    m_host_address_src = NULL;
+    m_cnt = cnt;
+    m_stream = stream;
+    m_sim_mode = false;
+    m_done = false;
+  }
+  stream_operation(size_t device_address_src, size_t device_address_dst,
+                   size_t cnt, struct CUstream_st *stream) {
+    m_kernel = NULL;
+    m_type = stream_memcpy_device_to_device;
+    m_device_address_src = device_address_src;
+    m_device_address_dst = device_address_dst;
+    m_host_address_src = NULL;
+    m_host_address_dst = NULL;
+    m_cnt = cnt;
+    m_stream = stream;
+    m_sim_mode = false;
+    m_done = false;
+  }
 
-    bool is_kernel() const { return m_type == stream_kernel_launch; }
-    bool is_mem() const {
-        return m_type == stream_memcpy_host_to_device ||
-               m_type == stream_memcpy_device_to_host ||
-               m_type == stream_memcpy_host_to_device;
-    }
-    bool is_noop() const { return m_type == stream_no_op; }
-    bool is_done() const { return m_done; }
-    kernel_info_t *get_kernel() { return m_kernel; }
-    bool do_operation( gpgpu_sim *gpu );
-    void print( FILE *fp ) const;
-    struct CUstream_st *get_stream() { return m_stream; }
-    void set_stream( CUstream_st *stream ) { m_stream = stream; }
+  bool is_kernel() const { return m_type == stream_kernel_launch; }
+  bool is_mem() const {
+    return m_type == stream_memcpy_host_to_device ||
+           m_type == stream_memcpy_device_to_host ||
+           m_type == stream_memcpy_host_to_device;
+  }
+  bool is_noop() const { return m_type == stream_no_op; }
+  bool is_done() const { return m_done; }
+  kernel_info_t *get_kernel() { return m_kernel; }
+  bool do_operation(gpgpu_sim *gpu);
+  void print(FILE *fp) const;
+  struct CUstream_st *get_stream() {
+    return m_stream;
+  }
+  void set_stream(CUstream_st *stream) { m_stream = stream; }
 
-private:
-    struct CUstream_st *m_stream;
+ private:
+  struct CUstream_st *m_stream;
 
-    bool m_done;
+  bool m_done;
 
-    stream_operation_type m_type;
-    size_t      m_device_address_dst;
-    size_t      m_device_address_src;
-    void       *m_host_address_dst;
-    const void *m_host_address_src;
-    size_t      m_cnt;
+  stream_operation_type m_type;
+  size_t m_device_address_dst;
+  size_t m_device_address_src;
+  void *m_host_address_dst;
+  const void *m_host_address_src;
+  size_t m_cnt;
 
-    const char *m_symbol;
-    size_t m_offset;
+  const char *m_symbol;
+  size_t m_offset;
 
-    bool m_sim_mode;
-    kernel_info_t *m_kernel;
-    struct CUevent_st *m_event;
+  bool m_sim_mode;
+  kernel_info_t *m_kernel;
+  struct CUevent_st *m_event;
 };
 
 struct CUevent_st {
-public:
-   CUevent_st( bool blocking )
-   {
-      m_uid = ++m_next_event_uid;
-      m_blocking = blocking;
-      m_updates = 0;
-      m_wallclock = 0;
-      m_gpu_tot_sim_cycle = 0;
-      m_done = false;
-   }
-   void update( double cycle, time_t clk )
-   {
-      m_updates++;
-      m_wallclock=clk;
-      m_gpu_tot_sim_cycle=cycle;
-      m_done = true;
-   }
-   //void set_done() { assert(!m_done); m_done=true; }
-   int get_uid() const { return m_uid; }
-   unsigned num_updates() const { return m_updates; }
-   bool done() const { return m_done; }
-   time_t clock() const { return m_wallclock; }
-private:
-   int m_uid;
-   bool m_blocking;
-   bool m_done;
-   int m_updates;
-   time_t m_wallclock;
-   double m_gpu_tot_sim_cycle;
+ public:
+  CUevent_st(bool blocking) {
+    m_uid = ++m_next_event_uid;
+    m_blocking = blocking;
+    m_updates = 0;
+    m_wallclock = 0;
+    m_gpu_tot_sim_cycle = 0;
+    m_done = false;
+  }
+  void update(double cycle, time_t clk) {
+    m_updates++;
+    m_wallclock = clk;
+    m_gpu_tot_sim_cycle = cycle;
+    m_done = true;
+  }
+  // void set_done() { assert(!m_done); m_done=true; }
+  int get_uid() const { return m_uid; }
+  unsigned num_updates() const { return m_updates; }
+  bool done() const { return m_done; }
+  time_t clock() const { return m_wallclock; }
 
-   static int m_next_event_uid;
+ private:
+  int m_uid;
+  bool m_blocking;
+  bool m_done;
+  int m_updates;
+  time_t m_wallclock;
+  double m_gpu_tot_sim_cycle;
+
+  static int m_next_event_uid;
 };
 
 struct CUstream_st {
-public:
-    CUstream_st(); 
-    bool empty();
-    bool busy();
-    void synchronize();
-    void push( const stream_operation &op );
-    void record_next_done();
-    stream_operation next();
-    void cancel_front(); //front operation fails, cancle the pending status
-    stream_operation &front() { return m_operations.front(); }
-    void print( FILE *fp );
-    unsigned get_uid() const { return m_uid; }
+ public:
+  CUstream_st();
+  bool empty();
+  bool busy();
+  void synchronize();
+  void push(const stream_operation &op);
+  void record_next_done();
+  stream_operation next();
+  void cancel_front();  // front operation fails, cancle the pending status
+  stream_operation &front() { return m_operations.front(); }
+  void print(FILE *fp);
+  unsigned get_uid() const { return m_uid; }
 
-private:
-    unsigned m_uid;
-    static unsigned sm_next_stream_uid;
+ private:
+  unsigned m_uid;
+  static unsigned sm_next_stream_uid;
 
-    std::list<stream_operation> m_operations;
-    bool m_pending; // front operation has started but not yet completed
+  std::list<stream_operation> m_operations;
+  bool m_pending;  // front operation has started but not yet completed
 
-    pthread_mutex_t m_lock; // ensure only one host or gpu manipulates stream operation at one time
+  pthread_mutex_t m_lock;  // ensure only one host or gpu manipulates stream
+                           // operation at one time
 };
 
 class stream_manager {
-public:
-    stream_manager( gpgpu_sim *gpu, bool cuda_launch_blocking );
-    bool register_finished_kernel(unsigned grid_uid  );
-    bool check_finished_kernel(  );
-    stream_operation front();
-    void add_stream( CUstream_st *stream );
-    void destroy_stream( CUstream_st *stream );
-    bool concurrent_streams_empty();
-    bool empty_protected();
-    bool empty();
-    void print( FILE *fp);
-    void push( stream_operation op );
-    void pushCudaStreamWaitEventToAllStreams( CUevent_st *e, unsigned int flags );
-    bool operation(bool * sim);
-    void stop_all_running_kernels();
-    unsigned size() {return m_streams.size(); };
-    bool is_blocking() {return m_cuda_launch_blocking; };
-private:
-    void print_impl( FILE *fp);
+ public:
+  stream_manager(gpgpu_sim *gpu, bool cuda_launch_blocking);
+  bool register_finished_kernel(unsigned grid_uid);
+  bool check_finished_kernel();
+  stream_operation front();
+  void add_stream(CUstream_st *stream);
+  void destroy_stream(CUstream_st *stream);
+  bool concurrent_streams_empty();
+  bool empty_protected();
+  bool empty();
+  void print(FILE *fp);
+  void push(stream_operation op);
+  void pushCudaStreamWaitEventToAllStreams(CUevent_st *e, unsigned int flags);
+  bool operation(bool *sim);
+  void stop_all_running_kernels();
+  unsigned size() { return m_streams.size(); };
+  bool is_blocking() { return m_cuda_launch_blocking; };
 
-    bool m_cuda_launch_blocking;
-    gpgpu_sim *m_gpu;
-    std::list<CUstream_st *> m_streams;
-    std::map<unsigned,CUstream_st *> m_grid_id_to_stream;
-    CUstream_st m_stream_zero;
-    bool m_service_stream_zero;
-    pthread_mutex_t m_lock;
+ private:
+  void print_impl(FILE *fp);
+
+  bool m_cuda_launch_blocking;
+  gpgpu_sim *m_gpu;
+  std::list<CUstream_st *> m_streams;
+  std::map<unsigned, CUstream_st *> m_grid_id_to_stream;
+  CUstream_st m_stream_zero;
+  bool m_service_stream_zero;
+  pthread_mutex_t m_lock;
 };
 
 #endif

--- a/src/stream_manager.h
+++ b/src/stream_manager.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -30,249 +28,248 @@
 #ifndef STREAM_MANAGER_H_INCLUDED
 #define STREAM_MANAGER_H_INCLUDED
 
+#include "abstract_hardware_model.h"
+#include <list>
 #include <pthread.h>
 #include <time.h>
-#include <list>
-#include "abstract_hardware_model.h"
 
-// class stream_barrier {
-// public:
+//class stream_barrier {
+//public:
 //    stream_barrier() { m_pending_streams=0; }
 //    void inc() { m_pending_streams++; }
 //    void dec() { assert(m_pending_streams); m_pending_streams--; }
 //    unsigned value() const { return m_pending_streams; }
-// private:
+//private:
 //    unsigned m_pending_streams;
 //};
 
 enum stream_operation_type {
-  stream_no_op,
-  stream_memcpy_host_to_device,
-  stream_memcpy_device_to_host,
-  stream_memcpy_device_to_device,
-  stream_memcpy_to_symbol,
-  stream_memcpy_from_symbol,
-  stream_kernel_launch,
-  stream_event,
-  stream_wait_event
+    stream_no_op,
+    stream_memcpy_host_to_device,
+    stream_memcpy_device_to_host,
+    stream_memcpy_device_to_device,
+    stream_memcpy_to_symbol,
+    stream_memcpy_from_symbol,
+    stream_kernel_launch,
+    stream_event,
+    stream_wait_event
 };
 
 class stream_operation {
- public:
-  stream_operation() {
-    m_kernel = NULL;
-    m_type = stream_no_op;
-    m_stream = NULL;
-    m_done = true;
-  }
-  stream_operation(const void *src, const char *symbol, size_t count,
-                   size_t offset, struct CUstream_st *stream) {
-    m_kernel = NULL;
-    m_stream = stream;
-    m_type = stream_memcpy_to_symbol;
-    m_host_address_src = src;
-    m_symbol = symbol;
-    m_cnt = count;
-    m_offset = offset;
-    m_done = false;
-  }
-  stream_operation(const char *symbol, void *dst, size_t count, size_t offset,
-                   struct CUstream_st *stream) {
-    m_kernel = NULL;
-    m_stream = stream;
-    m_type = stream_memcpy_from_symbol;
-    m_host_address_dst = dst;
-    m_symbol = symbol;
-    m_cnt = count;
-    m_offset = offset;
-    m_done = false;
-  }
-  stream_operation(kernel_info_t *kernel, bool sim_mode,
-                   struct CUstream_st *stream) {
-    m_type = stream_kernel_launch;
-    m_kernel = kernel;
-    m_sim_mode = sim_mode;
-    m_stream = stream;
-    m_done = false;
-  }
-  stream_operation(struct CUevent_st *e, struct CUstream_st *stream) {
-    m_kernel = NULL;
-    m_type = stream_event;
-    m_event = e;
-    m_stream = stream;
-    m_done = false;
-  }
-  stream_operation(struct CUstream_st *stream, class CUevent_st *e,
-                   unsigned int flags) {
-    m_kernel = NULL;
-    m_type = stream_wait_event;
-    m_event = e;
-    m_stream = stream;
-    m_done = false;
-  }
-  stream_operation(const void *host_address_src, size_t device_address_dst,
-                   size_t cnt, struct CUstream_st *stream) {
-    m_kernel = NULL;
-    m_type = stream_memcpy_host_to_device;
-    m_host_address_src = host_address_src;
-    m_device_address_dst = device_address_dst;
-    m_host_address_dst = NULL;
-    m_device_address_src = 0;
-    m_cnt = cnt;
-    m_stream = stream;
-    m_sim_mode = false;
-    m_done = false;
-  }
-  stream_operation(size_t device_address_src, void *host_address_dst,
-                   size_t cnt, struct CUstream_st *stream) {
-    m_kernel = NULL;
-    m_type = stream_memcpy_device_to_host;
-    m_device_address_src = device_address_src;
-    m_host_address_dst = host_address_dst;
-    m_device_address_dst = 0;
-    m_host_address_src = NULL;
-    m_cnt = cnt;
-    m_stream = stream;
-    m_sim_mode = false;
-    m_done = false;
-  }
-  stream_operation(size_t device_address_src, size_t device_address_dst,
-                   size_t cnt, struct CUstream_st *stream) {
-    m_kernel = NULL;
-    m_type = stream_memcpy_device_to_device;
-    m_device_address_src = device_address_src;
-    m_device_address_dst = device_address_dst;
-    m_host_address_src = NULL;
-    m_host_address_dst = NULL;
-    m_cnt = cnt;
-    m_stream = stream;
-    m_sim_mode = false;
-    m_done = false;
-  }
+public:
+    stream_operation()
+    {
+        m_kernel=NULL;
+        m_type = stream_no_op;
+        m_stream = NULL;
+        m_done=true;
+    }
+    stream_operation( const void *src, const char *symbol, size_t count, size_t offset, struct CUstream_st *stream )
+    {
+        m_kernel=NULL;
+        m_stream = stream;
+        m_type=stream_memcpy_to_symbol;
+        m_host_address_src=src;
+        m_symbol=symbol;
+        m_cnt=count;
+        m_offset=offset;
+        m_done=false;
+    }
+    stream_operation( const char *symbol, void *dst, size_t count, size_t offset, struct CUstream_st *stream )
+    {
+        m_kernel=NULL;
+        m_stream = stream;
+        m_type=stream_memcpy_from_symbol;
+        m_host_address_dst=dst;
+        m_symbol=symbol;
+        m_cnt=count;
+        m_offset=offset;
+        m_done=false;
+    }
+    stream_operation( kernel_info_t *kernel, bool sim_mode, struct CUstream_st *stream )
+    {
+        m_type=stream_kernel_launch;
+        m_kernel=kernel;
+        m_sim_mode=sim_mode;
+        m_stream=stream;
+        m_done=false;
+    }
+    stream_operation( struct CUevent_st *e, struct CUstream_st *stream )
+    {
+        m_kernel=NULL;
+        m_type=stream_event;
+        m_event=e;
+        m_stream=stream;
+        m_done=false;
+    }
+    stream_operation( struct CUstream_st *stream, class CUevent_st *e, unsigned int flags )
+    {
+        m_kernel=NULL;
+        m_type=stream_wait_event;
+        m_event=e;
+        m_stream=stream;
+        m_done=false;
+    }
+    stream_operation( const void *host_address_src, size_t device_address_dst, size_t cnt, struct CUstream_st *stream )
+    {
+        m_kernel=NULL;
+        m_type=stream_memcpy_host_to_device;
+        m_host_address_src  =host_address_src;
+        m_device_address_dst=device_address_dst;
+        m_host_address_dst=NULL;
+        m_device_address_src=0;
+        m_cnt=cnt;
+        m_stream=stream;
+        m_sim_mode=false;
+        m_done=false;
+    }
+    stream_operation( size_t device_address_src, void *host_address_dst, size_t cnt, struct CUstream_st *stream  )
+    {
+        m_kernel=NULL;
+        m_type=stream_memcpy_device_to_host;
+        m_device_address_src=device_address_src;
+        m_host_address_dst=host_address_dst;
+        m_device_address_dst=0;
+        m_host_address_src=NULL;
+        m_cnt=cnt;
+        m_stream=stream;
+        m_sim_mode=false;
+        m_done=false;
+    }
+    stream_operation( size_t device_address_src, size_t device_address_dst, size_t cnt, struct CUstream_st *stream  )
+    {
+        m_kernel=NULL;
+        m_type=stream_memcpy_device_to_device;
+        m_device_address_src=device_address_src;
+        m_device_address_dst=device_address_dst;
+        m_host_address_src=NULL;
+        m_host_address_dst=NULL;
+        m_cnt=cnt;
+        m_stream=stream;
+        m_sim_mode=false;
+        m_done=false;
+    }
 
-  bool is_kernel() const { return m_type == stream_kernel_launch; }
-  bool is_mem() const {
-    return m_type == stream_memcpy_host_to_device ||
-           m_type == stream_memcpy_device_to_host ||
-           m_type == stream_memcpy_host_to_device;
-  }
-  bool is_noop() const { return m_type == stream_no_op; }
-  bool is_done() const { return m_done; }
-  kernel_info_t *get_kernel() { return m_kernel; }
-  bool do_operation(gpgpu_sim *gpu);
-  void print(FILE *fp) const;
-  struct CUstream_st *get_stream() {
-    return m_stream;
-  }
-  void set_stream(CUstream_st *stream) { m_stream = stream; }
+    bool is_kernel() const { return m_type == stream_kernel_launch; }
+    bool is_mem() const {
+        return m_type == stream_memcpy_host_to_device ||
+               m_type == stream_memcpy_device_to_host ||
+               m_type == stream_memcpy_host_to_device;
+    }
+    bool is_noop() const { return m_type == stream_no_op; }
+    bool is_done() const { return m_done; }
+    kernel_info_t *get_kernel() { return m_kernel; }
+    bool do_operation( gpgpu_sim *gpu );
+    void print( FILE *fp ) const;
+    struct CUstream_st *get_stream() { return m_stream; }
+    void set_stream( CUstream_st *stream ) { m_stream = stream; }
 
- private:
-  struct CUstream_st *m_stream;
+private:
+    struct CUstream_st *m_stream;
 
-  bool m_done;
+    bool m_done;
 
-  stream_operation_type m_type;
-  size_t m_device_address_dst;
-  size_t m_device_address_src;
-  void *m_host_address_dst;
-  const void *m_host_address_src;
-  size_t m_cnt;
+    stream_operation_type m_type;
+    size_t      m_device_address_dst;
+    size_t      m_device_address_src;
+    void       *m_host_address_dst;
+    const void *m_host_address_src;
+    size_t      m_cnt;
 
-  const char *m_symbol;
-  size_t m_offset;
+    const char *m_symbol;
+    size_t m_offset;
 
-  bool m_sim_mode;
-  kernel_info_t *m_kernel;
-  struct CUevent_st *m_event;
+    bool m_sim_mode;
+    kernel_info_t *m_kernel;
+    struct CUevent_st *m_event;
 };
 
 struct CUevent_st {
- public:
-  CUevent_st(bool blocking) {
-    m_uid = ++m_next_event_uid;
-    m_blocking = blocking;
-    m_updates = 0;
-    m_wallclock = 0;
-    m_gpu_tot_sim_cycle = 0;
-    m_done = false;
-  }
-  void update(double cycle, time_t clk) {
-    m_updates++;
-    m_wallclock = clk;
-    m_gpu_tot_sim_cycle = cycle;
-    m_done = true;
-  }
-  // void set_done() { assert(!m_done); m_done=true; }
-  int get_uid() const { return m_uid; }
-  unsigned num_updates() const { return m_updates; }
-  bool done() const { return m_done; }
-  time_t clock() const { return m_wallclock; }
+public:
+   CUevent_st( bool blocking )
+   {
+      m_uid = ++m_next_event_uid;
+      m_blocking = blocking;
+      m_updates = 0;
+      m_wallclock = 0;
+      m_gpu_tot_sim_cycle = 0;
+      m_done = false;
+   }
+   void update( double cycle, time_t clk )
+   {
+      m_updates++;
+      m_wallclock=clk;
+      m_gpu_tot_sim_cycle=cycle;
+      m_done = true;
+   }
+   //void set_done() { assert(!m_done); m_done=true; }
+   int get_uid() const { return m_uid; }
+   unsigned num_updates() const { return m_updates; }
+   bool done() const { return m_done; }
+   time_t clock() const { return m_wallclock; }
+private:
+   int m_uid;
+   bool m_blocking;
+   bool m_done;
+   int m_updates;
+   time_t m_wallclock;
+   double m_gpu_tot_sim_cycle;
 
- private:
-  int m_uid;
-  bool m_blocking;
-  bool m_done;
-  int m_updates;
-  time_t m_wallclock;
-  double m_gpu_tot_sim_cycle;
-
-  static int m_next_event_uid;
+   static int m_next_event_uid;
 };
 
 struct CUstream_st {
- public:
-  CUstream_st();
-  bool empty();
-  bool busy();
-  void synchronize();
-  void push(const stream_operation &op);
-  void record_next_done();
-  stream_operation next();
-  void cancel_front();  // front operation fails, cancle the pending status
-  stream_operation &front() { return m_operations.front(); }
-  void print(FILE *fp);
-  unsigned get_uid() const { return m_uid; }
+public:
+    CUstream_st(); 
+    bool empty();
+    bool busy();
+    void synchronize();
+    void push( const stream_operation &op );
+    void record_next_done();
+    stream_operation next();
+    void cancel_front(); //front operation fails, cancle the pending status
+    stream_operation &front() { return m_operations.front(); }
+    void print( FILE *fp );
+    unsigned get_uid() const { return m_uid; }
 
- private:
-  unsigned m_uid;
-  static unsigned sm_next_stream_uid;
+private:
+    unsigned m_uid;
+    static unsigned sm_next_stream_uid;
 
-  std::list<stream_operation> m_operations;
-  bool m_pending;  // front operation has started but not yet completed
+    std::list<stream_operation> m_operations;
+    bool m_pending; // front operation has started but not yet completed
 
-  pthread_mutex_t m_lock;  // ensure only one host or gpu manipulates stream
-                           // operation at one time
+    pthread_mutex_t m_lock; // ensure only one host or gpu manipulates stream operation at one time
 };
 
 class stream_manager {
- public:
-  stream_manager(gpgpu_sim *gpu, bool cuda_launch_blocking);
-  bool register_finished_kernel(unsigned grid_uid);
-  bool check_finished_kernel();
-  stream_operation front();
-  void add_stream(CUstream_st *stream);
-  void destroy_stream(CUstream_st *stream);
-  bool concurrent_streams_empty();
-  bool empty_protected();
-  bool empty();
-  void print(FILE *fp);
-  void push(stream_operation op);
-  void pushCudaStreamWaitEventToAllStreams(CUevent_st *e, unsigned int flags);
-  bool operation(bool *sim);
-  void stop_all_running_kernels();
-  unsigned size() { return m_streams.size(); };
-  bool is_blocking() { return m_cuda_launch_blocking; };
+public:
+    stream_manager( gpgpu_sim *gpu, bool cuda_launch_blocking );
+    bool register_finished_kernel(unsigned grid_uid  );
+    bool check_finished_kernel(  );
+    stream_operation front();
+    void add_stream( CUstream_st *stream );
+    void destroy_stream( CUstream_st *stream );
+    bool concurrent_streams_empty();
+    bool empty_protected();
+    bool empty();
+    void print( FILE *fp);
+    void push( stream_operation op );
+    void pushCudaStreamWaitEventToAllStreams( CUevent_st *e, unsigned int flags );
+    bool operation(bool * sim);
+    void stop_all_running_kernels();
+    unsigned size() {return m_streams.size(); };
+    bool is_blocking() {return m_cuda_launch_blocking; };
+private:
+    void print_impl( FILE *fp);
 
- private:
-  void print_impl(FILE *fp);
-
-  bool m_cuda_launch_blocking;
-  gpgpu_sim *m_gpu;
-  std::list<CUstream_st *> m_streams;
-  std::map<unsigned, CUstream_st *> m_grid_id_to_stream;
-  CUstream_st m_stream_zero;
-  bool m_service_stream_zero;
-  pthread_mutex_t m_lock;
+    bool m_cuda_launch_blocking;
+    gpgpu_sim *m_gpu;
+    std::list<CUstream_st *> m_streams;
+    std::map<unsigned,CUstream_st *> m_grid_id_to_stream;
+    CUstream_st m_stream_zero;
+    bool m_service_stream_zero;
+    pthread_mutex_t m_lock;
 };
 
 #endif

--- a/src/stream_manager.h
+++ b/src/stream_manager.h
@@ -7,269 +7,271 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef STREAM_MANAGER_H_INCLUDED
 #define STREAM_MANAGER_H_INCLUDED
 
-#include "abstract_hardware_model.h"
-#include <list>
 #include <pthread.h>
 #include <time.h>
+#include <list>
+#include "abstract_hardware_model.h"
 
-//class stream_barrier {
-//public:
+// class stream_barrier {
+// public:
 //    stream_barrier() { m_pending_streams=0; }
 //    void inc() { m_pending_streams++; }
 //    void dec() { assert(m_pending_streams); m_pending_streams--; }
 //    unsigned value() const { return m_pending_streams; }
-//private:
+// private:
 //    unsigned m_pending_streams;
 //};
 
 enum stream_operation_type {
-    stream_no_op,
-    stream_memcpy_host_to_device,
-    stream_memcpy_device_to_host,
-    stream_memcpy_device_to_device,
-    stream_memcpy_to_symbol,
-    stream_memcpy_from_symbol,
-    stream_kernel_launch,
-    stream_event,
-    stream_wait_event
+  stream_no_op,
+  stream_memcpy_host_to_device,
+  stream_memcpy_device_to_host,
+  stream_memcpy_device_to_device,
+  stream_memcpy_to_symbol,
+  stream_memcpy_from_symbol,
+  stream_kernel_launch,
+  stream_event,
+  stream_wait_event
 };
 
 class stream_operation {
-public:
-    stream_operation()
-    {
-        m_kernel=NULL;
-        m_type = stream_no_op;
-        m_stream = NULL;
-        m_done=true;
-    }
-    stream_operation( const void *src, const char *symbol, size_t count, size_t offset, struct CUstream_st *stream )
-    {
-        m_kernel=NULL;
-        m_stream = stream;
-        m_type=stream_memcpy_to_symbol;
-        m_host_address_src=src;
-        m_symbol=symbol;
-        m_cnt=count;
-        m_offset=offset;
-        m_done=false;
-    }
-    stream_operation( const char *symbol, void *dst, size_t count, size_t offset, struct CUstream_st *stream )
-    {
-        m_kernel=NULL;
-        m_stream = stream;
-        m_type=stream_memcpy_from_symbol;
-        m_host_address_dst=dst;
-        m_symbol=symbol;
-        m_cnt=count;
-        m_offset=offset;
-        m_done=false;
-    }
-    stream_operation( kernel_info_t *kernel, bool sim_mode, struct CUstream_st *stream )
-    {
-        m_type=stream_kernel_launch;
-        m_kernel=kernel;
-        m_sim_mode=sim_mode;
-        m_stream=stream;
-        m_done=false;
-    }
-    stream_operation( struct CUevent_st *e, struct CUstream_st *stream )
-    {
-        m_kernel=NULL;
-        m_type=stream_event;
-        m_event=e;
-        m_stream=stream;
-        m_done=false;
-    }
-    stream_operation( struct CUstream_st *stream, class CUevent_st *e, unsigned int flags )
-    {
-        m_kernel=NULL;
-        m_type=stream_wait_event;
-        m_event=e;
-        m_stream=stream;
-        m_done=false;
-    }
-    stream_operation( const void *host_address_src, size_t device_address_dst, size_t cnt, struct CUstream_st *stream )
-    {
-        m_kernel=NULL;
-        m_type=stream_memcpy_host_to_device;
-        m_host_address_src  =host_address_src;
-        m_device_address_dst=device_address_dst;
-        m_host_address_dst=NULL;
-        m_device_address_src=0;
-        m_cnt=cnt;
-        m_stream=stream;
-        m_sim_mode=false;
-        m_done=false;
-    }
-    stream_operation( size_t device_address_src, void *host_address_dst, size_t cnt, struct CUstream_st *stream  )
-    {
-        m_kernel=NULL;
-        m_type=stream_memcpy_device_to_host;
-        m_device_address_src=device_address_src;
-        m_host_address_dst=host_address_dst;
-        m_device_address_dst=0;
-        m_host_address_src=NULL;
-        m_cnt=cnt;
-        m_stream=stream;
-        m_sim_mode=false;
-        m_done=false;
-    }
-    stream_operation( size_t device_address_src, size_t device_address_dst, size_t cnt, struct CUstream_st *stream  )
-    {
-        m_kernel=NULL;
-        m_type=stream_memcpy_device_to_device;
-        m_device_address_src=device_address_src;
-        m_device_address_dst=device_address_dst;
-        m_host_address_src=NULL;
-        m_host_address_dst=NULL;
-        m_cnt=cnt;
-        m_stream=stream;
-        m_sim_mode=false;
-        m_done=false;
-    }
+ public:
+  stream_operation() {
+    m_kernel = NULL;
+    m_type = stream_no_op;
+    m_stream = NULL;
+    m_done = true;
+  }
+  stream_operation(const void *src, const char *symbol, size_t count,
+                   size_t offset, struct CUstream_st *stream) {
+    m_kernel = NULL;
+    m_stream = stream;
+    m_type = stream_memcpy_to_symbol;
+    m_host_address_src = src;
+    m_symbol = symbol;
+    m_cnt = count;
+    m_offset = offset;
+    m_done = false;
+  }
+  stream_operation(const char *symbol, void *dst, size_t count, size_t offset,
+                   struct CUstream_st *stream) {
+    m_kernel = NULL;
+    m_stream = stream;
+    m_type = stream_memcpy_from_symbol;
+    m_host_address_dst = dst;
+    m_symbol = symbol;
+    m_cnt = count;
+    m_offset = offset;
+    m_done = false;
+  }
+  stream_operation(kernel_info_t *kernel, bool sim_mode,
+                   struct CUstream_st *stream) {
+    m_type = stream_kernel_launch;
+    m_kernel = kernel;
+    m_sim_mode = sim_mode;
+    m_stream = stream;
+    m_done = false;
+  }
+  stream_operation(struct CUevent_st *e, struct CUstream_st *stream) {
+    m_kernel = NULL;
+    m_type = stream_event;
+    m_event = e;
+    m_stream = stream;
+    m_done = false;
+  }
+  stream_operation(struct CUstream_st *stream, class CUevent_st *e,
+                   unsigned int flags) {
+    m_kernel = NULL;
+    m_type = stream_wait_event;
+    m_event = e;
+    m_stream = stream;
+    m_done = false;
+  }
+  stream_operation(const void *host_address_src, size_t device_address_dst,
+                   size_t cnt, struct CUstream_st *stream) {
+    m_kernel = NULL;
+    m_type = stream_memcpy_host_to_device;
+    m_host_address_src = host_address_src;
+    m_device_address_dst = device_address_dst;
+    m_host_address_dst = NULL;
+    m_device_address_src = 0;
+    m_cnt = cnt;
+    m_stream = stream;
+    m_sim_mode = false;
+    m_done = false;
+  }
+  stream_operation(size_t device_address_src, void *host_address_dst,
+                   size_t cnt, struct CUstream_st *stream) {
+    m_kernel = NULL;
+    m_type = stream_memcpy_device_to_host;
+    m_device_address_src = device_address_src;
+    m_host_address_dst = host_address_dst;
+    m_device_address_dst = 0;
+    m_host_address_src = NULL;
+    m_cnt = cnt;
+    m_stream = stream;
+    m_sim_mode = false;
+    m_done = false;
+  }
+  stream_operation(size_t device_address_src, size_t device_address_dst,
+                   size_t cnt, struct CUstream_st *stream) {
+    m_kernel = NULL;
+    m_type = stream_memcpy_device_to_device;
+    m_device_address_src = device_address_src;
+    m_device_address_dst = device_address_dst;
+    m_host_address_src = NULL;
+    m_host_address_dst = NULL;
+    m_cnt = cnt;
+    m_stream = stream;
+    m_sim_mode = false;
+    m_done = false;
+  }
 
-    bool is_kernel() const { return m_type == stream_kernel_launch; }
-    bool is_mem() const {
-        return m_type == stream_memcpy_host_to_device ||
-               m_type == stream_memcpy_device_to_host ||
-               m_type == stream_memcpy_host_to_device;
-    }
-    bool is_noop() const { return m_type == stream_no_op; }
-    bool is_done() const { return m_done; }
-    kernel_info_t *get_kernel() { return m_kernel; }
-    bool do_operation( gpgpu_sim *gpu );
-    void print( FILE *fp ) const;
-    struct CUstream_st *get_stream() { return m_stream; }
-    void set_stream( CUstream_st *stream ) { m_stream = stream; }
+  bool is_kernel() const { return m_type == stream_kernel_launch; }
+  bool is_mem() const {
+    return m_type == stream_memcpy_host_to_device ||
+           m_type == stream_memcpy_device_to_host ||
+           m_type == stream_memcpy_host_to_device;
+  }
+  bool is_noop() const { return m_type == stream_no_op; }
+  bool is_done() const { return m_done; }
+  kernel_info_t *get_kernel() { return m_kernel; }
+  bool do_operation(gpgpu_sim *gpu);
+  void print(FILE *fp) const;
+  struct CUstream_st *get_stream() {
+    return m_stream;
+  }
+  void set_stream(CUstream_st *stream) { m_stream = stream; }
 
-private:
-    struct CUstream_st *m_stream;
+ private:
+  struct CUstream_st *m_stream;
 
-    bool m_done;
+  bool m_done;
 
-    stream_operation_type m_type;
-    size_t      m_device_address_dst;
-    size_t      m_device_address_src;
-    void       *m_host_address_dst;
-    const void *m_host_address_src;
-    size_t      m_cnt;
+  stream_operation_type m_type;
+  size_t m_device_address_dst;
+  size_t m_device_address_src;
+  void *m_host_address_dst;
+  const void *m_host_address_src;
+  size_t m_cnt;
 
-    const char *m_symbol;
-    size_t m_offset;
+  const char *m_symbol;
+  size_t m_offset;
 
-    bool m_sim_mode;
-    kernel_info_t *m_kernel;
-    struct CUevent_st *m_event;
+  bool m_sim_mode;
+  kernel_info_t *m_kernel;
+  struct CUevent_st *m_event;
 };
 
 struct CUevent_st {
-public:
-   CUevent_st( bool blocking )
-   {
-      m_uid = ++m_next_event_uid;
-      m_blocking = blocking;
-      m_updates = 0;
-      m_wallclock = 0;
-      m_gpu_tot_sim_cycle = 0;
-      m_done = false;
-   }
-   void update( double cycle, time_t clk )
-   {
-      m_updates++;
-      m_wallclock=clk;
-      m_gpu_tot_sim_cycle=cycle;
-      m_done = true;
-   }
-   //void set_done() { assert(!m_done); m_done=true; }
-   int get_uid() const { return m_uid; }
-   unsigned num_updates() const { return m_updates; }
-   bool done() const { return m_done; }
-   time_t clock() const { return m_wallclock; }
-private:
-   int m_uid;
-   bool m_blocking;
-   bool m_done;
-   int m_updates;
-   time_t m_wallclock;
-   double m_gpu_tot_sim_cycle;
+ public:
+  CUevent_st(bool blocking) {
+    m_uid = ++m_next_event_uid;
+    m_blocking = blocking;
+    m_updates = 0;
+    m_wallclock = 0;
+    m_gpu_tot_sim_cycle = 0;
+    m_done = false;
+  }
+  void update(double cycle, time_t clk) {
+    m_updates++;
+    m_wallclock = clk;
+    m_gpu_tot_sim_cycle = cycle;
+    m_done = true;
+  }
+  // void set_done() { assert(!m_done); m_done=true; }
+  int get_uid() const { return m_uid; }
+  unsigned num_updates() const { return m_updates; }
+  bool done() const { return m_done; }
+  time_t clock() const { return m_wallclock; }
 
-   static int m_next_event_uid;
+ private:
+  int m_uid;
+  bool m_blocking;
+  bool m_done;
+  int m_updates;
+  time_t m_wallclock;
+  double m_gpu_tot_sim_cycle;
+
+  static int m_next_event_uid;
 };
 
 struct CUstream_st {
-public:
-    CUstream_st(); 
-    bool empty();
-    bool busy();
-    void synchronize();
-    void push( const stream_operation &op );
-    void record_next_done();
-    stream_operation next();
-    void cancel_front(); //front operation fails, cancle the pending status
-    stream_operation &front() { return m_operations.front(); }
-    void print( FILE *fp );
-    unsigned get_uid() const { return m_uid; }
+ public:
+  CUstream_st();
+  bool empty();
+  bool busy();
+  void synchronize();
+  void push(const stream_operation &op);
+  void record_next_done();
+  stream_operation next();
+  void cancel_front();  // front operation fails, cancle the pending status
+  stream_operation &front() { return m_operations.front(); }
+  void print(FILE *fp);
+  unsigned get_uid() const { return m_uid; }
 
-private:
-    unsigned m_uid;
-    static unsigned sm_next_stream_uid;
+ private:
+  unsigned m_uid;
+  static unsigned sm_next_stream_uid;
 
-    std::list<stream_operation> m_operations;
-    bool m_pending; // front operation has started but not yet completed
+  std::list<stream_operation> m_operations;
+  bool m_pending;  // front operation has started but not yet completed
 
-    pthread_mutex_t m_lock; // ensure only one host or gpu manipulates stream operation at one time
+  pthread_mutex_t m_lock;  // ensure only one host or gpu manipulates stream
+                           // operation at one time
 };
 
 class stream_manager {
-public:
-    stream_manager( gpgpu_sim *gpu, bool cuda_launch_blocking );
-    bool register_finished_kernel(unsigned grid_uid  );
-    bool check_finished_kernel(  );
-    stream_operation front();
-    void add_stream( CUstream_st *stream );
-    void destroy_stream( CUstream_st *stream );
-    bool concurrent_streams_empty();
-    bool empty_protected();
-    bool empty();
-    void print( FILE *fp);
-    void push( stream_operation op );
-    void pushCudaStreamWaitEventToAllStreams( CUevent_st *e, unsigned int flags );
-    bool operation(bool * sim);
-    void stop_all_running_kernels();
-    unsigned size() {return m_streams.size(); };
-    bool is_blocking() {return m_cuda_launch_blocking; };
-private:
-    void print_impl( FILE *fp);
+ public:
+  stream_manager(gpgpu_sim *gpu, bool cuda_launch_blocking);
+  bool register_finished_kernel(unsigned grid_uid);
+  bool check_finished_kernel();
+  stream_operation front();
+  void add_stream(CUstream_st *stream);
+  void destroy_stream(CUstream_st *stream);
+  bool concurrent_streams_empty();
+  bool empty_protected();
+  bool empty();
+  void print(FILE *fp);
+  void push(stream_operation op);
+  void pushCudaStreamWaitEventToAllStreams(CUevent_st *e, unsigned int flags);
+  bool operation(bool *sim);
+  void stop_all_running_kernels();
+  unsigned size() { return m_streams.size(); };
+  bool is_blocking() { return m_cuda_launch_blocking; };
 
-    bool m_cuda_launch_blocking;
-    gpgpu_sim *m_gpu;
-    std::list<CUstream_st *> m_streams;
-    std::map<unsigned,CUstream_st *> m_grid_id_to_stream;
-    CUstream_st m_stream_zero;
-    bool m_service_stream_zero;
-    pthread_mutex_t m_lock;
+ private:
+  void print_impl(FILE *fp);
+
+  bool m_cuda_launch_blocking;
+  gpgpu_sim *m_gpu;
+  std::list<CUstream_st *> m_streams;
+  std::map<unsigned, CUstream_st *> m_grid_id_to_stream;
+  CUstream_st m_stream_zero;
+  bool m_service_stream_zero;
+  pthread_mutex_t m_lock;
 };
 
 #endif

--- a/src/tr1_hash_map.h
+++ b/src/tr1_hash_map.h
@@ -7,44 +7,46 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
-#pragma once 
+#pragma once
 
 // detection and fallback for unordered_map in C++0x
 #ifdef __cplusplus
-   // detect GCC 4.3 or later and use unordered map (part of C++0x)
-   // unordered map doesn't play nice with _GLIBCXX_DEBUG, just use a map if its enabled.
-   #if  defined( __GNUC__ ) and not defined( _GLIBCXX_DEBUG )
-       #if __GNUC__ >= 4 && __GNUC_MINOR__ >= 3
-          #include <unordered_map>
-          #define tr1_hash_map std::unordered_map
-          #define tr1_hash_map_ismap 0
-       #else
-          #include <map>
-          #define tr1_hash_map std::map
-          #define tr1_hash_map_ismap 1
-       #endif
-   #else
-      #include <map>
-      #define tr1_hash_map std::map
-      #define tr1_hash_map_ismap 1
-   #endif
+// detect GCC 4.3 or later and use unordered map (part of C++0x)
+// unordered map doesn't play nice with _GLIBCXX_DEBUG, just use a map if its
+// enabled.
+#if defined(__GNUC__) and not defined(_GLIBCXX_DEBUG)
+#if __GNUC__ >= 4 && __GNUC_MINOR__ >= 3
+#include <unordered_map>
+#define tr1_hash_map std::unordered_map
+#define tr1_hash_map_ismap 0
+#else
+#include <map>
+#define tr1_hash_map std::map
+#define tr1_hash_map_ismap 1
+#endif
+#else
+#include <map>
+#define tr1_hash_map std::map
+#define tr1_hash_map_ismap 1
+#endif
 
 #endif

--- a/src/tr1_hash_map.h
+++ b/src/tr1_hash_map.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -27,27 +25,26 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#pragma once
+#pragma once 
 
 // detection and fallback for unordered_map in C++0x
 #ifdef __cplusplus
-// detect GCC 4.3 or later and use unordered map (part of C++0x)
-// unordered map doesn't play nice with _GLIBCXX_DEBUG, just use a map if its
-// enabled.
-#if defined(__GNUC__) and not defined(_GLIBCXX_DEBUG)
-#if __GNUC__ >= 4 && __GNUC_MINOR__ >= 3
-#include <unordered_map>
-#define tr1_hash_map std::unordered_map
-#define tr1_hash_map_ismap 0
-#else
-#include <map>
-#define tr1_hash_map std::map
-#define tr1_hash_map_ismap 1
-#endif
-#else
-#include <map>
-#define tr1_hash_map std::map
-#define tr1_hash_map_ismap 1
-#endif
+   // detect GCC 4.3 or later and use unordered map (part of C++0x)
+   // unordered map doesn't play nice with _GLIBCXX_DEBUG, just use a map if its enabled.
+   #if  defined( __GNUC__ ) and not defined( _GLIBCXX_DEBUG )
+       #if __GNUC__ >= 4 && __GNUC_MINOR__ >= 3
+          #include <unordered_map>
+          #define tr1_hash_map std::unordered_map
+          #define tr1_hash_map_ismap 0
+       #else
+          #include <map>
+          #define tr1_hash_map std::map
+          #define tr1_hash_map_ismap 1
+       #endif
+   #else
+      #include <map>
+      #define tr1_hash_map std::map
+      #define tr1_hash_map_ismap 1
+   #endif
 
 #endif

--- a/src/tr1_hash_map.h
+++ b/src/tr1_hash_map.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -25,26 +27,27 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#pragma once 
+#pragma once
 
 // detection and fallback for unordered_map in C++0x
 #ifdef __cplusplus
-   // detect GCC 4.3 or later and use unordered map (part of C++0x)
-   // unordered map doesn't play nice with _GLIBCXX_DEBUG, just use a map if its enabled.
-   #if  defined( __GNUC__ ) and not defined( _GLIBCXX_DEBUG )
-       #if __GNUC__ >= 4 && __GNUC_MINOR__ >= 3
-          #include <unordered_map>
-          #define tr1_hash_map std::unordered_map
-          #define tr1_hash_map_ismap 0
-       #else
-          #include <map>
-          #define tr1_hash_map std::map
-          #define tr1_hash_map_ismap 1
-       #endif
-   #else
-      #include <map>
-      #define tr1_hash_map std::map
-      #define tr1_hash_map_ismap 1
-   #endif
+// detect GCC 4.3 or later and use unordered map (part of C++0x)
+// unordered map doesn't play nice with _GLIBCXX_DEBUG, just use a map if its
+// enabled.
+#if defined(__GNUC__) and not defined(_GLIBCXX_DEBUG)
+#if __GNUC__ >= 4 && __GNUC_MINOR__ >= 3
+#include <unordered_map>
+#define tr1_hash_map std::unordered_map
+#define tr1_hash_map_ismap 0
+#else
+#include <map>
+#define tr1_hash_map std::map
+#define tr1_hash_map_ismap 1
+#endif
+#else
+#include <map>
+#define tr1_hash_map std::map
+#define tr1_hash_map_ismap 1
+#endif
 
 #endif

--- a/src/trace.cc
+++ b/src/trace.cc
@@ -7,50 +7,51 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #include "trace.h"
 #include "string.h"
 
 namespace Trace {
 
-
 #define TS_TUP_BEGIN(X) const char* trace_streams_str[] = {
 #define TS_TUP(X) #X
-#define TS_TUP_END(X) };
+#define TS_TUP_END(X) \
+  }                   \
+  ;
 #include "trace_streams.tup"
 #undef TS_TUP_BEGIN
 #undef TS_TUP
 #undef TS_TUP_END
 
-    bool enabled = false;
-    int sampling_core = 0;
-    int sampling_memory_partition = -1;
-    bool trace_streams_enabled[NUM_TRACE_STREAMS] = {false};
-    const char* config_str;
+bool enabled = false;
+int sampling_core = 0;
+int sampling_memory_partition = -1;
+bool trace_streams_enabled[NUM_TRACE_STREAMS] = {false};
+const char* config_str;
 
-    void init()
-    {
-        for ( unsigned i = 0; i < NUM_TRACE_STREAMS; ++i ) {
-            if ( strstr( config_str, trace_streams_str[i] ) != NULL ) {
-                trace_streams_enabled[ i ] = true;
-            }
-        }
+void init() {
+  for (unsigned i = 0; i < NUM_TRACE_STREAMS; ++i) {
+    if (strstr(config_str, trace_streams_str[i]) != NULL) {
+      trace_streams_enabled[i] = true;
     }
-} 
+  }
+}
+}  // namespace Trace

--- a/src/trace.cc
+++ b/src/trace.cc
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -32,27 +30,27 @@
 
 namespace Trace {
 
+
 #define TS_TUP_BEGIN(X) const char* trace_streams_str[] = {
 #define TS_TUP(X) #X
-#define TS_TUP_END(X) \
-  }                   \
-  ;
+#define TS_TUP_END(X) };
 #include "trace_streams.tup"
 #undef TS_TUP_BEGIN
 #undef TS_TUP
 #undef TS_TUP_END
 
-bool enabled = false;
-int sampling_core = 0;
-int sampling_memory_partition = -1;
-bool trace_streams_enabled[NUM_TRACE_STREAMS] = {false};
-const char* config_str;
+    bool enabled = false;
+    int sampling_core = 0;
+    int sampling_memory_partition = -1;
+    bool trace_streams_enabled[NUM_TRACE_STREAMS] = {false};
+    const char* config_str;
 
-void init() {
-  for (unsigned i = 0; i < NUM_TRACE_STREAMS; ++i) {
-    if (strstr(config_str, trace_streams_str[i]) != NULL) {
-      trace_streams_enabled[i] = true;
+    void init()
+    {
+        for ( unsigned i = 0; i < NUM_TRACE_STREAMS; ++i ) {
+            if ( strstr( config_str, trace_streams_str[i] ) != NULL ) {
+                trace_streams_enabled[ i ] = true;
+            }
+        }
     }
-  }
-}
-}
+} 

--- a/src/trace.cc
+++ b/src/trace.cc
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -30,27 +32,27 @@
 
 namespace Trace {
 
-
 #define TS_TUP_BEGIN(X) const char* trace_streams_str[] = {
 #define TS_TUP(X) #X
-#define TS_TUP_END(X) };
+#define TS_TUP_END(X) \
+  }                   \
+  ;
 #include "trace_streams.tup"
 #undef TS_TUP_BEGIN
 #undef TS_TUP
 #undef TS_TUP_END
 
-    bool enabled = false;
-    int sampling_core = 0;
-    int sampling_memory_partition = -1;
-    bool trace_streams_enabled[NUM_TRACE_STREAMS] = {false};
-    const char* config_str;
+bool enabled = false;
+int sampling_core = 0;
+int sampling_memory_partition = -1;
+bool trace_streams_enabled[NUM_TRACE_STREAMS] = {false};
+const char* config_str;
 
-    void init()
-    {
-        for ( unsigned i = 0; i < NUM_TRACE_STREAMS; ++i ) {
-            if ( strstr( config_str, trace_streams_str[i] ) != NULL ) {
-                trace_streams_enabled[ i ] = true;
-            }
-        }
+void init() {
+  for (unsigned i = 0; i < NUM_TRACE_STREAMS; ++i) {
+    if (strstr(config_str, trace_streams_str[i]) != NULL) {
+      trace_streams_enabled[i] = true;
     }
-} 
+  }
+}
+}

--- a/src/trace.h
+++ b/src/trace.h
@@ -7,14 +7,16 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
+// Redistributions in binary form must reproduce the above copyright notice,
+// this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -35,52 +37,57 @@ namespace Trace {
 
 #define TS_TUP_BEGIN(X) enum X {
 #define TS_TUP(X) X
-#define TS_TUP_END(X) };
+#define TS_TUP_END(X) \
+  }                   \
+  ;
 #include "trace_streams.tup"
 #undef TS_TUP_BEGIN
 #undef TS_TUP
 #undef TS_TUP_END
 
-    extern bool enabled;
-    extern int sampling_core;
-    extern int sampling_memory_partition;
-    extern const char* trace_streams_str[];
-    extern bool trace_streams_enabled[NUM_TRACE_STREAMS];
-    extern const char* config_str;
+extern bool enabled;
+extern int sampling_core;
+extern int sampling_memory_partition;
+extern const char* trace_streams_str[];
+extern bool trace_streams_enabled[NUM_TRACE_STREAMS];
+extern const char* config_str;
 
-    void init();
+void init();
 
-} // namespace Trace
-
+}  // namespace Trace
 
 #if TRACING_ON
 
 #define SIM_PRINT_STR "GPGPU-Sim Cycle %llu: %s - "
 #define DTRACE(x) ((Trace::trace_streams_enabled[Trace::x]) && Trace::enabled)
-#define DPRINTF(x, ...) do {\
-    if (DTRACE(x)) {\
-        printf( SIM_PRINT_STR,\
-        		m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle,\
-                Trace::trace_streams_str[Trace::x] );\
-        printf(__VA_ARGS__);\
-    }\
-} while (0)
+#define DPRINTF(x, ...)                                                      \
+  do {                                                                       \
+    if (DTRACE(x)) {                                                         \
+      printf(SIM_PRINT_STR, m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle, \
+             Trace::trace_streams_str[Trace::x]);                            \
+      printf(__VA_ARGS__);                                                   \
+    }                                                                        \
+  } while (0)
 
-#define DPRINTFG(x, ...) do {\
-    if (DTRACE(x)) {\
-        printf( SIM_PRINT_STR,\
-        		gpu_sim_cycle + gpu_tot_sim_cycle,\
-                Trace::trace_streams_str[Trace::x] );\
-        printf(__VA_ARGS__);\
-    }\
-} while (0)
+#define DPRINTFG(x, ...)                                       \
+  do {                                                         \
+    if (DTRACE(x)) {                                           \
+      printf(SIM_PRINT_STR, gpu_sim_cycle + gpu_tot_sim_cycle, \
+             Trace::trace_streams_str[Trace::x]);              \
+      printf(__VA_ARGS__);                                     \
+    }                                                          \
+  } while (0)
 
-#else 
+#else
 
 #define DTRACE(x) (false)
-#define DPRINTF(x, ...) do {} while (0)
-#define DPRINTFG(x, ...) do {} while (0)
+#define DPRINTF(x, ...) \
+  do {                  \
+  } while (0)
+#define DPRINTFG(x, ...) \
+  do {                   \
+  } while (0)
 
-#endif  
+#endif
 
-#endif 
+#endif

--- a/src/trace.h
+++ b/src/trace.h
@@ -7,23 +7,24 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this
-// list of conditions and the following disclaimer in the documentation and/or
-// other materials provided with the distribution.
-// Neither the name of The University of British Columbia nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// software without specific prior written permission.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution. Neither the name of
+// The University of British Columbia nor the names of its contributors may be
+// used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 // This file is inspired by the trace system in gem5.
 // This is a highly simplified version adpated for gpgpusim
@@ -35,52 +36,57 @@ namespace Trace {
 
 #define TS_TUP_BEGIN(X) enum X {
 #define TS_TUP(X) X
-#define TS_TUP_END(X) };
+#define TS_TUP_END(X) \
+  }                   \
+  ;
 #include "trace_streams.tup"
 #undef TS_TUP_BEGIN
 #undef TS_TUP
 #undef TS_TUP_END
 
-    extern bool enabled;
-    extern int sampling_core;
-    extern int sampling_memory_partition;
-    extern const char* trace_streams_str[];
-    extern bool trace_streams_enabled[NUM_TRACE_STREAMS];
-    extern const char* config_str;
+extern bool enabled;
+extern int sampling_core;
+extern int sampling_memory_partition;
+extern const char* trace_streams_str[];
+extern bool trace_streams_enabled[NUM_TRACE_STREAMS];
+extern const char* config_str;
 
-    void init();
+void init();
 
-} // namespace Trace
-
+}  // namespace Trace
 
 #if TRACING_ON
 
 #define SIM_PRINT_STR "GPGPU-Sim Cycle %llu: %s - "
 #define DTRACE(x) ((Trace::trace_streams_enabled[Trace::x]) && Trace::enabled)
-#define DPRINTF(x, ...) do {\
-    if (DTRACE(x)) {\
-        printf( SIM_PRINT_STR,\
-        		m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle,\
-                Trace::trace_streams_str[Trace::x] );\
-        printf(__VA_ARGS__);\
-    }\
-} while (0)
+#define DPRINTF(x, ...)                                                      \
+  do {                                                                       \
+    if (DTRACE(x)) {                                                         \
+      printf(SIM_PRINT_STR, m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle, \
+             Trace::trace_streams_str[Trace::x]);                            \
+      printf(__VA_ARGS__);                                                   \
+    }                                                                        \
+  } while (0)
 
-#define DPRINTFG(x, ...) do {\
-    if (DTRACE(x)) {\
-        printf( SIM_PRINT_STR,\
-        		gpu_sim_cycle + gpu_tot_sim_cycle,\
-                Trace::trace_streams_str[Trace::x] );\
-        printf(__VA_ARGS__);\
-    }\
-} while (0)
+#define DPRINTFG(x, ...)                                       \
+  do {                                                         \
+    if (DTRACE(x)) {                                           \
+      printf(SIM_PRINT_STR, gpu_sim_cycle + gpu_tot_sim_cycle, \
+             Trace::trace_streams_str[Trace::x]);              \
+      printf(__VA_ARGS__);                                     \
+    }                                                          \
+  } while (0)
 
-#else 
+#else
 
 #define DTRACE(x) (false)
-#define DPRINTF(x, ...) do {} while (0)
-#define DPRINTFG(x, ...) do {} while (0)
+#define DPRINTF(x, ...) \
+  do {                  \
+  } while (0)
+#define DPRINTFG(x, ...) \
+  do {                   \
+  } while (0)
 
-#endif  
+#endif
 
-#endif 
+#endif

--- a/src/trace.h
+++ b/src/trace.h
@@ -7,16 +7,14 @@
 //
 // Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this
+// Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
 // Neither the name of The University of British Columbia nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
@@ -37,57 +35,52 @@ namespace Trace {
 
 #define TS_TUP_BEGIN(X) enum X {
 #define TS_TUP(X) X
-#define TS_TUP_END(X) \
-  }                   \
-  ;
+#define TS_TUP_END(X) };
 #include "trace_streams.tup"
 #undef TS_TUP_BEGIN
 #undef TS_TUP
 #undef TS_TUP_END
 
-extern bool enabled;
-extern int sampling_core;
-extern int sampling_memory_partition;
-extern const char* trace_streams_str[];
-extern bool trace_streams_enabled[NUM_TRACE_STREAMS];
-extern const char* config_str;
+    extern bool enabled;
+    extern int sampling_core;
+    extern int sampling_memory_partition;
+    extern const char* trace_streams_str[];
+    extern bool trace_streams_enabled[NUM_TRACE_STREAMS];
+    extern const char* config_str;
 
-void init();
+    void init();
 
-}  // namespace Trace
+} // namespace Trace
+
 
 #if TRACING_ON
 
 #define SIM_PRINT_STR "GPGPU-Sim Cycle %llu: %s - "
 #define DTRACE(x) ((Trace::trace_streams_enabled[Trace::x]) && Trace::enabled)
-#define DPRINTF(x, ...)                                                      \
-  do {                                                                       \
-    if (DTRACE(x)) {                                                         \
-      printf(SIM_PRINT_STR, m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle, \
-             Trace::trace_streams_str[Trace::x]);                            \
-      printf(__VA_ARGS__);                                                   \
-    }                                                                        \
-  } while (0)
+#define DPRINTF(x, ...) do {\
+    if (DTRACE(x)) {\
+        printf( SIM_PRINT_STR,\
+        		m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle,\
+                Trace::trace_streams_str[Trace::x] );\
+        printf(__VA_ARGS__);\
+    }\
+} while (0)
 
-#define DPRINTFG(x, ...)                                       \
-  do {                                                         \
-    if (DTRACE(x)) {                                           \
-      printf(SIM_PRINT_STR, gpu_sim_cycle + gpu_tot_sim_cycle, \
-             Trace::trace_streams_str[Trace::x]);              \
-      printf(__VA_ARGS__);                                     \
-    }                                                          \
-  } while (0)
+#define DPRINTFG(x, ...) do {\
+    if (DTRACE(x)) {\
+        printf( SIM_PRINT_STR,\
+        		gpu_sim_cycle + gpu_tot_sim_cycle,\
+                Trace::trace_streams_str[Trace::x] );\
+        printf(__VA_ARGS__);\
+    }\
+} while (0)
 
-#else
+#else 
 
 #define DTRACE(x) (false)
-#define DPRINTF(x, ...) \
-  do {                  \
-  } while (0)
-#define DPRINTFG(x, ...) \
-  do {                   \
-  } while (0)
+#define DPRINTF(x, ...) do {} while (0)
+#define DPRINTFG(x, ...) do {} while (0)
 
-#endif
+#endif  
 
-#endif
+#endif 


### PR DESCRIPTION
This PR is for a full reformat of the following directories:

- /src
- /src/gpgpu-sim
- /src/cuda-sim
- /src/gpuwattch
- /libcuda

Formatting requirements:

- clang-format version 6.0 (This is what is on the cluster)
- .clang-format file in the base directory defines the style we use (dumped directly from clang-format)

Other Details:

Jenkins has now been changed to fail commits that are not properly formatted. The current check will find all files that have been changed between a branch being regressed and the purdue-aalp dev branch. A wrapper script (located inside the root directory) is called, and runs clang-format on all C++ files that have been edited. If any differences between the style of committed code and the Google style is found, this test fails.

Two files inside the formatted directories were found to have include ordering dependencies. This is being ignored presently (formatting has been turned off for re-arranging the headers using "// clang-format off" and "// clang-format on").